### PR TITLE
feat(settings): add startup.checkUpdate for disable update check

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `startup.checkUpdate` setting, set to `true` by default, can be disabled to skip the update check on agent initialization
+
 ## [13.12.7] - 2026-03-16
 
 ### Added

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -549,6 +549,16 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"startup.checkUpdate": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "interaction",
+			label: "Check for Updates",
+			description: "If false, skip update check",
+		},
+	},
+
 	collapseChangelog: {
 		type: "boolean",
 		default: false,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -34,6 +34,9 @@ import { resolvePromptInput } from "./system-prompt";
 import { getChangelogPath, getNewEntries, parseChangelog } from "./utils/changelog";
 
 async function checkForNewVersion(currentVersion: string): Promise<string | undefined> {
+	if (!settings.get("startup.checkUpdate")) {
+		return;
+	}
 	try {
 		const response = await fetch("https://registry.npmjs.org/@oh-my-pi/pi-coding-agent/latest");
 		if (!response.ok) return undefined;
@@ -109,6 +112,9 @@ async function runInteractiveMode(
 
 	versionCheckPromise
 		.then(newVersion => {
+			if (!settings.get("startup.checkUpdate")) {
+				return;
+			}
 			if (newVersion) {
 				mode.showNewVersionNotification(newVersion);
 			}


### PR DESCRIPTION
## What

<!-- Brief description of the change -->
add a setting `startup.checkupdate`,default true.
## Why
need a config to disable update check
<!-- Motivation, context, or link to issue (fixes #N) -->

## Testing

<!-- How was this tested? -->
local tested.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
