### PR TITLE
feat(ai): add mimo-v2-flash-free and nemotron-3-super-free models to opencode-zen

### DIFF
--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -30694,6 +30694,50 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"mimo-v2-flash-free": {
+			"id": "mimo-v2-flash-free",
+			"name": "Mimo V2 Flash",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"nemotron-3-super-free": {
+			"id": "nemotron-3-super-free",
+			"name": "Nemotron 3 Super",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 8192
+		},
 		"trinity-large-preview-free": {
 			"id": "trinity-large-preview-free",
 			"name": "Trinity Large Preview",


### PR DESCRIPTION
## Summary

Add two new free models to the opencode-zen provider to match the current opencode.ai API:

- **mimo-v2-flash-free**: Vision support, reasoning capability, 262K context window
- **nemotron-3-super-free**: 1M context window

Both models are free (cost: 0) and available through the opencode.ai Zen API.

## Testing

- Validated JSON structure
- Verified models are correctly registered in models.json

## Related Issue

Closes #383