### PR TITLE
fix: disable bunfig.toml and .env autoloading in compiled binary

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed compiled `omp` binaries to ignore project-local `bunfig.toml` and `.env` autoloading at startup, preventing unrelated project config from crashing or preloading code into the CLI
 - Fixed edit tool diff and replace operations to report missing-file failures as `File not found: <path>` errors instead of raw filesystem ENOENT errors
 - Fixed `local://` URL path leak on Linux where `//` collapsing to `/` produced `local:/path` forms that bypassed the internal protocol handler and leaked as filesystem paths, breaking plan mode file resolution
 - Fixed Tavily web search silently returning off-topic news articles when `--recency` was set. The provider was unconditionally coupling `topic: "news"` to recency, which scoped Tavily's index to news publications and excluded documentation, release notes, GitHub, and all non-news technical content. Technical queries with `--recency` now return the correct corpus.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -31,7 +31,7 @@
 		"omp": "src/cli.ts"
 	},
 	"scripts": {
-		"build": "bun --cwd=../stats scripts/generate-client-bundle.ts --generate && bun --cwd=../natives run embed:native && bun build --compile --define PI_COMPILED=true --external mupdf --root ../.. ./src/cli.ts --outfile dist/omp && bun --cwd=../natives run embed:native --reset && bun --cwd=../stats scripts/generate-client-bundle.ts --reset",
+		"build": "bun --cwd=../stats scripts/generate-client-bundle.ts --generate && bun --cwd=../natives run embed:native && bun build --compile --no-compile-autoload-bunfig --no-compile-autoload-dotenv --define PI_COMPILED=true --external mupdf --root ../.. ./src/cli.ts --outfile dist/omp && bun --cwd=../natives run embed:native --reset && bun --cwd=../stats scripts/generate-client-bundle.ts --reset",
 		"check": "biome check . && bun run check:types",
 		"check:types": "tsgo -p tsconfig.json --noEmit",
 		"lint": "biome lint .",

--- a/scripts/ci-release-build-binaries.ts
+++ b/scripts/ci-release-build-binaries.ts
@@ -67,11 +67,11 @@ async function buildBinary(target: BinaryTarget): Promise<void> {
 	console.log(`Building ${target.outfile}...`);
 	await embedNative(target);
 	if (isDryRun) {
-		console.log(`DRY RUN bun build --compile --define PI_COMPILED=true --root . --external mupdf --target=${target.target} ${entrypoint} --outfile ${target.outfile}`);
+		console.log(`DRY RUN bun build --compile --no-compile-autoload-bunfig --no-compile-autoload-dotenv --define PI_COMPILED=true --root . --external mupdf --target=${target.target} ${entrypoint} --outfile ${target.outfile}`);
 		return;
 	}
 
-	await $`bun build --compile --define PI_COMPILED=true --root . --external mupdf --target=${target.target} ${entrypoint} --outfile ${target.outfile}`.cwd(
+	await $`bun build --compile --no-compile-autoload-bunfig --no-compile-autoload-dotenv --define PI_COMPILED=true --root . --external mupdf --target=${target.target} ${entrypoint} --outfile ${target.outfile}`.cwd(
 		repoRoot,
 	);
 }


### PR DESCRIPTION
Compiled Bun binaries unconditionally load `bunfig.toml` and `.env` from the current working directory at runtime, before any application code runs. Since omp is a coding agent that runs from arbitrary project directories, it picks up foreign project configs -- most critically `preload` directives that cause immediate crashes, but also a potential security issue since preloads execute arbitrary code.

## What

Add `--no-compile-autoload-bunfig` and `--no-compile-autoload-dotenv` to all `bun build --compile` invocations (local build script and CI release script).

## Why

Running `omp` from any directory containing a `bunfig.toml` with a `preload` entry (e.g. a Bun monorepo) crashes before application code executes:

```
$ cd ~/my-project  # has bunfig.toml with preload = ["./packages/loader"]
$ omp --help
error: preload not found "./packages/loader"
```

Beyond crashes, this is a security concern: a malicious `bunfig.toml` with a `preload` directive achieves arbitrary code execution under the invoking user's privileges -- simply by being present in the working directory.

Bun added `--no-compile-autoload-bunfig` and `--no-compile-autoload-dotenv` in [v1.3.3](https://bun.com/blog/bun-v1.3.3) specifically for this case.

## Open issue

Source installs via `bun install -g` are still affected because `bun run` has no equivalent flag to suppress CWD config loading. That path needs a separate fix (e.g. a shell wrapper entrypoint that passes `bun --config ''`).

## Testing

Built locally with the new flags, confirmed `omp --help` works from a directory containing a foreign `bunfig.toml` with preloads.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
