### PR TITLE
feat(coding-agent): surface resolved subagent model badge in task widget

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Added
 
+- Added resolved subagent model badge to the task widget status line showing `<provider>/<id>` (with optional `:<thinkingLevel>` suffix when thinking is set explicitly), opt-in via `task.showResolvedModelBadge` Appearance setting (default off)
 - Added `codex` and `gemini` to the web search provider settings so users can configure OpenAI and Gemini web search directly from provider selection
 - Added OpenAI (`codex`) and Gemini web search options with updated setup descriptions for `omp /login openai-codex` and Gemini OAuth login
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2458,6 +2458,16 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"task.showResolvedModelBadge": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "appearance",
+			label: "Show Resolved Model Badge",
+			description: "Display the actual model ID used by each subagent in the task widget status line",
+		},
+	},
+
 	// Skills
 	"skills.enabled": { type: "boolean", default: true },
 

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1146,6 +1146,11 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 			if (model?.contextWindow && model.contextWindow > 0) {
 				progress.contextWindow = model.contextWindow;
 			}
+			if (model) {
+				progress.resolvedModel = explicitThinkingLevel
+					? `${model.provider}/${model.id}:${resolvedThinkingLevel}`
+					: `${model.provider}/${model.id}`;
+			}
 			const effectiveThinkingLevel = explicitThinkingLevel
 				? resolvedThinkingLevel
 				: (thinkingLevel ?? resolvedThinkingLevel);
@@ -1603,6 +1608,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 		contextTokens: progress.contextTokens,
 		contextWindow: progress.contextWindow,
 		modelOverride,
+		resolvedModel: progress.resolvedModel,
 		error: exitCode !== 0 && stderr ? stderr : undefined,
 		aborted: wasAborted,
 		abortReason: finalAbortReason,

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -570,14 +570,15 @@ function renderAgentProgress(
 		statusLine += ` ${formatBadge(statusLabel, iconColor, theme)}`;
 	}
 
+	const showBadge = settings.get("task.showResolvedModelBadge");
 	if (progress.status === "running") {
 		if (!description) {
 			const taskPreview = truncateToWidth(progress.assignment ?? progress.task, 40);
 			statusLine += ` ${theme.fg("muted", taskPreview)}`;
 		}
-		statusLine = appendAgentStats(statusLine, { ...progress, showResolvedModelBadge: settings.get("task.showResolvedModelBadge") }, theme);
+		statusLine = appendAgentStats(statusLine, { ...progress, showResolvedModelBadge: showBadge }, theme);
 	} else if (progress.status === "completed") {
-		statusLine = appendAgentStats(statusLine, { ...progress, showResolvedModelBadge: settings.get("task.showResolvedModelBadge") }, theme);
+		statusLine = appendAgentStats(statusLine, { ...progress, showResolvedModelBadge: showBadge }, theme);
 	}
 
 	lines.push(statusLine);
@@ -844,6 +845,7 @@ function renderAgentResult(result: SingleResult, isLast: boolean, expanded: bool
 		iconColor,
 		theme,
 	)}`;
+	const showBadge = settings.get("task.showResolvedModelBadge");
 	statusLine = appendAgentStats(
 		statusLine,
 		{
@@ -852,7 +854,7 @@ function renderAgentResult(result: SingleResult, isLast: boolean, expanded: bool
 			contextWindow: result.contextWindow,
 			cost: result.usage?.cost.total ?? 0,
 			resolvedModel: result.resolvedModel,
-			showResolvedModelBadge: settings.get("task.showResolvedModelBadge"),
+			showResolvedModelBadge: showBadge,
 		},
 		theme,
 	);

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import type { Component } from "@oh-my-pi/pi-tui";
 import { Container, Text } from "@oh-my-pi/pi-tui";
 import { formatNumber } from "@oh-my-pi/pi-utils";
+import { settings } from "../config/settings";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import type { Theme } from "../modes/theme/theme";
 import {
@@ -59,6 +60,7 @@ function appendAgentStats(
 		contextTokens?: number;
 		contextWindow?: number;
 		cost: number;
+		resolvedModel?: string;
 	},
 	theme: Theme,
 ): string {
@@ -82,6 +84,9 @@ function appendAgentStats(
 	}
 	if (opts.cost > 0) {
 		line += `${theme.sep.dot}${theme.fg("statusLineCost", `$${opts.cost.toFixed(2)}`)}`;
+	}
+	if (opts.resolvedModel && settings.get("task.showResolvedModelBadge")) {
+		line += `${theme.sep.dot}${theme.fg("dim", opts.resolvedModel)}`;
 	}
 	return line;
 }
@@ -845,6 +850,7 @@ function renderAgentResult(result: SingleResult, isLast: boolean, expanded: bool
 			contextTokens: result.contextTokens,
 			contextWindow: result.contextWindow,
 			cost: result.usage?.cost.total ?? 0,
+			resolvedModel: result.resolvedModel,
 		},
 		theme,
 	);

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -61,6 +61,7 @@ function appendAgentStats(
 		contextWindow?: number;
 		cost: number;
 		resolvedModel?: string;
+		showResolvedModelBadge?: boolean;
 	},
 	theme: Theme,
 ): string {
@@ -85,8 +86,8 @@ function appendAgentStats(
 	if (opts.cost > 0) {
 		line += `${theme.sep.dot}${theme.fg("statusLineCost", `$${opts.cost.toFixed(2)}`)}`;
 	}
-	if (opts.resolvedModel && settings.get("task.showResolvedModelBadge")) {
-		line += `${theme.sep.dot}${theme.fg("dim", opts.resolvedModel)}`;
+	if (opts.resolvedModel && opts.showResolvedModelBadge) {
+		line += `${theme.sep.dot}${theme.fg("dim", truncateToWidth(replaceTabs(opts.resolvedModel), 30))}`;
 	}
 	return line;
 }
@@ -574,9 +575,9 @@ function renderAgentProgress(
 			const taskPreview = truncateToWidth(progress.assignment ?? progress.task, 40);
 			statusLine += ` ${theme.fg("muted", taskPreview)}`;
 		}
-		statusLine = appendAgentStats(statusLine, progress, theme);
+		statusLine = appendAgentStats(statusLine, { ...progress, showResolvedModelBadge: settings.get("task.showResolvedModelBadge") }, theme);
 	} else if (progress.status === "completed") {
-		statusLine = appendAgentStats(statusLine, progress, theme);
+		statusLine = appendAgentStats(statusLine, { ...progress, showResolvedModelBadge: settings.get("task.showResolvedModelBadge") }, theme);
 	}
 
 	lines.push(statusLine);
@@ -851,6 +852,7 @@ function renderAgentResult(result: SingleResult, isLast: boolean, expanded: bool
 			contextWindow: result.contextWindow,
 			cost: result.usage?.cost.total ?? 0,
 			resolvedModel: result.resolvedModel,
+			showResolvedModelBadge: settings.get("task.showResolvedModelBadge"),
 		},
 		theme,
 	);

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -210,6 +210,8 @@ export interface AgentProgress {
 	cost: number;
 	durationMs: number;
 	modelOverride?: string | string[];
+	/** Resolved model display string in the form `<provider>/<id>`, optionally suffixed with `:<thinkingLevel>` when the level was set explicitly. Undefined when the model could not be resolved. */
+	resolvedModel?: string;
 	/** Data extracted by registered subprocess tool handlers (keyed by tool name) */
 	extractedToolData?: Record<string, unknown[]>;
 	/**
@@ -268,6 +270,8 @@ export interface SingleResult {
 	/** Model's context window in tokens, when known. */
 	contextWindow?: number;
 	modelOverride?: string | string[];
+	/** Resolved model display string in the form `<provider>/<id>`, optionally suffixed with `:<thinkingLevel>` when the level was set explicitly. Omitted from tool-result JSON when undefined to keep wire payloads small. */
+	resolvedModel?: string;
 	error?: string;
 	aborted?: boolean;
 	abortReason?: string;


### PR DESCRIPTION
## What

Adds a resolved model ID badge to the task widget status line. When a subagent's model is resolved, the status line displays `<provider>/<id>`, or `<provider>/<id>:<thinkingLevel>` when thinking is set explicitly. The badge is opt-in via the `task.showResolvedModelBadge` Appearance setting (default off).

## Why

 When working in subagent heavy workflows with multiple providers and usage limits, this makes it easy to verify which model a subagent actually ran with. Useful for debugging cost, capability, and routing issues and "which model did I set for this agent again?".

## Testing
 - Verified badge renders in task widget status line when setting is enabled
 - Verified badge is hidden when setting is off (default)
 - Verified `:<thinkingLevel>` suffix appears only when thinking level was set explicitly
 
<img width="1872" height="314" alt="image" src="https://github.com/user-attachments/assets/26e8890f-09cd-4359-85b7-e0f6fb0d12fe" />

   ---

   - [x] `bun check` passes
   - [x] Tested locally
   - [x] CHANGELOG updated (if user-facing)