### PR TITLE
fix(mcp): propagate mcpManager to nested subagent sessions

### DIFF
--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -194,6 +194,8 @@ export interface CreateAgentSessionOptions {
 
 	/** Enable MCP server discovery from .mcp.json files. Default: true */
 	enableMCP?: boolean;
+	/** Existing MCP manager to reuse (skips discovery, propagates to toolSession). */
+	mcpManager?: MCPManager;
 
 	/** Enable LSP integration (tool, formatting, diagnostics, warmup). Default: true */
 	enableLsp?: boolean;
@@ -1005,10 +1007,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		const builtinTools = await logger.time("createAllTools", createTools, toolSession, options.toolNames);
 
 		// Discover MCP tools from .mcp.json files
-		let mcpManager: MCPManager | undefined;
+		let mcpManager: MCPManager | undefined = options.mcpManager;
 		const enableMCP = options.enableMCP ?? true;
 		const customTools: CustomTool[] = [];
-		if (enableMCP) {
+		if (enableMCP && !mcpManager) {
 			const mcpResult = await logger.time("discoverAndLoadMCPTools", discoverAndLoadMCPTools, cwd, {
 				onConnecting: serverNames => {
 					if (options.hasUI && serverNames.length > 0) {
@@ -1024,7 +1026,6 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				authStorage,
 			});
 			mcpManager = mcpResult.manager;
-			toolSession.mcpManager = mcpManager;
 
 			if (settings.get("mcp.notifications")) {
 				mcpManager.setNotificationsEnabled(true);
@@ -1044,6 +1045,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				customTools.push(...mcpResult.tools.map(loaded => loaded.tool));
 			}
 		}
+		toolSession.mcpManager = mcpManager;
 
 		// Add Gemini image tools if GEMINI_API_KEY (or GOOGLE_API_KEY) is available
 		const geminiImageTools = await logger.time("getGeminiImageTools", getGeminiImageTools);
@@ -1663,8 +1665,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			}),
 		);
 
-		// Wire MCP manager callbacks to session for reactive tool updates
-		if (mcpManager) {
+		// Wire MCP manager callbacks to session for reactive tool updates.
+		// Skip when reusing a parent's manager — the parent owns the callbacks.
+		if (mcpManager && !options.mcpManager) {
 			mcpManager.setOnToolsChanged(tools => {
 				void session.refreshMCPTools(tools);
 			});

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -970,6 +970,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				enableLsp: lspEnabled,
 				skipPythonPreflight,
 				enableMCP,
+				mcpManager: options.mcpManager,
 				customTools: mcpProxyTools.length > 0 ? mcpProxyTools : undefined,
 			});
 


### PR DESCRIPTION
## Problem

Depth-2+ subagents each spawned their own MCP stdio server processes instead of reusing the parent's connections. A single omp session with nested task invocations could accumulate a lot of duplicate `mcp server` processes, each with auto-reconnect keeping them alive.

### Root cause

`toolSession.mcpManager` was only set inside the `if (enableMCP)` block in `createAgentSession()`. Depth-1 subagents received proxy tools with `enableMCP=false`, so their `toolSession.mcpManager` was never set. When they spawned depth-2 subagents, `this.session.mcpManager` was `undefined`, causing full MCP re-discovery and new server processes.

| Depth | enableMCP | toolSession.mcpManager | New process? |
|-------|-----------|----------------------|--------------|
| 0 (main) | true | Set | 1 (expected) |
| 1 (subagent) | false | **undefined** | No (proxy tools) |
| 2 (sub-subagent) | true (fallback) | Set | **Yes (duplicate)** |

### Timeline

- `d6af8e7da` (Jan 11) — Original worker-based MCP proxy via IPC, no issue
- `b9149a12c` (Jan 27) — In-process subagent migration introduced the latent bug
- `faa2ddfa7` (Feb 5) — `task.maxRecursionDepth` made depth-2 agents common, exposing it

## Fix

- Add `mcpManager?: MCPManager` to `CreateAgentSessionOptions`
- Guard discovery with `if (enableMCP && !mcpManager)` to skip when manager is provided
- Move `toolSession.mcpManager = mcpManager` after the `if` block (unconditional)
- Pass `options.mcpManager` from executor through to `createAgentSession`

All depths now share the same `MCPManager` reference. Proxy tools at each level call directly into the shared connection pool — no re-wrapping, no duplicate processes.