### PR TITLE
fix(coding-agent): spell out xhigh in the status-line label

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Changed the status-line thinking-level label for `xhigh` from `xhi` to `xhigh` across the unicode, nerd, and ASCII symbol presets. The 3-char abbreviation was ambiguous (`xhi` is not a recognizable shorthand for `xhigh`), and the status line has the column budget for the extra two characters.
+
 ## [14.9.9] - 2026-05-12
 
 ### Added

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -290,7 +290,7 @@ const UNICODE_SYMBOLS: SymbolMap = {
 	"thinking.low": "◑ low",
 	"thinking.medium": "◒ med",
 	"thinking.high": "◕ high",
-	"thinking.xhigh": "◉ xhi",
+	"thinking.xhigh": "◉ xhigh",
 	// Checkboxes
 	"checkbox.checked": "☑",
 	"checkbox.unchecked": "☐",
@@ -535,8 +535,8 @@ const NERD_SYMBOLS: SymbolMap = {
 	"thinking.medium": "\u{F192} med",
 	// pick: 🤯 high | alt:  high  high
 	"thinking.high": "\u{F111} high",
-	// pick: 🧠 xhi | alt:  xhi  xhi
-	"thinking.xhigh": "\u{F06D} xhi",
+	// pick: 🧠 xhigh | alt:  xhigh  xhigh
+	"thinking.xhigh": "\u{F06D} xhigh",
 	// Checkboxes
 	// pick:  | alt:  
 	"checkbox.checked": "\uf14a",
@@ -704,7 +704,7 @@ const ASCII_SYMBOLS: SymbolMap = {
 	"thinking.low": "[low]",
 	"thinking.medium": "[med]",
 	"thinking.high": "[high]",
-	"thinking.xhigh": "[xhi]",
+	"thinking.xhigh": "[xhigh]",
 	// Checkboxes
 	"checkbox.checked": "[x]",
 	"checkbox.unchecked": "[ ]",


### PR DESCRIPTION
## What

Expand the status-line thinking-level label for `xhigh` from `xhi` to `xhigh` across all three symbol presets (unicode, nerd, ascii).

## Why

All five thinking-level labels currently render with a fixed-width abbreviation in the status line:

| level   | unicode    | nerd            | ascii    |
|---------|------------|-----------------|----------|
| minimal | `◔ min`    | ` min`         | `[min]`  |
| low     | `◑ low`    | ` low`         | `[low]`  |
| medium  | `◒ med`    | ` med`         | `[med]`  |
| high    | `◕ high`   | ` high`        | `[high]` |
| xhigh   | `◉ xhi`    | ` xhi`         | `[xhi]`  |

`min`, `low`, `med`, and `high` are recognizable, but `xhi` is not — there is no convention that maps `xhi` to `xhigh`, and the status-line context is exactly where someone glancing at it wants an unambiguous answer. A user just reported it as a truncation bug.

The status line has no fixed column budget for the thinking segment (it's appended after a dot separator), so dropping the abbreviation costs two columns at most.

## Change

`packages/coding-agent/src/modes/theme/theme.ts` — three one-line label updates, one per preset. Icons unchanged.

```
- "thinking.xhigh": "◉ xhi"           →   "◉ xhigh"
- "thinking.xhigh": "\u{F06D} xhi"    →   "\u{F06D} xhigh"
- "thinking.xhigh": "[xhi]"           →   "[xhigh]"
```

No test changes — the label is data, not behavior. The existing theme snapshot/preset tests pass.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated
