### PR TITLE
fix: correct context window percentage and provider token mapping

### DIFF
--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -234,11 +234,17 @@ export const streamGoogleVertex: StreamFunction<"google-vertex"> = (
 				}
 
 				if (chunk.usageMetadata) {
+					// promptTokenCount includes cachedContentTokenCount when cached content is used.
+					// Subtract to get non-cached input, matching the OpenAI convention where
+					// input = uncached prompt tokens and cacheRead = cached tokens so that
+					// input + cacheRead = total prompt tokens (no double-counting).
+					// Ref: https://ai.google.dev/api/generate-content#v1beta.GenerateContentResponse.UsageMetadata
+					const cachedTokens = chunk.usageMetadata.cachedContentTokenCount || 0;
 					output.usage = {
-						input: chunk.usageMetadata.promptTokenCount || 0,
+						input: (chunk.usageMetadata.promptTokenCount || 0) - cachedTokens,
 						output:
 							(chunk.usageMetadata.candidatesTokenCount || 0) + (chunk.usageMetadata.thoughtsTokenCount || 0),
-						cacheRead: chunk.usageMetadata.cachedContentTokenCount || 0,
+						cacheRead: cachedTokens,
 						cacheWrite: 0,
 						totalTokens: chunk.usageMetadata.totalTokenCount || 0,
 						cost: {

--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -217,11 +217,17 @@ export const streamGoogle: StreamFunction<"google-generative-ai"> = (
 				}
 
 				if (chunk.usageMetadata) {
+					// promptTokenCount includes cachedContentTokenCount when cached content is used.
+					// Subtract to get non-cached input, matching the OpenAI convention where
+					// input = uncached prompt tokens and cacheRead = cached tokens so that
+					// input + cacheRead = total prompt tokens (no double-counting).
+					// Ref: https://ai.google.dev/api/generate-content#v1beta.GenerateContentResponse.UsageMetadata
+					const cachedTokens = chunk.usageMetadata.cachedContentTokenCount || 0;
 					output.usage = {
-						input: chunk.usageMetadata.promptTokenCount || 0,
+						input: (chunk.usageMetadata.promptTokenCount || 0) - cachedTokens,
 						output:
 							(chunk.usageMetadata.candidatesTokenCount || 0) + (chunk.usageMetadata.thoughtsTokenCount || 0),
-						cacheRead: chunk.usageMetadata.cachedContentTokenCount || 0,
+						cacheRead: cachedTokens,
 						cacheWrite: 0,
 						totalTokens: chunk.usageMetadata.totalTokenCount || 0,
 						cost: {

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -115,7 +115,7 @@ export function isContextOverflow(message: AssistantMessage, contextWindow?: num
 
 	// Case 2: Usage-based overflow (silent or provider-specific)
 	if (contextWindow) {
-		const inputTokens = message.usage.input + message.usage.cacheRead;
+		const inputTokens = message.usage.input + message.usage.cacheRead + message.usage.cacheWrite;
 		if (inputTokens > contextWindow) {
 			return true;
 		}

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -7,6 +7,7 @@ import { settings } from "../../config/settings";
 import type { StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle } from "../../config/settings-schema";
 import { theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
+import { calculatePromptTokens } from "../../session/compaction/compaction";
 import { findGitHeadPathSync, sanitizeStatusText } from "../shared";
 import {
 	canReuseCachedPr,
@@ -365,12 +366,7 @@ export class StatusLineComponent implements Component {
 			.reverse()
 			.find(m => m.role === "assistant" && m.stopReason !== "aborted") as AssistantMessage | undefined;
 
-		const contextTokens = lastAssistantMessage
-			? lastAssistantMessage.usage.input +
-				lastAssistantMessage.usage.output +
-				lastAssistantMessage.usage.cacheRead +
-				lastAssistantMessage.usage.cacheWrite
-			: 0;
+		const contextTokens = lastAssistantMessage ? calculatePromptTokens(lastAssistantMessage.usage) : 0;
 		const contextWindow = state.model?.contextWindow || 0;
 		const contextPercent = contextWindow > 0 ? (contextTokens / contextWindow) * 100 : 0;
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -105,6 +105,7 @@ import { extractFileMentions, generateFileMentionMessages } from "../utils/file-
 import {
 	type CompactionResult,
 	calculateContextTokens,
+	calculatePromptTokens,
 	collectEntriesForBranchSummary,
 	compact,
 	estimateTokens,
@@ -4934,7 +4935,7 @@ Be thorough - include exact file paths, function names, error messages, and tech
 			};
 		}
 
-		const usageTokens = calculateContextTokens(lastUsage);
+		const usageTokens = calculatePromptTokens(lastUsage);
 		let trailingTokens = 0;
 		for (let i = lastUsageIndex + 1; i < messages.length; i++) {
 			trailingTokens += estimateTokens(messages[i]);


### PR DESCRIPTION
## Problem

The context fullness gauge in the status bar and footer was producing erratic readings — jumping from 84% down to 64% between turns with no compaction occurring. The percentage was inversely correlated with response length: long responses spiked the gauge, short responses deflated it, even as the actual conversation history grew.

### Root cause 1 — output tokens in context percentage formula

Both display paths (`status-line.ts` inline formula and `agent-session.ts` `#estimateContextTokens` feeding `footer.ts`) computed context size as:

```
input + output + cacheRead + cacheWrite
```

Including `output` here is wrong for a stable display metric. The context window overflow condition — both the API error (`"prompt is too long: X tokens > Y maximum"`) and the silent-overflow check in `isContextOverflow` — is based on **input tokens only**. Output tokens from turn N become input tokens in turn N+1, so they will be captured correctly in the next measurement. Including them in the current turn's display produces no predictive value and causes the observed jumps.

Fixed by switching both sites to `calculatePromptTokens()`, which returns `input + cacheRead + cacheWrite` — the total prompt the model received, with no output component.

### Root cause 2 — `isContextOverflow` missing `cacheWrite`

The usage-based silent-overflow fallback (for providers like z.ai that silently accept overflow requests) checked:

```ts
input + cacheRead > contextWindow   // missing cacheWrite
```

`cache_creation_input_tokens` (= `cacheWrite`) are part of the prompt sent to the model and consume context window space just like regular input tokens. A request with 180K cached + 30K new cache-writes = 210K total prompt tokens would slip past a 200K window undetected.

### Root cause 3 — Gemini/Vertex double-counting cached tokens

`google.ts` and `google-vertex.ts` mapped Gemini's usage fields as:

```ts
input: chunk.usageMetadata.promptTokenCount,         // includes cached
cacheRead: chunk.usageMetadata.cachedContentTokenCount,  // cached again
```

Per the [Gemini API docs](https://ai.google.dev/api/generate-content#v1beta.GenerateContentResponse.UsageMetadata), `promptTokenCount` **already includes** `cachedContentTokenCount` when cached content is used:

> `promptTokenCount` — "The total number of tokens in the prompt. When `cached_content` is set, this also includes the number of tokens in the cached content."

This meant cached tokens were counted twice in every context percentage calculation for Gemini/Vertex users.

Fixed to match the OpenAI convention (subtract first):

```ts
const cachedTokens = chunk.usageMetadata.cachedContentTokenCount || 0;
input: (chunk.usageMetadata.promptTokenCount || 0) - cachedTokens,
cacheRead: cachedTokens,
// input + cacheRead = promptTokenCount  ✓
```

## Changes

| File | Change |
|---|---|
| `packages/coding-agent/src/modes/components/status-line.ts` | Replace inline `input+output+cacheRead+cacheWrite` with `calculatePromptTokens()` |
| `packages/coding-agent/src/session/agent-session.ts` | `#estimateContextTokens` (feeds `footer.ts` display) uses `calculatePromptTokens()` |
| `packages/ai/src/utils/overflow.ts` | Add `cacheWrite` to silent-overflow threshold |
| `packages/ai/src/providers/google.ts` | Subtract `cachedContentTokenCount` from `promptTokenCount` before assigning to `input` |
| `packages/ai/src/providers/google-vertex.ts` | Same fix as `google.ts` |

## Provider audit

All other providers were validated during this investigation:

| Provider | Status | Notes |
|---|---|---|
| `anthropic.ts` | ✓ | `input_tokens` is uncached by API design; separate `cache_read`/`cache_creation` fields |
| `amazon-bedrock.ts` | ✓ | `inputTokens` is uncached-only per AWS Converse API contract |
| `openai-completions.ts` | ✓ | Already subtracts `cached_tokens` from `prompt_tokens` |
| `openai-responses.ts` | ✓ | Same pattern as completions |
| `azure-openai-responses.ts` | ✓ | Same pattern as completions |
| `kimi.ts` | ✓ | Delegates to `anthropic.ts` / `openai-completions.ts` |
| `gitlab-duo.ts` | ✓ | Delegates to `anthropic.ts` / `openai-responses.ts` / `openai-completions.ts` |
| `cursor.ts` | ✓ | Cursor protocol only exposes output tokens; `input` stays 0 by API design |

## Invariant established

After this fix, all providers share the same convention:

```
input       = uncached prompt tokens
cacheRead   = tokens read from cache
cacheWrite  = tokens written to cache (cache_creation)

input + cacheRead + cacheWrite = total prompt tokens sent to the model
```

`calculatePromptTokens()` expresses this invariant and is now the single authoritative function for context window fullness.