### PR TITLE
fix: yt-dlp auto-download hanging YouTube reads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -485,6 +485,7 @@
 - Chunk edit error messages now consistently report checksum mismatches with the format `did not match checksum "XXXX"` instead of variable phrasing
 - Chunk selector validation for edits now rejects non-canonical selectors (suffix-only like `fn_run` or prefix-stripped like `run`), requiring fully-qualified paths to prevent ambiguity
 - Plan review previews now re-append at the chat tail on refresh, keeping them adjacent to the active selector instead of updating off-screen
+- Fixed yt-dlp auto-download hangs during YouTube reads by streaming direct-binary installs into the current agent tools directory ([#644](https://github.com/can1357/oh-my-pi/issues/644))
 - `log_experiment` validates and reverts run-scoped file changes without clobbering unrelated dirty worktree state
 - Chunk edit targets that embed CRC in the selector (e.g. `fn_foo#ABCD`) parse correctly
 - Shell paths check errors before consuming chunk output (bash executor, config resolution)

--- a/packages/coding-agent/src/utils/tools-manager.ts
+++ b/packages/coding-agent/src/utils/tools-manager.ts
@@ -1,11 +1,25 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { $which, APP_NAME, getToolsDir, logger, ptree, TempDir } from "@oh-my-pi/pi-utils";
+import { pipeline } from "node:stream/promises";
+import { $which, APP_NAME, getToolsDir, isEnoent, logger, ptree, TempDir } from "@oh-my-pi/pi-utils";
 
-const TOOLS_DIR = getToolsDir();
 const TOOL_DOWNLOAD_TIMEOUT_MS = 120_000;
 const TOOL_METADATA_TIMEOUT_MS = 5000;
+
+function resolveToolsDir(): string {
+	// Resolve at call time so runtime/test agent-dir changes are respected.
+	return getToolsDir();
+}
+
+async function waitForWriteStreamOpen(stream: fs.WriteStream): Promise<void> {
+	if (!stream.pending) return;
+
+	const { promise, resolve, reject } = Promise.withResolvers<void>();
+	stream.once("open", () => resolve());
+	stream.once("error", reject);
+	await promise;
+}
 
 interface ToolConfig {
 	name: string;
@@ -103,7 +117,8 @@ export function getToolPath(tool: ToolName): string | null {
 	if (!config) return null;
 
 	// Check our tools directory first
-	const localPath = path.join(TOOLS_DIR, config.binaryName + (os.platform() === "win32" ? ".exe" : ""));
+	const toolsDir = resolveToolsDir();
+	const localPath = path.join(toolsDir, config.binaryName + (os.platform() === "win32" ? ".exe" : ""));
 	if (fs.existsSync(localPath)) {
 		return localPath;
 	}
@@ -137,6 +152,8 @@ async function getLatestVersion(repo: string, signal?: AbortSignal): Promise<str
 
 // Download a file from URL
 async function downloadFile(url: string, dest: string, signal?: AbortSignal): Promise<void> {
+	const tempPath = `${dest}.download-${process.pid}-${Date.now()}`;
+	const backupPath = `${dest}.bak`;
 	let response: Response;
 	try {
 		response = await fetch(url, {
@@ -149,11 +166,51 @@ async function downloadFile(url: string, dest: string, signal?: AbortSignal): Pr
 		throw err;
 	}
 	if (!response.ok) {
-		throw new Error(`Failed to download: ${response.status}`);
-	} else if (!response.body) {
-		throw new Error("No response body");
+		throw new Error(`Failed to download: ${response.status} ${response.statusText}`.trim());
 	}
-	await Bun.write(dest, response);
+	if (!response.body) {
+		throw new Error(`No response body for: ${url}`);
+	}
+
+	await fs.promises.mkdir(path.dirname(dest), { recursive: true });
+
+	try {
+		const fileStream = fs.createWriteStream(tempPath);
+		await waitForWriteStreamOpen(fileStream);
+		await pipeline(response.body, fileStream);
+
+		await fs.promises.rm(backupPath, { force: true });
+
+		let replacedExistingFile = false;
+		try {
+			await fs.promises.rename(dest, backupPath);
+			replacedExistingFile = true;
+		} catch (err) {
+			if (!isEnoent(err)) throw err;
+		}
+
+		try {
+			await fs.promises.rename(tempPath, dest);
+		} catch (err) {
+			if (replacedExistingFile) {
+				try {
+					await fs.promises.rename(backupPath, dest);
+				} catch (restoreErr) {
+					throw new Error(
+						`Failed to replace ${dest}: ${err instanceof Error ? err.message : String(err)}; rollback failed: ${restoreErr instanceof Error ? restoreErr.message : String(restoreErr)}`,
+					);
+				}
+			}
+			throw err;
+		}
+
+		if (replacedExistingFile) {
+			await fs.promises.rm(backupPath, { force: true });
+		}
+	} catch (err) {
+		await fs.promises.rm(tempPath, { force: true });
+		throw err;
+	}
 }
 
 // Download and install a tool
@@ -173,12 +230,14 @@ async function downloadTool(tool: ToolName, signal?: AbortSignal): Promise<strin
 		throw new Error(`Unsupported platform: ${plat}/${architecture}`);
 	}
 
+	const toolsDir = resolveToolsDir();
+
 	// Create tools directory
-	await fs.promises.mkdir(TOOLS_DIR, { recursive: true });
+	await fs.promises.mkdir(toolsDir, { recursive: true });
 
 	const downloadUrl = `https://github.com/${config.repo}/releases/download/${config.tagPrefix}${version}/${assetName}`;
 	const binaryExt = plat === "win32" ? ".exe" : "";
-	const binaryPath = path.join(TOOLS_DIR, config.binaryName + binaryExt);
+	const binaryPath = path.join(toolsDir, config.binaryName + binaryExt);
 
 	// Handle direct binary downloads (no archive extraction needed)
 	if (config.isDirectBinary) {
@@ -190,7 +249,7 @@ async function downloadTool(tool: ToolName, signal?: AbortSignal): Promise<strin
 	}
 
 	// Download archive
-	const archivePath = path.join(TOOLS_DIR, assetName);
+	const archivePath = path.join(toolsDir, assetName);
 	await downloadFile(downloadUrl, archivePath, signal);
 
 	// Extract

--- a/packages/coding-agent/test/utils/tools-manager.test.ts
+++ b/packages/coding-agent/test/utils/tools-manager.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getConfigRootDir, getToolsDir, hookFetch, setAgentDir } from "@oh-my-pi/pi-utils";
+import { ensureTool } from "../../src/utils/tools-manager";
+
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+
+let testAgentDir = "";
+
+function getYtDlpAssetName(): string {
+	const platform = os.platform();
+	const architecture = os.arch();
+
+	if (platform === "darwin") {
+		return "yt-dlp_macos";
+	}
+	if (platform === "linux") {
+		return architecture === "arm64" ? "yt-dlp_linux_aarch64" : "yt-dlp_linux";
+	}
+	if (platform === "win32") {
+		return architecture === "arm64" ? "yt-dlp_arm64.exe" : "yt-dlp.exe";
+	}
+
+	throw new Error(`Unsupported test platform: ${platform}/${architecture}`);
+}
+
+function createStreamingBinaryResponse(): Response {
+	return new Response(
+		new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(new Uint8Array([0x7f, 0x45, 0x4c, 0x46]));
+				setTimeout(() => {
+					controller.enqueue(new Uint8Array([0x01, 0x02, 0x03, 0x04]));
+					controller.close();
+				}, 10);
+			},
+		}),
+		{
+			status: 200,
+			headers: { "Content-Type": "application/octet-stream" },
+		},
+	);
+}
+
+beforeEach(async () => {
+	testAgentDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-tools-manager-"));
+	setAgentDir(testAgentDir);
+});
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	if (originalAgentDir) {
+		setAgentDir(originalAgentDir);
+	} else {
+		setAgentDir(fallbackAgentDir);
+		delete process.env.PI_CODING_AGENT_DIR;
+	}
+	if (testAgentDir) {
+		await fs.promises.rm(testAgentDir, { recursive: true, force: true });
+		testAgentDir = "";
+	}
+});
+
+describe("ensureTool yt-dlp auto-install", () => {
+	it(
+		"installs into the current agent tools dir when yt-dlp is missing",
+		async () => {
+			const version = "2026.04.07";
+			const expectedToolsDir = getToolsDir();
+			const expectedBinaryName = os.platform() === "win32" ? "yt-dlp.exe" : "yt-dlp";
+			const assetName = getYtDlpAssetName();
+			const binarySuffix = path.join("tools", expectedBinaryName);
+			const latestReleaseUrl = "https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest";
+			const downloadUrl = `https://github.com/yt-dlp/yt-dlp/releases/download/${version}/${assetName}`;
+			const requests: string[] = [];
+			const originalWhich = Bun.which.bind(Bun) as typeof Bun.which;
+			const originalExistsSync = fs.existsSync.bind(fs) as typeof fs.existsSync;
+			const originalMkdir = fs.promises.mkdir.bind(fs.promises) as typeof fs.promises.mkdir;
+
+			vi.spyOn(Bun, "which").mockImplementation(command => (command === "yt-dlp" ? null : originalWhich(command)));
+			vi.spyOn(fs, "existsSync").mockImplementation(candidate => {
+				if (typeof candidate === "string" && path.normalize(candidate).endsWith(binarySuffix)) {
+					return false;
+				}
+				return originalExistsSync(candidate);
+			});
+			vi.spyOn(fs.promises, "mkdir").mockImplementation(
+				(async (...args: Parameters<typeof fs.promises.mkdir>) => {
+					const [dir, options] = args;
+					const resolvedDir = path.resolve(String(dir));
+					if (resolvedDir !== expectedToolsDir) {
+						throw new Error(`unexpected mkdir outside test tools dir: ${resolvedDir}`);
+					}
+					return await originalMkdir(dir, options);
+				}) as typeof fs.promises.mkdir,
+			);
+
+			using _hook = hookFetch(async input => {
+				const url = String(input);
+				requests.push(url);
+				if (url === latestReleaseUrl) {
+					return new Response(JSON.stringify({ tag_name: version }), {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					});
+				}
+				if (url === downloadUrl) {
+					return createStreamingBinaryResponse();
+				}
+				return new Response(`unexpected fetch: ${url}`, { status: 500 });
+			});
+
+			const installedPath = await ensureTool("yt-dlp", { silent: true });
+			expect(installedPath).toBeDefined();
+			expect(installedPath).toBe(path.join(expectedToolsDir, expectedBinaryName));
+			expect(requests).toEqual([latestReleaseUrl, downloadUrl]);
+
+			const installedStat = await fs.promises.stat(installedPath!);
+			expect(installedStat.size).toBeGreaterThan(0);
+			expect(path.dirname(installedPath!)).toBe(expectedToolsDir);
+
+			if (os.platform() !== "win32") {
+				expect(installedStat.mode & 0o111).not.toBe(0);
+			}
+		},
+		{ timeout: 2000 },
+	);
+});

--- a/packages/coding-agent/test/utils/tools-manager.test.ts
+++ b/packages/coding-agent/test/utils/tools-manager.test.ts
@@ -87,16 +87,14 @@ describe("ensureTool yt-dlp auto-install", () => {
 				}
 				return originalExistsSync(candidate);
 			});
-			vi.spyOn(fs.promises, "mkdir").mockImplementation(
-				(async (...args: Parameters<typeof fs.promises.mkdir>) => {
-					const [dir, options] = args;
-					const resolvedDir = path.resolve(String(dir));
-					if (resolvedDir !== expectedToolsDir) {
-						throw new Error(`unexpected mkdir outside test tools dir: ${resolvedDir}`);
-					}
-					return await originalMkdir(dir, options);
-				}) as typeof fs.promises.mkdir,
-			);
+			vi.spyOn(fs.promises, "mkdir").mockImplementation((async (...args: Parameters<typeof fs.promises.mkdir>) => {
+				const [dir, options] = args;
+				const resolvedDir = path.resolve(String(dir));
+				if (resolvedDir !== expectedToolsDir) {
+					throw new Error(`unexpected mkdir outside test tools dir: ${resolvedDir}`);
+				}
+				return await originalMkdir(dir, options);
+			}) as typeof fs.promises.mkdir);
 
 			using _hook = hookFetch(async input => {
 				const url = String(input);


### PR DESCRIPTION
Closes #644.

## Summary
- stream tool downloads to disk instead of using `Bun.write(dest, response)` for direct-binary installs
- resolve the tools directory at call time so temp agent dirs and tests do not use stale cached paths
- add regression coverage for `ensureTool("yt-dlp")` auto-install and record the fix in the coding-agent changelog

## Verification
- `bun test packages/coding-agent/test/utils/tools-manager.test.ts`
- `bun check:ts`
- real-network `ensureTool("yt-dlp")` install into a fresh temp agent dir completed and produced an executable binary inside the temp tools dir

## Notes
- attempted `bun test packages/coding-agent/test/tools/web-scrapers/youtube-parallel.test.ts` and a full CLI repro, but both are currently blocked by unrelated `@oh-my-pi/pi-natives` export mismatches in this checkout (`formatAnchor` / `Ellipsis`).