### PR TITLE
fix(ai): recover stale Codex previous_response_id

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI Codex websocket continuations to retry with full context when `previous_response_id` expires server-side instead of surfacing `previous_response_not_found`.
+
 ## [14.6.2] - 2026-05-03
 ### Added
 

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -1221,6 +1221,9 @@ async function recoverCodexStreamError(
 	if (await tryReconnectCodexWebSocketOnConnectionLimit(context, runtime, error)) {
 		return true;
 	}
+	if (await tryRecoverCodexPreviousResponseNotFound(context, runtime, error)) {
+		return true;
+	}
 	if (await tryReplayWebsocketFailureOverSse(context, runtime, error)) {
 		return true;
 	}
@@ -1275,6 +1278,44 @@ async function tryReconnectCodexWebSocketOnConnectionLimit(
 
 	// No content emitted yet — reconnect over websocket.
 	runtime.websocketStreamRetries += 1;
+	await reopenCodexWebSocketRuntimeStream(context, runtime, websocketState);
+	return true;
+}
+
+function isCodexPreviousResponseNotFound(error: unknown): boolean {
+	return error instanceof CodexProviderStreamError && error.code === "previous_response_not_found";
+}
+
+async function tryRecoverCodexPreviousResponseNotFound(
+	context: CodexStreamProcessingContext,
+	runtime: CodexStreamRuntime,
+	error: unknown,
+): Promise<boolean> {
+	const websocketState = context.requestContext.websocketState;
+	if (
+		!isCodexPreviousResponseNotFound(error) ||
+		!websocketState ||
+		runtime.transport !== "websocket" ||
+		context.output.content.length > 0 ||
+		context.options?.signal?.aborted ||
+		runtime.providerRetryAttempt >= CODEX_MAX_RETRIES
+	) {
+		return false;
+	}
+
+	runtime.providerRetryAttempt += 1;
+	resetCodexWebSocketAppendState(websocketState);
+	resetCodexSessionMetadata(websocketState);
+	runtime.currentItem = null;
+	runtime.currentBlock = null;
+	runtime.sawTerminalEvent = false;
+	runtime.nativeOutputItems.length = 0;
+	resetOutputState(context.output);
+	context.firstTokenTime = undefined;
+
+	logCodexDebug("codex previous_response_id expired; retrying with full context", {
+		retry: runtime.providerRetryAttempt,
+	});
 	await reopenCodexWebSocketRuntimeStream(context, runtime, websocketState);
 	return true;
 }

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -1416,6 +1416,114 @@ describe("openai-codex streaming", () => {
 		});
 	});
 
+	it("retries websocket continuations with full context when previous_response_id expires", async () => {
+		const tempDir = TempDir.createSync("@pi-codex-stream-");
+		setAgentDir(tempDir.path());
+		const token = createCodexTestToken();
+		const sentRequests: Array<Record<string, unknown>> = [];
+		const fetchMock = vi.fn(async () => {
+			throw new Error("SSE fallback should not be called");
+		});
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		class PreviousResponseMissingWebSocket extends MockWebSocket {
+			constructor(url: string, options?: { headers?: WsHeaders }) {
+				super(url, options);
+				this.scheduleOpen();
+			}
+
+			send(data: string): void {
+				const request = JSON.parse(data) as Record<string, unknown>;
+				sentRequests.push(request);
+				const requestIndex = sentRequests.length;
+
+				if (requestIndex === 1) {
+					this.emitCodexResponse({
+						messageId: "msg_1",
+						responseId: "resp_1",
+						text: "First answer",
+						terminalType: "response.completed",
+						includeCreated: true,
+					});
+					return;
+				}
+
+				if (requestIndex === 2) {
+					expect(request.previous_response_id).toBe("resp_1");
+					this.sendJson({
+						type: "error",
+						code: "previous_response_not_found",
+						message: "Previous response with id 'resp_1' not found.",
+					});
+					return;
+				}
+
+				if (requestIndex === 3) {
+					expect(request.previous_response_id).toBeUndefined();
+					this.emitCodexResponse({
+						messageId: "msg_3",
+						responseId: "resp_3",
+						text: "Second answer",
+						terminalType: "response.completed",
+						includeCreated: true,
+					});
+					return;
+				}
+
+				throw new Error(`Unexpected websocket request index: ${requestIndex}`);
+			}
+		}
+
+		global.WebSocket = PreviousResponseMissingWebSocket as unknown as typeof WebSocket;
+		const model = createCodexTestModel("https://chatgpt.com/backend-api");
+		const providerSessionState = new Map<string, ProviderSessionState>();
+		const firstContext: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [{ role: "user", content: "First question", timestamp: Date.now() }],
+		};
+		const firstResponse = await streamOpenAICodexResponses(model, firstContext, {
+			apiKey: token,
+			sessionId: "ws-expired-previous-response-session",
+			providerSessionState,
+		}).result();
+		const secondContext: Context = {
+			systemPrompt: "You are a helpful assistant.",
+			messages: [
+				...firstContext.messages,
+				firstResponse,
+				{ role: "user", content: "Second question", timestamp: Date.now() + 1 },
+			],
+		};
+
+		const secondResponse = await streamOpenAICodexResponses(model, secondContext, {
+			apiKey: token,
+			sessionId: "ws-expired-previous-response-session",
+			providerSessionState,
+		}).result();
+
+		expect(secondResponse.stopReason).toBe("stop");
+		expect(JSON.stringify(secondResponse.content)).toContain("Second answer");
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(sentRequests).toHaveLength(3);
+		expect(sentRequests[2]?.prompt_cache_key).toBe("ws-expired-previous-response-session");
+		const retryInput = sentRequests[2]?.input;
+		expect(Array.isArray(retryInput)).toBe(true);
+		expect(JSON.stringify(retryInput)).toContain("First question");
+		expect(JSON.stringify(retryInput)).toContain("Second question");
+
+		const stats = getOpenAICodexWebSocketDebugStats(model, {
+			sessionId: "ws-expired-previous-response-session",
+			providerSessionState,
+		});
+		expect(stats).toEqual({
+			fullContextRequests: 2,
+			deltaRequests: 1,
+			lastInputItems: (retryInput as unknown[]).length,
+			lastDeltaInputItems: undefined,
+			lastPreviousResponseId: undefined,
+		});
+	});
+
 	it("uses low Codex text verbosity by default while preserving explicit overrides", async () => {
 		const tempDir = TempDir.createSync("@pi-codex-verbosity-");
 		setAgentDir(tempDir.path());


### PR DESCRIPTION
## Summary

- recover Codex websocket continuations when the cached `previous_response_id` expires server-side
- clear append/session metadata and retry the current turn with full context before any output has been emitted
- add regression coverage for the websocket delta -> `previous_response_not_found` -> full-context retry path

Fixes #925

## Verification

```bash
bun test packages/ai/test/openai-codex-stream.test.ts -t "websocket continuation"
```

```text
2 pass
28 filtered out
0 fail
```

Also ran:

```bash
bun run check
```

Biome passed. Type check is currently blocked in this checkout by missing workspace/dependency modules after pulling latest:

- `@aws-sdk/credential-provider-node`
- `proxy-agent`
- `@oh-my-pi/pi-natives`
