### PR TITLE
fix(status-line): strip complete ANSI escape sequences

### DIFF
--- a/packages/coding-agent/src/modes/shared.ts
+++ b/packages/coding-agent/src/modes/shared.ts
@@ -5,9 +5,16 @@ import { theme } from "./theme/theme";
 // Text Sanitization
 // ═══════════════════════════════════════════════════════════════════════════
 
-/** Sanitize text for display in a single-line status. Strips C0/C1 control characters (including ANSI ESC), collapses whitespace, trims. */
+const ANSI_OSC_RE = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
+const ANSI_CSI_RE = /\x1b\[[0-?]*[ -/]*[@-~]/g;
+const ANSI_SINGLE_RE = /\x1b[@-Z\\-_]/g;
+
+/** Sanitize text for display in a single-line status. Strips ANSI escape sequences, C0/C1 control characters, collapses whitespace, trims. */
 export function sanitizeStatusText(text: string): string {
 	return text
+		.replace(ANSI_OSC_RE, "")
+		.replace(ANSI_CSI_RE, "")
+		.replace(ANSI_SINGLE_RE, "")
 		.replace(/[\u0000-\u001f\u007f-\u009f]/g, " ")
 		.replace(/ +/g, " ")
 		.trim();


### PR DESCRIPTION
Fixes #713

   ## What

   - Updated `sanitizeStatusText()` in `packages/coding-agent/src/modes/shared.ts` to strip **full ANSI escape sequences** before control-char/whitespace normalization.
   - Added handling for:
     - OSC sequences (`ESC ] ... BEL/ST`)
     - CSI sequences (`ESC [ ...`)
     - single ESC sequences
   - This prevents literal fragments like `[38;2;...m` from leaking into footer hook status text.

   ## Why

   Extension hook statuses (e.g. from `pi-rewind`) can include themed ANSI output.
   The previous sanitizer removed ESC bytes only, leaving the payload text visible in the UI.
   This change fixes that regression while keeping existing status text normalization behavior.

   ## Testing

   - Reproduced the issue locally (`[38;...m` artifacts in footer hook status).
   - Built and ran local OMP from this commit on macOS arm64:
     - `bun run build:native`
     - `bun --cwd=packages/coding-agent run build`
     - `./packages/coding-agent/dist/omp`
   - Verified footer status renders cleanly (no ANSI payload fragments).

   ---

   - [ ] `bun check` passes
   - [x] Tested locally
   - [ ] CHANGELOG updated (if user-facing)