### PR TITLE
feat(skill-command): inline --steer / --follow-up flag for /skill:* invocations

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -136,8 +136,22 @@ If `skills.enableSkillCommands` is true, interactive mode registers one slash co
 
 - reads the skill file directly from `filePath`
 - strips frontmatter
-- injects skill body as a follow-up custom message
+- injects skill body as a custom message
+- defaults to **follow-up** delivery; pass `--steer` to interrupt the current turn, or `--follow-up` to be explicit
+- the mode flag is position-independent and is stripped before `args` are forwarded
 - appends metadata (`Skill: <path>`, optional `User: <args>`)
+
+The mode flag only affects delivery while the agent is **streaming**, since `streamingBehavior` is only consulted on the streaming path of `promptCustomMessage`. When the agent is idle, the message prompts normally regardless of which mode flag was given.
+
+Examples:
+
+```text
+/skill:debugging                          → followUp (default)
+/skill:debugging --steer                  → steer (interrupt)
+/skill:debugging --steer focus on hooks   → steer; args="focus on hooks"
+/skill:debugging focus --follow-up        → followUp; args="focus"
+/skill:debugging --steer --follow-up      → followUp (last-occurrence wins)
+```
 
 ## `skill://` URL behavior
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -244,12 +244,13 @@ export class InputController {
 			if (text.startsWith("/skill:")) {
 				const spaceIndex = text.indexOf(" ");
 				const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-				const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
+				const rawArgs = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
 				const skillPath = this.ctx.skillCommands?.get(commandName);
 				if (skillPath) {
 					this.ctx.editor.addToHistory(text);
 					this.ctx.editor.setText("");
 					try {
+						const { args, streamingBehavior } = parseSkillInvocationArgs(rawArgs);
 						const content = await Bun.file(skillPath).text();
 						const body = content.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
 						const metaLines = [`Skill: ${skillPath}`];
@@ -272,7 +273,7 @@ export class InputController {
 								details,
 								attribution: "user",
 							},
-							{ streamingBehavior: "followUp" },
+							{ streamingBehavior },
 						);
 					} catch (err) {
 						this.ctx.showError(`Failed to load skill: ${err instanceof Error ? err.message : String(err)}`);
@@ -800,4 +801,43 @@ export class InputController {
 			});
 		}
 	}
+}
+
+const STEER_FLAGS: ReadonlySet<string> = new Set(["--steer"]);
+const FOLLOWUP_FLAGS: ReadonlySet<string> = new Set(["--follow-up", "--followup"]);
+
+/**
+ * Parse the streaming-behavior flag out of a `/skill:<name>` argument string.
+ *
+ * Recognized tokens:
+ *   - `--steer`               -> streamingBehavior = "steer"
+ *   - `--follow-up`           -> streamingBehavior = "followUp"
+ *   - `--followup` (alias)    -> streamingBehavior = "followUp"
+ *
+ * Flag is position-independent, stripped from the returned `args`, and
+ * last-occurrence wins if multiple are given. Defaults to `"followUp"` when
+ * no flag is present, preserving prior behavior.
+ */
+function parseSkillInvocationArgs(rawArgs: string): {
+	args: string;
+	streamingBehavior: "steer" | "followUp";
+} {
+	if (!rawArgs) {
+		return { args: "", streamingBehavior: "followUp" };
+	}
+	const tokens = rawArgs.split(/\s+/);
+	let mode: "steer" | "followUp" = "followUp";
+	const rest: string[] = [];
+	for (const token of tokens) {
+		if (STEER_FLAGS.has(token)) {
+			mode = "steer";
+			continue;
+		}
+		if (FOLLOWUP_FLAGS.has(token)) {
+			mode = "followUp";
+			continue;
+		}
+		rest.push(token);
+	}
+	return { args: rest.join(" "), streamingBehavior: mode };
 }


### PR DESCRIPTION
Closes #1031.

Lets users choose `steer` vs `follow-up` delivery when invoking a `/skill:*` slash command interactively. Defaults to `follow-up` (backward-compatible).

### Behavior

```text
/skill:debugging                          → followUp (default)
/skill:debugging --steer                  → steer (interrupt)
/skill:debugging --steer focus on hooks   → steer; args="focus on hooks"
/skill:debugging focus --follow-up        → followUp; args="focus"
/skill:debugging --steer --follow-up      → followUp (last-occurrence wins)
```

Flag is position-independent, stripped from `User: <args>` metadata, last-occurrence wins. `--followup` is an alias for `--follow-up`.

### Scope

Two files:

- `packages/coding-agent/src/modes/controllers/input-controller.ts` — add `parseSkillInvocationArgs` helper; thread resolved mode into `promptCustomMessage`.
- `docs/skills.md` — document the flag and behavior.

No type extensions, no UI changes, no settings, no frontmatter.

### Backward compatibility

- Existing `/skill:name` invocations behave identically (default `followUp`).
- The mode flag is only consulted on the streaming path of `promptCustomMessage` (`agent-session.ts:3214-3220`); the idle path drops `streamingBehavior` and prompts normally.
- `SkillPromptDetails` is unchanged; persisted / replayed skill messages render identically.

### Untouched

`command-controller.ts:handleSkillCommand` (line 1086) — `rg -n handleSkillCommand packages` reports zero call sites in the repo, so this PR does not modify it. If it is wired up later, it can call `parseSkillInvocationArgs` from the same module.

### Verification

- `bun run check:ts` — clean across all workspaces.
- `bun --cwd packages/coding-agent run test test/input-controller-escape.test.ts test/input-controller-keybindings.test.ts` — 14/14 pass.
- Helper exits unchanged on no-flag input (`/skill:foo` → `followUp`, args unchanged) and parses flags in any position with last-occurrence-wins semantics.
