### PR TITLE
fix(tui): crash fix - normalize undefined to null for optional napi parameters on Windows

### DIFF
--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -12,7 +12,7 @@ export { Ellipsis } from "@oh-my-pi/pi-natives";
 export { getDefaultTabWidth, getIndentation } from "@oh-my-pi/pi-utils";
 
 export function sliceWithWidth(line: string, startCol: number, length: number, strict?: boolean | null): SliceResult {
-	return nativeSliceWithWidth(line, startCol, length, strict, getDefaultTabWidth());
+	return nativeSliceWithWidth(line, startCol, length, strict ?? null, getDefaultTabWidth());
 }
 
 export function truncateToWidth(
@@ -21,7 +21,7 @@ export function truncateToWidth(
 	ellipsisKind?: Ellipsis | null,
 	pad?: boolean | null,
 ): string {
-	return nativeTruncateToWidth(text, maxWidth, ellipsisKind, pad, getDefaultTabWidth());
+	return nativeTruncateToWidth(text, maxWidth, ellipsisKind ?? null, pad ?? null, getDefaultTabWidth());
 }
 
 export function wrapTextWithAnsi(text: string, width: number): string[] {


### PR DESCRIPTION
## Problem

Hitting `/` (or any action that renders the select list) causes an unhandled crash:

```
[Uncaught Exception] Error: Failed to convert napi value into rust type bool
    at truncateToWidth (unknown)
    at #truncatePrimary (B:/~BUN/root/omp-windows-x64.exe:338802:25)
    at #renderItem (...)
```

Reported in #725 — closed as a workaround (switching from bundled exe to Bun-installed), but the underlying bug was never fixed. Affects both Windows and Linux bundled executables.

## Root cause

napi-rs `Option<T>` coerces JS `null`/`undefined` to `None` via a `type_of!` check. In Bun-bundled executables (which use JSC's napi layer), `undefined` is not reliably reported as `napi_undefined`, so the check falls through and napi-rs attempts `bool::from_napi_value()` on an undefined value, which calls `napi_get_value_bool` and fails.

Crash path: `#truncatePrimary` calls `truncateToWidth(text, maxWidth, Ellipsis.Omit)` — `pad` is implicitly `undefined` — the wrapper forwards `undefined` to `pad: Option<bool>` in Rust.

## Fix

Normalize `undefined → null` with `?? null` before passing optional parameters to the native functions. `null` (napi_null) is detected reliably across all platforms. `??` is used (not `||`) to correctly preserve `false` and `Ellipsis.Unicode = 0`.

Applied to both affected wrappers:
- `truncateToWidth`: `ellipsisKind` and `pad`
- `sliceWithWidth`: `strict`

Closes #725