### PR TITLE
feat(overflow): enhance context overflow detection for model_context_…

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed context overflow detection to recognize `model_context_window_exceeded` from z.ai / GLM providers, preventing infinite retry loops when context window is exceeded ([#638](https://github.com/can1357/oh-my-pi/issues/638))
+
+
 ## [14.1.0] - 2026-04-11
 ### Added
 
@@ -31,6 +36,7 @@
 
 ### Removed
 - Removed Copilot JWT proxy-ep base URL resolution (no longer needed with opencode auth).
+
 ## [14.0.3] - 2026-04-09
 
 ### Fixed

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -21,6 +21,7 @@ import type { AssistantMessage } from "../types";
  * - Kimi For Coding: "Your request exceeded model token limit: X (requested: Y)"
  * - Anthropic 413: "request_too_large" / "Request exceeds the maximum size" (payload too large)
  * - HTTP 413 variants: "Payload Too Large" / "Request Entity Too Large"
+ * - z.ai / GLM: Returns finish_reason: "model_context_window_exceeded" mapped to error message
  * - z.ai: Does NOT error, accepts overflow silently - handled via usage.input > contextWindow
  * - Ollama: Silently truncates input - not detectable via error message
  */
@@ -49,6 +50,7 @@ const OVERFLOW_PATTERNS = [
 	/payload too large/i, // Generic HTTP 413 variant
 	/entity too large/i, // Generic HTTP 413 variant
 	/\b413\b.*\b(request|payload|entity)\b.*\btoo large\b/i, // "413 Request Entity Too Large" variants
+	/model_context_window_exceeded/i, // z.ai non-standard finish_reason surfaced as error text
 ];
 /**
  * Check if an assistant message represents a context overflow error.

--- a/packages/ai/test/overflow-utils.test.ts
+++ b/packages/ai/test/overflow-utils.test.ts
@@ -23,6 +23,18 @@ function createErrorMessage(errorMessage: string): AssistantMessage {
 	};
 }
 
+describe("isContextOverflow - model_context_window_exceeded", () => {
+	it("detects model_context_window_exceeded from OpenAI-compatible providers", () => {
+		const message = createErrorMessage("Provider finish_reason: model_context_window_exceeded");
+		expect(isContextOverflow(message)).toBe(true);
+	});
+
+	it("detects raw model_context_window_exceeded in error message", () => {
+		const message = createErrorMessage("model_context_window_exceeded");
+		expect(isContextOverflow(message)).toBe(true);
+	});
+});
+
 describe("isContextOverflow - HTTP 413 variants", () => {
 	it("detects generic 413 payload-too-large errors", () => {
 		const message = createErrorMessage("413 Request Entity Too Large: payload too large for request body");

--- a/packages/ai/test/overflow-utils.test.ts
+++ b/packages/ai/test/overflow-utils.test.ts
@@ -24,7 +24,7 @@ function createErrorMessage(errorMessage: string): AssistantMessage {
 }
 
 describe("isContextOverflow - model_context_window_exceeded", () => {
-	it("detects model_context_window_exceeded from OpenAI-compatible providers", () => {
+	it("detects model_context_window_exceeded in finish_reason error message", () => {
 		const message = createErrorMessage("Provider finish_reason: model_context_window_exceeded");
 		expect(isContextOverflow(message)).toBe(true);
 	});


### PR DESCRIPTION
## What
- Fixed context overflow detection to recognize `model_context_window_exceeded` from z.ai / GLM providers, preventing infinite retry loops when context window is exceeded ([#638](https://github.com/can1357/oh-my-pi/issues/638))

Sync from pi-mono.

<!-- Brief description of the change -->

## Why
Error Chain
Model API Layer: The OpenAI-compatible provider you are using (such as the Zhipu GLM series) returns finish_reason: "model_context_window_exceeded" when the context window overflows, instead of the standard "length" or "stop".

pi-ai's mapStopReason() (openai-completions.ts): This function does not recognize model_context_window_exceeded and directly throws an Error("Unhandled stop reason: model_context_window_exceeded").

OMP's automatic compression: The compression recovery mechanism relies on isLikelyContextOverflowError() to detect context overflow. However, this function matches string patterns like "context_length_exceeded", not the thrown error message "Unhandled stop reason: model_context_window_exceeded". Therefore, automatic compression will never be triggered.

Infinite loop: The session gets stuck in an overflow state, and each retry reports the same error because compression is not triggered, and the context does not shrink. ### Why is this error "prone to occur"?

The APIs of domestic models like Zhipu GLM use the non-standard model_context_window_exceeded finish_reason.

The pi-ai code only handles OpenAI's standard stop, length, tool_calls, and content_filter functions.

OMP's system prompt is very long (the current session's system prompt contains thousands of tokens), and with tool definitions, skill loading, and dialogue history, the context grows rapidly.

Automatic compression is the only self-healing mechanism, but it cannot recognize this error.

Known Fixes
An issue has been raised upstream (pi-mono#1870, openclaw#34632, oh-my-pi#44). The proposed fix is ​​to map model_context_window_exceeded to "length" in mapStopReason(), which will then trigger automatic compression correctly.

Temporary Relief
Pre-compression: Manually /compact before the context reaches its limit

Reduce system prompts: Reduce the number of skills loaded

Change provider: Use a provider that returns the standard finish_reason: "length" (such as the OpenAI official provider)

Open a new session: When encountering a freeze, you can only manually delete the session file and start over

This is not a configuration issue on your end; it's a lack of support for non-standard finish_reasons from the upstream pi-ai.
([#638](https://github.com/can1357/oh-my-pi/issues/638))

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
