### PR TITLE
fix(nanogpt): avoid false login failures when model is not included

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ Use `/login` with supported providers:
 
 For `ollama`, API key is optional. Leave it unset for local no-auth instances, or set `OLLAMA_API_KEY` for authenticated hosts.
 For `vllm`, paste your key in `/login` (or use `VLLM_API_KEY`). For local no-auth servers, any placeholder value works (for example `vllm-local`).
-For `nanogpt`, `/login nanogpt` opens `https://nano-gpt.com/api` and prompts for your `sk-...` key (or set `NANO_GPT_API_KEY`).
+For `nanogpt`, `/login nanogpt` opens `https://nano-gpt.com/api` and prompts for your `sk-...` key (or set `NANO_GPT_API_KEY`). Login validates the key via NanoGPT's models endpoint (not a fixed model entitlement).
 For `cloudflare-ai-gateway`, set provider base URL to
 `https://gateway.ai.cloudflare.com/v1/<account_id>/<gateway_id>/anthropic`
 (for example in `~/.omp/agent/models.yml`).

--- a/packages/ai/src/utils/oauth/nanogpt.ts
+++ b/packages/ai/src/utils/oauth/nanogpt.ts
@@ -8,12 +8,12 @@
  * 3. Paste key into CLI
  */
 
-import { validateOpenAICompatibleApiKey } from "./api-key-validation";
+import { validateApiKeyAgainstModelsEndpoint } from "./api-key-validation";
 import type { OAuthController } from "./types";
 
 const AUTH_URL = "https://nano-gpt.com/api";
 const API_BASE_URL = "https://nano-gpt.com/api/v1";
-const VALIDATION_MODEL = "openai/gpt-4o-mini";
+const MODELS_URL = `${API_BASE_URL}/models`;
 
 export async function loginNanoGPT(options: OAuthController): Promise<string> {
 	if (!options.onPrompt) {
@@ -40,11 +40,10 @@ export async function loginNanoGPT(options: OAuthController): Promise<string> {
 	}
 
 	options.onProgress?.("Validating API key...");
-	await validateOpenAICompatibleApiKey({
+	await validateApiKeyAgainstModelsEndpoint({
 		provider: "NanoGPT",
 		apiKey: trimmed,
-		baseUrl: API_BASE_URL,
-		model: VALIDATION_MODEL,
+		modelsUrl: MODELS_URL,
 		signal: options.signal,
 	});
 

--- a/packages/ai/test/nanogpt-login.test.ts
+++ b/packages/ai/test/nanogpt-login.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { loginNanoGPT } from "../src/utils/oauth/nanogpt";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+	global.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+describe("nanogpt login", () => {
+	it("validates API key without requiring a specific model entitlement", async () => {
+		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			expect(url).toBe("https://nano-gpt.com/api/v1/models");
+			expect(init?.method).toBe("GET");
+			expect(init?.headers).toEqual({ Authorization: "Bearer sk-nano-test" });
+			return new Response(JSON.stringify({ object: "list", data: [] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		const apiKey = await loginNanoGPT({
+			onPrompt: async () => "sk-nano-test",
+		});
+
+		expect(apiKey).toBe("sk-nano-test");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("surfaces validation errors from models endpoint", async () => {
+		const fetchMock = vi.fn(async () => {
+			return new Response('{"code":"invalid_api_key"}', {
+				status: 401,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		await expect(
+			loginNanoGPT({
+				onPrompt: async () => "sk-nano-test",
+			}),
+		).rejects.toThrow("NanoGPT API key validation failed (401)");
+	});
+});


### PR DESCRIPTION
## Summary
NanoGPT login currently validates API keys by calling chat completions with a fixed model (`openai/gpt-4o-mini`).

For valid keys that do not include that specific model, `/login nanogpt` fails with:
`403 {"code":"model_not_included"}`

This PR switches NanoGPT login validation to an auth-only check against the NanoGPT models endpoint, so key validation does not depend on a specific model entitlement.

## Changes
- Added `validateApiKeyAgainstModelsEndpoint(...)` helper in `api-key-validation.ts`
- Updated NanoGPT login to validate via `GET https://nano-gpt.com/api/v1/models`
- Added focused tests for NanoGPT login validation behavior
- Updated README note for NanoGPT login behavior

## Why this is safer
- Valid keys are no longer rejected because of plan-specific model access
- Invalid keys still fail validation with provider status/details

## Verification
- `bun --cwd=packages/ai test test/nanogpt-login.test.ts` (pass)
- `bun --cwd=packages/ai run check` could not run in this environment because `tsgo` is not installed
