### PR TITLE
feat(ai): add ZenMux provider and /login flow

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -61,6 +61,7 @@ These are consumed via `getEnvApiKey()` (`packages/ai/src/stream.ts`) unless not
 | `QIANFAN_API_KEY` | Qianfan auth | Using `qianfan` provider |  |
 | `QWEN_OAUTH_TOKEN` | Qwen Portal auth | Using `qwen-portal` with OAuth token | Takes precedence over `QWEN_PORTAL_API_KEY` |
 | `QWEN_PORTAL_API_KEY` | Qwen Portal auth | Using `qwen-portal` with API key | Fallback after `QWEN_OAUTH_TOKEN` |
+| `ZENMUX_API_KEY` | ZenMux auth | Using `zenmux` provider | Used for ZenMux OpenAI and Anthropic-compatible routes |
 | `VLLM_API_KEY` | vLLM auth/discovery opt-in | Using `vllm` provider (local OpenAI-compatible servers) | Any non-empty value works for no-auth local servers |
 | `CURSOR_ACCESS_TOKEN` | Cursor provider auth | Using Cursor provider |  |
 | `AI_GATEWAY_API_KEY` | Vercel AI Gateway auth | Using `vercel-ai-gateway` provider |  |

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added ZenMux provider support with mixed API routing: Anthropic-owned models discovered from `https://zenmux.ai/api/v1/models` now use the Anthropic transport (`https://zenmux.ai/api/anthropic`), while other ZenMux models use the OpenAI-compatible transport.
+
 ## [13.7.2] - 2026-03-04
 ### Added
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -68,6 +68,7 @@ Unified LLM API with automatic model discovery, provider configuration, token an
 - **zAI** (requires `ZAI_API_KEY`)
 - **MiniMax Coding Plan** (requires `MINIMAX_CODE_API_KEY` or `MINIMAX_CODE_CN_API_KEY`)
 - **Xiaomi MiMo** (requires `XIAOMI_API_KEY`)
+- **ZenMux** (requires `ZENMUX_API_KEY`)
 - **Qwen Portal** (supports `QWEN_OAUTH_TOKEN` or `QWEN_PORTAL_API_KEY`)
 - **Cloudflare AI Gateway** (requires `CLOUDFLARE_AI_GATEWAY_API_KEY` and provider-specific gateway base URL)
 - **Ollama** (local OpenAI-compatible runtime; optional `OLLAMA_API_KEY`)
@@ -929,6 +930,7 @@ In Node.js environments, you can set environment variables to avoid passing API 
 | zAI            | `ZAI_API_KEY`                                                                |
 | MiniMax Code   | `MINIMAX_CODE_API_KEY` (international) or `MINIMAX_CODE_CN_API_KEY` (China) |
 | Xiaomi MiMo    | `XIAOMI_API_KEY`                                                             |
+| ZenMux         | `ZENMUX_API_KEY`                                                             |
 | vLLM           | `VLLM_API_KEY`                                                               |
 | Cloudflare AI Gateway | `CLOUDFLARE_AI_GATEWAY_API_KEY`                                      |
 | GitHub Copilot | `COPILOT_GITHUB_TOKEN` or `GH_TOKEN` or `GITHUB_TOKEN`                      |
@@ -950,6 +952,8 @@ Provider endpoint defaults for the current OpenAI-compatible integrations:
 - Hugging Face Inference: `https://router.huggingface.co/v1`
 - Venice: `https://api.venice.ai/api/v1`
 - Xiaomi MiMo: `https://api.xiaomimimo.com/anthropic`
+- ZenMux (OpenAI): `https://zenmux.ai/api/v1`
+- ZenMux (Anthropic models): `https://zenmux.ai/api/anthropic`
 - vLLM: `http://127.0.0.1:8000/v1`
 - Ollama: local OpenAI-compatible runtime
 - LiteLLM: `http://localhost:4000/v1`

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -64,6 +64,7 @@ import { loginVenice } from "./utils/oauth/venice";
 import { loginVllm } from "./utils/oauth/vllm";
 import { loginXiaomi } from "./utils/oauth/xiaomi";
 import { loginZai } from "./utils/oauth/zai";
+import { loginZenMux } from "./utils/oauth/zenmux";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Credential Types
@@ -917,6 +918,11 @@ export class AuthStorage {
 			}
 			case "xiaomi": {
 				const apiKey = await loginXiaomi(ctrl);
+				await saveApiKeyCredential(apiKey);
+				return;
+			}
+			case "zenmux": {
+				const apiKey = await loginZenMux(ctrl);
 				await saveApiKeyCredential(apiKey);
 				return;
 			}

--- a/packages/ai/src/cli.ts
+++ b/packages/ai/src/cli.ts
@@ -15,6 +15,7 @@ import { loginNanoGPT } from "./utils/oauth/nanogpt";
 import { loginOpenAICodex } from "./utils/oauth/openai-codex";
 import type { OAuthCredentials, OAuthProvider } from "./utils/oauth/types";
 import { loginZai } from "./utils/oauth/zai";
+import { loginZenMux } from "./utils/oauth/zenmux";
 
 const PROVIDERS = getOAuthProviders();
 
@@ -220,6 +221,22 @@ async function login(provider: OAuthProvider): Promise<void> {
 				return;
 			}
 
+			case "zenmux": {
+				const apiKey = await loginZenMux({
+					onAuth(info) {
+						const { url, instructions } = info;
+						console.log(`\nOpen this URL in your browser:\n${url}`);
+						if (instructions) console.log(instructions);
+						console.log();
+					},
+					onPrompt(p) {
+						return promptFn(`${p.message}${p.placeholder ? ` (${p.placeholder})` : ""}:`);
+					},
+				});
+				storage.saveApiKey(provider, apiKey);
+				console.log(`\nAPI key saved to ~/.omp/agent/agent.db`);
+				return;
+			}
 			case "minimax-code": {
 				const apiKey = await loginMiniMaxCode({
 					onAuth(info) {
@@ -294,6 +311,7 @@ Providers:
   minimax-code      MiniMax Coding Plan (International)
   minimax-code-cn   MiniMax Coding Plan (China)
   cursor            Cursor (Claude, GPT, etc.)
+  zenmux            ZenMux
 
 Examples:
   bunx @oh-my-pi/pi-ai login              # interactive provider selection

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -35,6 +35,7 @@ import {
 	vllmModelManagerOptions,
 	xaiModelManagerOptions,
 	xiaomiModelManagerOptions,
+	zenmuxModelManagerOptions,
 } from "./openai-compat";
 import { cursorModelManagerOptions } from "./special";
 
@@ -240,6 +241,12 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		"mimo-v2-flash",
 		config => xiaomiModelManagerOptions(config),
 		catalog("Xiaomi", ["XIAOMI_API_KEY"]),
+	),
+	catalogDescriptor(
+		"zenmux",
+		"anthropic/claude-opus-4.6",
+		config => zenmuxModelManagerOptions(config),
+		catalog("ZenMux", ["ZENMUX_API_KEY"]),
 	),
 	descriptor("github-copilot", "gpt-4o", config => githubCopilotModelManagerOptions(config)),
 	descriptor("google", "gemini-2.5-pro", config => googleModelManagerOptions(config)),

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -668,8 +668,115 @@ export function openrouterModelManagerOptions(
 	};
 }
 
+const ZENMUX_OPENAI_BASE_URL = "https://zenmux.ai/api/v1";
+const ZENMUX_ANTHROPIC_BASE_URL = "https://zenmux.ai/api/anthropic";
+
+function normalizeZenMuxOpenAiBaseUrl(baseUrl?: string): string {
+	const value = baseUrl?.trim();
+	if (!value) {
+		return ZENMUX_OPENAI_BASE_URL;
+	}
+	return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function toZenMuxAnthropicBaseUrl(openAiBaseUrl: string): string {
+	try {
+		const parsed = new URL(openAiBaseUrl);
+		const trimmedPath = parsed.pathname.replace(/\/+$/g, "");
+		parsed.pathname = trimmedPath.endsWith("/api/v1")
+			? `${trimmedPath.slice(0, -"/api/v1".length)}/api/anthropic`
+			: "/api/anthropic";
+		return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+	} catch {
+		return ZENMUX_ANTHROPIC_BASE_URL;
+	}
+}
+
+function isZenMuxAnthropicModel(entry: OpenAICompatibleModelRecord, modelId: string): boolean {
+	if (typeof entry.owned_by === "string" && entry.owned_by.toLowerCase() === "anthropic") {
+		return true;
+	}
+	return modelId.toLowerCase().startsWith("anthropic/");
+}
+
+function getZenMuxPricingValue(pricings: Record<string, unknown> | undefined, key: string): number {
+	const bucket = pricings?.[key];
+	if (!Array.isArray(bucket)) {
+		return 0;
+	}
+	for (const item of bucket) {
+		if (!isRecord(item)) {
+			continue;
+		}
+		const value = toNumber(item.value);
+		if (value !== undefined) {
+			return value;
+		}
+	}
+	return 0;
+}
+
+function getZenMuxCacheWritePrice(pricings: Record<string, unknown> | undefined): number {
+	const oneHour = getZenMuxPricingValue(pricings, "input_cache_write_1_h");
+	if (oneHour > 0) {
+		return oneHour;
+	}
+	const fiveMinute = getZenMuxPricingValue(pricings, "input_cache_write_5_min");
+	if (fiveMinute > 0) {
+		return fiveMinute;
+	}
+	return getZenMuxPricingValue(pricings, "input_cache_write");
+}
+
 // ---------------------------------------------------------------------------
-// 10.5 Kilo Gateway
+// 10.5 ZenMux
+// ---------------------------------------------------------------------------
+
+export interface ZenMuxModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+}
+
+export function zenmuxModelManagerOptions(config?: ZenMuxModelManagerConfig): ModelManagerOptions<Api> {
+	const apiKey = config?.apiKey;
+	const openAiBaseUrl = normalizeZenMuxOpenAiBaseUrl(config?.baseUrl);
+	const anthropicBaseUrl = toZenMuxAnthropicBaseUrl(openAiBaseUrl);
+	return {
+		providerId: "zenmux",
+		...(apiKey && {
+			fetchDynamicModels: () =>
+				fetchOpenAICompatibleModels<Api>({
+					api: "openai-completions",
+					provider: "zenmux",
+					baseUrl: openAiBaseUrl,
+					apiKey,
+					mapModel: (entry, defaults) => {
+						const pricings = isRecord(entry.pricings) ? entry.pricings : undefined;
+						const capabilities = isRecord(entry.capabilities) ? entry.capabilities : undefined;
+						const isAnthropicModel = isZenMuxAnthropicModel(entry, defaults.id);
+						return {
+							...defaults,
+							name: toModelName(entry.display_name, defaults.name),
+							api: isAnthropicModel ? "anthropic-messages" : "openai-completions",
+							baseUrl: isAnthropicModel ? anthropicBaseUrl : openAiBaseUrl,
+							reasoning: capabilities?.reasoning === true || defaults.reasoning,
+							input: toInputCapabilities(entry.input_modalities),
+							cost: {
+								input: getZenMuxPricingValue(pricings, "prompt"),
+								output: getZenMuxPricingValue(pricings, "completion"),
+								cacheRead: getZenMuxPricingValue(pricings, "input_cache_read"),
+								cacheWrite: getZenMuxCacheWritePrice(pricings),
+							},
+							contextWindow: toPositiveNumber(entry.context_length, defaults.contextWindow),
+						};
+					},
+				}),
+		}),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// 10.6 Kilo Gateway
 // ---------------------------------------------------------------------------
 
 export interface KiloModelManagerConfig {

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -132,6 +132,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	qianfan: "QIANFAN_API_KEY",
 	"qwen-portal": () => $pickenv("QWEN_OAUTH_TOKEN", "QWEN_PORTAL_API_KEY"),
 	together: "TOGETHER_API_KEY",
+	zenmux: "ZENMUX_API_KEY",
 	venice: "VENICE_API_KEY",
 	vllm: "VLLM_API_KEY",
 	xiaomi: "XIAOMI_API_KEY",

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -105,6 +105,7 @@ export type KnownProvider =
 	| "venice"
 	| "vllm"
 	| "xiaomi"
+	| "zenmux"
 	| "lm-studio";
 export type Provider = KnownProvider | string;
 

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -37,6 +37,7 @@ import type {
  * - NanoGPT
  * - Venice
  * - vLLM
+ * - ZenMux
  */
 // Anthropic
 export { loginAnthropic, refreshAnthropicToken } from "./anthropic";
@@ -111,6 +112,8 @@ export { loginVllm } from "./vllm";
 export { loginXiaomi } from "./xiaomi";
 // Z.AI (API key)
 export { loginZai } from "./zai";
+// ZenMux (API key)
+export { loginZenMux } from "./zenmux";
 
 const builtInOAuthProviders: OAuthProviderInfo[] = [
 	{
@@ -259,6 +262,11 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		available: true,
 	},
 	{
+		id: "zenmux",
+		name: "ZenMux",
+		available: true,
+	},
+	{
 		id: "vllm",
 		name: "vLLM (Local OpenAI-compatible)",
 		available: true,
@@ -365,6 +373,7 @@ export async function refreshOAuthToken(
 		case "kagi":
 		case "cloudflare-ai-gateway":
 		case "qwen-portal":
+		case "zenmux":
 		case "vllm":
 			// API keys / static bearer tokens don't expire, return as-is
 			newCredentials = credentials;

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -39,6 +39,7 @@ export type OAuthProvider =
 	| "venice"
 	| "vllm"
 	| "xiaomi"
+	| "zenmux"
 	| "zai";
 
 export type OAuthProviderId = OAuthProvider | (string & {});

--- a/packages/ai/src/utils/oauth/zenmux.ts
+++ b/packages/ai/src/utils/oauth/zenmux.ts
@@ -1,0 +1,51 @@
+/**
+ * ZenMux login flow.
+ *
+ * ZenMux provides both OpenAI-compatible and Anthropic-compatible endpoints.
+ * This is an API key flow:
+ * 1. Open browser to ZenMux API key settings
+ * 2. User copies their API key
+ * 3. User pastes the API key into CLI
+ */
+
+import { validateApiKeyAgainstModelsEndpoint } from "./api-key-validation";
+import type { OAuthController } from "./types";
+
+const AUTH_URL = "https://zenmux.ai/settings/keys";
+const API_BASE_URL = "https://zenmux.ai/api/v1";
+const MODELS_URL = `${API_BASE_URL}/models`;
+
+export async function loginZenMux(options: OAuthController): Promise<string> {
+	if (!options.onPrompt) {
+		throw new Error("ZenMux login requires onPrompt callback");
+	}
+
+	options.onAuth?.({
+		url: AUTH_URL,
+		instructions: "Create or copy your ZenMux API key",
+	});
+
+	const apiKey = await options.onPrompt({
+		message: "Paste your ZenMux API key",
+		placeholder: "sk-...",
+	});
+
+	if (options.signal?.aborted) {
+		throw new Error("Login cancelled");
+	}
+
+	const trimmed = apiKey.trim();
+	if (!trimmed) {
+		throw new Error("API key is required");
+	}
+
+	options.onProgress?.("Validating API key...");
+	await validateApiKeyAgainstModelsEndpoint({
+		provider: "ZenMux",
+		apiKey: trimmed,
+		modelsUrl: MODELS_URL,
+		signal: options.signal,
+	});
+
+	return trimmed;
+}

--- a/packages/ai/test/zenmux-login.test.ts
+++ b/packages/ai/test/zenmux-login.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { loginZenMux } from "../src/utils/oauth/zenmux";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+	global.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+describe("zenmux login", () => {
+	it("opens ZenMux key settings and validates against models endpoint", async () => {
+		let authUrl: string | undefined;
+		let authInstructions: string | undefined;
+		let promptMessage: string | undefined;
+		let promptPlaceholder: string | undefined;
+
+		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+			const url = typeof input === "string" ? input : input.toString();
+			expect(url).toBe("https://zenmux.ai/api/v1/models");
+			expect(init?.method).toBe("GET");
+			expect(init?.headers).toEqual({ Authorization: "Bearer sk-zenmux-test" });
+			return new Response(JSON.stringify({ object: "list", data: [] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		const apiKey = await loginZenMux({
+			onAuth: info => {
+				authUrl = info.url;
+				authInstructions = info.instructions;
+			},
+			onPrompt: async prompt => {
+				promptMessage = prompt.message;
+				promptPlaceholder = prompt.placeholder;
+				return "sk-zenmux-test";
+			},
+		});
+
+		expect(authUrl).toBe("https://zenmux.ai/settings/keys");
+		expect(authInstructions).toContain("Create or copy your ZenMux API key");
+		expect(promptMessage).toBe("Paste your ZenMux API key");
+		expect(promptPlaceholder).toBe("sk-...");
+		expect(apiKey).toBe("sk-zenmux-test");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects empty keys", async () => {
+		await expect(
+			loginZenMux({
+				onPrompt: async () => "   ",
+			}),
+		).rejects.toThrow("API key is required");
+	});
+
+	it("requires onPrompt callback", async () => {
+		await expect(loginZenMux({})).rejects.toThrow("ZenMux login requires onPrompt callback");
+	});
+
+	it("surfaces models endpoint validation errors", async () => {
+		global.fetch = vi.fn(
+			async () => new Response('{"error":"invalid_api_key"}', { status: 401 }),
+		) as unknown as typeof fetch;
+
+		await expect(
+			loginZenMux({
+				onPrompt: async () => "sk-zenmux-test",
+			}),
+		).rejects.toThrow("ZenMux API key validation failed (401)");
+	});
+});

--- a/packages/ai/test/zenmux-provider.test.ts
+++ b/packages/ai/test/zenmux-provider.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import { DEFAULT_MODEL_PER_PROVIDER, PROVIDER_DESCRIPTORS } from "../src/provider-models/descriptors";
+import { zenmuxModelManagerOptions } from "../src/provider-models/openai-compat";
+import { getEnvApiKey } from "../src/stream";
+import { getOAuthProviders } from "../src/utils/oauth";
+
+const originalZenMuxApiKey = Bun.env.ZENMUX_API_KEY;
+const originalFetch = global.fetch;
+
+afterEach(() => {
+	if (originalZenMuxApiKey === undefined) {
+		delete Bun.env.ZENMUX_API_KEY;
+	} else {
+		Bun.env.ZENMUX_API_KEY = originalZenMuxApiKey;
+	}
+	global.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+describe("zenmux provider support", () => {
+	test("resolves ZENMUX_API_KEY from environment", () => {
+		Bun.env.ZENMUX_API_KEY = "zenmux-test-key";
+		expect(getEnvApiKey("zenmux")).toBe("zenmux-test-key");
+	});
+
+	test("registers built-in descriptor and default model", () => {
+		const descriptor = PROVIDER_DESCRIPTORS.find(item => item.providerId === "zenmux");
+		expect(descriptor).toBeDefined();
+		expect(descriptor?.defaultModel).toBe("anthropic/claude-opus-4.6");
+		expect(descriptor?.catalogDiscovery?.envVars).toContain("ZENMUX_API_KEY");
+		expect(DEFAULT_MODEL_PER_PROVIDER.zenmux).toBe("anthropic/claude-opus-4.6");
+	});
+
+	test("registers ZenMux in OAuth provider selector", () => {
+		const provider = getOAuthProviders().find(item => item.id === "zenmux");
+		expect(provider?.name).toBe("ZenMux");
+	});
+	test("routes Anthropic-owned models to anthropic-messages", async () => {
+		global.fetch = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						data: [
+							{
+								id: "anthropic/claude-opus-4.6",
+								display_name: "Anthropic: Claude Opus 4.6",
+								owned_by: "anthropic",
+								input_modalities: ["text", "image"],
+								capabilities: { reasoning: true },
+								context_length: 200000,
+								pricings: {
+									prompt: [{ value: 15, unit: "perMTokens", currency: "USD" }],
+									completion: [{ value: 75, unit: "perMTokens", currency: "USD" }],
+									input_cache_read: [{ value: 1.5, unit: "perMTokens", currency: "USD" }],
+									input_cache_write_1_h: [{ value: 18.75, unit: "perMTokens", currency: "USD" }],
+								},
+							},
+							{
+								id: "openai/gpt-5.2",
+								display_name: "OpenAI: GPT-5.2",
+								owned_by: "openai",
+								input_modalities: ["text"],
+								capabilities: { reasoning: true },
+								context_length: 400000,
+								pricings: {
+									prompt: [{ value: 1.25, unit: "perMTokens", currency: "USD" }],
+									completion: [{ value: 10, unit: "perMTokens", currency: "USD" }],
+								},
+							},
+						],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+		) as unknown as typeof fetch;
+
+		const options = zenmuxModelManagerOptions({ apiKey: "zenmux-test-key" });
+		expect(options.providerId).toBe("zenmux");
+		expect(options.fetchDynamicModels).toBeDefined();
+
+		const models = await options.fetchDynamicModels?.();
+		expect(models).not.toBeNull();
+		expect(global.fetch).toHaveBeenCalledWith(
+			"https://zenmux.ai/api/v1/models",
+			expect.objectContaining({ method: "GET" }),
+		);
+
+		const anthropic = models?.find(model => model.id === "anthropic/claude-opus-4.6");
+		expect(anthropic?.api).toBe("anthropic-messages");
+		expect(anthropic?.baseUrl).toBe("https://zenmux.ai/api/anthropic");
+		expect(anthropic?.input).toEqual(["text", "image"]);
+		expect(anthropic?.cost.input).toBe(15);
+		expect(anthropic?.cost.cacheWrite).toBe(18.75);
+
+		const openai = models?.find(model => model.id === "openai/gpt-5.2");
+		expect(openai?.api).toBe("openai-completions");
+		expect(openai?.baseUrl).toBe("https://zenmux.ai/api/v1");
+		expect(openai?.cost.output).toBe(10);
+	});
+});


### PR DESCRIPTION
## Context
This PR is based on the ZenMux provider proposal in [badlogic/pi-mono#1811](https://github.com/badlogic/pi-mono/issues/1811).

From that issue:
- ZenMux is positioned as a multi-model aggregation provider (similar to OpenRouter), so adding it expands built-in provider choices.
- ZenMux now supports subscription plans, which is useful for users who want Anthropic access in non-ClaudeCode tools (e.g. OpenCode/OpenClaw scenarios mentioned in the issue).

Reference links from the issue:
- Official site: https://zenmux.ai/
- Intro docs: https://zenmux.ai/docs/about/intro.html
- Subscription pricing: https://zenmux.ai/pricing/subscription
- Subscription docs: https://zenmux.ai/docs/guide/subscription.html

## Summary
- add built-in `zenmux` provider wiring in `@oh-my-pi/pi-ai`
- add ZenMux dynamic model discovery with mixed routing:
  - Anthropic-owned models -> `anthropic-messages` via `https://zenmux.ai/api/anthropic`
  - other models -> `openai-completions` via `https://zenmux.ai/api/v1`
- add interactive API-key login flow (`/login zenmux`) through OAuth provider registry + AuthStorage
- document `ZENMUX_API_KEY` in README/docs and add changelog entry
- add ZenMux tests for provider wiring and login flow

## Behavior details
- model catalog is discovered from `https://zenmux.ai/api/v1/models`
- Anthropic models are intentionally handled with Anthropic transport format (not generic OpenAI request format)
- non-Anthropic models remain on OpenAI-compatible transport

## Verification
- `bun test packages/ai/test/zenmux-login.test.ts packages/ai/test/zenmux-provider.test.ts`
- `bun run --cwd packages/ai check`
- `bun run --cwd packages/coding-agent check`

## Notes
- follows existing NanoGPT/GitLab Duo provider integration patterns for provider registration and login wiring