### PR TITLE
fix(ai): use bundled model maxTokens fallback for ZenMux models

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- ZenMux model mapper now uses bundled model `maxTokens` fallback for known models, preventing premature truncation from the generic 8888 token cap
+
 ## [13.9.2] - 2026-03-05
 
 ### Added

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -747,6 +747,7 @@ export function zenmuxModelManagerOptions(config?: ZenMuxModelManagerConfig): Mo
 	const apiKey = config?.apiKey;
 	const openAiBaseUrl = normalizeZenMuxOpenAiBaseUrl(config?.baseUrl);
 	const anthropicBaseUrl = toZenMuxAnthropicBaseUrl(openAiBaseUrl);
+	const references = createGlobalReferenceMap();
 	return {
 		providerId: "zenmux",
 		...(apiKey && {
@@ -760,12 +761,13 @@ export function zenmuxModelManagerOptions(config?: ZenMuxModelManagerConfig): Mo
 						const pricings = isRecord(entry.pricings) ? entry.pricings : undefined;
 						const capabilities = isRecord(entry.capabilities) ? entry.capabilities : undefined;
 						const isAnthropicModel = isZenMuxAnthropicModel(entry, defaults.id);
+						const reference = references.get(defaults.id);
 						return {
 							...defaults,
-							name: toModelName(entry.display_name, defaults.name),
+							name: toModelName(entry.display_name, reference?.name ?? defaults.name),
 							api: isAnthropicModel ? "anthropic-messages" : "openai-completions",
 							baseUrl: isAnthropicModel ? anthropicBaseUrl : openAiBaseUrl,
-							reasoning: capabilities?.reasoning === true || defaults.reasoning,
+							reasoning: capabilities?.reasoning === true || reference?.reasoning === true || defaults.reasoning,
 							input: toInputCapabilities(entry.input_modalities),
 							cost: {
 								input: getZenMuxPricingValue(pricings, "prompt"),
@@ -773,8 +775,14 @@ export function zenmuxModelManagerOptions(config?: ZenMuxModelManagerConfig): Mo
 								cacheRead: getZenMuxPricingValue(pricings, "input_cache_read"),
 								cacheWrite: getZenMuxCacheWritePrice(pricings),
 							},
-							contextWindow: toPositiveNumber(entry.context_length, defaults.contextWindow),
-							maxTokens: toPositiveNumber(entry.max_completion_tokens, defaults.maxTokens),
+							contextWindow: toPositiveNumber(
+								entry.context_length,
+								reference?.contextWindow ?? defaults.contextWindow,
+							),
+							maxTokens: toPositiveNumber(
+								entry.max_completion_tokens,
+								reference?.maxTokens ?? defaults.maxTokens,
+							),
 						};
 					},
 				}),

--- a/packages/ai/test/zenmux-provider.test.ts
+++ b/packages/ai/test/zenmux-provider.test.ts
@@ -35,6 +35,7 @@ describe("zenmux provider support", () => {
 		const provider = getOAuthProviders().find(item => item.id === "zenmux");
 		expect(provider?.name).toBe("ZenMux");
 	});
+
 	test("routes Anthropic-owned models to anthropic-messages", async () => {
 		global.fetch = vi.fn(
 			async () =>
@@ -90,10 +91,59 @@ describe("zenmux provider support", () => {
 		expect(anthropic?.input).toEqual(["text", "image"]);
 		expect(anthropic?.cost.input).toBe(15);
 		expect(anthropic?.cost.cacheWrite).toBe(18.75);
+		expect(anthropic?.maxTokens).toBe(128000);
 
 		const openai = models?.find(model => model.id === "openai/gpt-5.2");
 		expect(openai?.api).toBe("openai-completions");
 		expect(openai?.baseUrl).toBe("https://zenmux.ai/api/v1");
 		expect(openai?.cost.output).toBe(10);
+	});
+
+	test("uses bundled model maxTokens fallback for known models", async () => {
+		global.fetch = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						data: [
+							{
+								id: "anthropic/claude-opus-4.6",
+								display_name: "Anthropic: Claude Opus 4.6",
+								owned_by: "anthropic",
+								input_modalities: ["text", "image"],
+								capabilities: { reasoning: true },
+								context_length: 200000,
+								pricings: {
+									prompt: [{ value: 15, unit: "perMTokens", currency: "USD" }],
+									completion: [{ value: 75, unit: "perMTokens", currency: "USD" }],
+								},
+							},
+							{
+								id: "unknown/new-model",
+								display_name: "Unknown: New Model",
+								owned_by: "unknown",
+								input_modalities: ["text"],
+								capabilities: { reasoning: false },
+								context_length: 100000,
+								pricings: {
+									prompt: [{ value: 1, unit: "perMTokens", currency: "USD" }],
+									completion: [{ value: 2, unit: "perMTokens", currency: "USD" }],
+								},
+							},
+						],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+		) as unknown as typeof fetch;
+
+		const options = zenmuxModelManagerOptions({ apiKey: "zenmux-test-key" });
+		const models = await options.fetchDynamicModels?.();
+
+		// Known model should use bundled maxTokens (128000 for claude-opus-4.6)
+		const knownModel = models?.find(model => model.id === "anthropic/claude-opus-4.6");
+		expect(knownModel?.maxTokens).toBe(128000);
+
+		// Unknown model should fall back to UNK_MAX_TOKENS (8888)
+		const unknownModel = models?.find(model => model.id === "unknown/new-model");
+		expect(unknownModel?.maxTokens).toBe(8888);
 	});
 });


### PR DESCRIPTION
## Summary

Follow-up fix for #289 addressing the maxTokens review feedback.

ZenMux API does not return `max_completion_tokens` in `/models` response, causing all models to fall back to `UNK_MAX_TOKENS` (8888), which can prematurely truncate models supporting much larger outputs.

## Changes

- Added `createGlobalReferenceMap()` lookup in `zenmuxModelManagerOptions`
- For known models, uses bundled model metadata for `maxTokens` and `contextWindow` fallback
- Also applies bundled `name` and `reasoning` when available
- Unknown models still fall back to `UNK_MAX_TOKENS` (8888)

## Test

```bash
bun test packages/ai/test/zenmux-provider.test.ts packages/ai/test/zenmux-login.test.ts
# 9 pass, 0 fail
```

## Verification

For `anthropic/claude-opus-4.6`:
- Before: `maxTokens = 8888` (UNK_MAX_TOKENS fallback)
- After: `maxTokens = 128000` (from bundled ZenMux models)

For unknown models: still falls back to 8888