### PR TITLE
feat(ai): add zhipu-coding-plan provider for domestic Zhipu BigModel API

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+
+### Added
+
+- Added `zhipu-coding-plan` provider for Zhipu (智谱) BigModel's domestic coding-plan SKU at `https://open.bigmodel.cn/api/coding/paas/v4`, with dynamic model discovery (`ZHIPU_API_KEY`), zai-format thinking, `reasoning_content` field, and OAuth login flow ([#1340](https://github.com/can1357/oh-my-pi/issues/1340)).
+
 ### Removed
 
 - Removed the `pi-ai` CLI binary (`packages/ai/src/cli.ts`) and its `bin` entry. Use the in-process equivalent in the omp coding-agent CLI: `omp auth-broker login [provider]`, `omp auth-broker logout [provider]`, and `omp auth-broker list`. The library API (`AuthStorage.login()`, `getOAuthProviders()`, etc.) is unchanged.

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1520,6 +1520,12 @@ export class AuthStorage {
 				await saveApiKeyCredential(apiKey);
 				return;
 			}
+			case "zhipu-coding-plan": {
+				const { loginZhipuCodingPlan } = await import("./utils/oauth/zhipu");
+				const apiKey = await loginZhipuCodingPlan(ctrl);
+				await saveApiKeyCredential(apiKey);
+				return;
+			}
 			case "qianfan": {
 				const { loginQianfan } = await import("./utils/oauth/qianfan");
 				const apiKey = await loginQianfan(ctrl);

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -42,6 +42,7 @@ import {
 	xaiModelManagerOptions,
 	xiaomiModelManagerOptions,
 	zenmuxModelManagerOptions,
+	zhipuCodingPlanModelManagerOptions,
 } from "./openai-compat";
 import { cursorModelManagerOptions, zaiModelManagerOptions } from "./special";
 
@@ -292,6 +293,12 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		catalog("ZenMux", ["ZENMUX_API_KEY"]),
 	),
 	catalogDescriptor("zai", "glm-5.1", config => zaiModelManagerOptions(config), catalog("zAI", ["ZAI_API_KEY"])),
+	catalogDescriptor(
+		"zhipu-coding-plan",
+		"glm-5.1",
+		config => zhipuCodingPlanModelManagerOptions(config),
+		catalog("Zhipu Coding Plan", ["ZHIPU_API_KEY"]),
+	),
 	descriptor("github-copilot", "gpt-4o", config => githubCopilotModelManagerOptions(config)),
 	descriptor("google", "gemini-2.5-pro", config => googleModelManagerOptions(config)),
 	descriptor("google-vertex", "gemini-3-pro-preview", config => googleVertexModelManagerOptions(config), {

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -601,6 +601,70 @@ export function deepseekModelManagerOptions(
 	return createSimpleOpenAICompletionsOptions("deepseek", "https://api.deepseek.com", config);
 }
 // ---------------------------------------------------------------------------
+// 6.7 Zhipu Coding Plan
+// ---------------------------------------------------------------------------
+
+export interface ZhipuCodingPlanModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+}
+
+export function zhipuCodingPlanModelManagerOptions(
+	config?: ZhipuCodingPlanModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	const apiKey = config?.apiKey;
+	const baseUrl = config?.baseUrl ?? "https://open.bigmodel.cn/api/paas/v4";
+	return {
+		providerId: "zhipu-coding-plan",
+		...(apiKey && {
+			fetchDynamicModels: () =>
+				fetchOpenAICompatibleModels({
+					api: "openai-completions",
+					provider: "zhipu-coding-plan",
+					baseUrl,
+					apiKey,
+					mapModel: (
+						_entry: OpenAICompatibleModelRecord,
+						defaults: Model<"openai-completions">,
+						_context: OpenAICompatibleModelMapperContext<"openai-completions">,
+					): Model<"openai-completions"> => {
+						const id = defaults.id;
+						return {
+							...defaults,
+							reasoning: ZHIPU_REASONING_MODELS[id] === true || id.includes("thinking"),
+							input: ZHIPU_VISION_PATTERN.test(id) ? (["text", "image"] as const) : ["text"],
+							compat: {
+								thinkingFormat: "zai",
+								reasoningContentField: "reasoning_content",
+								supportsDeveloperRole: false,
+							},
+						};
+					},
+				}),
+		}),
+	};
+}
+
+// Reasoning-capable GLM models on the BigModel coding-plan SKU. Keep this
+// explicit rather than regex-matching `glm-[45]\.\d` so newly-added integers
+// like `glm-5` / `glm-5-turbo` are covered and unrelated future SKUs (e.g.
+// `glm-5-preview`) do not silently flip into thinking mode.
+const ZHIPU_REASONING_MODELS: Readonly<Record<string, true>> = {
+	"glm-4.5": true,
+	"glm-4.5-air": true,
+	"glm-4.6": true,
+	"glm-4.7": true,
+	"glm-5": true,
+	"glm-5-turbo": true,
+	"glm-5.1": true,
+};
+
+// Vision-capable GLM models follow the `glm-<N>[.<N>]v[-<variant>]` shape
+// (e.g. `glm-4v`, `glm-4.5v`, `glm-4v-plus`). The previous `id.includes("v")`
+// check matched anything with a `v` — including the non-vision `glm-5-preview`.
+const ZHIPU_VISION_PATTERN = /^glm-[45](?:\.\d+)?v(?:-|$)/;
+
+// ---------------------------------------------------------------------------
 // 7.5 Fireworks
 // ---------------------------------------------------------------------------
 
@@ -2184,6 +2248,14 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS: readonly ModelsDevProviderDe
 			},
 		},
 	),
+	// --- Zhipu Coding Plan ---
+	openAiCompletionsDescriptor("zhipu-coding-plan", "zhipu-coding-plan", "https://open.bigmodel.cn/api/paas/v4", {
+		compat: {
+			thinkingFormat: "zai",
+			reasoningContentField: "reasoning_content",
+			supportsDeveloperRole: false,
+		},
+	}),
 ];
 
 const filterActiveToolCallModels = (_id: string, m: ModelsDevModel): boolean => {

--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -51,6 +51,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 
 	const isCerebras = provider === "cerebras" || baseUrl.includes("cerebras.ai");
 	const isZai = provider === "zai" || baseUrl.includes("api.z.ai");
+	const isZhipu = provider === "zhipu-coding-plan" || baseUrl.includes("open.bigmodel.cn");
 	const isKilo = provider === "kilo" || baseUrl.includes("api.kilo.ai");
 	const isKimiModel = model.id.includes("moonshotai/kimi") || /(^|\/)kimi[-.]/i.test(model.id);
 	const isMoonshotKimi =
@@ -97,6 +98,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		baseUrl.includes("fireworks.ai") ||
 		isAlibaba ||
 		isZai ||
+		isZhipu ||
 		isKilo ||
 		isQwen ||
 		provider === "opencode-zen" ||
@@ -156,6 +158,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 			isMistral ||
 			isGrok ||
 			isZai ||
+			isZhipu ||
 			isCopilotHost ||
 			isZenmuxHost);
 
@@ -194,7 +197,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		// OpenAI's reasoning-API surface.
 		supportsDeveloperRole: isOpenAIHost || isAzureHost,
 		supportsMultipleSystemMessages: supportsMultipleSystemMessagesDefault,
-		supportsReasoningEffort: !isGrok && !isZai,
+		supportsReasoningEffort: !isGrok && !isZai && !isZhipu,
 		reasoningEffortMap,
 		supportsUsageInStreaming: !isCerebras,
 		disableReasoningOnForcedToolChoice: isKimiModel || isAnthropicModel,
@@ -206,7 +209,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		requiresThinkingAsText: isMistral,
 		requiresMistralToolIds: isMistral,
 		thinkingFormat:
-			isZai || isMoonshotKimi
+			isZai || isZhipu || isMoonshotKimi
 				? "zai"
 				: provider === "openrouter" || baseUrl.includes("openrouter.ai")
 					? "openrouter"

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -108,6 +108,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	kilo: "KILO_API_KEY",
 	"vercel-ai-gateway": "AI_GATEWAY_API_KEY",
 	zai: "ZAI_API_KEY",
+	"zhipu-coding-plan": "ZHIPU_API_KEY",
 	mistral: "MISTRAL_API_KEY",
 	minimax: "MINIMAX_API_KEY",
 	"minimax-code": "MINIMAX_CODE_API_KEY",

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -121,6 +121,7 @@ export type KnownProvider =
 	| "kilo"
 	| "vercel-ai-gateway"
 	| "zai"
+	| "zhipu-coding-plan"
 	| "mistral"
 	| "minimax"
 	| "opencode-go"

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -151,6 +151,11 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		available: true,
 	},
 	{
+		id: "zhipu-coding-plan",
+		name: "Zhipu Coding Plan (智谱)",
+		available: true,
+	},
+	{
 		id: "minimax-code",
 		name: "MiniMax Coding Plan (International)",
 		available: true,
@@ -328,6 +333,7 @@ export async function refreshOAuthToken(
 		case "ollama-cloud":
 		case "xiaomi":
 		case "zai":
+		case "zhipu-coding-plan":
 		case "qianfan":
 		case "venice":
 		case "minimax-code":

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -50,7 +50,8 @@ export type OAuthProvider =
 	| "vllm"
 	| "xiaomi"
 	| "zenmux"
-	| "zai";
+	| "zai"
+	| "zhipu-coding-plan";
 
 export type OAuthProviderId = OAuthProvider | (string & {});
 

--- a/packages/ai/src/utils/oauth/zhipu.ts
+++ b/packages/ai/src/utils/oauth/zhipu.ts
@@ -1,0 +1,60 @@
+/**
+ * Zhipu Coding Plan login flow.
+ *
+ * Zhipu BigModel (智谱) provides an OpenAI-compatible API.
+ * API docs: https://docs.bigmodel.cn/cn/guide/develop/openai/introduction
+ *
+ * Simple API key flow:
+ * 1. User gets their API key from https://open.bigmodel.cn
+ * 2. User pastes the API key into the CLI
+ */
+
+import { validateOpenAICompatibleApiKey } from "./api-key-validation";
+import type { OAuthController } from "./types";
+
+const AUTH_URL = "https://open.bigmodel.cn/usercenter/apikeys";
+const API_BASE_URL = "https://open.bigmodel.cn/api/paas/v4";
+const VALIDATION_MODEL = "glm-5.1";
+
+/**
+ * Login to Zhipu Coding Plan.
+ *
+ * Opens browser to API keys page, prompts user to paste their API key.
+ * Returns the API key directly (not OAuthCredentials - this isn't OAuth).
+ */
+export async function loginZhipuCodingPlan(options: OAuthController): Promise<string> {
+	if (!options.onPrompt) {
+		throw new Error("Zhipu Coding Plan login requires onPrompt callback");
+	}
+
+	// Open browser to API keys page
+	options.onAuth?.({
+		url: AUTH_URL,
+		instructions: "Copy your API key from the dashboard",
+	});
+
+	// Prompt user to paste their API key
+	const apiKey = await options.onPrompt({
+		message: "Paste your Zhipu API key",
+		placeholder: "sk-...",
+	});
+
+	if (options.signal?.aborted) {
+		throw new Error("Login cancelled");
+	}
+
+	const trimmed = apiKey.trim();
+	if (!trimmed) {
+		throw new Error("API key is required");
+	}
+
+	options.onProgress?.("Validating API key...");
+	await validateOpenAICompatibleApiKey({
+		provider: "Zhipu",
+		apiKey: trimmed,
+		baseUrl: API_BASE_URL,
+		model: VALIDATION_MODEL,
+		signal: options.signal,
+	});
+	return trimmed;
+}

--- a/packages/ai/test/zhipu-compat.test.ts
+++ b/packages/ai/test/zhipu-compat.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "bun:test";
+import { detectOpenAICompat, resolveOpenAICompat } from "@oh-my-pi/pi-ai/providers/openai-completions-compat";
+import type { Model } from "@oh-my-pi/pi-ai/types";
+
+/**
+ * Resolver-branch coverage for the `isZhipu` path added by the
+ * `zhipu-coding-plan` provider. Mirrors the shape of existing zai/cerebras
+ * tests: assert the contract the provider relies on (zai thinking format,
+ * disabled `reasoning_effort`, no `developer` role) so future refactors of
+ * `detectOpenAICompat` cannot silently regress the BigModel SKU.
+ */
+
+const baseModel: Omit<Model<"openai-completions">, "provider" | "baseUrl"> = {
+	api: "openai-completions",
+	id: "glm-4.7",
+	name: "GLM-4.7",
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	maxTokens: 32_000,
+	contextWindow: 200_000,
+	reasoning: true,
+};
+
+function zhipuByProvider(): Model<"openai-completions"> {
+	return {
+		...baseModel,
+		provider: "zhipu-coding-plan",
+		baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4",
+	};
+}
+
+function zhipuByBaseUrl(): Model<"openai-completions"> {
+	return {
+		...baseModel,
+		// Provider intentionally not "zhipu-coding-plan" — exercises the
+		// URL-based fallback branch.
+		provider: "custom",
+		baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4/chat/completions",
+	};
+}
+
+describe("openai-completions compat — zhipu-coding-plan branch", () => {
+	it("forces zai thinking format and disables reasoning_effort / developer role", () => {
+		const compat = detectOpenAICompat(zhipuByProvider());
+
+		expect(compat.thinkingFormat).toBe("zai");
+		expect(compat.supportsReasoningEffort).toBe(false);
+		expect(compat.supportsDeveloperRole).toBe(false);
+		expect(compat.reasoningContentField).toBe("reasoning_content");
+		// Zhipu shares the multi-system-message tolerance of Z.AI.
+		expect(compat.supportsMultipleSystemMessages).toBe(true);
+		// `isZhipu` participates in the non-standard set, so `store` is off.
+		expect(compat.supportsStore).toBe(false);
+	});
+
+	it("detects zhipu by baseUrl when provider id is custom", () => {
+		const compat = detectOpenAICompat(zhipuByBaseUrl());
+
+		expect(compat.thinkingFormat).toBe("zai");
+		expect(compat.supportsReasoningEffort).toBe(false);
+	});
+
+	it("lets explicit model.compat overrides win at the resolver layer", () => {
+		const model: Model<"openai-completions"> = {
+			...zhipuByProvider(),
+			compat: {
+				supportsDeveloperRole: true,
+				supportsReasoningEffort: true,
+				thinkingFormat: "openai",
+			},
+		};
+		const resolved = resolveOpenAICompat(model);
+
+		expect(resolved.supportsDeveloperRole).toBe(true);
+		expect(resolved.supportsReasoningEffort).toBe(true);
+		expect(resolved.thinkingFormat).toBe("openai");
+		// Untouched fields still come from the zhipu branch.
+		expect(resolved.reasoningContentField).toBe("reasoning_content");
+	});
+});


### PR DESCRIPTION
## What

Add support for Zhipu (智谱) BigModel domestic Chinese endpoint (`open.bigmodel.cn`) as an OpenAI-compatible provider (`zhipu-coding-plan`).

#1340

## Why

omp currently only supports z.ai (international GLM endpoint). Users in China need direct access to the domestic Zhipu BigModel API at `open.bigmodel.cn`.

## Changes

- Register `zhipu-coding-plan` in `KnownProvider` union type
- Add provider descriptor with catalog discovery (`ZHIPU_API_KEY`)
- Implement model manager with dynamic model fetching from Zhipu API
- Add OpenAI compat layer detection (zai thinking format, `reasoningContentField`, no `developer` role, no `reasoning_effort`)
- Create OAuth login flow (API key validation against `open.bigmodel.cn`)
- Wire into auth-storage, CLI help, env var mapping, OAuth types

## Supported Models

glm-4.5, glm-4.5-air, glm-4.6, glm-4.7, glm-5, glm-5-turbo, glm-5.1

## Testing

- `bun check` — all packages pass (biome + tsgo + cargo)
- Compiled binary — provider appears in `--list-models` (7 models discovered)
- `omp login zhipu-coding-plan` — API key validated and saved
- `omp --provider zhipu-coding-plan --model glm-4.7 -p "Say hi"` — streaming response ✅
- Raw API verification: chat completions, streaming SSE, function calling all confirmed

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)