### PR TITLE
fix(agent): update tool cwd after /move

### DIFF
--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1070,7 +1070,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			return undefined;
 		};
 		const toolSession: ToolSession = {
-			cwd,
+			get cwd() {
+				return sessionManager.getCwd();
+			},
 			hasUI: options.hasUI ?? false,
 			enableLsp,
 			get hasEditTool() {

--- a/packages/coding-agent/test/sdk-move-cwd.test.ts
+++ b/packages/coding-agent/test/sdk-move-cwd.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getBundledModel } from "@oh-my-pi/pi-ai";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+
+function textContent(result: { content?: Array<{ type: string; text?: string }> }): string {
+	return (
+		result.content
+			?.filter(
+				(block): block is { type: "text"; text: string } => block.type === "text" && typeof block.text === "string",
+			)
+			.map(block => block.text)
+			.join("\n") ?? ""
+	);
+}
+
+describe("createAgentSession cwd after /move", () => {
+	const tempDirs: string[] = [];
+
+	afterEach(() => {
+		for (const tempDir of tempDirs.splice(0)) {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("runs tools from the moved session directory", async () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), `pi-sdk-move-cwd-${Snowflake.next()}-`));
+		tempDirs.push(tempDir);
+		const cwdA = path.join(tempDir, "cwd-a");
+		const cwdB = path.join(tempDir, "cwd-b");
+		fs.mkdirSync(cwdA, { recursive: true });
+		fs.mkdirSync(cwdB, { recursive: true });
+
+		const sessionManager = SessionManager.create(cwdA, path.join(tempDir, "sessions"));
+		const { session } = await createAgentSession({
+			cwd: cwdA,
+			agentDir: tempDir,
+			sessionManager,
+			settings: Settings.isolated({
+				"async.enabled": false,
+				"bash.autoBackground.enabled": false,
+				"bashInterceptor.enabled": false,
+			}),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			toolNames: ["bash"],
+		});
+
+		try {
+			await sessionManager.moveTo(cwdB);
+
+			const bashTool = session.getToolByName("bash");
+			if (!bashTool) throw new Error("Expected bash tool");
+			const result = await bashTool.execute("pwd-after-move", { command: "pwd" });
+
+			expect(textContent(result)).toContain(cwdB);
+		} finally {
+			await session.dispose();
+		}
+	});
+});


### PR DESCRIPTION
## Repro
After a session is moved from `cwd-a` to `cwd-b`, running the existing `bash` tool with `pwd` still reports `cwd-a`. Reproduced with `cd packages/coding-agent && bun test test/sdk-move-cwd.test.ts`, which failed before the fix with `Expected to contain: .../cwd-b` and `Received: .../cwd-a`.

## Cause
`createAgentSession` in `packages/coding-agent/src/sdk.ts` constructed the shared `ToolSession` with a snapshot `cwd` value. `/move` updated `SessionManager.moveTo(...)` and process/project cwd, but already-created built-in tools kept reading the stale `ToolSession.cwd` string.

## Fix
- Changed `ToolSession.cwd` construction to resolve through `sessionManager.getCwd()` so existing tools observe moves immediately.
- Added `packages/coding-agent/test/sdk-move-cwd.test.ts` to assert that `bash` runs from the moved session directory after `SessionManager.moveTo(...)`.

## Verification
Passed `cd packages/coding-agent && bun test test/sdk-move-cwd.test.ts test/session-manager/move-to.test.ts`; passed `cd packages/coding-agent && bun run check:types`; passed `bunx biome check packages/coding-agent/src/sdk.ts packages/coding-agent/test/sdk-move-cwd.test.ts`. Fixes #1168