### PR TITLE
feat(rules): implemented alwaysApply auto-injection into system prompt

### DIFF
--- a/docs/rulebook-matching-pipeline.md
+++ b/docs/rulebook-matching-pipeline.md
@@ -156,24 +156,31 @@ Notable source-order differences:
 - `windsurf` appends user `global_rules` first, then project rules.
 - `cline` loads only nearest `.clinerules` source.
 
-## 5. Split into Rulebook vs TTSR buckets
+## 5. Split into Rulebook, Always-Apply, and TTSR buckets
 
 After rule discovery in `createAgentSession` (`sdk.ts`):
 
 1. All discovered rules are scanned.
-2. Rules with `ttsrTrigger` are registered into `TtsrManager`.
+2. Rules with `condition` (frontmatter key; `ttsr_trigger` / `ttsrTrigger` accepted as fallback) are registered into `TtsrManager`.
 3. A separate `rulebookRules` list is built with this predicate:
 
 ```ts
-!rule.ttsrTrigger && !rule.alwaysApply && !!rule.description
+!registeredTtsrRuleNames.has(rule.name) && !rule.alwaysApply && !!rule.description
+```
+
+4. An `alwaysApplyRules` list is built:
+
+```ts
+!registeredTtsrRuleNames.has(rule.name) && rule.alwaysApply === true
 ```
 
 ### Bucket behavior
 
-- **TTSR bucket**: any rule with `ttsrTrigger` (description not required).
-- **Rulebook bucket**: must have description, must not be TTSR, must not be `alwaysApply`.
-- A rule with both `ttsrTrigger` and `description` goes to TTSR only.
-- A rule marked `alwaysApply` is currently excluded from rulebook.
+- **TTSR bucket**: any rule with `condition` (description not required). Takes priority over other buckets.
+- **Always-apply bucket**: `alwaysApply === true`, not TTSR. Full content injected into system prompt. Resolvable via `rule://`.
+- **Rulebook bucket**: must have description, must not be TTSR, must not be `alwaysApply`. Listed in system prompt by name+description; content read on demand via `rule://`.
+- A rule with both `condition` and `alwaysApply` goes to TTSR only (TTSR takes priority).
+- A rule with both `alwaysApply` and `description` goes to always-apply only (not rulebook).
 
 ## 6. How metadata affects runtime surfaces
 
@@ -195,7 +202,8 @@ After rule discovery in `createAgentSession` (`sdk.ts`):
 - Parsed and preserved by providers.
 - Used in UI display (`"always"` trigger label in extensions state manager).
 - Used as an exclusion condition from `rulebookRules`.
-- **Not used to auto-inject content into system prompt in current implementation.**
+- **Full rule content is auto-injected into the system prompt** (before the rulebook rules section).
+- Rule is also addressable via `rule://<name>` for re-reading.
 
 ### `ttsr_trigger`
 
@@ -204,12 +212,14 @@ After rule discovery in `createAgentSession` (`sdk.ts`):
 
 ## 7. System prompt inclusion path
 
-`buildSystemPromptInternal(..., { rules: rulebookRules })` injects rulebook rules into system prompt templates.
+`buildSystemPromptInternal` receives both `rules` (rulebook) and `alwaysApplyRules`.
 
-Templates include:
+Always-apply rules are rendered first, injecting their raw content directly into the prompt.
+
+Rulebook rules are rendered in a `# Rules` section with:
 
 - `Read rule://<name> when working in matching domain`
-- A `<rules>` block with each rule's `name`, `description`, and optional `<glob>` list
+- Each rule's `name`, `description`, and optional `<glob>` list
 
 This is advisory/contextual: prompt text asks the model to read applicable rules, but code does not enforce glob applicability.
 
@@ -218,13 +228,13 @@ This is advisory/contextual: prompt text asks the model to read applicable rules
 `RuleProtocolHandler` is registered with:
 
 ```ts
-new RuleProtocolHandler({ getRules: () => rulebookRules })
+new RuleProtocolHandler({ getRules: () => [...rulebookRules, ...alwaysApplyRules] })
 ```
 
 Implications:
 
-- `rule://<name>` resolves only against **rulebookRules** (not all discovered rules).
-- TTSR-only rules and rules filtered out for missing description/`alwaysApply` are not addressable via `rule://`.
+- `rule://<name>` resolves against both **rulebookRules** and **alwaysApplyRules**.
+- TTSR-only rules and rules with no description and no `alwaysApply` are not addressable via `rule://`.
 - Resolution is exact name match.
 - Unknown names return error listing available rule names.
 - Returned content is raw `rule.content` (frontmatter stripped), content type `text/markdown`.
@@ -233,6 +243,5 @@ Implications:
 
 1. Provider descriptions mention legacy files (`.cursorrules`, `.windsurfrules`), but current loader code paths do not actually read those files.
 2. `globs` metadata is surfaced to prompt/UI but not enforced by rule selection logic.
-3. `alwaysApply` does not force inclusion into system prompt; current behavior excludes such rules from `rulebookRules`.
-4. Rule selection for `rule://` is constrained to prefiltered rulebook rules, not the full discovered set.
-5. Discovery warnings (`loadCapability("rules").warnings`) are produced but `createAgentSession` does not currently surface/log them in this path.
+3. Rule selection for `rule://` includes rulebook and always-apply rules, but not TTSR-only rules.
+4. Discovery warnings (`loadCapability("rules").warnings`) are produced but `createAgentSession` does not currently surface/log them in this path.

--- a/packages/coding-agent/src/prompts/system/custom-system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/custom-system-prompt.md
@@ -40,6 +40,11 @@ If a skill covers your output, you **MUST** read `skill://<name>` before proceed
 {{/list}}
 </skills>
 {{/if}}
+{{#if alwaysApplyRules.length}}
+{{#each alwaysApplyRules}}
+{{content}}
+{{/each}}
+{{/if}}
 {{#if rules.length}}
 Rules are local constraints.
 You **MUST** read `rule://<name>` when working in that domain.

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -124,6 +124,12 @@ You **MUST** use the following skills, to save you time, when working in their d
 {{/each}}
 {{/if}}
 
+{{#if alwaysApplyRules.length}}
+{{#each alwaysApplyRules}}
+{{content}}
+{{/each}}
+{{/if}}
+
 {{#if rules.length}}
 # Rules
 Domain-specific rules from past experience. **MUST** read `rule://<name>` when working in their territory.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -785,6 +785,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		}),
 	);
 
+	// collect alwaysApply rules — full content injected into system prompt
+	const alwaysApplyRules = rulesResult.items.filter((rule: Rule) => {
+		if (registeredTtsrRuleNames.has(rule.name)) return false;
+		return rule.alwaysApply === true;
+	});
+
 	const contextFiles = await logger.timeAsync(
 		"discoverContextFiles",
 		async () => options.contextFiles ?? (await discoverContextFiles(cwd, agentDir)),
@@ -919,7 +925,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	);
 	internalRouter.register(
 		new RuleProtocolHandler({
-			getRules: () => rulebookRules,
+			getRules: () => [...rulebookRules, ...alwaysApplyRules],
 		}),
 	);
 	internalRouter.register(new PiProtocolHandler());
@@ -1240,6 +1246,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			tools: promptTools,
 			toolNames,
 			rules: rulebookRules,
+			alwaysApplyRules,
 			skillsSettings: settings.getGroup("skills"),
 			appendSystemPrompt: appendPrompt,
 			repeatToolDescriptions,
@@ -1260,6 +1267,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				tools: promptTools,
 				toolNames,
 				rules: rulebookRules,
+				alwaysApplyRules,
 				skillsSettings: settings.getGroup("skills"),
 				customPrompt: options.systemPrompt,
 				appendSystemPrompt: appendPrompt,

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -370,6 +370,8 @@ export interface BuildSystemPromptOptions {
 	mcpDiscoveryServerSummaries?: string[];
 	/** Encourage the agent to delegate via tasks unless changes are trivial. */
 	eagerTasks?: boolean;
+	/** Rules with alwaysApply=true — their full content is injected into the prompt. */
+	alwaysApplyRules?: Array<{ name: string; content: string; path: string }>;
 }
 
 /** Build the system prompt with tools, guidelines, and context */
@@ -389,6 +391,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		contextFiles: providedContextFiles,
 		skills: providedSkills,
 		rules,
+		alwaysApplyRules,
 		intentField,
 		mcpDiscoveryMode = false,
 		mcpDiscoveryServerSummaries = [],
@@ -521,6 +524,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		agentsMdSearch,
 		skills: filteredSkills,
 		rules: rules ?? [],
+		alwaysApplyRules: alwaysApplyRules ?? [],
 		date,
 		dateTime,
 		cwd: promptCwd,


### PR DESCRIPTION
## Summary

Rules with `alwaysApply: true` were parsed by all providers and used to *exclude* the rule from `rulebookRules`, but the inclusion half was never built — rule content was silently dropped into a void.

Now:
- **Full content is injected directly into the system prompt** (before the rulebook rules section)
- Rules remain addressable via `rule://` for re-reading
- TTSR rules still take priority (a rule with both `condition` and `alwaysApply` goes to TTSR only)
- Works in both default and custom prompt templates

### Files changed

| File | Change |
|------|--------|
| `sdk.ts` | Collect `alwaysApplyRules` bucket, pass to system prompt builder, combine with `rulebookRules` in `RuleProtocolHandler` |
| `system-prompt.ts` | Add `alwaysApplyRules` to `BuildSystemPromptOptions` and template data |
| `system-prompt.md` | Render alwaysApply rule content before rulebook section |
| `custom-system-prompt.md` | Same for custom prompt template |
| `rulebook-matching-pipeline.md` | Updated docs to reflect three-bucket split (TTSR > always-apply > rulebook) |

### Note on Python tool availability

During investigation we also looked into why the Python tool was missing in some sessions. Root cause: `resolvePythonRuntime` prefers project `.venv` over system Python. If the venv doesn't have `kernel_gateway`/`ipykernel`, the preflight fails silently. Fix is to install the packages in the project venv. Not a session resume bug.

### Type check
```
bunx tsgo -p tsconfig.json --noEmit  # zero errors
```