### PR TITLE
feat(coding-agent): add rpc-ui mode with tool UI context over RPC protocol

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -7,7 +7,7 @@ import chalk from "chalk";
 import { parseEffort } from "../thinking";
 import { BUILTIN_TOOLS } from "../tools";
 
-export type Mode = "text" | "json" | "rpc" | "acp";
+export type Mode = "text" | "json" | "rpc" | "acp" | "rpc-ui";
 
 export interface Args {
 	cwd?: string;
@@ -79,7 +79,7 @@ export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "
 			result.allowHome = true;
 		} else if (arg === "--mode" && i + 1 < args.length) {
 			const mode = args[++i];
-			if (mode === "text" || mode === "json" || mode === "rpc" || mode === "acp") {
+			if (mode === "text" || mode === "json" || mode === "rpc" || mode === "acp" || mode === "rpc-ui") {
 				result.mode = mode;
 			}
 		} else if (arg === "--continue" || arg === "-c") {

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -49,8 +49,8 @@ export default class Index extends Command {
 			description: "Allow starting in ~ without auto-switching to a temp dir",
 		}),
 		mode: Flags.string({
-			description: "Output mode: text (default), json, or rpc",
-			options: ["text", "json", "rpc"],
+			description: "Output mode: text (default), json, rpc, or rpc-ui",
+			options: ["text", "json", "rpc", "acp", "rpc-ui"],
 		}),
 		print: Flags.boolean({
 			char: "p",

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -638,7 +638,7 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 		process.exit(0);
 	}
 
-	if (parsedArgs.mode === "rpc" && parsedArgs.fileArgs.length > 0) {
+	if ((parsedArgs.mode === "rpc" || parsedArgs.mode === "rpc-ui") && parsedArgs.fileArgs.length > 0) {
 		process.stderr.write(`${chalk.red("Error: @file arguments are not supported in RPC mode")}\n`);
 		process.exit(1);
 	}
@@ -656,13 +656,13 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 
 	const cwd = getProjectDir();
 	const settingsInstance = await logger.time("settings:init", Settings.init, { cwd });
-	if (parsedArgs.mode === "rpc") {
+	if (parsedArgs.mode === "rpc" || parsedArgs.mode === "rpc-ui") {
 		applyRpcDefaultSettingOverrides();
 	}
 	if (parsedArgs.noPty) {
 		Bun.env.PI_NO_PTY = "1";
 	}
-	if (parsedArgs.noTitle || parsedArgs.mode === "rpc") {
+	if (parsedArgs.noTitle || parsedArgs.mode === "rpc" || parsedArgs.mode === "rpc-ui") {
 		Bun.env.PI_NO_TITLE = "1";
 	}
 	const { pipedInput, fileText, fileImages } = await logger.time("prepareInitialMessage", async () => {
@@ -783,7 +783,7 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 	);
 	sessionOptions.authStorage = authStorage;
 	sessionOptions.modelRegistry = modelRegistry;
-	sessionOptions.hasUI = isInteractive;
+	sessionOptions.hasUI = isInteractive || mode === "rpc-ui";
 	sessionOptions.settings = settingsInstance;
 
 	// Handle CLI --api-key as runtime override (not persisted)
@@ -879,8 +879,8 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 		return nextSession;
 	};
 
-	if (mode === "rpc") {
-		await runRpcMode(session);
+	if (mode === "rpc" || mode === "rpc-ui") {
+		await runRpcMode(session, mode === "rpc-ui" ? setToolUIContext : undefined);
 	} else if (mode === "acp") {
 		await runAcpMode(session, createAcpSession);
 	} else if (isInteractive) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -659,7 +659,7 @@ export async function runRootCommand(parsed: Args, rawArgs: string[]): Promise<v
 	if (parsedArgs.mode === "rpc" || parsedArgs.mode === "rpc-ui") {
 		applyRpcDefaultSettingOverrides();
 	}
-	if (parsedArgs.noPty) {
+	if (parsedArgs.noPty || parsedArgs.mode === "rpc-ui") {
 		Bun.env.PI_NO_PTY = "1";
 	}
 	if (parsedArgs.noTitle || parsedArgs.mode === "rpc" || parsedArgs.mode === "rpc-ui") {

--- a/packages/coding-agent/src/modes/rpc/rpc-mode.ts
+++ b/packages/coding-agent/src/modes/rpc/rpc-mode.ts
@@ -154,8 +154,17 @@ export function requestRpcEditor(
  * Run in RPC mode.
  * Listens for JSON commands on stdin, outputs events and responses on stdout.
  */
-export async function runRpcMode(session: AgentSession): Promise<never> {
+export async function runRpcMode(
+	session: AgentSession,
+	setToolUIContext?: (uiContext: ExtensionUIContext, hasUI: boolean) => void,
+): Promise<never> {
 	// Signal to RPC clients that the server is ready to accept commands
+	// Suppress terminal notifications: they write \x07 (BEL) or OSC sequences directly to
+	// process.stdout with no newline, which the reader merges with the next JSON line and
+	// breaks JSON.parse. In RPC mode stdout is the JSON protocol channel — nothing else
+	// may write there.
+	process.env.PI_NOTIFICATIONS = "off";
+
 	process.stdout.write(`${JSON.stringify({ type: "ready" })}\n`);
 	const output = (obj: RpcResponse | RpcExtensionUIRequest | object) => {
 		process.stdout.write(`${JSON.stringify(obj)}\n`);
@@ -405,6 +414,12 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 		}
 	}
 
+	// Wire up UI context for tool execution (ask tool, etc.) and extensions.
+	// A single shared instance routes all responses received on stdin to the
+	// correct waiting promise regardless of which code path created the request.
+	const rpcUiContext = new RpcExtensionUIContext(pendingExtensionRequests, output);
+	setToolUIContext?.(rpcUiContext, true);
+
 	// Set up extensions with RPC-based UI context
 	const extensionRunner = session.extensionRunner;
 	if (extensionRunner) {
@@ -481,7 +496,7 @@ export async function runRpcMode(session: AgentSession): Promise<never> {
 				},
 				compact: instructionsOrOptions => runExtensionCompact(session, instructionsOrOptions),
 			},
-			new RpcExtensionUIContext(pendingExtensionRequests, output),
+			rpcUiContext,
 		);
 		extensionRunner.onError(err => {
 			output({ type: "extension_error", extensionPath: err.extensionPath, event: err.event, error: err.error });


### PR DESCRIPTION
## Summary

Adds a new `rpc-ui` mode that extends the existing headless RPC mode with interactive tool support (`ask` tool, extension UI dialogs, etc.).

## Motivation

In plain `rpc` mode the session has `hasUI=false` and no UI context is wired, so interactive tools are disabled. Embedding hosts that render their own UI (editors, IDEs) need a way to run the agent headlessly over the RPC protocol while still being able to surface interactive prompts to the user. `rpc-ui` fills that gap.

## How it works

`rpc-ui` sets `hasUI=true` and wires a single shared `RpcExtensionUIContext` instance into both the tool context store and the extension runner. Both consumers share the same `pendingExtensionRequests` map and output closure, so `extension_ui_response` messages received on stdin are routed to the correct waiting promise regardless of which code path (tool or extension) created the request.

## Changes

- **`args.ts`** — add `rpc-ui` to the `Mode` union and parse guard
- **`launch.ts`** — expose `rpc-ui` in the OCLIF flag definition and help text (also adds the previously missing `acp` entry)
- **`main.ts`** — propagate `rpc-ui` through all RPC-mode guard conditions; pass `setToolUIContext` to `runRpcMode` when mode is `rpc-ui`
- **`rpc-mode.ts`** — accept optional `setToolUIContext` callback; create one shared `RpcExtensionUIContext` instance passed to both the tool context store and the extension runner