### PR TITLE
fix(ai): restore Pi-style stream timeout defaults

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Changed OAuth selection in `AuthStorage` to treat credentials as stale when they are within 60 seconds of expiry and rotate them preemptively
 - Changed Google Gemini CLI, Google Gemini usage, Antigravity usage, and Kimi usage flows to stop refreshing OAuth tokens directly and rely on `AuthStorage` for token rotation
+- Changed provider stream watchdog defaults to Pi-style waiting: first-event and idle watchdogs stay disabled unless explicitly enabled through stream options or `PI_STREAM_*_TIMEOUT_MS` env vars, so slow-but-valid providers are no longer treated as failed just because they are silent before first output.
 
 ### Removed
 

--- a/packages/ai/src/utils/idle-iterator.ts
+++ b/packages/ai/src/utils/idle-iterator.ts
@@ -3,10 +3,10 @@ import { $env } from "@oh-my-pi/pi-utils";
 const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 120_000;
 const DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_MS = 100_000;
 
-function normalizeIdleTimeoutMs(value: string | undefined, fallback: number): number | undefined {
-	if (value === undefined) return fallback;
+function normalizeOptionalTimeoutMs(value: string | undefined): number | undefined {
+	if (value === undefined) return undefined;
 	const parsed = Number(value);
-	if (!Number.isFinite(parsed)) return fallback;
+	if (!Number.isFinite(parsed)) return undefined;
 	if (parsed <= 0) return undefined;
 	return Math.trunc(parsed);
 }
@@ -15,46 +15,37 @@ function normalizeIdleTimeoutMs(value: string | undefined, fallback: number): nu
  * Returns the idle timeout used for provider streaming transports.
  *
  * `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` is accepted as a backward-compatible alias.
- * Set `PI_STREAM_IDLE_TIMEOUT_MS=0` to disable the watchdog.
+ * Leave unset, or set `PI_STREAM_IDLE_TIMEOUT_MS=0`, to disable the watchdog.
  *
- * Providers that legitimately stream much slower than the global default can pass
- * `fallbackMs` to widen the floor used when neither env var nor caller option is set.
- * Caller options still take precedence; env overrides still trump the fallback.
+ * The optional fallback parameter is kept for provider call-site compatibility, but
+ * Pi-style streaming no longer arms silence watchdogs by default.
  */
-export function getStreamIdleTimeoutMs(fallbackMs: number = DEFAULT_STREAM_IDLE_TIMEOUT_MS): number | undefined {
-	return normalizeIdleTimeoutMs($env.PI_STREAM_IDLE_TIMEOUT_MS ?? $env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS, fallbackMs);
+export function getStreamIdleTimeoutMs(_fallbackMs: number = DEFAULT_STREAM_IDLE_TIMEOUT_MS): number | undefined {
+	return normalizeOptionalTimeoutMs($env.PI_STREAM_IDLE_TIMEOUT_MS ?? $env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS);
 }
 
 /**
  * Returns the idle timeout used for OpenAI-family streaming transports.
  *
- * Set `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS=0` to disable the watchdog.
+ * Leave unset, or set `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS=0`, to disable the watchdog.
  */
 export function getOpenAIStreamIdleTimeoutMs(): number | undefined {
-	return normalizeIdleTimeoutMs(
-		$env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS ?? $env.PI_STREAM_IDLE_TIMEOUT_MS,
-		DEFAULT_STREAM_IDLE_TIMEOUT_MS,
-	);
+	return normalizeOptionalTimeoutMs($env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS ?? $env.PI_STREAM_IDLE_TIMEOUT_MS);
 }
 
 /**
  * Returns the timeout used while waiting for the first stream event.
- * The first token can legitimately take longer than later inter-event gaps,
- * so the default never undershoots the steady-state idle timeout.
  *
- * Set `PI_STREAM_FIRST_EVENT_TIMEOUT_MS=0` to disable the watchdog.
+ * Leave unset, or set `PI_STREAM_FIRST_EVENT_TIMEOUT_MS=0`, to disable the watchdog.
  *
- * Providers whose first response can legitimately take longer (heavy reasoning,
- * slow cold-start proxies) can pass `fallbackMs` to widen the floor used when
- * neither env var nor caller option is set. Caller options still take precedence;
- * env overrides still trump the fallback.
+ * The idle/fallback parameters are kept for provider call-site compatibility, but
+ * Pi-style streaming no longer treats silence before first output as failure by default.
  */
 export function getStreamFirstEventTimeoutMs(
-	idleTimeoutMs?: number,
-	fallbackMs: number = DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_MS,
+	_idleTimeoutMs?: number,
+	_fallbackMs: number = DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_MS,
 ): number | undefined {
-	const fallback = idleTimeoutMs === undefined ? fallbackMs : Math.max(fallbackMs, idleTimeoutMs);
-	return normalizeIdleTimeoutMs($env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS, fallback);
+	return normalizeOptionalTimeoutMs($env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS);
 }
 
 export type Watchdog = NodeJS.Timeout | undefined;

--- a/packages/ai/test/stream-timeout-defaults.test.ts
+++ b/packages/ai/test/stream-timeout-defaults.test.ts
@@ -2,12 +2,11 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs } from "../src/utils/idle-iterator";
 
 /**
- * Per-provider fallback overrides on the stream-watchdog helpers.
+ * Stream watchdog defaults.
  *
- * These are the gear that lets `google-gemini-cli` widen its first-event floor
- * beyond the 100s global default without forcing every other provider to wait
- * just as long. Tests pin the precedence contract callers depend on:
- * caller option > env var > per-provider fallback > base default.
+ * OMP follows Pi-style streaming by default: provider silence alone is not
+ * treated as failure. Watchdogs are only armed when explicitly requested by env
+ * or per-request StreamOptions.
  */
 
 const ENV_KEYS = [
@@ -37,11 +36,11 @@ afterEach(() => {
 });
 
 describe("getStreamIdleTimeoutMs(fallbackMs)", () => {
-	it("returns the per-provider fallback when env vars are unset", () => {
-		expect(getStreamIdleTimeoutMs(300_000)).toBe(300_000);
+	it("does not arm an idle watchdog when env vars are unset", () => {
+		expect(getStreamIdleTimeoutMs(300_000)).toBeUndefined();
 	});
 
-	it("lets PI_STREAM_IDLE_TIMEOUT_MS override the per-provider fallback", () => {
+	it("lets PI_STREAM_IDLE_TIMEOUT_MS explicitly enable the watchdog", () => {
 		Bun.env.PI_STREAM_IDLE_TIMEOUT_MS = "42";
 		expect(getStreamIdleTimeoutMs(300_000)).toBe(42);
 	});
@@ -53,19 +52,19 @@ describe("getStreamIdleTimeoutMs(fallbackMs)", () => {
 });
 
 describe("getStreamFirstEventTimeoutMs(idleTimeoutMs, fallbackMs)", () => {
-	it("returns the per-provider fallback when env unset and idle timeout is undefined", () => {
-		expect(getStreamFirstEventTimeoutMs(undefined, 300_000)).toBe(300_000);
+	it("does not arm a first-event watchdog when env is unset", () => {
+		expect(getStreamFirstEventTimeoutMs(undefined, 300_000)).toBeUndefined();
 	});
 
-	it("floors the first-event timeout at the per-provider fallback even when idle is shorter", () => {
-		expect(getStreamFirstEventTimeoutMs(50_000, 300_000)).toBe(300_000);
+	it("does not inherit a timeout from the idle watchdog by default", () => {
+		expect(getStreamFirstEventTimeoutMs(50_000, 300_000)).toBeUndefined();
 	});
 
-	it("never undershoots the steady-state idle timeout", () => {
-		expect(getStreamFirstEventTimeoutMs(500_000, 300_000)).toBe(500_000);
+	it("does not use the per-provider fallback as a default timeout", () => {
+		expect(getStreamFirstEventTimeoutMs(500_000, 300_000)).toBeUndefined();
 	});
 
-	it("lets PI_STREAM_FIRST_EVENT_TIMEOUT_MS override the per-provider fallback", () => {
+	it("lets PI_STREAM_FIRST_EVENT_TIMEOUT_MS explicitly enable the watchdog", () => {
 		Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS = "42";
 		expect(getStreamFirstEventTimeoutMs(undefined, 300_000)).toBe(42);
 	});
@@ -75,7 +74,7 @@ describe("getStreamFirstEventTimeoutMs(idleTimeoutMs, fallbackMs)", () => {
 		expect(getStreamFirstEventTimeoutMs(undefined, 300_000)).toBeUndefined();
 	});
 
-	it("falls back to the 100s global default when no fallback or env is provided", () => {
-		expect(getStreamFirstEventTimeoutMs()).toBe(100_000);
+	it("does not arm a global first-event watchdog when no fallback or env is provided", () => {
+		expect(getStreamFirstEventTimeoutMs()).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Summary

Restores Pi-style provider streaming by removing OMP's first-event and idle watchdog enforcement from provider stream consumption.

Instead of failing a turn because no stream event arrived inside OMP's watchdog window, OMP now waits on the provider stream until the provider emits, errors, or the user aborts.

Closes https://github.com/can1357/oh-my-pi/issues/1392

## Motivation

Standalone Pi does not appear to enforce this extra first-event/idle stream timeout layer in the same provider paths. OMP's added watchdog can break slow-but-valid providers, especially custom OpenAI-compatible providers and local proxy/gateway setups.

A slow first token is not the same thing as a dead provider.

## Before

Slow provider:

```text
provider is still working
no first stream event yet
OMP watchdog fires
turn fails
retry burns attempts
```

Example failure:

```text
Provider stream timed out while waiting for the first event
Retry failed after 3 attempts: Provider stream timed out while waiting for the first event
```

## After

Slow provider:

```text
provider is still working
OMP keeps waiting
provider eventually emits
turn continues normally
```

Abort/error behavior remains handled by the user abort signal and the underlying provider/socket/SDK failure path.

## Notes

This intentionally removes the global stream silence watchdog behavior rather than making custom users tune timeouts per provider.

The goal is to match the simpler Pi behavior:

```text
wait for the stream
do not treat silence as failure
abort only on user abort or real provider/request failure
```

## Risk

This may make genuinely stuck provider streams wait longer than before.

I think that tradeoff is better than killing valid slow streams, especially because users can still abort manually and SDK/request-level timeouts can still exist where explicitly configured.

## Test plan

- `git diff --check`
- `bun install`
- `bun test packages/ai/test/stream-timeout-defaults.test.ts` currently does not complete in my clone because the fresh checkout is missing the compiled `pi_natives` addon after install:

```text
Failed to load pi_natives native addon for linux-x64
```

The same test invocation also attempted to write the local OMP log path in my sandbox before the native-addon failure. I did not fake a green run.
