### PR TITLE
fix(plugin-loader): expand manifest extensions directories to nested entries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed plugins whose manifest declares an `extensions` directory entry (e.g. `pi-autoresearch`'s `pi: { extensions: ["./extensions"] }`) but lays out concrete extensions under nested subdirectories (`./extensions/<name>/index.ts`) silently resolving to zero entry points. `resolveManifestEntries` now mirrors the agent's own `discoverExtensionsInDir` rules when a manifest extensions entry points at a directory without a top-level `index.{ts,js,mjs,cjs}`: the directory's immediate children are scanned for direct `.ts`/`.js`/`.mjs`/`.cjs` files and subdirectories containing an index file. Behavior is unchanged for the tools/hooks/commands keys, which still require explicit single-file entries ([#1292](https://github.com/can1357/oh-my-pi/issues/1292))
+
 ## [15.2.4] - 2026-05-22
 ### Breaking Changes
 

--- a/packages/coding-agent/src/extensibility/plugins/loader.ts
+++ b/packages/coding-agent/src/extensibility/plugins/loader.ts
@@ -120,26 +120,64 @@ export async function getEnabledPlugins(cwd: string): Promise<InstalledPlugin[]>
 const MANIFEST_ENTRY_INDEX_NAMES = ["index.ts", "index.js", "index.mjs", "index.cjs"];
 
 /**
- * Resolve a plugin manifest entry to a concrete loadable file path. Returns the
- * file path itself when the entry points at a file, the matching index file when
- * the entry points at a directory containing index.{ts,js,mjs,cjs}, and null
- * when no entry exists at the joined path.
+ * Resolve a plugin manifest entry to one or more concrete loadable file paths.
+ *
+ * - A file entry resolves to itself.
+ * - A directory entry resolves to its `index.{ts,js,mjs,cjs}` when present.
+ * - When `expandDirectory` is set and the directory has no top-level index,
+ *   the directory's immediate children are scanned for entry points: direct
+ *   `.ts`/`.js`/`.mjs`/`.cjs` files and subdirectories containing an index
+ *   file. Mirrors the agent's own `discoverExtensionsInDir` rules so that
+ *   plugins declaring `pi.extensions: ["./extensions"]` and laying out
+ *   concrete extensions under `./extensions/<name>/index.ts` resolve to
+ *   those nested entries instead of silently dropping to zero.
+ *
+ * Returns an empty array when no entry exists at the joined path.
  */
-function resolveManifestEntryFile(joined: string): string | null {
+function resolveManifestEntries(joined: string, options: { expandDirectory: boolean }): string[] {
 	let stats: fs.Stats;
 	try {
 		stats = fs.statSync(joined);
 	} catch {
-		return null;
+		return [];
 	}
-	if (stats.isDirectory()) {
-		for (const name of MANIFEST_ENTRY_INDEX_NAMES) {
-			const candidate = path.join(joined, name);
-			if (fs.existsSync(candidate)) return candidate;
+	if (!stats.isDirectory()) {
+		return [joined];
+	}
+	for (const name of MANIFEST_ENTRY_INDEX_NAMES) {
+		const candidate = path.join(joined, name);
+		if (fs.existsSync(candidate)) return [candidate];
+	}
+	if (!options.expandDirectory) return [];
+
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(joined, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+	const results: string[] = [];
+	for (const entry of entries) {
+		const entryPath = path.join(joined, entry.name);
+		if ((entry.isFile() || entry.isSymbolicLink()) && isExtensionEntryFile(entry.name)) {
+			results.push(entryPath);
+			continue;
 		}
-		return null;
+		if (entry.isDirectory() || entry.isSymbolicLink()) {
+			for (const name of MANIFEST_ENTRY_INDEX_NAMES) {
+				const candidate = path.join(entryPath, name);
+				if (fs.existsSync(candidate)) {
+					results.push(candidate);
+					break;
+				}
+			}
+		}
 	}
-	return joined;
+	return results;
+}
+
+function isExtensionEntryFile(name: string): boolean {
+	return name.endsWith(".ts") || name.endsWith(".js") || name.endsWith(".mjs") || name.endsWith(".cjs");
 }
 
 /**
@@ -149,16 +187,16 @@ function resolveManifestEntryFile(joined: string): string | null {
 function resolvePluginPaths(plugin: InstalledPlugin, key: "tools" | "hooks" | "commands" | "extensions"): string[] {
 	const paths: string[] = [];
 	const manifest = plugin.manifest;
+	// Directory-of-extensions expansion is extensions-only; tools/hooks/commands
+	// are addressed by single explicit files in the manifest.
+	const expandDirectory = key === "extensions";
 
 	// Base entry (always included if exists)
 	const base = manifest[key];
 	if (base) {
 		const entries = Array.isArray(base) ? base : [base];
 		for (const entry of entries) {
-			const resolved = resolveManifestEntryFile(path.join(plugin.path, entry));
-			if (resolved) {
-				paths.push(resolved);
-			}
+			paths.push(...resolveManifestEntries(path.join(plugin.path, entry), { expandDirectory }));
 		}
 	}
 
@@ -171,10 +209,7 @@ function resolvePluginPaths(plugin: InstalledPlugin, key: "tools" | "hooks" | "c
 
 			if (feat[key]) {
 				for (const entry of feat[key]) {
-					const resolved = resolveManifestEntryFile(path.join(plugin.path, entry));
-					if (resolved) {
-						paths.push(resolved);
-					}
+					paths.push(...resolveManifestEntries(path.join(plugin.path, entry), { expandDirectory }));
 				}
 			}
 		}
@@ -185,10 +220,7 @@ function resolvePluginPaths(plugin: InstalledPlugin, key: "tools" | "hooks" | "c
 
 			if (feat[key]) {
 				for (const entry of feat[key]) {
-					const resolved = resolveManifestEntryFile(path.join(plugin.path, entry));
-					if (resolved) {
-						paths.push(resolved);
-					}
+					paths.push(...resolveManifestEntries(path.join(plugin.path, entry), { expandDirectory }));
 				}
 			}
 		}

--- a/packages/coding-agent/test/plugin-extensions-discovery.test.ts
+++ b/packages/coding-agent/test/plugin-extensions-discovery.test.ts
@@ -184,4 +184,66 @@ describe("plugin extension discovery", () => {
 		expect(extension).toBeDefined();
 		expect(extension?.commands.has("dir-entry-ext")).toBe(true);
 	});
+	it("loads installed plugin extensions whose manifest entry points at a directory of subdirectory extensions", async () => {
+		// `pi-autoresearch` layout (issue #1292): `pi.extensions: ["./extensions"]`
+		// where `extensions/` has no top-level `index.{ts,js,...}` but contains
+		// `extensions/<name>/index.ts` per nested extension. Loader must expand
+		// the directory to those nested entry points instead of silently dropping
+		// the plugin to zero extensions.
+		const pluginsDir = getPluginsDir();
+		const pluginDir = path.join(pluginsDir, "node_modules", "pi-autoresearch");
+		const nestedExtensionPath = path.join(pluginDir, "extensions", "pi-autoresearch", "index.ts");
+		const siblingExtensionPath = path.join(pluginDir, "extensions", "sibling", "index.ts");
+		fs.rmSync(path.join(pluginsDir, "node_modules"), { recursive: true, force: true });
+		fs.mkdirSync(path.dirname(nestedExtensionPath), { recursive: true });
+		fs.mkdirSync(path.dirname(siblingExtensionPath), { recursive: true });
+		fs.writeFileSync(
+			path.join(pluginsDir, "package.json"),
+			JSON.stringify({
+				name: "omp-plugins",
+				private: true,
+				dependencies: {
+					"pi-autoresearch": "1.0.0",
+				},
+			}),
+		);
+		fs.writeFileSync(
+			path.join(pluginDir, "package.json"),
+			JSON.stringify({
+				name: "pi-autoresearch",
+				version: "1.0.0",
+				pi: {
+					// Directory entry without top-level index — the loader must
+					// expand it to the nested subdirectory extensions.
+					extensions: ["./extensions"],
+				},
+			}),
+		);
+		fs.writeFileSync(
+			nestedExtensionPath,
+			[
+				"export default function(pi) {",
+				'\tpi.registerCommand("autoresearch-ext", { handler: async () => {} });',
+				"}",
+			].join("\n"),
+		);
+		fs.writeFileSync(
+			siblingExtensionPath,
+			[
+				"export default function(pi) {",
+				'\tpi.registerCommand("autoresearch-sibling", { handler: async () => {} });',
+				"}",
+			].join("\n"),
+		);
+
+		const result = await discoverAndLoadExtensions([], projectDir.path());
+		const nested = result.extensions.find(ext => ext.path === nestedExtensionPath);
+		const sibling = result.extensions.find(ext => ext.path === siblingExtensionPath);
+
+		expect(result.errors).toEqual([]);
+		expect(nested).toBeDefined();
+		expect(nested?.commands.has("autoresearch-ext")).toBe(true);
+		expect(sibling).toBeDefined();
+		expect(sibling?.commands.has("autoresearch-sibling")).toBe(true);
+	});
 });


### PR DESCRIPTION
## Repro

`omp plugin install pi-autoresearch@latest`, then start `omp`. The plugin is reported healthy by `omp plugin doctor` but registers zero extensions — `pi-autoresearch`'s `schedule_prompt`-style functionality never reaches the model. This is the secondary report in #1292 (the primary `B:\~BUN\root` failure for the other four plugins listed in that issue is the same root cause as #1215 and tracked in #1216).

```
omp plugin install pi-autoresearch
omp plugin doctor --json  # reports OK
omp                        # no autoresearch tools/commands registered
```

## Cause

`pi-autoresearch`'s `package.json` declares `pi: { extensions: ["./extensions"] }` but its installed tree contains `extensions/pi-autoresearch/index.ts` — i.e. the directory has no top-level `index.{ts,js,mjs,cjs}`, only a nested subdirectory with one.

`resolveManifestEntryFile` in `packages/coding-agent/src/extensibility/plugins/loader.ts` handled three shapes for a manifest entry: a file (returned as-is), a directory containing a top-level index (returned as that index), and anything else (returned `null`). The directory-of-subdirectories layout fell into the third branch and was silently dropped — the loader produced zero extension paths for the plugin, no error was logged, and the plugin appeared registered but inert.

The agent's own auto-discovery (`discoverExtensionsInDir` in `extensions/loader.ts`) already supports this layout for the user's `~/.omp/agent/extensions/` directory: it scans for direct `.ts`/`.js`/`.mjs`/`.cjs` files plus immediate subdirectories with index files. Plugin manifest resolution did not mirror that contract.

## Fix

- Renamed `resolveManifestEntryFile` → `resolveManifestEntries` and changed its return shape to `string[]`. File entries return `[joined]`, directory entries with a top-level index return `[index]`, everything else returns `[]`.
- Added an `expandDirectory: boolean` option. When set and the entry is a directory without a top-level index, the directory's immediate children are scanned: direct `.ts`/`.js`/`.mjs`/`.cjs` files and subdirectories containing `index.{ts,js,mjs,cjs}`. Mirrors `discoverExtensionsInDir`'s rules so the manifest contract is symmetric with auto-discovery.
- `resolvePluginPaths` opts in to expansion only for `key === "extensions"`. Tools/hooks/commands still require explicit single-file entries — directory expansion for those keys would be ambiguous and is out of scope for this fix.

## Verification

New regression test in `packages/coding-agent/test/plugin-extensions-discovery.test.ts`: builds a `pi-autoresearch`-shaped plugin (manifest `pi.extensions: ["./extensions"]` + nested `extensions/pi-autoresearch/index.ts` + `extensions/sibling/index.ts`) and asserts both nested extensions load and register their commands.

```
$ bun test test/plugin-extensions-discovery.test.ts test/issue-973-legacy-pi-plugin.test.ts \
           test/pi-scope-aliases.test.ts test/issue-983-multi-file-extension.test.ts
 7 pass
 0 fail
 22 expect() calls
```

The pre-existing `dir-entry-plugin` test (manifest pointing at a directory **with** a top-level `index.ts`) still passes, confirming the happy path is preserved.

This PR does not touch the `Bun.resolveSync` from `/$bunfs/root` failure that is the bulk of #1292's report — that root cause is the same as #1215 and is being fixed in #1216. Both fixes are independently useful: #1216 unblocks plugins whose source imports `@oh-my-pi/pi-*`; this PR unblocks plugins whose manifest declares a directory-of-extensions layout.

Fixes #1292