### PR TITLE
flow agent: a concept playground

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -21,6 +21,12 @@ import {
 	type ToolResultMessage,
 } from "@oh-my-pi/pi-ai";
 import { agentLoop, agentLoopContinue } from "./agent-loop";
+import {
+	applyStrategyConvertToLlm,
+	composeSyncBeforeModelCall,
+	composeTransformContext,
+	type ExecutionStrategy,
+} from "./execution-strategy";
 import type {
 	AgentContext,
 	AgentEvent,
@@ -245,6 +251,7 @@ export class Agent {
 	#getToolChoice?: () => ToolChoice | undefined;
 	#onPayload?: SimpleStreamOptions["onPayload"];
 	#onAssistantMessageEvent?: (message: AssistantMessage, event: AssistantMessageEvent) => void;
+	#strategy?: ExecutionStrategy;
 
 	/** Buffered Cursor tool results with text length at time of call (for correct ordering) */
 	#cursorToolResultBuffer: CursorToolResultEntry[] = [];
@@ -417,6 +424,56 @@ export class Agent {
 		fn: ((message: AssistantMessage, event: AssistantMessageEvent) => void) | undefined,
 	): void {
 		this.#onAssistantMessageEvent = fn;
+	}
+
+	/**
+	 * Install (or remove) an execution strategy. Strategies compose with the
+	 * Agent's base hooks — they do not replace them. Pass `undefined` to
+	 * revert to the base behavior. See {@link ExecutionStrategy} for the
+	 * composition rules.
+	 *
+	 * Swapping the strategy while the agent is streaming is safe from a
+	 * memory-safety standpoint but semantically dubious: the in-flight turn
+	 * will finish under whichever strategy was active when its
+	 * AgentLoopConfig was built. Prefer to install before calling `prompt()`.
+	 */
+	setExecutionStrategy(strategy: ExecutionStrategy | undefined): void {
+		this.#strategy = strategy;
+	}
+
+	/** Currently installed execution strategy, or `undefined` for default. */
+	get executionStrategy(): ExecutionStrategy | undefined {
+		return this.#strategy;
+	}
+
+	/**
+	 * Install (or replace) an `onPayload` hook that sees every provider
+	 * request payload right before it is sent over HTTP. Use with care: the
+	 * hook is invoked on the hot path of every LLM call.
+	 *
+	 * When an existing hook is present, the new one wraps it — the old hook
+	 * runs first, the new hook sees its result.
+	 *
+	 * Passing `undefined` removes the **entire** hook chain, not just the
+	 * last layer. There is no per-layer unwrap — this is intentional for
+	 * simplicity given a single-consumer use case (flow trace logger).
+	 */
+	setOnPayload(fn: SimpleStreamOptions["onPayload"] | undefined): void {
+		if (!fn) {
+			this.#onPayload = undefined;
+			return;
+		}
+		const existing = this.#onPayload;
+		if (!existing) {
+			this.#onPayload = fn;
+			return;
+		}
+		this.#onPayload = async (payload, model) => {
+			const first = await existing(payload, model);
+			const effective = first ?? payload;
+			const second = await fn(effective, model);
+			return second ?? effective;
+		};
 	}
 
 	emitExternalEvent(event: AgentEvent) {
@@ -742,6 +799,28 @@ export class Agent {
 		const getToolChoice = () =>
 			this.#getToolChoice?.() ?? refreshToolChoiceForActiveTools(options?.toolChoice, this.#state.tools);
 
+		// Base syncContextBeforeModelCall — refreshes live session state
+		// (system prompt, tools) onto the loop's working context before
+		// every model call. An installed ExecutionStrategy, if any, runs
+		// *before* this base hook so its observations happen on the
+		// untouched context.
+		const baseSyncBeforeModelCall = async (context: AgentContext) => {
+			if (this.#listeners.size > 0) {
+				await Bun.sleep(0);
+			}
+			context.systemPrompt = this.#state.systemPrompt;
+			context.tools = this.#state.tools;
+		};
+
+		// Compose the base hooks with the installed strategy (if any).
+		// When no strategy is present these reduce to the base hooks
+		// unchanged, so default behavior is byte-identical.
+		const strategy = this.#strategy;
+		const effectiveConvertToLlm = applyStrategyConvertToLlm(this.#convertToLlm, strategy);
+		const effectiveTransformContext = composeTransformContext(this.#transformContext, strategy);
+		const effectiveSyncBeforeModelCall =
+			composeSyncBeforeModelCall(baseSyncBeforeModelCall, strategy) ?? baseSyncBeforeModelCall;
+
 		const config: AgentLoopConfig = {
 			model,
 			reasoning,
@@ -759,18 +838,12 @@ export class Agent {
 			maxRetryDelayMs: this.#maxRetryDelayMs,
 			kimiApiFormat: this.#kimiApiFormat,
 			preferWebsockets: this.#preferWebsockets,
-			convertToLlm: this.#convertToLlm,
-			transformContext: this.#transformContext,
+			convertToLlm: effectiveConvertToLlm,
+			transformContext: effectiveTransformContext,
 			onPayload: this.#onPayload,
 			getApiKey: this.getApiKey,
 			getToolContext: this.#getToolContext,
-			syncContextBeforeModelCall: async context => {
-				if (this.#listeners.size > 0) {
-					await Bun.sleep(0);
-				}
-				context.systemPrompt = this.#state.systemPrompt;
-				context.tools = this.#state.tools;
-			},
+			syncContextBeforeModelCall: effectiveSyncBeforeModelCall,
 			cursorExecHandlers: this.#cursorExecHandlers,
 			cursorOnToolResult,
 			transformToolCallArguments: this.#transformToolCallArguments,
@@ -837,11 +910,24 @@ export class Agent {
 						if (event.message.role === "assistant" && (event.message as any).errorMessage) {
 							this.#state.error = (event.message as any).errorMessage;
 						}
+						if (strategy?.onTurnEnd) {
+							await strategy.onTurnEnd({
+								context,
+								message: event.message,
+								newMessages: [event.message, ...event.toolResults],
+							});
+						}
 						break;
 
 					case "agent_end":
 						this.#state.isStreaming = false;
 						this.#state.streamMessage = null;
+						if (strategy?.onAgentEnd) {
+							await strategy.onAgentEnd({
+								context,
+								newMessages: event.messages,
+							});
+						}
 						break;
 				}
 

--- a/packages/agent/src/execution-strategy.ts
+++ b/packages/agent/src/execution-strategy.ts
@@ -1,0 +1,155 @@
+/**
+ * ExecutionStrategy — composable hook bundle for customizing how the agent
+ * loop runs without subclassing Agent or forking agent-loop.
+ *
+ * Agent has always exposed individual hooks (convertToLlm, transformContext,
+ * syncContextBeforeModelCall) via its constructor options. Those hooks are
+ * fine for single-purpose customization, but they are frozen at construction
+ * time and can only be composed by hand. An ExecutionStrategy groups them
+ * into a single coherent object that can be swapped atomically at runtime,
+ * carries its own state, and is testable in isolation.
+ *
+ * The strategy's hooks are *composed* with whatever base hooks the Agent was
+ * constructed with. A strategy cannot silently shadow convertToLlm — it
+ * receives the base converter and returns a wrapped one. The same holds for
+ * transformContext, which runs after any base transform.
+ *
+ * Conceptual shape:
+ *   base.transformContext → strategy.transformContext → convertToLlm boundary
+ *   strategy.syncBeforeModelCall (runs before base sync)
+ *   strategy.wrapConvertToLlm(base) → effective converter
+ *   strategy.onTurnEnd (runs after each assistant turn, before event dispatch
+ *                      resumes on the caller side)
+ *
+ * Default: undefined. When no strategy is installed, Agent behaves exactly
+ * as it did before this interface existed. This is a strict additive change.
+ */
+
+import type { Message } from "@oh-my-pi/pi-ai";
+import type { AgentContext, AgentMessage, AgentTool } from "./types";
+
+export type StrategyConvertToLlmFn = (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
+
+export type StrategyTransformContextFn = (messages: AgentMessage[], signal?: AbortSignal) => Promise<AgentMessage[]>;
+
+export type StrategySyncBeforeModelCallFn = (context: AgentContext) => void | Promise<void>;
+
+export type StrategyTurnEndFn = (info: {
+	context: AgentContext;
+	message: AgentMessage;
+	newMessages: readonly AgentMessage[];
+}) => void | Promise<void>;
+
+export type StrategyAgentEndFn = (info: {
+	context: AgentContext;
+	newMessages: readonly AgentMessage[];
+}) => void | Promise<void>;
+
+/**
+ * A pluggable execution strategy for the agent loop.
+ *
+ * Every field is optional. An implementation only needs to fill the hooks it
+ * cares about; the rest fall through to the Agent's base behavior.
+ */
+export interface ExecutionStrategy {
+	/** Human-readable identifier. Used only for diagnostics. */
+	readonly name: string;
+
+	/**
+	 * Wrap the base convertToLlm to filter, reorder, or augment messages
+	 * before they reach the LLM. The base converter must be called from
+	 * inside the wrapper unless the strategy deliberately shadows it.
+	 */
+	wrapConvertToLlm?(base: StrategyConvertToLlmFn): StrategyConvertToLlmFn;
+
+	/**
+	 * Transform the AgentMessage[] view of the context before convertToLlm
+	 * runs. Invoked *after* the Agent's base transformContext (if any), so
+	 * strategies see the already-transformed view.
+	 */
+	transformContext?(messages: AgentMessage[], signal?: AbortSignal): Promise<AgentMessage[]>;
+
+	/**
+	 * Called before every model call, *after* the Agent's base
+	 * syncContextBeforeModelCall (which refreshes ctx.systemPrompt and
+	 * ctx.tools from the live session state). The strategy sees the
+	 * already-refreshed context and can override whatever it needs.
+	 */
+	syncBeforeModelCall?(context: AgentContext): void | Promise<void>;
+
+	/**
+	 * Called after each turn (one assistant response plus any tool results)
+	 * completes. The `newMessages` array contains every AgentMessage added
+	 * during this turn, in order.
+	 */
+	onTurnEnd?(info: {
+		context: AgentContext;
+		message: AgentMessage;
+		newMessages: readonly AgentMessage[];
+	}): void | Promise<void>;
+
+	/**
+	 * Called once when the agent loop for a single prompt completes, after
+	 * the final turn. Use this for end-of-run bookkeeping: persisting
+	 * derived state, emitting summary events, etc.
+	 */
+	onAgentEnd?(info: { context: AgentContext; newMessages: readonly AgentMessage[] }): void | Promise<void>;
+}
+
+/**
+ * Apply a strategy's convertToLlm wrapper to a base converter. Returns the
+ * base unchanged when the strategy is absent or does not override the hook.
+ */
+export function applyStrategyConvertToLlm(
+	base: StrategyConvertToLlmFn,
+	strategy: ExecutionStrategy | undefined,
+): StrategyConvertToLlmFn {
+	if (!strategy?.wrapConvertToLlm) return base;
+	return strategy.wrapConvertToLlm(base);
+}
+
+/**
+ * Compose a base transformContext with a strategy's transformContext.
+ * The base runs first; the strategy sees the output of the base. Either or
+ * both may be absent.
+ */
+export function composeTransformContext(
+	base: StrategyTransformContextFn | undefined,
+	strategy: ExecutionStrategy | undefined,
+): StrategyTransformContextFn | undefined {
+	const stratFn = strategy?.transformContext;
+	if (!base && !stratFn) return undefined;
+	if (!stratFn) return base;
+	if (!base) return (msgs, signal) => stratFn.call(strategy, msgs, signal);
+	return async (msgs, signal) => {
+		const afterBase = await base(msgs, signal);
+		return stratFn.call(strategy, afterBase, signal);
+	};
+}
+
+/**
+ * Compose a base syncBeforeModelCall with the strategy's. Base runs first
+ * so the loop's live state (system prompt, tools) is installed on the
+ * context; the strategy runs after and can override whatever it needs.
+ * This lets a strategy replace the system prompt or filter the tool list
+ * for a specific run without fighting the agent's refresh pass.
+ */
+export function composeSyncBeforeModelCall(
+	base: StrategySyncBeforeModelCallFn | undefined,
+	strategy: ExecutionStrategy | undefined,
+): StrategySyncBeforeModelCallFn | undefined {
+	const stratFn = strategy?.syncBeforeModelCall;
+	if (!base && !stratFn) return undefined;
+	if (!stratFn) return base;
+	if (!base) return ctx => stratFn.call(strategy, ctx);
+	return async ctx => {
+		await base(ctx);
+		await stratFn.call(strategy, ctx);
+	};
+}
+
+/**
+ * Utility re-export so implementations can type their hooks without pulling
+ * a second import line from "./types".
+ */
+export type { AgentContext, AgentMessage, AgentTool };

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2,6 +2,8 @@
 export * from "./agent";
 // Loop functions
 export * from "./agent-loop";
+// Execution strategy (composable hook bundle)
+export * from "./execution-strategy";
 // Proxy utilities
 export * from "./proxy";
 // Thinking selectors

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -254,6 +254,14 @@
 			"types": "./src/extensibility/*.ts",
 			"import": "./src/extensibility/*.ts"
 		},
+		"./flow": {
+			"types": "./src/flow/index.ts",
+			"import": "./src/flow/index.ts"
+		},
+		"./flow/*": {
+			"types": "./src/flow/*.ts",
+			"import": "./src/flow/*.ts"
+		},
 		"./extensibility/custom-commands": {
 			"types": "./src/extensibility/custom-commands/index.ts",
 			"import": "./src/extensibility/custom-commands/index.ts"

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -176,6 +176,7 @@ export class ExtensionRunner {
 	#reloadHandler: () => Promise<void> = async () => {};
 	#shutdownHandler: ShutdownHandler = () => {};
 	#commandDiagnostics: Array<{ type: string; message: string; path: string }> = [];
+	#externalCommands = new Map<string, RegisteredCommand>();
 
 	constructor(
 		private readonly extensions: Extension[],
@@ -350,6 +351,12 @@ export class ExtensionRunner {
 		this.#commandDiagnostics = [];
 
 		const commands = new Map<string, RegisteredCommand>();
+		// External commands (registered via runner.registerCommand from
+		// outside the extension system, e.g. flow strategy nodes).
+		for (const command of this.#externalCommands.values()) {
+			if (reserved?.has(command.name)) continue;
+			commands.set(command.name, command);
+		}
 		for (const ext of this.extensions) {
 			for (const command of ext.commands.values()) {
 				if (reserved?.has(command.name)) {
@@ -372,6 +379,8 @@ export class ExtensionRunner {
 	}
 
 	getCommand(name: string): RegisteredCommand | undefined {
+		const ext = this.#externalCommands.get(name);
+		if (ext) return ext;
 		for (let index = this.extensions.length - 1; index >= 0; index -= 1) {
 			const command = this.extensions[index]?.commands.get(name);
 			if (command) {
@@ -379,6 +388,11 @@ export class ExtensionRunner {
 			}
 		}
 		return undefined;
+	}
+
+	/** Register a command from outside the extension system (e.g. flow strategy). */
+	registerCommand(name: string, options: { description?: string; handler: RegisteredCommand["handler"] }): void {
+		this.#externalCommands.set(name, { name, ...options });
 	}
 
 	createContext(): ExtensionContext {

--- a/packages/coding-agent/src/flow/flow-edge-resolver.ts
+++ b/packages/coding-agent/src/flow/flow-edge-resolver.ts
@@ -1,0 +1,46 @@
+/**
+ * Flow edge resolver.
+ *
+ * Pure function: given the current top node id and the most recent event,
+ * find the first outgoing edge from that node whose `when` clause matches
+ * the event. Returns the target node id or null if no edge fires.
+ *
+ * Event kinds:
+ *   - `tool_call`: a tool with the given name was called by the model.
+ *   - `ret`: the current frame is returning.
+ *   - `error`: an error occurred (in a hook, tool, or nested frame).
+ *
+ * Edge condition `custom` is treated as a no-match at the pure level —
+ * higher layers can plug in an expression evaluator if needed.
+ */
+
+import type { Flow, NodeId } from "./flow-types";
+
+export type FlowEvent =
+	| { kind: "tool_call"; name: string }
+	| { kind: "ret" }
+	| { kind: "error" };
+
+export function resolveEdge(flow: Flow, currentNodeId: NodeId, event: FlowEvent): NodeId | null {
+	for (const edge of flow.edges) {
+		if (edge.from !== currentNodeId) continue;
+		const when = edge.when ?? { kind: "always" };
+		if (edgeMatches(when, event)) return edge.to;
+	}
+	return null;
+}
+
+function edgeMatches(when: NonNullable<Flow["edges"][number]["when"]>, event: FlowEvent): boolean {
+	switch (when.kind) {
+		case "always":
+			return true;
+		case "tool_call":
+			return event.kind === "tool_call" && when.name === event.name;
+		case "ret":
+			return event.kind === "ret";
+		case "error":
+			return event.kind === "error";
+		case "custom":
+			return false;
+	}
+}

--- a/packages/coding-agent/src/flow/flow-hook-executor.ts
+++ b/packages/coding-agent/src/flow/flow-hook-executor.ts
@@ -1,0 +1,73 @@
+/**
+ * Flow hook executor.
+ *
+ * Hooks are hardcoded tool invocations the runtime performs automatically
+ * at frame lifecycle boundaries. They do NOT go through the model — they
+ * are side effects injected by the flow author to offload repetitive work
+ * (load rule files, run a build, etc.).
+ *
+ * Given a list of `HookCall` and a minimal context (the tool table), the
+ * executor iterates the hooks in order, looks up each tool by name, and
+ * calls its `execute(toolCallId, args)`. Results are appended to an output
+ * channel (the caller decides where — typically the current frame's
+ * pocketMessages).
+ *
+ * On error, the executor invokes the node's `onError` hook list (if any)
+ * and rethrows so the interpreter can surface the failure.
+ */
+
+import type { AgentMessage, AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { HookCall } from "./flow-types";
+
+export interface HookExecutorContext {
+	tools: readonly AgentTool<any>[];
+	/** Called once per hook result. The sink chooses how to persist. */
+	appendMessage: (message: AgentMessage) => void;
+}
+
+function nextHookCallId(): string {
+	return `hook_${crypto.randomUUID().slice(0, 8)}`;
+}
+
+function hookResultToMessage(toolName: string, result: unknown): AgentMessage {
+	const text = typeof result === "string" ? result : JSON.stringify(result ?? null);
+	return {
+		role: "developer",
+		content: [{ type: "text", text: `[hook ${toolName}] ${text}` }],
+		timestamp: Date.now(),
+	} as AgentMessage;
+}
+
+export async function runHooks(
+	hooks: readonly HookCall[] | undefined,
+	ctx: HookExecutorContext,
+	onError?: readonly HookCall[],
+): Promise<void> {
+	if (!hooks || hooks.length === 0) return;
+	for (const hook of hooks) {
+		const tool = ctx.tools.find(t => t.name === hook.tool);
+		if (!tool) {
+			const msg = hookResultToMessage(hook.tool, `(skipped: tool not found)`);
+			ctx.appendMessage(msg);
+			continue;
+		}
+		try {
+			const id = nextHookCallId();
+			const result = await tool.execute(id, (hook.args ?? {}) as any);
+			let rendered = "";
+			if (result && typeof result === "object" && "content" in result && Array.isArray((result as any).content)) {
+				for (const block of (result as any).content as Array<Record<string, unknown>>) {
+					if (block && block.type === "text" && typeof block.text === "string") rendered += block.text;
+				}
+			}
+			ctx.appendMessage(hookResultToMessage(hook.tool, rendered));
+		} catch (e) {
+			ctx.appendMessage(hookResultToMessage(hook.tool, `(error: ${e instanceof Error ? e.message : String(e)})`));
+			if (onError && onError.length > 0) {
+				// Run the onError list but don't recurse its own errors.
+				await runHooks(onError, ctx);
+			}
+			throw e;
+		}
+	}
+}

--- a/packages/coding-agent/src/flow/flow-interpreter.ts
+++ b/packages/coding-agent/src/flow/flow-interpreter.ts
@@ -1,0 +1,256 @@
+/**
+ * Flow interpreter — runtime for data-driven flows.
+ *
+ * Wraps a `FlowRuntime` (which owns the frame stack) and layers the
+ * flow semantics on top: tool filter, node-as-tool exposure, edges,
+ * triggers, and lifecycle hooks.
+ *
+ * Callers drive the interpreter from the strategy:
+ *
+ *   const interp = new FlowInterpreter(flow);
+ *   await interp.pushNode("chat", ctx);
+ *   ...
+ *   interp.resolveTools(parentScope);   // effective scope for current frame
+ *   interp.handleEvent({kind:"tool_call", name:"..."}, ctx);  // drive edges
+ *   await interp.popNode("done", ctx);
+ */
+
+import type { AgentMessage, AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { Type } from "@sinclair/typebox";
+import { FlowRuntime } from "./flow-runtime";
+import { type FlowEvent, resolveEdge } from "./flow-edge-resolver";
+import { type HookExecutorContext, runHooks } from "./flow-hook-executor";
+import { applyToolFilter } from "./flow-tool-filter";
+import { matchTriggers, type TriggerEvent } from "./flow-trigger-matcher";
+import type { Flow as FlowV2, FlowNode, NodeId } from "./flow-types";
+import type { CallFrame } from "./types";
+
+export interface InterpreterContext {
+	/** Tool table visible at the outermost scope; used to resolve hook tool names. */
+	tools: readonly AgentTool<any>[];
+	/** Called whenever the interpreter wants to persist a message into the current frame. */
+	appendMessage?: (message: AgentMessage) => void;
+}
+
+export class FlowInterpreter {
+	#flow: FlowV2;
+	#runtime: FlowRuntime;
+	/** Current node id per frame, keyed by frame.id. Edge transitions mutate this without popping. */
+	#nodeByFrame: Map<string, NodeId> = new Map();
+
+	constructor(flow: FlowV2, runtime?: FlowRuntime) {
+		this.#flow = flow;
+		this.#runtime = runtime ?? new FlowRuntime(flow);
+	}
+
+	get flow(): FlowV2 {
+		return this.#flow;
+	}
+
+	get runtime(): FlowRuntime {
+		return this.#runtime;
+	}
+
+	get currentNodeId(): NodeId | undefined {
+		const top = this.#runtime.topFrame;
+		if (!top) return undefined;
+		return this.#nodeByFrame.get(top.id) ?? top.nodeId;
+	}
+
+	get currentNode(): FlowNode | undefined {
+		const id = this.currentNodeId;
+		return id ? this.#flow.nodes[id] : undefined;
+	}
+
+	get frameStack(): readonly CallFrame[] {
+		return this.#runtime.frameStack;
+	}
+
+	get isStackEmpty(): boolean {
+		return this.#runtime.isStackEmpty;
+	}
+
+	/**
+	 * Replace the in-memory flow definition (used by flow_edit). Also
+	 * refreshes the runtime's node table so new node ids can be pushed.
+	 */
+	replaceFlow(flow: FlowV2): void {
+		this.#flow = flow;
+		this.#runtime.replaceNodes(flow.nodes);
+	}
+
+	/**
+	 * Compute the effective tool list for the current frame by:
+	 *  1. Applying the current node's `available_tools` filter over the
+	 *     parent scope (which is the base tools provided by the agent).
+	 *  2. Adding one exposed "node-as-tool" per node id that appears in the
+	 *     filter and exists in `flow.nodes` but is NOT already in the base
+	 *     scope. Calling that tool pushes a new frame on that node.
+	 *
+	 * If the stack is empty or the current node is unknown, returns the
+	 * parent scope unchanged.
+	 */
+	resolveTools(parentScope: readonly AgentTool<any>[]): AgentTool<any>[] {
+		const node = this.currentNode;
+		if (!node) return [...parentScope];
+		const filtered = applyToolFilter(parentScope, node.available_tools);
+
+		// Expose any node id mentioned (positively) in the filter as a tool.
+		const filter = node.available_tools ?? [];
+		for (const entry of filter) {
+			if (entry.startsWith("!")) continue;
+			if (entry.includes("*")) continue;
+			if (this.#flow.nodes[entry] && !filtered.some(t => t.name === entry)) {
+				filtered.push(this.makeNodeEntryTool(entry, () => parentScope));
+			}
+		}
+		return filtered;
+	}
+
+	/**
+	 * Build an AgentTool the model can call to push a new frame on the
+	 * given node id. The tool name/label/description mirror the node
+	 * definition. `ctxTools` supplies the tool catalog handed to onEnter
+	 * hooks at push time — the strategy passes the live parent-frame
+	 * catalog so hooks can reach the same tools the model sees.
+	 */
+	makeNodeEntryTool(
+		nodeId: NodeId,
+		ctxTools: () => readonly AgentTool<any>[],
+		overrides?: { description?: string; label?: string; appendMessage?: () => ((msg: AgentMessage) => void) | undefined },
+	): AgentTool<any> {
+		const interp = this;
+		const node = this.#flow.nodes[nodeId];
+		const getAppend = overrides?.appendMessage;
+		return {
+			name: nodeId,
+			label: overrides?.label ?? nodeId,
+			description: overrides?.description ?? node?.description ?? `Enter sub-flow ${nodeId}`,
+			parameters: Type.Object({
+				reason: Type.String({
+					minLength: 1,
+					description: "REQUIRED — brief description of why you are entering this sub-flow, based on the user request or current task.",
+				}),
+			}),
+			strict: false,
+			concurrency: "exclusive",
+			async execute(_id: string, params: { reason?: string }): Promise<AgentToolResult> {
+				const reason = params?.reason ?? nodeId;
+				await interp.pushNode(nodeId, { tools: ctxTools(), appendMessage: getAppend?.() });
+				return { content: [{ type: "text", text: `Entered ${nodeId}: ${reason}` }] };
+			},
+		};
+	}
+
+	/**
+	 * Push a new frame on the given node id. Runs `onEnter` hooks as real
+	 * tool calls against the provided context and seeds the frame pocket
+	 * with their rendered results. If the node has a `prompt` field, it
+	 * is appended as a user message *after* the hooks — the model sees
+	 * the loaded context first, then the instructions.
+	 */
+	async pushNode(nodeId: NodeId, ctx: InterpreterContext): Promise<CallFrame> {
+		const node = this.#flow.nodes[nodeId];
+		if (!node) {
+			throw new Error(`FlowInterpreter: unknown node "${nodeId}"`);
+		}
+		const frame = this.#runtime.openFrame(nodeId, node.description ?? `frame at ${nodeId}`);
+		this.#nodeByFrame.set(frame.id, nodeId);
+		await this.#runHooks(node.onEnter, node.onError, ctx, frame);
+
+		const prompt = node.prompt?.trim();
+		if (prompt && ctx.appendMessage) {
+			ctx.appendMessage({
+				role: "user",
+				content: [{ type: "text", text: prompt }],
+				timestamp: Date.now(),
+			} as unknown as AgentMessage);
+		}
+
+		return frame;
+	}
+
+	/**
+	 * Pop the top frame. Runs `onLeave` hooks first. Returns the closed
+	 * frame with its return value.
+	 */
+	async popNode(returnValue: string | undefined, ctx: InterpreterContext): Promise<CallFrame | undefined> {
+		const top = this.#runtime.topFrame;
+		if (!top) return undefined;
+		const currentId = this.#nodeByFrame.get(top.id) ?? top.nodeId;
+		const node = this.#flow.nodes[currentId];
+		await this.#runHooks(node?.onLeave, node?.onError, ctx, top);
+		const closed = this.#runtime.closeFrame(returnValue ?? "");
+		this.#nodeByFrame.delete(top.id);
+		return closed;
+	}
+
+	/**
+	 * Drive an event through the current frame. If an outgoing edge from
+	 * the current node matches, transition:
+	 *   - `ret` edge → pop the frame
+	 *   - anything else → mutate the frame's active node under the frame
+	 *                    (same frame, different node)
+	 * Returns the new current node id (or null if no transition).
+	 */
+	async handleEvent(event: FlowEvent, ctx: InterpreterContext): Promise<NodeId | null> {
+		const top = this.#runtime.topFrame;
+		if (!top) return null;
+		const currentId = this.#nodeByFrame.get(top.id) ?? top.nodeId;
+		const next = resolveEdge(this.#flow, currentId, event);
+		if (!next) return null;
+
+		// A `ret` edge or an edge whose target is an ancestor: pop.
+		const wantsPop = event.kind === "ret";
+		if (wantsPop) {
+			await this.popNode(next, ctx);
+			return next;
+		}
+
+		// In-frame transition: swap the current node without popping.
+		const newNode = this.#flow.nodes[next];
+		if (newNode) {
+			this.#nodeByFrame.set(top.id, next);
+			await this.#runHooks(newNode.onEnter, newNode.onError, ctx, top);
+		}
+		return next;
+	}
+
+	/**
+	 * Scan flow-level triggers and auto-push any node whose trigger fires
+	 * for this event. Returns the ids of nodes that were pushed.
+	 */
+	async runTriggers(event: TriggerEvent, ctx: InterpreterContext): Promise<NodeId[] > {
+		const ids = matchTriggers(this.#flow, event);
+		for (const id of ids) {
+			await this.pushNode(id, ctx);
+		}
+		return ids;
+	}
+
+	async #runHooks(
+		hooks: FlowNode["onEnter"],
+		onError: FlowNode["onError"],
+		ctx: InterpreterContext,
+		frame: CallFrame,
+	): Promise<void> {
+		if (!hooks || hooks.length === 0) return;
+		const hookCtx: HookExecutorContext = {
+			tools: ctx.tools,
+			appendMessage: (msg: AgentMessage) => {
+				// Append into the frame's pocket. Also invoke the outer sink
+				// if provided so the strategy can mirror hooks into its own
+				// pocketRefs tracking.
+				this.#runtime.appendToCurrentFrame(msg);
+				ctx.appendMessage?.(msg);
+			},
+		};
+		try {
+			await runHooks(hooks, hookCtx, onError);
+		} catch {
+			// Hook errors are surfaced via the pocket message trail; the
+			// frame stays open so the model can observe and recover.
+		}
+		void frame;
+	}
+}

--- a/packages/coding-agent/src/flow/flow-message-utils.ts
+++ b/packages/coding-agent/src/flow/flow-message-utils.ts
@@ -1,0 +1,110 @@
+/**
+ * Flow message utilities — shared helpers for inspecting AgentMessage
+ * content blocks. Kept in one place so the strategy, runtime, and sub-agent
+ * helper agree on what "text" or "tool call" means in a message.
+ */
+
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+
+interface ContentBlock {
+	type?: unknown;
+	text?: unknown;
+	name?: unknown;
+	id?: unknown;
+}
+
+function blocksOf(msg: AgentMessage): ContentBlock[] {
+	const m = msg as { content?: unknown };
+	return Array.isArray(m.content) ? (m.content as ContentBlock[]) : [];
+}
+
+/**
+ * Concatenate every `text` block in the message. Non-text blocks are
+ * skipped. Returns "" for string-content or non-array content.
+ */
+export function extractText(message: AgentMessage): string {
+	const m = message as { content?: unknown };
+	if (typeof m.content === "string") return m.content;
+	if (!Array.isArray(m.content)) return "";
+	const parts: string[] = [];
+	for (const block of m.content as ContentBlock[]) {
+		if (block && block.type === "text" && typeof block.text === "string") {
+			parts.push(block.text);
+		}
+	}
+	return parts.join(" ");
+}
+
+/**
+ * Short preview for trace logs: text blocks concatenated, tool calls
+ * rendered as `[tool:NAME]`, thinking blocks as `[thinking]`. Clipped to
+ * 200 chars so it never bloats a trace file.
+ */
+export function previewMessage(message: AgentMessage): string {
+	const m = message as { content?: unknown };
+	if (typeof m.content === "string") return m.content.slice(0, 200);
+	if (!Array.isArray(m.content)) return "";
+	const parts: string[] = [];
+	for (const block of m.content as ContentBlock[]) {
+		if (!block || typeof block !== "object") continue;
+		if (block.type === "text" && typeof block.text === "string") parts.push(block.text);
+		else if (block.type === "toolCall" && typeof block.name === "string") parts.push(`[tool:${block.name}]`);
+		else if (block.type === "thinking") parts.push("[thinking]");
+	}
+	return parts.join(" ").slice(0, 200);
+}
+
+/**
+ * Walk a conversation in reverse and return the last assistant message's
+ * concatenated text. Used by the sub-agent runner to surface the final
+ * result to the caller. Empty assistant turns are skipped.
+ */
+export function extractFinalAssistantText(messages: readonly AgentMessage[]): string {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const msg = messages[i];
+		if ((msg as { role?: string }).role !== "assistant") continue;
+		const text = extractText(msg);
+		if (text.trim().length > 0) return text;
+	}
+	return "(sub-agent produced no text output)";
+}
+
+/**
+ * Result of classifying an assistant message in a single pass over its
+ * content blocks.
+ */
+export interface AssistantClassification {
+	/** True if the message has no toolCall blocks. */
+	isPlainText: boolean;
+	/** Ordered list of tool call names (may be empty). */
+	toolCallNames: string[];
+	/** Ordered list of tool call ids aligned with toolCallNames. */
+	toolCallIds: string[];
+}
+
+/**
+ * Single-pass scan of an assistant message's content. Everything the
+ * strategy needs to know about a turn (plain text? which tools were
+ * called?) is derived from one iteration. Non-assistant messages return
+ * an empty classification.
+ */
+export function classifyAssistantMessage(message: AgentMessage): AssistantClassification {
+	const role = (message as { role?: string }).role;
+	if (role !== "assistant") {
+		return { isPlainText: false, toolCallNames: [], toolCallIds: [] };
+	}
+	const toolCallNames: string[] = [];
+	const toolCallIds: string[] = [];
+	for (const block of blocksOf(message)) {
+		if (block?.type === "toolCall") {
+			const name = typeof block.name === "string" ? block.name : "";
+			toolCallNames.push(name);
+			toolCallIds.push(typeof block.id === "string" ? block.id : "");
+		}
+	}
+	return {
+		isPlainText: toolCallNames.length === 0,
+		toolCallNames,
+		toolCallIds,
+	};
+}

--- a/packages/coding-agent/src/flow/flow-runtime.ts
+++ b/packages/coding-agent/src/flow/flow-runtime.ts
@@ -1,0 +1,331 @@
+/**
+ * FlowRuntime — call stack over LLM.
+ *
+ * The runtime owns a stack of CallFrames. Each frame is one in-flight pocket
+ * call: a sub-conversation between the model and the orchestrator that is
+ * invisible to the persisted history. Push a frame to enter a call; pop it
+ * (with a return value) to exit. Recursive by construction: while a frame is
+ * open, the model can call into another node which pushes a child frame; when
+ * the child returns, the parent resumes with the return value as the result
+ * of its tool call.
+ *
+ * Edits to the flow are first-class. The model can rewrite a node mid-call;
+ * if the rewritten node corresponds to an open frame, every descendant frame
+ * is marked superseded and a fresh frame is pushed at the same nodeId so the
+ * call stack re-runs from that point. The original frames stay in the
+ * executionLog forever — the audit trail is append-only.
+ *
+ * The runtime is deliberately framework-free: it does not import from
+ * pi-agent-core. The strategy adapts ctx.messages / ctx.tools / pocketMessages
+ * at the boundary; the runtime only knows about its own data model.
+ */
+
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { previewMessage } from "./flow-message-utils";
+import type { Flow, FlowNode, NodeId } from "./flow-types";
+import type { CallFrame, FlowState } from "./types";
+
+function newFrameId(): string {
+	return `f_${crypto.randomUUID().slice(0, 8)}`;
+}
+
+/**
+ * Edit operation produced by the model via the flow_edit tool. `set_node`
+ * writes a complete replacement FlowNode; `delete_node` removes one.
+ *
+ * If the edited node corresponds to a frame currently on the stack, the
+ * runtime supersedes that frame (and its descendants) and re-pushes a fresh
+ * frame at the same node id so execution restarts from the rewritten point.
+ * Superseded frames remain in the execution log with status="superseded".
+ */
+export type FlowEditOp =
+	| { kind: "set_node"; nodeId: NodeId; node: FlowNode }
+	| { kind: "delete_node"; nodeId: NodeId };
+
+export interface FlowEditResult {
+	applied: FlowEditOp[];
+	supersededFrameIds: string[];
+	rerunFrameId?: string;
+}
+
+export type FlowTraceEvent =
+	| { kind: "frame_open"; frameId: string; parentId: string | null; nodeId: NodeId; purpose: string; at: number }
+	| { kind: "frame_message"; frameId: string; role: string; preview: string; at: number }
+	| { kind: "frame_close"; frameId: string; returnValue: string; at: number }
+	| {
+			kind: "flow_edit";
+			ops: FlowEditOp[];
+			supersededFrameIds: string[];
+			rerunFrameId?: string;
+			at: number;
+	  }
+	| {
+			kind: "model_request";
+			at: number;
+			systemPrompt: string;
+			tools: string[];
+			messages: unknown[];
+	  };
+
+export type FlowTraceListener = (event: FlowTraceEvent) => void;
+export type FlowEditListener = (result: FlowEditResult, flow: Flow) => void;
+
+export class FlowRuntime {
+	#flow: Flow;
+	#nodes: Record<NodeId, FlowNode>;
+	#frameStack: CallFrame[] = [];
+	#executionLog: CallFrame[] = [];
+	#listener: FlowTraceListener | null = null;
+	#editListener: FlowEditListener | null = null;
+	/** O(1) index of the most recent executionLog entry for a frame id. */
+	#logIndexByFrame: Map<string, number> = new Map();
+
+	constructor(
+		flow: Flow,
+		initialState?: { frameStack?: readonly CallFrame[]; executionLog?: readonly CallFrame[] },
+	) {
+		this.#flow = clone(flow);
+		this.#nodes = clone(this.#flow.nodes ?? {});
+		if (initialState?.frameStack) {
+			this.#frameStack = clone([...initialState.frameStack]);
+		}
+		if (initialState?.executionLog) {
+			this.#executionLog = clone([...initialState.executionLog]);
+			for (let i = 0; i < this.#executionLog.length; i++) {
+				this.#logIndexByFrame.set(this.#executionLog[i].id, i);
+			}
+		}
+	}
+
+	setTraceListener(listener: FlowTraceListener | null): void {
+		this.#listener = listener;
+	}
+
+	setEditListener(listener: FlowEditListener | null): void {
+		this.#editListener = listener;
+	}
+
+	/**
+	 * Replace the entire node table. Used by the strategy to reload the
+	 * flow from disk after an edit is persisted. Does not touch the frame
+	 * stack or the execution log.
+	 */
+	replaceNodes(nodes: Record<NodeId, FlowNode>): void {
+		this.#nodes = clone(nodes);
+	}
+
+	get flow(): Flow {
+		return { ...this.#flow, nodes: this.#nodes };
+	}
+
+	get nodes(): Readonly<Record<NodeId, FlowNode>> {
+		return this.#nodes;
+	}
+
+	getNode(id: NodeId): FlowNode | undefined {
+		return this.#nodes[id];
+	}
+
+	get currentNode(): FlowNode | undefined {
+		const top = this.topFrame;
+		return top ? this.#nodes[top.nodeId] : undefined;
+	}
+
+	get topFrame(): CallFrame | undefined {
+		return this.#frameStack[this.#frameStack.length - 1];
+	}
+
+	get frameStack(): readonly CallFrame[] {
+		return this.#frameStack;
+	}
+
+	get executionLog(): readonly CallFrame[] {
+		return this.#executionLog;
+	}
+
+	get isStackEmpty(): boolean {
+		return this.#frameStack.length === 0;
+	}
+
+	/**
+	 * Push a fresh frame onto the stack. The new frame becomes the active
+	 * frame; subsequent appendToCurrentFrame / closeFrame calls operate on it.
+	 *
+	 * Throws if nodeId does not exist. Caller is responsible for surfacing
+	 * this as a tool error to the model.
+	 */
+	openFrame(nodeId: NodeId, purpose: string): CallFrame {
+		if (!this.#nodes[nodeId]) {
+			throw new Error(`FlowRuntime: cannot open frame at unknown node "${nodeId}"`);
+		}
+		const parent = this.topFrame;
+		const frame: CallFrame = {
+			id: newFrameId(),
+			parentId: parent?.id ?? null,
+			nodeId,
+			purpose,
+			status: "open",
+			openedAt: Date.now(),
+		};
+		this.#frameStack.push(frame);
+		this.#executionLog.push(clone(frame));
+		this.#logIndexByFrame.set(frame.id, this.#executionLog.length - 1);
+		this.#emit({
+			kind: "frame_open",
+			frameId: frame.id,
+			parentId: frame.parentId,
+			nodeId: frame.nodeId,
+			purpose: frame.purpose,
+			at: frame.openedAt,
+		});
+		return frame;
+	}
+
+	/**
+	 * Record a message event in the active frame's trace log. The message
+	 * itself is NOT stored on the frame — filtering is done via
+	 * entryMessageIndex/exitMessageIndex in transformContext.
+	 */
+	appendToCurrentFrame(message: AgentMessage): void {
+		const top = this.topFrame;
+		if (!top) {
+			throw new Error("FlowRuntime: appendToCurrentFrame called with empty stack");
+		}
+		this.#emit({
+			kind: "frame_message",
+			frameId: top.id,
+			role: (message as { role?: string }).role ?? "unknown",
+			preview: previewMessage(message),
+			at: Date.now(),
+		});
+	}
+
+	/**
+	 * Close the active frame with a return value. Pops it off the stack and
+	 * mirrors the final state into the execution log. Returns the closed
+	 * frame so the caller can use the return value (e.g., to inject it as a
+	 * tool result into the parent frame).
+	 */
+	closeFrame(returnValue: string): CallFrame {
+		const top = this.topFrame;
+		if (!top) {
+			throw new Error("FlowRuntime: closeFrame called with empty stack");
+		}
+		top.status = "returned";
+		top.returnValue = returnValue;
+		top.closedAt = Date.now();
+		this.#mirrorToLog(top);
+		this.#frameStack.pop();
+		this.#emit({ kind: "frame_close", frameId: top.id, returnValue, at: top.closedAt });
+		return top;
+	}
+
+	/**
+	 * Apply edit ops to the flow definition. If any edited node corresponds
+	 * to a frame currently on the stack, the runtime supersedes that frame
+	 * and every descendant above it, then re-pushes a clean frame at the
+	 * earliest superseded node so execution restarts from the rewritten
+	 * point. The superseded frames stay in the execution log with
+	 * status="superseded" and supersededBy pointing at the new frame.
+	 */
+	editFlow(ops: FlowEditOp[]): FlowEditResult {
+		const result: FlowEditResult = { applied: [], supersededFrameIds: [] };
+		let earliestAffectedIdx: number | null = null;
+
+		for (const op of ops) {
+			if (op.kind === "set_node") {
+				this.#nodes[op.nodeId] = clone(op.node);
+				result.applied.push(op);
+				const idx = this.#frameStack.findIndex(f => f.nodeId === op.nodeId);
+				if (idx >= 0 && (earliestAffectedIdx === null || idx < earliestAffectedIdx)) {
+					earliestAffectedIdx = idx;
+				}
+			} else if (op.kind === "delete_node") {
+				delete this.#nodes[op.nodeId];
+				result.applied.push(op);
+				const idx = this.#frameStack.findIndex(f => f.nodeId === op.nodeId);
+				if (idx >= 0 && (earliestAffectedIdx === null || idx < earliestAffectedIdx)) {
+					earliestAffectedIdx = idx;
+				}
+			}
+		}
+
+		if (earliestAffectedIdx !== null) {
+			const targetNodeId = this.#frameStack[earliestAffectedIdx].nodeId;
+			const targetPurpose = this.#frameStack[earliestAffectedIdx].purpose;
+			const supersededSlice = this.#frameStack.slice(earliestAffectedIdx);
+			this.#frameStack.length = earliestAffectedIdx;
+
+			if (this.#nodes[targetNodeId]) {
+				const replacement = this.openFrame(targetNodeId, targetPurpose);
+				result.rerunFrameId = replacement.id;
+				for (const old of supersededSlice) {
+					old.status = "superseded";
+					old.supersededBy = replacement.id;
+					old.closedAt = Date.now();
+					this.#mirrorToLog(old);
+					result.supersededFrameIds.push(old.id);
+				}
+			} else {
+				for (const old of supersededSlice) {
+					old.status = "superseded";
+					old.closedAt = Date.now();
+					this.#mirrorToLog(old);
+					result.supersededFrameIds.push(old.id);
+				}
+			}
+		}
+
+		this.#emit({
+			kind: "flow_edit",
+			ops: result.applied,
+			supersededFrameIds: result.supersededFrameIds,
+			rerunFrameId: result.rerunFrameId,
+			at: Date.now(),
+		});
+		if (this.#editListener) {
+			try {
+				this.#editListener(result, { ...this.#flow, nodes: this.#nodes });
+			} catch {
+				// listener errors must not break the runtime
+			}
+		}
+		return result;
+	}
+
+	/**
+	 * Snapshot the runtime into FlowState fields ready for serialization.
+	 * Called by the strategy in onAgentEnd before persisting the state
+	 * message into the conversation history.
+	 */
+	snapshot(): Pick<FlowState, "frameStack" | "executionLog"> {
+		return {
+			frameStack: clone(this.#frameStack),
+			executionLog: clone(this.#executionLog),
+		};
+	}
+
+	#emit(event: FlowTraceEvent): void {
+		if (this.#listener) {
+			try {
+				this.#listener(event);
+			} catch {
+				// trace errors must never break the runtime
+			}
+		}
+	}
+
+	#mirrorToLog(frame: CallFrame): void {
+		const logIdx = this.#logIndexByFrame.get(frame.id);
+		if (logIdx !== undefined && this.#executionLog[logIdx]?.id === frame.id) {
+			this.#executionLog[logIdx] = clone(frame);
+		} else {
+			this.#executionLog.push(clone(frame));
+			this.#logIndexByFrame.set(frame.id, this.#executionLog.length - 1);
+		}
+	}
+}
+
+function clone<T>(value: T): T {
+	return structuredClone(value);
+}

--- a/packages/coding-agent/src/flow/flow-skill-seed.ts
+++ b/packages/coding-agent/src/flow/flow-skill-seed.ts
@@ -1,0 +1,52 @@
+/**
+ * Flow skill seed — copies bundled skill files (SKILL.md + helpers) into
+ * the project's `.omp/skills/<name>/` directory on first run so the live
+ * flow can reference them via `skill://<name>`.
+ *
+ * The skill content is statically imported from `./skills/*​/SKILL.md` so
+ * it survives `bun build --compile` (reading from fs at runtime would fail
+ * once the binary is compiled).
+ *
+ * Only flow-owned skills live here. Pre-existing user skills in the
+ * project are never touched.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import flowEditorSkill from "./skills/flow-editor/SKILL.md" with { type: "text" };
+
+/**
+ * The set of skills the flow engine manages. Keys are skill names
+ * (matching `skill://<name>`). Values are the SKILL.md body.
+ */
+const BUNDLED_FLOW_SKILLS: Record<string, string> = {
+	"flow-editor": flowEditorSkill,
+};
+
+/**
+ * Seed the bundled flow skills into `<cwd>/.omp/skills/<name>/SKILL.md`
+ * if the destination file does not yet exist. Returns the list of skill
+ * names that were written this time (may be empty on subsequent runs).
+ */
+export function seedFlowSkills(cwd: string = process.cwd()): string[] {
+	const written: string[] = [];
+	const skillsDir = join(cwd, ".omp", "skills");
+	try {
+		mkdirSync(skillsDir, { recursive: true });
+	} catch {
+		// ignore
+	}
+	for (const [name, body] of Object.entries(BUNDLED_FLOW_SKILLS)) {
+		const dir = join(skillsDir, name);
+		const file = join(dir, "SKILL.md");
+		if (existsSync(file)) continue;
+		try {
+			mkdirSync(dir, { recursive: true });
+			writeFileSync(file, body, "utf8");
+			written.push(name);
+		} catch {
+			// best effort
+		}
+	}
+	return written;
+}

--- a/packages/coding-agent/src/flow/flow-state-codec.ts
+++ b/packages/coding-agent/src/flow/flow-state-codec.ts
@@ -1,0 +1,50 @@
+/**
+ * FlowState codec — serializes flow runtime state into the conversation
+ * history as a CustomMessage with customType "flow-state".
+ *
+ * Why CustomMessage:
+ * - Already exists in coding-agent (session/messages.ts). Zero touch required.
+ * - Gets persisted/loaded with session history for free.
+ * - Branching/undo/export/rollback all work because the state rides along
+ *   with the conversation.
+ *
+ * Why filter in convertToLlm:
+ * - The existing convertToLlm turns `custom` messages into user messages —
+ *   we don't want raw flow state as user text. The strategy strips
+ *   flow-state messages before delegating to the base converter.
+ */
+
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { CustomMessage } from "../session/messages";
+import { FLOW_STATE_CUSTOM_TYPE, type FlowState } from "./types";
+
+export type FlowStateMessage = CustomMessage<FlowState>;
+
+export function createFlowStateMessage(state: FlowState): FlowStateMessage {
+	return {
+		role: "custom",
+		customType: FLOW_STATE_CUSTOM_TYPE,
+		content: "",
+		display: false,
+		details: state,
+		timestamp: Date.now(),
+	};
+}
+
+export function isFlowStateMessage(message: AgentMessage): message is FlowStateMessage {
+	return message.role === "custom" && (message as CustomMessage).customType === FLOW_STATE_CUSTOM_TYPE;
+}
+
+/**
+ * Scan history backwards for the most recent flow-state message. Returns
+ * undefined if the conversation has no flow state yet.
+ */
+export function extractLatestFlowState(messages: readonly AgentMessage[]): FlowState | undefined {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const msg = messages[i];
+		if (isFlowStateMessage(msg)) {
+			return msg.details;
+		}
+	}
+	return undefined;
+}

--- a/packages/coding-agent/src/flow/flow-store.ts
+++ b/packages/coding-agent/src/flow/flow-store.ts
@@ -1,0 +1,80 @@
+/**
+ * Flow store — project-local persistence for the live flow definition.
+ *
+ * The live flow lives at `<cwd>/.omp/flow.json`. On first use, if the
+ * file does not exist, the store writes a copy of the bundled base flow
+ * and returns it. Users can hand-edit the file between runs; the model
+ * edits it at runtime via `flow_edit`.
+ *
+ * The seed is imported statically from `./flows/base-flow.json` (NOT
+ * read via fs) so the compiled `bun build --compile` binary inlines it
+ * at build time.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import baseFlow from "./flows/base-flow.json" with { type: "json" };
+import type { Flow as FlowV2 } from "./flow-types";
+
+export const BUNDLED_BASE_FLOW: FlowV2 = baseFlow as FlowV2;
+
+export class FlowStore {
+	#path: string;
+	#fallback: FlowV2;
+
+	constructor(options?: { path?: string; fallback?: FlowV2; cwd?: string }) {
+		const cwd = options?.cwd ?? process.cwd();
+		this.#path = options?.path ?? join(cwd, ".omp", "flow.json");
+		this.#fallback = options?.fallback ?? cloneFlow(BUNDLED_BASE_FLOW);
+	}
+
+	get path(): string {
+		return this.#path;
+	}
+
+	load(): FlowV2 {
+		let raw: string;
+		try {
+			raw = readFileSync(this.#path, "utf8");
+		} catch (e) {
+			if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
+			this.save(this.#fallback);
+			return this.#fallback;
+		}
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(raw);
+		} catch (e) {
+			throw new Error(
+				`FlowStore: failed to parse ${this.#path} as JSON — ${(e as Error).message}. Fix or delete the file to reseed from the bundled base flow.`,
+			);
+		}
+		if (
+			parsed &&
+			typeof parsed === "object" &&
+			(parsed as FlowV2).version === 1 &&
+			(parsed as FlowV2).nodes &&
+			typeof (parsed as FlowV2).nodes === "object"
+		) {
+			const flow = parsed as FlowV2;
+			if (!Array.isArray(flow.edges)) flow.edges = [];
+			return flow;
+		}
+		throw new Error(
+			`FlowStore: ${this.#path} is not a valid flow (expected { version: 1, nodes: {...} }). Delete the file to reseed.`,
+		);
+	}
+
+	save(flow: FlowV2): void {
+		try {
+			mkdirSync(join(this.#path, ".."), { recursive: true });
+		} catch (e) {
+			if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+		}
+		writeFileSync(this.#path, `${JSON.stringify(flow, null, 2)}\n`, "utf8");
+	}
+}
+
+function cloneFlow(flow: FlowV2): FlowV2 {
+	return JSON.parse(JSON.stringify(flow)) as FlowV2;
+}

--- a/packages/coding-agent/src/flow/flow-strategy.ts
+++ b/packages/coding-agent/src/flow/flow-strategy.ts
@@ -1,0 +1,808 @@
+/**
+ * FlowExecutionStrategy — data-driven orchestrator over the live Agent.
+ *
+ * Wiring summary:
+ *   - syncBeforeModelCall: push the entry frame on first turn, compute the
+ *     effective tool set for the top of the flow stack, install the flow
+ *     system prompt, and expose meta tools + node-as-tools + attachments.
+ *   - transformContext: stable prefix + pocket messages from the open
+ *     frames + a trailing <flow> developer block describing the current
+ *     node and outgoing edges.
+ *   - onTurnEnd: drive the interpreter with each tool_call event; auto-pop
+ *     the top frame if the assistant answered with plain text and no tool
+ *     calls. Parent frames resume with their attached tools intact.
+ *   - onAgentEnd: persist flow state as a CustomMessage and close trace.
+ *
+ * Sub-flows are real. The `tool_selection` node, when pushed, injects the
+ * scene-local toolbox (search_tools / describe_tool / select_tool /
+ * drop_tool / ret) for as long as it is on top of the stack. select_tool
+ * attaches tools to the PARENT frame's attachment set; when the sub-flow
+ * rets, the parent resumes with those tools in scope.
+ */
+
+import type {
+	AgentContext,
+	AgentMessage,
+	AgentTool,
+	ExecutionStrategy,
+	StrategyConvertToLlmFn,
+} from "@oh-my-pi/pi-agent-core";
+import type { DeveloperMessage, Message, Model } from "@oh-my-pi/pi-ai";
+import { classifyAssistantMessage, extractText } from "./flow-message-utils";
+import { FlowRuntime } from "./flow-runtime";
+import {
+	createFlowStateMessage,
+	extractLatestFlowState,
+	isFlowStateMessage,
+} from "./flow-state-codec";
+import basePrompt from "./prompts/base.md" with { type: "text" };
+import stylePrompt from "./prompts/style.md" with { type: "text" };
+import toolSelectionPrompt from "./prompts/tool-selection.md" with { type: "text" };
+import { seedFlowSkills } from "./flow-skill-seed";
+import { FlowStore } from "./flow-store";
+import { createFlowEditTool, createFlowInspectTool, isFlowOwnedToolName } from "./flow-tools";
+import { FlowTraceWriter } from "./flow-trace";
+import { FlowInterpreter } from "./flow-interpreter";
+import { matchesName } from "./flow-tool-filter";
+import {
+	createToolSelectionTools,
+	TOOL_SELECTION_NODE_ID,
+	type ToolSelectionBackend,
+} from "./flow-tool-selection";
+import type { Flow as FlowV2 } from "./flow-types";
+import type { CallFrame, FlowState } from "./types";
+
+
+/**
+ * Core builtin tools that are always active in any chat/flow frame. The
+ * model should never need to `tool_selection` to reach these — they are
+ * the basic toolkit. MCP tools and niche builtins still go through the
+ * toolbox.
+ */
+const ALWAYS_ACTIVE_BUILTINS = [
+	"bash",
+	"read",
+	"write",
+	"edit",
+	"grep",
+	"find",
+	"lsp",
+	"ast_grep",
+	"ast_edit",
+	"task",
+	"todo_write",
+	"web_search",
+	"fetch",
+	"ask",
+];
+
+/**
+ * Auto-scout: tools that are "quiet" and can stay in the root frame
+ * without polluting context. Everything else is "noisy" — when called
+ * from the root node and a `scout` node exists, the strategy wraps the
+ * tool so it auto-pushes a scout frame before executing.
+ *
+ * The model doesn't notice — it calls `bash` as usual. The wrapper
+ * pushes scout, runs the real tool inside, and returns the result.
+ * The model continues working in scout, then calls `ret(summary)` to
+ * surface findings. All intermediate output dies with the frame.
+ */
+const QUIET_TOOLS = new Set([
+	"ask",
+	"todo_write",
+	"task",
+]);
+
+export interface FlowExecutionStrategyOptions {
+	getSubAgentModel?: () => Model | undefined;
+	trace?: boolean;
+	storePath?: string;
+	/** Project working directory. Used to place .omp/flow.json. Defaults to process.cwd(). */
+	cwd?: string;
+	/** Session identifier used as a prefix for trace folders. */
+	sessionId?: string;
+	/** Node id to push at the start of every fresh user turn. Defaults to "chat". */
+	entryNodeId?: string;
+	/**
+	 * Persist a message through the host's normal pipeline (agent state +
+	 * session manager). Used by node-prompt injection so injected user
+	 * messages end up in session.jsonl. Caller wires this from main.ts.
+	 */
+	persistMessage?: (msg: AgentMessage) => void;
+}
+
+export class FlowExecutionStrategy implements ExecutionStrategy {
+	readonly name = "flow";
+
+	#options: FlowExecutionStrategyOptions;
+	#store: FlowStore;
+	#flow: FlowV2;
+	#interpreter: FlowInterpreter;
+	#hydratedFromHistory = false;
+	#trace: FlowTraceWriter | null = null;
+	#traceEnabled: boolean;
+	#seenUserMessages = new WeakSet<AgentMessage>();
+	#rootClosedForCurrentTurn = false;
+	#lastSystemPrompt: string | null = null;
+	#lastToolNames: string[] = [];
+	#entryNodeId: string;
+
+	/**
+	 * Per-node attachments. `select_tool` inside tool_selection adds to the
+	 * SET keyed on the parent frame's NODE ID (not frame id). This way the
+	 * attachments survive across user turns: when a fresh `chat` frame is
+	 * pushed for the next user message, it inherits the chat-node
+	 * attachment set automatically.
+	 *
+	 * When a frame closes its own node's attachments stay around — they
+	 * live with the node, not the frame instance — unless the user or the
+	 * model explicitly drops them via `drop_tool`.
+	 */
+	#attachments = new Map<string, Set<string>>();
+
+	/**
+	 * Pending ret request. Processed at onTurnEnd or drainPendingRet.
+	 */
+	#pendingRet: { value?: string } | null = null;
+
+	/**
+	 * Reference to the live AgentContext.messages array — set on every
+	 * syncBeforeModelCall. Used by interpreter pushNode (via the
+	 * appendMessage callback) to inject node prompts as user messages
+	 * after onEnter hooks complete.
+	 */
+	#liveMessages: AgentMessage[] | null = null;
+
+	/** Sub-flows that completed (ret) this conversation. Rendered in <flow>. */
+	#completedSubFlows: { nodeId: string; result: string }[] = [];
+
+
+	/**
+	 * Catalog snapshot refreshed every turn — mirror of ctx.tools sans the
+	 * flow-owned meta tools. Used by the tool_selection backend.
+	 */
+	#catalogSnapshot: { name: string; description: string }[] = [];
+
+
+
+	constructor(options: FlowExecutionStrategyOptions = {}) {
+		this.#options = options;
+		this.#traceEnabled = options.trace ?? !!process.env.OMP_FLOW_TRACE;
+		// Seed bundled flow skills (flow-editor, ...) into <cwd>/.omp/skills/
+		// before loading the flow, so `onEnter` hooks that reference
+		// `skill://flow-editor` resolve on first run.
+		seedFlowSkills(options.cwd);
+		this.#store = new FlowStore({ path: options.storePath, cwd: options.cwd });
+		this.#flow = this.#store.load();
+		this.#entryNodeId = options.entryNodeId ?? (this.#flow.nodes.chat ? "chat" : Object.keys(this.#flow.nodes)[0] ?? "chat");
+		this.#interpreter = new FlowInterpreter(this.#flow, new FlowRuntime(this.#flow));
+		this.#installTraceListener();
+	}
+
+	get storePath(): string {
+		return this.#store.path;
+	}
+
+	get interpreter(): FlowInterpreter {
+		return this.#interpreter;
+	}
+
+	/**
+	 * Register each flow node as a slash command (e.g. /scout, /fixer).
+	 * The command handler sends the args as a user prompt prefixed with
+	 * "enter <node>:" so the model enters the node with context.
+	 *
+	 * `promptFn` is called with the final text — the caller wires it to
+	 * session.prompt() from main.ts.
+	 */
+	registerNodeCommands(
+		runner: { registerCommand(name: string, options: { description?: string; handler: (args: string, ctx: any) => Promise<void> }): void },
+		promptFn: (text: string) => Promise<void>,
+	): void {
+		const skipNodes = new Set([this.#entryNodeId, TOOL_SELECTION_NODE_ID]);
+		for (const [nodeId, node] of Object.entries(this.#flow.nodes)) {
+			if (skipNodes.has(nodeId)) continue;
+			runner.registerCommand(nodeId, {
+				description: node.description ?? `Enter ${nodeId} sub-flow`,
+				async handler(args: string) {
+					const prompt = args.trim()
+						? `enter ${nodeId}: ${args.trim()}`
+						: `enter ${nodeId}`;
+					await promptFn(prompt);
+				},
+			});
+		}
+	}
+
+	createPayloadLogger(): ((payload: unknown) => unknown) | undefined {
+		if (!this.#traceEnabled || !this.#trace) return undefined;
+		const writer = this.#trace;
+		return (payload: unknown) => {
+			writer.writePayload(payload);
+			return undefined;
+		};
+	}
+
+	/**
+	 * Return the correct flowFrameId for a message at persist time.
+	 *
+	 * Called by session manager (the single writer) from `#appendEntry`.
+	 * The strategy owns the "which frame?" logic:
+	 *
+	 * For toolResult messages:
+	 *   - toolName is a node id → parent frame (node-entry tool's
+	 *     execute() already pushed a child frame, but the result
+	 *     belongs to the caller)
+	 *   - toolName is "ret" → parent frame (ret pops the child,
+	 *     result belongs to the caller)
+	 *
+	 * For assistant messages:
+	 *   - Contains a toolCall whose name is a node id → top frame
+	 *     (entry tool hasn't executed yet at message_end time, so
+	 *     stack is still the caller's — top is correct)
+	 *   - Contains a toolCall named "ret" → parent frame (the
+	 *     assistant decided to ret from the current sub-frame, so
+	 *     the message belongs to the caller that will resume)
+	 *
+	 * Everything else → top frame.
+	 */
+	getFrameIdForMessage(msg: unknown): string | undefined {
+		const stack = this.#interpreter.runtime.frameStack;
+		if (stack.length === 0) return undefined;
+
+		const m = msg as { role?: string; toolName?: string; content?: unknown[] };
+
+		// toolResult: node-entry and ret results belong to parent
+		if (m.role === "toolResult" && typeof m.toolName === "string") {
+			const isNodeEntry = m.toolName in this.#flow.nodes;
+			const isRet = m.toolName === "ret";
+			if ((isNodeEntry || isRet) && stack.length >= 2) {
+				return stack[stack.length - 2].id;
+			}
+		}
+
+		// assistant: node-entry or ret tool call → parent frame.
+		// Race: by the time the consumer persists the assistant message,
+		// the producer may have already executed the tool (pushing a child
+		// frame for node-entry, or setting pendingRet for ret). So the
+		// stack already reflects the post-execute state. We need parent.
+		if (m.role === "assistant" && Array.isArray(m.content)) {
+			const hasNodeEntry = m.content.some(
+				(b: any) => b?.type === "toolCall" && b.name in this.#flow.nodes,
+			);
+			const hasRet = m.content.some(
+				(b: any) => b?.type === "toolCall" && b.name === "ret",
+			);
+			if ((hasNodeEntry || hasRet) && stack.length >= 2) {
+				return stack[stack.length - 2].id;
+			}
+		}
+
+		return stack[stack.length - 1].id;
+	}
+
+	#installTraceListener(): void {
+		if (!this.#traceEnabled) return;
+		if (!this.#trace) this.#trace = new FlowTraceWriter(this.#options.sessionId);
+		const writer = this.#trace;
+		this.#interpreter.runtime.setTraceListener(event => writer.write(event));
+	}
+
+	get state(): Readonly<FlowState> {
+		const attachments: Record<string, string[]> = {};
+		for (const [nodeId, set] of this.#attachments) {
+			if (set.size > 0) attachments[nodeId] = Array.from(set);
+		}
+		return {
+			version: 2,
+			flowId: this.#flow.id,
+			cursor: this.#interpreter.currentNodeId ?? this.#entryNodeId,
+			frameStack: [...this.#interpreter.runtime.frameStack],
+			executionLog: [...this.#interpreter.runtime.executionLog],
+			attachments: Object.keys(attachments).length > 0 ? attachments : undefined,
+			completedSubFlows: this.#completedSubFlows.length > 0 ? [...this.#completedSubFlows] : undefined,
+		};
+	}
+
+	wrapConvertToLlm(base: StrategyConvertToLlmFn): StrategyConvertToLlmFn {
+		return async (messages: AgentMessage[]): Promise<Message[]> => {
+			const filtered = messages.filter(m => !isFlowStateMessage(m));
+			return base(filtered);
+		};
+	}
+
+	async transformContext(messages: AgentMessage[]): Promise<AgentMessage[]> {
+		this.#rehydrateOnce(messages);
+
+		// Set of frameIds that are currently open (on the stack).
+		const openFrameIds = new Set(
+			this.#interpreter.runtime.frameStack.map(f => f.id),
+		);
+
+		const view: AgentMessage[] = [];
+		for (let i = 0; i < messages.length; i++) {
+			if (isFlowStateMessage(messages[i])) continue;
+			const frameId = (messages[i] as any).flowFrameId as string | undefined;
+			// No frameId = pre-flow message, always include.
+			// frameId in openFrameIds = active frame, include.
+			// frameId NOT in openFrameIds = closed frame, exclude.
+			if (frameId !== undefined && !openFrameIds.has(frameId)) continue;
+			view.push(messages[i]);
+		}
+
+		const statusMsg = this.#buildFlowStatusMessage(view.length);
+		if (statusMsg) view.push(statusMsg);
+
+		this.#dumpModelRequest(view);
+		return view;
+	}
+
+	#dumpModelRequest(messages: readonly AgentMessage[]): void {
+		if (!this.#trace) return;
+		this.#trace.write({
+			kind: "model_request",
+			at: Date.now(),
+			systemPrompt: this.#lastSystemPrompt ?? "",
+			tools: this.#lastToolNames,
+			messages: messages as unknown[],
+		});
+	}
+
+	async syncBeforeModelCall(ctx: AgentContext): Promise<void> {
+		this.#rehydrateOnce(ctx.messages);
+		this.#maybeStartNewTrace(ctx.messages);
+
+		// Bind the live messages array so pushNode can append node prompts
+		// (via interpreter context's appendMessage callback) — both for
+		// the root push below and for auto-scout pushes triggered later
+		// inside tool execute closures.
+		this.#liveMessages = ctx.messages;
+
+		// The catalog is everything ctx.tools has minus our own meta tools
+		// AND minus any scene-local tools the strategy itself injected on
+		// the previous turn (search_tools / describe_tool / select_tool /
+		// drop_tool / ret). Refreshed each turn because MCP loads async.
+		// Meta tools `read_flow` / `flow_edit` are prepended so any node
+		// that mentions them in `available_tools` can opt in via the
+		// standard filter path — no special-casing of node ids.
+		const SCENE_LOCAL = new Set(["search_tools", "describe_tool", "select_tool", "drop_tool", "ret"]);
+		const baseCatalog = (ctx.tools ?? []).filter(
+			t => !isFlowOwnedToolName(t.name) && !SCENE_LOCAL.has(t.name) && t.name !== TOOL_SELECTION_NODE_ID,
+		);
+		const metaTools: AgentTool<any>[] = [
+			createFlowInspectTool(this.#interpreter),
+			createFlowEditTool(this.#interpreter, flow => {
+				this.#flow = flow;
+				this.#store.save(flow);
+			}),
+		];
+		const catalog: AgentTool<any>[] = [...metaTools, ...baseCatalog];
+		this.#catalogSnapshot = catalog.map(t => ({ name: t.name, description: t.description ?? "" }));
+
+		// Process any pending frame transitions left over from the previous
+		// turn (race: onTurnEnd may run after the next syncBeforeModelCall in
+		// the agent-loop producer/consumer pair).
+		await this.#drainPendingRet(catalog);
+
+		if (this.#interpreter.isStackEmpty && !this.#rootClosedForCurrentTurn) {
+			await this.#interpreter.pushNode(this.#entryNodeId, this.#interpreterCtx(catalog));
+		}
+
+		const topFrame = this.#interpreter.runtime.topFrame;
+		const topNodeId = this.#interpreter.currentNodeId;
+
+		// In-frame tool set:
+		//   1. Node-as-tool exposure for any other node the model can call
+		//      from the current node (resolved from the node's available_tools
+		//      filter). We do NOT leak the full catalog here.
+		//   2. Plus any tools this frame has "attached" via tool_selection.
+		//   3. If we are currently inside tool_selection, expose its
+		//      scene-local tools (search/describe/select/drop/ret).
+		let effective: AgentTool<any>[] = [];
+
+		if (topNodeId === TOOL_SELECTION_NODE_ID && topFrame) {
+			effective = createToolSelectionTools(this.#makeToolSelectionBackend(topFrame, catalog));
+		} else if (topFrame && topNodeId) {
+			const currentNode = this.#interpreter.currentNode;
+			const nodeFilter = currentNode?.available_tools;
+			const byName = new Map(catalog.map(t => [t.name, t]));
+
+			// Start with the baseline: core builtins + attached tools.
+			for (const name of ALWAYS_ACTIVE_BUILTINS) {
+				const tool = byName.get(name);
+				if (tool && !effective.some(t => t.name === name)) effective.push(tool);
+			}
+			const attached = this.#attachments.get(topNodeId) ?? new Set<string>();
+			for (const name of attached) {
+				const tool = byName.get(name);
+				if (tool && !effective.some(t => t.name === name)) effective.push(tool);
+			}
+
+			if (nodeFilter && nodeFilter.length > 0) {
+				// Node declared a filter: add allowed tools and node-as-tools
+				// on top of the baseline, then apply deny entries.
+				const denied: string[] = [];
+				for (const entry of nodeFilter) {
+					if (entry.startsWith("!")) {
+						denied.push(entry.slice(1));
+						continue;
+					}
+					// Wildcard allow: pull in every catalog tool that matches.
+					if (entry.includes("*")) {
+						for (const tool of catalog) {
+							if (matchesName(entry, tool.name) && !effective.some(t => t.name === tool.name)) {
+								effective.push(tool);
+							}
+						}
+						continue;
+					}
+					const tool = byName.get(entry);
+					if (tool && !effective.some(t => t.name === entry)) {
+						effective.push(tool);
+						continue;
+					}
+					const node = this.#flow.nodes[entry];
+					if (node && !effective.some(t => t.name === entry)) {
+						effective.push(this.#makeGenericNodeTool(entry, catalog));
+					}
+				}
+				// Remove denied tools (literal or wildcard).
+				if (denied.length > 0) {
+					effective = effective.filter(t => !denied.some(pat => matchesName(pat, t.name)));
+				}
+			} else {
+				// No filter: expose all flow nodes as callable tools.
+				for (const nodeId of Object.keys(this.#flow.nodes)) {
+					if (nodeId === topNodeId) continue;
+					if (nodeId === TOOL_SELECTION_NODE_ID) continue;
+					if (effective.some(t => t.name === nodeId)) continue;
+					effective.push(this.#makeGenericNodeTool(nodeId, catalog));
+				}
+			}
+
+			// tool_selection is always available (navigation, not work).
+			if (!effective.some(t => t.name === TOOL_SELECTION_NODE_ID)) {
+				effective.push(this.#makeToolSelectionEntryTool(catalog));
+			}
+
+			// In any non-root sub-frame, expose a generic `ret` tool so the
+			// model has an explicit way to close the frame and return to
+			// the caller. `tool_selection` supplies its own `ret` via the
+			// scene-local toolset above.
+			if (this.#interpreter.runtime.frameStack.length > 1 && !effective.some(t => t.name === "ret")) {
+				effective.push(this.#makeRetTool(catalog));
+			}
+		}
+
+		// Auto-scout: when at root and a `scout` node exists, wrap noisy
+		// tools so they auto-push a scout frame before executing. The model
+		// calls `bash` as usual — the wrapper is transparent. After the
+		// tool runs, the model continues in scout and must `ret(summary)`
+		// to surface findings. All intermediate output dies with the frame.
+		const isRoot = this.#interpreter.runtime.frameStack.length === 1;
+		const hasScout = !!this.#flow.nodes.scout;
+		if (isRoot && hasScout) {
+			effective = effective.map(t =>
+				QUIET_TOOLS.has(t.name) ? t : this.#wrapAutoScout(t, catalog),
+			);
+		}
+
+		ctx.tools = effective;
+		ctx.systemPrompt = this.#buildFlowSystemPrompt();
+		this.#lastSystemPrompt = ctx.systemPrompt;
+		this.#lastToolNames = ctx.tools.map(t => t.name);
+	}
+
+	/**
+	 * Build the InterpreterContext used for pushNode/popNode/handleEvent.
+	 * `appendMessage` writes into the live AgentContext.messages array
+	 * (bound at the top of syncBeforeModelCall) so node prompts injected
+	 * by the interpreter end up in the conversation immediately.
+	 */
+	#interpreterCtx(catalog: AgentTool<any>[]): { tools: AgentTool<any>[]; appendMessage?: (msg: AgentMessage) => void } {
+		return {
+			tools: catalog,
+			appendMessage: this.#makeAppendMessage(),
+		};
+	}
+
+	#makeToolSelectionEntryTool(catalog: AgentTool<any>[]): AgentTool<any> {
+		const strategy = this;
+		return this.#interpreter.makeNodeEntryTool(TOOL_SELECTION_NODE_ID, () => catalog, {
+			label: "ToolSelection",
+			description:
+				"Enter the tool_selection sub-flow to browse and activate tools from the catalog. Inside this frame you will see search_tools / describe_tool / select_tool / drop_tool / ret. Any tool you select is attached to THIS frame (the parent) and becomes callable when tool_selection rets. Scratch in the sub-flow dies with it.",
+			appendMessage: () => strategy.#makeAppendMessage(),
+		});
+	}
+
+	#makeGenericNodeTool(nodeId: string, catalog: AgentTool<any>[]): AgentTool<any> {
+		const strategy = this;
+		return this.#interpreter.makeNodeEntryTool(nodeId, () => catalog, {
+			appendMessage: () => strategy.#makeAppendMessage(),
+		});
+	}
+
+	#makeAppendMessage(): ((msg: AgentMessage) => void) | undefined {
+		const persist = this.#options.persistMessage;
+		const live = this.#liveMessages;
+		if (!persist && !live) return undefined;
+		return msg => {
+			// Persist through the host pipeline (agent state + session manager).
+			persist?.(msg);
+			// Also push into the live ctx.messages so the model sees the
+			// message *immediately* this turn — without waiting for the
+			// agent loop to round-trip the new message back into context.
+			if (live && !live.includes(msg)) live.push(msg);
+		};
+	}
+
+	/**
+	 * Wrap a tool for auto-scout: when the model calls it from root, the
+	 * wrapper pushes a scout frame, executes the real tool inside, and
+	 * returns the result. The model continues in scout (sees ret + all
+	 * noisy tools) and must ret(summary) to exit. Transparent — same
+	 * name, same params, same result shape.
+	 */
+	#wrapAutoScout(tool: AgentTool<any>, catalog: AgentTool<any>[]): AgentTool<any> {
+		// Don't wrap node-entry tools or flow meta tools
+		if (tool.name in this.#flow.nodes) return tool;
+		if (isFlowOwnedToolName(tool.name)) return tool;
+		if (tool.name === "ret") return tool;
+
+		const strategy = this;
+		const realExecute = tool.execute.bind(tool);
+		return {
+			...tool,
+			async execute(id: string, params: any, ...rest: any[]): Promise<any> {
+				// If we're already inside scout (or any sub-frame), don't
+				// push again. The first noisy tool call in a root turn
+				// pushes scout; subsequent tool calls in the same turn run
+				// in the existing scout frame.
+				const stack = strategy.#interpreter.runtime.frameStack;
+				const alreadyInScout = stack.some(f => f.nodeId === "scout");
+				if (!alreadyInScout) {
+					await strategy.#interpreter.pushNode("scout", strategy.#interpreterCtx(catalog));
+				}
+				return realExecute(id, params, ...rest);
+			},
+		};
+	}
+
+	#makeRetTool(_catalog: AgentTool<any>[]): AgentTool<any> {
+		const strategy = this;
+		return {
+			name: "ret",
+			label: "Ret",
+			description:
+				"Close the current sub-flow frame and return control to the caller. `value` is REQUIRED and MUST be a non-empty string — it is the ONLY information that survives into the parent frame. Everything else (search results, file contents, reasoning) is discarded when the frame closes. Write a concrete, actionable summary of what you found or accomplished. If you have nothing to report, say why. An empty or missing value means the parent learns nothing from this sub-flow.",
+			parameters: {
+				type: "object",
+				properties: {
+					value: {
+						type: "string",
+						minLength: 1,
+						description: "REQUIRED — concrete result of this sub-flow: findings, decisions, artifacts. This is the only thing the caller will see.",
+					},
+				},
+				required: ["value"],
+			} as never,
+			strict: false,
+			concurrency: "exclusive",
+			async execute(_id: string, params: { value?: string }): Promise<{ content: { type: "text"; text: string }[] }> {
+				strategy.#pendingRet = { value: params?.value };
+				return { content: [{ type: "text", text: "ret" }] };
+			},
+		};
+	}
+
+	#makeToolSelectionBackend(topFrame: CallFrame, catalog: AgentTool<any>[]): ToolSelectionBackend {
+		const strategy = this;
+		// Attachments key is the PARENT NODE ID (not frame.id) so the
+		// attachments persist across user turns even when the chat frame
+		// is re-created for each fresh root push.
+		const stack = strategy.#interpreter.runtime.frameStack;
+		const parentFrame = stack[stack.length - 2];
+		const parentNodeId = parentFrame?.nodeId ?? topFrame.nodeId;
+		if (!strategy.#attachments.has(parentNodeId)) {
+			strategy.#attachments.set(parentNodeId, new Set<string>());
+		}
+		const set = strategy.#attachments.get(parentNodeId)!;
+		const byName = new Map(catalog.map(t => [t.name, t]));
+		return {
+			listCatalog: () => strategy.#catalogSnapshot.slice(),
+			attach: (name: string) => {
+				if (!byName.has(name)) return { ok: false, reason: `unknown tool "${name}"` };
+				set.add(name);
+				return { ok: true };
+			},
+			detach: (name: string) => {
+				if (!set.has(name)) return { ok: false, reason: `"${name}" not attached` };
+				set.delete(name);
+				return { ok: true };
+			},
+			currentAttachments: () => Array.from(set),
+			requestRet: (value?: string) => {
+				strategy.#pendingRet = { value };
+			},
+		};
+	}
+
+	async #popWithRetValue(retValue: string, catalog: AgentTool<any>[]): Promise<void> {
+		const nodeId = this.#interpreter.currentNodeId ?? "unknown";
+		await this.#interpreter.popNode(retValue, this.#interpreterCtx(catalog));
+		this.#completedSubFlows.push({ nodeId, result: retValue || "(no value)" });
+	}
+
+	async #drainPendingRet(catalog: AgentTool<any>[]): Promise<void> {
+		while (this.#pendingRet && this.#interpreter.runtime.frameStack.length > 1) {
+			await this.#popWithRetValue(this.#pendingRet.value ?? "", catalog);
+			this.#pendingRet = null;
+		}
+		// If pendingRet is still set but we're at root, discard it — never
+		// pop the root frame.
+		if (this.#pendingRet && this.#interpreter.runtime.frameStack.length <= 1) {
+			this.#pendingRet = null;
+		}
+	}
+
+	#buildFlowSystemPrompt(): string {
+		const cur = this.#interpreter.currentNodeId;
+		const node = this.#interpreter.currentNode;
+		const sections: string[] = [basePrompt.trimEnd()];
+		if (cur === TOOL_SELECTION_NODE_ID) {
+			sections.push(toolSelectionPrompt.trimEnd());
+		} else if (cur && node) {
+			const lines = [`## Current node: \`${cur}\``];
+			if (node.description) lines.push(node.description);
+			sections.push(lines.join("\n"));
+		}
+		sections.push(stylePrompt.trimEnd());
+		sections.push(`Today is ${new Date().toISOString().slice(0, 10)}.`);
+		return sections.join("\n\n");
+	}
+
+	async onTurnEnd(info: {
+		context: AgentContext;
+		message: AgentMessage;
+		newMessages: readonly AgentMessage[];
+	}): Promise<void> {
+		const stackWasNonEmpty =
+			!this.#interpreter.isStackEmpty || this.#interpreter.runtime.executionLog.length > 0;
+
+		// Single pass over the assistant message's content blocks.
+		const cls = classifyAssistantMessage(info.message);
+
+		// flowFrameId stamping is handled by session manager at persist
+		// time via getFrameIdForMessage(). No re-stamping here.
+
+		// Drive edges for every tool call in the assistant message.
+		// onTurnEnd doesn't have ctx.messages directly — but #liveMessages
+		// is still set from the last syncBeforeModelCall, so #interpreterCtx
+		// works. info.context.messages is the same array anyway.
+		this.#liveMessages = info.context.messages;
+		const catalog = (info.context.tools ?? []).filter(t => !isFlowOwnedToolName(t.name));
+		for (const name of cls.toolCallNames) {
+			await this.#interpreter.handleEvent({ kind: "tool_call", name }, this.#interpreterCtx(catalog));
+		}
+
+		// Ret: pop the sub-frame. Never pop the root frame — only sub-frames
+		// (depth > 1) should be closed by ret.
+		if (this.#pendingRet && this.#interpreter.runtime.frameStack.length > 1) {
+			await this.#popWithRetValue(this.#pendingRet.value ?? "", catalog);
+			this.#pendingRet = null;
+		}
+
+		if (this.#interpreter.isStackEmpty && stackWasNonEmpty) {
+			this.#rootClosedForCurrentTurn = true;
+		}
+	}
+
+	async onAgentEnd(info: { context: AgentContext; newMessages: readonly AgentMessage[] }): Promise<void> {
+		const stateMsg = createFlowStateMessage(this.state);
+		// Persist through the host pipeline so the state message lands in
+		// session.jsonl and survives restart. Falls back to in-memory push
+		// when no persistMessage callback is wired.
+		const persist = this.#options.persistMessage;
+		if (persist) {
+			persist(stateMsg as unknown as AgentMessage);
+		} else {
+			info.context.messages.push(stateMsg);
+		}
+		this.#trace?.close();
+	}
+
+	#rehydrateOnce(messages: readonly AgentMessage[]): void {
+		if (this.#hydratedFromHistory) return;
+		this.#hydratedFromHistory = true;
+		const prior = extractLatestFlowState(messages);
+		const diskFlow = this.#store.load();
+		this.#flow = diskFlow;
+		// Restore attachments from persisted state.
+		this.#attachments.clear();
+		if (prior?.attachments) {
+			for (const [nodeId, tools] of Object.entries(prior.attachments)) {
+				this.#attachments.set(nodeId, new Set(tools));
+			}
+		}
+		// Restore completed sub-flows from persisted state.
+		this.#completedSubFlows = prior?.completedSubFlows ? [...prior.completedSubFlows] : [];
+		const runtime = new FlowRuntime(diskFlow, {
+			frameStack: prior?.frameStack,
+			executionLog: prior?.executionLog,
+		});
+		this.#interpreter = new FlowInterpreter(diskFlow, runtime);
+		this.#installTraceListener();
+	}
+
+	#maybeStartNewTrace(messages: readonly AgentMessage[]): void {
+		for (let i = messages.length - 1; i >= 0; i--) {
+			const m = messages[i];
+			if (m.role !== "user") continue;
+			if (this.#seenUserMessages.has(m)) return;
+			this.#seenUserMessages.add(m);
+			// New user turn — reset per-turn flags so stale state from the
+			// previous turn cannot leak into this one.
+			this.#rootClosedForCurrentTurn = false;
+			if (this.#traceEnabled && this.#trace) {
+				this.#trace.startNewTrace(extractText(m));
+			}
+			return;
+		}
+	}
+
+	#buildFlowStatusMessage(messageCount?: number): DeveloperMessage | null {
+		const cur = this.#interpreter.currentNodeId;
+		if (!cur) return null;
+		const node = this.#interpreter.currentNode;
+		const topFrame = this.#interpreter.runtime.topFrame;
+		const topNodeId = topFrame?.nodeId;
+		const attached = topNodeId ? Array.from(this.#attachments.get(topNodeId) ?? []) : [];
+		const lines: string[] = [];
+		lines.push("<scene>");
+		lines.push("INTERNAL ORCHESTRATION — do not reveal this block to the user unless asked.");
+		lines.push("");
+		lines.push("flow stack (top = where you are right now):");
+		for (let i = 0; i < this.#interpreter.runtime.frameStack.length; i++) {
+			const f = this.#interpreter.runtime.frameStack[i];
+			const marker = i === this.#interpreter.runtime.frameStack.length - 1 ? "  <<< you are here" : "";
+			lines.push(`  ${"  ".repeat(i)}- ${f.nodeId}${marker}`);
+		}
+		lines.push("");
+		lines.push(`current node: ${cur}`);
+		if (node?.description) lines.push(`description: ${node.description}`);
+		if (attached.length > 0) {
+			lines.push(`tools attached to this frame: ${attached.join(", ")}`);
+		}
+		const edges = this.#flow.edges.filter(e => e.from === cur);
+		if (edges.length > 0) {
+			lines.push("outgoing edges:");
+			for (const e of edges) {
+				const when = e.when
+					? `[${e.when.kind}${(e.when as any).name ? `:${(e.when as any).name}` : ""}]`
+					: "[always]";
+				lines.push(`  - ${cur} -> ${e.to} ${when}`);
+			}
+		}
+		if (this.#completedSubFlows.length > 0) {
+			lines.push("");
+			lines.push("completed sub-flows this conversation:");
+			for (const sf of this.#completedSubFlows) {
+				lines.push(`  - ${sf.nodeId}: ${sf.result}`);
+			}
+		}
+		if (messageCount !== undefined) {
+			lines.push("");
+			lines.push(`context: ${messageCount} messages in window`);
+		}
+		lines.push("</scene>");
+		return {
+			role: "developer",
+			content: [{ type: "text", text: lines.join("\n") }],
+			timestamp: Date.now(),
+		};
+	}
+
+}
+
+export type { CallFrame };

--- a/packages/coding-agent/src/flow/flow-subagent.ts
+++ b/packages/coding-agent/src/flow/flow-subagent.ts
@@ -1,0 +1,79 @@
+/**
+ * Sub-agent helper — spawn a nested agentLoop with a minimal context so the
+ * parent conversation is not polluted with intermediate turns.
+ *
+ * The sub-agent receives only the task text and the allowed subset of tools.
+ * It returns the final assistant text, which the caller injects into the
+ * parent context as a single developer message.
+ *
+ * v1 constraints:
+ * - Model is inherited from the first LLM tool's implicit environment;
+ *   callers must pass it explicitly via `model`.
+ * - No nested flow execution — sub-agents use the plain agentLoop runner.
+ *   A sub-agent with its own flow is straightforward to add later by
+ *   calling runFlow recursively instead of agentLoop.
+ * - budgetTurns is advisory; the current agentLoop does not enforce a turn
+ *   cap directly, so the helper stops after the first assistant message
+ *   with no tool calls. Follow-up budget enforcement is not yet implemented.
+ */
+
+import type { AgentContext, AgentLoopConfig, AgentMessage, AgentTool } from "@oh-my-pi/pi-agent-core";
+import { agentLoop } from "@oh-my-pi/pi-agent-core";
+import type { Model, UserMessage } from "@oh-my-pi/pi-ai";
+import { convertToLlm as baseConvertToLlm } from "../session/messages";
+import { extractFinalAssistantText } from "./flow-message-utils";
+import { isFlowStateMessage } from "./flow-state-codec";
+import subAgentPrompt from "./prompts/sub-agent.md" with { type: "text" };
+
+export interface RunSubAgentOptions {
+	parentTools: readonly AgentTool<any>[];
+	task: string;
+	allowedTools: string[] | "*";
+	model: Model;
+	systemPrompt?: string;
+	budgetTurns?: number;
+	signal?: AbortSignal;
+}
+
+/**
+ * Run a sub-agent to completion and return its final text output.
+ *
+ * The sub-agent has its own fresh context — no access to parent history.
+ * This is deliberate: the whole point is to isolate a side task so the
+ * parent's prompt cache stays hot and its history stays small.
+ */
+export async function runSubAgent(options: RunSubAgentOptions): Promise<string> {
+	const { parentTools, task, allowedTools, model, systemPrompt, signal } = options;
+
+	const tools = filterTools(parentTools, allowedTools);
+
+	const context: AgentContext = {
+		systemPrompt: systemPrompt ?? subAgentPrompt.trim(),
+		messages: [],
+		tools,
+	};
+
+	const taskPrompt: UserMessage = {
+		role: "user",
+		content: [{ type: "text", text: task }],
+		timestamp: Date.now(),
+	};
+
+	const config: AgentLoopConfig = {
+		model,
+		convertToLlm: async (messages: AgentMessage[]) => baseConvertToLlm(messages.filter(m => !isFlowStateMessage(m))),
+		// No flow hooks here — sub-agents run plain.
+		getSteeringMessages: async () => [],
+		getFollowUpMessages: async () => [],
+	};
+
+	const stream = agentLoop([taskPrompt], context, config, signal);
+	const messages = await stream.result();
+	return extractFinalAssistantText(messages);
+}
+
+function filterTools(all: readonly AgentTool<any>[], allowed: string[] | "*"): AgentTool<any>[] {
+	if (allowed === "*") return [...all];
+	const set = new Set(allowed);
+	return all.filter(t => set.has(t.name));
+}

--- a/packages/coding-agent/src/flow/flow-tool-filter.ts
+++ b/packages/coding-agent/src/flow/flow-tool-filter.ts
@@ -1,0 +1,60 @@
+/**
+ * Flow tool filter.
+ *
+ * Given a parent tool scope and a node's `available_tools` filter, compute
+ * the effective tool set for the frame. Semantics:
+ *
+ *  - `filter === undefined` → pass-through (inherit parent scope).
+ *  - `filter` is a list of entries processed in order. Each entry is either
+ *    `"name"` (allow) or `"!name"` (deny). Allow entries add to the
+ *    working set; deny entries remove. Later entries override earlier ones.
+ *  - A `"*"` wildcard is supported on both sides (e.g. `"mcp_*"`, `"!mcp_*"`).
+ *  - Unknown names in an allow list are silently ignored (the tool is simply
+ *    not present in the parent scope).
+ *  - If the filter contains no allow entries but has deny entries, the
+ *    starting set is the parent scope (deny-only mode). If the filter has
+ *    any allow entry, the starting set is empty and allow entries opt tools
+ *    in one by one.
+ */
+
+import type { AgentTool } from "@oh-my-pi/pi-agent-core";
+
+/** Convert a glob with `*` wildcards to an anchored RegExp. */
+function globToRegex(glob: string): RegExp {
+	const escaped = glob.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+	return new RegExp(`^${escaped}$`);
+}
+
+export function matchesName(pattern: string, name: string): boolean {
+	if (!pattern.includes("*")) return pattern === name;
+	return globToRegex(pattern).test(name);
+}
+
+export function applyToolFilter(
+	parentScope: readonly AgentTool<any>[],
+	filter: readonly string[] | undefined,
+): AgentTool<any>[] {
+	if (filter === undefined) return [...parentScope];
+	if (filter.length === 0) return [...parentScope];
+
+	const hasAllow = filter.some(e => !e.startsWith("!"));
+	// Deny-only starts from the parent scope; allow-mode starts empty.
+	let working: AgentTool<any>[] = hasAllow ? [] : [...parentScope];
+
+	for (const entry of filter) {
+		if (entry.startsWith("!")) {
+			const pat = entry.slice(1);
+			working = working.filter(t => !matchesName(pat, t.name));
+		} else {
+			// Allow: find any tool in parentScope matching the pattern that
+			// is not already in `working`, and add it.
+			for (const tool of parentScope) {
+				if (matchesName(entry, tool.name) && !working.includes(tool)) {
+					working.push(tool);
+				}
+			}
+		}
+	}
+
+	return working;
+}

--- a/packages/coding-agent/src/flow/flow-tool-selection.ts
+++ b/packages/coding-agent/src/flow/flow-tool-selection.ts
@@ -1,0 +1,168 @@
+/**
+ * tool_selection sub-flow — runtime implementation.
+ *
+ * When the model calls the `tool_selection` node from a parent scope, a
+ * new frame is pushed. Inside that frame the model sees five real tools
+ * (search_tools, describe_tool, select_tool, drop_tool, ret) that the
+ * strategy injects dynamically while the frame is on top of the stack.
+ *
+ * Selections are recorded on the PARENT frame's attachment set — a map
+ * `parentFrameId → Set<string>` owned by the strategy. When the parent
+ * resumes after `ret`, the strategy merges the attachment set into the
+ * parent's resolved tool list. Attachments live only as long as the
+ * parent frame, and disappear when it itself closes.
+ *
+ * Scratch messages inside the tool_selection frame (search results,
+ * describe output) are pocket-only: they never survive past the ret.
+ */
+
+import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { type Static, Type } from "@sinclair/typebox";
+
+export const TOOL_SELECTION_NODE_ID = "tool_selection";
+
+export const TOOL_SELECTION_TOOL_NAMES = [
+	"search_tools",
+	"describe_tool",
+	"select_tool",
+	"drop_tool",
+	"ret",
+] as const;
+
+export type ToolSelectionToolName = (typeof TOOL_SELECTION_TOOL_NAMES)[number];
+
+/** Strategy-side API the scene-local tools need to do their job. */
+export interface ToolSelectionBackend {
+	/** Full catalog: every tool name the agent could possibly expose. */
+	listCatalog(): { name: string; description: string }[];
+	/** Attach a tool to the parent frame's attachment set. */
+	attach(name: string): { ok: boolean; reason?: string };
+	/** Detach a tool from the parent frame's attachment set. */
+	detach(name: string): { ok: boolean; reason?: string };
+	/** Read the parent frame's current attachment set. */
+	currentAttachments(): string[];
+	/** Signal: the model wants to return from this frame now. */
+	requestRet(value?: string): void;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tool factories
+// ──────────────────────────────────────────────────────────────────────────
+
+const searchSchema = Type.Object({
+	query: Type.String({ description: "substring or simple glob to match against tool names" }),
+});
+
+const describeSchema = Type.Object({
+	name: Type.String({ description: "exact tool name to describe" }),
+});
+
+const selectSchema = Type.Object({
+	name: Type.String({ description: "exact tool name to attach to the parent scope" }),
+});
+
+const dropSchema = Type.Object({
+	name: Type.String({ description: "exact tool name to detach from the parent scope" }),
+});
+
+const retSchema = Type.Object({
+	value: Type.String({ minLength: 1, description: "REQUIRED — concrete summary of what you accomplished or selected. This is the only information the caller will see." }),
+});
+
+export function createToolSelectionTools(backend: ToolSelectionBackend): AgentTool<any>[] {
+	return [
+		{
+			name: "search_tools",
+			label: "SearchTools",
+			description:
+				"Search the tool catalog by substring. Returns matching tool names. The result is scratch — it dies when you `ret` from this frame, so any tool you want must be `select_tool`-ed before ret.",
+			parameters: searchSchema,
+			strict: true,
+			concurrency: "shared",
+			async execute(_id: string, params: Static<typeof searchSchema>): Promise<AgentToolResult> {
+				const needle = params.query.toLowerCase();
+				const hits = backend.listCatalog().filter(t => t.name.toLowerCase().includes(needle));
+				const text = hits.length ? hits.map(t => t.name).join("\n") : "(no matches)";
+				return { content: [{ type: "text", text }], details: { hits } };
+			},
+		},
+		{
+			name: "describe_tool",
+			label: "DescribeTool",
+			description: "Return the full description of a tool by exact name without attaching it.",
+			parameters: describeSchema,
+			strict: true,
+			concurrency: "shared",
+			async execute(_id: string, params: Static<typeof describeSchema>): Promise<AgentToolResult> {
+				const entry = backend.listCatalog().find(t => t.name === params.name);
+				if (!entry) {
+					return {
+						content: [{ type: "text", text: `describe_tool: unknown tool "${params.name}"` }],
+						details: { found: false },
+					};
+				}
+				return {
+					content: [{ type: "text", text: `${entry.name}\n\n${entry.description}` }],
+					details: { found: true, name: entry.name },
+				};
+			},
+		},
+		{
+			name: "select_tool",
+			label: "SelectTool",
+			description:
+				"Attach a tool to the PARENT frame. The tool becomes callable in the caller as soon as this frame rets. The attachment lives on the parent frame and disappears when the parent itself closes.",
+			parameters: selectSchema,
+			strict: true,
+			concurrency: "exclusive",
+			async execute(_id: string, params: Static<typeof selectSchema>): Promise<AgentToolResult> {
+				const res = backend.attach(params.name);
+				return {
+					content: [
+						{ type: "text", text: res.ok ? `Attached \`${params.name}\` to parent scope.` : `select_tool: ${res.reason ?? "failed"}` },
+					],
+					details: res,
+				};
+			},
+		},
+		{
+			name: "drop_tool",
+			label: "DropTool",
+			description: "Remove a tool from the parent frame's attachment set.",
+			parameters: dropSchema,
+			strict: true,
+			concurrency: "exclusive",
+			async execute(_id: string, params: Static<typeof dropSchema>): Promise<AgentToolResult> {
+				const res = backend.detach(params.name);
+				return {
+					content: [
+						{ type: "text", text: res.ok ? `Detached \`${params.name}\`.` : `drop_tool: ${res.reason ?? "failed"}` },
+					],
+					details: res,
+				};
+			},
+		},
+		{
+			name: "ret",
+			label: "Ret",
+			description:
+				"Close the current frame and return control to the caller. `value` is REQUIRED — summarize which tools you attached and why. Any scratch in this frame is discarded; only the attached tools and your summary survive in the parent.",
+			parameters: retSchema,
+			strict: true,
+			concurrency: "exclusive",
+			async execute(_id: string, params: Static<typeof retSchema>): Promise<AgentToolResult> {
+				const selected = backend.currentAttachments();
+				backend.requestRet(params.value);
+				return {
+					content: [
+						{
+							type: "text",
+							text: `Returning with ${selected.length} attached tool(s): ${selected.join(", ") || "(none)"}`,
+						},
+					],
+					details: { attached: selected },
+				};
+			},
+		},
+	];
+}

--- a/packages/coding-agent/src/flow/flow-tools.ts
+++ b/packages/coding-agent/src/flow/flow-tools.ts
@@ -1,0 +1,205 @@
+/**
+ * Flow meta tools — `read_flow` and `flow_edit`.
+ *
+ * These are always-available tools the model uses to inspect and mutate
+ * the live flow definition. Both tools close over a `FlowInterpreter`
+ * instance; mutations go through the interpreter so that:
+ *   1. The in-memory flow is updated atomically.
+ *   2. The runtime's shim scene table is kept in sync so new node ids
+ *      can be pushed immediately.
+ *   3. The host strategy can persist the flow to disk via FlowStore.
+ *
+ * The v1 scene-action generator and the toolbox tool were removed —
+ * Uses triggers + `available_tools` to control tool surfacing.
+ */
+
+import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { type Static, Type } from "@sinclair/typebox";
+import type { FlowInterpreter } from "./flow-interpreter";
+import type { Flow as FlowV2, FlowEdge, FlowNode, FlowTrigger, NodeId } from "./flow-types";
+
+export const FLOW_EDIT_TOOL_NAME = "flow_edit";
+export const FLOW_INSPECT_TOOL_NAME = "read_flow";
+
+const FLOW_OWNED_NAMES = new Set<string>([FLOW_EDIT_TOOL_NAME, FLOW_INSPECT_TOOL_NAME]);
+
+export function isFlowOwnedToolName(name: string): boolean {
+	return FLOW_OWNED_NAMES.has(name);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// read_flow
+// ──────────────────────────────────────────────────────────────────────────
+
+const inspectSchema = Type.Object({});
+
+export interface FlowInspectDetails {
+	flowId: string;
+	flow: FlowV2;
+	currentNode: string | null;
+	stack: Array<{ id: string; nodeId: string; purpose: string }>;
+}
+
+export function createFlowInspectTool(
+	interpreter: FlowInterpreter,
+): AgentTool<typeof inspectSchema, FlowInspectDetails> {
+	return {
+		name: FLOW_INSPECT_TOOL_NAME,
+		label: "ReadFlow",
+		description:
+			"Read the whole live flow (nodes, edges, triggers) plus the current frame stack and the current node. Call this before `flow_edit` whenever you need to see what already exists so you can extend it instead of duplicating.",
+		parameters: inspectSchema,
+		strict: true,
+		concurrency: "shared",
+		async execute(): Promise<AgentToolResult<FlowInspectDetails>> {
+			const flow = interpreter.flow;
+			const details: FlowInspectDetails = {
+				flowId: flow.id,
+				flow,
+				currentNode: interpreter.currentNodeId ?? null,
+				stack: interpreter.frameStack.map(f => ({ id: f.id, nodeId: f.nodeId, purpose: f.purpose })),
+			};
+			return {
+				content: [{ type: "text", text: JSON.stringify(details, null, 2) }],
+				details,
+			};
+		},
+	};
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// flow_edit
+// ──────────────────────────────────────────────────────────────────────────
+
+const nodeShape = Type.Object({
+	description: Type.Optional(Type.String()),
+	prompt: Type.Optional(Type.String({ description: "Instructions injected into the system prompt when this frame is active." })),
+	available_tools: Type.Optional(Type.Array(Type.String())),
+	onEnter: Type.Optional(Type.Array(Type.Object({ tool: Type.String(), args: Type.Optional(Type.Object({}, { additionalProperties: true })) }))),
+	onLeave: Type.Optional(Type.Array(Type.Object({ tool: Type.String(), args: Type.Optional(Type.Object({}, { additionalProperties: true })) }))),
+	onError: Type.Optional(Type.Array(Type.Object({ tool: Type.String(), args: Type.Optional(Type.Object({}, { additionalProperties: true })) }))),
+	env: Type.Optional(Type.Object({}, { additionalProperties: true })),
+});
+
+const edgeShape = Type.Object({
+	from: Type.String(),
+	to: Type.String(),
+	when: Type.Optional(
+		Type.Object({
+			kind: Type.String(),
+			name: Type.Optional(Type.String()),
+			expr: Type.Optional(Type.String()),
+		}),
+	),
+});
+
+const triggerShape = Type.Object({
+	when: Type.String(),
+	match: Type.Object({
+		tool: Type.Optional(Type.String()),
+		path: Type.Optional(Type.String()),
+		flow: Type.Optional(Type.String()),
+		expr: Type.Optional(Type.String()),
+	}),
+});
+
+const editOpSchema = Type.Union([
+	Type.Object({
+		kind: Type.Literal("add_node"),
+		node_id: Type.String({ description: "Unique identifier for the new node (e.g. 'scout', 'backend_editor'). This is a SIBLING of 'node', not inside it." }),
+		node: Type.Intersect([nodeShape], { description: "Node definition: {description?, available_tools?, onEnter?, onLeave?, onError?, env?}. Do NOT put node_id here." }),
+	}),
+	Type.Object({ kind: Type.Literal("remove_node"), node_id: Type.String() }),
+	Type.Object({ kind: Type.Literal("add_edge"), edge: edgeShape }),
+	Type.Object({
+		kind: Type.Literal("remove_edge"),
+		from: Type.String(),
+		to: Type.String(),
+	}),
+	Type.Object({ kind: Type.Literal("add_trigger"), trigger: triggerShape }),
+	Type.Object({ kind: Type.Literal("remove_trigger"), index: Type.Number() }),
+]);
+
+const editSchema = Type.Object({
+	ops: Type.Array(editOpSchema, { minItems: 1 }),
+});
+
+export type FlowV2EditOp =
+	| { kind: "add_node"; node_id: NodeId; node: FlowNode }
+	| { kind: "remove_node"; node_id: NodeId }
+	| { kind: "add_edge"; edge: FlowEdge }
+	| { kind: "remove_edge"; from: NodeId; to: NodeId }
+	| { kind: "add_trigger"; trigger: FlowTrigger }
+	| { kind: "remove_trigger"; index: number };
+
+export interface FlowEditDetails {
+	applied: number;
+}
+
+/**
+ * Apply a list of edit operations to a flow, returning a new flow.
+ * Pure: the input is not mutated. Exported for tests.
+ */
+export function applyV2EditOps(flow: FlowV2, ops: readonly FlowV2EditOp[]): FlowV2 {
+	const next: FlowV2 = JSON.parse(JSON.stringify(flow));
+	for (const op of ops) {
+		switch (op.kind) {
+			case "add_node":
+				next.nodes[op.node_id] = op.node;
+				break;
+			case "remove_node":
+				delete next.nodes[op.node_id];
+				next.edges = next.edges.filter(e => e.from !== op.node_id && e.to !== op.node_id);
+				break;
+			case "add_edge":
+				next.edges.push(op.edge);
+				break;
+			case "remove_edge":
+				next.edges = next.edges.filter(e => !(e.from === op.from && e.to === op.to));
+				break;
+			case "add_trigger":
+				next.triggers = [...(next.triggers ?? []), op.trigger];
+				break;
+			case "remove_trigger":
+				next.triggers = (next.triggers ?? []).filter((_, i) => i !== op.index);
+				break;
+		}
+	}
+	return next;
+}
+
+export type FlowEditPersistFn = (flow: FlowV2) => void;
+
+export function createFlowEditTool(
+	interpreter: FlowInterpreter,
+	persist?: FlowEditPersistFn,
+): AgentTool<typeof editSchema, FlowEditDetails> {
+	return {
+		name: FLOW_EDIT_TOOL_NAME,
+		label: "FlowEdit",
+		description: [
+			"Mutate the live flow: add/remove nodes, add/remove edges, add/remove triggers.",
+			"",
+			"Ops:",
+			"  - add_node    { node_id, node }",
+			"  - remove_node { node_id }",
+			"  - add_edge    { edge: { from, to, when? } }",
+			"  - remove_edge { from, to }",
+			"  - add_trigger { trigger: { when, match } }",
+			"  - remove_trigger { index }",
+		].join("\n"),
+		parameters: editSchema,
+		strict: true,
+		concurrency: "exclusive",
+		async execute(_id: string, params: Static<typeof editSchema>): Promise<AgentToolResult<FlowEditDetails>> {
+			const ops = params.ops as unknown as FlowV2EditOp[];
+			const nextFlow = applyV2EditOps(interpreter.flow, ops);
+			interpreter.replaceFlow(nextFlow);
+			persist?.(nextFlow);
+			return {
+				content: [{ type: "text", text: `Applied ${ops.length} op(s) to flow.` }],
+				details: { applied: ops.length },
+			};
+		},
+	};
+}

--- a/packages/coding-agent/src/flow/flow-trace.ts
+++ b/packages/coding-agent/src/flow/flow-trace.ts
@@ -1,0 +1,122 @@
+/**
+ * Flow trace writer — dumps the raw HTTP payload sent to the provider,
+ * one file per request, JSON with indentation. Nothing else.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { FlowTraceEvent } from "./flow-runtime";
+
+export class FlowTraceWriter {
+	#dir: string;
+	#sessionId: string;
+
+	constructor(sessionId?: string) {
+		this.#sessionId = sanitizeId(sessionId ?? "nosession");
+		this.#dir = join(homedir(), ".omp", "traces");
+	}
+
+	get path(): string | null {
+		return this.#dir;
+	}
+
+	startNewTrace(_userPreview: string): string {
+		try {
+			mkdirSync(this.#dir, { recursive: true });
+		} catch {
+			// ignore
+		}
+		return this.#dir;
+	}
+
+	write(_event: FlowTraceEvent): void {
+		// no-op — only raw HTTP payloads go to disk
+	}
+
+	writePayload(payload: unknown): void {
+		try {
+			mkdirSync(this.#dir, { recursive: true });
+		} catch {
+			// ignore
+		}
+		const ts = new Date().toISOString().replace(/[:.]/g, "-");
+		const base = join(this.#dir, `${this.#sessionId}-${ts}`);
+		try {
+			writeFileSync(`${base}.json`, JSON.stringify(payload, null, 2), "utf8");
+		} catch {
+			// ignore
+		}
+		try {
+			writeFileSync(`${base}.md`, renderMarkdown(payload), "utf8");
+		} catch {
+			// ignore
+		}
+	}
+
+	close(): void {
+		// nothing to flush
+	}
+}
+
+function sanitizeId(id: string): string {
+	return id.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Markdown render — best-effort unwrap of common provider payload shapes.
+// ──────────────────────────────────────────────────────────────────────────
+
+function renderMarkdown(payload: unknown): string {
+	const out: string[] = [];
+	out.push(`# LLM request — ${new Date().toISOString()}`);
+	out.push("");
+	const obj = payload as Record<string, unknown>;
+	const toolsField = obj.tools;
+	if (Array.isArray(toolsField) && toolsField.length > 0) {
+		const names = toolsField
+			.map(t => {
+				const tool = t as Record<string, unknown>;
+				const fn = tool.function as Record<string, unknown> | undefined;
+				return (tool.name as string) ?? (fn?.name as string) ?? "?";
+			})
+			.filter(Boolean);
+		out.push(`## Tools (${names.length})`);
+		out.push("");
+		out.push(names.map(n => `\`${n}\``).join(", "));
+		out.push("");
+	}
+
+	const convo = Array.isArray(obj.input) ? obj.input : Array.isArray(obj.messages) ? obj.messages : null;
+	if (Array.isArray(convo)) {
+		const callIdToName = new Map<string, string>();
+		for (const item of convo) {
+			const it = item as { type?: string; name?: string; call_id?: string };
+			if (it.type === "function_call" && it.call_id && it.name) {
+				callIdToName.set(it.call_id, it.name);
+			}
+		}
+
+		out.push(`## Conversation (${convo.length})`);
+		out.push("");
+		convo.forEach((item, i) => {
+			out.push(`### [${i}] ${describeItem(item, callIdToName)}`);
+			out.push("");
+			out.push(JSON.stringify(item));
+			out.push("\n");
+		});
+	}
+
+	return out.join("\n");
+}
+
+function describeItem(item: unknown, callIdToName?: Map<string, string>): string {
+	const it = item as { role?: string; type?: string; name?: string; call_id?: string };
+	if (it.type === "function_call") return `function_call \`${it.name ?? "?"}\``;
+	if (it.type === "function_call_output") {
+		const name = it.name ?? (it.call_id && callIdToName?.get(it.call_id)) ?? "?";
+		return `function_call_output \`${name}\``;
+	}
+	if (it.type && !it.role) return it.type;
+	return it.role ?? "?";
+}

--- a/packages/coding-agent/src/flow/flow-trigger-matcher.ts
+++ b/packages/coding-agent/src/flow/flow-trigger-matcher.ts
@@ -1,0 +1,89 @@
+/**
+ * Flow trigger matcher.
+ *
+ * Pure function: scan every node in the flow for triggers whose `when`
+ * phase equals the event phase AND whose `match` fields all agree with the
+ * event payload. Returns a list of node ids that should be auto-pushed.
+ *
+ * Matching rules:
+ *   - `tool`: glob over the event.tool name (`*` wildcard).
+ *   - `path`: glob over the event.args.path (simple minimatch-lite, supports
+ *              `*` single segment and `**` recursive segment).
+ *   - `flow`: exact match on event.flowId.
+ *   - `expr`: not supported here; treated as no-match (pure).
+ *
+ * All specified fields must match. A trigger with an empty `match` object
+ * fires on every event of its phase.
+ */
+
+import type { Flow, NodeId, TriggerWhen } from "./flow-types";
+
+export interface TriggerEvent {
+	phase: TriggerWhen;
+	tool?: string;
+	args?: Record<string, unknown>;
+	flowId?: string;
+}
+
+/** Compile a glob with `*` and `**` to a regex. */
+export function pathGlobToRegex(glob: string): RegExp {
+	// Split on `/` and translate each segment; `**` matches any number of
+	// path segments, `*` matches anything except `/` in the current segment.
+	const segments = glob.split("/");
+	const parts: string[] = [];
+	for (let i = 0; i < segments.length; i++) {
+		const seg = segments[i];
+		if (seg === "**") {
+			parts.push("(?:.*)");
+			continue;
+		}
+		// Escape regex metacharacters except `*`, then replace `*` with `[^/]*`.
+		const escaped = seg.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, "[^/]*");
+		parts.push(escaped);
+	}
+	// Join with `/`, but collapse `(?:.*)/` at boundaries so `**/foo` also
+	// matches `foo` at the root.
+	let joined = parts.join("/");
+	joined = joined.replace(/\(\?:\.\*\)\//g, "(?:.*/)?");
+	joined = joined.replace(/\/\(\?:\.\*\)/g, "(?:/.*)?");
+	return new RegExp(`^${joined}$`);
+}
+
+export function simpleNameGlob(pattern: string, value: string): boolean {
+	if (!pattern.includes("*")) return pattern === value;
+	const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+	return new RegExp(`^${escaped}$`).test(value);
+}
+
+export function matchTriggers(flow: Flow, event: TriggerEvent): NodeId[] {
+	const triggers = flow.triggers ?? [];
+	const matchedFlowLevel = triggers.some(t => t.when === event.phase && triggerMatches(t.match, event));
+	// Flow-level triggers are the primary mechanism, but we also scan every
+	// node for triggers (if a future extension stores triggers on nodes).
+	// The spec keeps triggers at the flow level, so we only resolve
+	// which nodes to push when flow-level triggers match. Convention: the
+	// flow's `id` matches a node id with the same id, else no-op.
+	if (!matchedFlowLevel) return [];
+	const nodeId = flow.id;
+	if (flow.nodes[nodeId]) return [nodeId];
+	// Fall back to the first node if the flow id is not itself a node.
+	const first = Object.keys(flow.nodes)[0];
+	return first ? [first] : [];
+}
+
+function triggerMatches(match: { tool?: string; path?: string; flow?: string; expr?: string }, event: TriggerEvent): boolean {
+	if (match.expr !== undefined) return false; // pure resolver cannot evaluate
+	if (match.tool !== undefined) {
+		if (!event.tool) return false;
+		if (!simpleNameGlob(match.tool, event.tool)) return false;
+	}
+	if (match.path !== undefined) {
+		const p = event.args?.path;
+		if (typeof p !== "string") return false;
+		if (!pathGlobToRegex(match.path).test(p)) return false;
+	}
+	if (match.flow !== undefined) {
+		if (event.flowId !== match.flow) return false;
+	}
+	return true;
+}

--- a/packages/coding-agent/src/flow/flow-types.ts
+++ b/packages/coding-agent/src/flow/flow-types.ts
@@ -1,0 +1,141 @@
+/**
+ * Flow — data-driven flow definition.
+ *
+ * Top-level: a flow is `{ version, id, description, nodes, edges, triggers }`.
+ *
+ * Core idea: every executable unit is a *node*. A node is a pure closure —
+ * it does not run anything on its own. What gives a node behavior is its
+ * hooks (onEnter / onLeave / onError) and the edges that connect it to
+ * other nodes.
+ *
+ * Hooks are hardcoded tool calls that the runtime executes automatically
+ * at the push / pop / error boundaries of a frame. They exist to offload
+ * repetitive work off the model: loading rule files, running a build, etc.
+ *
+ * Tools in `available_tools` are a filter, not a declaration. Use `"name"`
+ * to allow a tool and `"!name"` to deny one. The effective set is computed
+ * per frame by intersecting the parent scope with the node's filter.
+ *
+ * Flows can be triggered three ways:
+ *   1. Called explicitly: the parent scope sees the flow as a tool and
+ *      calls it by id.
+ *   2. Auto-pushed by a trigger: the runtime matches a pattern on the
+ *      current state (tool call, file path, etc.) and pushes the flow.
+ *   3. Chat root: the top-level conversation is itself a flow.
+ */
+
+/** Unique id of a node inside a flow. Lowercase snake_case by convention. */
+export type NodeId = string;
+
+/**
+ * A hardcoded tool invocation the runtime executes automatically. Used in
+ * hook lists (onEnter / onLeave / onError).
+ *
+ * `tool` is the name of a tool available at the parent scope (a builtin,
+ * a sub-flow, or an MCP tool). `args` is the fixed argument object passed
+ * to that tool. No templating — arguments are static.
+ */
+export interface HookCall {
+	tool: string;
+	args?: Record<string, unknown>;
+}
+
+/**
+ * Tool filter entry. `"name"` allows the tool, `"!name"` denies it. The
+ * filter is applied over the parent scope's effective tool set.
+ */
+export type ToolFilter = string;
+
+/**
+ * A single node in a flow. Pure closure: holds description, env, tool
+ * filters, and lifecycle hooks. No executor is attached to the node
+ * itself — behavior emerges from hooks and the graph structure.
+ */
+export interface FlowNode {
+	/** Optional per-node runtime environment. Scoped to the frame. */
+	env?: Record<string, unknown>;
+
+	/** Human-readable description of what this node represents. */
+	description?: string;
+
+	/**
+	 * Instructions injected into the model context as part of the system
+	 * prompt when this frame is active. Use this to give the model
+	 * node-specific guidance (what to do, what to avoid, when to ret).
+	 */
+	prompt?: string;
+
+	/**
+	 * Tool filter applied when this frame is on top of the stack. Each
+	 * entry is either `"name"` (allow) or `"!name"` (deny). The effective
+	 * tool set is `parentScope ∩ filter`. Omit to inherit the parent
+	 * scope unchanged.
+	 */
+	available_tools?: ToolFilter[];
+
+	/** Hardcoded tool calls executed automatically when the frame is pushed. */
+	onEnter?: HookCall[];
+	/** Hardcoded tool calls executed automatically when the frame is popped. */
+	onLeave?: HookCall[];
+	/** Hardcoded tool calls executed when a hook or contained node errors. */
+	onError?: HookCall[];
+}
+
+/**
+ * Directed edge between two nodes. The `when` clause is a condition on
+ * the current frame's most recent event.
+ */
+export type EdgeCondition =
+	| { kind: "always" }
+	| { kind: "tool_call"; name: string }
+	| { kind: "ret" }
+	| { kind: "error" }
+	| { kind: "custom"; expr: string };
+
+export interface FlowEdge {
+	from: NodeId;
+	to: NodeId;
+	when?: EdgeCondition;
+}
+
+/**
+ * Auto-push trigger for this flow. When the runtime observes an event at
+ * any level of the stack that matches `when` and `match`, it pushes this
+ * flow onto the stack. The flow's own nodes decide what happens next.
+ */
+export type TriggerWhen = "before_tool_call" | "after_tool_call" | "on_user_message" | "on_flow_enter" | "on_flow_leave";
+
+export interface TriggerMatch {
+	/** Tool name match (exact or glob, e.g. "file_write", "mcp_gitea_*"). */
+	tool?: string;
+	/** File path glob applied to args.path (e.g. "backend/**\/*.ts"). */
+	path?: string;
+	/** Match on the id of the flow currently entering/leaving. */
+	flow?: string;
+	/** Arbitrary JSONPath-like expression on the event payload. Runtime dep. */
+	expr?: string;
+}
+
+export interface FlowTrigger {
+	when: TriggerWhen;
+	match: TriggerMatch;
+}
+
+/**
+ * A flow is a DAG of nodes connected by edges, with optional triggers
+ * that cause the flow to be auto-pushed by the runtime.
+ */
+export interface Flow {
+	version: 1;
+	id: string;
+	description?: string;
+
+	/** All nodes in the flow, keyed by id. Any node may serve as an entry. */
+	nodes: Record<NodeId, FlowNode>;
+
+	/** Directed transitions between nodes. */
+	edges: FlowEdge[];
+
+	/** Conditions under which the runtime auto-pushes this flow. */
+	triggers?: FlowTrigger[];
+}

--- a/packages/coding-agent/src/flow/flow.schema.json
+++ b/packages/coding-agent/src/flow/flow.schema.json
@@ -1,0 +1,195 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://oh-my-pi/schemas/flow.json",
+	"title": "Flow",
+	"description": "Data-driven flow definition. A flow is a DAG of nodes connected by edges, with optional auto-push triggers. Every node is a pure closure; behavior comes from onEnter/onLeave/onError hooks and the edges that connect nodes together.",
+	"type": "object",
+	"required": ["version", "id", "nodes", "edges"],
+	"additionalProperties": false,
+	"properties": {
+		"version": {
+			"const": 1,
+			"description": "Schema version. Must be 1."
+		},
+		"id": {
+			"type": "string",
+			"description": "Unique flow id. Lowercase snake_case, e.g. `tool_selection`, `backend_editor`.",
+			"pattern": "^[a-z][a-z0-9_]*$"
+		},
+		"description": {
+			"type": "string",
+			"description": "Human-readable summary of what the flow does."
+		},
+		"nodes": {
+			"type": "object",
+			"description": "All nodes in the flow, keyed by node id. Any node may serve as an entry point — the runtime decides which one to push based on the caller or trigger.",
+			"additionalProperties": { "$ref": "#/$defs/node" }
+		},
+		"edges": {
+			"type": "array",
+			"description": "Directed transitions between nodes. The `when` clause decides which edge fires based on the current frame's most recent event.",
+			"items": { "$ref": "#/$defs/edge" }
+		},
+		"triggers": {
+			"type": "array",
+			"description": "Conditions under which the runtime auto-pushes this flow onto the stack. Without triggers, the flow is only callable explicitly.",
+			"items": { "$ref": "#/$defs/trigger" }
+		}
+	},
+
+	"$defs": {
+		"node": {
+			"type": "object",
+			"description": "A pure closure. No executor — behavior comes from hooks and outgoing edges.",
+			"additionalProperties": false,
+			"properties": {
+				"env": {
+					"type": "object",
+					"description": "Per-node runtime environment, scoped to the frame.",
+					"additionalProperties": true
+				},
+				"description": {
+					"type": "string",
+					"description": "What this node represents."
+				},
+				"available_tools": {
+					"type": "array",
+					"description": "Tool filter applied when this frame is on top of the stack. Each entry is `name` (allow) or `!name` (deny). Effective set = parentScope ∩ filter.",
+					"items": {
+						"type": "string",
+						"pattern": "^!?[a-zA-Z_][a-zA-Z0-9_*]*$"
+					}
+				},
+				"onEnter": {
+					"type": "array",
+					"description": "Hardcoded tool calls executed automatically when this frame is pushed. Used to inject rule files, load context, etc., so the model does not have to do it.",
+					"items": { "$ref": "#/$defs/hookCall" }
+				},
+				"onLeave": {
+					"type": "array",
+					"description": "Hardcoded tool calls executed automatically when this frame is popped.",
+					"items": { "$ref": "#/$defs/hookCall" }
+				},
+				"onError": {
+					"type": "array",
+					"description": "Hardcoded tool calls executed when a hook or nested frame errors out.",
+					"items": { "$ref": "#/$defs/hookCall" }
+				}
+			}
+		},
+
+		"hookCall": {
+			"type": "object",
+			"description": "A hardcoded tool invocation the runtime performs automatically on a lifecycle boundary. Static args only — no templating.",
+			"required": ["tool"],
+			"additionalProperties": false,
+			"properties": {
+				"tool": {
+					"type": "string",
+					"description": "Name of a tool available at the parent scope (builtin, sub-flow, or MCP tool)."
+				},
+				"args": {
+					"type": "object",
+					"description": "Fixed argument object passed to the tool.",
+					"additionalProperties": true
+				}
+			}
+		},
+
+		"edge": {
+			"type": "object",
+			"required": ["from", "to"],
+			"additionalProperties": false,
+			"properties": {
+				"from": { "type": "string" },
+				"to": { "type": "string" },
+				"when": { "$ref": "#/$defs/edgeCondition" }
+			}
+		},
+
+		"edgeCondition": {
+			"description": "Condition on the frame's most recent event that determines if this edge fires.",
+			"oneOf": [
+				{
+					"type": "object",
+					"required": ["kind"],
+					"properties": { "kind": { "const": "always" } },
+					"additionalProperties": false
+				},
+				{
+					"type": "object",
+					"required": ["kind", "name"],
+					"properties": {
+						"kind": { "const": "tool_call" },
+						"name": { "type": "string", "description": "Tool name whose call fires this edge." }
+					},
+					"additionalProperties": false
+				},
+				{
+					"type": "object",
+					"required": ["kind"],
+					"properties": { "kind": { "const": "ret" } },
+					"additionalProperties": false
+				},
+				{
+					"type": "object",
+					"required": ["kind"],
+					"properties": { "kind": { "const": "error" } },
+					"additionalProperties": false
+				},
+				{
+					"type": "object",
+					"required": ["kind", "expr"],
+					"properties": {
+						"kind": { "const": "custom" },
+						"expr": { "type": "string", "description": "Runtime-defined expression on the event payload." }
+					},
+					"additionalProperties": false
+				}
+			]
+		},
+
+		"trigger": {
+			"type": "object",
+			"required": ["when", "match"],
+			"additionalProperties": false,
+			"properties": {
+				"when": {
+					"enum": [
+						"before_tool_call",
+						"after_tool_call",
+						"on_user_message",
+						"on_flow_enter",
+						"on_flow_leave"
+					],
+					"description": "Runtime phase at which to check the trigger."
+				},
+				"match": { "$ref": "#/$defs/triggerMatch" }
+			}
+		},
+
+		"triggerMatch": {
+			"type": "object",
+			"description": "Pattern matched against the event payload. All specified fields must match.",
+			"additionalProperties": false,
+			"properties": {
+				"tool": {
+					"type": "string",
+					"description": "Tool name glob, e.g. `file_write`, `mcp_gitea_*`."
+				},
+				"path": {
+					"type": "string",
+					"description": "File path glob against args.path, e.g. `backend/**/*.ts`."
+				},
+				"flow": {
+					"type": "string",
+					"description": "Flow id match, for on_flow_enter / on_flow_leave."
+				},
+				"expr": {
+					"type": "string",
+					"description": "Runtime-defined expression on the event payload."
+				}
+			}
+		}
+	}
+}

--- a/packages/coding-agent/src/flow/flows/base-flow.json
+++ b/packages/coding-agent/src/flow/flows/base-flow.json
@@ -1,0 +1,52 @@
+{
+  "version": 1,
+  "id": "base_flow",
+  "description": "Minimal seed flow. `chat` is the root with core builtin tools + access to tool_selection and flow_editor sub-flows.",
+  "nodes": {
+    "chat": {
+      "description": "Root conversation node. Has the core builtin toolkit always active (bash, read, write, edit, grep, find, lsp, ast_grep, ast_edit, task, todo_write, web_search, fetch, ask). Use these directly. Enter `tool_selection` for MCP tools or niche capabilities. Enter `flow_editor` to inspect or mutate the flow itself."
+    },
+    "tool_selection": {
+      "description": "Sub-flow for discovering and activating tools from the MCP catalog. Inside, you have search_tools, describe_tool, select_tool, drop_tool, and ret. Selected tools attach to the parent (chat) frame."
+    },
+    "scout": {
+      "description": "Isolated exploration frame. Read files, search code, run commands — all output stays here. When done, call ret(summary) to push findings back to chat. Everything else is discarded."
+    },
+    "flow_editor": {
+      "description": "Sub-flow for inspecting and mutating the live flow definition. Inside, you have read_flow and flow_edit. Any change persists immediately to the on-disk flow file.",
+      "available_tools": ["read_flow", "flow_edit"],
+      "onEnter": [
+        {
+          "tool": "read",
+          "args": {
+            "path": "skill://flow-editor"
+          }
+        }
+      ]
+    },
+    "ui-editor": {
+      "description": "Sub-flow for visual editing and UI component management.",
+      "onEnter": [
+        {
+          "tool": "read",
+          "args": {
+            "path": "skill://ui-editor"
+          }
+        }
+      ]
+    },
+    "skill_writer": {
+      "description": "Skill to write the ui-editor instructions.",
+      "onEnter": [
+        {
+          "args": {
+            "content": "# UI Editor Skill\nYou are the UI Editor. Your purpose is to help users design and manage UI components.\n\n## Capabilities\n- Component Inspection\n- Layout Management\n- Style Configuration\n\n## Guidelines\n- Always prioritize user intent for visual hierarchy.\n- Maintain consistency with existing design systems.",
+            "path": "skill://ui-editor"
+          },
+          "tool": "write"
+        }
+      ]
+    }
+  },
+  "edges": []
+}

--- a/packages/coding-agent/src/flow/index.ts
+++ b/packages/coding-agent/src/flow/index.ts
@@ -1,0 +1,45 @@
+/**
+ * Flow agent — data-driven orchestrator packaged as an ExecutionStrategy.
+ *
+ * Opt-in via OMP_FLOW=1 env var. See the flow-agent skill under
+ * .claude/skills/flow-agent/ for the design brief, implementation plan,
+ * and architecture references.
+ *
+ * The strategy is installed on `session.agent` at startup and then every
+ * `session.prompt()` call — interactive, print, rpc, acp, nested — runs
+ * through flow semantics without a parallel code path.
+ */
+
+export {
+	createFlowStateMessage,
+	extractLatestFlowState,
+	isFlowStateMessage,
+} from "./flow-state-codec";
+export type { FlowExecutionStrategyOptions } from "./flow-strategy";
+export { FlowExecutionStrategy } from "./flow-strategy";
+export type { RunSubAgentOptions } from "./flow-subagent";
+export { runSubAgent } from "./flow-subagent";
+
+export type { FlowEditOp, FlowEditResult, FlowTraceEvent, FlowTraceListener } from "./flow-runtime";
+export { FlowRuntime } from "./flow-runtime";
+export type { FlowInspectDetails, FlowV2EditOp } from "./flow-tools";
+export {
+	applyV2EditOps,
+	createFlowEditTool,
+	createFlowInspectTool,
+	FLOW_EDIT_TOOL_NAME,
+	FLOW_INSPECT_TOOL_NAME,
+	isFlowOwnedToolName,
+} from "./flow-tools";
+export { BUNDLED_BASE_FLOW, FlowStore } from "./flow-store";
+export { FlowInterpreter } from "./flow-interpreter";
+export type {
+	Flow,
+	FlowEdge,
+	FlowNode,
+	FlowTrigger,
+	HookCall,
+	NodeId,
+} from "./flow-types";
+export type { CallFrame, FlowState } from "./types";
+export { FLOW_STATE_CUSTOM_TYPE } from "./types";

--- a/packages/coding-agent/src/flow/prompts/base.md
+++ b/packages/coding-agent/src/flow/prompts/base.md
@@ -1,0 +1,19 @@
+You are running inside Flow — a data-driven orchestrator.
+
+## Rule #0 — USE the tools you already have
+Look at your tool list for this turn. If the tool you need is ALREADY THERE, call it directly. Do NOT re-enter `tool_selection` for a tool you already have. The scene block below lists `tools attached to this frame:` — those are ready for you.
+
+## How it works
+- The flow is a DAG of *nodes*. Each node is a pure closure.
+- `chat` is the default node. It has the core builtin toolkit always active.
+- **Auto-scout**: when you call any tool that produces output (bash, read, grep, find, etc.) from `chat`, the orchestrator transparently moves you into a `scout` frame. You won't notice — the tool runs normally. But now you are inside scout: all subsequent tool output stays isolated. When you have what you need, call **`ret(summary)`** to push a concise result back to chat. Everything else is discarded. This keeps the main context clean.
+- `tool_selection` is a sub-flow for MCP tools not in the core set. Inside, search → select → ret.
+- `flow_edit` lets you reshape the flow (add nodes, edges, triggers).
+
+## Sub-flows callable from chat
+- `tool_selection` — enter the tool discovery sub-flow.
+- `flow_editor` — enter the flow editor sub-flow (read_flow / flow_edit live there).
+- `scout` — enter explicitly for extended exploration. Auto-scout handles this for you in most cases.
+
+## Exiting a sub-flow
+To leave a sub-flow you MUST call **`ret({value})`** with a concise summary of what this sub-flow run accomplished. The `value` is REQUIRED — it is the only piece of scratch that survives into the parent frame. Everything else (search results, file contents, reasoning) is discarded. Make `value` dense: state outcomes, decisions, or artifacts the parent needs to continue. Plain-text replies do NOT close the frame — you stay inside the sub-flow until you call `ret`.

--- a/packages/coding-agent/src/flow/prompts/style.md
+++ b/packages/coding-agent/src/flow/prompts/style.md
@@ -1,0 +1,2 @@
+## Style
+- Be concise. Prefer extending existing nodes over creating near-duplicates.

--- a/packages/coding-agent/src/flow/prompts/sub-agent.md
+++ b/packages/coding-agent/src/flow/prompts/sub-agent.md
@@ -1,0 +1,1 @@
+You are a focused sub-agent. Complete the assigned task and return a concise, structured result. Do not ask clarifying questions; make reasonable assumptions and state them.

--- a/packages/coding-agent/src/flow/prompts/tool-selection.md
+++ b/packages/coding-agent/src/flow/prompts/tool-selection.md
@@ -1,0 +1,19 @@
+## You are INSIDE tool_selection
+- `search_tools({query})` — substring search on tool NAMES (not descriptions).
+- `describe_tool({name})` — read a tool's description.
+- `select_tool({name})` — attach to parent scope.
+- `drop_tool({name})` — detach.
+- `ret({value?})` — close this frame; parent resumes with attached tools.
+
+## Popular builtin tool names (try these BEFORE exhaustive search)
+- `bash` — run shell commands (ls, cat, find, grep, etc.). Best general-purpose tool for filesystem work.
+- `read` / `write` / `edit` — file operations.
+- `grep` / `find` / `ast_grep` — codebase search.
+- `lsp` — language server queries (definitions, references, types).
+- `puppeteer` — browser automation.
+- `task` — delegate to a sub-agent.
+- `web_search` / `fetch` — web access.
+
+Workflow: if the user wants filesystem work, just `select_tool('bash')` and `ret`. Do not exhaustively search. Search is only for when you genuinely do not know which tool to pick.
+
+Scratch here disappears on ret. Only the tools you select survive in the parent.

--- a/packages/coding-agent/src/flow/skills/flow-editor/SKILL.md
+++ b/packages/coding-agent/src/flow/skills/flow-editor/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: flow-editor
+description: Instructions for editing the live flow definition from inside the `flow_editor` sub-flow.
+---
+
+# Flow editor
+
+You are inside the `flow_editor` sub-flow. You have two tools:
+
+- **`read_flow`** — returns the whole live flow (every node, edge, trigger) plus the current call stack.
+- **`flow_edit`** — mutates the flow. Accepts a list of `ops`. Each op is one of:
+  - `{ kind: "add_node", node_id, node }` — create or replace a node. A node is `{ description?, env?, available_tools?, onEnter?, onLeave?, onError? }`.
+  - `{ kind: "remove_node", node_id }` — delete a node and any edges touching it.
+  - `{ kind: "add_edge", edge }` — add a directed edge `{ from, to, when? }`. `when` is `{ kind: "always" | "tool_call" | "ret" | "error" | "custom", name?, expr? }`.
+  - `{ kind: "remove_edge", from, to }` — remove an edge.
+  - `{ kind: "add_trigger", trigger }` — add an auto-push trigger `{ when, match }`. `when` is one of `before_tool_call | after_tool_call | on_user_message | on_flow_enter | on_flow_leave`. `match` can filter by `tool`, `path`, `flow`, or `expr`.
+  - `{ kind: "remove_trigger", index }` — remove a trigger by its position.
+
+## Node shape
+
+```json
+{
+  "description": "what this node represents",
+  "available_tools": ["name", "!name"],
+  "onEnter": [{ "tool": "read", "args": { "path": "skill://name" } }],
+  "onLeave": [],
+  "onError": []
+}
+```
+
+### `available_tools` filter
+
+List of entries processed in order. Each entry is either `"name"` (allow) or `"!name"` (deny). The effective tool set is the parent scope intersected with this filter.
+
+- Empty or omitted → inherit the parent scope as-is.
+- Deny-only (`["!bash"]`) → parent scope minus the denied tools.
+- Any allow entry flips it into allow-mode: start empty, add what's allowed.
+- Wildcards `*` are supported (`"mcp_gitea_*"`).
+- A node id that appears in the filter and matches an existing node is exposed as a **node-as-tool**: calling it pushes a new frame on that node.
+
+### Lifecycle hooks
+
+`onEnter` / `onLeave` / `onError` are lists of hardcoded tool calls the runtime executes automatically at the corresponding lifecycle boundary. They are NOT things the model calls — they are side effects owned by the flow. Typical uses:
+
+- Load a skill file when entering a node: `{ "tool": "read", "args": { "path": "skill://frontend-rules" } }`
+- Run a build check on leave: `{ "tool": "bash", "args": { "command": "cargo build" } }`
+
+## Workflow
+
+1. If you need to understand the current state, call `read_flow` first. It returns `{ flowId, flow: { nodes, edges, triggers }, currentNode, stack }`.
+2. Plan the mutation. Prefer extending an existing node over creating a near-duplicate.
+3. Call `flow_edit` with a batch of `ops`. Mutations persist immediately to `<cwd>/.omp/flow.json`.
+4. When satisfied, respond with plain text. That closes the frame and returns control to the caller (usually `chat`).
+
+## Style
+
+- Be concise.
+- Do not paste the current flow back into your reply to the user — the scene block already tells you where you are.
+- Prefer small, targeted edits. If an op touches a node currently on the stack, the runtime will supersede affected frames and re-enter the edited version automatically.

--- a/packages/coding-agent/src/flow/types.ts
+++ b/packages/coding-agent/src/flow/types.ts
@@ -1,0 +1,61 @@
+/**
+ * Flow agent shared types.
+ *
+ * Flow definition itself lives in `flow-types.ts`. This module holds the
+ * runtime-only types that are not part of the static DSL: call frames,
+ * pocket entries, and the custom-message envelope used to persist runtime
+ * state in the conversation history.
+ */
+
+import type { NodeId } from "./flow-types";
+
+export type { NodeId };
+
+/**
+ * A live call frame on the runtime stack. Each frame represents one in-flight
+ * sub-flow call. Conceptually identical to an assembly call frame: parentId
+ * points at the caller, status moves open → returned, returnValue carries
+ * the result back up the stack.
+ *
+ * Every message in the session is stamped with `flowFrameId` = the top
+ * frame id at creation time (via session manager's flowState snapshot).
+ * `transformContext` checks each message's frameId against the set of open
+ * frames — if the frame is closed, the message is excluded.
+ */
+export type CallFrame = {
+	id: string;
+	parentId: string | null;
+	nodeId: NodeId;
+	purpose: string;
+	status: "open" | "returned" | "superseded";
+	returnValue?: string;
+	openedAt: number;
+	closedAt?: number;
+	supersededBy?: string;
+	/** Reason provided by the model when entering this sub-flow. */
+	reason?: string;
+};
+
+/**
+ * Runtime state of a flow execution. Serialized into the conversation history
+ * as a CustomMessage with customType "flow-state" so it rides along with the
+ * conversation for free: branching, undo, export, and replay all work.
+ */
+export type FlowState = {
+	version: 2;
+	flowId: string;
+	cursor: NodeId;
+	frameStack: CallFrame[];
+	executionLog: CallFrame[];
+	/** Tool attachments per node id. Persisted so fork/resume restores them. */
+	attachments?: Record<string, string[]>;
+	/** Sub-flows that completed (ret) this conversation. Rendered in <scene>. */
+	completedSubFlows?: { nodeId: string; result: string }[];
+};
+
+/**
+ * Custom message type used to serialize FlowState into the conversation
+ * history. We reuse the existing `custom` role rather than registering a new
+ * one so we don't touch coding-agent/src/session/messages.ts.
+ */
+export const FLOW_STATE_CUSTOM_TYPE = "flow-state";

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -40,6 +40,7 @@ import {
 	MarketplaceManager,
 } from "./extensibility/plugins/marketplace";
 import type { MCPManager } from "./mcp";
+import { FlowExecutionStrategy } from "./flow";
 import { InteractiveMode, runAcpMode, runPrintMode, runRpcMode } from "./modes";
 import { initTheme, stopThemeWatcher } from "./modes/theme/theme";
 import type { SubmittedUserInput } from "./modes/types";
@@ -849,6 +850,50 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 		}
 		return nextSession;
 	};
+
+	// Opt-in flow agent: install a FlowExecutionStrategy on the live Agent
+	// so every subsequent session.prompt() — interactive, print, rpc, acp —
+	// runs through the flow semantics. No mode replacement; the existing
+	// dispatch below is reused unchanged.
+	if ($env.OMP_FLOW) {
+		const sm = session.sessionManager;
+		const flowStrategy = new FlowExecutionStrategy({
+			getSubAgentModel: () => session.model,
+			sessionId: session.sessionId,
+			// Persist injected messages through the normal pipeline
+			// (agent state + session.jsonl). Custom messages (flow state)
+			// route through appendCustomMessageEntry; everything else
+			// (node-prompt user messages, etc.) goes through appendMessage.
+			persistMessage: msg => {
+				session.agent.appendMessage(msg);
+				const m = msg as any;
+				if (m.role === "custom") {
+					sm.appendCustomMessageEntry(
+						m.customType,
+						m.content,
+						m.display,
+						m.details,
+						m.attribution ?? "agent",
+					);
+				} else {
+					sm.appendMessage(m);
+				}
+			},
+		});
+		session.agent.setExecutionStrategy(flowStrategy);
+		sm.setFlowStateGetter(() => flowStrategy.state);
+		sm.setFlowFrameIdGetter((msg: any) => flowStrategy.getFrameIdForMessage(msg));
+		const payloadLogger = flowStrategy.createPayloadLogger();
+		if (payloadLogger) {
+			session.agent.setOnPayload(payloadLogger);
+		}
+		// Register flow nodes as slash commands (e.g. /fixer, /scout)
+		if (session.extensionRunner) {
+			flowStrategy.registerNodeCommands(session.extensionRunner, async (text: string) => {
+				await session.prompt(text);
+			});
+		}
+	}
 
 	if (mode === "rpc") {
 		await runRpcMode(session);

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -72,6 +72,8 @@ export interface SessionEntryBase {
 	id: string;
 	parentId: string | null;
 	timestamp: string;
+	/** FlowState snapshot at the moment this entry was created. Present when OMP_FLOW=1. */
+	flowState?: import("../flow/types").FlowState;
 }
 
 export interface SessionMessageEntry extends SessionEntryBase {
@@ -1416,6 +1418,25 @@ export class SessionManager {
 	#inMemoryArtifactCounter = 0;
 	readonly #blobStore: BlobStore;
 
+	/** Optional getter injected by FlowExecutionStrategy. When set, every
+	 *  session entry gets a flowState snapshot at creation time. */
+	#flowStateGetter: (() => import("../flow/types").FlowState) | null = null;
+
+	/** Returns the correct flowFrameId for a message at persist time.
+	 *  The strategy owns the logic (node-entry → parent, ret → parent,
+	 *  otherwise → top). Session manager is just the single writer. */
+	#flowFrameIdGetter: ((msg: any) => string | undefined) | null = null;
+
+	setFlowStateGetter(getter: (() => import("../flow/types").FlowState) | null): void {
+		this.#flowStateGetter = getter;
+	}
+
+	setFlowFrameIdGetter(getter: ((msg: any) => string | undefined) | null): void {
+		this.#flowFrameIdGetter = getter;
+	}
+
+
+
 	private constructor(
 		private cwd: string,
 		private sessionDir: string,
@@ -2004,6 +2025,18 @@ export class SessionManager {
 	}
 
 	#appendEntry(entry: SessionEntry): void {
+		if (this.#flowStateGetter) {
+			entry.flowState = this.#flowStateGetter();
+		}
+		// Stamp flowFrameId on the message so transformContext can filter
+		// by open/closed frames. The strategy owns the "which frame?"
+		// logic; session manager is just the single writer.
+		if (this.#flowFrameIdGetter && entry.type === "message" && !(entry.message as any).flowFrameId) {
+			const frameId = this.#flowFrameIdGetter(entry.message);
+			if (frameId) {
+				(entry.message as any).flowFrameId = frameId;
+			}
+		}
 		this.#fileEntries.push(entry);
 		this.#byId.set(entry.id, entry);
 		this.#leafId = entry.id;

--- a/packages/coding-agent/test/flow-edge-resolver.test.ts
+++ b/packages/coding-agent/test/flow-edge-resolver.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { resolveEdge } from "../src/flow/flow-edge-resolver";
+import type { Flow } from "../src/flow/flow-types";
+
+const flow: Flow = {
+	version: 1,
+	id: "t",
+	nodes: { a: {}, b: {}, c: {}, d: {} },
+	edges: [
+		{ from: "a", to: "b", when: { kind: "always" } },
+		{ from: "a", to: "c", when: { kind: "tool_call", name: "bash" } },
+		{ from: "b", to: "c", when: { kind: "ret" } },
+		{ from: "b", to: "d", when: { kind: "error" } },
+	],
+};
+
+describe("resolveEdge", () => {
+	test("always matches any event", () => {
+		expect(resolveEdge(flow, "a", { kind: "ret" })).toBe("b");
+	});
+
+	test("tool_call matches exact tool name", () => {
+		const f: Flow = { ...flow, edges: flow.edges.slice(1) };
+		expect(resolveEdge(f, "a", { kind: "tool_call", name: "bash" })).toBe("c");
+		expect(resolveEdge(f, "a", { kind: "tool_call", name: "grep" })).toBeNull();
+	});
+
+	test("ret matches ret event", () => {
+		expect(resolveEdge(flow, "b", { kind: "ret" })).toBe("c");
+	});
+
+	test("error matches error event", () => {
+		expect(resolveEdge(flow, "b", { kind: "error" })).toBe("d");
+	});
+
+	test("no matching edge returns null", () => {
+		expect(resolveEdge(flow, "c", { kind: "ret" })).toBeNull();
+	});
+});

--- a/packages/coding-agent/test/flow-hook-executor.test.ts
+++ b/packages/coding-agent/test/flow-hook-executor.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentMessage, AgentTool } from "@oh-my-pi/pi-agent-core";
+import { Type } from "@sinclair/typebox";
+import { runHooks } from "../src/flow/flow-hook-executor";
+
+function echoTool(name: string, fail = false): AgentTool<any> {
+	return {
+		name,
+		label: name,
+		description: "",
+		parameters: Type.Object({}, { additionalProperties: true }),
+		strict: false,
+		async execute(_id, args) {
+			if (fail) throw new Error(`${name} boom`);
+			return { content: [{ type: "text", text: `${name}:${JSON.stringify(args)}` }] };
+		},
+	};
+}
+
+describe("runHooks", () => {
+	test("runs hooks in order and appends results", async () => {
+		const messages: AgentMessage[] = [];
+		const tools = [echoTool("load_rules"), echoTool("run_build")];
+		await runHooks(
+			[
+				{ tool: "load_rules", args: { kind: "backend" } },
+				{ tool: "run_build" },
+			],
+			{ tools, appendMessage: m => messages.push(m) },
+		);
+		expect(messages.length).toBe(2);
+		const t0 = ((messages[0] as any).content as any)[0].text as string;
+		const t1 = ((messages[1] as any).content as any)[0].text as string;
+		expect(t0).toContain("load_rules");
+		expect(t0).toContain("backend");
+		expect(t1).toContain("run_build");
+	});
+
+	test("unknown tool is skipped with a note and does not throw", async () => {
+		const messages: AgentMessage[] = [];
+		await runHooks([{ tool: "missing" }], { tools: [], appendMessage: m => messages.push(m) });
+		expect(messages.length).toBe(1);
+		expect(((messages[0] as any).content as any)[0].text).toContain("tool not found");
+	});
+
+	test("hook error triggers onError hooks and rethrows", async () => {
+		const messages: AgentMessage[] = [];
+		const tools = [echoTool("bad", true), echoTool("cleanup")];
+		let threw = false;
+		try {
+			await runHooks(
+				[{ tool: "bad" }],
+				{ tools, appendMessage: m => messages.push(m) },
+				[{ tool: "cleanup" }],
+			);
+		} catch {
+			threw = true;
+		}
+		expect(threw).toBe(true);
+		// First message: error note. Then cleanup result.
+		const texts = messages.map(m => ((m as any).content as any)[0].text as string);
+		expect(texts.some(t => t.includes("bad") && t.includes("error"))).toBe(true);
+		expect(texts.some(t => t.includes("cleanup"))).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/flow-interpreter.test.ts
+++ b/packages/coding-agent/test/flow-interpreter.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentTool } from "@oh-my-pi/pi-agent-core";
+import { Type } from "@sinclair/typebox";
+import { FlowInterpreter } from "../src/flow/flow-interpreter";
+import type { Flow } from "../src/flow/flow-types";
+
+function tool(name: string, exec?: () => void): AgentTool<any> {
+	return {
+		name,
+		label: name,
+		description: "",
+		parameters: Type.Object({}, { additionalProperties: true }),
+		strict: false,
+		async execute() {
+			exec?.();
+			return { content: [{ type: "text", text: `${name}_ok` }] };
+		},
+	};
+}
+
+describe("FlowInterpreter", () => {
+	test("pushNode and popNode track current node", async () => {
+		const flow: Flow = {
+			version: 1,
+			id: "t",
+			nodes: { a: { description: "A" }, b: { description: "B" } },
+			edges: [],
+		};
+		const interp = new FlowInterpreter(flow);
+		await interp.pushNode("a", { tools: [] });
+		expect(interp.currentNodeId).toBe("a");
+		await interp.pushNode("b", { tools: [] });
+		expect(interp.currentNodeId).toBe("b");
+		await interp.popNode("done", { tools: [] });
+		expect(interp.currentNodeId).toBe("a");
+		await interp.popNode("done", { tools: [] });
+		expect(interp.isStackEmpty).toBe(true);
+	});
+
+	test("resolveTools applies available_tools filter", async () => {
+		const flow: Flow = {
+			version: 1,
+			id: "t",
+			nodes: { chat: { available_tools: ["bash", "!grep"] } },
+			edges: [],
+		};
+		const interp = new FlowInterpreter(flow);
+		await interp.pushNode("chat", { tools: [] });
+		const parent = [tool("bash"), tool("grep"), tool("read_file")];
+		const out = interp.resolveTools(parent);
+		const names = out.map(t => t.name);
+		expect(names).toContain("bash");
+		expect(names).not.toContain("grep");
+	});
+
+	test("node-as-tool exposure: node id in filter becomes a callable tool", async () => {
+		const flow: Flow = {
+			version: 1,
+			id: "t",
+			nodes: {
+				root: { available_tools: ["sub_task"] },
+				sub_task: { description: "child flow" },
+			},
+			edges: [],
+		};
+		const interp = new FlowInterpreter(flow);
+		await interp.pushNode("root", { tools: [] });
+		const out = interp.resolveTools([]);
+		expect(out.find(t => t.name === "sub_task")).toBeDefined();
+		// calling it pushes a new frame
+		const subTool = out.find(t => t.name === "sub_task")!;
+		await subTool.execute("call_1", {} as any);
+		expect(interp.currentNodeId).toBe("sub_task");
+	});
+
+	test("handleEvent transitions in-frame on tool_call edge", async () => {
+		const flow: Flow = {
+			version: 1,
+			id: "t",
+			nodes: { a: {}, b: {} },
+			edges: [{ from: "a", to: "b", when: { kind: "tool_call", name: "bash" } }],
+		};
+		const interp = new FlowInterpreter(flow);
+		await interp.pushNode("a", { tools: [] });
+		const stackBefore = interp.frameStack.length;
+		await interp.handleEvent({ kind: "tool_call", name: "bash" }, { tools: [] });
+		expect(interp.currentNodeId).toBe("b");
+		expect(interp.frameStack.length).toBe(stackBefore);
+	});
+
+	test("handleEvent without matching edge keeps node unchanged (multi-turn)", async () => {
+		const flow: Flow = {
+			version: 1,
+			id: "t",
+			nodes: { a: {} },
+			edges: [],
+		};
+		const interp = new FlowInterpreter(flow);
+		await interp.pushNode("a", { tools: [] });
+		const next = await interp.handleEvent({ kind: "tool_call", name: "bash" }, { tools: [] });
+		expect(next).toBeNull();
+		expect(interp.currentNodeId).toBe("a");
+	});
+
+	test("onEnter / onLeave hooks run around push/pop", async () => {
+		const calls: string[] = [];
+		const flow: Flow = {
+			version: 1,
+			id: "t",
+			nodes: {
+				a: {
+					onEnter: [{ tool: "enter_hook" }],
+					onLeave: [{ tool: "leave_hook" }],
+				},
+			},
+			edges: [],
+		};
+		const interp = new FlowInterpreter(flow);
+		const tools = [tool("enter_hook", () => calls.push("enter")), tool("leave_hook", () => calls.push("leave"))];
+		await interp.pushNode("a", { tools });
+		expect(calls).toEqual(["enter"]);
+		await interp.popNode("bye", { tools });
+		expect(calls).toEqual(["enter", "leave"]);
+	});
+});

--- a/packages/coding-agent/test/flow-runtime.test.ts
+++ b/packages/coding-agent/test/flow-runtime.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { FlowRuntime } from "@oh-my-pi/pi-coding-agent/flow/flow-runtime";
+import type { Flow, FlowNode } from "../src/flow/flow-types";
+
+function node(description = ""): FlowNode {
+	return { description };
+}
+
+const flow: Flow = {
+	version: 1,
+	id: "test",
+	nodes: {
+		root: node("root"),
+		child: node("child"),
+		grand: node("grand"),
+	},
+	edges: [],
+};
+
+function userMsg(text: string): AgentMessage {
+	return { role: "user", content: [{ type: "text", text }], timestamp: 0 };
+}
+
+describe("FlowRuntime open/close", () => {
+	test("open frame pushes onto stack and into log", () => {
+		const r = new FlowRuntime(flow);
+		const f = r.openFrame("root", "p");
+		expect(r.frameStack.length).toBe(1);
+		expect(r.executionLog.length).toBe(1);
+		expect(r.topFrame?.id).toBe(f.id);
+		expect(r.topFrame?.parentId).toBeNull();
+	});
+
+	test("nested call sets parentId", () => {
+		const r = new FlowRuntime(flow);
+		const a = r.openFrame("root", "p1");
+		const b = r.openFrame("child", "p2");
+		expect(b.parentId).toBe(a.id);
+		expect(r.frameStack.length).toBe(2);
+	});
+
+	test("closeFrame pops and returns value", () => {
+		const r = new FlowRuntime(flow);
+		r.openFrame("root", "p");
+		const closed = r.closeFrame("hello");
+		expect(closed.returnValue).toBe("hello");
+		expect(closed.status).toBe("returned");
+		expect(r.isStackEmpty).toBe(true);
+	});
+
+	test("appendToCurrentFrame emits trace without storing on frame", () => {
+		const r = new FlowRuntime(flow);
+		r.openFrame("root", "p");
+		// Should not throw — message is traced but not stored on frame.
+		r.appendToCurrentFrame(userMsg("hi"));
+		// Frame has no pocketMessages field; trace is handled by listeners.
+	});
+
+	test("openFrame on unknown node throws", () => {
+		const r = new FlowRuntime(flow);
+		expect(() => r.openFrame("missing", "p")).toThrow();
+	});
+
+	test("currentNode tracks top frame", () => {
+		const r = new FlowRuntime(flow);
+		r.openFrame("root", "p");
+		expect(r.currentNode?.description).toBe("root");
+		r.openFrame("child", "p2");
+		expect(r.currentNode?.description).toBe("child");
+	});
+});
+
+describe("FlowRuntime editFlow + supersede", () => {
+	test("set_node on inactive node only updates flow", () => {
+		const r = new FlowRuntime(flow);
+		r.openFrame("root", "p");
+		const res = r.editFlow([{ kind: "set_node", nodeId: "newone", node: node("newone") }]);
+		expect(res.applied.length).toBe(1);
+		expect(res.supersededFrameIds.length).toBe(0);
+		expect(r.getNode("newone")).toBeDefined();
+		expect(r.frameStack.length).toBe(1);
+	});
+
+	test("set_node on active frame supersedes and re-pushes", () => {
+		const r = new FlowRuntime(flow);
+		r.openFrame("root", "p1");
+		r.openFrame("child", "p2");
+		r.openFrame("grand", "p3");
+
+		const res = r.editFlow([{ kind: "set_node", nodeId: "child", node: node("child") }]);
+		expect(res.supersededFrameIds.length).toBe(2);
+		expect(res.rerunFrameId).toBeDefined();
+		expect(r.frameStack.length).toBe(2);
+		expect(r.frameStack[1].nodeId).toBe("child");
+		const supersededInLog = r.executionLog.filter(f => f.status === "superseded");
+		expect(supersededInLog.length).toBe(2);
+		for (const old of supersededInLog) {
+			expect(old.supersededBy).toBe(res.rerunFrameId);
+		}
+	});
+
+	test("audit trail keeps every frame ever opened", () => {
+		const r = new FlowRuntime(flow);
+		r.openFrame("root", "p1");
+		r.openFrame("child", "p2");
+		r.editFlow([{ kind: "set_node", nodeId: "child", node: node("child") }]);
+		r.closeFrame("done");
+		r.closeFrame("done");
+		expect(r.executionLog.length).toBeGreaterThanOrEqual(3);
+	});
+
+	test("delete_node on active node supersedes without re-push", () => {
+		const r = new FlowRuntime(flow);
+		r.openFrame("root", "p1");
+		r.openFrame("child", "p2");
+		const res = r.editFlow([{ kind: "delete_node", nodeId: "child" }]);
+		expect(res.supersededFrameIds.length).toBe(1);
+		expect(res.rerunFrameId).toBeUndefined();
+		expect(r.frameStack.length).toBe(1);
+		expect(r.getNode("child")).toBeUndefined();
+	});
+});
+
+describe("FlowRuntime snapshot/rehydrate", () => {
+	test("snapshot then construct restores stack and log", () => {
+		const r1 = new FlowRuntime(flow);
+		r1.openFrame("root", "p1");
+		r1.appendToCurrentFrame(userMsg("a"));
+		r1.openFrame("child", "p2");
+		const snap = r1.snapshot();
+
+		const r2 = new FlowRuntime(flow, snap);
+		expect(r2.frameStack.length).toBe(2);
+		expect(r2.executionLog.length).toBe(2);
+		expect(r2.topFrame?.nodeId).toBe("child");
+	});
+});

--- a/packages/coding-agent/test/flow-state-codec.test.ts
+++ b/packages/coding-agent/test/flow-state-codec.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import {
+	createFlowStateMessage,
+	extractLatestFlowState,
+	isFlowStateMessage,
+} from "@oh-my-pi/pi-coding-agent/flow/flow-state-codec";
+import { FLOW_STATE_CUSTOM_TYPE, type FlowState } from "@oh-my-pi/pi-coding-agent/flow/types";
+
+function sampleState(cursor = "start"): FlowState {
+	return {
+		version: 2,
+		flowId: "test",
+		cursor,
+		frameStack: [],
+		executionLog: [],
+	};
+}
+
+describe("createFlowStateMessage", () => {
+	test("wraps a FlowState into a non-display custom message", () => {
+		const state = sampleState();
+		const msg = createFlowStateMessage(state);
+		expect(msg.role).toBe("custom");
+		expect(msg.customType).toBe(FLOW_STATE_CUSTOM_TYPE);
+		expect(msg.display).toBe(false);
+		expect(msg.details).toEqual(state);
+		expect(typeof msg.timestamp).toBe("number");
+	});
+});
+
+describe("isFlowStateMessage", () => {
+	test("returns true for flow-state custom messages", () => {
+		const msg = createFlowStateMessage(sampleState());
+		expect(isFlowStateMessage(msg)).toBe(true);
+	});
+
+	test("returns false for other custom types", () => {
+		const msg = {
+			role: "custom" as const,
+			customType: "something-else",
+			content: "",
+			display: true,
+			timestamp: 0,
+		};
+		expect(isFlowStateMessage(msg as unknown as AgentMessage)).toBe(false);
+	});
+
+	test("returns false for non-custom messages", () => {
+		const msg = {
+			role: "user" as const,
+			content: [{ type: "text" as const, text: "hi" }],
+			timestamp: 0,
+		};
+		expect(isFlowStateMessage(msg)).toBe(false);
+	});
+});
+
+describe("extractLatestFlowState", () => {
+	test("returns undefined for empty history", () => {
+		expect(extractLatestFlowState([])).toBeUndefined();
+	});
+
+	test("returns undefined when no flow-state messages are present", () => {
+		const history: AgentMessage[] = [{ role: "user", content: [{ type: "text", text: "hi" }], timestamp: 0 }];
+		expect(extractLatestFlowState(history)).toBeUndefined();
+	});
+
+	test("returns the state from the only flow-state message", () => {
+		const state = sampleState();
+		const history: AgentMessage[] = [createFlowStateMessage(state)];
+		expect(extractLatestFlowState(history)).toEqual(state);
+	});
+
+	test("returns the most recent flow-state when multiple exist", () => {
+		const first = sampleState("a");
+		const second = sampleState("b");
+		const history: AgentMessage[] = [
+			createFlowStateMessage(first),
+			{ role: "user", content: [{ type: "text", text: "hi" }], timestamp: 0 },
+			createFlowStateMessage(second),
+		];
+		expect(extractLatestFlowState(history)?.cursor).toBe("b");
+	});
+
+	test("ignores unrelated custom messages", () => {
+		const state = sampleState();
+		const history: AgentMessage[] = [
+			{
+				role: "custom",
+				customType: "other",
+				content: "foo",
+				display: true,
+				timestamp: 0,
+			},
+			createFlowStateMessage(state),
+		];
+		expect(extractLatestFlowState(history)).toEqual(state);
+	});
+});

--- a/packages/coding-agent/test/flow-store.test.ts
+++ b/packages/coding-agent/test/flow-store.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { BUNDLED_BASE_FLOW, FlowStore } from "@oh-my-pi/pi-coding-agent/flow/flow-store";
+
+let dir: string;
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "omp-flow-store-"));
+});
+afterEach(() => {
+	try { rmSync(dir, { recursive: true, force: true }); } catch {}
+});
+
+describe("FlowStore (project-local v2)", () => {
+	test("first use seeds from bundled base flow", () => {
+		const store = new FlowStore({ cwd: dir });
+		const flow = store.load();
+		expect(flow.version).toBe(1);
+		expect(flow.id).toBe(BUNDLED_BASE_FLOW.id);
+		expect(Object.keys(flow.nodes)).toContain("chat");
+		const p = join(dir, ".omp", "flow.json");
+		expect(existsSync(p)).toBe(true);
+	});
+
+	test("subsequent load returns on-disk version even if it differs", () => {
+		const store = new FlowStore({ cwd: dir });
+		store.load(); // seed
+		// hand-edit the file
+		const p = join(dir, ".omp", "flow.json");
+		const edited = { version: 1, id: "edited", nodes: { root: {} }, edges: [] };
+		const { writeFileSync } = require("node:fs");
+		writeFileSync(p, JSON.stringify(edited));
+		const store2 = new FlowStore({ cwd: dir });
+		const reloaded = store2.load();
+		expect(reloaded.id).toBe("edited");
+		expect(Object.keys(reloaded.nodes)).toEqual(["root"]);
+	});
+
+	test("save writes to the project dir", () => {
+		const store = new FlowStore({ cwd: dir });
+		store.load();
+		const custom = { version: 1 as const, id: "custom", nodes: { a: {} }, edges: [] };
+		store.save(custom);
+		const raw = readFileSync(join(dir, ".omp", "flow.json"), "utf8");
+		expect(JSON.parse(raw).id).toBe("custom");
+	});
+});

--- a/packages/coding-agent/test/flow-strategy-subflow.test.ts
+++ b/packages/coding-agent/test/flow-strategy-subflow.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentContext, AgentMessage, AgentTool } from "@oh-my-pi/pi-agent-core";
+import { Type } from "@sinclair/typebox";
+import { FlowExecutionStrategy } from "@oh-my-pi/pi-coding-agent/flow/flow-strategy";
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+function makeTool(name: string): AgentTool<any> {
+	return {
+		name, label: name, description: `tool ${name}`,
+		parameters: Type.Object({}), strict: false,
+		async execute() { return { content: [{ type: "text", text: `${name}_ok` }] }; },
+	};
+}
+
+function assistantToolCall(toolName: string, callId: string): AgentMessage {
+	return { role: "assistant", content: [{ type: "toolCall", id: callId, name: toolName, input: {} }], timestamp: Date.now() } as unknown as AgentMessage;
+}
+
+function toolResult(callId: string, text: string, toolName?: string): AgentMessage {
+	return { role: "toolResult", toolCallId: callId, toolName: toolName ?? "unknown", content: [{ type: "text", text }], isError: false, timestamp: Date.now() } as unknown as AgentMessage;
+}
+
+function userMessage(text: string): AgentMessage {
+	return { role: "user", content: [{ type: "text", text }], timestamp: Date.now() } as AgentMessage;
+}
+
+/**
+ * Creates a strategy. pushMsg stamps flowFrameId directly on each message
+ * using the current top frame from strategy.state — mirrors what the real
+ * session manager does in #appendEntry.
+ */
+function makeStrategy(flowJson: object) {
+	const dir = mkdtempSync(join(tmpdir(), "flow-test-"));
+	mkdirSync(join(dir, ".omp"), { recursive: true });
+	writeFileSync(join(dir, ".omp", "flow.json"), JSON.stringify(flowJson));
+	const strategy = new FlowExecutionStrategy({
+		storePath: join(dir, ".omp", "flow.json"),
+		cwd: dir,
+	});
+	/** Push messages and stamp each with the correct flowFrameId —
+	 *  mirrors what the real session manager does in #appendEntry
+	 *  via strategy.getFrameIdForMessage(). */
+	const pushMsg = (messages: AgentMessage[], ...msgs: AgentMessage[]) => {
+		for (const m of msgs) {
+			const frameId = strategy.getFrameIdForMessage(m);
+			if (frameId) {
+				(m as any).flowFrameId = frameId;
+			}
+			messages.push(m);
+		}
+	};
+	return { strategy, pushMsg };
+}
+
+const BASE_FLOW = {
+	version: 1, id: "test_flow",
+	nodes: {
+		chat: { description: "Root node" },
+		scout: { description: "Scout sub-flow", available_tools: ["bash", "read"] },
+	},
+	edges: [],
+};
+
+describe("FlowExecutionStrategy sub-flow lifecycle", () => {
+	test("transformContext filters sub-flow messages after ret", async () => {
+		const { strategy, pushMsg } = makeStrategy(BASE_FLOW);
+		const messages: AgentMessage[] = [];
+		pushMsg(messages, userMessage("enter scout"));
+		const ctx: AgentContext = { systemPrompt: "", messages, tools: [makeTool("bash"), makeTool("read")] };
+
+		await strategy.syncBeforeModelCall(ctx);
+		const entryTool = (ctx.tools ?? []).find(t => t.name === "scout")!;
+		const em1 = assistantToolCall("scout", "c1");
+		pushMsg(messages, em1);
+		await entryTool.execute("c1", { reason: "test entry" });
+		pushMsg(messages, toolResult("c1", "Entered scout.", "scout"));
+		await strategy.onTurnEnd({ context: ctx, message: em1, newMessages: [messages[1], messages[2]] });
+
+		await strategy.syncBeforeModelCall(ctx);
+		const retTool = (ctx.tools ?? []).find(t => t.name === "ret")!;
+		const em2 = assistantToolCall("ret", "c2");
+		pushMsg(messages, em2);
+		await retTool.execute("c2", { value: "Found 3 config files" });
+		pushMsg(messages, toolResult("c2", "ret", "ret"));
+		await strategy.onTurnEnd({ context: ctx, message: em2, newMessages: [messages[3], messages[4]] });
+
+		const view = await strategy.transformContext(messages);
+		const roles = view.map(m => (m as any).role);
+		expect(roles.filter(r => r === "user").length).toBe(1);
+		// Entry assistant message (with scout tool call) survives — re-stamped with parent frame
+		const assistantMsgs = view.filter(m => (m as any).role === "assistant");
+		expect(assistantMsgs.length).toBeGreaterThanOrEqual(1);
+		// Ret assistant message also survives — re-stamped with parent frame
+		const retAssistant = assistantMsgs.find(m =>
+			((m as any).content ?? []).some((c: any) => c.type === "toolCall" && c.name === "ret"));
+		expect(retAssistant).toBeDefined();
+	});
+
+	test("completed sub-flow appears in <scene> block", async () => {
+		const { strategy, pushMsg } = makeStrategy(BASE_FLOW);
+		const messages: AgentMessage[] = [];
+		pushMsg(messages, userMessage("enter scout"));
+		const ctx: AgentContext = { systemPrompt: "", messages, tools: [makeTool("bash"), makeTool("read")] };
+
+		await strategy.syncBeforeModelCall(ctx);
+		const entryTool = (ctx.tools ?? []).find(t => t.name === "scout")!;
+		const em = assistantToolCall("scout", "c1");
+		pushMsg(messages, em);
+		await entryTool.execute("c1", { reason: "test entry" });
+		const er = toolResult("c1", "Entered scout.", "scout");
+		pushMsg(messages, er);
+		await strategy.onTurnEnd({ context: ctx, message: em, newMessages: [em, er] });
+
+		await strategy.syncBeforeModelCall(ctx);
+		const retTool = (ctx.tools ?? []).find(t => t.name === "ret")!;
+		const rm = assistantToolCall("ret", "c2");
+		pushMsg(messages, rm);
+		await retTool.execute("c2", { value: "Found 3 config files" });
+		const rr = toolResult("c2", "ret", "ret");
+		pushMsg(messages, rr);
+		await strategy.onTurnEnd({ context: ctx, message: rm, newMessages: [rm, rr] });
+
+		const view = await strategy.transformContext(messages);
+		const flowBlock = view.find(m => {
+			const c = (m as any).content;
+			return Array.isArray(c) && c.some((b: any) => typeof b.text === "string" && b.text.includes("<scene>"));
+		});
+		expect(flowBlock).toBeDefined();
+		const flowText = ((flowBlock as any).content as any[])[0].text;
+		expect(flowText).toContain("scout");
+		expect(flowText).toContain("Found 3 config files");
+	});
+
+	test("original user message survives subflow entry + work + ret", async () => {
+		const { strategy, pushMsg } = makeStrategy(BASE_FLOW);
+		const messages: AgentMessage[] = [];
+
+		// [0] user: original request — stamped with chat frame
+		pushMsg(messages, userMessage("enter scout and find config files"));
+		const ctx: AgentContext = { systemPrompt: "", messages, tools: [makeTool("bash"), makeTool("read")] };
+
+		// Turn 1: model enters scout
+		// Real sequence: message_end(assistant) → tool execute → message_end(toolResult)
+		await strategy.syncBeforeModelCall(ctx);
+		const entryTool = (ctx.tools ?? []).find(t => t.name === "scout")!;
+		const assistantEntry = assistantToolCall("scout", "c1");
+		pushMsg(messages, assistantEntry); // assistant persisted BEFORE execute — stack is [chat]
+		await entryTool.execute("c1", { reason: "find config files" }); // stack becomes [chat, scout]
+		pushMsg(messages, toolResult("c1", "Entered scout.", "scout")); // toolResult persisted AFTER — stamped with parent (chat)
+		await strategy.onTurnEnd({ context: ctx, message: assistantEntry, newMessages: [messages[1], messages[2]] });
+
+		// Turn 2: model does work inside scout
+		await strategy.syncBeforeModelCall(ctx);
+		pushMsg(messages, assistantToolCall("read", "c3"), toolResult("c3", "file contents here", "read"));
+		await strategy.onTurnEnd({ context: ctx, message: messages[3], newMessages: [messages[3], messages[4]] });
+
+		// Turn 3: user sends message while in scout
+		pushMsg(messages, userMessage("ok now use ret to exit"));
+
+		// Turn 4: model rets
+		// Real sequence: message_end(assistant) → tool execute → message_end(toolResult)
+		await strategy.syncBeforeModelCall(ctx);
+		const retTool = (ctx.tools ?? []).find(t => t.name === "ret")!;
+		const assistantRet = assistantToolCall("ret", "c4");
+		pushMsg(messages, assistantRet); // assistant persisted BEFORE execute — ret detected → parent frame
+		await retTool.execute("c4", { value: "Found 3 config files in /etc" });
+		pushMsg(messages, toolResult("c4", "ret", "ret")); // toolResult persisted AFTER — stamped with parent
+		await strategy.onTurnEnd({ context: ctx, message: assistantRet, newMessages: [messages[6], messages[7]] });
+
+		const view = await strategy.transformContext(messages);
+		const userMessages = view.filter(m => (m as any).role === "user");
+		const userTexts = userMessages.map(m => {
+			const c = (m as any).content;
+			return Array.isArray(c) ? c[0]?.text : c;
+		});
+
+		// Original user message MUST survive — it was stamped with chat frame
+		expect(userTexts).toContain("enter scout and find config files");
+		// Entry assistant message (scout tool call) survives — re-stamped with parent
+		const assistantMsgs = view.filter(m => (m as any).role === "assistant");
+		const entryMsg = assistantMsgs.find(m =>
+			((m as any).content ?? []).some((c: any) => c.type === "toolCall" && c.name === "scout"));
+		expect(entryMsg).toBeDefined();
+		// Ret assistant message survives — re-stamped with parent
+		const retMsg = assistantMsgs.find(m =>
+			((m as any).content ?? []).some((c: any) => c.type === "toolCall" && c.name === "ret"));
+		expect(retMsg).toBeDefined();
+		// Sub-flow internal tool calls (read) must NOT survive
+		const internalMsg = assistantMsgs.find(m =>
+			((m as any).content ?? []).some((c: any) => c.type === "toolCall" && c.name === "read"));
+		expect(internalMsg).toBeUndefined();
+		// Scene block should mention completed sub-flow
+		const sceneMsg = view.find(m => {
+			const c = (m as any).content;
+			return Array.isArray(c) && c.some((b: any) => typeof b.text === "string" && b.text.includes("<scene>"));
+		});
+		expect(sceneMsg).toBeDefined();
+		const sceneText = ((sceneMsg as any).content as any[])[0].text;
+		expect(sceneText).toContain("Found 3 config files in /etc");
+	});
+
+	test("drainPendingRet path also works with transformContext filter", async () => {
+		const { strategy, pushMsg } = makeStrategy(BASE_FLOW);
+		const messages: AgentMessage[] = [];
+		pushMsg(messages, userMessage("scout"));
+		const ctx: AgentContext = { systemPrompt: "", messages, tools: [makeTool("bash"), makeTool("read")] };
+
+		await strategy.syncBeforeModelCall(ctx);
+		const entryTool = (ctx.tools ?? []).find(t => t.name === "scout")!;
+		const em = assistantToolCall("scout", "c1");
+		pushMsg(messages, em);
+		await entryTool.execute("c1", { reason: "test entry" });
+		const er = toolResult("c1", "Entered scout.", "scout");
+		pushMsg(messages, er);
+		await strategy.onTurnEnd({ context: ctx, message: em, newMessages: [em, er] });
+
+		await strategy.syncBeforeModelCall(ctx);
+		const retTool = (ctx.tools ?? []).find(t => t.name === "ret")!;
+		await retTool.execute("c2", { value: "5 endpoints found" });
+
+		// Skip onTurnEnd, go to next sync (race — drainPendingRet)
+		const rm = assistantToolCall("ret", "c2");
+		pushMsg(messages, rm);
+		pushMsg(messages, toolResult("c2", "ret", "ret"));
+		await strategy.syncBeforeModelCall(ctx);
+
+		const view = await strategy.transformContext(messages);
+		// 5 original + 2 synthetic (Entering + Exited) + 1 synthetic Entering chat (root re-push)
+		expect(messages.length).toBeGreaterThanOrEqual(5);
+		const flowText = view.flatMap(m => {
+			const c = (m as any).content;
+			return Array.isArray(c) ? c.map((b: any) => b.text ?? "") : [];
+		}).join("\n");
+		expect(flowText).toContain("5 endpoints found");
+	});
+
+	test("drainPendingRet never pops the root frame (race condition)", async () => {
+		const { strategy, pushMsg } = makeStrategy(BASE_FLOW);
+		const messages: AgentMessage[] = [];
+		pushMsg(messages, userMessage("scout"));
+		const ctx: AgentContext = { systemPrompt: "", messages, tools: [makeTool("bash"), makeTool("read")] };
+
+		await strategy.syncBeforeModelCall(ctx);
+
+		const entryTool = (ctx.tools ?? []).find(t => t.name === "scout")!;
+		const em = assistantToolCall("scout", "c1");
+		pushMsg(messages, em);
+		await entryTool.execute("c1", { reason: "test entry" });
+		const er = toolResult("c1", "Entered scout.", "scout");
+		pushMsg(messages, er);
+		await strategy.onTurnEnd({ context: ctx, message: em, newMessages: [em, er] });
+
+		await strategy.syncBeforeModelCall(ctx);
+		const retTool = (ctx.tools ?? []).find(t => t.name === "ret")!;
+		const rm = assistantToolCall("ret", "c2");
+		pushMsg(messages, rm);
+		await retTool.execute("c2", { value: "result" });
+		const rr = toolResult("c2", "ret", "ret");
+		pushMsg(messages, rr);
+		await strategy.onTurnEnd({ context: ctx, message: rm, newMessages: [rm, rr] });
+
+		const state = strategy.state;
+		expect(state.frameStack.length).toBeGreaterThanOrEqual(1);
+		expect(state.frameStack[0].nodeId).toBe("chat");
+
+		await strategy.syncBeforeModelCall(ctx);
+		expect(strategy.state.frameStack.length).toBe(1);
+		expect(strategy.state.frameStack[0].nodeId).toBe("chat");
+	});
+});

--- a/packages/coding-agent/test/flow-tool-filter.test.ts
+++ b/packages/coding-agent/test/flow-tool-filter.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentTool } from "@oh-my-pi/pi-agent-core";
+import { Type } from "@sinclair/typebox";
+import { applyToolFilter } from "../src/flow/flow-tool-filter";
+
+function tool(name: string): AgentTool<any> {
+	return {
+		name,
+		label: name,
+		description: "",
+		parameters: Type.Object({}),
+		strict: true,
+		async execute() {
+			return { content: [] };
+		},
+	};
+}
+
+const parent = [tool("bash"), tool("grep"), tool("read_file"), tool("mcp_gitea_list"), tool("mcp_gitea_read")];
+
+describe("applyToolFilter", () => {
+	test("undefined filter passes through parent scope", () => {
+		const out = applyToolFilter(parent, undefined);
+		expect(out.map(t => t.name)).toEqual(parent.map(t => t.name));
+	});
+
+	test("empty array passes through parent scope (inherit)", () => {
+		const out = applyToolFilter(parent, []);
+		expect(out.length).toBe(parent.length);
+	});
+
+	test("allow-only keeps only listed tools", () => {
+		const out = applyToolFilter(parent, ["bash", "grep"]);
+		expect(out.map(t => t.name).sort()).toEqual(["bash", "grep"]);
+	});
+
+	test("deny-only removes listed tools from parent", () => {
+		const out = applyToolFilter(parent, ["!bash"]);
+		expect(out.map(t => t.name)).not.toContain("bash");
+		expect(out.length).toBe(parent.length - 1);
+	});
+
+	test("glob allow matches multiple tools", () => {
+		const out = applyToolFilter(parent, ["mcp_gitea_*"]);
+		expect(out.map(t => t.name).sort()).toEqual(["mcp_gitea_list", "mcp_gitea_read"]);
+	});
+
+	test("mixed order: allow then deny", () => {
+		const out = applyToolFilter(parent, ["mcp_gitea_*", "!mcp_gitea_read"]);
+		expect(out.map(t => t.name)).toEqual(["mcp_gitea_list"]);
+	});
+
+	test("unknown names in allow list are silently ignored", () => {
+		const out = applyToolFilter(parent, ["bash", "does_not_exist"]);
+		expect(out.map(t => t.name)).toEqual(["bash"]);
+	});
+
+	test("glob deny over deny-only start set", () => {
+		const out = applyToolFilter(parent, ["!mcp_*"]);
+		expect(out.map(t => t.name).sort()).toEqual(["bash", "grep", "read_file"]);
+	});
+});

--- a/packages/coding-agent/test/flow-trigger-matcher.test.ts
+++ b/packages/coding-agent/test/flow-trigger-matcher.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { matchTriggers, pathGlobToRegex, simpleNameGlob } from "../src/flow/flow-trigger-matcher";
+import type { Flow } from "../src/flow/flow-types";
+
+function makeFlow(triggers: Flow["triggers"]): Flow {
+	return {
+		version: 1,
+		id: "check_backend",
+		nodes: { check_backend: { description: "run typecheck" } },
+		edges: [],
+		triggers,
+	};
+}
+
+describe("simpleNameGlob", () => {
+	test("literal match", () => {
+		expect(simpleNameGlob("bash", "bash")).toBe(true);
+		expect(simpleNameGlob("bash", "grep")).toBe(false);
+	});
+	test("wildcard match", () => {
+		expect(simpleNameGlob("mcp_*", "mcp_gitea_list")).toBe(true);
+		expect(simpleNameGlob("mcp_*", "bash")).toBe(false);
+	});
+});
+
+describe("pathGlobToRegex", () => {
+	test("star matches single segment", () => {
+		expect(pathGlobToRegex("src/*.ts").test("src/main.ts")).toBe(true);
+		expect(pathGlobToRegex("src/*.ts").test("src/sub/main.ts")).toBe(false);
+	});
+	test("double star matches recursively", () => {
+		expect(pathGlobToRegex("src/**/*.ts").test("src/main.ts")).toBe(true);
+		expect(pathGlobToRegex("src/**/*.ts").test("src/a/b/c.ts")).toBe(true);
+	});
+});
+
+describe("matchTriggers", () => {
+	test("tool name glob", () => {
+		const flow = makeFlow([{ when: "after_tool_call", match: { tool: "file_write" } }]);
+		const ids = matchTriggers(flow, { phase: "after_tool_call", tool: "file_write" });
+		expect(ids).toEqual(["check_backend"]);
+	});
+
+	test("tool name glob does not match wrong phase", () => {
+		const flow = makeFlow([{ when: "after_tool_call", match: { tool: "file_write" } }]);
+		const ids = matchTriggers(flow, { phase: "before_tool_call", tool: "file_write" });
+		expect(ids).toEqual([]);
+	});
+
+	test("path glob", () => {
+		const flow = makeFlow([{ when: "after_tool_call", match: { path: "backend/**/*.ts" } }]);
+		const ok = matchTriggers(flow, {
+			phase: "after_tool_call",
+			tool: "file_write",
+			args: { path: "backend/foo/bar.ts" },
+		});
+		expect(ok).toEqual(["check_backend"]);
+		const no = matchTriggers(flow, {
+			phase: "after_tool_call",
+			tool: "file_write",
+			args: { path: "frontend/a.ts" },
+		});
+		expect(no).toEqual([]);
+	});
+
+	test("flow id exact match", () => {
+		const flow = makeFlow([{ when: "on_flow_enter", match: { flow: "check_backend" } }]);
+		expect(matchTriggers(flow, { phase: "on_flow_enter", flowId: "check_backend" })).toEqual(["check_backend"]);
+		expect(matchTriggers(flow, { phase: "on_flow_enter", flowId: "other" })).toEqual([]);
+	});
+
+	test("combined tool + path match", () => {
+		const flow = makeFlow([
+			{ when: "after_tool_call", match: { tool: "file_write", path: "backend/**/*.ts" } },
+		]);
+		expect(
+			matchTriggers(flow, {
+				phase: "after_tool_call",
+				tool: "file_write",
+				args: { path: "backend/api.ts" },
+			}),
+		).toEqual(["check_backend"]);
+		expect(
+			matchTriggers(flow, {
+				phase: "after_tool_call",
+				tool: "grep",
+				args: { path: "backend/api.ts" },
+			}),
+		).toEqual([]);
+	});
+});


### PR DESCRIPTION
# Flow agent - concept playground

Hey, this isn't a feature PR. It's a vibe-coded playground I built on top
of your codebase to test a couple of ideas. I'd love your thoughts, but please
don't feel any pressure to merge any of it. Most of what's here is throw-away
exploration; the interesting parts (I hope) are the concepts.

You've built something genuinely impressive: the extension surface, the hook
system, the way `AgentSession` is structured, all of it made this experiment
possible without forking. Thank you for that.

---

## Concept 1: agent as flow, not as code

I've been thinking about this for a while: **asking the model to write code
to improve the agent feels like asking it to plant a time bomb.** Code can't
really be validated; one wrong line and you're debugging at 2am.

What if we ask the model to write **configuration** instead?

- Configuration can be scrutinized with a JSON schema.
- The model will happily iterate on a rule until the schema accepts it. This
  is exactly the loop MCP already uses for tool registration, just applied to
  orchestration.

The "flow" here is a DAG of nodes in `.omp/flow.json`. Each node is a pure
closure: `description`, `prompt`, `available_tools`, `onEnter/onLeave/onError`
hooks. The model can mutate this file via a `flow_edit` tool that's gated
behind the schema. Same loop as MCP, just for the orchestrator instead of the
tools.

I'm not claiming this is the right shape, just that it felt worth trying, and
having `omp` underneath made it cheap to try.

---

## Concept 2: scout / auto-scout

The context window shouldn't be littered with failed attempts to answer a
simple question like "where is the login form?".

**Scout** is a node that wraps the model into a frame where, after it finds
what it was looking for, it is *forced* to drop the noise and return only the
relevant summary to the parent. When you follow a flow you usually care about
*what was found*, not *how it was found*.

**Auto-scout** is the same idea, but automatic: the moment the model calls a
noisy tool (`bash`, `read`, `grep`, ...) from the root, the orchestrator
transparently moves it into scout. The model doesn't notice, it called
`bash` as usual. But everything that happens after lives in an isolated frame,
and the only way out is `ret(summary)`.

The effect I was hoping for: chat history stays a clean ladder of
*user question, ret summary, user question, ret summary*. All the file dumps
and grep results die with the scout frame.

(Whether this works in practice is exactly the kind of thing I'd love your
gut reaction on. You have way more intuition about how the model actually
behaves than I do.)

---

## What's in the box

- `packages/coding-agent/src/flow/` is the orchestrator itself, fully
  self-contained.
- A small `ExecutionStrategy` hook on `Agent` so the flow can attach without
  forking the agent loop. This is just a byproduct of needing somewhere to
  plug in. Happy to discuss whether it should exist at all, or live somewhere
  else, or be implemented differently.
- `OMP_FLOW=1` to opt in. Default behavior is byte-identical without the env
  var, I went out of my way to make sure of that.
- Flow nodes auto-register as slash commands (`/scout`, `/fixer`, ...) via a
  small addition to `ExtensionRunner.registerCommand`.

## What I'd love (if you have time)

- Does the "config-not-code" framing resonate, or is there a sharper way to
  think about it?
- Is auto-scout too aggressive? Too magical?
- Anything in the data model (`flow-types.ts`) that would obviously block
  real use cases?

## What I'm explicitly NOT asking for

- A merge. Really. Most of this is exploration.
- Bug-fix time. If something breaks, that's part of the playground.
- Roadmap commitments. If you read this and it sparks one idea you'd implement
  differently, that's already a win for me.

Thanks for taking a look.
