### PR TITLE
fix: improve Gemini tool selection with substitution table and read reinforcement

### DIFF
--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -22,7 +22,21 @@ Returns the output, and an exit code from command execution.
 </output>
 
 <critical>
+You **MUST** use specialized tools instead of bash for ALL file operations:
+
+| Instead of (WRONG) | Use (CORRECT) |
+|---|---|
+| `cat file`, `head -n N file` | `read(path="file", limit=N)` |
+| `cat -n file \| sed -n '50,150p'` | `read(path="file", offset=50, limit=100)` |
+| `grep -A 20 'pat' file` | `grep(pattern="pat", path="file", post=20)` |
+| `grep -rn 'pat' dir/` | `grep(pattern="pat", path="dir/")` |
+| `rg 'pattern' dir/` | `grep(pattern="pattern", path="dir/")` |
+| `find dir -name '*.ts'` | `find(pattern="dir/**/*.ts")` |
+| `ls dir/` | `read(path="dir/")` |
+| `cat <<'EOF' > file` | `write(path="file", content="...")` |
+| `sed -i 's/old/new/' file` | `edit(path="file", edits=[...])` |
+
 - You **MUST NOT** use Bash for these operations like read, grep, find, edit, write, where specialized tools exist.
-- You **MUST NOT** use `2>&1` pattern, stdout and stderr are already merged.
+- You **MUST NOT** use `2>&1` | `2>/dev/null` pattern, stdout and stderr are already merged.
 - You **MUST NOT** use `| head -n 50` or `| tail -n 100` pattern, use `head` and `tail` parameters instead.
 </critical>

--- a/packages/coding-agent/src/prompts/tools/read.md
+++ b/packages/coding-agent/src/prompts/tools/read.md
@@ -19,3 +19,10 @@ Reads files from local filesystem or internal URLs.
 - Returns file content as text; images return visual content; PDFs return extracted text
 - Missing files: returns closest filename matches for correction
 </output>
+
+<critical>
+- You **MUST** use `read` instead of bash for ALL file reading: `cat`, `head`, `tail`, `less`, `more` are FORBIDDEN.
+- You **MUST** use `read(path="dir/")` instead of `ls dir/` for directory listings.
+- You **MUST** always include the `path` parameter — NEVER call `read` with empty arguments `{}`.
+- When reading specific line ranges, use `offset` and `limit`: `read(path="file", offset=50, limit=100)` not `cat -n file | sed`.
+</critical>


### PR DESCRIPTION
## Why
- Gemini 3.1 Pro defaults to `bash` for file operations (cat, grep, find, ls) instead of using specialized tools
- Empty-args `{}` calls are common, causing validation failures

## How
- **bash.md**: 9-row substitution table inside `<critical>` showing exact tool calls to use instead of common bash patterns; added `2>/dev/null` to banned stderr patterns
- **read.md**: New `<critical>` section emphasizing read over cat/head/tail/ls, requiring the `path` parameter to prevent empty `{}` calls

Dropped the `custom-system-prompt.md` fix (unclosed `{{#if}}`) — already merged upstream.

## Tests
A/B tested with 10 diverse tasks using trace-informed Sonnet judge:

**v13.2.1 (latest):** Baseline avg 0.694 → PR avg 0.894 (**+0.200**)

| Task | Baseline | PR | Delta |
|---|---|---|---|
| grep_pattern | 0.000 | 0.938 | +0.938 |
| multi_tool_workflow | 0.000 | 0.955 | +0.955 |
| find_files | 0.795 | 0.983 | +0.188 |
| grep_and_read | 0.618 | 0.858 | +0.240 |
| read_with_offset | 0.969 | 0.983 | +0.014 |
| write_new_file | 0.980 | 0.994 | +0.014 |
| explore_directory | 0.767 | 0.767 | +0.000 |
| grep_with_context | 0.983 | 0.955 | -0.028 |
| read_file | 0.845 | 0.709 | -0.136 |
| find_and_count | 0.983 | 0.795 | -0.188 |

Wins 4 / Ties 3 / Losses 3

Two baseline runs scored **0.000** (complete tool selection failure) — the substitution table eliminates these.
