### PR TITLE
fix(sqlite): checkpoint WAL and clean sidecar files on close

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -10,7 +10,7 @@
 import { Database, type Statement } from "bun:sqlite";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { getAgentDir, logger } from "@oh-my-pi/pi-utils";
+import { closeWalDb, getAgentDir, logger } from "@oh-my-pi/pi-utils";
 import { getEnvApiKey } from "./stream";
 import type { Provider } from "./types";
 import type {
@@ -2569,6 +2569,6 @@ export class AuthCredentialStore {
 	}
 
 	close(): void {
-		this.#db.close();
+		closeWalDb(this.#db);
 	}
 }

--- a/packages/ai/src/model-cache.ts
+++ b/packages/ai/src/model-cache.ts
@@ -4,7 +4,7 @@
  */
 import { Database } from "bun:sqlite";
 import * as path from "node:path";
-import { getAgentDir } from "@oh-my-pi/pi-utils";
+import { closeWalDb, getAgentDir } from "@oh-my-pi/pi-utils";
 import type { Api, Model } from "./types";
 
 const CACHE_SCHEMA_VERSION = 2;
@@ -37,7 +37,7 @@ function getDb(dbPath?: string): Database {
 		return sharedDb;
 	}
 	if (sharedDb) {
-		sharedDb.close();
+		closeWalDb(sharedDb);
 	}
 	const db = new Database(resolvedPath, { create: true });
 	db.run("PRAGMA journal_mode = WAL");

--- a/packages/coding-agent/src/memories/storage.ts
+++ b/packages/coding-agent/src/memories/storage.ts
@@ -1,4 +1,5 @@
 import { Database } from "bun:sqlite";
+import { closeWalDb } from "@oh-my-pi/pi-utils";
 
 export interface MemoryThread {
 	id: string;
@@ -82,7 +83,7 @@ CREATE TABLE IF NOT EXISTS jobs (
 }
 
 export function closeMemoryDb(db: Database): void {
-	db.close();
+	closeWalDb(db);
 }
 
 export function clearMemoryData(db: Database): void {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -17,6 +17,7 @@ export { setNativeKillTree } from "./procmgr";
 export * as ptree from "./ptree";
 export { AbortError, ChildProcess, Exception, NonZeroExitError } from "./ptree";
 export * from "./snowflake";
+export * from "./sqlite";
 export * from "./stream";
 export * from "./temp";
 export * from "./type-guards";

--- a/packages/utils/src/sqlite.ts
+++ b/packages/utils/src/sqlite.ts
@@ -1,0 +1,41 @@
+import type { Database } from "bun:sqlite";
+import * as fs from "node:fs";
+
+/** Row returned by PRAGMA wal_checkpoint */
+type CheckpointRow = { busy: number; log: number; checkpointed: number };
+
+/**
+ * Checkpoints and closes a WAL-mode SQLite database, then removes the
+ * sidecar files (.db-wal, .db-shm) on macOS where SQLite does not delete
+ * them automatically after close.
+ *
+ * PRAGMA wal_checkpoint(TRUNCATE) returns a row with a `busy` flag that is
+ * non-zero when active readers or writers prevented a full checkpoint.  The
+ * sidecar files are only unlinked when `busy === 0`, meaning no other
+ * connection holds frames that still live in the WAL.  Deleting sidecars
+ * while they are in use by another connection would corrupt that connection
+ * with SQLITE_IOERR/short-read errors.
+ */
+export function closeWalDb(db: Database): void {
+	let checkpointClean = false;
+	try {
+		const row = db.query<CheckpointRow, []>("PRAGMA wal_checkpoint(TRUNCATE)").get();
+		// busy === 0 means no active connections blocked the checkpoint.
+		checkpointClean = row !== null && row.busy === 0;
+	} catch {
+		// Best-effort; proceed with close even if checkpoint fails.
+	}
+	db.close();
+	if (process.platform === "darwin" && checkpointClean) {
+		const { filename } = db;
+		if (filename && filename !== ":memory:") {
+			for (const suffix of ["-wal", "-shm"]) {
+				try {
+					fs.unlinkSync(filename + suffix);
+				} catch {
+					// File may not exist; ignore.
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

Ensures SQLite databases are properly closed with WAL checkpointing and sidecar file cleanup.

Specifically:
- Added `closeWalDb(db)` utility in `packages/utils/src/sqlite.ts` that runs `PRAGMA wal_checkpoint(TRUNCATE)` before closing and removes `.wal`/`.shm` sidecar files on macOS.
- Updated `packages/ai/src/auth-storage.ts` and `packages/ai/src/model-cache.ts` to use `closeWalDb()` on shutdown.
- Updated `packages/coding-agent/src/memories/storage.ts` to use `closeWalDb()$ on close.

## Why

SQLite WAL mode leaves `.wal` and `.shm` sidecar files behind when the database is closed without a checkpoint. On macOS, these files accumulate and can interfere with subsequent opens or cause stale state.

## Testing

- `bun check` passes
- Behavior verified: WAL files are removed after close