### PR TITLE
fix(upstream): allow to using extension dir in `pi.extension`

### DIFF
--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { FileType, glob } from "@oh-my-pi/pi-natives";
 import { CONFIG_DIR_NAME, getConfigDirName, tryParseJson } from "@oh-my-pi/pi-utils";
-import { readFile } from "../capability/fs";
+import { readDirEntries, readFile } from "../capability/fs";
 import { parseRuleConditionAndScope, type Rule, type RuleFrontmatter } from "../capability/rule";
 import type { Skill, SkillFrontmatter } from "../capability/skill";
 import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
@@ -529,7 +529,14 @@ export async function discoverExtensionModulePaths(_ctx: LoadContext, dir: strin
 		subdirsWithDeclaredExtensions.add(subdir);
 		const subdirPath = path.join(dir, subdir);
 		for (const extPath of declaredExtensions) {
-			const resolvedExtPath = path.resolve(subdirPath, extPath);
+			let resolvedExtPath = path.resolve(subdirPath, extPath);
+			const entries = await readDirEntries(resolvedExtPath);
+			if (entries.length !== 0) {
+				const pluginFilePath = entries.find(
+					e => e.isFile() && (e.name === "index.ts" || e.name === "index.js"),
+				)?.name;
+				resolvedExtPath = pluginFilePath ? path.join(resolvedExtPath, pluginFilePath) : resolvedExtPath;
+			}
 			const content = await readFile(resolvedExtPath);
 			if (content !== null) {
 				discovered.add(resolvedExtPath);


### PR DESCRIPTION

ref
https://github.com/badlogic/pi-mono/blob/8a8e2a8049fba194d999cf7f3ec4b247910657ee/packages/coding-agent/src/core/package-manager.ts#L446-L452


## What
allowed to using dir path rather than specific file path in `pi.extension` in `packages.json`

## Why

Alignment with upstream behavior
<!-- Motivation, context, or link to issue (fixes #N) -->

## Testing

local tested.
<!-- How was this tested? -->

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
