### PR TITLE
docs(coding-agent/edit): document Unicode escape semantics in edit tool prompts

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+
+### Changed
+- Documented Unicode escape semantics in the `write`, `replace`, `patch`, and `hashline` tool prompts. JSON natively decodes `\uXXXX`, so emitting `"\u2192"` (one backslash) writes the character → and emitting `"\\u2192"` (two backslashes) writes the literal 6-char escape sequence — useful for JS regex source, Python raw strings, JSON fixtures, and docs about Unicode.
+
 ## [14.7.0] - 2026-05-04
 ### Breaking Changes
 

--- a/packages/coding-agent/src/prompts/tools/hashline.md
+++ b/packages/coding-agent/src/prompts/tools/hashline.md
@@ -99,3 +99,10 @@ If your replacement payload would render with even one unchanged line in the dif
 - `= A..B` deletes the range; payload is what's written. If a payload edge line already exists immediately outside `A..B`, widen the range to cover it — otherwise it duplicates.
 - Multiple ops in one patch are cheap. Prefer two narrow ops over one wide `=`.
 </critical>
+
+<unicode-content>
+Your tool-call JSON is parsed before this tool sees `content`, so `\uXXXX` decodes natively.
+- To insert the **character** → (U+2192): emit `"\u2192"` (one backslash) in the JSON, or the literal → character.
+- To insert the **literal 6-char escape sequence** `\u2192` (source code that already contains `\u2192` — JS regex `/\u2192/`, Python `r"\u2192"`, JSON fixtures): emit `"\\u2192"` (two backslashes) in the JSON. The 6 chars arrive verbatim.
+- **NEVER** emit `"\\u2192"` when you intend the character →. That is a literal escape, not a Unicode character.
+</unicode-content>

--- a/packages/coding-agent/src/prompts/tools/patch.md
+++ b/packages/coding-agent/src/prompts/tools/patch.md
@@ -50,6 +50,13 @@ Returns success/failure; on failure, error message indicates:
 - **NEVER** use edit to fix indentation, whitespace, or reformat code. Formatting is a single command run once at the end (`bun fmt`, `cargo fmt`, `prettier —write`, etc.)—not N individual edits. If you see inconsistent indentation after an edit, leave it; the formatter will fix all of it in one pass.
 </critical>
 
+<unicode-content>
+Your tool-call JSON is parsed before this tool sees `diff`, so `\uXXXX` decodes natively in `+` lines, ` ` context, and `op:create` payloads.
+- To match or add the **character** → (U+2192): emit `"\u2192"` (one backslash) in the JSON, or the literal → character.
+- To match or add the **literal 6-char escape sequence** `\u2192` (source code that already contains `\u2192` — JS regex `/\u2192/`, Python `r"\u2192"`, JSON fixtures): emit `"\\u2192"` (two backslashes) in the JSON. The 6 chars arrive verbatim.
+- **NEVER** emit `"\\u2192"` when you intend the character →. That is a literal escape, not a Unicode character.
+</unicode-content>
+
 <examples>
 # Create
 `edit {"path":"hello.txt","edits":[{"op":"create","diff":"Hello\n"}]}`

--- a/packages/coding-agent/src/prompts/tools/replace.md
+++ b/packages/coding-agent/src/prompts/tools/replace.md
@@ -15,6 +15,13 @@ Returns success/failure status. On success, file modified in place with replacem
 - You **MUST** read the file at least once in the conversation before editing. Tool errors if you attempt edit without reading file first.
 </critical>
 
+<unicode-content>
+Your tool-call JSON is parsed before this tool sees `old_text` / `new_text`, so `\uXXXX` decodes natively.
+- To match or write the **character** → (U+2192): emit `"\u2192"` (one backslash) in the JSON, or the literal → character. Both arrive as →.
+- To match or write the **literal 6-char escape sequence** `\u2192` (e.g. `old_text` for source code that already contains `\u2192`, or `new_text` for JS regex `/\u2192/`, Python `r"\u2192"`, JSON fixtures): emit `"\\u2192"` (two backslashes) in the JSON. The 6 chars arrive verbatim.
+- **NEVER** emit `"\\u2192"` when you intend the character →. That is a literal escape, not a Unicode character.
+</unicode-content>
+
 <bash-alternatives>
 Replace for content-addressed changes—you identify \_what* to change by its text.
 

--- a/packages/coding-agent/src/prompts/tools/write.md
+++ b/packages/coding-agent/src/prompts/tools/write.md
@@ -12,3 +12,10 @@ Creates or overwrites file at specified path.
 - You **MUST NOT** create documentation files (*.md, README) unless explicitly requested
 - You **MUST NOT** use emojis unless requested
 </critical>
+
+<unicode-content>
+Your tool-call JSON is parsed before this tool sees `content`, so `\uXXXX` decodes natively.
+- To write the **character** → (U+2192) on disk: emit `"\u2192"` (one backslash) in the JSON, or the literal `→` character. Both arrive at the tool as `→` and are written as 3 UTF-8 bytes.
+- To write the **literal 6-char escape sequence** `\u2192` on disk (JS regex `/\u2192/`, Python `r"\u2192"`, JSON fixtures, docs about Unicode): emit `"\\u2192"` (two backslashes) in the JSON. The parser delivers the 6 chars to the tool and we write them verbatim.
+- **NEVER** emit `"\\u2192"` (two backslashes) when you intend the character →. That writes the literal text `\u2192`, not the character.
+</unicode-content>


### PR DESCRIPTION
## Background

This replaces #889, which proposed runtime decoding of `\uXXXX` escape sequences in the edit/write pipeline. The Codex review on that PR ([inline comment on `normalize.ts:237`](https://github.com/can1357/oh-my-pi/pull/889#discussion_r-)) correctly identified that runtime decoding is unsound: it makes it **impossible** to write a single literal 6-char `\u2192` source-code sequence to disk, because every viable JSON tool argument either decodes to the character or ends up with extra backslashes.

| LLM JSON tool arg | Parsed string | After runtime decode | On disk |
|---|---|---|---|
| `"\\u2192"` (natural) | `\u2192` (6 chars) | `→` | `→` ❌ |
| `"\\\\u2192"` (escape attempt) | `\\u2192` (7 chars) | unchanged by lookbehind | `\\u2192` ❌ |

That breaks JS regex source (`/\u2192/`), Python raw strings (`r"\u2192"`), JSON fixtures, and any code that contains `\uXXXX` literally.

## Approach

Document the convention in tool prompts instead of decoding at runtime. JSON natively decodes `\uXXXX` already, so:

- **For the character `→`** — emit `"\u2192"` (one backslash) in the JSON, or the literal `→` character. Both arrive at the tool as `→`.
- **For the literal 6-char `\u2192`** (regex source, raw strings, fixtures) — emit `"\\u2192"` (two backslashes) so the JSON parser delivers the 6 chars verbatim.
- **NEVER** emit `"\\u2192"` (two backslashes) when you intend the character. That writes literal text, not a Unicode character.

Add a `<unicode-content>` section to four tool prompts spelling out both directions and the negative example:

- `write.md` (`content`)
- `replace.md` (`old_text` / `new_text`)
- `patch.md` (`diff` — `+` lines and `op:create` payloads)
- `hashline.md` (`content`)

## Files

```
packages/coding-agent/CHANGELOG.md                  | 3 +++
packages/coding-agent/src/prompts/tools/hashline.md | 7 +++++++
packages/coding-agent/src/prompts/tools/patch.md    | 7 +++++++
packages/coding-agent/src/prompts/tools/replace.md  | 7 +++++++
packages/coding-agent/src/prompts/tools/write.md    | 7 +++++++
5 files changed, 31 insertions(+)
```

## Why this is better than runtime decoding

- **No silent corruption of valid source code.** `/\u2192/` written to a `.ts` file stays as 6 chars; the tool's job is to write what JSON delivered, not to second-guess it.
- **No new failure mode.** Runtime decoding meant LLMs that already emitted characters correctly would now have a hidden transformation between their intent and the file.
- **Teaches the convention.** Anthropic-style tool descriptions are read attentively by the LLM. A clear "do this, not that" instruction trains future calls; a runtime decoder hides the rule.
- **Reversible.** If experience shows LLMs ignore the guidance and persistently double-escape, we can revisit. A documentation change is cheap to evolve.

## Verification

- `bun run format-prompts` clean (no formatting changes needed)
- All four prompts use the actual U+2192 character in prose where the character is intended, and the literal 6-char escape sequence in code spans where the literal text is intended (verified via `xxd`)
