### PR TITLE
feat(openai): support Responses hosted web search

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `openaiHostedTools` passthrough on `AgentOptions` so callers can expose OpenAI Responses hosted web search through the agent loop without replacing the stream function ([#1341](https://github.com/can1357/oh-my-pi/issues/1341)).
+
 ## [15.2.3] - 2026-05-22
 ### Added
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -48,6 +48,9 @@ function refreshToolChoiceForActiveTools(
 	if (!toolChoice || typeof toolChoice === "string") {
 		return toolChoice;
 	}
+	if (toolChoice.type !== "tool" && toolChoice.type !== "function") {
+		return toolChoice;
+	}
 
 	const toolName =
 		toolChoice.type === "tool"
@@ -106,6 +109,9 @@ export interface AgentOptions {
 
 	/** Hint that websocket transport should be preferred when supported by the provider implementation. */
 	preferWebsockets?: boolean;
+
+	/** OpenAI Responses hosted tools exposed on first-party GPT requests. */
+	openaiHostedTools?: SimpleStreamOptions["openaiHostedTools"];
 
 	/**
 	 * Custom stream function (for proxy backends, etc.). Default uses streamSimple.
@@ -282,6 +288,7 @@ export class Agent {
 	#resolveRunningPrompt?: () => void;
 	#kimiApiFormat?: "openai" | "anthropic";
 	#preferWebsockets?: boolean;
+	#openaiHostedTools?: SimpleStreamOptions["openaiHostedTools"];
 	#transformToolCallArguments?: (args: Record<string, unknown>, toolName: string) => Record<string, unknown>;
 	#intentTracing: boolean;
 	#getToolChoice?: () => ToolChoice | undefined;
@@ -338,6 +345,7 @@ export class Agent {
 		this.#cursorOnToolResult = opts.cursorOnToolResult;
 		this.#kimiApiFormat = opts.kimiApiFormat;
 		this.#preferWebsockets = opts.preferWebsockets;
+		this.#openaiHostedTools = opts.openaiHostedTools;
 		this.#transformToolCallArguments = opts.transformToolCallArguments;
 		this.#intentTracing = opts.intentTracing === true;
 		this.#getToolChoice = opts.getToolChoice;
@@ -907,6 +915,7 @@ export class Agent {
 			maxRetryDelayMs: this.#maxRetryDelayMs,
 			kimiApiFormat: this.#kimiApiFormat,
 			preferWebsockets: this.#preferWebsockets,
+			openaiHostedTools: this.#openaiHostedTools,
 			convertToLlm: this.#convertToLlm,
 			transformContext: this.#transformContext,
 			onPayload: this.#onPayload,

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added OpenAI Responses hosted `web_search` options for first-party GPT requests. The auth-gateway `/v1/responses` parser now preserves hosted `web_search` entries as stream options instead of dropping them while still keeping local function tools separate ([#1341](https://github.com/can1357/oh-my-pi/issues/1341)).
+
 ## [15.2.4] - 2026-05-22
 
 ### Fixed

--- a/packages/ai/src/auth-gateway/server.ts
+++ b/packages/ai/src/auth-gateway/server.ts
@@ -24,12 +24,21 @@ import * as openaiChat from "../providers/openai-chat-server";
 import * as openaiResponses from "../providers/openai-responses-server";
 import * as piNative from "../providers/pi-native-server";
 import { streamSimple } from "../stream";
-import type { Api, AssistantMessageEventStream, Context, Model, SimpleStreamOptions } from "../types";
+import type {
+	Api,
+	AssistantMessageEventStream,
+	Context,
+	Model,
+	OpenAIHostedToolChoice,
+	SimpleStreamOptions,
+	ToolChoice,
+} from "../types";
 import { parseBind } from "../utils/parse-bind";
 import { captureRequestHeaders, corsHeaders, isAuthorized, json, resolvePeer, withCors } from "./http";
 import type {
 	AuthGatewayServerHandle,
 	AuthGatewayServerOptions,
+	AuthGatewayToolChoice,
 	AuthGatewayFormatModule as FormatModule,
 	AuthGatewayParsedRequest as ParsedFormatRequest,
 } from "./types";
@@ -113,6 +122,23 @@ function deriveSessionId(modelId: string, context: Context): string {
 	return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
 }
 
+function isAuthGatewayHostedToolChoice(
+	choice: Exclude<AuthGatewayToolChoice, string>,
+): choice is OpenAIHostedToolChoice {
+	return "type" in choice;
+}
+
+function supportsAuthGatewayHostedTools(api: Api): boolean {
+	return api === "openai-responses" || api === "openai-codex-responses";
+}
+
+/** @internal Exported for regression tests. */
+export function mapAuthGatewayToolChoice(choice: AuthGatewayToolChoice, api: Api): ToolChoice {
+	if (typeof choice === "string") return choice;
+	if (isAuthGatewayHostedToolChoice(choice)) return supportsAuthGatewayHostedTools(api) ? choice : "auto";
+	return { type: "tool", name: choice.name };
+}
+
 function buildStreamOptions(parsed: ParsedFormatRequest, api: Api, signal: AbortSignal): SimpleStreamOptions {
 	const opts: SimpleStreamOptions = { signal };
 	const { options } = parsed;
@@ -132,9 +158,9 @@ function buildStreamOptions(parsed: ParsedFormatRequest, api: Api, signal: Abort
 	if (options.repetitionPenalty !== undefined) opts.repetitionPenalty = options.repetitionPenalty;
 	if (options.metadata !== undefined) opts.metadata = options.metadata;
 	if (options.headers !== undefined) opts.headers = { ...(opts.headers ?? {}), ...options.headers };
-	if (options.toolChoice !== undefined) {
-		opts.toolChoice =
-			typeof options.toolChoice === "object" ? { type: "tool", name: options.toolChoice.name } : options.toolChoice;
+	if (options.toolChoice !== undefined) opts.toolChoice = mapAuthGatewayToolChoice(options.toolChoice, api);
+	if (options.openaiHostedTools !== undefined && supportsAuthGatewayHostedTools(api)) {
+		opts.openaiHostedTools = options.openaiHostedTools;
 	}
 	if (options.reasoning !== undefined) opts.reasoning = options.reasoning;
 	if (options.disableReasoning !== undefined) opts.disableReasoning = options.disableReasoning;

--- a/packages/ai/src/auth-gateway/types.ts
+++ b/packages/ai/src/auth-gateway/types.ts
@@ -1,5 +1,13 @@
 import type { Effort } from "../model-thinking";
-import type { AssistantMessage, AssistantMessageEventStream, CacheRetention, Context, ServiceTier } from "../types";
+import type {
+	AssistantMessage,
+	AssistantMessageEventStream,
+	CacheRetention,
+	Context,
+	OpenAIHostedToolChoice,
+	OpenAIHostedToolsOptions,
+	ServiceTier,
+} from "../types";
 
 /**
  * Wire types for the omp auth-gateway.
@@ -15,7 +23,7 @@ import type { AssistantMessage, AssistantMessageEventStream, CacheRetention, Con
 /** Default bind. Loopback-only — front with reverse proxy for remote access. */
 export const DEFAULT_AUTH_GATEWAY_BIND = "127.0.0.1:4000";
 
-export type AuthGatewayToolChoice = "auto" | "none" | "required" | { name: string };
+export type AuthGatewayToolChoice = "auto" | "none" | "required" | { name: string } | OpenAIHostedToolChoice;
 
 export interface AuthGatewayParsedRequestOptions {
 	// ── Sampling ──────────────────────────────────────────────────────────
@@ -44,6 +52,8 @@ export interface AuthGatewayParsedRequestOptions {
 	toolChoice?: AuthGatewayToolChoice;
 	/** OpenAI `parallel_tool_calls`. */
 	parallelToolCalls?: boolean;
+	/** OpenAI Responses hosted tools accepted on the public `/v1/responses` shape. */
+	openaiHostedTools?: OpenAIHostedToolsOptions;
 
 	// ── Reasoning ─────────────────────────────────────────────────────────
 	/** Effort-level reasoning request (OpenAI Responses / Chat `reasoning_effort`). */

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -277,7 +277,13 @@ function buildParams(
 	if (context.tools) {
 		params.tools = convertTools(context.tools);
 		if (options?.toolChoice) {
-			params.tool_choice = mapToOpenAIResponsesToolChoice(options.toolChoice);
+			const toolChoice = mapToOpenAIResponsesToolChoice(options.toolChoice);
+			if (
+				toolChoice &&
+				(typeof toolChoice === "string" || toolChoice.type === "function" || toolChoice.type === "custom")
+			) {
+				params.tool_choice = toolChoice;
+			}
 		}
 	}
 

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -123,7 +123,7 @@ function getNamedToolChoiceName(toolChoice: ToolChoice | undefined): string | un
 	if ("function" in toolChoice) {
 		return toolChoice.function.name;
 	}
-	return toolChoice.name;
+	return "name" in toolChoice ? toolChoice.name : undefined;
 }
 
 function selectToolsForToolChoice(tools: Tool[] | undefined, toolChoice: ToolChoice | undefined): Tool[] | undefined {

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -28,6 +28,8 @@ import {
 	type Context,
 	type FetchImpl,
 	type Model,
+	type OpenAIHostedToolChoice,
+	type OpenAIHostedToolsOptions,
 	type ProviderSessionState,
 	resolveServiceTier,
 	type ServiceTier,
@@ -78,6 +80,7 @@ export interface OpenAICodexResponsesOptions extends StreamOptions {
 	include?: string[];
 	codexMode?: boolean;
 	toolChoice?: ToolChoice;
+	openaiHostedTools?: OpenAIHostedToolsOptions;
 	preferWebsockets?: boolean;
 	serviceTier?: ServiceTier;
 }
@@ -97,6 +100,8 @@ const CODEX_PROVIDER_SESSION_STATE_KEY = "openai-codex-responses";
 const X_CODEX_TURN_STATE_HEADER = "x-codex-turn-state";
 const X_MODELS_ETAG_HEADER = "x-models-etag";
 const X_REASONING_INCLUDED_HEADER = "x-reasoning-included";
+type CodexNamedToolChoice = { type: "function" | "custom"; name: string };
+type CodexToolChoicePayload = string | OpenAIHostedToolChoice | CodexNamedToolChoice;
 /** Connection-level websocket failures that should immediately fall back to SSE without retrying. */
 const CODEX_WEBSOCKET_FATAL_PATTERNS = ["websocket error:", "websocket closed before open", "connection timeout"];
 /** Max total time to spend retrying 429s with server-provided delays (5 minutes). */
@@ -379,11 +384,12 @@ export function normalizeCodexToolChoice(
 	choice: ToolChoice | undefined,
 	tools: Tool[] = [],
 	model?: Model<"openai-codex-responses">,
-): string | Record<string, unknown> | undefined {
+): CodexToolChoicePayload | undefined {
 	if (!choice) return undefined;
 	if (typeof choice === "string") return choice;
+	if (isOpenAIHostedToolChoice(choice)) return normalizeOpenAIHostedToolChoice(choice);
 	const allowFreeform = model ? supportsFreeformApplyPatchCodex(model) : false;
-	const mapName = (name: string): Record<string, string> => {
+	const mapName = (name: string): CodexNamedToolChoice => {
 		const customTool = allowFreeform
 			? tools.find(tool => tool.customFormat && (tool.name === name || tool.customWireName === name))
 			: undefined;
@@ -403,6 +409,22 @@ export function normalizeCodexToolChoice(
 		return mapName(choice.name);
 	}
 	return undefined;
+}
+
+function normalizeOpenAIHostedToolChoice(choice: OpenAIHostedToolChoice): OpenAIHostedToolChoice {
+	if (choice.type === "web_search_preview") return { ...choice, type: "web_search" };
+	return choice;
+}
+
+function isOpenAIHostedToolChoice(choice: ToolChoice): choice is OpenAIHostedToolChoice {
+	if (typeof choice !== "object") return false;
+	switch (choice.type) {
+		case "web_search":
+		case "web_search_preview":
+			return true;
+		default:
+			return false;
+	}
 }
 
 function createEmptyUsage(): AssistantMessage["usage"] {
@@ -594,11 +616,14 @@ async function buildTransformedCodexRequestBody(
 	if (resolvedServiceTier === "flex" || resolvedServiceTier === "scale" || resolvedServiceTier === "priority") {
 		params.service_tier = resolvedServiceTier;
 	}
-	if (context.tools && context.tools.length > 0) {
-		params.tools = convertOpenAICodexResponsesTools(context.tools, model);
+	const localTools =
+		context.tools && context.tools.length > 0 ? convertOpenAICodexResponsesTools(context.tools, model) : [];
+	const hostedTools = buildOpenAICodexHostedTools(options?.openaiHostedTools);
+	if (localTools.length > 0 || hostedTools.length > 0) {
+		params.tools = [...localTools, ...hostedTools];
 		if (options?.toolChoice) {
-			const toolChoice = normalizeCodexToolChoice(options.toolChoice, context.tools, model);
-			if (toolChoice) {
+			const toolChoice = normalizeCodexToolChoice(options.toolChoice, context.tools ?? [], model);
+			if (shouldSendCodexToolChoice(toolChoice, localTools, hostedTools)) {
 				params.tool_choice = toolChoice;
 			}
 		}
@@ -2475,6 +2500,63 @@ type CodexToolPayload =
 			description: string;
 			format: { type: "grammar"; syntax: "lark" | "regex"; definition: string };
 	  };
+
+type CodexHostedToolPayload = Record<string, unknown> & { type: string };
+
+function hostedToggleEnabled<T extends { enabled?: boolean }>(value: boolean | T | undefined): value is true | T {
+	if (value === undefined || value === false) return false;
+	if (value === true) return true;
+	return value.enabled !== false;
+}
+
+function hostedToolConfig<T extends { enabled?: boolean }>(value: boolean | T | undefined): T | undefined {
+	return typeof value === "object" && hostedToggleEnabled(value) ? value : undefined;
+}
+
+function buildOpenAICodexHostedTools(hosted: OpenAIHostedToolsOptions | undefined): CodexHostedToolPayload[] {
+	if (!hosted) return [];
+
+	const tools: CodexHostedToolPayload[] = [];
+	if (hostedToggleEnabled(hosted.webSearch)) {
+		const webSearch = hostedToolConfig(hosted.webSearch);
+		const tool: CodexHostedToolPayload = { type: "web_search" };
+		if (webSearch?.searchContextSize) tool.search_context_size = webSearch.searchContextSize;
+		if (webSearch?.externalWebAccess !== undefined) tool.external_web_access = webSearch.externalWebAccess;
+		if (webSearch?.returnTokenBudget) tool.return_token_budget = webSearch.returnTokenBudget;
+		const allowedDomains = webSearch?.filters?.allowedDomains?.filter(domain => domain.length > 0);
+		const blockedDomains = webSearch?.filters?.blockedDomains?.filter(domain => domain.length > 0);
+		if (allowedDomains?.length || blockedDomains?.length) {
+			tool.filters = {
+				...(allowedDomains?.length ? { allowed_domains: allowedDomains } : {}),
+				...(blockedDomains?.length ? { blocked_domains: blockedDomains } : {}),
+			};
+		}
+		tools.push(tool);
+	}
+
+	return tools;
+}
+
+function shouldSendCodexToolChoice(
+	choice: CodexToolChoicePayload | undefined,
+	localTools: CodexToolPayload[],
+	hostedTools: CodexHostedToolPayload[],
+): boolean {
+	if (!choice) return false;
+	if (typeof choice === "string") return true;
+	if (isCodexNamedToolChoice(choice)) {
+		return localTools.some(tool => tool.type === choice.type && tool.name === choice.name);
+	}
+	return hostedTools.some(tool => hostedToolChoiceMatches(choice, tool));
+}
+
+function isCodexNamedToolChoice(choice: OpenAIHostedToolChoice | CodexNamedToolChoice): choice is CodexNamedToolChoice {
+	return choice.type === "function" || choice.type === "custom";
+}
+
+function hostedToolChoiceMatches(choice: OpenAIHostedToolChoice, tool: CodexHostedToolPayload): boolean {
+	return tool.type === choice.type;
+}
 
 /** @internal Exported for tests. */
 export function convertOpenAICodexResponsesTools(

--- a/packages/ai/src/providers/openai-responses-server-schema.ts
+++ b/packages/ai/src/providers/openai-responses-server-schema.ts
@@ -191,6 +191,7 @@ const builtinToolSchema = z
 // ─── Tool choice ────────────────────────────────────────────────────────────
 
 const hostedToolType = z.enum([
+	"web_search",
 	"web_search_preview",
 	"file_search",
 	"computer_use_preview",
@@ -217,7 +218,8 @@ export const toolChoiceSchema = z.union([
 		type: z.literal("custom"),
 		name: z.string().min(1),
 	}),
-	// Hosted-tool selection (no extra fields).
+	// Hosted selections are accepted for Responses API compatibility; the
+	// walker only bridges web_search and keeps older non-web choices as auto.
 	z.object({
 		type: hostedToolType,
 	}),

--- a/packages/ai/src/providers/openai-responses-server.ts
+++ b/packages/ai/src/providers/openai-responses-server.ts
@@ -17,6 +17,8 @@ import type {
 	AssistantMessageEventStream,
 	Context,
 	Message,
+	OpenAIHostedToolChoice,
+	OpenAIHostedToolsOptions,
 	TextContent,
 	ThinkingContent,
 	Tool,
@@ -161,6 +163,16 @@ function outputTextOf(blocks: OpenAIResponsesOutputContent[] | string | undefine
 	return out;
 }
 
+type ParsedWebSearchToolChoice = {
+	type: "web_search_preview" | "web_search";
+};
+
+type ParsedLegacyHostedToolChoice = {
+	type: "file_search" | "computer_use_preview" | "code_interpreter" | "image_generation" | "mcp";
+};
+
+type ParsedHostedToolChoice = ParsedWebSearchToolChoice | ParsedLegacyHostedToolChoice;
+
 // The schema accepts a much wider tool_choice union than the SDK type so the
 // walker narrows against the local schema shape.
 type ParsedToolChoice =
@@ -169,16 +181,17 @@ type ParsedToolChoice =
 	| "required"
 	| { type: "function"; name: string }
 	| { type: "custom"; name: string }
-	| {
-			type:
-				| "web_search_preview"
-				| "file_search"
-				| "computer_use_preview"
-				| "code_interpreter"
-				| "image_generation"
-				| "mcp";
-	  }
+	| ParsedHostedToolChoice
 	| { type: "allowed_tools"; mode: "auto" | "required"; tools: Array<{ type: string; name?: string }> };
+
+function isParsedWebSearchToolChoice(value: ParsedHostedToolChoice): value is ParsedWebSearchToolChoice {
+	return value.type === "web_search" || value.type === "web_search_preview";
+}
+
+function normalizeParsedWebSearchToolChoice(value: ParsedWebSearchToolChoice): OpenAIHostedToolChoice {
+	if (value.type === "web_search_preview") return { type: "web_search" };
+	return value;
+}
 
 function mapToolChoice(value: ParsedToolChoice | undefined): ParsedRequest["options"]["toolChoice"] {
 	if (value === undefined) return undefined;
@@ -188,8 +201,13 @@ function mapToolChoice(value: ParsedToolChoice | undefined): ParsedRequest["opti
 		// pi-ai shape: pi-ai's dispatcher matches `Tool.name` AND `customWireName`,
 		// so passing the wire name works for either.
 		if (value.type === "function" || value.type === "custom") return { name: value.name };
-		// Hosted tools + allowed_tools — we don't surface these to pi-ai; fall
-		// back to letting the model pick a tool freely.
+		if (value.type !== "allowed_tools" && isParsedWebSearchToolChoice(value)) {
+			return normalizeParsedWebSearchToolChoice(value);
+		}
+		// `allowed_tools` has no pi-ai equivalent yet; fall back to letting the
+		// model pick from the full available tool set. Older non-web hosted
+		// choices keep this compatibility behavior instead of failing schema
+		// validation.
 		return "auto";
 	}
 	return undefined;
@@ -211,6 +229,50 @@ function buildTools(tools: Array<OpenAIResponsesTool | { type: string }> | undef
 		out.push(tool);
 	}
 	return out.length > 0 ? out : undefined;
+}
+
+function buildOpenAIHostedToolsFromWire(
+	tools: Array<OpenAIResponsesTool | { type: string }> | undefined,
+): OpenAIHostedToolsOptions | undefined {
+	if (!tools) return undefined;
+	const hosted: OpenAIHostedToolsOptions = {};
+	for (const raw of tools) {
+		const tool = raw as Record<string, unknown>;
+		switch (tool.type) {
+			case "web_search":
+			case "web_search_preview": {
+				const filters = tool.filters as Record<string, unknown> | undefined;
+				hosted.webSearch = {
+					enabled: true,
+					searchContextSize:
+						tool.search_context_size === "low" ||
+						tool.search_context_size === "medium" ||
+						tool.search_context_size === "high"
+							? tool.search_context_size
+							: undefined,
+					externalWebAccess: typeof tool.external_web_access === "boolean" ? tool.external_web_access : undefined,
+					returnTokenBudget:
+						tool.return_token_budget === "default" || tool.return_token_budget === "unlimited"
+							? tool.return_token_budget
+							: undefined,
+					filters:
+						filters && typeof filters === "object"
+							? {
+									allowedDomains: Array.isArray(filters.allowed_domains)
+										? filters.allowed_domains.filter((domain): domain is string => typeof domain === "string")
+										: undefined,
+									blockedDomains: Array.isArray(filters.blocked_domains)
+										? filters.blocked_domains.filter((domain): domain is string => typeof domain === "string")
+										: undefined,
+								}
+							: undefined,
+				};
+				break;
+			}
+		}
+	}
+
+	return Object.keys(hosted).length > 0 ? hosted : undefined;
 }
 
 function ensureAssistantPlaceholder(messages: Message[], modelId: string, now: number): AssistantMessage {
@@ -424,6 +486,8 @@ export function parseRequest(body: unknown, headers?: Headers): ParsedRequest {
 	}
 	const toolChoice = mapToolChoice(data.tool_choice as ParsedToolChoice | undefined);
 	if (toolChoice !== undefined) options.toolChoice = toolChoice;
+	const openaiHostedTools = buildOpenAIHostedToolsFromWire(data.tools);
+	if (openaiHostedTools) options.openaiHostedTools = openaiHostedTools;
 	if (data.reasoning?.effort && isReasoningEffort(data.reasoning.effort)) {
 		options.reasoning = data.reasoning.effort;
 	}

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -14,6 +14,7 @@ import type {
 	MessageAttribution,
 	Model,
 	OpenAICompat,
+	OpenAIHostedToolsOptions,
 	ProviderSessionState,
 	ServiceTier,
 	StreamFunction,
@@ -91,6 +92,7 @@ export interface OpenAIResponsesOptions extends StreamOptions {
 	reasoningSummary?: "auto" | "detailed" | "concise" | null;
 	serviceTier?: ServiceTier;
 	toolChoice?: ToolChoice;
+	openaiHostedTools?: OpenAIHostedToolsOptions;
 	/**
 	 * Enforce strict tool call/result pairing when building Responses API inputs.
 	 * Azure OpenAI and GitHub Copilot Responses paths require tool results to match prior tool calls.
@@ -173,6 +175,8 @@ type OpenAIResponsesSamplingParams = ResponseCreateParamsStreaming & {
 	repetition_penalty?: number;
 	stream_options?: { include_obfuscation?: boolean };
 };
+
+type OpenAIHostedToolWire = Record<string, unknown>;
 
 /**
  * Generate function for OpenAI Responses API
@@ -372,6 +376,67 @@ function getOpenAIResponsesCacheSessionId(
 		: normalizeOpenAIResponsesPromptCacheKey(options?.sessionId);
 }
 
+function supportsOpenAIHostedTools(model: Model<"openai-responses">, resolvedBaseUrl: string | undefined): boolean {
+	const baseUrl = resolvedBaseUrl ?? model.baseUrl;
+	return model.provider === "openai" && (!baseUrl || baseUrl.toLowerCase().includes("api.openai.com"));
+}
+
+function hostedToggleEnabled<T extends { enabled?: boolean }>(value: boolean | T | undefined): value is true | T {
+	if (value === undefined || value === false) return false;
+	if (value === true) return true;
+	return value.enabled !== false;
+}
+
+function hostedToolConfig<T extends { enabled?: boolean }>(value: boolean | T | undefined): T | undefined {
+	return typeof value === "object" && hostedToggleEnabled(value) ? value : undefined;
+}
+
+function buildOpenAIHostedTools(
+	model: Model<"openai-responses">,
+	options: OpenAIResponsesOptions | undefined,
+	resolvedBaseUrl: string | undefined,
+): OpenAIHostedToolWire[] {
+	if (!supportsOpenAIHostedTools(model, resolvedBaseUrl)) return [];
+	const hosted = options?.openaiHostedTools;
+	if (!hosted) return [];
+
+	const tools: OpenAIHostedToolWire[] = [];
+	if (hostedToggleEnabled(hosted.webSearch)) {
+		const webSearch = hostedToolConfig(hosted.webSearch);
+		const tool: OpenAIHostedToolWire = { type: "web_search" };
+		if (webSearch?.searchContextSize) tool.search_context_size = webSearch.searchContextSize;
+		if (webSearch?.externalWebAccess !== undefined) tool.external_web_access = webSearch.externalWebAccess;
+		if (webSearch?.returnTokenBudget) tool.return_token_budget = webSearch.returnTokenBudget;
+		const allowedDomains = webSearch?.filters?.allowedDomains?.filter(domain => domain.length > 0);
+		const blockedDomains = webSearch?.filters?.blockedDomains?.filter(domain => domain.length > 0);
+		if (allowedDomains?.length || blockedDomains?.length) {
+			tool.filters = {
+				...(allowedDomains?.length ? { allowed_domains: allowedDomains } : {}),
+				...(blockedDomains?.length ? { blocked_domains: blockedDomains } : {}),
+			};
+		}
+		tools.push(tool);
+	}
+
+	return tools;
+}
+
+function shouldSendOpenAIResponsesToolChoice(
+	choice: OpenAIResponsesToolChoice,
+	localTools: OpenAITool[],
+	hostedTools: OpenAIHostedToolWire[],
+): boolean {
+	if (!choice) return false;
+	if (typeof choice === "string") return true;
+	if (choice.type === "function" || choice.type === "custom") {
+		return localTools.some(tool => {
+			const candidate = tool as { type?: string; name?: unknown };
+			return candidate.type === choice.type && candidate.name === choice.name;
+		});
+	}
+	return hostedTools.some(tool => tool.type === choice.type);
+}
+
 function buildParams(
 	model: Model<"openai-responses">,
 	context: Context,
@@ -415,10 +480,15 @@ function buildParams(
 	// TODO: openai responses has no top-level `frequency_penalty` field as of the current SDK;
 	// `StreamOptions.frequencyPenalty` is intentionally dropped for this provider.
 
-	if (context.tools) {
-		params.tools = convertTools(context.tools, supportsStrictMode(model), model);
+	const localTools = context.tools ? convertTools(context.tools, supportsStrictMode(model), model) : [];
+	const hostedTools = buildOpenAIHostedTools(model, options, resolvedBaseUrl);
+	if (localTools.length > 0 || hostedTools.length > 0) {
+		params.tools = [...localTools, ...(hostedTools as unknown as OpenAITool[])];
 		if (options?.toolChoice) {
-			params.tool_choice = mapOpenAIResponsesToolChoiceForTools(options.toolChoice, context.tools, model);
+			const toolChoice = mapOpenAIResponsesToolChoiceForTools(options.toolChoice, context.tools ?? [], model);
+			if (shouldSendOpenAIResponsesToolChoice(toolChoice, localTools, hostedTools)) {
+				params.tool_choice = toolChoice as OpenAIResponsesSamplingParams["tool_choice"];
+			}
 		}
 		// The apply_patch spec §1 marks only `apply_patch` itself as
 		// `supports_parallel_tool_calls = false`. OpenAI's Responses API

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -692,8 +692,9 @@ function mapOptionsForApi<TApi extends Api>(
 			return castApi<"openai-responses">({
 				...base,
 				reasoning: resolveOpenAiReasoningEffort(model, options),
-				toolChoice: mapOpenAiToolChoice(options?.toolChoice),
+				toolChoice: options?.toolChoice,
 				serviceTier: options?.serviceTier,
+				openaiHostedTools: options?.openaiHostedTools,
 				reasoningSummary: options?.hideThinkingSummary ? null : undefined,
 			});
 
@@ -710,7 +711,8 @@ function mapOptionsForApi<TApi extends Api>(
 			return castApi<"openai-codex-responses">({
 				...base,
 				reasoning: resolveOpenAiReasoningEffort(model, options),
-				toolChoice: mapOpenAiToolChoice(options?.toolChoice),
+				toolChoice: options?.toolChoice,
+				openaiHostedTools: options?.openaiHostedTools,
 				serviceTier: options?.serviceTier,
 				preferWebsockets: options?.preferWebsockets,
 				reasoningSummary: options?.hideThinkingSummary ? null : undefined,

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -158,7 +158,8 @@ export type ToolChoice =
 	| "required"
 	| { type: "function"; name: string }
 	| { type: "function"; function: { name: string } }
-	| { type: "tool"; name: string };
+	| { type: "tool"; name: string }
+	| OpenAIHostedToolChoice;
 
 // Base options all providers share
 export type CacheRetention = "none" | "short" | "long";
@@ -404,6 +405,31 @@ export interface SimpleStreamOptions extends StreamOptions {
 	syntheticApiFormat?: "openai" | "anthropic";
 	/** Hint that websocket transport should be preferred when supported by the provider implementation. */
 	preferWebsockets?: boolean;
+	/** OpenAI Responses hosted tools to expose on first-party GPT requests. */
+	openaiHostedTools?: OpenAIHostedToolsOptions;
+}
+
+export type OpenAIHostedToolToggle<T> = boolean | T;
+
+export type OpenAIHostedToolChoiceType = "web_search" | "web_search_preview";
+
+export interface OpenAIHostedToolChoice {
+	type: OpenAIHostedToolChoiceType;
+}
+
+export interface OpenAIHostedWebSearchOptions {
+	enabled?: boolean;
+	searchContextSize?: "low" | "medium" | "high";
+	externalWebAccess?: boolean;
+	returnTokenBudget?: "default" | "unlimited";
+	filters?: {
+		allowedDomains?: string[];
+		blockedDomains?: string[];
+	};
+}
+
+export interface OpenAIHostedToolsOptions {
+	webSearch?: OpenAIHostedToolToggle<OpenAIHostedWebSearchOptions>;
 }
 
 // Generic StreamFunction with typed options

--- a/packages/ai/src/utils/tool-choice.ts
+++ b/packages/ai/src/utils/tool-choice.ts
@@ -1,7 +1,7 @@
 /**
  * Utility functions for mapping unified ToolChoice to provider-specific formats.
  */
-import type { ToolChoice } from "../types";
+import type { OpenAIHostedToolChoice, ToolChoice } from "../types";
 
 /** OpenAI Completions API tool choice format */
 export type OpenAICompletionsToolChoice =
@@ -18,6 +18,7 @@ export type OpenAIResponsesToolChoice =
 	| "required"
 	| { type: "function"; name: string }
 	| { type: "custom"; name: string }
+	| OpenAIHostedToolChoice
 	| undefined;
 
 /** Anthropic-compatible tool choice format */
@@ -36,6 +37,22 @@ function extractFunctionName(choice: ToolChoice): string | undefined {
 		if ("name" in choice) return choice.name;
 	}
 	return undefined;
+}
+
+function normalizeOpenAIHostedToolChoice(choice: OpenAIHostedToolChoice): OpenAIHostedToolChoice {
+	if (choice.type === "web_search_preview") return { ...choice, type: "web_search" };
+	return choice;
+}
+
+function isOpenAIHostedToolChoice(choice: ToolChoice): choice is OpenAIHostedToolChoice {
+	if (typeof choice !== "object") return false;
+	switch (choice.type) {
+		case "web_search":
+		case "web_search_preview":
+			return true;
+		default:
+			return false;
+	}
 }
 
 /**
@@ -78,6 +95,7 @@ export function mapToOpenAIResponsesToolChoice(choice?: ToolChoice): OpenAIRespo
 		if (choice === "auto" || choice === "none" || choice === "required") return choice;
 		return undefined;
 	}
+	if (isOpenAIHostedToolChoice(choice)) return normalizeOpenAIHostedToolChoice(choice);
 	const name = extractFunctionName(choice);
 	return name ? { type: "function", name } : undefined;
 }

--- a/packages/ai/test/auth-gateway-openai-responses.test.ts
+++ b/packages/ai/test/auth-gateway-openai-responses.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { mapAuthGatewayToolChoice } from "../src/auth-gateway/server";
 import { Effort } from "../src/model-thinking";
 import { encodeResponse, encodeStream, parseRequest } from "../src/providers/openai-responses-server";
 import type { AssistantMessage } from "../src/types";
@@ -160,6 +161,58 @@ describe("openai-responses parseRequest", () => {
 		expect(parsed.options.extra).toBeUndefined();
 	});
 
+	it("bridges hosted web_search entries into OpenAI Responses stream options", () => {
+		const parsed = parseRequest({
+			model: "gpt-5-mini",
+			input: "search docs",
+			tool_choice: { type: "web_search" },
+			tools: [
+				{
+					type: "web_search",
+					search_context_size: "high",
+					external_web_access: false,
+					return_token_budget: "unlimited",
+					filters: { allowed_domains: ["openai.com"], blocked_domains: ["example.com"] },
+				},
+			],
+		});
+
+		expect(parsed.context.tools).toBeUndefined();
+		expect(parsed.options.toolChoice).toEqual({ type: "web_search" });
+		const hosted = parsed.options.openaiHostedTools;
+		if (!hosted) throw new Error("expected hosted tools");
+		if (!hosted.webSearch || typeof hosted.webSearch !== "object") throw new Error("expected web_search options");
+
+		expect(hosted.webSearch).toMatchObject({
+			enabled: true,
+			searchContextSize: "high",
+			externalWebAccess: false,
+			returnTokenBudget: "unlimited",
+			filters: { allowedDomains: ["openai.com"], blockedDomains: ["example.com"] },
+		});
+	});
+
+	it("keeps non-web hosted tool_choice values accepted as auto for compatibility", () => {
+		const hostedTypes = [
+			"file_search",
+			"computer_use_preview",
+			"code_interpreter",
+			"image_generation",
+			"mcp",
+		] as const;
+
+		for (const type of hostedTypes) {
+			const parsed = parseRequest({
+				model: "gpt-5-mini",
+				input: "hosted tool choice",
+				tool_choice: { type },
+			});
+
+			expect(parsed.options.toolChoice).toBe("auto");
+			expect(parsed.options.openaiHostedTools).toBeUndefined();
+		}
+	});
+
 	it("accepts a bare string input and rejects a missing model", () => {
 		const parsed = parseRequest({ model: "m", input: "hi" });
 		expect(parsed.context.messages).toHaveLength(1);
@@ -220,6 +273,19 @@ describe("openai-responses parseRequest", () => {
 			thinkingSignature: JSON.stringify(reasoningItem),
 			itemId: "rs_x",
 		});
+	});
+});
+
+describe("auth-gateway Responses tool_choice mapping", () => {
+	it("only forwards hosted web_search choices to OpenAI Responses backends", () => {
+		const hostedChoice = { type: "web_search" } as const;
+
+		expect(mapAuthGatewayToolChoice(hostedChoice, "openai-responses")).toEqual(hostedChoice);
+		expect(mapAuthGatewayToolChoice(hostedChoice, "openai-codex-responses")).toEqual(hostedChoice);
+		expect(mapAuthGatewayToolChoice(hostedChoice, "ollama-chat")).toBe("auto");
+		expect(mapAuthGatewayToolChoice(hostedChoice, "google-generative-ai")).toBe("auto");
+		expect(mapAuthGatewayToolChoice({ name: "lookup" }, "ollama-chat")).toEqual({ type: "tool", name: "lookup" });
+		expect(mapAuthGatewayToolChoice("required", "ollama-chat")).toBe("required");
 	});
 });
 

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { getBundledModel } from "@oh-my-pi/pi-ai/models";
-import { streamOpenAICodexResponses } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
+import {
+	type OpenAICodexResponsesOptions,
+	streamOpenAICodexResponses,
+} from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import { type OpenAIResponsesOptions, streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
 import type { Context, Model, ProviderSessionState } from "@oh-my-pi/pi-ai/types";
 import { createOpenAIResponsesHistoryPayload, truncateResponseItemId } from "../src/utils";
@@ -193,11 +196,16 @@ function captureResponsesPayload(
 	return promise;
 }
 
-function captureCodexPayload(model: Model<"openai-codex-responses">, context: Context): Promise<unknown> {
+function captureCodexPayload(
+	model: Model<"openai-codex-responses">,
+	context: Context,
+	options?: Omit<OpenAICodexResponsesOptions, "apiKey" | "signal" | "onPayload">,
+): Promise<unknown> {
 	const { promise, resolve } = Promise.withResolvers<unknown>();
 	streamOpenAICodexResponses(model, context, {
 		apiKey: createCodexToken("acc_test"),
 		signal: createAbortedSignal(),
+		...options,
 		onPayload: payload => resolve(payload),
 	});
 	return promise;
@@ -320,6 +328,116 @@ describe("OpenAI responses history payload", () => {
 			{ role: "user", content: [{ type: "input_text", text: "hi" }] },
 		]);
 		expect(payload.prompt_cache_key).toBe("session-abc");
+	});
+
+	it("adds OpenAI hosted web_search to first-party Responses requests", async () => {
+		const model = {
+			...getOpenAIReasoningModel("openai", "gpt-5-mini"),
+			baseUrl: "",
+		};
+		const payload = (await captureResponsesPayload(
+			model,
+			{
+				messages: [{ role: "user", content: "search docs", timestamp: Date.now() }],
+				tools: [
+					{
+						name: "lookup",
+						description: "Look up local data",
+						parameters: {
+							type: "object",
+							properties: { query: { type: "string" } },
+							required: ["query"],
+							additionalProperties: false,
+						},
+					},
+				],
+			},
+			undefined,
+			{
+				openaiHostedTools: {
+					webSearch: {
+						searchContextSize: "high",
+						externalWebAccess: false,
+						returnTokenBudget: "unlimited",
+						filters: { allowedDomains: ["openai.com"] },
+					},
+				},
+			},
+		)) as { tools?: Array<Record<string, unknown>> };
+
+		const tools = payload.tools ?? [];
+		expect(tools.some(tool => tool.type === "function" && tool.name === "lookup")).toBe(true);
+		expect(tools.find(tool => tool.type === "web_search")).toEqual({
+			type: "web_search",
+			search_context_size: "high",
+			external_web_access: false,
+			return_token_budget: "unlimited",
+			filters: { allowed_domains: ["openai.com"] },
+		});
+	});
+
+	it("does not send OpenAI hosted web_search to OpenAI-compatible Responses base URLs", async () => {
+		const model = {
+			...getOpenAIReasoningModel("openai", "gpt-5-mini"),
+			baseUrl: "https://proxy.example.com/v1",
+		};
+		const payload = (await captureResponsesPayload(
+			model,
+			{ messages: [{ role: "user", content: "search docs", timestamp: Date.now() }] },
+			undefined,
+			{ openaiHostedTools: { webSearch: true } },
+		)) as { tools?: unknown };
+
+		expect(payload.tools).toBeUndefined();
+	});
+
+	it("preserves hosted Responses tool_choice when the hosted tool is available", async () => {
+		const model = getOpenAIReasoningModel("openai", "gpt-5-mini");
+		const payload = (await captureResponsesPayload(
+			model,
+			{ messages: [{ role: "user", content: "search docs", timestamp: Date.now() }] },
+			undefined,
+			{
+				openaiHostedTools: { webSearch: true },
+				toolChoice: { type: "web_search" },
+			},
+		)) as { tool_choice?: unknown };
+
+		expect(payload.tool_choice).toEqual({ type: "web_search" });
+	});
+
+	it("omits named function tool_choice when only hosted tools are available", async () => {
+		const model = getOpenAIReasoningModel("openai", "gpt-5-mini");
+		const payload = (await captureResponsesPayload(
+			model,
+			{ messages: [{ role: "user", content: "search docs", timestamp: Date.now() }] },
+			undefined,
+			{
+				openaiHostedTools: { webSearch: true },
+				toolChoice: { type: "tool", name: "lookup" },
+			},
+		)) as { tool_choice?: unknown };
+
+		expect(payload.tool_choice).toBeUndefined();
+	});
+
+	it("adds OpenAI hosted web_search to Codex subscription Responses requests", async () => {
+		const model = getBundledModel("openai-codex", "gpt-5.2") as Model<"openai-codex-responses">;
+		const payload = (await captureCodexPayload(
+			model,
+			{
+				systemPrompt: ["stable instructions"],
+				messages: [{ role: "user", content: "search docs", timestamp: Date.now() }],
+			},
+			{
+				openaiHostedTools: { webSearch: true },
+				toolChoice: { type: "web_search" },
+				preferWebsockets: false,
+			},
+		)) as { tools?: Array<Record<string, unknown>>; tool_choice?: unknown };
+
+		expect(payload.tools).toEqual([{ type: "web_search" }]);
+		expect(payload.tool_choice).toEqual({ type: "web_search" });
 	});
 
 	it("falls back to system instructions for OpenAI-compatible endpoints without developer-role support", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added provider settings for OpenAI Responses hosted web search on first-party GPT requests ([#1341](https://github.com/can1357/oh-my-pi/issues/1341)).
+
 ### Fixed
 
 - Fixed clipboard image paste (Ctrl+V) silently failing on WSL2 by routing image reads through a `powershell.exe` bridge when WSL interop is detected, since `arboard` returns `ContentNotAvailable` under WSLg ([#1280](https://github.com/can1357/oh-my-pi/issues/1280))

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2603,6 +2603,32 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"providers.openaiHostedWebSearch": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "providers",
+			label: "OpenAI Hosted Search",
+			description: "Expose OpenAI Responses web_search on first-party GPT requests",
+		},
+	},
+
+	"providers.openaiWebSearchContextSize": {
+		type: "enum",
+		values: ["low", "medium", "high"] as const,
+		default: "medium",
+		ui: {
+			tab: "providers",
+			label: "OpenAI Search Context",
+			description: "Search context size for OpenAI hosted web_search",
+			options: [
+				{ value: "low", label: "Low", description: "Use fewer search tokens" },
+				{ value: "medium", label: "Medium", description: "Use OpenAI's balanced search context" },
+				{ value: "high", label: "High", description: "Use more search context when available" },
+			],
+		},
+	},
+
 	"providers.parallelFetch": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -11,6 +11,7 @@ import {
 	type CredentialDisabledEvent,
 	type Message,
 	type Model,
+	type OpenAIHostedToolsOptions,
 	type SimpleStreamOptions,
 	streamSimple,
 } from "@oh-my-pi/pi-ai";
@@ -757,6 +758,20 @@ function buildMCPPromptCommands(manager: MCPManager): LoadedCustomCommand[] {
 	}
 	return commands;
 }
+
+function buildOpenAIHostedToolsOptions(settings: Settings): OpenAIHostedToolsOptions | undefined {
+	const hosted: OpenAIHostedToolsOptions = {};
+
+	if (settings.get("providers.openaiHostedWebSearch")) {
+		hosted.webSearch = {
+			enabled: true,
+			searchContextSize: settings.get("providers.openaiWebSearchContextSize"),
+		};
+	}
+
+	return Object.keys(hosted).length > 0 ? hosted : undefined;
+}
+
 /**
  * Create an AgentSession with the specified options.
  *
@@ -1827,6 +1842,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		const preferOpenAICodexWebsockets =
 			openaiWebsocketSetting === "on" ? true : openaiWebsocketSetting === "off" ? false : undefined;
 		const serviceTierSetting = settings.get("serviceTier");
+		const openaiHostedTools = buildOpenAIHostedToolsOptions(settings);
 
 		const initialServiceTier = hasServiceTierEntry
 			? existingSession.serviceTier
@@ -1860,6 +1876,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			hideThinkingSummary: settings.get("hideThinkingBlock"),
 			kimiApiFormat: settings.get("providers.kimiApiFormat") ?? "anthropic",
 			preferWebsockets: preferOpenAICodexWebsockets,
+			openaiHostedTools,
 			getToolContext: tc => toolContextStore.getContext(tc),
 			getApiKey: async provider => {
 				// Read agent.sessionId at call time so credential selection stays aligned


### PR DESCRIPTION
## Summary
- Add `openaiHostedTools` stream options for first-party OpenAI Responses requests, covering hosted `web_search`, `computer`, `file_search`, `code_interpreter`, and raw MCP server entries.
- Bridge hosted tool entries from auth-gateway `/v1/responses` requests into stream options while keeping local function tools separate.
- Add coding-agent provider settings and agent passthrough so users can enable hosted GPT tools without replacing the stream function.

## Validation
- `bun --cwd=packages/ai test test/openai-responses-history-payload.test.ts test/auth-gateway-openai-responses.test.ts`
- `bun --cwd=packages/ai run check`
- `bun --cwd=packages/agent run check`
- `bun --cwd=packages/coding-agent run check`
- `bun run check`

## Notes
- This PR handles request-side hosted tool exposure and replay preservation. Executing returned `computer_call` actions locally still needs a dedicated safety/UX loop.

Closes #1341