### PR TITLE
fix(h2-fetch): fall back to HTTP/1.1 on connection-level errors, not just HTTP2Unsupported

### DIFF
--- a/packages/ai/src/utils/h2-fetch.ts
+++ b/packages/ai/src/utils/h2-fetch.ts
@@ -1,12 +1,18 @@
 /**
  * Patch `globalThis.fetch` to advertise HTTP/2 in TLS ALPN, with transparent
- * HTTP/1.1 fallback when the server doesn't select `h2`.
+ * HTTP/1.1 fallback when the server doesn't negotiate `h2`.
  *
  * Bun's HTTP/2 client is gated on `BUN_FEATURE_FLAG_EXPERIMENTAL_HTTP2_CLIENT`,
  * read by the native runtime before any JS executes; assigning to
  * `process.env` from inside JS is a no-op. Per-request `protocol: "http2"`
  * activates h2 over TLS ALPN and rejects with `error.code === "HTTP2Unsupported"`
  * if the server picks anything else, so we catch and retry without the hint.
+ *
+ * Some HTTPS endpoints (e.g. corporate API gateways behind reverse proxies)
+ * advertise h2 via ALPN but then refuse or reset the connection at the HTTP/2
+ * framing layer. Bun surfaces these as `ConnectionRefused`, `ConnectionReset`,
+ * or `ConnectionClosed` rather than `HTTP2Unsupported`, so we treat those
+ * codes as h2-fallback triggers as well.
  *
  * Bun negotiates h2 via ALPN over TLS only (no h2c), so plain `http://` URLs
  * skip the attempt entirely — avoids the throw/retry round-trip for localhost.
@@ -24,12 +30,19 @@ export function installH2Fetch(): void {
 	const original = globalThis.fetch as typeof fetch & PatchedFetch;
 	if (original[installed]) return;
 
+	/** Error codes that indicate h2 negotiation/transport failure (not an application error). */
+	const h2FallbackCodes: ReadonlySet<string> = new Set([
+		"HTTP2Unsupported",  // Server selected h1 in ALPN
+		"ConnectionRefused", // Server refused the h2 connection
+		"ConnectionReset",   // Server reset during h2 handshake
+		"ConnectionClosed",  // Server closed before h2 response
+	]);
 	const wrapper = async function h2fetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
 		if (!isHttps(input)) return original(input, init);
 		try {
 			return await original(input, { ...init, protocol: "http2" });
 		} catch (err) {
-			if ((err as { code?: unknown }).code !== "HTTP2Unsupported") throw err;
+			if (!h2FallbackCodes.has((err as { code?: string }).code ?? "")) throw err;
 			return original(input, init);
 		}
 	} as typeof fetch & PatchedFetch;


### PR DESCRIPTION
## Problem

When using a custom provider whose HTTPS endpoint does not fully support HTTP/2 (e.g. a corporate API gateway behind a reverse proxy), **all requests fail with a cryptic `"Connection error."`** that is impossible to diagnose from user-land.

### Root Cause

`installH2Fetch()` patches `globalThis.fetch` to attempt HTTP/2 on every HTTPS request, falling back to HTTP/1.1 only when the error code is exactly `"HTTP2Unsupported"`.

However, some servers advertise `h2` via TLS ALPN but then **refuse or reset** the connection at the HTTP/2 framing layer. Bun surfaces these failures with different error codes:

| Error Code | Meaning |
|---|---|
| `ConnectionRefused` | Server refused the h2 connection |
| `ConnectionReset` | Server reset during h2 handshake |
| `ConnectionClosed` | Server closed before h2 response |

Since none of these matched `"HTTP2Unsupported"`, the wrapper re-threw the error instead of retrying with HTTP/1.1.

### Reproduction

```ts
// Works — HTTP/1.1
await fetch("https://example-gateway.com/v1/messages", { method: "POST", ... });

// Fails — HTTP/2 attempt gets ConnectionRefused, no fallback
await fetch("https://example-gateway.com/v1/messages", { method: "POST", ..., protocol: "http2" });
```

Note: `http://` endpoints (like local proxies) were unaffected because `h2fetch` skips the h2 attempt for non-HTTPS URLs.

## Solution

Widen the set of error codes that trigger the transparent HTTP/1.1 fallback:

```ts
const h2FallbackCodes: ReadonlySet<string> = new Set([
    "HTTP2Unsupported",  // Server selected h1 in ALPN
    "ConnectionRefused", // Server refused the h2 connection
    "ConnectionReset",   // Server reset during h2 handshake
    "ConnectionClosed",  // Server closed before h2 response
]);
```

All four codes are **transport-layer indicators** that the h2 attempt itself failed — not the underlying application request — so retrying without `protocol: "http2"` is safe and expected.

## Testing

Verified with a real-world HTTPS endpoint that does not support HTTP/2:

- **Before fix**: `omp --model custom-provider/model -p "hi"` → `Connection error.`
- **After fix**: `omp --model custom-provider/model -p "hi"` → works correctly via HTTP/1.1 fallback

## Changed Files

- `packages/ai/src/utils/h2-fetch.ts` — the only file changed
