### PR TITLE
fix(irc): stop background exchange poll loop on session dispose

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Fixed edit rendering so provided `input` text is shown in the export even without a file path
 - Fixed `args.paths` handling in `ast_edit` and `find` so multiple paths are shown as a comma-separated list
 - Fixed power assertion state handling so subsequent prompts are no longer blocked after an aborted or canceled prompt
+- Fixed IRC background exchange poll loop leaking after session disposal: `#scheduleBackgroundExchangeFlush` now stops immediately when `dispose()` is called, preventing stale `setTimeout` callbacks from firing against a torn-down agent
 
 ## [14.9.2] - 2026-05-10
 ### Added

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -570,6 +570,7 @@ export class AgentSession {
 	#agentId: string | undefined;
 	#agentRegistry: AgentRegistry | undefined;
 	#providerSessionId: string | undefined;
+	#isDisposed = false;
 	// Extension system
 	#extensionRunner: ExtensionRunner | undefined = undefined;
 	#turnIndex = 0;
@@ -2136,6 +2137,8 @@ export class AgentSession {
 	 * Call this when completely done with the session.
 	 */
 	async dispose(): Promise<void> {
+		this.#isDisposed = true;
+		this.#pendingBackgroundExchanges = [];
 		this.#evalExecutionDisposing = true;
 		try {
 			if (this.#extensionRunner?.hasHandlers("session_shutdown")) {
@@ -6881,7 +6884,8 @@ export class AgentSession {
 		if (this.#scheduledBackgroundExchangeFlush) return;
 		this.#scheduledBackgroundExchangeFlush = true;
 		const attempt = (): void => {
-			if (this.#pendingBackgroundExchanges.length === 0) {
+			if (this.#pendingBackgroundExchanges.length === 0 || this.#isDisposed) {
+				this.#pendingBackgroundExchanges = [];
 				this.#scheduledBackgroundExchangeFlush = false;
 				return;
 			}


### PR DESCRIPTION
The 50ms retry loop in `#scheduleBackgroundExchangeFlush` had no guard against session teardown. If `dispose()` was called while streaming, the `setTimeout` callbacks kept firing and attempted `emitExternalEvent` on a disconnected agent indefinitely.

## Changes

- Add `#isDisposed` flag; set it synchronously at the top of `dispose()` before any async teardown so poll ticks that fire mid-teardown bail out cleanly
- Clear `#pendingBackgroundExchanges` in `dispose()` to drop queued messages that will never be rendered
- Widen the `attempt()` bail condition to include `#isDisposed` so the loop terminates even if new messages arrived between the `dispose()` clear and the next tick (small window during async teardown)