### PR TITLE
feat(ai): add native Command Code provider login

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added native Command Code support with browser-assisted `/login`, `COMMANDCODE_API_KEY` discovery, bundled Command Code models, and proprietary `/alpha/generate` streaming transport.
+
 ## [15.3.0] - 2026-05-25
 
 ### Added

--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -19,6 +19,7 @@ import {
 	linkOpenAIPromotionTargets,
 } from "../src/model-thinking";
 import prevModelsJson from "../src/models.json" with { type: "json" };
+import { COMMAND_CODE_MODELS } from "../src/provider-models/commandcode";
 import {
 	allowsUnauthenticatedCatalogDiscovery,
 	type CatalogDiscoveryConfig,
@@ -144,6 +145,11 @@ function applyGlobalModelsDevFallback(models: readonly Model[], modelsDevModels:
 	const providerScopedKeys = new Set(modelsDevModels.map(model => `${model.provider}/${model.id}`));
 	const globalReferences = createGlobalModelsDevReferenceMap(modelsDevModels);
 	return models.map(model => {
+		// Command Code exposes gateway-specific model metadata through its own catalog.
+		// Same-id models from other providers must not override those limits.
+		if (model.provider === "commandcode") {
+			return model;
+		}
 		if (providerScopedKeys.has(`${model.provider}/${model.id}`)) {
 			return model;
 		}
@@ -321,7 +327,7 @@ async function generateModels() {
 	const gitLabDuoModels = getGitLabDuoModels();
 	// Combine models (models.dev has priority)
 	let allModels = applyGlobalModelsDevFallback(
-		[...modelsDevModels, ...catalogProviderModels, ...gitLabDuoModels],
+		[...modelsDevModels, ...catalogProviderModels, ...gitLabDuoModels, ...COMMAND_CODE_MODELS],
 		modelsDevModels,
 	);
 

--- a/packages/ai/src/api-registry.ts
+++ b/packages/ai/src/api-registry.ts
@@ -26,6 +26,7 @@ const BUILTIN_APIS = new Set<KnownApi>([
 	"google-vertex",
 	"ollama-chat",
 	"cursor-agent",
+	"commandcode",
 ]);
 
 export type CustomStreamFn = (

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -29,6 +29,7 @@ import { kimiUsageProvider } from "./usage/kimi";
 import { codexRankingStrategy, openaiCodexUsageProvider } from "./usage/openai-codex";
 import { zaiUsageProvider } from "./usage/zai";
 import { getOAuthApiKey, getOAuthProvider, refreshOAuthToken } from "./utils/oauth";
+import { loginCommandCode } from "./utils/oauth/commandcode";
 import { loginDeepSeek } from "./utils/oauth/deepseek";
 import { loginOpenAICodexDevice } from "./utils/oauth/openai-codex";
 import type { OAuthController, OAuthCredentials, OAuthProvider, OAuthProviderId } from "./utils/oauth/types";
@@ -1381,6 +1382,11 @@ export class AuthStorage {
 			}
 			case "deepseek": {
 				const apiKey = await loginDeepSeek(ctrl);
+				await saveApiKeyCredential(apiKey);
+				return;
+			}
+			case "commandcode": {
+				const apiKey = await loginCommandCode(ctrl);
 				await saveApiKeyCredential(apiKey);
 				return;
 			}

--- a/packages/ai/src/cli.ts
+++ b/packages/ai/src/cli.ts
@@ -110,6 +110,7 @@ Providers:
   tavily            Tavily
   zai               Z.AI (GLM Coding Plan)
   deepseek          DeepSeek
+  commandcode       Command Code
   nanogpt           NanoGPT
   minimax-code      MiniMax Coding Plan (International)
   minimax-code-cn   MiniMax Coding Plan (China)

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -12,6 +12,7 @@ export * from "./provider-details";
 export * from "./provider-models";
 export * from "./providers/anthropic";
 export * from "./providers/azure-openai-responses";
+export * from "./providers/commandcode";
 export type * from "./providers/cursor";
 export * from "./providers/gitlab-duo";
 export type * from "./providers/google";

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -4044,6 +4044,478 @@
 			}
 		}
 	},
+	"commandcode": {
+		"claude-haiku-4-5-20251001": {
+			"id": "claude-haiku-4-5-20251001",
+			"name": "Claude Haiku 4.5 (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1,
+				"output": 5,
+				"cacheRead": 0.1,
+				"cacheWrite": 2
+			},
+			"contextWindow": 200000,
+			"maxTokens": 64000
+		},
+		"claude-opus-4-7": {
+			"id": "claude-opus-4-7",
+			"name": "Claude Opus 4.7 (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 10
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"claude-sonnet-4-6": {
+			"id": "claude-sonnet-4-6",
+			"name": "Claude Sonnet 4.6 (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 6
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"deepseek/deepseek-v4-flash": {
+			"id": "deepseek/deepseek-v4-flash",
+			"name": "DeepSeek V4 Flash (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"deepseek/deepseek-v4-pro": {
+			"id": "deepseek/deepseek-v4-pro",
+			"name": "DeepSeek V4 Pro (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"google/gemini-3.1-flash-lite": {
+			"id": "google/gemini-3.1-flash-lite",
+			"name": "Gemini 3.1 Flash Lite (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"google/gemini-3.5-flash": {
+			"id": "google/gemini-3.5-flash",
+			"name": "Gemini 3.5 Flash (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"gpt-5.3-codex": {
+			"id": "gpt-5.3-codex",
+			"name": "GPT-5.3 Codex (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 2,
+				"output": 8,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 272000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "xhigh"
+			}
+		},
+		"gpt-5.4": {
+			"id": "gpt-5.4",
+			"name": "GPT-5.4 (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "xhigh"
+			}
+		},
+		"gpt-5.4-mini": {
+			"id": "gpt-5.4-mini",
+			"name": "GPT-5.4 Mini (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.75,
+				"output": 4.5,
+				"cacheRead": 0.075,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "xhigh"
+			}
+		},
+		"gpt-5.5": {
+			"id": "gpt-5.5",
+			"name": "GPT-5.5 (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "xhigh"
+			},
+			"contextPromotionTarget": "commandcode/gpt-5.4"
+		},
+		"MiniMaxAI/MiniMax-M2.5": {
+			"id": "MiniMaxAI/MiniMax-M2.5",
+			"name": "MiniMax M2.5 (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.5,
+				"output": 2,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 65536
+		},
+		"MiniMaxAI/MiniMax-M2.7": {
+			"id": "MiniMaxAI/MiniMax-M2.7",
+			"name": "MiniMax M2.7 (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536
+		},
+		"moonshotai/Kimi-K2.5": {
+			"id": "moonshotai/Kimi-K2.5",
+			"name": "Kimi K2.5 (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 3,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 65536
+		},
+		"moonshotai/Kimi-K2.6": {
+			"id": "moonshotai/Kimi-K2.6",
+			"name": "Kimi K2.6 (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.95,
+				"output": 4,
+				"cacheRead": 0.16,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 65536
+		},
+		"Qwen/Qwen3.6-Max-Preview": {
+			"id": "Qwen/Qwen3.6-Max-Preview",
+			"name": "Qwen 3.6 Max Preview (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"Qwen/Qwen3.6-Plus": {
+			"id": "Qwen/Qwen3.6-Plus",
+			"name": "Qwen 3.6 Plus (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"Qwen/Qwen3.7-Max": {
+			"id": "Qwen/Qwen3.7-Max",
+			"name": "Qwen 3.7 Max (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"stepfun/Step-3.5-Flash": {
+			"id": "stepfun/Step-3.5-Flash",
+			"name": "Step 3.5 Flash (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"zai-org/GLM-5": {
+			"id": "zai-org/GLM-5",
+			"name": "GLM-5 (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.95,
+				"output": 3.15,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 65536
+		},
+		"zai-org/GLM-5.1": {
+			"id": "zai-org/GLM-5.1",
+			"name": "GLM-5.1 (Command Code)",
+			"api": "commandcode",
+			"provider": "commandcode",
+			"baseUrl": "https://api.commandcode.ai",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 65536
+		}
+	},
 	"cursor": {
 		"claude-4.5-opus-high": {
 			"id": "claude-4.5-opus-high",
@@ -62697,7 +63169,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888,
 			"compat": {
 				"supportsUsageInStreaming": false
@@ -62934,7 +63406,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 64000,
 			"maxTokens": 8888,
 			"compat": {
 				"supportsUsageInStreaming": false
@@ -62956,7 +63428,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 32000,
 			"maxTokens": 8888,
 			"compat": {
 				"supportsUsageInStreaming": false
@@ -63176,7 +63648,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 32000,
 			"maxTokens": 8888,
 			"compat": {
 				"supportsUsageInStreaming": false
@@ -63198,7 +63670,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 128000,
 			"maxTokens": 8888,
 			"compat": {
 				"supportsUsageInStreaming": false
@@ -63286,7 +63758,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888,
 			"compat": {
 				"supportsUsageInStreaming": false
@@ -63639,7 +64111,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 256000,
 			"maxTokens": 8888,
 			"compat": {
 				"supportsUsageInStreaming": false
@@ -64348,7 +64820,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888,
 			"compat": {
 				"supportsUsageInStreaming": false

--- a/packages/ai/src/provider-models/commandcode.ts
+++ b/packages/ai/src/provider-models/commandcode.ts
@@ -1,0 +1,86 @@
+/**
+ * Static Command Code model catalog.
+ *
+ * Command Code exposes its model catalog through its CLI/provider metadata
+ * rather than a model-list endpoint. This catalog is synchronized from the
+ * MIT-licensed provider source at github.com/ninehills/pi-commandcode-provider
+ * (models.json, revision 960d0d1f2388d039c8e8cd8f610723c2425ca92b).
+ */
+import type { ModelManagerOptions } from "../model-manager";
+import type { Model } from "../types";
+
+const COMMAND_CODE_BASE_URL = "https://api.commandcode.ai";
+const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } as const;
+const COST_BY_MODEL: Record<string, Model<"commandcode">["cost"]> = {
+	"claude-sonnet-4-6": { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 6 },
+	"claude-opus-4-7": { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 10 },
+	"claude-haiku-4-5-20251001": { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 2 },
+	"gpt-5.5": { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 0 },
+	"gpt-5.4": { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
+	"gpt-5.3-codex": { input: 2, output: 8, cacheRead: 0.5, cacheWrite: 0 },
+	"gpt-5.4-mini": { input: 0.75, output: 4.5, cacheRead: 0.075, cacheWrite: 0 },
+	"moonshotai/Kimi-K2.6": { input: 0.95, output: 4, cacheRead: 0.16, cacheWrite: 0 },
+	"moonshotai/Kimi-K2.5": { input: 0.6, output: 3, cacheRead: 0, cacheWrite: 0 },
+	"zai-org/GLM-5": { input: 0.95, output: 3.15, cacheRead: 0, cacheWrite: 0 },
+	"MiniMaxAI/MiniMax-M2.5": { input: 0.5, output: 2, cacheRead: 0, cacheWrite: 0 },
+};
+
+function model(
+	id: string,
+	name: string,
+	reasoning: boolean,
+	contextWindow: number,
+	maxTokens: number,
+): Model<"commandcode"> {
+	return {
+		id,
+		name: `${name} (Command Code)`,
+		api: "commandcode",
+		provider: "commandcode",
+		baseUrl: COMMAND_CODE_BASE_URL,
+		reasoning,
+		input: ["text"],
+		cost: COST_BY_MODEL[id] ?? { ...ZERO_COST },
+		contextWindow,
+		maxTokens,
+	};
+}
+
+export const COMMAND_CODE_MODELS: readonly Model<"commandcode">[] = [
+	model("claude-sonnet-4-6", "Claude Sonnet 4.6", true, 1_000_000, 64_000),
+	model("claude-opus-4-7", "Claude Opus 4.7", true, 1_000_000, 64_000),
+	model("claude-haiku-4-5-20251001", "Claude Haiku 4.5", false, 200_000, 64_000),
+	model("gpt-5.5", "GPT-5.5", true, 256_000, 128_000),
+	model("gpt-5.4", "GPT-5.4", true, 400_000, 128_000),
+	// OMP models Codex context as input capacity; the advertised 400K includes its 128K output budget.
+	model("gpt-5.3-codex", "GPT-5.3 Codex", true, 272_000, 128_000),
+	model("gpt-5.4-mini", "GPT-5.4 Mini", true, 400_000, 128_000),
+	model("moonshotai/Kimi-K2.6", "Kimi K2.6", false, 256_000, 65_536),
+	model("moonshotai/Kimi-K2.5", "Kimi K2.5", false, 256_000, 65_536),
+	model("zai-org/GLM-5.1", "GLM-5.1", false, 200_000, 65_536),
+	model("zai-org/GLM-5", "GLM-5", false, 200_000, 65_536),
+	model("MiniMaxAI/MiniMax-M2.7", "MiniMax M2.7", false, 1_048_576, 65_536),
+	model("MiniMaxAI/MiniMax-M2.5", "MiniMax M2.5", false, 200_000, 65_536),
+	model("deepseek/deepseek-v4-pro", "DeepSeek V4 Pro", true, 1_000_000, 384_000),
+	model("deepseek/deepseek-v4-flash", "DeepSeek V4 Flash", true, 1_000_000, 384_000),
+	model("Qwen/Qwen3.6-Max-Preview", "Qwen 3.6 Max Preview", true, 1_000_000, 65_536),
+	model("Qwen/Qwen3.6-Plus", "Qwen 3.6 Plus", true, 1_000_000, 65_536),
+	model("Qwen/Qwen3.7-Max", "Qwen 3.7 Max", true, 1_000_000, 65_536),
+	model("stepfun/Step-3.5-Flash", "Step 3.5 Flash", true, 1_000_000, 65_536),
+	model("google/gemini-3.5-flash", "Gemini 3.5 Flash", true, 1_000_000, 65_536),
+	model("google/gemini-3.1-flash-lite", "Gemini 3.1 Flash Lite", true, 1_000_000, 65_536),
+];
+
+export interface CommandCodeModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+}
+
+export function commandCodeModelManagerOptions(
+	_config: CommandCodeModelManagerConfig = {},
+): ModelManagerOptions<"commandcode"> {
+	return {
+		providerId: "commandcode",
+		staticModels: COMMAND_CODE_MODELS,
+	};
+}

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -6,6 +6,7 @@
 import type { ModelManagerOptions } from "../model-manager";
 import type { Api, KnownProvider } from "../types";
 import type { OAuthProvider } from "../utils/oauth/types";
+import { commandCodeModelManagerOptions } from "./commandcode";
 import { googleModelManagerOptions } from "./google";
 import { ollamaCloudModelManagerOptions } from "./ollama";
 import {
@@ -161,6 +162,7 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		config => deepseekModelManagerOptions(config),
 		catalog("DeepSeek", ["DEEPSEEK_API_KEY"]),
 	),
+	descriptor("commandcode", "deepseek/deepseek-v4-flash", config => commandCodeModelManagerOptions(config)),
 	descriptor("mistral", "devstral-medium-latest", config => mistralModelManagerOptions(config)),
 	catalogDescriptor(
 		"nvidia",

--- a/packages/ai/src/provider-models/index.ts
+++ b/packages/ai/src/provider-models/index.ts
@@ -1,3 +1,4 @@
+export * from "./commandcode";
 export * from "./descriptors";
 export * from "./google";
 export * from "./ollama";

--- a/packages/ai/src/providers/commandcode.ts
+++ b/packages/ai/src/providers/commandcode.ts
@@ -1,0 +1,402 @@
+/**
+ * Command Code provider transport.
+ *
+ * Command Code exposes a proprietary streaming endpoint rather than an
+ * OpenAI-compatible API. The request and event shapes here are based on the
+ * MIT-licensed community provider at github.com/ninehills/pi-commandcode-provider.
+ */
+import { extractHttpStatusFromError } from "@oh-my-pi/pi-utils";
+import { calculateCost } from "../models";
+import { getEnvApiKey } from "../stream";
+import type {
+	AssistantMessage,
+	Context,
+	Message,
+	Model,
+	StreamFunction,
+	StreamOptions,
+	Tool,
+	ToolCall,
+} from "../types";
+import { isRecord, normalizeSystemPrompts, toNumber } from "../utils";
+import { AssistantMessageEventStream } from "../utils/event-stream";
+import { notifyProviderResponse } from "../utils/provider-response";
+import { toolWireSchema } from "../utils/schema/wire";
+
+export interface CommandCodeOptions extends StreamOptions {}
+
+const DEFAULT_BASE_URL = "https://api.commandcode.ai";
+const COMMAND_CODE_MAX_OUTPUT_TOKENS = 200_000;
+
+type CommandCodeEvent = {
+	type?: string;
+	text?: unknown;
+	toolCallId?: unknown;
+	toolName?: unknown;
+	input?: unknown;
+	args?: unknown;
+	arguments?: unknown;
+	finishReason?: unknown;
+	totalUsage?: unknown;
+	error?: unknown;
+};
+
+function createEmptyOutput(model: Model<"commandcode">): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "commandcode",
+		provider: model.provider,
+		model: model.id,
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function asString(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function recordOrEmpty(value: unknown): Record<string, unknown> {
+	if (isRecord(value)) return value;
+	if (typeof value !== "string") return {};
+	try {
+		const parsed: unknown = JSON.parse(value);
+		return isRecord(parsed) ? parsed : {};
+	} catch {
+		return {};
+	}
+}
+
+function pairedToolCallIds(messages: readonly Message[]): Set<string> {
+	const calls = new Set<string>();
+	const results = new Set<string>();
+	for (const message of messages) {
+		if (message.role === "assistant") {
+			for (const content of message.content) {
+				if (content.type === "toolCall") calls.add(content.id);
+			}
+		} else if (message.role === "toolResult") {
+			results.add(message.toolCallId);
+		}
+	}
+	return new Set(Array.from(calls).filter(id => results.has(id)));
+}
+
+function toCommandCodeMessages(messages: readonly Message[]): unknown[] {
+	const pairedIds = pairedToolCallIds(messages);
+	const converted: unknown[] = [];
+	for (const message of messages) {
+		if (message.role === "user" || message.role === "developer") {
+			converted.push({ role: "user", content: message.content });
+			continue;
+		}
+		if (message.role === "assistant") {
+			const content: unknown[] = [];
+			for (const part of message.content) {
+				if (part.type === "text") {
+					content.push({ type: "text", text: part.text });
+				} else if (part.type === "thinking") {
+					content.push({ type: "reasoning", text: part.thinking });
+				}
+				if (part.type === "toolCall" && pairedIds.has(part.id)) {
+					content.push({
+						type: "tool-call",
+						toolCallId: part.id,
+						toolName: part.name,
+						input: part.arguments,
+					});
+				}
+			}
+			if (content.length > 0) converted.push({ role: "assistant", content });
+			continue;
+		}
+		if (pairedIds.has(message.toolCallId)) {
+			const value = message.content
+				.filter(part => part.type === "text")
+				.map(part => part.text)
+				.join("\n");
+			converted.push({
+				role: "tool",
+				content: [
+					{
+						type: "tool-result",
+						toolCallId: message.toolCallId,
+						toolName: message.toolName,
+						output: { type: message.isError ? "error-text" : "text", value },
+					},
+				],
+			});
+		}
+	}
+	return converted;
+}
+
+function toCommandCodeTools(tools: readonly Tool[] | undefined): unknown[] {
+	return (tools ?? []).map(tool => ({
+		type: "function",
+		name: tool.name,
+		description: tool.description,
+		input_schema: toolWireSchema(tool),
+	}));
+}
+
+function parseEventLine(line: string): CommandCodeEvent | undefined {
+	let value = line.trim();
+	if (!value || value.startsWith(":") || value.startsWith("event:")) return undefined;
+	if (value.startsWith("data:")) value = value.slice("data:".length).trim();
+	if (!value || value === "[DONE]") return undefined;
+	try {
+		const parsed: unknown = JSON.parse(value);
+		return isRecord(parsed) ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function doneReason(reason: unknown): Extract<AssistantMessage["stopReason"], "stop" | "length" | "toolUse"> {
+	if (reason === "tool-calls") return "toolUse";
+	if (reason === "length" || reason === "max_tokens" || reason === "max-tokens" || reason === "max_output_tokens") {
+		return "length";
+	}
+	return "stop";
+}
+
+function buildRequest(
+	model: Model<"commandcode">,
+	context: Context,
+	options: CommandCodeOptions,
+): Record<string, unknown> {
+	return {
+		config: {
+			workingDir: process.cwd(),
+			date: new Date().toISOString().split("T")[0],
+			environment: `${process.platform}-${process.arch}, Bun ${Bun.version}`,
+			structure: [],
+			isGitRepo: false,
+			currentBranch: "",
+			mainBranch: "",
+			gitStatus: "",
+			recentCommits: [],
+		},
+		memory: "",
+		taste: "",
+		skills: null,
+		permissionMode: "standard",
+		params: {
+			model: model.id,
+			messages: toCommandCodeMessages(context.messages),
+			tools: toCommandCodeTools(context.tools),
+			system: normalizeSystemPrompts(context.systemPrompt).join("\n\n"),
+			max_tokens: Math.min(options.maxTokens ?? model.maxTokens, COMMAND_CODE_MAX_OUTPUT_TOKENS),
+			stream: true,
+		},
+	};
+}
+
+export const streamCommandCode: StreamFunction<"commandcode"> = (
+	model: Model<"commandcode">,
+	context: Context,
+	options: CommandCodeOptions = {},
+): AssistantMessageEventStream => {
+	const stream = new AssistantMessageEventStream();
+	void (async () => {
+		const output = createEmptyOutput(model);
+		const startTime = Date.now();
+		let firstTokenTime: number | undefined;
+		let errorStatus: number | undefined;
+		let activeTextIndex: number | undefined;
+		let activeThinkingIndex: number | undefined;
+
+		const endText = (): void => {
+			if (activeTextIndex === undefined) return;
+			const part = output.content[activeTextIndex];
+			if (part?.type === "text") {
+				stream.push({ type: "text_end", contentIndex: activeTextIndex, content: part.text, partial: output });
+			}
+			activeTextIndex = undefined;
+		};
+		const endThinking = (): void => {
+			if (activeThinkingIndex === undefined) return;
+			const part = output.content[activeThinkingIndex];
+			if (part?.type === "thinking") {
+				stream.push({
+					type: "thinking_end",
+					contentIndex: activeThinkingIndex,
+					content: part.thinking,
+					partial: output,
+				});
+			}
+			activeThinkingIndex = undefined;
+		};
+		const markFirstToken = (): void => {
+			firstTokenTime ??= Date.now();
+		};
+
+		try {
+			const apiKey = options.apiKey || getEnvApiKey(model.provider);
+			if (!apiKey) throw new Error("No API key for provider: commandcode");
+
+			let body: unknown = buildRequest(model, context, options);
+			const replacementPayload = await options.onPayload?.(body, model);
+			if (replacementPayload !== undefined) body = replacementPayload;
+
+			const baseUrl = model.baseUrl?.replace(/\/+$/, "") || DEFAULT_BASE_URL;
+			const response = await (options.fetch ?? globalThis.fetch)(`${baseUrl}/alpha/generate`, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${apiKey}`,
+					"x-command-code-version": "0.24.1",
+					"x-cli-environment": "production",
+					"x-project-slug": "omp",
+					"x-taste-learning": "false",
+					"x-co-flag": "false",
+					"x-session-id": options.sessionId ?? crypto.randomUUID(),
+					...model.headers,
+					...options.headers,
+				},
+				body: JSON.stringify(body),
+				signal: options.signal,
+			});
+			await notifyProviderResponse(options, response, model);
+			if (!response.ok) {
+				errorStatus = response.status;
+				const detail = (await response.text().catch(() => "")).slice(0, 500);
+				throw new Error(`Command Code API error ${response.status}${detail ? `: ${detail}` : ""}`);
+			}
+			if (!response.body) throw new Error("Command Code returned an empty response body");
+
+			stream.push({ type: "start", partial: output });
+			const reader = response.body.getReader();
+			const decoder = new TextDecoder();
+			let buffer = "";
+			let finished = false;
+			const finish = (event: CommandCodeEvent): void => {
+				endText();
+				endThinking();
+				const usage = isRecord(event.totalUsage) ? event.totalUsage : undefined;
+				const details = usage && isRecord(usage.inputTokenDetails) ? usage.inputTokenDetails : undefined;
+				output.usage.input = toNumber(usage?.inputTokens) ?? 0;
+				output.usage.output = toNumber(usage?.outputTokens) ?? 0;
+				output.usage.cacheRead = toNumber(details?.cacheReadTokens) ?? 0;
+				output.usage.cacheWrite = toNumber(details?.cacheWriteTokens) ?? 0;
+				output.usage.totalTokens =
+					output.usage.input + output.usage.output + output.usage.cacheRead + output.usage.cacheWrite;
+				calculateCost(model, output.usage);
+				output.stopReason = doneReason(event.finishReason);
+			};
+			try {
+				while (!finished) {
+					const chunk = await reader.read();
+					if (chunk.done) break;
+					buffer += decoder.decode(chunk.value, { stream: true });
+					const lines = buffer.split("\n");
+					buffer = lines.pop() ?? "";
+					for (const line of lines) {
+						const event = parseEventLine(line);
+						if (!event) continue;
+						if (event.type === "text-delta") {
+							endThinking();
+							if (activeTextIndex === undefined) {
+								output.content.push({ type: "text", text: "" });
+								activeTextIndex = output.content.length - 1;
+								stream.push({ type: "text_start", contentIndex: activeTextIndex, partial: output });
+							}
+							const text = asString(event.text) ?? "";
+							const part = output.content[activeTextIndex];
+							if (part?.type === "text") part.text += text;
+							stream.push({ type: "text_delta", contentIndex: activeTextIndex, delta: text, partial: output });
+							markFirstToken();
+							continue;
+						}
+						if (event.type === "reasoning-delta") {
+							endText();
+							if (activeThinkingIndex === undefined) {
+								output.content.push({ type: "thinking", thinking: "" });
+								activeThinkingIndex = output.content.length - 1;
+								stream.push({ type: "thinking_start", contentIndex: activeThinkingIndex, partial: output });
+							}
+							const text = asString(event.text) ?? "";
+							const part = output.content[activeThinkingIndex];
+							if (part?.type === "thinking") part.thinking += text;
+							stream.push({
+								type: "thinking_delta",
+								contentIndex: activeThinkingIndex,
+								delta: text,
+								partial: output,
+							});
+							markFirstToken();
+							continue;
+						}
+						if (event.type === "reasoning-end") {
+							endThinking();
+							continue;
+						}
+						if (event.type === "tool-call") {
+							endText();
+							endThinking();
+							const toolCall: ToolCall = {
+								type: "toolCall",
+								id: asString(event.toolCallId) ?? crypto.randomUUID(),
+								name: asString(event.toolName) ?? "unknown_tool",
+								arguments: recordOrEmpty(event.input ?? event.args ?? event.arguments),
+							};
+							output.content.push(toolCall);
+							const index = output.content.length - 1;
+							stream.push({ type: "toolcall_start", contentIndex: index, partial: output });
+							stream.push({ type: "toolcall_end", contentIndex: index, toolCall, partial: output });
+							markFirstToken();
+							continue;
+						}
+						if (event.type === "finish") {
+							finish(event);
+							finished = true;
+							break;
+						}
+						if (event.type === "error") {
+							const error = isRecord(event.error) ? asString(event.error.message) : asString(event.error);
+							throw new Error(error ?? "Command Code stream error");
+						}
+					}
+				}
+			} finally {
+				await reader.cancel().catch(() => undefined);
+				reader.releaseLock();
+			}
+			if (!finished && buffer.trim()) {
+				const event = parseEventLine(buffer);
+				if (event?.type === "finish") {
+					finish(event);
+					finished = true;
+				}
+			}
+			if (!finished) throw new Error("Command Code stream ended before a finish event");
+			output.duration = Date.now() - startTime;
+			if (firstTokenTime !== undefined) output.ttft = firstTokenTime - startTime;
+			const reason =
+				output.stopReason === "length" ? "length" : output.stopReason === "toolUse" ? "toolUse" : "stop";
+			stream.push({ type: "done", reason, message: output });
+			stream.end();
+		} catch (error) {
+			output.stopReason = options.signal?.aborted ? "aborted" : "error";
+			output.errorStatus = errorStatus ?? extractHttpStatusFromError(error);
+			output.errorMessage =
+				output.stopReason === "aborted"
+					? "Request was aborted"
+					: String(error instanceof Error ? error.message : error);
+			output.duration = Date.now() - startTime;
+			stream.push({ type: "error", reason: output.stopReason, error: output });
+			stream.end();
+		}
+	})();
+	return stream;
+};

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -11,6 +11,7 @@ import {
 } from "./model-thinking";
 import type { BedrockOptions } from "./providers/amazon-bedrock";
 import type { AnthropicOptions } from "./providers/anthropic";
+import { streamCommandCode } from "./providers/commandcode";
 import type { CursorOptions } from "./providers/cursor";
 import { isGitLabDuoModel, streamGitLabDuo } from "./providers/gitlab-duo";
 import type { GoogleOptions } from "./providers/google";
@@ -96,6 +97,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	"opencode-zen": "OPENCODE_API_KEY",
 	cursor: "CURSOR_ACCESS_TOKEN",
 	deepseek: "DEEPSEEK_API_KEY",
+	commandcode: "COMMANDCODE_API_KEY",
 	"openai-codex": "OPENAI_CODEX_OAUTH_TOKEN",
 	"azure-openai-responses": "AZURE_OPENAI_API_KEY",
 	exa: "EXA_API_KEY",
@@ -261,6 +263,9 @@ export function stream<TApi extends Api>(
 
 		case "cursor-agent":
 			return streamCursor(model as Model<"cursor-agent">, context, providerOptions as CursorOptions);
+
+		case "commandcode":
+			return streamCommandCode(model as Model<"commandcode">, context, providerOptions);
 
 		default:
 			throw new Error(`Unhandled API: ${api}`);
@@ -857,6 +862,9 @@ function mapOptionsForApi<TApi extends Api>(
 				onToolResult,
 			});
 		}
+
+		case "commandcode":
+			return castApi<"commandcode">(base);
 
 		default:
 			throw new Error(`Unhandled API in mapOptionsForApi: ${model.api}`);

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -2,6 +2,7 @@ import type { ZodType, z } from "zod/v4";
 import type { BedrockOptions } from "./providers/amazon-bedrock";
 import type { AnthropicOptions } from "./providers/anthropic";
 import type { AzureOpenAIResponsesOptions } from "./providers/azure-openai-responses";
+import type { CommandCodeOptions } from "./providers/commandcode";
 import type { CursorOptions } from "./providers/cursor";
 import type {
 	DeleteArgs,
@@ -42,7 +43,8 @@ export type KnownApi =
 	| "google-gemini-cli"
 	| "google-vertex"
 	| "ollama-chat"
-	| "cursor-agent";
+	| "cursor-agent"
+	| "commandcode";
 export type Api = KnownApi | (string & {});
 export interface ApiOptionsMap {
 	"anthropic-messages": AnthropicOptions;
@@ -56,6 +58,7 @@ export interface ApiOptionsMap {
 	"google-vertex": GoogleVertexOptions;
 	"ollama-chat": OllamaChatOptions;
 	"cursor-agent": CursorOptions;
+	commandcode: CommandCodeOptions;
 }
 // Compile-time exhaustiveness check - this will fail if ApiOptionsMap doesn't have all KnownApi keys
 type _CheckExhaustive =
@@ -114,6 +117,7 @@ export type KnownProvider =
 	| "gitlab-duo"
 	| "cursor"
 	| "deepseek"
+	| "commandcode"
 	| "xai"
 	| "groq"
 	| "cerebras"

--- a/packages/ai/src/utils/oauth/commandcode.ts
+++ b/packages/ai/src/utils/oauth/commandcode.ts
@@ -1,0 +1,201 @@
+/**
+ * Command Code browser-assisted API-key login.
+ *
+ * Unlike OAuth code flows, Command Code Studio posts the generated API key
+ * directly to a localhost callback after authentication. Keys are stored by
+ * AuthStorage as ordinary API-key credentials because they do not refresh.
+ */
+import type { OAuthController } from "./types";
+
+const STUDIO_AUTH_URL = "https://commandcode.ai/studio/auth/cli";
+const CALLBACK_PATH = "/callback";
+const START_PORT = 5959;
+const PORT_RANGE = 10;
+const AUTH_TIMEOUT_MS = 5 * 60_000;
+const ALLOWED_ORIGINS = new Set(["https://commandcode.ai", "https://staging.commandcode.ai", "http://localhost:3000"]);
+
+export interface CommandCodeAuthCallback {
+	apiKey: string;
+	state: string;
+}
+
+export interface CommandCodeAuthServer {
+	server: Bun.Server<undefined>;
+	port: number;
+	waitForCallback: Promise<CommandCodeAuthCallback>;
+}
+
+export interface CommandCodeAuthServerOptions {
+	startPort?: number;
+	portRange?: number;
+}
+
+export interface CommandCodeLoginOptions {
+	authTimeoutMs?: number;
+	startAuthServer?: () => Promise<CommandCodeAuthServer>;
+}
+
+class CommandCodeCallbackTimeoutError extends Error {
+	constructor() {
+		super("Command Code browser authentication timed out");
+		this.name = "CommandCodeCallbackTimeoutError";
+	}
+}
+
+function responseHeaders(request: Request): Headers {
+	const headers = new Headers({ "Content-Type": "application/json" });
+	const origin = request.headers.get("origin");
+	if (origin && ALLOWED_ORIGINS.has(origin)) {
+		headers.set("Access-Control-Allow-Origin", origin);
+		headers.set("Access-Control-Allow-Methods", "POST, OPTIONS");
+		headers.set(
+			"Access-Control-Allow-Headers",
+			request.headers.get("access-control-request-headers") ?? "Content-Type",
+		);
+		headers.set("Access-Control-Allow-Private-Network", "true");
+	}
+	return headers;
+}
+
+function startServerOnPort(
+	port: number,
+	resolveCallback: (callback: CommandCodeAuthCallback) => void,
+	rejectCallback: (error: Error) => void,
+): Bun.Server<undefined> {
+	let server: Bun.Server<undefined>;
+	server = Bun.serve({
+		hostname: "127.0.0.1",
+		port,
+		fetch: async request => {
+			const url = new URL(request.url);
+			const headers = responseHeaders(request);
+			if (request.method === "OPTIONS") return new Response(null, { status: 204, headers });
+			if (url.pathname !== CALLBACK_PATH) {
+				return Response.json({ success: false, error: "Not found" }, { status: 404, headers });
+			}
+			if (request.method !== "POST") {
+				return Response.json({ success: false, error: "Method not allowed. Use POST." }, { status: 405, headers });
+			}
+			const text = await request.text();
+			if (text.length > 10_000) {
+				return Response.json({ success: false, error: "Request body too large" }, { status: 413, headers });
+			}
+			let payload: unknown;
+			try {
+				payload = JSON.parse(text);
+			} catch {
+				return Response.json({ success: false, error: "Invalid JSON" }, { status: 400, headers });
+			}
+			if (!payload || typeof payload !== "object") {
+				return Response.json({ success: false, error: "Missing required fields" }, { status: 400, headers });
+			}
+			const record = payload as Record<string, unknown>;
+			if (typeof record.error === "string") {
+				const message = typeof record.error_description === "string" ? record.error_description : record.error;
+				queueMicrotask(() => {
+					rejectCallback(new Error(message));
+					server.stop();
+				});
+				return Response.json({ success: true }, { headers });
+			}
+			const apiKey = typeof record.apiKey === "string" ? record.apiKey.trim() : "";
+			const state = typeof record.state === "string" ? record.state : "";
+			if (!apiKey || !state) {
+				return Response.json({ success: false, error: "Missing required fields" }, { status: 400, headers });
+			}
+			queueMicrotask(() => {
+				resolveCallback({ apiKey, state });
+				server.stop();
+			});
+			return Response.json({ success: true }, { headers });
+		},
+	});
+	return server;
+}
+
+export async function startCommandCodeAuthServer(
+	options: CommandCodeAuthServerOptions = {},
+): Promise<CommandCodeAuthServer> {
+	const { promise: waitForCallback, resolve, reject } = Promise.withResolvers<CommandCodeAuthCallback>();
+	const startPort = options.startPort ?? START_PORT;
+	const portRange = options.portRange ?? PORT_RANGE;
+	const attempts = startPort === 0 ? [0] : Array.from({ length: portRange }, (_, index) => startPort + index);
+	for (const port of [...attempts, 0]) {
+		try {
+			const server = startServerOnPort(port, resolve, reject);
+			const actualPort = server.port;
+			if (actualPort === undefined) {
+				server.stop(true);
+				throw new Error("Command Code callback server did not expose its listening port");
+			}
+			return { server, port: actualPort, waitForCallback };
+		} catch (error) {
+			const isAddressInUse = error instanceof Error && "code" in error && error.code === "EADDRINUSE";
+			if (port === 0 || !isAddressInUse) throw error;
+		}
+	}
+	throw new Error("Unable to start Command Code callback server");
+}
+
+export function sanitizeCommandCodeApiKey(input: string): string {
+	return input
+		.replaceAll("\u001b[200~", "")
+		.replaceAll("\u001b[201~", "")
+		.replaceAll("[200~", "")
+		.replaceAll("[201~", "")
+		.replaceAll(/[\u0000-\u001f\u007f]/g, "")
+		.trim();
+}
+
+async function promptForApiKey(ctrl: OAuthController): Promise<string> {
+	if (!ctrl.onPrompt) throw new Error("Command Code login requires an interactive prompt");
+	const apiKey = sanitizeCommandCodeApiKey(
+		await ctrl.onPrompt({ message: "Paste your Command Code API key", placeholder: "user_..." }),
+	);
+	if (!apiKey) throw new Error("Command Code API key is required");
+	return apiKey;
+}
+
+async function waitForCallback(
+	server: CommandCodeAuthServer,
+	ctrl: OAuthController,
+	authTimeoutMs: number,
+): Promise<CommandCodeAuthCallback> {
+	const timeoutSignal = AbortSignal.timeout(authTimeoutMs);
+	const signal = ctrl.signal ? AbortSignal.any([ctrl.signal, timeoutSignal]) : timeoutSignal;
+	const { promise, reject } = Promise.withResolvers<CommandCodeAuthCallback>();
+	const onAbort = (): void => {
+		reject(ctrl.signal?.aborted ? new Error("Login cancelled") : new CommandCodeCallbackTimeoutError());
+	};
+	signal.addEventListener("abort", onAbort, { once: true });
+	try {
+		return await Promise.race([server.waitForCallback, promise]);
+	} finally {
+		signal.removeEventListener("abort", onAbort);
+	}
+}
+
+export async function loginCommandCode(ctrl: OAuthController, options: CommandCodeLoginOptions = {}): Promise<string> {
+	if (ctrl.signal?.aborted) throw new Error("Login cancelled");
+	let server: CommandCodeAuthServer;
+	try {
+		server = await (options.startAuthServer ?? startCommandCodeAuthServer)();
+	} catch {
+		return promptForApiKey(ctrl);
+	}
+	const state = crypto.randomUUID();
+	const callbackUrl = `http://localhost:${server.port}${CALLBACK_PATH}`;
+	const authUrl = `${STUDIO_AUTH_URL}?callback=${encodeURIComponent(callbackUrl)}&state=${encodeURIComponent(state)}`;
+	ctrl.onAuth?.({ url: authUrl, instructions: "Sign in to Command Code in your browser to create an API key." });
+	ctrl.onProgress?.("Waiting for Command Code browser authentication...");
+	try {
+		const callback = await waitForCallback(server, ctrl, options.authTimeoutMs ?? AUTH_TIMEOUT_MS);
+		if (callback.state !== state) throw new Error("Command Code authentication state mismatch");
+		return callback.apiKey;
+	} catch (error) {
+		if (!(error instanceof CommandCodeCallbackTimeoutError)) throw error;
+		return promptForApiKey(ctrl);
+	} finally {
+		server.server.stop();
+	}
+}

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -61,6 +61,11 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		available: true,
 	},
 	{
+		id: "commandcode",
+		name: "Command Code",
+		available: true,
+	},
+	{
 		id: "fireworks",
 		name: "Fireworks",
 		available: true,

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -15,6 +15,7 @@ export type OAuthProvider =
 	| "cloudflare-ai-gateway"
 	| "cursor"
 	| "deepseek"
+	| "commandcode"
 	| "fireworks"
 	| "firepass"
 	| "github-copilot"

--- a/packages/ai/test/auth-storage-api-key-login.test.ts
+++ b/packages/ai/test/auth-storage-api-key-login.test.ts
@@ -5,6 +5,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { AuthStorage, SqliteAuthCredentialStore } from "../src/auth-storage";
+import * as commandCodeModule from "../src/utils/oauth/commandcode";
 import * as deepseekModule from "../src/utils/oauth/deepseek";
 import * as kagiModule from "../src/utils/oauth/kagi";
 import * as ollamaCloudModule from "../src/utils/oauth/ollama-cloud";
@@ -27,6 +28,7 @@ describe("AuthStorage api-key login replacement", () => {
 	let store: SqliteAuthCredentialStore | null = null;
 	let authStorage: AuthStorage | null = null;
 	let loginDeepSeekSpy: Mock<typeof deepseekModule.loginDeepSeek>;
+	let loginCommandCodeSpy: Mock<typeof commandCodeModule.loginCommandCode>;
 	let loginKagiSpy: Mock<typeof kagiModule.loginKagi>;
 	let loginOllamaCloudSpy: Mock<typeof ollamaCloudModule.loginOllamaCloud>;
 
@@ -36,6 +38,7 @@ describe("AuthStorage api-key login replacement", () => {
 		store = await SqliteAuthCredentialStore.open(dbPath);
 		authStorage = new AuthStorage(store);
 		loginDeepSeekSpy = vi.spyOn(deepseekModule, "loginDeepSeek");
+		loginCommandCodeSpy = vi.spyOn(commandCodeModule, "loginCommandCode");
 		loginKagiSpy = vi.spyOn(kagiModule, "loginKagi");
 		loginOllamaCloudSpy = vi.spyOn(ollamaCloudModule, "loginOllamaCloud");
 	});
@@ -128,5 +131,23 @@ describe("AuthStorage api-key login replacement", () => {
 		expect(stored.credential.key).toBe("same-deepseek-key");
 		expect(store.getApiKey("deepseek")).toBe("same-deepseek-key");
 		expect(await authStorage.getApiKey("deepseek", "session-deepseek-relogin")).toBe("same-deepseek-key");
+	});
+
+	it("stores Command Code login credentials as a reusable api-key credential", async () => {
+		if (!store || !authStorage || !dbPath) throw new Error("test setup failed");
+
+		loginCommandCodeSpy.mockResolvedValueOnce("same-commandcode-key").mockResolvedValueOnce("same-commandcode-key");
+
+		const controller = {
+			onAuth: () => {},
+			onPrompt: async () => "",
+		};
+
+		await authStorage.login("commandcode", controller);
+		await authStorage.login("commandcode", controller);
+
+		expect(countCredentialRows(dbPath, "commandcode")).toBe(1);
+		expect(store.getApiKey("commandcode")).toBe("same-commandcode-key");
+		expect(await authStorage.getApiKey("commandcode", "session-commandcode-relogin")).toBe("same-commandcode-key");
 	});
 });

--- a/packages/ai/test/commandcode-provider.test.ts
+++ b/packages/ai/test/commandcode-provider.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { getBundledModel } from "../src/models";
+import { COMMAND_CODE_MODELS } from "../src/provider-models/commandcode";
+import { DEFAULT_MODEL_PER_PROVIDER, PROVIDER_DESCRIPTORS } from "../src/provider-models/descriptors";
+import { streamCommandCode } from "../src/providers/commandcode";
+import { getEnvApiKey } from "../src/stream";
+import type { Context, Model } from "../src/types";
+import { getOAuthProviders } from "../src/utils/oauth";
+
+const originalApiKey = Bun.env.COMMANDCODE_API_KEY;
+
+afterEach(() => {
+	if (originalApiKey === undefined) {
+		delete Bun.env.COMMANDCODE_API_KEY;
+	} else {
+		Bun.env.COMMANDCODE_API_KEY = originalApiKey;
+	}
+});
+
+function ndjsonResponse(events: unknown[], trailingNewline = true): Response {
+	return new Response(`${events.map(event => JSON.stringify(event)).join("\n")}${trailingNewline ? "\n" : ""}`, {
+		status: 200,
+		headers: { "Content-Type": "application/x-ndjson" },
+	});
+}
+
+describe("Command Code native provider", () => {
+	it("registers native models, auth catalog metadata, and env-key discovery", () => {
+		const descriptor = PROVIDER_DESCRIPTORS.find(item => item.providerId === "commandcode");
+		expect(descriptor?.defaultModel).toBe("deepseek/deepseek-v4-flash");
+		expect(DEFAULT_MODEL_PER_PROVIDER.commandcode).toBe("deepseek/deepseek-v4-flash");
+		expect(getOAuthProviders().find(item => item.id === "commandcode")?.name).toBe("Command Code");
+
+		Bun.env.COMMANDCODE_API_KEY = "cc-test-key";
+		expect(getEnvApiKey("commandcode")).toBe("cc-test-key");
+
+		const bundled = getBundledModel("commandcode", "deepseek/deepseek-v4-flash");
+		expect(bundled?.api).toBe("commandcode");
+		expect(bundled?.baseUrl).toBe("https://api.commandcode.ai");
+		const bundledCodex = getBundledModel("commandcode", "gpt-5.3-codex");
+		expect(bundledCodex?.name).toBe("GPT-5.3 Codex (Command Code)");
+		expect(bundledCodex?.contextWindow).toBe(272_000);
+		expect(COMMAND_CODE_MODELS.find(model => model.id === "gpt-5.3-codex")?.contextWindow).toBe(272_000);
+		expect(COMMAND_CODE_MODELS.length).toBeGreaterThan(0);
+	});
+
+	it("serializes requests and consumes a final unterminated finish event", async () => {
+		const model = COMMAND_CODE_MODELS.find(item => item.id === "deepseek/deepseek-v4-flash") as Model<"commandcode">;
+		let requestBody: Record<string, unknown> | undefined;
+		const authHeaders: Array<string | null> = [];
+		const context: Context = {
+			systemPrompt: ["system one", "system two"],
+			messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
+			tools: [],
+		};
+		const stream = streamCommandCode(model, context, {
+			apiKey: "test-key",
+			maxTokens: 123,
+			sessionId: "session-test",
+			fetch: async (_input, init) => {
+				authHeaders.push(new Headers(init?.headers).get("Authorization"));
+				requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+				return ndjsonResponse(
+					[
+						{ type: "reasoning-delta", text: "thought" },
+						{ type: "reasoning-end" },
+						{ type: "text-delta", text: "answer" },
+						{
+							type: "finish",
+							finishReason: "stop",
+							totalUsage: {
+								inputTokens: 10,
+								outputTokens: 4,
+								inputTokenDetails: { cacheReadTokens: 2, cacheWriteTokens: 1 },
+							},
+						},
+					],
+					false,
+				);
+			},
+		});
+
+		const events = [];
+		for await (const event of stream) events.push(event);
+		const result = await stream.result();
+
+		expect(authHeaders[0]).toBe("Bearer test-key");
+		const params = requestBody?.params as Record<string, unknown> | undefined;
+		expect(params?.model).toBe("deepseek/deepseek-v4-flash");
+		expect(params?.system).toBe("system one\n\nsystem two");
+		expect(params?.max_tokens).toBe(123);
+		expect(events.map(event => event.type)).toEqual([
+			"start",
+			"thinking_start",
+			"thinking_delta",
+			"thinking_end",
+			"text_start",
+			"text_delta",
+			"text_end",
+			"done",
+		]);
+		expect(result.content.map(content => content.type)).toEqual(["thinking", "text"]);
+		expect(result.usage.totalTokens).toBe(17);
+	});
+
+	it("translates Command Code tool calls and finish reason", async () => {
+		const model = COMMAND_CODE_MODELS[0] as Model<"commandcode">;
+		const stream = streamCommandCode(
+			model,
+			{ messages: [], tools: [] },
+			{
+				apiKey: "test-key",
+				fetch: async () =>
+					ndjsonResponse([
+						{ type: "tool-call", toolCallId: "call-1", toolName: "read", input: '{"path":"x"}' },
+						{ type: "finish", finishReason: "tool-calls" },
+					]),
+			},
+		);
+
+		const result = await stream.result();
+		expect(result.stopReason).toBe("toolUse");
+		expect(result.content[0]).toMatchObject({
+			type: "toolCall",
+			id: "call-1",
+			name: "read",
+			arguments: { path: "x" },
+		});
+	});
+});

--- a/packages/ai/test/oauth-commandcode.test.ts
+++ b/packages/ai/test/oauth-commandcode.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "bun:test";
+import {
+	loginCommandCode,
+	sanitizeCommandCodeApiKey,
+	startCommandCodeAuthServer,
+} from "../src/utils/oauth/commandcode";
+
+describe("Command Code browser-assisted login", () => {
+	it("accepts the browser callback and returns its API key", async () => {
+		let authUrl = "";
+		const loginPromise = loginCommandCode(
+			{
+				onAuth: info => {
+					authUrl = info.url;
+				},
+				onPrompt: async () => {
+					throw new Error("manual prompt should not be used");
+				},
+			},
+			{ startAuthServer: () => startCommandCodeAuthServer({ startPort: 0 }) },
+		);
+
+		while (!authUrl) await Bun.sleep(1);
+		const url = new URL(authUrl);
+		const callback = new URL(url.searchParams.get("callback") ?? "");
+		const state = url.searchParams.get("state") ?? "";
+		const response = await fetch(callback, {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Origin: "https://commandcode.ai" },
+			body: JSON.stringify({ apiKey: "user_browser_key", state }),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await loginPromise).toBe("user_browser_key");
+	});
+
+	it("falls back to sanitized manual key input when callback transfer times out", async () => {
+		const key = await loginCommandCode(
+			{ onPrompt: async () => "\u001b[200~ user_manual_key\n\u001b[201~" },
+			{
+				authTimeoutMs: 1,
+				startAuthServer: () => startCommandCodeAuthServer({ startPort: 0 }),
+			},
+		);
+
+		expect(key).toBe("user_manual_key");
+	});
+
+	it("serves the CORS preflight expected by the Command Code browser page", async () => {
+		const authServer = await startCommandCodeAuthServer({ startPort: 0 });
+		try {
+			const response = await fetch(`http://127.0.0.1:${authServer.port}/callback`, {
+				method: "OPTIONS",
+				headers: {
+					Origin: "https://commandcode.ai",
+					"Access-Control-Request-Headers": "content-type,x-requested-with",
+				},
+			});
+			expect(response.status).toBe(204);
+			expect(response.headers.get("access-control-allow-origin")).toBe("https://commandcode.ai");
+			expect(response.headers.get("access-control-allow-private-network")).toBe("true");
+		} finally {
+			authServer.server.stop(true);
+		}
+	});
+
+	it("sanitizes bracketed paste API keys", () => {
+		expect(sanitizeCommandCodeApiKey("\u001b[200~ user_key \n\u001b[201~")).toBe("user_key");
+	});
+});

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1774,7 +1774,7 @@ export class ModelRegistry {
 	}
 	#applyHardcodedModelPolicies(models: Model<Api>[]): Model<Api>[] {
 		return models.map(model => {
-			if (model.id !== "gpt-5.4" || model.provider === "github-copilot") {
+			if (model.id !== "gpt-5.4" || model.provider === "github-copilot" || model.provider === "commandcode") {
 				return model;
 			}
 			const overrides = this.#modelOverrides.get(model.provider)?.get(model.id);

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -826,6 +826,11 @@ describe("ModelRegistry", () => {
 			expect(registry.find("openai", "gpt-5.4")?.contextWindow).toBe(1_000_000);
 		});
 
+		test("built-in Command Code gpt-5.4 keeps its gateway context window", () => {
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			expect(registry.find("commandcode", "gpt-5.4")?.contextWindow).toBe(400_000);
+		});
+
 		test("custom gpt-5.4 replacement keeps the hardcoded context window when contextWindow is omitted", () => {
 			writeRawModelsJson({
 				openai: {

--- a/packages/coding-agent/test/tools/apply-patch-renderer.test.ts
+++ b/packages/coding-agent/test/tools/apply-patch-renderer.test.ts
@@ -1,11 +1,21 @@
-import { describe, expect, it, vi } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
 import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { toolRenderers } from "@oh-my-pi/pi-coding-agent/tools/renderers";
 import type { TUI } from "@oh-my-pi/pi-tui";
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+});
 
 async function getUiTheme() {
 	await themeModule.initTheme(false, undefined, undefined, "dark", "light");


### PR DESCRIPTION
## What

- add Command Code as a native provider with proprietary `/alpha/generate` streaming, `COMMANDCODE_API_KEY` resolution, and browser-assisted `/login`
- bundle the Command Code model catalog from the MIT-licensed `ninehills/pi-commandcode-provider` reference source and preserve its gateway-specific limits
- keep `commandcode/gpt-5.4` from receiving the unrelated OpenAI 1M registry override
- initialize settings in the pre-existing `apply-patch-renderer` tests so the full local suite is self-contained instead of order-dependent

## Why

Command Code is not OpenAI-compatible: a login-only addition would store credentials without a usable native transport or model catalog. This adds the full built-in provider path following the existing OMP auth-storage, provider descriptor, model generation, and stream-dispatch patterns.

The renderer-test commit is separate (`090c9d672`) because untouched `origin/main` reproduced five local failures from accessing global settings before test setup; it is included so the required full local gate passes reliably.

`packages/ai/src/models.json` was regenerated from the generator; alongside the 21 Command Code entries, current public discovery refreshed eight existing placeholder context limits.

## Testing

- `PI_CODING_AGENT_DIR=/tmp/omp-commandcode-empty-agent bun --cwd=packages/ai run generate-models`
- `bun --cwd=packages/ai test test/commandcode-provider.test.ts test/oauth-commandcode.test.ts test/auth-storage-api-key-login.test.ts`
- `bun --cwd=packages/coding-agent test test/model-registry.test.ts test/tools/apply-patch-renderer.test.ts --only-failures`
- `bun run check`
- `GITHUB_ACTIONS='' bun run test`
- `bun run ci:test:smoke`
- source CLI authenticated discovery listed all 21 `commandcode` models with extensions disabled
- source CLI live smoke request through `commandcode/deepseek/deepseek-v4-flash` with extensions disabled and no session persisted returned the requested exact marker

---

- [x] `bun check` passes (`bun run check`)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)