### PR TITLE
fix for .gitattribute

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,14 +1,44 @@
 *.wasm filter=lfs diff=lfs merge=lfs -text linguist-vendored
 
+# Default: normalize text files, but do not force binary files as text.
+* text=auto eol=lf
+
+# Common binary assets and archives must never be line-ending normalized.
+*.png -text
+*.jpg -text
+*.jpeg -text
+*.gif -text
+*.webp -text
+*.ico -text
+*.pdf -text
+*.zip -text
+*.gz -text
+*.tar -text
+*.tgz -text
+*.7z -text
+*.ttf -text
+*.otf -text
+*.woff -text
+*.woff2 -text
+*.mp3 -text
+*.mp4 -text
+*.mov -text
+*.avi -text
+*.db -text
+*.sqlite -text
+*.exe -text
+*.dll -text
+*.so -text
+*.dylib -text
+*.class -text
+*.jar -text
+
 # Executed by Linux
-*.sh   text eol=lf
-*.py   text eol=lf
+*.sh text eol=lf
+*.py text eol=lf
 
 # Windows-native scripts
-*.ps1  text eol=lf
-*.cmd  text eol=crlf
-*.bat  text eol=crlf
-
-# Everything else
-*      text eol=lf
+*.ps1 text eol=lf
+*.cmd text eol=crlf
+*.bat text eol=crlf
 


### PR DESCRIPTION
Switched to * text=auto eol=lf and added explicit -text rules for binary types to prevent bin corruption