### PR TITLE
fix(coding-agent): derive web-search auto priority from provider order

### DIFF
--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -20,6 +20,7 @@ import {
 	type SettingTab,
 } from "../../config/settings-schema";
 import { getThinkingLevelMetadata } from "../../thinking";
+import { formatSearchProviderPriority } from "../../web/search/provider-order";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // UI Definition Types
@@ -224,7 +225,7 @@ const OPTION_PROVIDERS: Partial<Record<SettingPath, OptionProvider>> = {
 		{
 			value: "auto",
 			label: "Auto",
-			description: "Preferred web-search provider",
+			description: formatSearchProviderPriority(),
 		},
 		{ value: "exa", label: "Exa", description: "Requires EXA_API_KEY" },
 		{ value: "brave", label: "Brave", description: "Requires BRAVE_API_KEY" },

--- a/packages/coding-agent/src/web/search/provider-order.ts
+++ b/packages/coding-agent/src/web/search/provider-order.ts
@@ -1,0 +1,36 @@
+import type { SearchProviderId } from "./types";
+
+export const SEARCH_PROVIDER_ORDER: SearchProviderId[] = [
+	"tavily",
+	"perplexity",
+	"brave",
+	"jina",
+	"kimi",
+	"anthropic",
+	"gemini",
+	"codex",
+	"zai",
+	"exa",
+	"kagi",
+	"synthetic",
+];
+
+const SEARCH_PROVIDER_LABELS: Record<SearchProviderId, string> = {
+	tavily: "Tavily",
+	perplexity: "Perplexity",
+	brave: "Brave",
+	jina: "Jina",
+	kimi: "Kimi",
+	anthropic: "Anthropic",
+	gemini: "Gemini",
+	codex: "Codex",
+	zai: "Z.AI",
+	exa: "Exa",
+	kagi: "Kagi",
+	synthetic: "Synthetic",
+};
+
+export function formatSearchProviderPriority(): string {
+	const labels = SEARCH_PROVIDER_ORDER.map(provider => SEARCH_PROVIDER_LABELS[provider]);
+	return `Priority: ${labels.join(" > ")}`;
+}

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -1,3 +1,4 @@
+import { SEARCH_PROVIDER_ORDER } from "./provider-order";
 import { AnthropicProvider } from "./providers/anthropic";
 import type { SearchProvider } from "./providers/base";
 import { BraveProvider } from "./providers/brave";
@@ -31,20 +32,7 @@ const SEARCH_PROVIDERS: Record<SearchProviderId, SearchProvider> = {
 	synthetic: new SyntheticProvider(),
 } as const;
 
-export const SEARCH_PROVIDER_ORDER: SearchProviderId[] = [
-	"tavily",
-	"perplexity",
-	"brave",
-	"jina",
-	"kimi",
-	"anthropic",
-	"gemini",
-	"codex",
-	"zai",
-	"exa",
-	"kagi",
-	"synthetic",
-];
+export { SEARCH_PROVIDER_ORDER };
 
 export function getSearchProvider(provider: SearchProviderId): SearchProvider {
 	return SEARCH_PROVIDERS[provider];
@@ -58,7 +46,7 @@ export function setPreferredSearchProvider(provider: SearchProviderId | "auto"):
 	preferredProvId = provider;
 }
 
-/** Determine which providers are configured (priority: Perplexity → Brave → Jina → Kimi → Anthropic → Gemini → Codex → Z.AI → Exa → Tavily → Kagi → Synthetic) */
+/** Determine which configured providers to try, in SEARCH_PROVIDER_ORDER preference. */
 export async function resolveProviderChain(
 	preferredProvider: SearchProviderId | "auto" = preferredProvId,
 ): Promise<SearchProvider[]> {

--- a/packages/coding-agent/test/tools/web-search-provider-order.test.ts
+++ b/packages/coding-agent/test/tools/web-search-provider-order.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { formatSearchProviderPriority, SEARCH_PROVIDER_ORDER } from "../../src/web/search/provider-order";
+
+describe("web search provider order", () => {
+	it("keeps Exa after Gemini in auto priority", () => {
+		expect(SEARCH_PROVIDER_ORDER).toContain("gemini");
+		expect(SEARCH_PROVIDER_ORDER).toContain("exa");
+		expect(SEARCH_PROVIDER_ORDER.indexOf("gemini")).toBeLessThan(SEARCH_PROVIDER_ORDER.indexOf("exa"));
+	});
+
+	it("formats auto-priority description from shared provider order", () => {
+		expect(formatSearchProviderPriority()).toBe(
+			"Priority: Tavily > Perplexity > Brave > Jina > Kimi > Anthropic > Gemini > Codex > Z.AI > Exa > Kagi > Synthetic",
+		);
+	});
+});


### PR DESCRIPTION
## What

- Introduce a shared web-search provider-order module (`provider-order.ts`) that owns:
  - canonical `SEARCH_PROVIDER_ORDER`
  - auto-priority description formatter (`formatSearchProviderPriority()`)
- Reuse the shared provider order in runtime provider-chain resolution.
- Replace hardcoded settings description text with `formatSearchProviderPriority()` to eliminate duplicated order maintenance.
- Add tests verifying order invariants (Gemini before Exa) and formatted priority string.

## Why

Auto-priority text shown in settings drifted from runtime fallback order. Keeping separate hardcoded order strings creates ongoing maintenance risk and user confusion.

fixes #301

## Testing

- `PATH="$HOME/.cargo/bin:$PATH" mise exec -- bun run check`
- `PATH="$HOME/.cargo/bin:$PATH" mise exec -- bun test packages/coding-agent/test/tools/web-search-provider-order.test.ts`

---

- [x] `bun check` passes
- [x] Tested locally
