### PR TITLE
fix(providers): prune stale synthetic model cache entries

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Synthetic model discovery to treat the provider `/models` response as authoritative so deprecated bundled IDs are pruned from the runtime cache, and changed Synthetic login validation to avoid probing a specific model ([#1417](https://github.com/can1357/oh-my-pi/issues/1417)).
+
 ## [15.5.0] - 2026-05-26
 ### Added
 

--- a/packages/ai/src/model-manager.ts
+++ b/packages/ai/src/model-manager.ts
@@ -34,6 +34,8 @@ export interface ModelManagerOptions<TApi extends Api = Api, TModelsDevPayload =
 	cacheDbPath?: string;
 	/** Maximum cache age in milliseconds before considered stale. Default: 24h. */
 	cacheTtlMs?: number;
+	/** When true, a successful dynamic fetch is the complete provider catalog and prunes static-only models. */
+	dynamicModelsAuthoritative?: boolean;
 	/** Optional dynamic endpoint fetcher. */
 	fetchDynamicModels?: () => Promise<readonly Model<TApi>[] | null>;
 	/** Optional models.dev fallback hook. */
@@ -110,30 +112,27 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		options.staticModels ?? getBundledModels(options.providerId as GeneratedProvider),
 	);
 	const cache = readModelCache<TApi>(options.providerId, ttlMs, now, dbPath);
+	const dynamicModelsAuthoritative = options.dynamicModelsAuthoritative ?? false;
+	const staticFingerprint = fingerprintStatic(staticModels, dynamicModelsAuthoritative);
+	const cacheFingerprintMatches = cache?.staticFingerprint === staticFingerprint && staticFingerprint.length > 0;
+	const hasUsableFreshCache = (cache?.fresh ?? false) && (!dynamicModelsAuthoritative || cacheFingerprintMatches);
 	const dynamicFetcher = options.fetchDynamicModels;
 	const hasDynamicFetcher = typeof dynamicFetcher === "function";
-	const hasAuthoritativeCache = (cache?.authoritative ?? false) || !hasDynamicFetcher;
+	const hasAuthoritativeCache = ((cache?.authoritative ?? false) && hasUsableFreshCache) || !hasDynamicFetcher;
 	const cacheAgeMs = cache ? now() - cache.updatedAt : Number.POSITIVE_INFINITY;
 	const shouldFetchFromNetwork = shouldFetchRemoteSources(
 		strategy,
-		cache?.fresh ?? false,
+		hasUsableFreshCache,
 		hasAuthoritativeCache,
 		cacheAgeMs,
 	);
-	const staticFingerprint = fingerprintStatic(staticModels);
 
 	// Cold-start fast path: when a fresh, authoritative cache exists, the network
 	// fetch is skipped, AND the static catalog slice is byte-identical to what
 	// was merged in last time, the cache row IS the authoritative merge result.
 	// Re-running `mergeDynamicModels(static, cache)` would just rebuild the same
 	// objects (~800ms in the steady-state cold-start profile for `omp -p hi`).
-	if (
-		!shouldFetchFromNetwork &&
-		cache?.fresh &&
-		hasAuthoritativeCache &&
-		cache.staticFingerprint === staticFingerprint &&
-		cache.staticFingerprint.length > 0
-	) {
+	if (!shouldFetchFromNetwork && cache?.fresh && hasAuthoritativeCache && cacheFingerprintMatches) {
 		return { models: passModelList<TApi>(cache.models), stale: false };
 	}
 
@@ -142,16 +141,21 @@ export async function resolveProviderModels<TApi extends Api = Api, TModelsDevPa
 		: [null, null];
 	const modelsDevModels = normalizeModelList<TApi>(fetchedModelsDevModels ?? []);
 	const shouldUseFreshCacheAsAuthoritative =
-		strategy === "online-if-uncached" && (cache?.fresh ?? false) && hasAuthoritativeCache;
+		strategy === "online-if-uncached" && hasUsableFreshCache && hasAuthoritativeCache;
 	const dynamicFetchSucceeded = fetchedDynamicModels !== null;
 	const cacheModels = dynamicFetchSucceeded ? [] : normalizeModelList<TApi>(cache?.models ?? []);
 	const dynamicModels = fetchedDynamicModels ?? [];
 	const mergedWithCache = mergeDynamicModels(mergeModelSources(staticModels, modelsDevModels), cacheModels);
-	const models = mergeDynamicModels(mergedWithCache, dynamicModels);
+	const mergedModels = mergeDynamicModels(mergedWithCache, dynamicModels);
+	const models =
+		dynamicModelsAuthoritative && dynamicFetchSucceeded ? retainModelIds(mergedModels, dynamicModels) : mergedModels;
 	const dynamicAuthoritative = !hasDynamicFetcher || dynamicFetchSucceeded || shouldUseFreshCacheAsAuthoritative;
 	if (shouldFetchFromNetwork) {
 		if (dynamicFetchSucceeded) {
-			const snapshotModels = mergeDynamicModels(mergeModelSources(staticModels, modelsDevModels), dynamicModels);
+			const mergedSnapshot = mergeDynamicModels(mergeModelSources(staticModels, modelsDevModels), dynamicModels);
+			const snapshotModels = dynamicModelsAuthoritative
+				? retainModelIds(mergedSnapshot, dynamicModels)
+				: mergedSnapshot;
 			writeModelCache(options.providerId, now(), snapshotModels, true, staticFingerprint, dbPath);
 		} else {
 			// Dynamic fetch failed — update cache with a non-authoritative snapshot so
@@ -270,6 +274,15 @@ function mergeDynamicModels<TApi extends Api>(
 	return Array.from(merged.values());
 }
 
+function retainModelIds<TApi extends Api>(
+	models: readonly Model<TApi>[],
+	retainedModels: readonly Model<TApi>[],
+): Model<TApi>[] {
+	if (retainedModels.length === 0 || models.length === 0) return [];
+	const retainedIds = new Set(retainedModels.map(model => model.id));
+	return models.filter(model => retainedIds.has(model.id));
+}
+
 /**
  * Stable, low-collision fingerprint of a static catalog slice. Cached by
  * reference so repeat calls in the same process (e.g. multiple cold-start
@@ -278,8 +291,12 @@ function mergeDynamicModels<TApi extends Api>(
  */
 const kStaticFingerprint = Symbol("model-manager.staticFingerprint");
 type ModelArrayWithFingerprint = readonly Model<Api>[] & { [kStaticFingerprint]?: string };
-function fingerprintStatic<TApi extends Api>(models: readonly Model<TApi>[]): string {
+function fingerprintStatic<TApi extends Api>(
+	models: readonly Model<TApi>[],
+	dynamicModelsAuthoritative = false,
+): string {
 	if (models.length === 0) return "empty";
+	if (dynamicModelsAuthoritative) return `authoritative:${fingerprintStatic(models)}`;
 	const tagged = models as ModelArrayWithFingerprint;
 	const cached = tagged[kStaticFingerprint];
 	if (cached !== undefined) return cached;

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -66,6 +66,8 @@ export interface ProviderDescriptor {
 	defaultModel: string;
 	/** When true, the runtime creates a model manager even without a valid API key (e.g. ollama). */
 	allowUnauthenticated?: boolean;
+	/** When true, successful runtime discovery replaces bundled provider models instead of merging fallback-only IDs. */
+	dynamicModelsAuthoritative?: boolean;
 	/** Catalog discovery configuration. Only providers with this field participate in generate-models.ts. */
 	catalogDiscovery?: CatalogDiscoveryConfig;
 }
@@ -87,7 +89,7 @@ function descriptor(
 	providerId: KnownProvider,
 	defaultModel: string,
 	createModelManagerOptions: ProviderDescriptor["createModelManagerOptions"],
-	options: Pick<ProviderDescriptor, "allowUnauthenticated"> = {},
+	options: Pick<ProviderDescriptor, "allowUnauthenticated" | "dynamicModelsAuthoritative"> = {},
 ): ProviderDescriptor {
 	return {
 		providerId,
@@ -114,7 +116,7 @@ function catalogDescriptor(
 	defaultModel: string,
 	createModelManagerOptions: ProviderDescriptor["createModelManagerOptions"],
 	catalogDiscovery: CatalogDiscoveryConfig,
-	options: Pick<ProviderDescriptor, "allowUnauthenticated"> = {},
+	options: Pick<ProviderDescriptor, "allowUnauthenticated" | "dynamicModelsAuthoritative"> = {},
 ): ProviderDescriptor {
 	return {
 		...descriptor(providerId, defaultModel, createModelManagerOptions, options),
@@ -239,9 +241,10 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 	),
 	catalogDescriptor(
 		"synthetic",
-		"hf:moonshotai/Kimi-K2.5",
+		"hf:zai-org/GLM-5.1",
 		config => syntheticModelManagerOptions(config),
 		catalog("Synthetic", ["SYNTHETIC_API_KEY"]),
+		{ dynamicModelsAuthoritative: true },
 	),
 	catalogDescriptor(
 		"venice",

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -1290,6 +1290,7 @@ export function syntheticModelManagerOptions(
 	);
 	return {
 		providerId: "synthetic",
+		dynamicModelsAuthoritative: true,
 		...(apiKey && {
 			fetchDynamicModels: () =>
 				fetchOpenAICompatibleModels({

--- a/packages/ai/src/utils/oauth/synthetic.ts
+++ b/packages/ai/src/utils/oauth/synthetic.ts
@@ -8,9 +8,8 @@ export const loginSynthetic = createApiKeyLogin({
 	promptMessage: "Paste your Synthetic API key",
 	placeholder: "sk-...",
 	validation: {
-		kind: "chat-completions",
+		kind: "models-endpoint",
 		provider: "Synthetic",
-		baseUrl: "https://api.synthetic.new/openai/v1",
-		model: "hf:moonshotai/Kimi-K2.5",
+		modelsUrl: "https://api.synthetic.new/openai/v1/models",
 	},
 });

--- a/packages/ai/test/issue-1417-repro.test.ts
+++ b/packages/ai/test/issue-1417-repro.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { readModelCache } from "../src/model-cache";
+import { resolveProviderModels } from "../src/model-manager";
+import type { Model } from "../src/types";
+
+const TTL_MS = 24 * 60 * 60 * 1000;
+
+function syntheticModel(id: string): Model<"openai-completions"> {
+	return {
+		id,
+		name: id,
+		api: "openai-completions",
+		provider: "synthetic",
+		baseUrl: "https://api.synthetic.new/openai/v1",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 128_000,
+		maxTokens: 8_192,
+	};
+}
+
+describe("issue #1417 synthetic model deprecation", () => {
+	let tempDir = "";
+	let dbPath = "";
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-issue-1417-"));
+		dbPath = path.join(tempDir, "models.db");
+	});
+
+	afterEach(async () => {
+		if (tempDir) {
+			await fs.rm(tempDir, { recursive: true, force: true });
+			tempDir = "";
+			dbPath = "";
+		}
+	});
+
+	it("prunes static-only models when provider discovery is authoritative", async () => {
+		const deprecatedModel = syntheticModel("hf:moonshotai/Kimi-K2.5");
+		const supportedModel = syntheticModel("hf:zai-org/GLM-5.1");
+
+		const result = await resolveProviderModels(
+			{
+				providerId: "synthetic",
+				staticModels: [deprecatedModel],
+				dynamicModelsAuthoritative: true,
+				fetchDynamicModels: async () => [supportedModel],
+				cacheDbPath: dbPath,
+			},
+			"online",
+		);
+
+		expect(result.stale).toBe(false);
+		expect(result.models.map(model => model.id)).toEqual(["hf:zai-org/GLM-5.1"]);
+		expect(readModelCache("synthetic", TTL_MS, Date.now, dbPath)?.models.map(model => model.id)).toEqual([
+			"hf:zai-org/GLM-5.1",
+		]);
+	});
+});

--- a/packages/ai/test/synthetic-login.test.ts
+++ b/packages/ai/test/synthetic-login.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { loginSynthetic } from "../src/utils/oauth/synthetic";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+	global.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+describe("synthetic login", () => {
+	it("validates API keys against the models endpoint instead of a deprecated model", async () => {
+		const fetchMock = vi.fn(async (input: string | URL, init?: RequestInit) => {
+			expect(String(input)).toBe("https://api.synthetic.new/openai/v1/models");
+			expect(init?.method).toBe("GET");
+			expect(init?.headers).toEqual({ Authorization: "Bearer sk-synthetic-test" });
+			return new Response(JSON.stringify({ data: [{ id: "hf:zai-org/GLM-5.1" }] }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		});
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		const apiKey = await loginSynthetic({
+			onPrompt: async () => "sk-synthetic-test",
+		});
+
+		expect(apiKey).toBe("sk-synthetic-test");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed runtime model registry refresh and cache loading so providers with authoritative dynamic catalogs, including Synthetic, do not re-add deprecated bundled model IDs after discovery ([#1417](https://github.com/can1357/oh-my-pi/issues/1417)).
+
 ## [15.5.2] - 2026-05-26
 ### Breaking Changes
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -291,6 +291,12 @@ export function mergeDiscoveredModel<TApi extends Api>(
 	return model;
 }
 
+const AUTHORITATIVE_RUNTIME_CATALOG_PROVIDERS = new Set<string>(
+	PROVIDER_DESCRIPTORS.filter(descriptor => descriptor.dynamicModelsAuthoritative).map(
+		descriptor => descriptor.providerId,
+	),
+);
+
 function isAuthoritativeProjectCatalogModel(model: Model<Api>): boolean {
 	return (
 		model.provider === "google-vertex" &&
@@ -321,6 +327,11 @@ interface DiscoveryProviderConfig {
 	compat?: Model<Api>["compat"];
 	discovery: ProviderDiscovery;
 	optional?: boolean;
+}
+
+interface BuiltInDiscoveryResult {
+	models: Model<Api>[];
+	authoritativeProviders: Set<string>;
 }
 
 export type ProviderDiscoveryStatus = "idle" | "ok" | "empty" | "cached" | "unavailable" | "unauthenticated";
@@ -914,6 +925,11 @@ export class ModelRegistry {
 				cachedAuthoritativeProviders.add(provider);
 			}
 		}
+		for (const provider of cachedStandardResult.authoritativeFreshProviders) {
+			if (AUTHORITATIVE_RUNTIME_CATALOG_PROVIDERS.has(provider)) {
+				cachedAuthoritativeProviders.add(provider);
+			}
+		}
 		if (cachedAuthoritativeProviders.size > 0) {
 			builtInModels = dropProviderModels(builtInModels, cachedAuthoritativeProviders);
 		}
@@ -1253,12 +1269,12 @@ export class ModelRegistry {
 				: Promise.all(
 						selectedDiscoverableProviders.map(provider => this.#discoverProviderModels(provider, strategy)),
 					).then(results => results.flat());
-		const [configuredDiscovered, builtInDiscovered] = await Promise.all([
+		const [configuredDiscovered, builtInDiscovery] = await Promise.all([
 			configuredDiscoveriesPromise,
 			this.#discoverBuiltInProviderModels(strategy, providerFilter),
 		]);
-		const discovered = [...configuredDiscovered, ...builtInDiscovered];
-		if (discovered.length === 0) {
+		const discovered = [...configuredDiscovered, ...builtInDiscovery.models];
+		if (discovered.length === 0 && builtInDiscovery.authoritativeProviders.size === 0) {
 			return;
 		}
 		const discoveredModels = this.#applyHardcodedModelPolicies(
@@ -1271,6 +1287,9 @@ export class ModelRegistry {
 			),
 		);
 		const authoritativeProviders = providersWithAuthoritativeProjectCatalog(discoveredModels);
+		for (const provider of builtInDiscovery.authoritativeProviders) {
+			authoritativeProviders.add(provider);
+		}
 		const baseModels =
 			authoritativeProviders.size > 0 ? dropProviderModels(this.#models, authoritativeProviders) : this.#models;
 		const resolved = this.#mergeResolvedModels(baseModels, discoveredModels);
@@ -1385,7 +1404,7 @@ export class ModelRegistry {
 	async #discoverBuiltInProviderModels(
 		strategy: ModelRefreshStrategy,
 		providerFilter?: ReadonlySet<string>,
-	): Promise<Model<Api>[]> {
+	): Promise<BuiltInDiscoveryResult> {
 		// Skip providers already handled by configured discovery (e.g. user-configured ollama with discovery.type)
 		const configuredDiscoveryProviders = new Set(this.#discoverableProviders.map(p => p.provider));
 		const managerOptions = (await this.#collectBuiltInModelManagerOptions()).filter(opts => {
@@ -1395,12 +1414,20 @@ export class ModelRegistry {
 			return providerFilter ? providerFilter.has(opts.providerId) : true;
 		});
 		if (managerOptions.length === 0) {
-			return [];
+			return { models: [], authoritativeProviders: new Set() };
 		}
 		const discoveries = await Promise.all(
 			managerOptions.map(options => this.#discoverWithModelManager(options, strategy)),
 		);
-		return discoveries.flat();
+		const authoritativeProviders = new Set<string>();
+		const models: Model<Api>[] = [];
+		for (const discovery of discoveries) {
+			models.push(...discovery.models);
+			for (const provider of discovery.authoritativeProviders) {
+				authoritativeProviders.add(provider);
+			}
+		}
+		return { models, authoritativeProviders };
 	}
 
 	async #collectBuiltInModelManagerOptions(): Promise<ModelManagerOptions<Api>[]> {
@@ -1482,19 +1509,24 @@ export class ModelRegistry {
 	async #discoverWithModelManager(
 		options: ModelManagerOptions<Api>,
 		strategy: ModelRefreshStrategy,
-	): Promise<Model<Api>[]> {
+	): Promise<BuiltInDiscoveryResult> {
 		try {
 			const manager = createModelManager({ ...options, cacheDbPath: this.#cacheDbPath });
 			const result = await manager.refresh(strategy);
-			return result.models.map(model =>
+			const models = result.models.map(model =>
 				model.provider === options.providerId ? model : { ...model, provider: options.providerId },
 			);
+			const authoritativeProviders = new Set<string>();
+			if (options.dynamicModelsAuthoritative && !result.stale) {
+				authoritativeProviders.add(options.providerId);
+			}
+			return { models, authoritativeProviders };
 		} catch (error) {
 			logger.warn("model discovery failed for provider", {
 				provider: options.providerId,
 				error: error instanceof Error ? error.message : String(error),
 			});
-			return [];
+			return { models: [], authoritativeProviders: new Set() };
 		}
 	}
 

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -2257,6 +2257,40 @@ describe("ModelRegistry", () => {
 		expect(registry.find("google-vertex", "gemini-1.5-pro")).toBeUndefined();
 	});
 
+	test("does not re-add bundled synthetic models after authoritative cache load", () => {
+		const cachedModel: Model<"openai-completions"> = {
+			id: "hf:zai-org/GLM-5.1",
+			name: "GLM 5.1",
+			api: "openai-completions",
+			provider: "synthetic",
+			baseUrl: "https://api.synthetic.new/openai/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128_000,
+			maxTokens: 8_192,
+		};
+		writeModelCache("synthetic", Date.now(), [cachedModel], true, "authoritative:test", cacheDbPath);
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+		const syntheticModels = getModelsForProvider(registry, "synthetic");
+
+		expect(syntheticModels.map(model => model.id)).toEqual(["hf:zai-org/GLM-5.1"]);
+		expect(registry.find("synthetic", "hf:moonshotai/Kimi-K2.5")).toBeUndefined();
+	});
+
+	test("does not re-add bundled synthetic models after authoritative refresh", async () => {
+		authStorage.setRuntimeApiKey("synthetic", "synthetic-test-key");
+		using _hook = mockOpenAiCompatibleModels("https://api.synthetic.new/openai/v1/models", ["hf:zai-org/GLM-5.1"]);
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+
+		await registry.refresh("online");
+		const syntheticModels = getModelsForProvider(registry, "synthetic");
+
+		expect(syntheticModels.map(model => model.id)).toEqual(["hf:zai-org/GLM-5.1"]);
+		expect(registry.find("synthetic", "hf:moonshotai/Kimi-K2.5")).toBeUndefined();
+	});
+
 	test("keeps bundled google-vertex fallback when cached project catalog is non-authoritative", () => {
 		const cachedModel: Model<"openai-completions"> = {
 			id: "zai-org/glm-4.7-maas",


### PR DESCRIPTION
## Repro
Resolving Synthetic models with bundled `hf:moonshotai/Kimi-K2.5` and a successful authoritative discovery response containing only `hf:zai-org/GLM-5.1` reproduced the stale catalog: `bun --eval '<script imports resolveProviderModels, resolves synthetic with static hf:moonshotai/Kimi-K2.5 and dynamic hf:zai-org/GLM-5.1>'` returned both IDs and failed with `deprecated static model survived authoritative discovery`.

## Cause
`packages/ai/src/model-manager.ts` always merged static, cached, and dynamic provider catalogs additively, so a successful Synthetic `/models` fetch could update metadata but never remove deprecated bundled IDs. `packages/coding-agent/src/config/model-registry.ts` then merged authoritative cached provider rows back into the bundled catalog, reintroducing stale Synthetic entries during cache load and refresh. Synthetic login also validated keys through `packages/ai/src/utils/oauth/synthetic.ts` by sending a chat completion to the deprecated Kimi model.

## Fix
- Added an authoritative dynamic-catalog mode to `ModelManagerOptions` and enabled it for Synthetic so successful discovery prunes static-only IDs and rewrites cache snapshots without deprecated models.
- Taught the coding-agent model registry to drop bundled provider models when loading or refreshing an authoritative dynamic catalog.
- Switched Synthetic login validation to the `/models` endpoint and changed the Synthetic default model to `hf:zai-org/GLM-5.1`.
- Added regression coverage for Synthetic cache pruning, registry refresh/cache loading, and login validation.

## Verification
- `bun --cwd=packages/ai test test/model-cache.test.ts test/issue-1417-repro.test.ts test/synthetic-login.test.ts` passed.
- `bun --cwd=packages/coding-agent test test/model-registry.test.ts -t synthetic` passed.
- `bun --cwd=packages/ai run check` passed.
- `bun --cwd=packages/coding-agent run check` passed.
- Re-ran the repro script with `dynamicModelsAuthoritative: true`; it returned only `["hf:zai-org/GLM-5.1"]`. Fixes #1417