### PR TITLE
feat(lsp): replace deprecated kotlin-language-server with official kotlin-lsp

### DIFF
--- a/packages/coding-agent/src/lsp/defaults.json
+++ b/packages/coding-agent/src/lsp/defaults.json
@@ -189,9 +189,9 @@
 		"fileTypes": [".java"],
 		"rootMarkers": ["pom.xml", "build.gradle", "build.gradle.kts", "settings.gradle", ".project"]
 	},
-	"kotlin-language-server": {
-		"command": "kotlin-language-server",
-		"args": [],
+	"kotlin-lsp": {
+		"command": "kotlin-lsp",
+		"args": ["--stdio"],
 		"fileTypes": [".kt", ".kts"],
 		"rootMarkers": ["build.gradle", "build.gradle.kts", "pom.xml", "settings.gradle", "settings.gradle.kts"]
 	},


### PR DESCRIPTION
## Summary

Replace the default Kotlin LSP server from [fwcd/kotlin-language-server](https://github.com/fwcd/kotlin-language-server) to the official [JetBrains kotlin-lsp](https://github.com/Kotlin/kotlin-lsp).

## Why

The fwcd project is deprecated. From its README:

> There is now an [official language server](https://github.com/Kotlin/kotlin-lsp), so this project can be considered deprecated.

The JetBrains LSP is based on IntelliJ IDEA and the official Kotlin plugin, actively maintained, and installable via `brew install JetBrains/utils/kotlin-lsp`.

## Changes

- `defaults.json`: renamed `kotlin-language-server` entry to `kotlin-lsp`, updated command to `kotlin-lsp`, added `--stdio` arg (required by the JetBrains server)

## Migration

Users who had `kotlin-language-server` installed will need to install `kotlin-lsp` instead. Users who had custom overrides referencing `kotlin-language-server` by name in their `lsp.yml` will need to update the key to `kotlin-lsp`.