### PR TITLE
Fix sync slash autocomplete submission

### DIFF
--- a/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
+++ b/packages/coding-agent/src/modes/prompt-action-autocomplete.ts
@@ -169,6 +169,9 @@ export class PromptActionAutocompleteProvider implements AutocompleteProvider {
 	getInlineHint(lines: string[], cursorLine: number, cursorCol: number): string | null {
 		return this.#baseProvider.getInlineHint?.(lines, cursorLine, cursorCol) ?? null;
 	}
+	trySyncSlashCompletion(textBeforeCursor: string): { items: AutocompleteItem[]; prefix: string } | null {
+		return this.#baseProvider.trySyncSlashCompletion?.(textBeforeCursor) ?? null;
+	}
 }
 
 export function createPromptActionAutocompleteProvider(

--- a/packages/coding-agent/test/prompt-action-autocomplete.test.ts
+++ b/packages/coding-agent/test/prompt-action-autocomplete.test.ts
@@ -110,4 +110,40 @@ describe("prompt action autocomplete", () => {
 		const suggestions = await provider.getSuggestions(["release #v1"], 0, 11);
 		expect(suggestions).toBeNull();
 	});
+
+	it("delegates trySyncSlashCompletion to CombinedAutocompleteProvider", () => {
+		const provider = createPromptActionAutocompleteProvider({
+			commands: [{ name: "model", description: "Switch AI model" }],
+			basePath: "/tmp",
+			keybindings: AppKeybindingsManager.inMemory(),
+			copyCurrentLine: () => {},
+			copyPrompt: () => {},
+			undo: () => {},
+			moveCursorToMessageEnd: () => {},
+			moveCursorToMessageStart: () => {},
+			moveCursorToLineStart: () => {},
+			moveCursorToLineEnd: () => {},
+		});
+
+		const result = provider.trySyncSlashCompletion("/mo");
+		expect(result).not.toBeNull();
+		expect(result!.items.map(i => i.value)).toContain("model");
+	});
+
+	it("returns null from trySyncSlashCompletion for non-slash text", () => {
+		const provider = createPromptActionAutocompleteProvider({
+			commands: [{ name: "model", description: "Switch AI model" }],
+			basePath: "/tmp",
+			keybindings: AppKeybindingsManager.inMemory(),
+			copyCurrentLine: () => {},
+			copyPrompt: () => {},
+			undo: () => {},
+			moveCursorToMessageEnd: () => {},
+			moveCursorToMessageStart: () => {},
+			moveCursorToLineStart: () => {},
+			moveCursorToLineEnd: () => {},
+		});
+
+		expect(provider.trySyncSlashCompletion("hello")).toBeNull();
+	});
 });

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -193,6 +193,9 @@ export interface AutocompleteProvider {
 
 	/** Get inline hint text to show as dim ghost text after the cursor */
 	getInlineHint?(lines: string[], cursorLine: number, cursorCol: number): string | null;
+	/** Synchronously try to complete a slash command at the start of a line (no async I/O). */
+	/** Returns matched items and the full prefix, or null if not applicable. */
+	trySyncSlashCompletion?(textBeforeCursor: string): { items: AutocompleteItem[]; prefix: string } | null;
 }
 
 // Combined provider that handles both slash commands and file paths.
@@ -776,5 +779,40 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		}
 
 		return command.getInlineHint(argumentText);
+	}
+	trySyncSlashCompletion(textBeforeCursor: string): { items: AutocompleteItem[]; prefix: string } | null {
+		if (!textBeforeCursor.startsWith("/")) return null;
+		if (textBeforeCursor.length <= 1) return null; // Bare "/" alone, don't auto-complete
+		if (textBeforeCursor.includes(" ")) return null; // Only complete command name, not args
+
+		const prefix = textBeforeCursor.slice(1);
+		const lowerPrefix = prefix.toLowerCase();
+
+		const matches = this.#commands
+			.filter(cmd => {
+				const name = "name" in cmd ? cmd.name : cmd.value;
+				if (!name) return false;
+				if (fuzzyMatch(lowerPrefix, name.toLowerCase())) return true;
+				const desc = cmd.description?.toLowerCase();
+				return desc ? fuzzyMatch(lowerPrefix, desc) : false;
+			})
+			.map(cmd => {
+				const name = "name" in cmd ? cmd.name : cmd.value;
+				const lowerName = name?.toLowerCase() ?? "";
+				const lowerDesc = cmd.description?.toLowerCase() ?? "";
+				const nameScore = fuzzyMatch(lowerPrefix, lowerName) ? fuzzyScore(lowerPrefix, lowerName) : 0;
+				const descScore = fuzzyMatch(lowerPrefix, lowerDesc) ? fuzzyScore(lowerPrefix, lowerDesc) * 0.5 : 0;
+				return {
+					value: name,
+					label: "name" in cmd ? cmd.name : cmd.label,
+					score: Math.max(nameScore, descScore),
+					...(cmd.description && { description: cmd.description }),
+				} as AutocompleteItem & { score: number };
+			})
+			.sort((a, b) => b.score - a.score)
+			.map(({ score: _, ...rest }) => rest);
+
+		if (matches.length === 0) return null;
+		return { items: matches, prefix: textBeforeCursor };
 	}
 }

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1135,6 +1135,38 @@ export class Editor implements Component, Focusable {
 				return;
 			}
 
+			// Synchronous slash command completion for the race condition where
+			// async autocomplete hasn't resolved yet (user types /q quickly + Enter).
+			// Match the existing selected-item behavior when autocomplete IS showing.
+			if (!this.#autocompleteState) {
+				const currentLine = this.#state.lines[this.#state.cursorLine] ?? "";
+				const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
+				if (
+					textBeforeCursor.startsWith("/") &&
+					this.#isInSubmittedSlashCommandContext() &&
+					this.#autocompleteProvider?.trySyncSlashCompletion
+				) {
+					const syncResult = this.#autocompleteProvider.trySyncSlashCompletion(textBeforeCursor);
+					if (syncResult && syncResult.items.length > 0) {
+						// Invalidate any pending async autocomplete so its stale results are discarded
+						this.#autocompleteRequestId += 1;
+						// Apply the best match and submit the completed command
+						const selected = syncResult.items[0]!;
+						const result = this.#autocompleteProvider.applyCompletion(
+							this.#state.lines,
+							this.#state.cursorLine,
+							this.#state.cursorCol,
+							selected,
+							syncResult.prefix,
+						);
+						this.#state.lines = result.lines;
+						this.#state.cursorLine = result.cursorLine;
+						this.#setCursorCol(result.cursorCol);
+						result.onApplied?.();
+					}
+				}
+			}
+
 			this.#submitValue();
 		}
 		// Backspace (including Shift+Backspace)
@@ -1466,7 +1498,7 @@ export class Editor implements Component, Focusable {
 		// Check if we should trigger or update autocomplete
 		if (!this.#autocompleteState) {
 			// Auto-trigger for "/" at the start of a line (slash commands)
-			if (char === "/" && this.#isAtStartOfMessage()) {
+			if (char === "/" && this.#isAtStartOfSubmittedMessage()) {
 				this.#tryTriggerAutocomplete();
 			}
 			// Auto-trigger for "@" file reference (fuzzy search)
@@ -1488,7 +1520,7 @@ export class Editor implements Component, Focusable {
 				const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 				const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
 				// Check if we're in a slash command (with or without space for arguments)
-				if (textBeforeCursor.trimStart().startsWith("/")) {
+				if (this.#isInSubmittedSlashCommandContext()) {
 					this.#tryTriggerAutocomplete();
 				}
 				// Check if we're in an @ file reference context
@@ -1661,7 +1693,7 @@ export class Editor implements Component, Focusable {
 			const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 			const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
 			// Slash command context
-			if (textBeforeCursor.trimStart().startsWith("/")) {
+			if (this.#isInSubmittedSlashCommandContext()) {
 				this.#tryTriggerAutocomplete();
 			}
 			// @ file reference context
@@ -1817,7 +1849,7 @@ export class Editor implements Component, Focusable {
 		} else {
 			const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 			const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
-			if (textBeforeCursor.trimStart().startsWith("/")) {
+			if (this.#isInSubmittedSlashCommandContext()) {
 				this.#tryTriggerAutocomplete();
 			} else if (textBeforeCursor.match(/(?:^|[\s])@[^\s]*$/)) {
 				this.#tryTriggerAutocomplete();
@@ -2131,7 +2163,7 @@ export class Editor implements Component, Focusable {
 			const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 			const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol);
 			// Slash command context
-			if (textBeforeCursor.trimStart().startsWith("/")) {
+			if (this.#isInSubmittedSlashCommandContext()) {
 				this.#tryTriggerAutocomplete();
 			}
 			// @ file reference context
@@ -2327,13 +2359,27 @@ export class Editor implements Component, Focusable {
 		this.#setCursorCol(moveWordRight(currentLine, this.#state.cursorCol));
 	}
 
-	// Helper method to check if cursor is at start of message (for slash command detection)
-	#isAtStartOfMessage(): boolean {
+	#hasOnlyWhitespaceBeforeCursorLine(): boolean {
+		for (let i = 0; i < this.#state.cursorLine; i++) {
+			if ((this.#state.lines[i] || "").trim() !== "") {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	// Slash commands execute only when the submitted prompt starts with the command.
+	#isAtStartOfSubmittedMessage(): boolean {
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		const beforeCursor = currentLine.slice(0, this.#state.cursorCol);
 
-		// At start if line is empty, only contains whitespace, or is just "/"
-		return beforeCursor.trim() === "" || beforeCursor.trim() === "/";
+		return this.#hasOnlyWhitespaceBeforeCursorLine() && (beforeCursor.trim() === "" || beforeCursor.trim() === "/");
+	}
+
+	#isInSubmittedSlashCommandContext(): boolean {
+		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
+		const beforeCursor = currentLine.slice(0, this.#state.cursorCol);
+		return this.#hasOnlyWhitespaceBeforeCursorLine() && beforeCursor.trimStart().startsWith("/");
 	}
 
 	#isSlashCommandNameAutocompleteSelection(): boolean {
@@ -2343,7 +2389,9 @@ export class Editor implements Component, Focusable {
 
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol).trimStart();
-		return textBeforeCursor.startsWith("/") && !textBeforeCursor.includes(" ");
+		return (
+			this.#isInSubmittedSlashCommandContext() && textBeforeCursor.startsWith("/") && !textBeforeCursor.includes(" ")
+		);
 	}
 
 	#isCompletedSlashCommandAtCursor(): boolean {
@@ -2353,7 +2401,7 @@ export class Editor implements Component, Focusable {
 		}
 
 		const textBeforeCursor = currentLine.slice(0, this.#state.cursorCol).trimStart();
-		return /^\/\S+ $/.test(textBeforeCursor);
+		return this.#isInSubmittedSlashCommandContext() && /^\/\S+ $/.test(textBeforeCursor);
 	}
 
 	// Autocomplete methods
@@ -2407,7 +2455,7 @@ export class Editor implements Component, Focusable {
 		const beforeCursor = currentLine.slice(0, this.#state.cursorCol);
 
 		// Check if we're in a slash command context
-		if (beforeCursor.trimStart().startsWith("/") && !beforeCursor.trimStart().includes(" ")) {
+		if (this.#isInSubmittedSlashCommandContext() && !beforeCursor.trimStart().includes(" ")) {
 			this.#handleSlashCommandCompletion();
 		} else {
 			this.#forceFileAutocomplete(true);

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -168,3 +168,91 @@ describe("CombinedAutocompleteProvider", () => {
 		});
 	});
 });
+describe("trySyncSlashCompletion", () => {
+	it("returns null for bare '/' (no prefix to match)", () => {
+		const provider = new CombinedAutocompleteProvider([], "/tmp");
+		const result = provider.trySyncSlashCompletion("/");
+		expect(result).toBeNull();
+	});
+
+	it("returns null for non-slash text", () => {
+		const provider = new CombinedAutocompleteProvider([], "/tmp");
+		expect(provider.trySyncSlashCompletion("hello")).toBeNull();
+		expect(provider.trySyncSlashCompletion("")).toBeNull();
+	});
+
+	it("returns null when text has spaces (argument phase, not command name)", () => {
+		const provider = new CombinedAutocompleteProvider([], "/tmp");
+		expect(provider.trySyncSlashCompletion("/model claude")).toBeNull();
+		expect(provider.trySyncSlashCompletion("/model ")).toBeNull();
+	});
+
+	it("returns null when no commands match", () => {
+		const provider = new CombinedAutocompleteProvider([], "/tmp");
+		const result = provider.trySyncSlashCompletion("/zzzzz");
+		expect(result).toBeNull();
+	});
+
+	it("returns matching items for partial slash command name", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "model", description: "Switch AI model", value: "model" }],
+			"/tmp",
+		);
+		const result = provider.trySyncSlashCompletion("/mo");
+		expect(result).not.toBeNull();
+		expect(result!.prefix).toBe("/mo");
+		expect(result!.items.map(i => i.value)).toEqual(["model"]);
+	});
+
+	it("matches multiple commands and sorts by relevance", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{ name: "model", description: "Switch AI model", value: "model" },
+				{ name: "mode", description: "Change editor mode", value: "mode" },
+				{ name: "help", description: "Show help", value: "help" },
+			],
+			"/tmp",
+		);
+		const result = provider.trySyncSlashCompletion("/mo");
+		expect(result).not.toBeNull();
+		const values = result!.items.map(i => i.value);
+		// /model and /mode should match; /help should not
+		expect(values).toContain("model");
+		expect(values).toContain("mode");
+		expect(values).not.toContain("help");
+		// The better name match should come first (higher score)
+		const modelIdx = values.indexOf("model");
+		const modeIdx = values.indexOf("mode");
+		// model matches 3/5 chars, mode matches 3/4 chars — mode has higher match ratio
+		// Both should be present; order depends on fuzzyScore internals
+		expect(modelIdx).not.toBe(-1);
+		expect(modeIdx).not.toBe(-1);
+	});
+
+	it("matches case-insensitively", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "Model", description: "Switch AI model", value: "Model" }],
+			"/tmp",
+		);
+		const result = provider.trySyncSlashCompletion("/MOD");
+		expect(result).not.toBeNull();
+		expect(result!.items.map(i => i.value)).toContain("Model");
+	});
+
+	it("also matches against description", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[{ name: "md", description: "Switch AI model", value: "md" }],
+			"/tmp",
+		);
+		const result = provider.trySyncSlashCompletion("/model");
+		expect(result).not.toBeNull();
+		expect(result!.items.map(i => i.value)).toContain("md");
+	});
+
+	it("handles AutocompleteItem-shaped commands (no 'name' property)", () => {
+		const provider = new CombinedAutocompleteProvider([{ value: "model", label: "Switch model" }], "/tmp");
+		const result = provider.trySyncSlashCompletion("/mod");
+		expect(result).not.toBeNull();
+		expect(result!.items.map(i => i.value)).toEqual(["model"]);
+	});
+});

--- a/packages/tui/test/editor-autocomplete-actions.test.ts
+++ b/packages/tui/test/editor-autocomplete-actions.test.ts
@@ -55,3 +55,184 @@ describe("Editor hash autocomplete actions", () => {
 		expect(provider.calls).toBe(1);
 	});
 });
+class SyncSlashProvider implements AutocompleteProvider {
+	async getSuggestions(
+		_lines: string[],
+		_cursorLine: number,
+		_cursorCol: number,
+	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
+		return null;
+	}
+
+	trySyncSlashCompletion(textBeforeCursor: string): { items: AutocompleteItem[]; prefix: string } | null {
+		this.callCount += 1;
+		if (!textBeforeCursor.startsWith("/")) return null;
+		if (textBeforeCursor.length <= 1) return null;
+		if (textBeforeCursor.includes(" ")) return null;
+		// Only match known slash commands: /mo or /model
+		const prefix = textBeforeCursor.slice(1);
+		if (prefix === "mo" || prefix === "model") {
+			return {
+				prefix: textBeforeCursor,
+				items: [{ value: "model", label: "/model" }],
+			};
+		}
+		return null;
+	}
+
+	applyCompletion(
+		lines: string[],
+		cursorLine: number,
+		cursorCol: number,
+		_item: AutocompleteItem,
+		prefix: string,
+	): { lines: string[]; cursorLine: number; cursorCol: number; onApplied?: () => void } {
+		const line = lines[cursorLine] || "";
+		const beforePrefix = line.slice(0, cursorCol - prefix.length);
+		const afterCursor = line.slice(cursorCol);
+		const nextLines = [...lines];
+		nextLines[cursorLine] = `${beforePrefix}/${_item.value} ${afterCursor}`;
+		return {
+			lines: nextLines,
+			cursorLine,
+			cursorCol: beforePrefix.length + _item.value.length + 2,
+		};
+	}
+
+	callCount = 0;
+}
+
+describe("Editor Enter handler sync slash completion", () => {
+	it("does not trigger slash autocomplete after prior prompt text", async () => {
+		let suggestionCalls = 0;
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider({
+			async getSuggestions(lines, cursorLine, cursorCol) {
+				suggestionCalls += 1;
+				const currentLine = lines[cursorLine] ?? "";
+				return { prefix: currentLine.slice(0, cursorCol), items: [{ value: "model", label: "/model" }] };
+			},
+			applyCompletion(lines, cursorLine, cursorCol) {
+				return { lines, cursorLine, cursorCol };
+			},
+		});
+
+		editor.setText("explain this\n");
+		editor.handleInput("/");
+		await Bun.sleep(0);
+
+		expect(suggestionCalls).toBe(0);
+		expect(editor.isShowingAutocomplete()).toBe(false);
+	});
+
+	it("completes slash command synchronously before async resolves and submits", () => {
+		const provider = new SyncSlashProvider();
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(provider);
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.handleInput("/mo");
+		editor.handleInput("\r");
+
+		expect(submitted).toBe("/model");
+	});
+
+	it("completes slash command after leading blank lines", () => {
+		const provider = new SyncSlashProvider();
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(provider);
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.setText("\n/mo");
+		editor.handleInput("\r");
+
+		expect(submitted).toBe("/model");
+		expect(provider.callCount).toBe(1);
+	});
+
+	it("does not complete slash command after prior prompt text", () => {
+		const provider = new SyncSlashProvider();
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(provider);
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.setText("explain this\n/mo");
+		editor.handleInput("\r");
+
+		expect(submitted).toBe("explain this\n/mo");
+		expect(provider.callCount).toBe(0);
+	});
+
+	it("submits raw text when slash command has no sync match", () => {
+		const provider = new SyncSlashProvider();
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(provider);
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.handleInput("/xyz");
+		editor.handleInput("\r");
+
+		expect(submitted).toBe("/xyz");
+	});
+
+	it("does not interfere with non-slash text submission", () => {
+		const provider = new SyncSlashProvider();
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(provider);
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.handleInput("hello");
+		editor.handleInput("\r");
+
+		expect(submitted).toBe("hello");
+	});
+
+	it("applies completion from autocomplete list when autocomplete is already showing, then submits", async () => {
+		// Create a provider that returns results from getSuggestions too,
+		// so after a yield the autocomplete state is set and the autocomplete
+		// block in the Enter handler applies the completion before submitting.
+		let suggestionsCallCount = 0;
+		const provider = new SyncSlashProvider();
+		provider.getSuggestions = async (lines, _cursorLine, cursorCol) => {
+			suggestionsCallCount++;
+			const line = lines[0] || "";
+			const textBeforeCursor = line.slice(0, cursorCol);
+			if (textBeforeCursor.startsWith("/")) {
+				return { prefix: textBeforeCursor, items: [{ value: "model", label: "/model" }] };
+			}
+			return null;
+		};
+
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(provider);
+		let submitted = "";
+		editor.onSubmit = text => {
+			submitted = text;
+		};
+
+		editor.handleInput("/mo");
+		await Bun.sleep(0); // Let async autocomplete resolve and set state
+		editor.handleInput("\r");
+
+		// When autocomplete shows a slash command, Enter applies the completion
+		// (turning /mo into /model via the autocomplete block at line ~1005)
+		// then cancels autocomplete and submits the completed text.
+		expect(submitted).toBe("/model");
+		expect(suggestionsCallCount).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
## Summary
- add synchronous slash-command completion for fast Enter submissions before async autocomplete resolves
- keep slash autocomplete scoped to prompts whose submitted text starts with a slash command
- add TUI and coding-agent regression coverage for sync slash completion and formatting-safe autocomplete tests

## Validation
- bun check
- bun test packages/coding-agent/test/prompt-action-autocomplete.test.ts packages/tui/test/autocomplete.test.ts packages/tui/test/editor-autocomplete-actions.test.ts
- bun test packages/coding-agent/test/sdk-skills.test.ts

## Notes
- Full `bun test` was run locally. It timed out once in `packages/coding-agent/test/sdk-skills.test.ts` during the full-suite run, then that file passed when rerun by itself.