### PR TITLE
fix(coding-agent): bound ACP cancel cleanup

### DIFF
--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -86,6 +86,7 @@ const SESSION_PAGE_SIZE = 50;
  * wait past this guard without hard-coding the literal.
  */
 export const ACP_BOOTSTRAP_RACE_GUARD_MS = 50;
+const ACP_CANCEL_CLEANUP_TIMEOUT_MS = 5_000;
 
 type AgentImageContent = {
 	type: "image";
@@ -102,6 +103,8 @@ type PromptTurnState = {
 	userMessageId: string;
 	cancelRequested: boolean;
 	settled: boolean;
+	cleanup: Promise<void> | undefined;
+	finishCleanup: (() => void) | undefined;
 	usageBaseline: UsageStatistics;
 	unsubscribe: (() => void) | undefined;
 	resolve: (value: PromptResponse) => void;
@@ -337,11 +340,16 @@ export class AcpAgent implements Agent {
 	#disposePromise: Promise<void> | undefined;
 	#cleanupRegistered = false;
 	#clientCapabilities: ClientCapabilities | undefined;
+	#cancelCleanupTimeoutMs = ACP_CANCEL_CLEANUP_TIMEOUT_MS;
 
 	constructor(connection: AgentSideConnection, initialSession: AgentSession, createSession: CreateAcpSession) {
 		this.#connection = connection;
 		this.#initialSession = initialSession;
 		this.#createSession = createSession;
+	}
+
+	setCancelCleanupTimeoutForTesting(timeoutMs: number): void {
+		this.#cancelCleanupTimeoutMs = Math.max(1, timeoutMs);
 	}
 
 	async initialize(params: InitializeRequest): Promise<InitializeResponse> {
@@ -547,8 +555,9 @@ export class AcpAgent implements Agent {
 		}
 		return await this.#queuePrompt(record, async () => {
 			const queuedTurn = record.promptTurn;
-			if (queuedTurn && !queuedTurn.settled) {
+			if (queuedTurn && (!queuedTurn.settled || queuedTurn.cleanup)) {
 				await queuedTurn.promise.catch(() => undefined);
+				await queuedTurn.cleanup?.catch(() => undefined);
 			}
 
 			const converted = this.#convertPromptBlocks(params.prompt);
@@ -557,6 +566,8 @@ export class AcpAgent implements Agent {
 				userMessageId: params.messageId ?? crypto.randomUUID(),
 				cancelRequested: false,
 				settled: false,
+				cleanup: undefined,
+				finishCleanup: undefined,
 				usageBaseline: this.#cloneUsageStatistics(record.session.sessionManager.getUsageStatistics()),
 				unsubscribe: undefined,
 				resolve: pendingPrompt.resolve,
@@ -677,16 +688,41 @@ export class AcpAgent implements Agent {
 			return;
 		}
 		promptTurn.cancelRequested = true;
+		promptTurn.unsubscribe?.();
+		const cleanup = this.#startCancelledPromptCleanup(record, promptTurn);
+		this.#finishPrompt(record, {
+			stopReason: "cancelled",
+			usage: this.#buildTurnUsage(promptTurn.usageBaseline, record.session.sessionManager.getUsageStatistics()),
+			userMessageId: promptTurn.userMessageId,
+		});
 		try {
-			await record.session.abort();
-			this.#finishPrompt(record, {
-				stopReason: "cancelled",
-				usage: this.#buildTurnUsage(promptTurn.usageBaseline, record.session.sessionManager.getUsageStatistics()),
-				userMessageId: promptTurn.userMessageId,
-			});
+			await cleanup;
 		} catch (error: unknown) {
-			this.#finishPrompt(record, undefined, error);
+			logger.warn("ACP cancel cleanup timed out; closing session", { sessionId: record.session.sessionId, error });
+			await this.#closeManagedSession(record.session.sessionId, record);
 		}
+	}
+
+	async #startCancelledPromptCleanup(record: ManagedSessionRecord, promptTurn: PromptTurnState): Promise<void> {
+		if (promptTurn.cleanup) {
+			return await promptTurn.cleanup;
+		}
+		const cleanup = (async () => {
+			try {
+				await Promise.race([
+					record.session.abort(),
+					Bun.sleep(this.#cancelCleanupTimeoutMs).then(() => {
+						throw new Error("ACP cancel cleanup timed out");
+					}),
+				]);
+			} finally {
+				promptTurn.cleanup = undefined;
+				promptTurn.finishCleanup?.();
+				promptTurn.finishCleanup = undefined;
+			}
+		})();
+		promptTurn.cleanup = cleanup;
+		return await cleanup;
 	}
 
 	async extMethod(method: string, params: { [key: string]: unknown }): Promise<{ [key: string]: unknown }> {
@@ -950,7 +986,7 @@ export class AcpAgent implements Agent {
 
 	async #handlePromptEvent(record: ManagedSessionRecord, event: AgentSessionEvent): Promise<void> {
 		const promptTurn = record.promptTurn;
-		if (!promptTurn || promptTurn.settled) {
+		if (!promptTurn || promptTurn.settled || promptTurn.cancelRequested) {
 			return;
 		}
 
@@ -1019,7 +1055,15 @@ export class AcpAgent implements Agent {
 		}
 		promptTurn.settled = true;
 		promptTurn.unsubscribe?.();
-		record.promptTurn = undefined;
+		if (promptTurn.cleanup) {
+			promptTurn.finishCleanup = () => {
+				if (record.promptTurn === promptTurn) {
+					record.promptTurn = undefined;
+				}
+			};
+		} else {
+			record.promptTurn = undefined;
+		}
 		if (error !== undefined) {
 			promptTurn.reject(error);
 			return;
@@ -1893,16 +1937,17 @@ export class AcpAgent implements Agent {
 
 		promptTurn.cancelRequested = true;
 		promptTurn.unsubscribe?.();
-		try {
-			await record.session.abort();
-		} catch (error) {
-			logger.warn("Failed to abort ACP prompt during session close", { error });
-		}
+		const cleanup = this.#startCancelledPromptCleanup(record, promptTurn);
 		this.#finishPrompt(record, {
 			stopReason: "cancelled",
 			usage: this.#buildTurnUsage(promptTurn.usageBaseline, record.session.sessionManager.getUsageStatistics()),
 			userMessageId: promptTurn.userMessageId,
 		});
+		try {
+			await cleanup;
+		} catch (error) {
+			logger.warn("Failed to abort ACP prompt during session close", { error });
+		}
 	}
 
 	async #disposeSessionRecord(record: ManagedSessionRecord): Promise<void> {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -103,14 +103,29 @@ type PromptTurnState = {
 	userMessageId: string;
 	cancelRequested: boolean;
 	settled: boolean;
+	/**
+	 * `abort()` is in-flight (or its bounded-timeout race). `undefined` while the turn is
+	 * running normally and after cleanup completes. The turn occupies `record.promptTurn`
+	 * for as long as either `!settled` or `cleanup` is set — that combined window is the
+	 * "turn in flight" predicate (`isPromptTurnInFlight`) every consumer gates on.
+	 */
 	cleanup: Promise<void> | undefined;
-	finishCleanup: (() => void) | undefined;
 	usageBaseline: UsageStatistics;
 	unsubscribe: (() => void) | undefined;
 	resolve: (value: PromptResponse) => void;
 	reject: (reason?: unknown) => void;
 	promise: Promise<PromptResponse>;
 };
+
+/**
+ * A turn is "in flight" from the moment `prompt()` reserves the slot until `settled` is
+ * true AND any cancel cleanup has completed. Fork/queue/event gating all depend on this
+ * combined window — a settled-but-still-aborting turn is not safe to fork from, queue
+ * onto, or forward late events for.
+ */
+function isPromptTurnInFlight(turn: PromptTurnState | undefined): turn is PromptTurnState {
+	return turn !== undefined && (!turn.settled || turn.cleanup !== undefined);
+}
 
 type ManagedSessionRecord = {
 	session: AgentSession;
@@ -554,10 +569,15 @@ export class AcpAgent implements Agent {
 			throw new Error("ACP prompt already in progress for this session");
 		}
 		return await this.#queuePrompt(record, async () => {
-			const queuedTurn = record.promptTurn;
-			if (queuedTurn && (!queuedTurn.settled || queuedTurn.cleanup)) {
-				await queuedTurn.promise.catch(() => undefined);
-				await queuedTurn.cleanup;
+			const previousTurn = record.promptTurn;
+			if (previousTurn) {
+				// Wait for any prompt that's still settling or whose cancel cleanup is
+				// still in flight. We deliberately swallow the prompt rejection (the
+				// owning caller already received it) but let cleanup rejections
+				// propagate — a timed-out cancel must fail this queued prompt instead
+				// of letting it run on a session that is about to be closed.
+				await previousTurn.promise.catch(() => undefined);
+				await previousTurn.cleanup;
 			}
 
 			const converted = this.#convertPromptBlocks(params.prompt);
@@ -567,7 +587,6 @@ export class AcpAgent implements Agent {
 				cancelRequested: false,
 				settled: false,
 				cleanup: undefined,
-				finishCleanup: undefined,
 				usageBaseline: this.#cloneUsageStatistics(record.session.sessionManager.getUsageStatistics()),
 				unsubscribe: undefined,
 				resolve: pendingPrompt.resolve,
@@ -687,14 +706,7 @@ export class AcpAgent implements Agent {
 		if (!promptTurn || promptTurn.settled) {
 			return;
 		}
-		promptTurn.cancelRequested = true;
-		promptTurn.unsubscribe?.();
-		const cleanup = this.#startCancelledPromptCleanup(record, promptTurn);
-		this.#finishPrompt(record, {
-			stopReason: "cancelled",
-			usage: this.#buildTurnUsage(promptTurn.usageBaseline, record.session.sessionManager.getUsageStatistics()),
-			userMessageId: promptTurn.userMessageId,
-		});
+		const cleanup = this.#beginCancelCleanup(record, promptTurn);
 		try {
 			await cleanup;
 		} catch (error: unknown) {
@@ -703,26 +715,45 @@ export class AcpAgent implements Agent {
 		}
 	}
 
-	async #startCancelledPromptCleanup(record: ManagedSessionRecord, promptTurn: PromptTurnState): Promise<void> {
+	/**
+	 * Transition a still-running turn into cancellation: mark intent, drop the live-event
+	 * subscription, start the bounded `abort()` race, and resolve the ACP prompt response
+	 * with `stopReason: "cancelled"` so the client sees acceptance immediately. The
+	 * returned promise is the cleanup barrier — it resolves when `abort()` completes and
+	 * rejects when the timeout fires. Idempotent: a second call returns the same barrier.
+	 */
+	#beginCancelCleanup(record: ManagedSessionRecord, promptTurn: PromptTurnState): Promise<void> {
 		if (promptTurn.cleanup) {
-			return await promptTurn.cleanup;
+			return promptTurn.cleanup;
 		}
-		const cleanup = (async () => {
-			try {
-				await Promise.race([
-					record.session.abort(),
-					Bun.sleep(this.#cancelCleanupTimeoutMs).then(() => {
-						throw new Error("ACP cancel cleanup timed out");
-					}),
-				]);
-			} finally {
-				promptTurn.cleanup = undefined;
-				promptTurn.finishCleanup?.();
-				promptTurn.finishCleanup = undefined;
-			}
-		})();
+		promptTurn.cancelRequested = true;
+		promptTurn.unsubscribe?.();
+		const cleanup = this.#runCancelCleanup(record, promptTurn);
 		promptTurn.cleanup = cleanup;
-		return await cleanup;
+		this.#finishPrompt(record, {
+			stopReason: "cancelled",
+			usage: this.#buildTurnUsage(promptTurn.usageBaseline, record.session.sessionManager.getUsageStatistics()),
+			userMessageId: promptTurn.userMessageId,
+		});
+		return cleanup;
+	}
+
+	async #runCancelCleanup(record: ManagedSessionRecord, promptTurn: PromptTurnState): Promise<void> {
+		let timer: NodeJS.Timeout | undefined;
+		const timeout = new Promise<never>((_, reject) => {
+			timer = setTimeout(() => reject(new Error("ACP cancel cleanup timed out")), this.#cancelCleanupTimeoutMs);
+		});
+		try {
+			await Promise.race([record.session.abort(), timeout]);
+		} finally {
+			if (timer) clearTimeout(timer);
+			// Order matters: clear `cleanup` before evicting the slot so the slot-eviction
+			// branch matches what `#finishPrompt` saw if it ran first.
+			promptTurn.cleanup = undefined;
+			if (promptTurn.settled && record.promptTurn === promptTurn) {
+				record.promptTurn = undefined;
+			}
+		}
 	}
 
 	async extMethod(method: string, params: { [key: string]: unknown }): Promise<{ [key: string]: unknown }> {
@@ -965,8 +996,7 @@ export class AcpAgent implements Agent {
 	async #resolveForkSourceSessionPath(sessionId: string): Promise<string> {
 		const loaded = this.#sessions.get(sessionId);
 		if (loaded) {
-			const promptTurn = loaded.promptTurn;
-			if (promptTurn && !promptTurn.settled) {
+			if (isPromptTurnInFlight(loaded.promptTurn)) {
 				throw new Error(`ACP session fork is unavailable while a prompt is in progress: ${sessionId}`);
 			}
 			await loaded.session.sessionManager.flush();
@@ -1055,13 +1085,9 @@ export class AcpAgent implements Agent {
 		}
 		promptTurn.settled = true;
 		promptTurn.unsubscribe?.();
-		if (promptTurn.cleanup) {
-			promptTurn.finishCleanup = () => {
-				if (record.promptTurn === promptTurn) {
-					record.promptTurn = undefined;
-				}
-			};
-		} else {
+		// Keep the slot occupied until cancel cleanup finishes — `#runCancelCleanup`
+		// evicts the slot in its finally block once both flags say it's safe.
+		if (!promptTurn.cleanup && record.promptTurn === promptTurn) {
 			record.promptTurn = undefined;
 		}
 		if (error !== undefined) {
@@ -1931,29 +1957,10 @@ export class AcpAgent implements Agent {
 
 	async #cancelPromptForClose(record: ManagedSessionRecord): Promise<void> {
 		const promptTurn = record.promptTurn;
-		if (!promptTurn) {
+		if (!isPromptTurnInFlight(promptTurn)) {
 			return;
 		}
-		if (promptTurn.cleanup) {
-			try {
-				await promptTurn.cleanup;
-			} catch (error) {
-				logger.warn("Failed to abort ACP prompt during session close", { error });
-			}
-			return;
-		}
-		if (promptTurn.settled) {
-			return;
-		}
-
-		promptTurn.cancelRequested = true;
-		promptTurn.unsubscribe?.();
-		const cleanup = this.#startCancelledPromptCleanup(record, promptTurn);
-		this.#finishPrompt(record, {
-			stopReason: "cancelled",
-			usage: this.#buildTurnUsage(promptTurn.usageBaseline, record.session.sessionManager.getUsageStatistics()),
-			userMessageId: promptTurn.userMessageId,
-		});
+		const cleanup = promptTurn.cleanup ?? this.#beginCancelCleanup(record, promptTurn);
 		try {
 			await cleanup;
 		} catch (error) {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -557,7 +557,7 @@ export class AcpAgent implements Agent {
 			const queuedTurn = record.promptTurn;
 			if (queuedTurn && (!queuedTurn.settled || queuedTurn.cleanup)) {
 				await queuedTurn.promise.catch(() => undefined);
-				await queuedTurn.cleanup?.catch(() => undefined);
+				await queuedTurn.cleanup;
 			}
 
 			const converted = this.#convertPromptBlocks(params.prompt);

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1931,7 +1931,18 @@ export class AcpAgent implements Agent {
 
 	async #cancelPromptForClose(record: ManagedSessionRecord): Promise<void> {
 		const promptTurn = record.promptTurn;
-		if (!promptTurn || promptTurn.settled) {
+		if (!promptTurn) {
+			return;
+		}
+		if (promptTurn.cleanup) {
+			try {
+				await promptTurn.cleanup;
+			} catch (error) {
+				logger.warn("Failed to abort ACP prompt during session close", { error });
+			}
+			return;
+		}
+		if (promptTurn.settled) {
 			return;
 		}
 

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1035,6 +1035,97 @@ describe("ACP agent", () => {
 		}
 	});
 
+	it("suppresses late updates after cancel and waits cleanup before the next prompt", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		let releaseAbort!: () => void;
+		const abortBlocked = Promise.withResolvers<void>();
+		const releaseAbortPromise = new Promise<void>(resolve => {
+			releaseAbort = resolve;
+		});
+		session.abort = async () => {
+			session.isStreaming = false;
+			abortBlocked.resolve();
+			await releaseAbortPromise;
+		};
+		const finishPrompt = holdPromptStreaming(session);
+
+		const firstPrompt = harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000039",
+			prompt: [{ type: "text", text: "cancel me" }],
+		} as PromptRequest);
+		await Bun.sleep(0);
+		const beforeCancelUpdates = harness.updates.length;
+
+		const cancelPrompt = harness.agent.cancel({ sessionId: created.sessionId });
+		await abortBlocked.promise;
+		const returnedBeforeCleanup = await Promise.race([firstPrompt.then(() => true), Bun.sleep(0).then(() => false)]);
+		expect(returnedBeforeCleanup).toBe(true);
+		const cancelledResponse = await firstPrompt;
+		expect(cancelledResponse.stopReason).toBe("cancelled");
+
+		for (const listener of session.listeners()) {
+			listener({
+				type: "message_update",
+				message: makeAssistantMessage("late"),
+				assistantMessageEvent: { type: "text_delta", delta: "late" },
+			} as AgentSessionEvent);
+		}
+		expect(harness.updates).toHaveLength(beforeCancelUpdates);
+
+		const secondPrompt = harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000040",
+			prompt: [{ type: "text", text: "after cancel" }],
+		} as PromptRequest);
+		await Bun.sleep(0);
+		expect(session.promptCalls).toEqual(["cancel me"]);
+
+		releaseAbort();
+		await cancelPrompt;
+		finishPrompt();
+		await secondPrompt;
+		expect(session.promptCalls).toEqual(["cancel me", "after cancel"]);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("closes the ACP session when cancel cleanup times out", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		harness.agent.setCancelCleanupTimeoutForTesting(10);
+		session.abort = async () => new Promise<void>(() => undefined);
+		const finishPrompt = holdPromptStreaming(session);
+
+		const firstPrompt = harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000041",
+			prompt: [{ type: "text", text: "stuck cancel" }],
+		} as PromptRequest);
+		await Bun.sleep(0);
+
+		const cancelPrompt = harness.agent.cancel({ sessionId: created.sessionId });
+		const returnedBeforeTimeout = await Promise.race([firstPrompt.then(() => true), Bun.sleep(0).then(() => false)]);
+		expect(returnedBeforeTimeout).toBe(true);
+		await expect(cancelPrompt).resolves.toBeUndefined();
+		expect(session.disposed).toBe(true);
+		await expect(
+			harness.agent.prompt({
+				sessionId: created.sessionId,
+				messageId: "00000000-0000-4000-8000-000000000042",
+				prompt: [{ type: "text", text: "after stuck cancel" }],
+			} as PromptRequest),
+		).rejects.toThrow("Unsupported ACP session");
+
+		finishPrompt();
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
 	it("executes consumed ACP builtins without prompting the agent", async () => {
 		const harness = await createHarness();
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1203,6 +1203,48 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("rejects fork while cancel cleanup is pending", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		let releaseAbort!: () => void;
+		const abortBlocked = Promise.withResolvers<void>();
+		const releaseAbortPromise = new Promise<void>(resolve => {
+			releaseAbort = resolve;
+		});
+		session.abort = async () => {
+			session.isStreaming = false;
+			abortBlocked.resolve();
+			await releaseAbortPromise;
+		};
+		const finishPrompt = holdPromptStreaming(session);
+
+		const firstPrompt = harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000046",
+			prompt: [{ type: "text", text: "cancel before fork" }],
+		} as PromptRequest);
+		await Bun.sleep(0);
+
+		const cancelPrompt = harness.agent.cancel({ sessionId: created.sessionId });
+		await abortBlocked.promise;
+		await firstPrompt;
+
+		await expect(
+			harness.agent.unstable_forkSession({
+				sessionId: created.sessionId,
+				cwd: harness.cwdA,
+				mcpServers: [],
+			}),
+		).rejects.toThrow("ACP session fork is unavailable while a prompt is in progress");
+
+		releaseAbort();
+		await cancelPrompt;
+		finishPrompt();
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
 	it("executes consumed ACP builtins without prompting the agent", async () => {
 		const harness = await createHarness();
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1126,6 +1126,42 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("rejects a queued prompt when cancel cleanup closes the session", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		harness.agent.setCancelCleanupTimeoutForTesting(10);
+		session.abort = async () => new Promise<void>(() => undefined);
+		const finishPrompt = holdPromptStreaming(session);
+
+		const firstPrompt = harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000043",
+			prompt: [{ type: "text", text: "stuck cancel before queued" }],
+		} as PromptRequest);
+		await Bun.sleep(0);
+
+		const cancelPrompt = harness.agent.cancel({ sessionId: created.sessionId });
+		await firstPrompt;
+		const queuedPrompt = harness.agent
+			.prompt({
+				sessionId: created.sessionId,
+				messageId: "00000000-0000-4000-8000-000000000044",
+				prompt: [{ type: "text", text: "queued after stuck cancel" }],
+			} as PromptRequest)
+			.catch(error => error);
+
+		await cancelPrompt;
+		const queuedError = await queuedPrompt;
+		expect(queuedError).toBeInstanceOf(Error);
+		expect(queuedError.message).toBe("ACP cancel cleanup timed out");
+		expect(session.promptCalls).toEqual(["stuck cancel before queued"]);
+
+		finishPrompt();
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
 	it("executes consumed ACP builtins without prompting the agent", async () => {
 		const harness = await createHarness();
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1162,6 +1162,47 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("keeps closeSession gated while cancel cleanup is pending", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		let releaseAbort!: () => void;
+		const abortBlocked = Promise.withResolvers<void>();
+		const releaseAbortPromise = new Promise<void>(resolve => {
+			releaseAbort = resolve;
+		});
+		session.abort = async () => {
+			session.isStreaming = false;
+			abortBlocked.resolve();
+			await releaseAbortPromise;
+		};
+		const finishPrompt = holdPromptStreaming(session);
+
+		const firstPrompt = harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000045",
+			prompt: [{ type: "text", text: "cancel before close" }],
+		} as PromptRequest);
+		await Bun.sleep(0);
+
+		const cancelPrompt = harness.agent.cancel({ sessionId: created.sessionId });
+		await abortBlocked.promise;
+		await firstPrompt;
+
+		const closePrompt = harness.agent.closeSession({ sessionId: created.sessionId });
+		await Bun.sleep(0);
+		expect(session.disposed).toBe(false);
+
+		releaseAbort();
+		await cancelPrompt;
+		await closePrompt;
+		expect(session.disposed).toBe(true);
+
+		finishPrompt();
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
 	it("executes consumed ACP builtins without prompting the agent", async () => {
 		const harness = await createHarness();
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });


### PR DESCRIPTION
Fixes #1113.

## Summary

- Return the ACP prompt response with `stopReason: "cancelled"` as soon as cancel is accepted.
- Keep the cancelled prompt turn tracked internally until abort cleanup completes.
- Suppress late runtime events after cancel by unsubscribing and ignoring cancelled turns.
- Serialize the next `session/prompt` behind the cancelled turn cleanup barrier.
- Close the ACP session if cancel cleanup exceeds the bounded cleanup timeout.

## Tests

- `bun test packages/coding-agent/test/acp-agent.test.ts --test-name-pattern "cancel|idle cleanup|overlapping prompts|queues next prompt"`
- `bun test packages/coding-agent/test/acp-agent.test.ts`
- `bun --cwd=packages/coding-agent run check`
