### PR TITLE
Allow overriding the Codex web search model

### DIFF
--- a/packages/coding-agent/src/web/search/providers/codex.ts
+++ b/packages/coding-agent/src/web/search/providers/codex.ts
@@ -22,7 +22,8 @@ const DEFAULT_INSTRUCTIONS =
 	"You are a helpful assistant with web search capabilities. Search the web to answer the user's question accurately and cite your sources.";
 
 function getModel(): string {
-	return $env.PI_CODEX_WEB_SEARCH_MODEL ?? DEFAULT_MODEL;
+	const configuredModel = $env.PI_CODEX_WEB_SEARCH_MODEL?.trim();
+	return configuredModel ? configuredModel : DEFAULT_MODEL;
 }
 
 export interface CodexSearchParams {

--- a/packages/coding-agent/test/tools/web-search-codex.test.ts
+++ b/packages/coding-agent/test/tools/web-search-codex.test.ts
@@ -97,6 +97,18 @@ describe("searchCodex model selection", () => {
 		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
 	});
 
+	it("falls back to the default model when PI_CODEX_WEB_SEARCH_MODEL is blank", async () => {
+		process.env.PI_CODEX_WEB_SEARCH_MODEL = "   ";
+		using _hook = mockCodexFetch("gpt-5-codex-mini");
+
+		const result = await searchCodex({ query: "blank codex model" });
+
+		expect(capturedRequest).not.toBeNull();
+		expect(capturedRequest?.body?.model).toBe("gpt-5-codex-mini");
+		expect(result.model).toBe("gpt-5-codex-mini");
+	});
+
+
 	it("uses PI_CODEX_WEB_SEARCH_MODEL when provided", async () => {
 		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.4-mini";
 		using _hook = mockCodexFetch("gpt-5.4-mini");


### PR DESCRIPTION
## Summary
- read `PI_CODEX_WEB_SEARCH_MODEL` in the built-in Codex web search provider
- use the requested model for the outbound Codex Responses API request
- add focused tests for default and env-overridden model selection

## Testing
- bun test packages/coding-agent/test/tools/web-search-codex.test.ts
- bun --cwd=packages/coding-agent run check