### PR TITLE
fix(tui): compress deep session tree gutters

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the session tree selector to preserve a readable message column when deeply nested branch gutters would otherwise consume the viewport. ([#1144](https://github.com/can1357/oh-my-pi/issues/1144))
+
 ## [15.1.3] - 2026-05-17
 ### Breaking Changes
 

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -453,6 +453,16 @@ class TreeList implements Component {
 		);
 		const endIndex = Math.min(startIndex + this.maxVisibleLines, this.#filteredNodes.length);
 
+		// Cap the per-row gutter prefix so a content budget is always preserved.
+		// Each indent level renders as 3 cells; deep branching would otherwise eat the
+		// entire viewport (issue #1144). Reserve at least MIN_CONTENT_COLS for entry
+		// text — or half the viewport, whichever is larger — and compress older gutter
+		// levels off-screen behind a leading ellipsis when the row would exceed budget.
+		const MIN_CONTENT_COLS = 24;
+		const OVERHEAD_COLS = 4; // cursor (2) + a touch of breathing room
+		const contentReserve = Math.max(MIN_CONTENT_COLS, Math.floor(width / 2));
+		const maxIndentLevels = Math.max(1, Math.floor((width - contentReserve - OVERHEAD_COLS) / 3));
+
 		for (let i = startIndex; i < endIndex; i++) {
 			const flatNode = this.#filteredNodes[i];
 			const entry = flatNode.node.entry;
@@ -464,29 +474,34 @@ class TreeList implements Component {
 			// If multiple roots, shift display (roots at 0, not 1)
 			const displayIndent = this.#multipleRoots ? Math.max(0, flatNode.indent - 1) : flatNode.indent;
 
-			// Build prefix with gutters at their correct positions
-			// Each gutter has a position (displayIndent where its connector was shown)
+			// Build prefix with gutters at their correct positions, clamped to
+			// `maxIndentLevels` cells so the content always fits. When clamped, the
+			// leftmost cells represent the deepest visible ancestors and a `…` marker
+			// indicates older branch context has been compressed.
 			const hasConnector = flatNode.showConnector && !flatNode.isVirtualRootChild;
 			const connectorSymbol = hasConnector ? (flatNode.isLast ? theme.tree.last : theme.tree.branch) : "";
 			const connectorChars = hasConnector ? Array.from(connectorSymbol) : [];
-			const connectorPosition = hasConnector ? displayIndent - 1 : -1;
+			const renderedIndent = Math.min(displayIndent, maxIndentLevels);
+			const scrollOffset = displayIndent - renderedIndent;
+			const connectorPositionDisplay = hasConnector ? renderedIndent - 1 : -1;
 
 			// Build prefix char by char, placing gutters and connector at their positions
-			const totalChars = displayIndent * 3;
+			const totalChars = renderedIndent * 3;
 			const prefixChars: string[] = [];
 			for (let i = 0; i < totalChars; i++) {
 				const level = Math.floor(i / 3);
+				const originalLevel = level + scrollOffset;
 				const posInLevel = i % 3;
 
-				// Check if there's a gutter at this level
-				const gutter = flatNode.gutters.find(g => g.position === level);
+				// Check if there's a gutter at this level (translated to original tree depth)
+				const gutter = flatNode.gutters.find(g => g.position === originalLevel);
 				if (gutter) {
 					if (posInLevel === 0) {
 						prefixChars.push(gutter.show ? theme.tree.vertical : " ");
 					} else {
 						prefixChars.push(" ");
 					}
-				} else if (hasConnector && level === connectorPosition) {
+				} else if (hasConnector && level === connectorPositionDisplay) {
 					// Connector at this level
 					if (posInLevel === 0) {
 						prefixChars.push(connectorChars[0] ?? " ");
@@ -498,6 +513,10 @@ class TreeList implements Component {
 				} else {
 					prefixChars.push(" ");
 				}
+			}
+			// Mark the leftmost cell when ancestors were compressed off-screen.
+			if (scrollOffset > 0 && prefixChars.length > 0) {
+				prefixChars[0] = "…";
 			}
 			const prefix = prefixChars.join("");
 

--- a/packages/coding-agent/test/modes/components/tree-selector-overflow.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-overflow.test.ts
@@ -1,0 +1,77 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { TreeSelectorComponent } from "../../../src/modes/components/tree-selector";
+import * as themeModule from "../../../src/modes/theme/theme";
+import type { SessionEntry, SessionTreeNode } from "../../../src/session/session-manager";
+
+let counter = 0;
+function makeUserNode(text: string, parentId: string | null = null): SessionTreeNode {
+	const id = `entry-${counter++}`;
+	const message: AgentMessage = { role: "user", content: text, timestamp: counter };
+	const entry: SessionEntry = {
+		type: "message",
+		id,
+		parentId,
+		timestamp: new Date().toISOString(),
+		message,
+	};
+	return { entry, children: [] };
+}
+
+/** Build a tree where every parent has two children, simulating heavy rewind branching. */
+function buildBranchyTree(branchDepth: number): { root: SessionTreeNode; leaf: SessionTreeNode } {
+	const root = makeUserNode("root");
+	let current = root;
+	for (let i = 0; i < branchDepth; i++) {
+		const a = makeUserNode(`branch-${i}-a`, current.entry.id);
+		const b = makeUserNode(`branch-${i}-b-this-side-stays-active`, current.entry.id);
+		current.children.push(a, b);
+		current = b;
+	}
+	return { root, leaf: current };
+}
+
+function renderSelector(tree: SessionTreeNode, leafId: string, width: number): string[] {
+	const selector = new TreeSelectorComponent(
+		[tree],
+		leafId,
+		200,
+		() => {},
+		() => {},
+	);
+	return selector.render(width).map(line => Bun.stripANSI(line));
+}
+
+describe("TreeSelectorComponent deep branching overflow", () => {
+	beforeAll(async () => {
+		await themeModule.initTheme(false, undefined, undefined, "dark", "light");
+	});
+
+	it("keeps the selected entry text visible when branching exceeds the viewport width", () => {
+		const { root, leaf } = buildBranchyTree(80);
+		const width = 120;
+		const rendered = renderSelector(root, leaf.entry.id, width);
+
+		// Every rendered row must fit the viewport — never wider than `width` display cols.
+		for (const line of rendered) {
+			expect(Bun.stringWidth(line, { countAnsiEscapeCodes: false })).toBeLessThanOrEqual(width);
+		}
+
+		// The selected row (marked with the `›` cursor) must still show the entry text
+		// instead of spending the whole viewport on branch gutters.
+		const selectedRow = rendered.find(line => line.trimStart().startsWith("›"));
+		expect(selectedRow).toBeDefined();
+		expect(selectedRow!).toContain("user:");
+		expect(selectedRow!).toMatch(/branch-\d+-b/);
+	});
+
+	it("preserves prefix budget so the selected entry text remains legible at narrow width", () => {
+		const { root, leaf } = buildBranchyTree(40);
+		const width = 80;
+		const rendered = renderSelector(root, leaf.entry.id, width);
+
+		const selectedRow = rendered.find(line => line.trimStart().startsWith("›"));
+		expect(selectedRow).toBeDefined();
+		expect(selectedRow!).toContain("user:");
+	});
+});


### PR DESCRIPTION
## Repro
A synthetic session tree with 80 repeated rewind-style branch points reproduces the reporter's screenshot: run `bun test packages/coding-agent/test/modes/components/tree-selector-overflow.test.ts` before the fix and the selected row renders as gutter-only text (`› │  │  │  …`) with no `user:` message content visible.

## Cause
`TreeList.render()` in `packages/coding-agent/src/modes/components/tree-selector.ts` rendered the gutter prefix as `displayIndent * 3` cells. `#flattenTree()` increments indent for each branch point, so heavily branched sessions can produce a prefix wider than the terminal; `truncateToWidth()` then truncates the row before the entry text is reached.

## Fix
- Reserved a minimum readable content budget before rendering session-tree gutters.
- Clamped each row's visible gutter depth to the remaining prefix budget.
- Shifted deeper gutter rows to the most recent visible ancestors and added a leading `…` when older branch context is compressed.
- Added regression coverage for wide and narrow viewports with deep branch trees.
- Added the coding-agent changelog entry under `[Unreleased]`.

## Verification
`bun test packages/coding-agent/test/modes/components/tree-selector-overflow.test.ts packages/coding-agent/test/modes/components/tree-selector-developer.test.ts` passed with 4 tests and 120 expectations. `bun run check:ts` passed. Fixes #1144