### PR TITLE
fix(providers): skip disabled discovery probes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `disabledProviders` still probing local discovery endpoints for Ollama, llama.cpp, and LM Studio during background model refresh. Disabled providers are now excluded before implicit and built-in discovery managers are created. ([#1232](https://github.com/can1357/oh-my-pi/issues/1232))
+
 ## [15.1.8] - 2026-05-20
 
 ### Fixed

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1017,7 +1017,8 @@ export class ModelRegistry {
 	}
 
 	#addImplicitDiscoverableProviders(configuredProviders: Set<string>): void {
-		if (!configuredProviders.has("ollama")) {
+		const disabledProviders = getDisabledProviderIdsFromSettings();
+		if (!configuredProviders.has("ollama") && !disabledProviders.has("ollama")) {
 			this.#discoverableProviders.push({
 				provider: "ollama",
 				api: "openai-responses",
@@ -1027,7 +1028,7 @@ export class ModelRegistry {
 			});
 			this.#keylessProviders.add("ollama");
 		}
-		if (!configuredProviders.has("llama.cpp")) {
+		if (!configuredProviders.has("llama.cpp") && !disabledProviders.has("llama.cpp")) {
 			this.#discoverableProviders.push({
 				provider: "llama.cpp",
 				api: "openai-responses",
@@ -1040,7 +1041,7 @@ export class ModelRegistry {
 				this.#keylessProviders.add("llama.cpp");
 			}
 		}
-		if (!configuredProviders.has("lm-studio")) {
+		if (!configuredProviders.has("lm-studio") && !disabledProviders.has("lm-studio")) {
 			this.#discoverableProviders.push({
 				provider: "lm-studio",
 				api: "openai-completions",
@@ -1160,9 +1161,12 @@ export class ModelRegistry {
 		strategy: ModelRefreshStrategy,
 		providerFilter?: ReadonlySet<string>,
 	): Promise<void> {
-		const selectedDiscoverableProviders = providerFilter
-			? this.#discoverableProviders.filter(provider => providerFilter.has(provider.provider))
-			: this.#discoverableProviders;
+		const disabledProviders = getDisabledProviderIdsFromSettings();
+		const selectedDiscoverableProviders = (
+			providerFilter
+				? this.#discoverableProviders.filter(provider => providerFilter.has(provider.provider))
+				: this.#discoverableProviders
+		).filter(provider => !disabledProviders.has(provider.provider));
 		const configuredDiscoveriesPromise =
 			selectedDiscoverableProviders.length === 0
 				? Promise.resolve<Model<Api>[]>([])
@@ -1366,17 +1370,24 @@ export class ModelRegistry {
 				},
 			},
 		];
+		const disabledProviders = getDisabledProviderIdsFromSettings();
+		const standardProviderDescriptors = PROVIDER_DESCRIPTORS.filter(
+			descriptor => !disabledProviders.has(descriptor.providerId),
+		);
+		const enabledSpecialProviderDescriptors = specialProviderDescriptors.filter(
+			descriptor => !disabledProviders.has(descriptor.providerId),
+		);
 		// Use peekApiKey to avoid OAuth token refresh during discovery.
 		// The token is only needed if the dynamic fetch fires (cache miss),
 		// and failures there are handled gracefully.
 		const peekKey = (descriptor: { providerId: string }) => this.#peekApiKeyForProvider(descriptor.providerId);
 		const [standardProviderKeys, specialKeys] = await Promise.all([
-			Promise.all(PROVIDER_DESCRIPTORS.map(peekKey)),
-			Promise.all(specialProviderDescriptors.map(peekKey)),
+			Promise.all(standardProviderDescriptors.map(peekKey)),
+			Promise.all(enabledSpecialProviderDescriptors.map(peekKey)),
 		]);
 		const options: ModelManagerOptions<Api>[] = [];
-		for (let i = 0; i < PROVIDER_DESCRIPTORS.length; i++) {
-			const descriptor = PROVIDER_DESCRIPTORS[i];
+		for (let i = 0; i < standardProviderDescriptors.length; i++) {
+			const descriptor = standardProviderDescriptors[i];
 			const apiKey = standardProviderKeys[i];
 			if (isAuthenticated(apiKey) || descriptor.allowUnauthenticated) {
 				options.push(
@@ -1388,8 +1399,8 @@ export class ModelRegistry {
 			}
 		}
 
-		for (let i = 0; i < specialProviderDescriptors.length; i++) {
-			const descriptor = specialProviderDescriptors[i];
+		for (let i = 0; i < enabledSpecialProviderDescriptors.length; i++) {
+			const descriptor = enabledSpecialProviderDescriptors[i];
 			const key = descriptor.resolveKey(specialKeys[i]);
 			if (!isAuthenticated(key)) {
 				continue;

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -1482,6 +1482,28 @@ describe("ModelRegistry", () => {
 			expect(registry.getAvailable().some(model => model.provider === "github-copilot")).toBe(false);
 			expect(registry.getDiscoverableProviders()).not.toContain("ollama");
 		});
+
+		test("refresh skips discovery probes for disabled local providers", async () => {
+			await Settings.init({
+				inMemory: true,
+				overrides: {
+					disabledProviders: ["llama.cpp", "lm-studio", "ollama"],
+				},
+			});
+			const requestedUrls: string[] = [];
+			using _hook = hookFetch(input => {
+				requestedUrls.push(String(input));
+				throw new Error(`Unexpected URL: ${String(input)}`);
+			});
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			await registry.refresh("online");
+
+			const disabledProbeUrls = requestedUrls.filter(
+				url => url.includes("127.0.0.1:11434") || url.includes("127.0.0.1:8080") || url.includes("127.0.0.1:1234"),
+			);
+			expect(disabledProbeUrls).toEqual([]);
+		});
 	});
 	describe("runtime discovery", () => {
 		test("auto-discovers ollama models without provider config", async () => {


### PR DESCRIPTION
## Repro
With `disabledProviders: ["llama.cpp", "lm-studio", "ollama"]`, `ModelRegistry.refresh("online")` still probed disabled local endpoints. Repro command: `bun .wt/repro-1232.ts`, which recorded calls to `http://127.0.0.1:11434/api/tags`, `http://127.0.0.1:8080/models`, and `http://127.0.0.1:1234/v1/models` before the fix.

## Cause
`packages/coding-agent/src/config/model-registry.ts` only filtered disabled providers for availability/UI queries. `#addImplicitDiscoverableProviders`, `#refreshRuntimeDiscoveries`, and `#collectBuiltInModelManagerOptions` still registered or instantiated discovery work for disabled providers, so local discovery managers ran even after the provider was hidden.

## Fix
- Exclude disabled providers before adding implicit Ollama, llama.cpp, and LM Studio discovery configs.
- Filter configured discovery providers during refresh so explicit discovery configs do not run while disabled.
- Filter built-in provider descriptors before API-key peeking and model-manager creation.
- Add regression coverage that records fetch URLs and asserts disabled local endpoints are not probed.

## Verification
`bun --cwd=packages/coding-agent test test/model-registry.test.ts` passed with 87 tests. `bun --cwd=packages/coding-agent run check` passed. Re-running the repro script after the fix produced an empty `disabledProbeUrls` list. Fixes #1232