### PR TITLE
fix(loop-mode): block auto-submit while post-prompt background work is pending

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed loop mode submitting the next prompt while a background async-job delivery turn (idle flush) was still pending, which could cause the job result to be silently dropped and make the session appear to keep firing while work was ongoing ([#1294](https://github.com/can1357/oh-my-pi/issues/1294))
+
 ## [15.2.4] - 2026-05-22
 ### Breaking Changes
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -691,7 +691,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	#isLoopAutoSubmitBlocked(): boolean {
-		return this.session.isStreaming || this.session.isCompacting;
+		return this.session.isStreaming || this.session.isCompacting || this.session.hasPostPromptWork;
 	}
 
 	#submitLoopPromptWhenReady(prompt: string): void {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3573,6 +3573,18 @@ export class AgentSession {
 		return this.#autoCompactionAbortController !== undefined || this.#compactionAbortController !== undefined;
 	}
 
+	/**
+	 * Whether idle-flush tasks, auto-continuations, or other short-lived
+	 * post-prompt work are pending.  True in the brief window after
+	 * `session.prompt()` returns but before a scheduled background delivery
+	 * (e.g. an async-job result) has finished its own streaming turn.
+	 * Loop-mode and similar auto-submit paths should treat this as a block
+	 * to avoid racing against the delivery turn.
+	 */
+	get hasPostPromptWork(): boolean {
+		return this.#postPromptTasks.size > 0;
+	}
+
 	/** All messages including custom types like BashExecutionMessage */
 	get messages(): AgentMessage[] {
 		return this.agent.state.messages;

--- a/packages/coding-agent/test/interactive-mode-loop.test.ts
+++ b/packages/coding-agent/test/interactive-mode-loop.test.ts
@@ -111,4 +111,30 @@ describe("InteractiveMode loop auto-submit", () => {
 		expect(resolved).toHaveLength(1);
 		expect(resolved[0].text).toBe("repeat after compact");
 	});
+
+	it("does not resolve the next loop prompt while post-prompt background work is pending", async () => {
+		vi.useFakeTimers();
+		let hasPendingWork = true;
+		Object.defineProperty(session, "isCompacting", { configurable: true, get: () => false });
+		Object.defineProperty(session, "isStreaming", { configurable: true, get: () => false });
+		Object.defineProperty(session, "hasPostPromptWork", { configurable: true, get: () => hasPendingWork });
+
+		mode.loopModeEnabled = true;
+		mode.loopPrompt = "deliver this";
+		const resolved: SubmittedUserInput[] = [];
+		void mode.getUserInput().then(input => resolved.push(input));
+
+		// Loop timer fires while an idle-flush / delivery turn is still pending.
+		vi.advanceTimersByTime(800);
+		await flushMicrotasks();
+		expect(resolved).toHaveLength(0);
+
+		// Background delivery completes; loop may now fire.
+		hasPendingWork = false;
+		vi.advanceTimersByTime(800);
+		await flushMicrotasks();
+
+		expect(resolved).toHaveLength(1);
+		expect(resolved[0].text).toBe("deliver this");
+	});
 });


### PR DESCRIPTION
## Repro

Enable loop mode, start a task that uses `bash` with `async: true` (or any tool that triggers a background async job), then let the loop run unattended. The loop fires the next prompt in the 1 ms window between when the job-completion callback schedules the idle-flush post-prompt task and when that task actually starts its `agent.prompt()` call — before `isStreaming` has turned true. The `yieldQueue.flush("idle")` then hits `AgentBusyError`, the job result is silently dropped (logged as a warning), and the user sees the session advancing before the background work visibly settled.

Logical reproduction (timing model):

```
tasks.size at getUserInput(): 0
tasks.size after job completion: 1
at loop-fire: current blocked? false   proposed blocked? true
BUG: loop fires while idle flush is pending
```

## Cause

`InteractiveMode.#isLoopAutoSubmitBlocked()` (`interactive-mode.ts:694`) only checked:

```ts
return this.session.isStreaming || this.session.isCompacting;
```

`session.prompt()` drains all post-prompt work via `#waitForPostPromptRecovery()` before returning, so these flags are `false` when `getUserInput()` is called. However, a background async-job can complete *after* `session.prompt()` returns, triggering `yieldQueue.enqueue()` → `scheduleIdleFlush` → `#schedulePostPromptTask(run, {delayMs: 1})`. That call immediately adds an entry to `#postPromptTasks` (before the 1 ms delay fires), so `#postPromptTasks.size > 0` while `isStreaming` is still `false`.

## Fix

- Added `AgentSession.hasPostPromptWork` (`session/agent-session.ts`) — a public getter that returns `this.#postPromptTasks.size > 0`. Documented as the flag for loop-mode and similar auto-submit paths to poll.
- Updated `#isLoopAutoSubmitBlocked()` to include `this.session.hasPostPromptWork`, so the loop defers until the idle flush completes (which includes the delivery streaming turn).
- Added a regression test (`test/interactive-mode-loop.test.ts`) verifying that the loop does not resolve while `hasPostPromptWork` is `true` and does fire once it clears.

## Verification

```
bun test packages/coding-agent/test/interactive-mode-loop.test.ts

 3 pass
 0 fail
Ran 3 tests across 1 file. [847.00ms]
```

`bun run check:ts` passes clean across all packages.

Fixes #1294
