### PR TITLE
fix(ai): filter sentinel apiKey in google-vertex resolveApiKey

### DIFF
--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -338,7 +338,11 @@ function createClientWithApiKey(model: Model<"google-vertex">, apiKey: string): 
 }
 
 function resolveApiKey(options?: GoogleVertexOptions): string | undefined {
-	return options?.apiKey || $env.GOOGLE_CLOUD_API_KEY;
+	// options.apiKey may contain sentinel values like "<authenticated>" or "N/A"
+	// leaked from the agent loop — only use it if it looks like a real API key.
+	const optKey = options?.apiKey;
+	const realKey = optKey && !optKey.startsWith("<") && optKey !== "N/A" ? optKey : undefined;
+	return realKey || $env.GOOGLE_CLOUD_API_KEY;
 }
 
 function resolveProject(options?: GoogleVertexOptions): string {

--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -434,6 +434,48 @@ describe("Generate E2E Tests", () => {
 			}
 		});
 
+		it("ignores sentinel apiKey values like '<authenticated>' passed from agent loop", async () => {
+			const originalProject = Bun.env.GOOGLE_CLOUD_PROJECT;
+			const originalLocation = Bun.env.GOOGLE_CLOUD_LOCATION;
+			const originalApiKey = Bun.env.GOOGLE_CLOUD_API_KEY;
+			const llm = getBundledModel("google-vertex", "gemini-3-flash-preview");
+			const controller = new AbortController();
+			controller.abort();
+
+			// Capture console.debug to detect SDK warnings
+			const debugMessages: string[] = [];
+			const origDebug = console.debug;
+			console.debug = (...args: unknown[]) => {
+				debugMessages.push(args.map(String).join(" "));
+			};
+
+			try {
+				Bun.env.GOOGLE_CLOUD_PROJECT = "test-project";
+				Bun.env.GOOGLE_CLOUD_LOCATION = "us-central1";
+				delete Bun.env.GOOGLE_CLOUD_API_KEY;
+
+				// The agent loop passes "<authenticated>" as apiKey for credential-less providers.
+				// google-vertex should ignore this sentinel and use ADC (project/location) instead.
+				await complete(
+					llm,
+					{ messages: [{ role: "user", content: "Hello", timestamp: Date.now() }] },
+					{ apiKey: "<authenticated>", signal: controller.signal },
+				);
+
+				// Should NOT trigger the SDK warning about API key taking precedence
+				const hasWarning = debugMessages.some(m => m.includes("API key will take precedence"));
+				expect(hasWarning).toBe(false);
+			} finally {
+				console.debug = origDebug;
+				if (originalProject === undefined) delete Bun.env.GOOGLE_CLOUD_PROJECT;
+				else Bun.env.GOOGLE_CLOUD_PROJECT = originalProject;
+				if (originalLocation === undefined) delete Bun.env.GOOGLE_CLOUD_LOCATION;
+				else Bun.env.GOOGLE_CLOUD_LOCATION = originalLocation;
+				if (originalApiKey === undefined) delete Bun.env.GOOGLE_CLOUD_API_KEY;
+				else Bun.env.GOOGLE_CLOUD_API_KEY = originalApiKey;
+			}
+		});
+
 		it("allows explicit Vertex API keys without requiring project or location", async () => {
 			const originalApiKey = Bun.env.GOOGLE_CLOUD_API_KEY;
 			const originalProject = Bun.env.GOOGLE_CLOUD_PROJECT;


### PR DESCRIPTION
## Summary

- Filter sentinel values (`"<authenticated>"`, `"N/A"`) in `google-vertex.ts`'s `resolveApiKey` so they aren't passed to the `GoogleGenAI` SDK as real API keys
- Adds regression test that captures `console.debug` to verify the SDK warning is not emitted

Follow-up to #362 which fixed the same class of bug in `google.ts`. That fix was correct but insufficient — between #362 and v13.11.1, new code was added to `google-vertex.ts` (`resolveApiKey` / `createClientWithApiKey`) that introduced the same bug on a separate code path. The agent loop (`agent-loop.ts:332`) passes `"<authenticated>"` as `options.apiKey` for providers using ADC, and the new `resolveApiKey` treated it as a real key, passing it to `new GoogleGenAI({ vertexai: true, apiKey: "<authenticated>" })`.

Fixes #361

## Test plan

- [x] New test: `"ignores sentinel apiKey values like '<authenticated>' passed from agent loop"` — fails before fix, passes after
- [x] Existing test: `"allows explicit Vertex API keys without requiring project or location"` — still passes (real API keys work)
- [x] All 3 google-vertex env auth tests pass
- [x] `tsgo -p packages/ai/tsconfig.json` clean