### PR TITLE
fix(ai): coalesce chat completions system prompts

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI Chat Completions serialization to send ordered system prompt blocks as one leading `system`/`developer` message so strict chat templates do not reject follow-up system messages.
+
 ## [14.7.2] - 2026-05-06
 
 ### Fixed

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1191,9 +1191,7 @@ export function convertMessages(
 	if (systemPrompts.length > 0) {
 		const useDeveloperRole = model.reasoning && compat.supportsDeveloperRole;
 		const role = useDeveloperRole ? "developer" : "system";
-		for (const systemPrompt of systemPrompts) {
-			params.push({ role, content: systemPrompt });
-		}
+		params.push({ role, content: systemPrompts.join("\n\n") });
 	}
 
 	let lastRole: string | null = null;

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -121,7 +121,7 @@ describe("openai-completions compatibility", () => {
 		expect(assistant.content).toBe("hello world");
 	});
 
-	it("preserves multiple system prompts as leading system messages for chat completions", () => {
+	it("coalesces multiple system prompts into one leading system message for chat completions", () => {
 		const model: Model<"openai-completions"> = {
 			...getBundledModel("openai", "gpt-4o-mini"),
 			api: "openai-completions",
@@ -136,9 +136,8 @@ describe("openai-completions compatibility", () => {
 			detectCompat(model),
 		);
 
-		expect(messages.slice(0, 3)).toEqual([
-			{ role: "system", content: "stable instructions" },
-			{ role: "system", content: "cacheable policy" },
+		expect(messages.slice(0, 2)).toEqual([
+			{ role: "system", content: "stable instructions\n\ncacheable policy" },
 			{ role: "user", content: "hello" },
 		]);
 	});
@@ -159,9 +158,8 @@ describe("openai-completions compatibility", () => {
 			detectCompat(model),
 		);
 
-		expect(supportedMessages.slice(0, 3)).toEqual([
-			{ role: "developer", content: "stable instructions" },
-			{ role: "developer", content: "cacheable policy" },
+		expect(supportedMessages.slice(0, 2)).toEqual([
+			{ role: "developer", content: "stable instructions\n\ncacheable policy" },
 			{ role: "user", content: "hello" },
 		]);
 
@@ -174,9 +172,8 @@ describe("openai-completions compatibility", () => {
 			{ ...detectCompat(model), supportsDeveloperRole: false },
 		);
 
-		expect(unsupportedMessages.slice(0, 3)).toEqual([
-			{ role: "system", content: "stable instructions" },
-			{ role: "system", content: "cacheable policy" },
+		expect(unsupportedMessages.slice(0, 2)).toEqual([
+			{ role: "system", content: "stable instructions\n\ncacheable policy" },
 			{ role: "user", content: "hello" },
 		]);
 	});


### PR DESCRIPTION
## What

Serialise all system/developer prompts into a single tag at the start of the prompt.

## Why

Chat templates for vllm/sglang/llamacpp are generally written with support for a single <system> (or <developer>) prompt. When there are multiple, templates may fail and models may behave in unexpected ways.

Also, I've done some digging and I haven't found any pointers that it's supported nor that it's a good idea to have multiple <system> prompt in the prompt json structure, but technically the OpenAI API spec does not forbid it. 

Submitting them as multiple in a list was added in da87c8f54b122ffb730b6870394385d5bce7737b but I do not think this is something that open weight models are trained on. If I'm wrong, I'm happy to stand corrected, or to put this behind a compat flag.

## Testing

Locally using a strict Qwen 3.6 jinja template: https://gist.github.com/fakezeta/9e8e039c60332fcb143c6e805558afe0#file-qwen3-6_merged_template-jinja-L176

---

- [X] `bun check` passes
- [X] Tested locally
- [X] CHANGELOG updated (if user-facing)
