### PR TITLE
fix(browser): bound tab worker startup setup

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,10 @@
 - Changed search truncation metadata/renderer output from match/result-based limits to file-based limits (`fileLimitReached`, `perFileLimitReached`) and updated truncation labels accordingly
 - Lowered `read.defaultLimit` default from `500` to `300` lines, and split the per-range context padding into asymmetric `RANGE_LEADING_CONTEXT_LINES = 1` / `RANGE_TRAILING_CONTEXT_LINES = 3` (was symmetric `RANGE_CONTEXT_LINES = 3`). Replay analysis over post-summarizer sessions (`scripts/session-stats/optimize_read_config.py`) showed that bare-path reads are over-provisioned at the median (file p50 = 220 lines) and that most follow-up reads are disjoint hops rather than adjacent extensions — so a smaller default plus narrower leading context reclaims tokens without measurably changing first-cover rate. Trailing context stays at 3 lines to keep anchor-stale recovery on narrow reads. Explicit `read.defaultLimit` overrides in settings are honoured unchanged.
 
+### Fixed
+
+- Fixed headless `browser.open` tab startup on slow Chromium target enumeration by making worker-side stealth user-agent target setup selective, bounded, and best-effort for non-active targets. Worker startup errors are now surfaced directly instead of degrading into the generic tab worker initialization timeout.
+
 ## [15.0.0] - 2026-05-13
 ### Breaking Changes
 

--- a/packages/coding-agent/src/tools/browser/launch.ts
+++ b/packages/coding-agent/src/tools/browser/launch.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { $which, getPuppeteerDir, logger } from "@oh-my-pi/pi-utils";
 import * as browsers from "@puppeteer/browsers";
-import type { Browser, CDPSession, Page, default as Puppeteer } from "puppeteer-core";
+import type { Browser, CDPSession, Page, default as Puppeteer, Target } from "puppeteer-core";
 import { PUPPETEER_REVISIONS } from "puppeteer-core/internal/revisions.js";
 import stealthTamperingScript from "../puppeteer/00_stealth_tampering.txt" with { type: "text" };
 import stealthActivityScript from "../puppeteer/01_stealth_activity.txt" with { type: "text" };
@@ -37,6 +37,7 @@ export const STEALTH_IGNORE_DEFAULT_ARGS = [
 ];
 export const STEALTH_ACCEPT_LANGUAGE = "en-US,en";
 
+const USER_AGENT_TARGET_TIMEOUT_MS = 1_000;
 const PUPPETEER_SOURCE_URL_SUFFIX = "//# sourceURL=__puppeteer_evaluation_script__";
 
 /**
@@ -463,6 +464,7 @@ export interface UserAgentSession {
 async function configureUserAgentTargets(
 	browser: Browser,
 	state: { browserSession: CDPSession | null; override: UserAgentOverride },
+	targetTimeoutMs = USER_AGENT_TARGET_TIMEOUT_MS,
 ): Promise<void> {
 	if (!state.browserSession) {
 		state.browserSession = await browser.target().createCDPSession();
@@ -471,21 +473,66 @@ async function configureUserAgentTargets(
 			waitForDebuggerOnStart: false,
 			flatten: true,
 		});
-		state.browserSession.on("Target.attachedToTarget", async (event: { sessionId: string }) => {
-			const connection = state.browserSession?.connection();
-			const session = connection?.session(event.sessionId);
-			if (!session) return;
-			await sendUserAgentOverride(wrapSession(session), state.override);
-		});
+		state.browserSession.on(
+			"Target.attachedToTarget",
+			async (event: { sessionId: string; targetInfo?: { type?: string } }) => {
+				if (!targetInfoSupportsUserAgentOverride(event.targetInfo)) return;
+				const connection = state.browserSession?.connection();
+				const session = connection?.session(event.sessionId);
+				if (!session) return;
+				await withSoftTimeout(
+					sendUserAgentOverride(wrapSession(session), state.override),
+					targetTimeoutMs,
+					"new target user-agent override",
+				);
+			},
+		);
 	}
 
-	const targets = browser.targets();
+	const targets = browser.targets().filter(targetSupportsUserAgentOverride);
 	await Promise.all(
 		targets.map(async target => {
-			const session = await target.createCDPSession();
-			await sendUserAgentOverride(wrapSession(session), state.override);
+			await withSoftTimeout(
+				applyTargetUserAgentOverride(target, state.override),
+				targetTimeoutMs,
+				"target user-agent override",
+			);
 		}),
 	);
+}
+
+function targetSupportsUserAgentOverride(target: Target): boolean {
+	return targetInfoSupportsUserAgentOverride({ type: target.type() });
+}
+
+function targetInfoSupportsUserAgentOverride(targetInfo: { type?: string } | undefined): boolean {
+	return targetInfo?.type === "page" || targetInfo?.type === "webview";
+}
+
+async function applyTargetUserAgentOverride(target: Target, override: UserAgentOverride): Promise<void> {
+	const session = await target.createCDPSession();
+	await sendUserAgentOverride(wrapSession(session), override);
+}
+
+async function withSoftTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T | undefined> {
+	let timeout: NodeJS.Timeout | undefined;
+	const timeoutPromise = new Promise<undefined>(resolve => {
+		timeout = setTimeout(() => {
+			logger.debug(`Timed out applying ${label}`);
+			resolve(undefined);
+		}, timeoutMs);
+	});
+	try {
+		return await Promise.race([
+			promise.catch(error => {
+				logger.debug(`Failed to apply ${label}`, { error: error instanceof Error ? error.message : String(error) });
+				return undefined;
+			}),
+			timeoutPromise,
+		]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
 }
 
 async function injectStealthScripts(page: Page): Promise<void> {
@@ -573,4 +620,16 @@ export async function applyStealthPatches(
 	await configureUserAgentTargets(browser, targetState);
 	state.browserSession = targetState.browserSession;
 	await injectStealthScripts(page);
+}
+
+export function targetSupportsUserAgentOverrideForTest(target: Target): boolean {
+	return targetSupportsUserAgentOverride(target);
+}
+
+export async function configureUserAgentTargetsForTest(
+	browser: Browser,
+	state: { browserSession: CDPSession | null; override: UserAgentOverride },
+	targetTimeoutMs?: number,
+): Promise<void> {
+	await configureUserAgentTargets(browser, state, targetTimeoutMs);
 }

--- a/packages/coding-agent/src/tools/browser/tab-supervisor.ts
+++ b/packages/coding-agent/src/tools/browser/tab-supervisor.ts
@@ -30,6 +30,7 @@ import type {
 interface WorkerHandle {
 	send(msg: WorkerInbound, transferList?: Transferable[]): void;
 	onMessage(handler: (msg: WorkerOutbound) => void): () => void;
+	onError(handler: (error: Error) => void): () => void;
 	terminate(): Promise<void>;
 	readonly mode: "worker" | "inline";
 }
@@ -124,23 +125,14 @@ export async function acquireTab(
 
 	const initPayload = await buildInitPayload(browser, opts);
 	const worker = await spawnTabWorker();
-	const { promise, resolve, reject } = Promise.withResolvers<ReadyInfo>();
-	const unlisten = worker.onMessage(msg => {
-		if (msg.type === "ready") resolve(msg.info);
-		else if (msg.type === "init-failed") reject(errorFromPayload(msg.error));
-		else if (msg.type === "log") logWorkerMessage(msg);
-	});
 	let info: ReadyInfo;
 	try {
-		worker.send({ type: "init", payload: initPayload });
-		info = await raceWithTimeout(promise, opts.timeoutMs + GRACE_MS, "Timed out initializing browser tab worker");
+		info = await initializeTabWorker(worker, initPayload, opts.timeoutMs + GRACE_MS);
 	} catch (error) {
-		unlisten();
 		await worker.terminate().catch(() => undefined);
 		if (browser.refCount === 0) await releaseBrowser(browser, { kill: false });
 		throw error;
 	}
-	unlisten();
 
 	holdBrowser(browser);
 	const tab: TabSession = {
@@ -477,6 +469,17 @@ function wrapBunWorker(worker: Worker): WorkerHandle {
 			worker.addEventListener("message", wrap);
 			return () => worker.removeEventListener("message", wrap);
 		},
+		onError(handler) {
+			const onError = (event: ErrorEvent): void => handler(errorFromWorkerEvent(event));
+			const onMessageError = (event: MessageEvent): void =>
+				handler(new ToolError(`Tab worker message error: ${String(event.data)}`));
+			worker.addEventListener("error", onError);
+			worker.addEventListener("messageerror", onMessageError);
+			return () => {
+				worker.removeEventListener("error", onError);
+				worker.removeEventListener("messageerror", onMessageError);
+			};
+		},
 		async terminate() {
 			worker.terminate();
 		},
@@ -515,6 +518,44 @@ async function spawnInlineWorker(): Promise<WorkerHandle> {
 			hostListeners.add(handler);
 			return () => hostListeners.delete(handler);
 		},
+		onError: () => () => {},
 		async terminate() {},
 	};
+}
+
+async function initializeTabWorker(
+	worker: WorkerHandle,
+	payload: WorkerInitPayload,
+	timeoutMs: number,
+): Promise<ReadyInfo> {
+	const { promise, resolve, reject } = Promise.withResolvers<ReadyInfo>();
+	const unlisten = worker.onMessage(msg => {
+		if (msg.type === "ready") resolve(msg.info);
+		else if (msg.type === "init-failed") reject(errorFromPayload(msg.error));
+		else if (msg.type === "log") logWorkerMessage(msg);
+	});
+	const unlistenError = worker.onError(error => {
+		reject(new ToolError(`Tab worker failed during startup: ${error.message}`));
+	});
+	try {
+		worker.send({ type: "init", payload });
+		return await raceWithTimeout(promise, timeoutMs, "Timed out initializing browser tab worker");
+	} finally {
+		unlisten();
+		unlistenError();
+	}
+}
+
+export function initializeTabWorkerForTest(
+	worker: WorkerHandle,
+	payload: WorkerInitPayload,
+	timeoutMs: number,
+): Promise<ReadyInfo> {
+	return initializeTabWorker(worker, payload, timeoutMs);
+}
+
+function errorFromWorkerEvent(event: ErrorEvent): Error {
+	if (event.error instanceof Error) return event.error;
+	if (event.message) return new Error(event.message);
+	return new Error("Unknown tab worker error");
 }

--- a/packages/coding-agent/test/tools/browser-stealth-targets.test.ts
+++ b/packages/coding-agent/test/tools/browser-stealth-targets.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "bun:test";
+import type { Browser, CDPSession, Target } from "puppeteer-core";
+import {
+	configureUserAgentTargetsForTest,
+	targetSupportsUserAgentOverrideForTest,
+} from "../../src/tools/browser/launch";
+
+type SentCommand = {
+	method: string;
+	params?: Record<string, unknown>;
+};
+
+class FakeSession {
+	readonly commands: SentCommand[] = [];
+	readonly #delayMs: number;
+
+	constructor(delayMs = 0) {
+		this.#delayMs = delayMs;
+	}
+
+	async send(method: string, params?: Record<string, unknown>): Promise<unknown> {
+		this.commands.push({ method, params });
+		if (this.#delayMs > 0) await Bun.sleep(this.#delayMs);
+		return {};
+	}
+
+	on(): void {}
+
+	connection(): { session: () => null } {
+		return { session: () => null };
+	}
+}
+
+class FakeTarget {
+	readonly session: FakeSession;
+	createCalls = 0;
+	readonly #type: string;
+
+	constructor(type: string, delayMs = 0) {
+		this.#type = type;
+		this.session = new FakeSession(delayMs);
+	}
+
+	type(): string {
+		return this.#type;
+	}
+
+	async createCDPSession(): Promise<CDPSession> {
+		this.createCalls++;
+		return this.session as unknown as CDPSession;
+	}
+}
+
+class FakeBrowser {
+	readonly browserTarget = new FakeTarget("browser");
+	readonly #targets: FakeTarget[];
+
+	constructor(targets: FakeTarget[]) {
+		this.#targets = targets;
+	}
+
+	target(): Target {
+		return this.browserTarget as unknown as Target;
+	}
+
+	targets(): Target[] {
+		return this.#targets as unknown as Target[];
+	}
+}
+
+const override = {
+	userAgent: "Mozilla/5.0 Chrome/142.0.0.0 Safari/537.36",
+	acceptLanguage: "en-US,en",
+	platform: "Win32",
+	userAgentMetadata: {
+		brands: [{ brand: "Chromium", version: "142" }],
+		fullVersion: "142.0.0.0",
+		platform: "Windows",
+		platformVersion: "10.0.0",
+		architecture: "x86",
+		model: "",
+		mobile: false,
+	},
+};
+
+describe("browser stealth target setup", () => {
+	it("skips non-page targets during existing target user-agent sweep", async () => {
+		const page = new FakeTarget("page");
+		const serviceWorker = new FakeTarget("service_worker");
+		const other = new FakeTarget("other");
+		const browser = new FakeBrowser([page, serviceWorker, other]);
+
+		await configureUserAgentTargetsForTest(browser as unknown as Browser, { browserSession: null, override });
+
+		expect(page.createCalls).toBe(1);
+		expect(serviceWorker.createCalls).toBe(0);
+		expect(other.createCalls).toBe(0);
+	});
+
+	it("does not wait indefinitely for a slow existing page target", async () => {
+		const slowPage = new FakeTarget("page", 200);
+		const browser = new FakeBrowser([slowPage]);
+		const started = performance.now();
+
+		await configureUserAgentTargetsForTest(browser as unknown as Browser, { browserSession: null, override }, 10);
+
+		expect(performance.now() - started).toBeLessThan(100);
+	});
+
+	it("classifies only page-like targets as user-agent override targets", () => {
+		expect(targetSupportsUserAgentOverrideForTest({ type: () => "page" } as unknown as Target)).toBe(true);
+		expect(targetSupportsUserAgentOverrideForTest({ type: () => "webview" } as unknown as Target)).toBe(true);
+		expect(targetSupportsUserAgentOverrideForTest({ type: () => "browser" } as unknown as Target)).toBe(false);
+		expect(targetSupportsUserAgentOverrideForTest({ type: () => "service_worker" } as unknown as Target)).toBe(false);
+		expect(targetSupportsUserAgentOverrideForTest({ type: () => "other" } as unknown as Target)).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts
+++ b/packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import type { ReadyInfo, WorkerInbound, WorkerOutbound } from "../../src/tools/browser/tab-protocol";
+import { initializeTabWorkerForTest } from "../../src/tools/browser/tab-supervisor";
+
+class FakeStartupWorker {
+	#errorHandlers = new Set<(error: Error) => void>();
+	#messageHandlers = new Set<(msg: WorkerOutbound) => void>();
+	readonly sent: WorkerInbound[] = [];
+	readonly mode = "worker" as const;
+
+	send(msg: WorkerInbound): void {
+		this.sent.push(msg);
+	}
+
+	onMessage(handler: (msg: WorkerOutbound) => void): () => void {
+		this.#messageHandlers.add(handler);
+		return () => this.#messageHandlers.delete(handler);
+	}
+
+	onError(handler: (error: Error) => void): () => void {
+		this.#errorHandlers.add(handler);
+		return () => this.#errorHandlers.delete(handler);
+	}
+
+	async terminate(): Promise<void> {}
+
+	emitReady(info: ReadyInfo): void {
+		for (const handler of this.#messageHandlers) handler({ type: "ready", info });
+	}
+
+	emitError(error: Error): void {
+		for (const handler of this.#errorHandlers) handler(error);
+	}
+}
+
+const initPayload = {
+	mode: "headless" as const,
+	browserWSEndpoint: "ws://127.0.0.1/devtools/browser/test",
+	safeDir: "/tmp/omp-puppeteer",
+	timeoutMs: 1_000,
+};
+
+describe("browser tab worker startup", () => {
+	it("surfaces worker startup errors instead of waiting for the generic init timeout", async () => {
+		const worker = new FakeStartupWorker();
+		const pending = initializeTabWorkerForTest(worker, initPayload, 1_000);
+
+		worker.emitError(new Error("Cannot find tab-worker-entry.ts"));
+
+		await expect(pending).rejects.toThrow("Tab worker failed during startup: Cannot find tab-worker-entry.ts");
+		expect(worker.sent).toEqual([{ type: "init", payload: initPayload }]);
+	});
+});


### PR DESCRIPTION
## What

- Surface asynchronous tab worker `error` / `messageerror` events while `acquireTab()` waits for the initial worker `ready` / `init-failed` response.
- Keep active-page stealth setup synchronous, but make the broader CDP target UA override sweep selective, bounded, and best-effort.
- Add focused tests for worker startup diagnostics and bounded stealth target setup.

## Why

Fixes #1053.

On Windows with OMP v15.0.0, default headless `browser.open` can fail with:

```text
Timed out initializing browser tab worker
```

A local probe showed the worker eventually becomes ready, but initialization takes about 52s. The slow step is worker-side `applyStealthPatches()`, which took about 49s. Since the browser tool timeout is capped at 30s, `browser.open` times out before the worker can send `ready`.

The expensive part is the broad target UA override sweep. Some non-page or ephemeral Chrome targets can block close to the CDP protocol timeout or disappear while being attached. This change preserves the active-page stealth path while preventing those targets from delaying `browser.open`.

The worker error propagation change also makes compiled-binary/module-load regressions actionable instead of hiding them behind the same generic initialization timeout.

## Testing

- `bunx biome check packages/coding-agent/src/tools/browser/tab-supervisor.ts packages/coding-agent/src/tools/browser/launch.ts packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts packages/coding-agent/test/tools/browser-stealth-targets.test.ts packages/coding-agent/CHANGELOG.md --no-errors-on-unmatched`
- `bun --cwd=packages/coding-agent run check:types --pretty false --noCheck false`
- `bun test packages/coding-agent/test/tools/browser-tab-worker-startup.test.ts packages/coding-agent/test/tools/browser-stealth-targets.test.ts`
- `bun --cwd=packages/coding-agent check`
- Local Windows manual verification:
  - before the fix: default headless `browser.open` failed with `Timed out initializing browser tab worker`;
  - direct worker probe showed `ready` after about 52s;
  - finer-grained probe showed `applyStealthPatches()` took about 49s;
  - after the fix: `browser.open` for `about:blank` returned within the 30s tool timeout, `tab.observe()` succeeded, and `browser.close all` succeeded via `bun packages/coding-agent/src/cli.ts -p "Use browser open for about:blank, then run tab.observe, then close all. Return only whether it succeeded." --mode json`.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
