### PR TITLE
fix(ai): omit unsupported Copilot Anthropic reasoning fields

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1133,6 +1133,16 @@ function createClient(
 	return { client, isOAuthToken: oauthToken };
 }
 
+function stripGitHubCopilotReasoningControls(
+	model: Model<"anthropic-messages">,
+	params: MessageCreateParamsStreaming,
+): void {
+	if (model.provider !== "github-copilot") return;
+	// Copilot's Anthropic proxy rejects these controls with misleading model_not_supported errors.
+	delete params.thinking;
+	delete params.output_config;
+}
+
 function disableThinkingIfToolChoiceForced(params: MessageCreateParamsStreaming): void {
 	const toolChoice = params.tool_choice;
 	if (!toolChoice) return;
@@ -1470,6 +1480,7 @@ function buildParams(
 	if (systemBlocks) {
 		params.system = systemBlocks;
 	}
+	stripGitHubCopilotReasoningControls(model, params);
 	disableThinkingIfToolChoiceForced(params);
 	ensureMaxTokensForThinking(params, model);
 	applyPromptCaching(params, cacheControl);

--- a/packages/ai/test/github-copilot-anthropic-auth.test.ts
+++ b/packages/ai/test/github-copilot-anthropic-auth.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import { Effort } from "../src/model-thinking";
 import { buildAnthropicClientOptions, streamAnthropic } from "../src/providers/anthropic";
 import type { Context, Model } from "../src/types";
 import { buildAnthropicUrl } from "../src/utils/anthropic-auth";
@@ -186,6 +187,33 @@ describe("Anthropic Copilot auth config", () => {
 		});
 
 		expect(url).toBe("http://127.0.0.1:8317/v1/messages?beta=true");
+	});
+
+	it("omits unsupported thinking controls from Copilot Anthropic requests", async () => {
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		const controller = new AbortController();
+		controller.abort();
+
+		const model: Model<"anthropic-messages"> = {
+			...makeCopilotClaudeModel(),
+			thinking: {
+				mode: "anthropic-adaptive",
+				minLevel: Effort.Minimal,
+				maxLevel: Effort.XHigh,
+			},
+		};
+
+		streamAnthropic(model, testContext, {
+			apiKey: "ghu_test_copilot_token",
+			reasoning: Effort.XHigh,
+			thinkingEnabled: true,
+			signal: controller.signal,
+			onPayload: payload => resolve(payload),
+		});
+
+		const payload = (await promise) as { thinking?: unknown; output_config?: unknown };
+		expect(payload.thinking).toBeUndefined();
+		expect(payload.output_config).toBeUndefined();
 	});
 
 	it("forwards initiatorOverride to Copilot message requests", async () => {


### PR DESCRIPTION
## Summary
- strip `thinking` and `output_config` from Anthropic message payloads sent through the GitHub Copilot provider
- keep the existing Copilot-specific transport and auth handling unchanged
- add a regression test that captures a Copilot Claude payload with adaptive thinking enabled and verifies both fields are omitted

## Testing
- bunx biome check packages/ai/src/providers/anthropic.ts packages/ai/test/github-copilot-anthropic-auth.test.ts
- bun test packages/ai/test/github-copilot-anthropic-auth.test.ts
- bun --cwd=packages/ai run check:types

Fixes #688