### PR TITLE
fix(coding-agent): handle truncation markers and nested anchors in hashline stripping

### DIFF
--- a/packages/coding-agent/src/edit/modes/hashline.ts
+++ b/packages/coding-agent/src/edit/modes/hashline.ts
@@ -52,12 +52,14 @@ export type HashlineEdit =
 const HASHLINE_PREFIX_RE = /^\s*(?:>>>|>>)?\s*(?:\+?\s*(?:\d+\s*#\s*|#\s*)|\+)\s*[ZPMQVRWSNKTXJBYH]{2}:/;
 const HASHLINE_PREFIX_PLUS_RE = /^\s*(?:>>>|>>)?\s*\+\s*(?:\d+\s*#\s*|#\s*)?[ZPMQVRWSNKTXJBYH]{2}:/;
 const DIFF_PLUS_RE = /^[+](?![+])/;
+const READ_TRUNCATION_NOTICE_RE = /^\[(?:Showing lines \d+-\d+ of \d+|\d+ more lines? in (?:file|\S+))\b.*\bsel=L\d+/;
 
 type LinePrefixStats = {
 	nonEmpty: number;
 	hashPrefixCount: number;
 	diffPlusHashPrefixCount: number;
 	diffPlusCount: number;
+	truncationNoticeCount: number;
 };
 
 function collectLinePrefixStats(lines: string[]): LinePrefixStats {
@@ -66,10 +68,15 @@ function collectLinePrefixStats(lines: string[]): LinePrefixStats {
 		hashPrefixCount: 0,
 		diffPlusHashPrefixCount: 0,
 		diffPlusCount: 0,
+		truncationNoticeCount: 0,
 	};
 
 	for (const line of lines) {
 		if (line.length === 0) continue;
+		if (READ_TRUNCATION_NOTICE_RE.test(line)) {
+			stats.truncationNoticeCount++;
+			continue;
+		}
 		stats.nonEmpty++;
 		if (HASHLINE_PREFIX_RE.test(line)) stats.hashPrefixCount++;
 		if (HASHLINE_PREFIX_PLUS_RE.test(line)) stats.diffPlusHashPrefixCount++;
@@ -77,6 +84,20 @@ function collectLinePrefixStats(lines: string[]): LinePrefixStats {
 	}
 
 	return stats;
+}
+
+function stripLeadingHashlinePrefixes(line: string): string {
+	let result = line;
+	let prev: string;
+	do {
+		prev = result;
+		result = result.replace(HASHLINE_PREFIX_RE, "");
+	} while (result !== prev);
+	return result;
+}
+
+function filterTruncationNotices(lines: string[]): string[] {
+	return lines.filter(line => !READ_TRUNCATION_NOTICE_RE.test(line));
 }
 
 export function stripNewLinePrefixes(lines: string[]): string[] {
@@ -88,20 +109,26 @@ export function stripNewLinePrefixes(lines: string[]): string[] {
 		!stripHash && diffPlusHashPrefixCount === 0 && diffPlusCount > 0 && diffPlusCount >= nonEmpty * 0.5;
 	if (!stripHash && !stripPlus && diffPlusHashPrefixCount === 0) return lines;
 
-	return lines.map(line => {
-		if (stripHash) return line.replace(HASHLINE_PREFIX_RE, "");
-		if (stripPlus) return line.replace(DIFF_PLUS_RE, "");
-		if (diffPlusHashPrefixCount > 0 && HASHLINE_PREFIX_PLUS_RE.test(line)) {
-			return line.replace(HASHLINE_PREFIX_RE, "");
-		}
-		return line;
-	});
+	const mapped = lines
+		.filter(line => !READ_TRUNCATION_NOTICE_RE.test(line))
+		.map(line => {
+			if (stripHash) return stripLeadingHashlinePrefixes(line);
+			if (stripPlus) return line.replace(DIFF_PLUS_RE, "");
+			if (diffPlusHashPrefixCount > 0 && HASHLINE_PREFIX_PLUS_RE.test(line)) {
+				return line.replace(HASHLINE_PREFIX_RE, "");
+			}
+			return line;
+		});
+	return mapped;
 }
 
 export function stripHashlinePrefixes(lines: string[]): string[] {
 	const { nonEmpty, hashPrefixCount } = collectLinePrefixStats(lines);
-	if (nonEmpty === 0 || hashPrefixCount !== nonEmpty) return lines;
-	return lines.map(line => line.replace(HASHLINE_PREFIX_RE, ""));
+	if (nonEmpty === 0) return lines;
+	if (hashPrefixCount !== nonEmpty) return lines;
+	return lines
+		.filter(line => !READ_TRUNCATION_NOTICE_RE.test(line))
+		.map(line => stripLeadingHashlinePrefixes(line));
 }
 
 const linesSchema = Type.Union([

--- a/packages/coding-agent/test/core/hashline.test.ts
+++ b/packages/coding-agent/test/core/hashline.test.ts
@@ -9,6 +9,7 @@ import {
 	parseTag,
 	streamHashLinesFromLines,
 	streamHashLinesFromUtf8,
+	stripHashlinePrefixes,
 	stripNewLinePrefixes,
 	validateLineRef,
 } from "@oh-my-pi/pi-coding-agent/edit";
@@ -942,6 +943,85 @@ describe("stripNewLinePrefixes", () => {
 		const lines = ["++conflict marker", "++another"];
 		expect(stripNewLinePrefixes(lines)).toEqual(["++conflict marker", "++another"]);
 	});
+
+	it("strips hashline prefixes when truncation marker is present (anchor corruption bug)", () => {
+		const lines = [
+			"1#BQ:---",
+			"2#XS:title: example",
+			"3#BQ:---",
+			"",
+			"[Showing lines 1-300 of 332. Use sel=L301 to continue]",
+		];
+		const result = stripNewLinePrefixes(lines);
+		expect(result).not.toContain("[Showing lines 1-300 of 332. Use sel=L301 to continue]");
+		expect(result[0]).toBe("---");
+		expect(result[1]).toBe("title: example");
+	});
+
+	it("strips hashline prefixes when generic read truncation notice is present", () => {
+		const lines = [
+			"1#BQ:line one",
+			"2#XS:line two",
+			"",
+			"[42 more lines in file. Use sel=L3 to continue]",
+		];
+		const result = stripNewLinePrefixes(lines);
+		expect(result[0]).toBe("line one");
+		expect(result[1]).toBe("line two");
+	});
+
+	it("strips nested hashline prefixes (already-corrupted content re-read)", () => {
+		const lines = [
+			"1#NX:1#BQ:---",
+			"2#TY:2#XS:title: example",
+			"3#JZ:3#BQ:---",
+		];
+		const result = stripNewLinePrefixes(lines);
+		expect(result[0]).toBe("---");
+		expect(result[1]).toBe("title: example");
+		expect(result[2]).toBe("---");
+	});
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// stripHashlinePrefixes — used by Write tool
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("stripHashlinePrefixes", () => {
+	it("strips when all non-empty lines have hashline prefixes", () => {
+		const lines = ["1#BQ:---", "2#XS:title", "", "4#VV:content"];
+		expect(stripHashlinePrefixes(lines)).toEqual(["---", "title", "", "content"]);
+	});
+
+	it("does NOT strip when lines are plain content", () => {
+		const lines = ["hello", "world"];
+		expect(stripHashlinePrefixes(lines)).toBe(lines);
+	});
+
+	it("strips hashline prefixes even when truncation marker is present (anchor corruption bug)", () => {
+		const lines = [
+			"1#BQ:---",
+			"2#XS:title: example",
+			"3#BQ:---",
+			"",
+			"[Showing lines 1-300 of 332. Use sel=L301 to continue]",
+		];
+		const result = stripHashlinePrefixes(lines);
+		expect(result).not.toContain("[Showing lines 1-300 of 332. Use sel=L301 to continue]");
+		expect(result[0]).toBe("---");
+		expect(result[1]).toBe("title: example");
+	});
+
+	it("strips nested hashline prefixes from already-corrupted content", () => {
+		const lines = [
+			"1#NX:1#BQ:---",
+			"2#TY:2#XS:title",
+		];
+		const result = stripHashlinePrefixes(lines);
+		expect(result[0]).toBe("---");
+		expect(result[1]).toBe("title");
+	});
+
 });
 
 // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

This PR fixes a rare but critical bug where Read tool metadata (line anchors and truncation markers) can leak into file content during editing, causing silent file corruption.

### Problem

When using the Edit or Write tool, the hashline prefix stripping logic (`stripHashlinePrefixes` / `stripNewLinePrefixes`) uses an **all-or-nothing heuristic**: it only strips `N#XX:` anchors if **every** non-empty line has one. 

If the AI model includes a Read tool truncation notice (e.g. `[Showing lines 1-300 of 332. Use sel=L301 to continue]`) in its Edit/Write call content, that non-prefixed marker line causes the heuristic to fail — **no anchors get stripped at all**, and they are written to disk verbatim. On the next read, those persisted anchors get double-prefixed (`1#NX:1#BQ:---`), compounding the corruption over subsequent edits.

**Observed corruption example:**
```markdown
1#XK:1#BQ:---
2#SN:2#XS:title: My Document
3#TZ:3#BQ:---

[Showing lines 1-300 of 332. Use sel=L301 to continue]
```

This was encountered during a real editing session with a markdown file. The corruption is silent — no error is raised, and the corrupted content persists.

### Root Cause Discussion

This is arguably a **boundary issue between the AI model and the toolchain**:
- The model should not paste raw Read tool output (with anchors/truncation markers) into Edit/Write calls
- However, the toolchain should be **resilient** against this rather than silently corrupting files

I'd appreciate the maintainer's perspective on whether this is better addressed at the toolchain level (as in this PR), at the model prompt/instruction level, or both. Either way, the defensive fix seems worthwhile since the corruption is silent and compounding.

### Changes

- **`hashline.ts`**:
  - Add `READ_TRUNCATION_NOTICE_RE` regex to detect Read tool truncation markers
  - Update `collectLinePrefixStats` to exclude truncation marker lines from the non-empty count, so they no longer break the stripping heuristic
  - Add `stripLeadingHashlinePrefixes` helper for **recursive** stripping of nested/double-prefixed anchors (handles already-corrupted content gracefully)
  - Add `filterTruncationNotices` helper to remove truncation marker lines from output
  - Update both `stripNewLinePrefixes` and `stripHashlinePrefixes` to filter truncation markers and use recursive anchor stripping

- **`hashline.test.ts`**:
  - Add 5 new test cases covering:
    - Truncation marker mixed with hashline-prefixed content
    - Generic read truncation notice format
    - Nested/double-prefixed anchors (already-corrupted content)
    - `stripHashlinePrefixes` with truncation markers
    - `stripHashlinePrefixes` with nested prefixes

### Test Plan

- [x] All 113 existing + new tests pass (`bun test packages/coding-agent/test/core/hashline.test.ts`)
- [x] No regressions in existing stripping behavior
- [x] New tests specifically cover the truncation marker and nested anchor edge cases
