### PR TITLE
Fix compiled native addon drift in bundled builds

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed compiled release builds to rebuild and embed matching native addons before packaging, preventing startup crashes from stale native binaries ([#670](https://github.com/can1357/oh-my-pi/issues/670))
+
 ## [14.0.3] - 2026-04-09
 
 ### Fixed

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -31,7 +31,7 @@
 		"omp": "src/cli.ts"
 	},
 	"scripts": {
-		"build": "bun --cwd=../stats scripts/generate-client-bundle.ts --generate && bun --cwd=../natives run embed:native && bun build --compile --define PI_COMPILED=true --external mupdf --root ../.. ./src/cli.ts --outfile dist/omp && bun --cwd=../natives run embed:native --reset && bun --cwd=../stats scripts/generate-client-bundle.ts --reset",
+		"build": "bun --cwd=../stats scripts/generate-client-bundle.ts --generate && bun --cwd=../natives run build && bun --cwd=../natives run embed:native && bun build --compile --define PI_COMPILED=true --external mupdf --root ../.. ./src/cli.ts --outfile dist/omp && bun --cwd=../natives run embed:native --reset && bun --cwd=../stats scripts/generate-client-bundle.ts --reset",
 		"check": "biome check . && bun run check:types",
 		"check:types": "tsgo -p tsconfig.json --noEmit",
 		"lint": "biome lint .",

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored native loader export validation and made compiled builds prefer bundled addons over stale extracted caches, preventing `setDefaultTabWidth` startup crashes in compiled binaries ([#670](https://github.com/can1357/oh-my-pi/issues/670))
+
 ## [14.0.2] - 2026-04-09
 
 ### Added

--- a/packages/natives/scripts/build-native.ts
+++ b/packages/natives/scripts/build-native.ts
@@ -2,6 +2,7 @@ import * as fsSync from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { $ } from "bun";
+import { patchNativeLoader } from "./patch-loader";
 
 const repoRoot = path.join(import.meta.dir, "../../..");
 const rustDir = path.join(repoRoot, "crates/pi-natives");
@@ -137,29 +138,9 @@ async function installBinary(src: string, dest: string): Promise<void> {
 }
 async function patchGeneratedIndexLoader(): Promise<void> {
 	const indexPath = path.join(nativeDir, "index.js");
-	let content = await Bun.file(indexPath).text();
-	const embeddedLoadPatch = "let embeddedAddon = null;\n";
-	if (!content.includes(embeddedLoadPatch)) {
-		content = content.replace(/const \{ embeddedAddon \} = require\("\.\/embedded-addon"\);\n/, embeddedLoadPatch);
-	}
-	const lazyLoadPatch = [
-		"if (isCompiledBinary) {",
-		"\ttry {",
-		'\t\t({ embeddedAddon } = require("./embedded-addon"));',
-		"\t} catch {",
-		"\t\tembeddedAddon = null;",
-		"\t}",
-		"}",
-		"",
-	].join("\n");
-	if (!content.includes(lazyLoadPatch)) {
-		content = content.replace(
-			/(const isCompiledBinary =[\s\S]*?__filename\.includes\("%7EBUN"\);\n)/,
-			`$1\n${lazyLoadPatch}`,
-		);
-	}
-	await Bun.write(indexPath, content);
+	await patchNativeLoader(indexPath);
 }
+
 
 async function resolveBuiltAddonPath(canonicalFilename: string): Promise<string> {
 	// Variant-tagged files produced by previous invocations of this script that

--- a/packages/natives/scripts/embed-native.ts
+++ b/packages/natives/scripts/embed-native.ts
@@ -1,8 +1,10 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { patchNativeLoader } from "./patch-loader";
 
 const reset = process.argv.includes("--reset");
 const outputPath = path.join(import.meta.dir, "../native/embedded-addon.js");
+const indexPath = path.join(import.meta.dir, "../native/index.js");
 const packageJsonPath = path.join(import.meta.dir, "../package.json");
 const nativeDir = path.join(import.meta.dir, "../native");
 
@@ -29,6 +31,8 @@ const stubContent = `
 /** @type {EmbeddedAddon|null} */
 export const embeddedAddon = null;
 `;
+await patchNativeLoader(indexPath);
+
 if (reset) {
 	await Bun.write(outputPath, stubContent);
 	process.exit(0);
@@ -119,3 +123,4 @@ ${files}
 `;
 
 await Bun.write(outputPath, content);
+await patchNativeLoader(indexPath);

--- a/packages/natives/scripts/patch-loader.ts
+++ b/packages/natives/scripts/patch-loader.ts
@@ -1,0 +1,145 @@
+export const REQUIRED_EXPORTS = [
+	"astEdit",
+	"astGrep",
+	"ChunkState",
+	"copyToClipboard",
+	"detectMacOSAppearance",
+	"encodeSixel",
+	"executeShell",
+	"extractSegments",
+	"getDefaultTabWidth",
+	"getIndentation",
+	"getSupportedLanguages",
+	"getWorkProfile",
+	"glob",
+	"grep",
+	"highlightCode",
+	"htmlToMarkdown",
+	"invalidateFsScanCache",
+	"killTree",
+	"listDescendants",
+	"MacAppearanceObserver",
+	"matchesKey",
+	"matchesKittySequence",
+	"matchesLegacySequence",
+	"parseKey",
+	"parseKittySequence",
+	"PhotonImage",
+	"projfsOverlayProbe",
+	"projfsOverlayStart",
+	"projfsOverlayStop",
+	"PtySession",
+	"readImageFromClipboard",
+	"sanitizeText",
+	"SearchDb",
+	"search",
+	"setDefaultTabWidth",
+	"Shell",
+	"sliceWithWidth",
+	"supportsLanguage",
+	"truncateToWidth",
+	"visibleWidth",
+	"wrapTextWithAnsi",
+] as const;
+
+const embeddedLoadPatch = "let embeddedAddon = null;\n";
+const lazyLoadPatch = [
+	"if (isCompiledBinary) {",
+	"\ttry {",
+	'\t\t({ embeddedAddon } = require("./embedded-addon"));',
+	"\t} catch {",
+	"\t\tembeddedAddon = null;",
+	"\t}",
+	"}",
+	"",
+].join("\n");
+
+const requiredExportsBlock = `const REQUIRED_EXPORTS = [\n${REQUIRED_EXPORTS.map(name => `\t"${name}",`).join("\n")}\n];\n\nfunction validateNative(bindings) {\n\tconst missing = REQUIRED_EXPORTS.filter(name => typeof bindings[name] !== "function");\n\tif (missing.length === 0) {\n\t\treturn bindings;\n\t}\n\n\tthrow new Error(\`Native addon missing required exports: \${missing.join(", ")}\`);\n}\n\n`;
+
+const maybeExtractEmbeddedAddonBlock = `function maybeExtractEmbeddedAddon(errors) {\n\tif (!isCompiledBinary || !embeddedAddon) return null;\n\tif (embeddedAddon.platformTag !== platformTag || embeddedAddon.version !== packageVersion) return null;\n\n\tconst selectedEmbeddedFile = selectEmbeddedAddonFile();\n\tif (!selectedEmbeddedFile) return null;\n\tconst targetPath = path.join(versionedDir, selectedEmbeddedFile.filename);\n\n\ttry {\n\t\tfs.mkdirSync(versionedDir, { recursive: true });\n\t} catch (err) {\n\t\tconst message = err instanceof Error ? err.message : String(err);\n\t\terrors.push(\`embedded addon dir: \${message}\`);\n\t\treturn null;\n\t}\n\n\tlet embeddedBuffer;\n\ttry {\n\t\tembeddedBuffer = fs.readFileSync(selectedEmbeddedFile.filePath);\n\t} catch (err) {\n\t\tconst message = err instanceof Error ? err.message : String(err);\n\t\terrors.push(\`embedded addon read (\${selectedEmbeddedFile.filename}): \${message}\`);\n\t\treturn null;\n\t}\n\n\tif (fs.existsSync(targetPath)) {\n\t\ttry {\n\t\t\tconst cachedBuffer = fs.readFileSync(targetPath);\n\t\t\tif (cachedBuffer.equals(embeddedBuffer)) {\n\t\t\t\treturn targetPath;\n\t\t\t}\n\t\t\tif (process.env.PI_DEV) {\n\t\t\t\tconsole.warn(\`Embedded addon differs from cached copy \${targetPath}; using bundled payload\`);\n\t\t\t}\n\t\t\treturn selectedEmbeddedFile.filePath;\n\t\t} catch (err) {\n\t\t\tconst message = err instanceof Error ? err.message : String(err);\n\t\t\terrors.push(\`embedded addon compare (\${selectedEmbeddedFile.filename}): \${message}\`);\n\t\t\treturn selectedEmbeddedFile.filePath;\n\t\t}\n\t}\n\n\ttry {\n\t\tfs.writeFileSync(targetPath, embeddedBuffer);\n\t\treturn targetPath;\n\t} catch (err) {\n\t\tconst message = err instanceof Error ? err.message : String(err);\n\t\terrors.push(\`embedded addon write (\${selectedEmbeddedFile.filename}): \${message}\`);\n\t\treturn selectedEmbeddedFile.filePath;\n\t}\n}\n\n`;
+
+const oldLoadNativeSnippet = [
+	"\tconst embeddedCandidate = maybeExtractEmbeddedAddon(errors);",
+	"\tconst runtimeCandidates = embeddedCandidate ? [embeddedCandidate, ...dedupedCandidates] : dedupedCandidates;",
+	"\tfor (const candidate of runtimeCandidates) {",
+	"\t\ttry {",
+	"\t\t\tconst bindings = require_(candidate);",
+	"\t\t\tif (process.env.PI_DEV) {",
+	"\t\t\t\tconsole.log(`Loaded native addon from ${candidate}`);",
+	"\t\t\t}",
+	"\t\t\treturn bindings;",
+].join("\n");
+
+const newLoadNativeSnippet = [
+	"\tconst embeddedCandidate = maybeExtractEmbeddedAddon(errors);",
+	"\tconst runtimeCandidates = embeddedCandidate ? [...new Set([embeddedCandidate, ...dedupedCandidates])] : dedupedCandidates;",
+	"\tfor (const candidate of runtimeCandidates) {",
+	"\t\ttry {",
+	"\t\t\tconst bindings = validateNative(require_(candidate));",
+	"\t\t\tif (process.env.PI_DEV) {",
+	"\t\t\t\tconsole.log(`Loaded native addon from ${candidate}`);",
+	"\t\t\t}",
+	"\t\t\treturn bindings;",
+].join("\n");
+
+function insertBefore(content: string, marker: string, block: string, description: string): string {
+	if (content.includes(block)) {
+		return content;
+	}
+
+	const index = content.indexOf(marker);
+	if (index === -1) {
+		throw new Error(`Could not patch native loader: missing ${description}.`);
+	}
+	return `${content.slice(0, index)}${block}${content.slice(index)}`;
+}
+
+function replaceOnce(content: string, from: string, to: string, description: string): string {
+	if (content.includes(to)) {
+		return content;
+	}
+	if (!content.includes(from)) {
+		throw new Error(`Could not patch native loader: missing ${description}.`);
+	}
+	return content.replace(from, to);
+}
+
+function replaceBetween(content: string, startMarker: string, endMarker: string, replacement: string, description: string): string {
+	const startIndex = content.indexOf(startMarker);
+	if (startIndex === -1) {
+		throw new Error(`Could not patch native loader: missing ${description} start marker.`);
+	}
+	const endIndex = content.indexOf(endMarker, startIndex);
+	if (endIndex === -1) {
+		throw new Error(`Could not patch native loader: missing ${description} end marker.`);
+	}
+
+	const current = content.slice(startIndex, endIndex);
+	if (current === replacement) {
+		return content;
+	}
+	return `${content.slice(0, startIndex)}${replacement}${content.slice(endIndex)}`;
+}
+
+export async function patchNativeLoader(indexPath: string): Promise<void> {
+	let content = await Bun.file(indexPath).text();
+
+	if (!content.includes(embeddedLoadPatch)) {
+		content = content.replace(/const \{ embeddedAddon \} = require\("\.\/embedded-addon"\);\n/, embeddedLoadPatch);
+	}
+	if (!content.includes(lazyLoadPatch)) {
+		content = content.replace(/(const isCompiledBinary =[\s\S]*?__filename\.includes\("%7EBUN"\);\n)/, `$1\n${lazyLoadPatch}`);
+	}
+
+	content = insertBefore(content, "function runCommand(command, args) {\n", requiredExportsBlock, "validation block");
+	content = replaceBetween(
+		content,
+		"function maybeExtractEmbeddedAddon(errors) {\n",
+		"function loadNative() {\n",
+		maybeExtractEmbeddedAddonBlock,
+		"embedded addon extraction block",
+	);
+	content = replaceOnce(content, oldLoadNativeSnippet, newLoadNativeSnippet, "loadNative candidate validation block");
+
+	await Bun.write(indexPath, content);
+}

--- a/packages/natives/test/loader-compat.test.ts
+++ b/packages/natives/test/loader-compat.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import * as os from "node:os";
+import * as path from "node:path";
+import { REQUIRED_EXPORTS, patchNativeLoader } from "../scripts/patch-loader";
+
+const require_ = createRequire(import.meta.url);
+const loaderSourcePath = path.join(import.meta.dir, "../native/index.js");
+const packageVersion = "99.99.99";
+const tabWidthExports = new Set(["setDefaultTabWidth", "getDefaultTabWidth", "getIndentation"]);
+const classExports = new Set([
+	"ChunkState",
+	"MacAppearanceObserver",
+	"PhotonImage",
+	"PtySession",
+	"SearchDb",
+	"Shell",
+]);
+
+interface LoaderFixture {
+	rootDir: string;
+	loaderPath: string;
+	nativeDir: string;
+	platformTag: string;
+	canonicalFilename: string;
+	xdgDataHome: string;
+	versionedDir: string;
+}
+
+async function createLoaderFixture(): Promise<LoaderFixture> {
+	const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-natives-loader-"));
+	const nativeDir = path.join(rootDir, "native");
+	const loaderPath = path.join(nativeDir, "index.js");
+	const xdgDataHome = path.join(rootDir, "xdg");
+	const versionedDir = path.join(xdgDataHome, "omp", "natives", packageVersion);
+	const platformTag = `${process.platform}-${process.arch}`;
+	const canonicalFilename =
+		process.arch === "x64"
+			? `pi_natives.${platformTag}-baseline.node`
+			: `pi_natives.${platformTag}.node`;
+
+	await fs.mkdir(nativeDir, { recursive: true });
+	await fs.mkdir(path.join(xdgDataHome, "omp"), { recursive: true });
+	await Bun.write(path.join(rootDir, "package.json"), JSON.stringify({ version: packageVersion }, null, 2));
+	await Bun.write(loaderPath, await Bun.file(loaderSourcePath).text());
+	await patchNativeLoader(loaderPath);
+
+	return { rootDir, loaderPath, nativeDir, platformTag, canonicalFilename, xdgDataHome, versionedDir };
+}
+
+function buildAddonModule(includeTabWidthExports: boolean): string {
+	const lines = ["let tabWidth = 3;", "module.exports = {"];
+
+	for (const name of REQUIRED_EXPORTS) {
+		if (!includeTabWidthExports && tabWidthExports.has(name)) {
+			continue;
+		}
+		if (name === "setDefaultTabWidth") {
+			lines.push(`\t${name}(value) { tabWidth = value; },`);
+			continue;
+		}
+		if (name === "getDefaultTabWidth" || name === "getIndentation") {
+			lines.push(`\t${name}() { return tabWidth; },`);
+			continue;
+		}
+		if (classExports.has(name)) {
+			lines.push(`\t${name}: class ${name} {},`);
+			continue;
+		}
+		lines.push(`\t${name}() {},`);
+	}
+
+	lines.push("};", "");
+	return lines.join("\n");
+}
+
+function installFakeNodeExtension(): () => void {
+	const extensions = require_.extensions as NodeJS.RequireExtensions;
+	const original = extensions[".node"];
+	const jsLoader = extensions[".js"];
+	if (!jsLoader) {
+		throw new Error("Missing .js loader");
+	}
+	extensions[".node"] = jsLoader;
+	return () => {
+		if (original) {
+			extensions[".node"] = original;
+		} else {
+			delete extensions[".node"];
+		}
+	};
+}
+
+function purgeRequireCache(rootDir: string): void {
+	for (const key of Object.keys(require_.cache)) {
+		if (key.startsWith(rootDir)) {
+			delete require_.cache[key];
+		}
+	}
+}
+
+function restoreEnv(key: string, previous: string | undefined): void {
+	if (previous === undefined) {
+		delete process.env[key];
+		return;
+	}
+	process.env[key] = previous;
+}
+
+describe("native loader compatibility", () => {
+	it("prefers the bundled embedded addon when a cached compiled addon is stale", async () => {
+		const fixture = await createLoaderFixture();
+		const restoreNodeExtension = installFakeNodeExtension();
+		const previousCompiled = process.env.PI_COMPILED;
+		const previousVariant = process.env.PI_NATIVE_VARIANT;
+		const previousXdg = process.env.XDG_DATA_HOME;
+
+		try {
+			process.env.PI_COMPILED = "1";
+			if (process.arch === "x64") {
+				process.env.PI_NATIVE_VARIANT = "baseline";
+			}
+			process.env.XDG_DATA_HOME = fixture.xdgDataHome;
+
+			const bundledPath = path.join(fixture.rootDir, "bundled-addon.node");
+			await Bun.write(bundledPath, buildAddonModule(true));
+			await Bun.write(
+				path.join(fixture.nativeDir, "embedded-addon.js"),
+				[
+					"module.exports = {",
+					`\tembeddedAddon: {`,
+					`\t\tplatformTag: ${JSON.stringify(fixture.platformTag)},`,
+					`\t\tversion: ${JSON.stringify(packageVersion)},`,
+					`\t\tfiles: [{ variant: ${JSON.stringify(process.arch === "x64" ? "baseline" : "default")}, filename: ${JSON.stringify(fixture.canonicalFilename)}, filePath: ${JSON.stringify(bundledPath)} }],`,
+					"\t}",
+					"};",
+					"",
+				].join("\n"),
+			);
+			await fs.mkdir(fixture.versionedDir, { recursive: true });
+			await Bun.write(path.join(fixture.versionedDir, fixture.canonicalFilename), buildAddonModule(false));
+
+			purgeRequireCache(fixture.rootDir);
+			const native = require_(fixture.loaderPath) as {
+				setDefaultTabWidth(width: number): void;
+				getDefaultTabWidth(): number;
+				getIndentation(): number;
+			};
+			native.setDefaultTabWidth(5);
+			expect(native.getDefaultTabWidth()).toBe(5);
+			expect(native.getIndentation()).toBe(5);
+		} finally {
+			purgeRequireCache(fixture.rootDir);
+			restoreNodeExtension();
+			restoreEnv("PI_COMPILED", previousCompiled);
+			restoreEnv("PI_NATIVE_VARIANT", previousVariant);
+			restoreEnv("XDG_DATA_HOME", previousXdg);
+			await fs.rm(fixture.rootDir, { recursive: true, force: true });
+		}
+	});
+
+	it("fails fast with explicit missing export names when only a stale addon is available", async () => {
+		const fixture = await createLoaderFixture();
+		const restoreNodeExtension = installFakeNodeExtension();
+		const previousCompiled = process.env.PI_COMPILED;
+		const previousVariant = process.env.PI_NATIVE_VARIANT;
+		const previousXdg = process.env.XDG_DATA_HOME;
+
+		try {
+			delete process.env.PI_COMPILED;
+			if (process.arch === "x64") {
+				process.env.PI_NATIVE_VARIANT = "baseline";
+			}
+			delete process.env.XDG_DATA_HOME;
+			await Bun.write(path.join(fixture.nativeDir, fixture.canonicalFilename), buildAddonModule(false));
+
+			purgeRequireCache(fixture.rootDir);
+			expect(() => require_(fixture.loaderPath)).toThrow(
+				/Native addon missing required exports: .*setDefaultTabWidth.*getDefaultTabWidth.*getIndentation/,
+			);
+		} finally {
+			purgeRequireCache(fixture.rootDir);
+			restoreNodeExtension();
+			restoreEnv("PI_COMPILED", previousCompiled);
+			restoreEnv("PI_NATIVE_VARIANT", previousVariant);
+			restoreEnv("XDG_DATA_HOME", previousXdg);
+			await fs.rm(fixture.rootDir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- restore native loader export validation so stale addons fail fast instead of crashing later in settings hooks
- make compiled-mode extraction prefer the bundled addon when the cached same-version payload is stale
- rebuild pi-natives before packaging compiled coding-agent binaries and cover the stale-cache path with a loader regression test

## Verification
- targeted loader simulation reproducing a stale extracted addon missing tab-width exports alongside a fresh embedded payload now resolves the bundled addon and succeeds

Fixes #670