### PR TITLE
fix(coding-agent): do not prompt to use grep and find tools if they are disabled

### DIFF
--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -30,10 +30,10 @@ You **MUST** use specialized tools instead of bash for ALL file operations:
 |---|---|
 |`cat file`, `head -n N file`|`read(path="file", limit=N)`|
 |`cat -n file \|sed -n '50,150p'`|`read(path="file", offset=50, limit=100)`|
-|`grep -A 20 'pat' file`|`grep(pattern="pat", path="file", post=20)`|
+{{#if hasGrep}}|`grep -A 20 'pat' file`|`grep(pattern="pat", path="file", post=20)`|
 |`grep -rn 'pat' dir/`|`grep(pattern="pat", path="dir/")`|
-|`rg 'pattern' dir/`|`grep(pattern="pattern", path="dir/")`|
-|`find dir -name '*.ts'`|`find(pattern="dir/**/*.ts")`|
+|`rg 'pattern' dir/`|`grep(pattern="pattern", path="dir/")`|{{/if}}
+{{#if hasFind}}|`find dir -name '*.ts'`|`find(pattern="dir/**/*.ts")`|{{/if}}
 |`ls dir/`|`read(path="dir/")`|
 |`cat <<'EOF' > file`|`write(path="file", content="…")`|
 |`sed -i 's/old/new/' file`|`edit(path="file", edits=[…])`|

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -222,6 +222,8 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			asyncEnabled: this.#asyncEnabled,
 			hasAstGrep: this.session.settings.get("astGrep.enabled"),
 			hasAstEdit: this.session.settings.get("astEdit.enabled"),
+			hasGrep: this.session.settings.get("grep.enabled"),
+			hasFind: this.session.settings.get("find.enabled"),
 		});
 	}
 


### PR DESCRIPTION
## Summary

Currently the `bash.md` prompt the use of internal `grep` and `find` tools even if they are disabled in the settings.

Corrected to instruct to use them only if enabled in the settings (consistent with `hasAstGrep` and `hasAstEdit`).