### PR TITLE
fix(ai): resolve TS2322 type mismatch in openai-codex-responses

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -333,7 +333,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 			const conversationMessages = convertMessages(model, context);
 			const params: RequestBody = {
 				model: model.id,
-				input: [...conversationMessages],
+				input: conversationMessages as InputItem[],
 				stream: true,
 				prompt_cache_key: options?.sessionId,
 			};


### PR DESCRIPTION
Fixes the pre-existing type error:

```
packages/ai/src/providers/openai-codex-responses.ts(336,5): error TS2322:
Type 'ResponseInputItem[]' is not assignable to type 'InputItem[]'.
```

`convertMessages()` returns `ResponseInput` (`ResponseInputItem[]` from the openai SDK) but `RequestBody.input` expects `InputItem[]` (hand-written structural subset). TypeScript cannot prove the wide discriminated union is assignable to the simple interface because SDK interface members lack implicit index signatures (`ApplyPatchCall` etc.).

**Fix**: Cast at the assignment site. The objects are structurally compatible — `InputItem` captures the common fields (`type`, `role`, `content`, `call_id`, `id`, etc.) that all union members possess. Also removes the unnecessary array spread.

1 file changed: `packages/ai/src/providers/openai-codex-responses.ts`