### PR TITLE
fix(ai): handle raw reasoning_text.delta from local providers

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Renamed `rewriteCopilotAuthError` to `rewriteCopilotError` and extended it to rewrite `HTTP 400 model_not_supported` after retries are exhausted with guidance about Copilot's OAuth-client-specific rollout gap (see opencode#13313).
 
+### Fixed
+
+- Fixed OpenAI Responses streaming to display thinking tokens from local providers (llama.cpp, etc.) that send raw `reasoning_text.delta` events and empty `summary` arrays in `output_item.done`. Previously, thinking content was silently dropped during streaming while non-streaming mode worked correctly.
+
 ## [14.1.3] - 2026-04-17
 
 ### Fixed

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -250,7 +250,7 @@ export async function processResponsesStream<TApi extends Api>(
 			const item = event.item;
 			if (item.type === "reasoning") {
 				currentItem = item;
-				currentBlock = { type: "thinking", thinking: "" };
+				currentBlock = { type: "thinking", thinking: "", itemId: item.id };
 				output.content.push(currentBlock);
 				stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
 			} else if (item.type === "message") {
@@ -304,6 +304,18 @@ export async function processResponsesStream<TApi extends Api>(
 						partial: output,
 					});
 				}
+			}
+		} else if (event.type === "response.reasoning_text.delta") {
+			// Raw reasoning text delta from local providers that stream thinking
+			// directly rather than via the OpenAI summary tracking protocol.
+			if (currentItem?.type === "reasoning" && currentBlock?.type === "thinking") {
+				currentBlock.thinking += event.delta;
+				stream.push({
+					type: "thinking_delta",
+					contentIndex: blockIndex(),
+					delta: event.delta,
+					partial: output,
+				});
 			}
 		} else if (event.type === "response.content_part.added") {
 			if (currentItem?.type === "message") {
@@ -359,16 +371,28 @@ export async function processResponsesStream<TApi extends Api>(
 		} else if (event.type === "response.output_item.done") {
 			const item = structuredCloneJSON(event.item);
 			options?.onOutputItemDone?.(item);
-			if (item.type === "reasoning" && currentBlock?.type === "thinking") {
-				currentBlock.thinking = item.summary?.map(part => part.text).join("\n\n") || "";
-				currentBlock.thinkingSignature = JSON.stringify(item);
-				stream.push({
-					type: "thinking_end",
-					contentIndex: blockIndex(),
-					content: currentBlock.thinking,
-					partial: output,
-				});
-				currentBlock = null;
+			if (item.type === "reasoning") {
+				const thinking =
+					item.summary?.length > 0
+						? item.summary.map(part => part.text).join("\n\n")
+						: item.content?.[0]?.type === "reasoning_text"
+							? (item.content[0].text ?? "")
+							: "";
+				const reasoningBlock = output.content.find(
+					b => b.type === "thinking" && (b as ThinkingContent).itemId === item.id,
+				) as ThinkingContent | undefined;
+				if (reasoningBlock) {
+					reasoningBlock.thinking = thinking;
+					reasoningBlock.thinkingSignature = JSON.stringify(item);
+					const reasoningBlockIndex = output.content.indexOf(reasoningBlock);
+					stream.push({
+						type: "thinking_end",
+						contentIndex: reasoningBlockIndex,
+						content: thinking,
+						partial: output,
+					});
+				}
+				if ((currentBlock as ThinkingContent | null)?.itemId === item.id) currentBlock = null;
 			} else if (item.type === "message" && currentBlock?.type === "text") {
 				currentBlock.text = item.content
 					.map(part => (part.type === "output_text" ? (part.text ?? "") : (part.refusal ?? "")))

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -262,6 +262,7 @@ export interface ThinkingContent {
 	type: "thinking";
 	thinking: string;
 	thinkingSignature?: string; // e.g., for OpenAI responses, the reasoning item ID
+	itemId?: string; // item.id from output_item.added, used to match output_item.done
 }
 
 export interface RedactedThinkingContent {


### PR DESCRIPTION
## What

Add handler for \`response.reasoning_text.delta\` events and fix \`output_item.done\` to read from \`item.content\` when summary is empty. This enables streaming thinking tokens from local providers (llama.cpp, etc.) that use the raw reasoning text event type instead of the OpenAI summary tracking protocol.

## Why

OMP silently drops thinking tokens during streaming when the provider sends \`reasoning_text.delta\` events (llama.cpp, Qwen3.6). Non-streaming works because it reads the assembled JSON. Two issues:

1. No \`reasoning_text.delta\` handler — only \`reasoning_summary_text.delta\` was handled
2. \`output_item.done\` reasoning handler assumed non-empty \`summary\` — local providers send empty summary with full text in \`item.content[0].text\`

## Testing

- \`bun check:ts\` passes (lint + type check across all packages)
- Tested manually against Qwen3.6-35B-A3B served via llama.cpp Docker container

---

- [x] \`bun check\` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)