### PR TITLE
Fix OpenCode Go Qwen endpoints

### DIFF
--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -34729,9 +34729,9 @@
 		"qwen3.5-plus": {
 			"id": "qwen3.5-plus",
 			"name": "Qwen3.5 Plus",
-			"api": "anthropic-messages",
+			"api": "openai-completions",
 			"provider": "opencode-go",
-			"baseUrl": "https://opencode.ai/zen/go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -34754,9 +34754,9 @@
 		"qwen3.6-plus": {
 			"id": "qwen3.6-plus",
 			"name": "Qwen3.6 Plus",
-			"api": "anthropic-messages",
+			"api": "openai-completions",
 			"provider": "opencode-go",
-			"baseUrl": "https://opencode.ai/zen/go",
+			"baseUrl": "https://opencode.ai/zen/go/v1",
 			"reasoning": true,
 			"input": [
 				"text",

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -282,6 +282,17 @@ describe("openai-completions compatibility", () => {
 	});
 });
 
+describe("opencode-go bundled Qwen models", () => {
+	for (const id of ["qwen3.5-plus", "qwen3.6-plus"] as const) {
+		it(`${id} uses the documented OpenAI-compatible endpoint`, () => {
+			const model = getBundledModel("opencode-go", id);
+
+			expect(model?.api).toBe("openai-completions");
+			expect(model?.baseUrl).toBe("https://opencode.ai/zen/go/v1");
+		});
+	}
+});
+
 describe("kimi model detection via detectCompat", () => {
 	function kimiOpenCodeModel(id: string): Model<"openai-completions"> {
 		return {


### PR DESCRIPTION
## Summary
- switch OpenCode Go Qwen3.5/3.6 Plus bundled models to the documented OpenAI-compatible API
- point both models at the /zen/go/v1 base URL so chat/completions is used instead of the Anthropic messages path
- add a regression test for the bundled model metadata

## Source
- OpenCode Go endpoint docs list both qwen3.5-plus and qwen3.6-plus at https://opencode.ai/zen/go/v1/chat/completions: https://opencode.ai/docs/go/#endpoints

## Tests
- bun --cwd=packages/ai run check
- bun test packages/ai/test/openai-completions-compat.test.ts