### PR TITLE
fix(ai): use Vertex global endpoint host

### DIFF
--- a/packages/ai/src/providers/google-vertex.ts
+++ b/packages/ai/src/providers/google-vertex.ts
@@ -47,7 +47,8 @@ export const streamGoogleVertex: StreamFunction<"google-vertex"> = (
 			const project = resolveProject(options);
 			const location = resolveLocation(options);
 			const accessToken = await getVertexAccessToken({ signal: options?.signal, fetch: options?.fetch });
-			const url = `https://${location}-aiplatform.googleapis.com/${API_VERSION}/projects/${project}/locations/${location}/publishers/google/models/${model.id}:streamGenerateContent?alt=sse`;
+			const host = resolveEndpointHost(location);
+			const url = `https://${host}/${API_VERSION}/projects/${project}/locations/${location}/publishers/google/models/${model.id}:streamGenerateContent?alt=sse`;
 			return {
 				params,
 				url,
@@ -75,6 +76,9 @@ function resolveProject(options?: GoogleVertexOptions): string {
 	return project;
 }
 
+function resolveEndpointHost(location: string): string {
+	return location === "global" ? "aiplatform.googleapis.com" : `${location}-aiplatform.googleapis.com`;
+}
 function resolveLocation(options?: GoogleVertexOptions): string {
 	const location = options?.location || $env.GOOGLE_CLOUD_LOCATION;
 	if (!location) {

--- a/packages/ai/test/issue-1270-repro.test.ts
+++ b/packages/ai/test/issue-1270-repro.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { __resetVertexTokenCache } from "../src/providers/google-auth";
+import { streamGoogleVertex } from "../src/providers/google-vertex";
+import type { Model } from "../src/types";
+
+const context = {
+	messages: [{ role: "user" as const, content: "hello", timestamp: 0 }],
+};
+
+const model: Model<"google-vertex"> = {
+	id: "gemini-3.1-pro-preview",
+	name: "Gemini 3.1 Pro Preview",
+	api: "google-vertex",
+	provider: "google-vertex",
+	baseUrl: "https://{location}-aiplatform.googleapis.com",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1_000_000,
+	maxTokens: 65_536,
+};
+
+describe("issue #1270: Vertex AI global endpoint", () => {
+	const originalApiKey = Bun.env.GOOGLE_CLOUD_API_KEY;
+	const originalCredentials = Bun.env.GOOGLE_APPLICATION_CREDENTIALS;
+
+	afterEach(() => {
+		__resetVertexTokenCache();
+		if (originalApiKey === undefined) delete Bun.env.GOOGLE_CLOUD_API_KEY;
+		else Bun.env.GOOGLE_CLOUD_API_KEY = originalApiKey;
+		if (originalCredentials === undefined) delete Bun.env.GOOGLE_APPLICATION_CREDENTIALS;
+		else Bun.env.GOOGLE_APPLICATION_CREDENTIALS = originalCredentials;
+	});
+
+	it("uses the global Vertex AI service host for locations/global", async () => {
+		delete Bun.env.GOOGLE_CLOUD_API_KEY;
+		delete Bun.env.GOOGLE_APPLICATION_CREDENTIALS;
+
+		const urls: string[] = [];
+		const stream = streamGoogleVertex(model, context, {
+			project: "vertex-project",
+			location: "global",
+			fetch: async input => {
+				const url = input instanceof Request ? input.url : input.toString();
+				urls.push(url);
+				if (url === "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token") {
+					return new Response(JSON.stringify({ access_token: "token", expires_in: 3600 }));
+				}
+				return new Response('{"error":{"message":"stop after capture"}}', { status: 400 });
+			},
+		});
+
+		await stream.result();
+
+		expect(urls).toContain(
+			"https://aiplatform.googleapis.com/v1/projects/vertex-project/locations/global/publishers/google/models/gemini-3.1-pro-preview:streamGenerateContent?alt=sse",
+		);
+	});
+});


### PR DESCRIPTION
## Repro
Calling Gemini through Vertex AI with `GOOGLE_CLOUD_LOCATION=global` builds `https://global-aiplatform.googleapis.com/v1/projects/.../locations/global/publishers/google/models/gemini-3.1-pro-preview:streamGenerateContent`, which reproduces the reported Google 404. Reproduced with `bun --cwd packages/ai test test/issue-1270-repro.test.ts` before the fix: the captured URL used `global-aiplatform.googleapis.com` instead of `aiplatform.googleapis.com`.

## Cause
`packages/ai/src/providers/google-vertex.ts` always derived the Vertex AI host as `${location}-aiplatform.googleapis.com`. That is correct for regional locations, but Vertex AI’s global location uses the shared service host `aiplatform.googleapis.com` with `/locations/global` in the path.

## Fix
- Added host selection for Vertex AI ADC requests so `location === "global"` uses `aiplatform.googleapis.com`.
- Kept regional Vertex AI locations on `${location}-aiplatform.googleapis.com`.
- Added regression coverage for `gemini-3.1-pro-preview` through Vertex AI with `location: "global"`.

## Verification
`bun --cwd=packages/ai test test/issue-1270-repro.test.ts` passed. `bun --cwd=packages/ai run check` passed. Fixes #1270