### PR TITLE
fix(edit): accept dash-separated anchors from read collapsed output

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,9 +19,8 @@
 - Updated Tavily missing-credential feedback to prompt users to configure an API-key provider setting instead of referencing `agent.db` directly
 - Refreshed expired OpenAI Codex OAuth tokens during `web_search` execution and persisted the updated credentials so searches continue working after token expiry
 
-### Fixed
-
 - Fixed built-in `explore` agent failing every invocation with `schema_violation: files.0.ref: must not be present` on releases prior to 15.3.2 by renaming the `files[].ref` property to `files[].path` in the agent's output schema; `ref` is a JTD-reserved keyword (RFC 8927) and collides with JSON Type Definition's schema-reference form, so the converter previously dropped it from the generated JSON Schema. Defense-in-depth alongside the 15.3.2 converter fix ([#1379](https://github.com/can1357/oh-my-pi/issues/1379)).
+- Fixed `edit` rejecting dash-separated anchor ranges (e.g. `≔29ej-92rk`) that the `read` tool emits in its collapsed-line output, which previously forced models to retry with `..` form
 
 ## [15.3.2] - 2026-05-25
 ### Added

--- a/packages/coding-agent/src/hashline/parser.ts
+++ b/packages/coding-agent/src/hashline/parser.ts
@@ -5,6 +5,7 @@ import {
 	HL_BODY_SEP_RE_RAW,
 	HL_FILE_PREFIX,
 	HL_HASH_CAPTURE_RE_RAW,
+	HL_HASH_RE_RAW,
 	HL_OP_CHARS,
 	HL_OP_INSERT_AFTER,
 	HL_OP_INSERT_BEFORE,
@@ -18,6 +19,8 @@ import type { Anchor, HashlineCursor, HashlineEdit } from "./types";
 //   - an optional trailing `|TEXT` body (or anything after the hash) so users
 //     can paste a full `LINE+HASH|TEXT` line verbatim.
 const LID_CAPTURE_RE = new RegExp(`^\\s*[>+\\-*]*\\s*${HL_HASH_CAPTURE_RE_RAW}(?:\\|.*)?\\s*$`);
+/** Matches two anchors joined by a dash, as emitted by read's collapsed-range output (e.g. "29ej-92rk"). */
+const DASH_RANGE_RE = new RegExp(`^(${HL_HASH_RE_RAW})-(${HL_HASH_RE_RAW})$`);
 const regexEscape = (str: string): string => str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 function parseLid(raw: string, lineNum: number): Anchor {
@@ -37,6 +40,9 @@ interface ParsedRange {
 }
 
 function parseRange(raw: string, lineNum: number): ParsedRange {
+	// Normalize dash-separated anchors from read's collapsed-range output (e.g. "29ej-92rk") to the canonical ".." form.
+	const dashMatch = DASH_RANGE_RE.exec(raw);
+	if (dashMatch) raw = `${dashMatch[1]}..${dashMatch[2]}`;
 	if (!raw.includes("..")) {
 		const start = parseLid(raw, lineNum);
 		return { start, end: { ...start } };

--- a/packages/coding-agent/src/hashline/parser.ts
+++ b/packages/coding-agent/src/hashline/parser.ts
@@ -19,8 +19,8 @@ import type { Anchor, HashlineCursor, HashlineEdit } from "./types";
 //   - an optional trailing `|TEXT` body (or anything after the hash) so users
 //     can paste a full `LINE+HASH|TEXT` line verbatim.
 const LID_CAPTURE_RE = new RegExp(`^\\s*[>+\\-*]*\\s*${HL_HASH_CAPTURE_RE_RAW}(?:\\|.*)?\\s*$`);
-/** Matches two anchors joined by a dash, as emitted by read's collapsed-range output (e.g. "29ej-92rk"). */
-const DASH_RANGE_RE = new RegExp(`^(${HL_HASH_RE_RAW})-(${HL_HASH_RE_RAW})$`);
+/** Matches two anchors joined by a dash, as emitted by read's collapsed-range output (e.g. "29ej-92rk|..."). */
+const DASH_RANGE_RE = new RegExp(`^(${HL_HASH_RE_RAW})-(${HL_HASH_RE_RAW}(?:\\|.*)?)$`);
 const regexEscape = (str: string): string => str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 function parseLid(raw: string, lineNum: number): Anchor {
@@ -112,7 +112,7 @@ const INSERT_BEFORE_OP_RE = new RegExp(
 const INSERT_AFTER_OP_RE = new RegExp(
 	`^${regexEscape(HL_OP_INSERT_AFTER)}\\s*([^|\\s]+)(?:${HL_BODY_SEP_RE_RAW}(.*))?\\s*$`,
 );
-const REPLACE_OP_RE = new RegExp(`^${regexEscape(HL_OP_REPLACE)}\\s*([^\\s+<\\-=]\\S*)\\s*$`);
+const REPLACE_OP_RE = new RegExp(`^${regexEscape(HL_OP_REPLACE)}\\s*([^\\s+<\\-=][^\\r\\n]*)\\s*$`);
 
 function isEnvelopeOrAbortMarkerLine(line: string): boolean {
 	const trimmed = line.trimEnd();

--- a/packages/coding-agent/src/hashline/parser.ts
+++ b/packages/coding-agent/src/hashline/parser.ts
@@ -40,9 +40,23 @@ interface ParsedRange {
 }
 
 function parseRange(raw: string, lineNum: number): ParsedRange {
-	// Normalize dash-separated anchors from read's collapsed-range output (e.g. "29ej-92rk") to the canonical ".." form.
+	// read's collapsed-range output emits dash-separated anchors (e.g. "29ej-92rk|HEAD .. TAIL").
+	// Parse those directly: parseLid strips the trailing `|TEXT` body, and bypassing the
+	// `..` split avoids aliasing when `..` appears literally inside the collapsed body.
 	const dashMatch = DASH_RANGE_RE.exec(raw);
-	if (dashMatch) raw = `${dashMatch[1]}..${dashMatch[2]}`;
+	if (dashMatch) {
+		const start = parseLid(dashMatch[1], lineNum);
+		const end = parseLid(dashMatch[2], lineNum);
+		if (end.line < start.line) {
+			throw new Error(`line ${lineNum}: range ${dashMatch[1]}-${dashMatch[2]} ends before it starts.`);
+		}
+		if (end.line === start.line && end.hash !== start.hash) {
+			throw new Error(
+				`line ${lineNum}: range ${dashMatch[1]}-${dashMatch[2]} uses two different hashes for the same line.`,
+			);
+		}
+		return { start, end };
+	}
 	if (!raw.includes("..")) {
 		const start = parseLid(raw, lineNum);
 		return { start, end: { ...start } };
@@ -112,7 +126,7 @@ const INSERT_BEFORE_OP_RE = new RegExp(
 const INSERT_AFTER_OP_RE = new RegExp(
 	`^${regexEscape(HL_OP_INSERT_AFTER)}\\s*([^|\\s]+)(?:${HL_BODY_SEP_RE_RAW}(.*))?\\s*$`,
 );
-const REPLACE_OP_RE = new RegExp(`^${regexEscape(HL_OP_REPLACE)}\\s*([^\\s+<\\-=][^\\r\\n]*)\\s*$`);
+const REPLACE_OP_RE = new RegExp(`^${regexEscape(HL_OP_REPLACE)}\\s*([^\\s+<\\-=][^\\r\\n]*?)\\s*$`);
 
 function isEnvelopeOrAbortMarkerLine(line: string): boolean {
 	const trimmed = line.trimEnd();

--- a/packages/coding-agent/test/core/hashline.test.ts
+++ b/packages/coding-agent/test/core/hashline.test.ts
@@ -421,6 +421,17 @@ describe("hashline parser — block op syntax", () => {
 		expect(applyDiff(content, `»BOF|HEAD`)).toBe("HEAD\naaa\nbbb\nccc");
 		expect(applyDiff(content, `»EOF|TAIL`)).toBe("aaa\nbbb\nccc\nTAIL");
 	});
+
+	it('normalizes dash-separated range anchors from read collapsed output (e.g. "29ej-92rk")', () => {
+		// read's formatMergedBraceLine emits `START-END|content` for collapsed ranges.
+		// The model sometimes copies this dash form instead of the canonical `..` separator.
+		const anchor2 = tag(2, "bbb");
+		const anchor3 = tag(3, "ccc");
+		// Single-line replace via dash form should work like `≔anchor`
+		expect(applyDiff(content, `≔${anchor2}-${anchor2}\n${pl("BBB")}`)).toBe("aaa\nBBB\nccc");
+		// Multi-line range via dash form should work like `≔A..B`
+		expect(applyDiff(content, `≔${anchor2}-${anchor3}\n${pl("BBB")}\n${pl("CCC")}`)).toBe("aaa\nBBB\nCCC");
+	});
 });
 
 describe("hashline — stale anchors", () => {

--- a/packages/coding-agent/test/core/hashline.test.ts
+++ b/packages/coding-agent/test/core/hashline.test.ts
@@ -433,6 +433,10 @@ describe("hashline parser — block op syntax", () => {
 		expect(applyDiff(content, `≔${anchor2}-${anchor3}\n${pl("BBB")}\n${pl("CCC")}`)).toBe("aaa\nBBB\nCCC");
 		// The read tool's collapsed output includes a trailing `|TEXT` body after the end anchor.
 		expect(applyDiff(content, `≔${anchor2}-${anchor3}|collapsed body\n${pl("BBB")}`)).toBe("aaa\nBBB");
+		// read's formatMergedBraceLine emits `HEAD .. TAIL` inside the body when collapsing
+		// multi-line brace pairs. The dash-range parser must not be fooled by the literal `..`.
+		expect(applyDiff(content, `≔${anchor2}-${anchor3}|bbb .. ccc\n${pl("BBB")}`)).toBe("aaa\nBBB");
+		expect(applyDiff(content, `≔${anchor2}-${anchor2}|head .. tail\n${pl("BBB")}`)).toBe("aaa\nBBB\nccc");
 	});
 });
 

--- a/packages/coding-agent/test/core/hashline.test.ts
+++ b/packages/coding-agent/test/core/hashline.test.ts
@@ -431,6 +431,8 @@ describe("hashline parser — block op syntax", () => {
 		expect(applyDiff(content, `≔${anchor2}-${anchor2}\n${pl("BBB")}`)).toBe("aaa\nBBB\nccc");
 		// Multi-line range via dash form should work like `≔A..B`
 		expect(applyDiff(content, `≔${anchor2}-${anchor3}\n${pl("BBB")}\n${pl("CCC")}`)).toBe("aaa\nBBB\nCCC");
+		// The read tool's collapsed output includes a trailing `|TEXT` body after the end anchor.
+		expect(applyDiff(content, `≔${anchor2}-${anchor3}|collapsed body\n${pl("BBB")}`)).toBe("aaa\nBBB");
 	});
 });
 


### PR DESCRIPTION
## Problem

The `read` tool emits collapsed/summarized line ranges using a dash separator (e.g. `29ej-92rk|content`), but the edit parser only accepted `..` as a range separator. When a model copies this dash-formatted anchor into an edit command like `≔29ej-92rk`, the parser throws:

```
line 1: expected a full anchor such as "119sr", "119ab", "119th"; got "29ej-92rk".
```

This wastes tokens on every failed tool call and requires a retry.

Worse, when `read` collapses a multi-line brace pair, `formatMergedBraceLine` emits `START-END|HEAD .. TAIL` — a literal ` .. ` appears inside the body. A first-pass fix that normalized `A-B` to `A..B` and then split on `..` blew up on bodies like `bbb .. ccc` (three segments → "exactly two anchors" guard tripped).

## Root Cause

`formatMergedBraceLine` in `read.ts` outputs `START-END|HEAD .. TAIL` (dash separator with a `..`-bearing body). `parseRange` in `parser.ts` only accepted `..` as a range separator, and naive normalization aliased the body's `..` with the range separator.

## Fix

- **`parser.ts` — dash-range bypass.** When `DASH_RANGE_RE` matches, call `parseLid` directly on each side (it already strips the trailing `|TEXT` via `LID_CAPTURE_RE`) and skip the `..` split entirely. This sidesteps the body-aliasing trap.
- **`parser.ts` — `REPLACE_OP_RE`.** Made the body capture lazy (`[^\r\n]*?`) so the trailing `\s*$` actually trims whitespace from the captured anchor.
- **`hashline.test.ts`** — Added tests for single-line dash, multi-line dash, trailing `|TEXT` body, and `HEAD .. TAIL`-shaped bodies that mirror `formatMergedBraceLine`'s exact output.

## Verification

- New tests cover both shapes `read` actually emits: `≔A-B|bbb .. ccc` (multi-line collapse) and `≔A-A|head .. tail` (single-line collapse).
- Invalid inputs (reversed ranges, mismatched same-line hashes) still throw appropriate errors.
- Insert ops (`»`/`«`) still correctly reject dash ranges (single anchors only).
- All existing hashline tests pass (1 pre-existing Windows path-separator failure unrelated).
- `tsc -p packages/coding-agent` clean; `biome check` clean.
