### PR TITLE
fix: update webSearch auto priority text to match SEARCH_PROVIDER_ORDER

### DIFF
--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -224,7 +224,7 @@ const OPTION_PROVIDERS: Partial<Record<SettingPath, OptionProvider>> = {
 		{
 			value: "auto",
 			label: "Auto",
-			description: "Preferred web-search provider",
+			description: "Priority: Tavily > Perplexity > Brave > Jina > Kimi > Anthropic > Gemini > Codex > Z.AI > Exa > Kagi > Synthetic",
 		},
 		{ value: "exa", label: "Exa", description: "Requires EXA_API_KEY" },
 		{ value: "brave", label: "Brave", description: "Requires BRAVE_API_KEY" },


### PR DESCRIPTION
## Summary

Fixes #301 — the `providers.webSearch` auto description did not reflect the actual runtime fallback order from `SEARCH_PROVIDER_ORDER`.

### Before
```
"Preferred web-search provider"
```

### After
```
"Priority: Tavily > Perplexity > Brave > Jina > Kimi > Anthropic > Gemini > Codex > Z.AI > Exa > Kagi > Synthetic"
```

This matches the current `SEARCH_PROVIDER_ORDER` array in `src/web/search/provider.ts`.

### Changes
- `packages/coding-agent/src/modes/components/settings-defs.ts`: update auto option description