### PR TITLE
feat(ai): bump zai provider default model from glm-4.6 to glm-5.1

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped zai provider default model from glm-4.6 to glm-5.1
+
 ## [13.16.5] - 2026-03-29
 
 ### Added

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -257,7 +257,7 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		config => zenmuxModelManagerOptions(config),
 		catalog("ZenMux", ["ZENMUX_API_KEY"]),
 	),
-	catalogDescriptor("zai", "glm-4.6", config => zaiModelManagerOptions(config), catalog("zAI", ["ZAI_API_KEY"])),
+	catalogDescriptor("zai", "glm-5.1", config => zaiModelManagerOptions(config), catalog("zAI", ["ZAI_API_KEY"])),
 	descriptor("github-copilot", "gpt-4o", config => githubCopilotModelManagerOptions(config)),
 	descriptor("google", "gemini-2.5-pro", config => googleModelManagerOptions(config)),
 	catalogDescriptor(


### PR DESCRIPTION
## What

Bump the zai provider default model from `glm-4.6` to `glm-5.1`.

## Why

The default was set to `glm-4.6` on 2026-02-18 during a descriptor refactor, carried forward from older config. GLM-4.7 had already been GA for two months at that point.

| Model | GA Date | Notes |
|---|---|---|
| glm-4.6 | ~2025 Q3 | Current default (stale) |
| glm-4.7 | 2025-12-22 | Superseded |
| glm-5 | 2026-02-11 | Superseded |
| glm-5.1 | 2026-03-27 | Latest, [GA for all Coding Plan tiers](https://docs.z.ai/devpack/using5.1) |

GLM-5.1 scores 45.3 on coding benchmarks (94.6% of Claude Opus 4.6), a 28% improvement over GLM-5. Same endpoint, auth, and API type as all other zai models. Already in the catalog with full specs.

The default model controls fallback selection when a user has zai auth but no explicit model configured. Login validation is unaffected (hardcoded to `glm-4.7`).

## Testing

- `bun check` passes (biome + tsgo clean)
- No test asserts the zai default value
- Default is only used as a resolution fallback, not in login or validation

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)