### PR TITLE
feat(coding-agent): return JS eval final expressions

### DIFF
--- a/packages/coding-agent/src/eval/js/shared/rewrite-imports.ts
+++ b/packages/coding-agent/src/eval/js/shared/rewrite-imports.ts
@@ -217,7 +217,12 @@ const LOOKS_LIKE_TS =
 	/(?:\binterface\s+\w|\btype\s+\w+\s*=|\b(?:as|satisfies)\s+(?:[A-Z]|\bconst\b)|:\s*(?:string|number|boolean|any|unknown|void|never|object|[A-Z]\w*)\b|<\s*[A-Z]\w*\s*[,>])/;
 
 export function wrapCode(code: string): { source: string; asyncWrapped: boolean; finalExpressionReturned: boolean } {
-	const rewritten = returnFinalExpression(demoteTopLevelLexicals(rewriteStaticImports(stripTypeScript(code))));
+	const stripped = stripTypeScript(code);
+	const finalExpression = returnFinalExpression(stripped);
+	const rewritten = {
+		source: demoteTopLevelLexicals(rewriteStaticImports(finalExpression.source)),
+		returned: finalExpression.returned,
+	};
 	const needsAsyncWrapper = /\bawait\b|\breturn\b/.test(rewritten.source);
 	if (!needsAsyncWrapper) {
 		return { source: rewritten.source, asyncWrapped: false, finalExpressionReturned: rewritten.returned };

--- a/packages/coding-agent/src/eval/js/shared/rewrite-imports.ts
+++ b/packages/coding-agent/src/eval/js/shared/rewrite-imports.ts
@@ -29,6 +29,7 @@ type BabelExpressionStatement = {
 	type: "ExpressionStatement";
 	start: number;
 	end: number;
+	expression?: { type?: string };
 };
 
 type BabelProgramNode = BabelImportDeclaration | BabelLexicalDecl | BabelExpressionStatement | { type: string };
@@ -186,7 +187,10 @@ function returnFinalExpression(code: string): { source: string; returned: boolea
 	const suffix = code.slice(expression.end);
 	const semicolonMatch = statement.match(/;\s*$/);
 	const trimmedStatement = semicolonMatch ? statement.slice(0, semicolonMatch.index) : statement;
-	return { source: `${prefix}__omp_display__(${trimmedStatement});${suffix}`, returned: true };
+	const needsAwait =
+		expression.expression?.type === "AwaitExpression" || expression.expression?.type === "CallExpression";
+	const displayExpression = needsAwait ? `await (${trimmedStatement})` : trimmedStatement;
+	return { source: `${prefix}__omp_display__(${displayExpression});${suffix}`, returned: true };
 }
 
 /**

--- a/packages/coding-agent/src/eval/js/shared/rewrite-imports.ts
+++ b/packages/coding-agent/src/eval/js/shared/rewrite-imports.ts
@@ -216,14 +216,15 @@ export function stripTypeScript(code: string): string {
 const LOOKS_LIKE_TS =
 	/(?:\binterface\s+\w|\btype\s+\w+\s*=|\b(?:as|satisfies)\s+(?:[A-Z]|\bconst\b)|:\s*(?:string|number|boolean|any|unknown|void|never|object|[A-Z]\w*)\b|<\s*[A-Z]\w*\s*[,>])/;
 
-export function wrapCode(code: string): { source: string; asyncWrapped: boolean } {
+export function wrapCode(code: string): { source: string; asyncWrapped: boolean; finalExpressionReturned: boolean } {
 	const rewritten = returnFinalExpression(demoteTopLevelLexicals(rewriteStaticImports(stripTypeScript(code))));
 	const needsAsyncWrapper = /\bawait\b|\breturn\b/.test(rewritten.source);
 	if (!needsAsyncWrapper) {
-		return { source: rewritten.source, asyncWrapped: false };
+		return { source: rewritten.source, asyncWrapped: false, finalExpressionReturned: rewritten.returned };
 	}
 	return {
 		source: `(async () => {\n${rewritten.source}\n})()`,
 		asyncWrapped: true,
+		finalExpressionReturned: rewritten.returned,
 	};
 }

--- a/packages/coding-agent/src/eval/js/shared/rewrite-imports.ts
+++ b/packages/coding-agent/src/eval/js/shared/rewrite-imports.ts
@@ -175,10 +175,10 @@ export function demoteTopLevelLexicals(code: string): string {
 	return result;
 }
 
-function returnFinalExpression(code: string): string {
+function returnFinalExpression(code: string): { source: string; returned: boolean } {
 	const ast = parseProgram(code);
 	const last = ast?.program.body.at(-1);
-	if (last?.type !== "ExpressionStatement") return code;
+	if (last?.type !== "ExpressionStatement") return { source: code, returned: false };
 
 	const expression = last as BabelExpressionStatement;
 	const prefix = code.slice(0, expression.start);
@@ -186,7 +186,7 @@ function returnFinalExpression(code: string): string {
 	const suffix = code.slice(expression.end);
 	const semicolonMatch = statement.match(/;\s*$/);
 	const trimmedStatement = semicolonMatch ? statement.slice(0, semicolonMatch.index) : statement;
-	return `${prefix}return (${trimmedStatement});${suffix}`;
+	return { source: `${prefix}__omp_display__(${trimmedStatement});${suffix}`, returned: true };
 }
 
 /**
@@ -217,12 +217,12 @@ const LOOKS_LIKE_TS =
 
 export function wrapCode(code: string): { source: string; asyncWrapped: boolean } {
 	const rewritten = returnFinalExpression(demoteTopLevelLexicals(rewriteStaticImports(stripTypeScript(code))));
-	const needsAsyncWrapper = /\bawait\b|\breturn\b/.test(rewritten);
+	const needsAsyncWrapper = /\bawait\b|\breturn\b/.test(rewritten.source);
 	if (!needsAsyncWrapper) {
-		return { source: rewritten, asyncWrapped: false };
+		return { source: rewritten.source, asyncWrapped: false };
 	}
 	return {
-		source: `(async () => {\n${rewritten}\n})()`,
+		source: `(async () => {\n${rewritten.source}\n})()`,
 		asyncWrapped: true,
 	};
 }

--- a/packages/coding-agent/src/eval/js/shared/rewrite-imports.ts
+++ b/packages/coding-agent/src/eval/js/shared/rewrite-imports.ts
@@ -187,7 +187,7 @@ function returnFinalExpression(code: string): { source: string; returned: boolea
 	const suffix = code.slice(expression.end);
 	const semicolonMatch = statement.match(/;\s*$/);
 	const trimmedStatement = semicolonMatch ? statement.slice(0, semicolonMatch.index) : statement;
-	return { source: `${prefix}globalThis.__omp_final_expr__ = (${trimmedStatement});${suffix}`, returned: true };
+	return { source: `${prefix}__omp_set_final_expr__((${trimmedStatement}));${suffix}`, returned: true };
 }
 
 /**

--- a/packages/coding-agent/src/eval/js/shared/rewrite-imports.ts
+++ b/packages/coding-agent/src/eval/js/shared/rewrite-imports.ts
@@ -187,10 +187,7 @@ function returnFinalExpression(code: string): { source: string; returned: boolea
 	const suffix = code.slice(expression.end);
 	const semicolonMatch = statement.match(/;\s*$/);
 	const trimmedStatement = semicolonMatch ? statement.slice(0, semicolonMatch.index) : statement;
-	const needsAwait =
-		expression.expression?.type === "AwaitExpression" || expression.expression?.type === "CallExpression";
-	const displayExpression = needsAwait ? `await (${trimmedStatement})` : trimmedStatement;
-	return { source: `${prefix}__omp_display__(${displayExpression});${suffix}`, returned: true };
+	return { source: `${prefix}globalThis.__omp_final_expr__ = (${trimmedStatement});${suffix}`, returned: true };
 }
 
 /**

--- a/packages/coding-agent/src/eval/js/shared/rewrite-imports.ts
+++ b/packages/coding-agent/src/eval/js/shared/rewrite-imports.ts
@@ -25,6 +25,31 @@ type BabelLexicalDecl =
 	| { type: "VariableDeclaration"; kind: "const" | "let" | "var"; start: number; end: number }
 	| { type: "ClassDeclaration"; start: number; end: number; id: { start: number; end: number; name: string } | null };
 
+type BabelExpressionStatement = {
+	type: "ExpressionStatement";
+	start: number;
+	end: number;
+};
+
+type BabelProgramNode = BabelImportDeclaration | BabelLexicalDecl | BabelExpressionStatement | { type: string };
+
+function parseProgram(code: string): { program: { body: ReadonlyArray<BabelProgramNode> } } | null {
+	try {
+		return babelParse(code, {
+			sourceType: "module",
+			allowAwaitOutsideFunction: true,
+			allowReturnOutsideFunction: true,
+			allowImportExportEverywhere: true,
+			allowNewTargetOutsideFunction: true,
+			allowSuperOutsideMethod: true,
+			allowUndeclaredExports: true,
+			errorRecovery: true,
+		}) as unknown as { program: { body: ReadonlyArray<BabelProgramNode> } };
+	} catch {
+		return null;
+	}
+}
+
 function buildDynamicImportCall(sourceLiteral: string, withClause: string | undefined): string {
 	// Route every static import through the worker-injected `__omp_import__` helper so the
 	// specifier resolves against the session cwd (and `with`-attribute imports keep working).
@@ -76,19 +101,8 @@ function rewriteImportNode(node: BabelImportDeclaration): string {
 export function rewriteStaticImports(code: string): string {
 	if (!code.includes("import")) return code;
 
-	let ast: { program: { body: ReadonlyArray<{ type: string }> } };
-	try {
-		ast = babelParse(code, {
-			sourceType: "module",
-			allowAwaitOutsideFunction: true,
-			allowReturnOutsideFunction: true,
-			allowImportExportEverywhere: true,
-			allowNewTargetOutsideFunction: true,
-			allowSuperOutsideMethod: true,
-			allowUndeclaredExports: true,
-			errorRecovery: true,
-		}) as unknown as typeof ast;
-	} catch {
+	const ast = parseProgram(code);
+	if (!ast) {
 		// Parser bailed entirely — let the VM surface the real syntax error.
 		return code;
 	}
@@ -124,19 +138,8 @@ export function rewriteStaticImports(code: string): string {
 export function demoteTopLevelLexicals(code: string): string {
 	if (!/\b(?:const|let|class)\b/.test(code)) return code;
 
-	let ast: { program: { body: ReadonlyArray<{ type: string }> } };
-	try {
-		ast = babelParse(code, {
-			sourceType: "module",
-			allowAwaitOutsideFunction: true,
-			allowReturnOutsideFunction: true,
-			allowImportExportEverywhere: true,
-			allowNewTargetOutsideFunction: true,
-			allowSuperOutsideMethod: true,
-			allowUndeclaredExports: true,
-			errorRecovery: true,
-		}) as unknown as typeof ast;
-	} catch {
+	const ast = parseProgram(code);
+	if (!ast) {
 		return code;
 	}
 
@@ -172,6 +175,20 @@ export function demoteTopLevelLexicals(code: string): string {
 	return result;
 }
 
+function returnFinalExpression(code: string): string {
+	const ast = parseProgram(code);
+	const last = ast?.program.body.at(-1);
+	if (last?.type !== "ExpressionStatement") return code;
+
+	const expression = last as BabelExpressionStatement;
+	const prefix = code.slice(0, expression.start);
+	const statement = code.slice(expression.start, expression.end);
+	const suffix = code.slice(expression.end);
+	const semicolonMatch = statement.match(/;\s*$/);
+	const trimmedStatement = semicolonMatch ? statement.slice(0, semicolonMatch.index) : statement;
+	return `${prefix}return (${trimmedStatement});${suffix}`;
+}
+
 /**
  * Strip TypeScript syntax (type annotations, `interface`, `as`, `satisfies`, generics in
  * call expressions, etc.) before the import/lexical rewriters parse the code. We use Bun's
@@ -199,7 +216,7 @@ const LOOKS_LIKE_TS =
 	/(?:\binterface\s+\w|\btype\s+\w+\s*=|\b(?:as|satisfies)\s+(?:[A-Z]|\bconst\b)|:\s*(?:string|number|boolean|any|unknown|void|never|object|[A-Z]\w*)\b|<\s*[A-Z]\w*\s*[,>])/;
 
 export function wrapCode(code: string): { source: string; asyncWrapped: boolean } {
-	const rewritten = demoteTopLevelLexicals(rewriteStaticImports(stripTypeScript(code)));
+	const rewritten = returnFinalExpression(demoteTopLevelLexicals(rewriteStaticImports(stripTypeScript(code))));
 	const needsAsyncWrapper = /\bawait\b|\breturn\b/.test(rewritten);
 	if (!needsAsyncWrapper) {
 		return { source: rewritten, asyncWrapped: false };

--- a/packages/coding-agent/src/eval/js/shared/runtime.ts
+++ b/packages/coding-agent/src/eval/js/shared/runtime.ts
@@ -86,7 +86,7 @@ export class JsRuntime {
 		const wrapped = wrapCode(code);
 		const value = indirectEval(wrapped.source, filename);
 		const awaited = await awaitMaybePromise(value);
-		if (Reflect.has(globalThis, "__omp_final_expr__")) {
+		if (Object.hasOwn(globalThis, "__omp_final_expr__")) {
 			const finalValue = (globalThis as { __omp_final_expr__?: unknown }).__omp_final_expr__;
 			Reflect.deleteProperty(globalThis, "__omp_final_expr__");
 			return await awaitMaybePromise(finalValue);

--- a/packages/coding-agent/src/eval/js/shared/runtime.ts
+++ b/packages/coding-agent/src/eval/js/shared/runtime.ts
@@ -48,6 +48,8 @@ export class JsRuntime {
 	readonly sessionId: string;
 	#env: Map<string, string>;
 	#getHooks: () => RuntimeHooks | null;
+	#finalExpressionSet = false;
+	#finalExpressionValue: unknown;
 
 	constructor(opts: RuntimeOptions) {
 		this.#cwd = opts.initialCwd;
@@ -82,16 +84,21 @@ export class JsRuntime {
 	}
 
 	async run(code: string, filename?: string): Promise<unknown> {
-		Reflect.deleteProperty(globalThis, "__omp_final_expr__");
+		this.#finalExpressionSet = false;
+		this.#finalExpressionValue = undefined;
 		const wrapped = wrapCode(code);
 		const value = indirectEval(wrapped.source, filename);
-		const awaited = await awaitMaybePromise(value);
-		if (wrapped.finalExpressionReturned && Object.hasOwn(globalThis, "__omp_final_expr__")) {
-			const finalValue = (globalThis as { __omp_final_expr__?: unknown }).__omp_final_expr__;
-			Reflect.deleteProperty(globalThis, "__omp_final_expr__");
-			return await awaitMaybePromise(finalValue);
+		if (wrapped.finalExpressionReturned) {
+			const awaited = await awaitMaybePromise(value);
+			if (this.#finalExpressionSet) {
+				const finalValue = this.#finalExpressionValue;
+				this.#finalExpressionSet = false;
+				this.#finalExpressionValue = undefined;
+				return await awaitMaybePromise(finalValue);
+			}
+			return awaited;
 		}
-		return awaited;
+		return await awaitMaybePromise(value);
 	}
 
 	displayValue(value: unknown): void {
@@ -133,6 +140,10 @@ export class JsRuntime {
 				this.#getHooks()?.onText(text.endsWith("\n") ? text : `${text}\n`);
 			},
 			__omp_display__: (value: unknown) => this.displayValue(value),
+			__omp_set_final_expr__: (value: unknown) => {
+				this.#finalExpressionSet = true;
+				this.#finalExpressionValue = value;
+			},
 			webcrypto: crypto,
 			// `process` is intentionally not overridden — user code gets the host worker's real
 			// `process` object. Subsetting it caused segfaults in workers that share state with

--- a/packages/coding-agent/src/eval/js/shared/runtime.ts
+++ b/packages/coding-agent/src/eval/js/shared/runtime.ts
@@ -82,9 +82,16 @@ export class JsRuntime {
 	}
 
 	async run(code: string, filename?: string): Promise<unknown> {
+		Reflect.deleteProperty(globalThis, "__omp_final_expr__");
 		const wrapped = wrapCode(code);
 		const value = indirectEval(wrapped.source, filename);
-		return await awaitMaybePromise(value);
+		const awaited = await awaitMaybePromise(value);
+		if (Reflect.has(globalThis, "__omp_final_expr__")) {
+			const finalValue = (globalThis as { __omp_final_expr__?: unknown }).__omp_final_expr__;
+			Reflect.deleteProperty(globalThis, "__omp_final_expr__");
+			return await awaitMaybePromise(finalValue);
+		}
+		return awaited;
 	}
 
 	displayValue(value: unknown): void {

--- a/packages/coding-agent/src/eval/js/shared/runtime.ts
+++ b/packages/coding-agent/src/eval/js/shared/runtime.ts
@@ -86,7 +86,7 @@ export class JsRuntime {
 		const wrapped = wrapCode(code);
 		const value = indirectEval(wrapped.source, filename);
 		const awaited = await awaitMaybePromise(value);
-		if (Object.hasOwn(globalThis, "__omp_final_expr__")) {
+		if (wrapped.finalExpressionReturned && Object.hasOwn(globalThis, "__omp_final_expr__")) {
 			const finalValue = (globalThis as { __omp_final_expr__?: unknown }).__omp_final_expr__;
 			Reflect.deleteProperty(globalThis, "__omp_final_expr__");
 			return await awaitMaybePromise(finalValue);

--- a/packages/coding-agent/test/core/js-executor.test.ts
+++ b/packages/coding-agent/test/core/js-executor.test.ts
@@ -234,6 +234,32 @@ describe("executeJs", () => {
 		expect(execute.mock.calls[1]?.[1]).toEqual({ path: "agent://agent-42", _i: "js prelude" });
 	});
 
+	it("auto-displays the final awaited expression result", async () => {
+		const execute = vi.fn(
+			async (): Promise<AgentToolResult> => ({
+				content: [{ type: "text", text: "tool output" }],
+				details: { kind: "tool-result" },
+			}),
+		);
+		const toolSession: ToolSession = {
+			...session,
+			getToolByName: name => (name === "read" ? createTool("read", execute) : undefined),
+		};
+
+		const result = await executeJs("await tool.read({ path: 'package.json' });", {
+			sessionId,
+			session: toolSession,
+			sessionFile,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(getJsonData(result)).toEqual({
+			text: "tool output",
+			details: { kind: "tool-result" },
+			images: undefined,
+		});
+	});
+
 	it("auto-displays returned objects as structured output", async () => {
 		const result = await executeJs("return { answer: 42, nested: { ok: true } };", {
 			sessionId,

--- a/packages/coding-agent/test/core/js-executor.test.ts
+++ b/packages/coding-agent/test/core/js-executor.test.ts
@@ -94,20 +94,22 @@ describe("executeJs", () => {
 		expect(persisted.output.trim()).toBe("41");
 	});
 
-	it("ignores inherited final expression markers", async () => {
-		try {
-			await executeJs("Object.prototype.__omp_final_expr__ = 'poisoned';", { sessionId, session, sessionFile });
+	it("does not expose the final expression marker as a global property", async () => {
+		const result = await executeJs("const localOnly = 7; localOnly;", { sessionId, session, sessionFile });
+		expect(result.exitCode).toBe(0);
+		expect(result.output.trim()).toBe("7");
 
-			const result = await executeJs("const localOnly = 7;", { sessionId, session, sessionFile });
-			expect(result.exitCode).toBe(0);
-			expect(result.output.trim()).toBe("");
+		const marker = await executeJs("return Object.hasOwn(globalThis, '__omp_final_expr__');", {
+			sessionId,
+			session,
+			sessionFile,
+		});
+		expect(marker.exitCode).toBe(0);
+		expect(marker.output.trim()).toBe("false");
 
-			const persisted = await executeJs("return localOnly;", { sessionId, session, sessionFile });
-			expect(persisted.exitCode).toBe(0);
-			expect(persisted.output.trim()).toBe("7");
-		} finally {
-			await executeJs("delete Object.prototype.__omp_final_expr__;", { sessionId, session, sessionFile });
-		}
+		const persisted = await executeJs("return localOnly;", { sessionId, session, sessionFile });
+		expect(persisted.exitCode).toBe(0);
+		expect(persisted.output.trim()).toBe("7");
 	});
 
 	it("ignores user-assigned final expression markers without a rewritten final expression", async () => {
@@ -119,6 +121,38 @@ describe("executeJs", () => {
 
 		expect(result.exitCode).toBe(0);
 		expect(result.output.trim()).toBe("actual");
+	});
+
+	it("captures promise-valued final expression before promise callbacks can mutate the marker", async () => {
+		const result = await executeJs(
+			"const pending = Promise.resolve(1).then(value => { globalThis.__omp_final_expr__ = 999; return value; }); pending;",
+			{ sessionId, session, sessionFile },
+		);
+
+		expect(result.exitCode).toBe(0);
+		expect(result.output.trim()).toBe("1");
+	});
+
+	it("awaits rewritten thenable final expressions once", async () => {
+		const result = await executeJs(
+			[
+				"globalThis.thenCalls = 0;",
+				"const thenable = {",
+				"  then(resolve) {",
+				"    globalThis.thenCalls++;",
+				"    resolve('done');",
+				"  },",
+				"};",
+				"thenable;",
+			].join("\n"),
+			{ sessionId, session, sessionFile },
+		);
+		expect(result.exitCode).toBe(0);
+		expect(result.output.trim()).toBe("done");
+
+		const calls = await executeJs("return globalThis.thenCalls;", { sessionId, session, sessionFile });
+		expect(calls.exitCode).toBe(0);
+		expect(calls.output.trim()).toBe("1");
 	});
 
 	it("exposes the worker's real process object", async () => {

--- a/packages/coding-agent/test/core/js-executor.test.ts
+++ b/packages/coding-agent/test/core/js-executor.test.ts
@@ -84,6 +84,16 @@ describe("executeJs", () => {
 		expect(resetResult.output.trim()).toBe("undefined");
 	});
 
+	it("persists bindings when auto-displaying the final expression", async () => {
+		const first = await executeJs("const inspected = 40; inspected + 2;", { sessionId, session, sessionFile });
+		expect(first.exitCode).toBe(0);
+		expect(first.output.trim()).toBe("42");
+
+		const persisted = await executeJs("return inspected + 1;", { sessionId, session, sessionFile });
+		expect(persisted.exitCode).toBe(0);
+		expect(persisted.output.trim()).toBe("41");
+	});
+
 	it("exposes the worker's real process object", async () => {
 		const result = await executeJs(
 			[

--- a/packages/coding-agent/test/core/js-executor.test.ts
+++ b/packages/coding-agent/test/core/js-executor.test.ts
@@ -110,6 +110,17 @@ describe("executeJs", () => {
 		}
 	});
 
+	it("ignores user-assigned final expression markers without a rewritten final expression", async () => {
+		const result = await executeJs("globalThis.__omp_final_expr__ = 'manual'; return 'actual';", {
+			sessionId,
+			session,
+			sessionFile,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.output.trim()).toBe("actual");
+	});
+
 	it("exposes the worker's real process object", async () => {
 		const result = await executeJs(
 			[

--- a/packages/coding-agent/test/core/js-executor.test.ts
+++ b/packages/coding-agent/test/core/js-executor.test.ts
@@ -270,6 +270,17 @@ describe("executeJs", () => {
 		});
 	});
 
+	it("awaits promise-valued final expressions before displaying", async () => {
+		const result = await executeJs("read('config.json');", {
+			sessionId,
+			session,
+			sessionFile,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.output.trim()).toBe('{\n  "name": "demo",\n  "enabled": true\n}');
+	});
+
 	it("auto-displays returned objects as structured output", async () => {
 		const result = await executeJs("return { answer: 42, nested: { ok: true } };", {
 			sessionId,

--- a/packages/coding-agent/test/core/js-executor.test.ts
+++ b/packages/coding-agent/test/core/js-executor.test.ts
@@ -94,6 +94,22 @@ describe("executeJs", () => {
 		expect(persisted.output.trim()).toBe("41");
 	});
 
+	it("ignores inherited final expression markers", async () => {
+		try {
+			await executeJs("Object.prototype.__omp_final_expr__ = 'poisoned';", { sessionId, session, sessionFile });
+
+			const result = await executeJs("const localOnly = 7;", { sessionId, session, sessionFile });
+			expect(result.exitCode).toBe(0);
+			expect(result.output.trim()).toBe("");
+
+			const persisted = await executeJs("return localOnly;", { sessionId, session, sessionFile });
+			expect(persisted.exitCode).toBe(0);
+			expect(persisted.output.trim()).toBe("7");
+		} finally {
+			await executeJs("delete Object.prototype.__omp_final_expr__;", { sessionId, session, sessionFile });
+		}
+	});
+
 	it("exposes the worker's real process object", async () => {
 		const result = await executeJs(
 			[

--- a/packages/coding-agent/test/core/js-executor.test.ts
+++ b/packages/coding-agent/test/core/js-executor.test.ts
@@ -281,6 +281,17 @@ describe("executeJs", () => {
 		expect(result.output.trim()).toBe('{\n  "name": "demo",\n  "enabled": true\n}');
 	});
 
+	it("awaits identifier promise final expressions before displaying", async () => {
+		const result = await executeJs("const pending = read('config.json'); pending;", {
+			sessionId,
+			session,
+			sessionFile,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.output.trim()).toBe('{\n  "name": "demo",\n  "enabled": true\n}');
+	});
+
 	it("auto-displays returned objects as structured output", async () => {
 		const result = await executeJs("return { answer: 42, nested: { ok: true } };", {
 			sessionId,

--- a/packages/coding-agent/test/core/js-executor.test.ts
+++ b/packages/coding-agent/test/core/js-executor.test.ts
@@ -155,6 +155,14 @@ describe("executeJs", () => {
 		expect(calls.output.trim()).toBe("1");
 	});
 
+	it("does not auto-display side-effect import rewrites", async () => {
+		const result = await executeJs('import "node:path";', { sessionId, session, sessionFile });
+
+		expect(result.exitCode).toBe(0);
+		expect(result.output.trim()).toBe("");
+		expect(result.displayOutputs).toEqual([]);
+	});
+
 	it("exposes the worker's real process object", async () => {
 		const result = await executeJs(
 			[


### PR DESCRIPTION
## What

Returns the value of the final top-level JavaScript eval expression statement by rewriting it to a `return (...)` inside the existing async wrapper.

This makes natural one-line programmatic tool usage such as:

```js
await tool.read({ path: "package.json" });
```

surface the tool result without requiring an explicit `return` or `display(...)`.

## Why

Follow-up to #1021. The previous behavior awaited the final expression but discarded its value, so agents using JS eval for programmatic tool calls could get `(no output)` even though the tool returned useful content.

This PR is intentionally separate from the `hasError` marker change so upstream can review the syntax/ergonomics change independently.

## Testing

- `bun test packages/coding-agent/test/core/js-executor.test.ts --timeout 30000`
- `bun --cwd=packages/coding-agent run check`
