### PR TITLE
fix: app keybinding remaps and truthful hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,8 @@ Bundled custom slash commands include `/review` (interactive code review launche
 
 ### Keyboard Shortcuts
 
+Defaults below are the built-in app bindings. Remap them in `~/.omp/agent/keybindings.json`; `/hotkeys` shows your effective bindings.
+
 **Navigation:**
 
 | Key                      | Action                                       |
@@ -684,17 +686,18 @@ Bundled custom slash commands include `/review` (interactive code review launche
 | --------------------- | --------------------------------------------------------- |
 | Tab                   | Path completion / accept autocomplete                     |
 | Escape                | Cancel autocomplete / abort streaming                     |
-| Ctrl+C                | Clear editor (first) / exit (second)                      |
+| Ctrl+C                | Clear editor (press twice quickly to exit)                |
 | Ctrl+D                | Exit (when editor is empty)                               |
 | Ctrl+Z                | Suspend to background (use `fg` in shell to resume)       |
 | Shift+Tab             | Cycle thinking level                                      |
 | Ctrl+P / Shift+Ctrl+P | Cycle role models (slow/default/smol), temporary on shift |
 | Alt+P                 | Select model temporarily                                  |
-| Ctrl+L                | Open model selector                                       |
+| Ctrl+L                | Select model (set roles)                                  |
 | Alt+Shift+P           | Toggle plan mode                                          |
 | Ctrl+R                | Search prompt history                                     |
 | Ctrl+O                | Toggle tool output expansion                              |
 | Ctrl+T                | Toggle todo list expansion                                |
+| Unbound by default    | Toggle thinking block visibility                          |
 | Ctrl+G                | Edit message in external editor (`$VISUAL` or `$EDITOR`)  |
 | Alt+H                 | Toggle speech-to-text recording                           |
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed coding-agent app-level keybindings to honor remaps and unbinds, added a truthful todo-expansion action with `Ctrl+T`, left thinking-block visibility configurable but unbound by default, removed the dead named-filter action, and made `/hotkeys` reflect effective bindings ([#468](https://github.com/can1357/oh-my-pi/issues/468))
+
+
 ## [13.12.10] - 2026-03-17
 ### Added
 

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -24,8 +24,8 @@ export type AppAction =
 	| "selectModel"
 	| "togglePlanMode"
 	| "expandTools"
+	| "toggleTodoExpansion"
 	| "toggleThinking"
-	| "toggleSessionNamedFilter"
 	| "externalEditor"
 	| "historySearch"
 	| "followUp"
@@ -66,8 +66,8 @@ export const DEFAULT_APP_KEYBINDINGS: Record<AppAction, KeyId | KeyId[]> = {
 	togglePlanMode: "alt+shift+p",
 	historySearch: "ctrl+r",
 	expandTools: "ctrl+o",
-	toggleThinking: "ctrl+t",
-	toggleSessionNamedFilter: "ctrl+n",
+	toggleTodoExpansion: "ctrl+t",
+	toggleThinking: [],
 	externalEditor: "ctrl+g",
 	followUp: "ctrl+enter",
 	dequeue: "alt+up",
@@ -102,8 +102,8 @@ const APP_ACTIONS: AppAction[] = [
 	"togglePlanMode",
 	"historySearch",
 	"expandTools",
+	"toggleTodoExpansion",
 	"toggleThinking",
-	"toggleSessionNamedFilter",
 	"externalEditor",
 	"followUp",
 	"dequeue",

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -1,34 +1,39 @@
 import { Editor, type KeyId, matchesKey, parseKittySequence } from "@oh-my-pi/pi-tui";
+import type { AppAction } from "../../config/keybindings";
+
+type AppActionHandler = {
+	keys: KeyId[];
+	handler: () => void;
+};
 
 /**
- * Custom editor that handles Escape and Ctrl+C keys for coding-agent
+ * Custom editor that dispatches coding-agent app actions before editor defaults.
  */
 export class CustomEditor extends Editor {
 	onEscape?: () => void;
 	shouldBypassAutocompleteOnEscape?: () => boolean;
-	onCtrlC?: () => void;
-	onCtrlD?: () => void;
-	onShiftTab?: () => void;
-	onCtrlP?: () => void;
-	onShiftCtrlP?: () => void;
-	onCtrlL?: () => void;
-	onCtrlR?: () => void;
-	onCtrlO?: () => void;
-	onCtrlT?: () => void;
-	onCtrlG?: () => void;
-	onCtrlZ?: () => void;
 	onQuestionMark?: () => void;
 	onCapsLock?: () => void;
 	onAltP?: () => void;
-	/** Called when Alt+Shift+C is pressed to copy prompt to clipboard. */
-	onCopyPrompt?: () => void;
-	/** Called when Ctrl+V is pressed. Returns true if handled (image found), false to fall through to text paste. */
-	onCtrlV?: () => Promise<boolean>;
-	/** Called when Alt+Up is pressed (dequeue keybinding). */
-	onAltUp?: () => void;
 
-	/** Custom key handlers from extensions */
+	#appActionHandlers = new Map<AppAction, AppActionHandler>();
 	#customKeyHandlers = new Map<KeyId, () => void>();
+
+	setAppActionHandler(action: AppAction, keys: KeyId[], handler: (() => void) | undefined): void {
+		if (!handler || keys.length === 0) {
+			this.#appActionHandlers.delete(action);
+			return;
+		}
+		this.#appActionHandlers.set(action, { keys, handler });
+	}
+
+	removeAppActionHandler(action: AppAction): void {
+		this.#appActionHandlers.delete(action);
+	}
+
+	clearAppActionHandlers(): void {
+		this.#appActionHandlers.clear();
+	}
 
 	/**
 	 * Register a custom key handler. Extensions use this for shortcuts.
@@ -51,6 +56,38 @@ export class CustomEditor extends Editor {
 		this.#customKeyHandlers.clear();
 	}
 
+	#matchesAnyKey(data: string, keys: KeyId[]): boolean {
+		for (const key of keys) {
+			if (matchesKey(data, key)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	#handleAppAction(data: string): boolean {
+		for (const [action, { keys, handler }] of this.#appActionHandlers) {
+			if (!this.#matchesAnyKey(data, keys)) {
+				continue;
+			}
+
+			// Escape keeps its autocomplete-cancel behavior unless interrupt explicitly wins.
+			if (
+				action === "interrupt" &&
+				(matchesKey(data, "escape") || matchesKey(data, "esc")) &&
+				this.isShowingAutocomplete() &&
+				!this.shouldBypassAutocompleteOnEscape?.()
+			) {
+				continue;
+			}
+
+			handler();
+			return true;
+		}
+
+		return false;
+	}
+
 	handleInput(data: string): void {
 		const parsed = parseKittySequence(data);
 		if (parsed && (parsed.modifier & 64) !== 0 && this.onCapsLock) {
@@ -59,115 +96,20 @@ export class CustomEditor extends Editor {
 			return;
 		}
 
-		// Intercept Ctrl+V for image paste (async - fires and handles result)
-		if (matchesKey(data, "ctrl+v") && this.onCtrlV) {
-			void this.onCtrlV();
+		if (this.#handleAppAction(data)) {
 			return;
 		}
 
-		// Intercept Ctrl+G for external editor
-		if (matchesKey(data, "ctrl+g") && this.onCtrlG) {
-			this.onCtrlG();
-			return;
-		}
-
-		// Intercept Alt+P for quick model switching
 		if (matchesKey(data, "alt+p") && this.onAltP) {
 			this.onAltP();
 			return;
 		}
 
-		// Intercept Ctrl+Z for suspend
-		if (matchesKey(data, "ctrl+z") && this.onCtrlZ) {
-			this.onCtrlZ();
-			return;
-		}
-
-		// Intercept Ctrl+T for thinking block visibility toggle
-		if (matchesKey(data, "ctrl+t") && this.onCtrlT) {
-			this.onCtrlT();
-			return;
-		}
-
-		// Intercept Ctrl+L for model selector
-		if (matchesKey(data, "ctrl+l") && this.onCtrlL) {
-			this.onCtrlL();
-			return;
-		}
-
-		// Intercept Ctrl+R for history search
-		if (matchesKey(data, "ctrl+r") && this.onCtrlR) {
-			this.onCtrlR();
-			return;
-		}
-
-		// Intercept Ctrl+O for tool output expansion
-		if (matchesKey(data, "ctrl+o") && this.onCtrlO) {
-			this.onCtrlO();
-			return;
-		}
-
-		// Intercept Shift+Ctrl+P for backward model cycling (check before Ctrl+P)
-		if ((matchesKey(data, "shift+ctrl+p") || matchesKey(data, "ctrl+shift+p")) && this.onShiftCtrlP) {
-			this.onShiftCtrlP();
-			return;
-		}
-
-		// Intercept Ctrl+P for model cycling
-		if (matchesKey(data, "ctrl+p") && this.onCtrlP) {
-			this.onCtrlP();
-			return;
-		}
-
-		// Intercept Shift+Tab for thinking level cycling
-		if (matchesKey(data, "shift+tab") && this.onShiftTab) {
-			this.onShiftTab();
-			return;
-		}
-
-		// Intercept Escape key.
-		// Default behavior keeps autocomplete dismissal, but parent can prioritize global escape handling.
-		if ((matchesKey(data, "escape") || matchesKey(data, "esc")) && this.onEscape) {
-			if (!this.isShowingAutocomplete() || this.shouldBypassAutocompleteOnEscape?.()) {
-				this.onEscape();
-				return;
-			}
-		}
-
-		// Intercept Ctrl+C
-		if (matchesKey(data, "ctrl+c") && this.onCtrlC) {
-			this.onCtrlC();
-			return;
-		}
-
-		// Intercept Ctrl+D (only when editor is empty)
-		if (matchesKey(data, "ctrl+d")) {
-			if (this.getText().length === 0 && this.onCtrlD) {
-				this.onCtrlD();
-			}
-			// Always consume Ctrl+D (don't pass to parent)
-			return;
-		}
-
-		// Intercept Alt+Up for dequeue (restore queued message to editor)
-		if (matchesKey(data, "alt+up") && this.onAltUp) {
-			this.onAltUp();
-			return;
-		}
-
-		// Intercept Alt+Shift+C to copy prompt to clipboard
-		if (matchesKey(data, "alt+shift+c") && this.onCopyPrompt) {
-			this.onCopyPrompt();
-			return;
-		}
-
-		// Intercept ? when editor is empty to show hotkeys
 		if (data === "?" && this.getText().length === 0 && this.onQuestionMark) {
 			this.onQuestionMark();
 			return;
 		}
 
-		// Check custom key handlers (extensions)
 		for (const [keyId, handler] of this.#customKeyHandlers) {
 			if (matchesKey(data, keyId)) {
 				handler();
@@ -175,7 +117,6 @@ export class CustomEditor extends Editor {
 			}
 		}
 
-		// Pass to parent for normal handling
 		super.handleInput(data);
 	}
 }

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -14,6 +14,7 @@ import { Loader, Markdown, padding, Spacer, Text, visibleWidth } from "@oh-my-pi
 import { formatDuration, Snowflake, setProjectDir } from "@oh-my-pi/pi-utils";
 import { $ } from "bun";
 import { reset as resetCapabilities } from "../../capability";
+import type { AppAction } from "../../config/keybindings";
 import { loadCustomShare } from "../../export/custom-share";
 import type { CompactOptions } from "../../extensibility/extensions/types";
 import { getGatewayStatus } from "../../ipy/gateway-coordinator";
@@ -505,17 +506,31 @@ export class CommandController {
 	}
 
 	handleHotkeysCommand(): void {
-		const expandToolsKey = this.ctx.keybindings.getDisplayString("expandTools") || "Ctrl+O";
-		const planModeKey = this.ctx.keybindings.getDisplayString("togglePlanMode") || "Alt+Shift+P";
-		const sttKey = this.ctx.keybindings.getDisplayString("toggleSTT") || "Alt+H";
-		const copyLineKey = this.ctx.keybindings.getDisplayString("copyLine") || "Alt+Shift+L";
-		const copyPromptKey = this.ctx.keybindings.getDisplayString("copyPrompt") || "Alt+Shift+C";
+		const getAppActionKey = (action: AppAction): string => {
+			if (this.ctx.keybindings.getKeys(action).length === 0) {
+				return "";
+			}
+			return this.ctx.keybindings.getDisplayString(action);
+		};
+
 		const hotkeys = buildHotkeysMarkdown({
-			expandToolsKey,
-			planModeKey,
-			sttKey,
-			copyLineKey,
-			copyPromptKey,
+			interruptKey: getAppActionKey("interrupt"),
+			clearKey: getAppActionKey("clear"),
+			exitKey: getAppActionKey("exit"),
+			suspendKey: getAppActionKey("suspend"),
+			cycleThinkingLevelKey: getAppActionKey("cycleThinkingLevel"),
+			cycleModelForwardKey: getAppActionKey("cycleModelForward"),
+			cycleModelBackwardKey: getAppActionKey("cycleModelBackward"),
+			selectModelKey: getAppActionKey("selectModel"),
+			planModeKey: getAppActionKey("togglePlanMode"),
+			historySearchKey: getAppActionKey("historySearch"),
+			expandToolsKey: getAppActionKey("expandTools"),
+			toggleTodoExpansionKey: getAppActionKey("toggleTodoExpansion"),
+			toggleThinkingKey: getAppActionKey("toggleThinking"),
+			externalEditorKey: getAppActionKey("externalEditor"),
+			sttKey: getAppActionKey("toggleSTT"),
+			copyLineKey: getAppActionKey("copyLine"),
+			copyPromptKey: getAppActionKey("copyPrompt"),
 		});
 		this.ctx.chatContainer.addChild(new Spacer(1));
 		this.ctx.chatContainer.addChild(new DynamicBorder());

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -3,6 +3,7 @@ import { type AgentMessage, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { copyToClipboard, readImageFromClipboard, sanitizeText } from "@oh-my-pi/pi-natives";
 import type { AutocompleteProvider, SlashCommand } from "@oh-my-pi/pi-tui";
 import { $env } from "@oh-my-pi/pi-utils";
+import type { AppAction } from "../../config/keybindings";
 import { settings } from "../../config/settings";
 import { createPromptActionAutocompleteProvider } from "../../modes/prompt-action-autocomplete";
 import { theme } from "../../modes/theme/theme";
@@ -21,6 +22,33 @@ interface Expandable {
 function isExpandable(obj: unknown): obj is Expandable {
 	return typeof obj === "object" && obj !== null && "setExpanded" in obj && typeof obj.setExpanded === "function";
 }
+
+const BUILTIN_APP_ACTION_ORDER: AppAction[] = [
+	"interrupt",
+	"clear",
+	"exit",
+	"suspend",
+	"cycleThinkingLevel",
+	"cycleModelBackward",
+	"cycleModelForward",
+	"selectModel",
+	"historySearch",
+	"expandTools",
+	"toggleTodoExpansion",
+	"toggleThinking",
+	"externalEditor",
+	"pasteImage",
+	"followUp",
+	"dequeue",
+	"copyLine",
+	"copyPrompt",
+	"newSession",
+	"tree",
+	"fork",
+	"resume",
+	"togglePlanMode",
+	"toggleSTT",
+];
 
 export class InputController {
 	constructor(private ctx: InteractiveModeContext) {}
@@ -82,72 +110,64 @@ export class InputController {
 			}
 		};
 
-		this.ctx.editor.onCtrlC = () => this.handleCtrlC();
-		this.ctx.editor.onCtrlD = () => this.handleCtrlD();
-		this.ctx.editor.onCtrlZ = () => this.handleCtrlZ();
-		this.ctx.editor.onShiftTab = () => this.cycleThinkingLevel();
-		this.ctx.editor.onCtrlP = () => this.cycleRoleModel();
-		this.ctx.editor.onShiftCtrlP = () => this.cycleRoleModel({ temporary: true });
 		this.ctx.editor.onAltP = () => this.ctx.showModelSelector({ temporaryOnly: true });
 
 		// Global debug handler on TUI (works regardless of focus)
 		this.ctx.ui.onDebug = () => this.ctx.showDebugSelector();
-		this.ctx.editor.onCtrlL = () => this.ctx.showModelSelector();
-		this.ctx.editor.onCtrlR = () => this.ctx.showHistorySearch();
-		this.ctx.editor.onCtrlT = () => this.ctx.toggleTodoExpansion();
-		this.ctx.editor.onCtrlG = () => void this.openExternalEditor();
 		this.ctx.editor.onQuestionMark = () => this.ctx.handleHotkeysCommand();
-		this.ctx.editor.onCtrlV = () => this.handleImagePaste();
-		const copyPromptKeys = this.ctx.keybindings.getKeys("copyPrompt");
-		this.ctx.editor.onCopyPrompt = copyPromptKeys.includes("alt+shift+c") ? () => this.handleCopyPrompt() : undefined;
 
-		// Wire up extension shortcuts
+		const appActionHandlers: Record<AppAction, () => void> = {
+			interrupt: () => this.ctx.editor.onEscape?.(),
+			clear: () => this.handleCtrlC(),
+			exit: () => this.handleCtrlD(),
+			suspend: () => this.handleCtrlZ(),
+			cycleThinkingLevel: () => this.cycleThinkingLevel(),
+			cycleModelForward: () => {
+				void this.cycleRoleModel();
+			},
+			cycleModelBackward: () => {
+				void this.cycleRoleModel({ temporary: true });
+			},
+			selectModel: () => this.ctx.showModelSelector(),
+			togglePlanMode: () => {
+				void this.ctx.handlePlanModeCommand();
+			},
+			expandTools: () => this.toggleToolOutputExpansion(),
+			toggleTodoExpansion: () => this.ctx.toggleTodoExpansion(),
+			toggleThinking: () => this.toggleThinkingBlockVisibility(),
+			externalEditor: () => {
+				void this.openExternalEditor();
+			},
+			historySearch: () => this.ctx.showHistorySearch(),
+			followUp: () => {
+				void this.handleFollowUp();
+			},
+			dequeue: () => this.handleDequeue(),
+			pasteImage: () => {
+				void this.handleImagePaste();
+			},
+			copyLine: () => this.handleCopyCurrentLine(),
+			copyPrompt: () => this.handleCopyPrompt(),
+			newSession: () => {
+				void this.ctx.handleClearCommand();
+			},
+			tree: () => this.ctx.showTreeSelector(),
+			fork: () => this.ctx.showUserMessageSelector(),
+			resume: () => this.ctx.showSessionSelector(),
+			toggleSTT: () => {
+				void this.ctx.handleSTTToggle();
+			},
+		};
+
+		this.ctx.editor.clearAppActionHandlers();
+		for (const action of BUILTIN_APP_ACTION_ORDER) {
+			this.ctx.editor.setAppActionHandler(action, this.ctx.keybindings.getKeys(action), appActionHandlers[action]);
+		}
+
+		this.ctx.editor.clearCustomKeyHandlers();
+
+		// Wire up extension shortcuts after built-ins so app actions win on overlaps
 		this.registerExtensionShortcuts();
-
-		const expandToolsKeys = this.ctx.keybindings.getKeys("expandTools");
-		this.ctx.editor.onCtrlO = expandToolsKeys.includes("ctrl+o") ? () => this.toggleToolOutputExpansion() : undefined;
-		for (const key of expandToolsKeys) {
-			if (key === "ctrl+o") continue;
-			this.ctx.editor.setCustomKeyHandler(key, () => this.toggleToolOutputExpansion());
-		}
-
-		const dequeueKeys = this.ctx.keybindings.getKeys("dequeue");
-		this.ctx.editor.onAltUp = dequeueKeys.includes("alt+up") ? () => this.handleDequeue() : undefined;
-		for (const key of dequeueKeys) {
-			if (key === "alt+up") continue;
-			this.ctx.editor.setCustomKeyHandler(key, () => this.handleDequeue());
-		}
-
-		const planModeKeys = this.ctx.keybindings.getKeys("togglePlanMode");
-		for (const key of planModeKeys) {
-			this.ctx.editor.setCustomKeyHandler(key, () => void this.ctx.handlePlanModeCommand());
-		}
-
-		for (const key of this.ctx.keybindings.getKeys("newSession")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => this.ctx.handleClearCommand());
-		}
-		for (const key of this.ctx.keybindings.getKeys("tree")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => this.ctx.showTreeSelector());
-		}
-		for (const key of this.ctx.keybindings.getKeys("fork")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => this.ctx.showUserMessageSelector());
-		}
-		for (const key of this.ctx.keybindings.getKeys("resume")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => this.ctx.showSessionSelector());
-		}
-		for (const key of this.ctx.keybindings.getKeys("followUp")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => void this.handleFollowUp());
-		}
-		for (const key of this.ctx.keybindings.getKeys("toggleSTT")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => void this.ctx.handleSTTToggle());
-		}
-		for (const key of this.ctx.keybindings.getKeys("copyLine")) {
-			this.ctx.editor.setCustomKeyHandler(key, () => this.handleCopyCurrentLine());
-		}
-		for (const key of copyPromptKeys) {
-			if (key === "alt+shift+c") continue;
-			this.ctx.editor.setCustomKeyHandler(key, () => this.handleCopyPrompt());
-		}
 
 		this.ctx.editor.onChange = (text: string) => {
 			const wasBashMode = this.ctx.isBashMode;
@@ -357,7 +377,9 @@ export class InputController {
 	}
 
 	handleCtrlD(): void {
-		// Only called when editor is empty (enforced by CustomEditor)
+		if (this.ctx.editor.getText().length !== 0) {
+			return;
+		}
 		void this.ctx.shutdown();
 	}
 

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -1,13 +1,48 @@
 export interface HotkeysMarkdownBindings {
-	expandToolsKey: string;
+	interruptKey: string;
+	clearKey: string;
+	exitKey: string;
+	suspendKey: string;
+	cycleThinkingLevelKey: string;
+	cycleModelForwardKey: string;
+	cycleModelBackwardKey: string;
+	selectModelKey: string;
 	planModeKey: string;
+	historySearchKey: string;
+	expandToolsKey: string;
+	toggleTodoExpansionKey: string;
+	toggleThinkingKey: string;
+	externalEditorKey: string;
 	sttKey: string;
 	copyLineKey: string;
 	copyPromptKey: string;
 }
 
+function renderBinding(key: string): string {
+	return key || "(unbound)";
+}
+
 export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string {
-	const { expandToolsKey, planModeKey, sttKey, copyLineKey, copyPromptKey } = bindings;
+	const {
+		interruptKey,
+		clearKey,
+		exitKey,
+		suspendKey,
+		cycleThinkingLevelKey,
+		cycleModelForwardKey,
+		cycleModelBackwardKey,
+		selectModelKey,
+		planModeKey,
+		historySearchKey,
+		expandToolsKey,
+		toggleTodoExpansionKey,
+		toggleThinkingKey,
+		externalEditorKey,
+		sttKey,
+		copyLineKey,
+		copyPromptKey,
+	} = bindings;
+
 	return [
 		"**Navigation**",
 		"| Key | Action |",
@@ -25,28 +60,29 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 		"| `Ctrl+W` / `Option+Backspace` | Delete word backwards |",
 		"| `Ctrl+U` | Delete to start of line |",
 		"| `Ctrl+K` | Delete to end of line |",
-		`| \`${copyLineKey}\` | Copy current line |`,
-		`| \`${copyPromptKey}\` | Copy whole prompt |`,
+		`| \`${renderBinding(copyLineKey)}\` | Copy current line |`,
+		`| \`${renderBinding(copyPromptKey)}\` | Copy whole prompt |`,
 		"",
 		"**Other**",
 		"| Key | Action |",
 		"|-----|--------|",
 		"| `Tab` | Path completion / accept autocomplete |",
-		"| `Escape` | Cancel autocomplete / abort streaming |",
-		"| `Ctrl+C` | Clear editor (first) / exit (second) |",
-		"| `Ctrl+D` | Exit (when editor is empty) |",
-		"| `Ctrl+Z` | Suspend to background |",
-		"| `Shift+Tab` | Cycle thinking level |",
-		"| `Ctrl+P` | Cycle role models (slow/default/smol) |",
-		"| `Shift+Ctrl+P` | Cycle role models (temporary) |",
+		`| \`${renderBinding(interruptKey)}\` | Cancel autocomplete / abort streaming |`,
+		`| \`${renderBinding(clearKey)}\` | Clear editor (press twice quickly to exit) |`,
+		`| \`${renderBinding(exitKey)}\` | Exit (when editor is empty) |`,
+		`| \`${renderBinding(suspendKey)}\` | Suspend to background |`,
+		`| \`${renderBinding(cycleThinkingLevelKey)}\` | Cycle thinking level |`,
+		`| \`${renderBinding(cycleModelForwardKey)}\` | Cycle role models (slow/default/smol) |`,
+		`| \`${renderBinding(cycleModelBackwardKey)}\` | Cycle role models (temporary) |`,
 		"| `Alt+P` | Select model (temporary) |",
-		"| `Ctrl+L` | Select model (set roles) |",
-		`| \`${planModeKey}\` | Toggle plan mode |`,
-		"| `Ctrl+R` | Search prompt history |",
-		`| \`${expandToolsKey}\` | Toggle tool output expansion |`,
-		"| `Ctrl+T` | Toggle todo list expansion |",
-		"| `Ctrl+G` | Edit message in external editor |",
-		`| \`${sttKey}\` | Toggle speech-to-text recording |`,
+		`| \`${renderBinding(selectModelKey)}\` | Select model (set roles) |`,
+		`| \`${renderBinding(planModeKey)}\` | Toggle plan mode |`,
+		`| \`${renderBinding(historySearchKey)}\` | Search prompt history |`,
+		`| \`${renderBinding(expandToolsKey)}\` | Toggle tool output expansion |`,
+		`| \`${renderBinding(toggleTodoExpansionKey)}\` | Toggle todo list expansion |`,
+		`| \`${renderBinding(toggleThinkingKey)}\` | Toggle thinking block visibility |`,
+		`| \`${renderBinding(externalEditorKey)}\` | Edit message in external editor |`,
+		`| \`${renderBinding(sttKey)}\` | Toggle speech-to-text recording |`,
 		"| `#` | Open prompt actions |",
 		"| `/` | Slash commands |",
 		"| `!` | Run bash command |",

--- a/packages/coding-agent/test/app-action-keybindings-regression.test.ts
+++ b/packages/coding-agent/test/app-action-keybindings-regression.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, beforeEach, describe, expect, it, mock, vi } from "bun:test";
+
+const themeModulePath = new URL("../src/modes/theme/theme.ts", import.meta.url).pathname;
+
+function ctrl(key: string): string {
+	return String.fromCharCode(key.toLowerCase().charCodeAt(0) & 0x1f);
+}
+
+mock.module(themeModulePath, () => ({
+	getEditorTheme: () => ({ borderColor: (text: string) => text }),
+	getMarkdownTheme: () => ({}),
+	getSymbolTheme: () => ({}),
+	highlightCode: (text: string) => text,
+	getLanguageFromPath: () => undefined,
+	isLightTheme: () => false,
+	setAutoThemeMapping: () => Promise.resolve(),
+	setColorBlindMode: () => Promise.resolve(),
+	setSymbolPreset: () => Promise.resolve(),
+	onTerminalAppearanceChange: () => {},
+	onThemeChange: () => {},
+	theme: {
+		fg: (_tone: string, text: string) => text,
+	},
+}));
+
+mock.module("@oh-my-pi/pi-natives", () => ({
+	copyToClipboard: vi.fn(),
+	readImageFromClipboard: vi.fn(),
+	sanitizeText: (text: string) => text,
+	fuzzyFind: vi.fn(async () => ({ matches: [] })),
+	glob: vi.fn(async () => []),
+	FileType: { File: "file", Directory: "directory", Symlink: "symlink" },
+	ImageFormat: { Png: "png", Jpeg: "jpeg" },
+	SamplingFilter: { Lanczos3: "Lanczos3" },
+	PhotonImage: class PhotonImage {},
+	Shell: class Shell {},
+	PtySession: class PtySession {},
+	matchesKey: (data: string, keyId: string) => {
+		if (keyId === "escape" || keyId === "esc") return data === "\x1b";
+		const match = keyId.match(/^ctrl\+([a-z])$/i);
+		if (!match) return false;
+		return data === String.fromCharCode(match[1]!.toLowerCase().charCodeAt(0) & 0x1f);
+	},
+	parseKey: vi.fn(() => undefined),
+	parseKittySequence: vi.fn(() => null),
+	encodeSixel: vi.fn(),
+	sliceWithWidth: (text: string) => text,
+	Ellipsis: { Omit: "omit" },
+	extractSegments: vi.fn(() => []),
+	truncateToWidth: (text: string) => text,
+	wrapTextWithAnsi: (text: string) => [text],
+	executeShell: vi.fn(),
+	getWorkProfile: vi.fn(),
+	highlightCode: vi.fn((code: string) => code),
+	supportsLanguage: vi.fn(() => false),
+	projfsOverlayProbe: vi.fn(),
+	projfsOverlayStart: vi.fn(),
+	projfsOverlayStop: vi.fn(),
+	astEdit: vi.fn(),
+	astGrep: vi.fn(),
+	grep: vi.fn(),
+	htmlToMarkdown: vi.fn(),
+	invalidateFsScanCache: vi.fn(),
+}));
+
+const { Container } = await import("@oh-my-pi/pi-tui");
+const { _resetSettingsForTest, Settings } = await import("../src/config/settings");
+
+import type { KeybindingsConfig } from "../src/config/keybindings";
+import type { Settings as SettingsType } from "../src/config/settings";
+import type { CustomEditor as CustomEditorType } from "../src/modes/components/custom-editor";
+import type { InputController as InputControllerType } from "../src/modes/controllers/input-controller";
+import type { InteractiveModeContext } from "../src/modes/types";
+
+const { KeybindingsManager } = await import("../src/config/keybindings");
+const { CustomEditor } = await import("../src/modes/components/custom-editor");
+const { InputController } = await import("../src/modes/controllers/input-controller");
+
+type Shortcut = {
+	extensionPath: string;
+	handler: (ctx: unknown) => void;
+};
+
+function createHarness(
+	runtimeSettings: SettingsType,
+	config: KeybindingsConfig = {},
+	shortcuts: Map<string, Shortcut> = new Map(),
+): {
+	controller: InputControllerType;
+	ctx: InteractiveModeContext;
+	editor: CustomEditorType;
+	spies: {
+		toggleTodoExpansion: ReturnType<typeof vi.fn>;
+		rebuildChatFromMessages: ReturnType<typeof vi.fn>;
+		showStatus: ReturnType<typeof vi.fn>;
+	};
+} {
+	const editor = new CustomEditor({ borderColor: (text: string) => text } as never);
+	const toggleTodoExpansion = vi.fn();
+	const rebuildChatFromMessages = vi.fn();
+	const showStatus = vi.fn();
+	const extensionRunner = shortcuts.size
+		? {
+				getShortcuts: () => shortcuts,
+				createCommandContext: () => ({ source: "test" }),
+				emitError: vi.fn(),
+			}
+		: undefined;
+
+	const ctx = {
+		editor,
+		ui: { requestRender: vi.fn(), start: vi.fn(), stop: vi.fn() },
+		chatContainer: new Container(),
+		session: {
+			isStreaming: false,
+			isCompacting: false,
+			isGeneratingHandoff: false,
+			isBashRunning: false,
+			isPythonRunning: false,
+			queuedMessageCount: 0,
+			messages: [],
+			extensionRunner,
+			abort: vi.fn(),
+			abortBash: vi.fn(),
+			abortPython: vi.fn(),
+			clearQueue: vi.fn(() => ({ steering: [], followUp: [] })),
+			prompt: vi.fn(),
+		},
+		sessionManager: { getSessionName: () => "existing session" },
+		keybindings: KeybindingsManager.inMemory(config),
+		settings: runtimeSettings,
+		pendingImages: [],
+		isBashMode: false,
+		isPythonMode: false,
+		loadingAnimation: undefined,
+		autoCompactionLoader: undefined,
+		retryLoader: undefined,
+		autoCompactionEscapeHandler: undefined,
+		retryEscapeHandler: undefined,
+		optimisticUserMessageSignature: undefined,
+		toolOutputExpanded: false,
+		hideThinkingBlock: false,
+		streamingComponent: undefined,
+		streamingMessage: undefined,
+		lastSigintTime: 0,
+		lastEscapeTime: 0,
+		updateEditorBorderColor: vi.fn(),
+		toggleTodoExpansion,
+		rebuildChatFromMessages,
+		showStatus,
+		hasActiveBtw: vi.fn(() => false),
+		handleBtwEscape: vi.fn(() => false),
+		handleHotkeysCommand: vi.fn(),
+		handleSTTToggle: vi.fn(),
+		showDebugSelector: vi.fn(),
+		showTreeSelector: vi.fn(),
+		showUserMessageSelector: vi.fn(),
+		showSessionSelector: vi.fn(),
+		clearEditor: vi.fn(),
+		shutdown: vi.fn(async () => {}),
+	} as unknown as InteractiveModeContext;
+
+	return {
+		controller: new InputController(ctx),
+		ctx,
+		editor,
+		spies: {
+			toggleTodoExpansion,
+			rebuildChatFromMessages,
+			showStatus,
+		},
+	};
+}
+
+describe("app action keybinding regressions", () => {
+	let runtimeSettings: SettingsType;
+
+	beforeEach(async () => {
+		_resetSettingsForTest();
+		runtimeSettings = await Settings.init({ inMemory: true });
+	});
+
+	afterEach(() => {
+		_resetSettingsForTest();
+		vi.restoreAllMocks();
+	});
+
+	it("dispatches remapped external editor bindings and stops honoring ctrl+g", () => {
+		const { controller, editor } = createHarness(runtimeSettings, { externalEditor: "ctrl+x" });
+		const openExternalEditor = vi.fn(async (): Promise<void> => {});
+		controller.openExternalEditor = openExternalEditor;
+
+		controller.setupKeyHandlers();
+		editor.handleInput(ctrl("x"));
+		editor.handleInput(ctrl("g"));
+
+		expect(openExternalEditor).toHaveBeenCalledTimes(1);
+	});
+
+	it("disables formerly hardcoded actions when they are explicitly unbound", () => {
+		const { controller, editor } = createHarness(runtimeSettings, { externalEditor: [] });
+		const openExternalEditor = vi.fn(async (): Promise<void> => {});
+		controller.openExternalEditor = openExternalEditor;
+
+		controller.setupKeyHandlers();
+		editor.handleInput(ctrl("g"));
+
+		expect(openExternalEditor).not.toHaveBeenCalled();
+	});
+
+	it("lets built-in app actions win over extension custom handlers on the same key", () => {
+		const extensionShortcut = vi.fn();
+		const { controller, editor } = createHarness(
+			runtimeSettings,
+			{},
+			new Map([["ctrl+g", { extensionPath: "extensions/test-shortcut.ts", handler: extensionShortcut }]]),
+		);
+		const openExternalEditor = vi.fn(async (): Promise<void> => {});
+		controller.openExternalEditor = openExternalEditor;
+
+		controller.setupKeyHandlers();
+		editor.handleInput(ctrl("g"));
+
+		expect(openExternalEditor).toHaveBeenCalledTimes(1);
+		expect(extensionShortcut).not.toHaveBeenCalled();
+	});
+
+	it("routes custom toggleThinking bindings while ctrl+t remains toggleTodoExpansion", () => {
+		const { controller, ctx, editor, spies } = createHarness(runtimeSettings, { toggleThinking: "ctrl+y" });
+
+		controller.setupKeyHandlers();
+		editor.handleInput(ctrl("y"));
+		editor.handleInput(ctrl("t"));
+
+		expect(ctx.hideThinkingBlock).toBe(true);
+		expect(spies.rebuildChatFromMessages).toHaveBeenCalledTimes(1);
+		expect(spies.showStatus).toHaveBeenCalledWith("Thinking blocks: hidden");
+		expect(spies.toggleTodoExpansion).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/coding-agent/test/input-controller-escape.test.ts
+++ b/packages/coding-agent/test/input-controller-escape.test.ts
@@ -1,6 +1,66 @@
-import { describe, expect, it, vi } from "bun:test";
-import { InputController } from "@oh-my-pi/pi-coding-agent/modes/controllers/input-controller";
+import { describe, expect, it, mock, vi } from "bun:test";
 import type { InteractiveModeContext, SubmittedUserInput } from "@oh-my-pi/pi-coding-agent/modes/types";
+
+const themeModulePath = new URL("../src/modes/theme/theme.ts", import.meta.url).pathname;
+
+mock.module(themeModulePath, () => ({
+	getEditorTheme: () => ({ borderColor: (text: string) => text }),
+	getMarkdownTheme: () => ({}),
+	getSymbolTheme: () => ({}),
+	highlightCode: (text: string) => text,
+	getLanguageFromPath: () => undefined,
+	isLightTheme: () => false,
+	setAutoThemeMapping: () => Promise.resolve(),
+	setColorBlindMode: () => Promise.resolve(),
+	setSymbolPreset: () => Promise.resolve(),
+	onTerminalAppearanceChange: () => {},
+	onThemeChange: () => {},
+	theme: {
+		fg: (_tone: string, text: string) => text,
+	},
+}));
+
+mock.module("@oh-my-pi/pi-natives", () => ({
+	copyToClipboard: vi.fn(),
+	readImageFromClipboard: vi.fn(),
+	sanitizeText: (text: string) => text,
+	fuzzyFind: vi.fn(async () => ({ matches: [] })),
+	glob: vi.fn(async () => []),
+	FileType: { File: "file", Directory: "directory", Symlink: "symlink" },
+	ImageFormat: { Png: "png", Jpeg: "jpeg" },
+	SamplingFilter: { Lanczos3: "Lanczos3" },
+	PhotonImage: class PhotonImage {},
+	Shell: class Shell {},
+	PtySession: class PtySession {},
+	matchesKey: (data: string, keyId: string) => {
+		if (keyId === "escape" || keyId === "esc") return data === "\x1b";
+		const match = keyId.match(/^ctrl\+([a-z])$/i);
+		if (!match) return false;
+		return data === String.fromCharCode(match[1]!.toLowerCase().charCodeAt(0) & 0x1f);
+	},
+	parseKey: vi.fn(() => undefined),
+	parseKittySequence: vi.fn(() => null),
+	encodeSixel: vi.fn(),
+	sliceWithWidth: (text: string) => text,
+	Ellipsis: { Omit: "omit" },
+	extractSegments: vi.fn(() => []),
+	truncateToWidth: (text: string) => text,
+	wrapTextWithAnsi: (text: string) => [text],
+	executeShell: vi.fn(),
+	getWorkProfile: vi.fn(),
+	highlightCode: vi.fn((code: string) => code),
+	supportsLanguage: vi.fn(() => false),
+	projfsOverlayProbe: vi.fn(),
+	projfsOverlayStart: vi.fn(),
+	projfsOverlayStop: vi.fn(),
+	astEdit: vi.fn(),
+	astGrep: vi.fn(),
+	grep: vi.fn(),
+	htmlToMarkdown: vi.fn(),
+	invalidateFsScanCache: vi.fn(),
+}));
+
+const { InputController } = await import("@oh-my-pi/pi-coding-agent/modes/controllers/input-controller");
 
 type FakeEditor = {
 	onEscape?: () => void;
@@ -23,7 +83,10 @@ type FakeEditor = {
 	setText(text: string): void;
 	getText(): string;
 	addToHistory(text: string): void;
+	setAppActionHandler(action: string, keys: string[], handler: (() => void) | undefined): void;
+	clearAppActionHandlers(): void;
 	setCustomKeyHandler(key: string, handler: () => void): void;
+	clearCustomKeyHandlers(): void;
 };
 
 function createSubmission(input: {
@@ -47,6 +110,8 @@ function createContext(): {
 		abortPython: ReturnType<typeof vi.fn>;
 		addMessageToChat: ReturnType<typeof vi.fn>;
 		cancelPendingSubmission: ReturnType<typeof vi.fn>;
+		clearAppActionHandlers: ReturnType<typeof vi.fn>;
+		clearCustomKeyHandlers: ReturnType<typeof vi.fn>;
 		clearQueue: ReturnType<typeof vi.fn>;
 		ensureLoadingAnimation: ReturnType<typeof vi.fn>;
 		handleBtwCommand: ReturnType<typeof vi.fn>;
@@ -55,6 +120,7 @@ function createContext(): {
 		onInputCallback: ReturnType<typeof vi.fn>;
 		prompt: ReturnType<typeof vi.fn>;
 		requestRender: ReturnType<typeof vi.fn>;
+		setAppActionHandler: ReturnType<typeof vi.fn>;
 		startPendingSubmission: ReturnType<typeof vi.fn>;
 	};
 } {
@@ -75,6 +141,9 @@ function createContext(): {
 		ensureLoadingAnimation();
 		return createSubmission(input);
 	});
+	const clearAppActionHandlers = vi.fn();
+	const clearCustomKeyHandlers = vi.fn();
+	const setAppActionHandler = vi.fn();
 	const editor: FakeEditor = {
 		setText(text: string) {
 			editorText = text;
@@ -83,7 +152,10 @@ function createContext(): {
 			return editorText;
 		},
 		addToHistory: vi.fn(),
+		setAppActionHandler,
+		clearAppActionHandlers,
 		setCustomKeyHandler: vi.fn(),
+		clearCustomKeyHandlers,
 	};
 
 	let ctx!: InteractiveModeContext;
@@ -118,7 +190,7 @@ function createContext(): {
 			getSessionName: () => "existing session",
 		} as unknown as InteractiveModeContext["sessionManager"],
 		keybindings: {
-			getKeys: () => [],
+			getKeys: (action: string) => (action === "interrupt" ? ["escape"] : []),
 		} as unknown as InteractiveModeContext["keybindings"],
 		pendingImages: [],
 		isBashMode: false,
@@ -155,6 +227,8 @@ function createContext(): {
 			abortPython,
 			addMessageToChat,
 			cancelPendingSubmission,
+			clearAppActionHandlers,
+			clearCustomKeyHandlers,
 			clearQueue,
 			ensureLoadingAnimation,
 			handleBtwCommand,
@@ -163,12 +237,24 @@ function createContext(): {
 			onInputCallback,
 			prompt,
 			requestRender,
+			setAppActionHandler,
 			startPendingSubmission,
 		},
 	};
 }
 
 describe("InputController escape behavior", () => {
+	it("registers escape as the interrupt app action through the editor app-action API", () => {
+		const { ctx, spies } = createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+
+		expect(spies.clearAppActionHandlers).toHaveBeenCalledTimes(1);
+		expect(spies.clearCustomKeyHandlers).toHaveBeenCalledTimes(1);
+		expect(spies.setAppActionHandler).toHaveBeenCalledWith("interrupt", ["escape"], expect.any(Function));
+	});
+
 	it("prefers canceling a pending optimistic submission before aborting the session", async () => {
 		const { ctx, editor, spies } = createContext();
 		const submission = createSubmission({ text: "hello" });

--- a/packages/coding-agent/test/keybindings-display.test.ts
+++ b/packages/coding-agent/test/keybindings-display.test.ts
@@ -1,5 +1,41 @@
-import { describe, expect, it } from "bun:test";
-import { KeybindingsManager } from "../src/config/keybindings";
+import { describe, expect, it, mock, vi } from "bun:test";
+
+mock.module("@oh-my-pi/pi-natives", () => ({
+	fuzzyFind: vi.fn(async () => ({ matches: [] })),
+	glob: vi.fn(async () => []),
+	FileType: { File: "file", Directory: "directory", Symlink: "symlink" },
+	ImageFormat: { Png: "png", Jpeg: "jpeg" },
+	SamplingFilter: { Lanczos3: "Lanczos3" },
+	PhotonImage: class PhotonImage {},
+	Shell: class Shell {},
+	PtySession: class PtySession {},
+	matchesKey: vi.fn(() => false),
+	parseKey: vi.fn(() => undefined),
+	parseKittySequence: vi.fn(() => null),
+	encodeSixel: vi.fn(),
+	sliceWithWidth: (text: string) => text,
+	Ellipsis: { Omit: "omit" },
+	extractSegments: vi.fn(() => []),
+	truncateToWidth: (text: string) => text,
+	wrapTextWithAnsi: (text: string) => [text],
+	executeShell: vi.fn(),
+	getWorkProfile: vi.fn(),
+	highlightCode: vi.fn((code: string) => code),
+	supportsLanguage: vi.fn(() => false),
+	projfsOverlayProbe: vi.fn(),
+	projfsOverlayStart: vi.fn(),
+	projfsOverlayStop: vi.fn(),
+	astEdit: vi.fn(),
+	astGrep: vi.fn(),
+	grep: vi.fn(),
+	htmlToMarkdown: vi.fn(),
+	invalidateFsScanCache: vi.fn(),
+	copyToClipboard: vi.fn(),
+	readImageFromClipboard: vi.fn(),
+	sanitizeText: (text: string) => text,
+}));
+
+const { KeybindingsManager } = await import("../src/config/keybindings");
 
 describe("KeybindingsManager.getDisplayString", () => {
 	it("formats a single binding as a human-readable key hint", () => {
@@ -24,5 +60,23 @@ describe("KeybindingsManager.getDisplayString", () => {
 		});
 
 		expect(keybindings.getDisplayString("copyPrompt")).toBe("");
+	});
+
+	it("reflects the truthful default app-action surface for todo and thinking toggles", () => {
+		const keybindings = KeybindingsManager.inMemory();
+
+		expect(keybindings.getDisplayString("toggleTodoExpansion")).toBe("Ctrl+T");
+		expect(keybindings.getDisplayString("toggleThinking")).toBe("");
+	});
+});
+
+describe("KeybindingsManager.getEffectiveConfig", () => {
+	it("includes the effective todo/thinking toggle bindings without removed actions", () => {
+		const keybindings = KeybindingsManager.inMemory();
+		const effectiveConfig = keybindings.getEffectiveConfig() as Record<string, unknown>;
+
+		expect(effectiveConfig.toggleTodoExpansion).toBe("ctrl+t");
+		expect(effectiveConfig.toggleThinking).toEqual([]);
+		expect(Object.hasOwn(effectiveConfig, "toggleSessionNamedFilter")).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
+++ b/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
@@ -1,19 +1,36 @@
 import { describe, expect, it } from "bun:test";
-import { buildHotkeysMarkdown } from "../../../src/modes/utils/hotkeys-markdown";
+import { buildHotkeysMarkdown, type HotkeysMarkdownBindings } from "../../../src/modes/utils/hotkeys-markdown";
+
+function createBindings(overrides: Partial<HotkeysMarkdownBindings> = {}): HotkeysMarkdownBindings {
+	return {
+		interruptKey: "Esc",
+		clearKey: "Ctrl+C",
+		exitKey: "Ctrl+D",
+		suspendKey: "Ctrl+Z",
+		cycleThinkingLevelKey: "Shift+Tab",
+		cycleModelForwardKey: "Ctrl+P",
+		cycleModelBackwardKey: "Ctrl+Shift+P",
+		selectModelKey: "Ctrl+L",
+		planModeKey: "Alt+M",
+		historySearchKey: "Ctrl+R",
+		expandToolsKey: "Ctrl+O",
+		toggleTodoExpansionKey: "Ctrl+T",
+		toggleThinkingKey: "",
+		externalEditorKey: "Ctrl+G",
+		sttKey: "Alt+H",
+		copyLineKey: "Alt+Shift+L",
+		copyPromptKey: "Alt+Shift+C",
+		...overrides,
+	};
+}
 
 describe("buildHotkeysMarkdown", () => {
 	it("emits flush-left markdown so headings and tables are parsed instead of treated as indented text", () => {
-		const markdown = buildHotkeysMarkdown({
-			expandToolsKey: "Ctrl+O",
-			planModeKey: "Alt+M",
-			sttKey: "Alt+H",
-			copyLineKey: "Alt+Shift+L",
-			copyPromptKey: "Ctrl+Shift+P",
-		});
+		const markdown = buildHotkeysMarkdown(createBindings());
 
 		const lines = markdown.split("\n");
 		expect(lines[0]).toBe("**Navigation**");
-		expect(markdown).toContain("| `Ctrl+Shift+P` | Copy whole prompt |");
+		expect(markdown).toContain("| `Alt+Shift+C` | Copy whole prompt |");
 		expect(markdown).toContain("| `Alt+M` | Toggle plan mode |");
 		expect(markdown).toContain("| `#` | Open prompt actions |");
 		for (const line of lines) {
@@ -21,5 +38,19 @@ describe("buildHotkeysMarkdown", () => {
 			expect(line.startsWith(" ")).toBe(false);
 			expect(line.startsWith("\t")).toBe(false);
 		}
+	});
+
+	it("renders remapped and unbound app actions truthfully in /hotkeys markdown", () => {
+		const markdown = buildHotkeysMarkdown(
+			createBindings({
+				externalEditorKey: "Ctrl+X",
+				toggleThinkingKey: "",
+			}),
+		);
+
+		expect(markdown).toContain("| `Ctrl+T` | Toggle todo list expansion |");
+		expect(markdown).toContain("| `(unbound)` | Toggle thinking block visibility |");
+		expect(markdown).toContain("| `Ctrl+X` | Edit message in external editor |");
+		expect(markdown).not.toContain("| `Ctrl+G` | Edit message in external editor |");
 	});
 });


### PR DESCRIPTION
## What

- replace hardcoded coding-agent app shortcut interception with action-based dispatch driven by effective keybindings
- add a truthful `toggleTodoExpansion` app action on `Ctrl+T`, keep `toggleThinking` configurable but unbound by default, and remove the dead `toggleSessionNamedFilter` surface
- make `/hotkeys` and README shortcut docs reflect effective/default bindings, including explicit `(unbound)` rendering
- add regressions for remapped and unbound app actions, built-in precedence over extension shortcuts, and the todo/thinking split
- update the coding-agent changelog under `Unreleased`

## Why

fixes #468

The app had two competing representations of built-in shortcuts: `KeybindingsManager` loaded configurable app bindings, but `CustomEditor` and `InputController` still intercepted many legacy default chords directly. That made remaps and `[]` unbinds lie for several built-in actions and left `/hotkeys` showing stale defaults.

This PR does the full cutover to one truthful app-action dispatch path, keeps the existing product behavior of `Ctrl+T` expanding todos, preserves special `Escape` / `Ctrl+C` / `Ctrl+D` semantics, and removes the dead named-filter action instead of carrying unused config surface.

## Testing

- `bun test packages/coding-agent/test/input-controller-escape.test.ts`
- `bun test packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts`
- `bun test packages/coding-agent/test/keybindings-display.test.ts`
- `bun test packages/coding-agent/test/app-action-keybindings-regression.test.ts`
- `bun check:ts`
- `bun check` is currently blocked by unrelated pre-existing Rust formatting diffs in `crates/pi-natives/src/grep.rs`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
