### PR TITLE
fix(session): handle EPERM during session rewrite

### DIFF
--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -18,6 +18,7 @@ import {
 	getProjectDir,
 	getSessionsDir,
 	getTerminalSessionsDir,
+	hasFsCode,
 	isEnoent,
 	logger,
 	parseJsonlLenient,
@@ -2146,7 +2147,59 @@ export class SessionManager {
 			{ ignoreError: true },
 		);
 	}
+	// Windows can reject overwrite-style rename with EPERM even after our own writer is closed.
+	// Move the old session file aside first so a failed retry can roll back to the last good file.
 
+	async #replaceSessionFileAfterEperm(tempPath: string, targetPath: string, renameError: unknown): Promise<void> {
+		const dir = path.resolve(targetPath, "..");
+		const backupPath = path.join(dir, `.${path.basename(targetPath)}.${Snowflake.next()}.bak`);
+		try {
+			await this.storage.rename(targetPath, backupPath);
+		} catch (err) {
+			if (isEnoent(err)) {
+				await this.storage.rename(tempPath, targetPath);
+				return;
+			}
+			throw toError(renameError);
+		}
+
+		try {
+			await this.storage.rename(tempPath, targetPath);
+		} catch (err) {
+			const replaceError = toError(err);
+			try {
+				await this.storage.rename(backupPath, targetPath);
+			} catch (rollbackErr) {
+				const rollbackError = toError(rollbackErr);
+				throw new Error(
+					`Failed to replace session file after EPERM (${replaceError.message}); rollback from ${backupPath} also failed: ${rollbackError.message}`,
+					{ cause: replaceError },
+				);
+			}
+			throw replaceError;
+		}
+
+		try {
+			await this.storage.unlink(backupPath);
+		} catch (err) {
+			if (!isEnoent(err)) {
+				logger.warn("Failed to remove session rewrite backup", {
+					sessionFile: targetPath,
+					backupPath,
+					error: toError(err).message,
+				});
+			}
+		}
+	}
+
+	async #replaceSessionFile(tempPath: string, targetPath: string): Promise<void> {
+		try {
+			await this.storage.rename(tempPath, targetPath);
+		} catch (err) {
+			if (!hasFsCode(err, "EPERM")) throw toError(err);
+			await this.#replaceSessionFileAfterEperm(tempPath, targetPath, err);
+		}
+	}
 	async #writeEntriesAtomically(entries: FileEntry[]): Promise<void> {
 		if (!this.#sessionFile) return;
 		const dir = path.resolve(this.#sessionFile, "..");
@@ -2159,7 +2212,7 @@ export class SessionManager {
 			await writer.flush();
 			await writer.fsync();
 			await writer.close();
-			await this.storage.rename(tempPath, this.#sessionFile);
+			await this.#replaceSessionFile(tempPath, this.#sessionFile);
 		} catch (err) {
 			try {
 				await writer.close();

--- a/packages/coding-agent/test/session-manager/rewrite-rename-eperm.test.ts
+++ b/packages/coding-agent/test/session-manager/rewrite-rename-eperm.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { MemorySessionStorage } from "@oh-my-pi/pi-coding-agent/session/session-storage";
+
+class FsCodeError extends Error {
+	code: string;
+
+	constructor(code: string, message: string) {
+		super(message);
+		this.code = code;
+	}
+}
+
+class RenameEpermOnceStorage extends MemorySessionStorage {
+	failNextSessionReplace = false;
+	backupCleanupPath: string | undefined;
+
+	rename(source: string, target: string): Promise<void> {
+		if (
+			this.failNextSessionReplace &&
+			source.includes(".tmp") &&
+			target.endsWith(".jsonl") &&
+			this.existsSync(target)
+		) {
+			this.failNextSessionReplace = false;
+			return Promise.reject(
+				new FsCodeError("EPERM", `EPERM: operation not permitted, rename '${source}' -> '${target}'`),
+			);
+		}
+		return super.rename(source, target);
+	}
+
+	unlink(target: string): Promise<void> {
+		if (target.endsWith(".bak")) {
+			this.backupCleanupPath = target;
+		}
+		return super.unlink(target);
+	}
+}
+
+describe("SessionManager rewrite EPERM replacement fallback", () => {
+	it("keeps the active session healthy when replacing an existing file hits EPERM", async () => {
+		const storage = new RenameEpermOnceStorage();
+		const session = SessionManager.create("/cwd", "/sessions", storage);
+		await session.ensureOnDisk();
+		const sessionFile = session.getSessionFile();
+		if (!sessionFile) throw new Error("Expected session file");
+
+		storage.failNextSessionReplace = true;
+		await expect(session.setSessionName("renamed session", "user")).resolves.toBe(true);
+
+		const rewritten = storage.readTextSync(sessionFile);
+		expect(rewritten).toContain('"title":"renamed session"');
+		const backupPath = storage.backupCleanupPath;
+		if (!backupPath) throw new Error("Expected EPERM fallback to create a rollback backup");
+		expect(storage.existsSync(backupPath)).toBe(false);
+
+		session.appendMessage({ role: "user", content: "after rewrite", timestamp: Date.now() });
+		await expect(session.flush()).resolves.toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Repro
Forced `SessionManager.rewriteEntries()` to replace an existing active session file while `storage.rename(tmp, session.jsonl)` returns `EPERM`, matching the reported temp-file-to-session-file failure. Before the fix, `bun .wt/repro-1337.ts` exited with the same `#writeEntriesAtomically` rejection shape.

## Cause
`packages/coding-agent/src/session/session-manager.ts` wrote rewrites to a temp JSONL file and then called `storage.rename(tempPath, this.#sessionFile)` directly from `#writeEntriesAtomically()`. On Windows, overwrite-style rename can return `EPERM` against the existing active session file, which left the rewrite failed and propagated through compaction/prompt maintenance.

## Fix
- Added an EPERM-only replacement path that moves the current session file to a rollback backup, renames the temp file into place, and restores the backup if the retry fails.
- Kept non-EPERM rename failures on the existing error path.
- Added regression coverage for an active session rewrite that hits EPERM and then remains writable.

## Verification
`bun .wt/repro-1337.ts` now exits successfully. `bun test packages/coding-agent/test/session-manager/rewrite-rename-eperm.test.ts packages/coding-agent/test/session-manager-close-race.test.ts packages/coding-agent/test/session-storage.test.ts` passed. `bun --cwd=packages/coding-agent run check` passed. `gh_push_branch` pre-publish gate passed. Fixes #1337