### PR TITLE
feat(ai): emit onCredentialDisabled hook from AuthStorage

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `AuthStorage` `onCredentialDisabled` callback (sync or async) so embedders can react when a credential is automatically disabled (e.g. OAuth refresh fails with `invalid_grant`) — useful for surfacing a banner or auto-launching a re-login flow instead of letting the credential silently disappear. Sync throws and async rejections are both caught and logged so a misbehaving subscriber cannot break the disable path.
+
 ## [14.8.0] - 2026-05-09
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -82,6 +82,21 @@ export interface StoredAuthCredential {
 // AuthStorage Options
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Event payload describing a credential that was just soft-disabled.
+ *
+ * Today the only call site is OAuth refresh failures with a definitive cause
+ * (`invalid_grant`, `401/403` not from a network blip, etc.) — the
+ * disabled_cause string is the verbatim error captured for forensics.
+ *
+ * Subscribers can use this to surface a notification, banner, or auto-launch
+ * a re-login flow instead of letting the credential silently disappear.
+ */
+export interface CredentialDisabledEvent {
+	provider: string;
+	disabledCause: string;
+}
+
 export type AuthStorageOptions = {
 	usageProviderResolver?: (provider: Provider) => UsageProvider | undefined;
 	rankingStrategyResolver?: (provider: Provider) => CredentialRankingStrategy | undefined;
@@ -94,6 +109,14 @@ export type AuthStorageOptions = {
 	 * - Default: checks environment variable first, then treats as literal
 	 */
 	configValueResolver?: (config: string) => Promise<string | undefined>;
+	/**
+	 * Optional callback fired when AuthStorage automatically disables a
+	 * credential because something detected it as no longer usable — today
+	 * that's the OAuth refresh-failure path in `getApiKey`. NOT fired for
+	 * user-initiated `remove()` (the user already knows) or dedup of
+	 * duplicate credentials (uninteresting hygiene).
+	 */
+	onCredentialDisabled?: (event: CredentialDisabledEvent) => void | Promise<void>;
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -260,6 +283,7 @@ export class AuthStorage {
 	#fallbackResolver?: (provider: string) => string | undefined;
 	#store: AuthCredentialStore;
 	#configValueResolver: (config: string) => Promise<string | undefined>;
+	#onCredentialDisabled?: (event: CredentialDisabledEvent) => void | Promise<void>;
 	#closed = false;
 
 	constructor(store: AuthCredentialStore, options: AuthStorageOptions = {}) {
@@ -270,6 +294,7 @@ export class AuthStorage {
 		this.#usageCache = new AuthStorageUsageCache(this.#store);
 		this.#usageFetch = options.usageFetch ?? fetch;
 		this.#usageRequestTimeoutMs = options.usageRequestTimeoutMs ?? DEFAULT_USAGE_REQUEST_TIMEOUT_MS;
+		this.#onCredentialDisabled = options.onCredentialDisabled;
 		this.#usageLogger =
 			options.usageLogger ??
 			({
@@ -601,6 +626,23 @@ export class AuthStorage {
 		const updated = entries.filter((_value, idx) => idx !== index);
 		this.#setStoredCredentials(provider, updated);
 		this.#resetProviderAssignments(provider);
+		this.#emitCredentialDisabled({ provider, disabledCause });
+	}
+
+	#emitCredentialDisabled(event: CredentialDisabledEvent): void {
+		const handler = this.#onCredentialDisabled;
+		if (!handler) return;
+		const logHandlerError = (error: unknown): void => {
+			logger.warn("onCredentialDisabled handler threw", { provider: event.provider, error: String(error) });
+		};
+		try {
+			const result = handler(event);
+			if (result && typeof (result as PromiseLike<void>).then === "function") {
+				(result as Promise<void>).catch(logHandlerError);
+			}
+		} catch (error) {
+			logHandlerError(error);
+		}
 	}
 
 	/**

--- a/packages/ai/test/auth-storage-credential-disabled-event.test.ts
+++ b/packages/ai/test/auth-storage-credential-disabled-event.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthCredentialStore, AuthStorage, type CredentialDisabledEvent } from "../src/auth-storage";
+import * as oauthUtils from "../src/utils/oauth";
+
+describe("AuthStorage onCredentialDisabled callback", () => {
+	let tempDir = "";
+	let store: AuthCredentialStore | null = null;
+	let authStorage: AuthStorage | null = null;
+	let events: CredentialDisabledEvent[] = [];
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-auth-credential-disabled-event-"));
+		store = await AuthCredentialStore.open(path.join(tempDir, "agent.db"));
+		events = [];
+		authStorage = new AuthStorage(store, {
+			onCredentialDisabled: event => {
+				events.push(event);
+			},
+		});
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		store?.close();
+		store = null;
+		authStorage = null;
+		if (tempDir) {
+			await fs.rm(tempDir, { recursive: true, force: true });
+			tempDir = "";
+		}
+	});
+
+	test("fires when an OAuth credential is disabled by a definitive refresh failure", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "expired-access",
+				refresh: "stale-refresh",
+				expires: Date.now() - 60_000,
+			},
+		]);
+
+		vi.spyOn(oauthUtils, "getOAuthApiKey").mockImplementation(async () => {
+			throw new Error(
+				'HTTP 400 invalid_grant {"error":"invalid_grant","error_description":"Refresh token not found or invalid"}',
+			);
+		});
+
+		const apiKey = await authStorage.getApiKey("anthropic", "session-disabled-event");
+
+		expect(apiKey).toBeUndefined();
+		expect(events).toHaveLength(1);
+		expect(events[0]?.provider).toBe("anthropic");
+		expect(events[0]?.disabledCause).toContain("invalid_grant");
+	});
+
+	test("does not fire for transient (non-definitive) refresh failures", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "expired-access",
+				refresh: "stale-refresh",
+				expires: Date.now() - 60_000,
+			},
+		]);
+
+		vi.spyOn(oauthUtils, "getOAuthApiKey").mockImplementation(async () => {
+			throw new Error("fetch failed: ECONNRESET");
+		});
+
+		await authStorage.getApiKey("anthropic", "session-transient-failure");
+
+		expect(events).toHaveLength(0);
+	});
+
+	test("swallows handler exceptions so disable still completes", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		store?.close();
+		store = await AuthCredentialStore.open(path.join(tempDir, "agent.db"));
+		authStorage = new AuthStorage(store, {
+			onCredentialDisabled: () => {
+				throw new Error("subscriber exploded");
+			},
+		});
+
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "expired-access",
+				refresh: "stale-refresh",
+				expires: Date.now() - 60_000,
+			},
+		]);
+
+		vi.spyOn(oauthUtils, "getOAuthApiKey").mockImplementation(async () => {
+			throw new Error("invalid_grant");
+		});
+
+		await expect(authStorage.getApiKey("anthropic", "session-handler-throws")).resolves.toBeUndefined();
+		expect(authStorage.list()).not.toContain("anthropic");
+	});
+
+	test("swallows async handler rejections so the disable path still completes", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		store?.close();
+		store = await AuthCredentialStore.open(path.join(tempDir, "agent.db"));
+
+		const settled = Promise.withResolvers<void>();
+		authStorage = new AuthStorage(store, {
+			onCredentialDisabled: async () => {
+				// Yield once so the rejection lands on the microtask queue, not synchronously.
+				await Promise.resolve();
+				settled.resolve();
+				throw new Error("async subscriber exploded");
+			},
+		});
+
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "expired-access",
+				refresh: "stale-refresh",
+				expires: Date.now() - 60_000,
+			},
+		]);
+
+		vi.spyOn(oauthUtils, "getOAuthApiKey").mockImplementation(async () => {
+			throw new Error("invalid_grant");
+		});
+
+		const unhandled: unknown[] = [];
+		const onUnhandled = (reason: unknown): void => {
+			unhandled.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandled);
+		try {
+			await expect(authStorage.getApiKey("anthropic", "session-async-handler-throws")).resolves.toBeUndefined();
+			// Wait for the handler's microtask + our internal .catch to run.
+			await settled.promise;
+			await Bun.sleep(0);
+			expect(authStorage.list()).not.toContain("anthropic");
+			expect(unhandled).toHaveLength(0);
+		} finally {
+			process.off("unhandledRejection", onUnhandled);
+		}
+	});
+});


### PR DESCRIPTION
## What

Adds an optional `onCredentialDisabled `callback to `AuthStorage` so callers can react when a credential is soft-disabled (e.g. OAuth refresh fails with invalid_grant). Handler exceptions are caught and logged so the disable path always completes.

Includes tests covering: definitive refresh failures fire the event, transient failures don't, and a throwing handler still lets the credential get disabled.

## Why

I was using omp with SSO which expired and had a jarring experience. I had fallback providers + models defined so was able to continue, but I wanted to write an extension to handle this better, but need the hook to detect when a credential has been marked as invalid or soft-deleted.

## Testing

Tested locally

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
