### PR TITLE
fix(coding-agent): correct web search auto priority text

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -38,6 +38,7 @@
 
 ### Fixed
 
+- Fixed `providers.webSearch=auto` settings text to mirror the actual runtime fallback order (including Gemini before Exa and Kagi in the chain)
 - Fixed hashline line normalization to trim trailing whitespace and strip carriage returns instead of removing all whitespace, preserving intentional spacing in code
 - Fixed noop detection in hashline replace operations to check array length equality before comparing lines, preventing false noop classification when single-line replacements expand to multiple lines
 - Fixed path resolution to accept bare directory names without trailing slashes in comma/space-separated path lists (e.g., `apps packages phases`)

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -224,7 +224,7 @@ const OPTION_PROVIDERS: Partial<Record<SettingPath, OptionProvider>> = {
 		{
 			value: "auto",
 			label: "Auto",
-			description: "Preferred web-search provider",
+			description: "Priority: Tavily > Perplexity > Brave > Jina > Kimi > Anthropic > Gemini > Codex > Z.AI > Exa > Parallel > Kagi > Synthetic",
 		},
 		{ value: "exa", label: "Exa", description: "Uses Exa API when EXA_API_KEY is set; falls back to Exa MCP" },
 		{ value: "brave", label: "Brave", description: "Requires BRAVE_API_KEY" },


### PR DESCRIPTION
## What
- update the `providers.webSearch=auto` settings description to match the real runtime fallback order
- add a changelog entry for the user-facing fix

## Why
Fixes #301. The runtime provider chain in `src/web/search/provider.ts` tries Gemini before Exa (and also includes Tavily, Parallel, and Kagi), but the settings UI text was stale. That makes the settings screen misleading when users try to reason about fallback behavior.

## Testing
- `git diff --check`
- verified the updated settings description string matches the current runtime order in `packages/coding-agent/src/web/search/provider.ts`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
