### PR TITLE
feat(settings): highlighted changed settings

### DIFF
--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -13,7 +13,7 @@ import {
 	TabBar,
 	Text,
 } from "@oh-my-pi/pi-tui";
-import { type SettingPath, settings } from "../../config/settings";
+import { getDefault, type SettingPath, settings } from "../../config/settings";
 import type {
 	SettingTab,
 	StatusLinePreset,
@@ -294,6 +294,7 @@ export class SettingsSelectorComponent extends Container {
 		}
 
 		const currentValue = this.#getCurrentValue(def);
+		const changed = this.#isChanged(def, currentValue);
 
 		switch (def.type) {
 			case "boolean":
@@ -303,6 +304,7 @@ export class SettingsSelectorComponent extends Container {
 					description: def.description,
 					currentValue: currentValue ? "true" : "false",
 					values: ["true", "false"],
+					changed,
 				};
 
 			case "enum":
@@ -312,6 +314,7 @@ export class SettingsSelectorComponent extends Container {
 					description: def.description,
 					currentValue: currentValue as string,
 					values: [...def.values],
+					changed,
 				};
 
 			case "submenu":
@@ -321,6 +324,7 @@ export class SettingsSelectorComponent extends Container {
 					description: def.description,
 					currentValue: this.#getSubmenuCurrentValue(def.path, currentValue),
 					submenu: (cv, done) => this.#createSubmenu(def, cv, done),
+					changed,
 				};
 
 			case "text":
@@ -330,6 +334,7 @@ export class SettingsSelectorComponent extends Container {
 					description: def.description,
 					currentValue: (currentValue as string) ?? "",
 					submenu: (cv, done) => this.#createTextInput(def, cv, done),
+					changed,
 				};
 		}
 	}
@@ -339,6 +344,10 @@ export class SettingsSelectorComponent extends Container {
 	 */
 	#getCurrentValue(def: SettingDef): unknown {
 		return settings.get(def.path);
+	}
+
+	#isChanged(def: SettingDef, currentValue: unknown): boolean {
+		return !Object.is(currentValue, getDefault(def.path));
 	}
 
 	#getSubmenuCurrentValue(path: SettingPath, value: unknown): string {

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -2404,8 +2404,10 @@ export function getEditorTheme(): EditorTheme {
 
 export function getSettingsListTheme(): import("@oh-my-pi/pi-tui").SettingsListTheme {
 	return {
-		label: (text: string, selected: boolean) => (selected ? theme.fg("accent", text) : text),
-		value: (text: string, selected: boolean) => (selected ? theme.fg("accent", text) : theme.fg("muted", text)),
+		label: (text: string, selected: boolean, changed: boolean) =>
+			changed ? theme.fg("statusLineGitDirty", text) : selected ? theme.fg("accent", text) : text,
+		value: (text: string, selected: boolean, changed: boolean) =>
+			selected ? theme.fg("accent", text) : changed ? theme.fg("statusLineGitDirty", text) : theme.fg("muted", text),
 		description: (text: string) => theme.fg("dim", text),
 		cursor: theme.fg("accent", `${theme.nav.cursor} `),
 		hint: (text: string) => theme.fg("dim", text),

--- a/packages/coding-agent/test/modes/theme/settings-list-theme.test.ts
+++ b/packages/coding-agent/test/modes/theme/settings-list-theme.test.ts
@@ -1,0 +1,21 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { getSettingsListTheme, initTheme, theme } from "../../../src/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+describe("getSettingsListTheme", () => {
+	it("keeps modified labels dirty while selected values use the cursor accent", () => {
+		const settingsTheme = getSettingsListTheme();
+
+		const selectedChangedValue = settingsTheme.value("changed", true, true);
+		const unselectedChangedValue = settingsTheme.value("changed", false, true);
+		const selectedChangedLabel = settingsTheme.label("Changed", true, true);
+
+		expect(selectedChangedValue).toBe(theme.fg("accent", "changed"));
+		expect(unselectedChangedValue).toBe(theme.fg("statusLineGitDirty", "changed"));
+		expect(selectedChangedLabel).toBe(theme.fg("statusLineGitDirty", "Changed"));
+		expect(selectedChangedValue).not.toBe(unselectedChangedValue);
+	});
+});

--- a/packages/tui/src/components/settings-list.ts
+++ b/packages/tui/src/components/settings-list.ts
@@ -15,11 +15,13 @@ export interface SettingItem {
 	values?: string[];
 	/** If provided, Enter opens this submenu. Receives current value and done callback. */
 	submenu?: (currentValue: string, done: (selectedValue?: string) => void) => Component;
+	/** True when the displayed setting differs from its default value. */
+	changed?: boolean;
 }
 
 export interface SettingsListTheme {
-	label: (text: string, selected: boolean) => string;
-	value: (text: string, selected: boolean) => string;
+	label: (text: string, selected: boolean, changed: boolean) => string;
+	value: (text: string, selected: boolean, changed: boolean) => string;
 	description: (text: string) => string;
 	cursor: string;
 	hint: (text: string) => string;
@@ -117,7 +119,7 @@ export class SettingsList implements Component {
 
 			// Pad label to align values
 			const labelPadded = item.label + padding(Math.max(0, maxLabelWidth - visibleWidth(item.label)));
-			const labelText = this.#theme.label(labelPadded, isSelected);
+			const labelText = this.#theme.label(labelPadded, isSelected, item.changed === true);
 
 			// Calculate space for value
 			const separator = "  ";
@@ -127,6 +129,7 @@ export class SettingsList implements Component {
 			const valueText = this.#theme.value(
 				truncateToWidth(item.currentValue, valueMaxWidth, Ellipsis.Omit),
 				isSelected,
+				item.changed === true,
 			);
 
 			lines.push(truncateToWidth(prefix + labelText + separator + valueText, width));

--- a/packages/tui/test/settings-list.test.ts
+++ b/packages/tui/test/settings-list.test.ts
@@ -44,4 +44,30 @@ describe("SettingsList", () => {
 
 		expect(changes).toEqual([["mode", "on"]]);
 	});
+
+	it("passes changed state to item label and value renderers", () => {
+		const themed: SettingsListTheme = {
+			label: (text: string, _selected: boolean, changed: boolean) => (changed ? `[changed-label]${text}` : text),
+			value: (text: string, _selected: boolean, changed: boolean) => (changed ? `[changed-value]${text}` : text),
+			description: (text: string) => text,
+			cursor: "→ ",
+			hint: (text: string) => text,
+		};
+		const list = new SettingsList(
+			[
+				{ id: "default", label: "Default", currentValue: "off", values: ["off", "on"] },
+				{ id: "changed", label: "Changed", currentValue: "on", values: ["off", "on"], changed: true },
+			],
+			5,
+			themed,
+			() => {},
+			() => {},
+		);
+
+		const output = list.render(80).join("\n");
+
+		expect(output).toContain("[changed-label]Changed");
+		expect(output).toContain("[changed-value]on");
+		expect(output).not.toContain("[changed-label]Default");
+	});
 });


### PR DESCRIPTION
## What

Highlights settings that differ from their default values in the settings UI.

 Changed settings now use the modified/dirty theme color, while the selected row’s value still uses the normal selector
 accent color. The label keeps the modified color when selected so users can still see that the setting is customized.

## Why

 Makes customized settings easier to spot at a glance without changing the existing settings interaction model or
 adding a new theme token.

## Testing
locally + bun check + whatever

---

- [x ] `bun check` passes
- [x ] Tested locally
- [ nope ] CHANGELOG updated (if user-facing)
