### PR TITLE
fix(ai): preserve unsigned thinking blocks for DeepSeek V4 Anthropic endpoint

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1651,6 +1651,25 @@ function isZaiAnthropicEndpoint(model: Model<"anthropic-messages">): boolean {
 	} catch {
 		return false;
 	}
+
+	/**
+	 * Returns true for providers whose Anthropic-compatible endpoints do NOT
+	 * implement signature-based thinking-chain integrity (DeepSeek, Z.AI, etc.).
+	 * For these providers, unsigned thinking blocks must be preserved as
+	 * `type: "thinking"` instead of being degraded to text.
+	 */
+	function isNonSigningAnthropicEndpoint(model: Model<"anthropic-messages">): boolean {
+		// Known non-signing providers
+		if (model.provider === "zai" || model.provider === "deepseek") return true;
+		const baseUrl = model.baseUrl;
+		if (!baseUrl) return false;
+		try {
+			const hostname = new URL(baseUrl).hostname.toLowerCase();
+			return hostname === "api.deepseek.com" || hostname.endsWith(".deepseek.com");
+		} catch {
+			return false;
+		}
+	}
 }
 
 function buildToolResultBlock(model: Model<"anthropic-messages">, msg: ToolResultMessage): ContentBlockParam {
@@ -1752,10 +1771,18 @@ export function convertAnthropicMessages(
 					}
 					if (block.thinking.trim().length === 0) continue;
 					if (!block.thinkingSignature || block.thinkingSignature.trim().length === 0) {
-						blocks.push({
-							type: "text",
-							text: block.thinking.toWellFormed(),
-						});
+						if (isNonSigningAnthropicEndpoint(model)) {
+							blocks.push({
+								type: "thinking",
+								thinking: block.thinking.toWellFormed(),
+								signature: "",
+							});
+						} else {
+							blocks.push({
+								type: "text",
+								text: block.thinking.toWellFormed(),
+							});
+						}
 					} else {
 						blocks.push({
 							type: "thinking",


### PR DESCRIPTION
## Problem

DeepSeek V4's Anthropic-compatible API (`/anthropic/v1/messages`) requires thinking blocks to be passed back as `type: "thinking"` in multi-turn tool-call conversations. The current code converts all unsigned thinking blocks to `type: "text"`, which causes:

```
Expected 'thinking' or 'redacted_thinking', but found 'tool_use'
```

on follow-up requests that contain tool calls.

This happens because DeepSeek's Anthropic-compatible endpoint doesn't use cryptographic signatures on thinking blocks (unlike the real Anthropic API). When `hasSignedThinking` is `false` (all DeepSeek responses), every thinking block gets converted to text, breaking the thinking chain requirement.

## Fix

Change the non-signed thinking path to preserve thinking blocks as `type: "thinking"` with an empty `signature` string, instead of converting them to `type: "text"`.

Two locations in `convertAnthropicMessages`:

1. **Signed-path fallback**: When a message has at least one signed thinking block but this particular block has no signature — preserve as thinking
2. **Non-signed path**: When no blocks have signatures (DeepSeek, other non-Anthropic providers) — preserve as thinking

## Related

- [deepseek-ai/DeepSeek-V3#967](https://github.com/deepseek-ai/DeepSeek-V3/issues/967) — Upstream issue tracking DeepSeek's stricter tool_use/tool_result ordering requirements
- The v14.5.14 fix addressed the OpenAI-format path (`reasoning_content`) but not the Anthropic-format path