### PR TITLE
fix(ai): mark qwen models as non-standard for developer role support

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -77,7 +77,7 @@ function serializeToolArguments(value: unknown): string {
 			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
 				return JSON.stringify(parsed);
 			}
-		} catch {}
+		} catch { }
 		return "{}";
 	}
 
@@ -1063,7 +1063,7 @@ function detectStrictModeSupport(provider: string, baseUrl: string): boolean {
  * Provider takes precedence over URL-based detection since it's explicitly configured.
  * Returns a fully resolved OpenAICompat object with all fields set.
  */
-function detectCompat(model: Model<"openai-completions">): ResolvedOpenAICompat {
+export function detectCompat(model: Model<"openai-completions">): ResolvedOpenAICompat {
 	const provider = model.provider;
 	const baseUrl = model.baseUrl;
 
@@ -1071,6 +1071,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAICompat 
 	const isZai = provider === "zai" || baseUrl.includes("api.z.ai");
 	const isOpenRouterKimi = provider === "openrouter" && model.id.includes("moonshotai/kimi");
 	const isAlibaba = provider === "alibaba-coding-plan" || baseUrl.includes("dashscope");
+	const isQwen = model.id.toLowerCase().includes("qwen");
 
 	const isNonStandard =
 		isCerebras ||
@@ -1082,6 +1083,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAICompat 
 		baseUrl.includes("deepseek.com") ||
 		isAlibaba ||
 		isZai ||
+		isQwen ||
 		provider === "opencode-zen" ||
 		provider === "opencode-go" ||
 		baseUrl.includes("opencode.ai");
@@ -1103,7 +1105,7 @@ function detectCompat(model: Model<"openai-completions">): ResolvedOpenAICompat 
 		requiresAssistantAfterToolResult: false, // Mistral no longer requires this as of Dec 2024
 		requiresThinkingAsText: isMistral,
 		requiresMistralToolIds: isMistral,
-		thinkingFormat: isZai ? "zai" : isAlibaba ? "qwen" : "openai",
+		thinkingFormat: isZai ? "zai" : (isAlibaba || isQwen) ? "qwen" : "openai",
 		reasoningContentField: "reasoning_content",
 		requiresReasoningContentForToolCalls: isOpenRouterKimi,
 		requiresAssistantContentForToolCalls: isOpenRouterKimi,

--- a/packages/ai/test/openai-completions-qwen-compat.test.ts
+++ b/packages/ai/test/openai-completions-qwen-compat.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "bun:test";
+import { detectCompat } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import type { Model } from "@oh-my-pi/pi-ai/types";
+
+function createQwenModel(modelId: string, provider: string = "ollama"): Model<"openai-completions"> {
+	return {
+		id: modelId,
+		provider,
+		api: "openai-completions",
+		baseUrl: "http://localhost:11434/v1",
+		input: ["text"],
+		output: ["text"],
+		context: 4096,
+		maxTokens: 4096,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	} as Model<"openai-completions">;
+}
+
+describe("detectCompat - qwen model detection", () => {
+	describe("isNonStandard detection for qwen models", () => {
+		it("detects qwen3.5 models as non-standard (supportsDeveloperRole: false)", () => {
+			const model = createQwenModel("qwen3.5:397b-cloud");
+			const compat = detectCompat(model);
+			expect(compat.supportsDeveloperRole).toBe(false);
+		});
+
+		it("detects qwen2.5-coder models as non-standard", () => {
+			const model = createQwenModel("qwen2.5-coder:7b");
+			const compat = detectCompat(model);
+			expect(compat.supportsDeveloperRole).toBe(false);
+		});
+
+		it("detects qwen3 models as non-standard", () => {
+			const model = createQwenModel("qwen3-235b-a22b");
+			const compat = detectCompat(model);
+			expect(compat.supportsDeveloperRole).toBe(false);
+		});
+
+		it("detects qwen models with different casings", () => {
+			const uppercaseModel = createQwenModel("QWEN3.5:7B");
+			const compatUpper = detectCompat(uppercaseModel);
+			expect(compatUpper.supportsDeveloperRole).toBe(false);
+
+			const mixedCaseModel = createQwenModel("Qwen3-Coder:exacto");
+			const compatMixed = detectCompat(mixedCaseModel);
+			expect(compatMixed.supportsDeveloperRole).toBe(false);
+		});
+
+		it("detects qwen models via openrouter provider", () => {
+			const model = createQwenModel("qwen/qwen3-max-thinking", "openrouter");
+			model.baseUrl = "https://openrouter.ai/api/v1";
+			const compat = detectCompat(model);
+			expect(compat.supportsDeveloperRole).toBe(false);
+		});
+	});
+
+	describe("non-qwen models should not be affected", () => {
+		it("does not mark llama models as qwen", () => {
+			const model = createQwenModel("llama3.2:3b");
+			const compat = detectCompat(model);
+			// llama models via ollama should use standard OpenAI behavior
+			// supportsDeveloperRole should be true for standard OpenAI-compatible providers
+			expect(compat.supportsDeveloperRole).toBe(true);
+		});
+
+		it("does not mark glm models as qwen", () => {
+			const model = createQwenModel("glm-4.7", "zai");
+			model.baseUrl = "https://api.z.ai/v1";
+			const compat = detectCompat(model);
+			// GLM via Zai has its own detection via isZai
+			expect(compat.supportsDeveloperRole).toBe(false); // Zai is also non-standard
+		});
+	});
+
+	describe("thinkingFormat for qwen models", () => {
+		it("sets thinkingFormat to 'qwen' for qwen models", () => {
+			const model = createQwenModel("qwen3.5:397b-cloud");
+			const compat = detectCompat(model);
+			expect(compat.thinkingFormat).toBe("qwen");
+		});
+
+		it("sets thinkingFormat to 'qwen' for qwen models via other providers", () => {
+			const model = createQwenModel("qwen/qwen2.5-coder-32b", "openrouter");
+			model.baseUrl = "https://openrouter.ai/api/v1";
+			const compat = detectCompat(model);
+			expect(compat.thinkingFormat).toBe("qwen");
+		});
+	});
+
+	describe("existing non-standard providers remain unaffected", () => {
+		it("still marks cerebras as non-standard", () => {
+			const model: Model<"openai-completions"> = {
+				id: "llama-3.3-70b",
+				provider: "cerebras",
+				api: "openai-completions",
+				baseUrl: "https://api.cerebras.ai/v1",
+				input: ["text"],
+				output: ["text"],
+				context: 8192,
+				maxTokens: 8192,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			} as Model<"openai-completions">;
+			const compat = detectCompat(model);
+			expect(compat.supportsDeveloperRole).toBe(false);
+		});
+
+		it("still marks mistral as non-standard", () => {
+			const model: Model<"openai-completions"> = {
+				id: "mistral-large",
+				provider: "mistral",
+				api: "openai-completions",
+				baseUrl: "https://api.mistral.ai/v1",
+				input: ["text"],
+				output: ["text"],
+				context: 32768,
+				maxTokens: 32768,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			} as Model<"openai-completions">;
+			const compat = detectCompat(model);
+			expect(compat.supportsDeveloperRole).toBe(false);
+		});
+
+		it("still marks deepseek as non-standard", () => {
+			const model: Model<"openai-completions"> = {
+				id: "deepseek-chat",
+				provider: "openai-compat",
+				api: "openai-completions",
+				baseUrl: "https://api.deepseek.com/v1",
+				input: ["text"],
+				output: ["text"],
+				context: 65536,
+				maxTokens: 8192,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			} as Model<"openai-completions">;
+			const compat = detectCompat(model);
+			expect(compat.supportsDeveloperRole).toBe(false);
+		});
+	});
+});


### PR DESCRIPTION
## Problem
When using qwen3.5 models (like `ollama/qwen3.5:397b-cloud`) through the openai-completions provider, the code attempted to use the `developer` role in messages, which qwen models don't support. This caused a "developer role is not valid" error.

## Solution
- Added qwen model detection via `model.id.toLowerCase().includes("qwen")`
- Set `supportsDeveloperRole: false` for qwen models (prevents the developer role error)
- Set `thinkingFormat: "qwen"` for correct reasoning mode handling
- Exported `detectCompat` function for testing
- Added comprehensive tests for qwen model detection

## Models Affected
- `qwen3.5:397b-cloud`
- `qwen2.5-coder`
- `qwen3-coder`
- Any model with "qwen" in the ID (case-insensitive)

## Testing
- 12 new tests added for qwen model detection
- All existing tests pass