### PR TITLE
fix: invalidate capability fs cache after writing MCP config

### DIFF
--- a/packages/coding-agent/src/mcp/config-writer.ts
+++ b/packages/coding-agent/src/mcp/config-writer.ts
@@ -6,6 +6,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { isEnoent } from "@oh-my-pi/pi-utils";
+import { invalidate as invalidateFsCache } from "../capability/fs";
 
 import { validateServerConfig } from "./config";
 import type { MCPConfigFile, MCPServerConfig } from "./types";
@@ -44,6 +45,8 @@ export async function writeMCPConfigFile(filePath: string, config: MCPConfigFile
 
 	// Rename to final path (atomic on most systems)
 	await fs.promises.rename(tmpPath, filePath);
+	// Invalidate the capability fs cache so subsequent reads see the new content
+	invalidateFsCache(filePath);
 }
 
 /**


### PR DESCRIPTION
## Problem

`/mcp reauth <name>` completes the OAuth flow and writes a new credential ID to the MCP config file, but the subsequent `#reloadMCP` → `discoverAndConnect` reads **stale cached content** from the capability filesystem layer — causing the connection to use the old (deleted) credential ID and fail with `HTTP 401 missing_token`.

## Root Cause

`writeMCPConfigFile` writes to disk via `node:fs`, but the capability system's `readFile` (`capability/fs.ts`) caches file contents in an in-memory `Map<string, string | null>`. The cache is populated on first read (e.g., during startup) and never invalidated when the file is overwritten by `config-writer.ts`.

When the reauth flow:
1. Stores a new OAuth credential in SQLite
2. Writes the new credential ID to `~/.omp/agent/mcp.json` via `writeMCPConfigFile`
3. Calls `#reloadMCP` → `discoverAndConnect` → `loadCapability` → builtin provider → `readFile`

Step 3 hits the stale cache and returns the **old** config with the **old** credential ID. The old credential was already deleted by `#removeManagedOAuthCredential`, so `authStorage.get(oldCredentialId)` returns `undefined`, no `Authorization` header is added, and the server returns 401.

## Fix

Add `invalidateFsCache(filePath)` after the atomic rename in `writeMCPConfigFile`. This ensures subsequent `readFile` calls through the capability system see the fresh content.

This also fixes the same class of bug for `addMCPServer`, `removeMCPServer`, `setMCPServerEnabled`, `setMCPServerDisabled`, and `updateMCPServerDisabledList` — all of which call `writeMCPConfigFile`.

## Testing

Verified with a reproduction script that:
1. Loads configs (populates cache)
2. Updates the config file via `updateMCPServer` (which calls `writeMCPConfigFile`)
3. Reloads configs and confirms the new credential ID is returned (not the stale cached one)

Without the fix, step 3 returns the stale credential ID. With the fix, step 3 returns the correct updated credential ID.