### PR TITLE
Add Meridian model provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ return config
 | Ollama (`ollama`)                               | `OLLAMA_API_KEY` _(optional)_                |
 | LiteLLM (`litellm`)                             | `LITELLM_API_KEY`                            |
 | LM Studio (`lm-studio`)                         | `LM_STUDIO_API_KEY` _(optional)_             |
+| Meridian (`meridian`)                           | `MERIDIAN_API_KEY` _(optional; `x` works)_   |
 | llama.cpp (`llama.cpp`)                         | `LLAMA_CPP_API_KEY` _(optional)_             |
 | Xiaomi MiMo (`xiaomi`)                          | `XIAOMI_API_KEY`                             |
 | Moonshot (`moonshot`)                           | `MOONSHOT_API_KEY`                           |
@@ -533,6 +534,7 @@ Use `/login` with supported providers:
 - Qianfan (`qianfan`)
 - Ollama (local / self-hosted, `ollama`)
 - LM Studio (local / self-hosted, `lm-studio`)
+- Meridian (local Anthropic-compatible proxy, `meridian`)
 - llama.cpp (local / self-hosted, `llama.cpp`)
 - vLLM (local OpenAI-compatible, `vllm`)
 - Z.AI (GLM Coding Plan)
@@ -550,6 +552,7 @@ Use `/login` with supported providers:
 For `ollama`, API key is optional. Leave it unset for local no-auth instances, or set `OLLAMA_API_KEY` for authenticated hosts.
 For `llama.cpp`, API key is optional. Leave it unset for local no-auth instances, or set `LLAMA_CPP_API_KEY` for authenticated hosts.
 For `lm-studio`, API key is optional. Leave it unset for local no-auth instances, or set `LM_STUDIO_API_KEY` for authenticated hosts.
+For `meridian`, the default endpoint is `http://127.0.0.1:3456`. Any placeholder API key works (for example `x`), and you can override the endpoint with `MERIDIAN_BASE_URL`.
 For `vllm`, paste your key in `/login` (or use `VLLM_API_KEY`). For local no-auth servers, any placeholder value works (for example `vllm-local`).
 For `nanogpt`, `/login nanogpt` opens `https://nano-gpt.com/api` and prompts for your `sk-...` key (or set `NANO_GPT_API_KEY`). Login validates the key via NanoGPT's models endpoint (not a fixed model entitlement).
 For `cloudflare-ai-gateway`, set provider base URL to

--- a/bun.lock
+++ b/bun.lock
@@ -699,7 +699,6 @@
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
-
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -47,6 +47,7 @@ These are consumed via `getEnvApiKey()` (`packages/ai/src/stream.ts`) unless not
 | `VENICE_API_KEY`                | Venice auth | Using `venice` provider                                       |                                                                                                     |
 | `LITELLM_API_KEY`               | LiteLLM auth | Using `litellm` provider                                      | OpenAI-compatible LiteLLM proxy key                                                                 |
 | `LM_STUDIO_API_KEY`             | LM Studio auth (optional) | Using `lm-studio` provider with authenticated hosts           | Local LM Studio usually runs without auth; any non-empty token works when a key is required         |
+| `MERIDIAN_API_KEY`              | Meridian auth (optional) | Using `meridian` provider                                     | Local Meridian accepts any placeholder token; `x` is sufficient for the default local proxy         |
 | `OLLAMA_API_KEY`                | Ollama auth (optional) | Using `ollama` provider with authenticated hosts              | Local Ollama usually runs without auth; any non-empty token works when a key is required            |
 | `LLAMA_CPP_API_KEY`             | Ollama auth (optional) | Using `llama-server` with `--api-key` parameter              | Local llama.cpp usually runs without auth; any non-empty token works when a key is configured       |
 | `XIAOMI_API_KEY`                | Xiaomi MiMo auth | Using `xiaomi` provider                                       |                                                                                                     |
@@ -258,6 +259,7 @@ Extra conditional behavior:
 | `PI_PACKAGE_DIR`           | Overrides package asset base dir resolution (docs/examples/changelog path lookup)            |
 | `PI_DISABLE_LSPMUX`        | If `1`, disables lspmux detection/integration and forces direct LSP server spawning          |
 | `LM_STUDIO_BASE_URL`       | Default implicit LM Studio discovery base URL override (`http://127.0.0.1:1234/v1` if unset) |
+| `MERIDIAN_BASE_URL`        | Meridian provider base URL override (`http://127.0.0.1:3456` if unset)                       |
 | `OLLAMA_BASE_URL`          | Default implicit Ollama discovery base URL override (`http://127.0.0.1:11434` if unset)      |
 | `LLAMA_CPP_BASE_URL`       | Default implicit Llama.cpp discovery base URL override (`http://127.0.0.1:8080` if unset)    |
 | `PI_EDIT_VARIANT`          | If `hashline`, forces hashline read/grep display mode when edit tool available               |

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -46,6 +46,7 @@ import { loginKilo } from "./utils/oauth/kilo";
 import { loginKimi } from "./utils/oauth/kimi";
 import { loginLiteLLM } from "./utils/oauth/litellm";
 import { loginLmStudio } from "./utils/oauth/lm-studio";
+import { loginMeridian } from "./utils/oauth/meridian";
 import { loginMiniMaxCode, loginMiniMaxCodeCn } from "./utils/oauth/minimax-code";
 import { loginMoonshot } from "./utils/oauth/moonshot";
 import { loginNanoGPT } from "./utils/oauth/nanogpt";
@@ -876,6 +877,11 @@ export class AuthStorage {
 			}
 			case "litellm": {
 				const apiKey = await loginLiteLLM(ctrl);
+				await saveApiKeyCredential(apiKey);
+				return;
+			}
+			case "meridian": {
+				const apiKey = await loginMeridian(ctrl);
 				await saveApiKeyCredential(apiKey);
 				return;
 			}

--- a/packages/ai/src/cli.ts
+++ b/packages/ai/src/cli.ts
@@ -10,6 +10,7 @@ import { loginGeminiCli } from "./utils/oauth/google-gemini-cli";
 import { loginKagi } from "./utils/oauth/kagi";
 import { loginKilo } from "./utils/oauth/kilo";
 import { loginKimi } from "./utils/oauth/kimi";
+import { loginMeridian } from "./utils/oauth/meridian";
 import { loginMiniMaxCode, loginMiniMaxCodeCn } from "./utils/oauth/minimax-code";
 import { loginNanoGPT } from "./utils/oauth/nanogpt";
 import { loginOpenAICodex } from "./utils/oauth/openai-codex";
@@ -238,6 +239,22 @@ async function login(provider: OAuthProvider): Promise<void> {
 				return;
 			}
 
+			case "meridian": {
+				const apiKey = await loginMeridian({
+					onAuth(info) {
+						const { url, instructions } = info;
+						console.log(`\nOpen this URL in your browser:\n${url}`);
+						if (instructions) console.log(instructions);
+						console.log();
+					},
+					onPrompt(p) {
+						return promptFn(`${p.message}${p.placeholder ? ` (${p.placeholder})` : ""}:`);
+					},
+				});
+				storage.saveApiKey(provider, apiKey);
+				console.log(`\nAPI key saved to ~/.omp/agent/agent.db`);
+				return;
+			}
 			case "nanogpt": {
 				const apiKey = await loginNanoGPT({
 					onAuth(info) {
@@ -343,6 +360,7 @@ Providers:
   tavily            Tavily
   zai               Z.AI (GLM Coding Plan)
   nanogpt           NanoGPT
+  meridian          Meridian (Local Anthropic-compatible)
   minimax-code      MiniMax Coding Plan (International)
   minimax-code-cn   MiniMax Coding Plan (China)
   cursor            Cursor (Claude, GPT, etc.)

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -19,6 +19,7 @@ import {
 	kimiCodeModelManagerOptions,
 	litellmModelManagerOptions,
 	lmStudioModelManagerOptions,
+	meridianModelManagerOptions,
 	mistralModelManagerOptions,
 	moonshotModelManagerOptions,
 	nanoGptModelManagerOptions,
@@ -220,6 +221,9 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		config => litellmModelManagerOptions(config),
 		catalog("LiteLLM", ["LITELLM_API_KEY"], { allowUnauthenticated: true }),
 	),
+	descriptor("meridian", "claude-sonnet-4-6", config => meridianModelManagerOptions(config), {
+		allowUnauthenticated: true,
+	}),
 	descriptor("lm-studio", "llama-3-8b", config => lmStudioModelManagerOptions(config), { allowUnauthenticated: true }),
 	catalogDescriptor(
 		"vllm",

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -1570,6 +1570,67 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 	};
 }
 
+const MERIDIAN_BASE_URL = "http://127.0.0.1:3456/v1";
+
+function resolveMeridianBaseUrl(baseUrl?: string): string {
+	const value = baseUrl?.trim() || Bun.env.MERIDIAN_BASE_URL?.trim();
+	if (!value) {
+		return MERIDIAN_BASE_URL;
+	}
+	return toAnthropicDiscoveryBaseUrl(value.replace(/\/+$/, ""));
+}
+
+export interface MeridianModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+}
+
+export function meridianModelManagerOptions(
+	config?: MeridianModelManagerConfig,
+): ModelManagerOptions<"anthropic-messages"> {
+	const apiKey = config?.apiKey ?? "x";
+	const baseUrl = resolveMeridianBaseUrl(config?.baseUrl);
+	return {
+		providerId: "meridian",
+		fetchDynamicModels: async () => {
+			const modelsDevModels = await fetchModelsDevPayload()
+				.then(payload => mapAnthropicModelsDev(payload, baseUrl))
+				.catch(() => []);
+			const references = buildAnthropicReferenceMap(modelsDevModels);
+			return (
+				fetchOpenAICompatibleModels({
+					api: "anthropic-messages",
+					provider: "meridian",
+					baseUrl,
+					headers: buildAnthropicDiscoveryHeaders(apiKey),
+					mapModel: (
+						entry: OpenAICompatibleModelRecord,
+						defaults: Model<"anthropic-messages">,
+						_context: OpenAICompatibleModelMapperContext<"anthropic-messages">,
+					): Model<"anthropic-messages"> => {
+						const discoveredName = typeof entry.display_name === "string" ? entry.display_name : defaults.name;
+						const reference = references.get(defaults.id);
+						if (!reference) {
+							return {
+								...defaults,
+								name: discoveredName,
+							};
+						}
+						return {
+							...reference,
+							id: defaults.id,
+							name: discoveredName,
+							api: "anthropic-messages",
+							provider: "meridian",
+							baseUrl,
+						};
+					},
+				}) ?? null
+			);
+		},
+	};
+}
+
 // ---------------------------------------------------------------------------
 // 24. Anthropic
 // ---------------------------------------------------------------------------

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -132,6 +132,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	huggingface: () => $pickenv("HUGGINGFACE_HUB_TOKEN", "HF_TOKEN"),
 	litellm: "LITELLM_API_KEY",
 	moonshot: "MOONSHOT_API_KEY",
+	meridian: "MERIDIAN_API_KEY",
 	nvidia: "NVIDIA_API_KEY",
 	nanogpt: "NANO_GPT_API_KEY",
 	"lm-studio": "LM_STUDIO_API_KEY",
@@ -190,7 +191,7 @@ export function stream<TApi extends Api>(
 		return streamBedrock(model as Model<"bedrock-converse-stream">, context, (options || {}) as BedrockOptions);
 	}
 
-	const apiKey = options?.apiKey || getEnvApiKey(model.provider);
+	const apiKey = options?.apiKey || getEnvApiKey(model.provider) || (model.provider === "meridian" ? "x" : undefined);
 	if (!apiKey) {
 		throw new Error(`No API key for provider: ${model.provider}`);
 	}
@@ -261,7 +262,7 @@ export function streamSimple<TApi extends Api>(
 		return stream(model, context, providerOptions);
 	}
 
-	const apiKey = options?.apiKey || getEnvApiKey(model.provider);
+	const apiKey = options?.apiKey || getEnvApiKey(model.provider) || (model.provider === "meridian" ? "x" : undefined);
 	if (!apiKey) {
 		throw new Error(`No API key for provider: ${model.provider}`);
 	}

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -116,6 +116,7 @@ export type KnownProvider =
 	| "huggingface"
 	| "litellm"
 	| "moonshot"
+	| "meridian"
 	| "nvidia"
 	| "nanogpt"
 	| "ollama"

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -81,6 +81,8 @@ export { loginKimi, refreshKimiToken } from "./kimi";
 export { loginLiteLLM } from "./litellm";
 // LM Studio (optional API key)
 export { DEFAULT_LOCAL_TOKEN, loginLmStudio } from "./lm-studio";
+// Meridian (optional placeholder API key)
+export { loginMeridian } from "./meridian";
 // MiniMax Coding Plan (API key)
 export { loginMiniMaxCode, loginMiniMaxCodeCn } from "./minimax-code";
 // Moonshot (API key)
@@ -258,6 +260,11 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 	{
 		id: "nanogpt",
 		name: "NanoGPT",
+		available: true,
+	},
+	{
+		id: "meridian",
+		name: "Meridian (Local Anthropic-compatible)",
 		available: true,
 	},
 	{

--- a/packages/ai/src/utils/oauth/meridian.ts
+++ b/packages/ai/src/utils/oauth/meridian.ts
@@ -1,0 +1,38 @@
+/**
+ * Meridian login flow.
+ *
+ * Meridian is a local Anthropic-compatible proxy. It defaults to
+ * http://127.0.0.1:3456 and accepts any placeholder API key value because
+ * authentication happens through the local Claude Code session.
+ */
+
+import type { OAuthController } from "./types";
+
+const AUTH_URL = "https://github.com/rynfar/meridian";
+const DEFAULT_LOCAL_BASE_URL = "http://127.0.0.1:3456";
+const DEFAULT_PLACEHOLDER_TOKEN = "x";
+
+export async function loginMeridian(options: OAuthController): Promise<string> {
+	if (!options.onPrompt) {
+		throw new Error("Meridian login requires onPrompt callback");
+	}
+
+	options.onAuth?.({
+		url: AUTH_URL,
+		instructions: `Start Meridian locally, then point the provider at ${DEFAULT_LOCAL_BASE_URL}. Meridian accepts any placeholder API key, so the default token "${DEFAULT_PLACEHOLDER_TOKEN}" is sufficient.`,
+	});
+
+	const apiKey = await options.onPrompt({
+		message:
+			"Optional: paste a Meridian placeholder API key (press enter to use x; set MERIDIAN_BASE_URL to change the endpoint)",
+		placeholder: DEFAULT_PLACEHOLDER_TOKEN,
+		allowEmpty: true,
+	});
+
+	if (options.signal?.aborted) {
+		throw new Error("Login cancelled");
+	}
+
+	const trimmed = apiKey.trim();
+	return trimmed || DEFAULT_PLACEHOLDER_TOKEN;
+}

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -27,6 +27,7 @@ export type OAuthProvider =
 	| "minimax-code"
 	| "minimax-code-cn"
 	| "moonshot"
+	| "meridian"
 	| "nvidia"
 	| "nanogpt"
 	| "ollama"

--- a/packages/ai/test/meridian-login.test.ts
+++ b/packages/ai/test/meridian-login.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "bun:test";
+import { loginMeridian } from "../src/utils/oauth/meridian";
+
+describe("meridian login", () => {
+	it("uses placeholder token and Meridian instructions by default", async () => {
+		let authUrl: string | undefined;
+		let authInstructions: string | undefined;
+		let promptMessage: string | undefined;
+		let promptPlaceholder: string | undefined;
+
+		const apiKey = await loginMeridian({
+			onAuth: info => {
+				authUrl = info.url;
+				authInstructions = info.instructions;
+			},
+			onPrompt: async prompt => {
+				promptMessage = prompt.message;
+				promptPlaceholder = prompt.placeholder;
+				return "";
+			},
+		});
+
+		expect(authUrl).toBe("https://github.com/rynfar/meridian");
+		expect(authInstructions).toContain("http://127.0.0.1:3456");
+		expect(authInstructions).toContain('default token "x"');
+		expect(promptMessage).toContain("MERIDIAN_BASE_URL");
+		expect(promptMessage).not.toContain("ANTHROPIC_BASE_URL");
+		expect(promptPlaceholder).toBe("x");
+		expect(apiKey).toBe("x");
+	});
+
+	it("returns a provided placeholder token unchanged after trimming", async () => {
+		const apiKey = await loginMeridian({
+			onPrompt: async () => "  meridian-local  ",
+		});
+
+		expect(apiKey).toBe("meridian-local");
+	});
+
+	it("requires onPrompt callback", async () => {
+		await expect(loginMeridian({})).rejects.toThrow("Meridian login requires onPrompt callback");
+	});
+});

--- a/packages/ai/test/meridian-provider.test.ts
+++ b/packages/ai/test/meridian-provider.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import { DEFAULT_MODEL_PER_PROVIDER, PROVIDER_DESCRIPTORS } from "../src/provider-models/descriptors";
+import { meridianModelManagerOptions } from "../src/provider-models/openai-compat";
+import { getEnvApiKey } from "../src/stream";
+import { getOAuthProviders } from "../src/utils/oauth";
+
+const originalMeridianApiKey = Bun.env.MERIDIAN_API_KEY;
+const originalMeridianBaseUrl = Bun.env.MERIDIAN_BASE_URL;
+const originalFetch = global.fetch;
+
+afterEach(() => {
+	if (originalMeridianApiKey === undefined) {
+		delete Bun.env.MERIDIAN_API_KEY;
+	} else {
+		Bun.env.MERIDIAN_API_KEY = originalMeridianApiKey;
+	}
+	if (originalMeridianBaseUrl === undefined) {
+		delete Bun.env.MERIDIAN_BASE_URL;
+	} else {
+		Bun.env.MERIDIAN_BASE_URL = originalMeridianBaseUrl;
+	}
+	global.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+describe("meridian provider support", () => {
+	test("resolves MERIDIAN_API_KEY from environment", () => {
+		Bun.env.MERIDIAN_API_KEY = "meridian-test-key";
+		expect(getEnvApiKey("meridian")).toBe("meridian-test-key");
+	});
+
+	test("does not synthesize Meridian auth from generic fallback vars", () => {
+		delete Bun.env.MERIDIAN_API_KEY;
+		delete Bun.env.ANTHROPIC_API_KEY;
+		expect(getEnvApiKey("meridian")).toBeUndefined();
+	});
+
+	test("registers built-in descriptor and default model", () => {
+		const descriptor = PROVIDER_DESCRIPTORS.find(item => item.providerId === "meridian");
+		expect(descriptor).toBeDefined();
+		expect(descriptor?.defaultModel).toBe("claude-sonnet-4-6");
+		expect(descriptor?.allowUnauthenticated).toBe(true);
+		expect(descriptor?.catalogDiscovery).toBeUndefined();
+		expect(DEFAULT_MODEL_PER_PROVIDER.meridian).toBe("claude-sonnet-4-6");
+	});
+
+	test("registers Meridian in OAuth provider selector", () => {
+		const provider = getOAuthProviders().find(item => item.id === "meridian");
+		expect(provider?.name).toBe("Meridian (Local Anthropic-compatible)");
+	});
+
+	test("builds model manager options with Meridian defaults", async () => {
+		Bun.env.MERIDIAN_BASE_URL = "http://127.0.0.1:3456";
+		global.fetch = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						data: [
+							{
+								id: "claude-sonnet-4-6",
+								display_name: "Claude Sonnet 4.6",
+							},
+						],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+		) as unknown as typeof fetch;
+
+		const options = meridianModelManagerOptions();
+		expect(options.providerId).toBe("meridian");
+		expect(options.fetchDynamicModels).toBeDefined();
+		expect(options.modelsDev).toBeUndefined();
+
+		const models = await options.fetchDynamicModels?.();
+		expect(global.fetch).toHaveBeenNthCalledWith(
+			2,
+			"http://127.0.0.1:3456/v1/models",
+			expect.objectContaining({
+				method: "GET",
+				headers: expect.objectContaining({ "x-api-key": "x" }),
+			}),
+		);
+		expect(models?.[0]?.provider).toBe("meridian");
+		expect(models?.[0]?.api).toBe("anthropic-messages");
+		expect(models?.[0]?.baseUrl).toBe("http://127.0.0.1:3456/v1");
+	});
+});

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -219,6 +219,8 @@ export function getExtraHelpText(): string {
   OPENROUTER_API_KEY         - OpenRouter aggregated models
   KILO_API_KEY               - Kilo Gateway models
   MISTRAL_API_KEY            - Mistral models
+  MERIDIAN_API_KEY           - Meridian local Anthropic-compatible proxy (placeholder value is fine)
+  MERIDIAN_BASE_URL          - Meridian endpoint override (default http://127.0.0.1:3456)
   ZAI_API_KEY                - z.ai models (ZhipuAI/GLM)
   MINIMAX_API_KEY            - MiniMax models
   OPENCODE_API_KEY           - OpenCode Zen/OpenCode Go models

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1722,11 +1722,17 @@ export class ModelRegistry {
 		return this.#models;
 	}
 
+	#usesImplicitPlaceholderAuth(provider: string): boolean {
+		return provider === "meridian";
+	}
+
 	#isModelAvailable(model: Model<Api>): boolean {
 		const disabledProviders = getDisabledProviderIdsFromSettings();
 		return (
 			!disabledProviders.has(model.provider) &&
-			(this.#keylessProviders.has(model.provider) || this.authStorage.hasAuth(model.provider))
+			(this.#keylessProviders.has(model.provider) ||
+				this.#usesImplicitPlaceholderAuth(model.provider) ||
+				this.authStorage.hasAuth(model.provider))
 		);
 	}
 
@@ -1889,7 +1895,17 @@ export class ModelRegistry {
 		if (this.#keylessProviders.has(model.provider)) {
 			return kNoAuth;
 		}
-		return this.authStorage.getApiKey(model.provider, sessionId, { baseUrl: model.baseUrl, modelId: model.id });
+		const resolved = await this.authStorage.getApiKey(model.provider, sessionId, {
+			baseUrl: model.baseUrl,
+			modelId: model.id,
+		});
+		if (resolved) {
+			return resolved;
+		}
+		if (this.#usesImplicitPlaceholderAuth(model.provider)) {
+			return "x";
+		}
+		return undefined;
 	}
 
 	/**

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1396,6 +1396,30 @@ describe("ModelRegistry", () => {
 			expect(registry.getAvailable().some(m => m.provider === "ollama" && m.id === "phi4-mini")).toBe(true);
 			expect(await registry.getApiKey(ollamaModels[0])).toBe(kNoAuth);
 		});
+		test("discovers Meridian models at runtime and uses the implicit placeholder key", async () => {
+			using _hook = hookFetch(input => {
+				const url = String(input);
+				if (url === "https://models.dev/api.json") {
+					return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+				}
+				if (url === "http://127.0.0.1:3456/v1/models") {
+					return new Response(
+						JSON.stringify({ data: [{ id: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6" }] }),
+						{ status: 200, headers: { "Content-Type": "application/json" } },
+					);
+				}
+				throw new Error(`Unexpected URL: ${url}`);
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			await registry.refresh();
+			const meridianModels = getModelsForProvider(registry, "meridian");
+			expect(meridianModels.some(m => m.id === "claude-sonnet-4-6")).toBe(true);
+			expect(registry.getAvailable().some(m => m.provider === "meridian" && m.id === "claude-sonnet-4-6")).toBe(
+				true,
+			);
+			expect(await registry.getApiKey(meridianModels[0])).toBe("x");
+		});
 
 		test("discovers ollama models at runtime and treats auth:none providers as available", async () => {
 			writeRawModelsJson({


### PR DESCRIPTION
## Summary
- add a first-class Meridian provider with local Anthropic-compatible model discovery and login flow
- wire Meridian through ai provider registration, coding-agent availability checks, and request-time placeholder auth handling
- document Meridian setup and add targeted provider, login, and model-registry tests

## Verification
- `bun test test/meridian-provider.test.ts test/meridian-login.test.ts test/zenmux-provider.test.ts test/zenmux-login.test.ts` (packages/ai)
- `bun run check` (packages/ai)
- `biome check src/cli/args.ts src/config/model-registry.ts test/model-registry.test.ts && bun run check:types && bun test test/model-registry.test.ts` (packages/coding-agent)

## Notes
- reviewers flagged and this change addresses: no static models.dev fallback for Meridian, no synthetic global auth state, implicit placeholder auth only at request/model-selection time, and coding-agent runtime availability for discovered Meridian models.