### PR TITLE
fix(scripts): use import.meta.dir instead of URL.pathname for Windows compatibility

### DIFF
--- a/packages/coding-agent/scripts/format-prompts.ts
+++ b/packages/coding-agent/scripts/format-prompts.ts
@@ -16,9 +16,9 @@ import { prompt } from "@oh-my-pi/pi-utils";
  */
 import { Glob } from "bun";
 
-const PROMPTS_DIR = new URL("../src/prompts/", import.meta.url).pathname;
-const COMMIT_PROMPTS_DIR = new URL("../src/commit/prompts/", import.meta.url).pathname;
-const AGENTIC_PROMPTS_DIR = new URL("../src/commit/agentic/prompts/", import.meta.url).pathname;
+const PROMPTS_DIR = import.meta.dir + "/../src/prompts/";
+const COMMIT_PROMPTS_DIR = import.meta.dir + "/../src/commit/prompts/";
+const AGENTIC_PROMPTS_DIR = import.meta.dir + "/../src/commit/agentic/prompts/";
 
 const PROMPT_DIRS = [PROMPTS_DIR, COMMIT_PROMPTS_DIR, AGENTIC_PROMPTS_DIR];
 


### PR DESCRIPTION
## Problem

`new URL("../src/prompts/", import.meta.url).pathname` returns a POSIX-style path (`/D:/...`) on Windows, which is not a valid filesystem path. This causes `bun run fmt` to fail with `ENOENT: no such file or directory` on Windows.

## Fix

Replace `new URL(...).pathname` with `import.meta.dir + "/..."` which returns the correct native path on all platforms, consistent with Bun's preferred path resolution approach per the project's coding guidelines.