### PR TITLE
FEAT: Add Ollama Cloud as an OpenAI compatible provider.

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Ollama Cloud provider (`ollama-cloud`) with OpenAI-compatible API routing via `https://ollama.com/v1`
+- Added 36 bundled Ollama Cloud models with context windows, input modalities, and thinking capabilities from `/api/tags` metadata
+- Added Ollama Cloud login flow directing users to `https://ollama.com/settings/keys` for API key creation
+- Added Ollama Cloud usage provider using `ollama-usage` CLI with `OLLAMA_BROWSER_COOKIE` for session and weekly quota tracking
+- Added `metadata.note` rendering in usage reports to display prerequisite warnings when `ollama-usage` CLI or `OLLAMA_BROWSER_COOKIE` is missing
+
+### Changed
+
+- Changed Ollama Cloud dynamic model discovery to merge with bundled references, falling back to 222k context window for unknown models
+
 ## [14.1.1] - 2026-04-14
 
 ### Added

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -26,6 +26,7 @@ import { googleGeminiCliUsageProvider } from "./usage/gemini";
 import { githubCopilotUsageProvider } from "./usage/github-copilot";
 import { antigravityUsageProvider } from "./usage/google-antigravity";
 import { kimiUsageProvider } from "./usage/kimi";
+import { ollamaCloudUsageProvider } from "./usage/ollama-cloud";
 import { codexRankingStrategy, openaiCodexUsageProvider } from "./usage/openai-codex";
 import { zaiUsageProvider } from "./usage/zai";
 import { getOAuthApiKey, getOAuthProvider, refreshOAuthToken } from "./utils/oauth";
@@ -51,6 +52,7 @@ import { loginMoonshot } from "./utils/oauth/moonshot";
 import { loginNanoGPT } from "./utils/oauth/nanogpt";
 import { loginNvidia } from "./utils/oauth/nvidia";
 import { loginOllama } from "./utils/oauth/ollama";
+import { loginOllamaCloud } from "./utils/oauth/ollama-cloud";
 import { loginOpenAICodex } from "./utils/oauth/openai-codex";
 import { loginOpenCode } from "./utils/oauth/opencode";
 import { loginParallel } from "./utils/oauth/parallel";
@@ -158,6 +160,7 @@ const DEFAULT_USAGE_PROVIDERS: UsageProvider[] = [
 	claudeUsageProvider,
 	zaiUsageProvider,
 	githubCopilotUsageProvider,
+	ollamaCloudUsageProvider,
 ];
 
 const DEFAULT_USAGE_PROVIDER_MAP = new Map<Provider, UsageProvider>(
@@ -828,6 +831,14 @@ export class AuthStorage {
 			}
 			case "ollama": {
 				const apiKey = await loginOllama(ctrl);
+				if (!apiKey) {
+					return;
+				}
+				await saveApiKeyCredential(apiKey);
+				return;
+			}
+			case "ollama-cloud": {
+				const apiKey = await loginOllamaCloud(ctrl);
 				if (!apiKey) {
 					return;
 				}

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -40146,6 +40146,811 @@
 			}
 		}
 	},
+	"ollama-cloud": {
+		"cogito-2.1:671b": {
+			"id": "cogito-2.1:671b",
+			"name": "Cogito 2.1",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 163840,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"deepseek-v3.1:671b": {
+			"id": "deepseek-v3.1:671b",
+			"name": "DeepSeek V3.1",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 163840,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"deepseek-v3.2": {
+			"id": "deepseek-v3.2",
+			"name": "DeepSeek V3.2",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 163840,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"devstral-2:123b": {
+			"id": "devstral-2:123b",
+			"name": "Devstral 2",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384
+		},
+		"devstral-small-2:24b": {
+			"id": "devstral-small-2:24b",
+			"name": "Devstral Small 2",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384
+		},
+		"gemini-3-flash-preview": {
+			"id": "gemini-3-flash-preview",
+			"name": "Gemini 3 Flash Preview",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"gemma3:12b": {
+			"id": "gemma3:12b",
+			"name": "Gemma 3 (12B)",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 16384
+		},
+		"gemma3:27b": {
+			"id": "gemma3:27b",
+			"name": "Gemma 3 (27B)",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 16384
+		},
+		"gemma3:4b": {
+			"id": "gemma3:4b",
+			"name": "Gemma 3 (4B)",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 16384
+		},
+		"gemma4:31b": {
+			"id": "gemma4:31b",
+			"name": "Gemma 4",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"glm-4.6": {
+			"id": "glm-4.6",
+			"name": "GLM 4.6",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 202752,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"glm-4.7": {
+			"id": "glm-4.7",
+			"name": "GLM 4.7",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 202752,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"glm-5.1": {
+			"id": "glm-5.1",
+			"name": "GLM 5.1",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 202752,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"glm-5": {
+			"id": "glm-5",
+			"name": "GLM 5",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 202752,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"gpt-oss:120b": {
+			"id": "gpt-oss:120b",
+			"name": "GPT OSS (120B)",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"gpt-oss:20b": {
+			"id": "gpt-oss:20b",
+			"name": "GPT OSS (20B)",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"kimi-k2-thinking": {
+			"id": "kimi-k2-thinking",
+			"name": "Kimi K2 Thinking",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"kimi-k2.5": {
+			"id": "kimi-k2.5",
+			"name": "Kimi K2.5",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"kimi-k2:1t": {
+			"id": "kimi-k2:1t",
+			"name": "Kimi K2",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384
+		},
+		"minimax-m2.1": {
+			"id": "minimax-m2.1",
+			"name": "MiniMax M2.1",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 204800,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"minimax-m2.5": {
+			"id": "minimax-m2.5",
+			"name": "MiniMax M2.5",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 204800,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"minimax-m2.7": {
+			"id": "minimax-m2.7",
+			"name": "MiniMax M2.7",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 196608,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"minimax-m2": {
+			"id": "minimax-m2",
+			"name": "MiniMax M2",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 204800,
+			"maxTokens": 16384
+		},
+		"ministral-3:14b": {
+			"id": "ministral-3:14b",
+			"name": "Ministral 3 (14B)",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384
+		},
+		"ministral-3:3b": {
+			"id": "ministral-3:3b",
+			"name": "Ministral 3 (3B)",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384
+		},
+		"ministral-3:8b": {
+			"id": "ministral-3:8b",
+			"name": "Ministral 3 (8B)",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384
+		},
+		"mistral-large-3:675b": {
+			"id": "mistral-large-3:675b",
+			"name": "Mistral Large 3",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384
+		},
+		"nemotron-3-nano:30b": {
+			"id": "nemotron-3-nano:30b",
+			"name": "Nemotron 3 Nano",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"nemotron-3-super": {
+			"id": "nemotron-3-super",
+			"name": "Nemotron 3 Super",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"qwen3-coder-next": {
+			"id": "qwen3-coder-next",
+			"name": "Qwen 3 Coder Next",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384
+		},
+		"qwen3-coder:480b": {
+			"id": "qwen3-coder:480b",
+			"name": "Qwen 3 Coder (480B)",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384
+		},
+		"qwen3-next:80b": {
+			"id": "qwen3-next:80b",
+			"name": "Qwen 3 Next (80B)",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"qwen3-vl:235b-instruct": {
+			"id": "qwen3-vl:235b-instruct",
+			"name": "Qwen 3 VL (235B) Instruct",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384
+		},
+		"qwen3-vl:235b": {
+			"id": "qwen3-vl:235b",
+			"name": "Qwen 3 VL (235B)",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"qwen3.5:397b": {
+			"id": "qwen3.5:397b",
+			"name": "Qwen 3.5 (397B)",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"rnj-1:8b": {
+			"id": "rnj-1:8b",
+			"name": "RNJ 1",
+			"api": "openai-responses",
+			"provider": "ollama-cloud",
+			"baseUrl": "https://ollama.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 32768,
+			"maxTokens": 16384
+		}
+	},
 	"qianfan": {
 		"deepseek-v3.2": {
 			"id": "deepseek-v3.2",

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -23,6 +23,7 @@ import {
 	moonshotModelManagerOptions,
 	nanoGptModelManagerOptions,
 	nvidiaModelManagerOptions,
+	ollamaCloudModelManagerOptions,
 	ollamaModelManagerOptions,
 	openaiModelManagerOptions,
 	opencodeGoModelManagerOptions,
@@ -183,6 +184,12 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		config => ollamaModelManagerOptions(config),
 		catalog("Ollama", ["OLLAMA_API_KEY"]),
 		{ allowUnauthenticated: true },
+	),
+	catalogDescriptor(
+		"ollama-cloud",
+		"qwen3-coder-next",
+		config => ollamaCloudModelManagerOptions(config),
+		catalog("Ollama Cloud", ["OLLAMA_CLOUD_API_KEY"]),
 	),
 	catalogDescriptor(
 		"cloudflare-ai-gateway",

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -645,6 +645,47 @@ export function ollamaModelManagerOptions(config?: OllamaModelManagerConfig): Mo
 }
 
 // ---------------------------------------------------------------------------
+// 9b. Ollama Cloud
+// ---------------------------------------------------------------------------
+
+export interface OllamaCloudModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+}
+
+export function ollamaCloudModelManagerOptions(
+	config?: OllamaCloudModelManagerConfig,
+): ModelManagerOptions<"openai-responses"> {
+	const apiKey = config?.apiKey;
+	const baseUrl = config?.baseUrl ?? "https://ollama.com/v1";
+	const references = createBundledReferenceMap<"openai-responses">("ollama-cloud");
+	return {
+		providerId: "ollama-cloud",
+		...(apiKey && {
+			fetchDynamicModels: () =>
+				fetchOpenAICompatibleModels({
+					api: "openai-responses",
+					provider: "ollama-cloud",
+					baseUrl,
+					apiKey,
+					mapModel: (entry, defaults) => {
+						const reference = references.get(defaults.id);
+						if (!reference) {
+							return {
+								...defaults,
+								name: toModelName(entry.name, defaults.name),
+								contextWindow: 222000,
+								maxTokens: 16384,
+							};
+						}
+						return mapWithBundledReference(entry, defaults, reference);
+					},
+				}),
+		}),
+	};
+}
+
+// ---------------------------------------------------------------------------
 // 10. OpenRouter
 // ---------------------------------------------------------------------------
 
@@ -2041,7 +2082,10 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_SPECIALIZED: readonly ModelsDevProviderDes
 			return model;
 		},
 	}),
+	// --- Ollama Cloud ---
+	openAiCompletionsDescriptor("ollama-cloud", "ollama-cloud", "https://ollama.com/v1"),
 	// --- MiniMax (Anthropic) ---
+
 	anthropicMessagesDescriptor("minimax", "minimax", "https://api.minimax.io/anthropic"),
 	anthropicMessagesDescriptor("minimax-cn", "minimax-cn", "https://api.minimaxi.com/anthropic"),
 	// --- Qwen Portal ---

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -136,6 +136,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	nanogpt: "NANO_GPT_API_KEY",
 	"lm-studio": "LM_STUDIO_API_KEY",
 	ollama: "OLLAMA_API_KEY",
+	"ollama-cloud": "OLLAMA_CLOUD_API_KEY",
 	"llama.cpp": "LLAMA_CPP_API_KEY",
 	qianfan: "QIANFAN_API_KEY",
 	"qwen-portal": () => $pickenv("QWEN_OAUTH_TOKEN", "QWEN_PORTAL_API_KEY"),

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -119,6 +119,7 @@ export type KnownProvider =
 	| "nvidia"
 	| "nanogpt"
 	| "ollama"
+	| "ollama-cloud"
 	| "qianfan"
 	| "qwen-portal"
 	| "together"

--- a/packages/ai/src/usage/ollama-cloud.ts
+++ b/packages/ai/src/usage/ollama-cloud.ts
@@ -133,10 +133,10 @@ async function fetchOllamaUsageOutput(cookie: string): Promise<OllamaUsageJson> 
 function buildPrereqNote(): string {
 	const parts: string[] = [];
 	if (!checkOllamaUsageAvailable()) {
-		parts.push("install ollama-usage CLI (pip install ollama-usage)");
+		parts.push("install ollama-usage CLI (pip install git+https://github.com/florian-croiset/ollama-usage)");
 	}
 	if (!getBrowserCookie()) {
-		parts.push("set OLLAMA_BROWSER_COOKIE env var");
+		parts.push("set OLLAMA_BROWSER_COOKIE env var (See https://github.com/florian-croiset/ollama-usage?tab=readme-ov-file#finding-your-cookie-manually for info.");
 	}
 	return parts.length > 0 ? `Requires: ${parts.join(" and ")}` : "";
 }

--- a/packages/ai/src/usage/ollama-cloud.ts
+++ b/packages/ai/src/usage/ollama-cloud.ts
@@ -26,6 +26,9 @@ import type {
 const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
 
+const OLLAMA_USAGE_REPO = "https://github.com/1ts-Alec/ollama-usage";
+const MAX_STDERR_LENGTH = 200;
+
 interface OllamaUsageJson {
 	plan: string;
 	session: {
@@ -36,6 +39,20 @@ interface OllamaUsageJson {
 		used_pct: number;
 		resets_at: string;
 	};
+}
+
+function isValidUsageJson(value: unknown): value is OllamaUsageJson {
+	if (typeof value !== "object" || value === null) return false;
+	const obj = value as Record<string, unknown>;
+	if (typeof obj.plan !== "string") return false;
+	for (const key of ["session", "weekly"] as const) {
+		const bucket = obj[key];
+		if (typeof bucket !== "object" || bucket === null) return false;
+		const b = bucket as Record<string, unknown>;
+		if (typeof b.used_pct !== "number") return false;
+		if (typeof b.resets_at !== "string") return false;
+	}
+	return true;
 }
 
 function parseIsoTime(value: string | undefined): number | undefined {
@@ -98,51 +115,69 @@ function buildLimit(args: {
 	};
 }
 
-function checkOllamaUsageAvailable(): boolean {
+let ollamaUsageAvailable: boolean | undefined;
+
+async function checkOllamaUsageAvailable(): Promise<boolean> {
+	if (ollamaUsageAvailable !== undefined) return ollamaUsageAvailable;
 	try {
-		const result = Bun.spawnSync(["ollama-usage", "--version"], {
-			stdout: "pipe",
-			stderr: "pipe",
+		const proc = Bun.spawn(["ollama-usage", "--version"], {
+			stdout: "ignore",
+			stderr: "ignore",
 		});
-		return result.exitCode === 0;
+		const exitCode = await proc.exited;
+		ollamaUsageAvailable = exitCode === 0;
 	} catch {
-		return false;
+		ollamaUsageAvailable = false;
 	}
+	return ollamaUsageAvailable;
 }
 
 function getBrowserCookie(): string | undefined {
 	return Bun.env.OLLAMA_BROWSER_COOKIE?.trim() || undefined;
 }
 
+// The cookie is passed via OLLAMA_BROWSER_COOKIE env var — never as a CLI
+// argument, which would be visible in the process list to all local users.
 async function fetchOllamaUsageOutput(cookie: string): Promise<OllamaUsageJson> {
-	const proc = Bun.spawn(["ollama-usage", "--cookie", cookie, "--json"], {
+	const proc = Bun.spawn(["ollama-usage", "--json"], {
 		stdout: "pipe",
 		stderr: "pipe",
+		env: { ...process.env, OLLAMA_BROWSER_COOKIE: cookie },
 	});
 
 	const exitCode = await proc.exited;
 	if (exitCode !== 0) {
 		const stderr = await new Response(proc.stderr).text();
-		throw new Error(`ollama-usage exited with code ${exitCode}: ${stderr.trim()}`);
+		const sanitized = stderr
+			.trim()
+			.slice(0, MAX_STDERR_LENGTH)
+			.replaceAll(/[\t\r]/g, " ");
+		throw new Error(`ollama-usage exited with code ${exitCode}: ${sanitized}`);
 	}
 
 	const stdout = await new Response(proc.stdout).text();
-	return JSON.parse(stdout) as OllamaUsageJson;
+	const parsed: unknown = JSON.parse(stdout);
+	if (!isValidUsageJson(parsed)) {
+		throw new Error("ollama-usage returned unexpected JSON shape");
+	}
+	return parsed;
 }
 
-function buildPrereqNote(): string {
+async function buildPrereqNote(): Promise<string> {
 	const parts: string[] = [];
-	if (!checkOllamaUsageAvailable()) {
-		parts.push("install ollama-usage CLI (pip install git+https://github.com/florian-croiset/ollama-usage)");
+	if (!(await checkOllamaUsageAvailable())) {
+		parts.push(`install ollama-usage CLI (pip install git+${OLLAMA_USAGE_REPO})`);
 	}
 	if (!getBrowserCookie()) {
-		parts.push("set OLLAMA_BROWSER_COOKIE env var (See https://github.com/florian-croiset/ollama-usage?tab=readme-ov-file#finding-your-cookie-manually for info.");
+		parts.push(
+			`set OLLAMA_BROWSER_COOKIE env var (see ${OLLAMA_USAGE_REPO}?tab=readme-ov-file#finding-your-cookie-manually for info)`,
+		);
 	}
 	return parts.length > 0 ? `Requires: ${parts.join(" and ")}` : "";
 }
 
-function buildPrereqReport(): UsageReport {
-	const note = buildPrereqNote();
+async function buildPrereqReport(): Promise<UsageReport> {
+	const note = await buildPrereqNote();
 	return {
 		provider: "ollama-cloud",
 		fetchedAt: Date.now(),
@@ -155,7 +190,7 @@ function buildPrereqReport(): UsageReport {
 
 async function fetchOllamaCloudUsage(_params: UsageFetchParams, _ctx: UsageFetchContext): Promise<UsageReport | null> {
 	const cookie = getBrowserCookie();
-	const cliAvailable = checkOllamaUsageAvailable();
+	const cliAvailable = await checkOllamaUsageAvailable();
 
 	if (!cliAvailable || !cookie) {
 		return buildPrereqReport();
@@ -165,7 +200,6 @@ async function fetchOllamaCloudUsage(_params: UsageFetchParams, _ctx: UsageFetch
 	try {
 		output = await fetchOllamaUsageOutput(cookie);
 	} catch (error) {
-		// If the CLI fails, return a report with the error as a note
 		return {
 			provider: "ollama-cloud",
 			fetchedAt: Date.now(),
@@ -176,9 +210,9 @@ async function fetchOllamaCloudUsage(_params: UsageFetchParams, _ctx: UsageFetch
 		};
 	}
 
-	const plan = output.plan ?? "unknown";
-	const sessionResetsAt = parseIsoTime(output.session?.resets_at);
-	const weeklyResetsAt = parseIsoTime(output.weekly?.resets_at);
+	const plan = output.plan;
+	const sessionResetsAt = parseIsoTime(output.session.resets_at);
+	const weeklyResetsAt = parseIsoTime(output.weekly.resets_at);
 
 	const limits = [
 		buildLimit({
@@ -187,7 +221,7 @@ async function fetchOllamaCloudUsage(_params: UsageFetchParams, _ctx: UsageFetch
 			windowId: "session",
 			windowLabel: "Session",
 			durationMs: FIVE_HOURS_MS,
-			usedPct: output.session?.used_pct,
+			usedPct: output.session.used_pct,
 			resetsAt: sessionResetsAt,
 			plan,
 		}),
@@ -197,7 +231,7 @@ async function fetchOllamaCloudUsage(_params: UsageFetchParams, _ctx: UsageFetch
 			windowId: "weekly",
 			windowLabel: "Weekly",
 			durationMs: SEVEN_DAYS_MS,
-			usedPct: output.weekly?.used_pct,
+			usedPct: output.weekly.used_pct,
 			resetsAt: weeklyResetsAt,
 			plan,
 		}),

--- a/packages/ai/src/usage/ollama-cloud.ts
+++ b/packages/ai/src/usage/ollama-cloud.ts
@@ -1,0 +1,221 @@
+/**
+ * Ollama Cloud usage provider.
+ *
+ * Fetches quota usage via the `ollama-usage` CLI tool using the
+ * `OLLAMA_BROWSER_COOKIE` environment variable.
+ *
+ * Prerequisites:
+ * 1. `ollama-usage` CLI tool available on PATH
+ * 2. `OLLAMA_BROWSER_COOKIE` environment variable set
+ *
+ * If either prerequisite is missing, returns a report with a note
+ * explaining what's needed rather than failing silently.
+ */
+
+import type {
+	UsageAmount,
+	UsageFetchContext,
+	UsageFetchParams,
+	UsageLimit,
+	UsageProvider,
+	UsageReport,
+	UsageStatus,
+	UsageWindow,
+} from "../usage";
+
+const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface OllamaUsageJson {
+	plan: string;
+	session: {
+		used_pct: number;
+		resets_at: string;
+	};
+	weekly: {
+		used_pct: number;
+		resets_at: string;
+	};
+}
+
+function parseIsoTime(value: string | undefined): number | undefined {
+	if (!value) return undefined;
+	const parsed = Date.parse(value);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function buildAmount(usedPct: number | undefined): UsageAmount {
+	if (usedPct === undefined || !Number.isFinite(usedPct)) {
+		return { unit: "percent" };
+	}
+	const clamped = Math.min(Math.max(usedPct, 0), 100);
+	const usedFraction = clamped / 100;
+	return {
+		used: clamped,
+		limit: 100,
+		remaining: Math.max(0, 100 - clamped),
+		usedFraction,
+		remainingFraction: Math.max(0, 1 - usedFraction),
+		unit: "percent",
+	};
+}
+
+function deriveStatus(amount: UsageAmount): UsageStatus | undefined {
+	if (amount.usedFraction === undefined) return undefined;
+	if (amount.usedFraction >= 1) return "exhausted";
+	if (amount.usedFraction >= 0.9) return "warning";
+	return "ok";
+}
+
+function buildLimit(args: {
+	id: string;
+	label: string;
+	windowId: string;
+	windowLabel: string;
+	durationMs: number;
+	usedPct: number | undefined;
+	resetsAt: number | undefined;
+	plan: string;
+}): UsageLimit | null {
+	const amount = buildAmount(args.usedPct);
+	const window: UsageWindow = {
+		id: args.windowId,
+		label: args.windowLabel,
+		durationMs: args.durationMs,
+		...(args.resetsAt !== undefined ? { resetsAt: args.resetsAt } : {}),
+	};
+	return {
+		id: args.id,
+		label: args.label,
+		scope: {
+			provider: "ollama-cloud",
+			windowId: args.windowId,
+			tier: args.plan,
+		},
+		window,
+		amount,
+		status: deriveStatus(amount),
+	};
+}
+
+function checkOllamaUsageAvailable(): boolean {
+	try {
+		const result = Bun.spawnSync(["ollama-usage", "--version"], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		return result.exitCode === 0;
+	} catch {
+		return false;
+	}
+}
+
+function getBrowserCookie(): string | undefined {
+	return Bun.env.OLLAMA_BROWSER_COOKIE?.trim() || undefined;
+}
+
+async function fetchOllamaUsageOutput(cookie: string): Promise<OllamaUsageJson> {
+	const proc = Bun.spawn(["ollama-usage", "--cookie", cookie, "--json"], {
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+
+	const exitCode = await proc.exited;
+	if (exitCode !== 0) {
+		const stderr = await new Response(proc.stderr).text();
+		throw new Error(`ollama-usage exited with code ${exitCode}: ${stderr.trim()}`);
+	}
+
+	const stdout = await new Response(proc.stdout).text();
+	return JSON.parse(stdout) as OllamaUsageJson;
+}
+
+function buildPrereqNote(): string {
+	const parts: string[] = [];
+	if (!checkOllamaUsageAvailable()) {
+		parts.push("install ollama-usage CLI (pip install ollama-usage)");
+	}
+	if (!getBrowserCookie()) {
+		parts.push("set OLLAMA_BROWSER_COOKIE env var");
+	}
+	return parts.length > 0 ? `Requires: ${parts.join(" and ")}` : "";
+}
+
+function buildPrereqReport(): UsageReport {
+	const note = buildPrereqNote();
+	return {
+		provider: "ollama-cloud",
+		fetchedAt: Date.now(),
+		limits: [],
+		metadata: {
+			note,
+		},
+	};
+}
+
+async function fetchOllamaCloudUsage(_params: UsageFetchParams, _ctx: UsageFetchContext): Promise<UsageReport | null> {
+	const cookie = getBrowserCookie();
+	const cliAvailable = checkOllamaUsageAvailable();
+
+	if (!cliAvailable || !cookie) {
+		return buildPrereqReport();
+	}
+
+	let output: OllamaUsageJson;
+	try {
+		output = await fetchOllamaUsageOutput(cookie);
+	} catch (error) {
+		// If the CLI fails, return a report with the error as a note
+		return {
+			provider: "ollama-cloud",
+			fetchedAt: Date.now(),
+			limits: [],
+			metadata: {
+				note: `Failed to fetch usage: ${error instanceof Error ? error.message : String(error)}`,
+			},
+		};
+	}
+
+	const plan = output.plan ?? "unknown";
+	const sessionResetsAt = parseIsoTime(output.session?.resets_at);
+	const weeklyResetsAt = parseIsoTime(output.weekly?.resets_at);
+
+	const limits = [
+		buildLimit({
+			id: "ollama-cloud:session",
+			label: "Session Usage",
+			windowId: "session",
+			windowLabel: "Session",
+			durationMs: FIVE_HOURS_MS,
+			usedPct: output.session?.used_pct,
+			resetsAt: sessionResetsAt,
+			plan,
+		}),
+		buildLimit({
+			id: "ollama-cloud:weekly",
+			label: "Weekly Usage",
+			windowId: "weekly",
+			windowLabel: "Weekly",
+			durationMs: SEVEN_DAYS_MS,
+			usedPct: output.weekly?.used_pct,
+			resetsAt: weeklyResetsAt,
+			plan,
+		}),
+	].filter((limit): limit is UsageLimit => limit !== null);
+
+	return {
+		provider: "ollama-cloud",
+		fetchedAt: Date.now(),
+		limits,
+		metadata: {
+			planType: plan,
+		},
+		raw: output,
+	};
+}
+
+export const ollamaCloudUsageProvider: UsageProvider = {
+	id: "ollama-cloud",
+	supports: ({ provider }) => provider === "ollama-cloud",
+	fetchUsage: fetchOllamaCloudUsage,
+};

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -91,6 +91,8 @@ export { loginNanoGPT } from "./nanogpt";
 export { loginNvidia } from "./nvidia";
 // Ollama (optional API key)
 export { loginOllama } from "./ollama";
+// Ollama Cloud (API key)
+export { loginOllamaCloud } from "./ollama-cloud";
 export type { OpenAICodexLoginOptions } from "./openai-codex";
 // OpenAI Codex (ChatGPT OAuth)
 export { loginOpenAICodex, refreshOpenAICodexToken } from "./openai-codex";
@@ -198,6 +200,11 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 	{
 		id: "ollama",
 		name: "Ollama (Local OpenAI-compatible)",
+		available: true,
+	},
+	{
+		id: "ollama-cloud",
+		name: "Ollama Cloud",
 		available: true,
 	},
 	{

--- a/packages/ai/src/utils/oauth/ollama-cloud.ts
+++ b/packages/ai/src/utils/oauth/ollama-cloud.ts
@@ -1,0 +1,46 @@
+/**
+ * Ollama Cloud login flow.
+ *
+ * Ollama Cloud (https://ollama.com/v1) is an OpenAI-compatible API that
+ * requires an API key for authentication.
+ *
+ * This flow is API-key based (not OAuth):
+ * 1. Optionally open Ollama Cloud docs
+ * 2. Prompt user for API key
+ * 3. Persist key
+ */
+
+import type { OAuthController } from "./types";
+
+const OLLAMA_CLOUD_URL = "https://ollama.com/settings/keys";
+
+/**
+ * Login to Ollama Cloud.
+ *
+ * Returns an API key string. Empty string means no key provided.
+ */
+export async function loginOllamaCloud(options: OAuthController): Promise<string> {
+	if (options.signal?.aborted) {
+		throw new Error("Login cancelled");
+	}
+	if (!options.onPrompt) {
+		return "";
+	}
+
+	options.onAuth?.({
+		url: OLLAMA_CLOUD_URL,
+		instructions: "Paste your Ollama Cloud API key from your account settings.",
+	});
+
+	const apiKey = await options.onPrompt({
+		message: "Paste your Ollama Cloud API key",
+		placeholder: "ollama-cloud-...",
+		allowEmpty: false,
+	});
+
+	if (options.signal?.aborted) {
+		throw new Error("Login cancelled");
+	}
+
+	return apiKey.trim();
+}

--- a/packages/ai/src/utils/oauth/ollama-cloud.ts
+++ b/packages/ai/src/utils/oauth/ollama-cloud.ts
@@ -42,5 +42,9 @@ export async function loginOllamaCloud(options: OAuthController): Promise<string
 		throw new Error("Login cancelled");
 	}
 
-	return apiKey.trim();
+	const trimmed = apiKey.trim();
+	if (!trimmed) {
+		return "";
+	}
+	return trimmed;
 }

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -30,6 +30,7 @@ export type OAuthProvider =
 	| "nvidia"
 	| "nanogpt"
 	| "ollama"
+	| "ollama-cloud"
 	| "openai-codex"
 	| "opencode-go"
 	| "opencode-zen"

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Changed usage report renderer to display warning icon and `metadata.note` for providers with zero limits instead of showing "no limits"
+
 ## [14.1.1] - 2026-04-14
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1225,9 +1225,16 @@ function renderUsageReports(reports: UsageReport[], uiTheme: typeof theme, nowMs
 			const label = formatUnlimitedReportLabel(report, 0);
 			const tier = report.metadata?.planType as string | undefined;
 			const tierSuffix = tier ? ` ${uiTheme.fg("dim", `(${tier})`)}` : "";
-			lines.push(
-				`${uiTheme.fg("success", uiTheme.status.success)} ${label}${tierSuffix} ${uiTheme.fg("dim", "-- no limits")}`,
-			);
+			const note = report.metadata?.note as string | undefined;
+			if (note) {
+				lines.push(
+					`${uiTheme.fg("warning", uiTheme.status.warning)} ${label}${tierSuffix} ${uiTheme.fg("dim", note)}`,
+				);
+			} else {
+				lines.push(
+					`${uiTheme.fg("success", uiTheme.status.success)} ${label}${tierSuffix} ${uiTheme.fg("dim", "-- no limits")}`,
+				);
+			}
 		}
 		// No per-provider footer; global header shows last check.
 	}


### PR DESCRIPTION
## What

Added Ollama Cloud as a provider with API key authentication, 36 bundled models with context windows and capabilities from /api/tags and /api/show metadata, and /usage support via an external Python package (optional)

## Why

Wanted a cleaner way to use Ollama Cloud models exclusively without going through the Ollama CLI.

## Testing

Ran on a VM, installed dependencies, cloned my fork, built, ran /login to trigger the Ollama Cloud API key flow, typed in my key, tested /usage with the Ollama Cloud provider, installed the mentioned `ollama-usage` pip package, followed steps in the repo to get my session cookie, reran /usage to verify it works and looks okay. Audited both my changes here and the `ollama-usage` package to ensure security.

---

- [Y] `bun check` passes
- [Y] Tested locally
- [Y] CHANGELOG updated (if user-facing)
