### PR TITLE
Spill over artifact output and add token usage information display.

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added `buildNamedToolChoice` utility function to build provider-aware tool choice constraints for named tools
 - Support for comma/space-separated path lists in `find`, `grep`, `ast_grep`, and `ast_edit` tools (e.g., `apps/,packages/,phases/` or `apps/ packages/ phases/`)
 - New `resolveMultiSearchPath` and `resolveMultiFindPattern` functions to handle multi-path search inputs with automatic common base path detection
+- Added `display.showTokenUsage` setting to show per-turn token usage (input, output, cache) on assistant messages
 
 ### Changed
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -190,6 +190,15 @@ export const SETTINGS_SCHEMA = {
 			submenu: true,
 		},
 	},
+	"display.showTokenUsage": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "display",
+			label: "Show token usage",
+			description: "Show per-turn token usage on assistant messages",
+		},
+	},
 	defaultThinkingLevel: {
 		type: "enum",
 		values: THINKING_EFFORTS,

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -1,6 +1,7 @@
-import type { AssistantMessage, ImageContent } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, ImageContent, Usage } from "@oh-my-pi/pi-ai";
 import { Container, Image, ImageProtocol, Markdown, Spacer, TERMINAL, Text } from "@oh-my-pi/pi-tui";
-import { logger } from "@oh-my-pi/pi-utils";
+import { formatNumber, logger } from "@oh-my-pi/pi-utils";
+import { settings } from "../../config/settings";
 import { hasPendingMermaid, prerenderMermaid } from "../../modes/theme/mermaid-cache";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 
@@ -12,6 +13,7 @@ export class AssistantMessageComponent extends Container {
 	#lastMessage?: AssistantMessage;
 	#prerenderInFlight = false;
 	#toolImagesByCallId = new Map<string, ImageContent[]>();
+	#usageInfo?: Usage;
 
 	constructor(
 		message?: AssistantMessage,
@@ -47,6 +49,13 @@ export class AssistantMessageComponent extends Container {
 		} else {
 			this.#toolImagesByCallId.set(toolCallId, validImages);
 		}
+		if (this.#lastMessage) {
+			this.updateContent(this.#lastMessage);
+		}
+	}
+
+	setUsageInfo(usage: Usage): void {
+		this.#usageInfo = usage;
 		if (this.#lastMessage) {
 			this.updateContent(this.#lastMessage);
 		}
@@ -177,6 +186,20 @@ export class AssistantMessageComponent extends Container {
 				this.#contentContainer.addChild(new Spacer(1));
 				this.#contentContainer.addChild(new Text(theme.fg("error", `Error: ${errorMsg}`), 1, 0));
 			}
+		}
+
+		// Token usage metadata
+		if (settings.get("display.showTokenUsage") && this.#usageInfo) {
+			const usage = this.#usageInfo;
+			const totalInput = usage.input + usage.cacheWrite;
+			const parts: string[] = [];
+			parts.push(`${theme.icon.input} ${formatNumber(totalInput)}`);
+			parts.push(`${theme.icon.output} ${formatNumber(usage.output)}`);
+			if (usage.cacheRead > 0) {
+				parts.push(`cache: ${formatNumber(usage.cacheRead)}`);
+			}
+			this.#contentContainer.addChild(new Spacer(1));
+			this.#contentContainer.addChild(new Text(theme.fg("dim", parts.join("  ")), 1, 0));
 		}
 	}
 }

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -257,6 +257,7 @@ export class EventController {
 						}
 					}
 					this.#lastAssistantComponent = this.ctx.streamingComponent;
+					this.#lastAssistantComponent.setUsageInfo(event.message.usage);
 					this.ctx.streamingComponent = undefined;
 					this.ctx.streamingMessage = undefined;
 					this.ctx.statusLine.invalidate();

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -232,6 +232,9 @@ export class UiHelpers {
 				this.ctx.addMessageToChat(message);
 				const lastChild = this.ctx.chatContainer.children[this.ctx.chatContainer.children.length - 1];
 				const assistantComponent = lastChild instanceof AssistantMessageComponent ? lastChild : undefined;
+				if (assistantComponent) {
+					assistantComponent.setUsageInfo(message.usage);
+				}
 				readGroup = null;
 				const hasErrorStop = message.stopReason === "aborted" || message.stopReason === "error";
 				const errorMessage = hasErrorStop

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -14,7 +14,7 @@ import type {
 import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
 import { formatGroupedDiagnosticMessages } from "../lsp/utils";
 import type { Theme } from "../modes/theme/theme";
-import type { OutputSummary, TruncationResult } from "../session/streaming-output";
+import { type OutputSummary, type TruncationResult, truncateTail } from "../session/streaming-output";
 import { formatBytes, wrapBrackets } from "./render-utils";
 import { renderError } from "./tool-errors";
 
@@ -315,7 +315,7 @@ export function outputMeta(): OutputMetaBuilder {
 // =============================================================================
 
 export function formatFullOutputReference(artifactId: string): string {
-	return `Full output: artifact://${artifactId}`;
+	return `Read artifact://${artifactId} for full output`;
 }
 
 export function formatTruncationMetaNotice(truncation: TruncationMeta): string {
@@ -432,6 +432,93 @@ function appendOutputNotice(
 
 const kUnwrappedExecute = Symbol("OutputMeta.UnwrappedExecute");
 
+// =============================================================================
+// Centralized artifact spill for large tool results
+// =============================================================================
+
+/** Text content above this byte threshold gets saved to an artifact. */
+const RESULT_ARTIFACT_THRESHOLD = 50 * 1024; // 50KB
+
+/** When spilling, keep this many bytes of tail in the result sent to the LLM. */
+const RESULT_ARTIFACT_TAIL_BYTES = 20 * 1024; // 20KB
+
+/** When spilling, keep at most this many lines of tail. */
+const RESULT_ARTIFACT_TAIL_LINES = 500;
+
+/**
+ * If the tool result text exceeds RESULT_ARTIFACT_THRESHOLD, save the full
+ * output as a session artifact and replace the content with a tail-truncated
+ * version plus an artifact reference. Skips when the tool already saved its
+ * own artifact (e.g. bash/python via OutputSink).
+ */
+async function spillLargeResultToArtifact(
+	result: AgentToolResult,
+	toolName: string,
+	context: AgentToolContext | undefined,
+): Promise<AgentToolResult> {
+	const sessionManager = context?.sessionManager;
+	if (!sessionManager) return result;
+
+	// Skip if tool already saved an artifact
+	const existingMeta = (result.details as { meta?: OutputMeta } | undefined)?.meta;
+	if (existingMeta?.truncation?.artifactId) return result;
+
+	// Measure total text content
+	const textParts: string[] = [];
+	for (const block of result.content) {
+		if (block.type === "text" && block.text) {
+			textParts.push(block.text);
+		}
+	}
+	if (textParts.length === 0) return result;
+
+	const fullText = textParts.length === 1 ? textParts[0] : textParts.join("\n");
+	const totalBytes = Buffer.byteLength(fullText, "utf-8");
+	if (totalBytes <= RESULT_ARTIFACT_THRESHOLD) return result;
+
+	// Save full output as artifact
+	const artifactId = await sessionManager.saveArtifact(fullText, toolName);
+	if (!artifactId) return result;
+
+	// Truncate to tail
+	const truncated = truncateTail(fullText, {
+		maxBytes: RESULT_ARTIFACT_TAIL_BYTES,
+		maxLines: RESULT_ARTIFACT_TAIL_LINES,
+	});
+
+	// Replace text blocks with single tail-truncated block, keep images
+	const newContent: (TextContent | ImageContent)[] = [];
+	for (const block of result.content) {
+		if (block.type !== "text") {
+			newContent.push(block);
+		}
+	}
+	newContent.push({ type: "text", text: truncated.content });
+
+	// Build truncation meta
+	const shownStart = truncated.totalLines - truncated.outputLines + 1;
+	const truncationMeta: TruncationMeta = {
+		direction: "tail",
+		truncatedBy: truncated.truncatedBy ?? "bytes",
+		totalLines: truncated.totalLines,
+		totalBytes: truncated.totalBytes,
+		outputLines: truncated.outputLines,
+		outputBytes: truncated.outputBytes,
+		maxBytes: RESULT_ARTIFACT_TAIL_BYTES,
+		shownRange: { start: shownStart, end: truncated.totalLines },
+		artifactId,
+	};
+
+	const newMeta: OutputMeta = { ...(existingMeta ?? {}), truncation: truncationMeta };
+	const newDetails = { ...(result.details ?? {}), meta: newMeta };
+
+	return { ...result, content: newContent, details: newDetails };
+}
+
+// =============================================================================
+// Tool wrapper
+// =============================================================================
+
 async function wrappedExecute(
 	this: AgentTool & { [kUnwrappedExecute]: AgentToolExecFn },
 	toolCallId: string,
@@ -443,8 +530,12 @@ async function wrappedExecute(
 	const originalExecute = this[kUnwrappedExecute];
 
 	try {
+		let result = await originalExecute.call(this, toolCallId, params, signal, onUpdate, context);
+
+		// Spill large results to artifact, truncate to tail
+		result = await spillLargeResultToArtifact(result, this.name, context);
+
 		// Append notices from meta
-		const result = await originalExecute.call(this, toolCallId, params, signal, onUpdate, context);
 		const meta = (result.details as { meta?: OutputMeta } | undefined)?.meta;
 		if (meta) {
 			return {

--- a/packages/coding-agent/src/tools/output-meta.ts
+++ b/packages/coding-agent/src/tools/output-meta.ts
@@ -496,14 +496,16 @@ async function spillLargeResultToArtifact(
 	newContent.push({ type: "text", text: truncated.content });
 
 	// Build truncation meta
-	const shownStart = truncated.totalLines - truncated.outputLines + 1;
+	const outputLines = truncated.outputLines ?? truncated.totalLines;
+	const outputBytes = truncated.outputBytes ?? truncated.totalBytes;
+	const shownStart = truncated.totalLines - outputLines + 1;
 	const truncationMeta: TruncationMeta = {
 		direction: "tail",
 		truncatedBy: truncated.truncatedBy ?? "bytes",
 		totalLines: truncated.totalLines,
 		totalBytes: truncated.totalBytes,
-		outputLines: truncated.outputLines,
-		outputBytes: truncated.outputBytes,
+		outputLines,
+		outputBytes,
 		maxBytes: RESULT_ARTIFACT_TAIL_BYTES,
 		shownRange: { start: shownStart, end: truncated.totalLines },
 		artifactId,


### PR DESCRIPTION
## What

Spills over all tool calls and shows the end instead of select ones.
Adds a setting to view token usage per turn.

## Why

Some tool calls spill thousands of tokens when only tail is relevant. 
Helpful for debugging context hammering.

## Notes

Possibly remove tool specific artifacts as it is now centralized.

## Testing

-

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
