### PR TITLE
fix(tui): reassembled split private CSI probe responses so DA1 reply does not leak as keystrokes

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed terminal probe responses (DA1, kitty keyboard, Mode 2031) leaking into the prompt as keystrokes when the response is split across stdin reads. `ProcessTerminal` now reassembles `\x1b[?<digits>...` private CSI fragments and dispatches the complete response through the existing pattern handlers. ([#1238](https://github.com/can1357/oh-my-pi/issues/1238))
+
 ## [15.1.4] - 2026-05-19
 
 ### Fixed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -127,6 +127,7 @@ export class ProcessTerminal implements Terminal {
 	#osc11Pending = false;
 	#osc11QueryQueued = false;
 	#osc11ResponseBuffer = "";
+	#privateCsiResponseBuffer = "";
 	#pendingDa1Sentinels = 0;
 	#osc11PollTimer?: Timer;
 	#mode2031DebounceTimer?: Timer;
@@ -278,8 +279,51 @@ export class ProcessTerminal implements Terminal {
 		// DA1 (Primary Device Attributes) response: \x1b[?...c
 		const da1ResponsePattern = /^\x1b\[\?[\d;]*c$/;
 
+		// Private CSI partial: \x1b[?<digits/semicolons>... — incomplete probe response
+		// that the StdinBuffer flushed before the terminator arrived (split across
+		// stdin reads). Used to reassemble DA1, kitty, and Mode 2031 replies.
+		const privateCsiPartialPattern = /^\x1b\[\?[\d;]*$/;
+
 		// Forward individual sequences to the input handler
 		this.#stdinBuffer.on("data", (sequence: string) => {
+			// Reassemble split private CSI responses (DA1, kitty keyboard, Mode 2031).
+			// When the terminal writes the response slowly enough that the StdinBuffer's
+			// flush timeout elapses mid-sequence, the prefix `\x1b[?<digits>` arrives as
+			// one event and the tail `;...<terminator>` arrives as individual character
+			// events that would otherwise leak into the prompt as keystrokes. See #1238.
+			if (
+				this.#privateCsiResponseBuffer ||
+				(privateCsiPartialPattern.test(sequence) && this.#pendingDa1Sentinels > 0)
+			) {
+				if (this.#privateCsiResponseBuffer && sequence.startsWith("\x1b")) {
+					// New escape arrived mid-reassembly — abandon partial and re-process the new sequence.
+					this.#privateCsiResponseBuffer = "";
+				} else {
+					this.#privateCsiResponseBuffer += sequence;
+					// Cap accumulator to defend against runaway partials if the terminator never arrives.
+					if (this.#privateCsiResponseBuffer.length > 256) {
+						this.#privateCsiResponseBuffer = "";
+						return;
+					}
+					const lastChar = this.#privateCsiResponseBuffer.at(-1)!;
+					const lastCode = lastChar.charCodeAt(0);
+					if (lastCode >= 0x40 && lastCode <= 0x7e) {
+						// Terminator byte arrived. Fall through to the pattern checks with the
+						// reassembled sequence so the existing DA1/kitty/Mode 2031 handlers run.
+						sequence = this.#privateCsiResponseBuffer;
+						this.#privateCsiResponseBuffer = "";
+					} else if (!privateCsiPartialPattern.test(this.#privateCsiResponseBuffer)) {
+						// Diverged from a valid private CSI prefix (unexpected byte). Drop the
+						// probe noise we ate; do not forward to the input handler.
+						this.#privateCsiResponseBuffer = "";
+						return;
+					} else {
+						// Still accumulating.
+						return;
+					}
+				}
+			}
+
 			// Check for Kitty protocol response (only if not already enabled)
 			if (!this.#kittyProtocolActive) {
 				const match = sequence.match(kittyResponsePattern);
@@ -531,6 +575,7 @@ export class ProcessTerminal implements Terminal {
 		this.#osc11Pending = false;
 		this.#osc11QueryQueued = false;
 		this.#osc11ResponseBuffer = "";
+		this.#privateCsiResponseBuffer = "";
 		this.#pendingDa1Sentinels = 0;
 
 		// Disable Kitty keyboard protocol if not already done by drainInput()

--- a/packages/tui/test/terminal-appearance.test.ts
+++ b/packages/tui/test/terminal-appearance.test.ts
@@ -275,4 +275,58 @@ describe("ProcessTerminal OSC 11 appearance detection", () => {
 
 		terminal.stop();
 	});
+
+	it("reassembles a DA1 response split across stdin reads without leaking to input (#1238)", () => {
+		vi.useFakeTimers();
+		const { terminal, received } = setupTerminal();
+
+		// OSC 11 completes normally.
+		process.stdin.emit("data", "\x1b]11;rgb:1c1c/1c1c/1c1c\x07");
+
+		// DA1 reply arrives split: the prefix appears as one event and then the StdinBuffer
+		// flush timeout (10ms) elapses before the rest of the response is delivered.
+		// xterm-style "VT420 with extensions" response: \x1b[?62;6;7;14;...;52c
+		process.stdin.emit("data", "\x1b[?62");
+		vi.advanceTimersByTime(50);
+		process.stdin.emit("data", ";6;7;14;21;22;23;24;28;32;42;52c");
+
+		expect(received).toEqual([]);
+		expect(terminal.appearance).toBe("dark");
+
+		terminal.stop();
+	});
+
+	it("reassembles a DA1 response delivered byte-by-byte", () => {
+		vi.useFakeTimers();
+		const { terminal, received } = setupTerminal();
+
+		process.stdin.emit("data", "\x1b]11;rgb:1c1c/1c1c/1c1c\x07");
+		process.stdin.emit("data", "\x1b[?62");
+		vi.advanceTimersByTime(50);
+		for (const ch of ";6;7;14;21;22;23;24;28;32;42;52c") {
+			process.stdin.emit("data", ch);
+		}
+
+		expect(received).toEqual([]);
+		expect(terminal.appearance).toBe("dark");
+
+		terminal.stop();
+	});
+
+	it("abandons private CSI reassembly when a new escape arrives mid-stream", () => {
+		vi.useFakeTimers();
+		const { terminal, received } = setupTerminal();
+
+		// Start a partial DA1, then a fresh CSI (up arrow) interrupts before the terminator.
+		process.stdin.emit("data", "\x1b[?62");
+		vi.advanceTimersByTime(50);
+		process.stdin.emit("data", "\x1b[A");
+		vi.advanceTimersByTime(50);
+
+		// Up arrow must reach the input handler; probe noise must not.
+		expect(received).toContain("\x1b[A");
+		expect(received.some(seq => seq.includes("?62"))).toBe(false);
+
+		terminal.stop();
+	});
 });


### PR DESCRIPTION
## Repro

`omp` periodically polls the terminal background colour with OSC 11 + a DA1 sentinel (`\x1b]11;?\x07\x1b[c`) every 2s while idle. On Linux terminals that reply with a long VT420-style DA1 response (`\x1b[?62;6;7;14;21;22;23;24;28;32;42;52c`), if the reply arrives in two stdin reads more than ~10ms apart, the `StdinBuffer` flush timeout fires mid-sequence and the `;6;7;14;21;22;23;24;28;32;42;52c` tail leaks into the prompt as keystrokes — reproduced in #1238.

Reproduced with a unit-level harness on `StdinBuffer`:

```js
buf.process('\x1b]11;rgb:1c1c/1c1c/1c1c\x07\x1b[?62');
await Bun.sleep(15);  // exceeds the 10ms flush timeout
buf.process(';6;7;14;21;22;23;24;28;32;42;52c');
```

Before the fix, the buffer emits the partial `\x1b[?62` (which the DA1 regex does not match) followed by every continuation byte as an individual `data` event, all forwarded to the input handler.

## Cause

`packages/tui/src/terminal.ts` matches the DA1 sentinel reply against `/^\x1b\[\?[\d;]*c$/` on a single emitted sequence (terminal.ts:279). When `StdinBuffer.flush()` releases the unfinished CSI prefix and the trailing characters arrive as bare codepoints, neither half matches, so the prefix is silently dropped while the tail flows to the TUI input handler — producing the digits-and-semicolons seen in the screenshot. OSC 11 already had ad-hoc split handling alongside; DA1, kitty keyboard, and Mode 2031 responses did not.

## Fix

- Added `#privateCsiResponseBuffer` accumulator on `ProcessTerminal` plus a reassembly block at the top of the StdinBuffer `data` handler. While a DA1 sentinel is outstanding, sequences matching `^\x1b\[\?[\d;]*$` start a buffer; subsequent non-escape chunks are appended until a CSI terminator (0x40–0x7E) arrives, at which point the rebuilt sequence is dispatched through the existing DA1 / kitty / Mode 2031 / Mouse / OSC 11 pattern checks unchanged.
- A new escape interrupting the partial abandons the buffer (and the new escape is re-processed), divergence from the valid private-CSI prefix drops the probe noise without forwarding it, and a 256-byte cap defends against a runaway accumulator.
- Cleared the new buffer in `stop()` alongside the existing OSC 11 state.
- Added `### Fixed` changelog entry under `## [Unreleased]` referencing #1238.

## Verification

`bun --cwd=packages/tui test` — 365 / 365 pass, including three new regression tests covering: a chunk-then-tail DA1 split, a byte-by-byte DA1 reassembly, and an interrupting `\x1b[A` that must reach the input handler while probe bytes do not. `bun check` clean across the workspace.

Fixes #1238