### PR TITLE
fix(tui): preserve scrollback during redraws

### DIFF
--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -894,8 +894,6 @@ export class CommandController {
 		this.ctx.statusLine.setSessionStartTime(Date.now());
 		this.ctx.updateEditorTopBorder();
 		this.ctx.updateEditorBorderColor();
-		this.ctx.ui.requestRender();
-
 		this.ctx.chatContainer.clear();
 		this.ctx.pendingMessagesContainer.clear();
 		this.ctx.compactionQueuedMessages = [];
@@ -906,7 +904,7 @@ export class CommandController {
 		this.ctx.chatContainer.addChild(new Spacer(1));
 		this.ctx.chatContainer.addChild(new Text(`${theme.fg("accent", `${theme.status.success} ${label}`)}`, 1, 1));
 		await this.ctx.reloadTodos();
-		this.ctx.ui.requestRender();
+		this.ctx.ui.requestRender(true, { clearScrollback: true });
 	}
 
 	async handleClearCommand(): Promise<void> {

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -135,7 +135,7 @@ export class ExtensionUiController {
 			reload: async () => {
 				await this.ctx.session.reload();
 				this.ctx.chatContainer.clear();
-				this.ctx.renderInitialMessages();
+				this.ctx.renderInitialMessages(undefined, { clearTerminalHistory: true });
 				await this.ctx.reloadTodos();
 				this.ctx.showStatus("Reloaded session");
 			},
@@ -180,7 +180,7 @@ export class ExtensionUiController {
 					new Text(`${theme.fg("accent", `${theme.status.success} New session started`)}`, 1, 1),
 				);
 				await this.ctx.reloadTodos();
-				this.ctx.ui.requestRender();
+				this.ctx.ui.requestRender(true, { clearScrollback: true });
 
 				return { cancelled: false };
 			},
@@ -192,7 +192,7 @@ export class ExtensionUiController {
 
 				// Update UI
 				this.ctx.chatContainer.clear();
-				this.ctx.renderInitialMessages();
+				this.ctx.renderInitialMessages(undefined, { clearTerminalHistory: true });
 				await this.ctx.reloadTodos();
 				this.ctx.editor.setText(result.selectedText);
 				this.ctx.showStatus("Branched to new session");
@@ -207,7 +207,7 @@ export class ExtensionUiController {
 
 				// Update UI
 				this.ctx.chatContainer.clear();
-				this.ctx.renderInitialMessages();
+				this.ctx.renderInitialMessages(undefined, { clearTerminalHistory: true });
 				await this.ctx.reloadTodos();
 				if (result.editorText && !this.ctx.editor.getText().trim()) {
 					this.ctx.editor.setText(result.editorText);
@@ -225,7 +225,7 @@ export class ExtensionUiController {
 				}
 				setSessionTerminalTitle(this.ctx.sessionManager.getSessionName(), this.ctx.sessionManager.getCwd());
 				this.ctx.chatContainer.clear();
-				this.ctx.renderInitialMessages();
+				this.ctx.renderInitialMessages(undefined, { clearTerminalHistory: true });
 				await this.ctx.reloadTodos();
 				return { cancelled: false };
 			},
@@ -378,7 +378,7 @@ export class ExtensionUiController {
 				}
 				await this.ctx.session.reload();
 				this.ctx.chatContainer.clear();
-				this.ctx.renderInitialMessages();
+				this.ctx.renderInitialMessages(undefined, { clearTerminalHistory: true });
 				await this.ctx.reloadTodos();
 				this.ctx.showStatus("Reloaded session");
 			},
@@ -419,7 +419,7 @@ export class ExtensionUiController {
 					new Text(`${theme.fg("accent", `${theme.status.success} New session started`)}`, 1, 1),
 				);
 				await this.ctx.reloadTodos();
-				this.ctx.ui.requestRender();
+				this.ctx.ui.requestRender(true, { clearScrollback: true });
 
 				return { cancelled: false };
 			},
@@ -434,7 +434,7 @@ export class ExtensionUiController {
 
 				// Update UI
 				this.ctx.chatContainer.clear();
-				this.ctx.renderInitialMessages();
+				this.ctx.renderInitialMessages(undefined, { clearTerminalHistory: true });
 				await this.ctx.reloadTodos();
 				this.ctx.editor.setText(result.selectedText);
 				this.ctx.showStatus("Branched to new session");
@@ -452,7 +452,7 @@ export class ExtensionUiController {
 
 				// Update UI
 				this.ctx.chatContainer.clear();
-				this.ctx.renderInitialMessages();
+				this.ctx.renderInitialMessages(undefined, { clearTerminalHistory: true });
 				await this.ctx.reloadTodos();
 				if (result.editorText && !this.ctx.editor.getText().trim()) {
 					this.ctx.editor.setText(result.editorText);
@@ -472,7 +472,7 @@ export class ExtensionUiController {
 					return { cancelled: true };
 				}
 				this.ctx.chatContainer.clear();
-				this.ctx.renderInitialMessages();
+				this.ctx.renderInitialMessages(undefined, { clearTerminalHistory: true });
 				await this.ctx.reloadTodos();
 				return { cancelled: false };
 			},

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -553,7 +553,7 @@ export class SelectorController {
 					}
 
 					this.ctx.chatContainer.clear();
-					this.ctx.renderInitialMessages();
+					this.ctx.renderInitialMessages(undefined, { clearTerminalHistory: true });
 					this.ctx.editor.setText(result.selectedText);
 					done();
 					this.ctx.showStatus("Branched to new session");
@@ -664,7 +664,7 @@ export class SelectorController {
 
 						// Update UI — pass the context built by navigateTree to skip a second O(N) walk.
 						this.ctx.chatContainer.clear();
-						this.ctx.renderInitialMessages(result.sessionContext);
+						this.ctx.renderInitialMessages(result.sessionContext, { clearTerminalHistory: true });
 						await this.ctx.reloadTodos();
 						if (result.editorText && !this.ctx.editor.getText().trim()) {
 							this.ctx.editor.setText(result.editorText);
@@ -772,9 +772,9 @@ export class SelectorController {
 		this.ctx.statusLine.setSessionStartTime(Date.now());
 		this.ctx.updateEditorTopBorder();
 		this.ctx.updateEditorBorderColor();
-		this.ctx.renderInitialMessages();
+		this.ctx.renderInitialMessages(undefined, { clearTerminalHistory: true });
 		await this.ctx.reloadTodos();
-		this.ctx.ui.requestRender();
+		this.ctx.ui.requestRender(true, { clearScrollback: true });
 		return true;
 	}
 
@@ -788,7 +788,7 @@ export class SelectorController {
 
 		// Clear and re-render the chat
 		this.ctx.chatContainer.clear();
-		this.ctx.renderInitialMessages();
+		this.ctx.renderInitialMessages(undefined, { clearTerminalHistory: true });
 		await this.ctx.reloadTodos();
 		this.ctx.showStatus("Resumed session");
 	}

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -186,7 +186,10 @@ export interface InteractiveModeContext {
 		sessionContext: SessionContext,
 		options?: { updateFooter?: boolean; populateHistory?: boolean },
 	): void;
-	renderInitialMessages(prebuiltContext?: SessionContext, options?: { preserveExistingChat?: boolean }): void;
+	renderInitialMessages(
+		prebuiltContext?: SessionContext,
+		options?: { preserveExistingChat?: boolean; clearTerminalHistory?: boolean },
+	): void;
 	getUserMessageText(message: Message): string;
 	findLastAssistantMessage(): AssistantMessage | undefined;
 	extractAssistantText(message: AssistantMessage): string;

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -31,6 +31,7 @@ import { formatBytes, formatDuration } from "../../tools/render-utils";
 type TextBlock = { type: "text"; text: string };
 interface RenderInitialMessagesOptions {
 	preserveExistingChat?: boolean;
+	clearTerminalHistory?: boolean;
 }
 
 type QueuedMessages = {
@@ -489,6 +490,9 @@ export class UiHelpers {
 		if (compactionCount > 0) {
 			const times = compactionCount === 1 ? "1 time" : `${compactionCount} times`;
 			this.ctx.showStatus(`Session compacted ${times}`);
+		}
+		if (options.clearTerminalHistory) {
+			this.ctx.ui.requestRender(true, { clearScrollback: true });
 		}
 		if (preservedChatChildren && preservedChatChildren.length > 0) {
 			for (const child of preservedChatChildren) {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed `matchesKey(data, "ctrl+m")` (and the other named-key collisions: `ctrl+h`/`ctrl+i`/`ctrl+j`/`ctrl+[`) returning true for the bare `\r`/`\x08`/`\t`/`\n`/`\x1b` byte terminals send for Enter/Backspace/Tab/Escape in legacy mode. Binding a command to `Ctrl+M` no longer fires when the user presses Enter — the named key wins, and `ctrl+<colliding-letter>` matches only when the terminal disambiguates via the Kitty keyboard protocol or `modifyOtherKeys`. ([#1354](https://github.com/can1357/oh-my-pi/issues/1354))
+- Fixed full TUI redraws clearing terminal scrollback with `CSI 3 J`, preserving manual scrollback inspection while active sessions continue updating. ([#1295](https://github.com/can1357/oh-my-pi/issues/1295))
 
 ## [15.2.3] - 2026-05-22
 ### Added

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -70,6 +70,12 @@ export interface Focusable {
 	focused: boolean;
 }
 
+/** Options for scheduling a TUI render. */
+export interface RenderRequestOptions {
+	/** Clear terminal scrollback for intentional transcript replacement. */
+	clearScrollback?: boolean;
+}
+
 /** Type guard to check if a component implements Focusable */
 export function isFocusable(component: Component | null): component is Component & Focusable {
 	return component !== null && "focused" in component;
@@ -249,6 +255,7 @@ export class TUI extends Container {
 	#clearOnShrink = $flag("PI_CLEAR_ON_SHRINK"); // Clear empty rows when content shrinks (default: off)
 	#maxLinesRendered = 0; // Line count from last render, used for viewport calculation
 	#fullRedrawCount = 0;
+	#clearScrollbackOnNextRender = false;
 	#stopped = false;
 
 	// Overlay stack for modal components rendered on top of base content
@@ -583,8 +590,9 @@ export class TUI extends Container {
 		this.terminal.stop();
 	}
 
-	requestRender(force = false): void {
+	requestRender(force = false, options?: RenderRequestOptions): void {
 		if (force) {
+			this.#clearScrollbackOnNextRender ||= options?.clearScrollback === true;
 			this.#previousLines = [];
 			this.#previousWidth = -1; // -1 triggers widthChanged, forcing a full clear
 			this.#previousHeight = -1; // -1 triggers heightChanged, forcing a full clear
@@ -1062,8 +1070,10 @@ export class TUI extends Container {
 		const fullRender = (clear: boolean): void => {
 			this.#fullRedrawCount += 1;
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
-			// ED 3 clears terminal scrollback and disrupts manual scrollback inspection.
-			if (clear) buffer += "\x1b[2J\x1b[H";
+			if (clear) {
+				buffer += this.#clearScrollbackOnNextRender ? "\x1b[2J\x1b[H\x1b[3J" : "\x1b[2J\x1b[H";
+				this.#clearScrollbackOnNextRender = false;
+			}
 			for (let i = 0; i < newLines.length; i++) {
 				if (i > 0) buffer += "\r\n";
 				// Lines were pre-terminated/normalized by #applyLineResets; image

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -229,6 +229,31 @@ export class Container implements Component {
 }
 
 /**
+ * Render intent. `#planRender` decides which one a frame is, and the
+ * corresponding `#emit*` method owns the bytes written and the state update.
+ *
+ * - `noop`: no content change, only cursor may move.
+ * - `initial`: first paint after `start()` — clear viewport, emit transcript.
+ * - `sessionReplace`: caller asked for `{ clearScrollback: true }` on a forced
+ *   render — clear viewport, clear scrollback (outside multiplexers).
+ * - `historyRebuild`: width changed and offscreen rows changed — clear viewport
+ *   and scrollback so terminal history rewraps at the new width.
+ * - `viewportRepaint`: rewrite the visible viewport in place. If `appendFrom`
+ *   is set, emit those tail rows as scrollback growth first so streaming
+ *   output reaches terminal history before the corrected viewport is drawn.
+ * - `shrink`: trailing rows were dropped — clear extras inline.
+ * - `diff`: differential repaint of visible rows / append new rows below.
+ */
+type RenderIntent =
+	| { kind: "noop" }
+	| { kind: "initial" }
+	| { kind: "sessionReplace" }
+	| { kind: "historyRebuild" }
+	| { kind: "viewportRepaint"; appendFrom?: number }
+	| { kind: "shrink" }
+	| { kind: "diff"; firstChanged: number; lastChanged: number; appendedLines: boolean };
+
+/**
  * TUI - Main class for managing terminal UI with differential rendering
  */
 export class TUI extends Container {
@@ -1035,450 +1060,543 @@ export class TUI extends Container {
 		return lines;
 	}
 
+	/**
+	 * Render one frame. Composes the frame, classifies the intent, and delegates
+	 * to the matching emitter. Each emitter owns its bytes and ends with
+	 * {@link #commit}, the single state-transition point.
+	 */
 	#doRender(): void {
 		if (this.#stopped) return;
 		const width = this.terminal.columns;
 		const height = this.terminal.rows;
-		let viewportTop = Math.max(0, this.#maxLinesRendered - height);
-		let prevViewportTop = this.#viewportTopRow;
-		let hardwareCursorRow = this.#hardwareCursorRow;
-		const computeLineDiff = (targetRow: number): number => {
-			const currentScreenRow = hardwareCursorRow - prevViewportTop;
-			const targetScreenRow = targetRow - viewportTop;
-			return targetScreenRow - currentScreenRow;
-		};
 
-		// Render all components to get new lines
-		let newLines = this.render(width);
-
-		// Composite overlays into the rendered lines (before differential compare)
+		// 1. Compose the frame.
+		let lines = this.render(width);
 		if (this.overlayStack.length > 0) {
-			newLines = this.#compositeOverlays(newLines, width, height);
+			lines = this.#compositeOverlays(lines, width, height);
 		}
+		const cursorPos = this.#extractCursorPosition(lines, height);
+		lines = this.#applyLineResets(lines);
 
-		// Extract cursor position (marker must be found before diff comparison)
-		const cursorPos = this.#extractCursorPosition(newLines, height);
+		// 2. Capture transition + pre-render state before any emitter runs.
+		const prevViewportTop = this.#viewportTopRow;
+		const prevHardwareCursorRow = this.#hardwareCursorRow;
+		const widthChanged = this.#previousWidth > 0 && this.#previousWidth !== width;
+		const heightChanged = this.#previousHeight > 0 && this.#previousHeight !== height;
 
-		// Terminate every non-image line so #previousLines mirrors emitted bytes
-		// (closes SGR + OSC 8 hyperlink state). Must run after cursor extraction
-		// because the marker is embedded mid-line, and before any diff/full render
-		// path so cache comparisons stay byte-accurate.
-		newLines = this.#applyLineResets(newLines);
+		// 3. Classify intent.
+		const intent = this.#planRender(lines, widthChanged, heightChanged, prevViewportTop);
+		this.#logRedraw(intent, lines.length, height);
 
-		// Width/height changes can require viewport repainting.
-		const widthChanged = this.#previousWidth !== 0 && this.#previousWidth !== width;
-		const heightChanged = this.#previousHeight !== 0 && this.#previousHeight !== height;
-
-		// Helper to clear the viewport and render all new lines
-		const fullRender = (clear: boolean, options: { clearScrollback?: boolean } = {}): void => {
-			this.#fullRedrawCount += 1;
-			let buffer = "\x1b[?2026h"; // Begin synchronized output
-			if (clear) {
-				const clearScrollback =
-					(this.#clearScrollbackOnNextRender || options.clearScrollback === true) && !isMultiplexerSession();
-				buffer += clearScrollback ? "\x1b[2J\x1b[H\x1b[3J" : "\x1b[2J\x1b[H";
+		// 4. Execute.
+		switch (intent.kind) {
+			case "noop":
+				this.#writeCursorPosition(cursorPos, lines.length);
+				this.#viewportTopRow = Math.max(0, this.#maxLinesRendered - height);
+				this.#previousWidth = width;
+				this.#previousHeight = height;
+				return;
+			case "initial":
+				this.#emitFullPaint(lines, width, height, cursorPos, { clearViewport: true, clearScrollback: false });
+				this.#hasEverRendered = true;
+				return;
+			case "sessionReplace":
 				this.#clearScrollbackOnNextRender = false;
-			}
-			for (let i = 0; i < newLines.length; i++) {
-				if (i > 0) buffer += "\r\n";
-				// Lines were pre-terminated/normalized by #applyLineResets; image
-				// lines were left untouched there.
-				buffer += newLines[i];
-			}
-			this.#cursorRow = Math.max(0, newLines.length - 1);
-			const { seq, toRow } = this.#cursorControlSequence(cursorPos, newLines.length, this.#cursorRow);
-			this.#hardwareCursorRow = toRow;
-			buffer += seq;
-			buffer += "\x1b[?2026l"; // End synchronized output
-			this.terminal.write(buffer);
-			// Reset max lines when clearing, otherwise track growth
-			if (clear) {
-				this.#maxLinesRendered = newLines.length;
-			} else {
-				this.#maxLinesRendered = Math.max(this.#maxLinesRendered, newLines.length);
-			}
-			this.#viewportTopRow = Math.max(0, this.#maxLinesRendered - height);
-			this.#previousLines = newLines;
-			this.#previousWidth = width;
-			this.#previousHeight = height;
-		};
-
-		const debugRedraw = $flag("PI_DEBUG_REDRAW");
-		const logRedraw = (reason: string): void => {
-			if (!debugRedraw) return;
-			const logPath = getDebugLogPath();
-			const msg = `[${new Date().toISOString()}] fullRender: ${reason} (prev=${this.#previousLines.length}, new=${newLines.length}, height=${height})\n`;
-			fs.appendFileSync(logPath, msg);
-		};
-		const viewportRefresh = (): void => {
-			this.#fullRedrawCount += 1;
-			const nextViewportTop = Math.max(0, newLines.length - height);
-			let buffer = "\x1b[?2026h\x1b[H";
-
-			for (let screenRow = 0; screenRow < height; screenRow++) {
-				if (screenRow > 0) buffer += "\r\n";
-				buffer += "\x1b[2K";
-				const line = newLines[nextViewportTop + screenRow] ?? "";
-				let truncatedLine = line;
-				const isImage = TERMINAL.isImageLine(line);
-				if (!isImage && visibleWidth(line) > width) {
-					if (debugRedraw) {
-						const debugData = [
-							`[TUI Truncate] ${new Date().toISOString()}`,
-							`Line ${nextViewportTop + screenRow} truncated: ${visibleWidth(line)} > ${width}`,
-							`Content preview: ${line.slice(0, 100)}...`,
-							"",
-						].join("\n");
-						try {
-							fs.appendFileSync(getDebugLogPath(), debugData);
-						} catch {
-							// Ignore write errors - truncation should still work
-						}
-					}
-					truncatedLine = truncateToWidth(line, width, Ellipsis.Omit);
-					truncatedLine += truncatedLine.includes("\x1b]8;") ? LINE_TERMINATOR : SEGMENT_RESET;
+				this.#emitFullPaint(lines, width, height, cursorPos, {
+					clearViewport: true,
+					clearScrollback: !isMultiplexerSession(),
+				});
+				return;
+			case "historyRebuild":
+				this.#emitFullPaint(lines, width, height, cursorPos, {
+					clearViewport: true,
+					clearScrollback: !isMultiplexerSession(),
+				});
+				return;
+			case "viewportRepaint":
+				if (intent.appendFrom !== undefined) {
+					this.#emitAppendTail(lines, intent.appendFrom, height, prevViewportTop, prevHardwareCursorRow);
 				}
-				buffer += truncatedLine;
-			}
-
-			const finalCursorRow = Math.min(Math.max(0, newLines.length - 1), nextViewportTop + height - 1);
-			const { seq, toRow } = this.#cursorControlSequence(cursorPos, newLines.length, finalCursorRow);
-			this.#hardwareCursorRow = toRow;
-			buffer += seq;
-			buffer += "\x1b[?2026l";
-			this.terminal.write(buffer);
-
-			this.#cursorRow = Math.max(0, newLines.length - 1);
-			this.#maxLinesRendered = newLines.length;
-			this.#viewportTopRow = nextViewportTop;
-			this.#previousLines = newLines;
-			this.#previousWidth = width;
-			this.#previousHeight = height;
-		};
-		const appendRowsToScrollback = (start: number): void => {
-			if (start >= newLines.length) return;
-
-			let buffer = "\x1b[?2026h";
-			const currentScreenRow = Math.max(0, Math.min(height - 1, hardwareCursorRow - prevViewportTop));
-			const moveToBottom = height - 1 - currentScreenRow;
-			if (moveToBottom > 0) {
-				buffer += `\x1b[${moveToBottom}B`;
-			}
-			for (let i = start; i < newLines.length; i++) {
-				buffer += "\r\n";
-				buffer += newLines[i];
-			}
-			buffer += "\x1b[?2026l";
-			this.terminal.write(buffer);
-		};
-
-		// First-paint policy:
-		// - Initial startup (no prior render): clear the viewport before emitting
-		//   the full transcript so stale shell content is not left onscreen.
-		// - Forced reset later in the session: repaint the visible viewport only,
-		//   so we don't duplicate the transcript into terminal scrollback. The
-		//   caller can opt into clearing scrollback via `{ clearScrollback: true }`
-		//   for intentional transcript replacement (e.g. `/new`).
-		if (this.#previousLines.length === 0) {
-			logRedraw("first render");
-			if (!this.#hasEverRendered) {
-				fullRender(true);
-			} else if (this.#clearScrollbackOnNextRender) {
-				fullRender(true);
-			} else {
-				viewportRefresh();
-			}
-			this.#hasEverRendered = true;
-			return;
+				this.#emitViewportRepaint(lines, width, height, cursorPos);
+				return;
+			case "shrink":
+				this.#emitShrink(lines, width, height, cursorPos, prevHardwareCursorRow, prevViewportTop);
+				return;
+			case "diff":
+				this.#emitDiff(
+					lines,
+					width,
+					height,
+					cursorPos,
+					intent.firstChanged,
+					intent.lastChanged,
+					intent.appendedLines,
+					prevViewportTop,
+					prevHardwareCursorRow,
+				);
+				return;
 		}
+	}
+
+	/**
+	 * Map the current frame onto a single render intent. Order matters: forced
+	 * resets and session replacement short-circuit before any diff work, and
+	 * width-changed-with-offscreen edits route to {@link "historyRebuild"} so
+	 * terminal scrollback receives the new geometry.
+	 */
+	#planRender(
+		newLines: string[],
+		widthChanged: boolean,
+		heightChanged: boolean,
+		prevViewportTop: number,
+	): RenderIntent {
+		// Initial paint after start(): scrollback must keep its prior shell
+		// content, but the viewport must be cleared so stale rows do not bleed
+		// into the new UI.
+		if (!this.#hasEverRendered) return { kind: "initial" };
+
+		// Caller opted into a scrollback wipe via requestRender(true, { clearScrollback: true }).
+		if (this.#clearScrollbackOnNextRender) return { kind: "sessionReplace" };
+
+		// Forced reset (requestRender(true)) without scrollback wipe: previous
+		// lines were dropped, so no diff is possible. Repaint visible rows only
+		// — emitting the transcript here would duplicate it into scrollback.
+		if (this.#previousLines.length === 0) return { kind: "viewportRepaint" };
+
+		const diff = this.#diffLines(newLines);
+
+		if (diff.firstChanged === -1) {
+			// Content unchanged. Width change still alters wrapping geometry;
+			// height change shifts the visible window. Either needs a repaint
+			// (outside hostile environments).
+			if (widthChanged) return { kind: "viewportRepaint" };
+			if (heightChanged && !isTermuxSession() && !isMultiplexerSession()) return { kind: "viewportRepaint" };
+			return { kind: "noop" };
+		}
+
+		// Width changes alter wrapping for the whole transcript. Offscreen
+		// edits need a history rebuild so terminal scrollback receives the
+		// new geometry; pure appends fall through to the diff path so the
+		// append handler scrolls them into scrollback correctly.
+		if (widthChanged) {
+			if (diff.firstChanged < prevViewportTop) return { kind: "historyRebuild" };
+			const pureAppend = diff.appendedLines && diff.firstChanged === this.#previousLines.length;
+			if (!pureAppend) return { kind: "viewportRepaint" };
+		}
+
 		const contentGrew = newLines.length > this.#previousLines.length;
-		// Height changes need a viewport repaint to keep the visible rows aligned,
-		// but Termux changes height when the software keyboard shows or hides.
-		// In that environment, repainting causes the viewport to jump on every toggle.
+
+		// Height changes shift the visible window. Repaint when content didn't
+		// grow, but skip in Termux (software keyboard toggles height) and inside
+		// multiplexers (panes manage their own redraws).
 		if (heightChanged && !contentGrew && !isTermuxSession() && !isMultiplexerSession()) {
-			logRedraw(`terminal height changed (${this.#previousHeight} -> ${height})`);
-			viewportRefresh();
-			return;
+			return { kind: "viewportRepaint" };
 		}
 
-		// Content shrunk below the previous render and no overlays - re-render to clear empty rows
-		// (overlays need the padding, so only do this when no overlays are active)
-		// Configurable via setClearOnShrink() or PI_CLEAR_ON_SHRINK=0 env var
+		// Configurable shrink-clear: opt-in path that repaints to wipe rows the
+		// diff path would leave behind.
 		if (this.#clearOnShrink && newLines.length < this.#previousLines.length && this.overlayStack.length === 0) {
-			logRedraw(`clearOnShrink (prev=${this.#previousLines.length}, new=${newLines.length})`);
-			viewportRefresh();
-			return;
+			return { kind: "viewportRepaint" };
 		}
 
-		// Find first and last changed lines
+		// Pure trailing shrink: all changed indices live past the new tail.
+		if (diff.firstChanged >= newLines.length) {
+			return { kind: "shrink" };
+		}
+
+		// Offscreen edit: viewport repaint corrects the shifted rows. If new
+		// rows also appended in the same frame, emit them as scrollback growth
+		// first so streaming output is not lost from terminal history.
+		if (diff.firstChanged < prevViewportTop) {
+			const appendFrom = diff.appendedLines ? this.#findAppendedTailStart(newLines) : undefined;
+			return { kind: "viewportRepaint", appendFrom };
+		}
+
+		return {
+			kind: "diff",
+			firstChanged: diff.firstChanged,
+			lastChanged: diff.lastChanged,
+			appendedLines: diff.appendedLines,
+		};
+	}
+
+	/**
+	 * Two-pointer diff over `#previousLines` and `newLines`. `firstChanged` is
+	 * `-1` when the two are identical; otherwise it is the first differing
+	 * index. Trailing appends are normalized so `lastChanged` always ends at the
+	 * last row that needs to be touched.
+	 */
+	#diffLines(newLines: string[]): { firstChanged: number; lastChanged: number; appendedLines: boolean } {
 		let firstChanged = -1;
 		let lastChanged = -1;
 		const maxLines = Math.max(newLines.length, this.#previousLines.length);
 		for (let i = 0; i < maxLines; i++) {
 			const oldLine = i < this.#previousLines.length ? this.#previousLines[i] : "";
 			const newLine = i < newLines.length ? newLines[i] : "";
-
 			if (oldLine !== newLine) {
-				if (firstChanged === -1) {
-					firstChanged = i;
-				}
+				if (firstChanged === -1) firstChanged = i;
 				lastChanged = i;
 			}
 		}
 		const appendedLines = newLines.length > this.#previousLines.length;
 		if (appendedLines) {
-			if (firstChanged === -1) {
-				firstChanged = this.#previousLines.length;
-			}
+			if (firstChanged === -1) firstChanged = this.#previousLines.length;
 			lastChanged = newLines.length - 1;
 		}
-		const findAppendedTailStart = (): number => {
-			if (!appendedLines || this.#previousLines.length === 0) return newLines.length;
+		return { firstChanged, lastChanged, appendedLines };
+	}
 
-			const previousLast = this.#previousLines[this.#previousLines.length - 1];
-			let bestEnd = -1;
-			let bestLength = 0;
-			for (let end = newLines.length - 1; end >= 0; end--) {
-				if (newLines[end] !== previousLast) continue;
-
-				let length = 1;
-				while (
-					length < this.#previousLines.length &&
-					end - length >= 0 &&
-					this.#previousLines[this.#previousLines.length - 1 - length] === newLines[end - length]
-				) {
-					length += 1;
-				}
-				if (length > bestLength) {
-					bestLength = length;
-					bestEnd = end;
-				}
+	/**
+	 * Locate the longest suffix of `#previousLines` that appears in `newLines`.
+	 * The returned index is the first row past that suffix — the rows that are
+	 * "new appends" relative to the unchanged tail. Used to push streaming
+	 * output into scrollback even when an offscreen edit also moved rows.
+	 */
+	#findAppendedTailStart(newLines: string[]): number {
+		if (this.#previousLines.length === 0) return newLines.length;
+		const previousLast = this.#previousLines[this.#previousLines.length - 1];
+		let bestEnd = -1;
+		let bestLength = 0;
+		for (let end = newLines.length - 1; end >= 0; end--) {
+			if (newLines[end] !== previousLast) continue;
+			let length = 1;
+			while (
+				length < this.#previousLines.length &&
+				end - length >= 0 &&
+				this.#previousLines[this.#previousLines.length - 1 - length] === newLines[end - length]
+			) {
+				length += 1;
 			}
-
-			return bestEnd === -1 ? newLines.length : bestEnd + 1;
-		};
-
-		// No changes - but still need to update hardware cursor position if it moved.
-		if (firstChanged === -1) {
-			if (widthChanged) {
-				logRedraw(`terminal width changed (${this.#previousWidth} -> ${width})`);
-				viewportRefresh();
-				return;
+			if (length > bestLength) {
+				bestLength = length;
+				bestEnd = end;
 			}
-			this.#writeCursorPosition(cursorPos, newLines.length);
-			this.#viewportTopRow = Math.max(0, this.#maxLinesRendered - height);
-			this.#previousWidth = width;
-			this.#previousHeight = height;
+		}
+		return bestEnd === -1 ? newLines.length : bestEnd + 1;
+	}
+
+	/**
+	 * Truncate a line to the visible viewport width. Image lines are left
+	 * alone, narrow lines pass through unchanged. Truncation re-appends the
+	 * per-line terminator so SGR/OSC 8 state does not leak across rows when
+	 * `truncateToWidth` drops the trailing bytes appended by
+	 * {@link #applyLineResets}.
+	 */
+	#fitLineToWidth(line: string, width: number): string {
+		if (TERMINAL.isImageLine(line)) return line;
+		if (visibleWidth(line) <= width) return line;
+		const truncated = truncateToWidth(line, width, Ellipsis.Omit);
+		return truncated + (truncated.includes("\x1b]8;") ? LINE_TERMINATOR : SEGMENT_RESET);
+	}
+
+	/**
+	 * Single state-transition point. Every emitter calls this exactly once at
+	 * the end so cursor/viewport/scrollback accounting stays consistent.
+	 */
+	#commit(lines: string[], width: number, height: number, viewportTop: number, hardwareCursorRow: number): void {
+		this.#previousLines = lines;
+		this.#previousWidth = width;
+		this.#previousHeight = height;
+		this.#cursorRow = Math.max(0, lines.length - 1);
+		this.#viewportTopRow = viewportTop;
+		this.#hardwareCursorRow = hardwareCursorRow;
+	}
+
+	/**
+	 * Clear the viewport (optionally scrollback) and emit the full transcript.
+	 * Backs `initial`, `sessionReplace`, and `historyRebuild` intents.
+	 */
+	#emitFullPaint(
+		lines: string[],
+		width: number,
+		height: number,
+		cursorPos: { row: number; col: number } | null,
+		options: { clearViewport: boolean; clearScrollback: boolean },
+	): void {
+		this.#fullRedrawCount += 1;
+		let buffer = "\x1b[?2026h";
+		if (options.clearViewport) {
+			buffer += options.clearScrollback ? "\x1b[2J\x1b[H\x1b[3J" : "\x1b[2J\x1b[H";
+		}
+		for (let i = 0; i < lines.length; i++) {
+			if (i > 0) buffer += "\r\n";
+			buffer += lines[i];
+		}
+		const finalRow = Math.max(0, lines.length - 1);
+		const { seq, toRow } = this.#cursorControlSequence(cursorPos, lines.length, finalRow);
+		buffer += seq;
+		buffer += "\x1b[?2026l";
+		this.terminal.write(buffer);
+
+		this.#maxLinesRendered = options.clearViewport ? lines.length : Math.max(this.#maxLinesRendered, lines.length);
+		this.#commit(lines, width, height, Math.max(0, this.#maxLinesRendered - height), toRow);
+	}
+
+	/**
+	 * Rewrite the visible viewport in place. Cursor home, clear each row,
+	 * emit the bottom-anchored slice of `lines`. No scrollback growth.
+	 */
+	#emitViewportRepaint(
+		lines: string[],
+		width: number,
+		height: number,
+		cursorPos: { row: number; col: number } | null,
+	): void {
+		this.#fullRedrawCount += 1;
+		const viewportTop = Math.max(0, lines.length - height);
+		let buffer = "\x1b[?2026h\x1b[H";
+		for (let screenRow = 0; screenRow < height; screenRow++) {
+			if (screenRow > 0) buffer += "\r\n";
+			buffer += "\x1b[2K";
+			const line = lines[viewportTop + screenRow] ?? "";
+			buffer += this.#fitLineToWidth(line, width);
+		}
+		const finalRow = Math.min(Math.max(0, lines.length - 1), viewportTop + height - 1);
+		const { seq, toRow } = this.#cursorControlSequence(cursorPos, lines.length, finalRow);
+		buffer += seq;
+		buffer += "\x1b[?2026l";
+		this.terminal.write(buffer);
+
+		this.#maxLinesRendered = lines.length;
+		this.#commit(lines, width, height, viewportTop, toRow);
+	}
+
+	/**
+	 * Push the appended tail into terminal scrollback by `\r\n`-ing past the
+	 * previous viewport bottom. Used as a prefix to {@link #emitViewportRepaint}
+	 * when an offscreen edit and an append land in the same frame; does not
+	 * call {@link #commit} (the following repaint owns final state).
+	 */
+	#emitAppendTail(
+		lines: string[],
+		start: number,
+		height: number,
+		prevViewportTop: number,
+		prevHardwareCursorRow: number,
+	): void {
+		if (start >= lines.length) return;
+		let buffer = "\x1b[?2026h";
+		const currentScreenRow = Math.max(0, Math.min(height - 1, prevHardwareCursorRow - prevViewportTop));
+		const moveToBottom = height - 1 - currentScreenRow;
+		if (moveToBottom > 0) buffer += `\x1b[${moveToBottom}B`;
+		for (let i = start; i < lines.length; i++) {
+			buffer += "\r\n";
+			buffer += lines[i];
+		}
+		buffer += "\x1b[?2026l";
+		this.terminal.write(buffer);
+	}
+
+	/**
+	 * Trailing-shrink: prior content shared a prefix with the new content; the
+	 * extra rows below the new tail need to be cleared without scrolling. Falls
+	 * back to {@link #emitViewportRepaint} when more rows must be cleared than
+	 * fit on screen.
+	 */
+	#emitShrink(
+		lines: string[],
+		width: number,
+		height: number,
+		cursorPos: { row: number; col: number } | null,
+		prevHardwareCursorRow: number,
+		prevViewportTop: number,
+	): void {
+		const extraLines = this.#previousLines.length - lines.length;
+		if (extraLines <= 0) {
+			this.#commit(lines, width, height, Math.max(0, lines.length - height), prevHardwareCursorRow);
+			this.#maxLinesRendered = lines.length;
+			return;
+		}
+		if (extraLines > height) {
+			this.#emitViewportRepaint(lines, width, height, cursorPos);
 			return;
 		}
 
-		// Width changes alter wrapping for the whole transcript. If offscreen
-		// rows changed, rebuild the terminal history with the new width; leaving
-		// the old scrollback copy in place keeps historical components stale.
-		// Pure appends can keep the append path because there is no older
-		// width-dependent row to refresh.
-		if (widthChanged) {
-			logRedraw(`terminal width changed (${this.#previousWidth} -> ${width})`);
-			const pureAppend = appendedLines && firstChanged === this.#previousLines.length;
-			if (firstChanged < prevViewportTop) {
-				fullRender(true, { clearScrollback: true });
-				return;
-			}
-			if (!pureAppend) {
-				viewportRefresh();
-				return;
-			}
+		const viewportTop = Math.max(0, this.#maxLinesRendered - height);
+		const targetRow = Math.max(0, lines.length - 1);
+
+		let buffer = "\x1b[?2026h";
+
+		const currentScreenRow = prevHardwareCursorRow - prevViewportTop;
+		const targetScreenRow = targetRow - viewportTop;
+		const lineDiff = targetScreenRow - currentScreenRow;
+		if (lineDiff > 0) buffer += `\x1b[${lineDiff}B`;
+		else if (lineDiff < 0) buffer += `\x1b[${-lineDiff}A`;
+		buffer += "\r";
+
+		const clearStartOffset = lines.length > 0 ? 1 : 0;
+		if (clearStartOffset > 0) {
+			buffer += `\x1b[${clearStartOffset}B`;
+		}
+		for (let i = 0; i < extraLines; i++) {
+			buffer += "\r\x1b[2K";
+			if (i < extraLines - 1) buffer += "\x1b[1B";
+		}
+		const moveUp = extraLines - 1 + clearStartOffset;
+		if (moveUp > 0) {
+			buffer += `\x1b[${moveUp}A`;
 		}
 
-		// All changes are in deleted lines (nothing to render, just clear)
-		if (firstChanged >= newLines.length) {
-			if (this.#previousLines.length > newLines.length) {
-				let buffer = "\x1b[?2026h";
-				// Move to end of new content (clamp to 0 for empty content)
-				const targetRow = Math.max(0, newLines.length - 1);
-				const lineDiff = computeLineDiff(targetRow);
-				if (lineDiff > 0) buffer += `\x1b[${lineDiff}B`;
-				else if (lineDiff < 0) buffer += `\x1b[${-lineDiff}A`;
-				buffer += "\r";
-				// Clear extra lines without scrolling
-				const extraLines = this.#previousLines.length - newLines.length;
-				if (extraLines > height) {
-					logRedraw(`extraLines > height (${extraLines} > ${height})`);
-					viewportRefresh();
-					return;
-				}
-				const clearStartOffset = newLines.length > 0 && extraLines > 0 ? 1 : 0;
-				if (clearStartOffset > 0) {
-					buffer += `\x1b[${clearStartOffset}B`;
-				}
-				for (let i = 0; i < extraLines; i++) {
-					buffer += "\r\x1b[2K";
-					if (i < extraLines - 1) buffer += "\x1b[1B";
-				}
-				const moveUp = extraLines - 1 + clearStartOffset;
-				if (moveUp > 0) {
-					buffer += `\x1b[${moveUp}A`;
-				}
-				this.#cursorRow = targetRow;
-				const { seq, toRow } = this.#cursorControlSequence(cursorPos, newLines.length, targetRow);
-				this.#hardwareCursorRow = toRow;
-				buffer += seq;
-				buffer += "\x1b[?2026l";
-				this.terminal.write(buffer);
-			}
-			this.#previousLines = newLines;
-			this.#previousWidth = width;
-			this.#previousHeight = height;
-			this.#maxLinesRendered = newLines.length;
-			this.#viewportTopRow = Math.max(0, newLines.length - height);
-			return;
-		}
+		const { seq, toRow } = this.#cursorControlSequence(cursorPos, lines.length, targetRow);
+		buffer += seq;
+		buffer += "\x1b[?2026l";
+		this.terminal.write(buffer);
 
-		// Differential rendering can only touch what was actually visible. Repaint
-		// the visible viewport when earlier scrollback changes; treating the frame
-		// as append-only can leave shifted rows stale when edits and appends land
-		// together. If this frame also appended rows, emit only that appended tail
-		// first so the terminal's own scrollback still receives streaming output.
-		if (firstChanged < prevViewportTop) {
-			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
-			appendRowsToScrollback(findAppendedTailStart());
-			viewportRefresh();
-			return;
-		}
+		this.#maxLinesRendered = lines.length;
+		this.#commit(lines, width, height, Math.max(0, lines.length - height), toRow);
+	}
+
+	/**
+	 * Differential rewrite from `firstChanged` through `lastChanged`. Handles
+	 * three sub-shapes: pure append below the prior viewport (scroll + write),
+	 * in-place replace of visible rows, and replace-plus-trailing-shrink (clear
+	 * extras after writing). Cursor math is local to this method.
+	 */
+	#emitDiff(
+		lines: string[],
+		width: number,
+		height: number,
+		cursorPos: { row: number; col: number } | null,
+		firstChanged: number,
+		lastChanged: number,
+		appendedLines: boolean,
+		prevViewportTop: number,
+		prevHardwareCursorRow: number,
+	): void {
+		let viewportTop = Math.max(0, this.#maxLinesRendered - height);
+		let hardwareCursorRow = prevHardwareCursorRow;
+		let activeViewportTop = prevViewportTop;
 
 		const appendStart = appendedLines && firstChanged === this.#previousLines.length && firstChanged > 0;
-
-		// Render from first changed line to end
-		// Build buffer with all updates wrapped in synchronized output
-		let buffer = "\x1b[?2026h"; // Begin synchronized output
-		const prevViewportBottom = prevViewportTop + height - 1;
 		const moveTargetRow = appendStart ? firstChanged - 1 : firstChanged;
+
+		let buffer = "\x1b[?2026h";
+
+		// Scroll-down branch: target row is past the bottom of the previous
+		// viewport (a pure append). Emit `\r\n`s so the terminal pushes the
+		// existing viewport into scrollback before we start writing.
+		const prevViewportBottom = activeViewportTop + height - 1;
 		if (moveTargetRow > prevViewportBottom) {
-			const currentScreenRow = Math.max(0, Math.min(height - 1, hardwareCursorRow - prevViewportTop));
+			const currentScreenRow = Math.max(0, Math.min(height - 1, hardwareCursorRow - activeViewportTop));
 			const moveToBottom = height - 1 - currentScreenRow;
-			if (moveToBottom > 0) {
-				buffer += `\x1b[${moveToBottom}B`;
-			}
+			if (moveToBottom > 0) buffer += `\x1b[${moveToBottom}B`;
 			const scroll = moveTargetRow - prevViewportBottom;
 			buffer += "\r\n".repeat(scroll);
-			prevViewportTop += scroll;
+			activeViewportTop += scroll;
 			viewportTop += scroll;
 			hardwareCursorRow = moveTargetRow;
 		}
 
-		// Move cursor to first changed line (use hardwareCursorRow for actual position)
-		const lineDiff = computeLineDiff(moveTargetRow);
-		if (lineDiff > 0) {
-			buffer += `\x1b[${lineDiff}B`; // Move down
-		} else if (lineDiff < 0) {
-			buffer += `\x1b[${-lineDiff}A`; // Move up
-		}
+		// Position cursor at the row we need to start writing from.
+		const currentScreenRow = hardwareCursorRow - activeViewportTop;
+		const targetScreenRow = moveTargetRow - viewportTop;
+		const lineDiff = targetScreenRow - currentScreenRow;
+		if (lineDiff > 0) buffer += `\x1b[${lineDiff}B`;
+		else if (lineDiff < 0) buffer += `\x1b[${-lineDiff}A`;
+		buffer += appendStart ? "\r\n" : "\r";
 
-		buffer += appendStart ? "\r\n" : "\r"; // Move to column 0
-
-		// Only render changed lines (firstChanged to lastChanged), not all lines to end
-		// This reduces flicker when only a single line changes (e.g., spinner animation)
-		const renderEnd = Math.min(lastChanged, newLines.length - 1);
+		// Repaint only firstChanged..lastChanged, not all rows to the end.
+		// This bounds flicker for single-row updates (e.g. spinner ticks).
+		const renderEnd = Math.min(lastChanged, lines.length - 1);
 		for (let i = firstChanged; i <= renderEnd; i++) {
 			if (i > firstChanged) buffer += "\r\n";
-			buffer += "\x1b[2K"; // Clear current line
-			const line = newLines[i];
-			let truncatedLine = line;
-			const isImage = TERMINAL.isImageLine(line);
-			if (!isImage && visibleWidth(line) > width) {
-				if (debugRedraw) {
-					const debugData = [
-						`[TUI Truncate] ${new Date().toISOString()}`,
-						`Line ${i} truncated: ${visibleWidth(line)} > ${width}`,
-						`Content preview: ${line.slice(0, 100)}...`,
-						"",
-					].join("\n");
-					try {
-						fs.appendFileSync(getDebugLogPath(), debugData);
-					} catch {
-						// Ignore write errors - truncation should still work
-					}
-				}
-				truncatedLine = truncateToWidth(line, width, Ellipsis.Omit);
-				// Re-append the terminator: truncateToWidth removes trailing
-				// content past the visible-width budget, which may also drop the
-				// terminator appended by #applyLineResets. Match the conditional
-				// OSC 8 close strategy used there.
-				truncatedLine += truncatedLine.includes("\x1b]8;") ? LINE_TERMINATOR : SEGMENT_RESET;
-			}
-			// Non-image lines are pre-terminated/normalized by #applyLineResets;
-			// truncated lines re-append LINE_TERMINATOR above.
-			buffer += truncatedLine;
+			buffer += "\x1b[2K";
+			buffer += this.#fitLineToWidth(lines[i], width);
 		}
 
-		// Track where cursor ended up after rendering
+		// If the prior frame was taller, clear the trailing rows.
 		let finalCursorRow = renderEnd;
-
-		// If we had more lines before, clear them and move cursor back
-		if (this.#previousLines.length > newLines.length) {
-			// Move to end of new content first if we stopped before it
-			if (renderEnd < newLines.length - 1) {
-				const moveDown = newLines.length - 1 - renderEnd;
+		if (this.#previousLines.length > lines.length) {
+			if (renderEnd < lines.length - 1) {
+				const moveDown = lines.length - 1 - renderEnd;
 				buffer += `\x1b[${moveDown}B`;
-				finalCursorRow = newLines.length - 1;
+				finalCursorRow = lines.length - 1;
 			}
-			const extraLines = this.#previousLines.length - newLines.length;
-			for (let i = newLines.length; i < this.#previousLines.length; i++) {
+			const extraLines = this.#previousLines.length - lines.length;
+			for (let i = lines.length; i < this.#previousLines.length; i++) {
 				buffer += "\r\n\x1b[2K";
 			}
-			// Move cursor back to end of new content
 			buffer += `\x1b[${extraLines}A`;
 		}
 
-		const { seq, toRow } = this.#cursorControlSequence(cursorPos, newLines.length, finalCursorRow);
-		this.#hardwareCursorRow = toRow;
+		const { seq, toRow } = this.#cursorControlSequence(cursorPos, lines.length, finalCursorRow);
 		buffer += seq;
-		buffer += "\x1b[?2026l"; // End synchronized output
+		buffer += "\x1b[?2026l";
 
-		if ($flag("PI_TUI_DEBUG")) {
-			const debugDir = "/tmp/tui";
-			fs.mkdirSync(debugDir, { recursive: true });
-			const debugPath = path.join(debugDir, `render-${Date.now()}-${Math.random().toString(36).slice(2)}.log`);
-			const debugData = [
-				`firstChanged: ${firstChanged}`,
-				`viewportTop: ${viewportTop}`,
-				`cursorRow: ${this.#cursorRow}`,
-				`height: ${height}`,
-				`lineDiff: ${lineDiff}`,
-				`hardwareCursorRow: ${hardwareCursorRow}`,
-				`hardwareCursorRow (post): ${this.#hardwareCursorRow}`,
-				`renderEnd: ${renderEnd}`,
-				`finalCursorRow: ${finalCursorRow}`,
-				`cursorPos: ${JSON.stringify(cursorPos)}`,
-				`newLines.length: ${newLines.length}`,
-				`previousLines.length: ${this.#previousLines.length}`,
-				"",
-				"=== newLines ===",
-				JSON.stringify(newLines, null, 2),
-				"",
-				"=== previousLines ===",
-				JSON.stringify(this.#previousLines, null, 2),
-				"",
-				"=== buffer ===",
-				JSON.stringify(buffer),
-			].join("\n");
-			fs.writeFileSync(debugPath, debugData);
-		}
-
-		// Write entire buffer at once
+		this.#writeDiffDebug(
+			lines,
+			firstChanged,
+			viewportTop,
+			height,
+			lineDiff,
+			hardwareCursorRow,
+			renderEnd,
+			finalCursorRow,
+			cursorPos,
+			toRow,
+			buffer,
+		);
 		this.terminal.write(buffer);
 
-		// Track cursor position for next render.
-		// cursorRow tracks end of content (for viewport calculation).
-		// #hardwareCursorRow was already updated by #cursorControlSequence above.
-		this.#cursorRow = Math.max(0, newLines.length - 1);
-		// Track content height for viewport calculation
-		this.#maxLinesRendered = newLines.length;
-		this.#viewportTopRow = Math.max(0, newLines.length - height);
+		this.#maxLinesRendered = lines.length;
+		this.#commit(lines, width, height, Math.max(0, lines.length - height), toRow);
+	}
 
-		this.#previousLines = newLines;
-		this.#previousWidth = width;
-		this.#previousHeight = height;
+	/** Optional intent log under PI_DEBUG_REDRAW. */
+	#logRedraw(intent: RenderIntent, newLength: number, height: number): void {
+		if (!$flag("PI_DEBUG_REDRAW")) return;
+		const detail =
+			intent.kind === "diff"
+				? `${intent.kind}(first=${intent.firstChanged}, last=${intent.lastChanged}, appended=${intent.appendedLines})`
+				: intent.kind === "viewportRepaint" && intent.appendFrom !== undefined
+					? `${intent.kind}(appendFrom=${intent.appendFrom})`
+					: intent.kind;
+		const msg = `[${new Date().toISOString()}] render: ${detail} (prev=${this.#previousLines.length}, new=${newLength}, height=${height})\n`;
+		fs.appendFileSync(getDebugLogPath(), msg);
+	}
+
+	/** Optional per-render dump under PI_TUI_DEBUG; isolated so #emitDiff stays readable. */
+	#writeDiffDebug(
+		lines: string[],
+		firstChanged: number,
+		viewportTop: number,
+		height: number,
+		lineDiff: number,
+		hardwareCursorRow: number,
+		renderEnd: number,
+		finalCursorRow: number,
+		cursorPos: { row: number; col: number } | null,
+		toRow: number,
+		buffer: string,
+	): void {
+		if (!$flag("PI_TUI_DEBUG")) return;
+		const debugDir = "/tmp/tui";
+		fs.mkdirSync(debugDir, { recursive: true });
+		const debugPath = path.join(debugDir, `render-${Date.now()}-${Math.random().toString(36).slice(2)}.log`);
+		const debugData = [
+			`firstChanged: ${firstChanged}`,
+			`viewportTop: ${viewportTop}`,
+			`cursorRow: ${this.#cursorRow}`,
+			`height: ${height}`,
+			`lineDiff: ${lineDiff}`,
+			`hardwareCursorRow: ${hardwareCursorRow}`,
+			`hardwareCursorRow (post): ${toRow}`,
+			`renderEnd: ${renderEnd}`,
+			`finalCursorRow: ${finalCursorRow}`,
+			`cursorPos: ${JSON.stringify(cursorPos)}`,
+			`newLines.length: ${lines.length}`,
+			`previousLines.length: ${this.#previousLines.length}`,
+			"",
+			"=== newLines ===",
+			JSON.stringify(lines, null, 2),
+			"",
+			"=== previousLines ===",
+			JSON.stringify(this.#previousLines, null, 2),
+			"",
+			"=== buffer ===",
+			JSON.stringify(buffer),
+		].join("\n");
+		fs.writeFileSync(debugPath, debugData);
 	}
 
 	/**

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -135,7 +135,9 @@ function isTermuxSession(): boolean {
 }
 
 /** Detect terminal multiplexers where scrollback clearing and height-change redraws are hostile. */
-const isMultiplexer = Boolean(Bun.env.TMUX || Bun.env.STY || Bun.env.ZELLIJ);
+function isMultiplexerSession(): boolean {
+	return Boolean(Bun.env.TMUX || Bun.env.STY || Bun.env.ZELLIJ);
+}
 
 /**
  * Options for overlay positioning and sizing.
@@ -1072,7 +1074,8 @@ export class TUI extends Container {
 			this.#fullRedrawCount += 1;
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
 			if (clear) {
-				buffer += this.#clearScrollbackOnNextRender ? "\x1b[2J\x1b[H\x1b[3J" : "\x1b[2J\x1b[H";
+				const clearScrollback = this.#clearScrollbackOnNextRender && !isMultiplexerSession();
+				buffer += clearScrollback ? "\x1b[2J\x1b[H\x1b[3J" : "\x1b[2J\x1b[H";
 				this.#clearScrollbackOnNextRender = false;
 			}
 			for (let i = 0; i < newLines.length; i++) {
@@ -1172,19 +1175,10 @@ export class TUI extends Container {
 			return;
 		}
 		const contentGrew = newLines.length > this.#previousLines.length;
-
-		// Width changes need a viewport repaint because wrapping changes. If new
-		// rows also arrived, keep the append path so history reaches scrollback.
-		if (widthChanged && !contentGrew) {
-			logRedraw(`terminal width changed (${this.#previousWidth} -> ${width})`);
-			viewportRefresh();
-			return;
-		}
-
 		// Height changes need a viewport repaint to keep the visible rows aligned,
 		// but Termux changes height when the software keyboard shows or hides.
 		// In that environment, repainting causes the viewport to jump on every toggle.
-		if (heightChanged && !contentGrew && !isTermuxSession() && !isMultiplexer) {
+		if (heightChanged && !contentGrew && !isTermuxSession() && !isMultiplexerSession()) {
 			logRedraw(`terminal height changed (${this.#previousHeight} -> ${height})`);
 			viewportRefresh();
 			return;
@@ -1221,11 +1215,35 @@ export class TUI extends Container {
 			}
 			lastChanged = newLines.length - 1;
 		}
-		// No changes - but still need to update hardware cursor position if it moved
+		// No changes - but still need to update hardware cursor position if it moved.
 		if (firstChanged === -1) {
+			if (widthChanged) {
+				logRedraw(`terminal width changed (${this.#previousWidth} -> ${width})`);
+				viewportRefresh();
+				return;
+			}
 			this.#writeCursorPosition(cursorPos, newLines.length);
 			this.#viewportTopRow = Math.max(0, this.#maxLinesRendered - height);
+			this.#previousWidth = width;
+			this.#previousHeight = height;
 			return;
+		}
+
+		// Width changes alter wrapping for the whole transcript. If offscreen
+		// rows changed, replay the rendered transcript so scrollback receives
+		// the new width. Pure appends can keep the append path because there is
+		// no older width-dependent row to refresh.
+		if (widthChanged) {
+			logRedraw(`terminal width changed (${this.#previousWidth} -> ${width})`);
+			const pureAppend = appendedLines && firstChanged === this.#previousLines.length;
+			if (firstChanged < prevViewportTop) {
+				fullRender(true);
+				return;
+			}
+			if (!pureAppend) {
+				viewportRefresh();
+				return;
+			}
 		}
 
 		// All changes are in deleted lines (nothing to render, just clear)

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1376,7 +1376,11 @@ export class TUI extends Container {
 	): void {
 		if (start >= lines.length) return;
 		let buffer = "\x1b[?2026h";
-		const currentScreenRow = Math.max(0, Math.min(height - 1, prevHardwareCursorRow - prevViewportTop));
+		// Clamp tracked cursor to the visible viewport bottom — terminals clamp
+		// on resize, so a prior frame may have committed a row that no longer
+		// exists. Without this the scroll math points outside the viewport.
+		const clampedCursor = Math.min(prevHardwareCursorRow, prevViewportTop + height - 1);
+		const currentScreenRow = Math.max(0, Math.min(height - 1, clampedCursor - prevViewportTop));
 		const moveToBottom = height - 1 - currentScreenRow;
 		if (moveToBottom > 0) buffer += `\x1b[${moveToBottom}B`;
 		for (let i = start; i < lines.length; i++) {
@@ -1417,7 +1421,8 @@ export class TUI extends Container {
 
 		let buffer = "\x1b[?2026h";
 
-		const currentScreenRow = prevHardwareCursorRow - prevViewportTop;
+		const clampedCursor = Math.min(prevHardwareCursorRow, prevViewportTop + height - 1);
+		const currentScreenRow = clampedCursor - prevViewportTop;
 		const targetScreenRow = targetRow - viewportTop;
 		const lineDiff = targetScreenRow - currentScreenRow;
 		if (lineDiff > 0) buffer += `\x1b[${lineDiff}B`;
@@ -1464,8 +1469,11 @@ export class TUI extends Container {
 		prevHardwareCursorRow: number,
 	): void {
 		let viewportTop = Math.max(0, this.#maxLinesRendered - height);
-		let hardwareCursorRow = prevHardwareCursorRow;
 		let activeViewportTop = prevViewportTop;
+		// Terminals clamp the hardware cursor to the visible viewport on resize.
+		// If our tracked row is past the viewport bottom, the real cursor was
+		// clamped; clamp our tracking to match so relative moves land correctly.
+		let hardwareCursorRow = Math.min(prevHardwareCursorRow, activeViewportTop + height - 1);
 
 		const appendStart = appendedLines && firstChanged === this.#previousLines.length && firstChanged > 0;
 		const moveTargetRow = appendStart ? firstChanged - 1 : firstChanged;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -256,6 +256,7 @@ export class TUI extends Container {
 	#maxLinesRendered = 0; // Line count from last render, used for viewport calculation
 	#fullRedrawCount = 0;
 	#clearScrollbackOnNextRender = false;
+	#hasEverRendered = false;
 	#stopped = false;
 
 	// Overlay stack for modal components rendered on top of base content
@@ -1151,11 +1152,23 @@ export class TUI extends Container {
 			this.#previousHeight = height;
 		};
 
-		// First render outputs the full transcript so terminal scrollback contains
-		// the initial TUI state. Forced first renders still clear only the viewport.
+		// First-paint policy:
+		// - Initial startup (no prior render): emit the full transcript so terminal
+		//   scrollback receives the initial UI state.
+		// - Forced reset later in the session: repaint the visible viewport only,
+		//   so we don't duplicate the transcript into terminal scrollback. The
+		//   caller can opt into clearing scrollback via `{ clearScrollback: true }`
+		//   for intentional transcript replacement (e.g. `/new`).
 		if (this.#previousLines.length === 0) {
 			logRedraw("first render");
-			fullRender(widthChanged || heightChanged);
+			if (!this.#hasEverRendered) {
+				fullRender(false);
+			} else if (this.#clearScrollbackOnNextRender) {
+				fullRender(true);
+			} else {
+				viewportRefresh();
+			}
+			this.#hasEverRendered = true;
 			return;
 		}
 		const contentGrew = newLines.length > this.#previousLines.length;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1154,6 +1154,22 @@ export class TUI extends Container {
 			this.#previousWidth = width;
 			this.#previousHeight = height;
 		};
+		const appendRowsToScrollback = (start: number): void => {
+			if (start >= newLines.length) return;
+
+			let buffer = "\x1b[?2026h";
+			const currentScreenRow = Math.max(0, Math.min(height - 1, hardwareCursorRow - prevViewportTop));
+			const moveToBottom = height - 1 - currentScreenRow;
+			if (moveToBottom > 0) {
+				buffer += `\x1b[${moveToBottom}B`;
+			}
+			for (let i = start; i < newLines.length; i++) {
+				buffer += "\r\n";
+				buffer += newLines[i];
+			}
+			buffer += "\x1b[?2026l";
+			this.terminal.write(buffer);
+		};
 
 		// First-paint policy:
 		// - Initial startup (no prior render): emit the full transcript so terminal
@@ -1215,6 +1231,32 @@ export class TUI extends Container {
 			}
 			lastChanged = newLines.length - 1;
 		}
+		const findAppendedTailStart = (): number => {
+			if (!appendedLines || this.#previousLines.length === 0) return newLines.length;
+
+			const previousLast = this.#previousLines[this.#previousLines.length - 1];
+			let bestEnd = -1;
+			let bestLength = 0;
+			for (let end = newLines.length - 1; end >= 0; end--) {
+				if (newLines[end] !== previousLast) continue;
+
+				let length = 1;
+				while (
+					length < this.#previousLines.length &&
+					end - length >= 0 &&
+					this.#previousLines[this.#previousLines.length - 1 - length] === newLines[end - length]
+				) {
+					length += 1;
+				}
+				if (length > bestLength) {
+					bestLength = length;
+					bestEnd = end;
+				}
+			}
+
+			return bestEnd === -1 ? newLines.length : bestEnd + 1;
+		};
+
 		// No changes - but still need to update hardware cursor position if it moved.
 		if (firstChanged === -1) {
 			if (widthChanged) {
@@ -1293,9 +1335,11 @@ export class TUI extends Container {
 		// Differential rendering can only touch what was actually visible. Repaint
 		// the visible viewport when earlier scrollback changes; treating the frame
 		// as append-only can leave shifted rows stale when edits and appends land
-		// together.
+		// together. If this frame also appended rows, emit only that appended tail
+		// first so the terminal's own scrollback still receives streaming output.
 		if (firstChanged < prevViewportTop) {
 			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
+			appendRowsToScrollback(findAppendedTailStart());
 			viewportRefresh();
 			return;
 		}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1054,16 +1054,16 @@ export class TUI extends Container {
 		// path so cache comparisons stay byte-accurate.
 		newLines = this.#applyLineResets(newLines);
 
-		// Width changed - need full re-render (line wrapping changes)
+		// Width/height changes can require viewport repainting.
 		const widthChanged = this.#previousWidth !== 0 && this.#previousWidth !== width;
 		const heightChanged = this.#previousHeight !== 0 && this.#previousHeight !== height;
 
-		// Helper to clear scrollback and viewport and render all new lines
+		// Helper to clear the viewport and render all new lines
 		const fullRender = (clear: boolean): void => {
 			this.#fullRedrawCount += 1;
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
-			// Skip clearing scrollback (3J) in multiplexers — users actively navigate scrollback history
-			if (clear) buffer += isMultiplexer ? "\x1b[2J\x1b[H" : "\x1b[2J\x1b[H\x1b[3J";
+			// ED 3 clears terminal scrollback and disrupts manual scrollback inspection.
+			if (clear) buffer += "\x1b[2J\x1b[H";
 			for (let i = 0; i < newLines.length; i++) {
 				if (i > 0) buffer += "\r\n";
 				// Lines were pre-terminated/normalized by #applyLineResets; image
@@ -1095,27 +1095,75 @@ export class TUI extends Container {
 			const msg = `[${new Date().toISOString()}] fullRender: ${reason} (prev=${this.#previousLines.length}, new=${newLines.length}, height=${height})\n`;
 			fs.appendFileSync(logPath, msg);
 		};
+		const viewportRefresh = (): void => {
+			this.#fullRedrawCount += 1;
+			const nextViewportTop = Math.max(0, newLines.length - height);
+			let buffer = "\x1b[?2026h\x1b[H";
 
-		// First render - just output everything without clearing (assumes clean screen)
-		if (this.#previousLines.length === 0 && !widthChanged && !heightChanged) {
+			for (let screenRow = 0; screenRow < height; screenRow++) {
+				if (screenRow > 0) buffer += "\r\n";
+				buffer += "\x1b[2K";
+				const line = newLines[nextViewportTop + screenRow] ?? "";
+				let truncatedLine = line;
+				const isImage = TERMINAL.isImageLine(line);
+				if (!isImage && visibleWidth(line) > width) {
+					if (debugRedraw) {
+						const debugData = [
+							`[TUI Truncate] ${new Date().toISOString()}`,
+							`Line ${nextViewportTop + screenRow} truncated: ${visibleWidth(line)} > ${width}`,
+							`Content preview: ${line.slice(0, 100)}...`,
+							"",
+						].join("\n");
+						try {
+							fs.appendFileSync(getDebugLogPath(), debugData);
+						} catch {
+							// Ignore write errors - truncation should still work
+						}
+					}
+					truncatedLine = truncateToWidth(line, width, Ellipsis.Omit);
+					truncatedLine += truncatedLine.includes("\x1b]8;") ? LINE_TERMINATOR : SEGMENT_RESET;
+				}
+				buffer += truncatedLine;
+			}
+
+			const finalCursorRow = Math.min(Math.max(0, newLines.length - 1), nextViewportTop + height - 1);
+			const { seq, toRow } = this.#cursorControlSequence(cursorPos, newLines.length, finalCursorRow);
+			this.#hardwareCursorRow = toRow;
+			buffer += seq;
+			buffer += "\x1b[?2026l";
+			this.terminal.write(buffer);
+
+			this.#cursorRow = Math.max(0, newLines.length - 1);
+			this.#maxLinesRendered = newLines.length;
+			this.#viewportTopRow = nextViewportTop;
+			this.#previousLines = newLines;
+			this.#previousWidth = width;
+			this.#previousHeight = height;
+		};
+
+		// First render outputs the full transcript so terminal scrollback contains
+		// the initial TUI state. Forced first renders still clear only the viewport.
+		if (this.#previousLines.length === 0) {
 			logRedraw("first render");
-			fullRender(false);
+			fullRender(widthChanged || heightChanged);
 			return;
 		}
+		const contentGrew = newLines.length > this.#previousLines.length;
 
-		// Width changes always need a full re-render because wrapping changes.
-		if (widthChanged) {
+		// Width changes need a viewport repaint because wrapping changes. If new
+		// rows also arrived, keep the append path so history reaches scrollback.
+		if (widthChanged && !contentGrew) {
 			logRedraw(`terminal width changed (${this.#previousWidth} -> ${width})`);
-			fullRender(true);
+			viewportRefresh();
 			return;
 		}
 
-		// Height changes normally need a full re-render to keep the visible viewport aligned,
+		// Height changes need a viewport repaint to keep the visible rows aligned,
 		// but Termux changes height when the software keyboard shows or hides.
-		// In that environment, a full redraw causes the entire history to replay on every toggle.
-		if (heightChanged && !isTermuxSession() && !isMultiplexer) {
+		// In that environment, repainting causes the viewport to jump on every toggle.
+		if (heightChanged && !contentGrew && !isTermuxSession() && !isMultiplexer) {
 			logRedraw(`terminal height changed (${this.#previousHeight} -> ${height})`);
-			fullRender(true);
+			viewportRefresh();
 			return;
 		}
 
@@ -1124,7 +1172,7 @@ export class TUI extends Container {
 		// Configurable via setClearOnShrink() or PI_CLEAR_ON_SHRINK=0 env var
 		if (this.#clearOnShrink && newLines.length < this.#previousLines.length && this.overlayStack.length === 0) {
 			logRedraw(`clearOnShrink (prev=${this.#previousLines.length}, new=${newLines.length})`);
-			fullRender(true);
+			viewportRefresh();
 			return;
 		}
 
@@ -1150,8 +1198,6 @@ export class TUI extends Container {
 			}
 			lastChanged = newLines.length - 1;
 		}
-		const appendStart = appendedLines && firstChanged === this.#previousLines.length && firstChanged > 0;
-
 		// No changes - but still need to update hardware cursor position if it moved
 		if (firstChanged === -1) {
 			this.#writeCursorPosition(cursorPos, newLines.length);
@@ -1173,7 +1219,7 @@ export class TUI extends Container {
 				const extraLines = this.#previousLines.length - newLines.length;
 				if (extraLines > height) {
 					logRedraw(`extraLines > height (${extraLines} > ${height})`);
-					fullRender(true);
+					viewportRefresh();
 					return;
 				}
 				const clearStartOffset = newLines.length > 0 && extraLines > 0 ? 1 : 0;
@@ -1203,14 +1249,20 @@ export class TUI extends Container {
 			return;
 		}
 
-		// Differential rendering can only touch what was actually visible.
-		// Any change above the previous viewport requires a full redraw so terminal
-		// scrollback ends up consistent with the new transcript state.
+		// Differential rendering can only touch what was actually visible. When
+		// offscreen content changes while new rows are appended, preserve append
+		// history and leave the older scrollback copy untouched.
 		if (firstChanged < prevViewportTop) {
 			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
-			fullRender(true);
-			return;
+			if (!contentGrew) {
+				viewportRefresh();
+				return;
+			}
+			firstChanged = this.#previousLines.length;
+			lastChanged = newLines.length - 1;
 		}
+
+		const appendStart = appendedLines && firstChanged === this.#previousLines.length && firstChanged > 0;
 
 		// Render from first changed line to end
 		// Build buffer with all updates wrapped in synchronized output

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1259,18 +1259,14 @@ export class TUI extends Container {
 			return;
 		}
 
-		// Differential rendering can only touch what was actually visible. When
-		// offscreen content changes while new rows are appended, preserve append
-		// history and leave the older scrollback copy untouched unless width
-		// reflow invalidated visible row contents.
+		// Differential rendering can only touch what was actually visible. Repaint
+		// the visible viewport when earlier scrollback changes; treating the frame
+		// as append-only can leave shifted rows stale when edits and appends land
+		// together.
 		if (firstChanged < prevViewportTop) {
 			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
-			if (widthChanged || !contentGrew) {
-				viewportRefresh();
-				return;
-			}
-			firstChanged = this.#previousLines.length;
-			lastChanged = newLines.length - 1;
+			viewportRefresh();
+			return;
 		}
 
 		const appendStart = appendedLines && firstChanged === this.#previousLines.length && firstChanged > 0;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1251,10 +1251,11 @@ export class TUI extends Container {
 
 		// Differential rendering can only touch what was actually visible. When
 		// offscreen content changes while new rows are appended, preserve append
-		// history and leave the older scrollback copy untouched.
+		// history and leave the older scrollback copy untouched unless width
+		// reflow invalidated visible row contents.
 		if (firstChanged < prevViewportTop) {
 			logRedraw(`firstChanged < viewportTop (${firstChanged} < ${prevViewportTop})`);
-			if (!contentGrew) {
+			if (widthChanged || !contentGrew) {
 				viewportRefresh();
 				return;
 			}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1070,11 +1070,12 @@ export class TUI extends Container {
 		const heightChanged = this.#previousHeight !== 0 && this.#previousHeight !== height;
 
 		// Helper to clear the viewport and render all new lines
-		const fullRender = (clear: boolean): void => {
+		const fullRender = (clear: boolean, options: { clearScrollback?: boolean } = {}): void => {
 			this.#fullRedrawCount += 1;
 			let buffer = "\x1b[?2026h"; // Begin synchronized output
 			if (clear) {
-				const clearScrollback = this.#clearScrollbackOnNextRender && !isMultiplexerSession();
+				const clearScrollback =
+					(this.#clearScrollbackOnNextRender || options.clearScrollback === true) && !isMultiplexerSession();
 				buffer += clearScrollback ? "\x1b[2J\x1b[H\x1b[3J" : "\x1b[2J\x1b[H";
 				this.#clearScrollbackOnNextRender = false;
 			}
@@ -1172,8 +1173,8 @@ export class TUI extends Container {
 		};
 
 		// First-paint policy:
-		// - Initial startup (no prior render): emit the full transcript so terminal
-		//   scrollback receives the initial UI state.
+		// - Initial startup (no prior render): clear the viewport before emitting
+		//   the full transcript so stale shell content is not left onscreen.
 		// - Forced reset later in the session: repaint the visible viewport only,
 		//   so we don't duplicate the transcript into terminal scrollback. The
 		//   caller can opt into clearing scrollback via `{ clearScrollback: true }`
@@ -1181,7 +1182,7 @@ export class TUI extends Container {
 		if (this.#previousLines.length === 0) {
 			logRedraw("first render");
 			if (!this.#hasEverRendered) {
-				fullRender(false);
+				fullRender(true);
 			} else if (this.#clearScrollbackOnNextRender) {
 				fullRender(true);
 			} else {
@@ -1272,14 +1273,15 @@ export class TUI extends Container {
 		}
 
 		// Width changes alter wrapping for the whole transcript. If offscreen
-		// rows changed, replay the rendered transcript so scrollback receives
-		// the new width. Pure appends can keep the append path because there is
-		// no older width-dependent row to refresh.
+		// rows changed, rebuild the terminal history with the new width; leaving
+		// the old scrollback copy in place keeps historical components stale.
+		// Pure appends can keep the append path because there is no older
+		// width-dependent row to refresh.
 		if (widthChanged) {
 			logRedraw(`terminal width changed (${this.#previousWidth} -> ${width})`);
 			const pureAppend = appendedLines && firstChanged === this.#previousLines.length;
 			if (firstChanged < prevViewportTop) {
-				fullRender(true);
+				fullRender(true, { clearScrollback: true });
 				return;
 			}
 			if (!pureAppend) {

--- a/packages/tui/test/overlay-scroll.test.ts
+++ b/packages/tui/test/overlay-scroll.test.ts
@@ -149,6 +149,27 @@ describe("TUI overlays", () => {
 
 		tui.stop();
 	});
+	it("clears rendered scrollback when forced redraw replaces terminal history", async () => {
+		const term = new VirtualTerminal(40, 4);
+		const tui = new TUI(term);
+		const component = new MutableContentComponent(buildRows(120));
+		tui.addChild(component);
+
+		tui.start();
+		await flushRender(term);
+
+		expect(term.getScrollBuffer().join("\n").includes("row-0")).toBeTruthy();
+
+		component.setLines(["new-session-0", "new-session-1", "new-session-2", "new-session-3"]);
+		tui.requestRender(true, { clearScrollback: true });
+		await flushRender(term);
+
+		const scrollback = term.getScrollBuffer().join("\n");
+		expect(scrollback.includes("row-0")).toBeFalsy();
+		expect(scrollback.includes("new-session-3")).toBeTruthy();
+
+		tui.stop();
+	});
 	it("fully redraws on height increase to avoid stale viewport rows", async () => {
 		const term = new VirtualTerminal(40, 4);
 		term.write("shell-0\r\nshell-1\r\nshell-2\r\nshell-3\r\nshell-4\r\n");

--- a/packages/tui/test/overlay-scroll.test.ts
+++ b/packages/tui/test/overlay-scroll.test.ts
@@ -36,6 +36,16 @@ class MutableContentComponent implements Component {
 		return [...this.#lines];
 	}
 }
+class WidthAwareHistoryComponent implements Component {
+	invalidate(): void {
+		// No cached state
+	}
+
+	render(width: number): string[] {
+		const prefix = width < 30 ? "narrow" : "wide";
+		return Array.from({ length: 24 }, (_v, i) => `${prefix}-row-${i}`);
+	}
+}
 
 class CursorOnlyComponent implements Component {
 	#cursorCol = 0;
@@ -79,6 +89,19 @@ function longestBlankRun(lines: string[]): number {
 		}
 	}
 	return longest;
+}
+async function withEnv(name: string, value: string, run: () => Promise<void>): Promise<void> {
+	const previous = Bun.env[name];
+	Bun.env[name] = value;
+	try {
+		await run();
+	} finally {
+		if (previous === undefined) {
+			delete Bun.env[name];
+		} else {
+			Bun.env[name] = previous;
+		}
+	}
 }
 
 async function flushRender(term: VirtualTerminal): Promise<void> {
@@ -170,6 +193,28 @@ describe("TUI overlays", () => {
 
 		tui.stop();
 	});
+	it("preserves multiplexer scrollback when replacing terminal history", async () => {
+		await withEnv("TMUX", "1", async () => {
+			const term = new VirtualTerminal(40, 4);
+			const tui = new TUI(term);
+			const component = new MutableContentComponent(buildRows(120));
+			tui.addChild(component);
+
+			tui.start();
+			await flushRender(term);
+			expect(term.getScrollBuffer().join("\n").includes("row-0")).toBeTruthy();
+
+			component.setLines(["new-session-0", "new-session-1", "new-session-2", "new-session-3"]);
+			tui.requestRender(true, { clearScrollback: true });
+			await flushRender(term);
+
+			const scrollback = term.getScrollBuffer().join("\n");
+			expect(scrollback.includes("row-0")).toBeTruthy();
+			expect(term.getViewport().join("\n").includes("new-session-3")).toBeTruthy();
+
+			tui.stop();
+		});
+	});
 	it("does not duplicate transcript into scrollback on repeated forced redraws", async () => {
 		const term = new VirtualTerminal(40, 4);
 		const tui = new TUI(term);
@@ -245,6 +290,25 @@ describe("TUI overlays", () => {
 			await flushRender(term);
 			const viewport = term.getViewport();
 			expect(viewport.at(-1)?.includes("row-139")).toBeTruthy();
+		} finally {
+			tui.stop();
+		}
+	});
+	it("replays width-dependent offscreen scrollback on terminal width changes", async () => {
+		const term = new VirtualTerminal(40, 4);
+		const tui = new TUI(term);
+		tui.addChild(new WidthAwareHistoryComponent());
+		try {
+			tui.start();
+			await flushRender(term);
+			expect(term.getScrollBuffer().join("\n").includes("wide-row-0")).toBeTruthy();
+
+			term.resize(20, 4);
+			await flushRender(term);
+
+			const scrollback = term.getScrollBuffer().join("\n");
+			expect(scrollback.includes("narrow-row-0")).toBeTruthy();
+			expect(term.getViewport().at(-1)?.trim()).toBe("narrow-row-23");
 		} finally {
 			tui.stop();
 		}

--- a/packages/tui/test/overlay-scroll.test.ts
+++ b/packages/tui/test/overlay-scroll.test.ts
@@ -170,6 +170,26 @@ describe("TUI overlays", () => {
 
 		tui.stop();
 	});
+	it("does not duplicate transcript into scrollback on repeated forced redraws", async () => {
+		const term = new VirtualTerminal(40, 4);
+		const tui = new TUI(term);
+		const component = new MutableContentComponent(buildRows(60));
+		tui.addChild(component);
+
+		tui.start();
+		await flushRender(term);
+		const baseline = term.getScrollBuffer().filter(line => /^row-\d+$/.test(line.trim())).length;
+
+		for (let i = 0; i < 5; i++) {
+			tui.requestRender(true);
+			await flushRender(term);
+		}
+
+		const after = term.getScrollBuffer().filter(line => /^row-\d+$/.test(line.trim())).length;
+		expect(after).toBeLessThanOrEqual(baseline + 4);
+
+		tui.stop();
+	});
 	it("fully redraws on height increase to avoid stale viewport rows", async () => {
 		const term = new VirtualTerminal(40, 4);
 		term.write("shell-0\r\nshell-1\r\nshell-2\r\nshell-3\r\nshell-4\r\n");

--- a/packages/tui/test/overlay-scroll.test.ts
+++ b/packages/tui/test/overlay-scroll.test.ts
@@ -272,6 +272,36 @@ describe("TUI overlays", () => {
 
 		tui.stop();
 	});
+	it("keeps single viewport copy under simultaneous height and content changes", async () => {
+		const term = new VirtualTerminal(60, 8);
+		const tui = new TUI(term);
+		const component = new MutableContentComponent(buildRows(4));
+		tui.addChild(component);
+		try {
+			tui.start();
+			await flushRender(term);
+
+			for (let i = 0; i < 12; i++) {
+				component.setLines(buildRows(4 + i));
+				term.resize(60, i % 2 === 0 ? 7 : 9);
+				await flushRender(term);
+			}
+
+			const viewport = term.getViewport();
+			const rowOccurrences = new Map<string, number>();
+			for (const line of viewport) {
+				const trimmed = line.trim();
+				if (!/^row-\d+$/.test(trimmed)) continue;
+				rowOccurrences.set(trimmed, (rowOccurrences.get(trimmed) ?? 0) + 1);
+			}
+			for (const [row, count] of rowOccurrences) {
+				expect(count, `${row} should appear at most once in the viewport`).toBe(1);
+			}
+			expect(viewport.at(-1)?.trim()).toBe("row-14");
+		} finally {
+			tui.stop();
+		}
+	});
 	it("renders viewport-only on resize when content size is stable", async () => {
 		const term = new VirtualTerminal(60, 8);
 		const tui = new TUI(term);

--- a/packages/tui/test/overlay-scroll.test.ts
+++ b/packages/tui/test/overlay-scroll.test.ts
@@ -108,7 +108,7 @@ describe("TUI overlays", () => {
 		expect(term.getScrollBuffer().length).toBeLessThan(200);
 	});
 
-	it("clears preexisting terminal scrollback on startup full redraw", async () => {
+	it("preserves preexisting terminal scrollback on startup resize redraw", async () => {
 		const term = new VirtualTerminal(40, 4);
 		term.write("shell-0\r\nshell-1\r\nshell-2\r\nshell-3\r\nshell-4\r\n");
 		await flushRender(term);
@@ -124,7 +124,7 @@ describe("TUI overlays", () => {
 		await flushRender(term);
 
 		const scrollback = term.getScrollBuffer().join("\n");
-		expect(scrollback.includes("shell-0")).toBeFalsy();
+		expect(scrollback.includes("shell-0")).toBeTruthy();
 
 		tui.stop();
 	});
@@ -221,7 +221,7 @@ describe("TUI overlays", () => {
 			term.resize(39, 4);
 			await flushRender(term);
 			const scrollback = term.getScrollBuffer().join("\n");
-			expect(scrollback.includes("shell-0")).toBeFalsy();
+			expect(scrollback.includes("shell-0")).toBeTruthy();
 		} finally {
 			tui.stop();
 		}

--- a/packages/tui/test/overlay-scroll.test.ts
+++ b/packages/tui/test/overlay-scroll.test.ts
@@ -151,6 +151,23 @@ describe("TUI overlays", () => {
 
 		tui.stop();
 	});
+	it("clears stale viewport content on launch without clearing shell scrollback", async () => {
+		const term = new VirtualTerminal(40, 4);
+		term.write("shell-0\r\nshell-1\r\nshell-2\r\nshell-3\r\nshell-4\r\n");
+		await flushRender(term);
+
+		const tui = new TUI(term);
+		tui.addChild(new MutableContentComponent(["ui-0", "ui-1"]));
+		try {
+			tui.start();
+			await flushRender(term);
+
+			expect(term.getViewport().join("\n").includes("shell-")).toBeFalsy();
+			expect(term.getScrollBuffer().join("\n").includes("shell-0")).toBeTruthy();
+		} finally {
+			tui.stop();
+		}
+	});
 
 	it("preserves rendered scrollback on forced redraw after startup", async () => {
 		const term = new VirtualTerminal(40, 4);
@@ -308,6 +325,7 @@ describe("TUI overlays", () => {
 
 			const scrollback = term.getScrollBuffer().join("\n");
 			expect(scrollback.includes("narrow-row-0")).toBeTruthy();
+			expect(scrollback.includes("wide-row-0")).toBeFalsy();
 			expect(term.getViewport().at(-1)?.trim()).toBe("narrow-row-23");
 		} finally {
 			tui.stop();

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -780,6 +780,7 @@ describe("TUI terminal-state regressions", () => {
 					"line-9",
 					"line-10",
 				]);
+				const beforeBufferLength = term.getScrollBuffer().length;
 
 				component.setLines(["status-1", "expanded-details", ...rows("line-", 12)]);
 				tui.requestRender();
@@ -793,6 +794,7 @@ describe("TUI terminal-state regressions", () => {
 					"line-10",
 					"line-11",
 				]);
+				expect(term.getScrollBuffer().length - beforeBufferLength).toBe(1);
 			} finally {
 				tui.stop();
 			}

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -20,6 +20,31 @@ class MutableLinesComponent implements Component {
 	}
 }
 
+class WrappingLinesComponent implements Component {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = [...lines];
+	}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		const chunkWidth = Math.max(1, width);
+		const rendered: string[] = [];
+		for (const line of this.#lines) {
+			if (line.length === 0) {
+				rendered.push("");
+				continue;
+			}
+			for (let offset = 0; offset < line.length; offset += chunkWidth) {
+				rendered.push(line.slice(offset, offset + chunkWidth));
+			}
+		}
+		return rendered;
+	}
+}
+
 function rows(prefix: string, count: number): string[] {
 	return Array.from({ length: count }, (_v, i) => `${prefix}${i}`);
 }
@@ -265,6 +290,36 @@ describe("TUI terminal-state regressions", () => {
 					await settle(term);
 					expect(visible(term)).toEqual(expectedViewport(width, 18));
 				}
+			} finally {
+				tui.stop();
+			}
+		});
+		it("repaints viewport when width reflow grows rendered lines", async () => {
+			const term = new VirtualTerminal(40, 10);
+			const tui = new TUI(term);
+			const lines = [
+				...Array.from({ length: 5 }, (_v, i) => `long-${i}-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`),
+				...Array.from({ length: 20 }, (_v, i) => `tail-${i}`),
+			];
+			tui.addChild(new WrappingLinesComponent(lines));
+
+			const expectedViewport = (width: number, height: number): string[] => {
+				const rendered = new WrappingLinesComponent(lines).render(width);
+				const top = Math.max(0, rendered.length - height);
+				const viewport = rendered.slice(top, top + height);
+				while (viewport.length < height) viewport.push("");
+				return viewport.map(line => line.trimEnd());
+			};
+
+			try {
+				tui.start();
+				await settle(term);
+				expect(visible(term)).toEqual(expectedViewport(40, 10));
+
+				term.resize(20, 10);
+				await settle(term);
+
+				expect(visible(term)).toEqual(expectedViewport(20, 10));
 			} finally {
 				tui.stop();
 			}

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -733,7 +733,7 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 
-		it("retains append history when offscreen header changes during overflow growth", async () => {
+		it("keeps viewport aligned when offscreen header changes during overflow growth", async () => {
 			const term = new VirtualTerminal(32, 6);
 			const tui = new TUI(term);
 			const logLines = rows("line-", 6);
@@ -752,15 +752,6 @@ describe("TUI terminal-state regressions", () => {
 					tui.requestRender();
 					await settle(term);
 				}
-
-				const scrollback = term.getScrollBuffer();
-				for (let i = 0; i < 70; i++) {
-					expect(countMatches(scrollback, new RegExp(`\\bline-${i}\\b`))).toBe(1);
-				}
-				for (let i = 0; i <= tick; i++) {
-					expect(countMatches(scrollback, new RegExp(`\\bstatus-${i}\\b`))).toBeLessThanOrEqual(1);
-				}
-
 				const viewport = visible(term).map(line => line.trim());
 				expect(viewport.at(-1)).toBe("line-69");
 				for (let i = 1; i < viewport.length; i++) {
@@ -768,6 +759,40 @@ describe("TUI terminal-state regressions", () => {
 					const next = Number.parseInt(viewport[i]!.slice(5), 10);
 					expect(next - prev).toBe(1);
 				}
+			} finally {
+				tui.stop();
+			}
+		});
+		it("repaints viewport when offscreen expansion and append land together", async () => {
+			const term = new VirtualTerminal(32, 6);
+			const tui = new TUI(term);
+			const component = new MutableLinesComponent(["status-0", ...rows("line-", 11)]);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				expect(visible(term).map(line => line.trim())).toEqual([
+					"line-5",
+					"line-6",
+					"line-7",
+					"line-8",
+					"line-9",
+					"line-10",
+				]);
+
+				component.setLines(["status-1", "expanded-details", ...rows("line-", 12)]);
+				tui.requestRender();
+				await settle(term);
+
+				expect(visible(term).map(line => line.trim())).toEqual([
+					"line-6",
+					"line-7",
+					"line-8",
+					"line-9",
+					"line-10",
+					"line-11",
+				]);
 			} finally {
 				tui.stop();
 			}

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -157,7 +157,7 @@ describe("TUI terminal-state regressions", () => {
 	});
 
 	describe("resize + viewport behavior", () => {
-		it("clears preexisting shell rows on startup and resize redraw", async () => {
+		it("preserves preexisting shell scrollback on startup and resize redraw", async () => {
 			const term = new VirtualTerminal(50, 5);
 			term.write("shell-0\r\nshell-1\r\nshell-2\r\nshell-3\r\nshell-4\r\n");
 			await settle(term);
@@ -174,7 +174,7 @@ describe("TUI terminal-state regressions", () => {
 				await settle(term);
 
 				const buffer = term.getScrollBuffer().join("\n");
-				expect(buffer.includes("shell-")).toBeFalsy();
+				expect(buffer.includes("shell-")).toBeTruthy();
 			} finally {
 				tui.stop();
 			}


### PR DESCRIPTION
## Repro
A focused `packages/tui` regression reproduces the reported redraw behavior by writing shell scrollback, starting the TUI, triggering a resize redraw, and asserting the earlier scrollback entry is still present. Before the fix, `bun --cwd=packages/tui test test/overlay-scroll.test.ts -t "preserves preexisting terminal scrollback"` failed because `shell-0` disappeared from the terminal buffer.

## Cause
`TUI.#doRender()` in `packages/tui/src/tui.ts` used `fullRender(true)` for resize, shrink, and above-viewport mutation paths. That full render emitted `CSI 3 J` outside multiplexers, which clears terminal scrollback, and it replayed full transcripts for viewport-only redraws that should not rewrite history.

## Fix
- Removed `CSI 3 J` from full redraws so OMP no longer clears terminal scrollback.
- Added a viewport refresh path for resize, shrink, and offscreen-mutation redraws that repaints visible rows without replaying the full transcript.
- Kept append growth on the existing append path so new rows still enter terminal scrollback without duplicating prior history.
- Updated TUI regression tests and changelog coverage for preserving preexisting scrollback.

## Verification
`bun --cwd=packages/tui run check` passed. `bun --cwd=packages/tui test test/overlay-scroll.test.ts test/render-regressions.test.ts` passed (39 tests). `bun --cwd=packages/tui test` still fails in `test/visible-width-jamo.test.ts` because native text helpers count Hangul compatibility jamo as 2 cells; that failure is unrelated to this redraw change and does not touch the modified paths. Fixes #1295