### PR TITLE
fix(acp): drain async deliveries before prompt completion

### DIFF
--- a/packages/coding-agent/src/async/job-manager.ts
+++ b/packages/coding-agent/src/async/job-manager.ts
@@ -219,22 +219,23 @@ export class AsyncJobManager {
 		return this.#filterJobs(this.#jobs.values(), filter);
 	}
 
-	getDeliveryState(): AsyncJobDeliveryState {
-		const nextRetryAt = this.#deliveries.reduce<number | undefined>((next, delivery) => {
+	getDeliveryState(filter?: AsyncJobFilter): AsyncJobDeliveryState {
+		const deliveries = this.#filterDeliveries(filter);
+		const nextRetryAt = deliveries.reduce<number | undefined>((next, delivery) => {
 			if (next === undefined) return delivery.nextAttemptAt;
 			return Math.min(next, delivery.nextAttemptAt);
 		}, undefined);
 
 		return {
-			queued: this.#deliveries.length,
-			delivering: this.#deliveryLoop !== undefined,
+			queued: deliveries.length,
+			delivering: this.#deliveryLoop !== undefined && deliveries.length > 0,
 			nextRetryAt,
-			pendingJobIds: this.#deliveries.map(delivery => delivery.jobId),
+			pendingJobIds: deliveries.map(delivery => delivery.jobId),
 		};
 	}
 
-	hasPendingDeliveries(): boolean {
-		return this.#deliveries.length > 0;
+	hasPendingDeliveries(filter?: AsyncJobFilter): boolean {
+		return this.getDeliveryState(filter).queued > 0;
 	}
 
 	watchJobs(jobIds: string[]): number {
@@ -290,12 +291,19 @@ export class AsyncJobManager {
 		await Promise.all(Array.from(this.#jobs.values()).map(job => job.promise));
 	}
 
-	async drainDeliveries(options?: { timeoutMs?: number }): Promise<boolean> {
+	async drainDeliveries(options?: { timeoutMs?: number; filter?: AsyncJobFilter }): Promise<boolean> {
 		const timeoutMs = options?.timeoutMs;
+		const filter = options?.filter;
 		const hasDeadline = timeoutMs !== undefined;
 		const deadline = hasDeadline ? Date.now() + Math.max(timeoutMs, 0) : Number.POSITIVE_INFINITY;
 
-		while (this.hasPendingDeliveries()) {
+		while (this.hasPendingDeliveries(filter)) {
+			if (filter?.ownerId) {
+				const delivered = await this.#deliverNextFiltered(filter, deadline);
+				if (delivered) continue;
+				return false;
+			}
+
 			this.#ensureDeliveryLoop();
 			const loop = this.#deliveryLoop;
 			if (!loop) {
@@ -313,7 +321,7 @@ export class AsyncJobManager {
 			}
 
 			await Promise.race([loop, Bun.sleep(remainingMs)]);
-			if (Date.now() >= deadline && this.hasPendingDeliveries()) {
+			if (Date.now() >= deadline && this.hasPendingDeliveries(filter)) {
 				return false;
 			}
 		}
@@ -388,6 +396,52 @@ export class AsyncJobManager {
 		this.#evictionTimers.clear();
 	}
 
+	#filterDeliveries(filter?: AsyncJobFilter): AsyncJobDelivery[] {
+		const ownerId = filter?.ownerId;
+		if (!ownerId) return this.#deliveries;
+		return this.#deliveries.filter(delivery => this.#jobs.get(delivery.jobId)?.ownerId === ownerId);
+	}
+
+	async #deliverNextFiltered(filter: AsyncJobFilter, deadline: number): Promise<boolean> {
+		let selected: AsyncJobDelivery | undefined;
+		for (const delivery of this.#deliveries) {
+			if (this.#jobs.get(delivery.jobId)?.ownerId !== filter.ownerId) continue;
+			if (this.isDeliverySuppressed(delivery.jobId)) continue;
+			if (!selected || delivery.nextAttemptAt < selected.nextAttemptAt) {
+				selected = delivery;
+			}
+		}
+		if (!selected) return true;
+
+		const now = Date.now();
+		if (selected.nextAttemptAt > now) {
+			if (selected.nextAttemptAt > deadline) return false;
+			await Bun.sleep(selected.nextAttemptAt - now);
+		}
+
+		const index = this.#deliveries.indexOf(selected);
+		if (index === -1) return true;
+
+		try {
+			await this.#onJobComplete(selected.jobId, selected.text, this.#jobs.get(selected.jobId));
+			this.#deliveries.splice(index, 1);
+		} catch (error) {
+			selected.attempt += 1;
+			selected.lastError = error instanceof Error ? error.message : String(error);
+			selected.nextAttemptAt = Date.now() + this.#getRetryDelay(selected.attempt);
+			this.#deliveries.splice(index, 1);
+			if (!this.isDeliverySuppressed(selected.jobId)) {
+				this.#deliveries.push(selected);
+			}
+			logger.warn("Async job completion delivery failed", {
+				jobId: selected.jobId,
+				attempt: selected.attempt,
+				nextRetryAt: selected.nextAttemptAt,
+				error: selected.lastError,
+			});
+		}
+		return true;
+	}
 	isDeliverySuppressed(jobId: string): boolean {
 		return this.#suppressedDeliveries.has(jobId) || this.#watchedJobs.has(jobId);
 	}

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -87,6 +87,8 @@ const SESSION_PAGE_SIZE = 50;
  */
 export const ACP_BOOTSTRAP_RACE_GUARD_MS = 50;
 const ACP_CANCEL_CLEANUP_TIMEOUT_MS = 5_000;
+const ACP_ASYNC_DELIVERY_DRAIN_TIMEOUT_MS = 250;
+const ACP_ASYNC_DELIVERY_DRAIN_MAX_PASSES = 3;
 
 type AgentImageContent = {
 	type: "image";
@@ -1037,13 +1039,27 @@ export class AcpAgent implements Agent {
 
 		if (event.type === "agent_end") {
 			await this.#emitEndOfTurnUpdates(record);
-			await record.session.waitForIdle();
+			await this.#waitForAcpPromptIdle(record);
 			this.#finishPrompt(record, {
 				stopReason: this.#resolveStopReason(event, promptTurn.cancelRequested),
 				usage: this.#buildTurnUsage(promptTurn.usageBaseline, record.session.sessionManager.getUsageStatistics()),
 				userMessageId: promptTurn.userMessageId,
 			});
 		}
+	}
+
+	async #waitForAcpPromptIdle(record: ManagedSessionRecord): Promise<void> {
+		for (let pass = 0; pass < ACP_ASYNC_DELIVERY_DRAIN_MAX_PASSES; pass++) {
+			await record.session.waitForIdle();
+			const delivered = await record.session.drainAsyncJobDeliveriesForAcp({
+				timeoutMs: ACP_ASYNC_DELIVERY_DRAIN_TIMEOUT_MS,
+			});
+			if (!delivered) {
+				return;
+			}
+		}
+
+		await record.session.waitForIdle();
 	}
 
 	#prepareLiveAssistantMessage(record: ManagedSessionRecord, event: AgentSessionEvent): void {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1148,6 +1148,21 @@ export class AgentSession {
 		return { running, recent };
 	}
 
+	async drainAsyncJobDeliveriesForAcp(options?: { timeoutMs?: number }): Promise<boolean> {
+		const manager = AsyncJobManager.instance();
+		if (!manager) return false;
+		const filter = this.#agentId ? { ownerId: this.#agentId } : undefined;
+		if (!manager.hasPendingDeliveries(filter)) return false;
+		const drained = await manager.drainDeliveries({ timeoutMs: options?.timeoutMs, filter });
+		if (!drained) {
+			logger.warn("Async job completion deliveries still pending after ACP prompt drain", {
+				...manager.getDeliveryState(filter),
+			});
+			return false;
+		}
+		return true;
+	}
+
 	/**
 	 * Cancel async jobs registered by *this* agent only. Used by lifecycle
 	 * transitions (newSession, switchSession, handoff, dispose) so a subagent

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -101,6 +101,7 @@ class FakeAgentSession {
 	planModeState: PlanModeState | undefined;
 	waitForIdleCalls = 0;
 	waitForIdleBlocker: (() => Promise<void>) | undefined;
+	asyncJobDrain: ((options?: { timeoutMs?: number }) => Promise<boolean>) | undefined;
 	#listeners = new Set<(event: AgentSessionEvent) => void>();
 
 	constructor(
@@ -195,6 +196,10 @@ class FakeAgentSession {
 	async waitForIdle(): Promise<void> {
 		this.waitForIdleCalls++;
 		await this.waitForIdleBlocker?.();
+	}
+
+	async drainAsyncJobDeliveriesForAcp(options?: { timeoutMs?: number }): Promise<boolean> {
+		return this.asyncJobDrain?.(options) ?? false;
 	}
 
 	async abort(): Promise<void> {
@@ -957,6 +962,84 @@ describe("ACP agent", () => {
 			harness.abortController.abort();
 			await Bun.sleep(0);
 		}
+	});
+
+	it("drains async job deliveries before completing the ACP prompt", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		let releaseDelivery!: () => void;
+		let drainCalls = 0;
+		const deliveryBlocked = Promise.withResolvers<void>();
+		const deliveryRelease = new Promise<void>(resolve => {
+			releaseDelivery = resolve;
+		});
+		session.asyncJobDrain = async () => {
+			drainCalls++;
+			if (drainCalls > 1) return false;
+			deliveryBlocked.resolve();
+			await deliveryRelease;
+			return true;
+		};
+
+		const prompt = harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000047",
+			prompt: [{ type: "text", text: "wait for async delivery" }],
+		} as PromptRequest);
+		await deliveryBlocked.promise;
+
+		try {
+			const returnedBeforeDelivery = await Promise.race([prompt.then(() => true), Bun.sleep(0).then(() => false)]);
+			expect(returnedBeforeDelivery).toBe(false);
+			expect(session.waitForIdleCalls).toBe(1);
+
+			releaseDelivery();
+			const response = await prompt;
+			expect(response.userMessageId).toBe("00000000-0000-4000-8000-000000000047");
+			expect(session.waitForIdleCalls).toBe(2);
+			expect(drainCalls).toBe(2);
+		} finally {
+			releaseDelivery();
+			harness.abortController.abort();
+			await Bun.sleep(0);
+		}
+	});
+
+	it("keeps async delivery follow-up updates inside the owning ACP prompt", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		let delivered = false;
+		let drainCalls = 0;
+		session.asyncJobDrain = async () => {
+			drainCalls++;
+			if (delivered) return false;
+			delivered = true;
+			const assistantMessage = makeAssistantMessage("async continuation");
+			for (const listener of session.listeners()) {
+				listener({
+					type: "message_update",
+					message: assistantMessage,
+					assistantMessageEvent: { type: "text_delta", delta: "async continuation" },
+				} as AgentSessionEvent);
+			}
+			return true;
+		};
+
+		await harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000048",
+			prompt: [{ type: "text", text: "deliver async follow-up" }],
+		} as PromptRequest);
+
+		expect(harness.updates.some(notification => JSON.stringify(notification).includes("async continuation"))).toBe(
+			true,
+		);
+		expect(session.waitForIdleCalls).toBe(2);
+		expect(drainCalls).toBe(2);
+		harness.abortController.abort();
+		await Bun.sleep(0);
 	});
 
 	it("queues next prompt until AgentSession idle cleanup completes", async () => {

--- a/packages/coding-agent/test/async-job-manager.test.ts
+++ b/packages/coding-agent/test/async-job-manager.test.ts
@@ -229,6 +229,38 @@ describe("AsyncJobManager", () => {
 		expect(manager.hasPendingDeliveries()).toBe(false);
 	});
 
+	test("scoped delivery drain returns once matching owner deliveries finish", async () => {
+		let firstOwnerAttempts = 0;
+		const secondOwnerCompletions: Array<{ jobId: string; text: string }> = [];
+		const manager = new AsyncJobManager({
+			onJobComplete: async (jobId, text, job) => {
+				if (job?.ownerId === "0-Main") {
+					firstOwnerAttempts++;
+					throw new Error("first owner delivery retry");
+				}
+				secondOwnerCompletions.push({ jobId, text });
+			},
+		});
+
+		manager.register("task", "main job", async () => "main result", { ownerId: "0-Main" });
+		const targetJobId = manager.register("task", "subagent job", async () => "subagent result", {
+			ownerId: "3-AuthLoader",
+		});
+		await manager.waitForAll();
+		const firstAttemptDeadline = Date.now() + 2_000;
+		while (firstOwnerAttempts === 0) {
+			if (Date.now() >= firstAttemptDeadline) throw new Error("Timed out waiting for first owner delivery attempt");
+			await Bun.sleep(5);
+		}
+
+		const drained = await manager.drainDeliveries({ timeoutMs: 50, filter: { ownerId: "3-AuthLoader" } });
+
+		expect(drained).toBe(true);
+		expect(secondOwnerCompletions).toEqual([{ jobId: targetJobId, text: "subagent result" }]);
+		expect(manager.hasPendingDeliveries({ ownerId: "3-AuthLoader" })).toBe(false);
+		expect(manager.hasPendingDeliveries({ ownerId: "0-Main" })).toBe(true);
+	});
+
 	test("cancelAll with ownerId only cancels matching jobs", async () => {
 		const manager = new AsyncJobManager({
 			onJobComplete: async () => {},


### PR DESCRIPTION
## Summary

- drain scoped async job deliveries before resolving an ACP prompt after `agent_end`
- keep async delivery follow-up updates inside the owning `session/prompt` lifecycle
- make `AsyncJobManager.drainDeliveries({ filter })` stop waiting on the global delivery loop when a different owner has retry-delayed deliveries

Stacked on #1140. Complements the guard-only fix there by adding the async-delivery drain piece from #1137.

Supersedes the drain/filtering part of #1138 and addresses its P1 review feedback about scoped drains waiting on the global delivery loop: https://github.com/can1357/oh-my-pi/pull/1138#discussion_r3254049922

Note: CI is not expected to auto-run while this PR is stacked on #1140 because the workflow's `pull_request` trigger only targets `main`. Checks should run after retargeting/rebasing onto `main` once #1140 lands, or via manual workflow dispatch.

## Test plan

- `bun test packages/coding-agent/test/async-job-manager.test.ts -t "scoped delivery drain returns once matching owner deliveries finish"`
- `bun test packages/coding-agent/test/async-job-manager.test.ts -t "scoped delivery drain returns once matching owner deliveries finish|forwards progress updates and delivers completion|acknowledgeDeliveries suppresses pending retries" packages/coding-agent/test/acp-agent.test.ts -t "drains async job deliveries|keeps async delivery follow-up|waits for AgentSession idle cleanup after agent_end before returning|closes the ACP session when cancel cleanup times out"`
- `bun run check:ts`
