### PR TITLE
fix(ai): parse MiniMax CN think tags

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed Anthropic fast mode (`serviceTier: "priority"`) looping on 429 `rate_limit_error: "Extra usage is required for fast mode."` for accounts without the extra-usage entitlement. `isAnthropicFastModeUnsupportedError` now matches the 429 phrasing in addition to the 400 `invalid_request_error` "does not support the `speed` parameter" case, so the provider drops `speed: "fast"` on the in-turn retry, sets `providerSessionState.fastModeDisabled` for the remainder of the session, and surfaces `disabledFeatures: ["priority"]` to the caller instead of retrying with the same payload until `PROVIDER_MAX_RETRIES` is exhausted.
+- Fixed MiniMax Coding Plan CN streaming `<think>...</think>` reasoning as visible assistant text. The OpenAI-compatible stream parser now enables the existing MiniMax tag parser for both `minimax-code` and `minimax-code-cn`, so CN responses become structured `thinking` blocks instead of raw text. ([#1203](https://github.com/can1357/oh-my-pi/issues/1203))
 
 ## [15.1.6] - 2026-05-19
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -486,7 +486,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 			}
 			stream.push({ type: "start", partial: output });
 
-			const parseMiniMaxThinkTags = model.provider === "minimax-code";
+			const parseMiniMaxThinkTags = model.provider === "minimax-code" || model.provider === "minimax-code-cn";
 			// Some OpenAI-compatible DeepSeek hosts (including NVIDIA NIM and DeepSeek's
 			// native API) leak chat-template tool-call markers in `delta.content` even
 			// though tool calls are also surfaced structurally. Strip the leaked markers

--- a/packages/ai/test/issue-1203-repro.test.ts
+++ b/packages/ai/test/issue-1203-repro.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { getBundledModel } from "../src/models";
+import { streamOpenAICompletions } from "../src/providers/openai-completions";
+import type { Context, Model } from "../src/types";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+	global.fetch = originalFetch;
+});
+
+function createSseResponse(events: unknown[]): Response {
+	const payload = `${events
+		.map(event => `data: ${typeof event === "string" ? event : JSON.stringify(event)}`)
+		.join("\n\n")}\n\n`;
+	return new Response(payload, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function createMockFetch(events: unknown[]): typeof fetch {
+	async function mockFetch(_input: string | URL | Request, _init?: RequestInit): Promise<Response> {
+		return createSseResponse(events);
+	}
+	return Object.assign(mockFetch, { preconnect: originalFetch.preconnect });
+}
+
+function baseContext(): Context {
+	return {
+		messages: [
+			{
+				role: "user",
+				content: "hello",
+				timestamp: Date.now(),
+			},
+		],
+	};
+}
+
+function minimaxChunk(model: Model<"openai-completions">, content: string): unknown {
+	return {
+		id: "chatcmpl-minimax-cn",
+		object: "chat.completion.chunk",
+		created: 0,
+		model: model.id,
+		choices: [{ index: 0, delta: { content, role: "assistant" } }],
+	};
+}
+
+function stopChunk(model: Model<"openai-completions">): unknown {
+	return {
+		id: "chatcmpl-minimax-cn",
+		object: "chat.completion.chunk",
+		created: 0,
+		model: model.id,
+		choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+	};
+}
+
+describe("issue #1203 - MiniMax Coding Plan CN think tags", () => {
+	it("parses minimax-code-cn <think> content into a thinking block", async () => {
+		const model = getBundledModel("minimax-code-cn", "MiniMax-M2.5") as Model<"openai-completions">;
+		global.fetch = createMockFetch([
+			minimaxChunk(model, "<think>"),
+			minimaxChunk(model, "hidden reasoning"),
+			minimaxChunk(model, "</think>"),
+			minimaxChunk(model, "visible answer"),
+			stopChunk(model),
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(model, baseContext(), { apiKey: "test-key" }).result();
+
+		expect(result.content).toEqual([
+			{ type: "thinking", thinking: "hidden reasoning", thinkingSignature: undefined },
+			{ type: "text", text: "visible answer" },
+		]);
+	});
+});


### PR DESCRIPTION
## What

Fix MiniMax Coding Plan CN streaming `<think>...</think>` reasoning as visible assistant text.

`minimax-code-cn` uses the same OpenAI-compatible streaming shape as `minimax-code`: reasoning arrives in `delta.content` wrapped with MiniMax think tags, not in `delta.reasoning_content`. The existing parser only ran for `minimax-code`, so CN responses stayed in normal text blocks.

Fixes #1203.

## Why

CN Coding Plan responses like:

```json
{"delta":{"content":"<think>"}}
{"delta":{"content":"hidden reasoning"}}
{"delta":{"content":"</think>"}}
{"delta":{"content":"visible answer"}}
```

should normalize to structured assistant content:

```json
[
  { "type": "thinking", "thinking": "hidden reasoning" },
  { "type": "text", "text": "visible answer" }
]
```

instead of rendering raw `<think>` tags in the TUI/transcript.

## Testing

- `bun test packages/ai/test/issue-1203-repro.test.ts`
- `bun run check` from `packages/ai` was attempted; it fails on existing unrelated type errors:
  - `src/providers/anthropic.ts(1294,40): Property 'stop_details' does not exist on type 'Delta'.`
  - `src/utils/h2-fetch.ts(43,44): 'protocol' does not exist in type 'BunFetchRequestInit'.`
- `bun run check:ts` from repo root was attempted; it fails on the same existing errors plus unrelated workspace type errors/missing dependencies.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)