### PR TITLE
bug: prioritize COLORFGBG over macOS system appearance in theme auto-detection

### DIFF
--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -1629,24 +1629,25 @@ function detectTerminalBackground(): "dark" | "light" {
 	if (terminalReportedAppearance) {
 		return terminalReportedAppearance;
 	}
-	// macOS: query system appearance via CoreFoundation (native, no shell).
-	// Uses cached observer value, or falls back to CFPreferencesCopyAppValue.
-	// Works on all terminals including Warp which lacks Mode 2031 / OSC 11.
-	const macAppearance = macOSReportedAppearance ?? detectMacOSAppearance();
-	if (macAppearance) {
-		return macAppearance;
-	}
-	// Fallback: COLORFGBG environment variable (static, set once at terminal launch)
+	// COLORFGBG is set by the terminal emulator to reflect the actual profile colors.
+	// Check it before macOS system appearance because the terminal profile may differ
+	// from the OS-level dark/light setting (e.g. dark terminal on macOS light mode).
 	const colorfgbg = Bun.env.COLORFGBG || "";
 	if (colorfgbg) {
 		const parts = colorfgbg.split(";");
 		if (parts.length >= 2) {
 			const bg = parseInt(parts[1], 10);
 			if (!Number.isNaN(bg)) {
-				const result = bg < 8 ? "dark" : "light";
-				return result;
+				return bg < 8 ? "dark" : "light";
 			}
 		}
+	}
+	// macOS: query system appearance via CoreFoundation (native, no shell).
+	// Uses cached observer value, or falls back to CFPreferencesCopyAppValue.
+	// Works on all terminals including Warp which lacks Mode 2031 / OSC 11.
+	const macAppearance = macOSReportedAppearance ?? detectMacOSAppearance();
+	if (macAppearance) {
+		return macAppearance;
 	}
 	return "dark";
 }


### PR DESCRIPTION
## Background

When macOS is in light mode but the terminal profile has a dark background, omp incorrectly loads the light theme. This happens because `detectTerminalBackground()` checks macOS system appearance (via `detectMacOSAppearance()`) before the `COLORFGBG` environment variable. Since iTerm (and other emulators that don't support Mode 2031) never provide a terminal-level dark/light signal, the macOS appearance wins and returns `"light"` even though the terminal is dark.

Affected terminals: iTerm, Terminal.app, and any emulator that sets `COLORFGBG` but does not support Mode 2031 DSR responses.

Related: fix(stats): follow system light/dark theme (#219)

## Changes

- Reorder `detectTerminalBackground()` to check `COLORFGBG` before macOS system appearance
- `COLORFGBG` reflects the actual terminal profile colors (set by the emulator), so it is a more accurate signal than the OS-level dark/light setting
- Mode 2031 still takes top priority for terminals that support it (Ghostty, Kitty, etc.)
- macOS appearance is now the fallback when neither Mode 2031 nor `COLORFGBG` is available

Detection priority: Mode 2031 > COLORFGBG > macOS appearance > default dark

## Testing/validation

- Confirmed macOS reports light mode (`AppleInterfaceStyle` absent)
- Confirmed iTerm sets `COLORFGBG=15;0` (white on black = dark)
- Confirmed iTerm does not respond to Mode 2031 query (`CSI ? 996 n`)
- `bun check:ts` passes clean

Before:
<img width="763" height="539" alt="image" src="https://github.com/user-attachments/assets/3e6ebdb4-0b87-4e13-acdf-cd2206e6389a" />


After:

<img width="826" height="399" alt="image" src="https://github.com/user-attachments/assets/769e4f5f-f3ac-4675-9d45-9b0144dc484b" />