### PR TITLE
Add JINA_API_KEY to environment variables

### DIFF
--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -71,6 +71,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	cursor: "CURSOR_ACCESS_TOKEN",
 	"azure-openai-responses": "AZURE_OPENAI_API_KEY",
 	exa: "EXA_API_KEY",
+	jina: "JINA_API_KEY",
 	brave: "BRAVE_API_KEY",
 	perplexity: "PERPLEXITY_API_KEY",
 	// GitHub Copilot uses GitHub personal access token


### PR DESCRIPTION

## What
Jina Key was missing from the service provider map causing 
- findApiKey() → getEnvApiKey("jina") to always be undefined and preventing omp from using jina as a search provider


## Why

To fix jina search

## Testing
was not tested, trivial change
