### PR TITLE
fix(mcp): make disabledServers work on user-level third-party servers

### DIFF
--- a/packages/coding-agent/src/mcp/config.ts
+++ b/packages/coding-agent/src/mcp/config.ts
@@ -110,7 +110,7 @@ export async function loadAllMCPConfigs(cwd: string, options?: LoadMCPConfigsOpt
 	let sources: Record<string, SourceMeta> = {};
 	for (const server of servers) {
 		const config = convertToLegacyConfig(server);
-		if (config.enabled === false || (server._source.level !== "user" && disabledServers.has(server.name))) {
+		if (config.enabled === false || disabledServers.has(server.name)) {
 			continue;
 		}
 		configs[server.name] = config;


### PR DESCRIPTION
## What

Remove the level guard so disabledServers applies unconditionally. This is safe because the /mcp disable command already uses updateMCPServer (setting enabled: false inline) for servers defined in omp own configs; the disabledServers path only fires for third-party discovered servers.

Also fix the /mcp list display to cross-filter discovered servers against the disabled list, preventing a server from appearing both as "connected" and "disabled" when the MCP manager has stale state.

## Why

The disabledServers mechanism introduced in 445e0442 (Merge branch 'pr-82', 2026-02-16) was defeated by a level guard added after merge: servers with _source.level === "user" were exempt from the disabled check. This meant servers discovered from ~/.claude.json (which the Claude provider tags as level "user") were never actually filtered out, even when present in disabledServers.

## Testing

I had a mcp configured in `~/.claude.json` that kept showing up prior to this fix. I tested the fix in two ways
- running `/mcp list` and making sure it's not listed anymore
- running `/dump` and making sure that the context is no longer loaded

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
