### PR TITLE
fix(coding-agent): pass abort signal to Anthropic web search

### DIFF
--- a/docs/tools/web_search.md
+++ b/docs/tools/web_search.md
@@ -65,7 +65,7 @@ Failure output is not thrown at the tool boundary when at least one provider was
 - `details.response.provider = <last attempted provider> | "none"`
 - `details.error = ...`
 
-Streaming: none. `WebSearchTool.execute()` does not forward its `_signal` argument into `executeSearch()`, so provider cancellation is only available to internal callers that place `signal` inside `SearchQueryParams`.
+Streaming: none. `WebSearchTool.execute()` and the custom-tool wrapper forward their `AbortSignal` into `executeSearch()`, which passes it to the selected provider as `SearchParams.signal`. Cancellation then depends on the provider adapter forwarding that signal into its transport.
 
 ## Flow
 1. `WebSearchTool.execute()` in `packages/coding-agent/src/web/search/index.ts` delegates directly to `executeSearch()`.
@@ -75,9 +75,10 @@ Streaming: none. `WebSearchTool.execute()` does not forward its `_signal` argume
 3. `resolveProviderChain()` lazily loads each provider module on demand, checks `isAvailable()`, and returns only available providers. If a preferred provider is set, it is tried first, then the static `SEARCH_PROVIDER_ORDER` excluding that provider.
 4. If no providers are available, `executeSearch()` returns `Error: No web search provider configured.` with `details.response.provider = "none"`.
 5. For each provider in order, `executeSearch()` calls `provider.search()` with:
-   - `query` after year-rewrite,
-   - `limit`, `recency`, `temperature`, `maxOutputTokens`, `numSearchResults`,
-   - `systemPrompt` from `packages/coding-agent/src/prompts/tools/web-search.md`.
+	- `query` after year-rewrite,
+	- `limit`, `recency`, `temperature`, `maxOutputTokens`, `numSearchResults`,
+	- `systemPrompt` from `packages/coding-agent/src/prompts/tools/web-search.md`,
+	- the tool/custom-tool `AbortSignal`.
 6. On the first successful `SearchResponse`, `formatForLLM()` renders answer/sources/citations/related/search-queries into one text block and returns it with `details.response`.
 7. If a provider throws, `executeSearch()` records the error and tries the next provider. There is no provider-level parallel fan-out; fallback is sequential.
 8. After all candidates fail, `formatProviderError()` normalizes the last error:
@@ -185,7 +186,9 @@ Streaming: none. `WebSearchTool.execute()` does not forward its `_signal` argume
   - Uses a module-global preferred-provider setting in the same file.
   - `packages/coding-agent/src/tools/index.ts` gates tool availability behind `session.settings.get("web_search.enabled")`.
 - Background work / cancellation
-  - Many provider adapters accept `AbortSignal`, but `WebSearchTool.execute()` does not pass its `_signal` into `executeSearch()`. Internal callers can still use cancellation by calling `runSearchQuery()` / `executeSearch()` with `signal` embedded in params.
+	- `WebSearchTool.execute()` and `webSearchCustomTool.execute()` pass their `AbortSignal` into `executeSearch()` and then into `provider.search()` as `SearchParams.signal`.
+	- Provider adapters opt into cancellation by forwarding `SearchParams.signal` into their HTTP/SSE/JSON-RPC transport. Anthropic, Brave, Codex, Gemini, Kagi, Kimi, Parallel, Perplexity, SearXNG, Synthetic, Tavily, and the shared Parallel HTTP client do this; Exa, Jina, and Z.AI still have transport paths that do not forward the signal.
+	- `runSearchQuery()` currently calls `executeSearch()` without a signal, so CLI/testing callers through that helper are not abortable unless the helper API grows a signal parameter.
 
 ## Limits & Caps
 - Provider auto-order length: 14 providers (`SEARCH_PROVIDER_ORDER` in `packages/coding-agent/src/web/search/provider.ts`).

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -701,6 +701,27 @@ const ANTHROPIC_MESSAGE_EVENTS: ReadonlySet<string> = new Set([
 	"content_block_stop",
 ]);
 
+type AnthropicRefusalStopDetails = {
+	type: "refusal";
+	explanation?: string;
+	category?: string;
+};
+
+function getAnthropicRefusalStopDetails(delta: unknown): AnthropicRefusalStopDetails | undefined {
+	if (!isRecord(delta)) {
+		return undefined;
+	}
+	const stopDetails = delta.stop_details;
+	if (!isRecord(stopDetails) || stopDetails.type !== "refusal") {
+		return undefined;
+	}
+	return {
+		type: "refusal",
+		explanation: typeof stopDetails.explanation === "string" ? stopDetails.explanation : undefined,
+		category: typeof stopDetails.category === "string" ? stopDetails.category : undefined,
+	};
+}
+
 async function* iterateAnthropicEvents(
 	response: Response,
 	signal?: AbortSignal,
@@ -1206,8 +1227,8 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 								output.stopReason = mapStopReason(event.delta.stop_reason);
 								sawTerminalEnvelope = true;
 							}
-							const stopDetails = event.delta.stop_details;
-							if (stopDetails && stopDetails.type === "refusal") {
+							const stopDetails = getAnthropicRefusalStopDetails(event.delta);
+							if (stopDetails) {
 								const explanation = stopDetails.explanation?.trim();
 								const category = stopDetails.category;
 								const label = category ? `Refusal (${category})` : "Refusal";

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### Fixed
 
+- Fixed Anthropic web search cancellation so caller abort signals reach the underlying fetch request, preventing Esc-cancelled searches from continuing in-flight ([#1044](https://github.com/can1357/oh-my-pi/issues/1044)).
 - Fixed abrupt process termination data loss during session persistence by moving steady-state session writes to a synchronous path that writes each entry to the kernel page cache before returning
 - Fixed `--help` startup to avoid a config/model-registry load cycle so the root CLI help command now exits successfully in a clean environment
 - Queued `/skill:<name> [args]` invocations now show as compact `Steer: /skill:<name> [args]` / `Follow-up: /skill:<name> [args]` chips in the pending-messages bar and disappear when the agent consumes the queued message (parity with plain-text steer/follow-up). Previously the queued skill was invisible while queued and rendered as a full skill block at consumption with no chip ever appearing.

--- a/packages/coding-agent/src/web/search/providers/anthropic.ts
+++ b/packages/coding-agent/src/web/search/providers/anthropic.ts
@@ -34,6 +34,7 @@ export interface AnthropicSearchParams {
 	query: string;
 	system_prompt?: string;
 	num_results?: number;
+	signal?: AbortSignal;
 	/** Maximum output tokens. Defaults to 4096. */
 	max_tokens?: number;
 	/** Sampling temperature (0–1). Lower = more focused/factual. */
@@ -86,6 +87,7 @@ async function callSearch(
 	systemPrompt?: string,
 	maxTokens?: number,
 	temperature?: number,
+	signal?: AbortSignal,
 ): Promise<AnthropicApiResponse> {
 	const url = buildAnthropicUrl(auth);
 	const headers = buildAnthropicSearchHeaders(auth);
@@ -116,6 +118,7 @@ async function callSearch(
 		method: "POST",
 		headers,
 		body: JSON.stringify(body),
+		signal,
 	});
 
 	if (!response.ok) {
@@ -253,6 +256,7 @@ export async function searchAnthropic(params: AnthropicSearchParams): Promise<Se
 		params.system_prompt,
 		params.max_tokens,
 		params.temperature,
+		params.signal,
 	);
 
 	const result = parseResponse(response);
@@ -279,6 +283,7 @@ export class AnthropicProvider extends SearchProvider {
 			query: params.query,
 			system_prompt: params.systemPrompt,
 			num_results: params.numSearchResults ?? params.limit,
+			signal: params.signal,
 			max_tokens: params.maxOutputTokens,
 			temperature: params.temperature,
 		});

--- a/packages/coding-agent/test/tools/web-search-anthropic.test.ts
+++ b/packages/coding-agent/test/tools/web-search-anthropic.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { hookFetch } from "@oh-my-pi/pi-utils";
+import { searchAnthropic } from "../../src/web/search/providers/anthropic";
+
+const originalAnthropicSearchApiKey = process.env.ANTHROPIC_SEARCH_API_KEY;
+const originalAnthropicSearchBaseUrl = process.env.ANTHROPIC_SEARCH_BASE_URL;
+
+function restoreEnv(key: string, value: string | undefined): void {
+	if (value === undefined) {
+		delete process.env[key];
+		return;
+	}
+	process.env[key] = value;
+}
+
+describe("Anthropic web search provider", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		restoreEnv("ANTHROPIC_SEARCH_API_KEY", originalAnthropicSearchApiKey);
+		restoreEnv("ANTHROPIC_SEARCH_BASE_URL", originalAnthropicSearchBaseUrl);
+	});
+
+	it("passes the caller abort signal to the Anthropic request", async () => {
+		process.env.ANTHROPIC_SEARCH_API_KEY = "test-anthropic-key";
+		process.env.ANTHROPIC_SEARCH_BASE_URL = "https://api.anthropic.test";
+		const controller = new AbortController();
+		let capturedSignal: AbortSignal | null | undefined;
+
+		using _hook = hookFetch((_input, init) => {
+			capturedSignal = init?.signal as AbortSignal | null | undefined;
+			return new Response(
+				JSON.stringify({
+					id: "msg_test",
+					model: "claude-haiku-4-5",
+					content: [{ type: "text", text: "Anthropic answer" }],
+					usage: {
+						input_tokens: 1,
+						output_tokens: 1,
+					},
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		});
+
+		await searchAnthropic({ query: "latest AI news", signal: controller.signal });
+
+		expect(capturedSignal).toBe(controller.signal);
+	});
+});


### PR DESCRIPTION
## What

- Thread the web-search tool `AbortSignal` through the Anthropic provider into the underlying `fetch()` request.
- Add a focused regression test that asserts the caller signal reaches Anthropic `fetch` init.
- Narrow Anthropic `stop_details` handling in `packages/ai` so the full workspace check passes without type suppressions.
- Update the changelog and web-search cancellation docs.

## Why

Fixes #1044. Cancelling an Anthropic web search should abort the in-flight network request instead of letting the session continue waiting on it.

## Testing

- `bun test packages/coding-agent/test/tools/web-search-anthropic.test.ts`
- `bun test packages/ai/test/anthropic-stream-envelope.test.ts packages/ai/test/anthropic-stream-timeout.test.ts`
- `mise x rust@nightly-2026-03-27 -- bun check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)