### PR TITLE
fix(autoresearch): guard ctx.ui.notify() calls with optional chaining

### DIFF
--- a/packages/coding-agent/src/autoresearch/index.ts
+++ b/packages/coding-agent/src/autoresearch/index.ts
@@ -149,7 +149,7 @@ export const createAutoresearchExtension: ExtensionFactory = api => {
 				dashboard.updateWidget(ctx, runtime);
 				const experimentTools = new Set(EXPERIMENT_TOOL_NAMES);
 				await api.setActiveTools(api.getActiveTools().filter(name => !experimentTools.has(name)));
-				ctx.ui.notify("Autoresearch mode disabled", "info");
+				ctx.ui?.notify("Autoresearch mode disabled", "info");
 				return;
 			}
 
@@ -158,7 +158,7 @@ export const createAutoresearchExtension: ExtensionFactory = api => {
 				dashboard.updateWidget(ctx, runtime);
 				const experimentTools = new Set(EXPERIMENT_TOOL_NAMES);
 				await api.setActiveTools(api.getActiveTools().filter(name => !experimentTools.has(name)));
-				ctx.ui.notify("Autoresearch mode disabled", "info");
+				ctx.ui?.notify("Autoresearch mode disabled", "info");
 				return;
 			}
 
@@ -173,11 +173,11 @@ export const createAutoresearchExtension: ExtensionFactory = api => {
 			const goalArg = trimmed.length > 0 ? trimmed : null;
 			const branchResult = await ensureAutoresearchBranch(api, ctx.cwd, goalArg ?? runtime.goal);
 			if (!branchResult.ok) {
-				ctx.ui.notify(branchResult.error, "error");
+				ctx.ui?.notify(branchResult.error, "error");
 				return;
 			}
 			if (branchResult.warning) {
-				ctx.ui.notify(branchResult.warning, "warning");
+				ctx.ui?.notify(branchResult.warning, "warning");
 			}
 
 			// Look up an existing session for the branch we just landed on. A session
@@ -220,7 +220,7 @@ export const createAutoresearchExtension: ExtensionFactory = api => {
 			if (goalArg !== null) {
 				api.sendUserMessage(goalArg);
 			} else {
-				ctx.ui.notify("Autoresearch enabled—describe what to optimize in your next message.", "info");
+				ctx.ui?.notify("Autoresearch enabled—describe what to optimize in your next message.", "info");
 			}
 		},
 	});
@@ -230,7 +230,7 @@ export const createAutoresearchExtension: ExtensionFactory = api => {
 		handler(ctx): void {
 			const runtime = getRuntime(ctx);
 			if (runtime.state.results.length === 0 && !runtime.runningExperiment) {
-				ctx.ui.notify("No autoresearch results yet", "info");
+				ctx.ui?.notify("No autoresearch results yet", "info");
 				return;
 			}
 			runtime.dashboardExpanded = !runtime.dashboardExpanded;


### PR DESCRIPTION
## Problem

Six `ctx.ui.notify()` calls in `autoresearch/index.ts` are unguarded. `ctx.ui` is `undefined` in non-interactive modes (plain `rpc`, `text`, `json`) where `setToolUIContext` is never called. Invoking the `/autoresearch` command or the `Ctrl+X` shortcut from those modes throws a `TypeError` at runtime.

Affected callsites:
- `/autoresearch` handler: disable path (×2), branch error/warning notifications (×2), enable-without-goal path (×1)
- `Ctrl+X` shortcut handler: no-results-yet notification (×1)

## Fix

Replace bare `ctx.ui.notify(...)` with `ctx.ui?.notify(...)`. Notifications are informational; silently dropping them when no UI is available is correct behavior, consistent with how `dashboard.updateWidget` already guards its `setWidget` calls with `if (!ctx.hasUI) return`.