### PR TITLE
fix(web-search): thread AbortSignal to fetch() in anthropic, exa, jina, zai, gemini providers

### DIFF
--- a/packages/coding-agent/src/web/search/providers/anthropic.ts
+++ b/packages/coding-agent/src/web/search/providers/anthropic.ts
@@ -38,6 +38,7 @@ export interface AnthropicSearchParams {
 	max_tokens?: number;
 	/** Sampling temperature (0–1). Lower = more focused/factual. */
 	temperature?: number;
+	signal?: AbortSignal;
 }
 
 /**
@@ -86,6 +87,7 @@ async function callSearch(
 	systemPrompt?: string,
 	maxTokens?: number,
 	temperature?: number,
+	signal?: AbortSignal,
 ): Promise<AnthropicApiResponse> {
 	const url = buildAnthropicUrl(auth);
 	const headers = buildAnthropicSearchHeaders(auth);
@@ -116,6 +118,7 @@ async function callSearch(
 		method: "POST",
 		headers,
 		body: JSON.stringify(body),
+		signal,
 	});
 
 	if (!response.ok) {
@@ -253,6 +256,7 @@ export async function searchAnthropic(params: AnthropicSearchParams): Promise<Se
 		params.system_prompt,
 		params.max_tokens,
 		params.temperature,
+		params.signal,
 	);
 
 	const result = parseResponse(response);
@@ -281,6 +285,7 @@ export class AnthropicProvider extends SearchProvider {
 			num_results: params.numSearchResults ?? params.limit,
 			max_tokens: params.maxOutputTokens,
 			temperature: params.temperature,
+			signal: params.signal,
 		});
 	}
 }

--- a/packages/coding-agent/src/web/search/providers/exa.ts
+++ b/packages/coding-agent/src/web/search/providers/exa.ts
@@ -29,6 +29,7 @@ export interface ExaSearchParams {
 	exclude_domains?: string[];
 	start_published_date?: string;
 	end_published_date?: string;
+	signal?: AbortSignal;
 }
 
 interface ExaSearchResult {
@@ -179,6 +180,7 @@ async function callExaSearch(apiKey: string, params: ExaSearchParams): Promise<E
 			"x-api-key": apiKey,
 		},
 		body: JSON.stringify(body),
+		signal: params.signal,
 	});
 
 	if (!response.ok) {
@@ -259,6 +261,7 @@ export class ExaProvider extends SearchProvider {
 		return searchExa({
 			query: params.query,
 			num_results: params.numSearchResults ?? params.limit,
+			signal: params.signal,
 		});
 	}
 }

--- a/packages/coding-agent/src/web/search/providers/gemini.ts
+++ b/packages/coding-agent/src/web/search/providers/gemini.ts
@@ -39,6 +39,7 @@ export interface GeminiSearchParams extends GeminiToolParams {
 	max_output_tokens?: number;
 	/** Sampling temperature (0–1). Lower = more focused/factual. */
 	temperature?: number;
+	signal?: AbortSignal;
 }
 
 export function buildGeminiRequestTools(params: GeminiToolParams): Array<Record<string, Record<string, unknown>>> {
@@ -235,6 +236,7 @@ async function callGeminiSearch(
 	maxOutputTokens?: number,
 	temperature?: number,
 	toolParams: GeminiToolParams = {},
+	signal?: AbortSignal,
 ): Promise<{
 	answer: string;
 	sources: SearchSource[];
@@ -308,6 +310,7 @@ async function callGeminiSearch(
 			...headers,
 		},
 		body: JSON.stringify(requestBody),
+		signal,
 	});
 	const urlFor = (attempt: number) =>
 		`${endpoints[Math.min(attempt, endpoints.length - 1)]}/v1internal:streamGenerateContent?alt=sse`;
@@ -500,6 +503,7 @@ export async function searchGemini(params: GeminiSearchParams): Promise<SearchRe
 			code_execution: params.code_execution,
 			url_context: params.url_context,
 		},
+		params.signal,
 	);
 
 	let sources = result.sources;
@@ -539,6 +543,7 @@ export class GeminiProvider extends SearchProvider {
 			google_search: params.googleSearch,
 			code_execution: params.codeExecution,
 			url_context: params.urlContext,
+			signal: params.signal,
 		});
 	}
 }

--- a/packages/coding-agent/src/web/search/providers/jina.ts
+++ b/packages/coding-agent/src/web/search/providers/jina.ts
@@ -17,6 +17,7 @@ const JINA_SEARCH_URL = "https://s.jina.ai";
 export interface JinaSearchParams {
 	query: string;
 	num_results?: number;
+	signal?: AbortSignal;
 }
 
 interface JinaSearchResult {
@@ -33,13 +34,14 @@ export function findApiKey(): string | null {
 }
 
 /** Call Jina Reader search API. */
-async function callJinaSearch(apiKey: string, query: string): Promise<JinaSearchResponse> {
+async function callJinaSearch(apiKey: string, query: string, signal?: AbortSignal): Promise<JinaSearchResponse> {
 	const requestUrl = `${JINA_SEARCH_URL}/${encodeURIComponent(query)}`;
 	const response = await fetch(requestUrl, {
 		headers: {
 			Accept: "application/json",
 			Authorization: `Bearer ${apiKey}`,
 		},
+		signal,
 	});
 
 	if (!response.ok) {
@@ -58,7 +60,7 @@ export async function searchJina(params: JinaSearchParams): Promise<SearchRespon
 		throw new Error("JINA_API_KEY not found. Set it in environment or .env file.");
 	}
 
-	const response = await callJinaSearch(apiKey, params.query);
+	const response = await callJinaSearch(apiKey, params.query, params.signal);
 	const sources: SearchSource[] = [];
 
 	for (const result of response) {
@@ -91,6 +93,7 @@ export class JinaProvider extends SearchProvider {
 		return searchJina({
 			query: params.query,
 			num_results: params.numSearchResults ?? params.limit,
+			signal: params.signal,
 		});
 	}
 }

--- a/packages/coding-agent/src/web/search/providers/zai.ts
+++ b/packages/coding-agent/src/web/search/providers/zai.ts
@@ -20,6 +20,7 @@ const DEFAULT_NUM_RESULTS = 10;
 export interface ZaiSearchParams {
 	query: string;
 	num_results?: number;
+	signal?: AbortSignal;
 }
 
 interface ZaiSearchResult {
@@ -55,7 +56,7 @@ export async function findApiKey(): Promise<string | null> {
 	return findCredential(getEnvApiKey("zai"), "zai");
 }
 
-async function callZaiTool(apiKey: string, args: Record<string, unknown>): Promise<unknown> {
+async function callZaiTool(apiKey: string, args: Record<string, unknown>, signal?: AbortSignal): Promise<unknown> {
 	const response = await fetch(ZAI_MCP_URL, {
 		method: "POST",
 		headers: {
@@ -72,6 +73,7 @@ async function callZaiTool(apiKey: string, args: Record<string, unknown>): Promi
 				arguments: args,
 			},
 		}),
+		signal,
 	});
 
 	if (!response.ok) {
@@ -157,7 +159,7 @@ async function callZaiSearch(apiKey: string, params: ZaiSearchParams): Promise<u
 	let lastError: unknown;
 	for (let i = 0; i < attempts.length; i++) {
 		try {
-			return await callZaiTool(apiKey, attempts[i]);
+			return await callZaiTool(apiKey, attempts[i], params.signal);
 		} catch (error) {
 			lastError = error;
 			const isLastAttempt = i === attempts.length - 1;
@@ -302,6 +304,7 @@ export class ZaiProvider extends SearchProvider {
 		return searchZai({
 			query: params.query,
 			num_results: params.numSearchResults ?? params.limit,
+			signal: params.signal,
 		});
 	}
 }


### PR DESCRIPTION
## Repro

Any `web_search` call routed through the `anthropic`, `exa`, `jina`, `zai`, or `gemini` provider hangs if the upstream API is slow. Pressing Esc during the call has no effect — the in-flight `fetch()` ignores the session abort signal — and the session is frozen until the HTTP request resolves. Recovery requires Ctrl+C, which kills the entire OMP process.

## Cause

`SearchParams` (defined in `providers/base.ts`) already exposes `signal?: AbortSignal`. Nine of the fourteen providers forward it correctly all the way to `fetch()`. Five do not:

| Provider | `signal` in params type | threaded to `fetch()` |
|---|---|---|
| `anthropic.ts` | ❌ | ❌ |
| `exa.ts` | ❌ | ❌ |
| `jina.ts` | ❌ | ❌ |
| `zai.ts` | ❌ | ❌ |
| `gemini.ts` | ❌ | ❌ |

In each case `SearchProvider.search()` never forwarded `params.signal` into the underlying helper or its `fetch()` call.

## Fix

- **`anthropic.ts`**: added `signal?: AbortSignal` to `AnthropicSearchParams`, added the parameter to `callSearch()`, wired it to `fetch()`, and passed `params.signal` from `AnthropicProvider.search()`.
- **`exa.ts`**: added `signal?: AbortSignal` to `ExaSearchParams`, wired it from `callExaSearch()` → `fetch()`, and passed it from `ExaProvider.search()`.
- **`jina.ts`**: added `signal?: AbortSignal` to `JinaSearchParams`, added it to `callJinaSearch()` → `fetch()`, and passed it from `JinaProvider.search()`.
- **`zai.ts`**: added `signal?: AbortSignal` to `ZaiSearchParams`, threaded it through `callZaiSearch()` → `callZaiTool()` → `fetch()`, and passed it from `ZaiProvider.search()`.
- **`gemini.ts`**: added `signal?: AbortSignal` to `GeminiSearchParams`, added it to `callGeminiSearch()`, and included it inside `buildInit()` so both `fetchWithRetry` calls (initial request and the post-auth-refresh retry) carry the signal. Passed it from `GeminiProvider.search()`.

## Verification

Audited all 14 providers in `packages/coding-agent/src/web/search/providers/`. After this change, `signal` is correctly threaded in all providers that call `fetch()` directly:

```
brave       ✅ (unchanged)    kimi        ✅ (unchanged)
perplexity  ✅ (unchanged)    searxng     ✅ (unchanged)
tavily      ✅ (unchanged)    synthetic   ✅ (unchanged)
codex       ✅ (unchanged)    kagi        ✅ (unchanged)
parallel    ✅ (unchanged)
anthropic   ✅ (this PR)      exa         ✅ (this PR)
jina        ✅ (this PR)      zai         ✅ (this PR)
gemini      ✅ (this PR)
```

Changes are mechanically equivalent to the pattern already used in the working providers — only the missing parameter threaded, no logic changes.

Fixes #1044