### PR TITLE
feat: add session name getter/setter to extension API

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -114,9 +114,12 @@ Core methods:
 - `registerMessageRenderer`
 - `sendMessage`, `sendUserMessage`, `appendEntry`
 - `getActiveTools`, `getAllTools`, `setActiveTools`
+- `getSessionName`, `setSessionName`
 - `setModel`, `getThinkingLevel`, `setThinkingLevel`
 - `registerProvider`
 - `events` (shared event bus)
+
+In interactive mode, `input` handlers run before the built-in first-message auto-title check. Extensions that call `await pi.setSessionName(...)` from `input` can set the persisted session name and prevent the default auto-generated title from running for that session.
 
 Also exposed:
 

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -91,6 +91,14 @@ export class ExtensionRuntime implements IExtensionRuntime {
 	setThinkingLevel(): void {
 		throw new ExtensionRuntimeNotInitializedError();
 	}
+
+	getSessionName(): string | undefined {
+		throw new ExtensionRuntimeNotInitializedError();
+	}
+
+	setSessionName(): Promise<void> {
+		throw new ExtensionRuntimeNotInitializedError();
+	}
 }
 
 /**
@@ -221,6 +229,14 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 
 	setThinkingLevel(level: ThinkingLevel, persist?: boolean): void {
 		this.runtime.setThinkingLevel(level, persist);
+	}
+
+	getSessionName(): string | undefined {
+		return this.runtime.getSessionName();
+	}
+
+	setSessionName(name: string): Promise<void> {
+		return this.runtime.setSessionName(name);
 	}
 
 	registerProvider(name: string, config: import("./types").ProviderConfig): void {

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -204,6 +204,8 @@ export class ExtensionRunner {
 		this.runtime.setModel = actions.setModel;
 		this.runtime.getThinkingLevel = actions.getThinkingLevel;
 		this.runtime.setThinkingLevel = actions.setThinkingLevel;
+		this.runtime.getSessionName = actions.getSessionName;
+		this.runtime.setSessionName = actions.setSessionName;
 
 		// Context actions (required)
 		this.#getModel = contextActions.getModel;

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -1109,6 +1109,12 @@ export interface ExtensionAPI {
 	/** Set thinking level for the current session. */
 	setThinkingLevel(level: ThinkingLevel): void;
 
+	/** Get the current session name. */
+	getSessionName(): string | undefined;
+
+	/** Set the session name. Persists to the session file. */
+	setSessionName(name: string): Promise<void>;
+
 	// =========================================================================
 	// Provider Registration
 	// =========================================================================
@@ -1295,6 +1301,8 @@ export interface ExtensionActions {
 	setModel: SetModelHandler;
 	getThinkingLevel: GetThinkingLevelHandler;
 	setThinkingLevel: SetThinkingLevelHandler;
+	getSessionName: () => string | undefined;
+	setSessionName: (name: string) => Promise<void>;
 }
 
 /** Actions for ExtensionContext (ctx.* in event handlers). */

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1148,6 +1148,10 @@ export class AcpAgent implements Agent {
 				},
 				getThinkingLevel: () => record.session.thinkingLevel,
 				setThinkingLevel: level => record.session.setThinkingLevel(level),
+				getSessionName: () => record.session.sessionManager.getSessionName(),
+				setSessionName: async name => {
+					await record.session.sessionManager.setSessionName(name);
+				},
 			},
 			{
 				getModel: () => record.session.model,

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -120,6 +120,11 @@ export class ExtensionUiController {
 			getThinkingLevel: () => this.ctx.session.thinkingLevel,
 			setThinkingLevel: level => this.ctx.session.setThinkingLevel(level),
 			getCommands: () => [],
+			getSessionName: () => this.ctx.sessionManager.getSessionName(),
+			setSessionName: async name => {
+				await this.ctx.sessionManager.setSessionName(name);
+				setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+			},
 		};
 		const contextActions: ExtensionContextActions = {
 			getModel: () => this.ctx.session.model,
@@ -382,6 +387,11 @@ export class ExtensionUiController {
 			getThinkingLevel: () => this.ctx.session.thinkingLevel,
 			setThinkingLevel: (level, persist) => this.ctx.session.setThinkingLevel(level, persist),
 			getCommands: () => [],
+			getSessionName: () => this.ctx.sessionManager.getSessionName(),
+			setSessionName: async name => {
+				await this.ctx.sessionManager.setSessionName(name);
+				setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
+			},
 		};
 		const contextActions: ExtensionContextActions = {
 			getModel: () => this.ctx.session.model,

--- a/packages/coding-agent/src/modes/print-mode.ts
+++ b/packages/coding-agent/src/modes/print-mode.ts
@@ -72,6 +72,10 @@ export async function runPrintMode(session: AgentSession, options: PrintModeOpti
 				},
 				getThinkingLevel: () => session.thinkingLevel,
 				setThinkingLevel: level => session.setThinkingLevel(level),
+				getSessionName: () => session.sessionManager.getSessionName(),
+				setSessionName: async name => {
+					await session.sessionManager.setSessionName(name);
+				},
 			},
 			// ExtensionContextActions
 			{

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -440,6 +440,10 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 				},
 				getThinkingLevel: () => session.thinkingLevel,
 				setThinkingLevel: level => session.setThinkingLevel(level),
+				getSessionName: () => session.sessionManager.getSessionName(),
+				setSessionName: async name => {
+					await session.sessionManager.setSessionName(name);
+				},
 			},
 			// ExtensionContextActions
 			{

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -268,6 +268,7 @@ export type ReadonlySessionManager = Pick<
 	| "getSessionDir"
 	| "getSessionId"
 	| "getSessionFile"
+	| "getSessionName"
 	| "getArtifactsDir"
 	| "allocateArtifactPath"
 	| "saveArtifact"

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1057,6 +1057,10 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 						},
 						getThinkingLevel: () => session.thinkingLevel,
 						setThinkingLevel: level => session.setThinkingLevel(level),
+						getSessionName: () => session.sessionManager.getSessionName(),
+						setSessionName: async name => {
+							await session.sessionManager.setSessionName(name);
+						},
 					},
 					{
 						getModel: () => session.model,

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -525,6 +525,82 @@ describe("ExtensionRunner", () => {
 		});
 	});
 
+	describe("session name API", () => {
+		it("lets extensions read and set the session name after initialization", async () => {
+			const extCode = `
+				export default function(pi) {
+					pi.on("session_start", async () => {
+						if (pi.getSessionName() !== undefined) {
+							throw new Error("expected unnamed session");
+						}
+						await pi.setSessionName("Named by extension");
+					});
+				}
+			`;
+			const explicitExtensionPath = path.join(tempDir.path(), "session-name.ts");
+			fs.writeFileSync(explicitExtensionPath, extCode);
+
+			const result = await loadTestExtensions([explicitExtensionPath]);
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			runner.initialize(
+				{
+					sendMessage: () => {},
+					sendUserMessage: () => {},
+					appendEntry: () => {},
+					setLabel: () => {},
+					getActiveTools: () => [],
+					getAllTools: () => [],
+					setActiveTools: async () => {},
+					getCommands: () => [],
+					setModel: async () => false,
+					getThinkingLevel: () => undefined,
+					setThinkingLevel: () => {},
+					getSessionName: () => sessionManager.getSessionName(),
+					setSessionName: async name => {
+						await sessionManager.setSessionName(name);
+					},
+				},
+				{
+					getModel: () => undefined,
+					isIdle: () => true,
+					abort: () => {},
+					hasPendingMessages: () => false,
+					shutdown: () => {},
+					getContextUsage: () => undefined,
+					compact: async () => {},
+					getSystemPrompt: () => "",
+				},
+			);
+
+			await runner.emit({ type: "session_start" });
+
+			expect(sessionManager.getSessionName()).toBe("Named by extension");
+			expect(sessionManager.getHeader()?.title).toBe("Named by extension");
+		});
+
+		it("keeps session naming unavailable during extension load", async () => {
+			const extCode = `
+				export default function(pi) {
+					pi.getSessionName();
+				}
+			`;
+			const explicitExtensionPath = path.join(tempDir.path(), "session-name-load.ts");
+			fs.writeFileSync(explicitExtensionPath, extCode);
+
+			const result = await loadTestExtensions([explicitExtensionPath]);
+			const loadError = result.errors.find(error => error.path.includes("session-name-load.ts"));
+
+			expect(loadError).toBeDefined();
+			expect(loadError?.error).toContain("Extension runtime not initialized");
+		});
+	});
+
 	describe("hasHandlers", () => {
 		it("returns true when handlers exist for event type", async () => {
 			const extCode = `


### PR DESCRIPTION
## Summary

Adds  and  methods to the extension API, allowing extensions to read and modify the session name during runtime.

## Spirit/Intent

Enable extensions to customize session naming behavior, particularly for interactive workflows where extensions can set meaningful titles before the auto-title logic runs.

## Key Changes

- Added  and  to  interface
- Implemented in  with proper initialization error handling
- Wired in  for all mode implementations
- Added implementations in ACP, UI controller, print mode, RPC mode, and task executor
- UI controller updates terminal title when session name changes
- Added  to  type
- Updated documentation in 
- Added test coverage for both success and error cases

## Risks

- Extensions calling  from load-time code will throw (by design)
- Only UI mode updates terminal title; other modes defer title updates to their respective UI handlers