### PR TITLE
feat(coding-agent): standardize tool renderer signatures and fix TUI inconsistencies

### DIFF
--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -231,7 +231,7 @@ export interface AgentTool<TParameters extends TSchema = TSchema, TDetails = any
 	execute: AgentToolExecFn<TParameters, TDetails, TTheme>;
 
 	/** Optional custom rendering for tool call display (returns UI component) */
-	renderCall?: (args: Static<TParameters>, theme: TTheme) => unknown;
+	renderCall?: (args: Static<TParameters>, options: RenderResultOptions, theme: TTheme) => unknown;
 
 	/** Optional custom rendering for tool result display (returns UI component) */
 	renderResult?: (

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,16 @@
 ### Fixed
 
 - Fixed model discovery to use default refresh mode instead of explicit 'online' parameter
+- Fixed spinner not animating during tool execution: start on construction, rebuild display each tick
+- Fixed read tool status icon placement: use renderStatusLine instead of bordered renderCodeCell
+- Fixed ReadToolGroupComponent to show status icon before title instead of trailing
+
+### Changed
+
+- Unified renderCall/renderResult signatures to (args, options, theme) across all tool renderers
+- Replaced nerd font pie-chart spinner with clock-outline icons for smooth looping
+- Moved status icon to front of code-cell headers in formatHeader
+- Removed dead #argsComplete field from ToolExecutionComponent
 
 ## [12.10.1] - 2026-02-18
 

--- a/packages/coding-agent/src/extensibility/custom-tools/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/types.ts
@@ -182,7 +182,7 @@ export interface CustomTool<TParams extends TSchema = TSchema, TDetails = any> {
 	/** Called on session lifecycle events - use to reconstruct state or cleanup resources */
 	onSession?: (event: CustomToolSessionEvent, ctx: CustomToolContext) => void | Promise<void>;
 	/** Custom rendering for tool call display - return a Component */
-	renderCall?: (args: Static<TParams>, theme: Theme) => Component;
+	renderCall?: (args: Static<TParams>, options: RenderResultOptions, theme: Theme) => Component;
 
 	/** Custom rendering for tool result display - return a Component */
 	renderResult?: (

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -304,7 +304,7 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 	onSession?: (event: ToolSessionEvent, ctx: ExtensionContext) => void | Promise<void>;
 
 	/** Custom rendering for tool call display */
-	renderCall?: (args: Static<TParams>, theme: Theme) => Component;
+	renderCall?: (args: Static<TParams>, options: ToolRenderResultOptions, theme: Theme) => Component;
 
 	/** Custom rendering for tool result display */
 	renderResult?: (

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -18,7 +18,7 @@ export class RegisteredToolAdapter implements AgentTool<any, any, any> {
 	declare parameters: any;
 	declare label: string;
 
-	renderCall?: (args: any, theme: any) => any;
+	renderCall?: (args: any, options: any, theme: any) => any;
 	renderResult?: (result: any, options: any, theme: any, args?: any) => any;
 
 	constructor(
@@ -32,7 +32,8 @@ export class RegisteredToolAdapter implements AgentTool<any, any, any> {
 		// enters the custom-renderer path, gets undefined back, and silently
 		// discards tool result text (extensions without renderers show blank).
 		if (registeredTool.definition.renderCall) {
-			this.renderCall = (args: any, theme: any) => registeredTool.definition.renderCall!(args, theme as Theme);
+			this.renderCall = (args: any, options: any, theme: any) =>
+				registeredTool.definition.renderCall!(args, options, theme as Theme);
 		}
 		if (registeredTool.definition.renderResult) {
 			this.renderResult = (result: any, options: any, theme: any, args?: any) =>

--- a/packages/coding-agent/src/lsp/render.ts
+++ b/packages/coding-agent/src/lsp/render.ts
@@ -31,7 +31,7 @@ import type { LspParams, LspToolDetails } from "./types";
  * Render the LSP tool call in the TUI.
  * Shows: "lsp <operation> <file/filecount>"
  */
-export function renderCall(args: LspParams, theme: Theme): Text {
+export function renderCall(args: LspParams, options: RenderResultOptions, theme: Theme): Text {
 	const actionLabel = (args.action ?? "request").replace(/_/g, " ");
 	const queryPreview = args.query ? truncateToWidth(args.query, TRUNCATE_LENGTHS.SHORT) : undefined;
 
@@ -81,7 +81,8 @@ export function renderCall(args: LspParams, theme: Theme): Text {
 
 	const text = renderStatusLine(
 		{
-			icon: "pending",
+			icon: options.spinnerFrame != null ? "running" : "pending",
+			spinnerFrame: options.spinnerFrame,
 			title: "LSP",
 			description: descriptionParts.join(" "),
 			meta,

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -174,7 +174,7 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		this.mcpServerName = connection.name;
 	}
 
-	renderCall(args: unknown, theme: Theme) {
+	renderCall(args: unknown, _options: RenderResultOptions, theme: Theme) {
 		return renderMCPCall((args ?? {}) as Record<string, unknown>, theme, this.label);
 	}
 
@@ -280,7 +280,7 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 		this.#fallbackProviderName = source?.providerName;
 	}
 
-	renderCall(args: unknown, theme: Theme) {
+	renderCall(args: unknown, _options: RenderResultOptions, theme: Theme) {
 		return renderMCPCall((args ?? {}) as Record<string, unknown>, theme, this.label);
 	}
 

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -84,9 +84,7 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 			const entry = entries[0];
 			const statusSymbol = this.#formatStatus(entry.status);
 			const pathDisplay = this.#formatPath(entry);
-			this.#text.setText(
-				` ${theme.format.bullet} ${theme.fg("toolTitle", theme.bold("Read"))} ${pathDisplay} ${statusSymbol}`.trimEnd(),
-			);
+			this.#text.setText(` ${statusSymbol} ${theme.fg("toolTitle", theme.bold("Read"))} ${pathDisplay}`.trimEnd());
 			return;
 		}
 

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -765,7 +765,7 @@ const SPINNER_FRAMES: Record<SymbolPreset, Record<SpinnerType, string[]>> = {
 		activity: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
 	},
 	nerd: {
-		status: ["󰪥", "󰪤", "󰪣", "󰪢", "󰪡", "󰪠", "󰪟", "󰪞", "󰪥"],
+		status: ["󱑖", "󱑋", "󱑌", "󱑍", "󱑎", "󱑏", "󱑐", "󱑑", "󱑒", "󱑓", "󱑔", "󱑕"],
 		activity: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
 	},
 	ascii: {

--- a/packages/coding-agent/src/patch/shared.ts
+++ b/packages/coding-agent/src/patch/shared.ts
@@ -19,7 +19,6 @@ import {
 	ToolUIKit,
 	truncateDiffByHunk,
 } from "../tools/render-utils";
-import type { RenderCallOptions } from "../tools/renderers";
 import { Ellipsis, Hasher, type RenderCache, renderStatusLine, truncateToWidth } from "../tui";
 import type { DiffError, DiffResult, Operation } from "./types";
 
@@ -257,7 +256,7 @@ function renderDiffSection(
 export const editToolRenderer = {
 	mergeCallAndResult: true,
 
-	renderCall(args: EditRenderArgs, uiTheme: Theme, options?: RenderCallOptions): Component {
+	renderCall(args: EditRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 		const ui = new ToolUIKit(uiTheme);
 		const rawPath = args.file_path || args.path || "";
 		const filePath = shortenPath(rawPath);

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -445,9 +445,19 @@ function formatOutputInline(data: unknown, theme: Theme, maxWidth = 80): string 
 /**
  * Render the tool call arguments.
  */
-export function renderCall(args: TaskParams, theme: Theme): Component {
+export function renderCall(args: TaskParams, options: RenderResultOptions, theme: Theme): Component {
 	const lines: string[] = [];
-	lines.push(renderStatusLine({ icon: "pending", title: "Task", description: args.agent }, theme));
+	lines.push(
+		renderStatusLine(
+			{
+				icon: options.spinnerFrame != null ? "running" : "pending",
+				spinnerFrame: options.spinnerFrame,
+				title: "Task",
+				description: args.agent,
+			},
+			theme,
+		),
+	);
 
 	const contextTemplate = args.context ?? "";
 	const context = contextTemplate.trim();

--- a/packages/coding-agent/src/tools/ask.ts
+++ b/packages/coding-agent/src/tools/ask.ts
@@ -380,7 +380,7 @@ interface AskRenderArgs {
 }
 
 export const askToolRenderer = {
-	renderCall(args: AskRenderArgs, uiTheme: Theme): Component {
+	renderCall(args: AskRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
 		const ui = new ToolUIKit(uiTheme);
 		const label = ui.title("Ask");
 

--- a/packages/coding-agent/src/tools/bash-interactive.ts
+++ b/packages/coding-agent/src/tools/bash-interactive.ts
@@ -14,7 +14,7 @@ import xterm from "@xterm/headless";
 import type { Theme } from "../modes/theme/theme";
 import { OutputSink, type OutputSummary } from "../session/streaming-output";
 import { getStateIcon } from "../tui";
-import { replaceTabs, wrapBrackets } from "./render-utils";
+import { replaceTabs } from "./render-utils";
 
 export interface BashInteractiveResult extends OutputSummary {
 	exitCode: number | undefined;
@@ -196,7 +196,7 @@ class BashInteractiveOverlayComponent implements Component {
 					? getStateIcon("success", this.uiTheme)
 					: getStateIcon("warning", this.uiTheme);
 		const title = this.uiTheme.fg("accent", "Console");
-		const statusBadge = this.uiTheme.fg("dim", wrapBrackets(this.#stateText(), this.uiTheme));
+		const statusBadge = `${this.uiTheme.fg("dim", this.uiTheme.format.bracketLeft)}${this.#stateText()}${this.uiTheme.fg("dim", this.uiTheme.format.bracketRight)}`;
 		const prefix = `${statusIcon} ${title} `;
 		const suffix = ` ${statusBadge}`;
 		const available = Math.max(1, innerWidth - visibleWidth(prefix) - visibleWidth(suffix));

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -237,9 +237,17 @@ function formatBashCommand(args: BashRenderArgs, _uiTheme: Theme): string {
 export const BASH_PREVIEW_LINES = 10;
 
 export const bashToolRenderer = {
-	renderCall(args: BashRenderArgs, uiTheme: Theme): Component {
+	renderCall(args: BashRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 		const cmdText = formatBashCommand(args, uiTheme);
-		const text = renderStatusLine({ icon: "pending", title: "Bash", description: cmdText }, uiTheme);
+		const text = renderStatusLine(
+			{
+				icon: options.spinnerFrame != null ? "running" : "pending",
+				spinnerFrame: options.spinnerFrame,
+				title: "Bash",
+				description: cmdText,
+			},
+			uiTheme,
+		);
 		return new Text(text, 0, 0);
 	},
 

--- a/packages/coding-agent/src/tools/calculator.ts
+++ b/packages/coding-agent/src/tools/calculator.ts
@@ -444,7 +444,7 @@ export const calculatorToolRenderer = {
 	 * Render the tool call header showing the first expression and count.
 	 * Format: "Calc <expression> (N calcs)"
 	 */
-	renderCall(args: CalculatorRenderArgs, uiTheme: Theme): Component {
+	renderCall(args: CalculatorRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
 		const count = args.calculations?.length ?? 0;
 		const firstExpression = args.calculations?.[0]?.expression;
 		const description = firstExpression ? truncateToWidth(firstExpression, TRUNCATE_LENGTHS.TITLE) : undefined;

--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -967,6 +967,7 @@ function countNonEmptyLines(text: string): number {
 /** Render fetch call (URL preview) */
 export function renderFetchCall(
 	args: { url: string; timeout?: number; raw?: boolean },
+	options: RenderResultOptions,
 	uiTheme: Theme = theme,
 ): Component {
 	const domain = getDomain(args.url);
@@ -975,7 +976,16 @@ export function renderFetchCall(
 	const meta: string[] = [];
 	if (args.raw) meta.push("raw");
 	if (args.timeout !== undefined) meta.push(`timeout:${args.timeout}s`);
-	const text = renderStatusLine({ icon: "pending", title: "Fetch", description, meta }, uiTheme);
+	const text = renderStatusLine(
+		{
+			icon: options.spinnerFrame != null ? "running" : "pending",
+			spinnerFrame: options.spinnerFrame,
+			title: "Fetch",
+			description,
+			meta,
+		},
+		uiTheme,
+	);
 	return new Text(text, 0, 0);
 }
 

--- a/packages/coding-agent/src/tools/find.ts
+++ b/packages/coding-agent/src/tools/find.ts
@@ -407,12 +407,18 @@ const COLLAPSED_LIST_LIMIT = PREVIEW_LIMITS.COLLAPSED_ITEMS;
 
 export const findToolRenderer = {
 	inline: true,
-	renderCall(args: FindRenderArgs, uiTheme: Theme): Component {
+	renderCall(args: FindRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 		const meta: string[] = [];
 		if (args.limit !== undefined) meta.push(`limit:${args.limit}`);
 
 		const text = renderStatusLine(
-			{ icon: "pending", title: "Find", description: args.pattern || "*", meta },
+			{
+				icon: options.spinnerFrame != null ? "running" : "pending",
+				spinnerFrame: options.spinnerFrame,
+				title: "Find",
+				description: args.pattern || "*",
+				meta,
+			},
 			uiTheme,
 		);
 		return new Text(text, 0, 0);

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -299,7 +299,7 @@ const COLLAPSED_TEXT_LIMIT = PREVIEW_LIMITS.COLLAPSED_LINES * 2;
 
 export const grepToolRenderer = {
 	inline: true,
-	renderCall(args: GrepRenderArgs, uiTheme: Theme): Component {
+	renderCall(args: GrepRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 		const meta: string[] = [];
 		if (args.path) meta.push(`in ${args.path}`);
 		if (args.glob) meta.push(`glob:${args.glob}`);
@@ -316,7 +316,13 @@ export const grepToolRenderer = {
 		if (args.offset !== undefined && args.offset > 0) meta.push(`offset:${args.offset}`);
 
 		const text = renderStatusLine(
-			{ icon: "pending", title: "Grep", description: args.pattern || "?", meta },
+			{
+				icon: options.spinnerFrame != null ? "running" : "pending",
+				spinnerFrame: options.spinnerFrame,
+				title: "Grep",
+				description: args.pattern || "?",
+				meta,
+			},
 			uiTheme,
 		);
 		return new Text(text, 0, 0);

--- a/packages/coding-agent/src/tools/notebook.ts
+++ b/packages/coding-agent/src/tools/notebook.ts
@@ -203,7 +203,7 @@ interface NotebookRenderArgs {
 const COLLAPSED_TEXT_LIMIT = PREVIEW_LIMITS.COLLAPSED_LINES * 2;
 
 export const notebookToolRenderer = {
-	renderCall(args: NotebookRenderArgs, uiTheme: Theme): Component {
+	renderCall(args: NotebookRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 		const meta: string[] = [];
 		const notebookPath = args.notebookPath ?? args.notebook_path;
 		const cellNumber = args.cellNumber ?? args.cell_index;
@@ -213,7 +213,13 @@ export const notebookToolRenderer = {
 		if (cellType) meta.push(`type:${cellType}`);
 
 		const text = renderStatusLine(
-			{ icon: "pending", title: "Notebook", description: args.action || "?", meta },
+			{
+				icon: options.spinnerFrame != null ? "running" : "pending",
+				spinnerFrame: options.spinnerFrame,
+				title: "Notebook",
+				description: args.action || "?",
+				meta,
+			},
 			uiTheme,
 		);
 		return new Text(text, 0, 0);

--- a/packages/coding-agent/src/tools/python.ts
+++ b/packages/coding-agent/src/tools/python.ts
@@ -834,7 +834,7 @@ function formatCellOutputLines(
 }
 
 export const pythonToolRenderer = {
-	renderCall(args: PythonRenderArgs, uiTheme: Theme): Component {
+	renderCall(args: PythonRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
 		const ui = new ToolUIKit(uiTheme);
 		const cells = args.cells ?? [];
 		const cwd = getProjectDir();

--- a/packages/coding-agent/src/tools/renderers.ts
+++ b/packages/coding-agent/src/tools/renderers.ts
@@ -28,7 +28,7 @@ export interface RenderCallOptions {
 }
 
 type ToolRenderer = {
-	renderCall: (args: unknown, theme: Theme, options?: RenderCallOptions) => Component;
+	renderCall: (args: unknown, options: RenderResultOptions, theme: Theme) => Component;
 	renderResult: (
 		result: { content: Array<{ type: string; text?: string }>; details?: unknown; isError?: boolean },
 		options: RenderResultOptions & { renderContext?: Record<string, unknown> },

--- a/packages/coding-agent/src/tools/review.ts
+++ b/packages/coding-agent/src/tools/review.ts
@@ -104,7 +104,7 @@ export const reportFindingTool: AgentTool<typeof ReportFindingParams, ReportFind
 		};
 	},
 
-	renderCall(args, theme): Component {
+	renderCall(args, _options, theme): Component {
 		const { label, icon, color } = getPriorityDisplay(args.priority, theme);
 		const titleText = String(args.title).replace(/^\[P\d\]\s*/, "");
 		return new Text(

--- a/packages/coding-agent/src/tools/ssh.ts
+++ b/packages/coding-agent/src/tools/ssh.ts
@@ -229,10 +229,18 @@ interface SshRenderContext {
 }
 
 export const sshToolRenderer = {
-	renderCall(args: SshRenderArgs, uiTheme: Theme): Component {
+	renderCall(args: SshRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 		const host = args.host || "…";
 		const command = args.command || "…";
-		const text = renderStatusLine({ icon: "pending", title: "SSH", description: `[${host}] $ ${command}` }, uiTheme);
+		const text = renderStatusLine(
+			{
+				icon: options.spinnerFrame != null ? "running" : "pending",
+				spinnerFrame: options.spinnerFrame,
+				title: "SSH",
+				description: `[${host}] $ ${command}`,
+			},
+			uiTheme,
+		);
 		return new Text(text, 0, 0);
 	},
 

--- a/packages/coding-agent/src/tools/todo-write.ts
+++ b/packages/coding-agent/src/tools/todo-write.ts
@@ -214,10 +214,18 @@ interface TodoWriteRenderArgs {
 }
 
 export const todoWriteToolRenderer = {
-	renderCall(args: TodoWriteRenderArgs, uiTheme: Theme): Component {
+	renderCall(args: TodoWriteRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 		const count = args.todos?.length ?? 0;
 		const meta = count > 0 ? [`${count} items`] : ["empty"];
-		const text = renderStatusLine({ icon: "pending", title: "Todo Write", meta }, uiTheme);
+		const text = renderStatusLine(
+			{
+				icon: options.spinnerFrame != null ? "running" : "pending",
+				spinnerFrame: options.spinnerFrame,
+				title: "Todo Write",
+				meta,
+			},
+			uiTheme,
+		);
 		return new Text(text, 0, 0);
 	},
 

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -28,7 +28,6 @@ import {
 	shortenPath,
 	ToolUIKit,
 } from "./render-utils";
-import type { RenderCallOptions } from "./renderers";
 
 const writeSchema = Type.Object({
 	path: Type.String({ description: "Path to the file to write (relative or absolute)" }),
@@ -189,7 +188,7 @@ function renderContentPreview(content: string, expanded: boolean, uiTheme: Theme
 }
 
 export const writeToolRenderer = {
-	renderCall(args: WriteRenderArgs, uiTheme: Theme, options?: RenderCallOptions): Component {
+	renderCall(args: WriteRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
 		const ui = new ToolUIKit(uiTheme);
 		const rawPath = args.file_path || args.path || "";
 		const filePath = shortenPath(rawPath);

--- a/packages/coding-agent/src/tui/code-cell.ts
+++ b/packages/coding-agent/src/tui/code-cell.ts
@@ -34,18 +34,6 @@ function getState(status?: CodeCellOptions["status"]): State | undefined {
 function formatHeader(options: CodeCellOptions, theme: Theme): { title: string; meta?: string } {
 	const { index, total, title, status, spinnerFrame, duration } = options;
 	const parts: string[] = [];
-	if (index !== undefined && total !== undefined) {
-		parts.push(theme.fg("accent", `[${index + 1}/${total}]`));
-	}
-	if (title) {
-		parts.push(theme.fg("toolTitle", title));
-	}
-	const headerTitle = parts.length > 0 ? parts.join(" ") : theme.fg("toolTitle", "Code");
-
-	const metaParts: string[] = [];
-	if (duration !== undefined) {
-		metaParts.push(theme.fg("dim", `(${formatDuration(duration)})`));
-	}
 	if (status) {
 		const icon = getStateIcon(
 			status === "complete"
@@ -59,12 +47,23 @@ function formatHeader(options: CodeCellOptions, theme: Theme): { title: string; 
 			spinnerFrame,
 		);
 		if (status === "pending" || status === "running") {
-			metaParts.push(`${icon} ${theme.fg("muted", status)}`);
+			parts.push(`${icon} ${theme.fg("muted", status)}`);
 		} else {
-			metaParts.push(icon);
+			parts.push(icon);
 		}
 	}
+	if (index !== undefined && total !== undefined) {
+		parts.push(theme.fg("accent", `[${index + 1}/${total}]`));
+	}
+	if (title) {
+		parts.push(theme.fg("toolTitle", title));
+	}
+	const headerTitle = parts.length > 0 ? parts.join(" ") : theme.fg("toolTitle", "Code");
 
+	const metaParts: string[] = [];
+	if (duration !== undefined) {
+		metaParts.push(theme.fg("dim", `(${formatDuration(duration)})`));
+	}
 	if (metaParts.length === 0) return { title: headerTitle };
 	return { title: headerTitle, meta: metaParts.join(theme.fg("dim", theme.sep.dot)) };
 }

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -271,8 +271,8 @@ export const webSearchCustomTool: CustomTool<typeof webSearchSchema, SearchRende
 		return executeSearch(toolCallId, params);
 	},
 
-	renderCall(args: SearchParams, theme: Theme) {
-		return renderSearchCall(args, theme);
+	renderCall(args: SearchParams, options, theme: Theme) {
+		return renderSearchCall(args, options, theme);
 	},
 
 	renderResult(result, options: RenderResultOptions, theme: Theme) {
@@ -391,7 +391,7 @@ Parameters:
 		return executeExaTool("web_search_exa", args, "web_search_deep");
 	},
 
-	renderCall(args, theme) {
+	renderCall(args, _options, theme) {
 		return renderExaCall(args as Record<string, unknown>, "Deep Search", theme);
 	},
 
@@ -422,7 +422,7 @@ Parameters:
 		return executeExaTool("get_code_context_exa", params as Record<string, unknown>, "web_search_code_context");
 	},
 
-	renderCall(args, theme) {
+	renderCall(args, _options, theme) {
 		return renderExaCall(args as Record<string, unknown>, "Code Search", theme);
 	},
 
@@ -450,7 +450,7 @@ Parameters:
 		return executeExaTool("crawling", params as Record<string, unknown>, "web_search_crawl");
 	},
 
-	renderCall(args, theme) {
+	renderCall(args, _options, theme) {
 		const url = (args as { url: string }).url;
 		return renderExaCall({ query: url }, "Crawl URL", theme);
 	},
@@ -481,7 +481,7 @@ Parameters:
 		return executeExaTool("linkedin_search", params as Record<string, unknown>, "web_search_linkedin");
 	},
 
-	renderCall(args, theme) {
+	renderCall(args, _options, theme) {
 		return renderExaCall(args as Record<string, unknown>, "LinkedIn Search", theme);
 	},
 
@@ -511,7 +511,7 @@ Parameters:
 		return executeExaTool("company_research", params as Record<string, unknown>, "web_search_company");
 	},
 
-	renderCall(args, theme) {
+	renderCall(args, _options, theme) {
 		const name = (args as { company_name: string }).company_name;
 		return renderExaCall({ query: name }, "Company Research", theme);
 	},

--- a/packages/coding-agent/src/web/search/render.ts
+++ b/packages/coding-agent/src/web/search/render.ts
@@ -283,11 +283,21 @@ export function renderSearchResult(
 /** Render web search call (query preview) */
 export function renderSearchCall(
 	args: { query: string; provider?: string; [key: string]: unknown },
+	options: RenderResultOptions,
 	theme: Theme,
 ): Component {
 	const provider = args.provider ?? "auto";
 	const query = truncateToWidth(args.query, 80);
-	const text = renderStatusLine({ icon: "pending", title: "Web Search", description: query, meta: [provider] }, theme);
+	const text = renderStatusLine(
+		{
+			icon: options.spinnerFrame != null ? "running" : "pending",
+			spinnerFrame: options.spinnerFrame,
+			title: "Web Search",
+			description: query,
+			meta: [provider],
+		},
+		theme,
+	);
 	return new Text(text, 0, 0);
 }
 


### PR DESCRIPTION
## What

- Unified renderCall/renderResult signatures: (args, options, theme) across all tool renderers (BREAKING, but I doubt anyone uses these except me)
- Fixed spinner not animating: start spinner in constructor, call updateDisplay from interval (slightly hurts efficieny, but negligeable and looks nicer, can replace with hourglass instead probably)
- Fixed read tool status icon placement: use renderStatusLine instead of renderCodeCell
- Fixed ReadToolGroupComponent: status icon now leads (before title) instead of trailing  (different from every other tool for no reason)
- Replaced nerd font pie-chart spinner with clock-outline icons for smooth looping (looks a lot better)
- Moved status icon to front of code-cell headers (renderCodeCell formatHeader)
- Removed dead #argsComplete field from ToolExecutionComponent

## Why

OCD and renderState wasn't exposed, noticed that func signatures weren't consistent and crashed out

## Testing

-

---

- [x] `bun check` passes (weird dep errors, but unrelated to this commit)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
