### PR TITLE
feat: Allow /plan to accept an inline prompt

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -702,7 +702,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		await this.session.prompt(prompt, { synthetic: true });
 	}
 
-	async handlePlanModeCommand(): Promise<void> {
+	async handlePlanModeCommand(initialPrompt?: string): Promise<void> {
 		if (this.planModeEnabled) {
 			const confirmed = await this.showHookConfirm(
 				"Exit plan mode?",
@@ -713,6 +713,9 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 		await this.#enterPlanMode();
+		if (initialPrompt) {
+			this.onInputCallback?.({ text: initialPrompt });
+		}
 	}
 
 	async handleExitPlanModeTool(details: ExitPlanModeDetails): Promise<void> {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -197,7 +197,7 @@ export interface InteractiveModeContext {
 	toggleThinkingBlockVisibility(): void;
 	openExternalEditor(): void;
 	registerExtensionShortcuts(): void;
-	handlePlanModeCommand(): Promise<void>;
+	handlePlanModeCommand(initialPrompt?: string): Promise<void>;
 	handleExitPlanModeTool(details: ExitPlanModeDetails): Promise<void>;
 
 	// Hook UI methods

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -75,8 +75,10 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 	{
 		name: "plan",
 		description: "Toggle plan mode (agent plans before executing)",
-		handle: async (_command, runtime) => {
-			await runtime.ctx.handlePlanModeCommand();
+		inlineHint: "[prompt]",
+		allowArgs: true,
+		handle: async (command, runtime) => {
+			await runtime.ctx.handlePlanModeCommand(command.args || undefined);
 			runtime.ctx.editor.setText("");
 		},
 	},


### PR DESCRIPTION
## What

Allow `/plan <prompt>` to enter plan mode and immediately start planning with the given prompt. Previously, `/plan` only worked as a bare toggle — you had to enter plan mode first, then type your prompt separately.

## Why

Two-step workflow (`/plan` enter, then type prompt) adds unnecessary friction. Users naturally type `/plan redesign the auth flow` and expect it to work.

## Testing

- `bun check` passes
- Verified `/plan` (no args) still toggles plan mode on/off as before
- Verified `/plan <prompt>` enters plan mode and submits the prompt

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)