### PR TITLE
fix(acp): disable host MCP discovery in ACP session factory

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp acp` auto-discovering host `.mcp.json` servers in parallel with the ACP client's `session/new.mcpServers`, which shadowed client-supplied MCP tools in `search_tool_bm25` and the session tool registry. The ACP session factory now forces `enableMCP: false`, so MCP ownership stays with `AcpAgent#configureMcpServers`. Non-ACP modes keep on-disk discovery. ([#1234](https://github.com/can1357/oh-my-pi/issues/1234))
+
 ## [15.1.8] - 2026-05-20
 
 ### Fixed

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -199,7 +199,7 @@ function applyExtensionFlagValues(session: AgentSession, rawArgs: string[]): Map
 
 type AcpSessionFactory = (cwd: string) => Promise<AgentSession>;
 
-interface AcpSessionFactoryOptions {
+export interface AcpSessionFactoryOptions {
 	baseOptions: CreateAgentSessionOptions;
 	settings: Settings;
 	sessionDir?: string;
@@ -210,7 +210,17 @@ interface AcpSessionFactoryOptions {
 	createSession: (options: CreateAgentSessionOptions) => Promise<CreateAgentSessionResult>;
 }
 
-function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSessionFactory {
+/**
+ * Build the per-`session/new` factory used by ACP mode.
+ *
+ * MCP servers in ACP sessions are owned exclusively by the ACP client, which
+ * supplies them through `session/new.mcpServers` and re-applies them via
+ * {@link AcpAgent#configureMcpServers}. We therefore force `enableMCP: false`
+ * on every session created here so {@link createAgentSession} skips the on-disk
+ * `.mcp.json` discovery path — otherwise host MCP tools land in the session's
+ * tool registry and shadow the client-supplied servers (issue #1234).
+ */
+export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSessionFactory {
 	return async cwd => {
 		const nextSettings = await args.settings.cloneForCwd(cwd);
 		const nextSessionManager = SessionManager.create(cwd, args.sessionDir);
@@ -224,6 +234,7 @@ function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSessionFact
 			modelRegistry: args.modelRegistry,
 			agentId,
 			hasUI: false,
+			enableMCP: false,
 		});
 		if (args.parsedArgs.apiKey && !args.baseOptions.model && nextSession.model) {
 			args.authStorage.setRuntimeApiKey(nextSession.model.provider, args.parsedArgs.apiKey);

--- a/packages/coding-agent/test/acp-mcp-isolation.test.ts
+++ b/packages/coding-agent/test/acp-mcp-isolation.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Regression test for issue #1234.
+ *
+ * `omp acp` must not auto-discover host `.mcp.json` servers when creating a
+ * session for an ACP client. MCP server ownership belongs entirely to the ACP
+ * client (`session/new.mcpServers` → `AcpAgent#configureMcpServers`); letting
+ * `createAgentSession` run on-disk discovery in parallel registers host MCP
+ * tools that shadow the client-supplied ones in the session tool registry.
+ *
+ * The contract enforced here is narrow on purpose: every call routed through
+ * the ACP session factory must reach `createAgentSession` with
+ * `enableMCP: false`, regardless of what `baseOptions` carries.
+ */
+
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+import { ModelRegistry } from "../src/config/model-registry";
+import { Settings } from "../src/config/settings";
+import { createAcpSessionFactory } from "../src/main";
+import type { CreateAgentSessionOptions, CreateAgentSessionResult } from "../src/sdk";
+import type { AgentSession } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
+
+describe("createAcpSessionFactory MCP isolation (issue #1234)", () => {
+	it("forces enableMCP=false even when baseOptions opts in", async () => {
+		const tempDir = path.join(os.tmpdir(), `pi-acp-mcp-isolation-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		const authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+		try {
+			const modelRegistry = new ModelRegistry(authStorage);
+			const settings = Settings.isolated({});
+			const fakeSession = {} as AgentSession;
+			const captured: CreateAgentSessionOptions[] = [];
+			const createSession = async (options: CreateAgentSessionOptions): Promise<CreateAgentSessionResult> => {
+				captured.push(options);
+				return {
+					session: fakeSession,
+					extensionsResult: {
+						extensions: [],
+						errors: [],
+						runner: undefined,
+					} as unknown as CreateAgentSessionResult["extensionsResult"],
+					setToolUIContext: () => {},
+					eventBus: {
+						emit: () => {},
+						on: () => () => {},
+						off: () => {},
+					} as unknown as CreateAgentSessionResult["eventBus"],
+				};
+			};
+
+			// baseOptions deliberately sets enableMCP=true to prove the factory ignores it.
+			const factory = createAcpSessionFactory({
+				baseOptions: { enableMCP: true } as CreateAgentSessionOptions,
+				settings,
+				sessionDir: path.join(tempDir, "sessions"),
+				authStorage,
+				modelRegistry,
+				parsedArgs: {},
+				rawArgs: [],
+				createSession,
+			});
+
+			const result = await factory(tempDir);
+			expect(result).toBe(fakeSession);
+			expect(captured).toHaveLength(1);
+			expect(captured[0].enableMCP).toBe(false);
+		} finally {
+			authStorage.close();
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Repro

Launch `omp acp` from an ACP client that supplies its own MCP servers in `session/new.mcpServers` while a host `.mcp.json` is also configured. After the session starts, `search_tool_bm25` returns only the host MCP tools (`mcp__<host_server>_<tool>`) and the client-supplied servers are absent from the registry. Reproduced at the unit level in `packages/coding-agent/test/acp-mcp-isolation.test.ts` by spying on the `createSession` callback the ACP session factory invokes: without the fix, `enableMCP` reaches `createAgentSession` as `true`, which is exactly what triggers on-disk discovery.

## Cause

`createAcpSessionFactory` in `packages/coding-agent/src/main.ts` spread `baseOptions` (built by `buildSessionOptions`, which never sets `enableMCP`) straight into `createSession`. `createAgentSession` in `packages/coding-agent/src/sdk.ts` defaults `enableMCP = options.enableMCP ?? true`, so every `session/new` ran `discoverAndLoadMCPTools(cwd, …)` and registered host MCP tools in the session's tool registry. `AcpAgent#configureMcpServers` then layered the client-supplied servers on top via `refreshMCPTools`, but the host manager had already populated the BM25 discovery indexes and `MCPManager.setInstance(...)` had taken over the global slot — leaving the ACP client's tools effectively shadowed for tool discovery.

## Fix

- `createAcpSessionFactory` now passes `enableMCP: false` to `createSession`, so on-disk `.mcp.json` discovery is skipped for every ACP session. `AcpAgent#configureMcpServers` becomes the single source of truth for MCP servers in ACP mode, matching the protocol's contract.
- Exported `createAcpSessionFactory` and `AcpSessionFactoryOptions` so the regression can be defended at the unit level.
- Added a comment on the factory recording the invariant and pointing to this issue.
- Added `packages/coding-agent/test/acp-mcp-isolation.test.ts` to spy on the `createSession` callback and assert `enableMCP === false`, even when `baseOptions.enableMCP === true` (so a future caller cannot quietly re-enable host discovery).
- Non-ACP modes (`omp` interactive, print, RPC, RPC-UI) keep auto-discovery — the change is scoped to the ACP factory.

## Verification

`bun --cwd=packages/coding-agent test test/acp-mcp-isolation.test.ts test/acp-agent.test.ts test/sdk-mcp-discovery.test.ts test/acp-lazy-startup.test.ts test/acp-builtins.test.ts` → 117 pass, 0 fail. Reverted the one-line fix locally to confirm the new test reports `Expected: false / Received: true`, then restored. `bun --cwd=packages/coding-agent run check` passes (typecheck + biome).

Fixes #1234