### PR TITLE
fix(coding-agent): parse Exa MCP plain-text web_search payloads

### DIFF
--- a/packages/coding-agent/src/web/search/providers/exa.ts
+++ b/packages/coding-agent/src/web/search/providers/exa.ts
@@ -78,7 +78,8 @@ function parseExaMcpTextPayload(payload: unknown): ExaSearchResponse | null {
 	const textBlocks = content
 		.map(item => {
 			const part = asRecord(item);
-			return typeof part?.text === "string" ? part.text.trim() : "";
+			const text = typeof part?.text === "string" ? part.text : "";
+			return text.replace(/\r\n?/g, "\n").trim();
 		})
 		.filter(text => text.length > 0);
 

--- a/packages/coding-agent/test/tools/web-search-exa.test.ts
+++ b/packages/coding-agent/test/tools/web-search-exa.test.ts
@@ -483,6 +483,36 @@ describe("searchExa", () => {
 		expect(calledUrl).not.toContain("exaApiKey=");
 	});
 
+	it("splits MCP plain-text records with CRLF line endings", async () => {
+		delete process.env.EXA_API_KEY;
+		const payloadText = [
+			"Title: CRLF Alpha",
+			"URL: https://crlf-alpha.com",
+			"Text: First result",
+			"",
+			"Title: CRLF Beta",
+			"URL: https://crlf-beta.com",
+			"Text: Second result",
+		].join("\r\n");
+		// @ts-expect-error - test mock doesn't need fetch.preconnect
+		vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+			return new Response(
+				JSON.stringify({
+					jsonrpc: "2.0",
+					id: "mcp-content-crlf",
+					result: { content: [{ type: "text", text: payloadText }] },
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		});
+
+		const result = await searchExa({ query: "crlf payload" });
+		expect(result.provider).toBe("exa");
+		expect(result.sources).toHaveLength(2);
+		expect(result.sources[0]?.url).toBe("https://crlf-alpha.com");
+		expect(result.sources[1]?.url).toBe("https://crlf-beta.com");
+	});
+
 	it("keeps 'Title:' lines inside Text body when parsing MCP plain-text content", async () => {
 		delete process.env.EXA_API_KEY;
 		const payloadText = [


### PR DESCRIPTION
## What

- Add tolerant parsing for Exa MCP `web_search_exa` plain-text `content` payloads in the Exa web-search provider fallback path.
- Keep existing structured-response behavior unchanged.
- Add regression tests for plain-text MCP payload handling in both `searchExa(...)` and `runSearchQuery(..., provider: "exa")` when `EXA_API_KEY` is missing.

## Why

`web_search(provider="exa")` could fail with `Exa MCP search returned unexpected response shape.` when MCP returned text blocks instead of a structured object. This made explicit Exa provider usage unreliable in no-key MCP fallback scenarios.

fixes #299

## Testing

- `PATH="$HOME/.cargo/bin:$PATH" mise exec -- bun run check`
- `PATH="$HOME/.cargo/bin:$PATH" mise exec -- bun test packages/coding-agent/test/tools/web-search-exa.test.ts`

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
