### PR TITLE
chore: sync bundled OpenCode Go model catalog

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -16,7 +16,6 @@
 
 ## [14.1.3] - 2026-04-17
 
-
 ### Fixed
 
 - Preserved user-provided `session_id` and `x-client-request-id` headers in OpenAI Responses requests instead of overriding them with automatic session-derived values

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -10,7 +10,12 @@
 
 - Renamed `rewriteCopilotAuthError` to `rewriteCopilotError` and extended it to rewrite `HTTP 400 model_not_supported` after retries are exhausted with guidance about Copilot's OAuth-client-specific rollout gap (see opencode#13313).
 
+### Fixed
+
+- Synced the bundled OpenCode Go catalog with the current docs so `kimi-k2.6`, `mimo-v2.5`, and `mimo-v2.5-pro` appear in offline/default model lists
+
 ## [14.1.3] - 2026-04-17
+
 
 ### Fixed
 

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -33786,31 +33786,6 @@
 				"maxLevel": "xhigh"
 			}
 		},
-		"kimi-k2.6": {
-			"id": "kimi-k2.6",
-			"name": "Kimi K2.6",
-			"api": "openai-completions",
-			"provider": "opencode-go",
-			"baseUrl": "https://opencode.ai/zen/go/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.96,
-				"output": 4.83,
-				"cacheRead": 0.16,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": 65536,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
 		"kimi-k2.5": {
 			"id": "kimi-k2.5",
 			"name": "Kimi K2.5",
@@ -33953,55 +33928,6 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 128000,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"mimo-v2.5-pro": {
-			"id": "mimo-v2.5-pro",
-			"name": "MiMo V2.5 Pro",
-			"api": "openai-completions",
-			"provider": "opencode-go",
-			"baseUrl": "https://opencode.ai/zen/go/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 1,
-				"output": 3,
-				"cacheRead": 0.2,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 64000,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"mimo-v2.5": {
-			"id": "mimo-v2.5",
-			"name": "MiMo V2.5",
-			"api": "openai-completions",
-			"provider": "opencode-go",
-			"baseUrl": "https://opencode.ai/zen/go/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0.4,
-				"output": 2,
-				"cacheRead": 0.08,
-				"cacheWrite": 0
-			},
-			"contextWindow": 262144,
-			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -33786,6 +33786,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"kimi-k2.6": {
+			"id": "kimi-k2.6",
+			"name": "Kimi K2.6",
+			"api": "openai-completions",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.96,
+				"output": 4.83,
+				"cacheRead": 0.16,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"kimi-k2.5": {
 			"id": "kimi-k2.5",
 			"name": "Kimi K2.5",
@@ -33928,6 +33953,55 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"mimo-v2.5-pro": {
+			"id": "mimo-v2.5-pro",
+			"name": "MiMo V2.5 Pro",
+			"api": "openai-completions",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1,
+				"output": 3,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"mimo-v2.5": {
+			"id": "mimo-v2.5",
+			"name": "MiMo V2.5",
+			"api": "openai-completions",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.4,
+				"output": 2,
+				"cacheRead": 0.08,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",

--- a/packages/ai/test/zen.test.ts
+++ b/packages/ai/test/zen.test.ts
@@ -4,6 +4,27 @@ import { complete } from "@oh-my-pi/pi-ai/stream";
 import type { Model } from "@oh-my-pi/pi-ai/types";
 import { e2eApiKey } from "./oauth";
 
+describe("OpenCode bundled models", () => {
+	it("matches the current OpenCode Go model catalog", () => {
+		const expectedModelIds = [
+			"glm-5",
+			"glm-5.1",
+			"kimi-k2.5",
+			"kimi-k2.6",
+			"mimo-v2-omni",
+			"mimo-v2-pro",
+			"mimo-v2.5",
+			"mimo-v2.5-pro",
+			"minimax-m2.5",
+			"minimax-m2.7",
+			"qwen3.5-plus",
+			"qwen3.6-plus",
+		] as const;
+
+		expect(Object.keys(MODELS["opencode-go"]).sort()).toEqual(expectedModelIds.slice().sort());
+	});
+});
+
 describe.skipIf(!e2eApiKey("OPENCODE_API_KEY"))("OpenCode Models Smoke Test", () => {
 	const providers = [
 		{ key: "opencode-zen", label: "OpenCode Zen" },


### PR DESCRIPTION
## Summary

Sync the bundled `opencode-go` model catalog with the current OpenCode Go docs.

## Changes

- add bundled support for `opencode-go/mimo-v2.5`
- add bundled support for `opencode-go/mimo-v2.5-pro`
- keep bundled support for `opencode-go/kimi-k2.6`
- update the focused OpenCode Go test to assert the full advertised model catalog
- append changelog entries under `packages/ai/CHANGELOG.md`

## Why

OpenCode Go currently advertises these models in the docs:

- `glm-5`
- `glm-5.1`
- `kimi-k2.5`
- `kimi-k2.6`
- `mimo-v2-omni`
- `mimo-v2-pro`
- `mimo-v2.5`
- `mimo-v2.5-pro`
- `minimax-m2.5`
- `minimax-m2.7`
- `qwen3.5-plus`
- `qwen3.6-plus`