### PR TITLE
feat: session renaming

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `/session rename <name>` command to rename the current session
+
+
 ## [14.0.4] - 2026-04-10
 ### Added
 

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -431,6 +431,7 @@ export class CommandController {
 			}
 
 			await this.ctx.sessionManager.setSessionName(newName);
+			setSessionTerminalTitle(newName, this.ctx.sessionManager.getCwd());
 			this.ctx.showStatus(`Session renamed to: ${newName}`);
 			this.ctx.statusLine.invalidate();
 			this.ctx.updateEditorTopBorder();

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -423,6 +423,24 @@ export class CommandController {
 		this.ctx.ui.requestRender();
 	}
 
+	async handleSessionRenameCommand(newName?: string): Promise<void> {
+		try {
+			if (!newName) {
+				this.ctx.showError("Please provide a session name: /session rename <name>");
+				return;
+			}
+
+			await this.ctx.sessionManager.setSessionName(newName);
+			this.ctx.showStatus(`Session renamed to: ${newName}`);
+			this.ctx.statusLine.invalidate();
+			this.ctx.updateEditorTopBorder();
+			this.ctx.ui.requestRender();
+		} catch (error) {
+			const msg = error instanceof Error ? error.message : String(error);
+			this.ctx.showWarning(`Error renaming session: ${msg}`);
+		}
+	}
+
 	async handleJobsCommand(): Promise<void> {
 		const snapshot = this.ctx.session.getAsyncJobSnapshot({ recentLimit: 5 });
 		if (!snapshot) {

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1270,6 +1270,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#commandController.handleJobsCommand();
 	}
 
+	async handleSessionRenameCommand(newName?: string): Promise<void> {
+		return this.#commandController.handleSessionRenameCommand(newName);
+	}
+
 	handleUsageCommand(reports?: UsageReport[] | null): Promise<void> {
 		return this.#commandController.handleUsageCommand(reports);
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -171,6 +171,7 @@ export interface InteractiveModeContext {
 	handleShareCommand(): Promise<void>;
 	handleCopyCommand(sub?: string): void;
 	handleSessionCommand(): Promise<void>;
+	handleSessionRenameCommand(newName?: string): Promise<void>;
 	handleJobsCommand(): Promise<void>;
 	handleUsageCommand(reports?: UsageReport[] | null): Promise<void>;
 	handleChangelogCommand(showFull?: boolean): Promise<void>;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -264,17 +264,27 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 		subcommands: [
 			{ name: "info", description: "Show session info and stats" },
 			{ name: "delete", description: "Delete current session and return to selector" },
+			{ name: "rename", description: "Rename the session", usage: "[new-name]" },
 		],
 		allowArgs: true,
 		handle: async (command, runtime) => {
-			const sub = command.args.trim().toLowerCase() || "info";
-			if (sub === "delete") {
+			const args = command.args.trim();
+			const parts = args.split(/\s+/).filter(Boolean);
+			const subcommand = parts[0];
+			const rest = parts.slice(1);
+
+			if (subcommand === "delete") {
 				runtime.ctx.editor.setText("");
 				await runtime.ctx.handleSessionDeleteCommand();
 				return;
 			}
-			// Default: show session info
-			await runtime.ctx.handleSessionCommand();
+			if (subcommand === "rename") {
+				const newName = rest.join(" ") || undefined;
+				await runtime.ctx.handleSessionRenameCommand(newName);
+			} else {
+				// Default: show session info
+				await runtime.ctx.handleSessionCommand();
+			}
 			runtime.ctx.editor.setText("");
 		},
 	},

--- a/packages/coding-agent/test/slash-commands/session.test.ts
+++ b/packages/coding-agent/test/slash-commands/session.test.ts
@@ -5,6 +5,7 @@ import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-comm
 function createRuntimeHarness(options?: {
 	handleSessionCommand?: InteractiveModeContext["handleSessionCommand"];
 	handleSessionDeleteCommand?: InteractiveModeContext["handleSessionDeleteCommand"];
+	handleSessionRenameCommand?: InteractiveModeContext["handleSessionRenameCommand"];
 }) {
 	const setText = vi.fn();
 	const handleSessionCommand =
@@ -17,16 +18,23 @@ function createRuntimeHarness(options?: {
 		vi.fn(async () => {
 			return;
 		});
+	const handleSessionRenameCommand =
+		options?.handleSessionRenameCommand ??
+		vi.fn(async () => {
+			return;
+		});
 
 	return {
 		setText,
 		handleSessionCommand,
 		handleSessionDeleteCommand,
+		handleSessionRenameCommand,
 		runtime: {
 			ctx: {
 				editor: { setText } as unknown as InteractiveModeContext["editor"],
 				handleSessionCommand,
 				handleSessionDeleteCommand,
+				handleSessionRenameCommand,
 			} as InteractiveModeContext,
 			handleBackgroundCommand: () => {},
 		},
@@ -104,6 +112,17 @@ describe("/session slash command", () => {
 
 		await expect(executeBuiltinSlashCommand("/session delete", harness.runtime)).rejects.toBe(deleteError);
 		expect(handleSessionDeleteCommand).toHaveBeenCalledTimes(1);
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+	it("calls handleSessionRenameCommand with the provided name", async () => {
+		const handleSessionRenameCommand = vi.fn(async () => {
+			return;
+		});
+		const harness = createRuntimeHarness({ handleSessionRenameCommand });
+
+		await executeBuiltinSlashCommand("/session rename New Session", harness.runtime);
+
+		expect(handleSessionRenameCommand).toHaveBeenCalledWith("New Session");
 		expect(harness.setText).toHaveBeenCalledWith("");
 	});
 });


### PR DESCRIPTION
## What

add /session rename <name> to manually rename session
## Why

because i'd like to rename sessions.

I suppose this could have been an *extension*, but this seems like a fairly important core QoL feature

## Testing

I've been using this for a few weeks now

---

- [x ] `bun check` passes
- [x ] Tested locally
- [x ] CHANGELOG updated (if user-facing)
