### PR TITLE
fix(ai): normalize anthropic-messages base URLs

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -50,6 +50,15 @@ export type AnthropicHeaderOptions = {
 	modelHeaders?: Record<string, string>;
 };
 
+export function normalizeAnthropicBaseUrl(baseUrl?: string): string | undefined {
+	const trimmed = baseUrl?.trim();
+	if (!trimmed) {
+		return trimmed;
+	}
+	const withoutTrailingSlashes = trimmed.replace(/\/+$/, "");
+	return withoutTrailingSlashes.endsWith("/v1") ? withoutTrailingSlashes.slice(0, -3) : withoutTrailingSlashes;
+}
+
 // Build deduplicated beta header string
 export function buildBetaHeader(baseBetas: string[], extraBetas: string[]): string {
 	const seen = new Set<string>();
@@ -421,25 +430,20 @@ function isFoundryEnabled(): boolean {
 	return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
 }
 
-function normalizeBaseUrl(baseUrl: string | undefined): string | undefined {
-	const trimmed = baseUrl?.trim();
-	return trimmed ? trimmed.replace(/\/+$/, "") : undefined;
-}
-
 function resolveAnthropicBaseUrl(model: Model<"anthropic-messages">, apiKey?: string): string | undefined {
 	if (model.provider === "github-copilot") {
-		return normalizeBaseUrl(resolveGitHubCopilotBaseUrl(model.baseUrl, apiKey) ?? model.baseUrl);
+		return normalizeAnthropicBaseUrl(resolveGitHubCopilotBaseUrl(model.baseUrl, apiKey) ?? model.baseUrl);
 	}
 	if (model.provider === "anthropic" && isFoundryEnabled()) {
-		const foundryBaseUrl = normalizeBaseUrl($env.FOUNDRY_BASE_URL);
+		const foundryBaseUrl = normalizeAnthropicBaseUrl($env.FOUNDRY_BASE_URL);
 		if (foundryBaseUrl) {
 			return foundryBaseUrl;
 		}
 	}
 	if (model.provider === "anthropic") {
-		return normalizeBaseUrl(model.baseUrl) ?? "https://api.anthropic.com";
+		return normalizeAnthropicBaseUrl(model.baseUrl) ?? "https://api.anthropic.com";
 	}
-	return normalizeBaseUrl(model.baseUrl);
+	return normalizeAnthropicBaseUrl(model.baseUrl);
 }
 
 function parseAnthropicCustomHeaders(rawHeaders: string | undefined): Record<string, string> | undefined {
@@ -699,7 +703,11 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 									index: event.index,
 								};
 								output.content.push(block);
-								stream.push({ type: "text_start", contentIndex: output.content.length - 1, partial: output });
+								stream.push({
+									type: "text_start",
+									contentIndex: output.content.length - 1,
+									partial: output,
+								});
 							} else if (event.content_block.type === "thinking") {
 								const block: Block = {
 									type: "thinking",
@@ -1343,7 +1351,10 @@ function buildParams(
 		if (typeof options.toolChoice === "string") {
 			params.tool_choice = { type: options.toolChoice };
 		} else if (isOAuthToken && options.toolChoice.name) {
-			params.tool_choice = { ...options.toolChoice, name: applyClaudeToolPrefix(options.toolChoice.name) };
+			params.tool_choice = {
+				...options.toolChoice,
+				name: applyClaudeToolPrefix(options.toolChoice.name),
+			};
 		} else {
 			params.tool_choice = options.toolChoice;
 		}

--- a/packages/ai/src/utils/anthropic-auth.ts
+++ b/packages/ai/src/utils/anthropic-auth.ts
@@ -10,7 +10,10 @@
  */
 import { $env, getAgentDbPath } from "@oh-my-pi/pi-utils";
 import { type AuthCredential, AuthCredentialStore } from "../auth-storage";
-import { buildAnthropicHeaders as buildProviderAnthropicHeaders } from "../providers/anthropic";
+import {
+	buildAnthropicHeaders as buildProviderAnthropicHeaders,
+	normalizeAnthropicBaseUrl,
+} from "../providers/anthropic";
 import { getEnvApiKey } from "../stream";
 
 /** Auth configuration for Anthropic */
@@ -203,6 +206,7 @@ export function buildAnthropicSearchHeaders(auth: AnthropicAuthConfig): Record<s
  * @returns The complete API URL with beta query parameter
  */
 export function buildAnthropicUrl(auth: AnthropicAuthConfig): string {
-	const base = `${auth.baseUrl}/v1/messages`;
+	const normalizedBaseUrl = normalizeAnthropicBaseUrl(auth.baseUrl);
+	const base = `${normalizedBaseUrl}/v1/messages`;
 	return `${base}?beta=true`;
 }

--- a/packages/ai/test/github-copilot-anthropic-auth.test.ts
+++ b/packages/ai/test/github-copilot-anthropic-auth.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { buildAnthropicClientOptions, streamAnthropic } from "../src/providers/anthropic";
 import type { Context, Model } from "../src/types";
+import { buildAnthropicUrl } from "../src/utils/anthropic-auth";
 
 const originalFetch = global.fetch;
 
@@ -135,6 +136,33 @@ describe("Anthropic Copilot auth config", () => {
 		});
 
 		expect(result.isOAuthToken).toBe(false);
+	});
+
+	it("normalizes trailing /v1 in anthropic base URLs", () => {
+		const model = {
+			...makeCopilotClaudeModel(),
+			provider: "custom-proxy",
+			baseUrl: "http://127.0.0.1:8317/v1",
+		};
+		const result = buildAnthropicClientOptions({
+			model,
+			apiKey: "test-key",
+			extraBetas: [],
+			stream: true,
+			dynamicHeaders: {},
+		});
+
+		expect(result.baseURL).toBe("http://127.0.0.1:8317");
+	});
+
+	it("builds anthropic auth URLs from the normalized service root", () => {
+		const url = buildAnthropicUrl({
+			apiKey: "test-key",
+			baseUrl: "http://127.0.0.1:8317/v1",
+			isOAuth: false,
+		});
+
+		expect(url).toBe("http://127.0.0.1:8317/v1/messages?beta=true");
 	});
 
 	it("forwards initiatorOverride to Copilot message requests", async () => {


### PR DESCRIPTION
## Summary
- normalize trailing `/v1` from `anthropic-messages` base URLs before constructing Anthropic client and auth endpoints
- add regression coverage for both client option construction and auth URL generation
- preserve existing root-form configs while accepting the more common `/v1` form

## Problem
`anthropic-messages` currently treats `baseUrl` as the service root and appends `/v1/messages` internally.

That means a config like:

```yml
baseUrl: http://127.0.0.1:8317/v1
api: anthropic-messages
```

can produce requests to:

```text
http://127.0.0.1:8317/v1/v1/messages
```

which is surprising and inconsistent with common `baseUrl` expectations.

## Fix
This change normalizes a trailing `/v1` to the service root before:
- passing `baseURL` to the Anthropic SDK
- constructing Anthropic auth/search URLs
- recording request dump URLs

So both of these now work equivalently:

```yml
baseUrl: http://127.0.0.1:8317
```

```yml
baseUrl: http://127.0.0.1:8317/v1
```

## Verification
- `bun test packages/ai/test/github-copilot-anthropic-auth.test.ts`
- `bun check:ts`