### PR TITLE
Fix provider transport override durability across refresh and source handoff

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fixed edit streaming preview updates to cancel obsolete in-flight computations and avoid rendering stale previews as args change
 - Fixed Mermaid fenced markdown rendering in assistant messages on terminals without image protocol support ([#650](https://github.com/can1357/oh-my-pi/issues/650))
 - Fixed SQLite `read` helper queries to reject `where=` clauses with SQL control syntax that could override the structured selector's pagination; raw SQL remains available through `q=SELECT ...`
+- Fixed `models` provider overrides so `headers`-only entries now apply to built-in providers without requiring `baseUrl`, including runtime `registerProvider()` header-only overrides
 
 ## [14.2.0] - 2026-04-23
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Fixed edit streaming preview updates to cancel obsolete in-flight computations and avoid rendering stale previews as args change
 - Fixed Mermaid fenced markdown rendering in assistant messages on terminals without image protocol support ([#650](https://github.com/can1357/oh-my-pi/issues/650))
 - Fixed SQLite `read` helper queries to reject `where=` clauses with SQL control syntax that could override the structured selector's pagination; raw SQL remains available through `q=SELECT ...`
-- Fixed `models` provider transport overrides so `headers`-only entries apply without requiring `baseUrl`, including runtime `registerProvider()` overrides that now persist across `refresh()` / `refreshProvider()`, preserve existing `baseUrl` on subsequent headers-only updates, and clear stale transport overrides when a provider is re-registered under a different extension source
+- Fixed `models` provider transport overrides so `headers`-only entries apply without requiring `baseUrl`, including runtime `registerProvider()` overrides that now persist across `refresh()` / `refreshProvider()`, preserve existing `baseUrl` on subsequent headers-only updates, clear stale transport overrides when a provider is re-registered under a different extension source, and keep runtime transport headers authoritative when `modelOverrides` set overlapping header keys
 
 ## [14.2.0] - 2026-04-23
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Fixed edit streaming preview updates to cancel obsolete in-flight computations and avoid rendering stale previews as args change
 - Fixed Mermaid fenced markdown rendering in assistant messages on terminals without image protocol support ([#650](https://github.com/can1357/oh-my-pi/issues/650))
 - Fixed SQLite `read` helper queries to reject `where=` clauses with SQL control syntax that could override the structured selector's pagination; raw SQL remains available through `q=SELECT ...`
-- Fixed `models` provider transport overrides so `headers`-only entries apply without requiring `baseUrl`, including runtime `registerProvider()` overrides that now persist across `refresh()` / `refreshProvider()` and preserve existing `baseUrl` on subsequent headers-only updates
+- Fixed `models` provider transport overrides so `headers`-only entries apply without requiring `baseUrl`, including runtime `registerProvider()` overrides that now persist across `refresh()` / `refreshProvider()`, preserve existing `baseUrl` on subsequent headers-only updates, and clear stale transport overrides when a provider is re-registered under a different extension source
 
 ## [14.2.0] - 2026-04-23
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Fixed edit streaming preview updates to cancel obsolete in-flight computations and avoid rendering stale previews as args change
 - Fixed Mermaid fenced markdown rendering in assistant messages on terminals without image protocol support ([#650](https://github.com/can1357/oh-my-pi/issues/650))
 - Fixed SQLite `read` helper queries to reject `where=` clauses with SQL control syntax that could override the structured selector's pagination; raw SQL remains available through `q=SELECT ...`
-- Fixed `models` provider overrides so `headers`-only entries now apply to built-in providers without requiring `baseUrl`, including runtime `registerProvider()` header-only overrides
+- Fixed `models` provider transport overrides so `headers`-only entries apply without requiring `baseUrl`, including runtime `registerProvider()` overrides that now persist across `refresh()` / `refreshProvider()` and preserve existing `baseUrl` on subsequent headers-only updates
 
 ## [14.2.0] - 2026-04-23
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -300,6 +300,7 @@ interface ProviderValidationModel {
 
 interface ProviderValidationConfig {
 	baseUrl?: string;
+	headers?: Record<string, string>;
 	apiKey?: string;
 	api?: Api;
 	auth?: ProviderAuthMode;
@@ -321,9 +322,9 @@ function validateProviderConfiguration(
 	if (models.length === 0) {
 		if (mode === "models-config") {
 			const hasModelOverrides = config.modelOverrides && Object.keys(config.modelOverrides).length > 0;
-			if (!config.baseUrl && !config.compat && !hasModelOverrides && !config.discovery) {
+			if (!config.baseUrl && !config.headers && !config.compat && !hasModelOverrides && !config.discovery) {
 				throw new Error(
-					`Provider ${providerName}: must specify "baseUrl", "compat", "modelOverrides", "discovery", or "models"`,
+					`Provider ${providerName}: must specify "baseUrl", "headers", "compat", "modelOverrides", "discovery", or "models"`,
 				);
 			}
 		}
@@ -378,6 +379,7 @@ export const ModelsConfigFile = new ConfigFile<ModelsConfig>("models", ModelsCon
 				providerName,
 				{
 					baseUrl: providerConfig.baseUrl,
+					headers: providerConfig.headers,
 					apiKey: providerConfig.apiKey,
 					api: providerConfig.api as Api | undefined,
 					auth: (providerConfig.auth ?? "apiKey") as ProviderAuthMode,
@@ -1970,6 +1972,7 @@ export class ModelRegistry {
 			providerName,
 			{
 				baseUrl: config.baseUrl,
+				headers: config.headers,
 				apiKey: config.apiKey,
 				api: config.api,
 				oauthConfigured: Boolean(config.oauth),
@@ -2057,7 +2060,7 @@ export class ModelRegistry {
 			return;
 		}
 
-		if (config.baseUrl) {
+		if (config.baseUrl || config.headers) {
 			this.#models = this.#models.map(m => {
 				if (m.provider !== providerName) return m;
 				return {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -772,6 +772,7 @@ export class ModelRegistry {
 	// models registered by extensions survive the model selector's offline reload.
 	#runtimeModelOverlays: CustomModelOverlay[] = [];
 	#runtimeProviderApiKeys: Map<string, string> = new Map();
+	#runtimeProviderOverrides: Map<string, ProviderOverride> = new Map();
 	#runtimeProvidersBySource: Map<string, Set<string>> = new Map();
 	#runtimeProviderSourceByName: Map<string, string> = new Map();
 
@@ -875,6 +876,10 @@ export class ModelRegistry {
 		this.#discoverableProviders = discoverableProviders;
 		this.#customModelOverlays = customModels;
 		this.#providerOverrides = overrides;
+		for (const [providerName, runtimeOverride] of this.#runtimeProviderOverrides) {
+			const merged = this.#mergeProviderOverride(this.#providerOverrides.get(providerName), runtimeOverride);
+			this.#providerOverrides.set(providerName, merged);
+		}
 		this.#modelOverrides = modelOverrides;
 		this.#equivalenceConfig = equivalence;
 
@@ -1659,6 +1664,14 @@ export class ModelRegistry {
 		});
 	}
 
+	#mergeProviderOverride(baseOverride: ProviderOverride | undefined, override: ProviderOverride): ProviderOverride {
+		return {
+			...baseOverride,
+			...override,
+			headers: override.headers ? { ...(baseOverride?.headers ?? {}), ...override.headers } : baseOverride?.headers,
+			compat: override.compat ? mergeCompat(baseOverride?.compat, override.compat) : baseOverride?.compat,
+		};
+	}
 	#applyModelOverrides(models: Model<Api>[], overrides: Map<string, Map<string, ModelOverride>>): Model<Api>[] {
 		if (overrides.size === 0) return models;
 		return models.map(model => {
@@ -1935,6 +1948,7 @@ export class ModelRegistry {
 			}
 			this.#runtimeProviderSourceByName.delete(providerName);
 			this.#runtimeProviderApiKeys.delete(providerName);
+			this.#runtimeProviderOverrides.delete(providerName);
 			this.#runtimeModelOverlays = this.#runtimeModelOverlays.filter(overlay => overlay.provider !== providerName);
 		}
 		this.#reloadStaticModels();
@@ -2061,6 +2075,11 @@ export class ModelRegistry {
 		}
 
 		if (config.baseUrl || config.headers) {
+			const nextRuntimeOverride = this.#mergeProviderOverride(this.#runtimeProviderOverrides.get(providerName), {
+				baseUrl: config.baseUrl,
+				headers: config.headers,
+			});
+			this.#runtimeProviderOverrides.set(providerName, nextRuntimeOverride);
 			this.#models = this.#models.map(m => {
 				if (m.provider !== providerName) return m;
 				return {

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -876,10 +876,6 @@ export class ModelRegistry {
 		this.#discoverableProviders = discoverableProviders;
 		this.#customModelOverlays = customModels;
 		this.#providerOverrides = overrides;
-		for (const [providerName, runtimeOverride] of this.#runtimeProviderOverrides) {
-			const merged = this.#mergeProviderOverride(this.#providerOverrides.get(providerName), runtimeOverride);
-			this.#providerOverrides.set(providerName, merged);
-		}
 		this.#modelOverrides = modelOverrides;
 		this.#equivalenceConfig = equivalence;
 
@@ -890,8 +886,9 @@ export class ModelRegistry {
 		const withConfigModels = this.#mergeCustomModels(resolvedDefaults, this.#customModelOverlays);
 		// Merge runtime extension models so they survive refresh() cycles
 		const combined = this.#mergeCustomModels(withConfigModels, this.#runtimeModelOverlays);
+		const withRuntimeProviderOverrides = this.#applyRuntimeProviderOverrides(combined);
 
-		this.#models = this.#applyModelOverrides(combined, this.#modelOverrides);
+		this.#models = this.#applyModelOverrides(withRuntimeProviderOverrides, this.#modelOverrides);
 		this.#rebuildCanonicalIndex();
 	}
 
@@ -1182,7 +1179,8 @@ export class ModelRegistry {
 		const withConfigModels = this.#mergeCustomModels(resolved, this.#customModelOverlays);
 		// Merge runtime extension models so they survive online discovery completion
 		const combined = this.#mergeCustomModels(withConfigModels, this.#runtimeModelOverlays);
-		this.#models = this.#applyModelOverrides(combined, this.#modelOverrides);
+		const withRuntimeProviderOverrides = this.#applyRuntimeProviderOverrides(combined);
+		this.#models = this.#applyModelOverrides(withRuntimeProviderOverrides, this.#modelOverrides);
 		this.#rebuildCanonicalIndex();
 	}
 
@@ -1682,6 +1680,14 @@ export class ModelRegistry {
 			headers: override.headers ? { ...entry.headers, ...override.headers } : entry.headers,
 		};
 	}
+	#applyRuntimeProviderOverrides(models: Model<Api>[]): Model<Api>[] {
+		if (this.#runtimeProviderOverrides.size === 0) return models;
+		return models.map(model => {
+			const override = this.#runtimeProviderOverrides.get(model.provider);
+			if (!override) return model;
+			return this.#applyProviderTransportOverride(model, override);
+		});
+	}
 	#applyModelOverrides(models: Model<Api>[], overrides: Map<string, Map<string, ModelOverride>>): Model<Api>[] {
 		if (overrides.size === 0) return models;
 		return models.map(model => {
@@ -2091,10 +2097,6 @@ export class ModelRegistry {
 				transportOverride,
 			);
 			this.#runtimeProviderOverrides.set(providerName, nextRuntimeOverride);
-			this.#runtimeModelOverlays = this.#runtimeModelOverlays.map(overlay => {
-				if (overlay.provider !== providerName) return overlay;
-				return this.#applyProviderTransportOverride(overlay, transportOverride);
-			});
 			this.#models = this.#models.map(m => {
 				if (m.provider !== providerName) return m;
 				return this.#applyProviderTransportOverride(m, transportOverride);

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1946,6 +1946,12 @@ export class ModelRegistry {
 		return this.authStorage.hasOAuth(model.provider);
 	}
 
+	#clearRuntimeProviderState(providerName: string): void {
+		this.#runtimeProviderApiKeys.delete(providerName);
+		this.#runtimeProviderOverrides.delete(providerName);
+		this.#runtimeModelOverlays = this.#runtimeModelOverlays.filter(overlay => overlay.provider !== providerName);
+	}
+
 	/**
 	 * Remove custom API/OAuth registrations for a specific extension source.
 	 */
@@ -1962,9 +1968,7 @@ export class ModelRegistry {
 				continue;
 			}
 			this.#runtimeProviderSourceByName.delete(providerName);
-			this.#runtimeProviderApiKeys.delete(providerName);
-			this.#runtimeProviderOverrides.delete(providerName);
-			this.#runtimeModelOverlays = this.#runtimeModelOverlays.filter(overlay => overlay.provider !== providerName);
+			this.#clearRuntimeProviderState(providerName);
 		}
 		this.#reloadStaticModels();
 		this.#rebuildCanonicalIndex();
@@ -2025,6 +2029,7 @@ export class ModelRegistry {
 			});
 		}
 
+		let sourceHandoff = false;
 		if (sourceId) {
 			this.#registeredProviderSources.add(sourceId);
 			const previousSourceId = this.#runtimeProviderSourceByName.get(providerName);
@@ -2034,13 +2039,18 @@ export class ModelRegistry {
 				if (previousProviders && previousProviders.size === 0) {
 					this.#runtimeProvidersBySource.delete(previousSourceId);
 				}
-				this.#runtimeProviderOverrides.delete(providerName);
+				this.#clearRuntimeProviderState(providerName);
+				sourceHandoff = true;
 			}
 			const sourceProviders = this.#runtimeProvidersBySource.get(sourceId) ?? new Set<string>();
 			sourceProviders.add(providerName);
 			this.#runtimeProvidersBySource.set(sourceId, sourceProviders);
 			this.#runtimeProviderSourceByName.set(providerName, sourceId);
 		}
+		if (sourceHandoff) {
+			this.#reloadStaticModels();
+		}
+
 		if (config.apiKey) {
 			this.#customProviderApiKeys.set(providerName, config.apiKey);
 			// Persist runtime API keys so they survive #reloadStaticModels() cycles

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1666,8 +1666,8 @@ export class ModelRegistry {
 
 	#mergeProviderOverride(baseOverride: ProviderOverride | undefined, override: ProviderOverride): ProviderOverride {
 		return {
-			...baseOverride,
-			...override,
+			baseUrl: override.baseUrl ?? baseOverride?.baseUrl,
+			apiKey: override.apiKey ?? baseOverride?.apiKey,
 			headers: override.headers ? { ...(baseOverride?.headers ?? {}), ...override.headers } : baseOverride?.headers,
 			compat: override.compat ? mergeCompat(baseOverride?.compat, override.compat) : baseOverride?.compat,
 		};

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -886,9 +886,8 @@ export class ModelRegistry {
 		const withConfigModels = this.#mergeCustomModels(resolvedDefaults, this.#customModelOverlays);
 		// Merge runtime extension models so they survive refresh() cycles
 		const combined = this.#mergeCustomModels(withConfigModels, this.#runtimeModelOverlays);
-		const withRuntimeProviderOverrides = this.#applyRuntimeProviderOverrides(combined);
-
-		this.#models = this.#applyModelOverrides(withRuntimeProviderOverrides, this.#modelOverrides);
+		const withModelOverrides = this.#applyModelOverrides(combined, this.#modelOverrides);
+		this.#models = this.#applyRuntimeProviderOverrides(withModelOverrides);
 		this.#rebuildCanonicalIndex();
 	}
 
@@ -1179,8 +1178,8 @@ export class ModelRegistry {
 		const withConfigModels = this.#mergeCustomModels(resolved, this.#customModelOverlays);
 		// Merge runtime extension models so they survive online discovery completion
 		const combined = this.#mergeCustomModels(withConfigModels, this.#runtimeModelOverlays);
-		const withRuntimeProviderOverrides = this.#applyRuntimeProviderOverrides(combined);
-		this.#models = this.#applyModelOverrides(withRuntimeProviderOverrides, this.#modelOverrides);
+		const withModelOverrides = this.#applyModelOverrides(combined, this.#modelOverrides);
+		this.#models = this.#applyRuntimeProviderOverrides(withModelOverrides);
 		this.#rebuildCanonicalIndex();
 	}
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2075,17 +2075,24 @@ export class ModelRegistry {
 			for (const overlay of newOverlays) {
 				nextModels.push(finalizeCustomModel(overlay, { useDefaults: true }));
 			}
+			const runtimeTransportOverride = this.#runtimeProviderOverrides.get(providerName);
+			const withRuntimeTransportOverride = runtimeTransportOverride
+				? nextModels.map(model => {
+						if (model.provider !== providerName) return model;
+						return this.#applyProviderTransportOverride(model, runtimeTransportOverride);
+					})
+				: nextModels;
 
 			if (config.oauth?.modifyModels) {
 				const credential = this.authStorage.getOAuthCredential(providerName);
 				if (credential) {
-					this.#models = config.oauth.modifyModels(nextModels, credential);
+					this.#models = config.oauth.modifyModels(withRuntimeTransportOverride, credential);
 					this.#rebuildCanonicalIndex();
 					return;
 				}
 			}
 
-			this.#models = nextModels;
+			this.#models = withRuntimeTransportOverride;
 			this.#rebuildCanonicalIndex();
 			return;
 		}

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -2035,6 +2035,7 @@ export class ModelRegistry {
 				if (previousProviders && previousProviders.size === 0) {
 					this.#runtimeProvidersBySource.delete(previousSourceId);
 				}
+				this.#runtimeProviderOverrides.delete(providerName);
 			}
 			const sourceProviders = this.#runtimeProvidersBySource.get(sourceId) ?? new Set<string>();
 			sourceProviders.add(providerName);

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1672,6 +1672,16 @@ export class ModelRegistry {
 			compat: override.compat ? mergeCompat(baseOverride?.compat, override.compat) : baseOverride?.compat,
 		};
 	}
+	#applyProviderTransportOverride<T extends { baseUrl?: string; headers?: Record<string, string> }>(
+		entry: T,
+		override: Pick<ProviderOverride, "baseUrl" | "headers">,
+	): T {
+		return {
+			...entry,
+			baseUrl: override.baseUrl ?? entry.baseUrl,
+			headers: override.headers ? { ...entry.headers, ...override.headers } : entry.headers,
+		};
+	}
 	#applyModelOverrides(models: Model<Api>[], overrides: Map<string, Map<string, ModelOverride>>): Model<Api>[] {
 		if (overrides.size === 0) return models;
 		return models.map(model => {
@@ -2075,18 +2085,19 @@ export class ModelRegistry {
 		}
 
 		if (config.baseUrl || config.headers) {
-			const nextRuntimeOverride = this.#mergeProviderOverride(this.#runtimeProviderOverrides.get(providerName), {
-				baseUrl: config.baseUrl,
-				headers: config.headers,
-			});
+			const transportOverride = { baseUrl: config.baseUrl, headers: config.headers };
+			const nextRuntimeOverride = this.#mergeProviderOverride(
+				this.#runtimeProviderOverrides.get(providerName),
+				transportOverride,
+			);
 			this.#runtimeProviderOverrides.set(providerName, nextRuntimeOverride);
+			this.#runtimeModelOverlays = this.#runtimeModelOverlays.map(overlay => {
+				if (overlay.provider !== providerName) return overlay;
+				return this.#applyProviderTransportOverride(overlay, transportOverride);
+			});
 			this.#models = this.#models.map(m => {
 				if (m.provider !== providerName) return m;
-				return {
-					...m,
-					baseUrl: config.baseUrl ?? m.baseUrl,
-					headers: config.headers ? { ...m.headers, ...config.headers } : m.headers,
-				};
+				return this.#applyProviderTransportOverride(m, transportOverride);
 			});
 			this.#rebuildCanonicalIndex();
 		}

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -104,17 +104,57 @@ describe("ModelRegistry runtime provider registration", () => {
 		expect(model?.headers?.["X-Model"]).toBe("model-header");
 	});
 
-	test("registerProvider applies headers-only overrides to existing provider models", () => {
+	test("registerProvider applies headers-only overrides to existing provider models across refresh", async () => {
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const anthropicBefore = registry.getAll().filter(model => model.provider === "anthropic");
+		const runtimeHeader = "X-Runtime-Provider-Header";
+
+		expect(anthropicBefore.length).toBeGreaterThan(1);
+		registry.registerProvider("anthropic", { headers: { [runtimeHeader]: "runtime-header" } }, "ext://runtime");
+
+		const anthropicAfterRegister = registry.getAll().filter(model => model.provider === "anthropic");
+		expect(anthropicAfterRegister.length).toBe(anthropicBefore.length);
+		for (const model of anthropicAfterRegister) {
+			expect(model.headers?.[runtimeHeader]).toBe("runtime-header");
+		}
+
+		await registry.refresh("offline");
+		const anthropicAfterRefresh = registry.getAll().filter(model => model.provider === "anthropic");
+		expect(anthropicAfterRefresh.length).toBe(anthropicBefore.length);
+		for (const model of anthropicAfterRefresh) {
+			expect(model.headers?.[runtimeHeader]).toBe("runtime-header");
+		}
+
+		registry.clearSourceRegistrations("ext://runtime");
+		const anthropicAfterClear = registry.getAll().filter(model => model.provider === "anthropic");
+		for (const model of anthropicAfterClear) {
+			expect(model.headers?.[runtimeHeader]).toBeUndefined();
+		}
+	});
+
+	test("registerProvider applies baseUrl-only overrides to existing provider models across refresh", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const proxyBaseUrl = "https://runtime-proxy.example.com/v1";
 		const anthropicBefore = registry.getAll().filter(model => model.provider === "anthropic");
 
 		expect(anthropicBefore.length).toBeGreaterThan(1);
-		registry.registerProvider("anthropic", { headers: { "X-Provider": "runtime-header" } }, "ext://runtime");
+		registry.registerProvider("anthropic", { baseUrl: proxyBaseUrl }, "ext://runtime");
 
-		const anthropicAfter = registry.getAll().filter(model => model.provider === "anthropic");
-		expect(anthropicAfter.length).toBe(anthropicBefore.length);
-		for (const model of anthropicAfter) {
-			expect(model.headers?.["X-Provider"]).toBe("runtime-header");
+		const anthropicAfterRegister = registry.getAll().filter(model => model.provider === "anthropic");
+		for (const model of anthropicAfterRegister) {
+			expect(model.baseUrl).toBe(proxyBaseUrl);
+		}
+
+		await registry.refresh("offline");
+		const anthropicAfterRefresh = registry.getAll().filter(model => model.provider === "anthropic");
+		for (const model of anthropicAfterRefresh) {
+			expect(model.baseUrl).toBe(proxyBaseUrl);
+		}
+
+		registry.clearSourceRegistrations("ext://runtime");
+		const anthropicAfterClear = registry.getAll().filter(model => model.provider === "anthropic");
+		for (const model of anthropicAfterClear) {
+			expect(model.baseUrl).not.toBe(proxyBaseUrl);
 		}
 	});
 

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -104,6 +104,20 @@ describe("ModelRegistry runtime provider registration", () => {
 		expect(model?.headers?.["X-Model"]).toBe("model-header");
 	});
 
+	test("registerProvider applies headers-only overrides to existing provider models", () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const anthropicBefore = registry.getAll().filter(model => model.provider === "anthropic");
+
+		expect(anthropicBefore.length).toBeGreaterThan(1);
+		registry.registerProvider("anthropic", { headers: { "X-Provider": "runtime-header" } }, "ext://runtime");
+
+		const anthropicAfter = registry.getAll().filter(model => model.provider === "anthropic");
+		expect(anthropicAfter.length).toBe(anthropicBefore.length);
+		for (const model of anthropicAfter) {
+			expect(model.headers?.["X-Provider"]).toBe("runtime-header");
+		}
+	});
+
 	test("registerProvider preserves explicit thinking on runtime models", () => {
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);
 		const config: ProviderConfigInput = {

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -158,6 +158,40 @@ describe("ModelRegistry runtime provider registration", () => {
 		}
 	});
 
+	test("registerProvider provider overrides survive refreshProvider for that provider", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const runtimeHeader = "X-Runtime-Provider-Refresh-Header";
+		const proxyBaseUrl = "https://runtime-provider-refresh.example.com/v1";
+
+		registry.registerProvider(
+			"anthropic",
+			{ baseUrl: proxyBaseUrl, headers: { [runtimeHeader]: "runtime-header" } },
+			"ext://runtime",
+		);
+
+		const anthropicAfterRegister = registry.getAll().filter(model => model.provider === "anthropic");
+		expect(anthropicAfterRegister.length).toBeGreaterThan(1);
+		for (const model of anthropicAfterRegister) {
+			expect(model.baseUrl).toBe(proxyBaseUrl);
+			expect(model.headers?.[runtimeHeader]).toBe("runtime-header");
+		}
+
+		await registry.refreshProvider("anthropic", "offline");
+		const anthropicAfterProviderRefresh = registry.getAll().filter(model => model.provider === "anthropic");
+		expect(anthropicAfterProviderRefresh.length).toBeGreaterThan(1);
+		for (const model of anthropicAfterProviderRefresh) {
+			expect(model.baseUrl).toBe(proxyBaseUrl);
+			expect(model.headers?.[runtimeHeader]).toBe("runtime-header");
+		}
+
+		registry.clearSourceRegistrations("ext://runtime");
+		const anthropicAfterClear = registry.getAll().filter(model => model.provider === "anthropic");
+		for (const model of anthropicAfterClear) {
+			expect(model.baseUrl).not.toBe(proxyBaseUrl);
+			expect(model.headers?.[runtimeHeader]).toBeUndefined();
+		}
+	});
+
 	test("registerProvider preserves explicit thinking on runtime models", () => {
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);
 		const config: ProviderConfigInput = {

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -125,69 +125,16 @@ describe("ModelRegistry runtime provider registration", () => {
 			expect(model.headers?.[runtimeHeader]).toBe("runtime-header");
 		}
 
-		registry.clearSourceRegistrations("ext://runtime");
-		const anthropicAfterClear = registry.getAll().filter(model => model.provider === "anthropic");
-		for (const model of anthropicAfterClear) {
-			expect(model.headers?.[runtimeHeader]).toBeUndefined();
-		}
-	});
-
-	test("registerProvider applies baseUrl-only overrides to existing provider models across refresh", async () => {
-		const registry = new ModelRegistry(authStorage, modelsJsonPath);
-		const proxyBaseUrl = "https://runtime-proxy.example.com/v1";
-		const anthropicBefore = registry.getAll().filter(model => model.provider === "anthropic");
-
-		expect(anthropicBefore.length).toBeGreaterThan(1);
-		registry.registerProvider("anthropic", { baseUrl: proxyBaseUrl }, "ext://runtime");
-
-		const anthropicAfterRegister = registry.getAll().filter(model => model.provider === "anthropic");
-		for (const model of anthropicAfterRegister) {
-			expect(model.baseUrl).toBe(proxyBaseUrl);
-		}
-
-		await registry.refresh("offline");
-		const anthropicAfterRefresh = registry.getAll().filter(model => model.provider === "anthropic");
-		for (const model of anthropicAfterRefresh) {
-			expect(model.baseUrl).toBe(proxyBaseUrl);
-		}
-
-		registry.clearSourceRegistrations("ext://runtime");
-		const anthropicAfterClear = registry.getAll().filter(model => model.provider === "anthropic");
-		for (const model of anthropicAfterClear) {
-			expect(model.baseUrl).not.toBe(proxyBaseUrl);
-		}
-	});
-
-	test("registerProvider provider overrides survive refreshProvider for that provider", async () => {
-		const registry = new ModelRegistry(authStorage, modelsJsonPath);
-		const runtimeHeader = "X-Runtime-Provider-Refresh-Header";
-		const proxyBaseUrl = "https://runtime-provider-refresh.example.com/v1";
-
-		registry.registerProvider(
-			"anthropic",
-			{ baseUrl: proxyBaseUrl, headers: { [runtimeHeader]: "runtime-header" } },
-			"ext://runtime",
-		);
-
-		const anthropicAfterRegister = registry.getAll().filter(model => model.provider === "anthropic");
-		expect(anthropicAfterRegister.length).toBeGreaterThan(1);
-		for (const model of anthropicAfterRegister) {
-			expect(model.baseUrl).toBe(proxyBaseUrl);
-			expect(model.headers?.[runtimeHeader]).toBe("runtime-header");
-		}
-
 		await registry.refreshProvider("anthropic", "offline");
 		const anthropicAfterProviderRefresh = registry.getAll().filter(model => model.provider === "anthropic");
-		expect(anthropicAfterProviderRefresh.length).toBeGreaterThan(1);
+		expect(anthropicAfterProviderRefresh.length).toBe(anthropicBefore.length);
 		for (const model of anthropicAfterProviderRefresh) {
-			expect(model.baseUrl).toBe(proxyBaseUrl);
 			expect(model.headers?.[runtimeHeader]).toBe("runtime-header");
 		}
 
 		registry.clearSourceRegistrations("ext://runtime");
 		const anthropicAfterClear = registry.getAll().filter(model => model.provider === "anthropic");
 		for (const model of anthropicAfterClear) {
-			expect(model.baseUrl).not.toBe(proxyBaseUrl);
 			expect(model.headers?.[runtimeHeader]).toBeUndefined();
 		}
 	});

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -304,6 +304,50 @@ describe("ModelRegistry runtime provider registration", () => {
 		expect(registry.find("runtime-provider", modelId)).toBeUndefined();
 	});
 
+	test("headers-only runtime override preserves existing baseUrl across refresh", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const modelId = "runtime-headers-only-baseurl-survivor";
+		const overrideBaseUrl = "https://runtime-baseurl.example.com/v1";
+		const runtimeHeader = "X-Runtime-Headers-Only";
+
+		registry.registerProvider(
+			"runtime-provider",
+			{
+				baseUrl: "https://runtime.example.com/v1",
+				apiKey: "RUNTIME_KEY",
+				api: "openai-completions",
+				models: [{ ...baseModel, id: modelId }],
+			},
+			"ext://runtime",
+		);
+		registry.registerProvider("runtime-provider", { baseUrl: overrideBaseUrl }, "ext://runtime");
+		registry.registerProvider(
+			"runtime-provider",
+			{ headers: { [runtimeHeader]: "runtime-header" } },
+			"ext://runtime",
+		);
+
+		const modelAfterHeadersOnly = registry.find("runtime-provider", modelId);
+		expect(modelAfterHeadersOnly).toBeDefined();
+		expect(modelAfterHeadersOnly?.baseUrl).toBe(overrideBaseUrl);
+		expect(modelAfterHeadersOnly?.headers?.[runtimeHeader]).toBe("runtime-header");
+
+		await registry.refresh("offline");
+		const modelAfterRefresh = registry.find("runtime-provider", modelId);
+		expect(modelAfterRefresh).toBeDefined();
+		expect(modelAfterRefresh?.baseUrl).toBe(overrideBaseUrl);
+		expect(modelAfterRefresh?.headers?.[runtimeHeader]).toBe("runtime-header");
+
+		await registry.refreshProvider("runtime-provider", "offline");
+		const modelAfterProviderRefresh = registry.find("runtime-provider", modelId);
+		expect(modelAfterProviderRefresh).toBeDefined();
+		expect(modelAfterProviderRefresh?.baseUrl).toBe(overrideBaseUrl);
+		expect(modelAfterProviderRefresh?.headers?.[runtimeHeader]).toBe("runtime-header");
+
+		registry.clearSourceRegistrations("ext://runtime");
+		expect(registry.find("runtime-provider", modelId)).toBeUndefined();
+	});
+
 	test("extension-registered API keys survive refresh cycle for auth resolution", async () => {
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);
 

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -340,8 +340,10 @@ describe("ModelRegistry runtime provider registration", () => {
 		expect(getCustomApi("custom-runtime-api")).toBeDefined();
 	});
 
-	test("re-registering a provider replaces previous runtime overlays", async () => {
+	test("re-registering a provider replaces overlays and keeps transport overrides stable", async () => {
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const runtimeHeader = "X-ReRegister-Provider-Header";
+		const overrideBaseUrl = "https://runtime-override.example.com/v1";
 		const config1: ProviderConfigInput = {
 			baseUrl: "https://runtime.example.com/v1",
 			apiKey: "RUNTIME_KEY",
@@ -356,16 +358,28 @@ describe("ModelRegistry runtime provider registration", () => {
 		};
 
 		registry.registerProvider("runtime-provider", config1, "ext://runtime");
-		expect(registry.find("runtime-provider", "model-v1")).toBeDefined();
-
+		registry.registerProvider(
+			"runtime-provider",
+			{ baseUrl: overrideBaseUrl, headers: { [runtimeHeader]: "runtime-header" } },
+			"ext://runtime",
+		);
 		registry.registerProvider("runtime-provider", config2, "ext://runtime");
-		expect(registry.find("runtime-provider", "model-v2")).toBeDefined();
-		expect(registry.find("runtime-provider", "model-v1")).toBeUndefined();
 
-		// After refresh, only v2 should exist
-		await registry.refresh("offline");
-		expect(registry.find("runtime-provider", "model-v2")).toBeDefined();
 		expect(registry.find("runtime-provider", "model-v1")).toBeUndefined();
+		const modelAfterReplace = registry.find("runtime-provider", "model-v2");
+		expect(modelAfterReplace).toBeDefined();
+		expect(modelAfterReplace?.baseUrl).toBe(overrideBaseUrl);
+		expect(modelAfterReplace?.headers?.[runtimeHeader]).toBe("runtime-header");
+
+		await registry.refresh("offline");
+		const modelAfterRefresh = registry.find("runtime-provider", "model-v2");
+		expect(modelAfterRefresh?.baseUrl).toBe(overrideBaseUrl);
+		expect(modelAfterRefresh?.headers?.[runtimeHeader]).toBe("runtime-header");
+
+		await registry.refreshProvider("runtime-provider", "offline");
+		const modelAfterProviderRefresh = registry.find("runtime-provider", "model-v2");
+		expect(modelAfterProviderRefresh?.baseUrl).toBe(overrideBaseUrl);
+		expect(modelAfterProviderRefresh?.headers?.[runtimeHeader]).toBe("runtime-header");
 	});
 
 	test("multiple extension providers survive refresh independently", async () => {

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -295,6 +295,49 @@ describe("ModelRegistry runtime provider registration", () => {
 		expect(registry.find("runtime-provider", modelId)).toBeUndefined();
 	});
 
+	test("runtime headers override modelOverrides headers across refresh cycles", async () => {
+		const initialRegistry = new ModelRegistry(authStorage, modelsJsonPath);
+		const targetModel = initialRegistry.getAll().find(model => model.provider === "anthropic");
+		if (!targetModel) throw new Error("Expected bundled anthropic model");
+
+		const modelId = targetModel.id;
+		const sharedHeader = "X-Shared-Provider-Model-Header";
+		const configHeaderValue = "config-header";
+		const runtimeHeaderValue = "runtime-header";
+
+		fs.writeFileSync(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					anthropic: {
+						modelOverrides: {
+							[modelId]: { headers: { [sharedHeader]: configHeaderValue } },
+						},
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		expect(registry.find("anthropic", modelId)?.headers?.[sharedHeader]).toBe(configHeaderValue);
+
+		registry.registerProvider(
+			"anthropic",
+			{ headers: { [sharedHeader]: runtimeHeaderValue } },
+			"ext://runtime",
+		);
+		expect(registry.find("anthropic", modelId)?.headers?.[sharedHeader]).toBe(runtimeHeaderValue);
+
+		await registry.refresh("offline");
+		expect(registry.find("anthropic", modelId)?.headers?.[sharedHeader]).toBe(runtimeHeaderValue);
+
+		await registry.refreshProvider("anthropic", "offline");
+		expect(registry.find("anthropic", modelId)?.headers?.[sharedHeader]).toBe(runtimeHeaderValue);
+
+		registry.clearSourceRegistrations("ext://runtime");
+		expect(registry.find("anthropic", modelId)?.headers?.[sharedHeader]).toBe(configHeaderValue);
+	});
+
 	test("extension-registered API keys survive refresh cycle for auth resolution", async () => {
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);
 

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -473,6 +473,44 @@ describe("ModelRegistry runtime provider registration", () => {
 		expect(modelAfterProviderRefresh?.headers?.[leakedHeader]).toBeUndefined();
 	});
 
+	test("transport-only source handoff clears previous source headers immediately", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const providerName = "anthropic";
+		const sourceAHeader = "X-Source-A-Header";
+		const sourceBHeader = "X-Source-B-Header";
+
+		registry.registerProvider(
+			providerName,
+			{ headers: { [sourceAHeader]: "from-source-a" } },
+			"ext://a",
+		);
+		for (const model of registry.getAll().filter(entry => entry.provider === providerName)) {
+			expect(model.headers?.[sourceAHeader]).toBe("from-source-a");
+		}
+
+		registry.registerProvider(
+			providerName,
+			{ headers: { [sourceBHeader]: "from-source-b" } },
+			"ext://b",
+		);
+		for (const model of registry.getAll().filter(entry => entry.provider === providerName)) {
+			expect(model.headers?.[sourceAHeader]).toBeUndefined();
+			expect(model.headers?.[sourceBHeader]).toBe("from-source-b");
+		}
+
+		await registry.refresh("offline");
+		for (const model of registry.getAll().filter(entry => entry.provider === providerName)) {
+			expect(model.headers?.[sourceAHeader]).toBeUndefined();
+			expect(model.headers?.[sourceBHeader]).toBe("from-source-b");
+		}
+
+		await registry.refreshProvider(providerName, "offline");
+		for (const model of registry.getAll().filter(entry => entry.provider === providerName)) {
+			expect(model.headers?.[sourceAHeader]).toBeUndefined();
+			expect(model.headers?.[sourceBHeader]).toBe("from-source-b");
+		}
+	});
+
 	test("multiple extension providers survive refresh independently", async () => {
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);
 

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -382,6 +382,54 @@ describe("ModelRegistry runtime provider registration", () => {
 		expect(modelAfterProviderRefresh?.headers?.[runtimeHeader]).toBe("runtime-header");
 	});
 
+	test("provider source handoff does not retain previous source transport overrides", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const providerName = "shared-runtime-provider";
+		const leakedHeader = "X-Old-Source-Header";
+		const sourceBBaseUrl = "https://source-b.example.com/v1";
+
+		registry.registerProvider(
+			providerName,
+			{
+				baseUrl: "https://source-a.example.com/v1",
+				apiKey: "KEY_A",
+				api: "openai-completions",
+				models: [{ ...baseModel, id: "model-a" }],
+			},
+			"ext://a",
+		);
+		registry.registerProvider(
+			providerName,
+			{ baseUrl: "https://override-a.example.com/v1", headers: { [leakedHeader]: "from-source-a" } },
+			"ext://a",
+		);
+		registry.registerProvider(
+			providerName,
+			{
+				baseUrl: sourceBBaseUrl,
+				apiKey: "KEY_B",
+				api: "openai-completions",
+				models: [{ ...baseModel, id: "model-b" }],
+			},
+			"ext://b",
+		);
+
+		expect(registry.find(providerName, "model-a")).toBeUndefined();
+		const modelAfterHandoff = registry.find(providerName, "model-b");
+		expect(modelAfterHandoff?.baseUrl).toBe(sourceBBaseUrl);
+		expect(modelAfterHandoff?.headers?.[leakedHeader]).toBeUndefined();
+
+		await registry.refresh("offline");
+		const modelAfterRefresh = registry.find(providerName, "model-b");
+		expect(modelAfterRefresh?.baseUrl).toBe(sourceBBaseUrl);
+		expect(modelAfterRefresh?.headers?.[leakedHeader]).toBeUndefined();
+
+		await registry.refreshProvider(providerName, "offline");
+		const modelAfterProviderRefresh = registry.find(providerName, "model-b");
+		expect(modelAfterProviderRefresh?.baseUrl).toBe(sourceBBaseUrl);
+		expect(modelAfterProviderRefresh?.headers?.[leakedHeader]).toBeUndefined();
+	});
+
 	test("multiple extension providers survive refresh independently", async () => {
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);
 

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -53,6 +53,54 @@ describe("ModelRegistry runtime provider registration", () => {
 	const streamSimple: NonNullable<ProviderConfigInput["streamSimple"]> = () =>
 		({}) as unknown as AssistantMessageEventStream;
 
+	function getProviderModels(registry: ModelRegistry, providerName: string) {
+		return registry.getAll().filter(model => model.provider === providerName);
+	}
+
+	function expectProviderHeader(
+		registry: ModelRegistry,
+		providerName: string,
+		headerName: string,
+		expectedValue: string | undefined,
+	): void {
+		for (const model of getProviderModels(registry, providerName)) {
+			expect(model.headers?.[headerName]).toBe(expectedValue);
+		}
+	}
+
+	async function expectProviderHeaderAcrossRefresh(
+		registry: ModelRegistry,
+		providerName: string,
+		headerName: string,
+		expectedValue: string | undefined,
+	): Promise<void> {
+		expectProviderHeader(registry, providerName, headerName, expectedValue);
+		await registry.refresh("offline");
+		expectProviderHeader(registry, providerName, headerName, expectedValue);
+		await registry.refreshProvider(providerName, "offline");
+		expectProviderHeader(registry, providerName, headerName, expectedValue);
+	}
+
+	async function expectModelTransportAcrossRefresh(
+		registry: ModelRegistry,
+		providerName: string,
+		modelId: string,
+		baseUrl: string,
+		headerName: string,
+		headerValue: string | undefined,
+	): Promise<void> {
+		const model = registry.find(providerName, modelId);
+		expect(model).toBeDefined();
+		expect(model?.baseUrl).toBe(baseUrl);
+		expect(model?.headers?.[headerName]).toBe(headerValue);
+		await registry.refresh("offline");
+		expect(registry.find(providerName, modelId)?.baseUrl).toBe(baseUrl);
+		expect(registry.find(providerName, modelId)?.headers?.[headerName]).toBe(headerValue);
+		await registry.refreshProvider(providerName, "offline");
+		expect(registry.find(providerName, modelId)?.baseUrl).toBe(baseUrl);
+		expect(registry.find(providerName, modelId)?.headers?.[headerName]).toBe(headerValue);
+	}
+
 	test("loads built-in GitLab Duo models and OAuth provider metadata", () => {
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);
 		const model = registry.find("gitlab-duo", "claude-sonnet-4-5-20250929");
@@ -106,37 +154,15 @@ describe("ModelRegistry runtime provider registration", () => {
 
 	test("registerProvider applies headers-only overrides to existing provider models across refresh", async () => {
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);
-		const anthropicBefore = registry.getAll().filter(model => model.provider === "anthropic");
+		const providerName = "anthropic";
 		const runtimeHeader = "X-Runtime-Provider-Header";
 
-		expect(anthropicBefore.length).toBeGreaterThan(1);
-		registry.registerProvider("anthropic", { headers: { [runtimeHeader]: "runtime-header" } }, "ext://runtime");
-
-		const anthropicAfterRegister = registry.getAll().filter(model => model.provider === "anthropic");
-		expect(anthropicAfterRegister.length).toBe(anthropicBefore.length);
-		for (const model of anthropicAfterRegister) {
-			expect(model.headers?.[runtimeHeader]).toBe("runtime-header");
-		}
-
-		await registry.refresh("offline");
-		const anthropicAfterRefresh = registry.getAll().filter(model => model.provider === "anthropic");
-		expect(anthropicAfterRefresh.length).toBe(anthropicBefore.length);
-		for (const model of anthropicAfterRefresh) {
-			expect(model.headers?.[runtimeHeader]).toBe("runtime-header");
-		}
-
-		await registry.refreshProvider("anthropic", "offline");
-		const anthropicAfterProviderRefresh = registry.getAll().filter(model => model.provider === "anthropic");
-		expect(anthropicAfterProviderRefresh.length).toBe(anthropicBefore.length);
-		for (const model of anthropicAfterProviderRefresh) {
-			expect(model.headers?.[runtimeHeader]).toBe("runtime-header");
-		}
+		expect(getProviderModels(registry, providerName).length).toBeGreaterThan(1);
+		registry.registerProvider(providerName, { headers: { [runtimeHeader]: "runtime-header" } }, "ext://runtime");
+		await expectProviderHeaderAcrossRefresh(registry, providerName, runtimeHeader, "runtime-header");
 
 		registry.clearSourceRegistrations("ext://runtime");
-		const anthropicAfterClear = registry.getAll().filter(model => model.provider === "anthropic");
-		for (const model of anthropicAfterClear) {
-			expect(model.headers?.[runtimeHeader]).toBeUndefined();
-		}
+		expectProviderHeader(registry, providerName, runtimeHeader, undefined);
 	});
 
 	test("registerProvider preserves explicit thinking on runtime models", () => {
@@ -230,23 +256,14 @@ describe("ModelRegistry runtime provider registration", () => {
 			"ext://runtime",
 		);
 
-		const modelAfterOverride = registry.find("runtime-provider", modelId);
-		expect(modelAfterOverride).toBeDefined();
-		expect(modelAfterOverride?.baseUrl).toBe(overrideBaseUrl);
-		expect(modelAfterOverride?.headers?.[runtimeHeader]).toBe("runtime-header");
-
-		await registry.refresh("offline");
-		const modelAfterRefresh = registry.find("runtime-provider", modelId);
-		expect(modelAfterRefresh).toBeDefined();
-		expect(modelAfterRefresh?.baseUrl).toBe(overrideBaseUrl);
-		expect(modelAfterRefresh?.headers?.[runtimeHeader]).toBe("runtime-header");
-
-		await registry.refreshProvider("runtime-provider", "offline");
-		const modelAfterProviderRefresh = registry.find("runtime-provider", modelId);
-		expect(modelAfterProviderRefresh).toBeDefined();
-		expect(modelAfterProviderRefresh?.baseUrl).toBe(overrideBaseUrl);
-		expect(modelAfterProviderRefresh?.headers?.[runtimeHeader]).toBe("runtime-header");
-
+		await expectModelTransportAcrossRefresh(
+			registry,
+			"runtime-provider",
+			modelId,
+			overrideBaseUrl,
+			runtimeHeader,
+			"runtime-header",
+		);
 		registry.clearSourceRegistrations("ext://runtime");
 		expect(registry.find("runtime-provider", modelId)).toBeUndefined();
 	});
@@ -274,23 +291,14 @@ describe("ModelRegistry runtime provider registration", () => {
 			"ext://runtime",
 		);
 
-		const modelAfterHeadersOnly = registry.find("runtime-provider", modelId);
-		expect(modelAfterHeadersOnly).toBeDefined();
-		expect(modelAfterHeadersOnly?.baseUrl).toBe(overrideBaseUrl);
-		expect(modelAfterHeadersOnly?.headers?.[runtimeHeader]).toBe("runtime-header");
-
-		await registry.refresh("offline");
-		const modelAfterRefresh = registry.find("runtime-provider", modelId);
-		expect(modelAfterRefresh).toBeDefined();
-		expect(modelAfterRefresh?.baseUrl).toBe(overrideBaseUrl);
-		expect(modelAfterRefresh?.headers?.[runtimeHeader]).toBe("runtime-header");
-
-		await registry.refreshProvider("runtime-provider", "offline");
-		const modelAfterProviderRefresh = registry.find("runtime-provider", modelId);
-		expect(modelAfterProviderRefresh).toBeDefined();
-		expect(modelAfterProviderRefresh?.baseUrl).toBe(overrideBaseUrl);
-		expect(modelAfterProviderRefresh?.headers?.[runtimeHeader]).toBe("runtime-header");
-
+		await expectModelTransportAcrossRefresh(
+			registry,
+			"runtime-provider",
+			modelId,
+			overrideBaseUrl,
+			runtimeHeader,
+			"runtime-header",
+		);
 		registry.clearSourceRegistrations("ext://runtime");
 		expect(registry.find("runtime-provider", modelId)).toBeUndefined();
 	});
@@ -309,11 +317,7 @@ describe("ModelRegistry runtime provider registration", () => {
 			modelsJsonPath,
 			JSON.stringify({
 				providers: {
-					anthropic: {
-						modelOverrides: {
-							[modelId]: { headers: { [sharedHeader]: configHeaderValue } },
-						},
-					},
+					anthropic: { modelOverrides: { [modelId]: { headers: { [sharedHeader]: configHeaderValue } } } },
 				},
 			}),
 		);
@@ -326,13 +330,7 @@ describe("ModelRegistry runtime provider registration", () => {
 			{ headers: { [sharedHeader]: runtimeHeaderValue } },
 			"ext://runtime",
 		);
-		expect(registry.find("anthropic", modelId)?.headers?.[sharedHeader]).toBe(runtimeHeaderValue);
-
-		await registry.refresh("offline");
-		expect(registry.find("anthropic", modelId)?.headers?.[sharedHeader]).toBe(runtimeHeaderValue);
-
-		await registry.refreshProvider("anthropic", "offline");
-		expect(registry.find("anthropic", modelId)?.headers?.[sharedHeader]).toBe(runtimeHeaderValue);
+		await expectProviderHeaderAcrossRefresh(registry, "anthropic", sharedHeader, runtimeHeaderValue);
 
 		registry.clearSourceRegistrations("ext://runtime");
 		expect(registry.find("anthropic", modelId)?.headers?.[sharedHeader]).toBe(configHeaderValue);
@@ -409,20 +407,14 @@ describe("ModelRegistry runtime provider registration", () => {
 		registry.registerProvider("runtime-provider", config2, "ext://runtime");
 
 		expect(registry.find("runtime-provider", "model-v1")).toBeUndefined();
-		const modelAfterReplace = registry.find("runtime-provider", "model-v2");
-		expect(modelAfterReplace).toBeDefined();
-		expect(modelAfterReplace?.baseUrl).toBe(overrideBaseUrl);
-		expect(modelAfterReplace?.headers?.[runtimeHeader]).toBe("runtime-header");
-
-		await registry.refresh("offline");
-		const modelAfterRefresh = registry.find("runtime-provider", "model-v2");
-		expect(modelAfterRefresh?.baseUrl).toBe(overrideBaseUrl);
-		expect(modelAfterRefresh?.headers?.[runtimeHeader]).toBe("runtime-header");
-
-		await registry.refreshProvider("runtime-provider", "offline");
-		const modelAfterProviderRefresh = registry.find("runtime-provider", "model-v2");
-		expect(modelAfterProviderRefresh?.baseUrl).toBe(overrideBaseUrl);
-		expect(modelAfterProviderRefresh?.headers?.[runtimeHeader]).toBe("runtime-header");
+		await expectModelTransportAcrossRefresh(
+			registry,
+			"runtime-provider",
+			"model-v2",
+			overrideBaseUrl,
+			runtimeHeader,
+			"runtime-header",
+		);
 	});
 
 	test("provider source handoff does not retain previous source transport overrides", async () => {
@@ -458,19 +450,14 @@ describe("ModelRegistry runtime provider registration", () => {
 		);
 
 		expect(registry.find(providerName, "model-a")).toBeUndefined();
-		const modelAfterHandoff = registry.find(providerName, "model-b");
-		expect(modelAfterHandoff?.baseUrl).toBe(sourceBBaseUrl);
-		expect(modelAfterHandoff?.headers?.[leakedHeader]).toBeUndefined();
-
-		await registry.refresh("offline");
-		const modelAfterRefresh = registry.find(providerName, "model-b");
-		expect(modelAfterRefresh?.baseUrl).toBe(sourceBBaseUrl);
-		expect(modelAfterRefresh?.headers?.[leakedHeader]).toBeUndefined();
-
-		await registry.refreshProvider(providerName, "offline");
-		const modelAfterProviderRefresh = registry.find(providerName, "model-b");
-		expect(modelAfterProviderRefresh?.baseUrl).toBe(sourceBBaseUrl);
-		expect(modelAfterProviderRefresh?.headers?.[leakedHeader]).toBeUndefined();
+		await expectModelTransportAcrossRefresh(
+			registry,
+			providerName,
+			"model-b",
+			sourceBBaseUrl,
+			leakedHeader,
+			undefined,
+		);
 	});
 
 	test("transport-only source handoff clears previous source headers immediately", async () => {
@@ -484,31 +471,15 @@ describe("ModelRegistry runtime provider registration", () => {
 			{ headers: { [sourceAHeader]: "from-source-a" } },
 			"ext://a",
 		);
-		for (const model of registry.getAll().filter(entry => entry.provider === providerName)) {
-			expect(model.headers?.[sourceAHeader]).toBe("from-source-a");
-		}
+		expectProviderHeader(registry, providerName, sourceAHeader, "from-source-a");
 
 		registry.registerProvider(
 			providerName,
 			{ headers: { [sourceBHeader]: "from-source-b" } },
 			"ext://b",
 		);
-		for (const model of registry.getAll().filter(entry => entry.provider === providerName)) {
-			expect(model.headers?.[sourceAHeader]).toBeUndefined();
-			expect(model.headers?.[sourceBHeader]).toBe("from-source-b");
-		}
-
-		await registry.refresh("offline");
-		for (const model of registry.getAll().filter(entry => entry.provider === providerName)) {
-			expect(model.headers?.[sourceAHeader]).toBeUndefined();
-			expect(model.headers?.[sourceBHeader]).toBe("from-source-b");
-		}
-
-		await registry.refreshProvider(providerName, "offline");
-		for (const model of registry.getAll().filter(entry => entry.provider === providerName)) {
-			expect(model.headers?.[sourceAHeader]).toBeUndefined();
-			expect(model.headers?.[sourceBHeader]).toBe("from-source-b");
-		}
+		await expectProviderHeaderAcrossRefresh(registry, providerName, sourceAHeader, undefined);
+		expectProviderHeader(registry, providerName, sourceBHeader, "from-source-b");
 	});
 
 	test("multiple extension providers survive refresh independently", async () => {

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -234,39 +234,6 @@ describe("ModelRegistry runtime provider registration", () => {
 		expect(model?.api).toBe("openai-completions");
 	});
 
-	test("runtime model overlays keep provider overrides across refresh cycles", async () => {
-		const registry = new ModelRegistry(authStorage, modelsJsonPath);
-		const runtimeHeader = "X-Runtime-Overlay-Header";
-		const overrideBaseUrl = "https://runtime-overridden.example.com/v1";
-		const modelId = "runtime-override-survivor";
-
-		registry.registerProvider(
-			"runtime-provider",
-			{
-				baseUrl: "https://runtime.example.com/v1",
-				apiKey: "RUNTIME_KEY",
-				api: "openai-completions",
-				models: [{ ...baseModel, id: modelId }],
-			},
-			"ext://runtime",
-		);
-		registry.registerProvider(
-			"runtime-provider",
-			{ baseUrl: overrideBaseUrl, headers: { [runtimeHeader]: "runtime-header" } },
-			"ext://runtime",
-		);
-
-		await expectModelTransportAcrossRefresh(
-			registry,
-			"runtime-provider",
-			modelId,
-			overrideBaseUrl,
-			runtimeHeader,
-			"runtime-header",
-		);
-		registry.clearSourceRegistrations("ext://runtime");
-		expect(registry.find("runtime-provider", modelId)).toBeUndefined();
-	});
 
 	test("headers-only runtime override preserves existing baseUrl across refresh", async () => {
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);

--- a/packages/coding-agent/test/model-registry-runtime-provider.test.ts
+++ b/packages/coding-agent/test/model-registry-runtime-provider.test.ts
@@ -261,6 +261,49 @@ describe("ModelRegistry runtime provider registration", () => {
 		expect(model?.api).toBe("openai-completions");
 	});
 
+	test("runtime model overlays keep provider overrides across refresh cycles", async () => {
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const runtimeHeader = "X-Runtime-Overlay-Header";
+		const overrideBaseUrl = "https://runtime-overridden.example.com/v1";
+		const modelId = "runtime-override-survivor";
+
+		registry.registerProvider(
+			"runtime-provider",
+			{
+				baseUrl: "https://runtime.example.com/v1",
+				apiKey: "RUNTIME_KEY",
+				api: "openai-completions",
+				models: [{ ...baseModel, id: modelId }],
+			},
+			"ext://runtime",
+		);
+		registry.registerProvider(
+			"runtime-provider",
+			{ baseUrl: overrideBaseUrl, headers: { [runtimeHeader]: "runtime-header" } },
+			"ext://runtime",
+		);
+
+		const modelAfterOverride = registry.find("runtime-provider", modelId);
+		expect(modelAfterOverride).toBeDefined();
+		expect(modelAfterOverride?.baseUrl).toBe(overrideBaseUrl);
+		expect(modelAfterOverride?.headers?.[runtimeHeader]).toBe("runtime-header");
+
+		await registry.refresh("offline");
+		const modelAfterRefresh = registry.find("runtime-provider", modelId);
+		expect(modelAfterRefresh).toBeDefined();
+		expect(modelAfterRefresh?.baseUrl).toBe(overrideBaseUrl);
+		expect(modelAfterRefresh?.headers?.[runtimeHeader]).toBe("runtime-header");
+
+		await registry.refreshProvider("runtime-provider", "offline");
+		const modelAfterProviderRefresh = registry.find("runtime-provider", modelId);
+		expect(modelAfterProviderRefresh).toBeDefined();
+		expect(modelAfterProviderRefresh?.baseUrl).toBe(overrideBaseUrl);
+		expect(modelAfterProviderRefresh?.headers?.[runtimeHeader]).toBe("runtime-header");
+
+		registry.clearSourceRegistrations("ext://runtime");
+		expect(registry.find("runtime-provider", modelId)).toBeUndefined();
+	});
+
 	test("extension-registered API keys survive refresh cycle for auth resolution", async () => {
 		const registry = new ModelRegistry(authStorage, modelsJsonPath);
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -424,6 +424,22 @@ describe("ModelRegistry", () => {
 			}
 		});
 
+		test("headers-only override applies to built-in models", () => {
+			writeRawModelsJson({
+				anthropic: {
+					headers: { "X-Custom-Header": "custom-only" },
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const anthropicModels = getModelsForProvider(registry, "anthropic");
+
+			expect(anthropicModels.length).toBeGreaterThan(1);
+			for (const model of anthropicModels) {
+				expect(model.headers?.["X-Custom-Header"]).toBe("custom-only");
+			}
+		});
+
 		test("baseUrl-only override does not affect other providers", () => {
 			writeRawModelsJson({
 				anthropic: overrideConfig("https://my-proxy.example.com/v1"),


### PR DESCRIPTION
## Summary
- allow `providers.<name>.headers` without requiring `baseUrl` in models config validation
- support runtime `registerProvider(<provider>, { headers: ... })` transport overrides and persist runtime provider transport overrides across `refresh()` / `refreshProvider()`
- preserve existing runtime `baseUrl` when later overrides provide only `headers`
- keep runtime transport headers authoritative over overlapping `modelOverrides.<model>.headers` keys during refresh rebuilds
- clear stale runtime transport override state when provider ownership moves between extension sources to prevent cross-source header/baseUrl leakage
- add regression coverage for static headers-only overrides and runtime durability/source-handoff cases
- update `packages/coding-agent/CHANGELOG.md` unreleased entry

## Verification
- `bun --cwd=packages/coding-agent run check`
- `bun --cwd=packages/coding-agent test test/model-registry-runtime-provider.test.ts test/model-registry-runtime-cleanup.test.ts`
- `bun test test/model-registry-runtime-provider.test.ts test/model-registry.test.ts`