### PR TITLE
fix(coding-agent): honor claude plugin manifest paths

### DIFF
--- a/packages/coding-agent/src/discovery/claude-plugins.ts
+++ b/packages/coding-agent/src/discovery/claude-plugins.ts
@@ -28,6 +28,39 @@ const PROVIDER_ID = "claude-plugins";
 const DISPLAY_NAME = "Claude Code Marketplace";
 const PRIORITY = 70; // Below claude.ts (80) so user .claude/ overrides win
 
+interface ClaudePluginManifest {
+	skills?: string;
+	"slash-commands"?: string;
+}
+
+async function readPluginManifest(root: ClaudePluginRoot): Promise<ClaudePluginManifest | null> {
+	const manifestPath = path.join(root.path, ".claude-plugin", "plugin.json");
+	const raw = await readFile(manifestPath);
+	if (raw === null) return null;
+
+	try {
+		const parsed = JSON.parse(raw);
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+		return parsed as ClaudePluginManifest;
+	} catch {
+		return null;
+	}
+}
+
+async function resolvePluginDir(
+	root: ClaudePluginRoot,
+	manifestKey: keyof ClaudePluginManifest,
+	fallback: string,
+): Promise<string> {
+	const manifest = await readPluginManifest(root);
+	const configured = manifest?.[manifestKey];
+	if (typeof configured === "string" && configured.trim()) {
+		return path.resolve(root.path, configured.trim());
+	}
+
+	return path.join(root.path, fallback);
+}
+
 // =============================================================================
 // Skills
 // =============================================================================
@@ -41,7 +74,7 @@ async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
 
 	const results = await Promise.all(
 		roots.map(async root => {
-			const skillsDir = path.join(root.path, "skills");
+			const skillsDir = await resolvePluginDir(root, "skills", "skills");
 			const result = await scanSkillsFromDir(ctx, {
 				dir: skillsDir,
 				providerId: PROVIDER_ID,
@@ -75,7 +108,7 @@ async function loadSlashCommands(ctx: LoadContext): Promise<LoadResult<SlashComm
 
 	const results = await Promise.all(
 		roots.map(async root => {
-			const commandsDir = path.join(root.path, "commands");
+			const commandsDir = await resolvePluginDir(root, "slash-commands", "commands");
 			return loadFilesFromDir<SlashCommand>(ctx, commandsDir, PROVIDER_ID, root.scope, {
 				extensions: ["md"],
 				transform: (name, content, filePath, source) => {

--- a/packages/coding-agent/src/discovery/claude-plugins.ts
+++ b/packages/coding-agent/src/discovery/claude-plugins.ts
@@ -33,6 +33,11 @@ interface ClaudePluginManifest {
 	"slash-commands"?: string;
 }
 
+interface ResolvedPluginDir {
+	dir: string;
+	warning?: string;
+}
+
 async function readPluginManifest(root: ClaudePluginRoot): Promise<ClaudePluginManifest | null> {
 	const manifestPath = path.join(root.path, ".claude-plugin", "plugin.json");
 	const raw = await readFile(manifestPath);
@@ -47,18 +52,32 @@ async function readPluginManifest(root: ClaudePluginRoot): Promise<ClaudePluginM
 	}
 }
 
+function isWithinPluginRoot(rootPath: string, targetPath: string): boolean {
+	const relative = path.relative(rootPath, targetPath);
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
 async function resolvePluginDir(
 	root: ClaudePluginRoot,
 	manifestKey: keyof ClaudePluginManifest,
 	fallback: string,
-): Promise<string> {
+): Promise<ResolvedPluginDir> {
 	const manifest = await readPluginManifest(root);
+	const fallbackDir = path.join(root.path, fallback);
 	const configured = manifest?.[manifestKey];
-	if (typeof configured === "string" && configured.trim()) {
-		return path.resolve(root.path, configured.trim());
+	if (typeof configured !== "string" || !configured.trim()) {
+		return { dir: fallbackDir };
 	}
 
-	return path.join(root.path, fallback);
+	const resolved = path.resolve(root.path, configured.trim());
+	if (isWithinPluginRoot(root.path, resolved)) {
+		return { dir: resolved };
+	}
+
+	return {
+		dir: fallbackDir,
+		warning: `[claude-plugins] Ignoring ${String(manifestKey)} path outside plugin root for ${root.id}: ${configured}`,
+	};
 }
 
 // =============================================================================
@@ -74,17 +93,18 @@ async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
 
 	const results = await Promise.all(
 		roots.map(async root => {
-			const skillsDir = await resolvePluginDir(root, "skills", "skills");
+			const { dir: skillsDir, warning } = await resolvePluginDir(root, "skills", "skills");
 			const result = await scanSkillsFromDir(ctx, {
 				dir: skillsDir,
 				providerId: PROVIDER_ID,
 				level: root.scope,
 			});
-			return { root, result };
+			return { root, result, warning };
 		}),
 	);
 
-	for (const { root, result } of results) {
+	for (const { root, result, warning } of results) {
+		if (warning) warnings.push(warning);
 		for (const skill of result.items) {
 			if (root.plugin) skill.name = `${root.plugin}:${skill.name}`;
 			items.push(skill);
@@ -108,8 +128,8 @@ async function loadSlashCommands(ctx: LoadContext): Promise<LoadResult<SlashComm
 
 	const results = await Promise.all(
 		roots.map(async root => {
-			const commandsDir = await resolvePluginDir(root, "slash-commands", "commands");
-			return loadFilesFromDir<SlashCommand>(ctx, commandsDir, PROVIDER_ID, root.scope, {
+			const { dir: commandsDir, warning } = await resolvePluginDir(root, "slash-commands", "commands");
+			const result = await loadFilesFromDir<SlashCommand>(ctx, commandsDir, PROVIDER_ID, root.scope, {
 				extensions: ["md"],
 				transform: (name, content, filePath, source) => {
 					const cmdName = name.replace(/\.md$/, "");
@@ -122,10 +142,12 @@ async function loadSlashCommands(ctx: LoadContext): Promise<LoadResult<SlashComm
 					};
 				},
 			});
+			return { result, warning };
 		}),
 	);
 
-	for (const result of results) {
+	for (const { result, warning } of results) {
+		if (warning) warnings.push(warning);
 		items.push(...result.items);
 		if (result.warnings) warnings.push(...result.warnings);
 	}

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { loadCapability } from "@oh-my-pi/pi-coding-agent/capability";
 import { clearCache as clearFsCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
 import {
 	clearClaudePluginRootsCache,
@@ -346,7 +347,6 @@ describe("listClaudePluginRoots", () => {
 			"---\nname: manifest-skill\ndescription: Manifest skill\n---\nBody\n",
 		);
 
-		const { loadCapability } = await import("@oh-my-pi/pi-coding-agent/capability");
 		const result = await loadCapability<Skill>("skills", { cwd: tempDir });
 		expect(result.warnings).toEqual([]);
 		expect(result.all.length).toBeGreaterThan(0);
@@ -385,7 +385,6 @@ describe("listClaudePluginRoots", () => {
 		);
 		await fs.writeFile(path.join(pluginPath, ".claude", "commands", "ship.md"), "Ship it\n");
 
-		const { loadCapability } = await import("@oh-my-pi/pi-coding-agent/capability");
 		const result = await loadCapability<SlashCommand>("slash-commands", { cwd: tempDir });
 		expect(result.warnings).toEqual([]);
 		expect(result.all.length).toBeGreaterThan(0);
@@ -427,7 +426,6 @@ describe("listClaudePluginRoots", () => {
 			"---\nname: outside-skill\ndescription: Outside skill\n---\nBody\n",
 		);
 
-		const { loadCapability } = await import("@oh-my-pi/pi-coding-agent/capability");
 		const result = await loadCapability<Skill>("skills", { cwd: tempDir });
 		expect(result.warnings[0]).toContain("Ignoring skills path outside plugin root");
 		const found = result.all.find(skill => skill.name === "manifest-skills-outside:outside-skill");
@@ -465,7 +463,6 @@ describe("listClaudePluginRoots", () => {
 		);
 		await fs.writeFile(path.join(outsideDir, "ship.md"), "Ship it\n");
 
-		const { loadCapability } = await import("@oh-my-pi/pi-coding-agent/capability");
 		const result = await loadCapability<SlashCommand>("slash-commands", { cwd: tempDir });
 		expect(result.warnings[0]).toContain("Ignoring slash-commands path outside plugin root");
 		const found = result.all.find(command => command.name === "manifest-commands-outside:ship");

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -10,6 +10,8 @@ import {
 } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
 import "@oh-my-pi/pi-coding-agent/discovery/claude-plugins";
+import type { Skill } from "@oh-my-pi/pi-coding-agent/capability/skill";
+import type { SlashCommand } from "@oh-my-pi/pi-coding-agent/capability/slash-command";
 
 describe("parseClaudePluginsRegistry", () => {
 	test("parses valid registry", () => {
@@ -345,7 +347,7 @@ describe("listClaudePluginRoots", () => {
 		);
 
 		const { loadCapability } = await import("@oh-my-pi/pi-coding-agent/capability");
-		const result = await loadCapability("skills", { cwd: tempDir });
+		const result = await loadCapability<Skill>("skills", { cwd: tempDir });
 		expect(result.warnings).toEqual([]);
 		expect(result.all.length).toBeGreaterThan(0);
 		const found = result.all.find(skill => skill.name === "manifest-skills:manifest-skill");
@@ -384,13 +386,91 @@ describe("listClaudePluginRoots", () => {
 		await fs.writeFile(path.join(pluginPath, ".claude", "commands", "ship.md"), "Ship it\n");
 
 		const { loadCapability } = await import("@oh-my-pi/pi-coding-agent/capability");
-		const result = await loadCapability("slash-commands", { cwd: tempDir });
+		const result = await loadCapability<SlashCommand>("slash-commands", { cwd: tempDir });
 		expect(result.warnings).toEqual([]);
 		expect(result.all.length).toBeGreaterThan(0);
 		const found = result.all.find(command => command.name === "manifest-commands:ship");
 
 		expect(found).toBeDefined();
 		expect(found?.path).toContain(path.join(".claude", "commands", "ship.md"));
+	});
+	test("ignores manifest skills directory that resolves outside plugin root", async () => {
+		const pluginsDir = path.join(tempDir, ".claude", "plugins");
+		const pluginPath = path.join(tempDir, "plugins", "manifest-skills-outside");
+		const outsideDir = path.join(tempDir, "outside-skills", "outside-skill");
+		await fs.mkdir(path.join(pluginsDir), { recursive: true });
+		await fs.mkdir(path.join(pluginPath, ".claude-plugin"), { recursive: true });
+		await fs.mkdir(outsideDir, { recursive: true });
+
+		const registry = {
+			version: 2,
+			plugins: {
+				"manifest-skills-outside@market": [
+					{
+						scope: "user",
+						installPath: pluginPath,
+						version: "1.0.0",
+						installedAt: "2025-01-01T00:00:00Z",
+						lastUpdated: "2025-01-01T00:00:00Z",
+					},
+				],
+			},
+		};
+
+		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
+		await fs.writeFile(
+			path.join(pluginPath, ".claude-plugin", "plugin.json"),
+			JSON.stringify({ skills: "../../outside-skills" }),
+		);
+		await fs.writeFile(
+			path.join(outsideDir, "SKILL.md"),
+			"---\nname: outside-skill\ndescription: Outside skill\n---\nBody\n",
+		);
+
+		const { loadCapability } = await import("@oh-my-pi/pi-coding-agent/capability");
+		const result = await loadCapability<Skill>("skills", { cwd: tempDir });
+		expect(result.warnings[0]).toContain("Ignoring skills path outside plugin root");
+		const found = result.all.find(skill => skill.name === "manifest-skills-outside:outside-skill");
+
+		expect(found).toBeUndefined();
+	});
+
+	test("ignores manifest slash commands directory that resolves outside plugin root", async () => {
+		const pluginsDir = path.join(tempDir, ".claude", "plugins");
+		const pluginPath = path.join(tempDir, "plugins", "manifest-commands-outside");
+		const outsideDir = path.join(tempDir, "outside-commands");
+		await fs.mkdir(path.join(pluginsDir), { recursive: true });
+		await fs.mkdir(path.join(pluginPath, ".claude-plugin"), { recursive: true });
+		await fs.mkdir(outsideDir, { recursive: true });
+
+		const registry = {
+			version: 2,
+			plugins: {
+				"manifest-commands-outside@market": [
+					{
+						scope: "user",
+						installPath: pluginPath,
+						version: "1.0.0",
+						installedAt: "2025-01-01T00:00:00Z",
+						lastUpdated: "2025-01-01T00:00:00Z",
+					},
+				],
+			},
+		};
+
+		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
+		await fs.writeFile(
+			path.join(pluginPath, ".claude-plugin", "plugin.json"),
+			JSON.stringify({ "slash-commands": "../../outside-commands" }),
+		);
+		await fs.writeFile(path.join(outsideDir, "ship.md"), "Ship it\n");
+
+		const { loadCapability } = await import("@oh-my-pi/pi-coding-agent/capability");
+		const result = await loadCapability<SlashCommand>("slash-commands", { cwd: tempDir });
+		expect(result.warnings[0]).toContain("Ignoring slash-commands path outside plugin root");
+		const found = result.all.find(command => command.name === "manifest-commands-outside:ship");
+
+		expect(found).toBeUndefined();
 	});
 });
 

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -9,6 +9,7 @@ import {
 	parseClaudePluginsRegistry,
 } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
+import "@oh-my-pi/pi-coding-agent/discovery/claude-plugins";
 
 describe("parseClaudePluginsRegistry", () => {
 	test("parses valid registry", () => {
@@ -55,15 +56,26 @@ describe("parseClaudePluginsRegistry", () => {
 
 describe("listClaudePluginRoots", () => {
 	let tempDir: string;
+	let originalHome: string | undefined;
 
 	beforeEach(async () => {
 		clearClaudePluginRootsCache();
 		clearFsCache();
+		originalHome = process.env.HOME;
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "claude-plugins-test-"));
+		process.env.HOME = tempDir;
+		vi.spyOn(os, "homedir").mockReturnValue(tempDir);
 	});
 
 	afterEach(async () => {
 		clearClaudePluginRootsCache();
+		clearFsCache();
+		vi.restoreAllMocks();
+		if (originalHome === undefined) {
+			delete process.env.HOME;
+		} else {
+			process.env.HOME = originalHome;
+		}
 		await fs.rm(tempDir, { recursive: true, force: true });
 	});
 
@@ -299,6 +311,86 @@ describe("listClaudePluginRoots", () => {
 		const result = await listClaudePluginRoots(tempDir);
 		expect(result.roots).toHaveLength(1);
 		expect(result.roots[0].scope).toBe("user");
+	});
+	test("reads skills directory from plugin manifest skills field", async () => {
+		const pluginsDir = path.join(tempDir, ".claude", "plugins");
+		const pluginPath = path.join(tempDir, "plugins", "manifest-skills");
+		await fs.mkdir(path.join(pluginsDir), { recursive: true });
+		await fs.mkdir(path.join(pluginPath, ".claude-plugin"), { recursive: true });
+		await fs.mkdir(path.join(pluginPath, ".claude", "skills", "manifest-skill"), { recursive: true });
+
+		const registry = {
+			version: 2,
+			plugins: {
+				"manifest-skills@market": [
+					{
+						scope: "user",
+						installPath: pluginPath,
+						version: "1.0.0",
+						installedAt: "2025-01-01T00:00:00Z",
+						lastUpdated: "2025-01-01T00:00:00Z",
+					},
+				],
+			},
+		};
+
+		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
+		await fs.writeFile(
+			path.join(pluginPath, ".claude-plugin", "plugin.json"),
+			JSON.stringify({ skills: "./.claude/skills" }),
+		);
+		await fs.writeFile(
+			path.join(pluginPath, ".claude", "skills", "manifest-skill", "SKILL.md"),
+			"---\nname: manifest-skill\ndescription: Manifest skill\n---\nBody\n",
+		);
+
+		const { loadCapability } = await import("@oh-my-pi/pi-coding-agent/capability");
+		const result = await loadCapability("skills", { cwd: tempDir });
+		expect(result.warnings).toEqual([]);
+		expect(result.all.length).toBeGreaterThan(0);
+		const found = result.all.find(skill => skill.name === "manifest-skills:manifest-skill");
+
+		expect(found).toBeDefined();
+		expect(found?.path).toContain(path.join(".claude", "skills", "manifest-skill", "SKILL.md"));
+	});
+
+	test("reads slash commands directory from plugin manifest slash-commands field", async () => {
+		const pluginsDir = path.join(tempDir, ".claude", "plugins");
+		const pluginPath = path.join(tempDir, "plugins", "manifest-commands");
+		await fs.mkdir(path.join(pluginsDir), { recursive: true });
+		await fs.mkdir(path.join(pluginPath, ".claude-plugin"), { recursive: true });
+		await fs.mkdir(path.join(pluginPath, ".claude", "commands"), { recursive: true });
+
+		const registry = {
+			version: 2,
+			plugins: {
+				"manifest-commands@market": [
+					{
+						scope: "user",
+						installPath: pluginPath,
+						version: "1.0.0",
+						installedAt: "2025-01-01T00:00:00Z",
+						lastUpdated: "2025-01-01T00:00:00Z",
+					},
+				],
+			},
+		};
+
+		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
+		await fs.writeFile(
+			path.join(pluginPath, ".claude-plugin", "plugin.json"),
+			JSON.stringify({ "slash-commands": "./.claude/commands" }),
+		);
+		await fs.writeFile(path.join(pluginPath, ".claude", "commands", "ship.md"), "Ship it\n");
+
+		const { loadCapability } = await import("@oh-my-pi/pi-coding-agent/capability");
+		const result = await loadCapability("slash-commands", { cwd: tempDir });
+		expect(result.warnings).toEqual([]);
+		expect(result.all.length).toBeGreaterThan(0);
+		const found = result.all.find(command => command.name === "manifest-commands:ship");
+
+		expect(found).toBeDefined();
+		expect(found?.path).toContain(path.join(".claude", "commands", "ship.md"));
 	});
 });
 


### PR DESCRIPTION
## Summary

fix #747
- honor `.claude-plugin/plugin.json` `skills` paths during Claude marketplace plugin discovery
- honor `.claude-plugin/plugin.json` `slash-commands` paths during Claude marketplace plugin discovery
- add regression tests covering manifest-defined skills and slash command directories

## Test Plan
- [x] bun test packages/coding-agent/test/discovery/claude-plugins.test.ts
- [x] bun test packages/coding-agent/test/marketplace/manager.test.ts