### PR TITLE
feat(session-observer): full-screen viewer with scrolling, expand/collapse, markdown, and agent cycling

### DIFF
--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -141,6 +141,13 @@ export class SessionObserverOverlayComponent extends Container {
 		this.#expandedEntries.clear();
 		this.#wasAtBottom = true;
 		this.#rebuildViewerContent();
+		// Auto-select first non-user entry (skip prompt) and scroll to latest for active sessions
+		const firstNonUser = this.#viewerEntries.findIndex(e => e.kind !== "user");
+		if (firstNonUser >= 0) {
+			this.#selectedEntryIndex = firstNonUser;
+			this.#rebuildViewerContent();
+			this.#scrollToSelectedEntry();
+		}
 	}
 
 	/** Rebuild content from live registry data */
@@ -357,11 +364,12 @@ export class SessionObserverOverlayComponent extends Container {
 							lines.push(`${INDENT}${theme.fg("muted", tl)}`);
 						}
 					} else {
-						const preview = text.trim().split("\n")[0];
-						lines.push(`${cursor} ${theme.fg("dim", `[${label}]`)} ${theme.fg("muted", preview)}`);
-						if (text.trim().split("\n").length > 1) {
-							lines.push(`${INDENT}${theme.fg("dim", `... ${text.trim().split("\n").length - 1} more lines`)}`);
-						}
+						const firstLine = text.trim().split("\n")[0];
+						const totalLines = text.trim().split("\n").length;
+						const hint = totalLines > 1 ? theme.fg("dim", ` (${totalLines} lines)`) : "";
+						lines.push(
+							`${cursor} ${theme.fg("dim", `[${label}]`)} ${theme.fg("muted", truncateToWidth(firstLine, 60))}${hint}`,
+						);
 					}
 					this.#viewerEntries.push({ lineStart: startLine, lineCount: lines.length - startLine, kind: "user" });
 					entryIndex++;

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -285,7 +285,14 @@ export class SessionObserverOverlayComponent extends Container {
 					const isSelected = entryIndex === this.#selectedEntryIndex;
 					const cursor = isSelected ? theme.fg("accent", "▶") : " ";
 					lines.push("");
-					lines.push(`${cursor} ${theme.fg("error", `✗ Error: ${msg.errorMessage}`)}`);
+					const errorLines = msg.errorMessage.split("\n");
+					const maxWidth = Math.max(40, (process.stdout.columns || 80) - 6);
+					lines.push(
+						`${cursor} ${theme.fg("error", `✗ Error: ${truncateToWidth(replaceTabs(errorLines[0]), maxWidth)}`)}`,
+					);
+					for (let i = 1; i < errorLines.length; i++) {
+						lines.push(`${INDENT}${theme.fg("error", truncateToWidth(replaceTabs(errorLines[i]), maxWidth))}`);
+					}
 					this.#viewerEntries.push({ lineStart: startLine, lineCount: lines.length - startLine, kind: "text" });
 					entryIndex++;
 				} else {
@@ -642,7 +649,15 @@ export class SessionObserverOverlayComponent extends Container {
 		// Page Down
 		if (matchesKey(keyData, "pageDown")) {
 			if (entryCount > 0) {
+				const prevIndex = this.#selectedEntryIndex;
 				this.#selectedEntryIndex = Math.min(this.#selectedEntryIndex + 5, entryCount - 1);
+				// If selection didn't move (bottom of list or single oversized entry), fall back to line scroll
+				if (this.#selectedEntryIndex === prevIndex) {
+					this.#scrollOffset = Math.min(
+						this.#scrollOffset + PAGE_SIZE,
+						Math.max(0, this.#renderedLines.length - this.#viewportHeight),
+					);
+				}
 			} else {
 				this.#scrollOffset = Math.min(
 					this.#scrollOffset + PAGE_SIZE,
@@ -656,7 +671,12 @@ export class SessionObserverOverlayComponent extends Container {
 		// Page Up
 		if (matchesKey(keyData, "pageUp")) {
 			if (entryCount > 0) {
+				const prevIndex = this.#selectedEntryIndex;
 				this.#selectedEntryIndex = Math.max(this.#selectedEntryIndex - 5, 0);
+				// If selection didn't move (top of list or single oversized entry), fall back to line scroll
+				if (this.#selectedEntryIndex === prevIndex) {
+					this.#scrollOffset = Math.max(this.#scrollOffset - PAGE_SIZE, 0);
+				}
 			} else {
 				this.#scrollOffset = Math.max(this.#scrollOffset - PAGE_SIZE, 0);
 			}

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -15,14 +15,23 @@
  *   - Enter on main session -> close overlay (jump back)
  */
 import type { ToolResultMessage } from "@oh-my-pi/pi-ai";
-import { Container, matchesKey, type SelectItem, SelectList, Spacer, Text } from "@oh-my-pi/pi-tui";
+import {
+	Container,
+	Markdown,
+	type MarkdownTheme,
+	matchesKey,
+	type SelectItem,
+	SelectList,
+	Spacer,
+	Text,
+} from "@oh-my-pi/pi-tui";
 import { formatDuration, formatNumber, logger } from "@oh-my-pi/pi-utils";
 import type { KeyId } from "../../config/keybindings";
 import type { SessionMessageEntry } from "../../session/session-manager";
 import { parseSessionEntries } from "../../session/session-manager";
 import { replaceTabs, truncateToWidth } from "../../tools/render-utils";
 import type { ObservableSession, SessionObserverRegistry } from "../session-observer-registry";
-import { getSelectListTheme, theme } from "../theme/theme";
+import { getMarkdownTheme, getSelectListTheme, theme } from "../theme/theme";
 import { DynamicBorder } from "./dynamic-border";
 
 type Mode = "picker" | "viewer";
@@ -82,6 +91,8 @@ export class SessionObserverOverlayComponent extends Container {
 	// Cached header/footer for viewer (rebuilt on refresh)
 	#viewerHeaderLines: string[] = [];
 	#viewerFooterLines: string[] = [];
+	// Markdown rendering
+	#mdTheme: MarkdownTheme = getMarkdownTheme();
 
 	constructor(registry: SessionObserverRegistry, onDone: () => void, observeKeys: KeyId[]) {
 		super();
@@ -360,8 +371,9 @@ export class SessionObserverOverlayComponent extends Container {
 					lines.push("");
 					if (isExpanded) {
 						lines.push(`${cursor} ${theme.fg("dim", `[${label}]`)}`);
-						for (const tl of text.trim().split("\n")) {
-							lines.push(`${INDENT}${theme.fg("muted", tl)}`);
+						const mdLines = this.#renderMarkdownToLines(text.trim());
+						for (const ml of mdLines) {
+							lines.push(ml);
 						}
 					} else {
 						const firstLine = text.trim().split("\n")[0];
@@ -378,6 +390,14 @@ export class SessionObserverOverlayComponent extends Container {
 		}
 	}
 
+	/** Render markdown text into indented lines using the theme's markdown renderer */
+	#renderMarkdownToLines(text: string, indent: string = INDENT): string[] {
+		const width = Math.max(40, (process.stdout.columns || 80) - indent.length - 4);
+		const md = new Markdown(text, 0, 0, this.#mdTheme);
+		const rendered = md.render(width);
+		return rendered.map(line => `${indent}${line.trimEnd()}`);
+	}
+
 	#renderThinkingLines(lines: string[], thinking: string, expanded: boolean, selected: boolean): void {
 		const cursor = selected ? theme.fg("accent", "▶") : " ";
 		const maxChars = expanded ? MAX_THINKING_CHARS_EXPANDED : MAX_THINKING_CHARS_COLLAPSED;
@@ -388,28 +408,51 @@ export class SessionObserverOverlayComponent extends Container {
 		lines.push(`${cursor} ${theme.fg("dim", "💭 Thinking")}${expandLabel}`);
 
 		const displayText = truncated ? `${thinking.slice(0, maxChars)}...` : thinking;
-		const thinkingLines = displayText.split("\n");
-		const maxLines = expanded ? 100 : 4;
-		for (let i = 0; i < Math.min(thinkingLines.length, maxLines); i++) {
-			lines.push(`${INDENT}${theme.fg("thinkingText", replaceTabs(thinkingLines[i]))}`);
-		}
-		if (thinkingLines.length > maxLines) {
-			lines.push(`${INDENT}${theme.fg("dim", `... ${thinkingLines.length - maxLines} more lines`)}`);
+		if (expanded) {
+			// Expanded thinking: render as markdown for readable formatting
+			const mdLines = this.#renderMarkdownToLines(displayText);
+			const maxLines = 100;
+			for (let i = 0; i < Math.min(mdLines.length, maxLines); i++) {
+				lines.push(mdLines[i]);
+			}
+			if (mdLines.length > maxLines) {
+				lines.push(`${INDENT}${theme.fg("dim", `... ${mdLines.length - maxLines} more lines`)}`);
+			}
+		} else {
+			// Collapsed thinking: brief italic preview
+			const thinkingLines = displayText.split("\n");
+			const maxLines = 4;
+			for (let i = 0; i < Math.min(thinkingLines.length, maxLines); i++) {
+				lines.push(`${INDENT}${theme.fg("thinkingText", replaceTabs(thinkingLines[i]))}`);
+			}
+			if (thinkingLines.length > maxLines) {
+				lines.push(`${INDENT}${theme.fg("dim", `... ${thinkingLines.length - maxLines} more lines`)}`);
+			}
 		}
 	}
 
 	#renderTextLines(lines: string[], text: string, expanded: boolean, selected: boolean): void {
 		const cursor = selected ? theme.fg("accent", "▶") : " ";
-		const textLines = text.split("\n");
-		const maxLines = expanded ? 50 : 5;
 
 		lines.push("");
 		lines.push(`${cursor} ${theme.fg("muted", "Response")}`);
-		for (let i = 0; i < Math.min(textLines.length, maxLines); i++) {
-			lines.push(`${INDENT}${textLines[i]}`);
-		}
-		if (textLines.length > maxLines) {
-			lines.push(`${INDENT}${theme.fg("dim", `... ${textLines.length - maxLines} more lines`)}`);
+
+		if (expanded) {
+			// Expanded: full markdown rendering
+			const mdLines = this.#renderMarkdownToLines(text);
+			for (const ml of mdLines) {
+				lines.push(ml);
+			}
+		} else {
+			// Collapsed: first few lines as plain text
+			const textLines = text.split("\n");
+			const maxLines = 5;
+			for (let i = 0; i < Math.min(textLines.length, maxLines); i++) {
+				lines.push(`${INDENT}${textLines[i]}`);
+			}
+			if (textLines.length > maxLines) {
+				lines.push(`${INDENT}${theme.fg("dim", `... ${textLines.length - maxLines} more lines`)}`);
+			}
 		}
 	}
 

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -420,8 +420,9 @@ export class SessionObserverOverlayComponent extends Container {
 			// Collapsed: first few lines as plain text
 			const textLines = text.split("\n");
 			const maxLines = 5;
+			const maxWidth = Math.max(40, (process.stdout.columns || 80) - INDENT.length - 2);
 			for (let i = 0; i < Math.min(textLines.length, maxLines); i++) {
-				lines.push(`${INDENT}${textLines[i]}`);
+				lines.push(`${INDENT}${truncateToWidth(replaceTabs(textLines[i]), maxWidth)}`);
 			}
 			if (textLines.length > maxLines) {
 				lines.push(`${INDENT}${theme.fg("dim", `... ${textLines.length - maxLines} more lines`)}`);
@@ -752,11 +753,19 @@ export class SessionObserverOverlayComponent extends Container {
 		const entryTop = entry.lineStart;
 		const entryBottom = entry.lineStart + entry.lineCount;
 
-		if (entryTop < this.#scrollOffset) {
-			this.#scrollOffset = Math.max(0, entryTop - 1);
-		}
-		if (entryBottom > this.#scrollOffset + this.#viewportHeight) {
-			this.#scrollOffset = Math.max(0, entryBottom - this.#viewportHeight + 1);
+		if (entry.lineCount >= this.#viewportHeight) {
+			// Entry taller than viewport: ensure top is visible, don't snap to bottom
+			if (entryTop < this.#scrollOffset || entryTop >= this.#scrollOffset + this.#viewportHeight) {
+				this.#scrollOffset = Math.max(0, entryTop - 1);
+			}
+		} else {
+			// Entry fits in viewport: ensure it's fully visible
+			if (entryTop < this.#scrollOffset) {
+				this.#scrollOffset = Math.max(0, entryTop - 1);
+			}
+			if (entryBottom > this.#scrollOffset + this.#viewportHeight) {
+				this.#scrollOffset = Math.max(0, entryBottom - this.#viewportHeight + 1);
+			}
 		}
 	}
 }

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -200,7 +200,12 @@ export class SessionObserverOverlayComponent extends Container {
 			const statusColor = session.status === "active" ? "success" : session.status === "failed" ? "error" : "dim";
 			const statusText = theme.fg(statusColor, `[${session.status}]`);
 			const agentTag = session.agent ? theme.fg("dim", ` ${session.agent}`) : "";
-			this.#viewerHeaderLines.push(`${theme.bold(session.label)} ${statusText}${agentTag}`);
+			// Session position indicator for cycling
+			const subagentIds = this.#getSubagentSessionIds();
+			const posIdx = subagentIds.indexOf(this.#selectedSessionId ?? "");
+			const posLabel =
+				subagentIds.length > 1 && posIdx >= 0 ? theme.fg("dim", ` (${posIdx + 1}/${subagentIds.length})`) : "";
+			this.#viewerHeaderLines.push(`${theme.bold(session.label)} ${statusText}${agentTag}${posLabel}`);
 		}
 
 		// Content
@@ -229,7 +234,7 @@ export class SessionObserverOverlayComponent extends Container {
 		const statsLine = this.#buildStatsLine(session);
 		if (statsLine) this.#viewerFooterLines.push(statsLine);
 		this.#viewerFooterLines.push(
-			theme.fg("dim", "j/k:navigate  Enter:expand/collapse  Esc:back  PgUp/PgDn:page  g/G:top/bottom"),
+			theme.fg("dim", "j/k:navigate  Enter:expand  [/]:prev/next agent  Esc:back  g/G:top/bottom"),
 		);
 
 		// Auto-scroll to bottom if we were at bottom
@@ -753,6 +758,49 @@ export class SessionObserverOverlayComponent extends Container {
 			this.#scrollOffset = 0;
 			this.#rebuildAndScroll();
 			return;
+		}
+
+		// ] or Tab — next sub-agent session
+		if (keyData === "]" || matchesKey(keyData, "tab")) {
+			this.#cycleSession(1);
+			return;
+		}
+
+		// [ or Shift+Tab — previous sub-agent session
+		if (keyData === "[" || matchesKey(keyData, "shift+tab")) {
+			this.#cycleSession(-1);
+			return;
+		}
+	}
+
+	/** Get the ordered list of sub-agent session IDs (excludes main) */
+	#getSubagentSessionIds(): string[] {
+		return this.#registry
+			.getSessions()
+			.filter(s => s.kind === "subagent")
+			.map(s => s.id);
+	}
+
+	/** Cycle to next (+1) or previous (-1) sub-agent session */
+	#cycleSession(direction: 1 | -1): void {
+		const ids = this.#getSubagentSessionIds();
+		if (ids.length <= 1) return;
+		const currentIdx = ids.indexOf(this.#selectedSessionId ?? "");
+		if (currentIdx < 0) return;
+		const nextIdx = (currentIdx + direction + ids.length) % ids.length;
+		this.#selectedSessionId = ids[nextIdx];
+		this.#transcriptCache = undefined;
+		this.#scrollOffset = 0;
+		this.#selectedEntryIndex = 0;
+		this.#expandedEntries.clear();
+		this.#wasAtBottom = true;
+		this.#rebuildViewerContent();
+		// Auto-skip to first non-user entry
+		const firstNonUser = this.#viewerEntries.findIndex(e => e.kind !== "user");
+		if (firstNonUser >= 0) {
+			this.#selectedEntryIndex = firstNonUser;
+			this.#rebuildViewerContent();
+			this.#scrollToSelectedEntry();
 		}
 	}
 

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -20,7 +20,7 @@ import { formatDuration, formatNumber, logger } from "@oh-my-pi/pi-utils";
 import type { KeyId } from "../../config/keybindings";
 import type { SessionMessageEntry } from "../../session/session-manager";
 import { parseSessionEntries } from "../../session/session-manager";
-import { replaceTabs, truncateToWidth } from "../../tools/render-utils";
+import { PREVIEW_LIMITS, replaceTabs, TRUNCATE_LENGTHS, truncateToWidth } from "../../tools/render-utils";
 import type { ObservableSession, SessionObserverRegistry } from "../session-observer-registry";
 import { getMarkdownTheme, theme } from "../theme/theme";
 import { DynamicBorder } from "./dynamic-border";
@@ -31,14 +31,20 @@ const MAX_THINKING_CHARS_COLLAPSED = 200;
 const MAX_THINKING_CHARS_EXPANDED = 4000;
 /** Max tool args characters to display */
 const MAX_TOOL_ARGS_CHARS = 500;
-/** Max tool result lines in collapsed state */
-const MAX_TOOL_RESULT_LINES_COLLAPSED = 3;
-/** Max tool result lines in expanded state */
-const MAX_TOOL_RESULT_LINES_EXPANDED = 30;
 /** Lines per page for PageUp/PageDown */
 const PAGE_SIZE = 15;
 /** Left indent for content under entry headers */
 const INDENT = "    ";
+
+/** Compute the max content width for the current terminal, accounting for indent and chrome. */
+function contentWidth(indent = INDENT): number {
+	return Math.max(TRUNCATE_LENGTHS.SHORT, (process.stdout.columns || 80) - indent.length - 2);
+}
+
+/** Sanitize a line for TUI display: replace tabs, then truncate to viewport width. */
+function sanitizeLine(text: string, maxWidth?: number): string {
+	return truncateToWidth(replaceTabs(text), maxWidth ?? contentWidth());
+}
 
 /** Represents a rendered entry in the viewer for selection/expand tracking */
 interface ViewerEntry {
@@ -286,12 +292,10 @@ export class SessionObserverOverlayComponent extends Container {
 					const cursor = isSelected ? theme.fg("accent", "▶") : " ";
 					lines.push("");
 					const errorLines = msg.errorMessage.split("\n");
-					const maxWidth = Math.max(40, (process.stdout.columns || 80) - 6);
-					lines.push(
-						`${cursor} ${theme.fg("error", `✗ Error: ${truncateToWidth(replaceTabs(errorLines[0]), maxWidth)}`)}`,
-					);
+					const maxWidth = contentWidth();
+					lines.push(`${cursor} ${theme.fg("error", `✗ Error: ${sanitizeLine(errorLines[0], maxWidth)}`)}`);
 					for (let i = 1; i < errorLines.length; i++) {
-						lines.push(`${INDENT}${theme.fg("error", truncateToWidth(replaceTabs(errorLines[i]), maxWidth))}`);
+						lines.push(`${INDENT}${theme.fg("error", sanitizeLine(errorLines[i], maxWidth))}`);
 					}
 					this.#viewerEntries.push({ lineStart: startLine, lineCount: lines.length - startLine, kind: "text" });
 					entryIndex++;
@@ -360,7 +364,7 @@ export class SessionObserverOverlayComponent extends Container {
 						const totalLines = text.trim().split("\n").length;
 						const hint = totalLines > 1 ? theme.fg("dim", ` (${totalLines} lines)`) : "";
 						lines.push(
-							`${cursor} ${theme.fg("dim", `[${label}]`)} ${theme.fg("muted", truncateToWidth(replaceTabs(firstLine), 60))}${hint}`,
+							`${cursor} ${theme.fg("dim", `[${label}]`)} ${theme.fg("muted", sanitizeLine(firstLine, TRUNCATE_LENGTHS.TITLE))}${hint}`,
 						);
 					}
 					this.#viewerEntries.push({ lineStart: startLine, lineCount: lines.length - startLine, kind: "user" });
@@ -401,9 +405,9 @@ export class SessionObserverOverlayComponent extends Container {
 		} else {
 			// Collapsed thinking: brief italic preview
 			const thinkingLines = displayText.split("\n");
-			const maxLines = 4;
+			const maxLines = PREVIEW_LIMITS.COLLAPSED_LINES;
 			for (let i = 0; i < Math.min(thinkingLines.length, maxLines); i++) {
-				lines.push(`${INDENT}${theme.fg("thinkingText", replaceTabs(thinkingLines[i]))}`);
+				lines.push(`${INDENT}${theme.fg("thinkingText", sanitizeLine(thinkingLines[i]))}`);
 			}
 			if (thinkingLines.length > maxLines) {
 				lines.push(`${INDENT}${theme.fg("dim", `... ${thinkingLines.length - maxLines} more lines`)}`);
@@ -426,10 +430,10 @@ export class SessionObserverOverlayComponent extends Container {
 		} else {
 			// Collapsed: first few lines as plain text
 			const textLines = text.split("\n");
-			const maxLines = 5;
-			const maxWidth = Math.max(40, (process.stdout.columns || 80) - INDENT.length - 2);
+			const maxLines = PREVIEW_LIMITS.COLLAPSED_LINES;
+			const maxWidth = contentWidth();
 			for (let i = 0; i < Math.min(textLines.length, maxLines); i++) {
-				lines.push(`${INDENT}${truncateToWidth(replaceTabs(textLines[i]), maxWidth)}`);
+				lines.push(`${INDENT}${sanitizeLine(textLines[i], maxWidth)}`);
 			}
 			if (textLines.length > maxLines) {
 				lines.push(`${INDENT}${theme.fg("dim", `... ${textLines.length - maxLines} more lines`)}`);
@@ -448,13 +452,13 @@ export class SessionObserverOverlayComponent extends Container {
 		lines.push("");
 
 		// Tool call header
-		const intentStr = call.intent ? theme.fg("dim", ` ${call.intent}`) : "";
-		lines.push(`${cursor} ${theme.fg("accent", "▸")} ${theme.bold(theme.fg("muted", call.name))}${intentStr}`);
+		const intentStr = call.intent ? theme.fg("dim", ` ${sanitizeLine(call.intent, TRUNCATE_LENGTHS.SHORT)}`) : "";
+		lines.push(`${cursor} ${theme.fg("accent", "\u25B8")} ${theme.bold(theme.fg("muted", call.name))}${intentStr}`);
 
 		// Key arguments
 		const argSummary = this.#formatToolArgs(call.name, call.arguments);
 		if (argSummary) {
-			lines.push(`${INDENT}${theme.fg("dim", argSummary)}`);
+			lines.push(`${INDENT}${theme.fg("dim", sanitizeLine(argSummary, contentWidth()))}`);
 		}
 
 		// Tool result
@@ -471,10 +475,11 @@ export class SessionObserverOverlayComponent extends Container {
 
 		if (result.isError) {
 			const errorLines = text.split("\n");
-			const maxErrorLines = expanded ? 15 : 2;
-			lines.push(`${INDENT}${theme.fg("error", `✗ ${replaceTabs(errorLines[0] || "Error")}`)}`);
+			const maxErrorLines = expanded ? PREVIEW_LIMITS.EXPANDED_LINES : PREVIEW_LIMITS.COLLAPSED_LINES;
+			const maxWidth = contentWidth();
+			lines.push(`${INDENT}${theme.fg("error", `✗ ${sanitizeLine(errorLines[0] || "Error", maxWidth)}`)}`);
 			for (let i = 1; i < Math.min(errorLines.length, maxErrorLines); i++) {
-				lines.push(`${INDENT}  ${theme.fg("error", replaceTabs(errorLines[i]))}`);
+				lines.push(`${INDENT}  ${theme.fg("error", sanitizeLine(errorLines[i], maxWidth))}`);
 			}
 			if (errorLines.length > maxErrorLines) {
 				lines.push(`${INDENT}  ${theme.fg("dim", `... ${errorLines.length - maxErrorLines} more lines`)}`);
@@ -488,20 +493,20 @@ export class SessionObserverOverlayComponent extends Container {
 		}
 
 		const resultLines = text.split("\n");
-		const maxLines = expanded ? MAX_TOOL_RESULT_LINES_EXPANDED : MAX_TOOL_RESULT_LINES_COLLAPSED;
+		const maxLines = expanded ? PREVIEW_LIMITS.EXPANDED_LINES : PREVIEW_LIMITS.OUTPUT_COLLAPSED;
 
 		// Status line
 		const statusPrefix = `${INDENT}${theme.fg("success", "✓")}`;
 
-		if (resultLines.length === 1 && text.length < 100) {
-			lines.push(`${statusPrefix} ${theme.fg("dim", replaceTabs(text))}`);
+		if (resultLines.length === 1 && text.length < TRUNCATE_LENGTHS.LONG) {
+			lines.push(`${statusPrefix} ${theme.fg("dim", sanitizeLine(text))}`);
 			return;
 		}
 
 		lines.push(`${statusPrefix} ${theme.fg("dim", `${resultLines.length} lines`)}`);
 		const displayLines = resultLines.slice(0, maxLines);
 		for (const rl of displayLines) {
-			lines.push(`${INDENT}  ${theme.fg("dim", replaceTabs(rl))}`);
+			lines.push(`${INDENT}  ${theme.fg("dim", sanitizeLine(rl))}`);
 		}
 		if (resultLines.length > maxLines) {
 			lines.push(`${INDENT}  ${theme.fg("dim", `... ${resultLines.length - maxLines} more`)}`);

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -779,10 +779,16 @@ export class SessionObserverOverlayComponent extends Container {
 		const entryBottom = entry.lineStart + entry.lineCount;
 
 		if (entry.lineCount >= this.#viewportHeight) {
-			// Entry taller than viewport: ensure top is visible, don't snap to bottom
-			if (entryTop < this.#scrollOffset || entryTop >= this.#scrollOffset + this.#viewportHeight) {
+			// Entry taller than viewport: only snap when it's completely out of view.
+			// If the viewport overlaps the entry at all, the user may be paging within it.
+			if (this.#scrollOffset + this.#viewportHeight <= entryTop) {
+				// Viewport is entirely above the entry — snap to entry top
 				this.#scrollOffset = Math.max(0, entryTop - 1);
+			} else if (this.#scrollOffset >= entryBottom) {
+				// Viewport is entirely below the entry — snap to show entry bottom
+				this.#scrollOffset = Math.max(0, entryBottom - this.#viewportHeight);
 			}
+			// Otherwise: viewport overlaps the entry — don't override manual scroll
 		} else {
 			// Entry fits in viewport: ensure it's fully visible
 			if (entryTop < this.#scrollOffset) {

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -2,36 +2,65 @@
  * Session observer overlay component.
  *
  * Picker mode: lists main + active subagent sessions with live status.
- * Viewer mode: renders a read-only transcript of the selected subagent's session
- *   by reading its JSONL session file — shows thinking, text, tool calls, results.
+ * Viewer mode: renders a scrollable, interactive transcript of the selected subagent's session
+ *   by reading its JSONL session file — shows thinking, text, tool calls, results
+ *   with expand/collapse per entry and breadcrumb navigation for nested sub-agents.
  *
  * Lifecycle:
  *   - shortcut opens picker
  *   - Enter on a subagent -> viewer
  *   - shortcut while in viewer -> back to picker
- *   - Esc from viewer -> back to picker
+ *   - Esc from viewer -> back to picker (or pop breadcrumb)
  *   - Esc from picker -> close overlay
  *   - Enter on main session -> close overlay (jump back)
  */
-import type { AssistantMessage, ToolResultMessage } from "@oh-my-pi/pi-ai";
-import { Container, Markdown, matchesKey, type SelectItem, SelectList, Spacer, Text } from "@oh-my-pi/pi-tui";
+import type { ToolResultMessage } from "@oh-my-pi/pi-ai";
+import { Container, matchesKey, type SelectItem, SelectList, Spacer, Text } from "@oh-my-pi/pi-tui";
 import { formatDuration, formatNumber, logger } from "@oh-my-pi/pi-utils";
 import type { KeyId } from "../../config/keybindings";
 import type { SessionMessageEntry } from "../../session/session-manager";
 import { parseSessionEntries } from "../../session/session-manager";
-import { replaceTabs, shortenPath, truncateToWidth } from "../../tools/render-utils";
+import { replaceTabs, truncateToWidth } from "../../tools/render-utils";
 import type { ObservableSession, SessionObserverRegistry } from "../session-observer-registry";
-import { getMarkdownTheme, getSelectListTheme, theme } from "../theme/theme";
+import { getSelectListTheme, theme } from "../theme/theme";
 import { DynamicBorder } from "./dynamic-border";
 
 type Mode = "picker" | "viewer";
 
-/** Max thinking characters to show (long thinking can be huge) */
-const MAX_THINKING_CHARS = 600;
+/** Max thinking characters to show in collapsed state */
+const MAX_THINKING_CHARS_COLLAPSED = 200;
+/** Max thinking characters to show in expanded state */
+const MAX_THINKING_CHARS_EXPANDED = 2000;
 /** Max tool args characters to display */
-const MAX_TOOL_ARGS_CHARS = 200;
-/** Max tool result text to display */
-const MAX_TOOL_RESULT_CHARS = 300;
+const MAX_TOOL_ARGS_CHARS = 500;
+/** Max tool result text in collapsed state */
+const MAX_TOOL_RESULT_LINES_COLLAPSED = 3;
+/** Max tool result text in expanded state */
+const MAX_TOOL_RESULT_LINES_EXPANDED = 20;
+/** Max line width for tool results */
+const MAX_TOOL_RESULT_LINE_WIDTH = 90;
+/** Lines per page for PageUp/PageDown */
+const PAGE_SIZE = 15;
+
+/** Represents a rendered entry in the viewer for selection/expand tracking */
+interface ViewerEntry {
+	/** Index in the rendered lines array where this entry starts */
+	lineStart: number;
+	/** Number of lines this entry occupies */
+	lineCount: number;
+	/** Type of entry for rendering decisions */
+	kind: "thinking" | "text" | "toolCall" | "user";
+	/** Original data for re-rendering on expand/collapse */
+	data: unknown;
+}
+
+/** Breadcrumb item for nested session navigation */
+interface BreadcrumbItem {
+	sessionId: string;
+	label: string;
+	/** Session file path to restore when navigating back */
+	sessionFile: string;
+}
 
 export class SessionObserverOverlayComponent extends Container {
 	#registry: SessionObserverRegistry;
@@ -43,8 +72,21 @@ export class SessionObserverOverlayComponent extends Container {
 	#observeKeys: KeyId[];
 	/** Cached parsed transcript per session file to avoid reparsing on every refresh */
 	#transcriptCache?: { path: string; bytesRead: number; entries: SessionMessageEntry[] };
-	/** Live stats text component, placed after transcript to avoid above-viewport diffs */
-	#statsText?: Text;
+
+	// --- Scroll state (Bead 3) ---
+	#scrollOffset = 0;
+	#renderedLines: string[] = [];
+	#viewportHeight = 20;
+	/** Whether we were at the bottom before the last content update (for auto-scroll) */
+	#wasAtBottom = true;
+
+	// --- Entry selection & expand/collapse (Bead 4) ---
+	#viewerEntries: ViewerEntry[] = [];
+	#selectedEntryIndex = 0;
+	#expandedEntries = new Set<number>();
+
+	// --- Breadcrumb navigation (Bead 6) ---
+	#navigationStack: BreadcrumbItem[] = [];
 
 	constructor(registry: SessionObserverRegistry, onDone: () => void, observeKeys: KeyId[]) {
 		super();
@@ -60,6 +102,11 @@ export class SessionObserverOverlayComponent extends Container {
 	#setupPicker(): void {
 		this.#mode = "picker";
 		this.children = [];
+		// Reset viewer state
+		this.#navigationStack = [];
+		this.#scrollOffset = 0;
+		this.#selectedEntryIndex = 0;
+		this.#expandedEntries.clear();
 
 		this.addChild(new DynamicBorder());
 		this.addChild(new Text(theme.bold(theme.fg("accent", "Session Observer")), 1, 0));
@@ -88,16 +135,12 @@ export class SessionObserverOverlayComponent extends Container {
 	#setupViewer(): void {
 		this.#mode = "viewer";
 		this.children = [];
+		this.#scrollOffset = 0;
+		this.#selectedEntryIndex = 0;
+		this.#expandedEntries.clear();
 		this.#viewerContainer = new Container();
-		this.#statsText = new Text("", 1, 0);
+		this.#wasAtBottom = true;
 		this.#refreshViewer();
-
-		this.addChild(new DynamicBorder());
-		this.addChild(this.#viewerContainer);
-		this.addChild(new Spacer(1));
-		this.addChild(this.#statsText);
-		this.addChild(new Text(theme.fg("dim", "Esc: back to picker  |  Ctrl+S: back to picker"), 1, 0));
-		this.addChild(new DynamicBorder());
 	}
 
 	/** Rebuild content from live registry data */
@@ -105,6 +148,9 @@ export class SessionObserverOverlayComponent extends Container {
 		if (this.#mode === "picker") {
 			this.#refreshPickerItems();
 		} else if (this.#mode === "viewer" && this.#selectedSessionId) {
+			// Check if we were at bottom before refresh for auto-scroll
+			const totalLines = this.#renderedLines.length;
+			this.#wasAtBottom = this.#scrollOffset >= totalLines - this.#viewportHeight;
 			this.#refreshViewer();
 		}
 	}
@@ -132,53 +178,424 @@ export class SessionObserverOverlayComponent extends Container {
 
 	#refreshViewer(): void {
 		this.#viewerContainer.clear();
+		this.children = [];
 
 		const sessions = this.#registry.getSessions();
 		const session = sessions.find(s => s.id === this.#selectedSessionId);
+
+		// Build header
+		const headerLines: string[] = [];
+
+		// Breadcrumb header (Bead 5 + 6)
+		const breadcrumb = this.#buildBreadcrumb(session);
+		headerLines.push(theme.fg("accent", breadcrumb));
+
+		if (session) {
+			const statusColor = session.status === "active" ? "success" : session.status === "failed" ? "error" : "dim";
+			const statusText = theme.fg(statusColor, `[${session.status}]`);
+			const agentTag = session.agent ? theme.fg("dim", ` ${session.agent}`) : "";
+			headerLines.push(`${theme.bold(session.label)} ${statusText}${agentTag}`);
+		}
+
+		// Build transcript content
+		const contentLines: string[] = [];
+		this.#viewerEntries = [];
+
 		if (!session) {
-			this.#viewerContainer.addChild(new Text(theme.fg("dim", "Session no longer available."), 1, 0));
-			this.#updateStats(undefined);
-			return;
+			contentLines.push(theme.fg("dim", "Session no longer available."));
+		} else if (!session.sessionFile) {
+			contentLines.push(theme.fg("dim", "No session file available yet."));
+		} else {
+			const messageEntries = this.#loadTranscript(session.sessionFile);
+			if (!messageEntries) {
+				contentLines.push(theme.fg("dim", "Unable to read session file."));
+			} else if (messageEntries.length === 0) {
+				contentLines.push(theme.fg("dim", "No messages yet."));
+			} else {
+				this.#buildTranscriptLines(messageEntries, contentLines);
+			}
 		}
 
-		this.#renderSessionHeader(session);
-		this.#renderSessionTranscript(session);
-		this.#updateStats(session);
+		// Build stats footer
+		const statsLine = this.#buildStatsLine(session);
+
+		// Build footer with key hints
+		const footerHints = theme.fg("dim", "j/k:scroll  Enter:expand  Esc:back  PgUp/PgDn:page");
+
+		// Compute viewport: terminal height minus header, borders, footer
+		const termRows = process.stdout.rows || 40;
+		const headerHeight = headerLines.length + 2; // +2 for border + spacer
+		const footerHeight = 3; // stats + hints + border
+		this.#viewportHeight = Math.max(5, termRows - headerHeight - footerHeight);
+
+		// Store all content lines for scrolling
+		this.#renderedLines = contentLines;
+
+		// Auto-scroll to bottom if we were at bottom
+		if (this.#wasAtBottom) {
+			this.#scrollOffset = Math.max(0, contentLines.length - this.#viewportHeight);
+		}
+		// Clamp scroll offset
+		this.#scrollOffset = Math.max(
+			0,
+			Math.min(this.#scrollOffset, Math.max(0, contentLines.length - this.#viewportHeight)),
+		);
+
+		// Build final display
+		this.addChild(new DynamicBorder());
+
+		// Header
+		for (const line of headerLines) {
+			this.addChild(new Text(line, 1, 0));
+		}
+		this.addChild(new DynamicBorder());
+
+		// Scrolled content viewport
+		const visibleLines = contentLines.slice(this.#scrollOffset, this.#scrollOffset + this.#viewportHeight);
+		for (const line of visibleLines) {
+			this.addChild(new Text(line, 1, 0));
+		}
+
+		// Scroll indicator
+		const scrollInfo =
+			contentLines.length > this.#viewportHeight
+				? theme.fg(
+						"dim",
+						` [${this.#scrollOffset + 1}-${Math.min(this.#scrollOffset + this.#viewportHeight, contentLines.length)}/${contentLines.length}]`,
+					)
+				: "";
+
+		this.addChild(new Spacer(1));
+		this.addChild(new Text(`${statsLine}${scrollInfo}`, 1, 0));
+		this.addChild(new Text(footerHints, 1, 0));
+		this.addChild(new DynamicBorder());
 	}
 
-	#renderSessionHeader(session: ObservableSession): void {
-		const c = this.#viewerContainer;
-
-		// Header: label + status + [agent]
-		const statusColor = session.status === "active" ? "success" : session.status === "failed" ? "error" : "dim";
-		const statusText = theme.fg(statusColor, session.status);
-		const agentTag = session.agent ? theme.fg("dim", ` [${session.agent}]`) : "";
-		c.addChild(new Text(`${theme.bold(theme.fg("accent", session.label))}  ${statusText}${agentTag}`, 1, 0));
-
-		if (session.description) {
-			c.addChild(new Text(theme.fg("muted", session.description), 1, 0));
+	#buildBreadcrumb(session: ObservableSession | undefined): string {
+		const parts: string[] = ["Session Observer"];
+		for (const item of this.#navigationStack) {
+			parts.push(item.label);
 		}
-
-		if (session.sessionFile) {
-			c.addChild(new Text(theme.fg("dim", `Session: ${shortenPath(session.sessionFile)}`), 1, 0));
+		if (session) {
+			parts.push(session.label);
 		}
-
-		c.addChild(new DynamicBorder());
+		return parts.join(" > ");
 	}
 
-	/** Update live stats in-place (below transcript, within viewport). */
-	#updateStats(session: ObservableSession | undefined): void {
-		if (!this.#statsText) return;
+	#buildStatsLine(session: ObservableSession | undefined): string {
 		const progress = session?.progress;
-		if (!progress) {
-			this.#statsText.setText("");
-			return;
-		}
+		if (!progress) return "";
 		const stats: string[] = [];
 		if (progress.toolCount > 0) stats.push(`${formatNumber(progress.toolCount)} tools`);
 		if (progress.tokens > 0) stats.push(`${formatNumber(progress.tokens)} tokens`);
 		if (progress.durationMs > 0) stats.push(formatDuration(progress.durationMs));
-		this.#statsText.setText(stats.length > 0 ? theme.fg("dim", stats.join(theme.sep.dot)) : "");
+		return stats.length > 0 ? theme.fg("dim", stats.join(theme.sep.dot)) : "";
+	}
+
+	#buildTranscriptLines(messageEntries: SessionMessageEntry[], lines: string[]): void {
+		// Build a tool call ID -> tool result map for matching
+		const toolResults = new Map<string, ToolResultMessage>();
+		for (const entry of messageEntries) {
+			if (entry.message.role === "toolResult") {
+				toolResults.set(entry.message.toolCallId, entry.message);
+			}
+		}
+
+		let entryIndex = 0;
+		for (const entry of messageEntries) {
+			const msg = entry.message;
+
+			if (msg.role === "assistant") {
+				for (const content of msg.content) {
+					if (content.type === "thinking" && content.thinking.trim()) {
+						const startLine = lines.length;
+						const isExpanded = this.#expandedEntries.has(entryIndex);
+						const isSelected = entryIndex === this.#selectedEntryIndex;
+						this.#renderThinkingLines(lines, content.thinking.trim(), isExpanded, isSelected);
+						this.#viewerEntries.push({
+							lineStart: startLine,
+							lineCount: lines.length - startLine,
+							kind: "thinking",
+							data: content,
+						});
+						entryIndex++;
+					} else if (content.type === "text" && content.text.trim()) {
+						const startLine = lines.length;
+						const isSelected = entryIndex === this.#selectedEntryIndex;
+						lines.push("");
+						const prefix = isSelected ? theme.fg("accent", "▶ ") : "  ";
+						const textLines = content.text.trim().split("\n").slice(0, 5);
+						for (const tl of textLines) {
+							lines.push(`${prefix}${tl}`);
+						}
+						if (content.text.trim().split("\n").length > 5) {
+							lines.push(`  ${theme.fg("dim", `... ${content.text.trim().split("\n").length - 5} more lines`)}`);
+						}
+						this.#viewerEntries.push({
+							lineStart: startLine,
+							lineCount: lines.length - startLine,
+							kind: "text",
+							data: content,
+						});
+						entryIndex++;
+					} else if (content.type === "toolCall") {
+						const startLine = lines.length;
+						const isExpanded = this.#expandedEntries.has(entryIndex);
+						const isSelected = entryIndex === this.#selectedEntryIndex;
+						const result = toolResults.get(content.id);
+						this.#renderToolCallLines(lines, content, result, isExpanded, isSelected);
+						this.#viewerEntries.push({
+							lineStart: startLine,
+							lineCount: lines.length - startLine,
+							kind: "toolCall",
+							data: { call: content, result },
+						});
+						entryIndex++;
+					}
+				}
+			} else if (msg.role === "user" || msg.role === "developer") {
+				const text =
+					typeof msg.content === "string"
+						? msg.content
+						: msg.content
+								.filter((b): b is { type: "text"; text: string } => b.type === "text")
+								.map(b => b.text)
+								.join("\n");
+				if (text.trim()) {
+					const startLine = lines.length;
+					const isSelected = entryIndex === this.#selectedEntryIndex;
+					const label = msg.role === "developer" ? "System" : "User";
+					const prefix = isSelected ? theme.fg("accent", "▶ ") : "  ";
+					lines.push("");
+					lines.push(
+						`${prefix}${theme.fg("dim", `[${label}]`)} ${theme.fg("muted", truncateToWidth(text.trim(), 80))}`,
+					);
+					this.#viewerEntries.push({
+						lineStart: startLine,
+						lineCount: lines.length - startLine,
+						kind: "user",
+						data: msg,
+					});
+					entryIndex++;
+				}
+			}
+			// toolResult entries are rendered inline with their tool calls above
+		}
+	}
+
+	#renderThinkingLines(lines: string[], thinking: string, expanded: boolean, selected: boolean): void {
+		const prefix = selected ? theme.fg("accent", "▶ ") : "  ";
+		const maxChars = expanded ? MAX_THINKING_CHARS_EXPANDED : MAX_THINKING_CHARS_COLLAPSED;
+		const expandHint =
+			!expanded && thinking.length > MAX_THINKING_CHARS_COLLAPSED ? theme.fg("dim", " [Enter to expand]") : "";
+
+		lines.push("");
+		lines.push(`${prefix}${theme.fg("dim", "💭 Thinking")}${expandHint}`);
+
+		const displayText = thinking.length > maxChars ? `${thinking.slice(0, maxChars)}...` : thinking;
+
+		const thinkingLines = displayText.split("\n");
+		const maxLines = expanded ? 50 : 4;
+		for (let i = 0; i < Math.min(thinkingLines.length, maxLines); i++) {
+			lines.push(
+				`    ${theme.fg("thinkingText", truncateToWidth(replaceTabs(thinkingLines[i]), MAX_TOOL_RESULT_LINE_WIDTH))}`,
+			);
+		}
+		if (thinkingLines.length > maxLines) {
+			lines.push(`    ${theme.fg("dim", `... ${thinkingLines.length - maxLines} more lines`)}`);
+		}
+	}
+
+	#renderToolCallLines(
+		lines: string[],
+		call: { id: string; name: string; arguments: Record<string, unknown>; intent?: string },
+		result: ToolResultMessage | undefined,
+		expanded: boolean,
+		selected: boolean,
+	): void {
+		const prefix = selected ? theme.fg("accent", "▶ ") : "  ";
+		lines.push("");
+
+		// Tool call header with intent
+		const intentStr = call.intent ? theme.fg("dim", ` ${truncateToWidth(call.intent, 50)}`) : "";
+		lines.push(`${prefix}${theme.fg("accent", "▸")} ${theme.bold(theme.fg("muted", call.name))}${intentStr}`);
+
+		// Key arguments
+		const argSummary = this.#formatToolArgs(call.name, call.arguments);
+		if (argSummary) {
+			lines.push(`    ${theme.fg("dim", argSummary)}`);
+		}
+
+		// Tool result
+		if (result) {
+			this.#renderToolResultLines(lines, call.name, result, expanded);
+		}
+	}
+
+	/** Rich tool result rendering (Bead 2) — per-tool-type display */
+	#renderToolResultLines(lines: string[], toolName: string, result: ToolResultMessage, expanded: boolean): void {
+		const textParts = result.content
+			.filter((p): p is { type: "text"; text: string } => p.type === "text")
+			.map(p => p.text);
+		const text = textParts.join("\n").trim();
+
+		if (result.isError) {
+			const errorLines = text.split("\n");
+			const maxErrorLines = expanded ? 10 : 2;
+			lines.push(
+				`    ${theme.fg("error", `✗ ${truncateToWidth(replaceTabs(errorLines[0] || "Error"), MAX_TOOL_RESULT_LINE_WIDTH)}`)}`,
+			);
+			for (let i = 1; i < Math.min(errorLines.length, maxErrorLines); i++) {
+				lines.push(
+					`      ${theme.fg("error", truncateToWidth(replaceTabs(errorLines[i]), MAX_TOOL_RESULT_LINE_WIDTH))}`,
+				);
+			}
+			if (errorLines.length > maxErrorLines) {
+				lines.push(`      ${theme.fg("dim", `... ${errorLines.length - maxErrorLines} more lines`)}`);
+			}
+			return;
+		}
+
+		if (!text) {
+			lines.push(`    ${theme.fg("dim", "✓ done")}`);
+			return;
+		}
+
+		const resultLines = text.split("\n");
+		const maxLines = expanded ? MAX_TOOL_RESULT_LINES_EXPANDED : MAX_TOOL_RESULT_LINES_COLLAPSED;
+
+		// Per-tool-type rendering
+		switch (toolName) {
+			case "bash":
+			case "python": {
+				// Show command output with line preview
+				const displayLines = resultLines.slice(0, maxLines);
+				lines.push(`    ${theme.fg("success", "✓")} ${theme.fg("dim", `${resultLines.length} lines`)}`);
+				for (const rl of displayLines) {
+					lines.push(`      ${theme.fg("dim", truncateToWidth(replaceTabs(rl), MAX_TOOL_RESULT_LINE_WIDTH))}`);
+				}
+				if (resultLines.length > maxLines) {
+					lines.push(`      ${theme.fg("dim", `... ${resultLines.length - maxLines} more`)}`);
+				}
+				break;
+			}
+			case "read":
+			case "grep":
+			case "find":
+			case "ast_grep": {
+				// Show search/read results
+				const displayLines = resultLines.slice(0, maxLines);
+				lines.push(`    ${theme.fg("success", "✓")} ${theme.fg("dim", `${resultLines.length} lines`)}`);
+				for (const rl of displayLines) {
+					lines.push(`      ${theme.fg("dim", truncateToWidth(replaceTabs(rl), MAX_TOOL_RESULT_LINE_WIDTH))}`);
+				}
+				if (resultLines.length > maxLines) {
+					lines.push(`      ${theme.fg("dim", `... ${resultLines.length - maxLines} more`)}`);
+				}
+				break;
+			}
+			case "edit":
+			case "write":
+			case "ast_edit": {
+				// Show file path + brief summary
+				if (resultLines.length === 1) {
+					lines.push(
+						`    ${theme.fg("success", "✓")} ${theme.fg("dim", truncateToWidth(replaceTabs(resultLines[0]), MAX_TOOL_RESULT_LINE_WIDTH))}`,
+					);
+				} else {
+					lines.push(`    ${theme.fg("success", "✓")} ${theme.fg("dim", `${resultLines.length} lines`)}`);
+					const displayLines = resultLines.slice(0, expanded ? 8 : 2);
+					for (const rl of displayLines) {
+						lines.push(`      ${theme.fg("dim", truncateToWidth(replaceTabs(rl), MAX_TOOL_RESULT_LINE_WIDTH))}`);
+					}
+					if (resultLines.length > displayLines.length) {
+						lines.push(`      ${theme.fg("dim", `... ${resultLines.length - displayLines.length} more`)}`);
+					}
+				}
+				break;
+			}
+			case "task": {
+				// Show task result - detect nested sessions for breadcrumb nav (Bead 6)
+				lines.push(`    ${theme.fg("success", "✓")} ${theme.fg("dim", "task completed")}`);
+				const displayLines = resultLines.slice(0, maxLines);
+				for (const rl of displayLines) {
+					lines.push(`      ${theme.fg("dim", truncateToWidth(replaceTabs(rl), MAX_TOOL_RESULT_LINE_WIDTH))}`);
+				}
+				if (resultLines.length > maxLines) {
+					lines.push(`      ${theme.fg("dim", `... ${resultLines.length - maxLines} more`)}`);
+				}
+				break;
+			}
+			default: {
+				// Generic rendering
+				if (resultLines.length === 1 && text.length < 80) {
+					lines.push(
+						`    ${theme.fg("success", "✓")} ${theme.fg("dim", truncateToWidth(replaceTabs(text), MAX_TOOL_RESULT_LINE_WIDTH))}`,
+					);
+				} else {
+					lines.push(`    ${theme.fg("success", "✓")} ${theme.fg("dim", `${resultLines.length} lines`)}`);
+					const displayLines = resultLines.slice(0, maxLines);
+					for (const rl of displayLines) {
+						lines.push(`      ${theme.fg("dim", truncateToWidth(replaceTabs(rl), MAX_TOOL_RESULT_LINE_WIDTH))}`);
+					}
+					if (resultLines.length > maxLines) {
+						lines.push(`      ${theme.fg("dim", `... ${resultLines.length - maxLines} more`)}`);
+					}
+				}
+				break;
+			}
+		}
+	}
+
+	#formatToolArgs(toolName: string, args: Record<string, unknown>): string {
+		// Show the most relevant arg for common tools
+		switch (toolName) {
+			case "read":
+				return args.path ? `path: ${args.path}` : "";
+			case "write":
+				return args.path ? `path: ${args.path}` : "";
+			case "edit":
+				return args.path ? `path: ${args.path}` : "";
+			case "grep":
+				return [args.pattern ? `pattern: ${args.pattern}` : "", args.path ? `path: ${args.path}` : ""]
+					.filter(Boolean)
+					.join(", ");
+			case "find":
+				return args.pattern ? `pattern: ${args.pattern}` : "";
+			case "bash": {
+				const cmd = args.command;
+				if (typeof cmd === "string") {
+					return truncateToWidth(replaceTabs(cmd), 80);
+				}
+				return "";
+			}
+			case "lsp":
+				return [args.action, args.file, args.symbol].filter(Boolean).join(" ");
+			case "ast_grep":
+			case "ast_edit":
+				return args.path ? `path: ${args.path}` : "";
+			case "task": {
+				const tasks = args.tasks;
+				if (Array.isArray(tasks)) {
+					return `${tasks.length} task(s)`;
+				}
+				return "";
+			}
+			default: {
+				// Generic: show first few args truncated
+				const parts: string[] = [];
+				let total = 0;
+				for (const [key, value] of Object.entries(args)) {
+					if (key.startsWith("_")) continue;
+					const v = typeof value === "string" ? value : JSON.stringify(value);
+					const entry = `${key}: ${truncateToWidth(replaceTabs(v ?? ""), 50)}`;
+					if (total + entry.length > MAX_TOOL_ARGS_CHARS) break;
+					parts.push(entry);
+					total += entry.length;
+				}
+				return parts.join(", ");
+			}
+		}
 	}
 
 	/** Incrementally read and parse the session JSONL, caching already-parsed entries. */
@@ -225,191 +642,70 @@ export class SessionObserverOverlayComponent extends Container {
 		return this.#transcriptCache.entries;
 	}
 
-	#renderSessionTranscript(session: ObservableSession): void {
-		const c = this.#viewerContainer;
+	/** Try to detect nested sub-agent session files from a task tool call's result */
+	#detectNestedSessionFile(
+		call: { name: string; arguments: Record<string, unknown> },
+		result: ToolResultMessage | undefined,
+	): string | undefined {
+		if (call.name !== "task") return undefined;
+		if (!result) return undefined;
 
-		if (!session.sessionFile) {
-			c.addChild(new Text(theme.fg("dim", "No session file available yet."), 1, 0));
-			return;
-		}
-
-		const messageEntries = this.#loadTranscript(session.sessionFile);
-		if (!messageEntries) {
-			c.addChild(new Text(theme.fg("dim", "Unable to read session file."), 1, 0));
-			return;
-		}
-		if (messageEntries.length === 0) {
-			c.addChild(new Text(theme.fg("dim", "No messages yet."), 1, 0));
-			return;
-		}
-
-		// Build a tool call ID -> tool result map for matching
-		const toolResults = new Map<string, ToolResultMessage>();
-		for (const entry of messageEntries) {
-			if (entry.message.role === "toolResult") {
-				toolResults.set(entry.message.toolCallId, entry.message);
-			}
-		}
-
-		for (const entry of messageEntries) {
-			const msg = entry.message;
-
-			if (msg.role === "assistant") {
-				this.#renderAssistantMessage(c, msg, toolResults);
-			} else if (msg.role === "user" || msg.role === "developer") {
-				// Show user/developer messages briefly
-				const text =
-					typeof msg.content === "string"
-						? msg.content
-						: msg.content
-								.filter((b): b is { type: "text"; text: string } => b.type === "text")
-								.map(b => b.text)
-								.join("\n");
-				if (text.trim()) {
-					const label = msg.role === "developer" ? "System" : "User";
-					c.addChild(new Spacer(1));
-					c.addChild(
-						new Text(
-							`${theme.fg("dim", `[${label}]`)} ${theme.fg("muted", truncateToWidth(text.trim(), 80))}`,
-							1,
-							0,
-						),
-					);
-				}
-			}
-			// toolResult entries are rendered inline with their tool calls above
-		}
-	}
-
-	#renderAssistantMessage(c: Container, msg: AssistantMessage, toolResults: Map<string, ToolResultMessage>): void {
-		for (const content of msg.content) {
-			if (content.type === "thinking" && content.thinking.trim()) {
-				const thinking = content.thinking.trim();
-				c.addChild(new Spacer(1));
-				if (thinking.length > MAX_THINKING_CHARS) {
-					// Show truncated thinking as markdown for proper formatting
-					const truncated = `${thinking.slice(0, MAX_THINKING_CHARS)}...`;
-					c.addChild(
-						new Markdown(truncated, 1, 0, getMarkdownTheme(), {
-							color: (t: string) => theme.fg("thinkingText", t),
-							italic: true,
-						}),
-					);
-				} else {
-					c.addChild(
-						new Markdown(thinking, 1, 0, getMarkdownTheme(), {
-							color: (t: string) => theme.fg("thinkingText", t),
-							italic: true,
-						}),
-					);
-				}
-			} else if (content.type === "text" && content.text.trim()) {
-				c.addChild(new Spacer(1));
-				c.addChild(new Markdown(content.text.trim(), 1, 0, getMarkdownTheme()));
-			} else if (content.type === "toolCall") {
-				this.#renderToolCall(c, content, toolResults);
-			}
-		}
-	}
-
-	#renderToolCall(
-		c: Container,
-		call: { id: string; name: string; arguments: Record<string, unknown>; intent?: string },
-		toolResults: Map<string, ToolResultMessage>,
-	): void {
-		c.addChild(new Spacer(1));
-
-		// Tool call header with intent
-		const intentStr = call.intent ? theme.fg("dim", ` ${truncateToWidth(call.intent, 50)}`) : "";
-		c.addChild(new Text(`${theme.fg("accent", "▸")} ${theme.bold(theme.fg("muted", call.name))}${intentStr}`, 1, 0));
-
-		// Key arguments (skip very long ones, show summary)
-		const argEntries = Object.entries(call.arguments);
-		if (argEntries.length > 0) {
-			const argSummary = this.#formatToolArgs(call.name, call.arguments);
-			if (argSummary) {
-				c.addChild(new Text(`  ${theme.fg("dim", argSummary)}`, 1, 0));
-			}
-		}
-
-		// Inline tool result
-		const result = toolResults.get(call.id);
-		if (result) {
-			this.#renderToolResult(c, result);
-		}
-	}
-
-	#formatToolArgs(toolName: string, args: Record<string, unknown>): string {
-		// Show the most relevant arg for common tools
-		switch (toolName) {
-			case "read":
-				return args.path ? `path: ${args.path}` : "";
-			case "write":
-				return args.path ? `path: ${args.path}` : "";
-			case "edit":
-				return args.path ? `path: ${args.path}` : "";
-			case "grep":
-				return [args.pattern ? `pattern: ${args.pattern}` : "", args.path ? `path: ${args.path}` : ""]
-					.filter(Boolean)
-					.join(", ");
-			case "find":
-				return args.pattern ? `pattern: ${args.pattern}` : "";
-			case "bash": {
-				const cmd = args.command;
-				if (typeof cmd === "string") {
-					return truncateToWidth(replaceTabs(cmd), 70);
-				}
-				return "";
-			}
-			case "lsp":
-				return [args.action, args.file, args.symbol].filter(Boolean).join(" ");
-			case "ast_grep":
-			case "ast_edit":
-				return args.path ? `path: ${args.path}` : "";
-			case "task": {
-				const tasks = args.tasks;
-				if (Array.isArray(tasks)) {
-					return `${tasks.length} task(s)`;
-				}
-				return "";
-			}
-			default: {
-				// Generic: show first few args truncated
-				const parts: string[] = [];
-				let total = 0;
-				for (const [key, value] of Object.entries(args)) {
-					if (key.startsWith("_")) continue;
-					const v = typeof value === "string" ? value : JSON.stringify(value);
-					const entry = `${key}: ${truncateToWidth(replaceTabs(v ?? ""), 40)}`;
-					if (total + entry.length > MAX_TOOL_ARGS_CHARS) break;
-					parts.push(entry);
-					total += entry.length;
-				}
-				return parts.join(", ");
-			}
-		}
-	}
-
-	#renderToolResult(c: Container, result: ToolResultMessage): void {
+		// Look for agent:// URLs or session file paths in the result text
 		const textParts = result.content
 			.filter((p): p is { type: "text"; text: string } => p.type === "text")
 			.map(p => p.text);
-		const text = textParts.join("\n").trim();
+		const text = textParts.join("\n");
 
-		if (result.isError) {
-			const preview = truncateToWidth(replaceTabs(text || "Error"), 70);
-			c.addChild(new Text(`  ${theme.fg("error", `✗ ${preview}`)}`, 1, 0));
-		} else if (text) {
-			// Show brief result preview
-			const lines = text.split("\n");
-			if (lines.length === 1 && text.length < MAX_TOOL_RESULT_CHARS) {
-				c.addChild(new Text(`  ${theme.fg("dim", `✓ ${truncateToWidth(replaceTabs(text), 70)}`)}`, 1, 0));
-			} else {
-				c.addChild(new Text(`  ${theme.fg("dim", `✓ ${lines.length} lines`)}`, 1, 0));
-			}
-		} else {
-			c.addChild(new Text(`  ${theme.fg("dim", "✓ done")}`, 1, 0));
+		// Check result details for session file references
+		const details = (result as any).details;
+		if (details?.sessionFile && typeof details.sessionFile === "string") {
+			return details.sessionFile;
 		}
+
+		// Try to find .jsonl file paths in output
+		const jsonlMatch = text.match(/([^\s"']+\.jsonl)/);
+		if (jsonlMatch) {
+			return jsonlMatch[1];
+		}
+
+		return undefined;
+	}
+
+	/** Navigate into a nested sub-agent session (Bead 6) */
+	#diveIntoSession(sessionFile: string): void {
+		// Push current session onto navigation stack
+		const currentSession = this.#registry.getSessions().find(s => s.id === this.#selectedSessionId);
+		if (currentSession?.sessionFile) {
+			this.#navigationStack.push({
+				sessionId: this.#selectedSessionId!,
+				label: currentSession.label,
+				sessionFile: currentSession.sessionFile,
+			});
+		}
+
+		// Clear transcript cache for new session
+		this.#transcriptCache = undefined;
+		this.#scrollOffset = 0;
+		this.#selectedEntryIndex = 0;
+		this.#expandedEntries.clear();
+
+		// Create a synthetic session ID for the nested session
+		this.#selectedSessionId = `nested:${sessionFile}`;
+		this.#refreshViewer();
+	}
+
+	/** Pop navigation stack (Bead 6) */
+	#navigateBack(): boolean {
+		if (this.#navigationStack.length === 0) return false;
+
+		const prev = this.#navigationStack.pop()!;
+		this.#selectedSessionId = prev.sessionId;
+		this.#transcriptCache = undefined;
+		this.#scrollOffset = 0;
+		this.#selectedEntryIndex = 0;
+		this.#expandedEntries.clear();
+		this.#refreshViewer();
+		return true;
 	}
 
 	#buildPickerItems(): SelectItem[] {
@@ -448,10 +744,132 @@ export class SessionObserverOverlayComponent extends Container {
 		if (this.#mode === "picker") {
 			this.#selectList.handleInput(keyData);
 		} else if (this.#mode === "viewer") {
-			if (matchesKey(keyData, "escape")) {
+			this.#handleViewerInput(keyData);
+		}
+	}
+
+	#handleViewerInput(keyData: string): void {
+		const maxScroll = Math.max(0, this.#renderedLines.length - this.#viewportHeight);
+		const entryCount = this.#viewerEntries.length;
+
+		if (matchesKey(keyData, "escape")) {
+			// Try to pop navigation stack first (Bead 6)
+			if (!this.#navigateBack()) {
 				this.#setupPicker();
-				return;
 			}
+			return;
+		}
+
+		// j / down arrow — move selection down
+		if (keyData === "j" || matchesKey(keyData, "down")) {
+			if (entryCount > 0) {
+				this.#selectedEntryIndex = Math.min(this.#selectedEntryIndex + 1, entryCount - 1);
+				this.#scrollToSelectedEntry();
+			} else {
+				this.#scrollOffset = Math.min(this.#scrollOffset + 1, maxScroll);
+			}
+			this.#refreshViewer();
+			return;
+		}
+
+		// k / up arrow — move selection up
+		if (keyData === "k" || matchesKey(keyData, "up")) {
+			if (entryCount > 0) {
+				this.#selectedEntryIndex = Math.max(this.#selectedEntryIndex - 1, 0);
+				this.#scrollToSelectedEntry();
+			} else {
+				this.#scrollOffset = Math.max(this.#scrollOffset - 1, 0);
+			}
+			this.#refreshViewer();
+			return;
+		}
+
+		// Page Down
+		if (matchesKey(keyData, "pageDown")) {
+			if (entryCount > 0) {
+				this.#selectedEntryIndex = Math.min(this.#selectedEntryIndex + 5, entryCount - 1);
+				this.#scrollToSelectedEntry();
+			} else {
+				this.#scrollOffset = Math.min(this.#scrollOffset + PAGE_SIZE, maxScroll);
+			}
+			this.#refreshViewer();
+			return;
+		}
+
+		// Page Up
+		if (matchesKey(keyData, "pageUp")) {
+			if (entryCount > 0) {
+				this.#selectedEntryIndex = Math.max(this.#selectedEntryIndex - 5, 0);
+				this.#scrollToSelectedEntry();
+			} else {
+				this.#scrollOffset = Math.max(this.#scrollOffset - PAGE_SIZE, 0);
+			}
+			this.#refreshViewer();
+			return;
+		}
+
+		// Enter — toggle expand/collapse on selected entry (Bead 4)
+		// Or dive into nested session for task tool calls (Bead 6)
+		if (keyData === "\r" || keyData === "\n") {
+			if (entryCount > 0 && this.#selectedEntryIndex < entryCount) {
+				const entry = this.#viewerEntries[this.#selectedEntryIndex];
+
+				// Check if this is a task tool call with a nested session (Bead 6)
+				if (entry?.kind === "toolCall") {
+					const entryData = entry.data as { call: any; result: any };
+					const nestedFile = this.#detectNestedSessionFile(entryData.call, entryData.result);
+					if (nestedFile) {
+						this.#diveIntoSession(nestedFile);
+						return;
+					}
+				}
+
+				// Toggle expand/collapse
+				if (this.#expandedEntries.has(this.#selectedEntryIndex)) {
+					this.#expandedEntries.delete(this.#selectedEntryIndex);
+				} else {
+					this.#expandedEntries.add(this.#selectedEntryIndex);
+				}
+				this.#refreshViewer();
+			}
+			return;
+		}
+
+		// G — jump to bottom
+		if (keyData === "G") {
+			if (entryCount > 0) {
+				this.#selectedEntryIndex = entryCount - 1;
+			}
+			this.#scrollOffset = maxScroll;
+			this.#refreshViewer();
+			return;
+		}
+
+		// g — jump to top
+		if (keyData === "g") {
+			this.#selectedEntryIndex = 0;
+			this.#scrollOffset = 0;
+			this.#refreshViewer();
+			return;
+		}
+	}
+
+	/** Ensure the selected entry is visible in the viewport */
+	#scrollToSelectedEntry(): void {
+		if (this.#viewerEntries.length === 0) return;
+		const entry = this.#viewerEntries[this.#selectedEntryIndex];
+		if (!entry) return;
+
+		const entryTop = entry.lineStart;
+		const entryBottom = entry.lineStart + entry.lineCount;
+
+		// Scroll up if entry is above viewport
+		if (entryTop < this.#scrollOffset) {
+			this.#scrollOffset = Math.max(0, entryTop - 1);
+		}
+		// Scroll down if entry is below viewport
+		if (entryBottom > this.#scrollOffset + this.#viewportHeight) {
+			this.#scrollOffset = Math.max(0, entryBottom - this.#viewportHeight + 1);
 		}
 	}
 }

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -15,26 +15,15 @@
  *   - Enter on main session -> close overlay (jump back)
  */
 import type { ToolResultMessage } from "@oh-my-pi/pi-ai";
-import {
-	Container,
-	Markdown,
-	type MarkdownTheme,
-	matchesKey,
-	type SelectItem,
-	SelectList,
-	Spacer,
-	Text,
-} from "@oh-my-pi/pi-tui";
+import { Container, Markdown, type MarkdownTheme, matchesKey } from "@oh-my-pi/pi-tui";
 import { formatDuration, formatNumber, logger } from "@oh-my-pi/pi-utils";
 import type { KeyId } from "../../config/keybindings";
 import type { SessionMessageEntry } from "../../session/session-manager";
 import { parseSessionEntries } from "../../session/session-manager";
 import { replaceTabs, truncateToWidth } from "../../tools/render-utils";
 import type { ObservableSession, SessionObserverRegistry } from "../session-observer-registry";
-import { getMarkdownTheme, getSelectListTheme, theme } from "../theme/theme";
+import { getMarkdownTheme, theme } from "../theme/theme";
 import { DynamicBorder } from "./dynamic-border";
-
-type Mode = "picker" | "viewer";
 
 /** Max thinking characters in collapsed state */
 const MAX_THINKING_CHARS_COLLAPSED = 200;
@@ -68,8 +57,6 @@ interface BreadcrumbItem {
 export class SessionObserverOverlayComponent extends Container {
 	#registry: SessionObserverRegistry;
 	#onDone: () => void;
-	#mode: Mode = "picker";
-	#selectList: SelectList;
 	#selectedSessionId?: string;
 	#observeKeys: KeyId[];
 	#transcriptCache?: { path: string; bytesRead: number; entries: SessionMessageEntry[]; model?: string };
@@ -99,53 +86,33 @@ export class SessionObserverOverlayComponent extends Container {
 		this.#registry = registry;
 		this.#onDone = onDone;
 		this.#observeKeys = observeKeys;
-		this.#selectList = new SelectList([], 0, getSelectListTheme());
-		this.#setupPicker();
+
+		// Jump directly to the most recently active sub-agent
+		const mostRecent = this.#getMostRecentSubagent();
+		if (mostRecent) {
+			this.#selectedSessionId = mostRecent.id;
+			this.#setupViewer();
+		} else {
+			// No sub-agents — close immediately
+			queueMicrotask(() => this.#onDone());
+		}
 	}
 
-	// --- Override render to implement viewport scrolling in viewer mode ---
+	/** Find the most recently updated sub-agent session (prefer active ones) */
+	#getMostRecentSubagent(): ObservableSession | undefined {
+		const sessions = this.#registry.getSessions().filter(s => s.kind === "subagent");
+		if (sessions.length === 0) return undefined;
+		// Prefer active sessions, then sort by lastUpdate descending
+		const active = sessions.filter(s => s.status === "active");
+		const pool = active.length > 0 ? active : sessions;
+		return pool.sort((a, b) => b.lastUpdate - a.lastUpdate)[0];
+	}
+
 	override render(width: number): string[] {
-		if (this.#mode === "picker") {
-			return super.render(width);
-		}
-		// Viewer mode: build all lines, then slice to viewport
 		return this.#renderViewer(width);
 	}
 
-	#setupPicker(): void {
-		this.#mode = "picker";
-		this.children = [];
-		this.#navigationStack = [];
-		this.#scrollOffset = 0;
-		this.#selectedEntryIndex = 0;
-		this.#expandedEntries.clear();
-
-		this.addChild(new DynamicBorder());
-		this.addChild(new Text(theme.bold(theme.fg("accent", "Session Observer")), 1, 0));
-		this.addChild(new Spacer(1));
-
-		const items = this.#buildPickerItems();
-		this.#selectList = new SelectList(items, Math.min(items.length, 12), getSelectListTheme());
-
-		this.#selectList.onSelect = item => {
-			if (item.value === "main") {
-				this.#onDone();
-				return;
-			}
-			this.#selectedSessionId = item.value;
-			this.#setupViewer();
-		};
-
-		this.#selectList.onCancel = () => {
-			this.#onDone();
-		};
-
-		this.addChild(this.#selectList);
-		this.addChild(new DynamicBorder());
-	}
-
 	#setupViewer(): void {
-		this.#mode = "viewer";
 		this.children = [];
 		this.#scrollOffset = 0;
 		this.#selectedEntryIndex = 0;
@@ -163,28 +130,11 @@ export class SessionObserverOverlayComponent extends Container {
 
 	/** Rebuild content from live registry data */
 	refreshFromRegistry(): void {
-		if (this.#mode === "picker") {
-			this.#refreshPickerItems();
-		} else if (this.#mode === "viewer" && this.#selectedSessionId) {
+		if (this.#selectedSessionId) {
 			const totalLines = this.#renderedLines.length;
 			this.#wasAtBottom = this.#scrollOffset >= totalLines - this.#viewportHeight;
 			this.#rebuildViewerContent();
 		}
-	}
-
-	#refreshPickerItems(): void {
-		const previousValue = this.#selectList.getSelectedItem()?.value;
-		const items = this.#buildPickerItems();
-		const newList = new SelectList(items, Math.min(items.length, 12), getSelectListTheme());
-		newList.onSelect = this.#selectList.onSelect;
-		newList.onCancel = this.#selectList.onCancel;
-		if (previousValue) {
-			const newIndex = items.findIndex(i => i.value === previousValue);
-			if (newIndex >= 0) newList.setSelectedIndex(newIndex);
-		}
-		const idx = this.children.indexOf(this.#selectList);
-		if (idx >= 0) this.children[idx] = newList;
-		this.#selectList = newList;
 	}
 
 	/** Rebuild the transcript content lines (called on setup and refresh) */
@@ -237,7 +187,7 @@ export class SessionObserverOverlayComponent extends Container {
 		const statsLine = this.#buildStatsLine(session);
 		if (statsLine) this.#viewerFooterLines.push(statsLine);
 		this.#viewerFooterLines.push(
-			theme.fg("dim", "j/k:navigate  Enter:expand  [/]:prev/next agent  Esc:back  g/G:top/bottom"),
+			theme.fg("dim", "j/k:scroll  Enter:expand  [/]:cycle agents  Esc/Ctrl+S:close  g/G:top/bottom"),
 		);
 
 		// Auto-scroll to bottom if we were at bottom
@@ -647,59 +597,25 @@ export class SessionObserverOverlayComponent extends Container {
 		return true;
 	}
 
-	#buildPickerItems(): SelectItem[] {
-		const sessions = this.#registry.getSessions();
-		return sessions.map(s => {
-			const statusIcon =
-				s.status === "active" ? "●" : s.status === "completed" ? "✓" : s.status === "failed" ? "✗" : "○";
-			const statusColor = s.status === "active" ? "success" : s.status === "failed" ? "error" : "dim";
-			const prefix = theme.fg(statusColor, statusIcon);
-			const agentSuffix = s.agent ? theme.fg("dim", ` [${s.agent}]`) : "";
-			const modelInfo = s.progress?.modelOverride
-				? theme.fg(
-						"dim",
-						` ${Array.isArray(s.progress.modelOverride) ? s.progress.modelOverride[0] : s.progress.modelOverride}`,
-					)
-				: "";
-			const label =
-				s.kind === "main" ? `${prefix} ${s.label} (return)` : `${prefix} ${s.label}${agentSuffix}${modelInfo}`;
-
-			let description = s.description;
-			if (s.progress?.currentTool) {
-				const intent = s.progress.lastIntent;
-				description = intent ? `${s.progress.currentTool}: ${truncateToWidth(intent, 40)}` : s.progress.currentTool;
-			}
-
-			return { value: s.id, label, description };
-		});
-	}
-
 	handleInput(keyData: string): void {
+		// Ctrl+S (observe key) always closes the overlay
 		for (const key of this.#observeKeys) {
 			if (matchesKey(keyData, key)) {
-				if (this.#mode === "viewer") {
-					this.#setupPicker();
-					return;
-				}
 				this.#onDone();
 				return;
 			}
 		}
 
-		if (this.#mode === "picker") {
-			this.#selectList.handleInput(keyData);
-		} else if (this.#mode === "viewer") {
-			this.#handleViewerInput(keyData);
-		}
+		this.#handleViewerInput(keyData);
 	}
 
 	#handleViewerInput(keyData: string): void {
 		const entryCount = this.#viewerEntries.length;
 
-		// Escape — pop navigation or go to picker
+		// Escape — pop breadcrumb navigation or close overlay
 		if (matchesKey(keyData, "escape")) {
 			if (!this.#navigateBack()) {
-				this.#setupPicker();
+				this.#onDone();
 			}
 			return;
 		}

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -360,7 +360,7 @@ export class SessionObserverOverlayComponent extends Container {
 						const totalLines = text.trim().split("\n").length;
 						const hint = totalLines > 1 ? theme.fg("dim", ` (${totalLines} lines)`) : "";
 						lines.push(
-							`${cursor} ${theme.fg("dim", `[${label}]`)} ${theme.fg("muted", truncateToWidth(firstLine, 60))}${hint}`,
+							`${cursor} ${theme.fg("dim", `[${label}]`)} ${theme.fg("muted", truncateToWidth(replaceTabs(firstLine), 60))}${hint}`,
 						);
 					}
 					this.#viewerEntries.push({ lineStart: startLine, lineCount: lines.length - startLine, kind: "user" });
@@ -577,14 +577,14 @@ export class SessionObserverOverlayComponent extends Container {
 				const newEntries = parseSessionEntries(completeChunk);
 				for (const entry of newEntries) {
 					if (entry.type === "message") {
-						this.#transcriptCache.entries.push(entry as SessionMessageEntry);
+						this.#transcriptCache.entries.push(entry);
 						// Extract model from first assistant message
-						const msg = (entry as SessionMessageEntry).message;
-						if (!this.#transcriptCache.model && msg.role === "assistant" && "model" in msg) {
-							this.#transcriptCache.model = (msg as any).model;
+						const msg = entry.message;
+						if (!this.#transcriptCache.model && msg.role === "assistant") {
+							this.#transcriptCache.model = msg.model;
 						}
-					} else if (entry.type === "model_change" && "model" in entry) {
-						this.#transcriptCache.model = (entry as any).model;
+					} else if (entry.type === "model_change") {
+						this.#transcriptCache.model = entry.model;
 					}
 				}
 				this.#transcriptCache.bytesRead = fromByte + Buffer.byteLength(completeChunk, "utf-8");

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -9,7 +9,7 @@
  * Lifecycle:
  *   - shortcut opens picker
  *   - Enter on a subagent -> viewer
- *   - shortcut while in viewer -> back to picker
+ *   - shortcut while in viewer -> back to picker (or pop breadcrumb)
  *   - Esc from viewer -> back to picker (or pop breadcrumb)
  *   - Esc from picker -> close overlay
  *   - Enter on main session -> close overlay (jump back)
@@ -27,38 +27,32 @@ import { DynamicBorder } from "./dynamic-border";
 
 type Mode = "picker" | "viewer";
 
-/** Max thinking characters to show in collapsed state */
+/** Max thinking characters in collapsed state */
 const MAX_THINKING_CHARS_COLLAPSED = 200;
-/** Max thinking characters to show in expanded state */
-const MAX_THINKING_CHARS_EXPANDED = 2000;
+/** Max thinking characters in expanded state */
+const MAX_THINKING_CHARS_EXPANDED = 4000;
 /** Max tool args characters to display */
 const MAX_TOOL_ARGS_CHARS = 500;
-/** Max tool result text in collapsed state */
+/** Max tool result lines in collapsed state */
 const MAX_TOOL_RESULT_LINES_COLLAPSED = 3;
-/** Max tool result text in expanded state */
-const MAX_TOOL_RESULT_LINES_EXPANDED = 20;
-/** Max line width for tool results */
-const MAX_TOOL_RESULT_LINE_WIDTH = 90;
+/** Max tool result lines in expanded state */
+const MAX_TOOL_RESULT_LINES_EXPANDED = 30;
 /** Lines per page for PageUp/PageDown */
 const PAGE_SIZE = 15;
+/** Left indent for content under entry headers */
+const INDENT = "    ";
 
 /** Represents a rendered entry in the viewer for selection/expand tracking */
 interface ViewerEntry {
-	/** Index in the rendered lines array where this entry starts */
 	lineStart: number;
-	/** Number of lines this entry occupies */
 	lineCount: number;
-	/** Type of entry for rendering decisions */
 	kind: "thinking" | "text" | "toolCall" | "user";
-	/** Original data for re-rendering on expand/collapse */
-	data: unknown;
 }
 
 /** Breadcrumb item for nested session navigation */
 interface BreadcrumbItem {
 	sessionId: string;
 	label: string;
-	/** Session file path to restore when navigating back */
 	sessionFile: string;
 }
 
@@ -67,26 +61,27 @@ export class SessionObserverOverlayComponent extends Container {
 	#onDone: () => void;
 	#mode: Mode = "picker";
 	#selectList: SelectList;
-	#viewerContainer: Container;
 	#selectedSessionId?: string;
 	#observeKeys: KeyId[];
-	/** Cached parsed transcript per session file to avoid reparsing on every refresh */
 	#transcriptCache?: { path: string; bytesRead: number; entries: SessionMessageEntry[] };
 
-	// --- Scroll state (Bead 3) ---
+	// Scroll state
 	#scrollOffset = 0;
 	#renderedLines: string[] = [];
 	#viewportHeight = 20;
-	/** Whether we were at the bottom before the last content update (for auto-scroll) */
 	#wasAtBottom = true;
 
-	// --- Entry selection & expand/collapse (Bead 4) ---
+	// Entry selection & expand/collapse
 	#viewerEntries: ViewerEntry[] = [];
 	#selectedEntryIndex = 0;
 	#expandedEntries = new Set<number>();
 
-	// --- Breadcrumb navigation (Bead 6) ---
+	// Breadcrumb navigation
 	#navigationStack: BreadcrumbItem[] = [];
+
+	// Cached header/footer for viewer (rebuilt on refresh)
+	#viewerHeaderLines: string[] = [];
+	#viewerFooterLines: string[] = [];
 
 	constructor(registry: SessionObserverRegistry, onDone: () => void, observeKeys: KeyId[]) {
 		super();
@@ -94,15 +89,21 @@ export class SessionObserverOverlayComponent extends Container {
 		this.#onDone = onDone;
 		this.#observeKeys = observeKeys;
 		this.#selectList = new SelectList([], 0, getSelectListTheme());
-		this.#viewerContainer = new Container();
-
 		this.#setupPicker();
+	}
+
+	// --- Override render to implement viewport scrolling in viewer mode ---
+	override render(width: number): string[] {
+		if (this.#mode === "picker") {
+			return super.render(width);
+		}
+		// Viewer mode: build all lines, then slice to viewport
+		return this.#renderViewer(width);
 	}
 
 	#setupPicker(): void {
 		this.#mode = "picker";
 		this.children = [];
-		// Reset viewer state
 		this.#navigationStack = [];
 		this.#scrollOffset = 0;
 		this.#selectedEntryIndex = 0;
@@ -138,9 +139,8 @@ export class SessionObserverOverlayComponent extends Container {
 		this.#scrollOffset = 0;
 		this.#selectedEntryIndex = 0;
 		this.#expandedEntries.clear();
-		this.#viewerContainer = new Container();
 		this.#wasAtBottom = true;
-		this.#refreshViewer();
+		this.#rebuildViewerContent();
 	}
 
 	/** Rebuild content from live registry data */
@@ -148,56 +148,44 @@ export class SessionObserverOverlayComponent extends Container {
 		if (this.#mode === "picker") {
 			this.#refreshPickerItems();
 		} else if (this.#mode === "viewer" && this.#selectedSessionId) {
-			// Check if we were at bottom before refresh for auto-scroll
 			const totalLines = this.#renderedLines.length;
 			this.#wasAtBottom = this.#scrollOffset >= totalLines - this.#viewportHeight;
-			this.#refreshViewer();
+			this.#rebuildViewerContent();
 		}
 	}
 
 	#refreshPickerItems(): void {
-		// Preserve selection across refresh by matching on value
 		const previousValue = this.#selectList.getSelectedItem()?.value;
-
 		const items = this.#buildPickerItems();
 		const newList = new SelectList(items, Math.min(items.length, 12), getSelectListTheme());
 		newList.onSelect = this.#selectList.onSelect;
 		newList.onCancel = this.#selectList.onCancel;
-
 		if (previousValue) {
 			const newIndex = items.findIndex(i => i.value === previousValue);
 			if (newIndex >= 0) newList.setSelectedIndex(newIndex);
 		}
-
 		const idx = this.children.indexOf(this.#selectList);
-		if (idx >= 0) {
-			this.children[idx] = newList;
-		}
+		if (idx >= 0) this.children[idx] = newList;
 		this.#selectList = newList;
 	}
 
-	#refreshViewer(): void {
-		this.#viewerContainer.clear();
-		this.children = [];
-
+	/** Rebuild the transcript content lines (called on setup and refresh) */
+	#rebuildViewerContent(): void {
 		const sessions = this.#registry.getSessions();
 		const session = sessions.find(s => s.id === this.#selectedSessionId);
 
-		// Build header
-		const headerLines: string[] = [];
-
-		// Breadcrumb header (Bead 5 + 6)
+		// Header
+		this.#viewerHeaderLines = [];
 		const breadcrumb = this.#buildBreadcrumb(session);
-		headerLines.push(theme.fg("accent", breadcrumb));
-
+		this.#viewerHeaderLines.push(theme.fg("accent", breadcrumb));
 		if (session) {
 			const statusColor = session.status === "active" ? "success" : session.status === "failed" ? "error" : "dim";
 			const statusText = theme.fg(statusColor, `[${session.status}]`);
 			const agentTag = session.agent ? theme.fg("dim", ` ${session.agent}`) : "";
-			headerLines.push(`${theme.bold(session.label)} ${statusText}${agentTag}`);
+			this.#viewerHeaderLines.push(`${theme.bold(session.label)} ${statusText}${agentTag}`);
 		}
 
-		// Build transcript content
+		// Content
 		const contentLines: string[] = [];
 		this.#viewerEntries = [];
 
@@ -216,59 +204,70 @@ export class SessionObserverOverlayComponent extends Container {
 			}
 		}
 
-		// Build stats footer
-		const statsLine = this.#buildStatsLine(session);
-
-		// Build footer with key hints
-		const footerHints = theme.fg("dim", "j/k:scroll  Enter:expand  Esc:back  PgUp/PgDn:page");
-
-		// Compute viewport: terminal height minus header, borders, footer
-		const termRows = process.stdout.rows || 40;
-		const headerHeight = headerLines.length + 2; // +2 for border + spacer
-		const footerHeight = 3; // stats + hints + border
-		this.#viewportHeight = Math.max(5, termRows - headerHeight - footerHeight);
-
-		// Store all content lines for scrolling
 		this.#renderedLines = contentLines;
+
+		// Footer
+		this.#viewerFooterLines = [];
+		const statsLine = this.#buildStatsLine(session);
+		if (statsLine) this.#viewerFooterLines.push(statsLine);
+		this.#viewerFooterLines.push(
+			theme.fg("dim", "j/k:navigate  Enter:expand/collapse  Esc:back  PgUp/PgDn:page  g/G:top/bottom"),
+		);
 
 		// Auto-scroll to bottom if we were at bottom
 		if (this.#wasAtBottom) {
 			this.#scrollOffset = Math.max(0, contentLines.length - this.#viewportHeight);
 		}
+	}
+
+	/** Produce the final viewer output for the overlay system */
+	#renderViewer(width: number): string[] {
+		const termHeight = process.stdout.rows || 40;
+
+		// Compute viewport: total height minus header chrome and footer chrome
+		// Header: border(1) + headerLines + border(1) = headerLines.length + 2
+		// Footer: spacer(1) + scrollInfo(1) + footerLines + border(1) = footerLines.length + 2
+		const headerChrome = this.#viewerHeaderLines.length + 2;
+		const footerChrome = this.#viewerFooterLines.length + 2;
+		this.#viewportHeight = Math.max(5, termHeight - headerChrome - footerChrome);
+
 		// Clamp scroll offset
-		this.#scrollOffset = Math.max(
-			0,
-			Math.min(this.#scrollOffset, Math.max(0, contentLines.length - this.#viewportHeight)),
-		);
+		const maxScroll = Math.max(0, this.#renderedLines.length - this.#viewportHeight);
+		this.#scrollOffset = Math.max(0, Math.min(this.#scrollOffset, maxScroll));
 
-		// Build final display
-		this.addChild(new DynamicBorder());
+		const lines: string[] = [];
 
-		// Header
-		for (const line of headerLines) {
-			this.addChild(new Text(line, 1, 0));
+		// --- Header ---
+		lines.push(...new DynamicBorder().render(width));
+		for (const hl of this.#viewerHeaderLines) {
+			lines.push(` ${hl}`);
 		}
-		this.addChild(new DynamicBorder());
+		lines.push(...new DynamicBorder().render(width));
 
-		// Scrolled content viewport
-		const visibleLines = contentLines.slice(this.#scrollOffset, this.#scrollOffset + this.#viewportHeight);
-		for (const line of visibleLines) {
-			this.addChild(new Text(line, 1, 0));
+		// --- Scrolled content viewport ---
+		const visibleLines = this.#renderedLines.slice(this.#scrollOffset, this.#scrollOffset + this.#viewportHeight);
+		for (const vl of visibleLines) {
+			lines.push(` ${vl}`);
+		}
+		// Pad to fill viewport if content is shorter
+		const pad = this.#viewportHeight - visibleLines.length;
+		for (let i = 0; i < pad; i++) {
+			lines.push("");
 		}
 
-		// Scroll indicator
+		// --- Footer ---
 		const scrollInfo =
-			contentLines.length > this.#viewportHeight
-				? theme.fg(
-						"dim",
-						` [${this.#scrollOffset + 1}-${Math.min(this.#scrollOffset + this.#viewportHeight, contentLines.length)}/${contentLines.length}]`,
-					)
+			this.#renderedLines.length > this.#viewportHeight
+				? ` ${theme.fg("dim", `[${this.#scrollOffset + 1}-${Math.min(this.#scrollOffset + this.#viewportHeight, this.#renderedLines.length)}/${this.#renderedLines.length}]`)}`
 				: "";
+		lines.push("");
+		lines.push(` ${this.#viewerFooterLines[0] ?? ""}${scrollInfo}`);
+		for (let i = 1; i < this.#viewerFooterLines.length; i++) {
+			lines.push(` ${this.#viewerFooterLines[i]}`);
+		}
+		lines.push(...new DynamicBorder().render(width));
 
-		this.addChild(new Spacer(1));
-		this.addChild(new Text(`${statsLine}${scrollInfo}`, 1, 0));
-		this.addChild(new Text(footerHints, 1, 0));
-		this.addChild(new DynamicBorder());
+		return lines;
 	}
 
 	#buildBreadcrumb(session: ObservableSession | undefined): string {
@@ -276,9 +275,7 @@ export class SessionObserverOverlayComponent extends Container {
 		for (const item of this.#navigationStack) {
 			parts.push(item.label);
 		}
-		if (session) {
-			parts.push(session.label);
-		}
+		if (session) parts.push(session.label);
 		return parts.join(" > ");
 	}
 
@@ -293,7 +290,7 @@ export class SessionObserverOverlayComponent extends Container {
 	}
 
 	#buildTranscriptLines(messageEntries: SessionMessageEntry[], lines: string[]): void {
-		// Build a tool call ID -> tool result map for matching
+		// Build a tool call ID -> tool result map
 		const toolResults = new Map<string, ToolResultMessage>();
 		for (const entry of messageEntries) {
 			if (entry.message.role === "toolResult") {
@@ -316,27 +313,14 @@ export class SessionObserverOverlayComponent extends Container {
 							lineStart: startLine,
 							lineCount: lines.length - startLine,
 							kind: "thinking",
-							data: content,
 						});
 						entryIndex++;
 					} else if (content.type === "text" && content.text.trim()) {
 						const startLine = lines.length;
+						const isExpanded = this.#expandedEntries.has(entryIndex);
 						const isSelected = entryIndex === this.#selectedEntryIndex;
-						lines.push("");
-						const prefix = isSelected ? theme.fg("accent", "▶ ") : "  ";
-						const textLines = content.text.trim().split("\n").slice(0, 5);
-						for (const tl of textLines) {
-							lines.push(`${prefix}${tl}`);
-						}
-						if (content.text.trim().split("\n").length > 5) {
-							lines.push(`  ${theme.fg("dim", `... ${content.text.trim().split("\n").length - 5} more lines`)}`);
-						}
-						this.#viewerEntries.push({
-							lineStart: startLine,
-							lineCount: lines.length - startLine,
-							kind: "text",
-							data: content,
-						});
+						this.#renderTextLines(lines, content.text.trim(), isExpanded, isSelected);
+						this.#viewerEntries.push({ lineStart: startLine, lineCount: lines.length - startLine, kind: "text" });
 						entryIndex++;
 					} else if (content.type === "toolCall") {
 						const startLine = lines.length;
@@ -348,7 +332,6 @@ export class SessionObserverOverlayComponent extends Container {
 							lineStart: startLine,
 							lineCount: lines.length - startLine,
 							kind: "toolCall",
-							data: { call: content, result },
 						});
 						entryIndex++;
 					}
@@ -364,45 +347,61 @@ export class SessionObserverOverlayComponent extends Container {
 				if (text.trim()) {
 					const startLine = lines.length;
 					const isSelected = entryIndex === this.#selectedEntryIndex;
+					const isExpanded = this.#expandedEntries.has(entryIndex);
 					const label = msg.role === "developer" ? "System" : "User";
-					const prefix = isSelected ? theme.fg("accent", "▶ ") : "  ";
+					const cursor = isSelected ? theme.fg("accent", "▶") : " ";
 					lines.push("");
-					lines.push(
-						`${prefix}${theme.fg("dim", `[${label}]`)} ${theme.fg("muted", truncateToWidth(text.trim(), 80))}`,
-					);
-					this.#viewerEntries.push({
-						lineStart: startLine,
-						lineCount: lines.length - startLine,
-						kind: "user",
-						data: msg,
-					});
+					if (isExpanded) {
+						lines.push(`${cursor} ${theme.fg("dim", `[${label}]`)}`);
+						for (const tl of text.trim().split("\n")) {
+							lines.push(`${INDENT}${theme.fg("muted", tl)}`);
+						}
+					} else {
+						const preview = text.trim().split("\n")[0];
+						lines.push(`${cursor} ${theme.fg("dim", `[${label}]`)} ${theme.fg("muted", preview)}`);
+						if (text.trim().split("\n").length > 1) {
+							lines.push(`${INDENT}${theme.fg("dim", `... ${text.trim().split("\n").length - 1} more lines`)}`);
+						}
+					}
+					this.#viewerEntries.push({ lineStart: startLine, lineCount: lines.length - startLine, kind: "user" });
 					entryIndex++;
 				}
 			}
-			// toolResult entries are rendered inline with their tool calls above
 		}
 	}
 
 	#renderThinkingLines(lines: string[], thinking: string, expanded: boolean, selected: boolean): void {
-		const prefix = selected ? theme.fg("accent", "▶ ") : "  ";
+		const cursor = selected ? theme.fg("accent", "▶") : " ";
 		const maxChars = expanded ? MAX_THINKING_CHARS_EXPANDED : MAX_THINKING_CHARS_COLLAPSED;
-		const expandHint =
-			!expanded && thinking.length > MAX_THINKING_CHARS_COLLAPSED ? theme.fg("dim", " [Enter to expand]") : "";
+		const truncated = thinking.length > maxChars;
+		const expandLabel = !expanded && truncated ? theme.fg("dim", " ↵") : "";
 
 		lines.push("");
-		lines.push(`${prefix}${theme.fg("dim", "💭 Thinking")}${expandHint}`);
+		lines.push(`${cursor} ${theme.fg("dim", "💭 Thinking")}${expandLabel}`);
 
-		const displayText = thinking.length > maxChars ? `${thinking.slice(0, maxChars)}...` : thinking;
-
+		const displayText = truncated ? `${thinking.slice(0, maxChars)}...` : thinking;
 		const thinkingLines = displayText.split("\n");
-		const maxLines = expanded ? 50 : 4;
+		const maxLines = expanded ? 100 : 4;
 		for (let i = 0; i < Math.min(thinkingLines.length, maxLines); i++) {
-			lines.push(
-				`    ${theme.fg("thinkingText", truncateToWidth(replaceTabs(thinkingLines[i]), MAX_TOOL_RESULT_LINE_WIDTH))}`,
-			);
+			lines.push(`${INDENT}${theme.fg("thinkingText", replaceTabs(thinkingLines[i]))}`);
 		}
 		if (thinkingLines.length > maxLines) {
-			lines.push(`    ${theme.fg("dim", `... ${thinkingLines.length - maxLines} more lines`)}`);
+			lines.push(`${INDENT}${theme.fg("dim", `... ${thinkingLines.length - maxLines} more lines`)}`);
+		}
+	}
+
+	#renderTextLines(lines: string[], text: string, expanded: boolean, selected: boolean): void {
+		const cursor = selected ? theme.fg("accent", "▶") : " ";
+		const textLines = text.split("\n");
+		const maxLines = expanded ? 50 : 5;
+
+		lines.push("");
+		lines.push(`${cursor} ${theme.fg("muted", "Response")}`);
+		for (let i = 0; i < Math.min(textLines.length, maxLines); i++) {
+			lines.push(`${INDENT}${textLines[i]}`);
+		}
+		if (textLines.length > maxLines) {
+			lines.push(`${INDENT}${theme.fg("dim", `... ${textLines.length - maxLines} more lines`)}`);
 		}
 	}
 
@@ -413,27 +412,26 @@ export class SessionObserverOverlayComponent extends Container {
 		expanded: boolean,
 		selected: boolean,
 	): void {
-		const prefix = selected ? theme.fg("accent", "▶ ") : "  ";
+		const cursor = selected ? theme.fg("accent", "▶") : " ";
 		lines.push("");
 
-		// Tool call header with intent
-		const intentStr = call.intent ? theme.fg("dim", ` ${truncateToWidth(call.intent, 50)}`) : "";
-		lines.push(`${prefix}${theme.fg("accent", "▸")} ${theme.bold(theme.fg("muted", call.name))}${intentStr}`);
+		// Tool call header
+		const intentStr = call.intent ? theme.fg("dim", ` ${call.intent}`) : "";
+		lines.push(`${cursor} ${theme.fg("accent", "▸")} ${theme.bold(theme.fg("muted", call.name))}${intentStr}`);
 
 		// Key arguments
 		const argSummary = this.#formatToolArgs(call.name, call.arguments);
 		if (argSummary) {
-			lines.push(`    ${theme.fg("dim", argSummary)}`);
+			lines.push(`${INDENT}${theme.fg("dim", argSummary)}`);
 		}
 
 		// Tool result
 		if (result) {
-			this.#renderToolResultLines(lines, call.name, result, expanded);
+			this.#renderToolResultLines(lines, result, expanded);
 		}
 	}
 
-	/** Rich tool result rendering (Bead 2) — per-tool-type display */
-	#renderToolResultLines(lines: string[], toolName: string, result: ToolResultMessage, expanded: boolean): void {
+	#renderToolResultLines(lines: string[], result: ToolResultMessage, expanded: boolean): void {
 		const textParts = result.content
 			.filter((p): p is { type: "text"; text: string } => p.type === "text")
 			.map(p => p.text);
@@ -441,119 +439,47 @@ export class SessionObserverOverlayComponent extends Container {
 
 		if (result.isError) {
 			const errorLines = text.split("\n");
-			const maxErrorLines = expanded ? 10 : 2;
-			lines.push(
-				`    ${theme.fg("error", `✗ ${truncateToWidth(replaceTabs(errorLines[0] || "Error"), MAX_TOOL_RESULT_LINE_WIDTH)}`)}`,
-			);
+			const maxErrorLines = expanded ? 15 : 2;
+			lines.push(`${INDENT}${theme.fg("error", `✗ ${replaceTabs(errorLines[0] || "Error")}`)}`);
 			for (let i = 1; i < Math.min(errorLines.length, maxErrorLines); i++) {
-				lines.push(
-					`      ${theme.fg("error", truncateToWidth(replaceTabs(errorLines[i]), MAX_TOOL_RESULT_LINE_WIDTH))}`,
-				);
+				lines.push(`${INDENT}  ${theme.fg("error", replaceTabs(errorLines[i]))}`);
 			}
 			if (errorLines.length > maxErrorLines) {
-				lines.push(`      ${theme.fg("dim", `... ${errorLines.length - maxErrorLines} more lines`)}`);
+				lines.push(`${INDENT}  ${theme.fg("dim", `... ${errorLines.length - maxErrorLines} more lines`)}`);
 			}
 			return;
 		}
 
 		if (!text) {
-			lines.push(`    ${theme.fg("dim", "✓ done")}`);
+			lines.push(`${INDENT}${theme.fg("dim", "✓ done")}`);
 			return;
 		}
 
 		const resultLines = text.split("\n");
 		const maxLines = expanded ? MAX_TOOL_RESULT_LINES_EXPANDED : MAX_TOOL_RESULT_LINES_COLLAPSED;
 
-		// Per-tool-type rendering
-		switch (toolName) {
-			case "bash":
-			case "python": {
-				// Show command output with line preview
-				const displayLines = resultLines.slice(0, maxLines);
-				lines.push(`    ${theme.fg("success", "✓")} ${theme.fg("dim", `${resultLines.length} lines`)}`);
-				for (const rl of displayLines) {
-					lines.push(`      ${theme.fg("dim", truncateToWidth(replaceTabs(rl), MAX_TOOL_RESULT_LINE_WIDTH))}`);
-				}
-				if (resultLines.length > maxLines) {
-					lines.push(`      ${theme.fg("dim", `... ${resultLines.length - maxLines} more`)}`);
-				}
-				break;
-			}
-			case "read":
-			case "grep":
-			case "find":
-			case "ast_grep": {
-				// Show search/read results
-				const displayLines = resultLines.slice(0, maxLines);
-				lines.push(`    ${theme.fg("success", "✓")} ${theme.fg("dim", `${resultLines.length} lines`)}`);
-				for (const rl of displayLines) {
-					lines.push(`      ${theme.fg("dim", truncateToWidth(replaceTabs(rl), MAX_TOOL_RESULT_LINE_WIDTH))}`);
-				}
-				if (resultLines.length > maxLines) {
-					lines.push(`      ${theme.fg("dim", `... ${resultLines.length - maxLines} more`)}`);
-				}
-				break;
-			}
-			case "edit":
-			case "write":
-			case "ast_edit": {
-				// Show file path + brief summary
-				if (resultLines.length === 1) {
-					lines.push(
-						`    ${theme.fg("success", "✓")} ${theme.fg("dim", truncateToWidth(replaceTabs(resultLines[0]), MAX_TOOL_RESULT_LINE_WIDTH))}`,
-					);
-				} else {
-					lines.push(`    ${theme.fg("success", "✓")} ${theme.fg("dim", `${resultLines.length} lines`)}`);
-					const displayLines = resultLines.slice(0, expanded ? 8 : 2);
-					for (const rl of displayLines) {
-						lines.push(`      ${theme.fg("dim", truncateToWidth(replaceTabs(rl), MAX_TOOL_RESULT_LINE_WIDTH))}`);
-					}
-					if (resultLines.length > displayLines.length) {
-						lines.push(`      ${theme.fg("dim", `... ${resultLines.length - displayLines.length} more`)}`);
-					}
-				}
-				break;
-			}
-			case "task": {
-				// Show task result - detect nested sessions for breadcrumb nav (Bead 6)
-				lines.push(`    ${theme.fg("success", "✓")} ${theme.fg("dim", "task completed")}`);
-				const displayLines = resultLines.slice(0, maxLines);
-				for (const rl of displayLines) {
-					lines.push(`      ${theme.fg("dim", truncateToWidth(replaceTabs(rl), MAX_TOOL_RESULT_LINE_WIDTH))}`);
-				}
-				if (resultLines.length > maxLines) {
-					lines.push(`      ${theme.fg("dim", `... ${resultLines.length - maxLines} more`)}`);
-				}
-				break;
-			}
-			default: {
-				// Generic rendering
-				if (resultLines.length === 1 && text.length < 80) {
-					lines.push(
-						`    ${theme.fg("success", "✓")} ${theme.fg("dim", truncateToWidth(replaceTabs(text), MAX_TOOL_RESULT_LINE_WIDTH))}`,
-					);
-				} else {
-					lines.push(`    ${theme.fg("success", "✓")} ${theme.fg("dim", `${resultLines.length} lines`)}`);
-					const displayLines = resultLines.slice(0, maxLines);
-					for (const rl of displayLines) {
-						lines.push(`      ${theme.fg("dim", truncateToWidth(replaceTabs(rl), MAX_TOOL_RESULT_LINE_WIDTH))}`);
-					}
-					if (resultLines.length > maxLines) {
-						lines.push(`      ${theme.fg("dim", `... ${resultLines.length - maxLines} more`)}`);
-					}
-				}
-				break;
-			}
+		// Status line
+		const statusPrefix = `${INDENT}${theme.fg("success", "✓")}`;
+
+		if (resultLines.length === 1 && text.length < 100) {
+			lines.push(`${statusPrefix} ${theme.fg("dim", replaceTabs(text))}`);
+			return;
+		}
+
+		lines.push(`${statusPrefix} ${theme.fg("dim", `${resultLines.length} lines`)}`);
+		const displayLines = resultLines.slice(0, maxLines);
+		for (const rl of displayLines) {
+			lines.push(`${INDENT}  ${theme.fg("dim", replaceTabs(rl))}`);
+		}
+		if (resultLines.length > maxLines) {
+			lines.push(`${INDENT}  ${theme.fg("dim", `... ${resultLines.length - maxLines} more`)}`);
 		}
 	}
 
 	#formatToolArgs(toolName: string, args: Record<string, unknown>): string {
-		// Show the most relevant arg for common tools
 		switch (toolName) {
 			case "read":
-				return args.path ? `path: ${args.path}` : "";
 			case "write":
-				return args.path ? `path: ${args.path}` : "";
 			case "edit":
 				return args.path ? `path: ${args.path}` : "";
 			case "grep":
@@ -564,10 +490,7 @@ export class SessionObserverOverlayComponent extends Container {
 				return args.pattern ? `pattern: ${args.pattern}` : "";
 			case "bash": {
 				const cmd = args.command;
-				if (typeof cmd === "string") {
-					return truncateToWidth(replaceTabs(cmd), 80);
-				}
-				return "";
+				return typeof cmd === "string" ? replaceTabs(cmd) : "";
 			}
 			case "lsp":
 				return [args.action, args.file, args.symbol].filter(Boolean).join(" ");
@@ -576,19 +499,15 @@ export class SessionObserverOverlayComponent extends Container {
 				return args.path ? `path: ${args.path}` : "";
 			case "task": {
 				const tasks = args.tasks;
-				if (Array.isArray(tasks)) {
-					return `${tasks.length} task(s)`;
-				}
-				return "";
+				return Array.isArray(tasks) ? `${tasks.length} task(s)` : "";
 			}
 			default: {
-				// Generic: show first few args truncated
 				const parts: string[] = [];
 				let total = 0;
 				for (const [key, value] of Object.entries(args)) {
 					if (key.startsWith("_")) continue;
 					const v = typeof value === "string" ? value : JSON.stringify(value);
-					const entry = `${key}: ${truncateToWidth(replaceTabs(v ?? ""), 50)}`;
+					const entry = `${key}: ${replaceTabs(v ?? "")}`;
 					if (total + entry.length > MAX_TOOL_ARGS_CHARS) break;
 					parts.push(entry);
 					total += entry.length;
@@ -598,9 +517,7 @@ export class SessionObserverOverlayComponent extends Container {
 		}
 	}
 
-	/** Incrementally read and parse the session JSONL, caching already-parsed entries. */
 	#loadTranscript(sessionFile: string): SessionMessageEntry[] | null {
-		// Invalidate cache if session file changed (e.g. switched to different subagent)
 		if (this.#transcriptCache && this.#transcriptCache.path !== sessionFile) {
 			this.#transcriptCache = undefined;
 		}
@@ -612,7 +529,6 @@ export class SessionObserverOverlayComponent extends Container {
 			return this.#transcriptCache?.entries ?? null;
 		}
 
-		// File shrank (compaction or pruning rewrote it) — invalidate and re-read from scratch
 		if (result.newSize < fromByte) {
 			this.#transcriptCache = undefined;
 			return this.#loadTranscript(sessionFile);
@@ -622,9 +538,6 @@ export class SessionObserverOverlayComponent extends Container {
 			this.#transcriptCache = { path: sessionFile, bytesRead: 0, entries: [] };
 		}
 
-		// Parse only new bytes, but only up to the last complete line.
-		// A partial trailing record (mid-write) must not be consumed —
-		// we leave those bytes for the next refresh.
 		if (result.text.length > 0) {
 			const lastNewline = result.text.lastIndexOf("\n");
 			if (lastNewline >= 0) {
@@ -637,74 +550,19 @@ export class SessionObserverOverlayComponent extends Container {
 				}
 				this.#transcriptCache.bytesRead = fromByte + Buffer.byteLength(completeChunk, "utf-8");
 			}
-			// If no newline found, the entire chunk is partial — leave bytesRead unchanged
 		}
 		return this.#transcriptCache.entries;
 	}
 
-	/** Try to detect nested sub-agent session files from a task tool call's result */
-	#detectNestedSessionFile(
-		call: { name: string; arguments: Record<string, unknown> },
-		result: ToolResultMessage | undefined,
-	): string | undefined {
-		if (call.name !== "task") return undefined;
-		if (!result) return undefined;
-
-		// Look for agent:// URLs or session file paths in the result text
-		const textParts = result.content
-			.filter((p): p is { type: "text"; text: string } => p.type === "text")
-			.map(p => p.text);
-		const text = textParts.join("\n");
-
-		// Check result details for session file references
-		const details = (result as any).details;
-		if (details?.sessionFile && typeof details.sessionFile === "string") {
-			return details.sessionFile;
-		}
-
-		// Try to find .jsonl file paths in output
-		const jsonlMatch = text.match(/([^\s"']+\.jsonl)/);
-		if (jsonlMatch) {
-			return jsonlMatch[1];
-		}
-
-		return undefined;
-	}
-
-	/** Navigate into a nested sub-agent session (Bead 6) */
-	#diveIntoSession(sessionFile: string): void {
-		// Push current session onto navigation stack
-		const currentSession = this.#registry.getSessions().find(s => s.id === this.#selectedSessionId);
-		if (currentSession?.sessionFile) {
-			this.#navigationStack.push({
-				sessionId: this.#selectedSessionId!,
-				label: currentSession.label,
-				sessionFile: currentSession.sessionFile,
-			});
-		}
-
-		// Clear transcript cache for new session
-		this.#transcriptCache = undefined;
-		this.#scrollOffset = 0;
-		this.#selectedEntryIndex = 0;
-		this.#expandedEntries.clear();
-
-		// Create a synthetic session ID for the nested session
-		this.#selectedSessionId = `nested:${sessionFile}`;
-		this.#refreshViewer();
-	}
-
-	/** Pop navigation stack (Bead 6) */
 	#navigateBack(): boolean {
 		if (this.#navigationStack.length === 0) return false;
-
 		const prev = this.#navigationStack.pop()!;
 		this.#selectedSessionId = prev.sessionId;
 		this.#transcriptCache = undefined;
 		this.#scrollOffset = 0;
 		this.#selectedEntryIndex = 0;
 		this.#expandedEntries.clear();
-		this.#refreshViewer();
+		this.#rebuildViewerContent();
 		return true;
 	}
 
@@ -718,7 +576,6 @@ export class SessionObserverOverlayComponent extends Container {
 			const agentSuffix = s.agent ? theme.fg("dim", ` [${s.agent}]`) : "";
 			const label = s.kind === "main" ? `${prefix} ${s.label} (return)` : `${prefix} ${s.label}${agentSuffix}`;
 
-			// Show current activity in the picker description for subagents
 			let description = s.description;
 			if (s.progress?.currentTool) {
 				const intent = s.progress.lastIntent;
@@ -749,38 +606,31 @@ export class SessionObserverOverlayComponent extends Container {
 	}
 
 	#handleViewerInput(keyData: string): void {
-		const maxScroll = Math.max(0, this.#renderedLines.length - this.#viewportHeight);
 		const entryCount = this.#viewerEntries.length;
 
+		// Escape — pop navigation or go to picker
 		if (matchesKey(keyData, "escape")) {
-			// Try to pop navigation stack first (Bead 6)
 			if (!this.#navigateBack()) {
 				this.#setupPicker();
 			}
 			return;
 		}
 
-		// j / down arrow — move selection down
+		// j / down — move selection down
 		if (keyData === "j" || matchesKey(keyData, "down")) {
 			if (entryCount > 0) {
 				this.#selectedEntryIndex = Math.min(this.#selectedEntryIndex + 1, entryCount - 1);
-				this.#scrollToSelectedEntry();
-			} else {
-				this.#scrollOffset = Math.min(this.#scrollOffset + 1, maxScroll);
 			}
-			this.#refreshViewer();
+			this.#rebuildAndScroll();
 			return;
 		}
 
-		// k / up arrow — move selection up
+		// k / up — move selection up
 		if (keyData === "k" || matchesKey(keyData, "up")) {
 			if (entryCount > 0) {
 				this.#selectedEntryIndex = Math.max(this.#selectedEntryIndex - 1, 0);
-				this.#scrollToSelectedEntry();
-			} else {
-				this.#scrollOffset = Math.max(this.#scrollOffset - 1, 0);
 			}
-			this.#refreshViewer();
+			this.#rebuildAndScroll();
 			return;
 		}
 
@@ -788,11 +638,13 @@ export class SessionObserverOverlayComponent extends Container {
 		if (matchesKey(keyData, "pageDown")) {
 			if (entryCount > 0) {
 				this.#selectedEntryIndex = Math.min(this.#selectedEntryIndex + 5, entryCount - 1);
-				this.#scrollToSelectedEntry();
 			} else {
-				this.#scrollOffset = Math.min(this.#scrollOffset + PAGE_SIZE, maxScroll);
+				this.#scrollOffset = Math.min(
+					this.#scrollOffset + PAGE_SIZE,
+					Math.max(0, this.#renderedLines.length - this.#viewportHeight),
+				);
 			}
-			this.#refreshViewer();
+			this.#rebuildAndScroll();
 			return;
 		}
 
@@ -800,48 +652,32 @@ export class SessionObserverOverlayComponent extends Container {
 		if (matchesKey(keyData, "pageUp")) {
 			if (entryCount > 0) {
 				this.#selectedEntryIndex = Math.max(this.#selectedEntryIndex - 5, 0);
-				this.#scrollToSelectedEntry();
 			} else {
 				this.#scrollOffset = Math.max(this.#scrollOffset - PAGE_SIZE, 0);
 			}
-			this.#refreshViewer();
+			this.#rebuildAndScroll();
 			return;
 		}
 
-		// Enter — toggle expand/collapse on selected entry (Bead 4)
-		// Or dive into nested session for task tool calls (Bead 6)
-		if (keyData === "\r" || keyData === "\n") {
+		// Enter — toggle expand/collapse, or dive into nested session
+		if (matchesKey(keyData, "enter") || keyData === "\r" || keyData === "\n") {
 			if (entryCount > 0 && this.#selectedEntryIndex < entryCount) {
-				const entry = this.#viewerEntries[this.#selectedEntryIndex];
-
-				// Check if this is a task tool call with a nested session (Bead 6)
-				if (entry?.kind === "toolCall") {
-					const entryData = entry.data as { call: any; result: any };
-					const nestedFile = this.#detectNestedSessionFile(entryData.call, entryData.result);
-					if (nestedFile) {
-						this.#diveIntoSession(nestedFile);
-						return;
-					}
-				}
-
 				// Toggle expand/collapse
 				if (this.#expandedEntries.has(this.#selectedEntryIndex)) {
 					this.#expandedEntries.delete(this.#selectedEntryIndex);
 				} else {
 					this.#expandedEntries.add(this.#selectedEntryIndex);
 				}
-				this.#refreshViewer();
+				this.#rebuildAndScroll();
 			}
 			return;
 		}
 
 		// G — jump to bottom
 		if (keyData === "G") {
-			if (entryCount > 0) {
-				this.#selectedEntryIndex = entryCount - 1;
-			}
-			this.#scrollOffset = maxScroll;
-			this.#refreshViewer();
+			if (entryCount > 0) this.#selectedEntryIndex = entryCount - 1;
+			this.#scrollOffset = Math.max(0, this.#renderedLines.length - this.#viewportHeight);
+			this.#rebuildAndScroll();
 			return;
 		}
 
@@ -849,12 +685,18 @@ export class SessionObserverOverlayComponent extends Container {
 		if (keyData === "g") {
 			this.#selectedEntryIndex = 0;
 			this.#scrollOffset = 0;
-			this.#refreshViewer();
+			this.#rebuildAndScroll();
 			return;
 		}
 	}
 
-	/** Ensure the selected entry is visible in the viewport */
+	/** Rebuild transcript lines (which depend on selectedEntryIndex/expandedEntries) and scroll to selection */
+	#rebuildAndScroll(): void {
+		this.#wasAtBottom = false;
+		this.#rebuildViewerContent();
+		this.#scrollToSelectedEntry();
+	}
+
 	#scrollToSelectedEntry(): void {
 		if (this.#viewerEntries.length === 0) return;
 		const entry = this.#viewerEntries[this.#selectedEntryIndex];
@@ -863,24 +705,18 @@ export class SessionObserverOverlayComponent extends Container {
 		const entryTop = entry.lineStart;
 		const entryBottom = entry.lineStart + entry.lineCount;
 
-		// Scroll up if entry is above viewport
 		if (entryTop < this.#scrollOffset) {
 			this.#scrollOffset = Math.max(0, entryTop - 1);
 		}
-		// Scroll down if entry is below viewport
 		if (entryBottom > this.#scrollOffset + this.#viewportHeight) {
 			this.#scrollOffset = Math.max(0, entryBottom - this.#viewportHeight + 1);
 		}
 	}
 }
 
-// Sync helpers for render path — avoid async in component rendering
+// Sync helpers for render path
 import * as fs from "node:fs";
 
-/**
- * Read new bytes from a file starting at the given byte offset.
- * Returns the new text and updated file size, or null on error.
- */
 function readFileIncremental(filePath: string, fromByte: number): { text: string; newSize: number } | null {
 	try {
 		const stat = fs.statSync(filePath);

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -321,37 +321,52 @@ export class SessionObserverOverlayComponent extends Container {
 			const msg = entry.message;
 
 			if (msg.role === "assistant") {
-				for (const content of msg.content) {
-					if (content.type === "thinking" && content.thinking.trim()) {
-						const startLine = lines.length;
-						const isExpanded = this.#expandedEntries.has(entryIndex);
-						const isSelected = entryIndex === this.#selectedEntryIndex;
-						this.#renderThinkingLines(lines, content.thinking.trim(), isExpanded, isSelected);
-						this.#viewerEntries.push({
-							lineStart: startLine,
-							lineCount: lines.length - startLine,
-							kind: "thinking",
-						});
-						entryIndex++;
-					} else if (content.type === "text" && content.text.trim()) {
-						const startLine = lines.length;
-						const isExpanded = this.#expandedEntries.has(entryIndex);
-						const isSelected = entryIndex === this.#selectedEntryIndex;
-						this.#renderTextLines(lines, content.text.trim(), isExpanded, isSelected);
-						this.#viewerEntries.push({ lineStart: startLine, lineCount: lines.length - startLine, kind: "text" });
-						entryIndex++;
-					} else if (content.type === "toolCall") {
-						const startLine = lines.length;
-						const isExpanded = this.#expandedEntries.has(entryIndex);
-						const isSelected = entryIndex === this.#selectedEntryIndex;
-						const result = toolResults.get(content.id);
-						this.#renderToolCallLines(lines, content, result, isExpanded, isSelected);
-						this.#viewerEntries.push({
-							lineStart: startLine,
-							lineCount: lines.length - startLine,
-							kind: "toolCall",
-						});
-						entryIndex++;
+				// Handle error messages with empty content
+				if (msg.content.length === 0 && msg.errorMessage) {
+					const startLine = lines.length;
+					const isSelected = entryIndex === this.#selectedEntryIndex;
+					const cursor = isSelected ? theme.fg("accent", "▶") : " ";
+					lines.push("");
+					lines.push(`${cursor} ${theme.fg("error", `✗ Error: ${msg.errorMessage}`)}`);
+					this.#viewerEntries.push({ lineStart: startLine, lineCount: lines.length - startLine, kind: "text" });
+					entryIndex++;
+				} else {
+					for (const content of msg.content) {
+						if (content.type === "thinking" && content.thinking.trim()) {
+							const startLine = lines.length;
+							const isExpanded = this.#expandedEntries.has(entryIndex);
+							const isSelected = entryIndex === this.#selectedEntryIndex;
+							this.#renderThinkingLines(lines, content.thinking.trim(), isExpanded, isSelected);
+							this.#viewerEntries.push({
+								lineStart: startLine,
+								lineCount: lines.length - startLine,
+								kind: "thinking",
+							});
+							entryIndex++;
+						} else if (content.type === "text" && content.text.trim()) {
+							const startLine = lines.length;
+							const isExpanded = this.#expandedEntries.has(entryIndex);
+							const isSelected = entryIndex === this.#selectedEntryIndex;
+							this.#renderTextLines(lines, content.text.trim(), isExpanded, isSelected);
+							this.#viewerEntries.push({
+								lineStart: startLine,
+								lineCount: lines.length - startLine,
+								kind: "text",
+							});
+							entryIndex++;
+						} else if (content.type === "toolCall") {
+							const startLine = lines.length;
+							const isExpanded = this.#expandedEntries.has(entryIndex);
+							const isSelected = entryIndex === this.#selectedEntryIndex;
+							const result = toolResults.get(content.id);
+							this.#renderToolCallLines(lines, content, result, isExpanded, isSelected);
+							this.#viewerEntries.push({
+								lineStart: startLine,
+								lineCount: lines.length - startLine,
+								kind: "toolCall",
+							});
+							entryIndex++;
+						}
 					}
 				}
 			} else if (msg.role === "user" || msg.role === "developer") {

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -72,7 +72,7 @@ export class SessionObserverOverlayComponent extends Container {
 	#selectList: SelectList;
 	#selectedSessionId?: string;
 	#observeKeys: KeyId[];
-	#transcriptCache?: { path: string; bytesRead: number; entries: SessionMessageEntry[] };
+	#transcriptCache?: { path: string; bytesRead: number; entries: SessionMessageEntry[]; model?: string };
 
 	// Scroll state
 	#scrollOffset = 0;
@@ -192,6 +192,12 @@ export class SessionObserverOverlayComponent extends Container {
 		const sessions = this.#registry.getSessions();
 		const session = sessions.find(s => s.id === this.#selectedSessionId);
 
+		// Load transcript first so model info is available for header
+		let messageEntries: SessionMessageEntry[] | null = null;
+		if (session?.sessionFile) {
+			messageEntries = this.#loadTranscript(session.sessionFile);
+		}
+
 		// Header
 		this.#viewerHeaderLines = [];
 		const breadcrumb = this.#buildBreadcrumb(session);
@@ -200,12 +206,13 @@ export class SessionObserverOverlayComponent extends Container {
 			const statusColor = session.status === "active" ? "success" : session.status === "failed" ? "error" : "dim";
 			const statusText = theme.fg(statusColor, `[${session.status}]`);
 			const agentTag = session.agent ? theme.fg("dim", ` ${session.agent}`) : "";
-			// Session position indicator for cycling
 			const subagentIds = this.#getSubagentSessionIds();
 			const posIdx = subagentIds.indexOf(this.#selectedSessionId ?? "");
 			const posLabel =
 				subagentIds.length > 1 && posIdx >= 0 ? theme.fg("dim", ` (${posIdx + 1}/${subagentIds.length})`) : "";
-			this.#viewerHeaderLines.push(`${theme.bold(session.label)} ${statusText}${agentTag}${posLabel}`);
+			const modelName = this.#transcriptCache?.model;
+			const modelLabel = modelName ? theme.fg("muted", ` · ${modelName}`) : "";
+			this.#viewerHeaderLines.push(`${theme.bold(session.label)} ${statusText}${agentTag}${posLabel}${modelLabel}`);
 		}
 
 		// Content
@@ -216,17 +223,13 @@ export class SessionObserverOverlayComponent extends Container {
 			contentLines.push(theme.fg("dim", "Session no longer available."));
 		} else if (!session.sessionFile) {
 			contentLines.push(theme.fg("dim", "No session file available yet."));
+		} else if (!messageEntries) {
+			contentLines.push(theme.fg("dim", "Unable to read session file."));
+		} else if (messageEntries.length === 0) {
+			contentLines.push(theme.fg("dim", "No messages yet."));
 		} else {
-			const messageEntries = this.#loadTranscript(session.sessionFile);
-			if (!messageEntries) {
-				contentLines.push(theme.fg("dim", "Unable to read session file."));
-			} else if (messageEntries.length === 0) {
-				contentLines.push(theme.fg("dim", "No messages yet."));
-			} else {
-				this.#buildTranscriptLines(messageEntries, contentLines);
-			}
+			this.#buildTranscriptLines(messageEntries, contentLines);
 		}
-
 		this.#renderedLines = contentLines;
 
 		// Footer
@@ -617,6 +620,13 @@ export class SessionObserverOverlayComponent extends Container {
 				for (const entry of newEntries) {
 					if (entry.type === "message") {
 						this.#transcriptCache.entries.push(entry as SessionMessageEntry);
+						// Extract model from first assistant message
+						const msg = (entry as SessionMessageEntry).message;
+						if (!this.#transcriptCache.model && msg.role === "assistant" && "model" in msg) {
+							this.#transcriptCache.model = (msg as any).model;
+						}
+					} else if (entry.type === "model_change" && "model" in entry) {
+						this.#transcriptCache.model = (entry as any).model;
 					}
 				}
 				this.#transcriptCache.bytesRead = fromByte + Buffer.byteLength(completeChunk, "utf-8");
@@ -645,7 +655,14 @@ export class SessionObserverOverlayComponent extends Container {
 			const statusColor = s.status === "active" ? "success" : s.status === "failed" ? "error" : "dim";
 			const prefix = theme.fg(statusColor, statusIcon);
 			const agentSuffix = s.agent ? theme.fg("dim", ` [${s.agent}]`) : "";
-			const label = s.kind === "main" ? `${prefix} ${s.label} (return)` : `${prefix} ${s.label}${agentSuffix}`;
+			const modelInfo = s.progress?.modelOverride
+				? theme.fg(
+						"dim",
+						` ${Array.isArray(s.progress.modelOverride) ? s.progress.modelOverride[0] : s.progress.modelOverride}`,
+					)
+				: "";
+			const label =
+				s.kind === "main" ? `${prefix} ${s.label} (return)` : `${prefix} ${s.label}${agentSuffix}${modelInfo}`;
 
 			let description = s.description;
 			if (s.progress?.currentTool) {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1,14 +1,17 @@
+import * as os from "node:os";
+import * as path from "node:path";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { getOAuthProviders, type OAuthProvider } from "@oh-my-pi/pi-ai";
 import type { Component, OverlayHandle } from "@oh-my-pi/pi-tui";
 import { Input, Loader, Spacer, Text } from "@oh-my-pi/pi-tui";
-import { getAgentDbPath, getProjectDir } from "@oh-my-pi/pi-utils";
+import { getAgentDbPath, getConfigDirName, getProjectDir } from "@oh-my-pi/pi-utils";
+import { invalidate as invalidateFsCache } from "../../capability/fs";
 import { getRoleInfo } from "../../config/model-registry";
 import { formatModelSelectorValue } from "../../config/model-resolver";
 import { settings } from "../../config/settings";
 import { DebugSelectorComponent } from "../../debug";
 import { disableProvider, enableProvider } from "../../discovery";
-import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
+import { clearClaudePluginRootsCache, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import {
 	getInstalledPluginsRegistryPath,
 	getMarketplacesCacheDir,
@@ -440,7 +443,13 @@ export class SelectorController {
 			projectInstalledRegistryPath: (await resolveActiveProjectRegistryPath(getProjectDir())) ?? undefined,
 			marketplacesCacheDir: getMarketplacesCacheDir(),
 			pluginsCacheDir: getPluginsCacheDir(),
-			clearPluginRootsCache: clearPluginRootsAndCaches,
+			clearPluginRootsCache: (extraPaths?: readonly string[]) => {
+				const home = os.homedir();
+				invalidateFsCache(path.join(home, ".claude", "plugins", "installed_plugins.json"));
+				invalidateFsCache(path.join(home, getConfigDirName(), "plugins", "installed_plugins.json"));
+				for (const p of extraPaths ?? []) invalidateFsCache(p);
+				clearClaudePluginRootsCache();
+			},
 		});
 
 		const [marketplaces, installed] = await Promise.all([mgr.listMarketplaces(), mgr.listInstalledPlugins()]);

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -1,17 +1,14 @@
-import * as os from "node:os";
-import * as path from "node:path";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { getOAuthProviders, type OAuthProvider } from "@oh-my-pi/pi-ai";
-import type { Component } from "@oh-my-pi/pi-tui";
+import type { Component, OverlayHandle } from "@oh-my-pi/pi-tui";
 import { Input, Loader, Spacer, Text } from "@oh-my-pi/pi-tui";
-import { getAgentDbPath, getConfigDirName, getProjectDir } from "@oh-my-pi/pi-utils";
-import { invalidate as invalidateFsCache } from "../../capability/fs";
+import { getAgentDbPath, getProjectDir } from "@oh-my-pi/pi-utils";
 import { getRoleInfo } from "../../config/model-registry";
 import { formatModelSelectorValue } from "../../config/model-resolver";
 import { settings } from "../../config/settings";
 import { DebugSelectorComponent } from "../../debug";
 import { disableProvider, enableProvider } from "../../discovery";
-import { clearClaudePluginRootsCache, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
+import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import {
 	getInstalledPluginsRegistryPath,
 	getMarketplacesCacheDir,
@@ -443,13 +440,7 @@ export class SelectorController {
 			projectInstalledRegistryPath: (await resolveActiveProjectRegistryPath(getProjectDir())) ?? undefined,
 			marketplacesCacheDir: getMarketplacesCacheDir(),
 			pluginsCacheDir: getPluginsCacheDir(),
-			clearPluginRootsCache: (extraPaths?: readonly string[]) => {
-				const home = os.homedir();
-				invalidateFsCache(path.join(home, ".claude", "plugins", "installed_plugins.json"));
-				invalidateFsCache(path.join(home, getConfigDirName(), "plugins", "installed_plugins.json"));
-				for (const p of extraPaths ?? []) invalidateFsCache(p);
-				clearClaudePluginRootsCache();
-			},
+			clearPluginRootsCache: clearPluginRootsAndCaches,
 		});
 
 		const [marketplaces, installed] = await Promise.all([mgr.listMarketplaces(), mgr.listInstalledPlugins()]);
@@ -979,7 +970,7 @@ export class SelectorController {
 	showSessionObserver(registry: SessionObserverRegistry): void {
 		const observeKeys = this.ctx.keybindings.getKeys("app.session.observe");
 		let cleanup: (() => void) | undefined;
-		let overlayHandle: ReturnType<typeof this.ctx.ui.showOverlay> | undefined;
+		let overlayHandle: OverlayHandle | undefined;
 
 		const done = () => {
 			cleanup?.();

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -978,25 +978,29 @@ export class SelectorController {
 
 	showSessionObserver(registry: SessionObserverRegistry): void {
 		const observeKeys = this.ctx.keybindings.getKeys("app.session.observe");
+		let cleanup: (() => void) | undefined;
+		let overlayHandle: ReturnType<typeof this.ctx.ui.showOverlay> | undefined;
 
-		this.showSelector(done => {
-			let cleanup: (() => void) | undefined;
+		const done = () => {
+			cleanup?.();
+			overlayHandle?.hide();
+			this.ctx.ui.requestRender();
+		};
 
-			const selector = new SessionObserverOverlayComponent(
-				registry,
-				() => {
-					cleanup?.();
-					done();
-				},
-				observeKeys,
-			);
+		const selector = new SessionObserverOverlayComponent(registry, done, observeKeys);
 
-			cleanup = registry.onChange(() => {
-				selector.refreshFromRegistry();
-				this.ctx.ui.requestRender();
-			});
-
-			return { component: selector, focus: selector };
+		cleanup = registry.onChange(() => {
+			selector.refreshFromRegistry();
+			this.ctx.ui.requestRender();
 		});
+
+		overlayHandle = this.ctx.ui.showOverlay(selector, {
+			anchor: "bottom-center",
+			width: "100%",
+			maxHeight: "100%",
+			margin: 0,
+		});
+		this.ctx.ui.setFocus(selector);
+		this.ctx.ui.requestRender();
 	}
 }


### PR DESCRIPTION
## What

Rewrites the Session Observer (Ctrl+S) from a cramped inline overlay with truncated content into a full-screen, scrollable transcript viewer with expand/collapse, markdown rendering, model visibility, and seamless agent cycling.

**User impact:** You can now see exactly what each sub-agent is thinking, which tools it calls, what results it gets, and which model it runs — without leaving the terminal or losing your chat context.

## Why

The existing Session Observer showed truncated summaries (600 chars thinking, "N lines" tool results) in a small overlay that replaced the editor area. It required navigating a picker list on every Ctrl+S, had no scrolling, and rendered markdown as raw text. Compared to OpenCode's sub-agent dive-in, it was unusable for understanding what sub-agents were actually doing.

## Changes

### Full-screen overlay
Switch from `showSelector` (inline editor replacement) to `showOverlay` with `width: 100%`, `maxHeight: 100%` so the viewer fills the terminal.

### Scrollable viewer with entry navigation
- `j`/`k`/arrows navigate between entries (thinking, tool calls, responses)
- `PgUp`/`PgDn` for page jumps, `g`/`G` for top/bottom  
- Scroll position indicator in footer: `[5-25/42]`

### Expand/collapse per entry
- `Enter` toggles any entry between collapsed preview and full content
- Collapsed: first few lines or character limit. Expanded: full content
- Selection cursor (`▶`) shows which entry is active

### Markdown rendering
Expanded content renders through the TUI `Markdown` component using `getMarkdownTheme()` — headings, code blocks with syntax highlighting, bold/italic, links, lists all styled with the active theme.

### Agent cycling
- `]`/`Tab` and `[`/`Shift+Tab` cycle through sub-agent sessions inline
- Header shows position: `ScanCodingAgent [active] explore (2/5) · anthropic/claude-sonnet-4-6`
- No picker list — Ctrl+S jumps directly to the most recently active sub-agent

### Model visibility
Extracts model name from JSONL transcript (`model_change` entry or first assistant message) and shows it in the viewer header.

### Error message rendering  
Assistant messages with empty content and `errorMessage` (connection errors, rate limits) now render as `✗ Error: <message>` instead of being silently hidden.

### Smart initial position
Auto-selects the first non-user entry on viewer open (skips the system prompt). Collapsed user messages show a truncated one-liner with line count.

## Testing

**Scrolling & expand:** Run a task that spawns sub-agents. Press Ctrl+S. Navigate with `j`/`k`, expand entries with Enter. Scroll indicator updates in footer.

**Markdown:** Expand an entry containing markdown (headings, code blocks). Verify theme-colored rendering vs raw text when collapsed.

**Cycling:** With multiple sub-agents, press `]` to cycle. Header shows agent name, status, position, and model. Wraps around.

**Direct jump:** Press Ctrl+S — lands on most recent active sub-agent, not a picker. Esc or Ctrl+S closes.

**Errors:** If a sub-agent hits connection errors, verify `✗ Error: ...` appears instead of blank space.

---

- [x] `bun check` passes (tsgo --noEmit + biome check)  
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)