### PR TITLE
fix(tool): block bash cwd workspace escapes

### DIFF
--- a/packages/coding-agent/src/tools/bash.ts
+++ b/packages/coding-agent/src/tools/bash.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as path from "node:path";
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { ImageProtocol, TERMINAL, Text } from "@oh-my-pi/pi-tui";
@@ -119,6 +120,25 @@ function normalizeBashEnv(env: Record<string, string> | undefined): Record<strin
 		normalized[key] = value;
 	}
 	return normalized;
+}
+
+function isWithinDirectory(candidate: string, directory: string): boolean {
+	const relative = path.relative(directory, candidate);
+	return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function assertBashCwdInsideWorkspace(
+	commandCwd: string,
+	workspaceRoots: readonly string[],
+	workspaceDisplay: string,
+): void {
+	const resolvedCwd = path.resolve(commandCwd);
+	for (const root of workspaceRoots) {
+		if (isWithinDirectory(resolvedCwd, root)) return;
+	}
+	throw new ToolError(
+		`Working directory "${commandCwd}" is outside the workspace boundary "${workspaceDisplay}". Use only relative paths or explicit workspace subdirectories.`,
+	);
 }
 
 function escapeBashEnvValueForDisplay(value: string): string {
@@ -541,7 +561,11 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 			cwd = await expandInternalUrls(cwd, { ...internalUrlOptions, noEscape: true });
 		}
 
-		const commandCwd = cwd ? resolveToCwd(cwd, this.session.cwd) : this.session.cwd;
+		const workspaceRoot = path.resolve(this.session.cwd);
+		const workspaceRoots = [workspaceRoot];
+		const workspaceDisplay = workspaceRoot;
+		let commandCwd = cwd ? resolveToCwd(cwd, this.session.cwd) : this.session.cwd;
+		assertBashCwdInsideWorkspace(commandCwd, workspaceRoots, workspaceDisplay);
 		let cwdStat: fs.Stats;
 		try {
 			cwdStat = await fs.promises.stat(commandCwd);
@@ -554,6 +578,12 @@ export class BashTool implements AgentTool<BashToolSchema, BashToolDetails> {
 		if (!cwdStat.isDirectory()) {
 			throw new ToolError(`Working directory is not a directory: ${commandCwd}`);
 		}
+		const workspaceRealRoot = await fs.promises.realpath(workspaceRoot);
+		if (workspaceRealRoot !== workspaceRoot) {
+			workspaceRoots.push(workspaceRealRoot);
+		}
+		commandCwd = await fs.promises.realpath(commandCwd);
+		assertBashCwdInsideWorkspace(commandCwd, workspaceRoots, workspaceDisplay);
 
 		// Clamp to reasonable range: 1s - 3600s (1 hour)
 		const requestedTimeoutSec = rawTimeout;

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -957,6 +957,39 @@ function b() {
 			expect(result.details?.timeoutSeconds).toBe(300);
 		});
 
+		it("should allow cwd inside the workspace boundary", async () => {
+			const subdir = path.join(testDir, "subdir");
+			fs.mkdirSync(subdir);
+
+			const result = await bashTool.execute("test-call-8-cwd-inside", { command: "pwd", cwd: subdir });
+
+			expect(getTextOutput(result).trim()).toBe(fs.realpathSync(subdir));
+		});
+
+		it("should reject cwd outside the workspace boundary", async () => {
+			await expect(
+				bashTool.execute("test-call-8-cwd-outside", { command: "pwd", cwd: os.tmpdir() }),
+			).rejects.toThrow(/outside the workspace boundary/);
+		});
+
+		it("should reject cwd symlinks that escape the workspace boundary", async () => {
+			if (process.platform === "win32") {
+				return;
+			}
+
+			const outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), "coding-agent-outside-"));
+			const linkDir = path.join(testDir, "outside-link");
+			fs.symlinkSync(outsideDir, linkDir, "dir");
+
+			try {
+				await expect(
+					bashTool.execute("test-call-8-cwd-symlink-outside", { command: "pwd", cwd: linkDir }),
+				).rejects.toThrow(/outside the workspace boundary/);
+			} finally {
+				fs.rmSync(outsideDir, { recursive: true, force: true });
+			}
+		});
+
 		it("should expose built-in interceptor defaults truthfully", () => {
 			const defaultSettings = Settings.isolated({ "bashInterceptor.enabled": true });
 			const explicitEmptySettings = Settings.isolated({


### PR DESCRIPTION
## Repro
A `BashTool` session rooted in a temporary workspace accepted `cwd: "/tmp"` and executed `pwd` there instead of rejecting the out-of-workspace directory. Reproduced with `bun -e "$REPRO_SCRIPT"`, which printed `output=/tmp` before the fix.

## Cause
`packages/coding-agent/src/tools/bash.ts` resolved the requested cwd with `resolveToCwd` and only checked that the result existed and was a directory before passing it to `executeBash`, `runInteractiveBashPty`, async jobs, or the ACP terminal bridge. Absolute paths outside `this.session.cwd` were therefore treated as valid execution directories.

## Fix
- Added bash-specific workspace boundary validation before cwd stat and before command execution.
- Canonicalized the accepted cwd after stat and rejected symlinks that resolve outside the workspace.
- Added regression coverage for allowed in-workspace cwd, rejected absolute out-of-workspace cwd, and rejected symlink escapes.

## Verification
`bun --cwd=packages/coding-agent test test/tools.test.ts` passed: 90 pass, 1 skip. `bun --cwd=packages/coding-agent test test/tools.test.ts test/tools/bash-interceptor.test.ts test/tools/bash-command-fixup.test.ts test/tools/bash-pty-selection.test.ts test/tools/bash-skill-urls.test.ts test/bash-acp-terminal.test.ts test/bash-executor.test.ts` passed: 208 pass, 1 skip. `bun --cwd=packages/coding-agent run check:types` passed. The original repro now returns `Working directory "/tmp" is outside the workspace boundary ...`. Fixes #1331