### PR TITLE
fix(coding-agent): show compaction summary after manual /compact

### DIFF
--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -467,15 +467,7 @@ export class EventController {
 						isHandoffAction ? "Auto-handoff cancelled" : "Auto context-full maintenance cancelled",
 					);
 				} else if (event.result) {
-					this.ctx.chatContainer.clear();
 					this.ctx.rebuildChatFromMessages();
-					this.ctx.addMessageToChat({
-						role: "compactionSummary",
-						tokensBefore: event.result.tokensBefore,
-						summary: event.result.summary,
-						shortSummary: event.result.shortSummary,
-						timestamp: Date.now(),
-					});
 					this.ctx.statusLine.invalidate();
 					this.ctx.updateEditorTopBorder();
 				} else if (event.errorMessage) {

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -219,7 +219,13 @@ export class UiHelpers {
 		let readGroup: ReadToolGroupComponent | null = null;
 		const readToolCallArgs = new Map<string, Record<string, unknown>>();
 		const readToolCallAssistantComponents = new Map<string, AssistantMessageComponent>();
+		const deferredMessages: AgentMessage[] = [];
 		for (const message of sessionContext.messages) {
+			// Defer compaction summaries so they render at the bottom (visible after scroll)
+			if (message.role === "compactionSummary") {
+				deferredMessages.push(message);
+				continue;
+			}
 			// Assistant messages need special handling for tool calls
 			if (message.role === "assistant") {
 				this.ctx.addMessageToChat(message);
@@ -343,6 +349,11 @@ export class UiHelpers {
 				// All other messages use standard rendering
 				this.ctx.addMessageToChat(message, options);
 			}
+		}
+
+		// Render deferred messages (compaction summaries) at the bottom so they're visible
+		for (const message of deferredMessages) {
+			this.ctx.addMessageToChat(message, options);
 		}
 
 		this.ctx.pendingTools.clear();


### PR DESCRIPTION
Manual `/compact` command never showed the compaction summary message (token count + summary text). The auto-compaction path in `event-controller.ts` explicitly added a `compactionSummary` message after `rebuildChatFromMessages()`, but the manual path in `command-controller.ts` was missing this step.

**Root cause**: `rebuildChatFromMessages()` rebuilds the chat UI from session entries. The compaction summary is a synthetic UI-only message not stored in the session, so it was never rendered after manual `/compact`.

**Fix**: Instead of duplicating the `addMessageToChat` call in both code paths, move compaction summary rendering into `rebuildChatFromMessages()` itself. Compaction summary messages in the message list are now deferred during rebuild and rendered at the bottom so they stay visible after scroll.

### Changes

- **`packages/coding-agent/src/modes/utils/ui-helpers.ts`** — `rebuildChatFromMessages()` now collects `compactionSummary` messages during iteration and appends them at the end, so they always render at the bottom regardless of where they appear in the message list.
- **`packages/coding-agent/src/modes/controllers/event-controller.ts`** — Removed the duplicate manual `addMessageToChat` + `chatContainer.clear()` calls from the auto-compaction path; `rebuildChatFromMessages()` now handles it.

2 files changed, 11 insertions, 8 deletions.