### PR TITLE
fix(ai): use VLLM max_model_len for context window

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed VLLM model discovery to use `max_model_len` as the context window when the endpoint reports it.
+
 ## [14.7.0] - 2026-05-04
 ### Breaking Changes
 

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -1407,8 +1407,11 @@ export function vllmModelManagerOptions(config?: VllmModelManagerConfig): ModelM
 				baseUrl,
 				apiKey,
 				mapModel: (entry, defaults) => {
-					const reference = references.get(defaults.id);
-					return mapWithBundledReference(entry, defaults, reference);
+					const model = mapWithBundledReference(entry, defaults, references.get(defaults.id));
+					return {
+						...model,
+						contextWindow: toPositiveNumber(entry.max_model_len, model.contextWindow),
+					};
 				},
 			}),
 	};


### PR DESCRIPTION
## What

Use max_model_len to set the models correct context size

## Why

VLLM exposes max_model_len which is the configured context window length for the active model. Using this saves having to configure it for each model and prevents fallback to the default when exposed.

## Testing

Confirmed locally via DeepSeek v4 at 512k and Qwen3 27B at 256k

---

- [X] `bun check` passes
- [X] Tested locally
- [X] CHANGELOG updated (if user-facing)
