### PR TITLE
fix(coding-agent): inject received notifications into agent context immediately

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2924,6 +2924,13 @@ export class AgentSession {
 			attribution: "user",
 			timestamp: Date.now(),
 		});
+		// When idle, schedule an immediate continue so the queued follow-up is
+		// delivered without waiting for the next user turn.
+		if (!this.isStreaming) {
+			this.#scheduleAgentContinue({
+				shouldContinue: () => !this.agent.state.isStreaming && this.agent.hasQueuedMessages(),
+			});
+		}
 	}
 
 	queueDeferredMessage(message: CustomMessage): void {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -2924,13 +2924,30 @@ export class AgentSession {
 			attribution: "user",
 			timestamp: Date.now(),
 		});
-		// When idle, schedule an immediate continue so the queued follow-up is
-		// delivered without waiting for the next user turn.
-		if (!this.isStreaming) {
+		// When fully idle AND the session is in a resumable assistant-ended state,
+		// schedule an immediate continue so the queued follow-up is delivered
+		// without waiting for the next user turn. We gate on isStreaming (model
+		// actively producing), isRetrying (auto-retry backoff is sleeping between
+		// attempts, #retryPromise set), and the last message being assistant —
+		// agent.continue() only dequeues follow-ups from an assistant-ended state;
+		// resuming from user/toolResult state runs an extra model call on the
+		// stale prompt before draining the queue.
+		if (this.#canAutoContinueForFollowUp()) {
 			this.#scheduleAgentContinue({
-				shouldContinue: () => !this.agent.state.isStreaming && this.agent.hasQueuedMessages(),
+				shouldContinue: () => this.#canAutoContinueForFollowUp() && this.agent.hasQueuedMessages(),
 			});
 		}
+	}
+
+	/**
+	 * Gate for idle-path follow-up auto-continue. See `#queueFollowUp` for rationale.
+	 */
+	#canAutoContinueForFollowUp(): boolean {
+		if (this.isStreaming) return false;
+		if (this.isRetrying) return false;
+		const messages = this.agent.state.messages;
+		const last = messages[messages.length - 1];
+		return last?.role === "assistant";
 	}
 
 	queueDeferredMessage(message: CustomMessage): void {


### PR DESCRIPTION
## Problem

`session.followUp()` — used by the MCP resource-change notification handler — enqueues a message via `agent.followUp()` but never schedules the agent to consume it when idle. The message sits in the follow-up queue until the next user turn provides a prompt.

## Root cause

`#queueFollowUp` was missing the pairing that TTSR deferred injection already does correctly (lines 1177–1205 in `agent-session.ts`): after `agent.followUp()`, call `#scheduleAgentContinue()`.

## Fix

In `#queueFollowUp`, after enqueuing, schedule a continue when the agent is not streaming:

```typescript
if (!this.isStreaming) {
    this.#scheduleAgentContinue({
        shouldContinue: () => !this.agent.state.isStreaming && this.agent.hasQueuedMessages(),
    });
}
```

The `shouldContinue` guard prevents spurious continues if multiple follow-ups arrive in a burst and the queue drains before a scheduled task runs.

## Scope

Only the idle path is affected. When `isStreaming` is true, `#queueFollowUp` is called from inside `if (this.isStreaming)` branches where the running loop's `getFollowUpMessages` callback drains the queue at end of turn naturally.