### PR TITLE
fix(ai): don't pass empty string apiKey to Google GenAI SDK

### DIFF
--- a/packages/ai/src/providers/google.ts
+++ b/packages/ai/src/providers/google.ts
@@ -80,7 +80,7 @@ export const streamGoogle: StreamFunction<"google-generative-ai"> = (
 		let rawRequestDump: RawHttpRequestDump | undefined;
 
 		try {
-			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
+			const apiKey = options?.apiKey || getEnvApiKey(model.provider);
 			const client = createClient(model, apiKey);
 			const params = buildParams(model, context, options);
 			options?.onPayload?.(params);


### PR DESCRIPTION
## Summary

- Remove `|| ""` fallback when resolving Google API key, passing `undefined` instead of empty string to `GoogleGenAI` constructor
- Fixes Vertex AI authentication broken by `@google/genai@1.44.0`

Fixes #361

## Test plan

- [x] `tsgo -p packages/ai/tsconfig.json` passes clean
- [x] All 45 Google-related tests pass (`bun test --filter google`)
- [x] Verified SDK behavior: `new GoogleGenAI({ apiKey: undefined })` correctly falls through to Vertex project/location auth