### PR TITLE
fix(ai): repair orphan function_call_output in openai-responses replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `openai-responses` requests intermittently 400ing with `No tool call found for function call output with call_id …` after an aborted turn or a locally-rejected tool call (e.g. argument-validation failure). `convertConversationMessages` now folds orphan `function_call_output` / `custom_tool_call_output` items — those whose matching `function_call` was wiped by an earlier `dt: false` snapshot splice or never landed in any persisted provider payload — into assistant text notes, preserving the payload while keeping the request grammatically valid ([#1351](https://github.com/can1357/oh-my-pi/issues/1351)).
+
 ## [15.2.4] - 2026-05-22
 
 ### Fixed

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -117,6 +117,76 @@ export function collectCustomCallIds(messages: ResponseInput): Set<string> {
 	return customCallIds;
 }
 
+/**
+ * Convert orphan `function_call_output` / `custom_tool_call_output` items —
+ * those whose `call_id` has no matching preceding `function_call` /
+ * `custom_tool_call` in the same input — into assistant text notes.
+ *
+ * The Responses API rejects unpaired outputs with
+ * `400 No tool call found for function call output with call_id …`. Orphans
+ * sneak in through two paths today:
+ *
+ * - A previous turn's `providerPayload` snapshot replaces the input array via
+ *   the `dt: false` splice (see {@link convertConversationMessages}), wiping
+ *   the matching `function_call` while leaving the matching
+ *   `function_call_output` queued in a later `toolResult`.
+ * - A locally-rejected tool call (argument-validation failure, hook reject,
+ *   aborted turn before the call streamed) produces a tool result without a
+ *   `function_call` ever landing in any persisted provider payload.
+ *
+ * Dropping the result loses information the model needs to recover; sending
+ * it as-is 400s the request. Folding it into an assistant `message` preserves
+ * the payload (call_id + truncated output) while staying within the Responses
+ * input grammar. Matches the behavior of {@link transformRequestBody} in the
+ * codex provider — issue #1351 / regression of #472.
+ */
+export function repairOrphanResponsesToolOutputs(input: ResponseInput): ResponseInput {
+	const knownCallIds = new Set<string>();
+	for (const item of input) {
+		const t = (item as { type?: string }).type;
+		const callId = (item as { call_id?: unknown }).call_id;
+		if (typeof callId !== "string") continue;
+		if (t === "function_call" || t === "custom_tool_call") knownCallIds.add(callId);
+	}
+	let hasOrphan = false;
+	for (const item of input) {
+		const t = (item as { type?: string }).type;
+		if (t !== "function_call_output" && t !== "custom_tool_call_output") continue;
+		const callId = (item as { call_id?: unknown }).call_id;
+		if (typeof callId === "string" && !knownCallIds.has(callId)) {
+			hasOrphan = true;
+			break;
+		}
+	}
+	if (!hasOrphan) return input;
+	return input.map(item => {
+		const t = (item as { type?: string }).type;
+		if (t !== "function_call_output" && t !== "custom_tool_call_output") return item;
+		const record = item as { call_id?: unknown; output?: unknown; name?: unknown };
+		const callId = record.call_id;
+		if (typeof callId !== "string" || knownCallIds.has(callId)) return item;
+		const toolName = typeof record.name === "string" && record.name.length > 0 ? record.name : "tool";
+		const rawOutput = record.output;
+		let text: string;
+		if (typeof rawOutput === "string") text = rawOutput;
+		else if (rawOutput == null) text = "";
+		else {
+			try {
+				text = JSON.stringify(rawOutput);
+			} catch {
+				text = String(rawOutput);
+			}
+		}
+		const ORPHAN_OUTPUT_LIMIT = 16_000;
+		if (text.length > ORPHAN_OUTPUT_LIMIT) text = `${text.slice(0, ORPHAN_OUTPUT_LIMIT)}\n...[truncated]`;
+		return {
+			type: "message",
+			role: "assistant",
+			content: `[Orphan ${toolName} result; call_id=${callId}]: ${text}`,
+		} as ResponseInput[number];
+	});
+}
+
 export function convertResponsesInputContent(
 	content: string | Array<TextContent | ImageContent>,
 	supportsImages: boolean,

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -61,6 +61,7 @@ import {
 	createInitialResponsesAssistantMessage,
 	normalizeResponsesToolCallIdForTransform,
 	processResponsesStream,
+	repairOrphanResponsesToolOutputs,
 } from "./openai-responses-shared";
 import { transformMessages } from "./transform-messages";
 
@@ -543,7 +544,7 @@ function convertConversationMessages(
 		msgIndex++;
 	}
 
-	return messages;
+	return repairOrphanResponsesToolOutputs(messages);
 }
 
 /**

--- a/packages/ai/test/openai-responses-history-payload.test.ts
+++ b/packages/ai/test/openai-responses-history-payload.test.ts
@@ -760,4 +760,71 @@ describe("OpenAI responses history payload", () => {
 			output: "Tool execution was aborted.",
 		});
 	});
+
+	it("converts orphan function_call_output replayed from providerPayload into an assistant note (issue #1351)", async () => {
+		// Reproduces the symptom: a previous turn's snapshot carries a
+		// `function_call_output` whose matching `function_call` was wiped by an
+		// earlier `dt: false` splice (or never landed because the call was
+		// rejected locally). OpenAI rejects that with
+		// `400 No tool call found for function call output with call_id …`.
+		const orphanCallId = "call_jR3cVxeU10g0YVtR2KSgpveO";
+		const orphanOutput = "(see attached image)";
+		const pairedCallId = "call_paired_ok";
+		const context: Context = {
+			messages: [
+				{
+					role: "user",
+					content: "follow-up after aborted turn",
+					providerPayload: createOpenAIResponsesHistoryPayload("openai", [
+						{
+							type: "function_call",
+							call_id: pairedCallId,
+							name: "read",
+							arguments: '{"path":"README.md"}',
+						},
+						{
+							type: "function_call_output",
+							call_id: pairedCallId,
+							output: "file contents",
+						},
+						{
+							type: "function_call_output",
+							call_id: orphanCallId,
+							output: orphanOutput,
+						},
+					]),
+					timestamp: Date.now(),
+				},
+			],
+		};
+
+		const model = getOpenAIReasoningModel("openai", "gpt-5-mini");
+		const payload = (await captureResponsesPayload(model, context)) as { input?: unknown[] };
+
+		const orphanSurvivors = (payload.input ?? []).filter(item => {
+			if (!item || typeof item !== "object") return false;
+			const candidate = item as { type?: unknown; call_id?: unknown };
+			return candidate.type === "function_call_output" && candidate.call_id === orphanCallId;
+		});
+		expect(orphanSurvivors).toEqual([]);
+
+		const pairedOutputs = (payload.input ?? []).filter(item => {
+			if (!item || typeof item !== "object") return false;
+			const candidate = item as { type?: unknown; call_id?: unknown };
+			return candidate.type === "function_call_output" && candidate.call_id === pairedCallId;
+		});
+		expect(pairedOutputs).toHaveLength(1);
+
+		const note = (payload.input ?? []).find(item => {
+			if (!item || typeof item !== "object") return false;
+			const candidate = item as { type?: unknown; role?: unknown; content?: unknown };
+			return (
+				candidate.type === "message" &&
+				candidate.role === "assistant" &&
+				typeof candidate.content === "string" &&
+				(candidate.content as string).includes(orphanCallId)
+			);
+		}) as { content?: string } | undefined;
+		expect(note?.content).toContain(orphanOutput);
+	});
 });


### PR DESCRIPTION
## Repro

For non-Azure / non-Copilot providers on `api: openai-responses`
(`strictResponsesPairing` defaults to `false`), a previous turn's
`providerPayload` snapshot can land in the input array via the
`dt: false` splice in `convertConversationMessages`
(`packages/ai/src/providers/openai-responses.ts`). The splice replaces
the entire `messages` array with the assistant payload's items, wiping
any earlier `function_call` items while leaving the matching
`function_call_output` queued in a later `toolResult`. Locally-rejected
tool calls (argument-validation failure, hook reject, aborted turn
before the call streamed) hit the same pattern: a `toolResult` lands
without a `function_call` ever being persisted in any payload.

`appendResponsesToolResultMessages` then appends an orphan
`function_call_output` to the request, and OpenAI rejects with
`400 No tool call found for function call output with call_id …`. The
session is unrecoverable until restart.

Repro test:
```
cd packages/ai && bun test test/openai-responses-history-payload.test.ts \
  -t "orphan"
```
Without the fix it fails with the orphan output still present in
`payload.input`.

## Cause

`convertConversationMessages` returned `messages` directly without any
pairing invariant check, and `appendResponsesToolResultMessages` only
short-circuits when `strictResponsesPairing` is `true` — i.e. only for
Azure (`isAzureOpenAIBaseUrl`) and `github-copilot`. Every other
provider (the bug report's `DDDD-codex`, plus any third-party
`openai-responses`-compatible endpoint) shipped the orphan to the wire.

The `openai-codex` provider already had this protection via
`transformRequestBody` in `packages/ai/src/providers/openai-codex/request-transformer.ts`,
but the generic `openai-responses` path did not.

## Fix

- New `repairOrphanResponsesToolOutputs(input)` helper in
  `openai-responses-shared.ts`: scans the assembled input for
  `function_call` / `custom_tool_call` items to build the set of known
  `call_id`s, then rewrites any unpaired `function_call_output` /
  `custom_tool_call_output` into an assistant `message` text note
  (`[Orphan <tool> result; call_id=…]: …`, output truncated to 16k).
  Mirrors the existing behavior of the `openai-codex` request
  transformer so the model still sees the result content while the
  request stays within the Responses input grammar.
- `convertConversationMessages` in `openai-responses.ts` now returns
  `repairOrphanResponsesToolOutputs(messages)` as its final step. No
  changes to `appendResponsesToolResultMessages` or to the
  `strictResponsesPairing` semantics — the new guard fires only when an
  orphan actually slipped through.

## Verification

- `cd packages/ai && bun test test/openai-responses-history-payload.test.ts`
  → 20 pass, 0 fail (19 prior + 1 new regression test).
- `cd packages/ai && bun test` → 1133 pass, 337 skip, 0 fail (full
  package suite).
- Confirmed the new test fails on the parent commit (orphan output
  observed in `payload.input`) and passes with the fix applied.
- `bun run fmt:ts` and `bun run check:ts` both clean.

Fixes #1351