### PR TITLE
fix(coding-agent): add null safety for finding.title in renderFindings

### DIFF
--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -684,7 +684,7 @@ function renderFindings(
 		const findingContinue = isLastFinding ? "   " : `${theme.tree.vertical}  `;
 
 		const { color } = getPriorityInfo(finding.priority);
-		const titleText = finding.title.replace(/^\[P\d\]\s*/, "");
+		const titleText = finding.title?.replace(/^\[P\d\]\s*/, "") ?? "Untitled";
 		const loc = `${path.basename(finding.file_path)}:${finding.line_start}`;
 
 		lines.push(


### PR DESCRIPTION
Handle cases where finding.title is null/undefined by defaulting to 'Untitled'.

[Uncaught Exception] TypeError: undefined is not an object (evaluating 'finding.title.replace')
    at renderFindings (/home/zhizhen/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/src/task/render.ts:687:29)
    at renderAgentProgress (/home/zhizhen/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/src/task/render.ts:581:19)
    at <anonymous> (/home/zhizhen/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/src/task/render.ts:886:20)
    at forEach (native:1:11)
    at render (/home/zhizhen/.bun/install/global/node_modules/@oh-my-pi/pi-coding-agent/src/task/render.ts:884:22)
    at render (/home/zhizhen/.bun/install/global/node_modules/@oh-my-pi/pi-tui/src/components/box.ts:90:24)
    at render (/home/zhizhen/.bun/install/global/node_modules/@oh-my-pi/pi-tui/src/tui.ts:190:24)
    at render (/home/zhizhen/.bun/install/global/node_modules/@oh-my-pi/pi-tui/src/tui.ts:190:24)
    at render (/home/zhizhen/.bun/install/global/node_modules/@oh-my-pi/pi-tui/src/tui.ts:190:24)
    at #doRender (/home/zhizhen/.bun/install/global/node_modules/@oh-my-pi/pi-tui/src/tui.ts:832:23)