### PR TITLE
fix(coding-agent) Restrict automatic session title generation to the resolved smol model otherwise current.

### DIFF
--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -322,7 +322,7 @@ export class InputController {
 			const hasUserMessages = this.ctx.session.messages.some((m: AgentMessage) => m.role === "user");
 			if (!hasUserMessages && !this.ctx.sessionManager.getSessionName() && !$env.PI_NO_TITLE) {
 				const registry = this.ctx.session.modelRegistry;
-				generateSessionTitle(text, registry, this.ctx.settings, this.ctx.session.sessionId)
+				generateSessionTitle(text, registry, this.ctx.settings, this.ctx.session.sessionId, this.ctx.session.model)
 					.then(async title => {
 						if (title) {
 							await this.ctx.sessionManager.setSessionName(title);

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -19,6 +19,7 @@ const MAX_INPUT_CHARS = 2000;
 function getTitleModel(
 	registry: ModelRegistry,
 	settings: Settings,
+	currentModel?: Model<Api>,
 ): { model: Model<Api>; thinkingLevel?: ThinkingLevel } | undefined {
 	const availableModels = registry.getAvailable();
 	if (availableModels.length === 0) return undefined;
@@ -30,6 +31,10 @@ function getTitleModel(
 	});
 	if (configuredSmol.model) {
 		return { model: configuredSmol.model, thinkingLevel: configuredSmol.thinkingLevel };
+	}
+
+	if (currentModel) {
+		return { model: currentModel };
 	}
 
 	return undefined;
@@ -48,10 +53,11 @@ export async function generateSessionTitle(
 	registry: ModelRegistry,
 	settings: Settings,
 	sessionId?: string,
+	currentModel?: Model<Api>,
 ): Promise<string | null> {
-	const candidate = getTitleModel(registry, settings);
+	const candidate = getTitleModel(registry, settings, currentModel);
 	if (!candidate) {
-		logger.debug("title-generator: no smol model found");
+		logger.debug("title-generator: no title model found");
 		return null;
 	}
 


### PR DESCRIPTION
• ## What                                                                                                                                                                                                          
                                                                                                                                                                                                                   
  Restrict automatic session title generation to the resolved `smol` model otherwise to current.
                                                                                                         
  ## Why

  The first prompt could previously trigger title-generation requests against multiple logged-in providers because the title generator iterated across all available authenticated models until one succeeded. That
  was the wrong policy for a `smol`-only path and could cause unexpected provider activity and token waste unrelated to the selected chat model.

  Fixes [#408](https://github.com/can1357/oh-my-pi/issues/408).

  ## Testing

  Ran local validation:
  - `bun install`
  - `cargo fetch --locked`
  - `bun check`

  ---

  - [x] `bun check` passes
  - [x] Tested locally
  - [ ] CHANGELOG updated (if user-facing)