### PR TITLE
Persist extension-registered models across refresh cycles

### DIFF
--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -697,31 +697,6 @@ function finalizeCustomModel(model: CustomModelOverlay, options: CustomModelBuil
 	} as Model<Api>);
 }
 
-function buildCustomModel(
-	providerName: string,
-	providerBaseUrl: string,
-	providerApi: Api | undefined,
-	providerHeaders: Record<string, string> | undefined,
-	providerApiKey: string | undefined,
-	authHeader: boolean | undefined,
-	providerCompat: Model<Api>["compat"] | undefined,
-	modelDef: CustomModelDefinitionLike,
-	options: CustomModelBuildOptions,
-): Model<Api> | undefined {
-	const model = buildCustomModelOverlay(
-		providerName,
-		providerBaseUrl,
-		providerApi,
-		providerHeaders,
-		providerApiKey,
-		authHeader,
-		providerCompat,
-		modelDef,
-	);
-	if (!model) return undefined;
-	return finalizeCustomModel(model, options);
-}
-
 function normalizeSuppressedSelector(selector: string): string {
 	const trimmed = selector.trim();
 	if (!trimmed) return trimmed;
@@ -757,6 +732,11 @@ export class ModelRegistry {
 	#suppressedSelectors: Map<string, number> = new Map();
 	#backgroundRefresh?: Promise<void>;
 	#lastDiscoveryWarnings: Map<string, string> = new Map();
+	// Runtime extension model overlays — persist across refresh() cycles so that
+	// models registered by extensions survive the model selector's offline reload.
+	#runtimeModelOverlays: CustomModelOverlay[] = [];
+	#runtimeProviderApiKeys: Map<string, string> = new Map();
+	#runtimeKeylessProviders: Set<string> = new Set();
 
 	/**
 	 * @param authStorage - Auth storage for API key resolution
@@ -821,11 +801,21 @@ export class ModelRegistry {
 		this.#customProviderApiKeys.clear();
 		this.#keylessProviders.clear();
 		this.#discoverableProviders = [];
+		// Restore runtime API keys before #loadModels — survives because
+		// #loadModels only calls .set() on #customProviderApiKeys, never reassigns it.
+		for (const [k, v] of this.#runtimeProviderApiKeys) {
+			this.#customProviderApiKeys.set(k, v);
+		}
 		this.#providerOverrides.clear();
 		this.#modelOverrides.clear();
 		this.#configError = undefined;
 		this.#providerDiscoveryStates.clear();
 		this.#loadModels();
+		// Restore runtime keyless providers AFTER #loadModels, because #loadModels
+		// replaces this.#keylessProviders via = with a new Set from models.yml.
+		for (const k of this.#runtimeKeylessProviders) {
+			this.#keylessProviders.add(k);
+		}
 	}
 
 	/**
@@ -857,7 +847,9 @@ export class ModelRegistry {
 		const builtInModels = this.#applyHardcodedModelPolicies(this.#loadBuiltInModels(overrides));
 		const cachedDiscoveries = this.#applyHardcodedModelPolicies(this.#loadCachedDiscoverableModels());
 		const resolvedDefaults = this.#mergeResolvedModels(builtInModels, cachedDiscoveries);
-		const combined = this.#mergeCustomModels(resolvedDefaults, this.#customModelOverlays);
+		const withConfigModels = this.#mergeCustomModels(resolvedDefaults, this.#customModelOverlays);
+		// Merge runtime extension models so they survive refresh() cycles
+		const combined = this.#mergeCustomModels(withConfigModels, this.#runtimeModelOverlays);
 
 		this.#models = this.#applyModelOverrides(combined, this.#modelOverrides);
 	}
@@ -1144,7 +1136,9 @@ export class ModelRegistry {
 			}),
 		);
 		const resolved = this.#mergeResolvedModels(this.#models, discoveredModels);
-		const combined = this.#mergeCustomModels(resolved, this.#customModelOverlays);
+		const withConfigModels = this.#mergeCustomModels(resolved, this.#customModelOverlays);
+		// Merge runtime extension models so they survive online discovery completion
+		const combined = this.#mergeCustomModels(withConfigModels, this.#runtimeModelOverlays);
 		this.#models = this.#applyModelOverrides(combined, this.#modelOverrides);
 	}
 
@@ -1826,12 +1820,15 @@ export class ModelRegistry {
 		}
 		if (config.apiKey) {
 			this.#customProviderApiKeys.set(providerName, config.apiKey);
+			// Persist runtime API keys so they survive #reloadStaticModels() cycles
+			this.#runtimeProviderApiKeys.set(providerName, config.apiKey);
 		}
 
 		if (config.models && config.models.length > 0) {
-			const nextModels = this.#models.filter(m => m.provider !== providerName);
+			// Build model overlays that persist across refresh() cycles
+			const newOverlays: CustomModelOverlay[] = [];
 			for (const modelDef of config.models) {
-				const model = buildCustomModel(
+				const overlay = buildCustomModelOverlay(
 					providerName,
 					config.baseUrl!,
 					config.api,
@@ -1840,12 +1837,20 @@ export class ModelRegistry {
 					config.authHeader,
 					config.compat,
 					modelDef as CustomModelDefinitionLike,
-					{ useDefaults: true },
 				);
-				if (!model) {
+				if (!overlay) {
 					throw new Error(`Provider ${providerName}, model ${modelDef.id}: no "api" specified.`);
 				}
-				nextModels.push(model);
+				newOverlays.push(overlay);
+			}
+			// Store as runtime overlays so they survive #reloadStaticModels()
+			this.#runtimeModelOverlays = this.#runtimeModelOverlays.filter(m => m.provider !== providerName);
+			this.#runtimeModelOverlays.push(...newOverlays);
+
+			// Also update #models immediately for the current cycle
+			const nextModels = this.#models.filter(m => m.provider !== providerName);
+			for (const overlay of newOverlays) {
+				nextModels.push(finalizeCustomModel(overlay, { useDefaults: true }));
 			}
 
 			if (config.oauth?.modifyModels) {

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -134,6 +134,151 @@ describe("ModelRegistry runtime provider registration", () => {
 		});
 	});
 
+	test("extension-registered models survive refresh('offline') cycle", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const config: ProviderConfigInput = {
+			baseUrl: "https://runtime.example.com/v1",
+			apiKey: "RUNTIME_KEY",
+			api: "openai-completions",
+			models: [baseModel],
+		};
+
+		registry.registerProvider("runtime-provider", config, "ext://runtime");
+		expect(registry.find("runtime-provider", "runtime-model")).toBeDefined();
+
+		await registry.refresh("offline");
+
+		const model = registry.find("runtime-provider", "runtime-model");
+		expect(model).toBeDefined();
+		expect(model?.baseUrl).toBe("https://runtime.example.com/v1");
+		expect(model?.api).toBe("openai-completions");
+	});
+
+	test("extension-registered models survive refresh('online') cycle", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const config: ProviderConfigInput = {
+			baseUrl: "https://runtime.example.com/v1",
+			apiKey: "RUNTIME_KEY",
+			api: "openai-completions",
+			models: [{ ...baseModel, id: "online-survivor" }],
+		};
+
+		registry.registerProvider("runtime-provider", config, "ext://runtime");
+		expect(registry.find("runtime-provider", "online-survivor")).toBeDefined();
+
+		await registry.refresh("online");
+
+		const model = registry.find("runtime-provider", "online-survivor");
+		expect(model).toBeDefined();
+		expect(model?.api).toBe("openai-completions");
+	});
+
+	test("extension-registered API keys survive refresh cycle for auth resolution", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+
+		// Set up the env var that the apiKey config references
+		process.env.TEST_RUNTIME_KEY = "test-value";
+
+		const config: ProviderConfigInput = {
+			baseUrl: "https://runtime.example.com/v1",
+			apiKey: "TEST_RUNTIME_KEY",
+			api: "openai-completions",
+			models: [baseModel],
+		};
+
+		registry.registerProvider("runtime-provider", config, "ext://runtime");
+		expect(registry.authStorage.hasAuth("runtime-provider")).toBe(true);
+
+		await registry.refresh("offline");
+
+		// The fallback resolver should still find the API key after refresh
+		expect(registry.authStorage.hasAuth("runtime-provider")).toBe(true);
+
+		delete process.env.TEST_RUNTIME_KEY;
+	});
+
+	test("extension-registered custom API handler survives model refresh", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const config: ProviderConfigInput = {
+			baseUrl: "https://runtime.example.com/v1",
+			apiKey: "RUNTIME_KEY",
+			api: "custom-runtime-api",
+			streamSimple,
+			models: [baseModel],
+		};
+
+		registry.registerProvider("runtime-provider", config, "ext://runtime");
+		expect(getCustomApi("custom-runtime-api")).toBeDefined();
+
+		// Custom API registry is separate from model registry — verify it persists
+		// Note: refresh clears+re-registers source registrations via sdk.ts,
+		// but the custom API registry itself is not cleared by refresh()
+		await registry.refresh("offline");
+
+		expect(getCustomApi("custom-runtime-api")).toBeDefined();
+	});
+
+	test("re-registering a provider replaces previous runtime overlays", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const config1: ProviderConfigInput = {
+			baseUrl: "https://runtime.example.com/v1",
+			apiKey: "RUNTIME_KEY",
+			api: "openai-completions",
+			models: [{ ...baseModel, id: "model-v1", name: "Model V1" }],
+		};
+		const config2: ProviderConfigInput = {
+			baseUrl: "https://runtime.example.com/v2",
+			apiKey: "RUNTIME_KEY",
+			api: "openai-completions",
+			models: [{ ...baseModel, id: "model-v2", name: "Model V2" }],
+		};
+
+		registry.registerProvider("runtime-provider", config1, "ext://runtime");
+		expect(registry.find("runtime-provider", "model-v1")).toBeDefined();
+
+		registry.registerProvider("runtime-provider", config2, "ext://runtime");
+		expect(registry.find("runtime-provider", "model-v2")).toBeDefined();
+		expect(registry.find("runtime-provider", "model-v1")).toBeUndefined();
+
+		// After refresh, only v2 should exist
+		await registry.refresh("offline");
+		expect(registry.find("runtime-provider", "model-v2")).toBeDefined();
+		expect(registry.find("runtime-provider", "model-v1")).toBeUndefined();
+	});
+
+	test("multiple extension providers survive refresh independently", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+
+		registry.registerProvider(
+			"provider-a",
+			{
+				baseUrl: "https://a.example.com",
+				apiKey: "KEY_A",
+				api: "openai-completions",
+				models: [{ ...baseModel, id: "model-a" }],
+			},
+			"ext://a",
+		);
+		registry.registerProvider(
+			"provider-b",
+			{
+				baseUrl: "https://b.example.com",
+				apiKey: "KEY_B",
+				api: "openai-completions",
+				models: [{ ...baseModel, id: "model-b" }],
+			},
+			"ext://b",
+		);
+
+		expect(registry.find("provider-a", "model-a")).toBeDefined();
+		expect(registry.find("provider-b", "model-b")).toBeDefined();
+
+		await registry.refresh("offline");
+
+		expect(registry.find("provider-a", "model-a")).toBeDefined();
+		expect(registry.find("provider-b", "model-b")).toBeDefined();
+	});
+
 	test("clearSourceRegistrations and syncExtensionSources remove source-scoped API and OAuth providers", () => {
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);
 		const oauthCredentials: OAuthCredentials = {


### PR DESCRIPTION
## What

Extension-registered models now persist across `ModelRegistry.refresh()` cycles. Models registered via `registerProvider()` are stored as runtime overlays and merged during every model rebuild, alongside the existing `#customModelOverlays` from `models.yml`.

Changes to `model-registry.ts`:
- Add `#runtimeModelOverlays`, `#runtimeProviderApiKeys`, and `#runtimeKeylessProviders` fields that are not cleared by `#reloadStaticModels()`
- Merge runtime overlays in both `#loadModels()` and `#refreshRuntimeDiscoveries()`
- Restore runtime API keys and keyless providers after each clear cycle
- Refactor `registerProvider()` to store models as overlays via `buildCustomModelOverlay` + `finalizeCustomModel`
- Remove now-unused `buildCustomModel` wrapper

## Why

When the model selector opens, it calls `modelRegistry.refresh("offline")`, which rebuilds `#models` entirely from built-in + `models.yml` sources and clears `#customProviderApiKeys`. Models registered by extensions via `registerProvider()` were stored directly in `#models` and lost on every refresh.

This made it impossible for extensions to register custom providers — models would appear after startup but vanish the moment the user opened the model selector.

## Testing

Added 6 new tests to `model-registry-runtime-provider.test.ts`:

- Extension-registered models survive `refresh('offline')` cycle
- Extension-registered models survive `refresh('online')` cycle
- Extension-registered API keys survive refresh for auth resolution
- Extension-registered custom API handler survives model refresh
- Re-registering a provider replaces previous runtime overlays
- Multiple extension providers survive refresh independently

---
- [X] `bun check` passes
- [X] Tested locally
- [ ] CHANGELOG updated (if user-facing) - Not really user-facing?