### PR TITLE
fix(ai): separate cache_control placement from system block construction

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -746,18 +746,18 @@ type SystemBlockOptions = {
 	includeClaudeCodeInstruction?: boolean;
 	extraInstructions?: string[];
 	billingPayload?: unknown;
+	cacheControl?: AnthropicCacheControl;
 };
 
 export function buildAnthropicSystemBlocks(
 	systemPrompt: string | undefined,
 	options: SystemBlockOptions = {},
 ): AnthropicSystemBlock[] | undefined {
-	const { includeClaudeCodeInstruction = false, extraInstructions = [], billingPayload } = options;
+	const { includeClaudeCodeInstruction = false, extraInstructions = [], billingPayload, cacheControl } = options;
 	const blocks: AnthropicSystemBlock[] = [];
 	const sanitizedPrompt = systemPrompt ? systemPrompt.toWellFormed() : "";
 	const trimmedInstructions = extraInstructions.map(instruction => instruction.trim()).filter(Boolean);
 	const hasBillingHeader = sanitizedPrompt.includes(CLAUDE_BILLING_HEADER_PREFIX);
-	const claudeCodeSystemCacheControl: AnthropicCacheControl = { type: "ephemeral" };
 
 	if (includeClaudeCodeInstruction && !hasBillingHeader) {
 		const payloadSeed = billingPayload ?? {
@@ -777,7 +777,7 @@ export function buildAnthropicSystemBlocks(
 		blocks.push({
 			type: "text",
 			text: instruction,
-			...(includeClaudeCodeInstruction ? { cache_control: claudeCodeSystemCacheControl } : {}),
+			...(cacheControl ? { cache_control: cacheControl } : {}),
 		});
 	}
 
@@ -785,7 +785,7 @@ export function buildAnthropicSystemBlocks(
 		blocks.push({
 			type: "text",
 			text: sanitizedPrompt,
-			...(includeClaudeCodeInstruction ? { cache_control: claudeCodeSystemCacheControl } : {}),
+			...(cacheControl ? { cache_control: cacheControl } : {}),
 		});
 	}
 
@@ -923,10 +923,6 @@ type CacheControlBlock = {
 	cache_control?: AnthropicCacheControl | null;
 };
 
-function hasCacheControlInBlocks<T extends CacheControlBlock>(blocks: T[]): boolean {
-	return blocks.some(block => "cache_control" in block && block.cache_control != null);
-}
-
 function applyCacheControlToLastBlock<T extends CacheControlBlock>(
 	blocks: T[],
 	cacheControl: AnthropicCacheControl,
@@ -952,11 +948,12 @@ function applyCacheControlToLastTextBlock(
 
 function applyPromptCaching(params: MessageCreateParamsStreaming, cacheControl?: AnthropicCacheControl): void {
 	if (!cacheControl) return;
-	if (params.tools && hasCacheControlInBlocks(params.tools as Array<CacheControlBlock>)) return;
-	if (params.system && Array.isArray(params.system) && hasCacheControlInBlocks(params.system)) return;
+
+	// Skip if cache_control breakpoints were already placed externally on messages.
 	for (const message of params.messages) {
 		if (Array.isArray(message.content)) {
-			if (hasCacheControlInBlocks(message.content as Array<ContentBlockParam & CacheControlBlock>)) return;
+			if ((message.content as Array<ContentBlockParam & CacheControlBlock>).some(b => b.cache_control != null))
+				return;
 		}
 	}
 

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -110,6 +110,24 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(blocks?.[2]).toEqual({
 			type: "text",
 			text: "Use citations when possible",
+		});
+		expect(blocks?.[3]).toEqual({
+			type: "text",
+			text: "Stay concise.",
+		});
+	});
+
+	it("applies cache_control to system blocks when cacheControl option is set", () => {
+		const blocks = buildAnthropicSystemBlocks("Stay concise.", {
+			includeClaudeCodeInstruction: true,
+			extraInstructions: ["Use citations when possible"],
+			cacheControl: { type: "ephemeral" },
+		});
+
+		expect(blocks).toBeDefined();
+		expect(blocks?.[2]).toEqual({
+			type: "text",
+			text: "Use citations when possible",
 			cache_control: { type: "ephemeral" },
 		});
 		expect(blocks?.[3]).toEqual({

--- a/packages/coding-agent/src/web/search/providers/anthropic.ts
+++ b/packages/coding-agent/src/web/search/providers/anthropic.ts
@@ -66,6 +66,7 @@ function buildSystemBlocks(
 	return buildAnthropicSystemBlocks(systemPrompt, {
 		includeClaudeCodeInstruction: includeClaudeCode,
 		extraInstructions,
+		cacheControl: { type: "ephemeral" },
 	});
 }
 


### PR DESCRIPTION
## What

- fixed anthropic caching not working anymore

## Why



## Testing

<img width="932" height="154" alt="image" src="https://github.com/user-attachments/assets/d40c8aa5-e54a-4fdc-9e67-df9480df0b9d" />

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
