### PR TITLE
fix(discovery): honor Claude plugin commands manifest key

### DIFF
--- a/packages/coding-agent/src/discovery/claude-plugins.ts
+++ b/packages/coding-agent/src/discovery/claude-plugins.ts
@@ -31,6 +31,7 @@ const PRIORITY = 70; // Below claude.ts (80) so user .claude/ overrides win
 interface ClaudePluginManifest {
 	skills?: string;
 	"slash-commands"?: string;
+	commands?: string;
 }
 
 interface ResolvedPluginDir {
@@ -59,24 +60,35 @@ function isWithinPluginRoot(rootPath: string, targetPath: string): boolean {
 
 async function resolvePluginDir(
 	root: ClaudePluginRoot,
-	manifestKey: keyof ClaudePluginManifest,
+	manifestKeys: ReadonlyArray<keyof ClaudePluginManifest>,
 	fallback: string,
 ): Promise<ResolvedPluginDir> {
 	const manifest = await readPluginManifest(root);
 	const fallbackDir = path.join(root.path, fallback);
-	const configured = manifest?.[manifestKey];
-	if (typeof configured !== "string" || !configured.trim()) {
+
+	let configured: string | undefined;
+	let matchedKey: keyof ClaudePluginManifest | undefined;
+	for (const key of manifestKeys) {
+		const val = manifest?.[key];
+		if (typeof val === "string" && val.trim()) {
+			configured = val.trim();
+			matchedKey = key;
+			break;
+		}
+	}
+
+	if (configured === undefined) {
 		return { dir: fallbackDir };
 	}
 
-	const resolved = path.resolve(root.path, configured.trim());
+	const resolved = path.resolve(root.path, configured);
 	if (isWithinPluginRoot(root.path, resolved)) {
 		return { dir: resolved };
 	}
 
 	return {
 		dir: fallbackDir,
-		warning: `[claude-plugins] Ignoring ${String(manifestKey)} path outside plugin root for ${root.id}: ${configured}`,
+		warning: `[claude-plugins] Ignoring ${String(matchedKey)} path outside plugin root for ${root.id}: ${configured}`,
 	};
 }
 
@@ -93,7 +105,7 @@ async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
 
 	const results = await Promise.all(
 		roots.map(async root => {
-			const { dir: skillsDir, warning } = await resolvePluginDir(root, "skills", "skills");
+			const { dir: skillsDir, warning } = await resolvePluginDir(root, ["skills"], "skills");
 			const result = await scanSkillsFromDir(ctx, {
 				dir: skillsDir,
 				providerId: PROVIDER_ID,
@@ -128,7 +140,7 @@ async function loadSlashCommands(ctx: LoadContext): Promise<LoadResult<SlashComm
 
 	const results = await Promise.all(
 		roots.map(async root => {
-			const { dir: commandsDir, warning } = await resolvePluginDir(root, "slash-commands", "commands");
+			const { dir: commandsDir, warning } = await resolvePluginDir(root, ["commands", "slash-commands"], "commands");
 			const result = await loadFilesFromDir<SlashCommand>(ctx, commandsDir, PROVIDER_ID, root.scope, {
 				extensions: ["md"],
 				transform: (name, content, filePath, source) => {

--- a/packages/coding-agent/test/discovery/claude-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/claude-plugins.test.ts
@@ -393,6 +393,85 @@ describe("listClaudePluginRoots", () => {
 		expect(found).toBeDefined();
 		expect(found?.path).toContain(path.join(".claude", "commands", "ship.md"));
 	});
+
+	test("reads slash commands directory from plugin manifest commands field (standard Claude plugin format)", async () => {
+		const pluginsDir = path.join(tempDir, ".claude", "plugins");
+		const pluginPath = path.join(tempDir, "plugins", "manifest-commands-key");
+		await fs.mkdir(path.join(pluginsDir), { recursive: true });
+		await fs.mkdir(path.join(pluginPath, ".claude-plugin"), { recursive: true });
+		await fs.mkdir(path.join(pluginPath, ".claude", "commands"), { recursive: true });
+
+		const registry = {
+			version: 2,
+			plugins: {
+				"manifest-commands-key@market": [
+					{
+						scope: "user",
+						installPath: pluginPath,
+						version: "1.0.0",
+						installedAt: "2025-01-01T00:00:00Z",
+						lastUpdated: "2025-01-01T00:00:00Z",
+					},
+				],
+			},
+		};
+
+		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
+		await fs.writeFile(
+			path.join(pluginPath, ".claude-plugin", "plugin.json"),
+			JSON.stringify({ commands: "./.claude/commands" }),
+		);
+		await fs.writeFile(path.join(pluginPath, ".claude", "commands", "plan.md"), "Plan it\n");
+
+		const result = await loadCapability<SlashCommand>("slash-commands", { cwd: tempDir });
+		expect(result.warnings).toEqual([]);
+		const found = result.all.find(command => command.name === "manifest-commands-key:plan");
+
+		expect(found).toBeDefined();
+		expect(found?.path).toContain(path.join(".claude", "commands", "plan.md"));
+	});
+
+	test("commands field takes precedence over slash-commands field when both are present", async () => {
+		const pluginsDir = path.join(tempDir, ".claude", "plugins");
+		const pluginPath = path.join(tempDir, "plugins", "manifest-commands-precedence");
+		await fs.mkdir(path.join(pluginsDir), { recursive: true });
+		await fs.mkdir(path.join(pluginPath, ".claude-plugin"), { recursive: true });
+		// commands points to .claude/commands, slash-commands points to a different dir
+		await fs.mkdir(path.join(pluginPath, ".claude", "commands"), { recursive: true });
+		await fs.mkdir(path.join(pluginPath, "legacy-commands"), { recursive: true });
+
+		const registry = {
+			version: 2,
+			plugins: {
+				"manifest-commands-precedence@market": [
+					{
+						scope: "user",
+						installPath: pluginPath,
+						version: "1.0.0",
+						installedAt: "2025-01-01T00:00:00Z",
+						lastUpdated: "2025-01-01T00:00:00Z",
+					},
+				],
+			},
+		};
+
+		await fs.writeFile(path.join(pluginsDir, "installed_plugins.json"), JSON.stringify(registry));
+		await fs.writeFile(
+			path.join(pluginPath, ".claude-plugin", "plugin.json"),
+			JSON.stringify({ commands: "./.claude/commands", "slash-commands": "./legacy-commands" }),
+		);
+		await fs.writeFile(path.join(pluginPath, ".claude", "commands", "ship.md"), "Ship it\n");
+		// This file exists only under the legacy dir — should NOT be found
+		await fs.writeFile(path.join(pluginPath, "legacy-commands", "old.md"), "Old\n");
+
+		const result = await loadCapability<SlashCommand>("slash-commands", { cwd: tempDir });
+		expect(result.warnings).toEqual([]);
+		const found = result.all.find(command => command.name === "manifest-commands-precedence:ship");
+		const notFound = result.all.find(command => command.name === "manifest-commands-precedence:old");
+
+		expect(found).toBeDefined();
+		expect(notFound).toBeUndefined();
+	});
 	test("ignores manifest skills directory that resolves outside plugin root", async () => {
 		const pluginsDir = path.join(tempDir, ".claude", "plugins");
 		const pluginPath = path.join(tempDir, "plugins", "manifest-skills-outside");


### PR DESCRIPTION
## Repro
A Claude plugin manifest declaring slash command location with the standard Claude plugin key (`{"commands":"./.claude/commands"}`) was scanned at the fallback `<plugin-root>/commands/` path instead of the configured `.claude/commands` path, so commands like `/plan` or `/ship` were not loaded. Repro was captured in `context/repro/1778810321-plugin-manifest--commands--key-ignored---slash-c.md`; verification command: `bun test packages/coding-agent/test/discovery/claude-plugins.test.ts`.

## Cause
`packages/coding-agent/src/discovery/claude-plugins.ts` defined `ClaudePluginManifest` with only `skills` and `"slash-commands"`, and `loadSlashCommands` called `resolvePluginDir(root, "slash-commands", "commands")`. That meant `resolvePluginDir` never inspected `manifest.commands`, so standard Claude plugin command path overrides were ignored and discovery fell back to `<plugin-root>/commands/`.

## Fix
- Added `commands?: string` to `ClaudePluginManifest`.
- Updated `resolvePluginDir` to accept manifest keys in priority order and use the first non-empty configured path.
- Updated `loadSlashCommands` to resolve `commands` first and retain `slash-commands` as a compatibility fallback.
- Added regression coverage for `commands` loading and `commands` precedence over `slash-commands`.

## Verification
Ran `bun test packages/coding-agent/test/discovery/claude-plugins.test.ts` successfully: 20 pass, 0 fail. The publish gate also passed `bun run fix` and `bun check` before push after repairing the incomplete local dependency install. Fixes #1076