### PR TITLE
Append only mode for Deepseek Enjoyers

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Fixed `transformContext` receiving the loop config object as the `signal` argument instead of the actual `AbortSignal`, so hooks that check `signal.aborted` or call `signal.addEventListener` now work correctly under abort/timeout conditions
+- Fixed `appendOnlyContext` not being re-evaluated after `setModel()` — the mode was decided once at session construction based on the initial model's provider, so switching from/to DeepSeek (or changing `provider.appendOnlyContext`) mid-session produced incorrect mode behavior
 
 ## [15.2.3] - 2026-05-22
 ### Added

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -640,19 +640,26 @@ async function streamAssistantResponse(
 	// Apply context transform if configured (AgentMessage[] → AgentMessage[])
 	let messages = context.messages;
 	if (config.transformContext) {
-		messages = await config.transformContext(messages, signal);
+		messages = await config.transformContext(messages, config as any);
 	}
 
 	// Convert to LLM-compatible messages (AgentMessage[] → Message[])
 	const llmMessages = await config.convertToLlm(messages);
 	const normalizedMessages = normalizeMessagesForProvider(llmMessages, config.model);
 
-	// Build LLM context
-	const llmContext: Context = {
-		systemPrompt: context.systemPrompt,
-		messages: normalizedMessages,
-		tools: normalizeTools(context.tools, !!config.intentTracing),
-	};
+	// Build LLM context — append-only mode caches system prompt + tools
+	// AND keeps an append-only message log so prior-turn bytes are stable.
+	let llmContext: Context;
+	if (config.appendOnlyContext) {
+		config.appendOnlyContext.syncMessages(normalizedMessages);
+		llmContext = config.appendOnlyContext.build(context);
+	} else {
+		llmContext = {
+			systemPrompt: context.systemPrompt,
+			messages: normalizedMessages,
+			tools: normalizeTools(context.tools, !!config.intentTracing),
+		};
+	}
 
 	const streamFunction = streamFn || streamSimple;
 

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -640,7 +640,7 @@ async function streamAssistantResponse(
 	// Apply context transform if configured (AgentMessage[] → AgentMessage[])
 	let messages = context.messages;
 	if (config.transformContext) {
-		messages = await config.transformContext(messages, config as any);
+		messages = await config.transformContext(messages, signal);
 	}
 
 	// Convert to LLM-compatible messages (AgentMessage[] → Message[])

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -21,6 +21,7 @@ import {
 	type ToolResultMessage,
 } from "@oh-my-pi/pi-ai";
 import { agentLoop, agentLoopContinue } from "./agent-loop";
+import type { AppendOnlyContextManager } from "./append-only-context";
 import type { HarmonyAuditEvent } from "./harmony-leak";
 import type {
 	AgentContext,
@@ -227,6 +228,11 @@ export interface AgentOptions {
 	 * {@link AgentLoopConfig.telemetry} for the full surface.
 	 */
 	telemetry?: AgentLoopConfig["telemetry"];
+	/**
+	 * Immutable context mode — stabilizes system prompt + tool spec bytes
+	 * across turns so DeepSeek/Anthropic prefix caches hit at maximum rate.
+	 */
+	appendOnlyContext?: AppendOnlyContextManager;
 }
 
 export interface AgentPromptOptions {
@@ -292,6 +298,7 @@ export class Agent {
 	#onHarmonyLeak?: (event: HarmonyAuditEvent) => void | Promise<void>;
 	#onBeforeYield?: () => Promise<void> | void;
 	#telemetry?: AgentLoopConfig["telemetry"];
+	#appendOnlyContext?: AppendOnlyContextManager;
 
 	/** Buffered Cursor tool results with text length at time of call (for correct ordering) */
 	#cursorToolResultBuffer: CursorToolResultEntry[] = [];
@@ -346,6 +353,7 @@ export class Agent {
 		this.beforeToolCall = opts.beforeToolCall;
 		this.afterToolCall = opts.afterToolCall;
 		this.#telemetry = opts.telemetry;
+		this.#appendOnlyContext = opts.appendOnlyContext;
 	}
 
 	/**
@@ -925,6 +933,7 @@ export class Agent {
 			cursorOnToolResult,
 			transformToolCallArguments: this.#transformToolCallArguments,
 			intentTracing: this.#intentTracing,
+			appendOnlyContext: this.#appendOnlyContext,
 			beforeToolCall: this.beforeToolCall ? (ctx, signal) => this.beforeToolCall?.(ctx, signal) : undefined,
 			afterToolCall: this.afterToolCall ? (ctx, signal) => this.afterToolCall?.(ctx, signal) : undefined,
 			onAssistantMessageEvent: this.#onAssistantMessageEvent,

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -549,6 +549,14 @@ export class Agent {
 		return this.#state;
 	}
 
+	get appendOnlyContext(): AppendOnlyContextManager | undefined {
+		return this.#appendOnlyContext;
+	}
+
+	setAppendOnlyContext(manager?: AppendOnlyContextManager): void {
+		this.#appendOnlyContext = manager;
+	}
+
 	subscribe(fn: (e: AgentEvent) => void): () => void {
 		this.#listeners.add(fn);
 		return () => this.#listeners.delete(fn);

--- a/packages/agent/src/append-only-context.ts
+++ b/packages/agent/src/append-only-context.ts
@@ -151,6 +151,8 @@ export class AppendOnlyContextManager {
 	readonly log = new AppendOnlyLog();
 	/** How many normalized messages were synced into the log as of the last sync. */
 	#lastSyncCount = 0;
+	/** Rolling digest of synced message content — detects in-place rewrites. */
+	#syncedDigest = 0;
 
 	build(context: AgentContext): Context {
 		this.prefix.build(context);
@@ -161,19 +163,21 @@ export class AppendOnlyContextManager {
 	/**
 	 * Sync normalized (provider-level) messages into the append-only log.
 	 *
-	 * On the first call, all messages are appended. On subsequent calls,
-	 * only the delta since the last sync is appended (the prior messages
-	 * are already in the log with stable bytes).
-	 *
-	 * Call this **before** `build()` each turn so the log is up to date
-	 * and `build()` returns the correct messages from the log, not from
-	 * a freshly-converted array.
-	 *
-	 * When the message array shrinks (compaction), the log is reset and
-	 * re-synced from scratch.
+	 * Detects both compaction (shorter array) and in-place rewrites
+	 * (same length, changed content via a rolling digest).
 	 */
 	syncMessages(normalizedMessages: any[]): void {
-		// Compaction or full reset — message root changed
+		// Detect in-place rewrites of already-synced messages.
+		if (
+			this.#lastSyncCount > 0 &&
+			this.#lastSyncCount <= normalizedMessages.length &&
+			this.#computeDigest(normalizedMessages.slice(0, this.#lastSyncCount)) !== this.#syncedDigest
+		) {
+			this.log.clear();
+			this.#lastSyncCount = 0;
+		}
+
+		// Compaction — array shrunk.
 		if (normalizedMessages.length < this.#lastSyncCount) {
 			this.log.clear();
 			this.#lastSyncCount = 0;
@@ -185,12 +189,22 @@ export class AppendOnlyContextManager {
 		}
 
 		this.#lastSyncCount = normalizedMessages.length;
+		this.#syncedDigest = this.#computeDigest(normalizedMessages);
 	}
 
-	/** Reset the sync cursor AND clear the log (call after retry or explicit reset). */
+	/** Reset prefix + log for a model/provider switch while mode stays active. */
+	invalidateForModelChange(): void {
+		this.prefix.invalidate();
+		this.log.clear();
+		this.#lastSyncCount = 0;
+		this.#syncedDigest = 0;
+	}
+
+	/** Reset the sync cursor AND clear the log. */
 	resetSyncCursor(): void {
 		this.log.clear();
 		this.#lastSyncCount = 0;
+		this.#syncedDigest = 0;
 	}
 
 	appendMessage(message: any): void {
@@ -209,7 +223,24 @@ export class AppendOnlyContextManager {
 		this.prefix.invalidate();
 		this.log.clear();
 		this.#lastSyncCount = 0;
+		this.#syncedDigest = 0;
 		this.prefix.build(context);
+	}
+
+	/** Fast rolling digest of message content. */
+	#computeDigest(messages: any[]): number {
+		let hash = 0;
+		for (let i = 0; i < messages.length; i++) {
+			const msg = messages[i];
+			if (msg && typeof msg === "object") {
+				const payload =
+					String(msg.role) + (typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content ?? ""));
+				for (let j = 0; j < payload.length; j++) {
+					hash = ((hash << 5) - hash + payload.charCodeAt(j)) | 0;
+				}
+			}
+		}
+		return hash >>> 0;
 	}
 }
 

--- a/packages/agent/src/append-only-context.ts
+++ b/packages/agent/src/append-only-context.ts
@@ -1,0 +1,257 @@
+/**
+ * Append-only context mode — stabilizes the byte prefix sent to the LLM
+ * across turns so provider prefix caches (DeepSeek, Anthropic, etc.)
+ * hit at the maximum possible rate.
+ *
+ * Two mechanisms:
+ *
+ * 1. **StablePrefix** — system prompt + tool specs are computed once
+ *    and frozen. Subsequent turns reuse the exact same byte sequence
+ *    unless `invalidate()` is called (e.g. after MCP reconnect).
+ *
+ * 2. **AppendOnlyLog** — messages only grow; prior turns are never
+ *    re-serialized. Combined with a stable prefix, only the user's new
+ *    message delta is a cache miss each turn.
+ */
+
+import type { Context, Message, Tool } from "@oh-my-pi/pi-ai";
+import type { AgentContext, AgentTool } from "./types";
+
+// ---------------------------------------------------------------------------
+// StablePrefix (formerly ImmutablePrefix)
+// ---------------------------------------------------------------------------
+
+/** Frozen system prompt + tool spec snapshot. */
+export interface StablePrefixSnapshot {
+	systemPrompt: string[];
+	tools: Tool[];
+	fingerprint: string;
+}
+
+/**
+ * A frozen prefix (system prompt + tools) that produces stable byte
+ * sequences across `build()` calls.
+ *
+ * The first `build()` snapshots the live state. Subsequent calls reuse
+ * the cached copy until `invalidate()` is called or the live state's
+ * fingerprint changes.
+ */
+export class StablePrefix {
+	#snapshot: StablePrefixSnapshot | null = null;
+	#version = 0;
+
+	get fingerprint(): string {
+		return this.#snapshot?.fingerprint ?? "<unbuilt>";
+	}
+	get version(): number {
+		return this.#version;
+	}
+	get built(): boolean {
+		return this.#snapshot !== null;
+	}
+
+	/**
+	 * Build or rebuild from live context.
+	 * Returns `true` if the prefix actually changed (cache miss imminent).
+	 */
+	build(context: AgentContext): boolean {
+		const snapshot = takeSnapshot(context);
+		if (this.#snapshot && this.#snapshot.fingerprint === snapshot.fingerprint) {
+			return false;
+		}
+		this.#snapshot = snapshot;
+		this.#version++;
+		return true;
+	}
+
+	/** Force rebuild on the next `build()` call. */
+	invalidate(): void {
+		this.#snapshot = null;
+	}
+
+	/**
+	 * Returns the cached prefix.
+	 * @throws if `build()` was never called.
+	 */
+	toContext(): { systemPrompt: string[]; tools: Tool[] } {
+		const s = this.#snapshot;
+		if (!s) throw new Error("StablePrefix.toContext() called before build()");
+		return { systemPrompt: s.systemPrompt, tools: s.tools };
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AppendOnlyLog
+// ---------------------------------------------------------------------------
+
+/**
+ * Append-only message log at the `Message[]` (provider-level) layer.
+ *
+ * The only mutation path is `replaceTail()`, reserved for compaction.
+ * Every other operation is append-only.
+ */
+export class AppendOnlyLog {
+	#entries: Message[] = [];
+
+	get length(): number {
+		return this.#entries.length;
+	}
+
+	append(message: Message): void {
+		this.#entries.push(message);
+	}
+
+	extend(messages: Message[]): void {
+		for (const m of messages) this.#entries.push(m);
+	}
+
+	/** Replace the last entry — only legal for compaction. */
+	replaceTail(replacement: Message): void {
+		const idx = this.#entries.length - 1;
+		if (idx >= 0) this.#entries[idx] = replacement;
+	}
+
+	/** Returns a shallow copy of all entries. */
+	toMessages(): Message[] {
+		return this.#entries.slice();
+	}
+
+	/** Direct readonly access for in-place inspection. */
+	entries(): readonly Message[] {
+		return this.#entries;
+	}
+
+	clear(): void {
+		this.#entries = [];
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AppendOnlyContextManager
+// ---------------------------------------------------------------------------
+
+/**
+ * Manages a stable prefix + append-only log for the agent loop.
+ *
+ * Call `build(context)` each turn to get a `Context` with stable
+ * `systemPrompt` and `tools` and append-only messages. Call
+ * `syncMessages(normalizedMessages)` after `convertToLlm` each
+ * turn to keep the log in sync.
+ *
+ * Example:
+ * ```
+ * const mgr = new AppendOnlyContextManager();
+ * const ctx = mgr.build(context);  // first call snapshots prefix
+ * mgr.syncMessages(normalized);    // grow the log
+ * ctx = mgr.build(context);        // subsequent calls use cache
+ * ```
+ */
+export class AppendOnlyContextManager {
+	readonly prefix = new StablePrefix();
+	readonly log = new AppendOnlyLog();
+	/** How many normalized messages were synced into the log as of the last sync. */
+	#lastSyncCount = 0;
+
+	build(context: AgentContext): Context {
+		this.prefix.build(context);
+		const { systemPrompt, tools } = this.prefix.toContext();
+		return { systemPrompt, messages: this.log.toMessages(), tools };
+	}
+
+	/**
+	 * Sync normalized (provider-level) messages into the append-only log.
+	 *
+	 * On the first call, all messages are appended. On subsequent calls,
+	 * only the delta since the last sync is appended (the prior messages
+	 * are already in the log with stable bytes).
+	 *
+	 * Call this **before** `build()` each turn so the log is up to date
+	 * and `build()` returns the correct messages from the log, not from
+	 * a freshly-converted array.
+	 *
+	 * When the message array shrinks (compaction), the log is reset and
+	 * re-synced from scratch.
+	 */
+	syncMessages(normalizedMessages: Message[]): void {
+		// Compaction or full reset — message root changed
+		if (normalizedMessages.length < this.#lastSyncCount) {
+			this.log.clear();
+			this.#lastSyncCount = 0;
+		}
+
+		const newMsgs = normalizedMessages.slice(this.#lastSyncCount);
+		for (const msg of newMsgs) {
+			this.log.append(msg);
+		}
+
+		this.#lastSyncCount = normalizedMessages.length;
+	}
+
+	/** Reset the sync cursor AND clear the log (call after retry or explicit reset). */
+	resetSyncCursor(): void {
+		this.log.clear();
+		this.#lastSyncCount = 0;
+	}
+
+	appendMessage(message: Message): void {
+		this.log.append(message);
+	}
+
+	replaceTailMessage(message: Message): void {
+		this.log.replaceTail(message);
+	}
+
+	invalidate(): void {
+		this.prefix.invalidate();
+	}
+
+	reset(context: AgentContext): void {
+		this.prefix.invalidate();
+		this.log.clear();
+		this.#lastSyncCount = 0;
+		this.prefix.build(context);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Produce a stable serialization of tools that matches what
+ * `normalizeTools(tools, false)` outputs (no intent injection).
+ *
+ * The spread `{ ...agentTool }` preserves all own enumerable properties
+ * that survive JSON.stringify — functions are dropped, but strings,
+ * booleans, objects are included.
+ */
+function normalizeTool(t: AgentTool): Tool {
+	const description = t.description ?? "";
+	return { ...t, parameters: t.parameters, description };
+}
+
+function takeSnapshot(context: AgentContext): StablePrefixSnapshot {
+	const systemPrompt = [...context.systemPrompt];
+	const tools = (context.tools ?? []).map(normalizeTool);
+	return {
+		systemPrompt,
+		tools,
+		fingerprint: computeFingerprint(systemPrompt, tools),
+	};
+}
+
+function computeFingerprint(systemPrompt: string[], tools: Tool[]): string {
+	const payload = JSON.stringify({
+		s: systemPrompt.join("\n"),
+		t: tools.map(t => ({
+			n: t.name,
+			d: t.description,
+			p: t.parameters,
+		})),
+	});
+	let hash = 0;
+	for (let i = 0; i < payload.length; i++) {
+		hash = ((hash << 5) - hash + payload.charCodeAt(i)) | 0;
+	}
+	return (hash >>> 0).toString(36);
+}

--- a/packages/agent/src/append-only-context.ts
+++ b/packages/agent/src/append-only-context.ts
@@ -97,16 +97,16 @@ export class AppendOnlyLog {
 		return this.#entries.length;
 	}
 
-	append(message: Message): void {
+	append(message: any): void {
 		this.#entries.push(message);
 	}
 
-	extend(messages: Message[]): void {
+	extend(messages: any[]): void {
 		for (const m of messages) this.#entries.push(m);
 	}
 
 	/** Replace the last entry — only legal for compaction. */
-	replaceTail(replacement: Message): void {
+	replaceTail(replacement: any): void {
 		const idx = this.#entries.length - 1;
 		if (idx >= 0) this.#entries[idx] = replacement;
 	}
@@ -172,7 +172,7 @@ export class AppendOnlyContextManager {
 	 * When the message array shrinks (compaction), the log is reset and
 	 * re-synced from scratch.
 	 */
-	syncMessages(normalizedMessages: Message[]): void {
+	syncMessages(normalizedMessages: any[]): void {
 		// Compaction or full reset — message root changed
 		if (normalizedMessages.length < this.#lastSyncCount) {
 			this.log.clear();
@@ -193,11 +193,11 @@ export class AppendOnlyContextManager {
 		this.#lastSyncCount = 0;
 	}
 
-	appendMessage(message: Message): void {
+	appendMessage(message: any): void {
 		this.log.append(message);
 	}
 
-	replaceTailMessage(message: Message): void {
+	replaceTailMessage(message: any): void {
 		this.log.replaceTail(message);
 	}
 

--- a/packages/agent/src/append-only-context.ts
+++ b/packages/agent/src/append-only-context.ts
@@ -278,6 +278,9 @@ function computeFingerprint(systemPrompt: string[], tools: Tool[]): string {
 			n: t.name,
 			d: t.description,
 			p: t.parameters,
+			s: t.strict,
+			cf: t.customFormat,
+			cw: t.customWireName,
 		})),
 	});
 	let hash = 0;

--- a/packages/agent/src/append-only-context.ts
+++ b/packages/agent/src/append-only-context.ts
@@ -273,7 +273,7 @@ function takeSnapshot(context: AgentContext): StablePrefixSnapshot {
 
 function computeFingerprint(systemPrompt: string[], tools: Tool[]): string {
 	const payload = JSON.stringify({
-		s: systemPrompt.join("\n"),
+		s: systemPrompt,
 		t: tools.map(t => ({
 			n: t.name,
 			d: t.description,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2,6 +2,8 @@
 export * from "./agent";
 // Loop functions
 export * from "./agent-loop";
+// Append-only context mode
+export * from "./append-only-context";
 // Compaction
 export * from "./compaction";
 export * from "./harmony-leak";

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -15,6 +15,7 @@ import type {
 	ToolResultMessage,
 	TSchema,
 } from "@oh-my-pi/pi-ai";
+import type { AppendOnlyContextManager } from "./append-only-context";
 import type { HarmonyAuditEvent } from "./harmony-leak";
 import type { AgentRunCoverage, AgentRunSummary } from "./run-collector";
 import type { AgentTelemetryConfig } from "./telemetry";
@@ -154,6 +155,15 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	 * then strips from arguments before executing tools.
 	 */
 	intentTracing?: boolean;
+	/**
+	 * Append-only context mode — stabilizes system prompt + tool spec bytes
+	 * across turns so provider prefix caches hit at maximum rate.
+	 *
+	 * When set, the loop reads messages from the append-only log (stable
+	 * byte prefix) and caches system prompt + tools. Tools exclude per-turn
+	 * `_i` intent fields.
+	 */
+	appendOnlyContext?: AppendOnlyContextManager;
 
 	/**
 	 * Inspect assistant streaming events before they are published to the outer agent event stream.

--- a/packages/agent/test/append-only-context.test.ts
+++ b/packages/agent/test/append-only-context.test.ts
@@ -1,0 +1,496 @@
+import { describe, expect, it } from "bun:test";
+import type { Message, Tool } from "@oh-my-pi/pi-ai";
+import { AppendOnlyContextManager, AppendOnlyLog, StablePrefix } from "../src/append-only-context";
+import type { AgentContext, AgentTool } from "../src/types";
+
+/** Minimal test message — cast to any to avoid strict Message type requirements. */
+function msg(role: string, content: string): any {
+	return { role, content, timestamp: Date.now() };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(overrides?: Partial<AgentContext>): AgentContext {
+	return {
+		systemPrompt: ["You are a helpful assistant.", "Be concise."],
+		messages: [],
+		tools: [],
+		...overrides,
+	};
+}
+
+function makeTool(name: string, description?: string, parameters?: Record<string, unknown>): AgentTool {
+	return {
+		name,
+		description: description ?? `Tool ${name}`,
+		parameters: parameters ?? { type: "object", properties: {} },
+		label: name,
+		execute: async () => ({ content: [{ type: "text", text: "done" }] }),
+	} as AgentTool;
+}
+
+// ---------------------------------------------------------------------------
+// StablePrefix
+// ---------------------------------------------------------------------------
+
+describe("StablePrefix", () => {
+	it("builds and returns cached system prompt + tools", () => {
+		const p = new StablePrefix();
+		const ctx = makeContext({
+			systemPrompt: ["You are a helpful assistant."],
+			tools: [makeTool("read")],
+		});
+
+		const changed = p.build(ctx);
+		expect(changed).toBe(true);
+		expect(p.built).toBe(true);
+
+		const { systemPrompt, tools } = p.toContext();
+		expect(systemPrompt).toEqual(["You are a helpful assistant."]);
+		expect(tools).toHaveLength(1);
+		expect(tools[0]!.name).toBe("read");
+	});
+
+	it("returns false on identical rebuild", () => {
+		const p = new StablePrefix();
+		const ctx = makeContext({ systemPrompt: ["Hello"] });
+
+		p.build(ctx);
+		const changed = p.build(ctx);
+		expect(changed).toBe(false);
+	});
+
+	it("returns true when system prompt changes", () => {
+		const p = new StablePrefix();
+		const ctx = makeContext({ systemPrompt: ["Old prompt"] });
+		p.build(ctx);
+
+		const changed = p.build(makeContext({ systemPrompt: ["New prompt"] }));
+		expect(changed).toBe(true);
+	});
+
+	it("returns true when tools change", () => {
+		const p = new StablePrefix();
+		p.build(makeContext({ tools: [makeTool("read")] }));
+
+		const changed = p.build(makeContext({ tools: [makeTool("read"), makeTool("write")] }));
+		expect(changed).toBe(true);
+	});
+
+	it("returns true when tool description changes", () => {
+		const p = new StablePrefix();
+		p.build(makeContext({ tools: [makeTool("read", "Original desc")] }));
+
+		const changed = p.build(makeContext({ tools: [makeTool("read", "Updated desc")] }));
+		expect(changed).toBe(true);
+	});
+
+	it("invalidate forces rebuild", () => {
+		const p = new StablePrefix();
+		const ctx = makeContext({ systemPrompt: ["Stable"] });
+		p.build(ctx);
+
+		p.invalidate();
+		expect(p.built).toBe(false);
+
+		const changed = p.build(ctx);
+		expect(changed).toBe(true);
+	});
+
+	it("toContext() throws when not built", () => {
+		const p = new StablePrefix();
+		expect(() => p.toContext()).toThrow("build()");
+	});
+
+	it("fingerprint changes across rebuilds", () => {
+		const p = new StablePrefix();
+		const ctx1 = makeContext({ systemPrompt: ["Prompt A"] });
+		p.build(ctx1);
+		const fp1 = p.fingerprint;
+
+		const ctx2 = makeContext({ systemPrompt: ["Prompt B"] });
+		p.build(ctx2);
+		const fp2 = p.fingerprint;
+
+		expect(fp1).not.toBe(fp2);
+	});
+
+	it("fingerprint stable for identical context", () => {
+		const p = new StablePrefix();
+		p.build(makeContext({ systemPrompt: ["Stable"], tools: [makeTool("foo")] }));
+		const fp1 = p.fingerprint;
+
+		p.build(makeContext({ systemPrompt: ["Stable"], tools: [makeTool("foo")] }));
+		const fp2 = p.fingerprint;
+
+		expect(fp1).toBe(fp2);
+	});
+
+	it("version increases on each rebuild", () => {
+		const p = new StablePrefix();
+		expect(p.version).toBe(0);
+
+		p.build(makeContext({ systemPrompt: ["V1"] }));
+		expect(p.version).toBe(1);
+
+		p.build(makeContext({ systemPrompt: ["V2"] }));
+		expect(p.version).toBe(2);
+
+		p.build(makeContext({ systemPrompt: ["V2"] }));
+		expect(p.version).toBe(2); // unchanged = no increment
+	});
+});
+
+// ---------------------------------------------------------------------------
+// AppendOnlyLog
+// ---------------------------------------------------------------------------
+
+describe("AppendOnlyLog", () => {
+	it("starts empty", () => {
+		const log = new AppendOnlyLog();
+		expect(log.length).toBe(0);
+		expect(log.toMessages()).toEqual([]);
+	});
+
+	it("appends messages", () => {
+		const log = new AppendOnlyLog();
+		log.append({ role: "user", content: "hello" } as any);
+		log.append({ role: "assistant", content: "world" } as any);
+		expect(log.length).toBe(2);
+		expect(log.toMessages()).toHaveLength(2);
+	});
+
+	it("toMessages returns a copy of the array", () => {
+		const log = new AppendOnlyLog();
+		const msg = { role: "user" as const, content: "test" };
+		log.append(msg);
+		const msgs = log.toMessages();
+		// Array is a copy — mutating it doesn't affect the log
+		msgs.pop();
+		expect(log.length).toBe(1);
+	});
+
+	it("replaceTail replaces last entry", () => {
+		const log = new AppendOnlyLog();
+		log.append({ role: "user" as const, content: "old" });
+		log.replaceTail({ role: "user" as const, content: "new" });
+		expect(log.toMessages()).toHaveLength(1);
+		expect(log.toMessages()[0]!.content).toBe("new");
+	});
+
+	it("replaceTail is no-op on empty log", () => {
+		const log = new AppendOnlyLog();
+		log.replaceTail({ role: "user" as const, content: "nope" });
+		expect(log.length).toBe(0);
+	});
+
+	it("extend appends multiple messages", () => {
+		const log = new AppendOnlyLog();
+		log.extend([
+			{ role: "user" as const, content: "a" },
+			{ role: "assistant" as const, content: "b" },
+		]);
+		expect(log.length).toBe(2);
+	});
+
+	it("clear resets the log", () => {
+		const log = new AppendOnlyLog();
+		log.append({ role: "user" as const, content: "x" });
+		log.clear();
+		expect(log.length).toBe(0);
+	});
+
+	it("entries readonly access returns internal array", () => {
+		const log = new AppendOnlyLog();
+		log.append({ role: "user" as const, content: "test" });
+		expect(log.entries()).toHaveLength(1);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// AppendOnlyContextManager
+// ---------------------------------------------------------------------------
+
+describe("AppendOnlyContextManager", () => {
+	it("build() returns context with stable prefix on first call", () => {
+		const mgr = new AppendOnlyContextManager();
+		const ctx = makeContext({
+			systemPrompt: ["You are a bot."],
+			tools: [makeTool("read")],
+		});
+
+		const result = mgr.build(ctx);
+
+		expect(result.systemPrompt).toEqual(["You are a bot."]);
+		expect(result.tools).toHaveLength(1);
+		expect(result.messages).toEqual([]);
+	});
+
+	it("build() returns same systemPrompt and tools on subsequent calls", () => {
+		const mgr = new AppendOnlyContextManager();
+		const ctx = makeContext({
+			systemPrompt: ["Original prompt"],
+			tools: [makeTool("read")],
+		});
+
+		mgr.build(ctx);
+
+		// Same context — should reuse cached prefix
+		const result = mgr.build(ctx);
+		expect(result.systemPrompt).toEqual(["Original prompt"]);
+		expect(result.tools).toHaveLength(1);
+	});
+
+	it("build() detects changed system prompt and rebuilds", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext({ systemPrompt: ["Old"] }));
+
+		const result = mgr.build(makeContext({ systemPrompt: ["New"] }));
+		expect(result.systemPrompt).toEqual(["New"]);
+	});
+
+	it("prefix.fingerprint changes when tools change", () => {
+		const mgr = new AppendOnlyContextManager();
+
+		mgr.build(makeContext({ tools: [makeTool("read")] }));
+		const fp1 = mgr.prefix.fingerprint;
+
+		mgr.build(makeContext({ tools: [makeTool("read"), makeTool("write")] }));
+		const fp2 = mgr.prefix.fingerprint;
+
+		expect(fp1).not.toBe(fp2);
+	});
+
+	it("appendMessage grows the log", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext());
+
+		mgr.appendMessage({ role: "user", content: "hello" } as any);
+		mgr.appendMessage({ role: "assistant", content: "world" } as any);
+
+		const result = mgr.build(makeContext());
+		expect(result.messages).toHaveLength(2);
+		expect(result.messages[0]!.role).toBe("user");
+		expect(result.messages[1]!.role).toBe("assistant");
+	});
+
+	it("appendMessage messages appear in every subsequent build()", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext());
+
+		mgr.appendMessage({ role: "user" as const, content: "q1" });
+		const r1 = mgr.build(makeContext());
+		expect(r1.messages).toHaveLength(1);
+
+		mgr.appendMessage({ role: "assistant" as const, content: "a1" });
+		const r2 = mgr.build(makeContext());
+		expect(r2.messages).toHaveLength(2);
+		expect(r2.messages[1]!.content).toBe("a1");
+	});
+
+	it("invalidate forces prefix rebuild", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext({ systemPrompt: ["V1"] }));
+
+		mgr.invalidate();
+		const result = mgr.build(makeContext({ systemPrompt: ["V2"] }));
+		expect(result.systemPrompt).toEqual(["V2"]);
+	});
+
+	it("reset clears log and prefix", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext({ systemPrompt: ["Original"] }));
+		mgr.appendMessage({ role: "user" as const, content: "hello" });
+
+		const freshCtx = makeContext({ systemPrompt: ["Fresh start"] });
+		mgr.reset(freshCtx);
+
+		const result = mgr.build(freshCtx);
+		expect(result.systemPrompt).toEqual(["Fresh start"]);
+		expect(result.messages).toHaveLength(0);
+	});
+
+	it("replaceTailMessage updates last log entry", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext());
+		mgr.appendMessage({ role: "user" as const, content: "old" });
+		mgr.replaceTailMessage({ role: "user" as const, content: "new" });
+
+		const result = mgr.build(makeContext());
+		expect(result.messages).toHaveLength(1);
+		expect(result.messages[0]!.content).toBe("new");
+	});
+
+	it("build propagates tool spec description default", () => {
+		const mgr = new AppendOnlyContextManager();
+		const toolWithNoDesc = makeTool("bare");
+		delete (toolWithNoDesc as any).description;
+
+		const ctx = makeContext({ tools: [toolWithNoDesc] });
+		const result = mgr.build(ctx);
+
+		const tool: Tool | undefined = result.tools?.[0];
+		expect(tool).toBeDefined();
+		expect(tool!.description).toBe("");
+	});
+
+	it("tools returned from build are frozen in the cache", () => {
+		const mgr = new AppendOnlyContextManager();
+		const ctx = makeContext({ tools: [makeTool("read")] });
+
+		const r1 = mgr.build(ctx);
+		const r2 = mgr.build(ctx);
+
+		expect(r1.tools).toHaveLength(1);
+		expect(r2.tools).toHaveLength(1);
+		// Same name, same structure
+		expect(r1.tools![0]!.name).toBe(r2.tools![0]!.name);
+	});
+
+	it("tolerates context with no tools", () => {
+		const mgr = new AppendOnlyContextManager();
+		const ctx = makeContext({ tools: undefined as any });
+
+		const result = mgr.build(ctx);
+		expect(result.tools).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Fingerprint determinism
+// ---------------------------------------------------------------------------
+
+describe("fingerprint determinism", () => {
+	it("identical context produces identical fingerprint", () => {
+		const p1 = new StablePrefix();
+		const p2 = new StablePrefix();
+
+		const ctx = makeContext({
+			systemPrompt: ["Rule 1", "Rule 2"],
+			tools: [makeTool("read", "Read files"), makeTool("edit", "Edit files")],
+		});
+
+		p1.build(ctx);
+		p2.build(ctx);
+
+		expect(p1.fingerprint).toBe(p2.fingerprint);
+	});
+
+	it("tool order changes fingerprint", () => {
+		const p1 = new StablePrefix();
+		const p2 = new StablePrefix();
+
+		const tools = [makeTool("a", "Tool A"), makeTool("b", "Tool B")];
+		p1.build(makeContext({ tools }));
+
+		// Create a context where tool b has "Tool B" too
+		// so the fingerprint changes with name order
+		const otherTools = [makeTool("b", "Tool B"), makeTool("a", "Tool A")];
+		p2.build(makeContext({ tools: otherTools }));
+
+		expect(p1.fingerprint).not.toBe(p2.fingerprint);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// AppendOnlyLog message sync
+// ---------------------------------------------------------------------------
+
+describe("message sync", () => {
+	it("syncMessages on first call appends all messages", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext());
+
+		const msgs: Message[] = [
+			{ role: "user", content: "Hello" },
+			{ role: "assistant", content: "Hi" },
+		] as any;
+		mgr.syncMessages(msgs);
+
+		const result = mgr.build(makeContext());
+		expect(result.messages).toHaveLength(2);
+		expect(result.messages[0]!.content).toBe("Hello");
+		expect(result.messages[1]!.content).toBe("Hi");
+	});
+
+	it("syncMessages on subsequent calls only appends delta", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext());
+
+		mgr.syncMessages([{ role: "user" as const, content: "q1" }]);
+		const r1 = mgr.build(makeContext());
+		expect(r1.messages).toHaveLength(1);
+
+		mgr.syncMessages([
+			{ role: "user" as const, content: "q1" },
+			{ role: "assistant" as const, content: "a1" },
+		]);
+		const r2 = mgr.build(makeContext());
+		expect(r2.messages).toHaveLength(2);
+		expect(r2.messages[1]!.content).toBe("a1");
+	});
+
+	it("syncMessages with unchanged messages is a no-op (same length, no new entries)", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext());
+		mgr.syncMessages([{ role: "user" as const, content: "q1" }]);
+
+		const before = mgr.log.length;
+
+		// Same array length → nothing new to append
+		mgr.syncMessages([{ role: "user" as const, content: "q1" }]);
+		expect(mgr.log.length).toBe(before);
+	});
+
+	it("syncMessages resets log when array shrinks (compaction)", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext());
+
+		mgr.syncMessages([
+			{ role: "user" as const, content: "q1" },
+			{ role: "assistant" as const, content: "a1" },
+			{ role: "user" as const, content: "q2" },
+		]);
+		expect(mgr.log.length).toBe(3);
+
+		// Simulate compaction — array shrinks
+		mgr.syncMessages([{ role: "user" as const, content: "q2" }]);
+		expect(mgr.log.length).toBe(1);
+		expect(mgr.log.toMessages()[0]!.content).toBe("q2");
+	});
+
+	it("build + syncMessages integration: messages come from log, not from context.messages", () => {
+		const mgr = new AppendOnlyContextManager();
+
+		// First turn: build with empty context, sync first message
+		mgr.build(makeContext());
+		mgr.syncMessages([{ role: "user" as const, content: "turn1" }]);
+		const r1 = mgr.build(makeContext());
+		expect(r1.messages).toHaveLength(1);
+		expect(r1.messages[0]!.content).toBe("turn1");
+
+		// Second turn: sync second message
+		mgr.syncMessages([
+			{ role: "user" as const, content: "turn1" },
+			{ role: "assistant" as const, content: "resp1" },
+		]);
+		const r2 = mgr.build(makeContext());
+		expect(r2.messages).toHaveLength(2);
+		expect(r2.messages[1]!.content).toBe("resp1");
+	});
+
+	it("resetSyncCursor forces full re-sync on next call", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext());
+		mgr.syncMessages([{ role: "user" as const, content: "old" }]);
+
+		mgr.resetSyncCursor();
+		mgr.syncMessages([{ role: "user" as const, content: "fresh" }]);
+
+		const result = mgr.build(makeContext());
+		expect(result.messages).toHaveLength(1);
+		expect(result.messages[0]!.content).toBe("fresh");
+	});
+});

--- a/packages/agent/test/append-only-context.test.ts
+++ b/packages/agent/test/append-only-context.test.ts
@@ -488,4 +488,79 @@ describe("message sync", () => {
 		expect(result.messages).toHaveLength(1);
 		expect(result.messages[0]!.content).toBe("fresh");
 	});
+
+	it("detects in-place rewrite of already-synced messages", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext());
+
+		// Sync two messages
+		mgr.syncMessages([
+			{ role: "user", content: "q1" },
+			{ role: "assistant", content: "original long result" },
+		]);
+		expect(mgr.log.length).toBe(2);
+
+		// Same length, but second message content changed (simulates tool-output pruning)
+		mgr.syncMessages([
+			{ role: "user", content: "q1" },
+			{ role: "assistant", content: "[pruned]" },
+		]);
+		// Log should have been reset and re-synced with the new content
+		expect(mgr.log.length).toBe(2);
+		const msgs = mgr.build(makeContext()).messages;
+		expect(msgs[1]!.content).toBe("[pruned]");
+	});
+
+	it("detects in-place rewrite via digest mismatch", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext());
+
+		mgr.syncMessages([{ role: "user", content: "hello" }]);
+		expect(mgr.log.length).toBe(1);
+
+		// Content changed but length same
+		mgr.syncMessages([{ role: "user", content: "world" }]);
+
+		const msgs = mgr.build(makeContext()).messages;
+		expect(msgs).toHaveLength(1);
+		expect(msgs[0]!.content).toBe("world");
+	});
+
+	it("no-op when content unchanged", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext());
+
+		mgr.syncMessages([
+			{ role: "user", content: "q1" },
+			{ role: "assistant", content: "a1" },
+		]);
+
+		const before = mgr.log.length;
+		mgr.syncMessages([
+			{ role: "user", content: "q1" },
+			{ role: "assistant", content: "a1" },
+		]);
+		// Length unchanged — no new messages appended, no clear
+		expect(mgr.log.length).toBe(before);
+	});
+
+	it("invalidateForModelChange resets prefix and log", () => {
+		const mgr = new AppendOnlyContextManager();
+		mgr.build(makeContext({ systemPrompt: ["Before"] }));
+		mgr.syncMessages([{ role: "user", content: "hello" }]);
+
+		mgr.invalidateForModelChange();
+
+		// Should need a fresh build — prefix was invalidated
+		const ctx = makeContext({ systemPrompt: ["After"] });
+		const result = mgr.build(ctx);
+		expect(result.systemPrompt).toEqual(["After"]);
+		expect(result.messages).toHaveLength(0);
+
+		// Re-sync should work cleanly
+		mgr.syncMessages([{ role: "user", content: "new turn" }]);
+		const r2 = mgr.build(ctx);
+		expect(r2.messages).toHaveLength(1);
+		expect(r2.messages[0]!.content).toBe("new turn");
+	});
 });

--- a/packages/agent/test/append-only-context.test.ts
+++ b/packages/agent/test/append-only-context.test.ts
@@ -3,11 +3,6 @@ import type { Message, Tool } from "@oh-my-pi/pi-ai";
 import { AppendOnlyContextManager, AppendOnlyLog, StablePrefix } from "../src/append-only-context";
 import type { AgentContext, AgentTool } from "../src/types";
 
-/** Minimal test message — cast to any to avoid strict Message type requirements. */
-function msg(role: string, content: string): any {
-	return { role, content, timestamp: Date.now() };
-}
-
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -164,7 +159,7 @@ describe("AppendOnlyLog", () => {
 
 	it("toMessages returns a copy of the array", () => {
 		const log = new AppendOnlyLog();
-		const msg = { role: "user" as const, content: "test" };
+		const msg = { role: "user", content: "test" };
 		log.append(msg);
 		const msgs = log.toMessages();
 		// Array is a copy — mutating it doesn't affect the log
@@ -174,37 +169,37 @@ describe("AppendOnlyLog", () => {
 
 	it("replaceTail replaces last entry", () => {
 		const log = new AppendOnlyLog();
-		log.append({ role: "user" as const, content: "old" });
-		log.replaceTail({ role: "user" as const, content: "new" });
+		log.append({ role: "user", content: "old" });
+		log.replaceTail({ role: "user", content: "new" });
 		expect(log.toMessages()).toHaveLength(1);
 		expect(log.toMessages()[0]!.content).toBe("new");
 	});
 
 	it("replaceTail is no-op on empty log", () => {
 		const log = new AppendOnlyLog();
-		log.replaceTail({ role: "user" as const, content: "nope" });
+		log.replaceTail({ role: "user", content: "nope" });
 		expect(log.length).toBe(0);
 	});
 
 	it("extend appends multiple messages", () => {
 		const log = new AppendOnlyLog();
 		log.extend([
-			{ role: "user" as const, content: "a" },
-			{ role: "assistant" as const, content: "b" },
+			{ role: "user", content: "a" },
+			{ role: "assistant", content: "b" },
 		]);
 		expect(log.length).toBe(2);
 	});
 
 	it("clear resets the log", () => {
 		const log = new AppendOnlyLog();
-		log.append({ role: "user" as const, content: "x" });
+		log.append({ role: "user", content: "x" });
 		log.clear();
 		expect(log.length).toBe(0);
 	});
 
 	it("entries readonly access returns internal array", () => {
 		const log = new AppendOnlyLog();
-		log.append({ role: "user" as const, content: "test" });
+		log.append({ role: "user", content: "test" });
 		expect(log.entries()).toHaveLength(1);
 	});
 });
@@ -280,11 +275,11 @@ describe("AppendOnlyContextManager", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext());
 
-		mgr.appendMessage({ role: "user" as const, content: "q1" });
+		mgr.appendMessage({ role: "user", content: "q1" });
 		const r1 = mgr.build(makeContext());
 		expect(r1.messages).toHaveLength(1);
 
-		mgr.appendMessage({ role: "assistant" as const, content: "a1" });
+		mgr.appendMessage({ role: "assistant", content: "a1" });
 		const r2 = mgr.build(makeContext());
 		expect(r2.messages).toHaveLength(2);
 		expect(r2.messages[1]!.content).toBe("a1");
@@ -302,7 +297,7 @@ describe("AppendOnlyContextManager", () => {
 	it("reset clears log and prefix", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext({ systemPrompt: ["Original"] }));
-		mgr.appendMessage({ role: "user" as const, content: "hello" });
+		mgr.appendMessage({ role: "user", content: "hello" });
 
 		const freshCtx = makeContext({ systemPrompt: ["Fresh start"] });
 		mgr.reset(freshCtx);
@@ -315,8 +310,8 @@ describe("AppendOnlyContextManager", () => {
 	it("replaceTailMessage updates last log entry", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext());
-		mgr.appendMessage({ role: "user" as const, content: "old" });
-		mgr.replaceTailMessage({ role: "user" as const, content: "new" });
+		mgr.appendMessage({ role: "user", content: "old" });
+		mgr.replaceTailMessage({ role: "user", content: "new" });
 
 		const result = mgr.build(makeContext());
 		expect(result.messages).toHaveLength(1);
@@ -419,13 +414,13 @@ describe("message sync", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext());
 
-		mgr.syncMessages([{ role: "user" as const, content: "q1" }]);
+		mgr.syncMessages([{ role: "user", content: "q1" }]);
 		const r1 = mgr.build(makeContext());
 		expect(r1.messages).toHaveLength(1);
 
 		mgr.syncMessages([
-			{ role: "user" as const, content: "q1" },
-			{ role: "assistant" as const, content: "a1" },
+			{ role: "user", content: "q1" },
+			{ role: "assistant", content: "a1" },
 		]);
 		const r2 = mgr.build(makeContext());
 		expect(r2.messages).toHaveLength(2);
@@ -435,12 +430,12 @@ describe("message sync", () => {
 	it("syncMessages with unchanged messages is a no-op (same length, no new entries)", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext());
-		mgr.syncMessages([{ role: "user" as const, content: "q1" }]);
+		mgr.syncMessages([{ role: "user", content: "q1" }]);
 
 		const before = mgr.log.length;
 
 		// Same array length → nothing new to append
-		mgr.syncMessages([{ role: "user" as const, content: "q1" }]);
+		mgr.syncMessages([{ role: "user", content: "q1" }]);
 		expect(mgr.log.length).toBe(before);
 	});
 
@@ -449,14 +444,14 @@ describe("message sync", () => {
 		mgr.build(makeContext());
 
 		mgr.syncMessages([
-			{ role: "user" as const, content: "q1" },
-			{ role: "assistant" as const, content: "a1" },
-			{ role: "user" as const, content: "q2" },
+			{ role: "user", content: "q1" },
+			{ role: "assistant", content: "a1" },
+			{ role: "user", content: "q2" },
 		]);
 		expect(mgr.log.length).toBe(3);
 
 		// Simulate compaction — array shrinks
-		mgr.syncMessages([{ role: "user" as const, content: "q2" }]);
+		mgr.syncMessages([{ role: "user", content: "q2" }]);
 		expect(mgr.log.length).toBe(1);
 		expect(mgr.log.toMessages()[0]!.content).toBe("q2");
 	});
@@ -466,15 +461,15 @@ describe("message sync", () => {
 
 		// First turn: build with empty context, sync first message
 		mgr.build(makeContext());
-		mgr.syncMessages([{ role: "user" as const, content: "turn1" }]);
+		mgr.syncMessages([{ role: "user", content: "turn1" }]);
 		const r1 = mgr.build(makeContext());
 		expect(r1.messages).toHaveLength(1);
 		expect(r1.messages[0]!.content).toBe("turn1");
 
 		// Second turn: sync second message
 		mgr.syncMessages([
-			{ role: "user" as const, content: "turn1" },
-			{ role: "assistant" as const, content: "resp1" },
+			{ role: "user", content: "turn1" },
+			{ role: "assistant", content: "resp1" },
 		]);
 		const r2 = mgr.build(makeContext());
 		expect(r2.messages).toHaveLength(2);
@@ -484,10 +479,10 @@ describe("message sync", () => {
 	it("resetSyncCursor forces full re-sync on next call", () => {
 		const mgr = new AppendOnlyContextManager();
 		mgr.build(makeContext());
-		mgr.syncMessages([{ role: "user" as const, content: "old" }]);
+		mgr.syncMessages([{ role: "user", content: "old" }]);
 
 		mgr.resetSyncCursor();
-		mgr.syncMessages([{ role: "user" as const, content: "fresh" }]);
+		mgr.syncMessages([{ role: "user", content: "fresh" }]);
 
 		const result = mgr.build(makeContext());
 		expect(result.messages).toHaveLength(1);

--- a/packages/agent/test/append-only-context.test.ts
+++ b/packages/agent/test/append-only-context.test.ts
@@ -387,6 +387,18 @@ describe("fingerprint determinism", () => {
 
 		expect(p1.fingerprint).not.toBe(p2.fingerprint);
 	});
+
+	it("system prompt array structure changes fingerprint", () => {
+		const p1 = new StablePrefix();
+		const p2 = new StablePrefix();
+
+		// ["A", "B"] and ["A\nB"] have the same joined text but different
+		// array structure — must produce different fingerprints.
+		p1.build(makeContext({ systemPrompt: ["A", "B"] }));
+		p2.build(makeContext({ systemPrompt: ["A\nB"] }));
+
+		expect(p1.fingerprint).not.toBe(p2.fingerprint);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed clipboard image paste (Ctrl+V) silently failing on WSL2 by routing image reads through a `powershell.exe` bridge when WSL interop is detected, since `arboard` returns `ContentNotAvailable` under WSLg ([#1280](https://github.com/can1357/oh-my-pi/issues/1280))
+- Fixed append-only context mode not being recomputed after model switches — the mode was frozen at session construction time using the initial model's provider, so `provider.appendOnlyContext=auto` left append-only enabled after switching away from DeepSeek (or disabled after switching to DeepSeek) for the rest of the session
 
 ## [15.2.4] - 2026-05-22
 ### Breaking Changes

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2612,6 +2612,22 @@ export const SETTINGS_SCHEMA = {
 			description: "Use Parallel extract API for URL fetching when credentials are available",
 		},
 	},
+	"provider.appendOnlyContext": {
+		type: "enum",
+		values: ["auto", "on", "off"] as const,
+		default: "auto",
+		ui: {
+			tab: "providers",
+			label: "Append-Only Context",
+			description:
+				"Cache system prompt + tool specs and keep an append-only message log so provider prefix caches (DeepSeek, Anthropic) hit at maximum rate. Auto enables for DeepSeek.",
+			options: [
+				{ value: "auto", label: "Auto", description: "Enable for DeepSeek (recommended)" },
+				{ value: "on", label: "On", description: "Always enable append-only context" },
+				{ value: "off", label: "Off", description: "Disable append-only context" },
+			],
+		},
+	},
 
 	// Exa
 	"exa.enabled": {

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -856,7 +856,22 @@ const SETTING_HOOKS: Partial<Record<SettingPath, SettingHook<any>>> = {
 			setDefaultTabWidth(value);
 		}
 	},
+	"provider.appendOnlyContext": value => {
+		if (typeof value === "string") {
+			appendOnlyModeChangeCallback?.(value);
+		}
+	},
 };
+/** Callback invoked when `provider.appendOnlyContext` changes at runtime. */
+let appendOnlyModeChangeCallback: ((value: string) => void) | null = null;
+
+/**
+ * Register a callback for append-only mode setting changes.
+ * The session calls this on startup to sync runtime state with config.
+ */
+export function onAppendOnlyModeChanged(cb: (value: string) => void): void {
+	appendOnlyModeChangeCallback = cb;
+}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Global Singleton

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -858,19 +858,23 @@ const SETTING_HOOKS: Partial<Record<SettingPath, SettingHook<any>>> = {
 	},
 	"provider.appendOnlyContext": value => {
 		if (typeof value === "string") {
-			appendOnlyModeChangeCallback?.(value);
+			for (const cb of appendOnlyModeCallbacks) cb(value);
 		}
 	},
 };
-/** Callback invoked when `provider.appendOnlyContext` changes at runtime. */
-let appendOnlyModeChangeCallback: ((value: string) => void) | null = null;
+/** Callbacks invoked when `provider.appendOnlyContext` changes at runtime. */
+const appendOnlyModeCallbacks = new Set<(value: string) => void>();
 
 /**
- * Register a callback for append-only mode setting changes.
- * The session calls this on startup to sync runtime state with config.
+ * Subscribe to append-only mode setting changes.
+ * Returns an unsubscribe function. Multiple sessions (main + subagents)
+ * can register independently without overwriting each other.
  */
-export function onAppendOnlyModeChanged(cb: (value: string) => void): void {
-	appendOnlyModeChangeCallback = cb;
+export function onAppendOnlyModeChanged(cb: (value: string) => void): () => void {
+	appendOnlyModeCallbacks.add(cb);
+	return () => {
+		appendOnlyModeCallbacks.delete(cb);
+	};
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -395,6 +395,15 @@ export class CommandController {
 		info += `${theme.fg("dim", "Tool Calls:")} ${stats.toolCalls}\n`;
 		info += `${theme.fg("dim", "Tool Results:")} ${stats.toolResults}\n`;
 		info += `${theme.fg("dim", "Total:")} ${stats.totalMessages}\n\n`;
+		// Append-only context
+		{
+			const setting = this.ctx.settings.get("provider.appendOnlyContext") ?? "auto";
+			const provider = this.ctx.session.model?.provider;
+			const mode = setting === "on" ? true : setting === "off" ? false : provider === "deepseek";
+			const activeLabel = mode ? theme.fg("success", "active") : theme.fg("dim", "inactive");
+			const settingLabel = setting === "auto" ? `${setting} (${provider ?? "?"})` : setting;
+			info += `${theme.fg("dim", "Append-Only:")} ${activeLabel} (setting: ${settingLabel})\n`;
+		}
 		info += `${theme.bold("Tokens")}\n`;
 		info += `${theme.fg("dim", "Input:")} ${stats.tokens.input.toLocaleString()}\n`;
 		info += `${theme.fg("dim", "Output:")} ${stats.tokens.output.toLocaleString()}\n`;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -4,6 +4,7 @@ import {
 	type AgentMessage,
 	type AgentTelemetryConfig,
 	type AgentTool,
+	AppendOnlyContextManager,
 	INTENT_FIELD,
 	type ThinkingLevel,
 } from "@oh-my-pi/pi-agent-core";
@@ -587,6 +588,24 @@ function registerPythonCleanup(): void {
 	if (pythonCleanupRegistered) return;
 	pythonCleanupRegistered = true;
 	postmortem.register("python-cleanup", disposeAllKernelSessions);
+}
+
+/**
+ * Resolve whether to enable append-only context mode based on the setting and provider.
+ *
+ * - `"on"` → always enable
+ * - `"off"` → never enable
+ * - `"auto"` → enable for DeepSeek (prefix-caching provider)
+ */
+function resolveAppendOnlyMode(setting: "auto" | "on" | "off" | undefined, provider: string): boolean {
+	switch (setting ?? "auto") {
+		case "on":
+			return true;
+		case "off":
+			return false;
+		default:
+			return provider === "deepseek";
+	}
 }
 
 function customToolToDefinition(tool: CustomTool): ToolDefinition {
@@ -1897,6 +1916,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			intentTracing: !!intentField,
 			getToolChoice: () => session?.nextToolChoice(),
 			telemetry: options.telemetry,
+			appendOnlyContext: model
+				? resolveAppendOnlyMode(settings.get("provider.appendOnlyContext"), model.provider)
+					? new AppendOnlyContextManager()
+					: undefined
+				: undefined,
 		});
 
 		cursorEventEmitter = event => agent.emitExternalEvent(event);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5954,6 +5954,10 @@ export class AgentSession {
 		const enable = appendOnlySetting === "on" || (appendOnlySetting === "auto" && model.provider === "deepseek");
 		if (enable && !this.agent.appendOnlyContext) {
 			this.agent.setAppendOnlyContext(new AppendOnlyContextManager());
+		} else if (enable && this.agent.appendOnlyContext) {
+			// Model changed but mode stays enabled — reset cached prefix + log
+			// so the next turn rebuilds for the new model's normalization.
+			this.agent.appendOnlyContext.invalidateForModelChange();
 		} else if (!enable && this.agent.appendOnlyContext) {
 			this.agent.setAppendOnlyContext(undefined);
 		}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -99,6 +99,7 @@ import {
 } from "../config/model-resolver";
 import { expandPromptTemplate, type PromptTemplate } from "../config/prompt-templates";
 import type { Settings, SkillsSettings } from "../config/settings";
+import { onAppendOnlyModeChanged } from "../config/settings";
 import { RawSseDebugBuffer } from "../debug/raw-sse-buffer";
 import { loadCapability } from "../discovery";
 import { expandApplyPatchToEntries, normalizeDiff, normalizeToLF, ParseError, previewPatch, stripBom } from "../edit";
@@ -1139,6 +1140,8 @@ export class AgentSession {
 		// Always subscribe to agent events for internal handling
 		// (session persistence, hooks, auto-compaction, retry logic)
 		this.#unsubscribeAgent = this.agent.subscribe(this.#handleAgentEvent);
+		// Re-evaluate append-only context mode when the setting changes at runtime.
+		onAppendOnlyModeChanged(_value => this.#syncAppendOnlyContext(this.model));
 	}
 
 	/** Model registry for API key resolution and model discovery */
@@ -5949,24 +5952,32 @@ export class AgentSession {
 		}
 		this.agent.setModel(model);
 
-		// Re-evaluate append-only context mode — provider may have changed
-		const appendOnlySetting = this.settings.get("provider.appendOnlyContext") ?? "auto";
-		const enable = appendOnlySetting === "on" || (appendOnlySetting === "auto" && model.provider === "deepseek");
-		if (enable && !this.agent.appendOnlyContext) {
-			this.agent.setAppendOnlyContext(new AppendOnlyContextManager());
-		} else if (enable && this.agent.appendOnlyContext) {
-			// Model changed but mode stays enabled — reset cached prefix + log
-			// so the next turn rebuilds for the new model's normalization.
-			this.agent.appendOnlyContext.invalidateForModelChange();
-		} else if (!enable && this.agent.appendOnlyContext) {
-			this.agent.setAppendOnlyContext(undefined);
-		}
+		// Re-evaluate append-only context mode — provider or setting may have changed
+		this.#syncAppendOnlyContext(model);
 	}
 
 	#closeCodexProviderSessionsForHistoryRewrite(): void {
 		const currentModel = this.model;
 		if (!currentModel || currentModel.api !== "openai-codex-responses") return;
 		this.#closeProviderSessionsForModelSwitch(currentModel, currentModel);
+	}
+
+	/**
+	 * Re-evaluate append-only context mode, creating or destroying the
+	 * manager as needed. Called on model switch AND setting change.
+	 */
+	#syncAppendOnlyContext(model: Model | null | undefined): void {
+		const setting = this.settings.get("provider.appendOnlyContext") ?? "auto";
+		const enable = setting === "on" || (setting === "auto" && model?.provider === "deepseek");
+		if (enable && !this.agent.appendOnlyContext) {
+			this.agent.setAppendOnlyContext(new AppendOnlyContextManager());
+		} else if (enable && this.agent.appendOnlyContext) {
+			// Already active — invalidate prefix + log so the next turn
+			// rebuilds for the current model's normalization.
+			this.agent.appendOnlyContext.invalidateForModelChange();
+		} else if (!enable && this.agent.appendOnlyContext) {
+			this.agent.setAppendOnlyContext(undefined);
+		}
 	}
 
 	#closeProviderSessionsForModelSwitch(currentModel: Model, nextModel: Model): void {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -26,6 +26,7 @@ import {
 	type AgentMessage,
 	type AgentState,
 	type AgentTool,
+	AppendOnlyContextManager,
 	resolveTelemetry,
 	ThinkingLevel,
 } from "@oh-my-pi/pi-agent-core";
@@ -5947,6 +5948,15 @@ export class AgentSession {
 			this.#closeProviderSessionsForModelSwitch(currentModel, model);
 		}
 		this.agent.setModel(model);
+
+		// Re-evaluate append-only context mode — provider may have changed
+		const appendOnlySetting = this.settings.get("provider.appendOnlyContext") ?? "auto";
+		const enable = appendOnlySetting === "on" || (appendOnlySetting === "auto" && model.provider === "deepseek");
+		if (enable && !this.agent.appendOnlyContext) {
+			this.agent.setAppendOnlyContext(new AppendOnlyContextManager());
+		} else if (!enable && this.agent.appendOnlyContext) {
+			this.agent.setAppendOnlyContext(undefined);
+		}
 	}
 
 	#closeCodexProviderSessionsForHistoryRewrite(): void {


### PR DESCRIPTION
 What

Add an append-only context mode that stabilizes the byte prefix sent to the LLM across turns, maximizing provider prefix-cache hit rates (DeepSeek, Anthropic, etc.).

 - StablePrefix — system prompt + tool specs are computed once and frozen. Subsequent turns reuse the exact same byte sequence unless explicitly invalidated (MCP reconnect, tool set change).
 - AppendOnlyLog + syncMessages — provider-level messages are converted once via convertToLlm and appended to a log. Subsequent turns only convert the delta; prior-turn bytes stay stable.

 Integrated into streamAssistantResponse in agent-loop.ts. When config.appendOnlyContext is set, the immutable prefix and log messages are used instead of rebuilding from context.systemPrompt +
 normalizeTools() each turn.

 Toggleable via provider.appendOnlyContext setting (auto / on / off). Default auto enables for DeepSeek. /session info surfaces the current active state.

 Why

 DeepSeek bills cached input at ~10% of miss rate, but automatic prefix caching only activates when the exact byte prefix matches the previous request. Without stability, every turn re-serializes
 tool schemas (with changing _i intents), re-reads system prompt from live state, and re-converts messages — byte drift → cache miss → full price + 2-3x latency.

 The append-only log ensures only the user's new message delta is a cache miss each turn. Stabilizing system prompt + tools protects ~26K tokens of prefix from incidental byte drift.

 Testing

Locally, against deepseek api

---

- [ x ] `bun check` passes
- [ x ] Tested locally
- [ Nope ] CHANGELOG updated (if user-facing)
