### PR TITLE
fix(coding-agent): suppress false maintenance-failed warning on benign compaction skips

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -554,6 +554,8 @@ export interface AutoCompactionEndEvent {
 	aborted: boolean;
 	willRetry: boolean;
 	errorMessage?: string;
+	/** True when compaction was skipped for a benign reason (no model, no candidates, nothing to compact). */
+	skipped?: boolean;
 }
 
 /** Fired when auto-retry starts */

--- a/packages/coding-agent/src/extensibility/hooks/types.ts
+++ b/packages/coding-agent/src/extensibility/hooks/types.ts
@@ -406,6 +406,8 @@ export interface AutoCompactionEndEvent {
 	aborted: boolean;
 	willRetry: boolean;
 	errorMessage?: string;
+	/** True when compaction was skipped for a benign reason (no model, no candidates, nothing to compact). */
+	skipped?: boolean;
 }
 
 /** Event data for auto_retry_start event. */

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -484,6 +484,9 @@ export class EventController {
 					this.ctx.updateEditorTopBorder();
 					await this.ctx.reloadTodos();
 					this.ctx.showStatus("Auto-handoff completed");
+				} else if (event.skipped) {
+					// Benign skip: no model selected, no candidate models available, or nothing
+					// to compact yet. Not a failure — suppress the warning.
 				} else {
 					this.ctx.showWarning("Auto context-full maintenance failed; continuing without maintenance");
 				}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -145,6 +145,8 @@ export type AgentSessionEvent =
 			aborted: boolean;
 			willRetry: boolean;
 			errorMessage?: string;
+			/** True when compaction was skipped for a benign reason (no model, no candidates, nothing to compact). */
+			skipped?: boolean;
 	  }
 	| { type: "auto_retry_start"; attempt: number; maxAttempts: number; delayMs: number; errorMessage: string }
 	| { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
@@ -1442,6 +1444,7 @@ export class AgentSession {
 				aborted: event.aborted,
 				willRetry: event.willRetry,
 				errorMessage: event.errorMessage,
+				skipped: event.skipped,
 			});
 		} else if (event.type === "auto_retry_start") {
 			await this.#extensionRunner.emit({
@@ -3853,6 +3856,7 @@ export class AgentSession {
 					result: undefined,
 					aborted: false,
 					willRetry: false,
+					skipped: true,
 				});
 				return;
 			}
@@ -3865,6 +3869,7 @@ export class AgentSession {
 					result: undefined,
 					aborted: false,
 					willRetry: false,
+					skipped: true,
 				});
 				return;
 			}
@@ -3879,6 +3884,7 @@ export class AgentSession {
 					result: undefined,
 					aborted: false,
 					willRetry: false,
+					skipped: true,
 				});
 				if (!willRetry && this.agent.hasQueuedMessages()) {
 					this.#scheduleAgentContinue({


### PR DESCRIPTION
## What

Add a `skipped?: boolean` field to the `auto_compaction_end` event and set it on the three early-return paths in `#runAutoCompaction` that exit without compacting for benign reasons. Update the event-controller to treat `skipped` events as silent no-ops instead of showing a failure warning.

Fixes #395

## Why

Three early-return paths in `#runAutoCompaction` all emitted `auto_compaction_end` with `result: undefined`, `aborted: false`, and no `errorMessage`:

1. No model selected
2. No candidate models available
3. `prepareCompaction` returns `null` (nothing to compact)

The event-controller had no way to distinguish these benign skips from a genuine compaction failure, and fell through to show:

> Auto context-full maintenance failed; continuing without maintenance

The most common trigger: after a successful compaction, the last session branch entry is a compaction record. The next threshold check calls `prepareCompaction`, which returns `undefined` immediately (line 1085: "last entry is already a compaction"). This emits a soft-skip event with `result: undefined, aborted: false, errorMessage: undefined` — which previously surfaced as the false warning.

## Testing

`bunx tsc -p packages/coding-agent/tsconfig.json --noEmit` passes clean.

Runtime verification requires a real session reaching the compaction threshold:
1. Use OMP until auto-compaction fires and completes
2. Send another message — the subsequent threshold check will find nothing new to compact (`prepareCompaction` returns `undefined` because the last entry is already a compaction)
3. **Before fix**: warning appears. **After fix**: silent no-op.

Genuine failures (compaction attempted and errored, all candidate models exhausted) still surface via `errorMessage` — that code path is unchanged.