### PR TITLE
fix(coding-agent/rpc): exit cleanly when stdin closes instead of busy-polling

### DIFF
--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -688,6 +688,6 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 		}
 	}
 
-	// Keep process alive forever
-	return new Promise(() => {});
+	// stdin closed — RPC client is gone, exit cleanly
+	process.exit(0);
 }


### PR DESCRIPTION
## What

exits instead of busy waiting

## Why

-

## Testing

rpc still works after change

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
