### PR TITLE
test(coding-agent): cover invalid bash env names

### DIFF
--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -455,6 +455,15 @@ function b() {
 			expect(result.details).toBeUndefined();
 		});
 
+		it("should reject invalid env variable names before execution", async () => {
+			await expect(
+				bashTool.execute("test-call-8-invalid-env", {
+					command: "echo test",
+					env: { "BAD-NAME": "value" },
+				}),
+			).rejects.toThrow(/Invalid bash env name: BAD-NAME/);
+		});
+
 		it("should expose env values without shell re-parsing", async () => {
 			const mermaid = [
 				"flowchart TD",


### PR DESCRIPTION
## Summary
- add a focused bash tool test for invalid environment variable names
- verify the tool rejects malformed env keys before invoking the shell

## Why
The bash tool already validates env var names against a shell-safe pattern, but that input guard was untested. This PR locks down the current behavior so future refactors do not accidentally defer the error to the shell layer or silently pass malformed env keys through.

## Validation
- `bun test packages/coding-agent/test/tools.test.ts -t 'invalid env variable names before execution'`
- `git diff --check`
