### PR TITLE
fix(usage): show percentage and invert bar to show remaining capacity

### DIFF
--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -857,7 +857,7 @@ function formatNumber(value: number, maxFractionDigits = 1): string {
 }
 
 function formatUsedAccounts(value: number): string {
-	return `${value.toFixed(2)} used`;
+	return `${formatNumber(value * 100)}% used`;
 }
 
 function resolveProviderAuthMode(authStorage: AuthStorage, provider: string): string {
@@ -1043,7 +1043,8 @@ function renderUsageBar(limit: UsageLimit, uiTheme: typeof theme): string {
 		return uiTheme.fg("dim", `[${"·".repeat(BAR_WIDTH)}]`);
 	}
 	const clamped = Math.min(Math.max(fraction, 0), 1);
-	const filled = Math.round(clamped * BAR_WIDTH);
+	const remaining = 1 - clamped;
+	const filled = Math.round(remaining * BAR_WIDTH);
 	const filledBar = "█".repeat(filled);
 	const emptyBar = "░".repeat(Math.max(0, BAR_WIDTH - filled));
 	const color = resolveStatusColor(limit.status);


### PR DESCRIPTION
## Summary

Two fixes for the `/usage` display:

1. **Percentage formatting**: `formatUsedAccounts` showed raw fraction (e.g. `0.02 used`) instead of percentage (`2% used`). Now multiplies by 100 and uses `formatNumber()` for consistent display.

2. **Bar direction**: `renderUsageBar` filled portion represented **used** amount, making the bar mostly gray at low usage. Users intuitively expect a full green bar when plenty of quota remains. Inverted to fill based on **remaining** fraction (`1 - used`).

### Before
```
[░░░░░░░░░░░░░░░░░░░░░░░░] 0.02 used (98% left)
```
Bar is almost entirely empty/gray despite 98% quota remaining.

### After
```
[████████████████████████░] 2% used (98% left)
```
Bar is almost entirely green, reflecting available capacity.

## Test plan
- [ ] Run `/usage` with a provider that has low usage — bar should be mostly filled (green)
- [ ] Run `/usage` with a provider near limit — bar should be mostly empty (red/warning)
- [ ] Verify multi-account aggregate display still shows correct `X% used (Y% left)`