### PR TITLE
fix(coding-agent): scope Responses history replay by provider

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -28,7 +28,12 @@ import type {
 	ToolCall,
 	ToolChoice,
 } from "../types";
-import { normalizeResponsesToolCallId } from "../utils";
+import {
+	createOpenAIResponsesHistoryPayload,
+	getOpenAIResponsesHistoryItems,
+	getOpenAIResponsesHistoryPayload,
+	normalizeResponsesToolCallId,
+} from "../utils";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
 import { parseStreamingJson } from "../utils/json-parse";
@@ -901,11 +906,7 @@ export const streamOpenAICodexResponses: StreamFunction<"openai-codex-responses"
 				throw new Error("Codex response failed");
 			}
 
-			output.providerPayload = {
-				type: "openaiResponsesHistory",
-				dt: true,
-				items: nativeOutputItems,
-			};
+			output.providerPayload = createOpenAIResponsesHistoryPayload(model.provider, nativeOutputItems);
 
 			output.duration = Date.now() - startTime;
 			if (firstTokenTime) output.ttft = firstTokenTime - startTime;
@@ -1603,15 +1604,6 @@ function getAccountId(accessToken: string): string {
 	return accountId;
 }
 
-function getOpenAIResponsesHistoryItems(
-	providerPayload: { type?: string; items?: unknown } | undefined,
-): ResponseInput | undefined {
-	if (providerPayload?.type !== "openaiResponsesHistory" || !Array.isArray(providerPayload.items)) {
-		return undefined;
-	}
-	return providerPayload.items as ResponseInput;
-}
-
 function convertMessages(model: Model<"openai-codex-responses">, context: Context): ResponseInput {
 	const messages: ResponseInput = [];
 
@@ -1636,8 +1628,10 @@ function convertMessages(model: Model<"openai-codex-responses">, context: Contex
 	let msgIndex = 0;
 	for (const msg of transformedMessages) {
 		if (msg.role === "user") {
-			const providerPayload = (msg as { providerPayload?: { type?: string; items?: unknown } }).providerPayload;
-			const historyItems = getOpenAIResponsesHistoryItems(providerPayload);
+			const providerPayload = (msg as { providerPayload?: AssistantMessage["providerPayload"] }).providerPayload;
+			const historyItems = getOpenAIResponsesHistoryItems(providerPayload, model.provider) as
+				| Array<ResponseInput[number]>
+				| undefined;
 			if (historyItems) {
 				messages.push(...historyItems);
 				msgIndex++;
@@ -1681,8 +1675,10 @@ function convertMessages(model: Model<"openai-codex-responses">, context: Contex
 				});
 			}
 		} else if (msg.role === "developer") {
-			const providerPayload = (msg as { providerPayload?: { type?: string; items?: unknown } }).providerPayload;
-			const historyItems = getOpenAIResponsesHistoryItems(providerPayload);
+			const providerPayload = (msg as { providerPayload?: AssistantMessage["providerPayload"] }).providerPayload;
+			const historyItems = getOpenAIResponsesHistoryItems(providerPayload, model.provider) as
+				| Array<ResponseInput[number]>
+				| undefined;
 			if (historyItems) {
 				messages.push(...historyItems);
 				msgIndex++;
@@ -1724,9 +1720,13 @@ function convertMessages(model: Model<"openai-codex-responses">, context: Contex
 				});
 			}
 		} else if (msg.role === "assistant") {
-			const providerPayload = (msg as { providerPayload?: { type?: string; dt?: boolean; items?: unknown } })
-				.providerPayload;
-			const historyItems = getOpenAIResponsesHistoryItems(providerPayload);
+			const assistantMsg = msg as AssistantMessage;
+			const providerPayload = getOpenAIResponsesHistoryPayload(
+				assistantMsg.providerPayload,
+				model.provider,
+				assistantMsg.provider,
+			);
+			const historyItems = providerPayload?.items as Array<ResponseInput[number]> | undefined;
 			if (historyItems) {
 				if (providerPayload?.dt) {
 					messages.push(...historyItems);

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -29,7 +29,13 @@ import type {
 	ToolCall,
 	ToolChoice,
 } from "../types";
-import { normalizeResponsesToolCallId, resolveCacheRetention } from "../utils";
+import {
+	createOpenAIResponsesHistoryPayload,
+	getOpenAIResponsesHistoryItems,
+	getOpenAIResponsesHistoryPayload,
+	normalizeResponsesToolCallId,
+	resolveCacheRetention,
+} from "../utils";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
 import { parseStreamingJson } from "../utils/json-parse";
@@ -368,11 +374,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 				throw new Error("An unknown error occurred");
 			}
 
-			output.providerPayload = {
-				type: "openaiResponsesHistory",
-				dt: true,
-				items: nativeOutputItems,
-			};
+			output.providerPayload = createOpenAIResponsesHistoryPayload(model.provider, nativeOutputItems);
 
 			output.duration = Date.now() - startTime;
 			if (firstTokenTime) output.ttft = firstTokenTime - startTime;
@@ -544,15 +546,6 @@ function supportsStrictMode(model: Model<"openai-responses">): boolean {
 	);
 }
 
-function getOpenAIResponsesHistoryItems(
-	providerPayload: { type?: string; items?: unknown } | undefined,
-): ResponseInput | undefined {
-	if (providerPayload?.type !== "openaiResponsesHistory" || !Array.isArray(providerPayload.items)) {
-		return undefined;
-	}
-	return providerPayload.items as ResponseInput;
-}
-
 function collectKnownCallIds(messages: ResponseInput): Set<string> {
 	const knownCallIds = new Set<string>();
 	for (const item of messages) {
@@ -592,8 +585,10 @@ function convertConversationMessages(
 	let msgIndex = 0;
 	for (const msg of transformedMessages) {
 		if (msg.role === "user" || msg.role === "developer") {
-			const providerPayload = (msg as { providerPayload?: { type?: string; items?: unknown } }).providerPayload;
-			const historyItems = getOpenAIResponsesHistoryItems(providerPayload);
+			const providerPayload = (msg as { providerPayload?: AssistantMessage["providerPayload"] }).providerPayload;
+			const historyItems = getOpenAIResponsesHistoryItems(providerPayload, model.provider) as
+				| Array<ResponseInput[number]>
+				| undefined;
 			if (historyItems) {
 				messages.push(...historyItems);
 				knownCallIds = collectKnownCallIds(messages);
@@ -638,9 +633,13 @@ function convertConversationMessages(
 				});
 			}
 		} else if (msg.role === "assistant") {
-			const providerPayload = (msg as { providerPayload?: { type?: string; dt?: boolean; items?: unknown } })
-				.providerPayload;
-			const historyItems = getOpenAIResponsesHistoryItems(providerPayload);
+			const assistantMsg = msg as AssistantMessage;
+			const providerPayload = getOpenAIResponsesHistoryPayload(
+				assistantMsg.providerPayload,
+				model.provider,
+				assistantMsg.provider,
+			);
+			const historyItems = providerPayload?.items as Array<ResponseInput[number]> | undefined;
 			if (historyItems) {
 				if (providerPayload?.dt) {
 					messages.push(...historyItems);
@@ -653,7 +652,6 @@ function convertConversationMessages(
 			}
 
 			const output: ResponseInput = [];
-			const assistantMsg = msg as AssistantMessage;
 
 			// Check if this message is from a different model (same provider, different model ID).
 			// For such messages, tool call IDs with fc_ prefix need to be stripped to avoid

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -289,6 +289,7 @@ export type StopReason = "stop" | "length" | "toolUse" | "error" | "aborted";
 
 export interface OpenAIResponsesHistoryPayload {
 	type: "openaiResponsesHistory";
+	provider?: string;
 	dt?: boolean;
 	items: Array<Record<string, unknown>>;
 }

--- a/packages/ai/src/utils.ts
+++ b/packages/ai/src/utils.ts
@@ -1,5 +1,5 @@
 import { $env } from "@oh-my-pi/pi-utils";
-import type { CacheRetention } from "./types";
+import type { CacheRetention, OpenAIResponsesHistoryPayload, ProviderPayload } from "./types";
 
 export { isRecord } from "@oh-my-pi/pi-utils";
 
@@ -60,6 +60,42 @@ function normalizeResponsesItemId(itemId: string): string {
 export function truncateResponseItemId(id: string, prefix: string): string {
 	if (id.length <= 64) return id;
 	return `${prefix}_${Bun.hash.xxHash64(id).toString(36)}`;
+}
+
+export function createOpenAIResponsesHistoryPayload(
+	provider: string,
+	items: Array<Record<string, unknown>>,
+	incremental = true,
+): OpenAIResponsesHistoryPayload {
+	return {
+		type: "openaiResponsesHistory",
+		provider,
+		...(incremental ? { dt: true } : {}),
+		items,
+	};
+}
+
+export function getOpenAIResponsesHistoryPayload(
+	providerPayload: ProviderPayload | undefined,
+	currentProvider: string,
+	fallbackProvider?: string,
+): OpenAIResponsesHistoryPayload | undefined {
+	if (providerPayload?.type !== "openaiResponsesHistory" || !Array.isArray(providerPayload.items)) {
+		return undefined;
+	}
+	const payloadProvider = providerPayload.provider ?? fallbackProvider;
+	if (!payloadProvider || payloadProvider !== currentProvider) {
+		return undefined;
+	}
+	return { ...providerPayload, provider: payloadProvider };
+}
+
+export function getOpenAIResponsesHistoryItems(
+	providerPayload: ProviderPayload | undefined,
+	currentProvider: string,
+	fallbackProvider?: string,
+): Array<Record<string, unknown>> | undefined {
+	return getOpenAIResponsesHistoryPayload(providerPayload, currentProvider, fallbackProvider)?.items;
 }
 
 /**

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -3,6 +3,7 @@ import { getBundledModel } from "@oh-my-pi/pi-ai/models";
 import { streamOpenAICodexResponses } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import { streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
 import type { Context, Model } from "@oh-my-pi/pi-ai/types";
+import { createOpenAIResponsesHistoryPayload } from "../src/utils";
 
 function createAbortedSignal(): AbortSignal {
 	const controller = new AbortController();
@@ -33,7 +34,7 @@ const preservedHistoryContext: Context = {
 		{
 			role: "user",
 			content: "summary that should be ignored",
-			providerPayload: { type: "openaiResponsesHistory", items: preservedHistoryItems },
+			providerPayload: createOpenAIResponsesHistoryPayload("openai", preservedHistoryItems, false),
 			timestamp: Date.now(),
 		},
 	],
@@ -42,23 +43,29 @@ const preservedHistoryContext: Context = {
 const assistantSnapshotContext: Context = {
 	messages: [
 		{ role: "user", content: "generic history that should be replaced", timestamp: Date.now() },
+		makeAssistantMessage(snapshotHistoryItems),
+		{ role: "user", content: "follow-up user", timestamp: Date.now() },
+	],
+};
+
+const codexAssistantSnapshotContext: Context = {
+	messages: [
+		{ role: "user", content: "generic history that should be replaced", timestamp: Date.now() },
+		makeAssistantMessage(snapshotHistoryItems, false, "openai-codex", "gpt-5.2-codex"),
+		{ role: "user", content: "follow-up user", timestamp: Date.now() },
+	],
+};
+
+const codexToCopilotContext: Context = {
+	messages: [
+		{ role: "user", content: "generic user before switch", timestamp: Date.now() },
 		{
-			role: "assistant",
-			content: [{ type: "text", text: "generic assistant that should be replaced" }],
-			api: "openai-responses",
-			provider: "openai",
-			model: "gpt-5-mini",
-			usage: {
-				input: 0,
-				output: 0,
-				cacheRead: 0,
-				cacheWrite: 0,
-				totalTokens: 0,
-				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-			},
-			stopReason: "stop",
-			providerPayload: { type: "openaiResponsesHistory", items: snapshotHistoryItems },
-			timestamp: Date.now(),
+			...makeAssistantMessage([], false, "openai-codex", "gpt-5.2-codex"),
+			content: [{ type: "text", text: "generic assistant that should be rebuilt" }],
+			providerPayload: createOpenAIResponsesHistoryPayload("openai-codex", [
+				{ type: "reasoning", encrypted_content: "enc_123" },
+				...snapshotHistoryItems,
+			]),
 		},
 		{ role: "user", content: "follow-up user", timestamp: Date.now() },
 	],
@@ -104,13 +111,18 @@ const incrementalItems2 = [
 	},
 ];
 
-function makeAssistantMessage(items: Record<string, unknown>[], incremental?: boolean) {
+function makeAssistantMessage(
+	items: Record<string, unknown>[],
+	incremental = false,
+	provider: "openai" | "openai-codex" = "openai",
+	model = provider === "openai" ? "gpt-5-mini" : "gpt-5.2-codex",
+) {
 	return {
 		role: "assistant" as const,
 		content: [{ type: "text" as const, text: "ignored" }],
-		api: "openai-responses" as const,
-		provider: "openai" as const,
-		model: "gpt-5-mini",
+		api: provider === "openai" ? ("openai-responses" as const) : ("openai-codex-responses" as const),
+		provider,
+		model,
 		usage: {
 			input: 0,
 			output: 0,
@@ -120,11 +132,7 @@ function makeAssistantMessage(items: Record<string, unknown>[], incremental?: bo
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		},
 		stopReason: "stop" as const,
-		providerPayload: {
-			type: "openaiResponsesHistory" as const,
-			...(incremental ? { dt: true } : {}),
-			items,
-		},
+		providerPayload: createOpenAIResponsesHistoryPayload(provider, items, incremental),
 		timestamp: Date.now(),
 	};
 }
@@ -138,6 +146,28 @@ const incrementalContext: Context = {
 		{ role: "user", content: "third question", timestamp: Date.now() },
 	],
 };
+
+function containsAssistantOutputText(input: unknown[] | undefined, text: string): boolean {
+	return (input ?? []).some(item => {
+		if (!item || typeof item !== "object") return false;
+		const candidate = item as { type?: unknown; role?: unknown; content?: unknown };
+		if (candidate.type !== "message" || candidate.role !== "assistant" || !Array.isArray(candidate.content))
+			return false;
+		return candidate.content.some(part => {
+			if (!part || typeof part !== "object") return false;
+			const content = part as { type?: unknown; text?: unknown };
+			return content.type === "output_text" && content.text === text;
+		});
+	});
+}
+
+function containsEncryptedReasoning(input: unknown[] | undefined): boolean {
+	return (input ?? []).some(item => {
+		if (!item || typeof item !== "object") return false;
+		const candidate = item as { encrypted_content?: unknown };
+		return typeof candidate.encrypted_content === "string";
+	});
+}
 
 describe("OpenAI responses history payload", () => {
 	it("inlines preserved replacement history for openai-responses", async () => {
@@ -157,11 +187,18 @@ describe("OpenAI responses history payload", () => {
 
 	it("prefers assistant native history snapshots for openai-codex-responses", async () => {
 		const model = getBundledModel("openai-codex", "gpt-5.2-codex") as Model<"openai-codex-responses">;
-		const payload = (await captureCodexPayload(model, assistantSnapshotContext)) as { input?: unknown[] };
+		const payload = (await captureCodexPayload(model, codexAssistantSnapshotContext)) as { input?: unknown[] };
 		expect(payload.input).toEqual([
 			...snapshotHistoryItems,
 			{ role: "user", content: [{ type: "input_text", text: "follow-up user" }] },
 		]);
+	});
+
+	it("ignores incompatible native history snapshots across providers", async () => {
+		const model = getBundledModel("github-copilot", "gpt-5.4") as Model<"openai-responses">;
+		const payload = (await captureResponsesPayload(model, codexToCopilotContext)) as { input?: unknown[] };
+		expect(containsEncryptedReasoning(payload.input)).toBe(false);
+		expect(containsAssistantOutputText(payload.input, "generic assistant that should be rebuilt")).toBe(true);
 	});
 
 	it("builds up history incrementally from multiple assistant messages", async () => {
@@ -176,7 +213,7 @@ describe("OpenAI responses history payload", () => {
 		]);
 	});
 
-	it("backward compat: old full-snapshot payloads still replace history", async () => {
+	it("backward compat: old full-snapshot payloads still replace history for legacy same-provider assistant turns", async () => {
 		const fullSnapshotItems = [
 			{ type: "message", role: "user", content: [{ type: "input_text", text: "Canonical user" }] },
 			{ type: "message", role: "assistant", content: [{ type: "output_text", text: "Canonical assistant" }] },
@@ -186,14 +223,13 @@ describe("OpenAI responses history payload", () => {
 				{ role: "user", content: "old user message that gets replaced", timestamp: Date.now() },
 				{
 					...makeAssistantMessage(fullSnapshotItems, false),
-					// no incremental flag — old format
+					providerPayload: { type: "openaiResponsesHistory", items: fullSnapshotItems },
 				},
 				{ role: "user", content: "follow-up", timestamp: Date.now() },
 			],
 		};
 		const model = getBundledModel("openai", "gpt-5-mini") as Model<"openai-responses">;
 		const payload = (await captureResponsesPayload(model, context)) as { input?: unknown[] };
-		// Old full-snapshot should replace all prior history
 		expect(payload.input).toEqual([
 			...fullSnapshotItems,
 			{ role: "user", content: [{ type: "input_text", text: "follow-up" }] },

--- a/packages/coding-agent/src/session/compaction/compaction.ts
+++ b/packages/coding-agent/src/session/compaction/compaction.ts
@@ -13,7 +13,11 @@ import {
 	OPENAI_HEADERS,
 } from "@oh-my-pi/pi-ai/providers/openai-codex/constants";
 import { transformMessages } from "@oh-my-pi/pi-ai/providers/transform-messages";
-import { normalizeResponsesToolCallId } from "@oh-my-pi/pi-ai/utils";
+import {
+	getOpenAIResponsesHistoryItems,
+	getOpenAIResponsesHistoryPayload,
+	normalizeResponsesToolCallId,
+} from "@oh-my-pi/pi-ai/utils";
 import { logger } from "@oh-my-pi/pi-utils";
 import { renderPromptTemplate } from "../../config/prompt-templates";
 import compactionShortSummaryPrompt from "../../prompts/compaction/compaction-short-summary.md" with { type: "text" };
@@ -473,6 +477,7 @@ type OpenAiRemoteCompactionItem = {
 };
 
 interface OpenAiRemoteCompactionPreserveData {
+	provider?: string;
 	replacementHistory: Array<Record<string, unknown>>;
 	compactionItem: OpenAiRemoteCompactionItem;
 }
@@ -523,7 +528,7 @@ function getPreservedOpenAiRemoteCompactionData(
 ): OpenAiRemoteCompactionPreserveData | undefined {
 	const candidate = preserveData?.[OPENAI_REMOTE_COMPACTION_PRESERVE_KEY];
 	if (!candidate || typeof candidate !== "object") return undefined;
-	const maybeData = candidate as { replacementHistory?: unknown; compactionItem?: unknown };
+	const maybeData = candidate as { provider?: unknown; replacementHistory?: unknown; compactionItem?: unknown };
 	if (!Array.isArray(maybeData.replacementHistory)) return undefined;
 	const maybeItem = maybeData.compactionItem;
 	if (!maybeItem || typeof maybeItem !== "object") return undefined;
@@ -535,6 +540,7 @@ function getPreservedOpenAiRemoteCompactionData(
 		return undefined;
 	}
 	return {
+		provider: typeof maybeData.provider === "string" ? maybeData.provider : undefined,
 		replacementHistory: maybeData.replacementHistory as Array<Record<string, unknown>>,
 		compactionItem: compactionItem as unknown as OpenAiRemoteCompactionItem,
 	};
@@ -634,15 +640,6 @@ function trimOpenAiCompactInput(
 	return trimmed;
 }
 
-function getOpenAIResponsesHistoryItems(
-	providerPayload: { type?: string; items?: unknown } | undefined,
-): Array<Record<string, unknown>> | undefined {
-	if (providerPayload?.type !== "openaiResponsesHistory" || !Array.isArray(providerPayload.items)) {
-		return undefined;
-	}
-	return providerPayload.items as Array<Record<string, unknown>>;
-}
-
 function collectKnownOpenAiCallIds(items: Array<Record<string, unknown>>): Set<string> {
 	const knownCallIds = new Set<string>();
 	for (const item of items) {
@@ -667,8 +664,8 @@ function buildOpenAiNativeHistory(
 	let knownCallIds = collectKnownOpenAiCallIds(input);
 	for (const message of transformedMessages) {
 		if (message.role === "user" || message.role === "developer") {
-			const providerPayload = (message as { providerPayload?: { type?: string; items?: unknown } }).providerPayload;
-			const historyItems = getOpenAIResponsesHistoryItems(providerPayload);
+			const providerPayload = (message as { providerPayload?: AssistantMessage["providerPayload"] }).providerPayload;
+			const historyItems = getOpenAIResponsesHistoryItems(providerPayload, model.provider);
 			if (historyItems) {
 				input.push(...historyItems);
 				knownCallIds = collectKnownOpenAiCallIds(input);
@@ -705,22 +702,22 @@ function buildOpenAiNativeHistory(
 		}
 
 		if (message.role === "assistant") {
-			const providerPayload = (
-				message as { providerPayload?: { type?: string; incremental?: boolean; items?: unknown } }
-			).providerPayload;
-			const historyItems = getOpenAIResponsesHistoryItems(providerPayload);
-			if (historyItems) {
-				if (providerPayload?.incremental) {
-					input.push(...historyItems);
+			const assistant = message as AssistantMessage;
+			const providerPayload = getOpenAIResponsesHistoryPayload(
+				assistant.providerPayload,
+				model.provider,
+				assistant.provider,
+			);
+			if (providerPayload) {
+				if (providerPayload.dt) {
+					input.push(...providerPayload.items);
 				} else {
-					input.splice(0, input.length, ...historyItems);
+					input.splice(0, input.length, ...providerPayload.items);
 				}
 				knownCallIds = collectKnownOpenAiCallIds(input);
 				msgIndex++;
 				continue;
 			}
-
-			const assistant = message as AssistantMessage;
 			const isDifferentModel =
 				assistant.model !== model.id && assistant.provider === model.provider && assistant.api === model.api;
 
@@ -889,7 +886,7 @@ async function requestOpenAiRemoteCompaction(
 		});
 		throw new Error("Remote compaction response missing compaction item");
 	}
-	return { replacementHistory, compactionItem };
+	return { provider: model.provider, replacementHistory, compactionItem };
 }
 
 interface RemoteCompactionRequest {
@@ -1224,11 +1221,11 @@ export async function compact(
 	if (settings.remoteEnabled !== false && shouldUseOpenAiRemoteCompaction(model)) {
 		const previousRemoteCompaction = getPreservedOpenAiRemoteCompactionData(previousPreserveData);
 		const remoteMessages = [...messagesToSummarize, ...turnPrefixMessages, ...recentMessages];
-		const remoteHistory = buildOpenAiNativeHistory(
-			remoteMessages,
-			model,
-			previousRemoteCompaction?.replacementHistory,
-		);
+		const previousReplacementHistory =
+			previousRemoteCompaction?.provider === model.provider
+				? previousRemoteCompaction.replacementHistory
+				: undefined;
+		const remoteHistory = buildOpenAiNativeHistory(remoteMessages, model, previousReplacementHistory);
 		if (remoteHistory.length > 0) {
 			try {
 				const remote = await requestOpenAiRemoteCompaction(

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -532,16 +532,19 @@ export function buildSessionContext(
 	};
 
 	if (compaction) {
-		const remoteReplacementHistory = (() => {
+		const providerPayload: ProviderPayload | undefined = (() => {
 			const candidate = compaction.preserveData?.openaiRemoteCompaction;
 			if (!candidate || typeof candidate !== "object") return undefined;
-			const replacementHistory = (candidate as { replacementHistory?: unknown }).replacementHistory;
-			if (!Array.isArray(replacementHistory)) return undefined;
-			return replacementHistory as Array<Record<string, unknown>>;
+			const remote = candidate as { provider?: unknown; replacementHistory?: unknown };
+			if (typeof remote.provider !== "string" || remote.provider.length === 0) return undefined;
+			if (!Array.isArray(remote.replacementHistory)) return undefined;
+			return {
+				type: "openaiResponsesHistory",
+				provider: remote.provider,
+				items: remote.replacementHistory as Array<Record<string, unknown>>,
+			};
 		})();
-		const providerPayload: ProviderPayload | undefined = remoteReplacementHistory
-			? { type: "openaiResponsesHistory", items: remoteReplacementHistory }
-			: undefined;
+		const remoteReplacementHistory = providerPayload?.items;
 
 		// Emit summary first
 		messages.push(

--- a/packages/coding-agent/test/compaction.test.ts
+++ b/packages/coding-agent/test/compaction.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, mock, vi } from "bun:test"
 import * as path from "node:path";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { getBundledModel } from "@oh-my-pi/pi-ai/models";
-import type { AssistantMessage, Model, Usage } from "@oh-my-pi/pi-ai/types";
+import type { AssistantMessage, Model, ProviderPayload, Usage } from "@oh-my-pi/pi-ai/types";
 import { hookFetch } from "@oh-my-pi/pi-utils";
 
 const completeSimpleMock = vi.fn();
@@ -78,7 +78,7 @@ function createOpenAiAssistantMessage(
 	model: Model,
 	usage?: Usage,
 	encryptedReasoning: string = "encrypted-reasoning",
-	providerPayload?: { type: "openaiResponsesHistory"; items: Array<Record<string, unknown>> },
+	providerPayload?: ProviderPayload,
 ): AssistantMessage {
 	return {
 		role: "assistant",
@@ -351,6 +351,7 @@ describe("remote compaction setting", () => {
 		const previousCompaction = createCompactionEntry("Previous summary", oldAssistant.id);
 		previousCompaction.preserveData = {
 			openaiRemoteCompaction: {
+				provider: "openai",
 				replacementHistory: [
 					{ type: "message", role: "user", content: [{ type: "input_text", text: "Previous preserved user" }] },
 					{ type: "compaction", encrypted_content: "prior_encrypted" },
@@ -430,6 +431,7 @@ describe("remote compaction setting", () => {
 		expect(result.summary).toContain("History summary");
 		expect(result.preserveData).toEqual({
 			openaiRemoteCompaction: {
+				provider: "openai",
 				replacementHistory: remoteOutput,
 				compactionItem: { type: "compaction", encrypted_content: "new_encrypted" },
 			},
@@ -451,7 +453,7 @@ describe("remote compaction setting", () => {
 					model,
 					createMockUsage(0, 100, 9000, 0),
 					"encrypted_reasoning_turn_1",
-					{ type: "openaiResponsesHistory", items: assistantHistory },
+					{ type: "openaiResponsesHistory", provider: "openai", items: assistantHistory },
 				),
 			),
 			createMessageEntry(createUserMessage("follow-up user")),
@@ -570,6 +572,7 @@ describe("remote compaction setting", () => {
 		expect(requestBody.instructions).toBe("BASE INSTRUCTIONS");
 		expect(result.preserveData).toEqual({
 			openaiRemoteCompaction: {
+				provider: "openai",
 				replacementHistory: [
 					{ type: "message", role: "user", content: [{ type: "input_text", text: "Real preserved user" }] },
 					{ type: "message", role: "assistant", content: [{ type: "output_text", text: "Kept assistant" }] },

--- a/packages/coding-agent/test/session-manager/build-context.test.ts
+++ b/packages/coding-agent/test/session-manager/build-context.test.ts
@@ -197,6 +197,7 @@ describe("buildSessionContext", () => {
 				...compaction("3", "2", "Remote summary", "1"),
 				preserveData: {
 					openaiRemoteCompaction: {
+						provider: "openai",
 						replacementHistory: [
 							{ type: "message", role: "user", content: [{ type: "input_text", text: "Preserved user" }] },
 							{ type: "compaction", encrypted_content: "enc_123" },
@@ -217,6 +218,7 @@ describe("buildSessionContext", () => {
 			if (ctx.messages[0]?.role !== "compactionSummary") throw new Error("Expected compaction summary message");
 			expect(ctx.messages[0].providerPayload).toEqual({
 				type: "openaiResponsesHistory",
+				provider: "openai",
 				items: [
 					{ type: "message", role: "user", content: [{ type: "input_text", text: "Preserved user" }] },
 					{ type: "compaction", encrypted_content: "enc_123" },

--- a/packages/coding-agent/test/session-manager/save-entry.test.ts
+++ b/packages/coding-agent/test/session-manager/save-entry.test.ts
@@ -19,9 +19,9 @@ describe("SessionManager.saveCustomEntry", () => {
 		const msg2Id = session.appendMessage({
 			role: "assistant",
 			content: [{ type: "text", text: "hi" }],
-			api: "anthropic-messages",
-			provider: "anthropic",
-			model: "test",
+			api: "openai-responses",
+			provider: "openai",
+			model: "gpt-5-mini",
 			usage: {
 				input: 1,
 				output: 1,
@@ -31,7 +31,7 @@ describe("SessionManager.saveCustomEntry", () => {
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 			},
 			stopReason: "stop",
-			providerPayload: { type: "openaiResponsesHistory", items: nativeHistory },
+			providerPayload: { type: "openaiResponsesHistory", provider: "openai", items: nativeHistory },
 			timestamp: 2,
 		});
 
@@ -57,6 +57,10 @@ describe("SessionManager.saveCustomEntry", () => {
 		const ctx = session.buildSessionContext();
 		expect(ctx.messages).toHaveLength(2); // only message entries
 		if (ctx.messages[1]?.role !== "assistant") throw new Error("Expected assistant message");
-		expect(ctx.messages[1].providerPayload).toEqual({ type: "openaiResponsesHistory", items: nativeHistory });
+		expect(ctx.messages[1].providerPayload).toEqual({
+			type: "openaiResponsesHistory",
+			provider: "openai",
+			items: nativeHistory,
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- add provider metadata to OpenAIResponsesHistoryPayload
- only replay native Responses history when it matches the current provider
- preserve provider through remote compaction and session reconstruction
- add regression coverage for same-provider replay and codex -> copilot rejection

## Testing
- bun test packages/ai/test/openai-responses-history-payload.test.ts packages/coding-agent/test/session-manager/save-entry.test.ts packages/coding-agent/test/session-manager/build-context.test.ts packages/coding-agent/test/compaction.test.ts

Fixes #336