### PR TITLE
fix(opencode-go): disable tool_choice for deepseek-v4 models

### DIFF
--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -319,13 +319,25 @@ function applyGeneratedModelPolicy(model: ApiModel<Api>): void {
 		(model.provider === "minimax-code" || model.provider === "minimax-code-cn")
 	) {
 		model.compat = {
-			...model.compat,
+			...(model.compat ?? {}),
 			supportsStore: false,
 			supportsDeveloperRole: false,
 			supportsReasoningEffort: false,
 			reasoningContentField: "reasoning_content",
 		};
 		delete model.compat.thinkingFormat;
+	}
+	if (
+		model.api === "openai-completions" &&
+		model.provider === "opencode-go" &&
+		(model.id === "deepseek-v4-flash" || model.id === "deepseek-v4-pro")
+	) {
+		model.compat = {
+			...(model.compat ?? {}),
+			supportsToolChoice: false,
+			reasoningContentField: "reasoning_content",
+			requiresReasoningContentForToolCalls: true,
+		};
 	}
 	const parsedModel = parseKnownModel(model.id);
 	const applyPatchToolType = inferGeneratedApplyPatchToolType(model, parsedModel);

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -403,6 +403,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"au.anthropic.claude-haiku-4-5-20251001-v1:0": {
+			"id": "au.anthropic.claude-haiku-4-5-20251001-v1:0",
+			"name": "Claude Haiku 4.5 (AU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 5,
+				"cacheRead": 0.1,
+				"cacheWrite": 1.25
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"au.anthropic.claude-opus-4-6-v1": {
 			"id": "au.anthropic.claude-opus-4-6-v1",
 			"name": "AU Anthropic Claude Opus 4.6",
@@ -426,6 +451,31 @@
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
+			}
+		},
+		"au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+			"id": "au.anthropic.claude-sonnet-4-5-20250929-v1:0",
+			"name": "Claude Sonnet 4.5 (AU)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "anthropic-budget-effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
 			}
 		},
 		"au.anthropic.claude-sonnet-4-6": {
@@ -1162,6 +1212,81 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096
+		},
+		"jp.anthropic.claude-opus-4-7": {
+			"id": "jp.anthropic.claude-opus-4-7",
+			"name": "Claude Opus 4.7 (JP)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
+			"id": "jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
+			"name": "Claude Sonnet 4.5 (JP)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "anthropic-budget-effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"jp.anthropic.claude-sonnet-4-6": {
+			"id": "jp.anthropic.claude-sonnet-4-6",
+			"name": "Claude Sonnet 4.6 (JP)",
+			"api": "bedrock-converse-stream",
+			"provider": "amazon-bedrock",
+			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "anthropic-budget-effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"meta.llama3-1-405b-instruct-v1:0": {
 			"id": "meta.llama3-1-405b-instruct-v1:0",
@@ -4136,7 +4261,11 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"gemini-3.1-pro": {
@@ -4161,7 +4290,11 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"gpt-5.1-codex-max": {
@@ -5341,7 +5474,11 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"gemini-3.1-pro-preview": {
@@ -5374,7 +5511,11 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"gpt-4.1": {
@@ -5520,7 +5661,7 @@
 		},
 		"gpt-5.1-codex": {
 			"id": "gpt-5.1-codex",
-			"name": "GPT-5.1-Codex",
+			"name": "GPT-5.1 Codex",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5548,7 +5689,7 @@
 		},
 		"gpt-5.1-codex-max": {
 			"id": "gpt-5.1-codex-max",
-			"name": "GPT-5.1-Codex-max",
+			"name": "GPT-5.1 Codex Max",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5576,7 +5717,7 @@
 		},
 		"gpt-5.1-codex-mini": {
 			"id": "gpt-5.1-codex-mini",
-			"name": "GPT-5.1-Codex-mini",
+			"name": "GPT-5.1 Codex mini",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -6606,6 +6747,35 @@
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "low",
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
+			}
+		},
+		"gemini-3.1-flash-lite": {
+			"id": "gemini-3.1-flash-lite",
+			"name": "Gemini 3.1 Flash Lite",
+			"api": "google-generative-ai",
+			"provider": "google",
+			"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.25,
+				"output": 1.5,
+				"cacheRead": 0.025,
+				"cacheWrite": 1
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "google-level",
+				"minLevel": "minimal",
 				"maxLevel": "high"
 			}
 		},
@@ -6656,7 +6826,11 @@
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"gemini-3.1-pro-preview-customtools": {
@@ -6681,7 +6855,11 @@
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"gemini-flash-latest": {
@@ -7202,7 +7380,11 @@
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"gemini-3-pro-low": {
@@ -7227,7 +7409,11 @@
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"gemini-3.1-pro-high": {
@@ -7252,7 +7438,11 @@
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"gemini-3.1-pro-low": {
@@ -7277,7 +7467,11 @@
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"gpt-oss-120b-medium": {
@@ -7423,7 +7617,11 @@
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"gemini-3.1-flash-lite-preview": {
@@ -7473,7 +7671,11 @@
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		}
 	},
@@ -7725,7 +7927,11 @@
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"gemini-3.1-pro-preview": {
@@ -7750,7 +7956,11 @@
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"gemini-3.1-pro-preview-customtools": {
@@ -7775,7 +7985,11 @@
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		}
 	},
@@ -9319,6 +9533,25 @@
 			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
+		"baidu/cobuddy:free": {
+			"id": "baidu/cobuddy:free",
+			"name": "Baidu Qianfan: CoBuddy (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"baidu/ernie-4.5-21b-a3b": {
 			"id": "baidu/ernie-4.5-21b-a3b",
 			"name": "Baidu: ERNIE 4.5 21B A3B",
@@ -10254,7 +10487,11 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"google/gemini-3-pro-preview": {
@@ -10279,12 +10516,35 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"google/gemini-3.1-flash-image-preview": {
 			"id": "google/gemini-3.1-flash-image-preview",
 			"name": "Google: Nano Banana 2 (Gemini 3.1 Flash Image Preview)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"google/gemini-3.1-flash-lite": {
+			"id": "google/gemini-3.1-flash-lite",
+			"name": "Google: Gemini 3.1 Flash Lite",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -10343,7 +10603,11 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"google/gemini-3.1-pro-preview-customtools": {
@@ -10682,6 +10946,25 @@
 			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
+		"inclusionai/ling-2.6-1t": {
+			"id": "inclusionai/ling-2.6-1t",
+			"name": "inclusionAI: Ling-2.6-1T",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"inclusionai/ling-2.6-1t:free": {
 			"id": "inclusionai/ling-2.6-1t:free",
 			"name": "inclusionAI: Ling-2.6-1T (free)",
@@ -10723,6 +11006,25 @@
 		"inclusionai/ling-2.6-flash:free": {
 			"id": "inclusionai/ling-2.6-flash:free",
 			"name": "inclusionAI: Ling-2.6-flash (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"inclusionai/ring-2.6-1t:free": {
+			"id": "inclusionai/ring-2.6-1t:free",
+			"name": "inclusionAI: Ring-2.6-1T (free)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -11366,6 +11668,31 @@
 			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
+		"microsoft/phi-4-mini-instruct": {
+			"id": "microsoft/phi-4-mini-instruct",
+			"name": "Phi-4-Mini",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 8192,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"microsoft/wizardlm-2-8x22b": {
 			"id": "microsoft/wizardlm-2-8x22b",
 			"name": "WizardLM-2 8x22B",
@@ -11826,6 +12153,25 @@
 		"mistralai/mistral-medium-3": {
 			"id": "mistralai/mistral-medium-3",
 			"name": "Mistral: Mistral Medium 3",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"mistralai/mistral-medium-3-5": {
+			"id": "mistralai/mistral-medium-3-5",
+			"name": "Mistral: Mistral Medium 3.5",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -13631,6 +13977,25 @@
 		"openai/gpt-audio-mini": {
 			"id": "openai/gpt-audio-mini",
 			"name": "OpenAI: GPT Audio Mini",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"openai/gpt-chat-latest": {
+			"id": "openai/gpt-chat-latest",
+			"name": "OpenAI: GPT Chat Latest",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -15660,6 +16025,30 @@
 			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
+		"tencent/hy3-preview": {
+			"id": "tencent/hy3-preview",
+			"name": "Hy3 preview",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"tencent/hy3-preview:free": {
 			"id": "tencent/hy3-preview:free",
 			"name": "Tencent: Hy3 preview (free)",
@@ -16103,7 +16492,7 @@
 		},
 		"x-ai/grok-code-fast-1:optimized:free": {
 			"id": "x-ai/grok-code-fast-1:optimized:free",
-			"name": "xAI: Grok Code Fast 1 Optimized (free)",
+			"name": "xAI: Grok Code Fast 1, retiring May 15 (free)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -16136,8 +16525,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262000,
-			"maxTokens": 64000,
+			"contextWindow": 262144,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -16150,7 +16539,7 @@
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
@@ -16162,7 +16551,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 265000,
-			"maxTokens": 265000
+			"maxTokens": 265000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"xiaomi/mimo-v2-omni:free": {
 			"id": "xiaomi/mimo-v2-omni:free",
@@ -16191,8 +16585,7 @@
 			"baseUrl": "https://api.kilo.ai/api/gateway",
 			"reasoning": true,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0,
@@ -16235,7 +16628,8 @@
 			"baseUrl": "https://api.kilo.ai/api/gateway",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -16259,8 +16653,7 @@
 			"baseUrl": "https://api.kilo.ai/api/gateway",
 			"reasoning": true,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0,
@@ -17315,7 +17708,11 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"gemini-3-pro-preview": {
@@ -17340,7 +17737,11 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"glm-4.5": {
@@ -18509,7 +18910,8 @@
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsReasoningEffort": false,
-				"reasoningContentField": "reasoning_content"
+				"reasoningContentField": "reasoning_content",
+				"supportsStore": false
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 32000,
@@ -18598,7 +19000,8 @@
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsReasoningEffort": false,
-				"reasoningContentField": "reasoning_content"
+				"reasoningContentField": "reasoning_content",
+				"supportsStore": false
 			},
 			"contextWindow": 204800,
 			"maxTokens": 32000,
@@ -18749,7 +19152,8 @@
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsReasoningEffort": false,
-				"reasoningContentField": "reasoning_content"
+				"reasoningContentField": "reasoning_content",
+				"supportsStore": false
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 32000,
@@ -18838,7 +19242,8 @@
 			"compat": {
 				"supportsDeveloperRole": false,
 				"supportsReasoningEffort": false,
-				"reasoningContentField": "reasoning_content"
+				"reasoningContentField": "reasoning_content",
+				"supportsStore": false
 			},
 			"contextWindow": 204800,
 			"maxTokens": 32000,
@@ -22943,7 +23348,11 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"gemini-3-pro-preview-thinking": {
@@ -23621,7 +24030,11 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"google/gemini-3.1-pro-preview-customtools": {
@@ -23646,7 +24059,11 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"google/gemini-3.1-pro-preview-high": {
@@ -31907,7 +32324,7 @@
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
@@ -31919,7 +32336,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 265000,
-			"maxTokens": 265000
+			"maxTokens": 265000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"xiaomi/mimo-v2-pro": {
 			"id": "xiaomi/mimo-v2-pro",
@@ -31929,8 +32351,7 @@
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"reasoning": true,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0,
@@ -31954,7 +32375,8 @@
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -31978,8 +32400,7 @@
 			"baseUrl": "https://nano-gpt.com/api/v1",
 			"reasoning": true,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 0,
@@ -35709,6 +36130,11 @@
 				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
+			},
+			"compat": {
+				"supportsToolChoice": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true
 			}
 		},
 		"deepseek-v4-pro": {
@@ -35733,6 +36159,11 @@
 				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
+			},
+			"compat": {
+				"supportsToolChoice": false,
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true
 			}
 		},
 		"glm-5": {
@@ -35810,7 +36241,7 @@
 		},
 		"kimi-k2.6": {
 			"id": "kimi-k2.6",
-			"name": "Kimi K2.6 (3x limits)",
+			"name": "Kimi K2.6",
 			"api": "openai-completions",
 			"provider": "opencode-go",
 			"baseUrl": "https://opencode.ai/zen/go/v1",
@@ -35820,9 +36251,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.32,
-				"output": 1.34,
-				"cacheRead": 0.054,
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.16,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -35835,7 +36266,7 @@
 		},
 		"mimo-v2-omni": {
 			"id": "mimo-v2-omni",
-			"name": "MiMo V2 Omni",
+			"name": "MiMo-V2-Omni",
 			"api": "openai-completions",
 			"provider": "opencode-go",
 			"baseUrl": "https://opencode.ai/zen/go/v1",
@@ -35860,7 +36291,7 @@
 		},
 		"mimo-v2-pro": {
 			"id": "mimo-v2-pro",
-			"name": "MiMo V2 Pro",
+			"name": "MiMo-V2-Pro",
 			"api": "openai-completions",
 			"provider": "opencode-go",
 			"baseUrl": "https://opencode.ai/zen/go/v1",
@@ -36034,9 +36465,9 @@
 		"big-pickle": {
 			"id": "big-pickle",
 			"name": "Big Pickle",
-			"api": "anthropic-messages",
+			"api": "openai-completions",
 			"provider": "opencode-zen",
-			"baseUrl": "https://opencode.ai/zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
 			"reasoning": true,
 			"input": [
 				"text"
@@ -36050,7 +36481,7 @@
 			"contextWindow": 200000,
 			"maxTokens": 128000,
 			"thinking": {
-				"mode": "budget",
+				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
@@ -36322,7 +36753,11 @@
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"gemini-3.1-pro": {
@@ -36347,7 +36782,11 @@
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"glm-4.6": {
@@ -36508,9 +36947,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.05,
+				"output": 0.4,
+				"cacheRead": 0.005,
 				"cacheWrite": 0
 			},
 			"contextWindow": 400000,
@@ -37276,6 +37715,30 @@
 				"maxLevel": "high"
 			}
 		},
+		"ring-2.6-1t-free": {
+			"id": "ring-2.6-1t-free",
+			"name": "Ring 2.6 1T Free",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262000,
+			"maxTokens": 66000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"trinity-large-preview-free": {
 			"id": "trinity-large-preview-free",
 			"name": "Trinity Large Preview",
@@ -37434,13 +37897,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.74,
-				"output": 3.49,
-				"cacheRead": 0.14,
+				"input": 0.75,
+				"output": 3.5,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262142,
-			"maxTokens": 262142,
+			"contextWindow": 262144,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -38190,6 +38653,33 @@
 				"maxLevel": "high"
 			}
 		},
+		"baidu/cobuddy:free": {
+			"id": "baidu/cobuddy:free",
+			"name": "Baidu Qianfan: CoBuddy (free)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 65536,
+			"compat": {
+				"supportsToolChoice": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"baidu/ernie-4.5-21b-a3b": {
 			"id": "baidu/ernie-4.5-21b-a3b",
 			"name": "Baidu: ERNIE 4.5 21B A3B",
@@ -38623,8 +39113,8 @@
 				"cacheRead": 0.003625,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131000,
-			"maxTokens": 131000,
+			"contextWindow": 1048576,
+			"maxTokens": 384000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -38667,7 +39157,7 @@
 				"cacheRead": 0.024999999999999998,
 				"cacheWrite": 0.08333333333333334
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1000000,
 			"maxTokens": 8192
 		},
 		"google/gemini-2.0-flash-lite-001": {
@@ -38907,6 +39397,35 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
+			}
+		},
+		"google/gemini-3.1-flash-lite": {
+			"id": "google/gemini-3.1-flash-lite",
+			"name": "Google: Gemini 3.1 Flash Lite",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.25,
+				"output": 1.5,
+				"cacheRead": 0.024999999999999998,
+				"cacheWrite": 0.08333333333333334
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
 				"maxLevel": "high"
 			}
 		},
@@ -38952,7 +39471,11 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"google/gemini-3.1-pro-preview-customtools": {
@@ -38977,7 +39500,11 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"google/gemma-3-12b-it": {
@@ -39225,6 +39752,25 @@
 			"contextWindow": 128000,
 			"maxTokens": 32000
 		},
+		"inclusionai/ling-2.6-1t": {
+			"id": "inclusionai/ling-2.6-1t",
+			"name": "inclusionAI: Ling-2.6-1T",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.3,
+				"output": 2.5,
+				"cacheRead": 0.06,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768
+		},
 		"inclusionai/ling-2.6-1t:free": {
 			"id": "inclusionai/ling-2.6-1t:free",
 			"name": "inclusionAI: Ling-2.6-1T (free)",
@@ -39281,6 +39827,30 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768
+		},
+		"inclusionai/ring-2.6-1t:free": {
+			"id": "inclusionai/ring-2.6-1t:free",
+			"name": "inclusionAI: Ring-2.6-1T (free)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"kwaipilot/kat-coder-pro": {
 			"id": "kwaipilot/kat-coder-pro",
@@ -39582,7 +40152,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 196608,
-			"maxTokens": 131072,
+			"maxTokens": 196608,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -39627,13 +40197,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
+				"input": 0.29900000000000004,
 				"output": 1.2,
 				"cacheRead": 0.059,
 				"cacheWrite": 0
 			},
 			"contextWindow": 196608,
-			"maxTokens": 131070,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -39872,6 +40442,31 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 8888
+		},
+		"mistralai/mistral-medium-3-5": {
+			"id": "mistralai/mistral-medium-3-5",
+			"name": "Mistral: Mistral Medium 3.5",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.5,
+				"output": 7.5,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 8888,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"mistralai/mistral-medium-3.1": {
 			"id": "mistralai/mistral-medium-3.1",
@@ -40224,13 +40819,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.44,
-				"output": 2,
-				"cacheRead": 0.22,
+				"input": 0.39999999999999997,
+				"output": 1.9800000000000002,
+				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65535,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -40249,13 +40844,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.74,
-				"output": 3.49,
-				"cacheRead": 0.14,
+				"input": 0.75,
+				"output": 3.5,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262142,
-			"maxTokens": 262142,
+			"contextWindow": 262144,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -41548,6 +42143,26 @@
 			"contextWindow": 128000,
 			"maxTokens": 16384
 		},
+		"openai/gpt-chat-latest": {
+			"id": "openai/gpt-chat-latest",
+			"name": "OpenAI: GPT Chat Latest",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000
+		},
 		"openai/gpt-oss-120b": {
 			"id": "openai/gpt-oss-120b",
 			"name": "GPT OSS 120B",
@@ -42484,12 +43099,12 @@
 			],
 			"cost": {
 				"input": 0.08,
-				"output": 0.24,
+				"output": 0.28,
 				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
 			"contextWindow": 40960,
-			"maxTokens": 40960,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -42636,7 +43251,7 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.12,
+				"input": 0.11,
 				"output": 0.7999999999999999,
 				"cacheRead": 0.07,
 				"cacheWrite": 0
@@ -43028,13 +43643,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.15,
+				"input": 0.14,
 				"output": 1,
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 81920,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -43078,13 +43693,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
+				"input": 0.04,
 				"output": 0.15,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 8888,
+			"maxTokens": 81920,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -43502,6 +44117,30 @@
 			"compat": {
 				"supportsToolChoice": false
 			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"tencent/hy3-preview": {
+			"id": "tencent/hy3-preview",
+			"name": "Hy3 preview",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.06599999999999999,
+				"output": 0.26,
+				"cacheRead": 0.029,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -43937,9 +44576,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09,
-				"output": 0.29,
-				"cacheRead": 0.045,
+				"input": 0.09999999999999999,
+				"output": 0.3,
+				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -43956,7 +44595,7 @@
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
@@ -43968,7 +44607,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"xiaomi/mimo-v2-pro": {
 			"id": "xiaomi/mimo-v2-pro",
@@ -43978,8 +44622,7 @@
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"reasoning": true,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 1,
@@ -44003,7 +44646,8 @@
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.39999999999999997,
@@ -44027,8 +44671,7 @@
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"reasoning": true,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 1,
@@ -44037,7 +44680,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 131072,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -44244,13 +44887,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.38,
-				"output": 1.74,
-				"cacheRead": 0.195,
+				"input": 0.39999999999999997,
+				"output": 1.75,
+				"cacheRead": 0.08,
 				"cacheWrite": 0
 			},
 			"contextWindow": 202752,
-			"maxTokens": 64000,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -44293,12 +44936,12 @@
 			],
 			"cost": {
 				"input": 0.6,
-				"output": 2.08,
+				"output": 1.92,
 				"cacheRead": 0.12,
 				"cacheWrite": 0
 			},
 			"contextWindow": 202752,
-			"maxTokens": 16384,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -45714,7 +46357,11 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"gemma-4-uncensored": {
@@ -48384,6 +49031,35 @@
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "low",
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
+			}
+		},
+		"google/gemini-3.1-flash-lite": {
+			"id": "google/gemini-3.1-flash-lite",
+			"name": "Gemini 3.1 Flash Lite",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.25,
+				"output": 1.5,
+				"cacheRead": 0.03,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
 				"maxLevel": "high"
 			}
 		},
@@ -48429,7 +49105,11 @@
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"google/gemma-4-26b-a4b-it": {
@@ -50540,8 +51220,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 6,
+				"input": 1.25,
+				"output": 2.5,
 				"cacheRead": 0.19999999999999998,
 				"cacheWrite": 0
 			},
@@ -50565,8 +51245,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 6,
+				"input": 1.25,
+				"output": 2.5,
 				"cacheRead": 0.19999999999999998,
 				"cacheWrite": 0
 			},
@@ -50590,8 +51270,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 6,
+				"input": 1.25,
+				"output": 2.5,
 				"cacheRead": 0.19999999999999998,
 				"cacheWrite": 0
 			},
@@ -50610,8 +51290,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 6,
+				"input": 1.25,
+				"output": 2.5,
 				"cacheRead": 0.19999999999999998,
 				"cacheWrite": 0
 			},
@@ -50630,8 +51310,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 6,
+				"input": 1.25,
+				"output": 2.5,
 				"cacheRead": 0.19999999999999998,
 				"cacheWrite": 0
 			},
@@ -50655,8 +51335,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 6,
+				"input": 1.25,
+				"output": 2.5,
 				"cacheRead": 0.19999999999999998,
 				"cacheWrite": 0
 			},
@@ -50749,8 +51429,7 @@
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"reasoning": true,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 1,
@@ -50774,7 +51453,8 @@
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.39999999999999997,
@@ -50798,8 +51478,7 @@
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"reasoning": true,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 1,
@@ -51757,8 +52436,8 @@
 				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 64000,
+			"contextWindow": 262144,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -51782,8 +52461,8 @@
 				"cacheRead": 0.08,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 128000,
+			"contextWindow": 262144,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -51806,8 +52485,8 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
-			"maxTokens": 128000,
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -51822,7 +52501,8 @@
 			"baseUrl": "https://api.xiaomimimo.com/anthropic",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.4,
@@ -51846,8 +52526,7 @@
 			"baseUrl": "https://api.xiaomimimo.com/anthropic",
 			"reasoning": true,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 1,
@@ -53053,7 +53732,11 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"google/gemini-3-pro-preview": {
@@ -53078,7 +53761,11 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"google/gemini-3.1-flash-lite-preview": {
@@ -53123,7 +53810,11 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
-				"maxLevel": "high"
+				"maxLevel": "high",
+				"levels": [
+					"low",
+					"high"
+				]
 			}
 		},
 		"google/gemma-3-12b-it": {
@@ -55301,8 +55992,8 @@
 				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262000,
-			"maxTokens": 64000,
+			"contextWindow": 262144,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -55339,7 +56030,7 @@
 			"api": "openai-completions",
 			"provider": "zenmux",
 			"baseUrl": "https://zenmux.ai/api/v1",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
@@ -55347,11 +56038,16 @@
 			"cost": {
 				"input": 0.4,
 				"output": 2,
-				"cacheRead": 0,
+				"cacheRead": 0.08,
 				"cacheWrite": 0
 			},
 			"contextWindow": 265000,
-			"maxTokens": 265000
+			"maxTokens": 265000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"xiaomi/mimo-v2-pro": {
 			"id": "xiaomi/mimo-v2-pro",
@@ -55361,13 +56057,12 @@
 			"baseUrl": "https://zenmux.ai/api/v1",
 			"reasoning": true,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
-				"input": 1.5,
-				"output": 4.5,
-				"cacheRead": 0,
+				"input": 1,
+				"output": 3,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -55386,7 +56081,8 @@
 			"baseUrl": "https://zenmux.ai/api/v1",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.4,
@@ -55410,8 +56106,7 @@
 			"baseUrl": "https://zenmux.ai/api/v1",
 			"reasoning": true,
 			"input": [
-				"text",
-				"image"
+				"text"
 			],
 			"cost": {
 				"input": 1,

--- a/packages/ai/test/issue-945-repro.test.ts
+++ b/packages/ai/test/issue-945-repro.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import { getBundledModel } from "@oh-my-pi/pi-ai/models";
-import { detectCompat, streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
 import type { Context, Model, Tool } from "@oh-my-pi/pi-ai/types";
 import { Type } from "@sinclair/typebox";
 
@@ -38,19 +38,16 @@ async function capturePayload(opts: Parameters<typeof streamOpenAICompletions>[2
 	return (await promise) as Record<string, unknown>;
 }
 
-describe("issue #945 — OpenCode Go DeepSeek disables reasoning when tool_choice is used", () => {
-	it("detects deepseek-v4-pro as supporting tool_choice with per-request reasoning suppression", () => {
+describe("issue #945 — OpenCode Go DeepSeek tool_choice is disabled", () => {
+	it("marks deepseek-v4-pro as not supporting tool_choice via compat override", () => {
 		const model = getBundledModel("opencode-go", "deepseek-v4-pro") as Model<"openai-completions">;
-		expect(model.compat?.supportsToolChoice).toBeUndefined();
-		const compat = detectCompat(model);
-		expect(compat.supportsToolChoice).toBe(true);
-		expect(compat.disableReasoningOnToolChoice).toBe(true);
+		expect(model.compat?.supportsToolChoice).toBe(false);
 	});
 
-	it("preserves tool_choice and tools while omitting reasoning_effort", async () => {
+	it("omits tool_choice from payload but preserves tools and reasoning_effort", async () => {
 		const body = await capturePayload({ reasoning: "high", toolChoice: "auto" });
 		expect(body.tools).toBeDefined();
-		expect(body.tool_choice).toBe("auto");
-		expect(body.reasoning_effort).toBeUndefined();
+		expect(body.tool_choice).toBeUndefined();
+		expect(body.reasoning_effort).toBe("high");
 	});
 });


### PR DESCRIPTION
Closes #945. DeepSeek v4 Flash and Pro served through the opencode-go provider (openai-completions API) reject requests with `tool_choice`. Override compat to set `supportsToolChoice: false` and configure the reasoning content field requirements. Also fixes a latent bug where spreading `model.compat` could crash on undefined.