### PR TITLE
fix(ai): send system prompts via canonical instructions field in responses

### DIFF
--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -391,10 +391,19 @@ function buildParams(
 	const messages: ResponseInput = [...conversationMessages];
 
 	const systemPrompts = normalizeSystemPrompts(context.systemPrompt);
+	// Developer role (reasoning models on api.openai.com / Azure / Copilot) must
+	// go in the input array. For all other endpoints, mirror the Codex variant:
+	// first prompt → canonical `instructions`, extras → input[{role:"system"}].
+	const needsDeveloperRole = model.reasoning && supportsDeveloperRole(resolvedBaseUrl ?? model);
 	if (systemPrompts.length > 0) {
-		const role: "developer" | "system" =
-			model.reasoning && supportsDeveloperRole(resolvedBaseUrl ?? model) ? "developer" : "system";
-		messages.unshift(...systemPrompts.map(systemPrompt => ({ role, content: systemPrompt })));
+		if (needsDeveloperRole) {
+			messages.unshift(...systemPrompts.map(p => ({ role: "developer", content: p })));
+		} else {
+			const extras = systemPrompts.slice(1);
+			if (extras.length > 0) {
+				messages.unshift(...extras.map(p => ({ role: "system", content: p })));
+			}
+		}
 	}
 
 	const cacheRetention = resolveCacheRetention(options?.cacheRetention);
@@ -407,6 +416,7 @@ function buildParams(
 		prompt_cache_retention: promptCacheKey ? getPromptCacheRetention(model.baseUrl, cacheRetention) : undefined,
 		store: false,
 		stream_options: model.provider === "openai" ? { include_obfuscation: false } : undefined,
+		...(systemPrompts.length > 0 && !needsDeveloperRole && { instructions: systemPrompts[0] }),
 	};
 
 	applyCommonResponsesSamplingParams(params, options, model.provider);


### PR DESCRIPTION
Closes #1282.

Mirror the openai-codex-responses provider behavior: when the developer
role is not required (non-reasoning models or non-api.openai.com/azure/
copilot endpoints), use the canonical instructions top-level field
instead of putting system prompts in input[{role: system}].

First system prompt goes to instructions; extras go to input[{role: system}]
to match the Codex variant's semantics and avoid hiding multi-prompt
boundaries from servers that diff/cache on instruction text.

### Branch matrix

| Endpoint | Reasoning | Before | After |
|---|---|---|---|
| api.openai.com | yes | input[developer] | input[developer] (unchanged) |
| api.openai.com | no | input[system] | instructions (+ extras as input[system]) |
| Azure / Copilot | yes | input[developer] | input[developer] (unchanged) |
| Azure / Copilot | no | input[system] | instructions (+ extras) |
| Unknown proxy | any | input[system] | instructions (+ extras) |

### Change

Single file, single function (buildParams in packages/ai/src/providers/openai-responses.ts).

### Open questions from #1282 review

1. Multi-prompt extras go to input[{role: system}]. Acceptable or coalesce?
2. Test coverage — happy to add tests to openai-responses.test.ts if desired.
3. Shared helper extraction between openai-responses and openai-codex-responses — scope creep or desirable?