### PR TITLE
feat(ai): add DeepSeek API key login flow

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1378,6 +1378,12 @@ export class AuthStorage {
 				await saveApiKeyCredential(apiKey);
 				return;
 			}
+			case "deepseek": {
+				const { loginDeepSeek } = await import("./utils/oauth/deepseek");
+				const apiKey = await loginDeepSeek(ctrl);
+				await saveApiKeyCredential(apiKey);
+				return;
+			}
 			case "fireworks": {
 				const { loginFireworks } = await import("./utils/oauth/fireworks");
 				const apiKey = await loginFireworks(ctrl);

--- a/packages/ai/src/utils/oauth/deepseek.ts
+++ b/packages/ai/src/utils/oauth/deepseek.ts
@@ -1,0 +1,16 @@
+/** DeepSeek login flow (API key paste against https://api.deepseek.com). */
+import { createApiKeyLogin } from "./api-key-login";
+
+export const loginDeepSeek = createApiKeyLogin({
+	providerLabel: "DeepSeek",
+	authUrl: "https://platform.deepseek.com/api_keys",
+	instructions: "Copy your API key from the DeepSeek dashboard",
+	promptMessage: "Paste your DeepSeek API key",
+	placeholder: "sk-...",
+	validation: {
+		kind: "chat-completions",
+		provider: "deepseek",
+		baseUrl: "https://api.deepseek.com",
+		model: "deepseek-v4-flash",
+	},
+});

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -56,6 +56,11 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		available: true,
 	},
 	{
+		id: "deepseek",
+		name: "DeepSeek",
+		available: true,
+	},
+	{
 		id: "fireworks",
 		name: "Fireworks",
 		available: true,

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -12,6 +12,7 @@ export type OAuthProvider =
 	| "alibaba-coding-plan"
 	| "anthropic"
 	| "cerebras"
+	| "deepseek"
 	| "cloudflare-ai-gateway"
 	| "cursor"
 	| "fireworks"


### PR DESCRIPTION
## Summary

Add `/login deepseek` support using the existing `createApiKeyLogin` factory — same pattern as Cerebras, Moonshot, Fireworks, etc.

Opens `platform.deepseek.com/api_keys` in the browser, prompts the user to paste their API key, validates it against `deepseek-v4-flash` on `api.deepseek.com`, and stores it in the credential store.

## Changes (4 files, 28 lines)

- `packages/ai/src/utils/oauth/deepseek.ts` — new login flow via `createApiKeyLogin`
- `packages/ai/src/utils/oauth/types.ts` — add `"deepseek"` to `OAuthProvider` union
- `packages/ai/src/utils/oauth/index.ts` — add DeepSeek to `builtInOAuthProviders`
- `packages/ai/src/auth-storage.ts` — add `case "deepseek"` to login switch

## Verification

```ts
const { getOAuthProviders } = await import('./packages/ai/src/utils/oauth/index.ts');
getOAuthProviders().find(p => p.id === 'deepseek');
// { id: 'deepseek', name: 'DeepSeek', available: true }
```

Supersedes #1181 (which has merge conflicts and includes the entire repo history in its diff).