### PR TITLE
fix(ai): remove 200K context clamp for Claude Opus 4.6 / Sonnet 4.6

### DIFF
--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -288,11 +288,6 @@ function applyAnthropicCatalogPolicy(model: ApiModel<Api>, parsedModel: Anthropi
 		model.cost.cacheWrite = 6.25;
 	}
 
-	// Opus 4.6 / Sonnet 4.6: 1M context is beta; clamp to 200K.
-	if (semverEqual(parsedModel.version, "4.6")) {
-		model.contextWindow = 200000;
-	}
-
 	// OpenCode variants: Claude Sonnet 4/4.5 listed with 1M context, actual limit is 200K.
 	if (
 		(model.provider === "opencode-zen" || model.provider === "opencode-go") &&

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -177,7 +177,7 @@ describe("generated model policies", () => {
 		});
 		expect(models[1]?.cost.cacheRead).toBe(0.5);
 		expect(models[1]?.cost.cacheWrite).toBe(6.25);
-		expect(models[1]?.contextWindow).toBe(200000);
+		expect(models[1]?.contextWindow).toBe(1000000);
 		expect(models[2]?.contextWindow).toBe(272000);
 	});
 


### PR DESCRIPTION
## Summary

As of March 13 2026, Anthropic made the 1M context window generally available for Claude Opus 4.6 and Sonnet 4.6 at standard pricing — no beta header required, no long-context pricing premium.

The blanket clamp in `applyAnthropicCatalogPolicy` that forced all version 4.6 models to 200K is no longer correct. This causes the status bar to show >100% context usage (e.g. `105%/200K`) while the API happily accepts up to 1M, and auto-compaction fires against a stale limit.

## Changes

- **`packages/ai/src/model-thinking.ts`**: Remove the `semverEqual(parsedModel.version, "4.6")` context window override (lines 291-294)
- **`packages/ai/src/models.json`**: Regenerated — first-party Anthropic entries now report 1M; Bedrock entries remain at 200K (matches their upstream catalog)
- **`packages/ai/test/model-thinking.test.ts`**: Updated assertion to expect 1M instead of 200K for the Bedrock Opus 4.6 test fixture (policy no longer clamps it)

## Reference

- [Anthropic announcement](https://platform.claude.com/docs/en/about-claude/models/overview) — Opus 4.6 and Sonnet 4.6 context window listed as 1M
- [Context windows docs](https://platform.claude.com/docs/en/build-with-claude/context-windows) — confirms 1M GA, no beta header needed

## Testing

```
bun test ./packages/ai/test/ — 396 pass, 0 fail
```