### PR TITLE
fix(mcp): unify enable state persistence

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/mcp enable` and `/mcp disable` persisting MCP server state in both `disabledExtensions` and `mcp.json`; slash commands now use the shared `disabledExtensions` entry and clean legacy inline `enabled` fields. ([#1262](https://github.com/can1357/oh-my-pi/issues/1262))
+
 ## [15.2.1] - 2026-05-21
 
 ### Fixed

--- a/packages/coding-agent/src/config/mcp-schema.json
+++ b/packages/coding-agent/src/config/mcp-schema.json
@@ -19,15 +19,6 @@
       "additionalProperties": {
         "$ref": "#/$defs/serverConfig"
       }
-    },
-    "disabledServers": {
-      "type": "array",
-      "description": "User-level denylist for disabling discovered servers by name.",
-      "items": {
-        "type": "string",
-        "minLength": 1
-      },
-      "uniqueItems": true
     }
   },
   "$defs": {
@@ -92,10 +83,6 @@
     "serverBase": {
       "type": "object",
       "properties": {
-        "enabled": {
-          "type": "boolean",
-          "description": "Whether OMP should try to connect this server."
-        },
         "timeout": {
           "type": "number",
           "exclusiveMinimum": 0,

--- a/packages/coding-agent/src/mcp/config-writer.ts
+++ b/packages/coding-agent/src/mcp/config-writer.ts
@@ -190,36 +190,3 @@ export async function listMCPServers(filePath: string): Promise<string[]> {
 	const config = await readMCPConfigFile(filePath);
 	return Object.keys(config.mcpServers ?? {});
 }
-
-/**
- * Read the disabled servers list from a config file.
- */
-export async function readDisabledServers(filePath: string): Promise<string[]> {
-	const config = await readMCPConfigFile(filePath);
-	return Array.isArray(config.disabledServers) ? config.disabledServers : [];
-}
-
-/**
- * Add or remove a server name from the disabled servers list.
- */
-export async function setServerDisabled(filePath: string, name: string, disabled: boolean): Promise<void> {
-	const config = await readMCPConfigFile(filePath);
-	const current = new Set(config.disabledServers ?? []);
-
-	if (disabled) {
-		current.add(name);
-	} else {
-		current.delete(name);
-	}
-
-	const updated: MCPConfigFile = {
-		...config,
-		disabledServers: current.size > 0 ? Array.from(current).sort() : undefined,
-	};
-
-	if (!updated.disabledServers) {
-		delete updated.disabledServers;
-	}
-
-	await writeMCPConfigFile(filePath, updated);
-}

--- a/packages/coding-agent/src/mcp/config.ts
+++ b/packages/coding-agent/src/mcp/config.ts
@@ -4,12 +4,10 @@
  * Uses the capability system to load MCP servers from multiple sources.
  */
 
-import { getMCPConfigPath } from "@oh-my-pi/pi-utils";
 import { mcpCapability } from "../capability/mcp";
 import type { SourceMeta } from "../capability/types";
 import type { MCPServer } from "../discovery";
 import { loadCapability } from "../discovery";
-import { readDisabledServers } from "./config-writer";
 import type { MCPServerConfig } from "./types";
 
 /** Options for loading MCP configs */
@@ -105,14 +103,11 @@ export async function loadAllMCPConfigs(cwd: string, options?: LoadMCPConfigsOpt
 		? result.items
 		: result.items.filter(server => server._source.level !== "project");
 
-	// Load user-level disabled servers list
-	const disabledServers = new Set(await readDisabledServers(getMCPConfigPath("user", cwd)));
-	// Convert to legacy format and preserve source metadata
 	let configs: Record<string, MCPServerConfig> = {};
 	let sources: Record<string, SourceMeta> = {};
 	for (const server of servers) {
 		const config = convertToLegacyConfig(server);
-		if (config.enabled === false || disabledServers.has(server.name)) {
+		if (config.enabled === false) {
 			continue;
 		}
 		configs[server.name] = config;

--- a/packages/coding-agent/src/mcp/disabled.ts
+++ b/packages/coding-agent/src/mcp/disabled.ts
@@ -1,0 +1,44 @@
+import type { Settings } from "../config/settings";
+import type { MCPServerConfig } from "./types";
+
+/** Returns the disabledExtensions entry used to persist MCP server state. */
+export function mcpDisabledExtensionId(name: string): string {
+	return `mcp:${name}`;
+}
+
+/** Returns MCP server names disabled through the shared extension settings. */
+export function getDisabledMcpServerNames(settings: Settings): Set<string> {
+	const disabledExtensions = settings.get("disabledExtensions") ?? [];
+	const names = new Set<string>();
+	for (const id of disabledExtensions) {
+		if (id.startsWith("mcp:")) {
+			names.add(id.slice(4));
+		}
+	}
+	return names;
+}
+
+/** Removes the legacy inline enabled flag before persisting an MCP server config. */
+export function withoutInlineMcpEnabled(config: MCPServerConfig): MCPServerConfig {
+	const { enabled: _enabled, ...stripped } = config;
+	return stripped;
+}
+
+/** Checks whether a server is disabled through the shared extension settings. */
+export function isMcpServerDisabled(settings: Settings, name: string): boolean {
+	return settings.get("disabledExtensions")?.includes(mcpDisabledExtensionId(name)) ?? false;
+}
+
+/** Persists MCP server enabled state in disabledExtensions and reports whether it changed. */
+export function setMcpServerDisabled(settings: Settings, name: string, disabled: boolean): boolean {
+	const id = mcpDisabledExtensionId(name);
+	const disabledExtensions = settings.get("disabledExtensions") ?? [];
+	const isDisabled = disabledExtensions.includes(id);
+	if (isDisabled === disabled) return false;
+
+	const next = disabled
+		? [...disabledExtensions, id].sort()
+		: disabledExtensions.filter(disabledId => disabledId !== id);
+	settings.set("disabledExtensions", next);
+	return true;
+}

--- a/packages/coding-agent/src/mcp/types.ts
+++ b/packages/coding-agent/src/mcp/types.ts
@@ -107,7 +107,6 @@ export const MCP_CONFIG_SCHEMA_URL =
 export interface MCPConfigFile {
 	$schema?: string;
 	mcpServers?: Record<string, MCPServerConfig>;
-	disabledServers?: string[];
 }
 
 // =============================================================================

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -9,14 +9,13 @@ import { getMCPConfigPath, getProjectDir } from "@oh-my-pi/pi-utils";
 import type { SourceMeta } from "../../capability/types";
 import { analyzeAuthError, discoverOAuthEndpoints, MCPManager } from "../../mcp";
 import { connectToServer, disconnectServer, listTools } from "../../mcp/client";
+import { addMCPServer, readMCPConfigFile, removeMCPServer, updateMCPServer } from "../../mcp/config-writer";
 import {
-	addMCPServer,
-	readDisabledServers,
-	readMCPConfigFile,
-	removeMCPServer,
-	setServerDisabled,
-	updateMCPServer,
-} from "../../mcp/config-writer";
+	getDisabledMcpServerNames,
+	isMcpServerDisabled,
+	setMcpServerDisabled,
+	withoutInlineMcpEnabled,
+} from "../../mcp/disabled";
 import { MCPOAuthFlow } from "../../mcp/oauth-flow";
 import {
 	clearSmitheryApiKey,
@@ -930,7 +929,7 @@ export class MCPCommandController {
 
 			// Collect runtime-discovered servers not in config files
 			const configServerNames = new Set([...userServers, ...projectServers]);
-			const disabledServerNames = new Set(await readDisabledServers(userPath));
+			const disabledServerNames = getDisabledMcpServerNames(this.ctx.settings);
 			const discoveredServers: { name: string; source: SourceMeta }[] = [];
 			if (this.ctx.mcpManager) {
 				for (const name of this.ctx.mcpManager.getAllServerNames()) {
@@ -970,7 +969,7 @@ export class MCPCommandController {
 					const config = userConfig.mcpServers![name];
 					const type = config.type ?? "stdio";
 					const state =
-						config.enabled === false
+						config.enabled === false || disabledServerNames.has(name)
 							? "inactive"
 							: (this.ctx.mcpManager?.getConnectionStatus(name) ?? "disconnected");
 					const status =
@@ -993,7 +992,7 @@ export class MCPCommandController {
 					const config = projectConfig.mcpServers![name];
 					const type = config.type ?? "stdio";
 					const state =
-						config.enabled === false
+						config.enabled === false || disabledServerNames.has(name)
 							? "inactive"
 							: (this.ctx.mcpManager?.getConnectionStatus(name) ?? "disconnected");
 					const status =
@@ -1200,12 +1199,10 @@ export class MCPCommandController {
 
 		try {
 			const found = await this.#findConfiguredServer(name);
+			const isCurrentlyDisabled = isMcpServerDisabled(this.ctx.settings, name);
 			if (!found) {
 				// Check if this is a discovered server from a third-party config
-				const userConfigPath = getMCPConfigPath("user", getProjectDir());
-				const disabledServers = new Set(await readDisabledServers(userConfigPath));
 				const isDiscovered = this.ctx.mcpManager?.getSource(name);
-				const isCurrentlyDisabled = disabledServers.has(name);
 				if (!isDiscovered && !isCurrentlyDisabled) {
 					this.ctx.showError(`Server "${name}" not found.`);
 					return;
@@ -1218,7 +1215,7 @@ export class MCPCommandController {
 					);
 					return;
 				}
-				await setServerDisabled(userConfigPath, name, !enabled);
+				setMcpServerDisabled(this.ctx.settings, name, !enabled);
 				if (enabled) {
 					await this.#reloadMCP();
 					const state = await this.#waitForServerConnectionWithAnimation(name);
@@ -1239,7 +1236,9 @@ export class MCPCommandController {
 				return;
 			}
 
-			if ((found.config.enabled ?? true) === enabled) {
+			const currentlyEnabled = found.config.enabled !== false && !isCurrentlyDisabled;
+			const needsInlineCleanup = found.config.enabled !== undefined;
+			if (currentlyEnabled === enabled && !needsInlineCleanup) {
 				this.#showMessage(
 					["", theme.fg("muted", `Server "${name}" is already ${enabled ? "enabled" : "disabled"}.`), ""].join(
 						"\n",
@@ -1248,10 +1247,14 @@ export class MCPCommandController {
 				return;
 			}
 
-			const updated: MCPServerConfig = { ...found.config, enabled };
-			await updateMCPServer(found.filePath, name, updated);
+			if (needsInlineCleanup && enabled) {
+				await updateMCPServer(found.filePath, name, withoutInlineMcpEnabled(found.config));
+			}
+			setMcpServerDisabled(this.ctx.settings, name, !enabled);
+			if (needsInlineCleanup && !enabled) {
+				await updateMCPServer(found.filePath, name, withoutInlineMcpEnabled(found.config));
+			}
 			await this.#reloadMCP();
-
 			let status = "";
 			if (enabled) {
 				const state = await this.#waitForServerConnectionWithAnimation(name);

--- a/packages/coding-agent/src/slash-commands/helpers/mcp.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/mcp.ts
@@ -1,13 +1,12 @@
 import { getMCPConfigPath, logger } from "@oh-my-pi/pi-utils";
 import { connectToServer, disconnectServer, listPrompts, listResources, listTools } from "../../mcp/client";
+import { addMCPServer, readMCPConfigFile, removeMCPServer, updateMCPServer } from "../../mcp/config-writer";
 import {
-	addMCPServer,
-	readDisabledServers,
-	readMCPConfigFile,
-	removeMCPServer,
-	setServerDisabled,
-	updateMCPServer,
-} from "../../mcp/config-writer";
+	getDisabledMcpServerNames,
+	isMcpServerDisabled,
+	setMcpServerDisabled,
+	withoutInlineMcpEnabled,
+} from "../../mcp/disabled";
 import { MCPManager } from "../../mcp/manager";
 import { getSmitheryApiKey } from "../../mcp/smithery-auth";
 import { searchSmitheryRegistry } from "../../mcp/smithery-registry";
@@ -78,6 +77,7 @@ const MCP_ADD_OPTION_PARSERS = new Map<string, McpAddOptionParser>([
 
 async function getMcpConfiguredServers(
 	cwd: string,
+	disabledServerNames: Set<string>,
 ): Promise<Array<{ name: string; config: MCPServerConfig; scope: AcpMcpScope }>> {
 	const userPath = getMCPConfigPath("user", cwd);
 	const projectPath = getMCPConfigPath("project", cwd);
@@ -85,15 +85,43 @@ async function getMcpConfiguredServers(
 	const servers: Array<{ name: string; config: MCPServerConfig; scope: AcpMcpScope }> = [];
 	const seen = new Set<string>();
 	for (const [name, config] of Object.entries(projectConfig.mcpServers ?? {})) {
-		if (config.enabled !== false) {
+		if (config.enabled !== false && !disabledServerNames.has(name)) {
 			servers.push({ name, config, scope: "project" });
 			seen.add(name);
 		}
 	}
 	for (const [name, config] of Object.entries(userConfig.mcpServers ?? {})) {
-		if (!seen.has(name) && config.enabled !== false) servers.push({ name, config, scope: "user" });
+		if (!seen.has(name) && config.enabled !== false && !disabledServerNames.has(name)) {
+			servers.push({ name, config, scope: "user" });
+		}
 	}
 	return servers;
+}
+
+async function persistMcpEnabledState(
+	runtime: SlashCommandRuntime,
+	filePath: string,
+	name: string,
+	config: MCPServerConfig,
+	scope: AcpMcpScope,
+	enabled: boolean,
+): Promise<void> {
+	const isDisabled = isMcpServerDisabled(runtime.settings, name);
+	const currentlyEnabled = config.enabled !== false && !isDisabled;
+	const needsInlineCleanup = config.enabled !== undefined;
+	if (currentlyEnabled === enabled && !needsInlineCleanup) {
+		await runtime.output(`Server "${name}" is already ${enabled ? "enabled" : "disabled"}.`);
+		return;
+	}
+
+	if (needsInlineCleanup && enabled) {
+		await updateMCPServer(filePath, name, withoutInlineMcpEnabled(config));
+	}
+	setMcpServerDisabled(runtime.settings, name, !enabled);
+	if (needsInlineCleanup && !enabled) {
+		await updateMCPServer(filePath, name, withoutInlineMcpEnabled(config));
+	}
+	await runtime.output(`Server "${name}" ${enabled ? "enabled" : "disabled"} (${scope} config).`);
 }
 
 function validateParsedMcpAddArgs(parsed: ParsedMcpAddArgs): ParsedMcpAddArgs {
@@ -231,7 +259,7 @@ async function collectConnectedMcpLines(
 	runtime: SlashCommandRuntime,
 	collect: (serverName: string, connection: MCPServerConnection) => Promise<string[]>,
 ): Promise<string[] | undefined> {
-	const servers = await getMcpConfiguredServers(runtime.cwd);
+	const servers = await getMcpConfiguredServers(runtime.cwd, getDisabledMcpServerNames(runtime.settings));
 	if (servers.length === 0) return undefined;
 
 	const lines: string[] = [];
@@ -277,7 +305,7 @@ async function handlePromptsCommand(runtime: SlashCommandRuntime): Promise<Slash
 async function handleTestCommand(rest: string, runtime: SlashCommandRuntime): Promise<SlashCommandResult> {
 	const name = rest.split(/\s+/)[0]?.trim() ?? "";
 	if (!name) return usage("Usage: /mcp test <name>", runtime);
-	const servers = await getMcpConfiguredServers(runtime.cwd);
+	const servers = await getMcpConfiguredServers(runtime.cwd, getDisabledMcpServerNames(runtime.settings));
 	const server = servers.find(item => item.name === name);
 	if (!server) return usage(`Server "${name}" not found. Run /mcp list to see configured servers.`, runtime);
 
@@ -368,7 +396,7 @@ async function handleListCommand(runtime: SlashCommandRuntime): Promise<SlashCom
 			readMCPConfigFile(userPath),
 			readMCPConfigFile(projectPath),
 		]);
-		const disabledSet = new Set(await readDisabledServers(userPath));
+		const disabledSet = getDisabledMcpServerNames(runtime.settings);
 		const entries: Array<{ name: string; config: MCPServerConfig; scope: string }> = [];
 		for (const [name, config] of Object.entries(userConfig.mcpServers ?? {})) {
 			entries.push({ name, config, scope: "user" });
@@ -430,19 +458,24 @@ async function handleEnableDisableCommand(
 			readMCPConfigFile(userPath),
 			readMCPConfigFile(projectPath),
 		]);
-		if (projectConfig.mcpServers?.[name] !== undefined) {
-			await updateMCPServer(projectPath, name, { ...projectConfig.mcpServers[name], enabled } as MCPServerConfig);
-			await runtime.output(`Server "${name}" ${enabled ? "enabled" : "disabled"} (project config).`);
+		const projectServer = projectConfig.mcpServers?.[name];
+		if (projectServer !== undefined) {
+			await persistMcpEnabledState(runtime, projectPath, name, projectServer, "project", enabled);
 			return commandConsumed();
 		}
-		if (userConfig.mcpServers?.[name] !== undefined) {
-			await updateMCPServer(userPath, name, { ...userConfig.mcpServers[name], enabled } as MCPServerConfig);
-			await runtime.output(`Server "${name}" ${enabled ? "enabled" : "disabled"} (user config).`);
+		const userServer = userConfig.mcpServers?.[name];
+		if (userServer !== undefined) {
+			await persistMcpEnabledState(runtime, userPath, name, userServer, "user", enabled);
 			return commandConsumed();
 		}
-		const disabledList = await readDisabledServers(userPath);
-		if (!enabled || disabledList.includes(name)) {
-			await setServerDisabled(userPath, name, !enabled);
+
+		const isDisabled = isMcpServerDisabled(runtime.settings, name);
+		if (!enabled || isDisabled) {
+			if (isDisabled === !enabled) {
+				await runtime.output(`Server "${name}" is already ${enabled ? "enabled" : "disabled"}.`);
+				return commandConsumed();
+			}
+			setMcpServerDisabled(runtime.settings, name, !enabled);
 			await runtime.output(`Server "${name}" ${enabled ? "enabled" : "disabled"}.`);
 			return commandConsumed();
 		}

--- a/packages/coding-agent/test/acp-builtins.test.ts
+++ b/packages/coding-agent/test/acp-builtins.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getAgentDir, setAgentDir } from "@oh-my-pi/pi-utils";
 import { Settings } from "../src/config/settings";
 import type { AgentSession } from "../src/session/agent-session";
 import type { SessionManager } from "../src/session/session-manager";
@@ -758,6 +762,51 @@ describe("wave 5 — adapters and polish", () => {
 			});
 		} finally {
 			spy.mockRestore();
+		}
+	});
+
+	it("/mcp disable and enable persist state only in disabledExtensions", async () => {
+		const originalAgentDir = getAgentDir();
+		const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-disable-"));
+		const agentDir = path.join(tempRoot, "agent");
+		const projectDir = path.join(tempRoot, "project");
+		await fs.mkdir(agentDir, { recursive: true });
+		await fs.mkdir(projectDir, { recursive: true });
+		setAgentDir(agentDir);
+		try {
+			const mcpPath = path.join(agentDir, "mcp.json");
+			await fs.writeFile(
+				mcpPath,
+				JSON.stringify(
+					{
+						mcpServers: {
+							exa: {
+								type: "http",
+								url: "https://mcp.exa.ai/mcp",
+							},
+						},
+					},
+					null,
+					2,
+				),
+			);
+
+			const { runtime } = createRuntime();
+			runtime.cwd = projectDir;
+
+			const disableResult = await executeAcpBuiltinSlashCommand("/mcp disable exa", runtime);
+			const disabledConfig = await fs.readFile(mcpPath, "utf8");
+			expect(disableResult).toEqual({ consumed: true });
+			expect(disabledConfig).not.toContain('"enabled"');
+			expect(runtime.settings.get("disabledExtensions")).toEqual(["mcp:exa"]);
+
+			const enableResult = await executeAcpBuiltinSlashCommand("/mcp enable exa", runtime);
+			const enabledConfig = await fs.readFile(mcpPath, "utf8");
+			expect(enableResult).toEqual({ consumed: true });
+			expect(enabledConfig).not.toContain('"enabled"');
+			expect(runtime.settings.get("disabledExtensions")).toEqual([]);
+		} finally {
+			setAgentDir(originalAgentDir);
 		}
 	});
 


### PR DESCRIPTION
## Repro
With `~/.omp/agent/mcp.json` containing an `exa` server, invoking `/mcp disable exa` could leave state in two places: `disabledExtensions` contained `mcp:exa` while the server entry in `mcp.json` also gained `enabled: false`. I reproduced this with a Bun script that invoked `handleMcpAcp("/mcp disable exa")` against a temp agent dir.

## Cause
`packages/coding-agent/src/slash-commands/helpers/mcp.ts` and `packages/coding-agent/src/modes/controllers/mcp-command-controller.ts` wrote enable/disable state back into MCP config entries via `updateMCPServer(..., { ...config, enabled })`, while the extension control path already used the shared `disabledExtensions` setting for MCP item state.

## Fix
- Added `packages/coding-agent/src/mcp/disabled.ts` as the single helper for MCP `disabledExtensions` IDs and legacy inline `enabled` cleanup.
- Updated ACP and TUI `/mcp enable|disable` to persist state through `disabledExtensions` and remove legacy inline `enabled` fields when encountered.
- Removed the unused `disabledServers` MCP config path and removed `enabled`/`disabledServers` from the MCP JSON schema.
- Added regression coverage for `/mcp disable` followed by `/mcp enable` preserving `mcp.json` while toggling `disabledExtensions`.

## Verification
- `bun test packages/coding-agent/test/acp-builtins.test.ts` → 63 pass
- `bun run check:types` in `packages/coding-agent` → pass
- Manual Bun repro confirmed disable writes `disabledExtensions: ["mcp:exa"]` without adding `enabled` to `mcp.json`, and enable removes the setting while preserving `mcp.json`.

Fixes #1262