### PR TITLE
feat(ai): add DeepSeek V4 support

### DIFF
--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -4751,6 +4751,56 @@
 			}
 		}
 	},
+	"deepseek": {
+		"deepseek-v4-flash": {
+			"id": "deepseek-v4-flash",
+			"name": "DeepSeek V4 Flash",
+			"api": "openai-completions",
+			"provider": "deepseek",
+			"baseUrl": "https://api.deepseek.com",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"deepseek-v4-pro": {
+			"id": "deepseek-v4-pro",
+			"name": "DeepSeek V4 Pro",
+			"api": "openai-completions",
+			"provider": "deepseek",
+			"baseUrl": "https://api.deepseek.com",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.74,
+				"output": 3.48,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		}
+	},
 	"github-copilot": {
 		"claude-haiku-4.5": {
 			"id": "claude-haiku-4.5",

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -72,6 +72,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	"opencode-go": "OPENCODE_API_KEY",
 	"opencode-zen": "OPENCODE_API_KEY",
 	cursor: "CURSOR_ACCESS_TOKEN",
+	deepseek: "DEEPSEEK_API_KEY",
 	"openai-codex": "OPENAI_CODEX_OAUTH_TOKEN",
 	"azure-openai-responses": "AZURE_OPENAI_API_KEY",
 	exa: "EXA_API_KEY",

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -100,6 +100,7 @@ export type KnownProvider =
 	| "github-copilot"
 	| "gitlab-duo"
 	| "cursor"
+	| "deepseek"
 	| "xai"
 	| "groq"
 	| "cerebras"


### PR DESCRIPTION
Add DeepSeek as a first-class provider with V4 model support.

### Changes
- **types.ts**: Register `deepseek` in `KnownProvider`
- **stream.ts**: Add `DEEPSEEK_API_KEY` environment variable resolution
- **models.json**: Add DeepSeek V4 Flash and V4 Pro models

### Models
| Model | Context | Max Output | Input/Output (per 1M) |
|---|---|---|---|
| deepseek-v4-flash | 1M | 384K | \.14 / \.28 |
| deepseek-v4-pro | 1M | 384K | \.74 / \.48 |

Both use the `openai-completions` API at `https://api.deepseek.com` with effort-based thinking mode support.