### PR TITLE
fix(lsp): check root markers when config overrides are present

### DIFF
--- a/packages/coding-agent/src/lsp/config.ts
+++ b/packages/coding-agent/src/lsp/config.ts
@@ -332,6 +332,7 @@ export function loadConfig(cwd: string): LspConfig {
 
 	for (const [name, config] of Object.entries(mergedWithRuntime)) {
 		if (config.disabled) continue;
+		if (!hasRootMarkers(cwd, config.rootMarkers)) continue;
 		const resolved = resolveCommand(config.command, cwd);
 		if (!resolved) continue;
 		available[name] = { ...config, resolvedCommand: resolved };


### PR DESCRIPTION
## Problem

When an LSP config file exists (e.g. `~/.omp/agent/lsp.yml`), the override code path in `loadConfig` skips root marker validation. It starts every non-disabled server whose binary is found on `$PATH`, regardless of whether the project actually matches that server's `rootMarkers`.

This means adding *any* override (even just `disabled: true` for a single server) causes all installed LSP servers to start in every project — e.g. metals and jdtls launching in a Rust project.

## Fix

Add the same `hasRootMarkers` check that the auto-detect path already uses to the override path:

```typescript
for (const [name, config] of Object.entries(mergedWithRuntime)) {
    if (config.disabled) continue;
    if (!hasRootMarkers(cwd, config.rootMarkers)) continue; // added
    const resolved = resolveCommand(config.command, cwd);
    if (!resolved) continue;
    available[name] = { ...config, resolvedCommand: resolved };
}
```

## Reproduction

1. Create `~/.omp/agent/lsp.yml` with any override (e.g. disable clangd)
2. Open OMP in a directory without Java/Scala/Kotlin project files
3. Observe jdtls, metals, kotlin-language-server etc. all attempting to start and failing