### PR TITLE
feat: Add dart support for ast_grep and ast_edit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2220,6 +2220,7 @@ dependencies = [
  "tree-sitter-cmake",
  "tree-sitter-cpp",
  "tree-sitter-css",
+ "tree-sitter-dart",
  "tree-sitter-diff",
  "tree-sitter-dockerfile-updated",
  "tree-sitter-elixir",
@@ -3203,6 +3204,16 @@ name = "tree-sitter-css"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5cbc5e18f29a2c6d6435891f42569525cf95435a3e01c2f1947abcde178686f"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-dart"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bba6bf8675e6fe92ba6da371a5497ee5df2a04d2c503e3599c8ad771f6f1faec"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/crates/pi-natives/Cargo.toml
+++ b/crates/pi-natives/Cargo.toml
@@ -42,6 +42,7 @@ tree-sitter-clojure = "0.1"
 tree-sitter-cmake = "0.7.1"
 tree-sitter-c-sharp = "0.23"
 tree-sitter-cpp = "0.23"
+tree-sitter-dart = "0.1"
 tree-sitter-css = "0.25"
 tree-sitter-diff = "0.1"
 tree-sitter-dockerfile = { version = "0.2.0", package = "tree-sitter-dockerfile-updated" }

--- a/crates/pi-natives/build.rs
+++ b/crates/pi-natives/build.rs
@@ -107,6 +107,11 @@ const GRAMMARS: &[GrammarSpec] = &[
 		node_types_rel: "src/node-types.json",
 	},
 	GrammarSpec {
+		language:       "dart",
+		package:        "tree-sitter-dart",
+		node_types_rel: "src/node-types.json",
+	},
+	GrammarSpec {
 		language:       "css",
 		package:        "tree-sitter-css",
 		node_types_rel: "src/node-types.json",

--- a/crates/pi-natives/src/language/mod.rs
+++ b/crates/pi-natives/src/language/mod.rs
@@ -166,6 +166,7 @@ impl_lang!(Toml, language_toml);
 impl_lang!(Diff, language_diff);
 impl_lang!(Xml, language_xml);
 impl_lang!(Regex, language_regex);
+impl_lang!(Dart, language_dart);
 
 // ── Html (custom implementation with injection support) ──────────────────
 
@@ -273,6 +274,7 @@ pub enum SupportLang {
 	Cmake,
 	Cpp,
 	CSharp,
+	Dart,
 	Clojure,
 	Css,
 	Diff,
@@ -335,10 +337,10 @@ impl SupportLang {
 	pub const fn all_langs() -> &'static [Self] {
 		use SupportLang::*;
 		&[
-			Astro, Bash, C, Cmake, Cpp, CSharp, Clojure, Css, Diff, Dockerfile, Elixir, Erlang, Go,
-			Graphql, Handlebars, Haskell, Hcl, Html, Ini, Java, JavaScript, Json, Just, Julia, Kotlin,
-			Lua, Make, Markdown, Nix, ObjC, Ocaml, Odin, Perl, Php, Powershell, Proto, Python, R,
-			Regex, Ruby, Rust, Scala, Solidity, Sql, Starlark, Svelte, Swift, Toml, Tlaplus, Tsx,
+			Astro, Bash, C, Cmake, Cpp, CSharp, Dart, Clojure, Css, Diff, Dockerfile, Elixir, Erlang,
+			Go, Graphql, Handlebars, Haskell, Hcl, Html, Ini, Java, JavaScript, Json, Just, Julia,
+			Kotlin, Lua, Make, Markdown, Nix, ObjC, Ocaml, Odin, Perl, Php, Powershell, Proto, Python,
+			R, Regex, Ruby, Rust, Scala, Solidity, Sql, Starlark, Svelte, Swift, Toml, Tlaplus, Tsx,
 			TypeScript, Verilog, Vue, Xml, Yaml, Zig,
 		]
 	}
@@ -353,6 +355,7 @@ impl SupportLang {
 			Self::Cmake => "cmake",
 			Self::Cpp => "cpp",
 			Self::CSharp => "csharp",
+			Self::Dart => "dart",
 			Self::Clojure => "clojure",
 			Self::Css => "css",
 			Self::Diff => "diff",
@@ -434,6 +437,7 @@ macro_rules! execute_lang_method {
 			S::Cmake => Cmake.$method($($pname,)*),
 			S::Cpp => Cpp.$method($($pname,)*),
 			S::CSharp => CSharp.$method($($pname,)*),
+			S::Dart => Dart.$method($($pname,)*),
 			S::Clojure => Clojure.$method($($pname,)*),
 			S::Css => Css.$method($($pname,)*),
 			S::Diff => Diff.$method($($pname,)*),
@@ -548,6 +552,7 @@ const fn extensions(lang: SupportLang) -> &'static [&'static str] {
 		Cmake => &["cmake"],
 		Cpp => &["cc", "hpp", "cpp", "c++", "hh", "cxx", "cu", "ino"],
 		CSharp => &["cs"],
+		Dart => &["dart"],
 		Clojure => &["clj", "cljs", "cljc", "edn"],
 		Css => &["css", "scss"],
 		Diff => &["diff", "patch"],
@@ -651,6 +656,7 @@ static LANG_ALIASES: phf::Map<&'static str, SupportLang> = phf_map! {
 "csharp"         => SupportLang::CSharp,
 "c#"             => SupportLang::CSharp,
 "cs"             => SupportLang::CSharp,
+"dart"           => SupportLang::Dart,
 "css"            => SupportLang::Css,
 "clj"            => SupportLang::Clojure,
 "cljc"           => SupportLang::Clojure,

--- a/crates/pi-natives/src/language/parsers.rs
+++ b/crates/pi-natives/src/language/parsers.rs
@@ -23,6 +23,9 @@ pub fn language_cpp() -> TSLanguage {
 pub fn language_c_sharp() -> TSLanguage {
 	tree_sitter_c_sharp::LANGUAGE.into()
 }
+pub fn language_dart() -> TSLanguage {
+	tree_sitter_dart::LANGUAGE.into()
+}
 pub fn language_css() -> TSLanguage {
 	tree_sitter_css::LANGUAGE.into()
 }

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Dart support to `astGrep` and `astEdit` through the native tree-sitter Dart grammar ([#748](https://github.com/can1357/oh-my-pi/pull/748) by [@0fflineuser](https://github.com/0fflineuser))
+
 ## [14.1.1] - 2026-04-14
 
 ### Added


### PR DESCRIPTION
## What

Added tree-sitter-dart, and dart grammar for AST tools.

## Why

AST tools don't support dart yet. 
This is usefull for both dart and flutter projects.

## Testing

Create tmp dart file

```bash
mkdir -p /tmp/dart-test && cat > /tmp/dart-test/main.dart <<'EOF'
void main() {
  print('hello');
}

void greet(String name) {
  print('hi $name');
}

class Widget {
  void build() {}
}
EOF
```

Test astGrep:
```bash
bun -e '
  const { astGrep } = require("./packages/natives/native/index.js");
  const r = await astGrep({
    patterns: ["void $NAME()"],
    lang: "dart",
    path: "/tmp/dart-test",
  });
  console.log(JSON.stringify(r, null, 2));
'
```

Test astEdit:
```bash
bun -e '
  const { astEdit } = require("./packages/natives/native/index.js");
  const r = await astEdit({
    rewrites: { "void $NAME()": "Future<void> $NAME()" },
    lang: "dart",
    path: "/tmp/dart-test/main.dart",
  });
  console.log(JSON.stringify(r, null, 2));
'
```

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
