### PR TITLE
feat(coding-agent/web): support SearXNG Basic auth

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1769,38 +1769,33 @@ export const SETTINGS_SCHEMA = {
 		ui: {
 			tab: "providers",
 			label: "SearXNG Endpoint",
-			description: "Base URL of the SearXNG instance (e.g. https://searx.example.org)",
+			description: "Self-hosted search base URL",
 		},
 	},
 
 	"searxng.token": {
 		type: "string",
 		default: undefined,
-		ui: {
-			tab: "providers",
-			label: "SearXNG Token",
-			description: "Optional bearer token for SearXNG authentication",
-		},
+	},
+
+	"searxng.basicUsername": {
+		type: "string",
+		default: undefined,
+	},
+
+	"searxng.basicPassword": {
+		type: "string",
+		default: undefined,
 	},
 
 	"searxng.categories": {
 		type: "string",
 		default: undefined,
-		ui: {
-			tab: "providers",
-			label: "SearXNG Categories",
-			description: "Comma-separated categories filter (e.g. general,news,science)",
-		},
 	},
 
 	"searxng.language": {
 		type: "string",
 		default: undefined,
-		ui: {
-			tab: "providers",
-			label: "SearXNG Language",
-			description: "Language code for search results (e.g. en, zh-CN)",
-		},
 	},
 
 	"commit.mapReduceEnabled": { type: "boolean", default: true },

--- a/packages/coding-agent/src/modes/components/settings-defs.ts
+++ b/packages/coding-agent/src/modes/components/settings-defs.ts
@@ -348,7 +348,7 @@ const OPTION_PROVIDERS: Partial<Record<SettingPath, OptionProvider>> = {
 		{ value: "kagi", label: "Kagi", description: "Requires KAGI_API_KEY and Kagi Search API beta access" },
 		{ value: "synthetic", label: "Synthetic", description: "Requires SYNTHETIC_API_KEY" },
 		{ value: "parallel", label: "Parallel", description: "Requires PARALLEL_API_KEY" },
-		{ value: "searxng", label: "SearXNG", description: "Self-hosted metasearch; set searxng.endpoint" },
+		{ value: "searxng", label: "SearXNG", description: "Requires searxng.endpoint" },
 	],
 	"providers.image": [
 		{

--- a/packages/coding-agent/src/web/search/providers/searxng.ts
+++ b/packages/coding-agent/src/web/search/providers/searxng.ts
@@ -9,14 +9,18 @@
  * and various authentication methods (bearer token, basic auth, or none).
  *
  * Configuration via settings:
- *   searxng.endpoint  - Base URL of the SearXNG instance (e.g. https://searx.example.org)
- *   searxng.token     - Optional bearer token for authentication
- *   searxng.categories - Optional comma-separated categories filter
- *   searxng.language  - Optional language code (e.g. en, zh-CN)
+ *   searxng.endpoint      - Base URL of the SearXNG instance (e.g. https://searx.example.org)
+ *   searxng.token         - Optional bearer token for authentication
+ *   searxng.basicUsername - Optional RFC 7617 Basic auth username
+ *   searxng.basicPassword - Optional RFC 7617 Basic auth password
+ *   searxng.categories    - Optional comma-separated categories filter
+ *   searxng.language      - Optional language code (e.g. en, zh-CN)
  *
  * Environment variable fallbacks:
- *   SEARXNG_ENDPOINT  - Base URL of the SearXNG instance
- *   SEARXNG_TOKEN     - Optional bearer token
+ *   SEARXNG_ENDPOINT       - Base URL of the SearXNG instance
+ *   SEARXNG_TOKEN          - Optional bearer token
+ *   SEARXNG_BASIC_USERNAME - Optional RFC 7617 Basic auth username
+ *   SEARXNG_BASIC_PASSWORD - Optional RFC 7617 Basic auth password
  *
  * Reference: https://docs.searxng.org/dev/search_api.html
  */
@@ -61,6 +65,11 @@ interface SearXNGResponse {
 	unresponsive_engines?: Array<[string, string]>;
 }
 
+interface SearXNGAuth {
+	type: "basic" | "bearer";
+	value: string;
+}
+
 /** Find SearXNG endpoint from settings or environment. */
 function findEndpoint(): string | null {
 	try {
@@ -83,6 +92,53 @@ function findToken(): string | null {
 	return process.env.SEARXNG_TOKEN ?? null;
 }
 
+/** Find SearXNG Basic auth username from settings or environment. */
+function findBasicUsername(): string | null {
+	try {
+		const username = settings.get("searxng.basicUsername");
+		if (username !== undefined) return username;
+	} catch {
+		// Settings not initialized yet
+	}
+	return process.env.SEARXNG_BASIC_USERNAME ?? null;
+}
+
+/** Find SearXNG Basic auth password from settings or environment. */
+function findBasicPassword(): string | null {
+	try {
+		const password = settings.get("searxng.basicPassword");
+		if (password !== undefined) return password;
+	} catch {
+		// Settings not initialized yet
+	}
+	return process.env.SEARXNG_BASIC_PASSWORD ?? null;
+}
+
+/** Build the RFC 7617 Basic auth credential using UTF-8 bytes. */
+function buildBasicAuthValue(username: string, password: string): string {
+	return Buffer.from(`${username}:${password}`, "utf-8").toString("base64");
+}
+
+/** Find SearXNG authentication from settings or environment. Basic auth takes precedence over bearer tokens. */
+function findAuth(): SearXNGAuth | null {
+	const basicUsername = findBasicUsername();
+	const basicPassword = findBasicPassword();
+	if (basicUsername !== null || basicPassword !== null) {
+		if (basicUsername === null || basicPassword === null) {
+			throw new Error(
+				"SearXNG Basic auth requires both searxng.basicUsername and searxng.basicPassword, or SEARXNG_BASIC_USERNAME and SEARXNG_BASIC_PASSWORD.",
+			);
+		}
+		if (basicUsername.includes(":")) {
+			throw new Error("SearXNG Basic auth username cannot contain ':' because RFC 7617 uses it as the separator.");
+		}
+		return { type: "basic", value: buildBasicAuthValue(basicUsername, basicPassword) };
+	}
+
+	const token = findToken();
+	return token ? { type: "bearer", value: token } : null;
+}
+
 /** Build the search URL and headers for a SearXNG request */
 function buildRequest(
 	endpoint: string,
@@ -94,7 +150,7 @@ function buildRequest(
 		language?: string;
 		signal?: AbortSignal;
 	},
-	token: string | null,
+	auth: SearXNGAuth | null,
 ): { url: URL; headers: Record<string, string> } {
 	const base = endpoint.replace(/\/+$/, "");
 	const url = new URL(`${base}/search`);
@@ -122,8 +178,10 @@ function buildRequest(
 		Accept: "application/json",
 	};
 
-	if (token) {
-		headers.Authorization = `Bearer ${token}`;
+	if (auth?.type === "basic") {
+		headers.Authorization = `Basic ${auth.value}`;
+	} else if (auth?.type === "bearer") {
+		headers.Authorization = `Bearer ${auth.value}`;
 	}
 
 	return { url, headers };
@@ -139,9 +197,9 @@ async function callSearXNGSearch(
 		language?: string;
 		signal?: AbortSignal;
 	},
-	token: string | null,
+	auth: SearXNGAuth | null,
 ): Promise<SearXNGResponse> {
-	const { url, headers } = buildRequest(endpoint, params, token);
+	const { url, headers } = buildRequest(endpoint, params, auth);
 
 	const response = await fetch(url, {
 		headers,
@@ -172,7 +230,7 @@ export async function searchSearXNG(params: {
 		);
 	}
 
-	const token = findToken();
+	const auth = findAuth();
 
 	let categories: string | undefined;
 	let language: string | undefined;
@@ -190,7 +248,7 @@ export async function searchSearXNG(params: {
 			categories,
 			language,
 		},
-		token,
+		auth,
 	);
 
 	const sources: SearchSource[] = [];

--- a/packages/coding-agent/test/tools/web-search-searxng.test.ts
+++ b/packages/coding-agent/test/tools/web-search-searxng.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { hookFetch } from "@oh-my-pi/pi-utils";
+import { searchSearXNG } from "../../src/web/search/providers/searxng";
+
+describe("SearXNG web search provider", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		delete process.env.SEARXNG_ENDPOINT;
+		delete process.env.SEARXNG_TOKEN;
+		delete process.env.SEARXNG_BASIC_USERNAME;
+		delete process.env.SEARXNG_BASIC_PASSWORD;
+	});
+
+	it("sends RFC 7617 Basic auth when username and password are configured", async () => {
+		process.env.SEARXNG_ENDPOINT = "https://searx.example.org/";
+		process.env.SEARXNG_BASIC_USERNAME = "alice";
+		process.env.SEARXNG_BASIC_PASSWORD = "s3cret";
+
+		const captured: { url?: URL; headers?: Headers } = {};
+		using _hook = hookFetch((input, init) => {
+			captured.url = new URL(input.toString());
+			captured.headers = new Headers(init?.headers);
+			return new Response(
+				JSON.stringify({
+					results: [{ title: "SearXNG", url: "https://example.com/result", content: "Metasearch result" }],
+					suggestions: ["related search"],
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		});
+
+		const response = await searchSearXNG({ query: "private search", num_results: 1, recency: "week" });
+
+		expect(captured.url?.origin).toBe("https://searx.example.org");
+		expect(captured.url?.pathname).toBe("/search");
+		expect(captured.url?.searchParams.get("q")).toBe("private search");
+		expect(captured.url?.searchParams.get("format")).toBe("json");
+		expect(captured.url?.searchParams.get("time_range")).toBe("month");
+		expect(captured.headers?.get("Authorization")).toBe(
+			`Basic ${Buffer.from("alice:s3cret", "utf-8").toString("base64")}`,
+		);
+		expect(response).toMatchObject({
+			provider: "searxng",
+			relatedQuestions: ["related search"],
+			sources: [{ title: "SearXNG", url: "https://example.com/result", snippet: "Metasearch result" }],
+		});
+	});
+
+	it("prefers Basic auth over bearer token when both are configured", async () => {
+		process.env.SEARXNG_ENDPOINT = "https://searx.example.org";
+		process.env.SEARXNG_TOKEN = "bearer-token";
+		process.env.SEARXNG_BASIC_USERNAME = "alice";
+		process.env.SEARXNG_BASIC_PASSWORD = "s3cret";
+
+		const captured: { headers?: Headers } = {};
+		using _hook = hookFetch((_input, init) => {
+			captured.headers = new Headers(init?.headers);
+			return new Response(JSON.stringify({ results: [] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+
+		await searchSearXNG({ query: "auth precedence" });
+
+		expect(captured.headers?.get("Authorization")).toBe(
+			`Basic ${Buffer.from("alice:s3cret", "utf-8").toString("base64")}`,
+		);
+	});
+
+	it("sends Basic auth when the password is intentionally empty", async () => {
+		process.env.SEARXNG_ENDPOINT = "https://searx.example.org";
+		process.env.SEARXNG_BASIC_USERNAME = "alice";
+		process.env.SEARXNG_BASIC_PASSWORD = "";
+
+		const captured: { headers?: Headers } = {};
+		using _hook = hookFetch((_input, init) => {
+			captured.headers = new Headers(init?.headers);
+			return new Response(JSON.stringify({ results: [] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+
+		await searchSearXNG({ query: "empty password" });
+
+		expect(captured.headers?.get("Authorization")).toBe(`Basic ${Buffer.from("alice:", "utf-8").toString("base64")}`);
+	});
+
+	it("sends Basic auth when the username is intentionally empty", async () => {
+		process.env.SEARXNG_ENDPOINT = "https://searx.example.org";
+		process.env.SEARXNG_BASIC_USERNAME = "";
+		process.env.SEARXNG_BASIC_PASSWORD = "s3cret";
+
+		const captured: { headers?: Headers } = {};
+		using _hook = hookFetch((_input, init) => {
+			captured.headers = new Headers(init?.headers);
+			return new Response(JSON.stringify({ results: [] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+
+		await searchSearXNG({ query: "empty username" });
+
+		expect(captured.headers?.get("Authorization")).toBe(
+			`Basic ${Buffer.from(":s3cret", "utf-8").toString("base64")}`,
+		);
+	});
+
+	it("requires both Basic auth username and password", async () => {
+		process.env.SEARXNG_ENDPOINT = "https://searx.example.org";
+		process.env.SEARXNG_BASIC_USERNAME = "alice";
+
+		await expect(searchSearXNG({ query: "missing password" })).rejects.toThrow(
+			"SearXNG Basic auth requires both searxng.basicUsername and searxng.basicPassword",
+		);
+	});
+
+	it("requires a Basic auth username when only password is configured", async () => {
+		process.env.SEARXNG_ENDPOINT = "https://searx.example.org";
+		process.env.SEARXNG_BASIC_PASSWORD = "s3cret";
+
+		await expect(searchSearXNG({ query: "missing username" })).rejects.toThrow(
+			"SearXNG Basic auth requires both searxng.basicUsername and searxng.basicPassword",
+		);
+	});
+
+	it("rejects Basic auth usernames containing a colon", async () => {
+		process.env.SEARXNG_ENDPOINT = "https://searx.example.org";
+		process.env.SEARXNG_BASIC_USERNAME = "alice:admin";
+		process.env.SEARXNG_BASIC_PASSWORD = "s3cret";
+
+		await expect(searchSearXNG({ query: "invalid username" })).rejects.toThrow(
+			"SearXNG Basic auth username cannot contain ':'",
+		);
+	});
+
+	it("keeps bearer token authentication when Basic auth is not configured", async () => {
+		process.env.SEARXNG_ENDPOINT = "https://searx.example.org";
+		process.env.SEARXNG_TOKEN = "bearer-token";
+
+		const captured: { headers?: Headers } = {};
+		using _hook = hookFetch((_input, init) => {
+			captured.headers = new Headers(init?.headers);
+			return new Response(JSON.stringify({ results: [] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+
+		await searchSearXNG({ query: "bearer search" });
+
+		expect(captured.headers?.get("Authorization")).toBe("Bearer bearer-token");
+	});
+});


### PR DESCRIPTION
## Summary
- Add RFC 7617 Basic Auth support for SearXNG via `searxng.basicUsername` / `searxng.basicPassword` and matching environment variables.
- Preserve existing Bearer token behavior, with Basic Auth taking precedence when both are configured.
- Hide optional SearXNG settings from the TUI and keep only the required endpoint visible with clearer copy.

## Tests
- `bun test packages/coding-agent/test/tools/web-search-searxng.test.ts`
- `bunx biome check packages/coding-agent/src/web/search/providers/searxng.ts packages/coding-agent/src/config/settings-schema.ts packages/coding-agent/src/modes/components/settings-defs.ts packages/coding-agent/test/tools/web-search-searxng.test.ts`
- `bun --cwd=packages/coding-agent run check:types`

## Notes
- Built local native addon first with `bun --cwd=packages/natives run build` so the targeted Bun tests could load `@oh-my-pi/pi-natives` on darwin-arm64.