### PR TITLE
fix(ai): Bedrock thinking signature and tool_choice errors

### DIFF
--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -121,13 +121,25 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 
 			const cacheRetention = resolveCacheRetention(options.cacheRetention);
 
+			const toolConfig = convertToolConfig(context.tools, options.toolChoice);
+			let additionalModelRequestFields = buildAdditionalModelRequestFields(model, options);
+
+			// Bedrock rejects thinking + forced tool_choice ("any" or specific tool).
+			// When tool_choice forces tool use, disable thinking to avoid API errors.
+			if (toolConfig?.toolChoice && additionalModelRequestFields) {
+				const tc = toolConfig.toolChoice;
+				if ("any" in tc || "tool" in tc) {
+					additionalModelRequestFields = undefined;
+				}
+			}
+
 			const commandInput = {
 				modelId: model.id,
 				messages: convertMessages(context, model, cacheRetention),
 				system: buildSystemPrompt(context.systemPrompt, model, cacheRetention),
 				inferenceConfig: { maxTokens: options.maxTokens, temperature: options.temperature, topP: options.topP },
-				toolConfig: convertToolConfig(context.tools, options.toolChoice),
-				additionalModelRequestFields: buildAdditionalModelRequestFields(model, options),
+				toolConfig,
+				additionalModelRequestFields,
 			};
 			options?.onPayload?.(commandInput);
 			rawRequestDump = {
@@ -191,11 +203,28 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 				delete (block as Block).partialJson;
 			}
 			output.stopReason = options.signal?.aborted ? "aborted" : "error";
-			output.errorMessage = await appendRawHttpRequestDumpFor400(
-				error instanceof Error ? error.message : JSON.stringify(error),
-				error,
-				rawRequestDump,
-			);
+			const baseMessage = error instanceof Error ? error.message : JSON.stringify(error);
+			// Enrich error with thinking block diagnostics for signature-related failures
+			let diagnostics = "";
+			if (baseMessage.includes("signature") || baseMessage.includes("thinking")) {
+				const thinkingBlocks = context.messages
+					.filter((m): m is AssistantMessage => m.role === "assistant")
+					.flatMap((m, mi) =>
+						m.content
+							.filter(b => b.type === "thinking")
+							.map((b, bi) => ({
+								msg: mi,
+								block: bi,
+								stop: m.stopReason,
+								sigLen: b.thinkingSignature?.length ?? -1,
+								thinkLen: b.thinking.length,
+							})),
+					);
+				if (thinkingBlocks.length > 0) {
+					diagnostics = `\n[thinking-diag] ${JSON.stringify(thinkingBlocks)}`;
+				}
+			}
+			output.errorMessage = await appendRawHttpRequestDumpFor400(baseMessage + diagnostics, error, rawRequestDump);
 			output.duration = Date.now() - startTime;
 			if (firstTokenTime) output.ttft = firstTokenTime - startTime;
 			stream.push({ type: "error", reason: output.stopReason, error: output });
@@ -448,21 +477,25 @@ function convertMessages(
 						case "thinking":
 							// Skip empty thinking blocks
 							if (c.thinking.trim().length === 0) continue;
-							// Only Anthropic models support the signature field in reasoningText.
-							// For other models, we omit the signature to avoid errors like:
-							// "This model doesn't support the reasoningContent.reasoningText.signature field"
-							if (supportsThinkingSignature(model)) {
+							// Thinking blocks require a valid signature when sent as reasoningContent.
+							// If the signature is missing (e.g., from an aborted stream), or the model
+							// doesn't support signatures, convert to plain text instead.
+							if (supportsThinkingSignature(model) && c.thinkingSignature) {
 								contentBlocks.push({
 									reasoningContent: {
 										reasoningText: { text: c.thinking.toWellFormed(), signature: c.thinkingSignature },
 									},
 								});
-							} else {
+							} else if (!supportsThinkingSignature(model)) {
+								// Model doesn't support signatures at all — send as unsigned reasoning
 								contentBlocks.push({
 									reasoningContent: {
 										reasoningText: { text: c.thinking.toWellFormed() },
 									},
 								});
+							} else {
+								// Model requires signature but we don't have one — demote to text
+								contentBlocks.push({ text: `[Thinking]: ${c.thinking.toWellFormed()}` });
 							}
 							break;
 						default:

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -55,19 +55,26 @@ export function transformMessages<TApi extends Api>(
 				index === latestAssistantIndex &&
 				model.api === "anthropic-messages" &&
 				assistantMsg.api === "anthropic-messages";
+			// Aborted/errored messages may have partially-streamed thinking signatures.
+			// A partial signature is invalid and will be rejected by the API, so we must
+			// strip signatures from thinking blocks in these messages.
+			const hasInvalidSignatures = assistantMsg.stopReason === "aborted" || assistantMsg.stopReason === "error";
 
 			const transformedContent = assistantMsg.content.flatMap(block => {
 				if (block.type === "thinking") {
-					if (mustPreserveLatestAnthropicThinking) return block;
+					// Strip signature from aborted/errored messages — it's likely incomplete
+					const sanitized =
+						hasInvalidSignatures && block.thinkingSignature ? { ...block, thinkingSignature: undefined } : block;
+					if (mustPreserveLatestAnthropicThinking) return sanitized;
 					// For same model: keep thinking blocks with signatures (needed for replay)
 					// even if the thinking text is empty (OpenAI encrypted reasoning)
-					if (isSameModel && block.thinkingSignature) return block;
+					if (isSameModel && sanitized.thinkingSignature) return sanitized;
 					// Skip empty thinking blocks, convert others to plain text
-					if (!block.thinking || block.thinking.trim() === "") return [];
-					if (isSameModel) return block;
+					if (!sanitized.thinking || sanitized.thinking.trim() === "") return [];
+					if (isSameModel) return sanitized;
 					return {
 						type: "text" as const,
-						text: block.thinking,
+						text: sanitized.thinking,
 					};
 				}
 

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -897,6 +897,11 @@ async function truncateForPersistence<T>(obj: T, blobStore: BlobStore, key?: str
 
 	if (typeof obj === "string") {
 		if (obj.length > MAX_PERSIST_CHARS) {
+			// Cryptographic signatures must be preserved exactly or cleared entirely — never truncated.
+			// Truncation would produce an invalid signature that the API rejects.
+			if (key === "thinkingSignature" || key === "thoughtSignature" || key === "textSignature") {
+				return "" as T;
+			}
 			const limit = Math.max(0, MAX_PERSIST_CHARS - TRUNCATION_NOTICE.length);
 			return `${truncateString(obj, limit)}${TRUNCATION_NOTICE}` as T;
 		}


### PR DESCRIPTION
## What

Three Bedrock-specific fixes for errors that surface after aborting/interrupting the model:

1. **`Invalid signature in thinking block`** — Aborted streams leave thinking blocks with empty/partial cryptographic signatures. `transformMessages()` now strips signatures from aborted/errored messages so they are treated as unsigned (converted to text by the serializer).

2. **`signature: Field required`** — The Bedrock serializer was sending `reasoningContent` blocks without a `signature` field when the signature was missing. The API requires this field on all reasoning blocks. Now demotes unsigned thinking to plain text instead.

3. **`Thinking may not be enabled when tool_choice forces tool use`** — The Anthropic provider had `disableThinkingIfToolChoiceForced()` but the Bedrock provider had no equivalent. This surfaces when `ast_edit`/`resolve` previews force tool_choice while thinking is enabled.

Also adds thinking block diagnostics to Bedrock error messages (message index, stop reason, signature length) for easier debugging of future signature-related issues.

Also protects `truncateForPersistence` from corrupting signatures — clears them entirely instead of truncating, since a partial signature is always invalid.

## Why

These are Bedrock-only gaps. The direct Anthropic provider likely already handled all three cases. Users on Bedrock hit these after interrupting the model mid-response, especially in sessions with compaction.

## Testing

Stress-tested by repeatedly interrupting the model mid-thinking-stream across multiple turns. Verified no signature errors on subsequent API calls. Confirmed via session JSONL files that aborted messages with `thinkingSignature: ""` are properly handled.

---

- [x] `bun check` passes
- [x] Tested locally