### PR TITLE
feat(memories): typed memory taxonomy + knowledge & skill tools + user-protected zones

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `skill_create` accepting providers that return the string `"required"` from `buildToolChoice` as if it were a structured tool-choice; the tool now hard-fails with the same "no resolve channel" error as `knowledge_create` so users never see a `"pending user approval"` directive that was never queued
+- Fixed Phase-2 consolidator overwriting `scripts/`, `templates/`, and `examples/` assets in read-only skill directories (`readOnly: true` with `aiMaintained: true`); the asset write/prune loop now consults the same `readOnly` gate that already protects `SKILL.md`
+- Fixed `cleanupConsolidatedArtifacts` empty-pass `pruneSkillsDir` deleting read-only skill directories whose frontmatter still carried `aiMaintained: true`; the empty-pass now mirrors the main-loop `readOnly` check
+- Fixed `knowledge_create kind=directory` on an existing directory (and `knowledge_move` with `source === destination`) reporting `"pending user approval"` for a resolve directive that was never queued; idempotent no-ops are now surfaced as completed `(no-op)` results
+- Fixed `extractSummarySection` truncating multi-paragraph `## Summary` sections at the first newline; the regex end-anchor now matches true end-of-string so `knowledge_query` snippets and `knowledge_read part=summary` return the full section
+- Fixed Phase-2 consolidator becoming a permanent no-op against legacy `MEMORY.md` / `memory_summary.md` / `skills/<n>/SKILL.md` files after the first migration; `migrateLegacyMemoryLayout` now promotes each renamed marker-less doc into a body-marker-wrapped doc so subsequent consolidations can refresh the body region as they did pre-PR
+- Fixed `knowledge_move kind="directory"` bypassing `allowCreateDirectories: false` when the destination parent already existed; the gate now fires for any directory move into a sidecar-locked tree, mirroring the document branch's `allowCreateDocuments` check
+- Fixed `knowledge://memory/...` URLs serving content from a different bucket when the type-root directory itself was a symlink to another bucket; `tryResolveInRoot` now refuses any type root whose `realpath` does not equal its canonical path
+- Changed `knowledge.enabled` setting default from `false` to `true` so the seven `knowledge_*` tools are available out of the box alongside the four-bucket memory taxonomy they operate on
+
 ## [15.4.0] - 2026-05-26
 
 ### Breaking Changes
@@ -32,7 +44,6 @@
 - Refreshed expired OpenAI Codex OAuth tokens during `web_search` execution and persisted the updated credentials so searches continue working after token expiry
 - Fixed built-in `explore` agent failing every invocation with `schema_violation: files.0.ref: must not be present` on releases prior to 15.3.2 by renaming the `files[].ref` property to `files[].path` in the agent's output schema; `ref` is a JTD-reserved keyword (RFC 8927) and collides with JSON Type Definition's schema-reference form, so the converter previously dropped it from the generated JSON Schema. Defense-in-depth alongside the 15.3.2 converter fix ([#1379](https://github.com/can1357/oh-my-pi/issues/1379)).
 - Increased the `yield` tool's schema-validation retry budget from 1 to 3 so subagents whose first structured-output attempt mismatches the declared output schema get up to three retries before the parent's post-mortem `schema_violation` check hard-fails the task. The tool now also surfaces remaining retry attempts and an explicit "call yield again with the corrected shape" directive in each rejection message, giving the model the context it needs to converge — particularly helpful for models like GLM that tend to invent per-element field names instead of following the declared schema.
-
 ## [15.3.2] - 2026-05-25
 ### Added
 

--- a/packages/coding-agent/src/capability/skill.ts
+++ b/packages/coding-agent/src/capability/skill.ts
@@ -15,11 +15,20 @@ export interface SkillFrontmatter {
 	globs?: string[];
 	alwaysApply?: boolean;
 	/**
-	 * When `true`, the skill is loaded and accessible via `skill://<name>` (and
-	 * `/skill:<name>` slash commands), but is omitted from the rendered system
-	 * prompt's skill listing. Use for skills the user opts into explicitly
-	 * rather than ones the model should auto-discover.
+	 * Positive-framing surface selector.
+	 *
+	 *   - `"auto"`  (default) — listed in the rendered `<skills>` section so
+	 *     the model can auto-discover it.
+	 *   - `"command"` — loaded and reachable via `skill://<name>` and the
+	 *     `/skill:<name>` slash command, but **omitted** from the rendered
+	 *     prompt listing. Use this for skills the user opts into explicitly.
+	 *
+	 * Back-compat: `hide: true` is treated as `skillSurface: "command"`. New
+	 * skills SHOULD use `skillSurface`; `hide` may be removed in a future
+	 * release.
 	 */
+	skillSurface?: "auto" | "command";
+	/** @deprecated Use `skillSurface: "command"` instead. */
 	hide?: boolean;
 	[key: string]: unknown;
 }

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1937,6 +1937,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"knowledge.enabled": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "tools",
+			label: "Knowledge",
+			description:
+				"Enable the seven knowledge tools (list/query/read/create/edit/move/delete) for the unified memory taxonomy.",
+		},
+	},
+
 	"recipe.enabled": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/extensibility/skill-ops.ts
+++ b/packages/coding-agent/src/extensibility/skill-ops.ts
@@ -1,0 +1,251 @@
+/**
+ * Skill ops layer.
+ *
+ * Pure file/snapshot operations for the `skill_create` and `skill_reload`
+ * tools. No tool wiring, no process-global mutation — callers (the tools)
+ * are responsible for plumbing approval sinks and pushing the reloaded
+ * snapshot into `setActiveSkills`.
+ *
+ * Validation, path containment, and collision detection live here so the
+ * tool layer is a thin schema/approval shell.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { isEnoent } from "@oh-my-pi/pi-utils";
+import { YAML } from "bun";
+import { type LoadSkillsOptions, type LoadSkillsResult, loadSkills, type Skill, type SkillWarning } from "./skills";
+
+/** Project-relative directory that holds native skill packages. */
+const PROJECT_SKILLS_REL = path.join(".omp", "skills");
+
+/** Lowercase kebab-case identifier, 1-64 chars, leading alnum, [a-z0-9-_] thereafter. */
+const SKILL_NAME_PATTERN = /^[a-z0-9](?:[a-z0-9_-]{0,63})$/;
+
+export interface CreateSkillPackageInput {
+	/** Unique kebab-case identifier; becomes `.omp/skills/<name>/`. */
+	name: string;
+	/** One-line summary shown to future agents in the rendered <skills> block. */
+	description: string;
+	/** SKILL.md body (post-frontmatter, no leading `---`). */
+	body: string;
+	/** Effective skill surface. Default `"auto"` (omitted from frontmatter). */
+	skillSurface?: "auto" | "command";
+}
+
+export interface CreateSkillPackageResult {
+	/** Absolute path to `<projectRoot>/.omp/skills/<name>/`. */
+	skillDir: string;
+	/** Absolute path to the created SKILL.md. */
+	skillFile: string;
+}
+
+export interface ReloadSkillsDiff {
+	added: string[];
+	removed: string[];
+	/** Names present in both snapshots but pointing at a different `filePath`. */
+	changed: string[];
+	warnings: SkillWarning[];
+}
+
+export type SkillOpsErrorCode = "validation" | "collision" | "io";
+
+export class SkillOpsError extends Error {
+	constructor(
+		readonly code: SkillOpsErrorCode,
+		message: string,
+	) {
+		super(message);
+		this.name = "SkillOpsError";
+	}
+}
+
+function validateName(name: unknown): string {
+	if (typeof name !== "string" || name.length === 0) {
+		throw new SkillOpsError("validation", "Skill name is required");
+	}
+	// Reject any path-traversal-shaped or separator-bearing input before the
+	// regex so we can give a precise diagnostic instead of a generic "shape".
+	if (name.includes("/") || name.includes("\\")) {
+		throw new SkillOpsError("validation", `Skill name may not contain path separators: ${JSON.stringify(name)}`);
+	}
+	if (name === "." || name === "..") {
+		throw new SkillOpsError("validation", `Skill name may not be '.' or '..': ${JSON.stringify(name)}`);
+	}
+	if (name.length > 64) {
+		throw new SkillOpsError("validation", `Skill name exceeds 64 characters: ${JSON.stringify(name)}`);
+	}
+	if (!SKILL_NAME_PATTERN.test(name)) {
+		throw new SkillOpsError(
+			"validation",
+			`Skill name must be lowercase kebab/snake (start alnum, then [a-z0-9_-]): ${JSON.stringify(name)}`,
+		);
+	}
+	return name;
+}
+
+function validateDescription(description: unknown): string {
+	if (typeof description !== "string" || description.trim().length === 0) {
+		throw new SkillOpsError("validation", "Skill description is required");
+	}
+	return description.trim();
+}
+
+/**
+ * Resolve and contain the target skill directory under `<projectRoot>/.omp/skills/`.
+ * Defence-in-depth against any traversal that slipped past the name regex.
+ */
+function resolveSkillDir(projectRoot: string, name: string): { skillsRoot: string; skillDir: string } {
+	const skillsRoot = path.resolve(projectRoot, PROJECT_SKILLS_REL);
+	const skillDir = path.resolve(skillsRoot, name);
+	const rel = path.relative(skillsRoot, skillDir);
+	if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) {
+		throw new SkillOpsError("validation", `Skill path escapes project skills root: ${JSON.stringify(name)}`);
+	}
+	return { skillsRoot, skillDir };
+}
+
+/**
+ * Validation phase, separated so tools can fail fast on bad input or
+ * collisions BEFORE queueing an approval prompt the user would have to
+ * discard.
+ *
+ * Returns the resolved `skillDir` / `skillFile` and a normalized payload
+ * that `commitSkillPackage` consumes verbatim. Performs the same checks
+ * the commit phase would, plus an `fs.stat` collision probe.
+ */
+export interface PreparedSkillPackage {
+	name: string;
+	description: string;
+	body: string;
+	skillSurface?: "command";
+	skillDir: string;
+	skillFile: string;
+}
+
+export async function prepareSkillPackage(
+	projectRoot: string,
+	input: CreateSkillPackageInput,
+): Promise<PreparedSkillPackage> {
+	const name = validateName(input.name);
+	const description = validateDescription(input.description);
+	const body = typeof input.body === "string" ? input.body : "";
+	const skillSurface = input.skillSurface;
+	if (skillSurface !== undefined && skillSurface !== "auto" && skillSurface !== "command") {
+		throw new SkillOpsError(
+			"validation",
+			`skillSurface must be "auto" or "command": ${JSON.stringify(skillSurface)}`,
+		);
+	}
+
+	const { skillDir } = resolveSkillDir(projectRoot, name);
+	const skillFile = path.join(skillDir, "SKILL.md");
+
+	try {
+		await fs.stat(skillDir);
+		throw new SkillOpsError(
+			"collision",
+			`Skill directory already exists: ${skillDir}. Refusing to overwrite an existing skill package.`,
+		);
+	} catch (error) {
+		if (error instanceof SkillOpsError) throw error;
+		if (!isEnoent(error)) {
+			throw new SkillOpsError("io", `Failed to stat skill directory: ${skillDir} (${String(error)})`);
+		}
+	}
+
+	return {
+		name,
+		description,
+		body,
+		skillSurface: skillSurface === "command" ? "command" : undefined,
+		skillDir,
+		skillFile,
+	};
+}
+
+/** Write a previously prepared skill package to disk. */
+export async function commitSkillPackage(prepared: PreparedSkillPackage): Promise<CreateSkillPackageResult> {
+	const frontmatter: Record<string, unknown> = { name: prepared.name, description: prepared.description };
+	if (prepared.skillSurface === "command") {
+		frontmatter.skillSurface = "command";
+	}
+	const fm = YAML.stringify(frontmatter).trimEnd();
+	const content = `---\n${fm}\n---\n\n${prepared.body.trimEnd()}\n`;
+	// Re-check collision at commit time. Between prepare (pre-approval)
+	// and commit (post-approval), another process or user may have
+	// authored the same skill — refuse instead of overwriting it.
+	try {
+		await fs.stat(prepared.skillFile);
+		throw new SkillOpsError("collision", `Skill already exists at commit time: ${prepared.skillFile}`);
+	} catch (error) {
+		if (error instanceof SkillOpsError) throw error;
+		if (!isEnoent(error)) {
+			throw new SkillOpsError("io", `Failed to stat skill file at commit: ${prepared.skillFile} (${String(error)})`);
+		}
+	}
+	try {
+		await fs.mkdir(prepared.skillDir, { recursive: true });
+		// Exclusive write (wx) guards the narrow window between the stat
+		// above and this write — another writer creating the file in
+		// between will surface as EEXIST instead of an overwrite.
+		await fs.writeFile(prepared.skillFile, content, { flag: "wx", encoding: "utf-8" });
+	} catch (error) {
+		if (error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "EEXIST") {
+			throw new SkillOpsError("collision", `Skill was created concurrently: ${prepared.skillFile}`);
+		}
+		throw new SkillOpsError("io", `Failed to write skill file: ${prepared.skillFile} (${String(error)})`);
+	}
+	return { skillDir: prepared.skillDir, skillFile: prepared.skillFile };
+}
+
+/**
+ * Convenience helper: validate-and-commit in one shot. Useful for tests
+ * and any callsite that does not stage the write through user approval.
+ */
+export async function createSkillPackage(
+	projectRoot: string,
+	input: CreateSkillPackageInput,
+): Promise<CreateSkillPackageResult> {
+	const prepared = await prepareSkillPackage(projectRoot, input);
+	return commitSkillPackage(prepared);
+}
+
+/**
+ * Re-scan skill directories and compute a diff against an optional prior snapshot.
+ *
+ * Pure: does NOT call `setActiveSkills`. The caller (tool) decides when to
+ * publish the new snapshot to the process-global slot.
+ */
+export async function reloadSkills(
+	options: LoadSkillsOptions,
+	previous?: readonly Skill[],
+): Promise<{ skills: Skill[]; diff: ReloadSkillsDiff }> {
+	const result: LoadSkillsResult = await loadSkills(options);
+	const diff = diffSkills(previous ?? [], result.skills);
+	diff.warnings = result.warnings;
+	return { skills: result.skills, diff };
+}
+
+function diffSkills(prev: readonly Skill[], next: readonly Skill[]): ReloadSkillsDiff {
+	const prevByName = new Map(prev.map(s => [s.name, s]));
+	const nextByName = new Map(next.map(s => [s.name, s]));
+	const added: string[] = [];
+	const removed: string[] = [];
+	const changed: string[] = [];
+	for (const [name, nextSkill] of nextByName) {
+		const prevSkill = prevByName.get(name);
+		if (!prevSkill) {
+			added.push(name);
+		} else if (prevSkill.filePath !== nextSkill.filePath) {
+			changed.push(name);
+		}
+	}
+	for (const name of prevByName.keys()) {
+		if (!nextByName.has(name)) removed.push(name);
+	}
+	added.sort();
+	removed.sort();
+	changed.sort();
+	return { added, removed, changed, warnings: [] };
+}

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -15,9 +15,19 @@ export interface Skill {
 	baseDir: string;
 	source: string;
 	/**
-	 * When `true`, the skill is loaded and reachable via `skill://<name>` and
-	 * (when enabled) `/skill:<name>`, but is excluded from the rendered system
-	 * prompt's `<skills>` listing.
+	 * Effective surface for this skill:
+	 *
+	 *   - `"auto"`  (default) — listed in the rendered `<skills>` block.
+	 *   - `"command"` — loaded and reachable via `skill://<name>` and
+	 *     `/skill:<name>` only.
+	 *
+	 * Set via frontmatter `skillSurface`. The legacy `hide: true` flag is
+	 * carried over as `"command"`.
+	 */
+	surface?: "auto" | "command";
+	/**
+	 * @deprecated Mirrors `surface === "command"`. Retained so callsites that
+	 * still read `.hide` keep working until they migrate.
 	 */
 	hide?: boolean;
 	/** Source metadata for display */
@@ -36,6 +46,9 @@ export interface LoadSkillsResult {
 
 let activeSkills: readonly Skill[] = [];
 
+type ActiveSkillsListener = (skills: readonly Skill[]) => void;
+const activeSkillsListeners = new Set<ActiveSkillsListener>();
+
 /**
  * Process-global snapshot of skills the active session loaded.
  * Read by internal URL protocol handlers (skill://).
@@ -44,14 +57,57 @@ export function getActiveSkills(): readonly Skill[] {
 	return activeSkills;
 }
 
-/** Replace the active skill snapshot. Called once per top-level session. */
+/**
+ * Replace the active skill snapshot. Fans out to every registered
+ * listener so per-session caches (`AgentSession.#skills`, interactive
+ * `skillCommands` maps, etc.) refresh after `skill_reload` instead of
+ * staying frozen at the snapshot taken at session start.
+ *
+ * Listener errors are swallowed: one bad subscriber must not derail
+ * the whole reload path. Subscribers SHOULD be defensive.
+ */
 export function setActiveSkills(value: readonly Skill[]): void {
 	activeSkills = value;
+	for (const listener of activeSkillsListeners) {
+		try {
+			listener(value);
+		} catch {
+			// Subscribers handle their own logging — keep the fan-out alive.
+		}
+	}
+}
+
+/**
+ * Subscribe to active-skills changes. Returns an unsubscribe function
+ * the caller MUST invoke when its lifecycle ends (e.g. session dispose)
+ * to avoid leaking references into long-lived test runs.
+ */
+export function subscribeToActiveSkills(listener: ActiveSkillsListener): () => void {
+	activeSkillsListeners.add(listener);
+	return () => {
+		activeSkillsListeners.delete(listener);
+	};
 }
 
 /** Reset the active skill snapshot. Test-only. */
 export function resetActiveSkillsForTests(): void {
 	activeSkills = [];
+	activeSkillsListeners.clear();
+}
+
+/**
+ * Derive the runtime surface for a skill from its frontmatter.
+ *
+ * Precedence: explicit `skillSurface` wins; otherwise legacy `hide: true`
+ * maps to `"command"`; otherwise default `"auto"`.
+ */
+export function deriveSkillSurface(
+	frontmatter: { skillSurface?: unknown; hide?: unknown } | undefined,
+): "auto" | "command" {
+	const explicit = frontmatter?.skillSurface;
+	if (explicit === "auto" || explicit === "command") return explicit;
+	if (frontmatter?.hide === true) return "command";
+	return "auto";
 }
 
 export interface LoadSkillsFromDirOptions {
@@ -82,7 +138,8 @@ export async function loadSkillsFromDir(options: LoadSkillsFromDirOptions): Prom
 			filePath: capSkill.path,
 			baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 			source: options.source,
-			hide: capSkill.frontmatter?.hide === true,
+			surface: deriveSkillSurface(capSkill.frontmatter),
+			hide: deriveSkillSurface(capSkill.frontmatter) === "command",
 			_source: capSkill._source,
 		})),
 		warnings: (result.warnings ?? []).map(message => ({ skillPath: options.dir, message })),
@@ -197,7 +254,8 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 				filePath: capSkill.path,
 				baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 				source: `${capSkill._source.provider}:${capSkill.level}`,
-				hide: capSkill.frontmatter?.hide === true,
+				surface: deriveSkillSurface(capSkill.frontmatter),
+				hide: deriveSkillSurface(capSkill.frontmatter) === "command",
 				_source: capSkill._source,
 			});
 			realPathSet.add(resolvedPath);
@@ -234,7 +292,8 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 					filePath: capSkill.path,
 					baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 					source: "custom:user",
-					hide: capSkill.frontmatter?.hide === true,
+					surface: deriveSkillSurface(capSkill.frontmatter),
+					hide: deriveSkillSurface(capSkill.frontmatter) === "command",
 					_source: { ...capSkill._source, providerName: "Custom" },
 				},
 				path: capSkill.path,

--- a/packages/coding-agent/src/internal-urls/index.ts
+++ b/packages/coding-agent/src/internal-urls/index.ts
@@ -12,6 +12,7 @@ export * from "./agent-protocol";
 export * from "./artifact-protocol";
 export * from "./issue-pr-protocol";
 export * from "./json-query";
+export * from "./knowledge-protocol";
 export * from "./local-protocol";
 export * from "./mcp-protocol";
 export * from "./memory-protocol";

--- a/packages/coding-agent/src/internal-urls/knowledge-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/knowledge-protocol.ts
@@ -1,0 +1,263 @@
+/**
+ * Protocol handler for `knowledge://` URLs.
+ *
+ * Surfaces the four-bucket knowledge taxonomy directly to agents over the
+ * shared internal-URL plumbing. URL grammar:
+ *
+ *   knowledge://<type>[/<path>][?part=body|summary|full][&frontmatter=1]
+ *
+ * `<type>` ∈ `memory | skill | design | reference`. `<path>` is the
+ * type-root-relative document path; the `.md` suffix is auto-appended when
+ * absent so the slug form (`knowledge://memory/foo`) matches the slash
+ * command `/knowledge:memory/foo`.
+ *
+ * Selectors:
+ *   - `?frontmatter=1` — emit the YAML frontmatter head only.
+ *   - `?part=body`     — body region (between `omp:body` markers; falls
+ *                        back to frontmatter-stripped content).
+ *   - `?part=summary`  — frontmatter `summary` or the `## Summary` section.
+ *   - `?part=full`     — raw bytes (default; also the fallback for unknown
+ *                        `part` values).
+ *
+ * `frontmatter=1` wins over `part`. Sidecars (`*.omp-meta`) and non-`.md`
+ * paths are refused; use `memory://` for sidecars.
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { isEnoent } from "@oh-my-pi/pi-utils";
+import { isSidecarPath, TYPE_DIRS } from "../memories/directory-config";
+import type { MemoryDocType } from "../memories/document";
+import { parseMemoryDoc } from "../memories/document";
+import { extractSummarySection } from "../memories/knowledge-ops";
+import { memoryRootsFromRegistry } from "./memory-protocol";
+import { validateRelativePath } from "./skill-protocol";
+import type { InternalResource, InternalUrl, ProtocolHandler } from "./types";
+
+const KNOWN_TYPES = Object.keys(TYPE_DIRS) as MemoryDocType[];
+const FRONTMATTER_RE = /^---\r?\n[\s\S]*?\n---\r?\n/;
+const BODY_MARKER_LINE_RE = /^[ \t]*<!--\s*omp:body:(?:start|end)\s*-->[ \t]*\r?\n?/gm;
+
+type KnowledgePart = "full" | "body" | "summary";
+
+interface KnowledgeUrlParts {
+	type: MemoryDocType;
+	relFromTypeRoot: string;
+	frontmatterOnly: boolean;
+	part: KnowledgePart;
+}
+
+function parsePart(value: string | null): KnowledgePart {
+	if (value === "body" || value === "summary" || value === "full") return value;
+	return "full";
+}
+
+function parseFrontmatterFlag(value: string | null): boolean {
+	if (value === null) return false;
+	const lowered = value.toLowerCase();
+	return lowered === "1" || lowered === "true";
+}
+
+function parseKnowledgeUrl(url: InternalUrl): KnowledgeUrlParts {
+	const rawType = (url.rawHost || url.hostname).toLowerCase();
+	if (!rawType) {
+		throw new Error("knowledge:// URL requires a type bucket: knowledge://<type>/<doc>.md");
+	}
+	const type = rawType as MemoryDocType;
+	if (!KNOWN_TYPES.includes(type)) {
+		throw new Error(`Unknown knowledge type: ${rawType}. Supported: ${KNOWN_TYPES.join(", ")}`);
+	}
+
+	const rawPathname = url.rawPathname ?? url.pathname;
+	const hasPath = rawPathname && rawPathname !== "/" && rawPathname !== "";
+	if (!hasPath) {
+		throw new Error(`knowledge:// requires a path: knowledge://${type}/<doc>.md`);
+	}
+
+	let relativePath: string;
+	try {
+		relativePath = decodeURIComponent(rawPathname.slice(1));
+	} catch {
+		throw new Error(`Invalid URL encoding in knowledge:// path: ${url.href}`);
+	}
+	if (!relativePath) {
+		throw new Error(`knowledge:// requires a path: knowledge://${type}/<doc>.md`);
+	}
+
+	validateRelativePath(relativePath, "knowledge");
+
+	if (relativePath.split("/").some(seg => isSidecarPath(seg.toLowerCase()))) {
+		throw new Error(`knowledge:// only serves .md documents, not .omp-meta sidecars: ${url.href}`);
+	}
+
+	const ext = path.extname(relativePath).toLowerCase();
+	if (ext === "") {
+		relativePath += ".md";
+	} else if (ext !== ".md") {
+		throw new Error(`knowledge:// only serves .md documents: ${url.href}`);
+	}
+
+	return {
+		type,
+		relFromTypeRoot: relativePath,
+		frontmatterOnly: parseFrontmatterFlag(url.searchParams.get("frontmatter")),
+		part: parsePart(url.searchParams.get("part")),
+	};
+}
+
+interface TransformOutput {
+	content: string;
+	contentType: InternalResource["contentType"];
+	notes: string[];
+}
+
+function transformContent(raw: string, parts: KnowledgeUrlParts): TransformOutput {
+	if (parts.frontmatterOnly) {
+		const match = raw.match(FRONTMATTER_RE);
+		if (!match) {
+			return { content: "", contentType: "text/plain", notes: ["no frontmatter present"] };
+		}
+		return { content: match[0], contentType: "text/plain", notes: [] };
+	}
+
+	switch (parts.part) {
+		case "body": {
+			const doc = parseMemoryDoc(raw);
+			if (doc.hasBodyMarkers) {
+				return { content: doc.body.trim(), contentType: "text/markdown", notes: [] };
+			}
+			// Marker-less fallback: strip frontmatter and any dangling
+			// marker lines (one-sided start/end markers from a partial
+			// write or hand-edit). Operate on the CRLF-normalized text
+			// so the regex behavior is uniform across line-endings.
+			const stripped = doc.raw.replace(FRONTMATTER_RE, "").replace(BODY_MARKER_LINE_RE, "").trim();
+			return { content: stripped, contentType: "text/markdown", notes: [] };
+		}
+		case "summary": {
+			const doc = parseMemoryDoc(raw);
+			const fmSummary = typeof doc.frontmatter.summary === "string" ? doc.frontmatter.summary.trim() : "";
+			const summary = fmSummary || extractSummarySection(raw);
+			if (!summary) {
+				return { content: "", contentType: "text/markdown", notes: ["no summary present"] };
+			}
+			return { content: summary, contentType: "text/markdown", notes: [] };
+		}
+		default:
+			return { content: raw, contentType: "text/markdown", notes: [] };
+	}
+}
+
+async function tryResolveInRoot(
+	url: InternalUrl,
+	parts: KnowledgeUrlParts,
+	memoryRoot: string,
+): Promise<InternalResource | undefined> {
+	const resolvedRoot = await fs.realpath(memoryRoot).catch(error => {
+		if (isEnoent(error)) return undefined;
+		throw error;
+	});
+	if (!resolvedRoot) return undefined;
+
+	const typeRoot = path.join(resolvedRoot, TYPE_DIRS[parts.type]);
+	const targetPath = path.resolve(typeRoot, ...parts.relFromTypeRoot.split("/"));
+
+	if (targetPath !== typeRoot && !targetPath.startsWith(`${typeRoot}${path.sep}`)) {
+		throw new Error("knowledge:// URL escapes type root");
+	}
+
+	let realTargetPath: string;
+	try {
+		realTargetPath = await fs.realpath(targetPath);
+	} catch (error) {
+		if (isEnoent(error)) return undefined;
+		throw error;
+	}
+
+	// Defense in depth: resolve the type root separately and require the
+	// real target stays under it. If the type root itself is missing on
+	// disk, treat this memory root as not carrying this bucket and bail —
+	// NEVER fall back to the memory root as the perimeter (would silently
+	// widen the check from one bucket to all four).
+	let realTypeRoot: string;
+	try {
+		realTypeRoot = await fs.realpath(typeRoot);
+	} catch (error) {
+		if (isEnoent(error)) return undefined;
+		throw error;
+	}
+	// If the type root itself is a symlink that redirects to a different
+	// bucket (e.g. `memory/` -> `skill/`), `realTypeRoot` no longer points
+	// at the canonical bucket directory. Refuse so a single misplaced
+	// symlink cannot launder cross-bucket reads through the protocol.
+	if (realTypeRoot !== typeRoot) {
+		throw new Error("knowledge:// URL escapes type root");
+	}
+	if (realTargetPath !== realTypeRoot && !realTargetPath.startsWith(`${realTypeRoot}${path.sep}`)) {
+		throw new Error("knowledge:// URL escapes type root");
+	}
+
+	// Single-fd open guarantees the stat and read see the same inode,
+	// closing the realpath→stat→read TOCTOU window.
+	let raw: string;
+	const fh = await fs.open(realTargetPath, "r");
+	try {
+		const stat = await fh.stat();
+		if (!stat.isFile()) {
+			throw new Error(`knowledge:// URL must resolve to a file: ${url.href}`);
+		}
+		raw = await fh.readFile("utf-8");
+	} finally {
+		await fh.close();
+	}
+
+	const { content, contentType, notes } = transformContent(raw, parts);
+
+	return {
+		url: url.href,
+		content,
+		contentType,
+		size: Buffer.byteLength(content, "utf-8"),
+		sourcePath: realTargetPath,
+		notes,
+	};
+}
+
+/**
+ * Protocol handler for `knowledge://` URLs. Walks every active session's
+ * memory root (same semantics as `memory://`) and serves the first hit.
+ */
+export class KnowledgeProtocolHandler implements ProtocolHandler {
+	readonly scheme = "knowledge";
+	readonly immutable = true;
+
+	async resolve(url: InternalUrl): Promise<InternalResource> {
+		const parts = parseKnowledgeUrl(url);
+		const roots = memoryRootsFromRegistry();
+
+		if (roots.length === 0) {
+			throw new Error(
+				"Knowledge artifacts are not available for this project yet. Run a session with memories enabled first.",
+			);
+		}
+
+		let anyExists = false;
+		for (const root of roots) {
+			try {
+				await fs.stat(root);
+				anyExists = true;
+			} catch (error) {
+				if (isEnoent(error)) continue;
+				throw error;
+			}
+			const result = await tryResolveInRoot(url, parts, root);
+			if (result) return result;
+		}
+
+		if (!anyExists) {
+			throw new Error(
+				"Knowledge artifacts are not available for this project yet. Run a session with memories enabled first.",
+			);
+		}
+
+		throw new Error(`Knowledge document not found: ${url.href}`);
+	}
+}

--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -22,11 +22,6 @@ function ensureWithinRoot(targetPath: string, rootPath: string): void {
 	}
 }
 
-function toLocalValidationError(error: unknown): Error {
-	const message = error instanceof Error ? error.message : String(error);
-	return new Error(message.replace("skill://", "local://"));
-}
-
 function getContentType(filePath: string): InternalResource["contentType"] {
 	const ext = path.extname(filePath).toLowerCase();
 	if (ext === ".md") return "text/markdown";
@@ -100,11 +95,7 @@ function extractRelativePath(url: InternalUrl): string {
 	} catch {
 		throw new Error(`Invalid URL encoding in local:// path: ${url.href}`);
 	}
-	try {
-		validateRelativePath(decoded);
-	} catch (error) {
-		throw toLocalValidationError(error);
-	}
+	validateRelativePath(decoded, "local");
 	return decoded;
 }
 

--- a/packages/coding-agent/src/internal-urls/memory-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/memory-protocol.ts
@@ -6,8 +6,42 @@ import { AgentRegistry } from "../registry/agent-registry";
 import { validateRelativePath } from "./skill-protocol";
 import type { InternalResource, InternalUrl, ProtocolHandler } from "./types";
 
-const DEFAULT_MEMORY_FILE = "memory_summary.md";
+const DEFAULT_MEMORY_FILE = "memory/memory_summary.md";
+const LEGACY_DEFAULT_MEMORY_FILE = "memory_summary.md";
 const MEMORY_NAMESPACE = "root";
+
+/**
+ * Returns alternative paths under `memoryRoot` to try after the primary
+ * resolution missed. Mirrors the layout migration: requests for old-shape
+ * paths fall through to new-shape paths and vice versa.
+ */
+function legacyRedirectsFor(targetPath: string, memoryRoot: string): string[] {
+	const rel = path.relative(memoryRoot, targetPath).split(path.sep).join("/");
+	if (!rel || rel.startsWith("..")) return [];
+
+	// New shape primary → legacy fallback
+	if (rel === "memory/memory_summary.md") {
+		return [path.join(memoryRoot, "memory_summary.md")];
+	}
+	if (rel === "memory/MEMORY.md") {
+		return [path.join(memoryRoot, "MEMORY.md")];
+	}
+	if (rel.startsWith("skill/")) {
+		return [path.join(memoryRoot, "skills", ...rel.slice("skill/".length).split("/"))];
+	}
+
+	// Legacy primary → new-shape fallback
+	if (rel === "memory_summary.md") {
+		return [path.join(memoryRoot, "memory", "memory_summary.md")];
+	}
+	if (rel === "MEMORY.md") {
+		return [path.join(memoryRoot, "memory", "MEMORY.md")];
+	}
+	if (rel.startsWith("skills/")) {
+		return [path.join(memoryRoot, "skill", ...rel.slice("skills/".length).split("/"))];
+	}
+	return [];
+}
 
 /**
  * Snapshot of memory roots for every registered session, deduped.
@@ -32,11 +66,6 @@ function ensureWithinRoot(targetPath: string, rootPath: string): void {
 	}
 }
 
-function toMemoryValidationError(error: unknown): Error {
-	const message = error instanceof Error ? error.message : String(error);
-	return new Error(message.replace("skill://", "memory://"));
-}
-
 /**
  * Resolve a memory:// URL to an absolute filesystem path under memory root.
  */
@@ -52,6 +81,9 @@ export function resolveMemoryUrlToPath(url: InternalUrl, memoryRoot: string): st
 	const rawPathname = url.rawPathname ?? url.pathname;
 	const hasPath = rawPathname && rawPathname !== "/" && rawPathname !== "";
 	if (!hasPath) {
+		// Default file is the new-shape summary. Back-compat fallback happens
+		// in tryResolveInRoot: if the new path is missing, the legacy path is
+		// tried.
 		return path.resolve(memoryRoot, DEFAULT_MEMORY_FILE);
 	}
 	let relativePath: string;
@@ -61,11 +93,7 @@ export function resolveMemoryUrlToPath(url: InternalUrl, memoryRoot: string): st
 		throw new Error(`Invalid URL encoding in memory:// path: ${url.href}`);
 	}
 
-	try {
-		validateRelativePath(relativePath);
-	} catch (error) {
-		throw toMemoryValidationError(error);
-	}
+	validateRelativePath(relativePath, "memory");
 
 	return path.resolve(memoryRoot, relativePath);
 }
@@ -95,8 +123,37 @@ async function tryResolveInRoot(url: InternalUrl, memoryRoot: string): Promise<I
 	try {
 		realTargetPath = await fs.realpath(targetPath);
 	} catch (error) {
-		if (isEnoent(error)) return undefined;
-		throw error;
+		if (!isEnoent(error)) throw error;
+		// Primary missed — walk legacy/new fallbacks before giving up.
+		const fallbacks = legacyRedirectsFor(targetPath, resolvedRoot);
+		let fallbackResolved: string | undefined;
+		for (const fallback of fallbacks) {
+			ensureWithinRoot(fallback, resolvedRoot);
+			try {
+				fallbackResolved = await fs.realpath(fallback);
+				break;
+			} catch (innerErr) {
+				if (!isEnoent(innerErr)) throw innerErr;
+			}
+		}
+		if (!fallbackResolved) {
+			// Bare `memory://root` with no explicit path and nothing on disk:
+			// some callers depend on this missing → undefined contract.
+			const rawPathname = url.rawPathname ?? url.pathname;
+			const hasPath = rawPathname && rawPathname !== "/" && rawPathname !== "";
+			if (!hasPath) {
+				// Try legacy default too — `tryResolveInRoot` returns undefined,
+				// the handler then raises a clear error.
+				const legacyDefault = path.resolve(resolvedRoot, LEGACY_DEFAULT_MEMORY_FILE);
+				try {
+					fallbackResolved = await fs.realpath(legacyDefault);
+				} catch (legacyErr) {
+					if (!isEnoent(legacyErr)) throw legacyErr;
+				}
+			}
+		}
+		if (!fallbackResolved) return undefined;
+		realTargetPath = fallbackResolved;
 	}
 
 	ensureWithinRoot(realTargetPath, resolvedRoot);
@@ -108,6 +165,9 @@ async function tryResolveInRoot(url: InternalUrl, memoryRoot: string): Promise<I
 
 	const content = await Bun.file(realTargetPath).text();
 	const ext = path.extname(realTargetPath).toLowerCase();
+	// .md → text/markdown; .omp-meta / .yaml / .yml / everything else →
+	// text/plain (the InternalResource union does not currently include
+	// text/yaml; consumers can detect YAML by extension).
 	const contentType: InternalResource["contentType"] = ext === ".md" ? "text/markdown" : "text/plain";
 
 	return {

--- a/packages/coding-agent/src/internal-urls/router.ts
+++ b/packages/coding-agent/src/internal-urls/router.ts
@@ -8,6 +8,7 @@
 import { AgentProtocolHandler } from "./agent-protocol";
 import { ArtifactProtocolHandler } from "./artifact-protocol";
 import { IssueProtocolHandler, PrProtocolHandler } from "./issue-pr-protocol";
+import { KnowledgeProtocolHandler } from "./knowledge-protocol";
 import { LocalProtocolHandler } from "./local-protocol";
 import { McpProtocolHandler } from "./mcp-protocol";
 import { MemoryProtocolHandler } from "./memory-protocol";
@@ -27,6 +28,7 @@ export class InternalUrlRouter {
 		this.register(new AgentProtocolHandler());
 		this.register(new ArtifactProtocolHandler());
 		this.register(new MemoryProtocolHandler());
+		this.register(new KnowledgeProtocolHandler());
 		this.register(new LocalProtocolHandler());
 		this.register(new SkillProtocolHandler());
 		this.register(new RuleProtocolHandler());

--- a/packages/coding-agent/src/internal-urls/skill-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/skill-protocol.ts
@@ -18,16 +18,19 @@ function getContentType(filePath: string): InternalResource["contentType"] {
 }
 
 /**
- * Validate that a path is safe (no traversal, no absolute paths).
+ * Validate that a path is safe (no traversal, no absolute paths). The
+ * `schemeLabel` (without trailing `://`) is interpolated into error
+ * messages so per-scheme callers (memory, knowledge, local) surface the
+ * right URL in diagnostics — defaults to `"skill"` for back-compat.
  */
-export function validateRelativePath(relativePath: string): void {
+export function validateRelativePath(relativePath: string, schemeLabel = "skill"): void {
 	if (path.isAbsolute(relativePath)) {
-		throw new Error("Absolute paths are not allowed in skill:// URLs");
+		throw new Error(`Absolute paths are not allowed in ${schemeLabel}:// URLs`);
 	}
 
 	const normalized = path.normalize(relativePath);
 	if (normalized.startsWith("..") || normalized.includes("/../") || normalized.includes("/..")) {
-		throw new Error("Path traversal (..) is not allowed in skill:// URLs");
+		throw new Error(`Path traversal (..) is not allowed in ${schemeLabel}:// URLs`);
 	}
 }
 

--- a/packages/coding-agent/src/memories/directory-config.ts
+++ b/packages/coding-agent/src/memories/directory-config.ts
@@ -1,0 +1,466 @@
+/**
+ * `.omp-meta` directory sidecars.
+ *
+ * For every directory inside the memory root, an optional sidecar file
+ * lives **next to** the directory (NOT inside it), named
+ * `<dirname>.omp-meta`. Three properties this layout preserves:
+ *
+ *   - Policy is a single stat away — no directory enumeration required.
+ *   - Renaming a directory pairs `<name>/` and `<name>.omp-meta` as
+ *     siblings, no orphaned config files.
+ *   - The directory's children stay clean of policy artifacts.
+ *
+ * A doc's effective config is resolved in three tiers:
+ *
+ *   1. Type defaults (per top-level bucket: memory/skill/design/reference).
+ *   2. Walk the parent chain, merging non-null fields from any sidecar with
+ *      `inheritToChildren: true`. Stop at the first parent that opts out or
+ *      at the type root.
+ *   3. Per-doc frontmatter wins — except `inheritInjectMode: true` re-opts
+ *      into the parent's `injectMode`, and `inheritAiConfig: true` re-opts
+ *      into the parent's `aiMaintained` / `readOnly`.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { isEnoent, logger } from "@oh-my-pi/pi-utils";
+import { YAML } from "bun";
+import type { InjectMode, MemoryDocType } from "./document";
+
+/** Sidecar file suffix. */
+export const SIDECAR_SUFFIX = ".omp-meta";
+
+/** Top-level type directories under the memory root. */
+export const TYPE_DIRS: Readonly<Record<MemoryDocType, string>> = Object.freeze({
+	memory: "memory",
+	skill: "skill",
+	design: "design",
+	reference: "reference",
+});
+
+/** Raw shape of a `.omp-meta` sidecar file on disk. */
+export interface DirectoryConfigFile {
+	version?: number;
+	summary?: string;
+	injectMode?: InjectMode;
+	/**
+	 * When `true`, this sidecar's own `injectMode` is ignored and the dir
+	 * inherits from its parent chain instead. Symmetric counterpart of the
+	 * doc-level `inheritInjectMode` frontmatter flag.
+	 */
+	inheritInjectMode?: boolean;
+	inheritToChildren?: boolean;
+	aiMaintained?: boolean;
+	/**
+	 * When `true`, this sidecar's own `aiMaintained` is ignored and the dir
+	 * inherits from its parent chain instead.
+	 */
+	inheritAiConfig?: boolean;
+	explicitMaintenanceRules?: boolean;
+	allowCreateDocuments?: boolean;
+	allowCreateDirectories?: boolean;
+	allowMoveDocuments?: boolean;
+	allowMoveDirectories?: boolean;
+	maintenanceRules?: string;
+	externalSources?: unknown[];
+	[key: string]: unknown;
+}
+
+/**
+ * Fully-resolved effective config for a directory or document. All fields
+ * are present after resolution (defaults are filled in).
+ *
+ * Gate semantics:
+ *   - `readOnly: true` is the **hard** write block. Writes are refused.
+ *   - `aiMaintained: false` is **descriptive/routing** — it does NOT refuse AI
+ *     writes by itself. It surfaces as `requiresApproval: true` so callers
+ *     (knowledge tools) can route writes through a user-approval flow.
+ *   - The consolidator still uses `aiMaintained` as a routing discriminator:
+ *     Phase-2 writes only to `aiMaintained: true` paths.
+ */
+export interface EffectiveDirectoryConfig {
+	type: MemoryDocType;
+	injectMode: InjectMode;
+	aiMaintained: boolean;
+	readOnly: boolean;
+	/** Derived: `!aiMaintained && !readOnly`. Callers route writes through user approval when set. */
+	requiresApproval: boolean;
+	allowCreateDocuments: boolean;
+	allowCreateDirectories: boolean;
+	allowMoveDocuments: boolean;
+	allowMoveDirectories: boolean;
+	maintenanceRules?: string;
+	summary?: string;
+	externalSources: unknown[];
+}
+
+interface TypeDefault {
+	aiMaintained: boolean;
+	readOnly: boolean;
+	injectMode: InjectMode;
+	allowCreateDocuments: boolean;
+	allowCreateDirectories: boolean;
+	allowMoveDocuments: boolean;
+	allowMoveDirectories: boolean;
+}
+
+const TYPE_DEFAULTS: Readonly<Record<MemoryDocType, TypeDefault>> = Object.freeze({
+	memory: {
+		aiMaintained: true,
+		readOnly: false,
+		injectMode: "none",
+		allowCreateDocuments: true,
+		allowCreateDirectories: true,
+		allowMoveDocuments: true,
+		allowMoveDirectories: true,
+	},
+	skill: {
+		aiMaintained: true,
+		readOnly: false,
+		injectMode: "none",
+		allowCreateDocuments: true,
+		allowCreateDirectories: true,
+		allowMoveDocuments: true,
+		allowMoveDirectories: true,
+	},
+	design: {
+		// User-authored direction; AI may write through user approval.
+		// `requiresApproval` is derived from `aiMaintained: false` on the resolved
+		// config; the knowledge tools route through the resolve protocol.
+		aiMaintained: false,
+		readOnly: false,
+		injectMode: "path",
+		allowCreateDocuments: true,
+		allowCreateDirectories: true,
+		allowMoveDocuments: false,
+		allowMoveDirectories: false,
+	},
+	reference: {
+		// Read-only external material; user drops in, AI never mutates.
+		aiMaintained: false,
+		readOnly: true,
+		injectMode: "none",
+		allowCreateDocuments: true,
+		allowCreateDirectories: true,
+		allowMoveDocuments: false,
+		allowMoveDirectories: false,
+	},
+});
+
+/**
+ * Sidecar file path **next to** the directory.
+ *
+ *   memoryRoot/memory/topic/        → memoryRoot/memory/topic.omp-meta
+ */
+export function sidecarPathForDirectory(dirPath: string): string {
+	const parent = path.dirname(dirPath);
+	const name = path.basename(dirPath);
+	return path.join(parent, `${name}${SIDECAR_SUFFIX}`);
+}
+
+/** Is this an `.omp-meta` sidecar file path? */
+export function isSidecarPath(filePath: string): boolean {
+	return path.basename(filePath).endsWith(SIDECAR_SUFFIX);
+}
+
+/**
+ * Resolve a path to its `(type, typeRoot, relativeFromTypeRoot)` tuple, or
+ * `undefined` if the path is not under any known type root.
+ */
+export function classifyMemoryPath(
+	memoryRoot: string,
+	absPath: string,
+): { type: MemoryDocType; typeRoot: string; rel: string } | undefined {
+	const root = path.resolve(memoryRoot);
+	const target = path.resolve(absPath);
+	for (const type of Object.keys(TYPE_DIRS) as MemoryDocType[]) {
+		const typeRoot = path.join(root, TYPE_DIRS[type]);
+		if (target === typeRoot) {
+			return { type, typeRoot, rel: "" };
+		}
+		const prefix = `${typeRoot}${path.sep}`;
+		if (target.startsWith(prefix)) {
+			return { type, typeRoot, rel: target.slice(prefix.length) };
+		}
+	}
+	return undefined;
+}
+
+/** Read and parse a `.omp-meta` sidecar; returns `undefined` if missing. */
+export async function readSidecar(sidecarPath: string): Promise<DirectoryConfigFile | undefined> {
+	let text: string;
+	try {
+		text = await Bun.file(sidecarPath).text();
+	} catch (error) {
+		if (isEnoent(error)) return undefined;
+		throw error;
+	}
+	try {
+		const parsed = YAML.parse(text);
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			return parsed as DirectoryConfigFile;
+		}
+		return undefined;
+	} catch (error) {
+		logger.warn("Failed to parse .omp-meta sidecar", { path: sidecarPath, error: String(error) });
+		return undefined;
+	}
+}
+
+/** Serialize a sidecar config back to YAML. */
+export function stringifySidecar(config: DirectoryConfigFile): string {
+	return `${YAML.stringify(config).trimEnd()}\n`;
+}
+
+/**
+ * Resolve the effective config for a directory by walking parent
+ * sidecars up to the type root, merging fields from any sidecar with
+ * `inheritToChildren: true`.
+ *
+ * `inheritToChildren: false` on an ancestor acts as a **wall**: descendants
+ * below that ancestor see only type defaults from there on, regardless of
+ * what farther-up ancestors set. The walled-off ancestor's own sidecar
+ * still applies *to itself* — `inheritToChildren` governs descendants, not
+ * the directory it lives in.
+ *
+ * `dirPath` MUST be the absolute path of the directory whose config we
+ * want — for a doc, pass its parent directory.
+ */
+export async function resolveDirectoryConfig(
+	memoryRoot: string,
+	dirPath: string,
+): Promise<EffectiveDirectoryConfig | undefined> {
+	const classified = classifyMemoryPath(memoryRoot, dirPath);
+	if (!classified) return undefined;
+
+	const { type, typeRoot } = classified;
+	const defaults = TYPE_DEFAULTS[type];
+
+	// Walk from the type root *down* to `dirPath`, collecting sidecars in
+	// order. The type root is included so bucket-level sidecars (e.g.
+	// `memory.omp-meta`) can drive policy for the entire bucket and its
+	// descendants. The directory's own sidecar (if any) is the most specific.
+	const chain: string[] = [];
+	let cursor = path.resolve(dirPath);
+	const root = path.resolve(typeRoot);
+	while (true) {
+		chain.push(cursor);
+		if (cursor === root) break;
+		const parent = path.dirname(cursor);
+		if (parent === cursor) break;
+		cursor = parent;
+	}
+	chain.reverse();
+
+	let injectMode = defaults.injectMode;
+	let aiMaintained = defaults.aiMaintained;
+	const readOnly = defaults.readOnly;
+	let allowCreateDocuments = defaults.allowCreateDocuments;
+	let allowCreateDirectories = defaults.allowCreateDirectories;
+	let allowMoveDocuments = defaults.allowMoveDocuments;
+	let allowMoveDirectories = defaults.allowMoveDirectories;
+	let maintenanceRules: string | undefined;
+	let summary: string | undefined;
+	let externalSources: unknown[] = [];
+
+	const resetToDefaults = (): void => {
+		injectMode = defaults.injectMode;
+		aiMaintained = defaults.aiMaintained;
+		allowCreateDocuments = defaults.allowCreateDocuments;
+		allowCreateDirectories = defaults.allowCreateDirectories;
+		allowMoveDocuments = defaults.allowMoveDocuments;
+		allowMoveDirectories = defaults.allowMoveDirectories;
+		maintenanceRules = undefined;
+		summary = undefined;
+		externalSources = [];
+	};
+
+	const applySidecar = (sidecar: DirectoryConfigFile): void => {
+		if (sidecar.injectMode !== undefined && sidecar.inheritInjectMode !== true) {
+			injectMode = sidecar.injectMode;
+		}
+		if (sidecar.aiMaintained !== undefined && sidecar.inheritAiConfig !== true) {
+			aiMaintained = sidecar.aiMaintained;
+		}
+		if (sidecar.allowCreateDocuments !== undefined) allowCreateDocuments = sidecar.allowCreateDocuments;
+		if (sidecar.allowCreateDirectories !== undefined) allowCreateDirectories = sidecar.allowCreateDirectories;
+		if (sidecar.allowMoveDocuments !== undefined) allowMoveDocuments = sidecar.allowMoveDocuments;
+		if (sidecar.allowMoveDirectories !== undefined) allowMoveDirectories = sidecar.allowMoveDirectories;
+		if (sidecar.maintenanceRules !== undefined) maintenanceRules = sidecar.maintenanceRules;
+		if (sidecar.summary !== undefined) summary = sidecar.summary;
+		if (Array.isArray(sidecar.externalSources)) externalSources = sidecar.externalSources;
+		// readOnly is type-default driven; sidecars do not currently override it.
+		// Doc-level frontmatter is the override surface for readOnly.
+	};
+
+	for (let i = 0; i < chain.length; i++) {
+		const dir = chain[i];
+		const sidecar = await readSidecar(sidecarPathForDirectory(dir));
+		const isLast = i === chain.length - 1;
+
+		if (isLast) {
+			// The directory's own sidecar always applies to itself.
+			if (sidecar) applySidecar(sidecar);
+			continue;
+		}
+
+		if (!sidecar) continue;
+
+		if (sidecar.inheritToChildren !== true) {
+			// Wall: drop everything from above. The walled-off ancestor's
+			// own overrides do NOT reach the descendant (they apply only
+			// at the ancestor itself).
+			resetToDefaults();
+			continue;
+		}
+
+		applySidecar(sidecar);
+	}
+
+	return {
+		type,
+		injectMode,
+		aiMaintained,
+		readOnly,
+		requiresApproval: !aiMaintained && !readOnly,
+		allowCreateDocuments,
+		allowCreateDirectories,
+		allowMoveDocuments,
+		allowMoveDirectories,
+		maintenanceRules,
+		summary,
+		externalSources,
+	};
+}
+
+/**
+ * Resolve the effective per-doc config, honouring frontmatter overrides.
+ *
+ * `inheritInjectMode: true` on the doc re-opts into the parent's
+ * `injectMode` even when the doc also specifies its own value. Likewise,
+ * `inheritAiConfig: true` ignores the doc's own `aiMaintained` / `readOnly`
+ * and inherits both from the parent — useful when a doc moves under a
+ * directory whose policy should now win.
+ */
+export async function resolveDocConfig(
+	memoryRoot: string,
+	absDocPath: string,
+	docFrontmatter: {
+		injectMode?: InjectMode;
+		inheritInjectMode?: boolean;
+		readOnly?: boolean;
+		aiMaintained?: boolean;
+		inheritAiConfig?: boolean;
+	},
+): Promise<EffectiveDirectoryConfig | undefined> {
+	const parent = path.dirname(absDocPath);
+	const dirConfig = await resolveDirectoryConfig(memoryRoot, parent);
+	if (!dirConfig) return undefined;
+
+	const config: EffectiveDirectoryConfig = { ...dirConfig };
+	if (!docFrontmatter.inheritAiConfig) {
+		if (docFrontmatter.aiMaintained !== undefined) config.aiMaintained = docFrontmatter.aiMaintained;
+		if (docFrontmatter.readOnly !== undefined) config.readOnly = docFrontmatter.readOnly;
+	}
+	if (!docFrontmatter.inheritInjectMode && docFrontmatter.injectMode !== undefined) {
+		config.injectMode = docFrontmatter.injectMode;
+	}
+	config.requiresApproval = !config.aiMaintained && !config.readOnly;
+	return config;
+}
+
+/**
+ * Check whether a write to `absDocPath` is allowed. Returns the reason
+ * string if blocked, or `undefined` if allowed.
+ *
+ * Gate semantics:
+ *   - `readOnly: true` is the **hard** block (returns a refusal).
+ *   - `allowCreateDocuments: false` blocks create intent.
+ *   - `aiMaintained: false` does NOT refuse here. Inspect `requiresApproval`
+ *     on the resolved config (via `resolveDocConfig`) to route writes through
+ *     a user-approval flow.
+ *
+ * `intent` is one of:
+ *   - `"create"` — the doc does not yet exist on disk
+ *   - `"update"` — the doc exists and we want to rewrite it
+ */
+export async function checkWritePermission(
+	memoryRoot: string,
+	absDocPath: string,
+	intent: "create" | "update",
+	docFrontmatter: {
+		injectMode?: InjectMode;
+		inheritInjectMode?: boolean;
+		readOnly?: boolean;
+		aiMaintained?: boolean;
+		inheritAiConfig?: boolean;
+	} = {},
+): Promise<string | undefined> {
+	const config = await resolveDocConfig(memoryRoot, absDocPath, docFrontmatter);
+	if (!config) return undefined; // outside taxonomy (e.g. legacy paths) — no gating
+
+	if (config.readOnly) {
+		return `target is read-only: ${absDocPath}`;
+	}
+	if (intent === "create" && !config.allowCreateDocuments) {
+		return `directory denies new docs: ${path.dirname(absDocPath)}`;
+	}
+	return undefined;
+}
+
+/**
+ * Check whether deleting a doc/dir at `absPath` is allowed.
+ *
+ * Same gate semantics as `checkWritePermission`: `readOnly` is the hard
+ * block, `aiMaintained: false` is routing-only.
+ */
+export async function checkDeletePermission(
+	memoryRoot: string,
+	absPath: string,
+	docFrontmatter: { aiMaintained?: boolean; readOnly?: boolean; inheritAiConfig?: boolean } = {},
+): Promise<string | undefined> {
+	const stat = await fs.stat(absPath).catch(() => undefined);
+	if (!stat) return undefined;
+
+	if (stat.isDirectory()) {
+		const config = await resolveDirectoryConfig(memoryRoot, absPath);
+		if (config?.readOnly) return `target is read-only: ${absPath}`;
+		return undefined;
+	}
+
+	const config = await resolveDocConfig(memoryRoot, absPath, docFrontmatter);
+	if (!config) return undefined;
+	if (config.readOnly) return `target is read-only: ${absPath}`;
+	return undefined;
+}
+
+/**
+ * Rename a directory and its paired sidecar atomically. Either both move
+ * or neither does (the sidecar move is best-effort, but we restore the
+ * directory if the sidecar move fails).
+ */
+export async function renameDirectoryWithSidecar(sourceDir: string, destDir: string): Promise<void> {
+	const sourceSidecar = sidecarPathForDirectory(sourceDir);
+	const destSidecar = sidecarPathForDirectory(destDir);
+
+	const sourceSidecarExists = await fs.stat(sourceSidecar).then(
+		() => true,
+		() => false,
+	);
+
+	await fs.rename(sourceDir, destDir);
+	if (!sourceSidecarExists) return;
+
+	try {
+		await fs.rename(sourceSidecar, destSidecar);
+	} catch (error) {
+		// Roll back the directory move so the pair stays consistent.
+		await fs.rename(destDir, sourceDir).catch(() => undefined);
+		throw error;
+	}
+}
+
+/** Return the type defaults (read-only) — useful for tests and seed authoring. */
+export function getTypeDefaults(type: MemoryDocType): TypeDefault {
+	return TYPE_DEFAULTS[type];
+}

--- a/packages/coding-agent/src/memories/document.ts
+++ b/packages/coding-agent/src/memories/document.ts
@@ -1,0 +1,309 @@
+/**
+ * Memory document anatomy.
+ *
+ * Every doc under `memory_root/{memory,skill,design,reference}/` has three
+ * layered regions:
+ *
+ *   1. YAML frontmatter (between `---` fences).
+ *   2. Free markdown — typically the title and a `## Summary` section, plus
+ *      a `<!-- omp:maintain-rules:start -->` / `<!-- omp:maintain-rules:end -->`
+ *      region containing bulleted rules the AI must preserve.
+ *   3. `<!-- omp:body:start -->` / `<!-- omp:body:end -->` — the **only**
+ *      region the consolidator is allowed to rewrite.
+ *
+ * Docs without body markers are treated as "user-authored, do not touch":
+ * writes refuse to mutate them. New AI-emitted docs are wrapped in the body
+ * markers automatically on first write.
+ */
+
+import { parseFrontmatter } from "@oh-my-pi/pi-utils";
+import { YAML } from "bun";
+
+/**
+ * Supported injection modes for memory docs.
+ *
+ *   - `none`    — doc exists; nothing about it is injected.
+ *   - `path`    — only the canonical path + title are injected (a "I exist;
+ *                 read me if relevant" breadcrumb). No body or summary bytes.
+ *   - `summary` — frontmatter summary (or `## Summary` section) is injected.
+ *   - `full`    — the full body bytes are injected.
+ *   - `rule`    — the body is treated as imperative agent rules.
+ */
+export type InjectMode = "none" | "path" | "summary" | "full" | "rule";
+
+/** Four typed top-level buckets. */
+export type MemoryDocType = "memory" | "skill" | "design" | "reference";
+
+/** Body-marker prefix. */
+const BODY_MARKER_PREFIX = "omp";
+
+const BODY_START = `<!-- ${BODY_MARKER_PREFIX}:body:start -->`;
+const BODY_END = `<!-- ${BODY_MARKER_PREFIX}:body:end -->`;
+const RULES_START = `<!-- ${BODY_MARKER_PREFIX}:maintain-rules:start -->`;
+const RULES_END = `<!-- ${BODY_MARKER_PREFIX}:maintain-rules:end -->`;
+
+export const BODY_MARKERS = {
+	bodyStart: BODY_START,
+	bodyEnd: BODY_END,
+	rulesStart: RULES_START,
+	rulesEnd: RULES_END,
+} as const;
+
+/**
+ * Parsed frontmatter for a memory doc. Open-ended on purpose: unknown keys
+ * round-trip verbatim through writes.
+ */
+export interface MemoryDocFrontmatter {
+	id?: string;
+	type?: MemoryDocType;
+	path?: string;
+	title?: string;
+	injectMode?: InjectMode;
+	inheritInjectMode?: boolean;
+	summaryEnabled?: boolean;
+	readOnly?: boolean;
+	aiMaintained?: boolean;
+	inheritAiConfig?: boolean;
+	explicitMaintenanceRules?: boolean;
+	seedVersion?: number;
+	createdAt?: number;
+	updatedAt?: number;
+	/**
+	 * Opt-in: when `true`, the doc becomes invocable as
+	 * `/knowledge:<type>/<path>` in interactive / ACP frontends. Loading the
+	 * body region into context is read-only, mirroring the `/skill:<name>`
+	 * surface. Omit (or set to `false`) to keep the doc out of the slash menu.
+	 */
+	commandEnabled?: boolean;
+	[key: string]: unknown;
+}
+
+/**
+ * A parsed memory document. `raw` is the verbatim source we read off disk so
+ * non-body regions can be reproduced byte-for-byte on write.
+ */
+export interface MemoryDoc {
+	frontmatter: MemoryDocFrontmatter;
+	raw: string;
+	body: string;
+	/** `[start, end)` byte offsets in `raw` for the body region (between markers). */
+	bodyRange?: { start: number; end: number };
+	/** `true` when the doc carries `<!-- omp:body:start -->` markers. */
+	hasBodyMarkers: boolean;
+}
+
+/**
+ * Parse a memory document, preserving the raw bytes for non-destructive rewrites.
+ *
+ * Unlike `parseFrontmatter`, this never strips HTML comments and never trims
+ * the body — we need the markers intact and the offsets stable.
+ */
+export function parseMemoryDoc(raw: string): MemoryDoc {
+	const normalized = raw.replace(/\r\n?/g, "\n");
+
+	// Extract frontmatter via the shared parser (frontmatter values only; we
+	// do not trust its body output because it strips comments).
+	const { frontmatter } = parseFrontmatter(normalized, { normalize: false, level: "off" });
+
+	// Locate body markers in the raw text (post line-ending normalization).
+	const startIdx = normalized.indexOf(BODY_START);
+	let bodyRange: { start: number; end: number } | undefined;
+	if (startIdx !== -1) {
+		const afterStart = startIdx + BODY_START.length;
+		const endIdx = normalized.indexOf(BODY_END, afterStart);
+		if (endIdx !== -1) {
+			// Body region excludes the markers themselves. Newlines around the
+			// markers are part of the body.
+			bodyRange = { start: afterStart, end: endIdx };
+		}
+	}
+
+	const body = bodyRange ? normalized.slice(bodyRange.start, bodyRange.end) : "";
+
+	return {
+		frontmatter: frontmatter as MemoryDocFrontmatter,
+		raw: normalized,
+		body,
+		bodyRange,
+		hasBodyMarkers: bodyRange !== undefined,
+	};
+}
+
+/**
+ * Rewrite the body region of an existing doc, preserving frontmatter,
+ * heading, summary, and maintenance rules byte-for-byte.
+ *
+ * Returns the new file contents, or `undefined` if the doc has no body
+ * markers (callers MUST treat that as "do not write — user owns this doc").
+ */
+export function rewriteDocBody(doc: MemoryDoc, newBody: string): string | undefined {
+	if (!doc.bodyRange) return undefined;
+	const body = `\n${newBody.trim()}\n`;
+	return `${doc.raw.slice(0, doc.bodyRange.start)}${body}${doc.raw.slice(doc.bodyRange.end)}`;
+}
+
+/** Options for assembling a fresh memory doc with frontmatter + markers. */
+export interface BuildDocOptions {
+	frontmatter: MemoryDocFrontmatter;
+	title: string;
+	summary?: string;
+	maintenanceRules?: readonly string[];
+	body: string;
+}
+
+/**
+ * Build a complete memory document with frontmatter, summary, maintenance
+ * rules, and a body region enclosed in markers.
+ *
+ * Always emits markers, so future Phase-2 writes can mutate the body
+ * without trampling other regions.
+ */
+export function buildMemoryDoc(options: BuildDocOptions): string {
+	const fm = stringifyFrontmatter(options.frontmatter);
+	const parts: string[] = [fm, `# ${options.title.trim()}`, ""];
+	const summary = options.summary?.trim();
+	if (summary) {
+		parts.push("## Summary", summary, "");
+	}
+	const rules = options.maintenanceRules?.filter(rule => rule.trim().length > 0);
+	if (rules && rules.length > 0) {
+		parts.push(RULES_START);
+		for (const rule of rules) {
+			const trimmed = rule.trim().replace(/^[-*]\s*/, "");
+			parts.push(`- ${trimmed}`);
+		}
+		parts.push(RULES_END, "");
+	}
+	parts.push(BODY_START, options.body.trim(), BODY_END, "");
+	return parts.join("\n");
+}
+
+/**
+ * Wrap a fresh body with the start/end markers without recreating
+ * frontmatter or other regions. Used when we have a doc the model produced
+ * as plain markdown and need to attach body markers before first write.
+ */
+export function wrapBodyWithMarkers(body: string): string {
+	return `${BODY_START}\n${body.trim()}\n${BODY_END}\n`;
+}
+
+/**
+ * Serialize a frontmatter object as a `---`-fenced YAML block. Keys are
+ * emitted in insertion order; YAML strings are auto-quoted when needed.
+ */
+export function stringifyFrontmatter(frontmatter: MemoryDocFrontmatter): string {
+	const body = YAML.stringify(frontmatter).trimEnd();
+	return `---\n${body}\n---\n`;
+}
+
+/**
+ * Derive a deterministic id slug from a relative path. Produces a stable
+ * `kd_<slug>` shape so docs are addressable by id even when paths change.
+ */
+export function deriveDocId(relativePath: string): string {
+	const slug = relativePath
+		.replace(/\.md$/i, "")
+		.replace(/[\\/]/g, "_")
+		.replace(/[^A-Za-z0-9_-]/g, "_")
+		.replace(/_+/g, "_")
+		.replace(/^_+|_+$/g, "")
+		.toLowerCase();
+	return `kd_${slug || "doc"}`;
+}
+
+/**
+ * Monotonic seed version. Bump when the embedded built-in seed doc
+ * contents change — older seeds with a lower `seedVersion` are refreshed
+ * in-place (frontmatter + rules only; body is preserved).
+ */
+export const MEMORY_BUILTIN_SEED_VERSION = 2;
+
+/**
+ * Per-type default `summaryEnabled` value when a doc's frontmatter omits
+ * the field. Skill and reference docs default to summary-on (they are
+ * commonly injected by summary); memory and design default off.
+ */
+export function defaultSummaryEnabledForType(type: MemoryDocType): boolean {
+	return type === "skill" || type === "reference";
+}
+
+/**
+ * Per-type fallback maintenance-rules used when a caller creates an
+ * `aiMaintained: true` doc without supplying rules. AI-maintained docs
+ * always carry a non-empty rules section, so this fills the gap when the
+ * caller omits them.
+ */
+export function defaultMaintenanceRulesForType(type: MemoryDocType): readonly string[] {
+	switch (type) {
+		case "memory":
+			return [
+				"Keep entries durable and reusable; consolidate duplicates into the latest conclusion.",
+				"Drop transient context, one-off tasks, and unsupported guesses.",
+			];
+		case "skill":
+			return [
+				"Keep workflow steps, checks, and outputs stable across runs.",
+				"Update key steps when the underlying tools or process change.",
+				"Remove obsolete commands, duplicate notes, and expired limits.",
+			];
+		case "design":
+			return [
+				"Record confirmed design decisions and constraints.",
+				"Keep open questions current; replace outdated approaches in place.",
+				"Preserve the document structure while updating details.",
+			];
+		case "reference":
+			return [
+				"Capture verifiable facts, interfaces, and constraints.",
+				"Prefer durable conclusions and version-specific differences.",
+				"Drop outdated examples and unverified details.",
+			];
+	}
+}
+
+/**
+ * Input shape for `validateMemoryDoc`. Only the fields the validator
+ * inspects need to be supplied.
+ */
+export interface ValidateMemoryDocInput {
+	type: MemoryDocType;
+	injectMode?: InjectMode;
+	aiMaintained?: boolean;
+	explicitMaintenanceRules?: boolean;
+	maintenanceRules?: readonly string[] | string | null;
+}
+
+/**
+ * Structural invariants for a memory document. Returns a refusal string
+ * when the document is malformed; `undefined` when valid.
+ *
+ * Enforced rules:
+ *   - `aiMaintained: true` requires `explicitMaintenanceRules: true`.
+ *   - `aiMaintained: true` requires non-empty maintenance rules.
+ *   - `skill` / `reference` docs cannot use `injectMode=full` or `injectMode=rule`.
+ */
+export function validateMemoryDoc(input: ValidateMemoryDocInput): string | undefined {
+	const aiMaintained = input.aiMaintained === true;
+	const rules = input.maintenanceRules;
+	const rulesArray = Array.isArray(rules)
+		? rules
+		: typeof rules === "string"
+			? rules
+					.split(/\r?\n/)
+					.map(r => r.replace(/^\s*[-*]\s+/, "").trim())
+					.filter(Boolean)
+			: [];
+	const rulesHaveContent = rulesArray.some(r => r.trim().length > 0);
+
+	if (aiMaintained && input.explicitMaintenanceRules !== true) {
+		return "aiMaintained=true requires explicitMaintenanceRules=true";
+	}
+	if (aiMaintained && !rulesHaveContent) {
+		return "aiMaintained=true requires non-empty maintenance rules";
+	}
+	const mode = input.injectMode;
+	if ((input.type === "skill" || input.type === "reference") && (mode === "full" || mode === "rule")) {
+		return `${input.type} documents cannot use injectMode=full or injectMode=rule`;
+	}
+	return undefined;
+}

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -4,15 +4,28 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { completeSimple, Effort, type Model } from "@oh-my-pi/pi-ai";
-import { getAgentDbPath, getMemoriesDir, logger, parseJsonlLenient, prompt } from "@oh-my-pi/pi-utils";
+import { getAgentDbPath, getMemoriesDir, isEnoent, logger, parseJsonlLenient, prompt } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../config/model-registry";
 import { resolveModelRoleValue } from "../config/model-resolver";
 import type { Settings } from "../config/settings";
+import knowledgeMaintenanceTemplate from "../prompts/knowledge/maintenance.md" with { type: "text" };
+import knowledgeUsageTemplate from "../prompts/knowledge/usage.md" with { type: "text" };
 import consolidationTemplate from "../prompts/memories/consolidation.md" with { type: "text" };
 import readPathTemplate from "../prompts/memories/read-path.md" with { type: "text" };
 import stageOneInputTemplate from "../prompts/memories/stage_one_input.md" with { type: "text" };
 import stageOneSystemTemplate from "../prompts/memories/stage_one_system.md" with { type: "text" };
 import type { AgentSession } from "../session/agent-session";
+import { checkWritePermission, resolveDirectoryConfig, resolveDocConfig, TYPE_DIRS } from "./directory-config";
+import {
+	buildMemoryDoc,
+	deriveDocId,
+	type InjectMode,
+	type MemoryDocFrontmatter,
+	type MemoryDocType,
+	parseMemoryDoc,
+	rewriteDocBody,
+} from "./document";
+import { seedBuiltinDocs } from "./seed-docs";
 import {
 	claimStage1Jobs,
 	clearMemoryData as clearMemoryDataInDb,
@@ -105,10 +118,15 @@ interface ConsolidationSkillSchema {
 	templates?: ConsolidationSkillFileSchema[];
 	examples?: ConsolidationSkillFileSchema[];
 }
+interface ConsolidationDesignDraftSchema {
+	path: string;
+	content: string;
+}
 interface ConsolidationOutputSchema {
 	memory_md: string;
 	memory_summary: string;
 	skills: ConsolidationSkillSchema[];
+	design_drafts: ConsolidationDesignDraftSchema[];
 }
 
 /**
@@ -153,23 +171,23 @@ export async function buildMemoryToolDeveloperInstructions(
 	const cfg = loadMemoryConfig(settings);
 	if (!cfg.enabled) return undefined;
 	const memoryRoot = getMemoryRoot(agentDir, settings.getCwd());
-	const summaryPath = path.join(memoryRoot, "memory_summary.md");
+	const summary = await readMemorySummaryWithLegacyFallback(memoryRoot);
+	const knowledgeEnabled = settings.get("knowledge.enabled") === true;
 
-	let text: string;
-	try {
-		text = await Bun.file(summaryPath).text();
-	} catch {
-		return undefined;
+	const sections: string[] = [];
+	if (summary) {
+		const truncated = truncateByApproxTokens(summary, cfg.summaryInjectionTokenLimit);
+		if (truncated.trim()) {
+			sections.push(prompt.render(readPathTemplate, { memory_summary: truncated }));
+		}
 	}
-
-	const summary = text.trim();
-	if (!summary) return undefined;
-	const truncated = truncateByApproxTokens(summary, cfg.summaryInjectionTokenLimit);
-	if (!truncated.trim()) return undefined;
-
-	return prompt.render(readPathTemplate, {
-		memory_summary: truncated,
-	});
+	if (knowledgeEnabled) {
+		// Always inject the usage + maintenance rules when the knowledge
+		// tools are on, regardless of whether a summary exists yet.
+		sections.push(knowledgeUsageTemplate.trim(), knowledgeMaintenanceTemplate.trim());
+	}
+	if (sections.length === 0) return undefined;
+	return sections.join("\n\n");
 }
 
 /**
@@ -368,6 +386,8 @@ async function runPhase2(options: {
 		const outputs = listStage1OutputsForGlobal(db, config.maxRawMemoriesForGlobal, cwd);
 		const newWatermark = computeCompletionWatermark(claim.inputWatermark, outputs);
 
+		await migrateLegacyMemoryLayout(memoryRoot);
+		await seedBuiltinDocs(memoryRoot);
 		await syncPhase2Artifacts(memoryRoot, outputs);
 		if (outputs.length === 0) {
 			await cleanupConsolidatedArtifacts(memoryRoot);
@@ -679,10 +699,74 @@ async function syncPhase2Artifacts(memoryRoot: string, outputs: Stage1OutputRow[
 	await Bun.write(path.join(memoryRoot, "raw_memories.md"), rawBody);
 }
 
-async function cleanupConsolidatedArtifacts(memoryRoot: string): Promise<void> {
+/** @internal Exported for tests. */
+export async function cleanupConsolidatedArtifacts(memoryRoot: string): Promise<void> {
+	// Only remove AI-maintained artifacts. design/ and reference/ stay
+	// untouched — they are user-owned. Inside skill/, only directories whose
+	// effective config still says aiMaintained: true are eligible for delete.
+	await removeIfAiMaintained(memoryRoot, path.join(memoryRoot, "memory", "MEMORY.md"));
+	await removeIfAiMaintained(memoryRoot, path.join(memoryRoot, "memory", "memory_summary.md"));
+	await pruneSkillsDir(memoryRoot, path.join(memoryRoot, "skill"));
+
+	// Legacy locations: clean up only when no taxonomy override blocks them.
+	// Old roots have no .omp-meta files, so this is effectively unconditional
+	// for installs that never upgraded.
 	await fs.rm(path.join(memoryRoot, "MEMORY.md"), { force: true });
 	await fs.rm(path.join(memoryRoot, "memory_summary.md"), { force: true });
-	await fs.rm(path.join(memoryRoot, "skills"), { recursive: true, force: true });
+	await pruneSkillsDir(memoryRoot, path.join(memoryRoot, "skills"));
+}
+
+/** Remove a file iff its effective config still permits AI deletion. */
+async function removeIfAiMaintained(memoryRoot: string, absPath: string): Promise<void> {
+	const exists = await Bun.file(absPath)
+		.exists()
+		.catch(() => false);
+	if (!exists) return;
+	let frontmatter: MemoryDocFrontmatter = {};
+	try {
+		const text = await Bun.file(absPath).text();
+		frontmatter = parseMemoryDoc(text).frontmatter;
+	} catch {
+		// fall through with empty frontmatter
+	}
+	// If the doc is outside the taxonomy (legacy path), unconditional remove.
+	// Otherwise consult the doc-level config.
+	const config = await resolveDirectoryConfig(memoryRoot, path.dirname(absPath));
+	if (config) {
+		const aiMaintained = frontmatter.aiMaintained ?? config.aiMaintained;
+		const readOnly = frontmatter.readOnly ?? config.readOnly;
+		if (!aiMaintained || readOnly) return;
+	}
+	await fs.rm(absPath, { force: true });
+}
+
+/** Remove only AI-maintained skill directories under `skillsDir`. */
+async function pruneSkillsDir(memoryRoot: string, skillsDir: string): Promise<void> {
+	const entries = await fs.readdir(skillsDir, { withFileTypes: true }).catch(() => []);
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		const dir = path.join(skillsDir, entry.name);
+		const skillFile = path.join(dir, "SKILL.md");
+		let frontmatter: MemoryDocFrontmatter = {};
+		try {
+			const text = await Bun.file(skillFile).text();
+			frontmatter = parseMemoryDoc(text).frontmatter;
+		} catch {
+			// no SKILL.md or unparsable — fall through with empty frontmatter
+		}
+		const config = await resolveDirectoryConfig(memoryRoot, dir);
+		if (config) {
+			const aiMaintained = frontmatter.aiMaintained ?? config.aiMaintained;
+			const readOnly = frontmatter.readOnly ?? config.readOnly;
+			if (!aiMaintained || readOnly) continue;
+		}
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+	// Drop the dir itself if it's now empty.
+	const remaining = await fs.readdir(skillsDir).catch(() => [] as string[]);
+	if (remaining.length === 0) {
+		await fs.rm(skillsDir, { recursive: true, force: true });
+	}
 }
 
 function buildRawMemoriesMarkdown(outputs: Stage1OutputRow[]): string {
@@ -730,6 +814,7 @@ async function runConsolidationModel(options: {
 		templates: ConsolidationSkillFileSchema[];
 		examples: ConsolidationSkillFileSchema[];
 	}>;
+	designDrafts: ConsolidationDesignDraftSchema[];
 }> {
 	const { memoryRoot, model, apiKey } = options;
 	const rawMemories = await Bun.file(path.join(memoryRoot, "raw_memories.md")).text();
@@ -787,10 +872,12 @@ async function runConsolidationModel(options: {
 	if (!memoryMd || !memorySummary) {
 		throw new Error("phase2 returned empty consolidated memory");
 	}
-	return { memoryMd, memorySummary, skills };
+	const designDrafts = sanitizeDesignDrafts(schemaOutput.design_drafts);
+	return { memoryMd, memorySummary, skills, designDrafts };
 }
 
-async function applyConsolidation(
+/** @internal Exported for tests. */
+export async function applyConsolidation(
 	memoryRoot: string,
 	consolidated: {
 		memoryMd: string;
@@ -802,46 +889,481 @@ async function applyConsolidation(
 			templates: ConsolidationSkillFileSchema[];
 			examples: ConsolidationSkillFileSchema[];
 		}>;
+		designDrafts: ConsolidationDesignDraftSchema[];
 	},
 ): Promise<void> {
-	await Bun.write(path.join(memoryRoot, "MEMORY.md"), `${consolidated.memoryMd.trim()}\n`);
-	await Bun.write(path.join(memoryRoot, "memory_summary.md"), `${consolidated.memorySummary.trim()}\n`);
-	const skillsDir = path.join(memoryRoot, "skills");
-	await fs.mkdir(skillsDir, { recursive: true });
+	await migrateLegacyMemoryLayout(memoryRoot);
+	await seedBuiltinDocs(memoryRoot);
+
+	const memoryDir = path.join(memoryRoot, TYPE_DIRS.memory);
+	await fs.mkdir(memoryDir, { recursive: true });
+
+	await writeMemoryDoc(memoryRoot, path.join(memoryDir, "MEMORY.md"), {
+		type: "memory",
+		title: "Project Memory",
+		injectMode: "none",
+		summary: "Long-term project memory.",
+		body: consolidated.memoryMd,
+	});
+	await writeMemoryDoc(memoryRoot, path.join(memoryDir, "memory_summary.md"), {
+		type: "memory",
+		title: "Memory Summary",
+		injectMode: "summary",
+		summary: "Prompt-time guidance auto-injected each session.",
+		body: consolidated.memorySummary,
+	});
+
+	const skillsRoot = path.join(memoryRoot, TYPE_DIRS.skill);
+	await fs.mkdir(skillsRoot, { recursive: true });
+	const skillsRootConfig = await resolveDirectoryConfig(memoryRoot, skillsRoot);
+	const skillsRootAllowsCreate = skillsRootConfig?.allowCreateDirectories !== false;
 	const keep = new Set<string>();
 	for (const skill of consolidated.skills) {
-		const dir = path.join(skillsDir, skill.name);
+		const dir = path.join(skillsRoot, skill.name);
 		keep.add(skill.name);
+		const dirAlreadyExists = await fs
+			.stat(dir)
+			.then(s => s.isDirectory())
+			.catch(() => false);
+		if (!dirAlreadyExists && !skillsRootAllowsCreate) {
+			logger.debug("Skipped skill dir create: allowCreateDirectories=false at skills root", {
+				skill: skill.name,
+			});
+			continue;
+		}
 		await fs.mkdir(dir, { recursive: true });
-		const files = new Map<string, string>();
-		files.set("SKILL.md", `${skill.content.trim()}\n`);
+		const skillPath = path.join(dir, "SKILL.md");
+		await writeMemoryDoc(memoryRoot, skillPath, {
+			type: "skill",
+			title: skill.name,
+			injectMode: "none",
+			summary: `Skill playbook: ${skill.name}`,
+			body: skill.content,
+		});
+
+		// Asset buckets (scripts/templates/examples) are not body-marker docs;
+		// they are written verbatim and pruned to match the consolidator output.
+		// Both writes and the trailing prune are gated on the skill dir's
+		// effective `aiMaintained` AND `readOnly`: a user-protected or
+		// read-only skill keeps its assets intact even when the consolidator
+		// emits a same-named skill.
+		const gate = await resolveSkillGate(memoryRoot, dir, skillPath);
+		if (!gate.aiMaintained || gate.readOnly) {
+			logger.debug("Skipped skill asset writes: user-protected", {
+				skill: skill.name,
+				aiMaintained: gate.aiMaintained,
+				readOnly: gate.readOnly,
+			});
+			continue;
+		}
+
+		const assetFiles = new Map<string, string>();
 		for (const item of skill.scripts) {
-			files.set(path.posix.join("scripts", item.path), `${item.content.trim()}\n`);
+			assetFiles.set(path.posix.join("scripts", item.path), `${item.content.trim()}\n`);
 		}
 		for (const item of skill.templates) {
-			files.set(path.posix.join("templates", item.path), `${item.content.trim()}\n`);
+			assetFiles.set(path.posix.join("templates", item.path), `${item.content.trim()}\n`);
 		}
 		for (const item of skill.examples) {
-			files.set(path.posix.join("examples", item.path), `${item.content.trim()}\n`);
+			assetFiles.set(path.posix.join("examples", item.path), `${item.content.trim()}\n`);
 		}
-
-		for (const [relativePath, content] of [...files.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+		for (const [relativePath, content] of [...assetFiles.entries()].sort(([a], [b]) => a.localeCompare(b))) {
 			await Bun.write(path.join(dir, ...relativePath.split("/")), content);
 		}
-
-		const keepFiles = new Set(files.keys());
 		const existingFiles = await listRelativeFiles(dir);
+		const keepFiles = new Set<string>(["SKILL.md", ...assetFiles.keys()]);
 		for (const relativePath of existingFiles) {
 			if (keepFiles.has(relativePath)) continue;
 			await fs.rm(path.join(dir, ...relativePath.split("/")), { force: true });
 		}
 		await pruneEmptyDirectories(dir);
 	}
-	const dirs = await fs.readdir(skillsDir, { withFileTypes: true }).catch(() => []);
+
+	// Prune skill dirs the consolidator no longer emits — but only when the
+	// dir is AI-maintained. User-protected skills survive.
+	const dirs = await fs.readdir(skillsRoot, { withFileTypes: true }).catch(() => []);
 	for (const dirent of dirs) {
 		if (!dirent.isDirectory()) continue;
 		if (keep.has(dirent.name)) continue;
-		await fs.rm(path.join(skillsDir, dirent.name), { recursive: true, force: true });
+		const dir = path.join(skillsRoot, dirent.name);
+		const skillFile = path.join(dir, "SKILL.md");
+		const gate = await resolveSkillGate(memoryRoot, dir, skillFile);
+		if (!gate.aiMaintained || gate.readOnly) continue;
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+
+	// Drafts surfaced for user review go to design/_drafts/. They are
+	// frontmatter-tagged aiMaintained: false so the next pass refuses to
+	// touch them — drafts are write-once until the user promotes them.
+	if (consolidated.designDrafts.length > 0) {
+		const draftsDir = path.join(memoryRoot, TYPE_DIRS.design, "_drafts");
+		await fs.mkdir(draftsDir, { recursive: true });
+		for (const draft of consolidated.designDrafts) {
+			const safeRel = sanitizeSkillRelativePath(draft.path);
+			if (!safeRel) continue;
+			const absPath = path.join(draftsDir, ...safeRel.split("/"));
+			// Already-existing drafts are user-owned (or refused on prior pass).
+			const exists = await Bun.file(absPath)
+				.exists()
+				.catch(() => false);
+			if (exists) continue;
+			await fs.mkdir(path.dirname(absPath), { recursive: true });
+			const denied = await checkWritePermission(memoryRoot, absPath, "create", { aiMaintained: false });
+			if (denied) {
+				logger.debug("Skipped design_drafts write: permission denied", { path: absPath, reason: denied });
+				continue;
+			}
+			const relFromTypeRoot = path.posix.join("_drafts", safeRel);
+			const now = unixNow();
+			const content = buildMemoryDoc({
+				frontmatter: {
+					id: deriveDocId(relFromTypeRoot),
+					type: "design",
+					path: relFromTypeRoot,
+					title: safeRel.replace(/\.md$/i, ""),
+					injectMode: "none",
+					aiMaintained: false,
+					readOnly: false,
+					summaryEnabled: false,
+					explicitMaintenanceRules: false,
+					createdAt: now,
+					updatedAt: now,
+				},
+				title: safeRel.replace(/\.md$/i, ""),
+				summary: "Proposed design note — review and promote out of `_drafts/` to accept.",
+				body: draft.content,
+			});
+			await Bun.write(absPath, content);
+		}
+	}
+}
+
+/**
+ * Write a memory doc, honouring body markers and per-dir permissions.
+ *
+ * - If the doc already exists with `<!-- omp:body:start -->` markers, only
+ *   the body region is rewritten.
+ * - If the doc exists without markers, it is treated as user-authored and
+ *   left alone (writer logs and returns).
+ * - If the doc is missing, a fresh frontmatter + body-marker doc is written.
+ */
+async function writeMemoryDoc(
+	memoryRoot: string,
+	absPath: string,
+	spec: {
+		type: MemoryDocType;
+		title: string;
+		injectMode: InjectMode;
+		summary?: string;
+		maintenanceRules?: readonly string[];
+		body: string;
+	},
+): Promise<void> {
+	const trimmedBody = spec.body.trim();
+	if (!trimmedBody) return;
+
+	let existing: string | undefined;
+	try {
+		existing = await Bun.file(absPath).text();
+	} catch {
+		existing = undefined;
+	}
+
+	if (existing !== undefined) {
+		const doc = parseMemoryDoc(existing);
+		if (!doc.hasBodyMarkers) {
+			logger.debug("Skipped memory write: doc lacks body markers (user-authored)", { path: absPath });
+			return;
+		}
+		const denied = await checkWritePermission(memoryRoot, absPath, "update", doc.frontmatter);
+		if (denied) {
+			logger.debug("Skipped memory write: permission denied", { path: absPath, reason: denied });
+			return;
+		}
+		// Phase-2 routes only to `aiMaintained: true` paths. `aiMaintained: false`
+		// docs are user-protected — direct edits flow through the knowledge tools
+		// with user approval, not through the consolidator.
+		const docConfig = await resolveDocConfig(memoryRoot, absPath, doc.frontmatter);
+		if (docConfig && !docConfig.aiMaintained) {
+			logger.debug("Skipped memory write: target is not AI-maintained", { path: absPath });
+			return;
+		}
+		const rewritten = rewriteDocBody(doc, trimmedBody);
+		if (rewritten === undefined) return;
+		await Bun.write(absPath, rewritten);
+		return;
+	}
+
+	const denied = await checkWritePermission(memoryRoot, absPath, "create");
+	if (denied) {
+		logger.debug("Skipped memory write: permission denied", { path: absPath, reason: denied });
+		return;
+	}
+
+	// Same routing rule as the update branch: Phase-2 only creates docs in
+	// AI-maintained directories. `aiMaintained: false` targets are user-owned
+	// and must flow through the knowledge tools' approval sink, not the
+	// consolidator. `checkWritePermission` deliberately does not block this
+	// (it gates `readOnly` and `allowCreateDocuments` only), so the check is
+	// explicit here.
+	const parentConfig = await resolveDirectoryConfig(memoryRoot, path.dirname(absPath));
+	if (parentConfig && !parentConfig.aiMaintained) {
+		logger.debug("Skipped memory create: target dir is not AI-maintained", { path: absPath });
+		return;
+	}
+	const rel = computeRelativeFromTypeRoot(memoryRoot, absPath, spec.type);
+	const now = unixNow();
+	const content = buildMemoryDoc({
+		frontmatter: {
+			id: deriveDocId(rel),
+			type: spec.type,
+			path: rel,
+			title: spec.title,
+			injectMode: spec.injectMode,
+			inheritInjectMode: false,
+			inheritAiConfig: false,
+			aiMaintained: true,
+			readOnly: false,
+			summaryEnabled: true,
+			explicitMaintenanceRules: false,
+			createdAt: now,
+			updatedAt: now,
+		},
+		title: spec.title,
+		summary: spec.summary,
+		maintenanceRules: spec.maintenanceRules,
+		body: trimmedBody,
+	});
+	await Bun.write(absPath, content);
+}
+
+/**
+ * Resolve the effective `aiMaintained` / `readOnly` for a skill directory
+ * by reading SKILL.md frontmatter first and falling back to the directory's
+ * sidecar-resolved config. Missing / unparseable SKILL.md falls through to
+ * the dir config; missing dir config falls through to the skill type-default
+ * (`aiMaintained: true`, `readOnly: false`).
+ *
+ * Used to gate asset writes/prunes that bypass `writeMemoryDoc` — `readOnly`
+ * here is the hard refusal, mirroring `checkWritePermission` for the
+ * SKILL.md write path.
+ */
+async function resolveSkillGate(
+	memoryRoot: string,
+	skillDir: string,
+	skillFile: string,
+): Promise<{ aiMaintained: boolean; readOnly: boolean }> {
+	let frontmatter: MemoryDocFrontmatter = {};
+	let hasBodyMarkers = true;
+	let skillFileExists = true;
+	try {
+		const text = await Bun.file(skillFile).text();
+		const parsed = parseMemoryDoc(text);
+		frontmatter = parsed.frontmatter;
+		hasBodyMarkers = parsed.hasBodyMarkers;
+	} catch {
+		// missing or unparseable — defer to dir config. A truly absent
+		// SKILL.md is fine (fresh skill dir); a markerless one signals
+		// user-authored content that the consolidator must not touch.
+		skillFileExists = false;
+	}
+	const config = await resolveDirectoryConfig(memoryRoot, skillDir);
+	// A markerless SKILL.md is treated by `writeMemoryDoc` as user-authored
+	// and skipped. Mirror that here so the surrounding asset writes and the
+	// trailing skill prune cannot mutate `scripts/`, `templates/`, or
+	// `examples/` under a user-owned skill — even when frontmatter is
+	// silent and the dir config still defaults to `aiMaintained: true`.
+	if (skillFileExists && !hasBodyMarkers) {
+		return { aiMaintained: false, readOnly: frontmatter.readOnly ?? config?.readOnly ?? false };
+	}
+	const aiMaintained = frontmatter.aiMaintained ?? config?.aiMaintained ?? true;
+	const readOnly = frontmatter.readOnly ?? config?.readOnly ?? false;
+	return { aiMaintained, readOnly };
+}
+
+function computeRelativeFromTypeRoot(memoryRoot: string, absPath: string, type: MemoryDocType): string {
+	const typeRoot = path.join(memoryRoot, TYPE_DIRS[type]);
+	const rel = path.relative(typeRoot, absPath).split(path.sep).join("/");
+	return rel || path.basename(absPath);
+}
+
+async function readMemorySummaryWithLegacyFallback(memoryRoot: string): Promise<string | undefined> {
+	const candidates = [
+		path.join(memoryRoot, TYPE_DIRS.memory, "memory_summary.md"),
+		path.join(memoryRoot, "memory_summary.md"),
+	];
+	for (const candidate of candidates) {
+		let raw: string;
+		try {
+			raw = await Bun.file(candidate).text();
+		} catch {
+			continue;
+		}
+		// For new-shape docs with body markers we surface only the body
+		// region; legacy docs flow through verbatim.
+		const doc = parseMemoryDoc(raw);
+		const summary = doc.hasBodyMarkers ? doc.body.trim() : raw.trim();
+		if (summary) return summary;
+	}
+	return undefined;
+}
+
+/**
+ * One-shot best-effort migration of an old-shape memory root to the new
+ * taxonomy. Idempotent: safe to call on every Phase-2.
+ *
+ *   memory_root/MEMORY.md         → memory_root/memory/MEMORY.md
+ *   memory_root/memory_summary.md → memory_root/memory/memory_summary.md
+ *   memory_root/skills/<n>/       → memory_root/skill/<n>/
+ *
+ * Migrated files were AI-authored by the pre-PR consolidator, which wrote
+ * plain markdown without body markers. After the rename we promote each
+ * migrated `.md` into a marker-wrapped doc so subsequent Phase-2 runs
+ * recognize the file as AI-maintained and refresh the body region;
+ * otherwise `writeMemoryDoc` would treat the marker-less file as
+ * user-authored and the consolidator would silently no-op against it.
+ *
+ * If both old and new exist for the same artifact, the new shape wins and
+ * the old is left alone (the user may have intentionally written to it).
+ */
+async function migrateLegacyMemoryLayout(memoryRoot: string): Promise<void> {
+	const memoryDir = path.join(memoryRoot, TYPE_DIRS.memory);
+	const moves: Array<{
+		from: string;
+		to: string;
+		isDir: boolean;
+		type: MemoryDocType;
+		title: string;
+		summary?: string;
+	}> = [
+		{
+			from: path.join(memoryRoot, "MEMORY.md"),
+			to: path.join(memoryDir, "MEMORY.md"),
+			isDir: false,
+			type: "memory",
+			title: "Project Memory",
+			summary: "Long-term project memory.",
+		},
+		{
+			from: path.join(memoryRoot, "memory_summary.md"),
+			to: path.join(memoryDir, "memory_summary.md"),
+			isDir: false,
+			type: "memory",
+			title: "Memory Summary",
+			summary: "Prompt-time guidance auto-injected each session.",
+		},
+		{
+			from: path.join(memoryRoot, "skills"),
+			to: path.join(memoryRoot, TYPE_DIRS.skill),
+			isDir: true,
+			type: "skill",
+			title: "skill",
+		},
+	];
+	for (const move of moves) {
+		const fromExists = await Bun.file(move.from)
+			.exists()
+			.catch(() => false);
+		if (!fromExists && move.isDir) {
+			const stat = await fs.stat(move.from).catch(() => undefined);
+			if (!stat) continue;
+		} else if (!fromExists) {
+			continue;
+		}
+		const toExists = await Bun.file(move.to)
+			.exists()
+			.catch(() => false);
+		const toStat = move.isDir ? await fs.stat(move.to).catch(() => undefined) : undefined;
+		if (toExists || toStat) continue;
+		await fs.mkdir(path.dirname(move.to), { recursive: true });
+		try {
+			await fs.rename(move.from, move.to);
+		} catch (error) {
+			logger.warn("Memory layout migration step failed", {
+				from: move.from,
+				to: move.to,
+				error: String(error),
+			});
+			continue;
+		}
+		if (move.isDir) {
+			// Wrap every SKILL.md under the migrated skill tree. The
+			// consolidator overwrites these files on every Phase-2; without
+			// markers `writeMemoryDoc` treats them as user-authored.
+			await promoteLegacySkillDir(memoryRoot, move.to);
+		} else {
+			await promoteLegacyMemoryFile(memoryRoot, move.to, move.type, move.title, move.summary);
+		}
+	}
+}
+
+/**
+ * Wrap a marker-less legacy memory doc in body markers + frontmatter so the
+ * next consolidator pass can refresh its body region. Idempotent: already
+ * marker-wrapped docs are left untouched.
+ */
+async function promoteLegacyMemoryFile(
+	memoryRoot: string,
+	absPath: string,
+	type: MemoryDocType,
+	title: string,
+	summary: string | undefined,
+): Promise<void> {
+	let raw: string;
+	try {
+		raw = await Bun.file(absPath).text();
+	} catch (error) {
+		if (isEnoent(error)) return;
+		throw error;
+	}
+	const existing = parseMemoryDoc(raw);
+	if (existing.hasBodyMarkers) return;
+	// User-protected docs (`aiMaintained: false` / `readOnly: true`) keep
+	// their pre-PR shape — promoting them would force them under the
+	// consolidator's refresh path, defeating the user's protection.
+	if (existing.frontmatter.aiMaintained === false || existing.frontmatter.readOnly === true) {
+		return;
+	}
+	const rel = computeRelativeFromTypeRoot(memoryRoot, absPath, type);
+	const now = unixNow();
+	const body = raw.trim() || "<!-- Empty memory body. Replace with project content. -->";
+	const wrapped = buildMemoryDoc({
+		frontmatter: {
+			id: deriveDocId(rel),
+			type,
+			path: rel,
+			title,
+			injectMode: type === "memory" && path.basename(absPath) === "memory_summary.md" ? "summary" : "none",
+			inheritInjectMode: false,
+			inheritAiConfig: false,
+			aiMaintained: true,
+			readOnly: false,
+			summaryEnabled: true,
+			explicitMaintenanceRules: false,
+			createdAt: now,
+			updatedAt: now,
+		},
+		title,
+		summary,
+		body,
+	});
+	await Bun.write(absPath, wrapped);
+}
+
+/**
+ * Walk a migrated `skill/` directory and promote every marker-less
+ * `<n>/SKILL.md` so subsequent consolidations can refresh them.
+ */
+async function promoteLegacySkillDir(memoryRoot: string, skillsRoot: string): Promise<void> {
+	const entries = await fs.readdir(skillsRoot, { withFileTypes: true }).catch(() => []);
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		const skillFile = path.join(skillsRoot, entry.name, "SKILL.md");
+		const exists = await Bun.file(skillFile)
+			.exists()
+			.catch(() => false);
+		if (!exists) continue;
+		await promoteLegacyMemoryFile(memoryRoot, skillFile, "skill", entry.name, `Skill playbook: ${entry.name}`);
 	}
 }
 
@@ -923,10 +1445,15 @@ function parseStage1OutputSchema(value: Record<string, unknown>): Stage1OutputSc
 }
 
 function parseConsolidationOutputSchema(value: Record<string, unknown>): ConsolidationOutputSchema | undefined {
-	if (!hasExactKeys(value, ["memory_md", "memory_summary", "skills"])) return undefined;
+	const allowedKeys = ["memory_md", "memory_summary", "skills", "design_drafts"];
+	const sortedKeys = Object.keys(value).sort();
+	for (const key of sortedKeys) {
+		if (!allowedKeys.includes(key)) return undefined;
+	}
 	if (typeof value.memory_md !== "string") return undefined;
 	if (typeof value.memory_summary !== "string") return undefined;
 	if (!Array.isArray(value.skills)) return undefined;
+	if (value.design_drafts !== undefined && !Array.isArray(value.design_drafts)) return undefined;
 	const skills: ConsolidationSkillSchema[] = [];
 	for (const item of value.skills) {
 		if (!item || typeof item !== "object" || Array.isArray(item)) return undefined;
@@ -946,11 +1473,37 @@ function parseConsolidationOutputSchema(value: Record<string, unknown>): Consoli
 			examples,
 		});
 	}
+
+	const designDrafts: ConsolidationDesignDraftSchema[] = [];
+	if (Array.isArray(value.design_drafts)) {
+		for (const item of value.design_drafts) {
+			if (!item || typeof item !== "object" || Array.isArray(item)) return undefined;
+			const data = item as Record<string, unknown>;
+			if (!hasExactKeys(data, ["path", "content"])) return undefined;
+			if (typeof data.path !== "string" || typeof data.content !== "string") return undefined;
+			designDrafts.push({ path: data.path, content: data.content });
+		}
+	}
+
 	return {
 		memory_md: value.memory_md,
 		memory_summary: value.memory_summary,
 		skills,
+		design_drafts: designDrafts,
 	};
+}
+
+/** Strip empty/invalid draft entries; the schema parser already type-validates. */
+function sanitizeDesignDrafts(drafts: ConsolidationDesignDraftSchema[]): ConsolidationDesignDraftSchema[] {
+	const out: ConsolidationDesignDraftSchema[] = [];
+	for (const draft of drafts) {
+		const safe = sanitizeSkillRelativePath(draft.path);
+		if (!safe) continue;
+		const body = redactSecrets(draft.content).trim();
+		if (!body) continue;
+		out.push({ path: safe, content: body });
+	}
+	return out;
 }
 
 function hasExactKeys(value: Record<string, unknown>, expectedKeys: string[], allowMissing = false): boolean {

--- a/packages/coding-agent/src/memories/knowledge-ops.ts
+++ b/packages/coding-agent/src/memories/knowledge-ops.ts
@@ -1,0 +1,1344 @@
+/**
+ * Knowledge operations layer.
+ *
+ * Pure data layer exposing the seven knowledge operations
+ * against the four-bucket memory taxonomy. The `tools/knowledge.ts`
+ * wrappers turn these into AgentTool implementations; tests drive them
+ * directly.
+ *
+ * All ops accept a `memoryRoot` (the absolute path returned by
+ * `getMemoryRoot`) and a type-prefixed path of the form
+ * `<type>/<rest>` where `<type>` is one of memory|skill|design|reference.
+ *
+ *   - Document paths end in `.md`.
+ *   - Directory paths do not.
+ *   - The type prefix is mandatory.
+ *   - `..` segments are rejected.
+ *
+ * Writes flow through the `directory-config` permission gates and the
+ * `document` body-marker contract:
+ *
+ *   - `readOnly: true` is the hard refusal (reference/ default).
+ *   - `aiMaintained: false` is routing-only: the resolved config surfaces
+ *     `requiresApproval: true` and mutating ops route through an optional
+ *     `approvalSink` so the user can review the proposed change.
+ *   - Body-markerless docs are always treated as user-authored; `edit` is
+ *     refused regardless of approval.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { isEnoent } from "@oh-my-pi/pi-utils";
+import {
+	checkDeletePermission,
+	checkWritePermission,
+	type EffectiveDirectoryConfig,
+	isSidecarPath,
+	renameDirectoryWithSidecar,
+	resolveDirectoryConfig,
+	resolveDocConfig,
+	sidecarPathForDirectory,
+	TYPE_DIRS,
+} from "./directory-config";
+import {
+	buildMemoryDoc,
+	defaultMaintenanceRulesForType,
+	defaultSummaryEnabledForType,
+	deriveDocId,
+	type InjectMode,
+	type MemoryDoc,
+	type MemoryDocFrontmatter,
+	type MemoryDocType,
+	parseMemoryDoc,
+	rewriteDocBody,
+	validateMemoryDoc,
+} from "./document";
+
+const KNOWN_TYPES = Object.keys(TYPE_DIRS) as MemoryDocType[];
+
+/** Resolved type-prefixed path. */
+export interface ResolvedKnowledgePath {
+	type: MemoryDocType;
+	/** Absolute filesystem path under `memoryRoot/<typeRoot>/`. */
+	absPath: string;
+	/** Path relative to the type root (no `.md` stripped). */
+	relFromTypeRoot: string;
+	/** The original normalized type-prefixed path (e.g. `memory/foo.md`). */
+	canonical: string;
+}
+
+export class KnowledgeOpsError extends Error {
+	constructor(
+		readonly code: KnowledgeOpsErrorCode,
+		message: string,
+	) {
+		super(message);
+		this.name = "KnowledgeOpsError";
+	}
+}
+
+export type KnowledgeOpsErrorCode =
+	| "invalid_path"
+	| "not_found"
+	| "already_exists"
+	| "permission_denied"
+	| "kind_mismatch"
+	| "type_change"
+	| "io_error";
+
+// ────────────────────────────────────────────────────────────────────
+// approval sink
+// ────────────────────────────────────────────────────────────────────
+
+/** Summary of a proposed knowledge mutation, surfaced to the user for approval. */
+export interface KnowledgeApprovalPreview {
+	kind: "create" | "edit" | "move" | "delete";
+	/** Type-prefixed canonical source path. */
+	path: string;
+	/** Type-prefixed canonical destination path. Set only for `move`. */
+	destPath?: string;
+	type: MemoryDocType;
+	entryKind: "document" | "directory";
+	/** Doc title when known. */
+	title?: string;
+	/** New or current summary when relevant. */
+	summary?: string;
+	/** Excerpt of the new/proposed body when relevant. */
+	bodyPreview?: string;
+}
+
+/**
+ * Approval request handed to the sink. The sink decides when (and whether)
+ * to call `apply()`. Returning without calling `apply()` is interpreted as
+ * "deferred to user" — the caller reports `applied: false`.
+ */
+export interface KnowledgeApprovalRequest {
+	preview: KnowledgeApprovalPreview;
+	/** Performs the underlying write. Throws if the underlying op fails. */
+	apply(): Promise<void>;
+}
+
+/**
+ * User-approval callback. Tools that wire up `queueResolveHandler` pass a
+ * sink that queues the preview and calls `apply()` on the user's `resolve`
+ * invocation. Tests pass a synchronous auto-accept (`req => req.apply()`).
+ */
+export type KnowledgeApprovalSink = (request: KnowledgeApprovalRequest) => Promise<void>;
+
+export interface KnowledgeOpOptions {
+	approvalSink?: KnowledgeApprovalSink;
+}
+
+export interface KnowledgeOpOutcome {
+	/** `true` when the write actually ran (synchronously inside this call). */
+	applied: boolean;
+	/** `true` when the op was routed through an approval sink. */
+	requiredApproval: boolean;
+}
+
+/**
+ * Validate and resolve a type-prefixed path against `memoryRoot`.
+ *
+ * `kind` controls whether `.md` is required ("document"), forbidden
+ * ("directory"), or either ("any"). Returns the resolved location even
+ * when the target does not exist.
+ */
+export function resolveKnowledgePath(
+	memoryRoot: string,
+	pathInput: string,
+	kind: "document" | "directory" | "any",
+): ResolvedKnowledgePath {
+	if (typeof pathInput !== "string" || pathInput.length === 0) {
+		throw new KnowledgeOpsError("invalid_path", "Knowledge path is required");
+	}
+	const normalized = pathInput
+		.replace(/\\/g, "/")
+		.replace(/\/+/g, "/")
+		.replace(/^\/+|\/+$/g, "");
+	if (!normalized) {
+		throw new KnowledgeOpsError("invalid_path", "Knowledge path is required");
+	}
+	if (normalized.split("/").some(segment => segment === "" || segment === "." || segment === "..")) {
+		throw new KnowledgeOpsError("invalid_path", `Knowledge path may not contain '.' or '..' segments: ${pathInput}`);
+	}
+	const [rawType, ...rest] = normalized.split("/");
+	const type = rawType as MemoryDocType;
+	if (!KNOWN_TYPES.includes(type)) {
+		throw new KnowledgeOpsError(
+			"invalid_path",
+			`Unknown knowledge type "${rawType}". Expected one of: ${KNOWN_TYPES.join(", ")}`,
+		);
+	}
+	const relFromTypeRoot = rest.join("/");
+	const hasMdSuffix = /\.md$/i.test(relFromTypeRoot);
+	if (kind === "document" && !hasMdSuffix) {
+		throw new KnowledgeOpsError("invalid_path", `Document paths must end with .md: ${pathInput}`);
+	}
+	if (kind === "directory" && hasMdSuffix) {
+		throw new KnowledgeOpsError("invalid_path", `Directory paths must not end with .md: ${pathInput}`);
+	}
+	if (kind === "document" && relFromTypeRoot === "") {
+		throw new KnowledgeOpsError("invalid_path", `Document path is missing a filename: ${pathInput}`);
+	}
+	if (relFromTypeRoot.split("/").some(seg => isSidecarPath(seg))) {
+		throw new KnowledgeOpsError("invalid_path", `.omp-meta sidecars are not knowledge documents: ${pathInput}`);
+	}
+	const typeRoot = path.join(memoryRoot, TYPE_DIRS[type]);
+	const absPath = relFromTypeRoot ? path.join(typeRoot, ...relFromTypeRoot.split("/")) : typeRoot;
+	// Defense in depth: the assembled path must stay under the type root.
+	const rel = path.relative(typeRoot, absPath);
+	if (rel.startsWith("..") || path.isAbsolute(rel)) {
+		throw new KnowledgeOpsError("invalid_path", `Knowledge path escapes type root: ${pathInput}`);
+	}
+	return { type, absPath, relFromTypeRoot, canonical: normalized };
+}
+
+// ────────────────────────────────────────────────────────────────────
+// list
+// ────────────────────────────────────────────────────────────────────
+
+export interface KnowledgeListEntry {
+	/** Type-prefixed canonical path. */
+	path: string;
+	kind: "document" | "directory";
+	type: MemoryDocType;
+}
+
+/**
+ * List documents and child directories beneath an optional type-prefixed
+ * directory prefix. Omit `pathPrefix` to list across every type root.
+ *
+ * Output is sorted by canonical path. Sidecars are filtered; the `_drafts`
+ * machinery under `design/` is surfaced as ordinary entries.
+ */
+export async function knowledgeList(memoryRoot: string, pathPrefix?: string): Promise<KnowledgeListEntry[]> {
+	const targets: Array<{ type: MemoryDocType; root: string; rel: string }> = [];
+	if (pathPrefix && pathPrefix.trim() !== "") {
+		const resolved = resolveKnowledgePath(memoryRoot, pathPrefix, "directory");
+		targets.push({
+			type: resolved.type,
+			root: path.join(memoryRoot, TYPE_DIRS[resolved.type]),
+			rel: resolved.relFromTypeRoot,
+		});
+	} else {
+		for (const type of KNOWN_TYPES) {
+			targets.push({ type, root: path.join(memoryRoot, TYPE_DIRS[type]), rel: "" });
+		}
+	}
+	const entries: KnowledgeListEntry[] = [];
+	for (const target of targets) {
+		const startDir = target.rel ? path.join(target.root, ...target.rel.split("/")) : target.root;
+		await walkInto(startDir, target.root, target.type, entries);
+	}
+	entries.sort((a, b) => a.path.localeCompare(b.path));
+	return entries;
+}
+
+async function walkInto(dir: string, typeRoot: string, type: MemoryDocType, out: KnowledgeListEntry[]): Promise<void> {
+	const dirents = await fs.readdir(dir, { withFileTypes: true }).catch(error => {
+		if (isEnoent(error)) return [];
+		throw error;
+	});
+	for (const entry of dirents) {
+		if (entry.name.endsWith(".omp-meta")) continue;
+		const full = path.join(dir, entry.name);
+		const rel = path.relative(typeRoot, full).split(path.sep).join("/");
+		const canonical = `${TYPE_DIRS[type]}/${rel}`;
+		if (entry.isDirectory()) {
+			out.push({ path: canonical, kind: "directory", type });
+			await walkInto(full, typeRoot, type, out);
+			continue;
+		}
+		if (entry.isFile() && entry.name.toLowerCase().endsWith(".md")) {
+			out.push({ path: canonical, kind: "document", type });
+		}
+	}
+}
+
+// ────────────────────────────────────────────────────────────────────
+// query + ranker
+// ────────────────────────────────────────────────────────────────────
+
+export interface KnowledgeQueryOptions {
+	lexicalQuery?: string;
+	/** Optional semantic query. Routed through `ranker.rank` when set. */
+	semanticQuery?: string;
+	pathPrefix?: string;
+	/**
+	 * Restrict the search to the given top-level buckets. When omitted or
+	 * empty, every bucket is searched.
+	 */
+	types?: readonly MemoryDocType[];
+	limit?: number;
+	/** Optional ranker override. Defaults to `lexicalRanker`. */
+	ranker?: KnowledgeRanker;
+}
+
+/**
+ * Which section of the document a query term matched. Title and path are
+ * bonus surfaces for matches that only land outside the body region.
+ * Priority order when multiple sections match:
+ * `summary` > `maintenanceRules` > `body` > `title` > `path`.
+ */
+export type KnowledgeMatchSection = "summary" | "maintenanceRules" | "body" | "title" | "path";
+
+export interface KnowledgeQueryHit {
+	path: string;
+	type: MemoryDocType;
+	title?: string;
+	score: number;
+	snippet: string;
+	/** Which doc section the highest-priority match landed in. Omitted when
+	 * the candidate scored zero (in which case it isn't returned at all). */
+	matchedSection?: KnowledgeMatchSection;
+	/** Whether the doc has a non-empty summary surface (frontmatter or `## Summary`). */
+	hasSummary?: boolean;
+	/** Frontmatter `injectMode` when present. */
+	injectMode?: InjectMode;
+	/** Frontmatter `aiMaintained` when present. */
+	aiMaintained?: boolean;
+	/** Frontmatter `updatedAt` (unix seconds) when present. */
+	updatedAt?: number;
+}
+
+/** Document candidate handed to a ranker. */
+export interface KnowledgeRankCandidate {
+	entry: KnowledgeListEntry;
+	frontmatter: MemoryDocFrontmatter;
+	body: string;
+	title?: string;
+	/** Frontmatter `summary` or extracted `## Summary` section body. */
+	summary?: string;
+	/** Contents of the `<!-- omp:maintain-rules:* -->` block, newline-joined. */
+	maintenanceRules?: string;
+}
+
+export interface KnowledgeRankInput {
+	lexicalQuery: string;
+	semanticQuery: string;
+	candidates: KnowledgeRankCandidate[];
+}
+
+/**
+ * Pluggable ranker. Default is `lexicalRanker`. A semantic ranker can be
+ * registered without changing the surface; until one is, semantic-only
+ * queries fall through to lexical via the default impl.
+ */
+export interface KnowledgeRanker {
+	/** Score and rank candidates. Returns hits sorted best-first. */
+	rank(input: KnowledgeRankInput): Promise<KnowledgeQueryHit[]>;
+}
+
+/**
+ * Default lexical ranker. Scores per-section with these weights:
+ *
+ *   - title +1.5  · path +1.0  · summary +1.5  · maintenanceRules +1.2  · body +1.0
+ *
+ * Tracks the highest-priority matched section (`summary` > `maintenanceRules`
+ * > `body` > `title` > `path`) so the result tells callers *where* the term
+ * hit — agents can then decide whether to follow up with `knowledge_read
+ * part=summary` or `part=body`. Snippet is pulled from the matched section's
+ * text, not always from the body.
+ */
+export const lexicalRanker: KnowledgeRanker = {
+	async rank({ lexicalQuery, semanticQuery, candidates }): Promise<KnowledgeQueryHit[]> {
+		const query = (lexicalQuery || semanticQuery).trim();
+		if (!query) return [];
+		const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+		const hits: KnowledgeQueryHit[] = [];
+		for (const candidate of candidates) {
+			const { entry, title, body, summary, maintenanceRules } = candidate;
+			const titleLower = (title ?? "").toLowerCase();
+			const pathLower = entry.path.toLowerCase();
+			const summaryLower = (summary ?? "").toLowerCase();
+			const rulesLower = (maintenanceRules ?? "").toLowerCase();
+			const bodyLower = body.toLowerCase();
+
+			let score = 0;
+			let bodyHit = false;
+			let summaryHit = false;
+			let rulesHit = false;
+			let titleHit = false;
+			let pathHit = false;
+			for (const term of terms) {
+				if (titleLower.includes(term)) {
+					score += 1.5;
+					titleHit = true;
+				}
+				if (pathLower.includes(term)) {
+					score += 1.0;
+					pathHit = true;
+				}
+				if (summaryLower.includes(term)) {
+					score += 1.5;
+					summaryHit = true;
+				}
+				if (rulesLower.includes(term)) {
+					score += 1.2;
+					rulesHit = true;
+				}
+				if (bodyLower.includes(term)) {
+					score += 1.0;
+					bodyHit = true;
+				}
+			}
+			if (score === 0) continue;
+
+			// Priority: summary > maintenanceRules > body > title > path.
+			const matchedSection: KnowledgeMatchSection | undefined = summaryHit
+				? "summary"
+				: rulesHit
+					? "maintenanceRules"
+					: bodyHit
+						? "body"
+						: titleHit
+							? "title"
+							: pathHit
+								? "path"
+								: undefined;
+
+			const snippetSource =
+				matchedSection === "summary"
+					? (summary ?? "")
+					: matchedSection === "maintenanceRules"
+						? (maintenanceRules ?? "")
+						: matchedSection === "title"
+							? (title ?? "")
+							: matchedSection === "path"
+								? entry.path
+								: body;
+
+			const fm = candidate.frontmatter;
+			hits.push({
+				path: entry.path,
+				type: entry.type,
+				title,
+				score,
+				snippet: extractSnippet(snippetSource, terms),
+				matchedSection,
+				hasSummary: typeof summary === "string" && summary.trim().length > 0,
+				injectMode: typeof fm.injectMode === "string" ? fm.injectMode : undefined,
+				aiMaintained: typeof fm.aiMaintained === "boolean" ? fm.aiMaintained : undefined,
+				updatedAt: typeof fm.updatedAt === "number" ? fm.updatedAt : undefined,
+			});
+		}
+		hits.sort((a, b) => b.score - a.score || a.path.localeCompare(b.path));
+		return hits;
+	},
+};
+
+/**
+ * Search across the knowledge tree. `lexicalQuery` and `semanticQuery`
+ * are both accepted; both flow through the active ranker. A semantic
+ * backend can register a custom ranker via the `ranker` option; until
+ * one is registered, semantic queries fall through to lexical scoring.
+ */
+export async function knowledgeQuery(memoryRoot: string, options: KnowledgeQueryOptions): Promise<KnowledgeQueryHit[]> {
+	const lexical = (options.lexicalQuery ?? "").trim();
+	const semantic = (options.semanticQuery ?? "").trim();
+	if (!lexical && !semantic) return [];
+	const limit = clampLimit(options.limit ?? 5);
+
+	const docs = await knowledgeList(memoryRoot, options.pathPrefix);
+	const typeFilter = options.types && options.types.length > 0 ? new Set(options.types) : undefined;
+	const candidates: KnowledgeRankCandidate[] = [];
+	for (const entry of docs) {
+		if (entry.kind !== "document") continue;
+		if (typeFilter && !typeFilter.has(entry.type)) continue;
+		const absPath = resolveKnowledgePath(memoryRoot, entry.path, "document").absPath;
+		let raw: string;
+		try {
+			raw = await Bun.file(absPath).text();
+		} catch (error) {
+			if (isEnoent(error)) continue;
+			throw error;
+		}
+		const doc = parseMemoryDoc(raw);
+		const title = typeof doc.frontmatter.title === "string" ? doc.frontmatter.title : undefined;
+		const body = doc.hasBodyMarkers ? doc.body : raw;
+		const fmSummaryRaw = typeof doc.frontmatter.summary === "string" ? doc.frontmatter.summary.trim() : "";
+		const summary = fmSummaryRaw || extractSummarySection(raw) || undefined;
+		const rulesArr = extractMaintenanceRulesFromDoc(raw);
+		const maintenanceRules = rulesArr.length > 0 ? rulesArr.join("\n") : undefined;
+		candidates.push({ entry, frontmatter: doc.frontmatter, body, title, summary, maintenanceRules });
+	}
+	const ranker = options.ranker ?? lexicalRanker;
+	const ranked = await ranker.rank({ lexicalQuery: lexical, semanticQuery: semantic, candidates });
+	return ranked.slice(0, limit);
+}
+
+function clampLimit(value: number): number {
+	if (!Number.isFinite(value) || value <= 0) return 5;
+	return Math.min(Math.floor(value), 20);
+}
+
+function extractSnippet(body: string, terms: string[], windowSize = 160): string {
+	const lower = body.toLowerCase();
+	let best = -1;
+	for (const term of terms) {
+		const idx = lower.indexOf(term);
+		if (idx !== -1 && (best === -1 || idx < best)) best = idx;
+	}
+	const start = best === -1 ? 0 : Math.max(0, best - 40);
+	const end = Math.min(body.length, start + windowSize);
+	return body.slice(start, end).replace(/\s+/g, " ").trim();
+}
+
+// ────────────────────────────────────────────────────────────────────
+// read
+// ────────────────────────────────────────────────────────────────────
+
+export type KnowledgeReadPart = "full" | "summary" | "body";
+
+export interface KnowledgeReadResult {
+	path: string;
+	type: MemoryDocType;
+	part: KnowledgeReadPart;
+	content: string;
+	hasBodyMarkers: boolean;
+	frontmatter: MemoryDocFrontmatter;
+}
+
+/**
+ * Read a knowledge document.
+ *
+ * - `part: "summary"` returns the parsed frontmatter `summary` (or the
+ *   `## Summary` section body if frontmatter omits it).
+ * - `part: "body"` returns only the body region between markers.
+ * - `part: "full"` returns a reformatted markdown view (title, summary,
+ *   maintenance rules, content) — frontmatter and `<!-- omp:* -->` comment
+ *   markers are stripped so the LLM only sees the agent-facing surface.
+ */
+export async function knowledgeRead(
+	memoryRoot: string,
+	pathInput: string,
+	part: KnowledgeReadPart = "full",
+): Promise<KnowledgeReadResult> {
+	const resolved = resolveKnowledgePath(memoryRoot, pathInput, "document");
+	let raw: string;
+	try {
+		raw = await Bun.file(resolved.absPath).text();
+	} catch (error) {
+		if (isEnoent(error)) {
+			throw new KnowledgeOpsError("not_found", `Knowledge document not found: ${pathInput}`);
+		}
+		throw error;
+	}
+	const doc = parseMemoryDoc(raw);
+	let content: string;
+	if (part === "full") {
+		content = renderReadableFull(raw, doc);
+	} else if (part === "body") {
+		content = doc.hasBodyMarkers ? doc.body.trim() : raw.trim();
+	} else {
+		const fmSummary = typeof doc.frontmatter.summary === "string" ? doc.frontmatter.summary.trim() : "";
+		content = fmSummary || extractSummarySection(raw);
+	}
+	return {
+		path: resolved.canonical,
+		type: resolved.type,
+		part,
+		content,
+		hasBodyMarkers: doc.hasBodyMarkers,
+		frontmatter: doc.frontmatter,
+	};
+}
+
+/**
+ * Render a `part=full` knowledge read as agent-friendly markdown: the
+ * `# title`, a `## Summary` block when present, a `## Maintenance Rules`
+ * block when present, and a `## Content` block holding the body region.
+ * Frontmatter and `<!-- omp:* -->` comment markers are stripped so the
+ * LLM only sees the human-readable surface.
+ */
+function renderReadableFull(raw: string, doc: MemoryDoc): string {
+	const title =
+		typeof doc.frontmatter.title === "string" && doc.frontmatter.title.trim()
+			? doc.frontmatter.title.trim()
+			: undefined;
+	const fmSummaryRaw = typeof doc.frontmatter.summary === "string" ? doc.frontmatter.summary.trim() : "";
+	const summary = fmSummaryRaw || extractSummarySection(raw);
+	const rules = extractMaintenanceRulesFromDoc(raw);
+	const body = doc.hasBodyMarkers ? doc.body.trim() : raw.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
+
+	const parts: string[] = [];
+	if (title) parts.push(`# ${title}`, "");
+	if (summary) parts.push("## Summary", summary, "");
+	if (rules.length > 0) {
+		parts.push("## Maintenance Rules");
+		for (const rule of rules) parts.push(`- ${rule}`);
+		parts.push("");
+	}
+	parts.push("## Content", body || "");
+	return parts.join("\n").trimEnd();
+}
+
+export function extractSummarySection(raw: string): string {
+	// The end-anchor uses `$(?![\s\S])` (true end-of-string) rather than
+	// `\s*$`: with the `m` flag, `\s*$` matches at every line boundary, so a
+	// lazy `[\s\S]*?` would terminate at the first newline and silently
+	// truncate multi-paragraph summaries.
+	const match = raw.match(/^##\s+Summary\s*\n([\s\S]*?)(?=\n##\s|\n<!--\s*omp:|$(?![\s\S]))/im);
+	return match?.[1]?.trim() ?? "";
+}
+
+// ────────────────────────────────────────────────────────────────────
+// approval routing
+// ────────────────────────────────────────────────────────────────────
+
+/**
+ * Route a mutating write through the approval sink when required.
+ *
+ * - `requiresApproval` and `approvalSink` present  → call sink with `apply`.
+ *   The sink decides when to invoke `apply()`; if it returns without doing
+ *   so, the op is reported as `applied: false, requiredApproval: true`.
+ * - `requiresApproval` and no `approvalSink`        → throw `permission_denied`.
+ * - `requiresApproval: false`                       → run `apply` synchronously.
+ */
+async function routeApproval(
+	requiresApproval: boolean,
+	preview: KnowledgeApprovalPreview,
+	apply: () => Promise<void>,
+	approvalSink: KnowledgeApprovalSink | undefined,
+): Promise<KnowledgeOpOutcome> {
+	if (!requiresApproval) {
+		await apply();
+		return { applied: true, requiredApproval: false };
+	}
+	if (!approvalSink) {
+		throw new KnowledgeOpsError("permission_denied", `user approval required: ${preview.path}`);
+	}
+	let applied = false;
+	const wrapped = async (): Promise<void> => {
+		await apply();
+		applied = true;
+	};
+	await approvalSink({ preview, apply: wrapped });
+	return { applied, requiredApproval: true };
+}
+
+// ────────────────────────────────────────────────────────────────────
+// create
+// ────────────────────────────────────────────────────────────────────
+
+export interface KnowledgeCreateDocOptions {
+	summary?: string | null;
+	body?: string;
+	maintenanceRules?: string | null;
+	/**
+	 * Opt-in slash-command surface. When `true`, the resulting frontmatter
+	 * carries `commandEnabled: true` so `/knowledge:<type>/<path>` is
+	 * registered on the next session start. Omitted (or `false`) keeps the
+	 * doc out of the slash menu — the field is *not* written when falsy so
+	 * frontmatter stays quiet for the common case.
+	 */
+	commandEnabled?: boolean;
+}
+
+/**
+ * Create a knowledge document. Path must be type-prefixed and end with
+ * `.md`. Refuses if the file already exists or the parent directory
+ * sidecar denies new documents.
+ *
+ * The new doc inherits `aiMaintained` / `readOnly` from the parent
+ * directory's effective config so directories like `design/` (which
+ * default to `aiMaintained: false`) produce user-authored shape docs.
+ * When `requiresApproval` is set on the parent, the create routes
+ * through `options.approvalSink`.
+ */
+export async function knowledgeCreateDocument(
+	memoryRoot: string,
+	pathInput: string,
+	content: KnowledgeCreateDocOptions = {},
+	options: KnowledgeOpOptions = {},
+): Promise<KnowledgeOpOutcome> {
+	const resolved = resolveKnowledgePath(memoryRoot, pathInput, "document");
+	const exists = await fileExists(resolved.absPath);
+	if (exists) {
+		throw new KnowledgeOpsError("already_exists", `Knowledge document already exists: ${pathInput}`);
+	}
+	const denied = await checkWritePermission(memoryRoot, resolved.absPath, "create");
+	if (denied) {
+		throw new KnowledgeOpsError("permission_denied", denied);
+	}
+	const parentDir = path.dirname(resolved.absPath);
+	const parentExists = await fileExists(parentDir);
+	const dirConfig = await resolveDirectoryConfig(memoryRoot, parentDir);
+	if (!parentExists && dirConfig && !dirConfig.allowCreateDirectories) {
+		// Creating an intermediate directory along the way requires the
+		// type root / nearest sidecar to allow directory creation. Otherwise
+		// `knowledge_create kind=document` would launder around the
+		// `allowCreateDirectories: false` gate.
+		throw new KnowledgeOpsError("permission_denied", `directory create not allowed: ${parentDir}`);
+	}
+	const summary = content.summary ?? undefined;
+	const userRules = parseMaintenanceRules(content.maintenanceRules);
+	const trimmedBody = content.body?.trim();
+	const docTitle = deriveTitle(resolved.relFromTypeRoot, summary);
+
+	// Auto-fill maintenance rules on AI-maintained docs when the caller
+	// omits them, then validate the resulting frontmatter shape before
+	// any filesystem mutation so a doomed write never reaches the user as a
+	// pending approval preview.
+	const effectiveAiMaintained = dirConfig?.aiMaintained ?? true;
+	const effectiveReadOnly = dirConfig?.readOnly ?? false;
+	const effectiveInjectMode: InjectMode = dirConfig?.injectMode ?? "none";
+	const maintenanceRules =
+		userRules.length > 0
+			? userRules
+			: effectiveAiMaintained
+				? [...defaultMaintenanceRulesForType(resolved.type)]
+				: [];
+	const explicitMaintenanceRules = maintenanceRules.length > 0;
+	const summaryEnabled = summary !== undefined ? true : defaultSummaryEnabledForType(resolved.type);
+
+	const denial = validateMemoryDoc({
+		type: resolved.type,
+		injectMode: effectiveInjectMode,
+		aiMaintained: effectiveAiMaintained,
+		explicitMaintenanceRules,
+		maintenanceRules,
+	});
+	if (denial) {
+		throw new KnowledgeOpsError("invalid_path", denial);
+	}
+
+	const apply = async (): Promise<void> => {
+		// Materialize the parent only at apply time so a rejected/withheld
+		// approval leaves the tree untouched.
+		await fs.mkdir(parentDir, { recursive: true });
+		const now = unixNow();
+		const docContent = buildMemoryDoc({
+			frontmatter: {
+				id: deriveDocId(resolved.relFromTypeRoot),
+				type: resolved.type,
+				path: resolved.relFromTypeRoot,
+				title: docTitle,
+				injectMode: effectiveInjectMode,
+				inheritInjectMode: true,
+				inheritAiConfig: true,
+				aiMaintained: effectiveAiMaintained,
+				readOnly: effectiveReadOnly,
+				summaryEnabled,
+				explicitMaintenanceRules,
+				createdAt: now,
+				updatedAt: now,
+				// Only emit `commandEnabled` when the caller opted in; falsy values
+				// stay out of frontmatter to keep the doc quiet.
+				commandEnabled: content.commandEnabled === true ? true : undefined,
+			},
+			title: docTitle,
+			summary: summary ?? undefined,
+			maintenanceRules,
+			body: trimmedBody ?? "<!-- Empty knowledge body. Replace with project content. -->",
+		});
+		await Bun.write(resolved.absPath, docContent);
+	};
+	const preview: KnowledgeApprovalPreview = {
+		kind: "create",
+		path: resolved.canonical,
+		type: resolved.type,
+		entryKind: "document",
+		title: docTitle,
+		summary: summary ?? undefined,
+		bodyPreview: bodyExcerpt(trimmedBody),
+	};
+	return routeApproval(dirConfig?.requiresApproval ?? false, preview, apply, options.approvalSink);
+}
+
+/**
+ * Create a knowledge directory. Idempotent for an already-existing
+ * directory; throws if a file with the same name exists. Refuses bare
+ * type roots (those are seeded, not user-created). Honours the parent
+ * directory's `readOnly` / `allowCreateDirectories` gates and routes
+ * through `options.approvalSink` when the parent requires approval.
+ */
+export async function knowledgeCreateDirectory(
+	memoryRoot: string,
+	pathInput: string,
+	options: KnowledgeOpOptions = {},
+): Promise<KnowledgeOpOutcome> {
+	const resolved = resolveKnowledgePath(memoryRoot, pathInput, "directory");
+	if (resolved.relFromTypeRoot === "") {
+		throw new KnowledgeOpsError(
+			"invalid_path",
+			`Refusing to create taxonomy root directory: ${pathInput}. Type roots are reserved.`,
+		);
+	}
+	const stat = await fs.stat(resolved.absPath).catch(() => undefined);
+	if (stat) {
+		if (stat.isDirectory()) return { applied: false, requiredApproval: false };
+		throw new KnowledgeOpsError("kind_mismatch", `Knowledge path exists but is not a directory: ${pathInput}`);
+	}
+	const parentDir = path.dirname(resolved.absPath);
+	// resolveDirectoryConfig classifies by path string, so missing
+	// intermediate directories still resolve to the correct type-root
+	// defaults + type-root sidecar (no need to walk fs.stat upwards).
+	const ancestorConfig = await resolveDirectoryConfig(memoryRoot, parentDir);
+	if (ancestorConfig?.readOnly) {
+		throw new KnowledgeOpsError("permission_denied", `target is read-only: ${resolved.absPath}`);
+	}
+	if (ancestorConfig && !ancestorConfig.allowCreateDirectories) {
+		throw new KnowledgeOpsError("permission_denied", `directory create not allowed: ${resolved.absPath}`);
+	}
+	const apply = async (): Promise<void> => {
+		await fs.mkdir(resolved.absPath, { recursive: true });
+	};
+	const preview: KnowledgeApprovalPreview = {
+		kind: "create",
+		path: resolved.canonical,
+		type: resolved.type,
+		entryKind: "directory",
+	};
+	return routeApproval(ancestorConfig?.requiresApproval ?? false, preview, apply, options.approvalSink);
+}
+
+function deriveTitle(rel: string, summary: string | undefined): string {
+	const stem = rel.replace(/\.md$/i, "").split("/").pop() ?? rel;
+	if (summary) return stem;
+	return stem || "Knowledge Document";
+}
+
+function parseMaintenanceRules(value: string | null | undefined): string[] {
+	if (!value) return [];
+	const trimmed = value.trim();
+	if (!trimmed) return [];
+	return trimmed
+		.split(/\r?\n/)
+		.map(line => line.replace(/^\s*[-*]\s+/, "").trim())
+		.filter(Boolean);
+}
+
+function bodyExcerpt(body: string | undefined, limit = 280): string | undefined {
+	if (!body) return undefined;
+	const trimmed = body.trim();
+	if (!trimmed) return undefined;
+	return trimmed.length <= limit ? trimmed : `${trimmed.slice(0, limit - 1)}…`;
+}
+
+// ────────────────────────────────────────────────────────────────────
+// edit
+// ────────────────────────────────────────────────────────────────────
+
+export interface KnowledgeEditPatch {
+	summary?: string | null;
+	body?: string;
+	maintenanceRules?: string | null;
+}
+
+/**
+ * Patch the content sections of an existing knowledge document. Only
+ * provided sections change; omitted sections survive verbatim.
+ *
+ * Requires the doc to carry body markers — marker-less docs are treated
+ * as user-authored and the edit is refused regardless of approval. When
+ * the doc's effective config has `requiresApproval`, the write routes
+ * through `options.approvalSink`.
+ */
+export async function knowledgeEditDocument(
+	memoryRoot: string,
+	pathInput: string,
+	patch: KnowledgeEditPatch,
+	options: KnowledgeOpOptions = {},
+): Promise<KnowledgeOpOutcome> {
+	if (patch.summary === undefined && patch.body === undefined && patch.maintenanceRules === undefined) {
+		throw new KnowledgeOpsError(
+			"invalid_path",
+			`knowledge_edit requires at least one of summary, body, or maintenanceRules: ${pathInput}`,
+		);
+	}
+	const resolved = resolveKnowledgePath(memoryRoot, pathInput, "document");
+	let raw: string;
+	try {
+		raw = await Bun.file(resolved.absPath).text();
+	} catch (error) {
+		if (isEnoent(error)) {
+			throw new KnowledgeOpsError("not_found", `Knowledge document not found: ${pathInput}`);
+		}
+		throw error;
+	}
+	const doc = parseMemoryDoc(raw);
+	if (!doc.hasBodyMarkers) {
+		throw new KnowledgeOpsError(
+			"permission_denied",
+			`Knowledge document is user-authored (no body markers): ${pathInput}`,
+		);
+	}
+	const denied = await checkWritePermission(memoryRoot, resolved.absPath, "update", doc.frontmatter);
+	if (denied) {
+		throw new KnowledgeOpsError("permission_denied", denied);
+	}
+	const docConfig = await resolveDocConfig(memoryRoot, resolved.absPath, doc.frontmatter);
+
+	const nextBody = patch.body !== undefined ? patch.body : doc.body;
+	const nextSummary =
+		patch.summary === undefined ? doc.frontmatter.summary : patch.summary === null ? undefined : patch.summary;
+	const nextRules = patch.maintenanceRules === undefined ? undefined : parseMaintenanceRules(patch.maintenanceRules);
+
+	const onlyBodyChanged =
+		patch.body !== undefined && patch.summary === undefined && patch.maintenanceRules === undefined;
+
+	// Validate the resulting doc shape before writing. The effective rules
+	// are either the patch (when provided), the existing in-doc rules, or
+	// nothing — and we never let the edit transition a valid doc into an
+	// aiMaintained-but-empty-rules state.
+	const effectiveRules = nextRules !== undefined ? nextRules : extractMaintenanceRulesFromDoc(raw);
+	const effectiveExplicitRules =
+		nextRules !== undefined ? nextRules.length > 0 : doc.frontmatter.explicitMaintenanceRules === true;
+	const editDenial = validateMemoryDoc({
+		type: resolved.type,
+		injectMode: docConfig?.injectMode,
+		aiMaintained: docConfig?.aiMaintained === true,
+		explicitMaintenanceRules: effectiveExplicitRules,
+		maintenanceRules: effectiveRules,
+	});
+	if (editDenial) {
+		throw new KnowledgeOpsError("invalid_path", editDenial);
+	}
+
+	const apply = async (): Promise<void> => {
+		const now = unixNow();
+		const nextFrontmatter: MemoryDocFrontmatter = {
+			...doc.frontmatter,
+			summary: nextSummary,
+			summaryEnabled:
+				nextSummary !== undefined && nextSummary !== ""
+					? true
+					: (doc.frontmatter.summaryEnabled ?? defaultSummaryEnabledForType(resolved.type)),
+			explicitMaintenanceRules:
+				nextRules !== undefined ? nextRules.length > 0 : doc.frontmatter.explicitMaintenanceRules,
+			updatedAt: now,
+		};
+		if (!nextFrontmatter.createdAt) nextFrontmatter.createdAt = now;
+
+		if (onlyBodyChanged) {
+			const rewritten = rewriteDocBody(doc, nextBody.trim());
+			if (rewritten === undefined) {
+				throw new KnowledgeOpsError("io_error", "rewriteDocBody refused — body markers missing");
+			}
+			await Bun.write(resolved.absPath, rewritten);
+			return;
+		}
+
+		const summaryString = typeof nextSummary === "string" ? nextSummary : undefined;
+		const titleString =
+			typeof nextFrontmatter.title === "string"
+				? nextFrontmatter.title
+				: deriveTitle(resolved.relFromTypeRoot, summaryString);
+		const rebuilt = buildMemoryDoc({
+			frontmatter: nextFrontmatter,
+			title: titleString,
+			summary: summaryString,
+			maintenanceRules: nextRules ?? extractMaintenanceRulesFromDoc(raw),
+			body: nextBody.trim(),
+		});
+		await Bun.write(resolved.absPath, rebuilt);
+	};
+
+	const preview: KnowledgeApprovalPreview = {
+		kind: "edit",
+		path: resolved.canonical,
+		type: resolved.type,
+		entryKind: "document",
+		title: typeof doc.frontmatter.title === "string" ? doc.frontmatter.title : undefined,
+		summary: typeof nextSummary === "string" ? nextSummary : undefined,
+		bodyPreview: bodyExcerpt(patch.body),
+	};
+	return routeApproval(docConfig?.requiresApproval ?? false, preview, apply, options.approvalSink);
+}
+
+function extractMaintenanceRulesFromDoc(raw: string): string[] {
+	const match = raw.match(/<!--\s*omp:maintain-rules:start\s*-->([\s\S]*?)<!--\s*omp:maintain-rules:end\s*-->/);
+	if (!match) return [];
+	return parseMaintenanceRules(match[1]);
+}
+
+// ────────────────────────────────────────────────────────────────────
+// move
+// ────────────────────────────────────────────────────────────────────
+
+/**
+ * Rename a knowledge document or directory. Source and destination must
+ * be the same kind AND the same top-level type. Cross-type moves are
+ * refused — a document never silently changes meaning. When the source
+ * is under a `requiresApproval` directory, the move routes through
+ * `options.approvalSink`.
+ */
+export async function knowledgeMove(
+	memoryRoot: string,
+	pathInput: string,
+	newPathInput: string,
+	kind: "document" | "directory",
+	options: KnowledgeOpOptions = {},
+): Promise<KnowledgeOpOutcome> {
+	const source = resolveKnowledgePath(memoryRoot, pathInput, kind);
+	const dest = resolveKnowledgePath(memoryRoot, newPathInput, kind);
+	if (source.type !== dest.type) {
+		throw new KnowledgeOpsError(
+			"type_change",
+			`Cross-type move refused: ${pathInput} (${source.type}) → ${newPathInput} (${dest.type})`,
+		);
+	}
+	if (kind === "directory" && (source.relFromTypeRoot === "" || dest.relFromTypeRoot === "")) {
+		// Renaming a bucket root (`memory`, `skill`, `design`, `reference`)
+		// would relocate the entire taxonomy and break every subsequent
+		// path lookup. Refuse symmetrically with `knowledgeDelete` and
+		// `knowledgeCreateDirectory`, both of which reserve the type roots.
+		throw new KnowledgeOpsError(
+			"invalid_path",
+			`Refusing to move taxonomy root directory: ${pathInput} → ${newPathInput}. Type roots are reserved.`,
+		);
+	}
+	if (source.absPath === dest.absPath) {
+		return { applied: false, requiredApproval: false };
+	}
+
+	const stat = await fs.stat(source.absPath).catch(() => undefined);
+	if (!stat) {
+		throw new KnowledgeOpsError("not_found", `Knowledge ${kind} not found: ${pathInput}`);
+	}
+	if (kind === "document" && !stat.isFile()) {
+		throw new KnowledgeOpsError("kind_mismatch", `Expected a document, found a directory: ${pathInput}`);
+	}
+	if (kind === "directory" && !stat.isDirectory()) {
+		throw new KnowledgeOpsError("kind_mismatch", `Expected a directory, found a file: ${pathInput}`);
+	}
+
+	const destStat = await fs.stat(dest.absPath).catch(() => undefined);
+	if (destStat) {
+		throw new KnowledgeOpsError("already_exists", `Knowledge ${kind} already exists at destination: ${newPathInput}`);
+	}
+
+	// Source-side: who is allowed to mutate the thing being moved?
+	let requiresApproval = false;
+	let sourceFrontmatter: MemoryDocFrontmatter = {};
+	if (kind === "document") {
+		try {
+			sourceFrontmatter = parseMemoryDoc(await Bun.file(source.absPath).text()).frontmatter;
+		} catch {
+			// best-effort frontmatter read — fall through with empty fm
+		}
+		const denied = await checkWritePermission(memoryRoot, source.absPath, "update", sourceFrontmatter);
+		if (denied) throw new KnowledgeOpsError("permission_denied", denied);
+		const sourceParentConfig = await resolveDirectoryConfig(memoryRoot, path.dirname(source.absPath));
+		if (sourceParentConfig && !sourceParentConfig.allowMoveDocuments) {
+			throw new KnowledgeOpsError("permission_denied", `document move not allowed: ${pathInput}`);
+		}
+		const sourceConfig = await resolveDocConfig(memoryRoot, source.absPath, sourceFrontmatter);
+		requiresApproval = sourceConfig?.requiresApproval ?? false;
+	} else {
+		const config = await resolveDirectoryConfig(memoryRoot, source.absPath);
+		if (config && !config.allowMoveDirectories) {
+			throw new KnowledgeOpsError("permission_denied", `directory move not allowed: ${pathInput}`);
+		}
+		if (config?.readOnly) {
+			throw new KnowledgeOpsError("permission_denied", `target is read-only: ${pathInput}`);
+		}
+		// Refuse if any descendant doc carries `readOnly: true` — a moved
+		// directory must not silently drag user-locked content along.
+		const lockedDescendant = await findReadOnlyDescendant(source.absPath);
+		if (lockedDescendant) {
+			throw new KnowledgeOpsError(
+				"permission_denied",
+				`directory contains read-only document: ${lockedDescendant.rel}`,
+			);
+		}
+		requiresApproval = config?.requiresApproval ?? false;
+	}
+
+	// Destination-side: does the target tree accept this thing?
+	const destParentDir = path.dirname(dest.absPath);
+	const destParentExists = await fileExists(destParentDir);
+	const destAncestor = await resolveDirectoryConfig(memoryRoot, destParentDir);
+	if (destAncestor?.readOnly) {
+		throw new KnowledgeOpsError("permission_denied", `destination is read-only: ${newPathInput}`);
+	}
+	if (kind === "document" && destAncestor && !destAncestor.allowCreateDocuments) {
+		throw new KnowledgeOpsError("permission_denied", `destination denies new docs: ${destParentDir}`);
+	}
+	// Directory moves materialize a new child entry under `destParentDir`,
+	// even when the parent itself already exists. Honour
+	// `allowCreateDirectories: false` symmetrically with the document branch
+	// above so a `.omp-meta` lock on the destination tree cannot be
+	// laundered around via a move into an existing parent.
+	if ((kind === "directory" || !destParentExists) && destAncestor && !destAncestor.allowCreateDirectories) {
+		throw new KnowledgeOpsError("permission_denied", `destination denies new directories: ${destParentDir}`);
+	}
+	// If the destination's effective config also requires approval, escalate.
+	if (destAncestor?.requiresApproval) requiresApproval = true;
+
+	const apply = async (): Promise<void> => {
+		await fs.mkdir(destParentDir, { recursive: true });
+		if (kind === "directory") {
+			// Move the directory and its paired sidecar together so policy
+			// follows the rename and stale sidecars never orphan.
+			await renameDirectoryWithSidecar(source.absPath, dest.absPath);
+		} else {
+			await fs.rename(source.absPath, dest.absPath);
+		}
+	};
+	const preview: KnowledgeApprovalPreview = {
+		kind: "move",
+		path: source.canonical,
+		destPath: dest.canonical,
+		type: source.type,
+		entryKind: kind,
+	};
+	return routeApproval(requiresApproval, preview, apply, options.approvalSink);
+}
+
+// ────────────────────────────────────────────────────────────────────
+// delete
+// ────────────────────────────────────────────────────────────────────
+
+/**
+ * Delete a knowledge document or directory. `readOnly` is the hard
+ * refusal; `aiMaintained: false` routes through `options.approvalSink`.
+ */
+export async function knowledgeDelete(
+	memoryRoot: string,
+	pathInput: string,
+	kind: "document" | "directory",
+	options: KnowledgeOpOptions = {},
+): Promise<KnowledgeOpOutcome> {
+	const resolved = resolveKnowledgePath(memoryRoot, pathInput, kind);
+	if (kind === "directory" && resolved.relFromTypeRoot === "") {
+		throw new KnowledgeOpsError(
+			"permission_denied",
+			`Refusing to delete taxonomy root directory: ${pathInput}. Type roots are reserved.`,
+		);
+	}
+	const stat = await fs.stat(resolved.absPath).catch(() => undefined);
+	if (!stat) {
+		throw new KnowledgeOpsError("not_found", `Knowledge ${kind} not found: ${pathInput}`);
+	}
+	if (kind === "document" && !stat.isFile()) {
+		throw new KnowledgeOpsError("kind_mismatch", `Expected a document, found a directory: ${pathInput}`);
+	}
+	if (kind === "directory" && !stat.isDirectory()) {
+		throw new KnowledgeOpsError("kind_mismatch", `Expected a directory, found a file: ${pathInput}`);
+	}
+	let frontmatter: MemoryDocFrontmatter = {};
+	if (kind === "document") {
+		try {
+			frontmatter = parseMemoryDoc(await Bun.file(resolved.absPath).text()).frontmatter;
+		} catch {
+			// missing or unparseable — fall through with empty frontmatter
+		}
+	}
+	const denied = await checkDeletePermission(memoryRoot, resolved.absPath, frontmatter);
+	if (denied) {
+		throw new KnowledgeOpsError("permission_denied", denied);
+	}
+	let config: EffectiveDirectoryConfig | undefined;
+	if (kind === "document") {
+		config = await resolveDocConfig(memoryRoot, resolved.absPath, frontmatter);
+	} else {
+		config = await resolveDirectoryConfig(memoryRoot, resolved.absPath);
+	}
+	if (kind === "directory") {
+		// Refuse if any descendant doc carries `readOnly: true` — a recursive
+		// delete must not silently remove user-locked content.
+		const lockedDescendant = await findReadOnlyDescendant(resolved.absPath);
+		if (lockedDescendant) {
+			throw new KnowledgeOpsError(
+				"permission_denied",
+				`directory contains read-only document: ${lockedDescendant.rel}`,
+			);
+		}
+	}
+	const apply = async (): Promise<void> => {
+		if (kind === "document") {
+			await fs.rm(resolved.absPath, { force: true });
+			return;
+		}
+		await fs.rm(resolved.absPath, { recursive: true, force: true });
+		// Remove the paired sidecar too so a future same-named directory
+		// does not silently inherit stale policy.
+		await fs.rm(sidecarPathForDirectory(resolved.absPath), { force: true });
+	};
+	const preview: KnowledgeApprovalPreview = {
+		kind: "delete",
+		path: resolved.canonical,
+		type: resolved.type,
+		entryKind: kind,
+		title: typeof frontmatter.title === "string" ? frontmatter.title : undefined,
+	};
+	return routeApproval(config?.requiresApproval ?? false, preview, apply, options.approvalSink);
+}
+
+// ────────────────────────────────────────────────────────────────────
+// helpers
+// ────────────────────────────────────────────────────────────────────
+
+async function fileExists(absPath: string): Promise<boolean> {
+	const stat = await fs.stat(absPath).catch(() => undefined);
+	return stat !== undefined;
+}
+
+function unixNow(): number {
+	return Math.floor(Date.now() / 1000);
+}
+
+/**
+ * Enumerate every `.md` document under `dirAbsPath` and return the first
+ * whose frontmatter has `readOnly: true`. Used by directory move/delete to
+ * refuse mutations that would silently affect user-locked descendants.
+ */
+async function findReadOnlyDescendant(dirAbsPath: string): Promise<{ absPath: string; rel: string } | undefined> {
+	const stack: string[] = [dirAbsPath];
+	while (stack.length > 0) {
+		const current = stack.pop() as string;
+		const entries = await fs.readdir(current, { withFileTypes: true }).catch(error => {
+			if (isEnoent(error)) return [];
+			throw error;
+		});
+		for (const entry of entries) {
+			if (entry.name.endsWith(".omp-meta")) continue;
+			const full = path.join(current, entry.name);
+			if (entry.isDirectory()) {
+				stack.push(full);
+				continue;
+			}
+			if (!(entry.isFile() && entry.name.toLowerCase().endsWith(".md"))) continue;
+			let raw: string;
+			try {
+				raw = await Bun.file(full).text();
+			} catch (error) {
+				if (isEnoent(error)) continue;
+				throw error;
+			}
+			const fm = parseMemoryDoc(raw).frontmatter;
+			if (fm.readOnly === true) {
+				return { absPath: full, rel: path.relative(dirAbsPath, full).split(path.sep).join("/") };
+			}
+		}
+	}
+	return undefined;
+}
+// ────────────────────────────────────────────────────────────────────
+// commandEnabled slash-command surface
+// ────────────────────────────────────────────────────────────────────
+
+/**
+ * A knowledge doc that opted in to the `/knowledge:<slug>` slash-command
+ * surface via frontmatter `commandEnabled: true`. Mirrors the shape the
+ * skill-command flow consumes so both surfaces can share renderers.
+ */
+export interface KnowledgeCommandEntry {
+	/** Type-prefixed path without the `.md` suffix (e.g. `memory/api-style`). */
+	slug: string;
+	/** Absolute path to the on-disk doc. */
+	absPath: string;
+	/** Top-level type bucket. */
+	type: MemoryDocType;
+	/** Relative path from the type root (e.g. `api-style.md`). */
+	path: string;
+	/** Frontmatter `title`, falling back to the slug. */
+	title: string;
+	/** Short label used as the slash-command description. */
+	description: string;
+}
+
+/**
+ * Slash-command name for a knowledge entry (`knowledge:<slug>`). Pair with
+ * a leading `/` at the dispatch site to compose the command string.
+ */
+export function getKnowledgeSlashCommandName(entry: Pick<KnowledgeCommandEntry, "slug">): string {
+	return `knowledge:${entry.slug}`;
+}
+
+/**
+ * Walk the four type roots and collect every doc whose frontmatter sets
+ * `commandEnabled: true`. Sorted by slug for deterministic ordering.
+ *
+ * Files that fail to read/parse are skipped silently — a malformed doc
+ * MUST NOT take down the whole slash-command surface.
+ */
+export async function listCommandEnabledDocs(memoryRoot: string): Promise<KnowledgeCommandEntry[]> {
+	const listEntries: KnowledgeListEntry[] = [];
+	for (const type of KNOWN_TYPES) {
+		const typeRoot = path.join(memoryRoot, TYPE_DIRS[type]);
+		await walkInto(typeRoot, typeRoot, type, listEntries);
+	}
+	const out: KnowledgeCommandEntry[] = [];
+	for (const entry of listEntries) {
+		if (entry.kind !== "document") continue;
+		const typePrefix = TYPE_DIRS[entry.type];
+		// `entry.path` is canonical (`<type>/<relFromTypeRoot>`). Strip the
+		// prefix to recover the type-root-relative path, then strip `.md` to
+		// produce the slug.
+		const relFromTypeRoot = entry.path.startsWith(`${typePrefix}/`)
+			? entry.path.slice(typePrefix.length + 1)
+			: entry.path;
+		const absPath = path.join(memoryRoot, typePrefix, ...relFromTypeRoot.split("/"));
+		let raw: string;
+		try {
+			raw = await fs.readFile(absPath, "utf8");
+		} catch {
+			continue;
+		}
+		const parsed = parseMemoryDoc(raw);
+		if (parsed.frontmatter.commandEnabled !== true) continue;
+		const slug = `${typePrefix}/${relFromTypeRoot.replace(/\.md$/i, "")}`;
+		const title =
+			typeof parsed.frontmatter.title === "string" && parsed.frontmatter.title.trim()
+				? parsed.frontmatter.title.trim()
+				: slug;
+		out.push({
+			slug,
+			absPath,
+			type: entry.type,
+			path: relFromTypeRoot,
+			title,
+			description: title,
+		});
+	}
+	out.sort((a, b) => a.slug.localeCompare(b.slug));
+	return out;
+}
+
+/** Result of {@link buildKnowledgePromptMessage}. */
+export interface BuiltKnowledgePromptMessage {
+	message: string;
+	details: {
+		name: string;
+		path: string;
+		slug: string;
+		args?: string;
+		lineCount: number;
+	};
+}
+
+/**
+ * Build the prompt message that `/knowledge:<slug>` dispatches as a
+ * CustomMessage. Mirrors `buildSkillPromptMessage`: the body region is
+ * extracted via `parseMemoryDoc` when body markers are present, otherwise
+ * we fall back to frontmatter-stripped content (same regex the skill flow
+ * uses). Trailing meta lines disambiguate Knowledge from Skill in the
+ * agent's view.
+ */
+export async function buildKnowledgePromptMessage(
+	entry: KnowledgeCommandEntry,
+	args: string,
+): Promise<BuiltKnowledgePromptMessage> {
+	const content = await Bun.file(entry.absPath).text();
+	const parsed = parseMemoryDoc(content);
+	const body = parsed.hasBodyMarkers ? parsed.body.trim() : content.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
+	const metaLines = [`Knowledge: ${entry.type}/${entry.path}`];
+	const trimmedArgs = args.trim();
+	if (trimmedArgs) {
+		metaLines.push(`User: ${trimmedArgs}`);
+	}
+	const message = `${body}\n\n---\n\n${metaLines.join("\n")}`;
+	return {
+		message,
+		details: {
+			name: entry.title,
+			path: entry.absPath,
+			slug: entry.slug,
+			args: trimmedArgs || undefined,
+			lineCount: body ? body.split("\n").length : 0,
+		},
+	};
+}

--- a/packages/coding-agent/src/memories/seed-docs.ts
+++ b/packages/coding-agent/src/memories/seed-docs.ts
@@ -1,0 +1,224 @@
+/**
+ * Built-in seed docs and directory seeds.
+ *
+ * On first session (or whenever `MEMORY_BUILTIN_SEED_VERSION` bumps), seeds
+ * are materialized under `memory_root/memory/`:
+ *
+ *   - **Doc seeds** create a markdown file with frontmatter + body markers.
+ *     On a version bump, the frontmatter, summary, and maintenance rules
+ *     are refreshed in-place while the body bytes between markers survive.
+ *   - **Directory seeds** create an empty directory plus an `.omp-meta`
+ *     sidecar carrying inject mode, summary, and maintenance rules. The
+ *     directory's children are written by the AI as it explores.
+ *
+ * In both cases, user customization is preserved:
+ *   - A doc with stripped body markers is treated as user-owned (no touch).
+ *   - A sidecar with `explicitMaintenanceRules: true` keeps its
+ *     user-customized rules across refreshes.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { isEnoent, logger } from "@oh-my-pi/pi-utils";
+import { type DirectoryConfigFile, readSidecar, sidecarPathForDirectory, stringifySidecar } from "./directory-config";
+import {
+	buildMemoryDoc,
+	deriveDocId,
+	type InjectMode,
+	MEMORY_BUILTIN_SEED_VERSION,
+	type MemoryDocFrontmatter,
+	parseMemoryDoc,
+} from "./document";
+
+/** Common fields shared by every seed kind. */
+interface BuiltinSeedCommon {
+	/** Slug relative to `memory/` (filename for docs, dirname for directories). */
+	name: string;
+	title: string;
+	summary: string;
+	injectMode: InjectMode;
+	maintenanceRules: readonly string[];
+}
+
+interface BuiltinDocSeed extends BuiltinSeedCommon {
+	kind: "doc";
+	initialBody: string;
+}
+
+interface BuiltinDirectorySeed extends BuiltinSeedCommon {
+	kind: "directory";
+}
+
+type BuiltinSeedSpec = BuiltinDocSeed | BuiltinDirectorySeed;
+
+/**
+ * The embedded seed catalog. Edit a spec → bump
+ * `MEMORY_BUILTIN_SEED_VERSION` in `document.ts` so existing seeds refresh.
+ */
+const SEEDS: readonly BuiltinSeedSpec[] = [
+	{
+		kind: "doc",
+		name: "user-preference.md",
+		title: "User Preferences",
+		summary: "Durable, user-stated preferences the agent must respect across sessions.",
+		injectMode: "rule",
+		maintenanceRules: [
+			"Capture only explicit user-stated preferences, not inferred defaults.",
+			"Phrase each entry as an imperative rule the agent will follow.",
+			"Drop any rule the user contradicts; replace, do not append.",
+			"Keep rules orthogonal — split compound preferences into separate lines.",
+		],
+		initialBody:
+			"<!-- No preferences captured yet. The consolidator fills this section as the user states preferences. -->",
+	},
+	{
+		kind: "doc",
+		name: "project-mistake-note.md",
+		title: "Project Mistake Notes",
+		summary: "Patterns of failure observed in this project and the resolutions that fixed them.",
+		injectMode: "full",
+		maintenanceRules: [
+			"Record each mistake as `Symptom → Root cause → Fix` so the next run can pattern-match.",
+			"Prefer resolved failures with verified fixes; drop entries that turned out to be no-ops.",
+			"Cite the file path or callsite involved when relevant.",
+			"Consolidate near-duplicate entries; do not let the list grow unbounded.",
+		],
+		initialBody: "<!-- No mistake notes captured yet. The consolidator records resolved failures here. -->",
+	},
+	{
+		kind: "directory",
+		name: "project-understanding",
+		title: "Project Understanding",
+		summary:
+			"Cached, AI-maintained understanding of the project layout: directory roles, module boundaries, ownership notes, and structural shortcuts learned during exploration.",
+		// path-mode keeps the index light: only the directory + child titles
+		// surface in injection, never their bodies.
+		injectMode: "path",
+		maintenanceRules: [
+			"Capture durable structural facts: directory roles, module boundaries, ownership.",
+			"One topic per file; nest sub-areas as child directories.",
+			"Drop entries the codebase contradicts. Current code wins; never let the cache drift.",
+			"Prefer concise paragraphs over exhaustive listings — link to the code paths that prove the claim.",
+		],
+	},
+];
+
+/**
+ * Ensure every built-in seed exists under `memory_root/memory/`.
+ *
+ * Doc seeds:
+ *   - Missing file → create with frontmatter + body markers.
+ *   - Existing file with older `seedVersion` → refresh non-body regions.
+ *   - Existing file with stripped body markers → leave alone (user-owned).
+ *
+ * Directory seeds:
+ *   - Missing dir → create dir + `.omp-meta` sidecar with the seed payload.
+ *   - Existing dir without sidecar → write the sidecar.
+ *   - Existing sidecar with older `seedVersion` → refresh, but never
+ *     overwrite a sidecar carrying `explicitMaintenanceRules: true`
+ *     (treat the user's edits as ownership).
+ */
+export async function seedBuiltinDocs(memoryRoot: string): Promise<void> {
+	const memoryDir = path.join(memoryRoot, "memory");
+	await fs.mkdir(memoryDir, { recursive: true });
+
+	for (const seed of SEEDS) {
+		if (seed.kind === "doc") {
+			await seedDoc(memoryDir, seed);
+		} else {
+			await seedDirectory(memoryDir, seed);
+		}
+	}
+}
+
+async function seedDoc(memoryDir: string, seed: BuiltinDocSeed): Promise<void> {
+	const absPath = path.join(memoryDir, seed.name);
+	const relative = path.posix.join("memory", seed.name);
+
+	let existing: string | undefined;
+	try {
+		existing = await Bun.file(absPath).text();
+	} catch (error) {
+		if (!isEnoent(error)) {
+			logger.warn("Failed to read built-in seed doc", { path: absPath, error: String(error) });
+			return;
+		}
+	}
+
+	if (existing === undefined) {
+		const content = buildMemoryDoc({
+			frontmatter: buildSeedFrontmatter(seed, relative),
+			title: seed.title,
+			summary: seed.summary,
+			maintenanceRules: seed.maintenanceRules,
+			body: seed.initialBody,
+		});
+		await Bun.write(absPath, content);
+		return;
+	}
+
+	const doc = parseMemoryDoc(existing);
+	const recordedVersion = typeof doc.frontmatter.seedVersion === "number" ? doc.frontmatter.seedVersion : 0;
+	if (recordedVersion >= MEMORY_BUILTIN_SEED_VERSION) return;
+	if (!doc.hasBodyMarkers) return; // user stripped markers — they own it now
+
+	const refreshed = buildMemoryDoc({
+		frontmatter: buildSeedFrontmatter(seed, relative, doc.frontmatter),
+		title: seed.title,
+		summary: seed.summary,
+		maintenanceRules: seed.maintenanceRules,
+		body: doc.body.trim(),
+	});
+	await Bun.write(absPath, refreshed);
+}
+
+async function seedDirectory(memoryDir: string, seed: BuiltinDirectorySeed): Promise<void> {
+	const dir = path.join(memoryDir, seed.name);
+	const sidecarPath = sidecarPathForDirectory(dir);
+	await fs.mkdir(dir, { recursive: true });
+
+	const existing = await readSidecar(sidecarPath);
+	const recordedVersion = typeof existing?.seedVersion === "number" ? existing.seedVersion : 0;
+	if (existing && recordedVersion >= MEMORY_BUILTIN_SEED_VERSION) return;
+	// Preserve user-customized rules; only refresh the descriptive fields.
+	const preserveRules = existing?.explicitMaintenanceRules === true;
+	const sidecar: DirectoryConfigFile = {
+		...(existing ?? {}),
+		version: 1,
+		summary: seed.summary,
+		injectMode: seed.injectMode,
+		inheritToChildren: true,
+		aiMaintained: existing?.aiMaintained ?? true,
+		seedVersion: MEMORY_BUILTIN_SEED_VERSION,
+		maintenanceRules: preserveRules
+			? existing?.maintenanceRules
+			: seed.maintenanceRules.map(rule => `- ${rule}`).join("\n"),
+		explicitMaintenanceRules: preserveRules,
+	};
+	await Bun.write(sidecarPath, stringifySidecar(sidecar));
+}
+
+function buildSeedFrontmatter(
+	seed: BuiltinDocSeed,
+	relative: string,
+	existing?: MemoryDocFrontmatter,
+): MemoryDocFrontmatter {
+	const now = Math.floor(Date.now() / 1000);
+	const createdAt = typeof existing?.createdAt === "number" ? existing.createdAt : now;
+	return {
+		id: deriveDocId(relative),
+		type: "memory",
+		path: relative,
+		title: seed.title,
+		injectMode: seed.injectMode,
+		inheritInjectMode: false,
+		inheritAiConfig: false,
+		summaryEnabled: true,
+		aiMaintained: true,
+		readOnly: false,
+		explicitMaintenanceRules: true,
+		seedVersion: MEMORY_BUILTIN_SEED_VERSION,
+		createdAt,
+		updatedAt: now,
+	};
+}

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -54,6 +54,8 @@ import { buildSkillPromptMessage, getSkillSlashCommandName } from "../../extensi
 import { loadSlashCommands } from "../../extensibility/slash-commands";
 import { MCPManager } from "../../mcp/manager";
 import type { MCPServerConfig } from "../../mcp/types";
+import { getMemoryRoot } from "../../memories";
+import { buildKnowledgePromptMessage, listCommandEnabledDocs } from "../../memories/knowledge-ops";
 import { loadAllExtensions } from "../../modes/components/extensions/state-manager";
 import { theme } from "../../modes/theme/theme";
 import type { AgentSession, AgentSessionEvent } from "../../session/agent-session";
@@ -645,6 +647,10 @@ export class AcpAgent implements Agent {
 		if (skillResult) {
 			return;
 		}
+		const knowledgeResult = await this.#tryRunKnowledgeCommand(record, text);
+		if (knowledgeResult) {
+			return;
+		}
 
 		const builtinResult = await executeAcpBuiltinSlashCommand(text, {
 			session: record.session,
@@ -710,6 +716,56 @@ export class AcpAgent implements Agent {
 			content: built.message,
 			display: true,
 			details: built.details,
+			attribution: "user",
+		});
+		return true;
+	}
+
+	/**
+	 * Dispatch `/knowledge:<slug> [args]` against the doc set marked
+	 * `commandEnabled: true` in frontmatter. Per-call disk walk is fine
+	 * here — knowledge slash invocations are rare and the alternative
+	 * (per-record cache invalidated on every `knowledge_create`) would
+	 * cost more code than it saves.
+	 */
+	async #tryRunKnowledgeCommand(record: ManagedSessionRecord, text: string): Promise<boolean> {
+		if (!text.startsWith("/knowledge:")) {
+			return false;
+		}
+		if (record.session.settings.get("knowledge.enabled") === false) {
+			return false;
+		}
+		const spaceIndex = text.indexOf(" ");
+		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
+		const slug = commandName.slice("knowledge:".length);
+		if (!slug) {
+			return false;
+		}
+		const sm = record.session.sessionManager;
+		const memoryRoot = getMemoryRoot(record.session.settings.getAgentDir(), sm.getCwd());
+		let entries: Awaited<ReturnType<typeof listCommandEnabledDocs>>;
+		try {
+			entries = await listCommandEnabledDocs(memoryRoot);
+		} catch (error) {
+			logger.warn("Failed to list knowledge slash commands", { error: String(error) });
+			return false;
+		}
+		const entry = entries.find(candidate => candidate.slug === slug);
+		if (!entry) {
+			return false;
+		}
+		const built = await buildKnowledgePromptMessage(entry, args);
+		await record.session.promptCustomMessage({
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: built.message,
+			display: true,
+			details: {
+				name: built.details.name,
+				path: built.details.path,
+				args: built.details.args,
+				lineCount: built.details.lineCount,
+			},
 			attribution: "user",
 		});
 		return true;
@@ -1411,6 +1467,22 @@ export class AcpAgent implements Agent {
 					description: skill.description || `Run ${skill.name} skill`,
 					input: { hint: "arguments" },
 				});
+			}
+		}
+
+		if (session.settings.get("knowledge.enabled") !== false) {
+			try {
+				const memoryRoot = getMemoryRoot(session.settings.getAgentDir(), session.sessionManager.getCwd());
+				const knowledgeEntries = await listCommandEnabledDocs(memoryRoot);
+				for (const entry of knowledgeEntries) {
+					appendCommand({
+						name: `knowledge:${entry.slug}`,
+						description: entry.description || entry.title,
+						input: { hint: "arguments" },
+					});
+				}
+			} catch (error) {
+				logger.warn("Failed to load knowledge slash commands for ACP", { error: String(error) });
 			}
 		}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -3,6 +3,7 @@ import { type AgentMessage, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import type { AutocompleteProvider, SlashCommand } from "@oh-my-pi/pi-tui";
 import { $env, sanitizeText } from "@oh-my-pi/pi-utils";
 import { isSettingsInitialized, settings } from "../../config/settings";
+import { buildKnowledgePromptMessage } from "../../memories/knowledge-ops";
 import { expandEmoticons } from "../../modes/emoji-autocomplete";
 import { createPromptActionAutocompleteProvider } from "../../modes/prompt-action-autocomplete";
 import { theme } from "../../modes/theme/theme";
@@ -249,6 +250,13 @@ export class InputController {
 				return;
 			}
 
+			// Handle knowledge slash commands (/knowledge:<slug> [args]). Same
+			// dispatch semantics as /skill:; falls through to plain text if the
+			// command name is not in the snapshot.
+			if (await this.#invokeKnowledgeCommand(text, "steer")) {
+				return;
+			}
+
 			// Handle bash command (! for normal, !! for excluded from context)
 			if (text.startsWith("!")) {
 				const isExcluded = text.startsWith("!!");
@@ -473,6 +481,59 @@ export class InputController {
 		return true;
 	}
 
+	/**
+	 * Dispatch a `/knowledge:<slug> [args]` invocation. Mirrors
+	 * `#invokeSkillCommand` but resolves through the session's
+	 * `knowledgeCommands` map (populated at session init from
+	 * `listCommandEnabledDocs`). The dispatched CustomMessage reuses
+	 * `SKILL_PROMPT_MESSAGE_TYPE` because the rendering surface is
+	 * identical: a slash-command-injected doc body with a meta footer
+	 * (`Knowledge: <type>/<path>` instead of `Skill: <path>`). Returns
+	 * true when the text was a registered knowledge command and was
+	 * dispatched; false otherwise so the caller can fall through to
+	 * plain-text handling.
+	 */
+	async #invokeKnowledgeCommand(text: string, streamingBehavior: "steer" | "followUp"): Promise<boolean> {
+		if (!text.startsWith("/knowledge:")) return false;
+		const spaceIndex = text.indexOf(" ");
+		const commandName = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
+		const entry = this.ctx.knowledgeCommands?.get(commandName);
+		if (!entry) return false;
+		this.ctx.editor.addToHistory(text);
+		this.ctx.editor.setText("");
+		try {
+			const built = await buildKnowledgePromptMessage(entry, args);
+			const details: SkillPromptDetails = {
+				name: built.details.name,
+				path: built.details.path,
+				args: built.details.args,
+				lineCount: built.details.lineCount,
+			};
+			if (this.ctx.session.isStreaming) {
+				const tag = this.ctx.session.enqueueCustomMessageDisplay(text, streamingBehavior);
+				details.__pendingDisplayTag = tag;
+			}
+			await this.ctx.session.promptCustomMessage(
+				{
+					customType: SKILL_PROMPT_MESSAGE_TYPE,
+					content: built.message,
+					display: true,
+					details,
+					attribution: "user",
+				},
+				{ streamingBehavior },
+			);
+			if (this.ctx.session.isStreaming) {
+				this.ctx.updatePendingMessagesDisplay();
+				this.ctx.ui.requestRender();
+			}
+		} catch (err) {
+			this.ctx.showError(`Failed to load knowledge doc: ${err instanceof Error ? err.message : String(err)}`);
+		}
+		return true;
+	}
+
 	/** Send editor text as a follow-up message (queued behind current stream). */
 	async handleFollowUp(): Promise<void> {
 		const text = this.ctx.editor.getText().trim();
@@ -493,6 +554,9 @@ export class InputController {
 		// which keybinding submitted them. Enter routes them as `steer`;
 		// Ctrl+Enter (this handler) routes them as `followUp`.
 		if (await this.#invokeSkillCommand(text, "followUp")) {
+			return;
+		}
+		if (await this.#invokeKnowledgeCommand(text, "followUp")) {
 			return;
 		}
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -41,6 +41,8 @@ import { BUILTIN_SLASH_COMMANDS, loadSlashCommands } from "../extensibility/slas
 import type { Goal, GoalModeState } from "../goals/state";
 import { resolveLocalUrlToPath } from "../internal-urls";
 import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "../lsp/startup-events";
+import { getMemoryRoot } from "../memories";
+import { type KnowledgeCommandEntry, listCommandEnabledDocs } from "../memories/knowledge-ops";
 import {
 	humanizePlanTitle,
 	type PlanApprovalDetails,
@@ -280,6 +282,8 @@ export class InteractiveMode implements InteractiveModeContext {
 	lastStatusText: Text | undefined = undefined;
 	fileSlashCommands: Set<string> = new Set();
 	skillCommands: Map<string, string> = new Map();
+	knowledgeCommands: Map<string, KnowledgeCommandEntry> = new Map();
+	#skillsChangedUnsubscribe?: () => void;
 	oauthManualInput: OAuthManualInputManager = new OAuthManualInputManager();
 
 	#pendingSlashCommands: SlashCommand[] = [];
@@ -400,14 +404,23 @@ export class InteractiveMode implements InteractiveModeContext {
 			description: `${loaded.command.description} (${loaded.source})`,
 		}));
 
-		// Build skill commands from session.skills (if enabled)
+		// Build skill commands from session.skills (if enabled). Subscribed
+		// to `onSkillsChanged` so `skill_reload` rewires `/skill:<name>`
+		// dispatch in-place instead of waiting for a session restart.
 		const skillCommandList: SlashCommand[] = [];
-		if (settings.get("skills.enableSkillCommands")) {
+		const skillCommandsEnabled = settings.get("skills.enableSkillCommands");
+		if (skillCommandsEnabled) {
 			for (const skill of this.session.skills) {
 				const commandName = `skill:${skill.name}`;
 				this.skillCommands.set(commandName, skill.filePath);
 				skillCommandList.push({ name: commandName, description: skill.description });
 			}
+			this.#skillsChangedUnsubscribe = this.session.onSkillsChanged(skills => {
+				this.skillCommands.clear();
+				for (const skill of skills) {
+					this.skillCommands.set(`skill:${skill.name}`, skill.filePath);
+				}
+			});
 		}
 
 		// Store pending commands for init() where file commands are loaded async
@@ -439,6 +452,23 @@ export class InteractiveMode implements InteractiveModeContext {
 		// guarantees the decision persists even when the prompt is triggered
 		// from a subagent whose own `Settings` is an in-memory snapshot.
 		setAutoQaConsentHandler(() => this.#promptAutoQaConsent(), Settings.instance);
+
+		// Snapshot the `commandEnabled: true` knowledge docs so
+		// `/knowledge:<slug>` dispatch works for the rest of this session.
+		// New docs created later with `knowledge_create commandEnabled: true`
+		// only become dispatchable after the next session start, mirroring
+		// the existing `<skills>` block snapshot contract.
+		if (settings.get("knowledge.enabled") !== false) {
+			try {
+				const memoryRoot = getMemoryRoot(this.settings.getAgentDir(), this.session.sessionManager.getCwd());
+				const entries = await listCommandEnabledDocs(memoryRoot);
+				for (const entry of entries) {
+					this.knowledgeCommands.set(`knowledge:${entry.slug}`, entry);
+				}
+			} catch (error) {
+				logger.warn("Failed to load knowledge slash commands", { error: String(error) });
+			}
+		}
 
 		await logger.time(
 			"InteractiveMode.init:slashCommands",
@@ -2050,6 +2080,10 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 		if (this.#cleanupUnsubscribe) {
 			this.#cleanupUnsubscribe();
+		}
+		if (this.#skillsChangedUnsubscribe) {
+			this.#skillsChangedUnsubscribe();
+			this.#skillsChangedUnsubscribe = undefined;
 		}
 		// Clear the process-global consent handler so it doesn't outlive this
 		// InteractiveMode instance (e.g. test harnesses, headless re-init).

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -12,6 +12,7 @@ import type {
 } from "../extensibility/extensions";
 import type { CompactOptions } from "../extensibility/extensions/types";
 import type { MCPManager } from "../mcp";
+import type { KnowledgeCommandEntry } from "../memories/knowledge-ops";
 import type { PlanApprovalDetails } from "../plan-mode/approved-plan";
 import type { AgentSession, AgentSessionEvent } from "../session/agent-session";
 import type { HistoryStorage } from "../session/history-storage";
@@ -125,6 +126,7 @@ export interface InteractiveModeContext {
 	lastStatusText: Text | undefined;
 	fileSlashCommands: Set<string>;
 	skillCommands: Map<string, string>;
+	knowledgeCommands: Map<string, KnowledgeCommandEntry>;
 	oauthManualInput: OAuthManualInputManager;
 	todoPhases: TodoPhase[];
 

--- a/packages/coding-agent/src/prompts/knowledge/maintenance.md
+++ b/packages/coding-agent/src/prompts/knowledge/maintenance.md
@@ -1,0 +1,26 @@
+# Knowledge Maintenance
+
+Maintaining the knowledge base is part of the task, not optional follow-up. Across conversations the knowledge tree is how the next agent (or you, later) avoids re-doing the same investigation.
+
+Knowledge is split into four buckets:
+
+- **Design** — design documents discussed and agreed with the user. Sources of truth alongside the code. You MAY write here after an explicit discussion, but every mutating call (`knowledge_create`, `knowledge_edit`, `knowledge_move`, `knowledge_delete`) is staged through the `resolve` protocol — the user reviews and approves each change before it lands.
+- **Memory** — the agent-maintained store. Includes durable error notes, lessons learned, and cached project facts (e.g. how the input/event/asset systems work) that reduce future investigation cost.
+- **Skill** — reusable playbooks. User-imported references and any reusable material you decide is worth recording.
+- **Reference** — read-only external material (e.g. official docs). Never modify.
+
+When to write:
+
+- **After a discussion with the user about design or direction** — record the decision under `design/` via `knowledge_create` / `knowledge_edit`. The host stages each write for the user's approval; tool output will say "pending user approval" when this happens. Do not retry or rewrite the same change in response.
+- **After a task or research effort that produced reusable signal** — record it under `memory/`, following these rules:
+  - Memory drifts. Record what is true now; if you later find a memory disagrees with current observations, the current observation wins. Update or delete the stale memory rather than acting on it.
+  - Capture concrete signal: constraints, decisions, workflows, pitfalls with resolutions. Drop transient chatter.
+  - Keep entries self-contained — include enough context that a fresh session can reuse the note without re-reading the original rollout.
+  - Prefer `knowledge_edit` over appending duplicate documents on the same topic.
+- **As you explore the project** — record durable structural facts under `memory/project-understanding/` (directory roles, module boundaries, ownership notes). This bucket uses `injectMode: "path"`, so each doc surfaces as a breadcrumb the next session can `knowledge_read` on demand.
+
+Safety:
+
+- `knowledge_edit` refuses to overwrite a user-authored doc lacking body markers.
+- `knowledge_delete` refuses `readOnly` targets and stages user-protected targets through `resolve`.
+- Never bypass the knowledge tools by writing into `memory_root/` directly via `write` or shell redirects — those paths are not gated and clobber user-protected docs.

--- a/packages/coding-agent/src/prompts/knowledge/usage.md
+++ b/packages/coding-agent/src/prompts/knowledge/usage.md
@@ -1,0 +1,12 @@
+# Knowledge Usage
+
+Before any non-trivial engineering implementation, ground yourself in this project's existing knowledge. Do not rely on general engineering experience when the project has captured its own conventions.
+
+1. Use `knowledge_query` and `knowledge_list` to find relevant documents. Lexical queries are the default surface; multi-term queries narrow results.
+2. Read the matching documents with `knowledge_read` (`part: "summary"` first when the doc is large, `part: "body"` for the substantive content).
+3. If the knowledge base does not cover the area, delegate research to `task` with the appropriate subagent. Avoid analyzing large numbers of files directly in the main context.
+4. After research, if findings are worth keeping for future runs, use `knowledge_create` or `knowledge_edit` to record them under `memory/` (or `skill/<name>/` for reusable playbooks). Follow the maintenance rules.
+5. `design/` documents capture user-agreed direction. After a real discussion with the user, you may use `knowledge_create` / `knowledge_edit` to record decisions there; the host stages those writes through the `resolve` protocol so the user reviews each one before it lands. Never overwrite a `design/` doc the user maintains without that approval.
+6. `reference/` is read-only external material (e.g. official docs). Read freely; never write.
+
+Knowledge docs are also addressable as `knowledge://<type>/<path>` URLs through `read` — use `?part=body` to read the body region without frontmatter, `?part=summary` for the summary section, or `?frontmatter=1` for just the YAML head. `knowledge://memory/foo` (no `.md`) is the slug form and matches the `/knowledge:memory/foo` slash command.

--- a/packages/coding-agent/src/prompts/memories/consolidation.md
+++ b/packages/coding-agent/src/prompts/memories/consolidation.md
@@ -1,9 +1,11 @@
 Memory consolidation agent.
 Memory root: memory://root
+
 Input corpus (raw memories):
 {{raw_memories}}
 Input corpus (rollout summaries):
 {{rollout_summaries}}
+
 Produce strict JSON only with this schema — you NEVER include any other output:
 {
   "memory_md": "string",
@@ -16,15 +18,30 @@ Produce strict JSON only with this schema — you NEVER include any other output
       "templates": [{ "path": "string", "content": "string" }],
       "examples": [{ "path": "string", "content": "string" }]
     }
+  ],
+  "design_drafts": [
+    { "path": "string", "content": "string" }
   ]
 }
+
+Taxonomy:
+- `memory/` — durable project memory. You author `memory_md` (long-form) and `memory_summary` (prompt-time guidance).
+- `skill/<name>/` — reusable playbooks. You author the entries in `skills`.
+- `design/` — design notes and proposals. **User-owned.** The consolidator MUST NOT rewrite existing design notes. Surface new proposals via `design_drafts` only; the host writes them under `design/_drafts/` for the user to review and promote. Direct AI edits to existing design docs are possible at runtime through the `knowledge_create` / `knowledge_edit` tools (each staged for user approval); they never flow through this consolidation pass.
+- `reference/` — user-curated read-only material. You NEVER touch it.
+
+Write contract:
+- You emit **body content only** for `memory_md`, `memory_summary`, each `skills[].content`, and each `design_drafts[].content`. The host wraps your output in frontmatter and `<!-- omp:body:start --> … <!-- omp:body:end -->` markers and writes it under the correct typed directory.
+- If an existing doc on disk is missing the body markers, the host treats it as user-authored and skips the write. Author bodies that stand alone — do not assume context outside your own output.
+
 Requirements:
-- memory_md: long-term memory document.
-- memory_summary: prompt-time memory guidance.
-- skills: reusable playbooks. Empty array allowed.
-- skill.name maps to skills/<name>/.
-- skill.content maps to skills/<name>/SKILL.md.
-- scripts/templates/examples: optional. Each entry MUST write to skills/<name>/<bucket>/<path>.
+- `memory_md`: long-term memory document body.
+- `memory_summary`: prompt-time memory guidance body.
+- `skills`: reusable playbooks. Empty array allowed.
+  - `skill.name` maps to `skill/<name>/`.
+  - `skill.content` maps to `skill/<name>/SKILL.md` (body region only).
+  - `scripts`/`templates`/`examples`: optional. Each entry writes to `skill/<name>/<bucket>/<path>` verbatim (no body markers — these are asset files).
+- `design_drafts`: optional. Each entry writes to `design/_drafts/<path>` as a fresh draft with `aiMaintained: false`. The host refuses to overwrite an existing draft at the same path. Use this only for genuinely new proposals; if a draft already exists or the user maintains a hand-authored design doc on the same topic, prefer to surface the delta in `memory_md` instead.
 - Only include files worth keeping long-term. Omit stale assets so they are pruned.
 - Preserve useful prior themes. Remove stale or contradictory guidance.
 - Treat memory as advisory: current repository state wins.

--- a/packages/coding-agent/src/prompts/memories/read-path.md
+++ b/packages/coding-agent/src/prompts/memories/read-path.md
@@ -1,11 +1,24 @@
 # Memory Guidance
 Memory root: memory://root
+Memory is organized into four typed buckets under the memory root:
+- `memory/` — durable project memory (long-lived facts, conventions, decisions).
+- `skill/<name>/SKILL.md` — reusable playbooks for recurring workflows.
+- `design/` — design notes and proposals. User-owned; AI may surface drafts under `design/_drafts/` for review.
+- `reference/` — read-only reference material curated by the user.
+
+Read order:
+1) `memory://root/memory/memory_summary.md` — prompt-time guidance (refreshed by Phase-2 consolidation).
+2) `memory://root/memory/MEMORY.md` — long-form durable memory.
+3) `memory://root/skill/<name>/SKILL.md` — when a task matches an indexed skill.
+4) `memory://root/design/...` and `memory://root/reference/...` — when relevant to the current task.
+
 Operational rules:
-1) Read `memory://root/memory_summary.md` first.
-2) If needed, inspect `memory://root/MEMORY.md` and `memory://root/skills/<name>/SKILL.md`.
+1) Read `memory://root/memory/memory_summary.md` first. Legacy `memory://root/memory_summary.md` paths resolve via back-compat redirect; either works.
+2) If needed, inspect `memory://root/memory/MEMORY.md` and `memory://root/skill/<name>/SKILL.md`. Legacy `memory://root/MEMORY.md` and `memory://root/skills/<name>/SKILL.md` paths are also accepted.
 3) Trust memory for heuristics and process context. Trust current repo files, runtime output, and user instruction for factual state and final decisions.
-4) When memory changes your plan, cite the artifact path (e.g. `memory://root/skills/<name>/SKILL.md`) and pair it with current-repo evidence.
+4) When memory changes your plan, cite the artifact path (e.g. `memory://root/skill/<name>/SKILL.md`) and pair it with current-repo evidence.
 5) If memory disagrees with repo state or user instruction, prefer repo/user. Treat memory as stale. Proceed with corrected behavior, then update/regenerate memory artifacts.
 6) Escalate confidence only after repository verification. Memory alone is NEVER sufficient proof.
+7) `design/` and `reference/` are user-owned. Do not silently rewrite them; surface proposals to the user instead.
 Memory summary:
 {{memory_summary}}

--- a/packages/coding-agent/src/prompts/memories/stage_one_system.md
+++ b/packages/coding-agent/src/prompts/memories/stage_one_system.md
@@ -7,6 +7,10 @@ Extraction goals:
 - You MUST keep concrete technical signal (constraints, decisions, workflows, pitfalls, resolved failures).
 - You NEVER include transient chatter and low-signal noise.
 
+Your output is consumed by the four-bucket consolidator, which sorts durable signal into
+`memory/`, `skill/<name>/`, and (rarely) `design/_drafts/`. Capture enough context that the
+consolidator can route the signal correctly without re-reading the rollout.
+
 Output contract (required keys):
 {
   "rollout_summary": "string",

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -55,6 +55,7 @@ With most FS/bash-like tools, static references to them will automatically resol
    - `/<path>`: File within a skill
 - `rule://<name>`: Rule details
 - `memory://root`: Project memory summary
+- `knowledge://<type>/<path>`: Knowledge document (`type` ∈ memory|skill|design|reference). Auto-appends `.md`. Supports `?part=body|summary|full` and `?frontmatter=1` (frontmatter wins over part).
 - `agent://<id>`: Full agent output artifact
    - `/<path>`: JSON field extraction
 - `artifact://<id>`: Artifact content

--- a/packages/coding-agent/src/prompts/tools/read.md
+++ b/packages/coding-agent/src/prompts/tools/read.md
@@ -8,7 +8,7 @@ Read files, directories, archives, SQLite databases, images, documents, internal
 
 ## Parameters
 
-- `path` — required. Local path, internal URI (`skill://`, `agent://`, `artifact://`, `memory://`, `rule://`, `local://`, `mcp://`), or URL. Append `:<sel>` for line ranges, raw mode, or special modes (e.g. `src/foo.ts:50-200`, `src/foo.ts:raw`, `db.sqlite:users:42`).
+- `path` — required. Local path, internal URI (`skill://`, `agent://`, `artifact://`, `memory://`, `knowledge://`, `rule://`, `local://`, `mcp://`), or URL. Append `:<sel>` for line ranges, raw mode, or special modes (e.g. `src/foo.ts:50-200`, `src/foo.ts:raw`, `db.sqlite:users:42`).
 
 ## Selectors
 
@@ -70,7 +70,7 @@ For `.sqlite`, `.sqlite3`, `.db`, `.db3`:
 
 # Internal URIs
 
-`skill://<name>`, `agent://<id>`, `artifact://<id>`, `memory://root`, `rule://<name>`, `local://<name>.md`, `mcp://<uri>` resolve transparently and accept the same line selectors as filesystem paths. Use `artifact://<id>` to recover full output that a previous bash/eval/tool result spilled or truncated.
+`skill://<name>`, `agent://<id>`, `artifact://<id>`, `memory://root`, `knowledge://<type>/<path>`, `rule://<name>`, `local://<name>.md`, `mcp://<uri>` resolve transparently and accept the same line selectors as filesystem paths. Use `artifact://<id>` to recover full output that a previous bash/eval/tool result spilled or truncated.
 
 <critical>
 - You MUST use `read` for every file, directory, archive, and URL inspection. `cat`, `head`, `tail`, `less`, `more`, `ls`, `tar`, `unzip`, `curl`, `wget` are FORBIDDEN — any such bash call is a bug, regardless of how short or convenient it looks.

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -135,7 +135,7 @@ import type {
 import type { CompactOptions, ContextUsage } from "../extensibility/extensions/types";
 import { ExtensionToolWrapper } from "../extensibility/extensions/wrapper";
 import type { HookCommandContext } from "../extensibility/hooks/types";
-import type { Skill, SkillWarning } from "../extensibility/skills";
+import { type Skill, type SkillWarning, subscribeToActiveSkills } from "../extensibility/skills";
 import { expandSlashCommand, type FileSlashCommand } from "../extensibility/slash-commands";
 import { GoalRuntime } from "../goals/runtime";
 import type { Goal, GoalModeState } from "../goals/state";
@@ -832,6 +832,10 @@ export class AgentSession {
 
 	#skills: Skill[];
 	#skillWarnings: SkillWarning[];
+	/** Unsubscribe handle for `subscribeToActiveSkills`; cleared on dispose. */
+	#activeSkillsUnsubscribe: (() => void) | undefined;
+	/** Listeners notified when `#skills` is replaced via `setActiveSkills`. */
+	#skillsChangedListeners = new Set<(skills: readonly Skill[]) => void>();
 
 	// Custom commands (TypeScript slash commands)
 	#customCommands: LoadedCustomCommand[] = [];
@@ -1005,6 +1009,20 @@ export class AgentSession {
 		this.#extensionRunner = config.extensionRunner;
 		this.#skills = config.skills ?? [];
 		this.#skillWarnings = config.skillWarnings ?? [];
+		// Track process-global skill-snapshot changes (`skill_reload` calls
+		// `setActiveSkills` after a successful reload) so this session's
+		// cached skill list and any subscribed UI command maps refresh in
+		// place instead of staying frozen at session start.
+		this.#activeSkillsUnsubscribe = subscribeToActiveSkills(skills => {
+			this.#skills = [...skills];
+			for (const listener of this.#skillsChangedListeners) {
+				try {
+					listener(this.#skills);
+				} catch (error) {
+					logger.warn("Skills-changed listener threw", { error: String(error) });
+				}
+			}
+		});
 		this.#customCommands = config.customCommands ?? [];
 		this.#skillsSettings = config.skillsSettings;
 		this.#modelRegistry = config.modelRegistry;
@@ -2793,6 +2811,11 @@ export class AgentSession {
 			this.#unsubscribeAppendOnly = undefined;
 		}
 		this.#eventListeners = [];
+		if (this.#activeSkillsUnsubscribe) {
+			this.#activeSkillsUnsubscribe();
+			this.#activeSkillsUnsubscribe = undefined;
+		}
+		this.#skillsChangedListeners.clear();
 	}
 
 	#closeAllProviderSessions(reason: string): void {
@@ -4662,6 +4685,20 @@ export class AgentSession {
 	/** Skills loaded by SDK (empty if --no-skills or skills: [] was passed) */
 	get skills(): readonly Skill[] {
 		return this.#skills;
+	}
+
+	/**
+	 * Subscribe to skill-snapshot changes for this session. Triggered when
+	 * `skill_reload` (or any other call to `setActiveSkills`) replaces the
+	 * process-global snapshot. Returns an unsubscribe function the caller
+	 * MUST invoke when its lifecycle ends. Listener errors are swallowed
+	 * and logged so one bad subscriber never derails the reload fan-out.
+	 */
+	onSkillsChanged(listener: (skills: readonly Skill[]) => void): () => void {
+		this.#skillsChangedListeners.add(listener);
+		return () => {
+			this.#skillsChangedListeners.delete(listener);
+		};
 	}
 
 	/** Skill loading warnings captured by SDK */

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -532,9 +532,11 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 
 	// Filter skills for the rendered system prompt:
 	// - require the `read` tool so the model can actually fetch skill content;
-	// - drop skills with frontmatter `hide: true` (still loadable via skill:// and /skill:<name>).
+	// - drop skills whose `surface` resolves to `"command"` (still loadable
+	//   via skill:// and /skill:<name>). Legacy `hide: true` frontmatter maps
+	//   to `surface: "command"` via `deriveSkillSurface`.
 	const hasRead = tools?.has("read");
-	const filteredSkills = hasRead ? skills.filter(skill => skill.hide !== true) : [];
+	const filteredSkills = hasRead ? skills.filter(skill => (skill.surface ?? "auto") !== "command") : [];
 
 	const effectiveSystemPromptCustomization = dedupePromptSource(systemPromptCustomization, [
 		resolvedCustomPrompt,

--- a/packages/coding-agent/src/tools/bash-skill-urls.ts
+++ b/packages/coding-agent/src/tools/bash-skill-urls.ts
@@ -11,9 +11,18 @@ import { ToolError } from "./tool-errors";
 const SKILL_URL_PATTERN = /'skill:\/\/[^'\s")`\\]+'|"skill:\/\/[^"\s')`\\]+"|skill:\/\/[^\s'")`\\]+/g;
 
 const INTERNAL_URL_PATTERN_INCLUDING_NORMALIZED_LOCAL =
-	/'(?:skill|agent|artifact|plan|memory|rule|local):\/\/[^'\s")`\\]+'|"(?:skill|agent|artifact|plan|memory|rule|local):\/\/[^"\s')`\\]+"|(?:skill|agent|artifact|plan|memory|rule|local):\/\/[^\s'")`\\]+|'local:\/[^'\s")`\\]+'|"local:\/[^"\s')`\\]+"|(?<![./\\\\\w-])local:\/[^\s'")`\\]+/g;
+	/'(?:skill|knowledge|agent|artifact|plan|memory|rule|local):\/\/[^'\s")`\\]+'|"(?:skill|knowledge|agent|artifact|plan|memory|rule|local):\/\/[^"\s')`\\]+"|(?:skill|knowledge|agent|artifact|plan|memory|rule|local):\/\/[^\s'")`\\]+|'local:\/[^'\s")`\\]+'|"local:\/[^"\s')`\\]+"|(?<![./\\\\\w-])local:\/[^\s'")`\\]+/g;
 
-const SUPPORTED_INTERNAL_SCHEMES = ["skill", "agent", "artifact", "plan", "memory", "rule", "local"] as const;
+const SUPPORTED_INTERNAL_SCHEMES = [
+	"skill",
+	"knowledge",
+	"agent",
+	"artifact",
+	"plan",
+	"memory",
+	"rule",
+	"local",
+] as const;
 
 type SupportedInternalScheme = (typeof SUPPORTED_INTERNAL_SCHEMES)[number];
 
@@ -216,7 +225,7 @@ export function expandSkillUrls(command: string, skills: readonly Skill[]): stri
 
 /**
  * Expand supported internal URLs in a bash command string to shell-escaped absolute paths.
- * Supported schemes: skill://, agent://, artifact://, memory://, rule://, local://
+ * Supported schemes: skill://, knowledge://, agent://, artifact://, memory://, rule://, local://
  */
 export async function expandInternalUrls(command: string, options: InternalUrlExpansionOptions): Promise<string> {
 	if (!command.includes("://") && !command.includes("local:/")) return command;

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -39,6 +39,15 @@ import { HindsightRetainTool } from "./hindsight-retain";
 import { InspectImageTool } from "./inspect-image";
 import { IrcTool } from "./irc";
 import { JobTool } from "./job";
+import {
+	KnowledgeCreateTool,
+	KnowledgeDeleteTool,
+	KnowledgeEditTool,
+	KnowledgeListTool,
+	KnowledgeMoveTool,
+	KnowledgeQueryTool,
+	KnowledgeReadTool,
+} from "./knowledge";
 import { wrapToolWithMetaNotice } from "./output-meta";
 import { ReadTool } from "./read";
 import { RecipeTool } from "./recipe";
@@ -48,6 +57,7 @@ import { ResolveTool } from "./resolve";
 import { reportFindingTool } from "./review";
 import { SearchTool } from "./search";
 import { SearchToolBm25Tool } from "./search-tool-bm25";
+import { SkillCreateTool, SkillListTool, SkillReloadTool } from "./skill";
 import { loadSshTool } from "./ssh";
 import { type TodoPhase, TodoWriteTool } from "./todo-write";
 import { WriteTool } from "./write";
@@ -81,6 +91,7 @@ export * from "./image-gen";
 export * from "./inspect-image";
 export * from "./irc";
 export * from "./job";
+export * from "./knowledge";
 export * from "./read";
 export * from "./recipe";
 export * from "./render-mermaid";
@@ -89,6 +100,7 @@ export * from "./resolve";
 export * from "./review";
 export * from "./search";
 export * from "./search-tool-bm25";
+export * from "./skill";
 export * from "./ssh";
 export * from "./todo-write";
 export * from "./vim";
@@ -302,6 +314,16 @@ export const BUILTIN_TOOLS: Record<string, ToolFactory> = {
 	rewind: RewindTool.createIf,
 	task: s => TaskTool.create(s),
 	job: JobTool.createIf,
+	knowledge_list: s => new KnowledgeListTool(s),
+	knowledge_query: s => new KnowledgeQueryTool(s),
+	knowledge_read: s => new KnowledgeReadTool(s),
+	knowledge_create: s => new KnowledgeCreateTool(s),
+	knowledge_edit: s => new KnowledgeEditTool(s),
+	knowledge_move: s => new KnowledgeMoveTool(s),
+	knowledge_delete: s => new KnowledgeDeleteTool(s),
+	skill_create: s => new SkillCreateTool(s),
+	skill_reload: s => new SkillReloadTool(s),
+	skill_list: s => new SkillListTool(s),
 	recipe: RecipeTool.createIf,
 	irc: IrcTool.createIf,
 	todo_write: s => new TodoWriteTool(s),
@@ -460,6 +482,8 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		// search_tool_bm25 is allowed when either legacy mcp.discoveryMode or new tools.discoveryMode is active.
 		if (name === "search_tool_bm25") return discoveryActive;
 		if (name === "calc") return session.settings.get("calc.enabled");
+		if (name.startsWith("knowledge_")) return session.settings.get("knowledge.enabled");
+		if (name.startsWith("skill_")) return session.settings.get("skills.enabled") !== false;
 		if (name === "browser") return session.settings.get("browser.enabled");
 		if (name === "checkpoint" || name === "rewind") return session.settings.get("checkpoint.enabled");
 		if (name === "irc") {

--- a/packages/coding-agent/src/tools/knowledge.ts
+++ b/packages/coding-agent/src/tools/knowledge.ts
@@ -1,0 +1,510 @@
+/**
+ * Knowledge tools.
+ *
+ * Seven operations over the four-bucket memory taxonomy:
+ * `knowledge_list`, `_query`, `_read`, `_create`, `_edit`, `_move`,
+ * `_delete`. Each tool is a thin wrapper around the operations in
+ * `memories/knowledge-ops.ts` — the heavy lifting (path validation,
+ * body-marker rewrite, `.omp-meta` permission gating) lives there.
+ *
+ * Path conventions:
+ *   - Type-prefixed: `memory/foo.md`, `skill/bar/`, `design/baz.md`.
+ *   - Documents end in `.md`; directories do not.
+ *   - The type prefix is mandatory; cross-type moves are refused.
+ */
+
+import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { untilAborted } from "@oh-my-pi/pi-utils";
+import * as z from "zod/v4";
+import { getMemoryRoot } from "../memories";
+import {
+	type KnowledgeApprovalPreview,
+	type KnowledgeApprovalRequest,
+	type KnowledgeApprovalSink,
+	type KnowledgeOpOutcome,
+	KnowledgeOpsError,
+	knowledgeCreateDirectory,
+	knowledgeCreateDocument,
+	knowledgeDelete,
+	knowledgeEditDocument,
+	knowledgeList,
+	knowledgeMove,
+	knowledgeQuery,
+	knowledgeRead,
+} from "../memories/knowledge-ops";
+import type { ToolSession } from ".";
+import { queueResolveHandler } from "./resolve";
+import { ToolError } from "./tool-errors";
+
+// ────────────────────────────────────────────────────────────────────
+// shared helpers
+// ────────────────────────────────────────────────────────────────────
+
+function getMemoryRootFor(session: ToolSession): string {
+	return getMemoryRoot(session.settings.getAgentDir(), session.cwd);
+}
+
+function toToolError(error: unknown): never {
+	if (error instanceof KnowledgeOpsError) {
+		throw new ToolError(error.message);
+	}
+	throw error;
+}
+
+function plainText(text: string): AgentToolResult {
+	return { content: [{ type: "text", text }] };
+}
+
+/**
+ * Build an approval sink that stages knowledge writes through the
+ * resolve protocol. The sink queues a `resolve` directive describing the
+ * preview; on user `apply`, the underlying op runs and the tool emits a
+ * normal "done" result. On `discard`, the op is dropped.
+ */
+function buildKnowledgeApprovalSink(session: ToolSession, sourceToolName: string): KnowledgeApprovalSink {
+	return async (request: KnowledgeApprovalRequest) => {
+		const label = formatApprovalLabel(request.preview);
+		// Mirror skill_create: hard-fail if no resolve channel exists in
+		// this session so callers see a clear error instead of a silent
+		// "pending user approval" that can never be applied.
+		const queue = session.getToolChoiceQueue?.();
+		const forced = session.buildToolChoice?.("resolve");
+		if (!queue || !forced || typeof forced === "string") {
+			throw new ToolError(
+				`${sourceToolName} requires user approval but no resolve channel is available in this session. Use the equivalent file edit tools manually if necessary.`,
+			);
+		}
+		queueResolveHandler(session, {
+			label,
+			sourceToolName,
+			apply: async (_reason: string) => {
+				await request.apply();
+				return plainText(`Applied: ${label}`);
+			},
+		});
+	};
+}
+
+function formatApprovalLabel(preview: KnowledgeApprovalPreview): string {
+	const target = preview.destPath ? `${preview.path} -> ${preview.destPath}` : preview.path;
+	const verb =
+		preview.kind === "create"
+			? "Create"
+			: preview.kind === "edit"
+				? "Edit"
+				: preview.kind === "move"
+					? "Move"
+					: "Delete";
+	return `${verb} ${preview.entryKind}: ${target}`;
+}
+
+function pendingResult(outcome: KnowledgeOpOutcome, label: string): AgentToolResult {
+	if (outcome.applied) {
+		return plainText(label);
+	}
+	// `applied: false && requiredApproval: false` is a legitimate no-op
+	// (e.g. `knowledge_create kind=directory` on an existing dir,
+	// or `knowledge_move` with source == destination). No resolve handler
+	// was queued, so reporting "pending user approval" would dead-end the
+	// caller. Only the approval path queues a resolve.
+	if (!outcome.requiredApproval) {
+		return plainText(`${label} (no-op).`);
+	}
+	return plainText(`${label} pending user approval. The user must call \`resolve\` to apply or discard.`);
+}
+
+// ────────────────────────────────────────────────────────────────────
+// schemas
+// ────────────────────────────────────────────────────────────────────
+
+const listSchema = z
+	.object({
+		pathPrefix: z
+			.string()
+			.optional()
+			.describe(
+				"Optional type-prefixed directory prefix (e.g. `memory/`, `skill/sbox/`). Omit to list across every type root.",
+			),
+	})
+	.strict();
+
+const querySchema = z
+	.object({
+		lexicalQuery: z
+			.string()
+			.optional()
+			.describe("Lexical query for exact terms, titles, paths, identifiers, or short keyword combinations."),
+		semanticQuery: z
+			.string()
+			.optional()
+			.describe(
+				"Semantic query for intent- or meaning-based retrieval. Currently treated as a lexical query — OMP ships lexical scan only.",
+			),
+		limit: z
+			.number()
+			.int()
+			.min(1)
+			.max(20)
+			.default(5)
+			.optional()
+			.describe("Maximum number of results to return (default 5, max 20)."),
+		pathPrefix: z.string().optional().describe("Optional type-prefixed directory prefix to constrain the search."),
+		types: z
+			.array(z.enum(["memory", "skill", "design", "reference"]))
+			.optional()
+			.describe(
+				"Restrict the search to the listed top-level buckets. Omit (or pass an empty array) to search every bucket.",
+			),
+	})
+	.strict();
+
+const readSchema = z
+	.object({
+		path: z.string().describe("Type-prefixed document path ending in `.md` (e.g. `memory/preferences.md`)."),
+		part: z.enum(["full", "summary", "body"]).default("full").optional().describe("Which content section to read."),
+	})
+	.strict();
+
+const createSchema = z
+	.object({
+		kind: z
+			.enum(["document", "directory"])
+			.describe("Whether to create a knowledge document or a knowledge directory."),
+		path: z
+			.string()
+			.describe(
+				"Type-prefixed path. Use `.md` suffix for `kind=document`; omit `.md` for `kind=directory`. Type prefix is mandatory.",
+			),
+		document: z
+			.object({
+				summary: z.string().nullable().optional(),
+				body: z.string().optional(),
+				maintenanceRules: z
+					.string()
+					.nullable()
+					.optional()
+					.describe(
+						"Optional document-level maintenance rules. Provide one rule per line; omit to inherit from the parent directory.",
+					),
+				commandEnabled: z
+					.boolean()
+					.optional()
+					.describe(
+						"Opt-in: when true, the doc is registered as `/knowledge:<type>/<path>` at session start. Omit (or false) to keep it out of the slash menu.",
+					),
+			})
+			.strict()
+			.optional()
+			.describe("Document-only initial content. Ignored for `kind=directory`."),
+	})
+	.strict();
+
+const editSchema = z
+	.object({
+		path: z.string().describe("Type-prefixed document path ending in `.md`."),
+		document: z
+			.object({
+				summary: z.string().nullable().optional(),
+				body: z.string().optional(),
+				maintenanceRules: z.string().nullable().optional(),
+			})
+			.strict()
+			.describe("Document content patch. Provide one or more sections to update."),
+	})
+	.strict();
+
+const moveSchema = z
+	.object({
+		kind: z
+			.enum(["document", "directory"])
+			.describe("Whether the target is a knowledge document or a knowledge directory."),
+		path: z.string().describe("Current type-prefixed path."),
+		newPath: z.string().describe("Target type-prefixed path. Keep it inside the same top-level type tree."),
+	})
+	.strict();
+
+const deleteSchema = z
+	.object({
+		kind: z
+			.enum(["document", "directory"])
+			.describe("Whether the target is a knowledge document or a knowledge directory."),
+		path: z.string().describe("Current type-prefixed path. Use `.md` for documents; omit for directories."),
+	})
+	.strict();
+
+// ────────────────────────────────────────────────────────────────────
+// tool factories
+// ────────────────────────────────────────────────────────────────────
+
+export class KnowledgeListTool implements AgentTool<typeof listSchema> {
+	readonly name = "knowledge_list";
+	readonly label = "KnowledgeList";
+	readonly summary = "List knowledge documents and directories";
+	readonly loadMode = "discoverable";
+	readonly description =
+		"List knowledge documents in the unified knowledge store. Use this to browse the four top-level types: memory, skill, design, and reference. Returns plain text with one canonical type-prefixed path per line — directories end in `/`, documents in `.md`.";
+	readonly parameters = listSchema;
+	readonly strict = true;
+
+	constructor(private readonly session: ToolSession) {}
+
+	async execute(
+		_toolCallId: string,
+		params: z.infer<typeof listSchema>,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult> {
+		return untilAborted(signal, async () => {
+			const memoryRoot = getMemoryRootFor(this.session);
+			try {
+				const entries = await knowledgeList(memoryRoot, params.pathPrefix);
+				if (entries.length === 0) {
+					return plainText("(empty knowledge tree)");
+				}
+				const text = entries.map(entry => (entry.kind === "directory" ? `${entry.path}/` : entry.path)).join("\n");
+				return plainText(text);
+			} catch (error) {
+				toToolError(error);
+			}
+		});
+	}
+}
+
+export class KnowledgeQueryTool implements AgentTool<typeof querySchema> {
+	readonly name = "knowledge_query";
+	readonly label = "KnowledgeQuery";
+	readonly summary = "Search the unified knowledge store";
+	readonly loadMode = "discoverable";
+	readonly description =
+		"Search the unified knowledge store by lexical scan over canonical paths, titles, and document bodies. Provide `lexicalQuery` and/or `semanticQuery` — in this build both flow through the same lexical scorer; a semantic backend may land later as a parallel scorer. Returns ranked hits with canonical path, title, score, and a short snippet.";
+	readonly parameters = querySchema;
+	readonly strict = true;
+
+	constructor(private readonly session: ToolSession) {}
+
+	async execute(
+		_toolCallId: string,
+		params: z.infer<typeof querySchema>,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult> {
+		return untilAborted(signal, async () => {
+			const lexical = (params.lexicalQuery ?? "").trim();
+			const semantic = (params.semanticQuery ?? "").trim();
+			if (!lexical && !semantic) {
+				throw new ToolError("knowledge_query requires `lexicalQuery` or `semanticQuery`");
+			}
+			const memoryRoot = getMemoryRootFor(this.session);
+			try {
+				const hits = await knowledgeQuery(memoryRoot, {
+					lexicalQuery: lexical || undefined,
+					semanticQuery: semantic || undefined,
+					pathPrefix: params.pathPrefix,
+					types: params.types,
+					limit: params.limit,
+				});
+				if (hits.length === 0) {
+					return plainText(`(no matches for ${JSON.stringify(lexical || semantic)})`);
+				}
+				const lines: string[] = [];
+				for (const hit of hits) {
+					const title = hit.title ? ` · ${hit.title}` : "";
+					const section = hit.matchedSection ? ` section=${hit.matchedSection}` : "";
+					const meta: string[] = [];
+					if (hit.injectMode) meta.push(`inject=${hit.injectMode}`);
+					if (hit.aiMaintained !== undefined) meta.push(`ai=${hit.aiMaintained}`);
+					if (hit.hasSummary) meta.push("summary");
+					if (typeof hit.updatedAt === "number") meta.push(`updated=${hit.updatedAt}`);
+					const metaPart = meta.length > 0 ? ` ${meta.join(" ")}` : "";
+					lines.push(`${hit.path}${title}  score=${hit.score.toFixed(1)}${section}${metaPart}`);
+					if (hit.snippet) lines.push(`    ${hit.snippet}`);
+				}
+				return plainText(lines.join("\n"));
+			} catch (error) {
+				toToolError(error);
+			}
+		});
+	}
+}
+
+export class KnowledgeReadTool implements AgentTool<typeof readSchema> {
+	readonly name = "knowledge_read";
+	readonly label = "KnowledgeRead";
+	readonly summary = "Read a knowledge document";
+	readonly loadMode = "discoverable";
+	readonly description =
+		"Read a unified knowledge document by type-prefixed `.md` path. Returns plain-text markdown content. `part=full` returns the on-disk document; `part=body` returns only the body region between `<!-- omp:body:start --> ... <!-- omp:body:end -->` markers; `part=summary` returns the frontmatter `summary` value or the `## Summary` section.";
+	readonly parameters = readSchema;
+	readonly strict = true;
+
+	constructor(private readonly session: ToolSession) {}
+
+	async execute(
+		_toolCallId: string,
+		params: z.infer<typeof readSchema>,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult> {
+		return untilAborted(signal, async () => {
+			const memoryRoot = getMemoryRootFor(this.session);
+			try {
+				const result = await knowledgeRead(memoryRoot, params.path, params.part ?? "full");
+				return plainText(result.content);
+			} catch (error) {
+				toToolError(error);
+			}
+		});
+	}
+}
+
+export class KnowledgeCreateTool implements AgentTool<typeof createSchema> {
+	readonly name = "knowledge_create";
+	readonly label = "KnowledgeCreate";
+	readonly summary = "Create a knowledge document or directory";
+	readonly loadMode = "discoverable";
+	readonly description =
+		"Create a unified knowledge document or directory. Document paths must end with `.md` and carry a type prefix (`memory/`, `skill/`, `design/`, `reference/`). New documents inherit inject mode and AI edit config from the parent directory by default. `skill/<name>.md` creates a *skill knowledge document* (a reusable process reference doc), NOT a runtime-loadable skill — use `skill_create` for skill packages under `.omp/skills/<name>/`. Writes under `design/` route through user approval via the `resolve` protocol. Directory creation only creates the folder structure; metadata uses dedicated knowledge tools. Returns a plain-text status line.";
+	readonly parameters = createSchema;
+	readonly strict = true;
+
+	constructor(private readonly session: ToolSession) {}
+
+	async execute(
+		_toolCallId: string,
+		params: z.infer<typeof createSchema>,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult> {
+		return untilAborted(signal, async () => {
+			const memoryRoot = getMemoryRootFor(this.session);
+			try {
+				if (params.kind === "directory") {
+					const outcome = await knowledgeCreateDirectory(memoryRoot, params.path, {
+						approvalSink: buildKnowledgeApprovalSink(this.session, this.name),
+					});
+					return pendingResult(outcome, `Created directory ${params.path}`);
+				}
+				const outcome = await knowledgeCreateDocument(
+					memoryRoot,
+					params.path,
+					{
+						summary: params.document?.summary ?? undefined,
+						body: params.document?.body ?? undefined,
+						maintenanceRules: params.document?.maintenanceRules ?? undefined,
+						commandEnabled: params.document?.commandEnabled,
+					},
+					{ approvalSink: buildKnowledgeApprovalSink(this.session, this.name) },
+				);
+				return pendingResult(outcome, `Created document ${params.path}`);
+			} catch (error) {
+				toToolError(error);
+			}
+		});
+	}
+}
+
+export class KnowledgeEditTool implements AgentTool<typeof editSchema> {
+	readonly name = "knowledge_edit";
+	readonly label = "KnowledgeEdit";
+	readonly summary = "Edit a knowledge document";
+	readonly loadMode = "discoverable";
+	readonly description =
+		"Edit an existing unified knowledge document by type-prefixed `.md` path. Only updates content sections — frontmatter, identity, and on-disk layout survive. Body-only patches preserve the rest of the file byte-for-byte; summary/maintenance patches rebuild the doc with the new sections. User-authored documents lacking body markers are refused. Edits to docs whose effective config has `aiMaintained: false` (e.g. `design/`) route through user approval via the `resolve` protocol. Returns a plain-text status line.";
+	readonly parameters = editSchema;
+	readonly strict = true;
+
+	constructor(private readonly session: ToolSession) {}
+
+	async execute(
+		_toolCallId: string,
+		params: z.infer<typeof editSchema>,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult> {
+		return untilAborted(signal, async () => {
+			const memoryRoot = getMemoryRootFor(this.session);
+			try {
+				const outcome = await knowledgeEditDocument(
+					memoryRoot,
+					params.path,
+					{
+						summary: params.document.summary,
+						body: params.document.body,
+						maintenanceRules: params.document.maintenanceRules,
+					},
+					{ approvalSink: buildKnowledgeApprovalSink(this.session, this.name) },
+				);
+				return pendingResult(outcome, `Edited document ${params.path}`);
+			} catch (error) {
+				toToolError(error);
+			}
+		});
+	}
+}
+
+export class KnowledgeMoveTool implements AgentTool<typeof moveSchema> {
+	readonly name = "knowledge_move";
+	readonly label = "KnowledgeMove";
+	readonly summary = "Move a knowledge document or directory";
+	readonly loadMode = "discoverable";
+	readonly description =
+		"Move a unified knowledge document or directory within its knowledge type tree. Cross-type moves are refused — a document does not silently change meaning. Moves under `aiMaintained: false` paths (e.g. `design/`) route through user approval via the `resolve` protocol. Document paths must end with `.md`; directory paths do not. Returns a plain-text status line.";
+	readonly parameters = moveSchema;
+	readonly strict = true;
+
+	constructor(private readonly session: ToolSession) {}
+
+	async execute(
+		_toolCallId: string,
+		params: z.infer<typeof moveSchema>,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult> {
+		return untilAborted(signal, async () => {
+			const memoryRoot = getMemoryRootFor(this.session);
+			try {
+				const outcome = await knowledgeMove(memoryRoot, params.path, params.newPath, params.kind, {
+					approvalSink: buildKnowledgeApprovalSink(this.session, this.name),
+				});
+				return pendingResult(outcome, `Moved ${params.kind} ${params.path} -> ${params.newPath}`);
+			} catch (error) {
+				toToolError(error);
+			}
+		});
+	}
+}
+
+export class KnowledgeDeleteTool implements AgentTool<typeof deleteSchema> {
+	readonly name = "knowledge_delete";
+	readonly label = "KnowledgeDelete";
+	readonly summary = "Delete a knowledge document or directory";
+	readonly loadMode = "discoverable";
+	readonly description =
+		"Delete a unified knowledge document or directory by type-prefixed path. `readOnly` targets (e.g. under `reference/`) are refused. Deletes under `aiMaintained: false` paths route through user approval via the `resolve` protocol. Returns a plain-text status line.";
+	readonly parameters = deleteSchema;
+	readonly strict = true;
+
+	constructor(private readonly session: ToolSession) {}
+
+	async execute(
+		_toolCallId: string,
+		params: z.infer<typeof deleteSchema>,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult> {
+		return untilAborted(signal, async () => {
+			const memoryRoot = getMemoryRootFor(this.session);
+			try {
+				const outcome = await knowledgeDelete(memoryRoot, params.path, params.kind, {
+					approvalSink: buildKnowledgeApprovalSink(this.session, this.name),
+				});
+				return pendingResult(outcome, `Deleted ${params.kind} ${params.path}`);
+			} catch (error) {
+				toToolError(error);
+			}
+		});
+	}
+}
+
+export const KNOWLEDGE_TOOL_NAMES = [
+	"knowledge_list",
+	"knowledge_query",
+	"knowledge_read",
+	"knowledge_create",
+	"knowledge_edit",
+	"knowledge_move",
+	"knowledge_delete",
+] as const;

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -22,6 +22,7 @@ const INTERNAL_SCHEMES_WITH_SELECTORS: Record<string, true> = {
 	agent: true,
 	artifact: true,
 	issue: true,
+	knowledge: true,
 	local: true,
 	memory: true,
 	omp: true,

--- a/packages/coding-agent/src/tools/skill.ts
+++ b/packages/coding-agent/src/tools/skill.ts
@@ -1,0 +1,264 @@
+/**
+ * Skill tools.
+ *
+ * Two operations against the native skill package store at
+ * `<projectRoot>/.omp/skills/<name>/SKILL.md`:
+ *
+ *   - `skill_create` — author a new SKILL.md. ALWAYS routes through user
+ *     approval via the `resolve` protocol — skills become high-trust
+ *     instructions the agent will later read with `skill://<name>`.
+ *   - `skill_reload` — refresh the process-global active-skill snapshot
+ *     from disk so newly authored (or externally edited) skills become
+ *     reachable via `skill://<name>` and `/skill:<name>` without a
+ *     session restart. No approval: reload only re-reads files that
+ *     already exist on disk.
+ *
+ * Both tools are gated by the existing `skills.enabled` setting.
+ */
+
+import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { untilAborted } from "@oh-my-pi/pi-utils";
+import * as z from "zod/v4";
+import type { SkillsSettings } from "../config/settings";
+import {
+	type CreateSkillPackageInput,
+	type CreateSkillPackageResult,
+	commitSkillPackage,
+	type PreparedSkillPackage,
+	prepareSkillPackage,
+	type ReloadSkillsDiff,
+	reloadSkills,
+	SkillOpsError,
+} from "../extensibility/skill-ops";
+import { getActiveSkills, setActiveSkills } from "../extensibility/skills";
+import type { ToolSession } from ".";
+import { queueResolveHandler } from "./resolve";
+import { ToolError } from "./tool-errors";
+
+// ────────────────────────────────────────────────────────────────────
+// shared helpers
+// ────────────────────────────────────────────────────────────────────
+
+function toToolError(error: unknown): never {
+	if (error instanceof SkillOpsError) {
+		throw new ToolError(error.message);
+	}
+	throw error;
+}
+
+function plainText(text: string): AgentToolResult {
+	return { content: [{ type: "text", text }] };
+}
+
+/**
+ * Build a load-skills options object from the session's settings. Mirrors
+ * the shape `sdk.ts` passes to `loadSkills` at session start so that the
+ * reloaded snapshot matches what the user would see on a fresh launch.
+ */
+function buildLoadOptions(session: ToolSession) {
+	const skillsSettings = (session.settings.getGroup("skills") ?? {}) as SkillsSettings;
+	const disabledExtensions = session.settings.get("disabledExtensions") ?? [];
+	return {
+		...skillsSettings,
+		cwd: session.cwd,
+		disabledExtensions,
+	};
+}
+
+// ────────────────────────────────────────────────────────────────────
+// schemas
+// ────────────────────────────────────────────────────────────────────
+
+const createSchema = z
+	.object({
+		name: z
+			.string()
+			.min(1)
+			.describe("Lowercase kebab/snake skill identifier, 1-64 chars. Becomes `.omp/skills/<name>/`."),
+		description: z
+			.string()
+			.min(1)
+			.describe("One-line skill summary. Shown to future agents in the rendered <skills> block."),
+		body: z
+			.string()
+			.describe(
+				"SKILL.md body (markdown). Frontmatter (`name`, `description`, optional `skillSurface`) is generated for you.",
+			),
+		skillSurface: z
+			.enum(["auto", "command"])
+			.optional()
+			.describe(
+				'"auto" (default) — listed in the rendered <skills> block. "command" — hidden from listing, reachable via skill://<name> and /skill:<name> only.',
+			),
+	})
+	.strict();
+
+const reloadSchema = z.object({}).strict();
+
+const listSchema = z
+	.object({
+		surface: z
+			.enum(["auto", "command", "all"])
+			.optional()
+			.describe(
+				'Filter by skill surface. "auto" lists rendered-block skills; "command" lists hidden/command-only skills; "all" (default) lists every active skill.',
+			),
+	})
+	.strict();
+
+// ────────────────────────────────────────────────────────────────────
+// tool factories
+// ────────────────────────────────────────────────────────────────────
+
+export class SkillCreateTool implements AgentTool<typeof createSchema> {
+	readonly name = "skill_create";
+	readonly label = "SkillCreate";
+	readonly summary = "Author a new skill package";
+	readonly loadMode = "discoverable" as const;
+	readonly description =
+		"Create a new skill package at .omp/skills/<name>/SKILL.md. ALWAYS routes through user approval via the `resolve` protocol — skills become instructions future agents read with high trust. Refuses on name collision, unsafe identifiers, or pre-existing skill directories. After approval, run `skill_reload` to make the new skill reachable via skill://<name> and /skill:<name>. Project-scope only; user-scope skills (~/.omp/agent/skills/) must be authored manually.";
+	readonly parameters = createSchema;
+	readonly strict = true;
+
+	constructor(private readonly session: ToolSession) {}
+
+	async execute(
+		_toolCallId: string,
+		params: z.infer<typeof createSchema>,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult> {
+		return untilAborted(signal, async () => {
+			const input: CreateSkillPackageInput = {
+				name: params.name,
+				description: params.description,
+				body: params.body,
+				skillSurface: params.skillSurface,
+			};
+
+			// Validate eagerly so name/collision errors surface as ToolError
+			// without queueing a doomed preview the user would have to discard.
+			let prepared: PreparedSkillPackage;
+			try {
+				prepared = await prepareSkillPackage(this.session.cwd, input);
+			} catch (error) {
+				toToolError(error);
+			}
+
+			const queue = this.session.getToolChoiceQueue?.();
+			const forced = this.session.buildToolChoice?.("resolve");
+			if (!queue || !forced || typeof forced === "string") {
+				throw new ToolError(
+					`skill_create requires user approval but no resolve channel is available in this session. Author the skill manually under .omp/skills/${params.name}/SKILL.md if needed.`,
+				);
+			}
+
+			const label = `Create skill: ${params.name}`;
+			queueResolveHandler(this.session, {
+				label,
+				sourceToolName: this.name,
+				apply: async () => {
+					let result: CreateSkillPackageResult;
+					try {
+						result = await commitSkillPackage(prepared!);
+					} catch (error) {
+						toToolError(error);
+					}
+					return plainText(
+						`Created skill package: ${result!.skillFile}. Call \`skill_reload\` to activate it (skill://${params.name} will resolve only after reload).`,
+					);
+				},
+			});
+
+			return plainText(
+				`Create skill \`${params.name}\` pending user approval. The user must call \`resolve\` to apply or discard.`,
+			);
+		});
+	}
+}
+
+export class SkillReloadTool implements AgentTool<typeof reloadSchema> {
+	readonly name = "skill_reload";
+	readonly label = "SkillReload";
+	readonly summary = "Re-scan and reload the active skill snapshot";
+	readonly loadMode = "discoverable" as const;
+	readonly description =
+		"Re-scan skill directories and refresh the process-global active-skill snapshot. Returns added/removed/changed skill names. After a successful reload, new skills are reachable via skill://<name> and /skill:<name>. NOTE: the rendered <skills> system-prompt block reflects the snapshot at session start — restart the session to re-render that block.";
+	readonly parameters = reloadSchema;
+	readonly strict = true;
+
+	constructor(private readonly session: ToolSession) {}
+
+	async execute(
+		_toolCallId: string,
+		_params: z.infer<typeof reloadSchema>,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult> {
+		return untilAborted(signal, async () => {
+			const previous = getActiveSkills();
+			const options = buildLoadOptions(this.session);
+			const { skills, diff } = await reloadSkills(options, previous);
+			setActiveSkills(skills);
+			return plainText(formatReloadOutcome(diff, skills.length));
+		});
+	}
+}
+
+function formatReloadOutcome(diff: ReloadSkillsDiff, total: number): string {
+	const lines: string[] = [];
+	lines.push(`Reloaded skills: ${total} active.`);
+	lines.push(`  added: ${diff.added.length === 0 ? "(none)" : diff.added.join(", ")}`);
+	lines.push(`  removed: ${diff.removed.length === 0 ? "(none)" : diff.removed.join(", ")}`);
+	lines.push(`  changed: ${diff.changed.length === 0 ? "(none)" : diff.changed.join(", ")}`);
+	if (diff.warnings.length > 0) {
+		lines.push(`  warnings (${diff.warnings.length}):`);
+		for (const w of diff.warnings) {
+			lines.push(`    - ${w.skillPath}: ${w.message}`);
+		}
+	}
+	return lines.join("\n");
+}
+
+export class SkillListTool implements AgentTool<typeof listSchema> {
+	readonly name = "skill_list";
+	readonly label = "SkillList";
+	readonly summary = "List active skills";
+	readonly loadMode = "discoverable" as const;
+	readonly description =
+		"List currently-active skills (process-global snapshot, updated by `skill_reload`). Returns one skill per line: `<name>  surface=<auto|command>  source=<source>  · <description>`. Use this to see which skills the agent already has — without re-reading the rendered <skills> system block (which only reflects the snapshot at session start).";
+	readonly parameters = listSchema;
+	readonly strict = true;
+
+	constructor(private readonly session: ToolSession) {}
+
+	async execute(
+		_toolCallId: string,
+		params: z.infer<typeof listSchema>,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult> {
+		return untilAborted(signal, async () => {
+			void this.session; // session reserved for future per-session filtering
+			const filter = params.surface ?? "all";
+			const skills = getActiveSkills();
+			const filtered = skills.filter(skill => {
+				if (filter === "all") return true;
+				const surface = skill.surface ?? (skill.hide ? "command" : "auto");
+				return surface === filter;
+			});
+			if (filtered.length === 0) {
+				return plainText(filter === "all" ? "(no active skills)" : `(no ${filter} skills)`);
+			}
+			const lines = filtered
+				.slice()
+				.sort((a, b) => a.name.localeCompare(b.name))
+				.map(skill => {
+					const surface = skill.surface ?? (skill.hide ? "command" : "auto");
+					const source = skill.source || "unknown";
+					const desc = skill.description ? ` · ${skill.description}` : "";
+					return `${skill.name}  surface=${surface}  source=${source}${desc}`;
+				});
+			return plainText(lines.join("\n"));
+		});
+	}
+}
+
+export const SKILL_TOOL_NAMES = ["skill_create", "skill_reload", "skill_list"] as const;

--- a/packages/coding-agent/test/internal-urls/knowledge-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/knowledge-protocol.test.ts
@@ -1,0 +1,464 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { InternalUrlRouter } from "@oh-my-pi/pi-coding-agent/internal-urls";
+import { getMemoryRoot } from "@oh-my-pi/pi-coding-agent/memories";
+import type { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { getAgentDir, setAgentDir } from "@oh-my-pi/pi-utils";
+import { AgentRegistry } from "../../src/registry/agent-registry";
+
+interface KnowledgeFixture {
+	cwd: string;
+	memoryRoot: string;
+	agentDir: string;
+	cleanupRoot: string;
+}
+
+const SAMPLE_DOC = `---
+id: kd_demo
+title: Demo
+summary: Frontmatter summary line
+---
+# Demo
+
+## Summary
+Body summary section content.
+
+<!-- omp:body:start -->
+This is the body region.
+Second body line.
+<!-- omp:body:end -->
+`;
+
+const MARKER_LESS_DOC = `---
+id: kd_legacy
+title: Legacy
+---
+# Legacy
+
+Plain markdown body without markers.
+`;
+
+async function withKnowledgeFixture(fn: (fixture: KnowledgeFixture) => Promise<void>): Promise<void> {
+	const cleanupRoot = await fs.mkdtemp(path.join(os.tmpdir(), "knowledge-protocol-"));
+	const previousAgentDir = getAgentDir();
+	try {
+		const agentDir = path.join(cleanupRoot, "agent");
+		await fs.mkdir(agentDir, { recursive: true });
+		const cwd = path.join(cleanupRoot, "project");
+		await fs.mkdir(cwd, { recursive: true });
+		setAgentDir(agentDir);
+		const memoryRoot = getMemoryRoot(agentDir, cwd);
+		await fs.mkdir(memoryRoot, { recursive: true });
+		AgentRegistry.global().register({
+			id: "test-main",
+			displayName: "test",
+			kind: "main",
+			session: {
+				sessionManager: {
+					getCwd: () => cwd,
+					getArtifactsDir: () => null,
+					getSessionId: () => "test",
+				},
+			} as unknown as AgentSession,
+			sessionFile: null,
+		});
+		await fn({ cwd, memoryRoot, agentDir, cleanupRoot });
+	} finally {
+		setAgentDir(previousAgentDir);
+		await fs.rm(cleanupRoot, { recursive: true, force: true });
+	}
+}
+
+async function writeDoc(memoryRoot: string, rel: string, content: string): Promise<void> {
+	const absPath = path.join(memoryRoot, rel);
+	await fs.mkdir(path.dirname(absPath), { recursive: true });
+	await Bun.write(absPath, content);
+}
+
+describe("KnowledgeProtocolHandler", () => {
+	beforeEach(() => {
+		AgentRegistry.resetGlobalForTests();
+		InternalUrlRouter.resetForTests();
+	});
+
+	afterEach(() => {
+		AgentRegistry.resetGlobalForTests();
+		InternalUrlRouter.resetForTests();
+	});
+
+	describe("happy path", () => {
+		it("resolves knowledge://memory/<doc>.md", async () => {
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				await writeDoc(memoryRoot, "memory/notes.md", SAMPLE_DOC);
+
+				const router = InternalUrlRouter.instance();
+				const resource = await router.resolve("knowledge://memory/notes.md");
+
+				expect(resource.content).toBe(SAMPLE_DOC);
+				expect(resource.contentType).toBe("text/markdown");
+			});
+		});
+
+		it("auto-appends .md (slug form matches /knowledge:<slug>)", async () => {
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				await writeDoc(memoryRoot, "memory/notes.md", SAMPLE_DOC);
+
+				const router = InternalUrlRouter.instance();
+				const resource = await router.resolve("knowledge://memory/notes");
+
+				expect(resource.content).toBe(SAMPLE_DOC);
+			});
+		});
+
+		it("resolves skill, design, reference type buckets", async () => {
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				await writeDoc(memoryRoot, "skill/foo/SKILL.md", "skill-body");
+				await writeDoc(memoryRoot, "design/arch.md", "design-body");
+				await writeDoc(memoryRoot, "reference/api.md", "reference-body");
+
+				const router = InternalUrlRouter.instance();
+				expect((await router.resolve("knowledge://skill/foo/SKILL.md")).content).toBe("skill-body");
+				expect((await router.resolve("knowledge://design/arch.md")).content).toBe("design-body");
+				expect((await router.resolve("knowledge://reference/api.md")).content).toBe("reference-body");
+			});
+		});
+
+		it("marks resources immutable", async () => {
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				await writeDoc(memoryRoot, "memory/notes.md", SAMPLE_DOC);
+
+				const router = InternalUrlRouter.instance();
+				const resource = await router.resolve("knowledge://memory/notes.md");
+
+				expect(resource.immutable).toBe(true);
+			});
+		});
+	});
+
+	describe("part selectors", () => {
+		it("?part=body returns body region only when markers exist", async () => {
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				await writeDoc(memoryRoot, "memory/notes.md", SAMPLE_DOC);
+
+				const router = InternalUrlRouter.instance();
+				const resource = await router.resolve("knowledge://memory/notes.md?part=body");
+
+				expect(resource.content).toBe("This is the body region.\nSecond body line.");
+				expect(resource.contentType).toBe("text/markdown");
+			});
+		});
+
+		it("?part=body falls back to frontmatter-stripped content when markers absent", async () => {
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				await writeDoc(memoryRoot, "memory/legacy.md", MARKER_LESS_DOC);
+
+				const router = InternalUrlRouter.instance();
+				const resource = await router.resolve("knowledge://memory/legacy.md?part=body");
+
+				expect(resource.content).toBe("# Legacy\n\nPlain markdown body without markers.");
+			});
+		});
+
+		it("?part=summary returns frontmatter summary when set", async () => {
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				await writeDoc(memoryRoot, "memory/notes.md", SAMPLE_DOC);
+
+				const router = InternalUrlRouter.instance();
+				const resource = await router.resolve("knowledge://memory/notes.md?part=summary");
+
+				expect(resource.content).toBe("Frontmatter summary line");
+			});
+		});
+
+		it("?part=summary falls back to ## Summary section when frontmatter omits it", async () => {
+			const docWithoutFmSummary = SAMPLE_DOC.replace("summary: Frontmatter summary line\n", "");
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				await writeDoc(memoryRoot, "memory/notes.md", docWithoutFmSummary);
+
+				const router = InternalUrlRouter.instance();
+				const resource = await router.resolve("knowledge://memory/notes.md?part=summary");
+
+				expect(resource.content).toBe("Body summary section content.");
+			});
+		});
+
+		it("?part=full returns raw bytes", async () => {
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				await writeDoc(memoryRoot, "memory/notes.md", SAMPLE_DOC);
+
+				const router = InternalUrlRouter.instance();
+				const resource = await router.resolve("knowledge://memory/notes.md?part=full");
+
+				expect(resource.content).toBe(SAMPLE_DOC);
+			});
+		});
+
+		it("unknown ?part value falls through to full bytes", async () => {
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				await writeDoc(memoryRoot, "memory/notes.md", SAMPLE_DOC);
+
+				const router = InternalUrlRouter.instance();
+				const resource = await router.resolve("knowledge://memory/notes.md?part=garbage");
+
+				expect(resource.content).toBe(SAMPLE_DOC);
+			});
+		});
+	});
+
+	describe("frontmatter selector", () => {
+		it("?frontmatter=1 returns the YAML head only", async () => {
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				await writeDoc(memoryRoot, "memory/notes.md", SAMPLE_DOC);
+
+				const router = InternalUrlRouter.instance();
+				const resource = await router.resolve("knowledge://memory/notes.md?frontmatter=1");
+
+				expect(resource.content).toBe("---\nid: kd_demo\ntitle: Demo\nsummary: Frontmatter summary line\n---\n");
+				expect(resource.contentType).toBe("text/plain");
+			});
+		});
+
+		it("?frontmatter=1 wins over ?part=body", async () => {
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				await writeDoc(memoryRoot, "memory/notes.md", SAMPLE_DOC);
+
+				const router = InternalUrlRouter.instance();
+				const resource = await router.resolve("knowledge://memory/notes.md?frontmatter=1&part=body");
+
+				expect(resource.content.startsWith("---\n")).toBe(true);
+				expect(resource.content.includes("body region")).toBe(false);
+			});
+		});
+	});
+
+	describe("validation", () => {
+		it("rejects missing type bucket", async () => {
+			await withKnowledgeFixture(async () => {
+				const router = InternalUrlRouter.instance();
+				await expect(router.resolve("knowledge://")).rejects.toThrow("knowledge:// URL requires a type bucket");
+			});
+		});
+
+		it("rejects missing path", async () => {
+			await withKnowledgeFixture(async () => {
+				const router = InternalUrlRouter.instance();
+				await expect(router.resolve("knowledge://memory")).rejects.toThrow("knowledge:// requires a path");
+				await expect(router.resolve("knowledge://memory/")).rejects.toThrow("knowledge:// requires a path");
+			});
+		});
+
+		it("rejects unknown type", async () => {
+			await withKnowledgeFixture(async () => {
+				const router = InternalUrlRouter.instance();
+				await expect(router.resolve("knowledge://unknown/foo.md")).rejects.toThrow(
+					/Unknown knowledge type: unknown\. Supported: memory, skill, design, reference/,
+				);
+			});
+		});
+
+		it("blocks path traversal", async () => {
+			await withKnowledgeFixture(async () => {
+				const router = InternalUrlRouter.instance();
+				await expect(router.resolve("knowledge://memory/../secret.md")).rejects.toThrow(
+					"Path traversal (..) is not allowed in knowledge:// URLs",
+				);
+			});
+		});
+
+		it("rejects .omp-meta sidecars", async () => {
+			await withKnowledgeFixture(async () => {
+				const router = InternalUrlRouter.instance();
+				await expect(router.resolve("knowledge://memory/foo.omp-meta")).rejects.toThrow(
+					"knowledge:// only serves .md documents",
+				);
+			});
+		});
+
+		it("rejects non-.md extensions", async () => {
+			await withKnowledgeFixture(async () => {
+				const router = InternalUrlRouter.instance();
+				await expect(router.resolve("knowledge://memory/foo.txt")).rejects.toThrow(
+					"knowledge:// only serves .md documents",
+				);
+			});
+		});
+
+		it("reports missing docs with the requested URL", async () => {
+			await withKnowledgeFixture(async () => {
+				const router = InternalUrlRouter.instance();
+				await expect(router.resolve("knowledge://memory/missing.md")).rejects.toThrow(
+					"Knowledge document not found: knowledge://memory/missing.md",
+				);
+			});
+		});
+	});
+
+	describe("cross-session", () => {
+		it("resolves docs across multiple registered memory roots", async () => {
+			await withKnowledgeFixture(async ({ cleanupRoot, agentDir }) => {
+				// Register a second session with a disjoint cwd → different memory root.
+				const secondCwd = path.join(cleanupRoot, "project-2");
+				await fs.mkdir(secondCwd, { recursive: true });
+				const secondRoot = getMemoryRoot(agentDir, secondCwd);
+				await fs.mkdir(secondRoot, { recursive: true });
+				await writeDoc(secondRoot, "memory/only-here.md", "second-root-body");
+
+				AgentRegistry.global().register({
+					id: "test-worktree",
+					displayName: "worktree",
+					kind: "sub",
+					session: {
+						sessionManager: {
+							getCwd: () => secondCwd,
+							getArtifactsDir: () => null,
+							getSessionId: () => "test-2",
+						},
+					} as unknown as AgentSession,
+					sessionFile: null,
+				});
+
+				const router = InternalUrlRouter.instance();
+				const resource = await router.resolve("knowledge://memory/only-here.md");
+
+				expect(resource.content).toBe("second-root-body");
+			});
+		});
+	});
+
+	describe("CRLF line endings", () => {
+		it("?part=body strips frontmatter from a marker-less CRLF doc", async () => {
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				const crlf = MARKER_LESS_DOC.replace(/\n/g, "\r\n");
+				await writeDoc(memoryRoot, "memory/crlf.md", crlf);
+
+				const router = InternalUrlRouter.instance();
+				const resource = await router.resolve("knowledge://memory/crlf.md?part=body");
+
+				expect(resource.content.startsWith("---")).toBe(false);
+				expect(resource.content).toContain("Plain markdown body without markers.");
+			});
+		});
+
+		it("?frontmatter=1 returns the YAML head on a CRLF doc", async () => {
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				const crlf = SAMPLE_DOC.replace(/\n/g, "\r\n");
+				await writeDoc(memoryRoot, "memory/crlf.md", crlf);
+
+				const router = InternalUrlRouter.instance();
+				const resource = await router.resolve("knowledge://memory/crlf.md?frontmatter=1");
+
+				// Frontmatter head emitted with original CRLF preserved (regex did match).
+				expect(resource.content).toContain("id: kd_demo");
+				expect(resource.content).toContain("summary: Frontmatter summary line");
+				expect(resource.content.startsWith("---")).toBe(true);
+				expect(resource.content.trimEnd().endsWith("---")).toBe(true);
+			});
+		});
+	});
+
+	describe("case-insensitive type bucket", () => {
+		it("knowledge://Memory/<doc> resolves identically to lowercase", async () => {
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				await writeDoc(memoryRoot, "memory/notes.md", SAMPLE_DOC);
+
+				const router = InternalUrlRouter.instance();
+				const upper = await router.resolve("knowledge://Memory/notes.md");
+				const lower = await router.resolve("knowledge://memory/notes.md");
+
+				expect(upper.content).toBe(lower.content);
+			});
+		});
+	});
+
+	describe("symlink containment", () => {
+		it("rejects symlinks that escape the type root", async () => {
+			if (process.platform === "win32") return;
+
+			await withKnowledgeFixture(async ({ memoryRoot, cleanupRoot }) => {
+				const outsideDir = path.join(cleanupRoot, "outside");
+				await fs.mkdir(outsideDir, { recursive: true });
+				await Bun.write(path.join(outsideDir, "secret.md"), "secret");
+				await fs.mkdir(path.join(memoryRoot, "memory"), { recursive: true });
+				await fs.symlink(outsideDir, path.join(memoryRoot, "memory", "linked"));
+
+				const router = InternalUrlRouter.instance();
+				await expect(router.resolve("knowledge://memory/linked/secret.md")).rejects.toThrow(
+					"knowledge:// URL escapes type root",
+				);
+			});
+		});
+
+		it("rejects cross-bucket symlinks (memory/ → skill/)", async () => {
+			if (process.platform === "win32") return;
+
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				// Plant a real file in skill/, then point memory/ at skill/ via symlink.
+				await writeDoc(memoryRoot, "skill/secret/SKILL.md", "skill-body");
+				const memDir = path.join(memoryRoot, "memory");
+				// memory/ must not exist for the symlink to take its name.
+				await fs.symlink(path.join(memoryRoot, "skill"), memDir);
+
+				const router = InternalUrlRouter.instance();
+				await expect(router.resolve("knowledge://memory/secret/SKILL.md")).rejects.toThrow(
+					"knowledge:// URL escapes type root",
+				);
+			});
+		});
+	});
+
+	describe("absent-content notes", () => {
+		it("?part=summary returns no-summary note when neither source exists", async () => {
+			const noSummaryDoc = `---\nid: kd_nosum\ntitle: NoSummary\n---\n# NoSummary\n\nBody only.\n`;
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				await writeDoc(memoryRoot, "memory/nosum.md", noSummaryDoc);
+
+				const router = InternalUrlRouter.instance();
+				const resource = await router.resolve("knowledge://memory/nosum.md?part=summary");
+
+				expect(resource.content).toBe("");
+				expect(resource.notes).toEqual(["no summary present"]);
+			});
+		});
+
+		it("?frontmatter=1 returns no-frontmatter note for a doc without YAML head", async () => {
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				await writeDoc(memoryRoot, "memory/plain.md", "# plain\n\nbody\n");
+
+				const router = InternalUrlRouter.instance();
+				const resource = await router.resolve("knowledge://memory/plain.md?frontmatter=1");
+
+				expect(resource.content).toBe("");
+				expect(resource.notes).toEqual(["no frontmatter present"]);
+			});
+		});
+	});
+
+	describe("dangling body markers", () => {
+		it("?part=body strips orphan start/end markers when only one is present", async () => {
+			const orphanDoc = `---\nid: kd_orph\ntitle: Orphan\n---\n# Orphan\n\n<!-- omp:body:start -->\nbody-bytes\n`;
+			await withKnowledgeFixture(async ({ memoryRoot }) => {
+				await writeDoc(memoryRoot, "memory/orphan.md", orphanDoc);
+
+				const router = InternalUrlRouter.instance();
+				const resource = await router.resolve("knowledge://memory/orphan.md?part=body");
+
+				expect(resource.content).not.toContain("omp:body:start");
+				expect(resource.content).not.toContain("omp:body:end");
+				expect(resource.content).toContain("body-bytes");
+			});
+		});
+	});
+
+	describe("error message scheme labels", () => {
+		it("traversal error names knowledge:// (not skill://)", async () => {
+			await withKnowledgeFixture(async () => {
+				const router = InternalUrlRouter.instance();
+				await expect(router.resolve("knowledge://memory/../secret.md")).rejects.toThrow(
+					"Path traversal (..) is not allowed in knowledge:// URLs",
+				);
+			});
+		});
+	});
+});

--- a/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/memory-protocol.test.ts
@@ -57,29 +57,103 @@ describe("MemoryProtocolHandler", () => {
 		InternalUrlRouter.resetForTests();
 	});
 
-	it("resolves memory://root to memory_summary.md", async () => {
+	it("resolves memory://root to memory/memory_summary.md (new layout)", async () => {
 		await withMemoryFixture(async ({ memoryRoot }) => {
-			await Bun.write(path.join(memoryRoot, "memory_summary.md"), "summary");
+			await fs.mkdir(path.join(memoryRoot, "memory"), { recursive: true });
+			await Bun.write(path.join(memoryRoot, "memory", "memory_summary.md"), "new-shape summary");
 
 			const router = InternalUrlRouter.instance();
 			const resource = await router.resolve("memory://root");
 
-			expect(resource.content).toBe("summary");
+			expect(resource.content).toBe("new-shape summary");
 			expect(resource.contentType).toBe("text/markdown");
+		});
+	});
+
+	it("falls back to legacy memory_summary.md at the root", async () => {
+		await withMemoryFixture(async ({ memoryRoot }) => {
+			await Bun.write(path.join(memoryRoot, "memory_summary.md"), "legacy summary");
+
+			const router = InternalUrlRouter.instance();
+			const resource = await router.resolve("memory://root");
+
+			expect(resource.content).toBe("legacy summary");
+		});
+	});
+
+	it("redirects memory://root/memory/MEMORY.md to legacy MEMORY.md when only legacy exists", async () => {
+		await withMemoryFixture(async ({ memoryRoot }) => {
+			await Bun.write(path.join(memoryRoot, "MEMORY.md"), "legacy memory body");
+
+			const router = InternalUrlRouter.instance();
+			const resource = await router.resolve("memory://root/memory/MEMORY.md");
+
+			expect(resource.content).toBe("legacy memory body");
+		});
+	});
+
+	it("redirects legacy memory://root/MEMORY.md to new memory/MEMORY.md when only new exists", async () => {
+		await withMemoryFixture(async ({ memoryRoot }) => {
+			await fs.mkdir(path.join(memoryRoot, "memory"), { recursive: true });
+			await Bun.write(path.join(memoryRoot, "memory", "MEMORY.md"), "new memory body");
+
+			const router = InternalUrlRouter.instance();
+			const resource = await router.resolve("memory://root/MEMORY.md");
+
+			expect(resource.content).toBe("new memory body");
+		});
+	});
+
+	it("redirects memory://root/skill/<name>/SKILL.md to legacy skills/<name>/SKILL.md", async () => {
+		await withMemoryFixture(async ({ memoryRoot }) => {
+			const legacy = path.join(memoryRoot, "skills", "old", "SKILL.md");
+			await fs.mkdir(path.dirname(legacy), { recursive: true });
+			await Bun.write(legacy, "legacy skill body");
+
+			const router = InternalUrlRouter.instance();
+			const resource = await router.resolve("memory://root/skill/old/SKILL.md");
+
+			expect(resource.content).toBe("legacy skill body");
+		});
+	});
+
+	it("redirects legacy memory://root/skills/<name>/SKILL.md to new skill/<name>/SKILL.md", async () => {
+		await withMemoryFixture(async ({ memoryRoot }) => {
+			const newPath = path.join(memoryRoot, "skill", "fresh", "SKILL.md");
+			await fs.mkdir(path.dirname(newPath), { recursive: true });
+			await Bun.write(newPath, "new-shape skill body");
+
+			const router = InternalUrlRouter.instance();
+			const resource = await router.resolve("memory://root/skills/fresh/SKILL.md");
+
+			expect(resource.content).toBe("new-shape skill body");
 		});
 	});
 
 	it("resolves memory://root/<path> within memory root", async () => {
 		await withMemoryFixture(async ({ memoryRoot }) => {
-			const skillPath = path.join(memoryRoot, "skills", "demo", "SKILL.md");
+			const skillPath = path.join(memoryRoot, "skill", "demo", "SKILL.md");
 			await fs.mkdir(path.dirname(skillPath), { recursive: true });
 			await Bun.write(skillPath, "demo skill");
 
 			const router = InternalUrlRouter.instance();
-			const resource = await router.resolve("memory://root/skills/demo/SKILL.md");
+			const resource = await router.resolve("memory://root/skill/demo/SKILL.md");
 
 			expect(resource.content).toBe("demo skill");
 			expect(resource.contentType).toBe("text/markdown");
+		});
+	});
+
+	it("serves .omp-meta sidecars as text/plain", async () => {
+		await withMemoryFixture(async ({ memoryRoot }) => {
+			const sidecar = path.join(memoryRoot, "memory.omp-meta");
+			await Bun.write(sidecar, "aiMaintained: false\n");
+
+			const router = InternalUrlRouter.instance();
+			const resource = await router.resolve("memory://root/memory.omp-meta");
+
+			expect(resource.content).toBe("aiMaintained: false\n");
+			expect(resource.contentType).toBe("text/plain");
 		});
 	});
 

--- a/packages/coding-agent/test/memories-runtime.test.ts
+++ b/packages/coding-agent/test/memories-runtime.test.ts
@@ -211,16 +211,23 @@ describe("memories runtime", () => {
 		});
 
 		const memoryRoot = getMemoryRoot(fx.agentDir, fx.session.sessionManager.getCwd());
+		const bodyOf = (raw: string): string => {
+			const start = raw.indexOf("<!-- omp:body:start -->");
+			const end = raw.indexOf("<!-- omp:body:end -->");
+			return start === -1 || end === -1
+				? raw.trim()
+				: raw.slice(start + "<!-- omp:body:start -->".length, end).trim();
+		};
 		await waitFor(async () => {
-			expect((await fs.readFile(path.join(memoryRoot, "MEMORY.md"), "utf8")).trim()).toBe(
+			expect(bodyOf(await fs.readFile(path.join(memoryRoot, "memory", "MEMORY.md"), "utf8"))).toBe(
 				"# Memory\n\nConsolidated body",
 			);
-			expect((await fs.readFile(path.join(memoryRoot, "memory_summary.md"), "utf8")).trim()).toBe(
+			expect(bodyOf(await fs.readFile(path.join(memoryRoot, "memory", "memory_summary.md"), "utf8"))).toBe(
 				"Consolidated summary",
 			);
-			expect(
-				(await fs.readFile(path.join(memoryRoot, "skills", "deploy-playbook", "SKILL.md"), "utf8")).trim(),
-			).toBe("# Deploy\nUse blue/green.");
+			expect(bodyOf(await fs.readFile(path.join(memoryRoot, "skill", "deploy-playbook", "SKILL.md"), "utf8"))).toBe(
+				"# Deploy\nUse blue/green.",
+			);
 		});
 
 		expect(fx.session.refreshBaseSystemPrompt).toHaveBeenCalledTimes(1);
@@ -349,7 +356,7 @@ describe("buildMemoryToolDeveloperInstructions", () => {
 
 	test("returns undefined for missing or empty summaries", async () => {
 		const agentDir = await makeTempDir("memories-runtime-instructions");
-		const settings = Settings.isolated({ "memory.backend": "local" });
+		const settings = Settings.isolated({ "memory.backend": "local", "knowledge.enabled": false });
 
 		expect(await buildMemoryToolDeveloperInstructions(agentDir, settings)).toBeUndefined();
 
@@ -364,6 +371,7 @@ describe("buildMemoryToolDeveloperInstructions", () => {
 		const settings = Settings.isolated({
 			"memory.backend": "local",
 			"memories.summaryInjectionTokenLimit": 8,
+			"knowledge.enabled": false,
 		});
 		const memoryRoot = getMemoryRoot(agentDir, settings.getCwd());
 		await fs.mkdir(memoryRoot, { recursive: true });
@@ -374,7 +382,7 @@ describe("buildMemoryToolDeveloperInstructions", () => {
 
 		const payload = await buildMemoryToolDeveloperInstructions(agentDir, settings);
 		expect(payload).toBeDefined();
-		expect(payload).toContain("memory://root/memory_summary.md");
+		expect(payload).toContain("memory://root/memory/memory_summary.md");
 		expect(payload).not.toContain(memoryRoot);
 		expect(payload).toContain("...[truncated]...");
 	});

--- a/packages/coding-agent/test/memories/instructions.test.ts
+++ b/packages/coding-agent/test/memories/instructions.test.ts
@@ -15,18 +15,67 @@ async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
 }
 
 describe("buildMemoryToolDeveloperInstructions", () => {
-	it("uses memory:// URLs and does not expose raw memory root paths", async () => {
+	it("uses memory:// URLs under the new taxonomy and does not expose raw memory root paths", async () => {
+		await withTempDir(async agentDir => {
+			const settings = Settings.isolated({ "memories.enabled": true });
+			const memoryRoot = getMemoryRoot(agentDir, settings.getCwd());
+			await fs.mkdir(path.join(memoryRoot, "memory"), { recursive: true });
+			await Bun.write(
+				path.join(memoryRoot, "memory", "memory_summary.md"),
+				"Use structured retries for flaky network calls.",
+			);
+
+			const instructions = await buildMemoryToolDeveloperInstructions(agentDir, settings);
+			expect(instructions).toBeDefined();
+			expect(instructions).toContain("memory://root/memory/memory_summary.md");
+			expect(instructions).toContain("memory://root/skill/<name>/SKILL.md");
+			expect(instructions).toContain("Use structured retries for flaky network calls.");
+			expect(instructions).not.toContain(memoryRoot);
+		});
+	});
+
+	it("falls back to legacy memory_summary.md when the new-shape file is missing", async () => {
 		await withTempDir(async agentDir => {
 			const settings = Settings.isolated({ "memories.enabled": true });
 			const memoryRoot = getMemoryRoot(agentDir, settings.getCwd());
 			await fs.mkdir(memoryRoot, { recursive: true });
-			await Bun.write(path.join(memoryRoot, "memory_summary.md"), "Use structured retries for flaky network calls.");
+			await Bun.write(path.join(memoryRoot, "memory_summary.md"), "Legacy summary content.");
 
 			const instructions = await buildMemoryToolDeveloperInstructions(agentDir, settings);
 			expect(instructions).toBeDefined();
-			expect(instructions).toContain("memory://root/memory_summary.md");
-			expect(instructions).toContain("memory://root/skills/<name>/SKILL.md");
-			expect(instructions).not.toContain(memoryRoot);
+			expect(instructions).toContain("Legacy summary content.");
+		});
+	});
+
+	it("surfaces only the body region when the summary uses body markers", async () => {
+		await withTempDir(async agentDir => {
+			const settings = Settings.isolated({ "memories.enabled": true });
+			const memoryRoot = getMemoryRoot(agentDir, settings.getCwd());
+			await fs.mkdir(path.join(memoryRoot, "memory"), { recursive: true });
+			const docPath = path.join(memoryRoot, "memory", "memory_summary.md");
+			await Bun.write(
+				docPath,
+				[
+					"---",
+					"type: memory",
+					"injectMode: summary",
+					"---",
+					"# Memory Summary",
+					"",
+					"## Summary",
+					"Frontmatter summary block — should NOT appear in injection.",
+					"",
+					"<!-- omp:body:start -->",
+					"Body-only guidance must be the only thing injected.",
+					"<!-- omp:body:end -->",
+					"",
+				].join("\n"),
+			);
+
+			const instructions = await buildMemoryToolDeveloperInstructions(agentDir, settings);
+			expect(instructions).toBeDefined();
+			expect(instructions).toContain("Body-only guidance must be the only thing injected.");
+			expect(instructions).not.toContain("Frontmatter summary block");
 		});
 	});
 });

--- a/packages/coding-agent/test/memories/knowledge-ops.test.ts
+++ b/packages/coding-agent/test/memories/knowledge-ops.test.ts
@@ -1,0 +1,1087 @@
+// Coverage for the knowledge ops layer used by the seven knowledge
+// tools. Verifies path validation, body-marker rewrite, permission
+// gating, and cross-type guardrails.
+
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { sidecarPathForDirectory, stringifySidecar, TYPE_DIRS } from "../../src/memories/directory-config";
+import { parseMemoryDoc } from "../../src/memories/document";
+import {
+	extractSummarySection,
+	KnowledgeOpsError,
+	knowledgeCreateDirectory,
+	knowledgeCreateDocument,
+	knowledgeDelete,
+	knowledgeEditDocument,
+	knowledgeList,
+	knowledgeMove,
+	knowledgeQuery,
+	knowledgeRead,
+	resolveKnowledgePath,
+} from "../../src/memories/knowledge-ops";
+
+async function withTempRoot<T>(fn: (memoryRoot: string) => Promise<T>): Promise<T> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "knowledge-ops-"));
+	try {
+		const memoryRoot = path.join(dir, "memory-root");
+		await fs.mkdir(memoryRoot, { recursive: true });
+		return await fn(memoryRoot);
+	} finally {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+}
+
+describe("resolveKnowledgePath", () => {
+	it("rejects missing type prefix", () => {
+		expect(() => resolveKnowledgePath("/tmp/root", "foo.md", "document")).toThrow(/Unknown knowledge type/);
+	});
+
+	it("rejects path traversal", () => {
+		expect(() => resolveKnowledgePath("/tmp/root", "memory/../foo.md", "document")).toThrow(/'.'/);
+		expect(() => resolveKnowledgePath("/tmp/root", "memory/./foo.md", "document")).toThrow(/'.'/);
+	});
+
+	it("rejects sidecar paths", () => {
+		expect(() => resolveKnowledgePath("/tmp/root", "memory/topic.omp-meta", "document")).toThrow(/omp-meta/);
+	});
+
+	it("requires .md for documents and rejects it for directories", () => {
+		expect(() => resolveKnowledgePath("/tmp/root", "memory/foo", "document")).toThrow(/must end with .md/);
+		expect(() => resolveKnowledgePath("/tmp/root", "memory/foo.md", "directory")).toThrow(/must not end with .md/);
+	});
+
+	it("returns a resolved descriptor for valid input", () => {
+		const r = resolveKnowledgePath("/tmp/root", "skill/sbox/import.md", "document");
+		expect(r.type).toBe("skill");
+		expect(r.relFromTypeRoot).toBe("sbox/import.md");
+		expect(r.canonical).toBe("skill/sbox/import.md");
+		expect(r.absPath).toContain(`${path.sep}skill${path.sep}sbox${path.sep}import.md`);
+	});
+});
+
+describe("knowledgeList", () => {
+	it("lists across every type root when no prefix is given", async () => {
+		await withTempRoot(async memoryRoot => {
+			await fs.mkdir(path.join(memoryRoot, "memory"), { recursive: true });
+			await fs.mkdir(path.join(memoryRoot, "skill", "ops"), { recursive: true });
+			await fs.mkdir(path.join(memoryRoot, "design"), { recursive: true });
+			await Bun.write(path.join(memoryRoot, "memory", "MEMORY.md"), "x");
+			await Bun.write(path.join(memoryRoot, "skill", "ops", "SKILL.md"), "y");
+			await Bun.write(path.join(memoryRoot, "design", "rfc-001.md"), "z");
+
+			const entries = await knowledgeList(memoryRoot);
+			const docs = entries.filter(e => e.kind === "document").map(e => e.path);
+			expect(docs).toContain("memory/MEMORY.md");
+			expect(docs).toContain("skill/ops/SKILL.md");
+			expect(docs).toContain("design/rfc-001.md");
+			// Directories surfaced too.
+			expect(entries.some(e => e.kind === "directory" && e.path === "skill/ops")).toBe(true);
+		});
+	});
+
+	it("filters by pathPrefix", async () => {
+		await withTempRoot(async memoryRoot => {
+			await fs.mkdir(path.join(memoryRoot, "memory"), { recursive: true });
+			await fs.mkdir(path.join(memoryRoot, "skill"), { recursive: true });
+			await Bun.write(path.join(memoryRoot, "memory", "a.md"), "x");
+			await Bun.write(path.join(memoryRoot, "skill", "b.md"), "y");
+
+			const entries = await knowledgeList(memoryRoot, "memory/");
+			expect(entries.every(e => e.path.startsWith("memory/"))).toBe(true);
+			expect(entries.some(e => e.path === "memory/a.md")).toBe(true);
+			expect(entries.some(e => e.path === "skill/b.md")).toBe(false);
+		});
+	});
+
+	it("hides .omp-meta sidecars", async () => {
+		await withTempRoot(async memoryRoot => {
+			const memDir = path.join(memoryRoot, "memory");
+			await fs.mkdir(memDir, { recursive: true });
+			await Bun.write(path.join(memDir, "a.md"), "x");
+			await Bun.write(sidecarPathForDirectory(memDir), stringifySidecar({ aiMaintained: true }));
+
+			const entries = await knowledgeList(memoryRoot);
+			expect(entries.every(e => !e.path.endsWith(".omp-meta"))).toBe(true);
+		});
+	});
+});
+
+describe("knowledgeCreateDocument", () => {
+	it("creates a document with body markers and frontmatter", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/notes.md", {
+				summary: "Stub summary",
+				body: "Body text here.",
+			});
+			const raw = await Bun.file(path.join(memoryRoot, "memory", "notes.md")).text();
+			expect(raw).toContain("<!-- omp:body:start -->");
+			expect(raw).toContain("Body text here.");
+			expect(raw).toContain("Stub summary");
+			const fm = parseMemoryDoc(raw).frontmatter;
+			expect(fm.type).toBe("memory");
+			expect(fm.path).toBe("notes.md");
+			expect(fm.aiMaintained).toBe(true);
+			expect(fm.inheritAiConfig).toBe(true);
+		});
+	});
+
+	it("refuses to overwrite an existing document", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/notes.md", { body: "v1" });
+			await expect(knowledgeCreateDocument(memoryRoot, "memory/notes.md", { body: "v2" })).rejects.toThrow(
+				/already exists/,
+			);
+		});
+	});
+
+	it("honors allowCreateDocuments: false on the parent sidecar", async () => {
+		await withTempRoot(async memoryRoot => {
+			const memDir = path.join(memoryRoot, "memory");
+			await fs.mkdir(memDir, { recursive: true });
+			await Bun.write(sidecarPathForDirectory(memDir), stringifySidecar({ allowCreateDocuments: false }));
+
+			await expect(knowledgeCreateDocument(memoryRoot, "memory/blocked.md", { body: "x" })).rejects.toThrow(
+				/denies new docs/,
+			);
+		});
+	});
+
+	it("persists commandEnabled in frontmatter when requested", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/with-cmd.md", {
+				body: "body",
+				commandEnabled: true,
+			});
+			const raw = await Bun.file(path.join(memoryRoot, "memory", "with-cmd.md")).text();
+			expect(parseMemoryDoc(raw).frontmatter.commandEnabled).toBe(true);
+		});
+	});
+
+	it("omits commandEnabled from frontmatter when falsy or absent", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/no-cmd.md", { body: "body" });
+			await knowledgeCreateDocument(memoryRoot, "memory/off-cmd.md", {
+				body: "body",
+				commandEnabled: false,
+			});
+			const a = await Bun.file(path.join(memoryRoot, "memory", "no-cmd.md")).text();
+			const b = await Bun.file(path.join(memoryRoot, "memory", "off-cmd.md")).text();
+			// `commandEnabled` MUST NOT be written when omitted or false — keeps
+			// the on-disk frontmatter quiet for the common case.
+			expect(a).not.toContain("commandEnabled");
+			expect(b).not.toContain("commandEnabled");
+			expect(parseMemoryDoc(a).frontmatter.commandEnabled).toBeUndefined();
+			expect(parseMemoryDoc(b).frontmatter.commandEnabled).toBeUndefined();
+		});
+	});
+});
+
+describe("knowledgeRead", () => {
+	it("returns body-only when part=body", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/notes.md", {
+				summary: "summary text",
+				body: "body text",
+			});
+			const result = await knowledgeRead(memoryRoot, "memory/notes.md", "body");
+			expect(result.content).toBe("body text");
+			expect(result.content).not.toContain("summary text");
+		});
+	});
+
+	it("returns frontmatter summary when part=summary", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/notes.md", {
+				summary: "the summary",
+				body: "body",
+			});
+			const result = await knowledgeRead(memoryRoot, "memory/notes.md", "summary");
+			expect(result.content).toBe("the summary");
+		});
+	});
+
+	it("renders an agent-friendly markdown view when part=full", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/notes.md", { body: "body" });
+			const result = await knowledgeRead(memoryRoot, "memory/notes.md", "full");
+			// New behavior (G17): full reads strip frontmatter + omp comment markers
+			// and reformat into headings so the LLM only sees the agent surface.
+			expect(result.content).not.toContain("---");
+			expect(result.content).not.toContain("<!-- omp:");
+			expect(result.content).toContain("# notes");
+			expect(result.content).toContain("## Content");
+			expect(result.content).toContain("body");
+		});
+	});
+
+	it("throws not_found for missing documents", async () => {
+		await withTempRoot(async memoryRoot => {
+			await expect(knowledgeRead(memoryRoot, "memory/missing.md")).rejects.toThrow(/not found/);
+		});
+	});
+});
+
+describe("knowledgeEditDocument", () => {
+	it("body-only patch preserves frontmatter and summary bytes", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/notes.md", {
+				summary: "keep me",
+				body: "first body",
+			});
+			const before = await Bun.file(path.join(memoryRoot, "memory", "notes.md")).text();
+			const beforeFrontmatter = before.split("<!-- omp:body:start -->")[0];
+
+			await knowledgeEditDocument(memoryRoot, "memory/notes.md", { body: "second body" });
+
+			const after = await Bun.file(path.join(memoryRoot, "memory", "notes.md")).text();
+			expect(after).toContain("second body");
+			expect(after).not.toContain("first body");
+			// Non-body bytes survive byte-for-byte except for the createdAt/updatedAt timestamps
+			// which buildMemoryDoc would refresh; body-only path uses rewriteDocBody.
+			expect(after.split("<!-- omp:body:start -->")[0]).toBe(beforeFrontmatter);
+		});
+	});
+
+	it("refuses to edit user-authored docs (no body markers)", async () => {
+		await withTempRoot(async memoryRoot => {
+			const p = path.join(memoryRoot, "memory", "user.md");
+			await fs.mkdir(path.dirname(p), { recursive: true });
+			await Bun.write(p, "# User\n\nhand-authored, no markers.\n");
+
+			await expect(knowledgeEditDocument(memoryRoot, "memory/user.md", { body: "ai body" })).rejects.toThrow(
+				/user-authored/,
+			);
+
+			const after = await Bun.file(p).text();
+			expect(after).toBe("# User\n\nhand-authored, no markers.\n");
+		});
+	});
+
+	it("refuses to edit user-protected docs without an approvalSink", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/notes.md", { body: "v1" });
+			const p = path.join(memoryRoot, "memory", "notes.md");
+			const orig = await Bun.file(p).text();
+			await Bun.write(
+				p,
+				orig
+					.replace("aiMaintained: true", "aiMaintained: false")
+					.replace("inheritAiConfig: true", "inheritAiConfig: false"),
+			);
+
+			await expect(knowledgeEditDocument(memoryRoot, "memory/notes.md", { body: "v2" })).rejects.toThrow(
+				/user approval required/,
+			);
+			expect(await Bun.file(p).text()).toBe(
+				orig
+					.replace("aiMaintained: true", "aiMaintained: false")
+					.replace("inheritAiConfig: true", "inheritAiConfig: false"),
+			);
+		});
+	});
+
+	it("routes edit through approvalSink when target has aiMaintained: false (apply path)", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/notes.md", { body: "v1" });
+			const p = path.join(memoryRoot, "memory", "notes.md");
+			const orig = await Bun.file(p).text();
+			await Bun.write(
+				p,
+				orig
+					.replace("aiMaintained: true", "aiMaintained: false")
+					.replace("inheritAiConfig: true", "inheritAiConfig: false"),
+			);
+
+			let previewedKind: string | undefined;
+			const outcome = await knowledgeEditDocument(
+				memoryRoot,
+				"memory/notes.md",
+				{ body: "v2" },
+				{
+					approvalSink: async request => {
+						previewedKind = request.preview.kind;
+						await request.apply();
+					},
+				},
+			);
+			expect(previewedKind).toBe("edit");
+			expect(outcome.applied).toBe(true);
+			expect(outcome.requiredApproval).toBe(true);
+			expect(await Bun.file(p).text()).toContain("v2");
+		});
+	});
+
+	it("routes edit through approvalSink but does NOT write when sink withholds apply", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/notes.md", { body: "v1" });
+			const p = path.join(memoryRoot, "memory", "notes.md");
+			const orig = await Bun.file(p).text();
+			await Bun.write(
+				p,
+				orig
+					.replace("aiMaintained: true", "aiMaintained: false")
+					.replace("inheritAiConfig: true", "inheritAiConfig: false"),
+			);
+			const beforeBytes = await Bun.file(p).text();
+
+			const outcome = await knowledgeEditDocument(
+				memoryRoot,
+				"memory/notes.md",
+				{ body: "v2 should not land" },
+				{
+					approvalSink: async _request => {
+						// User declined / discarded — never invoke apply.
+					},
+				},
+			);
+			expect(outcome.applied).toBe(false);
+			expect(outcome.requiredApproval).toBe(true);
+			expect(await Bun.file(p).text()).toBe(beforeBytes);
+		});
+	});
+
+	it("design/ creates require approval; no-sink call refuses", async () => {
+		await withTempRoot(async memoryRoot => {
+			await expect(knowledgeCreateDocument(memoryRoot, "design/architecture.md", { body: "x" })).rejects.toThrow(
+				/user approval required/,
+			);
+			expect(await Bun.file(path.join(memoryRoot, "design", "architecture.md")).exists()).toBe(false);
+		});
+	});
+
+	it("design/ creates with auto-approve sink succeed and inherit aiMaintained: false", async () => {
+		await withTempRoot(async memoryRoot => {
+			const outcome = await knowledgeCreateDocument(
+				memoryRoot,
+				"design/architecture.md",
+				{ body: "AI-proposed architecture body" },
+				{
+					approvalSink: async req => {
+						await req.apply();
+					},
+				},
+			);
+			expect(outcome.applied).toBe(true);
+			expect(outcome.requiredApproval).toBe(true);
+			const written = await Bun.file(path.join(memoryRoot, "design", "architecture.md")).text();
+			expect(written).toContain("<!-- omp:body:start -->");
+			expect(written).toContain("AI-proposed architecture body");
+			expect(written).toContain("aiMaintained: false");
+		});
+	});
+});
+
+describe("knowledgeMove", () => {
+	it("renames a document within the same type", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/old.md", { body: "x" });
+			await knowledgeMove(memoryRoot, "memory/old.md", "memory/new.md", "document");
+			expect(await Bun.file(path.join(memoryRoot, "memory", "new.md")).exists()).toBe(true);
+			expect(await Bun.file(path.join(memoryRoot, "memory", "old.md")).exists()).toBe(false);
+		});
+	});
+
+	it("refuses cross-type moves", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/x.md", { body: "x" });
+			await expect(knowledgeMove(memoryRoot, "memory/x.md", "skill/x.md", "document")).rejects.toThrow(
+				/Cross-type move/,
+			);
+		});
+	});
+
+	it("refuses overwriting an existing destination", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/a.md", { body: "a" });
+			await knowledgeCreateDocument(memoryRoot, "memory/b.md", { body: "b" });
+			await expect(knowledgeMove(memoryRoot, "memory/a.md", "memory/b.md", "document")).rejects.toThrow(
+				/already exists/,
+			);
+		});
+	});
+
+	it("refuses to rename a taxonomy root directory (source side)", async () => {
+		await withTempRoot(async memoryRoot => {
+			await expect(knowledgeMove(memoryRoot, "memory", "memory/archive", "directory")).rejects.toThrow(
+				/taxonomy root/,
+			);
+		});
+	});
+
+	it("refuses to rename onto a taxonomy root directory (destination side)", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDirectory(memoryRoot, "memory/archive");
+			await expect(knowledgeMove(memoryRoot, "memory/archive", "memory", "directory")).rejects.toThrow(
+				/taxonomy root/,
+			);
+		});
+	});
+});
+
+describe("knowledgeDelete", () => {
+	it("deletes an AI-maintained document", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/x.md", { body: "x" });
+			await knowledgeDelete(memoryRoot, "memory/x.md", "document");
+			expect(await Bun.file(path.join(memoryRoot, "memory", "x.md")).exists()).toBe(false);
+		});
+	});
+
+	it("refuses to delete user-protected documents without approvalSink", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/x.md", { body: "x" });
+			const p = path.join(memoryRoot, "memory", "x.md");
+			const orig = await Bun.file(p).text();
+			await Bun.write(
+				p,
+				orig
+					.replace("aiMaintained: true", "aiMaintained: false")
+					.replace("inheritAiConfig: true", "inheritAiConfig: false"),
+			);
+
+			await expect(knowledgeDelete(memoryRoot, "memory/x.md", "document")).rejects.toThrow(/user approval required/);
+			expect(await Bun.file(p).exists()).toBe(true);
+		});
+	});
+
+	it("routes delete through approvalSink when target has aiMaintained: false", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/x.md", { body: "x" });
+			const p = path.join(memoryRoot, "memory", "x.md");
+			const orig = await Bun.file(p).text();
+			await Bun.write(
+				p,
+				orig
+					.replace("aiMaintained: true", "aiMaintained: false")
+					.replace("inheritAiConfig: true", "inheritAiConfig: false"),
+			);
+
+			const outcome = await knowledgeDelete(memoryRoot, "memory/x.md", "document", {
+				approvalSink: async req => {
+					await req.apply();
+				},
+			});
+			expect(outcome.applied).toBe(true);
+			expect(outcome.requiredApproval).toBe(true);
+			expect(await Bun.file(p).exists()).toBe(false);
+		});
+	});
+
+	it("refuses to delete under reference/ (read-only type root)", async () => {
+		await withTempRoot(async memoryRoot => {
+			const p = path.join(memoryRoot, "reference", "ext.md");
+			await fs.mkdir(path.dirname(p), { recursive: true });
+			await Bun.write(p, "external");
+
+			await expect(knowledgeDelete(memoryRoot, "reference/ext.md", "document")).rejects.toThrow(/read-only/);
+		});
+	});
+});
+
+describe("knowledgeQuery", () => {
+	it("ranks hits by term coverage", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/auth.md", {
+				summary: "OIDC + WebAuthn fallback",
+				body: "Use the OIDC provider for primary auth; WebAuthn handles MFA fallback.",
+			});
+			await knowledgeCreateDocument(memoryRoot, "memory/unrelated.md", {
+				body: "Nothing relevant in this file.",
+			});
+			await knowledgeCreateDocument(memoryRoot, "skill/auth-runbook.md", {
+				body: "Auth runbook: rotate OIDC client secret every quarter.",
+			});
+
+			const hits = await knowledgeQuery(memoryRoot, { lexicalQuery: "OIDC auth", limit: 5 });
+			expect(hits.length).toBeGreaterThanOrEqual(2);
+			expect(hits[0].path === "memory/auth.md" || hits[0].path === "skill/auth-runbook.md").toBe(true);
+			expect(hits.some(h => h.path === "memory/unrelated.md")).toBe(false);
+		});
+	});
+
+	it("returns empty when no terms match", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/a.md", { body: "alpha" });
+			const hits = await knowledgeQuery(memoryRoot, { lexicalQuery: "zzzz-no-match" });
+			expect(hits).toEqual([]);
+		});
+	});
+
+	it("respects pathPrefix scoping", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/auth.md", { body: "auth in memory" });
+			await knowledgeCreateDocument(memoryRoot, "skill/auth.md", { body: "auth in skill" });
+
+			const hits = await knowledgeQuery(memoryRoot, { lexicalQuery: "auth", pathPrefix: "skill/" });
+			expect(hits.every(h => h.path.startsWith("skill/"))).toBe(true);
+			expect(hits.some(h => h.path === "skill/auth.md")).toBe(true);
+		});
+	});
+
+	it("routes queries through a custom ranker when one is provided", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/a.md", { body: "alpha alpha alpha" });
+			await knowledgeCreateDocument(memoryRoot, "memory/b.md", { body: "alpha" });
+
+			// Custom ranker: prefer documents whose canonical path ends in "b.md".
+			const hits = await knowledgeQuery(memoryRoot, {
+				lexicalQuery: "alpha",
+				ranker: {
+					async rank({ candidates }) {
+						return candidates
+							.map(c => ({
+								path: c.entry.path,
+								type: c.entry.type,
+								title: c.title,
+								score: c.entry.path.endsWith("b.md") ? 100 : 1,
+								snippet: "",
+							}))
+							.sort((x, y) => y.score - x.score);
+					},
+				},
+			});
+			expect(hits.length).toBe(2);
+			expect(hits[0].path).toBe("memory/b.md");
+			expect(hits[0].score).toBe(100);
+		});
+	});
+
+	it("routes `semanticQuery` through the default (lexical) ranker", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/auth.md", {
+				body: "Use the OIDC provider for primary auth.",
+			});
+			const hits = await knowledgeQuery(memoryRoot, { semanticQuery: "OIDC" });
+			expect(hits.some(h => h.path === "memory/auth.md")).toBe(true);
+		});
+	});
+});
+
+describe("knowledgeCreateDirectory", () => {
+	it("creates an empty directory and is idempotent", async () => {
+		await withTempRoot(async memoryRoot => {
+			const first = await knowledgeCreateDirectory(memoryRoot, "memory/topic");
+			expect(first).toEqual({ applied: true, requiredApproval: false });
+			const target = path.join(memoryRoot, "memory", "topic");
+			const stat = await fs.stat(target);
+			expect(stat.isDirectory()).toBe(true);
+
+			// Second call is a no-op — distinct from "pending approval" so the
+			// tool layer can report it as completed rather than dead-end the user.
+			const second = await knowledgeCreateDirectory(memoryRoot, "memory/topic");
+			expect(second).toEqual({ applied: false, requiredApproval: false });
+			expect((await fs.stat(target)).isDirectory()).toBe(true);
+		});
+	});
+
+	it("knowledgeMove with source === dest is a no-op (applied:false, requiredApproval:false)", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/foo.md", { body: "hi" });
+			const outcome = await knowledgeMove(memoryRoot, "memory/foo.md", "memory/foo.md", "document");
+			expect(outcome).toEqual({ applied: false, requiredApproval: false });
+		});
+	});
+
+	it("refuses to step on an existing file at the same path", async () => {
+		await withTempRoot(async memoryRoot => {
+			const p = path.join(memoryRoot, "memory", "thing");
+			await fs.mkdir(path.dirname(p), { recursive: true });
+			await Bun.write(p, "x");
+
+			await expect(knowledgeCreateDirectory(memoryRoot, "memory/thing")).rejects.toThrow(/not a directory/);
+		});
+	});
+});
+
+describe("review-fix regressions", () => {
+	it("extractSummarySection captures multi-paragraph bodies up to the next ## section", async () => {
+		const raw = "## Summary\nPara 1.\n\nPara 2.\n\n## Other\nfoo";
+		expect(extractSummarySection(raw)).toBe("Para 1.\n\nPara 2.");
+	});
+
+	it("extractSummarySection captures multi-paragraph bodies up to the omp body-end marker", async () => {
+		const raw = "## Summary\nA.\n\nB.\n<!-- omp:body:end -->\n";
+		expect(extractSummarySection(raw)).toBe("A.\n\nB.");
+	});
+
+	it("knowledgeMove (directory) refuses when the destination parent denies new directories", async () => {
+		await withTempRoot(async memoryRoot => {
+			// Source bucket allows dir creation by default.
+			await knowledgeCreateDirectory(memoryRoot, "memory/src");
+			// Destination parent exists already but locks down new dirs via sidecar.
+			const destParent = path.join(memoryRoot, TYPE_DIRS.memory);
+			await fs.writeFile(
+				sidecarPathForDirectory(destParent),
+				stringifySidecar({ version: 1, allowCreateDirectories: false, inheritToChildren: true }),
+			);
+			await expect(knowledgeMove(memoryRoot, "memory/src", "memory/dst", "directory")).rejects.toThrow(
+				/destination denies new directories/,
+			);
+		});
+	});
+});
+
+describe("KnowledgeOpsError code", () => {
+	it("carries a stable code", async () => {
+		await withTempRoot(async memoryRoot => {
+			try {
+				await knowledgeRead(memoryRoot, "memory/missing.md");
+				expect(false).toBe(true);
+			} catch (error) {
+				expect(error).toBeInstanceOf(KnowledgeOpsError);
+				expect((error as KnowledgeOpsError).code).toBe("not_found");
+			}
+		});
+	});
+});
+
+// Sanity-check TYPE_DIRS to keep the test file aligned with the source.
+describe("type-root layout", () => {
+	it("declares the four expected types", () => {
+		expect(Object.keys(TYPE_DIRS).sort()).toEqual(["design", "memory", "reference", "skill"]);
+	});
+});
+
+describe("policy gates added by PR review fixes", () => {
+	it("knowledgeCreateDirectory refuses bare taxonomy roots", async () => {
+		await withTempRoot(async memoryRoot => {
+			await expect(knowledgeCreateDirectory(memoryRoot, "memory")).rejects.toThrow(/taxonomy root directory/);
+		});
+	});
+
+	it("knowledgeCreateDirectory respects readOnly bucket (reference/)", async () => {
+		await withTempRoot(async memoryRoot => {
+			await expect(knowledgeCreateDirectory(memoryRoot, "reference/locked")).rejects.toThrow(/read-only/);
+		});
+	});
+
+	it("knowledgeCreateDirectory refuses when allowCreateDirectories=false", async () => {
+		await withTempRoot(async memoryRoot => {
+			await fs.mkdir(path.join(memoryRoot, TYPE_DIRS.memory), { recursive: true });
+			const sidecar = sidecarPathForDirectory(path.join(memoryRoot, TYPE_DIRS.memory));
+			await Bun.write(
+				sidecar,
+				stringifySidecar({ version: 1, allowCreateDirectories: false, inheritToChildren: true }),
+			);
+			await expect(knowledgeCreateDirectory(memoryRoot, "memory/nope")).rejects.toThrow(
+				/directory create not allowed/,
+			);
+		});
+	});
+
+	it("knowledgeCreateDirectory routes through approvalSink when requiresApproval", async () => {
+		await withTempRoot(async memoryRoot => {
+			let captured = false;
+			const outcome = await knowledgeCreateDirectory(memoryRoot, "design/proposals", {
+				approvalSink: async req => {
+					captured = true;
+					await req.apply();
+				},
+			});
+			expect(captured).toBe(true);
+			expect(outcome.requiredApproval).toBe(true);
+			expect(outcome.applied).toBe(true);
+		});
+	});
+
+	it("knowledgeCreateDocument leaves no parent dir behind when approval is withheld", async () => {
+		await withTempRoot(async memoryRoot => {
+			const outcome = await knowledgeCreateDocument(
+				memoryRoot,
+				"design/draft/note.md",
+				{ summary: "s", body: "b" },
+				{
+					approvalSink: async _req => {
+						// withhold: never call apply()
+					},
+				},
+			);
+			expect(outcome.applied).toBe(false);
+			expect(outcome.requiredApproval).toBe(true);
+			// Parent dir must NOT exist on disk.
+			const parentExists = await fs
+				.stat(path.join(memoryRoot, "design", "draft"))
+				.then(s => s.isDirectory())
+				.catch(() => false);
+			expect(parentExists).toBe(false);
+		});
+	});
+
+	it("knowledgeMove refuses document moves when allowMoveDocuments=false", async () => {
+		await withTempRoot(async memoryRoot => {
+			// Author a document under design/ where allowMoveDocuments defaults to false.
+			await knowledgeCreateDocument(
+				memoryRoot,
+				"design/a.md",
+				{ summary: "", body: "x" },
+				{ approvalSink: async req => req.apply() },
+			);
+			await expect(knowledgeMove(memoryRoot, "design/a.md", "design/sub/a.md", "document")).rejects.toThrow(
+				/document move not allowed/,
+			);
+		});
+	});
+
+	it("knowledgeMove refuses when destination denies new docs", async () => {
+		await withTempRoot(async memoryRoot => {
+			// Source under memory/ (moves allowed) → destination under a
+			// custom locked directory.
+			await knowledgeCreateDocument(memoryRoot, "memory/src.md", { body: "x" });
+			await fs.mkdir(path.join(memoryRoot, "memory", "locked"), { recursive: true });
+			await Bun.write(
+				sidecarPathForDirectory(path.join(memoryRoot, "memory", "locked")),
+				stringifySidecar({ version: 1, allowCreateDocuments: false }),
+			);
+			await expect(knowledgeMove(memoryRoot, "memory/src.md", "memory/locked/dst.md", "document")).rejects.toThrow(
+				/destination denies new docs/,
+			);
+		});
+	});
+
+	it("knowledgeMove (directory) moves the paired sidecar atomically", async () => {
+		await withTempRoot(async memoryRoot => {
+			const srcDir = path.join(memoryRoot, "memory", "topic");
+			await fs.mkdir(srcDir, { recursive: true });
+			const srcSidecar = sidecarPathForDirectory(srcDir);
+			await Bun.write(srcSidecar, stringifySidecar({ version: 1, summary: "topic-sidecar" }));
+
+			await knowledgeMove(memoryRoot, "memory/topic", "memory/renamed", "directory");
+
+			const destDir = path.join(memoryRoot, "memory", "renamed");
+			expect(await fs.stat(destDir).then(s => s.isDirectory())).toBe(true);
+			expect(await fs.stat(sidecarPathForDirectory(destDir)).then(s => s.isFile())).toBe(true);
+			await expect(fs.stat(srcSidecar)).rejects.toMatchObject({ code: "ENOENT" });
+		});
+	});
+
+	it("knowledgeDelete refuses bare taxonomy roots", async () => {
+		await withTempRoot(async memoryRoot => {
+			await fs.mkdir(path.join(memoryRoot, "memory"), { recursive: true });
+			await expect(knowledgeDelete(memoryRoot, "memory", "directory")).rejects.toThrow(/taxonomy root/);
+		});
+	});
+
+	it("knowledgeDelete (directory) removes the paired sidecar", async () => {
+		await withTempRoot(async memoryRoot => {
+			const dir = path.join(memoryRoot, "memory", "topic");
+			await fs.mkdir(dir, { recursive: true });
+			const sidecar = sidecarPathForDirectory(dir);
+			await Bun.write(sidecar, stringifySidecar({ version: 1 }));
+
+			await knowledgeDelete(memoryRoot, "memory/topic", "directory");
+
+			await expect(fs.stat(dir)).rejects.toMatchObject({ code: "ENOENT" });
+			await expect(fs.stat(sidecar)).rejects.toMatchObject({ code: "ENOENT" });
+		});
+	});
+
+	it("knowledgeQuery forwards semanticQuery to the ranker", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/note.md", { body: "alpha" });
+			let receivedSemantic = "";
+			const hits = await knowledgeQuery(memoryRoot, {
+				semanticQuery: "find-me",
+				lexicalQuery: undefined,
+				ranker: {
+					rank: async input => {
+						receivedSemantic = input.semanticQuery;
+						return input.candidates.map(c => ({
+							path: c.entry.path,
+							type: c.entry.type,
+							title: c.title,
+							score: 1,
+							snippet: "stub",
+						}));
+					},
+				},
+			});
+			expect(receivedSemantic).toBe("find-me");
+			expect(hits.length).toBe(1);
+		});
+	});
+});
+describe("gap-fix batch 1+2", () => {
+	it("G18: knowledge_edit refuses an empty patch", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/notes.md", { body: "body" });
+			await expect(knowledgeEditDocument(memoryRoot, "memory/notes.md", {})).rejects.toThrow(
+				/at least one of summary, body, or maintenanceRules/,
+			);
+		});
+	});
+
+	it("G1: knowledge_move kind=directory refuses on read-only descendant", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDirectory(memoryRoot, "memory/topic");
+			// Hand-write a doc with readOnly:true to simulate user lock.
+			const locked = path.join(memoryRoot, "memory", "topic", "locked.md");
+			await fs.writeFile(
+				locked,
+				"---\nreadOnly: true\n---\n# locked\n\n<!-- omp:body:start -->\nbody\n<!-- omp:body:end -->\n",
+			);
+			await expect(knowledgeMove(memoryRoot, "memory/topic", "memory/moved", "directory")).rejects.toThrow(
+				/contains read-only document/,
+			);
+		});
+	});
+
+	it("G2: knowledge_delete kind=directory refuses on read-only descendant", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDirectory(memoryRoot, "memory/topic");
+			const locked = path.join(memoryRoot, "memory", "topic", "locked.md");
+			await fs.writeFile(
+				locked,
+				"---\nreadOnly: true\n---\n# locked\n\n<!-- omp:body:start -->\nbody\n<!-- omp:body:end -->\n",
+			);
+			await expect(knowledgeDelete(memoryRoot, "memory/topic", "directory")).rejects.toThrow(
+				/contains read-only document/,
+			);
+		});
+	});
+
+	it("G3: inheritToChildren:false walls off ancestor overrides", async () => {
+		const { resolveDirectoryConfig } = await import("../../src/memories/directory-config");
+		await withTempRoot(async memoryRoot => {
+			// memory/A.omp-meta — allowCreateDocuments:false + inheritToChildren:true
+			const outer = path.join(memoryRoot, "memory", "A");
+			await fs.mkdir(outer, { recursive: true });
+			await fs.writeFile(
+				sidecarPathForDirectory(outer),
+				stringifySidecar({
+					allowCreateDocuments: false,
+					inheritToChildren: true,
+				}),
+			);
+			// memory/A/B.omp-meta — inheritToChildren:false (wall)
+			const wall = path.join(memoryRoot, "memory", "A", "B");
+			await fs.mkdir(wall, { recursive: true });
+			await fs.writeFile(sidecarPathForDirectory(wall), stringifySidecar({ inheritToChildren: false }));
+			// memory/A/B/C — descendant. Should NOT inherit allowCreateDocuments:false.
+			const child = path.join(memoryRoot, "memory", "A", "B", "C");
+			await fs.mkdir(child, { recursive: true });
+
+			const config = await resolveDirectoryConfig(memoryRoot, child);
+			expect(config).toBeDefined();
+			// Type default for memory is allowCreateDocuments:true. The wall
+			// drops A's override, so C falls back to type default.
+			expect(config!.allowCreateDocuments).toBe(true);
+		});
+	});
+
+	it("G14/G15/G16: query reports matchedSection and pulls snippet from matched section", async () => {
+		await withTempRoot(async memoryRoot => {
+			// Doc with summary in frontmatter — term lives only in summary.
+			await knowledgeCreateDocument(memoryRoot, "memory/alpha.md", {
+				summary: "uniquetermXYZ lives in the summary section.",
+				body: "unrelated body content",
+			});
+			// Doc with the term in title-derived path only.
+			await knowledgeCreateDocument(memoryRoot, "memory/needleword.md", {
+				body: "unrelated body content too",
+			});
+
+			const summaryHits = await knowledgeQuery(memoryRoot, { lexicalQuery: "uniquetermXYZ" });
+			expect(summaryHits.length).toBe(1);
+			expect(summaryHits[0].matchedSection).toBe("summary");
+			expect(summaryHits[0].snippet).toContain("uniquetermXYZ");
+
+			const pathHits = await knowledgeQuery(memoryRoot, { lexicalQuery: "needleword" });
+			const titlePath = pathHits.find(h => h.path === "memory/needleword.md");
+			expect(titlePath).toBeDefined();
+			// Title is derived from filename ("needleword"), so the match
+			// lands in title before path.
+			expect(titlePath!.matchedSection === "title" || titlePath!.matchedSection === "path").toBe(true);
+		});
+	});
+
+	it("G17: knowledge_read part=full strips frontmatter and comment markers", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/notes.md", {
+				summary: "the summary",
+				body: "the body",
+				maintenanceRules: "- rule one\n- rule two",
+			});
+			const result = await knowledgeRead(memoryRoot, "memory/notes.md", "full");
+			expect(result.content).not.toContain("---");
+			expect(result.content).not.toContain("<!-- omp:");
+			expect(result.content).toContain("# notes");
+			expect(result.content).toContain("## Summary");
+			expect(result.content).toContain("the summary");
+			expect(result.content).toContain("## Maintenance Rules");
+			expect(result.content).toContain("- rule one");
+			expect(result.content).toContain("## Content");
+			expect(result.content).toContain("the body");
+		});
+	});
+});
+
+describe("gap-fix batch 3", () => {
+	it("G11: refuses to create a skill doc with injectMode=full", async () => {
+		await withTempRoot(async memoryRoot => {
+			const skillRoot = path.join(memoryRoot, "skill");
+			await fs.mkdir(skillRoot, { recursive: true });
+			await fs.writeFile(sidecarPathForDirectory(skillRoot), stringifySidecar({ injectMode: "full" }));
+			await expect(knowledgeCreateDocument(memoryRoot, "skill/widget.md", { body: "x" })).rejects.toThrow(
+				/skill documents cannot use injectMode=full/,
+			);
+		});
+	});
+
+	it("G11: refuses to create a skill doc with injectMode=rule", async () => {
+		await withTempRoot(async memoryRoot => {
+			// reference/ would also be a target for the invariant, but its
+			// `readOnly: true` type default short-circuits create before we
+			// reach the validator. Skill is read-write, so this exercises the
+			// invariant directly.
+			const skillRoot = path.join(memoryRoot, "skill");
+			await fs.mkdir(skillRoot, { recursive: true });
+			await fs.writeFile(sidecarPathForDirectory(skillRoot), stringifySidecar({ injectMode: "rule" }));
+			await expect(knowledgeCreateDocument(memoryRoot, "skill/rule-spec.md", { body: "x" })).rejects.toThrow(
+				/skill documents cannot use injectMode=full or injectMode=rule/,
+			);
+		});
+	});
+
+	it("G11: auto-fills maintenance rules on AI-maintained memory docs", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/auto.md", { body: "body" });
+			const raw = await Bun.file(path.join(memoryRoot, "memory", "auto.md")).text();
+			// Auto-fill kicks in for the default memory bucket (aiMaintained=true).
+			expect(raw).toContain("omp:maintain-rules:start");
+			expect(raw).toContain("Keep entries durable and reusable");
+			// And the resulting frontmatter records the invariant inputs.
+			expect(raw).toContain("explicitMaintenanceRules: true");
+		});
+	});
+
+	it("G11: leaves design docs without rules (aiMaintained:false bypasses auto-fill)", async () => {
+		await withTempRoot(async memoryRoot => {
+			// Need an approval sink because design/ has aiMaintained:false.
+			let applied = false;
+			await knowledgeCreateDocument(
+				memoryRoot,
+				"design/sketch.md",
+				{ body: "body" },
+				{
+					approvalSink: async req => {
+						await req.apply();
+						applied = true;
+					},
+				},
+			);
+			expect(applied).toBe(true);
+			const raw = await Bun.file(path.join(memoryRoot, "design", "sketch.md")).text();
+			expect(raw).not.toContain("omp:maintain-rules:start");
+			expect(raw).toContain("explicitMaintenanceRules: false");
+		});
+	});
+
+	it("G9: summaryEnabled default tracks per-type (skill/reference=true)", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/m.md", { body: "x" });
+			await knowledgeCreateDocument(memoryRoot, "skill/s.md", { body: "x" });
+			const mem = parseMemoryDoc(await Bun.file(path.join(memoryRoot, "memory", "m.md")).text());
+			const skl = parseMemoryDoc(await Bun.file(path.join(memoryRoot, "skill", "s.md")).text());
+			expect(mem.frontmatter.summaryEnabled).toBe(false);
+			expect(skl.frontmatter.summaryEnabled).toBe(true);
+		});
+	});
+
+	it("G4: sidecar inheritInjectMode skips the dir's own injectMode override", async () => {
+		const { resolveDirectoryConfig } = await import("../../src/memories/directory-config");
+		await withTempRoot(async memoryRoot => {
+			// memory/A.omp-meta — injectMode=full, inheritToChildren=true
+			const outer = path.join(memoryRoot, "memory", "A");
+			await fs.mkdir(outer, { recursive: true });
+			await fs.writeFile(
+				sidecarPathForDirectory(outer),
+				stringifySidecar({ injectMode: "full", inheritToChildren: true }),
+			);
+			// memory/A/B.omp-meta — sets injectMode=rule but flags inheritInjectMode
+			// so its own injectMode is ignored and B inherits "full" from A.
+			const inner = path.join(memoryRoot, "memory", "A", "B");
+			await fs.mkdir(inner, { recursive: true });
+			await fs.writeFile(
+				sidecarPathForDirectory(inner),
+				stringifySidecar({ injectMode: "rule", inheritInjectMode: true }),
+			);
+
+			const config = await resolveDirectoryConfig(memoryRoot, inner);
+			expect(config).toBeDefined();
+			expect(config!.injectMode).toBe("full");
+		});
+	});
+
+	it("G4: sidecar inheritAiConfig skips the dir's own aiMaintained override", async () => {
+		const { resolveDirectoryConfig } = await import("../../src/memories/directory-config");
+		await withTempRoot(async memoryRoot => {
+			// memory/A.omp-meta — aiMaintained=false (a user-locked subtree),
+			// inheritToChildren=true so policy reaches descendants.
+			const outer = path.join(memoryRoot, "memory", "A");
+			await fs.mkdir(outer, { recursive: true });
+			await fs.writeFile(
+				sidecarPathForDirectory(outer),
+				stringifySidecar({ aiMaintained: false, inheritToChildren: true }),
+			);
+			// memory/A/B.omp-meta — declares aiMaintained=true but defers to A.
+			const inner = path.join(memoryRoot, "memory", "A", "B");
+			await fs.mkdir(inner, { recursive: true });
+			await fs.writeFile(
+				sidecarPathForDirectory(inner),
+				stringifySidecar({ aiMaintained: true, inheritAiConfig: true }),
+			);
+
+			const config = await resolveDirectoryConfig(memoryRoot, inner);
+			expect(config).toBeDefined();
+			expect(config!.aiMaintained).toBe(false);
+			expect(config!.requiresApproval).toBe(true);
+		});
+	});
+});
+
+describe("gap-fix batch 4", () => {
+	it("query: types[] filter restricts hits to the listed buckets", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/needle.md", {
+				body: "uniquetokenABC in body",
+			});
+			await knowledgeCreateDocument(memoryRoot, "skill/needle.md", {
+				body: "uniquetokenABC in body too",
+			});
+
+			const all = await knowledgeQuery(memoryRoot, { lexicalQuery: "uniquetokenABC" });
+			expect(all.map(h => h.path).sort()).toEqual(["memory/needle.md", "skill/needle.md"]);
+
+			const onlyMemory = await knowledgeQuery(memoryRoot, {
+				lexicalQuery: "uniquetokenABC",
+				types: ["memory"],
+			});
+			expect(onlyMemory.map(h => h.path)).toEqual(["memory/needle.md"]);
+
+			// Empty types array behaves like "no filter".
+			const empty = await knowledgeQuery(memoryRoot, {
+				lexicalQuery: "uniquetokenABC",
+				types: [],
+			});
+			expect(empty.length).toBe(2);
+		});
+	});
+
+	it("query: hits carry hasSummary / injectMode / aiMaintained / updatedAt", async () => {
+		await withTempRoot(async memoryRoot => {
+			await knowledgeCreateDocument(memoryRoot, "memory/withSummary.md", {
+				summary: "alpha bravo charlie",
+				body: "needletoken in body",
+			});
+			const hits = await knowledgeQuery(memoryRoot, { lexicalQuery: "needletoken" });
+			expect(hits.length).toBe(1);
+			const hit = hits[0];
+			expect(hit.hasSummary).toBe(true);
+			expect(hit.injectMode).toBe("none");
+			expect(hit.aiMaintained).toBe(true);
+			expect(typeof hit.updatedAt).toBe("number");
+		});
+	});
+});

--- a/packages/coding-agent/test/memories/taxonomy.test.ts
+++ b/packages/coding-agent/test/memories/taxonomy.test.ts
@@ -1,0 +1,832 @@
+// Coverage for the four-bucket taxonomy: typed buckets, .omp-meta
+// sidecars, body-marker rewrites, built-in seeds, and the
+// `applyConsolidation` / `cleanupConsolidatedArtifacts` guardrails that
+// keep user-owned files intact.
+
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { applyConsolidation, cleanupConsolidatedArtifacts } from "../../src/memories";
+import {
+	checkDeletePermission,
+	checkWritePermission,
+	renameDirectoryWithSidecar,
+	resolveDirectoryConfig,
+	resolveDocConfig,
+	sidecarPathForDirectory,
+	stringifySidecar,
+	TYPE_DIRS,
+} from "../../src/memories/directory-config";
+import { buildMemoryDoc, parseMemoryDoc, rewriteDocBody } from "../../src/memories/document";
+import { seedBuiltinDocs } from "../../src/memories/seed-docs";
+
+async function withTempRoot<T>(fn: (memoryRoot: string) => Promise<T>): Promise<T> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "memory-taxonomy-"));
+	try {
+		const memoryRoot = path.join(dir, "memory-root");
+		await fs.mkdir(memoryRoot, { recursive: true });
+		return await fn(memoryRoot);
+	} finally {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+}
+
+interface ConsolidationInput {
+	memoryMd: string;
+	memorySummary: string;
+	skills: Array<{
+		name: string;
+		content: string;
+		scripts: { path: string; content: string }[];
+		templates: { path: string; content: string }[];
+		examples: { path: string; content: string }[];
+	}>;
+	designDrafts: { path: string; content: string }[];
+}
+
+function consolidationFixture(overrides: Partial<ConsolidationInput> = {}): ConsolidationInput {
+	return {
+		memoryMd: "memory body",
+		memorySummary: "summary body",
+		skills: [],
+		designDrafts: [],
+		...overrides,
+	};
+}
+
+describe("body-marker rewrite", () => {
+	it("preserves frontmatter, summary, and rules byte-for-byte; only mutates body", async () => {
+		const original = buildMemoryDoc({
+			frontmatter: {
+				id: "kd_demo",
+				type: "memory",
+				path: "demo.md",
+				title: "Demo",
+				injectMode: "summary",
+				aiMaintained: true,
+				readOnly: false,
+				createdAt: 1,
+				updatedAt: 1,
+			},
+			title: "Demo",
+			summary: "A demo doc — keep me intact.",
+			maintenanceRules: ["Rule A.", "Rule B."],
+			body: "first body",
+		});
+
+		const doc = parseMemoryDoc(original);
+		expect(doc.hasBodyMarkers).toBe(true);
+
+		const rewritten = rewriteDocBody(doc, "second body");
+		expect(rewritten).toBeDefined();
+		// Frontmatter / heading / summary / rules survive verbatim.
+		expect(rewritten).toContain("id: kd_demo");
+		expect(rewritten).toContain("# Demo");
+		expect(rewritten).toContain("## Summary\nA demo doc — keep me intact.");
+		expect(rewritten).toContain("- Rule A.");
+		expect(rewritten).toContain("- Rule B.");
+		// Body region replaced.
+		expect(rewritten).toContain("second body");
+		expect(rewritten).not.toContain("first body");
+
+		// Re-parse: structure preserved.
+		const reparsed = parseMemoryDoc(rewritten ?? "");
+		expect(reparsed.hasBodyMarkers).toBe(true);
+		expect(reparsed.body.trim()).toBe("second body");
+		expect(reparsed.frontmatter.id).toBe("kd_demo");
+	});
+
+	it("rewriteDocBody returns undefined for marker-less docs (user-owned)", () => {
+		const userDoc = "---\ntitle: User\n---\n# User\n\nhand-authored body, no markers.\n";
+		const doc = parseMemoryDoc(userDoc);
+		expect(doc.hasBodyMarkers).toBe(false);
+		expect(rewriteDocBody(doc, "anything")).toBeUndefined();
+	});
+});
+
+describe(".omp-meta directory config", () => {
+	it("inherits parent sidecar config when inheritToChildren is true", async () => {
+		await withTempRoot(async memoryRoot => {
+			// Three-level hierarchy: memory/topic/child. Sidecar on `topic`
+			// opts descendants in via inheritToChildren.
+			const memDir = path.join(memoryRoot, TYPE_DIRS.memory);
+			const topic = path.join(memDir, "topic");
+			const child = path.join(topic, "child");
+			await fs.mkdir(child, { recursive: true });
+
+			await Bun.write(
+				sidecarPathForDirectory(topic),
+				stringifySidecar({
+					aiMaintained: false,
+					inheritToChildren: true,
+				}),
+			);
+
+			const config = await resolveDirectoryConfig(memoryRoot, child);
+			expect(config?.aiMaintained).toBe(false);
+			expect(config?.requiresApproval).toBe(true);
+
+			// Update to a doc inside `child` is permitted by checkWritePermission
+			// (readOnly is the hard gate, not aiMaintained), but the resolved
+			// config carries requiresApproval=true so callers route through
+			// the approval sink.
+			const target = path.join(child, "note.md");
+			const updateReason = await checkWritePermission(memoryRoot, target, "update");
+			expect(updateReason).toBeUndefined();
+			const docConfig = await resolveDocConfig(memoryRoot, target, {});
+			expect(docConfig?.requiresApproval).toBe(true);
+		});
+	});
+
+	it("applies the type-root sidecar to the whole bucket when inheritToChildren is true", async () => {
+		await withTempRoot(async memoryRoot => {
+			// `memory.omp-meta` next to the type root with inheritToChildren
+			// drives policy for every descendant.
+			const memDir = path.join(memoryRoot, TYPE_DIRS.memory);
+			const child = path.join(memDir, "topic");
+			await fs.mkdir(child, { recursive: true });
+
+			await Bun.write(
+				sidecarPathForDirectory(memDir),
+				stringifySidecar({
+					allowCreateDocuments: false,
+					inheritToChildren: true,
+				}),
+			);
+
+			// Bucket-wide block — new docs refused at the type root AND in
+			// any descendant.
+			const blockedAtRoot = await checkWritePermission(memoryRoot, path.join(memDir, "new.md"), "create");
+			expect(blockedAtRoot).toContain("denies new docs");
+			const blockedInChild = await checkWritePermission(memoryRoot, path.join(child, "new.md"), "create");
+			expect(blockedInChild).toContain("denies new docs");
+		});
+	});
+
+	it("ancestor sidecars without inheritToChildren do NOT bleed into children", async () => {
+		await withTempRoot(async memoryRoot => {
+			const memDir = path.join(memoryRoot, TYPE_DIRS.memory);
+			const topic = path.join(memDir, "topic");
+			const child = path.join(topic, "child");
+			await fs.mkdir(child, { recursive: true });
+			await Bun.write(
+				sidecarPathForDirectory(topic),
+				stringifySidecar({
+					aiMaintained: false,
+					// no inheritToChildren
+				}),
+			);
+
+			const config = await resolveDirectoryConfig(memoryRoot, child);
+			// Falls back to type defaults (memory: aiMaintained true).
+			expect(config?.aiMaintained).toBe(true);
+		});
+	});
+
+	it("doc-level inheritInjectMode reuses parent injectMode", async () => {
+		await withTempRoot(async memoryRoot => {
+			const memDir = path.join(memoryRoot, TYPE_DIRS.memory);
+			const sub = path.join(memDir, "topic");
+			await fs.mkdir(sub, { recursive: true });
+			await Bun.write(
+				sidecarPathForDirectory(sub),
+				stringifySidecar({
+					injectMode: "rule",
+				}),
+			);
+
+			const docPath = path.join(sub, "doc.md");
+			const config = await resolveDocConfig(memoryRoot, docPath, {
+				injectMode: "summary",
+				inheritInjectMode: true,
+			});
+			// inheritInjectMode wins — falls back to parent's "rule".
+			expect(config?.injectMode).toBe("rule");
+
+			const explicit = await resolveDocConfig(memoryRoot, docPath, {
+				injectMode: "summary",
+				inheritInjectMode: false,
+			});
+			expect(explicit?.injectMode).toBe("summary");
+		});
+	});
+
+	it("doc-level inheritAiConfig re-opts into parent aiMaintained / readOnly", async () => {
+		await withTempRoot(async memoryRoot => {
+			// design/ defaults to aiMaintained: false (requires approval). A doc
+			// that pinned aiMaintained: true in its own frontmatter would normally
+			// override that — inheritAiConfig: true forces it to track the parent.
+			const designDir = path.join(memoryRoot, TYPE_DIRS.design);
+			await fs.mkdir(designDir, { recursive: true });
+			const docPath = path.join(designDir, "architecture.md");
+
+			const inherited = await resolveDocConfig(memoryRoot, docPath, {
+				aiMaintained: true,
+				inheritAiConfig: true,
+			});
+			expect(inherited?.aiMaintained).toBe(false);
+			expect(inherited?.requiresApproval).toBe(true);
+
+			const explicit = await resolveDocConfig(memoryRoot, docPath, {
+				aiMaintained: true,
+				inheritAiConfig: false,
+			});
+			expect(explicit?.aiMaintained).toBe(true);
+			expect(explicit?.requiresApproval).toBe(false);
+		});
+	});
+
+	it("doc-level inheritAiConfig honours parent readOnly for write + delete gates", async () => {
+		await withTempRoot(async memoryRoot => {
+			// reference/ defaults to readOnly: true. A doc that flipped readOnly
+			// off in its own frontmatter loses that override under inheritAiConfig.
+			const refDir = path.join(memoryRoot, TYPE_DIRS.reference);
+			await fs.mkdir(refDir, { recursive: true });
+			const docPath = path.join(refDir, "spec.md");
+			await Bun.write(docPath, "stub");
+
+			const inherited = await resolveDocConfig(memoryRoot, docPath, {
+				readOnly: false,
+				inheritAiConfig: true,
+			});
+			expect(inherited?.readOnly).toBe(true);
+
+			const writeBlocked = await checkWritePermission(memoryRoot, docPath, "update", {
+				readOnly: false,
+				inheritAiConfig: true,
+			});
+			expect(writeBlocked).toContain("read-only");
+
+			const deleteBlocked = await checkDeletePermission(memoryRoot, docPath, {
+				readOnly: false,
+				inheritAiConfig: true,
+			});
+			expect(deleteBlocked).toContain("read-only");
+		});
+	});
+
+	it("allowCreateDocuments: false blocks new docs in that directory only", async () => {
+		await withTempRoot(async memoryRoot => {
+			const memDir = path.join(memoryRoot, TYPE_DIRS.memory);
+			const locked = path.join(memDir, "locked");
+			const open = path.join(memDir, "open");
+			await fs.mkdir(locked, { recursive: true });
+			await fs.mkdir(open, { recursive: true });
+			await Bun.write(sidecarPathForDirectory(locked), stringifySidecar({ allowCreateDocuments: false }));
+
+			const blocked = await checkWritePermission(memoryRoot, path.join(locked, "new.md"), "create");
+			expect(blocked).toContain("denies new docs");
+
+			const allowed = await checkWritePermission(memoryRoot, path.join(open, "new.md"), "create");
+			expect(allowed).toBeUndefined();
+		});
+	});
+
+	it("renameDirectoryWithSidecar moves both atomically", async () => {
+		await withTempRoot(async memoryRoot => {
+			const memDir = path.join(memoryRoot, TYPE_DIRS.memory);
+			const src = path.join(memDir, "old");
+			const dest = path.join(memDir, "new");
+			await fs.mkdir(src, { recursive: true });
+			await Bun.write(path.join(src, "doc.md"), "x");
+			await Bun.write(sidecarPathForDirectory(src), stringifySidecar({ injectMode: "summary" }));
+
+			await renameDirectoryWithSidecar(src, dest);
+
+			expect(await Bun.file(path.join(dest, "doc.md")).exists()).toBe(true);
+			expect(await Bun.file(sidecarPathForDirectory(dest)).exists()).toBe(true);
+			expect(await Bun.file(src).exists()).toBe(false);
+			expect(await Bun.file(sidecarPathForDirectory(src)).exists()).toBe(false);
+		});
+	});
+});
+
+describe("seedBuiltinDocs", () => {
+	it("creates seeds with markers on first run and is idempotent", async () => {
+		await withTempRoot(async memoryRoot => {
+			await seedBuiltinDocs(memoryRoot);
+			const seedPath = path.join(memoryRoot, "memory", "user-preference.md");
+			const first = await Bun.file(seedPath).text();
+			expect(first).toContain("<!-- omp:body:start -->");
+			expect(first).toContain("seedVersion: 2");
+
+			await seedBuiltinDocs(memoryRoot);
+			const second = await Bun.file(seedPath).text();
+			// Same version → same content (idempotent).
+			expect(second).toBe(first);
+		});
+	});
+
+	it("preserves the body when refreshing from an older seedVersion", async () => {
+		await withTempRoot(async memoryRoot => {
+			const seedPath = path.join(memoryRoot, "memory", "user-preference.md");
+			await fs.mkdir(path.dirname(seedPath), { recursive: true });
+			const userBody = "User said: prefer tabs over spaces.";
+			const oldDoc = buildMemoryDoc({
+				frontmatter: {
+					id: "kd_user_preference",
+					type: "memory",
+					path: "user-preference.md",
+					title: "User Preferences",
+					injectMode: "rule",
+					aiMaintained: true,
+					readOnly: false,
+					seedVersion: 0,
+					createdAt: 1,
+					updatedAt: 1,
+				},
+				title: "User Preferences",
+				summary: "stale summary",
+				body: userBody,
+			});
+			await Bun.write(seedPath, oldDoc);
+
+			await seedBuiltinDocs(memoryRoot);
+
+			const refreshed = await Bun.file(seedPath).text();
+			const reparsed = parseMemoryDoc(refreshed);
+			expect(reparsed.body.trim()).toBe(userBody);
+			expect(reparsed.frontmatter.seedVersion).toBe(2);
+			// Summary refreshed to canonical text — not "stale summary".
+			expect(refreshed).not.toContain("stale summary");
+		});
+	});
+
+	it("leaves user-owned seed files (markers stripped) alone", async () => {
+		await withTempRoot(async memoryRoot => {
+			const seedPath = path.join(memoryRoot, "memory", "user-preference.md");
+			await fs.mkdir(path.dirname(seedPath), { recursive: true });
+			const userOwned = "---\ntitle: User Preferences\n---\n# Mine\n\nNo markers here.\n";
+			await Bun.write(seedPath, userOwned);
+
+			await seedBuiltinDocs(memoryRoot);
+
+			const after = await Bun.file(seedPath).text();
+			expect(after).toBe(userOwned);
+		});
+	});
+
+	it("materializes the `project-understanding/` directory seed with `.omp-meta`", async () => {
+		await withTempRoot(async memoryRoot => {
+			await seedBuiltinDocs(memoryRoot);
+			const dir = path.join(memoryRoot, "memory", "project-understanding");
+			const sidecar = sidecarPathForDirectory(dir);
+			expect((await fs.stat(dir)).isDirectory()).toBe(true);
+			expect(await Bun.file(sidecar).exists()).toBe(true);
+			const sidecarText = await Bun.file(sidecar).text();
+			expect(sidecarText).toContain("injectMode: path");
+			expect(sidecarText).toContain("seedVersion: 2");
+
+			// User customizes maintenance rules → flip explicitMaintenanceRules
+			// and re-run. The customized rules must survive.
+			await Bun.write(
+				sidecar,
+				stringifySidecar({
+					version: 1,
+					summary: "user-edited summary",
+					injectMode: "path",
+					inheritToChildren: true,
+					aiMaintained: true,
+					seedVersion: 1,
+					maintenanceRules: "- only my rule",
+					explicitMaintenanceRules: true,
+				}),
+			);
+			await seedBuiltinDocs(memoryRoot);
+			const refreshed = await Bun.file(sidecar).text();
+			expect(refreshed).toContain("only my rule");
+			expect(refreshed).toContain("explicitMaintenanceRules: true");
+		});
+	});
+
+	it("derives `requiresApproval: true` for `aiMaintained: false` directories", async () => {
+		await withTempRoot(async memoryRoot => {
+			const designDir = path.join(memoryRoot, TYPE_DIRS.design);
+			await fs.mkdir(designDir, { recursive: true });
+			const config = await resolveDirectoryConfig(memoryRoot, designDir);
+			expect(config?.aiMaintained).toBe(false);
+			expect(config?.requiresApproval).toBe(true);
+			expect(config?.injectMode).toBe("path");
+		});
+	});
+
+	it("derives `requiresApproval: false` for `readOnly` targets (no approval routing)", async () => {
+		await withTempRoot(async memoryRoot => {
+			const refDir = path.join(memoryRoot, TYPE_DIRS.reference);
+			await fs.mkdir(refDir, { recursive: true });
+			const config = await resolveDirectoryConfig(memoryRoot, refDir);
+			expect(config?.readOnly).toBe(true);
+			// readOnly is the hard refusal; no approval flow is offered.
+			expect(config?.requiresApproval).toBe(false);
+		});
+	});
+
+	it("round-trips `injectMode: path` through doc frontmatter", async () => {
+		await withTempRoot(async memoryRoot => {
+			const memDir = path.join(memoryRoot, TYPE_DIRS.memory);
+			await fs.mkdir(memDir, { recursive: true });
+			const docPath = path.join(memDir, "breadcrumb.md");
+			const doc = buildMemoryDoc({
+				frontmatter: {
+					id: "kd_breadcrumb",
+					type: "memory",
+					path: "breadcrumb.md",
+					title: "Breadcrumb",
+					injectMode: "path",
+					aiMaintained: true,
+					readOnly: false,
+					createdAt: 1,
+					updatedAt: 1,
+				},
+				title: "Breadcrumb",
+				body: "Body content",
+			});
+			await Bun.write(docPath, doc);
+
+			const parsed = parseMemoryDoc(await Bun.file(docPath).text());
+			expect(parsed.frontmatter.injectMode).toBe("path");
+
+			const resolved = await resolveDocConfig(memoryRoot, docPath, parsed.frontmatter);
+			expect(resolved?.injectMode).toBe("path");
+		});
+	});
+});
+
+describe("applyConsolidation", () => {
+	it("writes memory_md, memory_summary, and skills under the typed dirs", async () => {
+		await withTempRoot(async memoryRoot => {
+			await applyConsolidation(
+				memoryRoot,
+				consolidationFixture({
+					memoryMd: "long memory body",
+					memorySummary: "summary body",
+					skills: [
+						{
+							name: "demo",
+							content: "demo skill body",
+							scripts: [{ path: "run.sh", content: "echo hi" }],
+							templates: [],
+							examples: [],
+						},
+					],
+				}),
+			);
+
+			const memoryDoc = await Bun.file(path.join(memoryRoot, "memory", "MEMORY.md")).text();
+			expect(memoryDoc).toContain("<!-- omp:body:start -->");
+			expect(memoryDoc).toContain("long memory body");
+
+			const summaryDoc = await Bun.file(path.join(memoryRoot, "memory", "memory_summary.md")).text();
+			expect(summaryDoc).toContain("summary body");
+
+			const skillDoc = await Bun.file(path.join(memoryRoot, "skill", "demo", "SKILL.md")).text();
+			expect(skillDoc).toContain("demo skill body");
+
+			const script = await Bun.file(path.join(memoryRoot, "skill", "demo", "scripts", "run.sh")).text();
+			expect(script).toBe("echo hi\n");
+		});
+	});
+
+	it("preserves the body of a user-protected skill (aiMaintained: false)", async () => {
+		await withTempRoot(async memoryRoot => {
+			// First pass: create an AI-maintained skill.
+			await applyConsolidation(
+				memoryRoot,
+				consolidationFixture({
+					skills: [{ name: "userskill", content: "v1 body", scripts: [], templates: [], examples: [] }],
+				}),
+			);
+			const skillPath = path.join(memoryRoot, "skill", "userskill", "SKILL.md");
+			// User takes ownership of the SKILL.md by flipping aiMaintained.
+			const original = await Bun.file(skillPath).text();
+			const userOwned = original.replace("aiMaintained: true", "aiMaintained: false");
+			await Bun.write(skillPath, userOwned);
+
+			// Second pass tries to overwrite body — must be refused.
+			await applyConsolidation(
+				memoryRoot,
+				consolidationFixture({
+					skills: [
+						{ name: "userskill", content: "v2 SHOULD NOT APPEAR", scripts: [], templates: [], examples: [] },
+					],
+				}),
+			);
+
+			const after = await Bun.file(skillPath).text();
+			expect(after).toContain("v1 body");
+			expect(after).not.toContain("v2 SHOULD NOT APPEAR");
+		});
+	});
+
+	it("preserves a markerless user-authored SKILL.md and its assets across consolidations", async () => {
+		await withTempRoot(async memoryRoot => {
+			// First pass: AI-maintained skill with an asset.
+			await applyConsolidation(
+				memoryRoot,
+				consolidationFixture({
+					skills: [
+						{
+							name: "user-md",
+							content: "v1 body",
+							scripts: [{ path: "run.sh", content: "echo v1" }],
+							templates: [],
+							examples: [],
+						},
+					],
+				}),
+			);
+			const skillPath = path.join(memoryRoot, "skill", "user-md", "SKILL.md");
+			const assetPath = path.join(memoryRoot, "skill", "user-md", "scripts", "run.sh");
+
+			// User rewrites SKILL.md from scratch without frontmatter or body
+			// markers — the consolidator must treat the dir as user-owned and
+			// leave both the doc and its assets untouched, even though the
+			// effective `aiMaintained` config still defaults to `true`.
+			const userAuthored = "# My Skill\n\nHand-authored, no markers.\n";
+			await Bun.write(skillPath, userAuthored);
+			const userAsset = "echo user-curated\n";
+			await Bun.write(assetPath, userAsset);
+
+			await applyConsolidation(
+				memoryRoot,
+				consolidationFixture({
+					skills: [
+						{
+							name: "user-md",
+							content: "v2 SHOULD NOT APPEAR",
+							scripts: [{ path: "run.sh", content: "echo v2 SHOULD NOT APPEAR" }],
+							templates: [],
+							examples: [],
+						},
+					],
+				}),
+			);
+
+			expect(await Bun.file(skillPath).text()).toBe(userAuthored);
+			expect(await Bun.file(assetPath).text()).toBe(userAsset);
+		});
+	});
+
+	it("does not touch user-authored docs lacking body markers", async () => {
+		await withTempRoot(async memoryRoot => {
+			const memoryMdPath = path.join(memoryRoot, "memory", "MEMORY.md");
+			await fs.mkdir(path.dirname(memoryMdPath), { recursive: true });
+			const userDoc = "# Hand-authored\n\nNo markers — this is mine.\n";
+			await Bun.write(memoryMdPath, userDoc);
+
+			await applyConsolidation(memoryRoot, consolidationFixture({ memoryMd: "AI tried to write this" }));
+
+			const after = await Bun.file(memoryMdPath).text();
+			expect(after).toBe(userDoc);
+		});
+	});
+
+	it("preserves skill assets (scripts/templates/examples) when the skill is user-protected", async () => {
+		await withTempRoot(async memoryRoot => {
+			// First pass: AI-maintained skill with one asset.
+			await applyConsolidation(
+				memoryRoot,
+				consolidationFixture({
+					skills: [
+						{
+							name: "ops",
+							content: "ops body v1",
+							scripts: [{ path: "deploy.sh", content: "echo v1" }],
+							templates: [],
+							examples: [],
+						},
+					],
+				}),
+			);
+			// User takes ownership of the skill (aiMaintained: false) AND
+			// edits the asset by hand.
+			const skillPath = path.join(memoryRoot, "skill", "ops", "SKILL.md");
+			const assetPath = path.join(memoryRoot, "skill", "ops", "scripts", "deploy.sh");
+			const skillDoc = await Bun.file(skillPath).text();
+			await Bun.write(skillPath, skillDoc.replace("aiMaintained: true", "aiMaintained: false"));
+			const handEdited = "echo user-curated\n";
+			await Bun.write(assetPath, handEdited);
+
+			// Second pass: consolidator emits a new asset payload and a
+			// different file under the same skill. Both must be refused.
+			await applyConsolidation(
+				memoryRoot,
+				consolidationFixture({
+					skills: [
+						{
+							name: "ops",
+							content: "ops body v2",
+							scripts: [
+								{ path: "deploy.sh", content: "echo v2" },
+								{ path: "rollback.sh", content: "echo rollback" },
+							],
+							templates: [],
+							examples: [],
+						},
+					],
+				}),
+			);
+
+			expect(await Bun.file(assetPath).text()).toBe(handEdited);
+			// The new asset the consolidator tried to add was refused too —
+			// the user-protected dir is fully off-limits.
+			expect(await Bun.file(path.join(memoryRoot, "skill", "ops", "scripts", "rollback.sh")).exists()).toBe(false);
+		});
+	});
+
+	it("preserves skill assets when the skill is read-only (aiMaintained: true, readOnly: true)", async () => {
+		await withTempRoot(async memoryRoot => {
+			// First pass: AI-maintained skill with an asset.
+			await applyConsolidation(
+				memoryRoot,
+				consolidationFixture({
+					skills: [
+						{
+							name: "locked",
+							content: "locked body v1",
+							scripts: [{ path: "run.sh", content: "echo v1" }],
+							templates: [],
+							examples: [],
+						},
+					],
+				}),
+			);
+			// User locks the skill but leaves aiMaintained: true. readOnly is the
+			// hard gate — the consolidator must skip both SKILL.md AND the asset
+			// buckets even though aiMaintained still says "AI can touch this".
+			const skillPath = path.join(memoryRoot, "skill", "locked", "SKILL.md");
+			const assetPath = path.join(memoryRoot, "skill", "locked", "scripts", "run.sh");
+			const skillDoc = await Bun.file(skillPath).text();
+			await Bun.write(skillPath, skillDoc.replace("readOnly: false", "readOnly: true"));
+			const handEdited = "echo user-curated\n";
+			await Bun.write(assetPath, handEdited);
+
+			// Second pass: would overwrite the asset and add a new file.
+			await applyConsolidation(
+				memoryRoot,
+				consolidationFixture({
+					skills: [
+						{
+							name: "locked",
+							content: "locked body v2",
+							scripts: [
+								{ path: "run.sh", content: "echo v2" },
+								{ path: "extra.sh", content: "echo extra" },
+							],
+							templates: [],
+							examples: [],
+						},
+					],
+				}),
+			);
+
+			expect(await Bun.file(assetPath).text()).toBe(handEdited);
+			expect(await Bun.file(path.join(memoryRoot, "skill", "locked", "scripts", "extra.sh")).exists()).toBe(false);
+		});
+	});
+
+	it("preserves read-only skill dirs during the consolidator empty-pass prune", async () => {
+		await withTempRoot(async memoryRoot => {
+			// First pass: AI-maintained skill.
+			await applyConsolidation(
+				memoryRoot,
+				consolidationFixture({
+					skills: [{ name: "gamma", content: "g", scripts: [], templates: [], examples: [] }],
+				}),
+			);
+			// User locks the skill (readOnly: true) while leaving aiMaintained: true.
+			const gammaPath = path.join(memoryRoot, "skill", "gamma", "SKILL.md");
+			const gamma = await Bun.file(gammaPath).text();
+			await Bun.write(gammaPath, gamma.replace("readOnly: false", "readOnly: true"));
+
+			// cleanupConsolidatedArtifacts runs pruneSkillsDir directly (empty-pass
+			// path). The read-only skill must survive.
+			await cleanupConsolidatedArtifacts(memoryRoot);
+
+			expect(await Bun.file(gammaPath).exists()).toBe(true);
+		});
+	});
+
+	it("prunes AI-maintained skill dirs the consolidator no longer emits, but keeps user-protected ones", async () => {
+		await withTempRoot(async memoryRoot => {
+			// First pass: two AI skills.
+			await applyConsolidation(
+				memoryRoot,
+				consolidationFixture({
+					skills: [
+						{ name: "alpha", content: "a", scripts: [], templates: [], examples: [] },
+						{ name: "beta", content: "b", scripts: [], templates: [], examples: [] },
+					],
+				}),
+			);
+			// Make `beta` user-protected via doc-level frontmatter.
+			const betaPath = path.join(memoryRoot, "skill", "beta", "SKILL.md");
+			const beta = await Bun.file(betaPath).text();
+			await Bun.write(betaPath, beta.replace("aiMaintained: true", "aiMaintained: false"));
+
+			// Second pass emits neither skill.
+			await applyConsolidation(memoryRoot, consolidationFixture());
+
+			// alpha pruned, beta survives.
+			expect(await Bun.file(path.join(memoryRoot, "skill", "alpha", "SKILL.md")).exists()).toBe(false);
+			expect(await Bun.file(betaPath).exists()).toBe(true);
+		});
+	});
+
+	it("writes design_drafts under design/_drafts/ with aiMaintained: false and refuses to overwrite", async () => {
+		await withTempRoot(async memoryRoot => {
+			await applyConsolidation(
+				memoryRoot,
+				consolidationFixture({
+					designDrafts: [{ path: "spike.md", content: "proposed approach" }],
+				}),
+			);
+			const draftPath = path.join(memoryRoot, "design", "_drafts", "spike.md");
+			const first = await Bun.file(draftPath).text();
+			expect(first).toContain("proposed approach");
+			expect(first).toContain("aiMaintained: false");
+
+			// Second pass with different body must NOT overwrite the existing draft.
+			await applyConsolidation(
+				memoryRoot,
+				consolidationFixture({
+					designDrafts: [{ path: "spike.md", content: "different proposal" }],
+				}),
+			);
+			const after = await Bun.file(draftPath).text();
+			expect(after).toBe(first);
+			expect(after).not.toContain("different proposal");
+		});
+	});
+
+	it("leaves design/ and reference/ untouched on a no-output consolidation pass", async () => {
+		await withTempRoot(async memoryRoot => {
+			const designPath = path.join(memoryRoot, "design", "spec.md");
+			const referencePath = path.join(memoryRoot, "reference", "spec.md");
+			await fs.mkdir(path.dirname(designPath), { recursive: true });
+			await fs.mkdir(path.dirname(referencePath), { recursive: true });
+			await Bun.write(designPath, "user design note");
+			await Bun.write(referencePath, "user reference material");
+
+			await cleanupConsolidatedArtifacts(memoryRoot);
+
+			expect(await Bun.file(designPath).text()).toBe("user design note");
+			expect(await Bun.file(referencePath).text()).toBe("user reference material");
+		});
+	});
+
+	it("migrates legacy MEMORY.md / memory_summary.md / skills/ on first pass", async () => {
+		await withTempRoot(async memoryRoot => {
+			// Pre-populate with the old shape.
+			await Bun.write(path.join(memoryRoot, "MEMORY.md"), "legacy mem body");
+			await Bun.write(path.join(memoryRoot, "memory_summary.md"), "legacy summary body");
+			const legacySkillsDir = path.join(memoryRoot, "skills", "old");
+			await fs.mkdir(legacySkillsDir, { recursive: true });
+			await Bun.write(
+				path.join(legacySkillsDir, "SKILL.md"),
+				"---\naiMaintained: false\n---\n# Old\n\nlegacy skill body\n",
+			);
+
+			await applyConsolidation(memoryRoot, consolidationFixture());
+
+			// Migrated to new shape.
+			expect(await Bun.file(path.join(memoryRoot, "memory", "MEMORY.md")).exists()).toBe(true);
+			expect(await Bun.file(path.join(memoryRoot, "memory", "memory_summary.md")).exists()).toBe(true);
+			expect(await Bun.file(path.join(memoryRoot, "skill", "old", "SKILL.md")).exists()).toBe(true);
+			// Legacy roots cleared.
+			expect(await Bun.file(path.join(memoryRoot, "MEMORY.md")).exists()).toBe(false);
+		});
+	});
+
+	it("refreshes migrated legacy MEMORY.md and memory_summary.md on subsequent consolidations", async () => {
+		await withTempRoot(async memoryRoot => {
+			// Pre-PR shape: marker-less MEMORY.md / memory_summary.md.
+			await Bun.write(path.join(memoryRoot, "MEMORY.md"), "legacy mem body v0");
+			await Bun.write(path.join(memoryRoot, "memory_summary.md"), "legacy summary v0");
+
+			// First Phase-2 migrates AND seeds new body via the migrated docs.
+			await applyConsolidation(
+				memoryRoot,
+				consolidationFixture({ memoryMd: "phase2 v1", memorySummary: "summary v1" }),
+			);
+			const memPath = path.join(memoryRoot, "memory", "MEMORY.md");
+			const sumPath = path.join(memoryRoot, "memory", "memory_summary.md");
+			const memAfterFirst = await Bun.file(memPath).text();
+			const sumAfterFirst = await Bun.file(sumPath).text();
+			expect(memAfterFirst).toContain("<!-- omp:body:start -->");
+			expect(memAfterFirst).toContain("phase2 v1");
+			expect(sumAfterFirst).toContain("summary v1");
+
+			// Second Phase-2 must refresh the body region — this is the regression
+			// the migration->marker promotion guards against. Without the promote,
+			// writeMemoryDoc would see the marker-less migrated content and skip.
+			await applyConsolidation(
+				memoryRoot,
+				consolidationFixture({ memoryMd: "phase2 v2", memorySummary: "summary v2" }),
+			);
+			expect(await Bun.file(memPath).text()).toContain("phase2 v2");
+			expect(await Bun.file(sumPath).text()).toContain("summary v2");
+		});
+	});
+});

--- a/packages/coding-agent/test/skill-ops.test.ts
+++ b/packages/coding-agent/test/skill-ops.test.ts
@@ -1,0 +1,244 @@
+// Coverage for the skill ops layer used by the `skill_create` and
+// `skill_reload` tools. Verifies name validation, path containment,
+// collision detection, frontmatter emission, and reload diffs.
+
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { parseFrontmatter } from "@oh-my-pi/pi-utils";
+import {
+	commitSkillPackage,
+	createSkillPackage,
+	prepareSkillPackage,
+	reloadSkills,
+	SkillOpsError,
+} from "../src/extensibility/skill-ops";
+import { resetActiveSkillsForTests, type Skill } from "../src/extensibility/skills";
+
+async function withTempProject<T>(fn: (projectRoot: string) => Promise<T>): Promise<T> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "skill-ops-"));
+	try {
+		const projectRoot = path.join(dir, "project");
+		await fs.mkdir(projectRoot, { recursive: true });
+		return await fn(projectRoot);
+	} finally {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+}
+
+async function readSkill(skillFile: string): Promise<{ frontmatter: Record<string, unknown>; body: string }> {
+	const content = await fs.readFile(skillFile, "utf8");
+	const parsed = parseFrontmatter(content, { source: skillFile });
+	return { frontmatter: parsed.frontmatter, body: parsed.body };
+}
+
+describe("createSkillPackage", () => {
+	it("writes a SKILL.md with the expected frontmatter and body", async () => {
+		await withTempProject(async projectRoot => {
+			const result = await createSkillPackage(projectRoot, {
+				name: "deploy-playbook",
+				description: "Steps for blue/green deploys.",
+				body: "# Deploy\n\nUse blue/green.",
+			});
+			expect(result.skillFile).toBe(path.join(projectRoot, ".omp", "skills", "deploy-playbook", "SKILL.md"));
+			const { frontmatter, body } = await readSkill(result.skillFile);
+			expect(frontmatter.name).toBe("deploy-playbook");
+			expect(frontmatter.description).toBe("Steps for blue/green deploys.");
+			// Default skillSurface is implicit ("auto") — must not appear.
+			expect(frontmatter.skillSurface).toBeUndefined();
+			expect(body.trim()).toBe("# Deploy\n\nUse blue/green.");
+		});
+	});
+
+	it("emits explicit skillSurface only when set to 'command'", async () => {
+		await withTempProject(async projectRoot => {
+			const hidden = await createSkillPackage(projectRoot, {
+				name: "secret-handler",
+				description: "Opt-in skill.",
+				body: "body",
+				skillSurface: "command",
+			});
+			const { frontmatter } = await readSkill(hidden.skillFile);
+			expect(frontmatter.skillSurface).toBe("command");
+
+			const visible = await createSkillPackage(projectRoot, {
+				name: "open-handler",
+				description: "Visible skill.",
+				body: "body",
+				skillSurface: "auto",
+			});
+			const { frontmatter: visibleFm } = await readSkill(visible.skillFile);
+			expect(visibleFm.skillSurface).toBeUndefined();
+		});
+	});
+
+	for (const badName of [
+		"",
+		"../escape",
+		"foo/bar",
+		"foo\\bar",
+		"Foo",
+		"-leading-dash",
+		"_leading-underscore",
+		".",
+		"..",
+		"a".repeat(65),
+	]) {
+		it(`refuses unsafe name ${JSON.stringify(badName)}`, async () => {
+			await withTempProject(async projectRoot => {
+				await expect(
+					createSkillPackage(projectRoot, { name: badName, description: "x", body: "" }),
+				).rejects.toBeInstanceOf(SkillOpsError);
+				// No file written.
+				const root = path.join(projectRoot, ".omp", "skills");
+				const exists = await fs
+					.stat(root)
+					.then(() => true)
+					.catch(() => false);
+				expect(exists).toBe(false);
+			});
+		});
+	}
+
+	it("rejects Windows-style traversal at the name validator", async () => {
+		await withTempProject(async projectRoot => {
+			await expect(
+				createSkillPackage(projectRoot, { name: "..\\evil", description: "x", body: "" }),
+			).rejects.toBeInstanceOf(SkillOpsError);
+		});
+	});
+
+	it("refuses on existing directory collision", async () => {
+		await withTempProject(async projectRoot => {
+			const skillDir = path.join(projectRoot, ".omp", "skills", "existing");
+			await fs.mkdir(skillDir, { recursive: true });
+			try {
+				await createSkillPackage(projectRoot, {
+					name: "existing",
+					description: "x",
+					body: "",
+				});
+				throw new Error("expected to refuse");
+			} catch (error) {
+				expect(error).toBeInstanceOf(SkillOpsError);
+				expect((error as SkillOpsError).code).toBe("collision");
+			}
+		});
+	});
+
+	it("refuses empty descriptions", async () => {
+		await withTempProject(async projectRoot => {
+			await expect(
+				createSkillPackage(projectRoot, { name: "ok-name", description: "   ", body: "" }),
+			).rejects.toBeInstanceOf(SkillOpsError);
+		});
+	});
+
+	it("prepare phase reports collisions before any disk write", async () => {
+		await withTempProject(async projectRoot => {
+			await fs.mkdir(path.join(projectRoot, ".omp", "skills", "taken"), { recursive: true });
+			await expect(
+				prepareSkillPackage(projectRoot, { name: "taken", description: "x", body: "" }),
+			).rejects.toMatchObject({ code: "collision" });
+		});
+	});
+
+	it("commit writes only after prepare succeeds", async () => {
+		await withTempProject(async projectRoot => {
+			const prepared = await prepareSkillPackage(projectRoot, {
+				name: "two-phase",
+				description: "demo",
+				body: "body",
+			});
+			// Nothing on disk yet.
+			expect(
+				await fs
+					.stat(prepared.skillDir)
+					.then(() => true)
+					.catch(() => false),
+			).toBe(false);
+			await commitSkillPackage(prepared);
+			expect(
+				await fs
+					.stat(prepared.skillFile)
+					.then(() => true)
+					.catch(() => false),
+			).toBe(true);
+		});
+	});
+});
+
+describe("reloadSkills", () => {
+	const loadOpts = (projectRoot: string) => ({
+		cwd: projectRoot,
+		enabled: true,
+		enableCodexUser: false,
+		enableClaudeUser: false,
+		enableClaudeProject: false,
+		enablePiUser: false,
+		enablePiProject: true,
+		customDirectories: [] as string[],
+	});
+
+	it("reports added/removed/changed between snapshots", async () => {
+		await withTempProject(async projectRoot => {
+			resetActiveSkillsForTests();
+			await createSkillPackage(projectRoot, { name: "alpha", description: "A.", body: "" });
+			await createSkillPackage(projectRoot, { name: "bravo", description: "B.", body: "" });
+
+			const first = await reloadSkills(loadOpts(projectRoot), []);
+			const firstNames = first.skills.map(s => s.name).filter(n => n === "alpha" || n === "bravo");
+			expect(firstNames.sort()).toEqual(["alpha", "bravo"]);
+
+			// Add charlie, remove alpha, leave bravo as-is.
+			await createSkillPackage(projectRoot, { name: "charlie", description: "C.", body: "" });
+			await fs.rm(path.join(projectRoot, ".omp", "skills", "alpha"), { recursive: true });
+
+			const second = await reloadSkills(loadOpts(projectRoot), first.skills);
+			expect(second.diff.added).toContain("charlie");
+			expect(second.diff.removed).toContain("alpha");
+			expect(second.diff.changed).toEqual([]);
+		});
+	});
+
+	it("reports a skill as 'changed' when its on-disk filePath shifts", async () => {
+		await withTempProject(async projectRoot => {
+			resetActiveSkillsForTests();
+			await createSkillPackage(projectRoot, { name: "movable", description: "x.", body: "" });
+			const first = await reloadSkills(loadOpts(projectRoot), []);
+
+			// Synthesize a "moved" prior snapshot by altering the filePath in
+			// the previous record. This mirrors what reloadSkills sees when
+			// the skill directory itself is renamed/moved between scans.
+			const fakePrev: Skill[] = first.skills.map(s =>
+				s.name === "movable" ? { ...s, filePath: `${s.filePath}.old` } : s,
+			);
+
+			const second = await reloadSkills(loadOpts(projectRoot), fakePrev);
+			expect(second.diff.changed).toContain("movable");
+			expect(second.diff.added).toEqual([]);
+			expect(second.diff.removed).toEqual([]);
+		});
+	});
+
+	it("returns an empty diff against an identical snapshot", async () => {
+		await withTempProject(async projectRoot => {
+			resetActiveSkillsForTests();
+			await createSkillPackage(projectRoot, { name: "stable", description: "x.", body: "" });
+			const first = await reloadSkills(loadOpts(projectRoot), []);
+			const second = await reloadSkills(loadOpts(projectRoot), first.skills);
+			expect(second.diff.added).toEqual([]);
+			expect(second.diff.removed).toEqual([]);
+			expect(second.diff.changed).toEqual([]);
+		});
+	});
+
+	it("returns a warnings array (propagated from loadSkills)", async () => {
+		await withTempProject(async projectRoot => {
+			resetActiveSkillsForTests();
+			const result = await reloadSkills(loadOpts(projectRoot), []);
+			expect(Array.isArray(result.diff.warnings)).toBe(true);
+		});
+	});
+});

--- a/packages/coding-agent/test/skill-tools.test.ts
+++ b/packages/coding-agent/test/skill-tools.test.ts
@@ -1,0 +1,263 @@
+// Coverage for the SkillCreate / SkillReload tool wrappers. Verifies the
+// approval-sink protocol (eager validation + queued apply), tool-level
+// collision refusal, reload-into-process-global, and skill:// resolution
+// after reload.
+
+import { beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createSkillPackage } from "@oh-my-pi/pi-coding-agent/extensibility/skill-ops";
+import { getActiveSkills, resetActiveSkillsForTests } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
+import { parseInternalUrl } from "@oh-my-pi/pi-coding-agent/internal-urls/parse";
+import { SkillProtocolHandler } from "@oh-my-pi/pi-coding-agent/internal-urls/skill-protocol";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { SkillCreateTool, SkillReloadTool } from "@oh-my-pi/pi-coding-agent/tools/skill";
+
+interface QueuedDirective {
+	label: string;
+	onInvoked?: (input: unknown) => Promise<unknown>;
+}
+
+interface FakeQueue {
+	directives: QueuedDirective[];
+	pushOnce(_choice: unknown, options: { label: string; onInvoked: (input: unknown) => Promise<unknown> }): void;
+}
+
+function createFakeQueue(): FakeQueue {
+	const directives: QueuedDirective[] = [];
+	return {
+		directives,
+		pushOnce(_choice, options) {
+			directives.push({ label: options.label, onInvoked: options.onInvoked });
+		},
+	};
+}
+
+function createSession(opts: { cwd: string; queue?: FakeQueue }): ToolSession {
+	const queue = opts.queue;
+	const settings = Settings.isolated({
+		"skills.enabled": true,
+		"skills.enableCodexUser": false,
+		"skills.enableClaudeUser": false,
+		"skills.enableClaudeProject": false,
+		"skills.enablePiUser": false,
+		"skills.enablePiProject": true,
+	});
+	return {
+		cwd: opts.cwd,
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings,
+		getToolChoiceQueue: queue
+			? () => queue as unknown as ReturnType<NonNullable<ToolSession["getToolChoiceQueue"]>>
+			: undefined,
+		buildToolChoice: queue
+			? () =>
+					({ type: "tool", name: "resolve" }) as unknown as ReturnType<NonNullable<ToolSession["buildToolChoice"]>>
+			: undefined,
+		steer: () => {},
+	};
+}
+
+function getText(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content.find(p => p.type === "text")?.text ?? "";
+}
+
+async function withTempProject<T>(fn: (projectRoot: string) => Promise<T>): Promise<T> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "skill-tools-"));
+	try {
+		const projectRoot = path.join(dir, "project");
+		await fs.mkdir(projectRoot, { recursive: true });
+		return await fn(projectRoot);
+	} finally {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+}
+
+async function exists(p: string): Promise<boolean> {
+	try {
+		await fs.stat(p);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+beforeEach(() => {
+	resetActiveSkillsForTests();
+});
+
+describe("SkillCreateTool", () => {
+	it("refuses when no approval channel is available", async () => {
+		await withTempProject(async projectRoot => {
+			const session = createSession({ cwd: projectRoot }); // no queue
+			const tool = new SkillCreateTool(session);
+			await expect(
+				tool.execute("call-1", {
+					name: "needs-approval",
+					description: "x.",
+					body: "",
+				}),
+			).rejects.toThrow(/user approval/);
+			expect(await exists(path.join(projectRoot, ".omp", "skills", "needs-approval"))).toBe(false);
+		});
+	});
+
+	it("queues an approval directive and writes the skill on apply", async () => {
+		await withTempProject(async projectRoot => {
+			const queue = createFakeQueue();
+			const session = createSession({ cwd: projectRoot, queue });
+			const tool = new SkillCreateTool(session);
+
+			const pending = await tool.execute("call-1", {
+				name: "my-skill",
+				description: "Demo skill.",
+				body: "# Hello",
+			});
+			expect(getText(pending)).toContain("pending user approval");
+			expect(queue.directives).toHaveLength(1);
+			expect(queue.directives[0].label).toContain("skill_create");
+
+			// User approves → directive fires.
+			const onInvoked = queue.directives[0].onInvoked!;
+			const result = (await onInvoked({ action: "apply", reason: "looks good" })) as {
+				content: Array<{ type: string; text?: string }>;
+			};
+			expect(getText(result)).toMatch(/Created skill package/);
+			expect(getText(result)).toMatch(/skill_reload/);
+			const skillFile = path.join(projectRoot, ".omp", "skills", "my-skill", "SKILL.md");
+			expect(await exists(skillFile)).toBe(true);
+			const content = await fs.readFile(skillFile, "utf8");
+			expect(content).toContain("name: my-skill");
+			expect(content).toContain("description: Demo skill.");
+			expect(content).toContain("# Hello");
+		});
+	});
+
+	it("does NOT write when the user discards the directive", async () => {
+		await withTempProject(async projectRoot => {
+			const queue = createFakeQueue();
+			const session = createSession({ cwd: projectRoot, queue });
+			const tool = new SkillCreateTool(session);
+
+			await tool.execute("call-1", {
+				name: "withheld",
+				description: "x.",
+				body: "",
+			});
+			// User never invokes the directive — file must NOT exist on disk.
+			expect(await exists(path.join(projectRoot, ".omp", "skills", "withheld"))).toBe(false);
+		});
+	});
+
+	it("refuses on collision BEFORE queuing approval", async () => {
+		await withTempProject(async projectRoot => {
+			await fs.mkdir(path.join(projectRoot, ".omp", "skills", "taken"), { recursive: true });
+			const queue = createFakeQueue();
+			const session = createSession({ cwd: projectRoot, queue });
+			const tool = new SkillCreateTool(session);
+
+			await expect(tool.execute("call-1", { name: "taken", description: "x.", body: "" })).rejects.toThrow(
+				/already exists/,
+			);
+			expect(queue.directives).toHaveLength(0);
+		});
+	});
+
+	it("refuses on unsafe names BEFORE queuing approval", async () => {
+		await withTempProject(async projectRoot => {
+			const queue = createFakeQueue();
+			const session = createSession({ cwd: projectRoot, queue });
+			const tool = new SkillCreateTool(session);
+
+			await expect(tool.execute("call-1", { name: "../escape", description: "x.", body: "" })).rejects.toThrow();
+			expect(queue.directives).toHaveLength(0);
+		});
+	});
+
+	it('refuses when buildToolChoice returns a non-object value (e.g. "required")', async () => {
+		// Some providers return the string "required" from buildToolChoice
+		// instead of a structured tool-choice object. In that case
+		// queueResolveHandler no-ops, so skill_create must hard-fail rather
+		// than emit "pending user approval" for a directive that was never
+		// queued.
+		await withTempProject(async projectRoot => {
+			const queue = createFakeQueue();
+			const settings = Settings.isolated({
+				"skills.enabled": true,
+				"skills.enableCodexUser": false,
+				"skills.enableClaudeUser": false,
+				"skills.enableClaudeProject": false,
+				"skills.enablePiUser": false,
+				"skills.enablePiProject": true,
+			});
+			const session: ToolSession = {
+				cwd: projectRoot,
+				hasUI: false,
+				getSessionFile: () => null,
+				getSessionSpawns: () => "*",
+				settings,
+				getToolChoiceQueue: () => queue as unknown as ReturnType<NonNullable<ToolSession["getToolChoiceQueue"]>>,
+				buildToolChoice: () => "required" as unknown as ReturnType<NonNullable<ToolSession["buildToolChoice"]>>,
+				steer: () => {},
+			};
+			const tool = new SkillCreateTool(session);
+
+			await expect(tool.execute("call-1", { name: "needs-approval", description: "x.", body: "" })).rejects.toThrow(
+				/user approval/,
+			);
+			expect(queue.directives).toHaveLength(0);
+			expect(await exists(path.join(projectRoot, ".omp", "skills", "needs-approval"))).toBe(false);
+		});
+	});
+});
+
+describe("SkillReloadTool", () => {
+	it("publishes a fresh skill into the active snapshot and resolves via skill://", async () => {
+		await withTempProject(async projectRoot => {
+			const session = createSession({ cwd: projectRoot });
+			await createSkillPackage(projectRoot, {
+				name: "hotloaded",
+				description: "Reachable after reload.",
+				body: "# Hotloaded\n\nThe body.",
+			});
+
+			const tool = new SkillReloadTool(session);
+			const result = await tool.execute("call-r", {});
+			const text = getText(result);
+			expect(text).toMatch(/hotloaded/);
+			expect(text).toMatch(/added/);
+
+			const active = getActiveSkills();
+			expect(active.some(s => s.name === "hotloaded")).toBe(true);
+
+			// skill://hotloaded resolves via the protocol handler using the
+			// process-global active-skill snapshot we just published.
+			const handler = new SkillProtocolHandler();
+			const resource = await handler.resolve(parseInternalUrl("skill://hotloaded"));
+			expect(resource.content).toContain("# Hotloaded");
+			expect(resource.content).toContain("The body.");
+		});
+	});
+
+	it("is idempotent: two consecutive reloads with no FS change produce an empty diff", async () => {
+		await withTempProject(async projectRoot => {
+			const session = createSession({ cwd: projectRoot });
+			await createSkillPackage(projectRoot, {
+				name: "stable-skill",
+				description: "x.",
+				body: "",
+			});
+			const tool = new SkillReloadTool(session);
+			await tool.execute("call-r1", {});
+			const second = await tool.execute("call-r2", {});
+			const text = getText(second);
+			expect(text).toContain("added: (none)");
+			expect(text).toContain("removed: (none)");
+			expect(text).toContain("changed: (none)");
+		});
+	});
+});

--- a/packages/coding-agent/test/skills-surface.test.ts
+++ b/packages/coding-agent/test/skills-surface.test.ts
@@ -1,0 +1,102 @@
+// Coverage for positive-framing skill surface (`skillSurface: "auto" |
+// "command"`) and its legacy `hide: true` alias.
+
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { deriveSkillSurface, loadSkills } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
+
+interface SkillFixture {
+	name: string;
+	frontmatter: Record<string, unknown>;
+}
+
+async function withSkillFixtures<T>(fixtures: SkillFixture[], fn: (dir: string) => Promise<T>): Promise<T> {
+	const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "skill-surface-"));
+	try {
+		for (const fixture of fixtures) {
+			const skillDir = path.join(tempDir, fixture.name);
+			await fs.mkdir(skillDir, { recursive: true });
+			const fmLines = ["---", `name: ${fixture.name}`, "description: Test skill."];
+			for (const [key, value] of Object.entries(fixture.frontmatter)) {
+				fmLines.push(`${key}: ${JSON.stringify(value)}`);
+			}
+			fmLines.push("---", "", `# ${fixture.name}`, "");
+			await fs.writeFile(path.join(skillDir, "SKILL.md"), fmLines.join("\n"));
+		}
+		return await fn(tempDir);
+	} finally {
+		await fs.rm(tempDir, { recursive: true, force: true });
+	}
+}
+
+describe("deriveSkillSurface", () => {
+	it("defaults to auto when nothing is set", () => {
+		expect(deriveSkillSurface(undefined)).toBe("auto");
+		expect(deriveSkillSurface({})).toBe("auto");
+	});
+
+	it("honours explicit skillSurface", () => {
+		expect(deriveSkillSurface({ skillSurface: "auto" })).toBe("auto");
+		expect(deriveSkillSurface({ skillSurface: "command" })).toBe("command");
+	});
+
+	it("treats legacy hide: true as command", () => {
+		expect(deriveSkillSurface({ hide: true })).toBe("command");
+	});
+
+	it("explicit skillSurface beats legacy hide", () => {
+		expect(deriveSkillSurface({ skillSurface: "auto", hide: true })).toBe("auto");
+		expect(deriveSkillSurface({ skillSurface: "command", hide: false })).toBe("command");
+	});
+
+	it("ignores garbage skillSurface values and falls back to hide / default", () => {
+		expect(deriveSkillSurface({ skillSurface: "nonsense" as unknown as "auto" })).toBe("auto");
+		expect(deriveSkillSurface({ skillSurface: 42 as unknown as "auto", hide: true })).toBe("command");
+	});
+});
+
+describe("loadSkills with skillSurface", () => {
+	it("loads command-surfaced skills but tags them so the prompt filter can drop them", async () => {
+		await withSkillFixtures(
+			[
+				{ name: "auto-skill", frontmatter: {} },
+				{ name: "command-skill", frontmatter: { skillSurface: "command" } },
+				{ name: "hidden-legacy", frontmatter: { hide: true } },
+			],
+			async dir => {
+				const { skills } = await loadSkills({
+					enableCodexUser: false,
+					enableClaudeUser: false,
+					enableClaudeProject: false,
+					enablePiUser: false,
+					enablePiProject: false,
+					customDirectories: [dir],
+				});
+
+				const byName = new Map(skills.map(skill => [skill.name, skill]));
+				expect(byName.has("auto-skill")).toBe(true);
+				expect(byName.has("command-skill")).toBe(true);
+				expect(byName.has("hidden-legacy")).toBe(true);
+
+				expect(byName.get("auto-skill")?.surface ?? "auto").toBe("auto");
+				expect(byName.get("command-skill")?.surface).toBe("command");
+				expect(byName.get("hidden-legacy")?.surface).toBe("command");
+
+				// `.hide` mirror stays in sync so legacy callsites keep working.
+				expect(byName.get("auto-skill")?.hide).toBe(false);
+				expect(byName.get("command-skill")?.hide).toBe(true);
+				expect(byName.get("hidden-legacy")?.hide).toBe(true);
+
+				// The rendered-prompt filter (mirroring system-prompt.ts) drops
+				// any skill whose effective surface is "command".
+				const visibleInPrompt = skills.filter(skill => (skill.surface ?? "auto") !== "command");
+				const visibleNames = visibleInPrompt.map(skill => skill.name);
+				expect(visibleNames).toContain("auto-skill");
+				expect(visibleNames).not.toContain("command-skill");
+				expect(visibleNames).not.toContain("hidden-legacy");
+			},
+		);
+	});
+});

--- a/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
+++ b/packages/coding-agent/test/tools/split-internal-url-sel.test.ts
@@ -49,6 +49,21 @@ describe("splitInternalUrlSel", () => {
 		expect(splitInternalUrlSel("skill://plugin:name")).toEqual({ path: "skill://plugin:name" });
 	});
 
+	it("peels selectors from knowledge:// URLs", () => {
+		expect(splitInternalUrlSel("knowledge://memory/notes.md:50-100")).toEqual({
+			path: "knowledge://memory/notes.md",
+			sel: "50-100",
+		});
+		expect(splitInternalUrlSel("knowledge://memory/notes.md:raw")).toEqual({
+			path: "knowledge://memory/notes.md",
+			sel: "raw",
+		});
+		expect(splitInternalUrlSel("knowledge://memory/notes.md?part=body:1-20")).toEqual({
+			path: "knowledge://memory/notes.md?part=body",
+			sel: "1-20",
+		});
+	});
+
 	it("stops at the scheme separator `://`", () => {
 		expect(splitInternalUrlSel("agent://1-50")).toEqual({ path: "agent://1-50" });
 	});

--- a/scripts/bench-knowledge-tools.ts
+++ b/scripts/bench-knowledge-tools.ts
@@ -1,0 +1,412 @@
+// Knowledge tools end-to-end bench. Validates that the new knowledge API
+// (a) creates files where the taxonomy says it should, (b) refuses the
+// writes that would damage user-owned content, and (c) makes the result
+// discoverable through list/query/read.
+//
+// Baseline (upstream/main) ships no knowledge API at all, so the only
+// thing an agent on baseline can do is bash `write` and `read` blind
+// against the memory root. We simulate that here and compare.
+
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	knowledgeCreateDirectory,
+	knowledgeCreateDocument,
+	knowledgeDelete,
+	knowledgeEditDocument,
+	knowledgeList,
+	knowledgeQuery,
+	knowledgeRead,
+	KnowledgeOpsError,
+} from "../packages/coding-agent/src/memories/knowledge-ops";
+
+interface Check {
+	name: string;
+	pass: boolean;
+	detail?: string;
+}
+
+const checks: Check[] = [];
+function assert(name: string, pass: boolean, detail?: string) {
+	checks.push({ name, pass, detail });
+}
+
+async function mktemp(label: string): Promise<string> {
+	return fs.mkdtemp(path.join(os.tmpdir(), `bench-knowledge-${label}-`));
+}
+
+async function exists(p: string): Promise<boolean> {
+	try {
+		await fs.access(p);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+// ---------- new system ----------------------------------------------
+
+async function runNew(): Promise<void> {
+	const root = await mktemp("new");
+	try {
+		// Seed: user-owned reference doc and user-protected skill.
+		const refPath = path.join(root, "reference", "vendor-api.md");
+		await fs.mkdir(path.dirname(refPath), { recursive: true });
+		await Bun.write(refPath, "# Vendor API\n\n- POST /v1/widgets {sku}\n");
+
+		// Seed a body-marker'd skill, then flip aiMaintained to false on
+		// disk so mutating ops route through approvalSink rather than
+		// hitting the marker-less refusal.
+		await knowledgeCreateDocument(root, "skill/deploy-runbook/SKILL.md", {
+			body: "Hand-curated. Do not rewrite.",
+		});
+		const protectedSkill = path.join(root, "skill", "deploy-runbook", "SKILL.md");
+		const originalSkillBytes = await Bun.file(protectedSkill).text();
+		await Bun.write(
+			protectedSkill,
+			originalSkillBytes
+				.replace("aiMaintained: true", "aiMaintained: false")
+				.replace("inheritAiConfig: true", "inheritAiConfig: false"),
+		);
+
+		// Op 1: create a memory document. Expect file with frontmatter + body markers.
+		await knowledgeCreateDocument(root, "memory/eu-region.md", {
+			summary: "Production DB lives in eu-west-1",
+			body: "The production database is in eu-west-1 and snapshots nightly at 02:00 UTC.",
+		});
+		const memDocPath = path.join(root, "memory", "eu-region.md");
+		const memDocText = await Bun.file(memDocPath).text();
+		assert(
+			"create memory doc materializes file",
+			await exists(memDocPath),
+			memDocPath,
+		);
+		assert(
+			"memory doc carries frontmatter",
+			memDocText.startsWith("---\n") && memDocText.includes("aiMaintained:"),
+		);
+		assert(
+			"memory doc wraps body in omp markers",
+			memDocText.includes("<!-- omp:body:start -->") &&
+				memDocText.includes("<!-- omp:body:end -->"),
+		);
+		assert(
+			"memory doc body preserved verbatim",
+			memDocText.includes("eu-west-1 and snapshots nightly"),
+		);
+
+		// Op 2: create a skill playbook.
+		await knowledgeCreateDocument(root, "skill/test-runner/SKILL.md", {
+			summary: "Run focused bun tests",
+			body: "Use `bun test path/to/file.test.ts` rather than the package-wide runner.",
+		});
+		assert(
+			"create skill SKILL.md materializes",
+			await exists(path.join(root, "skill", "test-runner", "SKILL.md")),
+		);
+
+		// Op 3: create a directory.
+		await knowledgeCreateDirectory(root, "memory/team");
+		assert(
+			"create directory materializes",
+			await exists(path.join(root, "memory", "team")),
+		);
+
+		// Op 4: edit existing AI-maintained doc.
+		await knowledgeEditDocument(root, "memory/eu-region.md", {
+			body: "The production database is in eu-west-1. Snapshots every 30 minutes since the May incident.",
+		});
+		const edited = await Bun.file(memDocPath).text();
+		assert(
+			"edit replaces body inside markers",
+			edited.includes("every 30 minutes since the May incident"),
+		);
+
+		// Op 5: refuse to overwrite user-protected skill without approval.
+		let refusedSkillNoSink = false;
+		try {
+			await knowledgeEditDocument(root, "skill/deploy-runbook/SKILL.md", {
+				body: "rewritten by agent",
+			});
+		} catch (e) {
+			refusedSkillNoSink = e instanceof KnowledgeOpsError && e.code === "permission_denied";
+		}
+		const skillBytesAfter = await Bun.file(protectedSkill).text();
+		assert(
+			"refuses edit on aiMaintained:false skill without approvalSink",
+			refusedSkillNoSink && skillBytesAfter.includes("Hand-curated"),
+		);
+
+		// Op 5b: routes the edit through approvalSink when one is provided
+		// and lands the write on approval.
+		const sinkOutcome = await knowledgeEditDocument(
+			root,
+			"skill/deploy-runbook/SKILL.md",
+			{ body: "rewritten by agent (approved)" },
+			{ approvalSink: async req => { await req.apply(); } },
+		);
+		const skillAfterApproval = await Bun.file(protectedSkill).text();
+		assert(
+			"approvalSink lands the user-protected edit",
+			sinkOutcome.applied && sinkOutcome.requiredApproval && skillAfterApproval.includes("approved"),
+		);
+
+		// Op 5c: routes through approvalSink but sink withholds apply.
+		const beforeBytes = skillAfterApproval;
+		const withheld = await knowledgeEditDocument(
+			root,
+			"skill/deploy-runbook/SKILL.md",
+			{ body: "should not land" },
+			{ approvalSink: async _req => { /* user declined */ } },
+		);
+		const stillSame = (await Bun.file(protectedSkill).text()) === beforeBytes;
+		assert(
+			"approvalSink withholding apply leaves bytes untouched",
+			!withheld.applied && withheld.requiredApproval && stillSame,
+		);
+
+		// Restore the user-protected skill body (markers + aiMaintained:false)
+		// so downstream delete assertions can target it again.
+		await Bun.write(
+			protectedSkill,
+			originalSkillBytes
+				.replace("aiMaintained: true", "aiMaintained: false")
+				.replace("inheritAiConfig: true", "inheritAiConfig: false"),
+		);
+
+		// Op 5d: design/ create requires approval; without sink → refused.
+		let designRefused = false;
+		try {
+			await knowledgeCreateDocument(root, "design/architecture.md", { body: "x" });
+		} catch (e) {
+			designRefused = e instanceof KnowledgeOpsError && e.code === "permission_denied";
+		}
+		assert(
+			"design/ create refused without approvalSink",
+			designRefused && !(await exists(path.join(root, "design", "architecture.md"))),
+		);
+
+		// Op 5e: design/ create with auto-approve sink lands the doc and
+		// inherits `aiMaintained: false` from design/ defaults.
+		const designOutcome = await knowledgeCreateDocument(
+			root,
+			"design/architecture.md",
+			{ body: "AI-proposed architecture body" },
+			{ approvalSink: async req => { await req.apply(); } },
+		);
+		const designWritten = await Bun.file(path.join(root, "design", "architecture.md")).text();
+		assert(
+			"design/ create through approvalSink lands with aiMaintained:false",
+			designOutcome.applied
+				&& designOutcome.requiredApproval
+				&& designWritten.includes("<!-- omp:body:start -->")
+				&& designWritten.includes("AI-proposed architecture body")
+				&& designWritten.includes("aiMaintained: false"),
+		);
+
+		// Op 6: refuse to create in reference/.
+		let refusedRef = false;
+		try {
+			await knowledgeCreateDocument(root, "reference/notes.md", { body: "new" });
+		} catch (e) {
+			refusedRef = e instanceof KnowledgeOpsError && e.code === "permission_denied";
+		}
+		assert(
+			"refuses create under read-only reference/",
+			refusedRef && !(await exists(path.join(root, "reference", "notes.md"))),
+		);
+
+		// Op 7: refuse cross-type move (e.g. skill -> memory).
+		let refusedMove = false;
+		try {
+			await knowledgeDelete(root, "skill/test-runner/SKILL.md", "document");
+			// Recreate to keep state; then attempt invalid path shape.
+			await knowledgeCreateDocument(root, "skill/test-runner/SKILL.md", {
+				body: "back",
+			});
+			// Cross-type via resolveKnowledgePath rejection: try sidecar.
+			await knowledgeCreateDocument(root, "memory/.omp-meta", { body: "x" });
+		} catch (e) {
+			refusedMove = e instanceof KnowledgeOpsError && e.code === "invalid_path";
+		}
+		assert("refuses .omp-meta path as a document", refusedMove);
+
+		// Op 8: list + query + read.
+		const listed = await knowledgeList(root);
+		const listedPaths = listed.map(e => e.path);
+		assert(
+			"list surfaces memory and skill docs",
+			listedPaths.includes("memory/eu-region.md") &&
+				listedPaths.includes("skill/test-runner/SKILL.md") &&
+				listedPaths.includes("reference/vendor-api.md"),
+			`got ${listedPaths.length} entries`,
+		);
+
+		const hits = await knowledgeQuery(root, { lexicalQuery: "eu-west-1 snapshots" });
+		assert(
+			"query returns relevant hit",
+			hits.length > 0 && hits[0].path === "memory/eu-region.md" && hits[0].score > 0,
+			`top hit ${hits[0]?.path} score=${hits[0]?.score}`,
+		);
+
+		const readFull = await knowledgeRead(root, "memory/eu-region.md", "full");
+		const readBody = await knowledgeRead(root, "memory/eu-region.md", "body");
+		const readSummary = await knowledgeRead(root, "memory/eu-region.md", "summary");
+		assert("read full returns whole file", readFull.content.includes("aiMaintained"));
+		assert(
+			"read body strips frontmatter+markers",
+			!readBody.content.includes("aiMaintained") &&
+				!readBody.content.includes("<!-- omp:body:start -->") &&
+				readBody.content.includes("every 30 minutes"),
+		);
+		assert(
+			"read summary returns frontmatter summary",
+			readSummary.content.includes("eu-west-1"),
+		);
+
+		// Op 9: delete AI-maintained doc.
+		await knowledgeDelete(root, "memory/eu-region.md", "document");
+		assert(
+			"delete removes AI-maintained doc",
+			!(await exists(memDocPath)),
+		);
+
+		// Op 10: delete refuses on user-protected without approvalSink.
+		let refusedDelete = false;
+		try {
+			await knowledgeDelete(root, "skill/deploy-runbook/SKILL.md", "document");
+		} catch (e) {
+			refusedDelete = e instanceof KnowledgeOpsError && e.code === "permission_denied";
+		}
+		assert(
+			"delete refuses on aiMaintained:false without approvalSink",
+			refusedDelete && (await exists(protectedSkill)),
+		);
+
+		// Op 10b: delete proceeds when approvalSink applies the request.
+		const deleteOutcome = await knowledgeDelete(
+			root,
+			"skill/deploy-runbook/SKILL.md",
+			"document",
+			{ approvalSink: async req => { await req.apply(); } },
+		);
+		assert(
+			"delete routes through approvalSink on aiMaintained:false",
+			deleteOutcome.applied && deleteOutcome.requiredApproval && !(await exists(protectedSkill)),
+		);
+	} finally {
+		await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+	}
+}
+
+// ---------- baseline behaviour --------------------------------------
+//
+// Upstream/main has no knowledge API. An agent that wanted to record a
+// note would use raw `write` (bash redirect or the Write tool). There is
+// no path-shape enforcement, no body markers, and no permission gate —
+// so the agent CAN clobber user-owned files and emit files that the
+// consolidator will later treat as its own (re)writeable property.
+
+async function runBaseline(): Promise<void> {
+	const root = await mktemp("baseline");
+	try {
+		const refPath = path.join(root, "reference", "vendor-api.md");
+		await fs.mkdir(path.dirname(refPath), { recursive: true });
+		const originalRef = "# Vendor API\n\n- POST /v1/widgets {sku}\n";
+		await Bun.write(refPath, originalRef);
+
+		const protectedSkill = path.join(root, "skills", "deploy-runbook", "SKILL.md");
+		await fs.mkdir(path.dirname(protectedSkill), { recursive: true });
+		const originalSkill = "---\naiMaintained: false\n---\n# Deploy Runbook\n\nHand-curated. Do not rewrite.\n";
+		await Bun.write(protectedSkill, originalSkill);
+
+		// Agent "creates" a memory note via free-form write.
+		const memDocPath = path.join(root, "memory-notes-eu-region.md");
+		await Bun.write(memDocPath, "# eu-region\n\nThe production database is in eu-west-1.\n");
+		const memDocText = await Bun.file(memDocPath).text();
+		assert(
+			"baseline: create write puts file somewhere (no taxonomy enforced)",
+			await exists(memDocPath),
+		);
+		assert(
+			"baseline: no frontmatter present",
+			!memDocText.startsWith("---\n"),
+		);
+		assert(
+			"baseline: no omp body markers",
+			!memDocText.includes("<!-- omp:body:start -->"),
+		);
+
+		// Agent has no guard rail — it overwrites the user-protected skill.
+		await Bun.write(protectedSkill, "# Deploy Runbook\n\nRewritten by agent.\n");
+		const skillAfter = await Bun.file(protectedSkill).text();
+		assert(
+			"baseline: nothing stops overwrite of user-protected skill",
+			!skillAfter.includes("Hand-curated"),
+		);
+
+		// Agent overwrites reference/ too. There's no `reference/` concept upstream.
+		await Bun.write(refPath, "# Vendor API\n\nOverwritten.\n");
+		const refAfter = await Bun.file(refPath).text();
+		assert(
+			"baseline: nothing stops overwrite of reference/",
+			!refAfter.includes("POST /v1/widgets"),
+		);
+
+		// No query/list API: simulate by recursing.
+		const found: string[] = [];
+		async function walk(dir: string) {
+			for (const e of await fs.readdir(dir, { withFileTypes: true })) {
+				const full = path.join(dir, e.name);
+				if (e.isDirectory()) await walk(full);
+				else found.push(full);
+			}
+		}
+		await walk(root);
+		assert(
+			"baseline: no query helper — agents must walk and grep manually",
+			found.length > 0,
+			`found ${found.length} files`,
+		);
+	} finally {
+		await fs.rm(root, { recursive: true, force: true }).catch(() => {});
+	}
+}
+
+// ---------- driver ---------------------------------------------------
+
+async function main() {
+	console.log("=== new system (knowledge tools wired) ===");
+	const newStart = checks.length;
+	await runNew();
+	const newChecks = checks.slice(newStart);
+	for (const c of newChecks) {
+		console.log(`  ${c.pass ? "ok " : "FAIL"}  ${c.name}${c.detail ? "  (" + c.detail + ")" : ""}`);
+	}
+
+	console.log("\n=== baseline (upstream/main, free-form write) ===");
+	const baselineStart = checks.length;
+	await runBaseline();
+	const baselineChecks = checks.slice(baselineStart);
+	for (const c of baselineChecks) {
+		console.log(`  ${c.pass ? "ok " : "FAIL"}  ${c.name}${c.detail ? "  (" + c.detail + ")" : ""}`);
+	}
+
+	const newPass = newChecks.filter(c => c.pass).length;
+	const newTotal = newChecks.length;
+	const baseSafety = baselineChecks.filter(c =>
+		c.name.startsWith("baseline:") && c.name.includes("nothing stops"),
+	).length;
+
+	console.log("\n=== verdict ===");
+	console.log(`new system:  ${newPass}/${newTotal} behaviours correct`);
+	console.log(`baseline:    ${baseSafety} demonstrated user-data clobbers (no API to refuse them)`);
+
+	if (newPass !== newTotal) {
+		console.log("\nFAILURES on new system — bench failed.");
+		process.exit(1);
+	}
+}
+
+await main();

--- a/scripts/bench-memory-taxonomy.ts
+++ b/scripts/bench-memory-taxonomy.ts
@@ -1,0 +1,328 @@
+// Head-to-head benchmark: baseline (upstream/main) vs new four-bucket
+// taxonomy. Both implementations run against identical scenarios that
+// model what Phase-2 actually does in practice. We report:
+//
+//   - User-content preservation: bytes of user-authored files that
+//     survived a consolidation pass that did NOT mention them. A
+//     correct system should preserve 100%.
+//   - Throughput: wall-clock per applyConsolidation call.
+//
+// The baseline is reimplemented inline because the original
+// `applyConsolidation` is module-private; the body below matches
+// `fb863a590:packages/coding-agent/src/memories/index.ts` byte-for-byte
+// in behaviour.
+
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { applyConsolidation } from "../packages/coding-agent/src/memories";
+
+interface ConsolidationSkillFile {
+	path: string;
+	content: string;
+}
+interface ConsolidationSkill {
+	name: string;
+	content: string;
+	scripts: ConsolidationSkillFile[];
+	templates: ConsolidationSkillFile[];
+	examples: ConsolidationSkillFile[];
+}
+interface ConsolidationInput {
+	memoryMd: string;
+	memorySummary: string;
+	skills: ConsolidationSkill[];
+	designDrafts: ConsolidationSkillFile[];
+}
+
+// ------- BASELINE (verbatim port of fb863a590 behaviour) -----------
+
+async function listRelativeFiles(rootDir: string, prefix = ""): Promise<string[]> {
+	const entries = await fs.readdir(rootDir, { withFileTypes: true }).catch(() => []);
+	const files: string[] = [];
+	for (const entry of entries) {
+		const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+		if (entry.isDirectory()) {
+			files.push(...(await listRelativeFiles(path.join(rootDir, entry.name), relative)));
+			continue;
+		}
+		if (entry.isFile()) files.push(relative);
+	}
+	return files;
+}
+
+async function pruneEmptyDirectories(rootDir: string): Promise<void> {
+	const entries = await fs.readdir(rootDir, { withFileTypes: true }).catch(() => []);
+	for (const entry of entries) {
+		if (!entry.isDirectory()) continue;
+		const child = path.join(rootDir, entry.name);
+		await pruneEmptyDirectories(child);
+		const childEntries = await fs.readdir(child).catch(() => []);
+		if (childEntries.length === 0) {
+			await fs.rm(child, { recursive: true, force: true });
+		}
+	}
+}
+
+async function applyConsolidationBaseline(memoryRoot: string, c: ConsolidationInput): Promise<void> {
+	await fs.mkdir(memoryRoot, { recursive: true });
+	await Bun.write(path.join(memoryRoot, "MEMORY.md"), `${c.memoryMd.trim()}\n`);
+	await Bun.write(path.join(memoryRoot, "memory_summary.md"), `${c.memorySummary.trim()}\n`);
+	const skillsDir = path.join(memoryRoot, "skills");
+	await fs.mkdir(skillsDir, { recursive: true });
+	const keep = new Set<string>();
+	for (const skill of c.skills) {
+		const dir = path.join(skillsDir, skill.name);
+		keep.add(skill.name);
+		await fs.mkdir(dir, { recursive: true });
+		const files = new Map<string, string>();
+		files.set("SKILL.md", `${skill.content.trim()}\n`);
+		for (const item of skill.scripts)
+			files.set(path.posix.join("scripts", item.path), `${item.content.trim()}\n`);
+		for (const item of skill.templates)
+			files.set(path.posix.join("templates", item.path), `${item.content.trim()}\n`);
+		for (const item of skill.examples)
+			files.set(path.posix.join("examples", item.path), `${item.content.trim()}\n`);
+		for (const [rel, content] of [...files.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+			await Bun.write(path.join(dir, ...rel.split("/")), content);
+		}
+		const keepFiles = new Set(files.keys());
+		const existingFiles = await listRelativeFiles(dir);
+		for (const rel of existingFiles) {
+			if (keepFiles.has(rel)) continue;
+			await fs.rm(path.join(dir, ...rel.split("/")), { force: true });
+		}
+		await pruneEmptyDirectories(dir);
+	}
+	const dirs = await fs.readdir(skillsDir, { withFileTypes: true }).catch(() => []);
+	for (const dirent of dirs) {
+		if (!dirent.isDirectory()) continue;
+		if (keep.has(dirent.name)) continue;
+		await fs.rm(path.join(skillsDir, dirent.name), { recursive: true, force: true });
+	}
+}
+
+// ------- Scenarios -------------------------------------------------
+
+interface Scenario {
+	id: string;
+	description: string;
+	/**
+	 * Pre-populate the memory root with user-authored content. Returns
+	 * the unique "marker" substrings the test asserts must still appear
+	 * somewhere in the tree after consolidation.
+	 */
+	seed: (memoryRoot: string) => Promise<{ markers: string[] }>;
+	/** Consolidation input the model emits (does not mention user files). */
+	consolidation: ConsolidationInput;
+}
+
+const noConsolidation: ConsolidationInput = {
+	memoryMd: "ai-generated memory body",
+	memorySummary: "ai-generated summary body",
+	skills: [],
+	designDrafts: [],
+};
+
+const scenarios: Scenario[] = [
+	{
+		id: "user-edited-memory-md",
+		description: "User has hand-edited MEMORY.md with notes the model has never seen",
+		async seed(root) {
+			const p = path.join(root, "MEMORY.md");
+			await fs.mkdir(root, { recursive: true });
+			const marker = "The webhook secret rotates weekly";
+			const body = `# Hand-curated facts\n\n- ${marker}.\n- Never call deploy.sh in CI.\n- Production DB lives in eu-west-1.\n`;
+			await Bun.write(p, body);
+			return { markers: [marker] };
+		},
+		consolidation: noConsolidation,
+	},
+	{
+		id: "user-protected-skill",
+		description: "User-owned skill with aiMaintained: false in frontmatter",
+		async seed(root) {
+			// Legacy `skills/` path so both impls see the same input.
+			const p = path.join(root, "skills", "deploy-runbook", "SKILL.md");
+			await fs.mkdir(path.dirname(p), { recursive: true });
+			const marker = "My hand-curated runbook. Do not rewrite.";
+			const body = `---\naiMaintained: false\n---\n# Deploy Runbook\n\n${marker}\n`;
+			await Bun.write(p, body);
+			return { markers: [marker] };
+		},
+		consolidation: noConsolidation,
+	},
+	{
+		id: "user-design-notes",
+		description: "User stores design notes; the consolidator never proposes drafts for them",
+		async seed(root) {
+			const a = path.join(root, "design", "rfc-001.md");
+			const b = path.join(root, "design", "subsystems", "auth.md");
+			await fs.mkdir(path.dirname(a), { recursive: true });
+			await fs.mkdir(path.dirname(b), { recursive: true });
+			const markerA = "Phase A → Phase B → Phase C";
+			const markerB = "OIDC + WebAuthn fallback";
+			await Bun.write(a, `# RFC 001 — Cutover plan\n\n${markerA}.\n`);
+			await Bun.write(b, `# Auth subsystem\n\n${markerB}.\n`);
+			return { markers: [markerA, markerB] };
+		},
+		consolidation: noConsolidation,
+	},
+	{
+		id: "user-reference-material",
+		description: "User curated reference material under reference/ — must never be touched",
+		async seed(root) {
+			const p = path.join(root, "reference", "vendor-api.md");
+			await fs.mkdir(path.dirname(p), { recursive: true });
+			const marker = "POST /v1/widgets {sku}";
+			await Bun.write(p, `# Vendor API quickref\n\n- ${marker}\n- GET /v1/widgets/{id}\n`);
+			return { markers: [marker] };
+		},
+		consolidation: noConsolidation,
+	},
+	{
+		id: "mixed-cold-start",
+		description: "Cold root, large consolidation (10 skills, 50 KB body) — throughput check",
+		async seed() {
+			return { markers: [] };
+		},
+		consolidation: {
+			memoryMd: "x".repeat(25_000),
+			memorySummary: "y".repeat(25_000),
+			skills: Array.from({ length: 10 }, (_, i) => ({
+				name: `skill-${i}`,
+				content: `# Skill ${i}\n\n${"z".repeat(5_000)}`,
+				scripts: [],
+				templates: [],
+				examples: [],
+			})),
+			designDrafts: [],
+		},
+	},
+];
+
+// ------- Driver ----------------------------------------------------
+
+async function readPreservation(
+	root: string,
+	markers: string[],
+): Promise<{ surviving: number; total: number }> {
+	// Path-agnostic: the new impl migrates legacy paths under typed
+	// buckets, so the marker should still show up somewhere even if the
+	// file moved.
+	const allFiles = await listAllFiles(root);
+	const contents: string[] = [];
+	for (const file of allFiles) {
+		const text = await Bun.file(file)
+			.text()
+			.catch(() => undefined);
+		if (text) contents.push(text);
+	}
+	let surviving = 0;
+	let total = 0;
+	for (const marker of markers) {
+		const bytes = Buffer.byteLength(marker, "utf8");
+		total += bytes;
+		if (contents.some(c => c.includes(marker))) surviving += bytes;
+	}
+	return { surviving, total };
+}
+
+async function listAllFiles(root: string): Promise<string[]> {
+	const out: string[] = [];
+	const stack = [root];
+	while (stack.length) {
+		const dir = stack.pop()!;
+		const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
+		for (const e of entries) {
+			const full = path.join(dir, e.name);
+			if (e.isDirectory()) stack.push(full);
+			else if (e.isFile()) out.push(full);
+		}
+	}
+	return out;
+}
+
+interface Result {
+	scenario: string;
+	impl: "baseline" | "new";
+	userBytes: number;
+	preservedBytes: number;
+	ms: number;
+}
+
+async function runScenario(scenario: Scenario, impl: "baseline" | "new"): Promise<Result> {
+	const root = await fs.mkdtemp(path.join(os.tmpdir(), `bench-mem-${impl}-`));
+	try {
+		const { markers } = await scenario.seed(root);
+
+		const before = performance.now();
+		if (impl === "baseline") {
+			await applyConsolidationBaseline(root, scenario.consolidation);
+		} else {
+			await applyConsolidation(root, scenario.consolidation);
+		}
+		const elapsed = performance.now() - before;
+
+		const { surviving, total } = await readPreservation(root, markers);
+		return { scenario: scenario.id, impl, userBytes: total, preservedBytes: surviving, ms: elapsed };
+	} finally {
+		await fs.rm(root, { recursive: true, force: true });
+	}
+}
+
+function pct(n: number, d: number): string {
+	if (d === 0) return "n/a";
+	return `${((100 * n) / d).toFixed(1)}%`;
+}
+
+async function main() {
+	const rows: Result[] = [];
+	for (const s of scenarios) {
+		for (const impl of ["baseline", "new"] as const) {
+			// Warm + 3 timed runs; report best.
+			await runScenario(s, impl);
+			let best: Result | undefined;
+			for (let i = 0; i < 3; i++) {
+				const r = await runScenario(s, impl);
+				if (!best || r.ms < best.ms) best = r;
+			}
+			rows.push(best!);
+		}
+	}
+
+	console.log("scenario                          impl       userKB  preserved   ms");
+	console.log("-".repeat(78));
+	for (const r of rows) {
+		const userKB = (r.userBytes / 1024).toFixed(2).padStart(7);
+		const preserved = pct(r.preservedBytes, r.userBytes).padStart(9);
+		const ms = r.ms.toFixed(1).padStart(6);
+		console.log(`${r.scenario.padEnd(33)} ${r.impl.padEnd(9)} ${userKB}  ${preserved}  ${ms}`);
+	}
+
+	// Pairwise summary
+	console.log("\nPreservation delta (new − baseline):");
+	const byScen = new Map<string, { baseline: Result; new: Result }>();
+	for (const r of rows) {
+		const e = byScen.get(r.scenario) ?? ({} as { baseline: Result; new: Result });
+		// biome-ignore lint/suspicious/noExplicitAny: dynamic write
+		(e as any)[r.impl] = r;
+		byScen.set(r.scenario, e);
+	}
+	let netDelta = 0;
+	for (const [id, { baseline, new: nu }] of byScen) {
+		if (baseline.userBytes === 0) {
+			console.log(`  ${id.padEnd(33)} — no user content`);
+			continue;
+		}
+		const delta = nu.preservedBytes - baseline.preservedBytes;
+		netDelta += delta;
+		const sign = delta >= 0 ? "+" : "";
+		console.log(
+			`  ${id.padEnd(33)} baseline=${pct(baseline.preservedBytes, baseline.userBytes).padStart(6)}  new=${pct(nu.preservedBytes, nu.userBytes).padStart(6)}  Δ=${sign}${delta}B`,
+		);
+	}
+	console.log(`\nNet preserved-bytes delta: ${netDelta >= 0 ? "+" : ""}${netDelta}B`);
+}
+
+await main();


### PR DESCRIPTION
# What this changes

OMP keeps a folder of long-term notes the agent uses across sessions — its "memory." Today that folder is a flat pile: the consolidator (the background job that summarizes recent work) can overwrite anything in it, and there's no way to tell the agent "leave this alone, I own it." This PR reorganizes the memory folder into four labeled sub-folders, each with clear rules about who is allowed to touch what, and it adds tools the agent can call to read and edit notes safely.

## The four folders

Inside the memory root, content now lives under exactly one of these:

| Folder | Who writes it | Default behavior |
|---|---|---|
| `memory/` | AI | The consolidator refreshes it every run. Treat it like the agent's notebook. |
| `skill/<name>/` | AI | Reusable playbooks the agent reaches for via `skill://<name>`. Same refresh rules as `memory/`. |
| `design/` | You (the user) | Architecture notes, plans, decisions. The agent can propose edits, but every change needs your approval before it lands. |
| `reference/` | You (the user) | External material the agent should read but never modify. Like a library — look, don't write. |

When you drop a `.md` file into one of these folders, OMP already knows what to expect from it based on the folder name. No setup required.

## The two safety flags

Every folder (and every individual doc) carries two booleans:

- **`readOnly`** — the hard stop. If a doc or folder is read-only, no write goes through. Period. `reference/` is read-only by default; you can also flip individual files this way.
- **`aiMaintained`** — the routing flag. If a doc is `aiMaintained: false`, the agent can still propose edits, but the change is queued for your approval through the `resolve` tool (the same flow `ast_edit` uses) instead of landing immediately. `design/` is `aiMaintained: false` by default.

Together: `readOnly` means "refuse." `aiMaintained: false` means "ask first."

## Body markers protect your edits

Every file the AI maintains carries invisible HTML-comment markers around the part the consolidator is allowed to rewrite:

```
<!-- omp:body:start -->
... AI-managed content here ...
<!-- omp:body:end -->
```

Anything outside those markers — the YAML frontmatter at the top, your own notes around it — survives every refresh byte-for-byte. If you delete the markers, the file becomes yours: the consolidator never touches it again.

## `.omp-meta` sidecars

If you want different rules for a specific folder (e.g. "no new files allowed in this subtree"), drop a `<foldername>.omp-meta` YAML file next to it:

```yaml
allowCreateDocuments: false
allowCreateDirectories: false
inheritToChildren: true
```

Rules cascade down the tree, and each folder's sidecar can override what its parents declared.

## Knowledge tools

The agent gets seven new tools to work with this memory store:

| Tool | What it does |
|---|---|
| `knowledge_list` | List documents and folders |
| `knowledge_query` | Search by keywords (and a placeholder for semantic search) |
| `knowledge_read` | Read a doc (full, summary, or just the body region) |
| `knowledge_create` | Create a new doc or folder |
| `knowledge_edit` | Edit the summary, body, or maintenance rules of a doc |
| `knowledge_move` | Rename or relocate a doc / folder |
| `knowledge_delete` | Delete a doc / folder |

Any tool that mutates a file in a `design/` (or similarly `aiMaintained: false`) folder is automatically routed through your approval queue — the agent stages the change, you see a preview, and you accept or reject it.

## Skill authoring tools

Two more tools let the agent author its own playbooks:

- `skill_create` — drafts a new `SKILL.md` at `.omp/skills/<name>/SKILL.md`. Always routes through your approval, because skills become high-trust instructions the agent later reads back as `skill://<name>`.
- `skill_reload` — re-scans the skills directory and publishes the new snapshot. New skills become reachable via `skill://<name>` and `/skill:<name>` without restarting the session.

## What about existing memory files?

The PR handles the upgrade automatically. The first time Phase-2 runs on your old layout:

- `MEMORY.md` moves to `memory/MEMORY.md`
- `memory_summary.md` moves to `memory/memory_summary.md`
- `skills/<name>/` moves to `skill/<name>/`

Migration wraps each file in body markers so future consolidations can keep refreshing them. If you'd already marked a file `aiMaintained: false` or `readOnly: true` in its frontmatter, that protection is honored and the wrap is skipped.

## Built-in seeds

OMP ships three seed docs the first time you run it:

- `memory/user-preference.md` — your stated preferences
- `memory/project-mistake-note.md` — recurring mistakes worth remembering
- `memory/project-understanding/` — a directory the AI fills as it explores the project, with each subdoc surfaced only as a breadcrumb until the agent actually reads it

The seed version number is bumped on schema changes; the frontmatter and maintenance rules refresh while the body content survives.

## Failure modes the new pipeline refuses

- Writing to a doc whose markers were stripped (treated as user-authored).
- Writing into a `readOnly` folder or any descendant flagged `readOnly`.
- Creating a doc when the folder's sidecar says `allowCreateDocuments: false`.
- Moving a doc into a folder that disallows new documents (or moving a folder into a tree that disallows new directories).
- Deleting a folder that contains a read-only descendant.
- Editing an `aiMaintained: false` doc through the API without supplying an approval sink.
- `knowledge_create kind=directory` or `knowledge_move` with source == destination → returns `(no-op)` instead of a stuck "pending approval" message.
- `knowledge://memory/...` URLs where the type-root directory was symlinked to a different bucket (used to leak; now refused).

## Knobs (settings)

- `knowledge.enabled` (default **true**) — toggles the seven `knowledge_*` tools.
- `skills.enabled` (default true) — toggles `skill_create` / `skill_reload` / `skill_list`.
- Per-doc and per-folder gates: `readOnly`, `aiMaintained`, `allowCreateDocuments`, `allowCreateDirectories`, `allowMoveDocuments`, `allowMoveDirectories`.

## Tests

- `test/memories/taxonomy.test.ts` — bucket defaults, sidecar inheritance, body-marker rewrite invariants, gate enforcement, seed idempotence, `injectMode: path` round-trip, legacy migration, user-protected skill survival, read-only asset preservation, empty-pass prune, legacy MEMORY.md refresh.
- `test/memories/knowledge-ops.test.ts` — path validation, list/query/read, create/edit/move/delete, approvalSink paths, custom ranker, `extractSummarySection` regression coverage.
- `test/internal-urls/memory-protocol.test.ts`, `test/internal-urls/knowledge-protocol.test.ts` — URL handling, symlink containment.
- `test/skill-ops.test.ts`, `test/skill-tools.test.ts` — two-phase prepare/commit, collision recheck, name validation, `resolve` channel detection (including string-valued `forced` values), reload diff.
- `test/skills-surface.test.ts` — `deriveSkillSurface`, `skillSurface: "command"` filtering, `hide: true` legacy alias.
- `scripts/bench-knowledge-tools.ts` and `scripts/bench-memory-taxonomy.ts` — end-to-end behavior parity benches.

## Deferred

- Filesystem watcher (no query cache to invalidate yet).
- Concrete semantic embeddings backend (the `KnowledgeRanker` interface lands now; a provider can ship later).
