### PR TITLE
feat(theme): implement Mode 2031 for automatic dark/light theme switching

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -54,7 +54,7 @@ import { SSHCommandController } from "./controllers/ssh-command-controller";
 import { OAuthManualInputManager } from "./oauth-manual-input";
 import { setMermaidRenderCallback } from "./theme/mermaid-cache";
 import type { Theme } from "./theme/theme";
-import { getEditorTheme, getMarkdownTheme, onThemeChange, theme } from "./theme/theme";
+import { getEditorTheme, getMarkdownTheme, onTerminalAppearanceChange, onThemeChange, theme } from "./theme/theme";
 import type { CompactionQueuedMessage, InteractiveModeContext, TodoItem, TodoPhase } from "./types";
 import { UiHelpers } from "./utils/ui-helpers";
 
@@ -361,6 +361,13 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.ui.invalidate();
 			this.updateEditorBorderColor();
 			this.ui.requestRender();
+		});
+
+		// Subscribe to terminal Mode 2031 dark/light appearance change notifications.
+		// When the OS or terminal switches between dark and light mode, the terminal
+		// sends a DSR and we re-evaluate which theme to use.
+		this.ui.terminal.onAppearanceChange(mode => {
+			onTerminalAppearanceChange(mode);
 		});
 
 		// Set up git branch watcher

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -57,7 +57,7 @@ export {
 export { StdinBuffer, type StdinBufferEventMap, type StdinBufferOptions } from "./stdin-buffer";
 export type { BoxSymbols, SymbolTheme } from "./symbols";
 // Terminal interface and implementations
-export { emergencyTerminalRestore, ProcessTerminal, type Terminal } from "./terminal";
+export { emergencyTerminalRestore, ProcessTerminal, type Terminal, type TerminalAppearance } from "./terminal";
 // Terminal image support
 export * from "./terminal-capabilities";
 // TTY ID

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -30,6 +30,7 @@ export function emergencyTerminalRestore(): void {
 			// This avoids writing escape sequences for non-TUI commands (grep, commit, etc.)
 			process.stdout.write(
 				"\x1b[?2004l" + // Disable bracketed paste
+					"\x1b[?2031l" + // Disable Mode 2031 appearance notifications
 					"\x1b[<u" + // Pop kitty keyboard protocol
 					"\x1b[?25h", // Show cursor
 			);
@@ -41,6 +42,8 @@ export function emergencyTerminalRestore(): void {
 		// Terminal may already be dead during crash cleanup - ignore errors
 	}
 }
+/** Terminal-reported appearance (dark/light mode). */
+export type TerminalAppearance = "dark" | "light";
 export interface Terminal {
 	// Start the terminal with input and resize handlers
 	start(onInput: (data: string) => void, onResize: () => void): void;
@@ -80,6 +83,16 @@ export interface Terminal {
 
 	// Title operations
 	setTitle(title: string): void; // Set terminal window title
+
+	/**
+	 * Register a callback for Mode 2031 dark/light appearance change notifications.
+	 * Supported by Ghostty, Kitty, Contour, VTE (GNOME Terminal), and tmux 3.6+.
+	 * The callback fires when the terminal reports a change; it does NOT fire for the initial query.
+	 */
+	onAppearanceChange(callback: (appearance: TerminalAppearance) => void): void;
+
+	/** The last appearance reported by the terminal, or undefined if not yet known. */
+	get appearance(): TerminalAppearance | undefined;
 }
 
 /**
@@ -95,9 +108,19 @@ export class ProcessTerminal implements Terminal {
 	#dead = false;
 	#writeLogPath = $env.PI_TUI_WRITE_LOG || "";
 	#windowsVTInputRestore?: () => void;
+	#appearanceCallbacks: Array<(appearance: TerminalAppearance) => void> = [];
+	#appearance: TerminalAppearance | undefined;
 
 	get kittyProtocolActive(): boolean {
 		return this.#kittyProtocolActive;
+	}
+
+	get appearance(): TerminalAppearance | undefined {
+		return this.#appearance;
+	}
+
+	onAppearanceChange(callback: (appearance: TerminalAppearance) => void): void {
+		this.#appearanceCallbacks.push(callback);
 	}
 
 	start(onInput: (data: string) => void, onResize: () => void): void {
@@ -137,6 +160,13 @@ export class ProcessTerminal implements Terminal {
 		// The query handler intercepts input temporarily, then installs the user's handler
 		// See: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
 		this.#queryAndEnableKittyProtocol();
+
+		// Enable Mode 2031: terminal will send DSR notifications on dark/light appearance changes.
+		// Query current mode with CSI ? 996 n, then subscribe with CSI ? 2031 h.
+		// Supported by Ghostty, Kitty, Contour, VTE/GNOME Terminal, tmux 3.6+.
+		// Unsupported terminals silently ignore these sequences.
+		this.#safeWrite("\x1b[?996n"); // Query current appearance
+		this.#safeWrite("\x1b[?2031h"); // Subscribe to appearance changes
 	}
 
 	/**
@@ -203,6 +233,9 @@ export class ProcessTerminal implements Terminal {
 		// Kitty protocol response pattern: \x1b[?<flags>u
 		const kittyResponsePattern = /^\x1b\[\?(\d+)u$/;
 
+		// Mode 2031 DSR response pattern: \x1b[?997;{1=dark,2=light}n
+		const appearanceDsrPattern = /^\x1b\[\?997;([12])n$/;
+
 		// Forward individual sequences to the input handler
 		this.#stdinBuffer.on("data", (sequence: string) => {
 			// Check for Kitty protocol response (only if not already enabled)
@@ -221,6 +254,19 @@ export class ProcessTerminal implements Terminal {
 				}
 			}
 
+			// Check for Mode 2031 appearance DSR response: CSI ? 997 ; {1,2} n
+			const appearanceMatch = sequence.match(appearanceDsrPattern);
+			if (appearanceMatch) {
+				const mode: TerminalAppearance = appearanceMatch[1] === "1" ? "dark" : "light";
+				const changed = mode !== this.#appearance;
+				this.#appearance = mode;
+				if (changed) {
+					for (const cb of this.#appearanceCallbacks) {
+						try { cb(mode); } catch { /* ignore callback errors */ }
+					}
+				}
+				return; // Don't forward DSR to TUI
+			}
 			if (this.#inputHandler) {
 				this.#inputHandler(sequence);
 			}
@@ -297,6 +343,10 @@ export class ProcessTerminal implements Terminal {
 		// Disable bracketed paste mode
 		this.#safeWrite("\x1b[?2004l");
 
+		// Disable Mode 2031 appearance change notifications
+		this.#safeWrite("\x1b[?2031l");
+		this.#appearanceCallbacks = [];
+
 		// Disable Kitty keyboard protocol if not already done by drainInput()
 		if (this.#kittyProtocolActive) {
 			this.#safeWrite("\x1b[<u");
@@ -317,6 +367,7 @@ export class ProcessTerminal implements Terminal {
 			this.#stdinDataHandler = undefined;
 		}
 		this.#inputHandler = undefined;
+		this.#appearance = undefined;
 		if (this.#resizeHandler) {
 			process.stdout.removeListener("resize", this.#resizeHandler);
 			this.#resizeHandler = undefined;

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -1,4 +1,4 @@
-import type { Terminal } from "@oh-my-pi/pi-tui/terminal";
+import type { Terminal, TerminalAppearance } from "@oh-my-pi/pi-tui/terminal";
 import type { Terminal as XtermTerminalType } from "@xterm/headless";
 import xterm from "@xterm/headless";
 
@@ -62,6 +62,14 @@ export class VirtualTerminal implements Terminal {
 	get kittyProtocolActive(): boolean {
 		// Virtual terminal always reports Kitty protocol as active for testing
 		return true;
+	}
+
+	get appearance(): TerminalAppearance | undefined {
+		return undefined;
+	}
+
+	onAppearanceChange(_callback: (appearance: TerminalAppearance) => void): void {
+		// No-op for virtual terminal
 	}
 
 	moveBy(lines: number): void {


### PR DESCRIPTION
## Problem

Theme detection currently relies on the `COLORFGBG` environment variable, which is set once at terminal launch and never updates. When the OS switches between dark and light mode mid-session, the theme stays stuck on whatever it was at startup. The `SIGWINCH` listener only fires on terminal resize, not on appearance changes.

## Solution

Implement the **Mode 2031** VT extension — the cross-platform standard for terminal dark/light mode detection, already adopted by Neovim, Helix, and tmux.

### How it works

1. On terminal start, send `CSI ? 996 n` to query the current appearance
2. Send `CSI ? 2031 h` to subscribe to unsolicited appearance change notifications
3. Terminal responds with `CSI ? 997 ; 1 n` (dark) or `CSI ? 997 ; 2 n` (light)
4. On each DSR, `detectTerminalBackground()` uses the terminal-reported value and triggers auto-theme re-evaluation
5. On stop, send `CSI ? 2031 l` to unsubscribe

Unsupported terminals silently ignore the escape sequences and fall back to the existing `COLORFGBG` heuristic — no regressions.

### Terminal support

| Terminal | Since |
|---|---|
| Ghostty | 1.0.0 |
| Kitty | 0.38.1 |
| Contour | 0.4.0 |
| VTE / GNOME Terminal | 0.82.0 |
| tmux | 3.6 |

Spec: https://contour-terminal.org/vt-extensions/color-palette-update-notifications/

## Changes

- **`packages/tui/src/terminal.ts`** — Mode 2031 enable/disable lifecycle, DSR response parsing in stdin buffer, `onAppearanceChange` callback API
- **`packages/coding-agent/src/modes/theme/theme.ts`** — `detectTerminalBackground()` prefers terminal-reported appearance; new `onTerminalAppearanceChange()` triggers theme reload
- **`packages/coding-agent/src/modes/interactive-mode.ts`** — Wires terminal appearance callback to theme system
- **`packages/tui/src/index.ts`** — Exports `TerminalAppearance` type
- **`packages/tui/test/virtual-terminal.ts`** — Implements updated `Terminal` interface