### PR TITLE
test(coding-agent): cover empty string bash env

### DIFF
--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -473,6 +473,15 @@ function b() {
 			).rejects.toThrow(/Invalid bash env name: BAD-NAME/);
 		});
 
+		it("should preserve empty string env values", async () => {
+			const result = await bashTool.execute("test-call-8-empty-string-env", {
+				command: 'if [ "${EMPTY_VAR+x}" = "x" ] && [ -z "$EMPTY_VAR" ]; then echo empty-but-set; else echo wrong; fi',
+				env: { EMPTY_VAR: "" },
+			});
+
+			expect(getTextOutput(result)).toContain("empty-but-set");
+		});
+
 		it("should expose env values without shell re-parsing", async () => {
 			const mermaid = [
 				"flowchart TD",


### PR DESCRIPTION
## Summary
- add a focused bash tool regression test for empty-string env values
- verify `env: { EMPTY_VAR: "" }` is preserved as "set but empty" inside the shell

## Why
The bash tool normalizes empty env maps, but individual env values can still legitimately be empty strings. This PR locks down that contract so future refactors do not accidentally drop empty-string variables or treat them as unset.

## Validation
- `bun test packages/coding-agent/test/tools.test.ts -t 'should preserve empty string env values'`
- `git diff --check`
