### PR TITLE
feat(coding-agent): show timeout expiry wall-clock time for long-running commands

### DIFF
--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -105,6 +105,9 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 		this.#updateDisplay();
 	}
 
+	// reads have no execution-start timing; no-op satisfies ToolExecutionHandle
+	notifyExecutionStarted(): void {}
+
 	setExpanded(expanded: boolean): void {
 		this.#expanded = expanded;
 		this.#updateDisplay();

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -81,6 +81,7 @@ export interface ToolExecutionHandle {
 		toolCallId?: string,
 	): void;
 	setArgsComplete(toolCallId?: string): void;
+	notifyExecutionStarted(): void;
 	setExpanded(expanded: boolean): void;
 }
 
@@ -122,6 +123,7 @@ export class ToolExecutionComponent extends Container {
 	#spinnerInterval?: NodeJS.Timeout;
 	// Track if args are still being streamed (for edit/write spinner)
 	#argsComplete = false;
+	#executionStartTime: number | undefined;
 	#renderState: {
 		spinnerFrame?: number;
 		expanded: boolean;
@@ -188,6 +190,15 @@ export class ToolExecutionComponent extends Container {
 		this.#argsComplete = true;
 		this.#updateSpinnerAnimation();
 		this.#schedulePreviewDiff(0);
+	}
+
+	/**
+	/**
+	 * Called when the tool has actually started executing (tool_execution_start event).
+	 * More accurate than setArgsComplete() which fires at end of arg streaming.
+	 */
+	notifyExecutionStarted(): void {
+		this.#executionStartTime = Date.now();
 	}
 
 	/**
@@ -668,12 +679,14 @@ export class ToolExecutionComponent extends Container {
 			context.expanded = this.#expanded;
 			context.previewLines = BASH_DEFAULT_PREVIEW_LINES;
 			context.timeout = normalizeTimeoutSeconds(this.#args?.timeout, 3600);
+			context.executionStartMs = this.#executionStartTime;
 		} else if (this.#toolName === "python" && this.#result) {
 			const output = this.#getTextOutput().trimEnd();
 			context.output = output;
 			context.expanded = this.#expanded;
 			context.previewLines = PYTHON_DEFAULT_PREVIEW_LINES;
 			context.timeout = normalizeTimeoutSeconds(this.#args?.timeout, 600);
+			context.executionStartMs = this.#executionStartTime;
 		} else if (isEditLikeToolName(this.#toolName)) {
 			context.editMode = this.#editMode;
 			const previews = this.#editDiffPreview;

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -374,6 +374,7 @@ export class EventController {
 			this.ctx.pendingTools.set(event.toolCallId, component);
 			this.ctx.ui.requestRender();
 		}
+		this.ctx.pendingTools.get(event.toolCallId)?.notifyExecutionStarted();
 	}
 
 	async #handleToolExecutionUpdate(

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -20,7 +20,7 @@ import { applyHeadTail } from "./bash-normalize";
 import { expandInternalUrls, type InternalUrlExpansionOptions } from "./bash-skill-urls";
 import { formatStyledTruncationWarning, type OutputMeta } from "./output-meta";
 import { resolveToCwd } from "./path-utils";
-import { formatToolWorkingDirectory, replaceTabs } from "./render-utils";
+import { formatTimeoutLine, formatToolWorkingDirectory, replaceTabs } from "./render-utils";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout, TOOL_TIMEOUTS } from "./tool-timeouts";
@@ -709,6 +709,8 @@ interface BashRenderContext {
 	previewLines?: number;
 	/** Timeout in seconds */
 	timeout?: number;
+	/** Wall-clock time (ms since epoch) when execution started */
+	executionStartMs?: number;
 }
 
 function formatBashCommand(args: BashRenderArgs): string {
@@ -759,16 +761,11 @@ export const bashToolRenderer = {
 				// Build truncation warning
 				const timeoutSeconds = details?.timeoutSeconds ?? renderContext?.timeout;
 				const requestedTimeoutSeconds = details?.requestedTimeoutSeconds;
-				const timeoutLabel =
-					typeof timeoutSeconds === "number"
-						? requestedTimeoutSeconds !== undefined && requestedTimeoutSeconds !== timeoutSeconds
-							? `Timeout: ${timeoutSeconds}s (requested ${requestedTimeoutSeconds}s clamped)`
-							: `Timeout: ${timeoutSeconds}s`
-						: undefined;
+				const isClamped = requestedTimeoutSeconds !== undefined && requestedTimeoutSeconds !== timeoutSeconds;
 				const timeoutLine =
-					timeoutLabel !== undefined
-						? uiTheme.fg("dim", `${uiTheme.format.bracketLeft}${timeoutLabel}${uiTheme.format.bracketRight}`)
-						: undefined;
+					isClamped
+						? uiTheme.fg("dim", `${uiTheme.format.bracketLeft}Timeout: ${timeoutSeconds}s (requested ${requestedTimeoutSeconds}s clamped)${uiTheme.format.bracketRight}`)
+						: formatTimeoutLine(timeoutSeconds, renderContext?.executionStartMs, options.isPartial ?? false, uiTheme);
 				let warningLine: string | undefined;
 				if (details?.meta?.truncation && !showingFullOutput) {
 					warningLine = formatStyledTruncationWarning(details.meta, uiTheme) ?? undefined;

--- a/packages/coding-agent/src/tools/python.ts
+++ b/packages/coding-agent/src/tools/python.ts
@@ -15,7 +15,8 @@ import { DEFAULT_MAX_BYTES, OutputSink, type OutputSummary, TailBuffer } from ".
 import { getTreeBranch, getTreeContinuePrefix, renderCodeCell } from "../tui";
 import type { ToolSession } from ".";
 import { formatStyledTruncationWarning, type OutputMeta } from "./output-meta";
-import { formatTitle, replaceTabs, shortenPath, truncateToWidth, wrapBrackets } from "./render-utils";
+import { resolveToCwd } from "./path-utils";
+import { formatTimeoutLine, formatTitle, replaceTabs, shortenPath, truncateToWidth } from "./render-utils";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout } from "./tool-timeouts";
@@ -513,6 +514,7 @@ interface PythonRenderContext {
 	expanded?: boolean;
 	previewLines?: number;
 	timeout?: number;
+	executionStartMs?: number;
 }
 
 /** Format a status event as a single line for display. */
@@ -950,11 +952,12 @@ export const pythonToolRenderer = {
 			return [header, ...treeLines];
 		});
 
-		const timeoutSeconds = options.renderContext?.timeout;
-		const timeoutLine =
-			typeof timeoutSeconds === "number"
-				? uiTheme.fg("dim", wrapBrackets(`Timeout: ${timeoutSeconds}s`, uiTheme))
-				: undefined;
+		const timeoutLine = formatTimeoutLine(
+			options.renderContext?.timeout,
+			options.renderContext?.executionStartMs,
+			options.isPartial,
+			uiTheme,
+		);
 		let warningLine: string | undefined;
 		if (details?.meta?.truncation) {
 			warningLine = formatStyledTruncationWarning(details.meta, uiTheme) ?? undefined;

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -617,6 +617,31 @@ export function wrapBrackets(text: string, theme: Theme): string {
 	return `${theme.format.bracketLeft}${text}${theme.format.bracketRight}`;
 }
 
+const LONG_TIMEOUT_THRESHOLD_SECONDS = 30;
+
+/**
+ * Format the timeout info line for bash/python renderers.
+ * While the command is running and the timeout is long (>= 30s), shows the wall-clock
+ * time the command will expire rather than just the raw duration.
+ */
+export function formatTimeoutLine(
+	timeoutSeconds: number | undefined,
+	executionStartMs: number | undefined,
+	isPartial: boolean,
+	uiTheme: Theme,
+): string | undefined {
+	if (typeof timeoutSeconds !== "number") return undefined;
+	if (isPartial && executionStartMs !== undefined && timeoutSeconds >= LONG_TIMEOUT_THRESHOLD_SECONDS) {
+		const expiryMs = executionStartMs + timeoutSeconds * 1000;
+		const d = new Date(expiryMs);
+		const hh = d.getHours().toString().padStart(2, "0");
+		const mm = d.getMinutes().toString().padStart(2, "0");
+		const ss = d.getSeconds().toString().padStart(2, "0");
+		return uiTheme.fg("dim", wrapBrackets(`Times out at ${hh}:${mm}:${ss}`, uiTheme));
+	}
+	return uiTheme.fg("dim", wrapBrackets(`Timeout: ${timeoutSeconds}s`, uiTheme));
+}
+
 export const PARSE_ERRORS_LIMIT = 20;
 
 export function dedupeParseErrors(errors: string[] | undefined): string[] {


### PR DESCRIPTION
AI Slop Description: When a bash/python command is running and its timeout is >= 30s, shows the absolute expiry time (e.g. `[Times out at 14:32:05]`) instead of `[Timeout: Ns]`. Reverts to `[Timeout: Ns]` after completion.