### PR TITLE
fix(tui): enforce strict line budget for collapsed tool output

### DIFF
--- a/packages/coding-agent/src/tools/ast-edit.ts
+++ b/packages/coding-agent/src/tools/ast-edit.ts
@@ -435,18 +435,6 @@ export const astEditToolRenderer = {
 			group => !group[0]?.startsWith("Safety cap reached") && !group[0]?.startsWith("Parse issues:"),
 		);
 
-		const getCollapsedChangeLimit = (groups: string[][], maxLines: number): number => {
-			if (groups.length === 0) return 0;
-			let usedLines = 0;
-			let count = 0;
-			for (const group of groups) {
-				if (count > 0 && usedLines + group.length > maxLines) break;
-				usedLines += group.length;
-				count += 1;
-				if (usedLines >= maxLines) break;
-			}
-			return count;
-		};
 		const badge = { label: "proposed", color: "warning" as const };
 		const header = renderStatusLine(
 			{ icon: limitReached ? "warning" : "success", title: "AST Edit", description, badge, meta },
@@ -471,14 +459,12 @@ export const astEditToolRenderer = {
 				const { expanded } = options;
 				const key = new Hasher().bool(expanded).u32(width).digest();
 				if (cached?.key === key) return cached.lines;
-				const maxCollapsed = expanded
-					? changeGroups.length
-					: getCollapsedChangeLimit(changeGroups, COLLAPSED_CHANGE_LIMIT);
 				const changeLines = renderTreeList(
 					{
 						items: changeGroups,
 						expanded,
-						maxCollapsed,
+						maxCollapsed: changeGroups.length,
+						maxCollapsedLines: COLLAPSED_CHANGE_LIMIT,
 						itemType: "change",
 						renderItem: group =>
 							group.map(line => {

--- a/packages/coding-agent/src/tools/ast-grep.ts
+++ b/packages/coding-agent/src/tools/ast-grep.ts
@@ -402,19 +402,6 @@ export const astGrepToolRenderer = {
 			group => !group[0]?.startsWith("Result limit reached") && !group[0]?.startsWith("Parse issues:"),
 		);
 
-		const getCollapsedMatchLimit = (groups: string[][], maxLines: number): number => {
-			if (groups.length === 0) return 0;
-			let usedLines = 0;
-			let count = 0;
-			for (const group of groups) {
-				if (count > 0 && usedLines + group.length > maxLines) break;
-				usedLines += group.length;
-				count += 1;
-				if (usedLines >= maxLines) break;
-			}
-			return count;
-		};
-
 		const extraLines: string[] = [];
 		if (limitReached) {
 			extraLines.push(uiTheme.fg("warning", "limit reached; narrow path pattern or increase limit"));
@@ -434,14 +421,12 @@ export const astGrepToolRenderer = {
 				const { expanded } = options;
 				const key = new Hasher().bool(expanded).u32(width).digest();
 				if (cached?.key === key) return cached.lines;
-				const maxCollapsed = expanded
-					? matchGroups.length
-					: getCollapsedMatchLimit(matchGroups, COLLAPSED_MATCH_LIMIT);
 				const matchLines = renderTreeList(
 					{
 						items: matchGroups,
 						expanded,
-						maxCollapsed,
+						maxCollapsed: matchGroups.length,
+						maxCollapsedLines: COLLAPSED_MATCH_LIMIT,
 						itemType: "match",
 						renderItem: group =>
 							group.map(line => {

--- a/packages/coding-agent/src/tools/grep.ts
+++ b/packages/coding-agent/src/tools/grep.ts
@@ -522,19 +522,6 @@ export const grepToolRenderer = {
 			}
 		}
 
-		const getCollapsedMatchLimit = (groups: string[][], maxLines: number): number => {
-			if (groups.length === 0) return 0;
-			let usedLines = 0;
-			let count = 0;
-			for (const group of groups) {
-				if (count > 0 && usedLines + group.length > maxLines) break;
-				usedLines += group.length;
-				count += 1;
-				if (usedLines >= maxLines) break;
-			}
-			return count;
-		};
-
 		const truncationReasons: string[] = [];
 		if (limits?.matchLimit) truncationReasons.push(`limit ${limits.matchLimit.reached} matches`);
 		if (limits?.resultLimit) truncationReasons.push(`limit ${limits.resultLimit.reached} results`);
@@ -551,14 +538,12 @@ export const grepToolRenderer = {
 				const { expanded } = options;
 				const key = new Hasher().bool(expanded).u32(width).digest();
 				if (cached?.key === key) return cached.lines;
-				const maxCollapsed = expanded
-					? matchGroups.length
-					: getCollapsedMatchLimit(matchGroups, COLLAPSED_TEXT_LIMIT);
 				const matchLines = renderTreeList(
 					{
 						items: matchGroups,
 						expanded,
-						maxCollapsed,
+						maxCollapsed: matchGroups.length,
+						maxCollapsedLines: COLLAPSED_TEXT_LIMIT,
 						itemType: "match",
 						renderItem: group =>
 							group.map(line => {

--- a/packages/coding-agent/src/tui/tree-list.ts
+++ b/packages/coding-agent/src/tui/tree-list.ts
@@ -10,17 +10,47 @@ export interface TreeListOptions<T> {
 	items: T[];
 	expanded?: boolean;
 	maxCollapsed?: number;
+	/** Strict total-line budget for collapsed mode. When set (and not expanded),
+	 *  rendering stops as soon as emitting the next item would exceed this many
+	 *  lines, even within the first item. */
+	maxCollapsedLines?: number;
 	itemType?: string;
 	renderItem: (item: T, context: TreeContext) => string | string[];
 }
 
 export function renderTreeList<T>(options: TreeListOptions<T>, theme: Theme): string[] {
-	const { items, expanded = false, maxCollapsed = 8, itemType = "item", renderItem } = options;
-	const lines: string[] = [];
+	const { items, expanded = false, maxCollapsed = 8, maxCollapsedLines, itemType = "item", renderItem } = options;
 	const maxItems = expanded ? items.length : Math.min(items.length, maxCollapsed);
+	const linesBudget = !expanded && maxCollapsedLines !== undefined ? maxCollapsedLines : Infinity;
 
-	for (let i = 0; i < maxItems; i++) {
-		const isLast = i === maxItems - 1 && (expanded || items.length <= maxCollapsed);
+	// Pass 1: determine how many items fit within both the item count and line budget.
+	let fittingCount = maxItems;
+	if (linesBudget !== Infinity) {
+		fittingCount = 0;
+		let totalLines = 0;
+		for (let i = 0; i < maxItems; i++) {
+			const rendered = renderItem(items[i], {
+				index: i,
+				isLast: false,
+				depth: 0,
+				theme,
+				prefix: "",
+				continuePrefix: "",
+			});
+			const count = Array.isArray(rendered) ? rendered.length : rendered ? 1 : 0;
+			if (count > 0 && totalLines + count > linesBudget) break;
+			totalLines += count;
+			fittingCount = i + 1;
+		}
+	}
+
+	const remaining = items.length - fittingCount;
+	const hasSummary = !expanded && remaining > 0;
+
+	// Pass 2: render items with correct isLast and prefixes.
+	const lines: string[] = [];
+	for (let i = 0; i < fittingCount; i++) {
+		const isLast = !hasSummary && i === fittingCount - 1;
 		const branch = getTreeBranch(isLast, theme);
 		const prefix = `${theme.fg("dim", branch)} `;
 		const continuePrefix = `${theme.fg("dim", getTreeContinuePrefix(isLast, theme))}`;
@@ -44,8 +74,7 @@ export function renderTreeList<T>(options: TreeListOptions<T>, theme: Theme): st
 		}
 	}
 
-	if (!expanded && items.length > maxItems) {
-		const remaining = items.length - maxItems;
+	if (hasSummary) {
 		lines.push(`${theme.fg("dim", theme.tree.last)} ${theme.fg("muted", formatMoreItems(remaining, itemType))}`);
 	}
 

--- a/packages/coding-agent/test/tui-tree-list-collapsed-lines.test.ts
+++ b/packages/coding-agent/test/tui-tree-list-collapsed-lines.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "bun:test";
+import { renderTreeList } from "../src/tui/tree-list";
+
+const stubTheme = {
+	fg: (_color: string, text: string) => text,
+	tree: { branch: "├", last: "└", vertical: "│", horizontal: "─", hook: "╰" },
+} as Parameters<typeof renderTreeList>[1];
+
+describe("renderTreeList maxCollapsedLines", () => {
+	it("skips oversized first item instead of rendering broken fragments", () => {
+		const largeGroup = Array.from({ length: 15 }, (_, i) => `line-${i}`);
+		const smallGroup = ["a", "b"];
+
+		const collapsed = renderTreeList(
+			{
+				items: [largeGroup, smallGroup],
+				expanded: false,
+				maxCollapsedLines: 6,
+				itemType: "match",
+				renderItem: group => group,
+			},
+			stubTheme,
+		);
+
+		const contentLines = collapsed.filter(l => !l.includes("more match"));
+		expect(contentLines.length).toBeLessThanOrEqual(6);
+		const summaryLine = collapsed.find(l => l.includes("more match"));
+		expect(summaryLine).toBeDefined();
+	});
+
+	it("fits items within budget and skips those that exceed it", () => {
+		const items = [["a", "b"], ["c", "d", "e"], ["f"]];
+
+		const collapsed = renderTreeList(
+			{
+				items,
+				expanded: false,
+				maxCollapsedLines: 4,
+				itemType: "match",
+				renderItem: group => group,
+			},
+			stubTheme,
+		);
+
+		const contentLines = collapsed.filter(l => !l.includes("more match"));
+		expect(contentLines.length).toBeLessThanOrEqual(4);
+		expect(contentLines.length).toBe(2);
+		const summaryLine = collapsed.find(l => l.includes("more match"));
+		expect(summaryLine).toBeDefined();
+		expect(summaryLine).toContain("2");
+	});
+
+	it("does not cap lines in expanded mode", () => {
+		const largeGroup = Array.from({ length: 15 }, (_, i) => `line-${i}`);
+
+		const expanded = renderTreeList(
+			{
+				items: [largeGroup],
+				expanded: true,
+				maxCollapsedLines: 6,
+				itemType: "match",
+				renderItem: group => group,
+			},
+			stubTheme,
+		);
+
+		expect(expanded.length).toBe(15);
+		expect(expanded.some(l => l.includes("more"))).toBe(false);
+	});
+
+	it("shows correct remaining count when multiple items are hidden", () => {
+		const items = [
+			["a1", "a2", "a3"],
+			["b1", "b2", "b3"],
+			["c1", "c2"],
+		];
+
+		const collapsed = renderTreeList(
+			{
+				items,
+				expanded: false,
+				maxCollapsedLines: 4,
+				itemType: "change",
+				renderItem: group => group,
+			},
+			stubTheme,
+		);
+
+		const summaryLine = collapsed.find(l => l.includes("more change"));
+		expect(summaryLine).toBeDefined();
+		expect(summaryLine).toContain("2");
+	});
+
+	it("renders all items when total lines fit within budget", () => {
+		const items = [["a"], ["b"], ["c"]];
+
+		const collapsed = renderTreeList(
+			{
+				items,
+				expanded: false,
+				maxCollapsedLines: 10,
+				itemType: "item",
+				renderItem: group => group,
+			},
+			stubTheme,
+		);
+
+		expect(collapsed.length).toBe(3);
+		expect(collapsed.some(l => l.includes("more"))).toBe(false);
+	});
+
+	it("uses non-last tree branch when summary line follows", () => {
+		const items = [["a"], ["b", "c"]];
+
+		const collapsed = renderTreeList(
+			{
+				items,
+				expanded: false,
+				maxCollapsedLines: 1,
+				itemType: "item",
+				renderItem: group => group,
+			},
+			stubTheme,
+		);
+
+		expect(collapsed.length).toBe(2);
+		expect(collapsed[0]).toContain("├");
+		expect(collapsed[0]).toContain("a");
+		expect(collapsed[1]).toContain("└");
+		expect(collapsed[1]).toContain("more item");
+	});
+
+	it("uses last tree branch when no summary follows", () => {
+		const items = [["a"]];
+
+		const collapsed = renderTreeList(
+			{
+				items,
+				expanded: false,
+				maxCollapsedLines: 10,
+				itemType: "item",
+				renderItem: group => group,
+			},
+			stubTheme,
+		);
+
+		expect(collapsed.length).toBe(1);
+		expect(collapsed[0]).toContain("└");
+		expect(collapsed.some(l => l.includes("more"))).toBe(false);
+	});
+
+	it("budget=0 shows only summary line", () => {
+		const items = [["a"], ["b"]];
+
+		const collapsed = renderTreeList(
+			{
+				items,
+				expanded: false,
+				maxCollapsedLines: 0,
+				itemType: "item",
+				renderItem: group => group,
+			},
+			stubTheme,
+		);
+
+		expect(collapsed.length).toBe(1);
+		expect(collapsed[0]).toContain("2 more items");
+	});
+
+	it("budget exactly matching total lines shows no summary", () => {
+		const items = [["a", "b"], ["c"]];
+
+		const collapsed = renderTreeList(
+			{
+				items,
+				expanded: false,
+				maxCollapsedLines: 3,
+				itemType: "item",
+				renderItem: group => group,
+			},
+			stubTheme,
+		);
+
+		expect(collapsed.length).toBe(3);
+		expect(collapsed.some(l => l.includes("more"))).toBe(false);
+	});
+
+	it("empty items do not inflate remaining count", () => {
+		const items = [["a"], [], ["b"]];
+
+		const collapsed = renderTreeList(
+			{
+				items,
+				expanded: false,
+				maxCollapsedLines: 10,
+				itemType: "item",
+				renderItem: group => group,
+			},
+			stubTheme,
+		);
+
+		expect(collapsed.length).toBe(2);
+		expect(collapsed.some(l => l.includes("more"))).toBe(false);
+	});
+
+	it("maxCollapsed limits items even when line budget has room", () => {
+		const items = [["a"], ["b"], ["c"], ["d"]];
+
+		const collapsed = renderTreeList(
+			{
+				items,
+				expanded: false,
+				maxCollapsed: 2,
+				maxCollapsedLines: 100,
+				itemType: "item",
+				renderItem: group => group,
+			},
+			stubTheme,
+		);
+
+		const contentLines = collapsed.filter(l => !l.includes("more item"));
+		expect(contentLines.length).toBe(2);
+		const summaryLine = collapsed.find(l => l.includes("more item"));
+		expect(summaryLine).toBeDefined();
+		expect(summaryLine).toContain("2");
+	});
+});


### PR DESCRIPTION
## Summary

- Add `maxCollapsedLines` option to `renderTreeList` that enforces a strict total-line cap in collapsed mode, preventing oversized groups from dominating the view
- Items that exceed the remaining line budget are **skipped entirely** — no broken fragments like orphaned file headers without matches
- `isLast` tree branch is computed via a **two-pass approach**: pass 1 determines which items fit the budget, pass 2 renders with correct prefixes — no more double-last branches when a summary line follows
- **Early-out optimization**: when `maxCollapsedLines` is not set (all existing callers except the three fixed ones), pass 1 is skipped entirely — no unnecessary double `renderItem` calls
- Remove the per-tool `getCollapsedMatchLimit` / `getCollapsedChangeLimit` helpers from `grep.ts`, `ast-grep.ts`, and `ast-edit.ts` — redundant with the new `renderTreeList` line budget
- The three callers now pass `maxCollapsed: items.length` so only `maxCollapsedLines` acts as the binding constraint

### Root cause

The old `getCollapsedMatchLimit` functions counted groups to include, with a line budget of 6. The algorithm always included the first group unconditionally (`count > 0` guard), so a single large group (e.g., directory header + multiple file headers + many match lines) rendered 15+ lines in collapsed mode.

### Fix

`renderTreeList` now enforces a strict line budget via `maxCollapsedLines`. Groups that don't fit the remaining budget are skipped entirely (no partial rendering that produces useless fragments). The `isLast` tree branch character is computed after the budget check to ensure correct tree connector symbols.

### Example

A grep result with 3 groups where group 1 has 15 lines:

- **Before**: Collapsed shows all 15 lines of group 1 + "2 more matches" (16 lines total)
- **After**: Group 1 doesn't fit budget (6 lines), skipped → "3 more matches" (1 line)

## Test plan

11 test cases in `packages/coding-agent/test/tui-tree-list-collapsed-lines.test.ts`:

- [x] `bun check:ts` passes (biome + tsgo)
- [x] Oversized first item is skipped entirely (no broken fragments)
- [x] Items within budget are shown, those exceeding are skipped
- [x] Expanded mode ignores `maxCollapsedLines`
- [x] Remaining count is correct when multiple items hidden
- [x] All items shown when total lines fit within budget
- [x] Content items get non-last tree branch (`├`) when summary line follows
- [x] Last tree branch (`└`) used when no summary follows
- [x] Budget=0 shows only summary line
- [x] Budget exactly matching total lines shows no summary
- [x] Empty items do not inflate remaining count
- [x] `maxCollapsed` limits items even when line budget has room

Fixes #455