### PR TITLE
fix(model-registry): remove hardcoded gpt-5.4 context window override

### DIFF
--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -568,7 +568,7 @@ export class ModelRegistry {
 		const builtInModels = this.#loadBuiltInModels(overrides, modelOverrides);
 		const combined = this.#mergeCustomModels(builtInModels, customModels);
 
-		this.#models = this.#applyHardcodedModelPolicies(combined);
+		this.#models = combined;
 	}
 
 	/** Load built-in models, applying provider and per-model overrides */
@@ -747,7 +747,7 @@ export class ModelRegistry {
 					: model;
 			}),
 		);
-		this.#models = this.#applyHardcodedModelPolicies(this.#applyModelOverrides(merged, this.#modelOverrides));
+		this.#models = this.#applyModelOverrides(merged, this.#modelOverrides);
 	}
 
 	async #discoverProviderModels(providerConfig: DiscoveryProviderConfig): Promise<Model<Api>[]> {
@@ -1066,16 +1066,6 @@ export class ModelRegistry {
 			return applyModelOverride(model, override);
 		});
 	}
-
-	#applyHardcodedModelPolicies(models: Model<Api>[]): Model<Api>[] {
-		return models.map(model => {
-			if (model.id === "gpt-5.4") {
-				return { ...model, contextWindow: 1_000_000 };
-			}
-			return model;
-		});
-	}
-
 	#parseModels(config: ModelsConfig): Model<Api>[] {
 		const models: Model<Api>[] = [];
 


### PR DESCRIPTION
Fixes #332

## Root cause

`#applyHardcodedModelPolicies` forced `contextWindow = 1_000_000` on any model with `id === "gpt-5.4"` regardless of provider. It was called twice — after static load and after runtime discovery — reliably clobbering the correct provider-specific value both times.

Effect on every affected provider:

| Provider | Bundled | After policy | Should be |
|---|---|---|---|
| `github-copilot` | 400,000 | 1,000,000 | ~274,432 (from live discovery) |
| `openai` | 1,050,000 | 1,000,000 | 1,050,000 |
| `openai-codex` | 1,050,000 | 1,000,000 | 1,050,000 |
| `opencode` | 1,050,000 | 1,000,000 | 1,050,000 |
| `opencode-zen` | 1,050,000 | 1,000,000 | 1,050,000 |

No documented rationale exists for the override. The `models.json` bundled values are already correct.

## Fix

Delete `#applyHardcodedModelPolicies` and simplify its two call sites. After this change, `github-copilot/gpt-5.4` shows 400,000 (bundled) until live discovery runs, then whatever Copilot's `/models` endpoint reports via `capabilities.limits.*` — matching the existing behavior of `gpt-5.3-codex`.