### PR TITLE
fix(edit): add format reminder to hashline prompt

### DIFF
--- a/packages/coding-agent/src/prompts/tools/hashline.md
+++ b/packages/coding-agent/src/prompts/tools/hashline.md
@@ -8,6 +8,7 @@ Purely textual format. The tool has NO awareness of language, indentation, brack
 
 <ops>
 @@ PATH          header: subsequent ops apply to PATH
+Each op line is ONE of:
 + ANCHOR         insert lines AFTER  the anchored line (or EOF); payload follows as `{{hsep}}TEXT` lines
 < ANCHOR         insert lines BEFORE the anchored line (or BOF); payload follows as `{{hsep}}TEXT` lines
 - A..B           delete the line range (inclusive).
@@ -15,15 +16,11 @@ Purely textual format. The tool has NO awareness of language, indentation, brack
 </ops>
 
 <format-reminder>
-Each op line is ONE of:
-  + ANCHOR        ← nothing after the anchor! Content goes on ~ lines below.
-  < ANCHOR        ← same rule.
-  - A..B          ← no content needed (deletion).
-  = A..B          ← followed by ~TEXT payload lines.
+Op lines carry no content — payload goes on the next line.
 
-WRONG:  + 129pg|                 some code here
-RIGHT:  + 129pg
-        ~                some code here
+WRONG: + 5pg| some code
+RIGHT: + 5pg
+       {{hsep}} some code
 </format-reminder>
 
 <rules>

--- a/packages/coding-agent/src/prompts/tools/hashline.md
+++ b/packages/coding-agent/src/prompts/tools/hashline.md
@@ -14,6 +14,18 @@ Purely textual format. The tool has NO awareness of language, indentation, brack
 = A..B           replace the range with payload `{{hsep}}TEXT` lines, or with one blank line if no payload follows.
 </ops>
 
+<format-reminder>
+Each op line is ONE of:
+  + ANCHOR        ← nothing after the anchor! Content goes on ~ lines below.
+  < ANCHOR        ← same rule.
+  - A..B          ← no content needed (deletion).
+  = A..B          ← followed by ~TEXT payload lines.
+
+WRONG:  + 129pg|                 some code here
+RIGHT:  + 129pg
+        ~                some code here
+</format-reminder>
+
 <rules>
 - Every line of inserted/replacement content MUST be emitted as a payload line starting with `{{hsep}}`.
 - `{{hsep}}` is syntax, not content. The inserted text begins after the first `{{hsep}}`; use a bare `{{hsep}}` to insert a blank line.


### PR DESCRIPTION
## Problem

Models frequently construct invalid hashline edit input by putting the full line content after the anchor on the same `+`/`<` line:

```
+ 129pg|                 {record.videoClipPath && (    ← WRONG
```

instead of separating the anchor from the payload:

```
+ 129pg                                                  ← correct
~                {record.videoClipPath || ...             ← correct
```

This causes repeated parse errors ("unrecognized op") and long retry loops.

## Fix

Added a compact `<format-reminder>` block between `</ops>` and `<rules>` in the hashline prompt template (`packages/coding-agent/src/prompts/tools/hashline.md`) with a WRONG/RIGHT example that directly addresses this failure mode.

The reminder appears immediately after the ops definition, before any rules or examples, so models see it while constructing their first op line.