### PR TITLE
fix(coding-agent): reset powerbar immediately on new session

### DIFF
--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -625,7 +625,9 @@ export class CommandController {
 		await this.ctx.session.newSession();
 
 		this.ctx.statusLine.invalidate();
+		this.ctx.statusLine.setSessionStartTime(Date.now());
 		this.ctx.updateEditorTopBorder();
+		this.ctx.ui.requestRender();
 
 		this.ctx.chatContainer.clear();
 		this.ctx.pendingMessagesContainer.clear();

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -160,6 +160,12 @@ export class ExtensionUiController {
 					await options.setup(this.ctx.sessionManager);
 				}
 
+				// Reset and update status line
+				this.ctx.statusLine.invalidate();
+				this.ctx.statusLine.setSessionStartTime(Date.now());
+				this.ctx.updateEditorTopBorder();
+				this.ctx.ui.requestRender();
+
 				// Clear UI state
 				this.ctx.chatContainer.clear();
 				this.ctx.pendingMessagesContainer.clear();


### PR DESCRIPTION
## Problem

After `/new`, the powerbar keeps showing stale context window percentage and cost until the next prompt is submitted or settings are opened.

Two root causes:

1. **`#sessionStartTime` never reset** — `setSessionStartTime()` existed with zero call sites, so the `time_spent` segment kept counting from process start across sessions.

2. **Render fires before bar update** — pressing Enter queues a `process.nextTick` render via the TUI input handler before `handleClearCommand()` reaches `updateEditorTopBorder()`. The settings and event-controller paths both call `requestRender()` immediately after `updateEditorTopBorder()` with no awaits between; `handleClearCommand()` didn't follow that pattern.

3. **Extension-triggered sessions entirely missed** — the `newSession` handler in `extension-ui-controller.ts` called `session.newSession()` but skipped `statusLine.invalidate()`, `setSessionStartTime()`, and `updateEditorTopBorder()` altogether.

## Fix

In both `handleClearCommand()` and the extension `newSession` handler, after `await session.newSession()` resolves:
- call `statusLine.setSessionStartTime(Date.now())`
- call `updateEditorTopBorder()`
- call `requestRender()` immediately (before any subsequent `await`)

---

- [x] `bun check` passes
- [x] Tested locally