### PR TITLE
fix(move): resolve quoted Windows paths and fresh-session ENOENT

### DIFF
--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -27,7 +27,7 @@ import type { InteractiveModeContext } from "../../modes/types";
 import type { AsyncJobSnapshotItem } from "../../session/agent-session";
 import type { AuthStorage } from "../../session/auth-storage";
 import { outputMeta } from "../../tools/output-meta";
-import { resolveToCwd } from "../../tools/path-utils";
+import { resolveToCwd, stripOuterDoubleQuotes } from "../../tools/path-utils";
 import { replaceTabs } from "../../tools/render-utils";
 import { getChangelogPath, parseChangelog } from "../../utils/changelog";
 import { openPath } from "../../utils/open";
@@ -679,8 +679,14 @@ export class CommandController {
 			return;
 		}
 
+		const unquoted = stripOuterDoubleQuotes(targetPath);
+		if (!unquoted) {
+			this.ctx.showError("Usage: /move <path>");
+			return;
+		}
+
 		const cwd = this.ctx.sessionManager.getCwd();
-		const resolvedPath = resolveToCwd(targetPath, cwd);
+		const resolvedPath = resolveToCwd(unquoted, cwd);
 
 		try {
 			const stat = await fs.stat(resolvedPath);

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1449,6 +1449,7 @@ export class SessionManager {
 		if (resolvedCwd === this.cwd) return;
 
 		const newSessionDir = getDefaultSessionDir(resolvedCwd, this.storage);
+		let hadSessionFile = false;
 
 		if (this.persist && this.#sessionFile) {
 			// Close the persist writer before moving files
@@ -1461,12 +1462,16 @@ export class SessionManager {
 			const newSessionFile = path.join(newSessionDir, path.basename(oldSessionFile));
 			const oldArtifactDir = oldSessionFile.slice(0, -6); // strip .jsonl
 			const newArtifactDir = newSessionFile.slice(0, -6);
+			hadSessionFile = this.storage.existsSync(oldSessionFile);
 			let movedSessionFile = false;
 			let movedArtifactDir = false;
 
 			try {
-				await fs.promises.rename(oldSessionFile, newSessionFile);
-				movedSessionFile = true;
+				// Guard: session file may not exist yet (no assistant messages persisted)
+				if (hadSessionFile) {
+					await fs.promises.rename(oldSessionFile, newSessionFile);
+					movedSessionFile = true;
+				}
 
 				try {
 					const stat = await fs.promises.stat(oldArtifactDir);
@@ -1511,8 +1516,14 @@ export class SessionManager {
 			header.cwd = resolvedCwd;
 		}
 
-		// Rewrite the session file at its new location with updated header
-		if (this.persist && this.#sessionFile) {
+		// Rewrite the session file at its new location with updated header.
+		// hadSessionFile: file existed before move → must rewrite to update cwd
+		// hasAssistant: assistant messages in memory but file missing → recreate from memory
+		// Neither true → fresh session, never written → preserve lazy-persist
+		const hasAssistant = this.#fileEntries.some(
+			e => e.type === "message" && e.message.role === "assistant",
+		);
+		if (this.persist && this.#sessionFile && (hadSessionFile || hasAssistant)) {
 			await this.#rewriteFile();
 		}
 

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -111,6 +111,17 @@ export function resolveToCwd(filePath: string, cwd: string): string {
 	return path.resolve(cwd, expanded);
 }
 
+/**
+ * Strip matching surrounding double quotes from a path string.
+ * Common when users paste quoted paths from Windows Explorer or shell copy-paste.
+ * Only double quotes — single quotes are valid POSIX filename characters.
+ * Tradeoff: a POSIX path literally starting AND ending with " would also be unquoted.
+ * Accepted because such names are virtually nonexistent in practice.
+ */
+export function stripOuterDoubleQuotes(input: string): string {
+	return input.startsWith('"') && input.endsWith('"') && input.length > 1 ? input.slice(1, -1) : input;
+}
+
 const GLOB_PATH_CHARS = ["*", "?", "[", "{"] as const;
 
 export function hasGlobPathChars(filePath: string): boolean {

--- a/packages/coding-agent/test/session-manager/move-to.test.ts
+++ b/packages/coding-agent/test/session-manager/move-to.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	SessionManager,
+	loadEntriesFromFile,
+	type SessionHeader,
+} from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { stripOuterDoubleQuotes } from "@oh-my-pi/pi-coding-agent/tools/path-utils";
+import { getConfigRootDir, setAgentDir } from "@oh-my-pi/pi-utils";
+
+// -- helpers ----------------------------------------------------------------
+
+function makeAssistantMessage() {
+	return {
+		role: "assistant" as const,
+		content: [{ type: "text" as const, text: "ok" }],
+		api: "anthropic-messages" as const,
+		provider: "anthropic" as const,
+		model: "claude-sonnet-4-20250514",
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop" as const,
+		timestamp: Date.now(),
+	};
+}
+
+function getHeader(entries: unknown[]): SessionHeader | undefined {
+	return entries.find(
+		(e): e is SessionHeader => typeof e === "object" && e !== null && "type" in e && (e as any).type === "session",
+	) as SessionHeader | undefined;
+}
+
+function hasAssistantEntry(entries: unknown[]): boolean {
+	return entries.some(
+		(e) =>
+			typeof e === "object" &&
+			e !== null &&
+			"type" in e &&
+			(e as any).type === "message" &&
+			"message" in e &&
+			(e as any).message?.role === "assistant",
+	);
+}
+
+// -- stripOuterDoubleQuotes tests -------------------------------------------
+
+describe("stripOuterDoubleQuotes", () => {
+	it("strips matching double quotes", () => {
+		expect(stripOuterDoubleQuotes('"C:\\Users\\test"')).toBe("C:\\Users\\test");
+	});
+	it("strips matching double quotes from POSIX paths", () => {
+		expect(stripOuterDoubleQuotes('"/home/user/test"')).toBe("/home/user/test");
+	});
+	it("passes through unquoted paths", () => {
+		expect(stripOuterDoubleQuotes("C:\\Users\\test")).toBe("C:\\Users\\test");
+	});
+	it("does not strip mismatched quotes", () => {
+		expect(stripOuterDoubleQuotes('"mismatched')).toBe('"mismatched');
+	});
+	it("does not strip single quotes", () => {
+		expect(stripOuterDoubleQuotes("'foo'")).toBe("'foo'");
+	});
+	it("does not strip a lone double quote", () => {
+		expect(stripOuterDoubleQuotes('"')).toBe('"');
+	});
+	it("strips empty quoted string to empty", () => {
+		expect(stripOuterDoubleQuotes('""')).toBe("");
+	});
+});
+
+// -- moveTo() tests ---------------------------------------------------------
+
+describe("SessionManager.moveTo", () => {
+	let testAgentDir: string;
+	let cwdA: string;
+	let cwdB: string;
+	const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+	const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+
+	beforeEach(async () => {
+		testAgentDir = await fsp.mkdtemp(path.join(os.tmpdir(), "omp-move-test-"));
+		setAgentDir(testAgentDir);
+		cwdA = path.join(testAgentDir, "cwd-a");
+		cwdB = path.join(testAgentDir, "cwd-b");
+		fs.mkdirSync(cwdA, { recursive: true });
+		fs.mkdirSync(cwdB, { recursive: true });
+	});
+
+	afterEach(async () => {
+		if (originalAgentDir) {
+			setAgentDir(originalAgentDir);
+		} else {
+			setAgentDir(fallbackAgentDir);
+			delete process.env.PI_CODING_AGENT_DIR;
+		}
+		await fsp.rm(testAgentDir, { recursive: true, force: true });
+	});
+
+	it("moves session file and updates header cwd (baseline)", async () => {
+		const session = SessionManager.create(cwdA);
+		session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+		session.appendMessage(makeAssistantMessage());
+		await session.flush();
+
+		const oldFile = session.getSessionFile()!;
+		expect(fs.existsSync(oldFile)).toBe(true);
+
+		await session.moveTo(cwdB);
+
+		expect(session.getCwd()).toBe(path.resolve(cwdB));
+		expect(fs.existsSync(oldFile)).toBe(false);
+
+		const newFile = session.getSessionFile()!;
+		expect(fs.existsSync(newFile)).toBe(true);
+
+		// Reload and verify content
+		const entries = await loadEntriesFromFile(newFile);
+		const header = getHeader(entries);
+		expect(header?.cwd).toBe(path.resolve(cwdB));
+		expect(hasAssistantEntry(entries)).toBe(true);
+	});
+
+	it("succeeds on fresh session without ENOENT, then deferred persistence works", async () => {
+		const session = SessionManager.create(cwdA);
+		// No messages — file never written to disk
+		const oldFile = session.getSessionFile()!;
+		expect(fs.existsSync(oldFile)).toBe(false);
+
+		await session.moveTo(cwdB);
+
+		expect(session.getCwd()).toBe(path.resolve(cwdB));
+		const newFile = session.getSessionFile()!;
+		// Lazy-persist preserved: no header-only .jsonl created
+		expect(fs.existsSync(newFile)).toBe(false);
+
+		// Verify deferred persistence at the new path
+		session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+		session.appendMessage(makeAssistantMessage());
+		await session.flush();
+
+		expect(fs.existsSync(newFile)).toBe(true);
+		const entries = await loadEntriesFromFile(newFile);
+		const header = getHeader(entries);
+		expect(header?.cwd).toBe(path.resolve(cwdB));
+	});
+
+	it("recreates file from memory when old file is deleted (assistant exists)", async () => {
+		const session = SessionManager.create(cwdA);
+		session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+		session.appendMessage(makeAssistantMessage());
+		await session.flush();
+		await session.close();
+
+		const oldFile = session.getSessionFile()!;
+		// Delete the file to simulate unexpected removal
+		await fsp.unlink(oldFile);
+		expect(fs.existsSync(oldFile)).toBe(false);
+
+		await session.moveTo(cwdB);
+
+		expect(session.getCwd()).toBe(path.resolve(cwdB));
+		const newFile = session.getSessionFile()!;
+		expect(fs.existsSync(newFile)).toBe(true);
+
+		// Verify content recreated from memory
+		const entries = await loadEntriesFromFile(newFile);
+		const header = getHeader(entries);
+		expect(header?.cwd).toBe(path.resolve(cwdB));
+		expect(hasAssistantEntry(entries)).toBe(true);
+	});
+
+	it("moves header-only session and rewrites cwd", async () => {
+		// Create a header-only session via open() with a non-existent explicit path
+		const explicitPath = path.join(cwdA, "explicit-session.jsonl");
+		const session = await SessionManager.open(explicitPath);
+
+		expect(fs.existsSync(explicitPath)).toBe(true);
+
+		await session.moveTo(cwdB);
+
+		expect(session.getCwd()).toBe(path.resolve(cwdB));
+		expect(fs.existsSync(explicitPath)).toBe(false);
+
+		const newFile = session.getSessionFile()!;
+		expect(fs.existsSync(newFile)).toBe(true);
+
+		const entries = await loadEntriesFromFile(newFile);
+		const header = getHeader(entries);
+		expect(header?.cwd).toBe(path.resolve(cwdB));
+	});
+
+	it("moves header-only session with pending user message (#flushed regression)", async () => {
+		// Create a header-only session
+		const explicitPath = path.join(cwdA, "explicit-session-2.jsonl");
+		const session = await SessionManager.open(explicitPath);
+
+		expect(fs.existsSync(explicitPath)).toBe(true);
+
+		// Add a user message only — _persist() sets #flushed=false (line 1827)
+		session.appendMessage({ role: "user", content: "hello", timestamp: 1 });
+
+		await session.moveTo(cwdB);
+
+		expect(session.getCwd()).toBe(path.resolve(cwdB));
+		expect(fs.existsSync(explicitPath)).toBe(false);
+
+		const newFile = session.getSessionFile()!;
+		expect(fs.existsSync(newFile)).toBe(true);
+
+		// Rewrite must have run (hadSessionFile=true) even though #flushed was reset
+		const entries = await loadEntriesFromFile(newFile);
+		const header = getHeader(entries);
+		expect(header?.cwd).toBe(path.resolve(cwdB));
+	});
+
+	it("moves artifact dir independently when session file does not exist", async () => {
+		const session = SessionManager.create(cwdA);
+		// Allocate an artifact — creates dir via ArtifactManager
+		const { path: artifactPath } = await session.allocateArtifactPath("bash");
+		if (!artifactPath) throw new Error("Expected artifact path");
+
+		const oldArtifactDir = path.dirname(artifactPath);
+		expect(fs.existsSync(oldArtifactDir)).toBe(true);
+
+		// No messages — session file doesn't exist
+		const oldFile = session.getSessionFile()!;
+		expect(fs.existsSync(oldFile)).toBe(false);
+
+		await session.moveTo(cwdB);
+
+		expect(session.getCwd()).toBe(path.resolve(cwdB));
+		// Old artifact dir moved
+		expect(fs.existsSync(oldArtifactDir)).toBe(false);
+		// New artifact dir exists
+		const newFile = session.getSessionFile()!;
+		const newArtifactDir = newFile.slice(0, -6); // strip .jsonl
+		expect(fs.existsSync(newArtifactDir)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Fixes #416. Two `/move` bugs on Windows:

- **Quoted absolute paths** like `/move "C:\Users\...\project 2026"` were treated as relative because surrounding `"` weren't stripped before `path.isAbsolute()` check
- **Fresh session ENOENT** — `/move` before any model response threw ENOENT because the session `.jsonl` file hadn't been created on disk yet (lazy-persist defers until first assistant message)

## Changes

- **`path-utils.ts`**: Add `stripOuterDoubleQuotes()` helper (double quotes only — single quotes are valid POSIX filename chars)
- **`command-controller.ts`**: Use the helper in `handleMoveCommand()` with empty-after-strip guard for `/move ""`
- **`session-manager.ts`**: In `moveTo()`:
  - Guard session file rename with `existsSync` (skip if file doesn't exist yet)
  - Guard artifact dir rename independently (artifacts can exist before session file)
  - Guard `#rewriteFile()` with `hadSessionFile || hasAssistant` to preserve lazy-persist while updating header cwd for existing files
- **`move-to.test.ts`**: 13 tests covering:
  - `stripOuterDoubleQuotes` string logic (7 cases including edge cases)
  - Baseline move with content verification (header cwd + assistant message preserved)
  - Fresh session move without ENOENT + deferred persistence at new path
  - Deleted file recreation from in-memory entries
  - Header-only session cwd rewrite (from `--session`/`fork()`)
  - Header-only + user message regression (`#flushed` reset by `_persist()`)
  - Artifact dir migration when session file doesn't exist

## Test plan

- [x] All 13 new tests pass (`bun test test/session-manager/move-to.test.ts`)
- [x] Type check passes (`bun run check`)
- [ ] Manual smoke test on native Windows/PowerShell: `/move "C:\Users\...\project 2026"`