### PR TITLE
fix(extensions): guard wrapTextWithAnsi with width validation

### DIFF
--- a/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
@@ -298,7 +298,7 @@ class TwoColumnBody implements Component {
 
 	render(width: number): string[] {
 		const leftWidth = Math.floor(width * 0.5);
-		const rightWidth = width - leftWidth - 3;
+		const rightWidth = Math.max(0, width - leftWidth - 3);
 
 		const leftLines = this.leftPane.render(leftWidth);
 		const rightLines = this.rightPane.render(rightWidth);

--- a/packages/coding-agent/src/modes/components/extensions/inspector-panel.ts
+++ b/packages/coding-agent/src/modes/components/extensions/inspector-panel.ts
@@ -35,11 +35,17 @@ export class InspectorPanel implements Component {
 		lines.push("");
 
 		// Description (wrapped)
-		if (ext.description) {
-			const wrapped = wrapTextWithAnsi(ext.description, width - 2);
+		const desc = ext.description;
+		const isValidDescription = typeof desc === "string" && desc.length > 0;
+		if (isValidDescription && width > 2) {
+			const wrapped = wrapTextWithAnsi(desc, width - 2);
 			for (const line of wrapped) {
 				lines.push(truncateToWidth(line, width));
 			}
+			lines.push("");
+		} else if (isValidDescription) {
+			// Width too small for wrapping, show truncated single line
+			lines.push(truncateToWidth(desc, width));
 			lines.push("");
 		}
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -188,6 +188,7 @@ export class Container implements Component {
 	}
 
 	render(width: number): string[] {
+		width = Math.max(1, width);
 		const lines: string[] = [];
 		for (const child of this.children) {
 			lines.push(...child.render(width));


### PR DESCRIPTION
- Validate description is a string before passing to native function
- Guard against negative/zero width values
- Fall back to truncation when width <= 2

Fixes crash when opening extensions in narrow terminals

## What

Noticed a crash when opening Opencode's extensions:
<img width="2782" height="1022" alt="CleanShot 2026-02-23 at 10 55 50@2x" src="https://github.com/user-attachments/assets/a168a890-c925-4a78-a7b7-122d1dee4eb1" />

A short investigation (using omp!) led to a bug, which was vibefixed (can't see a lot of n-th order effects on code)

## Why (vibed)

The crash occurred in InspectorPanel.render() when calling wrapTextWithAnsi(ext.description, width - 2) with an invalid width parameter. The width can become negative or zero when:                                                                                                                                         
                                                                                                                                                                 1. TwoColumnBody.render() calculates rightWidth = width - leftWidth - 3 where leftWidth = Math.floor(width * 0.5)                                              
2. If terminal width is very small (0-2 columns), rightWidth becomes negative                                                                                  
3. This negative value gets passed to wrapTextWithAnsi, which crashes in the native module

## Testing

Applying the fix and testing:
<img width="2850" height="1438" alt="CleanShot 2026-02-23 at 10 58 54@2x" src="https://github.com/user-attachments/assets/b5d47a5b-a418-4a6e-9622-88539a7c0984" />

### bun check (the end, 1 warning)

```
❯ bun check
$ bun run check:ts && bun run check:rs
$ biome check . && tsgo -p tsconfig.json && tsgo -p packages/stats/tsconfig.client.json
Checked 935 files in 1289ms. No fixes applied.
$ cargo fmt --all -- --check && cargo clippy --workspace -- -D warnings && cargo check -Z minimal-versions --workspace && cargo check --workspace --target x86_64-pc-windows-msvc
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.43s
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.13s
warning: unused variable: `process_group_id`
   --> crates/pi-natives/src/pty.rs:197:2
    |
197 |     process_group_id: Option<i32>,
    |     ^^^^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_process_group_id`
    |
    = note: `#[warn(unused_variables)]` (part of `#[warn(unused)]`) on by default

warning: `pi-natives` (lib) generated 1 warning (run `cargo fix --lib -p pi-natives` to apply 1 suggestion)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.23s
```

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
