### PR TITLE
fix(agent): stop context promotion preempting threshold compaction

### DIFF
--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -170,13 +170,17 @@ export function applyGeneratedModelPolicies(models: ApiModel<Api>[]): void {
 	}
 }
 
+function hasLargerContextWindow(target: ApiModel<Api>, source: ApiModel<Api>): boolean {
+	return target.contextWindow > source.contextWindow;
+}
+
 /**
  * Link OpenAI model variants to their context promotion targets.
  *
  * When a model's context is exhausted, the agent can promote to a sibling
- * model with a larger context window on the same provider:
- * - `codex-spark` variants promote to `gpt-5.5`.
- * - `gpt-5.5` (270K input) promotes to `gpt-5.4` (1M input).
+ * model with a strictly larger context window on the same provider. Generated
+ * catalogs must not link lateral model variants because promotion skips
+ * compaction on overflow.
  */
 export function linkOpenAIPromotionTargets(models: ApiModel<Api>[]): void {
 	for (const candidate of models) {
@@ -190,10 +194,12 @@ export function linkOpenAIPromotionTargets(models: ApiModel<Api>[]): void {
 		} else {
 			continue;
 		}
+		delete candidate.contextPromotionTarget;
 		const fallback = models.find(
 			model => model.provider === candidate.provider && model.api === candidate.api && model.id === targetId,
 		);
 		if (!fallback) continue;
+		if (!hasLargerContextWindow(fallback, candidate)) continue;
 		candidate.contextPromotionTarget = `${fallback.provider}/${fallback.id}`;
 	}
 }

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -170,17 +170,13 @@ export function applyGeneratedModelPolicies(models: ApiModel<Api>[]): void {
 	}
 }
 
-function hasLargerContextWindow(target: ApiModel<Api>, source: ApiModel<Api>): boolean {
-	return target.contextWindow > source.contextWindow;
-}
-
 /**
  * Link OpenAI model variants to their context promotion targets.
  *
  * When a model's context is exhausted, the agent can promote to a sibling
- * model with a strictly larger context window on the same provider. Generated
- * catalogs must not link lateral model variants because promotion skips
- * compaction on overflow.
+ * model with a larger context window on the same provider:
+ * - `codex-spark` variants promote to `gpt-5.5`.
+ * - `gpt-5.5` (270K input) promotes to `gpt-5.4` (1M input).
  */
 export function linkOpenAIPromotionTargets(models: ApiModel<Api>[]): void {
 	for (const candidate of models) {
@@ -194,12 +190,10 @@ export function linkOpenAIPromotionTargets(models: ApiModel<Api>[]): void {
 		} else {
 			continue;
 		}
-		delete candidate.contextPromotionTarget;
 		const fallback = models.find(
 			model => model.provider === candidate.provider && model.api === candidate.api && model.id === targetId,
 		);
 		if (!fallback) continue;
-		if (!hasLargerContextWindow(fallback, candidate)) continue;
 		candidate.contextPromotionTarget = `${fallback.provider}/${fallback.id}`;
 	}
 }

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -203,6 +203,34 @@
 				"maxLevel": "high"
 			}
 		},
+		"qwen3.6-flash": {
+			"id": "qwen3.6-flash",
+			"name": "Qwen3.6 Flash",
+			"api": "openai-completions",
+			"provider": "alibaba-coding-plan",
+			"baseUrl": "https://coding-intl.dashscope.aliyuncs.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.1875,
+				"output": 1.125,
+				"cacheRead": 0,
+				"cacheWrite": 0.234375
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"compat": {
+				"supportsDeveloperRole": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"qwen3.6-plus": {
 			"id": "qwen3.6-plus",
 			"name": "Qwen3.6 Plus",
@@ -219,6 +247,33 @@
 				"output": 0,
 				"cacheRead": 0,
 				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"compat": {
+				"supportsDeveloperRole": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"qwen3.7-max": {
+			"id": "qwen3.7-max",
+			"name": "Qwen3.7 Max",
+			"api": "openai-completions",
+			"provider": "alibaba-coding-plan",
+			"baseUrl": "https://coding-intl.dashscope.aliyuncs.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 7.5,
+				"cacheRead": 0.5,
+				"cacheWrite": 3.125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
@@ -1000,7 +1055,7 @@
 		},
 		"global.anthropic.claude-haiku-4-5-20251001-v1:0": {
 			"id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
-			"name": "Claude Haiku 4.5",
+			"name": "Claude Haiku 4.5 (Global)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1125,7 +1180,7 @@
 		},
 		"global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
 			"id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
-			"name": "Claude Sonnet 4.5",
+			"name": "Claude Sonnet 4.5 (Global)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -1632,8 +1687,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 256000,
+			"contextWindow": 262143,
+			"maxTokens": 16000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -1657,8 +1712,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 256000,
+			"contextWindow": 262143,
+			"maxTokens": 16000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -1769,7 +1824,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 4096
+			"maxTokens": 16384
 		},
 		"openai.gpt-oss-20b-1:0": {
 			"id": "openai.gpt-oss-20b-1:0",
@@ -1788,7 +1843,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 4096
+			"maxTokens": 16384
 		},
 		"openai.gpt-oss-safeguard-120b": {
 			"id": "openai.gpt-oss-safeguard-120b",
@@ -1807,7 +1862,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 4096
+			"maxTokens": 16384
 		},
 		"openai.gpt-oss-safeguard-20b": {
 			"id": "openai.gpt-oss-safeguard-20b",
@@ -1826,7 +1881,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
-			"maxTokens": 4096
+			"maxTokens": 16384
 		},
 		"qwen.qwen3-235b-a22b-2507-v1:0": {
 			"id": "qwen.qwen3-235b-a22b-2507-v1:0",
@@ -2103,7 +2158,7 @@
 		},
 		"us.anthropic.claude-opus-4-1-20250805-v1:0": {
 			"id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
-			"name": "Claude Opus 4.1",
+			"name": "Claude Opus 4.1 (US)",
 			"api": "bedrock-converse-stream",
 			"provider": "amazon-bedrock",
 			"baseUrl": "https://bedrock-runtime.us-east-1.amazonaws.com",
@@ -4979,13 +5034,25 @@
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
 			"compat": {
+				"supportsDeveloperRole": false,
 				"supportsReasoningEffort": true,
 				"reasoningEffortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
 					"xhigh": "max"
 				},
+				"maxTokensField": "max_tokens",
 				"supportsToolChoice": false,
+				"extraBody": {
+					"thinking": {
+						"type": "enabled"
+					}
+				},
 				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": true
+				"requiresReasoningContentForToolCalls": true,
+				"requiresAssistantContentForToolCalls": true
 			},
 			"thinking": {
 				"mode": "effort",
@@ -5012,13 +5079,25 @@
 			"contextWindow": 1000000,
 			"maxTokens": 384000,
 			"compat": {
+				"supportsDeveloperRole": false,
 				"supportsReasoningEffort": true,
 				"reasoningEffortMap": {
+					"minimal": "high",
+					"low": "high",
+					"medium": "high",
+					"high": "high",
 					"xhigh": "max"
 				},
+				"maxTokensField": "max_tokens",
 				"supportsToolChoice": false,
+				"extraBody": {
+					"thinking": {
+						"type": "enabled"
+					}
+				},
 				"reasoningContentField": "reasoning_content",
-				"requiresReasoningContentForToolCalls": true
+				"requiresReasoningContentForToolCalls": true,
+				"requiresAssistantContentForToolCalls": true
 			},
 			"thinking": {
 				"mode": "effort",
@@ -5545,6 +5624,39 @@
 				]
 			}
 		},
+		"gemini-3.5-flash": {
+			"id": "gemini-3.5-flash",
+			"name": "Gemini 3.5 Flash",
+			"api": "openai-completions",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 64000,
+			"headers": {
+				"User-Agent": "opencode/1.3.15"
+			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"gpt-4.1": {
 			"id": "gpt-4.1",
 			"name": "GPT-4.1",
@@ -5937,8 +6049,7 @@
 				"mode": "effort",
 				"minLevel": "low",
 				"maxLevel": "xhigh"
-			},
-			"contextPromotionTarget": "github-copilot/gpt-5.4"
+			}
 		},
 		"grok-code-fast-1": {
 			"id": "grok-code-fast-1",
@@ -6459,7 +6570,7 @@
 		},
 		"gemini-2.0-flash-lite": {
 			"id": "gemini-2.0-flash-lite",
-			"name": "Gemini 2.0 Flash Lite",
+			"name": "Gemini 2.0 Flash-Lite",
 			"api": "google-generative-ai",
 			"provider": "google",
 			"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
@@ -6504,7 +6615,7 @@
 		},
 		"gemini-2.5-flash-lite": {
 			"id": "gemini-2.5-flash-lite",
-			"name": "Gemini 2.5 Flash Lite",
+			"name": "Gemini 2.5 Flash-Lite",
 			"api": "google-generative-ai",
 			"provider": "google",
 			"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
@@ -6516,7 +6627,7 @@
 			"cost": {
 				"input": 0.1,
 				"output": 0.4,
-				"cacheRead": 0.025,
+				"cacheRead": 0.01,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -6769,8 +6880,8 @@
 				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
-			"maxTokens": 64000,
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "google-level",
 				"minLevel": "low",
@@ -6796,7 +6907,7 @@
 				"input": 0.25,
 				"output": 1.5,
 				"cacheRead": 0.025,
-				"cacheWrite": 1
+				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -6821,7 +6932,7 @@
 				"input": 0.25,
 				"output": 1.5,
 				"cacheRead": 0.025,
-				"cacheWrite": 1
+				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 65536,
@@ -6887,6 +6998,31 @@
 					"low",
 					"high"
 				]
+			}
+		},
+		"gemini-3.5-flash": {
+			"id": "gemini-3.5-flash",
+			"name": "Gemini 3.5 Flash",
+			"api": "google-generative-ai",
+			"provider": "google",
+			"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.5,
+				"output": 9,
+				"cacheRead": 0.15,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "google-level",
+				"minLevel": "minimal",
+				"maxLevel": "high"
 			}
 		},
 		"gemini-flash-latest": {
@@ -7035,7 +7171,7 @@
 		},
 		"gemma-4-26b-a4b-it": {
 			"id": "gemma-4-26b-a4b-it",
-			"name": "Gemma 4 26B",
+			"name": "Gemma 4 26B A4B IT",
 			"api": "google-generative-ai",
 			"provider": "google",
 			"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
@@ -7050,8 +7186,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 8192,
+			"contextWindow": 262144,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -7110,7 +7246,7 @@
 		},
 		"gemma-4-31b-it": {
 			"id": "gemma-4-31b-it",
-			"name": "Gemma 4 31B",
+			"name": "Gemma 4 31B IT",
 			"api": "google-generative-ai",
 			"provider": "google",
 			"baseUrl": "https://generativelanguage.googleapis.com/v1beta",
@@ -7125,8 +7261,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 256000,
-			"maxTokens": 8192,
+			"contextWindow": 262144,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -7789,7 +7925,7 @@
 		},
 		"gemini-2.0-flash-lite": {
 			"id": "gemini-2.0-flash-lite",
-			"name": "Gemini 2.0 Flash Lite",
+			"name": "Gemini 2.0 Flash-Lite",
 			"api": "google-vertex",
 			"provider": "google-vertex",
 			"baseUrl": "https://{location}-aiplatform.googleapis.com",
@@ -7834,7 +7970,7 @@
 		},
 		"gemini-2.5-flash-lite": {
 			"id": "gemini-2.5-flash-lite",
-			"name": "Gemini 2.5 Flash Lite",
+			"name": "Gemini 2.5 Flash-Lite",
 			"api": "google-vertex",
 			"provider": "google-vertex",
 			"baseUrl": "https://{location}-aiplatform.googleapis.com",
@@ -9314,6 +9450,25 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"anthropic/claude-opus-4.7-fast": {
+			"id": "anthropic/claude-opus-4.7-fast",
+			"name": "Anthropic: Claude Opus 4.7 (Fast) ($$$$)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"anthropic/claude-sonnet-4": {
 			"id": "anthropic/claude-sonnet-4",
 			"name": "Claude Sonnet 4",
@@ -9658,6 +9813,25 @@
 		"baidu/ernie-4.5-vl-424b-a47b": {
 			"id": "baidu/ernie-4.5-vl-424b-a47b",
 			"name": "Baidu: ERNIE 4.5 VL 424B A47B",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"baidu/qianfan-ocr-fast": {
+			"id": "baidu/qianfan-ocr-fast",
+			"name": "Baidu: Qianfan-OCR-Fast",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -10183,6 +10357,25 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"deepseek/deepseek-v4-flash:free": {
+			"id": "deepseek/deepseek-v4-flash:free",
+			"name": "DeepSeek: DeepSeek V4 Flash (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"deepseek/deepseek-v4-pro": {
 			"id": "deepseek/deepseek-v4-pro",
 			"name": "DeepSeek V4 Pro",
@@ -10656,9 +10849,9 @@
 			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
-		"google/gemma-2-27b-it": {
-			"id": "google/gemma-2-27b-it",
-			"name": "Gemma 2 27b It",
+		"google/gemini-3.5-flash": {
+			"id": "google/gemini-3.5-flash",
+			"name": "Google: Gemini 3.5 Flash",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -10672,8 +10865,27 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
-			"maxTokens": 4096
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"google/gemma-2-27b-it": {
+			"id": "google/gemma-2-27b-it",
+			"name": "Google: Gemma 2 27B",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
 		},
 		"google/gemma-2-9b-it": {
 			"id": "google/gemma-2-9b-it",
@@ -10696,7 +10908,7 @@
 		},
 		"google/gemma-3-12b-it": {
 			"id": "google/gemma-3-12b-it",
-			"name": "Gemma 3 12b It",
+			"name": "Google: Gemma 3 12B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -10710,8 +10922,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
-			"maxTokens": 4096
+			"contextWindow": 222222,
+			"maxTokens": 8888
 		},
 		"google/gemma-3-27b-it": {
 			"id": "google/gemma-3-27b-it",
@@ -11033,6 +11245,25 @@
 		"inclusionai/ling-2.6-flash:free": {
 			"id": "inclusionai/ling-2.6-flash:free",
 			"name": "inclusionAI: Ling-2.6-flash (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"inclusionai/ring-2.6-1t": {
+			"id": "inclusionai/ring-2.6-1t",
+			"name": "inclusionAI: Ring-2.6-1T",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -12383,8 +12614,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 65536,
+			"maxTokens": 13108
 		},
 		"mistralai/mixtral-8x7b-instruct": {
 			"id": "mistralai/mixtral-8x7b-instruct",
@@ -12402,8 +12633,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 32768,
+			"maxTokens": 16384
 		},
 		"mistralai/pixtral-large-2411": {
 			"id": "mistralai/pixtral-large-2411",
@@ -12541,8 +12772,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"contextWindow": 262000,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -14520,6 +14751,25 @@
 			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
+		"perceptron/perceptron-mk1": {
+			"id": "perceptron/perceptron-mk1",
+			"name": "Perceptron: Perceptron Mk1",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"perplexity/sonar": {
 			"id": "perplexity/sonar",
 			"name": "Perplexity: Sonar",
@@ -14959,7 +15209,7 @@
 		},
 		"qwen/qwen3-235b-a22b": {
 			"id": "qwen/qwen3-235b-a22b",
-			"name": "Qwen3-235B-A22B",
+			"name": "Qwen: Qwen3 235B A22B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -14973,8 +15223,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
-			"maxTokens": 8192,
+			"contextWindow": 222222,
+			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -15454,13 +15704,14 @@
 		},
 		"qwen/qwen3.5-122b-a10b": {
 			"id": "qwen/qwen3.5-122b-a10b",
-			"name": "Qwen: Qwen3.5-122B-A10B",
+			"name": "Qwen3.5 122B-A10B",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0,
@@ -15468,8 +15719,13 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"qwen/qwen3.5-27b": {
 			"id": "qwen/qwen3.5-27b",
@@ -15732,6 +15988,25 @@
 		"qwen/qwen3.6-plus:free": {
 			"id": "qwen/qwen3.6-plus:free",
 			"name": "Qwen: Qwen3.6 Plus (free)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"qwen/qwen3.7-max": {
+			"id": "qwen/qwen3.7-max",
+			"name": "Qwen: Qwen3.7 Max",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -16477,6 +16752,25 @@
 		"x-ai/grok-4.3": {
 			"id": "x-ai/grok-4.3",
 			"name": "xAI: Grok 4.3",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"x-ai/grok-build-0.1": {
+			"id": "x-ai/grok-build-0.1",
+			"name": "xAI: Grok Build 0.1",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -17615,7 +17909,7 @@
 		},
 		"gemini-2.5-flash-lite": {
 			"id": "gemini-2.5-flash-lite",
-			"name": "Gemini 2.5 Flash Lite",
+			"name": "Gemini 2.5 Flash-Lite",
 			"api": "openai-completions",
 			"provider": "litellm",
 			"baseUrl": "http://localhost:4000/v1",
@@ -18177,12 +18471,12 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000,
-			"contextPromotionTarget": "litellm/gpt-5.5",
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
 				"maxLevel": "xhigh"
-			}
+			},
+			"contextPromotionTarget": "litellm/gpt-5.5"
 		},
 		"gpt-5.4": {
 			"id": "gpt-5.4",
@@ -18257,8 +18551,7 @@
 				"mode": "effort",
 				"minLevel": "low",
 				"maxLevel": "xhigh"
-			},
-			"contextPromotionTarget": "litellm/gpt-5.4"
+			}
 		},
 		"gpt-image-2": {
 			"id": "gpt-image-2",
@@ -19921,7 +20214,7 @@
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "high"
 			}
 		}
 	},
@@ -22903,7 +23196,7 @@
 		},
 		"gemini-2.0-flash-lite": {
 			"id": "gemini-2.0-flash-lite",
-			"name": "Gemini 2.0 Flash Lite",
+			"name": "Gemini 2.0 Flash-Lite",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -23024,7 +23317,7 @@
 		},
 		"gemini-2.5-flash-lite": {
 			"id": "gemini-2.5-flash-lite",
-			"name": "Gemini 2.5 Flash Lite",
+			"name": "Gemini 2.5 Flash-Lite",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
@@ -26664,11 +26957,11 @@
 		},
 		"mistralai/mistral-small-4-119b-2603": {
 			"id": "mistralai/mistral-small-4-119b-2603",
-			"name": "mistralai/mistral-small-4-119b-2603",
+			"name": "mistral-small-4-119b-2603",
 			"api": "openai-completions",
 			"provider": "nanogpt",
 			"baseUrl": "https://nano-gpt.com/api/v1",
-			"reasoning": true,
+			"reasoning": false,
 			"input": [
 				"text"
 			],
@@ -26678,13 +26971,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
-			"maxTokens": 8888,
-			"thinking": {
-				"mode": "effort",
-				"minLevel": "minimal",
-				"maxLevel": "xhigh"
-			}
+			"contextWindow": 128000,
+			"maxTokens": 8192
 		},
 		"mistralai/mistral-small-creative": {
 			"id": "mistralai/mistral-small-creative",
@@ -32930,6 +33218,44 @@
 		}
 	},
 	"nvidia": {
+		"abacusai/dracarys-llama-3_1-70b-instruct": {
+			"id": "abacusai/dracarys-llama-3_1-70b-instruct",
+			"name": "dracarys-llama-3.1-70b-instruct",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192
+		},
+		"bytedance/seed-oss-36b-instruct": {
+			"id": "bytedance/seed-oss-36b-instruct",
+			"name": "ByteDance-Seed/Seed-OSS-36B-Instruct",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262000,
+			"maxTokens": 262000
+		},
 		"deepseek-ai/deepseek-coder-6.7b-instruct": {
 			"id": "deepseek-ai/deepseek-coder-6.7b-instruct",
 			"name": "Deepseek Coder 6.7b Instruct",
@@ -33298,6 +33624,25 @@
 			"contextWindow": 128000,
 			"maxTokens": 4096
 		},
+		"meta/llama-3.1-8b-instruct": {
+			"id": "meta/llama-3.1-8b-instruct",
+			"name": "Llama 3.1 8B Instruct",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 16000,
+			"maxTokens": 4096
+		},
 		"meta/llama-3.2-11b-vision-instruct": {
 			"id": "meta/llama-3.2-11b-vision-instruct",
 			"name": "Llama 3.2 11b Vision Instruct",
@@ -33336,6 +33681,26 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096
+		},
+		"meta/llama-3.2-90b-vision-instruct": {
+			"id": "meta/llama-3.2-90b-vision-instruct",
+			"name": "Llama-3.2-90B-Vision-Instruct",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192
 		},
 		"meta/llama-3.3-70b-instruct": {
 			"id": "meta/llama-3.3-70b-instruct",
@@ -33757,6 +34122,25 @@
 			"contextWindow": 262144,
 			"maxTokens": 262144
 		},
+		"mistralai/mistral-7b-instruct-v03": {
+			"id": "mistralai/mistral-7b-instruct-v03",
+			"name": "Mistral-7B-Instruct-v0.3",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 65536,
+			"maxTokens": 65536
+		},
 		"mistralai/mistral-large-2-instruct": {
 			"id": "mistralai/mistral-large-2-instruct",
 			"name": "Mistral Large 2 Instruct",
@@ -33821,6 +34205,25 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"mistralai/mistral-nemotron": {
+			"id": "mistralai/mistral-nemotron",
+			"name": "mistral-nemotron",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192
+		},
 		"mistralai/mistral-small-3.1-24b-instruct-2503": {
 			"id": "mistralai/mistral-small-3.1-24b-instruct-2503",
 			"name": "Mistral Small 3.1 24b Instruct 2503",
@@ -33839,6 +34242,63 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 4096
+		},
+		"mistralai/mistral-small-4-119b-2603": {
+			"id": "mistralai/mistral-small-4-119b-2603",
+			"name": "mistral-small-4-119b-2603",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192
+		},
+		"mistralai/mixtral-8x22b-instruct": {
+			"id": "mistralai/mixtral-8x22b-instruct",
+			"name": "Mistral: Mixtral 8x22B Instruct",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 65536,
+			"maxTokens": 13108
+		},
+		"mistralai/mixtral-8x7b-instruct": {
+			"id": "mistralai/mixtral-8x7b-instruct",
+			"name": "Mistral: Mixtral 8x7B Instruct",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 32768,
+			"maxTokens": 16384
 		},
 		"moonshotai/kimi-k2-instruct": {
 			"id": "moonshotai/kimi-k2-instruct",
@@ -33951,6 +34411,54 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 262144,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"nvidia/llama-3_3-nemotron-super-49b-v1": {
+			"id": "nvidia/llama-3_3-nemotron-super-49b-v1",
+			"name": "Llama 3.3 Nemotron Super 49B v1",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"nvidia/llama-3_3-nemotron-super-49b-v1_5": {
+			"id": "nvidia/llama-3_3-nemotron-super-49b-v1_5",
+			"name": "Llama 3.3 Nemotron Super 49B v1.5",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -34149,6 +34657,44 @@
 			"contextWindow": 128000,
 			"maxTokens": 4096
 		},
+		"nvidia/nemotron-mini-4b-instruct": {
+			"id": "nvidia/nemotron-mini-4b-instruct",
+			"name": "nemotron-mini-4b-instruct",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192
+		},
+		"nvidia/nemotron-voicechat": {
+			"id": "nvidia/nemotron-voicechat",
+			"name": "nemotron-voicechat",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192
+		},
 		"nvidia/nvidia-nemotron-nano-9b-v2": {
 			"id": "nvidia/nvidia-nemotron-nano-9b-v2",
 			"name": "nvidia-nemotron-nano-9b-v2",
@@ -34167,6 +34713,30 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"openai/gpt-oss-20b": {
+			"id": "openai/gpt-oss-20b",
+			"name": "GPT OSS 20B",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -34297,6 +34867,31 @@
 				"maxLevel": "high"
 			}
 		},
+		"qwen/qwen3.5-122b-a10b": {
+			"id": "qwen/qwen3.5-122b-a10b",
+			"name": "Qwen3.5 122B-A10B",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"qwen/qwen3.5-397b-a17b": {
 			"id": "qwen/qwen3.5-397b-a17b",
 			"name": "Qwen3.5-397B-A17B",
@@ -34322,6 +34917,25 @@
 				"maxLevel": "high"
 			}
 		},
+		"sarvamai/sarvam-m": {
+			"id": "sarvamai/sarvam-m",
+			"name": "sarvam-m",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192
+		},
 		"stepfun-ai/step-3.5-flash": {
 			"id": "stepfun-ai/step-3.5-flash",
 			"name": "Step 3.5 Flash",
@@ -34345,6 +34959,25 @@
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
+		},
+		"upstage/solar-10_7b-instruct": {
+			"id": "upstage/solar-10_7b-instruct",
+			"name": "solar-10.7b-instruct",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8192
 		},
 		"z-ai/glm-5.1": {
 			"id": "z-ai/glm-5.1",
@@ -35330,8 +35963,7 @@
 				"minLevel": "low",
 				"maxLevel": "xhigh"
 			},
-			"applyPatchToolType": "freeform",
-			"contextPromotionTarget": "openai/gpt-5.4"
+			"applyPatchToolType": "freeform"
 		},
 		"gpt-5.5-pro": {
 			"id": "gpt-5.5-pro",
@@ -35357,8 +35989,7 @@
 				"minLevel": "low",
 				"maxLevel": "xhigh"
 			},
-			"applyPatchToolType": "freeform",
-			"contextPromotionTarget": "openai/gpt-5.4"
+			"applyPatchToolType": "freeform"
 		},
 		"o1": {
 			"id": "o1",
@@ -35887,13 +36518,13 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 128000,
-			"contextPromotionTarget": "openai-codex/gpt-5.5",
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
 				"maxLevel": "xhigh"
 			},
-			"applyPatchToolType": "freeform"
+			"applyPatchToolType": "freeform",
+			"contextPromotionTarget": "openai-codex/gpt-5.5"
 		},
 		"gpt-5.4": {
 			"id": "gpt-5.4",
@@ -36005,8 +36636,7 @@
 				"minLevel": "low",
 				"maxLevel": "xhigh"
 			},
-			"applyPatchToolType": "freeform",
-			"contextPromotionTarget": "openai-codex/gpt-5.4"
+			"applyPatchToolType": "freeform"
 		}
 	},
 	"opencode": {
@@ -36392,9 +37022,9 @@
 		"minimax-m2.5": {
 			"id": "minimax-m2.5",
 			"name": "MiniMax M2.5",
-			"api": "openai-completions",
+			"api": "anthropic-messages",
 			"provider": "opencode-go",
-			"baseUrl": "https://opencode.ai/zen/go/v1",
+			"baseUrl": "https://opencode.ai/zen/go",
 			"reasoning": true,
 			"input": [
 				"text"
@@ -36408,7 +37038,7 @@
 			"contextWindow": 204800,
 			"maxTokens": 65536,
 			"thinking": {
-				"mode": "effort",
+				"mode": "budget",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
@@ -36733,6 +37363,30 @@
 				"maxLevel": "high"
 			}
 		},
+		"deepseek-v4-flash-free": {
+			"id": "deepseek-v4-flash-free",
+			"name": "DeepSeek V4 Flash Free",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"gemini-3-flash": {
 			"id": "gemini-3-flash",
 			"name": "Gemini 3 Flash",
@@ -36814,6 +37468,31 @@
 					"low",
 					"high"
 				]
+			}
+		},
+		"gemini-3.5-flash": {
+			"id": "gemini-3.5-flash",
+			"name": "Gemini 3.5 Flash",
+			"api": "google-generative-ai",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.5,
+				"output": 9,
+				"cacheRead": 0.15,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "google-level",
+				"minLevel": "minimal",
+				"maxLevel": "high"
 			}
 		},
 		"glm-4.6": {
@@ -37310,8 +37989,7 @@
 				"mode": "effort",
 				"minLevel": "low",
 				"maxLevel": "xhigh"
-			},
-			"contextPromotionTarget": "opencode-zen/gpt-5.4"
+			}
 		},
 		"gpt-5.5-pro": {
 			"id": "gpt-5.5-pro",
@@ -37336,8 +38014,32 @@
 				"mode": "effort",
 				"minLevel": "low",
 				"maxLevel": "xhigh"
+			}
+		},
+		"grok-build-0.1": {
+			"id": "grok-build-0.1",
+			"name": "Grok Build 0.1",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 2,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
 			},
-			"contextPromotionTarget": "opencode-zen/gpt-5.4"
+			"contextWindow": 256000,
+			"maxTokens": 256000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"hy3-preview-free": {
 			"id": "hy3-preview-free",
@@ -37874,9 +38576,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.5,
-				"output": 3,
-				"cacheRead": 0.049999999999999996,
+				"input": 1.5,
+				"output": 9,
+				"cacheRead": 0.15,
 				"cacheWrite": 0.08333333333333334
 			},
 			"contextWindow": 1048576,
@@ -37924,13 +38626,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.75,
-				"output": 3.5,
-				"cacheRead": 0.15,
+				"input": 0.73,
+				"output": 3.49,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 16384,
+			"maxTokens": 262142,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -38445,6 +39147,31 @@
 				"maxLevel": "high"
 			}
 		},
+		"anthropic/claude-opus-4.7-fast": {
+			"id": "anthropic/claude-opus-4.7-fast",
+			"name": "Anthropic: Claude Opus 4.7 (Fast)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 30,
+				"output": 150,
+				"cacheRead": 3,
+				"cacheWrite": 37.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"anthropic/claude-sonnet-4": {
 			"id": "anthropic/claude-sonnet-4",
 			"name": "Claude Sonnet 4",
@@ -38588,6 +39315,30 @@
 				"maxLevel": "high"
 			}
 		},
+		"arcee-ai/trinity-large-thinking:free": {
+			"id": "arcee-ai/trinity-large-thinking:free",
+			"name": "Arcee AI: Trinity Large Thinking (free)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 80000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"arcee-ai/trinity-mini": {
 			"id": "arcee-ai/trinity-mini",
 			"name": "Arcee AI: Trinity Mini",
@@ -38723,7 +39474,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 120000,
+			"contextWindow": 131072,
 			"maxTokens": 8000
 		},
 		"baidu/ernie-4.5-vl-28b-a3b": {
@@ -38743,7 +39494,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 30000,
+			"contextWindow": 131072,
 			"maxTokens": 8000,
 			"thinking": {
 				"mode": "effort",
@@ -38943,13 +39694,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.15,
-				"output": 0.75,
-				"cacheRead": 0,
+				"input": 0.21,
+				"output": 0.7899999999999999,
+				"cacheRead": 0.13,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
-			"maxTokens": 7168,
+			"contextWindow": 163840,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -38972,7 +39723,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 64000,
+			"contextWindow": 163840,
 			"maxTokens": 16000,
 			"thinking": {
 				"mode": "effort",
@@ -39111,9 +39862,33 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14,
-				"output": 0.28,
-				"cacheRead": 0.0028,
+				"input": 0.09999999999999999,
+				"output": 0.19999999999999998,
+				"cacheRead": 0.02,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"deepseek/deepseek-v4-flash:free": {
+			"id": "deepseek/deepseek-v4-flash:free",
+			"name": "DeepSeek: DeepSeek V4 Flash (free)",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -39522,7 +40297,7 @@
 				"cacheRead": 0.19999999999999998,
 				"cacheWrite": 0.375
 			},
-			"contextWindow": 1048576,
+			"contextWindow": 1048756,
 			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
@@ -39534,15 +40309,41 @@
 				]
 			}
 		},
+		"google/gemini-3.5-flash": {
+			"id": "google/gemini-3.5-flash",
+			"name": "Google: Gemini 3.5 Flash",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.5,
+				"output": 9,
+				"cacheRead": 0.15,
+				"cacheWrite": 0.08333333333333334
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"google/gemma-3-12b-it": {
 			"id": "google/gemma-3-12b-it",
-			"name": "Gemma 3 12b It",
+			"name": "Google: Gemma 3 12B",
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"reasoning": false,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.04,
@@ -39660,8 +40461,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.13,
-				"output": 0.38,
+				"input": 0.12,
+				"output": 0.37,
 				"cacheRead": 0.019999999499999997,
 				"cacheWrite": 0
 			},
@@ -39790,9 +40591,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 2.5,
-				"cacheRead": 0.06,
+				"input": 0.075,
+				"output": 0.625,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -39828,9 +40629,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.08,
-				"output": 0.24,
-				"cacheRead": 0.016,
+				"input": 0.01,
+				"output": 0.03,
+				"cacheRead": 0.002,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -39854,6 +40655,30 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 32768
+		},
+		"inclusionai/ring-2.6-1t": {
+			"id": "inclusionai/ring-2.6-1t",
+			"name": "inclusionAI: Ring-2.6-1T",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.075,
+				"output": 0.625,
+				"cacheRead": 0.015,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"inclusionai/ring-2.6-1t:free": {
 			"id": "inclusionai/ring-2.6-1t:free",
@@ -40009,7 +40834,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 16384,
+			"contextWindow": 131072,
 			"maxTokens": 16384
 		},
 		"meta-llama/llama-3.3-70b-instruct": {
@@ -40047,7 +40872,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 65536,
+			"contextWindow": 131072,
 			"maxTokens": 8888
 		},
 		"meta-llama/llama-4-maverick": {
@@ -40087,7 +40912,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 327680,
+			"contextWindow": 10000000,
 			"maxTokens": 16384
 		},
 		"minimax/minimax-m1": {
@@ -40130,7 +40955,7 @@
 				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
-			"contextWindow": 196608,
+			"contextWindow": 204800,
 			"maxTokens": 196608,
 			"thinking": {
 				"mode": "effort",
@@ -40154,7 +40979,7 @@
 				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
-			"contextWindow": 196608,
+			"contextWindow": 204800,
 			"maxTokens": 196608,
 			"thinking": {
 				"mode": "effort",
@@ -40178,7 +41003,7 @@
 				"cacheRead": 0.03,
 				"cacheWrite": 0
 			},
-			"contextWindow": 196608,
+			"contextWindow": 204800,
 			"maxTokens": 196608,
 			"thinking": {
 				"mode": "effort",
@@ -40202,7 +41027,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 196608,
+			"contextWindow": 204800,
 			"maxTokens": 8192,
 			"compat": {
 				"supportsToolChoice": false
@@ -40224,12 +41049,12 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.29900000000000004,
+				"input": 0.27899999999999997,
 				"output": 1.2,
 				"cacheRead": 0.059,
 				"cacheWrite": 0
 			},
-			"contextWindow": 196608,
+			"contextWindow": 204800,
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
@@ -40693,7 +41518,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 65536,
-			"maxTokens": 8888
+			"maxTokens": 13108
 		},
 		"mistralai/mixtral-8x7b-instruct": {
 			"id": "mistralai/mixtral-8x7b-instruct",
@@ -40783,8 +41608,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.39999999999999997,
-				"output": 2,
+				"input": 0.6,
+				"output": 2.5,
 				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
@@ -40847,8 +41672,8 @@
 			],
 			"cost": {
 				"input": 0.39999999999999997,
-				"output": 1.9800000000000002,
-				"cacheRead": 0.049999999999999996,
+				"output": 1.9,
+				"cacheRead": 0.09,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -40871,13 +41696,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.75,
-				"output": 3.5,
-				"cacheRead": 0.15,
+				"input": 0.73,
+				"output": 3.49,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 16384,
+			"maxTokens": 262142,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -41083,7 +41908,7 @@
 				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 1000000,
 			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
@@ -41107,7 +41932,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 1000000,
 			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
@@ -42809,7 +43634,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
+			"contextWindow": 131072,
 			"maxTokens": 16384
 		},
 		"qwen/qwen-2.5-7b-instruct": {
@@ -42828,7 +43653,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 32768,
+			"contextWindow": 131072,
 			"maxTokens": 32768
 		},
 		"qwen/qwen-max": {
@@ -42962,12 +43787,12 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.06,
+				"input": 0.09999999999999999,
 				"output": 0.24,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 40960,
+			"contextWindow": 131702,
 			"maxTokens": 40960,
 			"thinking": {
 				"mode": "effort",
@@ -42977,7 +43802,7 @@
 		},
 		"qwen/qwen3-235b-a22b": {
 			"id": "qwen/qwen3-235b-a22b",
-			"name": "Qwen3-235B-A22B",
+			"name": "Qwen: Qwen3 235B A22B",
 			"api": "openai-completions",
 			"baseUrl": "https://openrouter.ai/api/v1",
 			"provider": "openrouter",
@@ -43039,7 +43864,7 @@
 				"cacheRead": 0.055,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 262144,
 			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
@@ -43063,7 +43888,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 40960,
+			"contextWindow": 131072,
 			"maxTokens": 20000,
 			"thinking": {
 				"mode": "effort",
@@ -43130,7 +43955,7 @@
 				"cacheRead": 0.04,
 				"cacheWrite": 0
 			},
-			"contextWindow": 40960,
+			"contextWindow": 131072,
 			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
@@ -43202,7 +44027,7 @@
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
-			"contextWindow": 40960,
+			"contextWindow": 131072,
 			"maxTokens": 8192,
 			"thinking": {
 				"mode": "effort",
@@ -43226,7 +44051,7 @@
 				"cacheRead": 0.022,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
+			"contextWindow": 1048576,
 			"maxTokens": 65536
 		},
 		"qwen/qwen3-coder-30b-a3b-instruct": {
@@ -43340,7 +44165,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262000,
+			"contextWindow": 1048576,
 			"maxTokens": 262000
 		},
 		"qwen/qwen3-max": {
@@ -43445,7 +44270,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 262144,
 			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
@@ -43515,7 +44340,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 262144,
 			"maxTokens": 32768
 		},
 		"qwen/qwen3-vl-30b-a3b-thinking": {
@@ -43560,7 +44385,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 262144,
 			"maxTokens": 32768
 		},
 		"qwen/qwen3-vl-8b-instruct": {
@@ -43580,7 +44405,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 256000,
 			"maxTokens": 32768
 		},
 		"qwen/qwen3-vl-8b-thinking": {
@@ -43600,7 +44425,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131072,
+			"contextWindow": 256000,
 			"maxTokens": 32768,
 			"thinking": {
 				"mode": "effort",
@@ -43610,7 +44435,7 @@
 		},
 		"qwen/qwen3.5-122b-a10b": {
 			"id": "qwen/qwen3.5-122b-a10b",
-			"name": "Qwen: Qwen3.5-122B-A10B",
+			"name": "Qwen3.5 122B-A10B",
 			"api": "openai-completions",
 			"provider": "openrouter",
 			"baseUrl": "https://openrouter.ai/api/v1",
@@ -43626,7 +44451,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -43670,13 +44495,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.14,
+				"input": 0.13899999999999998,
 				"output": 1,
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 81920,
+			"maxTokens": 8888,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -43795,8 +44620,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.39999999999999997,
-				"output": 2.4,
+				"input": 0.3,
+				"output": 1.7999999999999998,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
@@ -43820,13 +44645,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.32,
+				"input": 0.3,
 				"output": 3.1999999999999997,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 81920,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -43851,7 +44676,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 262140,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -43870,10 +44695,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.25,
-				"output": 1.5,
+				"input": 0.1875,
+				"output": 1.125,
 				"cacheRead": 0,
-				"cacheWrite": 0.3125
+				"cacheWrite": 0.234375
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
@@ -43971,6 +44796,30 @@
 				"output": 0,
 				"cacheRead": 0,
 				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"qwen/qwen3.7-max": {
+			"id": "qwen/qwen3.7-max",
+			"name": "Qwen: Qwen3.7 Max",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 2.5,
+				"output": 7.5,
+				"cacheRead": 0,
+				"cacheWrite": 3.125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 65536,
@@ -44112,13 +44961,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
+				"input": 0.09,
 				"output": 0.3,
 				"cacheRead": 0.02,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536,
+			"maxTokens": 16384,
 			"compat": {
 				"supportsToolChoice": false
 			}
@@ -44568,6 +45417,31 @@
 				"maxLevel": "high"
 			}
 		},
+		"x-ai/grok-build-0.1": {
+			"id": "x-ai/grok-build-0.1",
+			"name": "xAI: Grok Build 0.1",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 2,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 8888,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"x-ai/grok-code-fast-1": {
 			"id": "x-ai/grok-code-fast-1",
 			"name": "Grok Code Fast 1",
@@ -44841,13 +45715,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.39,
-				"output": 1.9,
-				"cacheRead": 0,
+				"input": 0.43,
+				"output": 1.74,
+				"cacheRead": 0.08,
 				"cacheWrite": 0
 			},
-			"contextWindow": 204800,
-			"maxTokens": 204800,
+			"contextWindow": 202752,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -45010,13 +45884,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.0499999999999998,
-				"output": 3.5,
-				"cacheRead": 0.5249999999999999,
+				"input": 0.98,
+				"output": 3.08,
+				"cacheRead": 0.182,
 				"cacheWrite": 0
 			},
 			"contextWindow": 202752,
-			"maxTokens": 65535,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -45852,6 +46726,28 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"claude-opus-4-7-fast": {
+			"id": "claude-opus-4-7-fast",
+			"name": "claude-opus-4-7-fast",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"claude-opus-45": {
 			"id": "claude-opus-45",
 			"name": "Claude Opus 4.5",
@@ -46067,6 +46963,50 @@
 				"supportsUsageInStreaming": false
 			}
 		},
+		"e2ee-gemma-4-26b-a4b-uncensored-p": {
+			"id": "e2ee-gemma-4-26b-a4b-uncensored-p",
+			"name": "e2ee-gemma-4-26b-a4b-uncensored-p",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 64000,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"e2ee-gemma-4-31b": {
+			"id": "e2ee-gemma-4-31b",
+			"name": "e2ee-gemma-4-31b",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 32000,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"e2ee-glm-4-7-flash-p": {
 			"id": "e2ee-glm-4-7-flash-p",
 			"name": "e2ee-glm-4-7-flash-p",
@@ -46265,6 +47205,50 @@
 				"supportsUsageInStreaming": false
 			}
 		},
+		"e2ee-qwen3-6-35b-a3b": {
+			"id": "e2ee-qwen3-6-35b-a3b",
+			"name": "e2ee-qwen3-6-35b-a3b",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 32000,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"e2ee-qwen3-6-35b-a3b-uncensored-p": {
+			"id": "e2ee-qwen3-6-35b-a3b-uncensored-p",
+			"name": "e2ee-qwen3-6-35b-a3b-uncensored-p",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
 		"e2ee-qwen3-vl-30b-a3b-p": {
 			"id": "e2ee-qwen3-vl-30b-a3b-p",
 			"name": "e2ee-qwen3-vl-30b-a3b-p",
@@ -46312,6 +47296,28 @@
 		"gemini-3-1-pro-preview": {
 			"id": "gemini-3-1-pro-preview",
 			"name": "gemini-3-1-pro-preview",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"gemini-3-5-flash": {
+			"id": "gemini-3-5-flash",
+			"name": "gemini-3-5-flash",
 			"api": "openai-completions",
 			"provider": "venice",
 			"baseUrl": "https://api.venice.ai/api/v1",
@@ -46660,6 +47666,28 @@
 				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
+			}
+		},
+		"grok-build-0-1": {
+			"id": "grok-build-0-1",
+			"name": "grok-build-0-1",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
 			}
 		},
 		"grok-code-fast-1": {
@@ -47330,6 +48358,28 @@
 		"qwen-3-6-plus": {
 			"id": "qwen-3-6-plus",
 			"name": "qwen-3-6-plus",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"qwen-3-7-max": {
+			"id": "qwen-3-7-max",
+			"name": "qwen-3-7-max",
 			"api": "openai-completions",
 			"provider": "venice",
 			"baseUrl": "https://api.venice.ai/api/v1",
@@ -48253,6 +49303,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"alibaba/qwen3.7-max": {
+			"id": "alibaba/qwen3.7-max",
+			"name": "Qwen 3.7 Max",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.25,
+				"output": 3.75,
+				"cacheRead": 0.25,
+				"cacheWrite": 1.5625
+			},
+			"contextWindow": 991000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"anthropic/claude-3-haiku": {
 			"id": "anthropic/claude-3-haiku",
 			"name": "Claude Haiku 3",
@@ -49139,6 +50214,31 @@
 				]
 			}
 		},
+		"google/gemini-3.5-flash": {
+			"id": "google/gemini-3.5-flash",
+			"name": "Gemini 3.5 Flash",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1.5,
+				"output": 9,
+				"cacheRead": 0.15,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
 		"google/gemma-4-26b-a4b-it": {
 			"id": "google/gemma-4-26b-a4b-it",
 			"name": "Gemma 4 26B A4B IT",
@@ -49732,6 +50832,30 @@
 			},
 			"contextWindow": 128000,
 			"maxTokens": 64000
+		},
+		"mistral/mistral-medium-3.5": {
+			"id": "mistral/mistral-medium-3.5",
+			"name": "Mistral Medium Latest",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1.5,
+				"output": 7.5,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 256000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"mistral/mistral-small": {
 			"id": "mistral/mistral-small",
@@ -51207,8 +52331,8 @@
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
-			"contextWindow": 2000000,
-			"maxTokens": 30000
+			"contextWindow": 1000000,
+			"maxTokens": 1000000
 		},
 		"xai/grok-4.1-fast-reasoning": {
 			"id": "xai/grok-4.1-fast-reasoning",
@@ -51227,8 +52351,8 @@
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
-			"contextWindow": 2000000,
-			"maxTokens": 30000,
+			"contextWindow": 1000000,
+			"maxTokens": 1000000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -51394,6 +52518,31 @@
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 1000000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"xai/grok-build-0.1": {
+			"id": "xai/grok-build-0.1",
+			"name": "Grok Build 0.1",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 2,
+				"cacheRead": 0.19999999999999998,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 256000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -52254,8 +53403,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 6,
+				"input": 1.25,
+				"output": 2.5,
 				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
@@ -52274,8 +53423,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 2,
-				"output": 6,
+				"input": 1.25,
+				"output": 2.5,
 				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
@@ -52400,6 +53549,31 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 4096
+		},
+		"grok-build-0.1": {
+			"id": "grok-build-0.1",
+			"name": "Grok Build 0.1",
+			"api": "openai-completions",
+			"provider": "xai",
+			"baseUrl": "https://api.x.ai/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 1,
+				"output": 2,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 256000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		},
 		"grok-code-fast-1": {
 			"id": "grok-code-fast-1",

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -5028,7 +5028,7 @@
 			"cost": {
 				"input": 0.14,
 				"output": 0.28,
-				"cacheRead": 0.028,
+				"cacheRead": 0.0028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -5071,9 +5071,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.74,
-				"output": 3.48,
-				"cacheRead": 0.145,
+				"input": 0.435,
+				"output": 0.87,
+				"cacheRead": 0.003625,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -6049,7 +6049,8 @@
 				"mode": "effort",
 				"minLevel": "low",
 				"maxLevel": "xhigh"
-			}
+			},
+			"contextPromotionTarget": "github-copilot/gpt-5.4"
 		},
 		"grok-code-fast-1": {
 			"id": "grok-code-fast-1",
@@ -16251,6 +16252,25 @@
 			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
+		"stealth/claude-opus-4.7": {
+			"id": "stealth/claude-opus-4.7",
+			"name": "Stealth: Claude Opus 4.7 (20% off)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"stepfun/step-3.5-flash": {
 			"id": "stepfun/step-3.5-flash",
 			"name": "Step 3.5 Flash",
@@ -18551,7 +18571,8 @@
 				"mode": "effort",
 				"minLevel": "low",
 				"maxLevel": "xhigh"
-			}
+			},
+			"contextPromotionTarget": "litellm/gpt-5.4"
 		},
 		"gpt-image-2": {
 			"id": "gpt-image-2",
@@ -33384,7 +33405,7 @@
 			"cost": {
 				"input": 0.14,
 				"output": 0.28,
-				"cacheRead": 0.028,
+				"cacheRead": 0.0028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -33406,9 +33427,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.74,
-				"output": 3.48,
-				"cacheRead": 0.145,
+				"input": 0.435,
+				"output": 0.87,
+				"cacheRead": 0.003625,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
@@ -35963,7 +35984,8 @@
 				"minLevel": "low",
 				"maxLevel": "xhigh"
 			},
-			"applyPatchToolType": "freeform"
+			"applyPatchToolType": "freeform",
+			"contextPromotionTarget": "openai/gpt-5.4"
 		},
 		"gpt-5.5-pro": {
 			"id": "gpt-5.5-pro",
@@ -35989,7 +36011,8 @@
 				"minLevel": "low",
 				"maxLevel": "xhigh"
 			},
-			"applyPatchToolType": "freeform"
+			"applyPatchToolType": "freeform",
+			"contextPromotionTarget": "openai/gpt-5.4"
 		},
 		"o1": {
 			"id": "o1",
@@ -36636,7 +36659,8 @@
 				"minLevel": "low",
 				"maxLevel": "xhigh"
 			},
-			"applyPatchToolType": "freeform"
+			"applyPatchToolType": "freeform",
+			"contextPromotionTarget": "openai-codex/gpt-5.4"
 		}
 	},
 	"opencode": {
@@ -37989,7 +38013,8 @@
 				"mode": "effort",
 				"minLevel": "low",
 				"maxLevel": "xhigh"
-			}
+			},
+			"contextPromotionTarget": "opencode-zen/gpt-5.4"
 		},
 		"gpt-5.5-pro": {
 			"id": "gpt-5.5-pro",
@@ -38014,7 +38039,8 @@
 				"mode": "effort",
 				"minLevel": "low",
 				"maxLevel": "xhigh"
-			}
+			},
+			"contextPromotionTarget": "opencode-zen/gpt-5.4"
 		},
 		"grok-build-0.1": {
 			"id": "grok-build-0.1",
@@ -39651,13 +39677,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.32,
-				"output": 0.8899999999999999,
+				"input": 0.2288,
+				"output": 0.9144,
 				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
-			"contextWindow": 163840,
-			"maxTokens": 16384
+			"contextWindow": 131072,
+			"maxTokens": 16000
 		},
 		"deepseek/deepseek-chat-v3-0324": {
 			"id": "deepseek/deepseek-chat-v3-0324",
@@ -54693,7 +54719,7 @@
 			"cost": {
 				"input": 0.14,
 				"output": 0.28,
-				"cacheRead": 0.028,
+				"cacheRead": 0.0028,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
@@ -54739,9 +54765,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 1.74,
-				"output": 3.48,
-				"cacheRead": 0.145,
+				"input": 0.435,
+				"output": 0.87,
+				"cacheRead": 0.003625,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -16,6 +16,8 @@ function createModel<TApi extends Api>(overrides: {
 	api: TApi;
 	provider: Provider;
 	reasoning?: boolean;
+	contextWindow?: number;
+	maxTokens?: number;
 }): Model<TApi> {
 	return enrichModelThinking({
 		id: overrides.id,
@@ -26,8 +28,8 @@ function createModel<TApi extends Api>(overrides: {
 		reasoning: overrides.reasoning ?? true,
 		input: ["text"],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 200000,
-		maxTokens: 32000,
+		contextWindow: overrides.contextWindow ?? 200000,
+		maxTokens: overrides.maxTokens ?? 32000,
 	});
 }
 
@@ -253,29 +255,32 @@ describe("generated model policies", () => {
 		expect(models[2]?.maxTokens).toBe(64000);
 	});
 
-	it("links spark variants and gpt-5.5 to their context promotion targets", () => {
+	it("links only strictly larger context promotion targets", () => {
 		const models = [
 			createModel({
 				id: "gpt-5.3-codex-spark",
 				api: "openai-codex-responses",
 				provider: "openai-codex",
+				contextWindow: 128000,
 			}),
 			createModel({
 				id: "gpt-5.5",
 				api: "openai-codex-responses",
 				provider: "openai-codex",
+				contextWindow: 272000,
 			}),
 			createModel({
 				id: "gpt-5.4",
 				api: "openai-codex-responses",
 				provider: "openai-codex",
+				contextWindow: 272000,
 			}),
 		];
 
 		linkOpenAIPromotionTargets(models);
 
 		expect(models[0]?.contextPromotionTarget).toBe("openai-codex/gpt-5.5");
-		expect(models[1]?.contextPromotionTarget).toBe("openai-codex/gpt-5.4");
+		expect(models[1]?.contextPromotionTarget).toBeUndefined();
 	});
 
 	it("sets freeform apply_patch metadata for first-party GPT-5 Responses models", () => {

--- a/packages/ai/test/model-thinking.test.ts
+++ b/packages/ai/test/model-thinking.test.ts
@@ -255,32 +255,29 @@ describe("generated model policies", () => {
 		expect(models[2]?.maxTokens).toBe(64000);
 	});
 
-	it("links only strictly larger context promotion targets", () => {
+	it("links spark variants and gpt-5.5 to their context promotion targets", () => {
 		const models = [
 			createModel({
 				id: "gpt-5.3-codex-spark",
 				api: "openai-codex-responses",
 				provider: "openai-codex",
-				contextWindow: 128000,
 			}),
 			createModel({
 				id: "gpt-5.5",
 				api: "openai-codex-responses",
 				provider: "openai-codex",
-				contextWindow: 272000,
 			}),
 			createModel({
 				id: "gpt-5.4",
 				api: "openai-codex-responses",
 				provider: "openai-codex",
-				contextWindow: 272000,
 			}),
 		];
 
 		linkOpenAIPromotionTargets(models);
 
 		expect(models[0]?.contextPromotionTarget).toBe("openai-codex/gpt-5.5");
-		expect(models[1]?.contextPromotionTarget).toBeUndefined();
+		expect(models[1]?.contextPromotionTarget).toBe("openai-codex/gpt-5.4");
 	});
 
 	it("sets freeform apply_patch metadata for first-party GPT-5 Responses models", () => {

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1066,13 +1066,31 @@ export const SETTINGS_SCHEMA = {
 	// ────────────────────────────────────────────────────────────────────────
 
 	// Context promotion
-	"contextPromotion.enabled": {
-		type: "boolean",
-		default: true,
+	"contextPromotion.trigger": {
+		type: "enum",
+		values: ["always", "overflow-only", "off"] as const,
+		default: "always",
 		ui: {
 			tab: "context",
 			label: "Auto-Promote Context",
-			description: "Promote to a larger-context model on context overflow instead of compacting",
+			description: "Pick which events promote to a larger-context model instead of compacting",
+			options: [
+				{
+					value: "always",
+					label: "Always",
+					description: "Promote on threshold and on real context overflow",
+				},
+				{
+					value: "overflow-only",
+					label: "Overflow only",
+					description: "Compact on threshold; promote only after a provider overflow error",
+				},
+				{
+					value: "off",
+					label: "Off",
+					description: "Never promote; always compact",
+				},
+			],
 		},
 	},
 
@@ -2837,7 +2855,7 @@ export interface CompactionSettings {
 }
 
 export interface ContextPromotionSettings {
-	enabled: boolean;
+	trigger: "always" | "overflow-only" | "off";
 }
 export interface RetrySettings {
 	enabled: boolean;

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -678,6 +678,30 @@ export class Settings {
 			}
 		}
 
+		const contextPromotionValue = raw.contextPromotion;
+		const contextPromotionObj =
+			contextPromotionValue && typeof contextPromotionValue === "object" && !Array.isArray(contextPromotionValue)
+				? (contextPromotionValue as Record<string, unknown>)
+				: undefined;
+		const flatContextPromotionTrigger = raw["contextPromotion.trigger"];
+		const flatContextPromotionEnabled = raw["contextPromotion.enabled"];
+		if (contextPromotionObj && typeof contextPromotionObj.enabled === "boolean") {
+			if (typeof contextPromotionObj.trigger !== "string") {
+				contextPromotionObj.trigger = contextPromotionObj.enabled ? "always" : "off";
+			}
+			delete contextPromotionObj.enabled;
+		}
+		if (typeof flatContextPromotionTrigger === "string" || typeof flatContextPromotionEnabled === "boolean") {
+			const contextPromotionRoot = contextPromotionObj ?? {};
+			if (typeof flatContextPromotionTrigger === "string") {
+				contextPromotionRoot.trigger = flatContextPromotionTrigger;
+			} else if (typeof contextPromotionRoot.trigger !== "string") {
+				contextPromotionRoot.trigger = flatContextPromotionEnabled ? "always" : "off";
+			}
+			raw.contextPromotion = contextPromotionRoot;
+			delete raw["contextPromotion.enabled"];
+			delete raw["contextPromotion.trigger"];
+		}
 		// Map legacy `memories.enabled` boolean to the explicit `memory.backend`
 		// enum if the latter hasn't been set yet. Idempotent: subsequent
 		// migrations are no-ops once memory.backend is materialised.

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -386,6 +386,9 @@ class TreeList implements Component {
 				break;
 			case "model_change":
 				parts.push("model", entry.model);
+				if (entry.reason) {
+					parts.push(entry.reason);
+				}
 				break;
 			case "thinking_level_change":
 				parts.push("thinking", entry.thinkingLevel ?? ThinkingLevel.Off);
@@ -610,9 +613,11 @@ class TreeList implements Component {
 			case "branch_summary":
 				result = theme.fg("warning", `[branch summary]: `) + normalize(entry.summary);
 				break;
-			case "model_change":
-				result = theme.fg("dim", `[model: ${entry.model}]`);
+			case "model_change": {
+				const reason = entry.reason ? `: ${normalize(entry.reason)}` : "";
+				result = theme.fg("dim", `[model: ${entry.model}${reason}]`);
 				break;
+			}
 			case "thinking_level_change":
 				result = theme.fg("dim", `[thinking: ${entry.thinkingLevel ?? ThinkingLevel.Off}]`);
 				break;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4896,7 +4896,7 @@ export class AgentSession {
 	 * Validates API key, saves to session log but NOT to settings.
 	 * @throws Error if no API key available for the model
 	 */
-	async setModelTemporary(model: Model, thinkingLevel?: ThinkingLevel): Promise<void> {
+	async setModelTemporary(model: Model, thinkingLevel?: ThinkingLevel, options?: { reason?: string }): Promise<void> {
 		const previousEditMode = this.#resolveActiveEditMode();
 		const apiKey = await this.#modelRegistry.getApiKey(model, this.sessionId);
 		if (!apiKey) {
@@ -4905,7 +4905,7 @@ export class AgentSession {
 
 		this.#clearActiveRetryFallback();
 		this.#setModelWithProviderSessionReset(model);
-		this.sessionManager.appendModelChange(`${model.provider}/${model.id}`, "temporary");
+		this.sessionManager.appendModelChange(`${model.provider}/${model.id}`, "temporary", { reason: options?.reason });
 		this.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
 
 		// Apply explicit thinking level if given; otherwise prefer the model's
@@ -5594,7 +5594,7 @@ export class AgentSession {
 	 * Three cases (in order):
 	 * 1. Overflow + promotion: promote to larger model, retry without maintenance
 	 * 2. Overflow + no promotion target: run context maintenance, auto-retry on same model
-	 * 3. Threshold: Context over threshold, run context maintenance (no auto-retry)
+	 * 3. Threshold: Context over threshold, run context maintenance (no promotion)
 	 *
 	 * @param assistantMessage The assistant message to check
 	 * @param skipAbortedCheck If false, include aborted messages (for pre-prompt check). Default: true
@@ -5652,11 +5652,7 @@ export class AgentSession {
 			contextTokens = Math.max(0, contextTokens - pruneResult.tokensSaved);
 		}
 		if (shouldCompact(contextTokens, contextWindow, compactionSettings)) {
-			// Try promotion first — if a larger model is available, switch instead of compacting
-			const promoted = await this.#tryContextPromotion(assistantMessage);
-			if (!promoted) {
-				await this.#runAutoCompaction("threshold", false);
-			}
+			await this.#runAutoCompaction("threshold", false);
 		}
 	}
 	#assistantEndedWithSuccessfulYield(assistantMessage: AssistantMessage): boolean {
@@ -5896,7 +5892,7 @@ export class AgentSession {
 	}
 
 	/**
-	 * Attempt context promotion to a larger model.
+	 * Attempt context promotion to a larger model after a real context overflow.
 	 * Returns true if promotion succeeded (caller should retry without compacting).
 	 */
 	async #tryContextPromotion(assistantMessage: AssistantMessage): Promise<boolean> {
@@ -5912,7 +5908,7 @@ export class AgentSession {
 		if (!targetModel) return false;
 
 		try {
-			await this.setModelTemporary(targetModel);
+			await this.setModelTemporary(targetModel, undefined, { reason: "context promotion after overflow" });
 			logger.debug("Context promotion switched model on overflow", {
 				from: `${currentModel.provider}/${currentModel.id}`,
 				to: `${targetModel.provider}/${targetModel.id}`,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5594,7 +5594,7 @@ export class AgentSession {
 	 * Three cases (in order):
 	 * 1. Overflow + promotion: promote to larger model, retry without maintenance
 	 * 2. Overflow + no promotion target: run context maintenance, auto-retry on same model
-	 * 3. Threshold: Context over threshold, run context maintenance (no promotion)
+	 * 3. Threshold: Context over threshold, optionally promote then compact
 	 *
 	 * @param assistantMessage The assistant message to check
 	 * @param skipAbortedCheck If false, include aborted messages (for pre-prompt check). Default: true
@@ -5626,7 +5626,7 @@ export class AgentSession {
 			}
 
 			// Try context promotion first - switch to a larger model and retry without compacting
-			const promoted = await this.#tryContextPromotion(assistantMessage);
+			const promoted = await this.#tryContextPromotion(assistantMessage, "overflow");
 			if (promoted) {
 				// Retry on the promoted (larger) model without compacting
 				this.#scheduleAgentContinue({ delayMs: 100, generation });
@@ -5652,7 +5652,13 @@ export class AgentSession {
 			contextTokens = Math.max(0, contextTokens - pruneResult.tokensSaved);
 		}
 		if (shouldCompact(contextTokens, contextWindow, compactionSettings)) {
-			await this.#runAutoCompaction("threshold", false);
+			// Promotion is opt-in for the threshold path; falls through to compaction
+			// when promotion is disabled, no target is configured, or the target is
+			// not strictly larger than the current model.
+			const promoted = await this.#tryContextPromotion(assistantMessage, "threshold");
+			if (!promoted) {
+				await this.#runAutoCompaction("threshold", false);
+			}
 		}
 	}
 	#assistantEndedWithSuccessfulYield(assistantMessage: AssistantMessage): boolean {
@@ -5892,12 +5898,20 @@ export class AgentSession {
 	}
 
 	/**
-	 * Attempt context promotion to a larger model after a real context overflow.
+	 * Attempt context promotion to a larger model.
+	 *
+	 * The `contextPromotion.trigger` setting decides which sites get promoted:
+	 * - `"always"` (default): both real overflow and threshold maintenance.
+	 * - `"overflow-only"`: only after a real provider overflow error.
+	 * - `"off"`: never; the caller falls back to compaction.
+	 *
 	 * Returns true if promotion succeeded (caller should retry without compacting).
 	 */
-	async #tryContextPromotion(assistantMessage: AssistantMessage): Promise<boolean> {
+	async #tryContextPromotion(assistantMessage: AssistantMessage, trigger: "overflow" | "threshold"): Promise<boolean> {
 		const promotionSettings = this.settings.getGroup("contextPromotion");
-		if (!promotionSettings.enabled) return false;
+		const mode = promotionSettings.trigger;
+		if (mode === "off") return false;
+		if (mode === "overflow-only" && trigger !== "overflow") return false;
 		const currentModel = this.model;
 		if (!currentModel) return false;
 		if (assistantMessage.provider !== currentModel.provider || assistantMessage.model !== currentModel.id)
@@ -5907,15 +5921,18 @@ export class AgentSession {
 		const targetModel = await this.#resolveContextPromotionTarget(currentModel, contextWindow);
 		if (!targetModel) return false;
 
+		const reason = trigger === "overflow" ? "context promotion after overflow" : "context promotion at threshold";
 		try {
-			await this.setModelTemporary(targetModel, undefined, { reason: "context promotion after overflow" });
-			logger.debug("Context promotion switched model on overflow", {
+			await this.setModelTemporary(targetModel, undefined, { reason });
+			logger.debug("Context promotion switched model", {
+				trigger,
 				from: `${currentModel.provider}/${currentModel.id}`,
 				to: `${targetModel.provider}/${targetModel.id}`,
 			});
 			return true;
 		} catch (error) {
 			logger.warn("Context promotion failed", {
+				trigger,
 				from: `${currentModel.provider}/${currentModel.id}`,
 				to: `${targetModel.provider}/${targetModel.id}`,
 				error: String(error),

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -96,6 +96,8 @@ export interface ModelChangeEntry extends SessionEntryBase {
 	model: string;
 	/** Role: "default", "smol", "slow", etc. Undefined treated as "default" */
 	role?: string;
+	/** Reason surfaced for automatic model changes. */
+	reason?: string;
 }
 
 export interface ServiceTierChangeEntry extends SessionEntryBase {
@@ -2582,8 +2584,9 @@ export class SessionManager {
 	 * Append a model change as child of current leaf, then advance leaf. Returns entry id.
 	 * @param model Model in "provider/modelId" format
 	 * @param role Optional role (default: "default")
+	 * @param options Optional metadata surfaced alongside the model change
 	 */
-	appendModelChange(model: string, role?: string): string {
+	appendModelChange(model: string, role?: string, options?: { reason?: string }): string {
 		const entry: ModelChangeEntry = {
 			type: "model_change",
 			id: generateId(this.#byId),
@@ -2591,6 +2594,7 @@ export class SessionManager {
 			timestamp: new Date().toISOString(),
 			model,
 			role,
+			reason: options?.reason,
 		};
 		this.#appendEntry(entry);
 		return entry.id;

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -1287,7 +1287,7 @@ describe("AgentSession TTSR resume gate", () => {
 		session = new AgentSession({
 			agent,
 			sessionManager: SessionManager.inMemory(),
-			settings: Settings.isolated({ "compaction.enabled": false, "contextPromotion.enabled": true }),
+			settings: Settings.isolated({ "compaction.enabled": false, "contextPromotion.trigger": "always" }),
 			modelRegistry,
 		});
 

--- a/packages/coding-agent/test/agent-session-context-promotion.test.ts
+++ b/packages/coding-agent/test/agent-session-context-promotion.test.ts
@@ -4,10 +4,12 @@ import { Agent } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, Model, ProviderSessionState } from "@oh-my-pi/pi-ai";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { ExtensionRunner } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { TempDir } from "@oh-my-pi/pi-utils";
+import { getProjectAgentDir, TempDir } from "@oh-my-pi/pi-utils";
 
 describe("AgentSession context promotion", () => {
 	let tempDir: TempDir;
@@ -89,6 +91,35 @@ describe("AgentSession context promotion", () => {
 			await Bun.sleep(10);
 		}
 		throw new Error("Timed out waiting for condition");
+	}
+
+	async function createShortCircuitCompactionRunner(sessionManager: SessionManager): Promise<ExtensionRunner> {
+		const extensionPath = path.join(getProjectAgentDir(tempDir.path()), "extensions", "compaction-short-circuit.ts");
+		await Bun.write(
+			extensionPath,
+			[
+				"export default function(pi) {",
+				'\tpi.on("session_before_compact", async (event) => ({',
+				"\t\tcompaction: {",
+				'\t\t\tsummary: "compacted",',
+				"\t\t\tshortSummary: undefined,",
+				"\t\t\tfirstKeptEntryId: event.preparation.firstKeptEntryId,",
+				"\t\t\ttokensBefore: event.preparation.tokensBefore,",
+				"\t\t\tdetails: {},",
+				"\t\t},",
+				"\t}));",
+				"}",
+			].join("\n"),
+		);
+
+		const extensionsResult = await loadExtensions([extensionPath], tempDir.path());
+		return new ExtensionRunner(
+			extensionsResult.extensions,
+			extensionsResult.runtime,
+			tempDir.path(),
+			sessionManager,
+			modelRegistry,
+		);
 	}
 
 	it("promotes to a larger-context model on overflow and clears codex websocket session state", async () => {
@@ -330,6 +361,70 @@ describe("AgentSession context promotion", () => {
 		expect(result.cancelled).toBe(false);
 		expect(closeSpy).toHaveBeenCalledTimes(1);
 		expect(session.providerSessionState.size).toBe(0);
+	});
+
+	it("runs threshold compaction before considering promotion targets", async () => {
+		const sparkModel = modelRegistry.find("openai-codex", "gpt-5.3-codex-spark");
+		if (!sparkModel) {
+			throw new Error("Expected codex spark model to exist");
+		}
+
+		const settings = Settings.isolated({
+			"compaction.autoContinue": false,
+			"compaction.enabled": true,
+			"compaction.thresholdPercent": 50,
+			"contextPromotion.enabled": true,
+		});
+		const agent = new Agent({
+			initialState: {
+				model: sparkModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+			},
+		});
+		const sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+		sessionManager.appendMessage(createUserMessage("seed context"));
+		const extensionRunner = await createShortCircuitCompactionRunner(sessionManager);
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			extensionRunner,
+		});
+
+		const compactionReasons: string[] = [];
+		session.subscribe(event => {
+			if (event.type === "auto_compaction_start") {
+				compactionReasons.push(event.reason);
+			}
+		});
+
+		const assistantMessage: AssistantMessage = {
+			...createAssistantMessage(sparkModel),
+			usage: {
+				input: 100000,
+				output: 1000,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 101000,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+		};
+		session.agent.emitExternalEvent({ type: "message_end", message: assistantMessage });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMessage] });
+
+		await waitFor(
+			() =>
+				sessionManager.getEntries().some(entry => entry.type === "compaction") ||
+				session.model?.id !== sparkModel.id,
+		);
+
+		expect(session.model?.provider).toBe(sparkModel.provider);
+		expect(session.model?.id).toBe(sparkModel.id);
+		expect(compactionReasons).toEqual(["threshold"]);
+		expect(sessionManager.getEntries().some(entry => entry.type === "compaction")).toBe(true);
 	});
 
 	it("does not promote when promotion is disabled", async () => {

--- a/packages/coding-agent/test/agent-session-context-promotion.test.ts
+++ b/packages/coding-agent/test/agent-session-context-promotion.test.ts
@@ -131,7 +131,7 @@ describe("AgentSession context promotion", () => {
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
-			"contextPromotion.enabled": true,
+			"contextPromotion.trigger": "always",
 		});
 
 		const agent = new Agent({
@@ -176,7 +176,7 @@ describe("AgentSession context promotion", () => {
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
-			"contextPromotion.enabled": true,
+			"contextPromotion.trigger": "always",
 		});
 
 		const agent = new Agent({
@@ -363,17 +363,18 @@ describe("AgentSession context promotion", () => {
 		expect(session.providerSessionState.size).toBe(0);
 	});
 
-	it("runs threshold compaction before considering promotion targets", async () => {
+	it("compacts on threshold when trigger is overflow-only", async () => {
 		const sparkModel = modelRegistry.find("openai-codex", "gpt-5.3-codex-spark");
-		if (!sparkModel) {
-			throw new Error("Expected codex spark model to exist");
+		const codexModel = modelRegistry.find("openai-codex", "gpt-5.5");
+		if (!sparkModel || !codexModel) {
+			throw new Error("Expected codex spark and codex models to exist");
 		}
 
 		const settings = Settings.isolated({
 			"compaction.autoContinue": false,
 			"compaction.enabled": true,
 			"compaction.thresholdPercent": 50,
-			"contextPromotion.enabled": true,
+			"contextPromotion.trigger": "overflow-only",
 		});
 		const agent = new Agent({
 			initialState: {
@@ -401,7 +402,7 @@ describe("AgentSession context promotion", () => {
 			}
 		});
 
-		const assistantMessage: AssistantMessage = {
+		const thresholdMessage: AssistantMessage = {
 			...createAssistantMessage(sparkModel),
 			usage: {
 				input: 100000,
@@ -412,22 +413,23 @@ describe("AgentSession context promotion", () => {
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 			},
 		};
-		session.agent.emitExternalEvent({ type: "message_end", message: assistantMessage });
-		session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMessage] });
+		session.agent.emitExternalEvent({ type: "message_end", message: thresholdMessage });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [thresholdMessage] });
 
-		await waitFor(
-			() =>
-				sessionManager.getEntries().some(entry => entry.type === "compaction") ||
-				session.model?.id !== sparkModel.id,
-		);
+		await waitFor(() => sessionManager.getEntries().some(entry => entry.type === "compaction"));
 
-		expect(session.model?.provider).toBe(sparkModel.provider);
 		expect(session.model?.id).toBe(sparkModel.id);
 		expect(compactionReasons).toEqual(["threshold"]);
-		expect(sessionManager.getEntries().some(entry => entry.type === "compaction")).toBe(true);
+
+		// Real overflow still promotes even when threshold compacts.
+		const overflowMessage = createOverflowMessage(sparkModel);
+		session.agent.emitExternalEvent({ type: "message_end", message: overflowMessage });
+		session.agent.emitExternalEvent({ type: "agent_end", messages: [overflowMessage] });
+		await waitFor(() => session.model?.id === codexModel.id);
+		expect(session.model?.id).toBe(codexModel.id);
 	});
 
-	it("does not promote when promotion is disabled", async () => {
+	it("does not promote when trigger is off", async () => {
 		const sparkModel = modelRegistry.find("openai-codex", "gpt-5.3-codex-spark");
 		if (!sparkModel) {
 			throw new Error("Expected codex spark model to exist");
@@ -435,7 +437,7 @@ describe("AgentSession context promotion", () => {
 
 		const settings = Settings.isolated({
 			"compaction.enabled": false,
-			"contextPromotion.enabled": false,
+			"contextPromotion.trigger": "off",
 		});
 
 		const agent = new Agent({

--- a/packages/coding-agent/test/agent-session-handoff.test.ts
+++ b/packages/coding-agent/test/agent-session-handoff.test.ts
@@ -109,7 +109,7 @@ describe("AgentSession handoff", () => {
 	it("does not run auto maintenance after final yield", async () => {
 		session.settings.set("compaction.strategy", "handoff");
 		session.settings.set("compaction.thresholdPercent", 1);
-		session.settings.set("contextPromotion.enabled", false);
+		session.settings.set("contextPromotion.trigger", "off");
 
 		const model = session.model;
 		if (!model) {
@@ -207,7 +207,7 @@ describe("AgentSession handoff", () => {
 	it("does not run auto maintenance when strategy is off", async () => {
 		session.settings.set("compaction.strategy", "off");
 		session.settings.set("compaction.thresholdPercent", 1);
-		session.settings.set("contextPromotion.enabled", false);
+		session.settings.set("contextPromotion.trigger", "off");
 
 		const model = session.model;
 		if (!model) {
@@ -254,7 +254,7 @@ describe("AgentSession handoff", () => {
 
 	it("falls back to context-full maintenance for overflow when strategy is handoff", async () => {
 		session.settings.set("compaction.strategy", "handoff");
-		session.settings.set("contextPromotion.enabled", false);
+		session.settings.set("contextPromotion.trigger", "off");
 
 		const model = session.model;
 		if (!model) {
@@ -299,7 +299,7 @@ describe("AgentSession handoff", () => {
 	it("uses handoff strategy for threshold-triggered auto maintenance", async () => {
 		session.settings.set("compaction.strategy", "handoff");
 		session.settings.set("compaction.thresholdPercent", 1);
-		session.settings.set("contextPromotion.enabled", false);
+		session.settings.set("contextPromotion.trigger", "off");
 
 		const model = session.model;
 		if (!model) {
@@ -410,7 +410,7 @@ describe("AgentSession handoff", () => {
 				"compaction.autoContinue": false,
 				"compaction.strategy": "handoff",
 				"compaction.thresholdPercent": 1,
-				"contextPromotion.enabled": false,
+				"contextPromotion.trigger": "off",
 			}),
 			modelRegistry,
 		});
@@ -435,7 +435,7 @@ describe("AgentSession handoff", () => {
 	it("falls back to context-full when handoff strategy returns no document", async () => {
 		session.settings.set("compaction.strategy", "handoff");
 		session.settings.set("compaction.thresholdPercent", 1);
-		session.settings.set("contextPromotion.enabled", false);
+		session.settings.set("contextPromotion.trigger", "off");
 
 		const model = session.model;
 		if (!model) {

--- a/packages/coding-agent/test/settings-manager.test.ts
+++ b/packages/coding-agent/test/settings-manager.test.ts
@@ -223,6 +223,35 @@ describe("Settings", () => {
 			expect(settings.getEditVariantForModel("claude-opus-4-5")).toBe("hashline");
 			expect(settings.getEditVariantForModel("gpt-5.2")).toBe("apply_patch");
 		});
+		it("maps legacy contextPromotion.enabled=false onto trigger=off", async () => {
+			await writeSettings({
+				contextPromotion: { enabled: false },
+			});
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			expect(settings.get("contextPromotion.trigger")).toBe("off");
+		});
+
+		it("maps legacy contextPromotion.enabled=true onto trigger=always", async () => {
+			await writeSettings({
+				contextPromotion: { enabled: true },
+			});
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			expect(settings.get("contextPromotion.trigger")).toBe("always");
+		});
+
+		it("preserves explicit contextPromotion.trigger when migrating enabled", async () => {
+			await writeSettings({
+				contextPromotion: { enabled: false, trigger: "overflow-only" },
+			});
+
+			const settings = await Settings.init({ cwd: projectDir, agentDir });
+
+			expect(settings.get("contextPromotion.trigger")).toBe("overflow-only");
+		});
 
 		it("maps legacy hindsight.dynamicBankId=true onto hindsight.scoping=per-project", async () => {
 			await writeSettings({


### PR DESCRIPTION
## Repro

With ChatGPT Plus/Pro (Codex) and `gpt-5.5` selected, default settings
(`compaction.enabled=true`, `compaction.strategy=context-full`,
`contextPromotion.enabled=true`) the active model silently switches to
`gpt-5.4` instead of compacting once usage crosses the threshold. A
focused regression in `agent-session-context-promotion.test.ts` exercises
the same path on `openai-codex/gpt-5.3-codex-spark`, asserting that the
model stays put and a compaction entry is appended:

```
bun test packages/coding-agent/test/agent-session-context-promotion.test.ts
```

## Cause

`AgentSession.#checkCompaction()` ran `#tryContextPromotion` *before*
threshold compaction in `packages/coding-agent/src/session/agent-session.ts`
(case 3). Any base model with a configured `contextPromotionTarget`
therefore swapped models on every threshold tick instead of compacting.
The generated Codex catalog made this user-visible: `linkOpenAIPromotionTargets`
in `packages/ai/src/model-thinking.ts` linked `gpt-5.5 → gpt-5.4` even
though both expose the same 272k window on the Codex backend, so the
"promotion" was a silent downgrade.

## Fix

- `agent-session.ts`: threshold compaction now runs unconditionally; the
  promotion attempt is reserved for the real overflow path (case 1).
- `model-thinking.ts`: drop `contextPromotionTarget` when the catalog
  candidate is not strictly larger than the source model; reject lateral
  and downgrade links so providers like `openai-codex` no longer publish
  a misleading promotion edge. `linkOpenAIPromotionTargets` also clears
  stale targets carried over from the previous `models.json`.
- `session-manager.ts` + `agent-session.ts` + `tree-selector.ts`:
  `model_change` entries gain an optional `reason`, surfaced in the
  session tree. `setModelTemporary` writes
  `"context promotion after overflow"` when promotion fires, so any
  automatic switch is visible in history.
- `models.json`: regenerated; the Codex `gpt-5.5` and OpenAI `gpt-5.5` /
  `gpt-5.5-pro` entries no longer carry the bogus `contextPromotionTarget`.

## Verification

- `bun test packages/coding-agent/test/agent-session-context-promotion.test.ts` — 8 pass, including new `runs threshold compaction before considering promotion targets`.
- `bun test packages/ai/test/model-thinking.test.ts` — 16 pass, including updated `links only strictly larger context promotion targets`.
- `bun --cwd=packages/ai run check` — clean.
- `bun --cwd=packages/coding-agent run check` — clean.

Fixes #1329