### PR TITLE
fix(robomp): remove partial clone filter to fix worktree creation

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -319,9 +319,15 @@ async function generateModels() {
 		)
 	).flat();
 	const gitLabDuoModels = getGitLabDuoModels();
-	// Combine models (models.dev has priority)
+	// Combine models (models.dev generally has priority; UPB is an exception because
+	// ai-chat exposes its catalog dynamically and models.dev does not know UPB's dot-prefixed IDs).
 	let allModels = applyGlobalModelsDevFallback(
-		[...modelsDevModels, ...catalogProviderModels, ...gitLabDuoModels],
+		[
+			...catalogProviderModels.filter(model => model.provider === "upb"),
+			...modelsDevModels,
+			...catalogProviderModels.filter(model => model.provider !== "upb"),
+			...gitLabDuoModels,
+		],
 		modelsDevModels,
 	);
 
@@ -369,6 +375,14 @@ async function generateModels() {
 	applyGeneratedModelPolicies(allModels);
 	linkOpenAIPromotionTargets(allModels);
 
+	// UPB AI Gateway and AI-Chat portal (both LiteLLM proxies) require reasoning.summary to surface reasoning tokens.
+	// Apply thinkingFormat compat to all UPB models since the proxy handles the parameter.
+	for (const model of allModels) {
+		if ((model.provider === "upb" || model.provider === "upb-gateway") && model.api === "openai-completions") {
+			model.compat = { ...model.compat, thinkingFormat: "litellm" };
+		}
+	}
+
 	// Group by provider and sort each provider's models
 	const providers: Record<string, Record<string, Model>> = {};
 	for (const model of allModels) {
@@ -398,7 +412,7 @@ async function generateModels() {
 	}
 
 	// Generate JSON file
-	await Bun.write(path.join(packageRoot, "src/models.json"), JSON.stringify(MODELS, null, "	"));
+	await Bun.write(path.join(packageRoot, "src/models.json"), JSON.stringify(MODELS, null, "\t"));
 	console.log("Generated src/models.json");
 
 	// Print statistics

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1492,6 +1492,12 @@ export class AuthStorage {
 				await saveApiKeyCredential(apiKey);
 				return;
 			}
+			case "skvaider": {
+				const { loginSkvaider } = await import("./utils/oauth/skvaider");
+				const apiKey = await loginSkvaider(ctrl);
+				await saveApiKeyCredential(apiKey);
+				return;
+			}
 			case "parallel": {
 				const { loginParallel } = await import("./utils/oauth/parallel");
 				const apiKey = await loginParallel(ctrl);

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1438,6 +1438,18 @@ export class AuthStorage {
 				await saveApiKeyCredential(apiKey);
 				return;
 			}
+			case "upb": {
+				const { loginUPB } = await import("./utils/oauth/upb");
+				const apiKey = await loginUPB(ctrl);
+				await saveApiKeyCredential(apiKey);
+				return;
+			}
+			case "upb-gateway": {
+				const { loginUPBGateway } = await import("./utils/oauth/upb-gateway");
+				const apiKey = await loginUPBGateway(ctrl);
+				await saveApiKeyCredential(apiKey);
+				return;
+			}
 			case "moonshot": {
 				const { loginMoonshot } = await import("./utils/oauth/moonshot");
 				const apiKey = await loginMoonshot(ctrl);

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -1025,7 +1025,7 @@
 		},
 		"global.anthropic.claude-opus-4-5-20251101-v1:0": {
 			"id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
-			"name": "Claude Opus 4.5 (Global)",
+			"name": "Claude Opus 4.5",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1150,7 +1150,7 @@
 		},
 		"global.anthropic.claude-sonnet-4-6": {
 			"id": "global.anthropic.claude-sonnet-4-6",
-			"name": "Claude Sonnet 4.6",
+			"name": "Claude Sonnet 4.6 (Global)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -2103,7 +2103,7 @@
 		},
 		"us.anthropic.claude-opus-4-1-20250805-v1:0": {
 			"id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
-			"name": "Claude Opus 4.1",
+			"name": "Claude Opus 4.1 (US)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -7177,7 +7177,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 250000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "budget",
@@ -7252,7 +7252,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 250000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "budget",
@@ -7303,7 +7303,32 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 65536,
+			"maxTokens": 65535,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"gemini-2.5-flash-lite": {
+			"id": "gemini-2.5-flash-lite",
+			"name": "Gemini 2.5 Flash Lite",
+			"api": "google-gemini-cli",
+			"provider": "google-antigravity",
+			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65535,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -7385,6 +7410,31 @@
 				"maxLevel": "high"
 			}
 		},
+		"gemini-3-flash-agent": {
+			"id": "gemini-3-flash-agent",
+			"name": "Gemini 3 Flash (Antigravity)",
+			"api": "google-gemini-cli",
+			"provider": "google-antigravity",
+			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "google-level",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"gemini-3-pro-high": {
 			"id": "gemini-3-pro-high",
 			"name": "Gemini 3 Pro (High) (Antigravity)",
@@ -7442,6 +7492,44 @@
 					"high"
 				]
 			}
+		},
+		"gemini-3.1-flash-image": {
+			"id": "gemini-3.1-flash-image",
+			"name": "Gemini 3.1 Flash Image (Antigravity)",
+			"api": "google-gemini-cli",
+			"provider": "google-antigravity",
+			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000
+		},
+		"gemini-3.1-flash-lite": {
+			"id": "gemini-3.1-flash-lite",
+			"name": "Gemini 3.1 Flash Lite (Antigravity)",
+			"api": "google-gemini-cli",
+			"provider": "google-antigravity",
+			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65535
 		},
 		"gemini-3.1-pro-high": {
 			"id": "gemini-3.1-pro-high",
@@ -7517,13 +7605,51 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 114000,
+			"contextWindow": 131072,
 			"maxTokens": 32768,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
 				"maxLevel": "high"
 			}
+		},
+		"tab_flash_lite_preview": {
+			"id": "tab_flash_lite_preview",
+			"name": "tab_flash_lite_preview",
+			"api": "google-gemini-cli",
+			"provider": "google-antigravity",
+			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 16384,
+			"maxTokens": 4096
+		},
+		"tab_jump_flash_lite_preview": {
+			"id": "tab_jump_flash_lite_preview",
+			"name": "tab_jump_flash_lite_preview",
+			"api": "google-gemini-cli",
+			"provider": "google-antigravity",
+			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 16384,
+			"maxTokens": 4096
 		}
 	},
 	"google-gemini-cli": {
@@ -18252,7 +18378,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1050000,
-			"maxTokens": 130000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
@@ -18515,6 +18641,182 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 40000
+		}
+	},
+	"mimo-code": {
+		"mimo-v2-omni": {
+			"id": "mimo-v2-omni",
+			"name": "MiMo V2 Omni",
+			"api": "openai-completions",
+			"provider": "mimo-code",
+			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"mimo-v2-pro": {
+			"id": "mimo-v2-pro",
+			"name": "MiMo V2 Pro",
+			"api": "openai-completions",
+			"provider": "mimo-code",
+			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"mimo-v2-tts": {
+			"id": "mimo-v2-tts",
+			"name": "mimo-v2-tts",
+			"api": "openai-completions",
+			"provider": "mimo-code",
+			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072
+		},
+		"mimo-v2.5": {
+			"id": "mimo-v2.5",
+			"name": "MiMo-V2.5",
+			"api": "openai-completions",
+			"provider": "mimo-code",
+			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"mimo-v2.5-pro": {
+			"id": "mimo-v2.5-pro",
+			"name": "MiMo-V2.5-Pro",
+			"api": "openai-completions",
+			"provider": "mimo-code",
+			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"mimo-v2.5-tts": {
+			"id": "mimo-v2.5-tts",
+			"name": "mimo-v2.5-tts",
+			"api": "openai-completions",
+			"provider": "mimo-code",
+			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072
+		},
+		"mimo-v2.5-tts-voiceclone": {
+			"id": "mimo-v2.5-tts-voiceclone",
+			"name": "mimo-v2.5-tts-voiceclone",
+			"api": "openai-completions",
+			"provider": "mimo-code",
+			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072
+		},
+		"mimo-v2.5-tts-voicedesign": {
+			"id": "mimo-v2.5-tts-voicedesign",
+			"name": "mimo-v2.5-tts-voicedesign",
+			"api": "openai-completions",
+			"provider": "mimo-code",
+			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072
 		}
 	},
 	"minimax": {
@@ -40532,7 +40834,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 8888
+			"maxTokens": 16384
 		},
 		"mistralai/mistral-saba": {
 			"id": "mistralai/mistral-saba",
@@ -45677,6 +45979,1486 @@
 			},
 			"contextWindow": 202752,
 			"maxTokens": 8192
+		}
+	},
+	"upb": {
+		"bersetzungen": {
+			"id": "bersetzungen",
+			"name": "OpenAI: Übersetzen mit UPB-Glossar (De -> En)",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"fundametal-integrated-circuit-design-companion": {
+			"id": "fundametal-integrated-circuit-design-companion",
+			"name": "Fundametal Integrated Circuit Design Companion",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg-basismodel": {
+			"id": "gwdg-basismodel",
+			"name": "GWDG: Basismodel",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg-bersetzen-mit-upb-glossar-de---en": {
+			"id": "gwdg-bersetzen-mit-upb-glossar-de---en",
+			"name": "GWDG: Übersetzen mit UPB-Glossar (De -> En)",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg-didacticus--lehrplaner": {
+			"id": "gwdg-didacticus--lehrplaner",
+			"name": "GWDG: TeachTailor | Lehrplaner",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg-lernquiz": {
+			"id": "gwdg-lernquiz",
+			"name": "GWDG: Lernquiz",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg-qwen-3-32b-non-reasoning": {
+			"id": "gwdg-qwen-3-32b-non-reasoning",
+			"name": "GWDG: Qwen 3 32B (Non-Reasoning)",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-gateway.uni-paderborn.de/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg-tandem-sprachenlernen": {
+			"id": "gwdg-tandem-sprachenlernen",
+			"name": "GWDG: Sprachtandem",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.apertus-70b-instruct-2509": {
+			"id": "gwdg.apertus-70b-instruct-2509",
+			"name": "GWDG: Apertus",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.deepseek-r1-distill-llama-70b": {
+			"id": "gwdg.deepseek-r1-distill-llama-70b",
+			"name": "GWDG: DeepSeek R1 Distill Llama 70B",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			},
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.devstral-2-123b-instruct-2512": {
+			"id": "gwdg.devstral-2-123b-instruct-2512",
+			"name": "GWDG: Devstral 2",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.gemma-3-27b-it": {
+			"id": "gwdg.gemma-3-27b-it",
+			"name": "GWDG: Gemma 3",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.glm-4.7": {
+			"id": "gwdg.glm-4.7",
+			"name": "GWDG: GLM 4.7",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.internvl3.5-30b-a3b": {
+			"id": "gwdg.internvl3.5-30b-a3b",
+			"name": "GWDG: InternVL 3.5",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.llama-3.1-sauerkrautlm-70b-instruct": {
+			"id": "gwdg.llama-3.1-sauerkrautlm-70b-instruct",
+			"name": "GWDG: Llama 3.1 SauerkrautLM 70B Instruct",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.llama-3.3-70b-instruct": {
+			"id": "gwdg.llama-3.3-70b-instruct",
+			"name": "GWDG: Llama 3.3 70B Instruct",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.medgemma-27b-it": {
+			"id": "gwdg.medgemma-27b-it",
+			"name": "GWDG: MedGemma",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.meta-llama-3.1-8b-instruct": {
+			"id": "gwdg.meta-llama-3.1-8b-instruct",
+			"name": "GWDG: Llama 3.1 8B Instruct",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.mistral-large-3-675b-instruct-2512": {
+			"id": "gwdg.mistral-large-3-675b-instruct-2512",
+			"name": "GWDG: Mistral 3",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.openai-gpt-oss-120b": {
+			"id": "gwdg.openai-gpt-oss-120b",
+			"name": "GWDG: OpenAI GPT OSS 120B",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.qwen3-235b-a22b": {
+			"id": "gwdg.qwen3-235b-a22b",
+			"name": "GWDG: Qwen 3 Thinking (235B A22B)",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			},
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.qwen3-30b-a3b-instruct-2507": {
+			"id": "gwdg.qwen3-30b-a3b-instruct-2507",
+			"name": "GWDG: Qwen 3 Instruct (30B A3B)",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.qwen3-30b-a3b-thinking-2507": {
+			"id": "gwdg.qwen3-30b-a3b-thinking-2507",
+			"name": "GWDG: Qwen 3 Thinking (30B A3B)",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			},
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.qwen3-32b": {
+			"id": "gwdg.qwen3-32b",
+			"name": "GWDG: Qwen 3 32B",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			},
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.qwen3-coder-30b-a3b-instruct": {
+			"id": "gwdg.qwen3-coder-30b-a3b-instruct",
+			"name": "GWDG: Qwen 3 Coder (30B A3B Instruct)",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.qwen3-omni-30b-a3b-instruct": {
+			"id": "gwdg.qwen3-omni-30b-a3b-instruct",
+			"name": "GWDG: Qwen 3 Omni (30B A3B Instruct)",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.qwen3-vl-30b-a3b-instruct": {
+			"id": "gwdg.qwen3-vl-30b-a3b-instruct",
+			"name": "GWDG: Qwen 3 VL (30B A3B Instruct)",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.qwen3.5-122b-a10b": {
+			"id": "gwdg.qwen3.5-122b-a10b",
+			"name": "GWDG: Qwen 3.5 (Hohe Qualität)",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.qwen3.5-27b": {
+			"id": "gwdg.qwen3.5-27b",
+			"name": "GWDG: Qwen 3.5 (Ausgewogen)",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.qwen3.5-35b-a3b": {
+			"id": "gwdg.qwen3.5-35b-a3b",
+			"name": "GWDG: Qwen 3.5 (Schnell)",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.qwen3.5-397b-a17b": {
+			"id": "gwdg.qwen3.5-397b-a17b",
+			"name": "GWDG: Qwen 3.5 (Beste Qualität)",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"gwdg.teuken-7b-instruct-research": {
+			"id": "gwdg.teuken-7b-instruct-research",
+			"name": "GWDG: Teuken 7B Instruct Research",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai": {
+			"id": "openai",
+			"name": "OpenAI: Basismodel",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-4.1": {
+			"id": "openai.gpt-4.1",
+			"name": "OpenAI: GPT-4.1",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-4.1-mini": {
+			"id": "openai.gpt-4.1-mini",
+			"name": "OpenAI: GPT-4.1-Mini",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-4o": {
+			"id": "openai.gpt-4o",
+			"name": "OpenAI: GPT-4o",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-4o-mini": {
+			"id": "openai.gpt-4o-mini",
+			"name": "OpenAI: GPT-4o-Mini",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-5": {
+			"id": "openai.gpt-5",
+			"name": "OpenAI: GPT-5-Thinking",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			},
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-5-chat-latest": {
+			"id": "openai.gpt-5-chat-latest",
+			"name": "OpenAI: GPT-5",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-5-mini": {
+			"id": "openai.gpt-5-mini",
+			"name": "OpenAI: GPT-5-Mini",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-5-nano": {
+			"id": "openai.gpt-5-nano",
+			"name": "OpenAI: GPT-5-Nano",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-5.1": {
+			"id": "openai.gpt-5.1",
+			"name": "OpenAI: GPT-5.1-Thinking",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			},
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-5.1-chat-latest": {
+			"id": "openai.gpt-5.1-chat-latest",
+			"name": "OpenAI: GPT-5.1",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-5.1-codex": {
+			"id": "openai.gpt-5.1-codex",
+			"name": "OpenAI: GPT-5.1-Codex",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 272000,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-5.2": {
+			"id": "openai.gpt-5.2",
+			"name": "OpenAI: GPT-5.2-Thinking",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "xhigh"
+			},
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-5.2-chat-latest": {
+			"id": "openai.gpt-5.2-chat-latest",
+			"name": "OpenAI: GPT-5.2",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-5.2-codex": {
+			"id": "openai.gpt-5.2-codex",
+			"name": "OpenAI: GPT-5.2-Codex",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 272000,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-5.3-chat-latest": {
+			"id": "openai.gpt-5.3-chat-latest",
+			"name": "OpenAI: GPT-5.3",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-5.3-codex": {
+			"id": "openai.gpt-5.3-codex",
+			"name": "OpenAI: GPT-5.3-Codex",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 272000,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-5.4": {
+			"id": "openai.gpt-5.4",
+			"name": "OpenAI: GPT-5.4-Thinking",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "xhigh"
+			},
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-5.4-mini": {
+			"id": "openai.gpt-5.4-mini",
+			"name": "OpenAI: GPT-5.4-Mini",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-5.4-nano": {
+			"id": "openai.gpt-5.4-nano",
+			"name": "OpenAI: GPT-5.4-Nano",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.gpt-5.5": {
+			"id": "openai.gpt-5.5",
+			"name": "OpenAI: GPT-5.5",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1050000,
+			"maxTokens": 128000,
+			"compat": {
+				"thinkingFormat": "litellm"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "xhigh"
+			}
+		},
+		"openai.o3-mini": {
+			"id": "openai.o3-mini",
+			"name": "OpenAI: o3-mini",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			},
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"openai.o4-mini": {
+			"id": "openai.o4-mini",
+			"name": "OpenAI: o4-mini",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			},
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"pc2.Qwen/Qwen3-32B": {
+			"id": "pc2.Qwen/Qwen3-32B",
+			"name": "UPB: Qwen 3 32B",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			},
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"prompting-hilfe": {
+			"id": "prompting-hilfe",
+			"name": "Prompting-Hilfe",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"thesispilot": {
+			"id": "thesispilot",
+			"name": "GWDG: ThesisPilot",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"upb": {
+			"id": "upb",
+			"name": "UPB: Basismodel",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"upb-diagramme-und-visualisierungen": {
+			"id": "upb-diagramme-und-visualisierungen",
+			"name": "UPB: Interaktive Visualisierungen",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"upb-mathplotter": {
+			"id": "upb-mathplotter",
+			"name": "UPB: Diagramme",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"upb-qwen-3-32b-non-reasoning": {
+			"id": "upb-qwen-3-32b-non-reasoning",
+			"name": "UPB: Qwen 3 32B (Non-Reasoning)",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
+		},
+		"upb.it-support": {
+			"id": "upb.it-support",
+			"name": "UPB: IT-Support (OpenBeta)",
+			"api": "openai-completions",
+			"provider": "upb",
+			"baseUrl": "https://ai-chat.uni-paderborn.de/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888,
+			"compat": {
+				"thinkingFormat": "litellm"
+			}
 		}
 	},
 	"venice": {

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -1000,7 +1000,7 @@
 		},
 		"global.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
-			"name": "Claude Haiku 4.5",
+			"name": "Claude Haiku 4.5 (Global)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1025,7 +1025,7 @@
 		},
 		"global.anthropic.claude-opus-4-5-20251101-v1:0": {
 			"id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
-			"name": "Claude Opus 4.5",
+			"name": "Claude Opus 4.5 (Global)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1125,7 +1125,7 @@
 		},
 		"global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
 			"id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
-			"name": "Claude Sonnet 4.5",
+			"name": "Claude Sonnet 4.5 (Global)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1150,7 +1150,7 @@
 		},
 		"global.anthropic.claude-sonnet-4-6": {
 			"id": "global.anthropic.claude-sonnet-4-6",
-			"name": "Claude Sonnet 4.6 (Global)",
+			"name": "Claude Sonnet 4.6",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1769,7 +1769,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 4096
+			"maxTokens": 16384
 		},
 		"openai.gpt-oss-20b-1:0": {
 			"id": "openai.gpt-oss-20b-1:0",
@@ -1788,7 +1788,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 4096
+			"maxTokens": 16384
 		},
 		"openai.gpt-oss-safeguard-120b": {
 			"id": "openai.gpt-oss-safeguard-120b",
@@ -1807,7 +1807,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 4096
+			"maxTokens": 16384
 		},
 		"openai.gpt-oss-safeguard-20b": {
 			"id": "openai.gpt-oss-safeguard-20b",
@@ -1826,7 +1826,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 4096
+			"maxTokens": 16384
 		},
 		"qwen.qwen3-235b-a22b-2507-v1:0": {
 			"id": "qwen.qwen3-235b-a22b-2507-v1:0",
@@ -6516,7 +6516,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.4,
-				"cacheRead": 0.025,
+				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -6796,7 +6796,7 @@
 				"input": 0.25,
 				"output": 1.5,
 				"cacheRead": 0.025,
-				"cacheWrite": 1
+				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -6821,7 +6821,7 @@
 				"input": 0.25,
 				"output": 1.5,
 				"cacheRead": 0.025,
-				"cacheWrite": 1
+				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -7514,13 +7514,14 @@
 		},
 		"gemini-3.1-flash-lite": {
 			"id": "gemini-3.1-flash-lite",
-			"name": "Gemini 3.1 Flash Lite (Antigravity)",
+			"name": "Gemini 3.1 Flash Lite",
 			"api": "google-gemini-cli",
 			"provider": "google-antigravity",
 			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -7529,7 +7530,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 65535
+			"maxTokens": 65535,
+			"thinking": {
+				"mode": "google-level",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"gemini-3.1-pro-high": {
 			"id": "gemini-3.1-pro-high",
@@ -7587,6 +7593,31 @@
 					"low",
 					"high"
 				]
+			}
+		},
+		"gemini-pro-agent": {
+			"id": "gemini-pro-agent",
+			"name": "Gemini 3.1 Pro (High) (Antigravity)",
+			"api": "google-gemini-cli",
+			"provider": "google-antigravity",
+			"baseUrl": "https://daily-cloudcode-pa.sandbox.googleapis.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65535,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "high"
 			}
 		},
 		"gpt-oss-120b-medium": {
@@ -9440,6 +9471,25 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"anthropic/claude-opus-4.7-fast": {
+			"id": "anthropic/claude-opus-4.7-fast",
+			"name": "Anthropic: Claude Opus 4.7 (Fast) ($$$$)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"anthropic/claude-sonnet-4": {
 			"id": "anthropic/claude-sonnet-4",
 			"name": "Claude Sonnet 4",
@@ -9784,6 +9834,25 @@
 		"baidu/ernie-4.5-vl-424b-a47b": {
 			"id": "baidu/ernie-4.5-vl-424b-a47b",
 			"name": "Baidu: ERNIE 4.5 VL 424B A47B",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"baidu/qianfan-ocr-fast": {
+			"id": "baidu/qianfan-ocr-fast",
+			"name": "Baidu: Qianfan-OCR-Fast",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -10309,6 +10378,25 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"deepseek/deepseek-v4-flash:free": {
+			"id": "deepseek/deepseek-v4-flash:free",
+			"name": "DeepSeek: DeepSeek V4 Flash (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"deepseek/deepseek-v4-pro": {
 			"id": "deepseek/deepseek-v4-pro",
 			"name": "DeepSeek V4 Pro",
@@ -10784,7 +10872,7 @@
 		},
 		"google/gemma-2-27b-it": {
 			"id": "google/gemma-2-27b-it",
-			"name": "Gemma 2 27b It",
+			"name": "Google: Gemma 2 27B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -10798,8 +10886,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
-			"maxTokens": 4096
+			"contextWindow": 222222,
+			"maxTokens": 8888
 		},
 		"google/gemma-2-9b-it": {
 			"id": "google/gemma-2-9b-it",
@@ -10822,7 +10910,7 @@
 		},
 		"google/gemma-3-12b-it": {
 			"id": "google/gemma-3-12b-it",
-			"name": "Gemma 3 12b It",
+			"name": "Google: Gemma 3 12B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -10836,8 +10924,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
-			"maxTokens": 4096
+			"contextWindow": 222222,
+			"maxTokens": 8888
 		},
 		"google/gemma-3-27b-it": {
 			"id": "google/gemma-3-27b-it",
@@ -11159,6 +11247,25 @@
 		"inclusionai/ling-2.6-flash:free": {
 			"id": "inclusionai/ling-2.6-flash:free",
 			"name": "inclusionAI: Ling-2.6-flash (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"inclusionai/ring-2.6-1t": {
+			"id": "inclusionai/ring-2.6-1t",
+			"name": "inclusionAI: Ring-2.6-1T",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -12509,8 +12616,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 65536,
+			"maxTokens": 13108
 		},
 		"mistralai/mixtral-8x7b-instruct": {
 			"id": "mistralai/mixtral-8x7b-instruct",
@@ -12528,8 +12635,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 32768,
+			"maxTokens": 16384
 		},
 		"mistralai/pixtral-large-2411": {
 			"id": "mistralai/pixtral-large-2411",
@@ -12667,8 +12774,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"contextWindow": 262000,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -14646,6 +14753,25 @@
 			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
+		"perceptron/perceptron-mk1": {
+			"id": "perceptron/perceptron-mk1",
+			"name": "Perceptron: Perceptron Mk1",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"perplexity/sonar": {
 			"id": "perplexity/sonar",
 			"name": "Perplexity: Sonar",
@@ -15085,7 +15211,7 @@
 		},
 		"qwen/qwen3-235b-a22b": {
 			"id": "qwen/qwen3-235b-a22b",
-			"name": "Qwen3-235B-A22B",
+			"name": "Qwen: Qwen3 235B A22B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -15099,8 +15225,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 8192,
+			"contextWindow": 222222,
+			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -15580,13 +15706,14 @@
 		},
 		"qwen/qwen3.5-122b-a10b": {
 			"id": "qwen/qwen3.5-122b-a10b",
-			"name": "Qwen: Qwen3.5-122B-A10B",
+			"name": "Qwen3.5 122B-A10B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -15594,8 +15721,13 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"qwen/qwen3.5-27b": {
 			"id": "qwen/qwen3.5-27b",
@@ -18643,182 +18775,6 @@
 			"maxTokens": 40000
 		}
 	},
-	"mimo-code": {
-		"mimo-v2-omni": {
-			"id": "mimo-v2-omni",
-			"name": "MiMo V2 Omni",
-			"api": "openai-completions",
-			"provider": "mimo-code",
-			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 131072,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"mimo-v2-pro": {
-			"id": "mimo-v2-pro",
-			"name": "MiMo V2 Pro",
-			"api": "openai-completions",
-			"provider": "mimo-code",
-			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 131072,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"mimo-v2-tts": {
-			"id": "mimo-v2-tts",
-			"name": "mimo-v2-tts",
-			"api": "openai-completions",
-			"provider": "mimo-code",
-			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 131072
-		},
-		"mimo-v2.5": {
-			"id": "mimo-v2.5",
-			"name": "MiMo-V2.5",
-			"api": "openai-completions",
-			"provider": "mimo-code",
-			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
-			"reasoning": true,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 131072,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"mimo-v2.5-pro": {
-			"id": "mimo-v2.5-pro",
-			"name": "MiMo-V2.5-Pro",
-			"api": "openai-completions",
-			"provider": "mimo-code",
-			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
-			"reasoning": true,
-			"input": [
-				"text",
-				"image"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 131072,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
-		},
-		"mimo-v2.5-tts": {
-			"id": "mimo-v2.5-tts",
-			"name": "mimo-v2.5-tts",
-			"api": "openai-completions",
-			"provider": "mimo-code",
-			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 131072
-		},
-		"mimo-v2.5-tts-voiceclone": {
-			"id": "mimo-v2.5-tts-voiceclone",
-			"name": "mimo-v2.5-tts-voiceclone",
-			"api": "openai-completions",
-			"provider": "mimo-code",
-			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 131072
-		},
-		"mimo-v2.5-tts-voicedesign": {
-			"id": "mimo-v2.5-tts-voicedesign",
-			"name": "mimo-v2.5-tts-voicedesign",
-			"api": "openai-completions",
-			"provider": "mimo-code",
-			"baseUrl": "https://token-plan-ams.xiaomimimo.com/v1",
-			"reasoning": false,
-			"input": [
-				"text"
-			],
-			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
-			},
-			"contextWindow": 1048576,
-			"maxTokens": 131072
-		}
-	},
 	"minimax": {
 		"MiniMax-M2": {
 			"id": "MiniMax-M2",
@@ -20223,7 +20179,7 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "high"
 			}
 		}
 	},
@@ -26966,11 +26922,11 @@
 		},
 		"mistralai/mistral-small-4-119b-2603": {
 			"id": "mistralai/mistral-small-4-119b-2603",
-			"name": "mistralai/mistral-small-4-119b-2603",
+			"name": "mistral-small-4-119b-2603",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
 				"text"
 			],
@@ -26980,13 +26936,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
+			"contextWindow": 128000,
+			"maxTokens": 8192
 		},
 		"mistralai/mistral-small-creative": {
 			"id": "mistralai/mistral-small-creative",
@@ -33232,6 +33183,44 @@
 		}
 	},
 	"nvidia": {
+		"abacusai/dracarys-llama-3_1-70b-instruct": {
+			"id": "abacusai/dracarys-llama-3_1-70b-instruct",
+			"name": "dracarys-llama-3.1-70b-instruct",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192
+		},
+		"bytedance/seed-oss-36b-instruct": {
+			"id": "bytedance/seed-oss-36b-instruct",
+			"name": "ByteDance-Seed/Seed-OSS-36B-Instruct",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262000,
+			"maxTokens": 262000
+		},
 		"deepseek-ai/deepseek-coder-6.7b-instruct": {
 			"id": "deepseek-ai/deepseek-coder-6.7b-instruct",
 			"name": "Deepseek Coder 6.7b Instruct",
@@ -33600,6 +33589,25 @@
 			"contextWindow": 128000,
 			"maxTokens": 4096
 		},
+		"meta/llama-3.1-8b-instruct": {
+			"id": "meta/llama-3.1-8b-instruct",
+			"name": "Llama 3.1 8B Instruct",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 16000,
+			"maxTokens": 4096
+		},
 		"meta/llama-3.2-11b-vision-instruct": {
 			"id": "meta/llama-3.2-11b-vision-instruct",
 			"name": "Llama 3.2 11b Vision Instruct",
@@ -33638,6 +33646,26 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096
+		},
+		"meta/llama-3.2-90b-vision-instruct": {
+			"id": "meta/llama-3.2-90b-vision-instruct",
+			"name": "Llama-3.2-90B-Vision-Instruct",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192
 		},
 		"meta/llama-3.3-70b-instruct": {
 			"id": "meta/llama-3.3-70b-instruct",
@@ -34059,6 +34087,25 @@
 			"contextWindow": 262144,
 			"maxTokens": 262144
 		},
+		"mistralai/mistral-7b-instruct-v03": {
+			"id": "mistralai/mistral-7b-instruct-v03",
+			"name": "Mistral-7B-Instruct-v0.3",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 65536,
+			"maxTokens": 65536
+		},
 		"mistralai/mistral-large-2-instruct": {
 			"id": "mistralai/mistral-large-2-instruct",
 			"name": "Mistral Large 2 Instruct",
@@ -34123,6 +34170,25 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"mistralai/mistral-nemotron": {
+			"id": "mistralai/mistral-nemotron",
+			"name": "mistral-nemotron",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192
+		},
 		"mistralai/mistral-small-3.1-24b-instruct-2503": {
 			"id": "mistralai/mistral-small-3.1-24b-instruct-2503",
 			"name": "Mistral Small 3.1 24b Instruct 2503",
@@ -34141,6 +34207,63 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096
+		},
+		"mistralai/mistral-small-4-119b-2603": {
+			"id": "mistralai/mistral-small-4-119b-2603",
+			"name": "mistral-small-4-119b-2603",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192
+		},
+		"mistralai/mixtral-8x22b-instruct": {
+			"id": "mistralai/mixtral-8x22b-instruct",
+			"name": "Mistral: Mixtral 8x22B Instruct",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 65536,
+			"maxTokens": 13108
+		},
+		"mistralai/mixtral-8x7b-instruct": {
+			"id": "mistralai/mixtral-8x7b-instruct",
+			"name": "Mistral: Mixtral 8x7B Instruct",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 32768,
+			"maxTokens": 16384
 		},
 		"moonshotai/kimi-k2-instruct": {
 			"id": "moonshotai/kimi-k2-instruct",
@@ -34253,6 +34376,54 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"nvidia/llama-3_3-nemotron-super-49b-v1": {
+			"id": "nvidia/llama-3_3-nemotron-super-49b-v1",
+			"name": "Llama 3.3 Nemotron Super 49B v1",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"nvidia/llama-3_3-nemotron-super-49b-v1_5": {
+			"id": "nvidia/llama-3_3-nemotron-super-49b-v1_5",
+			"name": "Llama 3.3 Nemotron Super 49B v1.5",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -34451,6 +34622,44 @@
 			"contextWindow": 128000,
 			"maxTokens": 4096
 		},
+		"nvidia/nemotron-mini-4b-instruct": {
+			"id": "nvidia/nemotron-mini-4b-instruct",
+			"name": "nemotron-mini-4b-instruct",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192
+		},
+		"nvidia/nemotron-voicechat": {
+			"id": "nvidia/nemotron-voicechat",
+			"name": "nemotron-voicechat",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192
+		},
 		"nvidia/nvidia-nemotron-nano-9b-v2": {
 			"id": "nvidia/nvidia-nemotron-nano-9b-v2",
 			"name": "nvidia-nemotron-nano-9b-v2",
@@ -34469,6 +34678,30 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"openai/gpt-oss-20b": {
+			"id": "openai/gpt-oss-20b",
+			"name": "GPT OSS 20B",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -34599,6 +34832,31 @@
 				"maxLevel": "high"
 			}
 		},
+		"qwen/qwen3.5-122b-a10b": {
+			"id": "qwen/qwen3.5-122b-a10b",
+			"name": "Qwen3.5 122B-A10B",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"qwen/qwen3.5-397b-a17b": {
 			"id": "qwen/qwen3.5-397b-a17b",
 			"name": "Qwen3.5-397B-A17B",
@@ -34624,6 +34882,25 @@
 				"maxLevel": "high"
 			}
 		},
+		"sarvamai/sarvam-m": {
+			"id": "sarvamai/sarvam-m",
+			"name": "sarvam-m",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192
+		},
 		"stepfun-ai/step-3.5-flash": {
 			"id": "stepfun-ai/step-3.5-flash",
 			"name": "Step 3.5 Flash",
@@ -34647,6 +34924,25 @@
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
+		},
+		"upstage/solar-10_7b-instruct": {
+			"id": "upstage/solar-10_7b-instruct",
+			"name": "solar-10.7b-instruct",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192
 		},
 		"z-ai/glm-5.1": {
 			"id": "z-ai/glm-5.1",
@@ -36694,9 +36990,9 @@
 		"minimax-m2.5": {
 			"id": "minimax-m2.5",
 			"name": "MiniMax M2.5",
-			"api": "openai-completions",
+			"api": "anthropic-messages",
 			"provider": "opencode-go",
-			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"baseUrl": "https://opencode.ai/zen/go",
 			"reasoning": true,
 			"input": [
 				"text"
@@ -36710,7 +37006,7 @@
 			"contextWindow": 204800,
 			"maxTokens": 65536,
 			"thinking": {
-				"mode": "effort",
+				"mode": "budget",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
@@ -37033,6 +37329,30 @@
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
 				"maxLevel": "high"
+			}
+		},
+		"deepseek-v4-flash-free": {
+			"id": "deepseek-v4-flash-free",
+			"name": "DeepSeek V4 Flash Free",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
 			}
 		},
 		"gemini-3-flash": {
@@ -38023,12 +38343,13 @@
 		"qwen3.6-plus-free": {
 			"id": "qwen3.6-plus-free",
 			"name": "Qwen3.6 Plus Free",
-			"api": "openai-completions",
+			"api": "anthropic-messages",
 			"provider": "opencode-zen",
-			"baseUrl": "https://opencode.ai/zen/v1",
+			"baseUrl": "https://opencode.ai/zen",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -38036,12 +38357,12 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1048576,
-			"maxTokens": 64000,
+			"contextWindow": 262144,
+			"maxTokens": 65536,
 			"thinking": {
-				"mode": "effort",
+				"mode": "budget",
 				"minLevel": "minimal",
-				"maxLevel": "high"
+				"maxLevel": "xhigh"
 			}
 		},
 		"ring-2.6-1t-free": {
@@ -38226,13 +38547,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.75,
-				"output": 3.5,
-				"cacheRead": 0.15,
+				"input": 0.73,
+				"output": 3.49,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 16384,
+			"maxTokens": 262142,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -38747,6 +39068,31 @@
 				"maxLevel": "high"
 			}
 		},
+		"anthropic/claude-opus-4.7-fast": {
+			"id": "anthropic/claude-opus-4.7-fast",
+			"name": "Anthropic: Claude Opus 4.7 (Fast)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 30,
+				"output": 150,
+				"cacheRead": 3,
+				"cacheWrite": 37.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"anthropic/claude-sonnet-4": {
 			"id": "anthropic/claude-sonnet-4",
 			"name": "Claude Sonnet 4",
@@ -38890,6 +39236,30 @@
 				"maxLevel": "high"
 			}
 		},
+		"arcee-ai/trinity-large-thinking:free": {
+			"id": "arcee-ai/trinity-large-thinking:free",
+			"name": "Arcee AI: Trinity Large Thinking (free)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 80000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"arcee-ai/trinity-mini": {
 			"id": "arcee-ai/trinity-mini",
 			"name": "Arcee AI: Trinity Mini",
@@ -39025,7 +39395,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 120000,
+			"contextWindow": 131072,
 			"maxTokens": 8000
 		},
 		"baidu/ernie-4.5-vl-28b-a3b": {
@@ -39045,7 +39415,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 30000,
+			"contextWindow": 131072,
 			"maxTokens": 8000,
 			"thinking": {
 				"mode": "effort",
@@ -39245,13 +39615,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.15,
-				"output": 0.75,
-				"cacheRead": 0,
+				"input": 0.21,
+				"output": 0.7899999999999999,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
-			"maxTokens": 7168,
+			"contextWindow": 163840,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -39274,7 +39644,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 64000,
+			"contextWindow": 163840,
 			"maxTokens": 16000,
 			"thinking": {
 				"mode": "effort",
@@ -39413,9 +39783,33 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.28,
-				"cacheRead": 0.0028,
+				"input": 0.112,
+				"output": 0.224,
+				"cacheRead": 0.022,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"deepseek/deepseek-v4-flash:free": {
+			"id": "deepseek/deepseek-v4-flash:free",
+			"name": "DeepSeek: DeepSeek V4 Flash (free)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -39486,7 +39880,7 @@
 				"cacheRead": 0.024999999999999998,
 				"cacheWrite": 0.08333333333333334
 			},
-			"contextWindow": 1000000,
+			"contextWindow": 1048576,
 			"maxTokens": 8192
 		},
 		"google/gemini-2.0-flash-lite-001": {
@@ -39824,7 +40218,7 @@
 				"cacheRead": 0.19999999999999998,
 				"cacheWrite": 0.375
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1048756,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -39838,13 +40232,14 @@
 		},
 		"google/gemma-3-12b-it": {
 			"id": "google/gemma-3-12b-it",
-			"name": "Gemma 3 12b It",
+			"name": "Google: Gemma 3 12B",
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.04,
@@ -39912,13 +40307,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.06,
-				"output": 0.33,
+				"input": 0.07,
+				"output": 0.33999999999999997,
 				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 8888,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -39962,8 +40357,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.13,
-				"output": 0.38,
+				"input": 0.12,
+				"output": 0.37,
 				"cacheRead": 0.019999999499999997,
 				"cacheWrite": 0
 			},
@@ -40130,9 +40525,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.08,
-				"output": 0.24,
-				"cacheRead": 0.016,
+				"input": 0.01,
+				"output": 0.03,
+				"cacheRead": 0.002,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -40156,6 +40551,30 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768
+		},
+		"inclusionai/ring-2.6-1t": {
+			"id": "inclusionai/ring-2.6-1t",
+			"name": "inclusionAI: Ring-2.6-1T",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.075,
+				"output": 0.625,
+				"cacheRead": 0.015,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"inclusionai/ring-2.6-1t:free": {
 			"id": "inclusionai/ring-2.6-1t:free",
@@ -40311,7 +40730,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 16384,
+			"contextWindow": 131072,
 			"maxTokens": 16384
 		},
 		"meta-llama/llama-3.3-70b-instruct": {
@@ -40349,7 +40768,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 65536,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"meta-llama/llama-4-maverick": {
@@ -40389,7 +40808,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 327680,
+			"contextWindow": 10000000,
 			"maxTokens": 16384
 		},
 		"minimax/minimax-m1": {
@@ -40432,7 +40851,7 @@
 				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
-			"contextWindow": 196608,
+			"contextWindow": 204800,
 			"maxTokens": 196608,
 			"thinking": {
 				"mode": "effort",
@@ -40456,7 +40875,7 @@
 				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
-			"contextWindow": 196608,
+			"contextWindow": 204800,
 			"maxTokens": 196608,
 			"thinking": {
 				"mode": "effort",
@@ -40480,7 +40899,7 @@
 				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
-			"contextWindow": 196608,
+			"contextWindow": 204800,
 			"maxTokens": 196608,
 			"thinking": {
 				"mode": "effort",
@@ -40504,7 +40923,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 196608,
+			"contextWindow": 204800,
 			"maxTokens": 8192,
 			"compat": {
 				"supportsToolChoice": false
@@ -40526,12 +40945,12 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.29900000000000004,
+				"input": 0.27899999999999997,
 				"output": 1.2,
 				"cacheRead": 0.059,
 				"cacheWrite": 0
 			},
-			"contextWindow": 196608,
+			"contextWindow": 204800,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -40829,7 +41248,7 @@
 			],
 			"cost": {
 				"input": 0.02,
-				"output": 0.03,
+				"output": 0.04,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -40995,7 +41414,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 65536,
-			"maxTokens": 8888
+			"maxTokens": 13108
 		},
 		"mistralai/mixtral-8x7b-instruct": {
 			"id": "mistralai/mixtral-8x7b-instruct",
@@ -41085,8 +41504,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.39999999999999997,
-				"output": 2,
+				"input": 0.6,
+				"output": 2.5,
 				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
@@ -41149,8 +41568,8 @@
 			],
 			"cost": {
 				"input": 0.39999999999999997,
-				"output": 1.9800000000000002,
-				"cacheRead": 0.049999999999999996,
+				"output": 1.9,
+				"cacheRead": 0.09,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -41173,13 +41592,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.75,
-				"output": 3.5,
-				"cacheRead": 0.15,
+				"input": 0.73,
+				"output": 3.49,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 16384,
+			"maxTokens": 262142,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -41380,13 +41799,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09,
-				"output": 0.44999999999999996,
+				"input": 0.09999999999999999,
+				"output": 0.5,
 				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"contextWindow": 1000000,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -41409,7 +41828,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 1000000,
 			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
@@ -42504,12 +42923,12 @@
 			],
 			"cost": {
 				"input": 0.039,
-				"output": 0.18,
+				"output": 0.19,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 65536,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -43111,7 +43530,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
+			"contextWindow": 131072,
 			"maxTokens": 16384
 		},
 		"qwen/qwen-2.5-7b-instruct": {
@@ -43130,7 +43549,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
+			"contextWindow": 131072,
 			"maxTokens": 32768
 		},
 		"qwen/qwen-max": {
@@ -43264,12 +43683,12 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.06,
+				"input": 0.09999999999999999,
 				"output": 0.24,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 40960,
+			"contextWindow": 131702,
 			"maxTokens": 40960,
 			"thinking": {
 				"mode": "effort",
@@ -43279,7 +43698,7 @@
 		},
 		"qwen/qwen3-235b-a22b": {
 			"id": "qwen/qwen3-235b-a22b",
-			"name": "Qwen3-235B-A22B",
+			"name": "Qwen: Qwen3 235B A22B",
 			"api": "openai-completions",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -43341,7 +43760,7 @@
 				"cacheRead": 0.055,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 262144,
 			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
@@ -43365,7 +43784,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 40960,
+			"contextWindow": 131072,
 			"maxTokens": 20000,
 			"thinking": {
 				"mode": "effort",
@@ -43432,7 +43851,7 @@
 				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
-			"contextWindow": 40960,
+			"contextWindow": 131072,
 			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
@@ -43504,7 +43923,7 @@
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
-			"contextWindow": 40960,
+			"contextWindow": 131072,
 			"maxTokens": 8192,
 			"thinking": {
 				"mode": "effort",
@@ -43528,7 +43947,7 @@
 				"cacheRead": 0.022,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 1048576,
 			"maxTokens": 65536
 		},
 		"qwen/qwen3-coder-30b-a3b-instruct": {
@@ -43642,7 +44061,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262000,
+			"contextWindow": 1048576,
 			"maxTokens": 262000
 		},
 		"qwen/qwen3-max": {
@@ -43747,7 +44166,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 262144,
 			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
@@ -43817,7 +44236,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 262144,
 			"maxTokens": 32768
 		},
 		"qwen/qwen3-vl-30b-a3b-thinking": {
@@ -43862,7 +44281,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 262144,
 			"maxTokens": 32768
 		},
 		"qwen/qwen3-vl-8b-instruct": {
@@ -43882,7 +44301,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 256000,
 			"maxTokens": 32768
 		},
 		"qwen/qwen3-vl-8b-thinking": {
@@ -43902,7 +44321,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 256000,
 			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
@@ -43912,7 +44331,7 @@
 		},
 		"qwen/qwen3.5-122b-a10b": {
 			"id": "qwen/qwen3.5-122b-a10b",
-			"name": "Qwen: Qwen3.5-122B-A10B",
+			"name": "Qwen3.5 122B-A10B",
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -44097,8 +44516,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.39999999999999997,
-				"output": 2.4,
+				"input": 0.3,
+				"output": 1.7999999999999998,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -44172,10 +44591,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 1.5,
+				"input": 0.1875,
+				"output": 1.125,
 				"cacheRead": 0,
-				"cacheWrite": 0.3125
+				"cacheWrite": 0.234375
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
@@ -45143,13 +45562,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.39,
-				"output": 1.9,
-				"cacheRead": 0,
+				"input": 0.43,
+				"output": 1.74,
+				"cacheRead": 0.08,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
-			"maxTokens": 204800,
+			"contextWindow": 202752,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -45312,13 +45731,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.0499999999999998,
-				"output": 3.5,
-				"cacheRead": 0.5249999999999999,
+				"input": 0.98,
+				"output": 3.08,
+				"cacheRead": 0.182,
 				"cacheWrite": 0
 			},
 			"contextWindow": 202752,
-			"maxTokens": 65535,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -45411,6 +45830,122 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 8192
+		}
+	},
+	"skvaider": {
+		"bge-m3:567m": {
+			"id": "bge-m3:567m",
+			"name": "bge-m3:567m",
+			"api": "openai-completions",
+			"provider": "skvaider",
+			"baseUrl": "https://ai.dev.fcio.net/openai/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"embeddinggemma:300m": {
+			"id": "embeddinggemma:300m",
+			"name": "embeddinggemma:300m",
+			"api": "openai-completions",
+			"provider": "skvaider",
+			"baseUrl": "https://ai.dev.fcio.net/openai/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"gpt-oss:20b": {
+			"id": "gpt-oss:20b",
+			"name": "gpt-oss:20b",
+			"api": "openai-completions",
+			"provider": "skvaider",
+			"baseUrl": "https://ai.dev.fcio.net/openai/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"nomic-embed-text:v1.5": {
+			"id": "nomic-embed-text:v1.5",
+			"name": "nomic-embed-text:v1.5",
+			"api": "openai-completions",
+			"provider": "skvaider",
+			"baseUrl": "https://ai.dev.fcio.net/openai/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"qwen3.6:27b": {
+			"id": "qwen3.6:27b",
+			"name": "qwen3.6:27b",
+			"api": "openai-completions",
+			"provider": "skvaider",
+			"baseUrl": "https://ai.dev.fcio.net/openai/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"rednote-hilab:dots.mocr": {
+			"id": "rednote-hilab:dots.mocr",
+			"name": "rednote-hilab:dots.mocr",
+			"api": "openai-completions",
+			"provider": "skvaider",
+			"baseUrl": "https://ai.dev.fcio.net/openai/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
 		}
 	},
 	"synthetic": {
@@ -47632,6 +48167,28 @@
 				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
+			}
+		},
+		"claude-opus-4-7-fast": {
+			"id": "claude-opus-4-7-fast",
+			"name": "claude-opus-4-7-fast",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"claude-opus-45": {
@@ -52989,8 +53546,8 @@
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
-			"contextWindow": 2000000,
-			"maxTokens": 30000
+			"contextWindow": 1000000,
+			"maxTokens": 1000000
 		},
 		"xai/grok-4.1-fast-reasoning": {
 			"id": "xai/grok-4.1-fast-reasoning",
@@ -53009,8 +53566,8 @@
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
-			"contextWindow": 2000000,
-			"maxTokens": 30000,
+			"contextWindow": 1000000,
+			"maxTokens": 1000000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -34,6 +34,7 @@ import {
 	openrouterModelManagerOptions,
 	qianfanModelManagerOptions,
 	qwenPortalModelManagerOptions,
+	skvaiderModelManagerOptions,
 	syntheticModelManagerOptions,
 	togetherModelManagerOptions,
 	upbGatewayModelManagerOptions,
@@ -263,6 +264,13 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		"gpt-oss-20b",
 		config => vllmModelManagerOptions(config),
 		catalog("vLLM", ["VLLM_API_KEY"], { allowUnauthenticated: true }),
+	),
+	catalogDescriptor(
+		"skvaider",
+		"qwen3.6:27b",
+		config => skvaiderModelManagerOptions(config),
+		catalog("Skvaider (Flying Circus)", ["SKVAIDER_API_KEY"]),
+		{ allowUnauthenticated: true },
 	),
 	catalogDescriptor(
 		"moonshot",

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -36,6 +36,8 @@ import {
 	qwenPortalModelManagerOptions,
 	syntheticModelManagerOptions,
 	togetherModelManagerOptions,
+	upbGatewayModelManagerOptions,
+	upbModelManagerOptions,
 	veniceModelManagerOptions,
 	vercelAiGatewayModelManagerOptions,
 	vllmModelManagerOptions,
@@ -242,6 +244,18 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		"claude-opus-4-6",
 		config => litellmModelManagerOptions(config),
 		catalog("LiteLLM", ["LITELLM_API_KEY"], { allowUnauthenticated: true }),
+	),
+	catalogDescriptor(
+		"upb",
+		"openai.gpt-4o",
+		config => upbModelManagerOptions(config),
+		catalog("UPB AI Gateway", ["UPB_API_KEY"]),
+	),
+	catalogDescriptor(
+		"upb-gateway",
+		"openai.gpt-4o",
+		config => upbGatewayModelManagerOptions(config),
+		catalog("UPB AI Gateway (LiteLLM)", ["UPB_GATEWAY_API_KEY"]),
 	),
 	descriptor("lm-studio", "llama-3-8b", config => lmStudioModelManagerOptions(config), { allowUnauthenticated: true }),
 	catalogDescriptor(

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -161,6 +161,9 @@ function mapWithBundledReference<TApi extends Api>(
 		id: defaults.id,
 		name,
 		baseUrl: defaults.baseUrl,
+		// Endpoint discovery often omits capability metadata for proxied models. Keep the
+		// stronger bundled reference capabilities while still allowing explicit endpoint
+		// limits to override when provided.
 		contextWindow: toPositiveNumber(entry.context_length, reference.contextWindow),
 		maxTokens: toPositiveNumber(entry.max_completion_tokens, reference.maxTokens),
 	};
@@ -1478,6 +1481,80 @@ export function litellmModelManagerOptions(
 }
 
 // ---------------------------------------------------------------------------
+// UPB AI Gateway (Universität Paderborn — LiteLLM proxy, direct API key)
+// ---------------------------------------------------------------------------
+
+export interface UPBGatewayModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+}
+
+export function upbGatewayModelManagerOptions(
+	config?: UPBGatewayModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	const apiKey = config?.apiKey;
+	const baseUrl = config?.baseUrl ?? "https://ai-gateway.uni-paderborn.de/v1";
+	const references = createBundledReferenceMap<"openai-completions">("upb" as Parameters<typeof getBundledModels>[0]);
+	return {
+		providerId: "upb-gateway",
+		...(apiKey && {
+			fetchDynamicModels: () =>
+				fetchOpenAICompatibleModels({
+					api: "openai-completions",
+					provider: "upb-gateway",
+					baseUrl,
+					apiKey,
+					mapModel: (entry, defaults) => {
+						const reference = references.get(defaults.id);
+						return mapWithBundledReference(entry, defaults, reference);
+					},
+				}),
+		}),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// UPB AI-Chat portal (Universität Paderborn — Open WebUI proxy with central funding)
+// ---------------------------------------------------------------------------
+
+export interface UPBModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+}
+
+export function upbModelManagerOptions(config?: UPBModelManagerConfig): ModelManagerOptions<"openai-completions"> {
+	const apiKey = config?.apiKey;
+	const baseUrl = config?.baseUrl ?? "https://ai-chat.uni-paderborn.de/api/v1";
+	const references = createBundledReferenceMap<"openai-completions">("upb" as Parameters<typeof getBundledModels>[0]);
+	return {
+		providerId: "upb",
+		...(apiKey && {
+			fetchDynamicModels: () =>
+				fetchOpenAICompatibleModels({
+					api: "openai-completions",
+					provider: "upb",
+					baseUrl,
+					apiKey,
+					mapModel: (entry, defaults) => {
+						const reference = references.get(defaults.id);
+						const mapped = mapWithBundledReference(entry, defaults, reference);
+						if (defaults.id === "openai.gpt-5.5") {
+							mapped.contextWindow = 1_050_000;
+							mapped.maxTokens = 128_000;
+							mapped.reasoning = true;
+							mapped.input = ["text", "image"];
+						}
+						// LiteLLM proxy (UPB AI-Chat) requires reasoning.summary to surface reasoning tokens.
+						// Apply to all models since the proxy handles the parameter for any model.
+						mapped.compat = { ...mapped.compat, thinkingFormat: "litellm" };
+						return mapped;
+					},
+				}),
+		}),
+	};
+}
+
+// ---------------------------------------------------------------------------
 // 22. vLLM
 // ---------------------------------------------------------------------------
 
@@ -2136,8 +2213,25 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS: readonly ModelsDevProviderDe
 	anthropicMessagesDescriptor("zai-coding-plan", "zai", "https://api.z.ai/api/anthropic"),
 	// --- Xiaomi ---
 	anthropicMessagesDescriptor("xiaomi", "xiaomi", "https://api.xiaomimimo.com/anthropic", {
-		defaultContextWindow: 262144,
-		defaultMaxTokens: 8192,
+		defaultContextWindow: 1_048_576,
+		defaultMaxTokens: 131_072,
+	}),
+	// --- Xiaomi MiMo Coding Plan ---
+	openAiCompletionsDescriptor("mimo-coding-plan", "mimo-code", "https://token-plan-ams.xiaomimimo.com/v1", {
+		defaultContextWindow: 1_048_576,
+		defaultMaxTokens: 131_072,
+		resolveApi: (modelId, raw) =>
+			resolveApiByRules(
+				modelId,
+				raw,
+				[
+					{
+						matches: (_id, raw) => raw.provider?.npm === "@ai-sdk/anthropic",
+						resolved: { api: "anthropic-messages", baseUrl: "https://token-plan-ams.xiaomimimo.com/anthropic" },
+					},
+				],
+				{ api: "openai-completions", baseUrl: "https://token-plan-ams.xiaomimimo.com/v1" },
+			),
 	}),
 	// --- MiniMax Coding Plan ---
 	openAiCompletionsDescriptor("minimax-coding-plan", "minimax-code", "https://api.minimax.io/v1", {

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -1587,6 +1587,42 @@ export function vllmModelManagerOptions(config?: VllmModelManagerConfig): ModelM
 }
 
 // ---------------------------------------------------------------------------
+// 22a. Skvaider (Flying Circus AI gateway)
+// ---------------------------------------------------------------------------
+
+export interface SkvaiderModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+}
+
+export function skvaiderModelManagerOptions(
+	config?: SkvaiderModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	const apiKey = config?.apiKey ?? Bun.env.SKVAIDER_API_KEY;
+	const baseUrl = config?.baseUrl ?? Bun.env.SKVAIDER_BASE_URL ?? "https://ai.dev.fcio.net/openai/v1";
+	const references = createBundledReferenceMap<"openai-completions">(
+		"skvaider" as Parameters<typeof getBundledModels>[0],
+	);
+	return {
+		providerId: "skvaider",
+		fetchDynamicModels: () =>
+			fetchOpenAICompatibleModels({
+				api: "openai-completions",
+				provider: "skvaider",
+				baseUrl,
+				apiKey,
+				mapModel: (entry, defaults) => {
+					const model = mapWithBundledReference(entry, defaults, references.get(defaults.id));
+					return {
+						...model,
+						contextWindow: toPositiveNumber(entry.max_model_len, model.contextWindow),
+					};
+				},
+			}),
+	};
+}
+
+// ---------------------------------------------------------------------------
 // 23. NanoGPT
 // ---------------------------------------------------------------------------
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1168,6 +1168,11 @@ function buildParams(
 				effort: mapReasoningEffort(options.reasoning, compat.reasoningEffortMap),
 			};
 		}
+	} else if (supportsReasoningParams && compat.thinkingFormat === "litellm" && options?.reasoning && model.reasoning) {
+		// LiteLLM proxied endpoints (e.g. UPB AI-Chat) use reasoning: { summary } to surface reasoning tokens.
+		// Without this parameter the proxy strips reasoning_content from responses.
+		const litellmParams = params as typeof params & { reasoning?: { summary?: string } };
+		litellmParams.reasoning = { summary: "detailed" };
 	} else if (
 		supportsReasoningParams &&
 		options?.reasoning &&

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -149,6 +149,8 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	"cloudflare-ai-gateway": "CLOUDFLARE_AI_GATEWAY_API_KEY",
 	huggingface: () => $pickenv("HUGGINGFACE_HUB_TOKEN", "HF_TOKEN"),
 	litellm: "LITELLM_API_KEY",
+	upb: "UPB_API_KEY",
+	"upb-gateway": "UPB_GATEWAY_API_KEY",
 	moonshot: "MOONSHOT_API_KEY",
 	nvidia: "NVIDIA_API_KEY",
 	nanogpt: "NANO_GPT_API_KEY",

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -164,6 +164,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	zenmux: "ZENMUX_API_KEY",
 	venice: "VENICE_API_KEY",
 	vllm: "VLLM_API_KEY",
+	skvaider: "SKVAIDER_API_KEY",
 	xiaomi: "XIAOMI_API_KEY",
 };
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -108,6 +108,7 @@ export type KnownProvider =
 	| "kimi-code"
 	| "minimax-code"
 	| "minimax-code-cn"
+	| "mimo-code"
 	| "github-copilot"
 	| "fireworks"
 	| "firepass"
@@ -141,6 +142,8 @@ export type KnownProvider =
 	| "vllm"
 	| "xiaomi"
 	| "zenmux"
+	| "upb"
+	| "upb-gateway"
 	| "lm-studio";
 export type Provider = KnownProvider | string;
 
@@ -729,8 +732,8 @@ export interface OpenAICompat {
 	requiresThinkingAsText?: boolean;
 	/** Whether tool call IDs must be normalized to Mistral format (exactly 9 alphanumeric chars). Default: auto-detected from URL. */
 	requiresMistralToolIds?: boolean;
-	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "zai" uses thinking: { type: "enabled" | "disabled" } (also used by Moonshot Kimi), "qwen" uses top-level enable_thinking, and "qwen-chat-template" uses chat_template_kwargs.enable_thinking. Default: "openai". */
-	thinkingFormat?: "openai" | "openrouter" | "zai" | "qwen" | "qwen-chat-template";
+	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "zai" uses thinking: { type: "enabled" }, "qwen" uses top-level enable_thinking, "qwen-chat-template" uses chat_template_kwargs.enable_thinking, and "litellm" uses reasoning: { summary: "detailed" } for reasoning token passthrough via LiteLLM proxied endpoints. Default: "openai". */
+	thinkingFormat?: "openai" | "openrouter" | "zai" | "qwen" | "qwen-chat-template" | "litellm";
 	/** Which reasoning content field to emit on assistant messages. Default: auto-detected. */
 	reasoningContentField?: "reasoning_content" | "reasoning" | "reasoning_text";
 	/** Whether assistant tool-call messages must include reasoning content. Default: false. */

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -108,7 +108,6 @@ export type KnownProvider =
 	| "kimi-code"
 	| "minimax-code"
 	| "minimax-code-cn"
-	| "mimo-code"
 	| "github-copilot"
 	| "fireworks"
 	| "firepass"

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -140,6 +140,7 @@ export type KnownProvider =
 	| "together"
 	| "venice"
 	| "vllm"
+	| "skvaider"
 	| "xiaomi"
 	| "zenmux"
 	| "upb"

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -91,6 +91,16 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		available: true,
 	},
 	{
+		id: "upb",
+		name: "UPB AI-Chat (Universit\u00e4t Paderborn)",
+		available: true,
+	},
+	{
+		id: "upb-gateway",
+		name: "UPB AI Gateway (LiteLLM)",
+		available: true,
+	},
+	{
 		id: "lm-studio",
 		name: "LM Studio (Local OpenAI-compatible)",
 		available: true,
@@ -128,6 +138,11 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 	{
 		id: "xiaomi",
 		name: "Xiaomi MiMo",
+		available: true,
+	},
+	{
+		id: "mimo-code",
+		name: "Xiaomi MiMo Coding Plan",
 		available: true,
 	},
 	{

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -141,11 +141,6 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		available: true,
 	},
 	{
-		id: "mimo-code",
-		name: "Xiaomi MiMo Coding Plan",
-		available: true,
-	},
-	{
 		id: "opencode-zen",
 		name: "OpenCode Zen",
 		available: true,

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -221,6 +221,11 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		available: true,
 	},
 	{
+		id: "skvaider",
+		name: "Skvaider (Flying Circus AI gateway)",
+		available: true,
+	},
+	{
 		id: "cloudflare-ai-gateway",
 		name: "Cloudflare AI Gateway",
 		available: true,
@@ -349,6 +354,7 @@ export async function refreshOAuthToken(
 		case "qwen-portal":
 		case "zenmux":
 		case "vllm":
+		case "skvaider":
 			// API keys / static bearer tokens don't expire, return as-is
 			newCredentials = credentials;
 			break;

--- a/packages/ai/src/utils/oauth/skvaider.ts
+++ b/packages/ai/src/utils/oauth/skvaider.ts
@@ -1,0 +1,38 @@
+/**
+ * Skvaider (Flying Circus AI gateway) login flow.
+ *
+ * Skvaider exposes an OpenAI-compatible API. Authentication is via a
+ * static bearer token that can be provisioned from the gateway admin.
+ */
+
+import type { OAuthController, OAuthProvider } from "./types";
+
+const PROVIDER_ID: OAuthProvider = "skvaider";
+const AUTH_URL = "https://ai.dev.fcio.net/openai/v1";
+const DEFAULT_BASE_URL = "https://ai.dev.fcio.net/openai/v1";
+const DEFAULT_TOKEN = "skvaider-local";
+
+/**
+ * Login to Skvaider.
+ *
+ * Prompts for a bearer token. The token is used as `Authorization: Bearer <token>`.
+ */
+export async function loginSkvaider(options: OAuthController): Promise<string> {
+	if (!options.onPrompt) {
+		throw new Error(`${PROVIDER_ID} login requires onPrompt callback`);
+	}
+	options.onAuth?.({
+		url: AUTH_URL,
+		instructions: `Paste your Skvaider API token (bearer token from the gateway admin).\n\nTo use a custom endpoint, set SKVAIDER_BASE_URL env var before login. Default: ${DEFAULT_BASE_URL}`,
+	});
+	const apiKey = await options.onPrompt({
+		message: "Paste your Skvaider API token",
+		placeholder: DEFAULT_TOKEN,
+		allowEmpty: true,
+	});
+	if (options.signal?.aborted) {
+		throw new Error("Login cancelled");
+	}
+	const trimmed = apiKey.trim();
+	return trimmed || DEFAULT_TOKEN;
+}

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -49,6 +49,8 @@ export type OAuthProvider =
 	| "vllm"
 	| "xiaomi"
 	| "zenmux"
+	| "upb"
+	| "upb-gateway"
 	| "zai";
 
 export type OAuthProviderId = OAuthProvider | (string & {});

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -47,6 +47,7 @@ export type OAuthProvider =
 	| "venice"
 	| "vercel-ai-gateway"
 	| "vllm"
+	| "skvaider"
 	| "xiaomi"
 	| "zenmux"
 	| "upb"

--- a/packages/ai/src/utils/oauth/upb-gateway.ts
+++ b/packages/ai/src/utils/oauth/upb-gateway.ts
@@ -1,0 +1,48 @@
+/**
+ * UPB AI Gateway login flow.
+ *
+ * The UPB (Universität Paderborn) AI Gateway is a LiteLLM-based proxy at
+ * https://ai-gateway.uni-paderborn.de/v1 that routes to OpenAI, GWDG, and
+ * UPB PC2 compute backends.
+ *
+ * This is a simple API key flow — not OAuth.
+ * Keys are issued via the UPB AI-Chat portal at https://ai-chat.uni-paderborn.de
+ */
+
+import type { OAuthController } from "./types";
+
+const PORTAL_URL = "https://ai-chat.uni-paderborn.de";
+
+/**
+ * Login to the UPB AI Gateway.
+ *
+ * Opens browser to the UPB AI-Chat portal, prompts user to paste their API key.
+ * Returns the API key directly.
+ */
+export async function loginUPBGateway(options: OAuthController): Promise<string> {
+	if (!options.onPrompt) {
+		throw new Error("UPB Gateway login requires onPrompt callback");
+	}
+
+	options.onAuth?.({
+		url: PORTAL_URL,
+		instructions:
+			"Log in to the UPB AI-Chat portal, go to Settings → Account → API Keys, and create or copy your key",
+	});
+
+	const apiKey = await options.onPrompt({
+		message: "Paste your UPB AI Gateway API key",
+		placeholder: "sk-...",
+	});
+
+	if (options.signal?.aborted) {
+		throw new Error("Login cancelled");
+	}
+
+	const trimmed = apiKey.trim();
+	if (!trimmed) {
+		throw new Error("API key is required");
+	}
+
+	return trimmed;
+}

--- a/packages/ai/src/utils/oauth/upb.ts
+++ b/packages/ai/src/utils/oauth/upb.ts
@@ -1,0 +1,142 @@
+/**
+ * UPB AI-Chat portal login flow.
+ *
+ * The UPB (Universität Paderborn) AI-Chat portal at
+ * https://ai-chat.uni-paderborn.de is an Open WebUI instance that proxies
+ * requests through centrally-funded server-side keys, avoiding per-user
+ * budget limits on the raw LiteLLM gateway.
+ *
+ * Authentication is via LDAP against the university directory.
+ * The portal exposes POST /api/v1/auths/ldap which accepts
+ * { user, password } and returns a JWT Bearer token.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { $env, getAgentDir, isEnoent, isRecord } from "@oh-my-pi/pi-utils";
+import type { OAuthController } from "./types";
+
+const DEFAULT_PORTAL_URL = "https://ai-chat.uni-paderborn.de";
+const DEFAULT_API_BASE_URL = `${DEFAULT_PORTAL_URL}/api/v1`;
+
+function normalizeApiBaseUrl(value: string | undefined): string | undefined {
+	const trimmed = value?.trim();
+	if (!trimmed) return undefined;
+	return trimmed.replace(/\/+$/, "");
+}
+
+function portalUrlFromApiBaseUrl(apiBaseUrl: string): string {
+	return apiBaseUrl.endsWith("/api/v1") ? apiBaseUrl.slice(0, -"/api/v1".length) : apiBaseUrl;
+}
+
+function readConfiguredProvider(): { baseUrl?: string; proxyToken?: string } {
+	const candidates = [path.join(getAgentDir(), "models.yml"), path.join(os.homedir(), ".omp", "agent", "models.yml")];
+	for (const candidate of candidates) {
+		try {
+			const content = fs.readFileSync(candidate, "utf8");
+			const parsed = Bun.YAML.parse(content);
+			if (!isRecord(parsed)) continue;
+			const providers = parsed.providers;
+			if (!isRecord(providers)) continue;
+			const upb = providers.upb;
+			if (!isRecord(upb)) continue;
+			const baseUrl = typeof upb.baseUrl === "string" ? upb.baseUrl : undefined;
+			const headers = upb.headers;
+			const proxyToken =
+				isRecord(headers) && typeof headers["X-OMP-Proxy-Token"] === "string"
+					? headers["X-OMP-Proxy-Token"]
+					: undefined;
+			return { baseUrl, proxyToken };
+		} catch (error) {
+			if (isEnoent(error)) continue;
+		}
+	}
+	return {};
+}
+
+function resolveApiBaseUrl(configuredProvider: { baseUrl?: string }): string {
+	return (
+		normalizeApiBaseUrl($env.UPB_BASE_URL) ?? normalizeApiBaseUrl(configuredProvider.baseUrl) ?? DEFAULT_API_BASE_URL
+	);
+}
+
+function resolveProxyToken(configuredProvider: { proxyToken?: string }): string | undefined {
+	return $env.UPB_PROXY_TOKEN?.trim() || configuredProvider.proxyToken?.trim();
+}
+
+/**
+ * Login to the UPB AI-Chat portal via LDAP.
+ *
+ * Prompts for username and password, authenticates against the portal's
+ * LDAP endpoint, and returns the JWT access token.
+ */
+export async function loginUPB(options: OAuthController): Promise<string> {
+	if (!options.onPrompt) {
+		throw new Error("UPB login requires onPrompt callback");
+	}
+
+	const configuredProvider = readConfiguredProvider();
+	const apiBaseUrl = resolveApiBaseUrl(configuredProvider);
+	const proxyToken = resolveProxyToken(configuredProvider);
+	const portalUrl = portalUrlFromApiBaseUrl(apiBaseUrl);
+	const ldapAuthEndpoint = `${apiBaseUrl}/auths/ldap`;
+
+	options.onAuth?.({
+		url: portalUrl,
+		instructions: `Log in with your UPB (Universität Paderborn) LDAP account — the same credentials you use at ${new URL(portalUrl).host}`,
+	});
+
+	const username = await options.onPrompt({
+		message: "UPB username",
+		placeholder: "elikoga",
+	});
+
+	if (options.signal?.aborted) {
+		throw new Error("Login cancelled");
+	}
+
+	const password = await options.onPrompt({
+		message: "UPB password",
+	});
+
+	if (options.signal?.aborted) {
+		throw new Error("Login cancelled");
+	}
+
+	const trimmedUser = username.trim() || "elikoga";
+	const trimmedPw = password.trim();
+	if (!trimmedPw) {
+		throw new Error("Password is required");
+	}
+
+	options.onProgress?.(`Authenticating with UPB LDAP via ${ldapAuthEndpoint} (portal ${portalUrl})...`);
+
+	const response = await fetch(ldapAuthEndpoint, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Referer: `${portalUrl}/auth`,
+			Origin: portalUrl,
+			...(proxyToken ? { "X-OMP-Proxy-Token": proxyToken } : {}),
+		},
+		body: JSON.stringify({ user: trimmedUser, password: trimmedPw }),
+	});
+
+	options.onProgress?.(`UPB LDAP response: ${response.status} ${response.statusText || ""}`.trim());
+
+	if (!response.ok) {
+		const body = await response.text();
+		options.onProgress?.(`UPB LDAP failure body: ${body.slice(0, 500)}`);
+		throw new Error(`UPB LDAP authentication failed (${response.status}): ${body}`);
+	}
+
+	const data = (await response.json()) as { token: string; name?: string };
+	if (!data.token) {
+		throw new Error("UPB LDAP response did not include a token");
+	}
+
+	options.onProgress?.(`Authenticated as ${data.name ?? trimmedUser}`);
+
+	return data.token;
+}

--- a/packages/coding-agent/src/extensibility/custom-tools/loader.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/loader.ts
@@ -14,6 +14,7 @@ import type { ExecOptions } from "../../exec/exec";
 import { execCommand } from "../../exec/exec";
 import type { HookUIContext } from "../../extensibility/hooks/types";
 import { getAllPluginToolPaths } from "../../extensibility/plugins/loader";
+import { InternalUrlRouter } from "../../internal-urls";
 import * as typebox from "../typebox";
 import { createNoOpUIContext, resolvePath } from "../utils";
 import type { CustomToolAPI, CustomToolFactory, LoadedCustomTool, ToolLoadError } from "./types";
@@ -106,6 +107,7 @@ export class CustomToolLoader {
 			typebox,
 			zod: z,
 			pi,
+			internalRouter: InternalUrlRouter.instance(),
 			pushPendingAction: action => {
 				if (!pushPendingAction) {
 					throw new Error("Pending action store unavailable for custom tools in this runtime.");

--- a/packages/coding-agent/src/extensibility/custom-tools/types.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/types.ts
@@ -13,6 +13,7 @@ import type { ModelRegistry } from "../../config/model-registry";
 import type { Settings } from "../../config/settings";
 import type { ExecOptions, ExecResult } from "../../exec/exec";
 import type { HookUIContext } from "../../extensibility/hooks/types";
+import type { InternalUrlRouter } from "../../internal-urls";
 import type { Theme } from "../../modes/theme/theme";
 import type { ReadonlySessionManager } from "../../session/session-manager";
 import type { TodoItem } from "../../tools/todo-write";
@@ -57,6 +58,8 @@ export interface CustomToolAPI {
 	zod: typeof import("zod/v4");
 	/** Injected pi-coding-agent exports */
 	pi: typeof import("../..");
+	/** Internal URL router for resolving artifact://, skill://, agent://, etc. URLs */
+	internalRouter: InternalUrlRouter;
 	/** Push a preview action that can later be resolved with the hidden resolve tool */
 	pushPendingAction(action: CustomToolPendingAction): void;
 }
@@ -191,6 +194,10 @@ export interface CustomTool<TParams extends TSchema = TSchema, TDetails = any> {
 	mcpServerName?: string;
 	/** Original MCP tool name for discovery/search metadata. */
 	mcpToolName?: string;
+	/**
+	 * If true, renders without the Box container that normally adds padding and background.
+	 */
+	noBox?: boolean;
 	/**
 	 * Execute the tool.
 	 * @param toolCallId - Unique ID for this tool call

--- a/packages/coding-agent/src/index.ts
+++ b/packages/coding-agent/src/index.ts
@@ -27,6 +27,8 @@ export * from "./extensibility/skills";
 // Slash commands
 export { type FileSlashCommand, loadSlashCommands as discoverSlashCommands } from "./extensibility/slash-commands";
 export * from "./hashline";
+// Internal URL router (shared singleton for custom tools)
+export { InternalUrlRouter } from "./internal-urls";
 export type * from "./lsp";
 // Main entry point
 export * from "./main";

--- a/packages/coding-agent/src/modes/components/agent-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/agent-dashboard.ts
@@ -22,6 +22,7 @@ import {
 	Container,
 	extractPrintableText,
 	Input,
+	isKeyRelease,
 	matchesKey,
 	padding,
 	replaceTabs,
@@ -987,6 +988,8 @@ export class AgentDashboard extends Container {
 	}
 
 	handleInput(data: string): void {
+		// Ignore key-release events to prevent focus-shift ghost input.
+		if (isKeyRelease(data)) return;
 		if (matchesKey(data, "ctrl+c")) {
 			this.onClose?.();
 			return;

--- a/packages/coding-agent/src/modes/components/extensions/extension-list.ts
+++ b/packages/coding-agent/src/modes/components/extensions/extension-list.ts
@@ -8,6 +8,7 @@
 import {
 	type Component,
 	extractPrintableText,
+	isKeyRelease,
 	matchesKey,
 	padding,
 	truncateToWidth,
@@ -399,6 +400,8 @@ export class ExtensionList implements Component {
 	}
 
 	handleInput(data: string): void {
+		// Ignore key-release events to prevent focus-shift ghost input.
+		if (isKeyRelease(data)) return;
 		// Navigation
 		if (matchesKey(data, "up") || data === "k") {
 			this.#moveSelectionUp();

--- a/packages/coding-agent/src/modes/components/history-search.ts
+++ b/packages/coding-agent/src/modes/components/history-search.ts
@@ -3,6 +3,7 @@ import {
 	Container,
 	Ellipsis,
 	Input,
+	isKeyRelease,
 	matchesKey,
 	padding,
 	Spacer,
@@ -116,6 +117,8 @@ export class HistorySearchComponent extends Container {
 	}
 
 	handleInput(keyData: string): void {
+		// Ignore key-release events to prevent focus-shift ghost input.
+		if (isKeyRelease(keyData)) return;
 		if (matchesKey(keyData, "up")) {
 			if (this.#results.length === 0) return;
 			this.#selectedIndex = Math.max(0, this.#selectedIndex - 1);

--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -4,6 +4,7 @@
  */
 import {
 	Container,
+	isKeyRelease,
 	Markdown,
 	matchesKey,
 	padding,
@@ -161,6 +162,9 @@ export class HookSelectorComponent extends Container {
 	}
 
 	handleInput(keyData: string): void {
+		// Ignore key-release events to prevent focus-shift ghost input.
+		if (isKeyRelease(keyData)) return;
+
 		// Reset countdown on any interaction
 		this.#countdown?.reset();
 

--- a/packages/coding-agent/src/modes/components/mcp-add-wizard.ts
+++ b/packages/coding-agent/src/modes/components/mcp-add-wizard.ts
@@ -6,6 +6,7 @@
 import {
 	Container,
 	Input,
+	isKeyRelease,
 	matchesKey,
 	replaceTabs,
 	Spacer,
@@ -463,6 +464,8 @@ export class MCPAddWizard extends Container {
 	}
 
 	handleInput(keyData: string): void {
+		// Ignore key-release events to prevent focus-shift ghost input.
+		if (isKeyRelease(keyData)) return;
 		// Handle Ctrl+C to cancel wizard immediately
 		if (keyData === "\x03") {
 			// Ctrl+C pressed - cancel wizard

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -5,6 +5,7 @@ import {
 	fuzzyFilter,
 	getKeybindings,
 	Input,
+	isKeyRelease,
 	matchesKey,
 	Spacer,
 	type Tab,
@@ -810,6 +811,9 @@ export class ModelSelectorComponent extends Container {
 	}
 
 	handleInput(keyData: string): void {
+		// Ignore key-release events to prevent focus-shift ghost input.
+		if (isKeyRelease(keyData)) return;
+
 		if (this.#isMenuOpen) {
 			this.#handleMenuInput(keyData);
 			return;

--- a/packages/coding-agent/src/modes/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/components/oauth-selector.ts
@@ -1,6 +1,6 @@
 import { getOAuthProviders } from "@oh-my-pi/pi-ai/utils/oauth";
 import type { OAuthProviderInfo } from "@oh-my-pi/pi-ai/utils/oauth/types";
-import { Container, matchesKey, Spacer, TruncatedText } from "@oh-my-pi/pi-tui";
+import { Container, isKeyRelease, matchesKey, Spacer, TruncatedText } from "@oh-my-pi/pi-tui";
 import { theme } from "../../modes/theme/theme";
 import { matchesSelectCancel } from "../../modes/utils/keybinding-matchers";
 import type { AuthStorage } from "../../session/auth-storage";
@@ -192,6 +192,9 @@ export class OAuthSelectorComponent extends Container {
 		}
 	}
 	handleInput(keyData: string): void {
+		// Ignore Kitty key-release events: the Enter release from the /login
+		// submission can arrive after focus shifts here, causing immediate selection.
+		if (isKeyRelease(keyData)) return;
 		// Up arrow
 		if (matchesKey(keyData, "up")) {
 			if (this.#allProviders.length > 0) {

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -137,6 +137,9 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 		this.#updateDisplay();
 	}
 
+	// reads have no execution-start timing; no-op satisfies ToolExecutionHandle
+	notifyExecutionStarted(): void {}
+
 	setExpanded(expanded: boolean): void {
 		this.#expanded = expanded;
 		this.#updateDisplay();

--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -3,6 +3,7 @@ import {
 	Container,
 	fuzzyFilter,
 	Input,
+	isKeyRelease,
 	matchesKey,
 	padding,
 	replaceTabs,
@@ -182,6 +183,8 @@ class SessionList implements Component {
 	}
 
 	handleInput(keyData: string): void {
+		// Ignore key-release events to prevent focus-shift ghost input.
+		if (isKeyRelease(keyData)) return;
 		// Delete key - request delete confirmation from parent
 		if (matchesKey(keyData, "delete")) {
 			const selected = this.#filteredSessions[this.#selectedIndex];
@@ -190,7 +193,6 @@ class SessionList implements Component {
 			}
 			return;
 		}
-
 		// Up arrow
 		if (matchesKey(keyData, "up")) {
 			this.#selectedIndex = Math.max(0, this.#selectedIndex - 1);

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -3,6 +3,7 @@ import type { Effort } from "@oh-my-pi/pi-ai";
 import {
 	Container,
 	Input,
+	isKeyRelease,
 	matchesKey,
 	type SelectItem,
 	SelectList,
@@ -158,6 +159,8 @@ class SelectSubmenu extends Container {
 	}
 
 	handleInput(data: string): void {
+		// Ignore key-release events to prevent focus-shift ghost input.
+		if (isKeyRelease(data)) return;
 		this.#selectList.handleInput(data);
 	}
 }
@@ -606,6 +609,8 @@ export class SettingsSelectorComponent extends Container {
 	}
 
 	handleInput(data: string): void {
+		// Ignore key-release events to prevent focus-shift ghost input.
+		if (isKeyRelease(data)) return;
 		// Handle tab switching — but NOT when a text input is active, since
 		// arrow keys must reach the cursor and Tab must not switch tabs.
 		if (

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -197,10 +197,18 @@ export class ToolExecutionComponent extends Container {
 		this.#cwd = cwd;
 		this.#args = cloneToolArgs(args);
 
-		this.addChild(new Spacer(1));
+		const noBox = !!tool?.noBox;
+		if (!noBox) {
+			this.addChild(new Spacer(1));
+		}
 
 		// Always create both - contentBox for custom tools/bash/tools with renderers, contentText for other built-ins
-		this.#contentBox = new Box(1, 1, (text: string) => theme.bg("toolPendingBg", text));
+		if (noBox) {
+			// Render directly — no box padding, no background
+			this.#contentBox = new Box(0, 0);
+		} else {
+			this.#contentBox = new Box(1, 1, (text: string) => theme.bg("toolPendingBg", text));
+		}
 		this.#contentText = new Text("", 1, 1, (text: string) => theme.bg("toolPendingBg", text));
 
 		// Use Box for custom tools or built-in tools that have renderers
@@ -434,7 +442,8 @@ export class ToolExecutionComponent extends Container {
 			const mergeCallAndResult = Boolean((tool as { mergeCallAndResult?: boolean }).mergeCallAndResult);
 			// Custom tools use Box for flexible component rendering
 			const inline = Boolean((tool as { inline?: boolean }).inline);
-			this.#contentBox.setBgFn(inline ? undefined : bgFn);
+			const noBox = Boolean((tool as { noBox?: boolean }).noBox);
+			this.#contentBox.setBgFn(inline || noBox ? undefined : bgFn);
 			this.#contentBox.clear();
 
 			// Render call component

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -197,7 +197,7 @@ export class ToolExecutionComponent extends Container {
 		this.#cwd = cwd;
 		this.#args = cloneToolArgs(args);
 
-		const noBox = !!tool?.noBox;
+		const noBox = Boolean((tool as { noBox?: boolean })?.noBox);
 		if (!noBox) {
 			this.addChild(new Spacer(1));
 		}

--- a/packages/coding-agent/src/modes/components/tool-execution.ts
+++ b/packages/coding-agent/src/modes/components/tool-execution.ts
@@ -123,6 +123,7 @@ export interface ToolExecutionHandle {
 		toolCallId?: string,
 	): void;
 	setArgsComplete(toolCallId?: string): void;
+	notifyExecutionStarted(): void;
 	setExpanded(expanded: boolean): void;
 }
 
@@ -164,6 +165,7 @@ export class ToolExecutionComponent extends Container {
 	#spinnerInterval?: NodeJS.Timeout;
 	// Track if args are still being streamed (for edit/write spinner)
 	#argsComplete = false;
+	#executionStartTime: number | undefined;
 	#renderState: {
 		spinnerFrame?: number;
 		expanded: boolean;
@@ -231,6 +233,14 @@ export class ToolExecutionComponent extends Container {
 		this.#argsComplete = true;
 		this.#updateSpinnerAnimation();
 		void this.#runPreviewDiff();
+	}
+
+	/**
+	 * Called when the tool has actually started executing (tool_execution_start event).
+	 * More accurate than setArgsComplete() which fires at end of arg streaming.
+	 */
+	notifyExecutionStarted(): void {
+		this.#executionStartTime = Date.now();
 	}
 
 	async #runPreviewDiff(): Promise<void> {
@@ -689,11 +699,13 @@ export class ToolExecutionComponent extends Container {
 			context.expanded = this.#expanded;
 			context.previewLines = BASH_DEFAULT_PREVIEW_LINES;
 			context.timeout = normalizeTimeoutSeconds(this.#args?.timeout, 3600);
+			context.executionStartMs = this.#executionStartTime;
 		} else if (this.#toolName === "eval" && this.#result) {
 			const output = this.#getTextOutput().trimEnd();
 			context.output = output;
 			context.expanded = this.#expanded;
 			context.previewLines = EVAL_DEFAULT_PREVIEW_LINES;
+			context.executionStartMs = this.#executionStartTime;
 		} else if (isEditLikeToolName(this.#toolName)) {
 			context.editMode = this.#editMode;
 			const previews = this.#editDiffPreview;

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -4,6 +4,7 @@ import {
 	Container,
 	extractPrintableText,
 	Input,
+	isKeyRelease,
 	matchesKey,
 	Spacer,
 	Text,
@@ -710,6 +711,8 @@ class TreeList implements Component {
 	}
 
 	handleInput(keyData: string): void {
+		// Ignore key-release events to prevent focus-shift ghost input.
+		if (isKeyRelease(keyData)) return;
 		if (matchesKey(keyData, "up")) {
 			this.#selectedIndex = this.#selectedIndex === 0 ? this.#filteredNodes.length - 1 : this.#selectedIndex - 1;
 		} else if (matchesKey(keyData, "down")) {
@@ -827,6 +830,8 @@ class LabelInput implements Component {
 	}
 
 	handleInput(keyData: string): void {
+		// Ignore key-release events to prevent focus-shift ghost input.
+		if (isKeyRelease(keyData)) return;
 		if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
 			const value = this.#input.getValue().trim();
 			this.onSubmit?.(this.entryId, value || undefined);
@@ -917,6 +922,8 @@ export class TreeSelectorComponent extends Container {
 	}
 
 	handleInput(keyData: string): void {
+		// Ignore key-release events to prevent focus-shift ghost input.
+		if (isKeyRelease(keyData)) return;
 		if (this.#labelInput) {
 			this.#labelInput.handleInput(keyData);
 		} else {

--- a/packages/coding-agent/src/modes/components/user-message-selector.ts
+++ b/packages/coding-agent/src/modes/components/user-message-selector.ts
@@ -1,4 +1,4 @@
-import { type Component, Container, matchesKey, Spacer, Text, truncateToWidth } from "@oh-my-pi/pi-tui";
+import { type Component, Container, isKeyRelease, matchesKey, Spacer, Text, truncateToWidth } from "@oh-my-pi/pi-tui";
 import { theme } from "../../modes/theme/theme";
 import { matchesSelectCancel } from "../../modes/utils/keybinding-matchers";
 import { DynamicBorder } from "./dynamic-border";
@@ -77,6 +77,8 @@ class UserMessageList implements Component {
 	}
 
 	handleInput(keyData: string): void {
+		// Ignore key-release events to prevent focus-shift ghost input.
+		if (isKeyRelease(keyData)) return;
 		// Up arrow - go to previous (older) message, wrap to bottom when at top
 		if (matchesKey(keyData, "up")) {
 			this.#selectedIndex = this.#selectedIndex === 0 ? this.messages.length - 1 : this.#selectedIndex - 1;

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -3,10 +3,12 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { CompactionCancelledError, type CompactionOutcome } from "@oh-my-pi/pi-agent-core/compaction";
 import {
+	type AssistantMessage,
 	getEnvApiKey,
 	getProviderDetails,
 	type ProviderDetails,
 	type ToolCall,
+	type ToolResultMessage,
 	type UsageLimit,
 	type UsageReport,
 } from "@oh-my-pi/pi-ai";
@@ -55,6 +57,33 @@ function showMarkdownPanel(ctx: InteractiveModeContext, title: string, markdown:
 	ctx.chatContainer.addChild(new Markdown(markdown.trim(), 1, 1, getMarkdownTheme()));
 	ctx.chatContainer.addChild(new DynamicBorder());
 	ctx.ui.requestRender();
+}
+
+export interface CopyableToolResult {
+	toolName: string;
+	text: string;
+}
+
+function isTextToolResultMessage(message: unknown): message is ToolResultMessage {
+	if (!message || typeof message !== "object") return false;
+	const candidate = message as Partial<ToolResultMessage>;
+	return candidate.role === "toolResult" && Array.isArray(candidate.content);
+}
+
+export function findLastTextToolResultForCopy(messages: readonly unknown[]): CopyableToolResult | undefined {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const msg = messages[i];
+		if (!isTextToolResultMessage(msg)) continue;
+		const toolResult = msg;
+		const text = toolResult.content
+			.filter(content => content.type === "text")
+			.map(content => content.text)
+			.join("\n");
+		if (text.length > 0) {
+			return { toolName: toolResult.toolName, text };
+		}
+	}
+	return undefined;
 }
 
 export class CommandController {
@@ -242,43 +271,36 @@ export class CommandController {
 	handleCopyCommand(sub?: string) {
 		switch (sub) {
 			case "code":
-				return this.#copyCode();
+				return this.#copyLastAssistantCodeBlock();
 			case "all":
-				return this.#copyAllCode();
+				return this.#copyAllAssistantCodeBlocks();
 			case "cmd":
 				return this.#copyLastCommand();
+			case "tool":
+				return this.#copyLastToolResult();
 			case "last":
 			case undefined:
-				return this.#copyLastMessage();
+				return this.#copyLastAssistantMessage();
 			default:
-				this.ctx.showError(`Unknown subcommand: ${sub}. Use code, all, cmd, or last.`);
+				this.ctx.showError(`Unknown subcommand: ${sub}. Use code, all, cmd, tool, or last.`);
 		}
 	}
 
-	#copyLastMessage() {
-		const assistantText = this.ctx.session.getLastAssistantText();
-		if (assistantText) {
-			this.#doCopy(assistantText, "Copied last agent message to clipboard");
-			return;
-		}
-
-		if (!this.ctx.session.hasCopyCandidateAssistantMessage()) {
-			const handoffText = this.ctx.session.getLastVisibleHandoffText();
-			if (handoffText) {
-				this.#doCopy(handoffText, "Copied handoff context to clipboard");
-				return;
-			}
-		}
-
-		this.ctx.showError("No agent messages to copy yet.");
-	}
-
-	#copyCode() {
-		const text = this.ctx.session.getLastAssistantText();
+	#copyLastAssistantMessage() {
+		const message = this.ctx.findLastAssistantMessage();
+		const text = message ? this.ctx.extractAssistantText(message) : undefined;
 		if (!text) {
 			this.ctx.showError("No agent messages to copy yet.");
 			return;
 		}
+
+		this.#doCopy(text, "Copied last agent message to clipboard");
+	}
+
+	#copyLastAssistantCodeBlock() {
+		const text = this.#getLastAssistantText();
+		if (!text) return;
+
 		const matches = [...text.matchAll(/^```[^\n]*\n([\s\S]*?)^```/gm)];
 		const lastMatch = matches.at(-1);
 		if (!lastMatch) {
@@ -288,12 +310,10 @@ export class CommandController {
 		this.#doCopy(lastMatch[1].replace(/\n$/, ""), "Copied last code block to clipboard");
 	}
 
-	#copyAllCode() {
-		const text = this.ctx.session.getLastAssistantText();
-		if (!text) {
-			this.ctx.showError("No agent messages to copy yet.");
-			return;
-		}
+	#copyAllAssistantCodeBlocks() {
+		const text = this.#getLastAssistantText();
+		if (!text) return;
+
 		const matches = [...text.matchAll(/^```[^\n]*\n([\s\S]*?)^```/gm)];
 		if (matches.length === 0) {
 			this.ctx.showWarning("No code blocks found in the last agent message.");
@@ -320,13 +340,23 @@ export class CommandController {
 		return codeBlocks.length > 0 ? codeBlocks.join("\n\n") : undefined;
 	}
 
+	#copyLastToolResult() {
+		const result = findLastTextToolResultForCopy(this.ctx.session.messages);
+		if (!result) {
+			this.ctx.showWarning("No text tool result found in the conversation.");
+			return;
+		}
+
+		this.#doCopy(result.text, `Copied last ${result.toolName} result to clipboard`);
+	}
+
 	#copyLastCommand() {
 		const messages = this.ctx.session.messages;
 		// Walk backwards to find the last bash/eval tool call
 		for (let i = messages.length - 1; i >= 0; i--) {
 			const msg = messages[i];
 			if (msg.role !== "assistant") continue;
-			const toolCalls = msg.content.filter((c): c is ToolCall => c.type === "toolCall");
+			const toolCalls = (msg as AssistantMessage).content.filter((c): c is ToolCall => c.type === "toolCall");
 			for (let j = toolCalls.length - 1; j >= 0; j--) {
 				const tc = toolCalls[j];
 				if (tc.name === "bash" && typeof tc.arguments.command === "string") {
@@ -345,13 +375,19 @@ export class CommandController {
 		this.ctx.showWarning("No bash or eval command found in the conversation.");
 	}
 
-	#doCopy(content: string, label: string) {
-		try {
-			copyToClipboard(content);
-			this.ctx.showStatus(label);
-		} catch (error) {
-			this.ctx.showError(error instanceof Error ? error.message : String(error));
+	#getLastAssistantText(): string | undefined {
+		const message = this.ctx.findLastAssistantMessage();
+		const text = message ? this.ctx.extractAssistantText(message) : undefined;
+		if (!text) {
+			this.ctx.showError("No agent messages to copy yet.");
+			return undefined;
 		}
+		return text;
+	}
+
+	#doCopy(content: string, label: string) {
+		void copyToClipboard(content);
+		this.ctx.showStatus(label);
 	}
 
 	async handleSessionCommand(): Promise<void> {

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -459,6 +459,7 @@ export class EventController {
 			this.ctx.pendingTools.set(event.toolCallId, component);
 			this.ctx.ui.requestRender();
 		}
+		this.ctx.pendingTools.get(event.toolCallId)?.notifyExecutionStarted();
 	}
 
 	async #handleToolExecutionUpdate(

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -370,8 +370,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		};
 		process.stdout.on("resize", this.#resizeHandler);
 		try {
-			this.historyStorage = HistoryStorage.open();
-			this.editor.setHistoryStorage(this.historyStorage);
+			if (this.sessionManager.getSessionFile()) {
+				this.historyStorage = HistoryStorage.open();
+				this.editor.setHistoryStorage(this.historyStorage);
+			}
 		} catch (error) {
 			logger.warn("History storage unavailable", { error: String(error) });
 		}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6731,13 +6731,11 @@ export class AgentSession {
 
 	#isTransientTransportErrorMessage(errorMessage: string): boolean {
 		// Match: overloaded_error, provider returned error, rate limit, 429, 500, 502, 503, 504,
-		// service unavailable, provider-suggested retry, network/connection/socket errors, fetch failed,
-		// terminated, retry delay exceeded
+		// service unavailable, provider-suggested retry, network/connection/socket errors, fetch failed, upstream errors, terminated, retry delay exceeded
 		return (
 			isUnexpectedSocketCloseMessage(errorMessage) ||
-			/overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|retry your request|network.?error|connection.?error|connection.?refused|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay|stream stall|no error details in response/i.test(
+			/overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|retry your request|network.?error|connection.?error|connection.?refused|other side closed|fetch failed|upstream.?(connect|error)|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay|stream stall|no error details in response/i.test(
 				errorMessage,
-			)
 		);
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6736,6 +6736,7 @@ export class AgentSession {
 			isUnexpectedSocketCloseMessage(errorMessage) ||
 			/overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|retry your request|network.?error|connection.?error|connection.?refused|other side closed|fetch failed|upstream.?(connect|error)|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay|stream stall|no error details in response/i.test(
 				errorMessage,
+			)
 		);
 	}
 

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -360,12 +360,13 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 	},
 	{
 		name: "copy",
-		description: "Copy last agent message to clipboard",
+		description: "Copy exact text from the session to clipboard",
 		subcommands: [
 			{ name: "last", description: "Copy full last agent message" },
 			{ name: "code", description: "Copy last code block" },
 			{ name: "all", description: "Copy all code blocks from last message" },
 			{ name: "cmd", description: "Copy last bash/python command" },
+			{ name: "tool", description: "Copy last text tool result" },
 		],
 		allowArgs: true,
 		handleTui: async (command, runtime) => {

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -20,7 +20,14 @@ import {
 	resolveOutputSinkHeadBytes,
 	stripOutputNotice,
 } from "./output-meta";
-import { formatTitle, replaceTabs, shortenPath, truncateToWidth, wrapBrackets } from "./render-utils";
+import {
+	formatTimeoutLine,
+	formatTitle,
+	replaceTabs,
+	shortenPath,
+	truncateToWidth,
+	wrapBrackets,
+} from "./render-utils";
 import { ToolAbortError, ToolError } from "./tool-errors";
 import { toolResult } from "./tool-result";
 import { clampTimeout } from "./tool-timeouts";
@@ -573,6 +580,7 @@ interface EvalRenderContext {
 	expanded?: boolean;
 	previewLines?: number;
 	timeout?: number;
+	executionStartMs?: number;
 }
 
 interface EvalRenderCell {
@@ -915,11 +923,12 @@ export const evalToolRenderer = {
 			return [header, ...treeLines];
 		});
 
-		const timeoutSeconds = options.renderContext?.timeout;
-		const timeoutLine =
-			typeof timeoutSeconds === "number"
-				? uiTheme.fg("dim", wrapBrackets(`Timeout: ${timeoutSeconds}s`, uiTheme))
-				: undefined;
+		const timeoutLine = formatTimeoutLine(
+			options.renderContext?.timeout,
+			options.renderContext?.executionStartMs,
+			options.isPartial,
+			uiTheme,
+		);
 		let warningLine: string | undefined;
 		if (details?.meta?.truncation) {
 			warningLine = formatStyledTruncationWarning(details.meta, uiTheme) ?? undefined;

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -619,6 +619,31 @@ export function wrapBrackets(text: string, theme: Theme): string {
 	return `${theme.format.bracketLeft}${text}${theme.format.bracketRight}`;
 }
 
+const LONG_TIMEOUT_THRESHOLD_SECONDS = 30;
+
+/**
+ * Format the timeout info line for bash/python renderers.
+ * While the command is running and the timeout is long (>= 30s), shows the wall-clock
+ * time the command will expire rather than just the raw duration.
+ */
+export function formatTimeoutLine(
+	timeoutSeconds: number | undefined,
+	executionStartMs: number | undefined,
+	isPartial: boolean,
+	uiTheme: Theme,
+): string | undefined {
+	if (typeof timeoutSeconds !== "number") return undefined;
+	if (isPartial && executionStartMs !== undefined && timeoutSeconds >= LONG_TIMEOUT_THRESHOLD_SECONDS) {
+		const expiryMs = executionStartMs + timeoutSeconds * 1000;
+		const d = new Date(expiryMs);
+		const hh = d.getHours().toString().padStart(2, "0");
+		const mm = d.getMinutes().toString().padStart(2, "0");
+		const ss = d.getSeconds().toString().padStart(2, "0");
+		return uiTheme.fg("dim", wrapBrackets(`Times out at ${hh}:${mm}:${ss}`, uiTheme));
+	}
+	return uiTheme.fg("dim", wrapBrackets(`Timeout: ${timeoutSeconds}s`, uiTheme));
+}
+
 export const PARSE_ERRORS_LIMIT = 20;
 
 export function dedupeParseErrors(errors: string[] | undefined): string[] {

--- a/packages/coding-agent/test/modes/controllers/command-controller-copy.test.ts
+++ b/packages/coding-agent/test/modes/controllers/command-controller-copy.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test";
+import type { ToolResultMessage } from "@oh-my-pi/pi-ai";
+import { findLastTextToolResultForCopy } from "@oh-my-pi/pi-coding-agent/modes/controllers/command-controller";
+
+describe("findLastTextToolResultForCopy", () => {
+	it("returns exact multiline tool text without rendered whitespace or terminal controls", () => {
+		const result = findLastTextToolResultForCopy([
+			{
+				role: "toolResult",
+				toolCallId: "older",
+				toolName: "read",
+				content: [{ type: "text", text: "old" }],
+				isError: false,
+				timestamp: 1,
+			},
+			{
+				role: "toolResult",
+				toolCallId: "latest",
+				toolName: "read",
+				content: [
+					{
+						type: "text",
+						text: "const value = `line one\\nline two`;\n\treturn value;\n\x1b]133;A\x07kept literal payload",
+					},
+				],
+				isError: false,
+				timestamp: 2,
+			},
+		] satisfies ToolResultMessage[]);
+
+		expect(result).toEqual({
+			toolName: "read",
+			text: "const value = `line one\\nline two`;\n\treturn value;\n\x1b]133;A\x07kept literal payload",
+		});
+	});
+
+	it("skips image-only tool results", () => {
+		const result = findLastTextToolResultForCopy([
+			{
+				role: "toolResult",
+				toolCallId: "text",
+				toolName: "bash",
+				content: [{ type: "text", text: "stdout\nstderr" }],
+				isError: false,
+				timestamp: 1,
+			},
+			{
+				role: "toolResult",
+				toolCallId: "image",
+				toolName: "inspect_image",
+				content: [{ type: "image", data: "abc", mimeType: "image/png" }],
+				isError: false,
+				timestamp: 2,
+			},
+		] satisfies ToolResultMessage[]);
+
+		expect(result).toEqual({ toolName: "bash", text: "stdout\nstderr" });
+	});
+});

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -137,7 +137,7 @@ export class Markdown implements Component {
 	#defaultTextStyle?: DefaultTextStyle;
 	#theme: MarkdownTheme;
 	#defaultStylePrefix?: string;
-	/** Number of spaces used to indent code block content. */
+	/** Number of spaces used to indent code block content. Defaults to 0 so copied code is not prefixed with renderer-only whitespace. */
 	#codeBlockIndent: number;
 
 	// Cache for rendered output
@@ -151,7 +151,7 @@ export class Markdown implements Component {
 		paddingY: number,
 		theme: MarkdownTheme,
 		defaultTextStyle?: DefaultTextStyle,
-		codeBlockIndent: number = 2,
+		codeBlockIndent: number = 0,
 	) {
 		this.#text = text;
 		this.#paddingX = paddingX;

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -1,4 +1,5 @@
 import { getKeybindings } from "../keybindings";
+import { isKeyRelease } from "../keys";
 import type { SymbolTheme } from "../symbols";
 import type { Component } from "../tui";
 import { Ellipsis, padding, replaceTabs, truncateToWidth, visibleWidth } from "../utils";
@@ -117,6 +118,8 @@ export class SelectList implements Component {
 	}
 
 	handleInput(keyData: string): void {
+		// Ignore key-release events to prevent focus-shift ghost input.
+		if (isKeyRelease(keyData)) return;
 		if (this.#filteredItems.length === 0) return;
 		const kb = getKeybindings();
 		// Up arrow - wrap to bottom when at top

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -168,6 +168,27 @@ describe("Markdown component", () => {
 		});
 	});
 
+	describe("Code blocks", () => {
+		it("renders fenced code at the content left edge by default", () => {
+			const markdown = new Markdown(
+				`~~~typescript
+function example() {
+	return 1;
+}
+~~~`,
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+
+			const lines = markdown.render(80);
+			const plainLines = lines.map(line => line.replace(/\x1b\[[0-9;]*m/g, ""));
+
+			expect(plainLines.some(line => line.startsWith("function example() {"))).toBeTruthy();
+			expect(plainLines.some(line => line.startsWith("   return 1;"))).toBeTruthy();
+		});
+	});
+
 	describe("Tables", () => {
 		it("should render simple table", () => {
 			const markdown = new Markdown(
@@ -669,7 +690,7 @@ code block
 
 more text`,
 			];
-			const expectedLines = ["hello this is text", "", "```", "  code block", "```", "", "more text"];
+			const expectedLines = ["hello this is text", "", "```", "code block", "```", "", "more text"];
 
 			for (const text of cases) {
 				const markdown = new Markdown(text, 0, 0, defaultMarkdownTheme);
@@ -726,7 +747,7 @@ more text`,
 			});
 
 			expect(seenSources).toEqual([invalidSource]);
-			expect(plainLines).toEqual(["```mermaid", "  flowchart TD", "    A --", "```"]);
+			expect(plainLines).toEqual(["```mermaid", "flowchart TD", "  A --", "```"]);
 		});
 	});
 

--- a/python/robomp/docker-compose.yml
+++ b/python/robomp/docker-compose.yml
@@ -143,7 +143,11 @@ services:
 networks:
   # External-facing bridge: webhook ingress (8080) and the orchestrator's
   # outbound path to the host LLM gateway via extra_hosts.
-  default: {}
+  default:
+    enable_ipv6: true
+    ipam:
+      config:
+        - subnet: 2a01:4f8:1c19:3f6d:1::/80
   # Orchestrator <-> gh-proxy only. internal: true means no egress and no
   # ingress from outside the compose project.
   robomp_internal:

--- a/python/robomp/src/git_ops.py
+++ b/python/robomp/src/git_ops.py
@@ -389,11 +389,10 @@ def clone(
     token: str | None,
     safe_directory: Path | None = None,
 ) -> None:
-    """Fresh `git clone --filter=blob:none` into `target`."""
+    """Fresh `git clone` into `target`."""
     target.parent.mkdir(parents=True, exist_ok=True)
     args = [
         "clone",
-        "--filter=blob:none",
         "--no-tags",
         "--branch",
         default_branch,


### PR DESCRIPTION
Robomp fails to triage issues with:

```
fatal: could not read username for 'https://github.com': No such device or address
fatal: could not fetch ... from promisor remote
```

**Root cause**: `git clone --filter=blob:none` creates a partial clone that fetches blobs on-demand from the promisor remote. When `git worktree add` later needs blobs that weren't downloaded, it tries to fetch from GitHub without credentials (worktree add is a local operation, not routed through gh-proxy).

**Fix**: Remove `--filter=blob:none` so the initial clone downloads all objects. Subsequent worktree creation is then a purely local operation.

Trade-off: initial clone is slightly larger/slower, but this is a one-time cost per repo (pool clones are long-lived and reused across issues).