### PR TITLE
fix(extension-tui): filtered it for / command, skills, and mcps

### DIFF
--- a/packages/coding-agent/src/extensibility/slash-commands.ts
+++ b/packages/coding-agent/src/extensibility/slash-commands.ts
@@ -185,12 +185,11 @@ export async function loadSlashCommands(options: LoadSlashCommandsOptions = {}):
 	const extensionDisabled = new Set(
 		settings
 			.get("disabledExtensions")
-			.filter(ext => ext.startsWith("slash-command"))
-			.map(ext => ext.replace("slash-command:", "")) || [],
+			.filter(ext => ext.startsWith("slash-command:"))
+			.map(ext => ext.replace("slash-command:", "")),
 	);
-	const filterdCommands = fileCommands.filter(cmd => !extensionDisabled.has(cmd.name));
 
-	const seenNames = new Set(filterdCommands.map(cmd => cmd.name));
+	const seenNames = new Set(fileCommands.map(cmd => cmd.name));
 	for (const cmd of EMBEDDED_SLASH_COMMANDS) {
 		const name = cmd.name.replace(/\.md$/, "");
 		if (seenNames.has(name)) continue;
@@ -208,7 +207,7 @@ export async function loadSlashCommands(options: LoadSlashCommandsOptions = {}):
 		seenNames.add(name);
 	}
 
-	return filterdCommands;
+	return fileCommands.filter(cmd => !extensionDisabled.has(cmd.name));
 }
 
 /**

--- a/packages/coding-agent/src/mcp/config-writer.ts
+++ b/packages/coding-agent/src/mcp/config-writer.ts
@@ -191,10 +191,9 @@ export async function readDisabledServers(filePath: string): Promise<string[]> {
 	const config = await readMCPConfigFile(filePath);
 	const extensionMcpConfig = settings
 		.get("disabledExtensions")
-		.filter(ext => ext.startsWith("mcp"))
+		.filter(ext => ext.startsWith("mcp:"))
 		.map(ext => ext.replace("mcp:", ""));
-	const combinedDisabled = [...(config.disabledServers ?? []), ...extensionMcpConfig];
-	return Array.isArray(combinedDisabled) ? combinedDisabled : [];
+	return [...(Array.isArray(config.disabledServers) ? config.disabledServers : []), ...extensionMcpConfig];
 }
 
 /**

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -631,7 +631,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		.get("disabledExtensions")
 		.filter(ext => ext.startsWith("skill:"))
 		.map(ext => ext.replace("skill:", ""));
-	skillsSettings.ignoredSkills = [...(skillsSettings.ignoredSkills ?? []), ...(systemFilterSkills ?? [])];
+	skillsSettings.ignoredSkills = [...(skillsSettings.ignoredSkills ?? []), ...systemFilterSkills];
 	const discoveredSkillsPromise =
 		options.skills === undefined ? discoverSkills(cwd, agentDir, skillsSettings) : undefined;
 
@@ -1017,7 +1017,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			configuredPaths,
 			cwd,
 			eventBus,
-			(settings.get("disabledExtensions") as string[]) ?? [],
+			settings.get("disabledExtensions"),
 		);
 		for (const { path, error } of extensionsResult.errors) {
 			logger.error("Failed to load extension", { path, error });


### PR DESCRIPTION
## What

add an little filter for command, skills and mcps in `disabledExtensions`

i don't know if this feature is wanted, maybe we need a different name, but this little pr fixed the original problem, which the `/extension` don't take effect。

## Why
fix #413


## Testing
`bun test` passed.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
