### PR TITLE
fix: exclude OpenCode providers from synthetic reasoning_content injection for Kimi models

### DIFF
--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -90,6 +90,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		provider === "opencode-zen" ||
 		provider === "opencode-go" ||
 		baseUrl.includes("opencode.ai");
+	const isOpenCodeProvider = provider === "opencode-go" || provider === "opencode-zen";
 
 	const useMaxTokens =
 		provider === "mistral" ||
@@ -182,13 +183,15 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 					: "openai",
 		reasoningContentField: "reasoning_content",
 		// Backends that 400 follow-up requests when prior assistant tool-call turns lack `reasoning_content`:
-		//   - Kimi: documented invariant on its native API and via OpenCode-Go.
+		//   - Kimi: documented invariant on its native API.
 		//   - Any reasoning-capable model reached through OpenRouter: DeepSeek V4 Pro and similar enforce
 		//     this server-side whenever the request is in thinking mode. We can't translate Anthropic's
 		//     redacted/encrypted reasoning into DeepSeek's plaintext form, so cross-provider continuations
 		//     rely on a placeholder — see `convertMessages` for the placeholder injection.
+		//   - OpenCode-Go and OpenCode-Zen handle reasoning content internally and reject
+		//     `reasoning_content` in client-sent messages — exclude them even for Kimi models.
 		requiresReasoningContentForToolCalls:
-			isKimiModel ||
+			(isKimiModel && !isOpenCodeProvider) ||
 			(isDeepseekFamily && Boolean(model.reasoning)) ||
 			((provider === "openrouter" || baseUrl.includes("openrouter.ai")) && Boolean(model.reasoning)),
 		// DeepSeek V4 rejects synthetic reasoning_content placeholders (".") on tool-call turns.


### PR DESCRIPTION
## Summary

**Fix: `reasoning_content` rejection on OpenCode-Go/OpenCode-Zen providers for Kimi models**

When OMP's retry fallback forwards conversation history to `opencode-go/kimi-k2.6` (or any Kimi-named model via OpenCode-Go/OpenCode-Zen), the compat layer injects a synthetic `reasoning_content: "."` field into assistant tool-call messages. The OpenCode-Go/OpenCode-Zen API rejects these fields at the provider level, returning:

```
Error: 400 — Extra inputs are not permitted, field: 'messages[N].reasoning', value: '.'
```

## Root Cause

In `openai-completions-compat.ts`, `requiresReasoningContentForToolCalls` is set to `true` for ALL providers when the model name matches `/^kimi[-.]/` — including OpenCode-Go and OpenCode-Zen. This triggers the `convertMessages` synthetic placeholder injection path, which emits `reasoning_content` fields that OpenCode providers reject.

OpenCode-Go/OpenCode-Zen handle reasoning content internally as part of their own API translation layer. They do not accept client-supplied `reasoning_content` in request messages.

## Fix

Gate `isKimiModel` in `requiresReasoningContentForToolCalls` on the provider NOT being OpenCode:

```diff
- isKimiModel ||
+ (isKimiModel && !isOpenCodeProvider) ||
```

Where `isOpenCodeProvider = provider === "opencode-go" || provider === "opencode-zen"`.

## Impact

- **Before:** Retry fallbacks to `opencode-go/kimi-k2.6` fail with HTTP 400 when prior assistant messages contain tool calls
- **After:** Messages sent to OpenCode providers no longer carry `reasoning_content`, allowing fallbacks and cross-provider retries to succeed

## Testing

This is provably correct by inspection:
- Regular Kimi native API (`moonshot`, `kimi-code`) → behavior unchanged (`isOpenCodeProvider` = false)
- DeepSeek family via any provider → behavior unchanged (separate branch in the condition)
- OpenRouter proxying → behavior unchanged (separate branch in the condition)
- OpenCode-Go / OpenCode-Zen proxying Kimi models → `reasoning_content` no longer injected
