### PR TITLE
Skip model role menu when re-selecting default

### DIFF
--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -733,6 +733,11 @@ export class ModelSelectorComponent extends Container {
 			: this.#filteredModels[this.#selectedIndex];
 	}
 
+	#isAssignedToRole(item: ModelItem | CanonicalModelItem, role: string): boolean {
+		const assigned = this.#roles[role];
+		return !!assigned && modelsAreEqual(assigned.model, item.model);
+	}
+
 	#openMenu(): void {
 		if (!this.#getSelectedItem()) return;
 
@@ -888,6 +893,13 @@ export class ModelSelectorComponent extends Container {
 			if (this.#menuStep === "role") {
 				const action = this.#menuRoleActions[this.#menuSelectedIndex];
 				if (!action) return;
+				if (action.role === "default" && this.#isAssignedToRole(selectedItem, "default")) {
+					// Re-selecting the already-default model as DEFAULT should not
+					// ask the user to choose its thinking level again.
+					this.#handleSelect(selectedItem, action.role);
+					this.#closeMenu();
+					return;
+				}
 				this.#menuSelectedRole = action.role;
 				this.#menuStep = "thinking";
 				this.#menuSelectedIndex = this.#getThinkingPreselectIndex(action.role, selectedItem.model);

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -17,7 +17,11 @@ function normalizeRenderedText(text: string): string {
 	);
 }
 
-function createSelector(model: Model, settings: Settings): ModelSelectorComponent {
+function createSelector(
+	model: Model,
+	settings: Settings,
+	onSelect: ConstructorParameters<typeof ModelSelectorComponent>[5] = () => {},
+): ModelSelectorComponent {
 	const modelRegistry = {
 		getAll: () => [model],
 		getDiscoverableProviders: () => [],
@@ -34,7 +38,7 @@ function createSelector(model: Model, settings: Settings): ModelSelectorComponen
 		settings,
 		modelRegistry,
 		[{ model, thinkingLevel: "off" }],
-		() => {},
+		onSelect,
 		() => {},
 	);
 }
@@ -60,11 +64,13 @@ describe("ModelSelector role badge thinking display", () => {
 		installTestTheme();
 		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+		const defaultModel = getBundledModel("anthropic", "claude-opus-4-5");
+		if (!defaultModel) throw new Error("Expected bundled model anthropic/claude-opus-4-5");
 
 		const settings = Settings.isolated({
 			cycleOrder: ["smol", "custom-fast", "default"],
 			modelRoles: {
-				default: `${model.provider}/${model.id}`,
+				default: `${defaultModel.provider}/${defaultModel.id}`,
 				"custom-fast": `${model.provider}/${model.id}:low`,
 				smol: `${model.provider}/${model.id}`,
 			},
@@ -86,5 +92,49 @@ describe("ModelSelector role badge thinking display", () => {
 		const menuRendered = normalizeRenderedText(selector.render(220).join("\n"));
 		expect(menuRendered).toContain("Set as custom-fast");
 		expect(menuRendered).toContain("Set as SMOL (Quick)");
+	});
+
+	test("re-selecting the default model keeps the role menu available", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: `${model.provider}/${model.id}:high`,
+			},
+		});
+		const onSelect = vi.fn();
+		const selector = createSelector(model, settings, onSelect);
+		await Bun.sleep(0);
+
+		selector.handleInput("\n");
+
+		expect(onSelect).not.toHaveBeenCalled();
+		const menuRendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(menuRendered).toContain("Action for:");
+		expect(menuRendered).toContain("Set as SMOL");
+	});
+
+	test("choosing DEFAULT for the default model confirms without opening thinking", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: `${model.provider}/${model.id}:high`,
+			},
+		});
+		const onSelect = vi.fn();
+		const selector = createSelector(model, settings, onSelect);
+		await Bun.sleep(0);
+
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+
+		expect(onSelect).toHaveBeenCalledTimes(1);
+		expect(onSelect.mock.calls[0]?.[1]).toBe("default");
+		expect(normalizeRenderedText(selector.render(220).join("\n"))).not.toContain("Thinking for:");
 	});
 });


### PR DESCRIPTION
## What

- Keep `/model` Enter opening the role/action menu, including when the highlighted model is already `DEFAULT`.
- Short-circuit only the redundant second step: choosing `Set as DEFAULT` for the already-default model now confirms immediately and preserves the current default thinking level.
- Add regression coverage for both menu accessibility and the default-confirm shortcut.

## Why

Re-selecting the current default model forced users through the generic thinking-level prompt again even when they chose `Set as DEFAULT`, which made the selector feel like it was asking for the model twice. The role menu still needs to remain available so users can assign the same model to `SMOL`, custom roles, or other role-specific settings.

## Testing

- [x] `bun test test/model-selector-role-badge-thinking.test.ts`
- [x] Installed CLI smoke-tested locally: `omp --version && omp --smoke-test`
- [ ] `bun check` passes — not run; fresh checkout dependency resolution hung at `bun install`/`bunx biome` in this environment.
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing) — not updated; small UX fix.