### PR TITLE
fix(coding-agent/edit): decode \uXXXX escape sequences in written content

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -28,6 +28,7 @@
 ### Fixed
 
 - Fixed hook editors to recognize Ctrl+Enter when terminals include NumLock or keypad Enter metadata.
+- Edit and write tools now decode `\uXXXX` escape sequences to their actual Unicode characters before writing to disk. A sequence preceded by a second backslash (`\\uXXXX`) is left unchanged so intentional literal escapes are preserved.
 ## [14.5.6] - 2026-04-29
 ### Changed
 

--- a/packages/coding-agent/src/edit/modes/hashline.ts
+++ b/packages/coding-agent/src/edit/modes/hashline.ts
@@ -29,7 +29,7 @@ import { enforcePlanModeWrite, resolvePlanPath } from "../../tools/plan-mode-gua
 import { formatCodeFrameLine } from "../../tools/render-utils";
 import { generateDiffString } from "../diff";
 import { computeLineHash, formatHashLine, HASHLINE_BIGRAM_RE_SRC, HASHLINE_CONTENT_SEPARATOR } from "../line-hash";
-import { detectLineEnding, normalizeToLF, restoreLineEndings, stripBom } from "../normalize";
+import { decodeUnicodeEscapes, detectLineEnding, normalizeToLF, restoreLineEndings, stripBom } from "../normalize";
 import type { EditToolDetails, LspBatchRequest } from "../renderer";
 
 export interface HashMismatch {
@@ -194,7 +194,7 @@ export function hashlineParseText(edit: string[] | string | null | undefined): s
 		const normalizedEdit = edit.endsWith("\n") ? edit.slice(0, -1) : edit;
 		edit = normalizedEdit.replaceAll("\r", "").split("\n");
 	}
-	return stripNewLinePrefixes(edit);
+	return stripNewLinePrefixes(edit.map(decodeUnicodeEscapes));
 }
 
 function resolveEditAnchors(edits: HashlineToolEdit[]): HashlineEdit[] {

--- a/packages/coding-agent/src/edit/modes/patch.ts
+++ b/packages/coding-agent/src/edit/modes/patch.ts
@@ -38,6 +38,8 @@ import {
 	adjustIndentation,
 	convertLeadingTabsToSpaces,
 	countLeadingWhitespace,
+	decodeUnicodeEscapes,
+	decodeUnicodeEscapesInDiffAdditions,
 	detectLineEnding,
 	getLeadingWhitespace,
 	normalizeToLF,
@@ -1709,7 +1711,13 @@ export async function executePatchSingle(
 		writethrough,
 		beginDeferredDiagnosticsForPath,
 	} = options;
-	const { op: rawOp, rename, diff } = params;
+	const { op: rawOp, rename, diff: rawDiff } = params;
+	const diff =
+		rawDiff != null
+			? rawOp === "create"
+				? decodeUnicodeEscapes(rawDiff) // create: full-text content, no "+" prefixes
+				: decodeUnicodeEscapesInDiffAdditions(rawDiff) // update: decode only "+" lines
+			: rawDiff;
 
 	const op: Operation = rawOp === "create" || rawOp === "delete" ? rawOp : "update";
 

--- a/packages/coding-agent/src/edit/modes/replace.ts
+++ b/packages/coding-agent/src/edit/modes/replace.ts
@@ -14,6 +14,7 @@ import { enforcePlanModeWrite, resolvePlanPath } from "../../tools/plan-mode-gua
 import { generateDiffString, replaceText } from "../diff";
 import {
 	countLeadingWhitespace,
+	decodeUnicodeEscapes,
 	detectLineEnding,
 	normalizeForFuzzy,
 	normalizeToLF,
@@ -1040,7 +1041,7 @@ export async function executeReplaceSingle(
 	const originalEnding = detectLineEnding(content);
 	const normalizedContent = normalizeToLF(content);
 	const normalizedOldText = normalizeToLF(old_text);
-	const normalizedNewText = normalizeToLF(new_text);
+	const normalizedNewText = normalizeToLF(decodeUnicodeEscapes(new_text));
 
 	const result = replaceText(normalizedContent, normalizedOldText, normalizedNewText, {
 		fuzzy: allowFuzzy,

--- a/packages/coding-agent/src/edit/normalize.ts
+++ b/packages/coding-agent/src/edit/normalize.ts
@@ -224,6 +224,39 @@ export function normalizeUnicode(s: string): string {
 }
 
 /**
+ * Decode JSON-style \uXXXX escape sequences in a string to their actual Unicode
+ * characters. Applies a second-pass decode for sequences that survived JSON parsing
+ * as literal text (e.g. the model emitted \\u2192 in JSON, producing the 6-char
+ * literal \u2192 instead of the arrow character).
+ *
+ * A \uXXXX preceded by another backslash (\\uXXXX) is intentional -- the model
+ * used \\\\uXXXX in JSON to write a literal backslash before a u-sequence -- and
+ * is left unchanged.
+ */
+export function decodeUnicodeEscapes(text: string): string {
+	return text.replace(/(?<!\\)\\u([0-9a-fA-F]{4})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+}
+
+/**
+ * Decode JSON-style \uXXXX escape sequences only in the addition lines of a
+ * unified diff string. Context lines (prefixed with a space) and removal lines
+ * (prefixed with `-`) are used for matching existing file content and must not be
+ * decoded. The `+++ ` file-header lines (identified by the trailing space, matching
+ * the unified-diff convention) are also left unchanged.
+ */
+export function decodeUnicodeEscapesInDiffAdditions(diff: string): string {
+	return diff
+		.split("\n")
+		.map(line => {
+			if (line.startsWith("+") && !line.startsWith("+++ ")) {
+				return `+${decodeUnicodeEscapes(line.slice(1))}`;
+			}
+			return line;
+		})
+		.join("\n");
+}
+
+/**
  * Normalize a line for fuzzy comparison.
  * Trims, collapses whitespace, and normalizes punctuation.
  */

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -7,7 +7,7 @@ import { Text } from "@oh-my-pi/pi-tui";
 import { isEnoent, isRecord, prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import { type Static, Type } from "@sinclair/typebox";
 import { unzipSync, zipSync } from "fflate";
-import { stripHashlinePrefixes } from "../edit";
+import { decodeUnicodeEscapes, stripHashlinePrefixes } from "../edit";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { createLspWritethrough, type FileDiagnosticsResult, type WritethroughCallback, writethroughNoop } from "../lsp";
 import { getLanguageFromPath, type Theme } from "../modes/theme/theme";
@@ -422,7 +422,8 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 	): Promise<AgentToolResult<WriteToolDetails>> {
 		return untilAborted(signal, async () => {
 			// Strip hashline display prefixes (LINE+ID|) if the model copied them from read output
-			const { text: cleanContent, stripped } = stripWriteContent(this.session, content);
+			const { text: rawContent, stripped } = stripWriteContent(this.session, content);
+			const cleanContent = decodeUnicodeEscapes(rawContent);
 			const resolvedArchivePath = await this.#resolveArchiveWritePath(path);
 			if (resolvedArchivePath) {
 				enforcePlanModeWrite(this.session, resolvedArchivePath.archivePath, {

--- a/packages/coding-agent/test/core/decode-unicode-escapes.test.ts
+++ b/packages/coding-agent/test/core/decode-unicode-escapes.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test";
+import { decodeUnicodeEscapes, decodeUnicodeEscapesInDiffAdditions } from "@oh-my-pi/pi-coding-agent/edit";
+
+describe("decodeUnicodeEscapes", () => {
+	it("decodes a single \\uXXXX sequence to the Unicode character", () => {
+		// \u2192 (right arrow) as literal 6-char escape should become →
+		expect(decodeUnicodeEscapes("hello \\u2192 world")).toBe("hello \u2192 world");
+	});
+
+	it("decodes multiple sequences in one string", () => {
+		expect(decodeUnicodeEscapes("\\u0041\\u0042\\u0043")).toBe("ABC");
+	});
+
+	it("decodes case-insensitive hex digits", () => {
+		expect(decodeUnicodeEscapes("\\u00E9")).toBe("\u00e9"); // é
+		expect(decodeUnicodeEscapes("\\u00e9")).toBe("\u00e9"); // é
+	});
+
+	it("leaves strings without escape sequences unchanged", () => {
+		const s = "hello world";
+		expect(decodeUnicodeEscapes(s)).toBe(s);
+	});
+
+	it("leaves already-decoded Unicode characters unchanged", () => {
+		// actual arrow character, not escape notation
+		const s = "hello \u2192 world";
+		expect(decodeUnicodeEscapes(s)).toBe(s);
+	});
+
+	it("does not decode \\uXXX with fewer than 4 hex digits", () => {
+		const s = "\\u219";
+		expect(decodeUnicodeEscapes(s)).toBe(s);
+	});
+
+	it("does not decode \\uXXXX preceded by another backslash (intentional literal)", () => {
+		// \\u2192 in the parsed string means the model used \\\\u2192 in JSON
+		expect(decodeUnicodeEscapes("\\\\u2192")).toBe("\\\\u2192");
+	});
+
+	it("handles empty string", () => {
+		expect(decodeUnicodeEscapes("")).toBe("");
+	});
+});
+
+describe("decodeUnicodeEscapesInDiffAdditions", () => {
+	it("decodes \\uXXXX in addition lines only", () => {
+		const diff = [
+			"--- a/file.ts",
+			"+++ b/file.ts",
+			"@@ -1,3 +1,3 @@",
+			' const x = "\\u2192";', // context line — must not be decoded
+			'-const y = "\\u2190";', // removal line — must not be decoded
+			'+const y = "\\u21d2";', // addition line — must be decoded
+		].join("\n");
+		const result = decodeUnicodeEscapesInDiffAdditions(diff);
+		const lines = result.split("\n");
+		// context line unchanged
+		expect(lines[3]).toBe(' const x = "\\u2192";');
+		// removal line unchanged
+		expect(lines[4]).toBe('-const y = "\\u2190";');
+		// addition line decoded
+		expect(lines[5]).toBe('+const y = "\u21d2";');
+	});
+
+	it("leaves +++ file headers unchanged", () => {
+		const diff = '+++ b/src/file.ts\n+const x = "\\u2192";\n';
+		const lines = decodeUnicodeEscapesInDiffAdditions(diff).split("\n");
+		expect(lines[0]).toBe("+++ b/src/file.ts");
+		expect(lines[1]).toBe('+const x = "\u2192";');
+	});
+
+	it("decodes addition lines whose content starts with +++", () => {
+		// A line in source that literally starts with "+++" is an addition: "++++...";
+		// the old "+++" guard (no trailing space) would have skipped this.
+		const diff = "++++\\u2192 marker";
+		expect(decodeUnicodeEscapesInDiffAdditions(diff)).toBe("++++→ marker");
+	});
+
+	it("does not decode raw-text (no-prefix) lines — handled upstream for create op", () => {
+		// create-op content may have no "+" prefix; decodeUnicodeEscapesInDiffAdditions
+		// intentionally leaves those lines alone. The caller (patch.ts) uses
+		// decodeUnicodeEscapes directly for op=\"create\".
+		const raw = 'const x = "\\u2192";';
+		expect(decodeUnicodeEscapesInDiffAdditions(raw)).toBe(raw);
+	});
+
+	it("handles empty diff", () => {
+		expect(decodeUnicodeEscapesInDiffAdditions("")).toBe("");
+	});
+});


### PR DESCRIPTION
## Problem

LLMs occasionally emit literal `\uXXXX` escape sequences in JSON tool output instead of the actual Unicode character. After JSON parsing the runtime string still contains the 6-char literal `\uXXXX` (e.g. `\u2192` instead of →), and that literal text gets written to disk.

## Fix

Add `decodeUnicodeEscapes` and `decodeUnicodeEscapesInDiffAdditions` helpers in `packages/coding-agent/src/edit/normalize.ts` and wire them into the four write paths:

- **`write`** — decode after stripping hashline prefixes
- **`replace`** — decode `new_text` only; `old_text` is left as-is so literal `\uXXXX` sequences in source files can still be matched
- **`patch` (update)** — decode only `+` addition lines; context and `-` removal lines used for fuzzy matching are untouched
- **`patch` (create)** — full-text decode (no `+` prefixes in create payloads)
- **`hashline`** — decode replacement lines

A `\uXXXX` sequence preceded by another backslash (parsed string `\\uXXXX`) is intentional literal-escape content and is left unchanged. Implemented via lookbehind `(?<!\\)\\u([0-9a-fA-F]{4})/g`.

## Tests

`test/core/decode-unicode-escapes.test.ts` covers:
- single/multi escape sequences, case-insensitive hex
- short hex (`\uXXX`) rejected
- double-backslash preservation
- diff addition-only decoding (context/removal/`+++ ` header untouched)
- raw-text passthrough (create-op caller path)
- empty inputs

## Note on surrogate pairs

`String.fromCharCode` is BMP-only on its surface, but adjacent calls across the `String.replace` callback produce contiguous UTF-16 code units that form valid surrogate pairs — verified empirically: input `\uD83D\uDE00` decodes to U+1F600 (😀) and round-trips through UTF-8 as the proper 4-byte sequence. No surrogate-pair handling needed.
