### PR TITLE
feat: add --hide-thinking CLI flag to suppress thinking blocks in TUI

### DIFF
--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -21,6 +21,7 @@ export interface Args {
 	systemPrompt?: string;
 	appendSystemPrompt?: string;
 	thinking?: Effort;
+	hideThinking?: boolean;
 	continue?: boolean;
 	resume?: string | true;
 	help?: boolean;
@@ -151,6 +152,8 @@ export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "
 					validThinkingLevels: THINKING_EFFORTS,
 				});
 			}
+		} else if (arg === "--hide-thinking") {
+			result.hideThinking = true;
 		} else if (arg === "--print" || arg === "-p") {
 			result.print = true;
 		} else if (arg === "--export" && i + 1 < args.length) {

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -90,6 +90,9 @@ export default class Index extends Command {
 			description: `Set thinking level: ${THINKING_EFFORTS.join(", ")}`,
 			options: [...THINKING_EFFORTS],
 		}),
+		"hide-thinking": Flags.boolean({
+			description: "Hide thinking blocks in TUI output (display only, does not disable model thinking)",
+		}),
 		hook: Flags.string({
 			description: "Load a hook/extension file (can be used multiple times)",
 			multiple: true,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -813,6 +813,11 @@ export async function runRootCommand(
 		});
 	}
 
+	// Apply --hide-thinking CLI flag (ephemeral, not persisted)
+	if (parsedArgs.hideThinking) {
+		settingsInstance.override("hideThinkingBlock", true);
+	}
+
 	await logger.time(
 		"initTheme:final",
 		initTheme,

--- a/packages/coding-agent/test/cli-hide-thinking-flag.test.ts
+++ b/packages/coding-agent/test/cli-hide-thinking-flag.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "bun:test";
+import { parseArgs } from "../src/cli/args";
+
+describe("parseArgs — --hide-thinking flag", () => {
+	it("parses --hide-thinking as a boolean flag", () => {
+		const result = parseArgs(["--hide-thinking"]);
+		expect(result.hideThinking).toBe(true);
+	});
+
+	it("defaults hideThinking to undefined when flag is not provided", () => {
+		const result = parseArgs([]);
+		expect(result.hideThinking).toBeUndefined();
+	});
+
+	it("parses --hide-thinking with other flags", () => {
+		const result = parseArgs(["--hide-thinking", "--model", "opus", "hello"]);
+		expect(result.hideThinking).toBe(true);
+		expect(result.model).toBe("opus");
+		expect(result.messages).toContain("hello");
+	});
+
+	it("parses --hide-thinking with --thinking flag (both can coexist)", () => {
+		const result = parseArgs(["--hide-thinking", "--thinking", "extended"]);
+		expect(result.hideThinking).toBe(true);
+		expect(result.thinking).toBe("extended");
+	});
+
+	it("parses --hide-thinking in any position", () => {
+		const result1 = parseArgs(["--hide-thinking", "prompt"]);
+		const result2 = parseArgs(["prompt", "--hide-thinking"]);
+		const result3 = parseArgs(["--model", "opus", "--hide-thinking", "prompt"]);
+
+		expect(result1.hideThinking).toBe(true);
+		expect(result2.hideThinking).toBe(true);
+		expect(result3.hideThinking).toBe(true);
+	});
+
+	it("does not consume a value after --hide-thinking", () => {
+		const result = parseArgs(["--hide-thinking", "--model", "opus"]);
+		expect(result.hideThinking).toBe(true);
+		expect(result.model).toBe("opus");
+		expect(result.messages).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

Add `--hide-thinking` launch flag that hides thinking/reasoning blocks in the TUI output. Display-only: does not disable model reasoning, just suppresses the thinking output in the terminal.

## Changes

- `packages/coding-agent/src/cli/args.ts` — Add `hideThinking` to Args interface and `parseArgs`
- `packages/coding-agent/src/commands/launch.ts` — Add `--hide-thinking` flag definition
- `packages/coding-agent/src/main.ts` — Apply setting via `settingsInstance.override('hideThinkingBlock', true)` before TUI init
- `packages/coding-agent/test/cli-hide-thinking-flag.test.ts` — Test coverage

## Usage

```bash
oh-my-pi --hide-thinking
```

Closes #1313