### PR TITLE
fix(prompts): SYSTEM.md content silently dropped in default sessions

### DIFF
--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -64,6 +64,10 @@ With most FS/bash-like tools, static references to them will automatically resol
 - `pr://<N>` (or `pr://<owner>/<repo>/<N>`): GitHub PR view; same cache. Append `?comments=0` to drop the comments section. Bare `pr://` (or `pr://<owner>/<repo>`) lists recent PRs; supports `?state=open|closed|merged|all&limit=&author=&label=`.
 - `omp://`: Harness documentation; AVOID reading unless user mentions the harness itself
 
+{{#if systemPromptCustomization}}
+{{systemPromptCustomization}}
+{{/if}}
+
 {{#if skills.length}}
 # Skills
 {{#each skills}}


### PR DESCRIPTION
## What

Add the `{{#if systemPromptCustomization}}` Handlebars block to the default `system-prompt.md` template so that `SYSTEM.md` content discovered by the capability system is actually rendered into the prompt.

## Why

`SYSTEM.md` files discovered by capability providers (`.agents/SYSTEM.md`, `.claude/SYSTEM.md`, `.gemini/system.md`, etc.) are loaded by `loadSystemPromptFiles()`, deduped, and passed as `data.systemPromptCustomization` to the Handlebars template — but the default `system-prompt.md` template never references the variable. The content is prepared correctly and then silently discarded.

The previous version of the template (before the rewrite in `7b17024`, Feb 24) did render it:

```handlebars
{{#if systemPromptCustomization}}
<context>
{{systemPromptCustomization}}
</context>
{{/if}}
```

The rewrite dropped this block. Only `custom-system-prompt.md` still renders it, but that template is only active when `customPrompt` is explicitly provided — which the default SDK path never does.

The block is placed after the internal URLs section and before Skills, matching the position of the old template's `<context>` block.

## Testing

- `bun run check:ts` — all workspaces pass (exit 0, no errors).
- Verified the Handlebars block matches the existing pattern in `custom-system-prompt.md`.
- Change is 4 lines in a `.md` template file with no logic.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)