### PR TITLE
fix(mcp): normalize object schemas by adding empty properties

### DIFF
--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -53,10 +53,15 @@ export interface MCPToolDetails {
 /**
  * Convert JSON Schema from MCP to TypeBox-compatible schema.
  * MCP uses standard JSON Schema, TypeBox uses a compatible subset.
+ *
+ * Also normalizes schemas to work around common issues:
+ * - Adds `properties: {}` to object schemas missing it (some LLM providers require this)
  */
 function convertSchema(mcpSchema: MCPToolDefinition["inputSchema"]): TSchema {
-	// MCP schemas are JSON Schema objects, TypeBox can use them directly
-	// as long as we ensure the structure is correct
+	// Normalize: object schemas must have properties field for some providers
+	if (mcpSchema.type === "object" && !("properties" in mcpSchema)) {
+		return { ...mcpSchema, properties: {} } as unknown as TSchema;
+	}
 	return mcpSchema as unknown as TSchema;
 }
 


### PR DESCRIPTION
## Problem

Some MCP servers (e.g., Pencil) return tool schemas with just `{"type": "object"}` without a `properties` field. While this is valid JSON Schema according to the spec, some LLM providers reject it with errors like:

```
Error: Invalid schema for function 'mcp_pencil_get_style_guide_tags': 
In context=(), object schema missing properties.
```

## Solution

Normalize MCP tool schemas by adding an empty `properties` object when the schema is type `object` but missing the `properties` field. This ensures compatibility with stricter LLM providers while maintaining correct behavior for properly formed schemas.

## Testing

- Confirmed the fix resolves the issue with Pencil MCP server
- Tools with empty parameter schemas now work correctly

## Example

Before (from Pencil MCP):
```json
{"type": "object"}
```

After normalization:
```json
{"type": "object", "properties": {}}
```