### PR TITLE
fix(ai): handle missing disabled column in auth schema V0-to-V1 migration

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed auth schema V0-to-V1 migration crash when the V0 table lacks a `disabled` column
+
 ## [13.11.0] - 2026-03-12
 ### Added
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -2291,6 +2291,9 @@ export class AuthCredentialStore {
 
 	#migrateAuthSchemaV0ToV1(): void {
 		const migrate = this.#db.transaction(() => {
+			const v0Cols = this.#db.prepare("PRAGMA table_info(auth_credentials)").all() as Array<{ name?: string }>;
+			const hasDisabled = v0Cols.some(col => col.name === "disabled");
+
 			this.#db.exec("ALTER TABLE auth_credentials RENAME TO auth_credentials_v0");
 			this.#db.exec(`
 				CREATE TABLE auth_credentials (
@@ -2310,7 +2313,7 @@ export class AuthCredentialStore {
 					provider,
 					credential_type,
 					data,
-					CASE WHEN disabled = 1 THEN 'disabled' ELSE NULL END,
+					${hasDisabled ? "CASE WHEN disabled = 1 THEN 'disabled' ELSE NULL END" : "NULL"},
 					created_at,
 					updated_at
 				FROM auth_credentials_v0


### PR DESCRIPTION
## What

  The V0-to-V1 auth schema migration now checks whether the `disabled` column exists before referencing it.


## Why

The migration unconditionally referenced a `disabled` column in the V0 table, but not all V0 schemas have it. This caused a `SQLiteError: no such column:
  disabled` crash on startup.

## Testing

  - Reproduced the crash by running `omp` with a V0 database lacking the `disabled` column
  - Verified `omp` starts successfully after the fix
  - `bun check` passes
---

  - [x] `bun check` passes
  - [x] Tested locally
  - [x] CHANGELOG updated (if user-facing)
