### PR TITLE
fix(coding-agent): append plan review previews on resubmit

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed plan mode review resubmits to append each refreshed `local://PLAN.md` preview to the chat history, preserving the full refined plan in terminal scrollback.
+
 ## [14.8.0] - 2026-05-09
 ### Added
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1011,13 +1011,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 	}
 
-	#renderPlanPreview(planContent: string): void {
-		const planReviewContainer = this.#planReviewContainer ?? new Container();
-		if (this.#planReviewContainer) {
-			// Re-append the preview so repeated plan-review refreshes stay adjacent to the
-			// active selector instead of updating an older off-screen preview in place.
-			this.chatContainer.removeChild(this.#planReviewContainer);
-		}
+	#renderPlanPreview(planContent: string, options?: { append?: boolean }): void {
+		const existingContainer = this.#planReviewContainer;
+		const replaceExisting = options?.append !== true && existingContainer !== undefined;
+		const planReviewContainer = replaceExisting ? existingContainer : new Container();
 		planReviewContainer.clear();
 		planReviewContainer.addChild(new Spacer(1));
 		planReviewContainer.addChild(new DynamicBorder());
@@ -1025,7 +1022,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		planReviewContainer.addChild(new Spacer(1));
 		planReviewContainer.addChild(new Markdown(planContent, 1, 1, getMarkdownTheme()));
 		planReviewContainer.addChild(new DynamicBorder());
-		this.chatContainer.addChild(planReviewContainer);
+		if (!replaceExisting) {
+			this.chatContainer.addChild(planReviewContainer);
+		}
 		this.#planReviewContainer = planReviewContainer;
 		this.ui.requestRender();
 	}
@@ -1182,7 +1181,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 
-		this.#renderPlanPreview(planContent);
+		this.#renderPlanPreview(planContent, { append: true });
 		const choice = await this.showHookSelector(
 			"Plan mode - next step",
 			["Approve and execute", "Approve and keep context", "Refine plan", "Stay in plan mode"],

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -58,7 +58,7 @@ describe("InteractiveMode plan review rendering", () => {
 		_resetSettingsForTest();
 	});
 
-	it("re-appends refreshed plan review previews at the chat tail", async () => {
+	it("appends each submitted plan review preview to preserve scrollback", async () => {
 		const planFilePath = "local://PLAN.md";
 		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
 			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
@@ -92,9 +92,14 @@ describe("InteractiveMode plan review rendering", () => {
 			finalPlanFilePath: "local://PLAN.md",
 		});
 
-		expect(mode.chatContainer.children.at(-1)).toBe(firstPreview);
+		const secondPreview = mode.chatContainer.children.at(-1);
+		expect(secondPreview).toBeDefined();
+		expect(secondPreview).not.toBe(firstPreview);
 		expect(mode.chatContainer.children.at(-2)).toBe(marker);
-		expect(firstPreview!.render(120).join("\n")).toContain("Second plan");
+		expect(mode.chatContainer.children.at(-3)).toBe(firstPreview);
+		expect(firstPreview!.render(120).join("\n")).toContain("First plan");
+		expect(firstPreview!.render(120).join("\n")).not.toContain("Second plan");
+		expect(secondPreview!.render(120).join("\n")).toContain("Second plan");
 	});
 
 	it("offers approve-and-keep-context as a distinct plan approval path", async () => {


### PR DESCRIPTION
- Render each exit_plan_mode submission as a fresh plan review entry so refined plans are emitted into terminal scrollback.
- Keep external-editor edits replacing the current preview instead of adding duplicate review entries.
- Updated the plan review regression test to preserve the first preview and append the second one after intervening chat content.

## What

Fixes plan mode review rendering so every `exit_plan_mode` resubmit appends a fresh full `local://PLAN.md` preview to chat history instead of mutating/reusing the previous preview in place.

Before this change, the first submitted plan rendered correctly and remained available in terminal scrollback. However, after choosing to refine the plan and submitting again, only the currently visible tail of
 the refreshed plan was reliably visible in scrollback. Long refined plans could not be scrolled back to from the beginning.

The fix changes the plan review lifecycle:

- Submitted plan reviews now append a new immutable `Plan Review` entry.
- The previous submitted preview remains in chat history.
- The refined preview is emitted as new terminal output, so the full document is available through terminal scrollback.
- External editor updates still replace the currently active preview instead of appending duplicate entries, because those edits are not a new `exit_plan_mode` submission.

A regression test was updated to verify that two submitted plan reviews are distinct chat entries and that the first preview remains preserved when the second preview is appended.

## Why

Plan mode review previews are rendered by `InteractiveMode`, not by the `exit_plan_mode` tool output itself. The tool only returns a short “Plan ready for approval.” result plus metadata; the UI reads `local://PLAN.md` and renders the full preview.

The previous implementation reused a single `#planReviewContainer`: it removed the old preview from the chat container, cleared it, repopulated it with the new plan content, and appended it back. That made the
refined plan look updated on the current screen, but it was still treated by the TUI as a mutation of existing rendered content.

The TUI renderer is intentionally differential. For existing content, it updates changed visible rows and skips many offscreen changes to preserve scrollback stability and avoid duplicating historical rows.
That behavior is correct globally, but it means mutating an old offscreen/partially visible plan preview does not emit the full refreshed document into terminal scrollback.

Several alternatives were considered:

1. Force a full TUI redraw on every plan resubmit.
   - Rejected because full redraw is global and can clear/rewrite viewport or scrollback depending on terminal behavior. It would be a broad rendering change for a local plan review lifecycle issue.

2. Change the TUI differential renderer to emit offscreen changed rows.
   - Rejected because the renderer has existing scrollback integrity guarantees. Changing it would affect all chat rendering, tool rendering, streaming output, overlays, and resize behavior.

3. Include the full plan text directly in the `exit_plan_mode` tool result.
   - Rejected because the approval UI already owns plan preview rendering. Duplicating the plan through tool output would create two rendering paths and risk inconsistent transcript/UI behavior.

4. Append plan review submissions as new chat entries while keeping editor edits as in-place updates.
   - Chosen because it matches the actual semantics: each `exit_plan_mode` call is a new review submission that should be visible in history; an external-editor edit is only an update to the currently
displayed review before the user chooses the next action.

This keeps the fix local, straightforward, and low-risk.

## Testing

- Unit test verified by running:

```sh
bun run test test/interactive-mode-plan-review.test.ts
```

Result: 4 pass.

- Formatting/lint check verified by running:
```sh
bunx biome check packages/coding-agent/src/modes/interactive-mode.ts packages/coding-agent/test/interactive-mode-plan-review.test.ts
```
Result: OK.

- Manually tested with a newly compiled patched binary:
  - Entered plan mode.
  - Submitted an initial plan.
  - Chose to refine the plan.
  - Submitted a refined plan.
  - Verified the refined plan is now preserved in terminal history and can be viewed through terminal scrollback.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
