### PR TITLE
feat(isolation): add fuse-based isolation and branch based merging with eager task tool use.

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Added `fuse-overlay` isolation mode for subagents using `fuse-overlayfs` (copy-on-write overlay, no baseline patch apply needed)
 - Added `task.isolation.merge` setting (`patch` or `branch`) to control how isolated task changes are integrated back. `branch` mode commits each task to a temp branch and cherry-picks for clean commit history
-- Added `task.isolation.commits` setting (`generic` or `ai`) for nested repo commit messages. `ai` mode uses a smol model to generate conventional commit messages from diffs
+- Added `task.isolation.commits` setting (`generic` or `ai`) for commit messages on isolated task branches and nested repos. `ai` mode uses a smol model to generate conventional commit messages from diffs
 - Nested non-submodule git repos are now discovered and handled during task isolation (changes captured and applied independently from parent repo)
 - Added `task.eager` setting to encourage the agent to delegate work to subagents by default
 
@@ -20,6 +20,9 @@
 - Fixed nested repo patches conflicting when multiple tasks contribute to the same repo (baseline untracked files no longer leak into patches)
 - Nested repo changes are now committed after patch application (previously left as untracked files)
 - Failed tasks no longer create stale branches or capture garbage patches (gated on exit code)
+- Merge failures (e.g. conflicting patches) are now non-fatal — agent output is preserved with `merge failed` status instead of `failed`
+- Stale branches are cleaned up when `commitToBranch` fails
+- Commit message generator filters lock files from diffs before AI summarization
 
 ## [13.2.0] - 2026-02-23
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Renamed `task.isolation.enabled` (boolean) setting to `task.isolation.mode` (enum: `none`, `worktree`, `fuse-overlay`). Existing `true`/`false` values are auto-migrated to `worktree`/`none`.
+
+### Added
+
+- Added `fuse-overlay` isolation mode for subagents using `fuse-overlayfs` (copy-on-write overlay, no baseline patch apply needed)
+
 ## [13.2.0] - 2026-02-23
 ### Breaking Changes
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Added
 
 - Added `fuse-overlay` isolation mode for subagents using `fuse-overlayfs` (copy-on-write overlay, no baseline patch apply needed)
+- Added `task.isolation.merge` setting (`patch` or `branch`) to control how isolated task changes are integrated back. `branch` mode commits each task to a temp branch and merges with `--no-ff` for proper commit history
 
 ## [13.2.0] - 2026-02-23
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,15 +9,17 @@
 ### Added
 
 - Added `fuse-overlay` isolation mode for subagents using `fuse-overlayfs` (copy-on-write overlay, no baseline patch apply needed)
-- Added `task.isolation.merge` setting (`patch` or `branch`) to control how isolated task changes are integrated back. `branch` mode commits each task to a temp branch and merges with `--no-ff` for proper commit history
+- Added `task.isolation.merge` setting (`patch` or `branch`) to control how isolated task changes are integrated back. `branch` mode commits each task to a temp branch and cherry-picks for clean commit history
 - Added `task.isolation.commits` setting (`generic` or `ai`) for nested repo commit messages. `ai` mode uses a smol model to generate conventional commit messages from diffs
 - Nested non-submodule git repos are now discovered and handled during task isolation (changes captured and applied independently from parent repo)
+- Added `task.eager` setting to encourage the agent to delegate work to subagents by default
 
 ### Fixed
 
 - Fixed nested repo changes being lost when tasks commit inside the isolation (baseline state is now committed before task runs, so delta correctly excludes it)
 - Fixed nested repo patches conflicting when multiple tasks contribute to the same repo (baseline untracked files no longer leak into patches)
 - Nested repo changes are now committed after patch application (previously left as untracked files)
+- Failed tasks no longer create stale branches or capture garbage patches (gated on exit code)
 
 ## [13.2.0] - 2026-02-23
 ### Breaking Changes

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,14 @@
 
 - Added `fuse-overlay` isolation mode for subagents using `fuse-overlayfs` (copy-on-write overlay, no baseline patch apply needed)
 - Added `task.isolation.merge` setting (`patch` or `branch`) to control how isolated task changes are integrated back. `branch` mode commits each task to a temp branch and merges with `--no-ff` for proper commit history
+- Added `task.isolation.commits` setting (`generic` or `ai`) for nested repo commit messages. `ai` mode uses a smol model to generate conventional commit messages from diffs
+- Nested non-submodule git repos are now discovered and handled during task isolation (changes captured and applied independently from parent repo)
+
+### Fixed
+
+- Fixed nested repo changes being lost when tasks commit inside the isolation (baseline state is now committed before task runs, so delta correctly excludes it)
+- Fixed nested repo patches conflicting when multiple tasks contribute to the same repo (baseline untracked files no longer leak into patches)
+- Nested repo changes are now committed after patch application (previously left as untracked files)
 
 ## [13.2.0] - 2026-02-23
 ### Breaking Changes

--- a/packages/coding-agent/DEVELOPMENT.md
+++ b/packages/coding-agent/DEVELOPMENT.md
@@ -907,11 +907,13 @@ Despite the name `runSubprocess`, `packages/coding-agent/src/task/executor.ts` c
 What _is_ isolated is execution context and artifacts, not process memory:
 
 - Optional filesystem isolation is controlled by the `task.isolation.mode` setting (`"none"`, `"worktree"`, or `"fuse-overlay"`).
-  - **worktree**: `ensureWorktree(...)`, `applyBaseline(...)`, `captureDeltaPatch(...)`, `cleanupWorktree(...)`.
-  - **fuse-overlay**: `ensureFuseOverlay(...)` (mounts a copy-on-write overlay via `fuse-overlayfs`), `captureDeltaPatch(...)`, `cleanupFuseOverlay(...)`. No baseline apply step needed since the overlay reflects the full working tree.
+  - **worktree**: `ensureWorktree(...)`, `applyBaseline(...)`, `captureDeltaPatch(...)`, `cleanupWorktree(...)`. Nested non-submodule git repos are discovered and handled independently.
+  - **fuse-overlay**: `ensureFuseOverlay(...)` (mounts a copy-on-write overlay via `fuse-overlayfs`), `captureDeltaPatch(...)`, `cleanupFuseOverlay(...)`. No baseline apply needed since the overlay reflects the full working tree. Fails outright if mount fails.
 - The `task.isolation.merge` setting controls how isolated changes are integrated back:
   - **patch** (default): captures a diff via `captureDeltaPatch(...)`, combines patches, and applies with `git apply`.
-  - **branch**: each task commits to a temp branch (`omp/task/<id>`) via `commitToBranch(...)`, then `mergeTaskBranches(...)` merges them sequentially with `--no-ff` merge commits.
+  - **branch**: each task commits to a temp branch (`omp/task/<id>`) via `commitToBranch(...)`, then `mergeTaskBranches(...)` cherry-picks them sequentially onto HEAD. If `git apply` fails inside `commitToBranch`, the error is non-fatal — the agent result is preserved with a `merge failed` status.
+- The `task.isolation.commits` setting (`generic` or `ai`) controls commit messages for branch commits and nested repo patches. `ai` mode uses a smol model to generate conventional commit messages from diffs.
+- Nested repo patches are applied via `applyNestedPatches(...)` after the parent merge, grouped by repo with one commit per repo.
 - Child session JSONL/markdown outputs are written under the task artifacts directory (`<id>.jsonl`, `<id>.md`, and in isolated mode `<id>.patch`).
 
 ### Tooling Surface in Child Sessions

--- a/packages/coding-agent/DEVELOPMENT.md
+++ b/packages/coding-agent/DEVELOPMENT.md
@@ -906,7 +906,9 @@ Despite the name `runSubprocess`, `packages/coding-agent/src/task/executor.ts` c
 
 What _is_ isolated is execution context and artifacts, not process memory:
 
-- Optional git worktree isolation is handled by `TaskTool.execute(...)` in `index.ts` using `ensureWorktree(...)`, `applyBaseline(...)`, `captureDeltaPatch(...)`, `cleanupWorktree(...)`.
+- Optional filesystem isolation is controlled by the `task.isolation.mode` setting (`"none"`, `"worktree"`, or `"fuse-overlay"`).
+  - **worktree**: `ensureWorktree(...)`, `applyBaseline(...)`, `captureDeltaPatch(...)`, `cleanupWorktree(...)`.
+  - **fuse-overlay**: `ensureFuseOverlay(...)` (mounts a copy-on-write overlay via `fuse-overlayfs`), `captureDeltaPatch(...)`, `cleanupFuseOverlay(...)`. No baseline apply step needed since the overlay reflects the full working tree.
 - Child session JSONL/markdown outputs are written under the task artifacts directory (`<id>.jsonl`, `<id>.md`, and in isolated mode `<id>.patch`).
 
 ### Tooling Surface in Child Sessions

--- a/packages/coding-agent/DEVELOPMENT.md
+++ b/packages/coding-agent/DEVELOPMENT.md
@@ -909,6 +909,9 @@ What _is_ isolated is execution context and artifacts, not process memory:
 - Optional filesystem isolation is controlled by the `task.isolation.mode` setting (`"none"`, `"worktree"`, or `"fuse-overlay"`).
   - **worktree**: `ensureWorktree(...)`, `applyBaseline(...)`, `captureDeltaPatch(...)`, `cleanupWorktree(...)`.
   - **fuse-overlay**: `ensureFuseOverlay(...)` (mounts a copy-on-write overlay via `fuse-overlayfs`), `captureDeltaPatch(...)`, `cleanupFuseOverlay(...)`. No baseline apply step needed since the overlay reflects the full working tree.
+- The `task.isolation.merge` setting controls how isolated changes are integrated back:
+  - **patch** (default): captures a diff via `captureDeltaPatch(...)`, combines patches, and applies with `git apply`.
+  - **branch**: each task commits to a temp branch (`omp/task/<id>`) via `commitToBranch(...)`, then `mergeTaskBranches(...)` merges them sequentially with `--no-ff` merge commits.
 - Child session JSONL/markdown outputs are written under the task artifacts directory (`<id>.jsonl`, `<id>.md`, and in isolated mode `<id>.patch`).
 
 ### Tooling Surface in Child Sessions

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -544,13 +544,14 @@ export const SETTINGS_SCHEMA = {
 	// ─────────────────────────────────────────────────────────────────────────
 	// Task tool settings
 	// ─────────────────────────────────────────────────────────────────────────
-	"task.isolation.enabled": {
-		type: "boolean",
-		default: false,
+	"task.isolation.mode": {
+		type: "enum",
+		values: ["none", "worktree", "fuse-overlay"] as const,
+		default: "none",
 		ui: {
 			tab: "tools",
 			label: "Task isolation",
-			description: "Run subagents in isolated git worktrees",
+			description: "Isolation mode for subagents (none, git worktree, or fuse-overlay)",
 			submenu: true,
 		},
 	},

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -555,6 +555,17 @@ export const SETTINGS_SCHEMA = {
 			submenu: true,
 		},
 	},
+	"task.isolation.merge": {
+		type: "enum",
+		values: ["patch", "branch"] as const,
+		default: "patch",
+		ui: {
+			tab: "tools",
+			label: "Task isolation merge",
+			description: "How isolated task changes are integrated (patch apply or branch merge)",
+			submenu: true,
+		},
+	},
 	"task.maxConcurrency": {
 		type: "number",
 		default: 32,

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -577,6 +577,15 @@ export const SETTINGS_SCHEMA = {
 			submenu: true,
 		},
 	},
+	"task.eager": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			label: "Eager task delegation",
+			description: "Encourage the agent to delegate work to subagents unless changes are trivial",
+		},
+	},
 	"task.maxConcurrency": {
 		type: "number",
 		default: 32,

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -566,6 +566,17 @@ export const SETTINGS_SCHEMA = {
 			submenu: true,
 		},
 	},
+	"task.isolation.commits": {
+		type: "enum",
+		values: ["generic", "ai"] as const,
+		default: "generic",
+		ui: {
+			tab: "tools",
+			label: "Task isolation commits",
+			description: "Commit message style for nested repo changes (generic or AI-generated)",
+			submenu: true,
+		},
+	},
 	"task.maxConcurrency": {
 		type: "number",
 		default: 32,

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -546,6 +546,16 @@ export class Settings {
 			}
 		}
 
+		// task.isolation.enabled (boolean) -> task.isolation.mode (enum)
+		const taskObj = raw.task as Record<string, unknown> | undefined;
+		const isolationObj = taskObj?.isolation as Record<string, unknown> | undefined;
+		if (isolationObj && "enabled" in isolationObj) {
+			if (typeof isolationObj.enabled === "boolean") {
+				isolationObj.mode = isolationObj.enabled ? "worktree" : "none";
+			}
+			delete isolationObj.enabled;
+		}
+
 		return raw;
 	}
 

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -93,6 +93,17 @@ const OPTION_PROVIDERS: Partial<Record<SettingPath, OptionProvider>> = {
 		{ value: "2", label: "Double" },
 		{ value: "3", label: "Triple" },
 	],
+	// Task isolation mode
+	"task.isolation.mode": [
+		{ value: "none", label: "None", description: "No isolation" },
+		{ value: "worktree", label: "Worktree", description: "Git worktree isolation" },
+		{ value: "fuse-overlay", label: "Fuse Overlay", description: "COW overlay via fuse-overlayfs" },
+	],
+	// Task isolation merge strategy
+	"task.isolation.merge": [
+		{ value: "patch", label: "Patch", description: "Combine diffs and git apply" },
+		{ value: "branch", label: "Branch", description: "Commit per task, merge with --no-ff" },
+	],
 	// Todo max reminders
 	"todo.reminders.max": [
 		{ value: "1", label: "1 reminder" },

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -104,6 +104,11 @@ const OPTION_PROVIDERS: Partial<Record<SettingPath, OptionProvider>> = {
 		{ value: "patch", label: "Patch", description: "Combine diffs and git apply" },
 		{ value: "branch", label: "Branch", description: "Commit per task, merge with --no-ff" },
 	],
+	// Task isolation commit messages
+	"task.isolation.commits": [
+		{ value: "generic", label: "Generic", description: "Static commit message" },
+		{ value: "ai", label: "AI", description: "AI-generated commit message from diff" },
+	],
 	// Todo max reminders
 	"todo.reminders.max": [
 		{ value: "1", label: "1 reminder" },

--- a/packages/coding-agent/src/prompts/system/commit-message-system.md
+++ b/packages/coding-agent/src/prompts/system/commit-message-system.md
@@ -1,0 +1,2 @@
+Generate a concise git commit message from the provided diff. Use conventional commit format: `type(scope): description` where type is feat/fix/refactor/chore/test/docs and scope is optional. The description MUST be lowercase, imperative mood, no trailing period. Keep it under 72 characters.
+You MUST output ONLY the commit message, nothing else.

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -270,6 +270,19 @@ Sequential work MUST be justified. If you cannot articulate why B depends on A, 
 </parallel-reflex>
 {{/has}}
 
+{{#if eagerTasks}}
+<eager-tasks>
+You SHOULD delegate work to subagents by default. Working alone is the exception, not the rule.
+
+Use the Task tool unless the change is:
+- A single-file edit under ~30 lines
+- A direct answer or explanation with no code changes
+- A command the user asked you to run yourself
+
+For everything else — multi-file changes, refactors, new features, test additions, investigations — break the work into tasks and delegate. Err on the side of delegating. You are an orchestrator first, a coder second.
+</eager-tasks>
+{{/if}}
+
 <stakes>
 Incomplete work means they start over — your effort wasted, their time lost.
 

--- a/packages/coding-agent/src/prompts/tools/task-summary.md
+++ b/packages/coding-agent/src/prompts/tools/task-summary.md
@@ -20,9 +20,9 @@
 {{/unless}}
 {{/each}}
 
-{{#if patchApplySummary}}
-<patch-summary>
-{{patchApplySummary}}
-</patch-summary>
+{{#if mergeSummary}}
+<merge-summary>
+{{mergeSummary}}
+</merge-summary>
 {{/if}}
 </task-summary>

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -18,7 +18,7 @@ Subagents lack your conversation history. Every decision, file content, and user
 - `context`: Shared background prepended to every assignment. Session-specific info only.
 - `schema`: JTD schema for expected output. Format lives here — MUST NOT be duplicated in assignments.
 - `tasks`: Tasks to execute in parallel.
-- `isolated`: Run in isolated git worktree; returns patches. Use when tasks edit overlapping files.
+- `isolated`: Run in isolated environment; returns patches. Use when tasks edit overlapping files.
 </parameters>
 
 <critical>

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1121,6 +1121,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	});
 
 	const repeatToolDescriptions = settings.get("repeatToolDescriptions");
+	const eagerTasks = settings.get("task.eager");
 	const intentField = settings.get("tools.intentTracing") || $env.PI_INTENT_TRACING === "1" ? INTENT_FIELD : undefined;
 	const rebuildSystemPrompt = async (toolNames: string[], tools: Map<string, AgentTool>): Promise<string> => {
 		toolContextStore.setToolNames(toolNames);
@@ -1136,6 +1137,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			skillsSettings: settings.getGroup("skills") as SkillsSettings,
 			appendSystemPrompt: memoryInstructions,
 			repeatToolDescriptions,
+			eagerTasks,
 			intentField,
 		});
 
@@ -1155,6 +1157,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				customPrompt: options.systemPrompt,
 				appendSystemPrompt: memoryInstructions,
 				repeatToolDescriptions,
+				eagerTasks,
 				intentField,
 			});
 		}

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -421,6 +421,8 @@ export interface BuildSystemPromptOptions {
 	rules?: Array<{ name: string; description?: string; path: string; globs?: string[] }>;
 	/** Intent field name injected into every tool schema. If set, explains the field in the prompt. */
 	intentField?: string;
+	/** Encourage the agent to delegate via tasks unless changes are trivial. */
+	eagerTasks?: boolean;
 }
 
 /** Build the system prompt with tools, guidelines, and context */
@@ -442,6 +444,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		preloadedSkills: providedPreloadedSkills,
 		rules,
 		intentField,
+		eagerTasks = false,
 	} = options;
 	const resolvedCwd = cwd ?? getProjectDir();
 	const preloadedSkills = providedPreloadedSkills;
@@ -614,5 +617,6 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		appendSystemPrompt: resolvedAppendPrompt ?? "",
 		intentTracing: !!intentField,
 		intentField: intentField ?? "",
+		eagerTasks,
 	});
 }

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -806,7 +806,6 @@ export class TaskTool implements AgentTool<TaskSchema, TaskToolDetails, Theme> {
 
 					if (isolationMode === "fuse-overlay") {
 						isolationDir = await ensureFuseOverlay(repoRoot, task.id);
-						// Overlay already reflects the full working tree state — no baseline apply needed
 					} else {
 						isolationDir = await ensureWorktree(repoRoot, task.id);
 						await applyBaseline(isolationDir, baseline);

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -847,6 +847,8 @@ function renderAgentResult(result: SingleResult, isLast: boolean, expanded: bool
 
 	if (result.patchPath && !aborted && result.exitCode === 0) {
 		lines.push(`${continuePrefix}${theme.fg("dim", `Patch: ${result.patchPath}`)}`);
+	} else if (result.branchName && !aborted && result.exitCode === 0) {
+		lines.push(`${continuePrefix}${theme.fg("dim", `Branch: ${result.branchName}`)}`);
 	}
 
 	// Error message

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -77,7 +77,7 @@ const createTaskSchema = (options: { isolationEnabled: boolean }) => {
 			...properties,
 			isolated: Type.Optional(
 				Type.Boolean({
-					description: "Run in isolated git worktree; returns patches. Use when tasks edit overlapping files.",
+					description: "Run in isolated environment; returns patches. Use when tasks edit overlapping files.",
 				}),
 			),
 		});

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -2,6 +2,7 @@ import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Usage } from "@oh-my-pi/pi-ai";
 import { $env } from "@oh-my-pi/pi-utils";
 import { type Static, Type } from "@sinclair/typebox";
+import type { NestedRepoPatch } from "./worktree";
 
 /** Source of an agent definition */
 export type AgentSource = "bundled" | "user" | "project";
@@ -179,6 +180,10 @@ export interface SingleResult {
 	outputPath?: string;
 	/** Patch path for isolated worktree output */
 	patchPath?: string;
+	/** Branch name for isolated branch-mode output */
+	branchName?: string;
+	/** Nested repo patches to apply after parent merge */
+	nestedPatches?: NestedRepoPatch[];
 	/** Data extracted by registered subprocess tool handlers (keyed by tool name) */
 	extractedToolData?: Record<string, unknown[]>;
 	/** Output metadata for agent:// URL integration */

--- a/packages/coding-agent/src/task/worktree.ts
+++ b/packages/coding-agent/src/task/worktree.ts
@@ -1,3 +1,4 @@
+import type { Dirent } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import path from "node:path";
@@ -5,11 +6,19 @@ import { isEnoent, Snowflake } from "@oh-my-pi/pi-utils";
 import { getWorktreeDir } from "@oh-my-pi/pi-utils/dirs";
 import { $ } from "bun";
 
-export interface WorktreeBaseline {
+/** Baseline state for a single git repository. */
+export interface RepoBaseline {
 	repoRoot: string;
 	staged: string;
 	unstaged: string;
 	untracked: string[];
+}
+
+/** Baseline state for the project, including any nested git repos. */
+export interface WorktreeBaseline {
+	root: RepoBaseline;
+	/** Nested git repos (path relative to root.repoRoot). */
+	nested: Array<{ relativePath: string; baseline: RepoBaseline }>;
 }
 
 export function getEncodedProjectName(cwd: string): string {
@@ -39,7 +48,55 @@ export async function ensureWorktree(baseCwd: string, id: string): Promise<strin
 	return worktreeDir;
 }
 
-export async function captureBaseline(repoRoot: string): Promise<WorktreeBaseline> {
+/** Find nested git repositories (non-submodule) under the given root. */
+async function discoverNestedRepos(repoRoot: string): Promise<string[]> {
+	// Get submodule paths so we can exclude them
+	const submoduleRaw = await $`git submodule --quiet foreach --recursive 'echo $sm_path'`
+		.cwd(repoRoot)
+		.quiet()
+		.nothrow()
+		.text();
+	const submodulePaths = new Set(
+		submoduleRaw
+			.split("\n")
+			.map(l => l.trim())
+			.filter(Boolean),
+	);
+
+	// Find all .git dirs/files that aren't the root or known submodules
+	const result: string[] = [];
+	async function walk(dir: string): Promise<void> {
+		let entries: Dirent[];
+		try {
+			entries = await fs.readdir(dir, { withFileTypes: true });
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			if (entry.name === "node_modules" || entry.name === ".git") continue;
+			if (!entry.isDirectory()) continue;
+			const full = path.join(dir, entry.name);
+			const rel = path.relative(repoRoot, full);
+			// Check if this directory is itself a git repo
+			const gitDir = path.join(full, ".git");
+			let hasGit = false;
+			try {
+				await fs.access(gitDir);
+				hasGit = true;
+			} catch {}
+			if (hasGit && !submodulePaths.has(rel)) {
+				result.push(rel);
+				// Don't recurse into nested repos — they manage their own tree
+				continue;
+			}
+			await walk(full);
+		}
+	}
+	await walk(repoRoot);
+	return result;
+}
+
+async function captureRepoBaseline(repoRoot: string): Promise<RepoBaseline> {
 	const staged = await $`git diff --cached --binary`.cwd(repoRoot).quiet().text();
 	const unstaged = await $`git diff --binary`.cwd(repoRoot).quiet().text();
 	const untrackedRaw = await $`git ls-files --others --exclude-standard`.cwd(repoRoot).quiet().text();
@@ -47,13 +104,18 @@ export async function captureBaseline(repoRoot: string): Promise<WorktreeBaselin
 		.split("\n")
 		.map(line => line.trim())
 		.filter(line => line.length > 0);
+	return { repoRoot, staged, unstaged, untracked };
+}
 
-	return {
-		repoRoot,
-		staged,
-		unstaged,
-		untracked,
-	};
+export async function captureBaseline(repoRoot: string): Promise<WorktreeBaseline> {
+	const [root, nestedPaths] = await Promise.all([captureRepoBaseline(repoRoot), discoverNestedRepos(repoRoot)]);
+	const nested = await Promise.all(
+		nestedPaths.map(async relativePath => ({
+			relativePath,
+			baseline: await captureRepoBaseline(path.join(repoRoot, relativePath)),
+		})),
+	);
+	return { root, nested };
 }
 
 async function writeTempPatchFile(patch: string): Promise<string> {
@@ -81,13 +143,13 @@ async function applyPatch(
 	}
 }
 
-export async function applyBaseline(worktreeDir: string, baseline: WorktreeBaseline): Promise<void> {
-	await applyPatch(worktreeDir, baseline.staged, { cached: true });
-	await applyPatch(worktreeDir, baseline.staged);
-	await applyPatch(worktreeDir, baseline.unstaged);
+async function applyRepoBaseline(worktreeDir: string, rb: RepoBaseline, sourceRoot: string): Promise<void> {
+	await applyPatch(worktreeDir, rb.staged, { cached: true });
+	await applyPatch(worktreeDir, rb.staged);
+	await applyPatch(worktreeDir, rb.unstaged);
 
-	for (const entry of baseline.untracked) {
-		const source = path.join(baseline.repoRoot, entry);
+	for (const entry of rb.untracked) {
+		const source = path.join(sourceRoot, entry);
 		const destination = path.join(worktreeDir, entry);
 		try {
 			await fs.mkdir(path.dirname(destination), { recursive: true });
@@ -96,6 +158,25 @@ export async function applyBaseline(worktreeDir: string, baseline: WorktreeBasel
 			if (isEnoent(err)) continue;
 			throw err;
 		}
+	}
+}
+
+export async function applyBaseline(worktreeDir: string, baseline: WorktreeBaseline): Promise<void> {
+	await applyRepoBaseline(worktreeDir, baseline.root, baseline.root.repoRoot);
+
+	// Restore nested repos into the worktree
+	for (const { relativePath, baseline: nb } of baseline.nested) {
+		const nestedDir = path.join(worktreeDir, relativePath);
+		// Copy the nested repo wholesale (it's not managed by root git)
+		const sourceDir = path.join(baseline.root.repoRoot, relativePath);
+		try {
+			await fs.cp(sourceDir, nestedDir, { recursive: true });
+		} catch (err) {
+			if (isEnoent(err)) continue;
+			throw err;
+		}
+		// Then apply any uncommitted changes from the nested baseline
+		await applyRepoBaseline(nestedDir, nb, nb.repoRoot);
 	}
 }
 
@@ -122,37 +203,55 @@ async function listUntracked(cwd: string): Promise<string[]> {
 		.filter(line => line.length > 0);
 }
 
-export async function captureDeltaPatch(worktreeDir: string, baseline: WorktreeBaseline): Promise<string> {
+async function captureRepoDeltaPatch(repoDir: string, rb: RepoBaseline): Promise<string> {
 	const tempIndex = path.join(os.tmpdir(), `omp-task-index-${Snowflake.next()}`);
 	try {
-		await $`git read-tree HEAD`.cwd(worktreeDir).env({
-			GIT_INDEX_FILE: tempIndex,
-		});
-		await applyPatchToIndex(worktreeDir, baseline.staged, tempIndex);
-		await applyPatchToIndex(worktreeDir, baseline.unstaged, tempIndex);
-		const diff = await $`git diff --binary`
-			.cwd(worktreeDir)
-			.env({
-				GIT_INDEX_FILE: tempIndex,
-			})
-			.quiet()
-			.text();
+		await $`git read-tree HEAD`.cwd(repoDir).env({ GIT_INDEX_FILE: tempIndex });
+		await applyPatchToIndex(repoDir, rb.staged, tempIndex);
+		await applyPatchToIndex(repoDir, rb.unstaged, tempIndex);
+		const diff = await $`git diff --binary`.cwd(repoDir).env({ GIT_INDEX_FILE: tempIndex }).quiet().text();
 
-		const currentUntracked = await listUntracked(worktreeDir);
-		const baselineUntracked = new Set(baseline.untracked);
+		const currentUntracked = await listUntracked(repoDir);
+		const baselineUntracked = new Set(rb.untracked);
 		const newUntracked = currentUntracked.filter(entry => !baselineUntracked.has(entry));
 
 		if (newUntracked.length === 0) return diff;
 
 		const untrackedDiffs = await Promise.all(
 			newUntracked.map(entry =>
-				$`git diff --binary --no-index /dev/null ${entry}`.cwd(worktreeDir).quiet().nothrow().text(),
+				$`git diff --binary --no-index /dev/null ${entry}`.cwd(repoDir).quiet().nothrow().text(),
 			),
 		);
 		return `${diff}${diff && !diff.endsWith("\n") ? "\n" : ""}${untrackedDiffs.join("\n")}`;
 	} finally {
 		await fs.rm(tempIndex, { force: true });
 	}
+}
+
+/** Rewrite a/b paths in a unified diff to be prefixed with a subdirectory. */
+function prefixPatchPaths(patch: string, prefix: string): string {
+	if (!patch.trim()) return patch;
+	return patch.replace(/^(---|	\+\+\+) (a|b)\//gm, (_, marker, ab) => `${marker} ${ab}/${prefix}/`);
+}
+
+export async function captureDeltaPatch(isolationDir: string, baseline: WorktreeBaseline): Promise<string> {
+	const rootPatch = await captureRepoDeltaPatch(isolationDir, baseline.root);
+	const parts = [rootPatch];
+
+	for (const { relativePath, baseline: nb } of baseline.nested) {
+		const nestedDir = path.join(isolationDir, relativePath);
+		try {
+			await fs.access(path.join(nestedDir, ".git"));
+		} catch {
+			continue; // nested repo doesn't exist in isolation dir
+		}
+		const nestedPatch = await captureRepoDeltaPatch(nestedDir, nb);
+		if (nestedPatch.trim()) {
+			parts.push(prefixPatchPaths(nestedPatch, relativePath));
+		}
+	}
+
+	return parts.filter(p => p.trim()).join("\n");
 }
 
 export async function cleanupWorktree(dir: string): Promise<void> {
@@ -222,5 +321,124 @@ export async function cleanupFuseOverlay(mergedDir: string): Promise<void> {
 		// baseDir is the parent of the merged directory
 		const baseDir = path.dirname(mergedDir);
 		await fs.rm(baseDir, { recursive: true, force: true });
+	}
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Branch-mode isolation
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Commit task-only changes to a new branch.
+ * Uses captureDeltaPatch to isolate the task's changes from the baseline,
+ * then applies that patch on a clean branch from HEAD.
+ * Returns the branch name, or null if no changes to commit.
+ */
+export async function commitToBranch(
+	isolationDir: string,
+	baseline: WorktreeBaseline,
+	taskId: string,
+	description: string | undefined,
+): Promise<string | null> {
+	// Capture root patch and nested patches separately
+	const rootPatch = await captureRepoDeltaPatch(isolationDir, baseline.root);
+	const nestedChanges: Array<{ relativePath: string; patch: string }> = [];
+	for (const { relativePath, baseline: nb } of baseline.nested) {
+		const nestedDir = path.join(isolationDir, relativePath);
+		try {
+			await fs.access(path.join(nestedDir, ".git"));
+		} catch {
+			continue;
+		}
+		const np = await captureRepoDeltaPatch(nestedDir, nb);
+		if (np.trim()) nestedChanges.push({ relativePath, patch: np });
+	}
+
+	const hasChanges = rootPatch.trim() || nestedChanges.length > 0;
+	if (!hasChanges) return null;
+
+	const repoRoot = baseline.root.repoRoot;
+	const branchName = `omp/task/${taskId}`;
+	const commitMessage = description || taskId;
+
+	await $`git branch ${branchName} HEAD`.cwd(repoRoot).quiet();
+
+	const tmpDir = path.join(os.tmpdir(), `omp-branch-${Snowflake.next()}`);
+	try {
+		await $`git worktree add ${tmpDir} ${branchName}`.cwd(repoRoot).quiet();
+
+		// Apply root repo patch via git apply
+		if (rootPatch.trim()) {
+			const patchPath = path.join(os.tmpdir(), `omp-branch-patch-${Snowflake.next()}.patch`);
+			try {
+				await Bun.write(patchPath, rootPatch);
+				await $`git apply --binary ${patchPath}`.cwd(tmpDir).quiet();
+			} finally {
+				await fs.rm(patchPath, { force: true });
+			}
+		}
+
+		// Copy nested repo changes directly (they aren't tracked by root git)
+		for (const { relativePath } of nestedChanges) {
+			const nestedSrc = path.join(isolationDir, relativePath);
+			const nestedDst = path.join(tmpDir, relativePath);
+			await fs.cp(nestedSrc, nestedDst, { recursive: true });
+		}
+
+		await $`git add -A`.cwd(tmpDir).quiet();
+		await $`git -c user.name=omp -c user.email=omp@task commit -m ${commitMessage}`.cwd(tmpDir).quiet();
+	} finally {
+		await $`git worktree remove -f ${tmpDir}`.cwd(repoRoot).quiet().nothrow();
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	}
+
+	return branchName;
+}
+
+export interface MergeBranchResult {
+	merged: string[];
+	failed: string[];
+	conflict?: string;
+}
+
+/**
+ * Merge task branches sequentially into the working tree.
+ * Each branch gets a --no-ff merge commit preserving the task identity.
+ * Stops on first conflict and reports which branches succeeded.
+ */
+export async function mergeTaskBranches(
+	repoRoot: string,
+	branches: Array<{ branchName: string; taskId: string; description?: string }>,
+): Promise<MergeBranchResult> {
+	const merged: string[] = [];
+	const failed: string[] = [];
+
+	for (const { branchName, taskId, description } of branches) {
+		const mergeMessage = description || taskId;
+
+		const result = await $`git merge --no-ff -m ${mergeMessage} ${branchName}`.cwd(repoRoot).quiet().nothrow();
+
+		if (result.exitCode !== 0) {
+			// Abort the failed merge to restore clean state
+			await $`git merge --abort`.cwd(repoRoot).quiet().nothrow();
+			const stderr = result.stderr.toString().trim();
+			failed.push(branchName);
+			return {
+				merged,
+				failed: [...failed, ...branches.slice(merged.length + failed.length).map(b => b.branchName)],
+				conflict: `${branchName}: ${stderr}`,
+			};
+		}
+
+		merged.push(branchName);
+	}
+
+	return { merged, failed };
+}
+
+/** Clean up temporary task branches. */
+export async function cleanupTaskBranches(repoRoot: string, branches: string[]): Promise<void> {
+	for (const branch of branches) {
+		await $`git branch -D ${branch}`.cwd(repoRoot).quiet().nothrow();
 	}
 }

--- a/packages/coding-agent/src/utils/commit-message-generator.ts
+++ b/packages/coding-agent/src/utils/commit-message-generator.ts
@@ -14,19 +14,18 @@ import commitSystemPrompt from "../prompts/system/commit-message-system.md" with
 const COMMIT_SYSTEM_PROMPT = renderPromptTemplate(commitSystemPrompt);
 const MAX_DIFF_CHARS = 4000;
 
-/** Paths that should be excluded from commit message generation diffs. */
-const NOISE_PATH_PREFIXES = ["node_modules/", ".yarn/", ".pnp.", "dist/", "build/", ".next/", "coverage/"];
+/** File patterns that should be excluded from commit message generation diffs. */
+const NOISE_SUFFIXES = [".lock", ".lockb", "-lock.json", "-lock.yaml"];
 
-/** Strip diff hunks for noisy paths that drown out real changes. */
+/** Strip diff hunks for noisy files that drown out real changes. */
 function filterDiffNoise(diff: string): string {
 	const lines = diff.split("\n");
 	const filtered: string[] = [];
 	let skip = false;
 	for (const line of lines) {
 		if (line.startsWith("diff --git ")) {
-			// Extract b/ path from "diff --git a/... b/..."
 			const bPath = line.split(" b/")[1];
-			skip = bPath != null && NOISE_PATH_PREFIXES.some(p => bPath.startsWith(p));
+			skip = bPath != null && NOISE_SUFFIXES.some(s => bPath.endsWith(s));
 		}
 		if (!skip) filtered.push(line);
 	}

--- a/packages/coding-agent/src/utils/commit-message-generator.ts
+++ b/packages/coding-agent/src/utils/commit-message-generator.ts
@@ -1,0 +1,108 @@
+/**
+ * Generate commit messages from diffs using a smol, fast model.
+ * Follows the same pattern as title-generator.ts.
+ */
+import type { Api, Model } from "@oh-my-pi/pi-ai";
+import { completeSimple } from "@oh-my-pi/pi-ai";
+import { logger } from "@oh-my-pi/pi-utils";
+import type { ModelRegistry } from "../config/model-registry";
+import { parseModelString } from "../config/model-resolver";
+import { renderPromptTemplate } from "../config/prompt-templates";
+import MODEL_PRIO from "../priority.json" with { type: "json" };
+import commitSystemPrompt from "../prompts/system/commit-message-system.md" with { type: "text" };
+
+const COMMIT_SYSTEM_PROMPT = renderPromptTemplate(commitSystemPrompt);
+const MAX_DIFF_CHARS = 4000;
+
+function getSmolModelCandidates(registry: ModelRegistry, savedSmolModel?: string): Model<Api>[] {
+	const availableModels = registry.getAvailable();
+	if (availableModels.length === 0) return [];
+
+	const candidates: Model<Api>[] = [];
+	const addCandidate = (model?: Model<Api>): void => {
+		if (!model) return;
+		if (candidates.some(c => c.provider === model.provider && c.id === model.id)) return;
+		candidates.push(model);
+	};
+
+	if (savedSmolModel) {
+		const parsed = parseModelString(savedSmolModel);
+		if (parsed) {
+			const match = availableModels.find(m => m.provider === parsed.provider && m.id === parsed.id);
+			addCandidate(match);
+		}
+	}
+
+	for (const pattern of MODEL_PRIO.smol) {
+		const needle = pattern.toLowerCase();
+		addCandidate(availableModels.find(m => m.id.toLowerCase() === needle));
+		addCandidate(availableModels.find(m => m.id.toLowerCase().includes(needle)));
+	}
+
+	for (const model of availableModels) {
+		addCandidate(model);
+	}
+
+	return candidates;
+}
+
+/**
+ * Generate a commit message from a unified diff.
+ * Returns null if generation fails (caller should fall back to generic message).
+ */
+export async function generateCommitMessage(
+	diff: string,
+	registry: ModelRegistry,
+	savedSmolModel?: string,
+	sessionId?: string,
+): Promise<string | null> {
+	const candidates = getSmolModelCandidates(registry, savedSmolModel);
+	if (candidates.length === 0) {
+		logger.debug("commit-msg-generator: no smol model found");
+		return null;
+	}
+
+	const truncatedDiff = diff.length > MAX_DIFF_CHARS ? `${diff.slice(0, MAX_DIFF_CHARS)}\n… (truncated)` : diff;
+	const userMessage = `<diff>\n${truncatedDiff}\n</diff>`;
+
+	for (const model of candidates) {
+		const apiKey = await registry.getApiKey(model, sessionId);
+		if (!apiKey) continue;
+
+		try {
+			const response = await completeSimple(
+				model,
+				{
+					systemPrompt: COMMIT_SYSTEM_PROMPT,
+					messages: [{ role: "user", content: userMessage, timestamp: Date.now() }],
+				},
+				{ apiKey, maxTokens: 60 },
+			);
+
+			if (response.stopReason === "error") {
+				logger.debug("commit-msg-generator: error", { model: model.id, error: response.errorMessage });
+				continue;
+			}
+
+			let msg = "";
+			for (const content of response.content) {
+				if (content.type === "text") msg += content.text;
+			}
+			msg = msg.trim();
+			if (!msg) continue;
+
+			// Clean up: remove wrapping quotes, backticks, trailing period
+			msg = msg.replace(/^[`"']|[`"']$/g, "").replace(/\.$/, "");
+
+			logger.debug("commit-msg-generator: generated", { model: model.id, msg });
+			return msg;
+		} catch (err) {
+			logger.debug("commit-msg-generator: error", {
+				model: model.id,
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	}
+
+	return null;
+}


### PR DESCRIPTION
## What

- Added fuse-based work tree isolation
- Added branch based merging instead of patches for better handling when merging changes from different agents fail.
- Commit summarization when subagents finish work in branch mode.
- Added support for untracked nested git repositories (without .gitmodules)
- Added eager task tool usage as an option.

## Why

- Fuse is much faster than git worktree, skips installing dependencies + inherits compile cache
- patches get lost when agents fail to merge fail - branches fix this by preserving them and letting the main agent manually merge it.
- creates ready to push commits when everything is delegated to tasks instead.
- some project configurations have unrelated git repositories in ex vendor/* that are optional and git submodules are just genuinely bad ux.
- added eager tasks to support task-based (as mentioned above) workflow.

## Testing

Used replica-benchmark suite to test working in parallel and merging changes, chess-benchmark still fails since todo is apparently just not good enough :shrug: 

---

- [ ] `bun check` passes (preexisting errors?)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

[‎packages/coding-agent/src/utils/commit-message-generator.ts](https://github.com/can1357/oh-my-pi/pull/155/changes#diff-80768f4ab305eab302a3275b6a2ff54b1a1cf4529ccb9dd0ad42cc9db1c9904f) feels like it can be deduplicated, but computer refused to
