### PR TITLE
enable image rendering if the fetch tool gets one

### DIFF
--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -655,6 +655,7 @@ async function renderUrl(
 
 	const imageMimeType = resolveImageMimeType(mime);
 	const canInlineImage = Boolean(imageMimeType && isInlineImageMimeTypeSupported(imageMimeType));
+	let skipConvertibleBinaryRetry = false;
 	if (imageMimeType && !canInlineImage) {
 		notes.push(
 			`Image MIME type ${imageMimeType} is unsupported for inline model serialization; falling back to textual rendering`,
@@ -765,10 +766,11 @@ async function renderUrl(
 		}
 		notes.push(binary.error ? `Binary fetch failed: ${binary.error}` : "Binary fetch failed");
 		notes.push("Falling back to textual rendering from initial response");
+		skipConvertibleBinaryRetry = true;
 	}
 
 	// Step 3: Handle convertible binary files (PDF, DOCX, etc.)
-	if (isConvertible(mime, extHint)) {
+	if (!skipConvertibleBinaryRetry && isConvertible(mime, extHint)) {
 		const binary = await fetchBinary(finalUrl, timeout, signal);
 		if (binary.ok) {
 			const ext = getExtensionHint(finalUrl, binary.contentDisposition) || extHint;

--- a/packages/coding-agent/test/tools/fetch-kagi-toggle.test.ts
+++ b/packages/coding-agent/test/tools/fetch-kagi-toggle.test.ts
@@ -286,7 +286,9 @@ describe("fetch tool Kagi summarization toggle", () => {
 			finalUrl: "https://example.com/transient.png",
 			content: "<html><body>temporary gateway page</body></html>",
 		});
-		vi.spyOn(scraperUtils, "fetchBinary").mockResolvedValue({ ok: false, error: "upstream blocked" });
+		const fetchBinarySpy = vi
+			.spyOn(scraperUtils, "fetchBinary")
+			.mockResolvedValue({ ok: false, error: "upstream blocked" });
 
 		const result = await tool.execute("fetch-image-refetch-failed", { url: "https://example.com/transient.png" });
 		const imageBlock = result.content.find(content => content.type === "image");
@@ -297,6 +299,7 @@ describe("fetch tool Kagi summarization toggle", () => {
 		expect(textBlock?.type).toBe("text");
 		expect(textBlock?.text).toContain("<html><body>temporary gateway page</body></html>");
 		expect(convertSpy).not.toHaveBeenCalled();
+		expect(fetchBinarySpy).toHaveBeenCalledTimes(1);
 	});
 	it("falls back to text-only output when image payload bytes are invalid", async () => {
 		const session = createSession({ "fetch.useKagiSummarizer": false });


### PR DESCRIPTION
## What

enable image rendering if the fetch tool gets one

## Why

why not

## Testing

locally

---

- [x ] `bun check` passes
- [ x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
