### PR TITLE
fix: web search falls through to Exa when Anthropic api_key is stored…

### DIFF
--- a/packages/ai/src/utils/anthropic-auth.ts
+++ b/packages/ai/src/utils/anthropic-auth.ts
@@ -1,10 +1,12 @@
 /**
  * Anthropic Authentication
  *
- * 3-tier auth resolution:
+ * 5-tier auth resolution:
  *   1. ANTHROPIC_SEARCH_API_KEY / ANTHROPIC_SEARCH_BASE_URL env vars
- *   2. OAuth credentials in ~/.omp/agent/agent.db (with expiry check)
- *   3. Generic Anthropic fallback (Foundry-aware key/base URL resolution)
+ *   2. ANTHROPIC_FOUNDRY_API_KEY override when Foundry mode is enabled
+ *   3. OAuth credentials in ~/.omp/agent/agent.db (with expiry check)
+ *   4. API key credentials in ~/.omp/agent/agent.db
+ *   5. Generic Anthropic fallback (ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL)
  */
 import { $env, getAgentDbPath } from "@oh-my-pi/pi-utils";
 import { type AuthCredential, AuthCredentialStore } from "../auth-storage";
@@ -105,7 +107,8 @@ async function readAnthropicOAuthCredentials(store?: AuthCredentialStore): Promi
  *   1. ANTHROPIC_SEARCH_API_KEY / ANTHROPIC_SEARCH_BASE_URL
  *   2. ANTHROPIC_FOUNDRY_API_KEY override when Foundry mode is enabled
  *   3. OAuth in agent.db (with 5-minute expiry buffer)
- *   4. ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL fallback
+ *   4. API key in agent.db
+ *   5. ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL fallback
  * @param store - Optional credential store (creates one from default db path if not provided)
  * @returns The first valid auth configuration found, or null if none available
  */
@@ -130,22 +133,42 @@ export async function findAnthropicAuth(store?: AuthCredentialStore): Promise<An
 			isOAuth: isOAuthToken(foundryApiKey),
 		};
 	}
-	// 3. OAuth credentials in agent.db (with 5-minute expiry buffer)
-	const expiryBuffer = 5 * 60 * 1000; // 5 minutes
-	const now = Date.now();
-	const credentials = await readAnthropicOAuthCredentials(store);
-	for (const credential of credentials) {
-		if (!credential.access) continue;
-		if (credential.expires > now + expiryBuffer) {
+
+	// Tiers 3-4 use the credential store; manage lifecycle once
+	const ownsStore = !store;
+	const effectiveStore = store ?? (await AuthCredentialStore.open(getAgentDbPath()));
+	try {
+		// 3. OAuth credentials in agent.db (with 5-minute expiry buffer)
+		const expiryBuffer = 5 * 60 * 1000; // 5 minutes
+		const now = Date.now();
+		const credentials = await readAnthropicOAuthCredentials(effectiveStore);
+		for (const credential of credentials) {
+			if (!credential.access) continue;
+			if (credential.expires > now + expiryBuffer) {
+				return {
+					apiKey: credential.access,
+					baseUrl: DEFAULT_BASE_URL,
+					isOAuth: true,
+				};
+			}
+		}
+
+		// 4. API key credentials in agent.db
+		const storedApiKey = effectiveStore.getApiKey("anthropic");
+		if (storedApiKey) {
 			return {
-				apiKey: credential.access,
-				baseUrl: DEFAULT_BASE_URL,
-				isOAuth: true,
+				apiKey: storedApiKey,
+				baseUrl: resolveAnthropicBaseUrlFromEnv() ?? DEFAULT_BASE_URL,
+				isOAuth: isOAuthToken(storedApiKey),
 			};
+		}
+	} finally {
+		if (ownsStore) {
+			effectiveStore.close();
 		}
 	}
 
-	// 4. Generic ANTHROPIC_API_KEY fallback
+	// 5. Generic ANTHROPIC_API_KEY fallback
 	const apiKey = getEnvApiKey("anthropic");
 	const baseUrl = resolveAnthropicBaseUrlFromEnv();
 	if (apiKey) {

--- a/packages/coding-agent/src/web/search/providers/exa.ts
+++ b/packages/coding-agent/src/web/search/providers/exa.ts
@@ -10,6 +10,7 @@ import { getEnvApiKey } from "@oh-my-pi/pi-ai";
 import { callExaTool, findApiKey, isSearchResponse } from "../../../exa/mcp-client";
 import type { SearchResponse, SearchSource } from "../../../web/search/types";
 import { SearchProviderError } from "../../../web/search/types";
+import { settings } from "../../../config/settings";
 import { dateToAgeSeconds } from "../utils";
 import type { SearchParams } from "./base";
 import { SearchProvider } from "./base";
@@ -173,7 +174,14 @@ export class ExaProvider extends SearchProvider {
 	readonly label = "Exa";
 
 	isAvailable(): boolean {
-		return true;
+		try {
+			if (settings.get("exa.enabled") === false || settings.get("exa.enableSearch") === false) {
+				return false;
+			}
+		} catch {
+			// Settings not initialized; fall through to credential check
+		}
+		return !!getEnvApiKey("exa") || !!findApiKey();
 	}
 
 	search(params: SearchParams): Promise<SearchResponse> {


### PR DESCRIPTION
… in DB

findAnthropicAuth() only checked OAuth credentials in agent.db, missing api_key type credentials entirely. Users authenticated via stored API key (not env var, not OAuth) got null from isAvailable(), causing the provider chain to skip Anthropic.

Added tier 4 (api_key in agent.db) between OAuth check and env var fallback. Refactored store lifecycle so tiers 3-4 share one instance.

Also fixed ExaProvider.isAvailable() which unconditionally returned true, ignoring exa.enabled/exa.enableSearch settings and never checking for credentials. It now respects both settings and requires an actual API key.

## What

<!-- Brief description of the change -->

## Why

<!-- Motivation, context, or link to issue (fixes #N) -->

## Testing

<!-- How was this tested? -->

---

- [ ] `bun check` passes
- [ ] Tested locally
- [ ] CHANGELOG updated (if user-facing)
