### PR TITLE
fix(ai): ensure non-null content for DeepSeek reasoning messages

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1106,6 +1106,10 @@ export function convertMessages(
 					(assistantMsg as any).reasoning_details = reasoningDetails;
 				}
 			}
+			// DeepSeek requires non-null content when reasoning_content is present
+			if (assistantMsg.content === null && hasReasoningField) {
+				assistantMsg.content = "";
+			}
 			// Skip assistant messages that have no content, no tool calls, and no reasoning payload.
 			// Some OpenAI-compatible backends require replaying reasoning-only assistant turns
 			// so follow-up requests preserve the provider-specific reasoning field name.


### PR DESCRIPTION
DeepSeek rejects assistant messages with `content: null` when `reasoning_content` is present. This sets `content` to `""` instead of null when `hasReasoningField` is true.

Fixes 400 error: "The `reasoning_content` in the thinking mode must be passed back to the API."