### PR TITLE
fix(coding-agent): disable interactive pty on windows

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Fixed bash tool calls with `pty: true` hanging indefinitely on Windows by falling back to the non-PTY executor instead of entering the ConPTY-backed interactive path. ([#1103](https://github.com/can1357/oh-my-pi/issues/1103))
 
 ## [15.1.0] - 2026-05-15
 ### Breaking Changes

--- a/packages/coding-agent/src/tools/bash-pty-selection.ts
+++ b/packages/coding-agent/src/tools/bash-pty-selection.ts
@@ -1,0 +1,14 @@
+import { $env } from "@oh-my-pi/pi-utils/env";
+
+/** Minimal UI-capability fields needed to decide whether bash can use the local PTY overlay. */
+export interface BashPtyContext {
+	hasUI?: boolean;
+	ui?: unknown;
+}
+
+/** Return whether a bash tool call should use the local interactive PTY overlay. */
+export function canUseInteractiveBashPty(pty: boolean, ctx: BashPtyContext | undefined): boolean {
+	if (!pty) return false;
+	if (process.platform === "win32") return false;
+	return $env.PI_NO_PTY !== "1" && ctx?.hasUI === true && ctx.ui !== undefined;
+}

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -2,7 +2,7 @@ import * as fs from "node:fs";
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { ImageProtocol, TERMINAL, Text } from "@oh-my-pi/pi-tui";
-import { $env, getProjectDir, isEnoent, logger, prompt } from "@oh-my-pi/pi-utils";
+import { getProjectDir, isEnoent, logger, prompt } from "@oh-my-pi/pi-utils";
 import * as z from "zod/v4";
 import { AsyncJobManager } from "../async";
 import { type BashResult, executeBash } from "../exec/bash-executor";
@@ -20,6 +20,7 @@ import type { ToolSession } from ".";
 import { applyBashFixups, formatBashFixupNotice } from "./bash-command-fixup";
 import { type BashInteractiveResult, runInteractiveBashPty } from "./bash-interactive";
 import { checkBashInterception } from "./bash-interceptor";
+import { canUseInteractiveBashPty } from "./bash-pty-selection";
 import { expandInternalUrls, type InternalUrlExpansionOptions } from "./bash-skill-urls";
 import { formatStyledTruncationWarning, type OutputMeta, stripOutputNotice } from "./output-meta";
 import { resolveToCwd } from "./path-utils";
@@ -807,9 +808,9 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		// Allocate artifact for truncated output storage
 		const { path: artifactPath, id: artifactId } = (await this.session.allocateOutputArtifact?.("bash")) ?? {};
 
-		const usePty = pty && $env.PI_NO_PTY !== "1" && ctx?.hasUI === true && ctx.ui !== undefined;
-		const result: BashResult | BashInteractiveResult = usePty
-			? await runInteractiveBashPty(ctx.ui!, {
+		const interactiveUi = canUseInteractiveBashPty(pty, ctx) ? ctx?.ui : undefined;
+		const result: BashResult | BashInteractiveResult = interactiveUi
+			? await runInteractiveBashPty(interactiveUi, {
 					command,
 					cwd: commandCwd,
 					timeoutMs,

--- a/packages/coding-agent/test/tools/bash-pty-selection.test.ts
+++ b/packages/coding-agent/test/tools/bash-pty-selection.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { canUseInteractiveBashPty } from "@oh-my-pi/pi-coding-agent/tools/bash-pty-selection";
+
+const originalPlatform = process.platform;
+const originalNoPty = Bun.env.PI_NO_PTY;
+
+function setPlatform(platform: NodeJS.Platform): void {
+	Object.defineProperty(process, "platform", {
+		value: platform,
+		configurable: true,
+		writable: true,
+	});
+}
+
+function restorePlatform(): void {
+	Object.defineProperty(process, "platform", {
+		value: originalPlatform,
+		configurable: true,
+		writable: true,
+	});
+}
+
+function setNoPty(value: string | undefined): void {
+	if (value === undefined) {
+		delete Bun.env.PI_NO_PTY;
+		return;
+	}
+	Bun.env.PI_NO_PTY = value;
+}
+
+function interactiveContext() {
+	return { hasUI: true, ui: {} };
+}
+
+describe("bash PTY selection", () => {
+	afterEach(() => {
+		restorePlatform();
+		setNoPty(originalNoPty);
+	});
+
+	it("disables interactive PTY on Windows even when requested with UI", () => {
+		setPlatform("win32");
+		setNoPty(undefined);
+
+		expect(canUseInteractiveBashPty(true, interactiveContext())).toBe(false);
+	});
+
+	it("allows interactive PTY on non-Windows only when requested with UI and not disabled", () => {
+		setPlatform("linux");
+		setNoPty(undefined);
+
+		expect(canUseInteractiveBashPty(true, interactiveContext())).toBe(true);
+		expect(canUseInteractiveBashPty(false, interactiveContext())).toBe(false);
+		expect(canUseInteractiveBashPty(true, undefined)).toBe(false);
+
+		setNoPty("1");
+		expect(canUseInteractiveBashPty(true, interactiveContext())).toBe(false);
+	});
+});


### PR DESCRIPTION
## Repro
`bash` tool calls with `{ "command": "echo hello", "pty": true, "timeout": 5 }` on Windows enter the interactive PTY path and never complete, while the same command without `pty` returns `hello` immediately. I traced the tool-call path from `BashTool.execute` to `runInteractiveBashPty` and recorded the reproduction against #1103.

## Cause
`packages/coding-agent/src/tools/bash.ts` selected PTY execution whenever `pty === true`, `PI_NO_PTY !== "1"`, and a UI context existed. That sent Windows tool calls into `packages/coding-agent/src/tools/bash-interactive.ts`, where the ConPTY-backed native `PtySession.start()` promise can remain pending indefinitely, so the tool timeout never surfaced through the normal non-PTY executor.

## Fix
- Added `canUseInteractiveBashPty()` to centralize PTY eligibility and make Windows return `false`.
- Updated `BashTool.execute` to use that gate and fall back to `executeBash()` on Windows.
- Added regression coverage for the Windows fallback plus the existing non-Windows UI and `PI_NO_PTY` gates.
- Added a changelog entry for the Windows PTY hang fix.

## Verification
- `bun run test test/tools/bash-pty-selection.test.ts` from `packages/coding-agent` passed: 2 tests, 5 assertions.
- `bun run check:ts` passed across workspace packages.
- `gh_push_branch` pre-publish gate passed and pushed `farm/cdace73b/fix-windows-pty-bash-hang` at `4f92c605231f`.

Fixes #1103