### PR TITLE
fix(windows): add arm64 native and binary release support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
                - { os: macos-15-intel, platform: darwin, arch: x64, variant: baseline }
                - { os: macos-14, platform: darwin, arch: arm64 }
                - { os: windows-latest, platform: win32, arch: x64, variant: baseline }
+               - { os: windows-latest, platform: win32, arch: arm64, target: aarch64-pc-windows-msvc }
       runs-on: ${{ matrix.os }}
       steps:
          - uses: actions/checkout@v4
@@ -266,6 +267,13 @@ jobs:
                     target_id: win32-x64,
                     binary_path: packages/coding-agent/binaries/omp-windows-x64.exe,
                  }
+               - {
+                    os: windows-latest,
+                    platform: win32,
+                    arch: arm64,
+                    target_id: win32-arm64,
+                    binary_path: packages/coding-agent/binaries/omp-windows-arm64.exe,
+                 }
       runs-on: ${{ matrix.os }}
       permissions:
          contents: read
@@ -297,7 +305,7 @@ jobs:
               HOME="$runtime_dir/home" XDG_DATA_HOME="$runtime_dir/xdg" "${{ matrix.binary_path }}" --version
               HOME="$runtime_dir/home" XDG_DATA_HOME="$runtime_dir/xdg" "${{ matrix.binary_path }}" --smoke-test
          - name: Smoke release binary (Windows)
-           if: runner.os == 'Windows'
+           if: runner.os == 'Windows' && matrix.arch != 'arm64'
            shell: pwsh
            run: |
               $runtimeDir = Join-Path $env:TEMP ("omp-runtime-" + [System.Guid]::NewGuid().ToString("N"))

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Vuln lookups answer with vendor data, not blog summaries.
 Three crates, one platform-tagged N-API addon. Search, shell, AST, highlight, PTY, image decode, BPE counting — all in-process on the libuv pool. No fork/exec on the hot path.
 
 - Crates: `pi-natives`, `pi-shell`, `pi-ast`
-- Platforms: `linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`, `win32-x64`
+- Platforms: `linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`, `win32-x64`, `win32-arm64`
 
 The table below is a per-module breakdown that intentionally omits glue and tests.
 

--- a/docs/natives-addon-loader-runtime.md
+++ b/docs/natives-addon-loader-runtime.md
@@ -53,6 +53,7 @@ At module initialization, `native/index.js` computes:
 - `darwin-x64`
 - `darwin-arm64`
 - `win32-x64`
+- `win32-arm64`
 
 Unsupported platforms are not rejected before probing. The loader first tries the computed candidate paths. If all fail and `platformTag` is unsupported, it throws an unsupported-platform error listing supported tags.
 

--- a/docs/natives-architecture.md
+++ b/docs/natives-architecture.md
@@ -49,6 +49,7 @@ Current capability groups in the generated API include:
   - `darwin-x64`
   - `darwin-arm64`
   - `win32-x64`
+  - `win32-arm64`
 - x64 can use CPU variants:
   - `modern` (AVX2-capable)
   - `baseline` (fallback)

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Windows ARM64 release binary wiring and installer selection so Windows ARM machines download `omp-windows-arm64.exe` instead of relying on the x64 build under Prism. ([#1260](https://github.com/can1357/oh-my-pi/issues/1260))
+
 ## [15.2.1] - 2026-05-21
 
 ### Fixed

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Windows ARM64 (`win32-arm64`) to the native addon support matrix so Bun installs and compiled binaries can load bundled pi-natives on Snapdragon/Surface devices. ([#1260](https://github.com/can1357/oh-my-pi/issues/1260))
+
 ## [15.0.2] - 2026-05-15
 
 ### Added

--- a/packages/natives/native/loader-state.d.ts
+++ b/packages/natives/native/loader-state.d.ts
@@ -18,6 +18,8 @@ export interface DetectCompiledBinaryInput {
 
 export function detectCompiledBinary(input: DetectCompiledBinaryInput): boolean;
 
+export function isSupportedPlatformTag(platformTag: string): boolean;
+
 export interface GetAddonFilenamesInput {
 	tag: string;
 	arch: string;

--- a/packages/natives/native/loader-state.js
+++ b/packages/natives/native/loader-state.js
@@ -30,7 +30,15 @@ import { embeddedAddon } from "./embedded-addon.js";
  * post-build `--reset` stub) is the authoritative compiled-mode signal.
  */
 
-const SUPPORTED_PLATFORMS = ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64", "win32-x64"];
+const SUPPORTED_PLATFORMS = ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64", "win32-x64", "win32-arm64"];
+
+/**
+ * @param {string} platformTag
+ * @returns {boolean}
+ */
+export function isSupportedPlatformTag(platformTag) {
+	return SUPPORTED_PLATFORMS.includes(platformTag);
+}
 
 function getNativesDir() {
 	const xdgDataHome = process.env.XDG_DATA_HOME;
@@ -428,7 +436,7 @@ export function loadNative() {
 		}
 	}
 
-	if (!SUPPORTED_PLATFORMS.includes(ctx.platformTag)) {
+	if (!isSupportedPlatformTag(ctx.platformTag)) {
 		throw new Error(
 			`Unsupported platform: ${ctx.platformTag}\n` +
 				`Supported platforms: ${SUPPORTED_PLATFORMS.join(", ")}\n` +

--- a/packages/natives/test/windows-staging.test.ts
+++ b/packages/natives/test/windows-staging.test.ts
@@ -21,7 +21,12 @@
  */
 import { describe, expect, it } from "bun:test";
 import * as path from "node:path";
-import { getAddonFilenames, resolveLoaderCandidates, shouldStageNodeModulesAddon } from "../native/loader-state.js";
+import {
+	getAddonFilenames,
+	isSupportedPlatformTag,
+	resolveLoaderCandidates,
+	shouldStageNodeModulesAddon,
+} from "../native/loader-state.js";
 import packageJson from "../package.json" with { type: "json" };
 
 const winNodeModulesNativeDir = "C:\\Users\\Admin\\node_modules\\@oh-my-pi\\pi-natives\\native";
@@ -125,6 +130,15 @@ describe("windows native addon staging", () => {
 		const nodeModulesBaseline = path.join(posixNodeModulesNativeDir, "pi_natives.linux-x64-baseline.node");
 		expect(candidates).not.toContain(versionedBaseline);
 		expect(candidates).toContain(nodeModulesBaseline);
+	});
+});
+
+describe("Windows ARM64 native support", () => {
+	it("accepts win32-arm64 and resolves the default addon filename", () => {
+		expect(isSupportedPlatformTag("win32-arm64")).toBe(true);
+		expect(getAddonFilenames({ tag: "win32-arm64", arch: "arm64", variant: null })).toEqual([
+			"pi_natives.win32-arm64.node",
+		]);
 	});
 });
 

--- a/scripts/ci-release-build-binaries.ts
+++ b/scripts/ci-release-build-binaries.ts
@@ -65,6 +65,13 @@ const targets: BinaryTarget[] = [
 		target: "bun-windows-x64-modern",
 		outfile: "packages/coding-agent/binaries/omp-windows-x64.exe",
 	},
+	{
+		id: "win32-arm64",
+		platform: "win32",
+		arch: "arm64",
+		target: "bun-windows-arm64",
+		outfile: "packages/coding-agent/binaries/omp-windows-arm64.exe",
+	},
 ];
 
 function parseRequestedTargets(): Set<string> | null {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -19,8 +19,20 @@ $ErrorActionPreference = "Stop"
 $Repo = "can1357/oh-my-pi"
 $Package = "@oh-my-pi/pi-coding-agent"
 $InstallDir = if ($env:PI_INSTALL_DIR) { $env:PI_INSTALL_DIR } else { "$env:LOCALAPPDATA\omp" }
-$BinaryName = "omp-windows-x64.exe"
 $MinimumBunVersion = "1.3.14"
+
+function Get-BinaryName {
+    $archValues = @($env:PROCESSOR_ARCHITECTURE, $env:PROCESSOR_ARCHITEW6432) | Where-Object { $_ }
+    if ($archValues -contains "ARM64") {
+        return "omp-windows-arm64.exe"
+    }
+    if ($archValues -contains "AMD64") {
+        return "omp-windows-x64.exe"
+    }
+
+    $archLabel = if ($archValues.Count -gt 0) { $archValues -join ", " } else { "unknown" }
+    throw "Unsupported Windows architecture: $archLabel"
+}
 
 function Test-BunInstalled {
     try {
@@ -256,6 +268,7 @@ function Install-Binary {
 
     New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
 
+    $BinaryName = Get-BinaryName
     # Download binary
     $BinaryUrl = "https://github.com/$Repo/releases/download/$Latest/$BinaryName"
     Write-Host "Downloading $BinaryName..."


### PR DESCRIPTION
## Repro
Forcing the native loader to evaluate `process.platform=win32` and `process.arch=arm64` reproduced the reported startup failure with `Unsupported platform: win32-arm64`: `bun -e 'Object.defineProperty(process,"platform",{value:"win32"}); Object.defineProperty(process,"arch",{value:"arm64"}); const { loadNative } = await import("./packages/natives/native/loader-state.js"); try { loadNative(); } catch (err) { console.error(err instanceof Error ? err.message : String(err)); process.exit(1); }'`.

## Cause
`packages/natives/native/loader-state.js` did not include `win32-arm64` in `SUPPORTED_PLATFORMS`, while `.github/workflows/ci.yml` and `scripts/ci-release-build-binaries.ts` only built Windows x64 native addons and compiled binaries. `scripts/install.ps1` also hard-coded `omp-windows-x64.exe`, so Windows ARM machines had no native addon path or native binary artifact.

## Fix
- Added `win32-arm64` to the native loader support matrix and pinned it with a regression test in `packages/natives/test/windows-staging.test.ts`.
- Added Windows ARM64 native-addon and compiled-binary release targets, while skipping the Windows ARM64 smoke run on x64 Windows runners.
- Updated the Windows installer to select `omp-windows-arm64.exe` when the host architecture reports ARM64.
- Updated platform lists and changelogs for the new supported target.

## Verification
`bun test packages/natives/test/windows-staging.test.ts` passed; `bun --cwd=packages/natives run check` passed; `bun run check:tools` passed; `RELEASE_TARGETS=win32-arm64 bun scripts/ci-release-build-binaries.ts --dry-run` selected `bun-windows-arm64` and `packages/coding-agent/binaries/omp-windows-arm64.exe`. Fixes #1260