### PR TITLE
feat(ai): added credential_process support to AWS credential resolver

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added `credential_process` support to AWS credential resolution. Profiles in `~/.aws/config` (or `~/.aws/credentials`) configured as `credential_process = <cmd>` now spawn the configured command and parse its `Version: 1` JSON output (`AccessKeyId`, `SecretAccessKey`, optional `SessionToken` and `Expiration`), matching the AWS CLI / SDK contract. Profiles using brokers like `aws-vault` or custom session-token helpers no longer fall through to "Unable to resolve AWS credentials".
 
 ## [15.1.3] - 2026-05-17
 ### Breaking Changes

--- a/packages/ai/src/providers/aws-credentials.ts
+++ b/packages/ai/src/providers/aws-credentials.ts
@@ -258,15 +258,32 @@ async function readProcessCredentials(
 	}
 	const bin = argv[0] as string;
 	const args = argv.slice(1);
+	// Node refuses to launch `.bat` / `.cmd` directly via execFile on Windows
+	// (they need cmd.exe), so route those through the shell. AWS docs include
+	// `.cmd` examples, so this branch is part of the documented contract.
+	// We hand cmd.exe the original (still-quoted) command line rather than
+	// our parsed argv: with shell: true Node concatenates argv with spaces
+	// and passes a single string to the shell, so any quoting we stripped
+	// would be lost and paths with spaces would break. The command line
+	// comes from a local config file we already trust to spawn arbitrary
+	// code, so shell interpretation is acceptable here.
+	const useShell = process.platform === "win32" && /\.(cmd|bat)$/i.test(bin);
 
 	let stdout: string;
 	try {
-		const result = await execFileAsync(bin, args, {
-			// AWS SDKs cap process credential output at 1 MiB.
-			maxBuffer: 1024 * 1024,
-			windowsHide: true,
-			signal,
-		});
+		const result = useShell
+			? await execFileAsync(commandLine, {
+					maxBuffer: 1024 * 1024,
+					windowsHide: true,
+					signal,
+					shell: true,
+				})
+			: await execFileAsync(bin, args, {
+					// AWS SDKs cap process credential output at 1 MiB.
+					maxBuffer: 1024 * 1024,
+					windowsHide: true,
+					signal,
+				});
 		stdout = result.stdout;
 	} catch (err) {
 		const detail = err instanceof Error ? err.message : String(err);

--- a/packages/ai/src/providers/aws-credentials.ts
+++ b/packages/ai/src/providers/aws-credentials.ts
@@ -4,8 +4,11 @@
  * Chain (first hit wins):
  *  1. Static credentials from the environment
  *     (`AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` [+ `AWS_SESSION_TOKEN`]).
- *  2. Profile in `~/.aws/credentials` (and `~/.aws/config` for SSO):
+ *  2. Profile in `~/.aws/credentials` (and `~/.aws/config` for SSO / process):
  *      - static `aws_access_key_id` / `aws_secret_access_key` / `aws_session_token`
+ *      - `credential_process = <cmd>` — spawn the command, read JSON
+ *        (`{Version:1, AccessKeyId, SecretAccessKey, SessionToken?, Expiration?}`)
+ *        from stdout (matches the AWS CLI / SDK contract).
  *      - SSO profile referencing a cached token in `~/.aws/sso/cache/*.json`,
  *        which we exchange for short-lived role credentials via
  *        `https://portal.sso.{region}.amazonaws.com/federation/credentials`.
@@ -16,11 +19,15 @@
  * 60 s before `Expiration` to absorb clock skew.
  */
 
+import { execFile } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { promisify } from "node:util";
 import { $env, isEnoent, logger } from "@oh-my-pi/pi-utils";
 import type { AwsCredentials } from "./aws-sigv4";
+
+const execFileAsync = promisify(execFile);
 
 export interface ResolvedCredentials extends AwsCredentials {
 	/** Absolute expiration timestamp in ms. `undefined` for non-expiring static creds. */
@@ -158,11 +165,129 @@ async function readProfileCredentials(
 		return out;
 	}
 
+	if (merged.credential_process) {
+		return readProcessCredentials(merged.credential_process, profile);
+	}
+
 	if (merged.sso_account_id && merged.sso_role_name) {
 		return readSsoCredentials(merged, configIni, region, signal);
 	}
 
 	return undefined;
+}
+
+// ---------- credential_process ----------
+
+interface CredentialProcessOutput {
+	Version?: number;
+	AccessKeyId?: string;
+	SecretAccessKey?: string;
+	SessionToken?: string;
+	Expiration?: string;
+}
+
+/**
+ * Tokenize a `credential_process` command line. Mirrors what botocore /
+ * the AWS CLI accept: whitespace-separated argv, with single- or
+ * double-quoted segments. Backslash escapes inside double quotes pass
+ * through, single quotes are literal. Good enough for the patterns the
+ * AWS docs sanction (e.g. `/usr/local/bin/aws-vault exec foo --json`).
+ */
+function tokenizeCredentialProcess(cmd: string): string[] {
+	const tokens: string[] = [];
+	let current = "";
+	let quote: '"' | "'" | undefined;
+	let i = 0;
+	let hasContent = false;
+	while (i < cmd.length) {
+		const ch = cmd[i] as string;
+		if (quote) {
+			if (ch === quote) {
+				quote = undefined;
+				i++;
+				continue;
+			}
+			if (ch === "\\" && quote === '"' && i + 1 < cmd.length) {
+				const next = cmd[i + 1] as string;
+				current += next;
+				i += 2;
+				continue;
+			}
+			current += ch;
+			i++;
+			continue;
+		}
+		if (ch === '"' || ch === "'") {
+			quote = ch as '"' | "'";
+			hasContent = true;
+			i++;
+			continue;
+		}
+		if (ch === " " || ch === "\t") {
+			if (hasContent) {
+				tokens.push(current);
+				current = "";
+				hasContent = false;
+			}
+			i++;
+			continue;
+		}
+		current += ch;
+		hasContent = true;
+		i++;
+	}
+	if (quote) throw new Error(`credential_process command has unbalanced ${quote} quote: ${cmd}`);
+	if (hasContent) tokens.push(current);
+	return tokens;
+}
+
+async function readProcessCredentials(commandLine: string, profile: string): Promise<ResolvedCredentials> {
+	const argv = tokenizeCredentialProcess(commandLine);
+	if (argv.length === 0) {
+		throw new Error(`credential_process for profile '${profile}' is empty`);
+	}
+	const [bin, ...args] = argv as [string, ...string[]];
+
+	let stdout: string;
+	try {
+		const result = await execFileAsync(bin, args, {
+			// AWS SDKs cap process credential output at 1 MiB.
+			maxBuffer: 1024 * 1024,
+			windowsHide: true,
+		});
+		stdout = result.stdout;
+	} catch (err) {
+		const detail = err instanceof Error ? err.message : String(err);
+		throw new Error(`credential_process for profile '${profile}' failed: ${detail}`);
+	}
+
+	let parsed: CredentialProcessOutput;
+	try {
+		parsed = JSON.parse(stdout) as CredentialProcessOutput;
+	} catch (err) {
+		const detail = err instanceof Error ? err.message : String(err);
+		throw new Error(`credential_process for profile '${profile}' returned invalid JSON: ${detail}`);
+	}
+
+	if (parsed.Version !== 1) {
+		throw new Error(
+			`credential_process for profile '${profile}' returned unsupported Version ${parsed.Version ?? "(missing)"}; expected 1`,
+		);
+	}
+	if (!parsed.AccessKeyId || !parsed.SecretAccessKey) {
+		throw new Error(`credential_process for profile '${profile}' returned no AccessKeyId/SecretAccessKey`);
+	}
+
+	const out: ResolvedCredentials = {
+		accessKeyId: parsed.AccessKeyId,
+		secretAccessKey: parsed.SecretAccessKey,
+	};
+	if (parsed.SessionToken) out.sessionToken = parsed.SessionToken;
+	if (parsed.Expiration) {
+		const exp = Date.parse(parsed.Expiration);
+		if (!Number.isNaN(exp)) out.expiresAt = exp;
+	}
+	return out;
 }
 
 interface SsoCachedToken {

--- a/packages/ai/src/providers/aws-credentials.ts
+++ b/packages/ai/src/providers/aws-credentials.ts
@@ -188,12 +188,18 @@ interface CredentialProcessOutput {
 
 /**
  * Tokenize a `credential_process` command line. Mirrors what botocore /
- * the AWS CLI accept: whitespace-separated argv, with single- or
- * double-quoted segments. Single quotes are literal. Inside double quotes,
- * backslash only escapes `\\` and `\"` (POSIX shell semantics) — every other
- * `\X` passes through as a literal `\X`, so Windows paths like
- * `"C:\Path\To\creds.cmd"` survive intact. Good enough for the patterns the
- * AWS docs sanction (e.g. `/usr/local/bin/aws-vault exec foo --json`).
+ * the AWS CLI accept (POSIX `shlex.split`): whitespace-separated argv with
+ * single- or double-quoted segments.
+ *
+ *  - Single quotes are literal (no escapes inside).
+ *  - Inside double quotes: `\\` and `\"` escape; every other `\X` passes
+ *    through as a literal `\X`, so Windows paths like
+ *    `"C:\Path\To\creds.cmd"` survive intact.
+ *  - Outside quotes: `\<char>` consumes both and emits a literal `<char>`,
+ *    so `arg\ with\ spaces` becomes a single token `arg with spaces`.
+ *
+ * POSIX-only: Windows command lines are handed straight to cmd.exe and
+ * never reach this function. A trailing `\` (or unbalanced quote) throws.
  */
 function tokenizeCredentialProcess(cmd: string): string[] {
 	const tokens: string[] = [];
@@ -221,6 +227,15 @@ function tokenizeCredentialProcess(cmd: string): string[] {
 			}
 			current += ch;
 			i++;
+			continue;
+		}
+		if (ch === "\\") {
+			if (i + 1 >= cmd.length) {
+				throw new Error(`credential_process command ends with a stray backslash: ${cmd}`);
+			}
+			current += cmd[i + 1] as string;
+			hasContent = true;
+			i += 2;
 			continue;
 		}
 		if (ch === '"' || ch === "'") {
@@ -269,9 +284,6 @@ async function readProcessCredentials(
 	const baseOpts = { maxBuffer: 1024 * 1024, windowsHide: true, signal } as const;
 	let stdout: string;
 	try {
-		// On Windows we hand cmd.exe the original command line; we deliberately
-		// don't run our POSIX tokenizer first, since it would reject configs
-		// (e.g. caret escapes) that cmd.exe parses fine.
 		if (useShell) {
 			const result = await execFileAsync(commandLine, { ...baseOpts, shell: true });
 			stdout = result.stdout;

--- a/packages/ai/src/providers/aws-credentials.ts
+++ b/packages/ai/src/providers/aws-credentials.ts
@@ -258,16 +258,18 @@ async function readProcessCredentials(
 	}
 	const bin = argv[0] as string;
 	const args = argv.slice(1);
-	// Node refuses to launch `.bat` / `.cmd` directly via execFile on Windows
-	// (they need cmd.exe), so route those through the shell. AWS docs include
-	// `.cmd` examples, so this branch is part of the documented contract.
-	// We hand cmd.exe the original (still-quoted) command line rather than
-	// our parsed argv: with shell: true Node concatenates argv with spaces
-	// and passes a single string to the shell, so any quoting we stripped
-	// would be lost and paths with spaces would break. The command line
-	// comes from a local config file we already trust to spawn arbitrary
-	// code, so shell interpretation is acceptable here.
-	const useShell = process.platform === "win32" && /\.(cmd|bat)$/i.test(bin);
+	// On Windows, always go through cmd.exe. Node's execFile cannot launch
+	// `.bat` / `.cmd` files directly (CVE-2024-27980 hardening as of Node
+	// 18.20.2), and a bare-name `bin` like `aws-vault` may resolve through
+	// PATHEXT to a `.cmd` shim — something only the shell does, not Win32
+	// CreateProcess. botocore's reference implementation also uses `shell=True`
+	// on Windows for the same reasons. We pass the original (still-quoted)
+	// command line rather than our split argv because `shell: true` joins
+	// argv with single spaces before re-parsing in the shell, which would
+	// drop the quoting we already stripped (paths with spaces would break).
+	// The command line comes from a local config file we already trust to
+	// spawn arbitrary code, so shell interpretation is acceptable here.
+	const useShell = process.platform === "win32";
 
 	let stdout: string;
 	try {

--- a/packages/ai/src/providers/aws-credentials.ts
+++ b/packages/ai/src/providers/aws-credentials.ts
@@ -252,41 +252,38 @@ async function readProcessCredentials(
 	profile: string,
 	signal: AbortSignal | undefined,
 ): Promise<ResolvedCredentials> {
-	const argv = tokenizeCredentialProcess(commandLine);
-	if (argv.length === 0) {
-		throw new Error(`credential_process for profile '${profile}' is empty`);
-	}
-	const bin = argv[0] as string;
-	const args = argv.slice(1);
 	// On Windows, always go through cmd.exe. Node's execFile cannot launch
 	// `.bat` / `.cmd` files directly (CVE-2024-27980 hardening as of Node
 	// 18.20.2), and a bare-name `bin` like `aws-vault` may resolve through
 	// PATHEXT to a `.cmd` shim — something only the shell does, not Win32
 	// CreateProcess. botocore's reference implementation also uses `shell=True`
-	// on Windows for the same reasons. We pass the original (still-quoted)
-	// command line rather than our split argv because `shell: true` joins
-	// argv with single spaces before re-parsing in the shell, which would
-	// drop the quoting we already stripped (paths with spaces would break).
-	// The command line comes from a local config file we already trust to
-	// spawn arbitrary code, so shell interpretation is acceptable here.
+	// on Windows for the same reasons. We hand cmd.exe the original command
+	// line (instead of reconstituting it from our split argv) so it can apply
+	// its own quoting rules, including caret escapes that our POSIX-flavored
+	// tokenizer doesn't model. The command line comes from a local config
+	// file we already trust to spawn arbitrary code, so shell interpretation
+	// is acceptable here.
 	const useShell = process.platform === "win32";
 
+	// AWS SDKs cap process credential output at 1 MiB.
+	const baseOpts = { maxBuffer: 1024 * 1024, windowsHide: true, signal } as const;
 	let stdout: string;
 	try {
-		const result = useShell
-			? await execFileAsync(commandLine, {
-					maxBuffer: 1024 * 1024,
-					windowsHide: true,
-					signal,
-					shell: true,
-				})
-			: await execFileAsync(bin, args, {
-					// AWS SDKs cap process credential output at 1 MiB.
-					maxBuffer: 1024 * 1024,
-					windowsHide: true,
-					signal,
-				});
-		stdout = result.stdout;
+		// On Windows we hand cmd.exe the original command line; we deliberately
+		// don't run our POSIX tokenizer first, since it would reject configs
+		// (e.g. caret escapes) that cmd.exe parses fine.
+		if (useShell) {
+			const result = await execFileAsync(commandLine, { ...baseOpts, shell: true });
+			stdout = result.stdout;
+		} else {
+			const argv = tokenizeCredentialProcess(commandLine);
+			if (argv.length === 0) {
+				throw new Error(`credential_process for profile '${profile}' is empty`);
+			}
+			const [bin, ...args] = argv as [string, ...string[]];
+			const result = await execFileAsync(bin, args, baseOpts);
+			stdout = result.stdout;
+		}
 	} catch (err) {
 		const detail = err instanceof Error ? err.message : String(err);
 		throw new Error(`credential_process for profile '${profile}' failed: ${detail}`);
@@ -314,9 +311,19 @@ async function readProcessCredentials(
 		secretAccessKey: parsed.SecretAccessKey,
 	};
 	if (parsed.SessionToken) out.sessionToken = parsed.SessionToken;
-	if (parsed.Expiration) {
-		const exp = Date.parse(parsed.Expiration);
-		if (!Number.isNaN(exp)) out.expiresAt = exp;
+	// AWS treats omitted Expiration as "non-expiring credentials". A *present*
+	// but unparseable value is a malformed envelope: silently dropping it would
+	// cache temporary creds forever (the resolver caches with `expiresAt ??
+	// Infinity`), so the helper would never be re-invoked even after the real
+	// credentials expired. Fail fast instead.
+	if (parsed.Expiration !== undefined && parsed.Expiration !== null) {
+		const exp = typeof parsed.Expiration === "string" ? Date.parse(parsed.Expiration) : Number.NaN;
+		if (!Number.isFinite(exp)) {
+			throw new Error(
+				`credential_process for profile '${profile}' returned invalid Expiration: ${JSON.stringify(parsed.Expiration)}`,
+			);
+		}
+		out.expiresAt = exp;
 	}
 	return out;
 }

--- a/packages/ai/src/providers/aws-credentials.ts
+++ b/packages/ai/src/providers/aws-credentials.ts
@@ -256,7 +256,8 @@ async function readProcessCredentials(
 	if (argv.length === 0) {
 		throw new Error(`credential_process for profile '${profile}' is empty`);
 	}
-	const [bin, ...args] = argv as [string, ...string[]];
+	const bin = argv[0] as string;
+	const args = argv.slice(1);
 
 	let stdout: string;
 	try {
@@ -264,8 +265,6 @@ async function readProcessCredentials(
 			// AWS SDKs cap process credential output at 1 MiB.
 			maxBuffer: 1024 * 1024,
 			windowsHide: true,
-			// Propagates AbortSignal aborts to the child via SIGTERM (Node default),
-			// matching the cancellation behavior of the SSO/IMDS branches.
 			signal,
 		});
 		stdout = result.stdout;

--- a/packages/ai/src/providers/aws-credentials.ts
+++ b/packages/ai/src/providers/aws-credentials.ts
@@ -166,7 +166,7 @@ async function readProfileCredentials(
 	}
 
 	if (merged.credential_process) {
-		return readProcessCredentials(merged.credential_process, profile);
+		return readProcessCredentials(merged.credential_process, profile, signal);
 	}
 
 	if (merged.sso_account_id && merged.sso_role_name) {
@@ -189,8 +189,10 @@ interface CredentialProcessOutput {
 /**
  * Tokenize a `credential_process` command line. Mirrors what botocore /
  * the AWS CLI accept: whitespace-separated argv, with single- or
- * double-quoted segments. Backslash escapes inside double quotes pass
- * through, single quotes are literal. Good enough for the patterns the
+ * double-quoted segments. Single quotes are literal. Inside double quotes,
+ * backslash only escapes `\\` and `\"` (POSIX shell semantics) — every other
+ * `\X` passes through as a literal `\X`, so Windows paths like
+ * `"C:\Path\To\creds.cmd"` survive intact. Good enough for the patterns the
  * AWS docs sanction (e.g. `/usr/local/bin/aws-vault exec foo --json`).
  */
 function tokenizeCredentialProcess(cmd: string): string[] {
@@ -209,9 +211,13 @@ function tokenizeCredentialProcess(cmd: string): string[] {
 			}
 			if (ch === "\\" && quote === '"' && i + 1 < cmd.length) {
 				const next = cmd[i + 1] as string;
-				current += next;
-				i += 2;
-				continue;
+				if (next === "\\" || next === '"') {
+					current += next;
+					i += 2;
+					continue;
+				}
+				// Not an escape sequence — keep the backslash literal so
+				// Windows paths inside double quotes round-trip correctly.
 			}
 			current += ch;
 			i++;
@@ -241,7 +247,11 @@ function tokenizeCredentialProcess(cmd: string): string[] {
 	return tokens;
 }
 
-async function readProcessCredentials(commandLine: string, profile: string): Promise<ResolvedCredentials> {
+async function readProcessCredentials(
+	commandLine: string,
+	profile: string,
+	signal: AbortSignal | undefined,
+): Promise<ResolvedCredentials> {
 	const argv = tokenizeCredentialProcess(commandLine);
 	if (argv.length === 0) {
 		throw new Error(`credential_process for profile '${profile}' is empty`);
@@ -254,6 +264,9 @@ async function readProcessCredentials(commandLine: string, profile: string): Pro
 			// AWS SDKs cap process credential output at 1 MiB.
 			maxBuffer: 1024 * 1024,
 			windowsHide: true,
+			// Propagates AbortSignal aborts to the child via SIGTERM (Node default),
+			// matching the cancellation behavior of the SSO/IMDS branches.
+			signal,
 		});
 		stdout = result.stdout;
 	} catch (err) {

--- a/packages/ai/test/aws-credentials.test.ts
+++ b/packages/ai/test/aws-credentials.test.ts
@@ -182,4 +182,40 @@ describe("aws-credentials credential_process", () => {
 		expect(creds.accessKeyId).toBe("AKIAFROMENV");
 		expect(creds.secretAccessKey).toBe("env-secret");
 	});
+
+	test("preserves backslashes inside double-quoted args (Windows-path tokenization)", async () => {
+		// Reproduces the shape AWS docs document for Windows:
+		//   credential_process = "C:\Tools\creds.cmd" --path "C:\x\y"
+		// The earlier tokenizer ate every backslash inside `"..."`, which would
+		// have turned `C:\x\y` into `C:xy`. The script echoes its argv[1] back
+		// inside the AccessKeyId so we can assert byte-exact preservation.
+		const scriptPath = path.join(tmpDir, "echo-arg.mjs");
+		fs.writeFileSync(
+			scriptPath,
+			`const arg = process.argv[2];\nprocess.stdout.write(JSON.stringify({Version:1,AccessKeyId:arg,SecretAccessKey:"SK"}));\n`,
+			"utf8",
+		);
+		const argWithBackslashes = "C:\\Path\\To\\creds.cmd";
+		writeConfig("windows-args", `"${process.execPath}" "${scriptPath}" "${argWithBackslashes}"`);
+
+		const creds = await resolveAwsCredentials({ profile: "windows-args" });
+		expect(creds.accessKeyId).toBe(argWithBackslashes);
+		expect(creds.secretAccessKey).toBe("SK");
+	});
+
+	test("AbortSignal cancels a hanging credential_process", async () => {
+		// Sleep forever — long enough that the only way the promise resolves is
+		// via the AbortSignal we hand to resolveAwsCredentials.
+		const scriptPath = path.join(tmpDir, "hang.mjs");
+		fs.writeFileSync(scriptPath, "setTimeout(() => {}, 60_000);\n", "utf8");
+		writeConfig("hanging-process", `${process.execPath} ${scriptPath}`);
+
+		const ac = new AbortController();
+		const pending = resolveAwsCredentials({ profile: "hanging-process", signal: ac.signal });
+		// Give the child a tick to actually spawn before aborting.
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		ac.abort();
+
+		await expect(pending).rejects.toThrow(/credential_process for profile 'hanging-process' failed/);
+	});
 });

--- a/packages/ai/test/aws-credentials.test.ts
+++ b/packages/ai/test/aws-credentials.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { clearAwsCredentialCache, resolveAwsCredentials } from "../src/providers/aws-credentials";
+import { withEnv } from "./helpers";
 
 // These tests cover the `credential_process` branch of the AWS credential
 // resolver. We point AWS_CONFIG_FILE / AWS_SHARED_CREDENTIALS_FILE at a
@@ -225,17 +226,12 @@ describe("aws-credentials credential_process", () => {
 			const payload = '{"Version":1,"AccessKeyId":"AKIABARE","SecretAccessKey":"bare-secret"}';
 			fs.writeFileSync(helperPath, `@echo off\r\necho ${payload}\r\n`, "utf8");
 
-			const originalPath = process.env.PATH;
-			process.env.PATH = `${tmpDir};${originalPath ?? ""}`;
-			try {
+			await withEnv({ PATH: `${tmpDir};${process.env.PATH ?? ""}` }, async () => {
 				writeConfig("windows-bare", helperName);
 				const creds = await resolveAwsCredentials({ profile: "windows-bare" });
 				expect(creds.accessKeyId).toBe("AKIABARE");
 				expect(creds.secretAccessKey).toBe("bare-secret");
-			} finally {
-				if (originalPath === undefined) delete process.env.PATH;
-				else process.env.PATH = originalPath;
-			}
+			});
 		},
 	);
 

--- a/packages/ai/test/aws-credentials.test.ts
+++ b/packages/ai/test/aws-credentials.test.ts
@@ -211,6 +211,34 @@ describe("aws-credentials credential_process", () => {
 		},
 	);
 
+	test.skipIf(process.platform !== "win32")(
+		"resolves bare-name Windows helpers via PATHEXT (.cmd shim)",
+		async () => {
+			// Real-world Windows entries often look like
+			//   credential_process = aws-vault exec foo --json
+			// where `aws-vault` has no extension and resolves to `aws-vault.cmd`
+			// (or .exe) through PATH + PATHEXT. That's a shell behavior — Win32
+			// CreateProcess wouldn't find it — so the resolver must use the shell
+			// even when the first token has no extension.
+			const helperName = "omp-test-creds";
+			const helperPath = path.join(tmpDir, `${helperName}.cmd`);
+			const payload = '{"Version":1,"AccessKeyId":"AKIABARE","SecretAccessKey":"bare-secret"}';
+			fs.writeFileSync(helperPath, `@echo off\r\necho ${payload}\r\n`, "utf8");
+
+			const originalPath = process.env.PATH;
+			process.env.PATH = `${tmpDir};${originalPath ?? ""}`;
+			try {
+				writeConfig("windows-bare", helperName);
+				const creds = await resolveAwsCredentials({ profile: "windows-bare" });
+				expect(creds.accessKeyId).toBe("AKIABARE");
+				expect(creds.secretAccessKey).toBe("bare-secret");
+			} finally {
+				if (originalPath === undefined) delete process.env.PATH;
+				else process.env.PATH = originalPath;
+			}
+		},
+	);
+
 	test("AbortSignal cancels a hanging credential_process", async () => {
 		// Sleep forever — long enough that the only way the promise resolves is
 		// via the AbortSignal we hand to resolveAwsCredentials.

--- a/packages/ai/test/aws-credentials.test.ts
+++ b/packages/ai/test/aws-credentials.test.ts
@@ -231,6 +231,32 @@ describe("aws-credentials credential_process", () => {
 		expect(creds.secretAccessKey).toBe("SK");
 	});
 
+	test("treats `\\ ` outside quotes as an escaped literal space (POSIX shell)", async () => {
+		// Without backslash-escape support outside quotes, `arg\ with\ spaces`
+		// would split into three argv entries. POSIX shells (and shlex.split,
+		// which botocore uses) treat `\<char>` outside quotes as a literal
+		// `<char>`, so the helper should receive a single token.
+		const scriptPath = path.join(tmpDir, "echo-arg.mjs");
+		fs.writeFileSync(
+			scriptPath,
+			`const arg = process.argv[2];\nprocess.stdout.write(JSON.stringify({Version:1,AccessKeyId:arg,SecretAccessKey:"SK"}));\n`,
+			"utf8",
+		);
+		writeConfig("escaped-spaces", `${process.execPath} ${scriptPath} arg\\ with\\ spaces`);
+
+		const creds = await resolveAwsCredentials({ profile: "escaped-spaces" });
+		expect(creds.accessKeyId).toBe("arg with spaces");
+		expect(creds.secretAccessKey).toBe("SK");
+	});
+
+	test("rejects a credential_process command line ending in a stray backslash", async () => {
+		writeConfig("trailing-backslash", `${process.execPath} foo\\`);
+
+		await expect(resolveAwsCredentials({ profile: "trailing-backslash" })).rejects.toThrow(
+			/ends with a stray backslash/,
+		);
+	});
+
 	test.skipIf(process.platform !== "win32")(
 		"runs Windows .cmd helpers through cmd.exe (execFile would refuse them)",
 		async () => {

--- a/packages/ai/test/aws-credentials.test.ts
+++ b/packages/ai/test/aws-credentials.test.ts
@@ -95,9 +95,9 @@ describe("aws-credentials credential_process", () => {
 			SessionToken: "session-from-process",
 			Expiration: "2099-01-01T00:00:00Z",
 		});
-		writeConfig("quarry-omp", `${process.execPath} ${script}`);
+		writeConfig("custom-aws-auth-tool", `${process.execPath} ${script}`);
 
-		const creds = await resolveAwsCredentials({ profile: "quarry-omp" });
+		const creds = await resolveAwsCredentials({ profile: "custom-aws-auth-tool" });
 
 		expect(creds.accessKeyId).toBe("AKIAPROCESS");
 		expect(creds.secretAccessKey).toBe("secret-from-process");

--- a/packages/ai/test/aws-credentials.test.ts
+++ b/packages/ai/test/aws-credentials.test.ts
@@ -10,18 +10,6 @@ import { clearAwsCredentialCache, resolveAwsCredentials } from "../src/providers
 // JSON envelope on stdout. The chain falls through env (cleared) and into the
 // profile reader, which spawns the script.
 
-interface SavedEnv {
-	AWS_PROFILE?: string;
-	AWS_REGION?: string;
-	AWS_DEFAULT_REGION?: string;
-	AWS_ACCESS_KEY_ID?: string;
-	AWS_SECRET_ACCESS_KEY?: string;
-	AWS_SESSION_TOKEN?: string;
-	AWS_SHARED_CREDENTIALS_FILE?: string;
-	AWS_CONFIG_FILE?: string;
-	AWS_EC2_METADATA_DISABLED?: string;
-}
-
 const ENV_KEYS = [
 	"AWS_PROFILE",
 	"AWS_REGION",
@@ -33,6 +21,8 @@ const ENV_KEYS = [
 	"AWS_CONFIG_FILE",
 	"AWS_EC2_METADATA_DISABLED",
 ] as const;
+
+type SavedEnv = Partial<Record<(typeof ENV_KEYS)[number], string>>;
 
 let savedEnv: SavedEnv = {};
 let tmpDir: string;

--- a/packages/ai/test/aws-credentials.test.ts
+++ b/packages/ai/test/aws-credentials.test.ts
@@ -133,6 +133,43 @@ describe("aws-credentials credential_process", () => {
 		await expect(resolveAwsCredentials({ profile: "bad-version" })).rejects.toThrow(/unsupported Version/i);
 	});
 
+	test("rejects malformed Expiration values (would otherwise cache as non-expiring)", async () => {
+		// Without this guard, an unparseable Expiration would silently become
+		// `undefined` and the cache would treat the credentials as eternal —
+		// requests would later fail with expired-token errors and the helper
+		// would never be re-invoked.
+		const script = writeProcessScript({
+			Version: 1,
+			AccessKeyId: "AKIA",
+			SecretAccessKey: "secret",
+			Expiration: "not-a-real-timestamp",
+		});
+		writeConfig("bad-expiration", `${process.execPath} ${script}`);
+
+		await expect(resolveAwsCredentials({ profile: "bad-expiration" })).rejects.toThrow(/invalid Expiration/i);
+	});
+
+	test("rejects empty Expiration string (still a malformed envelope)", async () => {
+		const script = writeProcessScript({
+			Version: 1,
+			AccessKeyId: "AKIA",
+			SecretAccessKey: "secret",
+			Expiration: "",
+		});
+		writeConfig("empty-expiration", `${process.execPath} ${script}`);
+
+		await expect(resolveAwsCredentials({ profile: "empty-expiration" })).rejects.toThrow(/invalid Expiration/i);
+	});
+
+	test("rejects responses missing AccessKeyId or SecretAccessKey", async () => {
+		const script = writeProcessScript({ Version: 1, AccessKeyId: "AKIA" });
+		writeConfig("missing-secret", `${process.execPath} ${script}`);
+
+		await expect(resolveAwsCredentials({ profile: "missing-secret" })).rejects.toThrow(
+			/no AccessKeyId\/SecretAccessKey/,
+		);
+	});
+
 	test("surfaces non-zero exit status from the process", async () => {
 		const script = writeFailingScript(7, "boom\n");
 		writeConfig("failing-process", `${process.execPath} ${script}`);

--- a/packages/ai/test/aws-credentials.test.ts
+++ b/packages/ai/test/aws-credentials.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { clearAwsCredentialCache, resolveAwsCredentials } from "../src/providers/aws-credentials";
+
+// These tests cover the `credential_process` branch of the AWS credential
+// resolver. We point AWS_CONFIG_FILE / AWS_SHARED_CREDENTIALS_FILE at a
+// throwaway tmpdir and provide a tiny Bun script that prints the documented
+// JSON envelope on stdout. The chain falls through env (cleared) and into the
+// profile reader, which spawns the script.
+
+interface SavedEnv {
+	AWS_PROFILE?: string;
+	AWS_REGION?: string;
+	AWS_DEFAULT_REGION?: string;
+	AWS_ACCESS_KEY_ID?: string;
+	AWS_SECRET_ACCESS_KEY?: string;
+	AWS_SESSION_TOKEN?: string;
+	AWS_SHARED_CREDENTIALS_FILE?: string;
+	AWS_CONFIG_FILE?: string;
+	AWS_EC2_METADATA_DISABLED?: string;
+}
+
+const ENV_KEYS = [
+	"AWS_PROFILE",
+	"AWS_REGION",
+	"AWS_DEFAULT_REGION",
+	"AWS_ACCESS_KEY_ID",
+	"AWS_SECRET_ACCESS_KEY",
+	"AWS_SESSION_TOKEN",
+	"AWS_SHARED_CREDENTIALS_FILE",
+	"AWS_CONFIG_FILE",
+	"AWS_EC2_METADATA_DISABLED",
+] as const;
+
+let savedEnv: SavedEnv = {};
+let tmpDir: string;
+
+function snapshotEnv() {
+	savedEnv = {};
+	for (const k of ENV_KEYS) {
+		const v = process.env[k];
+		if (v !== undefined) savedEnv[k] = v;
+		delete process.env[k];
+	}
+}
+
+function restoreEnv() {
+	for (const k of ENV_KEYS) {
+		const v = savedEnv[k];
+		if (v !== undefined) process.env[k] = v;
+		else delete process.env[k];
+	}
+}
+
+function writeProcessScript(payload: object): string {
+	const scriptPath = path.join(tmpDir, "creds-process.mjs");
+	fs.writeFileSync(scriptPath, `process.stdout.write(${JSON.stringify(JSON.stringify(payload))});\n`, "utf8");
+	return scriptPath;
+}
+
+function writeFailingScript(exitCode: number, stderr = ""): string {
+	const scriptPath = path.join(tmpDir, "creds-process-fail.mjs");
+	fs.writeFileSync(
+		scriptPath,
+		`process.stderr.write(${JSON.stringify(stderr)});\nprocess.exit(${exitCode});\n`,
+		"utf8",
+	);
+	return scriptPath;
+}
+
+function writeConfig(profile: string, command: string) {
+	fs.writeFileSync(
+		path.join(tmpDir, "config"),
+		`[profile ${profile}]\ncredential_process = ${command}\nregion = us-east-1\n`,
+		"utf8",
+	);
+	fs.writeFileSync(path.join(tmpDir, "credentials"), "", "utf8");
+	process.env.AWS_CONFIG_FILE = path.join(tmpDir, "config");
+	process.env.AWS_SHARED_CREDENTIALS_FILE = path.join(tmpDir, "credentials");
+	// Disable IMDS fallback so a missing process branch surfaces as an error
+	// instead of timing out against the metadata service.
+	process.env.AWS_EC2_METADATA_DISABLED = "true";
+}
+
+beforeEach(() => {
+	snapshotEnv();
+	tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "aws-credentials-test-"));
+	clearAwsCredentialCache();
+});
+
+afterEach(() => {
+	restoreEnv();
+	clearAwsCredentialCache();
+	fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("aws-credentials credential_process", () => {
+	test("spawns the configured process and parses Version 1 JSON", async () => {
+		const script = writeProcessScript({
+			Version: 1,
+			AccessKeyId: "AKIAPROCESS",
+			SecretAccessKey: "secret-from-process",
+			SessionToken: "session-from-process",
+			Expiration: "2099-01-01T00:00:00Z",
+		});
+		writeConfig("quarry-omp", `${process.execPath} ${script}`);
+
+		const creds = await resolveAwsCredentials({ profile: "quarry-omp" });
+
+		expect(creds.accessKeyId).toBe("AKIAPROCESS");
+		expect(creds.secretAccessKey).toBe("secret-from-process");
+		expect(creds.sessionToken).toBe("session-from-process");
+		expect(creds.expiresAt).toBe(Date.parse("2099-01-01T00:00:00Z"));
+	});
+
+	test("omits sessionToken/expiresAt when the process does not provide them", async () => {
+		const script = writeProcessScript({
+			Version: 1,
+			AccessKeyId: "AKIASTATIC",
+			SecretAccessKey: "static-secret",
+		});
+		writeConfig("static-process", `${process.execPath} ${script}`);
+
+		const creds = await resolveAwsCredentials({ profile: "static-process" });
+
+		expect(creds.accessKeyId).toBe("AKIASTATIC");
+		expect(creds.secretAccessKey).toBe("static-secret");
+		expect(creds.sessionToken).toBeUndefined();
+		expect(creds.expiresAt).toBeUndefined();
+	});
+
+	test("rejects unsupported Version values", async () => {
+		const script = writeProcessScript({
+			Version: 2,
+			AccessKeyId: "AKIA",
+			SecretAccessKey: "secret",
+		});
+		writeConfig("bad-version", `${process.execPath} ${script}`);
+
+		await expect(resolveAwsCredentials({ profile: "bad-version" })).rejects.toThrow(/unsupported Version/i);
+	});
+
+	test("surfaces non-zero exit status from the process", async () => {
+		const script = writeFailingScript(7, "boom\n");
+		writeConfig("failing-process", `${process.execPath} ${script}`);
+
+		await expect(resolveAwsCredentials({ profile: "failing-process" })).rejects.toThrow(
+			/credential_process for profile 'failing-process' failed/,
+		);
+	});
+
+	test("honors quoted arguments in the command line", async () => {
+		const dirWithSpace = path.join(tmpDir, "dir with space");
+		fs.mkdirSync(dirWithSpace);
+		const scriptPath = path.join(dirWithSpace, "creds.mjs");
+		fs.writeFileSync(
+			scriptPath,
+			`process.stdout.write(JSON.stringify({Version:1,AccessKeyId:"AK",SecretAccessKey:"SK"}));\n`,
+			"utf8",
+		);
+		writeConfig("quoted-args", `"${process.execPath}" "${scriptPath}"`);
+
+		const creds = await resolveAwsCredentials({ profile: "quoted-args" });
+		expect(creds.accessKeyId).toBe("AK");
+		expect(creds.secretAccessKey).toBe("SK");
+	});
+
+	test("env credentials still win over credential_process (chain order)", async () => {
+		const script = writeProcessScript({
+			Version: 1,
+			AccessKeyId: "AKIAPROCESS",
+			SecretAccessKey: "process-secret",
+		});
+		writeConfig("env-wins", `${process.execPath} ${script}`);
+
+		process.env.AWS_ACCESS_KEY_ID = "AKIAFROMENV";
+		process.env.AWS_SECRET_ACCESS_KEY = "env-secret";
+
+		const creds = await resolveAwsCredentials({ profile: "env-wins" });
+		expect(creds.accessKeyId).toBe("AKIAFROMENV");
+		expect(creds.secretAccessKey).toBe("env-secret");
+	});
+});

--- a/packages/ai/test/aws-credentials.test.ts
+++ b/packages/ai/test/aws-credentials.test.ts
@@ -193,6 +193,24 @@ describe("aws-credentials credential_process", () => {
 		expect(creds.secretAccessKey).toBe("SK");
 	});
 
+	test.skipIf(process.platform !== "win32")(
+		"runs Windows .cmd helpers through cmd.exe (execFile would refuse them)",
+		async () => {
+			// Node's execFile cannot launch .cmd / .bat directly on Windows, but the
+			// AWS docs include .cmd examples, so the resolver must route those
+			// through the shell. We write a tiny .cmd that prints the JSON envelope
+			// and assert it's invoked successfully.
+			const cmdPath = path.join(tmpDir, "creds.cmd");
+			const payload = '{"Version":1,"AccessKeyId":"AKIACMD","SecretAccessKey":"cmd-secret"}';
+			fs.writeFileSync(cmdPath, `@echo off\r\necho ${payload}\r\n`, "utf8");
+			writeConfig("windows-cmd", `"${cmdPath}"`);
+
+			const creds = await resolveAwsCredentials({ profile: "windows-cmd" });
+			expect(creds.accessKeyId).toBe("AKIACMD");
+			expect(creds.secretAccessKey).toBe("cmd-secret");
+		},
+	);
+
 	test("AbortSignal cancels a hanging credential_process", async () => {
 		// Sleep forever — long enough that the only way the promise resolves is
 		// via the AbortSignal we hand to resolveAwsCredentials.


### PR DESCRIPTION
## Summary

- Adds `credential_process` to the AWS credential resolution chain in `packages/ai/src/providers/aws-credentials.ts`. Profiles configured as `credential_process = <cmd>` (used by `aws-vault`, `leapp`, organization-specific session-token brokers, etc.) currently fall through every branch and surface as `Unable to resolve AWS credentials. Set AWS_ACCESS_KEY_ID+AWS_SECRET_ACCESS_KEY, or configure profile '<name>' in ~/.aws/credentials (or ~/.aws/config for SSO).`
- The new branch spawns the configured command and parses the documented Version 1 JSON envelope (`AccessKeyId`, `SecretAccessKey`, optional `SessionToken`, optional `Expiration`), matching the AWS CLI / SDK contract. `Expiration` is honored by the existing per-profile credential cache, so the process is invoked at most once per refresh cycle.
- Resolver order is preserved: env vars still win, static profile keys still beat the process branch, and SSO is consulted only when neither static keys nor `credential_process` are set.

## Why

Came up against this on `oh-my-pi` 15.1.3 with a `~/.aws/config` profile of the form:

```
[profile aws-omp]
credential_process = /opt/homebrew/bin/custom-aws-auth-tool
region = us-east-1
```

`8c474ca0` ("feat(ai): added AWS auth and Bedrock stream decoding with SigV4") replaced the AWS SDK with a hand-rolled chain that intentionally trims the SDK surface, but `credential_process` is the standard way to plug session-token helpers into AWS tooling, so dropping it makes those profiles unreachable. This PR re-adds just that branch — no other resolver behavior changes.

## Test plan

- [x] New `packages/ai/test/aws-credentials.test.ts` covering: happy path with full envelope, partial envelope (no session token / no expiration), unsupported `Version`, non-zero exit, quoted-args tokenization, env-vars-win precedence
- [x] `bun test packages/ai/test/aws-credentials.test.ts` — 6/6 pass
- [x] `bun test packages/ai/test/aws-sigv4.test.ts packages/ai/test/aws-eventstream.test.ts` — 12/12 pass (no regression in adjacent AWS tests)
- [x] `bun --cwd=packages/ai run check:types` clean
- [x] `bun --cwd=packages/ai run lint` clean
- [x] Manual smoke against a real `credential_process` profile (`/opt/homebrew/bin/custom-aws-auth-tool`): returns valid `accessKeyId` / `sessionToken` / `expiresAt`