### PR TITLE
fix(coding-agent): wait for ACP prompt idle cleanup

### DIFF
--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -97,6 +97,7 @@ type PromptTurnState = {
 	unsubscribe: (() => void) | undefined;
 	resolve: (value: PromptResponse) => void;
 	reject: (reason?: unknown) => void;
+	promise: Promise<PromptResponse>;
 };
 
 type ManagedSessionRecord = {
@@ -380,8 +381,12 @@ export class AcpAgent implements Agent {
 
 	async prompt(params: PromptRequest): Promise<PromptResponse> {
 		const record = this.#getSessionRecord(params.sessionId);
-		if (record.promptTurn && !record.promptTurn.settled) {
-			throw new Error("ACP prompt already in progress for this session");
+		const activeTurn = record.promptTurn;
+		if (activeTurn && !activeTurn.settled) {
+			if (record.session.isStreaming) {
+				throw new Error("ACP prompt already in progress for this session");
+			}
+			await activeTurn.promise.catch(() => undefined);
 		}
 
 		const converted = this.#convertPromptBlocks(params.prompt);
@@ -394,6 +399,7 @@ export class AcpAgent implements Agent {
 			unsubscribe: undefined,
 			resolve: pendingPrompt.resolve,
 			reject: pendingPrompt.reject,
+			promise: pendingPrompt.promise,
 		};
 
 		record.promptTurn.unsubscribe = record.session.subscribe(event => {
@@ -777,6 +783,7 @@ export class AcpAgent implements Agent {
 
 		if (event.type === "agent_end") {
 			await this.#emitEndOfTurnUpdates(record);
+			await record.session.waitForIdle();
 			this.#finishPrompt(record, {
 				stopReason: this.#resolveStopReason(event, promptTurn.cancelRequested),
 				usage: this.#buildTurnUsage(promptTurn.usageBaseline, record.session.sessionManager.getUsageStatistics()),

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -89,6 +89,11 @@ type AgentImageContent = {
 	mimeType: string;
 };
 
+type PromptQueueState = {
+	promise: Promise<void>;
+	release: (() => void) | undefined;
+};
+
 type PromptTurnState = {
 	userMessageId: string;
 	cancelRequested: boolean;
@@ -104,6 +109,7 @@ type ManagedSessionRecord = {
 	session: AgentSession;
 	mcpManager: MCPManager | undefined;
 	promptTurn: PromptTurnState | undefined;
+	promptQueue: PromptQueueState;
 	liveMessageId: string | undefined;
 	liveMessageProgress: { textEmitted: boolean; thoughtEmitted: boolean } | undefined;
 	extensionsConfigured: boolean;
@@ -381,36 +387,57 @@ export class AcpAgent implements Agent {
 
 	async prompt(params: PromptRequest): Promise<PromptResponse> {
 		const record = this.#getSessionRecord(params.sessionId);
-		const activeTurn = record.promptTurn;
-		if (activeTurn && !activeTurn.settled) {
-			if (record.session.isStreaming) {
-				throw new Error("ACP prompt already in progress for this session");
+		return await this.#queuePrompt(record, async () => {
+			const activeTurn = record.promptTurn;
+			if (activeTurn && !activeTurn.settled) {
+				if (record.session.isStreaming) {
+					throw new Error("ACP prompt already in progress for this session");
+				}
+				await activeTurn.promise.catch(() => undefined);
 			}
-			await activeTurn.promise.catch(() => undefined);
-		}
 
-		const converted = this.#convertPromptBlocks(params.prompt);
-		const pendingPrompt = Promise.withResolvers<PromptResponse>();
-		record.promptTurn = {
-			userMessageId: params.messageId ?? crypto.randomUUID(),
-			cancelRequested: false,
-			settled: false,
-			usageBaseline: this.#cloneUsageStatistics(record.session.sessionManager.getUsageStatistics()),
-			unsubscribe: undefined,
-			resolve: pendingPrompt.resolve,
-			reject: pendingPrompt.reject,
-			promise: pendingPrompt.promise,
+			const converted = this.#convertPromptBlocks(params.prompt);
+			const pendingPrompt = Promise.withResolvers<PromptResponse>();
+			record.promptTurn = {
+				userMessageId: params.messageId ?? crypto.randomUUID(),
+				cancelRequested: false,
+				settled: false,
+				usageBaseline: this.#cloneUsageStatistics(record.session.sessionManager.getUsageStatistics()),
+				unsubscribe: undefined,
+				resolve: pendingPrompt.resolve,
+				reject: pendingPrompt.reject,
+				promise: pendingPrompt.promise,
+			};
+
+			record.promptTurn.unsubscribe = record.session.subscribe(event => {
+				void this.#handlePromptEvent(record, event);
+			});
+
+			this.#runPromptOrCommand(record, converted.text, converted.images).catch((error: unknown) => {
+				this.#finishPrompt(record, undefined, error);
+			});
+
+			return await pendingPrompt.promise;
+		});
+	}
+
+	async #queuePrompt(record: ManagedSessionRecord, run: () => Promise<PromptResponse>): Promise<PromptResponse> {
+		const nextQueue = Promise.withResolvers<void>();
+		const releaseQueue = nextQueue.resolve;
+		const previousQueue = record.promptQueue;
+		record.promptQueue = {
+			promise: nextQueue.promise,
+			release: releaseQueue,
 		};
-
-		record.promptTurn.unsubscribe = record.session.subscribe(event => {
-			void this.#handlePromptEvent(record, event);
-		});
-
-		this.#runPromptOrCommand(record, converted.text, converted.images).catch((error: unknown) => {
-			this.#finishPrompt(record, undefined, error);
-		});
-
-		return await pendingPrompt.promise;
+		await previousQueue.promise;
+		try {
+			return await run();
+		} finally {
+			releaseQueue();
+			if (record.promptQueue.release === releaseQueue) {
+				record.promptQueue.release = undefined;
+			}
+		}
 	}
 
 	async #runPromptOrCommand(record: ManagedSessionRecord, text: string, images: AgentImageContent[]): Promise<void> {
@@ -706,6 +733,7 @@ export class AcpAgent implements Agent {
 			session,
 			mcpManager: undefined,
 			promptTurn: undefined,
+			promptQueue: { promise: Promise.resolve(), release: undefined },
 			liveMessageId: undefined,
 			liveMessageProgress: undefined,
 			extensionsConfigured: false,

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -387,13 +387,14 @@ export class AcpAgent implements Agent {
 
 	async prompt(params: PromptRequest): Promise<PromptResponse> {
 		const record = this.#getSessionRecord(params.sessionId);
+		const activeTurn = record.promptTurn;
+		if (activeTurn && !activeTurn.settled && record.session.isStreaming) {
+			throw new Error("ACP prompt already in progress for this session");
+		}
 		return await this.#queuePrompt(record, async () => {
-			const activeTurn = record.promptTurn;
-			if (activeTurn && !activeTurn.settled) {
-				if (record.session.isStreaming) {
-					throw new Error("ACP prompt already in progress for this session");
-				}
-				await activeTurn.promise.catch(() => undefined);
+			const queuedTurn = record.promptTurn;
+			if (queuedTurn && !queuedTurn.settled) {
+				await queuedTurn.promise.catch(() => undefined);
 			}
 
 			const converted = this.#convertPromptBlocks(params.prompt);

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -92,6 +92,8 @@ class FakeAgentSession {
 	skillsSettings = { enableSkillCommands: true };
 	skills: Array<{ name: string; description: string; filePath: string; baseDir: string; source: string }> = [];
 	planModeState: PlanModeState | undefined;
+	waitForIdleCalls = 0;
+	waitForIdleBlocker: (() => Promise<void>) | undefined;
 	#listeners = new Set<(event: AgentSessionEvent) => void>();
 
 	constructor(
@@ -102,7 +104,9 @@ class FakeAgentSession {
 		this.sessionId = this.sessionManager.getSessionId();
 		this.agent = {
 			sessionId: this.sessionId,
-			waitForIdle: async () => {},
+			waitForIdle: async () => {
+				await this.waitForIdle();
+			},
 		};
 		this.model = models[0];
 	}
@@ -173,6 +177,11 @@ class FakeAgentSession {
 			} as AgentSessionEvent);
 		}
 		this.isStreaming = false;
+	}
+
+	async waitForIdle(): Promise<void> {
+		this.waitForIdleCalls++;
+		await this.waitForIdleBlocker?.();
 	}
 
 	async abort(): Promise<void> {
@@ -838,6 +847,77 @@ describe("ACP agent", () => {
 
 		harness.abortController.abort();
 		await Bun.sleep(0);
+	});
+
+	it("waits for AgentSession idle cleanup after agent_end before returning", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		const { promise: idleBlocked, resolve: markIdleBlocked } = Promise.withResolvers<void>();
+		const { promise: releaseIdle, resolve: unblockIdle } = Promise.withResolvers<void>();
+		session.waitForIdleBlocker = async () => {
+			markIdleBlocked();
+			await releaseIdle;
+		};
+
+		const firstPrompt = harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000029",
+			prompt: [{ type: "text", text: "wait for cleanup" }],
+		} as PromptRequest);
+		await idleBlocked;
+
+		try {
+			const returnedBeforeIdle = await Promise.race([firstPrompt.then(() => true), Bun.sleep(0).then(() => false)]);
+			expect(returnedBeforeIdle).toBe(false);
+			expect(session.waitForIdleCalls).toBe(1);
+
+			unblockIdle();
+			const response = await firstPrompt;
+			expect(response.userMessageId).toBe("00000000-0000-4000-8000-000000000029");
+		} finally {
+			unblockIdle();
+			harness.abortController.abort();
+			await Bun.sleep(0);
+		}
+	});
+
+	it("queues next prompt until AgentSession idle cleanup completes", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		const { promise: idleBlocked, resolve: markIdleBlocked } = Promise.withResolvers<void>();
+		const { promise: releaseIdle, resolve: unblockIdle } = Promise.withResolvers<void>();
+		session.waitForIdleBlocker = async () => {
+			markIdleBlocked();
+			await releaseIdle;
+		};
+
+		const firstPrompt = harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000030",
+			prompt: [{ type: "text", text: "wait for cleanup" }],
+		} as PromptRequest);
+		await idleBlocked;
+
+		try {
+			const secondPrompt = harness.agent.prompt({
+				sessionId: created.sessionId,
+				messageId: "00000000-0000-4000-8000-000000000031",
+				prompt: [{ type: "text", text: "after cleanup" }],
+			} as PromptRequest);
+			await Bun.sleep(0);
+			expect(session.promptCalls).toEqual(["wait for cleanup"]);
+
+			unblockIdle();
+			await firstPrompt;
+			await secondPrompt;
+			expect(session.promptCalls).toEqual(["wait for cleanup", "after cleanup"]);
+		} finally {
+			unblockIdle();
+			harness.abortController.abort();
+			await Bun.sleep(0);
+		}
 	});
 
 	it("executes consumed ACP builtins without prompting the agent", async () => {

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -157,6 +157,10 @@ class FakeAgentSession {
 		};
 	}
 
+	listeners(): Array<(event: AgentSessionEvent) => void> {
+		return [...this.#listeners];
+	}
+
 	async prompt(text: string): Promise<void> {
 		this.promptCalls.push(text);
 		this.isStreaming = true;
@@ -301,6 +305,34 @@ class FakeAgentSession {
 		this.agent.sessionId = this.sessionId;
 		return true;
 	}
+}
+
+function holdPromptStreaming(session: FakeAgentSession): () => void {
+	let finishPrompt!: () => void;
+	session.prompt = async (text: string): Promise<void> => {
+		session.promptCalls.push(text);
+		session.isStreaming = true;
+		const blocker = Promise.withResolvers<void>();
+		finishPrompt = blocker.resolve;
+		await blocker.promise;
+		const assistantMessage = makeAssistantMessage("pong");
+		for (const listener of session.listeners()) {
+			listener({
+				type: "message_update",
+				message: assistantMessage,
+				assistantMessageEvent: { type: "text_delta", delta: "pong" },
+			} as AgentSessionEvent);
+		}
+		session.sessionManager.appendMessage(assistantMessage);
+		for (const listener of session.listeners()) {
+			listener({
+				type: "agent_end",
+				messages: [assistantMessage],
+			} as AgentSessionEvent);
+		}
+		session.isStreaming = false;
+	};
+	return () => finishPrompt();
 }
 
 interface AgentHarness {
@@ -847,6 +879,36 @@ describe("ACP agent", () => {
 
 		harness.abortController.abort();
 		await Bun.sleep(0);
+	});
+
+	it("rejects overlapping prompts while AgentSession is still streaming", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		const finishPrompt = holdPromptStreaming(session);
+
+		const firstPrompt = harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000035",
+			prompt: [{ type: "text", text: "long running" }],
+		} as PromptRequest);
+		await Bun.sleep(0);
+
+		try {
+			await expect(
+				harness.agent.prompt({
+					sessionId: created.sessionId,
+					messageId: "00000000-0000-4000-8000-000000000036",
+					prompt: [{ type: "text", text: "overlap" }],
+				} as PromptRequest),
+			).rejects.toThrow("ACP prompt already in progress for this session");
+			expect(session.promptCalls).toEqual(["long running"]);
+		} finally {
+			finishPrompt();
+			await firstPrompt;
+			harness.abortController.abort();
+			await Bun.sleep(0);
+		}
 	});
 
 	it("waits for AgentSession idle cleanup after agent_end before returning", async () => {

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -920,6 +920,50 @@ describe("ACP agent", () => {
 		}
 	});
 
+	it("serializes multiple prompts queued during idle cleanup", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		const { promise: idleBlocked, resolve: markIdleBlocked } = Promise.withResolvers<void>();
+		const { promise: releaseIdle, resolve: unblockIdle } = Promise.withResolvers<void>();
+		session.waitForIdleBlocker = async () => {
+			markIdleBlocked();
+			await releaseIdle;
+		};
+
+		const firstPrompt = harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000032",
+			prompt: [{ type: "text", text: "wait for cleanup" }],
+		} as PromptRequest);
+		await idleBlocked;
+
+		try {
+			const secondPrompt = harness.agent.prompt({
+				sessionId: created.sessionId,
+				messageId: "00000000-0000-4000-8000-000000000033",
+				prompt: [{ type: "text", text: "after cleanup A" }],
+			} as PromptRequest);
+			const thirdPrompt = harness.agent.prompt({
+				sessionId: created.sessionId,
+				messageId: "00000000-0000-4000-8000-000000000034",
+				prompt: [{ type: "text", text: "after cleanup B" }],
+			} as PromptRequest);
+			await Bun.sleep(0);
+			expect(session.promptCalls).toEqual(["wait for cleanup"]);
+
+			unblockIdle();
+			await firstPrompt;
+			await secondPrompt;
+			await thirdPrompt;
+			expect(session.promptCalls).toEqual(["wait for cleanup", "after cleanup A", "after cleanup B"]);
+		} finally {
+			unblockIdle();
+			harness.abortController.abort();
+			await Bun.sleep(0);
+		}
+	});
+
 	it("executes consumed ACP builtins without prompting the agent", async () => {
 		const harness = await createHarness();
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });


### PR DESCRIPTION
## Summary

Fixes #1069.

ACP prompt completion now waits for `AgentSession.waitForIdle()` after emitting final end-of-turn updates and before resolving `session/prompt`, so post-prompt recovery/cleanup is part of the tracked ACP turn boundary.

## Changes

- Add the tracked prompt promise to `PromptTurnState` so a prompt submitted during an idle-but-unsettled ACP turn can wait for that turn to finish instead of failing as concurrent.
- Await `record.session.waitForIdle()` in the `agent_end` path before resolving the ACP prompt response.
- Add regression coverage for:
  - `session/prompt` not returning while idle cleanup is blocked after `agent_end`.
  - The next prompt waiting until the previous prompt's idle cleanup completes.

## Verification

- `bun test packages/coding-agent/test/acp-agent.test.ts --test-name-pattern "idle cleanup"` — 2 pass, 0 fail
- `bun test packages/coding-agent/test/acp-agent.test.ts` — 14 pass, 0 fail
- `bun --cwd=packages/coding-agent run check` — pass
