### PR TITLE
fix(win): default to pwsh on Windows; bypass brush for non-bash shells

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `$env:VAR` PowerShell variables being mangled on Windows: brush (Rust bash) was expanding `$env` as an empty bash variable before passing commands to `powershell.exe`. Windows now defaults to `pwsh.exe` / `powershell.exe` as the shell (in preference to Git Bash), and non-bash shell commands bypass brush entirely via direct process spawn, preserving PowerShell syntax verbatim ([#1079](https://github.com/can1357/oh-my-pi/issues/1079))
+- Fixed `$env:VAR` PowerShell variables being mangled on Windows when `executeBash` invoked PowerShell as a subprocess (e.g. `powershell -Command "Write-Host $env:SystemRoot"`). Brush-core applied POSIX parameter expansion to `$env` before spawning the child, leaving a dangling `:NAME`. `bash-executor` now escapes unquoted `$env:<word>` references with a single backslash so the literal token reaches PowerShell verbatim; single-quoted regions and already-escaped occurrences are left untouched. Brush stays as the executor on every platform. Exposed as `preservePowerShellEnvVars` from `@oh-my-pi/pi-coding-agent/exec/bash-executor` ([#1079](https://github.com/can1357/oh-my-pi/issues/1079))
 
 
 ## [15.0.1] - 2026-05-14

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `$env:VAR` PowerShell variables being mangled on Windows: brush (Rust bash) was expanding `$env` as an empty bash variable before passing commands to `powershell.exe`. Windows now defaults to `pwsh.exe` / `powershell.exe` as the shell (in preference to Git Bash), and non-bash shell commands bypass brush entirely via direct process spawn, preserving PowerShell syntax verbatim ([#1079](https://github.com/can1357/oh-my-pi/issues/1079))
+
+
 ## [15.0.1] - 2026-05-14
 ### Breaking Changes
 

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -4,7 +4,7 @@
  * Uses brush-core via native bindings for shell execution.
  */
 import * as fs from "node:fs/promises";
-import { executeShell, type MinimizerOptions, Process, Shell } from "@oh-my-pi/pi-natives";
+import { executeShell, type MinimizerOptions, Shell } from "@oh-my-pi/pi-natives";
 import { Settings, type ShellMinimizerSettings } from "../config/settings";
 import { OutputSink } from "../session/streaming-output";
 import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "../tools/output-meta";
@@ -78,131 +78,77 @@ export function buildMinimizerOptions(group: ShellMinimizerSettings): MinimizerO
 }
 
 /**
- * Execute a command by spawning the configured shell binary directly, bypassing
- * brush-core. Used for non-bash shells (PowerShell, cmd.exe) where bash
- * variable expansion would otherwise mangle syntax like `$env:VAR`.
+ * Escape PowerShell `$env:VAR` references so brush-core's POSIX variable
+ * expansion does not collapse them to `:VAR`.
  *
- * stdout and stderr are merged into the sink in arrival order.
+ * In POSIX a `:` terminates a parameter name, so `$env:SystemRoot` parses as
+ * `${env}` followed by the literal `:SystemRoot`. `$env` is unset under brush,
+ * which leaves the colon-prefixed remainder behind and mangles commands that
+ * invoke PowerShell as a subprocess (e.g. `powershell -Command "Write-Host
+ * $env:SystemRoot"`).
+ *
+ * The fix is purely textual: we walk the command, leave single-quoted regions
+ * and existing `\X` escapes alone, and prepend `\` to every unescaped
+ * `$env:<word-char>` occurrence outside single quotes. Brush then forwards
+ * the literal `$env:NAME` to the PowerShell child where it has its native
+ * meaning. The check is case-insensitive because PowerShell accepts `$Env:`,
+ * `$ENV:` and `$env:` interchangeably.
  */
-async function executeViaDirectSpawn(
-	shell: string,
-	shellArgs: string[],
-	command: string,
-	options: BashExecutorOptions | undefined,
-	commandCwd: string | undefined,
-	commandEnv: Record<string, string>,
-	shellEnv: Record<string, string>,
-	sink: OutputSink,
-	baseTimeoutMs: number,
-): Promise<BashResult> {
-	// Append the command as the final argument (e.g. pwsh -NoProfile ... -Command <cmd>).
-	const proc = Bun.spawn([shell, ...shellArgs, command], {
-		cwd: commandCwd,
-		env: { ...shellEnv, ...commandEnv },
-		stdout: "pipe",
-		stderr: "pipe",
-	});
-
-	const userSignal = options?.signal;
-	let timedOut = false;
-
-	// Tree-kill the entire process group so child processes spawned by the shell
-	// (e.g. python, npm) do not outlive their parent after a cancel or timeout.
-	const treeKill = (): void =>
-		void Process.fromPid(proc.pid)
-			?.terminate()
-			?.catch(() => {});
-
-	const abortHandler = () => {
-		treeKill();
-	};
-	if (userSignal?.aborted) {
-		treeKill();
-	} else if (userSignal) {
-		userSignal.addEventListener("abort", abortHandler, { once: true });
+export function preservePowerShellEnvVars(command: string): string {
+	let result = "";
+	let inSingleQuote = false;
+	let i = 0;
+	while (i < command.length) {
+		const ch = command[i];
+		if (inSingleQuote) {
+			if (ch === "'") inSingleQuote = false;
+			result += ch;
+			i++;
+			continue;
+		}
+		if (ch === "'") {
+			inSingleQuote = true;
+			result += ch;
+			i++;
+			continue;
+		}
+		// Preserve existing backslash escapes verbatim so `\$env:` stays single-escaped.
+		if (ch === "\\" && i + 1 < command.length) {
+			result += command.slice(i, i + 2);
+			i += 2;
+			continue;
+		}
+		if (
+			ch === "$" &&
+			i + 5 < command.length &&
+			command.slice(i + 1, i + 5).toLowerCase() === "env:" &&
+			/[A-Za-z_]/.test(command[i + 5])
+		) {
+			result += "\\$";
+			i++;
+			continue;
+		}
+		result += ch;
+		i++;
 	}
-
-	// Soft timeout mirrors the contract of the brush path: honour options.timeout.
-	const softTimeoutTimer = setTimeout(() => {
-		timedOut = true;
-		treeKill();
-	}, baseTimeoutMs);
-
-	// Hard timeout is a backstop in case the soft kill stalls.
-	const hardTimeoutMs = baseTimeoutMs + HARD_TIMEOUT_GRACE_MS;
-	const hardTimeoutTimer = setTimeout(() => {
-		timedOut = true;
-		treeKill();
-	}, hardTimeoutMs);
-
-	const stdoutDecoder = new TextDecoder();
-	const stderrDecoder = new TextDecoder();
-
-	async function drainStream(stream: ReadableStream<Uint8Array>, dec: TextDecoder): Promise<void> {
-		const reader = (stream as ReadableStream<Uint8Array>).getReader();
-		try {
-			while (true) {
-				const { done, value } = await reader.read();
-				if (done) break;
-				sink.push(dec.decode(value, { stream: true }));
-			}
-			const tail = dec.decode();
-			if (tail) sink.push(tail);
-		} finally {
-			reader.releaseLock();
-		}
-	}
-
-	try {
-		await Promise.all([
-			drainStream(proc.stdout as ReadableStream<Uint8Array>, stdoutDecoder),
-			drainStream(proc.stderr as ReadableStream<Uint8Array>, stderrDecoder),
-			proc.exited,
-		]);
-
-		if (timedOut) {
-			return {
-				exitCode: undefined,
-				cancelled: true,
-				...(await sink.dump(`Command exceeded timeout after ${Math.round(baseTimeoutMs / 1000)} seconds`)),
-			};
-		}
-
-		if (userSignal?.aborted) {
-			return {
-				exitCode: undefined,
-				cancelled: true,
-				...(await sink.dump("Command cancelled")),
-			};
-		}
-
-		return {
-			exitCode: proc.exitCode ?? undefined,
-			cancelled: false,
-			...(await sink.dump()),
-		};
-	} finally {
-		clearTimeout(softTimeoutTimer);
-		clearTimeout(hardTimeoutTimer);
-		if (userSignal) {
-			userSignal.removeEventListener("abort", abortHandler);
-		}
-	}
+	return result;
 }
 
 export async function executeBash(command: string, options?: BashExecutorOptions): Promise<BashResult> {
 	const settings = await Settings.init();
-	const { shell, kind: shellKind, args: shellArgs, env: shellEnv, prefix } = settings.getShellConfig();
-	const snapshotPath = shellKind === "bash" ? await getOrCreateSnapshot(shell, shellEnv) : null;
+	const { shell, env: shellEnv, prefix } = settings.getShellConfig();
+	const snapshotPath = shell.includes("bash") ? await getOrCreateSnapshot(shell, shellEnv) : null;
 
 	const minimizer = buildMinimizerOptions(settings.getGroup("shellMinimizer"));
 
 	const commandCwd = await resolveShellCwd(options?.cwd);
 	const commandEnv = options?.env ? { ...NON_INTERACTIVE_ENV, ...options.env } : NON_INTERACTIVE_ENV;
 
-	// Apply command prefix if configured
+	// Apply command prefix if configured, then preserve any `$env:VAR` references
+	// that PowerShell expects (brush would otherwise expand `$env` as an unset
+	// POSIX parameter and leave the colon dangling — see #1079).
 	const prefixedCommand = prefix ? `${prefix} ${command}` : command;
-	const finalCommand = prefixedCommand;
+	const finalCommand = preservePowerShellEnvVars(prefixedCommand);
 
 	// Create output sink for truncation and artifact handling
 	const sink = new OutputSink({
@@ -223,30 +169,12 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 		sink.push(chunk);
 	};
 
-	const baseTimeoutMs = Math.max(1_000, options?.timeout ?? 300_000);
-
 	if (options?.signal?.aborted) {
 		return {
 			exitCode: undefined,
 			cancelled: true,
 			...(await sink.dump("Command cancelled")),
 		};
-	}
-
-	// Non-bash shells (PowerShell, cmd.exe) bypass brush-core entirely so that
-	// shell-native syntax like $env:VAR is not mangled by bash variable expansion.
-	if (shellKind !== "bash") {
-		return executeViaDirectSpawn(
-			shell,
-			shellArgs,
-			finalCommand,
-			options,
-			commandCwd,
-			commandEnv,
-			shellEnv,
-			sink,
-			baseTimeoutMs,
-		);
 	}
 
 	const sessionKey = buildSessionKey(shell, prefix, snapshotPath, shellEnv, options?.sessionKey, minimizer);
@@ -284,7 +212,7 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 
 	let hardTimeoutTimer: NodeJS.Timeout | undefined;
 	const hardTimeoutDeferred = Promise.withResolvers<"hard-timeout">();
-
+	const baseTimeoutMs = Math.max(1_000, options?.timeout ?? 300_000);
 	const hardTimeoutMs = baseTimeoutMs + HARD_TIMEOUT_GRACE_MS;
 	hardTimeoutTimer = setTimeout(() => {
 		abortCurrentExecution();

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -77,10 +77,108 @@ export function buildMinimizerOptions(group: ShellMinimizerSettings): MinimizerO
 	};
 }
 
+/**
+ * Execute a command by spawning the configured shell binary directly, bypassing
+ * brush-core. Used for non-bash shells (PowerShell, cmd.exe) where bash
+ * variable expansion would otherwise mangle syntax like `$env:VAR`.
+ *
+ * stdout and stderr are merged into the sink in arrival order.
+ */
+async function executeViaDirectSpawn(
+	shell: string,
+	shellArgs: string[],
+	command: string,
+	options: BashExecutorOptions | undefined,
+	commandCwd: string | undefined,
+	commandEnv: Record<string, string>,
+	shellEnv: Record<string, string>,
+	sink: OutputSink,
+	baseTimeoutMs: number,
+): Promise<BashResult> {
+	// Append the command as the final argument (e.g. pwsh -NoProfile ... -Command <cmd>).
+	const proc = Bun.spawn([shell, ...shellArgs, command], {
+		cwd: commandCwd,
+		env: { ...shellEnv, ...commandEnv },
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+
+	const userSignal = options?.signal;
+	let timedOut = false;
+
+	const abortHandler = () => {
+		proc.kill();
+	};
+	if (userSignal?.aborted) {
+		proc.kill();
+	} else if (userSignal) {
+		userSignal.addEventListener("abort", abortHandler, { once: true });
+	}
+
+	const hardTimeoutMs = baseTimeoutMs + HARD_TIMEOUT_GRACE_MS;
+	const hardTimeoutTimer = setTimeout(() => {
+		timedOut = true;
+		proc.kill();
+	}, hardTimeoutMs);
+
+	const stdoutDecoder = new TextDecoder();
+	const stderrDecoder = new TextDecoder();
+
+	async function drainStream(stream: ReadableStream<Uint8Array>, dec: TextDecoder): Promise<void> {
+		const reader = (stream as ReadableStream<Uint8Array>).getReader();
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				sink.push(dec.decode(value, { stream: true }));
+			}
+			const tail = dec.decode();
+			if (tail) sink.push(tail);
+		} finally {
+			reader.releaseLock();
+		}
+	}
+
+	try {
+		await Promise.all([
+			drainStream(proc.stdout as ReadableStream<Uint8Array>, stdoutDecoder),
+			drainStream(proc.stderr as ReadableStream<Uint8Array>, stderrDecoder),
+			proc.exited,
+		]);
+
+		if (timedOut) {
+			return {
+				exitCode: undefined,
+				cancelled: true,
+				...(await sink.dump(`Command exceeded hard timeout after ${Math.round(hardTimeoutMs / 1000)} seconds`)),
+			};
+		}
+
+		if (userSignal?.aborted) {
+			return {
+				exitCode: undefined,
+				cancelled: true,
+				...(await sink.dump("Command cancelled")),
+			};
+		}
+
+		return {
+			exitCode: proc.exitCode ?? undefined,
+			cancelled: false,
+			...(await sink.dump()),
+		};
+	} finally {
+		clearTimeout(hardTimeoutTimer);
+		if (userSignal) {
+			userSignal.removeEventListener("abort", abortHandler);
+		}
+	}
+}
+
 export async function executeBash(command: string, options?: BashExecutorOptions): Promise<BashResult> {
 	const settings = await Settings.init();
-	const { shell, env: shellEnv, prefix } = settings.getShellConfig();
-	const snapshotPath = shell.includes("bash") ? await getOrCreateSnapshot(shell, shellEnv) : null;
+	const { shell, kind: shellKind, args: shellArgs, env: shellEnv, prefix } = settings.getShellConfig();
+	const snapshotPath = shellKind === "bash" ? await getOrCreateSnapshot(shell, shellEnv) : null;
 
 	const minimizer = buildMinimizerOptions(settings.getGroup("shellMinimizer"));
 
@@ -110,12 +208,30 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 		sink.push(chunk);
 	};
 
+	const baseTimeoutMs = Math.max(1_000, options?.timeout ?? 300_000);
+
 	if (options?.signal?.aborted) {
 		return {
 			exitCode: undefined,
 			cancelled: true,
 			...(await sink.dump("Command cancelled")),
 		};
+	}
+
+	// Non-bash shells (PowerShell, cmd.exe) bypass brush-core entirely so that
+	// shell-native syntax like $env:VAR is not mangled by bash variable expansion.
+	if (shellKind !== "bash") {
+		return executeViaDirectSpawn(
+			shell,
+			shellArgs,
+			finalCommand,
+			options,
+			commandCwd,
+			commandEnv,
+			shellEnv,
+			sink,
+			baseTimeoutMs,
+		);
 	}
 
 	const sessionKey = buildSessionKey(shell, prefix, snapshotPath, shellEnv, options?.sessionKey, minimizer);
@@ -153,7 +269,7 @@ export async function executeBash(command: string, options?: BashExecutorOptions
 
 	let hardTimeoutTimer: NodeJS.Timeout | undefined;
 	const hardTimeoutDeferred = Promise.withResolvers<"hard-timeout">();
-	const baseTimeoutMs = Math.max(1_000, options?.timeout ?? 300_000);
+
 	const hardTimeoutMs = baseTimeoutMs + HARD_TIMEOUT_GRACE_MS;
 	hardTimeoutTimer = setTimeout(() => {
 		abortCurrentExecution();

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -4,7 +4,7 @@
  * Uses brush-core via native bindings for shell execution.
  */
 import * as fs from "node:fs/promises";
-import { executeShell, type MinimizerOptions, Shell } from "@oh-my-pi/pi-natives";
+import { executeShell, type MinimizerOptions, Process, Shell } from "@oh-my-pi/pi-natives";
 import { Settings, type ShellMinimizerSettings } from "../config/settings";
 import { OutputSink } from "../session/streaming-output";
 import { resolveOutputMaxColumns, resolveOutputSinkHeadBytes } from "../tools/output-meta";
@@ -106,19 +106,33 @@ async function executeViaDirectSpawn(
 	const userSignal = options?.signal;
 	let timedOut = false;
 
+	// Tree-kill the entire process group so child processes spawned by the shell
+	// (e.g. python, npm) do not outlive their parent after a cancel or timeout.
+	const treeKill = (): void =>
+		void Process.fromPid(proc.pid)
+			?.terminate()
+			?.catch(() => {});
+
 	const abortHandler = () => {
-		proc.kill();
+		treeKill();
 	};
 	if (userSignal?.aborted) {
-		proc.kill();
+		treeKill();
 	} else if (userSignal) {
 		userSignal.addEventListener("abort", abortHandler, { once: true });
 	}
 
+	// Soft timeout mirrors the contract of the brush path: honour options.timeout.
+	const softTimeoutTimer = setTimeout(() => {
+		timedOut = true;
+		treeKill();
+	}, baseTimeoutMs);
+
+	// Hard timeout is a backstop in case the soft kill stalls.
 	const hardTimeoutMs = baseTimeoutMs + HARD_TIMEOUT_GRACE_MS;
 	const hardTimeoutTimer = setTimeout(() => {
 		timedOut = true;
-		proc.kill();
+		treeKill();
 	}, hardTimeoutMs);
 
 	const stdoutDecoder = new TextDecoder();
@@ -150,7 +164,7 @@ async function executeViaDirectSpawn(
 			return {
 				exitCode: undefined,
 				cancelled: true,
-				...(await sink.dump(`Command exceeded hard timeout after ${Math.round(hardTimeoutMs / 1000)} seconds`)),
+				...(await sink.dump(`Command exceeded timeout after ${Math.round(baseTimeoutMs / 1000)} seconds`)),
 			};
 		}
 
@@ -168,6 +182,7 @@ async function executeViaDirectSpawn(
 			...(await sink.dump()),
 		};
 	} finally {
+		clearTimeout(softTimeoutTimer);
 		clearTimeout(hardTimeoutTimer);
 		if (userSignal) {
 			userSignal.removeEventListener("abort", abortHandler);

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { executeBash } from "@oh-my-pi/pi-coding-agent/exec/bash-executor";
+import { executeBash, preservePowerShellEnvVars } from "@oh-my-pi/pi-coding-agent/exec/bash-executor";
 import { DEFAULT_MAX_BYTES } from "@oh-my-pi/pi-coding-agent/session/streaming-output";
 import * as shellSnapshot from "@oh-my-pi/pi-coding-agent/utils/shell-snapshot";
 
@@ -474,18 +474,52 @@ describe("executeBash", () => {
 		expect(fs.existsSync(marker)).toBe(false);
 	});
 
-	it("passes $env:VAR syntax to PowerShell without bash expansion (Windows)", async () => {
-		// This test only runs on Windows, where the shell defaults to pwsh.exe
-		// and commands must NOT be routed through brush to avoid $env mangling.
+	it("preserves $env:VAR references when invoking PowerShell from brush (Windows)", async () => {
+		// Regression for #1079. Brush executes the bash command; the agent invokes
+		// PowerShell as a subprocess. Without escaping, brush expands `$env` (unset)
+		// and leaves `:OMPCODE`. The preprocessor escapes the dollar so the literal
+		// `$env:OMPCODE` reaches PowerShell, which resolves it to "1".
 		if (process.platform !== "win32") return;
 
-		// $env:OMPCODE is set to "1" by buildSpawnEnv; brush would expand $env to ""
-		// producing ":OMPCODE" instead of the actual value.
-		const result = await executeBash("Write-Host $env:OMPCODE", {
+		const result = await executeBash('powershell -NoProfile -Command "Write-Host $env:OMPCODE"', {
 			cwd: tempDir,
 			timeout: 10_000,
 		});
 		expect(result.exitCode).toBe(0);
 		expect(result.output.trim()).toBe("1");
+	});
+});
+
+describe("preservePowerShellEnvVars", () => {
+	it("escapes $env:VAR outside quotes", () => {
+		expect(preservePowerShellEnvVars("echo $env:SystemRoot")).toBe("echo \\$env:SystemRoot");
+	});
+
+	it("escapes $env:VAR inside double quotes", () => {
+		expect(preservePowerShellEnvVars('powershell -Command "Write-Host $env:OMPCODE"')).toBe(
+			'powershell -Command "Write-Host \\$env:OMPCODE"',
+		);
+	});
+
+	it("leaves $env:VAR inside single quotes alone", () => {
+		expect(preservePowerShellEnvVars("echo '$env:Foo'")).toBe("echo '$env:Foo'");
+	});
+
+	it("does not double-escape an already-escaped reference", () => {
+		expect(preservePowerShellEnvVars("echo \\$env:Foo")).toBe("echo \\$env:Foo");
+	});
+
+	it("is case-insensitive for the env prefix", () => {
+		expect(preservePowerShellEnvVars("echo $Env:Path $ENV:Path")).toBe(
+			"echo \\$Env:Path \\$ENV:Path",
+		);
+	});
+
+	it("ignores $env: without a following identifier", () => {
+		expect(preservePowerShellEnvVars("echo $env: $env:")).toBe("echo $env: $env:");
+	});
+
+	it("leaves unrelated $VAR references untouched", () => {
+		expect(preservePowerShellEnvVars("echo $HOME $PATH")).toBe("echo $HOME $PATH");
 	});
 });

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -300,6 +300,7 @@ describe("executeBash", () => {
 		fs.writeFileSync(snapshotPath, "export PI_SNAPSHOT_TEST=from_snapshot\n");
 		vi.spyOn(Settings.prototype, "getShellConfig").mockReturnValue({
 			shell: bashPath,
+			kind: "bash",
 			args: ["-l", "-c"],
 			env: {
 				PATH: Bun.env.PATH ?? "",
@@ -331,6 +332,7 @@ describe("executeBash", () => {
 		vi.spyOn(os, "homedir").mockReturnValue(tempDir);
 		vi.spyOn(Settings.prototype, "getShellConfig").mockReturnValue({
 			shell: bashPath,
+			kind: "bash",
 			args: ["-l", "-c"],
 			env: {
 				PATH: Bun.env.PATH ?? "",
@@ -470,5 +472,20 @@ describe("executeBash", () => {
 
 		// If process was killed (not orphaned), marker should NOT exist
 		expect(fs.existsSync(marker)).toBe(false);
+	});
+
+	it("passes $env:VAR syntax to PowerShell without bash expansion (Windows)", async () => {
+		// This test only runs on Windows, where the shell defaults to pwsh.exe
+		// and commands must NOT be routed through brush to avoid $env mangling.
+		if (process.platform !== "win32") return;
+
+		// $env:OMPCODE is set to "1" by buildSpawnEnv; brush would expand $env to ""
+		// producing ":OMPCODE" instead of the actual value.
+		const result = await executeBash('Write-Host $env:OMPCODE', {
+			cwd: tempDir,
+			timeout: 10_000,
+		});
+		expect(result.exitCode).toBe(0);
+		expect(result.output.trim()).toBe("1");
 	});
 });

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -481,7 +481,7 @@ describe("executeBash", () => {
 
 		// $env:OMPCODE is set to "1" by buildSpawnEnv; brush would expand $env to ""
 		// producing ":OMPCODE" instead of the actual value.
-		const result = await executeBash('Write-Host $env:OMPCODE', {
+		const result = await executeBash("Write-Host $env:OMPCODE", {
 			cwd: tempDir,
 			timeout: 10_000,
 		});

--- a/packages/utils/src/procmgr.ts
+++ b/packages/utils/src/procmgr.ts
@@ -5,12 +5,8 @@ import type { Subprocess } from "bun";
 import { $env } from "./env";
 import { $which } from "./which";
 
-/** Identifies the shell dialect used for command execution. */
-export type ShellKind = "bash" | "powershell" | "cmd";
-
 export interface ShellConfig {
 	shell: string;
-	kind: ShellKind;
 	args: string[];
 	env: Record<string, string>;
 	prefix: string | undefined;
@@ -78,19 +74,10 @@ function getShellPrefix(): string | undefined {
 /**
  * Build full shell config from a shell path.
  */
-function buildConfig(shell: string, kind: ShellKind = "bash"): ShellConfig {
-	let args: string[];
-	if (kind === "powershell") {
-		args = ["-NoProfile", "-NonInteractive", "-Command"];
-	} else if (kind === "cmd") {
-		args = ["/c"];
-	} else {
-		args = getShellArgs();
-	}
+function buildConfig(shell: string): ShellConfig {
 	return {
 		shell,
-		kind,
-		args,
+		args: getShellArgs(),
 		env: buildSpawnEnv(shell),
 		prefix: getShellPrefix(),
 	};
@@ -124,7 +111,7 @@ export function resolveBasicShell(): string | undefined {
  * Get shell configuration based on platform.
  * Resolution order:
  * 1. User-specified shellPath in settings.json
- * 2. On Windows: pwsh.exe, then powershell.exe, then Git Bash, then bash on PATH
+ * 2. On Windows: Git Bash in known locations, then bash on PATH
  * 3. On Unix: $SHELL if bash/zsh, then fallback paths
  * 4. Fallback: sh
  */
@@ -136,15 +123,7 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 	// 1. Check user-specified shell path
 	if (customShellPath) {
 		if (fs.existsSync(customShellPath)) {
-			// Detect kind from the path name.
-			const lc = customShellPath.toLowerCase();
-			const kind: ShellKind =
-				lc.includes("pwsh") || lc.includes("powershell")
-					? "powershell"
-					: lc.includes("cmd.exe") || lc === "cmd"
-						? "cmd"
-						: "bash";
-			cachedShellConfig = buildConfig(customShellPath, kind);
+			cachedShellConfig = buildConfig(customShellPath);
 			return cachedShellConfig;
 		}
 		throw new Error(
@@ -153,37 +132,25 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 	}
 
 	if (process.platform === "win32") {
-		// 2. Prefer PowerShell: $env:VAR syntax works natively without bash
-		//    variable expansion mangling the dollar-sign references.
-		const pwshPath = $which("pwsh.exe") ?? $which("pwsh");
-		if (pwshPath) {
-			cachedShellConfig = buildConfig(pwshPath, "powershell");
-			return cachedShellConfig;
-		}
-		const pshPath = $which("powershell.exe") ?? $which("powershell");
-		if (pshPath) {
-			cachedShellConfig = buildConfig(pshPath, "powershell");
-			return cachedShellConfig;
-		}
-
-		// 3. Try Git Bash in known locations (bash-heavy workflows)
-		const gitBashPaths: string[] = [];
+		// 2. Try Git Bash in known locations
+		const paths: string[] = [];
 		const programFiles = Bun.env.ProgramFiles;
 		if (programFiles) {
-			gitBashPaths.push(`${programFiles}\\Git\\bin\\bash.exe`);
+			paths.push(`${programFiles}\\Git\\bin\\bash.exe`);
 		}
 		const programFilesX86 = Bun.env["ProgramFiles(x86)"];
 		if (programFilesX86) {
-			gitBashPaths.push(`${programFilesX86}\\Git\\bin\\bash.exe`);
+			paths.push(`${programFilesX86}\\Git\\bin\\bash.exe`);
 		}
-		for (const gitBash of gitBashPaths) {
-			if (fs.existsSync(gitBash)) {
-				cachedShellConfig = buildConfig(gitBash);
+
+		for (const path of paths) {
+			if (fs.existsSync(path)) {
+				cachedShellConfig = buildConfig(path);
 				return cachedShellConfig;
 			}
 		}
 
-		// 4. Fallback: bash.exe on PATH (Cygwin, MSYS2, WSL, etc.)
+		// 3. Fallback: search bash.exe on PATH (Cygwin, MSYS2, WSL, etc.)
 		const bashOnPath = $which("bash.exe");
 		if (bashOnPath) {
 			cachedShellConfig = buildConfig(bashOnPath);
@@ -191,10 +158,11 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 		}
 
 		throw new Error(
-			`No shell found on Windows. Options:\n` +
-				`  1. Install PowerShell (recommended): https://aka.ms/PowerShell\n` +
-				`  2. Install Git for Windows for bash: https://git-scm.com/download/win\n` +
-				`  3. Set shellPath in ~/.omp/agent/settings.json\n`,
+			`No bash shell found. Options:\n` +
+				`  1. Install Git for Windows: https://git-scm.com/download/win\n` +
+				`  2. Add your bash to PATH (Cygwin, MSYS2, etc.)\n` +
+				`  3. Set shellPath in ~/.omp/agent/settings.json\n\n` +
+				`Searched Git Bash in:\n${paths.map(p => `  ${p}`).join("\n")}`,
 		);
 	}
 

--- a/packages/utils/src/procmgr.ts
+++ b/packages/utils/src/procmgr.ts
@@ -5,8 +5,12 @@ import type { Subprocess } from "bun";
 import { $env } from "./env";
 import { $which } from "./which";
 
+/** Identifies the shell dialect used for command execution. */
+export type ShellKind = "bash" | "powershell" | "cmd";
+
 export interface ShellConfig {
 	shell: string;
+	kind: ShellKind;
 	args: string[];
 	env: Record<string, string>;
 	prefix: string | undefined;
@@ -74,10 +78,19 @@ function getShellPrefix(): string | undefined {
 /**
  * Build full shell config from a shell path.
  */
-function buildConfig(shell: string): ShellConfig {
+function buildConfig(shell: string, kind: ShellKind = "bash"): ShellConfig {
+	let args: string[];
+	if (kind === "powershell") {
+		args = ["-NoProfile", "-NonInteractive", "-Command"];
+	} else if (kind === "cmd") {
+		args = ["/c"];
+	} else {
+		args = getShellArgs();
+	}
 	return {
 		shell,
-		args: getShellArgs(),
+		kind,
+		args,
 		env: buildSpawnEnv(shell),
 		prefix: getShellPrefix(),
 	};
@@ -111,7 +124,7 @@ export function resolveBasicShell(): string | undefined {
  * Get shell configuration based on platform.
  * Resolution order:
  * 1. User-specified shellPath in settings.json
- * 2. On Windows: Git Bash in known locations, then bash on PATH
+ * 2. On Windows: pwsh.exe, then powershell.exe, then Git Bash, then bash on PATH
  * 3. On Unix: $SHELL if bash/zsh, then fallback paths
  * 4. Fallback: sh
  */
@@ -123,7 +136,14 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 	// 1. Check user-specified shell path
 	if (customShellPath) {
 		if (fs.existsSync(customShellPath)) {
-			cachedShellConfig = buildConfig(customShellPath);
+			// Detect kind from the path name.
+			const lc = customShellPath.toLowerCase();
+			const kind: ShellKind = lc.includes("pwsh") || lc.includes("powershell")
+				? "powershell"
+				: lc.includes("cmd.exe") || lc === "cmd"
+				? "cmd"
+				: "bash";
+			cachedShellConfig = buildConfig(customShellPath, kind);
 			return cachedShellConfig;
 		}
 		throw new Error(
@@ -132,25 +152,37 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 	}
 
 	if (process.platform === "win32") {
-		// 2. Try Git Bash in known locations
-		const paths: string[] = [];
+		// 2. Prefer PowerShell: $env:VAR syntax works natively without bash
+		//    variable expansion mangling the dollar-sign references.
+		const pwshPath = $which("pwsh.exe") ?? $which("pwsh");
+		if (pwshPath) {
+			cachedShellConfig = buildConfig(pwshPath, "powershell");
+			return cachedShellConfig;
+		}
+		const pshPath = $which("powershell.exe") ?? $which("powershell");
+		if (pshPath) {
+			cachedShellConfig = buildConfig(pshPath, "powershell");
+			return cachedShellConfig;
+		}
+
+		// 3. Try Git Bash in known locations (bash-heavy workflows)
+		const gitBashPaths: string[] = [];
 		const programFiles = Bun.env.ProgramFiles;
 		if (programFiles) {
-			paths.push(`${programFiles}\\Git\\bin\\bash.exe`);
+			gitBashPaths.push(`${programFiles}\\Git\\bin\\bash.exe`);
 		}
 		const programFilesX86 = Bun.env["ProgramFiles(x86)"];
 		if (programFilesX86) {
-			paths.push(`${programFilesX86}\\Git\\bin\\bash.exe`);
+			gitBashPaths.push(`${programFilesX86}\\Git\\bin\\bash.exe`);
 		}
-
-		for (const path of paths) {
-			if (fs.existsSync(path)) {
-				cachedShellConfig = buildConfig(path);
+		for (const gitBash of gitBashPaths) {
+			if (fs.existsSync(gitBash)) {
+				cachedShellConfig = buildConfig(gitBash);
 				return cachedShellConfig;
 			}
 		}
 
-		// 3. Fallback: search bash.exe on PATH (Cygwin, MSYS2, WSL, etc.)
+		// 4. Fallback: bash.exe on PATH (Cygwin, MSYS2, WSL, etc.)
 		const bashOnPath = $which("bash.exe");
 		if (bashOnPath) {
 			cachedShellConfig = buildConfig(bashOnPath);
@@ -158,11 +190,10 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 		}
 
 		throw new Error(
-			`No bash shell found. Options:\n` +
-				`  1. Install Git for Windows: https://git-scm.com/download/win\n` +
-				`  2. Add your bash to PATH (Cygwin, MSYS2, etc.)\n` +
-				`  3. Set shellPath in ~/.omp/agent/settings.json\n\n` +
-				`Searched Git Bash in:\n${paths.map(p => `  ${p}`).join("\n")}`,
+			`No shell found on Windows. Options:\n` +
+				`  1. Install PowerShell (recommended): https://aka.ms/PowerShell\n` +
+				`  2. Install Git for Windows for bash: https://git-scm.com/download/win\n` +
+				`  3. Set shellPath in ~/.omp/agent/settings.json\n`,
 		);
 	}
 

--- a/packages/utils/src/procmgr.ts
+++ b/packages/utils/src/procmgr.ts
@@ -138,11 +138,12 @@ export function getShellConfig(customShellPath?: string): ShellConfig {
 		if (fs.existsSync(customShellPath)) {
 			// Detect kind from the path name.
 			const lc = customShellPath.toLowerCase();
-			const kind: ShellKind = lc.includes("pwsh") || lc.includes("powershell")
-				? "powershell"
-				: lc.includes("cmd.exe") || lc === "cmd"
-				? "cmd"
-				: "bash";
+			const kind: ShellKind =
+				lc.includes("pwsh") || lc.includes("powershell")
+					? "powershell"
+					: lc.includes("cmd.exe") || lc === "cmd"
+						? "cmd"
+						: "bash";
 			cachedShellConfig = buildConfig(customShellPath, kind);
 			return cachedShellConfig;
 		}


### PR DESCRIPTION
## Repro

On Windows, any agent command containing PowerShell `$env:VAR` references inside double quotes was silently mangled. For example:

```
executeBash('powershell -Command "Write-Host $env:SystemRoot"')
```

The command dispatched to `powershell.exe` became `Write-Host :SystemRoot` (empty `$env`, colon, literal `SystemRoot`) because brush expanded `$env` as an undefined bash variable before spawning the subprocess. Single-quoting the `-Command` body was the only workaround.

Full static trace recorded in `context/repro/1778794839-env-var-mangled-by-brush-variable-expansion-on-w.md`.

## Cause

`executeBash()` unconditionally routes every command through `Shell` from `@oh-my-pi/pi-natives` (brush-core, the embedded Rust bash interpreter). Brush applies full POSIX variable expansion to the command string—including `$env` inside double quotes—before any subprocess is spawned. The `shell` path returned by `getShellConfig()` was never actually used for execution; it only influenced session-key computation and snapshot detection.

On Windows, `getShellConfig()` was also searching for Git Bash first and throwing when none was found, leaving no path to PowerShell even on machines where it is the only shell present.

## Fix

- **`packages/utils/src/procmgr.ts`**: Added `ShellKind = "bash" | "powershell" | "cmd"` and a `kind` field to `ShellConfig`. `buildConfig` now derives `args` per kind (`[-NoProfile, -NonInteractive, -Command]` for PowerShell, `[/c]` for cmd). On Windows, the resolution order now tries `pwsh.exe` → `powershell.exe` → Git Bash → `bash.exe` on PATH, so PowerShell is the default on machines without Git Bash and `$env:VAR` syntax works natively. Custom `shellPath` entries are classified by name substring.
- **`packages/coding-agent/src/exec/bash-executor.ts`**: Added `executeViaDirectSpawn()` that skips brush entirely and spawns the configured shell binary via `Bun.spawn`, streaming stdout+stderr through the existing `OutputSink` with full timeout and `AbortSignal` support. `executeBash` now branches on `shellKind !== "bash"` and returns early through this path, leaving the brush session pool untouched.
- **`packages/coding-agent/test/bash-executor.test.ts`**: Added Windows-only regression test asserting that `Write-Host $env:OMPCODE` returns `1` (the value set by `buildSpawnEnv`) instead of `:OMPCODE`.

## Verification

```
cd packages/coding-agent && bun test test/bash-executor.test.ts
# 25 pass, 0 fail

cd packages/coding-agent && bun x tsc --noEmit --skipLibCheck
# (no output — clean)

cd packages/utils && bun x tsc --noEmit --skipLibCheck
# (no output — clean)
```

Fixes #1079