### PR TITLE
feat(coding-agent/slash-commands): add /retry command

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5983,6 +5983,32 @@ export class AgentSession {
 	setAutoRetryEnabled(enabled: boolean): void {
 		this.settings.set("retry.enabled", enabled);
 	}
+	/**
+	 * Manually retry the last failed assistant turn.
+	 * Removes the error message from agent state and re-attempts with a fresh retry budget.
+	 * @returns true if retry was initiated, false if no failed turn to retry or agent is busy
+	 */
+	async retry(): Promise<boolean> {
+		if (this.isStreaming || this.isCompacting || this.isRetrying) return false;
+
+		const messages = this.agent.state.messages;
+		const lastMsg = messages[messages.length - 1];
+		if (lastMsg?.role !== "assistant") return false;
+
+		const assistantMsg = lastMsg as AssistantMessage;
+		if (assistantMsg.stopReason !== "error" && assistantMsg.stopReason !== "aborted") return false;
+
+		// Remove the failed/aborted assistant message (same as auto-retry does before re-attempting)
+		this.agent.replaceMessages(messages.slice(0, -1));
+
+		// Reset retry budget for a fresh attempt
+		this.#retryAttempt = 0;
+
+		// Re-attempt the turn
+		this.#scheduleAgentContinue({ delayMs: 1 });
+
+		return true;
+	}
 
 	// =========================================================================
 	// Bash Execution

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -572,7 +572,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 			await runtime.ctx.handleBtwCommand(question);
 		},
 	},
- 	{
+	{
 		name: "retry",
 		description: "Retry the last failed agent turn",
 		handle: async (_command, runtime) => {

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -572,6 +572,17 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<BuiltinSlashCommandSpec> = [
 			await runtime.ctx.handleBtwCommand(question);
 		},
 	},
+ 	{
+		name: "retry",
+		description: "Retry the last failed agent turn",
+		handle: async (_command, runtime) => {
+			const didRetry = await runtime.ctx.session.retry();
+			if (!didRetry) {
+				runtime.ctx.showStatus("Nothing to retry");
+			}
+			runtime.ctx.editor.setText("");
+		},
+	},
 	{
 		name: "background",
 		aliases: ["bg"],

--- a/packages/coding-agent/test/agent-session-manual-retry.test.ts
+++ b/packages/coding-agent/test/agent-session-manual-retry.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { type AssistantMessage, getBundledModel, type Model } from "@oh-my-pi/pi-ai";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+class MockAssistantStream extends AssistantMessageEventStream {}
+
+function createAssistantMessage(
+	model: Model,
+	options: { text?: string; stopReason: "stop" | "error" | "aborted"; errorMessage?: string },
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content: options.text ? [{ type: "text", text: options.text }] : [],
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: options.stopReason,
+		errorMessage: options.errorMessage,
+		timestamp: Date.now(),
+	};
+}
+
+function lastAgentMessage(session: AgentSession): AssistantMessage {
+	const message = session.agent.state.messages.at(-1);
+	if (!message || message.role !== "assistant") {
+		throw new Error("Expected trailing assistant message");
+	}
+	return message as AssistantMessage;
+}
+
+describe("AgentSession manual retry", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession | undefined;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-manual-retry-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+	});
+
+	afterEach(async () => {
+		if (session) {
+			await session.dispose();
+			session = undefined;
+		}
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	it("removes the failed assistant turn and continues with a fresh attempt", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) {
+			throw new Error("Expected bundled Anthropic test model to exist");
+		}
+
+		let streamCalls = 0;
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: requestedModel => {
+				streamCalls += 1;
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					if (streamCalls === 1) {
+						const message = createAssistantMessage(requestedModel, {
+							stopReason: "error",
+							errorMessage: "manual retry test failure",
+						});
+						stream.push({ type: "start", partial: message });
+						stream.push({ type: "error", reason: "error", error: message });
+						return;
+					}
+
+					const message = createAssistantMessage(requestedModel, {
+						text: "recovered after manual retry",
+						stopReason: "stop",
+					});
+					stream.push({
+						type: "start",
+						partial: createAssistantMessage(requestedModel, { text: "", stopReason: "stop" }),
+					});
+					stream.push({ type: "done", reason: "stop", message });
+				});
+				return stream;
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false, "retry.enabled": false }),
+			modelRegistry: new ModelRegistry(authStorage),
+		});
+		session.subscribe(() => {});
+
+		await session.prompt("fail once");
+		await session.waitForIdle();
+		expect(lastAgentMessage(session).stopReason).toBe("error");
+
+		await expect(session.retry()).resolves.toBe(true);
+		await session.waitForIdle();
+
+		expect(streamCalls).toBe(2);
+		expect(lastAgentMessage(session).stopReason).toBe("stop");
+		expect(lastAgentMessage(session).content).toContainEqual({ type: "text", text: "recovered after manual retry" });
+	});
+
+	it("returns false when the trailing assistant turn succeeded", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) {
+			throw new Error("Expected bundled Anthropic test model to exist");
+		}
+
+		let streamCalls = 0;
+		const agent = new Agent({
+			getApiKey: provider => `${provider}-test-key`,
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+			streamFn: requestedModel => {
+				streamCalls += 1;
+				const stream = new MockAssistantStream();
+				queueMicrotask(() => {
+					const message = createAssistantMessage(requestedModel, { text: "already done", stopReason: "stop" });
+					stream.push({
+						type: "start",
+						partial: createAssistantMessage(requestedModel, { text: "", stopReason: "stop" }),
+					});
+					stream.push({ type: "done", reason: "stop", message });
+				});
+				return stream;
+			},
+		});
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "compaction.enabled": false }),
+			modelRegistry: new ModelRegistry(authStorage),
+		});
+		session.subscribe(() => {});
+
+		await session.prompt("succeed");
+		await session.waitForIdle();
+
+		await expect(session.retry()).resolves.toBe(false);
+		expect(streamCalls).toBe(1);
+		expect(lastAgentMessage(session).content).toContainEqual({ type: "text", text: "already done" });
+	});
+});

--- a/packages/coding-agent/test/slash-commands/retry.test.ts
+++ b/packages/coding-agent/test/slash-commands/retry.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { executeBuiltinSlashCommand } from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+
+function createRuntime(didRetry: boolean) {
+	const retry = vi.fn(async () => didRetry);
+	const showStatus = vi.fn();
+	const setText = vi.fn();
+	return {
+		retry,
+		showStatus,
+		setText,
+		runtime: {
+			ctx: {
+				session: { retry } as unknown as InteractiveModeContext["session"],
+				editor: { setText } as unknown as InteractiveModeContext["editor"],
+				showStatus,
+			} as unknown as InteractiveModeContext,
+			handleBackgroundCommand: () => {},
+		},
+	};
+}
+
+describe("/retry slash command", () => {
+	it("clears the editor after starting a retry", async () => {
+		const harness = createRuntime(true);
+
+		const handled = await executeBuiltinSlashCommand("/retry", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.retry).toHaveBeenCalledTimes(1);
+		expect(harness.showStatus).not.toHaveBeenCalled();
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("reports when there is no failed turn to retry", async () => {
+		const harness = createRuntime(false);
+
+		const handled = await executeBuiltinSlashCommand("/retry", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.retry).toHaveBeenCalledTimes(1);
+		expect(harness.showStatus).toHaveBeenCalledWith("Nothing to retry");
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+});


### PR DESCRIPTION
## Summary
- Adds a `/retry` slash command that manually re-attempts the last failed or aborted assistant turn.
- Implements `AgentSession.retry()`: removes the failed assistant message, resets the retry budget, and reschedules the agent to continue.
- No-ops (with a "Nothing to retry" status) when the agent is busy or the last message isn't a failed/aborted assistant turn.

## Motivation
Auto-retry handles transient failures during a turn, but once the budget is exhausted (or a turn is aborted) there was no first-class way to ask the agent to try again without manually editing state. `/retry` gives users a one-shot escape hatch with a fresh retry budget.

## Behavior
- Guards against re-entry while `isStreaming`, `isCompacting`, or `isRetrying`.
- Only acts on a trailing assistant message whose `stopReason` is `"error"` or `"aborted"`.
- Mirrors the auto-retry path: drops the failed message via `replaceMessages`, resets `#retryAttempt`, then schedules a continue.