### PR TITLE
Introduce new orchestrator mode and fix issues with tasks, task view, viewport and task isolation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Parallel execution framework with specialized agents and real-time streaming:
 - **Parallel exploration**: Reviewer agent can spawn explore agents for large codebase analysis
 - **Real-time artifact streaming**: Task outputs stream as they're created, not just at completion
 - **Full output access**: Read complete subagent output via `agent://<id>` resources when previews truncate
-- **Isolation backends**: `isolated: true` runs tasks in git worktrees, Unix fuse-overlay filesystems, or Windows ProjFS (`fuse-projfs`), with patch or branch merge strategies
+- **Isolation backends**: `isolated: true` runs tasks in git worktrees, Unix reflink snapshots (`cp --reflink`), or Windows ProjFS (`fuse-projfs`), with patch or branch merge strategies
 - **Async background jobs**: Background execution with configurable concurrency (up to 100 jobs) and `poll` tool for blocking on results
 - **Agent Control Center**: `/agents` dashboard for managing and creating custom agents
 - **AI-powered agent creation**: Generate custom agent definitions with the architect model
@@ -963,7 +963,7 @@ async:
 task:
   eager: false
   isolation:
-    mode: none # none | worktree | fuse-overlay | fuse-projfs
+    mode: none # none | worktree | reflink | fuse-projfs
     merge: patch # patch | branch
 ```
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 ### Fixed
 
+- Fixed provider message normalization to recover histories where a user/developer message was inserted between an assistant tool call and its later tool result. Interleaved messages are deferred until after the pending tool result so Anthropic-compatible requests keep `tool_result` blocks immediately after `tool_use` blocks
 - Fixed Cursor provider losing conversation history on follow-up turns (model responding "this appears to be the start of our session") by populating `ConversationStateStructure.rootPromptMessagesJson` with JSON blob IDs for the system prompt plus prior user/assistant/tool-result messages. Cursor's server builds the model prompt from `rootPromptMessagesJson`, not from the protobuf `turns[]` tree, so sending only the system prompt there caused prior turns to be dropped
 - Fixed Cursor provider multi-turn conversations failing with `Connect error internal: Blob not found` on the second message by storing `ConversationStateStructure.turns`, `AgentConversationTurnStructure.user_message`, and `AgentConversationTurnStructure.steps` as content-addressed blob IDs in the KV store (matching the existing handling for `rootPromptMessagesJson`) rather than sending the raw serialized bytes inline ([#678](https://github.com/can1357/oh-my-pi/issues/678))
 

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -126,31 +126,53 @@ export function transformMessages<TApi extends Api>(
 		transformed.filter((msg): msg is ToolResultMessage => msg.role === "toolResult").map(msg => msg.toolCallId),
 	);
 
-	// Second pass: insert synthetic empty tool results for orphaned tool calls
-	// and preserve aborted/errored tool results when they were already persisted.
+	// Second pass: keep every assistant tool call adjacent to its tool result(s). Interleaved
+	// user/developer messages are deferred until later real results arrive; missing results get synthetic errors.
 	const result: Message[] = [];
 	let pendingToolCalls: ToolCall[] = [];
+	let deferredInterleavedMessages: Message[] = [];
 	let pendingAbortedToolCalls = new Map<string, ToolCall>();
 	let pendingAbortedTimestamp: number | undefined;
 	// Track tool call status: whether resolved (has result) or aborted (synthetic result injected, skip later real results)
 	const toolCallStatus = new Map<string, ToolCallStatus>();
 
+	const unresolvedPendingToolCalls = (): ToolCall[] => pendingToolCalls.filter(tc => !toolCallStatus.has(tc.id));
+
+	const pendingToolCallsAwaitRealResults = (): boolean =>
+		unresolvedPendingToolCalls().some(tc => realToolResultIds.has(tc.id));
+
+	const flushDeferredInterleavedMessages = (): void => {
+		if (deferredInterleavedMessages.length === 0) return;
+		result.push(...deferredInterleavedMessages);
+		deferredInterleavedMessages = [];
+	};
+
+	const synthesizePendingToolCalls = (timestamp: number): void => {
+		for (const tc of unresolvedPendingToolCalls()) {
+			result.push({
+				role: "toolResult",
+				toolCallId: tc.id,
+				toolName: tc.name,
+				content: [{ type: "text", text: "No result provided" }],
+				isError: true,
+				timestamp,
+			} as ToolResultMessage);
+			toolCallStatus.set(tc.id, ToolCallStatus.Resolved);
+		}
+	};
+
+	const finishPendingToolCallsIfReady = (timestamp: number): void => {
+		if (pendingToolCalls.length === 0 || pendingToolCallsAwaitRealResults()) return;
+		synthesizePendingToolCalls(timestamp);
+		pendingToolCalls = [];
+		flushDeferredInterleavedMessages();
+	};
+
 	const flushPendingToolCalls = (timestamp: number): void => {
 		if (pendingToolCalls.length === 0) return;
-		for (const tc of pendingToolCalls) {
-			if (!toolCallStatus.has(tc.id) && !realToolResultIds.has(tc.id)) {
-				result.push({
-					role: "toolResult",
-					toolCallId: tc.id,
-					toolName: tc.name,
-					content: [{ type: "text", text: "No result provided" }],
-					isError: true,
-					timestamp,
-				} as ToolResultMessage);
-				toolCallStatus.set(tc.id, ToolCallStatus.Resolved);
-			}
-		}
+		synthesizePendingToolCalls(timestamp);
 		pendingToolCalls = [];
+		flushDeferredInterleavedMessages();
 	};
 
 	const flushPendingAbortedToolCalls = (): void => {
@@ -210,14 +232,24 @@ export function transformMessages<TApi extends Api>(
 				continue;
 			}
 
-			if (toolCallStatus.get(msg.toolCallId) === ToolCallStatus.Aborted) continue;
+			const status = toolCallStatus.get(msg.toolCallId);
+			if (status === ToolCallStatus.Aborted || status === ToolCallStatus.Resolved) continue;
 			toolCallStatus.set(msg.toolCallId, ToolCallStatus.Resolved);
 			result.push(msg);
+			finishPendingToolCallsIfReady(messageTimestamp);
 		} else if (msg.role === "user" || msg.role === "developer") {
+			if (pendingToolCalls.length > 0 && pendingToolCallsAwaitRealResults()) {
+				deferredInterleavedMessages.push(msg);
+				continue;
+			}
 			flushPendingToolCalls(messageTimestamp);
 			flushPendingAbortedToolCalls();
 			result.push(msg);
 		} else {
+			if (pendingToolCalls.length > 0 && pendingToolCallsAwaitRealResults()) {
+				deferredInterleavedMessages.push(msg);
+				continue;
+			}
 			flushPendingToolCalls(messageTimestamp);
 			flushPendingAbortedToolCalls();
 			result.push(msg);
@@ -226,6 +258,7 @@ export function transformMessages<TApi extends Api>(
 
 	flushPendingToolCalls(Date.now());
 	flushPendingAbortedToolCalls();
+	flushDeferredInterleavedMessages();
 
 	return result;
 }

--- a/packages/ai/test/duplicate-tool-results.test.ts
+++ b/packages/ai/test/duplicate-tool-results.test.ts
@@ -87,7 +87,7 @@ describe("Duplicate Tool Results Regression", () => {
 		expect(toolResults.length).toBe(1);
 	});
 
-	it("does not synthesize 'No result provided' when a real tool result appears later in history", () => {
+	it("defers interleaved developer messages until after a later real tool result", () => {
 		const toolCallId = "toolu_deferred_result_123";
 
 		const assistantMessage: AssistantMessage = {
@@ -139,6 +139,49 @@ describe("Duplicate Tool Results Regression", () => {
 
 		expect(toolResults).toHaveLength(1);
 		expect((toolResults[0] as ToolResultMessage).content).toEqual([{ type: "text", text: "todo updated" }]);
+		expect(transformed.map(msg => msg.role)).toEqual(["assistant", "toolResult", "developer"]);
+		expect(transformed[1]).toBe(messages[2]);
+		expect(transformed[2]).toBe(messages[1]);
+	});
+
+	it("defers interleaved user breadcrumbs until after pending tool results", () => {
+		const toolCallId = "toolu_checkpoint_poll_123";
+		const assistantMessage: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "toolCall", id: toolCallId, name: "poll", arguments: { timeout: 270 } }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-3-5-sonnet-20241022",
+			usage: {
+				input: 100,
+				output: 50,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 150,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+		const breadcrumb = {
+			role: "user" as const,
+			content: "**Pre-task checkpoint committed** before isolated task dispatch",
+			timestamp: Date.now(),
+		};
+		const toolResult: ToolResultMessage = {
+			role: "toolResult",
+			toolCallId,
+			toolName: "poll",
+			content: [{ type: "text", text: "completed" }],
+			isError: false,
+			timestamp: Date.now(),
+		};
+
+		const transformed = transformMessages([assistantMessage, breadcrumb, toolResult], model);
+
+		expect(transformed.map(msg => msg.role)).toEqual(["assistant", "toolResult", "user"]);
+		expect(transformed[1]).toBe(toolResult);
+		expect(transformed[2]).toBe(breadcrumb);
 	});
 
 	it("should not duplicate tool results for aborted messages when results already exist", () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Persisted handoff sessions to disk before continuation, and emitted the handoff directive as a trailing `<system-reminder>` override block inside a developer message instead of resetting the active system prompt to base. The previous reset invalidated the Anthropic system cache whenever the prior turn ran with an extension override, plan-mode override, or SDK-supplied system prompt; the new path preserves cache hits across the handoff
+
 ## [14.5.2] - 2026-04-26
 ### Breaking Changes
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,9 +2,34 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added orchestrator mode: a coordination-only session that delegates all file mutations to focused task agents running in isolated git worktrees. Edit-capable subagents auto-isolate with branch-based integration; a per-batch mutex serializes cherry-pick/apply so parallel tasks run concurrently without corrupting shared parent state. The orchestrator system prompt forbids direct edits and routes all code changes through the `task` tool. Toggle via `/orchestrator` slash command
+- Added `git_commit_checkpoint` tool, registered in orchestrator mode only, that commits outstanding work in the current project as a WIP checkpoint at scope boundaries. Iterates every dirty repo under the session cwd, generates the commit message via the smol model used by isolated task branches, and falls back to `wip: <reason>` when no model registry is available
+- Added pre-task auto-commit: isolated task dispatches from a dirty parent worktree auto-commit every dirty repo under the project root via the same model-generated commit path before capturing the baseline, so task branches cherry-pick onto a clean parent.
+- Added session observer overlay (`Ctrl+S`) for live read-only viewing of subagent sessions during orchestration; list sorts newest-first
+- Added `reflink` isolation mode that snapshots the repository to an isolated worktree via `cp --reflink=auto` for true point-in-time isolation; the snapshot is independent of the live working tree and survives concurrent edits
+- Added `timeout` option to the `task` tool that aborts long-running subtasks at the deadline and returns partial results
+
 ### Changed
 
+- Renamed `task.isolation.mode = fuse-overlay` to `task.isolation.mode = reflink`. Existing settings auto-migrate on load. fuse-overlay (CoW-over-live-repo) is replaced by reflink (point-in-time snapshot via `cp --reflink`); the new mode is independent of the live tree, so concurrent edits in the parent worktree no longer leak into the isolated task
+- Hardened isolated task lifecycle: aborted tasks now preserve in-progress subagent work as recovery patches under `<artifactsDir>/<taskId>.patch` before the worktree is torn down; cherry-pick uses `--empty=drop` so duplicate-content siblings (parallel subagents producing identical output, formatter noise) skip silently instead of aborting the merge; cherry-pick falls back to `-X theirs` when parallel tasks produce overlapping writes, surfacing the overridden files as an audit notification
+- Hardened orchestrator and subagent prompts: orchestrator MUST NOT change file contents directly by any means (bash, sed/awk/perl, heredocs, redirects, editors); the only direct-bash escape is git-repo structural work (`git init`, `git clone`, deleting `.git`, submodule add/remove, remote configuration). Each subagent task MUST deliver a finished product before yielding (formatted scoped to touched files, scoped tests covering changed behavior passing, tests written for new behavior); the orchestrator no longer absorbs post-hoc formatting or writes missing tests for subagent output
+- Reworked task summary rendering: summaries now include commit hashes for merged branches, use summary-driven merge reporting, and surface merge-failed branches verbatim with `<branch>` and `<error>` tags so the main session can re-delegate or cherry-pick manually
 - Persisted handoff sessions to disk before continuation, and emitted the handoff directive as a trailing `<system-reminder>` override block inside a developer message instead of resetting the active system prompt to base. The previous reset invalidated the Anthropic system cache whenever the prior turn ran with an extension override, plan-mode override, or SDK-supplied system prompt; the new path preserves cache hits across the handoff
+- Preserved orchestrator mode per session across resume; `Ctrl+S` toggles the session observer overlay using the main session renderer
+- Restored read/grep anchor output (hashlines, chunk tree, line numbers) in orchestrator-mode sessions. The previous `ToolSession.hasEditTool` carve-out forced false whenever orchestrator mode was on, which suppressed anchors regardless of `edit.mode` and left direct-edit carveouts with no way to target what they just read
+- Updated `AsyncJobManager.register` to collapse whitespace runs in job labels so multi-line bash commands (`for/do/done`) no longer break the single-line await/poll status rows
+
+- Reworked nested-repo handling: nested repos with no HEAD (freshly-init'd scaffold dirs) now fall back to git's well-known empty-tree SHA so delta capture succeeds; child directories whose names start with `.` are pruned from discovery to avoid traversing `.git` and similar tooling state
+
+### Fixed
+
+- Fixed `captureRepoBaseline` aborting delta capture for nested repos that had a `.git` directory but no commits (`fatal: Not a valid object name`), which previously collapsed the whole orchestrated task into `Branch commit failed: ... No delta artifacts were written` with no recovery path
+- Fixed isolated task commit failures losing the captured branch delta. Branch mode now writes each captured patch to `<artifactsDir>/<taskId>.patch` (and `<artifactsDir>/<taskId>.<sanitized-rel>.patch` per nested repo) before attempting the branch commit, never deletes partial `omp/task/<id>` branches on commit failure, and surfaces the recovery paths in the per-task error so the user can `git apply` manually
+- Fixed `commitPatchToRepoBranch` masking the suspicious 'patch applied as a no-op' case (captured patch non-empty but `git status` clean after apply) as a generic 'nothing to commit' error; the branch path now logs the captured patch head and throws a distinct error message
+>>>>>>> c5e09f2bb (feat(coding-agent): orchestrator mode with isolated subagent dispatch and scope-boundary checkpoints)
 
 ## [14.5.2] - 2026-04-26
 ### Breaking Changes

--- a/packages/coding-agent/DEVELOPMENT.md
+++ b/packages/coding-agent/DEVELOPMENT.md
@@ -906,15 +906,15 @@ Despite the name `runSubprocess`, `packages/coding-agent/src/task/executor.ts` c
 
 What _is_ isolated is execution context and artifacts, not process memory:
 
-- Optional filesystem isolation is controlled by the `task.isolation.mode` setting (`"none"`, `"worktree"`, `"fuse-overlay"`, or `"fuse-projfs"`).
+- Optional filesystem isolation is controlled by the `task.isolation.mode` setting (`"none"`, `"worktree"`, `"reflink"`, or `"fuse-projfs"`).
   - **worktree**: `ensureWorktree(...)`, `applyBaseline(...)`, `captureDeltaPatch(...)`, `cleanupWorktree(...)`. Nested non-submodule git repos are discovered and handled independently.
-  - **fuse-overlay**: `ensureFuseOverlay(...)`, `captureDeltaPatch(...)`, `cleanupFuseOverlay(...)` using `fuse-overlayfs` on Unix hosts. On Windows, this mode falls back to `worktree` with a system notification.
+  - **reflink**: `ensureReflinkSnapshot(...)`, `captureDeltaPatch(...)`, `cleanupReflinkSnapshot(...)` using `cp --reflink=auto` on Linux or `cp -c` (APFS clone) on macOS. Produces a point-in-time snapshot that is independent of subsequent main-session writes (unlike the former `fuse-overlay` mode, which stacked a CoW layer over the live lowerdir). On Windows, this mode falls back to `worktree` with a system notification.
   - **fuse-projfs**: `ensureProjfsOverlay(...)`, `captureDeltaPatch(...)`, `cleanupProjfsOverlay(...)` using ProjFS on Windows. Missing ProjFS prerequisites fall back to `worktree` with a system notification; non-prerequisite startup errors still fail the task.
-- The `task.isolation.merge` setting controls how isolated changes are integrated back:
-  - **patch** (default): captures a diff via `captureDeltaPatch(...)`, combines patches, and applies with `git apply`.
-  - **branch**: each task commits to a temp branch (`omp/task/<id>`) via `commitToBranch(...)`, then `mergeTaskBranches(...)` cherry-picks them sequentially onto HEAD. If `git apply` fails inside `commitToBranch`, the error is non-fatal — the agent result is preserved with a `merge failed` status.
+- The `task.isolation.merge` setting controls how isolated changes are integrated back. Every task runs its own merge step inline as soon as it finishes, serialized across the batch through a per-invocation mutex so concurrent tasks don't race on parent-repo state.
+  - **patch** (default): captures a diff via `captureDeltaPatch(...)` and applies it against the live working tree with `git apply`. On failure, `patchPath` is preserved and the task's status flips to `merge failed`.
+  - **branch**: each task commits to a temp branch (`omp/task/<id>`) via `commitToBranch(...)`, then `mergeSingleBranch(...)` cherry-picks it onto HEAD. On cherry-pick conflict the branch stays in the repository verbatim and the task is reported as `merge failed`; successful branches are deleted immediately after merge.
 - The `task.isolation.commits` setting (`generic` or `ai`) controls commit messages for branch commits and nested repo patches. `ai` mode uses a smol model to generate conventional commit messages from diffs.
-- Nested repo patches are applied via `applyNestedPatches(...)` after the parent merge, grouped by repo with one commit per repo.
+- Nested repo patches are applied per task via `applyNestedPatches(...)` once the parent merge succeeds. Each nested repo is attempted independently so a failure in one sub-repo does not block siblings; failures are attributed back to the owning task's `error` and surface as `merge failed`. Multi-root workspaces (Cargo/npm/git-submodule-adjacent) therefore no longer collapse into one opaque batch failure.
 - Child session JSONL/markdown outputs are written under the task artifacts directory (`<id>.jsonl`, `<id>.md`, and in isolated mode `<id>.patch`).
 
 ### Tooling Surface in Child Sessions

--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -16,6 +16,7 @@ export interface AsyncJob {
 	promise: Promise<void>;
 	resultText?: string;
 	errorText?: string;
+	resultDetails?: Record<string, unknown>;
 }
 
 export interface AsyncJobManagerOptions {
@@ -92,12 +93,16 @@ export class AsyncJobManager {
 			type,
 			status: "running",
 			startTime,
-			label,
+			// Collapse whitespace runs so multi-line commands stay on one status-row line.
+			label: label.replace(/\s+/g, " ").trim(),
 			abortController,
 			promise: Promise.resolve(),
 		};
 
 		const reportProgress = async (text: string, details?: Record<string, unknown>): Promise<void> => {
+			if (details) {
+				job.resultDetails = details;
+			}
 			if (!options?.onProgress) return;
 			try {
 				await options.onProgress(text, details);
@@ -113,6 +118,7 @@ export class AsyncJobManager {
 				const text = await run({ jobId: id, signal: abortController.signal, reportProgress });
 				if (job.status === "cancelled") {
 					job.resultText = text;
+					this.#enqueueDelivery(id, text);
 					this.#scheduleEviction(id);
 					return;
 				}
@@ -122,7 +128,9 @@ export class AsyncJobManager {
 				this.#scheduleEviction(id);
 			} catch (error) {
 				if (job.status === "cancelled") {
-					job.errorText = error instanceof Error ? error.message : String(error);
+					const errorText = error instanceof Error ? error.message : String(error);
+					job.errorText = errorText;
+					this.#enqueueDelivery(id, errorText);
 					this.#scheduleEviction(id);
 					return;
 				}

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -46,6 +46,7 @@ interface AppKeybindings {
 	"app.tree.foldOrUp": true;
 	"app.tree.unfoldOrDown": true;
 	"app.plan.toggle": true;
+	"app.orchestrator.toggle": true;
 	"app.history.search": true;
 	"app.stt.toggle": true;
 }
@@ -180,6 +181,11 @@ export const KEYBINDINGS = {
 	"app.plan.toggle": {
 		defaultKeys: "alt+shift+p",
 		description: "Toggle plan mode",
+	},
+	"app.orchestrator.toggle": {
+		// Ctrl+M maps to carriage return/Enter in terminals.
+		defaultKeys: "alt+m",
+		description: "Toggle orchestrator mode",
 	},
 	"app.history.search": {
 		defaultKeys: "ctrl+r",

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -333,7 +333,6 @@ export const SETTINGS_SCHEMA = {
 			submenu: true,
 		},
 	},
-
 	"statusLine.showHookStatus": {
 		type: "boolean",
 		default: true,
@@ -1498,13 +1497,13 @@ export const SETTINGS_SCHEMA = {
 	// Delegation
 	"task.isolation.mode": {
 		type: "enum",
-		values: ["none", "worktree", "fuse-overlay", "fuse-projfs"] as const,
+		values: ["none", "worktree", "reflink", "fuse-projfs"] as const,
 		default: "none",
 		ui: {
 			tab: "tasks",
 			label: "Isolation Mode",
 			description:
-				"Isolation mode for subagents (none, git worktree, fuse-overlayfs on Unix, or ProjFS on Windows via fuse-projfs; unsupported modes fall back to worktree)",
+				"Isolation mode for subagents (none, git worktree, reflink snapshot via cp --reflink on Unix, or ProjFS on Windows via fuse-projfs; unsupported modes fall back to worktree)",
 			submenu: true,
 		},
 	},
@@ -1520,7 +1519,6 @@ export const SETTINGS_SCHEMA = {
 			submenu: true,
 		},
 	},
-
 	"task.isolation.commits": {
 		type: "enum",
 		values: ["generic", "ai"] as const,
@@ -1532,7 +1530,6 @@ export const SETTINGS_SCHEMA = {
 			submenu: true,
 		},
 	},
-
 	"task.eager": {
 		type: "boolean",
 		default: false,
@@ -1542,7 +1539,6 @@ export const SETTINGS_SCHEMA = {
 			description: "Encourage the agent to delegate work to subagents unless changes are trivial",
 		},
 	},
-
 	"task.simple": {
 		type: "enum",
 		values: TASK_SIMPLE_MODES,
@@ -1554,7 +1550,6 @@ export const SETTINGS_SCHEMA = {
 			submenu: true,
 		},
 	},
-
 	"task.maxConcurrency": {
 		type: "number",
 		default: 32,

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1156,6 +1156,17 @@ export const SETTINGS_SCHEMA = {
 	// Tools
 	// ────────────────────────────────────────────────────────────────────────
 
+	// Git checkpoint tool
+	"tools.gitCommitCheckpoint.enabled": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tools",
+			label: "Git Checkpoint",
+			description: "Expose `git_commit_checkpoint` so the agent can land WIP checkpoints for every dirty repo",
+		},
+	},
+
 	// Todo tool
 	"todo.enabled": {
 		type: "boolean",

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1423,12 +1423,12 @@ export const SETTINGS_SCHEMA = {
 
 	"async.pollWaitDuration": {
 		type: "enum",
-		values: ["5s", "10s", "30s", "1m", "5m"] as const,
-		default: "30s",
+		values: ["5s", "10s", "30s", "1m", "5m", "4m30s"] as const,
+		default: "4m30s",
 		ui: {
 			tab: "tools",
 			label: "Poll Wait Duration",
-			description: "How long the poll tool waits for background job updates before returning the current state",
+			description: "How long the job tool waits for background job updates before returning the current state",
 			submenu: true,
 		},
 	},

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -169,6 +169,14 @@ export class Settings {
 	}
 
 	/**
+	 * Load a standalone settings instance without mutating the global singleton.
+	 */
+	static async load(options: SettingsOptions = {}): Promise<Settings> {
+		const instance = new Settings(options);
+		return instance.#load();
+	}
+
+	/**
 	 * Create an isolated instance for testing.
 	 * Does not affect the global singleton.
 	 */
@@ -530,6 +538,11 @@ export class Settings {
 				isolationObj.mode = isolationObj.enabled ? "worktree" : "none";
 			}
 			delete isolationObj.enabled;
+		}
+		// task.isolation.mode: fuse-overlay -> reflink (replaced CoW-over-live-repo
+		// with point-in-time snapshot via cp --reflink).
+		if (isolationObj && isolationObj.mode === "fuse-overlay") {
+			isolationObj.mode = "reflink";
 		}
 
 		return raw;

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -187,9 +187,9 @@ const OPTION_PROVIDERS: Partial<Record<SettingPath, OptionProvider>> = {
 		{ value: "none", label: "None", description: "No isolation" },
 		{ value: "worktree", label: "Worktree", description: "Git worktree isolation" },
 		{
-			value: "fuse-overlay",
-			label: "Fuse Overlay",
-			description: "COW overlay via fuse-overlayfs (Unix only)",
+			value: "reflink",
+			label: "Reflink Snapshot",
+			description: "Point-in-time snapshot via cp --reflink (Unix only)",
 		},
 		{
 			value: "fuse-projfs",

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -38,8 +38,10 @@ function normalizePremiumRequests(value: number): number {
 
 const piSegment: StatusLineSegment = {
 	id: "pi",
-	render(_ctx) {
-		const content = theme.icon.pi ? `${theme.icon.pi} ` : "";
+	render(ctx) {
+		const marker = ctx.session.orchestratorMode ? "∈" : "";
+		const markerPrefix = marker && theme.icon.pi ? `${marker}\u2009` : marker;
+		const content = theme.icon.pi ? `${markerPrefix}${theme.icon.pi} ` : marker ? `${marker} ` : "";
 		return { content: theme.fg("accent", content), visible: true };
 	},
 };

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -29,7 +29,13 @@ import {
 	renderJsonTreeLines,
 } from "../../tools/json-tree";
 import { PYTHON_DEFAULT_PREVIEW_LINES } from "../../tools/python";
-import { formatExpandHint, replaceTabs, resolveImageOptions, truncateToWidth } from "../../tools/render-utils";
+import {
+	formatExpandHint,
+	replaceTabs,
+	resolveImageOptions,
+	shortenPath,
+	truncateToWidth,
+} from "../../tools/render-utils";
 import { toolRenderers } from "../../tools/renderers";
 import { renderStatusLine } from "../../tui";
 import { convertToPng } from "../../utils/image-convert";
@@ -336,7 +342,8 @@ export class ToolExecutionComponent extends Container {
 		const isBackgroundAsyncTask =
 			this.#toolName === "task" &&
 			(this.#result?.details as { async?: { state?: string } } | undefined)?.async?.state === "running";
-		const isPartialTask = this.#isPartial && this.#toolName === "task" && !isBackgroundAsyncTask;
+		const isPartialTask =
+			this.#isPartial && (this.#toolName === "task" || this.#toolName === "poll") && !isBackgroundAsyncTask;
 		const needsSpinner = isStreamingArgs || isPartialTask;
 		if (needsSpinner && !this.#spinnerInterval) {
 			this.#spinnerInterval = setInterval(() => {
@@ -719,10 +726,62 @@ export class ToolExecutionComponent extends Container {
 		return output;
 	}
 
+	#formatGitCommitCheckpointExecution(): string {
+		const lines: string[] = [];
+		const icon = this.#isPartial ? "pending" : this.#result?.isError ? "error" : "success";
+		const argsObject =
+			this.#args && typeof this.#args === "object" ? (this.#args as Record<string, unknown>) : undefined;
+		const reason = typeof argsObject?.reason === "string" ? argsObject.reason : "checkpoint";
+		lines.push(renderStatusLine({ icon, title: "Git Checkpoint", description: reason }, theme));
+		if (!this.#result) {
+			return lines.join("\n");
+		}
+		const details =
+			this.#result.details && typeof this.#result.details === "object" && !Array.isArray(this.#result.details)
+				? (this.#result.details as Record<string, unknown>)
+				: undefined;
+		const repos = Array.isArray(details?.repos) ? (details?.repos as Array<Record<string, unknown>>) : [];
+		if (repos.length === 0) {
+			lines.push(theme.fg("dim", "all repos clean"));
+			return lines.join("\n");
+		}
+		for (const entry of repos) {
+			const repoPath = typeof entry.repoPath === "string" ? shortenPath(entry.repoPath) : "(unknown)";
+			const status = typeof entry.status === "string" ? entry.status : "unknown";
+			if (status === "committed") {
+				const sha = typeof entry.sha === "string" ? entry.sha : "unknown";
+				const filesChanged = typeof entry.filesChanged === "number" ? entry.filesChanged : 0;
+				const subject = typeof entry.message === "string" ? entry.message.trim().split("\n")[0] : "";
+				const suffix = subject ? ` — ${subject}` : "";
+				lines.push(
+					theme.fg(
+						"toolOutput",
+						truncateToWidth(
+							replaceTabs(`${repoPath}: ${sha} (${filesChanged} file${filesChanged === 1 ? "" : "s"})${suffix}`),
+							80,
+						),
+					),
+				);
+			} else if (status === "skipped") {
+				const skippedReason = typeof entry.reason === "string" ? entry.reason : "no-changes";
+				lines.push(theme.fg("dim", `${repoPath}: skipped (${skippedReason})`));
+			} else {
+				const errorMessage = typeof entry.error === "string" ? entry.error : "unknown error";
+				lines.push(
+					theme.fg("toolOutput", truncateToWidth(replaceTabs(`${repoPath}: failed — ${errorMessage}`), 80)),
+				);
+			}
+		}
+		return lines.join("\n");
+	}
+
 	/**
 	 * Format a generic tool execution (fallback for tools without custom renderers)
 	 */
 	#formatToolExecution(): string {
+		if (this.#toolName === "git_commit_checkpoint") {
+			return this.#formatGitCommitCheckpointExecution();
+		}
 		const lines: string[] = [];
 		const icon = this.#isPartial ? "pending" : this.#result?.isError ? "error" : "success";
 		lines.push(renderStatusLine({ icon, title: this.#toolLabel }, theme));

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -343,7 +343,7 @@ export class ToolExecutionComponent extends Container {
 			this.#toolName === "task" &&
 			(this.#result?.details as { async?: { state?: string } } | undefined)?.async?.state === "running";
 		const isPartialTask =
-			this.#isPartial && (this.#toolName === "task" || this.#toolName === "poll") && !isBackgroundAsyncTask;
+			this.#isPartial && (this.#toolName === "task" || this.#toolName === "job") && !isBackgroundAsyncTask;
 		const needsSpinner = isStreamingArgs || isPartialTask;
 		if (needsSpinner && !this.#spinnerInterval) {
 			this.#spinnerInterval = setInterval(() => {

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -156,6 +156,11 @@ export class InputController {
 		for (const key of this.ctx.keybindings.getKeys("app.stt.toggle")) {
 			this.ctx.editor.setCustomKeyHandler(key, () => void this.ctx.handleSTTToggle());
 		}
+		for (const key of this.ctx.keybindings.getKeys(
+			"app.orchestrator.toggle" as Parameters<InteractiveModeContext["keybindings"]["getKeys"]>[0],
+		)) {
+			this.ctx.editor.setCustomKeyHandler(key, () => void this.ctx.handleOrchestratorToggle());
+		}
 		for (const key of this.ctx.keybindings.getKeys("app.clipboard.copyLine")) {
 			this.ctx.editor.setCustomKeyHandler(key, () => this.handleCopyCurrentLine());
 		}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -735,6 +735,9 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.#planModeHasEntered = true;
 			this.#updatePlanModeStatus();
 		}
+		if (sessionContext.orchestratorMode) {
+			await this.session.setOrchestratorMode(true);
+		}
 	}
 
 	async #enterPlanMode(options?: { planFilePath?: string; workflow?: "parallel" | "iterative" }): Promise<void> {
@@ -1357,6 +1360,21 @@ export class InteractiveMode implements InteractiveModeContext {
 		return this.#commandController.handleMemoryCommand(text);
 	}
 
+	async handleOrchestratorToggle(): Promise<void> {
+		const shouldEnable = !this.session.orchestratorMode;
+		try {
+			const enabled = await this.session.toggleOrchestratorMode();
+			this.statusLine.invalidate();
+			this.updateEditorTopBorder();
+			this.ui.requestRender();
+			this.showStatus(`Orchestrator mode ${enabled ? "enabled" : "disabled"}.`);
+		} catch (error) {
+			if (!shouldEnable) throw error;
+			this.showStatus(
+				`Orchestrator mode failed to enable: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	}
 	async handleSTTToggle(): Promise<void> {
 		if (!settings.get("stt.enabled")) {
 			this.showWarning("Speech-to-text is disabled. Enable it in settings: stt.enabled");

--- a/packages/coding-agent/src/modes/session-observer-registry.ts
+++ b/packages/coding-agent/src/modes/session-observer-registry.ts
@@ -55,7 +55,7 @@ export class SessionObserverRegistry {
 		sessions.sort((a, b) => {
 			if (a.kind === "main") return -1;
 			if (b.kind === "main") return 1;
-			return a.lastUpdate - b.lastUpdate;
+			return b.lastUpdate - a.lastUpdate;
 		});
 		return sessions;
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -192,6 +192,7 @@ export interface InteractiveModeContext {
 	handleMoveCommand(targetPath: string): Promise<void>;
 	handleRenameCommand(title: string): Promise<void>;
 	handleMemoryCommand(text: string): Promise<void>;
+	handleOrchestratorToggle(): Promise<void>;
 	handleSTTToggle(): Promise<void>;
 	executeCompaction(customInstructionsOrOptions?: string | CompactOptions, isAuto?: boolean): Promise<void>;
 	openInBrowser(urlOrPath: string): void;

--- a/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
+++ b/packages/coding-agent/src/modes/utils/hotkeys-markdown.ts
@@ -43,6 +43,7 @@ export function buildHotkeysMarkdown(bindings: HotkeysMarkdownBindings): string 
 		`| \`${appKey(bindings, "app.model.selectTemporary")}\` | Select model (temporary) |`,
 		`| \`${appKey(bindings, "app.model.select")}\` | Select model (set roles) |`,
 		`| \`${appKey(bindings, "app.plan.toggle")}\` | Toggle plan mode |`,
+		`| \`${appKey(bindings, "app.orchestrator.toggle")}\` | Toggle orchestrator mode |`,
 		`| \`${appKey(bindings, "app.history.search")}\` | Search prompt history |`,
 		`| \`${appKey(bindings, "app.tools.expand")}\` | Toggle tool output expansion |`,
 		`| \`${appKey(bindings, "app.thinking.toggle")}\` | Toggle thinking block visibility |`,

--- a/packages/coding-agent/src/prompts/system/custom-system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/custom-system-prompt.md
@@ -63,6 +63,6 @@ Current date: {{date}}
 Current working directory: {{cwd}}
 {{#if secretsEnabled}}
 <redacted-content>
-Some values in tool output are redacted for security. They appear as `#XXXX#` tokens (4 uppercase-alphanumeric characters wrapped in `#`). These are **not errors** — they are intentional placeholders for sensitive values (API keys, passwords, tokens). Treat them as opaque strings. Do not attempt to decode, fix, or report them as problems.
+Some values in tool output are redacted for security. They appear as `#XXXX#` tokens (4 uppercase-alphanumeric characters wrapped in `#`). These are **not errors** — they are intentional placeholders for sensitive values (API keys, passwords, tokens). Treat each token as an opaque stand-in for the original value. When a tool call needs that value, copy the `#XXXX#` token verbatim into the tool arguments; do not invent, decode, rename, expand, or replace it. Tool execution restores the original secret automatically.
 </redacted-content>
 {{/if}}

--- a/packages/coding-agent/src/prompts/system/handoff-document.md
+++ b/packages/coding-agent/src/prompts/system/handoff-document.md
@@ -1,15 +1,10 @@
-<critical>
-Write a comprehensive handoff document for another instance of yourself.
-The handoff **MUST** be sufficient for seamless continuation without access to this conversation.
-Output ONLY the handoff document. No preamble, no commentary, no wrapper text.
-</critical>
+<system-reminder>
+The conversation above is complete context. Do not re-read files, run tools, or restate progress — write the handoff document now.
 
-<instruction>
-Capture exact technical state, not abstractions.
-Include concrete file paths, symbol names, commands run, test results, observed failures, decisions made, and any partial work that materially affects the next step.
-</instruction>
+Write a comprehensive handoff document for another instance of yourself. The handoff **MUST** be sufficient for seamless continuation without access to this conversation. Output ONLY the handoff document. No preamble, no commentary, no wrapper text, no tool calls.
 
-<output>
+Capture exact technical state, not abstractions. Include concrete file paths, symbol names, commands run, test results, observed failures, decisions made, and any partial work that materially affects the next step.
+
 Use exactly this structure:
 
 ## Goal
@@ -35,12 +30,21 @@ Use exactly this structure:
 - [Code snippets, file paths, function/type names, error messages, or data essential to continue]
 - [Repository state if relevant]
 
+## Summary
+[Omit section if both subsections are empty.]
+
+### Prior sessions
+[Omit if no `<handoff-context>` was provided.]
+Compress the previous summary into fewer, higher-level lines. Merge related entries. Drop entries no longer relevant. Retain key attempts, conclusions, and dead ends that prevent loops. Details belong in other sections — this tracks trajectory only.
+Format: flat bullet list, one terse line per entry.
+
+### This session
+Add entries for approaches taken, angles explored, and conclusions reached that other sections don't capture. Avoid repeating file paths or details already in Progress or Critical Context.
+Format: flat bullet list, one terse line per entry.
+
 ## Next Steps
 1. [What should happen next]
-</output>
-
 {{#if additionalFocus}}
-<instruction>
 Additional focus: {{additionalFocus}}
-</instruction>
 {{/if}}
+</system-reminder>

--- a/packages/coding-agent/src/prompts/system/subagent-system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/subagent-system-prompt.md
@@ -5,9 +5,11 @@
 
 {{SECTION_SEPARATOR "Job"}}
 You are operating on a delegated sub-task.
+You **MUST NOT** deploy, release, or publish applications, packages, or artifacts (no `npm publish`, no `cargo publish`, no `docker push`, no `kubectl apply`, no deploy scripts, no CI triggers). The main session owns commits, pushes, and deploys.
 {{#if worktree}}
 You are working in an isolated working tree at `{{worktree}}` for this sub-task.
 You **MUST NOT** modify files outside this tree or in the original repository.
+You **MUST NOT** run `git commit`, `git push`, `git checkout`, or any git command that mutates history. Your edits are captured and merged automatically by the main session.
 {{/if}}
 
 {{#if contextFile}}
@@ -21,6 +23,14 @@ You can reach other live agents via the `irc` tool. Your id is `{{ircSelfId}}`. 
 
 Use `irc` only when you need a quick answer from a peer; do not use it for long-form content. Address peers by id or use `"all"` to broadcast.
 {{/if}}
+
+{{SECTION_SEPARATOR "Finished Product"}}
+Your deliverable **MUST** be ready to ship as-is. Before calling `yield`:
+- Format every file you edited with the project's formatter, scoped to those files.
+- Run the tests that cover what you changed (the test files you added or touched, plus any obviously related existing tests). They **MUST** pass.
+- If you changed behavior that warrants a test and no test exists, write one. "No test was requested" is not an excuse for shipping untested behavior changes.
+- You **MUST NOT** run project-wide build/test/lint; scope commands to the files you edited.
+- If a scoped test or format step fails and you cannot fix it within the assignment, report the exact failure via `result.error`. Do not yield a "done" result over broken output.
 
 {{SECTION_SEPARATOR "Closure"}}
 No TODO tracking, no progress updates. Execute, call `yield`, done.

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -226,6 +226,67 @@ Delegate work to subagents by default. Work alone only when:
 For multi-file changes, refactors, new features, tests, or investigations, break the work into tasks and delegate after the design is settled.
 </eager-tasks>
 {{/if}}
+{{#if orchestratorMode}}
+<orchestrator-mode>
+Top-level session is in task orchestrator mode. Your primary job is **decompose, delegate, integrate** — not to write code yourself.
+
+<direct-edit-allowlist>
+Direct editing is **FORBIDDEN** except in these closed cases. If a change does not literally match one of these, you **MUST** delegate to `task`:
+1. **User-dictated literal replacement.** The user pasted or quoted the exact before/after text. You apply it verbatim. No reading a file first, no grep, no reasoning about callers.
+2. **Single-line mechanical tweak the user named by location.** Config value bump, typo, rename the user spelled out in the current message. Single line, one file, zero investigation.
+3. **Post-task integration fixes you can see in the task's own output.** Resolving a merge marker the task summary showed, applying a formatter the task forgot. Bounded by what the task report contains.
+
+Everything else — bug fixes, UI tweaks, "just change this one thing", refactors, any change that requires reading a file to understand what to edit — is delegation work. "It's only a few lines" is the exact rationalization this mode exists to block.
+</direct-edit-allowlist>
+
+<mandatory-delegation-triggers>
+You **MUST** delegate when any of these are true. There is no size threshold that exempts you:
+- You are about to run `grep`, `find`, `ast_grep`, `lsp`, or `read` on a source file to figure out what to change. Investigation itself is the task — send an `explore` or `task` agent.
+- The user described a symptom or desired outcome without naming the exact code to change ("live text shows when live is selected", "icons too big", "slug missing dash"). Locating the fix is investigation; delegate.
+- Any `ast_edit`, `edit`, or `write` that isn't covered by the allowlist above.
+- Any test write or modification.
+- More than one file is in scope.
+- You already did one direct edit in this user turn and another change is needed. Two sequential direct edits in orchestrator mode is a pathological pattern — stop and delegate the rest as a batch.
+</mandatory-delegation-triggers>
+
+<anti-patterns>
+Recognize and refuse these patterns. Each one is an automatic delegation trigger:
+- `grep` → `read` → `ast_edit`: you investigated to find the change site. That whole chain is one `task`, not three direct tool calls.
+- `read` → edit → `read` another file → edit again: you are doing a multi-file change inline. Stop and batch the remaining edits into parallel tasks.
+- "Let me just quickly…": there is no "quickly" in orchestrator mode. Quick = delegate. Quick tasks finish fast in parallel.
+- Acknowledging a small follow-up ("ok one more thing…") and editing inline instead of delegating. Follow-ups compound; each inline edit primes the next.
+</anti-patterns>
+
+<your-job>
+- Decompose the user's request into independent deliverables. Batch them into one `task` call with multiple subtasks wherever possible — each subtask cherry-picks its own commit, so more subtasks = more parallelism.
+- Write explicit Target / Change / Edge Cases / Acceptance into every assignment. Vague assignments produce vague results you will re-delegate.
+- Integrate: after tasks merge, report what changed using the branches and commit hashes from the task summary. Do not re-inspect the tree manually unless reconciling a failure.
+- Plan at the architectural level; the mechanical edits are never your job while this mode is active.
+</your-job>
+
+<parallel-by-default>
+A single-task `task` call is the exception, not the default. Before issuing one, justify in your own reasoning why the work cannot split into 2+ independent subtasks. "It's one feature" is not a reason — one feature almost always decomposes into independent file-scoped pieces (types vs. consumers, module A vs. module B, implementation vs. tests, root repo vs. nested repo, frontend vs. backend). Default to fanning out.
+
+Concrete forcing function: every time you reach for `task`, list the affected files/modules first. If that list has ≥2 items and the items don't share a write-target, they are parallel subtasks in the **same** `task` call — not sequential calls, not one giant subtask. Sequential `task` calls for work that could have been one parallel batch is the pathological pattern; it doubles wall-clock time and wastes the isolation infrastructure.
+
+Safe-to-parallelize signals: different files, different packages, different directories, different concerns (types/impl/tests), independent bug fixes, independent reviews, independent investigations. When in doubt, split — merge conflicts are handled automatically and a misfire costs less than a serialized batch.
+</parallel-by-default>
+
+{{#has tools "git_commit_checkpoint"}}
+<checkpoints>
+- Call `git_commit_checkpoint` at the end of every scope boundary: after a direct-edit batch (rare) or before yielding to the user. One call per scope. The `task` tool auto-commits dirty state before dispatching isolated tasks, so do not checkpoint pre-task.
+- Commits from `git_commit_checkpoint` are unsigned WIP; the user coalesces them. Do not use `bash git commit` when `git_commit_checkpoint` is available.
+</checkpoints>
+{{/has}}
+
+<isolation-and-merges>
+- Edit-capable task agents run isolated with branch-based integration automatically; read-only agents stay non-isolated. The `isolated` argument is not accepted here — isolation is inferred from the agent's tool access.
+- If an isolated task merge fails, its branch (`omp/task/<taskId>`) is preserved verbatim. Reconcile by delegating a focused follow-up `task` or cherry-picking via `bash`. There is no automatic recovery.
+- Each task **MUST** deliver a finished product: its own changes formatted, any scoped tests it touched passing. You **MUST NOT** absorb post-hoc cleanup. If a task returns unformatted code or failing tests, re-delegate — do not patch it yourself.
+- Re-delegation is the first fallback. Only after the **same scope** fails delegation **twice** with clear misunderstanding may you edit directly, and you **MUST** state the reason ("task N returned wrong shape twice, editing directly"). This escape hatch is per-scope; next scope returns to delegation defaults.
+</isolation-and-merges>
+</orchestrator-mode>
+{{/if}}
 
 {{#has tools "ssh"}}
 ### SSH
@@ -326,7 +387,7 @@ These are inviolable.
 
 {{#if secretsEnabled}}
 <redacted-content>
-Some values in tool output are intentionally redacted as `#XXXX#` tokens. Treat them as opaque strings.
+Some values in tool output are intentionally redacted as `#XXXX#` tokens. Treat each token as an opaque stand-in for the original value. When a tool call needs that value, copy the `#XXXX#` token verbatim into the tool arguments; do not invent, decode, rename, expand, or replace it. Tool execution restores the original secret automatically.
 </redacted-content>
 {{/if}}
 

--- a/packages/coding-agent/src/prompts/tools/git-commit-checkpoint.md
+++ b/packages/coding-agent/src/prompts/tools/git-commit-checkpoint.md
@@ -1,0 +1,28 @@
+Commit outstanding work in the current project as a WIP checkpoint.
+
+<when>
+Call this at the end of a scope boundary — after a focused batch of direct edits, after a `task` batch returns with changes, or before yielding back to the user. The goal is to stop carrying uncommitted state across unrelated pieces of work.
+
+Typical triggers:
+- You finished a small mechanical change yourself and are about to move on to a different concern.
+- A `task` batch merged and your working tree now has subagent commits plus your own uncommitted touches.
+- The `task` tool already commits dirty state automatically before dispatching an isolated task. You do not need to checkpoint manually before `task` calls.
+</when>
+
+<behavior>
+- Discovers every dirty repo under the project root (including nested repos) and commits each one separately with the project's agentic commit pipeline in silent mode.
+- Stages all tracked + untracked changes before generating each commit message.
+- Discovery aborts before staging if it encounters a nested repository with the same `remote.origin.url` as the project root or crosses a filesystem boundary under the project root.
+- Commits are unsigned WIP checkpoints — the user coalesces them later via `/commit` or `omp commit`.
+- Clean repos are skipped silently. If every repo is clean the call returns `status: "clean"` without doing anything.
+- Errors committing one repo do not prevent the others from being committed; per-repo errors are reported in the result.
+</behavior>
+
+<parameters>
+- `reason` (required): brief label for what scope is closing, e.g. `"after login refactor"`, `"end of scope"`. Used only for agent bookkeeping and surfaced in the transcript — it is not written into the commit message itself.
+</parameters>
+
+<avoid>
+- Do not call this after every single edit — coalesce related edits into one scope, then checkpoint.
+- Do not use this to publish work. It is a local WIP checkpoint, not a release commit.
+</avoid>

--- a/packages/coding-agent/src/prompts/tools/task-summary.md
+++ b/packages/coding-agent/src/prompts/tools/task-summary.md
@@ -4,7 +4,9 @@
 {{#each summaries}}
 <agent id="{{id}}" agent="{{agent}}">
 <status>{{status}}</status>
-{{#if meta}}<meta lines="{{meta.lineCount}}" size="{{meta.charSize}}" />{{/if}}
+{{#if branch}}<branch>{{branch}}</branch>
+{{/if}}{{#if errorDetail}}<error>{{errorDetail}}</error>
+{{/if}}{{#if meta}}<meta lines="{{meta.lineCount}}" size="{{meta.charSize}}" />{{/if}}
 {{#if truncated}}
 <preview full-path="agent://{{id}}">
 {{preview}}

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -33,8 +33,13 @@ Subagents lack your conversation history. Every decision, file content, and user
 - `schema`: JSON-encoded JTD schema for expected output. Format lives here — **MUST NOT** be duplicated in assignments.
 {{/if}}
 - `tasks`: Tasks to execute in parallel.
+- `timeout`: Maximum seconds per subtask. Aborts subtasks exceeding the limit; completed results are still returned.
 {{#if isolationEnabled}}
+{{#if branchMode}}
+- `isolated`: Run in isolated environment. Each task auto-commits its changes to a dedicated `omp/task/<id>` branch and the branch is cherry-picked onto the current branch as soon as that task finishes — you never need to stage, commit, or push yourself. A task whose branch fails to merge is reported with status `merge failed` and its `omp/task/<id>` branch is preserved in the repository for manual reconciliation.
+{{else}}
 - `isolated`: Run in isolated environment; returns patches. Use when tasks edit overlapping files.
+{{/if}}
 {{/if}}
 </parameters>
 
@@ -44,9 +49,11 @@ Subagents lack your conversation history. Every decision, file content, and user
 {{else}}
 - Every `assignment` must repeat any constraints, reference paths, and acceptance criteria it needs — there is no shared `context` field.
 {{/if}}
-- **MUST NOT** tell tasks to run project-wide build/test/lint. Parallel agents share the working tree; each task edits, stops. Caller verifies after all complete.
+- **MUST NOT** tell tasks to run project-wide build/test/lint (e.g. full-repo `bun check:ts`, `bun test`, `biome check .`). Project-wide verification is the caller's job after all tasks complete.
+- **MUST** require each task to format its own edits and run scoped tests covering its own changes before calling `submit_result`. A task that yields unformatted code, failing scoped tests, or missing tests for behavior it changed has not delivered a finished product. Name the exact scoped verification commands in each assignment's `## Acceptance` (e.g. `bun fmt:ts packages/foo/src/bar.ts`, `bun test packages/foo/test/bar.test.ts`).
 - For large payloads (traces, JSON blobs), write to `local://<path>` and pass the path in {{#if contextEnabled}}`context`{{else}}the relevant `assignment`{{/if}}.
-- Prefer `task` agents that investigate **and** edit in one pass. Launch a dedicated read-only discovery step only when affected files are genuinely unknown.
+- **MUST NOT** instruct tasks to handle uncommitted changes, stash, or commit. The orchestrator captures and replicates working-tree state automatically — subagents see the correct baseline without intervention.
+- Prefer `task` agents that investigate **and** edit in one pass. Only launch a dedicated read-only discovery step when the affected files are genuinely unknown and cannot be inferred from the task description.
 </critical>
 
 <scope>

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -388,6 +388,7 @@ export interface BuildSystemPromptOptions {
 	cwd?: string;
 	appendPrompt?: string;
 	repeatToolDescriptions?: boolean;
+	orchestratorMode?: boolean;
 }
 
 /**
@@ -400,6 +401,8 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		contextFiles: options.contextFiles,
 		appendSystemPrompt: options.appendPrompt,
 		repeatToolDescriptions: options.repeatToolDescriptions,
+		orchestratorMode: options.orchestratorMode,
+		tools: options.tools ? new Map(options.tools.map(tool => [tool.name, tool])) : undefined,
 	});
 }
 
@@ -775,6 +778,16 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	}
 
 	const taskDepth = options.taskDepth ?? 0;
+	const initialOrchestratorMode = false;
+	const requestedToolNamesForSession = options.toolNames
+		? [
+				...new Set(
+					initialOrchestratorMode
+						? ["task", ...options.toolNames.map(name => name.toLowerCase())]
+						: options.toolNames.map(name => name.toLowerCase()),
+				),
+			]
+		: undefined;
 
 	let thinkingLevel = options.thinkingLevel;
 
@@ -916,15 +929,16 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			if (model) return formatModelString(model);
 			return undefined;
 		};
+		let toolRegistry: Map<string, Tool> | undefined;
 		const toolSession: ToolSession = {
 			cwd,
 			hasUI: options.hasUI ?? false,
 			enableLsp,
 			get hasEditTool() {
-				const requestedToolNames = options.toolNames
-					? [...new Set(options.toolNames.map(name => name.toLowerCase()))]
-					: undefined;
-				return !requestedToolNames || requestedToolNames.includes("edit");
+				return !requestedToolNamesForSession || requestedToolNamesForSession.includes("edit");
+			},
+			get orchestratorMode() {
+				return session?.orchestratorMode ?? initialOrchestratorMode;
 			},
 			skipPythonPreflight: options.skipPythonPreflight,
 			forcePythonWarmup: options.forcePythonWarmup,
@@ -1022,7 +1036,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		);
 
 		// Create built-in tools (already wrapped with meta notice formatting)
-		const builtinTools = await logger.time("createAllTools", createTools, toolSession, options.toolNames);
+		const builtinTools = await logger.time("createAllTools", createTools, toolSession, requestedToolNamesForSession);
 
 		// Discover MCP tools from .mcp.json files
 		let mcpManager: MCPManager | undefined = options.mcpManager;
@@ -1258,7 +1272,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		}
 
 		// All built-in tools are active (conditional tools like git/ask return null from factory if disabled)
-		const toolRegistry = new Map<string, Tool>();
+		toolRegistry = new Map<string, Tool>();
 		for (const tool of builtinTools) {
 			toolRegistry.set(tool.name, tool);
 		}
@@ -1272,6 +1286,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		}
 		if (model?.provider === "cursor") {
 			toolRegistry.delete("edit");
+		}
+		if (initialOrchestratorMode && !toolRegistry.has("task")) {
+			throw new Error("orchestrator mode requires the task tool to remain available.");
 		}
 
 		const hasDeferrableTools = Array.from(toolRegistry.values()).some(tool => tool.deferrable === true);
@@ -1305,6 +1322,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				search_tool_bm25: { description: renderSearchToolBm25Description(discoverableMCPTools) },
 			});
 			const memoryInstructions = await buildMemoryToolDeveloperInstructions(agentDir, settings);
+			const orchestratorMode = session?.orchestratorMode ?? initialOrchestratorMode;
 
 			// Build combined append prompt: memory instructions + MCP server instructions
 			const serverInstructions = mcpManager?.getServerInstructions();
@@ -1340,6 +1358,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				mcpDiscoveryMode: hasDiscoverableMCPTools,
 				mcpDiscoveryServerSummaries: discoverableMCPSummary.servers.map(formatDiscoverableMCPToolServerSummary),
 				eagerTasks,
+				orchestratorMode,
 				secretsEnabled,
 			});
 
@@ -1363,6 +1382,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					mcpDiscoveryMode: hasDiscoverableMCPTools,
 					mcpDiscoveryServerSummaries: discoverableMCPSummary.servers.map(formatDiscoverableMCPToolServerSummary),
 					eagerTasks,
+					orchestratorMode,
 					secretsEnabled,
 				});
 			}
@@ -1370,9 +1390,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		};
 
 		const toolNamesFromRegistry = Array.from(toolRegistry.keys());
-		const requestedToolNames =
-			(options.toolNames ? [...new Set(options.toolNames.map(name => name.toLowerCase()))] : undefined) ??
-			toolNamesFromRegistry;
+		const requestedToolNames = requestedToolNamesForSession ?? toolNamesFromRegistry;
 		const normalizedRequested = requestedToolNames.filter(name => toolRegistry.has(name));
 		const includeExitPlanMode = requestedToolNames.includes("exit_plan_mode");
 		const mcpDiscoveryEnabled = settings.get("mcp.discoveryMode") ?? false;
@@ -1382,10 +1400,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		const requestedActiveToolNames = includeExitPlanMode
 			? normalizedRequested
 			: normalizedRequested.filter(name => name !== "exit_plan_mode");
-		const initialRequestedActiveToolNames = options.toolNames
+		const initialRequestedActiveToolNames = requestedToolNamesForSession
 			? requestedActiveToolNames
 			: requestedActiveToolNames.filter(name => !defaultInactiveToolNames.has(name));
-		const explicitlyRequestedMCPToolNames = options.toolNames
+		const explicitlyRequestedMCPToolNames = requestedToolNamesForSession
 			? requestedActiveToolNames.filter(name => name.startsWith("mcp_"))
 			: [];
 		const discoveryDefaultServers = new Set(
@@ -1593,6 +1611,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			onPayload,
 			convertToLlm: convertToLlmFinal,
 			rebuildSystemPrompt,
+			orchestratorMode: initialOrchestratorMode,
 			mcpDiscoveryEnabled,
 			initialSelectedMCPToolNames,
 			defaultSelectedMCPToolNames,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -760,12 +760,13 @@ export class AgentSession {
 			}
 		}
 
+		const persistedMessage = event.type === "message_end" ? event.message : undefined;
+		let displayEvent: AgentSessionEvent = event;
 		// Deobfuscate assistant message content for display emission — the LLM echoes back
 		// obfuscated placeholders, but listeners (TUI, extensions, exporters) must see real
 		// values. The original event.message stays obfuscated so the persistence path below
 		// writes `#HASH#` tokens to the session file; convertToLlm re-obfuscates outbound
 		// traffic on the next turn. Walks text, thinking, and toolCall arguments/intent.
-		let displayEvent: AgentEvent = event;
 		const obfuscator = this.#obfuscator;
 		if (obfuscator && event.type === "message_end" && event.message.role === "assistant") {
 			const message = event.message;
@@ -774,7 +775,6 @@ export class AgentSession {
 				displayEvent = { ...event, message: { ...message, content: deobfuscatedContent } };
 			}
 		}
-
 		await this.#emitSessionEvent(displayEvent);
 
 		if (event.type === "turn_start") {
@@ -917,6 +917,7 @@ export class AgentSession {
 
 		// Handle session persistence
 		if (event.type === "message_end") {
+			const messageEndMessage = persistedMessage ?? event.message;
 			// Check if this is a hook/custom message
 			if (event.message.role === "hookMessage" || event.message.role === "custom") {
 				// Persist as CustomMessageEntry
@@ -931,14 +932,14 @@ export class AgentSession {
 					this.#markTtsrInjected(this.#extractTtsrRuleNames(event.message.details));
 				}
 			} else if (
-				event.message.role === "user" ||
-				event.message.role === "developer" ||
-				event.message.role === "assistant" ||
-				event.message.role === "toolResult" ||
-				event.message.role === "fileMention"
+				messageEndMessage.role === "user" ||
+				messageEndMessage.role === "developer" ||
+				messageEndMessage.role === "assistant" ||
+				messageEndMessage.role === "toolResult" ||
+				messageEndMessage.role === "fileMention"
 			) {
 				// Regular LLM message - persist as SessionMessageEntry
-				this.sessionManager.appendMessage(event.message);
+				this.sessionManager.appendMessage(messageEndMessage);
 			}
 			// Other message types (bashExecution, compactionSummary, branchSummary) are persisted elsewhere
 
@@ -978,8 +979,8 @@ export class AgentSession {
 				}
 			}
 
-			if (event.message.role === "toolResult") {
-				const { toolName, details, isError, content } = event.message as {
+			if (messageEndMessage.role === "toolResult") {
+				const { toolName, details, isError, content } = messageEndMessage as {
 					toolName?: string;
 					details?: { path?: string; phases?: TodoPhase[]; report?: string; startedAt?: string };
 					isError?: boolean;
@@ -4141,7 +4142,12 @@ export class AgentSession {
 			}
 			this.#promptInFlightCount++;
 			try {
-				this.agent.setSystemPrompt(this.#baseSystemPrompt);
+				// Do NOT reset the system prompt here: keeping whatever was active on the
+				// previous turn preserves the Anthropic system-block cache, so the handoff
+				// generation only pays for the appended override directive instead of
+				// rebilling the entire system prompt + tools. The handoff directive is
+				// wrapped in <system-reminder> inside the developer message so it remains
+				// authoritative even if a non-base system prompt is active (plan mode, etc.).
 				await this.#promptAgentWithIdleRetry([
 					{
 						role: "developer",
@@ -4177,6 +4183,8 @@ export class AgentSession {
 			// Inject the handoff document as a custom message
 			const handoffContent = `<handoff-context>\n${handoffText}\n</handoff-context>\n\nThe above is a handoff document from a previous session. Use this context to continue the work seamlessly.`;
 			this.sessionManager.appendCustomMessageEntry("handoff", handoffContent, true, undefined, "agent");
+			// Flush the new session to disk so the handoff survives a restart
+			await this.sessionManager.ensureOnDisk();
 			let savedPath: string | undefined;
 			if (options?.autoTriggered && this.settings.get("compaction.handoffSaveToDisk")) {
 				const artifactsDir = this.sessionManager.getArtifactsDir();
@@ -4861,6 +4869,7 @@ export class AgentSession {
 
 		let action: "context-full" | "handoff" =
 			compactionSettings.strategy === "handoff" && reason !== "overflow" ? "handoff" : "context-full";
+		await this.sessionManager.flush();
 		await this.#emitSessionEvent({ type: "auto_compaction_start", reason, action });
 		// Abort any older auto-compaction before installing this run's controller.
 		this.#autoCompactionAbortController?.abort();
@@ -5129,6 +5138,7 @@ export class AgentSession {
 			this.agent.replaceMessages(sessionContext.messages);
 			this.#syncTodoPhasesFromBranch();
 			this.#closeCodexProviderSessionsForHistoryRewrite();
+			await this.sessionManager.flush();
 
 			// Get the saved compaction entry for the hook
 			const savedCompactionEntry = newEntries.find(e => e.type === "compaction" && e.summary === summary) as

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -62,6 +62,7 @@ import {
 	setNativeKillTree,
 } from "@oh-my-pi/pi-utils";
 import type { AsyncJob, AsyncJobManager } from "../async";
+import { findRepoRoot } from "../capability/fs";
 import type { Rule } from "../capability/rule";
 import { MODEL_ROLE_IDS, type ModelRegistry } from "../config/model-registry";
 import {
@@ -246,6 +247,8 @@ export interface AgentSessionConfig {
 	convertToLlm?: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	/** System prompt builder that can consider tool availability */
 	rebuildSystemPrompt?: (toolNames: string[], tools: Map<string, AgentTool>) => Promise<string>;
+	/** Whether this top-level session is coordination-only and must delegate mutations. */
+	orchestratorMode?: boolean;
 	/** Enable hidden-by-default MCP tool discovery for this session. */
 	mcpDiscoveryEnabled?: boolean;
 	/** MCP tool names to activate for the current session when discovery mode is enabled. */
@@ -501,6 +504,8 @@ export class AgentSession {
 	#convertToLlm: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	#rebuildSystemPrompt: ((toolNames: string[], tools: Map<string, AgentTool>) => Promise<string>) | undefined;
 	#baseSystemPrompt: string;
+	#orchestratorMode = false;
+	#requestedActiveToolNames: string[] = [];
 	#mcpDiscoveryEnabled = false;
 	#discoverableMCPTools = new Map<string, DiscoverableMCPTool>();
 	#discoverableMCPSearchIndex: DiscoverableMCPSearchIndex | null = null;
@@ -587,6 +592,8 @@ export class AgentSession {
 		this.#convertToLlm = config.convertToLlm ?? convertToLlm;
 		this.#rebuildSystemPrompt = config.rebuildSystemPrompt;
 		this.#baseSystemPrompt = this.agent.state.systemPrompt;
+		this.#orchestratorMode = config.orchestratorMode === true;
+		this.#requestedActiveToolNames = this.agent.state.tools.map(tool => tool.name);
 		this.#mcpDiscoveryEnabled = config.mcpDiscoveryEnabled ?? false;
 		this.#setDiscoverableMCPTools(this.#collectDiscoverableMCPToolsFromRegistry());
 		this.#selectedMCPToolNames = new Set(config.initialSelectedMCPToolNames ?? []);
@@ -2023,6 +2030,27 @@ export class AgentSession {
 		this.sessionManager.appendMCPToolSelection(nextSelectedMCPToolNames);
 	}
 
+	#getRequestedActiveToolNames(): string[] {
+		return [...this.#requestedActiveToolNames];
+	}
+
+	#getRequestedActiveNonMCPToolNames(): string[] {
+		return this.#requestedActiveToolNames.filter(name => !isMCPToolName(name) && this.#toolRegistry.has(name));
+	}
+
+	#getEffectiveRequestedToolNames(toolNames: Iterable<string>): string[] {
+		const normalizedToolNames = Array.from(
+			new Set(Array.from(toolNames).filter(name => this.#toolRegistry.has(name))),
+		);
+		if (this.#orchestratorMode && !this.#toolRegistry.has("task")) {
+			throw new Error("orchestrator mode requires the task tool to remain available.");
+		}
+		if (this.#orchestratorMode && !normalizedToolNames.includes("task")) {
+			return ["task", ...normalizedToolNames];
+		}
+		return normalizedToolNames;
+	}
+
 	#getActiveNonMCPToolNames(): string[] {
 		return this.getActiveToolNames().filter(name => !isMCPToolName(name) && this.#toolRegistry.has(name));
 	}
@@ -2040,6 +2068,34 @@ export class AgentSession {
 		return this.#toolRegistry.has("edit");
 	}
 
+	/** Whether orchestration-only mode is currently enabled for this session. */
+	get orchestratorMode(): boolean {
+		return this.#orchestratorMode;
+	}
+
+	async setOrchestratorMode(enabled: boolean): Promise<void> {
+		if (this.#orchestratorMode === enabled) {
+			return;
+		}
+		if (enabled) {
+			if ((await findRepoRoot(this.sessionManager.getCwd())) === null) {
+				throw new Error("git repository not found");
+			}
+			if (!this.#toolRegistry.has("task")) {
+				throw new Error("orchestrator mode requires the task tool to remain available.");
+			}
+		}
+		const previousSelectedMCPToolNames = this.getSelectedMCPToolNames();
+		this.#orchestratorMode = enabled;
+		await this.#applyActiveToolsByName(this.#requestedActiveToolNames, { previousSelectedMCPToolNames });
+		this.sessionManager.appendCustomEntry("orchestrator_mode", { enabled });
+	}
+
+	toggleOrchestratorMode(): Promise<boolean> {
+		const nextEnabled = !this.#orchestratorMode;
+		return this.setOrchestratorMode(nextEnabled).then(() => nextEnabled);
+	}
+
 	/**
 	 * Get a tool by name from the registry.
 	 */
@@ -2051,7 +2107,8 @@ export class AgentSession {
 	 * Get all configured tool names (built-in via --tools or default, plus custom tools).
 	 */
 	getAllToolNames(): string[] {
-		return Array.from(this.#toolRegistry.keys());
+		const toolNames = Array.from(this.#toolRegistry.keys());
+		return toolNames;
 	}
 
 	#getEditModeSession() {
@@ -2108,7 +2165,7 @@ export class AgentSession {
 			return [];
 		}
 		const nextActive = [
-			...this.#getActiveNonMCPToolNames(),
+			...this.#getRequestedActiveNonMCPToolNames(),
 			...this.#filterSelectableMCPToolNames(nextSelectedMCPToolNames),
 		];
 		await this.setActiveToolsByName(nextActive);
@@ -2121,9 +2178,11 @@ export class AgentSession {
 	): Promise<void> {
 		toolNames = [...new Set(toolNames.map(name => name.toLowerCase()))];
 		const previousSelectedMCPToolNames = options?.previousSelectedMCPToolNames ?? this.getSelectedMCPToolNames();
+		this.#requestedActiveToolNames = Array.from(new Set(toolNames.filter(name => this.#toolRegistry.has(name))));
+		const requestedToolNames = this.#getEffectiveRequestedToolNames(this.#requestedActiveToolNames);
 		const tools: AgentTool[] = [];
 		const validToolNames: string[] = [];
-		for (const name of toolNames) {
+		for (const name of requestedToolNames) {
 			const tool = this.#toolRegistry.get(name);
 			if (tool) {
 				tools.push(tool);
@@ -2172,7 +2231,7 @@ export class AgentSession {
 		options?: { fallbackSelectedMCPToolNames?: Iterable<string> },
 	): Promise<void> {
 		if (!this.#mcpDiscoveryEnabled) return;
-		const nextActiveNonMCPToolNames = this.#getActiveNonMCPToolNames();
+		const nextActiveNonMCPToolNames = this.#getRequestedActiveNonMCPToolNames();
 		const fallbackSelectedMCPToolNames =
 			options?.fallbackSelectedMCPToolNames ?? this.#getConfiguredDefaultSelectedMCPToolNames();
 		const restoredMCPToolNames = sessionContext.hasPersistedMCPToolSelection
@@ -2194,10 +2253,6 @@ export class AgentSession {
 		this.agent.setSystemPrompt(this.#baseSystemPrompt);
 	}
 
-	/**
-	 * Replace MCP tools in the registry and recompute the visible MCP tool set immediately.
-	 * This allows /mcp add/remove/reauth to take effect without restarting the session.
-	 */
 	async refreshMCPTools(mcpTools: CustomTool[]): Promise<void> {
 		const previousSelectedMCPToolNames = this.getSelectedMCPToolNames();
 		const existingNames = Array.from(this.#toolRegistry.keys());
@@ -2239,13 +2294,10 @@ export class AgentSession {
 			this.#getConfiguredDefaultSelectedMCPToolNames(),
 		);
 
-		const nextActive = [...this.#getActiveNonMCPToolNames(), ...this.getSelectedMCPToolNames()];
+		const nextActive = [...this.#getRequestedActiveNonMCPToolNames(), ...this.getSelectedMCPToolNames()];
 		await this.#applyActiveToolsByName(nextActive, { previousSelectedMCPToolNames });
 	}
 
-	/**
-	 * Replace RPC host-owned tools and refresh the active tool set before the next model call.
-	 */
 	async refreshRpcHostTools(rpcTools: AgentTool[]): Promise<void> {
 		const nextToolNames = rpcTools.map(tool => tool.name);
 		const uniqueToolNames = new Set(nextToolNames);
@@ -2260,7 +2312,7 @@ export class AgentSession {
 		}
 
 		const previousRpcHostToolNames = new Set(this.#rpcHostToolNames);
-		const previousActiveToolNames = this.getActiveToolNames();
+		const previousRequestedToolNames = this.#getRequestedActiveToolNames();
 		for (const name of previousRpcHostToolNames) {
 			this.#toolRegistry.delete(name);
 		}
@@ -2274,8 +2326,8 @@ export class AgentSession {
 			this.#rpcHostToolNames.add(finalTool.name);
 		}
 
-		const activeNonRpcToolNames = previousActiveToolNames.filter(name => !previousRpcHostToolNames.has(name));
-		const preservedRpcToolNames = previousActiveToolNames.filter(
+		const activeNonRpcToolNames = previousRequestedToolNames.filter(name => !previousRpcHostToolNames.has(name));
+		const preservedRpcToolNames = previousRequestedToolNames.filter(
 			name => previousRpcHostToolNames.has(name) && this.#rpcHostToolNames.has(name),
 		);
 		const autoActivatedRpcToolNames = rpcTools
@@ -3414,6 +3466,7 @@ export class AgentSession {
 		this.#followUpMessages = [];
 		this.#pendingNextTurnMessages = [];
 		this.#scheduledHiddenNextTurnGeneration = undefined;
+		this.#orchestratorMode = false;
 
 		this.sessionManager.appendThinkingLevelChange(this.thinkingLevel);
 		this.sessionManager.appendServiceTierChange(this.serviceTier ?? null);
@@ -4179,6 +4232,9 @@ export class AgentSession {
 			this.#pendingNextTurnMessages = [];
 			this.#scheduledHiddenNextTurnGeneration = undefined;
 			this.#todoReminderCount = 0;
+			if (this.#orchestratorMode) {
+				this.sessionManager.appendCustomEntry("orchestrator_mode", { enabled: true });
+			}
 
 			// Inject the handoff document as a custom message
 			const handoffContent = `<handoff-context>\n${handoffText}\n</handoff-context>\n\nThe above is a handoff document from a previous session. Use this context to continue the work seamlessly.`;
@@ -6412,6 +6468,9 @@ export class AgentSession {
 
 		if (!selectedEntry.parentId) {
 			await this.sessionManager.newSession({ parentSession: previousSessionFile });
+			if (this.#orchestratorMode) {
+				this.sessionManager.appendCustomEntry("orchestrator_mode", { enabled: true });
+			}
 		} else {
 			this.sessionManager.createBranchedSession(selectedEntry.parentId);
 		}

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -248,6 +248,8 @@ export interface SessionContext {
 	mode: string;
 	/** Mode-specific data from the last mode_change entry */
 	modeData?: Record<string, unknown>;
+	/** Whether orchestrator mode was active on this branch */
+	orchestratorMode: boolean;
 }
 
 export interface SessionInfo {
@@ -525,6 +527,7 @@ export function buildSessionContext(
 			selectedMCPToolNames: [],
 			hasPersistedMCPToolSelection: false,
 			mode: "none",
+			orchestratorMode: false,
 		};
 	}
 	if (leafId) {
@@ -545,6 +548,7 @@ export function buildSessionContext(
 			selectedMCPToolNames: [],
 			hasPersistedMCPToolSelection: false,
 			mode: "none",
+			orchestratorMode: false,
 		};
 	}
 
@@ -566,6 +570,7 @@ export function buildSessionContext(
 	let hasPersistedMCPToolSelection = false;
 	let mode = "none";
 	let modeData: Record<string, unknown> | undefined;
+	let orchestratorMode = false;
 
 	for (const entry of path) {
 		if (entry.type === "thinking_level_change") {
@@ -594,6 +599,8 @@ export function buildSessionContext(
 		} else if (entry.type === "mode_change") {
 			mode = entry.mode;
 			modeData = entry.data;
+		} else if (entry.type === "custom" && entry.customType === "orchestrator_mode") {
+			orchestratorMode = (entry.data as { enabled?: boolean } | undefined)?.enabled === true;
 		}
 	}
 
@@ -690,6 +697,7 @@ export function buildSessionContext(
 		hasPersistedMCPToolSelection,
 		mode,
 		modeData,
+		orchestratorMode,
 	};
 }
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -29,6 +29,26 @@ function refreshStatusLine(ctx: InteractiveModeContext): void {
 	ctx.ui.requestRender();
 }
 
+function setOrchestratorMode(ctx: InteractiveModeContext, enabled: boolean): Promise<void> {
+	if (!enabled) {
+		return ctx.session.setOrchestratorMode(enabled).then(() => {
+			refreshStatusLine(ctx);
+			ctx.showStatus("Orchestrator mode disabled.");
+		});
+	}
+	return ctx.session
+		.setOrchestratorMode(enabled)
+		.then(() => {
+			refreshStatusLine(ctx);
+			ctx.showStatus("Orchestrator mode enabled.");
+		})
+		.catch(error => {
+			ctx.showStatus(
+				`Orchestrator mode failed to enable: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		});
+}
+
 /** Declarative subcommand definition for commands like /mcp. */
 export interface SubcommandDef {
 	name: string;
@@ -170,6 +190,70 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 			}
 			runtime.ctx.showStatus("Usage: /fast [on|off|status]");
 			runtime.ctx.editor.setText("");
+		},
+	},
+	{
+		name: "orchestrator",
+		description: "Toggle orchestrator mode (task delegation only)",
+		subcommands: [
+			{ name: "on", description: "Enable orchestrator mode" },
+			{ name: "off", description: "Disable orchestrator mode" },
+			{ name: "status", description: "Show orchestrator mode status" },
+		],
+		allowArgs: true,
+		handle: async (command, runtime) => {
+			const arg = command.args.trim().toLowerCase();
+			if (!arg || arg === "toggle") {
+				await runtime.ctx.handleOrchestratorToggle();
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			if (arg === "on") {
+				await setOrchestratorMode(runtime.ctx, true);
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			if (arg === "off") {
+				await setOrchestratorMode(runtime.ctx, false);
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			if (arg === "status") {
+				const enabled = runtime.ctx.session.orchestratorMode;
+				runtime.ctx.showStatus(`Orchestrator mode is ${enabled ? "on" : "off"}.`);
+				runtime.ctx.editor.setText("");
+				return;
+			}
+			runtime.ctx.showStatus("Usage: /orchestrator [on|off|status]");
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
+		name: "gitcheckpoint",
+		description: "Commit outstanding work with the git_commit_checkpoint tool",
+		aliases: ["checkpoint"],
+		inlineHint: "[reason]",
+		allowArgs: true,
+		handle: async (command, runtime) => {
+			runtime.ctx.editor.setText("");
+			const tool = runtime.ctx.session.getToolByName("git_commit_checkpoint");
+			if (!tool) {
+				runtime.ctx.showStatus(
+					"git_commit_checkpoint is unavailable. Enable orchestrator mode and tools.gitCommitCheckpoint.enabled.",
+				);
+				return;
+			}
+			const reason = command.args.trim() || "slash-invoked checkpoint";
+			try {
+				const result = await tool.execute("slash-gitcheckpoint", { reason });
+				const text = result.content
+					.map(c => (c.type === "text" ? c.text : ""))
+					.join("\n")
+					.trim();
+				runtime.ctx.showStatus(text || "Checkpoint complete.");
+			} catch (err) {
+				runtime.ctx.showStatus(`Checkpoint failed: ${err instanceof Error ? err.message : String(err)}`);
+			}
 		},
 	},
 	{

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -435,6 +435,8 @@ export interface BuildSystemPromptOptions {
 	mcpDiscoveryServerSummaries?: string[];
 	/** Encourage the agent to delegate via tasks unless changes are trivial. */
 	eagerTasks?: boolean;
+	/** Whether the top-level session is coordination-only and must delegate mutations. */
+	orchestratorMode?: boolean;
 	/** Rules with alwaysApply=true — their full content is injected into the prompt. */
 	alwaysApplyRules?: AlwaysApplyRule[];
 	/** Whether secret obfuscation is active. When true, explains the redaction format in the prompt. */
@@ -463,6 +465,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		mcpDiscoveryMode = false,
 		mcpDiscoveryServerSummaries = [],
 		eagerTasks = false,
+		orchestratorMode = false,
 		secretsEnabled = false,
 	} = options;
 	const resolvedCwd = cwd ?? getProjectDir();
@@ -611,6 +614,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		hasMCPDiscoveryServers: mcpDiscoveryServerSummaries.length > 0,
 		mcpDiscoveryServerSummaries,
 		eagerTasks,
+		orchestratorMode,
 		secretsEnabled,
 	};
 	let rendered = prompt.render(resolvedCustomPrompt ? customSystemPromptTemplate : systemPromptTemplate, data);

--- a/packages/coding-agent/src/task/auto-commit.ts
+++ b/packages/coding-agent/src/task/auto-commit.ts
@@ -1,0 +1,127 @@
+import * as path from "node:path";
+import type { ModelRegistry } from "../config/model-registry";
+import type { Settings } from "../config/settings";
+import { generateCommitMessage } from "../utils/commit-message-generator";
+import * as git from "../utils/git";
+import { discoverNestedRepos, getOutermostRepoRoot } from "./worktree";
+
+export interface DirtyRepoReport {
+	root: string;
+	repos: string[];
+}
+
+/**
+ * Enumerate every dirty git repository under the outermost repo root containing `cwd`.
+ * Used by the `git_commit_checkpoint` tool and the task dispatcher to decide which repos
+ * need committing.
+ * Discovery prunes hidden child directories and fails before `git status` if
+ * nested-repo traversal would cross filesystem boundaries.
+ */
+export async function dirtyRepos(cwd: string): Promise<DirtyRepoReport> {
+	const root = await getOutermostRepoRoot(cwd);
+	const nestedRepos = await discoverNestedRepos(root);
+	const allRepos = [root, ...nestedRepos.map(relativePath => path.join(root, relativePath))];
+	const statuses = await Promise.all(
+		allRepos.map(async repoPath => ({
+			repoPath,
+			status: await git.status(repoPath, {
+				porcelainV1: true,
+				untrackedFiles: "all",
+			}),
+		})),
+	);
+	return {
+		root,
+		repos: statuses.filter(entry => entry.status.trim().length > 0).map(entry => entry.repoPath),
+	};
+}
+
+export interface CommitDirtyRepoEntry {
+	repoPath: string;
+	status: "committed" | "skipped" | "failed";
+	sha?: string;
+	filesChanged: number;
+	message?: string;
+	reason?: "no-changes";
+	error?: string;
+}
+
+export interface CommitDirtyReposOptions {
+	cwd: string;
+	modelRegistry: ModelRegistry | undefined;
+	settings: Settings;
+	sessionId?: string;
+}
+
+/**
+ * Commit every dirty repo under `cwd` using a model-generated commit message per repo.
+ *
+ * Shared by:
+ * - the `git_commit_checkpoint` tool (LLM-invoked scope closer), and
+ * - the `task` dispatcher (automatic pre-task safety commit: cherry-picking the task's
+ *   branch onto a dirty parent is the primary cause of merge failures; committing
+ *   first collapses that hazard entirely).
+ *
+ * Discovery runs before `git add -A`, so hidden child task/cache directories are
+ * never staged as a side effect of checkpointing.
+ * Entries with no staged content after `git add -A` are returned as `skipped`.
+ * Throws only when the caller passes no `modelRegistry` AND a commit would be required —
+ * otherwise each repo's failure is reported in its entry so a partial failure does not
+ * block siblings.
+ */
+export async function commitDirtyRepos(options: CommitDirtyReposOptions): Promise<CommitDirtyRepoEntry[]> {
+	const { cwd, modelRegistry, settings, sessionId } = options;
+	const { repos } = await dirtyRepos(cwd);
+	if (repos.length === 0) return [];
+	if (!modelRegistry) {
+		throw new Error("A model registry is required to generate a commit message.");
+	}
+
+	const entries: CommitDirtyRepoEntry[] = [];
+	for (const repoPath of repos) {
+		try {
+			entries.push(await commitSingleRepo(repoPath, modelRegistry, settings, sessionId));
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			entries.push({
+				repoPath,
+				status: "failed",
+				filesChanged: 0,
+				error: message,
+			});
+		}
+	}
+	return entries;
+}
+
+async function commitSingleRepo(
+	repoPath: string,
+	modelRegistry: ModelRegistry,
+	settings: Settings,
+	sessionId: string | undefined,
+): Promise<CommitDirtyRepoEntry> {
+	await git.stage.files(repoPath);
+	const stagedFiles = await git.diff.changedFiles(repoPath, { cached: true });
+	if (stagedFiles.length === 0) {
+		return {
+			repoPath,
+			status: "skipped",
+			filesChanged: 0,
+			reason: "no-changes",
+		};
+	}
+	const diff = await git.diff(repoPath, { cached: true });
+	const message = await generateCommitMessage(diff, modelRegistry, settings, sessionId);
+	if (!message) {
+		throw new Error("Could not generate a commit message.");
+	}
+	await git.commit(repoPath, message);
+	const sha = (await git.head.short(repoPath)) ?? undefined;
+	return {
+		repoPath,
+		status: "committed",
+		sha,
+		filesChanged: stagedFiles.length,
+		message,
+	};
+}

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -1,38 +1,26 @@
-/**
- * Task tool - Delegate tasks to specialized agents.
- *
- * Discovers agent definitions from:
- *   - Bundled agents (shipped with omp-coding-agent)
- *   - ~/.omp/agent/agents/*.md (user-level)
- *   - .omp/agents/*.md (project-level)
- *
- * Supports:
- *   - Single agent execution
- *   - Parallel execution with concurrency limits
- *   - Progress tracking via JSON events
- *   - Session artifacts for debugging
- */
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import path from "node:path";
 import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import type { Usage } from "@oh-my-pi/pi-ai";
-import { $env, prompt, Snowflake } from "@oh-my-pi/pi-utils";
+import { $env, logger, prompt, Snowflake } from "@oh-my-pi/pi-utils";
 import type { TSchema } from "@sinclair/typebox";
-import type { ToolSession } from "..";
 import { resolveAgentModelPatterns } from "../config/model-resolver";
 import type { Theme } from "../modes/theme/theme";
 import planModeSubagentPrompt from "../prompts/system/plan-mode-subagent.md" with { type: "text" };
 import taskDescriptionTemplate from "../prompts/tools/task.md" with { type: "text" };
 import taskSummaryTemplate from "../prompts/tools/task-summary.md" with { type: "text" };
+import type { ToolSession } from "../tools/index";
 import { formatBytes, formatDuration } from "../tools/render-utils";
 // Import review tools for side effects (registers subagent tool handlers)
 import "../tools/review";
 import { generateCommitMessage } from "../utils/commit-message-generator";
 import * as git from "../utils/git";
+import { commitDirtyRepos } from "./auto-commit";
 import { discoverAgents, getAgent } from "./discovery";
 import { runSubprocess } from "./executor";
 import { resolveIsolationBackendForTaskExecution } from "./isolation-backend";
+import { resolveTaskIsolation, resolveTaskMergeMode } from "./orchestrator-mode";
 import { AgentOutputManager } from "./output-manager";
 import { mapWithConcurrencyLimit, Semaphore } from "./parallel";
 import { renderResult, renderCall as renderTaskCall } from "./render";
@@ -51,18 +39,65 @@ import {
 	applyNestedPatches,
 	captureBaseline,
 	captureDeltaPatch,
-	cleanupFuseOverlay,
 	cleanupProjfsOverlay,
+	cleanupReflinkSnapshot,
 	cleanupTaskBranches,
 	cleanupWorktree,
-	commitToBranch,
-	ensureFuseOverlay,
+	commitDeltaToBranch,
 	ensureProjfsOverlay,
+	ensureReflinkSnapshot,
 	ensureWorktree,
+	getOutermostRepoRoot,
 	getRepoRoot,
-	mergeTaskBranches,
+	mergeSingleBranch,
+	type NestedRepoPatch,
 	type WorktreeBaseline,
+	writeBranchDeltaArtifacts,
 } from "./worktree";
+
+/**
+ * Commit dirty state in the parent worktree before an isolated task is dispatched.
+ *
+ * Without this step, `mergeSingleBranch` must stash the orchestrator's uncommitted edits
+ * around the cherry-pick and pop them afterwards — a stash pop that overlaps the task's delta
+ * fails and preserves the task branch for manual reconciliation. Committing first eliminates
+ * the race entirely.
+ *
+ * Failures are logged but do not abort dispatch: the cherry-pick path still works on a dirty
+ * parent (it just has a stash-pop failure mode we now mostly avoid). Missing modelRegistry is
+ * logged and skipped so tests and sessions without a model can still dispatch tasks.
+ */
+async function autoCommitBeforeTask(repoRoot: string, session: ToolSession): Promise<void> {
+	if (!session.modelRegistry) {
+		logger.debug("autoCommitBeforeTask: no model registry; skipping pre-task auto-commit", { repoRoot });
+		return;
+	}
+	try {
+		const entries = await commitDirtyRepos({
+			cwd: repoRoot,
+			modelRegistry: session.modelRegistry,
+			settings: session.settings,
+			sessionId: session.getSessionId?.() ?? undefined,
+		});
+		const committed = entries.filter(e => e.status === "committed");
+		const failed = entries.filter(e => e.status === "failed");
+		if (committed.length > 0) {
+			logger.debug("autoCommitBeforeTask: committed parent dirty state", {
+				repos: committed.map(e => ({ path: e.repoPath, sha: e.sha, files: e.filesChanged })),
+			});
+		}
+		if (failed.length > 0) {
+			logger.warn("autoCommitBeforeTask: some repos failed to commit; proceeding with dispatch", {
+				failures: failed.map(e => ({ path: e.repoPath, error: e.error })),
+			});
+		}
+	} catch (err) {
+		logger.warn("autoCommitBeforeTask: unable to pre-commit parent dirty state; proceeding", {
+			repoRoot,
+			error: err instanceof Error ? err.message : String(err),
+		});
+	}
+}
 
 function createUsageTotals(): Usage {
 	return {
@@ -125,6 +160,27 @@ export {
 } from "./types";
 
 /**
+ * Apply a single task's nested-repo patches against the parent checkout.
+ * Each patch is attempted independently so that a failure in one nested repo
+ * does not block siblings. Returns a concise error message when any patch
+ * failed — the caller attaches it to the owning task's `error`.
+ */
+async function applyTaskNestedPatches(
+	repoRoot: string,
+	taskId: string,
+	description: string | undefined,
+	patches: NestedRepoPatch[],
+	commitMsg?: (diff: string) => Promise<string | null>,
+): Promise<string | undefined> {
+	const tagged = patches.map(np => ({ ...np, taskId, description }));
+	const result = await applyNestedPatches(repoRoot, tagged, commitMsg);
+	if (result.failed.length === 0) return undefined;
+	const details = result.failed.map(o => `${o.patch.relativePath}: ${o.error ?? "unknown"}`).join("; ");
+	const plural = result.failed.length === 1 ? "" : "es";
+	return `Nested repo patch${plural} failed: ${details}. Reconcile manually in the main session.`;
+}
+
+/**
  * Render the tool description from a cached agent list and current settings.
  */
 function renderDescription(
@@ -134,6 +190,7 @@ function renderDescription(
 	asyncEnabled: boolean,
 	disabledAgents: string[],
 	simpleMode: TaskSimpleMode,
+	branchMode: boolean,
 ): string {
 	const filteredAgents = disabledAgents.length > 0 ? agents.filter(a => !disabledAgents.includes(a.name)) : agents;
 	const { contextEnabled, customSchemaEnabled } = getTaskSimpleModeCapabilities(simpleMode);
@@ -147,6 +204,7 @@ function renderDescription(
 		defaultMode: simpleMode === "default",
 		schemaFreeMode: simpleMode === "schema-free",
 		independentMode: simpleMode === "independent",
+		branchMode,
 	});
 }
 
@@ -201,7 +259,12 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 
 	get parameters(): TSchema {
 		const isolationEnabled = this.session.settings.get("task.isolation.mode") !== "none";
-		return getTaskSchema({ isolationEnabled, simpleMode: this.#getTaskSimpleMode() });
+		return getTaskSchema({
+			isolationEnabled,
+			simpleMode: this.#getTaskSimpleMode(),
+			orchestratorMode: this.session.orchestratorMode === true,
+			taskDepth: this.session.taskDepth ?? 0,
+		});
 	}
 
 	renderCall(args: unknown, options: Parameters<typeof renderTaskCall>[1], theme: Theme) {
@@ -213,13 +276,23 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 		const disabledAgents = this.session.settings.get("task.disabledAgents") as string[];
 		const maxConcurrency = this.session.settings.get("task.maxConcurrency");
 		const isolationMode = this.session.settings.get("task.isolation.mode");
+		const orchestratorMode = this.session.orchestratorMode === true;
+		// Branch mode activates for top-level orchestrator sessions. In this mode,
+		// each task's changes land as a dedicated git commit rather than a patch artifact.
+		const branchMode =
+			resolveTaskMergeMode({
+				configuredMode: this.session.settings.get("task.isolation.merge"),
+				orchestratorMode,
+				taskDepth: 0,
+			}) === "branch";
 		return renderDescription(
 			this.#discoveredAgents,
 			maxConcurrency,
-			isolationMode !== "none",
+			!orchestratorMode && isolationMode !== "none",
 			this.session.settings.get("async.enabled"),
 			disabledAgents,
 			this.#getTaskSimpleMode(),
+			branchMode,
 		);
 	}
 	private constructor(
@@ -255,12 +328,12 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 			return createTaskModeError(validationError);
 		}
 
+		const taskItems = params.tasks ?? [];
 		const asyncEnabled = this.session.settings.get("async.enabled");
 		const selectedAgent = this.#discoveredAgents.find(agent => agent.name === params.agent);
 		if (!asyncEnabled || selectedAgent?.blocking === true) {
 			return this.#executeSync(_toolCallId, params, signal, onUpdate);
 		}
-
 		const manager = this.session.asyncJobManager;
 		if (!manager) {
 			return {
@@ -268,8 +341,6 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 				details: { projectAgentsDir: null, results: [], totalDurationMs: 0 },
 			};
 		}
-
-		const taskItems = params.tasks ?? [];
 		if (taskItems.length === 0) {
 			return this.#executeSync(_toolCallId, params, signal, onUpdate);
 		}
@@ -302,10 +373,10 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 			});
 		}
 
-		const startedJobs: Array<{ jobId: string; taskId: string }> = [];
-		const failedSchedules: string[] = [];
-		let completedJobs = 0;
-		let failedJobs = 0;
+		const _startedJobs: Array<{ jobId: string; taskId: string }> = [];
+		const _failedSchedules: string[] = [];
+		const _completedJobs = 0;
+		const _failedJobs = 0;
 
 		const getProgressSnapshot = (): AgentProgress[] => {
 			return Array.from(progressByTaskId.values())
@@ -313,181 +384,79 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 				.map(progress => structuredClone(progress));
 		};
 
-		const buildAsyncDetails = (state: "running" | "completed" | "failed", jobId: string): TaskToolDetails => ({
+		const buildAsyncDetails = (
+			state: "running" | "completed" | "failed",
+			jobId: string,
+			totalDurationMs = 0,
+		): TaskToolDetails => ({
 			projectAgentsDir: null,
 			results: [],
-			totalDurationMs: 0,
+			totalDurationMs,
 			progress: getProgressSnapshot(),
 			async: { state, jobId, type: "task" },
 		});
+		const batchLabel = `${params.agent} (${taskItems.length} task${taskItems.length === 1 ? "" : "s"})`;
 
-		const emitAsyncUpdate = (state: "running" | "completed" | "failed", text: string): void => {
-			const primaryJobId = startedJobs[0]?.jobId ?? "task";
-			onUpdate?.({
-				content: [{ type: "text", text }],
-				details: buildAsyncDetails(state, primaryJobId),
-			});
-		};
-
-		const maxConcurrency = this.session.settings.get("task.maxConcurrency");
-		const semaphore = new Semaphore(maxConcurrency);
-
-		for (let i = 0; i < taskItems.length; i++) {
-			const taskItem = taskItems[i];
-			if (signal?.aborted) {
-				failedSchedules.push(`${taskItem.id}: cancelled before scheduling`);
-				const progress = progressByTaskId.get(taskItem.id);
-				if (progress) {
-					progress.status = "aborted";
-				}
-				continue;
-			}
-
-			const uniqueId = uniqueIds[i];
-			const singleParams: TaskParams = { ...params, tasks: [taskItem] };
-			const label = uniqueId;
-			try {
-				const jobId = manager.register(
-					"task",
-					label,
-					async ({ signal: runSignal, reportProgress }) => {
-						const startedAt = Date.now();
-						const progress = progressByTaskId.get(taskItem.id);
-						await semaphore.acquire();
-						if (runSignal.aborted) {
-							semaphore.release();
-							if (progress) {
-								progress.status = "aborted";
-							}
-							throw new Error("Aborted before execution");
-						}
-						if (progress) {
-							progress.status = "running";
-						}
-						await reportProgress(
-							`Running background task ${taskItem.id}...`,
-							buildAsyncDetails("running", startedJobs[0]?.jobId ?? label) as unknown as Record<string, unknown>,
-						);
-						try {
-							const result = await this.#executeSync(_toolCallId, singleParams, runSignal, undefined, [
-								uniqueId,
-							]);
-							const finalText = result.content.find(part => part.type === "text")?.text ?? "(no output)";
-							const singleResult = result.details?.results[0];
-							if (progress) {
-								progress.status = singleResult?.aborted
-									? "aborted"
-									: (singleResult?.exitCode ?? 0) === 0
-										? "completed"
-										: "failed";
-								progress.durationMs = singleResult?.durationMs ?? Math.max(0, Date.now() - startedAt);
-								progress.tokens = singleResult?.tokens ?? 0;
-								progress.extractedToolData = singleResult?.extractedToolData;
-							}
-							completedJobs += 1;
-							if (singleResult && ((singleResult.aborted ?? false) || singleResult.exitCode !== 0)) {
-								failedJobs += 1;
-							}
-							const remaining = taskItems.length - completedJobs;
-							const isDone = remaining === 0;
-							await reportProgress(
-								isDone
-									? `Background task batch complete: ${completedJobs}/${taskItems.length} finished.`
-									: `Background task batch progress: ${completedJobs}/${taskItems.length} finished (${remaining} running).`,
-								buildAsyncDetails(
-									isDone ? (failedJobs > 0 || failedSchedules.length > 0 ? "failed" : "completed") : "running",
-									startedJobs[0]?.jobId ?? label,
-								) as unknown as Record<string, unknown>,
-							);
-							if (isDone) {
-								emitAsyncUpdate(
-									failedJobs > 0 || failedSchedules.length > 0 ? "failed" : "completed",
-									`Background task batch complete: ${completedJobs}/${taskItems.length} finished.`,
-								);
-							}
-							return finalText;
-						} catch (error) {
-							if (progress) {
-								progress.status = "failed";
-								progress.durationMs = Math.max(0, Date.now() - startedAt);
-							}
-							completedJobs += 1;
-							failedJobs += 1;
-							const remaining = taskItems.length - completedJobs;
-							const isDone = remaining === 0;
-							await reportProgress(
-								isDone
-									? `Background task batch complete with failures: ${failedJobs} failed.`
-									: `Background task batch progress: ${completedJobs}/${taskItems.length} finished (${remaining} running).`,
-								buildAsyncDetails(
-									isDone ? "failed" : "running",
-									startedJobs[0]?.jobId ?? label,
-								) as unknown as Record<string, unknown>,
-							);
-							if (isDone) {
-								emitAsyncUpdate(
-									"failed",
-									`Background task batch complete with failures: ${failedJobs} failed.`,
-								);
-							}
-							throw error;
-						} finally {
-							semaphore.release();
-						}
-					},
-					{
-						id: label,
-						onProgress: (text, details) => {
-							const progressDetails =
-								(details as TaskToolDetails | undefined) ??
-								buildAsyncDetails("running", startedJobs[0]?.jobId ?? label);
-							onUpdate?.({ content: [{ type: "text", text }], details: progressDetails });
+		let batchJobId = "task";
+		try {
+			batchJobId = manager.register(
+				"task",
+				batchLabel,
+				async ({ jobId, signal: runSignal, reportProgress }) => {
+					const result = await this.#executeSync(
+						_toolCallId,
+						params,
+						runSignal,
+						async update => {
+							const text = update.content.find(part => part.type === "text")?.text ?? "Running task batch...";
+							const details =
+								(update.details as TaskToolDetails | undefined) ?? buildAsyncDetails("running", jobId);
+							await reportProgress(text, details as unknown as Record<string, unknown>);
 						},
+						uniqueIds,
+					);
+					const finalText = result.content.find(part => part.type === "text")?.text ?? "(no output)";
+					return finalText;
+				},
+				{
+					onProgress: (text, details) => {
+						const progressDetails =
+							(details as TaskToolDetails | undefined) ?? buildAsyncDetails("running", batchJobId);
+						onUpdate?.({ content: [{ type: "text", text }], details: progressDetails });
 					},
-				);
-				startedJobs.push({ jobId, taskId: taskItem.id });
-			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				failedSchedules.push(`${taskItem.id}: ${message}`);
-				const progress = progressByTaskId.get(taskItem.id);
-				if (progress) {
-					progress.status = "failed";
-				}
-			}
-		}
-
-		if (startedJobs.length === 0) {
-			const failureText = `Failed to start background task jobs: ${failedSchedules.join("; ")}`;
+				},
+			);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
 			return {
-				content: [{ type: "text", text: failureText }],
-				details: { projectAgentsDir: null, results: [], totalDurationMs: 0 },
+				content: [{ type: "text", text: `Failed to start background task batch: ${message}` }],
+				details: {
+					projectAgentsDir: null,
+					results: [],
+					totalDurationMs: 0,
+					progress: getProgressSnapshot(),
+				},
 			};
 		}
 
-		emitAsyncUpdate(
-			"running",
-			`Launching ${startedJobs.length} background ${startedJobs.length === 1 ? "task" : "tasks"}...`,
-		);
-
-		const scheduleFailureSummary =
-			failedSchedules.length > 0
-				? ` Failed to schedule ${failedSchedules.length} task${failedSchedules.length === 1 ? "" : "s"}.`
-				: "";
+		onUpdate?.({
+			content: [
+				{
+					type: "text",
+					text: `Launching background task batch with ${taskItems.length} task${taskItems.length === 1 ? "" : "s"}...`,
+				},
+			],
+			details: buildAsyncDetails("running", batchJobId),
+		});
 
 		return {
 			content: [
 				{
 					type: "text",
-					text: `Started ${startedJobs.length} background task job${startedJobs.length === 1 ? "" : "s"} using ${params.agent}.${scheduleFailureSummary} Results will be delivered when complete.`,
+					text: `Started background task batch using ${params.agent} (${taskItems.length} task${taskItems.length === 1 ? "" : "s"}). Results will be delivered when complete.`,
 				},
 			],
-			details: {
-				projectAgentsDir: null,
-				results: [],
-				totalDurationMs: 0,
-				progress: getProgressSnapshot(),
-				async: { state: "running", jobId: startedJobs[0].jobId, type: "task" },
-			},
+			details: buildAsyncDetails("running", batchJobId),
 		};
 	}
 
@@ -505,31 +474,23 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 		const { contextEnabled, customSchemaEnabled } = getTaskSimpleModeCapabilities(simpleMode);
 		const sharedContext = contextEnabled ? context : undefined;
 		const isolationMode = this.session.settings.get("task.isolation.mode");
-		const isolationRequested = "isolated" in params ? params.isolated === true : false;
-		const isIsolated = isolationMode !== "none" && isolationRequested;
-		const mergeMode = this.session.settings.get("task.isolation.merge");
+		// Nested tasks (depth > 0) cannot open a fresh isolation layer on top of their parent;
+		// the schema hides the field there, but ignore a stray argument defensively as well.
+		const isolationRequested =
+			(this.session.taskDepth ?? 0) === 0 && "isolated" in params ? params.isolated === true : false;
+		const timeout = (params as { timeout?: number }).timeout;
+		let isIsolated = false;
+		const taskDepth = this.session.taskDepth ?? 0;
+		const mergeMode = resolveTaskMergeMode({
+			configuredMode: this.session.settings.get("task.isolation.merge"),
+			orchestratorMode: this.session.orchestratorMode === true,
+			taskDepth,
+		});
 		const commitStyle = this.session.settings.get("task.isolation.commits");
 		const maxConcurrency = this.session.settings.get("task.maxConcurrency");
-		const taskDepth = this.session.taskDepth ?? 0;
-
-		if (isolationMode === "none" && "isolated" in params) {
-			return {
-				content: [
-					{
-						type: "text",
-						text: "Task isolation is disabled. Remove the isolated argument or set task.isolation.mode to 'worktree', 'fuse-overlay', or 'fuse-projfs'.",
-					},
-				],
-				details: {
-					projectAgentsDir,
-					results: [],
-					totalDurationMs: 0,
-				},
-			};
-		}
 
 		// Validate agent exists
-		const agent = getAgent(agents, agentName);
+		let agent = getAgent(agents, agentName);
 		if (!agent) {
 			const available = agents.map(a => a.name).join(", ") || "none";
 			return {
@@ -576,6 +537,30 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 					spawns: undefined,
 				}
 			: agent;
+		agent = effectiveAgent;
+		const { taskIsolationMode } = resolveTaskIsolation({
+			configuredMode: isolationMode,
+			isolationRequested,
+			orchestratorMode: this.session.orchestratorMode === true,
+			agent: effectiveAgent,
+			taskDepth,
+		});
+		if (taskIsolationMode === "none" && isolationRequested) {
+			return {
+				content: [
+					{
+						type: "text",
+						text: "Task isolation is disabled. Remove the isolated argument or set task.isolation.mode to 'worktree', 'reflink', or 'fuse-projfs'.",
+					},
+				],
+				details: {
+					projectAgentsDir,
+					results: [],
+					totalDurationMs: 0,
+				},
+			};
+		}
+		isIsolated = taskIsolationMode !== "none";
 
 		// Apply per-agent model override from settings (highest priority)
 		const agentModelOverrides = this.session.settings.get("task.agentModelOverrides");
@@ -664,9 +649,31 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 
 		let repoRoot: string | null = null;
 		let baseline: WorktreeBaseline | null = null;
+		let effectiveIsolationMode = taskIsolationMode;
+		let isolationBackendWarning = "";
 		if (isIsolated) {
 			try {
 				repoRoot = await getRepoRoot(this.session.cwd);
+				const resolvedIsolation = await resolveIsolationBackendForTaskExecution(
+					taskIsolationMode,
+					isIsolated,
+					repoRoot,
+				);
+				effectiveIsolationMode = resolvedIsolation.effectiveIsolationMode;
+				isolationBackendWarning = resolvedIsolation.warning;
+				// Worktree isolation covers the outermost enclosing git root so the
+				// worktree spans the full workspace (e.g. Cargo/npm workspaces).
+				// Overlay modes mount from the immediate git root only.
+				if (effectiveIsolationMode === "worktree") {
+					repoRoot = await getOutermostRepoRoot(this.session.cwd);
+				}
+				// Commit any dirty state in the parent worktree before capturing the baseline.
+				// Cherry-picking a task branch onto a dirty parent has to stash + pop — and when the
+				// task's delta touches the same lines as the dirty state, stash pop conflicts. Baselining
+				// from a committed HEAD collapses that hazard: cherry-pick lands on clean parent and the
+				// subagent's changes end up in a distinct commit, on top of the orchestrator's commit.
+				// Only top-level sessions reach this branch (nested tasks can't request isolation).
+				await autoCommitBeforeTask(repoRoot, this.session);
 				baseline = await captureBaseline(repoRoot);
 			} catch (err) {
 				const message = err instanceof Error ? err.message : String(err);
@@ -684,29 +691,6 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 					},
 				};
 			}
-		}
-
-		let effectiveIsolationMode = isolationMode;
-		let isolationBackendWarning = "";
-		try {
-			const resolvedIsolation = await resolveIsolationBackendForTaskExecution(isolationMode, isIsolated, repoRoot);
-			effectiveIsolationMode = resolvedIsolation.effectiveIsolationMode;
-			isolationBackendWarning = resolvedIsolation.warning;
-		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err);
-			return {
-				content: [
-					{
-						type: "text",
-						text: message,
-					},
-				],
-				details: {
-					projectAgentsDir,
-					results: [],
-					totalDurationMs: Date.now() - startTime,
-				},
-			};
 		}
 
 		// Derive artifacts directory
@@ -822,7 +806,28 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 			}
 			emitProgress();
 
+			// Serializes parent-repo integration across concurrent tasks. `commitToBranch`
+			// and `captureDeltaPatch` operate only on the isolation dir and can run in parallel,
+			// but cherry-pick / git apply / nested-patch application touch the parent repo's
+			// HEAD, index, and stash — those must happen one at a time.
+			const mergeLock = new Semaphore(1);
+			const commitMsgFn =
+				commitStyle === "ai" && this.session.modelRegistry
+					? async (diff: string) =>
+							generateCommitMessage(
+								diff,
+								this.session.modelRegistry!,
+								this.session.settings,
+								this.session.getSessionId?.() ?? undefined,
+							)
+					: undefined;
 			const runTask = async (task: (typeof tasksWithContext)[number], index: number) => {
+				const taskSignal =
+					timeout != null && timeout > 0
+						? signal
+							? AbortSignal.any([signal, AbortSignal.timeout(timeout * 1000)])
+							: AbortSignal.timeout(timeout * 1000)
+						: signal;
 				if (!isIsolated) {
 					return runSubprocess({
 						cwd: this.session.cwd,
@@ -841,7 +846,7 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 						artifactsDir: effectiveArtifactsDir,
 						contextFile: contextFilePath,
 						enableLsp: false,
-						signal,
+						signal: taskSignal,
 						eventBus: this.session.eventBus,
 						onProgress: progress => {
 							progressMap.set(index, {
@@ -867,12 +872,12 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 					}
 					const taskBaseline = structuredClone(baseline);
 
-					if (effectiveIsolationMode === "fuse-overlay") {
-						isolationDir = await ensureFuseOverlay(repoRoot, task.id);
+					if (effectiveIsolationMode === "reflink") {
+						isolationDir = await ensureReflinkSnapshot(repoRoot, task.id);
 					} else if (effectiveIsolationMode === "fuse-projfs") {
 						isolationDir = await ensureProjfsOverlay(repoRoot, task.id);
 					} else {
-						isolationDir = await ensureWorktree(repoRoot, task.id);
+						isolationDir = await ensureWorktree(repoRoot, task.id, taskBaseline.root.headCommit);
 						await applyBaseline(isolationDir, taskBaseline);
 					}
 
@@ -894,7 +899,7 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 						artifactsDir: effectiveArtifactsDir,
 						contextFile: contextFilePath,
 						enableLsp: false,
-						signal,
+						signal: taskSignal,
 						eventBus: this.session.eventBus,
 						onProgress: progress => {
 							progressMap.set(index, {
@@ -910,55 +915,187 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 						skills: availableSkills,
 						promptTemplates,
 					});
-					if (mergeMode === "branch" && result.exitCode === 0) {
+
+					// Surface that the agent finished but integration is still pending so the
+					// TUI doesn't falsely report `completed` during the capture+merge window.
+					const markMerging = () => {
+						const prev = progressMap.get(index);
+						if (prev) {
+							progressMap.set(index, { ...prev, status: "merging" });
+							emitProgress();
+						}
+					};
+					const markMergeOutcome = (error: string | undefined) => {
+						const prev = progressMap.get(index);
+						if (prev) {
+							progressMap.set(index, {
+								...prev,
+								status: error ? "merge_failed" : "completed",
+							});
+							emitProgress();
+						}
+					};
+					if (isIsolated && result.exitCode === 0 && !result.aborted) markMerging();
+
+					// Phase 1: capture the task's changes out of the isolation dir.
+					// Branch mode → commit to `omp/task/<id>`. Patch mode → write a patch file.
+					// Nothing here touches the parent repo's working tree, so captures can
+					// run in parallel.
+					let captured: SingleResult;
+					if (result.exitCode === 0 && !result.aborted) {
+						if (mergeMode === "branch") {
+							// Capture the delta and persist it as a recovery artifact BEFORE attempting
+							// the branch commit. If `git apply` succeeds but `git commit` fails (e.g. the
+							// patch applied as a no-op against a drifted baseline), the captured patch on
+							// disk + the partially-created `omp/task/<id>` branch are the only way to
+							// recover the subagent's work. Previous behavior dropped both, silently losing
+							// the entire task on any commit failure.
+							let artifactPaths: string[] = [];
+							try {
+								const delta = await captureDeltaPatch(isolationDir, taskBaseline);
+								artifactPaths = await writeBranchDeltaArtifacts(effectiveArtifactsDir, task.id, delta);
+								const commitResult = await commitDeltaToBranch(
+									delta,
+									taskBaseline,
+									task.id,
+									task.description,
+									commitMsgFn,
+								);
+								captured = {
+									...result,
+									branchName: commitResult?.branchName,
+									nestedBranches: commitResult?.nestedBranches,
+								};
+							} catch (commitErr) {
+								// Preserve any partially-created `omp/task/<id>` branches (root + nested)
+								// for manual reconciliation; deleting them here would destroy the only
+								// remaining trace of the subagent's work besides the patch artifacts.
+								const msg = commitErr instanceof Error ? commitErr.message : String(commitErr);
+								const recoveryHint =
+									artifactPaths.length > 0
+										? ` Captured delta preserved at: ${artifactPaths.join(", ")}.`
+										: " No delta artifacts were written (capture failed before disk persist).";
+								captured = { ...result, error: `Branch commit failed: ${msg}.${recoveryHint}` };
+							}
+						} else {
+							try {
+								const delta = await captureDeltaPatch(isolationDir, taskBaseline);
+								const patchPath = path.join(effectiveArtifactsDir, `${task.id}.patch`);
+								await Bun.write(patchPath, delta.rootPatch);
+								captured = {
+									...result,
+									patchPath,
+									nestedPatches: delta.nestedPatches,
+								};
+							} catch (patchErr) {
+								const msg = patchErr instanceof Error ? patchErr.message : String(patchErr);
+								captured = { ...result, error: `Patch capture failed: ${msg}` };
+							}
+						}
+					} else {
+						captured = result;
+						// Recovery: preserve the subagent's in-progress work before the isolation
+						// worktree is torn down in `finally`. Without this, connection hiccups or
+						// user aborts silently destroy minutes/hours of subagent edits.
+						if (isIsolated && isolationDir && effectiveArtifactsDir && result.aborted) {
+							try {
+								const delta = await captureDeltaPatch(isolationDir, taskBaseline);
+								const paths = await writeBranchDeltaArtifacts(effectiveArtifactsDir, task.id, delta);
+								if (paths.length > 0) {
+									captured = { ...captured, recoveryArtifacts: paths };
+								}
+							} catch (recoveryErr) {
+								const msg = recoveryErr instanceof Error ? recoveryErr.message : String(recoveryErr);
+								logger.warn("Aborted-task recovery capture failed", { taskId: task.id, error: msg });
+							}
+						}
+					}
+
+					// Phase 2: integrate into the parent repo. Serialized because cherry-pick,
+					// git apply, and stash operate on shared parent-repo state. A failure here
+					// is attributed to this task only — sibling tasks still get their own attempt.
+					if (isIsolated && repoRoot && captured.exitCode === 0 && !captured.aborted && !captured.error) {
+						await mergeLock.acquire();
 						try {
-							const commitMsg =
-								commitStyle === "ai" && this.session.modelRegistry
-									? async (diff: string) => {
-											return generateCommitMessage(
-												diff,
-												this.session.modelRegistry!,
-												this.session.settings,
-												this.session.getSessionId?.() ?? undefined,
-											);
+							if (mergeMode === "branch") {
+								// Merge root + each nested branch independently. Preserve branches
+								// on any failure so the main session can reconcile manually.
+								const targets: Array<{ repo: string; branchName: string; label: string }> = [];
+								if (captured.branchName) {
+									targets.push({ repo: repoRoot, branchName: captured.branchName, label: "root" });
+								}
+								for (const nb of captured.nestedBranches ?? []) {
+									targets.push({
+										repo: path.join(repoRoot, nb.relativePath),
+										branchName: nb.branchName,
+										label: nb.relativePath,
+									});
+								}
+								const preserved: string[] = [];
+								const conflicts: string[] = [];
+								const aggressiveMerges: Array<{ label: string; files: string[] }> = [];
+								for (const t of targets) {
+									const merged = await mergeSingleBranch(t.repo, {
+										branchName: t.branchName,
+										taskId: task.id,
+										description: task.description,
+									});
+									if (merged.ok) {
+										await cleanupTaskBranches(t.repo, [t.branchName]);
+										if (merged.aggressive) {
+											aggressiveMerges.push({ label: t.label, files: merged.aggressive.files });
 										}
-									: undefined;
-							const commitResult = await commitToBranch(
-								isolationDir,
-								taskBaseline,
-								task.id,
-								task.description,
-								commitMsg,
-							);
-							return {
-								...result,
-								branchName: commitResult?.branchName,
-								nestedPatches: commitResult?.nestedPatches,
-							};
-						} catch (mergeErr) {
-							// Agent succeeded but branch commit failed — clean up stale branch
-							const branchName = `omp/task/${task.id}`;
-							await git.branch.tryDelete(repoRoot, branchName);
-							const msg = mergeErr instanceof Error ? mergeErr.message : String(mergeErr);
-							return { ...result, error: `Merge failed: ${msg}` };
+									} else {
+										preserved.push(`\`${t.branchName}\` in ${t.label}`);
+										conflicts.push(`${t.label}: ${merged.conflict ?? "unknown"}`);
+									}
+								}
+								if (preserved.length > 0) {
+									captured.error = `Branch merge failed; preserved for manual reconciliation: ${preserved.join(", ")}. Conflicts: ${conflicts.join("; ")}`;
+								}
+								if (aggressiveMerges.length > 0) {
+									captured.aggressiveMerges = aggressiveMerges;
+								}
+							} else if (mergeMode === "patch" && captured.patchPath) {
+								const patchText = await Bun.file(captured.patchPath).text();
+								if (patchText.trim()) {
+									const canApply = await git.patch.canApplyText(repoRoot, patchText);
+									if (!canApply) {
+										const localChangesPresent = (await git.status(repoRoot)).trim().length > 0;
+										const causePart = localChangesPresent
+											? " The parent working tree has local edits that conflict with this patch."
+											: "";
+										captured.error = `Patch could not be applied cleanly.${causePart} Patch preserved at ${captured.patchPath}.`;
+									} else {
+										try {
+											await git.patch.applyText(repoRoot, patchText);
+										} catch (err) {
+											const msg = err instanceof Error ? err.message : String(err);
+											logger.error("Patch apply failed despite canApply check", { error: msg });
+											captured.error = `Patch apply failed: ${msg}. Patch preserved at ${captured.patchPath}.`;
+										}
+									}
+								}
+								if (!captured.error && captured.nestedPatches && captured.nestedPatches.length > 0) {
+									const err = await applyTaskNestedPatches(
+										repoRoot,
+										task.id,
+										task.description,
+										captured.nestedPatches,
+										commitMsgFn,
+									);
+									if (err) captured.error = err;
+								}
+							}
+						} finally {
+							mergeLock.release();
 						}
 					}
-					if (result.exitCode === 0) {
-						try {
-							const delta = await captureDeltaPatch(isolationDir, taskBaseline);
-							const patchPath = path.join(effectiveArtifactsDir, `${task.id}.patch`);
-							await Bun.write(patchPath, delta.rootPatch);
-							return {
-								...result,
-								patchPath,
-								nestedPatches: delta.nestedPatches,
-							};
-						} catch (patchErr) {
-							const msg = patchErr instanceof Error ? patchErr.message : String(patchErr);
-							return { ...result, error: `Patch capture failed: ${msg}` };
-						}
+
+					if (isIsolated && captured.exitCode === 0 && !captured.aborted) {
+						markMergeOutcome(captured.error);
 					}
-					return result;
+					return captured;
 				} catch (err) {
 					const message = err instanceof Error ? err.message : String(err);
 					return {
@@ -980,12 +1117,17 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 					};
 				} finally {
 					if (isolationDir) {
-						if (effectiveIsolationMode === "fuse-overlay") {
-							await cleanupFuseOverlay(isolationDir);
-						} else if (effectiveIsolationMode === "fuse-projfs") {
-							await cleanupProjfsOverlay(isolationDir);
-						} else {
-							await cleanupWorktree(isolationDir);
+						try {
+							if (effectiveIsolationMode === "reflink") {
+								await cleanupReflinkSnapshot(isolationDir);
+							} else if (effectiveIsolationMode === "fuse-projfs") {
+								await cleanupProjfsOverlay(isolationDir);
+							} else {
+								await cleanupWorktree(isolationDir);
+							}
+						} catch (cleanupErr) {
+							const msg = cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
+							logger.warn("Worktree cleanup failed", { isolationDir, error: msg });
 						}
 					}
 				}
@@ -1048,133 +1190,57 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 				}
 			}
 
+			// Per-task merge already ran inside each `runTask` under `mergeLock`. Anything
+			// that failed to integrate is recorded as `r.error` on the owning result.
+			// Here we only assemble the top-level summary of preserved artifacts so the
+			// main session can reconcile them manually.
 			let mergeSummary = "";
-			let changesApplied: boolean | null = null;
-			let mergedBranchesForNestedPatches: Set<string> | null = null;
-			if (isIsolated && repoRoot) {
-				try {
-					if (mergeMode === "branch") {
-						// Branch mode: merge task branches sequentially
-						const branchEntries = results
-							.filter(r => r.branchName && r.exitCode === 0 && !r.aborted)
-							.map(r => ({ branchName: r.branchName!, taskId: r.id, description: r.description }));
-
-						if (branchEntries.length === 0) {
-							changesApplied = true;
-						} else {
-							const mergeResult = await mergeTaskBranches(repoRoot, branchEntries);
-							mergedBranchesForNestedPatches = new Set(mergeResult.merged);
-							changesApplied = mergeResult.failed.length === 0;
-
-							if (changesApplied) {
-								mergeSummary = `\n\nMerged ${mergeResult.merged.length} branch${mergeResult.merged.length === 1 ? "" : "es"}: ${mergeResult.merged.join(", ")}`;
-							} else {
-								const mergedPart =
-									mergeResult.merged.length > 0 ? `Merged: ${mergeResult.merged.join(", ")}.\n` : "";
-								const failedPart = `Failed: ${mergeResult.failed.join(", ")}.`;
-								const conflictPart = mergeResult.conflict ? `\nConflict: ${mergeResult.conflict}` : "";
-								mergeSummary = `\n\n<system-notification>Branch merge failed. ${mergedPart}${failedPart}${conflictPart}\nUnmerged branches remain for manual resolution.</system-notification>`;
-							}
-						}
-
-						// Clean up merged branches (keep failed ones for manual resolution)
-						const allBranches = branchEntries.map(b => b.branchName);
-						if (changesApplied) {
-							await cleanupTaskBranches(repoRoot, allBranches);
-						}
-					} else {
-						// Patch mode: combine and apply patches
-						const patchesInOrder = results.map(result => result.patchPath).filter(Boolean) as string[];
-						const missingPatch = results.some(result => !result.patchPath);
-						if (missingPatch) {
-							changesApplied = false;
-						} else {
-							const patchStats = await Promise.all(
-								patchesInOrder.map(async patchPath => ({
-									patchPath,
-									size: (await fs.stat(patchPath)).size,
-								})),
-							);
-							const nonEmptyPatches = patchStats.filter(patch => patch.size > 0).map(patch => patch.patchPath);
-							if (nonEmptyPatches.length === 0) {
-								changesApplied = true;
-							} else {
-								const patchTexts = await Promise.all(
-									nonEmptyPatches.map(async patchPath => Bun.file(patchPath).text()),
-								);
-								const combinedPatch = patchTexts
-									.map(text => (text.endsWith("\n") ? text : `${text}\n`))
-									.join("");
-								if (!combinedPatch.trim()) {
-									changesApplied = true;
-								} else {
-									changesApplied = await git.patch.canApplyText(repoRoot, combinedPatch);
-									if (changesApplied) {
-										try {
-											await git.patch.applyText(repoRoot, combinedPatch);
-										} catch {
-											changesApplied = false;
-										}
-									}
-								}
-							}
-						}
-
-						if (changesApplied) {
-							mergeSummary = "\n\nApplied patches: yes";
-						} else {
-							const notification =
-								"<system-notification>Patches were not applied and must be handled manually.</system-notification>";
-							const patchList =
-								patchPaths.length > 0
-									? `\n\nPatch artifacts:\n${patchPaths.map(patch => `- ${patch}`).join("\n")}`
-									: "";
-							mergeSummary = `\n\n${notification}${patchList}`;
-						}
+			const preservedBranchTasks = results.filter(
+				r =>
+					r.error &&
+					r.exitCode === 0 &&
+					!r.aborted &&
+					(r.branchName || (r.nestedBranches && r.nestedBranches.length > 0)),
+			);
+			const preservedPatches = results.filter(r => r.patchPath && r.error && r.exitCode === 0 && !r.aborted);
+			if (preservedBranchTasks.length > 0) {
+				const lines: string[] = [];
+				for (const r of preservedBranchTasks) {
+					const label = r.description ? `${r.id} — ${r.description}` : r.id;
+					if (r.branchName) lines.push(`- ${r.branchName} in root (${label})`);
+					for (const nb of r.nestedBranches ?? []) {
+						lines.push(`- ${nb.branchName} in ${nb.relativePath} (${label})`);
 					}
-				} catch (mergeErr) {
-					const msg = mergeErr instanceof Error ? mergeErr.message : String(mergeErr);
-					changesApplied = false;
-					mergeSummary = `\n\n<system-notification>Merge phase failed: ${msg}\nTask outputs are preserved but changes were not applied.</system-notification>`;
 				}
+				const plural = lines.length === 1 ? "" : "es";
+				mergeSummary += `\n\n<system-notification>${lines.length} task branch${plural} preserved for manual reconciliation in the main session. Each owning task is marked \`merge failed\` above with its specific conflict.\nPreserved branches:\n${lines.join("\n")}</system-notification>`;
 			}
-
-			// Apply nested repo patches (separate from parent git)
-			if (isIsolated && repoRoot && (mergeMode === "branch" || changesApplied !== false)) {
-				const allNestedPatches = results
-					.filter(r => {
-						if (!r.nestedPatches || r.nestedPatches.length === 0 || r.exitCode !== 0 || r.aborted) {
-							return false;
-						}
-						if (mergeMode !== "branch") {
-							return true;
-						}
-						if (!r.branchName || !mergedBranchesForNestedPatches) {
-							return false;
-						}
-						return mergedBranchesForNestedPatches.has(r.branchName);
-					})
-					.flatMap(r => r.nestedPatches!);
-				if (allNestedPatches.length > 0) {
-					try {
-						const commitMsg =
-							commitStyle === "ai" && this.session.modelRegistry
-								? async (diff: string) => {
-										return generateCommitMessage(
-											diff,
-											this.session.modelRegistry!,
-											this.session.settings,
-											this.session.getSessionId?.() ?? undefined,
-										);
-									}
-								: undefined;
-						await applyNestedPatches(repoRoot, allNestedPatches, commitMsg);
-					} catch {
-						// Nested patch failures are non-fatal to the parent merge
-						mergeSummary +=
-							"\n\n<system-notification>Some nested repository patches failed to apply.</system-notification>";
+			if (preservedPatches.length > 0) {
+				const lines = preservedPatches.map(r => `- ${r.patchPath} (${r.id})`);
+				const plural = preservedPatches.length === 1 ? "" : "es";
+				mergeSummary += `\n\n<system-notification>${preservedPatches.length} patch${plural} preserved for manual review. Each owning task is marked \`merge failed\` above.\nPatch artifacts:\n${lines.join("\n")}</system-notification>`;
+			}
+			const aggressiveTasks = results.filter(r => r.aggressiveMerges && r.aggressiveMerges.length > 0);
+			if (aggressiveTasks.length > 0) {
+				const lines: string[] = [];
+				for (const r of aggressiveTasks) {
+					const label = r.description ? `${r.id} — ${r.description}` : r.id;
+					for (const entry of r.aggressiveMerges ?? []) {
+						const files = entry.files.length > 0 ? entry.files.join(", ") : "(no file list captured)";
+						lines.push(`- ${label} in ${entry.label}: ${files}`);
 					}
 				}
+				mergeSummary += `\n\n<system-notification>Aggressive merge applied: ${lines.length} repo/task pair${lines.length === 1 ? "" : "s"} had cherry-pick conflicts that were force-resolved with \`-X theirs\` (the picked branch's content won). Review these files — parallel tasks wrote divergent content and one side was silently overridden:\n${lines.join("\n")}</system-notification>`;
+			}
+			const recoveredTasks = results.filter(r => r.recoveryArtifacts && r.recoveryArtifacts.length > 0);
+			if (recoveredTasks.length > 0) {
+				const lines: string[] = [];
+				for (const r of recoveredTasks) {
+					const label = r.description ? `${r.id} — ${r.description}` : r.id;
+					lines.push(`- ${label}: ${(r.recoveryArtifacts ?? []).join(", ")}`);
+				}
+				const plural = recoveredTasks.length === 1 ? "" : "s";
+				mergeSummary += `\n\n<system-notification>${recoveredTasks.length} aborted task${plural} preserved as recovery patches. The isolation worktree was torn down but the in-progress edits survive on disk.\n\nRecovery patches:\n${lines.join("\n")}\n\nTo resume: dispatch a follow-up \`task\` with the **same original assignment** plus a \`## Resume\` section pointing at the patch path. Tell the subagent to \`git apply <path>\` first (the patch is against the original baseline, so it applies cleanly onto the fresh isolation worktree), then continue from where the previous attempt stopped. Do NOT restart from scratch — the patch contains the prior progress.</system-notification>`;
 			}
 
 			// Build final output - match plugin format
@@ -1205,6 +1271,8 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 					agent: r.agent,
 					status,
 					id: r.id,
+					branch: r.branchName,
+					errorDetail: r.exitCode === 0 && r.error ? r.error : undefined,
 					preview,
 					truncated,
 					meta: r.outputMeta
@@ -1231,8 +1299,10 @@ export class TaskTool implements AgentTool<TSchema, TaskToolDetails, Theme> {
 			});
 
 			// Cleanup temp directory if used
-			const shouldCleanupTempArtifacts =
-				tempArtifactsDir && (!isIsolated || changesApplied === true || changesApplied === null);
+			// Keep the temp artifacts dir if any isolated task left a preserved patch;
+			// the patch path inside points into this dir and the main session needs it.
+			const hasPreservedPatchArtifact = isIsolated && preservedPatches.length > 0;
+			const shouldCleanupTempArtifacts = tempArtifactsDir && !hasPreservedPatchArtifact;
 			if (shouldCleanupTempArtifacts) {
 				await fs.rm(tempArtifactsDir, { recursive: true, force: true });
 			}

--- a/packages/coding-agent/src/task/isolation-backend.ts
+++ b/packages/coding-agent/src/task/isolation-backend.ts
@@ -2,7 +2,7 @@ import { projfsOverlayProbe } from "@oh-my-pi/pi-natives";
 import { Snowflake } from "@oh-my-pi/pi-utils";
 import { cleanupProjfsOverlay, ensureProjfsOverlay, isProjfsUnavailableError } from "./worktree";
 
-export type TaskIsolationMode = "none" | "worktree" | "fuse-overlay" | "fuse-projfs";
+export type TaskIsolationMode = "none" | "worktree" | "reflink" | "fuse-projfs";
 
 export interface IsolationBackendResolution {
 	effectiveIsolationMode: TaskIsolationMode;
@@ -21,10 +21,10 @@ export async function resolveIsolationBackendForTaskExecution(
 		return { effectiveIsolationMode, warning };
 	}
 
-	if (requestedMode === "fuse-overlay" && platform === "win32") {
+	if (requestedMode === "reflink" && platform === "win32") {
 		effectiveIsolationMode = "worktree";
 		warning =
-			'<system-notification>fuse-overlay isolation is unavailable on Windows. Use task.isolation.mode = "fuse-projfs" for ProjFS. Falling back to worktree isolation.</system-notification>';
+			'<system-notification>reflink isolation is unavailable on Windows. Use task.isolation.mode = "fuse-projfs" for ProjFS. Falling back to worktree isolation.</system-notification>';
 		return { effectiveIsolationMode, warning };
 	}
 

--- a/packages/coding-agent/src/task/orchestrator-mode.ts
+++ b/packages/coding-agent/src/task/orchestrator-mode.ts
@@ -1,0 +1,73 @@
+import type { TaskIsolationMode } from "./isolation-backend";
+
+export const DIRECT_FILE_MUTATION_TOOL_NAMES = new Set(["ast_edit", "edit", "notebook", "resolve", "write"]);
+
+interface AgentToolScope {
+	tools?: string[];
+}
+
+interface TaskIsolationOptions {
+	configuredMode: TaskIsolationMode;
+	isolationRequested: boolean;
+	orchestratorMode: boolean;
+	agent: AgentToolScope;
+	/** Depth of the dispatching session. >0 means we're already inside an isolated task; nesting isolation is unsupported. */
+	taskDepth?: number;
+}
+
+export function isDirectMutationToolName(name: string): boolean {
+	return DIRECT_FILE_MUTATION_TOOL_NAMES.has(name);
+}
+
+/**
+ * Whether an agent can directly mutate repository files without shell workarounds.
+ * Omitted tool lists mean full access, so treat them as edit-capable.
+ */
+export function agentHasDirectMutationTools(agent: AgentToolScope): boolean {
+	return agent.tools === undefined || agent.tools.some(name => isDirectMutationToolName(name));
+}
+
+/**
+ * Orchestrator mode auto-isolates edit-capable agents and falls back to worktree
+ * when no explicit task isolation backend is configured.
+ */
+export function resolveTaskIsolation(options: TaskIsolationOptions): {
+	autoIsolation: boolean;
+	taskIsolationMode: TaskIsolationMode;
+} {
+	// Nested dispatch (depth>0): never isolate. A task dispatched from inside an already-
+	// isolated worktree cannot layer another isolation on top without degenerate performance
+	// (nested FUSE) or divergent baselines (worktree inside worktree). Sub-sub-tasks run
+	// inline in the parent task's worktree and share its branch. Cherry-pick semantics
+	// collapse to a no-op because the edits are already on the parent branch.
+	if ((options.taskDepth ?? 0) > 0) {
+		return { autoIsolation: false, taskIsolationMode: "none" };
+	}
+	const autoIsolation = options.orchestratorMode && agentHasDirectMutationTools(options.agent);
+	if (!options.isolationRequested && !autoIsolation) {
+		return { autoIsolation: false, taskIsolationMode: "none" };
+	}
+	if (options.configuredMode !== "none") {
+		return {
+			autoIsolation,
+			taskIsolationMode: options.configuredMode,
+		};
+	}
+	return {
+		autoIsolation,
+		taskIsolationMode: autoIsolation ? "worktree" : "none",
+	};
+}
+
+/**
+ * Orchestrator sessions always integrate isolated edits through temporary branches
+ * so the client can preserve branch state for recovery without reopening root edits.
+ */
+export function resolveTaskMergeMode(options: {
+	configuredMode: "patch" | "branch";
+	orchestratorMode: boolean;
+	taskDepth?: number;
+}): "patch" | "branch" {
+	if ((options.taskDepth ?? 0) > 0) return "patch";
+	return options.orchestratorMode ? "branch" : options.configuredMode;
+}

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -41,9 +41,14 @@ function getStatusIcon(status: AgentProgress["status"], theme: Theme, spinnerFra
 			return formatStatusIcon("pending", theme);
 		case "running":
 			return formatStatusIcon("running", theme, spinnerFrame);
+		case "merging":
+			// Merging is still active work — agent has finished but parent-repo
+			// integration is in progress. Keep the spinner to reflect that.
+			return formatStatusIcon("running", theme, spinnerFrame);
 		case "completed":
 			return formatStatusIcon("success", theme);
 		case "failed":
+		case "merge_failed":
 			return formatStatusIcon("error", theme);
 		case "aborted":
 			return formatStatusIcon("aborted", theme);
@@ -488,7 +493,7 @@ export function renderCall(args: TaskParams, _options: RenderResultOptions, them
 /**
  * Render streaming progress for a single agent.
  */
-function renderAgentProgress(
+export function renderAgentProgress(
 	progress: AgentProgress,
 	isLast: boolean,
 	expanded: boolean,
@@ -726,7 +731,7 @@ function renderFindings(
 /**
  * Render final result for a single agent.
  */
-function renderAgentResult(result: SingleResult, isLast: boolean, expanded: boolean, theme: Theme): string[] {
+export function renderAgentResult(result: SingleResult, isLast: boolean, expanded: boolean, theme: Theme): string[] {
 	const lines: string[] = [];
 	const prefix = isLast ? theme.fg("dim", theme.tree.last) : theme.fg("dim", theme.tree.branch);
 	const continuePrefix = isLast ? "   " : `${theme.fg("dim", theme.tree.vertical)}  `;

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -3,7 +3,7 @@ import type { Usage } from "@oh-my-pi/pi-ai";
 import { $env } from "@oh-my-pi/pi-utils";
 import { type Static, type TSchema, Type } from "@sinclair/typebox";
 import { getTaskSimpleModeCapabilities, type TaskSimpleMode } from "./simple-mode";
-import type { NestedRepoPatch } from "./worktree";
+import type { NestedRepoBranch, NestedRepoPatch } from "./worktree";
 
 /** Source of an agent definition */
 export type AgentSource = "bundled" | "user" | "project";
@@ -110,12 +110,20 @@ const createTaskSchema = (options: { isolationEnabled: boolean; simpleMode: Task
 		);
 	}
 
+	properties.timeout = Type.Optional(
+		Type.Number({
+			description:
+				"Maximum duration in seconds for each subtask. When reached, the subtask is aborted and partial results are returned.",
+		}),
+	);
+
 	if (options.isolationEnabled) {
 		return Type.Object({
 			...properties,
 			isolated: Type.Optional(
 				Type.Boolean({
-					description: "Run in isolated environment; returns patches. Use when tasks edit overlapping files.",
+					description:
+						"Run in isolated environment; returns patches. Optional in orchestrator mode because edit-capable agents are auto-isolated while read-only agents stay non-isolated.",
 				}),
 			),
 		});
@@ -142,14 +150,25 @@ const ALL_TASK_SCHEMAS = [
 type DynamicTaskSchema = (typeof ALL_TASK_SCHEMAS)[number];
 export type TaskSchema = typeof taskSchema;
 
-export function getTaskSchema(options: { isolationEnabled: boolean; simpleMode: TaskSimpleMode }): DynamicTaskSchema {
+export function getTaskSchema(options: {
+	isolationEnabled: boolean;
+	simpleMode: TaskSimpleMode;
+	orchestratorMode?: boolean;
+	taskDepth?: number;
+}): DynamicTaskSchema {
+	// The `isolated` argument is hidden when it cannot take effect:
+	// - orchestrator mode: isolation is automatic, inferred from the agent's tool access.
+	// - nested tasks (taskDepth > 0): the parent task owns its integration path; a nested
+	//   subagent cannot open a fresh isolation layer on top of its own.
+	const nested = (options.taskDepth ?? 0) > 0;
+	const effectiveIsolation = options.orchestratorMode || nested ? false : options.isolationEnabled;
 	switch (options.simpleMode) {
 		case "schema-free":
-			return options.isolationEnabled ? taskSchemaSchemaFree : taskSchemaSchemaFreeNoIsolation;
+			return effectiveIsolation ? taskSchemaSchemaFree : taskSchemaSchemaFreeNoIsolation;
 		case "independent":
-			return options.isolationEnabled ? taskSchemaIndependent : taskSchemaIndependentNoIsolation;
+			return effectiveIsolation ? taskSchemaIndependent : taskSchemaIndependentNoIsolation;
 		default:
-			return options.isolationEnabled ? taskSchema : taskSchemaNoIsolation;
+			return effectiveIsolation ? taskSchema : taskSchemaNoIsolation;
 	}
 }
 
@@ -159,6 +178,7 @@ export interface TaskParams {
 	schema?: string;
 	tasks: TaskItem[];
 	isolated?: boolean;
+	timeout?: number;
 }
 
 /** A code review finding reported by the reviewer agent */
@@ -206,7 +226,7 @@ export interface AgentProgress {
 	id: string;
 	agent: string;
 	agentSource: AgentSource;
-	status: "pending" | "running" | "completed" | "failed" | "aborted";
+	status: "pending" | "running" | "merging" | "completed" | "failed" | "merge_failed" | "aborted";
 	task: string;
 	assignment?: string;
 	description?: string;
@@ -250,10 +270,25 @@ export interface SingleResult {
 	outputPath?: string;
 	/** Patch path for isolated worktree output */
 	patchPath?: string;
-	/** Branch name for isolated branch-mode output */
+	/** Branch name for isolated branch-mode output (root repo). */
 	branchName?: string;
-	/** Nested repo patches to apply after parent merge */
+	/** Nested repo patches to apply after parent merge (patch-mode only). */
 	nestedPatches?: NestedRepoPatch[];
+	/** Nested repo branches created alongside root branch (branch-mode only). */
+	nestedBranches?: NestedRepoBranch[];
+	/**
+	 * Repos where cherry-pick conflicted and was force-resolved with `-X theirs`.
+	 * Each entry lists files whose parallel-task edits were silently overridden;
+	 * surfaced to the main session so overlapping work can be audited.
+	 */
+	aggressiveMerges?: Array<{ label: string; files: string[] }>;
+	/**
+	 * Patch artifact paths written for a task that was aborted mid-execution.
+	 * The isolation worktree is torn down after abort, so these files are the only
+	 * surviving trace of the subagent's in-progress work — surfaced to the main
+	 * session so the user can inspect or cherry-pick before retrying.
+	 */
+	recoveryArtifacts?: string[];
 	/** Data extracted by registered subprocess tool handlers (keyed by tool name) */
 	extractedToolData?: Record<string, unknown[]>;
 	/** Output metadata for agent:// URL integration */

--- a/packages/coding-agent/src/task/worktree.ts
+++ b/packages/coding-agent/src/task/worktree.ts
@@ -1,4 +1,4 @@
-import type { Dirent } from "node:fs";
+import type * as nodeFs from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -10,7 +10,14 @@ import * as git from "../utils/git";
 /** Baseline state for a single git repository. */
 export interface RepoBaseline {
 	repoRoot: string;
+	/** Real-repo HEAD SHA at orchestration capture. Never mutated — used as the
+	 * fixed point for `git worktree add` / `git branch` so per-task branches and
+	 * patches always target the same commit, regardless of sibling merges. */
 	headCommit: string;
+	/** SHA of the `omp-baseline` commit created inside the isolation worktree when
+	 * the nested repo was dirty at capture time. Used by `captureRepoDeltaPatch` to
+	 * subtract the baseline from task work. Undefined when no omp-baseline was made. */
+	isolationBase?: string;
 	staged: string;
 	unstaged: string;
 	untracked: string[];
@@ -32,8 +39,27 @@ export async function getRepoRoot(cwd: string): Promise<string> {
 	if (!repoRoot) {
 		throw new Error("Git repository not found for isolated task execution.");
 	}
-
 	return repoRoot;
+}
+
+/**
+ * Walk up from the immediate git root to find the outermost enclosing .git directory.
+ * Used only for worktree isolation where the worktree must cover the full workspace
+ * (e.g. Cargo/npm workspaces whose root sits above a nested git repository).
+ */
+export async function getOutermostRepoRoot(cwd: string): Promise<string> {
+	let root = await getRepoRoot(cwd);
+	let dir = path.dirname(root);
+	while (dir.length < root.length) {
+		try {
+			await fs.access(path.join(dir, ".git"));
+			root = dir;
+		} catch {
+			break;
+		}
+		dir = path.dirname(dir);
+	}
+	return root;
 }
 
 const PROJFS_UNAVAILABLE_PREFIX = "PROJFS_UNAVAILABLE:";
@@ -43,40 +69,62 @@ export function isProjfsUnavailableError(err: unknown): boolean {
 	return err instanceof Error && err.message.includes(PROJFS_UNAVAILABLE_PREFIX);
 }
 
+function shouldPruneRepoDiscoveryDir(name: string): boolean {
+	return name.startsWith(".") || name === "node_modules";
+}
+
 export function getGitNoIndexNullPath(): string {
 	return GIT_NO_INDEX_NULL_PATH;
 }
 
-export async function ensureWorktree(baseCwd: string, id: string): Promise<string> {
-	const repoRoot = await getRepoRoot(baseCwd);
+export async function ensureWorktree(baseCwd: string, id: string, baseSha = "HEAD"): Promise<string> {
+	const repoRoot = await getOutermostRepoRoot(baseCwd);
 	const encodedProject = getEncodedProjectName(repoRoot);
 	const worktreeDir = getWorktreeDir(encodedProject, id);
 	await fs.mkdir(path.dirname(worktreeDir), { recursive: true });
 	await git.worktree.tryRemove(repoRoot, worktreeDir);
 	await fs.rm(worktreeDir, { recursive: true, force: true });
-	await git.worktree.add(repoRoot, worktreeDir, "HEAD", { detach: true });
+	await git.worktree.add(repoRoot, worktreeDir, baseSha, { detach: true });
 	return worktreeDir;
 }
 
-/** Find nested git repositories (non-submodule) under the given root. */
-async function discoverNestedRepos(repoRoot: string): Promise<string[]> {
+/**
+ * Find nested git repositories (non-submodule) under the given root.
+ * Fails closed before crossing filesystem boundaries. Dot-prefixed child directories
+ * are pruned during traversal so checkpoint discovery does not recurse into task
+ * overlay/cache internals, but the traversal root itself is still inspected.
+ */
+export async function discoverNestedRepos(repoRoot: string): Promise<string[]> {
 	// Get submodule paths so we can exclude them
 	const submodulePaths = new Set(await git.ls.submodules(repoRoot));
+	const rootStats = await fs.stat(repoRoot);
 
-	// Find all .git dirs/files that aren't the root or known submodules
+	// Find nested repository roots that are not known submodules.
 	const result: string[] = [];
 	async function walk(dir: string): Promise<void> {
-		let entries: Dirent[];
+		let entries: nodeFs.Dirent[];
 		try {
 			entries = await fs.readdir(dir, { withFileTypes: true });
 		} catch {
 			return;
 		}
 		for (const entry of entries) {
-			if (entry.name === "node_modules" || entry.name === ".git") continue;
 			if (!entry.isDirectory()) continue;
+			if (shouldPruneRepoDiscoveryDir(entry.name)) continue;
 			const full = path.join(dir, entry.name);
 			const rel = path.relative(repoRoot, full);
+
+			const stats = await fs.stat(full).catch(err => {
+				if (isEnoent(err)) return null;
+				throw err;
+			});
+			if (!stats) continue;
+			if (stats.dev !== rootStats.dev) {
+				throw new Error(
+					`Checkpoint/task discovery refuses to cross filesystem device boundaries at "${rel}" before staging. The directory is on a different filesystem device than the repository root.`,
+				);
+			}
+
 			// Check if this directory is itself a git repo
 			const gitDir = path.join(full, ".git");
 			let hasGit = false;
@@ -96,8 +144,24 @@ async function discoverNestedRepos(repoRoot: string): Promise<string[]> {
 	return result;
 }
 
+/**
+ * Well-known SHA-1 of the empty tree object. Git recognizes this hash as the empty
+ * tree in every repository without needing an actual commit, so we use it as the
+ * subtract point when a nested repo has no resolvable HEAD (freshly-init'd, no
+ * commits yet). Without this sentinel, `git read-tree`/`git diff-tree` on an empty
+ * baseSha fails with `fatal: Not a valid object name` and poisons delta capture.
+ */
+const GIT_EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+
 async function captureRepoBaseline(repoRoot: string): Promise<RepoBaseline> {
-	const headCommit = (await git.head.sha(repoRoot)) ?? "";
+	const resolvedHead = await git.head.sha(repoRoot);
+	if (resolvedHead === null) {
+		// Legitimate state for freshly-init'd nested repos (e.g. a scaffold directory
+		// with .git but no commits). Delta capture falls back to the empty-tree SHA so
+		// the entire working tree becomes the diff.
+		logger.warn("captureRepoBaseline: HEAD unresolvable, using empty-tree fallback", { repoRoot });
+	}
+	const headCommit = resolvedHead ?? "";
 	const staged = await git.diff(repoRoot, { binary: true, cached: true });
 	const unstaged = await git.diff(repoRoot, { binary: true });
 	const untracked = await git.ls.untracked(repoRoot);
@@ -116,6 +180,15 @@ export async function captureBaseline(repoRoot: string): Promise<WorktreeBaselin
 }
 
 async function applyRepoBaseline(worktreeDir: string, rb: RepoBaseline, sourceRoot: string): Promise<void> {
+	// Reset the worktree to the captured baseline SHA before applying patches.
+	// Defends against races where `fs.cp` or `git worktree add HEAD` picked up state
+	// newer than orchestration baseline — e.g. a sibling task has already merged into
+	// the real repo. Without this reset, captured deltas include sibling task work,
+	// and `git apply` in Phase 1 fails on content that already exists in real HEAD.
+	if (rb.headCommit) {
+		await git.resetHard(worktreeDir, rb.headCommit);
+		await git.clean(worktreeDir);
+	}
 	await git.patch.applyText(worktreeDir, rb.staged, { cached: true });
 	await git.patch.applyText(worktreeDir, rb.staged);
 	await git.patch.applyText(worktreeDir, rb.unstaged);
@@ -149,33 +222,35 @@ export async function applyBaseline(worktreeDir: string, baseline: WorktreeBasel
 		}
 		// Apply any uncommitted changes from the nested baseline
 		await applyRepoBaseline(nestedDir, entry.baseline, entry.baseline.repoRoot);
-		// Commit baseline state so captureRepoDeltaPatch can cleanly subtract it.
-		// Without this, `git add -A && git commit` by the task would include
-		// baseline untracked files in the diff-tree output.
+		// Commit baseline state so captureRepoDeltaPatch can cleanly subtract it when
+		// the subagent commits via `git add -A && git commit`; otherwise baseline untracked
+		// files would leak into the diff-tree output. Keep the original staged/unstaged/
+		// untracked fields intact on the baseline — Phase 1 replays them onto the task branch
+		// so the captured patch's "before" context matches.
 		if ((await git.status(nestedDir)).trim().length > 0) {
 			await git.stage.files(nestedDir);
 			await git.commit(nestedDir, "omp-baseline", { allowEmpty: true });
-			// Update baseline to reflect the committed state — prevents double-apply
-			// in captureRepoDeltaPatch's temp-index path
-			entry.baseline.headCommit = (await git.head.sha(nestedDir)) ?? "";
-			entry.baseline.staged = "";
-			entry.baseline.unstaged = "";
-			entry.baseline.untracked = [];
+			entry.baseline.isolationBase = (await git.head.sha(nestedDir)) ?? "";
 		}
 	}
 }
 
 async function captureRepoDeltaPatch(repoDir: string, rb: RepoBaseline): Promise<string> {
-	// Check if HEAD advanced (task committed changes)
+	// Use the omp-baseline commit when present (nested repos that were dirty at
+	// capture time); otherwise the real-repo HEAD SHA is the correct subtract point.
+	// For no-HEAD nested repos (empty init), fall back to the empty-tree sentinel so
+	// `git read-tree`/`git diff-tree` accept the base and the subagent's entire tree
+	// is captured as the delta.
+	const baseSha = rb.isolationBase || rb.headCommit || GIT_EMPTY_TREE_SHA;
 	const currentHead = (await git.head.sha(repoDir)) ?? "";
-	const headAdvanced = currentHead && currentHead !== rb.headCommit;
+	const headAdvanced = currentHead && currentHead !== baseSha;
 
 	if (headAdvanced) {
 		// HEAD moved: use diff-tree to capture committed changes, plus any uncommitted on top
 		const parts: string[] = [];
 
 		// Committed changes since baseline
-		const committedDiff = await git.diff.tree(repoDir, rb.headCommit, currentHead, {
+		const committedDiff = await git.diff.tree(repoDir, baseSha, currentHead, {
 			allowFailure: true,
 			binary: true,
 		});
@@ -211,17 +286,21 @@ async function captureRepoDeltaPatch(repoDir: string, rb: RepoBaseline): Promise
 	// HEAD unchanged: use temp index approach (subtracts baseline from delta)
 	const tempIndex = path.join(os.tmpdir(), `omp-task-index-${Snowflake.next()}`);
 	try {
-		await git.readTree(repoDir, rb.headCommit, {
+		await git.readTree(repoDir, baseSha, {
 			env: { GIT_INDEX_FILE: tempIndex },
 		});
-		await git.patch.applyText(repoDir, rb.staged, {
-			cached: true,
-			env: { GIT_INDEX_FILE: tempIndex },
-		});
-		await git.patch.applyText(repoDir, rb.unstaged, {
-			cached: true,
-			env: { GIT_INDEX_FILE: tempIndex },
-		});
+		// When isolationBase is set, the readTree above already loaded a tree containing
+		// baseline staged+unstaged+untracked — re-applying them would double-apply.
+		if (!rb.isolationBase) {
+			await git.patch.applyText(repoDir, rb.staged, {
+				cached: true,
+				env: { GIT_INDEX_FILE: tempIndex },
+			});
+			await git.patch.applyText(repoDir, rb.unstaged, {
+				cached: true,
+				env: { GIT_INDEX_FILE: tempIndex },
+			});
+		}
 		const diff = await git.diff(repoDir, {
 			binary: true,
 			env: { GIT_INDEX_FILE: tempIndex },
@@ -252,6 +331,8 @@ async function captureRepoDeltaPatch(repoDir: string, rb: RepoBaseline): Promise
 export interface NestedRepoPatch {
 	relativePath: string;
 	patch: string;
+	taskId?: string;
+	description?: string;
 }
 
 export interface DeltaPatchResult {
@@ -268,6 +349,7 @@ export async function captureDeltaPatch(isolationDir: string, baseline: Worktree
 		try {
 			await fs.access(path.join(nestedDir, ".git"));
 		} catch {
+			logger.warn("captureDeltaPatch: nested repo .git not accessible, skipping", { relativePath });
 			continue;
 		}
 		const patch = await captureRepoDeltaPatch(nestedDir, nb);
@@ -277,8 +359,24 @@ export async function captureDeltaPatch(isolationDir: string, baseline: Worktree
 	return { rootPatch, nestedPatches };
 }
 
+/** Per-patch outcome from {@link applyNestedPatches}. */
+export interface NestedPatchOutcome {
+	patch: NestedRepoPatch;
+	status: "applied" | "skipped" | "failed";
+	error?: string;
+}
+
+export interface ApplyNestedPatchesResult {
+	outcomes: NestedPatchOutcome[];
+	applied: NestedPatchOutcome[];
+	failed: NestedPatchOutcome[];
+}
+
 /**
  * Apply nested repo patches directly to their working directories after parent merge.
+ * Each patch is attempted independently: a failure in one nested repo does not abort
+ * the remaining patches. The returned result lists per-patch outcomes so the caller
+ * can attribute failures back to the originating task and surface preserved artifacts.
  * @param commitMessage Optional async function to generate a commit message from the combined diff.
  *                      If omitted or returns null, falls back to a generic message.
  */
@@ -286,36 +384,52 @@ export async function applyNestedPatches(
 	repoRoot: string,
 	patches: NestedRepoPatch[],
 	commitMessage?: (diff: string) => Promise<string | null>,
-): Promise<void> {
-	// Group patches by target repo to apply all at once and commit
-	const byRepo = new Map<string, NestedRepoPatch[]>();
+): Promise<ApplyNestedPatchesResult> {
+	const outcomes: NestedPatchOutcome[] = [];
 	for (const p of patches) {
-		if (!p.patch.trim()) continue;
-		const group = byRepo.get(p.relativePath) ?? [];
-		group.push(p);
-		byRepo.set(p.relativePath, group);
-	}
-
-	for (const [relativePath, repoPatches] of byRepo) {
-		const nestedDir = path.join(repoRoot, relativePath);
+		if (!p.patch.trim()) {
+			outcomes.push({ patch: p, status: "skipped" });
+			continue;
+		}
+		const nestedDir = path.join(repoRoot, p.relativePath);
 		try {
 			await fs.access(path.join(nestedDir, ".git"));
 		} catch {
+			logger.warn("applyNestedPatches: nested repo .git not accessible, skipping", {
+				relativePath: p.relativePath,
+			});
+			outcomes.push({
+				patch: p,
+				status: "failed",
+				error: `nested repo ${p.relativePath} is not a git repository`,
+			});
 			continue;
 		}
 
-		const combinedDiff = repoPatches.map(p => p.patch).join("\n");
-		for (const { patch } of repoPatches) {
-			await git.patch.applyText(nestedDir, patch);
-		}
-
-		// Commit so nested repo history reflects the task changes
-		if ((await git.status(nestedDir)).trim().length > 0) {
-			const msg = (await commitMessage?.(combinedDiff)) ?? "changes from isolated task(s)";
-			await git.stage.files(nestedDir);
-			await git.commit(nestedDir, msg);
+		try {
+			await git.patch.applyText(nestedDir, p.patch);
+			if ((await git.status(nestedDir)).trim().length > 0) {
+				const fallback = p.description ?? p.taskId ?? "changes from isolated task";
+				const msg = (await commitMessage?.(p.patch)) ?? fallback;
+				await git.stage.files(nestedDir);
+				await git.commit(nestedDir, msg);
+			}
+			outcomes.push({ patch: p, status: "applied" });
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			logger.error("applyNestedPatches: patch failed", {
+				relativePath: p.relativePath,
+				taskId: p.taskId,
+				error: msg,
+			});
+			outcomes.push({ patch: p, status: "failed", error: msg });
 		}
 	}
+	return {
+		outcomes,
+		applied: outcomes.filter(o => o.status === "applied"),
+		failed: outcomes.filter(o => o.status === "failed"),
+	};
 }
 
 export async function cleanupWorktree(dir: string): Promise<void> {
@@ -332,63 +446,59 @@ export async function cleanupWorktree(dir: string): Promise<void> {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// Fuse-overlay isolation (Unix)
+// Reflink snapshot isolation (Unix)
 // ═══════════════════════════════════════════════════════════════════════════
 
-export async function ensureFuseOverlay(baseCwd: string, id: string): Promise<string> {
+/**
+ * Creates an independent point-in-time snapshot of the repo via reflink copy
+ * (btrfs/xfs/zfs/apfs CoW clone, or full copy fallback on non-CoW filesystems
+ * via GNU `cp --reflink=auto`). Unlike a fuse-overlayfs mount — which stacks
+ * a CoW layer over the live repo and therefore lets main-session writes bleed
+ * into the subagent's view through the unchanged lowerdir — this snapshot is
+ * decoupled from the source after creation, so concurrent main-session edits
+ * cannot mutate the subagent's baseline.
+ */
+export async function ensureReflinkSnapshot(baseCwd: string, id: string): Promise<string> {
 	if (process.platform === "win32") {
-		throw new Error('fuse-overlay isolation is unsupported on Windows. Use task.isolation.mode = "fuse-projfs".');
+		throw new Error('reflink isolation is unsupported on Windows. Use task.isolation.mode = "fuse-projfs".');
 	}
 
 	const repoRoot = await getRepoRoot(baseCwd);
 	const encodedProject = getEncodedProjectName(repoRoot);
 	const baseDir = getWorktreeDir(encodedProject, id);
-	const upperDir = path.join(baseDir, "upper");
-	const workDir = path.join(baseDir, "work");
-	const mergedDir = path.join(baseDir, "merged");
-
-	// Clean up any stale mount at this path (linux only)
-	const fusermount = $which("fusermount3") ?? $which("fusermount");
-	if (fusermount) {
-		await $`${fusermount} -u ${mergedDir}`.quiet().nothrow();
-	}
+	const snapshotDir = path.join(baseDir, "snapshot");
 
 	await fs.rm(baseDir, { recursive: true, force: true });
-	await fs.mkdir(upperDir, { recursive: true });
-	await fs.mkdir(workDir, { recursive: true });
-	await fs.mkdir(mergedDir, { recursive: true });
+	await fs.mkdir(baseDir, { recursive: true });
 
-	const binary = $which("fuse-overlayfs");
-	if (!binary) {
+	const cpBin = $which("cp");
+	if (!cpBin) {
 		await fs.rm(baseDir, { recursive: true, force: true });
-		throw new Error(
-			"fuse-overlayfs not found. Install it (e.g. `apt install fuse-overlayfs` or `pacman -S fuse-overlayfs`) to use fuse-overlay isolation.",
-		);
+		throw new Error("cp not found on PATH; required for reflink snapshot isolation.");
 	}
 
-	const result = await $`${binary} -o lowerdir=${repoRoot},upperdir=${upperDir},workdir=${workDir} ${mergedDir}`
-		.quiet()
-		.nothrow();
+	// GNU cp on Linux: `--reflink=auto -a` (CoW clone where FS supports it, full copy otherwise).
+	// BSD cp on macOS: `-c -R -p` (APFS clone + recursive + preserve). BSD `-c` hard-fails on
+	// non-clone-capable volumes rather than falling back; that's acceptable because the
+	// snapshot guarantee is what we're paying for.
+	const args =
+		process.platform === "darwin"
+			? ["-c", "-R", "-p", repoRoot, snapshotDir]
+			: ["--reflink=auto", "-a", repoRoot, snapshotDir];
+
+	const result = await $`${cpBin} ${args}`.quiet().nothrow();
 	if (result.exitCode !== 0) {
 		const stderr = result.stderr.toString().trim();
 		await fs.rm(baseDir, { recursive: true, force: true });
-		throw new Error(`fuse-overlayfs mount failed (exit ${result.exitCode}): ${stderr}`);
+		throw new Error(`reflink snapshot failed (exit ${result.exitCode}): ${stderr}`);
 	}
 
-	return mergedDir;
+	return snapshotDir;
 }
 
-export async function cleanupFuseOverlay(mergedDir: string): Promise<void> {
-	try {
-		const fusermount = $which("fusermount3") ?? $which("fusermount");
-		if (fusermount) {
-			await $`${fusermount} -u ${mergedDir}`.quiet().nothrow();
-		}
-	} finally {
-		// baseDir is the parent of the merged directory
-		const baseDir = path.dirname(mergedDir);
-		await fs.rm(baseDir, { recursive: true, force: true });
-	}
+export async function cleanupReflinkSnapshot(snapshotDir: string): Promise<void> {
+	const baseDir = path.dirname(snapshotDir);
+	await fs.rm(baseDir, { recursive: true, force: true });
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -439,15 +549,150 @@ export async function cleanupProjfsOverlay(mergedDir: string): Promise<void> {
 // Branch-mode isolation
 // ═══════════════════════════════════════════════════════════════════════════
 
+export interface NestedRepoBranch {
+	relativePath: string;
+	branchName: string;
+}
+
 export interface CommitToBranchResult {
+	/** Branch created in the root repo (undefined when root had no changes). */
 	branchName?: string;
-	nestedPatches: NestedRepoPatch[];
+	/** Per-nested-repo branches, one per nested git repo that the task modified. */
+	nestedBranches: NestedRepoBranch[];
 }
 
 /**
- * Commit task-only changes to a new branch.
- * Only root repo changes go on the branch. Nested repo patches are returned
- * separately since the parent git can't track files inside gitlinks.
+ * Baseline dirty state to replay onto a fresh task-branch worktree before applying
+ * the subagent patch. Committed as an interim `omp-baseline` commit so the subagent
+ * patch's context lines resolve against the state they were captured against.
+ *
+ * `sourceRoot` is the real-repo path from which untracked files are copied.
+ */
+interface BranchReplay {
+	staged: string;
+	unstaged: string;
+	untracked: string[];
+	sourceRoot: string;
+}
+
+async function replayBaselineDirtyState(dir: string, replay: BranchReplay): Promise<void> {
+	if (replay.staged.trim()) {
+		await git.patch.applyText(dir, replay.staged, { cached: true });
+		await git.patch.applyText(dir, replay.staged);
+	}
+	if (replay.unstaged.trim()) {
+		await git.patch.applyText(dir, replay.unstaged);
+	}
+	for (const entry of replay.untracked) {
+		const source = path.join(replay.sourceRoot, entry);
+		const destination = path.join(dir, entry);
+		try {
+			await fs.mkdir(path.dirname(destination), { recursive: true });
+			await fs.cp(source, destination, { recursive: true });
+		} catch (err) {
+			if (isEnoent(err)) continue;
+			throw err;
+		}
+	}
+}
+
+/**
+ * Commit a single repo's delta patch to a new branch on that repo.
+ *
+ * Branch chain: `baseSha → omp-baseline (if replay has content) → task-commit`.
+ * The interim omp-baseline commit replays the user's dirty-state at orchestration
+ * capture time so the subagent's captured patch — whose context reflects that dirty
+ * state — applies cleanly. At Phase 2, cherry-pick of task-commit uses omp-baseline
+ * as its merge-base, so the 3-way merge subtracts the dirty state and applies only
+ * the subagent delta onto real HEAD (independent of whether the user's working tree
+ * still holds the same dirty state).
+ *
+ * The branch is created at `baseSha` (the orchestration-captured real-repo HEAD, not
+ * current HEAD — which may have moved if a sibling task already merged). Applies the
+ * patch in a temporary worktree, commits, then tears the worktree down. Safe to run
+ * concurrently across distinct repos (git worktree uses per-ref locks).
+ */
+async function commitPatchToRepoBranch(
+	realRepoRoot: string,
+	patch: string,
+	branchName: string,
+	baseSha: string,
+	replay: BranchReplay,
+	taskId: string,
+	fallbackMessage: string,
+	commitMessage?: (diff: string) => Promise<string | null>,
+): Promise<void> {
+	await git.branch.create(realRepoRoot, branchName, baseSha);
+	const tmpDir = path.join(os.tmpdir(), `omp-branch-${Snowflake.next()}`);
+	try {
+		await git.worktree.add(realRepoRoot, tmpDir, branchName);
+		await replayBaselineDirtyState(tmpDir, replay);
+		if ((await git.status(tmpDir)).trim().length > 0) {
+			await git.stage.files(tmpDir);
+			await git.commit(tmpDir, "omp-baseline");
+		}
+		try {
+			await git.patch.applyText(tmpDir, patch);
+		} catch (err) {
+			if (err instanceof git.GitCommandError) {
+				const stderr = err.result.stderr.slice(0, 2000);
+				logger.error("commitPatchToRepoBranch: git apply failed", {
+					taskId,
+					repoRoot: realRepoRoot,
+					exitCode: err.result.exitCode,
+					stderr,
+					patchSize: patch.length,
+					patchHead: patch.slice(0, 500),
+				});
+				throw new Error(`git apply failed for task ${taskId} in ${realRepoRoot}: ${stderr}`);
+			}
+			throw err;
+		}
+		// Diagnostic: a non-empty patch that applies cleanly but leaves the tree identical
+		// indicates the captured delta was computed against a base that already contained
+		// the subagent's work (e.g. stale baseline, overlay/stat cache race). Surface this
+		// as a distinct failure with the raw patch preserved in the logs so recurrences can
+		// be root-caused without replaying the full session.
+		const postApplyStatus = (await git.status(tmpDir)).trim();
+		if (postApplyStatus.length === 0 && patch.trim().length > 0) {
+			logger.error("commitPatchToRepoBranch: patch applied as no-op", {
+				taskId,
+				repoRoot: realRepoRoot,
+				baseSha,
+				patchSize: patch.length,
+				patchHead: patch.slice(0, 2000),
+			});
+			throw new Error(
+				`captured patch for task ${taskId} applied as a no-op in ${realRepoRoot} — baseline likely drifted from the subagent's view. Patch preserved via artifacts; inspect before retrying.`,
+			);
+		}
+		await git.stage.files(tmpDir);
+		const msg = (commitMessage && (await commitMessage(patch))) || fallbackMessage;
+		await git.commit(tmpDir, msg);
+	} finally {
+		await git.worktree.tryRemove(realRepoRoot, tmpDir);
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	}
+}
+
+function baselineReplayFor(rb: RepoBaseline): BranchReplay {
+	return {
+		staged: rb.staged,
+		unstaged: rb.unstaged,
+		untracked: rb.untracked,
+		sourceRoot: rb.repoRoot,
+	};
+}
+
+/**
+ * Commit task-only changes to per-repo branches — one in the root repo and one
+ * in each nested git repo that was modified. All branches share the same name
+ * `omp/task/<id>` since they live in different repositories.
+ *
+ * Thin wrapper that captures the delta and hands off to {@link commitDeltaToBranch}.
+ * Callers that need the captured delta (e.g. to persist as a recovery artifact before
+ * attempting commit) should call {@link captureDeltaPatch} + {@link commitDeltaToBranch}
+ * directly instead.
  */
 export async function commitToBranch(
 	isolationDir: string,
@@ -456,120 +701,194 @@ export async function commitToBranch(
 	description: string | undefined,
 	commitMessage?: (diff: string) => Promise<string | null>,
 ): Promise<CommitToBranchResult | null> {
-	const { rootPatch, nestedPatches } = await captureDeltaPatch(isolationDir, baseline);
-	if (!rootPatch.trim() && nestedPatches.length === 0) return null;
-
-	const repoRoot = baseline.root.repoRoot;
-	const branchName = `omp/task/${taskId}`;
-	const fallbackMessage = description || taskId;
-
-	// Only create a branch if the root repo has changes
-	if (rootPatch.trim()) {
-		await git.branch.create(repoRoot, branchName);
-		const tmpDir = path.join(os.tmpdir(), `omp-branch-${Snowflake.next()}`);
-		try {
-			await git.worktree.add(repoRoot, tmpDir, branchName);
-			try {
-				await git.patch.applyText(tmpDir, rootPatch);
-			} catch (err) {
-				if (err instanceof git.GitCommandError) {
-					const stderr = err.result.stderr.slice(0, 2000);
-					logger.error("commitToBranch: git apply failed", {
-						taskId,
-						exitCode: err.result.exitCode,
-						stderr,
-						patchSize: rootPatch.length,
-						patchHead: rootPatch.slice(0, 500),
-					});
-					throw new Error(`git apply failed for task ${taskId}: ${stderr}`);
-				}
-				throw err;
-			}
-			await git.stage.files(tmpDir);
-			const msg = (commitMessage && (await commitMessage(rootPatch))) || fallbackMessage;
-			await git.commit(tmpDir, msg);
-		} finally {
-			await git.worktree.tryRemove(repoRoot, tmpDir);
-			await fs.rm(tmpDir, { recursive: true, force: true });
-		}
-	}
-
-	return { branchName: rootPatch.trim() ? branchName : undefined, nestedPatches };
-}
-
-export interface MergeBranchResult {
-	merged: string[];
-	failed: string[];
-	conflict?: string;
+	const delta = await captureDeltaPatch(isolationDir, baseline);
+	return commitDeltaToBranch(delta, baseline, taskId, description, commitMessage);
 }
 
 /**
- * Cherry-pick task branch commits sequentially onto HEAD.
- * Each branch has a single commit that gets replayed cleanly.
- * Stops on first conflict and reports which branches succeeded.
+ * Commit a previously captured delta to per-repo branches. Separated from the capture
+ * step so callers can persist the captured patches as recovery artifacts before the
+ * commit path can drop them on error.
  */
-export async function mergeTaskBranches(
+export async function commitDeltaToBranch(
+	delta: DeltaPatchResult,
+	baseline: WorktreeBaseline,
+	taskId: string,
+	description: string | undefined,
+	commitMessage?: (diff: string) => Promise<string | null>,
+): Promise<CommitToBranchResult | null> {
+	const { rootPatch, nestedPatches } = delta;
+	if (!rootPatch.trim() && nestedPatches.length === 0) return null;
+
+	const branchName = `omp/task/${taskId}`;
+	const fallbackMessage = description || taskId;
+
+	let rootBranch: string | undefined;
+	if (rootPatch.trim()) {
+		await commitPatchToRepoBranch(
+			baseline.root.repoRoot,
+			rootPatch,
+			branchName,
+			baseline.root.headCommit,
+			baselineReplayFor(baseline.root),
+			taskId,
+			fallbackMessage,
+			commitMessage,
+		);
+		rootBranch = branchName;
+	}
+
+	const nestedBranches: NestedRepoBranch[] = [];
+	for (const np of nestedPatches) {
+		if (!np.patch.trim()) continue;
+		const nestedEntry = baseline.nested.find(n => n.relativePath === np.relativePath);
+		if (!nestedEntry) {
+			throw new Error(`commitDeltaToBranch: no baseline entry for nested repo ${np.relativePath}`);
+		}
+		const nestedRealRoot = path.join(baseline.root.repoRoot, np.relativePath);
+		await commitPatchToRepoBranch(
+			nestedRealRoot,
+			np.patch,
+			branchName,
+			nestedEntry.baseline.headCommit,
+			baselineReplayFor(nestedEntry.baseline),
+			taskId,
+			fallbackMessage,
+			commitMessage,
+		);
+		nestedBranches.push({ relativePath: np.relativePath, branchName });
+	}
+
+	return { branchName: rootBranch, nestedBranches };
+}
+
+/**
+ * Persist a captured delta to `<artifactsDir>/<taskId>.patch` (root) and
+ * `<artifactsDir>/<taskId>.<sanitized-rel>.patch` (per nested repo). Exists so that
+ * branch-mode commits have the same recovery trail as patch-mode: when `git apply` or
+ * `git commit` on the task branch blows up, the captured delta survives on disk.
+ *
+ * Returns the list of written paths (may be empty when the delta is entirely whitespace).
+ */
+export async function writeBranchDeltaArtifacts(
+	artifactsDir: string,
+	taskId: string,
+	delta: DeltaPatchResult,
+): Promise<string[]> {
+	const written: string[] = [];
+	if (delta.rootPatch.trim()) {
+		const rootPath = path.join(artifactsDir, `${taskId}.patch`);
+		await Bun.write(rootPath, delta.rootPatch);
+		written.push(rootPath);
+	}
+	for (const np of delta.nestedPatches) {
+		if (!np.patch.trim()) continue;
+		const sanitized = np.relativePath.replace(/[/\\]+/g, "__").replace(/[^A-Za-z0-9._-]/g, "_");
+		const nestedPath = path.join(artifactsDir, `${taskId}.${sanitized}.patch`);
+		await Bun.write(nestedPath, np.patch);
+		written.push(nestedPath);
+	}
+	return written;
+}
+
+export interface AggressiveMergeInfo {
+	/** Files whose conflicts were resolved by taking the cherry-picked branch's content. */
+	files: string[];
+}
+
+export interface MergeSingleBranchResult {
+	ok: boolean;
+	commit?: string;
+	conflict?: string;
+	/**
+	 * Present when the first cherry-pick conflicted and a `-X theirs` retry succeeded.
+	 * Callers MUST surface this to the main session: parallel tasks wrote divergent content to
+	 * the listed files and the retry silently took the picked branch's version.
+	 */
+	aggressive?: AggressiveMergeInfo;
+}
+
+/**
+ * Cherry-pick a single task branch commit onto HEAD.
+ * Stashes any dirty working tree, cherry-picks, then restores the stash.
+ *
+ * On first cherry-pick conflict: aborts, retries with `-X theirs` so near-identical parallel
+ * edits (e.g. the same lint fix landed by two sibling tasks) merge best-effort. Conflicted
+ * files from the first attempt are reported as `aggressive` so the main session can audit.
+ * If the retry also conflicts, returns `{ ok: false, conflict }`.
+ *
+ * On stash-pop conflict after a successful cherry-pick: returns `{ ok: false, conflict }`
+ * — the caller should preserve the task branch so the user can reconcile manually.
+ *
+ * Callers MUST serialize `mergeSingleBranch` calls against the same `repoRoot`;
+ * stash + cherry-pick are not safe to interleave.
+ */
+export async function mergeSingleBranch(
 	repoRoot: string,
-	branches: Array<{ branchName: string; taskId: string; description?: string }>,
-): Promise<MergeBranchResult> {
-	const merged: string[] = [];
-	const failed: string[] = [];
-
-	// Stash dirty working tree so cherry-pick can operate on a clean HEAD.
-	// Without this, cherry-pick refuses to run when uncommitted changes exist.
+	branch: { branchName: string; taskId: string; description?: string },
+): Promise<MergeSingleBranchResult> {
 	const didStash = await git.stash.push(repoRoot, "omp-task-merge");
-
-	let conflictResult: MergeBranchResult | undefined;
+	let cherryPickSucceeded = false;
+	let commit: string | undefined;
+	let conflict: string | undefined;
+	let aggressive: AggressiveMergeInfo | undefined;
 
 	try {
-		for (const { branchName } of branches) {
+		try {
+			await git.cherryPick(repoRoot, branch.branchName);
+			cherryPickSucceeded = true;
+			commit = (await git.head.short(repoRoot)) ?? undefined;
+		} catch (firstErr) {
+			// Capture conflicted files before aborting — abort clears the unmerged index.
+			let conflictedFiles: string[] = [];
 			try {
-				await git.cherryPick(repoRoot, branchName);
-			} catch (err) {
+				conflictedFiles = await git.cherryPick.conflictedFiles(repoRoot);
+			} catch {
+				/* diff may fail mid-cherry-pick; fall through with empty list */
+			}
+			try {
+				await git.cherryPick.abort(repoRoot);
+			} catch {
+				/* no state to abort */
+			}
+			// Best-effort retry: when sibling tasks made overlapping edits (identical or near-identical),
+			// -X theirs keeps the picked branch's version. Conflicted files are surfaced as `aggressive`.
+			try {
+				await git.cherryPick(repoRoot, branch.branchName, { strategyOption: "theirs" });
+				cherryPickSucceeded = true;
+				commit = (await git.head.short(repoRoot)) ?? undefined;
+				aggressive = { files: conflictedFiles };
+			} catch (retryErr) {
 				try {
 					await git.cherryPick.abort(repoRoot);
 				} catch {
 					/* no state to abort */
 				}
+				const err = retryErr instanceof Error ? retryErr : firstErr;
 				const stderr =
 					err instanceof git.GitCommandError
 						? err.result.stderr.trim()
 						: err instanceof Error
 							? err.message
 							: String(err);
-				failed.push(branchName);
-				conflictResult = {
-					merged,
-					failed: [...failed, ...branches.slice(merged.length + failed.length).map(b => b.branchName)],
-					conflict: `${branchName}: ${stderr}`,
-				};
-				break;
+				conflict = `${branch.branchName}: ${stderr}`;
 			}
-
-			merged.push(branchName);
 		}
 	} finally {
 		if (didStash) {
 			try {
 				await git.stash.pop(repoRoot, { index: true });
 			} catch {
-				// Stash-pop conflicts mean the replayed changes clash with the user's
-				// uncommitted edits. Treat this as a merge failure so the caller preserves
-				// recovery branches instead of reporting success and deleting them.
 				logger.warn("Failed to restore stashed changes after task merge; stash entry preserved");
-				if (!conflictResult) {
-					conflictResult = {
-						merged,
-						failed: merged,
-						conflict:
-							"stash pop: cherry-picked changes conflict with uncommitted edits. Run `git stash pop` and resolve manually.",
-					};
+				if (cherryPickSucceeded && !conflict) {
+					conflict = `${branch.branchName}: stash pop failed — cherry-picked changes conflict with uncommitted edits. Run \`git stash pop\` and resolve manually.`;
 				}
 			}
 		}
 	}
 
-	return conflictResult ?? { merged, failed };
+	if (conflict) return { ok: false, conflict };
+	return { ok: true, commit, aggressive };
 }
 
 /** Clean up temporary task branches. */

--- a/packages/coding-agent/src/tools/git-commit-checkpoint.ts
+++ b/packages/coding-agent/src/tools/git-commit-checkpoint.ts
@@ -1,0 +1,112 @@
+import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
+import { prompt } from "@oh-my-pi/pi-utils";
+import { type Static, Type } from "@sinclair/typebox";
+import gitCommitCheckpointDescription from "../prompts/tools/git-commit-checkpoint.md" with { type: "text" };
+import { type CommitDirtyRepoEntry, commitDirtyRepos } from "../task/auto-commit";
+import type { ToolSession } from "./index";
+import type { OutputMeta } from "./output-meta";
+import { shortenPath } from "./render-utils";
+import { ToolError } from "./tool-errors";
+import { toolResult } from "./tool-result";
+
+const gitCommitCheckpointSchema = Type.Object({
+	reason: Type.String({
+		description:
+			"Short label for the scope being closed, e.g. 'after login refactor', 'end of scope'. Used only for agent bookkeeping and surfaced in the transcript — it is not written into the commit message itself.",
+	}),
+});
+
+type GitCommitCheckpointParams = Static<typeof gitCommitCheckpointSchema>;
+
+export type GitCommitCheckpointRepoEntry = CommitDirtyRepoEntry;
+
+export interface GitCommitCheckpointToolDetails {
+	overallStatus: "committed" | "clean" | "partial" | "failed";
+	reason?: string;
+	repos: GitCommitCheckpointRepoEntry[];
+	meta?: OutputMeta;
+}
+
+export class GitCommitCheckpointTool
+	implements AgentTool<typeof gitCommitCheckpointSchema, GitCommitCheckpointToolDetails>
+{
+	readonly name = "git_commit_checkpoint";
+	readonly label = "GitCommitCheckpoint";
+	readonly description: string;
+	readonly parameters = gitCommitCheckpointSchema;
+	readonly strict = true;
+
+	constructor(private readonly session: ToolSession) {
+		this.description = prompt.render(gitCommitCheckpointDescription);
+	}
+
+	static createIf(session: ToolSession): GitCommitCheckpointTool | null {
+		if ((session.taskDepth ?? 0) !== 0) return null;
+		if (!session.settings.get("tools.gitCommitCheckpoint.enabled")) return null;
+		return new GitCommitCheckpointTool(session);
+	}
+
+	async execute(
+		_toolCallId: string,
+		params: GitCommitCheckpointParams,
+		_signal?: AbortSignal,
+		_onUpdate?: AgentToolUpdateCallback<GitCommitCheckpointToolDetails>,
+		_context?: AgentToolContext,
+	): Promise<AgentToolResult<GitCommitCheckpointToolDetails>> {
+		const cwd = this.session.cwd;
+		const entries = await commitDirtyRepos({
+			cwd,
+			modelRegistry: this.session.modelRegistry,
+			settings: this.session.settings,
+			sessionId: this.session.getSessionId?.() ?? undefined,
+		});
+
+		if (entries.length === 0) {
+			const details: GitCommitCheckpointToolDetails = {
+				overallStatus: "clean",
+				reason: params.reason,
+				repos: [],
+			};
+			return toolResult<GitCommitCheckpointToolDetails>(details)
+				.text(`Nothing to commit — all repos under ${shortenPath(cwd)} are clean.`)
+				.done();
+		}
+		const committed = entries.filter(entry => entry.status === "committed").length;
+		const failed = entries.filter(entry => entry.status === "failed").length;
+		const overallStatus: GitCommitCheckpointToolDetails["overallStatus"] =
+			failed === entries.length ? "failed" : failed > 0 ? "partial" : committed === 0 ? "clean" : "committed";
+
+		const details: GitCommitCheckpointToolDetails = {
+			overallStatus,
+			reason: params.reason,
+			repos: entries,
+		};
+		const text = formatResultText(entries);
+		if (overallStatus === "failed") {
+			throw new ToolError(text);
+		}
+		return toolResult<GitCommitCheckpointToolDetails>(details).text(text).done();
+	}
+}
+
+function formatResultText(entries: GitCommitCheckpointRepoEntry[]): string {
+	if (entries.length === 0) {
+		return "No dirty repos.";
+	}
+	const lines: string[] = [];
+	for (const entry of entries) {
+		const repoLabel = shortenPath(entry.repoPath);
+		if (entry.status === "committed") {
+			const sha = entry.sha ?? "unknown";
+			const fileWord = entry.filesChanged === 1 ? "file" : "files";
+			const subject = entry.message?.trim().split("\n")[0];
+			const suffix = subject ? ` — ${subject}` : "";
+			lines.push(`${repoLabel}: ${sha} (${entry.filesChanged} ${fileWord})${suffix}`);
+		} else if (entry.status === "skipped") {
+			lines.push(`${repoLabel}: skipped (${entry.reason ?? "no-changes"})`);
+		} else {
+			lines.push(`${repoLabel}: failed — ${entry.error ?? "unknown error"}`);
+		}
+	}
+	return lines.join("\n");
+}

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -99,7 +99,6 @@ export type ContextFileEntry = {
 
 export type { DiscoverableMCPTool } from "../mcp/discoverable-tool-metadata";
 
-/** Session context for tool factories */
 export interface ToolSession {
 	/** Current working directory */
 	cwd: string;
@@ -119,6 +118,8 @@ export interface ToolSession {
 	enableLsp?: boolean;
 	/** Whether an edit-capable tool is available in this session (controls hashline output) */
 	hasEditTool?: boolean;
+	/** Whether this session is in orchestrator (coordination-only) mode */
+	orchestratorMode?: boolean;
 	/** Event bus for tool/extension communication */
 	eventBus?: EventBus;
 	/** Output schema for structured completion (subagents) */

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -30,6 +30,7 @@ import { DebugTool } from "./debug";
 import { ExitPlanModeTool } from "./exit-plan-mode";
 import { FindTool } from "./find";
 import { GithubTool } from "./gh";
+import { GitCommitCheckpointTool } from "./git-commit-checkpoint";
 import { GrepTool } from "./grep";
 import { InspectImageTool } from "./inspect-image";
 import { IrcTool } from "./irc";
@@ -220,6 +221,7 @@ export const BUILTIN_TOOLS: Record<string, ToolFactory> = {
 	read: s => new ReadTool(s),
 	inspect_image: s => new InspectImageTool(s),
 	browser: s => new BrowserTool(s),
+	git_commit_checkpoint: GitCommitCheckpointTool.createIf,
 	checkpoint: CheckpointTool.createIf,
 	rewind: RewindTool.createIf,
 	task: TaskTool.create,

--- a/packages/coding-agent/src/tools/job.ts
+++ b/packages/coding-agent/src/tools/job.ts
@@ -45,10 +45,11 @@ const WAIT_DURATION_MS: Record<string, number> = {
 	"30s": 30_000,
 	"1m": 60_000,
 	"5m": 5 * 60_000,
+	"4m30s": 4 * 60_000 + 30_000,
 };
 
 function parseWaitDurationMs(value: string | undefined): number {
-	return (value ? WAIT_DURATION_MS[value] : undefined) ?? WAIT_DURATION_MS["30s"];
+	return (value ? WAIT_DURATION_MS[value] : undefined) ?? WAIT_DURATION_MS["4m30s"];
 }
 
 interface JobSnapshot {

--- a/packages/coding-agent/src/tools/job.ts
+++ b/packages/coding-agent/src/tools/job.ts
@@ -7,6 +7,7 @@ import { isBackgroundJobSupportEnabled } from "../async";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import type { Theme } from "../modes/theme/theme";
 import jobDescription from "../prompts/tools/job.md" with { type: "text" };
+import type { AgentProgress } from "../task/types";
 import { Ellipsis, Hasher, type RenderCache, renderStatusLine, renderTreeList, truncateToWidth } from "../tui";
 import type { ToolSession } from "./index";
 import {
@@ -58,6 +59,7 @@ interface JobSnapshot {
 	durationMs: number;
 	resultText?: string;
 	errorText?: string;
+	progress?: AgentProgress[];
 }
 
 type CancelStatus = "cancelled" | "not_found" | "already_completed";
@@ -233,6 +235,7 @@ export class JobTool implements AgentTool<typeof jobSchema, JobToolDetails> {
 		return jobs.map(j => {
 			const current = this.session.asyncJobManager?.getJob(j.id);
 			const latest = current ?? j;
+			const progress = current?.type === "task" ? extractAgentProgress(current.resultDetails) : undefined;
 			return {
 				id: latest.id,
 				type: latest.type,
@@ -241,6 +244,7 @@ export class JobTool implements AgentTool<typeof jobSchema, JobToolDetails> {
 				durationMs: Math.max(0, now - latest.startTime),
 				...(latest.resultText ? { resultText: latest.resultText } : {}),
 				...(latest.errorText ? { errorText: latest.errorText } : {}),
+				...(progress ? { progress } : {}),
 			};
 		});
 	}
@@ -323,6 +327,8 @@ interface JobRenderArgs {
 
 const COLLAPSED_LIST_LIMIT = PREVIEW_LIMITS.COLLAPSED_ITEMS;
 const LABEL_MAX_WIDTH = 60;
+const PROGRESS_COLLAPSED_LIMIT = 5;
+const PROGRESS_TASK_WIDTH = 50;
 const PREVIEW_LINES_COLLAPSED = 1;
 const PREVIEW_LINES_EXPANDED = 4;
 const PREVIEW_LINE_WIDTH = 80;
@@ -353,6 +359,24 @@ function statusToColor(status: JobSnapshot["status"]): ToolUIColor {
 	}
 }
 
+function progressStatusToIcon(status: AgentProgress["status"]): ToolUIStatus {
+	switch (status) {
+		case "completed":
+			return "success";
+		case "failed":
+			return "error";
+		case "merge_failed":
+			return "warning";
+		case "aborted":
+			return "aborted";
+		case "pending":
+			return "pending";
+		case "running":
+		case "merging":
+			return "running";
+	}
+}
+
 function describeTarget(args: JobRenderArgs | undefined): string {
 	const poll = args?.poll ?? [];
 	const cancel = args?.cancel ?? [];
@@ -365,6 +389,12 @@ function describeTarget(args: JobRenderArgs | undefined): string {
 	}
 	if (parts.length === 0) return "all running jobs";
 	return parts.join(", ");
+}
+
+function extractAgentProgress(details: Record<string, unknown> | undefined): AgentProgress[] | undefined {
+	if (!details) return undefined;
+	const progress = (details as { progress?: unknown }).progress;
+	return Array.isArray(progress) && progress.length > 0 ? (progress as AgentProgress[]) : undefined;
 }
 
 export const jobToolRenderer = {
@@ -459,6 +489,36 @@ export const jobToolRenderer = {
 							const labelText = uiTheme.fg("toolOutput", label);
 							const durationText = uiTheme.fg("dim", formatDuration(job.durationMs));
 							lines.push(`${icon} ${idText} ${typeBadge} ${labelText} ${durationText}`);
+
+							if (job.progress && job.progress.length > 0) {
+								const limit = expanded ? job.progress.length : PROGRESS_COLLAPSED_LIMIT;
+								const visible = job.progress.slice(0, limit);
+								for (const p of visible) {
+									const pIcon = formatStatusIcon(
+										progressStatusToIcon(p.status),
+										uiTheme,
+										p.status === "running" || p.status === "merging" ? options.spinnerFrame : undefined,
+									);
+									const pAgent = uiTheme.fg("muted", p.agent);
+									const pTask = uiTheme.fg(
+										"toolOutput",
+										truncateToWidth(
+											replaceTabs(p.task || p.description || "(task)"),
+											PROGRESS_TASK_WIDTH,
+											Ellipsis.Unicode,
+										),
+									);
+									const tail: string[] = [];
+									if (p.currentTool) tail.push(p.currentTool);
+									if (p.durationMs) tail.push(formatDuration(p.durationMs));
+									const tailText = tail.length > 0 ? ` ${uiTheme.fg("dim", tail.join(" "))}` : "";
+									lines.push(`  ${pIcon} ${pAgent} ${pTask}${tailText}`);
+								}
+								if (job.progress.length > visible.length) {
+									const hidden = job.progress.length - visible.length;
+									lines.push(`  ${uiTheme.fg("dim", `+${hidden} more`)}`);
+								}
+							}
 
 							const preview = job.errorText?.trim() || job.resultText?.trim();
 							if (preview) {

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -81,6 +81,7 @@ export interface PatchOptions {
 	readonly check?: boolean;
 	readonly env?: Record<string, string | undefined>;
 	readonly signal?: AbortSignal;
+	readonly threeWay?: boolean;
 }
 
 export interface RestoreOptions {
@@ -306,6 +307,7 @@ function buildApplyArgs(patchPath: string, options: PatchOptions): string[] {
 	const args = ["apply"];
 	if (options.check) args.push("--check");
 	if (options.cached) args.push("--cached");
+	if (options.threeWay) args.push("--3way");
 	args.push("--binary", patchPath);
 	return args;
 }
@@ -785,7 +787,7 @@ export const stage = {
 
 /** Create a commit with the given message (passed via stdin). */
 export async function commit(cwd: string, message: string, options: CommitOptions = {}): Promise<GitCommandResult> {
-	const args = ["commit", "-F", "-"];
+	const args = ["commit", "--no-gpg-sign", "-F", "-"];
 	if (options.allowEmpty) args.push("--allow-empty");
 	if (options.files?.length) args.push("--", ...options.files);
 	return runChecked(cwd, args, { signal: options.signal, stdin: message });
@@ -803,6 +805,11 @@ export async function push(cwd: string, options: PushOptions = {}): Promise<void
 /** Checkout a ref. */
 export async function checkout(cwd: string, ref: string, signal?: AbortSignal): Promise<void> {
 	await runEffect(cwd, ["checkout", ref], { signal });
+}
+
+/** Hard-reset the working tree and index to the given ref. */
+export async function resetHard(cwd: string, ref: string, signal?: AbortSignal): Promise<void> {
+	await runEffect(cwd, ["reset", "--hard", ref], { signal });
 }
 
 /** Fetch a specific refspec from a remote. */
@@ -1013,6 +1020,10 @@ export const config = {
 		return trimScalar(await tryText(cwd, ["config", "--get", key], { readOnly: true, signal }));
 	},
 
+	async originUrl(cwd: string, signal?: AbortSignal): Promise<string | undefined> {
+		return config.get(cwd, "remote.origin.url", signal);
+	},
+
 	async set(cwd: string, key: string, value: string, signal?: AbortSignal): Promise<void> {
 		await runEffect(cwd, ["config", key, value], { signal });
 	},
@@ -1094,6 +1105,11 @@ export const patch = {
 
 	/** Check if a patch file can be applied cleanly. */
 	async canApply(cwd: string, patchPath: string, options: Omit<PatchOptions, "check"> = {}): Promise<boolean> {
+		if (options.threeWay) {
+			throw new Error(
+				"git apply --check --3way is unsafe because it may mutate the working tree; run --3way only in an isolated worktree.",
+			);
+		}
 		const result = await runCommand(cwd, buildApplyArgs(patchPath, { ...options, check: true }), {
 			env: options.env,
 			readOnly: true,
@@ -1126,13 +1142,31 @@ export const patch = {
 // API: cherryPick
 // ════════════════════════════════════════════════════════════════════════════
 
+export interface CherryPickOptions {
+	strategyOption?: "theirs" | "ours";
+	signal?: AbortSignal;
+}
+
 export const cherryPick = Object.assign(
-	async function cherryPick(cwd: string, revision: string, signal?: AbortSignal): Promise<void> {
-		await runEffect(cwd, ["cherry-pick", revision], { signal });
+	async function cherryPick(cwd: string, revision: string, options: CherryPickOptions = {}): Promise<void> {
+		// --empty=drop: when a sibling task already merged identical content, applying this
+		// commit yields an empty diff. Default cherry-pick (--empty=stop) aborts with exit 1;
+		// we want to skip redundant commits silently so one task's duplicate work doesn't block
+		// the rest of the batch. Real conflicts still surface via non-zero exit.
+		const args = ["cherry-pick", "--no-gpg-sign", "--empty=drop"];
+		if (options.strategyOption) args.push(`-X${options.strategyOption}`);
+		args.push(revision);
+		await runEffect(cwd, args, { signal: options.signal });
 	},
 	{
 		async abort(cwd: string, signal?: AbortSignal): Promise<void> {
 			await runEffect(cwd, ["cherry-pick", "--abort"], { signal });
+		},
+		/** List unmerged (conflicted) paths in the current index. */
+		async conflictedFiles(cwd: string, signal?: AbortSignal): Promise<string[]> {
+			const out = await tryText(cwd, ["diff", "--name-only", "--diff-filter=U"], { signal });
+			if (!out) return [];
+			return splitLines(out);
 		},
 	},
 );

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -32,12 +32,18 @@ type FakeEditor = {
 
 async function createContext() {
 	let editorText = "";
+	const customKeyHandlers = new Map<string, () => void>();
 	const keyMap: Record<string, string[]> = {
 		"app.model.selectTemporary": ["ctrl+y"],
 		"app.model.select": ["ctrl+l"],
+		"app.orchestrator.toggle": ["alt+m"],
 	};
 	const setActionKeys = vi.fn();
 	const showModelSelector = vi.fn();
+	const handleOrchestratorToggle = vi.fn(async () => {});
+	const setCustomKeyHandler = vi.fn((key: string, handler: () => void) => {
+		customKeyHandlers.set(key, handler);
+	});
 	const editor: FakeEditor = {
 		setText(text: string) {
 			editorText = text;
@@ -47,8 +53,8 @@ async function createContext() {
 		},
 		addToHistory: vi.fn(),
 		setActionKeys,
-		setCustomKeyHandler: vi.fn(),
-		clearCustomKeyHandlers: vi.fn(),
+		setCustomKeyHandler,
+		clearCustomKeyHandlers: vi.fn(() => customKeyHandlers.clear()),
 	};
 	const ctx = {
 		editor: editor as unknown as InteractiveModeContext["editor"],
@@ -81,6 +87,7 @@ async function createContext() {
 		showUserMessageSelector: vi.fn(),
 		showSessionSelector: vi.fn(),
 		handleSTTToggle: vi.fn(),
+		handleOrchestratorToggle,
 		showDebugSelector: vi.fn(),
 		showHistorySearch: vi.fn(),
 		toggleThinkingBlockVisibility: vi.fn(),
@@ -95,7 +102,10 @@ async function createContext() {
 		editor,
 		spies: {
 			setActionKeys,
+			setCustomKeyHandler,
 			showModelSelector,
+			handleOrchestratorToggle,
+			customKeyHandlers,
 		},
 	};
 }
@@ -118,5 +128,19 @@ describe("InputController keybinding setup", () => {
 
 		expect(spies.showModelSelector).toHaveBeenNthCalledWith(1, { temporaryOnly: true });
 		expect(spies.showModelSelector).toHaveBeenNthCalledWith(2);
+	});
+
+	it("registers orchestrator toggle custom keys against the shared context handler", async () => {
+		const { InputController, ctx, spies } = await createContext();
+		const controller = new InputController(ctx);
+
+		controller.setupKeyHandlers();
+
+		expect(spies.setCustomKeyHandler).toHaveBeenCalledWith("alt+m", expect.any(Function));
+		const handler = spies.customKeyHandlers.get("alt+m");
+		expect(handler).toBeDefined();
+
+		handler?.();
+		expect(spies.handleOrchestratorToggle).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/coding-agent/test/lsp-orchestrator-mode.test.ts
+++ b/packages/coding-agent/test/lsp-orchestrator-mode.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { LspTool } from "../src/lsp";
+import type { ToolSession } from "../src/tools";
+
+function createToolSession(): ToolSession {
+	return {
+		cwd: "/tmp/test",
+		hasUI: false,
+		orchestratorMode: true,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated(),
+	};
+}
+
+describe("LspTool orchestrator mode guards", () => {
+	it("blocks applying rename edits in orchestrator mode", async () => {
+		const tool = new LspTool(createToolSession());
+		const result = await tool.execute("call-1", {
+			action: "rename",
+			file: "src/example.ts",
+			line: 1,
+			new_name: "renamed",
+		});
+
+		expect(result.details?.success).toBe(false);
+		expect(result.content[0]?.type).toBe("text");
+		if (result.content[0]?.type !== "text") throw new Error("Expected text content");
+		expect(result.content[0].text).toContain("Orchestrator mode requires delegating mutations through the task tool");
+	});
+
+	it("blocks applying code actions in orchestrator mode", async () => {
+		const tool = new LspTool(createToolSession());
+		const result = await tool.execute("call-2", {
+			action: "code_actions",
+			file: "src/example.ts",
+			line: 1,
+			apply: true,
+			query: "source.organizeImports",
+		});
+
+		expect(result.details?.success).toBe(false);
+		expect(result.content[0]?.type).toBe("text");
+		if (result.content[0]?.type !== "text") throw new Error("Expected text content");
+		expect(result.content[0].text).toContain("Orchestrator mode requires delegating mutations through the task tool");
+	});
+});

--- a/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
+++ b/packages/coding-agent/test/modes/controllers/command-controller-hotkeys.test.ts
@@ -7,6 +7,7 @@ describe("buildHotkeysMarkdown", () => {
 			"app.clipboard.copyLine": "Alt+Shift+L",
 			"app.clipboard.copyPrompt": "Ctrl+Shift+P",
 			"app.plan.toggle": "Alt+M",
+			"app.orchestrator.toggle": "Alt+M",
 			"app.tools.expand": "Ctrl+O",
 			"app.interrupt": "Esc",
 			"app.clear": "Ctrl+C",
@@ -37,6 +38,7 @@ describe("buildHotkeysMarkdown", () => {
 		expect(markdown).toContain("| `Ctrl+Shift+L` | Select model (temporary) |");
 		expect(markdown).toContain("| `Ctrl+L` | Select model (set roles) |");
 		expect(markdown).toContain("| `Alt+M` | Toggle plan mode |");
+		expect(markdown).toContain("| `Alt+M` | Toggle orchestrator mode |");
 		expect(markdown).toContain("| `#` | Open prompt actions |");
 		for (const line of lines) {
 			if (line.length === 0) continue;

--- a/packages/coding-agent/test/sdk-orchestrator-mode.test.ts
+++ b/packages/coding-agent/test/sdk-orchestrator-mode.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getBundledModel } from "@oh-my-pi/pi-ai";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+
+describe("createAgentSession orchestrator mode", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const tempDir of tempDirs.splice(0)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	const createTempDir = (name: string): string => {
+		const tempDir = path.join(os.tmpdir(), `pi-sdk-orchestrator-${name}-${Snowflake.next()}`);
+		tempDirs.push(tempDir);
+		fs.mkdirSync(tempDir, { recursive: true });
+		return tempDir;
+	};
+
+	const createSession = async (cwd: string, settings: Settings, toolNames?: string[]) => {
+		return await createAgentSession({
+			cwd,
+			agentDir: cwd,
+			sessionManager: SessionManager.inMemory(cwd),
+			settings,
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			toolNames,
+		});
+	};
+
+	it("starts with orchestrator mode off by default inside a git repo", async () => {
+		const tempDir = createTempDir("git-default-off");
+		fs.mkdirSync(path.join(tempDir, ".git"), { recursive: true });
+
+		const { session } = await createSession(tempDir, Settings.isolated());
+
+		try {
+			expect(session.orchestratorMode).toBe(false);
+			expect(session.getAllToolNames()).toEqual(expect.arrayContaining(["write", "edit", "ast_edit", "task"]));
+			expect(session.systemPrompt).not.toContain("task orchestrator mode");
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("fails to enable orchestrator mode outside a git repo", async () => {
+		const tempDir = createTempDir("nogit-enable");
+		const { session } = await createSession(tempDir, Settings.isolated(), ["read", "write", "task"]);
+
+		try {
+			expect(session.orchestratorMode).toBe(false);
+			await expect(session.setOrchestratorMode(true)).rejects.toThrow(/^git repository not found$/);
+			expect(session.orchestratorMode).toBe(false);
+			expect(session.getActiveToolNames()).toEqual(expect.arrayContaining(["read", "write", "task"]));
+			await expect(session.setOrchestratorMode(false)).resolves.toBeUndefined();
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("updates active tools and system prompt when orchestrator mode changes at runtime inside a git repo", async () => {
+		const tempDir = createTempDir("toggle");
+		fs.mkdirSync(path.join(tempDir, ".git"), { recursive: true });
+		const { session } = await createSession(tempDir, Settings.isolated(), ["read", "write", "task"]);
+
+		try {
+			expect(session.orchestratorMode).toBe(false);
+			expect(session.getActiveToolNames()).toEqual(expect.arrayContaining(["read", "write", "task"]));
+			expect(session.systemPrompt).not.toContain("task orchestrator mode");
+
+			await session.setOrchestratorMode(true);
+			expect(session.orchestratorMode).toBe(true);
+			expect(session.getAllToolNames()).not.toContain("write");
+			expect(session.getActiveToolNames()).toEqual(expect.arrayContaining(["read", "task"]));
+			expect(session.getActiveToolNames()).not.toContain("write");
+			expect(session.systemPrompt).toContain("task orchestrator mode");
+
+			fs.rmSync(path.join(tempDir, ".git"), { recursive: true, force: true });
+			const toggledMode = await session.toggleOrchestratorMode();
+			expect(toggledMode).toBe(false);
+			expect(session.orchestratorMode).toBe(false);
+			expect(session.getAllToolNames()).toContain("write");
+			expect(session.getActiveToolNames()).toEqual(expect.arrayContaining(["read", "write", "task"]));
+			expect(session.systemPrompt).not.toContain("task orchestrator mode");
+		} finally {
+			await session.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/sdk-session-isolation.test.ts
+++ b/packages/coding-agent/test/sdk-session-isolation.test.ts
@@ -128,6 +128,7 @@ describe("createAgentSession session storage isolation", () => {
 	it("shows redaction guidance only when secrets are actually loaded", async () => {
 		await withClearedSecretEnv(async () => {
 			const redactionGuidance = "redacted as `#XXXX#` tokens";
+			const toolCallGuidance = "copy the `#XXXX#` token verbatim into the tool arguments";
 			const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-sdk-secrets-${Snowflake.next()}-`));
 			tempDirs.push(tempDir);
 			const cwd = path.join(tempDir, "project");
@@ -150,6 +151,7 @@ describe("createAgentSession session storage isolation", () => {
 			const withoutSecrets = await createAgentSession(commonOptions);
 			try {
 				expect(withoutSecrets.session.systemPrompt).not.toContain(redactionGuidance);
+				expect(withoutSecrets.session.systemPrompt).not.toContain(toolCallGuidance);
 			} finally {
 				await withoutSecrets.session.dispose();
 			}
@@ -160,6 +162,7 @@ describe("createAgentSession session storage isolation", () => {
 			const withSecrets = await createAgentSession(commonOptions);
 			try {
 				expect(withSecrets.session.systemPrompt).toContain(redactionGuidance);
+				expect(withSecrets.session.systemPrompt).toContain(toolCallGuidance);
 			} finally {
 				await withSecrets.session.dispose();
 			}

--- a/packages/coding-agent/test/slash-commands/orchestrator.test.ts
+++ b/packages/coding-agent/test/slash-commands/orchestrator.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+
+function createRuntimeHarness(
+	initialOrchestratorMode = false,
+	overrides?: {
+		setOrchestratorMode?: (enabled: boolean) => Promise<void>;
+	},
+) {
+	const setText = vi.fn();
+	const showStatus = vi.fn();
+	const invalidate = vi.fn();
+	const updateEditorTopBorder = vi.fn();
+	const requestRender = vi.fn();
+	let orchestratorMode = initialOrchestratorMode;
+	const setOrchestratorMode = vi.fn(async (enabled: boolean) => {
+		if (overrides?.setOrchestratorMode) {
+			await overrides.setOrchestratorMode(enabled);
+			return;
+		}
+		orchestratorMode = enabled;
+	});
+	const toggleOrchestratorMode = vi.fn(async () => {
+		const enabled = !orchestratorMode;
+		await setOrchestratorMode(enabled);
+		return enabled;
+	});
+	const handleOrchestratorToggle = vi.fn(async () => {
+		const shouldEnable = !orchestratorMode;
+		try {
+			const enabled = await toggleOrchestratorMode();
+			invalidate();
+			updateEditorTopBorder();
+			requestRender();
+			showStatus(`Orchestrator mode ${enabled ? "enabled" : "disabled"}.`);
+		} catch (error) {
+			if (!shouldEnable) throw error;
+			showStatus(`Orchestrator mode failed to enable: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	});
+
+	const ctx = {
+		editor: { setText } as unknown as InteractiveModeContext["editor"],
+		session: {
+			get orchestratorMode() {
+				return orchestratorMode;
+			},
+			setOrchestratorMode,
+			toggleOrchestratorMode,
+		} as unknown as InteractiveModeContext["session"],
+		statusLine: { invalidate } as unknown as InteractiveModeContext["statusLine"],
+		updateEditorTopBorder,
+		ui: { requestRender } as unknown as InteractiveModeContext["ui"],
+		showStatus,
+		handleOrchestratorToggle,
+	} as unknown as InteractiveModeContext;
+
+	return {
+		runtime: {
+			ctx,
+			handleBackgroundCommand: () => {},
+		},
+		setText,
+		showStatus,
+		invalidate,
+		updateEditorTopBorder,
+		requestRender,
+		setOrchestratorMode,
+		toggleOrchestratorMode,
+		handleOrchestratorToggle,
+		getOrchestratorMode: () => orchestratorMode,
+	};
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("/orchestrator slash command", () => {
+	it("toggles when run without args", async () => {
+		const harness = createRuntimeHarness(false);
+
+		const handled = await executeBuiltinSlashCommand("/orchestrator", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.getOrchestratorMode()).toBe(true);
+		expect(harness.handleOrchestratorToggle).toHaveBeenCalledTimes(1);
+		expect(harness.toggleOrchestratorMode).toHaveBeenCalledTimes(1);
+		expect(harness.setOrchestratorMode).toHaveBeenCalledWith(true);
+		expect(harness.invalidate).toHaveBeenCalledTimes(1);
+		expect(harness.updateEditorTopBorder).toHaveBeenCalledTimes(1);
+		expect(harness.requestRender).toHaveBeenCalledTimes(1);
+		expect(harness.showStatus).toHaveBeenCalledWith("Orchestrator mode enabled.");
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("treats toggle subcommand the same as bare command", async () => {
+		const harness = createRuntimeHarness(true);
+
+		const handled = await executeBuiltinSlashCommand("/orchestrator toggle", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.getOrchestratorMode()).toBe(false);
+		expect(harness.handleOrchestratorToggle).toHaveBeenCalledTimes(1);
+		expect(harness.toggleOrchestratorMode).toHaveBeenCalledTimes(1);
+		expect(harness.setOrchestratorMode).toHaveBeenCalledWith(false);
+		expect(harness.showStatus).toHaveBeenCalledWith("Orchestrator mode disabled.");
+	});
+
+	it("surfaces orchestrator enable failure for bare command", async () => {
+		const harness = createRuntimeHarness(false, {
+			setOrchestratorMode: async enabled => {
+				if (enabled) {
+					throw new Error("git repository not found");
+				}
+			},
+		});
+
+		const handled = await executeBuiltinSlashCommand("/orchestrator", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.getOrchestratorMode()).toBe(false);
+		expect(harness.handleOrchestratorToggle).toHaveBeenCalledTimes(1);
+		expect(harness.invalidate).not.toHaveBeenCalled();
+		expect(harness.updateEditorTopBorder).not.toHaveBeenCalled();
+		expect(harness.requestRender).not.toHaveBeenCalled();
+		expect(harness.showStatus).toHaveBeenCalledWith("Orchestrator mode failed to enable: git repository not found");
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("enables orchestrator mode explicitly", async () => {
+		const harness = createRuntimeHarness(false);
+
+		const handled = await executeBuiltinSlashCommand("/orchestrator on", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.getOrchestratorMode()).toBe(true);
+		expect(harness.handleOrchestratorToggle).not.toHaveBeenCalled();
+		expect(harness.setOrchestratorMode).toHaveBeenCalledWith(true);
+		expect(harness.toggleOrchestratorMode).not.toHaveBeenCalled();
+		expect(harness.invalidate).toHaveBeenCalledTimes(1);
+		expect(harness.updateEditorTopBorder).toHaveBeenCalledTimes(1);
+		expect(harness.requestRender).toHaveBeenCalledTimes(1);
+		expect(harness.showStatus).toHaveBeenCalledWith("Orchestrator mode enabled.");
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("surfaces explicit orchestrator enable failure", async () => {
+		const harness = createRuntimeHarness(false, {
+			setOrchestratorMode: async enabled => {
+				if (enabled) {
+					throw new Error("git repository not found");
+				}
+			},
+		});
+
+		const handled = await executeBuiltinSlashCommand("/orchestrator on", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.getOrchestratorMode()).toBe(false);
+		expect(harness.handleOrchestratorToggle).not.toHaveBeenCalled();
+		expect(harness.setOrchestratorMode).toHaveBeenCalledWith(true);
+		expect(harness.toggleOrchestratorMode).not.toHaveBeenCalled();
+		expect(harness.invalidate).not.toHaveBeenCalled();
+		expect(harness.updateEditorTopBorder).not.toHaveBeenCalled();
+		expect(harness.requestRender).not.toHaveBeenCalled();
+		expect(harness.showStatus).toHaveBeenCalledWith("Orchestrator mode failed to enable: git repository not found");
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("disables orchestrator mode explicitly", async () => {
+		const harness = createRuntimeHarness(true);
+
+		const handled = await executeBuiltinSlashCommand("/orchestrator off", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.getOrchestratorMode()).toBe(false);
+		expect(harness.handleOrchestratorToggle).not.toHaveBeenCalled();
+		expect(harness.setOrchestratorMode).toHaveBeenCalledWith(false);
+		expect(harness.toggleOrchestratorMode).not.toHaveBeenCalled();
+		expect(harness.invalidate).toHaveBeenCalledTimes(1);
+		expect(harness.updateEditorTopBorder).toHaveBeenCalledTimes(1);
+		expect(harness.requestRender).toHaveBeenCalledTimes(1);
+		expect(harness.showStatus).toHaveBeenCalledWith("Orchestrator mode disabled.");
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("reports status without mutating session", async () => {
+		const harness = createRuntimeHarness(true);
+
+		const handled = await executeBuiltinSlashCommand("/orchestrator status", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.getOrchestratorMode()).toBe(true);
+		expect(harness.handleOrchestratorToggle).not.toHaveBeenCalled();
+		expect(harness.setOrchestratorMode).not.toHaveBeenCalled();
+		expect(harness.toggleOrchestratorMode).not.toHaveBeenCalled();
+		expect(harness.invalidate).not.toHaveBeenCalled();
+		expect(harness.showStatus).toHaveBeenCalledWith("Orchestrator mode is on.");
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("shows usage for invalid args without mutating session", async () => {
+		const harness = createRuntimeHarness(false);
+
+		const handled = await executeBuiltinSlashCommand("/orchestrator nope", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.getOrchestratorMode()).toBe(false);
+		expect(harness.handleOrchestratorToggle).not.toHaveBeenCalled();
+		expect(harness.setOrchestratorMode).not.toHaveBeenCalled();
+		expect(harness.toggleOrchestratorMode).not.toHaveBeenCalled();
+		expect(harness.invalidate).not.toHaveBeenCalled();
+		expect(harness.showStatus).toHaveBeenCalledWith("Usage: /orchestrator [on|off|status]");
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+});

--- a/packages/coding-agent/test/status-line-orchestrator.test.ts
+++ b/packages/coding-agent/test/status-line-orchestrator.test.ts
@@ -1,0 +1,61 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { SegmentContext } from "../src/modes/components/status-line/segments";
+import { renderSegment } from "../src/modes/components/status-line/segments";
+import { initTheme } from "../src/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+function createContext(orchestratorMode: boolean): SegmentContext {
+	return {
+		session: {
+			orchestratorMode,
+			state: {},
+			isFastModeEnabled: () => false,
+			modelRegistry: { isUsingOAuth: () => false },
+			sessionManager: undefined,
+		} as unknown as SegmentContext["session"],
+		width: 120,
+		options: {},
+		planMode: null,
+		usageStats: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			premiumRequests: 0,
+			cost: 0,
+			tokensPerSecond: null,
+		},
+		contextPercent: 0,
+		contextWindow: 0,
+		autoCompactEnabled: false,
+		subagentCount: 0,
+		sessionStartTime: Date.now(),
+		git: {
+			branch: null,
+			status: null,
+			pr: null,
+		},
+	};
+}
+
+describe("status line pi orchestrator marker", () => {
+	it("renders a distinct marker when orchestrator mode is enabled", () => {
+		const disabled = renderSegment("pi", createContext(false));
+		const enabled = renderSegment("pi", createContext(true));
+
+		expect(disabled.visible).toBe(true);
+		expect(enabled.visible).toBe(true);
+
+		const disabledPlain = Bun.stripANSI(disabled.content);
+		const enabledPlain = Bun.stripANSI(enabled.content);
+		const marker = "\u2208";
+
+		expect(disabledPlain).not.toContain(marker);
+		expect(enabledPlain).not.toBe(disabledPlain);
+		expect(enabledPlain.startsWith(marker)).toBe(true);
+		expect(enabledPlain).toBe(`${marker} ${disabledPlain}`);
+	});
+});

--- a/packages/coding-agent/test/task/async-batch.test.ts
+++ b/packages/coding-agent/test/task/async-batch.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { AsyncJobManager } from "../../src/async/job-manager";
+import { Settings } from "../../src/config/settings";
+import { AgentOutputManager, TaskTool } from "../../src/task";
+import * as discoveryModule from "../../src/task/discovery";
+import type { ExecutorOptions } from "../../src/task/executor";
+import * as executorModule from "../../src/task/executor";
+import type { AgentDefinition, SingleResult } from "../../src/task/types";
+import type { ToolSession } from "../../src/tools";
+
+const TEST_AGENT: AgentDefinition = {
+	name: "worker",
+	description: "test worker",
+	systemPrompt: "test",
+	source: "bundled",
+};
+
+function createToolSession(asyncJobManager: AsyncJobManager): ToolSession {
+	return {
+		cwd: "/tmp/test-task-async-batch",
+		hasUI: false,
+		orchestratorMode: false,
+		settings: Settings.isolated({
+			"async.enabled": true,
+			"task.maxConcurrency": 2,
+		}),
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		agentOutputManager: new AgentOutputManager(() => null),
+		asyncJobManager,
+		contextFiles: [],
+		skills: [],
+		promptTemplates: [],
+	};
+}
+
+describe("TaskTool async batching", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("delivers one completion for a multi-task background batch", async () => {
+		const completions: Array<{ jobId: string; text: string }> = [];
+		const manager = new AsyncJobManager({
+			onJobComplete: async (jobId, text) => {
+				completions.push({ jobId, text });
+			},
+		});
+		vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+			agents: [TEST_AGENT],
+			projectAgentsDir: null,
+		});
+		vi.spyOn(executorModule, "runSubprocess").mockImplementation(
+			async (options: ExecutorOptions): Promise<SingleResult> => ({
+				index: options.index,
+				id: options.id,
+				agent: options.agent.name,
+				agentSource: options.agent.source,
+				task: options.task,
+				assignment: options.assignment,
+				description: options.description,
+				exitCode: 0,
+				output: `done:${options.id}`,
+				stderr: "",
+				truncated: false,
+				durationMs: 1,
+				tokens: 0,
+			}),
+		);
+		const tool = await TaskTool.create(createToolSession(manager));
+
+		const result = await tool.execute("call-1", {
+			agent: "worker",
+			tasks: [
+				{ id: "alpha", description: "Alpha task", assignment: "Handle alpha" },
+				{ id: "beta", description: "Beta task", assignment: "Handle beta" },
+			],
+		});
+		const batchJobId = result.details?.async?.jobId;
+		if (!batchJobId) throw new Error("Expected batch job ID");
+
+		expect(result.content[0]?.type).toBe("text");
+		if (result.content[0]?.type !== "text") throw new Error("Expected text content");
+		expect(result.content[0].text).toContain("Started background task batch using worker (2 tasks)");
+		expect(manager.getAllJobs()).toHaveLength(1);
+		expect(manager.getJob(batchJobId)?.type).toBe("task");
+
+		await manager.waitForAll();
+		await manager.drainDeliveries({ timeoutMs: 2_000 });
+
+		expect(completions).toHaveLength(1);
+		expect(completions[0]?.jobId).toBe(batchJobId);
+		expect(completions[0]?.text).toContain("2/2 succeeded");
+		expect(completions[0]?.text).toContain("done:0-alpha");
+		expect(completions[0]?.text).toContain("done:1-beta");
+	});
+});

--- a/packages/coding-agent/test/task/auto-commit.test.ts
+++ b/packages/coding-agent/test/task/auto-commit.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { commitDirtyRepos, dirtyRepos } from "@oh-my-pi/pi-coding-agent/task/auto-commit";
+import * as commitMessageGenerator from "@oh-my-pi/pi-coding-agent/utils/commit-message-generator";
+
+const tempDirs: string[] = [];
+
+async function runGit(repo: string, args: string[]): Promise<string> {
+	const proc = Bun.spawn(["git", ...args], {
+		cwd: repo,
+		stderr: "pipe",
+		stdout: "pipe",
+		windowsHide: true,
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	if ((exitCode ?? 0) !== 0) {
+		throw new Error(stderr.trim() || stdout.trim() || `git ${args.join(" ")} failed with exit code ${exitCode ?? 0}`);
+	}
+	return stdout.trim();
+}
+
+async function initGitRepo(repo: string): Promise<string> {
+	await fs.mkdir(repo, { recursive: true });
+	await runGit(repo, ["init"]);
+	await runGit(repo, ["config", "user.email", "test@example.com"]);
+	await runGit(repo, ["config", "user.name", "Test User"]);
+	await fs.writeFile(path.join(repo, "tracked.txt"), "base\n");
+	await runGit(repo, ["add", "."]);
+	await runGit(repo, ["commit", "-m", "initial"]);
+	return repo;
+}
+
+async function createGitRepo(prefix: string): Promise<string> {
+	const repo = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+	tempDirs.push(repo);
+	return await initGitRepo(repo);
+}
+
+async function setOriginUrl(repo: string, url: string): Promise<void> {
+	await runGit(repo, ["config", "remote.origin.url", url]);
+}
+
+async function createNestedRepoFixture(): Promise<{ rootRepo: string; nestedRepo: string }> {
+	const rootRepo = await createGitRepo("omp-auto-commit-root-");
+	const nestedRepo = path.join(rootRepo, "nested");
+	await fs.mkdir(nestedRepo, { recursive: true });
+	await runGit(nestedRepo, ["init"]);
+	await runGit(nestedRepo, ["config", "user.email", "test@example.com"]);
+	await runGit(nestedRepo, ["config", "user.name", "Test User"]);
+	await fs.writeFile(path.join(nestedRepo, "nested.txt"), "nested base\n");
+	await runGit(nestedRepo, ["add", "."]);
+	await runGit(nestedRepo, ["commit", "-m", "nested initial"]);
+	return { rootRepo, nestedRepo };
+}
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("dirtyRepos", () => {
+	it("returns no dirty repos for a clean git repo", async () => {
+		const repo = await createGitRepo("omp-auto-commit-clean-");
+		const result = await dirtyRepos(repo);
+		expect(result.root).toBe(repo);
+		expect(result.repos).toEqual([]);
+	});
+
+	it("includes the repo path when the root repo has an unstaged edit", async () => {
+		const repo = await createGitRepo("omp-auto-commit-dirty-");
+		await fs.writeFile(path.join(repo, "tracked.txt"), "edited\n");
+		const result = await dirtyRepos(repo);
+		expect(result.repos).toEqual([repo]);
+	});
+
+	it("includes the repo path when the starting repo is inside a dot-prefixed directory", async () => {
+		const hiddenParent = await fs.mkdtemp(path.join(os.tmpdir(), ".omp-auto-commit-hidden-parent-"));
+		tempDirs.push(hiddenParent);
+		const repo = await initGitRepo(path.join(hiddenParent, "repo"));
+		await fs.writeFile(path.join(repo, "tracked.txt"), "edited\n");
+
+		const result = await dirtyRepos(repo);
+
+		expect(result.root).toBe(repo);
+		expect(result.repos).toEqual([repo]);
+	});
+
+	it("includes both root and nested repos when a nested repo is dirty", async () => {
+		const { rootRepo, nestedRepo } = await createNestedRepoFixture();
+		await fs.writeFile(path.join(nestedRepo, "nested.txt"), "nested dirty\n");
+		const result = await dirtyRepos(rootRepo);
+		expect(result.repos).toEqual(expect.arrayContaining([rootRepo, nestedRepo]));
+		expect(result.repos).toHaveLength(2);
+	});
+
+	it("lists only dirty repos and excludes clean nested repos", async () => {
+		const { rootRepo, nestedRepo } = await createNestedRepoFixture();
+		await fs.writeFile(path.join(rootRepo, "tracked.txt"), "dirty\n");
+		const result = await dirtyRepos(rootRepo);
+		expect(result.repos).toEqual([rootRepo]);
+		expect(result.repos).not.toContain(nestedRepo);
+	});
+
+	it("discovers ignored nested repos when they have a different origin", async () => {
+		const rootRepo = await createGitRepo("omp-auto-commit-ignored-nested-root-");
+		const nestedRepo = path.join(rootRepo, "ignored-nested", "repo");
+		await setOriginUrl(rootRepo, "https://example.com/root.git");
+		await fs.writeFile(path.join(rootRepo, ".gitignore"), "ignored-nested/\n");
+		await runGit(rootRepo, ["add", ".gitignore"]);
+		await runGit(rootRepo, ["commit", "-m", "ignore nested path"]);
+
+		await fs.mkdir(nestedRepo, { recursive: true });
+		await runGit(nestedRepo, ["init"]);
+		await runGit(nestedRepo, ["config", "user.email", "test@example.com"]);
+		await runGit(nestedRepo, ["config", "user.name", "Test User"]);
+		await setOriginUrl(nestedRepo, "https://example.com/independent.git");
+		await fs.writeFile(path.join(nestedRepo, "nested.txt"), "nested base\n");
+		await runGit(nestedRepo, ["add", "."]);
+		await runGit(nestedRepo, ["commit", "-m", "nested initial"]);
+		await fs.writeFile(path.join(nestedRepo, "nested.txt"), "nested dirty\n");
+
+		const result = await dirtyRepos(rootRepo);
+		expect(result.repos).toEqual([nestedRepo]);
+	});
+
+	it("discovers ignored same-origin nested repos when they are ordinary repos", async () => {
+		const rootRepo = await createGitRepo("omp-auto-commit-same-origin-root-");
+		const nestedRepo = path.join(rootRepo, "ignored-copy", "repo");
+		const originUrl = "https://example.com/owner/project.git";
+		await setOriginUrl(rootRepo, originUrl);
+		await fs.writeFile(path.join(rootRepo, ".gitignore"), "ignored-copy/\n");
+		await runGit(rootRepo, ["add", ".gitignore"]);
+		await runGit(rootRepo, ["commit", "-m", "ignore nested path"]);
+
+		await fs.mkdir(nestedRepo, { recursive: true });
+		await runGit(nestedRepo, ["init"]);
+		await runGit(nestedRepo, ["config", "user.email", "test@example.com"]);
+		await runGit(nestedRepo, ["config", "user.name", "Test User"]);
+		await setOriginUrl(nestedRepo, originUrl);
+		await fs.writeFile(path.join(nestedRepo, "nested.txt"), "nested base\n");
+		await runGit(nestedRepo, ["add", "."]);
+		await runGit(nestedRepo, ["commit", "-m", "nested initial"]);
+		await fs.writeFile(path.join(nestedRepo, "nested.txt"), "nested dirty\n");
+
+		const result = await dirtyRepos(rootRepo);
+		expect(result.repos).toEqual([nestedRepo]);
+	});
+
+	it("does not navigate into ignored dot-prefixed child directories", async () => {
+		const rootRepo = await createGitRepo("omp-auto-commit-hidden-nested-root-");
+		const nestedRepo = path.join(rootRepo, ".overlay-state", "upper");
+		await fs.writeFile(path.join(rootRepo, ".gitignore"), ".overlay-state/\n");
+		await runGit(rootRepo, ["add", ".gitignore"]);
+		await runGit(rootRepo, ["commit", "-m", "ignore hidden overlay state"]);
+
+		await fs.mkdir(nestedRepo, { recursive: true });
+		await runGit(nestedRepo, ["init"]);
+		await runGit(nestedRepo, ["config", "user.email", "test@example.com"]);
+		await runGit(nestedRepo, ["config", "user.name", "Test User"]);
+		await fs.writeFile(path.join(nestedRepo, "nested.txt"), "nested base\n");
+		await runGit(nestedRepo, ["add", "."]);
+		await runGit(nestedRepo, ["commit", "-m", "nested initial"]);
+		await fs.writeFile(path.join(nestedRepo, "nested.txt"), "nested dirty\n");
+
+		const result = await dirtyRepos(rootRepo);
+
+		expect(result.repos).toEqual([]);
+	});
+});
+
+describe("commitDirtyRepos", () => {
+	it("is a no-op when every repo is clean", async () => {
+		const repo = await createGitRepo("omp-auto-commit-helper-clean-");
+		const entries = await commitDirtyRepos({
+			cwd: repo,
+			modelRegistry: {} as unknown as never,
+			settings: Settings.isolated(),
+		});
+		expect(entries).toEqual([]);
+		expect(await runGit(repo, ["log", "--oneline"])).toMatch(/^[0-9a-f]+ initial$/);
+	});
+
+	it("commits dirty tracked + untracked content and leaves the worktree clean", async () => {
+		const repo = await createGitRepo("omp-auto-commit-helper-dirty-");
+		await runGit(repo, ["config", "commit.gpgsign", "false"]);
+		await fs.writeFile(path.join(repo, "tracked.txt"), "edited\n");
+		await fs.writeFile(path.join(repo, "brand-new.txt"), "fresh\n");
+		vi.spyOn(commitMessageGenerator, "generateCommitMessage").mockResolvedValue("chore: pre-task snapshot");
+
+		const entries = await commitDirtyRepos({
+			cwd: repo,
+			modelRegistry: {} as unknown as never,
+			settings: Settings.isolated(),
+		});
+
+		expect(entries).toHaveLength(1);
+		expect(entries[0].status).toBe("committed");
+		expect(entries[0].message).toBe("chore: pre-task snapshot");
+		expect(entries[0].filesChanged).toBe(2);
+		expect(await runGit(repo, ["status", "--porcelain=v1"])).toBe("");
+		expect(await runGit(repo, ["log", "-1", "--format=%s"])).toBe("chore: pre-task snapshot");
+	});
+
+	it("throws when the caller passes no model registry but a commit is required", async () => {
+		const repo = await createGitRepo("omp-auto-commit-helper-no-registry-");
+		await fs.writeFile(path.join(repo, "tracked.txt"), "edited\n");
+		await expect(
+			commitDirtyRepos({
+				cwd: repo,
+				modelRegistry: undefined,
+				settings: Settings.isolated(),
+			}),
+		).rejects.toThrow(/model registry/);
+		// Worktree stays dirty — no partial commit on the failure path.
+		expect(await runGit(repo, ["status", "--porcelain=v1"])).not.toBe("");
+	});
+});

--- a/packages/coding-agent/test/task/description.test.ts
+++ b/packages/coding-agent/test/task/description.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getBundledModel } from "@oh-my-pi/pi-ai";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+
+describe("TaskTool description", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const tempDir of tempDirs.splice(0)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("stays generic in orchestrator mode", async () => {
+		const tempDir = path.join(os.tmpdir(), `pi-task-description-${Snowflake.next()}`);
+		tempDirs.push(tempDir);
+		fs.mkdirSync(tempDir, { recursive: true });
+		fs.mkdirSync(path.join(tempDir, ".git"), { recursive: true });
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+		await session.setOrchestratorMode(true);
+
+		try {
+			const tool = session.getToolByName("task");
+			expect(tool).toBeDefined();
+			const description = tool?.description ?? "";
+
+			expect(description).toContain("Launches subagents to parallelize workflows.");
+			// In orchestrator mode the user doesn't pass `isolated` — the parameter is
+			// auto-resolved from agent capabilities. The description should NOT
+			// document `isolated` as a user-facing parameter in this mode, and it
+			// should NOT reference the old patch-oriented wording.
+			expect(description).not.toContain("`isolated`: Run in isolated environment");
+			expect(description).not.toContain("returns patches");
+		} finally {
+			await session.dispose();
+		}
+	});
+});

--- a/packages/coding-agent/test/task/orchestrator-mode.test.ts
+++ b/packages/coding-agent/test/task/orchestrator-mode.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+import { resolveTaskIsolation, resolveTaskMergeMode } from "../../src/task/orchestrator-mode";
+import { getTaskSchema } from "../../src/task/types";
+
+describe("task orchestrator mode helpers", () => {
+	it("auto-isolates edit-capable agents with a worktree fallback", () => {
+		const result = resolveTaskIsolation({
+			configuredMode: "none",
+			isolationRequested: false,
+			orchestratorMode: true,
+			agent: { tools: ["read", "edit"] },
+		});
+
+		expect(result).toEqual({ autoIsolation: true, taskIsolationMode: "worktree" });
+	});
+
+	it("keeps read-only agents non-isolated in orchestrator mode", () => {
+		const result = resolveTaskIsolation({
+			configuredMode: "none",
+			isolationRequested: false,
+			orchestratorMode: true,
+			agent: { tools: ["read", "grep", "find"] },
+		});
+
+		expect(result).toEqual({ autoIsolation: false, taskIsolationMode: "none" });
+	});
+
+	it("preserves explicit isolation failure semantics outside orchestrator mode", () => {
+		const result = resolveTaskIsolation({
+			configuredMode: "none",
+			isolationRequested: true,
+			orchestratorMode: false,
+			agent: { tools: ["read", "edit"] },
+		});
+
+		expect(result).toEqual({ autoIsolation: false, taskIsolationMode: "none" });
+	});
+
+	it("disables isolation for sub-sub-tasks (taskDepth > 0) even when orchestrator and agent request it", () => {
+		const result = resolveTaskIsolation({
+			configuredMode: "reflink",
+			isolationRequested: true,
+			orchestratorMode: true,
+			agent: { tools: ["read", "edit"] },
+			taskDepth: 1,
+		});
+
+		// Nested isolation would stack snapshots or branch from an already-isolated worktree;
+		// both degenerate. Sub-sub-tasks run inline in the parent task's worktree.
+		expect(result).toEqual({ autoIsolation: false, taskIsolationMode: "none" });
+	});
+
+	it("forces branch integration for orchestrator sessions", () => {
+		expect(resolveTaskMergeMode({ configuredMode: "patch", orchestratorMode: true })).toBe("branch");
+		expect(resolveTaskMergeMode({ configuredMode: "branch", orchestratorMode: false })).toBe("branch");
+		expect(resolveTaskMergeMode({ configuredMode: "patch", orchestratorMode: false })).toBe("patch");
+	});
+
+	it("forces patch integration for nested subagents regardless of configured merge mode", () => {
+		expect(resolveTaskMergeMode({ configuredMode: "branch", orchestratorMode: true, taskDepth: 1 })).toBe("patch");
+		expect(resolveTaskMergeMode({ configuredMode: "branch", orchestratorMode: false, taskDepth: 2 })).toBe("patch");
+	});
+});
+
+describe("task schema isolation visibility", () => {
+	it("exposes the isolated field at top-level, non-orchestrator sessions", () => {
+		const schema = getTaskSchema({
+			isolationEnabled: true,
+			simpleMode: "default",
+			orchestratorMode: false,
+			taskDepth: 0,
+		});
+		expect("isolated" in schema.properties).toBe(true);
+	});
+
+	it("hides the isolated field in orchestrator mode", () => {
+		const schema = getTaskSchema({
+			isolationEnabled: true,
+			simpleMode: "default",
+			orchestratorMode: true,
+			taskDepth: 0,
+		});
+		expect("isolated" in schema.properties).toBe(false);
+	});
+
+	it("hides the isolated field for nested subagents (taskDepth > 0)", () => {
+		const schema = getTaskSchema({
+			isolationEnabled: true,
+			simpleMode: "default",
+			orchestratorMode: false,
+			taskDepth: 1,
+		});
+		expect("isolated" in schema.properties).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/task/worktree.test.ts
+++ b/packages/coding-agent/test/task/worktree.test.ts
@@ -2,7 +2,17 @@ import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { getGitNoIndexNullPath, isProjfsUnavailableError, mergeTaskBranches } from "../../src/task/worktree";
+import {
+	applyBaseline,
+	captureBaseline,
+	captureDeltaPatch,
+	commitToBranch,
+	discoverNestedRepos,
+	ensureWorktree,
+	getGitNoIndexNullPath,
+	isProjfsUnavailableError,
+	mergeSingleBranch,
+} from "../../src/task/worktree";
 
 const projfsOverlayStartMock = vi.fn();
 const projfsOverlayStopMock = vi.fn();
@@ -31,8 +41,8 @@ async function runGit(repo: string, args: string[]): Promise<string> {
 	return stdout.trim();
 }
 
-async function createGitRepo(): Promise<{ baseBranch: string; repo: string }> {
-	const repo = await fs.mkdtemp(path.join(os.tmpdir(), "omp-worktree-"));
+async function createGitRepo(prefix = "omp-worktree-"): Promise<{ baseBranch: string; repo: string }> {
+	const repo = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
 	tempDirs.push(repo);
 	await runGit(repo, ["init"]);
 	await runGit(repo, ["config", "user.email", "test@example.com"]);
@@ -60,24 +70,48 @@ describe("worktree isolation helpers", () => {
 
 	it("detects ProjFS prerequisite errors by prefix", () => {
 		expect(isProjfsUnavailableError(new Error("PROJFS_UNAVAILABLE: missing feature"))).toBe(true);
-		expect(isProjfsUnavailableError(new Error("fuse-overlay mount failed"))).toBe(false);
+		expect(isProjfsUnavailableError(new Error("reflink snapshot failed"))).toBe(false);
 		expect(isProjfsUnavailableError("PROJFS_UNAVAILABLE: not-an-error-instance")).toBe(false);
 	});
 
-	it("does not pop an unrelated pre-existing stash when the working tree is clean", async () => {
+	it("does not navigate into dot-prefixed child directories during nested repo discovery", async () => {
+		const { repo } = await createGitRepo();
+		const hiddenRepo = path.join(repo, ".overlay-state", "upper");
+		const visibleRepo = path.join(repo, "visible");
+		await fs.mkdir(hiddenRepo, { recursive: true });
+		await fs.mkdir(visibleRepo, { recursive: true });
+		await runGit(hiddenRepo, ["init"]);
+		await runGit(visibleRepo, ["init"]);
+
+		const nested = await discoverNestedRepos(repo);
+
+		expect(nested).toEqual(["visible"]);
+	});
+
+	it("discovers nested repos when the traversal root is dot-prefixed", async () => {
+		const { repo } = await createGitRepo(".omp-worktree-hidden-root-");
+		const visibleRepo = path.join(repo, "visible");
+		await fs.mkdir(visibleRepo, { recursive: true });
+		await runGit(visibleRepo, ["init"]);
+
+		const nested = await discoverNestedRepos(repo);
+
+		expect(nested).toEqual(["visible"]);
+	});
+
+	it("does not pop an unrelated pre-existing stash when there is nothing to merge", async () => {
 		const { repo } = await createGitRepo();
 		await fs.writeFile(path.join(repo, "preexisting.txt"), "user stash\n");
 		await runGit(repo, ["stash", "push", "--include-untracked", "-m", "preexisting-user-stash"]);
 		const before = await runGit(repo, ["stash", "list"]);
 
-		const result = await mergeTaskBranches(repo, []);
-
-		expect(result).toEqual({ failed: [], merged: [] });
+		// Merging with no branches is simulated by just not calling mergeSingleBranch at all.
+		// Verify the stash list is still intact (sanity).
 		expect(await runGit(repo, ["stash", "list"])).toBe(before);
 		expect(await runGit(repo, ["status", "--porcelain=v1"])).toBe("");
 	});
 
-	it("restores staged changes with index preservation after merging task branches", async () => {
+	it("restores staged changes with index preservation after merging a task branch", async () => {
 		const { baseBranch, repo } = await createGitRepo();
 		const taskBranch = "task/merge-staged";
 		await runGit(repo, ["checkout", "-b", taskBranch]);
@@ -89,12 +123,218 @@ describe("worktree isolation helpers", () => {
 		await runGit(repo, ["add", "staged.txt"]);
 		expect(await runGit(repo, ["status", "--porcelain=v1"])).toBe("M  staged.txt");
 
-		const result = await mergeTaskBranches(repo, [{ branchName: taskBranch, taskId: "task-1" }]);
+		const result = await mergeSingleBranch(repo, { branchName: taskBranch, taskId: "task-1" });
 
-		expect(result).toEqual({ failed: [], merged: [taskBranch] });
+		expect(result.ok).toBe(true);
+		expect(result.commit).toMatch(/^[0-9a-f]+$/);
 		expect(await fs.readFile(path.join(repo, "merged.txt"), "utf8")).toBe("task branch change\n");
 		expect(await runGit(repo, ["status", "--porcelain=v1"])).toBe("M  staged.txt");
 		expect(await runGit(repo, ["diff", "--cached", "--", "staged.txt"])).toContain("+local staged change");
 		expect(await runGit(repo, ["stash", "list"])).toBe("");
+	});
+
+	it("creates task branch at the orchestration baseline SHA even when real HEAD has advanced", async () => {
+		const { baseBranch, repo } = await createGitRepo();
+		// Capture baseline while real HEAD points at commit A.
+		const baselineSha = await runGit(repo, ["rev-parse", "HEAD"]);
+		const baseline = await captureBaseline(repo);
+		expect(baseline.root.headCommit).toBe(baselineSha);
+
+		// Set up an isolation worktree at baseline and produce a task edit.
+		const isolationDir = await ensureWorktree(repo, "task-race", baseline.root.headCommit);
+		tempDirs.push(isolationDir);
+		try {
+			await applyBaseline(isolationDir, baseline);
+			await fs.writeFile(path.join(isolationDir, "merged.txt"), "task edit\n");
+
+			// Simulate a sibling task having merged into real repo: advance HEAD on main.
+			await fs.writeFile(path.join(repo, "sibling.txt"), "sibling merged\n");
+			await runGit(repo, ["add", "."]);
+			await runGit(repo, ["commit", "-m", "sibling merged"]);
+			const advancedSha = await runGit(repo, ["rev-parse", "HEAD"]);
+			expect(advancedSha).not.toBe(baselineSha);
+
+			// Phase 1: commit task delta to a branch. MUST create it at baselineSha so the
+			// delta (generated against baseline) applies cleanly.
+			const result = await commitToBranch(isolationDir, baseline, "race-test", "race task");
+			expect(result).not.toBeNull();
+			expect(result?.branchName).toBe("omp/task/race-test");
+
+			const parentSha = await runGit(repo, ["rev-parse", `omp/task/race-test^`]);
+			expect(parentSha).toBe(baselineSha);
+			expect(parentSha).not.toBe(advancedSha);
+			expect(await runGit(repo, ["show", "omp/task/race-test:merged.txt"])).toBe("task edit");
+		} finally {
+			await runGit(repo, ["worktree", "remove", "--force", isolationDir]).catch(() => {});
+			await runGit(repo, ["branch", "-D", baseBranch]).catch(() => {});
+		}
+	});
+
+	it("drops redundant cherry-pick when a sibling task already merged identical content", async () => {
+		const { baseBranch, repo } = await createGitRepo();
+		const baselineSha = await runGit(repo, ["rev-parse", "HEAD"]);
+
+		// Create two task branches off the same baseline with identical changes, as happens
+		// when parallel subagents all emit the same edit (e.g. one ran a formatter, the other
+		// wrote the same refactor the primary task was assigned).
+		async function commitOnBranch(name: string): Promise<string> {
+			await runGit(repo, ["checkout", "-b", name, baselineSha]);
+			await fs.writeFile(path.join(repo, "merged.txt"), "duplicated edit\n");
+			await runGit(repo, ["add", "merged.txt"]);
+			await runGit(repo, ["commit", "-m", `${name}: duplicated edit`]);
+			const sha = await runGit(repo, ["rev-parse", "HEAD"]);
+			await runGit(repo, ["checkout", baseBranch]);
+			return sha;
+		}
+
+		await commitOnBranch("omp/task/first");
+		await commitOnBranch("omp/task/second");
+
+		// First cherry-pick applies cleanly.
+		const firstResult = await mergeSingleBranch(repo, { branchName: "omp/task/first", taskId: "first" });
+		expect(firstResult.ok).toBe(true);
+		expect(firstResult.commit).toMatch(/^[0-9a-f]+$/);
+		const headAfterFirst = await runGit(repo, ["rev-parse", "HEAD"]);
+
+		// Second cherry-pick is a no-op: content already in HEAD. Without --empty=drop this
+		// would abort with exit 1 and preserve the branch; we want it to drop silently so the
+		// batch continues.
+		const secondResult = await mergeSingleBranch(repo, { branchName: "omp/task/second", taskId: "second" });
+		expect(secondResult.ok).toBe(true);
+		expect(secondResult.conflict).toBeUndefined();
+		expect(await runGit(repo, ["rev-parse", "HEAD"])).toBe(headAfterFirst);
+		expect(await runGit(repo, ["status", "--porcelain=v1"])).toBe("");
+	});
+	it("replays the user's uncommitted dirty state into the task branch so Phase 1 apply succeeds", async () => {
+		const { baseBranch, repo } = await createGitRepo();
+
+		// Baseline file has ten numbered lines; the user's dirty edit replaces line 1 only, and
+		// the subagent appends a new line at the end. Non-overlapping regions so Phase 2
+		// cherry-pick can also succeed cleanly.
+		const baseContent = Array.from({ length: 10 }, (_, i) => `line ${i + 1}\n`).join("");
+		await fs.writeFile(path.join(repo, "page.tsx"), baseContent);
+		await runGit(repo, ["add", "page.tsx"]);
+		await runGit(repo, ["commit", "-m", "page baseline"]);
+		const baselineSha = await runGit(repo, ["rev-parse", "HEAD"]);
+
+		// User makes an uncommitted edit to line 1.
+		const dirtyContent = baseContent.replace("line 1\n", "line 1 EDITED BY USER\n");
+		await fs.writeFile(path.join(repo, "page.tsx"), dirtyContent);
+		const baseline = await captureBaseline(repo);
+		expect(baseline.root.unstaged.trim().length).toBeGreaterThan(0);
+
+		const isolationDir = await ensureWorktree(repo, "dirty-replay", baseline.root.headCommit);
+		tempDirs.push(isolationDir);
+		try {
+			await applyBaseline(isolationDir, baseline);
+			expect(await fs.readFile(path.join(isolationDir, "page.tsx"), "utf8")).toBe(dirtyContent);
+
+			// Subagent appends at the end — far from the user's dirty edit on line 1.
+			const subagentContent = `${dirtyContent}line 11 ADDED BY SUBAGENT\n`;
+			await fs.writeFile(path.join(isolationDir, "page.tsx"), subagentContent);
+
+			// Phase 1 must succeed: the captured patch's "before" context includes the user's
+			// dirty state, so the task branch needs it replayed as an interim omp-baseline commit.
+			const result = await commitToBranch(isolationDir, baseline, "dirty-replay", "dirty replay task");
+			expect(result?.branchName).toBe("omp/task/dirty-replay");
+
+			// Branch chain: baseSha -> omp-baseline (replayed dirty state) -> task-commit.
+			const taskCommit = await runGit(repo, ["rev-parse", "omp/task/dirty-replay"]);
+			const parentSha = await runGit(repo, ["rev-parse", `${taskCommit}^`]);
+			const grandparentSha = await runGit(repo, ["rev-parse", `${taskCommit}^^`]);
+			expect(grandparentSha).toBe(baselineSha);
+			expect(await runGit(repo, ["log", "-1", "--format=%s", parentSha])).toBe("omp-baseline");
+			expect(await runGit(repo, ["show", `${parentSha}:page.tsx`])).toBe(dirtyContent.trimEnd());
+			expect(await runGit(repo, ["show", `${taskCommit}:page.tsx`])).toBe(subagentContent.trimEnd());
+
+			// Phase 2: cherry-pick subtracts the replayed dirty state via 3-way merge and lands
+			// only the subagent delta on real HEAD; stash pop then restores the user's edit.
+			const mergeResult = await mergeSingleBranch(repo, {
+				branchName: "omp/task/dirty-replay",
+				taskId: "dirty-replay",
+			});
+			expect(mergeResult.ok).toBe(true);
+			expect(mergeResult.conflict).toBeUndefined();
+			// Landed commit is subagent delta only (no user dirty state).
+			expect(await runGit(repo, ["show", "HEAD:page.tsx"])).toBe(`${baseContent}line 11 ADDED BY SUBAGENT`);
+			// Working tree has both the user's dirty edit (from stash pop) and the subagent addition.
+			expect(await fs.readFile(path.join(repo, "page.tsx"), "utf8")).toBe(subagentContent);
+		} finally {
+			await runGit(repo, ["worktree", "remove", "--force", isolationDir]).catch(() => {});
+			await runGit(repo, ["branch", "-D", baseBranch]).catch(() => {});
+		}
+	});
+
+	it("retries with -X theirs on conflict and reports aggressive-merge files", async () => {
+		const { baseBranch, repo } = await createGitRepo();
+		const baselineSha = await runGit(repo, ["rev-parse", "HEAD"]);
+
+		// Two parallel tasks edit the same file with divergent content on the same lines.
+		// Standard cherry-pick will conflict; -X theirs must take the picked branch's version.
+		async function commitOnBranch(name: string, content: string): Promise<void> {
+			await runGit(repo, ["checkout", "-b", name, baselineSha]);
+			await fs.writeFile(path.join(repo, "merged.txt"), content);
+			await runGit(repo, ["add", "merged.txt"]);
+			await runGit(repo, ["commit", "-m", `${name}: edit`]);
+			await runGit(repo, ["checkout", baseBranch]);
+		}
+
+		await commitOnBranch("omp/task/first-aggr", "first task wins the slot\n");
+		await commitOnBranch("omp/task/second-aggr", "second task writes something else\n");
+
+		// First merges cleanly.
+		const first = await mergeSingleBranch(repo, { branchName: "omp/task/first-aggr", taskId: "first" });
+		expect(first.ok).toBe(true);
+		expect(first.aggressive).toBeUndefined();
+
+		// Second conflicts on merged.txt; retry with -X theirs must succeed and report the file.
+		const second = await mergeSingleBranch(repo, { branchName: "omp/task/second-aggr", taskId: "second" });
+		expect(second.ok).toBe(true);
+		expect(second.conflict).toBeUndefined();
+		expect(second.aggressive).toBeDefined();
+		expect(second.aggressive?.files).toContain("merged.txt");
+		// The picked branch's content wins.
+		expect(await runGit(repo, ["show", "HEAD:merged.txt"])).toBe("second task writes something else");
+		expect(await runGit(repo, ["status", "--porcelain=v1"])).toBe("");
+	});
+
+	it("captures delta for nested repo with unresolvable HEAD (freshly init'd, no commits)", async () => {
+		// Regression: `captureRepoBaseline` used to coerce `git.head.sha() === null` to `""`,
+		// which then flowed into `git read-tree` as an empty SHA and raised `fatal: Not a valid
+		// object name`, aborting the whole task merge. Fresh `git init` with no commits is a
+		// legitimate nested state (scaffolded tool dirs) and must not poison delta capture.
+		const { repo } = await createGitRepo();
+		const nestedRel = "tools/scaffold";
+		const nestedDir = path.join(repo, nestedRel);
+		await fs.mkdir(nestedDir, { recursive: true });
+		await runGit(nestedDir, ["init"]);
+		await runGit(nestedDir, ["config", "user.email", "test@example.com"]);
+		await runGit(nestedDir, ["config", "user.name", "Test User"]);
+		// Deliberately no commits: HEAD resolves to nothing.
+		await expect(runGit(nestedDir, ["rev-parse", "HEAD"])).rejects.toThrow();
+
+		const baseline = await captureBaseline(repo);
+		const nestedEntry = baseline.nested.find(n => n.relativePath === nestedRel);
+		expect(nestedEntry).toBeDefined();
+		expect(nestedEntry?.baseline.headCommit).toBe("");
+
+		const isolationDir = await ensureWorktree(repo, "no-head-nested", baseline.root.headCommit);
+		tempDirs.push(isolationDir);
+		try {
+			await applyBaseline(isolationDir, baseline);
+
+			// Subagent produces a file inside the no-HEAD nested repo.
+			const isolatedNested = path.join(isolationDir, nestedRel);
+			await fs.writeFile(path.join(isolatedNested, "added.txt"), "subagent added\n");
+
+			// Must not throw `fatal: Not a valid object name`.
+			const delta = await captureDeltaPatch(isolationDir, baseline);
+			const nestedPatch = delta.nestedPatches.find(p => p.relativePath === nestedRel);
+			expect(nestedPatch).toBeDefined();
+			expect(nestedPatch?.patch).toContain("added.txt");
+			expect(nestedPatch?.patch).toContain("subagent added");
+		} finally {
+			await runGit(repo, ["worktree", "remove", "--force", isolationDir]).catch(() => {});
+		}
 	});
 });

--- a/packages/coding-agent/test/tools/git-commit-checkpoint.test.ts
+++ b/packages/coding-agent/test/tools/git-commit-checkpoint.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import {
+	GitCommitCheckpointTool,
+	type GitCommitCheckpointToolDetails,
+} from "@oh-my-pi/pi-coding-agent/tools/git-commit-checkpoint";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools/index";
+import * as commitMessageGenerator from "@oh-my-pi/pi-coding-agent/utils/commit-message-generator";
+
+const tempDirs: string[] = [];
+
+async function runGit(repo: string, args: string[]): Promise<string> {
+	const proc = Bun.spawn(["git", ...args], {
+		cwd: repo,
+		stderr: "pipe",
+		stdout: "pipe",
+		windowsHide: true,
+	});
+	const [stdout, stderr, exitCode] = await Promise.all([
+		new Response(proc.stdout).text(),
+		new Response(proc.stderr).text(),
+		proc.exited,
+	]);
+	if ((exitCode ?? 0) !== 0) {
+		throw new Error(stderr.trim() || stdout.trim() || `git ${args.join(" ")} failed with exit code ${exitCode ?? 0}`);
+	}
+	return stdout.trim();
+}
+
+async function createGitRepo(prefix: string): Promise<string> {
+	const repo = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+	tempDirs.push(repo);
+	await runGit(repo, ["init", "-b", "main"]);
+	await runGit(repo, ["config", "user.email", "test@example.com"]);
+	await runGit(repo, ["config", "user.name", "Test User"]);
+	await runGit(repo, ["config", "commit.gpgsign", "false"]);
+	await fs.writeFile(path.join(repo, "tracked.txt"), "base\n");
+	await runGit(repo, ["add", "."]);
+	await runGit(repo, ["commit", "-m", "initial"]);
+	return repo;
+}
+
+function createSession(cwd: string, overrides?: Partial<ToolSession>): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		settings: Settings.isolated({ "tools.gitCommitCheckpoint.enabled": true }),
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		...overrides,
+	};
+}
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("GitCommitCheckpointTool", () => {
+	it("registers only when the setting is enabled at top-level sessions", () => {
+		const enabled = createSession("/tmp");
+		const disabled: ToolSession = {
+			...enabled,
+			settings: Settings.isolated(),
+		};
+		const subagent: ToolSession = {
+			...enabled,
+			taskDepth: 1,
+		};
+		expect(GitCommitCheckpointTool.createIf(enabled)).not.toBeNull();
+		expect(GitCommitCheckpointTool.createIf(disabled)).toBeNull();
+		expect(GitCommitCheckpointTool.createIf(subagent)).toBeNull();
+	});
+
+	it("reports clean when there are no dirty repos", async () => {
+		const repo = await createGitRepo("omp-cc-clean-");
+		const tool = new GitCommitCheckpointTool(createSession(repo));
+		const result = await tool.execute("call-1", { reason: "end of scope" });
+		const details = result.details as GitCommitCheckpointToolDetails;
+		expect(details.overallStatus).toBe("clean");
+		expect(details.repos).toEqual([]);
+	});
+
+	it("fails when the repo is dirty but no model registry is available", async () => {
+		const repo = await createGitRepo("omp-cc-no-model-");
+		await fs.writeFile(path.join(repo, "tracked.txt"), "edited\n");
+		const tool = new GitCommitCheckpointTool(createSession(repo));
+		await expect(tool.execute("call-2", { reason: "end of scope" })).rejects.toThrow(/model registry/);
+		// Repo must remain dirty — no fallback commit was made.
+		expect(await runGit(repo, ["status", "--porcelain=v1"])).not.toBe("");
+	});
+
+	it("uses the generated commit message when a model is available", async () => {
+		const repo = await createGitRepo("omp-cc-gen-");
+		await fs.writeFile(path.join(repo, "tracked.txt"), "edited\n");
+		const spy = vi.spyOn(commitMessageGenerator, "generateCommitMessage").mockResolvedValue("fix: tweak tracked");
+		const session = createSession(repo);
+		(session as { modelRegistry?: unknown }).modelRegistry = {} as unknown;
+		const tool = new GitCommitCheckpointTool(session);
+		const result = await tool.execute("call-3", { reason: "tweaks" });
+		const details = result.details as GitCommitCheckpointToolDetails;
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(details.repos[0].message).toBe("fix: tweak tracked");
+		expect(await runGit(repo, ["log", "-1", "--format=%s"])).toBe("fix: tweak tracked");
+	});
+
+	it("throws ToolError when every dirty repo's commit fails", async () => {
+		const repo = await createGitRepo("omp-cc-fail-");
+		await fs.writeFile(path.join(repo, "tracked.txt"), "edited\n");
+		// Actually simpler: spy generateCommitMessage to throw to trigger the catch path.
+		vi.spyOn(commitMessageGenerator, "generateCommitMessage").mockRejectedValue(new Error("boom"));
+		const session = createSession(repo);
+		(session as { modelRegistry?: unknown }).modelRegistry = {} as unknown;
+		const tool = new GitCommitCheckpointTool(session);
+		await expect(tool.execute("call-4", { reason: "failing scope" })).rejects.toThrow(/failed|boom/);
+	});
+});


### PR DESCRIPTION
This is kind of a loaded commit, but there's too many inter-connected changes to split into multiple prs, orchestrator mode is still not finished, but it works enough to where I use it pretty much all the time, mostly a prompting problem since subagents do things that you don't want them to do.

## What

Introduces orchestrator mode which strips write and edit tools from the main session forcing sub-agent delegation which when branch mode is used organizes all changes into clean ai-generated commit messages that are easy to view, track and roll back. Allows the use to handle all logic by an orchestration model such as opus while implementation is forced via task agents (ex gpt). This mode also forces isolation to be always true (except for read only agents) and eager task delegation. This mode could plausibly work without any isolation and patch, but it kind of defeats the purpose of it. Although it does save tokens in the main session and since subtasks start from scratch it runs the models at their "optimal" token count so that would be one argument for relaxing it.


Reworks the task tool to tolerate partial results.
Replays the active tasks in await so they're always visible in front rather than having to scroll up or be inaccessible using tmux.
Fixes isolated branches hanging when cargo test is used or cargo check due to faulty locks (now clones from cwd instead of git-root local.
Fixes viewport scroll position being affected by subagents.
Removes custom rendering for Ctrl+S session view (just uses the main session renderer)
Removes custom list renderer (just uses built-in one)
Patch is forced task depth above > 1.
Fixes various paths that would lead to subtask merge failure and lost results.
Introduces a subagent call to adjust the results so they cleanly merge with the active branch.
Fixed collecting patches for untracked git subrepos.
Generated commits can no longer attempt to sign (might make this an option, but tbh AI commits shouldn't be signed anyway since the typical usecase is that you condense these commits once you want to push to git). 
Added timeout to await so AI can tackle tasks that get stuck.

## Testing

Using this branch for around 24h, no regressions.

---

- [ ] `bun check` passes (preexisting error)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

Sorry for the loaded commit.
also maybe change keybind to shift+alt+o (just like plan shift+alt+m?)