### PR TITLE
feat(cursor): add missing Cursor provider models

### DIFF
--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -17339,6 +17339,165 @@
 			"contextWindow": 400000,
 			"maxTokens": 128000
 		},
+		"claude-4.6-opus-high": {
+			"id": "claude-4.6-opus-high",
+			"name": "Claude 4.6 Opus (Cursor)",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 128000
+		},
+		"claude-4.6-opus-high-thinking": {
+			"id": "claude-4.6-opus-high-thinking",
+			"name": "Claude 4.6 Opus Thinking (Cursor)",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 128000
+		},
+		"composer-1.5": {
+			"id": "composer-1.5",
+			"name": "Composer 1.5 (Cursor)",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000
+		},
+		"gpt-5.1-high": {
+			"id": "gpt-5.1-high",
+			"name": "GPT-5.1 High (Cursor)",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 272000,
+			"maxTokens": 128000
+		},
+		"gpt-5.2-codex": {
+			"id": "gpt-5.2-codex",
+			"name": "GPT-5.2 Codex (Cursor)",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000
+		},
+		"gpt-5.2-codex-fast": {
+			"id": "gpt-5.2-codex-fast",
+			"name": "GPT-5.2 Codex Fast (Cursor)",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000
+		},
+		"gpt-5.3-codex": {
+			"id": "gpt-5.3-codex",
+			"name": "GPT-5.3 Codex (Cursor)",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000
+		},
+		"gpt-5.3-codex-fast": {
+			"id": "gpt-5.3-codex-fast",
+			"name": "GPT-5.3 Codex Fast (Cursor)",
+			"api": "cursor-agent",
+			"provider": "cursor",
+			"baseUrl": "https://api2.cursor.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000
+		},
 		"grok-code-fast-1": {
 			"id": "grok-code-fast-1",
 			"name": "Grok (Cursor)",


### PR DESCRIPTION
## Summary

- Adds 8 missing models to the bundled Cursor provider in `models.json` that are available through Cursor subscriptions but were not in the static model list
- Model IDs sourced from [pi-cursor-agent](https://github.com/sudosubin/pi-cursor-agent) documentation and verified against Cursor's API

## Models Added

| Model ID | Name | Reasoning | Context Window | Max Tokens |
|---|---|---|---|---|
| `claude-4.6-opus-high` | Claude 4.6 Opus (Cursor) | No | 200k | 128k |
| `claude-4.6-opus-high-thinking` | Claude 4.6 Opus Thinking (Cursor) | Yes | 200k | 128k |
| `composer-1.5` | Composer 1.5 (Cursor) | No | 200k | 64k |
| `gpt-5.1-high` | GPT-5.1 High (Cursor) | Yes | 272k | 128k |
| `gpt-5.2-codex` | GPT-5.2 Codex (Cursor) | Yes | 400k | 128k |
| `gpt-5.2-codex-fast` | GPT-5.2 Codex Fast (Cursor) | Yes | 400k | 128k |
| `gpt-5.3-codex` | GPT-5.3 Codex (Cursor) | Yes | 400k | 128k |
| `gpt-5.3-codex-fast` | GPT-5.3 Codex Fast (Cursor) | Yes | 400k | 128k |

## Context

Users logged into Cursor via `omp login` only see 13 models in the CURSOR tab, despite having access to more through their Cursor subscription. The dynamic `GetUsableModels` discovery may not always return all available models (e.g. newer additions), so having them in the static bundled list ensures they're available as a fallback.

Context window and max token values are based on the corresponding base models already in the registry (e.g. GPT-5.2 → 400k/128k, Claude Opus 4.6 → 200k/128k).

Closes #104

Made with [Cursor](https://cursor.com)