### PR TITLE
fix(coding-agent): use local time in session filenames

### DIFF
--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -299,6 +299,23 @@ function createSessionId(): string {
 	return Bun.randomUUIDv7();
 }
 
+function padTimestampSegment(value: number, width: number): string {
+	return value.toString().padStart(width, "0");
+}
+
+function createSessionTimestampParts(date = new Date()): { timestamp: string; fileTimestamp: string } {
+	const timestamp = date.toISOString();
+	const timezoneOffsetMinutes = date.getTimezoneOffset();
+	const localDate = new Date(date.getTime() - timezoneOffsetMinutes * 60_000);
+	const timezoneOffsetTotalMinutes = -timezoneOffsetMinutes;
+	const timezoneSign = timezoneOffsetTotalMinutes >= 0 ? "+" : "-";
+	const absoluteOffsetMinutes = Math.abs(timezoneOffsetTotalMinutes);
+	const offsetHours = padTimestampSegment(Math.floor(absoluteOffsetMinutes / 60), 2);
+	const offsetMinutes = padTimestampSegment(absoluteOffsetMinutes % 60, 2);
+	const fileTimestamp = `${padTimestampSegment(localDate.getUTCFullYear(), 4)}-${padTimestampSegment(localDate.getUTCMonth() + 1, 2)}-${padTimestampSegment(localDate.getUTCDate(), 2)}T${padTimestampSegment(localDate.getUTCHours(), 2)}-${padTimestampSegment(localDate.getUTCMinutes(), 2)}-${padTimestampSegment(localDate.getUTCSeconds(), 2)}-${padTimestampSegment(localDate.getUTCMilliseconds(), 3)}${timezoneSign}${offsetHours}-${offsetMinutes}`;
+	return { timestamp, fileTimestamp };
+}
+
 /** Generate a unique short ID (8 hex chars, collision-checked) */
 function generateId(byId: { has(id: string): boolean }): string {
 	for (let i = 0; i < 100; i++) {
@@ -1942,8 +1959,7 @@ export class SessionManager {
 
 		// Create new session ID and header
 		this.#sessionId = createSessionId();
-		const timestamp = new Date().toISOString();
-		const fileTimestamp = timestamp.replace(/[:.]/g, "-");
+		const { timestamp, fileTimestamp } = createSessionTimestampParts();
 		this.#sessionFile = path.join(this.getSessionDir(), `${fileTimestamp}_${this.#sessionId}.jsonl`);
 
 		// Update the header with new ID but keep all entries
@@ -2075,7 +2091,7 @@ export class SessionManager {
 		this.#sessionId = createSessionId();
 		this.#sessionName = undefined;
 		this.#titleSource = undefined;
-		const timestamp = new Date().toISOString();
+		const { timestamp, fileTimestamp } = createSessionTimestampParts();
 		const header: SessionHeader = {
 			type: "session",
 			version: CURRENT_SESSION_VERSION,
@@ -2096,7 +2112,6 @@ export class SessionManager {
 		this.#inMemoryArtifactCounter = 0;
 
 		if (this.persist) {
-			const fileTimestamp = timestamp.replace(/[:.]/g, "-");
 			this.#sessionFile = path.join(this.getSessionDir(), `${fileTimestamp}_${this.#sessionId}.jsonl`);
 			writeTerminalBreadcrumb(this.cwd, this.#sessionFile);
 		}
@@ -3113,8 +3128,7 @@ export class SessionManager {
 		const pathWithoutLabels = branchPath.filter(e => e.type !== "label");
 
 		const newSessionId = createSessionId();
-		const timestamp = new Date().toISOString();
-		const fileTimestamp = timestamp.replace(/[:.]/g, "-");
+		const { timestamp, fileTimestamp } = createSessionTimestampParts();
 		const newSessionFile = path.join(this.getSessionDir(), `${fileTimestamp}_${newSessionId}.jsonl`);
 
 		const header: SessionHeader = {

--- a/packages/coding-agent/test/session-manager/session-id.test.ts
+++ b/packages/coding-agent/test/session-manager/session-id.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, setSystemTime } from "bun:test";
 import * as path from "node:path";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { TempDir } from "@oh-my-pi/pi-utils";
@@ -12,6 +12,18 @@ function expectUuidV7SessionId(session: SessionManager): string {
 	if (!header) throw new Error("Expected session header");
 	expect(header.id).toBe(sessionId);
 	return sessionId;
+}
+
+function withTimezoneOffset(minutesWestOfUtc: number, callback: () => void): void {
+	const originalGetTimezoneOffset = Date.prototype.getTimezoneOffset;
+	Date.prototype.getTimezoneOffset = function getTimezoneOffset(): number {
+		return minutesWestOfUtc;
+	};
+	try {
+		callback();
+	} finally {
+		Date.prototype.getTimezoneOffset = originalGetTimezoneOffset;
+	}
 }
 
 describe("SessionManager session ids", () => {
@@ -56,6 +68,44 @@ describe("SessionManager session ids", () => {
 		const forkedId = expectUuidV7SessionId(session);
 		expect(forkedId).not.toBe(firstId);
 		expect(session.getHeader()?.parentSession).toBe(firstId);
+	});
+
+	it("uses local timezone in persisted session filenames while keeping UTC header timestamps", () => {
+		setSystemTime(new Date("2025-01-15T18:07:08.009Z"));
+		try {
+			withTimezoneOffset(-330, () => {
+				using tempDir = TempDir.createSync("@pi-session-id-local-time-");
+				const session = SessionManager.create(tempDir.path(), tempDir.path());
+				const sessionFile = session.getSessionFile();
+				if (!sessionFile) throw new Error("Expected persisted session file");
+
+				expect(path.basename(sessionFile)).toMatch(
+					/^2025-01-15T23-37-08-009\+05-30_[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.jsonl$/,
+				);
+				expect(session.getHeader()?.timestamp).toBe("2025-01-15T18:07:08.009Z");
+			});
+		} finally {
+			setSystemTime();
+		}
+	});
+
+	it("uses local timezone offsets west of UTC in persisted session filenames", () => {
+		setSystemTime(new Date("2025-01-15T18:07:08.009Z"));
+		try {
+			withTimezoneOffset(480, () => {
+				using tempDir = TempDir.createSync("@pi-session-id-local-time-west-");
+				const session = SessionManager.create(tempDir.path(), tempDir.path());
+				const sessionFile = session.getSessionFile();
+				if (!sessionFile) throw new Error("Expected persisted session file");
+
+				expect(path.basename(sessionFile)).toMatch(
+					/^2025-01-15T10-07-08-009-08-00_[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.jsonl$/,
+				);
+				expect(session.getHeader()?.timestamp).toBe("2025-01-15T18:07:08.009Z");
+			});
+		} finally {
+			setSystemTime();
+		}
 	});
 
 	it("preserves existing session ids when reopening a saved session", async () => {


### PR DESCRIPTION
## Summary
Session filenames now reflect the user's local wall-clock time instead of always encoding UTC. The session header timestamp stays as a UTC ISO string, so existing session metadata parsing and display logic keep the same source-of-truth timestamp.

The filename generation path now builds the local date-time components and appends the explicit timezone offset in the persisted filename. The regression tests pin both east-of-UTC and west-of-UTC offsets so new sessions keep matching local time while the stored header timestamp remains unchanged.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
