### PR TITLE
feat(anthropic): add useApiKeyHeader compat option for non-Anthropic endpoints

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1652,9 +1652,9 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 	}
 
 	return {
-		isOAuthToken: oauthToken,
-		apiKey: oauthToken ? null : apiKey,
-		authToken: oauthToken ? apiKey : undefined,
+		isOAuthToken: oauthToken && !compat.useApiKeyHeader,
+		apiKey: oauthToken && !compat.useApiKeyHeader ? null : apiKey,
+		authToken: oauthToken && !compat.useApiKeyHeader ? apiKey : undefined,
 		baseURL: baseUrl,
 		maxRetries: 5,
 		dangerouslyAllowBrowser: true,

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -173,6 +173,12 @@ export function buildAnthropicHeaders(options: AnthropicHeaderOptions): Record<s
 		};
 	}
 
+	// When useApiKeyHeader is set for non-Anthropic proxies, always send
+	// x-api-key regardless of OAuth status — the upstream endpoint expects it.
+	const preferApiKeyHeader =
+		options.useApiKeyHeader && !isAnthropicApiBaseUrl(options.baseUrl);
+	const apiKeyHeader = { "X-Api-Key": options.apiKey };
+
 	if (oauthToken) {
 		const incomingUserAgent = getHeaderCaseInsensitive(options.modelHeaders, "User-Agent");
 		const userAgent = isClaudeCodeClientUserAgent(incomingUserAgent)
@@ -182,21 +188,24 @@ export function buildAnthropicHeaders(options: AnthropicHeaderOptions): Record<s
 			...modelHeaders,
 			...claudeCodeHeaders,
 			Accept: acceptHeader,
-			Authorization: `Bearer ${options.apiKey}`,
 			...sharedHeaders,
 			"Anthropic-Beta": betaHeader,
 			"User-Agent": userAgent,
+			...(preferApiKeyHeader ? apiKeyHeader : { Authorization: `Bearer ${options.apiKey}` }),
 		};
-	} else if (!isAnthropicApiBaseUrl(options.baseUrl)) {
-		if (options.useApiKeyHeader) {
-			return {
-				...modelHeaders,
-				Accept: acceptHeader,
-				...sharedHeaders,
-				"Anthropic-Beta": betaHeader,
-				"X-Api-Key": options.apiKey,
-			};
-		}
+	}
+
+	if (preferApiKeyHeader) {
+		return {
+			...modelHeaders,
+			Accept: acceptHeader,
+			...sharedHeaders,
+			"Anthropic-Beta": betaHeader,
+			...apiKeyHeader,
+		};
+	}
+
+	if (!isAnthropicApiBaseUrl(options.baseUrl)) {
 		return {
 			...modelHeaders,
 			Accept: acceptHeader,
@@ -204,15 +213,15 @@ export function buildAnthropicHeaders(options: AnthropicHeaderOptions): Record<s
 			...sharedHeaders,
 			"Anthropic-Beta": betaHeader,
 		};
-	} else {
-		return {
-			...modelHeaders,
-			Accept: acceptHeader,
-			...sharedHeaders,
-			"Anthropic-Beta": betaHeader,
-			"X-Api-Key": options.apiKey,
-		};
 	}
+
+	return {
+		...modelHeaders,
+		Accept: acceptHeader,
+		...sharedHeaders,
+		"Anthropic-Beta": betaHeader,
+		...apiKeyHeader,
+	};
 }
 
 type AnthropicCacheControl = { type: "ephemeral"; ttl?: "1h" | "5m" };

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -83,6 +83,8 @@ export type AnthropicHeaderOptions = {
 	stream?: boolean;
 	modelHeaders?: Record<string, string>;
 	isCloudflareAiGateway?: boolean;
+	/** When true, use `x-api-key` header instead of `Authorization: Bearer` for non-Anthropic endpoints. */
+	useApiKeyHeader?: boolean;
 };
 
 export function normalizeAnthropicBaseUrl(baseUrl?: string): string | undefined {
@@ -186,6 +188,15 @@ export function buildAnthropicHeaders(options: AnthropicHeaderOptions): Record<s
 			"User-Agent": userAgent,
 		};
 	} else if (!isAnthropicApiBaseUrl(options.baseUrl)) {
+		if (options.useApiKeyHeader) {
+			return {
+				...modelHeaders,
+				Accept: acceptHeader,
+				...sharedHeaders,
+				"Anthropic-Beta": betaHeader,
+				"X-Api-Key": options.apiKey,
+			};
+		}
 		return {
 			...modelHeaders,
 			Accept: acceptHeader,
@@ -869,6 +880,7 @@ function getAnthropicCompat(
 		disableAdaptiveThinking: model.compat?.disableAdaptiveThinking ?? false,
 		supportsEagerToolInputStreaming: model.compat?.supportsEagerToolInputStreaming ?? true,
 		supportsLongCacheRetention: model.compat?.supportsLongCacheRetention ?? true,
+		useApiKeyHeader: model.compat?.useApiKeyHeader ?? false,
 	};
 }
 
@@ -1613,6 +1625,7 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		stream,
 		modelHeaders: mergeHeaders(model.headers, foundryCustomHeaders, headers, dynamicHeaders),
 		isCloudflareAiGateway: model.provider === "cloudflare-ai-gateway",
+		useApiKeyHeader: compat.useApiKeyHeader,
 	});
 
 	if (model.provider === "cloudflare-ai-gateway") {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -815,6 +815,8 @@ export interface AnthropicCompat {
 	supportsEagerToolInputStreaming?: boolean;
 	/** Whether long prompt-cache retention (`ttl: "1h"`) is supported. Default: true for canonical Anthropic API. */
 	supportsLongCacheRetention?: boolean;
+	/** When true, non-Anthropic endpoints use `x-api-key` header instead of `Authorization: Bearer`. Default: false. */
+	useApiKeyHeader?: boolean;
 }
 
 /**

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -43,6 +43,8 @@ export const OpenAICompatSchema = z.object({
 	extraBody: z.record(z.string(), z.unknown()).optional(),
 	supportsStrictMode: z.boolean().optional(),
 	toolStrictMode: z.enum(["all_strict", "none"]).optional(),
+	/** When true, anthropic-messages non-Anthropic endpoints use `x-api-key` header instead of `Authorization: Bearer`. */
+	useApiKeyHeader: z.boolean().optional(),
 });
 
 const EffortSchema = z.enum(["minimal", "low", "medium", "high", "xhigh"]);


### PR DESCRIPTION
## Problem

`buildAnthropicHeaders` currently uses `Authorization: Bearer` for all non-Anthropic base URLs. However, some Anthropic-compatible proxy endpoints require the standard `x-api-key` header instead. 

For example, OpenCode Go's `/v1/messages` endpoint accepts `x-api-key` but rejects `Authorization: Bearer`, making it impossible to use `anthropic-messages` models through OpenCode Go (e.g., `qwen3.7-max`).

## Solution

Add `compat.useApiKeyHeader` option (default `false`) that, when set to `true`, sends `X-Api-Key` instead of `Authorization: Bearer` for non-canonical Anthropic base URLs.

### Usage in models.yml

```yaml
providers:
  opencode-go:
    models:
      - id: qwen3.7-max
        api: anthropic-messages
        baseUrl: https://opencode.ai/zen/go
        compat:
          useApiKeyHeader: true
```

## Changes

- `packages/ai/src/types.ts`: add `useApiKeyHeader?: boolean` to `AnthropicCompat`
- `packages/ai/src/providers/anthropic.ts`: implement header selection logic in `buildAnthropicHeaders`, pass through from `getAnthropicCompat` → `buildAnthropicClientOptions`
- `packages/coding-agent/src/config/models-config-schema.ts`: add field to compat schema