### PR TITLE
feat(status-line): add permission mode segment

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -76,7 +76,8 @@ export type StatusLineSegmentId =
 	| "hostname"
 	| "cache_read"
 	| "cache_write"
-	| "session_name";
+	| "session_name"
+	| "permission";
 
 interface UiMetadata {
 	tab: SettingTab;

--- a/packages/coding-agent/src/modes/components/status-line/presets.ts
+++ b/packages/coding-agent/src/modes/components/status-line/presets.ts
@@ -2,7 +2,7 @@ import type { PresetDef, StatusLinePreset } from "./types";
 
 export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	default: {
-		leftSegments: ["pi", "model", "plan_mode", "path", "git", "pr", "context_pct", "token_total", "cost"],
+		leftSegments: ["pi", "model", "plan_mode", "permission", "path", "git", "pr", "context_pct", "token_total", "cost"],
 		rightSegments: ["session_name"],
 		separator: "powerline-thin",
 		segmentOptions: {
@@ -33,7 +33,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	},
 
 	full: {
-		leftSegments: ["pi", "hostname", "model", "plan_mode", "path", "git", "pr", "subagents"],
+		leftSegments: ["pi", "hostname", "model", "plan_mode", "permission", "path", "git", "pr", "subagents"],
 		rightSegments: [
 			"session_name",
 			"token_in",

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -368,6 +368,45 @@ const sessionNameSegment: StatusLineSegment = {
 	},
 };
 
+// ---------------------------------------------------------------------------
+// Permission Mode
+// ---------------------------------------------------------------------------
+
+const PERMISSION_MODE_COLORS: Record<string, string> = {
+	"read-only": "dim",
+	"plan": "warning",
+	"standard": "muted",
+	"trust": "error",
+};
+
+const PERMISSION_MODE_LABELS: Record<string, string> = {
+	"read-only": "ro",
+	"plan": "plan",
+	"standard": "std",
+	"trust": "trust",
+};
+
+const permissionSegment: StatusLineSegment = {
+	id: "permission",
+	render(ctx) {
+		// Read mode from session entries (written by extensions that use
+		// customType "permission-mode" entries via SessionManager).
+		const entries = ctx.session.sessionManager?.getEntries() ?? [];
+		let mode = "standard";
+		for (let i = entries.length - 1; i >= 0; i--) {
+			const e = entries[i] as { type?: string; customType?: string; data?: { mode?: string } };
+			if (e.type === "custom" && e.customType === "permission-mode" && e.data?.mode) {
+				mode = e.data.mode;
+				break;
+			}
+		}
+
+		const color = PERMISSION_MODE_COLORS[mode] ?? "muted";
+		const label = PERMISSION_MODE_LABELS[mode] ?? mode;
+		return { content: theme.fg(color, label), visible: true };
+	},
+};
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Segment Registry
 // ═══════════════════════════════════════════════════════════════════════════
@@ -394,6 +433,7 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 	cache_read: cacheReadSegment,
 	cache_write: cacheWriteSegment,
 	session_name: sessionNameSegment,
+	permission: permissionSegment,
 };
 
 export function renderSegment(id: StatusLineSegmentId, ctx: SegmentContext): RenderedSegment {

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -646,6 +646,7 @@ export class ExtensionUiController {
 			return;
 		}
 		this.ctx.statusLine.setHookStatus(key, text);
+		this.ctx.updateEditorTopBorder();
 		this.ctx.ui.requestRender();
 	}
 


### PR DESCRIPTION
## Summary

Adds a built-in `permission` status line segment that reads the current permission mode from session entries. Extensions can write mode state via `SessionManager.appendCustomEntry("permission-mode", { mode })` and the segment picks it up on the next render.

This enables extensions like permission modes, gate guards, or any tool-restriction system to surface the current enforcement level directly in the status line without custom UI.

## Changes

**`settings-schema.ts`** — Add `"permission"` to the `StatusLineSegmentId` union type.

**`segments.ts`** — Add `permissionSegment`:
- Scans session entries in reverse for `customType === "permission-mode"`
- Defaults to `"standard"` when no entry is found
- Color-coded: `dim` = read-only, `warning` = plan, `muted` = standard, `error` = trust
- Short labels: `ro`, `plan`, `std`, `trust`
- Always visible so the user always knows the current enforcement level

**`presets.ts`** — Include `"permission"` in the `default` and `full` preset left segments (after `plan_mode`).

**`extension-ui-controller.ts`** — Call `updateEditorTopBorder()` inside `setHookStatus()`. Without this, the editor top border (where status line segments render) does not refresh when extensions call `ctx.ui.setStatus()`. This is a pre-existing bug that affects any extension using `setStatus` to trigger a UI update — the hook status text above the editor would update, but the top border segment content would remain stale until the next message or manual interaction.

## Extension integration

Any extension can drive this segment by writing session entries:

```ts
pi.appendEntry("permission-mode", { mode: "read-only" });
```

The segment reads the most recent entry, so the extension can update it on mode change. Combined with `ctx.ui.setStatus(key, undefined)` (to trigger `setHookStatus` → `updateEditorTopBorder` → re-render), the segment updates immediately.

## Testing

- Verified with a companion `omp-permission-modes` extension that switches between read-only, plan, standard, and trust modes
- Segment renders correctly in all four modes with appropriate colors
- Segment updates immediately on `/mode` command (via the `setHookStatus` top-border refresh fix)
- No impact on existing segments or presets