### PR TITLE
fix(ai): normalize OpenAI object tool schemas

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI Responses and Codex tool schema normalization to emit `properties: {}` for no-argument object schemas without rewriting literal payloads. ([#1147](https://github.com/can1357/oh-my-pi/issues/1147))
+
 ## [15.1.3] - 2026-05-17
 ### Breaking Changes
 

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -40,7 +40,7 @@ import { AssistantMessageEventStream } from "../utils/event-stream";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
 import { getOpenAIStreamIdleTimeoutMs, iterateWithIdleTimeout } from "../utils/idle-iterator";
 import { parseStreamingJson } from "../utils/json-parse";
-import { adaptSchemaForStrict, NO_STRICT, toolWireSchema } from "../utils/schema";
+import { adaptSchemaForStrict, NO_STRICT, sanitizeSchemaForOpenAIResponses, toolWireSchema } from "../utils/schema";
 import { compactGrammarDefinition } from "./grammar";
 import { CODEX_BASE_URL, getCodexAccountId, OPENAI_HEADER_VALUES, OPENAI_HEADERS } from "./openai-codex/constants";
 import {
@@ -2485,7 +2485,7 @@ export function convertOpenAICodexResponsesTools(
 			};
 		}
 		const strict = !!(!NO_STRICT && tool.strict);
-		const baseParameters = toolWireSchema(tool);
+		const baseParameters = sanitizeSchemaForOpenAIResponses(toolWireSchema(tool));
 		const { schema: parameters, strict: effectiveStrict } = adaptSchemaForStrict(baseParameters, strict);
 		return {
 			type: "function",

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -850,13 +850,36 @@ export function normalizeSchemaForMCP(value: unknown): unknown {
 }
 
 // ---------------------------------------------------------------------------
-// OpenAI Responses — `oneOf` → `anyOf` rewrite
+// OpenAI Responses — schema-valued normalization
 // ---------------------------------------------------------------------------
+
+const OPENAI_RESPONSES_SCHEMA_ARRAY_KEYS = new Set(["anyOf", "oneOf", "allOf", "prefixItems"]);
+const OPENAI_RESPONSES_SCHEMA_MAP_KEYS = new Set([
+	"properties",
+	"patternProperties",
+	"dependentSchemas",
+	"$defs",
+	"definitions",
+]);
+const OPENAI_RESPONSES_SCHEMA_VALUE_KEYS = new Set([
+	"items",
+	"additionalItems",
+	"contains",
+	"propertyNames",
+	"if",
+	"then",
+	"else",
+	"not",
+	"additionalProperties",
+	"unevaluatedItems",
+	"unevaluatedProperties",
+]);
 
 /**
  * OpenAI Responses rejects `oneOf` in tool schemas even when strict mode is
- * disabled. Non-strict schemas can still use `anyOf`, so preserve the union
- * shape by recursively rewriting `oneOf` branches to `anyOf`.
+ * disabled, and rejects every schema node with `type: "object"` unless it has
+ * a `properties` member. Normalize only schema-valued positions so literal
+ * payloads under `enum`, `const`, `default`, and `examples` remain unchanged.
  *
  * Identity-preserving: returns the input reference unchanged when no rewrite
  * occurred so callers can dedupe via reference equality (and the strict-mode
@@ -865,7 +888,7 @@ export function normalizeSchemaForMCP(value: unknown): unknown {
  * would not survive).
  */
 export function sanitizeSchemaForOpenAIResponses(schema: JsonObject): JsonObject {
-	return rewriteOneOfToAnyOf(schema) as JsonObject;
+	return normalizeOpenAIResponsesSchemaNode(schema, new WeakMap()) as JsonObject;
 }
 
 /**
@@ -874,48 +897,76 @@ export function sanitizeSchemaForOpenAIResponses(schema: JsonObject): JsonObject
  */
 export const normalizeSchemaForOpenAIResponses: (schema: JsonObject) => JsonObject = sanitizeSchemaForOpenAIResponses;
 
-function rewriteOneOfToAnyOf(value: unknown): unknown {
-	if (Array.isArray(value)) {
-		let changed = false;
-		const rewritten = value.map(item => {
-			const next = rewriteOneOfToAnyOf(item);
-			if (next !== item) changed = true;
-			return next;
-		});
-		return changed ? rewritten : value;
-	}
+function normalizeOpenAIResponsesSchemaNode(value: unknown, cache: WeakMap<JsonObject, JsonObject>): unknown {
+	if (!isJsonObject(value)) return value;
 
-	if (!value || typeof value !== "object") {
-		return value;
-	}
+	const cached = cache.get(value);
+	if (cached) return cached;
 
-	const input = value as Record<string, unknown>;
+	const output: JsonObject = {};
+	cache.set(value, output);
+
 	let changed = false;
-	const output: Record<string, unknown> = {};
-	for (const key in input) {
-		const child = input[key];
-		// Skip `oneOf` here; it is re-emitted as `anyOf` after the loop so
-		// neighboring `anyOf` entries can be folded in.
+	for (const key in value) {
+		if (!Object.hasOwn(value, key)) continue;
 		if (key === "oneOf") {
 			changed = true;
 			continue;
 		}
-		const next = rewriteOneOfToAnyOf(child);
+
+		const child = value[key];
+		let next: unknown = child;
+		if (OPENAI_RESPONSES_SCHEMA_MAP_KEYS.has(key) && isJsonObject(child)) {
+			next = normalizeOpenAIResponsesSchemaMap(child, cache);
+		} else if (OPENAI_RESPONSES_SCHEMA_ARRAY_KEYS.has(key) && Array.isArray(child)) {
+			next = normalizeOpenAIResponsesSchemaArray(child, cache);
+		} else if (OPENAI_RESPONSES_SCHEMA_VALUE_KEYS.has(key) && isJsonObject(child)) {
+			next = normalizeOpenAIResponsesSchemaNode(child, cache);
+		}
+
 		if (next !== child) changed = true;
 		output[key] = next;
 	}
 
-	// Re-emit `oneOf` content under `anyOf`, concatenating with any existing
-	// `anyOf` branches in the original node.
-	if (Array.isArray(input.oneOf)) {
-		const rewrittenOneOf = rewriteOneOfToAnyOf(input.oneOf);
+	if (Array.isArray(value.oneOf)) {
+		const rewrittenOneOf = normalizeOpenAIResponsesSchemaArray(value.oneOf, cache);
 		const existingAnyOf = output.anyOf;
 		output.anyOf = Array.isArray(existingAnyOf)
 			? [...existingAnyOf, ...(rewrittenOneOf as unknown[])]
 			: rewrittenOneOf;
 	}
 
+	if (value.type === "object" && !Object.hasOwn(value, "properties")) {
+		output.properties = {};
+		changed = true;
+	}
+
+	const result = changed ? output : value;
+	cache.set(value, result);
+	return result;
+}
+
+function normalizeOpenAIResponsesSchemaArray(value: unknown[], cache: WeakMap<JsonObject, JsonObject>): unknown[] {
+	let changed = false;
+	const output = value.map(item => {
+		const next = normalizeOpenAIResponsesSchemaNode(item, cache);
+		if (next !== item) changed = true;
+		return next;
+	});
 	return changed ? output : value;
+}
+
+function normalizeOpenAIResponsesSchemaMap(schemaMap: JsonObject, cache: WeakMap<JsonObject, JsonObject>): JsonObject {
+	let changed = false;
+	const output: JsonObject = {};
+	for (const key in schemaMap) {
+		if (!Object.hasOwn(schemaMap, key)) continue;
+		const child = schemaMap[key];
+		const next = normalizeOpenAIResponsesSchemaNode(child, cache);
+		if (next !== child) changed = true;
+		output[key] = next;
+	}
+	return changed ? output : schemaMap;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -857,6 +857,11 @@ const OPENAI_RESPONSES_SCHEMA_ARRAY_KEYS = new Set(["anyOf", "oneOf", "allOf", "
 const OPENAI_RESPONSES_SCHEMA_MAP_KEYS = new Set([
 	"properties",
 	"patternProperties",
+	// `dependencies` is the Draft-04..07 schema-valued form; older MCP servers
+	// still emit `{ dependencies: { foo: { type: "object" } } }`. String-array
+	// branches per key pass through `normalizeOpenAIResponsesSchemaNode`
+	// untouched because non-objects return as-is.
+	"dependencies",
 	"dependentSchemas",
 	"$defs",
 	"definitions",
@@ -865,6 +870,7 @@ const OPENAI_RESPONSES_SCHEMA_VALUE_KEYS = new Set([
 	"items",
 	"additionalItems",
 	"contains",
+	"contentSchema",
 	"propertyNames",
 	"if",
 	"then",
@@ -903,13 +909,24 @@ function normalizeOpenAIResponsesSchemaNode(value: unknown, cache: WeakMap<JsonO
 	const cached = cache.get(value);
 	if (cached) return cached;
 
+	// Seed the cache with the in-flight `output` BEFORE recursing so that a
+	// child re-entering this node mid-walk gets the partial back instead of
+	// triggering an infinite recursion. A cycle hitting this seeded entry
+	// forces `changed = true` below (the cached partial is referentially
+	// distinct from `value`), which is why the final `cache.set(value, result)`
+	// never silently overwrites the seed with `value` on a cyclic input.
 	const output: JsonObject = {};
 	cache.set(value, output);
 
 	let changed = false;
 	for (const key in value) {
 		if (!Object.hasOwn(value, key)) continue;
-		if (key === "oneOf") {
+		// Drop only well-formed `oneOf` arrays here; they are re-emitted as
+		// `anyOf` after the loop so any neighboring `anyOf` entries can be
+		// concatenated. A non-array `oneOf` is malformed for the wire but
+		// still preserved verbatim so callers can see the original payload
+		// instead of having it silently disappear.
+		if (key === "oneOf" && Array.isArray(value.oneOf)) {
 			changed = true;
 			continue;
 		}
@@ -936,14 +953,30 @@ function normalizeOpenAIResponsesSchemaNode(value: unknown, cache: WeakMap<JsonO
 			: rewrittenOneOf;
 	}
 
-	if (value.type === "object" && !Object.hasOwn(value, "properties")) {
+	// Draft 2020-12 lets `type` be an array (e.g. `["object", "null"]`); treat
+	// any variant that includes "object" as an object position for the
+	// properties requirement.
+	if (declaresObjectType(value.type) && !Object.hasOwn(value, "properties")) {
 		output.properties = {};
 		changed = true;
 	}
 
+	// Safe to overwrite the seed: any cyclic re-entry above already observed
+	// the seeded partial and set `changed = true` for that node, so a node
+	// that finishes with `changed === false` is provably non-cyclic and
+	// referentially equal to its input.
 	const result = changed ? output : value;
 	cache.set(value, result);
 	return result;
+}
+
+function declaresObjectType(type: unknown): boolean {
+	if (type === "object") return true;
+	if (!Array.isArray(type)) return false;
+	for (const variant of type) {
+		if (variant === "object") return true;
+	}
+	return false;
 }
 
 function normalizeOpenAIResponsesSchemaArray(value: unknown[], cache: WeakMap<JsonObject, JsonObject>): unknown[] {

--- a/packages/ai/test/openai-codex.test.ts
+++ b/packages/ai/test/openai-codex.test.ts
@@ -1,10 +1,33 @@
 import { describe, expect, it } from "bun:test";
 import { type RequestBody, transformRequestBody } from "@oh-my-pi/pi-ai/providers/openai-codex/request-transformer";
 import { parseCodexError } from "@oh-my-pi/pi-ai/providers/openai-codex/response-handler";
+import { convertOpenAICodexResponsesTools } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
+import type { Tool } from "@oh-my-pi/pi-ai/types";
 import { createCodexModel } from "./helpers";
 
 const DEFAULT_PROMPT_PREFIX =
 	"You are an expert coding assistant. You help users with coding tasks by reading files, executing commands";
+
+describe("openai-codex tool schemas", () => {
+	it("adds empty properties to no-argument object parameter schemas", () => {
+		const tools: Tool[] = [
+			{
+				name: "list_outgoing_messages",
+				description: "List outgoing messages",
+				parameters: { type: "object" },
+			},
+		];
+
+		const converted = convertOpenAICodexResponsesTools(tools, createCodexModel("gpt-5.1-codex"));
+
+		expect(converted[0]).toEqual({
+			type: "function",
+			name: "list_outgoing_messages",
+			description: "List outgoing messages",
+			parameters: { type: "object", properties: {} },
+		});
+	});
+});
 
 describe("openai-codex request transformer", () => {
 	it("filters item_reference and strips ids", async () => {

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -8,6 +8,7 @@ import {
 	normalizeSchemaForCCA,
 	normalizeSchemaForGoogle,
 	normalizeSchemaForMCP,
+	sanitizeSchemaForOpenAIResponses,
 	sanitizeSchemaForStrictMode,
 	schemaNeedsDraft202012Upgrade,
 	stripResidualCombiners,
@@ -345,6 +346,45 @@ describe("normalizeSchemaForMCP", () => {
 			pattern: "^\\d+$",
 			minLength: 1,
 			description: "ID",
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeSchemaForOpenAIResponses
+// ---------------------------------------------------------------------------
+
+describe("sanitizeSchemaForOpenAIResponses", () => {
+	it("adds empty properties to object schemas without rewriting literal payloads", () => {
+		const literal = { type: "object", oneOf: [{ const: "literal" }] };
+		const schema = {
+			type: "object",
+			properties: {
+				nested: { type: "object" },
+				union: {
+					oneOf: [{ type: "object" }],
+				},
+			},
+			oneOf: [{ type: "object" }],
+			enum: [literal],
+			const: literal,
+			default: literal,
+			examples: [literal],
+		};
+
+		expect(sanitizeSchemaForOpenAIResponses(schema)).toEqual({
+			type: "object",
+			properties: {
+				nested: { type: "object", properties: {} },
+				union: {
+					anyOf: [{ type: "object", properties: {} }],
+				},
+			},
+			enum: [literal],
+			const: literal,
+			default: literal,
+			examples: [literal],
+			anyOf: [{ type: "object", properties: {} }],
 		});
 	});
 });

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -387,6 +387,63 @@ describe("sanitizeSchemaForOpenAIResponses", () => {
 			anyOf: [{ type: "object", properties: {} }],
 		});
 	});
+
+	it("adds empty properties under draft-07 dependencies and draft 2019-09 contentSchema", () => {
+		const schema = {
+			type: "object",
+			properties: {
+				body: {
+					type: "string",
+					contentSchema: { type: "object" },
+				},
+			},
+			dependencies: {
+				body: { type: "object" },
+				other: ["body"],
+			},
+		};
+
+		expect(sanitizeSchemaForOpenAIResponses(schema)).toEqual({
+			type: "object",
+			properties: {
+				body: {
+					type: "string",
+					contentSchema: { type: "object", properties: {} },
+				},
+			},
+			dependencies: {
+				body: { type: "object", properties: {} },
+				other: ["body"],
+			},
+		});
+	});
+
+	it("adds empty properties when `type` is a draft 2020-12 array including object", () => {
+		expect(sanitizeSchemaForOpenAIResponses({ type: ["object", "null"] })).toEqual({
+			type: ["object", "null"],
+			properties: {},
+		});
+	});
+
+	it("preserves non-array oneOf payloads verbatim instead of dropping them", () => {
+		const malformed = { type: "object", oneOf: { type: "object" } } as unknown as Record<string, unknown>;
+
+		expect(sanitizeSchemaForOpenAIResponses(malformed)).toEqual({
+			type: "object",
+			oneOf: { type: "object" },
+			properties: {},
+		});
+	});
+
+	it("does not recurse infinitely on self-referential object schemas", () => {
+		const circular: Record<string, unknown> = { type: "object", properties: {} };
+		(circular.properties as Record<string, unknown>).self = circular;
+
+		const sanitized = sanitizeSchemaForOpenAIResponses(circular);
+		const properties = (sanitized as { properties: Record<string, unknown> }).properties;
+		expect(properties.self).toBe(sanitized as unknown as object);
+		expect((sanitized as { type: unknown }).type).toBe("object");
+	});
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Repro
Running the OpenAI Responses schema sanitizer on a tool schema containing `type: "object"` nodes without `properties` reproduced the invalid wire shape: `bun -e 'import { sanitizeSchemaForOpenAIResponses } from "@oh-my-pi/pi-ai/utils/schema"; const schema={type:"object",properties:{nested:{type:"object"}},oneOf:[{type:"object"}],examples:[{type:"object",oneOf:[{const:"literal"}]}]}; console.log(JSON.stringify(sanitizeSchemaForOpenAIResponses(schema)));'` emitted object schema nodes without `properties` and rewrote the literal `examples` payload.

## Cause
`packages/ai/src/utils/schema/normalize.ts` used a generic `rewriteOneOfToAnyOf` walker for OpenAI Responses schemas, so it did not enforce OpenAI's object-schema `properties` requirement and also traversed non-schema literal payloads. `packages/ai/src/providers/openai-codex-responses.ts` passed Codex tool schemas directly into `adaptSchemaForStrict`, so non-strict/no-argument MCP tools skipped the Responses sanitizer entirely.

## Fix
- Replaced the OpenAI Responses schema sanitizer with a schema-position-aware normalizer that rewrites `oneOf` to `anyOf`, adds `properties: {}` to object schema nodes, and skips literal payloads under `enum`, `const`, `default`, and `examples`.
- Routed OpenAI Codex Responses tool conversion through the same sanitizer before strict-mode adaptation.
- Added regression coverage for no-argument Codex tool parameters and literal-preserving OpenAI Responses schema normalization.
- Added the `packages/ai` changelog entry.

## Verification
`bun --cwd packages/ai test test/schema-normalization.test.ts test/openai-codex.test.ts` passed: 39 tests, 83 assertions. `bun run check` in `packages/ai` passed (`biome check .` and `tsgo -p tsconfig.json --noEmit`). Fixes #1147