### PR TITLE
feat(rpc): add get_login_providers and login commands

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `get_login_providers` RPC command to list registered OAuth providers with their current authentication status (`id`, `name`, `available`, `authenticated`)
+- Added `login` RPC command to trigger OAuth login for a given provider; emits an `open_url` extension UI event (fire-and-forget) carrying the auth URL and optional instructions so headless clients can open the browser, then resolves when the callback-server flow completes
+- Added `open_url` variant to `RpcExtensionUIRequest` for the above
+- Added `getLoginProviders()` and `login(providerId)` methods to `RpcClient`
+
 ## [14.8.0] - 2026-05-09
 ### Added
 

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -553,7 +553,7 @@ export class RpcClient {
 			: undefined;
 		if (listener) this.#extensionUiListeners.add(listener);
 		try {
-			const response = await this.#send({ type: "login", providerId });
+			const response = await this.#send({ type: "login", providerId }, 300_000);
 			return this.#getData<{ providerId: string }>(response);
 		} finally {
 			if (listener) this.#extensionUiListeners.delete(listener);
@@ -685,7 +685,7 @@ export class RpcClient {
 		}
 	}
 
-	#send(command: RpcCommandBody): Promise<RpcResponse> {
+	#send(command: RpcCommandBody, timeoutMs = 30_000): Promise<RpcResponse> {
 		if (!this.#process?.stdin) {
 			throw new Error("Client not started");
 		}
@@ -694,7 +694,7 @@ export class RpcClient {
 		const fullCommand = { ...command, id } as RpcCommand;
 		const { promise, resolve, reject } = Promise.withResolvers<RpcResponse>();
 		let settled = false;
-		const timeoutId = this.#startTimeout(30000, () => {
+		const timeoutId = this.#startTimeout(timeoutMs, () => {
 			if (settled) return;
 			this.#pendingRequests.delete(id);
 			settled = true;

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -517,6 +517,26 @@ export class RpcClient {
 	}
 
 	/**
+	 * Get list of OAuth providers available for login, with their current authentication status.
+	 */
+	async getLoginProviders(): Promise<Array<{ id: string; name: string; available: boolean; authenticated: boolean }>> {
+		const response = await this.#send({ type: "get_login_providers" });
+		return this.#getData<{
+			providers: Array<{ id: string; name: string; available: boolean; authenticated: boolean }>;
+		}>(response).providers;
+	}
+
+	/**
+	 * Trigger OAuth login for the given provider.
+	 * The server will emit an `open_url` extension_ui_request for the auth URL.
+	 * Resolves when login completes or rejects on failure.
+	 */
+	async login(providerId: string): Promise<{ providerId: string }> {
+		const response = await this.#send({ type: "login", providerId });
+		return this.#getData<{ providerId: string }>(response);
+	}
+
+	/**
 	 * Replace the host-owned custom tools exposed to the RPC session.
 	 * Changes take effect before the next model call.
 	 */

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -11,6 +11,7 @@ import type { SessionStats } from "../../session/agent-session";
 import type { CompactionResult } from "../../session/compaction";
 import type {
 	RpcCommand,
+	RpcExtensionUIRequest,
 	RpcHandoffResult,
 	RpcHostToolCallRequest,
 	RpcHostToolCancelRequest,
@@ -124,6 +125,11 @@ function isRpcHostToolCancelRequest(value: unknown): value is RpcHostToolCancelR
 	return value.type === "host_tool_cancel" && typeof value.id === "string" && typeof value.targetId === "string";
 }
 
+function isRpcExtensionUiRequest(value: unknown): value is RpcExtensionUIRequest {
+	if (!isRecord(value)) return false;
+	return value.type === "extension_ui_request" && typeof value.id === "string" && typeof value.method === "string";
+}
+
 function normalizeToolResult<TDetails>(result: RpcClientToolResult<TDetails>): AgentToolResult<TDetails> {
 	if (typeof result === "string") {
 		return {
@@ -145,6 +151,7 @@ export class RpcClient {
 	#customTools: RpcClientCustomTool[] = [];
 	#pendingHostToolCalls = new Map<string, { controller: AbortController }>();
 	#requestId = 0;
+	#extensionUiListeners: Set<(req: RpcExtensionUIRequest) => void> = new Set();
 	#abortController = new AbortController();
 
 	constructor(private options: RpcClientOptions = {}) {
@@ -530,10 +537,27 @@ export class RpcClient {
 	 * Trigger OAuth login for the given provider.
 	 * The server will emit an `open_url` extension_ui_request for the auth URL.
 	 * Resolves when login completes or rejects on failure.
+	 *
+	 * @param onOpenUrl Called when the server emits the auth URL. The host must open
+	 *   it in a browser for the callback-server OAuth flow to complete.
 	 */
-	async login(providerId: string): Promise<{ providerId: string }> {
-		const response = await this.#send({ type: "login", providerId });
-		return this.#getData<{ providerId: string }>(response);
+	async login(
+		providerId: string,
+		options?: { onOpenUrl?: (url: string, instructions?: string) => void },
+	): Promise<{ providerId: string }> {
+		const { onOpenUrl } = options ?? {};
+		const listener = onOpenUrl
+			? (req: RpcExtensionUIRequest) => {
+					if (req.method === "open_url") onOpenUrl(req.url, req.instructions);
+				}
+			: undefined;
+		if (listener) this.#extensionUiListeners.add(listener);
+		try {
+			const response = await this.#send({ type: "login", providerId });
+			return this.#getData<{ providerId: string }>(response);
+		} finally {
+			if (listener) this.#extensionUiListeners.delete(listener);
+		}
 	}
 
 	/**
@@ -638,6 +662,13 @@ export class RpcClient {
 
 		if (isRpcHostToolCallRequest(data)) {
 			void this.#handleHostToolCall(data);
+			return;
+		}
+
+		if (isRpcExtensionUiRequest(data)) {
+			for (const listener of this.#extensionUiListeners) {
+				listener(data);
+			}
 			return;
 		}
 

--- a/packages/coding-agent/src/modes/rpc/rpc-client.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-client.ts
@@ -553,7 +553,7 @@ export class RpcClient {
 			: undefined;
 		if (listener) this.#extensionUiListeners.add(listener);
 		try {
-			const response = await this.#send({ type: "login", providerId }, 300_000);
+			const response = await this.#send({ type: "login", providerId }, 600_000);
 			return this.#getData<{ providerId: string }>(response);
 		} finally {
 			if (listener) this.#extensionUiListeners.delete(listener);

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -790,12 +790,12 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 						onProgress: message => {
 							uiCtx.notify(message, "info");
 						},
-						onPrompt: async () => {
-							throw new Error(
-								"This provider requires manual verification code entry, " +
-									"which is not supported in RPC mode. Use the terminal UI to log in to this provider.",
-							);
-						},
+						onPrompt: () =>
+							// Never resolve rather than throw. OAuthCallbackFlow.#waitForCallback
+							// races onManualCodeInput against the browser callback and catches any
+							// rejection as null, which causes a tight retry loop. A forever-pending
+							// promise makes the race block until the callback server wins instead.
+							new Promise<string>(() => {}),
 					});
 					await session.modelRegistry.refresh();
 					return success(id, "login", { providerId: command.providerId });

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -150,7 +150,6 @@ export function requestRpcEditor(
 	} as RpcExtensionUIRequest);
 	return promise;
 }
-
 /**
  * Run in RPC mode.
  * Listens for JSON commands on stdin, outputs events and responses on stdout.
@@ -776,9 +775,16 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 					return error(id, "login", `Unknown OAuth provider: ${command.providerId}`);
 				}
 				const uiCtx = new RpcExtensionUIContext(pendingExtensionRequests, output);
+				// Track whether onAuth has fired. Providers that use OAuthCallbackFlow
+				// always call onAuth first (emit browser URL), then onManualCodeInput as
+				// a fallback. Providers that require interactive input (API-key paste,
+				// GitHub Enterprise URL, device-code entry) call onPrompt before onAuth.
+				// We use this ordering to self-classify at runtime — no static allowlist.
+				let authEmitted = false;
 				try {
 					await session.modelRegistry.authStorage.login(command.providerId, {
 						onAuth: info => {
+							authEmitted = true;
 							output({
 								type: "extension_ui_request",
 								id: Snowflake.next() as string,
@@ -790,12 +796,23 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 						onProgress: message => {
 							uiCtx.notify(message, "info");
 						},
-						onPrompt: () =>
-							// Never resolve rather than throw. OAuthCallbackFlow.#waitForCallback
-							// races onManualCodeInput against the browser callback and catches any
-							// rejection as null, which causes a tight retry loop. A forever-pending
-							// promise makes the race block until the callback server wins instead.
-							new Promise<string>(() => {}),
+						onPrompt: () => {
+							if (!authEmitted) {
+								// onPrompt called before any auth URL — provider requires
+								// interactive input that cannot be satisfied headlessly.
+								return Promise.reject(
+									new Error(
+										`Provider '${command.providerId}' requires interactive prompts ` +
+											"which are not supported in RPC mode. Use the terminal UI to log in.",
+									),
+								);
+							}
+							// onAuth has already fired — we are inside OAuthCallbackFlow's
+							// manual-redirect fallback race. Returning a never-settling promise
+							// lets the race block until the callback server wins; a rejection
+							// would be caught as null and spin the while(true) loop.
+							return new Promise<string>(() => {});
+						},
 					});
 					await session.modelRegistry.refresh();
 					return success(id, "login", { providerId: command.providerId });

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -10,6 +10,7 @@
  * - Events: AgentSessionEvent objects streamed as they occur
  * - Extension UI: Extension UI requests are emitted, client responds with extension_ui_response
  */
+import { getOAuthProviders } from "@oh-my-pi/pi-ai/utils/oauth";
 import { $env, readJsonl, Snowflake } from "@oh-my-pi/pi-utils";
 import type {
 	ExtensionUIContext,
@@ -753,6 +754,54 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 
 			case "get_messages": {
 				return success(id, "get_messages", { messages: session.messages });
+			}
+
+			// =================================================================
+			// Login
+			// =================================================================
+
+			case "get_login_providers": {
+				const providers = getOAuthProviders().map(provider => ({
+					id: provider.id,
+					name: provider.name,
+					available: provider.available,
+					authenticated: session.modelRegistry.authStorage.hasAuth(provider.id),
+				}));
+				return success(id, "get_login_providers", { providers });
+			}
+
+			case "login": {
+				const knownProvider = getOAuthProviders().find(p => p.id === command.providerId);
+				if (!knownProvider) {
+					return error(id, "login", `Unknown OAuth provider: ${command.providerId}`);
+				}
+				const uiCtx = new RpcExtensionUIContext(pendingExtensionRequests, output);
+				try {
+					await session.modelRegistry.authStorage.login(command.providerId, {
+						onAuth: info => {
+							output({
+								type: "extension_ui_request",
+								id: Snowflake.next() as string,
+								method: "open_url",
+								url: info.url,
+								instructions: info.instructions,
+							} as RpcExtensionUIRequest);
+						},
+						onProgress: message => {
+							uiCtx.notify(message, "info");
+						},
+						onPrompt: async () => {
+							throw new Error(
+								"This provider requires manual verification code entry, " +
+									"which is not supported in RPC mode. Use the terminal UI to log in to this provider.",
+							);
+						},
+					});
+					await session.modelRegistry.refresh();
+					return success(id, "login", { providerId: command.providerId });
+				} catch (err: unknown) {
+					return error(id, "login", err instanceof Error ? err.message : String(err));
+				}
 			}
 
 			default: {

--- a/packages/coding-agent/src/modes/rpc/rpc-types.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-types.ts
@@ -67,7 +67,11 @@ export type RpcCommand =
 	| { id?: string; type: "handoff"; customInstructions?: string }
 
 	// Messages
-	| { id?: string; type: "get_messages" };
+	| { id?: string; type: "get_messages" }
+
+	// Login
+	| { id?: string; type: "get_login_providers" }
+	| { id?: string; type: "login"; providerId: string };
 
 // ============================================================================
 // RPC State
@@ -193,6 +197,16 @@ export type RpcResponse =
 	// Messages
 	| { id?: string; type: "response"; command: "get_messages"; success: true; data: { messages: AgentMessage[] } }
 
+	// Login
+	| {
+			id?: string;
+			type: "response";
+			command: "get_login_providers";
+			success: true;
+			data: { providers: Array<{ id: string; name: string; available: boolean; authenticated: boolean }> };
+	  }
+	| { id?: string; type: "response"; command: "login"; success: true; data: { providerId: string } }
+
 	// Error response (any command can fail)
 	| { id?: string; type: "response"; command: string; success: false; error: string };
 
@@ -244,7 +258,8 @@ export type RpcExtensionUIRequest =
 			widgetPlacement?: "aboveEditor" | "belowEditor";
 	  }
 	| { type: "extension_ui_request"; id: string; method: "setTitle"; title: string }
-	| { type: "extension_ui_request"; id: string; method: "set_editor_text"; text: string };
+	| { type: "extension_ui_request"; id: string; method: "set_editor_text"; text: string }
+	| { type: "extension_ui_request"; id: string; method: "open_url"; url: string; instructions?: string };
 
 // ============================================================================
 // Host Tool Frames (bidirectional)


### PR DESCRIPTION
## Summary

Adds two new RPC commands and one new extension UI event to support OAuth login flows from headless RPC clients.

## New commands

### `get_login_providers`
Returns all registered OAuth providers decorated with their current authentication status.

```json
{ "type": "get_login_providers" }
```

Response:
```json
{
  "type": "response",
  "command": "get_login_providers",
  "success": true,
  "data": {
    "providers": [
      { "id": "anthropic", "name": "Anthropic (Claude Pro/Max)", "available": true, "authenticated": false }
    ]
  }
}
```

### `login`
Triggers the OAuth login flow for a given provider. Validates the provider exists up-front, then drives `authStorage.login()` with RPC-compatible callbacks. Resolves when the flow completes; rejects on failure.

```json
{ "type": "login", "providerId": "anthropic" }
```

Success response:
```json
{ "type": "response", "command": "login", "success": true, "data": { "providerId": "anthropic" } }
```

## New extension UI event

### `open_url` (fire-and-forget)

Emitted during login when the auth URL is ready. The client should open it in the system browser. No response is expected.

```json
{
  "type": "extension_ui_request",
  "method": "open_url",
  "url": "https://...",
  "instructions": "..."
}
```

## Constraints and edge cases

- Providers using a local callback server (Anthropic, Google, etc.) work end-to-end: `open_url` fires, the user authenticates in the browser, and the redirect completes the flow automatically.
- Providers requiring manual device-flow code entry are explicitly rejected with a descriptive error. The RPC command loop processes stdin serially — waiting for an `extension_ui_response` while blocked inside `handleCommand` would deadlock. Clients that need this flow should use the terminal UI.
- Unknown `providerId` values are rejected before touching `authStorage`.
- `onProgress` callbacks from the auth flow are forwarded to the client as `notify` extension UI events.

## Changed files

| File | Change |
|---|---|
| `rpc-types.ts` | `RpcCommand`: `get_login_providers`, `login`. `RpcResponse`: typed success shapes for both. `RpcExtensionUIRequest`: `open_url`. |
| `rpc-mode.ts` | Handlers for both commands inside `handleCommand`. |
| `rpc-client.ts` | `getLoginProviders()` and `login(providerId)` typed client methods. |