### PR TITLE
feat(coding-agent): Python tool bridge — expose agent tools in IPython kernel

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Python tool bridge: expose agent tools (builtin + MCP) as callable Python functions in the IPython kernel via `python.toolBridge` setting
+
 ## [13.7.6] - 2026-03-04
 ### Added
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -940,6 +940,15 @@ export const SETTINGS_SCHEMA = {
 			description: "Share IPython kernel gateway across pi instances",
 		},
 	},
+	"python.toolBridge": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "config",
+			label: "Python tool bridge",
+			description: "Expose agent tools (MCP, LSP, etc.) as callable functions in the Python kernel",
+		},
+	},
 
 	// ─────────────────────────────────────────────────────────────────────────
 	// STT settings

--- a/packages/coding-agent/src/ipy/executor.ts
+++ b/packages/coding-agent/src/ipy/executor.ts
@@ -12,6 +12,7 @@ import {
 } from "./kernel";
 import { discoverPythonModules } from "./modules";
 import { PYTHON_PRELUDE } from "./prelude";
+import type { ToolBridgeHandler } from "./tool-bridge";
 
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 const MAX_KERNEL_SESSIONS = 4;
@@ -41,6 +42,10 @@ export interface PythonExecutorOptions {
 	/** Artifact path/id for full output storage */
 	artifactPath?: string;
 	artifactId?: string;
+	/** Tool bridge handler for dispatching Python tool calls to real tools */
+	toolBridgeHandler?: ToolBridgeHandler;
+	/** Python code to inject as tool bridge prelude */
+	toolBridgePrelude?: string;
 }
 
 export interface PythonKernelExecutor {
@@ -523,6 +528,7 @@ export async function executePython(code: string, options?: PythonExecutorOption
 		const env: Record<string, string> | undefined = sessionFile ? { PI_SESSION_FILE: sessionFile } : undefined;
 		const kernel = await PythonKernel.start({ cwd, useSharedGateway, env });
 		try {
+			await setupToolBridge(kernel, options);
 			return await executeWithKernel(kernel, code, options);
 		} finally {
 			await kernel.shutdown();
@@ -539,8 +545,35 @@ export async function executePython(code: string, options?: PythonExecutorOption
 	return await withKernelSession(
 		sessionId,
 		cwd,
-		async kernel => executeWithKernel(kernel, code, options),
+		async kernel => {
+			await setupToolBridge(kernel, options);
+			return executeWithKernel(kernel, code, options);
+		},
 		useSharedGateway,
 		sessionFile,
 	);
+}
+
+/** Track which kernels already have the bridge prelude injected. */
+const bridgeInjectedKernels = new WeakSet<PythonKernel>();
+
+/**
+ * Set up the tool bridge on a kernel if configured in options.
+ * Injects the bridge prelude once per kernel and sets the dispatch handler.
+ */
+async function setupToolBridge(kernel: PythonKernel, options?: PythonExecutorOptions): Promise<void> {
+	if (!options?.toolBridgeHandler) return;
+	// Early return if bridge already configured — assumes handler reference is stable per kernel lifetime.
+	if (bridgeInjectedKernels.has(kernel)) return;
+
+	kernel.setToolBridgeHandler(options.toolBridgeHandler);
+
+	if (options.toolBridgePrelude) {
+		const result = await kernel.execute(options.toolBridgePrelude, { silent: true, storeHistory: false });
+		if (result.status === "error") {
+			logger.warn("Failed to inject tool bridge prelude", { error: result.error?.value });
+			return;
+		}
+	}
+	bridgeInjectedKernels.add(kernel);
 }

--- a/packages/coding-agent/src/ipy/kernel.ts
+++ b/packages/coding-agent/src/ipy/kernel.ts
@@ -6,6 +6,7 @@ import { acquireSharedGateway, releaseSharedGateway, shutdownSharedGateway } fro
 import { loadPythonModules } from "./modules";
 import { PYTHON_PRELUDE } from "./prelude";
 import { filterEnv, resolvePythonRuntime } from "./runtime";
+import type { ToolBridgeHandler } from "./tool-bridge";
 
 const TEXT_ENCODER = new TextEncoder();
 const TEXT_DECODER = new TextDecoder();
@@ -314,6 +315,7 @@ export class PythonKernel {
 	#messageHandlers = new Map<string, (msg: JupyterMessage) => void>();
 	#channelHandlers = new Map<string, Set<(msg: JupyterMessage) => void>>();
 	#pendingExecutions = new Map<string, (reason: string) => void>();
+	#toolBridgeHandler: ToolBridgeHandler | null = null;
 
 	private constructor(
 		readonly id: string,
@@ -593,6 +595,27 @@ export class PythonKernel {
 		return this.#alive && !this.#disposed && this.#ws?.readyState === WebSocket.OPEN;
 	}
 
+	#sendInputReply(parentHeader: Record<string, unknown>, value: string): void {
+		this.#sendMessage({
+			channel: "stdin",
+			header: {
+				msg_id: Snowflake.next(),
+				session: this.sessionId,
+				username: this.username,
+				date: new Date().toISOString(),
+				msg_type: "input_reply",
+				version: "5.5",
+			},
+			parent_header: parentHeader,
+			metadata: {},
+			content: { value },
+		});
+	}
+
+	setToolBridgeHandler(handler: ToolBridgeHandler | null): void {
+		this.#toolBridgeHandler = handler;
+	}
+
 	async execute(code: string, options?: KernelExecuteOptions): Promise<KernelExecuteResult> {
 		if (!this.isAlive()) {
 			throw new Error("Python kernel is not running");
@@ -616,7 +639,7 @@ export class PythonKernel {
 				silent: options?.silent ?? false,
 				store_history: options?.storeHistory ?? !(options?.silent ?? false),
 				user_expressions: {},
-				allow_stdin: options?.allowStdin ?? false,
+				allow_stdin: (options?.allowStdin ?? false) || this.#toolBridgeHandler !== null,
 				stop_on_error: true,
 			},
 		};
@@ -755,26 +778,30 @@ export class PythonKernel {
 					break;
 				}
 				case "input_request": {
-					stdinRequested = true;
-					if (options?.onChunk) {
-						await options.onChunk(
-							"[stdin] Kernel requested input. Interactive stdin is not supported; provide input programmatically.\n",
-						);
+					const prompt = String(response.content.prompt ?? "");
+					if (prompt.startsWith("__omp_tool__:") && this.#toolBridgeHandler) {
+						// Tool bridge call — dispatch and reply with result
+						const payload = prompt.slice("__omp_tool__:".length);
+						let bridgeResult: string;
+						try {
+							const { tool, args } = JSON.parse(payload) as { tool: string; args: Record<string, unknown> };
+							const result = await this.#toolBridgeHandler(tool, args);
+							bridgeResult = JSON.stringify(result);
+						} catch (err) {
+							const msg = err instanceof Error ? err.message : String(err);
+							bridgeResult = JSON.stringify({ error: msg });
+						}
+						this.#sendInputReply(response.header as unknown as Record<string, unknown>, bridgeResult);
+					} else {
+						// Standard stdin request — not supported
+						stdinRequested = true;
+						if (options?.onChunk) {
+							await options.onChunk(
+								"[stdin] Kernel requested input. Interactive stdin is not supported; provide input programmatically.\n",
+							);
+						}
+						this.#sendInputReply(response.header as unknown as Record<string, unknown>, "");
 					}
-					this.#sendMessage({
-						channel: "stdin",
-						header: {
-							msg_id: Snowflake.next(),
-							session: this.sessionId,
-							username: this.username,
-							date: new Date().toISOString(),
-							msg_type: "input_reply",
-							version: "5.5",
-						},
-						parent_header: response.header as unknown as Record<string, unknown>,
-						metadata: {},
-						content: { value: "" },
-					});
 					break;
 				}
 			}

--- a/packages/coding-agent/src/ipy/tool-bridge.ts
+++ b/packages/coding-agent/src/ipy/tool-bridge.ts
@@ -1,0 +1,348 @@
+/**
+ * Python tool bridge: exposes agent tools as callable functions in the IPython kernel.
+ *
+ * Uses Jupyter's stdin channel (input_request/input_reply) for IPC.
+ * Python calls `input("__omp_tool__:{json}")`, TypeScript intercepts it,
+ * dispatches to the real tool, and sends the result back via input_reply.
+ */
+import type { AgentTool } from "@oh-my-pi/pi-agent-core";
+import { logger } from "@oh-my-pi/pi-utils";
+import type { TSchema } from "@sinclair/typebox";
+import type { ModelRegistry } from "../config/model-registry";
+import type { CustomTool, CustomToolContext } from "../extensibility/custom-tools/types";
+import type { MCPToolDetails } from "../mcp/tool-bridge";
+import type { ReadonlySessionManager } from "../session/session-manager";
+import type { ToolSession } from "../tools";
+
+export const TOOL_BRIDGE_PREFIX = "__omp_tool__:";
+
+/** Tool names that already have prelude Python equivalents — do not bridge these. */
+const PRELUDE_COVERED = new Set([
+	// File I/O
+	"read",
+	"write",
+	// File ops
+	"find",
+	"grep",
+	// Edit (hashline-based)
+	"edit",
+	// Interactive / meta
+	"ask",
+	"todo_write",
+	"exit_plan_mode",
+	"resolve",
+	"submit_result",
+	"report_finding",
+	// Python itself (recursive)
+	"python",
+	// Browser (not useful from Python)
+	"browser",
+	"puppeteer",
+	// Checkpoint/rewind (session-level, not useful from Python)
+	"checkpoint",
+	"rewind",
+	// Calculator (Python IS a calculator)
+	"calc",
+	// SSH (interactive, not useful from Python)
+	"ssh",
+	// Await/cancel (async job management, not useful from Python)
+	"await",
+	"cancel_job",
+	// Render mermaid (visual, not useful from Python)
+	"render_mermaid",
+	// Image generation (visual, not useful from Python)
+	"generate_image",
+]);
+
+/** Python reserved words that cannot be used as function names. */
+const PYTHON_RESERVED = new Set([
+	"False",
+	"None",
+	"True",
+	"and",
+	"as",
+	"assert",
+	"async",
+	"await",
+	"break",
+	"class",
+	"continue",
+	"def",
+	"del",
+	"elif",
+	"else",
+	"except",
+	"finally",
+	"for",
+	"from",
+	"global",
+	"if",
+	"import",
+	"in",
+	"is",
+	"lambda",
+	"nonlocal",
+	"not",
+	"or",
+	"pass",
+	"raise",
+	"return",
+	"try",
+	"while",
+	"with",
+	"yield",
+]);
+
+/**
+ * Stub context for MCP tool dispatch from the Python bridge.
+ * MCP tool implementations do not access ctx fields (all params are prefixed with `_`).
+ * Using typed stubs instead of `{} as any` ensures TypeScript errors if CustomToolContext changes.
+ */
+const BRIDGE_CTX: CustomToolContext = {
+	sessionManager: null as unknown as ReadonlySessionManager,
+	modelRegistry: null as unknown as ModelRegistry,
+	model: undefined,
+	isIdle: () => true,
+	hasQueuedMessages: () => false,
+	abort: () => {},
+};
+
+export function shouldBridge(toolName: string): boolean {
+	return !PRELUDE_COVERED.has(toolName);
+}
+
+export interface BridgeableToolInfo {
+	name: string;
+	description: string;
+	parameters: Record<string, unknown>;
+}
+
+/**
+ * Collect all tools that should be bridged to Python.
+ */
+export function collectBridgeableTools(
+	builtinTools: AgentTool[],
+	mcpTools: CustomTool<TSchema, MCPToolDetails>[],
+): BridgeableToolInfo[] {
+	const result: BridgeableToolInfo[] = [];
+
+	for (const tool of builtinTools) {
+		if (shouldBridge(tool.name)) {
+			result.push({
+				name: tool.name,
+				description: tool.description ?? "",
+				parameters: (tool.parameters ?? {}) as Record<string, unknown>,
+			});
+		}
+	}
+
+	for (const tool of mcpTools) {
+		// MCP tools are always bridged (they never have prelude equivalents)
+		result.push({
+			name: tool.name,
+			description: tool.description ?? "",
+			parameters: (tool.parameters ?? {}) as Record<string, unknown>,
+		});
+	}
+
+	return result;
+}
+
+/**
+ * Generate a Python parameter signature from a JSON Schema properties object.
+ * Produces keyword-only args with type hints.
+ */
+function generatePythonParams(schema: Record<string, unknown>): string {
+	const properties = (schema.properties ?? {}) as Record<string, Record<string, unknown>>;
+	const required = new Set((schema.required ?? []) as string[]);
+
+	// Sort: required params first, then optional (preserves order within each group)
+	const entries = Object.entries(properties).sort(([nameA], [nameB]) => {
+		const aRequired = required.has(nameA);
+		const bRequired = required.has(nameB);
+		if (aRequired && !bRequired) return -1;
+		if (!aRequired && bRequired) return 1;
+		return 0;
+	});
+
+	const params: string[] = [];
+	for (const [name, prop] of entries) {
+		const pyType = jsonSchemaToPythonType(prop);
+		if (required.has(name)) {
+			params.push(`${name}: ${pyType}`);
+		} else {
+			params.push(`${name}: ${pyType} = None`);
+		}
+	}
+
+	if (params.length === 0) return "**kwargs";
+	return `${params.join(", ")}, **kwargs`;
+}
+
+function jsonSchemaToPythonType(prop: Record<string, unknown>): string {
+	const type = prop.type;
+	switch (type) {
+		case "string":
+			return "str";
+		case "number":
+			return "float";
+		case "integer":
+			return "int";
+		case "boolean":
+			return "bool";
+		case "array":
+			return "list";
+		case "object":
+			return "dict";
+		default:
+			return "object";
+	}
+}
+
+/**
+ * Generate the Python bridge prelude code that defines `call_tool()` and typed wrappers.
+ */
+export function generateToolBridgePrelude(tools: BridgeableToolInfo[]): string {
+	const lines: string[] = [
+		"# --- OMP Tool Bridge (auto-generated) ---",
+		"import json as _json",
+		"",
+		"def call_tool(__name: str, **kwargs) -> dict:",
+		'    """Call an agent tool by name. Returns the result as a dict."""',
+		`    request = _json.dumps({"tool": __name, "args": kwargs})`,
+		`    response = input("${TOOL_BRIDGE_PREFIX}" + request)`,
+		"    result = _json.loads(response)",
+		'    if isinstance(result.get("error"), str):',
+		"        raise RuntimeError(f\"Tool {__name} failed: {result['error']}\")",
+		"    return result",
+		"",
+	];
+
+	// Generate typed wrappers for each bridged tool
+	for (const tool of tools) {
+		const params = generatePythonParams(tool.parameters);
+		const docstring = escapePythonString(tool.description || `Call the ${tool.name} tool.`);
+		// Sanitize name for Python (replace dots/hyphens with underscores, ensure valid identifier)
+		let pyName = tool.name.replace(/[^a-zA-Z0-9_]/g, "_");
+		if (/^\d/.test(pyName)) pyName = `_${pyName}`;
+		if (PYTHON_RESERVED.has(pyName)) pyName = `${pyName}_`;
+
+		lines.push(`def ${pyName}(${params}) -> dict:`);
+		lines.push(`    """${docstring}"""`);
+		lines.push(
+			`    return call_tool("${tool.name}", **{k: v for k, v in {**locals(), **kwargs}.items() if k != "kwargs"})`,
+		);
+		lines.push("");
+	}
+
+	// refresh_tools: re-queries available tools from TypeScript
+	lines.push("def refresh_tools() -> list:");
+	lines.push('    """Refresh available tool list from the agent. Returns list of tool names."""');
+	lines.push('    result = call_tool("__bridge_refresh_tools__")');
+	lines.push('    return result.get("tools", [])');
+	lines.push("");
+
+	return lines.join("\n");
+}
+
+function escapePythonString(s: string): string {
+	return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+}
+
+/** Handler type for tool bridge dispatch. */
+export type ToolBridgeHandler = (toolName: string, args: Record<string, unknown>) => Promise<Record<string, unknown>>;
+
+/**
+ * Create a tool bridge handler that dispatches Python tool calls to real tools.
+ */
+export function createToolBridgeHandler(builtinTools: AgentTool[], session: ToolSession): ToolBridgeHandler {
+	// Build a lookup map for fast dispatch
+	const toolMap = new Map<string, AgentTool>();
+	for (const tool of builtinTools) {
+		if (shouldBridge(tool.name)) {
+			toolMap.set(tool.name, tool);
+		}
+	}
+
+	return async (toolName: string, args: Record<string, unknown>): Promise<Record<string, unknown>> => {
+		// Special: refresh tools list
+		if (toolName === "__bridge_refresh_tools__") {
+			const mcpTools = session.mcpManager?.getTools() ?? [];
+			const allNames = [...Array.from(toolMap.keys()), ...mcpTools.map(t => t.name)];
+			return { tools: allNames };
+		}
+
+		// Try builtin tools first
+		const builtin = toolMap.get(toolName);
+		if (builtin) {
+			return dispatchBuiltinTool(builtin, args);
+		}
+
+		// Try MCP tools
+		const mcpTools = session.mcpManager?.getTools() ?? [];
+		const mcpTool = mcpTools.find(t => t.name === toolName);
+		if (mcpTool) {
+			return dispatchMCPTool(mcpTool, args);
+		}
+
+		return { error: `Unknown tool: ${toolName}` };
+	};
+}
+
+async function dispatchBuiltinTool(tool: AgentTool, args: Record<string, unknown>): Promise<Record<string, unknown>> {
+	try {
+		const result = await tool.execute("bridge", args);
+		return flattenToolResult(result);
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		logger.warn("Tool bridge dispatch failed", { tool: tool.name, error: msg });
+		return { error: msg };
+	}
+}
+
+async function dispatchMCPTool(
+	tool: CustomTool<TSchema, MCPToolDetails>,
+	args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+	try {
+		const result = await tool.execute("bridge", args, undefined, BRIDGE_CTX);
+		return flattenToolResult(result);
+	} catch (err) {
+		const msg = err instanceof Error ? err.message : String(err);
+		logger.warn("Tool bridge MCP dispatch failed", { tool: tool.name, error: msg });
+		return { error: msg };
+	}
+}
+
+/**
+ * Flatten an AgentToolResult into a simple dict for Python consumption.
+ * Tries to parse JSON content strings into objects.
+ */
+function flattenToolResult(result: {
+	content: Array<{ type: string; text?: string }>;
+	details?: { isError?: boolean };
+}): Record<string, unknown> {
+	const textParts: string[] = [];
+	for (const block of result.content) {
+		if (block.type === "text" && block.text) {
+			textParts.push(block.text);
+		}
+	}
+	const text = textParts.join("\n");
+
+	if (result.details?.isError) {
+		return { error: text };
+	}
+
+	// Try to parse as JSON for structured results
+	try {
+		const parsed = JSON.parse(text);
+		if (typeof parsed === "object" && parsed !== null) {
+			return { content: parsed, isError: false };
+		}
+	} catch {
+		// Not JSON, return as string
+	}
+
+	return { content: text, isError: false };
+}

--- a/packages/coding-agent/src/prompts/tools/python.md
+++ b/packages/coding-agent/src/prompts/tools/python.md
@@ -58,3 +58,23 @@ cells: [
 ]
 ```
 </example>
+
+{{#if toolBridge}}
+<tool-bridge>
+Bridged tools call agent tools from Python via `call_tool(name, **kwargs)` or typed wrappers (same name as tool). Returns `{"content": ..., "isError": bool}`.
+
+Available: {{toolBridgeList}}
+
+Use for **batch/loop** operations — same action applied to N items in one cell:
+```python
+results = call_tool("ast_grep", patterns=["// TODO: $MSG"], path="src/", lang="typescript")
+for match in results["content"]["matches"]:
+    info = call_tool("lsp", action="hover", file=match["file"], line=match["line"])
+    print(f"{match['file']}:{match['line']} -> {info['content']}")
+```
+
+You **MUST NOT** use bridged tools for:
+- Single tool calls (direct calls have better TUI rendering, lower overhead)
+- Adaptive chains where each step depends on the previous result's content — use separate tool calls so you can reason between steps
+</tool-bridge>
+{{/if}}

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -7,6 +7,7 @@ import type { Skill } from "../extensibility/skills";
 import type { InternalUrlRouter } from "../internal-urls";
 import { getPreludeDocs, warmPythonEnvironment } from "../ipy/executor";
 import { checkPythonKernelAvailability } from "../ipy/kernel";
+import { collectBridgeableTools, createToolBridgeHandler, generateToolBridgePrelude } from "../ipy/tool-bridge";
 import { LspTool } from "../lsp";
 import { EditTool } from "../patch";
 import type { PlanModeState } from "../plan-mode/state";
@@ -346,6 +347,12 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		}),
 	);
 	const tools = baseResults.filter((r): r is Tool => r !== null);
+
+	// Set up Python tool bridge if enabled
+	if (session.settings.get("python.toolBridge")) {
+		setupPythonToolBridge(tools, session);
+	}
+
 	const hasDeferrableTools = tools.some(tool => tool.deferrable === true);
 	if (!hasDeferrableTools) {
 		return tools;
@@ -358,4 +365,24 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		tools.push(wrapToolWithMetaNotice(resolveTool));
 	}
 	return tools;
+}
+
+/**
+ * Configure the Python tool bridge when python.toolBridge is enabled.
+ * Collects bridgeable tools, generates the Python prelude, and sets up dispatch.
+ */
+function setupPythonToolBridge(tools: Tool[], session: ToolSession): void {
+	const pythonTool = tools.find(t => t.name === "python");
+	if (!pythonTool || !(pythonTool instanceof PythonTool)) return;
+
+	const mcpTools = session.mcpManager?.getTools() ?? [];
+	const bridgeableTools = collectBridgeableTools(tools as AgentTool[], mcpTools);
+	if (bridgeableTools.length === 0) return;
+
+	const prelude = generateToolBridgePrelude(bridgeableTools);
+	const handler = createToolBridgeHandler(tools as AgentTool[], session);
+	const toolList = bridgeableTools.map(t => `\`${t.name}\``).join(", ");
+
+	pythonTool.configureToolBridge(handler, prelude, toolList);
+	logger.debug("Python tool bridge configured", { toolCount: bridgeableTools.length });
 }

--- a/packages/coding-agent/src/tools/python.ts
+++ b/packages/coding-agent/src/tools/python.ts
@@ -10,6 +10,7 @@ import { renderPromptTemplate } from "../config/prompt-templates";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { executePython, getPreludeDocs, type PythonExecutorOptions } from "../ipy/executor";
 import type { PreludeHelper, PythonStatusEvent } from "../ipy/kernel";
+import type { ToolBridgeHandler } from "../ipy/tool-bridge";
 import { truncateToVisualLines } from "../modes/components/visual-truncate";
 import { getMarkdownTheme, type Theme } from "../modes/theme/theme";
 import pythonDescription from "../prompts/tools/python.md" with { type: "text" };
@@ -133,10 +134,11 @@ function renderJsonTree(value: unknown, theme: Theme, expanded: boolean, maxDept
 	return renderNode(value, "", 0, true);
 }
 
-export function getPythonToolDescription(): string {
+export function getPythonToolDescription(toolBridgeList?: string): string {
 	const helpers = getPreludeDocs();
 	const categories = groupPreludeHelpers(helpers);
-	return renderPromptTemplate(pythonDescription, { categories });
+	const toolBridge = !!toolBridgeList;
+	return renderPromptTemplate(pythonDescription, { categories, toolBridge, toolBridgeList: toolBridgeList ?? "" });
 }
 
 export interface PythonToolOptions {
@@ -146,10 +148,12 @@ export interface PythonToolOptions {
 export class PythonTool implements AgentTool<typeof pythonSchema> {
 	readonly name = "python";
 	readonly label = "Python";
-	readonly description: string;
+	description: string;
 	readonly parameters = pythonSchema;
 	readonly concurrency = "exclusive";
 	readonly strict = true;
+	#toolBridgeHandler?: ToolBridgeHandler;
+	#toolBridgePrelude?: string;
 
 	readonly #proxyExecutor?: PythonProxyExecutor;
 
@@ -159,6 +163,17 @@ export class PythonTool implements AgentTool<typeof pythonSchema> {
 	) {
 		this.#proxyExecutor = options?.proxyExecutor;
 		this.description = getPythonToolDescription();
+	}
+
+	/**
+	 * Configure the tool bridge with pre-created tools.
+	 * Called after createTools() when python.toolBridge is enabled.
+	 */
+	configureToolBridge(handler: ToolBridgeHandler, prelude: string, toolList: string): void {
+		this.#toolBridgeHandler = handler;
+		this.#toolBridgePrelude = prelude;
+		// Re-generate description with bridge info
+		this.description = getPythonToolDescription(toolList);
 	}
 
 	async execute(
@@ -273,6 +288,8 @@ export class PythonTool implements AgentTool<typeof pythonSchema> {
 				kernelMode: this.session.settings.get("python.kernelMode"),
 				useSharedGateway: this.session.settings.get("python.sharedGateway"),
 				sessionFile: sessionFile ?? undefined,
+				toolBridgeHandler: this.#toolBridgeHandler,
+				toolBridgePrelude: this.#toolBridgePrelude,
 			};
 
 			for (let i = 0; i < cells.length; i++) {


### PR DESCRIPTION
## What

Python tool bridge: expose agent tools (builtin + MCP) as callable Python functions in the IPython kernel, using Jupyter's existing stdin IPC channel.

Gated behind `python.toolBridge` setting (default: `false`).

### How it works

1. Python calls `input("__omp_tool__:{json}")`
2. TypeScript intercepts the `input_request` with the `__omp_tool__:` prefix
3. Dispatches to the real tool (builtin or MCP)
4. Sends result back via `input_reply`

This enables batch/loop tool operations in a single Python cell (e.g., "for each of N files, call lsp hover") — one LLM round trip instead of N.

### Files

| File | Change |
|------|--------|
| `ipy/tool-bridge.ts` | **New.** Tool collection, Python prelude generation, dispatch handler |
| `ipy/kernel.ts` | Stdin dispatch + `#sendInputReply` helper |
| `ipy/executor.ts` | `setupToolBridge()` with once-per-kernel guard |
| `tools/python.ts` | `configureToolBridge()` method |
| `tools/index.ts` | Wiring in `createTools()` |
| `config/settings-schema.ts` | `python.toolBridge` boolean setting |
| `prompts/tools/python.md` | Conditional `<tool-bridge>` prompt section |
| `CHANGELOG.md` | Unreleased entry |

## Why

For long conversations, chaining N tool calls costs N full context replays through the LLM. The bridge lets batch/loop patterns (same operation applied to many items) execute in a single Python cell, paying context cost once.

## Testing

- `bun check` passes (biome + tsgo)
- Tested locally with `python.toolBridge` enabled — bridged tool calls dispatch correctly through stdin IPC, typed wrappers generate valid Python, `None`/`null` args preserved

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)