### PR TITLE
fix(edit): do not strip leading '-' from string replacement content

### DIFF
--- a/packages/coding-agent/src/patch/index.ts
+++ b/packages/coding-agent/src/patch/index.ts
@@ -139,8 +139,8 @@ export type PatchParams = Static<typeof patchEditSchema>;
 /** Pattern matching hashline display format: `LINE#ID:CONTENT` */
 const HASHLINE_PREFIX_RE = /^\s*(?:>>>|>>)?\s*\d+#[0-9a-zA-Z]{1,16}:/;
 
-/** Pattern matching a unified-diff `+` prefix (but not `++`) */
-const DIFF_PLUS_RE = /^[+-](?![+-])/;
+/** Pattern matching a unified-diff added-line `+` prefix (but not `++`). Does NOT match `-` to avoid corrupting Markdown list items. */
+const DIFF_PLUS_RE = /^[+](?![+])/;
 
 /**
  * Strip hashline display prefixes and diff `+` markers from replacement lines.
@@ -149,7 +149,7 @@ const DIFF_PLUS_RE = /^[+-](?![+-])/;
  * replacement content, or include unified-diff `+` prefixes. Both corrupt the
  * output file. This strips them heuristically before application.
  */
-function stripNewLinePrefixes(lines: string[]): string[] {
+export function stripNewLinePrefixes(lines: string[]): string[] {
 	// Detect whether the *majority* of non-empty lines carry a prefix —
 	// if only one line out of many has a match it's likely real content.
 	let hashPrefixCount = 0;
@@ -193,7 +193,7 @@ const hashlineTagFormat = (what: string) =>
 		description: `Tag identifying the ${what} in "LINE#ID" format`,
 	});
 
-function hashlineParseContent(edit: string | string[] | null): string[] {
+export function hashlineParseContent(edit: string | string[] | null): string[] {
 	if (edit === null) return [];
 	if (Array.isArray(edit)) return edit;
 	const lines = stripNewLinePrefixes(edit.split("\n"));


### PR DESCRIPTION
## Problem

When passing replacement content as a bare **string** (not array) to a hashline `set` or `replace` operation, lines starting with `-` were silently stripped of their leading dash.

### Root cause

`DIFF_PLUS_RE` was defined as:

```ts
const DIFF_PLUS_RE = /^[+-](?![+-])/;
```

This regex is used in `stripNewLinePrefixes` to detect and remove unified-diff markers that models accidentally copy into replacement content. The function fires when **≥50% of non-empty lines** match the pattern.

The bug: `[+-]` matches both `+` (added-line marker) *and* `-` (removed-line marker / Markdown list prefix). When all replacement lines are Markdown list items (e.g. `- [x] item`), 100% of lines match, the heuristic fires, and every leading `-` is stripped — writing ` [x] item` instead of `- [x] item`.

### Reproducer

```ts
// Content as string — the path that calls hashlineParseContent → stripNewLinePrefixes
content: "- [x] done\n- [ ] todo"
// Was written to file as:  " [x] done\n [ ] todo"   ← leading '-' stripped
// Now written as:          "- [x] done\n- [ ] todo"  ← correct
```

Note: passing content as `string[]` was unaffected because the array branch in `hashlineParseContent` returns immediately without calling `stripNewLinePrefixes`.

## Fix

Narrow the regex to match only `+` (added-line markers):

```ts
// Before
const DIFF_PLUS_RE = /^[+-](?![+-])/;

// After
const DIFF_PLUS_RE = /^[+](?![+])/;
```

Removed-line markers (`-`) are never valid replacement content in any context, so stripping them was never correct. The docstring already stated the intent was `+` markers only; the implementation diverged from the spec.

## Tests

Two new `describe` blocks added to `test/core/hashline.test.ts`.

`stripNewLinePrefixes` — 6 cases:
- Strips `+` when ≥50% of lines carry it ✓
- **Does not strip `-` from Markdown list items** (the regression) ✓
- **Does not strip `-` from checkbox items** (`- [ ]` / `- [x]`) ✓
- Does not strip when fewer than 50% of lines start with `+` ✓
- Strips hashline display prefixes (`1#AB:foo`) ✓
- Does not strip `++` conflict markers ✓

`hashlineParseContent` — 5 cases:
- `null` → `[]` ✓
- Array input returned as-is (bypasses stripping entirely) ✓
- String with `-` list items → all `-` preserved ✓
- String with `+` diff markers → `+` stripped ✓
- **End-to-end regression**: `set` op with string `"- [x] new item"` writes `- [x] new item` to the file, not ` [x] new item` ✓

Both `stripNewLinePrefixes` and `hashlineParseContent` are now exported so they can be unit-tested directly without a full `ToolSession` harness.

## Verification

```
271 pass, 0 fail across 6 test files (hashline, apply-patch, apply-patch-adversarial, apply-patch-regression, fuzzy, edit-diff)
```