### PR TITLE
fix: allow dots in marketplace plugin names

### DIFF
--- a/packages/coding-agent/src/extensibility/plugins/marketplace/cache.ts
+++ b/packages/coding-agent/src/extensibility/plugins/marketplace/cache.ts
@@ -4,7 +4,7 @@
  * Cache layout: `<cacheDir>/<marketplace>___<pluginName>___<version>/`
  *
  * All three components are validated before any filesystem operation:
- *   - marketplace / pluginName: isValidNameSegment (lowercase alnum + hyphens, max 64)
+ *   - marketplace / pluginName: isValidNameSegment (lowercase alnum + hyphens + dots, max 64)
  *   - version: isValidVersionForCache (alnum + ._+-, max 128)
  *
  * This ensures cache paths cannot be crafted to escape the cache directory.


### PR DESCRIPTION
## Problem

`NAME_RE` in `types.ts` only allowed `[a-z0-9-]` in the middle segment, rejecting any plugin name containing a dot. The official Claude plugin marketplace catalog includes `wordpress.com` at index 116, which causes `parseMarketplaceCatalog` to throw:

```
Error: Missing or invalid field "plugins[116].name" in catalog: .../marketplace.json
```

This error surfaces as an unhandled rejection that crashes the `/marketplace` command entirely.

## Fix

Extend `NAME_RE` from `[a-z0-9-]` to `[a-z0-9.-]` in the middle character class.

Dots in plugin names are safe in the cache path layout (`\<marketplace\>___\<pluginName\>___\<version\>`) — the triple-underscore separator ensures plugin names are never standalone path components, so a dot-containing name cannot trigger directory traversal.

## Changes

- `types.ts`: extend `NAME_RE` to allow dots in plugin/marketplace name segments
- `cache.ts`: update comment to reflect the updated character set