### PR TITLE
feat(tui): OSC 8 hyperlinks for file paths in tool output

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added OSC 8 terminal hyperlink support for file paths in tool output. When the terminal supports hyperlinks (kitty, Ghostty, WezTerm, iTerm2, Alacritty, VS Code) and the new `tui.hyperlinks` setting is `auto` (default) or `always`, OMP wraps file paths emitted by `read`, `find`, `search`, `edit`, `ast_grep`, and `ast_edit` renderers in `file:///abs/path` hyperlinks. `local://` and other fs-backed internal URLs resolve to their backing path. Set `tui.hyperlinks: off` to disable. ([#1244](https://github.com/can1357/oh-my-pi/issues/1244))
+
 ## [15.1.8] - 2026-05-20
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -583,6 +583,18 @@ export const SETTINGS_SCHEMA = {
 		description:
 			"Maximum height in terminal rows for inline images (default 20). Set to 0 to use only the viewport-based limit (60% of terminal height).",
 	},
+
+	"tui.hyperlinks": {
+		type: "enum",
+		values: ["off", "auto", "always"] as const,
+		default: "auto",
+		ui: {
+			tab: "appearance",
+			label: "Terminal Hyperlinks",
+			description:
+				"Wrap file paths in OSC 8 hyperlinks for terminal-native click-to-open (auto: detect support; off: never; always: unconditional)",
+		},
+	},
 	// Display rendering
 	"display.tabWidth": {
 		type: "number",

--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -25,7 +25,7 @@ import {
 	truncateDiffByHunk,
 } from "../tools/render-utils";
 import { type VimRenderArgs, vimToolRenderer } from "../tools/vim";
-import { Hasher, type RenderCache, renderStatusLine, truncateToWidth } from "../tui";
+import { fileHyperlink, Hasher, type RenderCache, renderStatusLine, truncateToWidth } from "../tui";
 import type { EditMode } from "../utils/edit-mode";
 import type { VimToolDetails } from "../vim/types";
 import type { DiffError, DiffResult } from "./diff";
@@ -219,14 +219,16 @@ function formatEditPathDisplay(
 	uiTheme: Theme,
 	options?: { rename?: string; firstChangedLine?: number },
 ): string {
-	let pathDisplay = rawPath ? uiTheme.fg("accent", shortenPath(rawPath)) : uiTheme.fg("toolOutput", "…");
+	let pathDisplay = rawPath
+		? fileHyperlink(rawPath, uiTheme.fg("accent", shortenPath(rawPath)))
+		: uiTheme.fg("toolOutput", "…");
 
 	if (options?.firstChangedLine) {
 		pathDisplay += uiTheme.fg("warning", `:${options.firstChangedLine}`);
 	}
 
 	if (options?.rename) {
-		pathDisplay += ` ${uiTheme.fg("dim", "→")} ${uiTheme.fg("accent", shortenPath(options.rename))}`;
+		pathDisplay += ` ${uiTheme.fg("dim", "→")} ${fileHyperlink(options.rename, uiTheme.fg("accent", shortenPath(options.rename)))}`;
 	}
 
 	return pathDisplay;

--- a/packages/coding-agent/src/internal-urls/memory-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/memory-protocol.ts
@@ -14,7 +14,7 @@ const MEMORY_NAMESPACE = "root";
  * Each session has its own cwd (possibly a worktree), so subagents and main
  * may see different roots.
  */
-function memoryRootsFromRegistry(): string[] {
+export function memoryRootsFromRegistry(): string[] {
 	const agentDir = getAgentDir();
 	const roots: string[] = [];
 	for (const ref of AgentRegistry.global().list()) {

--- a/packages/coding-agent/src/tools/ast-edit.ts
+++ b/packages/coding-agent/src/tools/ast-edit.ts
@@ -495,27 +495,36 @@ export const astEditToolRenderer = {
 					maxCollapsed: changeGroups.length,
 					maxCollapsedLines: COLLAPSED_CHANGE_LIMIT,
 					itemType: "change",
-					renderItem: group => {
-						let contextDir = searchBase ?? "";
-						return group.map(line => {
-							if (line.startsWith("# ")) {
-								const dirPart = line.slice(2).trimEnd().replace(/\/$/, "");
+				renderItem: group => {
+					let contextDir = searchBase ?? "";
+					return group.map(line => {
+						if (line.startsWith("## ")) {
+							// Strip ` (3 replacements)` suffix attached by formatGroupedFiles.
+							const fileName = line.slice(3).trimEnd().replace(/\s+\([^)]*\)\s*$/, "");
+							const absPath = contextDir && fileName ? path.join(contextDir, fileName) : undefined;
+							const styled = uiTheme.fg("dim", line);
+							return absPath ? fileHyperlink(absPath, styled) : styled;
+						}
+						if (line.startsWith("# ")) {
+							const raw = line.slice(2).trimEnd().replace(/\s+\([^)]*\)\s*$/, "");
+							const isDirectory = raw.endsWith("/");
+							const name = raw.replace(/\/$/, "");
+							if (isDirectory) {
 								if (searchBase) {
-									contextDir = dirPart === "." ? searchBase : path.join(searchBase, dirPart);
+									contextDir = name === "." ? searchBase : path.join(searchBase, name);
 								}
 								return uiTheme.fg("accent", line);
 							}
-							if (line.startsWith("## ")) {
-								const fileName = line.slice(3).trimEnd();
-								const absPath = contextDir && fileName ? path.join(contextDir, fileName) : undefined;
-								const styled = uiTheme.fg("dim", line);
-								return absPath ? fileHyperlink(absPath, styled) : styled;
-							}
-							if (line.startsWith("+")) return uiTheme.fg("toolDiffAdded", line);
-							if (line.startsWith("-")) return uiTheme.fg("toolDiffRemoved", line);
-							return uiTheme.fg("toolOutput", line);
-						});
-					},
+							// Root-level file with optional suffix, e.g. `# foo.ts (3 replacements)`.
+							const absPath = searchBase && name ? path.join(searchBase, name) : undefined;
+							const styled = uiTheme.fg("accent", line);
+							return absPath ? fileHyperlink(absPath, styled) : styled;
+						}
+						if (line.startsWith("+")) return uiTheme.fg("toolDiffAdded", line);
+						if (line.startsWith("-")) return uiTheme.fg("toolDiffRemoved", line);
+						return uiTheme.fg("toolOutput", line);
+					});
+				},
 				},
 				uiTheme,
 			);

--- a/packages/coding-agent/src/tools/ast-edit.ts
+++ b/packages/coding-agent/src/tools/ast-edit.ts
@@ -9,7 +9,7 @@ import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { computeLineHash, HL_BODY_SEP } from "../hashline/hash";
 import type { Theme } from "../modes/theme/theme";
 import astEditDescription from "../prompts/tools/ast-edit.md" with { type: "text" };
-import { Ellipsis, renderStatusLine, renderTreeList, truncateToWidth } from "../tui";
+import { Ellipsis, fileHyperlink, renderStatusLine, renderTreeList, truncateToWidth } from "../tui";
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import type { ToolSession } from ".";
 import { createFileRecorder, formatResultPath } from "./file-recorder";
@@ -155,6 +155,9 @@ export interface AstEditToolDetails {
 	/** Pre-formatted text for the user-visible TUI render. Mirrors `result.text` lines but uses
 	 * a `│` gutter (no model-only hashline anchors). The TUI uses this directly so it never parses model-facing text. */
 	displayContent?: string;
+	/** Absolute base directory used during the edit. Used by the renderer to resolve
+	 * display-relative paths to absolute paths for OSC 8 hyperlinks. */
+	searchPath?: string;
 }
 
 export class AstEditTool implements AgentTool<typeof astEditSchema, AstEditToolDetails> {
@@ -233,17 +236,18 @@ export class AstEditTool implements AgentTool<typeof astEditSchema, AstEditToolD
 				changesByFile.get(relativePath)!.push(change);
 			}
 
-			const baseDetails: AstEditToolDetails = {
-				totalReplacements: result.totalReplacements,
-				filesTouched: result.filesTouched,
-				filesSearched: result.filesSearched,
-				applied: result.applied,
-				limitReached: result.limitReached,
-				...(cappedParseErrors.length > 0 ? { parseErrors: cappedParseErrors, parseErrorsTotal } : {}),
-				scopePath,
-				files: fileList,
-				fileReplacements: [],
-			};
+		const baseDetails: AstEditToolDetails = {
+			totalReplacements: result.totalReplacements,
+			filesTouched: result.filesTouched,
+			filesSearched: result.filesSearched,
+			applied: result.applied,
+			limitReached: result.limitReached,
+			...(cappedParseErrors.length > 0 ? { parseErrors: cappedParseErrors, parseErrorsTotal } : {}),
+			scopePath,
+			searchPath: resolvedSearchPath,
+			files: fileList,
+			fileReplacements: [],
+		};
 
 			if (result.totalReplacements === 0) {
 				const parseMessage = cappedParseErrors.length
@@ -480,30 +484,44 @@ export const astEditToolRenderer = {
 				uiTheme.fg("warning", formatParseErrorsCountLabel(details.parseErrors, details.parseErrorsTotal)),
 			);
 		}
-		return createCachedComponent(
-			() => options.expanded,
-			width => {
-				const changeLines = renderTreeList(
-					{
-						items: changeGroups,
-						expanded: options.expanded,
-						maxCollapsed: changeGroups.length,
-						maxCollapsedLines: COLLAPSED_CHANGE_LIMIT,
-						itemType: "change",
-						renderItem: group =>
-							group.map(line => {
-								if (line.startsWith("## ")) return uiTheme.fg("dim", line);
-								if (line.startsWith("# ")) return uiTheme.fg("accent", line);
-								if (line.startsWith("+")) return uiTheme.fg("toolDiffAdded", line);
-								if (line.startsWith("-")) return uiTheme.fg("toolDiffRemoved", line);
-								return uiTheme.fg("toolOutput", line);
-							}),
+	return createCachedComponent(
+		() => options.expanded,
+		width => {
+			const searchBase = details?.searchPath;
+			const changeLines = renderTreeList(
+				{
+					items: changeGroups,
+					expanded: options.expanded,
+					maxCollapsed: changeGroups.length,
+					maxCollapsedLines: COLLAPSED_CHANGE_LIMIT,
+					itemType: "change",
+					renderItem: group => {
+						let contextDir = searchBase ?? "";
+						return group.map(line => {
+							if (line.startsWith("# ")) {
+								const dirPart = line.slice(2).trimEnd().replace(/\/$/, "");
+								if (searchBase) {
+									contextDir = dirPart === "." ? searchBase : path.join(searchBase, dirPart);
+								}
+								return uiTheme.fg("accent", line);
+							}
+							if (line.startsWith("## ")) {
+								const fileName = line.slice(3).trimEnd();
+								const absPath = contextDir && fileName ? path.join(contextDir, fileName) : undefined;
+								const styled = uiTheme.fg("dim", line);
+								return absPath ? fileHyperlink(absPath, styled) : styled;
+							}
+							if (line.startsWith("+")) return uiTheme.fg("toolDiffAdded", line);
+							if (line.startsWith("-")) return uiTheme.fg("toolDiffRemoved", line);
+							return uiTheme.fg("toolOutput", line);
+						});
 					},
-					uiTheme,
-				);
-				return [header, ...changeLines, ...extraLines].map(l => truncateToWidth(l, width, Ellipsis.Omit));
-			},
-		);
+				},
+				uiTheme,
+			);
+			return [header, ...changeLines, ...extraLines].map(l => truncateToWidth(l, width, Ellipsis.Omit));
+		},
+	);
 	},
 	mergeCallAndResult: true,
 };

--- a/packages/coding-agent/src/tools/ast-grep.ts
+++ b/packages/coding-agent/src/tools/ast-grep.ts
@@ -378,26 +378,34 @@ export const astGrepToolRenderer = {
 					maxCollapsed: matchGroups.length,
 					maxCollapsedLines: COLLAPSED_MATCH_LIMIT,
 					itemType: "match",
-					renderItem: group => {
-						let contextDir = searchBase ?? "";
-						return group.map(line => {
-							if (line.startsWith("# ")) {
-								const dirPart = line.slice(2).trimEnd().replace(/\/$/, "");
+				renderItem: group => {
+					let contextDir = searchBase ?? "";
+					return group.map(line => {
+						if (line.startsWith("## ")) {
+							const fileName = line.slice(3).trimEnd().replace(/\s+\([^)]*\)\s*$/, "");
+							const absPath = contextDir && fileName ? path.join(contextDir, fileName) : undefined;
+							const styled = uiTheme.fg("dim", line);
+							return absPath ? fileHyperlink(absPath, styled) : styled;
+						}
+						if (line.startsWith("# ")) {
+							const raw = line.slice(2).trimEnd().replace(/\s+\([^)]*\)\s*$/, "");
+							const isDirectory = raw.endsWith("/");
+							const name = raw.replace(/\/$/, "");
+							if (isDirectory) {
 								if (searchBase) {
-									contextDir = dirPart === "." ? searchBase : path.join(searchBase, dirPart);
+									contextDir = name === "." ? searchBase : path.join(searchBase, name);
 								}
 								return uiTheme.fg("accent", line);
 							}
-							if (line.startsWith("## ")) {
-								const fileName = line.slice(3).trimEnd();
-								const absPath = contextDir && fileName ? path.join(contextDir, fileName) : undefined;
-								const styled = uiTheme.fg("dim", line);
-								return absPath ? fileHyperlink(absPath, styled) : styled;
-							}
-							if (line.startsWith("  meta:")) return uiTheme.fg("dim", line);
-							return uiTheme.fg("toolOutput", line);
-						});
-					},
+							// Root-level file (single # without trailing slash) from formatGroupedFiles.
+							const absPath = searchBase && name ? path.join(searchBase, name) : undefined;
+							const styled = uiTheme.fg("accent", line);
+							return absPath ? fileHyperlink(absPath, styled) : styled;
+						}
+						if (line.startsWith("  meta:")) return uiTheme.fg("dim", line);
+						return uiTheme.fg("toolOutput", line);
+					});
+				},
 				},
 				uiTheme,
 			);

--- a/packages/coding-agent/src/tools/ast-grep.ts
+++ b/packages/coding-agent/src/tools/ast-grep.ts
@@ -8,7 +8,7 @@ import * as z from "zod/v4";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import type { Theme } from "../modes/theme/theme";
 import astGrepDescription from "../prompts/tools/ast-grep.md" with { type: "text" };
-import { Ellipsis, renderStatusLine, renderTreeList, truncateToWidth } from "../tui";
+import { Ellipsis, fileHyperlink, renderStatusLine, renderTreeList, truncateToWidth } from "../tui";
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import type { ToolSession } from ".";
 import { createFileRecorder, formatResultPath } from "./file-recorder";
@@ -113,6 +113,9 @@ export interface AstGrepToolDetails {
 	/** Pre-formatted text for the user-visible TUI render. Mirrors `result.text` lines but uses
 	 * a `│` gutter and `*` to mark match lines. The TUI uses this directly so it never parses model-facing text. */
 	displayContent?: string;
+	/** Absolute base directory used during search. Used by the renderer to resolve
+	 * display-relative paths to absolute paths for OSC 8 hyperlinks. */
+	searchPath?: string;
 }
 
 export class AstGrepTool implements AgentTool<typeof astGrepSchema, AstGrepToolDetails> {
@@ -190,16 +193,17 @@ export class AstGrepTool implements AgentTool<typeof astGrepSchema, AstGrepToolD
 				matchesByFile.get(relativePath)!.push(match);
 			}
 
-			const baseDetails: AstGrepToolDetails = {
-				matchCount: result.totalMatches,
-				fileCount: result.filesWithMatches,
-				filesSearched: result.filesSearched,
-				limitReached: result.limitReached,
-				...(cappedParseErrors.length > 0 ? { parseErrors: cappedParseErrors, parseErrorsTotal } : {}),
-				scopePath,
-				files: fileList,
-				fileMatches: [],
-			};
+		const baseDetails: AstGrepToolDetails = {
+			matchCount: result.totalMatches,
+			fileCount: result.filesWithMatches,
+			filesSearched: result.filesSearched,
+			limitReached: result.limitReached,
+			...(cappedParseErrors.length > 0 ? { parseErrors: cappedParseErrors, parseErrorsTotal } : {}),
+			scopePath,
+			searchPath: resolvedSearchPath,
+			files: fileList,
+			fileMatches: [],
+		};
 
 			if (result.matches.length === 0) {
 				const noMatchMessage = cappedParseErrors.length
@@ -363,29 +367,43 @@ export const astGrepToolRenderer = {
 			);
 		}
 
-		return createCachedComponent(
-			() => options.expanded,
-			width => {
-				const matchLines = renderTreeList(
-					{
-						items: matchGroups,
-						expanded: options.expanded,
-						maxCollapsed: matchGroups.length,
-						maxCollapsedLines: COLLAPSED_MATCH_LIMIT,
-						itemType: "match",
-						renderItem: group =>
-							group.map(line => {
-								if (line.startsWith("## ")) return uiTheme.fg("dim", line);
-								if (line.startsWith("# ")) return uiTheme.fg("accent", line);
-								if (line.startsWith("  meta:")) return uiTheme.fg("dim", line);
-								return uiTheme.fg("toolOutput", line);
-							}),
+	return createCachedComponent(
+		() => options.expanded,
+		width => {
+			const searchBase = details?.searchPath;
+			const matchLines = renderTreeList(
+				{
+					items: matchGroups,
+					expanded: options.expanded,
+					maxCollapsed: matchGroups.length,
+					maxCollapsedLines: COLLAPSED_MATCH_LIMIT,
+					itemType: "match",
+					renderItem: group => {
+						let contextDir = searchBase ?? "";
+						return group.map(line => {
+							if (line.startsWith("# ")) {
+								const dirPart = line.slice(2).trimEnd().replace(/\/$/, "");
+								if (searchBase) {
+									contextDir = dirPart === "." ? searchBase : path.join(searchBase, dirPart);
+								}
+								return uiTheme.fg("accent", line);
+							}
+							if (line.startsWith("## ")) {
+								const fileName = line.slice(3).trimEnd();
+								const absPath = contextDir && fileName ? path.join(contextDir, fileName) : undefined;
+								const styled = uiTheme.fg("dim", line);
+								return absPath ? fileHyperlink(absPath, styled) : styled;
+							}
+							if (line.startsWith("  meta:")) return uiTheme.fg("dim", line);
+							return uiTheme.fg("toolOutput", line);
+						});
 					},
-					uiTheme,
-				);
-				return [header, ...matchLines, ...extraLines].map(l => truncateToWidth(l, width, Ellipsis.Omit));
-			},
-		);
+				},
+				uiTheme,
+			);
+			return [header, ...matchLines, ...extraLines].map(l => truncateToWidth(l, width, Ellipsis.Omit));
+		},
+	);
 	},
 	mergeCallAndResult: true,
 };

--- a/packages/coding-agent/src/tools/find.ts
+++ b/packages/coding-agent/src/tools/find.ts
@@ -11,7 +11,7 @@ import { InternalUrlRouter } from "../internal-urls";
 import type { Theme } from "../modes/theme/theme";
 import findDescription from "../prompts/tools/find.md" with { type: "text" };
 import { type TruncationResult, truncateHead } from "../session/streaming-output";
-import { Ellipsis, renderFileList, renderStatusLine, renderTreeList, truncateToWidth } from "../tui";
+import { Ellipsis, fileHyperlink, renderFileList, renderStatusLine, renderTreeList, truncateToWidth } from "../tui";
 import type { ToolSession } from ".";
 import { applyListLimit } from "./list-limit";
 import { formatFullOutputReference, type OutputMeta } from "./output-meta";
@@ -84,6 +84,9 @@ export interface FindToolDetails {
 	files?: string[];
 	truncated?: boolean;
 	error?: string;
+	/** Working directory at search time. Used by the renderer to resolve relative
+	 * file paths to absolute paths for OSC 8 hyperlinks. */
+	cwd?: string;
 	/** User-supplied paths whose base directory was missing on disk. The tool
 	 * skipped these and continued with the surviving entries; surfaced as a
 	 * non-fatal warning in the renderer and in the model-facing text. */
@@ -216,11 +219,12 @@ export class FindTool implements AgentTool<typeof findSchema, FindToolDetails> {
 				const notice = opts?.notice;
 				const forceTruncated = opts?.forceTruncated ?? false;
 				if (files.length === 0) {
-					const details: FindToolDetails = {
+				const details: FindToolDetails = {
 						scopePath,
 						fileCount: 0,
 						files: [],
 						truncated: forceTruncated,
+						cwd: this.session.cwd,
 						missingPaths: missingPaths.length > 0 ? missingPaths : undefined,
 					};
 					const parts = ["No files found matching pattern"];
@@ -246,6 +250,7 @@ export class FindTool implements AgentTool<typeof findSchema, FindToolDetails> {
 					truncated: Boolean(forceTruncated || limitMeta.resultLimit || truncation.truncated),
 					resultLimitReached: limitMeta.resultLimit?.reached,
 					truncation: truncation.truncated ? truncation : undefined,
+					cwd: this.session.cwd,
 					missingPaths: missingPaths.length > 0 ? missingPaths : undefined,
 				};
 
@@ -510,20 +515,26 @@ export const findToolRenderer = {
 		}
 		if (missingNote) extraLines.push(missingNote);
 
-		return createCachedComponent(
-			() => options.expanded,
-			width => {
-				const fileLines = renderFileList(
-					{
-						files: files.map(entry => ({ path: entry, isDirectory: entry.endsWith("/") })),
-						expanded: options.expanded,
-						maxCollapsed: COLLAPSED_LIST_LIMIT,
-					},
-					uiTheme,
-				);
-				return [header, ...fileLines, ...extraLines].map(l => truncateToWidth(l, width, Ellipsis.Omit));
-			},
-		);
+	return createCachedComponent(
+		() => options.expanded,
+		width => {
+			const cwd = details?.cwd;
+			const fileLines = renderFileList(
+				{
+					files: files.map(entry => ({
+						path: entry,
+						isDirectory: entry.endsWith("/"),
+						absPath: cwd && !entry.endsWith("/") ? path.resolve(cwd, entry) : undefined,
+					})),
+					expanded: options.expanded,
+					maxCollapsed: COLLAPSED_LIST_LIMIT,
+					hyperlinkFn: fileHyperlink,
+				},
+				uiTheme,
+			);
+			return [header, ...fileLines, ...extraLines].map(l => truncateToWidth(l, width, Ellipsis.Omit));
+		},
+	);
 	},
 	mergeCallAndResult: true,
 };

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -27,7 +27,7 @@ import {
 	truncateHeadBytes,
 	truncateLine,
 } from "../session/streaming-output";
-import { fileHyperlink, renderCodeCell, renderMarkdownCell, renderStatusLine } from "../tui";
+import { fileHyperlink, renderCodeCell, renderMarkdownCell, renderStatusLine, tryResolveInternalUrlSync } from "../tui";
 import { CachedOutputBlock } from "../tui/output-block";
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import { ImageInputTooLargeError, loadImageInput, MAX_IMAGE_INPUT_BYTES } from "../utils/image-loading";
@@ -2144,7 +2144,9 @@ export const readToolRenderer = {
 		}
 
 		const rawPath = args.file_path || args.path || "";
-		const filePath = shortenPath(rawPath);
+		const shortPath = shortenPath(rawPath);
+		const linkTarget = tryResolveInternalUrlSync(rawPath);
+		const filePath = linkTarget ? fileHyperlink(linkTarget, shortPath) : shortPath;
 		const offset = args.offset;
 		const limit = args.limit;
 
@@ -2262,10 +2264,12 @@ export const readToolRenderer = {
 
 		const suffix = details?.suffixResolution;
 		const plainDisplayPath = suffix ? shortenPath(suffix.to) : filePath;
-		// resolvedPath is the absolute fs path for regular files and fs-backed internal URLs (local://, skill://, etc.)
-		const displayPath = details?.resolvedPath
-			? fileHyperlink(details.resolvedPath, plainDisplayPath)
-			: plainDisplayPath;
+		// resolvedPath is the absolute fs path for fs-backed reads (regular files plus
+		// local:// / memory:// / skill:// / artifact:// resources). Fall back to a sync
+		// resolver for fs-backed internal URLs so the title is clickable even before the
+		// result lands or if the handler didn't populate resolvedPath.
+		const absForLink = details?.resolvedPath ?? tryResolveInternalUrlSync(rawPath);
+		const displayPath = absForLink ? fileHyperlink(absForLink, plainDisplayPath) : plainDisplayPath;
 		const correction = suffix ? ` ${uiTheme.fg("dim", `(corrected from ${shortenPath(suffix.from)})`)}` : "";
 		let title = displayPath ? `Read ${displayPath}${correction}` : "Read";
 		if (args?.offset !== undefined || args?.limit !== undefined) {

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -27,7 +27,7 @@ import {
 	truncateHeadBytes,
 	truncateLine,
 } from "../session/streaming-output";
-import { renderCodeCell, renderMarkdownCell, renderStatusLine } from "../tui";
+import { fileHyperlink, renderCodeCell, renderMarkdownCell, renderStatusLine } from "../tui";
 import { CachedOutputBlock } from "../tui/output-block";
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import { ImageInputTooLargeError, loadImageInput, MAX_IMAGE_INPUT_BYTES } from "../utils/image-loading";
@@ -2261,7 +2261,11 @@ export const readToolRenderer = {
 		}
 
 		const suffix = details?.suffixResolution;
-		const displayPath = suffix ? shortenPath(suffix.to) : filePath;
+		const plainDisplayPath = suffix ? shortenPath(suffix.to) : filePath;
+		// resolvedPath is the absolute fs path for regular files and fs-backed internal URLs (local://, skill://, etc.)
+		const displayPath = details?.resolvedPath
+			? fileHyperlink(details.resolvedPath, plainDisplayPath)
+			: plainDisplayPath;
 		const correction = suffix ? ` ${uiTheme.fg("dim", `(corrected from ${shortenPath(suffix.from)})`)}` : "";
 		let title = displayPath ? `Read ${displayPath}${correction}` : "Read";
 		if (args?.offset !== undefined || args?.limit !== undefined) {

--- a/packages/coding-agent/src/tools/search.ts
+++ b/packages/coding-agent/src/tools/search.ts
@@ -595,19 +595,30 @@ export const searchToolRenderer = {
 					itemType: "match",
 					renderItem: group => {
 						// Track directory context within a group for ## file headers.
+						// `# foo/` is a directory header; `# foo.ts` is a root-level file
+						// from formatGroupedFiles (single-# when directory is `.`).
 						let contextDir = searchBase ?? "";
 						return group.map(line => {
-							if (line.startsWith("# ")) {
-								const dirPart = line.slice(2).trimEnd().replace(/\/$/, "");
-								if (searchBase) {
-									contextDir = dirPart === "." ? searchBase : path.join(searchBase, dirPart);
-								}
-								return uiTheme.fg("accent", line);
-							}
 							if (line.startsWith("## ")) {
-								const fileName = line.slice(3).trimEnd();
+								// Strip optional ` (suffix)` like ` (3 replacements)` before resolving.
+								const fileName = line.slice(3).trimEnd().replace(/\s+\([^)]*\)\s*$/, "");
 								const absPath = contextDir && fileName ? path.join(contextDir, fileName) : undefined;
 								const styled = uiTheme.fg("dim", line);
+								return absPath ? fileHyperlink(absPath, styled) : styled;
+							}
+							if (line.startsWith("# ")) {
+								const raw = line.slice(2).trimEnd().replace(/\s+\([^)]*\)\s*$/, "");
+								const isDirectory = raw.endsWith("/");
+								const name = raw.replace(/\/$/, "");
+								if (isDirectory) {
+									if (searchBase) {
+										contextDir = name === "." ? searchBase : path.join(searchBase, name);
+									}
+									return uiTheme.fg("accent", line);
+								}
+								// Root-level file emitted by formatGroupedFiles when the directory is `.`.
+								const absPath = searchBase && name ? path.join(searchBase, name) : undefined;
+								const styled = uiTheme.fg("accent", line);
 								return absPath ? fileHyperlink(absPath, styled) : styled;
 							}
 							return uiTheme.fg("toolOutput", line);

--- a/packages/coding-agent/src/tools/search.ts
+++ b/packages/coding-agent/src/tools/search.ts
@@ -10,7 +10,7 @@ import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import type { Theme } from "../modes/theme/theme";
 import searchDescription from "../prompts/tools/search.md" with { type: "text" };
 import { DEFAULT_MAX_COLUMN, type TruncationResult, truncateHead } from "../session/streaming-output";
-import { Ellipsis, renderStatusLine, renderTreeList, truncateToWidth } from "../tui";
+import { Ellipsis, fileHyperlink, renderStatusLine, renderTreeList, truncateToWidth } from "../tui";
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import type { ToolSession } from ".";
 import { createFileRecorder, formatResultPath } from "./file-recorder";
@@ -103,6 +103,9 @@ export interface SearchToolDetails {
 	 * `result.text` lines but uses a `│` gutter and `*` to mark match lines (vs space for
 	 * context). The TUI uses this directly so it never parses model-facing hashline anchors. */
 	displayContent?: string;
+	/** Absolute base directory used during search. Used by the renderer to resolve
+	 * display-relative paths to absolute paths for OSC 8 hyperlinks. */
+	searchPath?: string;
 	/** User-supplied paths whose base directory was missing on disk. The tool
 	 * skipped these and continued with the surviving entries; surfaced as a
 	 * non-fatal warning in the renderer and in the model-facing text. */
@@ -317,8 +320,9 @@ export class SearchTool implements AgentTool<typeof searchSchema, SearchToolDeta
 			const missingPathsNote =
 				missingPaths.length > 0 ? `Skipped missing paths: ${missingPaths.join(", ")}` : undefined;
 			if (selectedMatches.length === 0) {
-				const details: SearchToolDetails = {
+			const details: SearchToolDetails = {
 					scopePath,
+					searchPath,
 					matchCount: 0,
 					fileCount: 0,
 					files: [],
@@ -423,8 +427,9 @@ export class SearchTool implements AgentTool<typeof searchSchema, SearchToolDeta
 			const truncated = Boolean(
 				fileLimitReached || perFileLimitReached || result.limitReached || truncation.truncated || linesTruncated,
 			);
-			const details: SearchToolDetails = {
+		const details: SearchToolDetails = {
 				scopePath,
+				searchPath,
 				matchCount: selectedMatches.length,
 				fileCount: fileList.length,
 				files: fileList,
@@ -576,29 +581,44 @@ export const searchToolRenderer = {
 		}
 		if (missingNote) extraLines.push(missingNote);
 
-		return createCachedComponent(
-			() => options.expanded,
-			width => {
-				const collapsedMatchLineBudget = Math.max(COLLAPSED_TEXT_LIMIT - extraLines.length, 0);
-				const matchLines = renderTreeList(
-					{
-						items: matchGroups,
-						expanded: options.expanded,
-						maxCollapsed: matchGroups.length,
-						maxCollapsedLines: collapsedMatchLineBudget,
-						itemType: "match",
-						renderItem: group =>
-							group.map(line => {
-								if (line.startsWith("## ")) return uiTheme.fg("dim", line);
-								if (line.startsWith("# ")) return uiTheme.fg("accent", line);
-								return uiTheme.fg("toolOutput", line);
-							}),
+	return createCachedComponent(
+		() => options.expanded,
+		width => {
+			const collapsedMatchLineBudget = Math.max(COLLAPSED_TEXT_LIMIT - extraLines.length, 0);
+			const searchBase = details?.searchPath;
+			const matchLines = renderTreeList(
+				{
+					items: matchGroups,
+					expanded: options.expanded,
+					maxCollapsed: matchGroups.length,
+					maxCollapsedLines: collapsedMatchLineBudget,
+					itemType: "match",
+					renderItem: group => {
+						// Track directory context within a group for ## file headers.
+						let contextDir = searchBase ?? "";
+						return group.map(line => {
+							if (line.startsWith("# ")) {
+								const dirPart = line.slice(2).trimEnd().replace(/\/$/, "");
+								if (searchBase) {
+									contextDir = dirPart === "." ? searchBase : path.join(searchBase, dirPart);
+								}
+								return uiTheme.fg("accent", line);
+							}
+							if (line.startsWith("## ")) {
+								const fileName = line.slice(3).trimEnd();
+								const absPath = contextDir && fileName ? path.join(contextDir, fileName) : undefined;
+								const styled = uiTheme.fg("dim", line);
+								return absPath ? fileHyperlink(absPath, styled) : styled;
+							}
+							return uiTheme.fg("toolOutput", line);
+						});
 					},
-					uiTheme,
-				);
-				return [header, ...matchLines, ...extraLines].map(l => truncateToWidth(l, width, Ellipsis.Omit));
-			},
-		);
+				},
+				uiTheme,
+			);
+			return [header, ...matchLines, ...extraLines].map(l => truncateToWidth(l, width, Ellipsis.Omit));
+		},
+	);
 	},
 	mergeCallAndResult: true,
 };

--- a/packages/coding-agent/src/tui/file-list.ts
+++ b/packages/coding-agent/src/tui/file-list.ts
@@ -7,6 +7,9 @@ import { renderTreeList } from "./tree-list";
 
 export interface FileEntry {
 	path: string;
+	/** Absolute filesystem path. When provided together with {@link FileListOptions.hyperlinkFn}, the
+	 * rendered path text is wrapped in an OSC 8 hyperlink. */
+	absPath?: string;
 	isDirectory?: boolean;
 	meta?: string;
 }
@@ -16,10 +19,13 @@ export interface FileListOptions {
 	expanded?: boolean;
 	maxCollapsed?: number;
 	showIcons?: boolean;
+	/** When provided, called with the entry's absolute path and the ANSI-styled display string to
+	 * optionally wrap the path in an OSC 8 hyperlink. Only invoked when {@link FileEntry.absPath} is set. */
+	hyperlinkFn?: (absPath: string, displayText: string) => string;
 }
 
 export function renderFileList(options: FileListOptions, theme: Theme): string[] {
-	const { files, expanded = false, maxCollapsed = 8, showIcons = true } = options;
+	const { files, expanded = false, maxCollapsed = 8, showIcons = true, hyperlinkFn } = options;
 
 	return renderTreeList(
 		{
@@ -39,7 +45,10 @@ export function renderFileList(options: FileListOptions, theme: Theme): string[]
 				const labelColor = isDirectory ? "accent" : "toolOutput";
 				const meta = entry.meta ? ` ${theme.fg("dim", entry.meta)}` : "";
 				const iconPrefix = icon ? `${icon} ` : "";
-				return `${iconPrefix}${theme.fg(labelColor, displayPath)}${meta}`;
+				const pathStr = theme.fg(labelColor, displayPath);
+				const linkedPath =
+					entry.absPath && hyperlinkFn ? hyperlinkFn(entry.absPath, pathStr) : pathStr;
+				return `${iconPrefix}${linkedPath}${meta}`;
 			},
 		},
 		theme,

--- a/packages/coding-agent/src/tui/hyperlink.ts
+++ b/packages/coding-agent/src/tui/hyperlink.ts
@@ -7,6 +7,13 @@
  */
 import { TERMINAL } from "@oh-my-pi/pi-tui";
 import { settings } from "../config/settings";
+import {
+	LocalProtocolHandler,
+	memoryRootsFromRegistry,
+	parseInternalUrl,
+	resolveLocalUrlToPath,
+	resolveMemoryUrlToPath,
+} from "../internal-urls";
 
 const OSC = "\x1b]";
 const ST = "\x1b\\";
@@ -81,4 +88,43 @@ export function fileHyperlink(
 	const uri = buildFileUri(absPath, opts);
 	const id = buildLinkId(uri);
 	return `${OSC}8;id=${id};${uri}${ST}${displayText}${OSC}8;;${ST}`;
+}
+
+/**
+ * Synchronously resolve a filesystem-backed internal URL (e.g. `local://foo.md`,
+ * `memory://root/notes.md`) to its absolute filesystem path. Returns `undefined`
+ * for inputs that aren't fs-backed, aren't resolvable in the current session
+ * registry, or fail to parse.
+ *
+ * Used by renderers to wrap fs-backed internal URLs in OSC 8 hyperlinks even
+ * when the resolved path isn't yet available from tool result details (e.g.
+ * during the call/streaming phase before a result lands).
+ *
+ * Async-resolved schemes (`artifact://`, `agent://`, `skill://`, `rule://`,
+ * `omp://`) are not handled here — those rely on `details.resolvedPath` set
+ * by the read tool's router resolution.
+ */
+export function tryResolveInternalUrlSync(input: string): string | undefined {
+	try {
+		if (input.startsWith("local://")) {
+			const opts = LocalProtocolHandler.resolveOptions();
+			if (!opts) return undefined;
+			return resolveLocalUrlToPath(input, opts);
+		}
+		if (input.startsWith("memory://")) {
+			const url = parseInternalUrl(input);
+			const roots = memoryRootsFromRegistry();
+			for (const root of roots) {
+				try {
+					return resolveMemoryUrlToPath(url, root);
+				} catch {
+					// Try the next root; some sessions may not have this namespace mounted.
+				}
+			}
+			return undefined;
+		}
+	} catch {
+		return undefined;
+	}
+	return undefined;
 }

--- a/packages/coding-agent/src/tui/hyperlink.ts
+++ b/packages/coding-agent/src/tui/hyperlink.ts
@@ -1,0 +1,84 @@
+/**
+ * OSC 8 terminal hyperlink support for file paths.
+ *
+ * Wraps display text in `ESC ] 8 ; id=HASH ; URI ESC \ TEXT ESC ] 8 ; ; ESC \`
+ * sequences when the active terminal supports hyperlinks and the user setting
+ * permits it. Falls back to plain text when disabled.
+ */
+import { TERMINAL } from "@oh-my-pi/pi-tui";
+import { settings } from "../config/settings";
+
+const OSC = "\x1b]";
+const ST = "\x1b\\";
+
+/** Stable 8-char hex ID derived from a URI — hints terminals to coalesce identical adjacent links. */
+function buildLinkId(uri: string): string {
+	let h = 0;
+	for (let i = 0; i < uri.length; i++) {
+		// FNV-1a-inspired mix — good enough for a UI hint, no deps
+		h = (Math.imul(31, h) + uri.charCodeAt(i)) | 0;
+	}
+	return (h >>> 0).toString(16).padStart(8, "0");
+}
+
+/** Build a `file://` URI for an absolute path with optional line/col query params. */
+function buildFileUri(absPath: string, opts?: { line?: number; col?: number }): string {
+	// Normalize backslashes for Windows paths before constructing the URL.
+	const normalized = absPath.replaceAll("\\", "/");
+	const prefix = normalized.startsWith("/") ? "file://" : "file:///";
+	// Split on slashes, encode each component, reassemble.
+	const encoded = normalized
+		.split("/")
+		.map(segment => encodeURIComponent(segment))
+		.join("/");
+	const params: string[] = [];
+	if (opts?.line !== undefined) params.push(`line=${opts.line}`);
+	if (opts?.col !== undefined) params.push(`col=${opts.col}`);
+	const query = params.length > 0 ? `?${params.join("&")}` : "";
+	return `${prefix}${encoded}${query}`;
+}
+
+/**
+ * Returns true when OSC 8 hyperlinks should be emitted.
+ *
+ * Respects `tui.hyperlinks` setting:
+ * - `"off"`: never
+ * - `"auto"`: when `process.stdout.isTTY`, `NO_COLOR` is unset, and the detected terminal reports hyperlink support
+ * - `"always"`: unconditionally (useful for viewers that support OSC 8 without advertising it)
+ */
+export function isHyperlinkEnabled(): boolean {
+	const mode = settings.get("tui.hyperlinks");
+	if (mode === "off") return false;
+	if (mode === "always") return true;
+	// auto: respect terminal capabilities and NO_COLOR
+	if (Bun.env.NO_COLOR) return false;
+	if (!process.stdout.isTTY) return false;
+	return TERMINAL.hyperlinks;
+}
+
+/**
+ * Wrap `displayText` in an OSC 8 hyperlink pointing at the given absolute file path.
+ *
+ * Returns `displayText` unchanged when hyperlinks are disabled or when
+ * the text already contains an OSC 8 sequence (prevents double-wrapping).
+ *
+ * The caller is responsible for passing an absolute path. Relative paths
+ * produce invalid `file://` URIs and are accepted silently to avoid runtime
+ * errors in renderer hot paths.
+ *
+ * @param absPath - Absolute filesystem path
+ * @param displayText - Text to render as the hyperlink anchor (may contain ANSI codes)
+ * @param opts - Optional line/col position appended as `?line=N&col=M` query params
+ */
+export function fileHyperlink(
+	absPath: string,
+	displayText: string,
+	opts?: { line?: number; col?: number },
+): string {
+	if (!isHyperlinkEnabled()) return displayText;
+	// Do not double-wrap if the text already embeds an OSC 8 sequence.
+	if (displayText.includes("\x1b]8;")) return displayText;
+	const uri = buildFileUri(absPath, opts);
+	const id = buildLinkId(uri);
+	return `${OSC}8;id=${id};${uri}${ST}${displayText}${OSC}8;;${ST}`;
+}

--- a/packages/coding-agent/src/tui/index.ts
+++ b/packages/coding-agent/src/tui/index.ts
@@ -9,3 +9,4 @@ export * from "./status-line";
 export * from "./tree-list";
 export * from "./types";
 export * from "./utils";
+export * from "./hyperlink";

--- a/packages/coding-agent/test/tui/hyperlink.test.ts
+++ b/packages/coding-agent/test/tui/hyperlink.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, spyOn } from "bun:test";
 import * as settingsModule from "@oh-my-pi/pi-coding-agent/config/settings";
 import * as terminalCaps from "@oh-my-pi/pi-tui";
-import { fileHyperlink, isHyperlinkEnabled } from "@oh-my-pi/pi-coding-agent/tui/hyperlink";
+import { fileHyperlink, isHyperlinkEnabled, tryResolveInternalUrlSync } from "@oh-my-pi/pi-coding-agent/tui/hyperlink";
 
 // OSC 8 sequence markers
 const OSC = "\x1b]";
@@ -177,5 +177,31 @@ describe("fileHyperlink", () => {
 		expect(result).toContain(colored);
 		expect(isHyperlinked(result)).toBe(true);
 		spy.mockRestore();
+	});
+});
+
+describe("tryResolveInternalUrlSync", () => {
+	it("returns undefined for non-internal URLs", () => {
+		expect(tryResolveInternalUrlSync("/abs/path/file.ts")).toBeUndefined();
+		expect(tryResolveInternalUrlSync("relative/path.ts")).toBeUndefined();
+		expect(tryResolveInternalUrlSync("https://example.com/foo")).toBeUndefined();
+	});
+
+	it("returns undefined for unsupported internal URL schemes", () => {
+		// Async-resolved schemes are intentionally not handled here.
+		expect(tryResolveInternalUrlSync("artifact://123")).toBeUndefined();
+		expect(tryResolveInternalUrlSync("agent://abc")).toBeUndefined();
+		expect(tryResolveInternalUrlSync("skill://foo")).toBeUndefined();
+		expect(tryResolveInternalUrlSync("omp://docs.md")).toBeUndefined();
+	});
+
+	it("returns undefined when local:// resolution has no session options", () => {
+		// No AgentRegistry main session in this unit test, no override installed.
+		expect(tryResolveInternalUrlSync("local://foo.md")).toBeUndefined();
+	});
+
+	it("swallows errors from malformed URLs", () => {
+		// Malformed input should not throw, just return undefined.
+		expect(tryResolveInternalUrlSync("local://%ZZ")).toBeUndefined();
 	});
 });

--- a/packages/coding-agent/test/tui/hyperlink.test.ts
+++ b/packages/coding-agent/test/tui/hyperlink.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import * as settingsModule from "@oh-my-pi/pi-coding-agent/config/settings";
+import * as terminalCaps from "@oh-my-pi/pi-tui";
+import { fileHyperlink, isHyperlinkEnabled } from "@oh-my-pi/pi-coding-agent/tui/hyperlink";
+
+// OSC 8 sequence markers
+const OSC = "\x1b]";
+const ST = "\x1b\\";
+const LINK_START = (id: string, uri: string) => `${OSC}8;id=${id};${uri}${ST}`;
+const LINK_END = `${OSC}8;;${ST}`;
+
+/** Extract the hyperlink URI from a wrapped string. Returns undefined if not wrapped. */
+function extractLinkUri(text: string): string | undefined {
+	const match = text.match(/\x1b\]8;[^;]*;([^\x1b]+)\x1b\\/);
+	return match?.[1];
+}
+
+/** Returns true if the string contains an OSC 8 hyperlink wrapping a given display text. */
+function isHyperlinked(text: string): boolean {
+	return text.includes(`${OSC}8;`) && text.includes(LINK_END);
+}
+
+describe("isHyperlinkEnabled", () => {
+	afterEach(() => {
+		delete Bun.env.NO_COLOR;
+	});
+
+	it('returns false when mode is "off"', () => {
+		const spy = spyOn(settingsModule.settings, "get").mockImplementation(
+			(key: string) => (key === "tui.hyperlinks" ? "off" : undefined) as never,
+		);
+		expect(isHyperlinkEnabled()).toBe(false);
+		spy.mockRestore();
+	});
+
+	it('returns true when mode is "always" regardless of TTY', () => {
+		const spy = spyOn(settingsModule.settings, "get").mockImplementation(
+			(key: string) => (key === "tui.hyperlinks" ? "always" : undefined) as never,
+		);
+		expect(isHyperlinkEnabled()).toBe(true);
+		spy.mockRestore();
+	});
+
+	it('returns false in auto mode when NO_COLOR is set', () => {
+		const spy = spyOn(settingsModule.settings, "get").mockImplementation(
+			(key: string) => (key === "tui.hyperlinks" ? "auto" : undefined) as never,
+		);
+		Bun.env.NO_COLOR = "1";
+		expect(isHyperlinkEnabled()).toBe(false);
+		spy.mockRestore();
+	});
+
+	it('returns false in auto mode when stdout is not a TTY', () => {
+		const spy = spyOn(settingsModule.settings, "get").mockImplementation(
+			(key: string) => (key === "tui.hyperlinks" ? "auto" : undefined) as never,
+		);
+		const origTTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+		Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+		expect(isHyperlinkEnabled()).toBe(false);
+		if (origTTY) Object.defineProperty(process.stdout, "isTTY", origTTY);
+		spy.mockRestore();
+	});
+
+	it("returns TERMINAL.hyperlinks value in auto mode when conditions are met", () => {
+		const settingsSpy = spyOn(settingsModule.settings, "get").mockImplementation(
+			(key: string) => (key === "tui.hyperlinks" ? "auto" : undefined) as never,
+		);
+		const origTTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+		Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+		// TERMINAL.hyperlinks may be true or false depending on the test runner env;
+		// what matters is that isHyperlinkEnabled mirrors it.
+		const expected = terminalCaps.TERMINAL.hyperlinks;
+		expect(isHyperlinkEnabled()).toBe(expected);
+		if (origTTY) Object.defineProperty(process.stdout, "isTTY", origTTY);
+		settingsSpy.mockRestore();
+	});
+});
+
+describe("fileHyperlink", () => {
+	afterEach(() => {
+		delete Bun.env.NO_COLOR;
+	});
+
+	it("returns plain text when hyperlinks are disabled (mode=off)", () => {
+		const spy = spyOn(settingsModule.settings, "get").mockImplementation(
+			(key: string) => (key === "tui.hyperlinks" ? "off" : undefined) as never,
+		);
+		const result = fileHyperlink("/Users/foo/bar.ts", "bar.ts");
+		expect(result).toBe("bar.ts");
+		spy.mockRestore();
+	});
+
+	it("wraps text in OSC 8 when hyperlinks are enabled (mode=always)", () => {
+		const spy = spyOn(settingsModule.settings, "get").mockImplementation(
+			(key: string) => (key === "tui.hyperlinks" ? "always" : undefined) as never,
+		);
+		const result = fileHyperlink("/Users/foo/bar.ts", "bar.ts");
+		expect(isHyperlinked(result)).toBe(true);
+		expect(result).toContain("bar.ts");
+		spy.mockRestore();
+	});
+
+	it("builds a valid file:// URI with the absolute path", () => {
+		const spy = spyOn(settingsModule.settings, "get").mockImplementation(
+			(key: string) => (key === "tui.hyperlinks" ? "always" : undefined) as never,
+		);
+		const result = fileHyperlink("/Users/foo/bar.ts", "bar.ts");
+		const uri = extractLinkUri(result);
+		expect(uri).toMatch(/^file:\/\//);
+		expect(uri).toContain("bar.ts");
+		spy.mockRestore();
+	});
+
+	it("encodes spaces in the path", () => {
+		const spy = spyOn(settingsModule.settings, "get").mockImplementation(
+			(key: string) => (key === "tui.hyperlinks" ? "always" : undefined) as never,
+		);
+		const result = fileHyperlink("/Users/foo/my file.ts", "my file.ts");
+		const uri = extractLinkUri(result);
+		expect(uri).toContain("%20");
+		expect(uri).not.toContain(" ");
+		spy.mockRestore();
+	});
+
+	it("appends line and col as query params when provided", () => {
+		const spy = spyOn(settingsModule.settings, "get").mockImplementation(
+			(key: string) => (key === "tui.hyperlinks" ? "always" : undefined) as never,
+		);
+		const result = fileHyperlink("/Users/foo/bar.ts", "bar.ts", { line: 42, col: 7 });
+		const uri = extractLinkUri(result);
+		expect(uri).toContain("line=42");
+		expect(uri).toContain("col=7");
+		spy.mockRestore();
+	});
+
+	it("omits query params when line/col are not provided", () => {
+		const spy = spyOn(settingsModule.settings, "get").mockImplementation(
+			(key: string) => (key === "tui.hyperlinks" ? "always" : undefined) as never,
+		);
+		const result = fileHyperlink("/Users/foo/bar.ts", "bar.ts");
+		const uri = extractLinkUri(result);
+		expect(uri).not.toContain("?");
+		spy.mockRestore();
+	});
+
+	it("produces a stable id for the same path", () => {
+		const spy = spyOn(settingsModule.settings, "get").mockImplementation(
+			(key: string) => (key === "tui.hyperlinks" ? "always" : undefined) as never,
+		);
+		const r1 = fileHyperlink("/Users/foo/bar.ts", "bar.ts");
+		const r2 = fileHyperlink("/Users/foo/bar.ts", "different display text");
+		// Extract id= from params (between "id=" and next ";")
+		const id1 = r1.match(/id=([^;]+)/)?.[1];
+		const id2 = r2.match(/id=([^;]+)/)?.[1];
+		expect(id1).toBeDefined();
+		expect(id1).toBe(id2);
+		spy.mockRestore();
+	});
+
+	it("does not double-wrap text that already contains an OSC 8 sequence", () => {
+		const spy = spyOn(settingsModule.settings, "get").mockImplementation(
+			(key: string) => (key === "tui.hyperlinks" ? "always" : undefined) as never,
+		);
+		const alreadyWrapped = `${OSC}8;id=abc123;file:///foo/bar.ts${ST}bar.ts${LINK_END}`;
+		const result = fileHyperlink("/Users/foo/other.ts", alreadyWrapped);
+		// Should return the already-wrapped text unchanged
+		expect(result).toBe(alreadyWrapped);
+		spy.mockRestore();
+	});
+
+	it("preserves ANSI color codes inside the hyperlink", () => {
+		const spy = spyOn(settingsModule.settings, "get").mockImplementation(
+			(key: string) => (key === "tui.hyperlinks" ? "always" : undefined) as never,
+		);
+		const colored = "\x1b[32mbar.ts\x1b[0m";
+		const result = fileHyperlink("/Users/foo/bar.ts", colored);
+		expect(result).toContain(colored);
+		expect(isHyperlinked(result)).toBe(true);
+		spy.mockRestore();
+	});
+});


### PR DESCRIPTION
## Repro

Any `read`, `find`, `search`, `edit`, `ast_grep`, or `ast_edit` output in kitty/Ghostty/WezTerm/iTerm2 — cmd-click on a file path does nothing because the path is plain text with no hyperlink metadata.

## Cause

OMP emits all file paths as plain ANSI-styled strings. Standalone terminals (kitty, Ghostty, WezTerm, iTerm2) cannot synthesize clickable paths from raw text — they require the producer to wrap paths in OSC 8 sequences (`ESC ] 8 ; params ; URI ST text ESC ] 8 ; ; ST`). Only editor-integrated terminals (Cursor, VS Code) work today because the editor itself scans rendered output.

## Fix

- **`src/tui/hyperlink.ts`** — new module: `isHyperlinkEnabled()` (checks `tui.hyperlinks` setting, `TERMINAL.hyperlinks`, `NO_COLOR`, `process.stdout.isTTY`) and `fileHyperlink(absPath, displayText, opts?)` (emits OSC 8 or plain text). Terminal detection (`TERMINAL.hyperlinks`) was already present in `terminal-capabilities.ts` with mux suppression for tmux/screen. Double-wrap guard skips if displayText already contains `\x1b]8;`.
- **`src/config/settings-schema.ts`** — new `tui.hyperlinks` enum setting (`off | auto | always`, default `auto`), UI tab `appearance`.
- **`src/tui/file-list.ts`** — `FileEntry.absPath?: string`, `FileListOptions.hyperlinkFn?` injected into `renderItem` for the path portion.
- **`src/tools/find.ts`** — `FindToolDetails.cwd` added; renderer resolves relative file entries to absolute, passes `fileHyperlink` as `hyperlinkFn`.
- **`src/tools/read.ts`** — renderer wraps `displayPath` via `details.resolvedPath`, covering regular files and fs-backed internal URLs (`local://`, `skill://`, `omp://`, etc.).
- **`src/edit/renderer.ts`** — `formatEditPathDisplay` wraps both the primary path and any rename target.
- **`src/tools/search.ts`**, **`ast-grep.ts`**, **`ast-edit.ts`** — `searchPath` added to tool details; renderers parse `# dir/` and `## file.ts` group headers, resolve to absolute paths, and wrap with hyperlinks. Directory headers remain unstyled (no clickable link added for directories, only files).

OSC 8 sequences are zero visible width: the existing Rust `truncate_to_width` in `crates/pi-natives` already handles OSC sequences (ESC `]` terminated by BEL or `ESC \`) — verified at `text.rs:327-338`.

## Verification

`bun run fix` fails on `main` because `biome` is not installed in this CI environment — `biome: command not found` reproduces on a clean checkout of `main` before any of my changes. Pre-publish gate skipped.

- Tests in `test/tui/hyperlink.test.ts`: mode gating (`off/auto/always`), URI encoding (spaces → `%20`), stable `id=` hash (same path → same 8-char hex), no-double-wrap, `line=`/`col=` params, ANSI preservation.
- OSC 8 width correctness verified by reading Rust source; `truncateToWidth` and `visibleWidth` both correctly skip `\x1b]...\x1b\` sequences.

Fixes #1244