### PR TITLE
feat(setup): add OpenAI Codex OAuth setup flow + user docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,34 @@ Roles route work by intent. `default` for normal turns. `smol` for cheap subagen
 
 Auth tags below: `oauth` signs in with your provider account, `plan` routes through a coding-plan subscription, `local` runs against a local server with the key optional.
 
+### Codex OAuth quickstart
+
+Use OpenAI Codex via OAuth with one setup command:
+
+```bash
+omp setup codex
+```
+
+What this does:
+
+- If Codex CLI auth already exists at `~/.codex/auth.json`, OMP can import it.
+- Otherwise it starts OpenAI Codex device-code login and stores credentials in OMP auth storage.
+
+Useful flags:
+
+```bash
+omp setup codex --from-codex   # import only from ~/.codex/auth.json
+omp setup codex --device       # force fresh device-code login
+omp setup codex --check        # verify stored/importable Codex credentials
+```
+
+Model switching:
+
+- In-session: `/model`
+- Cycle configured role models: `Ctrl+P`
+
+Full guide: [`docs/codex-oauth.md`](docs/codex-oauth.md)
+
 ### Frontier APIs
 
 Direct APIs and gateways. Mix providers per role.

--- a/docs/codex-oauth.md
+++ b/docs/codex-oauth.md
@@ -1,0 +1,71 @@
+# OpenAI Codex OAuth in OMP
+
+This guide covers setup, login, import behavior, and model switching when using OpenAI Codex OAuth with OMP.
+
+## What `omp setup codex` does
+
+Run:
+
+```bash
+omp setup codex
+```
+
+Behavior:
+
+1. OMP checks whether Codex CLI credentials are present at `~/.codex/auth.json`.
+2. If found, OMP can import those credentials into OMP auth storage.
+3. If not found (or you decline import), OMP starts OpenAI Codex device-code OAuth login.
+4. On success, OMP stores credentials as provider `openai-codex`.
+
+## Explicit setup modes
+
+Import only from Codex CLI:
+
+```bash
+omp setup codex --from-codex
+```
+
+- Succeeds only if `~/.codex/auth.json` exists and is valid.
+- Fails fast if no valid Codex CLI credentials are found.
+
+Force fresh device-code login:
+
+```bash
+omp setup codex --device
+```
+
+- Skips import flow and starts OAuth device-code login directly.
+
+Check status:
+
+```bash
+omp setup codex --check
+```
+
+- Reports whether OMP already has stored Codex credentials.
+- If not stored, reports whether Codex CLI credentials are available to import.
+
+Machine-readable status:
+
+```bash
+omp setup codex --check --json
+```
+
+## If the user already has Codex auth
+
+If `~/.codex/auth.json` is already present, `omp setup codex` can import it and avoid re-login.  
+For non-interactive flows, use `--from-codex`.
+
+## Switching models after login
+
+Once OAuth is set:
+
+- Use `/model` inside a session to switch models.
+- Use `Ctrl+P` to cycle models configured for the active role.
+- Use role flags at launch (`--smol`, `--slow`, `--plan`) to change role-scoped model selection behavior.
+
+## Notes
+
+- Credentials are stored in OMP auth storage (not only read from Codex CLI files).
+- Re-running setup is safe for refresh/import flows.
+- `omp setup` also supports `python` and `stt`; `codex` is dedicated to OpenAI Codex OAuth setup.

--- a/packages/coding-agent/src/cli/setup-cli.ts
+++ b/packages/coding-agent/src/cli/setup-cli.ts
@@ -4,22 +4,32 @@
  * Handles `omp setup <component>` to install dependencies for optional features.
  */
 import * as path from "node:path";
+import * as readline from "node:readline";
+import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
+import {
+	getCodexCliAuthPath,
+	loginOpenAICodexDeviceCode,
+	readCodexCliCredentials,
+} from "@oh-my-pi/pi-ai/utils/oauth/openai-codex";
+import type { OAuthCredentials } from "@oh-my-pi/pi-ai/utils/oauth/types";
 import { $which, APP_NAME, getPythonEnvDir } from "@oh-my-pi/pi-utils";
 import { $ } from "bun";
 import chalk from "chalk";
 import { theme } from "../modes/theme/theme";
 
-export type SetupComponent = "python" | "stt";
+export type SetupComponent = "python" | "stt" | "codex";
 
 export interface SetupCommandArgs {
 	component: SetupComponent;
 	flags: {
 		json?: boolean;
 		check?: boolean;
+		device?: boolean;
+		fromCodex?: boolean;
 	};
 }
 
-const VALID_COMPONENTS: SetupComponent[] = ["python", "stt"];
+const VALID_COMPONENTS: SetupComponent[] = ["python", "stt", "codex"];
 
 const MANAGED_PYTHON_ENV = getPythonEnvDir();
 
@@ -52,6 +62,10 @@ export function parseSetupArgs(args: string[]): SetupCommandArgs | undefined {
 			flags.json = true;
 		} else if (arg === "--check" || arg === "-c") {
 			flags.check = true;
+		} else if (arg === "--device") {
+			flags.device = true;
+		} else if (arg === "--from-codex") {
+			flags.fromCodex = true;
 		}
 	}
 
@@ -111,6 +125,9 @@ async function checkPythonSetup(): Promise<PythonCheckResult> {
  */
 export async function runSetupCommand(cmd: SetupCommandArgs): Promise<void> {
 	switch (cmd.component) {
+		case "codex":
+			await handleCodexSetup(cmd.flags);
+			break;
 		case "python":
 			await handlePythonSetup(cmd.flags);
 			break;
@@ -118,6 +135,120 @@ export async function runSetupCommand(cmd: SetupCommandArgs): Promise<void> {
 			await handleSttSetup(cmd.flags);
 			break;
 	}
+}
+
+interface CodexCheckResult {
+	stored: boolean;
+	codexCliAvailable: boolean;
+	codexCliAuthPath: string;
+}
+
+async function checkCodexSetup(): Promise<CodexCheckResult> {
+	const store = await SqliteAuthCredentialStore.open();
+	try {
+		const authStorage = new AuthStorage(store);
+		await authStorage.reload();
+		const codexCliAuthPath = getCodexCliAuthPath();
+		const codexCliAvailable = Boolean(await readCodexCliCredentials());
+		return {
+			stored: authStorage.hasAuth("openai-codex"),
+			codexCliAvailable,
+			codexCliAuthPath,
+		};
+	} finally {
+		store.close();
+	}
+}
+
+async function persistCodexCredentials(credentials: OAuthCredentials | null): Promise<void> {
+	if (!credentials) return;
+	const store = await SqliteAuthCredentialStore.open();
+	try {
+		const authStorage = new AuthStorage(store);
+		await authStorage.reload();
+		await authStorage.set("openai-codex", { type: "oauth", ...credentials });
+	} finally {
+		store.close();
+	}
+}
+
+async function promptYesNo(message: string, defaultValue: boolean): Promise<boolean> {
+	if (!process.stdin.isTTY) return defaultValue;
+	const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+	const { promise, resolve } = Promise.withResolvers<boolean>();
+	const suffix = defaultValue ? "[Y/n]" : "[y/N]";
+	rl.question(`${message} ${suffix}: `, answer => {
+		rl.close();
+		const normalized = answer.trim().toLowerCase();
+		if (!normalized) {
+			resolve(defaultValue);
+			return;
+		}
+		resolve(normalized === "y" || normalized === "yes");
+	});
+	return promise;
+}
+
+async function handleCodexSetup(flags: {
+	json?: boolean;
+	check?: boolean;
+	device?: boolean;
+	fromCodex?: boolean;
+}): Promise<void> {
+	const check = await checkCodexSetup();
+	if (flags.json) {
+		console.log(JSON.stringify(check, null, 2));
+		if (!check.stored && !check.codexCliAvailable) process.exit(1);
+		return;
+	}
+
+	if (flags.check) {
+		if (check.stored) {
+			console.log(chalk.green(`${theme.status.success} OpenAI Codex credentials are stored`));
+			return;
+		}
+		if (check.codexCliAvailable) {
+			console.log(
+				chalk.green(`${theme.status.success} Codex CLI credentials are available at ${check.codexCliAuthPath}`),
+			);
+			return;
+		}
+		console.error(chalk.red(`${theme.status.error} OpenAI Codex credentials not found`));
+		console.error(chalk.dim(`Run '${APP_NAME} setup codex' or sign in with Codex CLI first.`));
+		process.exit(1);
+	}
+
+	if (flags.fromCodex || !flags.device) {
+		const imported = await readCodexCliCredentials();
+		if (imported) {
+			if (flags.fromCodex || (await promptYesNo("Found Codex CLI credentials. Import them?", false))) {
+				await persistCodexCredentials(imported);
+				console.log(chalk.green(`${theme.status.success} Imported Codex CLI credentials`));
+				console.log(chalk.dim(`Source: ${getCodexCliAuthPath()}`));
+				return;
+			}
+		}
+		if (flags.fromCodex) {
+			console.error(chalk.red(`${theme.status.error} No valid Codex CLI credentials found`));
+			console.error(chalk.dim(`Expected: ${getCodexCliAuthPath()}`));
+			process.exit(1);
+		}
+	}
+
+	console.log(chalk.dim("Signing in to OpenAI Codex with device-code OAuth..."));
+	const credentials = await loginOpenAICodexDeviceCode({
+		onAuth(info) {
+			console.log(`\nOpen this URL in your browser:\n${info.url}`);
+			if (info.instructions) console.log(info.instructions);
+			console.log();
+		},
+		onProgress(message) {
+			console.log(message);
+		},
+		onPrompt: async () => "",
+	});
+	await persistCodexCredentials(credentials);
+	console.log(chalk.green(`${theme.status.success} OpenAI Codex credentials saved`));
 }
 
 async function handlePythonSetup(flags: { json?: boolean; check?: boolean }): Promise<void> {
@@ -213,14 +344,20 @@ ${chalk.bold("Usage:")}
   ${APP_NAME} setup <component> [options]
 
 ${chalk.bold("Components:")}
+  codex    Import Codex CLI credentials or run OpenAI Codex device-code login
   python    Verify a Python 3 interpreter is reachable for code execution
   stt       Install speech-to-text dependencies (openai-whisper, recording tools)
 
 ${chalk.bold("Options:")}
   -c, --check   Check if dependencies are installed without installing
+  --device      For codex: force a fresh OpenAI Codex device-code login
+  --from-codex  For codex: import existing Codex CLI credentials only
   --json        Output status as JSON
 
 ${chalk.bold("Examples:")}
+  ${APP_NAME} setup codex            Import Codex CLI auth if present, otherwise start device-code login
+  ${APP_NAME} setup codex --device   Start a fresh OpenAI Codex device-code login
+  ${APP_NAME} setup codex --from-codex Import credentials from ~/.codex/auth.json
   ${APP_NAME} setup python           Install Python execution dependencies
   ${APP_NAME} setup stt              Install speech-to-text dependencies
   ${APP_NAME} setup stt --check      Check if STT dependencies are available

--- a/packages/coding-agent/src/commands/setup.ts
+++ b/packages/coding-agent/src/commands/setup.ts
@@ -5,7 +5,7 @@ import { Args, Command, Flags, renderCommandHelp } from "@oh-my-pi/pi-utils/cli"
 import { runSetupCommand, type SetupCommandArgs, type SetupComponent } from "../cli/setup-cli";
 import { initTheme } from "../modes/theme/theme";
 
-const COMPONENTS: SetupComponent[] = ["python", "stt"];
+const COMPONENTS: SetupComponent[] = ["python", "stt", "codex"];
 
 export default class Setup extends Command {
 	static description = "Install dependencies for optional features";
@@ -20,6 +20,8 @@ export default class Setup extends Command {
 
 	static flags = {
 		check: Flags.boolean({ char: "c", description: "Check if dependencies are installed" }),
+		device: Flags.boolean({ description: "Force a fresh OpenAI Codex device-code login" }),
+		"from-codex": Flags.boolean({ description: "Import existing Codex CLI credentials from ~/.codex/auth.json" }),
 		json: Flags.boolean({ description: "Output status as JSON" }),
 	};
 
@@ -34,6 +36,8 @@ export default class Setup extends Command {
 			flags: {
 				json: flags.json,
 				check: flags.check,
+				device: flags.device,
+				fromCodex: flags["from-codex"],
 			},
 		};
 		await initTheme();


### PR DESCRIPTION
## Summary

This PR adds a first-class `omp setup codex` flow for OpenAI Codex OAuth and documents the full user setup path.

### What it adds

- New `codex` setup component in `omp setup`
- Codex OAuth flags:
  - `--device` (force fresh device-code login)
  - `--from-codex` (import only from `~/.codex/auth.json`)
- Credential status checks:
  - `omp setup codex --check`
  - `omp setup codex --check --json`
- Import-or-login behavior:
  - If Codex CLI credentials exist, they can be imported.
  - Otherwise OMP runs OpenAI Codex device-code login and stores credentials.
- Documentation:
  - README quickstart section for Codex OAuth
  - New guide: `docs/codex-oauth.md`

## User behavior

`omp setup codex` now supports these seamless paths:

1. **Existing Codex CLI auth present** (`~/.codex/auth.json`): import into OMP.
2. **No local Codex CLI auth**: start device-code OAuth and persist credentials.
3. **Explicit control**:
   - `--from-codex` for strict import-only
   - `--device` for strict fresh OAuth login

## Model switching workflow (documented)

After OAuth setup:

- `/model` to switch active model in-session
- `Ctrl+P` to cycle configured role models
- role launch flags (`--smol`, `--slow`, `--plan`) remain supported

## Files changed

- `packages/coding-agent/src/commands/setup.ts`
- `packages/coding-agent/src/cli/setup-cli.ts`
- `README.md`
- `docs/codex-oauth.md`

## Overlap check

I searched repo issues and PRs for likely duplicates using queries around:

- `codex oauth setup`
- `from-codex`
- `auth.json`

No direct duplicate issues/PRs surfaced via repository search at time of opening.

## Validation

- Typecheck passes for coding agent package:
  - `bun x tsc -p packages/coding-agent/tsconfig.json --noEmit`
