### PR TITLE
fix(coding-agent): align status-line context% with /context command output

### DIFF
--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -1,5 +1,4 @@
 import * as fs from "node:fs";
-import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { type Component, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
 import { formatCount, getProjectDir } from "@oh-my-pi/pi-utils";
 import { $ } from "bun";
@@ -7,7 +6,7 @@ import { settings } from "../../config/settings";
 import type { StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle } from "../../config/settings-schema";
 import { theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
-import { calculatePromptTokens } from "../../session/compaction/compaction";
+import { computeContextBreakdown } from "../utils/context-usage";
 import * as git from "../../utils/git";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../utils/session-color";
 import { sanitizeStatusText } from "../shared";
@@ -72,6 +71,10 @@ export class StatusLineComponent implements Component {
 	#defaultBranch?: string;
 	#lastTokensPerSecond: number | null = null;
 	#lastTokensPerSecondTimestamp: number | null = null;
+
+	// Context breakdown caching (2s TTL — aligns with /context command output)
+	#cachedBreakdown: { usedTokens: number; contextWindow: number } | null = null;
+	#breakdownFetchedAt = 0;
 
 	constructor(private readonly session: AgentSession) {
 		this.#settings = {
@@ -301,6 +304,19 @@ export class StatusLineComponent implements Component {
 		return null;
 	}
 
+	#getCachedContextBreakdown(): { usedTokens: number; contextWindow: number } {
+		const now = Date.now();
+		if (!this.#cachedBreakdown || now - this.#breakdownFetchedAt > 2_000) {
+			const breakdown = computeContextBreakdown(this.session);
+			this.#cachedBreakdown = {
+				usedTokens: breakdown.usedTokens,
+				contextWindow: breakdown.contextWindow,
+			};
+			this.#breakdownFetchedAt = now;
+		}
+		return this.#cachedBreakdown;
+	}
+
 	#buildSegmentContext(width: number): SegmentContext {
 		const state = this.session.state;
 
@@ -318,14 +334,10 @@ export class StatusLineComponent implements Component {
 			tokensPerSecond: this.#getTokensPerSecond(),
 		};
 
-		// Get context percentage
-		const lastAssistantMessage = state.messages
-			.slice()
-			.reverse()
-			.find(m => m.role === "assistant" && m.stopReason !== "aborted") as AssistantMessage | undefined;
-
-		const contextTokens = lastAssistantMessage ? calculatePromptTokens(lastAssistantMessage.usage) : 0;
-		const contextWindow = state.model?.contextWindow || 0;
+		// Context usage — aligned with /context command so both surfaces report the same value
+		const breakdown = this.#getCachedContextBreakdown();
+		const contextTokens = breakdown.usedTokens;
+		const contextWindow = breakdown.contextWindow || state.model?.contextWindow || 0;
 		const contextPercent = contextWindow > 0 ? (contextTokens / contextWindow) * 100 : 0;
 
 		return {


### PR DESCRIPTION
## Summary

The status-line `context_pct` segment and the `/context` slash command both display a single number that the user reads as "how full is my context window", but the two values can diverge by a factor of 2+ on the same active session because they are computed from completely different data sources.

`/context` (`packages/coding-agent/src/modes/utils/context-usage.ts:computeContextBreakdown`) is an offline estimate over the live session state — `systemPrompt + tools + skills + accumulated messages` — and reports e.g. `212K (21.2%)` for a typical mid-sized session.

`context_pct` in the status line (`packages/coding-agent/src/modes/components/status-line.ts:#buildSegmentContext` → `calculatePromptTokens(lastAssistantMessage.usage)`) reads the most recent assistant message's Anthropic API usage and returns `input + cacheRead + cacheWrite`. On a session that just rotated cache tiers (5m → 1h ephemeral re-cache, or a system-prompt change that creates a fresh breakpoint), `cacheWrite` can be a large one-shot value, producing `442K (44.2%)` for the same session that `/context` reports as `21.2%`.

Both numbers are correct under their own definition. They just mean very different things:

| | Status line (old) | `/context` panel |
|---|---|---|
| Source | Anthropic API `usage` (authoritative) | Local estimate over session state |
| Semantic | "tokens the model received in this turn's prompt" | "tokens the conversation currently occupies in the window" |
| Includes per-turn `cache_creation` | yes | no |
| Stable across cache rotations | no | yes |

A user staring at the status line sees `44.2%/1M` while opening `/context` returns `21.2%/1M` for the same session and concludes that one of them is broken. The mismatch is also visible in conjunction with `5h` / `7d` usage segments — users naturally read the status-line segments together as one consistent dashboard.

## Change

This PR aligns the status-line `context_pct` with `/context`'s `computeContextBreakdown` so the dashboard tells one consistent story: the in-session context occupancy.

- `status-line.ts`: replace `calculatePromptTokens(lastAssistantMessage.usage)` with `computeContextBreakdown(session).usedTokens` — same source `/context` uses.
- Add a 2-second cache on the breakdown result inside the component (`#cachedBreakdown`, `#breakdownFetchedAt`) so the per-frame status-line render does not re-iterate every message via `estimateTokens` on long sessions. TTL matches the granularity of other status-line caches (e.g. `1s` git status).
- Drop now-unused `calculatePromptTokens` import + the `lastAssistantMessage` lookup that exclusively fed it. The helper itself stays — it remains the right function for billing/quota/cost-style use cases inside `event-controller`, `agent-session`, and `compaction`.

The displayed `context_pct` now matches what the user gets when they explicitly ask the question via `/context`. The Anthropic API per-turn prompt size is still observable elsewhere (`token_in`, `cache_read`, `cache_write`, `token_total`) for users who want billing-level granularity.

## Acceptance

- Opening `/context` and reading the status line at the same time on the same session yields the same percent (within the 2-second cache window).
- A turn with a large `cache_creation` event no longer spikes the status-line percent past `/context`'s number.
- Long-session render cost of the status line does not regress measurably (2s TTL on `computeContextBreakdown` amortizes the `estimateMessagesTokens` walk).

## Repro (the case that surfaced this)

User session on `claude-opus-4-7[1m]`, mid-conversation, mostly cached. `/context` panel reports:

```
Claude Opus 4.7 (1m context)
212K/1m tokens (21.2%)
Estimated usage by category
  System prompt:    3.2K (0.3%)
  System tools:     15K  (1.5%)
  System context:   163  (<0.1%)
  Skills:           240  (<0.1%)
  Messages:         193K (19.3%)
  Free space:       638K (63.8%)
  Autocompact buf:  150K (15.0%)
```

Status line at the same moment displayed `44.2%/1M` — over 2× the `/context` number — because the last assistant message's `cache_creation_input_tokens` included a fresh 1h-ephemeral re-cache of the system prompt + tools (~230K) that the offline estimator (correctly) does not double-count.

## Non-goals

- Not changing `calculatePromptTokens` itself; its semantic ("tokens in this turn's prompt") is correct for the billing/quota call sites that still consume it.
- Not surfacing both numbers in the status line. If a user wants the API-side per-turn prompt size, the existing `token_in` / `cache_read` / `cache_write` / `token_total` segments already expose it.
