### PR TITLE
fix(clipboard): route image reads through powershell.exe on WSL

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed clipboard image paste (Ctrl+V) silently failing on WSL2 by routing image reads through a `powershell.exe` bridge when WSL interop is detected, since `arboard` returns `ContentNotAvailable` under WSLg ([#1280](https://github.com/can1357/oh-my-pi/issues/1280))
+
 ## [15.2.4] - 2026-05-22
 ### Breaking Changes
 

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -94,10 +94,11 @@ const POWERSHELL_TIMEOUT_MS = 5000;
  */
 async function readImageViaPowerShell(): Promise<ClipboardImage | null> {
 	try {
-		const proc = Bun.spawn(
-			["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", POWERSHELL_IMAGE_SCRIPT],
-			{ stdout: "pipe", stderr: "ignore", stdin: "ignore" },
-		);
+		const proc = Bun.spawn(["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", POWERSHELL_IMAGE_SCRIPT], {
+			stdout: "pipe",
+			stderr: "ignore",
+			stdin: "ignore",
+		});
 		const timer = setTimeout(() => proc.kill(), POWERSHELL_TIMEOUT_MS);
 		let stdout = "";
 		try {

--- a/packages/coding-agent/src/utils/clipboard.ts
+++ b/packages/coding-agent/src/utils/clipboard.ts
@@ -2,7 +2,13 @@ import { execSync } from "node:child_process";
 import type { ClipboardImage } from "@oh-my-pi/pi-natives";
 import * as native from "@oh-my-pi/pi-natives";
 
-const hasDisplay = process.platform !== "linux" || Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+function hasDisplay(): boolean {
+	return process.platform !== "linux" || Boolean(process.env.DISPLAY || process.env.WAYLAND_DISPLAY);
+}
+
+function isWsl(): boolean {
+	return process.platform === "linux" && Boolean(process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP);
+}
 
 /**
  * Copy text to the system clipboard.
@@ -59,11 +65,65 @@ export async function copyToClipboard(text: string): Promise<void> {
 	}
 }
 
+// PowerShell one-liner that emits the clipboard image as base64-encoded PNG on
+// stdout, or nothing when the clipboard does not hold image data. Used as the
+// WSL bridge — arboard cannot read the Windows clipboard through WSLg.
+const POWERSHELL_IMAGE_SCRIPT = `
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+$img = [System.Windows.Forms.Clipboard]::GetImage()
+if ($img -ne $null) {
+	$ms = New-Object System.IO.MemoryStream
+	$img.Save($ms, [System.Drawing.Imaging.ImageFormat]::Png)
+	[Console]::Out.Write([Convert]::ToBase64String($ms.ToArray()))
+}
+`;
+
+const POWERSHELL_TIMEOUT_MS = 5000;
+
+/**
+ * Read a clipboard image through the Windows host's PowerShell.
+ *
+ * WSLg exposes a Wayland socket but no native clipboard image transport, so
+ * `arboard` returns `ContentNotAvailable`. PowerShell, reached via WSL interop,
+ * can read the Windows clipboard directly and round-trip the bitmap as PNG.
+ *
+ * Returns null when no image is on the clipboard, the host PowerShell is
+ * missing, or the bridge times out.
+ */
+async function readImageViaPowerShell(): Promise<ClipboardImage | null> {
+	try {
+		const proc = Bun.spawn(
+			["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", POWERSHELL_IMAGE_SCRIPT],
+			{ stdout: "pipe", stderr: "ignore", stdin: "ignore" },
+		);
+		const timer = setTimeout(() => proc.kill(), POWERSHELL_TIMEOUT_MS);
+		let stdout = "";
+		try {
+			stdout = await new Response(proc.stdout).text();
+			await proc.exited;
+		} finally {
+			clearTimeout(timer);
+		}
+		if (proc.exitCode !== 0) return null;
+		const b64 = stdout.trim();
+		if (!b64) return null;
+		const bytes = Buffer.from(b64, "base64");
+		if (bytes.byteLength === 0) return null;
+		return { data: new Uint8Array(bytes), mimeType: "image/png" };
+	} catch {
+		return null;
+	}
+}
+
 /**
  * Read an image from the system clipboard.
  *
  * Returns null on Termux (no image clipboard support) or when no display
- * server is available (headless/SSH without forwarding).
+ * server is available (headless/SSH without forwarding). Under WSL the
+ * Windows clipboard is reached through `powershell.exe`, since WSLg's
+ * Wayland clipboard does not carry image payloads through to `arboard`.
  *
  * @returns PNG payload or null when no image is available.
  */
@@ -72,7 +132,11 @@ export async function readImageFromClipboard(): Promise<ClipboardImage | null> {
 		return null;
 	}
 
-	if (!hasDisplay) {
+	if (isWsl()) {
+		const image = await readImageViaPowerShell();
+		if (image) return image;
+		// Fall through: arboard may still succeed on a future WSLg release.
+	} else if (!hasDisplay()) {
 		return null;
 	}
 

--- a/packages/coding-agent/test/utils/clipboard.test.ts
+++ b/packages/coding-agent/test/utils/clipboard.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
-import type { Subprocess } from "bun";
 import * as native from "@oh-my-pi/pi-natives";
+import type { Subprocess } from "bun";
 import { readImageFromClipboard } from "../../src/utils/clipboard";
 
 type SpawnOptions = Bun.SpawnOptions.SpawnOptions<

--- a/packages/coding-agent/test/utils/clipboard.test.ts
+++ b/packages/coding-agent/test/utils/clipboard.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { Subprocess } from "bun";
+import * as native from "@oh-my-pi/pi-natives";
+import { readImageFromClipboard } from "../../src/utils/clipboard";
+
+type SpawnOptions = Bun.SpawnOptions.SpawnOptions<
+	Bun.SpawnOptions.Writable,
+	Bun.SpawnOptions.Readable,
+	Bun.SpawnOptions.Readable
+>;
+
+type SpawnCall = { cmd: string[]; options: SpawnOptions };
+
+function streamOf(text: string): ReadableStream<Uint8Array> {
+	const body = new Response(text).body;
+	if (!body) throw new Error("Failed to create response stream.");
+	return body;
+}
+
+function fakeProcess(stdout: string, exitCode = 0): Subprocess {
+	return {
+		pid: 1,
+		stdout: streamOf(stdout),
+		stderr: streamOf(""),
+		exitCode,
+		exited: Promise.resolve(exitCode),
+		kill: () => true,
+	} as unknown as Subprocess;
+}
+
+function spyPowershell(calls: SpawnCall[], stdout: string, exitCode = 0) {
+	function mockSpawn(opts: SpawnOptions & { cmd: string[] }): Subprocess;
+	function mockSpawn(cmd: string[], opts?: SpawnOptions): Subprocess;
+	function mockSpawn(first: string[] | (SpawnOptions & { cmd: string[] }), second?: SpawnOptions): Subprocess {
+		const cmd = Array.isArray(first) ? first : first.cmd;
+		const options = Array.isArray(first) ? (second ?? ({} as SpawnOptions)) : (first as SpawnOptions);
+		calls.push({ cmd, options });
+		return fakeProcess(stdout, exitCode);
+	}
+	return vi.spyOn(Bun, "spawn").mockImplementation(mockSpawn);
+}
+
+const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+
+function setPlatform(value: NodeJS.Platform): void {
+	Object.defineProperty(process, "platform", { value, configurable: true });
+}
+
+function restorePlatform(): void {
+	if (platformDescriptor) Object.defineProperty(process, "platform", platformDescriptor);
+}
+
+const ENV_KEYS = ["WSL_DISTRO_NAME", "WSL_INTEROP", "DISPLAY", "WAYLAND_DISPLAY", "TERMUX_VERSION"] as const;
+let savedEnv: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
+
+beforeEach(() => {
+	savedEnv = {};
+	for (const key of ENV_KEYS) {
+		savedEnv[key] = process.env[key];
+		delete process.env[key];
+	}
+});
+
+afterEach(() => {
+	for (const key of ENV_KEYS) {
+		const prior = savedEnv[key];
+		if (prior === undefined) delete process.env[key];
+		else process.env[key] = prior;
+	}
+	restorePlatform();
+	vi.restoreAllMocks();
+});
+
+// 1x1 red PNG; round-tripped through PowerShell as base64 in the real flow.
+const RED_1X1_PNG_BASE64 =
+	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC";
+
+describe("readImageFromClipboard on WSL", () => {
+	it("decodes the PowerShell base64 payload without touching the native bridge", async () => {
+		setPlatform("linux");
+		process.env.WSL_DISTRO_NAME = "Ubuntu-24.04";
+		process.env.WAYLAND_DISPLAY = "wayland-0";
+
+		const calls: SpawnCall[] = [];
+		spyPowershell(calls, RED_1X1_PNG_BASE64);
+		const nativeSpy = vi.spyOn(native, "readImageFromClipboard");
+
+		const image = await readImageFromClipboard();
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.cmd[0]).toBe("powershell.exe");
+		expect(calls[0]?.cmd).toContain("-NoProfile");
+		expect(image).not.toBeNull();
+		expect(image?.mimeType).toBe("image/png");
+		// PNG magic bytes — proves we actually base64-decoded the payload.
+		expect(Array.from(image!.data.subarray(0, 8))).toEqual([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+		expect(nativeSpy).not.toHaveBeenCalled();
+	});
+
+	it("falls back to the native bridge when PowerShell returns no payload", async () => {
+		setPlatform("linux");
+		process.env.WSL_INTEROP = "/run/WSL/1_interop";
+
+		spyPowershell([], "");
+		const nativeSpy = vi.spyOn(native, "readImageFromClipboard").mockResolvedValue(null);
+
+		const image = await readImageFromClipboard();
+
+		expect(image).toBeNull();
+		expect(nativeSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back to the native bridge when PowerShell exits non-zero", async () => {
+		setPlatform("linux");
+		process.env.WSL_DISTRO_NAME = "Ubuntu";
+
+		spyPowershell([], "noise", 1);
+		const nativeSpy = vi.spyOn(native, "readImageFromClipboard").mockResolvedValue(null);
+
+		await readImageFromClipboard();
+		expect(nativeSpy).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("readImageFromClipboard dispatch", () => {
+	it("returns null on linux without a display server and never spawns PowerShell", async () => {
+		setPlatform("linux");
+		const spawnSpy = vi.spyOn(Bun, "spawn");
+		const nativeSpy = vi.spyOn(native, "readImageFromClipboard");
+
+		expect(await readImageFromClipboard()).toBeNull();
+		expect(spawnSpy).not.toHaveBeenCalled();
+		expect(nativeSpy).not.toHaveBeenCalled();
+	});
+
+	it("delegates straight to the native bridge on non-WSL linux with a display", async () => {
+		setPlatform("linux");
+		process.env.DISPLAY = ":0";
+		const spawnSpy = vi.spyOn(Bun, "spawn");
+		const nativeSpy = vi.spyOn(native, "readImageFromClipboard").mockResolvedValue(null);
+
+		await readImageFromClipboard();
+		expect(spawnSpy).not.toHaveBeenCalled();
+		expect(nativeSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns null on Termux without spawning anything", async () => {
+		setPlatform("linux");
+		process.env.TERMUX_VERSION = "0.118";
+		process.env.WSL_DISTRO_NAME = "Ubuntu";
+		const spawnSpy = vi.spyOn(Bun, "spawn");
+		const nativeSpy = vi.spyOn(native, "readImageFromClipboard");
+
+		expect(await readImageFromClipboard()).toBeNull();
+		expect(spawnSpy).not.toHaveBeenCalled();
+		expect(nativeSpy).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Repro

On WSL2 with WSLg, copy any image to the Windows clipboard (e.g. Win+Shift+S), start `omp`, and press Ctrl+V. Nothing happens — no error, no attachment, just a "No image in clipboard" status. Confirmed via source trace: `WAYLAND_DISPLAY=wayland-0` flips `hasDisplay` true at `packages/coding-agent/src/utils/clipboard.ts:5`, so `readImageFromClipboard()` calls into the native bridge.

## Cause

`crates/pi-natives/src/clipboard.rs:78` maps `arboard::Clipboard::Error::ContentNotAvailable` to `Ok(None)`. WSLg's Wayland clipboard does not carry image payloads from the Windows clipboard through to Linux processes, so `arboard::Clipboard::get_image()` always returns `ContentNotAvailable` under WSLg. `handleImagePaste()` then takes the "No image in clipboard" branch, which the user perceives as a silent failure. There was no WSL detection or PowerShell fallback anywhere in the clipboard path.

## Fix

- `packages/coding-agent/src/utils/clipboard.ts`
  - Detect WSL with `WSL_DISTRO_NAME` / `WSL_INTEROP` (matching the existing detector in `packages/tui/src/terminal.ts`).
  - Add `readImageViaPowerShell()`: spawns `powershell.exe -NoProfile -NonInteractive -Command …` running a small `System.Windows.Forms.Clipboard::GetImage()` script that writes the PNG as base64 on stdout. 5s timeout with `proc.kill()` on overrun, swallows ENOENT / non-zero exits.
  - In `readImageFromClipboard()`, when WSL is detected, try the PowerShell bridge first; fall back to the native bridge (instead of returning `null`) so future WSLg fixes still work.
  - Promote `hasDisplay` / `isWsl` to lazy predicates so tests can flip environment.
- `packages/coding-agent/test/utils/clipboard.test.ts`
  - New test file covering: WSL + base64 payload → returns PNG without touching native; WSL + empty stdout → falls back to native; WSL + non-zero exit → falls back to native; linux headless → null, no spawn; linux + DISPLAY → native bridge only; Termux → null.
- `packages/coding-agent/CHANGELOG.md`
  - Unreleased `### Fixed` entry referencing the issue.

Native crate and other platforms are untouched.

## Verification

```
$ cd packages/coding-agent && bun test test/utils/clipboard.test.ts
 6 pass
 0 fail
 18 expect() calls
$ cd packages/coding-agent && bun run check:types
$ cd packages/coding-agent && bun run lint
```

Manual WSL2 validation is left to the reporter — the PowerShell helper is exercised end-to-end in tests via spawn spies, including the base64 → PNG magic-byte round trip.

Fixes #1280