### PR TITLE
fix(ai): dedupe Anthropic usage reports by email instead of org account ID

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -965,7 +965,7 @@ export class AuthStorage {
 		const identifiers: string[] = [];
 		const email = this.#getUsageReportMetadataValue(report, "email");
 		if (email) identifiers.push(`email:${email.toLowerCase()}`);
-		if (report.provider === "openai-codex") {
+		if (report.provider === "openai-codex" || report.provider === "anthropic") {
 			return identifiers.map(identifier => `${report.provider}:${identifier.toLowerCase()}`);
 		}
 		const accountId = this.#getUsageReportMetadataValue(report, "accountId");


### PR DESCRIPTION
Fixes #213

## Problem

Multiple Anthropic credentials on the same org collapse into one usage report entry because `#getUsageReportIdentifiers` includes the org-level `accountId` (returned by the Anthropic API) as a dedup key. Two different users in the same org share that ID, so their reports get merged.

## Fix

Apply the same email-only dedup strategy already used for `openai-codex` to `anthropic` as well. The org-level account ID is not a meaningful per-credential discriminator.

```ts
// before
if (report.provider === "openai-codex") {

// after
if (report.provider === "openai-codex" || report.provider === "anthropic") {
```

If a credential has no resolvable email the identifier list is empty, which causes it to always appear rather than be silently dropped — correct safe fallback behavior.