### PR TITLE
fix(reviewer): add cross-boundary dispatch tracing obligation

### DIFF
--- a/packages/coding-agent/src/prompts/agents/reviewer.md
+++ b/packages/coding-agent/src/prompts/agents/reviewer.md
@@ -77,6 +77,21 @@ Report issue only when ALL conditions hold:
 - **Proportionate rigor**: Fix doesn't demand rigor absent elsewhere in codebase
 </criteria>
 
+<cross-boundary>
+For every new type, variant, or value introduced by the patch that crosses a function or module boundary
+(event, message, command, frame, enum variant, queue item, IPC payload):
+
+1. Locate the **dispatch point** — the switch, router, filter chain, handler registry, or loop body
+   that receives and routes values of that kind on the **consuming** side.
+2. Confirm the new type has an explicit branch, or that the existing catch-all forwards it correctly.
+3. If the new type falls through to a silent drop, no-op, or discard (e.g. an unmatched `if`/`switch`
+   that simply returns without processing), report it as a defect.
+
+The dispatch point is frequently **outside the diff**. You **MUST** read it before concluding
+the producing side is correct. Tracing only the emitting code while skipping the consuming
+routing logic is the single most common source of missed integration bugs in reviews.
+</cross-boundary>
+
 <priority>
 |Level|Criteria|Example|
 |---|---|---|


### PR DESCRIPTION
## Problem

The reviewer agent misses a systematic class of integration bug: a patch introduces a new type (event, message, RPC frame, enum variant) on the **producing** side, but the **consuming** dispatch point — a switch, filter chain, or router — is in untouched code outside the diff. The new type silently falls through to a drop/no-op and the reviewer never checks it because they only read modified files.

Concrete example: PR #987 added an `open_url` `extension_ui_request` emitted during `login()`. `RpcClient#handleLine` had no case for `extension_ui_request` — every frame was silently dropped. Callers had no auth URL and the command hung until timeout. Caught by Codex post-merge, not by the local reviewer passes.

## Fix

Add a `<cross-boundary>` section to `reviewer.md` that makes the obligation explicit:

> For every new type, variant, or value introduced by the patch that crosses a function or module boundary, locate the dispatch point on the **consuming** side and confirm the new type has an explicit branch or is forwarded by a correct catch-all. The dispatch point is frequently outside the diff — you **MUST** read it before concluding the producing side is correct.