### PR TITLE
fix(event-stream): use #failed flag and override fail() in AssistantMessageEventStream

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed unhandled promise rejection when `getApiKey` or any other async error occurs during `streamAssistantResponse`: agent loop IIFEs now catch and route errors through `EventStream.fail()`, which terminates the `for await` loop and lets `Agent#runLoop`'s catch block create a proper error assistant message instead of crashing
+
 ## [14.6.0] - 2026-05-02
 ### Fixed
 

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -49,7 +49,11 @@ export function agentLoop(
 			stream.push({ type: "message_end", message: prompt });
 		}
 
-		await runLoop(currentContext, newMessages, config, signal, stream, streamFn);
+		try {
+			await runLoop(currentContext, newMessages, config, signal, stream, streamFn);
+		} catch (err) {
+			stream.fail(err);
+		}
 	})();
 
 	return stream;
@@ -86,7 +90,11 @@ export function agentLoopContinue(
 		stream.push({ type: "agent_start" });
 		stream.push({ type: "turn_start" });
 
-		await runLoop(currentContext, newMessages, config, signal, stream, streamFn);
+		try {
+			await runLoop(currentContext, newMessages, config, signal, stream, streamFn);
+		} catch (err) {
+			stream.fail(err);
+		}
 	})();
 
 	return stream;

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `EventStream.fail(err)` method to terminate the async iterator with an error, enabling consumers to catch stream-level failures via `for await` without hanging
+
 ## [14.6.0] - 2026-05-02
 
 ### Added

--- a/packages/ai/src/utils/event-stream.ts
+++ b/packages/ai/src/utils/event-stream.ts
@@ -5,6 +5,7 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 	queue: T[] = [];
 	waiting: Array<{ resolve: (value: IteratorResult<T>) => void; reject: (err: unknown) => void }> = [];
 	done = false;
+	#failed = false;
 	#error: unknown = undefined;
 	finalResultPromise: Promise<R>;
 	resolveFinalResult!: (result: R) => void;
@@ -72,6 +73,7 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 	fail(err: unknown): void {
 		if (this.done) return;
 		this.done = true;
+		this.#failed = true;
 		this.#error = err;
 		this.rejectFinalResult(err);
 		while (this.waiting.length > 0) {
@@ -84,7 +86,7 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 		while (true) {
 			if (this.queue.length > 0) {
 				yield this.queue.shift()!;
-			} else if (this.#error !== undefined) {
+			} else if (this.#failed) {
 				throw this.#error;
 			} else if (this.done) {
 				return;
@@ -163,6 +165,15 @@ export class AssistantMessageEventStream extends EventStream<AssistantMessageEve
 			this.resolveFinalResult(result);
 		}
 		this.endWaiting();
+	}
+
+	override fail(err: unknown): void {
+		if (this.#flushTimer) {
+			clearTimeout(this.#flushTimer);
+			this.#flushTimer = undefined;
+		}
+		this.#deltaBuffer = [];
+		super.fail(err);
 	}
 
 	#scheduleFlush(): void {

--- a/packages/ai/src/utils/event-stream.ts
+++ b/packages/ai/src/utils/event-stream.ts
@@ -3,17 +3,23 @@ import type { AssistantMessage, AssistantMessageEvent } from "../types";
 // Generic event stream class for async iteration
 export class EventStream<T, R = T> implements AsyncIterable<T> {
 	queue: T[] = [];
-	waiting: ((value: IteratorResult<T>) => void)[] = [];
+	waiting: Array<{ resolve: (value: IteratorResult<T>) => void; reject: (err: unknown) => void }> = [];
 	done = false;
+	#error: unknown = undefined;
 	finalResultPromise: Promise<R>;
 	resolveFinalResult!: (result: R) => void;
+	rejectFinalResult!: (err: unknown) => void;
 	isComplete: (event: T) => boolean;
 	extractResult: (event: T) => R;
 
 	constructor(isComplete: (event: T) => boolean, extractResult: (event: T) => R) {
-		const { promise, resolve } = Promise.withResolvers<R>();
+		const { promise, resolve, reject } = Promise.withResolvers<R>();
+		// Prevent an unhandled rejection when fail() is called but nobody awaits result().
+		// Callers who do await result() still receive the rejection normally.
+		promise.catch(() => {});
 		this.finalResultPromise = promise;
 		this.resolveFinalResult = resolve;
+		this.rejectFinalResult = reject;
 		this.isComplete = isComplete;
 		this.extractResult = extractResult;
 	}
@@ -29,7 +35,7 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 		// Deliver to waiting consumer or queue it
 		const waiter = this.waiting.shift();
 		if (waiter) {
-			waiter({ value: event, done: false });
+			waiter.resolve({ value: event, done: false });
 		} else {
 			this.queue.push(event);
 		}
@@ -38,7 +44,7 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 	deliver(event: T): void {
 		const waiter = this.waiting.shift();
 		if (waiter) {
-			waiter({ value: event, done: false });
+			waiter.resolve({ value: event, done: false });
 		} else {
 			this.queue.push(event);
 		}
@@ -52,14 +58,25 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 		// Notify all waiting consumers that we're done
 		while (this.waiting.length > 0) {
 			const waiter = this.waiting.shift()!;
-			waiter({ value: undefined as any, done: true });
+			waiter.resolve({ value: undefined as any, done: true });
 		}
 	}
 
 	endWaiting(): void {
 		while (this.waiting.length > 0) {
 			const waiter = this.waiting.shift()!;
-			waiter({ value: undefined as any, done: true });
+			waiter.resolve({ value: undefined as any, done: true });
+		}
+	}
+
+	fail(err: unknown): void {
+		if (this.done) return;
+		this.done = true;
+		this.#error = err;
+		this.rejectFinalResult(err);
+		while (this.waiting.length > 0) {
+			const waiter = this.waiting.shift()!;
+			waiter.reject(err);
 		}
 	}
 
@@ -67,10 +84,14 @@ export class EventStream<T, R = T> implements AsyncIterable<T> {
 		while (true) {
 			if (this.queue.length > 0) {
 				yield this.queue.shift()!;
+			} else if (this.#error !== undefined) {
+				throw this.#error;
 			} else if (this.done) {
 				return;
 			} else {
-				const result = await new Promise<IteratorResult<T>>(resolve => this.waiting.push(resolve));
+				const result = await new Promise<IteratorResult<T>>((resolve, reject) =>
+					this.waiting.push({ resolve, reject }),
+				);
 				if (result.done) return;
 				yield result.value;
 			}


### PR DESCRIPTION
Two follow-up fixes to the event-stream unhandled-rejection PR.

**Issue 1 — `#error` sentinel was `undefined`**

The iterator checked `this.#error !== undefined` to decide whether to throw. Calling `fail(undefined)` (e.g. from `throw undefined` upstream) set `#error` to `undefined` but left the check false, so the iterator exited normally while `result()` still rejected — silent inconsistency. A consumer's `catch` block would never be entered.

Fix: add a dedicated `#failed: boolean` flag. The iterator now checks `this.#failed` regardless of the error value.

**Issue 2 — `AssistantMessageEventStream` did not override `fail()`**

When `fail()` was called while the 50 ms throttle timer was pending, the timer would fire ~50 ms later, call `#flushDeltas()` → `deliver()`, and enqueue stale delta events into a dead queue (no consumers left after the iterator threw). Harmless but wasteful — a dangling timer and unreachable queue growth.

Fix: override `fail()` in `AssistantMessageEventStream` to cancel the timer and clear the delta buffer before delegating to `super.fail()`.