### PR TITLE
fix(coding-agent): clarified pipe separator in read/search tool prompts

### DIFF
--- a/packages/coding-agent/src/prompts/tools/read.md
+++ b/packages/coding-agent/src/prompts/tools/read.md
@@ -28,7 +28,7 @@ Append `:<sel>` to `path`. The bare path falls back to the default mode.
 
 - Reading a directory path returns a depth-limited dirent listing.
 {{#if IS_HL_MODE}}
-- Reading a file with an explicit selector returns lines prefixed with `line+hash` anchors: `41th|def alpha():`. The 2-char hash is a content fingerprint that `edit` / `apply_patch` consume — copy it verbatim, NEVER fabricate.
+- Reading a file with an explicit selector returns lines prefixed with `line+hash` anchors: `41th|def alpha():`. The 2-char hash is a content fingerprint that `edit` / `apply_patch` consume — copy it verbatim, NEVER fabricate. The pipe character after the hash is a separator, not part of the file content.
 {{else}}
 {{#if IS_LINE_NUMBER_MODE}}
 - Reading a file with an explicit selector returns lines prefixed with line numbers: `41|def alpha():`.

--- a/packages/coding-agent/src/prompts/tools/search.md
+++ b/packages/coding-agent/src/prompts/tools/search.md
@@ -8,7 +8,7 @@ Searches files using powerful regex matching.
 
 <output>
 {{#if IS_HL_MODE}}
-- Text output is anchor-prefixed: `*5th|content` (match) or ` 9x}|content` (context, leading space). The 2-char suffix is a content fingerprint.
+- Text output is anchor-prefixed: `*5th|content` (match) or ` 9x}|content` (context, leading space). The 2-char suffix is a content fingerprint. The `|` before content is a separator, not part of the file content.
 {{else}}
 {{#if IS_LINE_NUMBER_MODE}}
 - Text output is line-number-prefixed


### PR DESCRIPTION
## Problem

When using the `read` tool with a line range selector (e.g. `path:5-10`), every line is prefixed with a hashline anchor in the format:

```
LINENUM+HASH|<actual line content>
```

The `|` after the hash is a **separator**, not part of the file content. When file content starts with `|` (markdown tables, YAML block scalars, shell pipes, etc.), the separator merges with the content producing an ambiguous `||` prefix:

```
read("table.md:1")  →  1ab|| A | B |
```

The file actually contains `| A | B |` (single pipe), but the output shows `|| A | B |` (triple pipe). There is no reliable way to determine where the anchor ends and content begins.

## Impact

- Markdown table rows starting with `|` are visually corrupted in range output
- YAML block scalars (`|`) are corrupted
- Shell scripts with pipes are affected
- `edit` tool anchors reference these corrupted lines, making surgical edits to table rows error-prone

## Fix

Added clarification to both the `read` and `search` tool prompts informing the model that the pipe after the hash is a structural separator, not part of the file content. The `edit` tool already has this clarification (`hashline.md` line 140: "NEVER include the `|TEXT` body").

This requires zero code changes. The model just needs to know to treat the `|` as a delimiter when parsing read/search output for use in edits.

## Files Changed

- `packages/coding-agent/src/prompts/tools/read.md` — added separator note to hashline mode description
- `packages/coding-agent/src/prompts/tools/search.md` — added separator note to hashline mode output description