### PR TITLE
fix(ai): strip multipleOf from Cloud Code Assist tool schemas

### DIFF
--- a/packages/ai/src/utils/schema/fields.ts
+++ b/packages/ai/src/utils/schema/fields.ts
@@ -34,6 +34,7 @@ export const UNSUPPORTED_SCHEMA_FIELDS: Record<string, true> = {
 	maximum: true,
 	exclusiveMinimum: true,
 	exclusiveMaximum: true,
+	multipleOf: true,
 	pattern: true,
 	format: true,
 };


### PR DESCRIPTION
## Problem

The `multipleOf` JSON Schema keyword is not stripped from tool function parameters, causing Cloud Code Assist API to reject requests:

```
400: Invalid JSON payload received.
Unknown name "multipleOf" at 'request.tools[0].function_declarations[22].parameters.properties[4].value.items'
```

## Root Cause

`multipleOf` was missing from `UNSUPPORTED_SCHEMA_FIELDS` in `packages/ai/src/utils/schema/fields.ts`. The `normalizeSchemaForCCA()` function uses this list to remove validation keywords that Gemini/Claude models do not recognize.

Other numeric validation keywords (`minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`) were already included — `multipleOf` was the only one omitted.

## Fix

One line:

```diff
+ multipleOf: true,
```

in `UNSUPPORTED_SCHEMA_FIELDS`.

## Verification

- Reproduced the 400 error with Antigravity tool calls
- After fix: schema normalization strips `multipleOf`, API calls succeed