### PR TITLE
fix(coding-agent): hash SSH control sockets by connection

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Fixed SSH ControlMaster socket paths to use OpenSSH's connection hash (`%C`) so connections to the same host with different users, ports, or jump hosts do not share a master session.
+
 
 ## [14.6.1] - 2026-05-02
 ### Changed

--- a/packages/coding-agent/src/ssh/connection-manager.ts
+++ b/packages/coding-agent/src/ssh/connection-manager.ts
@@ -25,7 +25,7 @@ export interface SSHHostInfo {
 }
 
 const CONTROL_DIR = getSshControlDir();
-const CONTROL_PATH = path.join(CONTROL_DIR, "%h.sock");
+const CONTROL_PATH = path.join(CONTROL_DIR, "%C.sock");
 const HOST_INFO_DIR = getRemoteHostDir();
 const HOST_INFO_VERSION = 2;
 


### PR DESCRIPTION
## What

Change SSH control socket to use %C instead of %h - %C is a hash of:
 
- %l = local hostname, including domain                                                                                                                
 - %h = remote hostname                                                                                                                                 
 - %p = remote port                                                                                                                                     
 - %r = remote username                                                                                                                                 
 - %j = ProxyJump contents   

So it is a more unique variable per ssh controlpath socket. 

## Why

Current %h causes very confusing behaviour when adding ssh hosts with multiple users on the same host, e.g.:

/ssh add userA-host1 --host host1 --user userA
/ssh add userB-host1 --host host1 --user userB

Once a ssh tool call is active to userA-host1, control path makes it %h so just 'host1'.

Any subsequent call to userB-host1 ends up connecting to the session userA-host1

## Testing

Simple ssh tool calls as demonstrated above.


---

- [X] `bun check` passes
- [X] Tested locally
- [X] CHANGELOG updated (if user-facing)
