### PR TITLE
fix(goals): repair goal state machine after interrupts and reloads

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed goal state machine: `get` now returns paused goals (was returning null for `enabled=false`), `complete` now works on paused goals after interrupts, `create` is allowed after a previous goal reaches `complete` status, and the goal tool is re-added to the active tool set on session reload when a paused goal is persisted. Added `resume` and `drop` ops to the goal tool so the agent can re-engage or discard a paused goal without requiring user slash commands. ([#1249](https://github.com/can1357/oh-my-pi/issues/1249))
+
 ## [15.1.9] - 2026-05-21
 
 ### Fixed

--- a/packages/coding-agent/src/goals/runtime.ts
+++ b/packages/coding-agent/src/goals/runtime.ts
@@ -379,7 +379,7 @@ export class GoalRuntime {
 		validateTokenBudget(input.tokenBudget);
 		return await this.#withAccounting(async () => {
 			const existing = this.#host.getState();
-			if (existing?.goal && existing.goal.status !== "dropped") {
+			if (existing?.goal && existing.goal.status !== "dropped" && existing.goal.status !== "complete") {
 				throw new Error("cannot create a new goal because this session already has a goal");
 			}
 			const now = this.#now();
@@ -459,8 +459,14 @@ export class GoalRuntime {
 		return await this.#withAccounting(async () => {
 			await this.#flushUsageLocked("suppressed");
 			const state = this.#getStateClone();
-			if (!state?.enabled || !state.goal) {
-				throw new Error("cannot complete goal because goal mode is not active");
+			if (!state?.goal) {
+				throw new Error("cannot complete goal because no goal is active");
+			}
+			if (state.goal.status === "complete") {
+				throw new Error("goal is already complete");
+			}
+			if (state.goal.status === "dropped") {
+				throw new Error("cannot complete a dropped goal");
 			}
 			state.enabled = false;
 			state.goal.status = "complete";

--- a/packages/coding-agent/src/goals/state.ts
+++ b/packages/coding-agent/src/goals/state.ts
@@ -21,7 +21,7 @@ export interface GoalModeState {
 }
 
 export interface GoalToolDetails {
-	op: "create" | "get" | "complete";
+	op: "create" | "get" | "complete" | "resume" | "drop";
 	goal?: Goal | null;
 	remainingTokens?: number | null;
 	completionBudgetReport?: string | null;

--- a/packages/coding-agent/src/goals/tools/goal-tool.ts
+++ b/packages/coding-agent/src/goals/tools/goal-tool.ts
@@ -15,7 +15,7 @@ import { completionBudgetReport, remainingTokens } from "../runtime";
 import type { Goal, GoalStatus, GoalToolDetails } from "../state";
 
 const goalSchema = z.object({
-	op: z.enum(["create", "get", "complete"]).describe("goal operation"),
+	op: z.enum(["create", "get", "complete", "resume", "drop"]).describe("goal operation"),
 	objective: z.string().describe("goal objective").optional(),
 	token_budget: z.number().int().describe("token budget").optional(),
 });
@@ -86,7 +86,13 @@ export class GoalTool implements AgentTool<typeof goalSchema, GoalToolDetails> {
 			response = buildGoalToolResponse(created.goal);
 		} else if (params.op === "get") {
 			const state = this.#session.getGoalModeState?.();
-			response = buildGoalToolResponse(state?.enabled ? state.goal : null);
+			response = buildGoalToolResponse(state?.goal ?? null);
+		} else if (params.op === "resume") {
+			const resumed = await runtime.resumeGoal();
+			response = buildGoalToolResponse(resumed.goal);
+		} else if (params.op === "drop") {
+			const dropped = await runtime.dropGoal();
+			response = buildGoalToolResponse(dropped ?? null);
 		} else {
 			const completed = await runtime.completeGoalFromTool();
 			response = buildGoalToolResponse(completed, { includeCompletionReport: true });
@@ -126,6 +132,10 @@ function describeOp(op: string | undefined): string {
 			return "complete";
 		case "get":
 			return "check";
+		case "resume":
+			return "resume";
+		case "drop":
+			return "drop";
 		default:
 			return op ?? "?";
 	}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1063,6 +1063,12 @@ export class InteractiveMode implements InteractiveModeContext {
 			return;
 		}
 		if (event.type === "goal_updated") {
+			// Handle drop before clearing goalModeEnabled so #exitGoalMode can
+			// still restore the previous tool set while the flag is true.
+			if (event.state?.goal?.status === "dropped") {
+				await this.#exitGoalMode({ reason: "dropped", silent: true });
+				return;
+			}
 			this.goalModeEnabled = event.state?.enabled === true;
 			this.goalModePaused = event.state?.enabled !== true && event.state?.goal?.status === "paused";
 			if (!event.state?.enabled) {
@@ -1150,6 +1156,13 @@ export class InteractiveMode implements InteractiveModeContext {
 			const restored = await this.session.goalRuntime.onThreadResumed();
 			this.goalModeEnabled = restored?.enabled === true;
 			this.goalModePaused = restored?.enabled !== true && restored?.goal.status === "paused";
+			// sdk.ts excludes "goal" from the initial active tool set unconditionally.
+			// Re-add it now so the agent can call resume, complete, or drop on this goal.
+			if (restored?.goal) {
+				const previousTools = this.session.getActiveToolNames().filter(name => name !== "goal");
+				this.#goalModePreviousTools = previousTools;
+				await this.session.setActiveToolsByName([...new Set([...previousTools, "goal"])]);
+			}
 			this.#updateGoalModeStatus();
 			return;
 		}

--- a/packages/coding-agent/src/prompts/tools/goal.md
+++ b/packages/coding-agent/src/prompts/tools/goal.md
@@ -1,13 +1,18 @@
 Manage the active goal-mode objective.
 
 Use a single `op` field:
-- `create` starts a goal. Requires `objective`; optional `token_budget` must be positive. Use only when no goal exists.
-- `get` returns the current goal and remaining token budget.
+- `create` starts a goal. Requires `objective`; optional `token_budget` must be positive. Use only when no goal exists and no goal is paused.
+- `get` returns the current goal (active or paused) and remaining token budget.
+- `resume` re-activates a paused goal so work can continue.
 - `complete` marks the goal complete after you have verified every deliverable against current evidence.
+- `drop` discards the current goal without completing it.
 
 Examples:
 - `goal({"op":"create","objective":"Implement feature X","token_budget":50000})`
 - `goal({"op":"get"})`
+- `goal({"op":"resume"})`
 - `goal({"op":"complete"})`
+- `goal({"op":"drop"})`
 
 Do not call `complete` because a budget is low or a turn is ending. Call it only when the goal is actually done and verified.
+If `get` shows a paused goal, call `resume` before continuing work on it.

--- a/packages/coding-agent/test/goals/goal-runtime.test.ts
+++ b/packages/coding-agent/test/goals/goal-runtime.test.ts
@@ -296,4 +296,37 @@ describe("goal runtime", () => {
 			"cannot create a new goal because this session already has a goal",
 		);
 	});
+
+	it("allows creating a new goal after the previous one is complete", async () => {
+		const harness = createHarness({
+			state: {
+				enabled: false,
+				mode: "exiting",
+				reason: "completed",
+				goal: createGoal({ status: "complete" }),
+			},
+		});
+
+		const next = await harness.runtime.createGoal({ objective: "Phase 4" });
+		expect(next.goal.objective).toBe("Phase 4");
+		expect(next.goal.status).toBe("active");
+		expect(next.enabled).toBe(true);
+	});
+
+	it("completeGoalFromTool succeeds for a paused goal (enabled=false)", async () => {
+		const harness = createHarness({
+			state: {
+				enabled: false,
+				mode: "active",
+				goal: createGoal({ status: "paused", tokensUsed: 30, timeUsedSeconds: 5 }),
+			},
+		});
+
+		const completed = await harness.runtime.completeGoalFromTool();
+		expect(completed.status).toBe("complete");
+		const state = harness.getState();
+		expect(state?.enabled).toBe(false);
+		expect(state?.mode).toBe("exiting");
+		expect(state?.goal.status).toBe("complete");
+	});
 });

--- a/packages/coding-agent/test/goals/goal-tool.test.ts
+++ b/packages/coding-agent/test/goals/goal-tool.test.ts
@@ -151,7 +151,7 @@ describe("GoalTool", () => {
 		);
 
 		await expect(tool.execute("call-complete", { op: "complete" })).rejects.toThrow(
-			"cannot complete goal because goal mode is not active",
+			"cannot complete goal because no goal is active",
 		);
 	});
 
@@ -206,5 +206,101 @@ describe("GoalTool", () => {
 		expect(after?.mode).toBe("exiting");
 		expect(after?.reason).toBe("completed");
 		expect(after?.goal.status).toBe("complete");
+	});
+
+	it("completes a paused goal (enabled=false) — was broken before fix", async () => {
+		const harness = createRuntimeHarness({
+			enabled: false,
+			mode: "active",
+			goal: createGoal({ objective: "Paused work", status: "paused" }),
+		});
+		const tool = new GoalTool(
+			createToolSession({
+				getGoalRuntime: () => harness.runtime,
+				getGoalModeState: () => harness.getState(),
+			}),
+		);
+
+		const result = await tool.execute("call-complete", { op: "complete" });
+		expect(result.details?.goal?.status).toBe("complete");
+		expect(harness.getState()?.goal.status).toBe("complete");
+	});
+
+	it("allows create after previous goal is complete", async () => {
+		const harness = createRuntimeHarness({
+			enabled: false,
+			mode: "exiting",
+			reason: "completed",
+			goal: createGoal({ status: "complete" }),
+		});
+		const tool = new GoalTool(
+			createToolSession({
+				getGoalRuntime: () => harness.runtime,
+				getGoalModeState: () => harness.getState(),
+			}),
+		);
+
+		const result = await tool.execute("call-create", {
+			op: "create",
+			objective: "Next goal",
+		});
+		expect(result.details?.goal?.objective).toBe("Next goal");
+		expect(result.details?.goal?.status).toBe("active");
+	});
+
+	it("op=get returns a paused goal even when enabled=false", async () => {
+		const harness = createRuntimeHarness({
+			enabled: false,
+			mode: "active",
+			goal: createGoal({ status: "paused" }),
+		});
+		const tool = new GoalTool(
+			createToolSession({
+				getGoalRuntime: () => harness.runtime,
+				getGoalModeState: () => harness.getState(),
+			}),
+		);
+
+		const result = await tool.execute("call-get", { op: "get" });
+		expect(result.details?.goal?.status).toBe("paused");
+		expect(result.details?.goal?.objective).toBe("Ship it");
+	});
+
+	it("op=resume re-activates a paused goal", async () => {
+		const harness = createRuntimeHarness({
+			enabled: false,
+			mode: "active",
+			goal: createGoal({ status: "paused" }),
+		});
+		const tool = new GoalTool(
+			createToolSession({
+				getGoalRuntime: () => harness.runtime,
+				getGoalModeState: () => harness.getState(),
+			}),
+		);
+
+		const result = await tool.execute("call-resume", { op: "resume" });
+		expect(result.details?.op).toBe("resume");
+		expect(result.details?.goal?.status).toBe("active");
+		expect(harness.getState()?.enabled).toBe(true);
+	});
+
+	it("op=drop clears goal state", async () => {
+		const harness = createRuntimeHarness({
+			enabled: true,
+			mode: "active",
+			goal: createGoal({ objective: "Drop me" }),
+		});
+		const tool = new GoalTool(
+			createToolSession({
+				getGoalRuntime: () => harness.runtime,
+				getGoalModeState: () => harness.getState(),
+			}),
+		);
+
+		const result = await tool.execute("call-drop", { op: "drop" });
+		expect(result.details?.op).toBe("drop");
+		expect(result.details?.goal?.status).toBe("dropped");
+		expect(harness.getState()).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Repro

Start a goal session, interrupt it (Ctrl+C), then reload the session or continue in the same session. The following failures manifest:

1. `goal({op:"create"})` throws **"Tool goal not found"** after reload — the agent cannot reach the tool at all.
2. `goal({op:"get"})` returns **"No active goal."** for a paused goal (status=`paused`, `enabled=false`).
3. In the same state, `goal({op:"create"})` throws **"cannot create a new goal because this session already has a goal"** — contradicting the `get` result.
4. After `goal({op:"complete"})`, calling `create` in the same turn throws "already has a goal" because `#exitGoalMode` is deferred to the next `agent_end`.
5. `goal({op:"complete"})` throws **"cannot complete goal because goal mode is not active"** after any interrupt, because `onTaskAborted` sets `enabled=false` and the check required `enabled===true`.
6. No `resume` or `drop` ops exist; the agent cannot re-engage or discard a paused goal without user slash commands.

## Cause

**"Tool goal not found" on reload** — `sdk.ts:1599` unconditionally strips `"goal"` from the initial active tool set (`requestedActiveToolNames.filter(name => name !== "goal")`). `#restoreModeFromSession` (interactive-mode.ts) sets `goalModePaused=true` after detecting the persisted goal, but never calls `setActiveToolsByName` to re-add it.

**`get` invisible to paused goals** — `goal-tool.ts:89` gated the return on `state?.enabled`, so paused goals (`enabled=false`) returned `null`.

**`create` blocked by `complete`** — `runtime.ts:382` only allowed creation when `status === "dropped"`, not when `status === "complete"`. The completed goal's state persists until `#exitGoalMode` clears it at the next `agent_end`.

**`complete` rejected after interrupt** — `runtime.ts:462` checked `!state?.enabled`, but `onTaskAborted` always sets `enabled=false` on interrupt.

**Drop via tool leaves goal in active tools** — `goal_updated` with `status=dropped` did not trigger `#exitGoalMode`, so the previous tool set was never restored.

## Fix

- **`state.ts`**: add `"resume" | "drop"` to `GoalToolDetails.op`.
- **`runtime.ts`** (`createGoal`): allow creation when `existing.goal.status === "complete"`. (`completeGoalFromTool`): replace the `!state.enabled` guard with explicit status guards (`"complete"`, `"dropped"`).
- **`goal-tool.ts`**: `get` uses `state?.goal ?? null` instead of `state?.enabled ? state.goal : null`. Added `resume` and `drop` op branches calling `runtime.resumeGoal()` / `runtime.dropGoal()`. Updated `describeOp` for the new ops.
- **`goal.md`**: documents `resume` and `drop`, adds "If `get` shows a paused goal, call `resume` before continuing work on it."
- **`interactive-mode.ts`** (`#restoreModeFromSession`): after `onThreadResumed`, if a goal was restored, capture current tools as `#goalModePreviousTools` and call `setActiveToolsByName([...currentTools, "goal"])`. (`goal_updated` handler): handle `status === "dropped"` before clearing `goalModeEnabled`, so `#exitGoalMode` still has a truthy `goalModeEnabled` when it restores the previous tool set.
- **Tests** (`goal-runtime.test.ts`, `goal-tool.test.ts`): updated asserted error message; added tests for `complete` on paused goal, `create` after `complete`, `get` with paused state, `resume` op, `drop` op.

## Verification

All new tests cover the previously-broken contracts directly:
- `completeGoalFromTool succeeds for a paused goal (enabled=false)` 
- `allows creating a new goal after the previous one is complete`
- `op=get returns a paused goal even when enabled=false`
- `op=resume re-activates a paused goal`
- `op=drop clears goal state`
- `completes a paused goal (enabled=false) — was broken before fix`

Pre-existing test infrastructure failures are environment-wide (missing built packages) and unrelated to this diff.

Skipped pre-publish gate: `bun check` fails on `main` due to missing `biome` binary and unresolved workspace packages in the test environment.

Fixes #1249