### PR TITLE
fix(debug): consume abandoned stop outcome failures

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed failed DAP launches leaving stop-event waiters that could surface as unhandled rejections.
+
 ## [15.1.6] - 2026-05-19
 
 ### Fixed

--- a/packages/coding-agent/src/dap/session.ts
+++ b/packages/coding-agent/src/dap/session.ts
@@ -1081,11 +1081,15 @@ export class DapSessionManager {
 			session.client.waitForEvent("exited", undefined, signal, timeoutMs),
 		];
 		// Promise.race leaves the losing waiters pending; their timeouts would
-		// otherwise surface as unhandled rejections once they fire.
+		// otherwise surface as unhandled rejections once they fire. The returned
+		// race can also be abandoned when launch/attach fails before the initial
+		// stop capture is awaited, so consume it at creation time too.
 		for (const p of promises) {
 			p.catch(() => {});
 		}
-		return Promise.race(promises);
+		const outcome = Promise.race(promises);
+		outcome.catch(() => {});
+		return outcome;
 	}
 
 	/**

--- a/packages/coding-agent/test/dap-session-failure.test.ts
+++ b/packages/coding-agent/test/dap-session-failure.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import { DapClient } from "../src/dap/client";
+import { DapSessionManager } from "../src/dap/session";
+import type { DapResolvedAdapter } from "../src/dap/types";
+
+const fakeAdapter: DapResolvedAdapter = {
+	name: "fake-dap",
+	command: "fake-dap",
+	args: [],
+	resolvedCommand: "fake-dap",
+	languages: [],
+	fileTypes: [],
+	rootMarkers: [],
+	launchDefaults: {},
+	attachDefaults: {},
+	connectMode: "stdio",
+};
+
+function collectUnhandledRejections(): { errors: unknown[]; dispose(): void } {
+	const errors: unknown[] = [];
+	const handler = (error: unknown) => {
+		errors.push(error);
+	};
+	process.on("unhandledRejection", handler);
+	return {
+		errors,
+		dispose() {
+			process.off("unhandledRejection", handler);
+		},
+	};
+}
+
+function rejectAfter(delayMs: number, message: string): Promise<never> {
+	return Bun.sleep(delayMs).then(() => {
+		throw new Error(message);
+	});
+}
+
+describe("DapSessionManager failed launch cleanup", () => {
+	it("does not leave the initial stop outcome race unhandled when configurationDone fails", async () => {
+		const fakeClient = {
+			adapter: fakeAdapter,
+			cwd: process.cwd(),
+			proc: {
+				exited: Promise.resolve(0),
+				exitCode: null,
+			},
+			initialize: async () => ({ supportsConfigurationDoneRequest: true }),
+			sendRequest(command: string) {
+				if (command === "launch") return new Promise(() => {});
+				if (command === "configurationDone") throw new Error("DAP request configurationDone failed");
+				return Promise.resolve({});
+			},
+			waitForEvent(event: string) {
+				if (event === "initialized") return Promise.resolve({});
+				return rejectAfter(5, `DAP event ${event} timed out after 5ms`);
+			},
+			onEvent: () => () => {},
+			onReverseRequest: () => () => {},
+			isAlive: () => true,
+			dispose: async () => {},
+		};
+		const spawnSpy = spyOn(DapClient, "spawn").mockResolvedValue(fakeClient as unknown as DapClient);
+		const unhandled = collectUnhandledRejections();
+		try {
+			const manager = new DapSessionManager();
+			await expect(
+				manager.launch(
+					{
+						adapter: fakeAdapter,
+						program: "fake-program",
+						cwd: process.cwd(),
+					},
+					undefined,
+					25,
+				),
+			).rejects.toThrow("DAP request configurationDone failed");
+
+			await Bun.sleep(25);
+
+			expect(unhandled.errors).toEqual([]);
+		} finally {
+			unhandled.dispose();
+			spawnSpy.mockRestore();
+		}
+	});
+});


### PR DESCRIPTION
## What

Consume the `Promise.race(...)` returned by the DAP launch/attach stop-outcome watcher at creation time.

This prevents failed launch/attach handshakes from leaving an abandoned race promise that can later reject as an unhandled `DAP event stopped timed out ...` error.

## Why

Refs #1187.

## Batch context

This is part of a small debug-tool fix batch linked from #1187.

- PR 1 fixes failed-launch cleanup / unhandled rejection.
- PR 2 improves error reporting when `configurationDone` and launch both fail.
- PR 3 rejects invalid directory launch targets after adapter selection and before adapter startup, while preserving adapters such as Delve that accept directory programs.
- PR 4 improves Python/debugpy diagnostics and documentation.

This PR is intentionally scoped so it can be merged independently if the maintainer prefers a smaller subset.

## Testing

- `bun --cwd=packages/coding-agent test test/dap-session-failure.test.ts`
- `bun --cwd=packages/coding-agent run check`

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
