### PR TITLE
fix(stats): include subtask session files in usage stats

### DIFF
--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [Unreleased]
+### Fixed
+
+- Include subtask session files in usage stats ([#250](https://github.com/can1357/oh-my-pi/issues/250))

--- a/packages/stats/src/parser.ts
+++ b/packages/stats/src/parser.ts
@@ -10,9 +10,11 @@ import type { MessageStats, SessionEntry, SessionMessageEntry } from "./types";
  * The folder part uses -- as path separator.
  */
 function extractFolderFromPath(sessionPath: string): string {
-	const dir = path.basename(sessionPath.replace(/\/[^/]+\.jsonl$/, ""));
+	const sessionsDir = getSessionsDir();
+	const rel = path.relative(sessionsDir, sessionPath);
+	const projectDir = rel.split(path.sep)[0];
 	// Convert --work--pi-- to /work/pi
-	return dir.replace(/^--/, "/").replace(/--/g, "/");
+	return projectDir.replace(/^--/, "/").replace(/--/g, "/");
 }
 
 /**
@@ -99,8 +101,8 @@ export async function listSessionFolders(): Promise<string[]> {
  */
 export async function listSessionFiles(folderPath: string): Promise<string[]> {
 	try {
-		const entries = await fs.readdir(folderPath, { withFileTypes: true });
-		return entries.filter(e => e.isFile() && e.name.endsWith(".jsonl")).map(e => path.join(folderPath, e.name));
+		const entries = await fs.readdir(folderPath, { recursive: true, withFileTypes: true });
+		return entries.filter(e => e.isFile() && e.name.endsWith(".jsonl")).map(e => path.join(e.parentPath, e.name));
 	} catch {
 		return [];
 	}


### PR DESCRIPTION
listSessionFiles() only performed a flat readdir, missing subtask JSONL files nested inside artifact subdirectories. Switch to recursive readdir to discover .jsonl files at any depth.

Also fix extractFolderFromPath() to derive the project folder via path.relative from the sessions root instead of regex on basename, which returned the artifact directory name for nested paths.

## Why

Fixes #250 

## Testing

Tested by running `bun dev stats` and spawning a few tasks.
