### PR TITLE
fix(tui): apply Hangul jamo width correction only on macOS

### DIFF
--- a/crates/pi-natives/src/text.rs
+++ b/crates/pi-natives/src/text.rs
@@ -14,7 +14,7 @@ use napi::{JsString, bindgen_prelude::*};
 use napi_derive::napi;
 use smallvec::{SmallVec, smallvec};
 use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::UnicodeWidthChar;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 const MIN_TAB_WIDTH: u32 = 1;
 const MAX_TAB_WIDTH: u32 = 16;
@@ -380,13 +380,11 @@ const fn ascii_cell_width_u16(u: u16, tab_width: usize) -> usize {
 
 #[inline]
 fn char_width_corrected(c: char) -> Option<usize> {
-	// Hangul Compatibility Jamo U+3131..=U+318E render as a single cell in
-	// the terminals we ship to (Ghostty, Terminal.app, iTerm2) even though
-	// UAX#11 classifies them as Wide. Mirrors the TS-side correction in
-	// packages/tui/src/utils.ts (visibleWidth). U+318F is reserved and
-	// intentionally excluded.
+	// Hangul Compatibility Jamo U+3131..=U+318E render as 1 cell on macOS
+	// terminals (Ghostty, Terminal.app, iTerm2), but follow UAX#11 at 2
+	// cells on WezTerm and most Linux terminals. Only force 1 on macOS.
 	let cp = c as u32;
-	if (0x3131..=0x318e).contains(&cp) {
+	if cfg!(target_os = "macos") && (0x3131..=0x318e).contains(&cp) {
 		return Some(1);
 	}
 	UnicodeWidthChar::width(c)
@@ -404,12 +402,13 @@ fn grapheme_width_str(g: &str, tab_width: usize) -> usize {
 	if it.next().is_none() {
 		return char_width_corrected(c0).unwrap_or(0);
 	}
-	// Multi-char grapheme: sum per-char corrected widths so the jamo
-	// override applies even inside combining clusters. Matches what
-	// UnicodeWidthStr would compute, minus the UAX#11 jamo bias.
-	g.chars()
-		.map(|c| char_width_corrected(c).unwrap_or(0))
-		.sum()
+	if cfg!(target_os = "macos") {
+		g.chars()
+			.map(|c| char_width_corrected(c).unwrap_or(0))
+			.sum()
+	} else {
+		UnicodeWidthStr::width(g)
+	}
 }
 
 thread_local! {

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -101,6 +101,7 @@ export function visibleWidthRaw(str: string): number {
 	const tabWidth = getDefaultTabWidth();
 	let isPureAscii = true;
 	let jamoOvercount = 0;
+	const isMacOS = process.platform === "darwin";
 	for (let i = 0; i < str.length; i++) {
 		const code = str.charCodeAt(i);
 		if (code === 9) {
@@ -108,18 +109,9 @@ export function visibleWidthRaw(str: string): number {
 		} else if (code < 0x20 || code > 0x7e) {
 			isPureAscii = false;
 			// Hangul Compatibility Jamo (U+3131..U+318E) is EAW=W per UAX#11,
-			// so `Bun.stringWidth` returns 2 for each — but every macOS
-			// terminal we ship to (Ghostty, Terminal.app, iTerm2) renders
-			// them as a single cell in monospace fonts. Without this
-			// correction every jamo a Korean IME emits during composition
-			// adds 1 cell of drift to `#extractCursorPosition`, displacing
-			// the hardware cursor (and therefore the IME candidate window)
-			// `N_jamo` cells past the visible glyph. Hangul Syllables
-			// (U+AC00..U+D7A3, e.g. `안`) are correctly 2 cells in both Bun
-			// and the terminal — leave those alone. The Halfwidth Hangul
-			// block (U+FFA0..U+FFDC) is already Narrow in Bun, so no
-			// correction needed there.
-			if (code >= 0x3131 && code <= 0x318e) {
+			// but macOS terminals render them as 1 cell. WezTerm and others
+			// follow UAX#11 at 2 cells. Only correct on macOS.
+			if (isMacOS && code >= 0x3131 && code <= 0x318e) {
 				jamoOvercount++;
 			}
 		}


### PR DESCRIPTION
The Hangul Compatibility Jamo width correction was applied unconditionally, but only macOS terminals render jamo as 1 cell. WezTerm and Linux terminals follow UAX#11 at 2 cells. This caused TUI layout corruption on non-macOS platforms.

Changes:
- Rust: gate correction with cfg!(target_os = "macos")
- TS: gate correction with process.platform === 'darwin'
- Non-macOS uses UnicodeWidthStr for multi-char graphemes