### PR TITLE
fix(cli): support --flag=value equals syntax for all CLI flags

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -60,7 +60,16 @@ export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "
 	};
 
 	for (let i = 0; i < args.length; i++) {
-		const arg = args[i];
+		let arg = args[i];
+
+		// Support --flag=value syntax (e.g. --tools=ask,read)
+		if (arg.startsWith("--") && arg.includes("=")) {
+			const eqIdx = arg.indexOf("=");
+			const value = arg.slice(eqIdx + 1);
+			arg = arg.slice(0, eqIdx);
+			// Insert the value so the existing "args[++i]" logic picks it up
+			args.splice(i + 1, 0, value);
+		}
 
 		if (arg === "--help" || arg === "-h") {
 			result.help = true;

--- a/packages/coding-agent/test/args.test.ts
+++ b/packages/coding-agent/test/args.test.ts
@@ -104,6 +104,11 @@ describe("parseArgs", () => {
 			expect(result.model).toBe("gpt-4o");
 		});
 
+		test("parses --model=value with equals syntax", () => {
+			const result = parseArgs(["--model=gpt-4o"]);
+			expect(result.model).toBe("gpt-4o");
+		});
+
 		test("parses --api-key", () => {
 			const result = parseArgs(["--api-key", "sk-test-key"]);
 			expect(result.apiKey).toBe("sk-test-key");
@@ -216,6 +221,16 @@ describe("parseArgs", () => {
 		test("lowercases tool names passed to --tools", () => {
 			const result = parseArgs(["--tools", "Read,Grep"]);
 			expect(result.tools).toEqual(["read", "grep"]);
+		});
+
+		test("parses --tools=value with equals syntax", () => {
+			const result = parseArgs(["--tools=read,bash"]);
+			expect(result.tools).toEqual(["read", "bash"]);
+		});
+
+		test("parses --tools=value with single tool", () => {
+			const result = parseArgs(["--tools=ask"]);
+			expect(result.tools).toEqual(["ask"]);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Fixes #739

The CLI argument parser only handles `--tools <value>` (space-separated) but not `--tools=value` (equals-separated). This applies to all flags that take a value (`--model`, `--provider`, `--tools`, `--thinking`, etc.).

## Changes

- **`packages/coding-agent/src/cli/args.ts`**: Added generic `--flag=value` splitting at the top of the parse loop. When an arg starts with `--` and contains `=`, the value after `=` is extracted and spliced into the args array so existing `args[++i]` logic picks it up naturally.

- **`packages/coding-agent/test/args.test.ts`**: Added tests for `--tools=read,bash`, `--tools=ask`, and `--model=gpt-4o` equals syntax.

## How it works

```typescript
// Before: only --tools ask works
// After: both --tools ask and --tools=ask work

if (arg.startsWith("--") && arg.includes("=")) {
    const eqIdx = arg.indexOf("=");
    const value = arg.slice(eqIdx + 1);
    arg = arg.slice(0, eqIdx);
    args.splice(i + 1, 0, value);
}
```

This is a generic fix — it enables `=` syntax for all `--flag value` arguments without changing any individual flag handler.

## Note on custom tools

The issue also mentions that custom tools (e.g. `generate_image`) don't respect the `--tools` filter. That's a separate concern (plugin/extension tools bypass the built-in tool filter) and should be tracked in a separate issue.