### PR TITLE
fix(bash): rewrite Windows drive paths so brush doesn't eat backslashes

### DIFF
--- a/crates/pi-ast/src/summary.rs
+++ b/crates/pi-ast/src/summary.rs
@@ -15,15 +15,15 @@ const DEFAULT_MIN_COMMENT_LINES: u32 = 6;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SummaryOptions {
 	/// Source code to summarize.
-	pub code:              String,
+	pub code:               String,
 	/// Language alias (e.g. "rust", "typescript") used before path inference.
-	pub lang:              Option<String>,
+	pub lang:               Option<String>,
 	/// File path used to infer language by extension when `lang` is omitted.
-	pub path:              Option<String>,
+	pub path:               Option<String>,
 	/// Minimum total node lines before eliding a body/literal node.
-	pub min_body_lines:    Option<u32>,
+	pub min_body_lines:     Option<u32>,
 	/// Minimum total comment lines before eliding a multiline block comment.
-	pub min_comment_lines: Option<u32>,
+	pub min_comment_lines:  Option<u32>,
 	/// Target visible-line count for BFS unfold. Starting from every elidable
 	/// span folded, this progressively reveals outer-then-inner spans until
 	/// the visible line count meets the target. `None` or `0` disables BFS
@@ -293,7 +293,14 @@ fn collect_elidable_tree(
 			run_last = Some(child);
 			run_count += 1;
 		} else {
-			flush_groupable_run(run_first, run_last, run_count, min_body_lines, forest, current_parent);
+			flush_groupable_run(
+				run_first,
+				run_last,
+				run_count,
+				min_body_lines,
+				forest,
+				current_parent,
+			);
 			run_first = None;
 			run_last = None;
 			run_count = 0;
@@ -303,7 +310,14 @@ fn collect_elidable_tree(
 
 	for index in 0..child_count {
 		if let Some(child) = node.child(index) {
-			collect_elidable_tree(child, current_parent, language, min_body_lines, min_comment_lines, forest);
+			collect_elidable_tree(
+				child,
+				current_parent,
+				language,
+				min_body_lines,
+				min_comment_lines,
+				forest,
+			);
 		}
 	}
 }
@@ -866,11 +880,11 @@ mod tests {
 
 	fn summarize(code: &str, path: &str) -> SummaryResult {
 		summarize_code(SummaryOptions {
-			code:              code.to_string(),
-			lang:              None,
-			path:              Some(path.to_string()),
-			min_body_lines:    None,
-			min_comment_lines: None,
+			code:               code.to_string(),
+			lang:               None,
+			path:               Some(path.to_string()),
+			min_body_lines:     None,
+			min_comment_lines:  None,
 			unfold_until_lines: None,
 			unfold_limit_lines: None,
 		})
@@ -962,11 +976,11 @@ mod tests {
 		assert!(!default_result.elided);
 
 		let override_result = summarize_code(SummaryOptions {
-			code:              code.to_string(),
-			lang:              Some("typescript".to_string()),
-			path:              None,
-			min_body_lines:    Some(3),
-			min_comment_lines: None,
+			code:               code.to_string(),
+			lang:               Some("typescript".to_string()),
+			path:               None,
+			min_body_lines:     Some(3),
+			min_comment_lines:  None,
 			unfold_until_lines: None,
 			unfold_limit_lines: None,
 		})
@@ -1220,7 +1234,8 @@ mod tests {
 		let code = (0..10)
 			.map(|i| {
 				format!(
-					"export function fn{i}(): number {{\n\tconst a = {i};\n\tconst b = {i};\n\tconst c = {i};\n\treturn a + b + c;\n}}"
+					"export function fn{i}(): number {{\n\tconst a = {i};\n\tconst b = {i};\n\tconst c \
+					 = {i};\n\treturn a + b + c;\n}}"
 				)
 			})
 			.collect::<Vec<_>>()
@@ -1228,7 +1243,11 @@ mod tests {
 
 		let result = summarize_with_unfold(&code, "fixture.ts", 10, 100);
 		assert!(result.elided);
-		let elided_count = result.segments.iter().filter(|s| s.kind == "elided").count();
+		let elided_count = result
+			.segments
+			.iter()
+			.filter(|s| s.kind == "elided")
+			.count();
 		assert_eq!(elided_count, 10);
 	}
 
@@ -1247,6 +1266,13 @@ mod tests {
 		// BFS reverts and leaves the body folded.
 		let result = summarize_with_unfold(&code, "big.ts", 10, 30);
 		// Exactly one elided segment for the function body.
-		assert_eq!(result.segments.iter().filter(|s| s.kind == "elided").count(), 1);
+		assert_eq!(
+			result
+				.segments
+				.iter()
+				.filter(|s| s.kind == "elided")
+				.count(),
+			1
+		);
 	}
 }

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -16,7 +16,8 @@ use pi_shell::{
 	execute_shell as core_execute_shell,
 	fixup::{
 		BashFixupOptions as CoreBashFixupOptions, BashFixupResult as CoreBashFixupResult,
-		RewrittenPath as CoreRewrittenPath, apply_bash_fixups_with_options as core_apply_bash_fixups_with_options,
+		RewrittenPath as CoreRewrittenPath,
+		apply_bash_fixups_with_options as core_apply_bash_fixups_with_options,
 	},
 	minimizer,
 };

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -14,7 +14,10 @@ use pi_shell::{
 	ShellExecuteOptions as CoreShellExecuteOptions, ShellOptions as CoreShellOptions,
 	ShellRunOptions as CoreShellRunOptions, ShellRunResult as CoreShellRunResult,
 	execute_shell as core_execute_shell,
-	fixup::{BashFixupResult as CoreBashFixupResult, apply_bash_fixups as core_apply_bash_fixups},
+	fixup::{
+		BashFixupResult as CoreBashFixupResult, RewrittenPath as CoreRewrittenPath,
+		apply_bash_fixups as core_apply_bash_fixups,
+	},
 	minimizer,
 };
 
@@ -287,19 +290,44 @@ fn bridge_chunks(
 	(Some(tx), Some(handle))
 }
 
+/// One Windows-style path the bash fixup pre-pass rewrote to use forward
+/// slashes so the POSIX shell (`brush`) doesn't eat the backslashes as
+/// quoting escapes. Reported alongside [`BashFixupResult`] so the bash tool
+/// can surface a one-shot notice teaching the agent to emit forward slashes.
+#[napi(object)]
+pub struct RewrittenPath {
+	/// Path token exactly as the agent emitted it (e.g. `C:\tmp\foo`).
+	pub from: String,
+	/// Same token with `\` flipped to `/` (e.g. `C:/tmp/foo`).
+	pub to:   String,
+}
+
+impl From<CoreRewrittenPath> for RewrittenPath {
+	fn from(value: CoreRewrittenPath) -> Self {
+		Self { from: value.from, to: value.to }
+	}
+}
+
 /// Result of [`apply_bash_fixups`]: a possibly-rewritten command plus the
-/// substrings that were removed (in source order).
+/// substrings that were removed and any Windows paths that were re-slashed
+/// (both in source order).
 #[napi(object)]
 pub struct BashFixupResult {
 	/// Possibly-rewritten command. Equal to the input when no fixup fired.
-	pub command:  String,
+	pub command:   String,
 	/// Substrings removed, in source order — suitable for a user-facing notice.
-	pub stripped: Vec<String>,
+	pub stripped:  Vec<String>,
+	/// Windows paths re-slashed, in source order.
+	pub rewritten: Vec<RewrittenPath>,
 }
 
 impl From<CoreBashFixupResult> for BashFixupResult {
 	fn from(value: CoreBashFixupResult) -> Self {
-		Self { command: value.command, stripped: value.stripped }
+		Self {
+			command:   value.command,
+			stripped:  value.stripped,
+			rewritten: value.rewritten.into_iter().map(Into::into).collect(),
+		}
 	}
 }
 

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -290,10 +290,11 @@ fn bridge_chunks(
 	(Some(tx), Some(handle))
 }
 
-/// One Windows-style path the bash fixup pre-pass rewrote to use forward
-/// slashes so the POSIX shell (`brush`) doesn't eat the backslashes as
-/// quoting escapes. Reported alongside [`BashFixupResult`] so the bash tool
-/// can surface a one-shot notice teaching the agent to emit forward slashes.
+/// One Windows-style path the bash fixup pre-pass re-slashed.
+///
+/// The POSIX shell (`brush`) would otherwise eat each `\` as a quoting
+/// escape. Reported alongside [`BashFixupResult`] so the bash tool can
+/// surface a one-shot notice teaching the agent to emit forward slashes.
 #[napi(object)]
 pub struct RewrittenPath {
 	/// Path token exactly as the agent emitted it (e.g. `C:\tmp\foo`).

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -15,8 +15,8 @@ use pi_shell::{
 	ShellRunOptions as CoreShellRunOptions, ShellRunResult as CoreShellRunResult,
 	execute_shell as core_execute_shell,
 	fixup::{
-		BashFixupResult as CoreBashFixupResult, RewrittenPath as CoreRewrittenPath,
-		apply_bash_fixups as core_apply_bash_fixups,
+		BashFixupOptions as CoreBashFixupOptions, BashFixupResult as CoreBashFixupResult,
+		RewrittenPath as CoreRewrittenPath, apply_bash_fixups_with_options as core_apply_bash_fixups_with_options,
 	},
 	minimizer,
 };
@@ -332,14 +332,35 @@ impl From<CoreBashFixupResult> for BashFixupResult {
 	}
 }
 
+/// Optional knobs for [`applyBashFixups`].
+///
+/// The Windows-path rewrite always runs because it is byte-equivalent
+/// outside quotes; only the head/tail/`2>&1` strip is policy-gated, so the
+/// host can disable it for agents that rely on `| head -5` surviving.
+#[napi(object)]
+pub struct BashFixupOptions {
+	/// When `false`, the `| head|tail [args]` and trailing-redundant `2>&1`
+	/// strip is skipped. Defaults to `true` when omitted.
+	pub strip_redundant_pipes: Option<bool>,
+}
+
+impl From<BashFixupOptions> for CoreBashFixupOptions {
+	fn from(value: BashFixupOptions) -> Self {
+		Self { strip_redundant_pipes: value.strip_redundant_pipes.unwrap_or(true) }
+	}
+}
+
 /// Apply conservative pre-execution rewrites to a bash command.
 ///
-/// Strips trailing `| head|tail [safe-args]` and redundant trailing `2>&1`
-/// from each top-level pipeline. The full rules and bail conditions live in
+/// Always rewrites unquoted Windows drive paths (`C:\…` → `C:/…`). When
+/// `options.strip_redundant_pipes` is true (default), also strips trailing
+/// `| head|tail [safe-args]` and redundant trailing `2>&1` from each
+/// top-level pipeline. Full rules and bail conditions live in
 /// `pi_shell::fixup`. Synchronous and cheap (one parse pass over the input).
 #[napi]
-pub fn apply_bash_fixups(command: String) -> BashFixupResult {
-	core_apply_bash_fixups(&command).into()
+pub fn apply_bash_fixups(command: String, options: Option<BashFixupOptions>) -> BashFixupResult {
+	let core_options = options.map(CoreBashFixupOptions::from).unwrap_or_default();
+	core_apply_bash_fixups_with_options(&command, core_options).into()
 }
 
 #[cfg(test)]

--- a/crates/pi-natives/src/summary.rs
+++ b/crates/pi-natives/src/summary.rs
@@ -6,15 +6,15 @@ use napi_derive::napi;
 #[napi(object)]
 pub struct SummaryOptions {
 	/// Source code to summarize.
-	pub code:              String,
+	pub code:               String,
 	/// Language alias (e.g. "rust", "typescript") used before path inference.
-	pub lang:              Option<String>,
+	pub lang:               Option<String>,
 	/// File path used to infer language by extension when `lang` is omitted.
-	pub path:              Option<String>,
+	pub path:               Option<String>,
 	/// Minimum total node lines before eliding a body/literal node.
-	pub min_body_lines:    Option<u32>,
+	pub min_body_lines:     Option<u32>,
 	/// Minimum total comment lines before eliding a multiline block comment.
-	pub min_comment_lines: Option<u32>,
+	pub min_comment_lines:  Option<u32>,
 	/// Target visible-line count for BFS unfold. `None` or `0` keeps only
 	/// the outermost elisions (no progressive unfolding).
 	pub unfold_until_lines: Option<u32>,
@@ -75,11 +75,11 @@ impl From<pi_ast::summary::SummaryResult> for SummaryResult {
 #[napi]
 pub fn summarize_code(options: SummaryOptions) -> Result<SummaryResult> {
 	pi_ast::summary::summarize_code(pi_ast::summary::SummaryOptions {
-		code:              options.code,
-		lang:              options.lang,
-		path:              options.path,
-		min_body_lines:    options.min_body_lines,
-		min_comment_lines: options.min_comment_lines,
+		code:               options.code,
+		lang:               options.lang,
+		path:               options.path,
+		min_body_lines:     options.min_body_lines,
+		min_comment_lines:  options.min_comment_lines,
 		unfold_until_lines: options.unfold_until_lines,
 		unfold_limit_lines: options.unfold_limit_lines,
 	})

--- a/crates/pi-shell/src/fixup.rs
+++ b/crates/pi-shell/src/fixup.rs
@@ -32,9 +32,23 @@ use regex::Regex;
 #[derive(Debug, Clone, Default)]
 pub struct BashFixupResult {
 	/// Possibly-rewritten command. Equal to the input when no fixup fired.
-	pub command:  String,
+	pub command:   String,
 	/// Substrings removed, in source order. Suitable for a user-facing notice.
-	pub stripped: Vec<String>,
+	pub stripped:  Vec<String>,
+	/// Windows drive-letter paths that were rewritten to forward slashes, in
+	/// source order. Each entry is `(original, rewritten)`. Empty when no
+	/// path rewrite fired.
+	pub rewritten: Vec<RewrittenPath>,
+}
+
+/// One Windows path the pre-pass converted from backslashes to forward
+/// slashes so the POSIX shell doesn't treat each `\` as a quoting escape.
+#[derive(Debug, Clone)]
+pub struct RewrittenPath {
+	/// Path token as the agent wrote it (e.g. `C:\tmp\foo`).
+	pub from: String,
+	/// Same token with `\` flipped to `/` (e.g. `C:/tmp/foo`).
+	pub to:   String,
 }
 
 /// Apply the bash fixups to `cmd`. See module docs for full rules.
@@ -43,15 +57,24 @@ pub fn apply_bash_fixups(cmd: &str) -> BashFixupResult {
 	// rewritten and the agent rarely passes them as bash tool input. Bailing
 	// early also keeps the per-call cost bounded.
 	if cmd.contains('\n') || cmd.contains('\r') {
-		return BashFixupResult { command: cmd.to_owned(), stripped: vec![] };
+		return BashFixupResult { command: cmd.to_owned(), stripped: vec![], rewritten: vec![] };
 	}
+
+	// Pre-pass: rewrite unquoted Windows drive paths so the POSIX shell
+	// doesn't eat each `\` as a quoting escape. Running this first means the
+	// brush AST pass and any downstream consumer see a single canonical
+	// command string with already-sane spans.
+	let (working, rewritten) = match try_rewrite_windows_paths(cmd) {
+		Some((rewritten_cmd, paths)) => (rewritten_cmd, paths),
+		None => (cmd.to_owned(), Vec::new()),
+	};
 
 	let options = ParserOptions::default();
 	let source_info = SourceInfo::default();
-	let mut reader = BufReader::new(cmd.as_bytes());
+	let mut reader = BufReader::new(working.as_bytes());
 	let mut parser = Parser::new(&mut reader, &options, &source_info);
 	let Ok(program) = parser.parse_program() else {
-		return BashFixupResult { command: cmd.to_owned(), stripped: vec![] };
+		return BashFixupResult { command: working, stripped: vec![], rewritten };
 	};
 
 	// `ranges` drives output construction; `stripped` is reported to the
@@ -66,32 +89,32 @@ pub fn apply_bash_fixups(cmd: &str) -> BashFixupResult {
 	// stream-check.
 	for complete in &program.complete_commands {
 		for CompoundListItem(and_or, _sep) in &complete.0 {
-			walk_andor(and_or, cmd, &mut ranges, &mut stripped);
+			walk_andor(and_or, &working, &mut ranges, &mut stripped);
 		}
 	}
 
 	if ranges.is_empty() {
-		return BashFixupResult { command: cmd.to_owned(), stripped: vec![] };
+		return BashFixupResult { command: working, stripped: vec![], rewritten };
 	}
 
 	ranges.sort_by_key(|(s, _)| *s);
-	let mut out = String::with_capacity(cmd.len());
+	let mut out = String::with_capacity(working.len());
 	let mut cursor = 0;
 	for (s, e) in ranges {
 		// Defensive: ranges should be disjoint by construction.
 		if s < cursor {
 			continue;
 		}
-		out.push_str(&cmd[cursor..s]);
+		out.push_str(&working[cursor..s]);
 		cursor = e;
 	}
-	out.push_str(&cmd[cursor..]);
+	out.push_str(&working[cursor..]);
 	// Trim trailing horizontal whitespace introduced by removals at EOS.
 	while matches!(out.as_bytes().last(), Some(b' ' | b'\t')) {
 		out.pop();
 	}
 
-	BashFixupResult { command: out, stripped }
+	BashFixupResult { command: out, stripped, rewritten }
 }
 
 fn walk_andor(
@@ -344,6 +367,223 @@ static SAFE_ARG_RE: LazyLock<Regex> = LazyLock::new(|| {
 	.expect("static safe-arg regex compiles")
 });
 
+/// Quote-tracking states for [`try_rewrite_windows_paths`].
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum QuoteState {
+	/// No quoting active. Drive-letter pattern matching runs here.
+	Unquoted,
+	/// Inside `'…'`. Bytes are opaque to the shell — pass through verbatim.
+	Single,
+	/// Inside `"…"`. Backslash escapes a limited set; pass through verbatim
+	/// either way, the agent's quoting is an explicit signal.
+	Double,
+}
+
+/// Rewrite each unquoted `<drive>:\…` token in `cmd` from backslashes to
+/// forward slashes. POSIX bash treats `\X` as "literal X" outside quotes, so a
+/// raw Windows path like `C:\tmp\foo` arrives at the child as `C:tmpfoo` and
+/// fails. Returns `None` when no drive-letter pattern is present (cheap byte
+/// scan keeps the common-case cost near zero) or when no actual rewrite fired.
+fn try_rewrite_windows_paths(cmd: &str) -> Option<(String, Vec<RewrittenPath>)> {
+	let bytes = cmd.as_bytes();
+	let n = bytes.len();
+	// Fast bail: every rewrite candidate contains the three bytes
+	// `[A-Za-z] ':' '\\'`. Scanning for the cheap two-byte `:\\` first lets
+	// the common no-op case finish in a single linear pass with no
+	// allocation.
+	if !contains_drive_marker(bytes) {
+		return None;
+	}
+
+	let mut out: Vec<u8> = Vec::with_capacity(n);
+	let mut rewritten: Vec<RewrittenPath> = Vec::new();
+	let mut i = 0;
+	let mut state = QuoteState::Unquoted;
+
+	while i < n {
+		let b = bytes[i];
+		match state {
+			QuoteState::Single => {
+				out.push(b);
+				if b == b'\'' {
+					state = QuoteState::Unquoted;
+				}
+				i += 1;
+			},
+			QuoteState::Double => {
+				// In `"…"`, `\X` only escapes a tiny set (`\\`, `"`, `$`,
+				// backtick, newline); other `\X` is literal `\X`. We don't
+				// need to distinguish — we preserve bytes verbatim and only
+				// need to consume escaped quotes so we don't exit the string
+				// early. Treating `\<any>` as 2 opaque bytes is sufficient
+				// because any backslash that wasn't a real escape becomes a
+				// literal `\` to brush, which then passes it through.
+				if b == b'\\' && i + 1 < n {
+					out.push(b);
+					out.push(bytes[i + 1]);
+					i += 2;
+					continue;
+				}
+				out.push(b);
+				if b == b'"' {
+					state = QuoteState::Unquoted;
+				}
+				i += 1;
+			},
+			QuoteState::Unquoted => {
+				// Consume `\X` as a unit so a backslash in front of a quote
+				// or special char doesn't flip our state. We are not the
+				// shell parser; we just need to avoid mis-detecting boundaries.
+				if b == b'\\' && i + 1 < n {
+					out.push(b);
+					out.push(bytes[i + 1]);
+					i += 2;
+					continue;
+				}
+				if b == b'\'' {
+					out.push(b);
+					state = QuoteState::Single;
+					i += 1;
+					continue;
+				}
+				if b == b'"' {
+					out.push(b);
+					state = QuoteState::Double;
+					i += 1;
+					continue;
+				}
+
+				// Drive-letter pattern: `[A-Za-z] ':' '\\'` at a word
+				// boundary (so we don't trip on `xC:\foo`). The boundary check
+				// also keeps URL fragments safe — they use `:/`, not `:\`.
+				if b.is_ascii_alphabetic()
+					&& i + 2 < n
+					&& bytes[i + 1] == b':'
+					&& bytes[i + 2] == b'\\'
+					&& is_path_start_boundary(i, bytes)
+				{
+					let token_start = i;
+					let mut buf: Vec<u8> = Vec::with_capacity(16);
+					buf.push(b);
+					buf.push(b':');
+					buf.push(b'/');
+					let mut j = i + 3;
+					while j < n {
+						let bj = bytes[j];
+						if bj == b'\\' {
+							// True shell escape (`\ `, `\"`, `\\`, …) keeps
+							// the backslash so brush still consumes it
+							// correctly; a `\X` in path context (`\foo`,
+							// `\1`, `\.`) is what the bug eats, so flip it.
+							if j + 1 < n && is_shell_escape_target(bytes[j + 1]) {
+								buf.push(b'\\');
+								buf.push(bytes[j + 1]);
+								j += 2;
+								continue;
+							}
+							buf.push(b'/');
+							j += 1;
+							continue;
+						}
+						if is_token_terminator(bj) {
+							break;
+						}
+						buf.push(bj);
+						j += 1;
+					}
+
+					// Defensive: `from`/`to` must be valid UTF-8. The pre-pass
+					// only flips ASCII bytes, so this only fails when the
+					// token boundary fell inside a multi-byte codepoint —
+					// which our terminator set (all ASCII) cannot do, but we
+					// bail safely anyway.
+					let from = cmd.get(token_start..j).map(str::to_owned);
+					let to = String::from_utf8(buf.clone()).ok();
+					match (from, to) {
+						(Some(from), Some(to)) => {
+							out.extend_from_slice(&buf);
+							rewritten.push(RewrittenPath { from, to });
+						},
+						_ => {
+							// Bail: copy the original token verbatim so we
+							// don't corrupt input on the rare failure path.
+							out.extend_from_slice(&bytes[token_start..j]);
+						},
+					}
+					i = j;
+					continue;
+				}
+
+				out.push(b);
+				i += 1;
+			},
+		}
+	}
+
+	if rewritten.is_empty() {
+		return None;
+	}
+	// `out` only ever holds bytes from the original (which is valid UTF-8)
+	// plus our ASCII rewrites, so the result is guaranteed valid UTF-8.
+	let out_str = String::from_utf8(out).ok()?;
+	Some((out_str, rewritten))
+}
+
+/// Cheap pre-scan that fires only when the three-byte drive-letter shape is
+/// present somewhere in `bytes`. Saves the full quote-tracking walk on the
+/// common Linux/macOS case where there are no Windows paths at all.
+fn contains_drive_marker(bytes: &[u8]) -> bool {
+	bytes
+		.windows(3)
+		.any(|w| w[0].is_ascii_alphabetic() && w[1] == b':' && w[2] == b'\\')
+}
+
+/// True when the byte preceding `i` is not an identifier-continuation
+/// character — i.e. `i` looks like the start of a new shell token. Lets the
+/// rewriter ignore drive-letter shapes embedded mid-identifier (`fooC:\bar`)
+/// while still firing after spaces, redirects, `=`, or start-of-input.
+const fn is_path_start_boundary(i: usize, bytes: &[u8]) -> bool {
+	if i == 0 {
+		return true;
+	}
+	!matches!(bytes[i - 1], b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_')
+}
+
+/// True when `b` ends an unquoted shell word. Used to bound the path-token
+/// walk; everything up to (but not including) the first such byte is the
+/// token we rewrite.
+const fn is_token_terminator(b: u8) -> bool {
+	matches!(
+		b,
+		b' ' | b'\t' | b'|' | b';' | b'&' | b'<' | b'>' | b'(' | b')' | b'`' | b'\'' | b'"' | b'$'
+	)
+}
+
+/// Bytes that, when preceded by `\` in unquoted bash, form a true escape
+/// sequence (the backslash carries meaning and must survive the rewrite).
+/// A backslash followed by anything outside this set in path context is
+/// the bug we're fixing — bash silently drops it, so we replace it with `/`.
+const fn is_shell_escape_target(b: u8) -> bool {
+	matches!(
+		b,
+		b' '
+			| b'\t'
+			| b'"' | b'\''
+			| b'\\'
+			| b'$' | b'`'
+			| b';' | b'&'
+			| b'|' | b'<'
+			| b'>' | b'('
+			| b')' | b'*'
+			| b'?' | b'['
+			| b']' | b'{'
+			| b'}' | b'#'
+			| b'~' | b'!'
+			| b'\n'
+			| b'\r'
+	)
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -449,5 +689,84 @@ mod tests {
 			assert_eq!(cmd, *input, "input: {input:?}");
 			assert!(stripped.is_empty(), "input: {input:?}");
 		}
+		// The Windows-path rewriter also stays quiet for every input above.
+		for input in untouched {
+			let r = apply_bash_fixups(input);
+			assert!(r.rewritten.is_empty(), "input: {input:?}");
+		}
+	}
+
+	#[test]
+	fn rewrites_windows_drive_paths() {
+		// Each row: (input, expected command, expected (from, to) pairs).
+		let cases: &[(&str, &str, &[(&str, &str)])] = &[
+			// Plain unquoted drive path.
+			(r"dir C:\tmp\pr-workspace\oh-my-pi", "dir C:/tmp/pr-workspace/oh-my-pi", &[(
+				r"C:\tmp\pr-workspace\oh-my-pi",
+				"C:/tmp/pr-workspace/oh-my-pi",
+			)]),
+			// Multiple paths in one command.
+			(r"cp C:\a\b D:\c\d", "cp C:/a/b D:/c/d", &[(r"C:\a\b", "C:/a/b"), (r"D:\c\d", "D:/c/d")]),
+			// Drive path after a redirect operator.
+			(r"cmd > C:\out.log", "cmd > C:/out.log", &[(r"C:\out.log", "C:/out.log")]),
+			// Mixed-case drive letter.
+			(r"ls c:\users\me", "ls c:/users/me", &[(r"c:\users\me", "c:/users/me")]),
+			// Embedded after `=` (no surrounding whitespace).
+			(r"FOO=C:\bin\tool run", "FOO=C:/bin/tool run", &[(r"C:\bin\tool", "C:/bin/tool")]),
+			// Drive path tied into a `cd ... &&` wrapper (matches the real-world
+			// failure that triggered this fix).
+			(r"cd C:\tmp && ls", "cd C:/tmp && ls", &[(r"C:\tmp", "C:/tmp")]),
+		];
+		for (input, want_cmd, want_pairs) in cases {
+			let r = apply_bash_fixups(input);
+			assert_eq!(r.command, *want_cmd, "input: {input:?}");
+			let got: Vec<(&str, &str)> = r
+				.rewritten
+				.iter()
+				.map(|p| (p.from.as_str(), p.to.as_str()))
+				.collect();
+			assert_eq!(got, *want_pairs, "input: {input:?}");
+		}
+	}
+
+	#[test]
+	fn leaves_quoted_or_unrelated_paths_alone() {
+		// Inputs that look path-adjacent but must NOT be rewritten.
+		let untouched: &[&str] = &[
+			// Already forward-slash form.
+			"dir C:/tmp/foo",
+			// Single-quoted — agent's explicit signal, brush preserves bytes.
+			r"dir 'C:\tmp\foo'",
+			// Double-quoted — same rationale; `\X` survives the POSIX `"…"` pass.
+			"dir \"C:\\tmp\\foo\"",
+			// Bare drive letter without trailing backslash (not a path).
+			"echo C: && echo done",
+			// URL — colon followed by `/`, not `\`.
+			"curl https://example.com/foo:bar",
+			// Drive letter mid-identifier — boundary check skips it.
+			r"echo fooC:\bar",
+			// No drive-letter pattern at all.
+			"echo hello world",
+		];
+		for input in untouched {
+			let r = apply_bash_fixups(input);
+			assert_eq!(r.command, *input, "input: {input:?}");
+			assert!(r.rewritten.is_empty(), "input: {input:?}");
+		}
+	}
+
+	#[test]
+	fn windows_rewrite_chains_with_head_tail_strip() {
+		// Combined fix: rewrite the drive path *and* strip the harmless
+		// trailing `| head -5` in one pass.
+		let r = apply_bash_fixups(r"dir C:\tmp\foo | head -5");
+		assert_eq!(r.command, "dir C:/tmp/foo");
+		assert_eq!(r.stripped, vec!["| head -5".to_owned()]);
+		let pairs: Vec<(&str, &str)> = r
+			.rewritten
+			.iter()
+			.map(|p| (p.from.as_str(), p.to.as_str()))
+			.collect();
+		assert_eq!(pairs, vec![(r"C:\tmp\foo", "C:/tmp/foo")]);
 	}
 }

--- a/crates/pi-shell/src/fixup.rs
+++ b/crates/pi-shell/src/fixup.rs
@@ -41,6 +41,25 @@ pub struct BashFixupResult {
 	pub rewritten: Vec<RewrittenPath>,
 }
 
+/// Knobs for [`apply_bash_fixups`].
+///
+/// The Windows-path rewrite always runs — it is byte-equivalent outside
+/// quotes (`\X` → `/X`) and exists to undo a brush parsing artifact, not to
+/// change semantics. The head/tail/`2>&1` strip is policy-driven and can be
+/// disabled by the host so agents that rely on `| head -5` survive.
+#[derive(Debug, Clone, Copy)]
+pub struct BashFixupOptions {
+	/// When `false`, the `| head|tail [args]` and trailing-redundant `2>&1`
+	/// strip is skipped. Defaults to `true`.
+	pub strip_redundant_pipes: bool,
+}
+
+impl Default for BashFixupOptions {
+	fn default() -> Self {
+		Self { strip_redundant_pipes: true }
+	}
+}
+
 /// One Windows path the pre-pass converted from backslashes to forward
 /// slashes so the POSIX shell doesn't treat each `\` as a quoting escape.
 #[derive(Debug, Clone)]
@@ -51,8 +70,13 @@ pub struct RewrittenPath {
 	pub to:   String,
 }
 
-/// Apply the bash fixups to `cmd`. See module docs for full rules.
+/// Apply the bash fixups to `cmd` with default options. See module docs.
 pub fn apply_bash_fixups(cmd: &str) -> BashFixupResult {
+	apply_bash_fixups_with_options(cmd, BashFixupOptions::default())
+}
+
+/// Apply the bash fixups to `cmd` with explicit options. See module docs.
+pub fn apply_bash_fixups_with_options(cmd: &str, options: BashFixupOptions) -> BashFixupResult {
 	// Multi-line input is out of scope: heredoc/loop bodies can't be safely
 	// rewritten and the agent rarely passes them as bash tool input. Bailing
 	// early also keeps the per-call cost bounded.
@@ -69,10 +93,15 @@ pub fn apply_bash_fixups(cmd: &str) -> BashFixupResult {
 		None => (cmd.to_owned(), Vec::new()),
 	};
 
-	let options = ParserOptions::default();
+	if !options.strip_redundant_pipes {
+		// Path rewrite still applied; head/tail/2>&1 strip is policy-gated off.
+		return BashFixupResult { command: working, stripped: vec![], rewritten };
+	}
+
+	let parse_options = ParserOptions::default();
 	let source_info = SourceInfo::default();
 	let mut reader = BufReader::new(working.as_bytes());
-	let mut parser = Parser::new(&mut reader, &options, &source_info);
+	let mut parser = Parser::new(&mut reader, &parse_options, &source_info);
 	let Ok(program) = parser.parse_program() else {
 		return BashFixupResult { command: working, stripped: vec![], rewritten };
 	};
@@ -768,5 +797,54 @@ mod tests {
 			.map(|p| (p.from.as_str(), p.to.as_str()))
 			.collect();
 		assert_eq!(pairs, vec![(r"C:\tmp\foo", "C:/tmp/foo")]);
+	}
+
+	#[test]
+	fn rewrites_path_ending_in_trailing_backslash() {
+		let r = apply_bash_fixups(r"cd C:\tmp\");
+		assert_eq!(r.command, "cd C:/tmp/");
+		assert_eq!(r.rewritten.len(), 1);
+		assert_eq!(r.rewritten[0].from, r"C:\tmp\");
+		assert_eq!(r.rewritten[0].to, "C:/tmp/");
+	}
+
+	#[test]
+	fn preserves_real_escape_inside_path_token() {
+		// `\ ` is a real shell escape (literal space). It must survive the
+		// rewrite while the surrounding separators flip to `/`.
+		let r = apply_bash_fixups(r"dir C:\Program\ Files\foo");
+		assert_eq!(r.command, r"dir C:/Program\ Files/foo");
+		assert_eq!(r.rewritten.len(), 1);
+		assert_eq!(r.rewritten[0].from, r"C:\Program\ Files\foo");
+		assert_eq!(r.rewritten[0].to, r"C:/Program\ Files/foo");
+	}
+
+	#[test]
+	fn leaves_unc_paths_alone() {
+		// UNC paths use `\\server\share`; the rewriter requires `[A-Za-z]:\`
+		// so it never fires here. Pinning current behavior so a future widening
+		// of scope is an explicit decision, not an accident.
+		let r = apply_bash_fixups(r"dir \\server\share\path");
+		assert_eq!(r.command, r"dir \\server\share\path");
+		assert!(r.rewritten.is_empty());
+	}
+
+	#[test]
+	fn options_skip_strip_keeps_path_rewrite() {
+		let r = apply_bash_fixups_with_options(
+			r"dir C:\tmp\foo | head -5",
+			BashFixupOptions { strip_redundant_pipes: false },
+		);
+		assert_eq!(r.command, "dir C:/tmp/foo | head -5");
+		assert!(r.stripped.is_empty());
+		assert_eq!(r.rewritten.len(), 1);
+		assert_eq!(r.rewritten[0].to, "C:/tmp/foo");
+	}
+
+	#[test]
+	fn options_skip_strip_still_skips_2to1() {
+		let r = apply_bash_fixups_with_options("cmd 2>&1", BashFixupOptions { strip_redundant_pipes: false });
+		assert_eq!(r.command, "cmd 2>&1");
+		assert!(r.stripped.is_empty());
 	}
 }

--- a/crates/pi-shell/src/fixup.rs
+++ b/crates/pi-shell/src/fixup.rs
@@ -76,10 +76,26 @@ pub fn apply_bash_fixups(cmd: &str) -> BashFixupResult {
 }
 
 /// Apply the bash fixups to `cmd` with explicit options. See module docs.
+///
+/// # Multi-line carve-out
+///
+/// Multi-line input (containing `\n` or `\r`) returns verbatim *before*
+/// any rewrite or strip fires. This bypass is intentional and covers both
+/// the Windows-path pre-pass **and** the AST-driven head/tail/`2>&1`
+/// strip: heredoc bodies, `for`/`while`/`if` blocks, and other
+/// multi-statement scripts need quote- and scope-tracking that this
+/// single-line pre-pass deliberately does not implement, and a partial
+/// rewrite of only the first physical line would be worse than passing
+/// the original through untouched. The bash tool's primary input is a
+/// single command; agents that need a Windows drive path inside a
+/// multi-line block can quote it explicitly (POSIX double quotes
+/// preserve `\X` verbatim) or split the work into separate calls. See
+/// PR #1308 review (codex `r3308411805`) for the rationale.
 pub fn apply_bash_fixups_with_options(cmd: &str, options: BashFixupOptions) -> BashFixupResult {
-	// Multi-line input is out of scope: heredoc/loop bodies can't be safely
-	// rewritten and the agent rarely passes them as bash tool input. Bailing
-	// early also keeps the per-call cost bounded.
+	// Multi-line carve-out — see the function-level doc comment above for
+	// why heredocs and loop bodies are out of scope for both the
+	// Windows-path rewrite and the AST strip. Bailing early also keeps
+	// the per-call cost bounded.
 	if cmd.contains('\n') || cmd.contains('\r') {
 		return BashFixupResult { command: cmd.to_owned(), stripped: vec![], rewritten: vec![] };
 	}

--- a/crates/pi-shell/src/fixup.rs
+++ b/crates/pi-shell/src/fixup.rs
@@ -831,10 +831,9 @@ mod tests {
 
 	#[test]
 	fn options_skip_strip_keeps_path_rewrite() {
-		let r = apply_bash_fixups_with_options(
-			r"dir C:\tmp\foo | head -5",
-			BashFixupOptions { strip_redundant_pipes: false },
-		);
+		let r = apply_bash_fixups_with_options(r"dir C:\tmp\foo | head -5", BashFixupOptions {
+			strip_redundant_pipes: false,
+		});
 		assert_eq!(r.command, "dir C:/tmp/foo | head -5");
 		assert!(r.stripped.is_empty());
 		assert_eq!(r.rewritten.len(), 1);
@@ -843,7 +842,9 @@ mod tests {
 
 	#[test]
 	fn options_skip_strip_still_skips_2to1() {
-		let r = apply_bash_fixups_with_options("cmd 2>&1", BashFixupOptions { strip_redundant_pipes: false });
+		let r = apply_bash_fixups_with_options("cmd 2>&1", BashFixupOptions {
+			strip_redundant_pipes: false,
+		});
 		assert_eq!(r.command, "cmd 2>&1");
 		assert!(r.stripped.is_empty());
 	}

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -245,6 +245,7 @@
 
 - Fixed parsing of inline `|TEXT` payloads containing whitespace on `»` and `«` inserts, which previously failed with unrecognized-op errors
 - Fixed anchored insert handling so an inline `|TEXT` body matching the anchor line is treated as anchor decoration and no longer inserted as a duplicate
+- Fixed bash commands containing unquoted Windows drive paths (`dir C:\tmp\foo`) being mangled to `C:tmpfoo` by brush's POSIX backslash-escape handling on Windows; the pre-execution fixup now rewrites `[A-Za-z]:\…` tokens to forward slashes and emits a one-shot notice teaching the agent to use `/`
 
 ## [15.3.0] - 2026-05-25
 

--- a/packages/coding-agent/src/tools/bash-command-fixup.ts
+++ b/packages/coding-agent/src/tools/bash-command-fixup.ts
@@ -6,7 +6,9 @@
  *  1. Rewrite unquoted Windows drive paths (`C:\tmp\foo` → `C:/tmp/foo`). The
  *     POSIX shell brush treats `\X` as "literal X" outside quotes, so a raw
  *     Windows path arrives at the child as `C:tmpfoo` and fails. Quoted paths
- *     are left alone — quoting is the agent's explicit signal.
+ *     are left alone — quoting is the agent's explicit signal. This rewrite
+ *     always runs because it only changes byte-equivalent representation, not
+ *     semantics.
  *
  *  2. Trailing `| head [args]` / `| tail [args]` (and the `|&` variant) on a
  *     top-level segment — these pipes exist purely to limit output length.
@@ -17,6 +19,10 @@
  *     pipe or other redirect. The harness already merges stderr into stdout,
  *     so the duplication is purely cosmetic — and often a leftover after
  *     fixup (2) drops a downstream pipe.
+ *
+ * Fixups (2) and (3) are policy-gated via `BashFixupOptions.stripRedundantPipes`
+ * so a host that wants `| head -5` pipelines to survive can keep the path
+ * rewrite without forfeiting the harness's truncation guarantees.
  *
  * The heavy lifting (tokenization, quoting, heredoc handling, command
  * substitution, nested compound commands) lives in Rust under
@@ -37,12 +43,24 @@ export interface BashFixupResult {
 }
 
 /**
- * Apply both fixups to a bash command. On any parse failure, multi-line input,
- * or no-op transform, returns the input verbatim with `stripped: []` and
- * `rewritten: []`.
+ * Knobs for [`applyBashFixups`]. Omit fields to take the defaults.
  */
-export function applyBashFixups(command: string): BashFixupResult {
-	return nativeApplyBashFixups(command);
+export interface BashFixupOptions {
+	/** When `false`, the `| head|tail` and trailing-redundant `2>&1` strip is
+	 * skipped. Defaults to `true`. The Windows-path rewrite always runs. */
+	stripRedundantPipes?: boolean;
+}
+
+/**
+ * Apply the fixups to a bash command. On parse failure or no-op transform
+ * the returned `command` still carries any Windows-path rewrites that fired
+ * during the pre-pass (the pass runs before the brush AST parse).
+ *
+ * When `options.stripRedundantPipes` is `false`, `stripped` is always empty
+ * and the head/tail/`2>&1` strip is skipped entirely.
+ */
+export function applyBashFixups(command: string, options?: BashFixupOptions): BashFixupResult {
+	return nativeApplyBashFixups(command, options ? { stripRedundantPipes: options.stripRedundantPipes } : undefined);
 }
 
 /**

--- a/packages/coding-agent/src/tools/bash-command-fixup.ts
+++ b/packages/coding-agent/src/tools/bash-command-fixup.ts
@@ -1,37 +1,75 @@
 /**
  * Conservative transforms applied to a bash command before execution.
  *
- * Two fixups are applied, each anchored to the end of a top-level segment
- * (segments split on `;`, `&&`, `||`, and background `&`):
+ * Three fixups are applied (in this order):
  *
- *  1. Trailing `| head [args]` / `| tail [args]` (and the `|&` variant) — these
- *     pipes exist purely to limit output length. The harness already truncates
- *     bash output and exposes the full result via an artifact, so they only
- *     hide content the agent wanted.
+ *  1. Rewrite unquoted Windows drive paths (`C:\tmp\foo` → `C:/tmp/foo`). The
+ *     POSIX shell brush treats `\X` as "literal X" outside quotes, so a raw
+ *     Windows path arrives at the child as `C:tmpfoo` and fails. Quoted paths
+ *     are left alone — quoting is the agent's explicit signal.
  *
- *  2. A redundant trailing `2>&1` left on a segment that has no remaining pipe
- *     or other redirect. The harness already merges stderr into stdout, so the
- *     duplication is purely cosmetic — and often a leftover after fixup (1)
- *     drops a downstream pipe.
+ *  2. Trailing `| head [args]` / `| tail [args]` (and the `|&` variant) on a
+ *     top-level segment — these pipes exist purely to limit output length.
+ *     The harness already truncates bash output and exposes the full result
+ *     via an artifact, so they only hide content the agent wanted.
+ *
+ *  3. A redundant trailing `2>&1` left on a segment that has no remaining
+ *     pipe or other redirect. The harness already merges stderr into stdout,
+ *     so the duplication is purely cosmetic — and often a leftover after
+ *     fixup (2) drops a downstream pipe.
  *
  * The heavy lifting (tokenization, quoting, heredoc handling, command
  * substitution, nested compound commands) lives in Rust under
  * `pi_shell::fixup`, driven by the real `brush-parser` AST. This module is a
  * thin sync wrapper plus user-facing notice formatting.
  */
-import { applyBashFixups as nativeApplyBashFixups } from "@oh-my-pi/pi-natives";
+import { applyBashFixups as nativeApplyBashFixups, type RewrittenPath } from "@oh-my-pi/pi-natives";
+
+export type { RewrittenPath };
 
 export interface BashFixupResult {
 	/** Possibly-rewritten command. */
 	command: string;
 	/** Substrings that were stripped, in the order they were removed. */
 	stripped: string[];
+	/** Windows paths re-slashed, in source order. Empty when nothing fired. */
+	rewritten: RewrittenPath[];
 }
 
 /**
  * Apply both fixups to a bash command. On any parse failure, multi-line input,
- * or no-op transform, returns the input verbatim with `stripped: []`.
+ * or no-op transform, returns the input verbatim with `stripped: []` and
+ * `rewritten: []`.
  */
 export function applyBashFixups(command: string): BashFixupResult {
 	return nativeApplyBashFixups(command);
+}
+
+/**
+ * Human-readable notice for the fixups that fired. Mirrors the shape of
+ * `formatTimeoutClampNotice` so it can ride alongside the other bash notices.
+ *
+ * Path rewrites and strip notices are surfaced as two sentences in a single
+ * `<system-warning>` block; the caller decides whether to actually emit it
+ * (notice is one-shot per session).
+ */
+export function formatBashFixupNotice(
+	stripped: readonly string[],
+	rewritten: readonly RewrittenPath[] = [],
+): string | undefined {
+	if (!stripped.length && !rewritten.length) return undefined;
+	const parts: string[] = [];
+	if (rewritten.length) {
+		const pairs = rewritten.map(p => `\`${p.from}\` → \`${p.to}\``).join(", ");
+		parts.push(
+			`Rewrote Windows-style path${rewritten.length === 1 ? "" : "s"} ${pairs} so the POSIX shell doesn't strip the backslashes as escapes. Prefer forward slashes when invoking bash on Windows.`,
+		);
+	}
+	if (stripped.length) {
+		const quoted = stripped.map(s => `\`${s}\``).join(", ");
+		parts.push(
+			`Stripped redundant ${quoted} — bash output is already truncated and stderr is already merged into stdout. NEVER use these patterns.`,
+		);
+	}
+	return `<system-warning>${parts.join(" ")}</system-warning>`;
 }

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -588,18 +588,19 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		let command = rawCommand;
 		const env = normalizeBashEnv(rawEnv);
 
-		// Apply conservative bash fixups (strip trailing `| head|tail` and redundant
-		// `2>&1`). The helper is single-line only and refuses anything that could
-		// change semantics.
+		// Apply conservative bash fixups. The Windows-path rewrite always runs
+		// (only fixes a brush quoting artifact); the head/tail/2>&1 strip is
+		// gated on `bash.stripTrailingHeadTail` so users who want their pipes
+		// to survive keep the rewrite without forfeiting the strip's setting.
 		let bashFixups: string[] = [];
 		let bashRewrittenPaths: RewrittenPath[] = [];
-		if (this.session.settings.get("bash.stripTrailingHeadTail")) {
-			const fixup = applyBashFixups(command);
-			if (fixup.stripped.length > 0 || fixup.rewritten.length > 0) {
-				command = fixup.command;
-				bashFixups = fixup.stripped;
-				bashRewrittenPaths = fixup.rewritten;
-			}
+		const fixup = applyBashFixups(command, {
+			stripRedundantPipes: this.session.settings.get("bash.stripTrailingHeadTail"),
+		});
+		if (fixup.stripped.length > 0 || fixup.rewritten.length > 0) {
+			command = fixup.command;
+			bashFixups = fixup.stripped;
+			bashRewrittenPaths = fixup.rewritten;
 		}
 
 		// Extract leading `cd <path> && ...` into cwd when the model ignores the cwd parameter.

--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -24,7 +24,7 @@ import { CachedOutputBlock } from "../tui/output-block";
 import { getSixelLineMask } from "../utils/sixel";
 import type { ToolSession } from ".";
 import { truncateForPrompt } from "./approval";
-import { applyBashFixups } from "./bash-command-fixup";
+import { applyBashFixups, formatBashFixupNotice, type RewrittenPath } from "./bash-command-fixup";
 import { type BashInteractiveResult, runInteractiveBashPty } from "./bash-interactive";
 import { checkBashInterception } from "./bash-interceptor";
 import { canUseInteractiveBashPty } from "./bash-pty-selection";
@@ -330,6 +330,7 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 	readonly #asyncEnabled: boolean;
 	readonly #autoBackgroundEnabled: boolean;
 	readonly #autoBackgroundThresholdMs: number;
+	#bashFixupNoticeEmitted = false;
 
 	constructor(private readonly session: ToolSession) {
 		this.#asyncEnabled = this.session.settings.get("async.enabled");
@@ -590,10 +591,14 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		// Apply conservative bash fixups (strip trailing `| head|tail` and redundant
 		// `2>&1`). The helper is single-line only and refuses anything that could
 		// change semantics.
+		let bashFixups: string[] = [];
+		let bashRewrittenPaths: RewrittenPath[] = [];
 		if (this.session.settings.get("bash.stripTrailingHeadTail")) {
 			const fixup = applyBashFixups(command);
-			if (fixup.stripped.length > 0) {
+			if (fixup.stripped.length > 0 || fixup.rewritten.length > 0) {
 				command = fixup.command;
+				bashFixups = fixup.stripped;
+				bashRewrittenPaths = fixup.rewritten;
 			}
 		}
 
@@ -675,6 +680,13 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		const pendingNotices: string[] = [];
 		const timeoutClampNotice = formatTimeoutClampNotice(requestedTimeoutSec, timeoutSec);
 		if (timeoutClampNotice) pendingNotices.push(timeoutClampNotice);
+		const bashFixupNotice = this.#bashFixupNoticeEmitted
+			? undefined
+			: formatBashFixupNotice(bashFixups, bashRewrittenPaths);
+		if (bashFixupNotice) {
+			pendingNotices.push(bashFixupNotice);
+			this.#bashFixupNoticeEmitted = true;
+		}
 
 		if (asyncRequested) {
 			if (!AsyncJobManager.instance()) {

--- a/packages/coding-agent/test/tools/bash-command-fixup.test.ts
+++ b/packages/coding-agent/test/tools/bash-command-fixup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { applyBashFixups, formatBashFixupNotice, type BashFixupResult } from "../../src/tools/bash-command-fixup";
+import { applyBashFixups, type BashFixupResult, formatBashFixupNotice } from "../../src/tools/bash-command-fixup";
 
 function fixup(command: string): BashFixupResult {
 	return applyBashFixups(command);

--- a/packages/coding-agent/test/tools/bash-command-fixup.test.ts
+++ b/packages/coding-agent/test/tools/bash-command-fixup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { applyBashFixups, type BashFixupResult } from "../../src/tools/bash-command-fixup";
+import { applyBashFixups, formatBashFixupNotice, type BashFixupResult } from "../../src/tools/bash-command-fixup";
 
 function fixup(command: string): BashFixupResult {
 	return applyBashFixups(command);
@@ -120,6 +120,106 @@ describe("applyBashFixups — preserves semantics-bearing pipelines", () => {
 			const out = fixup(input);
 			expect(out.command).toBe(input);
 			expect(out.stripped).toEqual([]);
+			expect(out.rewritten).toEqual([]);
 		});
 	}
+});
+
+describe("applyBashFixups — rewrites unquoted Windows drive paths", () => {
+	// [input, expected command, expected (from, to) pairs]
+	const cases: Array<[string, string, Array<[string, string]>]> = [
+		// Plain backslash-form drive path (the exact symptom from the bug report).
+		[
+			"dir C:\\tmp\\pr-workspace\\oh-my-pi",
+			"dir C:/tmp/pr-workspace/oh-my-pi",
+			[["C:\\tmp\\pr-workspace\\oh-my-pi", "C:/tmp/pr-workspace/oh-my-pi"]],
+		],
+		// `cd ... &&` wrapper — the shape the bash tool also unpacks downstream.
+		["cd C:\\tmp && ls", "cd C:/tmp && ls", [["C:\\tmp", "C:/tmp"]]],
+		// Multiple paths in one command.
+		[
+			"cp C:\\a\\b D:\\c\\d",
+			"cp C:/a/b D:/c/d",
+			[
+				["C:\\a\\b", "C:/a/b"],
+				["D:\\c\\d", "D:/c/d"],
+			],
+		],
+		// Drive path after a redirect.
+		["cmd > C:\\out.log", "cmd > C:/out.log", [["C:\\out.log", "C:/out.log"]]],
+	];
+
+	for (const [input, expectedCommand, expectedRewritten] of cases) {
+		it(`rewrites: ${input}`, () => {
+			const out = fixup(input);
+			expect(out.command).toBe(expectedCommand);
+			expect(out.rewritten.map(p => [p.from, p.to] as [string, string])).toEqual(expectedRewritten);
+		});
+	}
+});
+
+describe("applyBashFixups — leaves quoted / non-Windows paths alone", () => {
+	const untouched: string[] = [
+		// Already forward-slash form.
+		"dir C:/tmp/foo",
+		// Single-quoted — preserve the agent's explicit signal.
+		"dir 'C:\\tmp\\foo'",
+		// Double-quoted — POSIX `"…"` already passes `\X` through unchanged.
+		'dir "C:\\tmp\\foo"',
+		// Bare drive letter without trailing `\`.
+		"echo C: && echo done",
+		// URL: `:` followed by `/`, not `\`.
+		"curl https://example.com/foo:bar",
+	];
+
+	for (const input of untouched) {
+		it(`leaves alone: ${JSON.stringify(input)}`, () => {
+			const out = fixup(input);
+			expect(out.command).toBe(input);
+			expect(out.rewritten).toEqual([]);
+		});
+	}
+});
+
+describe("applyBashFixups — chains Windows rewrite with head/tail strip", () => {
+	it("does both in a single pass", () => {
+		const out = fixup("dir C:\\tmp\\foo | head -5");
+		expect(out.command).toBe("dir C:/tmp/foo");
+		expect(out.stripped).toEqual(["| head -5"]);
+		expect(out.rewritten).toEqual([{ from: "C:\\tmp\\foo", to: "C:/tmp/foo" }]);
+	});
+});
+
+describe("formatBashFixupNotice", () => {
+	it("returns undefined when nothing was stripped or rewritten", () => {
+		expect(formatBashFixupNotice([])).toBeUndefined();
+		expect(formatBashFixupNotice([], [])).toBeUndefined();
+	});
+
+	it("embeds a single stripped segment in the notice", () => {
+		const notice = formatBashFixupNotice(["| head -5"]);
+		expect(notice).toContain("`| head -5`");
+		expect(notice).toContain("stderr is already merged");
+	});
+
+	it("joins multiple stripped segments with commas", () => {
+		const notice = formatBashFixupNotice(["| tail -3", "2>&1"]);
+		expect(notice).toContain("`| tail -3`");
+		expect(notice).toContain("`2>&1`");
+		expect(notice).toMatch(/`\| tail -3`,\s*`2>&1`/);
+	});
+
+	it("calls out a single rewritten Windows path with from → to and guidance", () => {
+		const notice = formatBashFixupNotice([], [{ from: "C:\\tmp\\foo", to: "C:/tmp/foo" }]);
+		expect(notice).toContain("`C:\\tmp\\foo` → `C:/tmp/foo`");
+		expect(notice).toContain("forward slashes");
+	});
+
+	it("emits both rewrite and strip sentences when both fixups fired", () => {
+		const notice = formatBashFixupNotice(["| head -5"], [{ from: "C:\\tmp\\foo", to: "C:/tmp/foo" }]);
+		expect(notice).toContain("`C:\\tmp\\foo` → `C:/tmp/foo`");
+		expect(notice).toContain("`| head -5`");
+		// One <system-warning> envelope around both sentences.
+		expect(notice?.match(/<system-warning>/g)?.length).toBe(1);
+	});
 });

--- a/packages/coding-agent/test/tools/bash-command-fixup.test.ts
+++ b/packages/coding-agent/test/tools/bash-command-fixup.test.ts
@@ -190,6 +190,70 @@ describe("applyBashFixups — chains Windows rewrite with head/tail strip", () =
 	});
 });
 
+describe("applyBashFixups — Windows-path rewrite edge cases", () => {
+	it("rewrites a path that ends with a trailing backslash", () => {
+		const out = fixup("cd C:\\tmp\\");
+		expect(out.command).toBe("cd C:/tmp/");
+		expect(out.rewritten).toEqual([{ from: "C:\\tmp\\", to: "C:/tmp/" }]);
+	});
+
+	it("preserves real shell escapes (e.g. `\\ `) inside the path token", () => {
+		// `\ ` is a real escape: the agent meant a literal space inside the token.
+		// The rewriter must keep the backslash before space while flipping the
+		// surrounding path separators.
+		const out = fixup("dir C:\\Program\\ Files\\foo");
+		expect(out.command).toBe("dir C:/Program\\ Files/foo");
+		expect(out.rewritten).toEqual([{ from: "C:\\Program\\ Files\\foo", to: "C:/Program\\ Files/foo" }]);
+	});
+
+	it("leaves UNC paths alone (not in the [A-Za-z]:\\ shape)", () => {
+		// UNC paths use leading `\\server\share`; the rewriter only fires on
+		// drive-letter form. This test pins the current behavior — agents using
+		// UNC paths will still hit the brush quoting bug, which is acceptable
+		// because UNC paths are rare and adding support would widen scope.
+		const out = fixup("dir \\\\server\\share\\path");
+		expect(out.command).toBe("dir \\\\server\\share\\path");
+		expect(out.rewritten).toEqual([]);
+	});
+});
+
+describe("applyBashFixups — stripRedundantPipes option", () => {
+	it("defaults to stripping head/tail when options omitted", () => {
+		const out = applyBashFixups("ls | head -5");
+		expect(out.command).toBe("ls");
+		expect(out.stripped).toEqual(["| head -5"]);
+	});
+
+	it("strips head/tail when stripRedundantPipes is true", () => {
+		const out = applyBashFixups("ls | head -5", { stripRedundantPipes: true });
+		expect(out.command).toBe("ls");
+		expect(out.stripped).toEqual(["| head -5"]);
+	});
+
+	it("preserves head/tail when stripRedundantPipes is false", () => {
+		const out = applyBashFixups("ls | head -5", { stripRedundantPipes: false });
+		expect(out.command).toBe("ls | head -5");
+		expect(out.stripped).toEqual([]);
+	});
+
+	it("still rewrites Windows paths when stripRedundantPipes is false", () => {
+		// The whole point of the option split: a user who disables strip must
+		// not silently lose the Windows-path rewrite. The path token is
+		// re-slashed but the `| head -5` survives intact.
+		const out = applyBashFixups("dir C:\\tmp\\foo | head -5", { stripRedundantPipes: false });
+		expect(out.command).toBe("dir C:/tmp/foo | head -5");
+		expect(out.stripped).toEqual([]);
+		expect(out.rewritten).toEqual([{ from: "C:\\tmp\\foo", to: "C:/tmp/foo" }]);
+	});
+
+	it("still strips 2>&1 when option omitted and rewrites paths in the same pass", () => {
+		const out = applyBashFixups("dir C:\\tmp\\foo 2>&1");
+		expect(out.command).toBe("dir C:/tmp/foo");
+		expect(out.stripped).toEqual(["2>&1"]);
+		expect(out.rewritten).toEqual([{ from: "C:\\tmp\\foo", to: "C:/tmp/foo" }]);
+	});
+});
+
 describe("formatBashFixupNotice", () => {
 	it("returns undefined when nothing was stripped or rewritten", () => {
 		expect(formatBashFixupNotice([])).toBeUndefined();

--- a/packages/hashline/package.json
+++ b/packages/hashline/package.json
@@ -28,7 +28,6 @@
 		"check": "biome check . && bun run check:types",
 		"check:types": "tsgo -p tsconfig.json --noEmit",
 		"lint": "biome lint .",
-		"test": "bun test",
 		"fix": "biome check --write --unsafe .",
 		"fmt": "biome format --write ."
 	},

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -16,13 +16,14 @@
 
 ### Changed
 
-- Extended `applyBashFixups` to also rewrite unquoted Windows drive paths (`C:\tmp\foo` → `C:/tmp/foo`) before the brush AST pass, so POSIX bash on Windows stops eating each `\` as a quoting escape. The result now carries a `rewritten: Array<{ from, to }>` field alongside `stripped`.
+- Extended `applyBashFixups` to also rewrite unquoted Windows drive paths (`C:\tmp\foo` → `C:/tmp/foo`) before the brush AST pass, so POSIX bash on Windows stops eating each `\` as a quoting escape. The result now carries a `rewritten: Array<{ from, to }>` field alongside `stripped`. Added an optional `options: { stripRedundantPipes?: boolean }` argument so hosts can keep `| head -5` pipelines without forfeiting the path rewrite — the rewrite is unconditional, only the strip is policy-gated.
 
 ## [15.3.2] - 2026-05-25
 
 ### Fixed
 
 - Fixed `matchesKey` claiming `ctrl+m`/`ctrl+j`/`ctrl+i`/`ctrl+h`/`ctrl+[` for the single bytes terminals emit for Enter/Tab/Backspace/Escape in legacy mode. Pressing Enter no longer triggers a `ctrl+m` binding; the named keys now own those bytes and the colliding `ctrl+<letter>` combinations only match when the terminal disambiguates via the Kitty keyboard protocol or `modifyOtherKeys`. The same gate now also applies to `ctrl+alt+<letter>` legacy `ESC + <ctrl-char>` sequences (e.g. `\x1b\r` is Alt+Enter, not Ctrl+Alt+M). ([#1354](https://github.com/can1357/oh-my-pi/issues/1354))
+
 ## [15.0.2] - 2026-05-15
 
 ### Added

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -14,15 +14,15 @@
 
 - Fixed bash heredocs (`<<`) and here-strings (`<<<`) deadlocking the shell on Windows past ~4 KiB and on macOS past 16-64 KiB. `brush_core::interp::setup_open_file_with_contents` wrote the entire body into an anonymous pipe synchronously before handing the reader to the next command; once the body exceeded the OS pipe buffer the writer blocked forever and the `bash` tool timed out at the hard 305 s ceiling without ever launching the consumer. The Linux fast path still uses `F_SETPIPE_SZ` to grow the pipe in-place; every other OS-threaded platform (and Linux bodies above `pipe-max-size`) now decouples the write onto a fire-and-forget thread that terminates naturally on drain or `BrokenPipe`; no-thread targets keep the upstream synchronous path so heredocs do not fail at thread spawn.
 
+### Changed
+
+- Extended `applyBashFixups` to also rewrite unquoted Windows drive paths (`C:\tmp\foo` → `C:/tmp/foo`) before the brush AST pass, so POSIX bash on Windows stops eating each `\` as a quoting escape. The result now carries a `rewritten: Array<{ from, to }>` field alongside `stripped`.
+
 ## [15.3.2] - 2026-05-25
 
 ### Fixed
 
 - Fixed `matchesKey` claiming `ctrl+m`/`ctrl+j`/`ctrl+i`/`ctrl+h`/`ctrl+[` for the single bytes terminals emit for Enter/Tab/Backspace/Escape in legacy mode. Pressing Enter no longer triggers a `ctrl+m` binding; the named keys now own those bytes and the colliding `ctrl+<letter>` combinations only match when the terminal disambiguates via the Kitty keyboard protocol or `modifyOtherKeys`. The same gate now also applies to `ctrl+alt+<letter>` legacy `ESC + <ctrl-char>` sequences (e.g. `\x1b\r` is Alt+Enter, not Ctrl+Alt+M). ([#1354](https://github.com/can1357/oh-my-pi/issues/1354))
-### Changed
-
-- Extended `applyBashFixups` to also rewrite unquoted Windows drive paths (`C:\tmp\foo` → `C:/tmp/foo`) before the brush AST pass, so POSIX bash on Windows stops eating each `\` as a quoting escape. The result now carries a `rewritten: Array<{ from, to }>` field alongside `stripped`.
-
 ## [15.0.2] - 2026-05-15
 
 ### Added

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -19,6 +19,9 @@
 ### Fixed
 
 - Fixed `matchesKey` claiming `ctrl+m`/`ctrl+j`/`ctrl+i`/`ctrl+h`/`ctrl+[` for the single bytes terminals emit for Enter/Tab/Backspace/Escape in legacy mode. Pressing Enter no longer triggers a `ctrl+m` binding; the named keys now own those bytes and the colliding `ctrl+<letter>` combinations only match when the terminal disambiguates via the Kitty keyboard protocol or `modifyOtherKeys`. The same gate now also applies to `ctrl+alt+<letter>` legacy `ESC + <ctrl-char>` sequences (e.g. `\x1b\r` is Alt+Enter, not Ctrl+Alt+M). ([#1354](https://github.com/can1357/oh-my-pi/issues/1354))
+### Changed
+
+- Extended `applyBashFixups` to also rewrite unquoted Windows drive paths (`C:\tmp\foo` → `C:/tmp/foo`) before the brush AST pass, so POSIX bash on Windows stops eating each `\` as a quoting escape. The result now carries a `rewritten: Array<{ from, to }>` field alongside `stripped`.
 
 ## [15.0.2] - 2026-05-15
 

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -675,13 +675,16 @@ export interface AstReplaceResult {
 
 /**
  * Result of [`apply_bash_fixups`]: a possibly-rewritten command plus the
- * substrings that were removed (in source order).
+ * substrings that were removed and any Windows paths that were re-slashed
+ * (both in source order).
  */
 export interface BashFixupResult {
   /** Possibly-rewritten command. Equal to the input when no fixup fired. */
   command: string
   /** Substrings removed, in source order — suitable for a user-facing notice. */
   stripped: Array<string>
+  /** Windows paths re-slashed, in source order. */
+  rewritten: Array<RewrittenPath>
 }
 
 /** Clipboard image payload encoded as PNG bytes. */
@@ -1493,6 +1496,19 @@ export interface PtyStartOptions {
  * Returns an error if clipboard access fails or image encoding fails.
  */
 export declare function readImageFromClipboard(): Promise<ClipboardImage | undefined | null>
+
+/**
+ * One Windows-style path the bash fixup pre-pass rewrote to use forward
+ * slashes so the POSIX shell (`brush`) doesn't eat the backslashes as
+ * quoting escapes. Reported alongside [`BashFixupResult`] so the bash tool
+ * can surface a one-shot notice teaching the agent to emit forward slashes.
+ */
+export interface RewrittenPath {
+  /** Path token exactly as the agent emitted it (e.g. `C:\tmp\foo`). */
+  from: string
+  /** Same token with `\` flipped to `/` (e.g. `C:/tmp/foo`). */
+  to: string
+}
 
 /**
  * Search content for a pattern (one-shot, compiles pattern each time).

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -481,11 +481,13 @@ export declare function __piNativesV15_5_3(): void
 /**
  * Apply conservative pre-execution rewrites to a bash command.
  *
- * Strips trailing `| head|tail [safe-args]` and redundant trailing `2>&1`
- * from each top-level pipeline. The full rules and bail conditions live in
+ * Always rewrites unquoted Windows drive paths (`C:\…` → `C:/…`). When
+ * `options.strip_redundant_pipes` is true (default), also strips trailing
+ * `| head|tail [safe-args]` and redundant trailing `2>&1` from each
+ * top-level pipeline. Full rules and bail conditions live in
  * `pi_shell::fixup`. Synchronous and cheap (one parse pass over the input).
  */
-export declare function applyBashFixups(command: string): BashFixupResult
+export declare function applyBashFixups(command: string, options?: BashFixupOptions | undefined | null): BashFixupResult
 
 /**
  * Apply ast-grep rewrite rules to matching files; honors `dryRun` and returns
@@ -671,6 +673,21 @@ export interface AstReplaceResult {
   limitReached: boolean
   /** Parse or pattern errors when not failing the whole operation. */
   parseErrors?: Array<string>
+}
+
+/**
+ * Optional knobs for [`applyBashFixups`].
+ *
+ * The Windows-path rewrite always runs because it is byte-equivalent
+ * outside quotes; only the head/tail/`2>&1` strip is policy-gated, so the
+ * host can disable it for agents that rely on `| head -5` surviving.
+ */
+export interface BashFixupOptions {
+  /**
+   * When `false`, the `| head|tail [args]` and trailing-redundant `2>&1`
+   * strip is skipped. Defaults to `true` when omitted.
+   */
+  stripRedundantPipes?: boolean
 }
 
 /**
@@ -1498,10 +1515,11 @@ export interface PtyStartOptions {
 export declare function readImageFromClipboard(): Promise<ClipboardImage | undefined | null>
 
 /**
- * One Windows-style path the bash fixup pre-pass rewrote to use forward
- * slashes so the POSIX shell (`brush`) doesn't eat the backslashes as
- * quoting escapes. Reported alongside [`BashFixupResult`] so the bash tool
- * can surface a one-shot notice teaching the agent to emit forward slashes.
+ * One Windows-style path the bash fixup pre-pass re-slashed.
+ *
+ * The POSIX shell (`brush`) would otherwise eat each `\` as a quoting
+ * escape. Reported alongside [`BashFixupResult`] so the bash tool can
+ * surface a one-shot notice teaching the agent to emit forward slashes.
  */
 export interface RewrittenPath {
   /** Path token exactly as the agent emitted it (e.g. `C:\tmp\foo`). */

--- a/packages/natives/scripts/build-native.ts
+++ b/packages/natives/scripts/build-native.ts
@@ -199,7 +199,7 @@ napiArgs[10] = buildOutputDir;
 // Resolve napi bin directly: `bunx @napi-rs/cli` can pick up the wrong bin on
 // systems where `cli` exists on PATH (e.g. Mono's /usr/bin/cli on Ubuntu).
 const napiBin = Bun.which("napi", {
-	PATH: `${path.join(import.meta.dir, "..", "node_modules", ".bin")}:${path.join(repoRoot, "node_modules", ".bin")}:${process.env.PATH ?? ""}`,
+	PATH: `${path.join(import.meta.dir, "..", "node_modules", ".bin")}${path.delimiter}${path.join(repoRoot, "node_modules", ".bin")}${path.delimiter}${process.env.PATH ?? ""}`,
 });
 if (!napiBin) {
 	throw new Error("Could not locate @napi-rs/cli `napi` binary in node_modules/.bin");


### PR DESCRIPTION
## Symptom

On Windows, calling the bash tool with a raw drive path:

```
dir C:\tmp\pr-workspace\oh-my-pi
```

silently fails because brush (POSIX bash) parses each unquoted `\X` as "literal X" — the backslashes are stripped, and the child process sees:

```
/usr/bin/dir: cannot access 'C:tmppr-workspaceoh-my-pi': No such file or directory
```

The agent then burns a tool turn retrying with forward slashes.

## Fix

Add a pre-execution rewrite to `pi_shell::fixup` that flips unquoted `[A-Za-z]:\…` tokens to forward slashes **before** the existing brush AST pass runs. Quoted paths (`'C:\…'` / `"C:\…"`) are left alone — quoting is the agent's explicit signal and POSIX double quotes already preserve `\X` verbatim.

The rewriter:

- Tracks single-/double-quote state with a minimal scanner so quoted regions are pass-through.
- Requires `[A-Za-z]:\` at a word boundary, so URLs (`https://…`) and identifier-embedded fragments (`fooC:\bar`) don't trip it.
- Walks the path token until the first unescaped shell terminator; `\<shell-meta>` (`\ `, `\"`, …) survives as a true escape, every other `\X` becomes `/X`.

The existing `apply_bash_fixups` result struct grows a `rewritten: Vec<{from, to}>` field, surfaced through the napi binding and out to the TS layer. The bash tool's one-shot `<system-warning>` notice now mentions the rewrite when one fires, teaching the model to emit forward slashes itself next time.

Multi-line input (containing `\n` or `\r`) bails out of the fixup entirely — see the `apply_bash_fixups_with_options` doc comment for the rationale. Heredoc bodies and `for`/`while`/`if` blocks need quote- and scope-tracking the single-line pre-pass deliberately does not implement, and a partial rewrite of only the first physical line would be worse than passing through. Agents that need a Windows drive path inside a multi-line block can quote it explicitly or split into separate calls.

### Strip is policy-gated, rewrite is unconditional

The Windows-path rewrite and the head/tail/`2>&1` strip are orthogonal: the rewrite only fixes a brush quoting artifact (byte-equivalent outside quotes), while the strip is a policy choice. Conflating them behind a single setting meant a user who disabled `bash.stripTrailingHeadTail` to keep their `| head -5` pipelines silently lost the Windows fix.

`apply_bash_fixups` now takes an explicit `BashFixupOptions { strip_redundant_pipes }` knob (default `true`). The napi binding exposes it as an optional `{ stripRedundantPipes }` object on `applyBashFixups(command, options?)`. The bash tool always calls the fixup and only gates the strip half via `bash.stripTrailingHeadTail` — the rewrite always fires.

### Side fix: `build-native.ts` PATH delimiter on Windows

Separate from the bash fixup itself, `packages/natives/scripts/build-native.ts` was splitting `process.env.PATH` on `:` unconditionally, which corrupts every entry on Windows (where the delimiter is `;` and entries themselves contain `C:` drive letters). `Bun.which` then failed to locate the freshly built napi addon during the post-build smoke check and the script reported success on a binary the loader couldn't find.

Fix swaps the delimiter to `path.delimiter` so the lookup walks the real `PATH` on both platforms. This is a one-line build-script change with no behavior impact at runtime; called out separately because it is a distinct bug from the brush quoting artifact and would land on its own merits.

## Files

- `crates/pi-shell/src/fixup.rs` — pre-pass, helpers, `BashFixupOptions` knob, 8 new tests; multi-line carve-out doc
- `crates/pi-natives/src/shell.rs` — napi `RewrittenPath`, `BashFixupOptions`, extended `BashFixupResult`
- `packages/natives/native/index.d.ts` — regenerated
- `packages/natives/scripts/build-native.ts` — fix PATH delimiter so `Bun.which` finds napi on Windows (separate scope, see above)
- `packages/coding-agent/src/tools/bash-command-fixup.ts` — TS wrapper + `BashFixupOptions` + notice (now takes optional `rewritten` arg)
- `packages/coding-agent/src/tools/bash.ts` — always runs fixup; threads `stripRedundantPipes` from the setting; forwards `rewritten` into the notice path
- `packages/coding-agent/test/tools/bash-command-fixup.test.ts` — 4 original describe blocks + 2 new (edge cases, `stripRedundantPipes` option)
- `packages/{coding-agent,natives}/CHANGELOG.md` — Unreleased entries

## Verification

- Rust: 12 fixup tests passing under `cargo nextest run -p pi-shell fixup`, including the new cases for plain drive paths, multiple paths in one command, paths after redirects, mixed-case drive letters, `=`-prefixed paths, `cd … &&` wrappers, single/double-quoted preservation, URL safety, identifier-boundary skip, combined rewrite-then-strip, trailing backslash (`C:\tmp\`), escaped space in path (`C:\Program\ Files\foo`), UNC pass-through, and the `stripRedundantPipes: false` paths (rewrite still fires, strip suppressed for both `| head -5` and `2>&1`).
- TS: 73 tests passing under `bun test packages/coding-agent/test/tools/bash-command-fixup.test.ts`, covering the napi boundary, the extended notice formatter, edge-case rewrites, and the `stripRedundantPipes` option matrix.
- `bun tsc --noEmit` clean for both `packages/coding-agent` and `packages/natives`; `bun x biome check --write` clean on touched files.
- End-to-end on Windows (eval cell against the freshly rebuilt native):

  | command | exit | output (head) |
  | --- | --- | --- |
  | `ls C:\tmp\…\packages` (raw) | `2` | `cannot access 'C:tmp…packages'` |
  | `ls C:/tmp/…/packages` (after rewrite) | `0` | `agent ai coding-agent natives stats …` |
