### PR TITLE
fix: skill baseDir regex fails on Windows backslash paths

### DIFF
--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -54,7 +54,7 @@ export async function loadSkillsFromDir(options: LoadSkillsFromDirOptions): Prom
 			name: capSkill.name,
 			description: typeof capSkill.frontmatter?.description === "string" ? capSkill.frontmatter.description : "",
 			filePath: capSkill.path,
-			baseDir: capSkill.path.replace(/\/SKILL\.md$/, ""),
+			baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 			source: options.source,
 			_source: capSkill._source,
 		})),
@@ -168,7 +168,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 				name: capSkill.name,
 				description: typeof capSkill.frontmatter?.description === "string" ? capSkill.frontmatter.description : "",
 				filePath: capSkill.path,
-				baseDir: capSkill.path.replace(/\/SKILL\.md$/, ""),
+				baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 				source: `${capSkill._source.provider}:${capSkill.level}`,
 				_source: capSkill._source,
 			});
@@ -204,7 +204,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 					description:
 						typeof capSkill.frontmatter?.description === "string" ? capSkill.frontmatter.description : "",
 					filePath: capSkill.path,
-					baseDir: capSkill.path.replace(/\/SKILL\.md$/, ""),
+					baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 					source: "custom:user",
 					_source: { ...capSkill._source, providerName: "Custom" },
 				},


### PR DESCRIPTION
## Problem

On Windows, `skill.baseDir` is computed via:

```ts
capSkill.path.replace(/\/SKILL\.md$/, "")
```

This regex only matches forward slashes. Windows paths use backslashes (`C:\...\skills\my-skill\SKILL.md`), so the replace is a no-op and `baseDir` remains the full path to `SKILL.md`.

This breaks sub-path resolution for skills — the subpath gets appended to the SKILL.md **file** path instead of the skill **directory**, producing an invalid path like `...\SKILL.md\references\foo.md`.

## Fix

Replace the forward-slash-only regex with a character class that matches both separators:

```ts
capSkill.path.replace(/[\\/]SKILL\.md$/, "")
```

Applied to all 3 occurrences in `packages/coding-agent/src/extensibility/skills.ts`.

No behavior change on Linux/macOS — `[/\\]` matches `/` just as the original regex did.