### PR TITLE
fix(coding-agent): correct install.sh fallback URL in omp update warning

### DIFF
--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -237,7 +237,7 @@ async function printVerification(expectedVersion: string): Promise<void> {
 	}
 	console.log(
 		chalk.yellow(
-			`You may need to reinstall: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/scripts/install.sh | bash`,
+			`You may need to reinstall: curl -fsSL https://omp.sh/install | sh`,
 		),
 	);
 }

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -237,7 +237,7 @@ async function printVerification(expectedVersion: string): Promise<void> {
 	}
 	console.log(
 		chalk.yellow(
-			`You may need to reinstall: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/install.sh | bash`,
+			`You may need to reinstall: curl -fsSL https://raw.githubusercontent.com/${REPO}/main/scripts/install.sh | bash`,
 		),
 	);
 }


### PR DESCRIPTION
## What

Fix the fallback installer URL printed by `omp update` when it cannot verify the newly written binary.

## Why

The warning currently prints:

```
https://raw.githubusercontent.com/can1357/oh-my-pi/main/install.sh
```

That URL returns **HTTP 404**. The installer actually lives at `scripts/install.sh`, which matches the path used in the README install instructions:

```
https://raw.githubusercontent.com/can1357/oh-my-pi/main/scripts/install.sh
```

### Reproduce

1. Trigger `omp update` on a host where post-install verification fails (e.g. existing standalone binary at `~/.local/bin/omp` that the updater rewrites but cannot re-exec to read `--version`).
2. Observe the printed reinstall hint.
3. `curl -fsSL <printed-url>` -> 404.

Hit while updating from 15.1.1 -> 15.1.2 on Linux x86_64; the verify step printed the bad URL.

## Testing

- `bun check` passes (all 9 workspace packages, including `pi-coding-agent`).
- String-only change in `printVerification()`; no behavior change to the update flow.
- No new test added per AGENTS.md "Testing Guidance" (tiny low-risk change with no contract to defend).

---

- [x] \`bun check\` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing) - intentionally skipped: typo-class fix in a warning string, no behavioral or feature change. Happy to add an \`[Unreleased]\` -> \`Fixed\` entry in \`packages/coding-agent/CHANGELOG.md\` if preferred.