### PR TITLE
fix(browser): handle null head in stealth bootstrap

### DIFF
--- a/packages/coding-agent/src/tools/browser/launch.ts
+++ b/packages/coding-agent/src/tools/browser/launch.ts
@@ -540,24 +540,24 @@ async function withSoftTimeout<T>(promise: Promise<T>, timeoutMs: number, label:
 	}
 }
 
-async function injectStealthScripts(page: Page): Promise<void> {
-	const scripts = [
-		stealthTamperingScript,
-		stealthActivityScript,
-		stealthHairlineScript,
-		stealthBotdScript,
-		stealthIframeScript,
-		stealthWebglScript,
-		stealthScreenScript,
-		stealthFontsScript,
-		stealthAudioScript,
-		stealthLocaleScript,
-		stealthPluginsScript,
-		stealthHardwareScript,
-		stealthCodecsScript,
-		stealthWorkerScript,
-	];
+const STEALTH_PATCH_SCRIPTS = [
+	stealthTamperingScript,
+	stealthActivityScript,
+	stealthHairlineScript,
+	stealthBotdScript,
+	stealthIframeScript,
+	stealthWebglScript,
+	stealthScreenScript,
+	stealthFontsScript,
+	stealthAudioScript,
+	stealthLocaleScript,
+	stealthPluginsScript,
+	stealthHardwareScript,
+	stealthCodecsScript,
+	stealthWorkerScript,
+];
 
+function buildStealthInjectionScript(scripts: readonly string[] = STEALTH_PATCH_SCRIPTS): string {
 	const joint = scripts
 		.map(
 			script => `
@@ -568,43 +568,55 @@ async function injectStealthScripts(page: Page): Promise<void> {
 		)
 		.join(";\n");
 
-	await page.evaluateOnNewDocument(`(() => {
+	return `(() => {
 				// Native function cache - captured before any tampering
 				const iframe = document.createElement("iframe");
 				iframe.style.display = "none";
-				document.head.appendChild(iframe);
-				const nativeWindow = iframe.contentWindow;
-				if (!nativeWindow) return;
+				const container = document.head ?? document.documentElement;
+				if (!container) return;
+				container.appendChild(iframe);
+				try {
+					const nativeWindow = iframe.contentWindow;
+					if (!nativeWindow) return;
 
-				// Cache pristine native functions
-				const Function_toString = nativeWindow.Function.prototype.toString;
-				const Object_getOwnPropertyDescriptor = nativeWindow.Object.getOwnPropertyDescriptor;
-				const Object_getOwnPropertyDescriptors = nativeWindow.Object.getOwnPropertyDescriptors;
-				const Object_getPrototypeOf = nativeWindow.Object.getPrototypeOf;
-				const Object_defineProperty = nativeWindow.Object.defineProperty;
-				const Object_getOwnPropertyDescriptorOriginal = nativeWindow.Object.getOwnPropertyDescriptor;
-				const Object_create = nativeWindow.Object.create;
-				const Object_keys = nativeWindow.Object.keys;
-				const Object_getOwnPropertyNames = nativeWindow.Object.getOwnPropertyNames;
-				const Object_entries = nativeWindow.Object.entries;
-				const Object_setPrototypeOf = nativeWindow.Object.setPrototypeOf;
-				const Object_assign = nativeWindow.Object.assign;
-				const Window_setTimeout = nativeWindow.setTimeout;
-				const Math_random = nativeWindow.Math.random;
-				const Math_floor = nativeWindow.Math.floor;
-				const Math_max = nativeWindow.Math.max;
-				const Math_min = nativeWindow.Math.min;
-				const Window_Event = nativeWindow.Event;
-				const Promise_resolve = nativeWindow.Promise.resolve.bind(nativeWindow.Promise);
-				const Window_Blob = nativeWindow.Blob;
-				const Window_Proxy = nativeWindow.Proxy;
-				const Intl_DateTimeFormat = nativeWindow.Intl.DateTimeFormat;
-				const Date_constructor = nativeWindow.Date;
+					// Cache pristine native functions
+					const Function_toString = nativeWindow.Function.prototype.toString;
+					const Object_getOwnPropertyDescriptor = nativeWindow.Object.getOwnPropertyDescriptor;
+					const Object_getOwnPropertyDescriptors = nativeWindow.Object.getOwnPropertyDescriptors;
+					const Object_getPrototypeOf = nativeWindow.Object.getPrototypeOf;
+					const Object_defineProperty = nativeWindow.Object.defineProperty;
+					const Object_getOwnPropertyDescriptorOriginal = nativeWindow.Object.getOwnPropertyDescriptor;
+					const Object_create = nativeWindow.Object.create;
+					const Object_keys = nativeWindow.Object.keys;
+					const Object_getOwnPropertyNames = nativeWindow.Object.getOwnPropertyNames;
+					const Object_entries = nativeWindow.Object.entries;
+					const Object_setPrototypeOf = nativeWindow.Object.setPrototypeOf;
+					const Object_assign = nativeWindow.Object.assign;
+					const Window_setTimeout = nativeWindow.setTimeout;
+					const Math_random = nativeWindow.Math.random;
+					const Math_floor = nativeWindow.Math.floor;
+					const Math_max = nativeWindow.Math.max;
+					const Math_min = nativeWindow.Math.min;
+					const Window_Event = nativeWindow.Event;
+					const Promise_resolve = nativeWindow.Promise.resolve.bind(nativeWindow.Promise);
+					const Window_Blob = nativeWindow.Blob;
+					const Window_Proxy = nativeWindow.Proxy;
+					const Intl_DateTimeFormat = nativeWindow.Intl.DateTimeFormat;
+					const Date_constructor = nativeWindow.Date;
 
-				
-				${joint}
+					${joint}
+				} finally {
+					if (iframe.parentNode) iframe.parentNode.removeChild(iframe);
+				}})();`;
+}
 
-				document.head.removeChild(iframe);})();`);
+async function injectStealthScripts(page: Page): Promise<void> {
+	await page.evaluateOnNewDocument(buildStealthInjectionScript());
+}
+
+/** Builds the browser-page stealth bootstrap source for regression tests. */
+export function buildStealthInjectionScriptForTest(scripts: readonly string[] = STEALTH_PATCH_SCRIPTS): string {
+	return buildStealthInjectionScript(scripts);
 }
 
 /** Apply stealth patches + UA override to a headless page. Idempotent within a tab. */

--- a/packages/coding-agent/test/tools/browser-stealth-targets.test.ts
+++ b/packages/coding-agent/test/tools/browser-stealth-targets.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { Browser, CDPSession, Target } from "puppeteer-core";
 import {
+	buildStealthInjectionScriptForTest,
 	configureUserAgentTargetsForTest,
 	targetSupportsUserAgentOverrideForTest,
 } from "../../src/tools/browser/launch";
@@ -88,6 +89,67 @@ const override = {
 	},
 };
 
+describe("browser stealth bootstrap", () => {
+	it("uses documentElement as the iframe container when document.head is unavailable", () => {
+		type NativeWindow = Pick<
+			typeof globalThis,
+			"Function" | "Object" | "setTimeout" | "Math" | "Event" | "Promise" | "Blob" | "Proxy" | "Intl" | "Date"
+		>;
+		type FakeContainer = {
+			appendChild(node: FakeIframe): void;
+			removeChild(node: FakeIframe): void;
+		};
+		type FakeIframe = {
+			contentWindow: NativeWindow;
+			parentNode: FakeContainer | null;
+			style: { display?: string };
+		};
+
+		const appended: FakeIframe[] = [];
+		const removed: FakeIframe[] = [];
+		const documentElement: FakeContainer = {
+			appendChild(node) {
+				appended.push(node);
+				node.parentNode = documentElement;
+			},
+			removeChild(node) {
+				removed.push(node);
+				node.parentNode = null;
+			},
+		};
+		const nativeWindow: NativeWindow = {
+			Function,
+			Object,
+			setTimeout,
+			Math,
+			Event,
+			Promise,
+			Blob,
+			Proxy,
+			Intl,
+			Date,
+		};
+		const iframe: FakeIframe = { contentWindow: nativeWindow, parentNode: null, style: {} };
+		const createdTags: string[] = [];
+		const document = {
+			head: null,
+			documentElement,
+			createElement(tagName: string) {
+				createdTags.push(tagName);
+				return iframe;
+			},
+		};
+
+		const run = new Function("document", buildStealthInjectionScriptForTest([]));
+		run(document);
+
+		expect(createdTags).toEqual(["iframe"]);
+		expect(iframe.style.display).toBe("none");
+		expect(appended).toEqual([iframe]);
+		expect(removed).toEqual([iframe]);
+		expect(iframe.parentNode).toBeNull();
+	});
+});
 describe("browser stealth target setup", () => {
 	it("attempts user-agent override for page-like existing targets and skips non-page worker/browser targets", async () => {
 		const page = new FakeTarget("page");


### PR DESCRIPTION
## Repro
The browser stealth bootstrap crashed during new-document evaluation when `document.head` was `null`; reproduced with `bun --eval 'const document = { head: null, documentElement: { appendChild() {}, removeChild() {} }, createElement() { return { style: {}, contentWindow: {} }; } }; const iframe = document.createElement("iframe"); iframe.style.display = "none"; document.head.appendChild(iframe);'`, which throws `TypeError: null is not an object (evaluating 'document.head.appendChild')`.

## Cause
`packages/coding-agent/src/tools/browser/launch.ts` built the stealth `evaluateOnNewDocument` script with an unconditional `document.head.appendChild(iframe)` and later `document.head.removeChild(iframe)`, so early document-construction states with no `<head>` surfaced as page-console errors before the stealth patches could run.

## Fix
- Build the stealth bootstrap through a helper so the injected source can be regression-tested.
- Use `document.head ?? document.documentElement` as the iframe mount point and return only when neither container exists.
- Clean up the iframe from its actual parent in a `finally` block, including early `contentWindow` exits.
- Add a browser stealth bootstrap regression test covering the null-head path.

## Verification
`bun test packages/coding-agent/test/tools/browser-stealth-targets.test.ts` passed; `bun --cwd=packages/coding-agent run check` passed. Fixes #1267