### PR TITLE
fix(win): use path.resolve instead of realpathSync for project path identity

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -50,6 +50,12 @@ import type { LspStartupServerInfo } from "./tools";
 import { getChangelogPath, getNewEntries, parseChangelog } from "./utils/changelog";
 import type { EventBus } from "./utils/event-bus";
 
+// realpathSync.native delegates to GetFinalPathNameByHandle on Windows, which correctly
+// follows NTFS junction reparse points. The JS-impl realpathSync fails with ENOENT on junctions.
+const resolveRealPath = (p: string): string => {
+  try { return realpathSync.native(p); } catch { return path.resolve(p); }
+};
+
 async function checkForNewVersion(currentVersion: string): Promise<string | undefined> {
 	if (!settings.get("startup.checkUpdate")) {
 		return;
@@ -220,7 +226,7 @@ function normalizePathForComparison(value: string): string {
 	const resolved = path.resolve(value);
 	let realPath = resolved;
 	try {
-		realPath = realpathSync(resolved);
+		realPath = resolveRealPath(resolved);
 	} catch {}
 	return process.platform === "win32" ? realPath.toLowerCase() : realPath;
 }
@@ -354,7 +360,7 @@ async function maybeAutoChdir(parsed: Args): Promise<void> {
 	}
 
 	const normalizePath = (value: string) => {
-		const resolved = realpathSync(path.resolve(value));
+		const resolved = resolveRealPath(path.resolve(value));
 		return process.platform === "win32" ? resolved.toLowerCase() : resolved;
 	};
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -5,7 +5,6 @@
  * createAgentSession() options. The SDK does the heavy lifting.
  */
 
-import { realpathSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -50,11 +49,11 @@ import type { LspStartupServerInfo } from "./tools";
 import { getChangelogPath, getNewEntries, parseChangelog } from "./utils/changelog";
 import type { EventBus } from "./utils/event-bus";
 
-// realpathSync.native delegates to GetFinalPathNameByHandle on Windows, which correctly
-// follows NTFS junction reparse points. The JS-impl realpathSync fails with ENOENT on junctions.
-const resolveRealPath = (p: string): string => {
-  try { return realpathSync.native(p); } catch { return path.resolve(p); }
-};
+// Project paths are normalized with path.resolve only — symlinks are NOT followed.
+// Following symlinks (realpathSync) breaks session matching when the user navigates
+// via a symlink: the session is saved with the symlink path but looked up at the real path.
+// path.resolve handles ./.. normalization and is sufficient for project identity.
+const resolveRealPath = (p: string): string => path.resolve(p);
 
 async function checkForNewVersion(currentVersion: string): Promise<string | undefined> {
 	if (!settings.get("startup.checkUpdate")) {

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -47,13 +47,11 @@ function standardizeMacOSPath(p: string): string {
 	return p;
 }
 
+// path.resolve is used instead of realpathSync to preserve symlink paths.
+// Following symlinks breaks session matching: a project accessed via a symlink
+// would encode to a different session dir name than the one sessions were saved under.
 export function resolveEquivalentPath(inputPath: string): string {
-	const resolvedPath = path.resolve(inputPath);
-	try {
-		return fs.realpathSync(resolvedPath);
-	} catch {
-		return resolvedPath;
-	}
+	return path.resolve(inputPath);
 }
 
 export function normalizePathForComparison(inputPath: string): string {


### PR DESCRIPTION
## Problem

On Windows, when a project directory is accessed via an **NTFS directory symlink**, `omp -r` returns **"No sessions found"** even when sessions exist.

## Root Cause

`fs.realpathSync` follows symlinks in two callsites used for path normalization:

- `packages/utils/src/dirs.ts` — `resolveEquivalentPath` (critical: used by `getDefaultSessionDirName` to compute the session dir name)
- `packages/coding-agent/src/main.ts` — `resolveRealPath`

When CWD is a symlink, `realpathSync` resolves it to the real path. Sessions are saved under the symlink path; OMP looks them up under the real path → mismatch → no sessions found.

## Fix

Replace `realpathSync` with `path.resolve`. Project identity should be the path the user navigates to, not the filesystem target.

```typescript
// packages/utils/src/dirs.ts
export function resolveEquivalentPath(inputPath: string): string {
  return path.resolve(inputPath);
}
```

Fixes issue #935.