### PR TITLE
fix(ollama): retry on 5xx for /api/chat and /api/tags

### DIFF
--- a/packages/ai/src/provider-models/ollama.ts
+++ b/packages/ai/src/provider-models/ollama.ts
@@ -1,3 +1,4 @@
+import { abortableSleep } from "@oh-my-pi/pi-utils";
 import type { ModelManagerOptions } from "../model-manager";
 import { Effort } from "../model-thinking";
 import type { ThinkingConfig } from "../types";
@@ -17,6 +18,17 @@ type OllamaShowResponse = {
 	capabilities?: string[];
 	model_info?: Record<string, unknown>;
 };
+
+const MODEL_RETRY_DELAYS_MS = [2_000, 5_000, 10_000];
+
+async function fetchWithRetry(url: string, init: RequestInit): Promise<Response> {
+	for (let attempt = 0; attempt < MODEL_RETRY_DELAYS_MS.length; attempt++) {
+		const response = await fetch(url, init);
+		if (response.ok || response.status < 500) return response;
+		await abortableSleep(MODEL_RETRY_DELAYS_MS[attempt]!);
+	}
+	return fetch(url, init);
+}
 
 function trimTrailingSlash(value: string): string {
 	return value.endsWith("/") ? value.slice(0, -1) : value;
@@ -94,7 +106,7 @@ export function ollamaCloudModelManagerOptions(
 			if (!apiKey) {
 				return [];
 			}
-			const response = await fetch(`${baseUrl}/api/tags`, {
+			const response = await fetchWithRetry(`${baseUrl}/api/tags`, {
 				method: "GET",
 				headers: createCloudHeaders(apiKey),
 			});

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -14,6 +14,7 @@ import type {
 	ToolResultMessage,
 	UserMessage,
 } from "../types";
+import { abortableSleep } from "@oh-my-pi/pi-utils";
 import { normalizeSystemPrompts } from "../utils";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
@@ -320,6 +321,18 @@ function mapDoneReason(doneReason: string | undefined, output: AssistantMessage)
 	return "stop";
 }
 
+const OLLAMA_RETRY_DELAYS_MS = [2_000, 5_000, 10_000];
+
+async function fetchChatWithRetry(url: string, init: RequestInit): Promise<Response> {
+	const signal = init.signal as AbortSignal | undefined;
+	for (let attempt = 0; attempt < OLLAMA_RETRY_DELAYS_MS.length; attempt++) {
+		const response = await fetch(url, init);
+		if (response.ok || response.status < 500) return response;
+		await abortableSleep(OLLAMA_RETRY_DELAYS_MS[attempt]!, signal);
+	}
+	return fetch(url, init);
+}
+
 export const streamOllama: StreamFunction<"ollama-chat"> = (
 	model: Model<"ollama-chat">,
 	context: Context,
@@ -353,7 +366,7 @@ export const streamOllama: StreamFunction<"ollama-chat"> = (
 				url: `${baseUrl}/api/chat`,
 				body,
 			};
-			const response = await fetch(`${baseUrl}/api/chat`, {
+			const response = await fetchChatWithRetry(`${baseUrl}/api/chat`, {
 				method: "POST",
 				headers: {
 					...model.headers,


### PR DESCRIPTION
## Summary

- `providers/ollama.ts`: wrap `POST /api/chat` fetch in `fetchChatWithRetry` — retries up to 3× on any HTTP 5xx with 2 s / 5 s / 10 s backoffs before surfacing the error
- `provider-models/ollama.ts`: same `fetchWithRetry` wrapping `GET /api/tags` in `fetchDynamicModels`

## Motivation

Ollama Cloud intermittently returns HTTP 503 (capacity exhausted). Without retry the error propagates immediately as a hard failure. With this change transient 503s are absorbed transparently.

## Test plan

- [ ] Confirm `check:types` passes (`npm run check:types` in `packages/ai`)
- [ ] Manually trigger a chat request against Ollama Cloud during a 503 window and verify auto-recovery