### PR TITLE
feat(coding-agent): add disableStrictTools provider option for anthropic-messages endpoints

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -55,6 +55,7 @@ providers:
       X-Team: platform
     authHeader: true
     auth: apiKey
+    disableStrictTools: false  # set true for Anthropic-compatible endpoints that reject the strict field
     discovery:
       type: ollama
     modelOverrides:
@@ -121,6 +122,7 @@ Must define at least one of:
 - `baseUrl`
 - `headers`
 - `compat`
+- `disableStrictTools`
 - `modelOverrides`
 - `discovery`
 
@@ -139,7 +141,7 @@ ModelRegistry pipeline (on refresh):
 
 1. Load built-in providers/models from `@oh-my-pi/pi-ai`.
 2. Load `models.yml` custom config.
-3. Apply provider overrides (`baseUrl`, `headers`) to built-in models.
+3. Apply provider overrides (`baseUrl`, `headers`, `disableStrictTools`) to built-in models.
 4. Apply `modelOverrides` (per provider + model id).
 5. Merge custom `models`:
    - same `provider + id` replaces existing
@@ -452,6 +454,33 @@ The built-in model generator also assigns this automatically for `*-spark` model
 
 These are consumed by the OpenAI-completions transport logic and combined with URL-based auto-detection.
 
+### Strict tool schemas (`disableStrictTools`)
+
+Anthropic's API supports a `strict` field on tool definitions that forces the model to always follow the provided schema exactly. This is enabled by default for all `anthropic-messages` providers because it guarantees schema conformance in agentic systems.
+
+Third-party providers that front the Anthropic API (AWS Bedrock, Azure, self-hosted proxies) do not always implement this field and will reject requests that include it. Set `disableStrictTools: true` at the provider level to opt out:
+
+```yaml
+providers:
+  bedrock-anthropic:
+    baseUrl: https://bedrock-runtime.us-east-1.amazonaws.com/anthropic
+    apiKey: AWS_BEARER_TOKEN
+    api: anthropic-messages
+    disableStrictTools: true
+    models:
+      - id: claude-sonnet-4-20250514
+        name: Claude Sonnet 4 (Bedrock)
+        input: [text, image]
+        contextWindow: 200000
+        maxTokens: 16384
+        cost:
+          input: 3.00
+          output: 15.00
+          cacheRead: 0.30
+          cacheWrite: 3.75
+```
+
+`disableStrictTools` is a provider-level flag that applies to all models in the provider.
 ## Practical examples
 
 ### Local OpenAI-compatible endpoint (no auth)
@@ -476,6 +505,7 @@ providers:
     apiKey: ANTHROPIC_PROXY_API_KEY
     api: anthropic-messages
     authHeader: true
+    disableStrictTools: true  # if the proxy doesn't support strict tool schemas
     models:
       - id: claude-sonnet-4-20250514
         name: Claude Sonnet 4 (Proxy)

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -281,6 +281,8 @@ const ProviderConfigSchema = Type.Object({
 	discovery: Type.Optional(ProviderDiscoverySchema),
 	models: Type.Optional(Type.Array(ModelDefinitionSchema)),
 	modelOverrides: Type.Optional(Type.Record(Type.String(), ModelOverrideSchema)),
+	/** When true, disables strict tool schemas for this provider (for third-party Anthropic-compatible endpoints that reject the strict field). */
+	disableStrictTools: Type.Optional(Type.Boolean()),
 });
 
 const EquivalenceConfigSchema = Type.Object({
@@ -316,6 +318,7 @@ interface ProviderValidationConfig {
 	oauthConfigured?: boolean;
 	discovery?: ProviderDiscovery;
 	compat?: Model<Api>["compat"];
+	disableStrictTools?: boolean;
 	modelOverrides?: Record<string, unknown>;
 	models: ProviderValidationModel[];
 }
@@ -331,9 +334,16 @@ function validateProviderConfiguration(
 	if (models.length === 0) {
 		if (mode === "models-config") {
 			const hasModelOverrides = config.modelOverrides && Object.keys(config.modelOverrides).length > 0;
-			if (!config.baseUrl && !config.headers && !config.compat && !hasModelOverrides && !config.discovery) {
+			if (
+				!config.baseUrl &&
+				!config.headers &&
+				!config.compat &&
+				!config.disableStrictTools &&
+				!hasModelOverrides &&
+				!config.discovery
+			) {
 				throw new Error(
-					`Provider ${providerName}: must specify "baseUrl", "headers", "compat", "modelOverrides", "discovery", or "models"`,
+					`Provider ${providerName}: must specify "baseUrl", "headers", "compat", "disableStrictTools", "modelOverrides", "discovery", or "models"`,
 				);
 			}
 		}
@@ -394,6 +404,7 @@ export const ModelsConfigFile = new ConfigFile<ModelsConfig>("models", ModelsCon
 					auth: (providerConfig.auth ?? "apiKey") as ProviderAuthMode,
 					discovery: providerConfig.discovery as ProviderDiscovery | undefined,
 					compat: providerConfig.compat,
+					disableStrictTools: providerConfig.disableStrictTools,
 					modelOverrides: providerConfig.modelOverrides,
 					models: (providerConfig.models ?? []) as ProviderValidationModel[],
 				},
@@ -1099,13 +1110,20 @@ export class ModelRegistry {
 		const configuredProviders = new Set(Object.keys(value.providers ?? {}));
 
 		for (const [providerName, providerConfig] of providerEntries) {
-			// Always set overrides when baseUrl/headers/apiKey/compat are present
-			if (providerConfig.baseUrl || providerConfig.headers || providerConfig.apiKey || providerConfig.compat) {
+			// Always set overrides when baseUrl/headers/apiKey/compat/disableStrictTools are present
+			if (
+				providerConfig.baseUrl ||
+				providerConfig.headers ||
+				providerConfig.apiKey ||
+				providerConfig.compat ||
+				providerConfig.disableStrictTools
+			) {
+				const disableStrictCompat = providerConfig.disableStrictTools ? { disableStrictTools: true } : undefined;
 				overrides.set(providerName, {
 					baseUrl: providerConfig.baseUrl,
 					headers: providerConfig.headers,
 					apiKey: providerConfig.apiKey,
-					compat: providerConfig.compat,
+					compat: mergeCompat(providerConfig.compat, disableStrictCompat),
 				});
 			}
 
@@ -1749,6 +1767,9 @@ export class ModelRegistry {
 				this.#customProviderApiKeys.set(providerName, providerConfig.apiKey);
 			}
 			for (const modelDef of modelDefs) {
+				const providerCompat = providerConfig.disableStrictTools
+					? mergeCompat(providerConfig.compat, { disableStrictTools: true })
+					: providerConfig.compat;
 				const model = buildCustomModelOverlay(
 					providerName,
 					providerConfig.baseUrl!,
@@ -1756,7 +1777,7 @@ export class ModelRegistry {
 					providerConfig.headers,
 					providerConfig.apiKey,
 					providerConfig.authHeader,
-					providerConfig.compat,
+					providerCompat,
 					(providerConfig.auth as ProviderAuthMode | undefined) ?? undefined,
 					modelDef as CustomModelDefinitionLike,
 				);

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1881,6 +1881,85 @@ describe("ModelRegistry", () => {
 			).toBe(true);
 		});
 	});
+	describe("disableStrictTools", () => {
+		test("custom provider with models gets disableStrictTools merged into compat", () => {
+			writeRawModelsJson({
+				"bedrock-anthropic": {
+					baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com/anthropic",
+					apiKey: "TEST_KEY",
+					api: "anthropic-messages",
+					disableStrictTools: true,
+					models: [
+						{
+							id: "claude-sonnet-4-20250514",
+							name: "Claude Sonnet 4",
+							reasoning: false,
+							input: ["text", "image"],
+							cost: { input: 3.0, output: 15.0, cacheRead: 0.3, cacheWrite: 3.75 },
+							contextWindow: 200000,
+							maxTokens: 16384,
+						},
+					],
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const model = registry.find("bedrock-anthropic", "claude-sonnet-4-20250514");
+
+			expect(model).toBeDefined();
+			expect((model?.compat as { disableStrictTools?: boolean } | undefined)?.disableStrictTools).toBe(true);
+		});
+
+		test("disableStrictTools on override-only provider applies to built-in models", () => {
+			writeRawModelsJson({ anthropic: { disableStrictTools: true } });
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const models = getModelsForProvider(registry, "anthropic");
+
+			expect(models.length).toBeGreaterThan(0);
+			for (const model of models) {
+				expect((model.compat as { disableStrictTools?: boolean } | undefined)?.disableStrictTools).toBe(true);
+			}
+		});
+
+		test("disableStrictTools is absent on built-in models without override", () => {
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const models = getModelsForProvider(registry, "anthropic");
+
+			expect(models.length).toBeGreaterThan(0);
+			for (const model of models) {
+				expect((model.compat as { disableStrictTools?: boolean } | undefined)?.disableStrictTools).toBeUndefined();
+			}
+		});
+
+		test("disableStrictTools is merged with explicit compat on custom provider", () => {
+			writeRawModelsJson({
+				"my-proxy": {
+					baseUrl: "https://proxy.example.com/anthropic",
+					apiKey: "TEST_KEY",
+					api: "anthropic-messages",
+					disableStrictTools: true,
+					models: [
+						{
+							id: "claude-sonnet-4",
+							name: "Sonnet",
+							reasoning: false,
+							input: ["text"],
+							cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+							contextWindow: 200000,
+							maxTokens: 16384,
+						},
+					],
+				},
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const model = registry.find("my-proxy", "claude-sonnet-4");
+
+			expect(model).toBeDefined();
+			expect((model?.compat as { disableStrictTools?: boolean } | undefined)?.disableStrictTools).toBe(true);
+		});
+	});
 
 	describe("provider auth: oauth", () => {
 		test("models from a provider with auth: oauth are marked isOAuth=true", async () => {


### PR DESCRIPTION
## Problem

Anthropic's API supports a `strict` field on tool definitions that forces the model to always follow the provided schema exactly ([docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/strict-tool-use)). This is already supported by the anthropic transport (added in #826 for Vertex AI).

Third-party providers that front the Anthropic API (AWS Bedrock, custom proxies) do not always implement the `strict` field and reject requests that include it. Previously there was no way to disable this in `models.yml` — it required code-level model construction.

## Solution

Expose `model.compat.disableStrictTools` (already supported by the transport) via a new top-level `disableStrictTools` provider field in `models.yml`:

```yaml
providers:
  bedrock-anthropic:
    baseUrl: https://bedrock-runtime.us-east-1.amazonaws.com/anthropic
    apiKey: AWS_BEARER_TOKEN
    api: anthropic-messages
    disableStrictTools: true
    models:
      - id: claude-sonnet-4-20250514
        ...
```

The field is provider-level and applies to all models in the provider. Internally it merges `{ disableStrictTools: true }` into the provider's `compat` object, flowing through the existing pipeline to `model.compat.disableStrictTools` which the transport already reads.

## Changes

- `packages/coding-agent/src/config/model-registry.ts` — add `disableStrictTools` to `ProviderConfigSchema` and `ProviderValidationConfig`; merge into provider compat override when set; allow `disableStrictTools` alone as a valid override-only provider entry
- `docs/models.md` — document the new field with a Bedrock example, update provider field reference and merge order
- Tests covering provider-level propagation, built-in model override, overlay merge, and default absence