### PR TITLE
fix(tui): preserve aspect ratio for height-capped images

### DIFF
--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -56,7 +56,10 @@ export class Image implements Component {
 		let lines: string[];
 
 		if (TERMINAL.imageProtocol) {
-			const result = renderImage(this.#base64Data, this.#dimensions, { maxWidthCells: maxWidth });
+			const result = renderImage(this.#base64Data, this.#dimensions, {
+				maxWidthCells: maxWidth,
+				maxHeightCells: this.#options.maxHeightCells,
+			});
 
 			if (result) {
 				// Return `rows` lines so TUI accounts for image height

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -214,6 +214,32 @@ export function calculateImageRows(
 	return Math.max(1, rows);
 }
 
+function calculateImageFit(
+	imageDimensions: ImageDimensions,
+	options: ImageRenderOptions,
+	cellDims: CellDimensions,
+): { columns: number; rows: number } {
+	const maxColumns = options.maxWidthCells !== undefined ? Math.max(1, Math.floor(options.maxWidthCells)) : undefined;
+	const maxRows = options.maxHeightCells !== undefined ? Math.max(1, Math.floor(options.maxHeightCells)) : undefined;
+
+	if (maxColumns === undefined && maxRows === undefined) {
+		const columns = Math.max(1, Math.ceil(imageDimensions.widthPx / cellDims.widthPx));
+		const rows = Math.max(1, Math.ceil(imageDimensions.heightPx / cellDims.heightPx));
+		return { columns, rows };
+	}
+
+	const maxWidthPx = maxColumns !== undefined ? maxColumns * cellDims.widthPx : Number.POSITIVE_INFINITY;
+	const maxHeightPx = maxRows !== undefined ? maxRows * cellDims.heightPx : Number.POSITIVE_INFINITY;
+	const scale = Math.min(maxWidthPx / imageDimensions.widthPx, maxHeightPx / imageDimensions.heightPx);
+	const fittedWidthPx = imageDimensions.widthPx * scale;
+	const fittedHeightPx = imageDimensions.heightPx * scale;
+
+	return {
+		columns: Math.max(1, Math.floor(fittedWidthPx / cellDims.widthPx)),
+		rows: Math.max(1, Math.ceil(fittedHeightPx / cellDims.heightPx)),
+	};
+}
+
 export function getPngDimensions(base64Data: string): ImageDimensions | null {
 	try {
 		const buffer = Buffer.from(base64Data, "base64");
@@ -364,21 +390,23 @@ export function renderImage(
 		return null;
 	}
 
-	const maxWidth = options.maxWidthCells ?? 80;
-	const rows = calculateImageRows(imageDimensions, maxWidth, getCellDimensions());
+	const fit = calculateImageFit(imageDimensions, options, getCellDimensions());
 
 	if (TERMINAL.imageProtocol === ImageProtocol.Kitty) {
-		const sequence = encodeKitty(base64Data, { columns: maxWidth, rows });
-		return { sequence, rows };
+		const sequence = encodeKitty(base64Data, {
+			columns: fit.columns,
+			rows: fit.rows,
+		});
+		return { sequence, rows: fit.rows };
 	}
 
 	if (TERMINAL.imageProtocol === ImageProtocol.Iterm2) {
 		const sequence = encodeITerm2(base64Data, {
-			width: maxWidth,
+			width: fit.columns,
 			height: "auto",
 			preserveAspectRatio: options.preserveAspectRatio ?? true,
 		});
-		return { sequence, rows };
+		return { sequence, rows: fit.rows };
 	}
 
 	return null;

--- a/packages/tui/test/image-render.test.ts
+++ b/packages/tui/test/image-render.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Image } from "@oh-my-pi/pi-tui/components/image";
+import {
+	type CellDimensions,
+	getCellDimensions,
+	ImageProtocol,
+	renderImage,
+	setCellDimensions,
+	TERMINAL,
+} from "@oh-my-pi/pi-tui/terminal-capabilities";
+
+type MutableTerminalInfo = {
+	imageProtocol: ImageProtocol | null;
+};
+
+const terminal = TERMINAL as unknown as MutableTerminalInfo;
+const BASE64_DUMMY = "AA==";
+const SQUARE_DIMENSIONS = { widthPx: 100, heightPx: 100 };
+
+function parseKittyParam(sequence: string, key: "c" | "r"): number | null {
+	const match = sequence.match(new RegExp(`${key}=(\\d+)`));
+	if (!match) return null;
+	return Number.parseInt(match[1], 10);
+}
+
+function parseITermWidth(sequence: string): string | null {
+	const match = sequence.match(/width=([^;:]+)/);
+	return match?.[1] ?? null;
+}
+
+describe("terminal image rendering", () => {
+	const originalProtocol = TERMINAL.imageProtocol;
+	let originalCellDims: CellDimensions;
+
+	beforeEach(() => {
+		originalCellDims = { ...getCellDimensions() };
+		setCellDimensions({ widthPx: 10, heightPx: 10 });
+		terminal.imageProtocol = null;
+	});
+
+	afterEach(() => {
+		setCellDimensions(originalCellDims);
+		terminal.imageProtocol = originalProtocol;
+	});
+
+	it("fits Kitty images within max width and max height while preserving aspect ratio", () => {
+		terminal.imageProtocol = ImageProtocol.Kitty;
+		const result = renderImage(BASE64_DUMMY, SQUARE_DIMENSIONS, {
+			maxWidthCells: 10,
+			maxHeightCells: 2,
+		});
+
+		expect(result).not.toBeNull();
+		expect(result?.rows).toBe(2);
+		expect(parseKittyParam(result?.sequence ?? "", "c")).toBe(2);
+		expect(parseKittyParam(result?.sequence ?? "", "r")).toBe(2);
+	});
+
+	it("uses intrinsic image size when no bounds are provided", () => {
+		terminal.imageProtocol = ImageProtocol.Kitty;
+		const result = renderImage(BASE64_DUMMY, SQUARE_DIMENSIONS);
+
+		expect(result).not.toBeNull();
+		expect(result?.rows).toBe(10);
+		expect(parseKittyParam(result?.sequence ?? "", "c")).toBe(10);
+		expect(parseKittyParam(result?.sequence ?? "", "r")).toBe(10);
+	});
+
+	it("reduces iTerm2 width when max height is the limiting bound", () => {
+		terminal.imageProtocol = ImageProtocol.Iterm2;
+		const result = renderImage(BASE64_DUMMY, SQUARE_DIMENSIONS, {
+			maxWidthCells: 10,
+			maxHeightCells: 2,
+		});
+
+		expect(result).not.toBeNull();
+		expect(result?.rows).toBe(2);
+		expect(parseITermWidth(result?.sequence ?? "")).toBe("2");
+		expect(result?.sequence).toContain("height=auto");
+	});
+
+	it("Image component forwards maxHeightCells to terminal rendering", () => {
+		terminal.imageProtocol = ImageProtocol.Kitty;
+		const image = new Image(
+			BASE64_DUMMY,
+			"image/png",
+			{ fallbackColor: text => text },
+			{ maxWidthCells: 10, maxHeightCells: 2 },
+			SQUARE_DIMENSIONS,
+		);
+
+		const lines = image.render(20);
+
+		expect(lines).toHaveLength(2);
+		expect(lines[1]).toContain("\x1b[1A");
+		expect(lines[1]).toContain("c=2");
+		expect(lines[1]).toContain("r=2");
+	});
+});


### PR DESCRIPTION
## What

Image previews were sized from max width first and then height-limited, which could stretch renders when maxHeightCells was the actual limiting bound. Compute a proportional fit within both bounds and forward maxHeightCells through the Image component.

## Why

#170

## Testing

* Unit test added
* Correct behavior verified in app

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
