### PR TITLE
fix: make Ctrl+O (app.tools.expand) work globally regardless of focus

### DIFF
--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -12,7 +12,6 @@ type ConfigurableEditorAction = Extract<
 	| "app.model.cycleBackward"
 	| "app.model.select"
 	| "app.model.selectTemporary"
-	| "app.tools.expand"
 	| "app.thinking.toggle"
 	| "app.editor.external"
 	| "app.history.search"
@@ -31,7 +30,6 @@ const DEFAULT_ACTION_KEYS: Record<ConfigurableEditorAction, KeyId[]> = {
 	"app.model.cycleBackward": ["shift+ctrl+p"],
 	"app.model.select": ["ctrl+l"],
 	"app.model.selectTemporary": ["alt+p"],
-	"app.tools.expand": ["ctrl+o"],
 	"app.thinking.toggle": ["ctrl+t"],
 	"app.editor.external": ["ctrl+g"],
 	"app.history.search": ["ctrl+r"],
@@ -52,7 +50,6 @@ export class CustomEditor extends Editor {
 	onCycleModelForward?: () => void;
 	onCycleModelBackward?: () => void;
 	onSelectModel?: () => void;
-	onExpandTools?: () => void;
 	onToggleThinking?: () => void;
 	onExternalEditor?: () => void;
 	onHistorySearch?: () => void;
@@ -155,12 +152,6 @@ export class CustomEditor extends Editor {
 		// Intercept configured history search shortcut
 		if (this.#matchesAction(data, "app.history.search") && this.onHistorySearch) {
 			this.onHistorySearch();
-			return;
-		}
-
-		// Intercept configured tool output expansion shortcut
-		if (this.#matchesAction(data, "app.tools.expand") && this.onExpandTools) {
-			this.onExpandTools();
 			return;
 		}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -114,6 +114,16 @@ export class InputController {
 
 		// Global debug handler on TUI (works regardless of focus)
 		this.ctx.ui.onDebug = () => this.ctx.showDebugSelector();
+
+		// Global tool output expand toggle
+		this.ctx.ui.addInputListener(data => {
+			if (this.ctx.keybindings.matches(data, "app.tools.expand")) {
+				this.toggleToolOutputExpansion();
+				return { consume: true };
+			}
+			return undefined;
+		});
+
 		this.ctx.editor.setActionKeys("app.model.select", this.ctx.keybindings.getKeys("app.model.select"));
 		this.ctx.editor.onSelectModel = () => this.ctx.showModelSelector();
 		this.ctx.editor.setActionKeys("app.history.search", this.ctx.keybindings.getKeys("app.history.search"));
@@ -133,8 +143,6 @@ export class InputController {
 			this.ctx.keybindings.getKeys("app.clipboard.copyPrompt"),
 		);
 		this.ctx.editor.onCopyPrompt = () => this.handleCopyPrompt();
-		this.ctx.editor.setActionKeys("app.tools.expand", this.ctx.keybindings.getKeys("app.tools.expand"));
-		this.ctx.editor.onExpandTools = () => this.toggleToolOutputExpansion();
 		this.ctx.editor.setActionKeys("app.message.dequeue", this.ctx.keybindings.getKeys("app.message.dequeue"));
 		this.ctx.editor.onDequeue = () => this.handleDequeue();
 

--- a/packages/coding-agent/test/input-controller-keybindings.test.ts
+++ b/packages/coding-agent/test/input-controller-keybindings.test.ts
@@ -17,7 +17,6 @@ type FakeEditor = {
 	onShowHotkeys?: () => void;
 	onPasteImage?: () => Promise<boolean>;
 	onCopyPrompt?: () => void;
-	onExpandTools?: () => void;
 	onToggleThinking?: () => void;
 	onExternalEditor?: () => void;
 	onDequeue?: () => void;
@@ -40,6 +39,7 @@ async function createContext() {
 	const showModelSelector = vi.fn();
 	const prompt = vi.fn(async () => {});
 	const updatePendingMessagesDisplay = vi.fn();
+	const uiAddInputListener = vi.fn();
 	const editor: FakeEditor = {
 		setText(text: string) {
 			editorText = text;
@@ -54,7 +54,7 @@ async function createContext() {
 	};
 	const ctx = {
 		editor: editor as unknown as InteractiveModeContext["editor"],
-		ui: { requestRender: vi.fn() } as unknown as InteractiveModeContext["ui"],
+		ui: { requestRender: vi.fn(), addInputListener: uiAddInputListener } as unknown as InteractiveModeContext["ui"],
 		loadingAnimation: undefined,
 		autoCompactionLoader: undefined,
 		retryLoader: undefined,
@@ -134,6 +134,30 @@ async function createContext() {
 }
 
 describe("InputController keybinding setup", () => {
+	it("registers app.tools.expand as a global input listener on UI", async () => {
+		const { InputController, ctx } = await createContext();
+		const controller = new InputController(ctx);
+		// Mock toggleToolOutputExpansion to check if it's called
+		const toggleSpy = vi.spyOn(controller, "toggleToolOutputExpansion").mockImplementation(() => {});
+		// Mock keybindings.matches to match ctrl+o
+		ctx.keybindings.matches = (data: string, action: string) => data === "ctrl+o" && action === "app.tools.expand";
+
+		controller.setupKeyHandlers();
+
+		expect(ctx.ui.addInputListener).toHaveBeenCalled();
+		const listener = (ctx.ui.addInputListener as any).mock.calls[0][0];
+
+		// Trigger with non-matching key
+		const noMatch = listener("ctrl+p");
+		expect(noMatch).toBeUndefined();
+		expect(toggleSpy).not.toHaveBeenCalled();
+
+		// Trigger with matching key
+		const match = listener("ctrl+o");
+		expect(match).toEqual({ consume: true });
+		expect(toggleSpy).toHaveBeenCalled();
+	});
+
 	it("registers temporary and persisted model selector actions separately", async () => {
 		const { InputController, ctx, editor, spies } = await createContext();
 		const controller = new InputController(ctx);


### PR DESCRIPTION
## Summary

Move the tool output expand toggle (Ctrl+O / `app.tools.expand`) from the editor-scoped handler to a global TUI input listener. This fixes Ctrl+O not responding when dialogs, model selectors, or other overlays have focus.

## Changes

- `packages/coding-agent/src/modes/components/custom-editor.ts` — Remove `app.tools.expand` from editor action keys and handler
- `packages/coding-agent/src/modes/controllers/input-controller.ts` — Add global input listener via `ctx.ui.addInputListener`, matching the pattern used by the debug key handler
- `packages/coding-agent/test/input-controller-keybindings.test.ts` — Test verifying global listener registration and dispatch

## Approach

Follows the same pattern as the existing debug key (`ctx.ui.onDebug`) which is already global. The listener returns `{ consume: true }` when matching to prevent event propagation.

Fixes #1156