### PR TITLE
fix extension dashboard toggles

### DIFF
--- a/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
@@ -27,15 +27,24 @@ import { theme } from "../../../modes/theme/theme";
 import { matchesAppInterrupt } from "../../../modes/utils/keybinding-matchers";
 import { ExtensionList } from "./extension-list";
 import { InspectorPanel } from "./inspector-panel";
-import { applyFilter, createInitialState, filterByProvider, refreshState, toggleProvider } from "./state-manager";
+import {
+	applyDisabledExtensionsToState,
+	applyFilter,
+	createInitialState,
+	filterByProvider,
+	refreshState,
+	toggleProvider,
+} from "./state-manager";
 import type { DashboardState } from "./types";
 
 export class ExtensionDashboard extends Container {
 	#state!: DashboardState;
 	#mainList!: ExtensionList;
 	#inspector!: InspectorPanel;
+	#refreshToken = 0;
 
 	onClose?: () => void;
+	onRequestRender?: () => void;
 
 	private constructor(
 		private readonly cwd: string,
@@ -181,16 +190,20 @@ export class ExtensionDashboard extends Container {
 			}
 		}
 
+		this.#applyDisabledExtensions(disabled);
 		void this.#refreshFromState();
 	}
 
 	async #refreshFromState(): Promise<void> {
+		const refreshToken = ++this.#refreshToken;
 		// Remember current tab ID before refresh
 		const currentTabId = this.#state.tabs[this.#state.activeTabIndex]?.id;
 
 		const sm = this.settings ?? Settings.instance;
 		const disabledIds = sm ? ((sm.get("disabledExtensions") as string[]) ?? []) : [];
-		this.#state = await refreshState(this.#state, this.cwd, disabledIds);
+		const nextState = await refreshState(this.#state, this.cwd, disabledIds);
+		if (refreshToken !== this.#refreshToken) return;
+		this.#state = nextState;
 
 		// Find the same tab in the new (re-sorted) list
 		if (currentTabId) {
@@ -208,6 +221,17 @@ export class ExtensionDashboard extends Container {
 		}
 
 		this.#buildLayout();
+		this.onRequestRender?.();
+	}
+
+	#applyDisabledExtensions(disabledIds: string[]): void {
+		this.#state = applyDisabledExtensionsToState(this.#state, disabledIds);
+		this.#mainList.setExtensions(this.#state.searchFiltered);
+		if (this.#state.selected) {
+			this.#inspector.setExtension(this.#state.selected);
+		}
+		this.#buildLayout();
+		this.onRequestRender?.();
 	}
 
 	#switchTab(direction: 1 | -1): void {

--- a/packages/coding-agent/src/modes/components/extensions/state-manager.ts
+++ b/packages/coding-agent/src/modes/components/extensions/state-manager.ts
@@ -510,6 +510,37 @@ export function filterByProvider(extensions: Extension[], providerId: string): E
 }
 
 /**
+ * Apply setting-backed item disable overrides to an existing dashboard state.
+ * This gives the UI immediate feedback while the full capability refresh runs.
+ */
+export function applyDisabledExtensionsToState(state: DashboardState, disabledIds: string[]): DashboardState {
+	const disabled = new Set(disabledIds);
+	const updateExtension = (ext: Extension): Extension => {
+		if (disabled.has(ext.id)) {
+			if (ext.state === "disabled" && ext.disabledReason === "item-disabled") return ext;
+			return { ...ext, state: "disabled", disabledReason: "item-disabled" };
+		}
+
+		if (ext.state !== "disabled" || ext.disabledReason !== "item-disabled") return ext;
+		if (!isProviderEnabled(ext.source.provider)) {
+			return { ...ext, state: "disabled", disabledReason: "provider-disabled" };
+		}
+
+		const enabled: Extension = { ...ext, state: "active" };
+		delete enabled.disabledReason;
+		return enabled;
+	};
+
+	return {
+		...state,
+		extensions: state.extensions.map(updateExtension),
+		tabFiltered: state.tabFiltered.map(updateExtension),
+		searchFiltered: state.searchFiltered.map(updateExtension),
+		selected: state.selected ? updateExtension(state.selected) : null,
+	};
+}
+
+/**
  * Create initial dashboard state.
  */
 export async function createInitialState(cwd?: string, disabledIds?: string[]): Promise<DashboardState> {

--- a/packages/coding-agent/src/modes/components/extensions/state-manager.ts
+++ b/packages/coding-agent/src/modes/components/extensions/state-manager.ts
@@ -509,6 +509,11 @@ export function filterByProvider(extensions: Extension[], providerId: string): E
 	return extensions.filter(ext => ext.source.provider === providerId);
 }
 
+function isShadowedExtension(ext: Extension): boolean {
+	if (ext.shadowedBy) return true;
+	return Boolean((ext.raw as { _shadowed?: boolean } | null | undefined)?._shadowed);
+}
+
 /**
  * Apply setting-backed item disable overrides to an existing dashboard state.
  * This gives the UI immediate feedback while the full capability refresh runs.
@@ -524,6 +529,11 @@ export function applyDisabledExtensionsToState(state: DashboardState, disabledId
 		if (ext.state !== "disabled" || ext.disabledReason !== "item-disabled") return ext;
 		if (!isProviderEnabled(ext.source.provider)) {
 			return { ...ext, state: "disabled", disabledReason: "provider-disabled" };
+		}
+
+		if (isShadowedExtension(ext)) {
+			const shadowed: Extension = { ...ext, state: "shadowed", disabledReason: "shadowed" };
+			return shadowed;
 		}
 
 		const enabled: Extension = { ...ext, state: "active" };

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -182,6 +182,9 @@ export class SelectorController {
 				done();
 				this.ctx.ui.requestRender();
 			};
+			dashboard.onRequestRender = () => {
+				this.ctx.ui.requestRender();
+			};
 			return { component: dashboard, focus: dashboard };
 		});
 	}

--- a/packages/coding-agent/test/extension-dashboard-state.test.ts
+++ b/packages/coding-agent/test/extension-dashboard-state.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test, vi } from "bun:test";
+import { applyDisabledExtensionsToState } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/state-manager";
+import type { DashboardState, Extension } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/types";
+
+vi.mock("@oh-my-pi/pi-coding-agent/discovery", () => ({
+	disableProvider: vi.fn(),
+	enableProvider: vi.fn(),
+	getAllProvidersInfo: vi.fn(() => []),
+	isProviderEnabled: vi.fn(() => true),
+	loadCapability: vi.fn(),
+}));
+
+function extension(overrides: Partial<Extension> & Pick<Extension, "id">): Extension {
+	return {
+		kind: "skill",
+		name: overrides.id.replace(/^skill:/, ""),
+		displayName: overrides.id.replace(/^skill:/, ""),
+		path: `/tmp/${overrides.id}`,
+		source: { provider: "native", providerName: "Native", level: "native" },
+		state: "active",
+		raw: {},
+		...overrides,
+	};
+}
+
+function dashboardState(extensions: Extension[], selected: Extension | null = extensions[0] ?? null): DashboardState {
+	return {
+		tabs: [{ id: "all", label: "ALL", enabled: true, count: extensions.length }],
+		activeTabIndex: 0,
+		extensions,
+		tabFiltered: extensions,
+		searchFiltered: extensions,
+		searchQuery: "",
+		listIndex: 0,
+		scrollOffset: 0,
+		selected,
+	};
+}
+
+describe("applyDisabledExtensionsToState", () => {
+	test("immediately applies item-disabled state to every visible dashboard slice", () => {
+		const selected = extension({ id: "skill:alpha" });
+		const state = dashboardState([selected, extension({ id: "skill:beta" })], selected);
+
+		const next = applyDisabledExtensionsToState(state, ["skill:alpha"]);
+
+		expect(next.extensions[0]).toMatchObject({
+			id: "skill:alpha",
+			state: "disabled",
+			disabledReason: "item-disabled",
+		});
+		expect(next.tabFiltered[0]).toMatchObject({
+			id: "skill:alpha",
+			state: "disabled",
+			disabledReason: "item-disabled",
+		});
+		expect(next.searchFiltered[0]).toMatchObject({
+			id: "skill:alpha",
+			state: "disabled",
+			disabledReason: "item-disabled",
+		});
+		expect(next.selected).toMatchObject({ id: "skill:alpha", state: "disabled", disabledReason: "item-disabled" });
+		expect(next.extensions[1]).toMatchObject({ id: "skill:beta", state: "active" });
+	});
+
+	test("restores a previously item-disabled shadowed extension as shadowed", () => {
+		const shadowed = extension({
+			id: "skill:shadowed",
+			state: "disabled",
+			disabledReason: "item-disabled",
+			shadowedBy: "skill:shadowing",
+		});
+		const state = dashboardState([shadowed], shadowed);
+
+		const next = applyDisabledExtensionsToState(state, []);
+
+		expect(next.extensions[0]).toMatchObject({
+			id: "skill:shadowed",
+			state: "shadowed",
+			disabledReason: "shadowed",
+			shadowedBy: "skill:shadowing",
+		});
+		expect(next.selected).toMatchObject({ id: "skill:shadowed", state: "shadowed", disabledReason: "shadowed" });
+	});
+});


### PR DESCRIPTION
The extension toggle bug was caused by the dashboard persisting the new disabledExtensions setting but continuing to render from the previously loaded dashboard state until the async capability refresh completed. Pressing Space could briefly make the selected extension look disabled, but navigating the list, switching providers, or closing and reopening the panel rebuilt the UI from stale extension objects that still had state: "active", so the indicator flipped back to green even though the setting had changed. This fix applies the updated disabled-extension set to the in-memory dashboard state immediately, then still runs the full capability refresh afterward so provider state, shadowing, and discovery results remain accurate. It also guards against stale async refresh completions and requests a render once refreshes finish, keeping the toggle state stable across navigation and panel reopen.