### PR TITLE
fix(ai): harden Claude tool schema path for Cloud Code Assist

### DIFF
--- a/packages/ai/src/providers/google-shared.ts
+++ b/packages/ai/src/providers/google-shared.ts
@@ -565,8 +565,12 @@ function getCloudCodeAssistSchemaValidator(): Ajv2020 {
  * Keep validation synchronous in this request path.
  */
 function isValidCloudCodeAssistClaudeSchema(schema: unknown): boolean {
-	const result = getCloudCodeAssistSchemaValidator().validateSchema(schema as AnySchema);
-	return typeof result === "boolean" ? result : false;
+	try {
+		const result = getCloudCodeAssistSchemaValidator().validateSchema(schema as AnySchema);
+		return typeof result === "boolean" ? result : false;
+	} catch {
+		return false;
+	}
 }
 
 const CLOUD_CODE_ASSIST_CLAUDE_FALLBACK_SCHEMA = {


### PR DESCRIPTION
**Summary**
This PR hardens the Claude schema path used by Cloud Code Assist (parameters), so tool declaration generation is more robust and does not fail on problematic schemas.

**What changed**
added prepareSchemaForCloudCodeAssistClaude()
sanitize schema, normalize object-only anyOf / one Of
validate with AJV Draft 2020-12
fallback to permissive schema when invalid
Updated convertTools() to use prepareSchemaForCloudCodeAssistClaude() for Claude models.
Added object-union flattening that preserves semantics while merging:
structural equality checks
compatible enum merging
safe anyOf composition when merge is not lossless

Made schema validation fail-safe:
catch AJV validateSchema exceptions (e.g. null input) and trigger fallback instead of throwing.