### PR TITLE
fix(coding-agent): align Codex web search with catalog

### DIFF
--- a/packages/coding-agent/src/web/search/providers/codex.ts
+++ b/packages/coding-agent/src/web/search/providers/codex.ts
@@ -106,6 +106,125 @@ function isImagePlaceholderAnswer(text: string): boolean {
 	return text.trim().toLowerCase() === "(see attached image)";
 }
 
+function addSource(sources: SearchSource[], source: SearchSource): void {
+	if (!sources.some(existing => existing.url === source.url)) {
+		sources.push(source);
+	}
+}
+
+function countCharacter(text: string, target: string): number {
+	let count = 0;
+	for (const char of text) {
+		if (char === target) {
+			count += 1;
+		}
+	}
+	return count;
+}
+
+/**
+ * Strips prose punctuation and unmatched closing delimiters from extracted URLs.
+ * Codex often returns links in markdown or sentence text without structured annotations.
+ */
+function normalizeExtractedUrl(candidate: string): string | null {
+	let url = candidate.trim();
+
+	while (url.length > 0) {
+		const lastCharacter = url.at(-1);
+		if (!lastCharacter) break;
+		if (/[.,!?;:'"]/u.test(lastCharacter)) {
+			url = url.slice(0, -1);
+			continue;
+		}
+		if (lastCharacter === ")" && countCharacter(url, ")") > countCharacter(url, "(")) {
+			url = url.slice(0, -1);
+			continue;
+		}
+		if (lastCharacter === "]" && countCharacter(url, "]") > countCharacter(url, "[")) {
+			url = url.slice(0, -1);
+			continue;
+		}
+		if (lastCharacter === "}" && countCharacter(url, "}") > countCharacter(url, "{")) {
+			url = url.slice(0, -1);
+			continue;
+		}
+		break;
+	}
+
+	if (!/^https?:\/\//.test(url)) {
+		return null;
+	}
+
+	try {
+		return new URL(url).toString();
+	} catch {
+		return null;
+	}
+}
+
+function findMarkdownLinkUrlEnd(text: string, openParenIndex: number): number | null {
+	let depth = 0;
+
+	for (let index = openParenIndex; index < text.length; index += 1) {
+		const character = text[index];
+		if (!character || character === "\n") {
+			return null;
+		}
+		if (character === "(") {
+			depth += 1;
+			continue;
+		}
+		if (character !== ")") {
+			continue;
+		}
+		depth -= 1;
+		if (depth === 0) {
+			return index;
+		}
+		if (depth < 0) {
+			return null;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Extracts citation sources from markdown links and bare URLs in the answer text.
+ * Used as a fallback when the Codex response omits `url_citation` annotations.
+ */
+function extractTextSources(text: string): SearchSource[] {
+	const sources: SearchSource[] = [];
+
+	for (let index = 0; index < text.length; index += 1) {
+		if (text[index] !== "[") {
+			continue;
+		}
+		const titleEnd = text.indexOf("]", index + 1);
+		if (titleEnd === -1 || text[titleEnd + 1] !== "(") {
+			continue;
+		}
+		const urlEnd = findMarkdownLinkUrlEnd(text, titleEnd + 1);
+		if (urlEnd === null) {
+			continue;
+		}
+		const title = text.slice(index + 1, titleEnd).trim();
+		const url = normalizeExtractedUrl(text.slice(titleEnd + 2, urlEnd));
+		if (url) {
+			addSource(sources, { title: title || url, url });
+		}
+		index = urlEnd;
+	}
+
+	for (const match of text.matchAll(/https?:\/\/\S+/g)) {
+		const url = normalizeExtractedUrl(match[0] ?? "");
+		if (!url) continue;
+		addSource(sources, { title: url, url });
+	}
+
+	return sources;
+}
+
 /**
  * Extracts account ID from a Codex access token.
  * @param accessToken - JWT access token
@@ -211,6 +330,7 @@ async function callCodexSearch(
 				search_context_size: options.searchContextSize ?? "high",
 			},
 		],
+		tool_choice: { type: "web_search" },
 		instructions: options.systemPrompt ?? DEFAULT_INSTRUCTIONS,
 	};
 
@@ -262,12 +382,7 @@ async function callCodexSearch(
 							for (const annotation of part.annotations) {
 								if (annotation.type === "url_citation" && annotation.url) {
 									// Deduplicate by URL
-									if (!sources.some(s => s.url === annotation.url)) {
-										sources.push({
-											title: annotation.title ?? annotation.url,
-											url: annotation.url,
-										});
-									}
+									addSource(sources, { title: annotation.title ?? annotation.url, url: annotation.url });
 								}
 							}
 						}
@@ -316,6 +431,14 @@ async function callCodexSearch(
 			: streamedAnswer.length > 0
 				? streamedAnswer
 				: finalAnswer;
+
+	// Fallback: when Codex omits url_citation annotations, scrape markdown links
+	// and bare URLs from the synthesized answer so callers still receive sources.
+	if (sources.length === 0 && answer.length > 0) {
+		for (const source of extractTextSources(answer)) {
+			addSource(sources, source);
+		}
+	}
 
 	return {
 		answer,

--- a/packages/coding-agent/test/tools/web-search-codex.test.ts
+++ b/packages/coding-agent/test/tools/web-search-codex.test.ts
@@ -77,10 +77,106 @@ function makeImagePlaceholderSseResponse(model: string): string {
 	].join("\n");
 }
 
+function makeMarkdownLinkSseResponse(model: string): string {
+	return [
+		`data: ${JSON.stringify({
+			type: "response.output_item.done",
+			item: {
+				type: "message",
+				content: [
+					{
+						type: "output_text",
+						text: "See [Example Article](https://example.com/article) for details.",
+						annotations: [],
+					},
+				],
+			},
+		})}`,
+		"",
+		`data: ${JSON.stringify({
+			type: "response.completed",
+			response: { id: "resp_codex_markdown_test", model },
+		})}`,
+		"",
+	].join("\n");
+}
+
+function makePlainUrlSseResponse(model: string): string {
+	return [
+		`data: ${JSON.stringify({
+			type: "response.output_item.done",
+			item: {
+				type: "message",
+				content: [
+					{
+						type: "output_text",
+						text: "Sources:\n- https://example.com/article\n- https://example.com/faq",
+						annotations: [],
+					},
+				],
+			},
+		})}`,
+		"",
+		`data: ${JSON.stringify({
+			type: "response.completed",
+			response: { id: "resp_codex_plain_url_test", model },
+		})}`,
+		"",
+	].join("\n");
+}
+
+function makeMarkdownParenthesesSseResponse(model: string): string {
+	return [
+		`data: ${JSON.stringify({
+			type: "response.output_item.done",
+			item: {
+				type: "message",
+				content: [
+					{
+						type: "output_text",
+						text: "See [Function](https://en.wikipedia.org/wiki/Function_(mathematics)) for details.",
+						annotations: [],
+					},
+				],
+			},
+		})}`,
+		"",
+		`data: ${JSON.stringify({
+			type: "response.completed",
+			response: { id: "resp_codex_markdown_parentheses_test", model },
+		})}`,
+		"",
+	].join("\n");
+}
+
+function makePlainUrlPunctuationSseResponse(model: string): string {
+	return [
+		`data: ${JSON.stringify({
+			type: "response.output_item.done",
+			item: {
+				type: "message",
+				content: [
+					{
+						type: "output_text",
+						text: "Read https://example.com/article. Then compare https://example.com/faq), and keep https://en.wikipedia.org/wiki/Function_(mathematics).",
+						annotations: [],
+					},
+				],
+			},
+		})}`,
+		"",
+		`data: ${JSON.stringify({
+			type: "response.completed",
+			response: { id: "resp_codex_plain_url_punctuation_test", model },
+		})}`,
+		"",
+	].join("\n");
+}
+
 describe("searchCodex model selection", () => {
 	let capturedRequest: CapturedRequest | null = null;
 
-	function mockCodexFetch(responseModel: string): Disposable {
+	function mockCodexFetch(responseModel: string, responseBody?: string): Disposable {
 		capturedRequest = null;
 		vi.spyOn(AgentStorage, "open").mockResolvedValue({
 			listAuthCredentials: () => [
@@ -101,7 +197,7 @@ describe("searchCodex model selection", () => {
 				headers: init?.headers,
 				body: init?.body ? (JSON.parse(init.body as string) as Record<string, unknown>) : null,
 			};
-			return new Response(makeSseResponse(responseModel), {
+			return new Response(responseBody ?? makeSseResponse(responseModel), {
 				status: 200,
 				headers: { "Content-Type": "text/event-stream" },
 			});
@@ -151,6 +247,56 @@ describe("searchCodex model selection", () => {
 		expect(capturedRequest).not.toBeNull();
 		expect(capturedRequest?.body?.model).toBe("gpt-5.4-mini");
 		expect(result.model).toBe("gpt-5.4-mini");
+	});
+
+	it("forces web_search tool choice and extracts markdown link citations when annotations are absent", async () => {
+		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.4";
+		using _hook = mockCodexFetch("gpt-5.4", makeMarkdownLinkSseResponse("gpt-5.4"));
+
+		const result = await searchCodex({ query: "markdown citations" });
+
+		expect(capturedRequest).not.toBeNull();
+		expect(capturedRequest?.body?.tool_choice).toEqual({ type: "web_search" });
+		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
+	});
+
+	it("extracts plain text URLs when annotations are absent", async () => {
+		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.4";
+		using _hook = mockCodexFetch("gpt-5.4", makePlainUrlSseResponse("gpt-5.4"));
+
+		const result = await searchCodex({ query: "plain url citations" });
+
+		expect(result.sources).toEqual([
+			{ title: "https://example.com/article", url: "https://example.com/article" },
+			{ title: "https://example.com/faq", url: "https://example.com/faq" },
+		]);
+	});
+
+	it("preserves markdown URLs that contain balanced parentheses", async () => {
+		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.4";
+		using _hook = mockCodexFetch("gpt-5.4", makeMarkdownParenthesesSseResponse("gpt-5.4"));
+
+		const result = await searchCodex({ query: "markdown parentheses citations" });
+
+		expect(result.sources).toEqual([
+			{ title: "Function", url: "https://en.wikipedia.org/wiki/Function_(mathematics)" },
+		]);
+	});
+
+	it("strips trailing prose punctuation from plain text URLs", async () => {
+		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.4";
+		using _hook = mockCodexFetch("gpt-5.4", makePlainUrlPunctuationSseResponse("gpt-5.4"));
+
+		const result = await searchCodex({ query: "plain url punctuation" });
+
+		expect(result.sources).toEqual([
+			{ title: "https://example.com/article", url: "https://example.com/article" },
+			{ title: "https://example.com/faq", url: "https://example.com/faq" },
+			{
+				title: "https://en.wikipedia.org/wiki/Function_(mathematics)",
+				url: "https://en.wikipedia.org/wiki/Function_(mathematics)",
+			},
+		]);
 	});
 
 	it("prefers streamed text when the final item only contains an image placeholder", async () => {


### PR DESCRIPTION
## Summary
- resolve official ChatGPT OAuth Codex web_search models from the Codex catalog instead of the stale `gpt-5-codex-mini` default (closes #723)
- force built-in Codex `web_search` and preserve sources from markdown links or plain URLs when the official backend omits `url_citation` annotations (closes #724)
- restore the missing `ci:check:affected` / `ci:test:affected` package scripts so the current PR workflow can run

## Testing
- `bun test packages/coding-agent/test/tools/web-search-codex.test.ts`
- `bun run check:ts`
- `bun packages/coding-agent/src/cli.ts q --provider codex --compact "what is ai infra"`