### PR TITLE
fix: enable xhigh thinking level for OpenAI-compatible APIs

### DIFF
--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -386,8 +386,16 @@ function inferFallbackEfforts<TApi extends Api>(model: ApiModel<TApi>): readonly
 	if (model.api === "bedrock-converse-stream") {
 		return DEFAULT_REASONING_EFFORTS;
 	}
-	// OpenAI-compatible APIs and OpenAI Responses API support xhigh
-	if (model.api === "openai-completions" || model.api === "openai-responses" || model.api === "openai-codex-responses") {
+	if (model.api === "openai-completions") {
+		const compat = model.compat;
+		const usesDiscreteEfforts = compat?.thinkingFormat === undefined || compat.thinkingFormat === "openai";
+		if (usesDiscreteEfforts && compat?.supportsReasoningEffort !== false) {
+			return DEFAULT_REASONING_EFFORTS_WITH_XHIGH;
+		}
+		return DEFAULT_REASONING_EFFORTS;
+	}
+	// OpenAI Responses APIs encode discrete effort levels, including xhigh.
+	if (model.api === "openai-responses" || model.api === "openai-codex-responses") {
 		return DEFAULT_REASONING_EFFORTS_WITH_XHIGH;
 	}
 	return DEFAULT_REASONING_EFFORTS;

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -249,6 +249,34 @@ describe("model thinking runtime helpers", () => {
 		expect(requireSupportedEffort(model, Effort.XHigh)).toBe(Effort.XHigh);
 	});
 
+	it("does not expose xhigh for binary-thinking openai-compat transports", () => {
+		const model = enrichModelThinking({
+			id: "glm-4.7",
+			name: "GLM-4.7",
+			api: "openai-completions",
+			provider: "zai",
+			baseUrl: "https://api.z.ai/v1",
+			reasoning: true,
+			compat: {
+				thinkingFormat: "zai",
+			},
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 32000,
+		} satisfies Model<"openai-completions">);
+
+		expect(model.thinking).toEqual({
+			mode: "effort",
+			minLevel: Effort.Minimal,
+			maxLevel: Effort.High,
+		});
+		expect(requireSupportedEffort(model, Effort.High)).toBe(Effort.High);
+		expect(() => requireSupportedEffort(model, Effort.XHigh)).toThrow(
+			/Supported efforts: minimal, low, medium, high/,
+		);
+	});
+
 	it("enables xhigh for openai-responses and openai-codex-responses APIs", () => {
 		const responsesModel = createModel({
 			id: "custom-responses",


### PR DESCRIPTION
Hey! 👋

This fixes an issue where custom models using OpenAI-compatible APIs couldn't use the `xhigh` thinking level — the UI only showed options up to `high`.

**Real-world example:**

I'm running a local Qwen Coder proxy (CPA) at `http://127.0.0.1:8317` with the `coder-model` endpoint. The model fully supports `xhigh` thinking level, but the UI selector capped it at `high` because `openai-completions` API wasn't in the allowed list.

**What changed:**

- Added `openai-completions`, `openai-responses`, and `openai-codex-responses` to the list of APIs that support xhigh by default
- These APIs now get the same thinking level range as Anthropic models

**Why this matters:**

- Local models and custom endpoints (Ollama, LM Studio, self-hosted proxies) often support deep reasoning
- They were artificially limited to `high` even though the underlying model can handle more
- This fix lets users actually use the full reasoning capabilities their models provide

**Tests:**

- Added 2 test cases to verify xhigh is enabled for these API types

Let me know if this looks good! 🙏