### PR TITLE
test(coding-agent): cover empty bash env

### DIFF
--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -455,6 +455,15 @@ function b() {
 			expect(result.details).toBeUndefined();
 		});
 
+		it("should treat empty env like no env", async () => {
+			const result = await bashTool.execute("test-call-8-empty-env", {
+				command: "echo 'empty env ok'",
+				env: {},
+			});
+
+			expect(getTextOutput(result)).toContain("empty env ok");
+		});
+
 		it("should reject invalid env variable names before execution", async () => {
 			await expect(
 				bashTool.execute("test-call-8-invalid-env", {


### PR DESCRIPTION
## Summary
- add a focused bash tool regression test for `env: {}`
- verify an empty env object behaves like omitting `env` entirely

## Why
The bash tool normalizes empty env maps to `undefined`, but that default-path behavior was untested. This PR locks down the current contract so future refactors do not accidentally treat `env: {}` as an error case or change execution behavior.

## Validation
- `bun test packages/coding-agent/test/tools.test.ts -t 'should treat empty env like no env'`
- `git diff --check`
