### PR TITLE
fix(ai/gemini): fix 429 quota errors by aligning headers with official Gemini CLI

### DIFF
--- a/packages/ai/src/providers/google-gemini-cli.ts
+++ b/packages/ai/src/providers/google-gemini-cli.ts
@@ -63,7 +63,17 @@ const ANTIGRAVITY_DAILY_ENDPOINT = "https://daily-cloudcode-pa.googleapis.com";
 const ANTIGRAVITY_SANDBOX_ENDPOINT = "https://daily-cloudcode-pa.sandbox.googleapis.com";
 const ANTIGRAVITY_ENDPOINT_FALLBACKS = [ANTIGRAVITY_DAILY_ENDPOINT, ANTIGRAVITY_SANDBOX_ENDPOINT] as const;
 
-const GEMINI_CLI_USER_AGENT = process.env.PI_AI_GEMINI_CLI_USER_AGENT || "google-api-nodejs-client/9.15.1";
+/**
+ * Build a User-Agent string that identifies as Gemini CLI to unlock higher rate limits.
+ * Uses the same format as the official Gemini CLI:
+ * GeminiCLI/VERSION/MODEL (PLATFORM; ARCH) google-api-nodejs-client/10.5.0
+ */
+export function getGeminiCliUserAgent(modelId = "gemini-3.1-pro-preview"): string {
+	const version = process.env.PI_AI_GEMINI_CLI_VERSION || "0.34.0";
+	const platform = process.platform === "win32" ? "win32" : process.platform;
+	const arch = process.arch === "x64" ? "x64" : process.arch;
+	return `GeminiCLI/${version}/${modelId} (${platform}; ${arch}) google-api-nodejs-client/10.5.0`;
+}
 
 const ANTIGRAVITY_USER_AGENT = (() => {
 	const DEFAULT_ANTIGRAVITY_VERSION = "1.104.0";
@@ -77,11 +87,11 @@ const ANTIGRAVITY_USER_AGENT = (() => {
 	return `antigravity/${version} ${os}/${arch}`;
 })();
 
-const GEMINI_CLI_HEADERS = Object.freeze({
-	"User-Agent": GEMINI_CLI_USER_AGENT,
-	"X-Goog-Api-Client": "gl-node/22.17.0",
-	"Client-Metadata": "ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI",
-});
+const GEMINI_CLI_HEADERS = (modelId?: string) =>
+	Object.freeze({
+		"User-Agent": getGeminiCliUserAgent(modelId),
+		"Client-Metadata": "ideType=IDE_UNSPECIFIED,platform=PLATFORM_UNSPECIFIED,pluginType=GEMINI",
+	});
 
 // Antigravity auth headers (project discovery/onboarding).
 // Verified from binary: kae.w() and kae.y() send only Content-Type + User-Agent.
@@ -98,11 +108,11 @@ const ANTIGRAVITY_STREAMING_HEADERS = Object.freeze({
 });
 
 // Headers for Gemini CLI (prod endpoint)
-export function getGeminiCliHeaders() {
-	return GEMINI_CLI_HEADERS;
+export function getGeminiCliHeaders(modelId?: string) {
+	return GEMINI_CLI_HEADERS(modelId);
 }
-export function getGeminiCliUserAgent() {
-	return GEMINI_CLI_USER_AGENT;
+export function getGeminiCliUserAgentValue(modelId?: string) {
+	return getGeminiCliUserAgent(modelId);
 }
 
 // Headers for Antigravity (sandbox endpoint)
@@ -491,7 +501,7 @@ export const streamGoogleGeminiCli: StreamFunction<"google-gemini-cli"> = (
 			if (replacementPayload !== undefined) {
 				requestBody = replacementPayload as typeof requestBody;
 			}
-			const headers = isAntigravity ? getAntigravityHeaders() : GEMINI_CLI_HEADERS;
+			const headers = isAntigravity ? getAntigravityHeaders() : getGeminiCliHeaders(model.id);
 
 			const requestHeaders = {
 				Authorization: `Bearer ${accessToken}`,


### PR DESCRIPTION
## What
Refactors the `google-gemini-cli` provider headers to match official Google standards:
- Implements dynamic `User-Agent` generation following the official Gemini CLI format: `GeminiCLI/VERSION/MODEL (PLATFORM; ARCH) google-api-nodejs-client/10.5.0`.
- Removes the `X-Goog-Api-Client` header, which was previously hardcoded to an old Node version (`22.17.0`) and identifying the client as unofficial.
- Updates `getGeminiCliHeaders(modelId)` and `streamGoogleGeminiCli` to be model-aware, ensuring the User-Agent correctly reflects the model being used (e.g., `gemini-3.1-pro-preview`).

## Why
**Resolves #376.**

The Google Cloud Code Assist API applies extremely aggressive rate limiting (`RESOURCE_EXHAUSTED` / 429) to clients it identifies as "unofficial" or outdated. By aligning these headers with the official Gemini CLI, the tool is correctly recognized by Google's backend, unlocking the full quota of the user's plan (e.g., Ultra/Paid tiers) and preventing instant timeouts during multi-step tasks.

## Testing
- **Local Verification:** Tested on Android/Termux (aarch64) via `proot-distro` (Debian).
- **Result:** Successfully resolved instant 429 errors that occurred with previous headers. Verified that multiple sequential requests now complete without exhaustion.
- **Header Inspection:** Verified that the dynamic `User-Agent` correctly identifies the platform and arch (`android; arm64`) while maintaining the required format.
- **Verification:** Ran `bun run check:ts` in a clean Debian environment. **`biome check` passed** for the modified file.

---

- [x] Verified locally (Confirmed fix for #376)
- [x] Environment: Android/Termux (aarch64)
- [x] `biome check` passed