### PR TITLE
fix(cursor): store conversation turns as KV blob IDs to fix multi-turn failures

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor provider multi-turn conversations failing with `Connect error internal: Blob not found` on the second message by storing `ConversationStateStructure.turns`, `AgentConversationTurnStructure.user_message`, and `AgentConversationTurnStructure.steps` as content-addressed blob IDs in the KV store (matching the existing handling for `rootPromptMessagesJson`) rather than sending the raw serialized bytes inline ([#678](https://github.com/can1357/oh-my-pi/issues/678))
+
 ## [14.1.1] - 2026-04-14
 
 ### Added

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -2103,12 +2103,25 @@ function extractAssistantMessageText(msg: Message): string {
 }
 
 /**
- * Convert context.messages to Cursor's serialized ConversationTurn format.
+ * Hash `data`, insert it into `blobStore`, and return its blob ID.
+ * Used to package bytes fields of the `*Structure` protobuf messages,
+ * which Cursor's backend resolves via the KV getBlob round-trip.
+ */
+function storeBlob(blobStore: Map<string, Uint8Array>, data: Uint8Array): Uint8Array {
+	const id = createBlobId(data);
+	blobStore.set(Buffer.from(id).toString("hex"), data);
+	return id;
+}
+
+/**
+ * Convert context.messages to Cursor's ConversationTurnStructure blob IDs.
  * Groups messages into turns: each turn is a user message followed by the assistant's response.
  * Excludes the last user message (which goes in the action).
- * Returns serialized bytes for ConversationStateStructure.turns field.
+ *
+ * Each `AgentConversationTurnStructure.user_message`, `steps[]`, and the outer
+ * `ConversationStateStructure.turns[]` entry is a blob ID into `blobStore`.
  */
-function buildConversationTurns(messages: Message[]): Uint8Array[] {
+function buildConversationTurns(messages: Message[], blobStore: Map<string, Uint8Array>): Uint8Array[] {
 	const turns: Uint8Array[] = [];
 
 	// Find turn boundaries - each turn starts with a user message
@@ -2146,9 +2159,10 @@ function buildConversationTurns(messages: Message[]): Uint8Array[] {
 			messageId: crypto.randomUUID(),
 		});
 		const userMessageBytes = toBinary(UserMessageSchema, userMessage);
+		const userMessageBlobId = storeBlob(blobStore, userMessageBytes);
 
 		// Collect and serialize steps until next user message
-		const stepBytes: Uint8Array[] = [];
+		const stepBlobIds: Uint8Array[] = [];
 		i++;
 
 		while (i < messages.length && messages[i].role !== "user" && messages[i].role !== "developer") {
@@ -2163,7 +2177,7 @@ function buildConversationTurns(messages: Message[]): Uint8Array[] {
 							value: create(AssistantMessageSchema, { text }),
 						},
 					});
-					stepBytes.push(toBinary(ConversationStepSchema, step));
+					stepBlobIds.push(storeBlob(blobStore, toBinary(ConversationStepSchema, step)));
 				}
 			} else if (stepMsg.role === "toolResult") {
 				// Include tool results as assistant text for context
@@ -2175,17 +2189,18 @@ function buildConversationTurns(messages: Message[]): Uint8Array[] {
 							value: create(AssistantMessageSchema, { text: `[Tool Result]\n${text}` }),
 						},
 					});
-					stepBytes.push(toBinary(ConversationStepSchema, step));
+					stepBlobIds.push(storeBlob(blobStore, toBinary(ConversationStepSchema, step)));
 				}
 			}
 
 			i++;
 		}
 
-		// Create the serialized turn using Structure types (bytes)
+		// Create the serialized turn using Structure types. The bytes fields
+		// (user_message, steps) are blob IDs resolved through the KV store.
 		const agentTurn = create(AgentConversationTurnStructureSchema, {
-			userMessage: userMessageBytes,
-			steps: stepBytes,
+			userMessage: userMessageBlobId,
+			steps: stepBlobIds,
 		});
 		const turn = create(ConversationTurnStructureSchema, {
 			turn: {
@@ -2193,7 +2208,8 @@ function buildConversationTurns(messages: Message[]): Uint8Array[] {
 				value: agentTurn,
 			},
 		});
-		turns.push(toBinary(ConversationTurnStructureSchema, turn));
+		const turnBytes = toBinary(ConversationTurnStructureSchema, turn);
+		turns.push(storeBlob(blobStore, turnBytes));
 	}
 
 	return turns;
@@ -2249,7 +2265,7 @@ function buildGrpcRequest(
 	});
 
 	// Build conversation turns from prior messages (excluding the last user message)
-	const turns = buildConversationTurns(context.messages);
+	const turns = buildConversationTurns(context.messages, blobStore);
 
 	const hasMatchingPrompt = state.conversationState?.rootPromptMessagesJson?.some(entry =>
 		Buffer.from(entry).equals(systemPromptId),

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -2114,6 +2114,17 @@ function storeBlob(blobStore: Map<string, Uint8Array>, data: Uint8Array): Uint8A
 }
 
 /**
+ * Derive a stable, UUID-formatted `message_id` from a content key.
+ * Ensures identical historical messages hash to the same blob IDs across
+ * requests, so `conversationBlobStores` does not grow unboundedly and
+ * unchanged history reuses existing blob IDs.
+ */
+function deterministicMessageId(key: string): string {
+	const hex = createHash("sha256").update(key).digest("hex");
+	return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+/**
  * Convert context.messages to Cursor's ConversationTurnStructure blob IDs.
  * Groups messages into turns: each turn is a user message followed by the assistant's response.
  * Excludes the last user message (which goes in the action).
@@ -2156,7 +2167,7 @@ function buildConversationTurns(messages: Message[], blobStore: Map<string, Uint
 
 		const userMessage = create(UserMessageSchema, {
 			text: userText,
-			messageId: crypto.randomUUID(),
+			messageId: deterministicMessageId(`u:${turns.length}:${userText}`),
 		});
 		const userMessageBytes = toBinary(UserMessageSchema, userMessage);
 		const userMessageBlobId = storeBlob(blobStore, userMessageBytes);


### PR DESCRIPTION
## What

Fixes Cursor provider multi-turn conversations so the second (and subsequent) messages no longer fail with `Connect error internal: Blob not found`.

`buildConversationTurns` now hashes each serialized `UserMessage`, `ConversationStep`, and outer `ConversationTurnStructure` and inserts the content into the per-conversation `blobStore` before sending the blob ID in the `bytes` field — mirroring the existing handling of `rootPromptMessagesJson`.

A small helper `storeBlob(blobStore, bytes)` centralizes the hash-and-store.

## Why

Root cause analysis (also in #678):

Cursor's proto exposes two parallel message families. The `*Structure` variants represent the stored form and their `bytes` fields are resolved through the KV `getBlob` round-trip:

```proto
message ConversationStateStructure {
  repeated bytes root_prompt_messages_json = 1; // blob IDs
  repeated bytes turns = 8;                     // blob IDs
}

message AgentConversationTurnStructure {
  bytes user_message = 1; // blob ID
  repeated bytes steps = 2; // blob IDs
}
```

`rootPromptMessagesJson` is already populated correctly:

```ts
const systemPromptId = createBlobId(systemPromptBytes);
blobStore.set(Buffer.from(systemPromptId).toString("hex"), systemPromptBytes);
// ...
rootPromptMessagesJson: [systemPromptId],
```

But `buildConversationTurns` returned raw serialized bytes and they were placed inline into the Structure fields, with no blob ever inserted into `blobStore`. On turn 2 the backend received these inline bytes, treated them as blob IDs, issued `KvServerMessage.getBlobArgs{blob_id=<raw bytes>}`, `handleKvServerMessage` could not find them, returned an empty `GetBlobResult`, and the backend surfaced:

```
Error: Connect error internal: Blob not found:
  10,47,10,45,10,5,104,101,108,108,111,18,36,53,50,52,...
```

(The decimal payload decodes to the prior `UserMessage { text: \"hello\", messageId: \"524d1719-...\" }` — proving those raw message bytes were what the backend was trying to resolve as a blob ID.)

Turn 1 succeeded because `turns[]` was empty (the only user message had gone into the `action` field).

Fixes #678.

## Testing

- `bun run check` passes in `packages/ai` (biome + tsgo).
- Verified locally by patching an installed `@oh-my-pi/pi-coding-agent@14.1.2` and running multi-turn chats with a `cursor/*` model. First turn and every subsequent turn now succeed; no more `Blob not found`. Without the patch the second turn reliably fails.
- The full `packages/ai` test suite requires the `pi-natives` native addon to be built locally, which was not available in my environment; the 42 unrelated failures were all `Failed to load pi_natives native addon for darwin-arm64`. 279 tests still pass.

## Notes

- The other `bytes` fields in `ConversationStateStructure` (`todos`, `summary`, `plan`, `summaryArchive`, `summaryArchives`, `fileStates`) are currently always sent empty by this provider, so they are unaffected. If any of those are populated in the future they will need the same hash-and-store treatment.
- The fix preserves the existing `conversationBlobStores`/`conversationStateCache` flow. Re-hashing prior turns on every request produces identical blob IDs (SHA-256), so the blobStore converges naturally across turns and survives process restart / session resume.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

Made with [Cursor](https://cursor.com)