### PR TITLE
Add provider response extension hook

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added an `onResponse` stream option for observing provider response metadata after response headers arrive.
+
 ## [14.2.0] - 2026-04-23
 
 ### Changed

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -132,6 +132,10 @@ export interface AgentOptions {
 	 */
 	onPayload?: SimpleStreamOptions["onPayload"];
 	/**
+	 * Inspect provider response metadata after headers arrive and before streaming body consumption.
+	 */
+	onResponse?: SimpleStreamOptions["onResponse"];
+	/**
 	 * Inspect assistant streaming events before they are emitted to subscribers.
 	 * Use this when abort decisions must happen before buffered events continue flowing.
 	 */
@@ -244,6 +248,7 @@ export class Agent {
 	#intentTracing: boolean;
 	#getToolChoice?: () => ToolChoice | undefined;
 	#onPayload?: SimpleStreamOptions["onPayload"];
+	#onResponse?: SimpleStreamOptions["onResponse"];
 	#onAssistantMessageEvent?: (message: AssistantMessage, event: AssistantMessageEvent) => void;
 
 	/** Buffered Cursor tool results with text length at time of call (for correct ordering) */
@@ -273,6 +278,7 @@ export class Agent {
 		this.#maxRetryDelayMs = opts.maxRetryDelayMs;
 		this.getApiKey = opts.getApiKey;
 		this.#onPayload = opts.onPayload;
+		this.#onResponse = opts.onResponse;
 		this.#getToolContext = opts.getToolContext;
 		this.#cursorExecHandlers = opts.cursorExecHandlers;
 		this.#cursorOnToolResult = opts.cursorOnToolResult;
@@ -762,6 +768,7 @@ export class Agent {
 			convertToLlm: this.#convertToLlm,
 			transformContext: this.#transformContext,
 			onPayload: this.#onPayload,
+			onResponse: this.#onResponse,
 			getApiKey: this.getApiKey,
 			getToolContext: this.#getToolContext,
 			syncContextBeforeModelCall: async context => {

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [Unreleased]
 
-<<<<<<< HEAD
+### Added
+
+- Added provider response metadata callbacks for Anthropic and OpenAI streaming requests.
+
 ## [14.5.9] - 2026-04-30
 ### Added
 
@@ -24,13 +27,6 @@
 
 - Fixed OpenAI Codex GPT model pricing by inheriting matching OpenAI catalog rates for zero-priced discovered Codex entries.
 
-||||||| parent of 57b1918ba (feat(ai): expose provider response metadata)
-=======
-### Added
-
-- Added provider response metadata callbacks for Anthropic and OpenAI streaming requests.
-
->>>>>>> 57b1918ba (feat(ai): expose provider response metadata)
 ## [14.5.3] - 2026-04-27
 ### Added
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+<<<<<<< HEAD
 ## [14.5.9] - 2026-04-30
 ### Added
 
@@ -23,6 +24,13 @@
 
 - Fixed OpenAI Codex GPT model pricing by inheriting matching OpenAI catalog rates for zero-priced discovered Codex entries.
 
+||||||| parent of 57b1918ba (feat(ai): expose provider response metadata)
+=======
+### Added
+
+- Added provider response metadata callbacks for Anthropic and OpenAI streaming requests.
+
+>>>>>>> 57b1918ba (feat(ai): expose provider response metadata)
 ## [14.5.3] - 2026-04-27
 ### Added
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -40,6 +40,7 @@ import { finalizeErrorMessage, type RawHttpRequestDump, rewriteCopilotError } fr
 import { createWatchdog, getStreamFirstEventTimeoutMs } from "../utils/idle-iterator";
 import { parseStreamingJson } from "../utils/json-parse";
 import { parseGitHubCopilotApiKey } from "../utils/oauth/github-copilot";
+import { notifyProviderResponse } from "../utils/provider-response";
 import { extractHttpStatusFromError, isCopilotRetryableError } from "../utils/retry";
 import { COMBINATOR_KEYS, NO_STRICT } from "../utils/schema";
 import {
@@ -841,7 +842,8 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 				let streamedReplayUnsafeContent = false;
 
 				try {
-					const { data: anthropicStream } = await anthropicRequest.withResponse();
+					const { data: anthropicStream, response, request_id } = await anthropicRequest.withResponse();
+					await notifyProviderResponse(options, response, model, request_id);
 					const firstEventWatchdog = createWatchdog(firstEventTimeoutMs, () =>
 						activeAbortTracker.abortLocally(firstEventTimeoutAbortError),
 					);

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -48,6 +48,7 @@ import {
 import { parseStreamingJson } from "../utils/json-parse";
 import { parseGitHubCopilotApiKey } from "../utils/oauth/github-copilot";
 import { getKimiCommonHeaders } from "../utils/oauth/kimi";
+import { notifyProviderResponse } from "../utils/provider-response";
 import { callWithCopilotModelRetry, extractHttpStatusFromError } from "../utils/retry";
 import { adaptSchemaForStrict, NO_STRICT } from "../utils/schema";
 import { mapToOpenAICompletionsToolChoice } from "../utils/tool-choice";
@@ -340,7 +341,11 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 					headers: requestHeaders,
 					body: params,
 				};
-				return client.chat.completions.create(params, { signal: requestSignal });
+				const { data, response, request_id } = await client.chat.completions
+					.create(params, { signal: requestSignal })
+					.withResponse();
+				await notifyProviderResponse(options, response, model, request_id);
+				return data;
 			};
 			let openaiStream: AsyncIterable<ChatCompletionChunk>;
 			try {

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -38,6 +38,7 @@ import {
 	iterateWithIdleTimeout,
 } from "../utils/idle-iterator";
 import { parseGitHubCopilotApiKey } from "../utils/oauth/github-copilot";
+import { notifyProviderResponse } from "../utils/provider-response";
 import { callWithCopilotModelRetry } from "../utils/retry";
 import { adaptSchemaForStrict, NO_STRICT } from "../utils/schema";
 import { mapToOpenAIResponsesToolChoice, type OpenAIResponsesToolChoice } from "../utils/tool-choice";
@@ -196,7 +197,13 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 				body: params,
 			};
 			const openaiStream = await callWithCopilotModelRetry(
-				() => client.responses.create(params, { signal: requestSignal }),
+				async () => {
+					const { data, response, request_id } = await client.responses
+						.create(params, { signal: requestSignal })
+						.withResponse();
+					await notifyProviderResponse(options, response, model, request_id);
+					return data;
+				},
 				{ provider: model.provider, signal: requestSignal },
 			);
 			const firstEventWatchdog = createWatchdog(

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -431,6 +431,7 @@ function mapOptionsForApi<TApi extends Api>(
 		sessionId: options?.sessionId,
 		providerSessionState: options?.providerSessionState,
 		onPayload: options?.onPayload,
+		onResponse: options?.onResponse,
 		execHandlers: options?.execHandlers,
 	};
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -171,6 +171,13 @@ export interface ProviderSessionState {
 	close(): void;
 }
 
+export interface ProviderResponseMetadata {
+	status: number;
+	headers: Record<string, string>;
+	requestId?: string | null;
+	metadata?: Record<string, unknown>;
+}
+
 export interface StreamOptions {
 	temperature?: number;
 	topP?: number;
@@ -221,6 +228,10 @@ export interface StreamOptions {
 	 * Return undefined to keep the payload unchanged.
 	 */
 	onPayload?: (payload: unknown, model?: Model<Api>) => unknown | undefined | Promise<unknown | undefined>;
+	/**
+	 * Optional callback for provider response metadata after headers are received.
+	 */
+	onResponse?: (response: ProviderResponseMetadata, model?: Model<Api>) => void | Promise<void>;
 	/**
 	 * Optional override for the first streamed event watchdog in milliseconds.
 	 * Set to 0 to disable the first-event watchdog for this request.

--- a/packages/ai/src/utils/provider-response.ts
+++ b/packages/ai/src/utils/provider-response.ts
@@ -1,0 +1,30 @@
+import type { Api, Model, ProviderResponseMetadata, StreamOptions } from "../types";
+
+export function normalizeProviderResponse(
+	response: Response,
+	requestId?: string | null,
+	metadata?: Record<string, unknown>,
+): ProviderResponseMetadata {
+	const headers: Record<string, string> = {};
+	response.headers.forEach((value, key) => {
+		headers[key.toLowerCase()] = value;
+	});
+	const providerResponse: ProviderResponseMetadata = {
+		status: response.status,
+		headers,
+	};
+	if (requestId !== undefined) providerResponse.requestId = requestId;
+	if (metadata !== undefined) providerResponse.metadata = metadata;
+	return providerResponse;
+}
+
+export async function notifyProviderResponse(
+	options: Pick<StreamOptions, "onResponse"> | undefined,
+	response: Response,
+	model?: Model<Api>,
+	requestId?: string | null,
+	metadata?: Record<string, unknown>,
+): Promise<void> {
+	if (!options?.onResponse) return;
+	await options.onResponse(normalizeProviderResponse(response, requestId, metadata), model);
+}

--- a/packages/ai/test/provider-response.test.ts
+++ b/packages/ai/test/provider-response.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, it } from "bun:test";
-import type { Model, ProviderResponseMetadata } from "../src/types";
+import { afterEach, describe, expect, it } from "bun:test";
+import { getBundledModel } from "../src/models";
+import { streamSimple } from "../src/stream";
+import type { Context, Model, ProviderResponseMetadata } from "../src/types";
 import { normalizeProviderResponse, notifyProviderResponse } from "../src/utils/provider-response";
 
 describe("provider response metadata", () => {
@@ -49,5 +51,67 @@ describe("provider response metadata", () => {
 				model,
 			},
 		]);
+	});
+});
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+	global.fetch = originalFetch;
+});
+
+function createSseResponse(events: unknown[], headers: Record<string, string> = {}): Response {
+	const payload = `${events.map(event => `data: ${typeof event === "string" ? event : JSON.stringify(event)}`).join("\n\n")}\n\n`;
+	return new Response(payload, {
+		status: 200,
+		headers: { "content-type": "text/event-stream", ...headers },
+	});
+}
+
+describe("streamSimple onResponse propagation", () => {
+	it("invokes onResponse for the default openai-completions path through streamSimple", async () => {
+		const model: Model<"openai-completions"> = {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+		};
+
+		global.fetch = Object.assign(
+			async (_input: string | URL | Request, _init?: RequestInit): Promise<Response> =>
+				createSseResponse(
+					[
+						{
+							id: "chatcmpl-onresponse",
+							object: "chat.completion.chunk",
+							created: 0,
+							model: model.id,
+							choices: [{ index: 0, delta: { content: "ok" } }],
+						},
+						{
+							id: "chatcmpl-onresponse",
+							object: "chat.completion.chunk",
+							created: 0,
+							model: model.id,
+							choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+						},
+						"[DONE]",
+					],
+					{ "x-request-id": "req_stream_simple" },
+				),
+			{ preconnect: originalFetch.preconnect },
+		);
+
+		const context: Context = { messages: [{ role: "user", content: "hello", timestamp: Date.now() }] };
+		const seen: ProviderResponseMetadata[] = [];
+		const result = await streamSimple(model, context, {
+			apiKey: "test-key",
+			onResponse: response => {
+				seen.push(response);
+			},
+		}).result();
+
+		expect(result.stopReason).toBe("stop");
+		expect(seen).toHaveLength(1);
+		expect(seen[0]?.status).toBe(200);
+		expect(seen[0]?.headers["x-request-id"]).toBe("req_stream_simple");
 	});
 });

--- a/packages/ai/test/provider-response.test.ts
+++ b/packages/ai/test/provider-response.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import type { Model, ProviderResponseMetadata } from "../src/types";
+import { normalizeProviderResponse, notifyProviderResponse } from "../src/utils/provider-response";
+
+describe("provider response metadata", () => {
+	it("normalizes response status, headers, and request id", () => {
+		const response = new Response(null, {
+			status: 202,
+			headers: {
+				"X-Request-ID": "req_123",
+				"X-RateLimit-Remaining": "42",
+			},
+		});
+
+		expect(normalizeProviderResponse(response, "req_123")).toEqual({
+			status: 202,
+			headers: {
+				"x-request-id": "req_123",
+				"x-ratelimit-remaining": "42",
+			},
+			requestId: "req_123",
+		});
+	});
+
+	it("invokes the response callback with normalized metadata", async () => {
+		const seen: Array<{ response: ProviderResponseMetadata; model: Model | undefined }> = [];
+		const model = { provider: "openai", api: "openai-responses", id: "gpt-test" } as Model;
+
+		await notifyProviderResponse(
+			{
+				onResponse: (response, responseModel) => {
+					seen.push({ response, model: responseModel });
+				},
+			},
+			new Response(null, { status: 204, headers: { "Cache-Control": "no-store" } }),
+			model,
+			null,
+			{ attempt: 1 },
+		);
+
+		expect(seen).toEqual([
+			{
+				response: {
+					status: 204,
+					headers: { "cache-control": "no-store" },
+					requestId: null,
+					metadata: { attempt: 1 },
+				},
+				model,
+			},
+		]);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -82,6 +82,7 @@
 
 ### Added
 
+- Added the `after_provider_response` extension event for observing provider response status, headers, and request IDs.
 - Added internal URL support to the `search` tool, allowing `artifact://`-style paths that resolve to local files to be searched directly
 - Added IRC relay observation in the main agent UI so every IRC exchange between agents is rendered in the main transcript, even when the main agent is not a direct participant
 - Added stateful `href`/`hrefr` prompt helpers that can reuse anchors remembered from prior `hline` helper calls

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -2,13 +2,14 @@
  * Extension runner - executes extensions and manages their lifecycle.
  */
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
-import type { ImageContent, Model } from "@oh-my-pi/pi-ai";
+import type { ImageContent, Model, ProviderResponseMetadata } from "@oh-my-pi/pi-ai";
 import type { KeyId } from "@oh-my-pi/pi-tui";
 import { logger } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../../config/model-registry";
 import { type Theme, theme } from "../../modes/theme/theme";
 import type { SessionManager } from "../../session/session-manager";
 import type {
+	AfterProviderResponseEvent,
 	BeforeAgentStartEvent,
 	BeforeAgentStartEventResult,
 	BeforeProviderRequestEvent,
@@ -70,6 +71,7 @@ type RunnerEmitEvent = Exclude<
 	| UserBashEvent
 	| ContextEvent
 	| BeforeProviderRequestEvent
+	| AfterProviderResponseEvent
 	| BeforeAgentStartEvent
 	| ResourcesDiscoverEvent
 	| InputEvent
@@ -757,6 +759,37 @@ export class ExtensionRunner {
 		}
 
 		return currentPayload;
+	}
+
+	async emitAfterProviderResponse(response: ProviderResponseMetadata, _model?: Model): Promise<void> {
+		const ctx = this.createContext();
+
+		for (const ext of this.extensions) {
+			const handlers = ext.handlers.get("after_provider_response");
+			if (!handlers || handlers.length === 0) continue;
+
+			for (const handler of handlers) {
+				try {
+					const event: AfterProviderResponseEvent = {
+						type: "after_provider_response",
+						status: response.status,
+						headers: response.headers,
+						requestId: response.requestId,
+						metadata: response.metadata,
+					};
+					await handler(event, ctx);
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					const stack = err instanceof Error ? err.stack : undefined;
+					this.emitError({
+						extensionPath: ext.path,
+						event: "after_provider_response",
+						error: message,
+						stack,
+					});
+				}
+			}
+		}
 	}
 
 	async emitBeforeAgentStart(

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -17,6 +17,7 @@ import type {
 	Model,
 	OAuthCredentials,
 	OAuthLoginCallbacks,
+	ProviderResponseMetadata,
 	SimpleStreamOptions,
 	TextContent,
 	ToolResultMessage,
@@ -482,6 +483,11 @@ export interface BeforeProviderRequestEvent {
 	payload: unknown;
 }
 
+/** Fired after a provider response is received, before its stream body is consumed. */
+export interface AfterProviderResponseEvent extends ProviderResponseMetadata {
+	type: "after_provider_response";
+}
+
 /** Fired after user submits prompt but before agent loop. */
 export interface BeforeAgentStartEvent {
 	type: "before_agent_start";
@@ -801,6 +807,7 @@ export type ExtensionEvent =
 	| SessionEvent
 	| ContextEvent
 	| BeforeProviderRequestEvent
+	| AfterProviderResponseEvent
 	| BeforeAgentStartEvent
 	| AgentStartEvent
 	| AgentEndEvent
@@ -981,6 +988,7 @@ export interface ExtensionAPI {
 		event: "before_provider_request",
 		handler: ExtensionHandler<BeforeProviderRequestEvent, BeforeProviderRequestEventResult>,
 	): void;
+	on(event: "after_provider_response", handler: ExtensionHandler<AfterProviderResponseEvent>): void;
 	on(event: "before_agent_start", handler: ExtensionHandler<BeforeAgentStartEvent, BeforeAgentStartEventResult>): void;
 	on(event: "agent_start", handler: ExtensionHandler<AgentStartEvent>): void;
 	on(event: "agent_end", handler: ExtensionHandler<AgentEndEvent>): void;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -6,7 +6,7 @@ import {
 	INTENT_FIELD,
 	type ThinkingLevel,
 } from "@oh-my-pi/pi-agent-core";
-import type { Message, Model } from "@oh-my-pi/pi-ai";
+import type { Message, Model, SimpleStreamOptions } from "@oh-my-pi/pi-ai";
 import {
 	getOpenAICodexTransportDetails,
 	prewarmOpenAICodexResponses,
@@ -1498,6 +1498,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					return await extensionRunner.emitBeforeProviderRequest(payload);
 				}
 			: undefined;
+		const onResponse: SimpleStreamOptions["onResponse"] | undefined = extensionRunner
+			? async (response, model) => {
+					await extensionRunner.emitAfterProviderResponse(response, model);
+				}
+			: undefined;
 
 		const setToolUIContext = (uiContext: ExtensionUIContext, hasUI: boolean) => {
 			toolContextStore.setUIContext(uiContext, hasUI);
@@ -1527,6 +1532,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			},
 			convertToLlm: convertToLlmFinal,
 			onPayload,
+			onResponse,
 			sessionId: providerSessionId,
 			transformContext,
 			steeringMode: settings.get("steeringMode") ?? "one-at-a-time",
@@ -1599,6 +1605,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			toolRegistry,
 			transformContext,
 			onPayload,
+			onResponse,
 			convertToLlm: convertToLlmFinal,
 			rebuildSystemPrompt,
 			mcpDiscoveryEnabled,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -244,6 +244,8 @@ export interface AgentSessionConfig {
 	transformContext?: (messages: AgentMessage[], signal?: AbortSignal) => AgentMessage[] | Promise<AgentMessage[]>;
 	/** Provider payload hook used by the active session request path */
 	onPayload?: SimpleStreamOptions["onPayload"];
+	/** Provider response hook used by the active session request path */
+	onResponse?: SimpleStreamOptions["onResponse"];
 	/** Current session message-to-LLM conversion pipeline */
 	convertToLlm?: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	/** System prompt builder that can consider tool availability */
@@ -507,6 +509,7 @@ export class AgentSession {
 	#toolRegistry: Map<string, AgentTool>;
 	#transformContext: (messages: AgentMessage[], signal?: AbortSignal) => AgentMessage[] | Promise<AgentMessage[]>;
 	#onPayload: SimpleStreamOptions["onPayload"] | undefined;
+	#onResponse: SimpleStreamOptions["onResponse"] | undefined;
 	#convertToLlm: (messages: AgentMessage[]) => Message[] | Promise<Message[]>;
 	#rebuildSystemPrompt: ((toolNames: string[], tools: Map<string, AgentTool>) => Promise<string>) | undefined;
 	#baseSystemPrompt: string;
@@ -593,6 +596,7 @@ export class AgentSession {
 		this.#toolRegistry = config.toolRegistry ?? new Map();
 		this.#transformContext = config.transformContext ?? (messages => messages);
 		this.#onPayload = config.onPayload;
+		this.#onResponse = config.onResponse;
 		this.#convertToLlm = config.convertToLlm ?? convertToLlm;
 		this.#rebuildSystemPrompt = config.rebuildSystemPrompt;
 		this.#baseSystemPrompt = this.agent.state.systemPrompt;
@@ -2327,21 +2331,39 @@ export class AgentSession {
 
 	/** Apply session-level stream hooks to a direct side request. */
 	prepareSimpleStreamOptions(options: SimpleStreamOptions): SimpleStreamOptions {
-		if (!this.#onPayload) return options;
-		if (!options.onPayload) {
-			return { ...options, onPayload: this.#onPayload };
-		}
 		const sessionOnPayload = this.#onPayload;
-		const requestOnPayload = options.onPayload;
-		return {
-			...options,
-			onPayload: async (payload, model) => {
-				const sessionPayload = await sessionOnPayload(payload, model);
-				const sessionResolvedPayload = sessionPayload ?? payload;
-				const requestPayload = await requestOnPayload(sessionResolvedPayload, model);
-				return requestPayload ?? sessionResolvedPayload;
-			},
-		};
+		const sessionOnResponse = this.#onResponse;
+		if (!sessionOnPayload && !sessionOnResponse) return options;
+
+		const preparedOptions: SimpleStreamOptions = { ...options };
+
+		if (sessionOnPayload) {
+			if (!options.onPayload) {
+				preparedOptions.onPayload = sessionOnPayload;
+			} else {
+				const requestOnPayload = options.onPayload;
+				preparedOptions.onPayload = async (payload, model) => {
+					const sessionPayload = await sessionOnPayload(payload, model);
+					const sessionResolvedPayload = sessionPayload ?? payload;
+					const requestPayload = await requestOnPayload(sessionResolvedPayload, model);
+					return requestPayload ?? sessionResolvedPayload;
+				};
+			}
+		}
+
+		if (sessionOnResponse) {
+			if (!options.onResponse) {
+				preparedOptions.onResponse = sessionOnResponse;
+			} else {
+				const requestOnResponse = options.onResponse;
+				preparedOptions.onResponse = async (response, model) => {
+					await sessionOnResponse(response, model);
+					await requestOnResponse(response, model);
+				};
+			}
+		}
+
+		return preparedOptions;
 	}
 
 	/** Current steering mode */

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -421,6 +421,79 @@ describe("ExtensionRunner", () => {
 		});
 	});
 
+	describe("after_provider_response", () => {
+		it("calls handlers with response metadata and reports handler errors without throwing", async () => {
+			const eventsPath = path.join(tempDir.path(), "after-provider-response-events.jsonl");
+			const extCode = `
+			import * as fs from "node:fs";
+
+			export default function(pi) {
+				pi.on("after_provider_response", async (event) => {
+					fs.appendFileSync(
+						${JSON.stringify(eventsPath)},
+						JSON.stringify({
+							status: event.status,
+							headers: event.headers,
+							requestId: event.requestId,
+							metadata: event.metadata,
+						}) + "\\n",
+					);
+				});
+
+				pi.on("after_provider_response", async () => {
+					throw new Error("response failed");
+				});
+
+				pi.on("after_provider_response", async (event) => {
+					fs.appendFileSync(
+						${JSON.stringify(eventsPath)},
+						JSON.stringify({ afterError: event.status }) + "\\n",
+					);
+				});
+			}
+		`;
+			fs.writeFileSync(path.join(extensionsDir, "after-provider-response.ts"), extCode);
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const errors: Array<{ extensionPath: string; event: string; error: string }> = [];
+			runner.onError(err => {
+				errors.push(err);
+			});
+
+			await runner.emitAfterProviderResponse({
+				status: 202,
+				headers: { "x-request-id": "req_123", "content-type": "text/event-stream" },
+				requestId: "req_123",
+				metadata: { provider: "test" },
+			});
+
+			const events = fs
+				.readFileSync(eventsPath, "utf8")
+				.trim()
+				.split("\n")
+				.map(line => JSON.parse(line));
+			expect(events).toEqual([
+				{
+					status: 202,
+					headers: { "x-request-id": "req_123", "content-type": "text/event-stream" },
+					requestId: "req_123",
+					metadata: { provider: "test" },
+				},
+				{ afterError: 202 },
+			]);
+			expect(errors).toHaveLength(1);
+			expect(errors[0]?.event).toBe("after_provider_response");
+			expect(errors[0]?.error).toContain("response failed");
+		});
+	});
+
 	describe("tool_result chaining", () => {
 		it("chains content modifications across handlers", async () => {
 			const extCode1 = `


### PR DESCRIPTION
## What

- Add provider response metadata plumbing in `@oh-my-pi/pi-ai`.
- Expose a coding-agent extension hook named `after_provider_response`.
- Forward HTTP status, response headers, request id, rate-limit/cache headers, and provider metadata where available.
- Add tests for provider callback plumbing and extension-runner event delivery.
- Update changelogs for the new hook/API.

## Why

OMP already has `before_provider_request`; this adds the matching post-response hook needed for extension-level observability, dashboards, retry/debug plugins, and provider diagnostics.

Part of the Pi runtime/agentic harness migration stack.

## Testing

- `bun test packages/ai/test/provider-response.test.ts packages/coding-agent/test/extensions-runner.test.ts`
- `bunx biome check` on all files changed by this PR
- Earlier pre-rebase checks: `bun run check:ts` and `PATH="$HOME/.cargo/bin:$PATH" bun run check`

Known caveat after rebasing onto latest `main`: full `bun run check:ts` is currently blocked by unrelated Biome formatting/import-order issues already present in `origin/main` files not touched by this PR (`line-hash.ts`, `tools/renderers.ts`, `tools.test.ts`, `tools/search-renderer.test.ts`).

---

- [ ] `bun check` passes (blocked after latest `main` rebase by unrelated upstream Biome issues listed above)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
