### PR TITLE
Add Wayland clipboard image fallback

### DIFF
--- a/packages/natives/src/clipboard/index.ts
+++ b/packages/natives/src/clipboard/index.ts
@@ -20,11 +20,15 @@ const hasDisplay = process.platform !== "linux" || Boolean(process.env.DISPLAY |
 const PREFERRED_WAYLAND_IMAGE_TYPES = ["image/png", "image/jpeg", "image/webp", "image/gif", "image/bmp"] as const;
 
 function runWaylandClipboardCommand(args: string[]): Uint8Array | null {
-	const result = Bun.spawnSync(["wl-paste", ...args], { stdout: "pipe", stderr: "pipe" });
-	if (result.exitCode !== 0 || result.stdout.length === 0) {
+	try {
+		const result = Bun.spawnSync(["wl-paste", ...args], { stdout: "pipe", stderr: "pipe" });
+		if (result.exitCode !== 0 || result.stdout.length === 0) {
+			return null;
+		}
+		return result.stdout;
+	} catch {
 		return null;
 	}
-	return result.stdout;
 }
 
 async function tryReadWaylandClipboardImage(): Promise<ClipboardImage | null> {

--- a/packages/natives/src/clipboard/index.ts
+++ b/packages/natives/src/clipboard/index.ts
@@ -7,6 +7,7 @@
 
 import { execSync } from "node:child_process";
 
+import { ImageFormat, PhotonImage } from "../image";
 import { native } from "../native";
 
 import type { ClipboardImage } from "./types";
@@ -15,6 +16,51 @@ export type { ClipboardImage } from "./types";
 
 /** Whether a display server is available on Linux. */
 const hasDisplay = process.platform !== "linux" || Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+
+const PREFERRED_WAYLAND_IMAGE_TYPES = ["image/png", "image/jpeg", "image/webp", "image/gif", "image/bmp"] as const;
+
+function runWaylandClipboardCommand(args: string[]): Uint8Array | null {
+	const result = Bun.spawnSync(["wl-paste", ...args], { stdout: "pipe", stderr: "pipe" });
+	if (result.exitCode !== 0 || result.stdout.length === 0) {
+		return null;
+	}
+	return result.stdout;
+}
+
+async function tryReadWaylandClipboardImage(): Promise<ClipboardImage | null> {
+	if (process.platform !== "linux" || !process.env.WAYLAND_DISPLAY) {
+		return null;
+	}
+
+	const typeBytes = runWaylandClipboardCommand(["--list-types"]);
+	if (!typeBytes) {
+		return null;
+	}
+
+	const types = Buffer.from(typeBytes)
+		.toString("utf-8")
+		.split(/\r?\n/)
+		.map(type => type.trim())
+		.filter(Boolean);
+	const imageType =
+		PREFERRED_WAYLAND_IMAGE_TYPES.find(type => types.includes(type)) ?? types.find(type => type.startsWith("image/"));
+	if (!imageType) {
+		return null;
+	}
+
+	const imageBytes = runWaylandClipboardCommand(["--type", imageType, "--no-newline"]);
+	if (!imageBytes) {
+		return null;
+	}
+
+	try {
+		const image = await PhotonImage.parse(imageBytes);
+		const pngBytes = await image.encode(ImageFormat.PNG, 100);
+		return { data: pngBytes, mimeType: "image/png" };
+	} catch {
+		return null;
+	}
+}
 
 /**
  * Copy text to the system clipboard.
@@ -88,5 +134,9 @@ export async function readImageFromClipboard(): Promise<ClipboardImage | null> {
 		return null;
 	}
 
-	return native.readImageFromClipboard();
+	const nativeImage = await native.readImageFromClipboard();
+	if (nativeImage) {
+		return nativeImage;
+	}
+	return tryReadWaylandClipboardImage();
 }

--- a/packages/natives/test/clipboard.test.ts
+++ b/packages/natives/test/clipboard.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, mock, test, vi } from "bun:test";
+
+const nativeReadImageFromClipboardMock = vi.fn();
+const photonParseMock = vi.fn();
+const clipboardModulePath = `${import.meta.dir}/../src/clipboard/index.ts`;
+const nativeModulePath = `${import.meta.dir}/../src/native.ts`;
+const imageModulePath = `${import.meta.dir}/../src/image/index.ts`;
+
+const ORIGINAL_WAYLAND_DISPLAY = process.env.WAYLAND_DISPLAY;
+const PNG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+const BMP_BYTES = new Uint8Array([0x42, 0x4d, 0x01, 0x00]);
+
+async function importClipboardModule() {
+	mock.module(nativeModulePath, () => ({
+		native: {
+			readImageFromClipboard: nativeReadImageFromClipboardMock,
+		},
+	}));
+	mock.module(imageModulePath, () => ({
+		ImageFormat: {
+			PNG: 0,
+		},
+		PhotonImage: {
+			parse: photonParseMock,
+		},
+	}));
+	return import(clipboardModulePath);
+}
+
+describe("readImageFromClipboard", () => {
+	beforeEach(() => {
+		process.env.WAYLAND_DISPLAY = "wayland-0";
+		nativeReadImageFromClipboardMock.mockReset();
+		photonParseMock.mockReset();
+	});
+
+	afterEach(() => {
+		if (ORIGINAL_WAYLAND_DISPLAY === undefined) {
+			delete process.env.WAYLAND_DISPLAY;
+		} else {
+			process.env.WAYLAND_DISPLAY = ORIGINAL_WAYLAND_DISPLAY;
+		}
+		vi.restoreAllMocks();
+	});
+
+	test("returns native clipboard image without invoking fallback", async () => {
+		nativeReadImageFromClipboardMock.mockResolvedValue({ data: PNG_BYTES, mimeType: "image/png" });
+		const spawnSpy = vi.spyOn(Bun, "spawnSync");
+		const { readImageFromClipboard } = await importClipboardModule();
+
+		const image = await readImageFromClipboard();
+
+		expect(image).toEqual({ data: PNG_BYTES, mimeType: "image/png" });
+		expect(spawnSpy).not.toHaveBeenCalled();
+	});
+
+	test("falls back to wl-paste and normalizes image bytes to png", async () => {
+		nativeReadImageFromClipboardMock.mockResolvedValue(null);
+		photonParseMock.mockResolvedValue({
+			encode: vi.fn().mockResolvedValue(PNG_BYTES),
+		});
+		const spawnSpy = vi.spyOn(Bun, "spawnSync");
+		spawnSpy
+			.mockReturnValueOnce({
+				exitCode: 0,
+				stdout: Buffer.from("image/gif\ntext/plain\n"),
+				stderr: Buffer.alloc(0),
+			} as never)
+			.mockReturnValueOnce({ exitCode: 0, stdout: BMP_BYTES, stderr: Buffer.alloc(0) } as never);
+		const { readImageFromClipboard } = await importClipboardModule();
+
+		const image = await readImageFromClipboard();
+
+		expect(spawnSpy).toHaveBeenNthCalledWith(1, ["wl-paste", "--list-types"], { stdout: "pipe", stderr: "pipe" });
+		expect(spawnSpy).toHaveBeenNthCalledWith(2, ["wl-paste", "--type", "image/gif", "--no-newline"], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		expect(photonParseMock).toHaveBeenCalledWith(BMP_BYTES);
+		expect(image).toEqual({ data: PNG_BYTES, mimeType: "image/png" });
+	});
+});


### PR DESCRIPTION
## Summary
Add a Linux/Wayland fallback for `readImageFromClipboard()` when the native clipboard path returns `null`.

## Problem
On some Wayland setups the native clipboard image reader can fail to surface image data even though the compositor clipboard advertises an image MIME type. In that state OMP reports `No image in clipboard` even when an image is actually available.

## Change
- Try `wl-paste --list-types` on Linux/Wayland only after the native image read returns `null`
- Read the clipboard payload through `wl-paste --type ...`
- Decode it with `PhotonImage.parse(...)`
- Re-encode to PNG before returning so the existing `ClipboardImage` contract stays intact

## Why this shape
The clipboard wrapper already promises PNG-or-null. Keeping the fallback in `packages/natives` avoids pushing Wayland clipboard MIME quirks upward into callers.

## Tests
- added coverage for native success without fallback
- added coverage for Wayland fallback plus PNG normalization