### PR TITLE
feat: add autoloadSkills frontmatter field for agent definitions

### DIFF
--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -211,6 +211,7 @@ export interface ParsedAgentFields {
 	model?: string[];
 	output?: unknown;
 	thinkingLevel?: ThinkingLevel;
+	autoloadSkills?: string[];
 	blocking?: boolean;
 }
 
@@ -264,7 +265,10 @@ export function parseAgentFields(frontmatter: Record<string, unknown>): ParsedAg
 	const thinkingLevel = parseThinkingLevel(rawThinkingLevel);
 	const model = parseModelList(frontmatter.model);
 	const blocking = parseBoolean(frontmatter.blocking);
-	return { name, description, tools, spawns, model, output, thinkingLevel, blocking };
+	const autoloadSkills = parseArrayOrCSV(frontmatter.autoloadSkills)
+		?.map(s => s.trim())
+		.filter(Boolean);
+	return { name, description, tools, spawns, model, output, thinkingLevel, blocking, autoloadSkills };
 }
 
 async function globIf(

--- a/packages/coding-agent/src/prompts/agents/frontmatter.md
+++ b/packages/coding-agent/src/prompts/agents/frontmatter.md
@@ -6,5 +6,6 @@ description: {{jsonStringify description}}
 {{/if}}{{#if model}}model: {{jsonStringify model}}
 {{/if}}{{#if thinkingLevel}}thinking-level: {{jsonStringify thinkingLevel}}
 {{/if}}{{#if blocking}}blocking: true
+{{/if}}{{#if autoloadSkills}}autoloadSkills: {{jsonStringify autoloadSkills}}
 {{/if}}---
 {{body}}

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -17,7 +17,7 @@ import { SETTINGS_SCHEMA, type SettingPath } from "../config/settings-schema";
 import type { CustomTool } from "../extensibility/custom-tools/types";
 import { runExtensionCompact, runExtensionSetModel } from "../extensibility/extensions/compact-handler";
 import { getSessionSlashCommands } from "../extensibility/extensions/get-commands-handler";
-import type { Skill } from "../extensibility/skills";
+import { type Skill, buildSkillPromptMessage } from "../extensibility/skills";
 import type { HindsightSessionState } from "../hindsight/state";
 import type { LocalProtocolOptions } from "../internal-urls";
 import { callTool } from "../mcp/client";
@@ -29,6 +29,7 @@ import { createAgentSession, discoverAuthStorage } from "../sdk";
 import type { AgentSession, AgentSessionEvent } from "../session/agent-session";
 import type { ArtifactManager } from "../session/artifacts";
 import type { AuthStorage } from "../session/auth-storage";
+import { SKILL_PROMPT_MESSAGE_TYPE } from "../session/messages";
 import { SessionManager } from "../session/session-manager";
 import { truncateTail } from "../session/streaming-output";
 import type { ContextFileEntry } from "../tools";
@@ -190,6 +191,8 @@ export interface ExecutorOptions {
 	 * transition explicitly.
 	 */
 	parentTelemetry?: AgentTelemetryConfig;
+	/** Skills to autoload via sendCustomMessage before the first prompt */
+	autoloadSkills?: Skill[];
 }
 
 function parseStringifiedJson(value: unknown): unknown {
@@ -1360,6 +1363,21 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			});
 
 			checkAbort();
+			// Autoload skills via sendCustomMessage (same mechanic as /skill:<name>)
+			if (options.autoloadSkills?.length) {
+				for (const skill of options.autoloadSkills) {
+					const { message } = await buildSkillPromptMessage(skill, "");
+					await session.sendCustomMessage(
+						{
+							customType: SKILL_PROMPT_MESSAGE_TYPE,
+							content: message,
+							display: false,
+							details: { name: skill.name, path: skill.filePath },
+						},
+						{ triggerTurn: false },
+					);
+				}
+			}
 			await awaitAbortable(session.prompt(task, { attribution: "agent" }));
 			await awaitAbortable(session.waitForIdle());
 

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -830,6 +830,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			const tasksWithUniqueIds = tasks.map((t, i) => ({ ...t, id: uniqueIds[i] }));
 
 			const availableSkills = [...(this.session.skills ?? [])];
+			// Resolve autoload skills from agent definition against available skills
+			const resolvedAutoloadSkills = agent.autoloadSkills?.length && availableSkills.length > 0
+				? agent.autoloadSkills
+					.map(name => availableSkills.find(s => s.name === name))
+					.filter((s): s is NonNullable<typeof s> => s !== undefined)
+				: [];
 			const contextFiles = this.session.contextFiles?.filter(
 				file => path.basename(file.path).toLowerCase() !== "agents.md",
 			);
@@ -894,6 +900,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						mcpManager: MCPManager.instance(),
 						contextFiles,
 						skills: availableSkills,
+						autoloadSkills: resolvedAutoloadSkills,
 						workspaceTree: this.session.workspaceTree,
 						promptTemplates,
 						localProtocolOptions,
@@ -948,6 +955,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						mcpManager: MCPManager.instance(),
 						contextFiles,
 						skills: availableSkills,
+						autoloadSkills: resolvedAutoloadSkills,
 						workspaceTree: this.session.workspaceTree,
 						promptTemplates,
 						localProtocolOptions,

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -173,6 +173,7 @@ export interface AgentDefinition {
 	thinkingLevel?: ThinkingLevel;
 	output?: unknown;
 	blocking?: boolean;
+	autoloadSkills?: string[];
 	source: AgentSource;
 	filePath?: string;
 }

--- a/packages/coding-agent/test/discovery/agent-fields.test.ts
+++ b/packages/coding-agent/test/discovery/agent-fields.test.ts
@@ -66,4 +66,47 @@ describe("parseAgentFields", () => {
 
 		expect(fields?.tools).toEqual(["read", "search", "yield"]);
 	});
+
+	test("parses autoloadSkills from array frontmatter", () => {
+		const fields = parseAgentFields({
+			name: "oracle",
+			description: "desc",
+			autoloadSkills: ["user-created-skill-a", "user-created-skill-b"],
+		});
+
+		expect(fields).toBeDefined();
+		expect(fields?.autoloadSkills).toEqual(["user-created-skill-a", "user-created-skill-b"]);
+	});
+
+	test("parses autoloadSkills from CSV string", () => {
+		const fields = parseAgentFields({
+			name: "oracle",
+			description: "desc",
+			autoloadSkills: "user-created-skill-a, user-created-skill-b",
+		});
+
+		expect(fields).toBeDefined();
+		expect(fields?.autoloadSkills).toEqual(["user-created-skill-a", "user-created-skill-b"]);
+	});
+
+	test("returns undefined autoloadSkills when field absent", () => {
+		const fields = parseAgentFields({
+			name: "oracle",
+			description: "desc",
+		});
+
+		expect(fields).toBeDefined();
+		expect(fields?.autoloadSkills).toBeUndefined();
+	});
+
+	test("returns undefined autoloadSkills for empty array", () => {
+		const fields = parseAgentFields({
+			name: "oracle",
+			description: "desc",
+			autoloadSkills: [],
+		});
+
+		expect(fields).toBeDefined();
+		expect(fields?.autoloadSkills).toBeUndefined();
+	});
 });

--- a/packages/coding-agent/test/task/autoload-skills.test.ts
+++ b/packages/coding-agent/test/task/autoload-skills.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { Settings } from "../../src/config/settings";
+import type { Skill } from "../../src/extensibility/skills";
+import type { CreateAgentSessionResult } from "../../src/sdk";
+import * as sdkModule from "../../src/sdk";
+import { SKILL_PROMPT_MESSAGE_TYPE } from "../../src/session/messages";
+import type { AgentSession, AgentSessionEvent, PromptOptions } from "../../src/session/agent-session";
+import { runSubprocess } from "../../src/task/executor";
+import type { AgentDefinition } from "../../src/task/types";
+import { EventBus } from "../../src/utils/event-bus";
+import * as skillsModule from "../../src/extensibility/skills";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function createMockSession(
+	onPrompt: (params: {
+		text: string;
+		options?: PromptOptions;
+		promptIndex: number;
+		emit: (event: AgentSessionEvent) => void;
+	}) => void,
+): AgentSession {
+	const listeners: Array<(event: AgentSessionEvent) => void> = [];
+	let promptIndex = 0;
+	const state = { messages: [] as unknown[] };
+
+	const emit = (event: AgentSessionEvent) => {
+		for (const listener of listeners) listener(event);
+	};
+
+	return {
+		state,
+		agent: { state: { systemPrompt: ["test"] } },
+		model: undefined,
+		extensionRunner: undefined,
+		sessionManager: {
+			appendSessionInit: () => {},
+		},
+		getActiveToolNames: () => ["read", "yield"],
+		setActiveToolsByName: async () => {},
+		subscribe: (listener: (event: AgentSessionEvent) => void) => {
+			listeners.push(listener);
+			return () => {
+				const index = listeners.indexOf(listener);
+				if (index >= 0) listeners.splice(index, 1);
+			};
+		},
+		prompt: async (text: string, options?: PromptOptions) => {
+			promptIndex += 1;
+			onPrompt({ text, options, promptIndex, emit });
+		},
+		sendCustomMessage: vi.fn(async () => {}),
+		waitForIdle: async () => {},
+		getLastAssistantMessage: () => state.messages[state.messages.length - 1],
+		abort: async () => {},
+		dispose: async () => {},
+	} as unknown as AgentSession;
+}
+
+function createSessionResult(session: AgentSession): CreateAgentSessionResult {
+	return {
+		session,
+		extensionsResult: {} as unknown as import("../../src/extensibility/extensions/types").LoadExtensionsResult,
+		setToolUIContext: () => {},
+		eventBus: new EventBus(),
+	};
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("autoloadSkills in executor", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	const baseAgent: AgentDefinition = {
+		name: "task",
+		description: "test",
+		systemPrompt: "test",
+		source: "bundled",
+	};
+
+	const baseOptions = {
+		cwd: "/tmp",
+		agent: baseAgent,
+		task: "do work",
+		index: 0,
+		id: "subagent-1",
+		settings: Settings.isolated(),
+		modelRegistry: {
+			refresh: async () => {},
+		} as unknown as import("../../src/config/model-registry").ModelRegistry,
+		enableLsp: false,
+	};
+
+	it("calls sendCustomMessage for each autoloaded skill before prompt", async () => {
+		const session = createMockSession(({ emit }) => {
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-1",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+
+		const mockSkills: Skill[] = [
+			{ name: "user-created-skill-a", description: "Skill A", filePath: "/skills/user-created-skill-a/SKILL.md", baseDir: "/skills/user-created-skill-a", source: "user" },
+			{ name: "user-created-skill-b", description: "Skill B", filePath: "/skills/user-created-skill-b/SKILL.md", baseDir: "/skills/user-created-skill-b", source: "user" },
+		];
+
+		vi.spyOn(skillsModule, "buildSkillPromptMessage").mockImplementation(async (skill) => ({
+			message: `Content of ${skill.name}\n\n---\n\nSkill: ${skill.filePath}`,
+			details: {
+				name: skill.name,
+				path: skill.filePath,
+				args: undefined,
+				lineCount: 1,
+			},
+		}));
+
+		await runSubprocess({
+			...baseOptions,
+			skills: mockSkills,
+			autoloadSkills: mockSkills,
+		});
+
+		const sendCustomMessage = session.sendCustomMessage as ReturnType<typeof vi.fn>;
+		expect(sendCustomMessage).toHaveBeenCalledTimes(2);
+
+		// Verify first skill
+		expect(sendCustomMessage).toHaveBeenNthCalledWith(
+			1,
+			{
+				customType: SKILL_PROMPT_MESSAGE_TYPE,
+				content: expect.stringContaining("Content of user-created-skill-a"),
+				display: false,
+				details: { name: "user-created-skill-a", path: "/skills/user-created-skill-a/SKILL.md" },
+			},
+			{ triggerTurn: false },
+		);
+
+		// Verify second skill
+		expect(sendCustomMessage).toHaveBeenNthCalledWith(
+			2,
+			{
+				customType: SKILL_PROMPT_MESSAGE_TYPE,
+				content: expect.stringContaining("Content of user-created-skill-b"),
+				display: false,
+				details: { name: "user-created-skill-b", path: "/skills/user-created-skill-b/SKILL.md" },
+			},
+			{ triggerTurn: false },
+		);
+	});
+
+	it("does not call sendCustomMessage when autoloadSkills is empty", async () => {
+		const session = createMockSession(({ emit }) => {
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-1",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+
+		await runSubprocess(baseOptions);
+
+		const sendCustomMessage = session.sendCustomMessage as ReturnType<typeof vi.fn>;
+		expect(sendCustomMessage).not.toHaveBeenCalled();
+	});
+
+	it("does not call sendCustomMessage when autoloadSkills is undefined", async () => {
+		const session = createMockSession(({ emit }) => {
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-1",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+
+		await runSubprocess({ ...baseOptions, autoloadSkills: undefined });
+
+		const sendCustomMessage = session.sendCustomMessage as ReturnType<typeof vi.fn>;
+		expect(sendCustomMessage).not.toHaveBeenCalled();
+	});
+
+	it("skill messages are sent before the task prompt", async () => {
+		const callOrder: string[] = [];
+		const session = createMockSession(({ emit }) => {
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-1",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+
+		// Track sendCustomMessage call order
+		(session.sendCustomMessage as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+			callOrder.push("sendCustomMessage");
+		});
+
+		// Track the original prompt to capture order
+		const originalPrompt = session.prompt;
+		session.prompt = async (text: string, options?: PromptOptions) => {
+			callOrder.push("prompt");
+			return originalPrompt(text, options);
+		};
+
+		vi.spyOn(sdkModule, "createAgentSession").mockResolvedValue(createSessionResult(session));
+
+		const mockSkill: Skill = {
+			name: "user-created-skill",
+			description: "A custom skill",
+			filePath: "/skills/user-created-skill/SKILL.md",
+			baseDir: "/skills/user-created-skill",
+			source: "user",
+		};
+
+		vi.spyOn(skillsModule, "buildSkillPromptMessage").mockResolvedValue({
+			message: "Skill content\n\n---\n\nSkill: /skills/user-created-skill/SKILL.md",
+			details: { name: "user-created-skill", path: "/skills/user-created-skill/SKILL.md", lineCount: 1 },
+		});
+
+		await runSubprocess({
+			...baseOptions,
+			skills: [mockSkill],
+			autoloadSkills: [mockSkill],
+		});
+
+		expect(callOrder).toEqual(["sendCustomMessage", "prompt"]);
+	});
+});


### PR DESCRIPTION
## Summary

Closes #1334

Adds an optional `autoloadSkills` frontmatter field to OMP agent definitions. When a sub-agent is spawned, any listed skills are automatically loaded using the same `buildSkillPromptMessage` + `sendCustomMessage` mechanism that the interactive load-skill command uses.

## Example

```
name: oracle
description: Wise senior engineer
autoloadSkills: [user-created-skill-a, user-created-skill-b]
```

## Changes

| File | Change |
|---|---|
| `src/discovery/helpers.ts` | `autoloadSkills?: string[]` in ParsedAgentFields + parsing in parseAgentFields |
| `src/task/types.ts` | `autoloadSkills?: string[]` in AgentDefinition |
| `src/task/executor.ts` | Import buildSkillPromptMessage + SKILL_PROMPT_MESSAGE_TYPE; autoloadSkills in ExecutorOptions; injection before session.prompt(task) |
| `src/task/index.ts` | Resolve autoload skill names against parent skill list; pass to runSubprocess |
| `src/prompts/agents/frontmatter.md` | Template field |
| `test/discovery/agent-fields.test.ts` | 4 new parsing tests |
| `test/task/autoload-skills.test.ts` | New file: 4 executor integration tests |

## Design Decisions

1. **Same mechanic as interactive skill loading** - uses buildSkillPromptMessage which strips frontmatter and adds Skill: /path/to/SKILL.md metadata
2. **triggerTurn: false** - skill messages appended without extra agent turns; first session.prompt(task) delivers everything together
3. **Skills stay in listing** - not hidden; agent can access sub-resources via the skill protocol URL
4. **Compaction matches manual loading** - skill content is conversation history; after compaction agent can re-load
5. **Unknown skill names silently skipped** - no error if a listed skill is not in the parent skill list

## Verification

- TypeScript compiles clean (`tsc --noEmit` passes)
- Tests follow existing executor mocking patterns from executor-subagent-reminders.test.ts
- Full bun test suite cannot run locally (requires pi_natives native addon built from Rust)