### PR TITLE
[Superseded] Improve ACP command tool-call details

### DIFF
--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -66,7 +66,11 @@ import {
 import { ACP_BUILTIN_SLASH_COMMANDS, executeAcpBuiltinSlashCommand } from "../../slash-commands/acp-builtins";
 import { parseThinkingLevel } from "../../thinking";
 import { createAcpClientBridge } from "./acp-client-bridge";
-import { mapAgentSessionEventToAcpSessionUpdates, mapToolKind } from "./acp-event-mapper";
+import {
+	buildToolCallStartUpdate,
+	mapAgentSessionEventToAcpSessionUpdates,
+	normalizeReplayToolArguments,
+} from "./acp-event-mapper";
 import { ACP_TERMINAL_AUTH_FLAG } from "./terminal-auth";
 
 const ACP_DEFAULT_MODE_ID = "default";
@@ -1590,7 +1594,7 @@ export class AcpAgent implements Agent {
 
 	#messageToReplayNotifications(sessionId: string, message: ReplayableMessage, cwd: string): SessionNotification[] {
 		if (message.role === "assistant") {
-			return this.#replayAssistantMessage(sessionId, message);
+			return this.#replayAssistantMessage(sessionId, message, cwd);
 		}
 		if (
 			message.role === "user" ||
@@ -1631,7 +1635,7 @@ export class AcpAgent implements Agent {
 		return [];
 	}
 
-	#replayAssistantMessage(sessionId: string, message: ReplayableMessage): SessionNotification[] {
+	#replayAssistantMessage(sessionId: string, message: ReplayableMessage, cwd: string): SessionNotification[] {
 		const notifications: SessionNotification[] = [];
 		const messageId = crypto.randomUUID();
 		if (Array.isArray(message.content)) {
@@ -1673,16 +1677,14 @@ export class AcpAgent implements Agent {
 					"name" in item &&
 					typeof item.name === "string"
 				) {
-					const update: SessionUpdate = {
-						sessionUpdate: "tool_call",
+					const args = normalizeReplayToolArguments("arguments" in item ? item.arguments : undefined).args;
+					const update = buildToolCallStartUpdate({
 						toolCallId: item.id,
-						title: item.name,
-						kind: mapToolKind(item.name),
+						toolName: item.name,
+						args,
 						status: "completed",
-					};
-					if ("arguments" in item && typeof item.arguments === "string") {
-						update.rawInput = item.arguments;
-					}
+						cwd,
+					});
 					notifications.push({ sessionId, update });
 				}
 			}

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -154,6 +154,14 @@ type ReplayableMessage = {
 	isError?: boolean;
 };
 
+type ReplayableToolItem = {
+	type?: unknown;
+	id?: unknown;
+	name?: unknown;
+	arguments?: unknown;
+	input?: unknown;
+};
+
 type MCPConfigMap = {
 	[name: string]: MCPServerConfig;
 };
@@ -1585,16 +1593,27 @@ export class AcpAgent implements Agent {
 
 	async #replaySessionHistory(record: ManagedSessionRecord): Promise<void> {
 		const cwd = record.session.sessionManager.getCwd();
+		const replayedToolCallIds = new Set<string>();
 		for (const message of record.session.sessionManager.buildSessionContext().messages as ReplayableMessage[]) {
-			for (const notification of this.#messageToReplayNotifications(record.session.sessionId, message, cwd)) {
+			for (const notification of this.#messageToReplayNotifications(
+				record.session.sessionId,
+				message,
+				cwd,
+				replayedToolCallIds,
+			)) {
 				await this.#connection.sessionUpdate(notification);
 			}
 		}
 	}
 
-	#messageToReplayNotifications(sessionId: string, message: ReplayableMessage, cwd: string): SessionNotification[] {
+	#messageToReplayNotifications(
+		sessionId: string,
+		message: ReplayableMessage,
+		cwd: string,
+		replayedToolCallIds: Set<string>,
+	): SessionNotification[] {
 		if (message.role === "assistant") {
-			return this.#replayAssistantMessage(sessionId, message, cwd);
+			return this.#replayAssistantMessage(sessionId, message, cwd, replayedToolCallIds);
 		}
 		if (
 			message.role === "user" ||
@@ -1614,11 +1633,16 @@ export class AcpAgent implements Agent {
 			typeof message.toolCallId === "string" &&
 			typeof message.toolName === "string"
 		) {
-			return this.#replayToolResult(sessionId, cwd, {
-				...message,
-				toolCallId: message.toolCallId,
-				toolName: message.toolName,
-			});
+			return this.#replayToolResult(
+				sessionId,
+				cwd,
+				{
+					...message,
+					toolCallId: message.toolCallId,
+					toolName: message.toolName,
+				},
+				{ includeStart: !replayedToolCallIds.has(message.toolCallId) },
+			);
 		}
 		if (
 			message.role === "bashExecution" ||
@@ -1635,7 +1659,12 @@ export class AcpAgent implements Agent {
 		return [];
 	}
 
-	#replayAssistantMessage(sessionId: string, message: ReplayableMessage, cwd: string): SessionNotification[] {
+	#replayAssistantMessage(
+		sessionId: string,
+		message: ReplayableMessage,
+		cwd: string,
+		replayedToolCallIds: Set<string>,
+	): SessionNotification[] {
 		const notifications: SessionNotification[] = [];
 		const messageId = crypto.randomUUID();
 		if (Array.isArray(message.content)) {
@@ -1670,22 +1699,22 @@ export class AcpAgent implements Agent {
 					});
 					continue;
 				}
+				const toolItem = item as ReplayableToolItem;
 				if (
-					(item.type === "toolCall" || item.type === "tool_use") &&
-					"id" in item &&
-					typeof item.id === "string" &&
-					"name" in item &&
-					typeof item.name === "string"
+					(toolItem.type === "toolCall" || toolItem.type === "tool_use") &&
+					typeof toolItem.id === "string" &&
+					typeof toolItem.name === "string"
 				) {
-					const args = normalizeReplayToolArguments("arguments" in item ? item.arguments : undefined).args;
+					const args = this.#buildReplayAssistantToolArgs(toolItem);
 					const update = buildToolCallStartUpdate({
-						toolCallId: item.id,
-						toolName: item.name,
+						toolCallId: toolItem.id,
+						toolName: toolItem.name,
 						args,
 						status: "completed",
 						cwd,
 					});
 					notifications.push({ sessionId, update });
+					replayedToolCallIds.add(toolItem.id);
 				}
 			}
 		}
@@ -1702,10 +1731,21 @@ export class AcpAgent implements Agent {
 		return notifications;
 	}
 
+	#buildReplayAssistantToolArgs(item: ReplayableToolItem): unknown {
+		if ("arguments" in item) {
+			return normalizeReplayToolArguments(item.arguments).args;
+		}
+		if (item.type === "tool_use" && "input" in item) {
+			return { input: item.input };
+		}
+		return {};
+	}
+
 	#replayToolResult(
 		sessionId: string,
 		cwd: string,
 		message: Required<Pick<ReplayableMessage, "toolCallId" | "toolName">> & ReplayableMessage,
+		options: { includeStart?: boolean } = {},
 	): SessionNotification[] {
 		const args = this.#buildReplayToolArgs(message.details);
 		const startEvent: AgentSessionEvent = {
@@ -1725,10 +1765,11 @@ export class AcpAgent implements Agent {
 				errorMessage: message.errorMessage,
 			},
 		};
-		return [
-			...mapAgentSessionEventToAcpSessionUpdates(startEvent, sessionId, { cwd }),
-			...mapAgentSessionEventToAcpSessionUpdates(endEvent, sessionId, { cwd }),
-		];
+		const notifications = mapAgentSessionEventToAcpSessionUpdates(endEvent, sessionId, { cwd });
+		if (options.includeStart === false) {
+			return notifications;
+		}
+		return [...mapAgentSessionEventToAcpSessionUpdates(startEvent, sessionId, { cwd }), ...notifications];
 	}
 
 	#buildReplayToolArgs(details: unknown): { path?: string } {

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -335,6 +335,18 @@ export function buildToolCallStartUpdate(input: {
 	return update;
 }
 
+export function normalizeReplayToolArguments(value: unknown): { args: unknown } {
+	if (typeof value !== "string") {
+		return { args: value ?? {} };
+	}
+	try {
+		const parsed: unknown = JSON.parse(value);
+		return { args: parsed };
+	} catch {
+		return { args: value };
+	}
+}
+
 function buildToolStartContent(toolName: string, args: unknown): ToolCallContent[] {
 	if (!isCommandToolName(toolName)) {
 		return [];

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -1,6 +1,7 @@
 import type {
 	SessionNotification,
 	SessionUpdate,
+	ToolCall,
 	ToolCallContent,
 	ToolCallLocation,
 	ToolKind,
@@ -144,18 +145,13 @@ export function mapAgentSessionEventToAcpSessionUpdates(
 		case "message_end":
 			return mapAssistantMessageEnd(event, sessionId, options);
 		case "tool_execution_start": {
-			const update: SessionUpdate = {
-				sessionUpdate: "tool_call",
+			const update = buildToolCallStartUpdate({
 				toolCallId: event.toolCallId,
-				title: buildToolTitle(event.toolName, event.args, event.intent),
-				kind: mapToolKind(event.toolName),
-				status: "pending",
-				rawInput: event.args,
-			};
-			const locations = extractToolLocations(event.args, options.cwd);
-			if (locations.length > 0) {
-				update.locations = locations;
-			}
+				toolName: event.toolName,
+				args: event.args,
+				intent: event.intent,
+				cwd: options.cwd,
+			});
 			return [toSessionNotification(sessionId, update)];
 		}
 		case "tool_execution_update": {
@@ -310,6 +306,45 @@ const todoStatusMap: Record<TodoStatus, "pending" | "in_progress" | "completed">
 
 function mapTodoStatus(status: TodoStatus): "pending" | "in_progress" | "completed" {
 	return todoStatusMap[status];
+}
+
+export function buildToolCallStartUpdate(input: {
+	toolCallId: string;
+	toolName: string;
+	args: unknown;
+	intent?: string;
+	cwd?: string;
+	status?: "pending" | "completed";
+}): SessionUpdate {
+	const update: ToolCall & { sessionUpdate: "tool_call" } = {
+		sessionUpdate: "tool_call",
+		toolCallId: input.toolCallId,
+		title: buildToolTitle(input.toolName, input.args, input.intent),
+		kind: mapToolKind(input.toolName),
+		status: input.status ?? "pending",
+		rawInput: input.args,
+	};
+	const content = buildToolStartContent(input.toolName, input.args);
+	if (content.length > 0) {
+		update.content = content;
+	}
+	const locations = extractToolLocations(input.args, input.cwd);
+	if (locations.length > 0) {
+		update.locations = locations;
+	}
+	return update;
+}
+
+function buildToolStartContent(toolName: string, args: unknown): ToolCallContent[] {
+	if (!isCommandToolName(toolName)) {
+		return [];
+	}
+	const command = extractStringProperty<CommandContainer>(args, "command");
+	return command ? [textToolCallContent(`$ ${command}`)] : [];
+}
+
+function isCommandToolName(toolName: string): boolean {
+	return toolName === "bash" || toolName === "shell" || toolName === "exec";
 }
 
 function buildToolTitle(toolName: string, args: unknown, intent: string | undefined): string {

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -127,6 +127,8 @@ export function mapToolKind(toolName: string): ToolKind {
 		case "move":
 			return "move";
 		case "bash":
+		case "shell":
+		case "exec":
 		case "eval":
 			return "execute";
 		case "search":
@@ -163,7 +165,10 @@ export function mapAgentSessionEventToAcpSessionUpdates(
 			return [toSessionNotification(sessionId, update)];
 		}
 		case "tool_execution_update": {
-			const content = extractToolCallContent(event.partialResult);
+			const content = mergeToolUpdateContent(
+				buildToolStartContent(event.toolName, event.args),
+				extractToolCallContent(event.partialResult),
+			);
 			const update: SessionUpdate = {
 				sessionUpdate: "tool_call_update",
 				toolCallId: event.toolCallId,
@@ -357,6 +362,24 @@ function buildToolStartContent(toolName: string, args: unknown): ToolCallContent
 	}
 	const command = extractStringProperty<CommandContainer>(args, "command");
 	return command ? [textToolCallContent(`$ ${command}`)] : [];
+}
+
+function mergeToolUpdateContent(startContent: ToolCallContent[], resultContent: ToolCallContent[]): ToolCallContent[] {
+	if (startContent.length === 0) {
+		return resultContent;
+	}
+	const merged = [...startContent];
+	for (const item of resultContent) {
+		if (
+			item.type === "content" &&
+			item.content.type === "text" &&
+			hasEquivalentTextContent(merged, item.content.text)
+		) {
+			continue;
+		}
+		merged.push(item);
+	}
+	return merged;
 }
 
 function isCommandToolName(toolName: string): boolean {

--- a/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
+++ b/packages/coding-agent/src/modes/acp/acp-event-mapper.ts
@@ -31,12 +31,20 @@ interface ContentArrayContainer {
 	content?: unknown;
 }
 
+interface DetailsContainer {
+	details?: unknown;
+}
+
 interface TypedValue {
 	type?: unknown;
 }
 
 interface TextLikeContent extends TypedValue {
 	text?: unknown;
+}
+
+interface TerminalIdContainer {
+	terminalId?: unknown;
 }
 
 interface BinaryLikeContent extends TypedValue {
@@ -155,9 +163,7 @@ export function mapAgentSessionEventToAcpSessionUpdates(
 			return [toSessionNotification(sessionId, update)];
 		}
 		case "tool_execution_update": {
-			const terminalContent = extractTerminalToolCallContent(event.partialResult);
-			const otherContent = terminalContent.length > 0 ? [] : extractToolCallContent(event.partialResult);
-			const content = [...terminalContent, ...otherContent];
+			const content = extractToolCallContent(event.partialResult);
 			const update: SessionUpdate = {
 				sessionUpdate: "tool_call_update",
 				toolCallId: event.toolCallId,
@@ -175,9 +181,7 @@ export function mapAgentSessionEventToAcpSessionUpdates(
 		}
 		case "tool_execution_end": {
 			const diffContent = extractDiffToolCallContent(event.result);
-			const terminalContent = extractTerminalToolCallContent(event.result);
-			const otherContent = extractToolCallContent(event.result);
-			const content = [...diffContent, ...terminalContent, ...otherContent];
+			const content = [...diffContent, ...extractToolCallContent(event.result)];
 			const update: SessionUpdate = {
 				sessionUpdate: "tool_call_update",
 				toolCallId: event.toolCallId,
@@ -465,26 +469,33 @@ function buildDiffContent(entry: unknown): ToolCallContent | undefined {
 	};
 }
 
-/** Emit a `terminal` ToolCallContent when a tool result carries a `details.terminalId` (e.g. bash routed through ACP terminal/*). */
-function extractTerminalToolCallContent(result: unknown): ToolCallContent[] {
-	if (typeof result !== "object" || result === null) return [];
-	const details = (result as { details?: unknown }).details;
-	if (typeof details !== "object" || details === null) return [];
-	const terminalId = (details as { terminalId?: unknown }).terminalId;
-	if (typeof terminalId !== "string" || terminalId.length === 0) return [];
-	return [{ type: "terminal", terminalId }];
+function extractTerminalId(value: unknown): string | undefined {
+	const direct = extractStringProperty<TerminalIdContainer>(value, "terminalId");
+	if (direct) return direct;
+	if (typeof value !== "object" || value === null) return undefined;
+	const details = (value as DetailsContainer).details;
+	return extractStringProperty<TerminalIdContainer>(details, "terminalId");
+}
+
+function terminalToolCallContent(terminalId: string): ToolCallContent {
+	return { type: "terminal", terminalId };
 }
 
 function extractToolCallContent(value: unknown): ToolCallContent[] {
 	const richContent = extractStructuredToolCallContent(value);
+	const terminalId = extractTerminalId(value);
+	const content =
+		terminalId && !hasTerminalContent(richContent, terminalId)
+			? [...richContent, terminalToolCallContent(terminalId)]
+			: richContent;
 	const fallbackText = extractReadableText(value);
 	if (!fallbackText) {
-		return richContent;
+		return content;
 	}
-	if (hasEquivalentTextContent(richContent, fallbackText)) {
-		return richContent;
+	if (hasEquivalentTextContent(content, fallbackText)) {
+		return content;
 	}
-	return [...richContent, textToolCallContent(fallbackText)];
+	return [...content, textToolCallContent(fallbackText)];
 }
 
 function extractStructuredToolCallContent(value: unknown): ToolCallContent[] {
@@ -643,6 +654,10 @@ function hasEquivalentTextContent(content: ToolCallContent[], text: string): boo
 	return content.some(item => item.type === "content" && item.content.type === "text" && item.content.text === text);
 }
 
+function hasTerminalContent(content: ToolCallContent[], terminalId: string): boolean {
+	return content.some(item => item.type === "terminal" && item.terminalId === terminalId);
+}
+
 function extractReadableText(value: unknown): string | undefined {
 	if (typeof value === "string") {
 		return normalizeText(value);
@@ -672,9 +687,22 @@ function extractReadableText(value: unknown): string | undefined {
 			return normalizeText(text);
 		}
 	}
-
+	if (isTerminalOnlyDetails(value)) {
+		return undefined;
+	}
 	const serialized = safeJsonStringify(value);
 	return normalizeText(serialized);
+}
+
+function isTerminalOnlyDetails(value: unknown): boolean {
+	if (typeof value !== "object" || value === null) {
+		return false;
+	}
+	if (extractTerminalId(value) === undefined) {
+		return false;
+	}
+	const content = (value as ContentArrayContainer).content;
+	return content === undefined || (Array.isArray(content) && content.length === 0);
 }
 
 function extractAssistantMessageText(value: unknown): string {

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -753,6 +753,141 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("replays assistant tool calls and matching results without duplicating the start", async () => {
+		const harness = await createHarness();
+		const stored = new FakeAgentSession(harness.cwdA);
+		harness.sessions.push(stored);
+		stored.sessionManager.appendMessage({ role: "user", content: "run tests", timestamp: Date.now() });
+		stored.sessionManager.appendMessage({
+			role: "assistant",
+			content: [
+				{
+					type: "toolCall",
+					id: "toolu_bash_replay",
+					name: "bash",
+					arguments: { command: "npm test" },
+				},
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: TEST_MODELS[0].id,
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		});
+		stored.sessionManager.appendMessage({
+			role: "toolResult",
+			toolCallId: "toolu_bash_replay",
+			toolName: "bash",
+			content: [{ type: "text", text: "tests passed" }],
+			isError: false,
+			timestamp: Date.now(),
+		});
+		await stored.sessionManager.ensureOnDisk();
+		await stored.sessionManager.flush();
+
+		await harness.agent.loadSession({
+			sessionId: stored.sessionId,
+			cwd: harness.cwdA,
+			mcpServers: [],
+		});
+
+		const toolUpdates = harness.updates
+			.filter(update => update.sessionId === stored.sessionId)
+			.map(notification => notification.update)
+			.filter(update => "toolCallId" in update && update.toolCallId === "toolu_bash_replay");
+		const starts = toolUpdates.filter(update => update.sessionUpdate === "tool_call");
+		const completions = toolUpdates.filter(
+			update => update.sessionUpdate === "tool_call_update" && update.status === "completed",
+		);
+
+		expect(starts).toHaveLength(1);
+		expect(starts[0]).toEqual(
+			expect.objectContaining({
+				sessionUpdate: "tool_call",
+				toolCallId: "toolu_bash_replay",
+				rawInput: { command: "npm test" },
+			}),
+		);
+		expect(starts[0]).toEqual(
+			expect.objectContaining({
+				content: expect.arrayContaining([{ type: "content", content: { type: "text", text: "$ npm test" } }]),
+			}),
+		);
+		expect(starts.some(update => "rawInput" in update && JSON.stringify(update.rawInput) === "{}")).toBe(false);
+		expect(completions).toHaveLength(1);
+		expect(completions[0]).toEqual(
+			expect.objectContaining({
+				content: expect.arrayContaining([{ type: "content", content: { type: "text", text: "tests passed" } }]),
+			}),
+		);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
+	it("preserves tool_use input payloads when replaying assistant tool calls", async () => {
+		const harness = await createHarness();
+		const stored = new FakeAgentSession(harness.cwdA);
+		harness.sessions.push(stored);
+		stored.sessionManager.appendMessage({ role: "user", content: "use custom tool", timestamp: Date.now() });
+		stored.sessionManager.appendMessage({
+			role: "assistant",
+			content: [
+				{
+					type: "tool_use",
+					id: "toolu_custom",
+					name: "custom_tool",
+					input: "raw custom payload",
+				},
+			] as unknown as Array<{ type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }>,
+			api: "openai-responses",
+			provider: "openai",
+			model: TEST_MODELS[1].id,
+			usage: {
+				input: 1,
+				output: 1,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 2,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		});
+		await stored.sessionManager.ensureOnDisk();
+		await stored.sessionManager.flush();
+
+		await harness.agent.loadSession({
+			sessionId: stored.sessionId,
+			cwd: harness.cwdA,
+			mcpServers: [],
+		});
+
+		const start = harness.updates
+			.filter(update => update.sessionId === stored.sessionId)
+			.map(notification => notification.update)
+			.find(update => "toolCallId" in update && update.toolCallId === "toolu_custom");
+
+		expect(start).toEqual(
+			expect.objectContaining({
+				sessionUpdate: "tool_call",
+				toolCallId: "toolu_custom",
+				rawInput: { input: "raw custom payload" },
+			}),
+		);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
 	it("does not replay silent-abort marker as agent_message_chunk to ACP clients", async () => {
 		const harness = await createHarness();
 		const stored = new FakeAgentSession(harness.cwdA);

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "bun:test";
 import path from "node:path";
 import type { SessionNotification } from "@agentclientprotocol/sdk";
 import { zSessionNotification } from "@agentclientprotocol/sdk/dist/schema/zod.gen.js";
-import { mapAgentSessionEventToAcpSessionUpdates } from "../src/modes/acp/acp-event-mapper";
+import {
+	buildToolCallStartUpdate,
+	mapAgentSessionEventToAcpSessionUpdates,
+	normalizeReplayToolArguments,
+} from "../src/modes/acp/acp-event-mapper";
 import type { AgentSessionEvent } from "../src/session/agent-session";
 import { expectAcpStructure, expectAcpStructureRejects } from "./helpers/acp-schema";
 
@@ -271,6 +275,91 @@ describe("ACP event mapper", () => {
 		expect(update.status).toBe("pending");
 		expect(update.rawInput).toEqual({ command: "npm run check", cwd: "/repo" });
 		expect(update.content).toEqual([{ type: "content", content: { type: "text", text: "$ npm run check" } }]);
+	});
+
+	it("builds replayed bash tool calls from JSON string arguments", () => {
+		const replayArgs = normalizeReplayToolArguments(JSON.stringify({ command: "npm test", cwd: "/repo" }));
+		const update = buildToolCallStartUpdate({
+			toolCallId: "toolu_replay_1",
+			toolName: "bash",
+			args: replayArgs.args,
+			status: "completed",
+		});
+
+		expectAcpStructure(zSessionNotification, { sessionId: "session-1", update });
+		expect(update).toMatchObject({
+			sessionUpdate: "tool_call",
+			toolCallId: "toolu_replay_1",
+			title: "bash: npm test",
+			kind: "execute",
+			status: "completed",
+			rawInput: { command: "npm test", cwd: "/repo" },
+			content: [{ type: "content", content: { type: "text", text: "$ npm test" } }],
+		});
+	});
+
+	it("builds replayed read tool-call locations against the replay cwd", () => {
+		const replayArgs = normalizeReplayToolArguments(JSON.stringify({ path: "src/foo.ts" }));
+		const update = buildToolCallStartUpdate({
+			toolCallId: "toolu_replay_read",
+			toolName: "read",
+			args: replayArgs.args,
+			cwd: path.resolve("/repo"),
+			status: "completed",
+		});
+
+		expectAcpStructure(zSessionNotification, { sessionId: "session-1", update });
+		expect(update).toMatchObject({
+			sessionUpdate: "tool_call",
+			toolCallId: "toolu_replay_read",
+			title: "read: src/foo.ts",
+			kind: "read",
+			status: "completed",
+			rawInput: { path: "src/foo.ts" },
+			locations: [{ path: path.resolve("/repo", "src/foo.ts") }],
+		});
+		expect("content" in update).toBe(false);
+	});
+
+	it("keeps malformed replay arguments as raw input without command content", () => {
+		const replayArgs = normalizeReplayToolArguments("{not json");
+		const update = buildToolCallStartUpdate({
+			toolCallId: "toolu_replay_bad",
+			toolName: "bash",
+			args: replayArgs.args,
+			status: "completed",
+		});
+
+		expectAcpStructure(zSessionNotification, { sessionId: "session-1", update });
+		expect(update).toMatchObject({
+			sessionUpdate: "tool_call",
+			toolCallId: "toolu_replay_bad",
+			title: "bash",
+			kind: "execute",
+			status: "completed",
+			rawInput: "{not json",
+		});
+		expect("content" in update).toBe(false);
+	});
+
+	it("keeps object replay arguments unchanged and builds command content", () => {
+		const rawArgs = { command: "bun test", cwd: "/repo" };
+		const replayArgs = normalizeReplayToolArguments(rawArgs);
+		const update = buildToolCallStartUpdate({
+			toolCallId: "toolu_replay_object",
+			toolName: "bash",
+			args: replayArgs.args,
+			status: "completed",
+		});
+
+		expect(replayArgs.args).toBe(rawArgs);
+		expectAcpStructure(zSessionNotification, { sessionId: "session-1", update });
+		expect(update).toMatchObject({
+			title: "bash: bun test",
+			status: "completed",
+			rawInput: rawArgs,
+			content: [{ type: "content", content: { type: "text", text: "$ bun test" } }],
+		});
 	});
 
 	it("does not add command text content to non-command tool starts", () => {

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import path from "node:path";
 import type { SessionNotification } from "@agentclientprotocol/sdk";
 import { zSessionNotification } from "@agentclientprotocol/sdk/dist/schema/zod.gen.js";
 import { mapAgentSessionEventToAcpSessionUpdates } from "../src/modes/acp/acp-event-mapper";
@@ -240,6 +241,84 @@ describe("ACP event mapper", () => {
 		};
 		expect(update.sessionUpdate).toBe("tool_call_update");
 		expect(update.content).toEqual([{ type: "terminal", terminalId: "term-42" }]);
+	});
+	it("shows bash commands in visible tool call content", () => {
+		const updates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "tool_execution_start",
+				toolCallId: "toolu_bash_1",
+				toolName: "bash",
+				args: { command: "npm run check", cwd: "/repo" },
+			} as AgentSessionEvent,
+			"session-1",
+		);
+
+		expect(updates).toHaveLength(1);
+		expectAcpNotifications(updates);
+		const update = updates[0]!.update as {
+			sessionUpdate: string;
+			toolCallId?: string;
+			title?: string;
+			kind?: string;
+			status?: string;
+			rawInput?: unknown;
+			content?: unknown;
+		};
+		expect(update.sessionUpdate).toBe("tool_call");
+		expect(update.toolCallId).toBe("toolu_bash_1");
+		expect(update.title).toBe("bash: npm run check");
+		expect(update.kind).toBe("execute");
+		expect(update.status).toBe("pending");
+		expect(update.rawInput).toEqual({ command: "npm run check", cwd: "/repo" });
+		expect(update.content).toEqual([{ type: "content", content: { type: "text", text: "$ npm run check" } }]);
+	});
+
+	it("does not add command text content to non-command tool starts", () => {
+		const updates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "tool_execution_start",
+				toolCallId: "toolu_read_1",
+				toolName: "read",
+				args: { path: "README.md" },
+			} as AgentSessionEvent,
+			"session-1",
+		);
+
+		expect(updates).toHaveLength(1);
+		expectAcpNotifications(updates);
+		const update = updates[0]!.update as {
+			sessionUpdate: string;
+			title?: string;
+			kind?: string;
+			rawInput?: unknown;
+			locations?: { path: string }[];
+			content?: unknown;
+		};
+		expect(update.sessionUpdate).toBe("tool_call");
+		expect(update.title).toBe("read: README.md");
+		expect(update.kind).toBe("read");
+		expect(update.rawInput).toEqual({ path: "README.md" });
+		expect(update.locations).toEqual([{ path: "README.md" }]);
+		expect("content" in update).toBe(false);
+	});
+	it("resolves tool_execution_start locations against mapper cwd", () => {
+		const updates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "tool_execution_start",
+				toolCallId: "toolu_read_cwd",
+				toolName: "read",
+				args: { path: "src/file.ts" },
+			} as AgentSessionEvent,
+			"session-1",
+			{ cwd: "/repo" },
+		);
+
+		expect(updates).toHaveLength(1);
+		expectAcpNotifications(updates);
+		const update = updates[0]!.update as { sessionUpdate: string; locations?: { path: string }[]; content?: unknown };
+		expect(update.sessionUpdate).toBe("tool_call");
+		expect(update.locations).toEqual([{ path: path.resolve("/repo", "src/file.ts") }]);
+		expect("content" in update).toBe(false);
 	});
 	it("emits distinct locations for move-style path arguments", () => {
 		const updates = mapAgentSessionEventToAcpSessionUpdates(

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -225,13 +225,13 @@ describe("ACP event mapper", () => {
 		expect(update.locations).toEqual([{ path: "src/foo.ts" }]);
 	});
 
-	it("emits only terminal content from terminal-only tool update details", () => {
+	it("preserves command text when a command tool update replaces content", () => {
 		const updates = mapAgentSessionEventToAcpSessionUpdates(
 			{
 				type: "tool_execution_update",
 				toolCallId: "tc-3",
 				toolName: "bash",
-				args: { command: "echo hi" },
+				args: { command: "npm run check" },
 				partialResult: { details: { terminalId: "term-1" } },
 			} as AgentSessionEvent,
 			"session-1",
@@ -241,13 +241,18 @@ describe("ACP event mapper", () => {
 		expectAcpNotifications(updates);
 		const update = updates[0]!.update as {
 			sessionUpdate: string;
-			content?: Array<{ type: string; terminalId?: string }>;
+			content?: Array<{ type: string; terminalId?: string; content?: { type: string; text?: string } }>;
 		};
 		expect(update.sessionUpdate).toBe("tool_call_update");
-		expect(update.content).toEqual([{ type: "terminal", terminalId: "term-1" }]);
+		expect(update.content).toContainEqual({ type: "content", content: { type: "text", text: "$ npm run check" } });
+		expect(update.content).toContainEqual({ type: "terminal", terminalId: "term-1" });
+		expect(update.content).not.toContainEqual({
+			type: "content",
+			content: { type: "text", text: '{"details":{"terminalId":"term-1"}}' },
+		});
 	});
 
-	it("emits only terminal content when tool update details accompany empty content", () => {
+	it("preserves command text when tool update details accompany empty content", () => {
 		const updates = mapAgentSessionEventToAcpSessionUpdates(
 			{
 				type: "tool_execution_update",
@@ -263,10 +268,15 @@ describe("ACP event mapper", () => {
 		expectAcpNotifications(updates);
 		const update = updates[0]!.update as {
 			sessionUpdate: string;
-			content?: Array<{ type: string; terminalId?: string }>;
+			content?: Array<{ type: string; terminalId?: string; content?: { type: string; text?: string } }>;
 		};
 		expect(update.sessionUpdate).toBe("tool_call_update");
-		expect(update.content).toEqual([{ type: "terminal", terminalId: "term-1" }]);
+		expect(update.content).toContainEqual({ type: "content", content: { type: "text", text: "$ echo hi" } });
+		expect(update.content).toContainEqual({ type: "terminal", terminalId: "term-1" });
+		expect(update.content).not.toContainEqual({
+			type: "content",
+			content: { type: "text", text: '{"content":[],"details":{"terminalId":"term-1"}}' },
+		});
 	});
 
 	it("keeps terminal content alongside readable text", () => {
@@ -457,6 +467,31 @@ describe("ACP event mapper", () => {
 		expect(update.status).toBe("pending");
 		expect(update.rawInput).toEqual({ command: "npm run check", cwd: "/repo" });
 		expect(update.content).toEqual([{ type: "content", content: { type: "text", text: "$ npm run check" } }]);
+	});
+
+	it("maps shell and exec tool starts as execute", () => {
+		for (const toolName of ["shell", "exec"] as const) {
+			const updates = mapAgentSessionEventToAcpSessionUpdates(
+				{
+					type: "tool_execution_start",
+					toolCallId: `toolu_${toolName}_1`,
+					toolName,
+					args: { command: "echo hi" },
+				} as AgentSessionEvent,
+				"session-1",
+			);
+
+			expect(updates).toHaveLength(1);
+			expectAcpNotifications(updates);
+			const update = updates[0]!.update as {
+				sessionUpdate: string;
+				kind?: string;
+				content?: unknown;
+			};
+			expect(update.sessionUpdate).toBe("tool_call");
+			expect(update.kind).toBe("execute");
+			expect(update.content).toEqual([{ type: "content", content: { type: "text", text: "$ echo hi" } }]);
+		}
 	});
 
 	it("builds replayed bash tool calls from JSON string arguments", () => {

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -321,6 +321,71 @@ describe("ACP event mapper", () => {
 		expect(update.content).toContainEqual({ type: "terminal", terminalId: "term-1" });
 	});
 
+	it("keeps terminal content alongside readable error and message fields", () => {
+		const errorUpdates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "tool_execution_end",
+				toolCallId: "tc-terminal-error",
+				toolName: "bash",
+				isError: true,
+				result: { errorMessage: "command failed", details: { terminalId: "term-1" } },
+			} as AgentSessionEvent,
+			"session-1",
+		);
+		const messageUpdates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "tool_execution_end",
+				toolCallId: "tc-terminal-message",
+				toolName: "bash",
+				isError: false,
+				result: { message: "command completed", details: { terminalId: "term-1" } },
+			} as AgentSessionEvent,
+			"session-1",
+		);
+
+		expect(errorUpdates).toHaveLength(1);
+		expect(messageUpdates).toHaveLength(1);
+		expectAcpNotifications([...errorUpdates, ...messageUpdates]);
+		const errorUpdate = errorUpdates[0]!.update as {
+			content?: Array<{ type: string; terminalId?: string; content?: { type: string; text?: string } }>;
+		};
+		const messageUpdate = messageUpdates[0]!.update as {
+			content?: Array<{ type: string; terminalId?: string; content?: { type: string; text?: string } }>;
+		};
+
+		expect(errorUpdate.content).toContainEqual({ type: "terminal", terminalId: "term-1" });
+		expect(errorUpdate.content).toContainEqual({
+			type: "content",
+			content: { type: "text", text: "command failed" },
+		});
+		expect(messageUpdate.content).toContainEqual({ type: "terminal", terminalId: "term-1" });
+		expect(messageUpdate.content).toContainEqual({
+			type: "content",
+			content: { type: "text", text: "command completed" },
+		});
+	});
+
+	it("keeps plain command output visible without terminal details", () => {
+		const updates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "tool_execution_end",
+				toolCallId: "tc-plain-output",
+				toolName: "bash",
+				isError: false,
+				result: "hello from stdout",
+			} as AgentSessionEvent,
+			"session-1",
+		);
+
+		expect(updates).toHaveLength(1);
+		expectAcpNotifications(updates);
+		const update = updates[0]!.update as {
+			content?: Array<{ type: string; content?: { type: string; text?: string } }>;
+		};
+
+		expect(update.content).toEqual([{ type: "content", content: { type: "text", text: "hello from stdout" } }]);
+	});
+
 	it("embeds only terminal content from direct terminalId", () => {
 		const updates = mapAgentSessionEventToAcpSessionUpdates(
 			{

--- a/packages/coding-agent/test/acp-event-mapper.test.ts
+++ b/packages/coding-agent/test/acp-event-mapper.test.ts
@@ -225,14 +225,14 @@ describe("ACP event mapper", () => {
 		expect(update.locations).toEqual([{ path: "src/foo.ts" }]);
 	});
 
-	it("emits a terminal ToolCallContent when tool details carry a terminalId", () => {
+	it("emits only terminal content from terminal-only tool update details", () => {
 		const updates = mapAgentSessionEventToAcpSessionUpdates(
 			{
 				type: "tool_execution_update",
 				toolCallId: "tc-3",
 				toolName: "bash",
 				args: { command: "echo hi" },
-				partialResult: { content: [], details: { terminalId: "term-42" } },
+				partialResult: { details: { terminalId: "term-1" } },
 			} as AgentSessionEvent,
 			"session-1",
 		);
@@ -244,7 +244,124 @@ describe("ACP event mapper", () => {
 			content?: Array<{ type: string; terminalId?: string }>;
 		};
 		expect(update.sessionUpdate).toBe("tool_call_update");
-		expect(update.content).toEqual([{ type: "terminal", terminalId: "term-42" }]);
+		expect(update.content).toEqual([{ type: "terminal", terminalId: "term-1" }]);
+	});
+
+	it("emits only terminal content when tool update details accompany empty content", () => {
+		const updates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "tool_execution_update",
+				toolCallId: "tc-terminal-empty-content",
+				toolName: "bash",
+				args: { command: "echo hi" },
+				partialResult: { content: [], details: { terminalId: "term-1" } },
+			} as AgentSessionEvent,
+			"session-1",
+		);
+
+		expect(updates).toHaveLength(1);
+		expectAcpNotifications(updates);
+		const update = updates[0]!.update as {
+			sessionUpdate: string;
+			content?: Array<{ type: string; terminalId?: string }>;
+		};
+		expect(update.sessionUpdate).toBe("tool_call_update");
+		expect(update.content).toEqual([{ type: "terminal", terminalId: "term-1" }]);
+	});
+
+	it("keeps terminal content alongside readable text", () => {
+		const updates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "tool_execution_update",
+				toolCallId: "tc-terminal-update-text",
+				toolName: "bash",
+				args: { command: "echo hi" },
+				partialResult: {
+					content: [{ type: "text", text: "running" }],
+					details: { terminalId: "term-1" },
+				},
+			} as AgentSessionEvent,
+			"session-1",
+		);
+
+		expect(updates).toHaveLength(1);
+		expectAcpNotifications(updates);
+		const update = updates[0]!.update as {
+			sessionUpdate: string;
+			content?: Array<{ type: string; terminalId?: string; content?: { type: string; text?: string } }>;
+		};
+		expect(update.sessionUpdate).toBe("tool_call_update");
+		expect(update.content).toContainEqual({ type: "content", content: { type: "text", text: "running" } });
+		expect(update.content).toContainEqual({ type: "terminal", terminalId: "term-1" });
+	});
+
+	it("keeps terminal content alongside readable end text", () => {
+		const updates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "tool_execution_end",
+				toolCallId: "tc-terminal-end",
+				toolName: "bash",
+				isError: false,
+				result: {
+					content: [{ type: "text", text: "done" }],
+					details: { terminalId: "term-1" },
+				},
+			} as AgentSessionEvent,
+			"session-1",
+		);
+
+		expect(updates).toHaveLength(1);
+		expectAcpNotifications(updates);
+		const update = updates[0]!.update as {
+			sessionUpdate: string;
+			content?: Array<{ type: string; terminalId?: string; content?: { type: string; text?: string } }>;
+		};
+		expect(update.sessionUpdate).toBe("tool_call_update");
+		expect(update.content).toContainEqual({ type: "content", content: { type: "text", text: "done" } });
+		expect(update.content).toContainEqual({ type: "terminal", terminalId: "term-1" });
+	});
+
+	it("embeds only terminal content from direct terminalId", () => {
+		const updates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "tool_execution_end",
+				toolCallId: "tc-direct-terminal",
+				toolName: "bash",
+				isError: false,
+				result: { terminalId: "term-1" },
+			} as AgentSessionEvent,
+			"session-1",
+		);
+
+		expect(updates).toHaveLength(1);
+		expectAcpNotifications(updates);
+		const update = updates[0]!.update as {
+			content?: Array<{ type: string; terminalId?: string }>;
+		};
+		expect(update.content).toEqual([{ type: "terminal", terminalId: "term-1" }]);
+	});
+
+	it("does not duplicate existing terminal content", () => {
+		const updates = mapAgentSessionEventToAcpSessionUpdates(
+			{
+				type: "tool_execution_end",
+				toolCallId: "tc-terminal-dedup",
+				toolName: "bash",
+				isError: false,
+				result: {
+					content: [{ type: "terminal", terminalId: "term-1" }],
+					details: { terminalId: "term-1" },
+				},
+			} as AgentSessionEvent,
+			"session-1",
+		);
+
+		expect(updates).toHaveLength(1);
+		expectAcpNotifications(updates);
+		const update = updates[0]!.update as {
+			content?: Array<{ type: string; terminalId?: string }>;
+		};
+		expect(update.content?.filter(item => item.type === "terminal" && item.terminalId === "term-1")).toHaveLength(1);
 	});
 	it("shows bash commands in visible tool call content", () => {
 		const updates = mapAgentSessionEventToAcpSessionUpdates(


### PR DESCRIPTION
Superseded by the split PR train for #1118:\n\n- #1128 — command visibility\n- #1131 — replay parity\n- #1130 — terminal embedding\n- #1132 — fallback and integration regressions\n\nKeeping this integration PR open only as a temporary all-in-one branch until the split train is merged.