### PR TITLE
fix(compaction): prevent auto-continue from acting on stale summary plans

### DIFF
--- a/packages/coding-agent/src/prompts/compaction/branch-summary.md
+++ b/packages/coding-agent/src/prompts/compaction/branch-summary.md
@@ -24,7 +24,7 @@ You **MUST** use EXACT format:
 ## Key Decisions
 - **[Decision]**: [Brief rationale]
 
-## Next Steps
-1. [What should happen next to continue]
+## Open Threads
+1. [Open threads or likely continuation points]
 
 Sections **MUST** be kept concise. You **MUST** preserve exact file paths, function names, error messages.

--- a/packages/coding-agent/src/prompts/compaction/compaction-summary.md
+++ b/packages/coding-agent/src/prompts/compaction/compaction-summary.md
@@ -24,8 +24,8 @@ You **MUST** use this format (sections can be omitted if not applicable):
 ## Key Decisions
 - **[Decision]**: [Brief rationale]
 
-## Next Steps
-1. [Ordered list of next actions]
+## Open Threads
+1. [Open threads or likely continuation points]
 
 ## Critical Context
 - [Important data, pending questions, references]

--- a/packages/coding-agent/src/prompts/compaction/compaction-update-summary.md
+++ b/packages/coding-agent/src/prompts/compaction/compaction-update-summary.md
@@ -3,7 +3,7 @@ RULES:
 - **MUST** preserve all information from previous summary
 - **MUST** add new progress, decisions, and context from new messages
 - **MUST** update Progress: move items from "In Progress" to "Done" when completed
-- **MUST** update "Next Steps" based on what was accomplished
+- **MUST** update "Open Threads" based on what was accomplished
 - **MUST** preserve exact file paths, function names, and error messages
 - You **MAY** remove anything no longer relevant
 
@@ -31,8 +31,8 @@ You **MUST** use this format (omit sections if not applicable):
 ## Key Decisions
 - **[Decision]**: [Brief rationale] (preserve all previous, add new)
 
-## Next Steps
-1. [Update based on current state]
+## Open Threads
+1. [Open threads or likely continuation points]
 
 ## Critical Context
 - [Preserve important context; add new if needed]

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1207,11 +1207,16 @@ export class AgentSession {
 			await this.#promptWithMessage(
 				{
 					role: "developer",
-					content: [{ type: "text", text: "Continue if you have next steps." }],
+					content: [
+						{
+							type: "text",
+							text: "Continue only if the latest messages still show unfinished work. Treat older summaries and plans as background. Do not resume items that later messages completed or superseded.",
+						},
+					],
 					attribution: "agent",
 					timestamp: Date.now(),
 				},
-				"Continue if you have next steps.",
+				"Continue.",
 				{ skipPostPromptRecoveryWait: true },
 			);
 		};


### PR DESCRIPTION
## What

Rewrite the auto-continue developer prompt injected after threshold compaction and auto-handoff, and rename `## Next Steps` to `## Open Threads` in compaction and branch summary templates.

## Why

Fixes #840.

After threshold compaction, OMP injects `"Continue if you have next steps."` as a developer message. The compaction summary always contains a `## Next Steps` section generated from old (discarded) messages only; the kept recent ~20k tokens aren't fed to the summarizer. The summary's "Next Steps" are therefore stale by ~20k tokens of work, and the synthetic prompt's phrasing directly echoes the summary heading, anchoring the LLM on an outdated plan.

Two changes:

1. **Rewrite the auto-continue prompt** to privilege recent conversation over older summaries: `"Continue only if the latest messages still show unfinished work. Treat older summaries and plans as background. Do not resume items that later messages completed or superseded."`
2. **Rename `## Next Steps` → `## Open Threads`** in `compaction-summary.md`, `compaction-update-summary.md`, and `branch-summary.md` so the heading no longer claims currency. `handoff-document.md` is intentionally left unchanged (handoff is meant to be authoritative current context).

## Testing

Verified no in-tree runtime code parses the `## Next Steps` heading. The rename is prompt-only; no regex or string-match consumers exist. Confirmed `#scheduleAutoContinuePrompt()` is used after both context-full compaction and auto-handoff, and the new wording is safe for both paths.

---

- [ ] `bun check` passes
- [ ] Tested locally
- [ ] CHANGELOG updated (if user-facing)
