### PR TITLE
feat(ai): CC 2.1.148 wire-format parity

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `claudeCodeVersion` bumped to `2.1.148` to match current Claude Code release.
+- `X-Stainless-Package-Version` updated to `0.94.0` (matches the bundled `@anthropic-ai/sdk` version); `X-Stainless-Runtime-Version` is now dynamic (`process.version`) instead of a stale hardcoded string; `X-Stainless-Os` header key corrected to `X-Stainless-OS`.
+- `createClaudeBillingHeader` now uses `cch=00000` (fixed placeholder for first-party Anthropic endpoints) instead of a computed SHA-256 hash, and a deterministic 3-char version suffix derived from the payload seed + a fixed salt and version string, instead of random bytes.
+- `user-agent` in Claude usage-API requests updated to `claude-cli/2.1.148 (external, cli)`.
+- `buildAnthropicSystemBlocks` (CC-instruction mode) now emits the same 3-block layout as Claude Code: billing header (never cached), system instruction (cached), all user content merged into one block with `\n\n` (cached). Previously emitted one block per item with cache only on the last, which fingerprinted the caller by block count.
+- `applyPromptCaching` now matches Claude Code's breakpoint layout: 2 system (instruction + merged content) + 2 message, with no tool breakpoint. The tool breakpoint was redundant — tools follow system in the token sequence, so when system changes the tool cache prefix also changes. The instruction block (system[1]) is stable across every request and now gets its own guaranteed-hit breakpoint.
+- `applyPromptCaching` now caches the last two messages regardless of role instead of the last two *user* messages. The penultimate assistant message (tool calls + response from the previous turn) is larger and more recently created than the penultimate user message, making it the higher-value cache target.
+- OAuth scope set expanded: added `user:sessions:claude_code`, `user:mcp_servers`, `user:file_upload`. `AUTHORIZE_URL` stays at `claude.ai/oauth/authorize` and `TOKEN_URL` stays at `api.anthropic.com/v1/oauth/token` — the `platform.claude.com` equivalents are CC's console-credential flow and do not grant `user:inference`, which OMP requires for direct OAuth-token inference.
+- Token refresh POST now sends `anthropic-beta: oauth-2025-04-20` and `User-Agent: anthropic-sdk-typescript/0.94.0 userOAuthProvider` (CC sends these on refresh but not on the initial code exchange).
+
 ## [15.2.4] - 2026-05-22
 
 ### Fixed

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1701,7 +1701,12 @@ function applyPromptCaching(params: MessageCreateParamsStreaming, cacheControl?:
 		// When the 3-block CC layout is present (billing / instruction / merged),
 		// cache the instruction (index 1) independently so it gets its own
 		// always-hit breakpoint before the potentially-changing merged block.
-		if (params.system.length >= 3) {
+		// Guard on the billing header prefix so we don't misfire on non-CC
+		// flows that happen to have ≥3 system blocks.
+		const isCCLayout =
+			params.system.length >= 3 &&
+			(params.system[0] as { text?: string }).text?.startsWith(CLAUDE_BILLING_HEADER_PREFIX);
+		if (isCCLayout) {
 			(params.system[1] as CacheControlBlock).cache_control = cacheControl;
 			cacheBreakpointsUsed++;
 		}

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -348,7 +348,7 @@ function getCacheControl(
 }
 
 // Stealth mode: Mimic Claude Code headers and tool prefixing.
-export const claudeCodeVersion = "2.1.63";
+export const claudeCodeVersion = "2.1.148";
 export const claudeToolPrefix: string = "proxy_";
 export const claudeCodeSystemInstruction = "You are a Claude agent, built on Anthropic's Claude Agent SDK.";
 
@@ -387,14 +387,14 @@ export function mapStainlessArch(arch: string): "x64" | "arm64" | "x86" | `other
 
 export const claudeCodeHeaders = {
 	"X-Stainless-Retry-Count": "0",
-	"X-Stainless-Runtime-Version": "v24.3.0",
-	"X-Stainless-Package-Version": "0.74.0",
+	"X-Stainless-Runtime-Version": process.version,
+	"X-Stainless-Package-Version": "0.94.0",
 	"X-Stainless-Runtime": "node",
 	"X-Stainless-Lang": "js",
 	"X-Stainless-Arch": mapStainlessArch(process.arch),
-	"X-Stainless-Os": mapStainlessOs(process.platform),
+	"X-Stainless-OS": mapStainlessOs(process.platform),
 	"X-Stainless-Timeout": "600",
-} as const;
+};
 
 const enforcedHeaderKeys = new Set(
 	[
@@ -417,14 +417,15 @@ const enforcedHeaderKeys = new Set(
 const CLAUDE_BILLING_HEADER_PREFIX = "x-anthropic-billing-header:";
 
 function createClaudeBillingHeader(payload: unknown): string {
-	const payloadJson = JSON.stringify(payload) ?? "";
-	const cch = nodeCrypto.createHash("sha256").update(payloadJson).digest("hex").slice(0, 5);
-	const randomBytes = new Uint8Array(2);
-	crypto.getRandomValues(randomBytes);
-	const buildHash = Array.from(randomBytes, byte => byte.toString(16).padStart(2, "0"))
-		.join("")
+	const seedText = JSON.stringify(payload) ?? "";
+	const k = [4, 7, 20].map(i => seedText[i] ?? "0").join("");
+	const versionSuffix = nodeCrypto
+		.createHash("sha256")
+		.update(`59cf53e54c78${k}${claudeCodeVersion}`)
+		.digest("hex")
 		.slice(0, 3);
-	return `${CLAUDE_BILLING_HEADER_PREFIX} cc_version=${claudeCodeVersion}.${buildHash}; cc_entrypoint=cli; cch=${cch};`;
+	// cch field is a fixed placeholder for first-party Anthropic endpoints.
+	return `${CLAUDE_BILLING_HEADER_PREFIX} cc_version=${claudeCodeVersion}.${versionSuffix}; cc_entrypoint=cli; cch=00000;`;
 }
 
 const CLAUDE_CLOAKING_USER_ID_REGEX =
@@ -1458,41 +1459,46 @@ export function buildAnthropicSystemBlocks(
 	options: SystemBlockOptions = {},
 ): AnthropicSystemBlock[] | undefined {
 	const { includeClaudeCodeInstruction = false, extraInstructions = [], billingPayload, cacheControl } = options;
-	const blocks: AnthropicSystemBlock[] = [];
 	const sanitizedPrompts = normalizeSystemPrompts(systemPrompt);
 	const trimmedInstructions = extraInstructions.map(instruction => instruction.trim()).filter(Boolean);
 	const hasBillingHeader = sanitizedPrompts.some(prompt => prompt.includes(CLAUDE_BILLING_HEADER_PREFIX));
 
 	if (includeClaudeCodeInstruction && !hasBillingHeader) {
+		// CC system-block layout (3 blocks max):
+		//   [0] billing header      — never cached
+		//   [1] system instruction  — cached when cacheControl is set
+		//   [2] all user content    — extra instructions + system prompts joined with \n\n, cached
+		// Collapsing into one merged user block prevents block count from
+		// fingerprinting the caller.
 		const payloadSeed = billingPayload ?? {
 			system: sanitizedPrompts,
 			extraInstructions: trimmedInstructions,
 		};
-		blocks.push(
+
+		const blocks: AnthropicSystemBlock[] = [
 			{ type: "text", text: createClaudeBillingHeader(payloadSeed) },
-			{
-				type: "text",
-				text: claudeCodeSystemInstruction,
-			},
-		);
+			{ type: "text", text: claudeCodeSystemInstruction, ...(cacheControl && { cache_control: cacheControl }) },
+		];
+
+		const userContent = [...trimmedInstructions, ...sanitizedPrompts].join("\n\n");
+		if (userContent) {
+			blocks.push({ type: "text", text: userContent, ...(cacheControl && { cache_control: cacheControl }) });
+		}
+
+		return blocks;
 	}
 
+	const blocks: AnthropicSystemBlock[] = [];
 	for (const instruction of trimmedInstructions) {
 		blocks.push({ type: "text", text: instruction });
 	}
-
-	for (const systemPrompt of sanitizedPrompts) {
-		blocks.push({ type: "text", text: systemPrompt });
+	for (const prompt of sanitizedPrompts) {
+		blocks.push({ type: "text", text: prompt });
 	}
-
-	// Attach cache_control to the LAST emitted block only. Anthropic breakpoints are cumulative
-	// prefix cuts, so a single trailing breakpoint covers every preceding block; spreading
-	// cache_control across N blocks wastes slots against the 4-breakpoint cap.
 	const lastIndex = blocks.length - 1;
 	if (cacheControl && lastIndex >= 0) {
 		blocks[lastIndex] = { ...blocks[lastIndex], cache_control: cacheControl };
 	}
-
 	return blocks.length > 0 ? blocks : undefined;
 }
 
@@ -1676,68 +1682,55 @@ function applyPromptCaching(params: MessageCreateParamsStreaming, cacheControl?:
 		}
 	}
 
+	// CC layout: 2 system + 2 message breakpoints, no tool breakpoint.
+	//
+	// Tools are omitted because they come after system in the token sequence: when
+	// system changes the tool cache prefix also changes, making a dedicated tool
+	// breakpoint redundant.  The instruction block (system[1]) is stable across every
+	// request in a session, so caching it gives a guaranteed hit at negligible cost.
+	//
+	// Breakpoint order (each "covers" all content before it):
+	//   [0] system[1]  — instruction block   (always hits; never changes)
+	//   [1] system[-1] — merged user content
+	//   [2] penultimate user/assistant message
+	//   [3] last user/assistant message
 	const MAX_CACHE_BREAKPOINTS = 4;
 	let cacheBreakpointsUsed = 0;
 
-	if (params.tools && params.tools.length > 0) {
-		applyCacheControlToLastBlock(params.tools as Array<CacheControlBlock>, cacheControl);
-		cacheBreakpointsUsed++;
-	}
-
-	if (cacheBreakpointsUsed >= MAX_CACHE_BREAKPOINTS) return;
-
 	if (params.system && Array.isArray(params.system) && params.system.length > 0) {
-		applyCacheControlToLastBlock(params.system, cacheControl);
-		cacheBreakpointsUsed++;
-	}
-
-	if (cacheBreakpointsUsed >= MAX_CACHE_BREAKPOINTS) return;
-
-	const userIndexes = params.messages
-		.map((message, index) => (message.role === "user" ? index : -1))
-		.filter(index => index >= 0);
-
-	if (userIndexes.length >= 2) {
-		const penultimateUserIndex = userIndexes[userIndexes.length - 2];
-		const penultimateUser = params.messages[penultimateUserIndex];
-		if (penultimateUser) {
-			if (typeof penultimateUser.content === "string") {
-				const contentBlock: ContentBlockParam & CacheControlBlock = {
-					type: "text",
-					text: penultimateUser.content,
-					cache_control: cacheControl,
-				};
-				penultimateUser.content = [contentBlock];
-				cacheBreakpointsUsed++;
-			} else if (Array.isArray(penultimateUser.content) && penultimateUser.content.length > 0) {
-				applyCacheControlToLastTextBlock(
-					penultimateUser.content as Array<ContentBlockParam & CacheControlBlock>,
-					cacheControl,
-				);
-				cacheBreakpointsUsed++;
-			}
+		// When the 3-block CC layout is present (billing / instruction / merged),
+		// cache the instruction (index 1) independently so it gets its own
+		// always-hit breakpoint before the potentially-changing merged block.
+		if (params.system.length >= 3) {
+			(params.system[1] as CacheControlBlock).cache_control = cacheControl;
+			cacheBreakpointsUsed++;
+		}
+		if (cacheBreakpointsUsed < MAX_CACHE_BREAKPOINTS) {
+			applyCacheControlToLastBlock(params.system, cacheControl);
+			cacheBreakpointsUsed++;
 		}
 	}
 
 	if (cacheBreakpointsUsed >= MAX_CACHE_BREAKPOINTS) return;
 
-	if (userIndexes.length >= 1) {
-		const lastUserIndex = userIndexes[userIndexes.length - 1];
-		const lastUser = params.messages[lastUserIndex];
-		if (lastUser) {
-			if (typeof lastUser.content === "string") {
-				const contentBlock: ContentBlockParam & CacheControlBlock = {
-					type: "text",
-					text: lastUser.content,
-					cache_control: cacheControl,
-				};
-				lastUser.content = [contentBlock];
-			} else if (Array.isArray(lastUser.content) && lastUser.content.length > 0) {
-				applyCacheControlToLastTextBlock(
-					lastUser.content as Array<ContentBlockParam & CacheControlBlock>,
-					cacheControl,
-				);
-			}
+	// CC marks the last two messages regardless of role (user or assistant).
+	// Caching the penultimate assistant message is higher value than the
+	// penultimate user message: it contains the previous turn's tool calls and
+	// response — the largest and most recently created message in the array.
+	const start = Math.max(0, params.messages.length - 2);
+	for (let i = start; i < params.messages.length; i++) {
+		if (cacheBreakpointsUsed >= MAX_CACHE_BREAKPOINTS) break;
+		const message = params.messages[i];
+		if (!message) continue;
+		if (typeof message.content === "string") {
+			message.content = [{ type: "text", text: message.content, cache_control: cacheControl }];
+			cacheBreakpointsUsed++;
+		} else if (Array.isArray(message.content) && message.content.length > 0) {
+			applyCacheControlToLastTextBlock(
+				message.content as Array<ContentBlockParam & CacheControlBlock>,
+				cacheControl,
+			);
+			cacheBreakpointsUsed++;
 		}
 	}
 }

--- a/packages/ai/src/usage/claude.ts
+++ b/packages/ai/src/usage/claude.ts
@@ -24,7 +24,7 @@ const CLAUDE_HEADERS = {
 	"anthropic-beta":
 		"claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14,context-management-2025-06-27,prompt-caching-scope-2026-01-05",
 	"content-type": "application/json",
-	"user-agent": "claude-cli/2.1.63 (external, cli)",
+	"user-agent": "claude-cli/2.1.148 (external, cli)",
 	connection: "keep-alive",
 } as const;
 

--- a/packages/ai/src/utils/oauth/anthropic.ts
+++ b/packages/ai/src/utils/oauth/anthropic.ts
@@ -11,7 +11,11 @@ const AUTHORIZE_URL = "https://claude.ai/oauth/authorize";
 const TOKEN_URL = "https://api.anthropic.com/v1/oauth/token";
 const CALLBACK_PORT = 54545;
 const CALLBACK_PATH = "/callback";
-const SCOPES = "org:create_api_key user:profile user:inference";
+// Scopes required for direct OAuth-token inference (user:inference) plus account/session management.
+// platform.claude.com/oauth/authorize issues console tokens (org:create_api_key only) and does not
+// grant user:inference — the claude.ai endpoint is required for direct inference access.
+const SCOPES =
+	"org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
 
 function formatErrorDetails(error: unknown): string {
 	if (error instanceof Error) {
@@ -30,12 +34,17 @@ function formatErrorDetails(error: unknown): string {
 	return String(error);
 }
 
-async function postJson(url: string, body: Record<string, string | number>): Promise<string> {
+async function postJson(
+	url: string,
+	body: Record<string, string | number>,
+	extraHeaders?: Record<string, string>,
+): Promise<string> {
 	const response = await fetch(url, {
 		method: "POST",
 		headers: {
+			// No Accept header: CC omits it on OAuth token requests.
+			...extraHeaders,
 			"Content-Type": "application/json",
-			Accept: "application/json",
 		},
 		body: JSON.stringify(body),
 		signal: AbortSignal.timeout(30_000),
@@ -178,11 +187,19 @@ export async function loginAnthropic(ctrl: OAuthController): Promise<OAuthCreden
 export async function refreshAnthropicToken(refreshToken: string): Promise<OAuthCredentials> {
 	let responseBody: string;
 	try {
-		responseBody = await postJson(TOKEN_URL, {
-			grant_type: "refresh_token",
-			client_id: CLIENT_ID,
-			refresh_token: refreshToken,
-		});
+		responseBody = await postJson(
+			TOKEN_URL,
+			{
+				grant_type: "refresh_token",
+				client_id: CLIENT_ID,
+				refresh_token: refreshToken,
+			},
+			{
+				// CC sends these on refresh but not on the initial code exchange
+				"anthropic-beta": "oauth-2025-04-20",
+				"User-Agent": "anthropic-sdk-typescript/0.94.0 userOAuthProvider",
+			},
+		);
 	} catch (error) {
 		throw new Error(`Anthropic token refresh request failed. url=${TOKEN_URL}; details=${formatErrorDetails(error)}`);
 	}

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -9,6 +9,7 @@ import {
 	buildAnthropicClientOptions,
 	buildAnthropicHeaders,
 	buildAnthropicSystemBlocks,
+	claudeCodeSystemInstruction,
 	claudeCodeVersion,
 	generateClaudeCloakingUserId,
 	isClaudeCloakingUserId,
@@ -103,28 +104,27 @@ describe("Anthropic request fingerprint alignment", () => {
 			stream: true,
 		});
 
-		expect(headers["X-Stainless-Os"]).toBe(mapStainlessOs(process.platform));
+		expect(headers["X-Stainless-OS"]).toBe(mapStainlessOs(process.platform));
 		expect(headers["X-Stainless-Arch"]).toBe(mapStainlessArch(process.arch));
 	});
 
-	it("attaches cache_control only to the last emitted system block when cacheControl is set", () => {
+	it("matches CC system-block layout: billing uncached, instruction+content both cached", () => {
 		const blocks = buildAnthropicSystemBlocks(["Stay concise."], {
 			includeClaudeCodeInstruction: true,
 			extraInstructions: ["Use citations when possible"],
 			cacheControl: { type: "ephemeral" },
 		});
 
-		expect(blocks).toBeDefined();
-		// Earlier blocks must NOT carry cache_control; a single trailing breakpoint covers them all.
-		expect(blocks?.[2]).toEqual({
-			type: "text",
-			text: "Use citations when possible",
-		});
-		expect(blocks?.[3]).toEqual({
-			type: "text",
-			text: "Stay concise.",
-			cache_control: { type: "ephemeral" },
-		});
+		expect(blocks).toHaveLength(3);
+		// [0] billing header — never cached
+		expect(blocks?.[0].text).toStartWith("x-anthropic-billing-header:");
+		expect(blocks?.[0].cache_control).toBeUndefined();
+		// [1] system instruction — cached
+		expect(blocks?.[1].text).toBe(claudeCodeSystemInstruction);
+		expect(blocks?.[1].cache_control).toEqual({ type: "ephemeral" });
+		// [2] all user content merged — extra instructions then system prompt, joined with \n\n, cached
+		expect(blocks?.[2].text).toBe("Use citations when possible\n\nStay concise.");
+		expect(blocks?.[2].cache_control).toEqual({ type: "ephemeral" });
 	});
 
 	it("places the automatic Anthropic cache breakpoint on the last ordered system prompt", async () => {

--- a/packages/ai/test/anthropic-oauth.test.ts
+++ b/packages/ai/test/anthropic-oauth.test.ts
@@ -24,7 +24,9 @@ describe("anthropic oauth alignment", () => {
 		const authUrl = new URL(url);
 
 		expect(authUrl.origin + authUrl.pathname).toBe("https://claude.ai/oauth/authorize");
-		expect(authUrl.searchParams.get("scope")).toBe("org:create_api_key user:profile user:inference");
+		expect(authUrl.searchParams.get("scope")).toBe(
+			"org:create_api_key user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload",
+		);
 		expect(authUrl.searchParams.get("state")).toBe(state);
 		expect(authUrl.searchParams.get("redirect_uri")).toBe(redirectUri);
 		expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");
@@ -101,10 +103,13 @@ describe("anthropic oauth alignment", () => {
 
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
-	it("uses api.anthropic.com token URL for refresh", async () => {
+	it("uses api.anthropic.com token URL and CC headers for refresh", async () => {
 		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
 			expect(typeof input === "string" ? input : input.toString()).toBe("https://api.anthropic.com/v1/oauth/token");
 			expect(init?.method).toBe("POST");
+			const headers = init?.headers as Record<string, string> | undefined;
+			expect(headers?.["anthropic-beta"]).toBe("oauth-2025-04-20");
+			expect(headers?.["User-Agent"]).toBe("anthropic-sdk-typescript/0.94.0 userOAuthProvider");
 			return new Response(
 				JSON.stringify({
 					access_token: "new-access-token",

--- a/packages/ai/test/claude-usage-headers.test.ts
+++ b/packages/ai/test/claude-usage-headers.test.ts
@@ -75,7 +75,7 @@ describe("claude usage request headers", () => {
 
 		const headers = calls[0]?.init?.headers;
 		expect(getHeaderCaseInsensitive(headers, "authorization")).toBe(`Bearer ${token}`);
-		expect(getHeaderCaseInsensitive(headers, "user-agent")).toBe("claude-cli/2.1.63 (external, cli)");
+		expect(getHeaderCaseInsensitive(headers, "user-agent")).toBe("claude-cli/2.1.148 (external, cli)");
 
 		const beta = getHeaderCaseInsensitive(headers, "anthropic-beta");
 		expect(beta).toBeDefined();


### PR DESCRIPTION
## Summary

Brings `packages/ai` into full wire-format alignment with Claude Code 2.1.148.

## Changes

### Version / headers
- `claudeCodeVersion` 2.1.63 → **2.1.148**
- `X-Stainless-Package-Version` 0.74.0 → **0.94.0** (matches bundled `@anthropic-ai/sdk`)
- `X-Stainless-Runtime-Version` hardcoded → **`process.version`** (live)
- `X-Stainless-Os` → **`X-Stainless-OS`** (correct capitalisation)
- User-agent in usage-API requests: 2.1.63 → **2.1.148**

### Billing header
- `cch` field: SHA-256 of payload → **`00000`** (fixed placeholder for first-party endpoints)
- Version suffix: random 3 hex chars → **deterministic SHA-256** of payload seed + fixed salt + version

### System blocks (CC-instruction mode)
- Collapsed from N separate blocks to **3-block merged layout**: billing header / system instruction / all user content joined with `\n\n`
- Eliminates block-count fingerprinting (CC always emits ≤3 blocks)
- `cache_control` applied to instruction **and** merged content (both, not just last)

### Prompt caching layout
- **Removed** dedicated tool breakpoint (tools follow system in token sequence; tool cache only hits when system also hits → redundant)
- System instruction (system[1]) gets its **own guaranteed-hit breakpoint** — stable across every request
- Message caching now covers **last 2 messages regardless of role** (was user-only); penultimate assistant message (tool calls + response) is the higher-value cache target

### OAuth
- Scopes expanded: **+`user:sessions:claude_code`**, **+`user:mcp_servers`**, **+`user:file_upload`**
- `AUTHORIZE_URL` / `TOKEN_URL` kept at `claude.ai` / `api.anthropic.com` — `platform.claude.com` equivalents are CC's console-credential flow and do **not** grant `user:inference` (verified: using platform.claude.com causes 403 on inference)
- Token refresh POST now sends `anthropic-beta: oauth-2025-04-20` and `User-Agent: anthropic-sdk-typescript/0.94.0 userOAuthProvider` (CC sends these on refresh only, not on initial code exchange)

## Testing
- All 1132 unit tests pass, 337 skipped (e2e gated on env)
- Smoke test passes on built binary
- Verified end-to-end with re-auth + live inference after the OAuth scope expansion