### PR TITLE
fix: extract timeout field from all MCP discovery providers

### DIFF
--- a/packages/coding-agent/src/discovery/claude.ts
+++ b/packages/coding-agent/src/discovery/claude.ts
@@ -89,6 +89,7 @@ async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> 
 			const serverConfig = config as Record<string, unknown>;
 			return {
 				name,
+				timeout: typeof serverConfig.timeout === "number" ? serverConfig.timeout : undefined,
 				command: serverConfig.command as string | undefined,
 				args: serverConfig.args as string[] | undefined,
 				env: serverConfig.env as Record<string, string> | undefined,

--- a/packages/coding-agent/src/discovery/codex.ts
+++ b/packages/coding-agent/src/discovery/codex.ts
@@ -197,6 +197,10 @@ function extractMCPServersFromToml(toml: Record<string, unknown>): Record<string
 		}
 		// Note: validation of transport vs endpoint is handled by mcpCapability.validate()
 
+		// Map Codex tool_timeout_sec (seconds) to MCPServer timeout (milliseconds)
+		if (typeof config.tool_timeout_sec === "number" && config.tool_timeout_sec > 0) {
+			server.timeout = config.tool_timeout_sec * 1000;
+		}
 		result[name] = server;
 	}
 

--- a/packages/coding-agent/src/discovery/cursor.ts
+++ b/packages/coding-agent/src/discovery/cursor.ts
@@ -65,6 +65,7 @@ function parseMCPServers(
 			transport: ["stdio", "sse", "http"].includes(serverConfig.type as string)
 				? (serverConfig.type as "stdio" | "sse" | "http")
 				: undefined,
+			timeout: typeof serverConfig.timeout === "number" ? serverConfig.timeout : undefined,
 			_source: createSourceMeta(PROVIDER_ID, path, level),
 		});
 	}

--- a/packages/coding-agent/src/discovery/gemini.ts
+++ b/packages/coding-agent/src/discovery/gemini.ts
@@ -110,6 +110,7 @@ async function loadMCPFromSettings(
 			transport: ["stdio", "sse", "http"].includes(raw.type as string)
 				? (raw.type as "stdio" | "sse" | "http")
 				: undefined,
+			timeout: typeof raw.timeout === "number" ? raw.timeout : undefined,
 			_source: createSourceMeta(PROVIDER_ID, path, level),
 		} as MCPServer);
 	}

--- a/packages/coding-agent/src/discovery/vscode.ts
+++ b/packages/coding-agent/src/discovery/vscode.ts
@@ -94,6 +94,7 @@ async function loadMCPConfig(
 			transport: ["stdio", "sse", "http"].includes(expanded.transport as string)
 				? (expanded.transport as "stdio" | "sse" | "http")
 				: undefined,
+			timeout: typeof expanded.timeout === "number" ? expanded.timeout : undefined,
 			_source: createSourceMeta(PROVIDER_ID, path, level),
 		};
 

--- a/packages/coding-agent/src/discovery/windsurf.ts
+++ b/packages/coding-agent/src/discovery/windsurf.ts
@@ -54,6 +54,7 @@ function parseServerConfig(
 			url: server.url as string | undefined,
 			headers: server.headers as Record<string, string> | undefined,
 			transport: server.type as "stdio" | "sse" | "http" | undefined,
+			timeout: typeof server.timeout === "number" ? server.timeout : undefined,
 			_source: createSourceMeta(PROVIDER_ID, path, scope),
 		},
 	};


### PR DESCRIPTION
## fix: extract `timeout` field from all MCP discovery providers

### Problem

The MCP transport layer reads `config.timeout ?? 30000` for every JSON-RPC request (connection init and tool calls). The `timeout` field is defined on the `MCPServer` interface and users can set it per-server in their config files. However, most discovery providers silently dropped the `timeout` field when constructing `MCPServer` objects, causing all servers to fall back to the 30-second hardcoded default regardless of user configuration.

### Root cause

Only `builtin`, `mcp-json`, and `opencode` providers were extracting `timeout` from parsed config. The remaining 5 providers that construct `MCPServer` objects -- `claude`, `gemini`, `cursor`, `vscode`, `windsurf` -- omitted it entirely. `codex` had its own `tool_timeout_sec` (in seconds) that was never mapped to the millisecond-based `MCPServer.timeout`.

### Fix

Extract `timeout` in all providers that were missing it:

| Provider | Change |
|---|---|
| `claude.ts` | `timeout: typeof serverConfig.timeout === "number" ? serverConfig.timeout : undefined` |
| `gemini.ts` | `timeout: typeof raw.timeout === "number" ? raw.timeout : undefined` |
| `cursor.ts` | `timeout: typeof serverConfig.timeout === "number" ? serverConfig.timeout : undefined` |
| `vscode.ts` | `timeout: typeof expanded.timeout === "number" ? expanded.timeout : undefined` |
| `windsurf.ts` | `timeout: typeof server.timeout === "number" ? server.timeout : undefined` |
| `codex.ts` | Map `tool_timeout_sec` (seconds) to `server.timeout` (milliseconds) |

`opencode` and `builtin`/`mcp-json` already had it -- no changes needed.

### Consumption point

The `timeout` value flows into `mcp/transports/http.ts` and `mcp/transports/stdio.ts` where it is used as `this.config.timeout ?? 30000` for request timeouts.
