### PR TITLE
fix(tui): preserve /plan text in prompt history

### DIFF
--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -72,6 +72,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		inlineHint: "[prompt]",
 		allowArgs: true,
 		handleTui: async (command, runtime) => {
+			if (command.args) runtime.ctx.editor.addToHistory(command.text);
 			await runtime.ctx.handlePlanModeCommand(command.args || undefined);
 			runtime.ctx.editor.setText("");
 		},

--- a/packages/coding-agent/test/plan-command-history.test.ts
+++ b/packages/coding-agent/test/plan-command-history.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { ModelRegistry } from "../src/config/model-registry";
+import { InteractiveMode } from "../src/modes/interactive-mode";
+import { AgentSession } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
+import { SessionManager } from "../src/session/session-manager";
+import { executeBuiltinSlashCommand } from "../src/slash-commands/builtin-registry";
+
+describe("/plan prompt history", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+	let mode: InteractiveMode;
+
+	beforeAll(() => {
+		initTheme();
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-plan-history-");
+		await Settings.init({ inMemory: true, cwd: tempDir.path() });
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const defaultModel = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!defaultModel) throw new Error("Expected claude-sonnet-4-5 in registry");
+
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model: defaultModel,
+					systemPrompt: ["Test"],
+					tools: [],
+					messages: [],
+				},
+			}),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		mode?.stop();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		resetSettingsForTest();
+	});
+
+	it("keeps active /plan argument text recoverable when exit is canceled", async () => {
+		await mode.handlePlanModeCommand();
+		expect(mode.planModeEnabled).toBe(true);
+
+		const addToHistory = vi.spyOn(mode.editor, "addToHistory");
+		vi.spyOn(mode, "showHookConfirm").mockResolvedValue(false);
+
+		const consumed = await executeBuiltinSlashCommand("/plan long plan draft", {
+			ctx: mode,
+			handleBackgroundCommand: () => {},
+		});
+
+		expect(consumed).toBe(true);
+		expect(mode.planModeEnabled).toBe(true);
+		expect(addToHistory).toHaveBeenCalledWith("/plan long plan draft");
+	});
+});


### PR DESCRIPTION
## Repro
Running `bun test packages/coding-agent/test/plan-command-history.test.ts` reproduced that a `/plan <text>` invocation while plan mode is active is consumed, prompts through `handlePlanModeCommand(<text>)`, clears the editor, and never calls `editor.addToHistory`, leaving the text unrecoverable.

## Cause
`packages/coding-agent/src/slash-commands/builtin-registry.ts` handled the TUI `/plan` builtin by calling `InteractiveMode.handlePlanModeCommand(command.args || undefined)` and then clearing the editor. Because builtin slash commands return before `InputController` reaches normal prompt submission, the usual prompt-history write never ran for consumed `/plan <text>` commands.

## Fix
- Wrote `/plan <text>` to prompt history before dispatching the plan-mode toggle.
- Added regression coverage for the active-plan-mode exit-cancel path so the consumed command remains recoverable.

## Verification
- `bun test packages/coding-agent/test/plan-command-history.test.ts` passed.
- `bun test packages/coding-agent/test/issue-816-repro.test.ts packages/coding-agent/test/plan-command-history.test.ts` passed.
- `bun run check` passed in `packages/coding-agent`.

Fixes #1287