### PR TITLE
fix(ai): coerce string-to-number for Optional<number> tool parameters

### DIFF
--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -303,13 +303,10 @@ function normalizeOptionalNullsForSchema(schema: unknown, value: unknown): { val
 	// This fixes anyOf:[{type:"number"},{type:"null"}] (i.e. Optional<number>) where
 	// AJV reports an "anyOf" error rather than a "type" error, bypassing
 	// coerceArgsFromErrors which only handles keyword:"type" errors.
-	if (
-		(schemaObject.type === "number" || schemaObject.type === "integer") &&
-		typeof value === "string"
-	) {
+	if ((schemaObject.type === "number" || schemaObject.type === "integer") && typeof value === "string") {
 		return tryParseNumberString(value, [schemaObject.type as string]);
 	}
-	
+
 	if (schemaObject.type !== "object") return { value, changed: false };
 	if (typeof value !== "object" || value === null) return { value, changed: false };
 	if (Array.isArray(value)) return { value, changed: false };

--- a/packages/ai/test/tool-argument-coercion.test.ts
+++ b/packages/ai/test/tool-argument-coercion.test.ts
@@ -325,7 +325,7 @@ describe("Tool argument coercion", () => {
 
 		expect(() => validateToolArguments(tool, toolCall)).toThrow('Validation failed for tool "t6"');
 	});
-	
+
 	it("coerces numeric string for Optional<number> (anyOf:[number,null])", () => {
 		const tool: Tool = {
 			name: "t14",


### PR DESCRIPTION
## Problem

Tool parameters typed as `Type.Optional(Type.Number())` (i.e. optional numeric fields) were not being coerced when the LLM passed their value as a string (e.g. `"1.0"` instead of `1.0`).

Required numeric fields (`Type.Number()`) worked correctly — the existing `coerceArgsFromErrors` path handles `keyword:"type"` AJV errors produced by plain `{type:"number"}` schemas.

Optional fields are the bug surface. TypeBox compiles `Type.Optional(Type.Number())` to:

```json
{ "anyOf": [{"type": "number"}, {"type": "null"}] }
```

AJV validates `"1.0"` against this schema and reports a **`keyword:"anyOf"`** error — not a `keyword:"type"` error. `coerceArgsFromErrors` filters strictly on `keyword === "type"`, so the string is never coerced.

The secondary path, `normalizeOptionalNullsForSchema`, does traverse `anyOf` branches recursively. However, for a branch schema of `{type:"number"}` it immediately hits:

```ts
if (schemaObject.type !== "object") return { value, changed: false };
```

…and exits without attempting string-to-number coercion. So the traversal returns no change and the string is passed through to the MCP server, which rejects it.

## Root cause summary

`normalizeOptionalNullsForSchema` handles `null`-removal for optional fields but never attempts type coercion for primitive-typed branches. The coercion infrastructure (`tryParseNumberString`) existed and worked — it just wasn't reachable from the `anyOf` traversal path.

## Fix

Add a string-to-number guard in `normalizeOptionalNullsForSchema` before the early-return for non-object schemas:

```ts
if (
  (schemaObject.type === "number" || schemaObject.type === "integer") &&
  typeof value === "string"
) {
  return tryParseNumberString(value, [schemaObject.type as string]);
}
```

This makes the existing `anyOf` traversal in `normalizeAnyOfLike` correctly coerce `"1.0"` → `1.0` when it recurses into the `{type:"number"}` branch.

## Tests

Two new cases added to `tool-argument-coercion.test.ts`:

- **t14**: `Optional<number>` field receives string `"1.0"` → coerced to `1.0` ✓  
- **t15**: `Optional<number>` field absent → remains `undefined` ✓  

All 15 coercion tests pass (13 pre-existing + 2 new).

## Affected schema patterns

Any tool parameter declared as `Type.Optional(Type.Number())` or `Type.Optional(Type.Integer())`. Equivalent patterns from external MCP servers using JSON Schema `anyOf:[{type:"number"},{type:"null"}]` (e.g. Rust `schemars` deriving schema for `Option<f64>`) are also fixed.