### PR TITLE
fix(ai/responses): support status_details.error and retry opaque failures

### DIFF
--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -546,7 +546,7 @@ export async function processResponsesStream<TApi extends Api>(
 		} else if (event.type === "error") {
 			throw new Error(`Error Code ${event.code}: ${event.message}` || "Unknown error");
 		} else if (event.type === "response.failed") {
-			const error = event.response?.error;
+			const error = event.response?.error ?? (event.response as any)?.status_details?.error;
 			const details = event.response?.incomplete_details;
 			const message = error
 				? `${error.code || "unknown"}: ${error.message || "no message"}`

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -540,6 +540,19 @@ export async function processResponsesStream<TApi extends Api>(
 			}
 			calculateCost(model, output.usage);
 			output.stopReason = mapOpenAIResponsesStopReason(response?.status);
+			if (response?.status === "failed" || response?.status === "cancelled") {
+				const error = response?.error ?? (response as any)?.status_details?.error;
+				const details = response?.incomplete_details;
+				const statusDetailsReason = (response as any)?.status_details?.reason;
+				const message = error
+					? `${error.code || "unknown"}: ${error.message || "no message"}`
+					: details?.reason
+						? `incomplete: ${details.reason}`
+						: typeof statusDetailsReason === "string" && statusDetailsReason.length > 0
+							? `status_details: ${statusDetailsReason}`
+							: "Unknown error (no error details in response)";
+				throw new Error(message);
+			}
 			if (output.content.some(block => block.type === "toolCall") && output.stopReason === "stop") {
 				output.stopReason = "toolUse";
 			}

--- a/packages/ai/test/azure-openai-responses-stream.test.ts
+++ b/packages/ai/test/azure-openai-responses-stream.test.ts
@@ -120,6 +120,30 @@ describe("azure openai responses streaming", () => {
 		expect(result.errorMessage).toContain("incomplete: max_output_tokens");
 	});
 
+	it("surfaces response.completed failed status_details errors", async () => {
+		global.fetch = vi.fn(async () =>
+			createSseResponse([
+				{
+					type: "response.completed",
+					response: {
+						status: "failed",
+						status_details: {
+							error: { code: "server_error", message: "backend exploded late" },
+						},
+					},
+				},
+			]),
+		) as unknown as typeof fetch;
+
+		const result = await streamAzureOpenAIResponses(
+			azureModel,
+			{ messages: [{ role: "user", content: "Say hello", timestamp: Date.now() }] },
+			{ apiKey: "test-key", azureBaseUrl: azureModel.baseUrl, azureApiVersion: "v1" },
+		).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toContain("server_error: backend exploded late");
+	});
 	it("preserves assistant message phase when rebuilding fallback replay history", async () => {
 		const payload = await captureAzurePayload({
 			messages: [

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5340,7 +5340,7 @@ export class AgentSession {
 		// service unavailable, network/connection/socket errors, fetch failed, terminated, retry delay exceeded
 		return (
 			isUnexpectedSocketCloseMessage(errorMessage) ||
-			/overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay|stream stall/i.test(
+			/overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay|stream stall|no error details in response/i.test(
 				errorMessage,
 			)
 		);


### PR DESCRIPTION
This PR fixes opaque "Unknown error (no error details in response)" failures encountered with newer Azure OpenAI models like gpt-5.5.

### Changes
1. Updates the  adapter to check  in  events (standard for newer OpenAI/Azure Responses API schema).
2. Adds the opaque error fallback string to the auto-retry regex to allow recovery from transient provider rejections.