### PR TITLE
fix(acp): include execute metadata in bash permission requests

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ACP bash permission requests to include execute tool metadata and command content so clients can render command approval prompts consistently. ([#1189](https://github.com/can1357/oh-my-pi/issues/1189))
+
 ## [15.1.6] - 2026-05-19
 
 ### Fixed

--- a/packages/coding-agent/src/modes/acp/acp-client-bridge.ts
+++ b/packages/coding-agent/src/modes/acp/acp-client-bridge.ts
@@ -124,6 +124,7 @@ async function requestPermission(
 		...(toolCall.kind ? { kind: toolCall.kind as ToolCallUpdate["kind"] } : {}),
 		...(toolCall.status ? { status: toolCall.status as ToolCallUpdate["status"] } : {}),
 		...(toolCall.rawInput !== undefined ? { rawInput: toolCall.rawInput } : {}),
+		...(toolCall.content ? { content: toolCall.content as ToolCallUpdate["content"] } : {}),
 		...(toolCall.locations ? { locations: toolCall.locations } : {}),
 	};
 	const acpOptions: AcpPermissionOption[] = options.map(option => ({

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3101,6 +3101,13 @@ export class AgentSession {
 					if (!permissionIntent) {
 						return await target.execute(toolCallId, args as never, signal, onUpdate, ctx);
 					}
+					const command =
+						target.name === "bash" && args && typeof args === "object" && !Array.isArray(args)
+							? getStringProperty(args as Record<string, unknown>, "command")
+							: undefined;
+					const commandContent = command
+						? [{ type: "content" as const, content: { type: "text" as const, text: `$ ${command}` } }]
+						: undefined;
 					// Short-circuit on persisted decisions.
 					const persisted = this.#acpPermissionDecisions.get(permissionIntent.cacheKey);
 					if (persisted === "allow_always") {
@@ -3125,8 +3132,10 @@ export class AgentSession {
 								toolCallId,
 								toolName: target.name,
 								title: permissionIntent.title,
+								...(target.name === "bash" ? { kind: "execute" } : {}),
 								status: "pending",
 								rawInput: args,
+								...(commandContent ? { content: commandContent } : {}),
 								locations: extractPermissionLocations(
 									args,
 									this.sessionManager.getCwd(),

--- a/packages/coding-agent/src/session/client-bridge.ts
+++ b/packages/coding-agent/src/session/client-bridge.ts
@@ -27,6 +27,7 @@ export interface ClientBridgePermissionToolCall {
 	kind?: string;
 	status?: "pending" | "in_progress" | "completed" | "failed";
 	rawInput?: unknown;
+	content?: unknown[];
 	locations?: { path: string; line?: number }[];
 }
 

--- a/packages/coding-agent/test/acp-client-bridge.test.ts
+++ b/packages/coding-agent/test/acp-client-bridge.test.ts
@@ -22,6 +22,7 @@ describe("ACP client bridge permission requests", () => {
 				kind: "execute",
 				status: "pending",
 				rawInput: { command: "echo hi" },
+				content: [{ type: "content", content: { type: "text", text: "$ echo hi" } }],
 			},
 			[{ optionId: "allow_once", name: "Allow once", kind: "allow_once" }],
 		);
@@ -32,6 +33,7 @@ describe("ACP client bridge permission requests", () => {
 			kind: "execute",
 			status: "pending",
 			rawInput: { command: "echo hi" },
+			content: [{ type: "content", content: { type: "text", text: "$ echo hi" } }],
 		});
 	});
 });

--- a/packages/coding-agent/test/agent-session-acp-permission.test.ts
+++ b/packages/coding-agent/test/agent-session-acp-permission.test.ts
@@ -501,6 +501,43 @@ it("permission requests report the gated tool call as pending", async () => {
 	expect(bashTool.executeCalls).toBe(1);
 });
 
+it("bash permission requests include execute metadata and command content", async () => {
+	const bashTool = makeFakeTool("bash");
+	const requests: ClientBridgePermissionToolCall[] = [];
+	const bridge: ClientBridge = {
+		capabilities: { requestPermission: true },
+		async requestPermission(toolCall, _options, _signal) {
+			requests.push(toolCall);
+			return { outcome: "selected", optionId: "allow_once", kind: "allow_once" };
+		},
+	};
+	session = await createSession([bashTool], bridge);
+
+	await session.setActiveToolsByName(["bash"]);
+	const wrappedBash = session.agent.state.tools.find(t => t.name === "bash");
+	expect(wrappedBash).toBeDefined();
+
+	await wrappedBash!.execute(
+		"call-bash-rich",
+		{ command: "git status --short" },
+		undefined,
+		undefined as never,
+		undefined as never,
+	);
+
+	expect(requests).toHaveLength(1);
+	expect(requests[0]).toMatchObject({
+		toolCallId: "call-bash-rich",
+		toolName: "bash",
+		title: "git status --short",
+		kind: "execute",
+		status: "pending",
+		rawInput: { command: "git status --short" },
+		content: [{ type: "content", content: { type: "text", text: "$ git status --short" } }],
+	});
+	expect(bashTool.executeCalls).toBe(1);
+});
+
 it("ordinary edit calls still bypass ACP permission after rejecting edit moves forever", async () => {
 	const editTool = makeFakeTool("edit");
 	const bridge = makeBridge({ outcome: "selected", optionId: "reject_always", kind: "reject_always" });


### PR DESCRIPTION
## What

Populate ACP bash permission requests with the same execute metadata used by normal bash tool-call notifications:

- `kind: "execute"`
- `status: "pending"`
- `rawInput`
- command display content

## Why

The root ACP tool-call notification path already describes bash as an execute tool and includes command content. The permission request path was more minimal, which differs from Zed's official ACP agents and makes client-side rendering less robust.

This PR only changes the shape of the permission request. It does not change which tools require permission.

Fixes #1189.

## Batch context

This is part of a small ACP permission consistency batch:

- #1189 / this PR: enrich bash permission request metadata.
- #1190 / sibling PR: apply ACP permission policy to delegated sessions.
- #1191: track terminal lifecycle UX parity with Zed official ACP agents.

This PR is intentionally scoped so it can be reviewed and merged independently.

## Testing

- `bun test packages/coding-agent/test/agent-session-acp-permission.test.ts packages/coding-agent/test/acp-client-bridge.test.ts packages/coding-agent/test/acp-event-mapper.test.ts packages/coding-agent/test/bash-acp-terminal.test.ts`
  - 51 pass
  - 0 fail
  - 214 expect() calls
- `bun run check:ts`
  - exit 0

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)