### PR TITLE
fix(mcp): activate new server tools immediately after /mcp add

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MCP tools from newly added servers not being activated after `/mcp add` — `refreshMCPTools` preserves prior MCP tool selections, so brand-new servers had their tools registered in the registry but never passed to the agent; tools are now explicitly activated on successful connection
+
 ## [13.16.5] - 2026-03-29
 
 ### Fixed

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -793,6 +793,20 @@ export class MCPCommandController {
 				}
 			}
 
+			// refreshMCPTools preserves the prior MCP tool selection, so tools from
+			// brand-new servers are registered in the registry but never activated.
+			// Explicitly activate the newly added server's tools now.
+			if (isConnected && this.ctx.mcpManager) {
+				const serverTools = this.ctx.mcpManager.getTools().filter(t => t.mcpServerName === name);
+				if (serverTools.length > 0) {
+					const currentActive = this.ctx.session.getActiveToolNames();
+					const toActivate = serverTools.map(t => t.name).filter(n => this.ctx.session.getToolByName(n));
+					if (toActivate.length > 0) {
+						await this.ctx.session.setActiveToolsByName([...new Set([...currentActive, ...toActivate])]);
+					}
+				}
+			}
+
 			// Show success message
 			const scopeLabel = scope === "user" ? "user" : "project";
 			const lines = ["", theme.fg("success", `✓ Added server "${name}" to ${scopeLabel} config`), ""];


### PR DESCRIPTION
## Problem

When a user adds a new MCP server via `/mcp add`, the server shows as connected in `/mcp list` but its tools are not available to the agent in the current session.

## Root Cause

`refreshMCPTools` determines which MCP tools to activate by consulting `getSelectedMCPToolNames()`, which has two paths:

- **Discovery disabled** (default): returns `getActiveToolNames().filter(isMCPTool && inRegistry)` — only tools already active before the refresh.
- **Discovery enabled**: returns tools from `#selectedMCPToolNames`, seeded from `mcp.discoveryDefaultServers` config.

In both cases, a brand-new server's tools were never in the prior active set or the configured defaults, so they end up registered in `#toolRegistry` but never passed to `agent.setTools()`. The agent session never sees them.

This affects both `refreshMCPTools` calls in the add flow: the one inside `#reloadMCP` and the one inside `#waitForServerConnectionWithAnimation`.

## Fix

In `#handleWizardComplete`, after `isConnected` is confirmed (covering both the normal 10 s connection path and the fallback `#syncManagerConnection` path), filter the manager's current tools to just the new server and call `setActiveToolsByName` with the union of current active tools and the new server's tools.

Reconnects (`#handleReconnect`) are intentionally left untouched — those preserve prior selection by design, as the comment there notes.