### PR TITLE
fix(extensibility): treat Windows drive-letter paths as filesystem in legacy-pi mirror

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed legacy plugin extensions failing to load on Windows when they import a bare-specifier dependency from their own `node_modules` (e.g. `import YAML from "yaml"` in `supipowers`). The legacy-pi mirror resolved the dependency to its absolute path and then ran the path through `isUrlLikeSpecifier`, whose `^[A-Za-z][A-Za-z\d+.-]*:` regex matched the Windows drive letter (`C:`) and short-circuited the `pathToFileURL` conversion. The raw path was emitted into the mirrored TS source as `import x from "C:\\Users\\...\\dep\\dist\\index.js"`, where `\n`, `\U`, `\y` and other backslash sequences were eaten by the TS string-literal parser, producing nonsense package specifiers like `C:Usersjames.ompagentextensionssupipowers\node_modulesyamldistindex.js` that Bun's resolver rejected with `Cannot find package …`. `isUrlLikeSpecifier` now rejects `^[A-Za-z]:[\\/]` first, so Windows absolute paths flow through `pathToFileURL` like every other absolute path and reach the mirror as proper `file:///C:/...` URLs.
+
 ## [15.0.2] - 2026-05-15
 
 ### Added

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -99,6 +99,12 @@ const ANY_IMPORT_SPECIFIER_REGEX = /((?:from\s+|import\s*\(\s*)["'])([^"']+)(["'
 
 /** Resolve bare imports against the extension directory before loading mirrored legacy Pi files. */
 function isUrlLikeSpecifier(specifier: string): boolean {
+	// Windows drive-letter paths (e.g. `C:\foo` or `C:/foo`) also match the URL
+	// scheme shape `[A-Za-z][A-Za-z\d+.-]*:`. Treat them as filesystem paths so
+	// `toRewrittenImportSpecifier` converts them to `file://` URLs instead of
+	// emitting raw paths whose `\n`, `\U`, ... get eaten by TS string-literal
+	// escapes inside the mirrored extension file.
+	if (/^[a-zA-Z]:[\\/]/.test(specifier)) return false;
 	return /^[a-zA-Z][a-zA-Z\d+.-]*:/.test(specifier);
 }
 


### PR DESCRIPTION
## What

Fix legacy plugin extensions failing to load on Windows when they import a bare-specifier dep from their own `node_modules` (e.g. `import YAML from "yaml"` in [`supipowers`](https://github.com/ogrodev/supipowers)).

## Why

`isUrlLikeSpecifier` short-circuited the `pathToFileURL` step for any specifier matching the URL-scheme shape `^[A-Za-z][A-Za-z\d+.-]*:`. That regex matches a Windows drive letter (`C:`), so `rewriteBareImportsForLegacyExtension` resolved the bare specifier to its absolute path and then `toRewrittenImportSpecifier` passed the raw path through unchanged. The mirrored TS file ended up containing:

```ts
import YAML from "C:\Users\james\.omp\agent\extensions\supipowers\node_modules\yaml\dist\index.js";
```

The TS string-literal parser eats `\n`, `\U`, `\y`, ... in there, producing nonsense package specifiers like `C:Usersjames.ompagentextensionssupipowers\node_modulesyamldistindex.js` that Bun rejects with `Cannot find package …`. Net effect: every legacy extension that pulls in any `node_modules` dep failed to load on Windows. Repro is `bunx supipowers` → restart `omp` → no `/supi:*` commands appear; the OMP log shows:

```
Failed to load extension: ResolveMessage: Cannot find package '...'
  path: ...\supipowers\src\index.ts
  from: ...\AppData\Local\Temp\omp-legacy-pi-file\<hash>\<entry>.ts
```

## How

`isUrlLikeSpecifier` now rejects `^[A-Za-z]:[\\/]` before the URL-scheme test, so Windows absolute paths flow through `url.pathToFileURL` like every other absolute path and reach the mirror as proper `file:///C:/...` URLs — same shape the relative-import path was already producing.

Unix is unaffected — Unix absolute paths start with `/`, which already misses the drive-letter regex.

## Testing

- `bunx biome check packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` → OK
- `bun --cwd=packages/coding-agent run check:types` → clean
- Manual Windows repro on `omp` 15.0.2 + `supipowers` 2.2.0: patched the file in place (`C:\Users\<me>\.bun\install\global\node_modules\@oh-my-pi\pi-coding-agent\src\extensibility\plugins\legacy-pi-compat.ts`), cleared `%TEMP%\omp-legacy-pi-file`, restarted OMP — `/supi:*` commands now register; the mirrored shim contains `import x from "file:///C:/Users/.../node_modules/yaml/dist/index.js"` as expected.

Happy to add a unit test that exports `isUrlLikeSpecifier` (or asserts on `loadLegacyPiModule`'s mirror output) if you'd like the regression covered — skipped here per AGENTS.md guidance on tiny low-risk fixes.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
