### PR TITLE
fix(provider): support 5.3 codex properly in copilot

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -15,6 +15,10 @@
 - Modified handling of aborted/errored assistant messages to preserve tool call structure instead of converting to text summaries, with synthetic 'aborted' tool results injected
 - Updated tool call tracking to use status map (Resolved/Aborted) instead of separate sets for better handling of duplicate and aborted tool results
 
+### Fixed
+
+- Fixed GitHub Copilot gpt-5.3-codex model metadata to enable reasoning/tool calls and align its context window with gpt-5.2-codex
+
 ## [12.15.0] - 2026-02-20
 ### Fixed
 

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -3681,6 +3681,32 @@
 				"Copilot-Integration-Id": "vscode-chat"
 			}
 		},
+		"gpt-5.3-codex": {
+			"id": "gpt-5.3-codex",
+			"name": "GPT-5.3-Codex",
+			"api": "openai-responses",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.individual.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 272000,
+			"maxTokens": 128000,
+			"headers": {
+				"User-Agent": "GitHubCopilotChat/0.35.0",
+				"Editor-Version": "vscode/1.107.0",
+				"Editor-Plugin-Version": "copilot-chat/0.35.0",
+				"Copilot-Integration-Id": "vscode-chat"
+			}
+		},
 		"grok-code-fast-1": {
 			"id": "grok-code-fast-1",
 			"name": "Grok Code Fast 1",


### PR DESCRIPTION
## What

Supports 5.3 codex using the GitHub Copilot provider.

## Why

It was appearing in the models selector, but it said reasoning wasn't enabled for this model and tool calls weren't functional.

## Testing

I ran bun dev and ensured tool calls and reasoning functioned (5.3 codex hides reasoning tokens from the user, but it still showed the reasoning overview thing)

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
