### PR TITLE
fix(ai): use Cursor resume action for empty turns

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed Claude Opus 4.7 on Amazon Bedrock streaming no reasoning output (and appearing to hang on long reasoning runs) because Anthropic silently switched the adaptive-thinking display default to `"omitted"`. The Bedrock provider now sends `thinking.display = "summarized"` by default on Opus 4.7+ adaptive models and on budget-based Claude models, mirroring the existing direct-Anthropic behavior. `BedrockOptions.thinkingDisplay` (`"summarized" | "omitted"`) is exposed for callers that want to opt out, and `hideThinkingSummary` now wires through to the Bedrock case ([#1373](https://github.com/can1357/oh-my-pi/issues/1373)).
+- Fixed Cursor Composer resume/tool-continuation turns failing with `Cannot send empty user message to Cursor API`. Empty current user turns now use Cursor's `resumeAction` instead of constructing an invalid `userMessageAction` ([#1376](https://github.com/can1357/oh-my-pi/issues/1376)).
 
 ## [15.3.2] - 2026-05-25
 ### Added

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -103,6 +103,7 @@ import {
 	RequestContextResultSchema,
 	RequestContextSchema,
 	RequestContextSuccessSchema,
+	ResumeActionSchema,
 	SetBlobResultSchema,
 	type ShellArgs,
 	ShellFailureSchema,
@@ -2330,21 +2331,22 @@ function buildGrpcRequest(
 				: extractText(lastMessage.content)
 			: "";
 
-	// Validate that we have non-empty user text for the action
-	if (!userText || userText.trim().length === 0) {
-		throw new Error("Cannot send empty user message to Cursor API");
-	}
-
-	const userMessage = create(UserMessageSchema, {
-		text: userText,
-		messageId: crypto.randomUUID(),
-	});
-
 	const action = create(ConversationActionSchema, {
-		action: {
-			case: "userMessageAction",
-			value: create(UserMessageActionSchema, { userMessage }),
-		},
+		action:
+			userText.trim().length > 0
+				? {
+						case: "userMessageAction",
+						value: create(UserMessageActionSchema, {
+							userMessage: create(UserMessageSchema, {
+								text: userText,
+								messageId: crypto.randomUUID(),
+							}),
+						}),
+					}
+				: {
+						case: "resumeAction",
+						value: create(ResumeActionSchema, {}),
+					},
 	});
 
 	// Build conversation turns from prior messages (excluding the last user message).

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -104,6 +104,8 @@ import {
 	RequestContextSchema,
 	RequestContextSuccessSchema,
 	ResumeActionSchema,
+	SelectedContextSchema,
+	SelectedImageSchema,
 	SetBlobResultSchema,
 	type ShellArgs,
 	ShellFailureSchema,
@@ -2302,6 +2304,35 @@ function buildConversationTurns(messages: Message[], blobStore: Map<string, Uint
 
 	return turns;
 }
+function createCursorUserMessage(content: string | (TextContent | ImageContent)[], text: string) {
+	const images = typeof content === "string" ? [] : extractImages(content);
+	return create(UserMessageSchema, {
+		text,
+		messageId: crypto.randomUUID(),
+		...(images.length > 0
+			? {
+					selectedContext: create(SelectedContextSchema, {
+						selectedImages: images,
+					}),
+				}
+			: {}),
+	});
+}
+
+function extractImages(content: (TextContent | ImageContent)[]) {
+	return content
+		.filter((item): item is ImageContent => item.type === "image")
+		.map(image =>
+			create(SelectedImageSchema, {
+				uuid: crypto.randomUUID(),
+				mimeType: image.mimeType,
+				dataOrBlobId: {
+					case: "data",
+					value: Uint8Array.from(Buffer.from(image.data, "base64")),
+				},
+			}),
+		);
+}
 
 function buildGrpcRequest(
 	model: Model<"cursor-agent">,
@@ -2324,23 +2355,26 @@ function buildGrpcRequest(
 	);
 
 	const lastMessage = context.messages[context.messages.length - 1];
-	const userText =
-		lastMessage?.role === "user" || lastMessage?.role === "developer"
-			? typeof lastMessage.content === "string"
-				? lastMessage.content.trim()
-				: extractText(lastMessage.content)
-			: "";
+	let userContent: string | (TextContent | ImageContent)[] | undefined;
+	let userText = "";
+	let hasUserImages = false;
+	if (lastMessage?.role === "user" || lastMessage?.role === "developer") {
+		userContent = lastMessage.content;
+		if (typeof userContent === "string") {
+			userText = userContent.trim();
+		} else {
+			userText = extractText(userContent);
+			hasUserImages = hasImages(userContent);
+		}
+	}
 
 	const action = create(ConversationActionSchema, {
 		action:
-			userText.trim().length > 0
+			userContent && (userText.trim().length > 0 || hasUserImages)
 				? {
 						case: "userMessageAction",
 						value: create(UserMessageActionSchema, {
-							userMessage: create(UserMessageSchema, {
-								text: userText,
-								messageId: crypto.randomUUID(),
-							}),
+							userMessage: createCursorUserMessage(userContent, userText),
 						}),
 					}
 				: {
@@ -2434,6 +2468,9 @@ function buildGrpcRequest(
 	return { requestBytes, blobStore, conversationState };
 }
 
+function hasImages(content: (TextContent | ImageContent)[]): boolean {
+	return content.some(item => item.type === "image");
+}
 function extractText(content: (TextContent | ImageContent)[]): string {
 	return content
 		.filter((c): c is TextContent => c.type === "text")

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -2058,6 +2058,14 @@ function storeCursorBlob(blobStore: Map<string, Uint8Array>, data: Uint8Array): 
 	return blobId;
 }
 
+function readCursorBlob(blobStore: Map<string, Uint8Array>, blobId: Uint8Array): Uint8Array {
+	const data = blobStore.get(Buffer.from(blobId).toString("hex"));
+	if (!data) {
+		throw new Error("Cursor blob not found");
+	}
+	return data;
+}
+
 const CURSOR_NATIVE_TOOL_NAMES = new Set(["bash", "read", "write", "delete", "ls", "grep", "lsp", "todo_write"]);
 
 function buildMcpToolDefinitions(tools: Tool[] | undefined): McpToolDefinition[] {
@@ -2101,6 +2109,52 @@ function extractUserMessageText(msg: Message): string {
 	return text.trim();
 }
 
+function hasUserMessageImages(msg: Message): boolean {
+	return (
+		(msg.role === "user" || msg.role === "developer") &&
+		Array.isArray(msg.content) &&
+		msg.content.some(item => item.type === "image")
+	);
+}
+
+type CursorRootPromptContentPart = { type: "text"; text: string } | { type: "image"; image: string; mediaType: string };
+
+function buildCursorRootPromptContent(content: string | (TextContent | ImageContent)[]): CursorRootPromptContentPart[] {
+	if (typeof content === "string") {
+		const text = content.trim();
+		return text ? [{ type: "text", text }] : [];
+	}
+	const parts: CursorRootPromptContentPart[] = [];
+	for (const item of content) {
+		if (item.type === "text") {
+			const text = item.text.trim();
+			if (text) {
+				parts.push({ type: "text", text });
+			}
+		} else {
+			parts.push({ type: "image", image: item.data, mediaType: item.mimeType });
+		}
+	}
+	return parts;
+}
+
+function cursorUserContentKey(content: string | (TextContent | ImageContent)[]): string {
+	if (typeof content === "string") {
+		return content.trim();
+	}
+	const hash = createHash("sha256");
+	for (const item of content) {
+		hash.update(item.type);
+		if (item.type === "text") {
+			hash.update(item.text);
+		} else {
+			hash.update(item.mimeType);
+			hash.update(item.data);
+		}
+	}
+	return hash.digest("hex");
+}
+
 /**
  * Extract text content from an assistant message.
  */
@@ -2119,7 +2173,9 @@ function extractAssistantMessageText(msg: Message): string {
  * requests, so `conversationBlobStores` does not grow unboundedly and
  * unchanged history reuses existing blob IDs.
  */
-function deterministicMessageId(key: string): string {
+type CursorMessageId = `${string}-${string}-${string}-${string}-${string}`;
+
+function deterministicMessageId(key: string): CursorMessageId {
 	const hex = createHash("sha256").update(key).digest("hex");
 	return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
 }
@@ -2184,9 +2240,9 @@ function buildRootPromptMessagesJson(
 		if (i === lastUserIdx) break;
 		const msg = messages[i];
 		if (msg.role === "user" || msg.role === "developer") {
-			const text = extractUserMessageText(msg);
-			if (!text) continue;
-			pushJson({ role: "user", content: [{ type: "text", text }] });
+			const content = buildCursorRootPromptContent(msg.content);
+			if (content.length === 0) continue;
+			pushJson({ role: "user", content });
 		} else if (msg.role === "assistant") {
 			const text = extractAssistantMessageText(msg);
 			if (!text) continue;
@@ -2240,15 +2296,16 @@ function buildConversationTurns(messages: Message[], blobStore: Map<string, Uint
 
 		// Create and serialize user message
 		const userText = extractUserMessageText(msg);
-		if (!userText || userText.length === 0) {
+		if (userText.length === 0 && !hasUserMessageImages(msg)) {
 			i++;
 			continue;
 		}
 
-		const userMessage = create(UserMessageSchema, {
-			text: userText,
-			messageId: deterministicMessageId(`u:${turns.length}:${userText}`),
-		});
+		const userMessage = createCursorUserMessage(
+			msg.content,
+			userText,
+			deterministicMessageId(`u:${turns.length}:${cursorUserContentKey(msg.content)}`),
+		);
 		const userMessageBytes = toBinary(UserMessageSchema, userMessage);
 		const userMessageBlobId = storeCursorBlob(blobStore, userMessageBytes);
 
@@ -2304,11 +2361,36 @@ function buildConversationTurns(messages: Message[], blobStore: Map<string, Uint
 
 	return turns;
 }
-function createCursorUserMessage(content: string | (TextContent | ImageContent)[], text: string) {
+
+/** Exported for tests: decodes Cursor history blobs built from conversation messages. */
+export function buildCursorHistoryForTest(messages: Message[]): {
+	rootPromptMessagesJson: unknown[];
+	turnUserMessagesJson: JsonValue[];
+} {
+	const blobStore = new Map<string, Uint8Array>();
+	const rootPromptMessagesJson = buildRootPromptMessagesJson(messages, [], blobStore).map(blobId =>
+		JSON.parse(new TextDecoder().decode(readCursorBlob(blobStore, blobId))),
+	);
+	const turnUserMessagesJson: JsonValue[] = [];
+	for (const turnBlobId of buildConversationTurns(messages, blobStore)) {
+		const turn = fromBinary(ConversationTurnStructureSchema, readCursorBlob(blobStore, turnBlobId));
+		if (turn.turn.case !== "agentConversationTurn") {
+			continue;
+		}
+		const userMessage = fromBinary(UserMessageSchema, readCursorBlob(blobStore, turn.turn.value.userMessage));
+		turnUserMessagesJson.push(toJson(UserMessageSchema, userMessage));
+	}
+	return { rootPromptMessagesJson, turnUserMessagesJson };
+}
+function createCursorUserMessage(
+	content: string | (TextContent | ImageContent)[],
+	text: string,
+	messageId = crypto.randomUUID(),
+) {
 	const images = typeof content === "string" ? [] : extractImages(content);
 	return create(UserMessageSchema, {
 		text,
-		messageId: crypto.randomUUID(),
+		messageId,
 		...(images.length > 0
 			? {
 					selectedContext: create(SelectedContextSchema, {

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -1,5 +1,40 @@
 import { describe, expect, it } from "bun:test";
-import { buildCursorSystemPromptJsons, resolveExecHandler } from "../src/providers/cursor";
+import { buildCursorSystemPromptJsons, resolveExecHandler, streamCursor } from "../src/providers/cursor";
+import type { AgentRunRequest } from "../src/providers/cursor/gen/agent_pb";
+import type { Context, Model } from "../src/types";
+
+const cursorModel: Model<"cursor-agent"> = {
+	id: "cursor-composer-2.5",
+	name: "Cursor Composer 2.5",
+	api: "cursor-agent",
+	provider: "cursor",
+	baseUrl: "",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 1,
+	maxTokens: 1,
+};
+
+function captureCursorPayload(context: Context): Promise<AgentRunRequest> {
+	const { promise, resolve, reject } = Promise.withResolvers<AgentRunRequest>();
+	streamCursor(cursorModel, context, {
+		apiKey: "test-token",
+		onPayload: payload => {
+			if (isAgentRunRequest(payload)) {
+				resolve(payload);
+			} else {
+				reject(new Error("Cursor payload was not an AgentRunRequest"));
+			}
+			throw new Error("stop after capturing Cursor payload");
+		},
+	});
+	return promise;
+}
+
+function isAgentRunRequest(payload: unknown): payload is AgentRunRequest {
+	return !!payload && typeof payload === "object" && "$typeName" in payload;
+}
 
 describe("Cursor resolveExecHandler execHandlers binding", () => {
 	it("invokes handler with correct this when passed as bound method", async () => {
@@ -63,5 +98,22 @@ describe("Cursor system prompt encoding", () => {
 		const jsons = buildCursorSystemPromptJsons(["", ""]);
 		expect(jsons).toHaveLength(1);
 		expect(JSON.parse(jsons[0])).toEqual({ role: "system", content: "You are a helpful assistant." });
+	});
+});
+describe("Cursor request action encoding", () => {
+	it("uses a resume action for empty user turns", async () => {
+		const payload = await captureCursorPayload({
+			messages: [{ role: "user", content: "   ", timestamp: 0 }],
+		});
+
+		expect(payload.action?.action.case).toBe("resumeAction");
+	});
+
+	it("uses a user message action for non-empty user turns", async () => {
+		const payload = await captureCursorPayload({
+			messages: [{ role: "user", content: "continue", timestamp: 0 }],
+		});
+
+		expect(payload.action?.action.case).toBe("userMessageAction");
 	});
 });

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -116,4 +116,30 @@ describe("Cursor request action encoding", () => {
 
 		expect(payload.action?.action.case).toBe("userMessageAction");
 	});
+
+	it("uses a user message action with selected context for image-only user turns", async () => {
+		const imageData = "aW1hZ2U=";
+		const payload = await captureCursorPayload({
+			messages: [
+				{
+					role: "user",
+					content: [{ type: "image", data: imageData, mimeType: "image/png" }],
+					timestamp: 0,
+				},
+			],
+		});
+
+		if (payload.action?.action.case !== "userMessageAction") {
+			throw new Error("Expected Cursor userMessageAction");
+		}
+		const userMessage = payload.action.action.value.userMessage;
+		expect(userMessage?.text).toBe("");
+		expect(userMessage?.selectedContext?.selectedImages).toHaveLength(1);
+		const selectedImage = userMessage?.selectedContext?.selectedImages[0];
+		expect(selectedImage?.mimeType).toBe("image/png");
+		if (!selectedImage || selectedImage.dataOrBlobId.case !== "data") {
+			throw new Error("Expected Cursor selected image data");
+		}
+		expect(Array.from(selectedImage.dataOrBlobId.value)).toEqual(Array.from(Buffer.from(imageData, "base64")));
+	});
 });

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { buildCursorSystemPromptJsons, resolveExecHandler, streamCursor } from "../src/providers/cursor";
+import {
+	buildCursorHistoryForTest,
+	buildCursorSystemPromptJsons,
+	resolveExecHandler,
+	streamCursor,
+} from "../src/providers/cursor";
 import type { AgentRunRequest } from "../src/providers/cursor/gen/agent_pb";
 import type { Context, Model } from "../src/types";
 
@@ -141,5 +146,59 @@ describe("Cursor request action encoding", () => {
 			throw new Error("Expected Cursor selected image data");
 		}
 		expect(Array.from(selectedImage.dataOrBlobId.value)).toEqual(Array.from(Buffer.from(imageData, "base64")));
+	});
+});
+
+describe("Cursor history encoding", () => {
+	it("preserves image-only user turns in root prompt history and conversation turns", () => {
+		const imageData = "aW1hZ2U=";
+		const history = buildCursorHistoryForTest([
+			{
+				role: "user",
+				content: [{ type: "image", data: imageData, mimeType: "image/png" }],
+				timestamp: 0,
+			},
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "I can see it." }],
+				api: "cursor-agent",
+				provider: "cursor",
+				model: "cursor-composer-2.5",
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "stop",
+				timestamp: 0,
+			},
+			{ role: "user", content: "what is in the image?", timestamp: 0 },
+		]);
+
+		expect(history.rootPromptMessagesJson).toEqual([
+			{
+				role: "user",
+				content: [{ type: "image", image: imageData, mediaType: "image/png" }],
+			},
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "I can see it." }],
+			},
+		]);
+		expect(history.turnUserMessagesJson).toEqual([
+			expect.objectContaining({
+				selectedContext: {
+					selectedImages: [
+						expect.objectContaining({
+							mimeType: "image/png",
+							data: imageData,
+						}),
+					],
+				},
+			}),
+		]);
 	});
 });


### PR DESCRIPTION
## Repro
An empty or whitespace current user turn in Cursor Composer 2.5 failed before any request was sent. Reproduced with `bun --cwd packages/ai -e 'import { streamCursor } from "./src/providers/cursor"; const model={id:"cursor-composer-2.5",name:"Cursor Composer 2.5",api:"cursor-agent",provider:"cursor",baseUrl:"",reasoning:false,input:["text"],cost:{input:0,output:0,cacheRead:0,cacheWrite:0},contextWindow:1,maxTokens:1}; const stream=streamCursor(model,{messages:[{role:"user",content:"   ",timestamp:0}]},{apiKey:"token"}); for await (const event of stream) { if (event.type === "error") { console.log(event.error.errorMessage); process.exit(1); } }'`, which printed `Cannot send empty user message to Cursor API` and exited 1.

## Cause
`packages/ai/src/providers/cursor.ts` built every turn as `ConversationActionSchema.userMessageAction` and explicitly threw when the last user/developer message normalized to empty text. Cursor's protobuf has a `ResumeAction`, but the provider never used it for tool-continuation/resume turns.

## Fix
- Send `resumeAction` when the current Cursor user turn is empty or whitespace.
- Keep `userMessageAction` for non-empty user/developer turns.
- Add Cursor payload tests covering both empty resume turns and normal user-message turns.
- Document the fix in `packages/ai/CHANGELOG.md`.

## Verification
Ran `bun --cwd=packages/ai test test/cursor-exec-handlers.test.ts` (6 pass), `bun --cwd=packages/ai run check` (pass), and a payload probe for the empty-turn repro that now prints `resumeAction`. Fixes #1376