### PR TITLE
fix(tui): preserve terminal scrollback when above-viewport content changes

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed TUI differential renderer clearing terminal scrollback (`\x1b[3J`) when a component above the viewport updates (e.g. bash tool output streaming past the visible area). The renderer now clamps the repaint range to the viewport top instead of issuing a full redraw, preserving the user's scroll history. ([#1300](https://github.com/can1357/oh-my-pi/issues/1300))
+
 ## [15.2.3] - 2026-05-22
 ### Added
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1204,12 +1204,16 @@ export class TUI extends Container {
 		}
 
 		// Differential rendering can only touch what was actually visible.
-		// Any change above the previous viewport requires a full redraw so terminal
-		// scrollback ends up consistent with the new transcript state.
+		// Any change above the previous viewport cannot be reached with cursor
+		// movement sequences — the cursor cannot enter the terminal scrollback.
+		// Clamp firstChanged to the viewport top so the differential renderer
+		// operates within reachable screen rows. The scrollback entries above
+		// the viewport will be momentarily stale but remain navigable — this
+		// preserves the user's browse position instead of wiping scrollback
+		// with \x1b[3J.
 		if (firstChanged < prevViewportTop) {
-			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
-			fullRender(true);
-			return;
+			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop}), clamping`);
+			firstChanged = prevViewportTop;
 		}
 
 		// Render from first changed line to end

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -766,6 +766,49 @@ describe("TUI terminal-state regressions", () => {
 				tui.stop();
 			}
 		});
+
+		it("preserves scrollback when above-viewport content changes (no \x1b[3J)", async () => {
+			// 3-row terminal, 6 lines of content: top-* fills rows 0-2 (→ scrollback),
+			// bot-* fills rows 3-5 (→ visible). Changing the top component triggers
+			// firstChanged < prevViewportTop. The fix must NOT send \x1b[3J so the
+			// user's scrollback (top-A, top-B, top-C) survives the repaint.
+			const term = new VirtualTerminal(32, 3);
+			const tui = new TUI(term);
+			const top = new MutableLinesComponent(["top-A", "top-B", "top-C"]);
+			const bottom = new MutableLinesComponent(["bot-0", "bot-1", "bot-2"]);
+			tui.addChild(top);
+			tui.addChild(bottom);
+
+			try {
+				tui.start();
+				await settle(term);
+
+				// Verify initial state: top rows are in scrollback, bottom rows visible.
+				const scrollbackBefore = term.getScrollBuffer().join("\n");
+				expect(scrollbackBefore).toContain("top-A");
+				expect(scrollbackBefore).toContain("top-B");
+				expect(visible(term)[0]?.trim()).toBe("bot-0");
+
+				// Mutate the above-viewport component.
+				// firstChanged = 0 < prevViewportTop = 3 → triggers above-viewport path.
+				top.setLines(["top-X", "top-Y", "top-Z"]);
+				tui.requestRender();
+				await settle(term);
+
+				// The original scrollback content must survive — \x1b[3J was NOT sent.
+				const scrollbackAfter = term.getScrollBuffer().join("\n");
+				expect(scrollbackAfter).toContain("top-A");
+				expect(scrollbackAfter).toContain("top-B");
+
+				// Viewport must reflect current state correctly.
+				const viewport = visible(term);
+				expect(viewport[0]?.trim()).toBe("bot-0");
+				expect(viewport[1]?.trim()).toBe("bot-1");
+				expect(viewport[2]?.trim()).toBe("bot-2");
+			} finally {
+				tui.stop();
+			}
+		});
 	});
 
 	describe("overlay compositing", () => {


### PR DESCRIPTION
## Repro

Have the model invoke the bash tool while the user has scrolled the terminal to view earlier conversation content. As bash output streams in, the browsing position jumps to the very top (terminal scrollback wiped).

Reproducible on any terminal where the bash execution component has grown taller than `terminalHeight − (statusContainer + editor lines)` — typically around 30 lines — causing each new output chunk to trigger the above-viewport redraw path.

## Cause

In `packages/tui/src/tui.ts`, `#doRender()` computes `prevViewportTop = maxLinesRendered − terminalHeight`. When any line at index `< prevViewportTop` changes (i.e. above the currently visible screen), the renderer falls back to `fullRender(true)`, which emits `\x1b[2J\x1b[H\x1b[3J`. The `\x1b[3J` sequence erases the entire terminal scrollback buffer, destroying whatever scroll position the user had.

The trigger for bash output specifically: `BashExecutionComponent` is appended to `chatContainer`. As its streaming output fills the collapsed 20-line preview and pushes `prevViewportTop` past the component's start index, every subsequent spinner tick (80 ms) or output chunk sets `firstChanged < prevViewportTop`, invoking `fullRender(true)` and clearing scrollback on every frame.

## Fix

- **`packages/tui/src/tui.ts`** — Replace `fullRender(true)` in the `firstChanged < prevViewportTop` branch with a clamp: set `firstChanged = prevViewportTop` and fall through to the existing differential renderer. The differential renderer operates only within reachable screen rows; natural `\r\n` scrolling advances the viewport and adds lines to scrollback as content grows. Scrollback entries above the clamped boundary remain momentarily stale but navigable, and are corrected on the next height-change or force-render. `\x1b[3J` is never sent for this case.
- **`packages/tui/test/render-regressions.test.ts`** — Added a regression test `"preserves scrollback when above-viewport content changes (no \x1b[3J)"` that verifies old scrollback content (`top-A`, `top-B`) survives a mutation to a component above the viewport, and that the visible screen shows the correct bottom rows.
- **`packages/tui/CHANGELOG.md`** — Entry under `[Unreleased]`.

## Verification

```
cd packages/tui && bun test test/render-regressions.test.ts
# 25 pass, 0 fail
bun run check
# no type errors
```

The new regression test directly exercises the `firstChanged < prevViewportTop` code path and asserts that scrollback entries are not cleared.

`Fixes #1300`