### PR TITLE
fix: auto-retry on OpenAI stream stall errors

### DIFF
--- a/packages/ai/src/utils/retry.ts
+++ b/packages/ai/src/utils/retry.ts
@@ -8,7 +8,7 @@ type ErrorLike = {
 };
 
 const TRANSIENT_MESSAGE_PATTERN =
-	/overloaded|rate.?limit|usage.?limit|too many requests|service.?unavailable|server error|internal error|connection.?error|unable to connect|fetch failed/i;
+	/overloaded|rate.?limit|usage.?limit|too many requests|service.?unavailable|server error|internal error|connection.?error|unable to connect|fetch failed|stream stall/i;
 
 const VALIDATION_MESSAGE_PATTERN =
 	/invalid|validation|bad request|unsupported|schema|missing required|not found|unauthorized|forbidden/i;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4113,8 +4113,8 @@ export class AgentSession {
 	}
 
 	#isRetryableErrorMessage(errorMessage: string): boolean {
-		// Match: overloaded_error, rate limit, usage limit, 429, 500, 502, 503, 504, service unavailable, connection error, fetch failed, retry delay exceeded
-		return /overloaded|rate.?limit|usage.?limit|too many requests|429|500|502|503|504|service.?unavailable|server error|internal error|connection.?error|unable to connect|fetch failed|retry delay/i.test(
+		// Match: overloaded_error, rate limit, usage limit, 429, 500, 502, 503, 504, service unavailable, connection error, fetch failed, retry delay exceeded, stream stall
+		return /overloaded|rate.?limit|usage.?limit|too many requests|429|500|502|503|504|service.?unavailable|server error|internal error|connection.?error|unable to connect|fetch failed|retry delay|stream stall/i.test(
 			errorMessage,
 		);
 	}


### PR DESCRIPTION
## Summary

Fixes #348 — when the OpenAI responses stream stalls (commonly seen with `github-copilot/gpt-5.4`), OMP now automatically retries instead of surfacing the error to the user.

### Root Cause

The error message `"stream stalled while waiting for the next event"` was not matched by the retryable-error patterns in two places:
1. `packages/ai/src/utils/retry.ts` — `TRANSIENT_MESSAGE_PATTERN` (provider-level retry)
2. `packages/coding-agent/src/session/agent-session.ts` — `#isRetryableErrorMessage()` (session-level retry loop)

Because the error was not recognized as transient, the session stopped instead of retrying.

### Fix

Add `stream stall` to both regex patterns:

```diff
- /overloaded|rate.?limit|...|fetch failed/i
+ /overloaded|rate.?limit|...|fetch failed|stream stall/i
```

This matches `"OpenAI responses stream stalled while waiting for the next event"`, `"Azure OpenAI responses stream stalled..."`, and any similar future stall messages.

### Changes

| File | Change |
|------|--------|
| `packages/ai/src/utils/retry.ts` | Add `stream stall` to `TRANSIENT_MESSAGE_PATTERN` |
| `packages/coding-agent/src/session/agent-session.ts` | Add `stream stall` to `#isRetryableErrorMessage()` regex |