### PR TITLE
fix: support standalone mcp.json/.mcp.json in /mcp reauth and config commands

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed `/mcp reauth`, `/mcp unauth`, `/mcp enable`, and `/mcp disable` not finding servers configured in standalone `mcp.json` or `.mcp.json` files in the project root
-
 ## [14.6.1] - 2026-05-02
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/mcp reauth`, `/mcp unauth`, `/mcp enable`, and `/mcp disable` not finding servers configured in standalone `mcp.json` or `.mcp.json` files in the project root
+
 ## [14.6.1] - 2026-05-02
 ### Changed
 

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -661,9 +661,13 @@ export class MCPCommandController {
 		// Check standalone fallback files (mcp.json, .mcp.json) in project root
 		const standalonePaths = [path.join(cwd, "mcp.json"), path.join(cwd, ".mcp.json")];
 		for (const fallbackPath of standalonePaths) {
-			const fallbackConfig = await readMCPConfigFile(fallbackPath);
-			if (fallbackConfig.mcpServers?.[name]) {
-				return { filePath: fallbackPath, scope: "project", config: fallbackConfig.mcpServers[name] };
+			try {
+				const fallbackConfig = await readMCPConfigFile(fallbackPath);
+				if (fallbackConfig.mcpServers?.[name]) {
+					return { filePath: fallbackPath, scope: "project", config: fallbackConfig.mcpServers[name] };
+				}
+			} catch {
+				// Malformed JSON in standalone file — skip and continue lookup
 			}
 		}
 		return null;

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -3,6 +3,7 @@
  *
  * Handles /mcp subcommands for managing MCP servers.
  */
+import * as path from "node:path";
 import { Spacer, Text } from "@oh-my-pi/pi-tui";
 import { getMCPConfigPath, getProjectDir } from "@oh-my-pi/pi-utils";
 import type { SourceMeta } from "../../capability/types";
@@ -655,6 +656,15 @@ export class MCPCommandController {
 		}
 		if (projectConfig.mcpServers?.[name]) {
 			return { filePath: projectPath, scope: "project", config: projectConfig.mcpServers[name] };
+		}
+
+		// Check standalone fallback files (mcp.json, .mcp.json) in project root
+		const standalonePaths = [path.join(cwd, "mcp.json"), path.join(cwd, ".mcp.json")];
+		for (const fallbackPath of standalonePaths) {
+			const fallbackConfig = await readMCPConfigFile(fallbackPath);
+			if (fallbackConfig.mcpServers?.[name]) {
+				return { filePath: fallbackPath, scope: "project", config: fallbackConfig.mcpServers[name] };
+			}
 		}
 		return null;
 	}


### PR DESCRIPTION
## What

Extend `#findConfiguredServer` to check standalone `mcp.json` and `.mcp.json` files in the project root, matching the discovery paths used by the `mcp-json` provider.

## Why

`/mcp list` discovers servers from standalone `mcp.json`/`.mcp.json` via the `mcp-json` discovery provider (priority 5). However, `/mcp reauth`, `/mcp unauth`, `/mcp enable`, and `/mcp disable` use `#findConfiguredServer`, which only checks `.omp/mcp.json` (project) and `~/.omp/agent/mcp.json` (user). This causes `Server "name" not found` errors for servers that are visible and connected but configured in standalone fallback files.

## Testing

- Verified that `readMCPConfigFile` returns an empty `{ mcpServers: {} }` for non-existent paths (no crash on missing fallback files)
- The fallback check only runs when the server is not found in the primary OMP-managed config files, preserving existing precedence

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)