### PR TITLE
fix(ai): resolve Copilot context window from max_prompt_tokens, not max_context_window_tokens

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -147,8 +147,10 @@ function applyGlobalModelsDevFallback(models: readonly Model[], modelsDevModels:
 			name: reference.name,
 			reasoning: reference.reasoning,
 			input: reference.input,
-			contextWindow: reference.contextWindow,
-			maxTokens: reference.maxTokens,
+			// contextWindow and maxTokens intentionally NOT overwritten.
+			// Limits are provider-specific (e.g. Copilot imposes its own limits
+			// that are lower than native provider limits). Cross-provider models.dev
+			// references would inflate them.
 		};
 	});
 }

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -289,13 +289,6 @@ function applyAnthropicCatalogPolicy(model: ApiModel<Api>, parsedModel: Anthropi
 		model.cost.cacheWrite = 6.25;
 	}
 
-	// GitHub Copilot Opus 4.6: discovery currently reports a stale 144K prompt window,
-	// but the model supports a 1M context window. Keep the bundled catalog truthful
-	// until Copilot fixes the upstream metadata.
-	if (model.provider === "github-copilot" && parsedModel.kind === "opus" && semverEqual(parsedModel.version, "4.6")) {
-		model.contextWindow = 1000000;
-	}
-
 	// Bedrock Opus 4.6: upstream metadata is stale for cache pricing and context.
 	if (model.provider === "amazon-bedrock" && parsedModel.kind === "opus" && semverEqual(parsedModel.version, "4.6")) {
 		model.cost.cacheRead = 0.5;

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -5116,7 +5116,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 264000,
+			"contextWindow": 272000,
 			"maxTokens": 64000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -5200,7 +5200,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 400000,
+			"contextWindow": 272000,
 			"maxTokens": 128000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -4594,8 +4594,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 144000,
-			"maxTokens": 32000,
+			"contextWindow": 136000,
+			"maxTokens": 64000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
 			},
@@ -4623,7 +4623,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 160000,
+			"contextWindow": 168000,
 			"maxTokens": 32000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -4651,8 +4651,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
+			"contextWindow": 168000,
+			"maxTokens": 32000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
 			},
@@ -4680,7 +4680,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 216000,
+			"contextWindow": 128000,
 			"maxTokens": 16000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -4708,7 +4708,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 144000,
+			"contextWindow": 168000,
 			"maxTokens": 32000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -4736,7 +4736,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
+			"contextWindow": 168000,
 			"maxTokens": 32000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -4858,7 +4858,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 136000,
 			"maxTokens": 64000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -4919,7 +4919,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 64000,
 			"maxTokens": 4096,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -4976,7 +4976,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 264000,
+			"contextWindow": 128000,
 			"maxTokens": 64000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -5004,7 +5004,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 264000,
+			"contextWindow": 128000,
 			"maxTokens": 64000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -5117,7 +5117,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
-			"maxTokens": 64000,
+			"maxTokens": 128000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
 			},
@@ -5228,7 +5228,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 400000,
+			"contextWindow": 272000,
 			"maxTokens": 128000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -5256,7 +5256,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
+			"contextWindow": 192000,
 			"maxTokens": 64000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -173,31 +173,36 @@ function createBundledReferenceMap<TApi extends Api>(
 	return references;
 }
 
-function shouldReplaceGlobalReference(existing: Model<Api> | undefined, candidate: Model<Api>): boolean {
-	if (!existing) return true;
-	if (candidate.contextWindow !== existing.contextWindow) {
-		return candidate.contextWindow > existing.contextWindow;
-	}
-	if (candidate.maxTokens !== existing.maxTokens) {
-		return candidate.maxTokens > existing.maxTokens;
-	}
-	// When limits tie, prefer OpenAI as the canonical reference so generic OpenAI-family
-	// providers inherit OpenAI pricing/capabilities instead of Copilot-specific metadata.
-	return existing.provider !== "openai" && candidate.provider === "openai";
-}
-
-function createGlobalReferenceMap(): Map<string, Model<Api>> {
-	const references = new Map<string, Model<Api>>();
+/**
+ * Returns a lookup that resolves a model ID to a bundled reference, preferring
+ * the provider-specific entry over a cross-provider fallback. The global fallback
+ * picks the best entry across all providers (largest contextWindow, then maxTokens,
+ * then canonical OpenAI), but proxy providers (Copilot, nanogpt, etc.) impose their
+ * own limits that are typically lower than native provider limits, so the
+ * provider-specific entry must win.
+ */
+function createReferenceResolver<TApi extends Api>(
+	providerRefs: Map<string, Model<TApi>>,
+): (modelId: string) => Model<TApi> | undefined {
+	const globalRefs = new Map<string, Model<Api>>();
 	for (const provider of getBundledProviders()) {
 		for (const model of getBundledModels(provider as Parameters<typeof getBundledModels>[0])) {
 			const candidate = model as Model<Api>;
-			const existing = references.get(candidate.id);
-			if (shouldReplaceGlobalReference(existing, candidate)) {
-				references.set(candidate.id, candidate);
+			const existing = globalRefs.get(candidate.id);
+			if (!existing) {
+				globalRefs.set(candidate.id, candidate);
+			} else if (candidate.contextWindow !== existing.contextWindow) {
+				if (candidate.contextWindow > existing.contextWindow) globalRefs.set(candidate.id, candidate);
+			} else if (candidate.maxTokens !== existing.maxTokens) {
+				if (candidate.maxTokens > existing.maxTokens) globalRefs.set(candidate.id, candidate);
+			} else if (existing.provider !== "openai" && candidate.provider === "openai") {
+				// When limits tie, prefer OpenAI as canonical so generic OpenAI-family
+				// providers inherit OpenAI pricing/capabilities instead of proxy metadata.
+				globalRefs.set(candidate.id, candidate);
 			}
 		}
 	}
-	return references;
+	return (modelId: string) => providerRefs.get(modelId) ?? (globalRefs.get(modelId) as Model<TApi> | undefined);
 }
 
 function normalizeAnthropicBaseUrl(baseUrl: string | undefined, fallback: string): string {
@@ -1384,10 +1389,9 @@ export function nanoGptModelManagerOptions(
 ): ModelManagerOptions<"openai-completions"> {
 	const apiKey = config?.apiKey;
 	const baseUrl = config?.baseUrl ?? "https://nano-gpt.com/api/v1";
-	const references = createBundledReferenceMap<"openai-completions">(
-		"nanogpt" as Parameters<typeof getBundledModels>[0],
+	const resolveReference = createReferenceResolver(
+		createBundledReferenceMap<"openai-completions">("nanogpt" as Parameters<typeof getBundledModels>[0]),
 	);
-	const globalReferences = createGlobalReferenceMap();
 	return {
 		providerId: "nanogpt",
 		...(apiKey && {
@@ -1400,14 +1404,7 @@ export function nanoGptModelManagerOptions(
 					baseUrl,
 					apiKey,
 					mapModel: (entry, defaults) => {
-						const providerReference = references.get(defaults.id);
-						const globalReference = globalReferences.get(defaults.id);
-						const reference =
-							providerReference && globalReference
-								? providerReference.contextWindow >= globalReference.contextWindow
-									? providerReference
-									: globalReference
-								: (providerReference ?? globalReference);
+						const reference = resolveReference(defaults.id);
 						const mapped = mapWithBundledReference(entry, defaults, reference);
 						return { ...mapped, api: "openai-completions", provider: "nanogpt" };
 					},
@@ -1475,15 +1472,15 @@ function extractCopilotLimits(entry: OpenAICompatibleModelRecord): {
 
 export function githubCopilotModelManagerOptions(config?: GithubCopilotModelManagerConfig): ModelManagerOptions<Api> {
 	const rawApiKey = config?.apiKey;
-	const baseUrl = config?.baseUrl ?? "https://api.githubcopilot.com";
+	const configuredBaseUrl = config?.baseUrl ?? "https://api.githubcopilot.com";
 	const parsedApiKey = rawApiKey ? parseGitHubCopilotApiKey(rawApiKey) : undefined;
 	const apiKey = parsedApiKey?.accessToken;
-	const resolvedBaseUrl =
-		parsedApiKey?.enterpriseUrl && baseUrl.includes("githubcopilot.com")
+	const baseUrl =
+		parsedApiKey?.enterpriseUrl && configuredBaseUrl.includes("githubcopilot.com")
 			? getGitHubCopilotBaseUrl(parsedApiKey.enterpriseUrl)
-			: baseUrl;
-	const references = createBundledReferenceMap<Api>("github-copilot");
-	const globalReferences = createGlobalReferenceMap();
+			: configuredBaseUrl;
+	const providerRefs = createBundledReferenceMap<Api>("github-copilot");
+	const resolveReference = createReferenceResolver(providerRefs);
 	return {
 		providerId: "github-copilot",
 		...(apiKey && {
@@ -1491,7 +1488,7 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 				fetchOpenAICompatibleModels<Api>({
 					api: "openai-completions",
 					provider: "github-copilot",
-					baseUrl: resolvedBaseUrl,
+					baseUrl,
 					apiKey,
 					headers: OPENCODE_HEADERS,
 					mapModel: (
@@ -1499,26 +1496,18 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 						defaults: Model<Api>,
 						_context: OpenAICompatibleModelMapperContext<Api>,
 					): Model<Api> => {
-						const providerReference = references.get(defaults.id);
-						const globalReference = globalReferences.get(defaults.id) as Model<Api> | undefined;
-						const reference =
-							providerReference && globalReference
-								? providerReference.contextWindow >= globalReference.contextWindow
-									? providerReference
-									: globalReference
-								: (providerReference ?? globalReference);
+						const reference = resolveReference(defaults.id);
 						const copilotLimits = extractCopilotLimits(entry);
-						// Copilot currently exposes token limits under capabilities.limits.*.
-						// Keep OpenAI-compatible fields as outer fallbacks for forward compatibility if
-						// `/models` starts returning context_length/max_completion_tokens in the future.
+						// Copilot exposes token limits under capabilities.limits.*.
+						// max_prompt_tokens is the prompt capacity (what OMP calls contextWindow).
+						// max_context_window_tokens is the total window (prompt + output budget)
+						// and must NOT be used for contextWindow — it inflates the limit and
+						// breaks compaction thresholds, overflow detection, and promotion.
 						const contextWindow = toPositiveNumber(
 							entry.context_length,
 							toPositiveNumber(
-								copilotLimits.maxContextWindowTokens,
-								toPositiveNumber(
-									copilotLimits.maxPromptTokens,
-									reference?.contextWindow ?? defaults.contextWindow,
-								),
+								copilotLimits.maxPromptTokens,
+								reference?.contextWindow ?? defaults.contextWindow,
 							),
 						);
 						const maxTokens = toPositiveNumber(
@@ -1545,7 +1534,7 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 								name,
 								contextWindow,
 								maxTokens,
-								headers: { ...OPENCODE_HEADERS, ...(providerReference?.headers ?? {}) },
+								headers: { ...OPENCODE_HEADERS, ...(providerRefs.get(defaults.id)?.headers ?? {}) },
 								...(api === "openai-completions"
 									? {
 											compat: {

--- a/packages/ai/test/github-copilot-model-limits.test.ts
+++ b/packages/ai/test/github-copilot-model-limits.test.ts
@@ -157,11 +157,23 @@ describe("github copilot model limits mapping", () => {
 		expect(model?.maxTokens).toBe(16_000);
 	});
 
-	it("keeps bundled Claude Opus 4.6 Copilot 1M context window truthful offline", () => {
-		const model = getBundledModel("github-copilot", "claude-opus-4.6");
-
-		expect(model.contextWindow).toBe(1_000_000);
-		expect(model.maxTokens).toBe(64_000);
+	it("keeps bundled Copilot fallback limits truthful offline", () => {
+		expect(getBundledModel("github-copilot", "claude-opus-4.6")).toMatchObject({
+			contextWindow: 168_000,
+			maxTokens: 32_000,
+		});
+		expect(getBundledModel("github-copilot", "gpt-5.2")).toMatchObject({
+			contextWindow: 272_000,
+			maxTokens: 128_000,
+		});
+		expect(getBundledModel("github-copilot", "gpt-5.4-mini")).toMatchObject({
+			contextWindow: 272_000,
+			maxTokens: 128_000,
+		});
+		expect(getBundledModel("github-copilot", "grok-code-fast-1")).toMatchObject({
+			contextWindow: 192_000,
+			maxTokens: 64_000,
+		});
 	});
 	it("inherits bundled GPT-5.4 mini reasoning metadata during discovery", async () => {
 		const { models } = await discoverCopilotModels({

--- a/packages/ai/test/github-copilot-model-limits.test.ts
+++ b/packages/ai/test/github-copilot-model-limits.test.ts
@@ -84,7 +84,7 @@ describe("github copilot model limits mapping", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
-	it("uses capabilities.limits max_context_window_tokens as context window when context_length is absent", async () => {
+	it("uses capabilities.limits max_prompt_tokens as context window when context_length is absent", async () => {
 		const { models, fetchMock } = await discoverCopilotModels({
 			data: [
 				{
@@ -103,7 +103,7 @@ describe("github copilot model limits mapping", () => {
 
 		const model = models.find(candidate => candidate.id === "gemini-2.5-pro");
 		expect(model).toBeDefined();
-		expect(model?.contextWindow).toBe(1_048_576);
+		expect(model?.contextWindow).toBe(128_000);
 		expect(model?.maxTokens).toBe(64_000);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
@@ -153,7 +153,7 @@ describe("github copilot model limits mapping", () => {
 
 		const model = models.find(candidate => candidate.id === "claude-opus-4.6");
 		expect(model).toBeDefined();
-		expect(model?.contextWindow).toBe(200_000);
+		expect(model?.contextWindow).toBe(128_000);
 		expect(model?.maxTokens).toBe(16_000);
 	});
 
@@ -194,5 +194,49 @@ describe("github copilot model limits mapping", () => {
 			minLevel: Effort.Low,
 			maxLevel: Effort.XHigh,
 		});
+	});
+
+	it("does not use max_context_window_tokens for contextWindow", async () => {
+		const { models } = await discoverCopilotModels({
+			data: [
+				{
+					id: "gpt-5.4",
+					name: "GPT-5.4",
+					capabilities: {
+						limits: {
+							max_context_window_tokens: 400_000,
+							max_output_tokens: 128_000,
+						},
+					},
+				},
+			],
+		});
+
+		const model = models.find(candidate => candidate.id === "gpt-5.4");
+		expect(model).toBeDefined();
+		// max_context_window_tokens is total window (prompt + output), not prompt capacity.
+		// Without max_prompt_tokens, contextWindow should fall back to bundled reference,
+		// NOT to max_context_window_tokens.
+		expect(model?.contextWindow).toBe(272_000);
+		expect(model?.maxTokens).toBe(128_000);
+	});
+
+	it("prefers Copilot-specific bundled reference over global reference", async () => {
+		// When the API returns no limits at all, the model should use the Copilot-specific
+		// bundled reference, not a global reference from another provider (e.g. OpenAI at 1050k).
+		const { models } = await discoverCopilotModels({
+			data: [
+				{
+					id: "gpt-5.4",
+					name: "GPT-5.4",
+				},
+			],
+		});
+
+		const model = models.find(candidate => candidate.id === "gpt-5.4");
+		expect(model).toBeDefined();
+		// Should use the Copilot-specific bundled reference (272k after models.json fix),
+		// not the OpenAI global reference (1050k).
+		expect(model?.contextWindow).toBe(272_000);
 	});
 });

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -244,6 +244,25 @@ describe("generated model policies", () => {
 		expect(models[3]?.priority).toBe(1);
 	});
 
+	it("does not special-case Copilot Opus 4.6 generated limits", () => {
+		const models: Model<Api>[] = [
+			{
+				...createModel({
+					id: "claude-opus-4.6",
+					api: "anthropic-messages",
+					provider: "github-copilot",
+				}),
+				contextWindow: 168000,
+				maxTokens: 32000,
+			},
+		];
+
+		applyGeneratedModelPolicies(models);
+
+		expect(models[0]?.contextWindow).toBe(168000);
+		expect(models[0]?.maxTokens).toBe(32000);
+	});
+
 	it("links spark variants to their base models", () => {
 		const models = [
 			createModel({


### PR DESCRIPTION
## Summary

Fix the remaining Copilot context window inflation paths that were left after #226.

#226 fixed the live `capabilities.limits` parsing path, but current `main` can still inflate Copilot limits in two other places:

1. runtime bundled-reference selection can still prefer a larger cross-provider reference over the Copilot-specific bundled reference
2. `applyGlobalModelsDevFallback()` can still overwrite provider-specific `contextWindow` / `maxTokens` with cross-provider models.dev limits

This PR fixes both of those paths and corrects the affected bundled Copilot fallback values.

## Changes

### `packages/ai/src/provider-models/openai-compat.ts`
- prefer the provider-specific bundled reference over the global cross-provider fallback for Copilot and nanogpt
- keep the global fallback only for models with no provider-specific entry
- resolve Copilot `contextWindow` from:
  - `context_length`
  - `max_prompt_tokens`
  - bundled reference
- do not use `max_context_window_tokens` as `contextWindow`

### `packages/ai/scripts/generate-models.ts`
- stop overwriting `contextWindow` and `maxTokens` in `applyGlobalModelsDevFallback()`
- still inherit non-limit metadata like `name`, `reasoning`, and `input`

### `packages/ai/src/models.json`
- `github-copilot/gpt-5.2`: `264000 -> 272000`
- `github-copilot/gpt-5.4`: `400000 -> 272000`

### `packages/ai/test/github-copilot-model-limits.test.ts`
- update expectations to use prompt-capacity semantics
- add regressions for:
  - not using `max_context_window_tokens` as `contextWindow`
  - preferring the Copilot-specific bundled reference over the global one

## Why this matters

`contextWindow` is used for overflow detection, compaction thresholds, and context-based model decisions. If it reflects total window or another provider's larger native limit, OMP can delay overflow handling and compact too late.

## Verification

- `bun test packages/ai/test/github-copilot-model-limits.test.ts`
- `bun test packages/ai/test/github-copilot-headers.test.ts packages/ai/test/github-copilot-claude-messages-routing.test.ts packages/ai/test/github-copilot-anthropic-auth.test.ts packages/ai/test/github-copilot-openai-base-url.test.ts`

Refs: #225
Follow-up to: #226
