### PR TITLE
fix(ai): preserve thinking blocks for non-signing Anthropic endpoints

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1653,6 +1653,25 @@ function isZaiAnthropicEndpoint(model: Model<"anthropic-messages">): boolean {
 	}
 }
 
+/**
+ * Returns true for providers whose Anthropic-compatible endpoints do NOT
+ * implement signature-based thinking-chain integrity (DeepSeek, Z.AI, etc.).
+ * For these providers, unsigned thinking blocks must be preserved as
+ * `type: "thinking"` instead of being degraded to text.
+ */
+function isNonSigningAnthropicEndpoint(model: Model<"anthropic-messages">): boolean {
+	// Known non-signing providers
+	if (model.provider === "zai" || model.provider === "deepseek") return true;
+	const baseUrl = model.baseUrl;
+	if (!baseUrl) return false;
+	try {
+		const hostname = new URL(baseUrl).hostname.toLowerCase();
+		return hostname === "api.deepseek.com" || hostname.endsWith(".deepseek.com");
+	} catch {
+		return false;
+	}
+}
+
 function buildToolResultBlock(model: Model<"anthropic-messages">, msg: ToolResultMessage): ContentBlockParam {
 	const block: ContentBlockParam = {
 		type: "tool_result",
@@ -1752,10 +1771,18 @@ export function convertAnthropicMessages(
 					}
 					if (block.thinking.trim().length === 0) continue;
 					if (!block.thinkingSignature || block.thinkingSignature.trim().length === 0) {
-						blocks.push({
-							type: "text",
-							text: block.thinking.toWellFormed(),
-						});
+						if (isNonSigningAnthropicEndpoint(model)) {
+							blocks.push({
+								type: "thinking",
+								thinking: block.thinking.toWellFormed(),
+								signature: "",
+							});
+						} else {
+							blocks.push({
+								type: "text",
+								text: block.thinking.toWellFormed(),
+							});
+						}
 					} else {
 						blocks.push({
 							type: "thinking",


### PR DESCRIPTION
## Problem

DeepSeek V4's Anthropic-compatible API (`/anthropic/v1/messages`) requires thinking blocks to be passed back as `type: "thinking"` in multi-turn tool-call conversations. The non-signed thinking path in `convertAnthropicMessages` was converting all unsigned thinking blocks to `type: "text"`, which caused:

```
Expected 'thinking' or 'redacted_thinking', but found 'tool_use'
```

on follow-up requests that contain tool calls.

This happens because DeepSeek's Anthropic-compatible endpoint doesn't use cryptographic signatures on thinking blocks. When `hasSignedThinking` is `false`, every thinking block gets converted to text, losing the thinking semantics.

## Fix

1. Add `isNonSigningAnthropicEndpoint()` to detect providers (DeepSeek by provider name + base URL, Z.AI) that don't implement signature-based thinking-chain integrity
2. In the non-signed thinking path only: for non-signing endpoints, preserve thinking blocks as `type: "thinking"` with empty `signature`; for Anthropic API, keep the original `type: "text"` conversion
3. The signed-path fallback is completely unchanged

## Scope

| Code path | Behavior |
|-----------|----------|
| Signed path (real Anthropic API) | Unchanged |
| Non-signed path, non-signing endpoint | Preserve as `type: "thinking"` |
| Non-signed path, Anthropic API | Unchanged (`type: "text"`) |

## Related

- deepseek-ai/DeepSeek-V3#967 — Upstream issue tracking tool_use/tool_result ordering
- The v14.5.14 fix addressed the OpenAI-format path (`reasoning_content`) but not the Anthropic-format path