### PR TITLE
fix(ai): preserve peer-rotated OAuth credential on refresh race

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OAuth credentials being silently disabled when two omp processes (or any two `AuthStorage` instances sharing a `agent.db`) race on token refresh. Anthropic rotates refresh tokens on every use, so the loser's `invalid_grant` response previously soft-deleted the row that the winner just rotated, forcing the user to `/login` again. `#tryOAuthCredential` now re-reads the row from disk before declaring a definitive failure: if the persisted `refresh` differs from the snapshot it tried, the peer-rotated credential is reloaded and the request retries against the fresh token instead of disabling the live row.
+
 ## [14.9.3] - 2026-05-10
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1993,6 +1993,27 @@ export class AuthStorage {
 			});
 
 			if (isDefinitiveFailure) {
+				// The credential at this index may have been rotated by another process between
+				// our in-memory snapshot and the refresh attempt: Anthropic rotates refresh
+				// tokens on every use, so the peer's success leaves our stored token invalid.
+				// Re-read the row from disk before marking it disabled — if the persisted
+				// refresh token has changed, the peer rotation succeeded and we should pick
+				// up the new credential instead of soft-deleting the row that the peer just
+				// updated.
+				const credentialId = this.#getStoredCredentials(provider)[selection.index]?.id;
+				if (credentialId !== undefined) {
+					const latestRow = this.#store.listAuthCredentials(provider).find(row => row.id === credentialId);
+					const latestCredential = latestRow?.credential;
+					if (latestCredential?.type === "oauth" && latestCredential.refresh !== selection.credential.refresh) {
+						logger.debug("OAuth refresh race detected; another process rotated token first", {
+							provider,
+							index: selection.index,
+							credentialId,
+						});
+						await this.reload();
+						return this.getApiKey(provider, sessionId, options);
+					}
+				}
 				// Permanently disable invalid credentials with an explicit cause for inspection/debugging
 				this.#disableCredentialAt(provider, selection.index, `oauth refresh failed: ${errorMsg}`);
 				if (this.#getCredentialsForProvider(provider).some(credential => credential.type === "oauth")) {

--- a/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
+++ b/packages/ai/test/auth-storage-oauth-refresh-race.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthCredentialStore, AuthStorage, type CredentialDisabledEvent } from "../src/auth-storage";
+import * as oauthUtils from "../src/utils/oauth";
+import { withEnv } from "./helpers";
+
+const SUPPRESS_ANTHROPIC_ENV = {
+	ANTHROPIC_API_KEY: undefined,
+	ANTHROPIC_OAUTH_TOKEN: undefined,
+} as const;
+
+describe("AuthStorage OAuth refresh race", () => {
+	let tempDir = "";
+	let store: AuthCredentialStore | null = null;
+	let authStorage: AuthStorage | null = null;
+	let events: CredentialDisabledEvent[] = [];
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-auth-oauth-race-"));
+		store = await AuthCredentialStore.open(path.join(tempDir, "agent.db"));
+		events = [];
+		authStorage = new AuthStorage(store, {
+			onCredentialDisabled: event => {
+				events.push(event);
+			},
+		});
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		store?.close();
+		store = null;
+		authStorage = null;
+		if (tempDir) {
+			await fs.rm(tempDir, { recursive: true, force: true });
+			tempDir = "";
+		}
+	});
+
+	test("does not disable a credential another process already rotated", async () => {
+		if (!authStorage || !store) throw new Error("test setup failed");
+
+		// Seed the shared DB with one expired OAuth credential; this simulates the
+		// state two cooperating omp processes both load from the persisted row.
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "stale-access",
+				refresh: "stale-refresh",
+				expires: Date.now() - 60_000,
+			},
+		]);
+		const storedBefore = store.listAuthCredentials("anthropic");
+		expect(storedBefore).toHaveLength(1);
+		const credentialId = storedBefore[0]!.id;
+
+		// Simulate the peer's successful refresh: another process called the real
+		// `#replaceCredentialAt` path, which rotates the row in place via
+		// updateAuthCredential. The in-memory snapshot we hold is now stale.
+		store.updateAuthCredential(credentialId, {
+			type: "oauth",
+			access: "fresh-access-from-peer",
+			refresh: "fresh-refresh-from-peer",
+			expires: Date.now() + 60 * 60_000,
+		});
+
+		// Mock mirrors Anthropic: only the stale refresh token is rejected, because
+		// real rotation invalidates the previous refresh token on use.
+		vi.spyOn(oauthUtils, "getOAuthApiKey").mockImplementation(async (provider, creds) => {
+			const credential = creds[provider];
+			if (credential?.refresh === "stale-refresh") {
+				throw new Error(
+					'HTTP 400 invalid_grant {"error":"invalid_grant","error_description":"Refresh token not found or invalid"}',
+				);
+			}
+			return { newCredentials: credential!, apiKey: credential!.access };
+		});
+
+		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
+			const apiKey = await authStorage!.getApiKey("anthropic", "session-race");
+
+			// We should have picked up the rotated credential instead of disabling
+			// the row that the peer just updated.
+			expect(apiKey).toBe("fresh-access-from-peer");
+			expect(events).toHaveLength(0);
+			expect(authStorage!.list()).toContain("anthropic");
+
+			// The row must still be active in storage; before the fix it would be
+			// soft-deleted with disabled_cause set to the invalid_grant error.
+			const stored = store!.listAuthCredentials("anthropic");
+			expect(stored).toHaveLength(1);
+			expect(stored[0]?.id).toBe(credentialId);
+			expect(stored[0]?.credential.type).toBe("oauth");
+			if (stored[0]?.credential.type === "oauth") {
+				expect(stored[0].credential.refresh).toBe("fresh-refresh-from-peer");
+			}
+		});
+	});
+
+	test("still disables when the failure is real (no concurrent rotation)", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		// Single-process scenario: refresh genuinely fails and no peer updated the
+		// row. The credential should still be soft-deleted.
+		await authStorage.set("anthropic", [
+			{
+				type: "oauth",
+				access: "expired-access",
+				refresh: "stale-refresh",
+				expires: Date.now() - 60_000,
+			},
+		]);
+
+		vi.spyOn(oauthUtils, "getOAuthApiKey").mockImplementation(async () => {
+			throw new Error('invalid_grant {"error":"invalid_grant"}');
+		});
+
+		await withEnv(SUPPRESS_ANTHROPIC_ENV, async () => {
+			const apiKey = await authStorage!.getApiKey("anthropic", "session-real-failure");
+
+			expect(apiKey).toBeUndefined();
+			expect(events).toHaveLength(1);
+			expect(events[0]?.disabledCause).toContain("invalid_grant");
+		});
+	});
+});


### PR DESCRIPTION
## What

Stop `#tryOAuthCredential` from soft-deleting an OAuth row when the `invalid_grant` it received is the artifact of a concurrent peer rotation rather than a real token revocation. Before disabling, re-read the row from disk: if the persisted refresh token differs from the snapshot we just tried, reload the in-memory cache and retry against the fresh credential.

## Why

Anthropic (and every well-behaved OAuth provider) rotates refresh tokens on every use. Two omp processes sharing a single `agent.db` for the same Anthropic OAuth credential deterministically race when the access token expires:

1. Process A and Process B both load the credential `{access: AT1, refresh: RT1}` into their in-memory `#data` map.
2. Both notice `Date.now() >= credential.expires` and start refreshing.
3. A wins: the server responds with `{access: AT2, refresh: RT2}`. A persists the new tokens in-place via `#replaceCredentialAt → updateAuthCredential` (same row id).
4. B's request lands second, still carrying `RT1`. The server returns `400 invalid_grant — Refresh token not found or invalid` because `RT1` has already been consumed.
5. B's catch branch matched `isDefinitiveFailure` and called `#disableCredentialAt(provider, selection.index, …)`. That index resolves to the row id A just updated, so B's soft-delete writes `disabled_cause = "oauth refresh failed: …"` onto the row whose `data` column now contains the freshly rotated, perfectly valid credential.
6. From the user's perspective Anthropic OAuth disappeared and they must `/login` again, even though a valid token is sitting in the row right behind the disabled flag. Re-logging in inserts a new row, leaving the disabled-but-valid row behind as forensic clutter.

I hit this with five long-running omp panes attached to a single Anthropic OAuth login; the auth_credentials table accumulated three disabled rows in roughly a day:

```
1|anthropic|oauth|...|oauth refresh failed: ... invalid_grant ...
3|anthropic|oauth|...|oauth refresh failed: ... invalid_grant ...
6|anthropic|oauth|...|(active)
```

Each `disabled_cause` is the verbatim refresh error, and each ID is a separate `/login` round trip the user had to perform.

## Fix

In `auth-storage.ts:#tryOAuthCredential`, inside the `isDefinitiveFailure` branch, do a single targeted re-read of the row before calling `#disableCredentialAt`:

```ts
const credentialId = this.#getStoredCredentials(provider)[selection.index]?.id;
if (credentialId !== undefined) {
    const latestRow = this.#store
        .listAuthCredentials(provider)
        .find(row => row.id === credentialId);
    const latestCredential = latestRow?.credential;
    if (
        latestCredential?.type === "oauth" &&
        latestCredential.refresh !== selection.credential.refresh
    ) {
        logger.debug("OAuth refresh race detected; another process rotated token first", {
            provider, index: selection.index, credentialId,
        });
        await this.reload();
        return this.getApiKey(provider, sessionId, options);
    }
}
// fall through to the existing disable path
```

Rationale for the comparison:

- The in-memory snapshot's `refresh` is the token we just sent on the wire.
- The on-disk row's `refresh` is whatever the most recent successful refresh wrote (peer or self).
- If they match, the credential really is invalid (our refresh failed and nobody rotated it), so the existing disable path still runs unchanged.
- If they differ, the only way the row's `refresh` got rotated since our snapshot is a peer succeeding while we were in flight. The peer's token is, by construction, valid; reload and retry. The recursive `getApiKey` short-circuits at line 375 of `utils/oauth/index.ts` (`Date.now() >= creds.expires` is false for the fresh row), so no further refresh hits the network.

The check only triggers on `isDefinitiveFailure`; transient errors and usage-limit blocks are untouched.

## Why not a SQLite-level mutex

Considered, but the contract we actually need is "don't punish the loser for being late", not "serialize refreshes globally". Serializing would:

1. Add a cross-process lock that every refresh path has to acquire and that the timeout protection in `#refreshOAuthCredential` would have to coordinate with.
2. Still leave the disable path racy against any other code that legitimately rotates the row (e.g. interactive `/login` replacing the credential while another request is mid-flight).

The disk re-read is one extra read per definitive failure, which is the rare path, and it correctly handles every "peer changed the row under me" case, not just refresh.

## Testing

`packages/ai/test/auth-storage-oauth-refresh-race.test.ts` (new):

- **does not disable a credential another process already rotated** — seeds a stale OAuth row, simulates the peer's in-place rotation via `store.updateAuthCredential`, mocks `getOAuthApiKey` to mirror Anthropic's contract (only the stale `refresh` is rejected; the rotated one succeeds), then drives `getApiKey` through the race path. Asserts:
  - `apiKey` returns the rotated access token, not `undefined`.
  - No `onCredentialDisabled` event fires.
  - `authStorage.list()` still reports `anthropic`.
  - The row is still active in `store.listAuthCredentials("anthropic")`, retains its original id, and now carries the rotated `refresh`.
- **still disables when the failure is real (no concurrent rotation)** — single-process scenario where the refresh really fails and no peer rotated the row. Asserts the credential is soft-deleted and the `onCredentialDisabled` event fires with the `invalid_grant` cause, proving the existing disable path is preserved.

Suite results:

```
bun test test/auth-storage-oauth-refresh-race.test.ts → 2 pass / 0 fail
bun test test/auth-storage-*.test.ts                  → 44 pass / 0 fail (across 5 files)
bun run check:types                                   → clean
bunx biome check                                      → clean
```

The new test was first written to fail against the unmodified `auth-storage.ts` and only passes with the patch applied.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated
