### PR TITLE
fix(pi-shell): unblock bash heredocs >4 KiB on Windows and >64 KiB on macOS

### DIFF
--- a/crates/brush-core-vendored/src/interp.rs
+++ b/crates/brush-core-vendored/src/interp.rs
@@ -2152,22 +2152,59 @@ fn setup_process_substitution(
 	Ok((candidate_fd_num, target_file))
 }
 
+// LOCAL DIVERGENCE (vs upstream reubeno/brush@main):
+// Upstream writes the entire heredoc/here-string body into the pipe
+// synchronously on the calling thread. That deadlocks any time the body
+// exceeds the OS pipe buffer because the reader is not handed to the
+// downstream command (and therefore not drained) until after this
+// function returns. Concrete buffer sizes:
+//
+//   * Linux:    64 KiB default, growable via `F_SETPIPE_SZ` up to
+//               `/proc/sys/fs/pipe-max-size` (1 MiB default).
+//   * macOS:    16-64 KiB, no `F_SETPIPE_SZ` equivalent.
+//   * Windows:  ~4 KiB (`CreatePipe(nSize = 0)`), no portable knob to
+//               raise it.
+//
+// We keep the `F_SETPIPE_SZ` fast path for Linux (avoids a thread spawn
+// for the common in-process case) but fall through to a detached writer
+// thread on every other platform, and on Linux when the kernel rejects
+// the requested size (body > `pipe-max-size`). The thread owns the
+// writer; it terminates naturally when the consumer drains the pipe or
+// drops the reader (`BrokenPipe`), so no `JoinHandle` is retained.
 fn setup_open_file_with_contents(contents: &str) -> Result<OpenFile, error::Error> {
 	let (reader, mut writer) = std::io::pipe()?;
-
 	let bytes = contents.as_bytes();
 
+	// Linux fast path: grow the pipe so the entire body fits inline.
+	// Falls through to the generic writer when (a) `bytes.len()`
+	// overflows `i32`, or (b) the kernel rejects the requested size
+	// (body > /proc/sys/fs/pipe-max-size, default 1 MiB).
 	#[cfg(any(target_os = "linux", target_os = "android"))]
 	{
 		use std::os::fd::AsFd as _;
 
-		let len = i32::try_from(bytes.len())
-			.map_err(|_err| error::Error::from(error::ErrorKind::TooMuchData))?;
-		nix::fcntl::fcntl(reader.as_fd(), nix::fcntl::FcntlArg::F_SETPIPE_SZ(len))?;
+		if let Ok(len) = i32::try_from(bytes.len())
+			&& nix::fcntl::fcntl(reader.as_fd(), nix::fcntl::FcntlArg::F_SETPIPE_SZ(len)).is_ok()
+		{
+			writer.write_all(bytes)?;
+			drop(writer);
+			return Ok(reader.into());
+		}
 	}
 
-	writer.write_all(bytes)?;
-	drop(writer);
+	// Generic path: detached writer thread. Writing inline deadlocks
+	// once `bytes.len()` exceeds the OS pipe buffer (Windows ~4 KiB,
+	// macOS 16-64 KiB), neither of which has a `F_SETPIPE_SZ`
+	// equivalent.
+	let payload = bytes.to_vec();
+	std::thread::Builder::new()
+		.name("brush-heredoc-writer".into())
+		.spawn(move || {
+			// `BrokenPipe` is expected when the consumer drops the
+			// reader before the body is fully written; there is
+			// nothing useful to do with that error here.
+			let _ = writer.write_all(&payload);
+		})?;
 
 	Ok(reader.into())
 }

--- a/crates/brush-core-vendored/src/interp.rs
+++ b/crates/brush-core-vendored/src/interp.rs
@@ -2167,10 +2167,12 @@ fn setup_process_substitution(
 //
 // We keep the `F_SETPIPE_SZ` fast path for Linux (avoids a thread spawn
 // for the common in-process case) but fall through to a detached writer
-// thread on every other platform, and on Linux when the kernel rejects
-// the requested size (body > `pipe-max-size`). The thread owns the
-// writer; it terminates naturally when the consumer drains the pipe or
-// drops the reader (`BrokenPipe`), so no `JoinHandle` is retained.
+// thread on every other platform with OS threads, and on Linux when the
+// kernel rejects the requested size (body > `pipe-max-size`). The thread
+// owns the writer; it terminates naturally when the consumer drains the
+// pipe or drops the reader (`BrokenPipe`), so no `JoinHandle` is retained.
+// Targets without OS thread support keep upstream's synchronous write path
+// so heredocs continue to work there instead of failing at thread spawn.
 fn setup_open_file_with_contents(contents: &str) -> Result<OpenFile, error::Error> {
 	let (reader, mut writer) = std::io::pipe()?;
 	let bytes = contents.as_bytes();
@@ -2191,20 +2193,28 @@ fn setup_open_file_with_contents(contents: &str) -> Result<OpenFile, error::Erro
 			return Ok(reader.into());
 		}
 	}
-
-	// Generic path: detached writer thread. Writing inline deadlocks
-	// once `bytes.len()` exceeds the OS pipe buffer (Windows ~4 KiB,
-	// macOS 16-64 KiB), neither of which has a `F_SETPIPE_SZ`
-	// equivalent.
-	let payload = bytes.to_vec();
-	std::thread::Builder::new()
-		.name("brush-heredoc-writer".into())
-		.spawn(move || {
-			// `BrokenPipe` is expected when the consumer drops the
-			// reader before the body is fully written; there is
-			// nothing useful to do with that error here.
-			let _ = writer.write_all(&payload);
-		})?;
+	#[cfg(target_family = "wasm")]
+	{
+		writer.write_all(bytes)?;
+		drop(writer);
+		return Ok(reader.into());
+	}
+	#[cfg(not(target_family = "wasm"))]
+	{
+		// Generic path: detached writer thread. Writing inline deadlocks
+		// once `bytes.len()` exceeds the OS pipe buffer (Windows ~4 KiB,
+		// macOS 16-64 KiB), neither of which has a `F_SETPIPE_SZ`
+		// equivalent.
+		let payload = bytes.to_vec();
+		std::thread::Builder::new()
+			.name("brush-heredoc-writer".into())
+			.spawn(move || {
+				// `BrokenPipe` is expected when the consumer drops the
+				// reader before the body is fully written; there is
+				// nothing useful to do with that error here.
+				let _ = writer.write_all(&payload);
+			})?;
+	}
 
 	Ok(reader.into())
 }

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -1919,4 +1919,32 @@ mod tests {
 		}
 		assert_eq!(stdout, b"prod:8080");
 	}
+
+	/// Regression for a Windows/macOS deadlock in
+	/// `brush_core::interp::setup_open_file_with_contents`. The body is
+	/// 256 KiB — well past the default pipe buffer on every platform
+	/// (Windows ~4 KiB, macOS 16-64 KiB, Linux 64 KiB), so any inline
+	/// `write_all` on the calling thread blocks forever. The `:` builtin
+	/// never reads its stdin, so the only way `echo done` runs is if the
+	/// heredoc writer is decoupled from the main thread (or, on Linux,
+	/// the pipe buffer was grown via `F_SETPIPE_SZ`). The
+	/// `tokio::time::timeout` is the safety net that turns a regression
+	/// into a 10 s failure instead of hanging CI for the full
+	/// hard-timeout window.
+	#[tokio::test(flavor = "multi_thread")]
+	async fn large_heredoc_does_not_deadlock() {
+		let body = "X".repeat(256 * 1024);
+		let command = format!(": <<'EOF'\n{body}\nEOF\necho done");
+		let options = ShellExecuteOptions { command, ..Default::default() };
+
+		let result = time::timeout(
+			Duration::from_secs(10),
+			execute_shell(options, None, CancelToken::default()),
+		)
+		.await
+		.expect("execute_shell hung past 10 s — heredoc writer deadlocked")
+		.expect("execute_shell errored");
+
+		assert_eq!(result.exit_code, Some(0), "command did not run to completion");
+	}
 }

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -128,6 +128,7 @@
 - Fixed built-in `explore` agent failing every invocation with `schema_violation: files.0.ref: must not be present` on releases prior to 15.3.2 by renaming the `files[].ref` property to `files[].path` in the agent's output schema; `ref` is a JTD-reserved keyword (RFC 8927) and collides with JSON Type Definition's schema-reference form, so the converter previously dropped it from the generated JSON Schema. Defense-in-depth alongside the 15.3.2 converter fix ([#1379](https://github.com/can1357/oh-my-pi/issues/1379)).
 - Increased the `yield` tool's schema-validation retry budget from 1 to 3 so subagents whose first structured-output attempt mismatches the declared output schema get up to three retries before the parent's post-mortem `schema_violation` check hard-fails the task. The tool now also surfaces remaining retry attempts and an explicit "call yield again with the corrected shape" directive in each rejection message, giving the model the context it needs to converge — particularly helpful for models like GLM that tend to invent per-element field names instead of following the declared schema.
 - Fixed CLI PDF file arguments being decoded as raw bytes for local vision models; `.pdf` and other supported document files now go through the same Markit conversion path as the `read` tool before entering the prompt ([#1401](https://github.com/can1357/oh-my-pi/issues/1401)).
+- Fixed the `bash` tool hanging until the 305 s hard timeout when a command writes a file via heredoc on Windows (bodies > ~4 KiB) or macOS (bodies > 16-64 KiB). Root cause was in the embedded brush shell; see `@oh-my-pi/pi-natives` changelog for the underlying fix.
 
 ## [15.3.2] - 2026-05-25
 ### Added
@@ -141,8 +142,6 @@
 
 - Fixed parsing of inline `|TEXT` payloads containing whitespace on `»` and `«` inserts, which previously failed with unrecognized-op errors
 - Fixed anchored insert handling so an inline `|TEXT` body matching the anchor line is treated as anchor decoration and no longer inserted as a duplicate
-- Fixed clipboard image paste (Ctrl+V) silently failing on WSL2 by routing image reads through a `powershell.exe` bridge when WSL interop is detected, since `arboard` returns `ContentNotAvailable` under WSLg ([#1280](https://github.com/can1357/oh-my-pi/issues/1280))
-- Fixed the `bash` tool hanging until the 305 s hard timeout when a command writes a file via heredoc on Windows (bodies > ~4 KiB) or macOS (bodies > 16-64 KiB). Root cause was in the embedded brush shell; see `@oh-my-pi/pi-natives` changelog for the underlying fix.
 
 ## [15.3.0] - 2026-05-25
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -141,6 +141,8 @@
 
 - Fixed parsing of inline `|TEXT` payloads containing whitespace on `»` and `«` inserts, which previously failed with unrecognized-op errors
 - Fixed anchored insert handling so an inline `|TEXT` body matching the anchor line is treated as anchor decoration and no longer inserted as a duplicate
+- Fixed clipboard image paste (Ctrl+V) silently failing on WSL2 by routing image reads through a `powershell.exe` bridge when WSL interop is detected, since `arboard` returns `ContentNotAvailable` under WSLg ([#1280](https://github.com/can1357/oh-my-pi/issues/1280))
+- Fixed the `bash` tool hanging until the 305 s hard timeout when a command writes a file via heredoc on Windows (bodies > ~4 KiB) or macOS (bodies > 16-64 KiB). Root cause was in the embedded brush shell; see `@oh-my-pi/pi-natives` changelog for the underlying fix.
 
 ## [15.3.0] - 2026-05-25
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,14 +2,15 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bash heredocs (`<<`) and here-strings (`<<<`) deadlocking the shell on Windows past ~4 KiB and on macOS past 16-64 KiB. `brush_core::interp::setup_open_file_with_contents` wrote the entire body into an anonymous pipe synchronously before handing the reader to the next command; once the body exceeded the OS pipe buffer the writer blocked forever and the `bash` tool timed out at the hard 305 s ceiling without ever launching the consumer. The Linux fast path still uses `F_SETPIPE_SZ` to grow the pipe in-place; every other OS-threaded platform (and Linux bodies above `pipe-max-size`) now decouples the write onto a fire-and-forget thread that terminates naturally on drain or `BrokenPipe`; no-thread targets keep the upstream synchronous path so heredocs do not fail at thread spawn.
+
 ## [15.3.2] - 2026-05-25
 
 ### Fixed
 
 - Fixed `matchesKey` claiming `ctrl+m`/`ctrl+j`/`ctrl+i`/`ctrl+h`/`ctrl+[` for the single bytes terminals emit for Enter/Tab/Backspace/Escape in legacy mode. Pressing Enter no longer triggers a `ctrl+m` binding; the named keys now own those bytes and the colliding `ctrl+<letter>` combinations only match when the terminal disambiguates via the Kitty keyboard protocol or `modifyOtherKeys`. The same gate now also applies to `ctrl+alt+<letter>` legacy `ESC + <ctrl-char>` sequences (e.g. `\x1b\r` is Alt+Enter, not Ctrl+Alt+M). ([#1354](https://github.com/can1357/oh-my-pi/issues/1354))
-### Fixed
-
-- Fixed bash heredocs (`<<`) and here-strings (`<<<`) deadlocking the shell on Windows past ~4 KiB and on macOS past 16-64 KiB. `brush_core::interp::setup_open_file_with_contents` wrote the entire body into an anonymous pipe synchronously before handing the reader to the next command; once the body exceeded the OS pipe buffer the writer blocked forever and the `bash` tool timed out at the hard 305 s ceiling without ever launching the consumer. The Linux fast path still uses `F_SETPIPE_SZ` to grow the pipe in-place; every other platform (and Linux bodies above `pipe-max-size`) now decouples the write onto a fire-and-forget thread that terminates naturally on drain or `BrokenPipe`.
 
 ## [15.0.2] - 2026-05-15
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -7,6 +7,9 @@
 ### Fixed
 
 - Fixed `matchesKey` claiming `ctrl+m`/`ctrl+j`/`ctrl+i`/`ctrl+h`/`ctrl+[` for the single bytes terminals emit for Enter/Tab/Backspace/Escape in legacy mode. Pressing Enter no longer triggers a `ctrl+m` binding; the named keys now own those bytes and the colliding `ctrl+<letter>` combinations only match when the terminal disambiguates via the Kitty keyboard protocol or `modifyOtherKeys`. The same gate now also applies to `ctrl+alt+<letter>` legacy `ESC + <ctrl-char>` sequences (e.g. `\x1b\r` is Alt+Enter, not Ctrl+Alt+M). ([#1354](https://github.com/can1357/oh-my-pi/issues/1354))
+### Fixed
+
+- Fixed bash heredocs (`<<`) and here-strings (`<<<`) deadlocking the shell on Windows past ~4 KiB and on macOS past 16-64 KiB. `brush_core::interp::setup_open_file_with_contents` wrote the entire body into an anonymous pipe synchronously before handing the reader to the next command; once the body exceeded the OS pipe buffer the writer blocked forever and the `bash` tool timed out at the hard 305 s ceiling without ever launching the consumer. The Linux fast path still uses `F_SETPIPE_SZ` to grow the pipe in-place; every other platform (and Linux bodies above `pipe-max-size`) now decouples the write onto a fire-and-forget thread that terminates naturally on drain or `BrokenPipe`.
 
 ## [15.0.2] - 2026-05-15
 


### PR DESCRIPTION
## Symptom

The `bash` tool times out after 305 s when the agent sends a heredoc-style command such as:

```bash
mkdir -p .agent-context
cat > .agent-context/merge-context.md << 'CONTEXT'
... ~4 KB of literal body ...
CONTEXT
ls -la .agent-context/
```

The hard timeout text is the one emitted by `bash_executor.ts:214`: `Command exceeded hard timeout after <N> seconds`. Nothing about the user's command is malformed — the brush interpreter deadlocks before `cat`/`ls` ever runs.

## Root cause

`brush_core::interp::setup_open_file_with_contents` wires heredocs and here-strings to a process by:

1. creating an anonymous pipe via `std::io::pipe()`,
2. **synchronously** writing the whole body into the writer half on the calling thread,
3. handing the reader half to the next command as its stdin.

The reader is not consumed until after the function returns and the command spawns, so step (2) is bounded by the OS pipe buffer:

| Platform | Pipe buffer | Workaround in current code |
| -------- | ----------- | -------------------------- |
| Linux    | 64 KiB default, growable via `F_SETPIPE_SZ` up to `/proc/sys/fs/pipe-max-size` (1 MiB) | `F_SETPIPE_SZ(len)` before the write |
| macOS    | 16–64 KiB, no `F_SETPIPE_SZ` equivalent | **none** |
| Windows  | `CreatePipe(0)` ≈ 4 KiB | **none** |

Any heredoc bigger than the platform buffer (~4 KiB on Windows, 16–64 KiB on macOS) fills the buffer mid-write, `writer.write_all` blocks forever, and the 305 s hard-timeout in `pi-shell` finally trips. Confirmed present in upstream `reubeno/brush@main`.

## Fix

In the vendored `setup_open_file_with_contents`, keep the Linux `F_SETPIPE_SZ` fast path for the common in-process case, but fall through to a **detached writer thread** on every other platform (and on Linux when the kernel rejects the requested size — body > `pipe-max-size`). The thread owns the writer and terminates naturally on drain or `BrokenPipe`. No `JoinHandle` is kept — it's fire-and-forget, same shape `dash` uses for large heredocs.

A `LOCAL DIVERGENCE (vs upstream reubeno/brush@main)` comment block documents the fork.

## Tests

- New cross-platform regression `large_heredoc_does_not_deadlock` in `pi-shell::shell::tests` writes a 256 KiB body through the `:` builtin (never drains stdin) and asserts `execute_shell` finishes in ≤10 s with exit code 0. Pre-fix, the test panics with `execute_shell hung past 10 s — heredoc writer deadlocked` (verified locally by stashing the fix).
- Full `cargo test -p pi-shell` (184 tests) green.
- End-to-end smoke through the rebuilt napi binding: the user's exact heredoc shape (mkdir + `cat > .agent-context/merge-context.md << 'CONTEXT' … CONTEXT` + ls) with a 12,889-byte body completes in **178 ms**, exit 0, file written intact. Pre-fix the same command hangs to 305 s.
- `cargo clippy -p brush-core --lib` / `cargo clippy -p pi-shell --all-targets` — no new warnings (5 pre-existing in `process.rs`).

## Files

- `crates/brush-core-vendored/src/interp.rs` — rewrite `setup_open_file_with_contents`; document the divergence.
- `crates/pi-shell/src/shell.rs` — add `large_heredoc_does_not_deadlock`.
- `packages/natives/CHANGELOG.md` — `[Unreleased] → Fixed` entry.
- `packages/coding-agent/CHANGELOG.md` — `[Unreleased] → Fixed` entry pointing at the natives release.

Surfaced from a session report; no issue tracked.
