### PR TITLE
Refactor file opening to use 'wx' mode

### DIFF
--- a/packages/coding-agent/src/ipy/gateway-coordinator.ts
+++ b/packages/coding-agent/src/ipy/gateway-coordinator.ts
@@ -110,7 +110,7 @@ async function withGatewayLock<T>(handler: () => Promise<T>): Promise<T> {
 	while (true) {
 		let fd: fs.promises.FileHandle | undefined;
 		try {
-			fd = await fs.promises.open(lockPath, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL);
+			fd = await fs.promises.open(lockPath, "wx");
 			let heartbeatRunning = true;
 			const heartbeat = (async () => {
 				while (heartbeatRunning) {


### PR DESCRIPTION



## What

"wx" == O_WRONLY | O_CREAT | O_EXCL | O_TRUNC

## Why

fixes omp python gateway on windows

## Testing

tested locally
