### PR TITLE
fix(tools): resolve internal URLs in find tool before filesystem path lookup

### DIFF
--- a/packages/coding-agent/src/tools/find.ts
+++ b/packages/coding-agent/src/tools/find.ts
@@ -8,6 +8,7 @@ import { isEnoent, prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import type { Static } from "@sinclair/typebox";
 import { Type } from "@sinclair/typebox";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import { InternalUrlRouter } from "../internal-urls";
 import type { Theme } from "../modes/theme/theme";
 import findDescription from "../prompts/tools/find.md" with { type: "text" };
 import { type TruncationResult, truncateHead } from "../session/streaming-output";
@@ -25,6 +26,7 @@ import { applyListLimit } from "./list-limit";
 import { formatFullOutputReference, type OutputMeta } from "./output-meta";
 import {
 	formatPathRelativeToCwd,
+	hasGlobPathChars,
 	normalizePathLikeInput,
 	parseFindPattern,
 	partitionExistingPaths,
@@ -116,7 +118,23 @@ export class FindTool implements AgentTool<typeof findSchema, FindToolDetails> {
 
 		return untilAborted(signal, async () => {
 			const formatScopePath = (targetPath: string): string => formatPathRelativeToCwd(targetPath, this.session.cwd);
-			const normalizedPatterns = paths.map(input => normalizePathLikeInput(input).replace(/\\/g, "/"));
+			const rawPatterns = paths.map(input => normalizePathLikeInput(input).replace(/\\/g, "/"));
+			const internalRouter = InternalUrlRouter.instance();
+			const normalizedPatterns: string[] = [];
+			for (const rawPattern of rawPatterns) {
+				if (!internalRouter.canHandle(rawPattern)) {
+					normalizedPatterns.push(rawPattern);
+					continue;
+				}
+				if (hasGlobPathChars(rawPattern)) {
+					throw new ToolError(`Glob patterns are not supported for internal URLs: ${rawPattern}`);
+				}
+				const resource = await internalRouter.resolve(rawPattern);
+				if (!resource.sourcePath) {
+					throw new ToolError(`Cannot find internal URL without a backing file: ${rawPattern}`);
+				}
+				normalizedPatterns.push(resource.sourcePath);
+			}
 			if (normalizedPatterns.some(pattern => pattern.length === 0)) {
 				throw new ToolError("`paths` must contain non-empty globs or paths");
 			}

--- a/packages/coding-agent/test/tools/search-internal-urls.test.ts
+++ b/packages/coding-agent/test/tools/search-internal-urls.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { InternalUrlRouter, LocalProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { FindTool } from "@oh-my-pi/pi-coding-agent/tools/find";
 import { SearchTool } from "@oh-my-pi/pi-coding-agent/tools/search";
 import { AgentRegistry } from "../../src/registry/agent-registry";
 
@@ -147,6 +148,24 @@ describe("SearchTool internal URL resolution", () => {
 		expect(text).toContain("needle");
 		// No hashline anchors (LINE+ID|content) for immutable sources
 		expect(text).not.toMatch(/^\*?\s*\d+[a-z]{2}\|/m);
+	});
+
+	it("resolves local:// URLs before file-name lookup", async () => {
+		const localRoot = path.join(artifactsDir, "local");
+		await fs.mkdir(localRoot, { recursive: true });
+		await Bun.write(path.join(localRoot, "PLAN.md"), "# Plan\n");
+
+		LocalProtocolHandler.setOverride({ getArtifactsDir: () => artifactsDir, getSessionId: () => "session" });
+
+		const session = createSession();
+		const tool = new FindTool(session);
+
+		const result = await tool.execute("test-call", {
+			paths: ["local://PLAN.md"],
+		});
+
+		const text = getResultText(result);
+		expect(text).toContain("PLAN.md");
 	});
 
 	it("keeps hashline anchors when searching mutable local:// sources", async () => {


### PR DESCRIPTION
## Problem

`find` was missing the `InternalUrlRouter` pre-pass that `search` gained in 6c109f68 ("added global singletons for URL protocol handlers"). Any internal URL passed to `find` — including `'/Users/miroslav.drbal/.omp/agent/sessions/-devel-oh-my-pi/2026-05-12T09-33-13-839Z_019e1b88-8aef-7000-b557-f579826302e0/local/PLAN.md'` which the `/review` command's subagents use — would reach `assertNotInternalUrl` inside `resolveToCwd` and throw:

```
Error: Path "'/Users/miroslav.drbal/.omp/agent/sessions/-devel-oh-my-pi/2026-05-12T09-33-13-839Z_019e1b88-8aef-7000-b557-f579826302e0/local/PLAN.md'" uses internal scheme "'/Users/miroslav.drbal/.omp/agent/sessions/-devel-oh-my-pi/2026-05-12T09-33-13-839Z_019e1b88-8aef-7000-b557-f579826302e0/local'" and must be resolved
through the proper protocol handler, not as a filesystem path.
```

## Fix

Mirrors `search.ts` exactly: before the existing path-normalization loop, iterate the raw inputs through `InternalUrlRouter.instance()`, resolve any that `canHandle` matches to their backing `sourcePath`, and push that absolute path into the normalized list. Glob patterns on internal URLs are rejected (same error message shape as `search`).

## Test

Extended `search-internal-urls.test.ts` with a `FindTool` case that resolves `'/Users/miroslav.drbal/.omp/agent/sessions/-devel-oh-my-pi/2026-05-12T09-33-13-839Z_019e1b88-8aef-7000-b557-f579826302e0/local/PLAN.md'` through `LocalProtocolHandler.setOverride` — previously this threw, now it returns the file.