### PR TITLE
feat(skill-command): route /skill:* through the submission keybinding (Enter ⇒ steer, Ctrl+Enter ⇒ follow-up)

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -136,8 +136,13 @@ If `skills.enableSkillCommands` is true, interactive mode registers one slash co
 
 - reads the skill file directly from `filePath`
 - strips frontmatter
-- injects skill body as a follow-up custom message
+- injects skill body as a custom message
+- delivery mode follows the **submission keybinding**:
+  - **Enter** → invokes the skill on the `steer` queue while streaming (matches free-text Enter, which also steers), or as a normal idle prompt when the agent is not streaming
+  - **Ctrl+Enter** (`app.message.followUp`) → invokes the skill on the `followUp` queue while streaming, or as a normal idle prompt when the agent is not streaming
 - appends metadata (`Skill: <path>`, optional `User: <args>`)
+
+There is no flag, mode-selector, or frontmatter knob to override this — the keybinding *is* the choice, identical to how free text is routed during streaming (`input-controller.ts:243-249` for Enter, `input-controller.ts:462-500` for Ctrl+Enter; both dispatch through `#invokeSkillCommand`).
 
 ## `skill://` URL behavior
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -240,45 +240,12 @@ export class InputController {
 				text = slashResult;
 			}
 
-			// Handle skill commands (/skill:name [args])
-			if (text.startsWith("/skill:")) {
-				const spaceIndex = text.indexOf(" ");
-				const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
-				const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
-				const skillPath = this.ctx.skillCommands?.get(commandName);
-				if (skillPath) {
-					this.ctx.editor.addToHistory(text);
-					this.ctx.editor.setText("");
-					try {
-						const content = await Bun.file(skillPath).text();
-						const body = content.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
-						const metaLines = [`Skill: ${skillPath}`];
-						if (args) {
-							metaLines.push(`User: ${args}`);
-						}
-						const message = `${body}\n\n---\n\n${metaLines.join("\n")}`;
-						const skillName = commandName.slice("skill:".length);
-						const details: SkillPromptDetails = {
-							name: skillName || commandName,
-							path: skillPath,
-							args: args || undefined,
-							lineCount: body ? body.split("\n").length : 0,
-						};
-						await this.ctx.session.promptCustomMessage(
-							{
-								customType: SKILL_PROMPT_MESSAGE_TYPE,
-								content: message,
-								display: true,
-								details,
-								attribution: "user",
-							},
-							{ streamingBehavior: "followUp" },
-						);
-					} catch (err) {
-						this.ctx.showError(`Failed to load skill: ${err instanceof Error ? err.message : String(err)}`);
-					}
-					return;
-				}
+			// Handle skill commands (/skill:name [args]). Enter ⇒ steer (matches the
+			// free-text Enter semantics applied a few lines below at the streaming
+			// branch). Ctrl+Enter routes through `handleFollowUp` and dispatches the
+			// same helper with `"followUp"`.
+			if (await this.#invokeSkillCommand(text, "steer")) {
+				return;
 			}
 
 			// Handle bash command (! for normal, !! for excluded from context)
@@ -439,13 +406,79 @@ export class InputController {
 		}
 	}
 
+	/**
+	 * Dispatch a `/skill:<name> [args]` invocation through `promptCustomMessage`
+	 * using the supplied `streamingBehavior`. Returns true if the text was a
+	 * recognised skill command and was dispatched. A failure to load the skill
+	 * file is surfaced via `showError` but still returns true — the editor was
+	 * already cleared on the success path, so falling through to plain-text
+	 * handling at that point would double-submit. Returns false when the text
+	 * isn't a `/skill:` prefix or the command name isn't a registered skill,
+	 * so the caller can fall through to plain-text handling (this branch
+	 * leaves the editor state untouched). `streamingBehavior` is only consulted
+	 * while the agent is streaming; the idle path of `promptCustomMessage`
+	 * ignores it.
+	 */
+	async #invokeSkillCommand(text: string, streamingBehavior: "steer" | "followUp"): Promise<boolean> {
+		if (!text.startsWith("/skill:")) return false;
+		const spaceIndex = text.indexOf(" ");
+		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
+		const skillPath = this.ctx.skillCommands?.get(commandName);
+		if (!skillPath) return false;
+		this.ctx.editor.addToHistory(text);
+		this.ctx.editor.setText("");
+		try {
+			const content = await Bun.file(skillPath).text();
+			const body = content.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
+			const metaLines = [`Skill: ${skillPath}`];
+			if (args) {
+				metaLines.push(`User: ${args}`);
+			}
+			const message = `${body}\n\n---\n\n${metaLines.join("\n")}`;
+			const skillName = commandName.slice("skill:".length);
+			const details: SkillPromptDetails = {
+				name: skillName || commandName,
+				path: skillPath,
+				args: args || undefined,
+				lineCount: body ? body.split("\n").length : 0,
+			};
+			await this.ctx.session.promptCustomMessage(
+				{
+					customType: SKILL_PROMPT_MESSAGE_TYPE,
+					content: message,
+					display: true,
+					details,
+					attribution: "user",
+				},
+				{ streamingBehavior },
+			);
+		} catch (err) {
+			this.ctx.showError(`Failed to load skill: ${err instanceof Error ? err.message : String(err)}`);
+		}
+		return true;
+	}
+
 	/** Send editor text as a follow-up message (queued behind current stream). */
 	async handleFollowUp(): Promise<void> {
 		const text = this.ctx.editor.getText().trim();
 		if (!text) return;
 
+		// Compaction first: while compacting, free text gets queued via
+		// `queueCompactionMessage`, and `/skill:*` rides the same queue so a
+		// skill typed during compaction is not lost or short-circuited through
+		// `promptCustomMessage`. The skill text is queued verbatim; whether
+		// the queued entry is later re-parsed into a skill invocation is a
+		// separate concern owned by the compaction-resume path.
 		if (this.ctx.session.isCompacting) {
 			this.ctx.queueCompactionMessage(text, "followUp");
+			return;
+		}
+
+		// Skill commands invoke through the custom-message path regardless of
+		// which keybinding submitted them. Enter routes them as `steer`;
+		// Ctrl+Enter (this handler) routes them as `followUp`.
+		if (await this.#invokeSkillCommand(text, "followUp")) {
 			return;
 		}
 


### PR DESCRIPTION
Closes #1031. Supersedes #1032 (the flag-based approach was rejected in review).

Makes `/skill:<name> [args]` work identically under both submission keybindings, mirroring how free text is already routed during streaming:

| Submission | Stream state | Behavior |
|---|---|---|
| `/skill:foo` + Enter | idle | invokes skill (idle prompt) |
| `/skill:foo` + Enter | streaming | invokes skill on the **steer** queue |
| `/skill:foo` + Ctrl+Enter | idle | invokes skill (idle prompt) — previously sent the literal `/skill:foo …` as plain text |
| `/skill:foo` + Ctrl+Enter | streaming | invokes skill on the **followUp** queue — previously sent the literal `/skill:foo …` as plain followUp text |

### What changed vs #1032

The `--steer` / `--follow-up` / `--followup` flag parser is gone. The keybinding alone selects the mode, so the slash-command syntax stays minimal. If a user types `--steer` after a skill name now, it shows up in the `User:` metadata as a normal arg.

### Scope

Two files:

- `packages/coding-agent/src/modes/controllers/input-controller.ts` — adds `#invokeSkillCommand`; calls it from `setupEditorSubmitHandler` (`"steer"`) and `handleFollowUp` (`"followUp"`).
- `docs/skills.md` — rewrites the `/skill:<name>` subsection to describe keybinding-driven mode selection.

No type extensions, no new keybindings, no settings, no frontmatter.

### Compaction handling

`handleFollowUp` retains its `isCompacting` short-circuit **before** the skill dispatch, so `/skill:foo` typed during compaction queues via `queueCompactionMessage(text, "followUp")` exactly like free text. The skill is not re-parsed at compaction-resume time (matches existing free-text semantics; can be revisited as a follow-up if needed).

### Backward compatibility

- `/skill:foo` + Enter while **idle** behaves as it always has (idle prompt).
- `/skill:foo` + Enter while **streaming** now lands on the steer queue. Previously it landed on the followUp queue (pre-#1032) or wherever the `--steer` / `--follow-up` flag said (post-#1032). Users who relied on the followUp default can press Ctrl+Enter instead — same key they already use for free-text follow-ups.
- `/skill:foo` + Ctrl+Enter is **new** capability; before this PR the skill was simply not invoked.
- `SkillPromptDetails` is unchanged.

### Untouched

`command-controller.ts:handleSkillCommand` (line 1086) still has zero call sites in the repo (`rg -n handleSkillCommand packages`); not modified.

### Verification

- `bun run check:ts` — Biome clean across the workspace; every `tsgo -p tsconfig.json --noEmit` exits 0.
- `bun --cwd packages/coding-agent run test test/input-controller-escape.test.ts test/input-controller-keybindings.test.ts` — 14 pass / 0 fail.
