### PR TITLE
feat(coding-agent): default MiniMax providers to M2.5

### DIFF
--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -28,9 +28,9 @@ export const defaultModelPerProvider: Record<KnownProvider, string> = {
 	cerebras: "zai-glm-4.6",
 	zai: "glm-4.6",
 	mistral: "devstral-medium-latest",
-	minimax: "MiniMax-M2.1",
-	"minimax-code": "MiniMax-M2.1",
-	"minimax-code-cn": "MiniMax-M2.1",
+	minimax: "MiniMax-M2.5",
+	"minimax-code": "MiniMax-M2.5",
+	"minimax-code-cn": "MiniMax-M2.5",
 	opencode: "claude-opus-4-6",
 	"kimi-code": "kimi-k2.5",
 };


### PR DESCRIPTION
## Summary
- switch default model for `minimax` from `MiniMax-M2.1` to `MiniMax-M2.5`
- switch default model for `minimax-code` from `MiniMax-M2.1` to `MiniMax-M2.5`
- switch default model for `minimax-code-cn` from `MiniMax-M2.1` to `MiniMax-M2.5`

## Notes
MiniMax model catalogs are manually maintained in generated model data; this change only updates default selection in coding-agent.