### PR TITLE
fix(ai): dedupe openai-codex auth by email and keep /usage accounts separate

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -380,7 +380,13 @@ export class AuthStorage {
 		}
 	}
 
-	#dedupeOAuthCredentials(credentials: AuthCredential[]): AuthCredential[] {
+	#resolveOAuthDedupeIdentifiers(provider: string, credential: OAuthCredential): string[] {
+		const identifiers = this.#getOAuthIdentifiers(credential);
+		if (provider !== "openai-codex") return identifiers;
+		return identifiers.filter(identifier => identifier.startsWith("email:"));
+	}
+
+	#dedupeOAuthCredentials(provider: string, credentials: AuthCredential[]): AuthCredential[] {
 		const seen = new Set<string>();
 		const deduped: AuthCredential[] = [];
 		for (let index = credentials.length - 1; index >= 0; index -= 1) {
@@ -389,7 +395,7 @@ export class AuthStorage {
 				deduped.push(credential);
 				continue;
 			}
-			const identifiers = this.#getOAuthIdentifiers(credential);
+			const identifiers = this.#resolveOAuthDedupeIdentifiers(provider, credential);
 			if (identifiers.length === 0) {
 				deduped.push(credential);
 				continue;
@@ -416,7 +422,7 @@ export class AuthStorage {
 				kept.push(entry);
 				continue;
 			}
-			const identifiers = this.#getOAuthIdentifiers(credential);
+			const identifiers = this.#resolveOAuthDedupeIdentifiers(provider, credential);
 			if (identifiers.length === 0) {
 				kept.push(entry);
 				continue;
@@ -628,7 +634,7 @@ export class AuthStorage {
 	 */
 	async set(provider: string, credential: AuthCredentialEntry): Promise<void> {
 		const normalized = Array.isArray(credential) ? credential : [credential];
-		const deduped = this.#dedupeOAuthCredentials(normalized);
+		const deduped = this.#dedupeOAuthCredentials(provider, normalized);
 		const stored = this.#store.replaceAuthCredentialsForProvider(provider, deduped);
 		this.#setStoredCredentials(
 			provider,
@@ -959,6 +965,9 @@ export class AuthStorage {
 		const identifiers: string[] = [];
 		const email = this.#getUsageReportMetadataValue(report, "email");
 		if (email) identifiers.push(`email:${email.toLowerCase()}`);
+		if (report.provider === "openai-codex") {
+			return identifiers.map(identifier => `${report.provider}:${identifier.toLowerCase()}`);
+		}
 		const accountId = this.#getUsageReportMetadataValue(report, "accountId");
 		if (accountId) identifiers.push(`account:${accountId}`);
 		const account = this.#getUsageReportMetadataValue(report, "account");

--- a/packages/ai/test/auth-storage-email-dedupe.test.ts
+++ b/packages/ai/test/auth-storage-email-dedupe.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthCredentialStore, AuthStorage, type OAuthCredential } from "../src/auth-storage";
+
+function createCredential(args: { suffix: string; accountId: string; email: string }): OAuthCredential {
+	return {
+		type: "oauth",
+		access: `access-${args.suffix}`,
+		refresh: `refresh-${args.suffix}`,
+		expires: Date.now() + 60_000,
+		accountId: args.accountId,
+		email: args.email,
+	};
+}
+
+describe("AuthStorage openai-codex email dedupe", () => {
+	let tempDir = "";
+	let store: AuthCredentialStore | null = null;
+	let authStorage: AuthStorage | null = null;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-auth-email-dedupe-"));
+		const dbPath = path.join(tempDir, "agent.db");
+		store = await AuthCredentialStore.open(dbPath);
+		authStorage = new AuthStorage(store);
+	});
+
+	afterEach(async () => {
+		store?.close();
+		store = null;
+		authStorage = null;
+		if (tempDir) {
+			await fs.rm(tempDir, { recursive: true, force: true });
+			tempDir = "";
+		}
+	});
+
+	it("keeps both openai-codex credentials when accountId matches but emails differ", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+
+		await authStorage.set("openai-codex", [
+			createCredential({ suffix: "first", accountId: "shared-team", email: "first.user@example.com" }),
+			createCredential({ suffix: "second", accountId: "shared-team", email: "second.user@example.com" }),
+		]);
+
+		const credentials = store.listAuthCredentials("openai-codex");
+		expect(credentials).toHaveLength(2);
+	});
+
+	it("dedupes openai-codex credentials when email matches", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+
+		await authStorage.set("openai-codex", [
+			createCredential({ suffix: "first", accountId: "account-a", email: "shared.user@example.com" }),
+			createCredential({ suffix: "second", accountId: "account-b", email: "shared.user@example.com" }),
+		]);
+
+		const credentials = store.listAuthCredentials("openai-codex");
+		expect(credentials).toHaveLength(1);
+		const [remaining] = credentials;
+		expect(remaining?.credential.type).toBe("oauth");
+		if (!remaining || remaining.credential.type !== "oauth") throw new Error("expected oauth credential");
+		expect(remaining.credential.email).toBe("shared.user@example.com");
+		expect(remaining.credential.accountId).toBe("account-b");
+	});
+
+	it("keeps both openai-codex credentials after reload when accountId matches but emails differ", async () => {
+		if (!store) throw new Error("test setup failed");
+
+		store.replaceAuthCredentialsForProvider("openai-codex", [
+			createCredential({ suffix: "first", accountId: "shared-team", email: "first.user@example.com" }),
+			createCredential({ suffix: "second", accountId: "shared-team", email: "second.user@example.com" }),
+		]);
+
+		const reloaded = new AuthStorage(store);
+		await reloaded.reload();
+
+		const credentials = store.listAuthCredentials("openai-codex");
+		expect(credentials).toHaveLength(2);
+	});
+});

--- a/packages/ai/test/openai-codex-usage-cache.test.ts
+++ b/packages/ai/test/openai-codex-usage-cache.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "bun:test";
+import type { UsageCache, UsageFetchContext, UsageReport } from "../src/usage";
+import { openaiCodexUsageProvider } from "../src/usage/openai-codex";
+
+function createCodexToken(args: { accountId?: string; email?: string }): string {
+	const payload: Record<string, unknown> = {};
+	if (args.accountId) {
+		payload["https://api.openai.com/auth"] = { chatgpt_account_id: args.accountId };
+	}
+	if (args.email) {
+		payload["https://api.openai.com/profile"] = { email: args.email };
+	}
+	const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+	const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+	return `${header}.${body}.sig`;
+}
+
+function createUsagePayload(): unknown {
+	return {
+		plan_type: "team",
+		rate_limit: {
+			allowed: true,
+			limit_reached: false,
+			primary_window: {
+				used_percent: 12,
+				limit_window_seconds: 5 * 60 * 60,
+				reset_after_seconds: 60,
+			},
+		},
+	};
+}
+
+function createMemoryCache(): UsageCache {
+	const entries = new Map<string, { value: UsageReport | null; expiresAt: number }>();
+	return {
+		get(key) {
+			return entries.get(key);
+		},
+		set(key, entry) {
+			entries.set(key, entry);
+		},
+	};
+}
+
+describe("openai-codex usage cache identity", () => {
+	it("does not reuse cache for different emails sharing one accountId", async () => {
+		const now = Date.now();
+		let fetchCalls = 0;
+		const fetchMock = (async () => {
+			fetchCalls += 1;
+			return new Response(JSON.stringify(createUsagePayload()), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		}) as unknown as typeof fetch;
+		const ctx: UsageFetchContext = {
+			cache: createMemoryCache(),
+			fetch: fetchMock,
+			now: () => now,
+		};
+
+		await openaiCodexUsageProvider.fetchUsage(
+			{
+				provider: "openai-codex",
+				credential: {
+					type: "oauth",
+					accessToken: createCodexToken({ accountId: "shared", email: "first@example.com" }),
+					accountId: "shared",
+					email: "first@example.com",
+					expiresAt: now + 60_000,
+				},
+			},
+			ctx,
+		);
+		await openaiCodexUsageProvider.fetchUsage(
+			{
+				provider: "openai-codex",
+				credential: {
+					type: "oauth",
+					accessToken: createCodexToken({ accountId: "shared", email: "second@example.com" }),
+					accountId: "shared",
+					email: "second@example.com",
+					expiresAt: now + 60_000,
+				},
+			},
+			ctx,
+		);
+
+		expect(fetchCalls).toBe(2);
+	});
+
+	it("reuses cache for identical email identity", async () => {
+		const now = Date.now();
+		let fetchCalls = 0;
+		const fetchMock = (async () => {
+			fetchCalls += 1;
+			return new Response(JSON.stringify(createUsagePayload()), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		}) as unknown as typeof fetch;
+		const ctx: UsageFetchContext = {
+			cache: createMemoryCache(),
+			fetch: fetchMock,
+			now: () => now,
+		};
+
+		const credential = {
+			type: "oauth" as const,
+			accessToken: createCodexToken({ accountId: "shared", email: "same@example.com" }),
+			accountId: "shared",
+			email: "same@example.com",
+			expiresAt: now + 60_000,
+		};
+
+		await openaiCodexUsageProvider.fetchUsage({ provider: "openai-codex", credential }, ctx);
+		await openaiCodexUsageProvider.fetchUsage({ provider: "openai-codex", credential }, ctx);
+
+		expect(fetchCalls).toBe(1);
+	});
+
+	it("does not reuse cache when email is missing and tokens differ", async () => {
+		const now = Date.now();
+		let fetchCalls = 0;
+		const fetchMock = (async () => {
+			fetchCalls += 1;
+			return new Response(JSON.stringify(createUsagePayload()), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		}) as unknown as typeof fetch;
+		const ctx: UsageFetchContext = {
+			cache: createMemoryCache(),
+			fetch: fetchMock,
+			now: () => now,
+		};
+
+		await openaiCodexUsageProvider.fetchUsage(
+			{
+				provider: "openai-codex",
+				credential: {
+					type: "oauth",
+					accessToken: createCodexToken({ accountId: "shared" }),
+					accountId: "shared",
+					expiresAt: now + 60_000,
+				},
+			},
+			ctx,
+		);
+		await openaiCodexUsageProvider.fetchUsage(
+			{
+				provider: "openai-codex",
+				credential: {
+					type: "oauth",
+					accessToken: `${createCodexToken({ accountId: "shared" })}.variant`,
+					accountId: "shared",
+					expiresAt: now + 60_000,
+				},
+			},
+			ctx,
+		);
+
+		expect(fetchCalls).toBe(2);
+	});
+});


### PR DESCRIPTION
## Summary
This fixes a codex multi-account regression where distinct emails could be collapsed when account ids overlap.

### Changes
- AuthStorage: provider-aware OAuth dedupe for `openai-codex` now uses email identifiers only.
- AuthStorage usage dedupe: avoid account-id collapsing for `openai-codex` reports.
- OpenAI Codex usage provider cache identity now keys by normalized email, with token-fingerprint fallback when email is unavailable.
- Added focused regression tests:
  - `packages/ai/test/auth-storage-email-dedupe.test.ts`
  - `packages/ai/test/openai-codex-usage-cache.test.ts`

## Validation
- `bunx biome check packages/ai/src/auth-storage.ts packages/ai/src/usage/openai-codex.ts packages/ai/test/auth-storage-email-dedupe.test.ts packages/ai/test/openai-codex-usage-cache.test.ts`
- `bun --cwd=packages/ai run check`
- `bun test packages/ai/test/auth-storage-email-dedupe.test.ts packages/ai/test/openai-codex-usage-cache.test.ts`

Fixes #197
