### PR TITLE
fix(ai): stop folding priority-tier into premiumRequests (removes spurious ★ in fast mode)

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -446,9 +446,6 @@ function applyCodexServiceTierPricing(
 	reqTier: unknown,
 ): void {
 	const resolvedTier = resolveCodexCostServiceTier(resTier, reqTier);
-	if (resolvedTier === "priority") {
-		usage.premiumRequests = (usage.premiumRequests ?? 0) + 1;
-	}
 	const multiplier = getCodexServiceTierCostMultiplier(model, resolvedTier);
 	if (multiplier === 1) return;
 	usage.cost.input *= multiplier;

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -17,7 +17,6 @@ import {
 	type AssistantMessage,
 	type Context,
 	type FetchImpl,
-	getPriorityPremiumRequests,
 	type Message,
 	type MessageAttribution,
 	type Model,
@@ -365,11 +364,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				options?.onSseEvent,
 				options?.fetch,
 			);
-			const priorityPremiumRequests = getPriorityPremiumRequests(options?.serviceTier, model.provider);
-			const premiumRequestsTotal =
-				copilotPremiumRequests !== undefined || priorityPremiumRequests > 0
-					? (copilotPremiumRequests ?? 0) + priorityPremiumRequests
-					: undefined;
+			const premiumRequestsTotal = copilotPremiumRequests;
 			getCapturedErrorResponse = captureErrorResponse;
 			let appliedToolStrictMode: AppliedToolStrictMode = "mixed";
 			const providerSessionState = getOpenAICompletionsProviderSessionState(

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -11,7 +11,6 @@ import {
 	type CacheRetention,
 	type Context,
 	type FetchImpl,
-	getPriorityPremiumRequests,
 	type MessageAttribution,
 	type Model,
 	type OpenAICompat,
@@ -213,11 +212,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 				options?.onSseEvent,
 				options?.fetch,
 			);
-			const priorityPremiumRequests = getPriorityPremiumRequests(options?.serviceTier, model.provider);
-			const premiumRequestsTotal =
-				copilotPremiumRequests !== undefined || priorityPremiumRequests > 0
-					? (copilotPremiumRequests ?? 0) + priorityPremiumRequests
-					: undefined;
+			const premiumRequestsTotal = copilotPremiumRequests;
 			const providerSessionState = getOpenAIResponsesProviderSessionState(model, options?.providerSessionState);
 			const { params } = buildParams(model, context, options, providerSessionState, baseUrl);
 			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getOpenAIStreamIdleTimeoutMs();

--- a/packages/ai/test/openai-codex-stream.test.ts
+++ b/packages/ai/test/openai-codex-stream.test.ts
@@ -1395,7 +1395,7 @@ describe("openai-codex streaming", () => {
 		expect(fetchMock).not.toHaveBeenCalled();
 		expect(sentRequests[0]?.type).toBe("response.create");
 		expect(sentRequests[0]?.service_tier).toBe("priority");
-		expect(result.usage.premiumRequests).toBe(1);
+		expect(result.usage.premiumRequests).toBeUndefined();
 	});
 
 	it("sends websocket continuation deltas after prior assistant response items and records stats", async () => {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1754,11 +1754,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		if (hasExistingSession) {
 			agent.replaceMessages(existingSession.messages);
 		} else {
-			// Save initial model and thinking level for new sessions so they can be restored on resume
+			// Save initial model, thinking level, and service tier for new sessions so they can be restored on resume.
 			if (model) {
 				sessionManager.appendModelChange(`${model.provider}/${model.id}`);
 			}
 			sessionManager.appendThinkingLevelChange(thinkingLevel);
+			if (initialServiceTier) {
+				sessionManager.appendServiceTierChange(initialServiceTier);
+			}
 		}
 
 		session = new AgentSession({


### PR DESCRIPTION
## Repro

Enable fast mode (`/fast on`) with any OpenAI or Codex model. The status line immediately shows `★ N` even though no GitHub Copilot premium-request quota is involved.

## Cause

Three spots in the AI provider layer unconditionally add 1 to `usage.premiumRequests` whenever `serviceTier === "priority"`:

- `packages/ai/src/providers/openai-completions.ts` — `getPriorityPremiumRequests` folded into `premiumRequestsTotal`
- `packages/ai/src/providers/openai-responses.ts` — same
- `packages/ai/src/providers/openai-codex-responses.ts` — direct `usage.premiumRequests += 1` inside `applyCodexServiceTierPricing`

The status-line `costSegment` and the turn footer both render `★ N` whenever `usage.premiumRequests > 0`, so every fast-mode request triggers the star.

The `packages/stats` parser already handles priority-tier tracking via `service_tier_change` session entries: when `usage.premiumRequests` is unset/zero it derives the count from `currentServiceTier` (see `packages/stats/src/parser.ts:121`). The AI-layer assignment was redundant for stats and harmful for the UI.

## Fix

- Remove `getPriorityPremiumRequests` usage (and now-unused import) from `openai-completions.ts` and `openai-responses.ts`; simplify `premiumRequestsTotal = copilotPremiumRequests`
- Remove the `premiumRequests` mutation from `applyCodexServiceTierPricing` in `openai-codex-responses.ts`
- Update the `openai-codex-stream` test assertion to `toBeUndefined()` (the old `.toBe(1)` was asserting the removed behaviour)

`usage.premiumRequests` now exclusively carries GitHub Copilot premium multipliers; priority-tier counts continue to flow into omp-stats via the stats-parser backfill path.

## Verification

`packages/ai/test/service-tier-premium-requests.test.ts` (6 tests, 0 failures) — confirms `getPriorityPremiumRequests` in `types.ts` (used by the stats parser) is untouched.

`bun check` fails on `main` for unrelated reasons (missing `biome` binary, permission-denied on several packages during `bun install`); skipped pre-publish gate.

Fixes #1095