### PR TITLE
fix: resolve xdg path for marketplace

### DIFF
--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { FileType, glob } from "@oh-my-pi/pi-natives";
 import { CONFIG_DIR_NAME, getConfigDirName, getProjectDir, parseFrontmatter, tryParseJson } from "@oh-my-pi/pi-utils";
-import { readDirEntries, readFile } from "../capability/fs";
+import { invalidate as invalidateFsCache, readDirEntries, readFile } from "../capability/fs";
 import { parseRuleConditionAndScope, type Rule, type RuleFrontmatter } from "../capability/rule";
 import type { Skill, SkillFrontmatter } from "../capability/skill";
 import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
@@ -710,6 +710,42 @@ export async function resolveOrDefaultProjectRegistryPath(cwd: string): Promise<
 	return path.join(cwd, getConfigDirName(), "plugins", "installed_plugins.json");
 }
 
+export function getActiveUserOmpPluginsRegistryPath(home: string): string {
+	const xdgDataHome = process.env.XDG_DATA_HOME;
+	// Use os.homedir() for the home-match guard rather than process.env.HOME:
+	// HOME may be unset in non-login/service contexts, which would cause XDG
+	// selection to silently fall back even when the XDG registry is the active one.
+	if (
+		xdgDataHome &&
+		(process.platform === "linux" || process.platform === "darwin") &&
+		path.resolve(os.homedir()) === path.resolve(home)
+	) {
+		const xdgRegistryPath = path.join(xdgDataHome, "omp", "plugins", "installed_plugins.json");
+		if (fs.existsSync(xdgRegistryPath)) {
+			return xdgRegistryPath;
+		}
+	}
+	return path.join(home, getConfigDirName(), "plugins", "installed_plugins.json");
+}
+
+export function clearClaudePluginDiscoveryCaches(home: string, extraPaths?: readonly string[]): void {
+	invalidateFsCache(path.join(home, ".claude", "plugins", "installed_plugins.json"));
+	// Invalidate both OMP candidate paths unconditionally.
+	// getActiveUserOmpPluginsRegistryPath routes to whichever file currently exists on disk,
+	// but cache invalidation must clear all possible keys regardless of current on-disk state.
+	// (e.g. after uninstall the XDG file is gone, so the router returns the fallback path,
+	// but the XDG path still has a stale cache entry that must be evicted.)
+	invalidateFsCache(path.join(home, getConfigDirName(), "plugins", "installed_plugins.json"));
+	const xdgDataHome = process.env.XDG_DATA_HOME;
+	if (xdgDataHome) {
+		invalidateFsCache(path.join(xdgDataHome, "omp", "plugins", "installed_plugins.json"));
+	}
+	for (const filePath of extraPaths ?? []) {
+		invalidateFsCache(filePath);
+	}
+	clearClaudePluginRootsCache();
+}
+
 const pluginRootsCache = new Map<string, { roots: ClaudePluginRoot[]; warnings: string[] }>();
 
 /**
@@ -779,7 +815,7 @@ export async function listClaudePluginRoots(
 	// ── OMP installed plugins registry ───────────────────────────────────────
 	// OMP registry is authoritative: its entries replace Claude's entries for the same plugin ID.
 	// Path derived from `home` (not os.homedir()) so test isolation works when home is overridden.
-	const ompRegistryPath = path.join(home, getConfigDirName(), "plugins", "installed_plugins.json");
+	const ompRegistryPath = getActiveUserOmpPluginsRegistryPath(home);
 	const ompContent = await readFile(ompRegistryPath);
 	if (ompContent) {
 		const ompRegistry = parseClaudePluginsRegistry(ompContent);

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -11,9 +11,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { createInterface } from "node:readline/promises";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
-import { $env, getConfigDirName, getProjectDir, logger, postmortem, setProjectDir, VERSION } from "@oh-my-pi/pi-utils";
+import { $env, getProjectDir, logger, postmortem, setProjectDir, VERSION } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
-import { invalidate as invalidateFsCache } from "./capability/fs";
 import type { Args } from "./cli/args";
 import { processFileArguments } from "./cli/file-processor";
 import { buildInitialMessage } from "./cli/initial-message";
@@ -25,7 +24,7 @@ import { resolveCliModel, resolveModelRoleValue, resolveModelScope, type ScopedM
 import { getDefault, type SettingPath, Settings, settings } from "./config/settings";
 import { initializeWithSettings } from "./discovery";
 import {
-	clearClaudePluginRootsCache,
+	clearClaudePluginDiscoveryCaches,
 	injectPluginDirRoots,
 	preloadPluginRoots,
 	resolveActiveProjectRegistryPath,
@@ -720,11 +719,7 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 					marketplacesCacheDir: getMarketplacesCacheDir(),
 					pluginsCacheDir: getPluginsCacheDir(),
 					clearPluginRootsCache: (extraPaths?: readonly string[]) => {
-						const h = os.homedir();
-						invalidateFsCache(path.join(h, ".claude", "plugins", "installed_plugins.json"));
-						invalidateFsCache(path.join(h, getConfigDirName(), "plugins", "installed_plugins.json"));
-						for (const p of extraPaths ?? []) invalidateFsCache(p);
-						clearClaudePluginRootsCache();
+						clearClaudePluginDiscoveryCaches(os.homedir(), extraPaths);
 					},
 				});
 				await mgr.refreshStaleMarketplaces();

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1,16 +1,14 @@
 import * as os from "node:os";
-import * as path from "node:path";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { getOAuthProviders, type OAuthProvider } from "@oh-my-pi/pi-ai";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { Input, Loader, Spacer, Text } from "@oh-my-pi/pi-tui";
-import { getAgentDbPath, getConfigDirName, getProjectDir } from "@oh-my-pi/pi-utils";
-import { invalidate as invalidateFsCache } from "../../capability/fs";
+import { getAgentDbPath, getProjectDir } from "@oh-my-pi/pi-utils";
 import { getRoleInfo } from "../../config/model-registry";
 import { settings } from "../../config/settings";
 import { DebugSelectorComponent } from "../../debug";
 import { disableProvider, enableProvider } from "../../discovery";
-import { clearClaudePluginRootsCache, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
+import { clearClaudePluginDiscoveryCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import {
 	getInstalledPluginsRegistryPath,
 	getMarketplacesCacheDir,
@@ -436,11 +434,7 @@ export class SelectorController {
 			marketplacesCacheDir: getMarketplacesCacheDir(),
 			pluginsCacheDir: getPluginsCacheDir(),
 			clearPluginRootsCache: (extraPaths?: readonly string[]) => {
-				const home = os.homedir();
-				invalidateFsCache(path.join(home, ".claude", "plugins", "installed_plugins.json"));
-				invalidateFsCache(path.join(home, getConfigDirName(), "plugins", "installed_plugins.json"));
-				for (const p of extraPaths ?? []) invalidateFsCache(p);
-				clearClaudePluginRootsCache();
+				clearClaudePluginDiscoveryCaches(os.homedir(), extraPaths);
 			},
 		});
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1,13 +1,10 @@
 import * as os from "node:os";
-import * as path from "node:path";
 
 import { getOAuthProviders } from "@oh-my-pi/pi-ai";
-import { getConfigDirName } from "@oh-my-pi/pi-utils";
-import { invalidate as invalidateFsCache } from "../capability/fs";
 import type { SettingPath, SettingValue } from "../config/settings";
 import { settings } from "../config/settings";
 import {
-	clearClaudePluginRootsCache,
+	clearClaudePluginDiscoveryCaches,
 	resolveActiveProjectRegistryPath,
 	resolveOrDefaultProjectRegistryPath,
 } from "../discovery/helpers.js";
@@ -627,11 +624,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 				marketplacesCacheDir: getMarketplacesCacheDir(),
 				pluginsCacheDir: getPluginsCacheDir(),
 				clearPluginRootsCache: (extraPaths?: readonly string[]) => {
-					const home = os.homedir();
-					invalidateFsCache(path.join(home, ".claude", "plugins", "installed_plugins.json"));
-					invalidateFsCache(path.join(home, getConfigDirName(), "plugins", "installed_plugins.json"));
-					for (const p of extraPaths ?? []) invalidateFsCache(p);
-					clearClaudePluginRootsCache();
+					clearClaudePluginDiscoveryCaches(os.homedir(), extraPaths);
 				},
 			});
 
@@ -821,11 +814,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 					marketplacesCacheDir: getMarketplacesCacheDir(),
 					pluginsCacheDir: getPluginsCacheDir(),
 					clearPluginRootsCache: (extraPaths?: readonly string[]) => {
-						const home = os.homedir();
-						invalidateFsCache(path.join(home, ".claude", "plugins", "installed_plugins.json"));
-						invalidateFsCache(path.join(home, getConfigDirName(), "plugins", "installed_plugins.json"));
-						for (const p of extraPaths ?? []) invalidateFsCache(p);
-						clearClaudePluginRootsCache();
+						clearClaudePluginDiscoveryCaches(os.homedir(), extraPaths);
 					},
 				});
 
@@ -890,11 +879,8 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 			// Invalidate the fs content cache for all registry files so
 			// listClaudePluginRoots re-reads from disk on next access.
 			const home = os.homedir();
-			invalidateFsCache(path.join(home, ".claude", "plugins", "installed_plugins.json"));
-			invalidateFsCache(path.join(home, getConfigDirName(), "plugins", "installed_plugins.json"));
 			const projectPath = await resolveActiveProjectRegistryPath(runtime.ctx.sessionManager.getCwd());
-			if (projectPath) invalidateFsCache(projectPath);
-			clearClaudePluginRootsCache();
+			clearClaudePluginDiscoveryCaches(home, projectPath ? [projectPath] : undefined);
 			await runtime.ctx.refreshSlashCommandState();
 			runtime.ctx.showStatus("Plugins reloaded.");
 			runtime.ctx.editor.setText("");

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -1,10 +1,12 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { clearCache as clearFsCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
 import {
+	clearClaudePluginDiscoveryCaches,
 	clearClaudePluginRootsCache,
+	getActiveUserOmpPluginsRegistryPath,
 	listClaudePluginRoots,
 	parseClaudePluginsRegistry,
 } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
@@ -55,15 +57,34 @@ describe("parseClaudePluginsRegistry", () => {
 
 describe("listClaudePluginRoots", () => {
 	let tempDir: string;
+	// Declared at describe scope so afterEach restores it even when a test assertion throws.
+	let homedirSpy: ReturnType<typeof spyOn> | undefined;
+	let originalXdgDataHome: string | undefined;
+	let originalHome: string | undefined;
 
 	beforeEach(async () => {
 		clearClaudePluginRootsCache();
 		clearFsCache();
+		homedirSpy = undefined;
+		originalXdgDataHome = process.env.XDG_DATA_HOME;
+		originalHome = process.env.HOME;
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "claude-plugins-test-"));
 	});
 
 	afterEach(async () => {
 		clearClaudePluginRootsCache();
+		clearFsCache();
+		homedirSpy?.mockRestore();
+		if (originalXdgDataHome === undefined) {
+			delete process.env.XDG_DATA_HOME;
+		} else {
+			process.env.XDG_DATA_HOME = originalXdgDataHome;
+		}
+		if (originalHome === undefined) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
 		await fs.rm(tempDir, { recursive: true, force: true });
 	});
 
@@ -299,6 +320,96 @@ describe("listClaudePluginRoots", () => {
 		const result = await listClaudePluginRoots(tempDir);
 		expect(result.roots).toHaveLength(1);
 		expect(result.roots[0].scope).toBe("user");
+	});
+
+	test("XDG registry is used when XDG_DATA_HOME is set and registry file exists", async () => {
+		// Spy on os.homedir() so the home-match guard fires against tempDir
+		// without reading or writing the real user home directory.
+		homedirSpy = spyOn(os, "homedir").mockReturnValue(tempDir);
+		process.env.XDG_DATA_HOME = path.join(tempDir, "xdg-data");
+		const xdgRegistryPath = path.join(tempDir, "xdg-data", "omp", "plugins", "installed_plugins.json");
+		await fs.mkdir(path.dirname(xdgRegistryPath), { recursive: true });
+		await fs.writeFile(
+			xdgRegistryPath,
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"xdg-plugin@market": [
+						{
+							scope: "user",
+							installPath: "/xdg/plugin",
+							version: "1.0.0",
+							installedAt: "2025-01-01T00:00:00Z",
+							lastUpdated: "2025-01-01T00:00:00Z",
+						},
+					],
+				},
+			}),
+		);
+
+		const result = await listClaudePluginRoots(tempDir);
+		expect(result.roots).toHaveLength(1);
+		expect(result.roots[0]?.id).toBe("xdg-plugin@market");
+		expect(result.roots[0]?.path).toBe("/xdg/plugin");
+	});
+
+	test("clearClaudePluginDiscoveryCaches evicts XDG path even after registry file is deleted", async () => {
+		// This is the core regression case: after the XDG file is removed (uninstall),
+		// getActiveUserOmpPluginsRegistryPath returns the fallback path. A naive
+		// implementation that routes invalidation through that helper would skip the
+		// XDG cache entry, leaving stale plugins visible until process restart.
+		homedirSpy = spyOn(os, "homedir").mockReturnValue(tempDir);
+		process.env.XDG_DATA_HOME = path.join(tempDir, "xdg-data");
+		const xdgRegistryPath = path.join(tempDir, "xdg-data", "omp", "plugins", "installed_plugins.json");
+		await fs.mkdir(path.dirname(xdgRegistryPath), { recursive: true });
+		await fs.writeFile(
+			xdgRegistryPath,
+			JSON.stringify({
+				version: 2,
+				plugins: {
+					"xdg-plugin@market": [
+						{
+							scope: "user",
+							installPath: "/xdg/plugin",
+							version: "1.0.0",
+							installedAt: "2025-01-01T00:00:00Z",
+							lastUpdated: "2025-01-01T00:00:00Z",
+						},
+					],
+				},
+			}),
+		);
+
+		// Prime both cache layers.
+		const before = await listClaudePluginRoots(tempDir);
+		expect(before.roots.map(r => r.id)).toEqual(["xdg-plugin@market"]);
+
+		// Simulate uninstall: delete the registry file.
+		await fs.rm(xdgRegistryPath);
+
+		// Without clearing caches, stale data is still returned.
+		const stale = await listClaudePluginRoots(tempDir);
+		expect(stale.roots).toHaveLength(1);
+
+		// After clearing caches the XDG path must be evicted unconditionally.
+		clearClaudePluginDiscoveryCaches(tempDir);
+		const after = await listClaudePluginRoots(tempDir);
+		expect(after.roots).toHaveLength(0);
+	});
+
+	test("getActiveUserOmpPluginsRegistryPath uses os.homedir() not process.env.HOME", async () => {
+		// Contract: XDG selection must work even when HOME is absent (non-login shells,
+		// some CI environments, containerised processes). The fix uses os.homedir() for
+		// the home-match guard instead of process.env.HOME.
+		delete process.env.HOME;
+		homedirSpy = spyOn(os, "homedir").mockReturnValue(tempDir);
+		const xdgRegistryPath = path.join(tempDir, "xdg-data", "omp", "plugins", "installed_plugins.json");
+		process.env.XDG_DATA_HOME = path.join(tempDir, "xdg-data");
+		await fs.mkdir(path.dirname(xdgRegistryPath), { recursive: true });
+		await Bun.write(xdgRegistryPath, "{}");
+
+		// Must return XDG path, not the fallback ~/.omp/... path.
+		expect(getActiveUserOmpPluginsRegistryPath(tempDir)).toBe(xdgRegistryPath);
 	});
 });
 


### PR DESCRIPTION
## What
listClaudePluginRoots() was always reading the OMP user plugin registry from the legacy home-relative path (~/.omp/plugins/installed_plugins.json or `~/.config/omp/...` depending on getConfigDirName()). On XDG-enabled systems the marketplace writes the registry to `$XDG_DATA_HOME/omp/plugins/installed_plugins.json` , so the paths never matched and marketplace-installed skills were silently ignored at discovery time.

 Adds `getActiveUserOmpPluginsRegistryPath(home):` when `XDG_DATA_HOME` is set, `$HOME` resolves to the same path as home, and the XDG registry file actually exists on disk, the XDG path is used. Otherwise falls back to the legacy path. The existing "XDG dirs must exist to activate" semantics in DirResolver are intentionally preserved.

## Why
 Marketplace-installed skills were not loaded after installation on any system with `XDG_DATA_HOME` set. The install wrote to the XDG path; discovery always read from the legacy path.

## Testing

<!-- How was this tested? -->
Covered by the existing test suite in `packages/coding-agent/test/discovery/claude-plugins.test.ts`, which includes a regression case for the XDG path selection. Verified locally that skills installed via the marketplace are discovered correctly with `XDG_DATA_HOME=/home/parsifa1/.local/share`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
