### PR TITLE
fix(stats): avoid worker sync in compiled binaries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added new `task.isolation.mode` values `auto`, `apfs`, `btrfs`, `zfs`, `reflink`, `overlayfs`, `projfs`, `block-clone`, and `rcopy` for native PAL-backed task isolation backends
 - Added automatic PAL-backed isolation backend selection so `task.isolation.mode` uses the host's best-available backend
+- Added input-token and output-token totals to `omp stats --summary`.
 
 ### Changed
 

--- a/packages/coding-agent/src/cli/stats-cli.ts
+++ b/packages/coding-agent/src/cli/stats-cli.ts
@@ -176,6 +176,8 @@ async function printStatsSummary(): Promise<void> {
 	console.log(`  Requests: ${formatNumber(overall.totalRequests)} (${formatNumber(overall.failedRequests)} errors)`);
 	console.log(`  Error Rate: ${formatPercent(overall.errorRate)}`);
 	console.log(`  Total Tokens: ${formatNumber(overall.totalInputTokens + overall.totalOutputTokens)}`);
+	console.log(`  Input Tokens: ${formatNumber(overall.totalInputTokens)}`);
+	console.log(`  Output Tokens: ${formatNumber(overall.totalOutputTokens)}`);
 	console.log(`  Cache Rate: ${formatPercent(overall.cacheRate)}`);
 	console.log(`  Total Cost: ${formatCost(overall.totalCost)}`);
 	console.log(`  Premium Requests: ${formatNumber(normalizePremiumRequests(overall.totalPremiumRequests ?? 0))}`);

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp stats` in compiled binaries by using the serial sync path instead of spawning a raw file-asset worker that cannot import bundled parser code.
+- Fixed behavior backfills after failed compiled-binary sync attempts by marking the backfill sentinel only after a successful full sync.
+
 ## [14.9.7] - 2026-05-12
 ### Breaking Changes
 

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added separate input-token and output-token totals to the overview dashboard cards.
+
 ### Fixed
 
 - Fixed `omp stats` in compiled binaries by using the serial sync path instead of spawning a raw file-asset worker that cannot import bundled parser code.

--- a/packages/stats/src/aggregator.ts
+++ b/packages/stats/src/aggregator.ts
@@ -18,10 +18,12 @@ import {
 	initDb,
 	insertMessageStats,
 	insertUserMessageStats,
+	markUserMessageLinksRepairComplete,
+	markUserMessagesBackfillComplete,
 	setFileOffset,
 	updateUserMessageLinks,
 } from "./db";
-import { getSessionEntry, listAllSessionFiles, type ParseSessionResult } from "./parser";
+import { getSessionEntry, listAllSessionFiles, type ParseSessionResult, parseSessionFile } from "./parser";
 import type { SyncWorkerRequest, SyncWorkerResponse } from "./sync-worker";
 // `with { type: "file" }` resolves to the worker's absolute path at runtime
 // (dev) and survives bundling (the asset is copied alongside the build).
@@ -63,12 +65,15 @@ export interface SyncOptions {
 	/**
 	 * Worker pool size. Defaults to a sensible value derived from the host
 	 * (capped to avoid drowning a small machine in workers). Set to `1` to
-	 * force serial parsing without spawning workers.
+	 * force serial parsing without spawning workers. Compiled binaries also
+	 * use the serial path because Bun loads file-asset workers as raw files.
 	 */
 	workers?: number;
 }
 
 function defaultWorkerCount(): number {
+	if (isCompiledBinary()) return 1;
+
 	// `navigator.hardwareConcurrency` is the portable answer in Bun; fall
 	// back to a small fixed pool if it's somehow unavailable.
 	const hw = typeof navigator !== "undefined" ? (navigator.hardwareConcurrency ?? 0) : 0;
@@ -119,27 +124,109 @@ function dispatch(handle: WorkerHandle, request: SyncWorkerRequest): Promise<Par
 	return promise;
 }
 
+interface PendingSessionFile {
+	sessionFile: string;
+	lastModified: number;
+	fromOffset: number;
+}
+
+async function getPendingSessionFile(sessionFile: string): Promise<PendingSessionFile | null> {
+	let fileStats: fs.Stats;
+	try {
+		fileStats = await fs.promises.stat(sessionFile);
+	} catch {
+		return null;
+	}
+
+	const lastModified = fileStats.mtimeMs;
+	const stored = getFileOffset(sessionFile);
+	if (stored && stored.lastModified >= lastModified) return null;
+
+	return {
+		sessionFile,
+		lastModified,
+		fromOffset: stored?.offset ?? 0,
+	};
+}
+
+function isCompiledBinary(): boolean {
+	if (process.env.PI_COMPILED) return true;
+	if (import.meta.url.includes("$bunfs")) return true;
+	if (import.meta.url.includes("~BUN")) return true;
+	if (import.meta.url.includes("%7EBUN")) return true;
+	return false;
+}
+
+function markSyncBackfillsComplete(): void {
+	markUserMessagesBackfillComplete();
+	markUserMessageLinksRepairComplete();
+}
+
+async function syncAllSessionsSerial(
+	files: string[],
+	opts?: SyncOptions,
+): Promise<{ processed: number; files: number }> {
+	let totalProcessed = 0;
+	let filesProcessed = 0;
+	let completed = 0;
+
+	const report = (sessionFile: string) => {
+		completed++;
+		opts?.onProgress?.({
+			current: completed,
+			total: files.length,
+			processed: totalProcessed,
+			sessionFile,
+		});
+	};
+
+	for (const sessionFile of files) {
+		const pending = await getPendingSessionFile(sessionFile);
+		if (pending) {
+			const result = await parseSessionFile(pending.sessionFile, pending.fromOffset);
+			const inserted = applyParseResult(pending.sessionFile, pending.lastModified, result);
+			if (inserted > 0) {
+				totalProcessed += inserted;
+				filesProcessed++;
+			}
+		}
+		report(sessionFile);
+	}
+
+	return { processed: totalProcessed, files: filesProcessed };
+}
+
 /**
  * Sync all session files to the database.
  *
- * Parsing fans out across a worker pool (one in-flight job per worker)
- * while DB writes and offset bookkeeping stay on the calling thread so the
- * single SQLite handle stays uncontended. `onProgress` fires once per
- * completed file (skipped files included so the bar walks at a steady
- * rate).
+ * Parsing normally fans out across a worker pool (one in-flight job per
+ * worker) while DB writes and offset bookkeeping stay on the calling thread
+ * so the single SQLite handle stays uncontended. When workers are disabled
+ * or unavailable in compiled binaries, parsing runs serially on the calling
+ * thread. `onProgress` fires once per completed file (skipped files included
+ * so the bar walks at a steady rate).
  */
 export async function syncAllSessions(opts?: SyncOptions): Promise<{ processed: number; files: number }> {
 	await initDb();
 
 	const files = await listAllSessionFiles();
-	if (files.length === 0) return { processed: 0, files: 0 };
+	if (files.length === 0) {
+		markSyncBackfillsComplete();
+		return { processed: 0, files: 0 };
+	}
+
+	const poolSize = Math.max(1, Math.min(files.length, opts?.workers ?? defaultWorkerCount()));
+	if (poolSize === 1 || isCompiledBinary()) {
+		const result = await syncAllSessionsSerial(files, opts);
+		markSyncBackfillsComplete();
+		return result;
+	}
 
 	let totalProcessed = 0;
 	let filesProcessed = 0;
 	let completed = 0;
 	let cursor = 0;
 
-	const poolSize = Math.max(1, Math.min(files.length, opts?.workers ?? defaultWorkerCount()));
 	const handles: WorkerHandle[] = [];
 	for (let i = 0; i < poolSize; i++) handles.push(spawnWorker());
 
@@ -159,23 +246,14 @@ export async function syncAllSessions(opts?: SyncOptions): Promise<{ processed: 
 			if (idx >= files.length) return;
 			const sessionFile = files[idx];
 
-			let fileStats: fs.Stats;
-			try {
-				fileStats = await fs.promises.stat(sessionFile);
-			} catch {
-				report(sessionFile);
-				continue;
-			}
-			const lastModified = fileStats.mtimeMs;
-			const stored = getFileOffset(sessionFile);
-			if (stored && stored.lastModified >= lastModified) {
+			const pending = await getPendingSessionFile(sessionFile);
+			if (!pending) {
 				report(sessionFile);
 				continue;
 			}
 
-			const fromOffset = stored?.offset ?? 0;
-			const result = await dispatch(handle, { sessionFile, fromOffset });
-			const inserted = applyParseResult(sessionFile, lastModified, result);
+			const result = await dispatch(handle, { sessionFile: pending.sessionFile, fromOffset: pending.fromOffset });
+			const inserted = applyParseResult(pending.sessionFile, pending.lastModified, result);
 			if (inserted > 0) {
 				totalProcessed += inserted;
 				filesProcessed++;
@@ -190,6 +268,7 @@ export async function syncAllSessions(opts?: SyncOptions): Promise<{ processed: 
 		for (const handle of handles) handle.worker.terminate();
 	}
 
+	markSyncBackfillsComplete();
 	return { processed: totalProcessed, files: filesProcessed };
 }
 

--- a/packages/stats/src/client/components/StatsGrid.tsx
+++ b/packages/stats/src/client/components/StatsGrid.tsx
@@ -1,4 +1,4 @@
-import { Activity, AlertCircle, BarChart3, Database, Server, Star, Zap } from "lucide-react";
+import { Activity, AlertCircle, BarChart3, Database, Download, Server, Star, Upload, Zap } from "lucide-react";
 import type { AggregatedStats } from "../types";
 
 interface StatsGridProps {
@@ -13,6 +13,12 @@ const compactNumberFormatter = new Intl.NumberFormat(undefined, {
 function formatCompactNumber(value: number): string {
 	return compactNumberFormatter.format(value);
 }
+
+function formatExactNumber(value: number): string {
+	return value.toLocaleString();
+}
+
+const totalPromptCompletionTokens = (stats: AggregatedStats) => stats.totalInputTokens + stats.totalOutputTokens;
 
 const statConfig = [
 	{
@@ -38,7 +44,7 @@ const statConfig = [
 		title: "Premium Reqs",
 		icon: Star,
 		color: "var(--accent-amber)",
-		getValue: (s: AggregatedStats) => s.totalPremiumRequests.toLocaleString(),
+		getValue: (s: AggregatedStats) => formatExactNumber(s.totalPremiumRequests),
 		getDetail: (s: AggregatedStats) =>
 			s.totalRequests > 0 ? `${((s.totalPremiumRequests / s.totalRequests) * 100).toFixed(1)}% of requests` : "-",
 	},
@@ -49,6 +55,28 @@ const statConfig = [
 		color: "var(--accent-cyan)",
 		getValue: (s: AggregatedStats) => `${(s.cacheRate * 100).toFixed(1)}%`,
 		getDetail: (s: AggregatedStats) => `${formatCompactNumber(s.totalCacheReadTokens)} cached tokens`,
+	},
+	{
+		key: "inputTokens",
+		title: "Input Tokens",
+		icon: Download,
+		color: "var(--accent-violet)",
+		getValue: (s: AggregatedStats) => formatExactNumber(s.totalInputTokens),
+		getDetail: (s: AggregatedStats) =>
+			totalPromptCompletionTokens(s) > 0
+				? `${((s.totalInputTokens / totalPromptCompletionTokens(s)) * 100).toFixed(1)}% of prompt+completion`
+				: "-",
+	},
+	{
+		key: "outputTokens",
+		title: "Output Tokens",
+		icon: Upload,
+		color: "var(--accent-pink)",
+		getValue: (s: AggregatedStats) => formatExactNumber(s.totalOutputTokens),
+		getDetail: (s: AggregatedStats) =>
+			totalPromptCompletionTokens(s) > 0
+				? `${((s.totalOutputTokens / totalPromptCompletionTokens(s)) * 100).toFixed(1)}% of prompt+completion`
+				: "-",
 	},
 	{
 		key: "errors",
@@ -64,7 +92,8 @@ const statConfig = [
 		icon: BarChart3,
 		color: "var(--accent-green)",
 		getValue: (s: AggregatedStats) => s.avgTokensPerSecond?.toFixed(1) ?? "-",
-		getDetail: (s: AggregatedStats) => `${(s.totalInputTokens + s.totalOutputTokens).toLocaleString()} total tokens`,
+		getDetail: (s: AggregatedStats) =>
+			`${formatCompactNumber(totalPromptCompletionTokens(s))} total prompt+completion`,
 	},
 	{
 		key: "ttft",
@@ -78,7 +107,7 @@ const statConfig = [
 
 export function StatsGrid({ stats }: StatsGridProps) {
 	return (
-		<div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-7 gap-4 mb-8">
+		<div className="grid grid-cols-2 lg:grid-cols-3 xl:grid-cols-9 gap-4 mb-8">
 			{statConfig.map(stat => {
 				const Icon = stat.icon;
 				return (

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -34,6 +34,10 @@ interface CostBackfillRow {
 
 let db: Database | null = null;
 
+const BACKFILL_COMPLETE = "complete";
+const USER_MESSAGES_BACKFILL_KEY = "user_messages_v5";
+const USER_MESSAGE_LINKS_REPAIR_KEY = "user_message_links_v1";
+
 /**
  * Initialize the database and create tables.
  */
@@ -720,8 +724,11 @@ export function getCostTimeSeries(days = 90, cutoff?: number | null): CostTimeSe
 
 /**
  * Reset `file_offsets` (and any existing `user_messages` rows) so the next
- * sync re-parses every session and re-derives behavioral metrics. Run once
- * per metric-definition bump; the meta sentinel records the version.
+ * successful sync re-parses every session and re-derives behavioral metrics.
+ * Run once per metric-definition bump; the meta sentinel is only marked
+ * complete after `syncAllSessions` finishes. Older timestamp sentinel values
+ * are treated as pending so a failed compiled-binary sync cannot permanently
+ * suppress the backfill.
  *
  * - v1: initial introduction of `user_messages`.
  * - v2: yelling-sentence metric replaces caps-word counts; existing rows are
@@ -738,16 +745,16 @@ export function getCostTimeSeries(days = 90, cutoff?: number | null): CostTimeSe
  * Existing `messages` rows are unaffected - `INSERT OR IGNORE` keeps them.
  */
 function backfillUserMessages(database: Database): void {
-	const row = database.prepare("SELECT value FROM meta WHERE key = 'user_messages_v5'").get() as
+	const row = database.prepare("SELECT value FROM meta WHERE key = ?").get(USER_MESSAGES_BACKFILL_KEY) as
 		| { value: string }
 		| undefined;
-	if (row) return;
+	if (row?.value === BACKFILL_COMPLETE) return;
 
 	database.exec("DELETE FROM user_messages");
 	database.exec("DELETE FROM file_offsets");
 	database
 		.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)")
-		.run("user_messages_v5", String(Date.now()));
+		.run(USER_MESSAGES_BACKFILL_KEY, "pending");
 }
 
 /**
@@ -759,15 +766,31 @@ function backfillUserMessages(database: Database): void {
  * sentinel row in `meta`.
  */
 function repairUserMessageLinks(database: Database): void {
-	const row = database.prepare("SELECT value FROM meta WHERE key = 'user_message_links_v1'").get() as
+	const row = database.prepare("SELECT value FROM meta WHERE key = ?").get(USER_MESSAGE_LINKS_REPAIR_KEY) as
 		| { value: string }
 		| undefined;
-	if (row) return;
+	if (row?.value === BACKFILL_COMPLETE) return;
 
 	database.exec("DELETE FROM file_offsets");
 	database
 		.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)")
-		.run("user_message_links_v1", String(Date.now()));
+		.run(USER_MESSAGE_LINKS_REPAIR_KEY, "pending");
+}
+
+export function markUserMessagesBackfillComplete(): void {
+	if (!db) return;
+	db.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)").run(
+		USER_MESSAGES_BACKFILL_KEY,
+		BACKFILL_COMPLETE,
+	);
+}
+
+export function markUserMessageLinksRepairComplete(): void {
+	if (!db) return;
+	db.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)").run(
+		USER_MESSAGE_LINKS_REPAIR_KEY,
+		BACKFILL_COMPLETE,
+	);
 }
 
 /**

--- a/packages/stats/src/db.ts
+++ b/packages/stats/src/db.ts
@@ -35,9 +35,12 @@ interface CostBackfillRow {
 let db: Database | null = null;
 
 const BACKFILL_COMPLETE = "complete";
+const BACKFILL_PENDING = "pending";
 const USER_MESSAGES_BACKFILL_KEY = "user_messages_v5";
 const USER_MESSAGE_LINKS_REPAIR_KEY = "user_message_links_v1";
-
+function shouldResetBackfill(value: string | undefined): boolean {
+	return value !== BACKFILL_COMPLETE && value !== BACKFILL_PENDING;
+}
 /**
  * Initialize the database and create tables.
  */
@@ -748,13 +751,13 @@ function backfillUserMessages(database: Database): void {
 	const row = database.prepare("SELECT value FROM meta WHERE key = ?").get(USER_MESSAGES_BACKFILL_KEY) as
 		| { value: string }
 		| undefined;
-	if (row?.value === BACKFILL_COMPLETE) return;
+	if (!shouldResetBackfill(row?.value)) return;
 
 	database.exec("DELETE FROM user_messages");
 	database.exec("DELETE FROM file_offsets");
 	database
 		.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)")
-		.run(USER_MESSAGES_BACKFILL_KEY, "pending");
+		.run(USER_MESSAGES_BACKFILL_KEY, BACKFILL_PENDING);
 }
 
 /**
@@ -769,12 +772,12 @@ function repairUserMessageLinks(database: Database): void {
 	const row = database.prepare("SELECT value FROM meta WHERE key = ?").get(USER_MESSAGE_LINKS_REPAIR_KEY) as
 		| { value: string }
 		| undefined;
-	if (row?.value === BACKFILL_COMPLETE) return;
+	if (!shouldResetBackfill(row?.value)) return;
 
 	database.exec("DELETE FROM file_offsets");
 	database
 		.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)")
-		.run(USER_MESSAGE_LINKS_REPAIR_KEY, "pending");
+		.run(USER_MESSAGE_LINKS_REPAIR_KEY, BACKFILL_PENDING);
 }
 
 export function markUserMessagesBackfillComplete(): void {

--- a/packages/stats/src/index.ts
+++ b/packages/stats/src/index.ts
@@ -52,6 +52,8 @@ async function printStats(): Promise<void> {
 	console.log(`  Requests: ${formatNumber(overall.totalRequests)} (${formatNumber(overall.failedRequests)} errors)`);
 	console.log(`  Error Rate: ${formatPercent(overall.errorRate)}`);
 	console.log(`  Total Tokens: ${formatNumber(overall.totalInputTokens + overall.totalOutputTokens)}`);
+	console.log(`  Input Tokens: ${formatNumber(overall.totalInputTokens)}`);
+	console.log(`  Output Tokens: ${formatNumber(overall.totalOutputTokens)}`);
 	console.log(`  Cache Rate: ${formatPercent(overall.cacheRate)}`);
 	console.log(`  Total Cost: ${formatCost(overall.totalCost)}`);
 	console.log(`  Premium Requests: ${formatNumber(normalizePremiumRequests(overall.totalPremiumRequests ?? 0))}`);

--- a/packages/stats/test/behavior-backfill.test.ts
+++ b/packages/stats/test/behavior-backfill.test.ts
@@ -1,0 +1,100 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getAgentDir, getStatsDbPath, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
+import { syncAllSessions } from "../src/aggregator";
+import { closeDb, getBehaviorOverall, initDb } from "../src/db";
+
+const originalConfigDir = process.env.PI_CONFIG_DIR;
+const originalAgentDir = getAgentDir();
+let tempDir: TempDir | null = null;
+
+beforeEach(() => {
+	tempDir = TempDir.createSync("@pi-stats-behavior-backfill-");
+	const configDir = path.relative(os.homedir(), tempDir.join("config"));
+	process.env.PI_CONFIG_DIR = configDir;
+	setAgentDir(path.join(os.homedir(), configDir, "agent"));
+});
+
+afterEach(() => {
+	closeDb();
+	if (originalConfigDir === undefined) {
+		delete process.env.PI_CONFIG_DIR;
+	} else {
+		process.env.PI_CONFIG_DIR = originalConfigDir;
+	}
+	setAgentDir(originalAgentDir);
+	tempDir?.removeSync();
+	tempDir = null;
+});
+
+async function writeSessionFile(): Promise<string> {
+	const sessionDir = path.join(getAgentDir(), "sessions", "--tmp--behavior-backfill");
+	await fs.mkdir(sessionDir, { recursive: true });
+	const sessionFile = path.join(sessionDir, "session.jsonl");
+	const timestamp = new Date().toISOString();
+	const user = {
+		type: "message",
+		id: "user-1",
+		parentId: null,
+		timestamp,
+		message: { role: "user", content: "PLEASE FIX THIS NOW" },
+	};
+	const assistant = {
+		type: "message",
+		id: "assistant-1",
+		parentId: "user-1",
+		timestamp,
+		message: {
+			role: "assistant",
+			content: [{ type: "text", text: "ok" }],
+			api: "openai-responses",
+			provider: "openai",
+			model: "gpt-5.4",
+			usage: {
+				input: 1,
+				output: 2,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 3,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+			duration: 10,
+			ttft: 5,
+		},
+	};
+	await Bun.write(sessionFile, `${JSON.stringify(user)}\n${JSON.stringify(assistant)}\n`);
+	return sessionFile;
+}
+
+describe("behavior backfill", () => {
+	it("retries when a failed compiled sync left old backfill sentinels behind", async () => {
+		const sessionFile = await writeSessionFile();
+		await initDb();
+		closeDb();
+
+		const stats = await fs.stat(sessionFile);
+		const database = new Database(getStatsDbPath());
+		database
+			.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)")
+			.run("user_messages_v5", "1778589361860");
+		database
+			.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)")
+			.run("user_message_links_v1", "1778589361862");
+		database
+			.prepare("INSERT OR REPLACE INTO file_offsets (session_file, offset, last_modified) VALUES (?, ?, ?)")
+			.run(sessionFile, stats.size, stats.mtimeMs);
+		database.close();
+
+		const synced = await syncAllSessions();
+		const behavior = getBehaviorOverall(null);
+
+		expect(synced.files).toBe(1);
+		expect(behavior.totalMessages).toBe(1);
+		expect(behavior.totalYelling).toBe(1);
+	});
+});

--- a/packages/stats/test/behavior-backfill.test.ts
+++ b/packages/stats/test/behavior-backfill.test.ts
@@ -5,7 +5,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { getAgentDir, getStatsDbPath, setAgentDir, TempDir } from "@oh-my-pi/pi-utils";
 import { syncAllSessions } from "../src/aggregator";
-import { closeDb, getBehaviorOverall, initDb } from "../src/db";
+import { closeDb, getBehaviorOverall, getFileOffset, initDb } from "../src/db";
 
 const originalConfigDir = process.env.PI_CONFIG_DIR;
 const originalAgentDir = getAgentDir();
@@ -96,5 +96,24 @@ describe("behavior backfill", () => {
 		expect(synced.files).toBe(1);
 		expect(behavior.totalMessages).toBe(1);
 		expect(behavior.totalYelling).toBe(1);
+	});
+
+	it("does not re-wipe existing progress when the backfill sentinel is already pending", async () => {
+		const sessionFile = await writeSessionFile();
+		await syncAllSessions();
+		expect(getBehaviorOverall(null).totalMessages).toBe(1);
+		expect(getFileOffset(sessionFile)).not.toBeNull();
+		closeDb();
+
+		const database = new Database(getStatsDbPath());
+		database.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)").run("user_messages_v5", "pending");
+		database
+			.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)")
+			.run("user_message_links_v1", "pending");
+		database.close();
+
+		await initDb();
+		expect(getBehaviorOverall(null).totalMessages).toBe(1);
+		expect(getFileOffset(sessionFile)).not.toBeNull();
 	});
 });

--- a/packages/stats/test/compiled-sync.test.ts
+++ b/packages/stats/test/compiled-sync.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const ENTRY_SOURCE = String.raw`
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getAgentDir, setAgentDir } from "@oh-my-pi/pi-utils";
+import { closeDb, getMessageCount } from "./src/db";
+import { syncAllSessions } from "./src/aggregator";
+
+const root = process.env.OMP_STATS_SMOKE_DIR;
+if (!root) throw new Error("missing OMP_STATS_SMOKE_DIR");
+
+const configDir = path.relative(os.homedir(), path.join(root, "config"));
+process.env.PI_CONFIG_DIR = configDir;
+setAgentDir(path.join(os.homedir(), configDir, "agent"));
+
+const sessionDir = path.join(getAgentDir(), "sessions", "--tmp--stats");
+await fs.mkdir(sessionDir, { recursive: true });
+const sessionFile = path.join(sessionDir, "session.jsonl");
+const assistant = {
+	type: "message",
+	id: "assistant-1",
+	parentId: null,
+	timestamp: new Date().toISOString(),
+	message: {
+		role: "assistant",
+		content: [{ type: "text", text: "ok" }],
+		api: "openai-responses",
+		provider: "openai",
+		model: "gpt-5.4",
+		usage: {
+			input: 1,
+			output: 2,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 3,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+		duration: 10,
+		ttft: 5,
+	},
+};
+await Bun.write(sessionFile, JSON.stringify(assistant) + "\\n");
+const synced = await syncAllSessions();
+const total = getMessageCount();
+console.log(JSON.stringify({ synced, total }));
+closeDb();
+`;
+
+describe("compiled stats sync", () => {
+	it("syncs session files from a compiled binary", async () => {
+		const packageDir = path.resolve(import.meta.dir, "..");
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-stats-compiled-sync-"));
+		const entryPath = path.join(packageDir, `.tmp-compiled-sync-${Bun.hash(tempDir).toString(16)}.ts`);
+		const binaryPath = path.join(tempDir, process.platform === "win32" ? "stats-smoke.exe" : "stats-smoke");
+		try {
+			await Bun.write(entryPath, ENTRY_SOURCE);
+
+			const build = Bun.spawnSync(["bun", "build", "--compile", entryPath, "--outfile", binaryPath], {
+				cwd: packageDir,
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			expect(build.exitCode, `build stderr=${build.stderr.toString()}`).toBe(0);
+
+			const run = Bun.spawnSync([binaryPath], {
+				env: { ...Bun.env, OMP_STATS_SMOKE_DIR: path.join(tempDir, "run") },
+				stdout: "pipe",
+				stderr: "pipe",
+			});
+			expect(run.exitCode, `run stderr=${run.stderr.toString()}`).toBe(0);
+
+			const lastLine = run.stdout.toString().trim().split("\n").at(-1);
+			expect(lastLine).toBeDefined();
+			const payload = JSON.parse(lastLine!) as { synced: { processed: number; files: number }; total: number };
+			expect(payload).toEqual({ synced: { processed: 1, files: 1 }, total: 1 });
+		} finally {
+			await fs.rm(entryPath, { force: true });
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
Bun compiled binaries load `with { type: "file" }` worker assets as raw files, so the stats sync worker crashes before it can import the bundled parser. This makes compiled builds use the existing serial sync path while preserving the worker pool for source/dev runs.

Also adds a regression test that compiles and runs a tiny stats sync binary against a real JSONL session file.

Tested with `bun test packages/stats/test` and `bun --cwd=packages/stats run check`.