### PR TITLE
Preserve discovered Codex context windows

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed generated OpenAI Codex model policies preserving stale 272K context metadata for GPT-5.5 when Codex discovery reports a larger per-account context window.
+
 ## [15.2.4] - 2026-05-22
 
 ### Fixed

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -176,25 +176,28 @@ export function applyGeneratedModelPolicies(models: ApiModel<Api>[]): void {
  * When a model's context is exhausted, the agent can promote to a sibling
  * model with a larger context window on the same provider:
  * - `codex-spark` variants promote to `gpt-5.5`.
- * - `gpt-5.5` (270K input) promotes to `gpt-5.4` (1M input).
+ * - `gpt-5.5` promotes to `gpt-5.4` only when discovery reports `gpt-5.4`
+ *   as a larger-context sibling.
  */
 export function linkOpenAIPromotionTargets(models: ApiModel<Api>[]): void {
 	for (const candidate of models) {
 		const parsedCandidate = parseKnownModel(candidate.id);
 		if (parsedCandidate.family !== "openai") continue;
-		let targetId: string | undefined;
 		if (parsedCandidate.variant === "codex-spark") {
-			targetId = "gpt-5.5";
-		} else if (parsedCandidate.variant === "base" && semverEqual(parsedCandidate.version, "5.5")) {
-			targetId = "gpt-5.4";
-		} else {
+			const fallback = models.find(
+				model => model.provider === candidate.provider && model.api === candidate.api && model.id === "gpt-5.5",
+			);
+			if (!fallback) continue;
+			candidate.contextPromotionTarget = `${fallback.provider}/${fallback.id}`;
 			continue;
 		}
-		const fallback = models.find(
-			model => model.provider === candidate.provider && model.api === candidate.api && model.id === targetId,
-		);
-		if (!fallback) continue;
-		candidate.contextPromotionTarget = `${fallback.provider}/${fallback.id}`;
+		if (parsedCandidate.variant === "base" && semverEqual(parsedCandidate.version, "5.5")) {
+			const fallback = models.find(
+				model => model.provider === candidate.provider && model.api === candidate.api && model.id === "gpt-5.4",
+			);
+			if (!fallback || fallback.contextWindow <= candidate.contextWindow) continue;
+			candidate.contextPromotionTarget = `${fallback.provider}/${fallback.id}`;
+		}
 	}
 }
 
@@ -404,9 +407,11 @@ function inferGeneratedApplyPatchToolType(
 }
 
 function applyOpenAICatalogPolicy(model: ApiModel<Api>, parsedModel: OpenAIModel): void {
-	// Codex models: 400K figure includes output budget; input window is 272K.
+	// Codex model discovery is authoritative for prompt budgets. Older Codex
+	// catalogs omitted per-account context windows, so keep 272K only as a
+	// conservative floor instead of overwriting newly-discovered larger windows.
 	if (parsedModel.variant.startsWith("codex") && parsedModel.variant !== "codex-spark") {
-		model.contextWindow = 272000;
+		model.contextWindow = Math.max(model.contextWindow, 272000);
 		return;
 	}
 	// GPT-5.4 mini/nano use plain OpenAI IDs on the Codex transport, but Codex still

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -207,7 +207,7 @@ describe("generated model policies", () => {
 		expect(models[1]?.cost.cacheRead).toBe(0.5);
 		expect(models[1]?.cost.cacheWrite).toBe(6.25);
 		expect(models[1]?.contextWindow).toBe(1000000);
-		expect(models[2]?.contextWindow).toBe(272000);
+		expect(models[2]?.contextWindow).toBe(400000);
 		expect(models[3]?.contextWindow).toBe(272000);
 		expect(models[3]?.priority).toBe(1);
 	});
@@ -253,29 +253,60 @@ describe("generated model policies", () => {
 		expect(models[2]?.maxTokens).toBe(64000);
 	});
 
-	it("links spark variants and gpt-5.5 to their context promotion targets", () => {
+	it("links spark variants and gpt-5.5 to larger context promotion targets only", () => {
 		const models = [
 			createModel({
 				id: "gpt-5.3-codex-spark",
 				api: "openai-codex-responses",
 				provider: "openai-codex",
 			}),
-			createModel({
-				id: "gpt-5.5",
-				api: "openai-codex-responses",
-				provider: "openai-codex",
-			}),
-			createModel({
-				id: "gpt-5.4",
-				api: "openai-codex-responses",
-				provider: "openai-codex",
-			}),
+			{
+				...createModel({
+					id: "gpt-5.5",
+					api: "openai-codex-responses",
+					provider: "openai-codex",
+				}),
+				contextWindow: 272000,
+			},
+			{
+				...createModel({
+					id: "gpt-5.4",
+					api: "openai-codex-responses",
+					provider: "openai-codex",
+				}),
+				contextWindow: 1000000,
+			},
 		];
 
 		linkOpenAIPromotionTargets(models);
 
 		expect(models[0]?.contextPromotionTarget).toBe("openai-codex/gpt-5.5");
 		expect(models[1]?.contextPromotionTarget).toBe("openai-codex/gpt-5.4");
+	});
+
+	it("does not promote gpt-5.5 when discovery reports the same sized context window", () => {
+		const models = [
+			{
+				...createModel({
+					id: "gpt-5.5",
+					api: "openai-codex-responses",
+					provider: "openai-codex",
+				}),
+				contextWindow: 1000000,
+			},
+			{
+				...createModel({
+					id: "gpt-5.4",
+					api: "openai-codex-responses",
+					provider: "openai-codex",
+				}),
+				contextWindow: 1000000,
+			},
+		];
+
+		linkOpenAIPromotionTargets(models);
+
+		expect(models[0]?.contextPromotionTarget).toBeUndefined();
 	});
 
 	it("sets freeform apply_patch metadata for first-party GPT-5 Responses models", () => {


### PR DESCRIPTION
## What

Preserve dynamically discovered OpenAI Codex context windows instead of unconditionally normalizing Codex-family models back to 272K.

Specifically:
- keep 272K as a conservative floor for older Codex catalogs
- preserve larger discovered context windows if the Codex backend reports them
- only link `gpt-5.5` to `gpt-5.4` for context promotion when `gpt-5.4` is actually larger
- update model metadata tests and changelog

## Why

The Codex model discovery endpoint already returns `context_window` metadata, but OMP's generated model policy currently overwrites Codex-family models back to 272K. That makes the policy layer more authoritative than live provider metadata.

This change lets Codex discovery remain authoritative when the backend reports a larger per-account context window, without losing the old conservative fallback for catalogs that omit it.

Note: after further checking, a local Codex CLI display of `1M` may come from `~/.codex/config.toml` `model_context_window = 1000000`, while the backend can still report `gpt-5.5` as `context_window: 272000`. This PR does not add a user override setting; it only stops OMP from clobbering larger values returned by discovery.

## Testing

- `bun test packages/ai/test/model-thinking.test.ts` — 17 pass
- `bun run check:ts` — passes
- `bun check` — TypeScript checks passed, Rust check failed because rustup could not install `rust-std-x86_64-pc-windows-msvc` due a local toolchain component conflict: `lib/rustlib/x86_64-pc-windows-msvc/lib/liballoc-74e1f98a9fc1cd65.rlib`

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
