### PR TITLE
fix(overflow): detect context overflow in proxy-wrapped 400-no-body errors

### DIFF
--- a/packages/ai/src/utils/http-inspector.ts
+++ b/packages/ai/src/utils/http-inspector.ts
@@ -129,7 +129,11 @@ function formatCapturedHttpError(captured: CapturedHttpErrorResponse | undefined
 	if (!payload) return bodyText;
 
 	const errorPayload = getObjectProperty(payload, "error") ?? payload;
-	const message = getStringProperty(errorPayload, "message") ?? getStringProperty(payload, "message") ?? bodyText;
+	// {"error": "string"} — the error value is a plain string, not a nested object.
+	// Fall back to it when the structured fields ("message", etc.) are absent.
+	const stringError = errorPayload === payload ? getStringProperty(payload, "error") : undefined;
+	const message =
+		getStringProperty(errorPayload, "message") ?? getStringProperty(payload, "message") ?? stringError ?? bodyText;
 	const extras = [
 		getStringProperty(errorPayload, "type") ?? getStringProperty(payload, "type"),
 		getStringProperty(errorPayload, "param") ?? getStringProperty(payload, "param"),

--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -108,9 +108,12 @@ export function isContextOverflow(message: AssistantMessage, contextWindow?: num
 			return true;
 		}
 
-		// Cerebras and Mistral return 400/413 with no body for context overflow
+		// Cerebras and Mistral return 400/413 with no body for context overflow.
+		// Proxy providers (e.g. api.synthetic.new) wrap upstream 400/413 no-body
+		// responses in a JSON envelope, so the status code phrase may appear
+		// anywhere in the message rather than at its start.
 		// Note: 429 is rate limiting (requests/tokens per time), NOT context overflow
-		if (/^4(00|13)\s*(status code)?\s*\(no body\)/i.test(message.errorMessage)) {
+		if (/\b4(00|13)\s*(status code)?\s*\(no body\)/i.test(message.errorMessage)) {
 			return true;
 		}
 	}

--- a/packages/ai/test/overflow-utils.test.ts
+++ b/packages/ai/test/overflow-utils.test.ts
@@ -51,3 +51,39 @@ describe("isContextOverflow - HTTP 413 variants", () => {
 		expect(isContextOverflow(message)).toBe(false);
 	});
 });
+
+describe("isContextOverflow - 400/413 no-body (Cerebras, Mistral, proxy wrappers)", () => {
+	it("detects bare '400 status code (no body)'", () => {
+		expect(isContextOverflow(createErrorMessage("400 status code (no body)"))).toBe(true);
+	});
+
+	it("detects bare '413 status code (no body)'", () => {
+		expect(isContextOverflow(createErrorMessage("413 status code (no body)"))).toBe(true);
+	});
+
+	it("detects '400 (no body)' without 'status code' word", () => {
+		expect(isContextOverflow(createErrorMessage("400 (no body)"))).toBe(true);
+	});
+
+	// Regression: api.synthetic.new wraps upstream HF 400-no-body in a JSON envelope.
+	// finalizeErrorMessage transforms the response to "400 status code: {JSON}" where
+	// the JSON value contains the inner "400 status code (no body)" text.
+	it("detects wrapped proxy envelope: '400 status code: {\"error\":\"... 400 status code (no body)\"}'", () => {
+		const errorMessage =
+			'400 status code: {"error":"Error from inference backend: 400 status code (no body)"}';
+		expect(isContextOverflow(createErrorMessage(errorMessage))).toBe(true);
+	});
+
+	it("detects when status code phrase is embedded deeper in the message", () => {
+		const errorMessage = "Upstream rejected request: 400 status code (no body)";
+		expect(isContextOverflow(createErrorMessage(errorMessage))).toBe(true);
+	});
+
+	it("does not classify unrelated 400 errors as overflow", () => {
+		expect(isContextOverflow(createErrorMessage("400 Bad Request: invalid API key"))).toBe(false);
+	});
+
+	it("does not classify 429 (rate limit) as overflow", () => {
+		expect(isContextOverflow(createErrorMessage("429 status code (no body)"))).toBe(false);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed context overflow not being detected when the session's model (e.g. `hf:zai-org/GLM-5.1` via `synthetic` provider) returns a 400 with the upstream "400 status code (no body)" message wrapped inside a JSON envelope. The `isContextOverflow` check now matches the no-body status phrase anywhere in the error string rather than requiring it at the very start, so auto-compaction fires correctly instead of leaving the session silently stuck ([#1251](https://github.com/can1357/oh-my-pi/issues/1251)).
+- Fixed `formatCapturedHttpError` not extracting the error text from `{"error":"string"}` response bodies (only object-valued `error` fields were previously handled), resulting in raw JSON in error messages instead of the human-readable string.
+
 ## [15.2.0] - 2026-05-21
 
 ### Changed


### PR DESCRIPTION
## Repro

Start a long goal-mode session against `hf:zai-org/GLM-5.1` via the `synthetic` provider. After ~150 tool calls the request body grows to ~873 KB / ~219 K tokens. The upstream HF inference endpoint rejects the request with `HTTP 400` and an empty body; `api.synthetic.new` wraps it as:

```json
{"error":"Error from inference backend: 400 status code (no body)"}
```

OMP surfaces the error three times with no recovery, leaving the session stuck.

## Cause

`isContextOverflow` in `packages/ai/src/utils/overflow.ts` uses a start-of-string anchor to detect Cerebras/Mistral-style context overflow:

```ts
if (/^4(00|13)\s*(status code)?\s*\(no body\)/i.test(message.errorMessage)) {
```

`finalizeErrorMessage` in `http-inspector.ts` replaces the bare `"400 status code (no body)"` error with the captured body, producing:

```
400 status code: {"error":"Error from inference backend: 400 status code (no body)"}
```

The `^` anchor fails here because the outer status code is followed by `": {JSON}"`, not `"(no body)"`. The inner `400 status code (no body)` substring is present but not at position 0, so `isContextOverflow` returns `false`. With overflow undetected, neither auto-compaction nor retry suppression fires — the session exits with an unhelpful error.

Secondary: `formatCapturedHttpError` only handled `{"error":{object}}` bodies; it fell back to the raw JSON string for `{"error":"string value"}` payloads, so the displayed error contained the JSON envelope instead of the extracted message.

## Fix

- **`packages/ai/src/utils/overflow.ts`** — change `^4(00|13)` to `\b4(00|13)` so the no-body pattern matches anywhere in the error string, picking up the embedded phrase from proxy-wrapped responses.
- **`packages/ai/src/utils/http-inspector.ts`** — add a fallback in `formatCapturedHttpError` for `{"error":"string"}` payloads: when the `error` field is a plain string (not an object), use it as the message rather than serialising the whole body.
- **`packages/ai/test/overflow-utils.test.ts`** — add seven regression cases covering bare 400/413, wrapped proxy envelope, and embedded-in-message patterns, plus negative checks for unrelated 400 and 429 errors.

## Verification

```
bun test packages/ai/test/overflow-utils.test.ts
# 12 pass, 0 fail
```

The three other `packages/ai/test/` failures (`github-copilot-error`, `anthropic-retry`, `stream`) are pre-existing on `main` due to unbuilt workspace packages (`@oh-my-pi/pi-utils`, `@anthropic-ai/sdk` not found in the test environment) and are not caused by this diff.

Fixes #1251