### PR TITLE
feat(coding-agent): add Kagi web search provider

### DIFF
--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -74,6 +74,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	jina: "JINA_API_KEY",
 	brave: "BRAVE_API_KEY",
 	perplexity: "PERPLEXITY_API_KEY",
+	kagi: "KAGI_API_KEY",
 	// GitHub Copilot uses GitHub personal access token
 	"github-copilot": () => $pickenv("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"),
 	// ANTHROPIC_OAUTH_TOKEN takes precedence over ANTHROPIC_API_KEY

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Kagi web search provider (Search API v0) with related searches support and automatic `KAGI_API_KEY` detection
+
 ## [13.5.4] - 2026-03-01
 ### Added
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -757,6 +757,7 @@ export const SETTINGS_SCHEMA = {
 			"anthropic",
 			"gemini",
 			"codex",
+			"kagi",
 			"synthetic",
 		] as const,
 		default: "auto",

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -194,6 +194,7 @@ const OPTION_PROVIDERS: Partial<Record<SettingPath, OptionProvider>> = {
 		{ value: "perplexity", label: "Perplexity", description: "Requires PERPLEXITY_COOKIES or PERPLEXITY_API_KEY" },
 		{ value: "anthropic", label: "Anthropic", description: "Uses Anthropic web search" },
 		{ value: "zai", label: "Z.AI", description: "Calls Z.AI webSearchPrime MCP" },
+		{ value: "kagi", label: "Kagi", description: "Requires KAGI_API_KEY" },
 		{ value: "synthetic", label: "Synthetic", description: "Requires SYNTHETIC_API_KEY" },
 	],
 	"providers.image": [

--- a/packages/coding-agent/src/web/search/index.ts
+++ b/packages/coding-agent/src/web/search/index.ts
@@ -34,7 +34,20 @@ export const webSearchSchema = Type.Object({
 	query: Type.String({ description: "Search query" }),
 	provider: Type.Optional(
 		StringEnum(
-			["auto", "exa", "brave", "jina", "kimi", "zai", "anthropic", "perplexity", "gemini", "codex", "synthetic"],
+			[
+				"auto",
+				"exa",
+				"brave",
+				"jina",
+				"kimi",
+				"zai",
+				"anthropic",
+				"perplexity",
+				"gemini",
+				"codex",
+				"kagi",
+				"synthetic",
+			],
 			{
 				description: "Search provider (default: auto)",
 			},
@@ -64,6 +77,7 @@ export type SearchParams = {
 		| "perplexity"
 		| "gemini"
 		| "codex"
+		| "kagi"
 		| "synthetic";
 	recency?: "day" | "week" | "month" | "year";
 	limit?: number;

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -5,6 +5,7 @@ import { CodexProvider } from "./providers/codex";
 import { ExaProvider } from "./providers/exa";
 import { GeminiProvider } from "./providers/gemini";
 import { JinaProvider } from "./providers/jina";
+import { KagiProvider } from "./providers/kagi";
 import { KimiProvider } from "./providers/kimi";
 import { PerplexityProvider } from "./providers/perplexity";
 import { SyntheticProvider } from "./providers/synthetic";
@@ -24,6 +25,7 @@ const SEARCH_PROVIDERS: Record<SearchProviderId, SearchProvider> = {
 	anthropic: new AnthropicProvider(),
 	gemini: new GeminiProvider(),
 	codex: new CodexProvider(),
+	kagi: new KagiProvider(),
 	synthetic: new SyntheticProvider(),
 } as const;
 
@@ -37,6 +39,7 @@ export const SEARCH_PROVIDER_ORDER: SearchProviderId[] = [
 	"codex",
 	"zai",
 	"exa",
+	"kagi",
 	"synthetic",
 ];
 

--- a/packages/coding-agent/src/web/search/providers/kagi.ts
+++ b/packages/coding-agent/src/web/search/providers/kagi.ts
@@ -1,0 +1,148 @@
+/**
+ * Kagi Web Search Provider
+ *
+ * Calls Kagi's Search API (v0) and maps results into the unified
+ * SearchResponse shape used by the web search tool.
+ */
+import { getEnvApiKey } from "@oh-my-pi/pi-ai";
+import type { SearchResponse, SearchSource } from "../../../web/search/types";
+import { SearchProviderError } from "../../../web/search/types";
+import { clampNumResults, dateToAgeSeconds } from "../utils";
+import type { SearchParams } from "./base";
+import { SearchProvider } from "./base";
+
+const KAGI_SEARCH_URL = "https://kagi.com/api/v0/search";
+const DEFAULT_NUM_RESULTS = 10;
+const MAX_NUM_RESULTS = 40;
+
+interface KagiSearchResult {
+	t: 0;
+	url: string;
+	title: string;
+	snippet?: string;
+	published?: string;
+	thumbnail?: {
+		url: string;
+		width?: number | null;
+		height?: number | null;
+	};
+}
+
+interface KagiRelatedSearches {
+	t: 1;
+	list: string[];
+}
+
+type KagiSearchObject = KagiSearchResult | KagiRelatedSearches;
+
+interface KagiMeta {
+	id: string;
+	node: string;
+	ms: number;
+	api_balance?: number;
+}
+
+interface KagiSearchResponse {
+	meta: KagiMeta;
+	data: KagiSearchObject[];
+	error?: Array<{ code: number; msg: string; ref?: unknown }>;
+}
+
+/** Find KAGI_API_KEY from environment or .env files. */
+export function findApiKey(): string | null {
+	return getEnvApiKey("kagi") ?? null;
+}
+
+async function callKagiSearch(
+	apiKey: string,
+	query: string,
+	limit: number,
+	signal?: AbortSignal,
+): Promise<KagiSearchResponse> {
+	const url = new URL(KAGI_SEARCH_URL);
+	url.searchParams.set("q", query);
+	url.searchParams.set("limit", String(limit));
+
+	const response = await fetch(url, {
+		headers: {
+			Authorization: `Bot ${apiKey}`,
+			Accept: "application/json",
+		},
+		signal,
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		throw new SearchProviderError("kagi", `Kagi API error (${response.status}): ${errorText}`, response.status);
+	}
+
+	const data = (await response.json()) as KagiSearchResponse;
+
+	if (data.error && data.error.length > 0) {
+		const firstError = data.error[0];
+		throw new SearchProviderError("kagi", `Kagi API error: ${firstError.msg}`, firstError.code);
+	}
+
+	return data;
+}
+
+/** Execute Kagi web search. */
+export async function searchKagi(params: {
+	query: string;
+	num_results?: number;
+	signal?: AbortSignal;
+}): Promise<SearchResponse> {
+	const numResults = clampNumResults(params.num_results, DEFAULT_NUM_RESULTS, MAX_NUM_RESULTS);
+	const apiKey = findApiKey();
+	if (!apiKey) {
+		throw new Error("KAGI_API_KEY not found. Set it in environment or .env file.");
+	}
+
+	const data = await callKagiSearch(apiKey, params.query, numResults, params.signal);
+
+	const sources: SearchSource[] = [];
+	const relatedQuestions: string[] = [];
+
+	for (const item of data.data) {
+		if (item.t === 0) {
+			sources.push({
+				title: item.title,
+				url: item.url,
+				snippet: item.snippet,
+				publishedDate: item.published ?? undefined,
+				ageSeconds: dateToAgeSeconds(item.published),
+			});
+		} else if (item.t === 1) {
+			relatedQuestions.push(...item.list);
+		}
+	}
+
+	return {
+		provider: "kagi",
+		sources: sources.slice(0, numResults),
+		relatedQuestions: relatedQuestions.length > 0 ? relatedQuestions : undefined,
+		requestId: data.meta.id,
+	};
+}
+
+/** Search provider for Kagi web search. */
+export class KagiProvider extends SearchProvider {
+	readonly id = "kagi";
+	readonly label = "Kagi";
+
+	isAvailable() {
+		try {
+			return !!findApiKey();
+		} catch {
+			return false;
+		}
+	}
+
+	search(params: SearchParams): Promise<SearchResponse> {
+		return searchKagi({
+			query: params.query,
+			num_results: params.numSearchResults ?? params.limit,
+			signal: params.signal,
+		});
+	}
+}

--- a/packages/coding-agent/src/web/search/types.ts
+++ b/packages/coding-agent/src/web/search/types.ts
@@ -15,6 +15,7 @@ export type SearchProviderId =
 	| "perplexity"
 	| "gemini"
 	| "codex"
+	| "kagi"
 	| "synthetic";
 
 /** Source returned by search (all providers) */


### PR DESCRIPTION
## What

- Add KagiProvider implementation (Search API v0)
- Register kagi in SearchProviderId type, provider map, and fallback order
- Add kagi to tool schema enum, SearchParams type, and settings UI
- Register KAGI_API_KEY in service provider map
- Update CHANGELOG

## Why

It allows you to customize search results unlike (insert every other trash search engine here) + community based ai slop.

## Testing

web_search kagi

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
