### PR TITLE
fix(coding-agent): git branch display not updating on branch switch

### DIFF
--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -4,7 +4,7 @@ import { formatNumber, getProjectDir } from "@oh-my-pi/pi-utils";
 import { theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
 import { shortenPath } from "../../tools/render-utils";
-import { findGitHeadPathAsync, sanitizeStatusText } from "../shared";
+import { findGitHeadPathSync, sanitizeStatusText } from "../shared";
 
 /**
  * Footer component that shows pwd, token stats, and context usage
@@ -53,22 +53,31 @@ export class FooterComponent implements Component {
 			this.#gitWatcher = null;
 		}
 
-		findGitHeadPathAsync().then(result => {
-			if (!result) {
-				return;
-			}
+		const gitHeadPath = findGitHeadPathSync();
+		if (!gitHeadPath) return;
 
-			try {
-				this.#gitWatcher = fs.watch(result.path, () => {
-					this.#cachedBranch = undefined; // Invalidate cache
-					if (this.#onBranchChange) {
-						this.#onBranchChange();
+		try {
+			this.#gitWatcher = fs.watch(gitHeadPath, () => {
+				// Read branch synchronously when change detected
+				try {
+					const content = fs.readFileSync(gitHeadPath, "utf8").trim();
+					if (content.startsWith("ref: refs/heads/")) {
+						this.#cachedBranch = content.slice(16);
+					} else {
+						this.#cachedBranch = "detached";
 					}
-				});
-			} catch {
-				// Silently fail if we can't watch
-			}
-		});
+				} catch {
+					// Invalidate cache on transient read failure (e.g., atomic HEAD rewrite)
+					// so next render re-reads HEAD instead of caching null
+					this.#cachedBranch = undefined;
+				}
+				if (this.#onBranchChange) {
+					this.#onBranchChange();
+				}
+			});
+		} catch {
+			// Silently fail if we can't watch
+		}
 	}
 
 	/**
@@ -96,30 +105,25 @@ export class FooterComponent implements Component {
 			return this.#cachedBranch;
 		}
 
-		// Note: fire-and-forget async call - will return undefined on first call
-		// This is acceptable since it's a cached value that will update on next render
-		findGitHeadPathAsync().then(result => {
-			if (!result) {
-				this.#cachedBranch = null;
-				if (this.#onBranchChange) {
-					this.#onBranchChange();
-				}
-				return;
-			}
-			const content = result.content.trim();
+		// Read branch synchronously
+		const gitHeadPath = findGitHeadPathSync();
+		if (!gitHeadPath) {
+			this.#cachedBranch = null;
+			return null;
+		}
 
+		try {
+			const content = fs.readFileSync(gitHeadPath, "utf8").trim();
 			if (content.startsWith("ref: refs/heads/")) {
 				this.#cachedBranch = content.slice(16);
 			} else {
 				this.#cachedBranch = "detached";
 			}
-			if (this.#onBranchChange) {
-				this.#onBranchChange();
-			}
-		});
+		} catch {
+			this.#cachedBranch = null;
+		}
 
-		// Return undefined while loading (will show on next render once loaded)
-		return null;
+		return this.#cachedBranch ?? null;
 	}
 
 	render(width: number): string[] {

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -106,7 +106,19 @@ export class StatusLineComponent implements Component {
 
 		try {
 			this.#gitWatcher = fs.watch(gitHeadPath, () => {
-				this.#cachedBranch = undefined;
+				// Read branch synchronously when change detected
+				try {
+					const content = fs.readFileSync(gitHeadPath, "utf8").trim();
+					if (content.startsWith("ref: refs/heads/")) {
+						this.#cachedBranch = content.slice(16);
+					} else {
+						this.#cachedBranch = "detached";
+					}
+				} catch {
+					// Invalidate cache on transient read failure (e.g., atomic HEAD rewrite)
+					// so next render re-reads HEAD instead of caching null
+					this.#cachedBranch = undefined;
+				}
 				if (this.#onBranchChange) {
 					this.#onBranchChange();
 				}


### PR DESCRIPTION
## Problem

The git branch displayed in the footer (bottom of screen) and status line (editor top border) did not update when switching branches using `git checkout`.

## Root Cause

This regression was introduced in #919de2ce during the async file operations migration. The file watcher callback used an asynchronous approach to read the branch name:

1. When the watcher detected a change to `.git/HEAD`, it invalidated the cached branch
2. Called `onBranchChange()` to trigger a re-render
3. But the branch reading happened asynchronously in the background
4. During the immediate re-render, `getCurrentBranch()` returned `null` because the async operation hadn't completed
5. This created a race condition where the branch never appeared to update

## Solution

Read the branch **synchronously** in the watcher callback, populating the cache **before** calling `onBranchChange()`. This ensures the branch is available immediately when the re-render happens.

## Changes

- `packages/coding-agent/src/modes/components/footer.ts`: Fixed watcher to read branch synchronously
- `packages/coding-agent/src/modes/components/status-line.ts`: Fixed watcher to read branch synchronously (same issue)

## Testing

- TypeScript compilation passes (`bun check:ts`)
- Rust compilation passes (`bun check:rs`)
- All biome checks pass

## Verification

To verify the fix works:
1. Start the agent in a git repository
2. Switch branches using `git checkout <branch>` in another terminal
3. The branch name in the footer should update immediately