### PR TITLE
fix(tui): strip OSC sequences in visibleWidthRaw to prevent width overflow crash

### DIFF
--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -35,6 +35,10 @@ export function getSegmenter(): Intl.Segmenter {
 //const WIDTH_CACHE_SIZE = 512;
 //const widthCache = new Map<string, number>();
 
+// Strip OSC sequences (e.g. OSC 8 hyperlinks: \x1b]8;...;\x07 or \x1b]8;...;\x1b\\)
+// Bun.stringWidth doesn't handle these, so they get counted as visible characters.
+const OSC_RE = /\x1b\][\s\S]*?(?:\x07|\x1b\\)/g;
+
 /**
  * Calculate the visible width of a string in terminal columns.
  */
@@ -57,7 +61,9 @@ export function visibleWidthRaw(str: string): number {
 	if (isPureAscii) {
 		return str.length + tabLength;
 	}
-	return Bun.stringWidth(str) + tabLength;
+	// Strip OSC sequences before measuring since Bun.stringWidth doesn't handle them
+	const cleaned = str.replace(OSC_RE, "");
+	return Bun.stringWidth(cleaned) + tabLength;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #31 — TUI crashes with `Rendered line exceeds terminal width` on terminals like Ghostty.

## Root Cause

`Bun.stringWidth()` does not strip OSC sequences (e.g. OSC 8 hyperlinks like `\x1b]8;;\x07`), counting them as visible characters. Since `SEGMENT_RESET` (`"\x1b[0m\x1b]8;;\x07"`) is appended to every rendered line by `#applyLineResets()`, lines rendered at exactly terminal width get measured as `width + 4`, triggering the crash in `#doRender()`.

## Fix

Strip OSC sequences (`\x1b]...\x07` and `\x1b]...\x1b\\`) in `visibleWidthRaw()` before passing to `Bun.stringWidth()`. This handles:
- OSC 8 hyperlinks with BEL terminator
- OSC 8 hyperlinks with ST terminator  
- All other OSC sequences

## Verification

```
Before fix:
  visibleWidth("\x1b[0m\x1b]8;;\x07") → 4  ❌
  
After fix:
  visibleWidth("\x1b[0m\x1b]8;;\x07") → 0  ✅
```