### PR TITLE
fix: change Ollama model discovery to use /v1/models endpoint

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -149,7 +149,7 @@ If `ollama` is not explicitly configured, registry adds an implicit discoverable
 - base URL: `OLLAMA_BASE_URL` or `http://127.0.0.1:11434`
 - auth mode: keyless (`auth: none` behavior)
 
-Runtime discovery calls `GET /api/tags` on Ollama and synthesizes model entries with local defaults.
+Runtime discovery calls `GET /v1/models` on selfhosted providers like Ollama and synthesizes model entries with local defaults.
 
 ### Explicit provider discovery
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+- Fixed Ollama discovery to be more broadly compatible with self
+hosted providers by migrating from the Ollama specific `/api/tags`
+endpoint to the OpenAI compatible `/v1/models` endpoint
 
 ## [13.3.7] - 2026-02-27
 ### Breaking Changes

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -827,7 +827,7 @@ export class ModelRegistry {
 
 	async #discoverOllamaModels(providerConfig: DiscoveryProviderConfig): Promise<Model<Api>[]> {
 		const endpoint = this.#normalizeOllamaBaseUrl(providerConfig.baseUrl);
-		const tagsUrl = `${endpoint}/api/tags`;
+		const tagsUrl = `${endpoint}/v1/models`;
 		try {
 			const response = await fetch(tagsUrl, {
 				headers: { ...(providerConfig.headers ?? {}) },
@@ -841,15 +841,15 @@ export class ModelRegistry {
 				});
 				return [];
 			}
-			const payload = (await response.json()) as { models?: Array<{ name?: string; model?: string }> };
-			const models = payload.models ?? [];
+			const payload = (await response.json()) as { data?: Array<{ id?: string }> };
+			const models = payload.data ?? [];
 			const discovered: Model<Api>[] = [];
 			for (const item of models) {
-				const id = item.model || item.name;
+				const id = item.id;
 				if (!id) continue;
 				discovered.push({
 					id,
-					name: item.name || id,
+					name: id,
 					api: providerConfig.api,
 					provider: providerConfig.provider,
 					baseUrl: `${endpoint}/v1`,

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -554,8 +554,8 @@ describe("ModelRegistry", () => {
 		test("auto-discovers ollama models without provider config", async () => {
 			const originalFetch = globalThis.fetch;
 			globalThis.fetch = (async (input: string | URL | Request) => {
-				expect(String(input)).toBe("http://127.0.0.1:11434/api/tags");
-				return new Response(JSON.stringify({ models: [{ name: "phi4-mini" }] }), {
+				expect(String(input)).toBe("http://127.0.0.1:11434/v1/models");
+				return new Response(JSON.stringify({ data: [{ id: "phi4-mini" }] }), {
 					status: 200,
 					headers: { "Content-Type": "application/json" },
 				});
@@ -585,10 +585,10 @@ describe("ModelRegistry", () => {
 
 			const originalFetch = globalThis.fetch;
 			globalThis.fetch = (async (input: string | URL | Request) => {
-				expect(String(input)).toBe("http://127.0.0.1:11434/api/tags");
+				expect(String(input)).toBe("http://127.0.0.1:11434/v1/models");
 				return new Response(
 					JSON.stringify({
-						models: [{ name: "qwen2.5-coder:7b" }, { model: "llama3.2:3b", name: "llama3.2:3b" }],
+						data: [{ id: "qwen2.5-coder:7b" }, { id: "llama3.2:3b" }],
 					}),
 					{ status: 200, headers: { "Content-Type": "application/json" } },
 				);


### PR DESCRIPTION
## What

- Changed endpoint from /api/tags to /v1/models
- Changed payload structure from {models:[{name|model}]} to {data:[{id}]}
- Set model name to id to match the new structure
- Update coding-agent/CHANGELOG.md and docs/models.md

/api/tags is an Ollama specific endpoint, while the majority of self hosted providers (llama.cpp, lmstudio, ollama, etc) support the OpenAI API which uses the /v1/models endpoint to list models

## Why

This change more broadly supports self hosted providers other than Ollama. Ollama supports two enpoints to list models. Their own bespoke [/api/tags](https://docs.ollama.com/api/tags) endpoint as well as the widely supported OpenAI compatible [/v1/models](https://docs.ollama.com/api/openai-compatibility#%2Fv1%2Fmodels). Switching endpoints retains Ollama compatibility and extends discovery to work on a variety of custom providers

## Testing

I spun llama.cpp up on the host and tested my changes in a dev container by launching omp with the command `OLLAMA_BASE_URL=http://host.containers.internal:8080 bun dev` and checked that model auto discovery indeed worked.

---

- [X] `bun check` passes
- [X] Tested locally
- [X] CHANGELOG updated (if user-facing)
