### PR TITLE
fix(ai): correct Xiaomi model discovery endpoint and filter TTS models

### DIFF
--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -1163,7 +1163,35 @@ export interface XiaomiModelManagerConfig {
 export function xiaomiModelManagerOptions(
 	config?: XiaomiModelManagerConfig,
 ): ModelManagerOptions<"anthropic-messages"> {
-	return createSimpleAnthropicProviderOptions("xiaomi", "https://api.xiaomimimo.com/anthropic", config);
+	const apiKey = config?.apiKey;
+	const baseUrl = normalizeAnthropicBaseUrl(config?.baseUrl, "https://api.xiaomimimo.com/anthropic");
+	// Xiaomi hosts chat completions under /anthropic/* but exposes model
+	// discovery at the OpenAI-style /v1/models endpoint on the root host.
+	const discoveryRoot = baseUrl.endsWith("/anthropic") ? baseUrl.slice(0, -"/anthropic".length) : baseUrl;
+	const discoveryBaseUrl = toAnthropicDiscoveryBaseUrl(discoveryRoot);
+	const references = createBundledReferenceMap<"anthropic-messages">("xiaomi");
+	return {
+		providerId: "xiaomi",
+		...(apiKey && {
+			fetchDynamicModels: () =>
+				fetchOpenAICompatibleModels({
+					api: "anthropic-messages",
+					provider: "xiaomi",
+					baseUrl: discoveryBaseUrl,
+					apiKey,
+					filterModel: (_entry, model) => !model.id.includes("-tts"),
+					mapModel: (entry, defaults) => {
+						const reference = references.get(defaults.id);
+						const model = mapWithBundledReference(entry, defaults, reference);
+						return {
+							...model,
+							name: toModelName(entry.display_name, model.name),
+							baseUrl,
+						};
+					},
+				}),
+		}),
+	};
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

- Fix Xiaomi model discovery to use `/v1/models` (OpenAI format) instead of `/anthropic/v1/models` (returns 404)
- Switch auth from `x-api-key` header to `Authorization: Bearer` for the discovery endpoint
- Filter out TTS models (`mimo-v2-tts`, `mimo-v2.5-tts`, etc.) from the chat model list

## Why

Xiaomi's API uses two different endpoint prefixes:
- **Chat completions**: `POST /anthropic/v1/messages` with `x-api-key` header (works correctly)
- **Model listing**: `GET /v1/models` with `Authorization: Bearer` (OpenAI-compatible format)

The previous code used `toAnthropicDiscoveryBaseUrl()` which resolves to `/anthropic/v1/models`, returning 404. This caused dynamic model discovery to silently fail and fall back to the static catalog, so newer models like `mimo-v2.5-pro` never appeared.

Verified via curl that `api.xiaomimimo.com/v1/models` with Bearer auth returns all 9 models including v2.5 variants.

## Testing

```bash
# Verify dynamic discovery finds models beyond the static catalog
bun run test-xiaomi-discovery.ts
```

Expected: static catalog shows 3 models (`mimo-v2-flash`, `mimo-v2-omni`, `mimo-v2-pro`), dynamic discovery shows 6+ models including `mimo-v2.5` and `mimo-v2.5-pro`. TTS models are filtered out.

---

- [x] `bun check` passes
- [x] Tested locally with `XIAOMI_API_KEY`
- [x] No CHANGELOG update needed (bug fix for existing provider)