### PR TITLE
fix(tui): honored custom undo binding

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added Ctrl+_ as an additional default shortcut for undo
+
+### Fixed
+
+- Ensured undo functionality respects user-configured keybindings
 
 ## [13.12.0] - 2026-03-14
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -732,8 +732,8 @@ export class Editor implements Component, Focusable {
 			return;
 		}
 
-		// Ctrl+- / Ctrl+_ - Undo last edit
-		if (matchesKey(data, "ctrl+-") || matchesKey(data, "ctrl+_")) {
+		// Undo
+		if (kb.matches(data, "undo")) {
 			this.#applyUndo();
 			return;
 		}

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -86,7 +86,7 @@ export const DEFAULT_EDITOR_KEYBINDINGS: Required<EditorKeybindingsConfig> = {
 	// Clipboard
 	copy: "ctrl+c",
 	// Kill ring / undo
-	undo: "ctrl+-",
+	undo: ["ctrl+-", "ctrl+_"],
 	yank: "ctrl+y",
 	yankPop: "alt+y",
 };

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -1,11 +1,16 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { stripVTControlCharacters } from "node:util";
 import { CombinedAutocompleteProvider } from "@oh-my-pi/pi-tui/autocomplete";
 import { Editor } from "@oh-my-pi/pi-tui/components/editor";
 import { visibleWidth } from "@oh-my-pi/pi-tui/utils";
+import { EditorKeybindingsManager, setEditorKeybindings } from "../src/keybindings";
 import { defaultEditorTheme } from "./test-themes";
 
 describe("Editor component", () => {
+	afterEach(() => {
+		setEditorKeybindings(new EditorKeybindingsManager());
+	});
+
 	describe("Prompt history navigation", () => {
 		it("does nothing on Up arrow when history is empty", () => {
 			const editor = new Editor(defaultEditorTheme);
@@ -1332,6 +1337,23 @@ describe("Editor component", () => {
 			editor.handleInput("\x1b[A"); // Up - line 1, col 0
 			editor.handleInput("\x1b[A"); // Up - line 0, col 8 (new sticky from restored position)
 			expect(editor.getCursor()).toEqual({ line: 0, col: 8 });
+		});
+
+		it("uses the configured undo binding", () => {
+			setEditorKeybindings(
+				new EditorKeybindingsManager({
+					undo: "f8",
+				}),
+			);
+
+			const editor = new Editor(defaultEditorTheme);
+
+			editor.handleInput("a");
+			expect(editor.getText()).toBe("a");
+
+			editor.handleInput("\x1b[19~"); // F8
+			expect(editor.getText()).toBe("");
+			expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
 		});
 
 		it("undoes the last paste when a transient #undo trigger is executed", () => {


### PR DESCRIPTION
## What

Makes the multiline Editor resolve undo through the editor keybinding manager instead of hardcoded Ctrl+-/Ctrl+_ checks. 

I also changed the default keybinding to include the ctrl+_ case, in case it's relied upon...? Happy to revert this chunk if it's overly cautious.

Fixes #493 

## Why

Because I like ctrl+/

## Testing

We've got a test. 

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
