### PR TITLE
add azure foundry support for claude code

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -32,6 +32,7 @@ These are consumed via `getEnvApiKey()` (`packages/ai/src/stream.ts`) unless not
 |---|---|---|---|
 | `ANTHROPIC_OAUTH_TOKEN` | Anthropic API auth | Using Anthropic with OAuth token auth | Takes precedence over `ANTHROPIC_API_KEY` for provider auth resolution |
 | `ANTHROPIC_API_KEY` | Anthropic API auth | Using Anthropic without OAuth token | Fallback after `ANTHROPIC_OAUTH_TOKEN` |
+| `ANTHROPIC_FOUNDRY_API_KEY` | Anthropic via Azure Foundry / enterprise gateway | `CLAUDE_CODE_USE_FOUNDRY` enabled | Takes precedence over `ANTHROPIC_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` when Foundry mode is enabled |
 | `OPENAI_API_KEY` | OpenAI auth | Using OpenAI-family providers without explicit apiKey argument | Used by OpenAI Completions/Responses providers |
 | `GEMINI_API_KEY` | Google Gemini auth | Using `google` provider models | Primary key for Gemini provider mapping |
 | `GOOGLE_API_KEY` | Gemini image tool auth fallback | Using `gemini_image` tool without `GEMINI_API_KEY` | Used by coding-agent image tool fallback path |
@@ -75,6 +76,30 @@ These are consumed via `getEnvApiKey()` (`packages/ai/src/stream.ts`) unless not
 ---
 
 ## 2) Provider-specific runtime configuration
+
+### Anthropic Foundry Gateway (Azure / enterprise proxy)
+
+When `CLAUDE_CODE_USE_FOUNDRY` is enabled, Anthropic requests switch to Foundry mode:
+
+- Base URL resolves from `FOUNDRY_BASE_URL` (fallback remains model/default base URL if unset).
+- API key resolution for provider `anthropic` becomes:
+  `ANTHROPIC_FOUNDRY_API_KEY` → `ANTHROPIC_OAUTH_TOKEN` → `ANTHROPIC_API_KEY`.
+- `ANTHROPIC_CUSTOM_HEADERS` is parsed as comma/newline-separated `key: value` pairs and merged into request headers.
+- TLS client/server material can be injected from env values:
+  `NODE_EXTRA_CA_CERTS`, `CLAUDE_CODE_CLIENT_CERT`, `CLAUDE_CODE_CLIENT_KEY`.
+  Each accepts either:
+  - a filesystem path to PEM content, or
+  - inline PEM (including escaped `\n` sequences).
+
+| Variable | Value type | Behavior |
+|---|---|---|
+| `CLAUDE_CODE_USE_FOUNDRY` | Boolean-like string (`1`, `true`, `yes`, `on`) | Enables Foundry mode for Anthropic provider |
+| `FOUNDRY_BASE_URL` | URL string | Anthropic endpoint base URL in Foundry mode |
+| `ANTHROPIC_FOUNDRY_API_KEY` | Token string | Used for `Authorization: Bearer <token>` |
+| `ANTHROPIC_CUSTOM_HEADERS` | Header list string | Extra headers; format `header-a: value, header-b: value` or newline-separated |
+| `NODE_EXTRA_CA_CERTS` | PEM path or inline PEM | Extra CA chain for server certificate validation |
+| `CLAUDE_CODE_CLIENT_CERT` | PEM path or inline PEM | mTLS client certificate |
+| `CLAUDE_CODE_CLIENT_KEY` | PEM path or inline PEM | mTLS client private key (must be paired with cert) |
 
 ### Amazon Bedrock
 
@@ -174,7 +199,7 @@ OAuth host chain: `KIMI_CODE_OAUTH_HOST` → `KIMI_OAUTH_HOST` → `https://auth
 1. `ANTHROPIC_SEARCH_API_KEY` (+ optional `ANTHROPIC_SEARCH_BASE_URL`)
 2. `models.json` provider entry with `api: "anthropic-messages"`
 3. Anthropic OAuth credentials from `agent.db` (must not expire within 5-minute buffer)
-4. Generic Anthropic env fallback: provider key (`ANTHROPIC_OAUTH_TOKEN`/`ANTHROPIC_API_KEY`) + optional `ANTHROPIC_BASE_URL`
+4. Generic Anthropic env fallback: provider key (`ANTHROPIC_FOUNDRY_API_KEY`/`ANTHROPIC_OAUTH_TOKEN`/`ANTHROPIC_API_KEY`) + optional `ANTHROPIC_BASE_URL` (`FOUNDRY_BASE_URL` when Foundry mode is enabled)
 
 Related vars:
 
@@ -321,5 +346,6 @@ Treat these as secrets; do not log or commit them:
 - Provider/API keys and OAuth/bearer credentials (all `*_API_KEY`, `*_TOKEN`, OAuth access/refresh tokens)
 - Cloud credentials (`AWS_*`, `GOOGLE_APPLICATION_CREDENTIALS` path may expose service-account material)
 - Search/provider auth vars (`EXA_API_KEY`, `BRAVE_API_KEY`, `PERPLEXITY_API_KEY`, Anthropic search keys)
+- Foundry mTLS material (`CLAUDE_CODE_CLIENT_CERT`, `CLAUDE_CODE_CLIENT_KEY`, `NODE_EXTRA_CA_CERTS` when it points to private CA bundles)
 
 Python runtime also explicitly strips many common key vars before spawning kernel subprocesses (`packages/coding-agent/src/ipy/runtime.ts`).

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added Anthropic Foundry gateway mode controlled by `CLAUDE_CODE_USE_FOUNDRY`, with support for `FOUNDRY_BASE_URL`, `ANTHROPIC_FOUNDRY_API_KEY`, `ANTHROPIC_CUSTOM_HEADERS`, and optional mTLS material (`CLAUDE_CODE_CLIENT_CERT`, `CLAUDE_CODE_CLIENT_KEY`, `NODE_EXTRA_CA_CERTS`)
+
+### Changed
+
+- Anthropic key resolution now prefers `ANTHROPIC_FOUNDRY_API_KEY` over `ANTHROPIC_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` when Foundry mode is enabled
+- Anthropic auth base-URL fallback now prefers `FOUNDRY_BASE_URL` when `CLAUDE_CODE_USE_FOUNDRY` is enabled
 
 ## [13.5.8] - 2026-03-02
 ### Fixed

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -907,7 +907,7 @@ In Node.js environments, you can set environment variables to avoid passing API 
 | Provider       | Environment Variable(s)                                                      |
 | -------------- | ---------------------------------------------------------------------------- |
 | OpenAI         | `OPENAI_API_KEY`                                                             |
-| Anthropic      | `ANTHROPIC_API_KEY` or `ANTHROPIC_OAUTH_TOKEN`                               |
+| Anthropic      | `ANTHROPIC_API_KEY` or `ANTHROPIC_OAUTH_TOKEN` (or `ANTHROPIC_FOUNDRY_API_KEY` when `CLAUDE_CODE_USE_FOUNDRY=true`) |
 | Google         | `GEMINI_API_KEY`                                                             |
 | Vertex AI      | `GOOGLE_CLOUD_PROJECT` (or `GCLOUD_PROJECT`) + `GOOGLE_CLOUD_LOCATION` + ADC |
 | Mistral        | `MISTRAL_API_KEY`                                                            |
@@ -935,6 +935,10 @@ In Node.js environments, you can set environment variables to avoid passing API 
 
 For Cloudflare AI Gateway models, use provider base URL format
 `https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic`.
+
+For Anthropic Foundry routing, set `CLAUDE_CODE_USE_FOUNDRY=true` plus:
+`FOUNDRY_BASE_URL`, `ANTHROPIC_FOUNDRY_API_KEY`, optional `ANTHROPIC_CUSTOM_HEADERS`,
+and optional mTLS material (`CLAUDE_CODE_CLIENT_CERT`, `CLAUDE_CODE_CLIENT_KEY`, `NODE_EXTRA_CA_CERTS`).
 
 Provider endpoint defaults for the current OpenAI-compatible integrations:
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1,4 +1,5 @@
 import * as nodeCrypto from "node:crypto";
+import * as fs from "node:fs";
 import * as tls from "node:tls";
 import Anthropic, { type ClientOptions as AnthropicSdkClientOptions } from "@anthropic-ai/sdk";
 import type {
@@ -6,7 +7,7 @@ import type {
 	MessageCreateParamsStreaming,
 	MessageParam,
 } from "@anthropic-ai/sdk/resources/messages";
-import { abortableSleep } from "@oh-my-pi/pi-utils";
+import { $env, abortableSleep, isEnoent } from "@oh-my-pi/pi-utils";
 import { calculateCost } from "../models";
 import { getEnvApiKey, OUTPUT_FALLBACK_BUFFER } from "../stream";
 import type {
@@ -381,26 +382,132 @@ export type AnthropicClientOptionsResult = {
 
 const CLAUDE_CODE_TLS_CIPHERS = tls.DEFAULT_CIPHERS;
 
+type FoundryTlsOptions = {
+	ca?: string;
+	cert?: string;
+	key?: string;
+};
+
+function isFoundryEnabled(): boolean {
+	const value = $env.CLAUDE_CODE_USE_FOUNDRY;
+	if (!value) return false;
+	const normalized = value.trim().toLowerCase();
+	return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+function normalizeBaseUrl(baseUrl: string | undefined): string | undefined {
+	const trimmed = baseUrl?.trim();
+	return trimmed ? trimmed.replace(/\/+$/, "") : undefined;
+}
+
+function resolveAnthropicBaseUrl(model: Model<"anthropic-messages">): string | undefined {
+	if (model.provider === "anthropic" && isFoundryEnabled()) {
+		const foundryBaseUrl = normalizeBaseUrl($env.FOUNDRY_BASE_URL);
+		if (foundryBaseUrl) {
+			return foundryBaseUrl;
+		}
+	}
+	if (model.provider === "anthropic") {
+		return normalizeBaseUrl(model.baseUrl) ?? "https://api.anthropic.com";
+	}
+	return normalizeBaseUrl(model.baseUrl);
+}
+
+function parseAnthropicCustomHeaders(rawHeaders: string | undefined): Record<string, string> | undefined {
+	const source = rawHeaders?.trim();
+	if (!source) return undefined;
+
+	const parsed: Record<string, string> = {};
+	for (const token of source.split(/\r?\n|,/)) {
+		const entry = token.trim();
+		if (!entry) continue;
+		const separatorIndex = entry.indexOf(":");
+		if (separatorIndex <= 0) continue;
+		const key = entry.slice(0, separatorIndex).trim();
+		const value = entry.slice(separatorIndex + 1).trim();
+		if (!key || !value) continue;
+		parsed[key] = value;
+	}
+
+	return Object.keys(parsed).length > 0 ? parsed : undefined;
+}
+
+function resolveAnthropicCustomHeaders(model: Model<"anthropic-messages">): Record<string, string> | undefined {
+	if (model.provider !== "anthropic") return undefined;
+	if (!isFoundryEnabled()) return undefined;
+	return parseAnthropicCustomHeaders($env.ANTHROPIC_CUSTOM_HEADERS);
+}
+
+function looksLikeFilePath(value: string): boolean {
+	return value.includes("/") || value.includes("\\") || /\.(pem|crt|cer|key)$/i.test(value);
+}
+
+function resolvePemValue(value: string | undefined, name: string): string | undefined {
+	const trimmed = value?.trim();
+	if (!trimmed) return undefined;
+
+	const inline = trimmed.replace(/\\n/g, "\n");
+	if (inline.includes("-----BEGIN")) {
+		return inline;
+	}
+
+	if (looksLikeFilePath(trimmed)) {
+		try {
+			return fs.readFileSync(trimmed, "utf8");
+		} catch (error) {
+			if (isEnoent(error)) {
+				throw new Error(`${name} path does not exist: ${trimmed}`);
+			}
+			throw error;
+		}
+	}
+
+	return inline;
+}
+
+function resolveFoundryTlsOptions(model: Model<"anthropic-messages">): FoundryTlsOptions | undefined {
+	if (model.provider !== "anthropic") return undefined;
+	if (!isFoundryEnabled()) return undefined;
+
+	const ca = resolvePemValue($env.NODE_EXTRA_CA_CERTS, "NODE_EXTRA_CA_CERTS");
+	const cert = resolvePemValue($env.CLAUDE_CODE_CLIENT_CERT, "CLAUDE_CODE_CLIENT_CERT");
+	const key = resolvePemValue($env.CLAUDE_CODE_CLIENT_KEY, "CLAUDE_CODE_CLIENT_KEY");
+
+	if ((cert && !key) || (!cert && key)) {
+		throw new Error("Both CLAUDE_CODE_CLIENT_CERT and CLAUDE_CODE_CLIENT_KEY must be set for mTLS.");
+	}
+
+	const options: FoundryTlsOptions = {};
+	if (ca) options.ca = ca;
+	if (cert) options.cert = cert;
+	if (key) options.key = key;
+	return Object.keys(options).length > 0 ? options : undefined;
+}
+
 function buildClaudeCodeTlsFetchOptions(
 	model: Model<"anthropic-messages">,
+	baseUrl: string | undefined,
 ): AnthropicSdkClientOptions["fetchOptions"] | undefined {
 	if (model.provider !== "anthropic") return undefined;
-	if (!model.baseUrl) return undefined;
+	if (!baseUrl) return undefined;
 
 	let serverName: string;
 	try {
-		serverName = new URL(model.baseUrl).hostname;
+		serverName = new URL(baseUrl).hostname;
 	} catch {
 		return undefined;
 	}
 
 	if (!serverName) return undefined;
 
+	const foundryTlsOptions = resolveFoundryTlsOptions(model);
+
 	return {
 		tls: {
 			rejectUnauthorized: true,
 			serverName,
 			...(CLAUDE_CODE_TLS_CIPHERS ? { ciphers: CLAUDE_CODE_TLS_CIPHERS } : {}),
+			...(foundryTlsOptions ?? {}),
 		},
 	};
 }
@@ -471,6 +578,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 
 		try {
 			const apiKey = options?.apiKey ?? getEnvApiKey(model.provider) ?? "";
+			const baseUrl = resolveAnthropicBaseUrl(model) ?? "https://api.anthropic.com";
 
 			let copilotDynamicHeaders: Record<string, string> | undefined;
 			if (model.provider === "github-copilot") {
@@ -496,14 +604,14 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 				dynamicHeaders: copilotDynamicHeaders,
 				isOAuth: options?.isOAuth,
 			});
-			const params = buildParams(model, context, isOAuthToken, options);
+			const params = buildParams(model, baseUrl, context, isOAuthToken, options);
 			options?.onPayload?.(params);
 			rawRequestDump = {
 				provider: model.provider,
 				api: output.api,
 				model: model.id,
 				method: "POST",
-				url: `${model.baseUrl ?? "https://api.anthropic.com"}/v1/messages`,
+				url: `${baseUrl}/v1/messages`,
 				body: params,
 			};
 
@@ -830,8 +938,9 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		isOAuth,
 	} = args;
 	const oauthToken = isOAuth ?? isAnthropicOAuthToken(apiKey);
-
-	const tlsFetchOptions = buildClaudeCodeTlsFetchOptions(model);
+	const baseUrl = resolveAnthropicBaseUrl(model);
+	const foundryCustomHeaders = resolveAnthropicCustomHeaders(model);
+	const tlsFetchOptions = buildClaudeCodeTlsFetchOptions(model, baseUrl);
 	if (model.provider === "github-copilot") {
 		const betaFeatures = [...extraBetas];
 		if (interleavedThinking) {
@@ -853,7 +962,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 			isOAuthToken: false,
 			apiKey: null,
 			authToken: apiKey,
-			baseURL: model.baseUrl,
+			baseURL: baseUrl,
 			maxRetries: 5,
 			dangerouslyAllowBrowser: true,
 			defaultHeaders,
@@ -868,18 +977,18 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 
 	const defaultHeaders = buildAnthropicHeaders({
 		apiKey,
-		baseUrl: model.baseUrl,
+		baseUrl,
 		isOAuth: oauthToken,
 		extraBetas: betaFeatures,
 		stream,
-		modelHeaders: mergeHeaders(model.headers, headers, dynamicHeaders),
+		modelHeaders: mergeHeaders(model.headers, foundryCustomHeaders, headers, dynamicHeaders),
 	});
 
 	return {
 		isOAuthToken: oauthToken,
 		apiKey: oauthToken ? null : apiKey,
 		authToken: oauthToken ? apiKey : undefined,
-		baseURL: model.baseUrl,
+		baseURL: baseUrl,
 		maxRetries: 5,
 		dangerouslyAllowBrowser: true,
 		defaultHeaders,
@@ -1152,11 +1261,12 @@ function enforceCacheControlLimit(params: MessageCreateParamsStreaming, maxBreak
 }
 function buildParams(
 	model: Model<"anthropic-messages">,
+	baseUrl: string,
 	context: Context,
 	isOAuthToken: boolean,
 	options?: AnthropicOptions,
 ): MessageCreateParamsStreaming {
-	const { cacheControl } = getCacheControl(model.baseUrl, options?.cacheRetention);
+	const { cacheControl } = getCacheControl(baseUrl, options?.cacheRetention);
 	const params: AnthropicSamplingParams = {
 		model: model.id,
 		messages: convertAnthropicMessages(context.messages, model, isOAuthToken),

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -53,6 +53,13 @@ function hasVertexAdcCredentials(): boolean {
 
 type KeyResolver = string | (() => string | undefined);
 
+function isFoundryEnabled(): boolean {
+	const value = $env.CLAUDE_CODE_USE_FOUNDRY;
+	if (!value) return false;
+	const normalized = value.trim().toLowerCase();
+	return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
 const serviceProviderMap: Record<string, KeyResolver> = {
 	openai: "OPENAI_API_KEY",
 	google: "GEMINI_API_KEY",
@@ -77,8 +84,11 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	kagi: "KAGI_API_KEY",
 	// GitHub Copilot uses GitHub personal access token
 	"github-copilot": () => $pickenv("COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"),
-	// ANTHROPIC_OAUTH_TOKEN takes precedence over ANTHROPIC_API_KEY
-	anthropic: () => $pickenv("ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"),
+	// Foundry mode optionally switches Anthropic auth to enterprise gateway credentials.
+	anthropic: () =>
+		isFoundryEnabled()
+			? $pickenv("ANTHROPIC_FOUNDRY_API_KEY", "ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY")
+			: $pickenv("ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"),
 	"gitlab-duo": "GITLAB_TOKEN",
 	// Vertex AI uses Application Default Credentials, not API keys.
 	// Auth is configured via `gcloud auth application-default login`.

--- a/packages/ai/src/utils/anthropic-auth.ts
+++ b/packages/ai/src/utils/anthropic-auth.ts
@@ -4,7 +4,7 @@
  * 3-tier auth resolution:
  *   1. ANTHROPIC_SEARCH_API_KEY / ANTHROPIC_SEARCH_BASE_URL env vars
  *   2. OAuth credentials in ~/.omp/agent/agent.db (with expiry check)
- *   3. ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL fallback
+ *   3. Generic Anthropic fallback (Foundry-aware key/base URL resolution)
  */
 import { $env, getAgentDbPath } from "@oh-my-pi/pi-utils";
 import { type AuthCredential, AuthCredentialStore } from "../auth-storage";
@@ -28,6 +28,22 @@ export interface AnthropicOAuthCredential {
 }
 
 const DEFAULT_BASE_URL = "https://api.anthropic.com";
+
+function isFoundryEnabled(): boolean {
+	const value = $env.CLAUDE_CODE_USE_FOUNDRY;
+	if (!value) return false;
+	const normalized = value.trim().toLowerCase();
+	return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+function resolveAnthropicBaseUrlFromEnv(): string | undefined {
+	if (isFoundryEnabled()) {
+		const foundryBaseUrl = $env.FOUNDRY_BASE_URL?.trim();
+		if (foundryBaseUrl) return foundryBaseUrl;
+	}
+	const anthropicBaseUrl = $env.ANTHROPIC_BASE_URL?.trim();
+	return anthropicBaseUrl || undefined;
+}
 
 /**
  * Checks if a token is an OAuth token by looking for sk-ant-oat prefix.
@@ -117,7 +133,7 @@ export async function findAnthropicAuth(store?: AuthCredentialStore): Promise<An
 
 	// 3. Generic ANTHROPIC_API_KEY fallback
 	const apiKey = getEnvApiKey("anthropic");
-	const baseUrl = $env.ANTHROPIC_BASE_URL;
+	const baseUrl = resolveAnthropicBaseUrlFromEnv();
 	if (apiKey) {
 		return {
 			apiKey,

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import * as tls from "node:tls";
 import {
 	applyClaudeToolPrefix,
@@ -16,6 +19,7 @@ import {
 	stripClaudeToolPrefix,
 } from "@oh-my-pi/pi-ai/providers/anthropic";
 import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { getEnvApiKey } from "@oh-my-pi/pi-ai/stream";
 
 const ANTHROPIC_MODEL: Model<"anthropic-messages"> = {
 	id: "claude-sonnet-4-5",
@@ -34,6 +38,34 @@ function createAbortedSignal(): AbortSignal {
 	const controller = new AbortController();
 	controller.abort();
 	return controller.signal;
+}
+
+async function withEnv(
+	overrides: Record<string, string | undefined>,
+	fn: () => void | Promise<void>,
+): Promise<void> {
+	const previous = new Map<string, string | undefined>();
+	for (const key of Object.keys(overrides)) {
+		previous.set(key, Bun.env[key]);
+	}
+	try {
+		for (const [key, value] of Object.entries(overrides)) {
+			if (value === undefined) {
+				delete Bun.env[key];
+			} else {
+				Bun.env[key] = value;
+			}
+		}
+		await fn();
+	} finally {
+		for (const [key, value] of previous.entries()) {
+			if (value === undefined) {
+				delete Bun.env[key];
+			} else {
+				Bun.env[key] = value;
+			}
+		}
+	}
 }
 
 function captureAnthropicPayload(
@@ -298,6 +330,98 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(tlsOptions?.rejectUnauthorized).toBe(true);
 		expect(tlsOptions?.serverName).toBe("api.anthropic.com");
 		expect(tlsOptions?.ciphers).toBe(tls.DEFAULT_CIPHERS);
+	});
+
+	it("uses Foundry base URL, Bearer auth, and custom headers when enabled", async () => {
+		await withEnv(
+			{
+				CLAUDE_CODE_USE_FOUNDRY: "true",
+				FOUNDRY_BASE_URL: "https://foundry.example.com/anthropic/",
+				ANTHROPIC_CUSTOM_HEADERS: "user-id: alice, x-route: engineering",
+			},
+			() => {
+				const options = buildAnthropicClientOptions({
+					model: ANTHROPIC_MODEL,
+					apiKey: "foundry-token",
+					extraBetas: [],
+					stream: true,
+					interleavedThinking: false,
+					dynamicHeaders: {},
+				});
+
+				expect(options.baseURL).toBe("https://foundry.example.com/anthropic");
+				expect(options.defaultHeaders.Authorization).toBe("Bearer foundry-token");
+				expect(options.defaultHeaders["X-Api-Key"]).toBeUndefined();
+				expect(options.defaultHeaders["user-id"]).toBe("alice");
+				expect(options.defaultHeaders["x-route"]).toBe("engineering");
+			},
+		);
+	});
+
+	it("loads Foundry mTLS and CA material from file paths", async () => {
+		const tmpDir = path.join(os.tmpdir(), `pi-ai-foundry-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+		fs.mkdirSync(tmpDir, { recursive: true });
+		const caPath = path.join(tmpDir, "ca.pem");
+		const certPath = path.join(tmpDir, "client-cert.pem");
+		const keyPath = path.join(tmpDir, "client-key.pem");
+		fs.writeFileSync(caPath, "-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----\n", "utf8");
+		fs.writeFileSync(certPath, "-----BEGIN CERTIFICATE-----\nCERT\n-----END CERTIFICATE-----\n", "utf8");
+		fs.writeFileSync(keyPath, "-----BEGIN PRIVATE KEY-----\nKEY\n-----END PRIVATE KEY-----\n", "utf8");
+
+		try {
+			await withEnv(
+				{
+					CLAUDE_CODE_USE_FOUNDRY: "1",
+					FOUNDRY_BASE_URL: "https://foundry.example.com",
+					NODE_EXTRA_CA_CERTS: caPath,
+					CLAUDE_CODE_CLIENT_CERT: certPath,
+					CLAUDE_CODE_CLIENT_KEY: keyPath,
+				},
+				() => {
+					const options = buildAnthropicClientOptions({
+						model: ANTHROPIC_MODEL,
+						apiKey: "foundry-token",
+						extraBetas: [],
+						stream: true,
+						interleavedThinking: false,
+						dynamicHeaders: {},
+					});
+
+					const tlsOptions = (
+						options.fetchOptions as
+							| {
+									tls?: {
+										serverName?: string;
+										ca?: string;
+										cert?: string;
+										key?: string;
+									};
+							  }
+							| undefined
+					)?.tls;
+					expect(tlsOptions?.serverName).toBe("foundry.example.com");
+					expect(tlsOptions?.ca).toContain("BEGIN CERTIFICATE");
+					expect(tlsOptions?.cert).toContain("BEGIN CERTIFICATE");
+					expect(tlsOptions?.key).toContain("BEGIN PRIVATE KEY");
+				},
+			);
+		} finally {
+			fs.rmSync(tmpDir, { recursive: true, force: true });
+		}
+	});
+
+	it("resolves Anthropic Foundry API key when Foundry mode is enabled", async () => {
+		await withEnv(
+			{
+				CLAUDE_CODE_USE_FOUNDRY: "true",
+				ANTHROPIC_FOUNDRY_API_KEY: "foundry-env-token",
+				ANTHROPIC_OAUTH_TOKEN: "sk-ant-oat-should-not-win",
+				ANTHROPIC_API_KEY: "sk-ant-api-should-not-win",
+			},
+			() => {
+				expect(getEnvApiKey("anthropic")).toBe("foundry-env-token");
+			},
+		);
 	});
 
 	it("treats tool prefix helpers as no-ops when prefix is empty", () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+
+- Updated Anthropic Foundry environment variable documentation and CLI help text to the canonical names: `CLAUDE_CODE_USE_FOUNDRY`, `CLAUDE_CODE_CLIENT_CERT`, and `CLAUDE_CODE_CLIENT_KEY`
+- Documented Foundry-specific Anthropic runtime configuration (`FOUNDRY_BASE_URL`, `ANTHROPIC_FOUNDRY_API_KEY`, `ANTHROPIC_CUSTOM_HEADERS`, `NODE_EXTRA_CA_CERTS`) in environment variable reference docs
 
 ## [13.5.6] - 2026-03-01
 ### Changed

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -191,6 +191,13 @@ export function getExtraHelpText(): string {
   ${chalk.dim("# Core Providers")}
   ANTHROPIC_API_KEY          - Anthropic Claude models
   ANTHROPIC_OAUTH_TOKEN      - Anthropic OAuth (takes precedence over API key)
+  CLAUDE_CODE_USE_FOUNDRY    - Enable Anthropic Foundry mode (uses Foundry endpoint + mTLS)
+  FOUNDRY_BASE_URL           - Anthropic Foundry base URL (e.g., https://<foundry-host>)
+  ANTHROPIC_FOUNDRY_API_KEY  - Anthropic token used as Authorization: Bearer <token> in Foundry mode
+  ANTHROPIC_CUSTOM_HEADERS   - Extra Foundry headers (e.g., "user-id: USERNAME")
+  CLAUDE_CODE_CLIENT_CERT    - Client certificate (PEM path or inline PEM) for mTLS
+  CLAUDE_CODE_CLIENT_KEY     - Client private key (PEM path or inline PEM) for mTLS
+  NODE_EXTRA_CA_CERTS        - CA bundle path (or inline PEM) for server certificate validation
   OPENAI_API_KEY             - OpenAI GPT models
   GEMINI_API_KEY             - Google Gemini models
   GITHUB_TOKEN               - GitHub Copilot (or GH_TOKEN, COPILOT_GITHUB_TOKEN)


### PR DESCRIPTION
## What

Added support for azure foundry for claude code authentication

## Why

some organizations provide an API key, client certificate and private key for Claude code usage via foundry

## Testing

Ran it locally on my mac and saw it work

---

- [ x] `bun check` passes
- [x ] Tested locally
- [ x] CHANGELOG updated (if user-facing)
