### PR TITLE
feat(tui): make inline image max-width configurable via tui.maxInlineImageColumns

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -356,7 +356,7 @@ export const SETTINGS_SCHEMA = {
 	"tui.maxInlineImageColumns": {
 		type: "number",
 		default: 100,
-		description: "Maximum width in terminal columns for inline images (default 100). Set to 0 for unlimited.",
+		description: "Maximum width in terminal columns for inline images (default 100). Set to 0 for unlimited (bounded only by terminal width).",
 	},
 
 	// Display rendering

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -76,7 +76,7 @@ export class AssistantMessageComponent extends Container {
 						image.data,
 						image.mimeType,
 						{ fallbackColor: (text: string) => theme.fg("toolOutput", text) },
-						{ maxWidthCells: settings.get("tui.maxInlineImageColumns") || undefined },
+						{ maxWidthCells: settings.get("tui.maxInlineImageColumns") },
 					),
 				);
 				continue;

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -531,7 +531,7 @@ export class ToolExecutionComponent extends Container {
 						imageData,
 						imageMimeType,
 						{ fallbackColor: (s: string) => theme.fg("toolOutput", s) },
-						{ maxWidthCells: settings.get("tui.maxInlineImageColumns") || undefined },
+						{ maxWidthCells: settings.get("tui.maxInlineImageColumns") },
 					);
 					this.#imageComponents.push(imageComponent);
 					this.addChild(imageComponent);

--- a/packages/tui/src/components/image.ts
+++ b/packages/tui/src/components/image.ts
@@ -51,7 +51,8 @@ export class Image implements Component {
 			return this.#cachedLines;
 		}
 
-		const maxWidth = Math.min(width - 2, this.#options.maxWidthCells ?? 60);
+		const cap = this.#options.maxWidthCells;
+		const maxWidth = (cap != null && cap > 0) ? Math.min(width - 2, cap) : width - 2;
 
 		let lines: string[];
 


### PR DESCRIPTION
AI Slop Description: Adds `tui.maxInlineImageColumns` setting (default 100). Controls the terminal-column cap for inline images in assistant messages and tool output.