### PR TITLE
fix: dereference MCP tool schema $ref/$defs and suppress Ajv format warnings

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- MCP tool schemas with `$ref`/`$defs` are now dereferenced before being sent to LLM providers, fixing dangling references that left models without type definitions
+- Ajv schema validation no longer emits `console.warn()` for non-standard format keywords (e.g. `"uint"`) from MCP servers, preventing TUI corruption
+- Tool schema compilation is now cached per schema identity, eliminating redundant recompilation on every tool call
 ## [13.6.0] - 2026-03-03
 ### Added
 

--- a/packages/ai/src/utils/schema/dereference.ts
+++ b/packages/ai/src/utils/schema/dereference.ts
@@ -1,0 +1,93 @@
+/**
+ * Inline `$ref` / `$defs` in a JSON Schema so every consumer sees
+ * the full definition without needing a resolver.
+ *
+ * Handles:
+ * - Local `$ref` pointers (`#/$defs/Foo`, `#/definitions/Foo`)
+ * - Nested `$defs` / `definitions` blocks
+ * - Circular references (breaks the cycle by emitting `{}`)
+ *
+ * After dereferencing, `$defs` and `definitions` are stripped from the root.
+ */
+import { isJsonObject, type JsonObject } from "./types";
+
+/**
+ * Resolve a JSON-pointer-style `$ref` against the root schema's `$defs`
+ * or `definitions` block. Returns `undefined` for external or unresolvable refs.
+ */
+function resolveLocalRef(ref: string, root: JsonObject): JsonObject | undefined {
+	// Only handle local refs: #/$defs/Name or #/definitions/Name
+	const match = /^#\/(\$defs|definitions)\/(.+)$/.exec(ref);
+	if (!match) return undefined;
+
+	const [, defsKey, name] = match;
+	const defs = root[defsKey!];
+	if (!isJsonObject(defs)) return undefined;
+
+	const resolved = defs[name!];
+	return isJsonObject(resolved) ? resolved : undefined;
+}
+
+/**
+ * Recursively dereference a JSON Schema node, inlining all local `$ref` pointers.
+ */
+function dereferenceNode(node: unknown, root: JsonObject, visiting: Set<string>): unknown {
+	if (!isJsonObject(node)) return node;
+	if (Array.isArray(node)) return node.map(item => dereferenceNode(item, root, visiting));
+
+	const ref = node.$ref;
+	if (typeof ref === "string") {
+		// Break circular references
+		if (visiting.has(ref)) return {};
+		const resolved = resolveLocalRef(ref, root);
+		if (!resolved) return node; // External ref — leave as-is
+		visiting.add(ref);
+		const inlined = dereferenceNode(resolved, root, visiting);
+		visiting.delete(ref);
+
+		// Merge sibling keywords (e.g. description, default) from the
+		// referencing node. In draft 2020-12 these are valid alongside $ref.
+		const hasSiblings = Object.keys(node).some(k => k !== "$ref");
+		if (!hasSiblings || !isJsonObject(inlined)) return inlined;
+		const merged: JsonObject = { ...inlined };
+		for (const [key, value] of Object.entries(node)) {
+			if (key !== "$ref") merged[key] = value;
+		}
+		return merged;
+	}
+
+	const result: JsonObject = {};
+	for (const [key, value] of Object.entries(node)) {
+		// Skip $defs/definitions — they get inlined into consumers
+		if (key === "$defs" || key === "definitions") continue;
+
+		if (Array.isArray(value)) {
+			result[key] = value.map(item => dereferenceNode(item, root, visiting));
+		} else if (isJsonObject(value)) {
+			result[key] = dereferenceNode(value, root, visiting);
+		} else {
+			result[key] = value;
+		}
+	}
+	return result;
+}
+
+/**
+ * Dereference all local `$ref` pointers in a JSON Schema, inlining definitions
+ * from `$defs` / `definitions`. The `$defs` block is stripped from the output.
+ *
+ * Non-local refs (e.g. `http://...`) are left untouched.
+ * Circular references are broken with `{}`.
+ *
+ * @returns A new schema object with all local refs inlined, or the input unchanged
+ *          if it's not an object or has no `$defs`/`definitions`.
+ */
+export function dereferenceJsonSchema(schema: unknown): unknown {
+	if (!isJsonObject(schema)) return schema;
+
+	// Fast path: nothing to dereference
+	const hasDefs = schema.$defs !== undefined || schema.definitions !== undefined;
+	if (!hasDefs) return schema;
+
+	return dereferenceNode(schema, schema, new Set());
+}

--- a/packages/ai/src/utils/schema/index.ts
+++ b/packages/ai/src/utils/schema/index.ts
@@ -1,5 +1,6 @@
 export * from "./adapt";
 export * from "./compatibility";
+export * from "./dereference";
 export * from "./equality";
 export * from "./fields";
 export * from "./normalize-cca";

--- a/packages/ai/src/utils/schema/sanitize-google.ts
+++ b/packages/ai/src/utils/schema/sanitize-google.ts
@@ -1,3 +1,4 @@
+import { dereferenceJsonSchema } from "./dereference";
 import { areJsonValuesEqual } from "./equality";
 import { UNSUPPORTED_SCHEMA_FIELDS } from "./fields";
 
@@ -197,7 +198,11 @@ const MCP_UNSUPPORTED_SCHEMA_FIELDS = new Set(["$schema"]);
  * (`pattern`, `format`, `additionalProperties`, etc.) and `$ref`/`$defs`.
  */
 export function sanitizeSchemaForMCP(value: unknown): unknown {
-	return sanitizeSchemaImpl(value, {
+	// Dereference $ref/$defs first — MCP servers emit standard JSON Schema
+	// with $defs, but providers (Anthropic, Google) only forward `properties`
+	// and `required`, dropping $defs and leaving dangling $ref pointers.
+	const dereferenced = dereferenceJsonSchema(value);
+	return sanitizeSchemaImpl(dereferenced, {
 		insideProperties: false,
 		normalizeTypeArrayToNullable: false,
 		stripNullableKeyword: true,

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -451,11 +451,27 @@ function coerceArgsFromErrors(
 
 // Create a singleton AJV instance with formats (only if not in browser extension)
 // AJV requires 'unsafe-eval' CSP which is not allowed in Manifest V3
+//
+// Silent logger: MCP servers may declare non-standard format keywords (e.g. "uint")
+// which cause Ajv to emit console.warn() with strict:false — corrupting TUI output.
 const ajv = new Ajv({
 	allErrors: true,
 	strict: false,
+	logger: false,
 });
 addFormats(ajv);
+
+// Cache compiled validators by schema object identity to avoid
+// re-compiling the same tool schema on every call.
+const compiledSchemaCache = new WeakMap<object, import("ajv").ValidateFunction>();
+function compileSchema(schema: object): import("ajv").ValidateFunction {
+	let validate = compiledSchemaCache.get(schema);
+	if (!validate) {
+		validate = ajv.compile(schema);
+		compiledSchemaCache.set(schema, validate);
+	}
+	return validate;
+}
 
 const MAX_TYPE_COERCION_PASSES = 5;
 
@@ -484,8 +500,7 @@ export function validateToolCall(tools: Tool[], toolCall: ToolCall): any {
 export function validateToolArguments(tool: Tool, toolCall: ToolCall): any {
 	const originalArgs = toolCall.arguments;
 
-	// Compile the schema
-	const validate = ajv.compile(tool.parameters);
+	const validate = compileSchema(tool.parameters);
 
 	// Validate the arguments
 	if (validate(originalArgs)) {

--- a/packages/ai/test/schema-dereference.test.ts
+++ b/packages/ai/test/schema-dereference.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "bun:test";
+import { dereferenceJsonSchema } from "@oh-my-pi/pi-ai/utils/schema";
+
+describe("dereferenceJsonSchema", () => {
+	it("returns non-object input unchanged", () => {
+		expect(dereferenceJsonSchema(null)).toBe(null);
+		expect(dereferenceJsonSchema("string")).toBe("string");
+		expect(dereferenceJsonSchema(42)).toBe(42);
+	});
+
+	it("returns schema without $defs unchanged", () => {
+		const schema = {
+			type: "object",
+			properties: { name: { type: "string" } },
+			required: ["name"],
+		};
+		expect(dereferenceJsonSchema(schema)).toBe(schema);
+	});
+
+	it("inlines a simple $ref from $defs", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				anchor: { $ref: "#/$defs/Anchor" },
+			},
+			$defs: {
+				Anchor: {
+					type: "object",
+					properties: {
+						path: { type: "string" },
+						line: { type: "integer", minimum: 0 },
+					},
+				},
+			},
+		};
+		const result = dereferenceJsonSchema(schema) as any;
+		expect(result.$defs).toBeUndefined();
+		expect(result.properties.anchor).toEqual({
+			type: "object",
+			properties: {
+				path: { type: "string" },
+				line: { type: "integer", minimum: 0 },
+			},
+		});
+	});
+
+	it("inlines $ref from definitions (legacy keyword)", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				item: { $ref: "#/definitions/Item" },
+			},
+			definitions: {
+				Item: { type: "string", enum: ["a", "b"] },
+			},
+		};
+		const result = dereferenceJsonSchema(schema) as any;
+		expect(result.definitions).toBeUndefined();
+		expect(result.properties.item).toEqual({ type: "string", enum: ["a", "b"] });
+	});
+
+	it("inlines nested $ref inside arrays (items, anyOf, oneOf)", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				anchors: {
+					type: "array",
+					items: { $ref: "#/$defs/SourceAnchorInput" },
+				},
+				value: {
+					anyOf: [{ $ref: "#/$defs/Str" }, { type: "null" }],
+				},
+			},
+			$defs: {
+				SourceAnchorInput: {
+					type: "object",
+					properties: {
+						anchor_type: { type: "string", enum: ["file", "symbol", "pattern"] },
+						path: { type: "string" },
+					},
+					required: ["anchor_type", "path"],
+				},
+				Str: { type: "string" },
+			},
+		};
+		const result = dereferenceJsonSchema(schema) as any;
+		expect(result.$defs).toBeUndefined();
+		expect(result.properties.anchors.items).toEqual({
+			type: "object",
+			properties: {
+				anchor_type: { type: "string", enum: ["file", "symbol", "pattern"] },
+				path: { type: "string" },
+			},
+			required: ["anchor_type", "path"],
+		});
+		expect(result.properties.value.anyOf[0]).toEqual({ type: "string" });
+		expect(result.properties.value.anyOf[1]).toEqual({ type: "null" });
+	});
+
+	it("handles $ref inside a definition pointing to another definition", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				wrapper: { $ref: "#/$defs/Wrapper" },
+			},
+			$defs: {
+				Inner: { type: "integer", minimum: 0 },
+				Wrapper: {
+					type: "object",
+					properties: {
+						value: { $ref: "#/$defs/Inner" },
+					},
+				},
+			},
+		};
+		const result = dereferenceJsonSchema(schema) as any;
+		expect(result.$defs).toBeUndefined();
+		expect(result.properties.wrapper).toEqual({
+			type: "object",
+			properties: {
+				value: { type: "integer", minimum: 0 },
+			},
+		});
+	});
+
+	it("breaks circular $ref with empty object", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				node: { $ref: "#/$defs/TreeNode" },
+			},
+			$defs: {
+				TreeNode: {
+					type: "object",
+					properties: {
+						name: { type: "string" },
+						children: {
+							type: "array",
+							items: { $ref: "#/$defs/TreeNode" },
+						},
+					},
+				},
+			},
+		};
+		const result = dereferenceJsonSchema(schema) as any;
+		expect(result.$defs).toBeUndefined();
+		const node = result.properties.node;
+		expect(node.properties.name).toEqual({ type: "string" });
+		// Circular ref breaks to {}
+		expect(node.properties.children.items).toEqual({});
+	});
+
+	it("leaves external $ref untouched", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				ext: { $ref: "https://example.com/schema.json#/Foo" },
+			},
+			$defs: {},
+		};
+		const result = dereferenceJsonSchema(schema) as any;
+		expect(result.properties.ext).toEqual({ $ref: "https://example.com/schema.json#/Foo" });
+	});
+
+	it("preserves sibling keywords alongside $ref", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				anchor_type: {
+					$ref: "#/$defs/AnchorType",
+					description: "Field-level description",
+					default: "file",
+				},
+			},
+			$defs: {
+				AnchorType: {
+					type: "string",
+					enum: ["file", "symbol", "pattern"],
+					description: "Type-level description",
+				},
+			},
+		};
+		const result = dereferenceJsonSchema(schema) as any;
+		expect(result.$defs).toBeUndefined();
+		// Sibling description overrides the definition's description
+		expect(result.properties.anchor_type).toEqual({
+			type: "string",
+			enum: ["file", "symbol", "pattern"],
+			description: "Field-level description",
+			default: "file",
+		});
+	});
+
+	it("handles multiple properties referencing the same $def", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				a: { $ref: "#/$defs/Shared" },
+				b: { $ref: "#/$defs/Shared" },
+			},
+			$defs: {
+				Shared: { type: "string", maxLength: 100 },
+			},
+		};
+		const result = dereferenceJsonSchema(schema) as any;
+		expect(result.$defs).toBeUndefined();
+		expect(result.properties.a).toEqual({ type: "string", maxLength: 100 });
+		expect(result.properties.b).toEqual({ type: "string", maxLength: 100 });
+	});
+
+	it("reproduces the nucleus write_memory schema pattern", () => {
+		// Simplified version of the actual nucleus tool schema
+		const schema = {
+			type: "object",
+			properties: {
+				kind: { type: "string", description: "Memory kind" },
+				content: { type: "string", description: "Memory content" },
+				anchors: {
+					description: "Source anchors",
+					items: { $ref: "#/$defs/SourceAnchorInput" },
+					type: "array",
+				},
+			},
+			required: ["kind", "content", "anchors"],
+			$defs: {
+				SourceAnchorInput: {
+					type: "object",
+					properties: {
+						anchor_type: {
+							description: "Anchor type",
+							enum: ["file", "symbol", "pattern"],
+							type: "string",
+						},
+						path: { type: "string" },
+						role: { type: "string" },
+						symbol: { type: "string" },
+					},
+					required: ["anchor_type", "path"],
+				},
+			},
+		};
+		const result = dereferenceJsonSchema(schema) as any;
+
+		// $defs stripped
+		expect(result.$defs).toBeUndefined();
+
+		// anchors items fully inlined
+		expect(result.properties.anchors.items.properties.anchor_type.enum).toEqual(["file", "symbol", "pattern"]);
+		expect(result.properties.anchors.items.required).toEqual(["anchor_type", "path"]);
+
+		// Other properties preserved
+		expect(result.properties.kind).toEqual({ type: "string", description: "Memory kind" });
+		expect(result.required).toEqual(["kind", "content", "anchors"]);
+	});
+});

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -41,7 +41,7 @@ import {
 } from "./types";
 
 const MCP_CALL_TIMEOUT_MS = 60_000;
-const ajv = new Ajv({ allErrors: true, strict: false });
+const ajv = new Ajv({ allErrors: true, strict: false, logger: false });
 
 /** Agent event types to forward for progress tracking. */
 const agentEventTypes = new Set<AgentEvent["type"]>([

--- a/packages/coding-agent/src/tools/submit-result.ts
+++ b/packages/coding-agent/src/tools/submit-result.ts
@@ -4,7 +4,7 @@
  * Subagents must call this tool to finish and return structured JSON output.
  */
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
-import { sanitizeSchemaForStrictMode } from "@oh-my-pi/pi-ai/utils/schema";
+import { dereferenceJsonSchema, sanitizeSchemaForStrictMode } from "@oh-my-pi/pi-ai/utils/schema";
 import type { Static, TSchema } from "@sinclair/typebox";
 import { Type } from "@sinclair/typebox";
 import Ajv, { type ErrorObject, type ValidateFunction } from "ajv";
@@ -18,7 +18,7 @@ export interface SubmitResultDetails {
 	error?: string;
 }
 
-const ajv = new Ajv({ allErrors: true, strict: false });
+const ajv = new Ajv({ allErrors: true, strict: false, logger: false });
 
 function normalizeSchema(schema: unknown): { normalized?: unknown; error?: string } {
 	if (schema === undefined || schema === null) return {};
@@ -50,53 +50,6 @@ function formatAjvErrors(errors: ErrorObject[] | null | undefined): string {
 			return `${path}${err.message ?? "invalid"}`;
 		})
 		.join("; ");
-}
-
-/**
- * Resolve all $ref references in a JSON Schema by inlining definitions.
- * Handles $defs and definitions at any nesting level.
- * Removes $defs/definitions from the output since all refs are inlined.
- */
-function resolveSchemaRefs(schema: Record<string, unknown>): Record<string, unknown> {
-	const defs: Record<string, Record<string, unknown>> = {};
-	const defsObj = schema.$defs ?? schema.definitions;
-	if (defsObj && typeof defsObj === "object" && !Array.isArray(defsObj)) {
-		for (const [name, def] of Object.entries(defsObj as Record<string, unknown>)) {
-			if (def && typeof def === "object" && !Array.isArray(def)) {
-				defs[name] = def as Record<string, unknown>;
-			}
-		}
-	}
-	if (Object.keys(defs).length === 0) return schema;
-
-	const inlining = new Set<string>();
-	function inline(node: unknown): unknown {
-		if (node === null || typeof node !== "object") return node;
-		if (Array.isArray(node)) return node.map(inline);
-		const obj = node as Record<string, unknown>;
-		const ref = obj.$ref;
-		if (typeof ref === "string") {
-			const match = ref.match(/^#\/(?:\$defs|definitions)\/(.+)$/);
-			if (match) {
-				const name = match[1];
-				const def = defs[name];
-				if (def) {
-					if (inlining.has(name)) return {};
-					inlining.add(name);
-					const resolved = inline(def);
-					inlining.delete(name);
-					return resolved;
-				}
-			}
-		}
-		const result: Record<string, unknown> = {};
-		for (const [key, value] of Object.entries(obj)) {
-			if (key === "$defs" || key === "definitions") continue;
-			result[key] = inline(value);
-		}
-		return result;
-	}
-	return inline(schema) as Record<string, unknown>;
 }
 
 export class SubmitResultTool implements AgentTool<TSchema, SubmitResultDetails> {
@@ -168,11 +121,11 @@ export class SubmitResultTool implements AgentTool<TSchema, SubmitResultDetails>
 						: undefined;
 
 			if (sanitizedSchema !== undefined) {
-				const resolved = resolveSchemaRefs({
+				const resolved = dereferenceJsonSchema({
 					...sanitizedSchema,
 					description: schemaDescription,
 				});
-				dataSchema = Type.Unsafe(resolved);
+				dataSchema = Type.Unsafe(resolved as Record<string, unknown>);
 			} else {
 				dataSchema = Type.Record(Type.String(), Type.Any(), {
 					description: schemaError ? schemaDescription : "Structured JSON output (no schema specified)",


### PR DESCRIPTION
## Problem

MCP servers (e.g. nucleus) emit standard JSON Schema with `$defs` and `$ref` pointers for shared type definitions. OMP has two bugs in how it handles these schemas:

### 1. Dangling `$ref` — LLM never sees type definitions

`sanitizeSchemaForMCP()` passes `$ref`/`$defs` through unchanged, but the Anthropic provider's `convertTools()` (line 1494-1498) extracts only `properties` and `required` from the tool schema:

```ts
input_schema: {
    type: "object",
    properties: jsonSchema.properties || {},
    required: jsonSchema.required || [],
},
```

This drops `$defs` entirely. Any `$ref` in properties becomes a dangling pointer — the LLM sees `"$ref": "#/$defs/SourceAnchorInput"` as an opaque string with no definition available. It never learns the allowed enum values, required fields, or nested structure.

**Concrete impact:** For nucleus `write_memory`, the `anchors` parameter uses `$ref` to `SourceAnchorInput`. Without dereferencing, the LLM doesn't see that `anchor_type` must be one of `["file", "symbol", "pattern"]`, or that `path` is required.

### 2. `console.warn()` spam corrupts TUI

MCP servers may declare non-standard JSON Schema format keywords (e.g. `"format": "uint"` — valid in JTD/OpenAPI but not JSON Schema). Ajv with `strict: false` downgrades these to `console.warn()` instead of throwing. Since Ajv defaults to `console` as its logger, these warnings write directly to stderr, corrupting TUI output.

This is amplified by:
- **No compile cache**: `ajv.compile(tool.parameters)` is called on every tool call, not once per schema
- **Parallel subagents**: Multiple agents calling nucleus tools simultaneously = warning flood

```
unknown format "uint" ignored in schema at path "#/properties/line"
unknown format "uint" ignored in schema at path "#/properties/limit"
unknown format "uint" ignored in schema at path "#/properties/offset"
```

## Solution

### Dereference `$ref`/`$defs` in `sanitizeSchemaForMCP`

New `dereferenceJsonSchema()` utility that recursively inlines all local `$ref` pointers before the schema reaches any provider:

- Resolves `#/$defs/Name` and `#/definitions/Name` (legacy keyword)
- Handles nested refs (definition A referencing definition B)
- Breaks circular references with `{}` instead of infinite recursion
- Leaves external refs (e.g. `https://...`) untouched
- Strips `$defs`/`definitions` blocks from output
- Preserves sibling keywords alongside `$ref` (e.g. `description`, `default`) per draft 2020-12 semantics — field-level overrides win over the definition's values

Wired into `sanitizeSchemaForMCP()` as a pre-pass — dereference first, then sanitize. This means all downstream consumers (Anthropic, Google, OpenAI, Bedrock) get fully inlined schemas without any per-provider changes.

### Suppress Ajv format warnings

Set `logger: false` on all three Ajv instances that use `strict: false`:
- `packages/ai/src/utils/validation.ts` (tool argument validation)
- `packages/coding-agent/src/task/executor.ts` (subagent output validation)
- `packages/coding-agent/src/tools/submit-result.ts` (submit_result schema validation)

### Cache compiled schemas

Added `WeakMap<object, ValidateFunction>` cache in `validation.ts` keyed on the `tool.parameters` object reference. Tool parameter objects are stable (same reference per tool), so this eliminates redundant recompilation on every tool call — O(1) after first call.

## Files changed

| File | Change |
|---|---|
| `packages/ai/src/utils/schema/dereference.ts` | New. `dereferenceJsonSchema()` implementation |
| `packages/ai/src/utils/schema/sanitize-google.ts` | Wire dereferencing into `sanitizeSchemaForMCP()` |
| `packages/ai/src/utils/schema/index.ts` | Re-export dereference module |
| `packages/ai/src/utils/validation.ts` | Silent Ajv logger + compile cache |
| `packages/coding-agent/src/task/executor.ts` | Silent Ajv logger |
| `packages/coding-agent/src/tools/submit-result.ts` | Silent Ajv logger |
| `packages/ai/test/schema-dereference.test.ts` | 11 tests |
| `packages/ai/CHANGELOG.md` | Changelog entries |

## Testing

11 test cases covering:
- Non-object input passthrough
- Schema without `$defs` (fast path, returns same reference)
- Simple `$ref` inlining from `$defs`
- Legacy `definitions` keyword
- Nested refs in `items`, `anyOf`, `oneOf`
- Transitive refs (definition referencing another definition)
- Circular reference cycle-breaking
- External `$ref` left untouched
- Sibling keywords alongside `$ref` (description/default preserved, field-level overrides definition)
- Multiple properties sharing the same `$def`
- Real-world nucleus `write_memory` schema pattern

```
bun test packages/ai/test/schema-dereference.test.ts
# 11 pass, 0 fail, 28 expect() calls
```

Type check and lint clean: `bun check:ts` passes.