### PR TITLE
fix(tui): improve input wrapping and Unicode word navigation

### DIFF
--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -6,7 +6,15 @@ import { matchesKey } from "../keys";
 import { KillRing } from "../kill-ring";
 import type { SymbolTheme } from "../symbols";
 import { type Component, CURSOR_MARKER, type Focusable } from "../tui";
-import { getSegmenter, getWordNavKind, isWordNavJoiner, isWhitespaceChar, padding, truncateToWidth, visibleWidth } from "../utils";
+import {
+	getSegmenter,
+	getWordNavKind,
+	isWhitespaceChar,
+	isWordNavJoiner,
+	padding,
+	truncateToWidth,
+	visibleWidth,
+} from "../utils";
 import { SelectList, type SelectListTheme } from "./select-list";
 
 const segmenter = getSegmenter();
@@ -2012,7 +2020,10 @@ export class Editor implements Component, Focusable {
 			const kind = getWordNavKind(last);
 			if (kind === "delimiter") {
 				// Skip delimiter run (punctuation/symbols)
-				while (graphemes.length > 0 && getWordNavKind(graphemes[graphemes.length - 1]?.segment || "") === "delimiter") {
+				while (
+					graphemes.length > 0 &&
+					getWordNavKind(graphemes[graphemes.length - 1]?.segment || "") === "delimiter"
+				) {
 					newCol -= graphemes.pop()?.segment.length || 0;
 				}
 			} else if (kind === "cjk") {

--- a/packages/tui/src/components/input.ts
+++ b/packages/tui/src/components/input.ts
@@ -2,7 +2,7 @@ import { BracketedPasteHandler } from "../bracketed-paste";
 import { getEditorKeybindings } from "../keybindings";
 import { KillRing } from "../kill-ring";
 import { type Component, CURSOR_MARKER, type Focusable } from "../tui";
-import { getSegmenter, getWordNavKind, isWordNavJoiner, isWhitespaceChar, padding, sliceWithWidth, visibleWidth } from "../utils";
+import { getSegmenter, getWordNavKind, isWordNavJoiner, padding, sliceWithWidth, visibleWidth } from "../utils";
 
 const segmenter = getSegmenter();
 
@@ -350,7 +350,10 @@ export class Input implements Component, Focusable {
 			const kind = getWordNavKind(last);
 			if (kind === "delimiter") {
 				// Skip delimiter run (punctuation/symbols)
-				while (graphemes.length > 0 && getWordNavKind(graphemes[graphemes.length - 1]?.segment || "") === "delimiter") {
+				while (
+					graphemes.length > 0 &&
+					getWordNavKind(graphemes[graphemes.length - 1]?.segment || "") === "delimiter"
+				) {
 					this.#cursor -= graphemes.pop()?.segment.length || 0;
 				}
 			} else if (kind === "cjk") {
@@ -442,7 +445,6 @@ export class Input implements Component, Focusable {
 				this.#cursor += graphemes[i]?.segment.length || 0;
 			}
 		}
-
 	}
 
 	#handlePaste(pastedText: string): void {
@@ -472,7 +474,7 @@ export class Input implements Component, Focusable {
 
 		const cursorIndex = this.#cursor;
 		// Ensure we always have a grapheme to invert at the cursor (space at end).
-		const displayValue = cursorIndex >= this.#value.length ? this.#value + " " : this.#value;
+		const displayValue = cursorIndex >= this.#value.length ? `${this.#value} ` : this.#value;
 
 		const totalCols = visibleWidth(displayValue);
 		const cursorCols = visibleWidth(displayValue.slice(0, cursorIndex));

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -125,7 +125,12 @@ export function getWordNavKind(grapheme: string): WordNavKind {
 	if (!ch) return "other";
 	if (WORD_NAV_RE_WHITESPACE.test(ch)) return "whitespace";
 	if (WORD_NAV_RE_PUNCT.test(ch) || WORD_NAV_RE_SYMBOL.test(ch)) return "delimiter";
-	if (WORD_NAV_RE_HAN.test(ch) || WORD_NAV_RE_HIRAGANA.test(ch) || WORD_NAV_RE_KATAKANA.test(ch) || WORD_NAV_RE_HANGUL.test(ch)) {
+	if (
+		WORD_NAV_RE_HAN.test(ch) ||
+		WORD_NAV_RE_HIRAGANA.test(ch) ||
+		WORD_NAV_RE_KATAKANA.test(ch) ||
+		WORD_NAV_RE_HANGUL.test(ch)
+	) {
 		return "cjk";
 	}
 	if (ch === "_" || WORD_NAV_RE_LETTER.test(ch) || WORD_NAV_RE_NUMBER.test(ch)) return "word";
@@ -138,7 +143,6 @@ export function isWordNavJoiner(grapheme: string): boolean {
 	const ch = firstCodePointChar(grapheme);
 	return WORD_NAV_JOINERS.has(ch);
 }
-
 
 /**
  * Apply background color to a line, padding to full width.

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -596,7 +596,7 @@ describe("Editor component", () => {
 			const lines = editor.render(width);
 			const paddingX = defaultEditorTheme.editorPaddingX ?? 2;
 			const borderWidth = paddingX + 1;
-			return lines.slice(1).map((l) => stripVTControlCharacters(l).slice(borderWidth, -borderWidth).trimEnd());
+			return lines.slice(1).map(l => stripVTControlCharacters(l).slice(borderWidth, -borderWidth).trimEnd());
 		}
 
 		it("wraps at word boundaries instead of mid-word", () => {
@@ -925,7 +925,6 @@ describe("Editor component", () => {
 			expect(editor.getCursor()).toEqual({ line: 0, col: text.indexOf("—") });
 		});
 	});
-
 
 	describe("Sticky column", () => {
 		it("preserves target column when moving up through a shorter line", () => {

--- a/packages/tui/test/input.test.ts
+++ b/packages/tui/test/input.test.ts
@@ -9,7 +9,6 @@ function renderedWidth(input: Input, width: number): number {
 	return visibleWidth(line.replaceAll(CURSOR_MARKER, ""));
 }
 
-
 describe("Input component", () => {
 	const wordLeft = "\x1bb"; // ESC-b (alt+b)
 	const wordRight = "\x1bf"; // ESC-f (alt+f)


### PR DESCRIPTION
## What

Fix TUI input behavior for multilingual text: the editor no longer wastes end-of-line width or flickers when wrapping mixed ASCII + wide-script runs, word navigation/deletion is Unicode-aware across both Editor and Input (CJK blocks, Unicode punctuation/NBSP, common joiners), and the Ask “Other (type your own)” input no longer crashes when very long wide-character text would previously render a line wider than the terminal.

## Why

The previous implementation was effectively ASCII-centric in multiple places: 

- Editor wrapping could push an entire wide-script token to the next line even when there was remaining space (sometimes causing unstable behavior near the wrap boundary)
- Word navigation/deletion treated many non-ASCII punctuation/whitespace cases poorly
- Asking “Other” input could render a line wider than the terminal which triggers a hard TUI crash (Rendered line exceeds terminal width).

## Example

### Case 1

Copy `English word 天気がいいから、散歩しましょう！关注永雏塔菲谢谢喵！` in editor

<img width="845" height="157" alt="image" src="https://github.com/user-attachments/assets/317fe169-e94e-48fb-93fa-4b81c539cc2a" />

when the window width decreases, the entire CJK sentence may be incorrectly moved to the next line be like:

<img width="503" height="106" alt="image" src="https://github.com/user-attachments/assets/704d7da4-144c-4974-8a41-e44244e6d98e" />

the first commit(#0e2a41a) fixed it:

<img width="453" height="102" alt="image" src="https://github.com/user-attachments/assets/ae3ef8b8-daae-4d8e-bada-98be5eaa262c" />

## Case 2

When using the Option key + left and right arrow keys, the CJK section will be jumped as a whole jump, not a jump based on punctuation chars.

For the words in Case 1, when i am now at last, and use Option + Left Arrow:

<img width="655" height="108" alt="image" src="https://github.com/user-attachments/assets/878408f8-7b2d-4909-9a98-0766bb994bed" />

the second commit(#0e2a41a) fixed it:

<img width="629" height="89" alt="image" src="https://github.com/user-attachments/assets/767865cb-e206-47e9-95ba-271e513947d3" />

## Case 3

when user be asked for a question, if user select "Other" and input a long sentence by Chinese/Japanese, omp will be crashed.

<img width="724" height="540" alt="image" src="https://github.com/user-attachments/assets/672e2b75-e8ef-48ee-9ffb-2e45da1b22fb" />

paste in `天気がいいから、散歩しましょう！日本語は全然食べませんね！` twice:

<img width="730" height="419" alt="image" src="https://github.com/user-attachments/assets/67cef40d-d97e-4431-9424-6545dba9a684" />

the third commit(#05d22cd) fixed it.

## Testing

<!-- How was this tested? -->

Tested by `bun dev` and `bun check`. Test cases were added.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
