### PR TITLE
feat(tui/editor): add keyboard text selection

### DIFF
--- a/packages/tui/src/components/editor-selection.ts
+++ b/packages/tui/src/components/editor-selection.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure helpers for editor text selection geometry.
+ *
+ * These operate on logical lines/columns and have no dependency on rendering,
+ * so they can be unit-tested in isolation and reused by a future mouse-selection
+ * path. Columns are character (code-unit) offsets within a line, matching the
+ * editor's `cursorCol`.
+ */
+
+export interface Pos {
+	line: number;
+	col: number;
+}
+
+export interface SelectionRange {
+	start: Pos;
+	end: Pos;
+}
+
+/** True when `a` comes strictly before `b` in document order. */
+function isBefore(a: Pos, b: Pos): boolean {
+	return a.line < b.line || (a.line === b.line && a.col < b.col);
+}
+
+/** Order two endpoints into a document-ordered range (`start <= end`). */
+export function normalizeRange(anchor: Pos, cursor: Pos): SelectionRange {
+	return isBefore(cursor, anchor)
+		? { start: { ...cursor }, end: { ...anchor } }
+		: { start: { ...anchor }, end: { ...cursor } };
+}
+
+/** True when the range covers no characters. */
+export function isEmptyRange(range: SelectionRange): boolean {
+	return range.start.line === range.end.line && range.start.col === range.end.col;
+}
+
+/** Extract the selected text, joining across lines with `\n`. */
+export function getSelectedText(lines: string[], range: SelectionRange): string {
+	const { start, end } = range;
+	if (start.line === end.line) {
+		return (lines[start.line] ?? "").slice(start.col, end.col);
+	}
+	const parts: string[] = [(lines[start.line] ?? "").slice(start.col)];
+	for (let i = start.line + 1; i < end.line; i++) {
+		parts.push(lines[i] ?? "");
+	}
+	parts.push((lines[end.line] ?? "").slice(0, end.col));
+	return parts.join("\n");
+}
+
+/**
+ * Remove the range from `lines`, returning a new array and the resulting cursor
+ * position (always `range.start`). Does not mutate the input.
+ */
+export function deleteRange(lines: string[], range: SelectionRange): { lines: string[]; cursor: Pos } {
+	const { start, end } = range;
+	const next = lines.slice();
+	if (start.line === end.line) {
+		const line = lines[start.line] ?? "";
+		next[start.line] = line.slice(0, start.col) + line.slice(end.col);
+	} else {
+		const merged = (lines[start.line] ?? "").slice(0, start.col) + (lines[end.line] ?? "").slice(end.col);
+		next.splice(start.line, end.line - start.line + 1, merged);
+	}
+	return { lines: next, cursor: { line: start.line, col: start.col } };
+}

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1,6 +1,14 @@
 import { getProjectDir, logger } from "@oh-my-pi/pi-utils";
 import type { AutocompleteProvider, CombinedAutocompleteProvider } from "../autocomplete";
 import { BracketedPasteHandler } from "../bracketed-paste";
+import {
+	deleteRange,
+	getSelectedText as getSelectedTextInRange,
+	isEmptyRange,
+	normalizeRange,
+	type Pos,
+	type SelectionRange,
+} from "./editor-selection";
 import { getKeybindings, type KeybindingsManager } from "../keybindings";
 import { extractPrintableText, matchesKey } from "../keys";
 import { KillRing } from "../kill-ring";
@@ -273,18 +281,26 @@ interface EditorState {
 	lines: string[];
 	cursorLine: number;
 	cursorCol: number;
+	/** Fixed end of an active selection; the moving end is the cursor. Null when nothing is selected. */
+	selectionAnchor: Pos | null;
 }
 
 interface LayoutLine {
 	text: string;
 	hasCursor: boolean;
 	cursorPos?: number;
+	/** Logical line index this visual line belongs to. */
+	logicalLine: number;
+	/** Logical column where this visual line's text begins (0 unless word-wrapped). */
+	startCol: number;
 }
 
 export interface EditorTheme {
 	borderColor: (str: string) => string;
 	selectList: SelectListTheme;
 	symbols: SymbolTheme;
+	/** Style function for the active text selection. Falls back to a reverse-of-background default. */
+	selection?: (str: string) => string;
 	editorPaddingX?: number;
 	/** Style function for inline hint/ghost text (dim text after cursor) */
 	hintStyle?: (text: string) => string;
@@ -313,6 +329,7 @@ export class Editor implements Component, Focusable {
 		lines: [""],
 		cursorLine: 0,
 		cursorCol: 0,
+		selectionAnchor: null,
 	};
 
 	/** Focusable interface - set by TUI when focus changes */
@@ -342,6 +359,10 @@ export class Editor implements Component, Focusable {
 
 	// Preferred visual column for vertical cursor movement (sticky column)
 	#preferredVisualCol: number | null = null;
+
+	// True while a shift+movement is extending the selection; suppresses the
+	// auto-clear that plain cursor movement otherwise performs.
+	#extending = false;
 
 	// Border color (can be changed dynamically)
 	borderColor: (str: string) => string;
@@ -673,6 +694,33 @@ export class Editor implements Component, Focusable {
 		this.#scrollOffset = Math.min(this.#scrollOffset, maxOffset);
 	}
 
+	/** Selected sub-range within a layout line's text, in code-unit indices, or null. */
+	#selectionSpanFor(layoutLine: LayoutLine): { from: number; to: number } | null {
+		const range = this.getSelection();
+		if (!range) return null;
+		const { logicalLine, startCol } = layoutLine;
+		if (logicalLine < range.start.line || logicalLine > range.end.line) return null;
+		const lineLen = layoutLine.text.length;
+		const selStartCol = logicalLine === range.start.line ? range.start.col : 0;
+		const selEndCol = logicalLine === range.end.line ? range.end.col : startCol + lineLen;
+		const from = Math.max(0, Math.min(selStartCol - startCol, lineLen));
+		const to = Math.max(0, Math.min(selEndCol - startCol, lineLen));
+		return to > from ? { from, to } : null;
+	}
+
+	/** Wrap `text[from:to)` in the selection style. */
+	#styleRange(text: string, from: number, to: number): string {
+		const style = this.#theme.selection ?? ((t: string) => `\x1b[100m${t}\x1b[0m`);
+		return text.slice(0, from) + style(text.slice(from, to)) + text.slice(to);
+	}
+
+	/** Style the part of `segment` (which starts at `segStartCol`) covered by `selSpan`. */
+	#styleSelectionInSegment(segment: string, segStartCol: number, selSpan: { from: number; to: number }): string {
+		const from = Math.max(0, selSpan.from - segStartCol);
+		const to = Math.min(segment.length, selSpan.to - segStartCol);
+		return to > from ? this.#styleRange(segment, from, to) : segment;
+	}
+
 	render(width: number): string[] {
 		const paddingX = this.#getEditorPaddingX();
 		const borderVisible = this.#borderVisible;
@@ -729,6 +777,8 @@ export class Editor implements Component, Focusable {
 
 		for (let visibleIndex = 0; visibleIndex < visibleLayoutLines.length; visibleIndex++) {
 			const layoutLine = visibleLayoutLines[visibleIndex]!;
+			const selSpan = this.#selectionSpanFor(layoutLine);
+			let selectionApplied = false;
 			let displayText = layoutLine.text;
 			let displayWidth = visibleWidth(layoutLine.text);
 			let cursorInPadding = false;
@@ -786,8 +836,13 @@ export class Editor implements Component, Focusable {
 
 			if (hasCursor && this.#useTerminalCursor) {
 				if (marker) {
-					const before = displayText.slice(0, layoutLine.cursorPos);
-					const after = displayText.slice(layoutLine.cursorPos);
+					let before = displayText.slice(0, layoutLine.cursorPos);
+					let after = displayText.slice(layoutLine.cursorPos);
+					if (selSpan) {
+						before = this.#styleSelectionInSegment(before, 0, selSpan);
+						after = this.#styleSelectionInSegment(after, layoutLine.cursorPos ?? 0, selSpan);
+						selectionApplied = true;
+					}
 					if (after.length === 0 && inlineHint) {
 						const hintText = hintStyle(truncateToWidth(inlineHint, Math.max(0, lineContentWidth - displayWidth)));
 						displayText = before + marker + hintText;
@@ -799,15 +854,27 @@ export class Editor implements Component, Focusable {
 					}
 				}
 			} else if (hasCursor && !this.#useTerminalCursor) {
-				const before = displayText.slice(0, layoutLine.cursorPos);
+				let before = displayText.slice(0, layoutLine.cursorPos);
 				const after = displayText.slice(layoutLine.cursorPos);
+				if (selSpan) {
+					before = this.#styleSelectionInSegment(before, 0, selSpan);
+					selectionApplied = true;
+				}
 
 				if (after.length > 0) {
 					// Cursor is on a character (grapheme) - replace it with highlighted version
 					// Get the first grapheme from 'after'
 					const afterGraphemes = [...segmenter.segment(after)];
 					const firstGrapheme = afterGraphemes[0]?.segment || "";
-					const restAfter = after.slice(firstGrapheme.length);
+					let restAfter = after.slice(firstGrapheme.length);
+					if (selSpan) {
+						// The cursor grapheme renders as the caret; style the selected remainder.
+						restAfter = this.#styleSelectionInSegment(
+							restAfter,
+							(layoutLine.cursorPos ?? 0) + firstGrapheme.length,
+							selSpan,
+						);
+					}
 					const cursor = `\x1b[7m${firstGrapheme}\x1b[0m`;
 					displayText = before + marker + cursor + restAfter;
 					// displayWidth stays the same - we're replacing, not adding
@@ -854,6 +921,11 @@ export class Editor implements Component, Focusable {
 						cursorInPadding = true;
 					}
 				}
+			}
+
+			// Lines (or unfocused hardware-cursor lines) not handled above: highlight in place.
+			if (selSpan && !selectionApplied) {
+				displayText = this.#styleRange(displayText, selSpan.from, selSpan.to);
 			}
 
 			const linePad = padding(Math.max(0, lineContentWidth - displayWidth));
@@ -1067,6 +1139,16 @@ export class Editor implements Component, Focusable {
 		}
 
 		// Continue with rest of input handling
+
+		// Text selection: shift+movement extends; Escape clears an active selection.
+		if (this.#handleExtendSelection(data, kb)) {
+			return;
+		}
+		if (this.#hasSelection() && matchesKey(data, "escape")) {
+			this.#clearSelection();
+			return;
+		}
+
 		// Ctrl+K - Delete to end of line
 		if (matchesKey(data, "ctrl+k")) {
 			this.#deleteToEndOfLine();
@@ -1181,6 +1263,7 @@ export class Editor implements Component, Focusable {
 		}
 		// Page navigation (PageUp/PageDown)
 		else if (kb.matches(data, "tui.editor.pageUp")) {
+			this.#clearSelection();
 			if (this.#isEditorEmpty()) {
 				this.#navigateHistory(-1);
 			} else if (this.#historyIndex > -1 && this.#isOnFirstVisualLine()) {
@@ -1189,6 +1272,7 @@ export class Editor implements Component, Focusable {
 				this.#pageScroll(-1);
 			}
 		} else if (kb.matches(data, "tui.editor.pageDown")) {
+			this.#clearSelection();
 			if (this.#historyIndex > -1 && this.#isOnLastVisualLine()) {
 				this.#navigateHistory(1);
 			} else {
@@ -1233,11 +1317,19 @@ export class Editor implements Component, Focusable {
 				this.#moveCursor(1, 0); // Cursor movement (within text or history entry)
 			}
 		} else if (kb.matches(data, "tui.editor.cursorRight")) {
-			// Right
-			this.#moveCursor(0, 1);
+			// Right (collapse selection to its end when one is active)
+			if (this.#hasSelection()) {
+				this.#collapseSelection("end");
+			} else {
+				this.#moveCursor(0, 1);
+			}
 		} else if (kb.matches(data, "tui.editor.cursorLeft")) {
-			// Left
-			this.#moveCursor(0, -1);
+			// Left (collapse selection to its start when one is active)
+			if (this.#hasSelection()) {
+				this.#collapseSelection("start");
+			} else {
+				this.#moveCursor(0, -1);
+			}
 		}
 		// Shift+Space - insert regular space (Kitty protocol sends escape sequence)
 		else if (matchesKey(data, "shift+space")) {
@@ -1267,6 +1359,8 @@ export class Editor implements Component, Focusable {
 				text: "",
 				hasCursor: true,
 				cursorPos: 0,
+				logicalLine: 0,
+				startCol: 0,
 			});
 			return layoutLines;
 		}
@@ -1284,11 +1378,15 @@ export class Editor implements Component, Focusable {
 						text: line,
 						hasCursor: true,
 						cursorPos: this.#state.cursorCol,
+						logicalLine: i,
+						startCol: 0,
 					});
 				} else {
 					layoutLines.push({
 						text: line,
 						hasCursor: false,
+						logicalLine: i,
+						startCol: 0,
 					});
 				}
 			} else {
@@ -1332,11 +1430,15 @@ export class Editor implements Component, Focusable {
 							text: chunk.text,
 							hasCursor: true,
 							cursorPos: adjustedCursorPos,
+							logicalLine: i,
+							startCol: chunk.startIndex,
 						});
 					} else {
 						layoutLines.push({
 							text: chunk.text,
 							hasCursor: false,
+							logicalLine: i,
+							startCol: chunk.startIndex,
 						});
 					}
 				}
@@ -1348,6 +1450,99 @@ export class Editor implements Component, Focusable {
 
 	getText(): string {
 		return this.#state.lines.join("\n");
+	}
+
+	// === Text selection ===
+
+	/** Current selection as a document-ordered range, or null when nothing is selected. */
+	getSelection(): SelectionRange | null {
+		const anchor = this.#state.selectionAnchor;
+		if (!anchor) return null;
+		const range = normalizeRange(anchor, { line: this.#state.cursorLine, col: this.#state.cursorCol });
+		return isEmptyRange(range) ? null : range;
+	}
+
+	/** Selected text, or "" when there is no active selection. */
+	getSelectedText(): string {
+		const range = this.getSelection();
+		return range ? getSelectedTextInRange(this.#state.lines, range) : "";
+	}
+
+	#hasSelection(): boolean {
+		return this.getSelection() !== null;
+	}
+
+	#clearSelection(): void {
+		this.#state.selectionAnchor = null;
+	}
+
+	/** Anchor the selection at the current cursor if one is not already active. */
+	#beginSelection(): void {
+		if (this.#state.selectionAnchor === null) {
+			this.#state.selectionAnchor = { line: this.#state.cursorLine, col: this.#state.cursorCol };
+		}
+	}
+
+	/** Move the cursor to one edge of the selection and clear it (no extra movement). */
+	#collapseSelection(edge: "start" | "end"): void {
+		const range = this.getSelection();
+		if (range) {
+			const target = edge === "start" ? range.start : range.end;
+			this.#state.cursorLine = target.line;
+			this.#setCursorCol(target.col);
+		}
+		this.#clearSelection();
+	}
+
+	/** Delete the active selection if any. Returns true when it removed something. */
+	#deleteSelection(): boolean {
+		const range = this.getSelection();
+		if (!range) return false;
+		this.#exitHistoryForEditing();
+		this.#resetKillSequence();
+		this.#recordUndoState();
+		const result = deleteRange(this.#state.lines, range);
+		this.#state.lines = result.lines;
+		this.#state.cursorLine = result.cursor.line;
+		this.#setCursorCol(result.cursor.col);
+		this.#clearSelection();
+		if (this.onChange) {
+			this.onChange(this.getText());
+		}
+		return true;
+	}
+
+	/** Vertical selection extension, mirroring plain up/down minus history navigation. */
+	#extendVertical(direction: -1 | 1): void {
+		if (direction === -1) {
+			if (this.#isOnFirstVisualLine()) this.#moveToLineStart();
+			else this.#moveCursor(-1, 0);
+		} else {
+			if (this.#isOnLastVisualLine()) this.#moveToLineEnd();
+			else this.#moveCursor(1, 0);
+		}
+	}
+
+	/** Handle a shift+movement (or select-all) key. Returns true when handled. */
+	#handleExtendSelection(data: string, kb: KeybindingsManager): boolean {
+		let move: (() => void) | undefined;
+		if (kb.matches(data, "tui.editor.selectLeft")) move = () => this.#moveCursor(0, -1);
+		else if (kb.matches(data, "tui.editor.selectRight")) move = () => this.#moveCursor(0, 1);
+		else if (kb.matches(data, "tui.editor.selectUp")) move = () => this.#extendVertical(-1);
+		else if (kb.matches(data, "tui.editor.selectDown")) move = () => this.#extendVertical(1);
+		else if (kb.matches(data, "tui.editor.selectWordLeft")) move = () => this.#moveWordBackwards();
+		else if (kb.matches(data, "tui.editor.selectWordRight")) move = () => this.#moveWordForwards();
+		else if (kb.matches(data, "tui.editor.selectLineStart")) move = () => this.#moveToLineStart();
+		else if (kb.matches(data, "tui.editor.selectLineEnd")) move = () => this.#moveToLineEnd();
+		if (!move) return false;
+		this.#extending = true;
+		try {
+			this.#beginSelection();
+			move();
+		} finally {
+			this.#extending = false;
+		}
+		return true;
 	}
 
 	#expandPasteMarkers(text: string): string {
@@ -1461,6 +1656,7 @@ export class Editor implements Component, Focusable {
 
 	/** Insert text at the current cursor position */
 	insertText(text: string): void {
+		this.#deleteSelection();
 		this.#exitHistoryForEditing();
 		this.#resetKillSequence();
 		this.#recordUndoState();
@@ -1479,6 +1675,7 @@ export class Editor implements Component, Focusable {
 
 	// All the editor methods from before...
 	#insertCharacter(char: string): void {
+		this.#deleteSelection();
 		this.#exitHistoryForEditing();
 		this.#resetKillSequence();
 		this.#recordUndoState();
@@ -1565,6 +1762,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#handlePaste(pastedText: string): void {
+		this.#deleteSelection();
 		this.#historyIndex = -1; // Exit history browsing mode
 		this.#resetKillSequence();
 		this.#recordUndoState();
@@ -1639,6 +1837,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#addNewLine(): void {
+		this.#deleteSelection();
 		this.#historyIndex = -1; // Exit history browsing mode
 		this.#resetKillSequence();
 		this.#recordUndoState();
@@ -1677,7 +1876,7 @@ export class Editor implements Component, Focusable {
 
 		const result = this.#expandPasteMarkers(this.#state.lines.join("\n")).trim();
 
-		this.#state = { lines: [""], cursorLine: 0, cursorCol: 0 };
+		this.#state = { lines: [""], cursorLine: 0, cursorCol: 0, selectionAnchor: null };
 		this.#pastes.clear();
 		this.#pasteCounter = 0;
 		this.#historyIndex = -1;
@@ -1689,6 +1888,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#handleBackspace(): void {
+		if (this.#deleteSelection()) return;
 		this.#historyIndex = -1; // Exit history browsing mode
 		this.#resetKillSequence();
 		this.#recordUndoState();
@@ -1828,11 +2028,13 @@ export class Editor implements Component, Focusable {
 	}
 
 	#moveToLineStart(): void {
+		if (!this.#extending) this.#clearSelection();
 		this.#resetKillSequence();
 		this.#setCursorCol(0);
 	}
 
 	#moveToLineEnd(): void {
+		if (!this.#extending) this.#clearSelection();
 		this.#resetKillSequence();
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 		this.#setCursorCol(currentLine.length);
@@ -2166,6 +2368,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#handleForwardDelete(): void {
+		if (this.#deleteSelection()) return;
 		this.#historyIndex = -1; // Exit history browsing mode
 		this.#resetKillSequence();
 		this.#recordUndoState();
@@ -2273,6 +2476,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#moveCursor(deltaLine: number, deltaCol: number): void {
+		if (!this.#extending) this.#clearSelection();
 		this.#resetKillSequence();
 		const visualLines = this.#buildVisualLineMap(this.#lastLayoutWidth);
 		const currentVisualLine = this.#findCurrentVisualLine(visualLines);
@@ -2334,6 +2538,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#moveWordBackwards(): void {
+		if (!this.#extending) this.#clearSelection();
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 
 		// If at start of line, move to end of previous line
@@ -2384,6 +2589,7 @@ export class Editor implements Component, Focusable {
 	}
 
 	#moveWordForwards(): void {
+		if (!this.#extending) this.#clearSelection();
 		const currentLine = this.#state.lines[this.#state.cursorLine] || "";
 
 		// If at end of line, move to start of next line

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -27,6 +27,15 @@ export interface Keybindings {
 	"tui.editor.yank": true;
 	"tui.editor.yankPop": true;
 	"tui.editor.undo": true;
+	// Text selection
+	"tui.editor.selectLeft": true;
+	"tui.editor.selectRight": true;
+	"tui.editor.selectUp": true;
+	"tui.editor.selectDown": true;
+	"tui.editor.selectWordLeft": true;
+	"tui.editor.selectWordRight": true;
+	"tui.editor.selectLineStart": true;
+	"tui.editor.selectLineEnd": true;
 	// Generic input actions
 	"tui.input.newLine": true;
 	"tui.input.submit": true;
@@ -118,6 +127,20 @@ export const TUI_KEYBINDINGS = {
 	"tui.editor.yank": { defaultKeys: "ctrl+y", description: "Yank" },
 	"tui.editor.yankPop": { defaultKeys: "alt+y", description: "Yank pop" },
 	"tui.editor.undo": { defaultKeys: ["ctrl+-", "ctrl+_"], description: "Undo" },
+	"tui.editor.selectLeft": { defaultKeys: "shift+left", description: "Extend selection left" },
+	"tui.editor.selectRight": { defaultKeys: "shift+right", description: "Extend selection right" },
+	"tui.editor.selectUp": { defaultKeys: "shift+up", description: "Extend selection up" },
+	"tui.editor.selectDown": { defaultKeys: "shift+down", description: "Extend selection down" },
+	"tui.editor.selectWordLeft": {
+		defaultKeys: "shift+ctrl+left",
+		description: "Extend selection word left",
+	},
+	"tui.editor.selectWordRight": {
+		defaultKeys: "shift+ctrl+right",
+		description: "Extend selection word right",
+	},
+	"tui.editor.selectLineStart": { defaultKeys: "shift+home", description: "Extend selection to line start" },
+	"tui.editor.selectLineEnd": { defaultKeys: "shift+end", description: "Extend selection to line end" },
 	"tui.input.newLine": { defaultKeys: "shift+enter", description: "Insert newline" },
 	"tui.input.submit": { defaultKeys: "enter", description: "Submit input" },
 	"tui.input.tab": { defaultKeys: "tab", description: "Tab / autocomplete" },

--- a/packages/tui/test/editor-selection-keys.test.ts
+++ b/packages/tui/test/editor-selection-keys.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Editor } from "@oh-my-pi/pi-tui/components/editor";
+import { KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "../src/keybindings";
+import { defaultEditorTheme } from "./test-themes";
+
+// Raw sequences confirmed against the native key parser.
+const SHIFT_LEFT = "\x1b[1;2D";
+const SHIFT_RIGHT = "\x1b[1;2C";
+const SHIFT_UP = "\x1b[1;2A";
+const SHIFT_HOME = "\x1b[1;2H";
+const SHIFT_END = "\x1b[1;2F";
+const SHIFT_CTRL_LEFT = "\x1b[1;6D";
+const LEFT = "\x1b[D";
+const RIGHT = "\x1b[C";
+const UP = "\x1b[A";
+const LINE_START = "\x01"; // ctrl+a
+const NEWLINE = "\x1b[13;2~"; // shift+enter
+const BACKSPACE = "\x7f";
+const DELETE = "\x1b[3~";
+const ESC = "\x1b";
+
+function editorWith(text: string): Editor {
+	const e = new Editor(defaultEditorTheme);
+	e.handleInput(text);
+	return e;
+}
+
+describe("Editor shift-selection", () => {
+	beforeEach(() => setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS)));
+	afterEach(() => setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS)));
+
+	describe("extending", () => {
+		it("shift+left selects the character before the cursor", () => {
+			const e = editorWith("hello");
+			e.handleInput(SHIFT_LEFT);
+			expect(e.getSelectedText()).toBe("o");
+		});
+
+		it("shift+left twice selects two characters", () => {
+			const e = editorWith("hello");
+			e.handleInput(SHIFT_LEFT);
+			e.handleInput(SHIFT_LEFT);
+			expect(e.getSelectedText()).toBe("lo");
+		});
+
+		it("shift+right extends forward", () => {
+			const e = editorWith("hello");
+			e.handleInput(LINE_START);
+			e.handleInput(SHIFT_RIGHT);
+			e.handleInput(SHIFT_RIGHT);
+			expect(e.getSelectedText()).toBe("he");
+		});
+
+		it("shift+home selects to line start", () => {
+			const e = editorWith("hello");
+			e.handleInput(SHIFT_HOME);
+			expect(e.getSelectedText()).toBe("hello");
+		});
+
+		it("shift+end selects to line end", () => {
+			const e = editorWith("hello");
+			e.handleInput(LINE_START);
+			e.handleInput(SHIFT_END);
+			expect(e.getSelectedText()).toBe("hello");
+		});
+
+		it("shift+ctrl+left selects the previous word", () => {
+			const e = editorWith("hello world");
+			e.handleInput(SHIFT_CTRL_LEFT);
+			expect(e.getSelectedText()).toBe("world");
+		});
+
+		it("shift+up extends across lines", () => {
+			const e = new Editor(defaultEditorTheme);
+			e.handleInput("ab");
+			e.handleInput(NEWLINE);
+			e.handleInput("cd");
+			e.handleInput(LINE_START); // cursor at start of line 2
+			e.handleInput(SHIFT_UP);
+			expect(e.getSelectedText()).toBe("ab\n");
+		});
+	});
+
+	describe("collapsing / clearing", () => {
+		it("plain left collapses the selection to its start", () => {
+			const e = editorWith("hello");
+			e.handleInput(LINE_START);
+			e.handleInput(SHIFT_RIGHT);
+			e.handleInput(SHIFT_RIGHT); // selected "he", cursor at col 2
+			e.handleInput(LEFT); // collapse to col 0
+			expect(e.getSelectedText()).toBe("");
+			e.handleInput("X");
+			expect(e.getText()).toBe("Xhello");
+		});
+
+		it("plain right collapses the selection to its end", () => {
+			const e = editorWith("hello");
+			e.handleInput(LINE_START);
+			e.handleInput(SHIFT_RIGHT);
+			e.handleInput(SHIFT_RIGHT); // selected "he", cursor at col 2
+			e.handleInput(RIGHT); // collapse to col 2
+			expect(e.getSelectedText()).toBe("");
+			e.handleInput("X");
+			expect(e.getText()).toBe("heXllo");
+		});
+
+		it("escape clears the selection without changing the text", () => {
+			const e = editorWith("hello");
+			e.handleInput(SHIFT_LEFT);
+			e.handleInput(SHIFT_LEFT);
+			e.handleInput(ESC);
+			expect(e.getSelectedText()).toBe("");
+			expect(e.getText()).toBe("hello");
+		});
+	});
+
+	describe("mutations replace the selection", () => {
+		it("backspace deletes the selection", () => {
+			const e = editorWith("hello");
+			e.handleInput(SHIFT_LEFT);
+			e.handleInput(SHIFT_LEFT); // "lo"
+			e.handleInput(BACKSPACE);
+			expect(e.getText()).toBe("hel");
+			expect(e.getSelectedText()).toBe("");
+		});
+
+		it("delete removes the selection", () => {
+			const e = editorWith("hello");
+			e.handleInput(LINE_START);
+			e.handleInput(SHIFT_RIGHT);
+			e.handleInput(SHIFT_RIGHT); // "he"
+			e.handleInput(DELETE);
+			expect(e.getText()).toBe("llo");
+		});
+
+		it("typing a character replaces the selection", () => {
+			const e = editorWith("hello");
+			e.handleInput(SHIFT_LEFT);
+			e.handleInput(SHIFT_LEFT); // "lo"
+			e.handleInput("X");
+			expect(e.getText()).toBe("helX");
+		});
+	});
+
+	describe("no regression to history", () => {
+		it("shift+up does not navigate history", () => {
+			const e = new Editor(defaultEditorTheme);
+			e.addToHistory("old prompt");
+			e.handleInput("ab");
+			e.handleInput(SHIFT_UP);
+			expect(e.getText()).toBe("ab");
+		});
+
+		it("plain up still navigates history when at top with empty editor", () => {
+			const e = new Editor(defaultEditorTheme);
+			e.addToHistory("old prompt");
+			e.handleInput(UP);
+			expect(e.getText()).toBe("old prompt");
+		});
+	});
+});
+
+describe("Editor selection rendering", () => {
+	beforeEach(() => setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS)));
+	afterEach(() => setKeybindings(new KeybindingsManager(TUI_KEYBINDINGS)));
+
+	const selTheme = { ...defaultEditorTheme, selection: (t: string) => `<S>${t}</S>` };
+
+	it("wraps selected text before the cursor in the selection style", () => {
+		const e = new Editor(selTheme);
+		e.handleInput("hello");
+		e.handleInput(LINE_START);
+		e.handleInput(SHIFT_RIGHT);
+		e.handleInput(SHIFT_RIGHT); // "he" selected, cursor on "l"
+		expect(e.render(80).join("\n")).toContain("<S>he</S>");
+	});
+
+	it("wraps selected text after the cursor in the selection style", () => {
+		const e = new Editor(selTheme);
+		e.handleInput("hello");
+		e.handleInput(SHIFT_LEFT);
+		e.handleInput(SHIFT_LEFT); // "lo" selected, caret on "l", "o" highlighted
+		expect(e.render(80).join("\n")).toContain("<S>o</S>");
+	});
+
+	it("highlights a selected line that does not contain the cursor", () => {
+		const e = new Editor(selTheme);
+		e.handleInput("abc");
+		e.handleInput(NEWLINE);
+		e.handleInput("def");
+		e.handleInput(LEFT);
+		e.handleInput(LEFT); // cursor at (1,1)
+		e.handleInput(SHIFT_UP); // anchor (1,1), cursor (0,1); line 1 selected w/o cursor
+		expect(e.render(80).join("\n")).toContain("<S>d</S>");
+	});
+
+	it("applies no selection style when nothing is selected", () => {
+		const e = new Editor(selTheme);
+		e.handleInput("hello");
+		expect(e.render(80).join("\n")).not.toContain("<S>");
+	});
+
+	it("highlights the selection in hardware-cursor mode (as the real app uses)", () => {
+		const e = new Editor(selTheme);
+		e.setUseTerminalCursor(true);
+		e.focused = true;
+		e.handleInput("hello");
+		e.handleInput(LINE_START);
+		e.handleInput(SHIFT_RIGHT);
+		e.handleInput(SHIFT_RIGHT); // "he" selected
+		expect(e.render(80).join("\n")).toContain("<S>he</S>");
+	});
+});

--- a/packages/tui/test/editor-selection.test.ts
+++ b/packages/tui/test/editor-selection.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import {
+	deleteRange,
+	getSelectedText,
+	isEmptyRange,
+	normalizeRange,
+	type Pos,
+} from "@oh-my-pi/pi-tui/components/editor-selection";
+
+const pos = (line: number, col: number): Pos => ({ line, col });
+
+describe("editor-selection helpers", () => {
+	describe("normalizeRange", () => {
+		it("keeps order when anchor precedes cursor on the same line", () => {
+			expect(normalizeRange(pos(0, 2), pos(0, 5))).toEqual({ start: pos(0, 2), end: pos(0, 5) });
+		});
+
+		it("swaps when the cursor precedes the anchor on the same line", () => {
+			expect(normalizeRange(pos(0, 5), pos(0, 2))).toEqual({ start: pos(0, 2), end: pos(0, 5) });
+		});
+
+		it("orders across lines regardless of column", () => {
+			expect(normalizeRange(pos(2, 1), pos(0, 9))).toEqual({ start: pos(0, 9), end: pos(2, 1) });
+		});
+	});
+
+	describe("isEmptyRange", () => {
+		it("is true when start equals end", () => {
+			expect(isEmptyRange({ start: pos(1, 3), end: pos(1, 3) })).toBe(true);
+		});
+
+		it("is false when start and end differ", () => {
+			expect(isEmptyRange({ start: pos(1, 3), end: pos(1, 4) })).toBe(false);
+		});
+	});
+
+	describe("getSelectedText", () => {
+		it("returns the substring within a single line", () => {
+			expect(getSelectedText(["hello world"], { start: pos(0, 0), end: pos(0, 5) })).toBe("hello");
+		});
+
+		it("joins across multiple lines with newlines", () => {
+			const lines = ["alpha", "beta", "gamma"];
+			expect(getSelectedText(lines, { start: pos(0, 2), end: pos(2, 3) })).toBe("pha\nbeta\ngam");
+		});
+	});
+
+	describe("deleteRange", () => {
+		it("removes a span within a single line and lands the cursor at the start", () => {
+			const result = deleteRange(["hello world"], { start: pos(0, 5), end: pos(0, 11) });
+			expect(result.lines).toEqual(["hello"]);
+			expect(result.cursor).toEqual(pos(0, 5));
+		});
+
+		it("joins the boundary lines when the span crosses lines", () => {
+			const lines = ["alpha", "beta", "gamma"];
+			const result = deleteRange(lines, { start: pos(0, 2), end: pos(2, 3) });
+			expect(result.lines).toEqual(["alma"]);
+			expect(result.cursor).toEqual(pos(0, 2));
+		});
+
+		it("does not mutate the input lines array", () => {
+			const lines = ["hello world"];
+			deleteRange(lines, { start: pos(0, 0), end: pos(0, 5) });
+			expect(lines).toEqual(["hello world"]);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

  Adds keyboard-driven text selection to the TUI input editor. Holding Shift while
  moving the cursor now extends a selection, and Backspace/Delete (or typing/paste)
  removes or replaces it — standard editor behavior that was previously missing.

  ## Hotkeys

  | Keys | Action |
  | --- | --- |
  | Shift+← / → | Extend selection by character |
  | Shift+↑ / ↓ | Extend selection by line |
  | Shift+Home / End | Extend selection to line start / end |
  | Ctrl+Shift+← / → | Extend selection by word |

  `Ctrl+A` is intentionally left unchanged (move to line start). All bindings live
  in `TUI_KEYBINDINGS`, so they're user-rebindable.

  ## Behavior

  - Backspace / Delete remove the selection; typing or paste replaces it.
  - Plain ← / → collapse the selection to its near edge; other movement clears it.
  - Selection is rendered with a highlight in both the hardware-cursor (default app)
    and software-cursor render paths, including multi-line selections.
  - With no active selection, all existing editor behavior is unchanged.