### PR TITLE
fix(xiaomi): handle mimo token-plan keys

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -7,7 +7,10 @@
 - Added `zhipu-coding-plan` provider for Zhipu (智谱) BigModel's domestic coding-plan SKU at `https://open.bigmodel.cn/api/coding/paas/v4`, with dynamic model discovery (`ZHIPU_API_KEY`), zai-format thinking, `reasoning_content` field, and OAuth login flow ([#1340](https://github.com/can1357/oh-my-pi/issues/1340)).
 ### Fixed
 
-- Fixed Xiaomi MiMo Token Plan `tp-` keys issued for the CN cluster still failing with 401 by trying the official CN, SGP, and AMS token-plan endpoints in order while preserving explicit `baseUrl` overrides ([#772](https://github.com/can1357/oh-my-pi/issues/772)).
+- Fixed Xiaomi MiMo OpenAI-compatible reasoning requests to send the provider's top-level `thinking: { type: "enabled" }` control instead of dropping thinking when OpenAI `reasoning_effort` is unsupported.
+- Fixed Xiaomi MiMo Token Plan refreshes from cached official regional hosts, including Anthropic regional URLs, so TP-key discovery still falls back across CN, SGP, and AMS instead of pinning to the stale cached region.
+- Fixed Xiaomi MiMo Token Plan discovered models inheriting the bundled Anthropic transport metadata, which sent TP-key chat requests through the wrong API shape and left sessions stuck waiting for output.
+- Fixed Xiaomi MiMo Token Plan `tp-` keys issued for the CN cluster still failing with 401 by trying the official CN, SGP, and AMS token-plan endpoints in order, including when the configured standard Xiaomi base URL has a trailing slash or Anthropic `/v1` path, while preserving explicit `baseUrl` overrides ([#772](https://github.com/can1357/oh-my-pi/issues/772)).
 
 ### Removed
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 
 - Added `zhipu-coding-plan` provider for Zhipu (智谱) BigModel's domestic coding-plan SKU at `https://open.bigmodel.cn/api/coding/paas/v4`, with dynamic model discovery (`ZHIPU_API_KEY`), zai-format thinking, `reasoning_content` field, and OAuth login flow ([#1340](https://github.com/can1357/oh-my-pi/issues/1340)).
+### Fixed
+
+- Fixed Xiaomi MiMo Token Plan `tp-` keys issued for the CN cluster still failing with 401 by trying the official CN, SGP, and AMS token-plan endpoints in order while preserving explicit `baseUrl` overrides ([#772](https://github.com/can1357/oh-my-pi/issues/772)).
 
 ### Removed
 

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -1475,53 +1475,50 @@ export function xiaomiModelManagerOptions(
 ): ModelManagerOptions<"openai-completions"> {
 	const apiKey = config?.apiKey;
 	// Xiaomi splits API keys across two backends: standard `sk-` keys hit
-	// api.xiaomimimo.com; "token plan" `tp-` keys hit either the SG or EU
-	// token-plan host. Try SGP first; if discovery fails, retry AMS.
-	const TOKEN_PLAN_SGP_BASE_URL = "https://token-plan-sgp.xiaomimimo.com/v1";
-	const TOKEN_PLAN_AMS_BASE_URL = "https://token-plan-ams.xiaomimimo.com/v1";
-	const defaultBaseUrl = apiKey?.startsWith("tp-") ? TOKEN_PLAN_SGP_BASE_URL : "https://api.xiaomimimo.com/v1";
-	// Token-plan keys always use the TP baseUrl; config?.baseUrl (from catalog)
-	// would incorrectly pin to the standard endpoint (api.xiaomimimo.com).
-	const baseUrl = apiKey?.startsWith("tp-") ? defaultBaseUrl : (config?.baseUrl ?? defaultBaseUrl);
+	// api.xiaomimimo.com; "token plan" `tp-` keys are scoped to a regional
+	// token-plan host. Try the official clusters in order unless explicitly
+	// configured with a custom baseUrl.
+	const TOKEN_PLAN_BASE_URLS = [
+		"https://token-plan-cn.xiaomimimo.com/v1",
+		"https://token-plan-sgp.xiaomimimo.com/v1",
+		"https://token-plan-ams.xiaomimimo.com/v1",
+	] as const;
+	const defaultBaseUrl = "https://api.xiaomimimo.com/v1";
+	const isTokenPlanKey = apiKey?.startsWith("tp-") === true;
+	const configuredBaseUrl = config?.baseUrl?.trim() || undefined;
+	const isStandardXiaomiBaseUrl =
+		configuredBaseUrl === defaultBaseUrl || configuredBaseUrl === "https://api.xiaomimimo.com/anthropic";
+	const discoveryBaseUrls = isTokenPlanKey
+		? configuredBaseUrl && !isStandardXiaomiBaseUrl
+			? [configuredBaseUrl]
+			: TOKEN_PLAN_BASE_URLS
+		: [configuredBaseUrl ?? defaultBaseUrl];
 	const references = createBundledReferenceMap<"openai-completions">("xiaomi");
+	const fetchModels = (baseUrl: string) =>
+		fetchOpenAICompatibleModels({
+			api: "openai-completions",
+			provider: "xiaomi",
+			baseUrl,
+			apiKey,
+			filterModel: (_entry, model) => !model.id.includes("-tts"),
+			mapModel: (entry, defaults) => {
+				const reference = references.get(defaults.id);
+				const model = mapWithBundledReference(entry, defaults, reference);
+				return {
+					...model,
+					name: toModelName(entry.display_name, model.name),
+				};
+			},
+		});
 	return {
 		providerId: "xiaomi",
 		...(apiKey && {
 			fetchDynamicModels: async () => {
-				const sgpResult = await fetchOpenAICompatibleModels({
-					api: "openai-completions",
-					provider: "xiaomi",
-					baseUrl,
-					apiKey,
-					filterModel: (_entry, model) => !model.id.includes("-tts"),
-					mapModel: (entry, defaults) => {
-						const reference = references.get(defaults.id);
-						const model = mapWithBundledReference(entry, defaults, reference);
-						return {
-							...model,
-							name: toModelName(entry.display_name, model.name),
-						};
-					},
-				});
-				if (sgpResult || !apiKey?.startsWith("tp-")) {
-					return sgpResult;
+				for (const baseUrl of discoveryBaseUrls) {
+					const result = await fetchModels(baseUrl);
+					if (result) return result;
 				}
-				// Token-plan discovery failed with SGP; retry with AMS
-				return fetchOpenAICompatibleModels({
-					api: "openai-completions",
-					provider: "xiaomi",
-					baseUrl: TOKEN_PLAN_AMS_BASE_URL,
-					apiKey,
-					filterModel: (_entry, model) => !model.id.includes("-tts"),
-					mapModel: (entry, defaults) => {
-						const reference = references.get(defaults.id);
-						const model = mapWithBundledReference(entry, defaults, reference);
-						return {
-							...model,
-							name: toModelName(entry.display_name, model.name),
-						};
-					},
-				});
+				return null;
 			},
 		}),
 	};

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -160,6 +160,8 @@ function mapWithBundledReference<TApi extends Api>(
 		...reference,
 		id: defaults.id,
 		name,
+		api: defaults.api,
+		provider: defaults.provider,
 		baseUrl: defaults.baseUrl,
 		contextWindow: toPositiveNumber(entry.context_length, reference.contextWindow),
 		maxTokens: toPositiveNumber(entry.max_completion_tokens, reference.maxTokens),
@@ -1486,10 +1488,39 @@ export function xiaomiModelManagerOptions(
 	const defaultBaseUrl = "https://api.xiaomimimo.com/v1";
 	const isTokenPlanKey = apiKey?.startsWith("tp-") === true;
 	const configuredBaseUrl = config?.baseUrl?.trim() || undefined;
-	const isStandardXiaomiBaseUrl =
-		configuredBaseUrl === defaultBaseUrl || configuredBaseUrl === "https://api.xiaomimimo.com/anthropic";
+	const isStandardXiaomiBaseUrl = (baseUrl: string | undefined) => {
+		if (!baseUrl) return false;
+		try {
+			const url = new URL(baseUrl);
+			if (url.protocol !== "https:" || url.host !== "api.xiaomimimo.com" || url.search || url.hash) {
+				return false;
+			}
+			const pathname = url.pathname.replace(/\/+$/, "");
+			return pathname === "/v1" || pathname === "/anthropic" || pathname === "/anthropic/v1";
+		} catch {
+			return false;
+		}
+	};
+	const isOfficialTokenPlanBaseUrl = (baseUrl: string | undefined) => {
+		if (!baseUrl) return false;
+		try {
+			const url = new URL(baseUrl);
+			if (url.protocol !== "https:" || url.search || url.hash) {
+				return false;
+			}
+			const pathname = url.pathname.replace(/\/+$/, "");
+			return (
+				(pathname === "/v1" || pathname === "/anthropic" || pathname === "/anthropic/v1") &&
+				TOKEN_PLAN_BASE_URLS.some(candidate => new URL(candidate).host === url.host)
+			);
+		} catch {
+			return false;
+		}
+	};
 	const discoveryBaseUrls = isTokenPlanKey
-		? configuredBaseUrl && !isStandardXiaomiBaseUrl
+		? configuredBaseUrl &&
+			!isStandardXiaomiBaseUrl(configuredBaseUrl) &&
+			!isOfficialTokenPlanBaseUrl(configuredBaseUrl)
 			? [configuredBaseUrl]
 			: TOKEN_PLAN_BASE_URLS
 		: [configuredBaseUrl ?? defaultBaseUrl];

--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -53,6 +53,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 	const isZai = provider === "zai" || baseUrl.includes("api.z.ai");
 	const isZhipu = provider === "zhipu-coding-plan" || baseUrl.includes("open.bigmodel.cn");
 	const isKilo = provider === "kilo" || baseUrl.includes("api.kilo.ai");
+	const isXiaomi = provider === "xiaomi" || baseUrl.includes("xiaomimimo.com");
 	const isKimiModel = model.id.includes("moonshotai/kimi") || /(^|\/)kimi[-.]/i.test(model.id);
 	const isMoonshotKimi =
 		isKimiModel &&
@@ -100,6 +101,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		isZai ||
 		isZhipu ||
 		isKilo ||
+		isXiaomi ||
 		isQwen ||
 		provider === "opencode-zen" ||
 		provider === "opencode-go" ||
@@ -197,7 +199,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		// OpenAI's reasoning-API surface.
 		supportsDeveloperRole: isOpenAIHost || isAzureHost,
 		supportsMultipleSystemMessages: supportsMultipleSystemMessagesDefault,
-		supportsReasoningEffort: !isGrok && !isZai && !isZhipu,
+		supportsReasoningEffort: !isGrok && !isZai && !isZhipu && !isXiaomi,
 		reasoningEffortMap,
 		supportsUsageInStreaming: !isCerebras,
 		disableReasoningOnForcedToolChoice: isKimiModel || isAnthropicModel,
@@ -211,11 +213,13 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		thinkingFormat:
 			isZai || isZhipu || isMoonshotKimi
 				? "zai"
-				: provider === "openrouter" || baseUrl.includes("openrouter.ai")
-					? "openrouter"
-					: isAlibaba || isQwen
-						? "qwen"
-						: "openai",
+				: isXiaomi
+					? "xiaomi"
+					: provider === "openrouter" || baseUrl.includes("openrouter.ai")
+						? "openrouter"
+						: isAlibaba || isQwen
+							? "qwen"
+							: "openai",
 		reasoningContentField: "reasoning_content",
 		// Backends that 400 follow-up requests when prior assistant tool-call turns lack `reasoning_content`:
 		//   - Kimi: documented invariant on its native API.
@@ -229,11 +233,12 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		// client-sent `reasoning_content`, so exclude only that Kimi-on-OpenCode path.
 		requiresReasoningContentForToolCalls:
 			(isKimiModel && !isOpenCodeProvider) ||
+			(isXiaomi && Boolean(model.reasoning)) ||
 			(isDeepseekFamily && Boolean(model.reasoning)) ||
 			((provider === "openrouter" || baseUrl.includes("openrouter.ai")) && Boolean(model.reasoning)),
 		// DeepSeek V4 rejects synthetic reasoning_content placeholders (".") on tool-call turns.
 		// Kimi and OpenRouter accept them when actual reasoning is unavailable.
-		allowsSyntheticReasoningContentForToolCalls: !isDeepseekFamily || !model.reasoning,
+		allowsSyntheticReasoningContentForToolCalls: !(isDeepseekFamily || isXiaomi) || !model.reasoning,
 		requiresAssistantContentForToolCalls: isKimiModel || isDirectDeepseekReasoning,
 		openRouterRouting: undefined,
 		vercelGatewayRouting: undefined,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1142,6 +1142,10 @@ function buildParams(
 		// Must explicitly disable since z.ai defaults to thinking enabled.
 		const enabled = options?.reasoning && !options?.disableReasoning;
 		params.thinking = { type: enabled ? "enabled" : "disabled" };
+	} else if (supportsReasoningParams && compat.thinkingFormat === "xiaomi" && model.reasoning) {
+		// Xiaomi MiMo's OpenAI-compatible API uses binary top-level thinking.
+		const enabled = options?.reasoning && !options?.disableReasoning;
+		params.thinking = { type: enabled ? "enabled" : "disabled" };
 	} else if (supportsReasoningParams && compat.thinkingFormat === "qwen" && model.reasoning) {
 		// Qwen uses top-level enable_thinking: boolean
 		params.enable_thinking = !!options?.reasoning && !options?.disableReasoning;
@@ -1204,7 +1208,7 @@ function buildParams(
 		// turn while keeping the tool-selection contract intact.
 		delete params.reasoning_effort;
 		delete params.reasoning;
-		if (compat.thinkingFormat === "zai") {
+		if (compat.thinkingFormat === "zai" || compat.thinkingFormat === "xiaomi") {
 			params.thinking = { type: "disabled" };
 		}
 	}
@@ -1546,7 +1550,8 @@ export function convertMessages(
 				compat.allowsSyntheticReasoningContentForToolCalls &&
 				(compat.thinkingFormat === "openai" ||
 					compat.thinkingFormat === "openrouter" ||
-					compat.thinkingFormat === "zai");
+					compat.thinkingFormat === "zai" ||
+					compat.thinkingFormat === "xiaomi");
 			// DeepSeek reasoning models require reasoning_content on ALL assistant turns,
 			// not just tool-call turns. Other providers (Kimi, OpenRouter) only require it
 			// on tool-call turns.

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -754,7 +754,7 @@ export interface OpenAICompat {
 	/** Whether tool call IDs must be normalized to Mistral format (exactly 9 alphanumeric chars). Default: auto-detected from URL. */
 	requiresMistralToolIds?: boolean;
 	/** Format for reasoning/thinking parameter. "openai" uses reasoning_effort, "openrouter" uses reasoning: { effort }, "zai" uses thinking: { type: "enabled" | "disabled" } (also used by Moonshot Kimi), "qwen" uses top-level enable_thinking, and "qwen-chat-template" uses chat_template_kwargs.enable_thinking. Default: "openai". */
-	thinkingFormat?: "openai" | "openrouter" | "zai" | "qwen" | "qwen-chat-template";
+	thinkingFormat?: "openai" | "openrouter" | "zai" | "xiaomi" | "qwen" | "qwen-chat-template";
 	/** Which reasoning content field to emit on assistant messages. Default: auto-detected. */
 	reasoningContentField?: "reasoning_content" | "reasoning" | "reasoning_text";
 	/** Whether assistant tool-call messages must include reasoning content. Default: false. */

--- a/packages/ai/src/utils/oauth/xiaomi.ts
+++ b/packages/ai/src/utils/oauth/xiaomi.ts
@@ -16,8 +16,11 @@ const PROVIDER_ID = "xiaomi";
 const PROVIDER_NAME = "Xiaomi MiMo";
 const STANDARD_AUTH_URL = "https://platform.xiaomimimo.com/#/console/api-keys";
 const STANDARD_API_BASE_URL = "https://api.xiaomimimo.com/v1";
-const TOKEN_PLAN_SGP_API_BASE_URL = "https://token-plan-sgp.xiaomimimo.com/v1";
-const TOKEN_PLAN_AMS_API_BASE_URL = "https://token-plan-ams.xiaomimimo.com/v1";
+const TOKEN_PLAN_API_BASE_URLS = [
+	"https://token-plan-cn.xiaomimimo.com/v1",
+	"https://token-plan-sgp.xiaomimimo.com/v1",
+	"https://token-plan-ams.xiaomimimo.com/v1",
+] as const;
 const TOKEN_PLAN_KEY_PREFIX = "tp-";
 const STANDARD_VALIDATION_MODEL = "mimo-v2-flash";
 const TOKEN_PLAN_VALIDATION_MODEL = "mimo-v2.5";
@@ -29,13 +32,10 @@ function isTokenPlanKey(apiKey: string): boolean {
 const VALIDATION_TIMEOUT_MS = 15_000;
 
 async function validateXiaomiApiKey(apiKey: string, signal?: AbortSignal): Promise<void> {
-	// For token-plan keys try SGP first, then AMS as fallback.
+	// For token-plan keys try the official clusters in order.
 	// Standard sk- keys only hit the one endpoint.
 	const endpoints = isTokenPlanKey(apiKey)
-		? [
-				{ baseUrl: TOKEN_PLAN_SGP_API_BASE_URL, model: TOKEN_PLAN_VALIDATION_MODEL },
-				{ baseUrl: TOKEN_PLAN_AMS_API_BASE_URL, model: TOKEN_PLAN_VALIDATION_MODEL },
-			]
+		? TOKEN_PLAN_API_BASE_URLS.map(baseUrl => ({ baseUrl, model: TOKEN_PLAN_VALIDATION_MODEL }))
 		: [{ baseUrl: STANDARD_API_BASE_URL, model: STANDARD_VALIDATION_MODEL }];
 
 	let lastError: Error | null = null;
@@ -51,7 +51,7 @@ async function validateXiaomiApiKey(apiKey: string, signal?: AbortSignal): Promi
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					"x-api-key": apiKey,
+					"api-key": apiKey,
 				},
 				body: JSON.stringify({
 					model: ep.model,

--- a/packages/ai/test/issue-772-repro.test.ts
+++ b/packages/ai/test/issue-772-repro.test.ts
@@ -70,6 +70,24 @@ describe("issue-772: Xiaomi MiMo token-plan (tp-) keys", () => {
 		expect(url).toContain("/v1/models");
 	});
 
+	it("xiaomiModelManagerOptions keeps token-plan discovered models on openai-completions transport", async () => {
+		using _hook = hookFetch(() => {
+			return new Response(JSON.stringify({ data: [{ id: "mimo-v2.5", name: "MiMo-V2.5" }] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		});
+
+		const opts = xiaomiModelManagerOptions({ apiKey: "tp-test-key" });
+		const models = await opts.fetchDynamicModels?.();
+
+		expect(models).toHaveLength(1);
+		expect(models?.[0]?.id).toBe("mimo-v2.5");
+		expect(models?.[0]?.api).toBe("openai-completions");
+		expect(models?.[0]?.provider).toBe("xiaomi");
+		expect(models?.[0]?.baseUrl).toContain(TOKEN_PLAN_CN_HOST);
+	});
+
 	it("xiaomiModelManagerOptions falls back across token-plan clusters after discovery failures", async () => {
 		const seen: string[] = [];
 		using _hook = hookFetch(input => {
@@ -92,26 +110,70 @@ describe("issue-772: Xiaomi MiMo token-plan (tp-) keys", () => {
 		expect(seen[2]).toContain(TOKEN_PLAN_AMS_HOST);
 	});
 
-	it("xiaomiModelManagerOptions ignores bundled standard baseUrl for tp- keys", async () => {
-		const seen: string[] = [];
-		using _hook = hookFetch(input => {
-			seen.push(String(input));
-			return new Response(JSON.stringify({ data: [] }), {
-				status: 200,
-				headers: { "content-type": "application/json" },
+	for (const baseUrl of [
+		"https://api.xiaomimimo.com/v1",
+		"https://api.xiaomimimo.com/v1/",
+		"https://api.xiaomimimo.com/anthropic",
+		"https://api.xiaomimimo.com/anthropic/v1",
+	]) {
+		it(`xiaomiModelManagerOptions ignores standard baseUrl ${baseUrl} for tp- keys`, async () => {
+			const seen: string[] = [];
+			using _hook = hookFetch(input => {
+				seen.push(String(input));
+				return new Response(JSON.stringify({ data: [] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
 			});
-		});
 
-		const opts = xiaomiModelManagerOptions({
-			apiKey: "tp-test-key",
-			baseUrl: "https://api.xiaomimimo.com/v1",
-		});
-		await opts.fetchDynamicModels?.();
+			const opts = xiaomiModelManagerOptions({
+				apiKey: "tp-test-key",
+				baseUrl,
+			});
+			await opts.fetchDynamicModels?.();
 
-		expect(seen).toHaveLength(1);
-		expect(seen[0]).toContain(TOKEN_PLAN_CN_HOST);
-		expect(seen[0]).not.toContain(STANDARD_HOST);
-	});
+			expect(seen).toHaveLength(1);
+			expect(seen[0]).toContain(TOKEN_PLAN_CN_HOST);
+			expect(seen[0]).not.toContain(STANDARD_HOST);
+		});
+	}
+
+	for (const baseUrl of [
+		"https://token-plan-cn.xiaomimimo.com/v1",
+		"https://token-plan-cn.xiaomimimo.com/anthropic",
+		"https://token-plan-cn.xiaomimimo.com/anthropic/v1",
+		"https://token-plan-sgp.xiaomimimo.com/v1",
+		"https://token-plan-sgp.xiaomimimo.com/anthropic",
+		"https://token-plan-sgp.xiaomimimo.com/anthropic/v1",
+		"https://token-plan-ams.xiaomimimo.com/v1",
+		"https://token-plan-ams.xiaomimimo.com/anthropic",
+		"https://token-plan-ams.xiaomimimo.com/anthropic/v1",
+	]) {
+		it(`xiaomiModelManagerOptions keeps regional fallback for official token-plan baseUrl ${baseUrl}`, async () => {
+			const seen: string[] = [];
+			using _hook = hookFetch(input => {
+				seen.push(String(input));
+				if (seen.length < 3) {
+					return new Response("{}", { status: 401 });
+				}
+				return new Response(JSON.stringify({ data: [] }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
+			});
+
+			const opts = xiaomiModelManagerOptions({
+				apiKey: "tp-test-key",
+				baseUrl,
+			});
+			await opts.fetchDynamicModels?.();
+
+			expect(seen).toHaveLength(3);
+			expect(seen[0]).toContain(TOKEN_PLAN_CN_HOST);
+			expect(seen[1]).toContain(TOKEN_PLAN_SGP_HOST);
+			expect(seen[2]).toContain(TOKEN_PLAN_AMS_HOST);
+		});
+	}
 
 	it("xiaomiModelManagerOptions honors explicit baseUrl overrides for tp- keys", async () => {
 		const seen: string[] = [];

--- a/packages/ai/test/issue-772-repro.test.ts
+++ b/packages/ai/test/issue-772-repro.test.ts
@@ -4,11 +4,13 @@ import { hookFetch } from "@oh-my-pi/pi-utils";
 import { xiaomiModelManagerOptions } from "../src/provider-models/openai-compat";
 import { loginXiaomi } from "../src/utils/oauth/xiaomi";
 
+const TOKEN_PLAN_CN_HOST = "token-plan-cn.xiaomimimo.com";
 const TOKEN_PLAN_SGP_HOST = "token-plan-sgp.xiaomimimo.com";
+const TOKEN_PLAN_AMS_HOST = "token-plan-ams.xiaomimimo.com";
 const STANDARD_HOST = "api.xiaomimimo.com";
 
 describe("issue-772: Xiaomi MiMo token-plan (tp-) keys", () => {
-	it("loginXiaomi validates tp- keys against the SGP token-plan host first", async () => {
+	it("loginXiaomi validates tp- keys against the CN token-plan host first", async () => {
 		const seen: string[] = [];
 		using _hook = hookFetch(input => {
 			seen.push(String(input));
@@ -23,11 +25,33 @@ describe("issue-772: Xiaomi MiMo token-plan (tp-) keys", () => {
 
 		expect(seen).toHaveLength(1);
 		const url = seen[0]!;
-		expect(url).toContain(TOKEN_PLAN_SGP_HOST);
+		expect(url).toContain(TOKEN_PLAN_CN_HOST);
 		expect(url).toContain("/chat/completions");
 	});
 
-	it("xiaomiModelManagerOptions discovers models from the SGP token-plan host when given a tp- key", async () => {
+	it("loginXiaomi falls back across token-plan clusters after 401 responses", async () => {
+		const seen: string[] = [];
+		using _hook = hookFetch(input => {
+			seen.push(String(input));
+			if (seen.length < 3) {
+				return new Response("{}", { status: 401 });
+			}
+			return new Response("{}", { status: 200 });
+		});
+
+		await loginXiaomi({
+			onAuth: () => {},
+			onPrompt: async () => "tp-test-key",
+			onProgress: () => {},
+		});
+
+		expect(seen).toHaveLength(3);
+		expect(seen[0]).toContain(TOKEN_PLAN_CN_HOST);
+		expect(seen[1]).toContain(TOKEN_PLAN_SGP_HOST);
+		expect(seen[2]).toContain(TOKEN_PLAN_AMS_HOST);
+	});
+
+	it("xiaomiModelManagerOptions discovers models from the CN token-plan host when given a tp- key", async () => {
 		const seen: string[] = [];
 		using _hook = hookFetch(input => {
 			seen.push(String(input));
@@ -42,8 +66,74 @@ describe("issue-772: Xiaomi MiMo token-plan (tp-) keys", () => {
 
 		expect(seen.length).toBeGreaterThan(0);
 		const url = seen[0]!;
-		expect(url).toContain(TOKEN_PLAN_SGP_HOST);
+		expect(url).toContain(TOKEN_PLAN_CN_HOST);
 		expect(url).toContain("/v1/models");
+	});
+
+	it("xiaomiModelManagerOptions falls back across token-plan clusters after discovery failures", async () => {
+		const seen: string[] = [];
+		using _hook = hookFetch(input => {
+			seen.push(String(input));
+			if (seen.length < 3) {
+				return new Response("{}", { status: 401 });
+			}
+			return new Response(JSON.stringify({ data: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		});
+
+		const opts = xiaomiModelManagerOptions({ apiKey: "tp-test-key" });
+		await opts.fetchDynamicModels?.();
+
+		expect(seen).toHaveLength(3);
+		expect(seen[0]).toContain(TOKEN_PLAN_CN_HOST);
+		expect(seen[1]).toContain(TOKEN_PLAN_SGP_HOST);
+		expect(seen[2]).toContain(TOKEN_PLAN_AMS_HOST);
+	});
+
+	it("xiaomiModelManagerOptions ignores bundled standard baseUrl for tp- keys", async () => {
+		const seen: string[] = [];
+		using _hook = hookFetch(input => {
+			seen.push(String(input));
+			return new Response(JSON.stringify({ data: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		});
+
+		const opts = xiaomiModelManagerOptions({
+			apiKey: "tp-test-key",
+			baseUrl: "https://api.xiaomimimo.com/v1",
+		});
+		await opts.fetchDynamicModels?.();
+
+		expect(seen).toHaveLength(1);
+		expect(seen[0]).toContain(TOKEN_PLAN_CN_HOST);
+		expect(seen[0]).not.toContain(STANDARD_HOST);
+	});
+
+	it("xiaomiModelManagerOptions honors explicit baseUrl overrides for tp- keys", async () => {
+		const seen: string[] = [];
+		using _hook = hookFetch(input => {
+			seen.push(String(input));
+			return new Response(JSON.stringify({ data: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		});
+
+		const opts = xiaomiModelManagerOptions({
+			apiKey: "tp-test-key",
+			baseUrl: "https://proxy.example.com/v1",
+		});
+		await opts.fetchDynamicModels?.();
+
+		expect(seen).toHaveLength(1);
+		expect(seen[0]).toContain("https://proxy.example.com/v1/models");
+		expect(seen[0]).not.toContain(TOKEN_PLAN_CN_HOST);
+		expect(seen[0]).not.toContain(TOKEN_PLAN_SGP_HOST);
+		expect(seen[0]).not.toContain(TOKEN_PLAN_AMS_HOST);
 	});
 
 	it("xiaomiModelManagerOptions still uses the standard host for sk- keys", async () => {
@@ -62,6 +152,8 @@ describe("issue-772: Xiaomi MiMo token-plan (tp-) keys", () => {
 		expect(seen.length).toBeGreaterThan(0);
 		const url = seen[0]!;
 		expect(url).toContain(STANDARD_HOST);
+		expect(url).not.toContain(TOKEN_PLAN_CN_HOST);
 		expect(url).not.toContain(TOKEN_PLAN_SGP_HOST);
+		expect(url).not.toContain(TOKEN_PLAN_AMS_HOST);
 	});
 });

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import { Effort } from "../src/model-thinking";
 import { getBundledModel } from "../src/models";
 import { convertMessages, detectCompat, streamOpenAICompletions } from "../src/providers/openai-completions";
 import { resolveOpenAICompat } from "../src/providers/openai-completions-compat";
@@ -31,6 +32,13 @@ function getNestedBoolean(value: unknown, key: string): boolean | undefined {
 	if (!obj) return undefined;
 	const property = Reflect.get(obj, key);
 	return typeof property === "boolean" ? property : undefined;
+}
+
+function getNestedString(value: unknown, key: string): string | undefined {
+	const obj = toObject(value);
+	if (!obj) return undefined;
+	const property = Reflect.get(obj, key);
+	return typeof property === "string" ? property : undefined;
 }
 
 function createSseResponse(events: unknown[]): Response {
@@ -121,6 +129,74 @@ describe("openai-completions compatibility", () => {
 		}
 		expect(typeof assistant.content).toBe("string");
 		expect(assistant.content).toBe("hello world");
+	});
+
+	it("treats Xiaomi MiMo as nonstandard and replays reasoning_content for tool calls", () => {
+		const model: Model<"openai-completions"> = {
+			id: "mimo-v2.5",
+			name: "MiMo-V2.5",
+			api: "openai-completions",
+			provider: "xiaomi",
+			baseUrl: "https://token-plan-cn.xiaomimimo.com/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1048576,
+			maxTokens: 131072,
+			thinking: { mode: "budget", minLevel: Effort.Minimal, maxLevel: Effort.XHigh },
+		};
+
+		const compat = detectCompat(model);
+
+		expect(compat.supportsStore).toBe(false);
+		expect(compat.supportsReasoningEffort).toBe(false);
+		expect(compat.thinkingFormat).toBe("xiaomi");
+		expect(compat.requiresReasoningContentForToolCalls).toBe(true);
+		expect(compat.allowsSyntheticReasoningContentForToolCalls).toBe(false);
+		expect(compat.requiresAssistantContentForToolCalls).toBe(false);
+	});
+
+	it("injects Xiaomi reasoning_content on replayed assistant tool-call turns", () => {
+		const model: Model<"openai-completions"> = {
+			id: "mimo-v2.5",
+			name: "MiMo-V2.5",
+			api: "openai-completions",
+			provider: "xiaomi",
+			baseUrl: "https://token-plan-cn.xiaomimimo.com/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1048576,
+			maxTokens: 131072,
+			thinking: { mode: "budget", minLevel: Effort.Minimal, maxLevel: Effort.XHigh },
+		};
+		const assistantMessage: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "Need to inspect the file.", thinkingSignature: "reasoning_content" },
+				{ type: "toolCall", id: "call_1", name: "read", arguments: { filePath: "README.md" } },
+			],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+
+		const messages = convertMessages(model, { messages: [assistantMessage] }, detectCompat(model));
+		const assistant = messages.find(message => message.role === "assistant");
+
+		expect(assistant).toBeDefined();
+		expect(assistant ? Reflect.get(assistant, "reasoning_content") : undefined).toBe("Need to inspect the file.");
+		expect(assistant && "content" in assistant ? assistant.content : undefined).toBe("");
 	});
 
 	it("preserves multiple system prompts as leading system messages for chat completions", () => {
@@ -417,6 +493,62 @@ describe("openai-completions compatibility", () => {
 		const payload = await promise;
 		const chatTemplateArgs = getNestedObject(payload, "chat_template_kwargs");
 		expect(getNestedBoolean(chatTemplateArgs, "enable_thinking")).toBe(true);
+	});
+
+	it("maps Xiaomi reasoning into top-level thinking enabled", async () => {
+		const model: Model<"openai-completions"> = {
+			id: "mimo-v2.5-pro",
+			name: "MiMo-V2.5-Pro",
+			api: "openai-completions",
+			provider: "xiaomi",
+			baseUrl: "https://token-plan-cn.xiaomimimo.com/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1048576,
+			maxTokens: 131072,
+			thinking: { mode: "budget", minLevel: Effort.Minimal, maxLevel: Effort.XHigh },
+		};
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			reasoning: "high",
+			signal: createAbortedSignal(),
+			onPayload: payload => resolve(payload),
+		});
+
+		const payload = await promise;
+		const thinking = getNestedObject(payload, "thinking");
+		expect(getNestedString(thinking, "type")).toBe("enabled");
+		expect(Object.hasOwn(toObject(payload) ?? {}, "reasoning_effort")).toBe(false);
+	});
+
+	it("maps Xiaomi disabled reasoning into top-level thinking disabled", async () => {
+		const model: Model<"openai-completions"> = {
+			id: "mimo-v2.5-pro",
+			name: "MiMo-V2.5-Pro",
+			api: "openai-completions",
+			provider: "xiaomi",
+			baseUrl: "https://token-plan-cn.xiaomimimo.com/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 1048576,
+			maxTokens: 131072,
+			thinking: { mode: "budget", minLevel: Effort.Minimal, maxLevel: Effort.XHigh },
+		};
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			disableReasoning: true,
+			signal: createAbortedSignal(),
+			onPayload: payload => resolve(payload),
+		});
+
+		const payload = await promise;
+		const thinking = getNestedObject(payload, "thinking");
+		expect(getNestedString(thinking, "type")).toBe("disabled");
+		expect(Object.hasOwn(toObject(payload) ?? {}, "reasoning_effort")).toBe(false);
 	});
 
 	it("treats finish_reason end as stop", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -16,6 +16,11 @@
 - Changed `omp auth-broker login` to drive the per-provider OAuth/API-key flow in-process via `AuthStorage.login()` instead of spawning the `pi-ai` CLI subprocess. The pi-ai bin is being removed; the same login surface now lives entirely inside `omp`.
 - Changed default per-line truncation cap for search/grep output (`DEFAULT_MAX_COLUMN`) from `1024` to `512` characters.
 
+### Fixed
+
+- Fixed cached model rows so hardcoded metadata policies such as the non-Copilot `gpt-5.4` context window still apply after process restart.
+- Fixed stale Xiaomi MiMo Token Plan model caches that recorded plain `/v1` endpoints with Anthropic transport metadata by forcing those entries back to OpenAI-compatible chat completions at load time, while preserving nested Anthropic endpoints such as `/anthropic/v1`.
+
 ## [15.4.3] - 2026-05-26
 
 ### Fixed

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -291,6 +291,18 @@ export function mergeDiscoveredModel<TApi extends Api>(
 	return model;
 }
 
+function isPlainXiaomiV1BaseUrl(baseUrl: string): boolean {
+	try {
+		const url = new URL(baseUrl);
+		return (
+			(url.hostname === "xiaomimimo.com" || url.hostname.endsWith(".xiaomimimo.com")) &&
+			url.pathname.replace(/\/+$/, "") === "/v1"
+		);
+	} catch {
+		return false;
+	}
+}
+
 function isAuthoritativeProjectCatalogModel(model: Model<Api>): boolean {
 	return (
 		model.provider === "google-vertex" &&
@@ -901,8 +913,8 @@ export class ModelRegistry {
 		this.#addImplicitDiscoverableProviders(configuredProviders);
 		let builtInModels = this.#applyHardcodedModelPolicies(this.#loadBuiltInModels(overrides));
 		const cachedStandardResult = this.#loadCachedStandardProviderModels();
-		const cachedStandardModels = this.#applyHardcodedModelPolicies(cachedStandardResult.models);
-		const cachedDiscoveries = this.#applyHardcodedModelPolicies(this.#loadCachedDiscoverableModels());
+		const cachedStandardModels = cachedStandardResult.models;
+		const cachedDiscoveries = this.#loadCachedDiscoverableModels();
 		// Only drop bundled fallback models when the cached project-catalog row is
 		// itself fresh AND authoritative. A stale or non-authoritative snapshot
 		// (e.g. after ADC discovery failure rewrote the row with authoritative=0)
@@ -1044,7 +1056,9 @@ export class ModelRegistry {
 			const withCompat = providerOverride?.compat
 				? withTransport.map(model => ({ ...model, compat: mergeCompat(model.compat, providerOverride.compat) }))
 				: withTransport;
-			cachedModels.push(...this.#applyProviderModelOverrides(descriptor.providerId, withCompat));
+			cachedModels.push(
+				...this.#applyCachedModelPolicies(this.#applyProviderModelOverrides(descriptor.providerId, withCompat)),
+			);
 		}
 		return { models: cachedModels, authoritativeFreshProviders };
 	}
@@ -1070,14 +1084,15 @@ export class ModelRegistry {
 					this.#applyProviderCompat(providerConfig.compat, cache.models),
 				),
 			);
-			cachedModels.push(...models);
+			const cachedPolicyModels = this.#applyCachedModelPolicies(models);
+			cachedModels.push(...cachedPolicyModels);
 			this.#providerDiscoveryStates.set(providerConfig.provider, {
 				provider: providerConfig.provider,
 				status: "cached",
 				optional: providerConfig.optional ?? false,
 				stale: !cache.fresh || !cache.authoritative,
 				fetchedAt: cache.updatedAt,
-				models: models.map(model => model.id),
+				models: cachedPolicyModels.map(model => model.id),
 			});
 		}
 		return cachedModels;
@@ -1830,6 +1845,19 @@ export class ModelRegistry {
 				...overrides,
 			});
 		});
+	}
+	#applyCachedModelPolicies(models: Model<Api>[]): Model<Api>[] {
+		const withCacheFixups = models.map(model => {
+			if (
+				model.provider === "xiaomi" &&
+				model.api === "anthropic-messages" &&
+				isPlainXiaomiV1BaseUrl(model.baseUrl)
+			) {
+				return { ...model, api: "openai-completions" };
+			}
+			return model;
+		});
+		return this.#applyHardcodedModelPolicies(withCacheFixups);
 	}
 
 	#rebuildCanonicalIndex(): void {

--- a/packages/coding-agent/test/xiaomi-api-policy.test.ts
+++ b/packages/coding-agent/test/xiaomi-api-policy.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type Model, writeModelCache } from "@oh-my-pi/pi-ai";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resetSettingsForTest } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+
+describe("Xiaomi API policy", () => {
+	let tempDir: string;
+	let modelsJsonPath: string;
+	let authStorage: AuthStorage;
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = path.join(os.tmpdir(), `pi-test-xiaomi-api-policy-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		modelsJsonPath = path.join(tempDir, "models.json");
+		authStorage = await AuthStorage.create(path.join(tempDir, "auth.db"));
+	});
+
+	afterEach(async () => {
+		resetSettingsForTest();
+		authStorage.close();
+		await removeTempDir(tempDir);
+	});
+
+	function writeXiaomiModel(baseUrl: string, id: string): void {
+		fs.writeFileSync(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					xiaomi: {
+						baseUrl,
+						apiKey: "TEST_KEY",
+						api: "anthropic-messages",
+						models: [
+							{
+								id,
+								name: id,
+								reasoning: false,
+								input: ["text"],
+								cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+								contextWindow: 100000,
+								maxTokens: 8000,
+							},
+						],
+					},
+				},
+			}),
+		);
+	}
+
+	function writeDiscoverableOpenAIProvider(provider: string, baseUrl: string): void {
+		fs.writeFileSync(
+			modelsJsonPath,
+			JSON.stringify({
+				providers: {
+					[provider]: {
+						baseUrl,
+						apiKey: "TEST_KEY",
+						api: "openai-completions",
+						discovery: { type: "openai-models-list" },
+					},
+				},
+			}),
+		);
+	}
+
+	test("preserves explicit plain Xiaomi /v1 custom Anthropic models", () => {
+		writeXiaomiModel("https://api.xiaomimimo.com/v1", "mimo-openai-root");
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const model = registry.find("xiaomi", "mimo-openai-root");
+
+		expect(model?.api).toBe("anthropic-messages");
+	});
+
+	test("preserves explicit nested Anthropic /v1 custom models", () => {
+		writeXiaomiModel("https://api.xiaomimimo.com/anthropic/v1", "mimo-anthropic-root");
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const model = registry.find("xiaomi", "mimo-anthropic-root");
+
+		expect(model?.api).toBe("anthropic-messages");
+	});
+
+	test("rewrites stale cached plain Xiaomi /v1 entries to OpenAI completions", () => {
+		writeModelCache(
+			"xiaomi",
+			Date.now(),
+			[xiaomiCachedModel("https://api.xiaomimimo.com/v1")],
+			true,
+			"",
+			path.join(tempDir, "models.db"),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const model = registry.find("xiaomi", "mimo-cached");
+
+		expect(model?.api).toBe("openai-completions");
+	});
+
+	test("applies hardcoded policies to cached standard provider models", () => {
+		writeModelCache(
+			"openai",
+			Date.now(),
+			[cachedGpt54Model("openai", "https://api.openai.com/v1", 200000)],
+			true,
+			"",
+			path.join(tempDir, "models.db"),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const model = registry.find("openai", "gpt-5.4");
+
+		expect(model?.contextWindow).toBe(1_000_000);
+	});
+
+	test("applies hardcoded policies to cached discoverable provider models", () => {
+		writeDiscoverableOpenAIProvider("custom-local", "https://models.example.com/v1");
+		writeModelCache(
+			"custom-local",
+			Date.now(),
+			[cachedGpt54Model("custom-local", "https://models.example.com/v1", 200000)],
+			true,
+			"",
+			path.join(tempDir, "models.db"),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const model = registry.find("custom-local", "gpt-5.4");
+
+		expect(model?.contextWindow).toBe(1_000_000);
+	});
+});
+
+function xiaomiCachedModel(baseUrl: string): Model<"anthropic-messages"> {
+	return {
+		id: "mimo-cached",
+		name: "MiMo cached",
+		api: "anthropic-messages",
+		provider: "xiaomi",
+		baseUrl,
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 100000,
+		maxTokens: 8000,
+	};
+}
+
+function cachedGpt54Model(provider: string, baseUrl: string, contextWindow: number): Model<"openai-completions"> {
+	return {
+		id: "gpt-5.4",
+		name: "GPT-5.4",
+		api: "openai-completions",
+		provider,
+		baseUrl,
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow,
+		maxTokens: 128000,
+	};
+}
+
+async function removeTempDir(dir: string): Promise<void> {
+	for (let attempt = 0; attempt < 5; attempt++) {
+		try {
+			if (fs.existsSync(dir)) {
+				fs.rmSync(dir, { recursive: true });
+			}
+			return;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "EBUSY" && attempt === 4) {
+				return;
+			}
+			if ((error as NodeJS.ErrnoException).code !== "EBUSY") {
+				throw error;
+			}
+			await Bun.sleep(25);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fix Xiaomi MiMo Token Plan `tp-` keys that are issued for the CN token-plan cluster. PR #1336 only tried SGP and AMS token-plan endpoints, so CN-scoped TP keys still received 401 responses.

## Changes

- Try Xiaomi Token Plan model discovery and login validation against CN, then SGP, then AMS.
- Preserve explicit custom `baseUrl` overrides for `tp-` keys while ignoring bundled standard Xiaomi base URLs that would route TP keys to the wrong host.
- Validate Xiaomi login requests with the official `api-key` header.
- Extend the issue #772 regression tests to cover CN first, fallback ordering, bundled standard base URL handling, explicit overrides, and standard `sk-` keys.

## Validation

- `bun --cwd=packages/ai run check`
- `bun --cwd=packages/ai test issue-772-repro.test.ts`
- Manual live smoke checks with provided test credentials:
  - TP key: `https://token-plan-cn.xiaomimimo.com/v1/chat/completions` returned 200
  - TP key: `https://token-plan-cn.xiaomimimo.com/anthropic/v1/messages` returned 200
  - SK key: `https://api.xiaomimimo.com/v1/chat/completions` returned 200
  - SK key: `https://api.xiaomimimo.com/anthropic/v1/messages` returned 200

## Notes

Full `bun --cwd=packages/ai test` was also run. The Xiaomi regression test passed, but the full suite had unrelated Windows `EBUSY` temp-directory cleanup failures in auth/storage/broker tests.