### PR TITLE
fix(shell): bound captured buffer once max_capture_bytes exceeded

### DIFF
--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -1111,10 +1111,17 @@ async fn read_output_buffered(
 		if n > 0 {
 			let _ = activity.try_send(());
 		}
-		if captured.len().saturating_add(n) > max_capture_bytes {
-			exceeded = true;
+		// Once `exceeded`, the post-process minimizer is bypassed (see the
+		// `!output.exceeded` gate at the call site), so further appends just
+		// grow `captured` without serving any purpose. Stop accumulating to
+		// bound peak memory on commands that produce very large output.
+		if !exceeded {
+			if captured.len().saturating_add(n) > max_capture_bytes {
+				exceeded = true;
+			} else {
+				captured.extend_from_slice(&buf[..n]);
+			}
 		}
-		captured.extend_from_slice(&buf[..n]);
 
 		// Stream whatever is validly decodable *right now* to the callback,
 		// carrying incomplete trailing UTF-8 bytes over to the next iteration.


### PR DESCRIPTION
## Summary

`read_output_buffered` in `crates/pi-natives/src/shell.rs` sets `exceeded = true` when an incoming chunk would push `captured` past `max_capture_bytes`, but then keeps extending `captured` on every subsequent read. The post-process minimizer skips when `exceeded` (see the `!output.exceeded` gate where `BufferedOutput` is consumed), so the extra bytes are eventually discarded — but only after being held for the lifetime of the command. On commands that produce multi-gigabyte output (e.g. log streaming, video transcoding, large dumps), this grows unbounded.

## Fix

Stop appending to `captured` once `exceeded`. Live streaming via the `on_chunk` callback is unaffected — it uses the separate `pending` buffer, not `captured` — so callers still see all output as it arrives. Only peak memory changes.

```rust
if !exceeded {
    if captured.len().saturating_add(n) > max_capture_bytes {
        exceeded = true;
    } else {
        captured.extend_from_slice(&buf[..n]);
    }
}
```

## Credit

Found by `gemini-code-assist` reviewing a downstream sync PR. Filing here so it flows back to all forks.

## Test plan

- [ ] Existing shell tests pass (`cargo test -p pi-natives shell`)
- [ ] Manual: run a command that emits > `max_capture_bytes` (e.g. `yes | head -c 10G`) with the minimizer enabled — peak RSS should plateau near `max_capture_bytes`, not grow with output

🤖 Generated with [Claude Code](https://claude.com/claude-code)