### PR TITLE
fix: show read tool content preview by default

### DIFF
--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -1,7 +1,8 @@
 import type { Component } from "@oh-my-pi/pi-tui";
 import { Container, Text } from "@oh-my-pi/pi-tui";
-import { theme } from "../../modes/theme/theme";
-import { shortenPath } from "../../tools/render-utils";
+import { getLanguageFromPath, theme } from "../../modes/theme/theme";
+import { PREVIEW_LIMITS, shortenPath } from "../../tools/render-utils";
+import { renderCodeCell } from "../../tui";
 import type { ToolExecutionHandle } from "./tool-execution";
 
 type ReadRenderArgs = {
@@ -35,11 +36,16 @@ type ReadEntry = {
 	sel?: string;
 	status: "pending" | "success" | "warning" | "error";
 	correctedFrom?: string;
+	contentText?: string;
 };
+
+/** Number of code lines to show in collapsed preview mode */
+const COLLAPSED_PREVIEW_LINES = PREVIEW_LIMITS.OUTPUT_COLLAPSED;
 
 export class ReadToolGroupComponent extends Container implements ToolExecutionHandle {
 	#entries = new Map<string, ReadEntry>();
 	#text: Text;
+	#expanded = false;
 
 	constructor() {
 		super();
@@ -81,6 +87,11 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 			entry.correctedFrom = undefined;
 		}
 		entry.status = result.isError ? "error" : suffixResolution ? "warning" : "success";
+		// Store the text content for preview/expanded display
+		const textContent = result.content?.find(c => c.type === "text")?.text;
+		if (textContent !== undefined) {
+			entry.contentText = textContent;
+		}
 		this.#updateDisplay();
 	}
 
@@ -88,7 +99,8 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 		this.#updateDisplay();
 	}
 
-	setExpanded(_expanded: boolean): void {
+	setExpanded(expanded: boolean): void {
+		this.#expanded = expanded;
 		this.#updateDisplay();
 	}
 
@@ -99,8 +111,13 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 	#updateDisplay(): void {
 		const entries = [...this.#entries.values()];
 
+		// Clear previous children and re-add the text node
+		this.clear();
+		this.#text = new Text("", 0, 0);
+
 		if (entries.length === 0) {
 			this.#text.setText(` ${theme.format.bullet} ${theme.fg("toolTitle", theme.bold("Read"))}`);
+			this.addChild(this.#text);
 			return;
 		}
 
@@ -109,6 +126,12 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 			const statusSymbol = this.#formatStatus(entry.status);
 			const pathDisplay = this.#formatPath(entry);
 			this.#text.setText(` ${statusSymbol} ${theme.fg("toolTitle", theme.bold("Read"))} ${pathDisplay}`.trimEnd());
+			this.addChild(this.#text);
+
+			// Show content preview (collapsed) or full content (expanded)
+			if (entry.contentText !== undefined) {
+				this.#addContentPreview(entry);
+			}
 			return;
 		}
 
@@ -123,6 +146,52 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 		}
 
 		this.#text.setText(lines.join("\n"));
+		this.addChild(this.#text);
+
+		// Show content for each entry: full when expanded, preview when collapsed
+		for (const entry of entries) {
+			if (entry.contentText !== undefined) {
+				this.#addContentPreview(entry);
+			}
+		}
+	}
+
+	/**
+	 * Add a code-cell content preview below the entry summary.
+	 * When collapsed: shows first COLLAPSED_PREVIEW_LINES lines with "… N more lines (Ctrl+O for more)" hint.
+	 * When expanded: shows full content.
+	 */
+	#addContentPreview(entry: ReadEntry): void {
+		const lang = getLanguageFromPath(entry.path);
+		const filePath = shortenPath(entry.path);
+		const title = filePath ? `Read ${filePath}` : "Read";
+		let cachedWidth: number | undefined;
+		let cachedLines: string[] | undefined;
+		const expanded = this.#expanded;
+		const component: Component = {
+			render: (width: number) => {
+				if (cachedLines && cachedWidth === width) return cachedLines;
+				cachedLines = renderCodeCell(
+					{
+						code: entry.contentText ?? "",
+						language: lang,
+						title,
+						status: entry.status === "error" ? "error" : entry.status === "pending" ? "pending" : "complete",
+						expanded,
+						codeMaxLines: expanded ? undefined : COLLAPSED_PREVIEW_LINES,
+						width,
+					},
+					theme,
+				);
+				cachedWidth = width;
+				return cachedLines;
+			},
+			invalidate: () => {
+				cachedWidth = undefined;
+				cachedLines = undefined;
+			},
+		};
+		this.addChild(component);
 	}
 
 	#formatPath(entry: ReadEntry): string {


### PR DESCRIPTION
## Problem

`ReadToolGroupComponent` completely hid read tool output in the TUI. It showed only a one-line path summary (e.g. `✓ Read src/config/keybindings.ts`) with zero file content — unlike bash (shows last 20 lines) and grep (shows matches).

Two bugs caused this:

1. **`setExpanded()` discarded its parameter** — the `_expanded` argument was ignored, so Ctrl+O had no effect on read output
2. **`updateResult()` discarded the content** — only `suffixResolution` was extracted from the result; the actual file text was thrown away

## Fix

- **Store expanded state** — `setExpanded(expanded)` now persists to `#expanded` field instead of ignoring it
- **Store result content** — `updateResult()` saves `result.content[text].text` into `entry.contentText`
- **Collapsed (default):** Shows a 3-line code preview with `"… N more lines (Ctrl+O for more)"` hint, using `PREVIEW_LIMITS.OUTPUT_COLLAPSED` for consistency
- **Expanded (Ctrl+O):** Shows full file content via `renderCodeCell` with `expanded: true`

### Before
```
✓ Read src/config/keybindings.ts
```

### After (collapsed)
```
✓ Read src/config/keybindings.ts
┌─ Read src/config/keybindings.ts ───────────┐
│ 1│ import { existsSync, readFileSync…        │
│ 2│ import { type Keybinding…                 │
│ 3│ import { setKeybindings, …                │
│ … 497 more lines (Ctrl+O for more)          │
└──────────────────────────────────────────────┘
```

### After (expanded, Ctrl+O)
Full file content rendered with syntax highlighting.

## Files changed

- `packages/coding-agent/src/modes/components/read-tool-group.ts` — the only file modified