### PR TITLE
fix(tui): progressive enhancement keyboard negotiation for Zellij

### DIFF
--- a/crates/pi-natives/src/keys.rs
+++ b/crates/pi-natives/src/keys.rs
@@ -554,6 +554,31 @@ fn matches_key_inner(bytes: &[u8], key_id: &str, kitty_protocol_active: bool) ->
 		return false;
 	};
 
+	// ESC-prefixed sequences (terminals with metaSendsEscape / "Use Option as Meta"):
+	// \x1b\x1b[...] = Alt + inner-key. Strip the ESC prefix and match the inner
+	// sequence against the base key (without alt modifier).
+	// Example: \x1b\x1b[A matches "alt+up" because \x1b[A matches "up".
+	// Active in BOTH legacy and kitty mode (mixed mode) because terminals like
+	// Zellij in mixed mode may send legacy Alt sequences alongside Kitty ones.
+	if modifier & MOD_ALT != 0
+		&& bytes.len() > 2
+		&& bytes[0] == 0x1b
+		&& bytes[1] == 0x1b
+		&& (bytes[2] == b'[' || bytes[2] == b'O')
+	{
+		let inner_modifier = modifier & !MOD_ALT;
+		let inner_key_id: String = if inner_modifier == 0 {
+			key.to_string()
+		} else {
+			let mut s = String::with_capacity(16);
+			if inner_modifier & MOD_SHIFT != 0 { s.push_str("shift+"); }
+			if inner_modifier & MOD_CTRL != 0  { s.push_str("ctrl+"); }
+			s.push_str(key);
+			s
+		};
+		return matches_key_inner(&bytes[1..], &inner_key_id, true);
+	}
+
 	// Parse Kitty once (avoid repeated parsing in branches).
 	let kitty_parsed = parse_kitty_sequence_bytes(bytes);
 	let kitty_matches = |codepoint: i32, m: u32| -> bool {
@@ -1025,6 +1050,19 @@ fn parse_key_inner(bytes: &[u8], kitty_protocol_active: bool) -> Option<Cow<'sta
 		return format_kitty_key(&parsed);
 	}
 
+	// ESC-prefixed sequences (terminals with metaSendsEscape / "Use Option as Meta"):
+	// \x1b + inner-sequence = Alt modifier on that key.
+	// Example: iTerm2 "Use Option as Meta" sends \x1b\x1b[A for Alt+Up.
+	// Active in BOTH legacy and kitty mode (mixed mode) because terminals like
+	// Zellij in mixed mode may send legacy Alt sequences alongside Kitty ones.
+	if bytes.len() > 2 && bytes[0] == 0x1b && bytes[1] == 0x1b
+		&& (bytes[2] == b'[' || bytes[2] == b'O')
+	{
+		if let Some(inner_key) = parse_key_inner(&bytes[1..], true) {
+			return Some(Cow::Owned(format!("alt+{inner_key}")));
+		}
+	}
+
 	// Two-byte ESC sequences (legacy ALT prefix, with exceptions even in kitty
 	// mode)
 	if bytes.len() == 2 {
@@ -1462,6 +1500,26 @@ fn parse_optional_digits(bytes: &[u8], idx: usize, end: usize) -> (Option<u32>, 
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn esc_prefix_alt_arrows_mixed_mode() {
+		// Mixed mode: legacy Alt sequences must parse even when kitty is active
+		assert!(matches_key_inner(b"\x1b\x1b[A", "alt+up", true));
+		assert!(matches_key_inner(b"\x1b\x1b[B", "alt+down", true));
+		assert!(matches_key_inner(b"\x1b\x1b[C", "alt+right", true));
+		assert!(matches_key_inner(b"\x1b\x1b[D", "alt+left", true));
+		assert_eq!(parse_key_inner(b"\x1b\x1b[A", true).as_deref(), Some("alt+up"));
+		assert_eq!(parse_key_inner(b"\x1b\x1b[B", true).as_deref(), Some("alt+down"));
+		// Bare double ESC should NOT be parsed as alt
+		assert_eq!(parse_key_inner(b"\x1b\x1b", true).as_deref(), None);
+	}
+
+	#[test]
+	fn esc_prefix_csi_only() {
+		// Only CSI and SS3 inner sequences parse as Alt; other double-ESC does not
+		assert_eq!(parse_key_inner(b"\x1b\x1bX", true).as_deref(), None);
+		assert_eq!(parse_key_inner(b"\x1b\x1bX", false).as_deref(), None);
+	}
 
 	#[test]
 	fn matches_key_ignores_kitty_release_events() {

--- a/packages/tui/src/stdin-buffer.ts
+++ b/packages/tui/src/stdin-buffer.ts
@@ -67,6 +67,18 @@ function isCompleteSequence(data: string): "complete" | "incomplete" | "not-esca
 		return afterEsc.length >= 2 ? "complete" : "incomplete";
 	}
 
+	// ESC-prefixed sequences (terminals with metaSendsEscape):
+	// Only when the inner ESC starts a CSI ('[') or SS3 ('O') sequence.
+	// Bare double-ESC (e.g. \x1b\x1bX) remains complete to avoid 10ms timeout lag.
+	if (afterEsc.startsWith(ESC)) {
+		const inner = data.slice(1);
+		const third = inner.charCodeAt(1);
+		if (third === 0x5b || third === 0x4f) {
+			return isCompleteSequence(inner);
+		}
+		return "complete";
+	}
+
 	// Meta key sequences: ESC followed by a single character
 	if (afterEsc.length === 1) {
 		return "complete";

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -324,41 +324,54 @@ export class ProcessTerminal implements Terminal {
 				}
 			}
 
-			// Check for Kitty protocol response (only if not already enabled)
-			if (!this.#kittyProtocolActive) {
-				const match = sequence.match(kittyResponsePattern);
-				if (match) {
-					if (this.#modifyOtherKeysTimeout) {
-						clearTimeout(this.#modifyOtherKeysTimeout);
-						this.#modifyOtherKeysTimeout = undefined;
-					}
-					this.#kittyProtocolActive = true;
-					setKittyProtocolActive(true);
-
-					// Enable Kitty keyboard protocol (push flags)
-					// Flag 1 = disambiguate escape codes
-					// Flag 2 = report event types (press/repeat/release)
-					// Flag 4 = report alternate keys
-					this.#safeWrite("\x1b[>7u");
-					return; // Don't forward protocol response to TUI
-				}
-			}
-
 			// DA1 response: swallow our sentinel reply regardless of whether OSC 11
 			// already succeeded. Other terminal probes should never see these replies.
 			if (da1ResponsePattern.test(sequence) && this.#pendingDa1Sentinels > 0) {
 				this.#pendingDa1Sentinels--;
 				if (this.#osc11Pending) {
-					// DA1 arrived before OSC 11 response: terminal does not support
-					// OSC 11. Clear the pending state without starting a queued query
-					// (queued query is started below, after sentinel is consumed).
+					// DA1 before OSC 11: terminal does not support OSC 11.
 					this.#osc11Pending = false;
 					this.#osc11ResponseBuffer = "";
 				}
-				// Now that this DA1 cycle is complete, start any queued query.
+				// Start queued OSC 11 query after this DA1 cycle.
 				if (this.#osc11QueryQueued && !this.#dead) {
 					this.#osc11QueryQueued = false;
 					this.#startOsc11Query();
+				}
+				// Keyboard probe only: OSC 11 uses the same DA1 sentinel counter.
+				// If kitty reply has not arrived yet, DA1 means no progressive enhancement.
+				if (!this.#kittyProtocolActive && !this.#modifyOtherKeysActive && this.#modifyOtherKeysTimeout) {
+					clearTimeout(this.#modifyOtherKeysTimeout);
+					this.#modifyOtherKeysTimeout = undefined;
+					this.#safeWrite("\x1b[>4;2m");
+					this.#modifyOtherKeysActive = true;
+				}
+				return;
+			}
+
+			// Progressive enhancement: parse Kitty response flags to determine level.
+			const match = sequence.match(kittyResponsePattern);
+			if (match && !this.#modifyOtherKeysActive) {
+				if (this.#modifyOtherKeysTimeout) {
+					clearTimeout(this.#modifyOtherKeysTimeout);
+					this.#modifyOtherKeysTimeout = undefined;
+				}
+				const reportedFlags = parseInt(match[1]!, 10);
+				if (reportedFlags >= 3) {
+					// Full Kitty protocol (level 2+)
+					this.#kittyProtocolActive = true;
+					setKittyProtocolActive(true);
+					this.#safeWrite("\x1b[>7u");
+				} else if (reportedFlags >= 1) {
+					// Level 1 (disambiguate escape codes) – enough for Shift+Enter
+					// without modifyOtherKeys fallback that caused regression #3259.
+					this.#kittyProtocolActive = true;
+					setKittyProtocolActive(true);
+					this.#safeWrite("\x1b[>1u");
+				} else if (reportedFlags === 0) {
+					// Terminal explicitly says "no kitty support" (flag 0)
+					this.#safeWrite("\x1b[>4;2m");
+					this.#modifyOtherKeysActive = true;
 				}
 				return;
 			}
@@ -498,7 +511,10 @@ export class ProcessTerminal implements Terminal {
 	#queryAndEnableKittyProtocol(): void {
 		this.#setupStdinBuffer();
 		process.stdin.on("data", this.#stdinDataHandler!);
-		this.#safeWrite("\x1b[?u");
+		// Progressive enhancement query: send CSI >31u (request capability flags),
+		// then CSI ?u (query mode), then DA1 sentinel. If terminal replies with
+		// CSI ?<flags>u before DA1, we know the exact supported level.
+		this.#safeWrite("\x1b[>31u\x1b[?u\x1b[c");
 		this.#modifyOtherKeysTimeout = setTimeout(() => {
 			this.#modifyOtherKeysTimeout = undefined;
 			if (this.#kittyProtocolActive || this.#modifyOtherKeysActive) {


### PR DESCRIPTION
Keyboard CSI negotiation aligned with upstream pi — track there first:

- Same issue in Pi-mono: https://github.com/earendil-works/pi/issues/5033
- Draft pi fix (auto-closed pending `lgtm`): https://github.com/earendil-works/pi/pull/5032

oh-my-pi **v15.3.2**. Same idea as pi: `CSI >31u` + `CSI ?u` + DA1 sentinel, enable `>7u` / `>1u` / modifyOtherKeys from reported flags; mixed-mode `\x1b\x1b[` Alt parsing in `pi-natives`. OSC 11 / appearance probes untouched.

**Test:** Zellij — ESC, Shift+Enter, Alt+G, Alt+arrows; direct Kitty/Alacritty — full Kitty still OK.

**Refs:** [Kitty progressive enhancement query](https://sw.kovidgoyal.net/kitty/keyboard-protocol/#querying-terminal-for-support)

---

@can1357
