### PR TITLE
fix(discovery): stop agents provider from scanning ~/.agent[s]/ as project

### DIFF
--- a/packages/coding-agent/src/discovery/agents.ts
+++ b/packages/coding-agent/src/discovery/agents.ts
@@ -33,13 +33,24 @@ function getUserPathCandidates(ctx: LoadContext, ...segments: string[]): string[
 	return AGENT_DIR_CANDIDATES.map(baseDir => path.join(ctx.home, baseDir, ...segments));
 }
 
-/** Project-level paths: walk up from cwd to repoRoot, returning .agent/<segments> and .agents/<segments> at each level. */
-function getProjectPathCandidates(ctx: LoadContext, ...segments: string[]): string[] {
+/**
+ * Project-level paths: walk up from cwd to repoRoot, returning `.agent/<segments>`
+ * and `.agents/<segments>` at each ancestor.
+ *
+ * The user home directory is skipped: `~/.agent[s]/` is by definition
+ * user-level config and is already enumerated by {@link getUserPathCandidates}.
+ * Without this guard, any cwd under `$HOME` (with no closer git repoRoot) would
+ * walk up to home and yield duplicate project+user entries for the same
+ * directory — see https://github.com/can1357/oh-my-pi/issues/1116.
+ */
+export function getProjectPathCandidates(ctx: LoadContext, ...segments: string[]): string[] {
 	const paths: string[] = [];
 	let current = ctx.cwd;
 	while (true) {
-		for (const baseDir of AGENT_DIR_CANDIDATES) {
-			paths.push(path.join(current, baseDir, ...segments));
+		if (current !== ctx.home) {
+			for (const baseDir of AGENT_DIR_CANDIDATES) {
+				paths.push(path.join(current, baseDir, ...segments));
+			}
 		}
 		if (current === (ctx.repoRoot ?? ctx.home)) break;
 		const parent = path.dirname(current);

--- a/packages/coding-agent/test/discovery/agents-monorepo-skills.test.ts
+++ b/packages/coding-agent/test/discovery/agents-monorepo-skills.test.ts
@@ -13,6 +13,7 @@ import * as path from "node:path";
 import { clearCache, readFile } from "@oh-my-pi/pi-coding-agent/capability/fs";
 import type { Rule } from "@oh-my-pi/pi-coding-agent/capability/rule";
 import type { LoadContext } from "@oh-my-pi/pi-coding-agent/capability/types";
+import { getProjectPathCandidates } from "@oh-my-pi/pi-coding-agent/discovery/agents";
 import {
 	buildRuleFromMarkdown,
 	calculateDepth,
@@ -20,23 +21,7 @@ import {
 	scanSkillsFromDir,
 } from "@oh-my-pi/pi-coding-agent/discovery/helpers";
 
-const AGENT_DIR_CANDIDATES = [".agent", ".agents"] as const;
 const PROVIDER_ID = "agents";
-
-function getProjectPathCandidates(ctx: LoadContext, ...segments: string[]): string[] {
-	const paths: string[] = [];
-	let current = ctx.cwd;
-	while (true) {
-		for (const baseDir of AGENT_DIR_CANDIDATES) {
-			paths.push(path.join(current, baseDir, ...segments));
-		}
-		if (current === (ctx.repoRoot ?? ctx.home)) break;
-		const parent = path.dirname(current);
-		if (parent === current) break;
-		current = parent;
-	}
-	return paths;
-}
 
 function writeSkill(dir: string, name: string, description: string): void {
 	const skillDir = path.join(dir, name);
@@ -145,24 +130,40 @@ describe("agents provider project-level discovery", () => {
 			expect(names).not.toContain("above-repo-skill");
 		});
 
-		test("walk-up stops at home when no repo root", async () => {
-			// ctx without repoRoot
+		test("project walk-up skips home directory (no repo root)", async () => {
+			// Regression for https://github.com/can1357/oh-my-pi/issues/1116:
+			// when cwd is under $HOME and no closer repoRoot exists, the walk-up
+			// must NOT enumerate `~/.agent[s]/` as project paths — those belong
+			// to the user level and getUserPathCandidates already covers them.
 			const noRepoCtx: LoadContext = { cwd: subProject, home: repoRoot, repoRoot: null };
-			// Skill above home (should NOT be found)
+			// Skill above home (should NOT be found via project walk-up).
 			writeSkill(path.join(tempDir, ".agents", "skills"), "above-home-skill", "Above home");
-			// Skill at home (should be found)
+			// Skill *at* the home directory (must NOT be enumerated as project).
 			writeSkill(path.join(repoRoot, ".agents", "skills"), "home-skill", "At home");
+			// Skill at the sub-project (must still be found).
+			writeSkill(path.join(subProject, ".agents", "skills"), "local-skill", "Sub-project");
+
+			const candidates = getProjectPathCandidates(noRepoCtx, "skills");
+			expect(candidates).not.toContain(path.join(repoRoot, ".agent", "skills"));
+			expect(candidates).not.toContain(path.join(repoRoot, ".agents", "skills"));
 
 			const results = await Promise.all(
-				getProjectPathCandidates(noRepoCtx, "skills").map(dir =>
-					scanSkillsFromDir(noRepoCtx, { dir, providerId: PROVIDER_ID, level: "project" }),
-				),
+				candidates.map(dir => scanSkillsFromDir(noRepoCtx, { dir, providerId: PROVIDER_ID, level: "project" })),
 			);
 			const names = results.flatMap(r => r.items).map(s => s.name);
-			expect(names).toContain("home-skill");
+			expect(names).toContain("local-skill");
+			expect(names).not.toContain("home-skill");
 			expect(names).not.toContain("above-home-skill");
 		});
 
+		test("project and user candidates do not overlap when cwd is under home", () => {
+			// Regression for https://github.com/can1357/oh-my-pi/issues/1116.
+			const noRepoCtx: LoadContext = { cwd: subProject, home: repoRoot, repoRoot: null };
+			const project = getProjectPathCandidates(noRepoCtx, "skills");
+			const user = [".agent", ".agents"].map(b => path.join(repoRoot, b, "skills"));
+			const overlap = project.filter(p => user.includes(p));
+			expect(overlap).toEqual([]);
+		});
 		test("returns empty when no ancestor has skills", async () => {
 			const results = await Promise.all(
 				getProjectPathCandidates(ctx, "skills").map(dir =>


### PR DESCRIPTION
## Repro

With cwd anywhere under `$HOME` and no closer `.git` boundary (e.g. `cd ~/projects/foo`), the `agents` provider in `packages/coding-agent/src/discovery/agents.ts` enumerates `~/.agent/skills` and `~/.agents/skills` twice — once as **project** (via `getProjectPathCandidates`' walk-up to home), once as **user** (via `getUserPathCandidates`). The Extension Dashboard renders shadowed items, so users see one active and one greyed-out duplicate of every home-level skill, rule, prompt, command, and AGENTS.md.

Path simulation of the pre-fix logic with `cwd=/home/user/projects/foo`, `home=/home/user`, `repoRoot=null`:

```
project: [.../projects/foo/.agent, .../projects/foo/.agents,
          .../projects/.agent,     .../projects/.agents,
          /home/user/.agent,       /home/user/.agents]
user:    [/home/user/.agent,       /home/user/.agents]
overlap: [/home/user/.agent,       /home/user/.agents]   # the bug
```

## Cause

`getProjectPathCandidates` in `packages/coding-agent/src/discovery/agents.ts` walks `ctx.cwd → ctx.repoRoot ?? ctx.home`, pushing `.agent/<segments>` and `.agents/<segments>` at every level. When the loop reaches `ctx.home`, those candidates are by definition the same paths `getUserPathCandidates` already returns — the agents provider scans them twice, the dedupe layer marks the second copy as shadowed, and the Extension Dashboard (which includes shadowed entries) renders both.

Comparison with sibling providers (`claude`, `codex`, `gemini`) confirms only `agents` has this overlap because only `agents` walks up.

## Fix

- `packages/coding-agent/src/discovery/agents.ts`: in `getProjectPathCandidates`, gate the per-level push on `current !== ctx.home` so the home directory is still a valid walk-up terminator but never contributes project-level candidates. Documented with an inline reference to this issue. Exported the function so the test no longer duplicates it.
- `packages/coding-agent/test/discovery/agents-monorepo-skills.test.ts`:
  - Drop the local copy of `getProjectPathCandidates`; import the real one so behavior stays in lockstep with production.
  - Replace `walk-up stops at home when no repo root` (which encoded the buggy behavior — it asserted that a skill at `~/.agents/skills` *should* surface as project) with `project walk-up skips home directory (no repo root)`, pinning the new contract: home-level skills are not enumerated as project paths; the sub-project skill still is; above-home skills still are not.
  - Add a focused regression assertion that project ∩ user candidate sets are empty when cwd is under home.

## Verification

`bun test test/discovery/` from `packages/coding-agent/`:

```
 77 pass
 0 fail
 187 expect() calls
Ran 77 tests across 10 files.
```

The new and updated assertions both exercise the home-overlap scenario from the issue. `bun run check:ts` would not run cleanly on this worktree (Rust workspace not provisioned, biome native binary missing from the install cache) — the pre-publish gate run by `gh_push_branch` is the authoritative check.

Fixes #1116