### PR TITLE
Preserve explicit Copilot X-Initiator for subagent sessions

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -30,7 +30,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
 import { parseStreamingJson } from "../utils/json-parse";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode";
-import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers";
+import { buildCopilotDynamicHeaders, getCopilotInitiatorOverride, hasCopilotVisionInput } from "./github-copilot-headers";
 import { transformMessages } from "./transform-messages";
 
 export type AnthropicHeaderOptions = {
@@ -347,9 +347,14 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 			let copilotDynamicHeaders: Record<string, string> | undefined;
 			if (model.provider === "github-copilot") {
 				const hasImages = hasCopilotVisionInput(context.messages);
+				const initiatorOverride = getCopilotInitiatorOverride({
+					...(model.headers ?? {}),
+					...(options?.headers ?? {}),
+				});
 				copilotDynamicHeaders = buildCopilotDynamicHeaders({
 					messages: context.messages,
 					hasImages,
+					initiatorOverride,
 				});
 			}
 

--- a/packages/ai/src/providers/github-copilot-headers.ts
+++ b/packages/ai/src/providers/github-copilot-headers.ts
@@ -39,15 +39,36 @@ export function hasCopilotVisionInput(messages: Message[]): boolean {
 }
 
 /**
+ * Resolve an explicitly configured Copilot initiator header, if present.
+ * Handles case-insensitive X-Initiator keys and returns the last valid value.
+ */
+export function getCopilotInitiatorOverride(
+	headers: Record<string, string> | undefined,
+): "user" | "agent" | undefined {
+	if (!headers) return undefined;
+
+	let override: "user" | "agent" | undefined;
+	for (const [key, value] of Object.entries(headers)) {
+		if (key.toLowerCase() !== "x-initiator") continue;
+		const normalized = value.trim().toLowerCase();
+		if (normalized === "user" || normalized === "agent") {
+			override = normalized;
+		}
+	}
+
+	return override;
+}
+/**
  * Build dynamic Copilot headers that vary per-request.
  * Static headers (User-Agent, Editor-Version, etc.) come from model.headers.
  */
 export function buildCopilotDynamicHeaders(params: {
 	messages: unknown[];
 	hasImages: boolean;
+	initiatorOverride?: "user" | "agent";
 }): Record<string, string> {
 	const headers: Record<string, string> = {
-		"X-Initiator": inferCopilotInitiator(params.messages),
+		"X-Initiator": params.initiatorOverride ?? inferCopilotInitiator(params.messages),
 		"Openai-Intent": "conversation-edits",
 	};
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -34,7 +34,7 @@ import { getKimiCommonHeaders } from "../utils/oauth/kimi";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode";
 import { mapToOpenAICompletionsToolChoice } from "../utils/tool-choice";
 import { NO_STRICT, tryEnforceStrictSchema } from "../utils/typebox-helpers";
-import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers";
+import { buildCopilotDynamicHeaders, getCopilotInitiatorOverride, hasCopilotVisionInput } from "./github-copilot-headers";
 import { transformMessages } from "./transform-messages";
 
 /**
@@ -512,6 +512,7 @@ async function createClient(
 		const copilotHeaders = buildCopilotDynamicHeaders({
 			messages: context.messages,
 			hasImages,
+			initiatorOverride: getCopilotInitiatorOverride(headers),
 		});
 		Object.assign(headers, copilotHeaders);
 	}

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -35,7 +35,7 @@ import { parseStreamingJson } from "../utils/json-parse";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode";
 import { mapToOpenAIResponsesToolChoice } from "../utils/tool-choice";
 import { NO_STRICT, tryEnforceStrictSchema } from "../utils/typebox-helpers";
-import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers";
+import { buildCopilotDynamicHeaders, getCopilotInitiatorOverride, hasCopilotVisionInput } from "./github-copilot-headers";
 import { transformMessages } from "./transform-messages";
 
 /**
@@ -394,6 +394,7 @@ function createClient(
 		const copilotHeaders = buildCopilotDynamicHeaders({
 			messages: context.messages,
 			hasImages,
+			initiatorOverride: getCopilotInitiatorOverride(headers),
 		});
 		Object.assign(headers, copilotHeaders);
 	}


### PR DESCRIPTION
## Summary
- preserve explicitly configured `X-Initiator` (case-insensitive) when composing dynamic Copilot headers
- thread the override through OpenAI completions, OpenAI responses, and Anthropic Copilot request paths
- add regression tests for initiator override resolution and dynamic header precedence

## Why
Subagent sessions intentionally force `X-Initiator: agent`, but dynamic Copilot header inference could overwrite it from message role. This keeps explicit session-level intent authoritative.

## Changes
- `packages/ai/src/providers/github-copilot-headers.ts`
  - added `getCopilotInitiatorOverride(...)`
  - added optional `initiatorOverride` to `buildCopilotDynamicHeaders(...)`
- `packages/ai/src/providers/openai-completions.ts`
  - pass explicit initiator override from merged request headers
- `packages/ai/src/providers/openai-responses.ts`
  - pass explicit initiator override from merged request headers
- `packages/ai/src/providers/anthropic.ts`
  - pass explicit initiator override derived from static Copilot headers
- `packages/ai/test/github-copilot-headers.test.ts`
  - added tests for override extraction and precedence

## Validation
- `bun --cwd=packages/ai test test/github-copilot-headers.test.ts test/github-copilot-anthropic-auth.test.ts`
- `bun --cwd=packages/ai test test/openai-tool-strict-mode.test.ts`
- `bun --cwd=packages/ai run check`

Refs #202
