### PR TITLE
ci: removed dangling ci:check:affected and ci:test:affected references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,7 @@ jobs:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
       - run: bun install --frozen-lockfile
-      - name: Type check changed packages
-        if: github.event_name == 'pull_request'
-        run: bun run ci:check:affected
-      - name: Type check full workspace
-        if: github.event_name != 'pull_request'
+      - name: Type check workspace
         run: bun run ci:check:full
 
   native:
@@ -139,11 +135,7 @@ jobs:
           sudo ln -sf /usr/bin/convert /usr/local/bin/magick
       - run: bun install --frozen-lockfile
       - run: bun run build:native
-      - name: Test changed packages
-        if: github.event_name == 'pull_request'
-        run: bun run ci:test:affected
-      - name: Test full workspace
-        if: github.event_name != 'pull_request'
+      - name: Test workspace
         run: bun run ci:test:full
       - name: CLI smoke test
         run: bun run ci:test:smoke


### PR DESCRIPTION
## What

Removed dangling `bun run ci:check:affected` and `bun run ci:test:affected` steps from `.github/workflows/ci.yml`. Dropped the corresponding `if: github.event_name != 'pull_request'` guard on the `:full` steps so they run in both contexts.

## Why

Fixes #730

Commit [`723d4fd06`](https://github.com/can1357/oh-my-pi/commit/723d4fd06) ("removed turbo-based workspace pipeline") correctly removed the `test:affected`, `check:affected`, `ci:check:affected`, and `ci:test:affected` entries from `package.json` — they relied on `turbo run --affected` which no longer exists. But the workflow kept invoking `ci:check:affected` and `ci:test:affected` on the `pull_request` branch. Every PR opened after that commit has failed both jobs identically:

```
Run bun run ci:check:affected
error: Script not found "ci:check:affected"
```

```
Run bun run ci:test:affected
error: Script not found "ci:test:affected"
```

Confirmed on #706, #717, #720, and every other open PR against main after `723d4fd06`.

The `ci:check:full` and `ci:test:full` scripts are unchanged and already work on the push-to-main branch — this PR just routes PR builds to them too.

## Testing

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — no parse errors
- `grep -E '"ci:(check|test):full"' package.json` confirms the scripts this workflow now calls exist
- No script changes, no behavioral change for push-to-main builds

## Diff

```
 .github/workflows/ci.yml | 12 ++----------
 1 file changed, 2 insertions(+), 10 deletions(-)
```

Minimal, reversible, and immediately unblocks every open PR.

---

- [x] `bun check` passes (no code changed)
- [x] Tested locally (YAML parse + script existence)
- [ ] CHANGELOG updated (N/A — CI-only, no user-facing change)
