### PR TITLE
feat(coding-agent): add inherit and off options to default thinking level

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -346,7 +346,7 @@ export const SETTINGS_SCHEMA = {
 	// Reasoning and prompts
 	defaultThinkingLevel: {
 		type: "enum",
-		values: THINKING_EFFORTS,
+		values: ["inherit", "off", ...THINKING_EFFORTS],
 		default: "high",
 		ui: {
 			tab: "model",

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -7,6 +7,7 @@
  * 2. That's it - it appears in the UI automatically
  */
 
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { THINKING_EFFORTS } from "@oh-my-pi/pi-ai";
 import { TERMINAL } from "@oh-my-pi/pi-tui";
 import {
@@ -318,7 +319,7 @@ const OPTION_PROVIDERS: Partial<Record<SettingPath, OptionProvider>> = {
 		{ value: "on", label: "On", description: "Force websockets for OpenAI Codex models" },
 	],
 	// Default thinking level
-	defaultThinkingLevel: [...THINKING_EFFORTS.map(getThinkingLevelMetadata)],
+	defaultThinkingLevel: [ThinkingLevel.Inherit, ThinkingLevel.Off, ...THINKING_EFFORTS].map(getThinkingLevelMetadata),
 	// Temperature
 	temperature: [
 		{ value: "-1", label: "Default", description: "Use provider default" },

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -307,13 +307,7 @@ export class SettingsSelectorComponent extends Container {
 	): Container {
 		let options = def.options;
 
-		// Special case: inject runtime options for thinking level
-		if (def.path === "defaultThinkingLevel") {
-			options = this.context.availableThinkingLevels.map(level => {
-				const baseOpt = options.find(o => o.value === level);
-				return baseOpt || { value: level, label: level };
-			});
-		} else if (def.path === "theme.dark" || def.path === "theme.light") {
+		if (def.path === "theme.dark" || def.path === "theme.light") {
 			options = this.context.availableThemes.map(t => ({ value: t, label: t }));
 		}
 


### PR DESCRIPTION
## Summary
- Added 'inherit' option to allow users to inherit the thinking level from project config
- Added 'off' option to explicitly disable thinking for sessions that don't need it

## Motivation
Currently, the `defaultThinkingLevel` setting only supports the predefined thinking efforts (low, medium, high). Users who want to defer to project-level configuration or disable thinking entirely have no way to do so through the settings UI.

## Changes
- `settings-schema.ts`: Extended values to include "inherit" and "off"
- `settings-defs.ts`: Updated option provider to include new choices
- `settings-selector.ts`: Removed special-case handling since runtime injection is no longer needed

## Testing
- Verified settings UI shows new options
- Confirmed existing thinking level options still work

fixes #486