### PR TITLE
fix(ai): always include reasoning.encrypted_content for reasoning models

### DIFF
--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -460,12 +460,17 @@ function buildParams(
 	}
 
 	if (model.reasoning) {
+		// Always request encrypted reasoning content so reasoning items can be
+		// replayed in multi-turn conversations when store is false (items aren't
+		// persisted server-side, so we must include the full content).
+		// See: https://github.com/can1357/oh-my-pi/issues/41
+		params.include = ["reasoning.encrypted_content"];
+
 		if (options?.reasoningEffort || options?.reasoningSummary) {
 			params.reasoning = {
 				effort: options?.reasoningEffort || "medium",
 				summary: options?.reasoningSummary || "auto",
 			};
-			params.include = ["reasoning.encrypted_content"];
 		} else {
 			if (model.name.toLowerCase().startsWith("gpt-5")) {
 				// Jesus Christ, see https://community.openai.com/t/need-reasoning-false-option-for-gpt-5/1351588/7

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -454,12 +454,17 @@ function buildParams(model: Model<"openai-responses">, context: Context, options
 	}
 
 	if (model.reasoning) {
+		// Always request encrypted reasoning content so reasoning items can be
+		// replayed in multi-turn conversations when store is false (items aren't
+		// persisted server-side, so we must include the full content).
+		// See: https://github.com/can1357/oh-my-pi/issues/41
+		params.include = ["reasoning.encrypted_content"];
+
 		if (options?.reasoningEffort || options?.reasoningSummary) {
 			params.reasoning = {
 				effort: options?.reasoningEffort || "medium",
 				summary: options?.reasoningSummary || "auto",
 			};
-			params.include = ["reasoning.encrypted_content"];
 		} else {
 			if (model.name.startsWith("gpt-5")) {
 				// Jesus Christ, see https://community.openai.com/t/need-reasoning-false-option-for-gpt-5/1351588/7


### PR DESCRIPTION
## Summary

- Always request `reasoning.encrypted_content` for reasoning models in the OpenAI Responses API and Azure OpenAI Responses API, regardless of whether `reasoningEffort`/`reasoningSummary` options are explicitly set
- Previously, encrypted content was only included conditionally, causing 404 errors in multi-turn conversations when `store: false` (items aren't persisted server-side, so ID references fail)
- Aligns behavior with `openai-codex/request-transformer.ts` which already does this correctly

Fixes #41

## Test plan

- [x] Tested locally with OpenAI reasoning model in multi-turn conversation — no more 404 errors