### PR TITLE
fix(coding-agent/prompts): rename explore agent output `ref` field to `path`

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed built-in `explore` agent failing every invocation with `schema_violation: files.0.ref: must not be present` on releases prior to 15.3.2 by renaming the `files[].ref` property to `files[].path` in the agent's output schema; `ref` is a JTD-reserved keyword (RFC 8927) and collides with JSON Type Definition's schema-reference form, so the converter previously dropped it from the generated JSON Schema. Defense-in-depth alongside the 15.3.2 converter fix ([#1379](https://github.com/can1357/oh-my-pi/issues/1379)).
+
 ## [15.3.2] - 2026-05-25
 ### Added
 

--- a/packages/coding-agent/src/prompts/agents/explore.md
+++ b/packages/coding-agent/src/prompts/agents/explore.md
@@ -15,7 +15,7 @@ output:
         description: Files examined with relevant code references
       elements:
         properties:
-          ref:
+          path:
             metadata:
               description: Project-relative path or paths to the most relevant code reference(s), optionally suffixed with line ranges like `:12-34` when relevant
             type: string


### PR DESCRIPTION
## Repro

On OMP 15.3.1 (and earlier), every `task` invocation that spawned the built-in `explore` agent failed with:

```
schema_violation: files.0.ref: must not be present
```

The agents produced valid data, but the structured-output validator rejected it before the parent could read it. Simulated the 15.3.1 converter against the explore agent's output schema and observed:

```text
files.items.properties = {"$ref":"#/$defs/[object Object]"}
files.items.required   = ["ref","description"]
```

The generated JSON Schema collapsed `{ref, description}` into a single `$ref` key while still requiring `ref` (and `description`), so every output failed validation.

## Cause

`packages/coding-agent/src/prompts/agents/explore.md` declared `ref` as a property name inside `files.elements.properties`:

```yaml
files:
  elements:
    properties:
      ref:                   # JTD-reserved
        metadata: { description: "Project-relative path ..." }
        type: string
```

`ref` is a [JTD-reserved keyword (RFC 8927)](https://datatracker.ietf.org/doc/html/rfc8927#section-2.2.7) denoting a schema reference. On 15.3.1, `normalizeMixedSchemaNode` in `packages/coding-agent/src/tools/jtd-to-json-schema.ts` re-walked the converter output, treating the user-named `ref` property as a JTD reference and consuming its `{type: "string"}` value as the ref target. The runtime validator built by `buildOutputValidator` in `packages/coding-agent/src/task/executor.ts` then rejected every `files[]` entry. The converter side was already hardened in #1345 (shipped in 15.3.2).

## Fix

- Rename `files[].ref` → `files[].path` in `packages/coding-agent/src/prompts/agents/explore.md`. The field already describes "Project-relative path or paths", so `path` matches what it carries and removes the JTD-keyword collision.
- Add an `[Unreleased]` CHANGELOG entry crediting #1379 and noting the rename is defense-in-depth alongside the 15.3.2 converter fix.

No production code reads the field by name (`task/agents.ts` only embeds the frontmatter as YAML), and the existing `#1345` JTD test still guards the converter against `ref`-named properties.

Review order:
- `packages/coding-agent/src/prompts/agents/explore.md` — single-line rename.
- `packages/coding-agent/CHANGELOG.md` — `[Unreleased] / Fixed` entry.

## Verification

- `bun test packages/coding-agent/test/tools/jtd-to-json-schema.test.ts` → 3 pass, 0 fail (covers the `ref`-collision regression test from #1345).
- Parsed the updated `explore.md` frontmatter through the current `jtdToJsonSchema` and confirmed `files.items` resolves to:

  ```json
  {
    "type": "object",
    "properties": { "path": { "type": "string" }, "description": { "type": "string" } },
    "additionalProperties": false,
    "required": ["path", "description"]
  }
  ```

Fixes #1379