### PR TITLE
docs(readme): surface goal tool and 75-handler read stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ _[Watch the capture ↗](https://omp.sh/clips/irc.mp4)_
 
 ### 06 · Read a pdf on arxiv, why not?
 
-web_search chains fourteen ranked providers and hands whatever URLs it finds straight to read. Arxiv PDFs, GitHub pages, Stack Overflow threads come back as structured markdown with anchors intact — the same tool surface you use on local files. Cite, follow, quote, never lose where you came from.
+web_search chains fourteen ranked providers and hands whatever URLs it finds straight to read. Arxiv PDFs, GitHub pages, Stack Overflow threads come back as structured markdown with anchors intact — the same tool surface you use on local files. Cite, follow, quote, never lose where you came from. Seventy-five URL shapes carry their own lens underneath: package registries (npm, PyPI, crates.io, Hex, Maven, Go), research stacks (Arxiv, bioRxiv, PubMed, Semantic Scholar), the forum mesh (Reddit, Hacker News, Lobsters, Mastodon, Bluesky), YouTube and Vimeo transcripts, NVD/OSV/CISA-KEV advisories. Readability is the fallback, not the headline.
 
 ![omp TUI: web_search returns 10 ranked Perplexity sources for inference-time compute scaling, the agent picks an arxiv paper, calls read https://arxiv.org/pdf/2604.10739v1, and summarizes the paper's headline result with real numbers.](https://omp.sh/clips/web-poster.webp)
 

--- a/README.md
+++ b/README.md
@@ -419,26 +419,6 @@ The [Agent Client Protocol](https://github.com/zed-industries/agent-client-proto
 
 Full reference: [omp.sh/docs/sdk](https://omp.sh/docs/sdk).
 
-### Utility subcommands — _not just the TUI_
-
-Everything below shares the same engine; pick the one that matches what you actually want to do.
-
-| Command            | What it does                                                                                          |
-| ------------------ | ----------------------------------------------------------------------------------------------------- |
-| `omp commit`       | Read the working tree, split into atomic commits, validate the messages, update changelogs.           |
-| `omp config`       | Inspect and mutate the settings tree (`~/.omp` + `.omp/`) from the shell.                             |
-| `omp setup`        | Install optional dependencies for features that need them — currently `python` and `stt`.             |
-| `omp plugin`       | Install, uninstall, enable, configure, and doctor plugins from npm or local paths.                    |
-| `omp agents`       | Export the bundled task agents (`explore`, `plan`, `reviewer`, …) onto disk so you can edit them.     |
-| `omp ssh`          | Manage SSH host configs the `ssh` tool will reach for.                                                |
-| `omp stats`        | Token, request, and cost usage rolled up across every session.                                        |
-| `omp update`       | Check for and install a new release.                                                                  |
-| `omp shell`        | Drop into the same persistent bash session the `bash` tool uses — handy for poking at it directly.    |
-| `omp search` (`q`) | Run `web_search` from the shell without spinning up the TUI; walks the configured provider chain and returns the first one that responds.                |
-| `omp read PATH`    | Run `read` from the shell against any path, internal scheme, or URL and print exactly what the model would see. |
-| `omp auth-broker`  | Start the credential-vault server that other omp processes (slot containers, swarm extensions) talk to. |
-| `omp auth-gateway` | Forward-proxy provider traffic through the broker so the agent never touches the real keys.           |
-
 ## A harness worth keeping is one you _don't_ outgrow.
 
 Pick it up at **[omp.sh](https://omp.sh)**.

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Stealth's on by default, so pages see a normal user instead of a headless bot. T
 - `todo_write` — ordered mutations over the session todo list with phase tracking.
 - `job` — wait on or cancel background jobs.
 - `ask` — structured follow-up questions for interactive runs.
+- `goal` — pin a persistent objective with a token budget; surfaced when goal mode is on (`/goal`), tracked in the footer, and steered as the run approaches the limit.
 
 **Outside the box**
 
@@ -417,6 +418,26 @@ The [Agent Client Protocol](https://github.com/zed-industries/agent-client-proto
 | `edit, ast_edit, write, bash` | `session/request_permission`        |
 
 Full reference: [omp.sh/docs/sdk](https://omp.sh/docs/sdk).
+
+### Utility subcommands — _not just the TUI_
+
+Everything below shares the same engine; pick the one that matches what you actually want to do.
+
+| Command            | What it does                                                                                          |
+| ------------------ | ----------------------------------------------------------------------------------------------------- |
+| `omp commit`       | Read the working tree, split into atomic commits, validate the messages, update changelogs.           |
+| `omp config`       | Inspect and mutate the settings tree (`~/.omp` + `.omp/`) from the shell.                             |
+| `omp setup`        | Install optional dependencies for features that need them — currently `python` and `stt`.             |
+| `omp plugin`       | Install, uninstall, enable, configure, and doctor plugins from npm or local paths.                    |
+| `omp agents`       | Export the bundled task agents (`explore`, `plan`, `reviewer`, …) onto disk so you can edit them.     |
+| `omp ssh`          | Manage SSH host configs the `ssh` tool will reach for.                                                |
+| `omp stats`        | Token, request, and cost usage rolled up across every session.                                        |
+| `omp update`       | Check for and install a new release.                                                                  |
+| `omp shell`        | Drop into the same persistent bash session the `bash` tool uses — handy for poking at it directly.    |
+| `omp search` (`q`) | Run `web_search` from the shell without spinning up the TUI; rank-merges every configured provider.   |
+| `omp read PATH`    | Run `read` from the shell against any path, internal scheme, or URL and print exactly what the model would see. |
+| `omp auth-broker`  | Start the credential-vault server that other omp processes (slot containers, swarm extensions) talk to. |
+| `omp auth-gateway` | Forward-proxy provider traffic through the broker so the agent never touches the real keys.           |
 
 ## A harness worth keeping is one you _don't_ outgrow.
 

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ Everything below shares the same engine; pick the one that matches what you actu
 | `omp stats`        | Token, request, and cost usage rolled up across every session.                                        |
 | `omp update`       | Check for and install a new release.                                                                  |
 | `omp shell`        | Drop into the same persistent bash session the `bash` tool uses — handy for poking at it directly.    |
-| `omp search` (`q`) | Run `web_search` from the shell without spinning up the TUI; rank-merges every configured provider.   |
+| `omp search` (`q`) | Run `web_search` from the shell without spinning up the TUI; walks the configured provider chain and returns the first one that responds.                |
 | `omp read PATH`    | Run `read` from the shell against any path, internal scheme, or URL and print exactly what the model would see. |
 | `omp auth-broker`  | Start the credential-vault server that other omp processes (slot containers, swarm extensions) talk to. |
 | `omp auth-gateway` | Forward-proxy provider traffic through the broker so the agent never touches the real keys.           |


### PR DESCRIPTION
## Why

Walked the registered tool and CLI surface against the README and found two concrete gaps worth fixing:

**1. The `goal` tool is registered but undocumented.**

`packages/coding-agent/src/tools/index.ts` registers `goal: s => new GoalTool(s)` in `HIDDEN_TOOLS` and auto-injects it whenever goal mode is active:

```ts
// packages/coding-agent/src/tools/index.ts
HIDDEN_TOOLS: {
  ...,
  goal: s => new GoalTool(s),
};

// in createTools
if (goalModeActive && requestedTools && !requestedTools.includes("goal")) {
  requestedTools = [...requestedTools, "goal"];
}
```

It's a real model-facing tool with `create`/`get`/`complete` operations (`packages/coding-agent/src/goals/tools/goal-tool.ts`), tied to the `/goal` slash command (`packages/coding-agent/src/slash-commands/builtin-registry.ts`) and the `goal.enabled` setting (default `true`). None of `goal`, `/goal`, or goal mode was mentioned anywhere in the README.

**2. The 75 specialized URL handlers under `read` were only hinted at.**

`packages/coding-agent/src/web/scrapers/` ships 75 site-specific scrapers (counted: every `.ts` file minus `index.ts`/`types.ts`/`utils.ts`). The previous highlight 06 paragraph named three — arxiv, github, stackoverflow — which conveys the idea but understates the surface: package registries (npm, PyPI, crates.io, Hex, Maven, Go), research stacks (arXiv, bioRxiv, PubMed, Semantic Scholar), forum mesh (Reddit, Hacker News, Lobsters, Mastodon, Bluesky), YouTube and Vimeo transcripts, security advisories (NVD/OSV/CISA-KEV), and the rest all get pre-parsed shapes instead of falling through to Readability.

## What this changes

1. Adds a single bullet for `goal` under **Coordination** in the tool surface section, including the `/goal` slash reference.

2. Extends the existing highlight 06 paragraph with one sentence surfacing the 75-handler stack with concrete examples per category — same rhythm as the rest of the paragraph, ends on the Readability-as-fallback punchline.

## Out of scope

- A utility-subcommands reference table was drafted and then removed at the author's request — `omp --help` already enumerates the CLI surface, so the README didn't need a parallel table.
- Hidden tools that are pure plumbing (`yield`, `report_finding`, `report_tool_issue`, `resolve`) — `goal` was the only one with a user-visible `/goal` command worth surfacing.

## Verification

- Cross-referenced `BUILTIN_TOOLS` + `HIDDEN_TOOLS` in `packages/coding-agent/src/tools/index.ts` against every bullet in the README's tool surface; `goal` was the only gap.
- Counted `packages/coding-agent/src/web/scrapers/*.ts` minus the three non-scraper files (`index.ts`, `types.ts`, `utils.ts`) → 75 scrapers; pulled category exemplars from the actual file names.
- Pure docs change; no behavior modified, no test churn, no changelog entry.