### PR TITLE
fix: allow Exa MCP tools without EXA_API_KEY

### DIFF
--- a/packages/coding-agent/src/exa/factory.ts
+++ b/packages/coding-agent/src/exa/factory.ts
@@ -31,12 +31,7 @@ export function createExaTool(
 		async execute(_toolCallId, params, _onUpdate, _ctx, _signal) {
 			try {
 				const apiKey = await findApiKey();
-				if (!apiKey) {
-					return {
-						content: [{ type: "text" as const, text: "Error: EXA_API_KEY not found" }],
-						details: { error: "EXA_API_KEY not found", toolName: name },
-					};
-				}
+				// Exa MCP endpoint is publicly accessible; API key is optional
 				const args = transformParams ? transformParams(params as Record<string, unknown>) : params;
 				const response = await callExaTool(mcpToolName, args, apiKey);
 

--- a/packages/coding-agent/src/exa/mcp-client.ts
+++ b/packages/coding-agent/src/exa/mcp-client.ts
@@ -17,8 +17,11 @@ export function findApiKey(): string | null {
 }
 
 /** Fetch available tools from Exa MCP */
-export async function fetchExaTools(apiKey: string, toolNames: string[]): Promise<MCPTool[]> {
-	const url = `https://mcp.exa.ai/mcp?exaApiKey=${encodeURIComponent(apiKey)}&toolNames=${encodeURIComponent(toolNames.join(","))}`;
+export async function fetchExaTools(apiKey: string | null, toolNames: string[]): Promise<MCPTool[]> {
+	const params = new URLSearchParams();
+	if (apiKey) params.set("exaApiKey", apiKey);
+	params.set("toolNames", toolNames.join(","));
+	const url = `https://mcp.exa.ai/mcp?${params.toString()}`;
 	const response = (await callMCP(url, "tools/list")) as MCPToolsResponse;
 
 	if (response.error) {
@@ -43,8 +46,11 @@ export async function fetchWebsetsTools(apiKey: string): Promise<MCPTool[]> {
 }
 
 /** Call a tool on Exa MCP (simplified: toolName as first arg for easier use) */
-export async function callExaTool(toolName: string, args: Record<string, unknown>, apiKey: string): Promise<unknown> {
-	const url = `https://mcp.exa.ai/mcp?exaApiKey=${encodeURIComponent(apiKey)}&tools=${encodeURIComponent(toolName)}`;
+export async function callExaTool(toolName: string, args: Record<string, unknown>, apiKey: string | null): Promise<unknown> {
+	const params = new URLSearchParams();
+	if (apiKey) params.set("exaApiKey", apiKey);
+	params.set("tools", toolName);
+	const url = `https://mcp.exa.ai/mcp?${params.toString()}`;
 	const response = (await callMCP(url, "tools/call", {
 		name: toolName,
 		arguments: args,
@@ -174,15 +180,16 @@ export class MCPWrappedTool implements CustomTool<TSchema, ExaRenderDetails> {
 	): Promise<CustomToolResult<ExaRenderDetails>> {
 		try {
 			const apiKey = await findApiKey();
-			if (!apiKey) {
+			// Websets tools require an API key; basic Exa MCP tools work without one
+			if (!apiKey && this.config.isWebsetsTool) {
 				return {
-					content: [{ type: "text" as const, text: "Error: EXA_API_KEY not found" }],
-					details: { error: "EXA_API_KEY not found", toolName: this.config.name },
+					content: [{ type: "text" as const, text: "Error: EXA_API_KEY required for Websets tools" }],
+					details: { error: "EXA_API_KEY required for Websets tools", toolName: this.config.name },
 				};
 			}
 
 			const response = this.config.isWebsetsTool
-				? await callWebsetsTool(apiKey, this.config.mcpToolName, params as Record<string, unknown>)
+				? await callWebsetsTool(apiKey!, this.config.mcpToolName, params as Record<string, unknown>)
 				: await callExaTool(this.config.mcpToolName, params as Record<string, unknown>, apiKey);
 
 			if (isSearchResponse(response)) {


### PR DESCRIPTION
## Problem

The Exa MCP endpoint at `https://mcp.exa.ai/mcp` is publicly accessible without an API key, but omp gates all Exa tools behind `EXA_API_KEY`. Users without a key get zero Exa functionality (#151).

Verified:
```bash
curl -s -X POST https://mcp.exa.ai/mcp \
  -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
# Returns web_search_exa, company_research_exa, get_code_context_exa — no key required
```

## Fix

- **`mcp-client.ts`**: `fetchExaTools` and `callExaTool` now accept `null` API key, omitting the `exaApiKey` query param when absent
- **`mcp-client.ts`**: `MCPWrappedTool.execute` only requires API key for Websets tools (which do need auth)
- **`factory.ts`**: Remove the early-return guard on missing key in `createExaTool`

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| No EXA_API_KEY, basic tools | ❌ Error | ✅ Works via public endpoint |
| No EXA_API_KEY, Websets tools | ❌ Error | ❌ Error (key required) |
| With EXA_API_KEY | ✅ Works | ✅ Works (key sent in URL) |

Fixes #151