### PR TITLE
fix(web-search/anthropic): thread AbortSignal through callSearch to fetch

### DIFF
--- a/packages/coding-agent/src/web/search/providers/anthropic.ts
+++ b/packages/coding-agent/src/web/search/providers/anthropic.ts
@@ -38,6 +38,7 @@ export interface AnthropicSearchParams {
 	max_tokens?: number;
 	/** Sampling temperature (0–1). Lower = more focused/factual. */
 	temperature?: number;
+	signal?: AbortSignal;
 }
 
 /**
@@ -86,6 +87,7 @@ async function callSearch(
 	systemPrompt?: string,
 	maxTokens?: number,
 	temperature?: number,
+	signal?: AbortSignal,
 ): Promise<AnthropicApiResponse> {
 	const url = buildAnthropicUrl(auth);
 	const headers = buildAnthropicSearchHeaders(auth);
@@ -116,6 +118,7 @@ async function callSearch(
 		method: "POST",
 		headers,
 		body: JSON.stringify(body),
+		signal,
 	});
 
 	if (!response.ok) {
@@ -253,6 +256,7 @@ export async function searchAnthropic(params: AnthropicSearchParams): Promise<Se
 		params.system_prompt,
 		params.max_tokens,
 		params.temperature,
+		params.signal,
 	);
 
 	const result = parseResponse(response);
@@ -281,6 +285,7 @@ export class AnthropicProvider extends SearchProvider {
 			num_results: params.numSearchResults ?? params.limit,
 			max_tokens: params.maxOutputTokens,
 			temperature: params.temperature,
+			signal: params.signal,
 		});
 	}
 }


### PR DESCRIPTION
## Problem

`SearchParams.signal` was already defined in `base.ts` but never forwarded through the Anthropic provider call chain. When a `web_search` was in-flight and the user pressed **Esc**, the session froze — `fetch()` had no abort signal so the HTTP request ran to completion. **Ctrl+C** was the only recovery.

Closes #1044.

## Changes

`packages/coding-agent/src/web/search/providers/anthropic.ts` (5 lines, 4 sites):

- `AnthropicSearchParams`: add `signal?: AbortSignal`
- `callSearch()`: add `signal` param, pass to `fetch()`
- `searchAnthropic()`: forward `params.signal` to `callSearch()`
- `AnthropicProvider.search()`: forward `params.signal` to `searchAnthropic()`

## Validation

Reproduced the freeze on Windows 11 (OMP 15.0.0, `webSearch: anthropic`). After this fix, Esc during an in-flight `web_search` correctly cancels the HTTP request.

## Scope note

The same gap exists in `exa.ts`, `gemini.ts`, `jina.ts`, and `zai.ts`. Not included here — no test environment for those providers.