### PR TITLE
fix(ai): Use glm-4.7 for Z.AI validation

### DIFF
--- a/packages/ai/src/utils/oauth/zai.ts
+++ b/packages/ai/src/utils/oauth/zai.ts
@@ -14,7 +14,7 @@ import type { OAuthController } from "./types";
 
 const AUTH_URL = "https://z.ai/manage-apikey/apikey-list";
 const API_BASE_URL = "https://api.z.ai/api/coding/paas/v4";
-const VALIDATION_MODEL = "glm-5";
+const VALIDATION_MODEL = "glm-4.7";
 
 /**
  * Login to Z.AI.


### PR DESCRIPTION
The Z.AI login flow was hardcoded to validate API keys using the 'glm-5' model. However, the Z.AI Coding Plan, which this login is for, currently provides access to 'glm-4.7', with 'glm-5' being rolled out incrementally.

This caused login to fail for users who did not yet have 'glm-5' access.

This change updates the validation model to 'glm-4.7' to match the model available in the Coding Plan.

Fixes #39