### PR TITLE
fix(task): activate yield tool when subagent has explicit tool list

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed plan-mode subagents being unable to terminate because `yield` was registered but missing from the active tool set when `requireYieldTool` was combined with an explicit `toolNames` list ([#1408](https://github.com/can1357/oh-my-pi/issues/1408))
+
 ## [15.4.1] - 2026-05-26
 
 ### Breaking Changes

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1658,9 +1658,18 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		};
 
 		const toolNamesFromRegistry = Array.from(toolRegistry.keys());
-		const requestedToolNames =
-			(options.toolNames ? [...new Set(options.toolNames.map(name => name.toLowerCase()))] : undefined) ??
-			toolNamesFromRegistry;
+		const explicitlyRequestedToolNames = options.toolNames
+			? [...new Set(options.toolNames.map(name => name.toLowerCase()))]
+			: undefined;
+		// When `requireYieldTool` is set, the subagent's prompts and idle-reminders demand a
+		// `yield` call to terminate. The tool registry already includes `yield` (see
+		// `createTools`), but an explicit `toolNames` list would otherwise drop it from the
+		// active set — leaving the model unable to satisfy the contract. Mirror the same
+		// invariant `parseAgentFields` enforces on frontmatter `tools`.
+		if (options.requireYieldTool === true && explicitlyRequestedToolNames && !explicitlyRequestedToolNames.includes("yield")) {
+			explicitlyRequestedToolNames.push("yield");
+		}
+		const requestedToolNames = explicitlyRequestedToolNames ?? toolNamesFromRegistry;
 		const normalizedRequested = requestedToolNames.filter(name => toolRegistry.has(name));
 		const requestedToolNameSet = new Set(normalizedRequested);
 		// Effective discovery mode: tools.discoveryMode takes precedence; mcp.discoveryMode is back-compat alias.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1666,7 +1666,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// `createTools`), but an explicit `toolNames` list would otherwise drop it from the
 		// active set — leaving the model unable to satisfy the contract. Mirror the same
 		// invariant `parseAgentFields` enforces on frontmatter `tools`.
-		if (options.requireYieldTool === true && explicitlyRequestedToolNames && !explicitlyRequestedToolNames.includes("yield")) {
+		if (
+			options.requireYieldTool === true &&
+			explicitlyRequestedToolNames &&
+			!explicitlyRequestedToolNames.includes("yield")
+		) {
 			explicitlyRequestedToolNames.push("yield");
 		}
 		const requestedToolNames = explicitlyRequestedToolNames ?? toolNamesFromRegistry;

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -107,4 +107,37 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			await session.dispose();
 		}
 	});
+
+	it("activates the yield tool when requireYieldTool is set and toolNames is explicit", async () => {
+		// Regression for #1408: plan-mode subagents pass an explicit `toolNames` list
+		// (e.g. `["read", "search", "find", "lsp", "web_search"]`). Without this
+		// invariant, `yield` ended up registered but not active, and the model
+		// could not satisfy the idle-reminder contract that demands a `yield` call.
+		const tempDir = path.join(os.tmpdir(), `pi-sdk-tool-activation-${Snowflake.next()}`);
+		tempDirs.push(tempDir);
+		fs.mkdirSync(tempDir, { recursive: true });
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			requireYieldTool: true,
+			toolNames: ["read", "search", "find", "web_search"],
+		});
+
+		try {
+			expect(session.getActiveToolNames()).toContain("yield");
+		} finally {
+			await session.dispose();
+		}
+	});
 });


### PR DESCRIPTION
## Repro

A subagent launched while the main agent is in plan mode (or any subagent whose `agent.tools` frontmatter explicitly lists a non-empty tool set) cannot terminate via `yield`. The session keeps injecting the idle reminder demanding a `yield` call while the provider-visible tool list lacks `yield`, so the model reasons "there doesn't seem to be a yield tool available" and the turn idles out.

Regression test:

```
cd packages/coding-agent
bun test test/sdk-tool-activation.test.ts
```

Before the fix the new `activates the yield tool when requireYieldTool is set and toolNames is explicit` case fails with `Expected to contain: "yield" / Received: [ "read", "search", "find", "web_search" ]`.

## Cause

`runSubprocess` in `packages/coding-agent/src/task/executor.ts` passes `requireYieldTool: true` to `createAgentSession` and forwards `agent.tools` as `toolNames`. In plan mode, `task/index.ts` rewrites `agent.tools` to `["read", "search", "find", "lsp", "web_search"]`, bypassing the frontmatter-time append in `discovery/helpers.ts#parseAgentFields` that normally adds `yield` to any explicit tool list.

Inside `createAgentSession` (`packages/coding-agent/src/sdk.ts`), `createTools` does add `yield` to the **tool registry** when `requireYieldTool` is set, but `requestedToolNames` is derived from `options.toolNames` directly:

```ts
const requestedToolNames =
    (options.toolNames ? [...new Set(options.toolNames.map(name => name.toLowerCase()))] : undefined) ??
    toolNamesFromRegistry;
```

`initialToolNames` — and therefore `agent.state.tools` — is built from `requestedToolNames`, so `yield` ends up registered but inactive.

## Fix

- `packages/coding-agent/src/sdk.ts`: when `options.requireYieldTool === true` and the caller passed an explicit `toolNames` array, append `yield` to it before filtering. Mirrors the invariant already enforced in `discovery/helpers.ts#parseAgentFields` for frontmatter-derived tool lists.
- `packages/coding-agent/test/sdk-tool-activation.test.ts`: regression test that creates a session with `requireYieldTool: true` and a plan-mode-style `toolNames` list, asserting `getActiveToolNames()` contains `yield`.
- `packages/coding-agent/CHANGELOG.md`: entry under `[Unreleased] > Fixed`.

## Verification

`bun test test/sdk-tool-activation.test.ts` → 3 pass / 0 fail / 8 expect() calls. Confirmed the new case fails on `main` (stashed the `sdk.ts` change and reran) and passes once the patch is applied.

Fixes #1408