### PR TITLE
fix: preserve PR indicator during status-line refresh

### DIFF
--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -149,7 +149,6 @@ export class StatusLineComponent implements Component {
 	#invalidateGitCaches(): void {
 		this.#cachedBranch = undefined;
 		this.#cachedBranchRepoId = undefined;
-		this.#cachedPr = undefined;
 		this.#cachedPrContext = undefined;
 	}
 	#getCurrentBranch(): string | null {
@@ -261,20 +260,17 @@ export class StatusLineComponent implements Component {
 			return this.#cachedPr ?? null;
 		}
 
-		if (this.#cachedPr !== undefined) {
-			this.#cachedPr = undefined;
-			this.#cachedPrContext = undefined;
-		}
+		const stalePr = this.#cachedPr;
 
 		// Don't look up if no branch, detached HEAD, default branch, or already in flight
 		if (!branch || branch === "detached" || this.#isDefaultBranch(branch) || this.#prLookupInFlight) {
-			return null;
+			return stalePr ?? null;
 		}
 
 		this.#prLookupInFlight = true;
 		const lookupContext = currentContext;
 
-		// Fire async lookup, return null until resolved
+		// Fire async lookup, keep stale value visible until resolved
 		(async () => {
 			// Helper: only write cache if branch/repo context hasn't changed since launch
 			const setCachedPr = (value: { number: number; url: string } | null) => {
@@ -304,13 +300,13 @@ export class StatusLineComponent implements Component {
 				setCachedPr(null);
 			} finally {
 				this.#prLookupInFlight = false;
-				if (this.#cachedPr && this.#onBranchChange) {
+				if (this.#onBranchChange) {
 					this.#onBranchChange();
 				}
 			}
 		})();
 
-		return null;
+		return stalePr ?? null;
 	}
 
 	#getTokensPerSecond(): number | null {


### PR DESCRIPTION
## Summary
- keep the last known pull request indicator visible while a refresh is in flight
- rerender the status line after every PR lookup completion so removals also apply cleanly
- avoid clearing the cached PR value on generic git cache invalidation

## Testing
- bun check:ts

Fixes #345
