### PR TITLE
fix(coding-agent): apply plan model changes immediately

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed PLAN mode `/model` changes to the Architect role not applying to the active session until exiting and re-entering PLAN mode ([#1286](https://github.com/can1357/oh-my-pi/issues/1286)).
+
 ## [15.2.4] - 2026-05-22
 ### Breaking Changes
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -421,11 +421,19 @@ export class SelectorController {
 							this.ctx.showStatus(`Default model: ${selector ?? model.id}`);
 							// Don't call done() - selector stays open for role assignment
 						} else {
-							// Other roles (smol, slow): just update settings, not current model
+							// Role assignments usually update settings only; active plan mode also updates the session model.
 							this.ctx.settings.setModelRole(
 								role,
 								formatModelSelectorValue(selector ?? `${model.provider}/${model.id}`, thinkingLevel),
 							);
+							if (role === "plan" && this.ctx.session.getPlanModeState()?.enabled) {
+								await this.ctx.session.setModelTemporary(
+									model,
+									thinkingLevel && thinkingLevel !== ThinkingLevel.Inherit ? thinkingLevel : undefined,
+								);
+								this.ctx.statusLine.invalidate();
+								this.ctx.updateEditorBorderColor();
+							}
 							const roleInfo = getRoleInfo(role, settings);
 							const roleLabel = roleInfo?.name ?? role;
 							this.ctx.showStatus(`${roleLabel} model: ${selector ?? model.id}`);

--- a/packages/coding-agent/test/model-selector-plan-mode.test.ts
+++ b/packages/coding-agent/test/model-selector-plan-mode.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { getBundledModel, type Model, modelsAreEqual } from "@oh-my-pi/pi-ai";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ModelSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/model-selector";
+import { SelectorController } from "@oh-my-pi/pi-coding-agent/modes/controllers/selector-controller";
+import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import type { Component } from "@oh-my-pi/pi-tui";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+function expectAnthropicModel(id: string): Model {
+	const model = getBundledModel("anthropic", id);
+	if (!model) throw new Error(`Expected bundled model anthropic/${id}`);
+	return model;
+}
+
+async function flushModelSelection(): Promise<void> {
+	await Bun.sleep(0);
+	await Bun.sleep(0);
+}
+
+describe("model selector in plan mode", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+
+	beforeEach(async () => {
+		const testTheme = await getThemeByName("dark");
+		if (!testTheme) throw new Error("Failed to load dark theme");
+		setThemeInstance(testTheme);
+		tempDir = TempDir.createSync("@pi-plan-model-selector-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+	});
+
+	afterEach(async () => {
+		await session?.dispose();
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	it("applies a changed plan role to the active plan-mode session immediately", async () => {
+		const oldPlan = expectAnthropicModel("claude-sonnet-4-5");
+		const newPlan = expectAnthropicModel("claude-opus-4-1");
+		const settings = Settings.isolated({
+			modelRoles: {
+				plan: `${oldPlan.provider}/${oldPlan.id}`,
+			},
+		});
+		const modelRegistry = new ModelRegistry(authStorage);
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: { model: oldPlan, systemPrompt: ["Test"], tools: [], messages: [] },
+			}),
+			sessionManager: SessionManager.inMemory(tempDir.path()),
+			settings,
+			modelRegistry,
+			scopedModels: [{ model: oldPlan }, { model: newPlan }],
+		});
+		session.setPlanModeState({ enabled: true, planFilePath: "local://PLAN.md" });
+
+		let selector: ModelSelectorComponent | undefined;
+		const editor = {} as Component;
+		const ctx = {
+			editor,
+			editorContainer: {
+				clear: vi.fn(),
+				addChild: vi.fn((component: Component) => {
+					if (component instanceof ModelSelectorComponent) selector = component;
+				}),
+			},
+			ui: {
+				setFocus: vi.fn(),
+				requestRender: vi.fn(),
+			},
+			session,
+			settings,
+			statusLine: { invalidate: vi.fn() },
+			updateEditorBorderColor: vi.fn(),
+			showStatus: vi.fn(),
+			showError: vi.fn(),
+			planModeEnabled: true,
+		} as unknown as InteractiveModeContext;
+
+		new SelectorController(ctx).showModelSelector();
+		await Bun.sleep(0);
+		if (!selector) throw new Error("Expected model selector to be mounted");
+
+		for (const char of "opus") selector.handleInput(char);
+		selector.handleInput("\n");
+		for (let i = 0; i < 4; i++) selector.handleInput("\x1b[B");
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+		await flushModelSelection();
+
+		expect(settings.getModelRole("plan")).toBe(`${newPlan.provider}/${newPlan.id}`);
+		expect(modelsAreEqual(session.model, newPlan)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Repro
Changing the PLAN/Architect model through `/model` while PLAN mode is active updated `settings.modelRoles.plan`, but the running session stayed on the previous plan model until PLAN mode was exited and re-entered. Reproduced with `cd packages/coding-agent && bun test test/model-selector-plan-mode.test.ts`, which failed before the fix because `session.model` did not match the newly selected plan model.

## Cause
`SelectorController.showModelSelector` in `packages/coding-agent/src/modes/controllers/selector-controller.ts` persisted non-default role selections to settings only. PLAN mode applies the plan role only on entry through `InteractiveMode.#applyPlanModeModel`, so changing the `plan` role while already in PLAN mode left the active `AgentSession` on the stale model.

## Fix
- Updated the model selector role path to call `session.setModelTemporary(...)` when the `plan` role changes while PLAN mode is active.
- Preserved normal settings-only behavior for non-active roles and kept `Inherit` thinking from being written as an explicit temporary thinking level.
- Added `test/model-selector-plan-mode.test.ts` to cover `/model` Architect role changes against an active PLAN-mode session.
- Added an Unreleased changelog entry for the coding-agent package.

## Verification
- `cd packages/coding-agent && bun test test/model-selector-plan-mode.test.ts test/model-selector-role-badge-thinking.test.ts` → 2 pass, 0 fail.
- `bun run check:ts` → all workspace checks passed.
- `gh_push_branch` pre-publish gate completed and pushed the branch. Fixes #1286