### PR TITLE
fix(coding-agent): use valid JSON schema for submit_result when no ou…

### DIFF
--- a/packages/coding-agent/src/tools/submit-result.ts
+++ b/packages/coding-agent/src/tools/submit-result.ts
@@ -89,7 +89,7 @@ export class SubmitResultTool implements AgentTool<TObject, SubmitResultDetails>
 					...(normalizedSchema as object),
 					description: `Structured output matching the schema:\n${schemaHint}`,
 				})
-			: Type.Any({ description: "Structured JSON output (no schema specified)" });
+			: Type.Object({}, { additionalProperties: true, description: "Structured JSON output (no schema specified)" });
 
 		this.parameters = Type.Object({
 			data: Type.Optional(dataSchema),


### PR DESCRIPTION
## fix(coding-agent): use valid JSON schema for submit_result when no output schema specified

### Summary

Fixes the `submit_result` tool so its fallback data schema (when no output schema is provided) produces **valid JSON Schema** that strict providers (MiniMax, Cloud Code Assist, etc.) accept. Swaps `Type.Any()` for `Type.Object({}, { additionalProperties: true })`.

### Problem

When `session.outputSchema` is not provided, the code uses `Type.Any({ description: "..." })`, which serializes to:

```json
{"description": "Structured JSON output (no schema specified)"}
```

This is **invalid JSON Schema**—it lacks the required `type` field per JSON Schema draft 2020-12. Strict providers reject it with HTTP 400:

**Observed errors:**

- **MiniMax**: `400 JSON schema conversion failed: Unrecognized schema: {"description":"Structured JSON output (no schema specified)"}`

### Solution

Replace `Type.Any()` with:

```typescript
Type.Object({}, { additionalProperties: true, description: "Structured JSON output (no schema specified)" })
```

This yields:

```json
{
  "type": "object",
  "additionalProperties": true,
  "description": "Structured JSON output (no schema specified)"
}
```

- **Valid JSON Schema** — includes required `type` field
- **Semantically equivalent** — still accepts arbitrary structured output
- **Provider-compatible** — works with MiniMax and other strict providers

### Changes

| File | Change |
|------|--------|
| `packages/coding-agent/src/tools/submit-result.ts` | Replace `Type.Any(...)` with `Type.Object({}, { additionalProperties: true, ... })` in the fallback `dataSchema` (line ~102) |

### Testing

- Ran omp-swarm with MiniMax: agents complete successfully; no schema rejection.
- Verified `submit_result` is invoked in subagent/task flows; validation against `outputSchema` when provided remains intact.