### PR TITLE
Add PUPPETEER_PROXY and PUPPETEER_PROXY_IGNORE_CERT_ERRORS env vars

### DIFF
--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -527,7 +527,8 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 		if (proxy) {
 			launchArgs.push(`--proxy-server=${proxy}`);
 		}
-		if (process.env.PUPPETEER_PROXY_IGNORE_CERT_ERRORS) {
+		const ignoreCert = process.env.PUPPETEER_PROXY_IGNORE_CERT_ERRORS?.toLowerCase();
+		if (ignoreCert === "true" || ignoreCert === "1" || ignoreCert === "yes" || ignoreCert === "on") {
 			launchArgs.push("--ignore-certificate-errors");
 		}
 		this.#browser = await puppeteer.launch({


### PR DESCRIPTION
Adds two new environment variables to enable a proxy in the puppeteer tool. 

- PUPPETEER_PROXY: routes browser traffic through specified proxy
- PUPPETEER_PROXY_IGNORE_CERT_ERRORS: ignore HTTPS cert errors when set (useful when a Root CA hasn't been installed on the system)
