### PR TITLE
fix: preserve slash command text in editor history when plan/goal mode is already active

### DIFF
--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -72,7 +72,12 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		inlineHint: "[prompt]",
 		allowArgs: true,
 		handleTui: async (command, runtime) => {
+			const hadArgs = !!command.args;
 			await runtime.ctx.handlePlanModeCommand(command.args || undefined);
+			if (hadArgs && runtime.ctx.planModeEnabled) {
+				// plan was already active — preserve the typed command in input history
+				runtime.ctx.editor.addToHistory(command.text);
+			}
 			runtime.ctx.editor.setText("");
 		},
 	},
@@ -90,7 +95,12 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		inlineHint: "[objective]",
 		allowArgs: true,
 		handleTui: async (command, runtime) => {
+			const hadArgs = !!command.args;
 			await runtime.ctx.handleGoalModeCommand(command.args || undefined);
+			if (hadArgs && runtime.ctx.goalModeEnabled) {
+				// goal was already active — preserve the typed command in input history
+				runtime.ctx.editor.addToHistory(command.text);
+			}
 			runtime.ctx.editor.setText("");
 		},
 	},


### PR DESCRIPTION
## Description

When `/plan <text>` or `/goal set <text>` is typed while plan/goal mode is already active, the handler shows a warning and clears the editor — but the typed text is silently discarded and cannot be recovered with Up Arrow.

Fix: save the text to editor history before clearing, so it remains recoverable.

## Related Issue

Fixes #1287

## Type of Change

- [x] Bug fix

## Testing

Tested plan + goal mode rejection paths: text now preserved in Up Arrow history.