### PR TITLE
fix(discovery): load top-level RULES.md as sticky always-apply rule

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `RULES.md` not being injected. The documented sticky-rules file at `~/.omp/agent/RULES.md` and `<repo>/.omp/RULES.md` was never read by any discovery provider; only `.omp/rules/*.md` was scanned. The native provider now loads both as always-apply rules so they re-attach every turn as documented ([#1266](https://github.com/can1357/oh-my-pi/issues/1266)).
+
 ## [15.2.1] - 2026-05-21
 
 ### Fixed

--- a/packages/coding-agent/src/discovery/builtin.ts
+++ b/packages/coding-agent/src/discovery/builtin.ts
@@ -346,7 +346,37 @@ async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
 		if (result.warnings) warnings.push(...result.warnings);
 	}
 
+	// Top-level RULES.md is a sticky always-apply rule. Documented in
+	// https://omp.sh/docs/context-files as the file that gets "re-injected near
+	// the current turn so they keep hold across long conversations".
+	// User scope:    ~/.omp/agent/RULES.md
+	// Project scope: nearest .omp/RULES.md walking up from cwd to repoRoot
+	const userRulesFile = path.join(ctx.home, PATHS.userAgent, "RULES.md");
+	const userRule = await loadStickyRulesFile(userRulesFile, "user");
+	if (userRule) items.push(userRule);
+
+	const nearestProjectConfigDir = await findNearestProjectConfigDir(ctx.cwd, ctx.repoRoot);
+	if (nearestProjectConfigDir) {
+		const projectRulesFile = path.join(nearestProjectConfigDir.dir, "RULES.md");
+		const projectRule = await loadStickyRulesFile(projectRulesFile, "project");
+		if (projectRule) items.push(projectRule);
+	}
+
 	return { items, warnings };
+}
+
+/**
+ * Read a top-level `RULES.md` and synthesize an always-apply rule.
+ * Returns null when the file is absent or empty so callers can short-circuit.
+ */
+async function loadStickyRulesFile(filePath: string, level: "user" | "project"): Promise<Rule | null> {
+	const content = await readFile(filePath);
+	if (!content) return null;
+	const source = createSourceMeta(PROVIDER_ID, filePath, level);
+	const rule = buildRuleFromMarkdown("RULES.md", content, filePath, source, { ruleName: "RULES" });
+	// Force alwaysApply regardless of frontmatter — the whole point of RULES.md
+	// is to be reattached every turn.
+	return { ...rule, alwaysApply: true };
 }
 
 registerProvider<Rule>(ruleCapability.id, {

--- a/packages/coding-agent/test/discovery/builtin-rules-md.test.ts
+++ b/packages/coding-agent/test/discovery/builtin-rules-md.test.ts
@@ -90,10 +90,7 @@ test("project RULES.md is found walking up from a sub-package cwd", async () => 
 });
 
 test("alwaysApply is forced even when frontmatter says false", async () => {
-	writeFile(
-		path.join(home, ".omp", "agent", "RULES.md"),
-		"---\nalwaysApply: false\n---\nStick around anyway.\n",
-	);
+	writeFile(path.join(home, ".omp", "agent", "RULES.md"), "---\nalwaysApply: false\n---\nStick around anyway.\n");
 
 	const rules = await loadNativeRules({ cwd: project, home, repoRoot: project });
 

--- a/packages/coding-agent/test/discovery/builtin-rules-md.test.ts
+++ b/packages/coding-agent/test/discovery/builtin-rules-md.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Regression test for #1266:
+ * `RULES.md` (singular, top-level) MUST be loaded as a sticky always-apply rule
+ * from both `~/.omp/agent/RULES.md` (user) and the nearest `.omp/RULES.md`
+ * (project, walked up from cwd to repoRoot).
+ *
+ * Calls the native provider's `load` directly to bypass `loadCapability`'s
+ * hardcoded `os.homedir()` so the user scope can be staged inside a tempdir.
+ */
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getCapability } from "@oh-my-pi/pi-coding-agent/capability";
+import { clearCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import { type Rule, ruleCapability } from "@oh-my-pi/pi-coding-agent/capability/rule";
+import type { LoadContext } from "@oh-my-pi/pi-coding-agent/capability/types";
+// Register all discovery providers as a side effect.
+import "@oh-my-pi/pi-coding-agent/discovery";
+
+let tempDir: string;
+let home: string;
+let project: string;
+
+function writeFile(filePath: string, content: string): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, content);
+}
+
+async function loadNativeRules(ctx: LoadContext): Promise<Rule[]> {
+	const cap = getCapability(ruleCapability.id);
+	if (!cap) throw new Error("rules capability missing");
+	const native = cap.providers.find(p => p.id === "native");
+	if (!native) throw new Error("native rules provider missing");
+	const result = await (native.load as (ctx: LoadContext) => Promise<{ items: Rule[] }>)(ctx);
+	return result.items;
+}
+
+beforeEach(() => {
+	clearCache();
+	tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-rules-md-"));
+	home = path.join(tempDir, "home");
+	project = path.join(tempDir, "project");
+	fs.mkdirSync(home, { recursive: true });
+	fs.mkdirSync(project, { recursive: true });
+	fs.mkdirSync(path.join(project, ".git"), { recursive: true });
+});
+
+afterEach(() => {
+	clearCache();
+	fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+test("user ~/.omp/agent/RULES.md becomes an alwaysApply rule", async () => {
+	writeFile(
+		path.join(home, ".omp", "agent", "RULES.md"),
+		"**CRITICAL**: You _MUST_ use beads task tracker for any project\n",
+	);
+
+	const rules = await loadNativeRules({ cwd: project, home, repoRoot: project });
+
+	const userRule = rules.find(r => r._source.level === "user" && r.name === "RULES");
+	expect(userRule).toBeDefined();
+	expect(userRule?.alwaysApply).toBe(true);
+	expect(userRule?.content).toContain("beads task tracker");
+});
+
+test("project .omp/RULES.md becomes an alwaysApply rule", async () => {
+	writeFile(path.join(project, ".omp", "RULES.md"), "# Project rule\nAlways say hi.\n");
+
+	const rules = await loadNativeRules({ cwd: project, home, repoRoot: project });
+
+	const projectRule = rules.find(r => r._source.level === "project" && r.name === "RULES");
+	expect(projectRule).toBeDefined();
+	expect(projectRule?.alwaysApply).toBe(true);
+	expect(projectRule?.content).toContain("Always say hi.");
+});
+
+test("project RULES.md is found walking up from a sub-package cwd", async () => {
+	const subPkg = path.join(project, "packages", "app");
+	fs.mkdirSync(subPkg, { recursive: true });
+	writeFile(path.join(project, ".omp", "RULES.md"), "# Repo-wide sticky rule\n");
+
+	const rules = await loadNativeRules({ cwd: subPkg, home, repoRoot: project });
+
+	const projectRule = rules.find(r => r._source.level === "project" && r.name === "RULES");
+	expect(projectRule).toBeDefined();
+	expect(projectRule?.alwaysApply).toBe(true);
+	expect(projectRule?.path).toBe(path.join(project, ".omp", "RULES.md"));
+});
+
+test("alwaysApply is forced even when frontmatter says false", async () => {
+	writeFile(
+		path.join(home, ".omp", "agent", "RULES.md"),
+		"---\nalwaysApply: false\n---\nStick around anyway.\n",
+	);
+
+	const rules = await loadNativeRules({ cwd: project, home, repoRoot: project });
+
+	const userRule = rules.find(r => r._source.level === "user" && r.name === "RULES");
+	expect(userRule?.alwaysApply).toBe(true);
+	expect(userRule?.content).toContain("Stick around anyway.");
+});
+
+test("absent RULES.md does not produce a rule", async () => {
+	// No RULES.md anywhere — only a sibling .omp/rules/ to make sure the directory exists.
+	writeFile(path.join(home, ".omp", "agent", "rules", "other.md"), "# Unrelated rule\n");
+
+	const rules = await loadNativeRules({ cwd: project, home, repoRoot: project });
+
+	expect(rules.find(r => r.name === "RULES")).toBeUndefined();
+});


### PR DESCRIPTION
## Repro

Created `~/.omp/agent/RULES.md` containing `**CRITICAL**: You _MUST_ use beads task tracker for any project`, started a session, and inspected the outgoing prompt — the rule never appears. The documented sticky-rules file at [`~/.omp/agent/RULES.md`](https://omp.sh/docs/context-files) is silently ignored. Reproduced as a unit test in `packages/coding-agent/test/discovery/builtin-rules-md.test.ts`, which fails without the fix because the native rule provider returns no rule with `name === "RULES"`.

## Cause

`loadRules` in `packages/coding-agent/src/discovery/builtin.ts` only scans the `rules/` subdirectory (`.omp/rules/*.md` and `~/.omp/agent/rules/*.md`). No discovery provider reads a singular top-level `RULES.md` anywhere — a `search` for `RULES\.md` across `packages/` returns zero hits. So both `~/.omp/agent/RULES.md` and `<repo>/.omp/RULES.md` are filesystem-invisible to the rule loader, contradicting the docs.

## Fix

- `packages/coding-agent/src/discovery/builtin.ts`: after the existing `.omp/rules/*` scan, look up two sticky files —
  - user: `~/.omp/agent/RULES.md` via `path.join(ctx.home, PATHS.userAgent, "RULES.md")`.
  - project: nearest `.omp/RULES.md` walking up from `cwd` to `repoRoot`, reusing the same `findNearestProjectConfigDir` helper `AGENTS.md` uses.
- Each present file is parsed with `buildRuleFromMarkdown` (`ruleName: "RULES"`) so frontmatter still applies, then `alwaysApply` is forced to `true` — the whole point of `RULES.md` is to be reattached every turn, so the file's behavior cannot depend on the user remembering frontmatter.
- New helper `loadStickyRulesFile(filePath, level)` keeps the read/synthesize path testable in isolation.

## Verification

- `bun test test/discovery/builtin-rules-md.test.ts` — 5/5 pass (new regression suite: user scope, project scope, walk-up from sub-package cwd, `alwaysApply: false` frontmatter overridden, absent file produces no rule).
- `bun test test/discovery/` — 82/82 pass (no regression in existing discovery suites).
- `bun test test/ttsr.test.ts test/agent-session-concurrent.test.ts` — 36/36 pass (rule consumers unaffected).

Fixes #1266