### PR TITLE
fix(ai): normalize OpenAI object tool schemas

### DIFF
--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -40,7 +40,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
 import { getOpenAIStreamIdleTimeoutMs, iterateWithIdleTimeout } from "../utils/idle-iterator";
 import { parseStreamingJson } from "../utils/json-parse";
-import { adaptSchemaForStrict, NO_STRICT, toolWireSchema } from "../utils/schema";
+import { adaptSchemaForStrict, ensureObjectProperties, NO_STRICT, toolWireSchema } from "../utils/schema";
 import { compactGrammarDefinition } from "./grammar";
 import { CODEX_BASE_URL, getCodexAccountId, OPENAI_HEADER_VALUES, OPENAI_HEADERS } from "./openai-codex/constants";
 import {
@@ -2486,7 +2486,10 @@ export function convertOpenAICodexResponsesTools(
 		}
 		const strict = !!(!NO_STRICT && tool.strict);
 		const baseParameters = toolWireSchema(tool);
-		const { schema: parameters, strict: effectiveStrict } = adaptSchemaForStrict(baseParameters, strict);
+		const { schema: parameters, strict: effectiveStrict } = adaptSchemaForStrict(
+			ensureObjectProperties(baseParameters) as Record<string, unknown>,
+			strict,
+		);
 		return {
 			type: "function",
 			name: tool.name,

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -865,7 +865,121 @@ export function normalizeSchemaForMCP(value: unknown): unknown {
  * would not survive).
  */
 export function sanitizeSchemaForOpenAIResponses(schema: JsonObject): JsonObject {
-	return rewriteOneOfToAnyOf(schema) as JsonObject;
+	return rewriteOneOfToAnyOf(ensureObjectProperties(schema)) as JsonObject;
+}
+
+const OPENAI_SCHEMA_MAP_KEYS = new Set([
+	"$defs",
+	"definitions",
+	"dependencies",
+	"dependentSchemas",
+	"patternProperties",
+	"properties",
+]);
+const OPENAI_SCHEMA_ARRAY_KEYS = new Set(["allOf", "anyOf", "oneOf", "prefixItems"]);
+const OPENAI_SCHEMA_VALUE_KEYS = new Set([
+	"additionalItems",
+	"additionalProperties",
+	"contains",
+	"else",
+	"contentSchema",
+	"if",
+	"items",
+	"not",
+	"propertyNames",
+	"then",
+	"unevaluatedItems",
+	"unevaluatedProperties",
+]);
+
+/**
+ * Ensure every JSON Schema node with `type: "object"` has a `properties` field.
+ * OpenAI's Responses and Codex APIs reject object schemas that lack
+ * `properties` — even `{ "type": "object" }` is invalid without it.
+ *
+ * Traversal is schema-aware: it follows schema-valued keywords but does not walk
+ * literal payload containers such as `enum`, `const`, `default`, or `examples`.
+ */
+export function ensureObjectProperties(value: unknown): unknown {
+	return ensureObjectPropertiesImpl(value, new WeakMap(), new WeakSet());
+}
+
+function ensureObjectPropertiesImpl(
+	value: unknown,
+	cache: WeakMap<object, unknown>,
+	visiting: WeakSet<object>,
+): unknown {
+	if (!isJsonObject(value) && !Array.isArray(value)) {
+		return value;
+	}
+
+	if (visiting.has(value)) {
+		return {};
+	}
+	const cached = cache.get(value);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	visiting.add(value);
+	if (Array.isArray(value)) {
+		let changed = false;
+		const mapped = value.map(item => {
+			const next = ensureObjectPropertiesImpl(item, cache, visiting);
+			if (next !== item) changed = true;
+			return next;
+		});
+		const result = changed ? mapped : value;
+		cache.set(value, result);
+		visiting.delete(value);
+		return result;
+	}
+
+	let changed = false;
+	const result: Record<string, unknown> = {};
+	for (const [key, child] of Object.entries(value)) {
+		const next = normalizeOpenAISchemaChild(key, child, cache, visiting);
+		if (next !== child) changed = true;
+		result[key] = next;
+	}
+
+	if (result.type === "object" && !outHasOwn(result, "properties")) {
+		changed = true;
+		result.properties = {};
+	}
+
+	const normalized = changed ? result : value;
+	cache.set(value, normalized);
+	visiting.delete(value);
+	return normalized;
+}
+
+function normalizeOpenAISchemaChild(
+	key: string,
+	child: unknown,
+	cache: WeakMap<object, unknown>,
+	visiting: WeakSet<object>,
+): unknown {
+	if (OPENAI_SCHEMA_MAP_KEYS.has(key) && isJsonObject(child)) {
+		let changed = false;
+		const mapped: Record<string, unknown> = {};
+		for (const [name, schema] of Object.entries(child)) {
+			const next = ensureObjectPropertiesImpl(schema, cache, visiting);
+			if (next !== schema) changed = true;
+			mapped[name] = next;
+		}
+		return changed ? mapped : child;
+	}
+
+	if (OPENAI_SCHEMA_ARRAY_KEYS.has(key) && Array.isArray(child)) {
+		return ensureObjectPropertiesImpl(child, cache, visiting);
+	}
+
+	if (OPENAI_SCHEMA_VALUE_KEYS.has(key) && (isJsonObject(child) || Array.isArray(child))) {
+		return ensureObjectPropertiesImpl(child, cache, visiting);
+	}
+
+	return child;
 }
 
 /**

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -4,6 +4,7 @@ import { convertTools } from "@oh-my-pi/pi-ai/providers/google-shared";
 import type { Context, Model, TJsonSchema, Tool } from "@oh-my-pi/pi-ai/types";
 import {
 	enforceStrictSchema,
+	ensureObjectProperties,
 	mergeCompatibleEnumSchemas,
 	normalizeSchemaForCCA,
 	normalizeSchemaForGoogle,
@@ -726,5 +727,97 @@ describe("circular schema safety", () => {
 
 		expect(() => normalizeSchemaForGoogle(circular)).not.toThrow();
 		expect(() => sanitizeSchemaForStrictMode(circular)).not.toThrow();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// ensureObjectProperties
+// ---------------------------------------------------------------------------
+
+describe("ensureObjectProperties", () => {
+	it("adds properties:{} to root and nested object schemas", () => {
+		const normalized = ensureObjectProperties({
+			type: "object",
+			properties: {
+				address: { type: "object" },
+				tags: {
+					type: "array",
+					items: { type: "object" },
+				},
+			},
+		}) as Record<string, unknown>;
+
+		const properties = normalized.properties as Record<string, Record<string, unknown>>;
+		expect(normalized.properties).toBeDefined();
+		expect(properties.address).toEqual({ type: "object", properties: {} });
+		expect(properties.tags.items).toEqual({ type: "object", properties: {} });
+	});
+
+	it("adds properties:{} to object schemas inside combinators", () => {
+		const normalized = ensureObjectProperties({
+			anyOf: [{ type: "string" }, { type: "object" }],
+			oneOf: [{ type: "object" }],
+			allOf: [{ type: "object" }],
+		}) as Record<string, Record<string, unknown>[]>;
+
+		expect(normalized.anyOf[1]).toEqual({ type: "object", properties: {} });
+		expect(normalized.oneOf[0]).toEqual({ type: "object", properties: {} });
+		expect(normalized.allOf[0]).toEqual({ type: "object", properties: {} });
+	});
+
+	it("does not rewrite object literals in enum values", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				mode: {
+					enum: [{ type: "object" }],
+				},
+			},
+		};
+
+		const normalized = ensureObjectProperties(schema) as Record<string, unknown>;
+		const properties = normalized.properties as Record<string, Record<string, unknown>>;
+		expect(properties.mode.enum).toEqual([{ type: "object" }]);
+	});
+
+	it("normalizes schema-valued dependencies and additionalItems", () => {
+		const normalized = ensureObjectProperties({
+			type: "array",
+			additionalItems: { type: "object" },
+			dependencies: {
+				payload: { type: "object" },
+				name: ["payload"],
+			},
+		}) as Record<string, unknown>;
+
+		const dependencies = normalized.dependencies as Record<string, unknown>;
+		expect(normalized.additionalItems).toEqual({ type: "object", properties: {} });
+		expect(dependencies.payload).toEqual({ type: "object", properties: {} });
+		expect(dependencies.name).toEqual(["payload"]);
+	});
+
+	it("normalizes schema-valued contentSchema", () => {
+		const normalized = ensureObjectProperties({
+			type: "string",
+			contentSchema: { type: "object" },
+		}) as Record<string, unknown>;
+
+		expect(normalized.contentSchema).toEqual({ type: "object", properties: {} });
+	});
+
+	it("does not overflow on circular object schemas", () => {
+		const circular: Record<string, unknown> = {
+			type: "object",
+			properties: {},
+		};
+		(circular.properties as Record<string, unknown>).self = circular;
+
+		expect(() => ensureObjectProperties(circular)).not.toThrow();
+		expect(ensureObjectProperties(circular)).toEqual({
+			type: "object",
+			properties: {
+				self: {},
+			},
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes #1147.

OpenAI Responses/Codex reject any JSON Schema node with `type: "object"` that lacks a `properties` key. No-argument MCP tools can expose exactly that shape, which can make `/handoff` fail before it generates a handoff document.

This PR:

- adds `ensureObjectProperties()` to normalize OpenAI-bound schema-valued nodes
- applies it in `sanitizeSchemaForOpenAIResponses()` before the existing `oneOf` -> `anyOf` rewrite
- applies it in the OpenAI Codex Responses tool conversion before strict adaptation
- keeps traversal schema-aware so literal payload containers like `enum` are not rewritten
- guards cyclic schema graphs
- adds regression coverage for nested objects, combinators, schema-valued `dependencies`/`additionalItems`/`contentSchema`, enum literals, and cycles

## Verification

Passed:

```text
bun test packages/ai/test/schema-normalization.test.ts packages/ai/test/schema-strict-mode.test.ts packages/ai/test/schema-compatibility.test.ts packages/ai/test/schema-dereference.test.ts
# 103 pass, 0 fail

bun test packages/ai/test/openai-codex.test.ts packages/ai/test/openai-responses-cache-affinity.test.ts packages/ai/test/openai-responses-developer-role.test.ts packages/ai/test/openai-first-event-timeout.test.ts
# 31 pass, 0 fail
```

Known unrelated failure on latest `origin/main`:

```text
bun --cwd=packages/ai run check:types
# src/providers/anthropic.ts(1217,40): error TS2339: Property 'stop_details' does not exist on type 'Delta'.
```
