### PR TITLE
feat(coding-agent): priority to commit model for titles (with fallback to smol)

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Create images directly from the agent:
 
 Modern terminal interface with smart session management:
 
-- **Auto session titles**: Sessions automatically titled based on first message using smol model
+- **Auto session titles**: Sessions automatically titled based on first message using commit model, fallback to smol
 - **Welcome screen**: Logo, tips, recent sessions with selection
 - **Powerline footer**: Model, cwd, git branch/status, token usage, context %
 - **LSP status**: Shows which language servers are active and ready

--- a/packages/coding-agent/src/commit/model-selection.ts
+++ b/packages/coding-agent/src/commit/model-selection.ts
@@ -1,7 +1,7 @@
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Api, Model } from "@oh-my-pi/pi-ai";
 import { MODEL_ROLE_IDS } from "../config/model-registry";
-import { parseModelPattern, resolveModelRoleValue } from "../config/model-resolver";
+import { parseModelPattern, resolveModelRoleValue, resolveRoleSelection } from "../config/model-resolver";
 import type { Settings } from "../config/settings";
 import MODEL_PRIO from "../priority.json" with { type: "json" };
 
@@ -9,24 +9,6 @@ export interface ResolvedCommitModel {
 	model: Model<Api>;
 	apiKey: string;
 	thinkingLevel?: ThinkingLevel;
-}
-
-function resolveRoleSelection(
-	roles: readonly string[],
-	settings: Settings,
-	availableModels: Model<Api>[],
-): { model: Model<Api>; thinkingLevel?: ThinkingLevel } | undefined {
-	const matchPreferences = { usageOrder: settings.getStorage()?.getModelUsageOrder() };
-	for (const role of roles) {
-		const resolved = resolveModelRoleValue(settings.getModelRole(role), availableModels, {
-			settings,
-			matchPreferences,
-		});
-		if (resolved.model) {
-			return { model: resolved.model, thinkingLevel: resolved.thinkingLevel };
-		}
-	}
-	return undefined;
 }
 
 export async function resolvePrimaryModel(

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -588,6 +588,27 @@ export function resolveModelOverride(
 }
 
 /**
+ * Resolve a list of role patterns to the first matching model.
+ */
+export function resolveRoleSelection(
+	roles: readonly string[],
+	settings: Settings,
+	availableModels: Model<Api>[],
+): { model: Model<Api>; thinkingLevel?: ThinkingLevel } | undefined {
+	const matchPreferences = { usageOrder: settings.getStorage()?.getModelUsageOrder() };
+	for (const role of roles) {
+		const resolved = resolveModelRoleValue(settings.getModelRole(role), availableModels, {
+			settings,
+			matchPreferences,
+		});
+		if (resolved.model) {
+			return { model: resolved.model, thinkingLevel: resolved.thinkingLevel };
+		}
+	}
+	return undefined;
+}
+
+/**
  * Resolve model patterns to actual Model objects with optional thinking levels
  * Format: "pattern:level" where :level is optional
  * For each pattern, finds all matching models and picks the best version:

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -7,7 +7,7 @@ import type { Api, Model } from "@oh-my-pi/pi-ai";
 import { completeSimple } from "@oh-my-pi/pi-ai";
 import { logger } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../config/model-registry";
-import { resolveModelRoleValue } from "../config/model-resolver";
+import { resolveRoleSelection } from "../config/model-resolver";
 import { renderPromptTemplate } from "../config/prompt-templates";
 import type { Settings } from "../config/settings";
 import titleSystemPrompt from "../prompts/system/title-system.md" with { type: "text" };
@@ -29,12 +29,9 @@ function getTitleModel(
 	if (availableModels.length === 0) return undefined;
 
 	const matchPreferences = { usageOrder: settings.getStorage()?.getModelUsageOrder() };
-	const configuredSmol = resolveModelRoleValue(settings.getModelRole("smol"), availableModels, {
-		settings,
-		matchPreferences,
-	});
-	if (configuredSmol.model) {
-		return { model: configuredSmol.model, thinkingLevel: configuredSmol.thinkingLevel };
+	const titleModel = resolveRoleSelection(["commit", "smol"], settings, availableModels);
+	if (titleModel) {
+		return { model: titleModel.model, thinkingLevel: titleModel.thinkingLevel };
 	}
 
 	if (currentModel) {


### PR DESCRIPTION
## Summary

We can use an even less expensive model for titles than `smol`: the `commit` model. Fallback to `smol` if not configured. No other change.