### PR TITLE
Normalize pasted image formats before attach

### DIFF
--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -11,6 +11,7 @@ import type { AgentSessionEvent } from "../../session/agent-session";
 import { SKILL_PROMPT_MESSAGE_TYPE, type SkillPromptDetails } from "../../session/messages";
 import { executeBuiltinSlashCommand } from "../../slash-commands/builtin-registry";
 import { getEditorCommand, openInEditor } from "../../utils/external-editor";
+import { ensureSupportedImageInput } from "../../utils/image-input";
 import { resizeImage } from "../../utils/image-resize";
 import { generateSessionTitle, setSessionTerminalTitle } from "../../utils/title-generator";
 
@@ -498,17 +499,25 @@ export class InputController {
 			const image = await readImageFromClipboard();
 			if (image) {
 				const base64Data = image.data.toBase64();
-				let imageData = { data: base64Data, mimeType: image.mimeType };
+				let imageData = await ensureSupportedImageInput({
+					type: "image",
+					data: base64Data,
+					mimeType: image.mimeType,
+				});
+				if (!imageData) {
+					this.ctx.showStatus(`Unsupported clipboard image format: ${image.mimeType}`);
+					return false;
+				}
 				if (settings.get("images.autoResize")) {
 					try {
 						const resized = await resizeImage({
 							type: "image",
-							data: base64Data,
-							mimeType: image.mimeType,
+							data: imageData.data,
+							mimeType: imageData.mimeType,
 						});
-						imageData = { data: resized.data, mimeType: resized.mimeType };
+						imageData = { type: "image", data: resized.data, mimeType: resized.mimeType };
 					} catch {
-						imageData = { data: base64Data, mimeType: image.mimeType };
+						// Keep the normalized image when resize fails.
 					}
 				}
 

--- a/packages/coding-agent/src/utils/image-input.ts
+++ b/packages/coding-agent/src/utils/image-input.ts
@@ -1,12 +1,14 @@
 import * as fs from "node:fs/promises";
+import type { ImageContent } from "@oh-my-pi/pi-ai";
 import { formatBytes } from "@oh-my-pi/pi-utils";
 import { resolveReadPath } from "../tools/path-utils";
+import { convertToPng } from "./image-convert";
 import { formatDimensionNote, resizeImage } from "./image-resize";
 import { detectSupportedImageMimeTypeFromFile } from "./mime";
 
 export const MAX_IMAGE_INPUT_BYTES = 20 * 1024 * 1024;
 const MAX_IMAGE_METADATA_HEADER_BYTES = 256 * 1024;
-
+export const SUPPORTED_INPUT_IMAGE_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
 export interface ImageMetadata {
 	mimeType: string;
 	bytes: number;
@@ -23,6 +25,14 @@ export interface LoadedImageInput {
 	textNote: string;
 	dimensionNote?: string;
 	bytes: number;
+}
+
+export async function ensureSupportedImageInput(image: ImageContent): Promise<ImageContent | null> {
+	if (SUPPORTED_INPUT_IMAGE_MIME_TYPES.has(image.mimeType)) {
+		return image;
+	}
+	const converted = await convertToPng(image.data, image.mimeType);
+	return converted ? { type: "image", data: converted.data, mimeType: converted.mimeType } : null;
 }
 
 export interface ReadImageMetadataOptions {

--- a/packages/coding-agent/test/image-input-normalization.test.ts
+++ b/packages/coding-agent/test/image-input-normalization.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, mock, test, vi } from "bun:test";
+
+const convertToPngMock = vi.fn();
+const imageInputModulePath = `${import.meta.dir}/../src/utils/image-input.ts`;
+const imageConvertModulePath = `${import.meta.dir}/../src/utils/image-convert.ts`;
+const imageResizeModulePath = `${import.meta.dir}/../src/utils/image-resize.ts`;
+const mimeModulePath = `${import.meta.dir}/../src/utils/mime.ts`;
+
+async function importImageInputModule() {
+	mock.module(imageConvertModulePath, () => ({
+		convertToPng: convertToPngMock,
+	}));
+	mock.module(imageResizeModulePath, () => ({
+		formatDimensionNote: () => undefined,
+		resizeImage: vi.fn(),
+	}));
+	mock.module(mimeModulePath, () => ({
+		detectSupportedImageMimeTypeFromFile: vi.fn(),
+	}));
+	return import(imageInputModulePath);
+}
+
+describe("ensureSupportedImageInput", () => {
+	afterEach(() => {
+		convertToPngMock.mockReset();
+		vi.restoreAllMocks();
+	});
+
+	test("returns supported image input unchanged", async () => {
+		const { ensureSupportedImageInput } = await importImageInputModule();
+		const input = { type: "image" as const, data: "abc", mimeType: "image/png" };
+
+		const result = await ensureSupportedImageInput(input);
+
+		expect(result).toEqual(input);
+		expect(convertToPngMock).not.toHaveBeenCalled();
+	});
+
+	test("converts unsupported image input to png", async () => {
+		convertToPngMock.mockResolvedValue({ type: "image", data: "pngdata", mimeType: "image/png" });
+		const { ensureSupportedImageInput } = await importImageInputModule();
+
+		const result = await ensureSupportedImageInput({ type: "image", data: "bmpdata", mimeType: "image/bmp" });
+
+		expect(convertToPngMock).toHaveBeenCalledWith("bmpdata", "image/bmp");
+		expect(result).toEqual({ type: "image", data: "pngdata", mimeType: "image/png" });
+	});
+});


### PR DESCRIPTION
## Summary
Normalize pasted images to provider-supported MIME types before attaching them to user input.

## Problem
The paste-image path previously accepted whatever clipboard MIME came through. If an unsupported or opaque image format reached the coding-agent layer, it could be forwarded into model requests unchanged and trigger invalid-image errors.

## Change
- add `ensureSupportedImageInput(...)` in `image-input.ts`
- keep supported formats unchanged: `image/png`, `image/jpeg`, `image/gif`, `image/webp`
- convert unsupported pasted images to PNG before attach
- use the helper from `InputController.handleImagePaste()` before the image enters `pendingImages`

## Why this shape
`packages/natives` should handle clipboard acquisition, but `packages/coding-agent` still owns the invariant that model-bound image inputs must use a provider-supported MIME type.

## Tests
- added coverage for supported inputs remaining unchanged
- added coverage for unsupported inputs being normalized to PNG