### PR TITLE
fix(coding-agent): stopped forced redraws on autocomplete updates

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -200,7 +200,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.ui.requestRender(true);
 		};
 		this.editor.onAutocompleteUpdate = () => {
-			this.ui.requestRender(true);
+			this.ui.requestRender();
 		};
 		this.#syncEditorMaxHeight();
 		this.#resizeHandler = () => {


### PR DESCRIPTION
## What

When the editor is pushed to the bottom of the terminal and the user triggers the slash `/` menu, typing causes the entire screen to flicker on every keystroke.

**Root cause:** `onAutocompleteUpdate` was calling `requestRender(true)` (forced render), which resets all differential rendering state — `previousLines`, `maxLinesRendered`, cursor tracking — and schedules a full screen clear + repaint. Since autocomplete updates are debounced at 100ms, every character typed while the menu is open triggers a full screen wipe and repaint from scratch, producing the flicker.

## Testing
I installed the dev version (`bun run install:dev`) and verify that it works.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
