### PR TITLE
fix(browser): route localhost through proxy when PUPPETEER_PROXY_BYPASS_LOOPBACK is set

### DIFF
--- a/packages/coding-agent/src/tools/browser.ts
+++ b/packages/coding-agent/src/tools/browser.ts
@@ -526,9 +526,12 @@ export class BrowserTool implements AgentTool<typeof browserSchema, BrowserToolD
 		const proxy = process.env.PUPPETEER_PROXY;
 		if (proxy) {
 			launchArgs.push(`--proxy-server=${proxy}`);
-			// Chrome (since v72) bypasses proxies for localhost by default; <-loopback> disables that
-			// so traffic to localhost:3000 reaches mitmdump and can be captured for auth flow analysis
-			launchArgs.push("--proxy-bypass-list=<-loopback>");
+			// Chrome (since v72) bypasses proxies for localhost by default. When PUPPETEER_PROXY_BYPASS_LOOPBACK
+			// is true, add <-loopback> so traffic to localhost reaches the proxy (e.g. for mitmdump/auth capture).
+			const bypassLoopback = process.env.PUPPETEER_PROXY_BYPASS_LOOPBACK?.toLowerCase();
+			if (bypassLoopback === "true" || bypassLoopback === "1" || bypassLoopback === "yes" || bypassLoopback === "on") {
+				launchArgs.push("--proxy-bypass-list=<-loopback>");
+			}
 		}
 		const ignoreCert = process.env.PUPPETEER_PROXY_IGNORE_CERT_ERRORS?.toLowerCase();
 		if (ignoreCert === "true" || ignoreCert === "1" || ignoreCert === "yes" || ignoreCert === "on") {


### PR DESCRIPTION
## Problem

Chrome (since v72) bypasses proxies for localhost and loopback addresses by default. When `PUPPETEER_PROXY` is set, traffic to `localhost:3000` never reaches the proxy (e.g. mitmdump), so proxy logs miss browser requests and auth flows cannot be captured.

## Solution

Add `--proxy-bypass-list=<-loopback>` when both:
- `PUPPETEER_PROXY` is set (proxy URL)
- `PUPPETEER_PROXY_BYPASS_LOOPBACK` is true/1/yes/on

This is opt-in so users who use a proxy for remote targets are unaffected. 

## References

- [Chrome bypass rules](https://chromium.googlesource.com/chromium/src/+/main/net/docs/proxy.md)
- [Proxy localhost and loopback](https://zzz.buzz/2019/12/12/proxy-localhost-and-loopback-in-chrome/)