### PR TITLE
feat(ai): update Claude 4.6 context window to 1M (GA)

### DIFF
--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -288,11 +288,6 @@ function applyAnthropicCatalogPolicy(model: ApiModel<Api>, parsedModel: Anthropi
 		model.cost.cacheWrite = 6.25;
 	}
 
-	// Opus 4.6 / Sonnet 4.6: 1M context is beta; clamp to 200K.
-	if (semverEqual(parsedModel.version, "4.6")) {
-		model.contextWindow = 200000;
-	}
-
 	// OpenCode variants: Claude Sonnet 4/4.5 listed with 1M context, actual limit is 200K.
 	if (
 		(model.provider === "opencode-zen" || model.provider === "opencode-go") &&

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -342,7 +342,7 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 6.25
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1000000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
@@ -693,7 +693,7 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 6.25
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1000000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
@@ -768,7 +768,7 @@
 				"cacheRead": 0.3,
 				"cacheWrite": 3.75
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1000000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "budget",
@@ -863,7 +863,7 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 6.25
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1000000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
@@ -938,7 +938,7 @@
 				"cacheRead": 0.3,
 				"cacheWrite": 3.75
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1000000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "budget",
@@ -1691,7 +1691,7 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 6.25
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1000000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
@@ -1766,7 +1766,7 @@
 				"cacheRead": 0.3,
 				"cacheWrite": 3.75
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1000000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "budget",
@@ -2310,7 +2310,7 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 6.25
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1000000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "anthropic-adaptive",
@@ -2435,7 +2435,7 @@
 				"cacheRead": 0.3,
 				"cacheWrite": 3.75
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1000000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "anthropic-adaptive",
@@ -2803,7 +2803,7 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 6.25
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1000000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "anthropic-adaptive",
@@ -2878,7 +2878,7 @@
 				"cacheRead": 0.3,
 				"cacheWrite": 3.75
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1000000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "anthropic-adaptive",
@@ -6022,7 +6022,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1000000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "budget",
@@ -6139,7 +6139,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1000000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
@@ -30397,7 +30397,7 @@
 				"cacheRead": 0.5,
 				"cacheWrite": 6.25
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1000000,
 			"maxTokens": 128000,
 			"thinking": {
 				"mode": "anthropic-adaptive",
@@ -30472,7 +30472,7 @@
 				"cacheRead": 0.3,
 				"cacheWrite": 3.75
 			},
-			"contextWindow": 200000,
+			"contextWindow": 1000000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "anthropic-adaptive",

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -177,7 +177,7 @@ describe("generated model policies", () => {
 		});
 		expect(models[1]?.cost.cacheRead).toBe(0.5);
 		expect(models[1]?.cost.cacheWrite).toBe(6.25);
-		expect(models[1]?.contextWindow).toBe(200000);
+		expect(models[1]?.contextWindow).toBe(1000000);
 		expect(models[2]?.contextWindow).toBe(272000);
 	});
 


### PR DESCRIPTION
Anthropic made the 1M-token context window generally available for Claude Opus 4.6 and Sonnet 4.6, dropping the long-context pricing premium entirely.

## Changes

- Remove the `applyAnthropicCatalogPolicy` 200K context clamp for version 4.6 in `model-thinking.ts`
- Update all 4.6 model entries in `models.json` to `contextWindow: 1000000`

No pricing changes needed — already correct ($5/$25 Opus, $3/$15 Sonnet).

## Ref

https://awesomeagents.ai/news/anthropic-1m-context-ga-opus-sonnet/