### PR TITLE
feat: support explicit OAuth clientId and callbackPort in MCP server config

### DIFF
--- a/packages/coding-agent/src/capability/mcp.ts
+++ b/packages/coding-agent/src/capability/mcp.ts
@@ -32,6 +32,11 @@ export interface MCPServer {
 		type: "oauth" | "apikey";
 		credentialId?: string;
 	};
+	/** OAuth configuration (clientId, callbackPort) for servers requiring explicit client credentials */
+	oauth?: {
+		clientId?: string;
+		callbackPort?: number;
+	};
 	/** Transport type */
 	transport?: "stdio" | "sse" | "http";
 	/** Source metadata (added by loader) */

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -157,6 +157,7 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 				url: serverConfig.url as string | undefined,
 				headers: serverConfig.headers as Record<string, string> | undefined,
 				auth: serverConfig.auth as { type: "oauth" | "apikey"; credentialId?: string } | undefined,
+				oauth: serverConfig.oauth as { clientId?: string; callbackPort?: number } | undefined,
 				transport: serverConfig.type as "stdio" | "sse" | "http" | undefined,
 				_source: createSourceMeta(PROVIDER_ID, path, level),
 			});

--- a/packages/coding-agent/src/discovery/mcp-json.ts
+++ b/packages/coding-agent/src/discovery/mcp-json.ts
@@ -36,6 +36,7 @@ interface MCPConfigFile {
 				credentialId?: string;
 			};
 			type?: "stdio" | "sse" | "http";
+			oauth?: { clientId?: string; callbackPort?: number };
 		}
 	>;
 }
@@ -81,6 +82,7 @@ function transformMCPConfig(config: MCPConfigFile, source: SourceMeta): MCPServe
 				url: serverConfig.url,
 				headers: serverConfig.headers,
 				auth: serverConfig.auth,
+				oauth: serverConfig.oauth,
 				transport: serverConfig.type,
 				_source: source,
 			};

--- a/packages/coding-agent/src/mcp/config.ts
+++ b/packages/coding-agent/src/mcp/config.ts
@@ -42,6 +42,7 @@ function convertToLegacyConfig(server: MCPServer): MCPServerConfig {
 		enabled: server.enabled,
 		timeout: server.timeout,
 		auth: server.auth,
+		oauth: server.oauth,
 	};
 
 	if (transport === "stdio") {

--- a/packages/coding-agent/src/mcp/oauth-flow.ts
+++ b/packages/coding-agent/src/mcp/oauth-flow.ts
@@ -22,6 +22,8 @@ export interface MCPOAuthConfig {
 	clientSecret?: string;
 	/** OAuth scopes (space-separated) */
 	scopes?: string;
+	/** Custom callback port (default: 3000) */
+	callbackPort?: number;
 }
 
 /**
@@ -37,7 +39,7 @@ export class MCPOAuthFlow extends OAuthCallbackFlow {
 		private config: MCPOAuthConfig,
 		ctrl: OAuthController,
 	) {
-		super(ctrl, DEFAULT_PORT, CALLBACK_PATH);
+		super(ctrl, config.callbackPort ?? DEFAULT_PORT, CALLBACK_PATH);
 		this.#resolvedClientId = this.#resolveClientId(config);
 	}
 

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -59,6 +59,11 @@ interface MCPServerConfigBase {
 	timeout?: number;
 	/** Authentication configuration (optional) */
 	auth?: MCPAuthConfig;
+	/** OAuth configuration for servers requiring explicit client credentials */
+	oauth?: {
+		clientId?: string;
+		callbackPort?: number;
+	};
 }
 
 /** Stdio server configuration */

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -282,9 +282,10 @@ export class MCPCommandController {
 							const credentialId = await this.#handleOAuthFlow(
 								oauth.authorizationUrl,
 								oauth.tokenUrl,
-								oauth.clientId ?? "",
+								oauth.clientId ?? finalConfig.oauth?.clientId ?? "",
 								"",
 								oauth.scopes ?? "",
+								finalConfig.oauth?.callbackPort,
 							);
 							finalConfig = {
 								...finalConfig,
@@ -352,6 +353,7 @@ export class MCPCommandController {
 		clientId: string,
 		clientSecret: string,
 		scopes: string,
+		callbackPort?: number,
 	): Promise<string> {
 		const authStorage = this.ctx.session.modelRegistry.authStorage;
 		let parsedAuthUrl: URL;
@@ -377,6 +379,7 @@ export class MCPCommandController {
 					clientId: resolvedClientId,
 					clientSecret: clientSecret || undefined,
 					scopes: scopes || undefined,
+					callbackPort,
 				},
 				{
 					onAuth: (info: { url: string; instructions?: string }) => {
@@ -1198,9 +1201,10 @@ export class MCPCommandController {
 			const credentialId = await this.#handleOAuthFlow(
 				oauth.authorizationUrl,
 				oauth.tokenUrl,
-				oauth.clientId ?? "",
+				oauth.clientId ?? found.config.oauth?.clientId ?? "",
 				"",
 				oauth.scopes ?? "",
+				found.config.oauth?.callbackPort,
 			);
 
 			const updated: MCPServerConfig = {


### PR DESCRIPTION
## What

Add support for an `oauth` config block on MCP server entries in `mcp.json`, allowing explicit `clientId` and `callbackPort` values for servers that don't expose these through auto-discovery.

This enables support for the config format used by [Claude's official Slack plugin](https://github.com/anthropics/claude-plugins-official/blob/main/external_plugins/slack/.mcp.json), where `oauth.clientId` and `oauth.callbackPort` are specified directly in the server config.

## Why

Some MCP servers (notably Slack) require an explicit `client_id` in the OAuth authorization URL but don't return it in their 401 error response or `.well-known/oauth-authorization-server` metadata. Similarly, some servers require a specific callback port that differs from the default (3000).

Without this, the OAuth flow fails with `Please specify client_id` because auto-discovery can't find the value.

The `oauth.clientId` is used as a **fallback** — if the server's error response or well-known metadata includes a `client_id`, that takes precedence.

## Testing

- Tested locally with Slack MCP server (`https://mcp.slack.com/mcp`)
- Verified `client_id` appears in the OAuth authorization URL
- Verified `callbackPort: 3118` is used instead of default 3000
- Verified OAuth flow completes and token is stored
- Verified existing servers with auto-discovered OAuth continue to work unchanged

---

- [ ] `bun check` passes
- [ ] Tested locally
- [ ] CHANGELOG updated (if user-facing)