### PR TITLE
fix: resolve --model provider/id to correct provider when ambiguous

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `--model provider/id` resolving to wrong provider when model ID exists in multiple catalogs ([#560](https://github.com/can1357/oh-my-pi/issues/560))
+
 ## [13.16.4] - 2026-03-28
 ### Changed
 

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -730,9 +730,24 @@ export function resolveCliModel(options: {
 
 	if (!provider) {
 		const lower = cliModel.toLowerCase();
-		const exact = availableModels.find(
-			model => model.id.toLowerCase() === lower || `${model.provider}/${model.id}`.toLowerCase() === lower,
-		);
+		// When input has provider/id format (e.g. "zai/glm-5"), prefer decomposed
+		// provider+id match over flat id match. Without this, a model with id
+		// "zai/glm-5" on provider "vercel-ai-gateway" wins over provider "zai"
+		// with id "glm-5", because Array.find returns the first catalog hit.
+		const slashIdx = lower.indexOf("/");
+		let exact: (typeof availableModels)[number] | undefined;
+		if (slashIdx !== -1) {
+			const prefix = lower.substring(0, slashIdx);
+			const suffix = lower.substring(slashIdx + 1);
+			exact = availableModels.find(
+				model => model.provider.toLowerCase() === prefix && model.id.toLowerCase() === suffix,
+			);
+		}
+		if (!exact) {
+			exact = availableModels.find(
+				model => model.id.toLowerCase() === lower || `${model.provider}/${model.id}`.toLowerCase() === lower,
+			);
+		}
 		if (exact) {
 			return { model: exact, warning: undefined, thinkingLevel: undefined, error: undefined };
 		}

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -551,6 +551,49 @@ describe("resolveCliModel", () => {
 		expect(result.model?.provider).toBe("openrouter");
 		expect(result.model?.id).toBe("qwen/qwen3-coder:exacto");
 	});
+
+	test("prefers decomposed provider+id over flat id match when ambiguous", () => {
+		// Simulates the zai/glm-5 bug: vercel-ai-gateway has id="zai/glm-5",
+		// zai has id="glm-5". Input "zai/glm-5" should resolve to provider=zai.
+		const ambiguousModels: Model<"anthropic-messages">[] = [
+			{
+				id: "zai/glm-5",
+				name: "GLM-5 (Vercel)",
+				api: "anthropic-messages",
+				provider: "vercel-ai-gateway",
+				baseUrl: "https://vercel.ai",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 1 },
+				contextWindow: 128000,
+				maxTokens: 4096,
+			},
+			{
+				id: "glm-5",
+				name: "GLM-5",
+				api: "anthropic-messages",
+				provider: "zai",
+				baseUrl: "https://api.z.ai",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 1 },
+				contextWindow: 128000,
+				maxTokens: 4096,
+			},
+		];
+		const registry = {
+			getAll: () => ambiguousModels,
+		} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+
+		const result = resolveCliModel({
+			cliModel: "zai/glm-5",
+			modelRegistry: registry,
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.model?.provider).toBe("zai");
+		expect(result.model?.id).toBe("glm-5");
+	});
 });
 
 describe("parseModelString", () => {


### PR DESCRIPTION
## What

Fix `--model zai/glm-5` resolving to `vercel-ai-gateway` instead of `zai` provider.

When the CLI input has `provider/id` format, the exact-match logic now checks decomposed `provider+id` first (e.g., provider=`zai`, id=`glm-5`) before falling back to flat `model.id` string match. Previously, `Array.find()` returned the first catalog hit where `model.id === "zai/glm-5"`, which matched `vercel-ai-gateway` (catalog index #36) before the `provider/id` combo could match `zai` (index #39).

Intentionally keeps `getAll()` rather than switching to `getAvailable()` to preserve the `--api-key` ephemeral flow, where auth is injected after model resolution.

## Why

fixes #560

`--model zai/glm-5` fails with "No API key found for vercel-ai-gateway" even though `ZAI_API_KEY` is set. The TUI model picker works because it uses a different code path.

## Testing

- All 49 existing tests pass
- Added test case: "prefers decomposed provider+id over flat id match when ambiguous" -- reproduces the exact bug scenario with both conflicting models in the registry
- Manually traced all existing `resolveCliModel` test inputs through the patched code:
  - `openai/gpt-4o` -- decomposed exact match (unchanged)
  - `openai/gpt-4o:extended` -- decomposed miss, flat hit on openrouter (unchanged)
  - `openrouter/qwen` -- both miss, falls through to fuzzy match (unchanged)
  - `gpt-4o` -- no slash, skips decomposed entirely (unchanged)
  - Bare patterns with `--provider` -- skips `!provider` block entirely (unchanged)

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)