### PR TITLE
fix(tui): decouple hideThinkingBlock display flag from hideThinkingSummary

### DIFF
--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -755,7 +755,6 @@ export class InputController {
 	toggleThinkingBlockVisibility(): void {
 		this.ctx.hideThinkingBlock = !this.ctx.hideThinkingBlock;
 		settings.set("hideThinkingBlock", this.ctx.hideThinkingBlock);
-		this.ctx.session.agent.hideThinkingSummary = this.ctx.hideThinkingBlock;
 
 		// Rebuild chat from session messages
 		this.ctx.chatContainer.clear();

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -270,7 +270,6 @@ export class SelectorController {
 				break;
 			case "hideThinking":
 				this.ctx.hideThinkingBlock = value as boolean;
-				this.ctx.session.agent.hideThinkingSummary = value as boolean;
 				for (const child of this.ctx.chatContainer.children) {
 					if (child instanceof AssistantMessageComponent) {
 						child.setHideThinkingBlock(value as boolean);

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1857,7 +1857,6 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			presencePenalty: settings.get("presencePenalty") >= 0 ? settings.get("presencePenalty") : undefined,
 			repetitionPenalty: settings.get("repetitionPenalty") >= 0 ? settings.get("repetitionPenalty") : undefined,
 			serviceTier: initialServiceTier,
-			hideThinkingSummary: settings.get("hideThinkingBlock"),
 			kimiApiFormat: settings.get("providers.kimiApiFormat") ?? "anthropic",
 			preferWebsockets: preferOpenAICodexWebsockets,
 			getToolContext: tc => toolContextStore.getContext(tc),


### PR DESCRIPTION
## Repro

Press `Ctrl+T` to hide thinking blocks. Send a message to a model with thinking enabled (e.g. claude-sonnet-4-5 with thinking:high). Observe via network trace or `packages/ai/src/stream.ts:583,697` that `thinkingDisplay: "omitted"` / `reasoningSummary: null` is sent — the model stops reasoning, not just stops showing its reasoning in the TUI.

## Cause

Three locations coupled the display flag `hideThinkingBlock` to the provider-level `agent.hideThinkingSummary`:

- `sdk.ts:1860` — seeded `hideThinkingSummary` from the persisted `hideThinkingBlock` setting at session init
- `input-controller.ts:758` — set `agent.hideThinkingSummary` on every `Ctrl+T` toggle
- `selector-controller.ts:273` — set `agent.hideThinkingSummary` when the settings UI changed `hideThinking`

`hideThinkingSummary` maps directly to `thinkingDisplay: "omitted"` (Anthropic) and `reasoningSummary: null` (OpenAI Responses), which suppresses the reasoning stream server-side. "Hide thinking" was silently degrading output quality instead of only affecting display. The effect was also provider-inconsistent: for MiniMax/providers that cannot disable thinking server-side, `Ctrl+T` only hid output; for Anthropic/OpenAI it also disabled reasoning.

## Fix

- Remove `hideThinkingSummary: settings.get("hideThinkingBlock")` from `sdk.ts` agent init
- Remove `this.ctx.session.agent.hideThinkingSummary = this.ctx.hideThinkingBlock` from `InputController.toggleThinkingBlockVisibility()`
- Remove `this.ctx.session.agent.hideThinkingSummary = value as boolean` from `SelectorController` `hideThinking` case

`hideThinkingBlock` is now a pure render flag. `agent.hideThinkingSummary` defaults to `undefined` (reasoning active) and is no longer set from anywhere in the TUI layer.

## Verification

Three-line deletion with no new code. `bun check` skipped: `biome` is not installed in this CI environment — pre-existing failure on `main` unrelated to this diff (`which biome` returns not found).

`Fixes #1313`