### PR TITLE
feat(ai): add gemini-3.1-pro models to google-vertex provider

### DIFF
--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -6839,6 +6839,60 @@
 					"high"
 				]
 			}
+		},
+		"gemini-3.1-pro-preview": {
+			"id": "gemini-3.1-pro-preview",
+			"name": "Gemini 3.1 Pro Preview",
+			"api": "google-vertex",
+			"provider": "google-vertex",
+			"baseUrl": "https://{location}-aiplatform.googleapis.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "google-level",
+				"levels": [
+					"low",
+					"high"
+				]
+			}
+		},
+		"gemini-3.1-pro-preview-customtools": {
+			"id": "gemini-3.1-pro-preview-customtools",
+			"name": "Gemini 3.1 Pro Preview Custom Tools",
+			"api": "google-vertex",
+			"provider": "google-vertex",
+			"baseUrl": "https://{location}-aiplatform.googleapis.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "google-level",
+				"levels": [
+					"low",
+					"high"
+				]
+			}
 		}
 	},
 	"groq": {


### PR DESCRIPTION
## Summary

- Add `gemini-3.1-pro-preview` and `gemini-3.1-pro-preview-customtools` to the `google-vertex` provider in `models.json`
- Config mirrors the existing `google-generative-ai` entries (cost, context window, thinking mode) adapted to vertex conventions (`levels` array)

These models are available via the Vertex AI API but were only listed under the `google-generative-ai` provider.

Fixes #520

## Test plan

- [x] `tsgo -p packages/ai/tsconfig.json` clean
- [ ] Verify models are selectable via `omp /model` with a Vertex-configured environment