### PR TITLE
Fix threshold auto-compaction preempted by context promotion

### DIFF
--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -108,8 +108,7 @@ The automatic paths are intentionally different:
 - **Threshold maintenance**
   - Trigger: successful, non-error assistant message whose adjusted context tokens exceed `resolveThresholdTokens(...)`.
   - Tool-output pruning can reduce the measured token count before threshold comparison.
-  - Context promotion is tried before compaction.
-  - If promotion is unavailable, auto maintenance runs with `reason: "threshold"` and `willRetry: false`.
+  - Context promotion is not used on the threshold path; threshold maintenance preserves the selected model and runs auto maintenance with `reason: "threshold"` and `willRetry: false`.
   - With `compaction.strategy: "handoff"`, threshold maintenance starts a new handoff session instead of writing a compaction entry; if handoff returns no document without aborting, it falls back to context-full compaction.
   - On success, if `compaction.autoContinue !== false`, schedules an agent-authored developer auto-continue prompt from `prompts/system/auto-continue.md`.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed clipboard image paste (Ctrl+V) silently failing on WSL2 by routing image reads through a `powershell.exe` bridge when WSL interop is detected, since `arboard` returns `ContentNotAvailable` under WSLg ([#1280](https://github.com/can1357/oh-my-pi/issues/1280))
+- Fixed threshold auto-compaction being preempted by context promotion, which could silently switch long Codex sessions from the selected model before compaction ran ([#1329](https://github.com/can1357/oh-my-pi/issues/1329)).
 
 ## [15.2.4] - 2026-05-22
 ### Breaking Changes

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5588,13 +5588,13 @@ export class AgentSession {
 	}
 
 	/**
-	 * Check if context maintenance or promotion is needed and run it.
+	 * Check if context maintenance or overflow promotion is needed and run it.
 	 * Called after agent_end and before prompt submission.
 	 *
-	 * Three cases (in order):
-	 * 1. Overflow + promotion: promote to larger model, retry without maintenance
+	 * Three cases:
+	 * 1. Overflow + promotion target: promote to larger model, retry without maintenance
 	 * 2. Overflow + no promotion target: run context maintenance, auto-retry on same model
-	 * 3. Threshold: Context over threshold, run context maintenance (no auto-retry)
+	 * 3. Threshold: run context maintenance on the selected model (no promotion, no auto-retry)
 	 *
 	 * @param assistantMessage The assistant message to check
 	 * @param skipAbortedCheck If false, include aborted messages (for pre-prompt check). Default: true
@@ -5643,7 +5643,7 @@ export class AgentSession {
 		const compactionSettings = this.settings.getGroup("compaction");
 		if (!compactionSettings.enabled || compactionSettings.strategy === "off") return;
 
-		// Case 2: Threshold - turn succeeded but context is getting large
+		// Case 3: Threshold - turn succeeded but context is getting large
 		// Skip if this was an error (non-overflow errors don't have usage data)
 		if (assistantMessage.stopReason === "error") return;
 		const pruneResult = await this.#pruneToolOutputs();
@@ -5652,11 +5652,7 @@ export class AgentSession {
 			contextTokens = Math.max(0, contextTokens - pruneResult.tokensSaved);
 		}
 		if (shouldCompact(contextTokens, contextWindow, compactionSettings)) {
-			// Try promotion first — if a larger model is available, switch instead of compacting
-			const promoted = await this.#tryContextPromotion(assistantMessage);
-			if (!promoted) {
-				await this.#runAutoCompaction("threshold", false);
-			}
+			await this.#runAutoCompaction("threshold", false);
 		}
 	}
 	#assistantEndedWithSuccessfulYield(assistantMessage: AssistantMessage): boolean {

--- a/packages/coding-agent/test/agent-session-context-promotion.test.ts
+++ b/packages/coding-agent/test/agent-session-context-promotion.test.ts
@@ -176,6 +176,69 @@ describe("AgentSession context promotion", () => {
 		expect(session.model?.provider).toBe(codexModel.provider);
 		expect(session.model?.id).toBe(codexModel.id);
 	});
+
+	it("runs threshold compaction instead of context promotion", async () => {
+		const sparkModel = modelRegistry.find("openai-codex", "gpt-5.3-codex-spark");
+		const promotedModel = modelRegistry.find("openai-codex", "gpt-5.5");
+		if (!sparkModel || !promotedModel) {
+			throw new Error("Expected codex spark and promoted codex models to exist");
+		}
+
+		const settings = Settings.isolated({
+			"compaction.enabled": true,
+			"compaction.autoContinue": false,
+			"contextPromotion.enabled": true,
+		});
+
+		const agent = new Agent({
+			initialState: {
+				model: sparkModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			modelRegistry,
+		});
+
+		let thresholdCompactionStarted = false;
+		let thresholdCompactionEnded = false;
+		session.subscribe(event => {
+			if (event.type === "auto_compaction_start" && event.reason === "threshold") {
+				thresholdCompactionStarted = true;
+			}
+			if (event.type === "auto_compaction_end") {
+				thresholdCompactionEnded = true;
+			}
+		});
+
+		const thresholdMessage: AssistantMessage = {
+			...createAssistantMessage(sparkModel),
+			usage: {
+				input: sparkModel.contextWindow,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: sparkModel.contextWindow,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+		};
+		session.agent.emitExternalEvent({ type: "message_end", message: thresholdMessage });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [thresholdMessage] });
+
+		await waitFor(() => thresholdCompactionEnded);
+
+		expect(thresholdCompactionStarted).toBe(true);
+		expect(session.model?.provider).toBe(sparkModel.provider);
+		expect(session.model?.id).toBe(sparkModel.id);
+		expect(session.model?.id).not.toBe(promotedModel.id);
+	});
+
 	it("clears codex provider session state on manual setModel switch away from codex", async () => {
 		const codexModel = modelRegistry.find("openai-codex", "gpt-5.3-codex");
 		const nonCodexModel = modelRegistry.getAll().find(model => model.api !== "openai-codex-responses");


### PR DESCRIPTION
## Summary

- keep context promotion scoped to real overflow recovery instead of threshold maintenance
- make threshold auto-compaction run on the selected model without first switching to a promotion target
- add a regression test proving threshold maintenance emits compaction events and leaves the selected Codex model unchanged
- update compaction docs and changelog

Fixes #1329

## Verification

- `bun test packages/coding-agent/test/agent-session-context-promotion.test.ts`
- `bun test packages/coding-agent/test/agent-session-auto-compaction-queue.test.ts`
- `bun --cwd=packages/coding-agent run check`
