### PR TITLE
fix(cursor): resolve context loss and tool card ordering

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -949,19 +949,35 @@ export class Agent {
 			}
 		}
 
-		// If no text or split point is 0 or at/past end, don't split
-		if (fullText.length === 0 || splitPoint <= 0 || splitPoint >= fullText.length) {
-			// Emit assistant message first, then tool results (original behavior but with buffered results)
+		// If no text or split point is at/past end, don't split
+		if (fullText.length === 0 || splitPoint >= fullText.length) {
+			// Emit assistant message first, then tool results
 			this.#state.streamMessage = null;
 			this.appendMessage(assistantMessage);
 			this.#emit({ type: "message_end", message: assistantMessage });
 
-			// Emit buffered tool results
 			for (const { toolResult } of buffer) {
 				this.#emit({ type: "message_start", message: toolResult });
 				this.appendMessage(toolResult);
 				this.#emit({ type: "message_end", message: toolResult });
 			}
+			return;
+		}
+
+		// splitPoint === 0 means tools executed before any assistant text arrived.
+		// This is the typical Cursor flow: tool runs first, then the model composes
+		// its response referencing the tool output.  Emit tool results first.
+		if (splitPoint <= 0) {
+			this.#state.streamMessage = null;
+
+			for (const { toolResult } of buffer) {
+				this.#emit({ type: "message_start", message: toolResult });
+				this.appendMessage(toolResult);
+				this.#emit({ type: "message_end", message: toolResult });
+			}
+
+			this.appendMessage(assistantMessage);
+			this.#emit({ type: "message_end", message: assistantMessage });
 			return;
 		}
 

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -2262,9 +2262,6 @@ function buildGrpcRequest(
 		},
 	});
 
-	// Build conversation turns from prior messages (excluding the last user message)
-	const turns = buildConversationTurns(context.messages, blobStore);
-
 	// When a server checkpoint exists, use it as-is. The checkpoint contains
 	// server-generated blob references (turns, rootPromptMessagesJson) that must
 	// stay in sync with the server's state.  The server may inject additional
@@ -2273,22 +2270,30 @@ function buildGrpcRequest(
 	// incorrectly discard valid checkpoints.
 	// Only fall back to locally built state for the very first message in a
 	// new conversation (no checkpoint yet).
-	const conversationState = state.conversationState
-		? state.conversationState
-		: create(ConversationStateStructureSchema, {
-				rootPromptMessagesJson: [systemPromptId],
-				turns: turns.length > 0 ? turns : [],
-				todos: [],
-				pendingToolCalls: [],
-				previousWorkspaceUris: [],
-				fileStates: {},
-				fileStatesV2: {},
-				summaryArchives: [],
-				turnTimings: [],
-				subagentStates: {},
-				selfSummaryCount: 0,
-				readPaths: [],
-			});
+	//
+	// We also skip buildConversationTurns entirely when a checkpoint exists to
+	// avoid unnecessary blob store churn: each call generates fresh UUIDs for
+	// historical user messages, producing new hashes for identical content.
+	let conversationState: ConversationStateStructure;
+	if (state.conversationState) {
+		conversationState = state.conversationState;
+	} else {
+		const turns = buildConversationTurns(context.messages, blobStore);
+		conversationState = create(ConversationStateStructureSchema, {
+			rootPromptMessagesJson: [systemPromptId],
+			turns: turns.length > 0 ? turns : [],
+			todos: [],
+			pendingToolCalls: [],
+			previousWorkspaceUris: [],
+			fileStates: {},
+			fileStatesV2: {},
+			summaryArchives: [],
+			turnTimings: [],
+			subagentStates: {},
+			selfSummaryCount: 0,
+			readPaths: [],
+		});
+	}
 
 	const modelDetails = create(ModelDetailsSchema, {
 		modelId: model.id,

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -366,6 +366,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 
 			let pendingBuffer = Buffer.alloc(0);
 			let endStreamError: Error | null = null;
+			const pendingHandlers: Promise<void>[] = [];
 			let currentTextBlock: (TextContent & { index: number }) | null = null;
 			let currentThinkingBlock: (ThinkingContent & { index: number }) | null = null;
 			let currentToolCall: ToolCallState | null = null;
@@ -429,7 +430,7 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 						const isTurnEnded =
 							serverMessage.message.case === "interactionUpdate" &&
 							serverMessage.message.value.message?.case === "turnEnded";
-						void handleServerMessage(
+						const handlerPromise = handleServerMessage(
 							serverMessage,
 							output,
 							stream,
@@ -444,13 +445,16 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 						).catch(error => {
 							log("error", "handleServerMessage", { error: String(error) });
 						});
+						pendingHandlers.push(handlerPromise);
 
 						// Resolve only on explicit turnEnded. stopReason defaults to "stop"
 						// and is not a reliable signal for stream completion.
+						// Wait for all in-flight handlers (especially tool executions) to
+						// finish before resolving, so context.messages is fully populated.
 						if (isTurnEnded && resolveH2) {
 							const r = resolveH2;
 							resolveH2 = undefined;
-							r();
+							Promise.all(pendingHandlers).then(() => r());
 						}
 					} catch (e) {
 						log("error", "parseServerMessage", { error: String(e) });
@@ -490,7 +494,9 @@ export const streamCursor: StreamFunction<"cursor-agent"> = (
 						reject(endStreamError);
 						return;
 					}
-					resolve();
+					// Wait for all in-flight handlers before resolving,
+					// ensuring tool results are fully processed.
+					Promise.all(pendingHandlers).then(() => resolve());
 				});
 
 				h2Request!.on("error", reject);
@@ -2106,9 +2112,11 @@ function extractAssistantMessageText(msg: Message): string {
  * Convert context.messages to Cursor's serialized ConversationTurn format.
  * Groups messages into turns: each turn is a user message followed by the assistant's response.
  * Excludes the last user message (which goes in the action).
- * Returns serialized bytes for ConversationStateStructure.turns field.
+ * Returns blob IDs (sha256 hashes) for ConversationStateStructure.turns field.
+ * The actual serialized turn data is stored in blobStore so the server can
+ * retrieve it via getBlobArgs.
  */
-function buildConversationTurns(messages: Message[]): Uint8Array[] {
+function buildConversationTurns(messages: Message[], blobStore: Map<string, Uint8Array>): Uint8Array[] {
 	const turns: Uint8Array[] = [];
 
 	// Find turn boundaries - each turn starts with a user message
@@ -2193,7 +2201,13 @@ function buildConversationTurns(messages: Message[]): Uint8Array[] {
 				value: agentTurn,
 			},
 		});
-		turns.push(toBinary(ConversationTurnStructureSchema, turn));
+		const turnBytes = toBinary(ConversationTurnStructureSchema, turn);
+		// Store the serialized turn data in the blob store and record
+		// only the blob ID (sha256 hash) in the turns array.  The server
+		// fetches the actual data via getBlobArgs using this ID.
+		const turnBlobId = createBlobId(turnBytes);
+		blobStore.set(Buffer.from(turnBlobId).toString("hex"), turnBytes);
+		turns.push(turnBlobId);
 	}
 
 	return turns;
@@ -2249,37 +2263,32 @@ function buildGrpcRequest(
 	});
 
 	// Build conversation turns from prior messages (excluding the last user message)
-	const turns = buildConversationTurns(context.messages);
+	const turns = buildConversationTurns(context.messages, blobStore);
 
-	const hasMatchingPrompt = state.conversationState?.rootPromptMessagesJson?.some(entry =>
-		Buffer.from(entry).equals(systemPromptId),
-	);
-
-	// Use cached state if available and system prompt matches, but always update turns
-	// from context.messages to ensure full conversation history is sent
-	const baseState =
-		state.conversationState && hasMatchingPrompt
-			? state.conversationState
-			: create(ConversationStateStructureSchema, {
-					rootPromptMessagesJson: [systemPromptId],
-					turns: [],
-					todos: [],
-					pendingToolCalls: [],
-					previousWorkspaceUris: [],
-					fileStates: {},
-					fileStatesV2: {},
-					summaryArchives: [],
-					turnTimings: [],
-					subagentStates: {},
-					selfSummaryCount: 0,
-					readPaths: [],
-				});
-
-	// Always populate turns from context.messages to ensure Cursor sees full conversation
-	const conversationState = create(ConversationStateStructureSchema, {
-		...baseState,
-		turns: turns.length > 0 ? turns : baseState.turns,
-	});
+	// When a server checkpoint exists, use it as-is. The checkpoint contains
+	// server-generated blob references (turns, rootPromptMessagesJson) that must
+	// stay in sync with the server's state.  The server may inject additional
+	// system prompts (e.g. Cursor's internal instructions) so our systemPromptId
+	// won't necessarily appear in rootPromptMessagesJson — matching on it would
+	// incorrectly discard valid checkpoints.
+	// Only fall back to locally built state for the very first message in a
+	// new conversation (no checkpoint yet).
+	const conversationState = state.conversationState
+		? state.conversationState
+		: create(ConversationStateStructureSchema, {
+				rootPromptMessagesJson: [systemPromptId],
+				turns: turns.length > 0 ? turns : [],
+				todos: [],
+				pendingToolCalls: [],
+				previousWorkspaceUris: [],
+				fileStates: {},
+				fileStatesV2: {},
+				summaryArchives: [],
+				turnTimings: [],
+				subagentStates: {},
+				selfSummaryCount: 0,
+				readPaths: [],
+			});
 
 	const modelDetails = create(ModelDetailsSchema, {
 		modelId: model.id,

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -247,7 +247,19 @@ export class EventController {
 						content.id,
 					);
 					component.setExpanded(this.ctx.toolOutputExpanded);
-					this.ctx.chatContainer.addChild(component);
+					// When a tool fires during assistant streaming (typical for Cursor
+					// exec tools), insert the tool card *before* the in-progress
+					// assistant component so it appears above the response text.
+					if (this.ctx.streamingComponent) {
+						const idx = this.ctx.chatContainer.children.indexOf(this.ctx.streamingComponent);
+						if (idx !== -1) {
+							this.ctx.chatContainer.children.splice(idx, 0, component);
+						} else {
+							this.ctx.chatContainer.addChild(component);
+						}
+					} else {
+						this.ctx.chatContainer.addChild(component);
+					}
 					this.ctx.pendingTools.set(content.id, component);
 				} else {
 					const component = this.ctx.pendingTools.get(content.id);


### PR DESCRIPTION
Fixes #134

## Summary

This PR fixes the two remaining Cursor provider regressions introduced after #555 (stream hang fix):

1. **Context loss across conversation turns** — second-turn requests lost all prior context
2. **Tool card ordering** — tool execution cards rendered below the assistant's text summary instead of above

## Changes

### `packages/ai/src/providers/cursor.ts`

- **Race condition**: `handleServerMessage` was fire-and-forget (`void`). Collected promises in `pendingHandlers[]` and `await Promise.all()` before resolving the turn, so tool results are fully processed before `turnEnded` fires.
- **Blob ID format**: `buildConversationTurns` was putting raw serialized protobuf bytes into `turns[]`, but the server treats those entries as blob ID lookups (sha256 hashes). Now hashes turn data with `createBlobId()` and stores the actual bytes in `blobStore`.
- **Checkpoint usage**: Removed `hasMatchingPrompt` guard that was always `false` (server injects 4 system prompt blobs that never match the client's `systemPromptId`). Always reuses the server-provided `conversationCheckpointUpdate` when available.

### `packages/agent/src/agent.ts`

- When `splitPoint === 0` (tools executed before any assistant text — typical Cursor flow), emit tool results **before** the assistant message instead of after.

### `packages/coding-agent/src/modes/controllers/event-controller.ts`

- When `tool_execution_start` fires while `streamingComponent` is active (Cursor exec tools fire mid-stream), splice the tool card **before** the streaming assistant component so it renders above the response text.
- **Safe for other providers**: For Anthropic/OpenAI, `tool_execution_start` always fires after `message_end` clears `streamingComponent`, so the original `addChild` path is taken unchanged.

## Testing

- Verified context is preserved across multiple conversation turns with Cursor provider
- Verified tool cards render above assistant text summaries
- Verified Anthropic provider behavior is unchanged