### PR TITLE
fix(agent): prevent subagent session_start busy race

### DIFF
--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -968,7 +968,7 @@ export interface ExtensionAPI {
 		options?: { triggerTurn?: boolean; deliverAs?: "steer" | "followUp" | "nextTurn" },
 	): void;
 
-	/** Send a user message to the agent. Always triggers a turn. */
+	/** Send a user message to the agent, or queue it when deliverAs is set. */
 	sendUserMessage(
 		content: string | (TextContent | ImageContent)[],
 		options?: { deliverAs?: "steer" | "followUp" },

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4535,11 +4535,11 @@ export class AgentSession {
 	}
 
 	/**
-	 * Send a user message to the agent. Always triggers a turn.
-	 * When the agent is streaming, use deliverAs to specify how to queue the message.
+	 * Send a user message to the agent.
+	 * When deliverAs is set, queue the message instead of starting a new turn.
 	 *
 	 * @param content User message content (string or content array)
-	 * @param options.deliverAs Delivery mode when streaming: "steer" or "followUp"
+	 * @param options.deliverAs Delivery mode: "steer" or "followUp"
 	 */
 	async sendUserMessage(
 		content: string | (TextContent | ImageContent)[],
@@ -4565,10 +4565,18 @@ export class AgentSession {
 			if (images.length === 0) images = undefined;
 		}
 
+		if (options?.deliverAs === "followUp") {
+			await this.#queueFollowUp(text, images);
+			return;
+		}
+		if (options?.deliverAs === "steer") {
+			await this.#queueSteer(text, images);
+			return;
+		}
+
 		// Use prompt() with expandPromptTemplates: false to skip command handling and template expansion
 		await this.prompt(text, {
 			expandPromptTemplates: false,
-			streamingBehavior: options?.deliverAs,
 			images,
 		});
 	}

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1292,22 +1292,25 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			}
 
 			const extensionRunner = session.extensionRunner;
+			const pendingExtensionMessages: Promise<void>[] = [];
 			if (extensionRunner) {
 				extensionRunner.initialize(
 					{
 						sendMessage: (message, options) => {
-							session.sendCustomMessage(message, options).catch(e => {
+							const sendPromise = session.sendCustomMessage(message, options).catch(e => {
 								logger.error("Extension sendMessage failed", {
 									error: e instanceof Error ? e.message : String(e),
 								});
 							});
+							pendingExtensionMessages.push(sendPromise);
 						},
 						sendUserMessage: (content, options) => {
-							session.sendUserMessage(content, options).catch(e => {
+							const sendPromise = session.sendUserMessage(content, options).catch(e => {
 								logger.error("Extension sendUserMessage failed", {
 									error: e instanceof Error ? e.message : String(e),
 								});
 							});
+							pendingExtensionMessages.push(sendPromise);
 						},
 						appendEntry: (customType, data) => {
 							session.sessionManager.appendCustomEntry(customType, data);
@@ -1343,6 +1346,9 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					logger.error("Extension error", { path: err.extensionPath, error: err.error });
 				});
 				await awaitAbortable(extensionRunner.emit({ type: "session_start" }));
+				while (pendingExtensionMessages.length > 0) {
+					await awaitAbortable(Promise.all(pendingExtensionMessages.splice(0)));
+				}
 			}
 
 			const MAX_YIELD_RETRIES = 3;

--- a/packages/coding-agent/test/agent-session-concurrent.test.ts
+++ b/packages/coding-agent/test/agent-session-concurrent.test.ts
@@ -268,6 +268,38 @@ describe("AgentSession concurrent prompt guard", () => {
 		// Second prompt should work
 		await expect(session.prompt("Second message")).resolves.toBeUndefined();
 	});
+	it("queues extension follow-up user messages on an idle session without starting a turn", async () => {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const mock = createMockModel({ handler: () => ({ content: ["Done"] }) });
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+			},
+			streamFn: mock.stream,
+		});
+
+		const sessionManager = SessionManager.inMemory();
+		const settings = Settings.isolated();
+		const authStorage = await AuthStorage.create(path.join(tempDir, "testauth-idle-followup.db"));
+		authStorages.push(authStorage);
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models-idle-followup.yml"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+		});
+
+		await session.sendUserMessage("hello from session_start", { deliverAs: "followUp" });
+
+		expect(mock.calls).toHaveLength(0);
+		expect(session.queuedMessageCount).toBe(1);
+	});
 
 	// Regression: a subscriber that fires the next prompt synchronously from the
 	// agent_end listener (the shape every wire transport ends up in — rpc-mode

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import type { AgentTelemetryConfig, Tracer } from "@oh-my-pi/pi-agent-core";
+import { AgentBusyError, type AgentTelemetryConfig, type Tracer } from "@oh-my-pi/pi-agent-core";
 import { type AssistantMessage, Effort } from "@oh-my-pi/pi-ai";
 import { Settings } from "../../src/config/settings";
-import type { LoadExtensionsResult } from "../../src/extensibility/extensions/types";
+import type { ExtensionActions, LoadExtensionsResult } from "../../src/extensibility/extensions/types";
 import type { CreateAgentSessionResult } from "../../src/sdk";
 import * as sdkModule from "../../src/sdk";
 import type { AgentSession, AgentSessionEvent, PromptOptions } from "../../src/session/agent-session";
@@ -113,6 +113,61 @@ describe("runSubprocess yield reminders", () => {
 		modelRegistry: { refresh: async () => {} } as unknown as import("../../src/config/model-registry").ModelRegistry,
 		enableLsp: false,
 	};
+
+	it("waits for session_start extension user messages before prompting the subagent", async () => {
+		let extensionSendUserMessage: ExtensionActions["sendUserMessage"] | undefined;
+		let messageInFlight = false;
+		let sendStarted = false;
+
+		const session = createMockSession(({ emit }) => {
+			if (messageInFlight) {
+				throw new AgentBusyError();
+			}
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "tool-extension-session-start",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		});
+		const mutableSession = session as unknown as {
+			extensionRunner: NonNullable<AgentSession["extensionRunner"]>;
+			sendUserMessage: AgentSession["sendUserMessage"];
+		};
+		mutableSession.sendUserMessage = async () => {
+			sendStarted = true;
+			messageInFlight = true;
+			await Bun.sleep(20);
+			messageInFlight = false;
+		};
+		mutableSession.extensionRunner = {
+			initialize: (actions: ExtensionActions) => {
+				extensionSendUserMessage = actions.sendUserMessage;
+			},
+			onError: () => {},
+			emit: async (event: { type: string }) => {
+				if (event.type === "session_start") {
+					extensionSendUserMessage?.("hello from session_start", { deliverAs: "followUp" });
+				}
+				return undefined;
+			},
+		} as unknown as NonNullable<AgentSession["extensionRunner"]>;
+
+		mockCreateAgentSession(session);
+
+		const result = await runSubprocess({
+			...baseOptions,
+			id: "subagent-session-start-extension",
+		});
+
+		expect(sendStarted).toBe(true);
+		expect(result.exitCode).toBe(0);
+		expect(result.error).toBeUndefined();
+	});
 
 	it("skips modelRegistry.refresh when reusing the parent registry", async () => {
 		const session = createMockSession(({ emit }) => {


### PR DESCRIPTION
## Repro
A `session_start` extension that calls `pi.sendUserMessage("hello", { deliverAs: "followUp" })` can leave a fresh subagent session busy before `runSubprocess` submits the task prompt. Reproduced with `cd packages/coding-agent && bun test test/task/executor-subagent-reminders.test.ts test/agent-session-concurrent.test.ts -t 'session_start extension|idle session without starting'`, which failed before the fix because the idle extension message started a model turn and the subagent prompt observed `AgentBusyError`.

## Cause
`packages/coding-agent/src/session/agent-session.ts` routed `sendUserMessage(..., { deliverAs })` through `prompt()`, but `prompt()` only queued `streamingBehavior` while `isStreaming` was already true, so an idle subagent started an ownerless turn. `packages/coding-agent/src/task/executor.ts` also discarded the promises returned by `session.sendCustomMessage` and `session.sendUserMessage` in extension actions, allowing `extensionRunner.emit({ type: "session_start" })` to finish before those side effects settled.

## Fix
- Queue `AgentSession.sendUserMessage` directly through `#queueFollowUp` / `#queueSteer` whenever `deliverAs` is set, including on idle sessions.
- Track `session_start` extension message promises in `runSubprocess` and drain them before submitting the subagent task prompt.
- Add regressions covering idle extension follow-up delivery and the subagent `session_start` race.

## Verification
`cd packages/coding-agent && bun run check:types && bun test test/task/executor-subagent-reminders.test.ts test/agent-session-concurrent.test.ts -t 'session_start extension|idle session without starting'` passed: 2 tests, 0 failures. Fixes #1343