### PR TITLE
Fix adaptive thinking effort for Bedrock Sonnet 4.6 and Opus 4.5

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -950,6 +950,13 @@ function buildParams(
 				type: "enabled",
 				budget_tokens: options.thinkingBudgetTokens || 1024,
 			};
+			// Opus 4.5 supports effort alongside budget-based thinking
+			if (model.id.includes("opus-4-5") || model.id.includes("opus-4.5")) {
+				const effort = options.effort ?? mapThinkingLevelToEffort(options.reasoning);
+				if (effort) {
+					params.output_config = { effort };
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes three issues with thinking effort handling found by comparing against [Anthropic's official effort docs](https://docs.anthropic.com/en/docs/build-with-claude/effort):

## Bedrock: Sonnet 4.6 missing adaptive thinking (bug)

`amazon-bedrock.ts` `supportsAdaptiveThinking` only checked for Opus 4.6, not Sonnet 4.6. Since Sonnet 4.6 failed the adaptive check, and the next branch checks `!model.id.includes("anthropic.claude")`, thinking was silently disabled entirely for Sonnet 4.6 on Bedrock.

The direct Anthropic provider (`anthropic.ts`) and stream layer (`stream.ts`) both already include Sonnet 4.6 -- only Bedrock was missing it.

## Bedrock: No max effort clamping for Sonnet 4.6 (latent bug, exposed by fix above)

Per Anthropic docs, `max` effort is Opus 4.6 only and errors on other models. The Bedrock path had no `supportsMaxEffort` guard (unlike `stream.ts` which correctly clamps `xhigh` -> `high` for Sonnet). Without this fix, enabling the Sonnet 4.6 adaptive path would send `max` effort to the API when thinking level is `xhigh`, causing API errors.

## Anthropic: Opus 4.5 not sending output_config effort (gap)

Per [Anthropic docs](https://docs.anthropic.com/en/docs/build-with-claude/effort): *"Claude Opus 4.5 and other Claude 4 models use manual thinking, where effort works alongside the thinking token budget."*

The `buildParams` else-branch for non-adaptive models set `thinking: {type: "enabled", budget_tokens}` but never set `output_config`. Added effort support for Opus 4.5 alongside budget-based thinking.

## Changes

- `packages/ai/src/providers/amazon-bedrock.ts`: Add Sonnet 4.6 to `supportsAdaptiveThinking`, clamp max effort for non-Opus models
- `packages/ai/src/providers/anthropic.ts`: Add `output_config: {effort}` for Opus 4.5 in budget-based thinking path

Verified: `bun check:ts` passes (biome + tsgo).
