### PR TITLE
fix: gracefully disable thinking for non-reasoning models

### DIFF
--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -391,7 +391,7 @@ function resolveOpenAiReasoningEffort<TApi extends Api>(
 	options?: SimpleStreamOptions,
 ): Effort | undefined {
 	const reasoning = options?.reasoning;
-	if (!reasoning) return undefined;
+	if (!reasoning || !model.reasoning) return undefined;
 	return requireSupportedEffort(model, reasoning);
 }
 
@@ -424,9 +424,9 @@ function mapOptionsForApi<TApi extends Api>(
 
 	switch (model.api) {
 		case "anthropic-messages": {
-			// Explicitly disable thinking when reasoning is not specified
+			// Explicitly disable thinking when reasoning is not specified or model doesn't support it
 			const reasoning = options?.reasoning;
-			if (!reasoning) {
+			if (!reasoning || !model.reasoning) {
 				return castApi<"anthropic-messages">({
 					...base,
 					thinkingEnabled: false,
@@ -548,10 +548,10 @@ function mapOptionsForApi<TApi extends Api>(
 			});
 
 		case "google-generative-ai": {
-			// Explicitly disable thinking when reasoning is not specified
+			// Explicitly disable thinking when reasoning is not specified or model doesn't support it
 			// This is needed because Gemini has "dynamic thinking" enabled by default
 			const reasoning = options?.reasoning;
-			if (!reasoning) {
+			if (!reasoning || !model.reasoning) {
 				return castApi<"google-generative-ai">({
 					...base,
 					thinking: { enabled: false },
@@ -587,7 +587,7 @@ function mapOptionsForApi<TApi extends Api>(
 
 		case "google-gemini-cli": {
 			const reasoning = options?.reasoning;
-			if (!reasoning) {
+			if (!reasoning || !model.reasoning) {
 				return castApi<"google-gemini-cli">({
 					...base,
 					thinking: { enabled: false },
@@ -637,9 +637,9 @@ function mapOptionsForApi<TApi extends Api>(
 		}
 
 		case "google-vertex": {
-			// Explicitly disable thinking when reasoning is not specified
+			// Explicitly disable thinking when reasoning is not specified or model doesn't support it
 			const reasoning = options?.reasoning;
-			if (!reasoning) {
+			if (!reasoning || !model.reasoning) {
 				return castApi<"google-vertex">({
 					...base,
 					thinking: { enabled: false },


### PR DESCRIPTION
## Bug
[#350](https://github.com/can1357/oh-my-pi/issues/350) — Selecting a model that doesn't support thinking (e.g., Gemini 1.5 Flash) while a thinking level is still active from a previously selected model causes an uncaught exception that crashes the app.

The crash originates from `requireSupportedEffort()` being called without first checking whether the model actually supports reasoning.

## Fix
Added `!model.reasoning` guards to every provider path in `mapOptionsForApi()` (`packages/ai/src/stream.ts`), so thinking is gracefully disabled when the active model does not support it — instead of throwing.

Affected paths:
- `anthropic-messages`
- `google-generative-ai`
- `google-gemini-cli`
- `google-vertex`
- `resolveOpenAiReasoningEffort` (used by all OpenAI variants)

The `bedrock-converse-stream` path already had this guard in `resolveBedrockThinkingBudget`, so it was unaffected.

## Testing
- Traced the full call path from model selection → `mapOptionsForApi` → `requireSupportedEffort`
- Confirmed that with a stale `options.reasoning` value and `model.reasoning === false`, the previous code throws on every provider except Bedrock
- After the fix, each path early-returns the "thinking disabled" configuration, matching existing behavior for when no reasoning effort is requested

Greetings, saschabuehrle