### PR TITLE
fix: close unclosed Handlebars block and restore git section in custom-system-prompt

### DIFF
--- a/packages/coding-agent/src/prompts/system/custom-system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/custom-system-prompt.md
@@ -16,6 +16,16 @@
 </file>
 {{/list}}
 </instructions>
+{{/if}}
+{{#if git.isRepo}}
+## Version Control
+Snapshot; does not update during conversation.
+Current branch: {{git.currentBranch}}
+Main branch: {{git.mainBranch}}
+{{git.status}}
+### History
+{{git.commits}}
+{{/if}}
 </project>
 {{/ifAny}}
 {{#if skills.length}}


### PR DESCRIPTION
## Problem

Running `omp` crashes immediately with:

```
[Uncaught Exception] Error: if doesn't match ifAny - 10:3
    at validateClose (handlebars/compiler/helpers.js:28:27)
    ...
    at renderPromptTemplate (prompt-templates.ts:259:81)
```

## Root Cause

In `packages/coding-agent/src/prompts/system/custom-system-prompt.md`:

1. **Missing `{{/if}}`**: The `{{#if contextFiles.length}}` block on line 10 is never closed. Handlebars reaches `{{/ifAny}}` while still inside the unclosed `{{#if}}`, causing a tag mismatch error.

2. **Missing git version control section**: The outer guard `{{#ifAny contextFiles.length git.isRepo}}` references both context files and git repo status, but the `{{#if git.isRepo}}` section with branch/status/history info is entirely absent.

## Fix

- Add the missing `{{/if}}` to properly close the `contextFiles.length` block
- Restore the `{{#if git.isRepo}}` conditional section for version control info (branch, status, commit history)
- Ensure `</project>` and `{{/ifAny}}` are properly positioned after both conditional sections

## Before (broken)
```handlebars
{{#ifAny contextFiles.length git.isRepo}}
<project>
{{#if contextFiles.length}}
...
</instructions>
</project>
{{/ifAny}}
```

The `{{#if}}` on line 10 has no matching `{{/if}}`. Handlebars tries to close the `#if` with `{{/ifAny}}` and throws a mismatch error.

## After (fixed)
```handlebars
{{#ifAny contextFiles.length git.isRepo}}
<project>
{{#if contextFiles.length}}
...
</instructions>
{{/if}}
{{#if git.isRepo}}
## Version Control
...
{{/if}}
</project>
{{/ifAny}}
```
