### PR TITLE
feat(mcp): support disabling discovered servers from third-party configs

### DIFF
--- a/packages/coding-agent/src/mcp/config-writer.ts
+++ b/packages/coding-agent/src/mcp/config-writer.ts
@@ -180,3 +180,36 @@ export async function listMCPServers(filePath: string): Promise<string[]> {
 	const config = await readMCPConfigFile(filePath);
 	return Object.keys(config.mcpServers ?? {});
 }
+
+/**
+ * Read the disabled servers list from a config file.
+ */
+export async function readDisabledServers(filePath: string): Promise<string[]> {
+	const config = await readMCPConfigFile(filePath);
+	return config.disabledServers ?? [];
+}
+
+/**
+ * Add or remove a server name from the disabled servers list.
+ */
+export async function setServerDisabled(filePath: string, name: string, disabled: boolean): Promise<void> {
+	const config = await readMCPConfigFile(filePath);
+	const current = new Set(config.disabledServers ?? []);
+
+	if (disabled) {
+		current.add(name);
+	} else {
+		current.delete(name);
+	}
+
+	const updated: MCPConfigFile = {
+		...config,
+		disabledServers: current.size > 0 ? Array.from(current).sort() : undefined,
+	};
+
+	if (!updated.disabledServers) {
+		delete updated.disabledServers;
+	}
+
+	await writeMCPConfigFile(filePath, updated);
+}

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -89,6 +89,7 @@ export type MCPServerConfig = MCPStdioServerConfig | MCPHttpServerConfig | MCPSs
 /** Root .mcp.json file structure */
 export interface MCPConfigFile {
 	mcpServers?: Record<string, MCPServerConfig>;
+	disabledServers?: string[];
 }
 
 // =============================================================================


### PR DESCRIPTION
Previously, `/mcp enable|disable` only worked for servers defined directly in user or project config files. Discovered servers from third-party configs (e.g. capability-provided) could not be toggled off without removing them at the source.

This adds a `disabledServers` list to the user-level `.mcp.json` config that acts as an overlay. When loading MCP configs, servers whose names appear in this list are excluded alongside those with `enabled: false`.

### Changes

- Add `disabledServers` field to `MCPConfigFile` type
- Add `readDisabledServers`/`setServerDisabled` helpers in config-writer
- Filter discovered servers against the disabled list during config load
- Handle enable/disable toggle for discovered servers in the MCP command controller, including reconnection on re-enable
- Show disabled discovered servers in `/mcp list` output