### PR TITLE
fix(coding-agent): fail early when plan file is missing

### DIFF
--- a/packages/coding-agent/src/tools/exit-plan-mode.ts
+++ b/packages/coding-agent/src/tools/exit-plan-mode.ts
@@ -77,6 +77,12 @@ export class ExitPlanModeTool implements AgentTool<typeof exitPlanModeSchema, Ex
 			}
 		}
 
+		if (!planExists) {
+			throw new ToolError(
+				`Plan file not found at ${state.planFilePath}. Write the finalized plan to ${state.planFilePath} before calling exit_plan_mode.`,
+			);
+		}
+
 		return {
 			content: [{ type: "text", text: "Plan ready for approval." }],
 			details: {

--- a/packages/coding-agent/test/tools/exit-plan-mode.test.ts
+++ b/packages/coding-agent/test/tools/exit-plan-mode.test.ts
@@ -58,6 +58,15 @@ describe("ExitPlanModeTool", () => {
 		expect(result.details?.finalPlanFilePath).toBe("local://WP_MIGRATION_PLAN.md");
 	});
 
+	it("fails early when the draft plan file was never written", async () => {
+		await fs.rm(path.join(artifactsDir, "local", "PLAN.md"), { force: true });
+		const tool = new ExitPlanModeTool(createSession());
+
+		await expect(tool.execute("call-missing", { title: "WP_MIGRATION_PLAN" })).rejects.toThrow(
+			"Plan file not found at local://PLAN.md. Write the finalized plan to local://PLAN.md before calling exit_plan_mode.",
+		);
+	});
+
 	it("rejects invalid title characters", async () => {
 		const tool = new ExitPlanModeTool(createSession());
 		await expect(tool.execute("call-3", { title: "../bad" })).rejects.toThrow(


### PR DESCRIPTION
## What
- make `exit_plan_mode` fail immediately when `local://PLAN.md` was never written
- add a regression test for the missing-plan case

## Why
Fixes #374. Today `exit_plan_mode` can return "Plan ready for approval." even when the draft plan file does not exist, and the UI only fails later with `Plan file not found at local://PLAN.md`. Failing inside the tool gives the model an actionable error in the same turn so it can write `local://PLAN.md` and retry instead of falling into a confusing post-tool abort.

## Testing
- `bun test packages/coding-agent/test/tools/exit-plan-mode.test.ts`
- `git diff --check`
