### PR TITLE
fix(coding-agent): respect user model overrides in hardcoded policies

### DIFF
--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1441,7 +1441,8 @@ export class ModelRegistry {
 	#applyHardcodedModelPolicies(models: Model<Api>[]): Model<Api>[] {
 		return models.map(model => {
 			if (model.id === "gpt-5.4" && model.provider !== "github-copilot") {
-				return { ...model, contextWindow: 1_000_000 };
+				const overrides = this.#modelOverrides.get(model.provider)?.get(model.id);
+				return { ...model, contextWindow: 1_000_000, ...overrides };
 			}
 			return model;
 		});


### PR DESCRIPTION
## Summary

Re-submission of #466 — I accidentally deleted the branch which closed the PR. This implements the fix @can1357 suggested in the review: using spread to apply all user overrides after the hardcoded defaults.

## Change

```diff
 #applyHardcodedModelPolicies(models) {
     return models.map(model => {
         if (model.id === "gpt-5.4" && model.provider !== "github-copilot") {
-            return { ...model, contextWindow: 1_000_000 };
+            const overrides = this.#modelOverrides.get(model.provider)?.get(model.id);
+            return { ...model, contextWindow: 1_000_000, ...overrides };
         }
         return model;
     });
 }
```

- Without user override: identical behavior (gpt-5.4 gets 1M context window)
- With user override: user's `modelOverrides` values take precedence via spread

## Use cases

- **Cost control:** OpenAI doubles input pricing above 272k tokens ($2.50 -> $5.00/M). Capping `contextWindow` via `models.json` keeps costs in the cheaper tier.
- **Quality control:** Model performance degrades at large context sizes. Capping `contextWindow` lets users find the sweet spot between context size and output quality, with compaction kicking in at the right time.

Rebased on current `main` (470c90c).