### PR TITLE
fix(ai): prevent Codex OAuth 403 from port-fallback redirect_uri mismatch + device-code flow

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ChatGPT Plus/Pro (Codex) OAuth login returning `Token exchange failed: 403` on Windows. When port 1455 was in use, the callback server silently fell back to a random port; OpenAI's authorization endpoint accepts any localhost redirect URI (loose validation), so the browser callback succeeds and shows "Authentication Successful", but the token endpoint rejects the non-registered port with 403. The `OpenAICodexOAuthFlow` now enforces a fixed `redirectUri` option so a busy port immediately surfaces as "port unavailable" instead of producing a confusing 403 ([#1277](https://github.com/can1357/oh-my-pi/issues/1277)).
+- Improved `exchangeCodeForToken` error diagnostics: the 403 response body (`error` / `error_description` fields) is now included in the thrown message, matching the existing `refreshOpenAICodexToken` behaviour.
+
+### Added
+
+- Added `ChatGPT Plus/Pro (Codex, headless/device)` (`openai-codex-device`) as an alternative login method for the Codex provider. Uses OpenAI's device-code flow (`/api/accounts/deviceauth/usercode` → poll `/api/accounts/deviceauth/token`), which avoids a local callback server and port 1455 entirely. Credentials are stored under the existing `openai-codex` provider key so all models and tooling continue to work without reconfiguration ([#1277](https://github.com/can1357/oh-my-pi/issues/1277)).
+
 ## [15.2.2] - 2026-05-22
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -29,6 +29,7 @@ import { kimiUsageProvider } from "./usage/kimi";
 import { codexRankingStrategy, openaiCodexUsageProvider } from "./usage/openai-codex";
 import { zaiUsageProvider } from "./usage/zai";
 import { getOAuthApiKey, getOAuthProvider, refreshOAuthToken } from "./utils/oauth";
+import { loginOpenAICodexDevice } from "./utils/oauth/openai-codex";
 import type { OAuthController, OAuthCredentials, OAuthProvider, OAuthProviderId } from "./utils/oauth/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1297,6 +1298,14 @@ export class AuthStorage {
 					onManualCodeInput: ctrl.onManualCodeInput ?? manualCodeInput,
 				});
 				break;
+			}
+			case "openai-codex-device": {
+				// Device/headless flow — stores credentials under "openai-codex" so the
+				// provider can pick them up without a separate provider configuration.
+				const deviceCredentials = await loginOpenAICodexDevice(ctrl);
+				const newCredential: OAuthCredential = { type: "oauth", ...deviceCredentials };
+				await this.#upsertOAuthCredential("openai-codex", newCredential);
+				return;
 			}
 			case "gitlab-duo": {
 				const { loginGitLabDuo } = await import("./utils/oauth/gitlab-duo");

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -26,6 +26,11 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		available: true,
 	},
 	{
+		id: "openai-codex-device",
+		name: "ChatGPT Plus/Pro (Codex, headless/device)",
+		available: true,
+	},
+	{
 		id: "gitlab-duo",
 		name: "GitLab Duo",
 		available: true,
@@ -279,7 +284,8 @@ export async function refreshOAuthToken(
 			newCredentials = await refreshAntigravityToken(credentials.refresh, credentials.projectId);
 			break;
 		}
-		case "openai-codex": {
+		case "openai-codex":
+		case "openai-codex-device": {
 			const { refreshOpenAICodexToken } = await import("./openai-codex");
 			newCredentials = await refreshOpenAICodexToken(credentials.refresh);
 			break;

--- a/packages/ai/src/utils/oauth/openai-codex.ts
+++ b/packages/ai/src/utils/oauth/openai-codex.ts
@@ -1,7 +1,7 @@
 /**
- * OpenAI Codex (ChatGPT OAuth) flow
+ * OpenAI Codex (ChatGPT OAuth) flow — browser and device-code flows.
  */
-import { OAuthCallbackFlow } from "./callback-server";
+import { OAuthCallbackFlow, type OAuthCallbackFlowOptions } from "./callback-server";
 import { generatePKCE } from "./pkce";
 import type { OAuthController, OAuthCredentials } from "./types";
 
@@ -14,6 +14,14 @@ const SCOPE = "openid profile email offline_access";
 const JWT_CLAIM_PATH = "https://api.openai.com/auth";
 const JWT_PROFILE_CLAIM = "https://api.openai.com/profile";
 const TOKEN_REQUEST_TIMEOUT_MS = 15_000;
+const DEVICE_USERCODE_URL = "https://auth.openai.com/api/accounts/deviceauth/usercode";
+const DEVICE_TOKEN_URL = "https://auth.openai.com/api/accounts/deviceauth/token";
+const DEVICE_REDIRECT_URI = "https://auth.openai.com/deviceauth/callback";
+const DEVICE_AUTH_URL = "https://auth.openai.com/codex/device";
+const DEVICE_POLL_INTERVAL_MS = 5_000;
+const DEVICE_POLL_SAFETY_MARGIN_MS = 3_000;
+/** Upper bound on device-code polling to avoid infinite loops on server errors. */
+const DEVICE_MAX_POLLS = 120;
 
 type JwtPayload = {
 	[JWT_CLAIM_PATH]?: {
@@ -59,7 +67,15 @@ class OpenAICodexOAuthFlow extends OAuthCallbackFlow {
 		private readonly pkce: PKCE,
 		private readonly originator: string,
 	) {
-		super(ctrl, CALLBACK_PORT, CALLBACK_PATH);
+		super(ctrl, {
+			preferredPort: CALLBACK_PORT,
+			callbackPath: CALLBACK_PATH,
+			// Enforce the fixed port: OpenAI only allows http://localhost:1455/auth/callback.
+			// Without this, a busy port 1455 falls back to a random port, and the token
+			// exchange would fail with 403 because the redirect_uri no longer matches the
+			// registered allowlist entry.
+			redirectUri: `http://localhost:${CALLBACK_PORT}${CALLBACK_PATH}`,
+		} satisfies OAuthCallbackFlowOptions);
 	}
 
 	async generateAuthUrl(state: string, redirectUri: string): Promise<{ url: string; instructions?: string }> {
@@ -100,7 +116,13 @@ async function exchangeCodeForToken(code: string, verifier: string, redirectUri:
 	});
 
 	if (!tokenResponse.ok) {
-		throw new Error(`Token exchange failed: ${tokenResponse.status}`);
+		let detail = `${tokenResponse.status}`;
+		try {
+			const body = (await tokenResponse.json()) as { error?: string; error_description?: string };
+			if (body.error)
+				detail = `${tokenResponse.status} ${body.error}${body.error_description ? `: ${body.error_description}` : ""}`;
+		} catch {}
+		throw new Error(`Token exchange failed: ${detail}`);
 	}
 
 	const tokenData = (await tokenResponse.json()) as {
@@ -141,6 +163,93 @@ export async function loginOpenAICodex(options: OpenAICodexLoginOptions): Promis
 	const flow = new OpenAICodexOAuthFlow(options, pkce, originator);
 
 	return flow.login();
+}
+
+/**
+ * Login with OpenAI Codex using the device-code (headless) flow.
+ *
+ * Avoids a local callback server entirely — useful when port 1455 is unavailable
+ * or when the browser callback flow fails with 403 (e.g. network/proxy issues).
+ */
+export async function loginOpenAICodexDevice(ctrl: OAuthController): Promise<OAuthCredentials> {
+	ctrl.onProgress?.("Initiating device authorization…");
+
+	const initResponse = await fetch(DEVICE_USERCODE_URL, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ client_id: CLIENT_ID }),
+		signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
+	});
+
+	if (!initResponse.ok) {
+		throw new Error(`Device authorization initiation failed: ${initResponse.status}`);
+	}
+
+	const initData = (await initResponse.json()) as {
+		device_auth_id?: string;
+		user_code?: string;
+		interval?: string | number;
+	};
+
+	if (!initData.device_auth_id || !initData.user_code) {
+		throw new Error("Device authorization response missing required fields");
+	}
+
+	const userCode = initData.user_code;
+	const pollIntervalMs =
+		(typeof initData.interval === "number"
+			? initData.interval
+			: parseInt(String(initData.interval ?? "5"), 10) || 5) *
+			1000 +
+		DEVICE_POLL_SAFETY_MARGIN_MS;
+
+	ctrl.onAuth?.({
+		url: DEVICE_AUTH_URL,
+		instructions: `Enter code: ${userCode}`,
+	});
+
+	ctrl.onProgress?.(`Waiting for browser authorization (code: ${userCode})…`);
+
+	for (let poll = 0; poll < DEVICE_MAX_POLLS; poll++) {
+		await Bun.sleep(poll === 0 ? Math.min(pollIntervalMs, DEVICE_POLL_INTERVAL_MS) : pollIntervalMs);
+
+		if (ctrl.signal?.aborted) {
+			throw new Error("Device authorization cancelled");
+		}
+
+		const pollResponse = await fetch(DEVICE_TOKEN_URL, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				device_auth_id: initData.device_auth_id,
+				user_code: userCode,
+			}),
+			signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
+		});
+
+		// 403/404 = authorization pending, keep polling
+		if (pollResponse.status === 403 || pollResponse.status === 404) {
+			continue;
+		}
+
+		if (!pollResponse.ok) {
+			throw new Error(`Device token polling failed: ${pollResponse.status}`);
+		}
+
+		const pollData = (await pollResponse.json()) as {
+			authorization_code?: string;
+			code_verifier?: string;
+		};
+
+		if (!pollData.authorization_code || !pollData.code_verifier) {
+			throw new Error("Device token response missing authorization_code or code_verifier");
+		}
+
+		ctrl.onProgress?.("Exchanging authorization code for tokens…");
+		return exchangeCodeForToken(pollData.authorization_code, pollData.code_verifier, DEVICE_REDIRECT_URI);
+	}
+
+	throw new Error("Device authorization timed out — user did not complete login in time");
 }
 
 /**

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -34,6 +34,7 @@ export type OAuthProvider =
 	| "ollama"
 	| "ollama-cloud"
 	| "openai-codex"
+	| "openai-codex-device"
 	| "opencode-go"
 	| "opencode-zen"
 	| "parallel"


### PR DESCRIPTION
## Repro

On Windows (and any system where port 1455 is in use), `/login` → `ChatGPT Plus/Pro (Codex Subscription)` completes the browser OAuth flow ("Authentication Successful" / "This window will close automatically"), then fails with:

```
Error: Login failed: Token exchange failed: 403
```

Minimal scenario: start any process that occupies port 1455 before running `omp`, then attempt the Codex login.

## Cause

`OAuthCallbackFlow.#startCallbackServer` falls back to a random port when the preferred port (1455) is in use. The auth URL is constructed with `redirect_uri=http://localhost:<RANDOM>/auth/callback`. OpenAI's `/oauth/authorize` applies loose localhost URI validation, so the browser redirect still hits our callback server and the browser page shows "Authentication Successful". But `/oauth/token` enforces the registered allowlist strictly — only `http://localhost:1455/auth/callback` is registered — so it rejects the random port with **403**.

Secondary issues: `exchangeCodeForToken` discarded the 403 response body, hiding the actual `error`/`error_description` fields; and there was no headless fallback for users whose network blocks the browser callback flow.

Code paths:
- `packages/ai/src/utils/oauth/openai-codex.ts` — `OpenAICodexOAuthFlow` constructor, `exchangeCodeForToken`
- `packages/ai/src/utils/oauth/callback-server.ts` — `#startCallbackServer` fallback logic (unchanged, `redirectUri` option already existed)

## Fix

- **`OpenAICodexOAuthFlow` constructor**: pass `redirectUri: "http://localhost:1455/auth/callback"` via `OAuthCallbackFlowOptions`. When port 1455 is busy, `#startCallbackServer` now throws immediately with a clear "port unavailable" error instead of silently using a random port that will fail at token exchange.
- **`exchangeCodeForToken`**: read the response body on non-2xx and include `error`/`error_description` in the thrown message, matching the existing `refreshOpenAICodexToken` error handling.
- **New `openai-codex-device` provider**: implements OpenAI's device-code flow (`POST /api/accounts/deviceauth/usercode` → poll `POST /api/accounts/deviceauth/token` → `POST /oauth/token` with server-supplied `code_verifier` and `redirect_uri=https://auth.openai.com/deviceauth/callback`). No local callback server or port 1455 needed. Credentials are written under `"openai-codex"` so all existing models and tooling work without reconfiguration.

## Verification

- `packages/ai/src/utils/oauth/openai-codex.ts` — constructor, `exchangeCodeForToken`, new `loginOpenAICodexDevice`
- `packages/ai/src/utils/oauth/types.ts` — `"openai-codex-device"` added to `OAuthProvider`
- `packages/ai/src/utils/oauth/index.ts` — device entry in `builtInOAuthProviders`, fallthrough in `refreshOAuthToken`
- `packages/ai/src/auth-storage.ts` — static import `loginOpenAICodexDevice`, new `"openai-codex-device"` switch case

Test suite failures are all pre-existing `Cannot find module '@oh-my-pi/pi-utils'` / `'zod/v4'` module-resolution errors from an uninstalled workspace — they are present identically on `main` and are not caused by this diff.

Fixes #1277