### PR TITLE
fix(ai): extend MiniMax think-tag parser to minimax-code-cn

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `minimax-code-cn` leaking raw `<think>...</think>` blocks as visible assistant text. The `<think>` tag parser gate in `streamOpenAICompletions` now covers both `minimax-code` and `minimax-code-cn` providers, matching the pattern already in place in `model-thinking.ts`, `openai-completions-compat.ts`, and `usage/minimax-code.ts` ([#1203](https://github.com/can1357/oh-my-pi/issues/1203)).
+
+
 ## [15.1.7] - 2026-05-19
 ### Added
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -486,7 +486,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 			}
 			stream.push({ type: "start", partial: output });
 
-			const parseMiniMaxThinkTags = model.provider === "minimax-code";
+			const parseMiniMaxThinkTags = model.provider === "minimax-code" || model.provider === "minimax-code-cn";
 			// Some OpenAI-compatible DeepSeek hosts (including NVIDIA NIM and DeepSeek's
 			// native API) leak chat-template tool-call markers in `delta.content` even
 			// though tool calls are also surfaced structurally. Strip the leaked markers

--- a/packages/ai/test/issue-1203-repro.test.ts
+++ b/packages/ai/test/issue-1203-repro.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { getBundledModel } from "../src/models";
+import { streamOpenAICompletions } from "../src/providers/openai-completions";
+import type { Context, Model } from "../src/types";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+	global.fetch = originalFetch;
+});
+
+function createSseResponse(events: unknown[]): Response {
+	const payload = `${events
+		.map(event => `data: ${typeof event === "string" ? event : JSON.stringify(event)}`)
+		.join("\n\n")}\n\n`;
+	return new Response(payload, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function createMockFetch(events: unknown[]): typeof fetch {
+	async function mockFetch(_input: string | URL | Request, _init?: RequestInit): Promise<Response> {
+		return createSseResponse(events);
+	}
+	return Object.assign(mockFetch, { preconnect: originalFetch.preconnect });
+}
+
+function baseContext(): Context {
+	return {
+		messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+	};
+}
+
+/**
+ * Regression test for issue #1203.
+ *
+ * MiniMax Coding Plan CN (`minimax-code-cn`) streams reasoning inside
+ * `delta.content` wrapped in `<think>...</think>` tags — the same wire
+ * format as the international `minimax-code` provider. The tag-parser gate
+ * in `streamOpenAICompletions` previously excluded `minimax-code-cn`,
+ * causing the raw `<think>` markup to be stored as visible assistant text
+ * instead of a structured `thinking` content block.
+ */
+describe("issue #1203 — minimax-code-cn <think> tag parser", () => {
+	const model = getBundledModel("minimax-code-cn", "MiniMax-M2.5") as Model<"openai-completions">;
+
+	function thinkTagSseEvents(modelId: string): unknown[] {
+		return [
+			{
+				id: "chatcmpl-minimax-cn-1",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: modelId,
+				choices: [{ index: 0, delta: { content: "<think>", role: "assistant" } }],
+			},
+			{
+				id: "chatcmpl-minimax-cn-1",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: modelId,
+				choices: [{ index: 0, delta: { content: "The user wrote in Chinese: ...", role: "assistant" } }],
+			},
+			{
+				id: "chatcmpl-minimax-cn-1",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: modelId,
+				choices: [{ index: 0, delta: { content: "</think>", role: "assistant" } }],
+			},
+			{
+				id: "chatcmpl-minimax-cn-1",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: modelId,
+				choices: [{ index: 0, delta: { content: "完成", role: "assistant" } }],
+			},
+			{
+				id: "chatcmpl-minimax-cn-1",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: modelId,
+				choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+			},
+			"[DONE]",
+		];
+	}
+
+	it("parses <think>...</think> as a structured thinking block", async () => {
+		global.fetch = createMockFetch(thinkTagSseEvents(model.id));
+
+		const result = await streamOpenAICompletions(model, baseContext(), { apiKey: "test-key" }).result();
+
+		const thinkingBlocks = result.content.filter(b => b.type === "thinking");
+		const textBlocks = result.content.filter(b => b.type === "text");
+
+		expect(thinkingBlocks).toHaveLength(1);
+		expect(textBlocks).toHaveLength(1);
+
+		const thinking = thinkingBlocks[0];
+		if (thinking.type === "thinking") {
+			expect(thinking.thinking).toBe("The user wrote in Chinese: ...");
+		}
+
+		const text = textBlocks.map(b => (b.type === "text" ? b.text : "")).join("");
+		expect(text).toBe("完成");
+	});
+
+	it("does not leak raw <think> tags as visible text", async () => {
+		global.fetch = createMockFetch(thinkTagSseEvents(model.id));
+
+		const result = await streamOpenAICompletions(model, baseContext(), { apiKey: "test-key" }).result();
+
+		const allText = result.content
+			.filter(b => b.type === "text")
+			.map(b => (b.type === "text" ? b.text : ""))
+			.join("");
+
+		expect(allText).not.toContain("<think>");
+		expect(allText).not.toContain("</think>");
+	});
+});


### PR DESCRIPTION
## Repro

Configure `MINIMAX_CODE_CN_API_KEY`, select `minimax-code-cn / MiniMax-M2.5`, and send a prompt that triggers reasoning. The upstream SSE delivers `delta.content` wrapped in `<think>...</think>` tags (not `delta.reasoning_content`). Before this fix, the provider emitted the raw markup as a `text` content block — `<think>…</think>` visible in the assistant response — instead of a structured `thinking` block.

The parser gate that routes `<think>`-tagged content to the thinking accumulator:

```ts
// packages/ai/src/providers/openai-completions.ts
const parseMiniMaxThinkTags = model.provider === "minimax-code";
```

`minimax-code-cn` was excluded, so `delta.content` fell through to `appendTextDelta()`.

## Cause

`parseMiniMaxThinkTags` in `streamOpenAICompletions` (`packages/ai/src/providers/openai-completions.ts`, line 489) only checked `model.provider === "minimax-code"`. The CN endpoint (`https://api.minimaxi.com/v1`) uses the same `<think>` tag wire format as the international one, but the guard never fired for `minimax-code-cn`.

Every other location in the codebase that distinguishes MiniMax providers already handles both together: `model-thinking.ts` (line 336), `openai-completions-compat.ts` (line 132–135), `usage/minimax-code.ts` (line 29).

## Fix

- `packages/ai/src/providers/openai-completions.ts`: extend the guard to `model.provider === "minimax-code" || model.provider === "minimax-code-cn"` (one-line change).
- `packages/ai/CHANGELOG.md`: entry under `## [Unreleased] → ### Fixed`.
- `packages/ai/test/issue-1203-repro.test.ts`: two regression tests using a mock SSE fetch — one asserting the `thinking` block is produced with the right content, one asserting no raw `<think>` tags appear in the `text` block.

## Verification

```
cd packages/ai && bun test test/issue-1203-repro.test.ts test/issue-959-repro.test.ts test/issue-955-repro.test.ts test/openai-completions-compat.test.ts test/model-thinking.test.ts
```

```
bun test v1.3.14 (0d9b296a)
 48 pass
 0 fail
Ran 48 tests across 5 files. [...]
```

`Fixes #1203`