### PR TITLE
Fix ExtensionUIContext.setEditorComponent in interactive mode

### DIFF
--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -68,7 +68,7 @@ export class ExtensionUiController {
 			},
 			setFooter: () => {},
 			setHeader: () => {},
-			setEditorComponent: () => {},
+			setEditorComponent: factory => this.ctx.setEditorComponent(factory),
 			getToolsExpanded: () => this.ctx.toolOutputExpanded,
 			setToolsExpanded: expanded => this.ctx.setToolsExpanded(expanded),
 		};

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -13,7 +13,7 @@ import {
 	modelsAreEqual,
 	type UsageReport,
 } from "@oh-my-pi/pi-ai";
-import type { Component, SlashCommand } from "@oh-my-pi/pi-tui";
+import type { Component, EditorComponent, EditorTheme, SlashCommand } from "@oh-my-pi/pi-tui";
 import {
 	Container,
 	clearRenderCache,
@@ -1206,11 +1206,66 @@ export class InteractiveMode implements InteractiveModeContext {
 	initializeHookRunner(uiContext: ExtensionUIContext, hasUI: boolean): void {
 		this.#extensionUiController.initializeHookRunner(uiContext, hasUI);
 	}
-
 	createBackgroundUiContext(): ExtensionUIContext {
 		return this.#extensionUiController.createBackgroundUiContext();
 	}
 
+	setEditorComponent(
+		factory: ((tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager) => EditorComponent) | undefined,
+	): void {
+		const previousEditor = this.editor;
+		const previousText = previousEditor.getText();
+		const nextComponent = factory
+			? factory(this.ui, getEditorTheme(), this.keybindings)
+			: new CustomEditor(getEditorTheme());
+
+		if (!this.#isCustomEditorCompatible(nextComponent)) {
+			this.showWarning("Custom editor components must implement CustomEditor-compatible interactive methods.");
+			return;
+		}
+		const nextEditor = nextComponent;
+		nextEditor.setUseTerminalCursor(this.ui.getShowHardwareCursor());
+		nextEditor.setAutocompleteMaxVisible(this.settings.get("autocompleteMaxVisible"));
+		nextEditor.onAutocompleteCancel = () => {
+			this.ui.requestRender(true);
+		};
+		nextEditor.onAutocompleteUpdate = () => {
+			this.ui.requestRender();
+		};
+		nextEditor.setMaxHeight(this.#computeEditorMaxHeight());
+		if (this.historyStorage) {
+			nextEditor.setHistoryStorage(this.historyStorage);
+		}
+		nextEditor.setText(previousText);
+
+		this.editorContainer.clear();
+		this.editor = nextEditor;
+		this.editorContainer.addChild(nextEditor);
+		this.ui.setFocus(nextEditor);
+
+		this.#inputController.setupKeyHandlers();
+		this.#inputController.setupEditorSubmitHandler();
+
+		void this.refreshSlashCommandState().catch(error => {
+			logger.warn("Failed to refresh slash command state for custom editor", { error: String(error) });
+		});
+
+		this.updateEditorBorderColor();
+		this.updateEditorTopBorder();
+		this.ui.requestRender();
+	}
+	#isCustomEditorCompatible(component: EditorComponent): component is CustomEditor {
+		const candidate = component as CustomEditor;
+		return (
+			typeof candidate.setUseTerminalCursor === "function" &&
+			typeof candidate.setAutocompleteMaxVisible === "function" &&
+			typeof candidate.setMaxHeight === "function" &&
+			typeof candidate.setHistoryStorage === "function" &&
+			typeof candidate.setActionKeys === "function" &&
+			typeof candidate.clearCustomKeyHandlers === "function" &&
+			typeof candidate.setCustomKeyHandler === "function"
+		);
+	}
 	// Event handling
 	async handleBackgroundEvent(event: AgentSessionEvent): Promise<void> {
 		await this.#eventController.handleBackgroundEvent(event);

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -1,6 +1,6 @@
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, ImageContent, Message, UsageReport } from "@oh-my-pi/pi-ai";
-import type { Component, Container, Loader, Spacer, Text, TUI } from "@oh-my-pi/pi-tui";
+import type { Component, Container, EditorComponent, EditorTheme, Loader, Spacer, Text, TUI } from "@oh-my-pi/pi-tui";
 import type { KeybindingsManager } from "../config/keybindings";
 import type { Settings } from "../config/settings";
 import type {
@@ -129,6 +129,9 @@ export interface InteractiveModeContext {
 	setToolUIContext(uiContext: ExtensionUIContext, hasUI: boolean): void;
 	initializeHookRunner(uiContext: ExtensionUIContext, hasUI: boolean): void;
 	createBackgroundUiContext(): ExtensionUIContext;
+	setEditorComponent(
+		factory: ((tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager) => EditorComponent) | undefined,
+	): void;
 
 	// Event handling
 	handleBackgroundEvent(event: AgentSessionEvent): Promise<void>;

--- a/packages/coding-agent/test/interactive-mode-editor-component.test.ts
+++ b/packages/coding-agent/test/interactive-mode-editor-component.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { _resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { Editor } from "@oh-my-pi/pi-tui";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { ModelRegistry } from "../src/config/model-registry";
+import { CustomEditor } from "../src/modes/components/custom-editor";
+import { InteractiveMode } from "../src/modes/interactive-mode";
+import { AgentSession } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
+import { SessionManager } from "../src/session/session-manager";
+
+class TestModalEditor extends CustomEditor {}
+
+describe("InteractiveMode.setEditorComponent", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+	let mode: InteractiveMode;
+
+	beforeAll(() => {
+		initTheme();
+	});
+
+	beforeEach(async () => {
+		_resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-editor-component-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) {
+			throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+		}
+
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model,
+					systemPrompt: "Test",
+					tools: [],
+					messages: [],
+				},
+			}),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		mode?.stop();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		_resetSettingsForTest();
+	});
+
+	it("replaces the editor and rebinds interactive handlers", () => {
+		mode.editor.setText("draft prompt");
+		const previousEditor = mode.editor;
+		const refreshSpy = vi.spyOn(mode, "refreshSlashCommandState").mockResolvedValue();
+
+		mode.setEditorComponent((_tui, editorTheme) => new TestModalEditor(editorTheme));
+
+		expect(mode.editor).toBeInstanceOf(TestModalEditor);
+		expect(mode.editor).not.toBe(previousEditor);
+		expect(mode.editor.getText()).toBe("draft prompt");
+		expect(mode.editor.onSubmit).toBeDefined();
+		expect(mode.editor.onEscape).toBeDefined();
+		expect(refreshSpy).toHaveBeenCalled();
+	});
+
+	it("keeps the current editor when factory returns a non-CustomEditor", () => {
+		const previousEditor = mode.editor;
+		const warningSpy = vi.spyOn(mode, "showWarning");
+
+		mode.setEditorComponent((_tui, editorTheme) => new Editor(editorTheme));
+
+		expect(mode.editor).toBe(previousEditor);
+		expect(warningSpy).toHaveBeenCalledWith(
+			"Custom editor components must implement CustomEditor-compatible interactive methods.",
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- wire `ExtensionUIContext.setEditorComponent` to interactive mode instead of no-op
- add `InteractiveMode.setEditorComponent(...)` to safely replace the prompt editor
- rebind input handlers/autocomplete after editor swap and preserve current draft text
- add regression tests for replacement and guard behavior

## Root cause
`pi-vim` relies on `session_start -> ctx.ui.setEditorComponent(...)`, but interactive mode's `ExtensionUiController` provided `setEditorComponent: () => {}`. The plugin loaded successfully, but editor replacement never occurred, so vim NORMAL/INSERT mode never activated.

## Verification
- `bun test packages/coding-agent/test/interactive-mode-editor-component.test.ts`
- `bun run check:types` (from `packages/coding-agent`)
- `bun x biome check packages/coding-agent/src/modes/types.ts packages/coding-agent/src/modes/interactive-mode.ts packages/coding-agent/src/modes/controllers/extension-ui-controller.ts packages/coding-agent/test/interactive-mode-editor-component.test.ts`
