### PR TITLE
fix(docs): correct user MCP config path to ~/.omp/agent/mcp.json

### DIFF
--- a/docs/mcp-config.md
+++ b/docs/mcp-config.md
@@ -15,14 +15,14 @@ Source of truth in code:
 OMP can discover MCP servers from multiple tools (`.claude/`, `.cursor/`, `.vscode/`, `opencode.json`, and more), but for OMP-native configuration you should usually use one of these files:
 
 - Project: `.omp/mcp.json`
-- User: `~/.omp/mcp.json`
+- User: `~/.omp/agent/mcp.json`
 
 OMP also accepts fallback standalone files in the project root:
 
 - `mcp.json`
 - `.mcp.json`
 
-Use `.omp/mcp.json` when you want OMP to own the configuration. Use root `mcp.json` / `.mcp.json` only when you want a portable fallback file that other MCP clients may also read.
+Use `.omp/mcp.json` or `~/.omp/agent/mcp.json` when you want OMP to own the configuration. Use root `mcp.json` / `.mcp.json` only when you want a portable fallback file that other MCP clients may also read.
 
 ## Add a schema reference
 
@@ -315,7 +315,7 @@ This matches GitHub's official local Docker image `ghcr.io/github/github-mcp-ser
 
 This is the part that usually trips people up.
 
-### In `.omp/mcp.json` and `~/.omp/mcp.json`
+### In `.omp/mcp.json` and `~/.omp/agent/mcp.json`
 
 Before OMP launches a server or makes an HTTP request, it resolves `env` and `headers` values like this:
 
@@ -362,11 +362,11 @@ Example:
 }
 ```
 
-If you want the least surprising OMP behavior, prefer `.omp/mcp.json` and use explicit env/header values.
+If you want the least surprising OMP behavior, prefer `.omp/mcp.json` or `~/.omp/agent/mcp.json` and use explicit env/header values.
 
 ## `disabledServers`
 
-`disabledServers` is mainly useful in the user config file (`~/.omp/mcp.json`) when a server is discovered from some other source and you want OMP to ignore it without editing that other tool's config.
+`disabledServers` is mainly useful in the user config file (`~/.omp/agent/mcp.json`) when a server is discovered from some other source and you want OMP to ignore it without editing that other tool's config.
 
 Example:
 
@@ -414,7 +414,7 @@ OMP does not merge duplicate server definitions across files. Discovery provider
 
 In practice:
 
-- prefer `.omp/mcp.json` or `~/.omp/mcp.json` when you want an OMP-specific override
+- prefer `.omp/mcp.json` or `~/.omp/agent/mcp.json` when you want an OMP-specific override
 - keep server names unique across tools when possible
 - use `disabledServers` in the user config when a third-party config keeps reintroducing a server you do not want
 

--- a/docs/mcp-server-tool-authoring.md
+++ b/docs/mcp-server-tool-authoring.md
@@ -62,7 +62,7 @@ The dedicated fallback provider in `src/discovery/mcp-json.ts` reads project-roo
 
 In practice MCP servers also come from higher-priority providers (for example native `.omp/...` and tool-specific config dirs). Authoring guidance:
 
-- Prefer `.omp/mcp.json` (project) or `~/.omp/mcp.json` (user) for explicit control.
+- Prefer `.omp/mcp.json` (project) or `~/.omp/agent/mcp.json` (user) for explicit control.
 - Use root `mcp.json` / `.mcp.json` when you need fallback compatibility.
 - Reusing the same server name in multiple sources causes precedence shadowing, not merge.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MCP config docs and schema to use `~/.omp/agent/mcp.json` for user-scoped OMP-native MCP config while keeping project config at `<cwd>/.omp/mcp.json`
+
 ## [14.0.4] - 2026-04-10
 ### Added
 

--- a/packages/coding-agent/src/config/mcp-schema.json
+++ b/packages/coding-agent/src/config/mcp-schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json",
   "title": "OMP MCP configuration",
-  "description": "Schema for mcp.json, .mcp.json, .omp/mcp.json, and ~/.omp/mcp.json used by the OMP coding agent.",
+  "description": "Schema for mcp.json, .mcp.json, .omp/mcp.json, and ~/.omp/agent/mcp.json used by the OMP coding agent.",
   "type": "object",
   "additionalProperties": false,
   "properties": {


### PR DESCRIPTION
## Summary

Fix MCP config path documentation/schema mismatch for OMP-native user config.

Current runtime reads user-scoped OMP MCP config from:

- `~/.omp/agent/mcp.json`

Project-scoped OMP MCP config remains:

- `<cwd>/.omp/mcp.json`

However, docs and schema text still referenced `~/.omp/mcp.json`, which causes users to place their MCP config in the documented path and then see:

- `No MCP servers configured.`

## Root cause

The path change happened silently across two refactoring commits:

1. `d24adac68` (2026-02-12) — Refactored MCP discovery from `USER_DIRS.map(name => join(home, name, "mcp.json"))` (resolving to `~/.omp/mcp.json`) to `join(home, PATHS.userAgent, "mcp.json")` (resolving to `~/.omp/agent/mcp.json`). This was a side effect of removing `.pi` alias support.

2. `83d6f7a87` (2026-02-13) — Centralized `getMCPConfigPath` into `@oh-my-pi/pi-utils/dirs`. Old code returned `path.join(os.homedir(), ".omp", "mcp.json")`; new code returns `path.join(getAgentDir(), "mcp.json")`.

Then a month later, `b4dbbd26d` (2026-03-18) created `docs/mcp-config.md` and `mcp-schema.json` using the **pre-February** path `~/.omp/mcp.json`. The docs were stale from birth.

## What changed

- Updated `docs/mcp-config.md` to use `~/.omp/agent/mcp.json` for user-scoped OMP MCP config
- Updated `docs/mcp-server-tool-authoring.md` to match runtime
- Updated `packages/coding-agent/src/config/mcp-schema.json` description text
- Added a changelog entry

## Notes

This PR does not add runtime compatibility for `~/.omp/mcp.json`. From current upstream code, the native user-scoped config convention is consistently `~/.omp/agent/...` across all capabilities (sessions, extensions, skills, rules, commands, etc.), so this change keeps docs/schema aligned with the existing runtime source of truth.

Related: #462 (docs were created stale), #264 (UI had same stale path, fixed in #263)