### PR TITLE
fix(coding-agent): skip skills disabled via frontmatter

### DIFF
--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -304,6 +304,9 @@ export async function scanSkillsFromDir(
 			const content = await readFile(skillPath);
 			if (!content) return;
 			const { frontmatter, body } = parseFrontmatter(content, { source: skillPath });
+			if (frontmatter.enabled === false) {
+				return;
+			}
 			if (requireDescription && !frontmatter.description) {
 				return;
 			}

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -217,6 +217,37 @@ describe("skills", () => {
 			expect(skills.every(s => !s.name.startsWith("valid-"))).toBe(true);
 		});
 
+		it("should skip skills disabled via frontmatter", async () => {
+			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-disabled-skill-"));
+			const skillDir = path.join(tempDir, "disabled-skill");
+			await fs.mkdir(skillDir, { recursive: true });
+			await fs.writeFile(
+				path.join(skillDir, "SKILL.md"),
+				`---
+name: disabled-skill
+description: Should not be discovered.
+enabled: false
+---
+
+# Disabled Skill
+`,
+			);
+
+			try {
+				const { skills } = await loadSkills({
+					enableCodexUser: false,
+					enableClaudeUser: false,
+					enableClaudeProject: false,
+					enablePiUser: false,
+					enablePiProject: false,
+					customDirectories: [tempDir],
+				});
+				expect(skills.some(s => s.name === "disabled-skill")).toBe(false);
+			} finally {
+				await fs.rm(tempDir, { recursive: true, force: true });
+			}
+		});
+
 		it("should have ignoredSkills take precedence over includeSkills", async () => {
 			const { skills } = await loadSkills({
 				enableCodexUser: false,


### PR DESCRIPTION
## What
- stop discovering skills whose frontmatter explicitly sets `enabled: false`
- add a regression test that verifies disabled skills are filtered out before discovery results are exposed

## Why
Fixes #364. Codex-imported skills can carry their own enabled/disabled state. OMP was already honoring manual `ignoredSkills`, but the low-level skill scanner still loaded skills whose frontmatter declared `enabled: false`, which meant disabled skills could keep showing up in discovery, prompts, and `skill://` resolution.

## Testing
- `bun test packages/coding-agent/test/skills.test.ts -t 'disabled via frontmatter'`
- `git diff --check`
