### PR TITLE
fix(coding-agent): make skill ordering deterministic in prompts

### DIFF
--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -275,6 +275,16 @@ export interface ScanSkillsFromDirOptions {
 	requireDescription?: boolean;
 }
 
+// Stable ordering used for skill lists in prompts: name (case-insensitive), then name, then path.
+export function compareSkillOrder(aName: string, aPath: string, bName: string, bPath: string): number {
+	const cmp = (a: string, b: string): number => (a < b ? -1 : a > b ? 1 : 0);
+	const lowerCompare = cmp(aName.toLowerCase(), bName.toLowerCase());
+	if (lowerCompare !== 0) return lowerCompare;
+	const nameCompare = cmp(aName, bName);
+	if (nameCompare !== 0) return nameCompare;
+	return cmp(aPath, bPath);
+}
+
 export async function scanSkillsFromDir(
 	_ctx: LoadContext,
 	options: ScanSkillsFromDirOptions,
@@ -301,8 +311,10 @@ export async function scanSkillsFromDir(
 				return;
 			}
 			const skillDirName = path.basename(path.dirname(skillPath));
+			const rawName = frontmatter.name;
+			const name = typeof rawName === "string" ? rawName.trim() || skillDirName : skillDirName;
 			items.push({
-				name: (frontmatter.name as string) || skillDirName,
+				name,
 				path: skillPath,
 				content: body,
 				frontmatter: frontmatter as SkillFrontmatter,
@@ -324,6 +336,9 @@ export async function scanSkillsFromDir(
 		}
 	}
 	await Promise.all(work);
+
+	// Deterministic ordering: async file reads complete nondeterministically, so sort after loading.
+	items.sort((a, b) => compareSkillOrder(a.name, a.path, b.name, b.path));
 
 	return { items, warnings };
 }

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -5,7 +5,7 @@ import { skillCapability } from "../capability/skill";
 import type { SourceMeta } from "../capability/types";
 import type { SkillsSettings } from "../config/settings";
 import { type Skill as CapabilitySkill, loadCapability } from "../discovery";
-import { scanSkillsFromDir } from "../discovery/helpers";
+import { compareSkillOrder, scanSkillsFromDir } from "../discovery/helpers";
 import { expandTilde } from "../tools/path-utils";
 
 export interface Skill {
@@ -235,8 +235,12 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 		}
 	}
 
+	const skills = Array.from(skillMap.values());
+	// Deterministic ordering for prompt stability (case-insensitive, then exact name, then path).
+	skills.sort((a, b) => compareSkillOrder(a.name, a.filePath, b.name, b.filePath));
+
 	return {
-		skills: Array.from(skillMap.values()),
+		skills,
 		warnings: [...(result.warnings ?? []).map(w => ({ skillPath: "", message: w })), ...collisionWarnings],
 	};
 }

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -9,6 +9,16 @@ import { loadSkills, loadSkillsFromDir, type Skill } from "@oh-my-pi/pi-coding-a
 const fixturesDir = path.resolve(import.meta.dirname, "fixtures/skills");
 const collisionFixturesDir = path.resolve(import.meta.dirname, "fixtures/skills-collision");
 
+const longSkillName = "this-is-a-very-long-skill-name-that-exceeds-the-sixty-four-character-limit-set-by-the-standard";
+const expectedFixtureSkillOrder: string[] = [
+	"bad--name",
+	"different-name",
+	"Invalid_Name",
+	longSkillName,
+	"unknown-field",
+	"valid-skill",
+];
+
 describe("skills", () => {
 	describe("loadSkillsFromDir", () => {
 		const loadFixtureRoot = () => loadSkillsFromDir({ dir: fixturesDir, source: "test" });
@@ -95,6 +105,13 @@ describe("skills", () => {
 			expect(skills).toHaveLength(6);
 		});
 
+		it("should return skills sorted by name (case-insensitive)", async () => {
+			const { skills } = await loadFixtureRoot();
+			const names = skills.map(skill => skill.name);
+
+			expect(names).toEqual(expectedFixtureSkillOrder);
+		});
+
 		it("should return empty for non-existent directory", async () => {
 			const { skills, warnings } = await loadSkillsFromDir({
 				dir: "/non/existent/path",
@@ -127,6 +144,19 @@ describe("skills", () => {
 			expect(skills.length).toBeGreaterThan(0);
 			// Custom directory skills have source "custom:user"
 			expect(skills.every(s => s.source.startsWith("custom"))).toBe(true);
+		});
+
+		it("should return customDirectory skills sorted by name (case-insensitive)", async () => {
+			const { skills } = await loadSkills({
+				enableCodexUser: false,
+				enableClaudeUser: false,
+				enableClaudeProject: false,
+				enablePiUser: false,
+				enablePiProject: false,
+				customDirectories: [fixturesDir],
+			});
+
+			expect(skills.map(s => s.name)).toEqual(expectedFixtureSkillOrder);
 		});
 
 		it("should keep user Claude skills when project .claude/skills is missing", async () => {


### PR DESCRIPTION
## What

Make skills ordering deterministic by sorting skills after discovery/loading (case-insensitive name, then name, then path/filePath), so the rendered skills section in the system prompt is stable.

## Why

Skills were previously loaded concurrently and appended in IO completion order, which is nondeterministic across runs/resumes (and can be amplified by in-process file caching). This caused the skills section of the system prompt to change even when the underlying skills didn’t, reducing reproducibility and hurting any prompt-caching keyed on exact prompt content.

## Testing

 - `bun test packages/coding-agent/test/skills.test.ts`: pass
 - `bun check:ts`: pass
 - Built and manually inspected the generated system prompt(skills section ordering)

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
