### PR TITLE
fix(tui): strip OSC sequences in visibleWidth to prevent crash

### DIFF
--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -84,10 +84,10 @@ export class SelectList implements Component {
 					// Calculate how much space we have for value + description
 					const maxValueWidth = Math.min(30, width - prefixWidth - 4);
 					const truncatedValue = truncateToWidth(displayValue, maxValueWidth, Ellipsis.Omit);
-					const spacing = padding(Math.max(1, 32 - truncatedValue.length));
+					const spacing = padding(Math.max(1, 32 - visibleWidth(truncatedValue)));
 
 					// Calculate remaining space for description using visible widths
-					const descriptionStart = prefixWidth + truncatedValue.length + spacing.length;
+					const descriptionStart = prefixWidth + visibleWidth(truncatedValue) + spacing.length;
 					const remainingWidth = width - descriptionStart - 2; // -2 for safety
 
 					if (remainingWidth > 10) {
@@ -112,10 +112,10 @@ export class SelectList implements Component {
 					// Calculate how much space we have for value + description
 					const maxValueWidth = Math.min(30, width - prefix.length - 4);
 					const truncatedValue = truncateToWidth(displayValue, maxValueWidth, Ellipsis.Omit);
-					const spacing = padding(Math.max(1, 32 - truncatedValue.length));
+					const spacing = padding(Math.max(1, 32 - visibleWidth(truncatedValue)));
 
 					// Calculate remaining space for description
-					const descriptionStart = prefix.length + truncatedValue.length + spacing.length;
+					const descriptionStart = prefix.length + visibleWidth(truncatedValue) + spacing.length;
 					const remainingWidth = width - descriptionStart - 2; // -2 for safety
 
 					if (remainingWidth > 10) {

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -57,7 +57,9 @@ export function visibleWidthRaw(str: string): number {
 	if (isPureAscii) {
 		return str.length + tabLength;
 	}
-	return Bun.stringWidth(str) + tabLength;
+	// Strip OSC sequences (e.g. \x1b]8;;\x07 hyperlink close) that Bun.stringWidth miscounts
+	const stripped = str.indexOf("\x1b]") !== -1 ? str.replace(/\x1b\][^\x07]*\x07/g, "") : str;
+	return Bun.stringWidth(stripped) + tabLength;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `Bun.stringWidth()` doesn't handle OSC sequences (`\x1b]...\x07`), miscounting the `\x1b]8;;\x07` hyperlink close in `SEGMENT_RESET` as 4 visible characters
- This caused every rendered line to be measured 4 chars wider than actual, triggering a crash on the width assertion in the differential render path
- Fix strips OSC sequences before passing to `Bun.stringWidth`, with a fast `indexOf` guard to avoid regex on strings without OSC sequences
- Also fixes `select-list` to use `visibleWidth()` instead of `.length` for measuring truncated strings that may contain ANSI codes

## Test plan

- [x] All 176 existing TUI tests pass
- [x] Verified `Bun.stringWidth("\x1b[0m\x1b]8;;\x07")` returns 4 (broken) vs 0 (fixed)
- [x] Verified a 90-char line + SEGMENT_RESET measures as 90 (not 94) after fix