### PR TITLE
fix: derive web search auto priority text from runtime order

### DIFF
--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -20,6 +20,7 @@ import {
 	type SettingTab,
 } from "../../config/settings-schema";
 import { getThinkingLevelMetadata } from "../../thinking";
+import { SEARCH_PROVIDER_PRIORITY_DESCRIPTION } from "../../web/search/provider";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // UI Definition Types
@@ -224,7 +225,7 @@ const OPTION_PROVIDERS: Partial<Record<SettingPath, OptionProvider>> = {
 		{
 			value: "auto",
 			label: "Auto",
-			description: "Preferred web-search provider",
+			description: SEARCH_PROVIDER_PRIORITY_DESCRIPTION,
 		},
 		{ value: "exa", label: "Exa", description: "Uses Exa API when EXA_API_KEY is set; falls back to Exa MCP" },
 		{ value: "brave", label: "Brave", description: "Requires BRAVE_API_KEY" },

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -16,6 +16,21 @@ import type { SearchProviderId } from "./types";
 export type { SearchParams } from "./providers/base";
 export { SearchProvider } from "./providers/base";
 
+const SEARCH_PROVIDER_LABELS: Record<SearchProviderId, string> = {
+	tavily: "Tavily",
+	perplexity: "Perplexity",
+	brave: "Brave",
+	jina: "Jina",
+	kimi: "Kimi",
+	anthropic: "Anthropic",
+	gemini: "Gemini",
+	codex: "Codex",
+	zai: "Z.AI",
+	exa: "Exa",
+	kagi: "Kagi",
+	synthetic: "Synthetic",
+};
+
 const SEARCH_PROVIDERS: Record<SearchProviderId, SearchProvider> = {
 	exa: new ExaProvider(),
 	brave: new BraveProvider(),
@@ -46,6 +61,8 @@ export const SEARCH_PROVIDER_ORDER: SearchProviderId[] = [
 	"synthetic",
 ];
 
+export const SEARCH_PROVIDER_PRIORITY_DESCRIPTION = `Priority: ${SEARCH_PROVIDER_ORDER.map(id => SEARCH_PROVIDER_LABELS[id]).join(" > ")}`;
+
 export function getSearchProvider(provider: SearchProviderId): SearchProvider {
 	return SEARCH_PROVIDERS[provider];
 }
@@ -58,7 +75,7 @@ export function setPreferredSearchProvider(provider: SearchProviderId | "auto"):
 	preferredProvId = provider;
 }
 
-/** Determine which providers are configured (priority: Perplexity → Brave → Jina → Kimi → Anthropic → Gemini → Codex → Z.AI → Exa → Tavily → Kagi → Synthetic) */
+/** Determine which providers are configured (priority follows SEARCH_PROVIDER_ORDER) */
 export async function resolveProviderChain(
 	preferredProvider: SearchProviderId | "auto" = preferredProvId,
 ): Promise<SearchProvider[]> {


### PR DESCRIPTION
$## What\n- derive the `providers.webSearch=auto` description from `SEARCH_PROVIDER_ORDER` instead of hardcoding stale text\n- reuse the same generated string in settings UI so the displayed fallback order stays aligned with runtime behavior\n- replace the outdated inline priority comment in `provider.ts` with a source-of-truth reference\n\n## Why\nFixes #301. The settings/help text had drifted away from the actual runtime fallback order, which made provider selection behavior harder to reason about.\n\n## Testing\n- `bun x tsc -p packages/coding-agent/tsconfig.json --noEmit`\n- `npx @biomejs/biome check packages/coding-agent/src/modes/components/settings-defs.ts packages/coding-agent/src/web/search/provider.ts`\n\n---\n- [x] `bun check` passes for the touched TypeScript surface (`tsc --noEmit` on the coding-agent package)
- [x] Tested locally
- [ ] CHANGELOG updated (not needed; internal UI/help-text correctness fix)