### PR TITLE
Assign correct line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,14 @@
 *.wasm filter=lfs diff=lfs merge=lfs -text linguist-vendored
+
+# Executed by Linux
+*.sh   text eol=lf
+*.py   text eol=lf
+
+# Windows-native scripts
+*.ps1  text eol=lf
+*.cmd  text eol=crlf
+*.bat  text eol=crlf
+
+# Everything else
+*      text eol=lf
+


### PR DESCRIPTION
## Summary
- Added comprehensive line ending configurations to `.gitattributes` to ensure consistent behavior across platforms

## Changes
- Set LF endings for shell scripts (`.sh`), Python files (`.py`), and PowerShell scripts (`.ps1`)
- Set CRLF endings for Windows batch files (`.cmd`, `.bat`)
- Default to LF for all other text files

This helps prevent line ending issues when working across different operating systems.

## Test plan
- [ ] Verify line endings are correctly applied when checking out files on different platforms
- [ ] Confirm existing files maintain their intended line endings

🤖 Generated with [Claude Code](https://claude.com/claude-code)