### PR TITLE
fix(coding-agent): resolve workspace typescript lsp startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ pi-*.html
 # Generated files
 packages/coding-agent/src/internal-urls/docs-index.generated.ts
 packages/typescript-edit-benchmark/runs/
+codedb.snapshot

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "lint-staged": "^16.3",
         "prettier": "^3.8",
         "turbo": "^2.5.8",
+        "typescript": "^5.4.5",
       },
     },
     "packages/agent": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
 		"@typescript/native-preview": "^7.0.0-dev.20260302.1",
 		"lint-staged": "^16.3",
 		"prettier": "^3.8",
-		"turbo": "^2.5.8"
+		"turbo": "^2.5.8",
+		"typescript": "^5.4.5"
 	},
 	"lint-staged": {
 		"*.{js,ts,jsx,tsx,json,jsonc,css}": "biome check --write --no-errors-on-unmatched"

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -602,14 +602,10 @@ export interface OllamaModelManagerConfig {
 	baseUrl?: string;
 }
 
-export function ollamaModelManagerOptions(
-	config?: OllamaModelManagerConfig,
-): ModelManagerOptions<"openai-responses"> {
+export function ollamaModelManagerOptions(config?: OllamaModelManagerConfig): ModelManagerOptions<"openai-responses"> {
 	const apiKey = config?.apiKey;
 	const baseUrl = normalizeOllamaBaseUrl(config?.baseUrl);
-	const references = createBundledReferenceMap<"openai-responses">(
-		"ollama" as Parameters<typeof getBundledModels>[0],
-	);
+	const references = createBundledReferenceMap<"openai-responses">("ollama" as Parameters<typeof getBundledModels>[0]);
 	return {
 		providerId: "ollama",
 		fetchDynamicModels: async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed cached Ollama discovery rows so upgraded installs switch to the OpenAI Responses transport instead of staying on the old completions transport
+- Fixed TypeScript LSP startup in Bun workspaces by wiring it to the workspace TypeScript SDK instead of relying on implicit server discovery.
 
 ## [14.0.2] - 2026-04-09
 ### Added

--- a/packages/coding-agent/src/lsp/config.ts
+++ b/packages/coding-agent/src/lsp/config.ts
@@ -127,8 +127,68 @@ function mergeServers(
 	return merged;
 }
 
-function applyRuntimeDefaults(servers: Record<string, ServerConfig>): Record<string, ServerConfig> {
+function getWorkspaceBoundary(cwd: string): string {
+	const boundaryMarkers = [".git", "bun.lock", "bun.lockb", "package-lock.json", "pnpm-workspace.yaml", "yarn.lock"];
+	let packageBoundary: string | null = null;
+	let currentDir = cwd;
+	while (true) {
+		if (packageBoundary === null && fs.existsSync(path.join(currentDir, "package.json"))) {
+			packageBoundary = currentDir;
+		}
+		if (boundaryMarkers.some(marker => fs.existsSync(path.join(currentDir, marker)))) {
+			return currentDir;
+		}
+		const parentDir = path.dirname(currentDir);
+		if (parentDir === currentDir) {
+			return packageBoundary ?? cwd;
+		}
+		currentDir = parentDir;
+	}
+}
+
+function getWorkspaceTsserverPath(cwd: string): string | null {
+	const boundaryDir = getWorkspaceBoundary(cwd);
+	let currentDir = cwd;
+	while (true) {
+		const candidates = [
+			path.join(currentDir, "node_modules/typescript/lib/tsserver.js"),
+			path.join(currentDir, "node_modules/typescript/lib"),
+		];
+		for (const candidate of candidates) {
+			if (fs.existsSync(candidate)) {
+				return candidate;
+			}
+		}
+		if (currentDir === boundaryDir) {
+			return null;
+		}
+		currentDir = path.dirname(currentDir);
+	}
+}
+
+function applyRuntimeDefaults(cwd: string, servers: Record<string, ServerConfig>): Record<string, ServerConfig> {
 	const updated: Record<string, ServerConfig> = { ...servers };
+
+	const typescriptServer = updated["typescript-language-server"];
+	if (typescriptServer) {
+		const tsserverPath = getWorkspaceTsserverPath(cwd);
+		if (tsserverPath) {
+			const initOptions = isRecord(typescriptServer.initOptions) ? { ...typescriptServer.initOptions } : {};
+			const tsserver = isRecord(initOptions.tsserver) ? { ...initOptions.tsserver } : {};
+			if (typeof tsserver.path !== "string" || tsserver.path.length === 0) {
+				updated["typescript-language-server"] = {
+					...typescriptServer,
+					initOptions: {
+						...initOptions,
+						tsserver: {
+							...tsserver,
+							path: tsserverPath,
+						},
+					},
+				};
+			}
+		}
+	}
 
 	if (updated.biome) {
 		updated.biome = { ...updated.biome, createClient: BiomeClient.create };
@@ -183,9 +243,13 @@ export function hasRootMarkers(cwd: string, markers: string[]): boolean {
  * Local bin directories to check before $PATH, ordered by priority.
  * Each entry maps a root marker to the bin directory to check.
  */
-const LOCAL_BIN_PATHS: Array<{ markers: string[]; binDir: string }> = [
-	// Node.js - check node_modules/.bin/
-	{ markers: ["package.json", "package-lock.json", "yarn.lock", "pnpm-lock.yaml"], binDir: "node_modules/.bin" },
+const LOCAL_BIN_PATHS: Array<{ markers: string[]; binDir: string; searchUpToWorkspaceBoundary?: boolean }> = [
+	// Node.js - check node_modules/.bin/ in the current package, then walk up to the workspace root for hoisted binaries.
+	{
+		markers: ["package.json", "package-lock.json", "yarn.lock", "pnpm-lock.yaml"],
+		binDir: "node_modules/.bin",
+		searchUpToWorkspaceBoundary: true,
+	},
 	// Python - check virtual environment bin directories
 	{ markers: ["pyproject.toml", "requirements.txt", "setup.py", "Pipfile"], binDir: ".venv/bin" },
 	{ markers: ["pyproject.toml", "requirements.txt", "setup.py", "Pipfile"], binDir: "venv/bin" },
@@ -198,6 +262,22 @@ const LOCAL_BIN_PATHS: Array<{ markers: string[]; binDir: string }> = [
 ];
 
 const WINDOWS_LOCAL_EXECUTABLE_EXTENSIONS = [".exe", ".cmd", ".bat"] as const;
+
+function getLocalBinSearchDirs(cwd: string, searchUpToWorkspaceBoundary: boolean): string[] {
+	if (!searchUpToWorkspaceBoundary) {
+		return [cwd];
+	}
+	const boundaryDir = getWorkspaceBoundary(cwd);
+	const dirs: string[] = [];
+	let currentDir = cwd;
+	while (true) {
+		dirs.push(currentDir);
+		if (currentDir === boundaryDir) {
+			return dirs;
+		}
+		currentDir = path.dirname(currentDir);
+	}
+}
 
 function resolveLocalCommand(basePath: string): string | null {
 	if (fs.existsSync(basePath)) return basePath;
@@ -222,12 +302,14 @@ function resolveLocalCommand(basePath: string): string | null {
  */
 export function resolveCommand(command: string, cwd: string): string | null {
 	// Check local bin directories based on project markers
-	for (const { markers, binDir } of LOCAL_BIN_PATHS) {
+	for (const { markers, binDir, searchUpToWorkspaceBoundary = false } of LOCAL_BIN_PATHS) {
 		if (hasRootMarkers(cwd, markers)) {
-			const localPath = path.join(cwd, binDir, command);
-			const resolvedLocalPath = resolveLocalCommand(localPath);
-			if (resolvedLocalPath) {
-				return resolvedLocalPath;
+			for (const searchDir of getLocalBinSearchDirs(cwd, searchUpToWorkspaceBoundary)) {
+				const localPath = path.join(searchDir, binDir, command);
+				const resolvedLocalPath = resolveLocalCommand(localPath);
+				if (resolvedLocalPath) {
+					return resolvedLocalPath;
+				}
 			}
 		}
 	}
@@ -335,7 +417,7 @@ export function loadConfig(cwd: string): LspConfig {
 	if (!hasOverrides) {
 		// Auto-detect: find servers based on project markers AND available binaries
 		const detected: Record<string, ServerConfig> = {};
-		const defaultsWithRuntime = applyRuntimeDefaults(mergedServers);
+		const defaultsWithRuntime = applyRuntimeDefaults(cwd, mergedServers);
 
 		for (const [name, config] of Object.entries(defaultsWithRuntime)) {
 			// Check if project has root markers for this language
@@ -352,7 +434,7 @@ export function loadConfig(cwd: string): LspConfig {
 	}
 
 	// Merge overrides with defaults and filter to available servers
-	const mergedWithRuntime = applyRuntimeDefaults(mergedServers);
+	const mergedWithRuntime = applyRuntimeDefaults(cwd, mergedServers);
 	const available: Record<string, ServerConfig> = {};
 
 	for (const [name, config] of Object.entries(mergedWithRuntime)) {

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -253,6 +253,121 @@ describe("lsp regressions", () => {
 		}
 	});
 
+	it("preserves an explicit tsserver path override for TypeScript LSP", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-typescript-override-");
+		const workspacePath = tempDir.path();
+		const workspaceTsserverPath = path.join(workspacePath, "node_modules/typescript/lib/tsserver.js");
+		const configuredTsserverPath = path.join(workspacePath, "custom/typescript/lib/tsserver.js");
+		const languageServerPath = path.join(workspacePath, "node_modules/.bin/typescript-language-server");
+
+		try {
+			await Bun.write(path.join(workspacePath, "package.json"), '{"name":"fixture"}\n');
+			await Bun.write(languageServerPath, "");
+			await Bun.write(workspaceTsserverPath, "");
+			await Bun.write(
+				path.join(workspacePath, "lsp.json"),
+				JSON.stringify({
+					servers: {
+						"typescript-language-server": {
+							initOptions: { tsserver: { path: configuredTsserverPath } },
+						},
+					},
+				}),
+			);
+
+			const config = loadConfig(workspacePath);
+			const server = config.servers["typescript-language-server"];
+
+			expect(server).toBeDefined();
+			expect(server?.initOptions).toMatchObject({
+				tsserver: { path: configuredTsserverPath },
+			});
+		} finally {
+			tempDir.removeSync();
+		}
+	});
+
+	it("finds a hoisted workspace tsserver path from ancestor directories", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-typescript-hoisted-");
+		const repoRoot = tempDir.path();
+		const packagePath = path.join(repoRoot, "packages/coding-agent");
+		const hoistedTsserverPath = path.join(repoRoot, "node_modules/typescript/lib/tsserver.js");
+		const languageServerPath = path.join(repoRoot, "node_modules/.bin/typescript-language-server");
+
+		const whichSpy = vi.spyOn(piUtils, "$which").mockReturnValue(null);
+
+		try {
+			await Bun.write(path.join(repoRoot, ".git"), "gitdir: ./.git/worktrees/test\n");
+			await Bun.write(path.join(repoRoot, "package.json"), '{"name":"fixture-root"}\n');
+			await Bun.write(path.join(packagePath, "package.json"), '{"name":"fixture-package"}\n');
+			await Bun.write(languageServerPath, "");
+			await Bun.write(hoistedTsserverPath, "");
+
+			const config = loadConfig(packagePath);
+			const server = config.servers["typescript-language-server"];
+
+			expect(server).toBeDefined();
+			expect(server?.resolvedCommand).toBe(languageServerPath);
+			expect(server?.initOptions).toMatchObject({
+				tsserver: { path: hoistedTsserverPath },
+			});
+			expect(whichSpy).not.toHaveBeenCalledWith("typescript-language-server");
+		} finally {
+			vi.restoreAllMocks();
+			tempDir.removeSync();
+		}
+	});
+
+	it("does not resolve tsserver paths above the workspace boundary", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-typescript-boundary-");
+		const outerRoot = path.join(tempDir.path(), "outer");
+		const repoRoot = path.join(outerRoot, "repo");
+		const packagePath = path.join(repoRoot, "packages/coding-agent");
+		const outsideTsserverPath = path.join(outerRoot, "node_modules/typescript/lib/tsserver.js");
+		const languageServerPath = path.join(packagePath, "node_modules/.bin/typescript-language-server");
+
+		try {
+			await Bun.write(path.join(repoRoot, ".git"), "gitdir: ./.git/worktrees/test\n");
+			await Bun.write(path.join(repoRoot, "package.json"), '{"name":"fixture-root"}\n');
+			await Bun.write(path.join(packagePath, "package.json"), '{"name":"fixture-package"}\n');
+			await Bun.write(languageServerPath, "");
+			await Bun.write(outsideTsserverPath, "");
+
+			const config = loadConfig(packagePath);
+			const server = config.servers["typescript-language-server"];
+
+			expect(server).toBeDefined();
+			expect(server?.initOptions).not.toMatchObject({
+				tsserver: { path: outsideTsserverPath },
+			});
+		} finally {
+			tempDir.removeSync();
+		}
+	});
+
+	it("prefers a workspace-local tsserver path for TypeScript LSP", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-typescript-");
+		const workspacePath = tempDir.path();
+		const tsserverPath = path.join(workspacePath, "node_modules/typescript/lib/tsserver.js");
+		const languageServerPath = path.join(workspacePath, "node_modules/.bin/typescript-language-server");
+
+		try {
+			await Bun.write(path.join(workspacePath, "package.json"), '{"name":"fixture"}\n');
+			await Bun.write(languageServerPath, "");
+			await Bun.write(tsserverPath, "");
+
+			const config = loadConfig(workspacePath);
+			const server = config.servers["typescript-language-server"];
+
+			expect(server).toBeDefined();
+			expect(server?.initOptions).toMatchObject({
+				tsserver: { path: tsserverPath },
+			});
+		} finally {
+			tempDir.removeSync();
+		}
+	});
+
 	it("detects tlaplus files for LSP startup and language ids", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-tlaplus-");
 		const specPath = path.join(tempDir.path(), "Spec.tla");


### PR DESCRIPTION
## What

Fix TypeScript LSP startup in Bun workspaces by wiring `typescript-language-server` to the workspace TypeScript SDK and by resolving hoisted workspace binaries from the workspace root.

## Why

Starting the agent from a workspace package could fail with `Could not find a valid TypeScript installation` even though the repo was installed correctly. The previous lookup relied on implicit discovery and only checked the current package directory.

## Testing

- `bun test packages/coding-agent/test/tools/lsp-regressions.test.ts`
- `bun check:ts`
- `bun lint:ts`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)