### PR TITLE
fix(xdg): resolve `marketplace` plugins path when using xdg spec 

### DIFF
--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { FileType, glob } from "@oh-my-pi/pi-natives";
-import { CONFIG_DIR_NAME, getConfigDirName, getProjectDir, parseFrontmatter, tryParseJson } from "@oh-my-pi/pi-utils";
+import { CONFIG_DIR_NAME, getConfigDirName, getProjectDir, getUserPluginsRegistryDir, parseFrontmatter, tryParseJson } from "@oh-my-pi/pi-utils";
 import type { ExtensionModule } from "../capability/extension-module";
 import { invalidate as invalidateFsCache, readDirEntries, readFile } from "../capability/fs";
 import { parseRuleConditionAndScope, type Rule, type RuleFrontmatter } from "../capability/rule";
@@ -805,7 +805,7 @@ export async function listClaudePluginRoots(
 	// ── OMP installed plugins registry ───────────────────────────────────────
 	// OMP registry is authoritative: its entries replace Claude's entries for the same plugin ID.
 	// Path derived from `home` (not os.homedir()) so test isolation works when home is overridden.
-	const ompRegistryPath = path.join(home, getConfigDirName(), "plugins", "installed_plugins.json");
+	const ompRegistryPath = path.join(getUserPluginsRegistryDir(home));
 	const ompContent = await readFile(ompRegistryPath);
 	if (ompContent) {
 		const ompRegistry = parseClaudePluginsRegistry(ompContent);

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -13,7 +13,7 @@ import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
 import "@oh-my-pi/pi-coding-agent/discovery/claude-plugins";
 import type { Skill } from "@oh-my-pi/pi-coding-agent/capability/skill";
 import type { SlashCommand } from "@oh-my-pi/pi-coding-agent/capability/slash-command";
-
+import { getAgentDir, getConfigDirName, setAgentDir } from "@oh-my-pi/pi-utils";
 describe("parseClaudePluginsRegistry", () => {
 	test("parses valid registry", () => {
 		const content = JSON.stringify({
@@ -60,24 +60,35 @@ describe("parseClaudePluginsRegistry", () => {
 describe("listClaudePluginRoots", () => {
 	let tempDir: string;
 	let originalHome: string | undefined;
-
+	let originalAgentDir: string;
+	let originalXdgDataHome: string | undefined;
 	beforeEach(async () => {
 		clearClaudePluginRootsCache();
 		clearFsCache();
 		originalHome = process.env.HOME;
+		originalAgentDir = getAgentDir();
+		originalXdgDataHome = process.env.XDG_DATA_HOME;
+		delete process.env.XDG_DATA_HOME;
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "claude-plugins-test-"));
 		process.env.HOME = tempDir;
 		vi.spyOn(os, "homedir").mockReturnValue(tempDir);
+		setAgentDir(path.join(tempDir, getConfigDirName(), "agent"));
 	});
 
 	afterEach(async () => {
 		clearClaudePluginRootsCache();
 		clearFsCache();
 		vi.restoreAllMocks();
+		setAgentDir(originalAgentDir);
 		if (originalHome === undefined) {
 			delete process.env.HOME;
 		} else {
 			process.env.HOME = originalHome;
+		}
+		if (originalXdgDataHome === undefined) {
+			delete process.env.XDG_DATA_HOME;
+		} else {
+			process.env.XDG_DATA_HOME = originalXdgDataHome;
 		}
 		await fs.rm(tempDir, { recursive: true, force: true });
 	});

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -241,6 +241,15 @@ export function getPluginsDir(): string {
 	return dirs.rootSubdir("plugins", "data");
 }
 
+/** Get the users plugins directory (~/.omp/plugins or ~/.local/share/omp/plugins). */
+export function getUserPluginsRegistryDir(home: string): string {
+	if (home != os.homedir()) {
+		// If a custom home directory is provided, assume plugins are stored under it without XDG redirection.
+		return path.join(home, getConfigDirName(), "plugins", "installed_plugins.json");
+	}
+	return path.join(getPluginsDir(), "installed_plugins.json")
+}
+
 /** Where npm installs packages (~/.omp/plugins/node_modules). */
 export function getPluginsNodeModules(): string {
 	return path.join(getPluginsDir(), "node_modules");


### PR DESCRIPTION
## What
`listClaudePluginRoots()` was always reading the OMP user plugin registry from the legacy home-relative path ( `~/.omp/plugins/installed_plugins.json` or `~/.config/omp/...` depending on `getConfigDirName()`). On XDG-enabled systems the marketplace writes the registry to `$XDG_DATA_HOME/omp/plugins/installed_plugins.json` , so the paths never matched and marketplace-installed skills were silently ignored at discovery time.

now we using `resolveUserPluginsDir()` to resolve user plugins, and also resolve xdg spec.

## Why
 Marketplace-installed skills were not loaded after installation on any system with `XDG_DATA_HOME` set. The install wrote to the XDG path; discovery always read from the legacy path.

# Test
- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)

---

all same as #707, but fix the test, able to merge :)

mainly fixed the `/marketplace` plugins resolved for xdg plugin discovery
