### PR TITLE
fix: setWidget(key, undefined) now correctly clears the widget

### DIFF
--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -253,7 +253,7 @@ export class ExtensionUiController {
 	}
 
 	setHookWidget(key: string, content: unknown): void {
-		this.ctx.statusLine.setHookStatus(key, String(content));
+		this.ctx.statusLine.setHookStatus(key, content === undefined ? undefined : String(content));
 		this.ctx.ui.requestRender();
 	}
 


### PR DESCRIPTION
## Problem

`ctx.ui.setWidget(key, undefined)` — the pattern for clearing a widget — was instead writing the literal string `"undefined"` into the footer status line.

**Root cause:** `setHookWidget` coerces its `content` argument with `String()` before forwarding to `setHookStatus`:

```ts
// before
setHookWidget(key: string, content: unknown): void {
    this.ctx.statusLine.setHookStatus(key, String(content)); // String(undefined) === "undefined"
}
```

`setHookStatus` correctly deletes the key when given `undefined`, but it never received `undefined` — it received the string `"undefined"`.

**Visible symptom:** `pi-superpowers-plus` calls `setWidget("plan_tracker", undefined)` and `setWidget("workflow_monitor", undefined)` on session start. Both land as literal `"undefined"` entries in the hook status map. The render path joins all statuses by space → **`undefined undefined`** displays in the footer above the input field on every session.

## Fix

```ts
// after
setHookWidget(key: string, content: unknown): void {
    this.ctx.statusLine.setHookStatus(key, content === undefined ? undefined : String(content));
}
```

Pass `undefined` through directly so `setHookStatus` can delete the key.

Fixes #496