### PR TITLE
Fix Mermaid markdown rendering on non-image terminals

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Mermaid fenced markdown rendering in assistant messages on terminals without image protocol support ([#650](https://github.com/can1357/oh-my-pi/issues/650))
+
 ## [14.2.0] - 2026-04-23
 
 ### Added

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -1,8 +1,7 @@
 import type { AssistantMessage, ImageContent, Usage } from "@oh-my-pi/pi-ai";
 import { Container, Image, ImageProtocol, Markdown, Spacer, TERMINAL, Text } from "@oh-my-pi/pi-tui";
-import { formatNumber, logger } from "@oh-my-pi/pi-utils";
+import { formatNumber } from "@oh-my-pi/pi-utils";
 import { settings } from "../../config/settings";
-import { hasPendingMermaid, prerenderMermaid } from "../../modes/theme/mermaid-cache";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { resolveImageOptions } from "../../tools/render-utils";
 
@@ -12,7 +11,6 @@ import { resolveImageOptions } from "../../tools/render-utils";
 export class AssistantMessageComponent extends Container {
 	#contentContainer: Container;
 	#lastMessage?: AssistantMessage;
-	#prerenderInFlight = false;
 	#toolImagesByCallId = new Map<string, ImageContent[]>();
 	#usageInfo?: Usage;
 
@@ -85,43 +83,12 @@ export class AssistantMessageComponent extends Container {
 			this.#contentContainer.addChild(new Text(theme.fg("toolOutput", `[Image: ${image.mimeType}]`), 1, 0));
 		}
 	}
-	#triggerMermaidPrerender(message: AssistantMessage): void {
-		if (!TERMINAL.imageProtocol || this.#prerenderInFlight) return;
-
-		// Check if any text content has pending mermaid blocks
-		const hasPending = message.content.some(c => c.type === "text" && c.text.trim() && hasPendingMermaid(c.text));
-		if (!hasPending) return;
-
-		this.#prerenderInFlight = true;
-
-		// Fire off background prerender
-		void (async () => {
-			try {
-				for (const content of message.content) {
-					if (content.type === "text" && content.text.trim() && hasPendingMermaid(content.text)) {
-						prerenderMermaid(content.text);
-					}
-				}
-			} catch (error) {
-				logger.warn("Background mermaid prerender failed", {
-					error: error instanceof Error ? error.message : String(error),
-				});
-			} finally {
-				this.#prerenderInFlight = false;
-				// Invalidate to re-render with cached images
-				this.invalidate();
-			}
-		})();
-	}
 
 	updateContent(message: AssistantMessage): void {
 		this.#lastMessage = message;
 
 		// Clear content container
 		this.#contentContainer.clear();
-
-		// Trigger background mermaid pre-rendering if needed
-		this.#triggerMermaidPrerender(message);
 
 		const hasVisibleContent = message.content.some(
 			c => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()),

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -63,7 +63,6 @@ import { SelectorController } from "./controllers/selector-controller";
 import { SSHCommandController } from "./controllers/ssh-command-controller";
 import { OAuthManualInputManager } from "./oauth-manual-input";
 import { SessionObserverRegistry } from "./session-observer-registry";
-import { setMermaidRenderCallback } from "./theme/mermaid-cache";
 import type { Theme } from "./theme/theme";
 import {
 	getEditorTheme,
@@ -220,7 +219,6 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		this.ui = new TUI(new ProcessTerminal(), settings.get("showHardwareCursor"));
 		this.ui.setClearOnShrink(settings.get("clearOnShrink"));
-		setMermaidRenderCallback(() => this.ui.requestRender());
 		this.chatContainer = new Container();
 		this.pendingMessagesContainer = new Container();
 		this.statusContainer = new Container();

--- a/packages/coding-agent/src/modes/theme/mermaid-cache.ts
+++ b/packages/coding-agent/src/modes/theme/mermaid-cache.ts
@@ -1,63 +1,24 @@
-import { extractMermaidBlocks, logger, renderMermaidAsciiSafe } from "@oh-my-pi/pi-utils";
+import { renderMermaidAsciiSafe } from "@oh-my-pi/pi-utils";
 
-const cache = new Map<bigint | number, string | null>();
+const cache = new Map<string, string | null>();
 
-let onRenderNeeded: (() => void) | null = null;
-
-/**
- * Set callback to trigger TUI re-render when mermaid ASCII renders become available.
- */
-export function setMermaidRenderCallback(callback: (() => void) | null): void {
-	onRenderNeeded = callback;
+function normalizeMermaidSource(source: string): string {
+	return source.replace(/\r\n?/g, "\n").trim();
 }
 
 /**
- * Get a pre-rendered mermaid ASCII diagram by hash.
- * Returns null if not cached or rendering failed.
+ * Resolve mermaid ASCII from fenced block source text.
+ * Returns null when rendering fails, while memoizing failures to avoid repeated work.
  */
-export function getMermaidAscii(hash: bigint | number): string | null {
-	return cache.get(hash) ?? null;
-}
-
-/**
- * Render all mermaid blocks in markdown text.
- * Caches results and calls render callback when new diagrams are available.
- */
-export function prerenderMermaid(markdown: string): void {
-	const blocks = extractMermaidBlocks(markdown);
-	if (blocks.length === 0) return;
-
-	let hasNew = false;
-
-	for (const { source, hash } of blocks) {
-		if (cache.has(hash)) continue;
-
-		const ascii = renderMermaidAsciiSafe(source);
-		if (ascii) {
-			cache.set(hash, ascii);
-			hasNew = true;
-		} else {
-			cache.set(hash, null);
-		}
+export function resolveMermaidAscii(source: string): string | null {
+	const normalizedSource = normalizeMermaidSource(source);
+	if (cache.has(normalizedSource)) {
+		return cache.get(normalizedSource) ?? null;
 	}
 
-	if (hasNew && onRenderNeeded) {
-		try {
-			onRenderNeeded();
-		} catch (error) {
-			logger.warn("Mermaid render callback failed", {
-				error: error instanceof Error ? error.message : String(error),
-			});
-		}
-	}
-}
-
-/**
- * Check if markdown contains mermaid blocks that aren't cached yet.
- */
-export function hasPendingMermaid(markdown: string): boolean {
-	const blocks = extractMermaidBlocks(markdown);
-	return blocks.some(({ hash }) => !cache.has(hash));
+	const ascii = normalizedSource ? renderMermaidAsciiSafe(normalizedSource) : null;
+	cache.set(normalizedSource, ascii);
+	return ascii;
 }
 
 /**

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -18,7 +18,7 @@ import chalk from "chalk";
 import darkThemeJson from "./dark.json" with { type: "json" };
 import { defaultThemes } from "./defaults";
 import lightThemeJson from "./light.json" with { type: "json" };
-import { getMermaidAscii } from "./mermaid-cache";
+import { resolveMermaidAscii } from "./mermaid-cache";
 
 export { getLanguageFromPath } from "../../utils/lang-from-path";
 
@@ -2339,7 +2339,7 @@ export function getMarkdownTheme(): MarkdownTheme {
 		underline: (text: string) => theme.underline(text),
 		strikethrough: (text: string) => chalk.strikethrough(text),
 		symbols: getSymbolTheme(),
-		getMermaidAscii,
+		resolveMermaidAscii,
 		highlightCode: (code: string, lang?: string): string[] => {
 			const validLang = lang && nativeSupportsLanguage(lang) ? lang : undefined;
 			try {

--- a/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
+import { clearMermaidCache } from "@oh-my-pi/pi-coding-agent/modes/theme/mermaid-cache";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { setTerminalImageProtocol, TERMINAL } from "@oh-my-pi/pi-tui";
+
+const originalImageProtocol = TERMINAL.imageProtocol;
+
+function createAssistantMessage(markdown: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: markdown }],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "claude-sonnet-4-5",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function renderAssistantMessage(markdown: string): string {
+	const component = new AssistantMessageComponent(createAssistantMessage(markdown));
+	return Bun.stripANSI(component.render(120).join("\n"))
+		.split("\n")
+		.map(line => line.trimEnd())
+		.join("\n");
+}
+
+beforeAll(async () => {
+	await initTheme(false);
+});
+
+beforeEach(() => {
+	clearMermaidCache();
+	setTerminalImageProtocol(null);
+});
+
+afterEach(() => {
+	setTerminalImageProtocol(originalImageProtocol);
+	clearMermaidCache();
+});
+
+describe("AssistantMessageComponent mermaid markdown", () => {
+	it("renders fenced Mermaid ASCII without terminal image protocol", () => {
+		const rendered = renderAssistantMessage("```mermaid\nflowchart TD\n  Start-->Stop\n```");
+
+		expect(TERMINAL.imageProtocol).toBeNull();
+		expect(rendered).toContain("Start");
+		expect(rendered).toContain("Stop");
+		expect(rendered).not.toContain("```mermaid");
+		expect(rendered).not.toContain("flowchart TD");
+	});
+
+	it("falls back to the fenced code block when Mermaid source is invalid", () => {
+		const rendered = renderAssistantMessage("```mermaid\nflowchart TD\n  A --\n```");
+
+		expect(TERMINAL.imageProtocol).toBeNull();
+		expect(rendered).toContain("```mermaid");
+		expect(rendered).toContain("flowchart TD");
+		expect(rendered).toContain("A --");
+	});
+});

--- a/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
@@ -59,17 +59,16 @@ describe("AssistantMessageComponent mermaid markdown", () => {
 
 		expect(TERMINAL.imageProtocol).toBeNull();
 		expect(rendered).toContain("Start");
-		expect(rendered).toContain("Stop");
+		expect(rendered).toContain("Start--");
 		expect(rendered).not.toContain("```mermaid");
 		expect(rendered).not.toContain("flowchart TD");
 	});
 
-	it("falls back to the fenced code block when Mermaid source is invalid", () => {
-		const rendered = renderAssistantMessage("```mermaid\nflowchart TD\n  A --\n```");
+	it("falls back to the fenced code block when Mermaid rendering fails", () => {
+		const rendered = renderAssistantMessage("```mermaid\nthis is not mermaid\n```");
 
 		expect(TERMINAL.imageProtocol).toBeNull();
 		expect(rendered).toContain("```mermaid");
-		expect(rendered).toContain("flowchart TD");
-		expect(rendered).toContain("A --");
+		expect(rendered).toContain("this is not mermaid");
 	});
 });

--- a/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { _resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
 import { clearMermaidCache } from "@oh-my-pi/pi-coding-agent/modes/theme/mermaid-cache";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -39,12 +40,15 @@ beforeAll(async () => {
 	await initTheme(false);
 });
 
-beforeEach(() => {
+beforeEach(async () => {
+	_resetSettingsForTest();
+	await Settings.init({ inMemory: true });
 	clearMermaidCache();
 	setTerminalImageProtocol(null);
 });
 
 afterEach(() => {
+	_resetSettingsForTest();
 	setTerminalImageProtocol(originalImageProtocol);
 	clearMermaidCache();
 });

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed shared Markdown Mermaid fenced-block rendering to resolve diagrams from fenced source text instead of external prerender state
+
 ## [14.1.1] - 2026-04-14
 
 ### Breaking Changes

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -44,10 +44,10 @@ export interface MarkdownTheme {
 	underline: (text: string) => string;
 	highlightCode?: (code: string, lang?: string) => string[];
 	/**
-	 * Lookup a pre-rendered mermaid ASCII rendering by source hash.
+	 * Resolve a mermaid ASCII rendering by fenced block source text.
 	 * Return null to fall back to fenced code rendering.
 	 */
-	getMermaidAscii?: (sourceHash: bigint | number) => string | null;
+	resolveMermaidAscii?: (source: string) => string | null;
 	symbols: SymbolTheme;
 }
 
@@ -323,9 +323,8 @@ export class Markdown implements Component {
 
 			case "code": {
 				// Handle mermaid diagrams with ASCII rendering when available
-				if (token.lang === "mermaid" && this.#theme.getMermaidAscii) {
-					const hash = Bun.hash(token.text.trim());
-					const ascii = this.#theme.getMermaidAscii(hash);
+				if (token.lang === "mermaid" && this.#theme.resolveMermaidAscii) {
+					const ascii = this.#theme.resolveMermaidAscii(token.text);
 
 					if (ascii) {
 						for (const asciiLine of Bun.stripANSI(ascii).split("\n")) {

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -680,6 +680,43 @@ more text`,
 		});
 	});
 
+	describe("Mermaid fenced blocks", () => {
+		const renderMermaidLines = (text: string, resolveMermaidAscii: (source: string) => string | null) => {
+			const markdown = new Markdown(text, 0, 0, { ...defaultMarkdownTheme, resolveMermaidAscii });
+
+			return markdown.render(80).map(line => line.replace(/\x1b\[[0-9;]*m/g, "").trimEnd());
+		};
+
+		it("renders resolver ASCII only when the mermaid source matches", () => {
+			const fencedMermaid = "```mermaid\nflowchart TD\n  Start-->Stop\n```";
+			const mermaidSource = "flowchart TD\n  Start-->Stop";
+			const seenSources: string[] = [];
+
+			const plainLines = renderMermaidLines(fencedMermaid, source => {
+				seenSources.push(source);
+				return source === mermaidSource ? "Start\n  |\nStop" : null;
+			});
+
+			expect(seenSources).toEqual([mermaidSource]);
+			expect(plainLines).toEqual(["Start", "  |", "Stop"]);
+			expect(plainLines.some(line => line.includes("```mermaid"))).toBeFalsy();
+		});
+
+		it("falls back to the original fenced code block when mermaid resolution returns null", () => {
+			const invalidMermaid = "```mermaid\nflowchart TD\n  A --\n```";
+			const invalidSource = "flowchart TD\n  A --";
+			const seenSources: string[] = [];
+
+			const plainLines = renderMermaidLines(invalidMermaid, source => {
+				seenSources.push(source);
+				return null;
+			});
+
+			expect(seenSources).toEqual([invalidSource]);
+			expect(plainLines).toEqual(["```mermaid", "  flowchart TD", "    A --", "```"]);
+		});
+	});
+
 	describe("Spacing after dividers", () => {
 		it("should have only one blank line between divider and following paragraph", () => {
 			const markdown = new Markdown(


### PR DESCRIPTION
## What
- switch shared Markdown Mermaid rendering from a hash lookup to a source-based resolver callback
- resolve and cache Mermaid ASCII synchronously in the coding-agent theme layer so fenced Mermaid blocks render without assistant-only prerendering
- remove obsolete assistant-message/interative-mode Mermaid prerender wiring and add regression coverage plus changelog entries

## Why
Fixes #650.

Mermaid fenced markdown currently falls back to raw code blocks on non-image terminals because auto-rendering still depends on an old image-protocol-gated prerender path even though Mermaid output is ASCII.

## Testing
- `bun check:ts`
- attempted `bun test packages/tui/test/markdown.test.ts packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts` but this checkout currently fails before test execution with `SyntaxError: export 'Ellipsis' not found in '@oh-my-pi/pi-natives'`
- attempted `bun run build:native` while investigating the runtime test failure, but the local build is currently blocked on stable Rust by `smallvec` specialization

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
