### PR TITLE
fix(submit-result): make data required in schema to prevent submit loop

### DIFF
--- a/packages/coding-agent/src/tools/submit-result.ts
+++ b/packages/coding-agent/src/tools/submit-result.ts
@@ -92,7 +92,7 @@ export class SubmitResultTool implements AgentTool<TObject, SubmitResultDetails>
 			: Type.Object({}, { additionalProperties: true, description: "Structured JSON output (no schema specified)" });
 
 		this.parameters = Type.Object({
-			data: Type.Optional(dataSchema),
+			data: dataSchema,
 			status: Type.Optional(
 				StringEnum(["success", "aborted"], {
 					description: "Use 'aborted' if the task cannot be completed, defaults to 'success'",


### PR DESCRIPTION
## Problem

The `submit_result` tool marks `data` as optional (`Type.Optional`) in its JSON schema, but runtime validation requires it when `status` is `'success'`. Models that follow the schema literally omit the `data` parameter, causing every call to fail with:

```
data is required when status is 'success' (got null/undefined)
```

The agent then retries indefinitely, never advancing to the next pipeline stage.

## Solution

Change `data: Type.Optional(dataSchema)` to `data: dataSchema` so the schema matches runtime requirements. Models are now forced to include the data object when calling `submit_result` with success.

For `status: 'aborted'`, models can pass `data: {}`; validation is skipped for aborts.

## Testing

- `bun test packages/coding-agent/test/tools/submit-result-extraction.test.ts` passes

Made with [Cursor](https://cursor.com)