### PR TITLE
fix(opencode-go): mark deepseek-v4 models as not supporting tool_choice

### DIFF
--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -35705,6 +35705,11 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
+			"compat": {
+				"supportsToolChoice": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -35729,6 +35734,11 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
+			"compat": {
+				"supportsToolChoice": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",


### PR DESCRIPTION
The `opencode-go` provider definitions for `deepseek-v4-flash` and `deepseek-v4-pro` were missing `compat.supportsToolChoice: false`, causing OMP to send `tool_choice` in requests. DeepSeek's API rejects the `tool_choice` parameter with a 400 error (`"deepseek-reasoner does not support this tool_choice"`).

Mirrors the compat block already present on the direct `deepseek` provider definitions for the same models (lines 4848-4855). OMP's `openai-completions` provider already guards `tool_choice` on `compat.supportsToolChoice` (line 978) — this just fixes the missing model config.