### PR TITLE
fix(openai-completions): inject deployment path and api-version for Azure OpenAI

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -614,6 +614,16 @@ async function createClient(
 		copilotPremiumRequests = copilot.premiumRequests;
 		baseUrl = resolveGitHubCopilotBaseUrl(model.baseUrl, rawApiKey) ?? model.baseUrl;
 	}
+	// Azure OpenAI requires /deployments/{id}/chat/completions?api-version=YYYY-MM-DD.
+	// The generic openai-completions path adds neither, producing silent 404s.
+	let azureDefaultQuery: Record<string, string> | undefined;
+	if (baseUrl && baseUrl.includes(".openai.azure.com")) {
+		const apiVersion = $env.AZURE_OPENAI_API_VERSION || "2024-10-21";
+		if (!baseUrl.includes("/deployments/")) {
+			baseUrl = `${baseUrl}/deployments/${model.id}`;
+		}
+		azureDefaultQuery = { "api-version": apiVersion };
+	}
 	let capturedErrorResponse: CapturedHttpErrorResponse | undefined;
 	const wrappedFetch = Object.assign(
 		async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
@@ -649,6 +659,7 @@ async function createClient(
 			dangerouslyAllowBrowser: true,
 			maxRetries: 5,
 			defaultHeaders: headers,
+			defaultQuery: azureDefaultQuery,
 			fetch: wrappedFetch,
 		}),
 		copilotPremiumRequests,


### PR DESCRIPTION
## Problem

When using `openai-completions` provider with an Azure OpenAI endpoint (`*.openai.azure.com`), every request results in a silent 404. The root cause is that Azure OpenAI's completions API has two requirements that the generic OpenAI completions path does not satisfy:

1. **Deployment path**: Azure requires the URL to include `/deployments/{model-id}/chat/completions`, not just `/chat/completions`.
2. **api-version query parameter**: Azure rejects requests without `?api-version=YYYY-MM-DD`.

Without these, the SDK sends `POST {baseUrl}/chat/completions` with no query params and receives a 404 with no useful error body.

Verified via direct curl:
- `POST /deployments/gpt-5.4/chat/completions?api-version=2024-10-21` → 200
- `POST /chat/completions` (no deployment, no api-version) → 404

## Fix

In `createClient`, after the GitHub Copilot URL resolution block, detect `.openai.azure.com` in the base URL and:
- Append `/deployments/{model.id}` if not already present
- Set `defaultQuery: { "api-version": apiVersion }` on the OpenAI client constructor

The api-version is read from `AZURE_OPENAI_API_VERSION` env (consistent with how `azure-openai-responses` provider reads it), defaulting to `2024-10-21`.

## Notes

- The existing `azure-openai-responses` provider already handles Azure correctly for the responses API. This PR brings the same awareness to the completions API path.
- No changes to the `azure-openai-responses` provider.
- The `baseUrl` null-guard (`baseUrl && baseUrl.includes(...)`) handles the case where `baseUrl` is undefined for providers like standard OpenAI.