### PR TITLE
fix(ai): mark opencode-go deepseek-v4 models as not supporting tool_choice

### DIFF
--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -35705,6 +35705,11 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
+			"compat": {
+				"supportsToolChoice": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -35729,6 +35734,11 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
+			"compat": {
+				"supportsToolChoice": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true
+			},
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",


### PR DESCRIPTION
The opencode-go provider entries for `deepseek-v4-flash` and `deepseek-v4-pro` were missing `compat.supportsToolChoice: false`, causing OMP to send `tool_choice` in requests. DeepSeek's API rejects the parameter with a 400 error.

Mirrors the compat block already present on the direct `deepseek` provider definitions for the same models.