### PR TITLE
fix: grep tool silently mangles pi:// URLs and produces misleading Path not found error

### DIFF
--- a/packages/coding-agent/src/internal-urls/pi-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/pi-protocol.ts
@@ -45,7 +45,6 @@ export class PiProtocolHandler implements ProtocolHandler {
 			content,
 			contentType: "text/markdown",
 			size: Buffer.byteLength(content, "utf-8"),
-			sourcePath: "pi://",
 		};
 	}
 
@@ -78,7 +77,6 @@ export class PiProtocolHandler implements ProtocolHandler {
 			content,
 			contentType: "text/markdown",
 			size: Buffer.byteLength(content, "utf-8"),
-			sourcePath: `pi://${normalized}`,
 		};
 	}
 }


### PR DESCRIPTION
 ##  Fixes #657

**Repro:**

In any session, call the `grep` tool with a `pi://` URL as `path`:

```
grep(pattern="anything", path="pi://session.md")
```

**Actual error:**
```
Path not found: pi:/session.md
```

**Expected error:**
```
Cannot grep internal URL without a backing file: pi://session.md
```


   `pi://` documents are embedded in memory at build time — there is no filesystem backing. Setting `sourcePath` to the virtual `pi://` string caused the `grep` tool's truthy-check guard to be bypassed, after which the virtual path was passed
 to `Bun.file().stat()`. `path.relative` then collapsed `//` → `/`, producing the misleading `Path not found: pi:/session.md` error.

   ## Fix

   Remove `sourcePath` from both `#listDocs` and `#readDoc` return values in `src/internal-urls/pi-protocol.ts`. `undefined` is the correct signal to filesystem tools that no backing file exists, which lets the existing guard in `grep.ts` fire
 correctly.

   ## Verification

   - `read(path="pi://session.md")` — unchanged, still works
   - `grep(pattern="x", path="pi://session.md")` — now returns `Cannot grep internal URL without a backing file: pi://session.md`
   - `grep` against a skill URL with a real filesystem `sourcePath` — unchanged