### PR TITLE
fix(ai): restore email-first identity matching for Codex and Anthropic

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1952,10 +1952,11 @@ function toStoredAuthCredential(row: AuthRow, credential: AuthCredential): Store
 	return { id: row.id, provider: row.provider, credential, disabledCause: row.disabled_cause };
 }
 
-function resolveProviderCredentialIdentityKey(_provider: string, identifiers: string[]): string | null {
+function resolveProviderCredentialIdentityKey(provider: string, identifiers: string[]): string | null {
+	const emailIdentifier = identifiers.find(identifier => identifier.startsWith("email:"));
+	if ((provider === "openai-codex" || provider === "anthropic") && emailIdentifier) return emailIdentifier;
 	const accountIdentifier = identifiers.find(identifier => identifier.startsWith("account:"));
 	if (accountIdentifier) return accountIdentifier;
-	const emailIdentifier = identifiers.find(identifier => identifier.startsWith("email:"));
 	if (emailIdentifier) return emailIdentifier;
 	return null;
 }

--- a/packages/ai/test/auth-storage-email-dedupe.test.ts
+++ b/packages/ai/test/auth-storage-email-dedupe.test.ts
@@ -112,8 +112,8 @@ describe("AuthStorage openai-codex email dedupe", () => {
 		}
 	});
 
-	it("dedupes openai-codex credentials when accountId matches but emails differ", async () => {
-		if (!authStorage || !store) throw new Error("test setup failed");
+	it("keeps both openai-codex credentials when accountId matches but emails differ", async () => {
+		if (!authStorage || !store || !dbPath) throw new Error("test setup failed");
 
 		await authStorage.set("openai-codex", [
 			createCredential({ suffix: "first", accountId: "shared-team", email: "first.user@example.com" }),
@@ -121,16 +121,12 @@ describe("AuthStorage openai-codex email dedupe", () => {
 		]);
 
 		const credentials = store.listAuthCredentials("openai-codex");
-		expect(credentials).toHaveLength(1);
-		const [remaining] = credentials;
-		expect(remaining?.credential.type).toBe("oauth");
-		if (!remaining || remaining.credential.type !== "oauth") throw new Error("expected oauth credential");
-		expect(remaining.credential.accountId).toBe("shared-team");
-		expect(remaining.credential.email).toBe("second.user@example.com");
+		expect(credentials).toHaveLength(2);
+		expect(readDisabledCauses(dbPath, "openai-codex")).toEqual([]);
 	});
 
-	it("keeps both openai-codex credentials when email matches but accountId differs", async () => {
-		if (!authStorage || !store || !dbPath) throw new Error("test setup failed");
+	it("dedupes openai-codex credentials when email matches but accountId differs", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
 
 		await authStorage.set("openai-codex", [
 			createCredential({ suffix: "first", accountId: "account-a", email: "shared.user@example.com" }),
@@ -138,11 +134,15 @@ describe("AuthStorage openai-codex email dedupe", () => {
 		]);
 
 		const credentials = store.listAuthCredentials("openai-codex");
-		expect(credentials).toHaveLength(2);
-		expect(readDisabledCauses(dbPath, "openai-codex")).toEqual([]);
+		expect(credentials).toHaveLength(1);
+		const [remaining] = credentials;
+		expect(remaining?.credential.type).toBe("oauth");
+		if (!remaining || remaining.credential.type !== "oauth") throw new Error("expected oauth credential");
+		expect(remaining.credential.accountId).toBe("account-b");
+		expect(remaining.credential.email).toBe("shared.user@example.com");
 	});
 
-	it("keeps both openai-codex credentials when matching email exists only in JWT profile claim but accountId differs", async () => {
+	it("dedupes openai-codex credentials when matching email exists only in JWT profile claim but accountId differs", async () => {
 		if (!authStorage || !store) throw new Error("test setup failed");
 
 		await authStorage.set("openai-codex", [
@@ -151,54 +151,58 @@ describe("AuthStorage openai-codex email dedupe", () => {
 		]);
 
 		const credentials = store.listAuthCredentials("openai-codex");
-		expect(credentials).toHaveLength(2);
+		expect(credentials).toHaveLength(1);
+		const [remaining] = credentials;
+		expect(remaining?.credential.type).toBe("oauth");
+		if (!remaining || remaining.credential.type !== "oauth") throw new Error("expected oauth credential");
+		expect(remaining.credential.accountId).toBe("account-b");
 	});
 
-	it("does not soft-disable a different codex account just because the email matches", async () => {
+	it("soft-disables a different codex account when the email matches", async () => {
 		if (!store || !dbPath) throw new Error("test setup failed");
 
 		store.replaceAuthCredentialsForProvider("openai-codex", [
 			createJwtOnlyCredential({ suffix: "first", accountId: "account-a", email: "shared.user@example.com" }),
 		]);
 		store.replaceAuthCredentialsForProvider("openai-codex", [
-			createJwtOnlyCredential({ suffix: "first", accountId: "account-a", email: "shared.user@example.com" }),
 			createJwtOnlyCredential({ suffix: "second", accountId: "account-b", email: "shared.user@example.com" }),
 		]);
 
 		expect(countCredentialRows(dbPath, "openai-codex")).toBe(2);
 		const credentials = store.listAuthCredentials("openai-codex");
-		expect(credentials).toHaveLength(2);
-		expect(readDisabledCauses(dbPath, "openai-codex")).toEqual([]);
+		expect(credentials).toHaveLength(1);
+		expect(readDisabledCauses(dbPath, "openai-codex")).toEqual(["replaced by newer credential"]);
 	});
 
-	it("hard deletes disabled codex rows once a replacement for the same account becomes active", async () => {
+	it("hard deletes disabled codex rows once a replacement for the same email becomes active", async () => {
 		if (!authStorage || !store || !dbPath) throw new Error("test setup failed");
 
 		await authStorage.set(
 			"openai-codex",
-			createCredential({ suffix: "first", accountId: "account-a", email: "first.user@example.com" }),
+			createCredential({ suffix: "first", accountId: "account-a", email: "shared.user@example.com" }),
 		);
 		await authStorage.set(
 			"openai-codex",
-			createCredential({ suffix: "second", accountId: "account-a", email: "second.user@example.com" }),
+			createCredential({ suffix: "second", accountId: "account-b", email: "shared.user@example.com" }),
 		);
 
-		expect(countCredentialRows(dbPath, "openai-codex")).toBe(1);
+		expect(countCredentialRows(dbPath, "openai-codex")).toBe(2);
 		const credentials = store.listAuthCredentials("openai-codex");
 		expect(credentials).toHaveLength(1);
 		const [remaining] = credentials;
 		expect(remaining?.credential.type).toBe("oauth");
 		if (!remaining || remaining.credential.type !== "oauth") throw new Error("expected oauth credential");
-		expect(remaining.credential.accountId).toBe("account-a");
-		expect(remaining.credential.email).toBe("second.user@example.com");
+		expect(remaining.credential.accountId).toBe("account-b");
+		expect(remaining.credential.email).toBe("shared.user@example.com");
+		expect(readDisabledCauses(dbPath, "openai-codex")).toEqual(["replaced by newer credential"]);
 	});
 
-	it("prunes existing JWT-only codex duplicates on reload when accountId matches", async () => {
+	it("prunes existing JWT-only codex duplicates on reload when email matches", async () => {
 		if (!store) throw new Error("test setup failed");
 
 		store.replaceAuthCredentialsForProvider("openai-codex", [
-			createJwtOnlyCredential({ suffix: "first", accountId: "account-a", email: "first.user@example.com" }),
-			createJwtOnlyCredential({ suffix: "second", accountId: "account-a", email: "second.user@example.com" }),
+			createJwtOnlyCredential({ suffix: "first", accountId: "account-a", email: "shared.user@example.com" }),
+			createJwtOnlyCredential({ suffix: "second", accountId: "account-b", email: "shared.user@example.com" }),
 		]);
 
 		const reloaded = new AuthStorage(store);
@@ -209,15 +213,15 @@ describe("AuthStorage openai-codex email dedupe", () => {
 		const [remaining] = credentials;
 		expect(remaining?.credential.type).toBe("oauth");
 		if (!remaining || remaining.credential.type !== "oauth") throw new Error("expected oauth credential");
-		expect(remaining.credential.accountId).toBe("account-a");
+		expect(remaining.credential.accountId).toBe("account-b");
 	});
 
-	it("dedupes openai-codex credentials after reload when accountId matches even if emails differ", async () => {
+	it("dedupes openai-codex credentials after reload when email matches even if accountId differs", async () => {
 		if (!store) throw new Error("test setup failed");
 
 		store.replaceAuthCredentialsForProvider("openai-codex", [
-			createCredential({ suffix: "first", accountId: "shared-team", email: "first.user@example.com" }),
-			createCredential({ suffix: "second", accountId: "shared-team", email: "second.user@example.com" }),
+			createCredential({ suffix: "first", accountId: "account-a", email: "shared.user@example.com" }),
+			createCredential({ suffix: "second", accountId: "account-b", email: "shared.user@example.com" }),
 		]);
 
 		const reloaded = new AuthStorage(store);
@@ -228,10 +232,90 @@ describe("AuthStorage openai-codex email dedupe", () => {
 		const [remaining] = credentials;
 		expect(remaining?.credential.type).toBe("oauth");
 		if (!remaining || remaining.credential.type !== "oauth") throw new Error("expected oauth credential");
-		expect(remaining.credential.accountId).toBe("shared-team");
-		expect(remaining.credential.email).toBe("second.user@example.com");
+		expect(remaining.credential.accountId).toBe("account-b");
+		expect(remaining.credential.email).toBe("shared.user@example.com");
 	});
 
+	describe("AuthStorage anthropic email identity", () => {
+		it("keeps both anthropic credentials when accountId matches but emails differ", async () => {
+			if (!authStorage || !store || !dbPath) throw new Error("test setup failed");
+
+			await authStorage.set("anthropic", [
+				createCredential({ suffix: "first", accountId: "shared-org", email: "first.user@example.com" }),
+				createCredential({ suffix: "second", accountId: "shared-org", email: "second.user@example.com" }),
+			]);
+
+			const credentials = store.listAuthCredentials("anthropic");
+			expect(credentials).toHaveLength(2);
+			expect(readDisabledCauses(dbPath, "anthropic")).toEqual([]);
+		});
+
+		it("dedupes anthropic credentials when email matches but accountId differs", async () => {
+			if (!authStorage || !store) throw new Error("test setup failed");
+
+			await authStorage.set("anthropic", [
+				createCredential({ suffix: "first", accountId: "org-a", email: "shared.user@example.com" }),
+				createCredential({ suffix: "second", accountId: "org-b", email: "shared.user@example.com" }),
+			]);
+
+			const credentials = store.listAuthCredentials("anthropic");
+			expect(credentials).toHaveLength(1);
+			const [remaining] = credentials;
+			expect(remaining?.credential.type).toBe("oauth");
+			if (!remaining || remaining.credential.type !== "oauth") throw new Error("expected oauth credential");
+			expect(remaining.credential.accountId).toBe("org-b");
+			expect(remaining.credential.email).toBe("shared.user@example.com");
+		});
+
+		it("backfills anthropic identity_key from email when migrating v1 auth schema", async () => {
+			if (!tempDir) throw new Error("test setup failed");
+
+			const legacyDbPath = path.join(tempDir, "legacy-v1-anthropic-agent.db");
+			const legacyDb = new Database(legacyDbPath);
+			legacyDb.exec(`
+				CREATE TABLE auth_schema_version (
+					id INTEGER PRIMARY KEY CHECK (id = 1),
+					version INTEGER NOT NULL
+				);
+				INSERT INTO auth_schema_version(id, version) VALUES (1, 1);
+				CREATE TABLE auth_credentials (
+					id INTEGER PRIMARY KEY AUTOINCREMENT,
+					provider TEXT NOT NULL,
+					credential_type TEXT NOT NULL,
+					data TEXT NOT NULL,
+					disabled_cause TEXT DEFAULT NULL,
+					created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+					updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+				);
+			`);
+			legacyDb
+				.prepare(
+					"INSERT INTO auth_credentials (provider, credential_type, data, disabled_cause) VALUES (?, ?, ?, ?)",
+				)
+				.run(
+					"anthropic",
+					"oauth",
+					JSON.stringify(
+						createCredential({
+							suffix: "legacy-v1-anthropic",
+							accountId: "legacy-org",
+							email: "legacy-anthropic@example.com",
+						}),
+					),
+					null,
+				);
+			legacyDb.close();
+
+			const migratedStore = await AuthCredentialStore.open(legacyDbPath);
+			try {
+				expect(readStoredIdentityRows(legacyDbPath, "anthropic")).toEqual([
+					{ identity_key: "email:legacy-anthropic@example.com", disabled_cause: null },
+				]);
+			} finally {
+				migratedStore.close();
+			}
+		});
+	});
 	it("stores the disable cause when a credential is soft-disabled", async () => {
 		if (!store || !dbPath) throw new Error("test setup failed");
 
@@ -320,9 +404,8 @@ describe("AuthStorage openai-codex email dedupe", () => {
 
 		const migratedStore = await AuthCredentialStore.open(legacyDbPath);
 		try {
-			expect(migratedStore.listAuthCredentials("openai-codex")).toHaveLength(1);
 			expect(readStoredIdentityRows(legacyDbPath, "openai-codex")).toEqual([
-				{ identity_key: "account:legacy-v1-account", disabled_cause: null },
+				{ identity_key: "email:legacy-v1@example.com", disabled_cause: null },
 			]);
 		} finally {
 			migratedStore.close();
@@ -361,7 +444,7 @@ describe("AuthStorage openai-codex email dedupe", () => {
 		try {
 			expect(migratedStore.listAuthCredentials("openai-codex")).toHaveLength(0);
 			expect(readStoredIdentityRows(legacyDbPath, "openai-codex")).toEqual([
-				{ identity_key: "account:legacy-account", disabled_cause: "disabled" },
+				{ identity_key: "email:legacy@example.com", disabled_cause: "disabled" },
 			]);
 		} finally {
 			migratedStore.close();


### PR DESCRIPTION
Closes #343.

## Summary

- restored email-first auth identity matching for `openai-codex`
- restored email-first auth identity matching for `anthropic`
- added focused regression coverage for dedupe and legacy `identity_key` backfill

## Why

`/usage` already dedupes Codex and Anthropic by email, but auth-storage credential identity had drifted to accountId-first. That created inconsistent behavior between usage display and stored credential replacement/deduping.

For both providers, org/account identifiers can be shared while email identifies the actual user. Email-first identity keeps auth storage aligned with existing usage-report behavior.

## Changes

### `packages/ai/src/auth-storage.ts`
- updated `resolveProviderCredentialIdentityKey()` so `openai-codex` and `anthropic` prefer `email:` before `account:`

### `packages/ai/test/auth-storage-email-dedupe.test.ts`
- updated Codex expectations to email-first semantics
- added Anthropic coverage for:
  - same accountId + different emails => keep both
  - same email + different accountIds => dedupe to latest
  - v1 schema migration backfills `identity_key` as `email:*`

## Verification

- `bun test packages/ai/test/auth-storage-email-dedupe.test.ts`
