### PR TITLE
fix: only show update banner when npm version is strictly newer

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -46,7 +46,7 @@ async function checkForNewVersion(currentVersion: string): Promise<string | unde
 		const data = (await response.json()) as { version?: string };
 		const latestVersion = data.version;
 
-		if (latestVersion && latestVersion !== currentVersion) {
+		if (latestVersion && Bun.semver.order(latestVersion, currentVersion) > 0) {
 			return latestVersion;
 		}
 


### PR DESCRIPTION
AI Slop Description: Replaces `latestVersion !== currentVersion` with a proper semver comparison so the banner doesn't fire when running a locally-built version newer than npm.