### PR TITLE
feat(ai): support Claude Opus 4.7

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added support for Claude Opus 4.7 (`claude-opus-4-7`) model ([#726](https://github.com/can1357/oh-my-pi/issues/726))
+  - Suppresses sampling parameters (temperature/top_p/top_k) that Opus 4.7 rejects
+  - Enables `display: "summarized"` for adaptive thinking to restore visible thinking content
+
 ### Fixed
 
 - Fixed Cursor provider losing conversation history on follow-up turns (model responding "this appears to be the start of our session") by populating `ConversationStateStructure.rootPromptMessagesJson` with JSON blob IDs for the system prompt plus prior user/assistant/tool-result messages. Cursor's server builds the model prompt from `rootPromptMessagesJson`, not from the protobuf `turns[]` tree, so sending only the system prompt there caused prior turns to be dropped

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -283,6 +283,17 @@ export function mapEffortToAnthropicAdaptiveEffort<TApi extends Api>(
 	}
 }
 
+/**
+ * Returns true for Anthropic models with Opus 4.7 API restrictions:
+ * - Sampling parameters (temperature/top_p/top_k) return 400 error
+ * - Thinking content is omitted by default (needs display: "summarized")
+ */
+export function hasOpus47ApiRestrictions(modelId: string): boolean {
+	const parsed = parseAnthropicModel(getCanonicalModelId(modelId));
+	if (!parsed) return false;
+	return semverGte(parsed.version, "4.7") && parsed.kind === "opus";
+}
+
 function anthropicModelHasRealXHighEffort<TApi extends Api>(model: ApiModel<TApi>): boolean {
 	if (model.api !== "anthropic-messages") return false;
 	const parsedModel = parseKnownModel(model.id);

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -8,7 +8,7 @@ import type {
 	MessageParam,
 } from "@anthropic-ai/sdk/resources/messages";
 import { $env, abortableSleep, isEnoent } from "@oh-my-pi/pi-utils";
-import { mapEffortToAnthropicAdaptiveEffort } from "../model-thinking";
+import { hasOpus47ApiRestrictions, mapEffortToAnthropicAdaptiveEffort } from "../model-thinking";
 import { calculateCost } from "../models";
 import { getEnvApiKey, OUTPUT_FALLBACK_BUFFER } from "../stream";
 import type {
@@ -1419,6 +1419,13 @@ function buildParams(
 	}
 	if (options?.topK !== undefined) {
 		params.top_k = options.topK;
+	}
+
+	// Opus 4.7+ rejects non-default sampling parameters with 400 error.
+	if (hasOpus47ApiRestrictions(model.id)) {
+		delete params.temperature;
+		delete (params as AnthropicSamplingParams).top_p;
+		delete (params as AnthropicSamplingParams).top_k;
 	}
 
 	if (context.tools) {

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as tls from "node:tls";
+import { Effort } from "@oh-my-pi/pi-ai";
 import {
 	applyClaudeToolPrefix,
 	buildAnthropicClientOptions,
@@ -41,10 +42,20 @@ function createAbortedSignal(): AbortSignal {
 	return controller.signal;
 }
 
+type CaptureAnthropicOptions = {
+	isOAuth?: boolean;
+	metadata?: { user_id?: string };
+	thinkingEnabled?: boolean;
+	reasoning?: Effort;
+	temperature?: number;
+	topP?: number;
+	topK?: number;
+};
+
 function captureAnthropicPayload(
 	model: Model<"anthropic-messages">,
 	context: Context,
-	options?: { isOAuth?: boolean; metadata?: { user_id?: string } },
+	options?: CaptureAnthropicOptions,
 ): Promise<unknown> {
 	const { promise, resolve } = Promise.withResolvers<unknown>();
 	streamAnthropic(model, context, {
@@ -52,6 +63,11 @@ function captureAnthropicPayload(
 		isOAuth: options?.isOAuth ?? true,
 		signal: createAbortedSignal(),
 		metadata: options?.metadata,
+		thinkingEnabled: options?.thinkingEnabled,
+		reasoning: options?.reasoning,
+		temperature: options?.temperature,
+		topP: options?.topP,
+		topK: options?.topK,
 		onPayload: payload => resolve(payload),
 	});
 	return promise;
@@ -422,6 +438,44 @@ describe("Anthropic request fingerprint alignment", () => {
 				expect(getEnvApiKey("anthropic")).toBe("foundry-env-token");
 			},
 		);
+	});
+
+	it("drops sampling params and requests summarized adaptive thinking for Opus 4.7", async () => {
+		const payload = (await captureAnthropicPayload(
+			{
+				...ANTHROPIC_MODEL,
+				id: "claude-opus-4-7",
+				name: "Claude Opus 4.7",
+				thinking: {
+					mode: "anthropic-adaptive",
+					minLevel: Effort.Minimal,
+					maxLevel: Effort.XHigh,
+				},
+			},
+			{
+				systemPrompt: "Stay concise.",
+				messages: [{ role: "user", content: "Hi", timestamp: Date.now() }],
+			},
+			{
+				thinkingEnabled: true,
+				reasoning: Effort.High,
+				temperature: 0.2,
+				topP: 0.3,
+				topK: 4,
+			},
+		)) as {
+			temperature?: number;
+			top_p?: number;
+			top_k?: number;
+			thinking?: { type?: string; display?: string };
+			output_config?: { effort?: string };
+		};
+
+		expect(payload.temperature).toBeUndefined();
+		expect(payload.top_p).toBeUndefined();
+		expect(payload.top_k).toBeUndefined();
+		expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+		expect(payload.output_config).toEqual({ effort: "high" });
 	});
 
 	it("treats tool prefix helpers as no-ops when prefix is empty", () => {

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1781,4 +1781,16 @@ describe("ModelRegistry", () => {
 			expect(llama?.input).toEqual(["text", "image"]);
 		});
 	});
+	describe("bundled Anthropic catalog availability", () => {
+		test("includes native Opus 4.7 in available models when Anthropic auth exists", async () => {
+			await authStorage.set("anthropic", [{ type: "api_key", key: "sk-ant-api-test" }]);
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			await registry.refresh("offline");
+
+			expect(
+				registry.getAvailable().some(model => model.provider === "anthropic" && model.id === "claude-opus-4-7"),
+			).toBe(true);
+		});
+	});
 });


### PR DESCRIPTION
- Upgrade @anthropic-ai/sdk to ^0.90 for Opus 4.7 types
- Strip sampling parameters (temperature/top_p/top_k) for Opus 4.7+ which rejects them with 400 error
- Add display: summarized to adaptive thinking for Opus 4.7+ which omits thinking content by default
- Regenerate models.json catalog
- Register claude-opus-4-7 model entry in models.json
- Cover adaptive thinking/sampling payload shape in anthropic-alignment test
- Assert Opus 4.7 surfaces in ModelRegistry available models

Closes #726
