### PR TITLE
feat(coding-agent): add /drop command to delete current session and start fresh

### DIFF
--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -28,6 +28,7 @@ import { buildHotkeysMarkdown } from "../../modes/utils/hotkeys-markdown";
 import { buildToolsMarkdown } from "../../modes/utils/tools-markdown";
 import type { AsyncJobSnapshotItem } from "../../session/agent-session";
 import type { AuthStorage } from "../../session/auth-storage";
+import type { NewSessionOptions } from "../../session/session-manager";
 import { outputMeta } from "../../tools/output-meta";
 import { resolveToCwd, stripOuterDoubleQuotes } from "../../tools/path-utils";
 import { replaceTabs } from "../../tools/render-utils";
@@ -573,7 +574,7 @@ export class CommandController {
 		this.ctx.showError("Usage: /memory <view|clear|reset|enqueue|rebuild>");
 	}
 
-	async handleClearCommand(): Promise<void> {
+	async #runNewSessionFlow(options?: NewSessionOptions, label: string = "New session started"): Promise<void> {
 		if (this.ctx.loadingAnimation) {
 			this.ctx.loadingAnimation.stop();
 			this.ctx.loadingAnimation = undefined;
@@ -586,7 +587,7 @@ export class CommandController {
 				await Bun.sleep(10);
 			}
 		}
-		await this.ctx.session.newSession();
+		await this.ctx.session.newSession(options);
 		this.ctx.resetObserverRegistry();
 		setSessionTerminalTitle(
 			this.ctx.sessionManager.getSessionName(),
@@ -608,11 +609,21 @@ export class CommandController {
 		this.ctx.pendingTools.clear();
 
 		this.ctx.chatContainer.addChild(new Spacer(1));
-		this.ctx.chatContainer.addChild(
-			new Text(`${theme.fg("accent", `${theme.status.success} New session started`)}`, 1, 1),
-		);
+		this.ctx.chatContainer.addChild(new Text(`${theme.fg("accent", `${theme.status.success} ${label}`)}`, 1, 1));
 		await this.ctx.reloadTodos();
 		this.ctx.ui.requestRender();
+	}
+
+	async handleClearCommand(): Promise<void> {
+		await this.#runNewSessionFlow();
+	}
+
+	async handleDropCommand(): Promise<void> {
+		if (!this.ctx.sessionManager.getSessionFile()) {
+			this.ctx.showError("Nothing to drop (in-memory session)");
+			return;
+		}
+		await this.#runNewSessionFlow({ drop: true }, "Session dropped");
 	}
 
 	async handleForkCommand(): Promise<void> {

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -587,7 +587,7 @@ export class CommandController {
 				await Bun.sleep(10);
 			}
 		}
-		await this.ctx.session.newSession(options);
+		if (!(await this.ctx.session.newSession(options))) return;
 		this.ctx.resetObserverRegistry();
 		setSessionTerminalTitle(
 			this.ctx.sessionManager.getSessionName(),

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1324,11 +1324,20 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.#commandController.handleToolsCommand();
 	}
 
-	handleClearCommand(): Promise<void> {
+	#prepareSessionSwitch(): void {
 		this.#btwController.dispose();
 		this.#extensionUiController.clearExtensionTerminalInputListeners();
 		this.#planReviewContainer = undefined;
+	}
+
+	handleClearCommand(): Promise<void> {
+		this.#prepareSessionSwitch();
 		return this.#commandController.handleClearCommand();
+	}
+
+	handleDropCommand(): Promise<void> {
+		this.#prepareSessionSwitch();
+		return this.#commandController.handleDropCommand();
 	}
 
 	handleForkCommand(): Promise<void> {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -181,6 +181,7 @@ export interface InteractiveModeContext {
 	handleDumpCommand(): void;
 	handleDebugTranscriptCommand(): Promise<void>;
 	handleClearCommand(): Promise<void>;
+	handleDropCommand(): Promise<void>;
 	handleForkCommand(): Promise<void>;
 	handleBashCommand(command: string, excludeFromContext?: boolean): Promise<void>;
 	handlePythonCommand(code: string, excludeFromContext?: boolean): Promise<void>;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3364,7 +3364,15 @@ export class AgentSession {
 		this.#asyncJobManager?.cancelAll();
 		this.#closeAllProviderSessions("new session");
 		this.agent.reset();
-		await this.sessionManager.flush();
+		if (options?.drop && previousSessionFile) {
+			try {
+				await this.sessionManager.dropSession(previousSessionFile);
+			} catch (err) {
+				logger.error("Failed to delete session during /drop", { err });
+			}
+		} else {
+			await this.sessionManager.flush();
+		}
 		await this.sessionManager.newSession(options);
 		this.setTodoPhases([]);
 		this.agent.sessionId = this.sessionManager.getSessionId();

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -66,6 +66,8 @@ export interface SessionHeader {
 
 export interface NewSessionOptions {
 	parentSession?: string;
+	/** Skip flushing the current session and delete it instead of saving. */
+	drop?: boolean;
 }
 
 export interface SessionEntryBase {
@@ -1705,6 +1707,16 @@ export class SessionManager {
 	async newSession(options?: NewSessionOptions): Promise<string | undefined> {
 		await this.#closePersistWriter();
 		return this.#newSessionSync(options);
+	}
+
+	/** Delete a session file and its artifacts. ENOENT is treated as success. */
+	async dropSession(sessionPath: string): Promise<void> {
+		try {
+			await this.storage.deleteSessionWithArtifacts(sessionPath);
+		} catch (err) {
+			if (isEnoent(err)) return;
+			throw err;
+		}
 	}
 
 	/**

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -1709,8 +1709,9 @@ export class SessionManager {
 		return this.#newSessionSync(options);
 	}
 
-	/** Delete a session file and its artifacts. ENOENT is treated as success. */
+	/** Delete a session file and its artifacts. Drains the persist writer first to avoid EPERM on Windows. ENOENT is treated as success. */
 	async dropSession(sessionPath: string): Promise<void> {
+		await this.#closePersistWriter();
 		try {
 			await this.storage.deleteSessionWithArtifacts(sessionPath);
 		} catch (err) {

--- a/packages/coding-agent/src/session/session-storage.ts
+++ b/packages/coding-agent/src/session/session-storage.ts
@@ -32,6 +32,7 @@ export interface SessionStorage {
 	writeText(path: string, content: string): Promise<void>;
 	rename(path: string, nextPath: string): Promise<void>;
 	unlink(path: string): Promise<void>;
+	deleteSessionWithArtifacts(sessionPath: string): Promise<void>;
 	openWriter(path: string, options?: { flags?: "a" | "w"; onError?: (err: Error) => void }): SessionStorageWriter;
 }
 
@@ -358,6 +359,9 @@ export class MemorySessionStorage implements SessionStorage {
 
 	unlink(path: string): Promise<void> {
 		this.#files.delete(path);
+		return Promise.resolve();
+	}
+	deleteSessionWithArtifacts(_sessionPath: string): Promise<void> {
 		return Promise.resolve();
 	}
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -513,6 +513,14 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 		},
 	},
 	{
+		name: "drop",
+		description: "Delete the current session and start a new one",
+		handle: async (_command, runtime) => {
+			runtime.ctx.editor.setText("");
+			await runtime.ctx.handleDropCommand();
+		},
+	},
+	{
 		name: "compact",
 		description: "Manually compact the session context",
 		inlineHint: "[focus instructions]",


### PR DESCRIPTION
## Motivation

The `/new` command starts a fresh session but preserves the previous one on disk. When a small task or implementation is finished and the context needs to be cleared for new work, there is no need to keep the old session. Over time, these accumulate and clutter the `~/.omp` workspace.

`/drop` fills this gap: it deletes the current session file and its artifacts directory, then immediately starts a new session — no confirmation dialog, matching the `/new` UX.

## What changed

- **`/drop` slash command** registered between `/new` and `/compact`
- **`SessionStorage` interface** gains `deleteSessionWithArtifacts(sessionPath)`; `MemorySessionStorage` provides a no-op implementation
- **`SessionManager.dropSession(sessionPath)`** routes deletion through the manager's own storage (ENOENT treated as success — deletion is best-effort)
- **`NewSessionOptions.drop?`** flag wires the delete branch into the existing `newSession()` flow without duplicating its internals
- **`#runNewSessionFlow`** private helper on `CommandController` de-duplicates the UI reset sequence shared by `/clear` and `/drop`
- **`#prepareSessionSwitch`** private helper on `InteractiveMode` de-duplicates the three-line preamble shared by `handleClearCommand` and `handleDropCommand`

## Behaviour

- Calling `/drop` on an in-memory session (no file) shows an error and does nothing
- Deletion failure is non-fatal: the error is logged and a new session starts regardless
- Extension events: `session_before_switch` with `reason: "new"` — no extension API change needed