### PR TITLE
fix(coding-agent): handle async rejection in terminal breadcrumb write

### DIFF
--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -629,15 +629,11 @@ function writeTerminalBreadcrumb(cwd: string, sessionFile: string): void {
 	const terminalId = getTerminalId();
 	if (!terminalId) return;
 
-	try {
-		const breadcrumbDir = path.join(getDefaultAgentDir(), TERMINAL_SESSIONS_DIR);
-		const breadcrumbFile = path.join(breadcrumbDir, terminalId);
-		const content = `${cwd}\n${sessionFile}\n`;
-		// Bun.write auto-creates parent dirs
-		void Bun.write(breadcrumbFile, content);
-	} catch {
-		// Best-effort — don't break session creation if breadcrumb fails
-	}
+	const breadcrumbDir = path.join(getDefaultAgentDir(), TERMINAL_SESSIONS_DIR);
+	const breadcrumbFile = path.join(breadcrumbDir, terminalId);
+	const content = `${cwd}\n${sessionFile}\n`;
+	// Best-effort — don't break session creation if breadcrumb fails
+	Bun.write(breadcrumbFile, content).catch(() => {});
 }
 
 /**


### PR DESCRIPTION
## Problem

`writeTerminalBreadcrumb` used `void Bun.write()` to fire-and-forget a breadcrumb file write. `void` discards the promise — any rejection becomes an unhandled rejection that crashes the process. The surrounding synchronous `try/catch` caught nothing since `Bun.write` is async.

Reproduces on Windows when parallel tasks write the same breadcrumb file concurrently (EBUSY from exclusive file access), but any I/O error on any platform would trigger the same unhandled rejection.

```
[Unhandled Rejection] Error: EBUSY: resource busy or locked, open 'C:\Users\...\.omp\agent\terminal-sessions\wt-...'
```

## Fix

Replace `void Bun.write(...)` with `Bun.write(...).catch(() => {})` and remove the useless synchronous `try/catch`. The breadcrumb is best-effort — silently swallowing the rejection is the intended behavior.

## Testing

Verified with two rounds of 5 parallel task dispatches (10 total) on Windows — no crashes.