### PR TITLE
Fix delayed display of submitted user messages

### DIFF
--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -134,8 +134,19 @@ export class EventController {
 					this.ctx.addMessageToChat(event.message);
 					this.ctx.ui.requestRender();
 				} else if (event.message.role === "user") {
+					const textContent = this.ctx.getUserMessageText(event.message);
+					const imageCount =
+						typeof event.message.content === "string"
+							? 0
+							: event.message.content.filter(content => content.type === "image").length;
+					const signature = `${textContent}\u0000${imageCount}`;
+
 					this.#resetReadGroup();
-					this.ctx.addMessageToChat(event.message);
+					if (this.ctx.optimisticUserMessageSignature !== signature) {
+						this.ctx.addMessageToChat(event.message);
+					}
+					this.ctx.optimisticUserMessageSignature = undefined;
+
 					if (!event.message.synthetic) {
 						this.ctx.editor.setText("");
 						this.ctx.updatePendingMessagesDisplay();

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -318,6 +318,19 @@ export class InputController {
 				// Include any pending images from clipboard paste
 				const images = inputImages && inputImages.length > 0 ? [...inputImages] : undefined;
 				this.ctx.pendingImages = [];
+
+				// Render user message immediately, then let session events catch up
+				this.ctx.optimisticUserMessageSignature = `${text}\u0000${images?.length ?? 0}`;
+				const optimisticMessage: AgentMessage = {
+					role: "user",
+					content: [{ type: "text", text }, ...(images ?? [])],
+					attribution: "user",
+					timestamp: Date.now(),
+				};
+				this.ctx.addMessageToChat(optimisticMessage);
+				this.ctx.editor.setText("");
+				this.ctx.ui.requestRender();
+
 				this.ctx.onInputCallback({ text, images });
 			}
 			this.ctx.editor.addToHistory(text);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -123,6 +123,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	retryEscapeHandler?: () => void;
 	unsubscribe?: () => void;
 	onInputCallback?: (input: { text: string; images?: ImageContent[] }) => void;
+	optimisticUserMessageSignature: string | undefined = undefined;
 	lastSigintTime = 0;
 	lastEscapeTime = 0;
 	shutdownRequested = false;
@@ -855,6 +856,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	showError(message: string): void {
+		this.optimisticUserMessageSignature = undefined;
 		this.#uiHelpers.showError(message);
 	}
 

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -88,6 +88,7 @@ export interface InteractiveModeContext {
 	retryEscapeHandler?: () => void;
 	unsubscribe?: () => void;
 	onInputCallback?: (input: { text: string; images?: ImageContent[] }) => void;
+	optimisticUserMessageSignature: string | undefined;
 	lastSigintTime: number;
 	lastEscapeTime: number;
 	shutdownRequested: boolean;


### PR DESCRIPTION
Fixes #311

## Summary
- render user messages optimistically in interactive mode immediately on submit
- deduplicate the later `message_start` user event using a text+image-count signature
- clear optimistic state on UI errors to avoid stale dedupe state

## Verification
- bun check:ts
