### PR TITLE
fix: unify XDG plugin discovery path with write path

### DIFF
--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -7,6 +7,7 @@ import {
 	APP_NAME,
 	CONFIG_DIR_NAME,
 	getConfigDirName,
+	getPluginsDir,
 	getProjectDir,
 	parseFrontmatter,
 	resolveUserPluginsDir,

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -4,11 +4,12 @@ import * as path from "node:path";
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { FileType, glob } from "@oh-my-pi/pi-natives";
 import {
+	APP_NAME,
 	CONFIG_DIR_NAME,
 	getConfigDirName,
-	getPluginsDir,
 	getProjectDir,
 	parseFrontmatter,
+	resolveUserPluginsDir,
 	tryParseJson,
 } from "@oh-my-pi/pi-utils";
 import type { ExtensionModule } from "../capability/extension-module";
@@ -743,6 +744,28 @@ export async function resolveOrDefaultProjectRegistryPath(cwd: string): Promise<
 	return path.join(cwd, getConfigDirName(), "plugins", "installed_plugins.json");
 }
 
+/**
+ * Clears all discovery caches for the given home directory, including both
+ * the legacy config path and the XDG path (if XDG_DATA_HOME is set).
+ * Must clear both candidates unconditionally: after uninstall the XDG file
+ * is gone so resolveUserPluginsDir() routes to the legacy path, but the
+ * XDG fs-cache entry still needs eviction.
+ */
+export function clearClaudePluginDiscoveryCaches(home: string, extraPaths?: readonly string[]): void {
+	invalidateFsCache(path.join(home, ".claude", "plugins", "installed_plugins.json"));
+	// Legacy OMP path
+	invalidateFsCache(path.join(home, getConfigDirName(), "plugins", "installed_plugins.json"));
+	// XDG OMP path (if configured)
+	const xdgDataHome = process.env.XDG_DATA_HOME;
+	if (xdgDataHome) {
+		invalidateFsCache(path.join(xdgDataHome, APP_NAME, "plugins", "installed_plugins.json"));
+	}
+	for (const filePath of extraPaths ?? []) {
+		invalidateFsCache(filePath);
+	}
+	clearClaudePluginRootsCache();
+}
+
 const pluginRootsCache = new Map<string, { roots: ClaudePluginRoot[]; warnings: string[] }>();
 
 /**
@@ -811,9 +834,10 @@ export async function listClaudePluginRoots(
 
 	// ── OMP installed plugins registry ───────────────────────────────────────
 	// OMP registry is authoritative: its entries replace Claude's entries for the same plugin ID.
-	// getPluginsDir() resolves to the same path the marketplace writer uses
-	// (XDG-aware via the dir resolver), so reads and writes always agree.
-	const ompRegistryPath = path.join(getPluginsDir(), "installed_plugins.json");
+	// Path derived from `home` (not os.homedir()) so test isolation works when home is overridden.
+	// resolveUserPluginsDir applies XDG with the same directory-existence condition as DirResolver,
+	// ensuring read and write paths stay in sync.
+	const ompRegistryPath = path.join(resolveUserPluginsDir(home), "installed_plugins.json");
 	const ompContent = await readFile(ompRegistryPath);
 	if (ompContent) {
 		const ompRegistry = parseClaudePluginsRegistry(ompContent);

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -24,7 +24,7 @@ import { resolveCliModel, resolveModelRoleValue, resolveModelScope, type ScopedM
 import { getDefault, type SettingPath, Settings, settings } from "./config/settings";
 import { initializeWithSettings } from "./discovery";
 import {
-	clearPluginRootsAndCaches,
+	clearClaudePluginDiscoveryCaches,
 	injectPluginDirRoots,
 	preloadPluginRoots,
 	resolveActiveProjectRegistryPath,
@@ -761,7 +761,9 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 					projectInstalledRegistryPath: (await resolveActiveProjectRegistryPath(getProjectDir())) ?? undefined,
 					marketplacesCacheDir: getMarketplacesCacheDir(),
 					pluginsCacheDir: getPluginsCacheDir(),
-					clearPluginRootsCache: clearPluginRootsAndCaches,
+					clearPluginRootsCache: (extraPaths?: readonly string[]) => {
+						clearClaudePluginDiscoveryCaches(os.homedir(), extraPaths);
+					},
 				});
 				await mgr.refreshStaleMarketplaces();
 				const updates = await mgr.checkForUpdates();

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1,3 +1,4 @@
+import * as os from "node:os";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/utils/oauth";
 import type { OAuthProvider } from "@oh-my-pi/pi-ai/utils/oauth/types";
@@ -9,7 +10,7 @@ import { formatModelSelectorValue } from "../../config/model-resolver";
 import { settings } from "../../config/settings";
 import { DebugSelectorComponent } from "../../debug";
 import { disableProvider, enableProvider } from "../../discovery";
-import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
+import { clearClaudePluginDiscoveryCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import {
 	getInstalledPluginsRegistryPath,
 	getMarketplacesCacheDir,
@@ -448,7 +449,9 @@ export class SelectorController {
 			projectInstalledRegistryPath: (await resolveActiveProjectRegistryPath(getProjectDir())) ?? undefined,
 			marketplacesCacheDir: getMarketplacesCacheDir(),
 			pluginsCacheDir: getPluginsCacheDir(),
-			clearPluginRootsCache: clearPluginRootsAndCaches,
+			clearPluginRootsCache: (extraPaths?: readonly string[]) => {
+				clearClaudePluginDiscoveryCaches(os.homedir(), extraPaths);
+			},
 		});
 
 		const [marketplaces, installed] = await Promise.all([mgr.listMarketplaces(), mgr.listInstalledPlugins()]);

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1,6 +1,6 @@
 import * as os from "node:os";
 
-import { getOAuthProviders } from "@oh-my-pi/pi-ai";
+import { getOAuthProviders } from "@oh-my-pi/pi-ai/utils/oauth";
 import type { SettingPath, SettingValue } from "../config/settings";
 import { settings } from "../config/settings";
 import {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -1,8 +1,10 @@
-import { getOAuthProviders } from "@oh-my-pi/pi-ai/utils/oauth";
+import * as os from "node:os";
+
+import { getOAuthProviders } from "@oh-my-pi/pi-ai";
 import type { SettingPath, SettingValue } from "../config/settings";
 import { settings } from "../config/settings";
 import {
-	clearPluginRootsAndCaches,
+	clearClaudePluginDiscoveryCaches,
 	resolveActiveProjectRegistryPath,
 	resolveOrDefaultProjectRegistryPath,
 } from "../discovery/helpers.js";
@@ -697,7 +699,9 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 				),
 				marketplacesCacheDir: getMarketplacesCacheDir(),
 				pluginsCacheDir: getPluginsCacheDir(),
-				clearPluginRootsCache: clearPluginRootsAndCaches,
+				clearPluginRootsCache: (extraPaths?: readonly string[]) => {
+					clearClaudePluginDiscoveryCaches(os.homedir(), extraPaths);
+				},
 			});
 
 			try {
@@ -885,7 +889,9 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 					),
 					marketplacesCacheDir: getMarketplacesCacheDir(),
 					pluginsCacheDir: getPluginsCacheDir(),
-					clearPluginRootsCache: clearPluginRootsAndCaches,
+					clearPluginRootsCache: (extraPaths?: readonly string[]) => {
+						clearClaudePluginDiscoveryCaches(os.homedir(), extraPaths);
+					},
 				});
 
 				switch (sub) {
@@ -946,10 +952,8 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 		name: "reload-plugins",
 		description: "Reload all plugins (skills, commands, hooks, tools, agents, MCP)",
 		handle: async (_command, runtime) => {
-			// Invalidate registry fs caches and the plugin roots cache so
-			// listClaudePluginRoots re-reads from disk on next access.
 			const projectPath = await resolveActiveProjectRegistryPath(runtime.ctx.sessionManager.getCwd());
-			clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
+			clearClaudePluginDiscoveryCaches(os.homedir(), projectPath ? [projectPath] : undefined);
 			await runtime.ctx.refreshSlashCommandState();
 			runtime.ctx.showStatus("Plugins reloaded.");
 			runtime.ctx.editor.setText("");

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -13,6 +13,7 @@ import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
 import "@oh-my-pi/pi-coding-agent/discovery/claude-plugins";
 import type { Skill } from "@oh-my-pi/pi-coding-agent/capability/skill";
 import type { SlashCommand } from "@oh-my-pi/pi-coding-agent/capability/slash-command";
+import { resolveUserPluginsDir } from "@oh-my-pi/pi-utils";
 
 describe("parseClaudePluginsRegistry", () => {
 	test("parses valid registry", () => {
@@ -468,6 +469,112 @@ describe("listClaudePluginRoots", () => {
 		const found = result.all.find(command => command.name === "manifest-commands-outside:ship");
 
 		expect(found).toBeUndefined();
+
+	describe("XDG data directory support", () => {
+		let homedirSpy: ReturnType<typeof spyOn> | undefined;
+		let savedXdgDataHome: string | undefined;
+
+		beforeEach(() => {
+			homedirSpy = undefined;
+			savedXdgDataHome = process.env.XDG_DATA_HOME;
+		});
+
+		afterEach(() => {
+			homedirSpy?.mockRestore();
+			if (savedXdgDataHome === undefined) {
+				delete process.env.XDG_DATA_HOME;
+			} else {
+				process.env.XDG_DATA_HOME = savedXdgDataHome;
+			}
+			clearClaudePluginRootsCache();
+			clearFsCache();
+		});
+
+		const makeEntry = (installPath: string) => ({
+			scope: "user" as const,
+			installPath,
+			version: "1.0.0",
+			installedAt: "2025-01-01T00:00:00Z",
+			lastUpdated: "2025-01-01T00:00:00Z",
+		});
+
+		test("uses XDG plugins dir when $XDG_DATA_HOME/omp directory exists", async () => {
+			// Spy so the home-match guard in resolveUserPluginsDir fires against tempDir.
+			homedirSpy = spyOn(os, "homedir").mockReturnValue(tempDir);
+			const xdgBase = path.join(tempDir, "xdg");
+			process.env.XDG_DATA_HOME = xdgBase;
+
+			// Create $XDG_DATA_HOME/omp directory — this is the activation condition.
+			const xdgRoot = path.join(xdgBase, "omp");
+			await fs.mkdir(xdgRoot, { recursive: true });
+
+			const xdgPluginsDir = path.join(xdgRoot, "plugins");
+			await fs.mkdir(xdgPluginsDir, { recursive: true });
+			await fs.writeFile(
+				path.join(xdgPluginsDir, "installed_plugins.json"),
+				JSON.stringify({ version: 2, plugins: { "xdg-plugin@mkt": [makeEntry("/xdg/path")] } }),
+			);
+
+			// resolveUserPluginsDir must return the XDG path, not the legacy path.
+			expect(resolveUserPluginsDir(tempDir)).toBe(xdgPluginsDir);
+
+			const result = await listClaudePluginRoots(tempDir);
+			expect(result.roots).toHaveLength(1);
+			expect(result.roots[0]?.id).toBe("xdg-plugin@mkt");
+			expect(result.roots[0]?.path).toBe("/xdg/path");
+		});
+
+		test("falls back to legacy path when $XDG_DATA_HOME/omp directory does not exist", async () => {
+			homedirSpy = spyOn(os, "homedir").mockReturnValue(tempDir);
+			process.env.XDG_DATA_HOME = path.join(tempDir, "xdg-absent");
+			// Do NOT create $XDG_DATA_HOME/omp — activation condition not met.
+
+			const legacyPluginsDir = path.join(tempDir, ".omp", "plugins");
+			await fs.mkdir(legacyPluginsDir, { recursive: true });
+			await fs.writeFile(
+				path.join(legacyPluginsDir, "installed_plugins.json"),
+				JSON.stringify({ version: 2, plugins: { "legacy-plugin@mkt": [makeEntry("/legacy/path")] } }),
+			);
+
+			expect(resolveUserPluginsDir(tempDir)).toBe(legacyPluginsDir);
+
+			const result = await listClaudePluginRoots(tempDir);
+			expect(result.roots).toHaveLength(1);
+			expect(result.roots[0]?.id).toBe("legacy-plugin@mkt");
+		});
+
+		test("XDG dir exists but no registry: legacy registry is not read", async () => {
+			// Critical: write/read must use the same path. If XDG dir exists, the write path
+			// (DirResolver) writes to XDG. Discovery must also read from XDG, not fall back
+			// to legacy — even when the XDG registry file is absent.
+			homedirSpy = spyOn(os, "homedir").mockReturnValue(tempDir);
+			const xdgBase = path.join(tempDir, "xdg");
+			process.env.XDG_DATA_HOME = xdgBase;
+			await fs.mkdir(path.join(xdgBase, "omp"), { recursive: true });
+			// No XDG registry file — but write a legacy registry to confirm it is not read.
+			const legacyPluginsDir = path.join(tempDir, ".omp", "plugins");
+			await fs.mkdir(legacyPluginsDir, { recursive: true });
+			await fs.writeFile(
+				path.join(legacyPluginsDir, "installed_plugins.json"),
+				JSON.stringify({ version: 2, plugins: { "stale-plugin@mkt": [makeEntry("/stale/path")] } }),
+			);
+
+			const result = await listClaudePluginRoots(tempDir);
+			// Must return empty: XDG is active (dir exists), XDG registry is absent.
+			// A file-existence-based fallback would incorrectly surface the legacy entry.
+			expect(result.roots).toHaveLength(0);
+		});
+
+		test("XDG not applied when home differs from os.homedir()", async () => {
+			// No spy — os.homedir() returns the real home, but tempDir != real home.
+			// resolveUserPluginsDir must skip XDG even if XDG_DATA_HOME is set.
+			const xdgBase = path.join(tempDir, "xdg");
+			process.env.XDG_DATA_HOME = xdgBase;
+			await fs.mkdir(path.join(xdgBase, "omp"), { recursive: true });
+
+			const legacyPluginsDir = path.join(tempDir, ".omp", "plugins");
+			expect(resolveUserPluginsDir(tempDir)).toBe(legacyPluginsDir);
+		});
 	});
 });
 

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -469,7 +469,7 @@ describe("listClaudePluginRoots", () => {
 		const found = result.all.find(command => command.name === "manifest-commands-outside:ship");
 
 		expect(found).toBeUndefined();
-		});
+	});
 
 	describe("XDG data directory support", () => {
 		let homedirSpy: Mock<() => string> | undefined;

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -13,7 +13,7 @@ import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
 import "@oh-my-pi/pi-coding-agent/discovery/claude-plugins";
 import type { Skill } from "@oh-my-pi/pi-coding-agent/capability/skill";
 import type { SlashCommand } from "@oh-my-pi/pi-coding-agent/capability/slash-command";
-import { resolveUserPluginsDir } from "@oh-my-pi/pi-utils";
+import { getConfigDirName, resetUserPluginsDirCache, resolveUserPluginsDir } from "@oh-my-pi/pi-utils";
 
 describe("parseClaudePluginsRegistry", () => {
 	test("parses valid registry", () => {
@@ -61,11 +61,15 @@ describe("parseClaudePluginsRegistry", () => {
 describe("listClaudePluginRoots", () => {
 	let tempDir: string;
 	let originalHome: string | undefined;
+	let savedXdgDataHome: string | undefined;
 
 	beforeEach(async () => {
 		clearClaudePluginRootsCache();
 		clearFsCache();
+		resetUserPluginsDirCache();
 		originalHome = process.env.HOME;
+		savedXdgDataHome = process.env.XDG_DATA_HOME;
+		delete process.env.XDG_DATA_HOME;
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "claude-plugins-test-"));
 		process.env.HOME = tempDir;
 		vi.spyOn(os, "homedir").mockReturnValue(tempDir);
@@ -74,11 +78,17 @@ describe("listClaudePluginRoots", () => {
 	afterEach(async () => {
 		clearClaudePluginRootsCache();
 		clearFsCache();
+		resetUserPluginsDirCache();
 		vi.restoreAllMocks();
 		if (originalHome === undefined) {
 			delete process.env.HOME;
 		} else {
 			process.env.HOME = originalHome;
+			if (savedXdgDataHome === undefined) {
+				delete process.env.XDG_DATA_HOME;
+			} else {
+				process.env.XDG_DATA_HOME = savedXdgDataHome;
+			}
 		}
 		await fs.rm(tempDir, { recursive: true, force: true });
 	});
@@ -489,6 +499,7 @@ describe("listClaudePluginRoots", () => {
 			}
 			clearClaudePluginRootsCache();
 			clearFsCache();
+			resetUserPluginsDirCache();
 		});
 
 		const makeEntry = (installPath: string) => ({
@@ -530,7 +541,7 @@ describe("listClaudePluginRoots", () => {
 			process.env.XDG_DATA_HOME = path.join(tempDir, "xdg-absent");
 			// Do NOT create $XDG_DATA_HOME/omp — activation condition not met.
 
-			const legacyPluginsDir = path.join(tempDir, ".omp", "plugins");
+			const legacyPluginsDir = path.join(tempDir, getConfigDirName(), "plugins");
 			await fs.mkdir(legacyPluginsDir, { recursive: true });
 			await fs.writeFile(
 				path.join(legacyPluginsDir, "installed_plugins.json"),
@@ -553,7 +564,7 @@ describe("listClaudePluginRoots", () => {
 			process.env.XDG_DATA_HOME = xdgBase;
 			await fs.mkdir(path.join(xdgBase, "omp"), { recursive: true });
 			// No XDG registry file — but write a legacy registry to confirm it is not read.
-			const legacyPluginsDir = path.join(tempDir, ".omp", "plugins");
+			const legacyPluginsDir = path.join(tempDir, getConfigDirName(), "plugins");
 			await fs.mkdir(legacyPluginsDir, { recursive: true });
 			await fs.writeFile(
 				path.join(legacyPluginsDir, "installed_plugins.json"),
@@ -575,7 +586,7 @@ describe("listClaudePluginRoots", () => {
 			process.env.XDG_DATA_HOME = xdgBase;
 			await fs.mkdir(path.join(xdgBase, "omp"), { recursive: true });
 
-			const legacyPluginsDir = path.join(tempDir, ".omp", "plugins");
+			const legacyPluginsDir = path.join(tempDir, getConfigDirName(), "plugins");
 			expect(resolveUserPluginsDir(tempDir)).toBe(legacyPluginsDir);
 		});
 	});

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -567,8 +567,10 @@ describe("listClaudePluginRoots", () => {
 		});
 
 		test("XDG not applied when home differs from os.homedir()", async () => {
-			// No spy — os.homedir() returns the real home, but tempDir != real home.
+			// Override the outer describe's os.homedir mock so the home-equality guard
+			// in resolveUserPluginsDir fails — home=tempDir, os.homedir()=elsewhere.
 			// resolveUserPluginsDir must skip XDG even if XDG_DATA_HOME is set.
+			homedirSpy = spyOn(os, "homedir").mockReturnValue(path.join(tempDir, "not-home"));
 			const xdgBase = path.join(tempDir, "xdg");
 			process.env.XDG_DATA_HOME = xdgBase;
 			await fs.mkdir(path.join(xdgBase, "omp"), { recursive: true });

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, spyOn, test, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, type Mock, spyOn, test, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -469,9 +469,10 @@ describe("listClaudePluginRoots", () => {
 		const found = result.all.find(command => command.name === "manifest-commands-outside:ship");
 
 		expect(found).toBeUndefined();
+		});
 
 	describe("XDG data directory support", () => {
-		let homedirSpy: ReturnType<typeof spyOn> | undefined;
+		let homedirSpy: Mock<() => string> | undefined;
 		let savedXdgDataHome: string | undefined;
 
 		beforeEach(() => {

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -256,29 +256,59 @@ export function getPluginsDir(): string {
  * (matching DirResolver's `isDefault` guard exactly: PI_CODING_AGENT_DIR must
  * be unset or point to the same path as the default agent dir), XDG is not
  * applied — preserving test isolation and consistency with the write path.
+ *
+ * The decision is memoized per `(home, os.homedir(), XDG_DATA_HOME, PI_CODING_AGENT_DIR)`
+ * tuple so it matches `DirResolver`'s “decide once at startup” semantics. Without
+ * this, reads and writes can diverge if `$XDG_DATA_HOME/omp` is created after the
+ * process started (e.g. external migration), leaving newly-written plugins invisible
+ * to discovery until restart. Tests that intentionally mutate filesystem/env state
+ * within a single `home` scope can call `resetUserPluginsDirCache()` to re-evaluate.
  */
+const userPluginsDirCache = new Map<string, string>();
+
 export function resolveUserPluginsDir(home: string): string {
 	// Replicate DirResolver's `isDefault` guard exactly: XDG is skipped when a
 	// non-default agent dir is active. This mirrors `isDefault = agentDir === defaultAgent`.
-	const _agentDirOverride = process.env.PI_CODING_AGENT_DIR;
-	const _isDefaultAgentDir =
-		!_agentDirOverride || path.resolve(_agentDirOverride) === path.join(home, getConfigDirName(), "agent");
+	const agentDirOverride = process.env.PI_CODING_AGENT_DIR;
+	const xdgDataHome = process.env.XDG_DATA_HOME;
+	const realHome = os.homedir();
+
+	// Key includes every input that influences the decision. Different tests use
+	// different `home` tempdirs, so each test gets its own cache slot and the
+	// first call within a test captures that test's filesystem state correctly.
+	const cacheKey = `${home}\0${realHome}\0${xdgDataHome ?? ""}\0${agentDirOverride ?? ""}`;
+	const cached = userPluginsDirCache.get(cacheKey);
+	if (cached !== undefined) return cached;
+
+	const isDefaultAgentDir =
+		!agentDirOverride || path.resolve(agentDirOverride) === path.join(home, getConfigDirName(), "agent");
 	if (
 		(process.platform === "linux" || process.platform === "darwin") &&
-		_isDefaultAgentDir &&
-		path.resolve(home) === path.resolve(os.homedir())
+		isDefaultAgentDir &&
+		path.resolve(home) === path.resolve(realHome)
 	) {
-		const xdgData = process.env.XDG_DATA_HOME;
-		if (xdgData) {
+		if (xdgDataHome) {
 			try {
-				const xdgRoot = path.join(xdgData, APP_NAME);
+				const xdgRoot = path.join(xdgDataHome, APP_NAME);
 				if (fs.existsSync(xdgRoot)) {
-					return path.join(xdgRoot, "plugins");
+					const result = path.join(xdgRoot, "plugins");
+					userPluginsDirCache.set(cacheKey, result);
+					return result;
 				}
 			} catch {}
 		}
 	}
-	return path.join(home, getConfigDirName(), "plugins");
+	const result = path.join(home, getConfigDirName(), "plugins");
+	userPluginsDirCache.set(cacheKey, result);
+	return result;
+}
+
+/**
+ * Invalidate the XDG-activation cache. Call from tests that mutate
+ * `$XDG_DATA_HOME`/filesystem state within a single `home` scope.
+ */
+export function resetUserPluginsDirCache(): void {
+	userPluginsDirCache.clear();
 }
 
 /** Where npm installs packages (~/.omp/plugins/node_modules). */

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -130,8 +130,10 @@ class DirResolver {
 		this.agentDir = agentDirOverride ? path.resolve(agentDirOverride) : defaultAgent;
 		const isDefault = this.agentDir === defaultAgent;
 
-		// XDG is a Linux convention. On other platforms, or for non-default
-		// profiles, all categories resolve to the legacy paths.
+		// XDG is a Linux convention, but macOS users sometimes configure these vars
+		// (e.g. via Homebrew dotfiles or Nix). We respect them on darwin too; the
+		// directory-existence guard below prevents accidental activation on systems
+		// where the vars are set but no migration has been done.
 		let xdgData: string | undefined;
 		let xdgState: string | undefined;
 		let xdgCache: string | undefined;
@@ -244,12 +246,26 @@ export function getPluginsDir(): string {
 /**
  * Resolves the plugins directory path for the given user home, respecting XDG.
  * Uses the same activation condition as DirResolver: $XDG_DATA_HOME/omp directory must exist.
- * When `home` differs from the current os.homedir(), XDG is not applied —
- * this preserves test isolation when a caller passes a temp directory as home.
+ *
+ * XDG is a Linux convention, but macOS users sometimes configure XDG_DATA_HOME
+ * (e.g. via Homebrew dotfiles or Nix). darwin is therefore treated identically
+ * to linux. The directory-existence guard prevents activation on systems where
+ * the var is set but data has not been migrated.
+ *
+ * When `home` differs from os.homedir(), or when the agent dir is non-default
+ * (matching DirResolver's `isDefault` guard exactly: PI_CODING_AGENT_DIR must
+ * be unset or point to the same path as the default agent dir), XDG is not
+ * applied — preserving test isolation and consistency with the write path.
  */
 export function resolveUserPluginsDir(home: string): string {
+	// Replicate DirResolver's `isDefault` guard exactly: XDG is skipped when a
+	// non-default agent dir is active. This mirrors `isDefault = agentDir === defaultAgent`.
+	const _agentDirOverride = process.env.PI_CODING_AGENT_DIR;
+	const _isDefaultAgentDir =
+		!_agentDirOverride || path.resolve(_agentDirOverride) === path.join(home, getConfigDirName(), "agent");
 	if (
 		(process.platform === "linux" || process.platform === "darwin") &&
+		_isDefaultAgentDir &&
 		path.resolve(home) === path.resolve(os.homedir())
 	) {
 		const xdgData = process.env.XDG_DATA_HOME;

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -241,6 +241,30 @@ export function getPluginsDir(): string {
 	return dirs.rootSubdir("plugins", "data");
 }
 
+/**
+ * Resolves the plugins directory path for the given user home, respecting XDG.
+ * Uses the same activation condition as DirResolver: $XDG_DATA_HOME/omp directory must exist.
+ * When `home` differs from the current os.homedir(), XDG is not applied —
+ * this preserves test isolation when a caller passes a temp directory as home.
+ */
+export function resolveUserPluginsDir(home: string): string {
+	if (
+		(process.platform === "linux" || process.platform === "darwin") &&
+		path.resolve(home) === path.resolve(os.homedir())
+	) {
+		const xdgData = process.env.XDG_DATA_HOME;
+		if (xdgData) {
+			try {
+				const xdgRoot = path.join(xdgData, APP_NAME);
+				if (fs.existsSync(xdgRoot)) {
+					return path.join(xdgRoot, "plugins");
+				}
+			} catch {}
+		}
+	}
+	return path.join(home, getConfigDirName(), "plugins");
+}
+
 /** Where npm installs packages (~/.omp/plugins/node_modules). */
 export function getPluginsNodeModules(): string {
 	return path.join(getPluginsDir(), "node_modules");


### PR DESCRIPTION
## What

`listClaudePluginRoots` was computing the OMP registry path with a hardcoded `path.join(home, configDirName, "plugins", ...)` that bypassed `DirResolver` entirely. On XDG-enabled systems the marketplace writes the registry to `$XDG_DATA_HOME/omp/plugins/installed_plugins.json` (via `getPluginsDir()` → `DirResolver.rootSubdir("plugins", "data")`), so discovery always read from the wrong path and marketplace-installed skills were silently ignored.

Supersedes #627 — same root cause, unified fix.

## Changes

**`packages/utils/src/dirs.ts`**
- Add `resolveUserPluginsDir(home: string): string` using the same directory-existence activation condition as `DirResolver` (`$XDG_DATA_HOME/omp` dir must exist). Guards: home must match `os.homedir()` (test isolation) and agent dir must be default (replicates `DirResolver`'s `isDefault` check exactly: `!override || path.resolve(override) === path.join(home, configDirName, "agent")`).
- Update DirResolver comment to explain darwin support.

**`packages/coding-agent/src/discovery/helpers.ts`**
- `listClaudePluginRoots`: replace hardcoded path with `resolveUserPluginsDir(home)`.
- Add `clearClaudePluginDiscoveryCaches(home, extraPaths?)`: unconditionally invalidates both the legacy and XDG path candidates. Routing through `resolveUserPluginsDir` for invalidation would miss the XDG entry after uninstall (file gone, dir still present → router returns legacy path).
- Replace four duplicate 5-line cache-clearing blocks across `main.ts`, `selector-controller.ts`, and `builtin-registry.ts` (3 sites).

## Why the PR approach differs from #627

The PR used a file-existence check (`existsSync` on the registry file). `DirResolver` uses a directory-existence check (`existsSync` on `$XDG_DATA_HOME/omp`). These diverge after uninstall: the dir remains, the file is gone, so a file-existence check would fall back to the legacy path and surface stale plugins. This fix uses directory existence throughout, keeping read and write paths semantically identical.

## Testing

Four new regression tests in `packages/coding-agent/test/discovery/claude-plugins.test.ts`:
1. XDG dir exists → plugin discovered via XDG path
2. XDG dir absent → legacy path used
3. XDG dir present, registry file absent → empty result (legacy not silently read)
4. `home !== os.homedir()` → XDG not applied (test isolation guard)