### PR TITLE
fix(natives): skipped grep special files

### DIFF
--- a/crates/pi-natives/src/fs_cache.rs
+++ b/crates/pi-natives/src/fs_cache.rs
@@ -198,8 +198,10 @@ pub fn classify_file_type(path: &Path) -> Option<(FileType, Option<f64>)> {
 		Some((FileType::Symlink, mtime_ms))
 	} else if file_type.is_dir() {
 		Some((FileType::Dir, mtime_ms))
-	} else {
+	} else if file_type.is_file() {
 		Some((FileType::File, mtime_ms))
+	} else {
+		None
 	}
 }
 
@@ -400,5 +402,60 @@ pub fn invalidate_fs_scan_cache(path: Option<String>) {
 			invalidate_path(&target);
 		},
 		None => invalidate_all(),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	#[cfg(unix)]
+	use std::{ffi::CString, os::unix::ffi::OsStrExt};
+	use std::{
+		fs,
+		path::{Path, PathBuf},
+		time::{SystemTime, UNIX_EPOCH},
+	};
+
+	use super::classify_file_type;
+
+	struct TempDirGuard(PathBuf);
+
+	impl TempDirGuard {
+		fn new() -> Self {
+			let unique = SystemTime::now()
+				.duration_since(UNIX_EPOCH)
+				.expect("system time is after UNIX_EPOCH")
+				.as_nanos();
+			let path = std::env::temp_dir().join(format!("pi-fs-cache-test-{unique}"));
+			fs::create_dir_all(&path).expect("create temp test directory");
+			Self(path)
+		}
+
+		fn path(&self) -> &Path {
+			&self.0
+		}
+	}
+
+	impl Drop for TempDirGuard {
+		fn drop(&mut self) {
+			let _ = fs::remove_dir_all(&self.0);
+		}
+	}
+
+	#[cfg(unix)]
+	fn make_fifo(path: &Path) {
+		let fifo_path =
+			CString::new(path.as_os_str().as_bytes()).expect("fifo path has no NUL bytes");
+		let rc = unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o600) };
+		assert_eq!(rc, 0, "create fifo: {}", std::io::Error::last_os_error());
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn classify_file_type_skips_fifo() {
+		let root = TempDirGuard::new();
+		let fifo = root.path().join("skip-me.fifo");
+		make_fifo(&fifo);
+
+		assert_eq!(classify_file_type(&fifo), None);
 	}
 }

--- a/crates/pi-natives/src/grep.rs
+++ b/crates/pi-natives/src/grep.rs
@@ -643,13 +643,24 @@ fn build_searcher(multiline: bool) -> Searcher {
 
 /// Read file bytes, returning `None` for oversized or binary files.
 fn read_file_bytes(path: &Path, prefer_text_fast_path: bool) -> io::Result<Option<FileBytes>> {
-	let file = File::open(path)?;
-	let metadata = file.metadata()?;
-	if metadata.len() > MAX_FILE_BYTES {
+	let metadata = std::fs::symlink_metadata(path)?;
+	let resolved_metadata = if metadata.file_type().is_symlink() {
+		let target_metadata = std::fs::metadata(path)?;
+		if !target_metadata.is_file() {
+			return Ok(None);
+		}
+		target_metadata
+	} else if metadata.is_file() {
+		metadata
+	} else {
 		return Ok(None);
-	} else if metadata.len() == 0 {
+	};
+	if resolved_metadata.len() > MAX_FILE_BYTES {
+		return Ok(None);
+	} else if resolved_metadata.len() == 0 {
 		return Ok(Some(FileBytes::Owned(Vec::new())));
 	}
+	let file = File::open(path)?;
 
 	let mapping = unsafe {
 		// SAFETY: The mapping is read-only and tied to the opened file handle.
@@ -661,25 +672,6 @@ fn read_file_bytes(path: &Path, prefer_text_fast_path: bool) -> io::Result<Optio
 	let bytes = if let Ok(mapped) = mapping {
 		FileBytes::Mapped(mapped)
 	} else {
-		// Resolve symlinks: if the path is a symlink, follow it and check the target.
-		// Reject FIFOs, sockets, block/char devices, and other non-regular-file types.
-		let file_type = metadata.file_type();
-		if file_type.is_symlink() {
-			// Follow the symlink and check the target's file type.
-			let target_metadata = std::fs::metadata(path)?;
-			if !target_metadata.is_file() {
-				return Err(io::Error::new(
-					io::ErrorKind::InvalidInput,
-					format!("not a regular file: {}", path.display()),
-				));
-			}
-		} else if !file_type.is_file() {
-			return Err(io::Error::new(
-				io::ErrorKind::InvalidInput,
-				format!("not a regular file: {}", path.display()),
-			));
-		}
-
 		FileBytes::Owned(std::fs::read(path)?)
 	};
 
@@ -1046,7 +1038,77 @@ fn build_regex_matcher(
 
 #[cfg(test)]
 mod tests {
-	use super::{escape_unescaped_parentheses, sanitize_braces};
+	#[cfg(unix)]
+	use std::{ffi::CString, os::unix::ffi::OsStrExt};
+	use std::{
+		fs,
+		path::{Path, PathBuf},
+		time::{SystemTime, UNIX_EPOCH},
+	};
+
+	use super::{GrepConfig, escape_unescaped_parentheses, grep_sync, sanitize_braces};
+	use crate::task;
+
+	struct TempDirGuard(PathBuf);
+
+	impl TempDirGuard {
+		fn new() -> Self {
+			let unique = SystemTime::now()
+				.duration_since(UNIX_EPOCH)
+				.expect("system time is after UNIX_EPOCH")
+				.as_nanos();
+			let path = std::env::temp_dir().join(format!("pi-grep-test-{unique}"));
+			fs::create_dir_all(&path).expect("create temp test directory");
+			Self(path)
+		}
+
+		fn path(&self) -> &Path {
+			&self.0
+		}
+	}
+
+	impl Drop for TempDirGuard {
+		fn drop(&mut self) {
+			let _ = fs::remove_dir_all(&self.0);
+		}
+	}
+
+	fn write_file(path: &Path, content: &str) {
+		if let Some(parent) = path.parent() {
+			fs::create_dir_all(parent).expect("create parent directories for test file");
+		}
+		fs::write(path, content).expect("write test file");
+	}
+
+	#[cfg(unix)]
+	fn make_fifo(path: &Path) {
+		let fifo_path =
+			CString::new(path.as_os_str().as_bytes()).expect("fifo path has no NUL bytes");
+		let rc = unsafe { libc::mkfifo(fifo_path.as_ptr(), 0o600) };
+		assert_eq!(rc, 0, "create fifo: {}", std::io::Error::last_os_error());
+	}
+
+	#[cfg(unix)]
+	fn base_grep_config(path: &Path) -> GrepConfig {
+		GrepConfig {
+			pattern:        "needle".to_string(),
+			path:           path.to_string_lossy().into_owned(),
+			glob:           None,
+			type_filter:    None,
+			ignore_case:    None,
+			multiline:      None,
+			hidden:         None,
+			gitignore:      Some(false),
+			cache:          Some(false),
+			max_count:      None,
+			offset:         None,
+			context_before: None,
+			context_after:  None,
+			context:        None,
+			max_columns:    None,
+			mode:           None,
+		}
+	}
 
 	#[test]
 	fn preserves_unicode_property_escapes() {
@@ -1088,6 +1150,41 @@ mod tests {
 			escape_unescaped_parentheses("fetchAnthropicProvider()").as_ref(),
 			r"fetchAnthropicProvider\(\)"
 		);
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn grep_directory_skips_fifo_entries() {
+		let root = TempDirGuard::new();
+		write_file(&root.path().join("regular.txt"), "needle\n");
+		make_fifo(&root.path().join("skip-me.fifo"));
+
+		let result =
+			grep_sync(base_grep_config(root.path()), None, None, task::CancelToken::default())
+				.expect("directory grep should succeed");
+
+		assert_eq!(result.total_matches, 1);
+		assert_eq!(result.files_with_matches, 1);
+		assert_eq!(result.files_searched, 1);
+		assert_eq!(result.matches.len(), 1);
+		assert_eq!(result.matches[0].path, "regular.txt");
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn grep_special_root_path_returns_empty_result() {
+		let root = TempDirGuard::new();
+		let fifo = root.path().join("direct.fifo");
+		make_fifo(&fifo);
+
+		let result = grep_sync(base_grep_config(&fifo), None, None, task::CancelToken::default())
+			.expect("special-file grep should return an empty result");
+
+		assert!(result.matches.is_empty());
+		assert_eq!(result.total_matches, 0);
+		assert_eq!(result.files_with_matches, 0);
+		assert_eq!(result.files_searched, 0);
+		assert_eq!(result.limit_reached, None);
 	}
 }
 
@@ -1299,6 +1396,16 @@ fn grep_sync(
 		multiline,
 	};
 	let searcher = build_searcher(multiline);
+
+	if !metadata.is_file() && !metadata.is_dir() {
+		return Ok(GrepResult {
+			matches:            Vec::new(),
+			total_matches:      0,
+			files_with_matches: 0,
+			files_searched:     0,
+			limit_reached:      None,
+		});
+	}
 
 	if metadata.is_file() {
 		if let Some(filter) = type_filter.as_ref()

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -25,6 +25,25 @@ function getTextOutput(result: any): string {
 	);
 }
 
+function createFifoOrSkip(fifoPath: string): boolean {
+	if (process.platform === "win32") {
+		return false;
+	}
+
+	const mkfifoPath = Bun.which("mkfifo");
+	if (!mkfifoPath) {
+		return false;
+	}
+
+	const result = Bun.spawnSync([mkfifoPath, fifoPath], { stdout: "ignore", stderr: "pipe" });
+	if (result.exitCode !== 0) {
+		const errorText = result.stderr.toString("utf-8").trim();
+		throw new Error(`mkfifo failed${errorText ? `: ${errorText}` : ""}`);
+	}
+
+	return true;
+}
+
 let artifactCounter = 0;
 function createTestToolSession(cwd: string, settings: Settings = Settings.isolated()): ToolSession {
 	const sessionFile = path.join(cwd, "session.jsonl");
@@ -847,6 +866,31 @@ function b() {
 
 			const output = getTextOutput(result);
 			expect(output).toContain("ignored.txt");
+			expect(result.details?.fileCount).toBe(1);
+			expect(result.details?.matchCount).toBe(1);
+		});
+
+		it("should ignore FIFOs when searching a directory with gitignore disabled", async () => {
+			const scenarioDir = path.join(testDir, "grep-fifo-dir");
+			fs.mkdirSync(scenarioDir, { recursive: true });
+			fs.writeFileSync(path.join(scenarioDir, "match.txt"), "needle kept\n");
+			const fifoPath = path.join(scenarioDir, "blocked.fifo");
+
+			if (!createFifoOrSkip(fifoPath)) {
+				return;
+			}
+
+			const result = await grepTool.execute("test-call-16-fifo-dir", {
+				pattern: "needle",
+				path: scenarioDir,
+				gitignore: false,
+			});
+
+			const output = getTextOutput(result);
+			expect(output).toContain("match.txt");
+			expect(output).toContain("needle kept");
+			expect(output).not.toContain("blocked.fifo");
+			expect(output).not.toContain("## └─ blocked.fifo");
 			expect(result.details?.fileCount).toBe(1);
 			expect(result.details?.matchCount).toBe(1);
 		});

--- a/packages/natives/test/native.test.ts
+++ b/packages/natives/test/native.test.ts
@@ -55,6 +55,23 @@ async function cleanupFixtures() {
 	await fs.rm(testDir, { recursive: true, force: true });
 }
 
+function canCreateFifo() {
+	return process.platform !== "win32" && Boolean(Bun.which("mkfifo"));
+}
+
+async function createFifo(fifoPath: string) {
+	const process = Bun.spawn(["mkfifo", fifoPath], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	const exitCode = await process.exited;
+	if (exitCode === 0) {
+		return;
+	}
+
+	throw new Error(await new Response(process.stderr).text());
+}
+
 describe("pi-natives", () => {
 	beforeAll(async () => {
 		await setupFixtures();
@@ -171,6 +188,77 @@ describe("pi-natives", () => {
 
 			expect(hiddenIncluded.totalMatches).toBe(1);
 			expect(hiddenIncluded.matches.some(match => match.path.endsWith(".hidden-ignored.ts"))).toBe(true);
+		});
+
+		it("should skip FIFOs when searching a directory", async () => {
+			if (!canCreateFifo()) {
+				return;
+			}
+
+			const scopedDir = path.join(testDir, "grep-fifo-directory-case");
+			const filePath = path.join(scopedDir, "match.txt");
+			const fifoPath = path.join(scopedDir, "ignored.fifo");
+			await fs.mkdir(scopedDir, { recursive: true });
+
+			try {
+				await fs.writeFile(filePath, "FIFO_TOKEN in regular file\n");
+				await createFifo(fifoPath);
+
+				const outcome = await Promise.race([
+					grep({
+						pattern: "FIFO_TOKEN",
+						path: scopedDir,
+						gitignore: false,
+					}).then(result => ({ kind: "done" as const, result })),
+					Bun.sleep(2000).then(() => ({ kind: "timeout" as const })),
+				]);
+
+				expect(outcome.kind).toBe("done");
+				if (outcome.kind !== "done") {
+					return;
+				}
+
+				expect(outcome.result.totalMatches).toBe(1);
+				expect(outcome.result.matches).toHaveLength(1);
+				expect(outcome.result.matches[0].path.endsWith("match.txt")).toBe(true);
+				expect(outcome.result.matches.some(match => match.path.endsWith("ignored.fifo"))).toBe(false);
+			} finally {
+				await fs.rm(scopedDir, { recursive: true, force: true });
+			}
+		});
+
+		it("should return no matches for a FIFO path", async () => {
+			if (!canCreateFifo()) {
+				return;
+			}
+
+			const scopedDir = path.join(testDir, "grep-fifo-direct-path-case");
+			const fifoPath = path.join(scopedDir, "direct.fifo");
+			await fs.mkdir(scopedDir, { recursive: true });
+
+			try {
+				await createFifo(fifoPath);
+
+				const outcome = await Promise.race([
+					grep({
+						pattern: "FIFO_TOKEN",
+						path: fifoPath,
+						gitignore: false,
+					}).then(result => ({ kind: "done" as const, result })),
+					Bun.sleep(2000).then(() => ({ kind: "timeout" as const })),
+				]);
+
+				expect(outcome.kind).toBe("done");
+				if (outcome.kind !== "done") {
+					return;
+				}
+
+				expect(outcome.result.totalMatches).toBe(0);
+				expect(outcome.result.filesWithMatches).toBe(0);
+				expect(outcome.result.matches).toHaveLength(0);
+			} finally {
+				await fs.rm(scopedDir, { recursive: true, force: true });
+			}
 		});
 	});
 	describe("fuzzyFind", () => {


### PR DESCRIPTION
   ## Summary                                                                                                          
                                                                                                                       
   Fix the built-in grep hang when the searched path contains a FIFO / named pipe.                                     
                                                                                                                       
   ### What changed                                                                                                    
                                                                                                                       
   - `fs_cache::classify_file_type()` now skips special filesystem nodes instead of classifying them as regular files. 
   - `grep::read_file_bytes()` now checks file type before opening anything.                                           
   - Grep now silently skips:                                                                                          
     - FIFOs                                                                                                           
     - sockets                                                                                                         
     - block / char devices                                                                                            
     - symlinks that resolve to non-regular targets                                                                    
   - A top-level grep path that is neither a regular file nor a directory now returns an empty result instead of       
 hanging.                                                                                                              
                                                                                                                       
   ### Tests                                                                                                           
                                                                                                                       
   - Added Rust regression tests for:                                                                                  
     - FIFO classification in fs-cache                                                                                 
     - directory grep with a FIFO present                                                                              
     - direct FIFO root-path grep                                                                                      
   - Added native package regression tests for:                                                                        
     - directory grep with a normal file plus FIFO                                                                     
     - direct FIFO path behavior                                                                                       
   - Added coding-agent GrepTool regression for a directory containing a normal file plus FIFO                         
                                                                                                                       
   ## Verification                                                                                                     
                                                                                                                       
   - `cargo test -p pi-natives grep::tests::grep_directory_skips_fifo_entries -- --exact`                              
   - `cargo test -p pi-natives grep::tests::grep_special_root_path_returns_empty_result -- --exact`                    
   - `cargo test -p pi-natives fs_cache::tests::classify_file_type_skips_fifo -- --exact`                              
   - `bun run build:native`                                                                                            
   - `bun test packages/natives/test/native.test.ts -t FIFO`                                                           
   - `bun test packages/coding-agent/test/tools.test.ts -t FIFO`                                                       
   - `bun check:ts`                                                                                                    
   - `bun check:rs`        