### PR TITLE
fix(lsp): filter informational log lines from LSP startup warnings

### DIFF
--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -436,7 +436,14 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 
 			// Reject any pending requests — the server is gone, they will never complete.
 			if (client.pendingRequests.size > 0) {
-				const stderr = proc.peekStderr().trim();
+				// Strip informational log lines (e.g. marksman's [INF]/[DBG] prefix)
+				// — they are startup noise, not actionable errors.
+				const rawStderr = proc.peekStderr().trim();
+				const stderr = rawStderr
+					.split("\n")
+					.filter(line => !/^\[\d{2}:\d{2}:\d{2} (?:INF|DBG|VRB)\]/.test(line))
+					.join("\n")
+					.trim();
 				const code = proc.exitCode;
 				const err = new Error(
 					stderr ? `LSP server exited (code ${code}): ${stderr}` : `LSP server exited unexpectedly (code ${code})`,

--- a/packages/coding-agent/src/lsp/defaults.json
+++ b/packages/coding-agent/src/lsp/defaults.json
@@ -857,7 +857,8 @@
 		"rootMarkers": [
 			".marksman.toml",
 			".git"
-		]
+		],
+		"warmupTimeoutMs": 15000
 	},
 	"texlab": {
 		"command": "texlab",


### PR DESCRIPTION
## What

Filter `[INF]`/`[DBG]`/`[VRB]` timestamped lines from LSP `peekStderr()` before including them in error messages. Give marksman a 15s `warmupTimeoutMs` (up from 5s default).

## Why

Fixes #667. On arm64, marksman's .NET runtime takes >5s to respond to `initialize`, so it gets killed by the warmup timeout. The warning then includes marksman's own startup logs:

**Before:**
```
Warning: LSP startup failed for marksman: LSP server exited (code null):
[19:50:13 INF] <LSP Entry> Starting Marksman LSP server: {"arch": "Arm64"...}
[19:50:13 INF] <Folder> Loading folder documents: {"uri": "file:///workspace"}. It will retry lazily on write.
```

**After:** (filtered — only real errors surface)
```
Warning: LSP startup failed for marksman: LSP server exited unexpectedly (code null). It will retry lazily on write.
```

Or with 15s timeout, marksman responds in time and no warning appears at all.

## Testing

Reproduced on linux-arm64 (marksman 2026-02-08, Bun 1.3.11). Verified the regex keeps `[WRN]`/`[ERR]` lines and plain error messages while filtering `[INF]`/`[DBG]`/`[VRB]`. Shipped in our fork as v14.3.1 — no regressions.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
