### PR TITLE
fix: clear Kitty protocol images on /drop and /clear

### DIFF
--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -10,7 +10,7 @@ import {
 	type UsageLimit,
 	type UsageReport,
 } from "@oh-my-pi/pi-ai";
-import { Loader, Markdown, padding, Spacer, Text, visibleWidth } from "@oh-my-pi/pi-tui";
+import { Loader, Markdown, padding, Spacer, Text, visibleWidth, TERMINAL, ImageProtocol } from "@oh-my-pi/pi-tui";
 import { formatDuration, Snowflake, setProjectDir } from "@oh-my-pi/pi-utils";
 import { $ } from "bun";
 import { reset as resetCapabilities } from "../../capability";
@@ -880,6 +880,14 @@ export class CommandController {
 		this.ctx.updateEditorTopBorder();
 		this.ctx.updateEditorBorderColor();
 		this.ctx.ui.requestRender();
+
+		// Clear terminal-rendered images before removing components.
+		// Kitty protocol images float above the character grid and persist
+		// after text is cleared; send an explicit "delete all" command.
+		// This affects Kitty, Ghostty, WezTerm and other Kitty-compatible terminals.
+		if (TERMINAL.imageProtocol === ImageProtocol.Kitty) {
+			this.ctx.ui.terminal.write("\x1b_Ga=d\x1b\\");
+		}
 
 		this.ctx.chatContainer.clear();
 		this.ctx.pendingMessagesContainer.clear();


### PR DESCRIPTION
## Problem

When using `/drop` or `/clear` (which both go through `#runNewSessionFlow`) in terminals that use the Kitty graphics protocol (Kitty, Ghostty, WezTerm, etc.), previously rendered images persist on screen as ghost artifacts.

This happens because `chatContainer.clear()` only removes `Image` components from the TUI render tree — it does **not** send any protocol-level image deletion commands to the terminal emulator.

Kitty protocol images are rendered as floating placements above the character grid, independent of the text content. So even when the screen text is fully cleared, the image placements remain visible.

## Fix

Before calling `chatContainer.clear()`, detect if the terminal uses the Kitty graphics protocol and send the "delete all images" command (`ESC_Ga=d ESC\`). This is the standard Kitty graphics protocol command to remove all image placements from the terminal.

## Affected terminals

All terminals using the Kitty graphics protocol: Kitty, Ghostty, WezTerm, and others detected via `TERMINAL.imageProtocol === ImageProtocol.Kitty`.

## Testing

Tested on Ghostty with `mcli/gpt-5.4` — after `/drop`, images from the previous session are now properly cleared.
