### PR TITLE
fix(auth): let OAuth credentials override keyless provider flag from stale models.yml (#749)

### DIFF
--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1886,7 +1886,7 @@ export class ModelRegistry {
 	 * Get API key for a model.
 	 */
 	async getApiKey(model: Model<Api>, sessionId?: string): Promise<string | undefined> {
-		if (this.#keylessProviders.has(model.provider)) {
+		if (this.#keylessProviders.has(model.provider) && !this.authStorage.hasAuth(model.provider)) {
 			return kNoAuth;
 		}
 		return this.authStorage.getApiKey(model.provider, sessionId, { baseUrl: model.baseUrl, modelId: model.id });
@@ -1896,14 +1896,14 @@ export class ModelRegistry {
 	 * Get API key for a provider (e.g., "openai").
 	 */
 	async getApiKeyForProvider(provider: string, sessionId?: string, baseUrl?: string): Promise<string | undefined> {
-		if (this.#keylessProviders.has(provider)) {
+		if (this.#keylessProviders.has(provider) && !this.authStorage.hasAuth(provider)) {
 			return kNoAuth;
 		}
 		return this.authStorage.getApiKey(provider, sessionId, { baseUrl });
 	}
 
 	async #peekApiKeyForProvider(provider: string): Promise<string | undefined> {
-		if (this.#keylessProviders.has(provider)) {
+		if (this.#keylessProviders.has(provider) && !this.authStorage.hasAuth(provider)) {
 			return kNoAuth;
 		}
 		return this.authStorage.peekApiKey(provider);


### PR DESCRIPTION
## Problem

After upgrading to `@oh-my-pi/pi-coding-agent@14.1.2`, GitHub Copilot requests fail with:
```
400 bad request: Authorization header is badly formatted
```

A stale user `~/.omp/agent/models.yml` (auto-seeded by an earlier version) declares `github-copilot` with `auth: none`. This marks the provider as keyless, causing `getApiKey()` to return the literal `"N/A"` — which is then sent as `Bearer N/A` — **without ever consulting `authStorage`**, even when valid OAuth credentials exist from a successful `/login`.

## Root Cause

In `model-registry.ts`, `getApiKey()`, `getApiKeyForProvider()`, and `#peekApiKeyForProvider()` all check `this.#keylessProviders.has(provider)` and immediately return `kNoAuth` without checking whether `authStorage` actually has credentials for that provider.

## Fix

Added `&& !this.authStorage.hasAuth(provider)` to the keyless guard in all three methods. If real credentials are present (e.g., from a successful OAuth flow), the methods now fall through to the normal auth resolution path instead of returning `"N/A"`.

This is a minimal change — 3 lines modified — that handles the upgrade scenario without requiring users to manually edit their `models.yml`.

Fixes #749