### PR TITLE
feat(coding-agent/rpc): expose session continuation state

### DIFF
--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -11,6 +11,7 @@ import type { SessionStats } from "../../session/agent-session";
 import type { CompactionResult } from "../../session/compaction";
 import type {
 	RpcCommand,
+	RpcHandoffResult,
 	RpcHostToolCallRequest,
 	RpcHostToolCancelRequest,
 	RpcHostToolDefinition,
@@ -454,6 +455,14 @@ export class RpcClient {
 	 */
 	async getSessionStats(): Promise<SessionStats> {
 		const response = await this.#send({ type: "get_session_stats" });
+		return this.#getData(response);
+	}
+
+	/**
+	 * Hand off session context to a new session.
+	 */
+	async handoff(customInstructions?: string): Promise<RpcHandoffResult | null> {
+		const response = await this.#send({ type: "handoff", customInstructions });
 		return this.#getData(response);
 	}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -574,6 +574,7 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 						description: tool.description,
 						parameters: tool.parameters,
 					})),
+					contextUsage: session.getContextUsage(),
 				};
 				return success(id, "get_state", state);
 			}

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -741,6 +741,11 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 				return success(id, "set_session_name");
 			}
 
+			case "handoff": {
+				const result = await session.handoff(command.customInstructions);
+				return success(id, "handoff", result ? { savedPath: result.savedPath } : null);
+			}
+
 			// =================================================================
 			// Messages
 			// =================================================================

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -7,6 +7,7 @@
 import type { AgentMessage, AgentToolResult, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { Effort, ImageContent, Model } from "@oh-my-pi/pi-ai";
 import type { BashResult } from "../../exec/bash-executor";
+import type { ContextUsage } from "../../extensibility/extensions/types";
 import type { SessionStats } from "../../session/agent-session";
 import type { CompactionResult } from "../../session/compaction";
 import type { TodoPhase } from "../../tools/todo-write";
@@ -90,6 +91,8 @@ export interface RpcSessionState {
 	/** For session dump / export (plain-text parity with /dump). */
 	systemPrompt?: string;
 	dumpTools?: Array<{ name: string; description: string; parameters: unknown }>;
+	/** Current context window usage. Null tokens/percent when unknown (e.g. right after compaction). */
+	contextUsage?: ContextUsage;
 }
 
 export interface RpcHandoffResult {

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -63,6 +63,7 @@ export type RpcCommand =
 	| { id?: string; type: "get_branch_messages" }
 	| { id?: string; type: "get_last_assistant_text" }
 	| { id?: string; type: "set_session_name"; name: string }
+	| { id?: string; type: "handoff"; customInstructions?: string }
 
 	// Messages
 	| { id?: string; type: "get_messages" };
@@ -89,6 +90,10 @@ export interface RpcSessionState {
 	/** For session dump / export (plain-text parity with /dump). */
 	systemPrompt?: string;
 	dumpTools?: Array<{ name: string; description: string; parameters: unknown }>;
+}
+
+export interface RpcHandoffResult {
+	savedPath?: string;
 }
 
 // ============================================================================
@@ -180,6 +185,7 @@ export type RpcResponse =
 			data: { text: string | null };
 	  }
 	| { id?: string; type: "response"; command: "set_session_name"; success: true }
+	| { id?: string; type: "response"; command: "handoff"; success: true; data: RpcHandoffResult | null }
 
 	// Messages
 	| { id?: string; type: "response"; command: "get_messages"; success: true; data: { messages: AgentMessage[] } }

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4248,9 +4248,10 @@ export class AgentSession {
 			}
 
 			// Start a new session
+			const previousSessionFile = this.sessionFile;
 			await this.sessionManager.flush();
 			this.#asyncJobManager?.cancelAll();
-			await this.sessionManager.newSession();
+			await this.sessionManager.newSession(previousSessionFile ? { parentSession: previousSessionFile } : undefined);
 			this.agent.reset();
 			this.agent.sessionId = this.sessionManager.getSessionId();
 			this.#steeringMessages = [];
@@ -4262,6 +4263,7 @@ export class AgentSession {
 			// Inject the handoff document as a custom message
 			const handoffContent = `<handoff-context>\n${handoffText}\n</handoff-context>\n\nThe above is a handoff document from a previous session. Use this context to continue the work seamlessly.`;
 			this.sessionManager.appendCustomMessageEntry("handoff", handoffContent, true, undefined, "agent");
+			await this.sessionManager.ensureOnDisk();
 			let savedPath: string | undefined;
 			if (options?.autoTriggered && this.settings.get("compaction.handoffSaveToDisk")) {
 				const artifactsDir = this.sessionManager.getArtifactsDir();

--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -188,6 +188,72 @@ describe("AgentSession handoff", () => {
 		expect(events.filter(event => event.type === "auto_compaction_end")).toHaveLength(0);
 	});
 
+	it("persists handoff session immediately with previous session as parent", async () => {
+		const previousSessionFile = session.sessionFile;
+		if (!previousSessionFile) {
+			throw new Error("Expected previous session file");
+		}
+
+		const model = session.model;
+		if (!model) {
+			throw new Error("Expected model to be set");
+		}
+
+		const handoffText = "## Goal\nContinue from here";
+		const handoffAssistant: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: handoffText }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			stopReason: "stop",
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			timestamp: Date.now(),
+		};
+
+		vi.spyOn(session.agent, "prompt").mockImplementation(async () => {
+			session.agent.replaceMessages([handoffAssistant]);
+			session.agent.emitExternalEvent({ type: "message_end", message: handoffAssistant });
+			session.agent.emitExternalEvent({ type: "agent_end", messages: [handoffAssistant] });
+		});
+
+		const result = await session.handoff();
+		const handoffSessionFile = session.sessionFile;
+		if (!handoffSessionFile) {
+			throw new Error("Expected handoff session file");
+		}
+
+		type PersistedEntry = {
+			type?: string;
+			parentSession?: string;
+			customType?: string;
+			display?: boolean;
+		};
+		const handoffEntries = (await Bun.file(handoffSessionFile).text())
+			.trim()
+			.split("\n")
+			.map(line => JSON.parse(line) as PersistedEntry);
+
+		expect(result?.document).toBe(handoffText);
+		expect(handoffSessionFile).not.toBe(previousSessionFile);
+		expect(handoffEntries[0]).toMatchObject({ type: "session", parentSession: previousSessionFile });
+		expect(
+			handoffEntries.some(
+				entry => entry.type === "custom_message" && entry.customType === "handoff" && entry.display,
+			),
+		).toBe(true);
+
+		const previousSessionText = await Bun.file(previousSessionFile).text();
+		expect(previousSessionText).toContain('"text":"seed"');
+	});
+
 	it("does not run auto maintenance when strategy is off", async () => {
 		session.settings.set("compaction.strategy", "off");
 		session.settings.set("compaction.thresholdPercent", 1);


### PR DESCRIPTION
## What

Adds the first RPC/session-state slice needed for external clients to continue and inspect sessions:

- Persists newly-created handoff sessions immediately and links them to the previous session as parent.
- Adds a `handoff` RPC command that delegates to `AgentSession.handoff`.
- Exposes `contextUsage` in RPC `get_state` responses.
- Adds regression coverage for immediate handoff-session persistence.

## Why

External RPC clients need durable and inspectable session-continuation state without reaching into the in-process TUI.

This fixes a handoff persistence gap where a newly-created handoff session could exist only in memory until later assistant activity. It also lets RPC clients trigger handoff and render context-window status from `get_state`.

## Testing

Passed:

```bash
bun test test/agent-session-handoff.test.ts
bun run check:types
```

Failed, outside this PR slice:

```bash
bun check
```

`bun check` currently fails on repo-wide checks outside the changed files, including Rust formatting diffs under `crates/brush-core-vendored`. The PR-specific test and coding-agent typecheck pass.

---

- [ ] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)