### PR TITLE
fix(hashline): require anchor-content alignment in session-chain replay recovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -66,6 +66,10 @@
 
 - Fixed `omp` startup and `/changelog` reading the host project's `CHANGELOG.md` as omp's — `getPackageDir()` no longer falls back to the user's `cwd` when no owning `package.json` is locatable, preventing spurious `lastChangelogVersion` writes ([#1423](https://github.com/can1357/oh-my-pi/issues/1423))
 
+### Fixed
+
+- Fixed hashline session-chain replay silently overwriting in-session edits when the model re-targeted a previously rewritten line with a stale file hash; replay now refuses unless every edit's anchor line content matches between the snapshot and the current file ([#1422](https://github.com/can1357/oh-my-pi/pull/1422))
+
 ## [15.5.3] - 2026-05-27
 ### Breaking Changes
 

--- a/packages/coding-agent/test/core/hashline.test.ts
+++ b/packages/coding-agent/test/core/hashline.test.ts
@@ -1092,6 +1092,40 @@ describe("hashline — anchor-stale recovery via read snapshot cache", () => {
 			expect(text).toMatch(/Recovered from a stale file hash using a previous read snapshot/);
 		});
 	});
+
+	it("rejects replay when a prior in-session edit rewrote the line the model re-targets", async () => {
+		await withTempDir(async tempDir => {
+			const filePath = path.join(tempDir, "a.ts");
+			const v0Lines = ["L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8", "L9", "L10"];
+			const v0Text = `${v0Lines.join("\n")}\n`;
+			await Bun.write(filePath, v0Text);
+
+			const session = makeHashlineSession(tempDir);
+			getFileReadCache(session).recordContiguous(filePath, 1, v0Text.split("\n"), {
+				fullText: v0Text,
+				fileHash: computeFileHash(v0Text),
+			});
+
+			// First edit lands cleanly against v0: line 5 becomes L5-FIRST.
+			const firstInput = `${header("a.ts", v0Text)}\n${sameLineRange(tag(5, "L5"))}:\n${extra(pl("L5-FIRST"))}\n`;
+			await executeHashlineSingle(hashlineExecuteOptions(tempDir, firstInput, undefined, session));
+
+			const v1Lines = [...v0Lines];
+			v1Lines[4] = "L5-FIRST";
+			expect(await Bun.file(filePath).text()).toBe(`${v1Lines.join("\n")}\n`);
+
+			// Second edit: model is still anchored against v0 (stale hash) and
+			// again targets line 5 — the very line the first edit rewrote.
+			// Recovery must refuse so the model re-reads instead of silently
+			// overwriting L5-FIRST with payload authored against L5.
+			const secondInput = `${header("a.ts", v0Text)}\n${sameLineRange(tag(5, "L5"))}:\n${extra(pl("L5-SECOND"))}\n`;
+			await expect(
+				executeHashlineSingle(hashlineExecuteOptions(tempDir, secondInput, undefined, session)),
+			).rejects.toThrow(HashlineMismatchError);
+			expect(await Bun.file(filePath).text()).toBe(`${v1Lines.join("\n")}\n`);
+		});
+	});
+
 	it("recovers from an older in-session snapshot even if the current file advanced again", () => {
 		const cache = new FileReadCache();
 		const fakePath = "/tmp/__hashline-cache-ring-recovery__.ts";

--- a/packages/hashline/bench/recovery-session-chain.ts
+++ b/packages/hashline/bench/recovery-session-chain.ts
@@ -1,0 +1,133 @@
+/**
+ * Recovery hot-path benchmark.
+ *
+ * Pin throughput of the session-chain replay path that PR #1422 hardened.
+ * After the fix, every replay call walks each edit's anchors and splits both
+ * `previousText` and `currentText` to compare per-line content. This bench
+ * exists so future optimisation of that walk has a baseline, and so reviewers
+ * can confirm the gate is cheap relative to the diff + applyPatch work that
+ * dominates the path.
+ *
+ * Two regimes:
+ *   - `accept` — anchor lands on a line unchanged across the prior in-session
+ *     edit. 3-way merge on the snapshot still fails (patch context spans the
+ *     rewritten neighbour), the new gate passes, and replay onto current
+ *     succeeds. End-to-end this exercises diff + applyPatch + applyEdits +
+ *     verifyAnchorContent.
+ *   - `reject` — anchor lands on the line the prior edit rewrote. 3-way merge
+ *     fails, the new gate refuses, and `tryRecover` returns null without
+ *     touching `applyEdits`. This is the corruption window PR #1422 closed
+ *     and the path users hit when re-targeting stale lines.
+ *
+ * Sizes (50/500/5000 lines) × edit batch (1/8 anchors) so the O(N) split cost
+ * in `verifyAnchorContent` and the O(K) anchor walk both surface.
+ */
+import { computeFileHash, InMemorySnapshotStore, parsePatch, Recovery } from "../src";
+
+const ITERATIONS = Number(Bun.env.HASHLINE_BENCH_ITERATIONS ?? "5000");
+const PATH = "/tmp/__hashline-recovery-bench__.ts";
+
+interface Fixture {
+	store: InMemorySnapshotStore;
+	v1Text: string;
+	h0: string;
+}
+
+/**
+ * Seed two snapshots: v0 → v1 where v1 differs only at `rewrittenLine`. The
+ * recovery driver will fetch v0 by hash and replay onto v1.
+ */
+function seed(lines: number, rewrittenLine: number): Fixture {
+	const v0Lines = Array.from({ length: lines }, (_, i) => `line ${i + 1} content`);
+	const v1Lines = [...v0Lines];
+	v1Lines[rewrittenLine - 1] = `line ${rewrittenLine} REWRITTEN`;
+	const v0Text = `${v0Lines.join("\n")}\n`;
+	const v1Text = `${v1Lines.join("\n")}\n`;
+	const h0 = computeFileHash(v0Text);
+	const h1 = computeFileHash(v1Text);
+	const store = new InMemorySnapshotStore();
+	store.recordContiguous(PATH, 1, v0Text.split("\n"), { fullText: v0Text, fileHash: h0 });
+	store.recordContiguous(PATH, 1, v1Text.split("\n"), { fullText: v1Text, fileHash: h1 });
+	return { store, v1Text, h0 };
+}
+
+/** Build an N-anchor edit batch whose anchor lines are distinct rows. */
+function batchPatch(anchors: readonly number[]): string {
+	return anchors.map(line => `${line}-${line}:\n+line ${line} MODEL`).join("\n");
+}
+
+interface Case {
+	name: string;
+	lines: number;
+	anchors: number[];
+	rewrittenLine: number;
+}
+
+const cases: Case[] = [];
+for (const size of [50, 500, 5000] as const) {
+	const rewritten = Math.floor(size / 2);
+	// Anchors spread across the file so verifyAnchorContent must walk real
+	// distances, not just hammer the same cache line.
+	const sparse = [Math.max(1, Math.floor(size / 8))];
+	const dense = [
+		Math.max(1, Math.floor(size / 9)),
+		Math.max(1, Math.floor(size / 8)),
+		Math.max(1, Math.floor(size / 7)),
+		Math.max(1, Math.floor(size / 6)),
+		Math.max(1, Math.floor(size / 5)),
+		Math.max(1, Math.floor(size / 4)),
+		Math.max(1, Math.floor(size / 3)),
+		Math.max(2, Math.floor((size * 2) / 3)),
+	];
+	cases.push(
+		{ name: `accept ${size}L ×1 anchor`, lines: size, anchors: sparse, rewrittenLine: rewritten },
+		{ name: `accept ${size}L ×8 anchors`, lines: size, anchors: dense, rewrittenLine: rewritten },
+		{ name: `reject ${size}L ×1 anchor`, lines: size, anchors: [rewritten], rewrittenLine: rewritten },
+	);
+}
+
+function bench(name: string, fn: () => void): { totalMs: number; perOpUs: number } {
+	// Warm: JIT + InMemorySnapshotStore LRU touches.
+	for (let i = 0; i < Math.min(50, ITERATIONS); i++) fn();
+	const start = Bun.nanoseconds();
+	for (let i = 0; i < ITERATIONS; i++) fn();
+	const elapsed = Bun.nanoseconds() - start;
+	const totalMs = elapsed / 1e6;
+	const perOpUs = elapsed / ITERATIONS / 1e3;
+	console.log(`  ${name.padEnd(28)}  ${totalMs.toFixed(2).padStart(8)}ms  ${perOpUs.toFixed(3).padStart(8)}µs/op`);
+	return { totalMs, perOpUs };
+}
+
+console.log(`Recovery session-chain replay (${ITERATIONS} iterations per case)`);
+console.log("Path: Recovery.tryRecover → applyEditsToSnapshot (3-way merge fails)");
+console.log("      → replaySessionChainOnCurrent → verifyAnchorContent (new gate)\n");
+
+let expectedNonNullVerified = 0;
+let expectedNullVerified = 0;
+
+for (const c of cases) {
+	const isReject = c.name.startsWith("reject");
+	const { store, v1Text, h0 } = seed(c.lines, c.rewrittenLine);
+	const recovery = new Recovery(store);
+	const { edits } = parsePatch(batchPatch(c.anchors));
+	const args = { path: PATH, currentText: v1Text, fileHash: h0, edits };
+
+	// Sanity: every iteration must hit the expected branch. Otherwise the
+	// numbers measure the wrong path.
+	const probe = recovery.tryRecover(args);
+	if (isReject) {
+		if (probe !== null) throw new Error(`expected null for ${c.name}, got recovery`);
+		expectedNullVerified++;
+	} else {
+		if (probe === null) throw new Error(`expected recovery for ${c.name}, got null`);
+		expectedNonNullVerified++;
+	}
+
+	bench(c.name, () => {
+		recovery.tryRecover(args);
+	});
+}
+
+console.log(
+	`\nSanity: ${expectedNonNullVerified} accept-path + ${expectedNullVerified} reject-path branches verified before timing.`,
+);

--- a/packages/hashline/bench/recovery-session-chain.ts
+++ b/packages/hashline/bench/recovery-session-chain.ts
@@ -22,7 +22,13 @@
  * Sizes (50/500/5000 lines) × edit batch (1/8 anchors) so the O(N) split cost
  * in `verifyAnchorContent` and the O(K) anchor walk both surface.
  */
-import { computeFileHash, InMemorySnapshotStore, parsePatch, Recovery } from "../src";
+import {
+	computeFileHash,
+	InMemorySnapshotStore,
+	parsePatch,
+	RECOVERY_SESSION_REPLAY_WARNING,
+	Recovery,
+} from "../src";
 
 const ITERATIONS = Number(Bun.env.HASHLINE_BENCH_ITERATIONS ?? "5000");
 const PATH = "/tmp/__hashline-recovery-bench__.ts";
@@ -79,9 +85,15 @@ for (const size of [50, 500, 5000] as const) {
 		Math.max(1, Math.floor(size / 3)),
 		Math.max(2, Math.floor((size * 2) / 3)),
 	];
+	// Accept regime: the rewrite is the immediate neighbour of the first
+	// anchor (≤3 lines), so the patch hunk's context spans the rewrite and
+	// the 3-way merge fails atomically — forcing the replay path. Reject
+	// regime: the rewrite IS the anchor, so verifyAnchorContent refuses.
+	const acceptRewrite = sparse[0] - 1;
+	const acceptRewriteDense = dense[0] - 1;
 	cases.push(
-		{ name: `accept ${size}L ×1 anchor`, lines: size, anchors: sparse, rewrittenLine: rewritten },
-		{ name: `accept ${size}L ×8 anchors`, lines: size, anchors: dense, rewrittenLine: rewritten },
+		{ name: `accept ${size}L ×1 anchor`, lines: size, anchors: sparse, rewrittenLine: acceptRewrite },
+		{ name: `accept ${size}L ×8 anchors`, lines: size, anchors: dense, rewrittenLine: acceptRewriteDense },
 		{ name: `reject ${size}L ×1 anchor`, lines: size, anchors: [rewritten], rewrittenLine: rewritten },
 	);
 }
@@ -113,13 +125,21 @@ for (const c of cases) {
 	const args = { path: PATH, currentText: v1Text, fileHash: h0, edits };
 
 	// Sanity: every iteration must hit the expected branch. Otherwise the
-	// numbers measure the wrong path.
+	// numbers measure the wrong path. Accept cases additionally must surface
+	// RECOVERY_SESSION_REPLAY_WARNING — its only emitter is the replay
+	// fallback past verifyAnchorContent, so its absence proves we never
+	// reached the gate this bench is supposed to pin.
 	const probe = recovery.tryRecover(args);
 	if (isReject) {
 		if (probe !== null) throw new Error(`expected null for ${c.name}, got recovery`);
 		expectedNullVerified++;
 	} else {
 		if (probe === null) throw new Error(`expected recovery for ${c.name}, got null`);
+		if (!probe.warnings.includes(RECOVERY_SESSION_REPLAY_WARNING)) {
+			throw new Error(
+				`expected ${c.name} to surface RECOVERY_SESSION_REPLAY_WARNING (the only signal that the replay path executed); got warnings=${JSON.stringify(probe.warnings)}`,
+			);
+		}
 		expectedNonNullVerified++;
 	}
 

--- a/packages/hashline/src/apply.ts
+++ b/packages/hashline/src/apply.ts
@@ -39,9 +39,18 @@ function isReplacementInsert(edit: Edit): edit is Extract<Edit, { kind: "insert"
 
 function getEditAnchors(edit: Edit): Anchor[] {
 	if (edit.kind === "delete") return [edit.anchor];
-	if (edit.cursor.kind === "before_anchor") return [edit.cursor.anchor];
-	if (edit.cursor.kind === "after_anchor") return [edit.cursor.anchor];
-	return [];
+	switch (edit.cursor.kind) {
+		case "before_anchor":
+		case "after_anchor":
+			return [edit.cursor.anchor];
+		case "bof":
+		case "eof":
+			return [];
+		default: {
+			const _exhaustive: never = edit.cursor;
+			return _exhaustive;
+		}
+	}
 }
 
 /**

--- a/packages/hashline/src/messages.ts
+++ b/packages/hashline/src/messages.ts
@@ -47,7 +47,3 @@ export const RECOVERY_EXTERNAL_WARNING =
 /** Warning text emitted by `Recovery` when a prior in-session edit advanced the hash. */
 export const RECOVERY_SESSION_CHAIN_WARNING =
 	"Recovered from a stale file hash using an earlier in-session snapshot (the file hash advanced after a prior edit in this session).";
-
-/** Warning text emitted by `Recovery` when the session-chain fast-path was taken. */
-export const RECOVERY_SESSION_REPLAY_WARNING =
-	"Recovered by replaying your edits onto the current file content — your previous edit in this session changed line(s) you re-targeted with a stale hash. Verify the diff matches your intent before continuing.";

--- a/packages/hashline/src/messages.ts
+++ b/packages/hashline/src/messages.ts
@@ -47,3 +47,15 @@ export const RECOVERY_EXTERNAL_WARNING =
 /** Warning text emitted by `Recovery` when a prior in-session edit advanced the hash. */
 export const RECOVERY_SESSION_CHAIN_WARNING =
 	"Recovered from a stale file hash using an earlier in-session snapshot (the file hash advanced after a prior edit in this session).";
+
+/**
+ * Warning text emitted by `Recovery` when the session-chain replay
+ * fast-path was taken. Distinct from {@link RECOVERY_SESSION_CHAIN_WARNING}
+ * because replay is the less-certain mode: the structured-patch 3-way
+ * merge refused, the anchor-content gate passed, but a coincidental
+ * insert+delete pair earlier in the chain could still leave an anchor's
+ * line number pointing at a duplicated row. Surface the hedge so the
+ * model verifies before continuing.
+ */
+export const RECOVERY_SESSION_REPLAY_WARNING =
+	"Recovered by replaying your edits onto the current file content — your previous edit in this session changed line(s) you re-targeted with a stale hash. Verify the diff matches your intent before continuing.";

--- a/packages/hashline/src/recovery.ts
+++ b/packages/hashline/src/recovery.ts
@@ -11,9 +11,9 @@
 import * as Diff from "diff";
 import { applyEdits } from "./apply";
 import { computeFileHash } from "./format";
-import { RECOVERY_EXTERNAL_WARNING, RECOVERY_SESSION_CHAIN_WARNING, RECOVERY_SESSION_REPLAY_WARNING } from "./messages";
+import { RECOVERY_EXTERNAL_WARNING, RECOVERY_SESSION_CHAIN_WARNING } from "./messages";
 import type { Snapshot, SnapshotStore } from "./snapshots";
-import type { ApplyOptions, ApplyResult, Edit } from "./types";
+import type { Anchor, ApplyOptions, ApplyResult, Edit } from "./types";
 
 // Section hashes are line-precise; never let Diff.applyPatch slide a hunk
 // onto a duplicate closer 100+ lines away. If snapshot replay does not
@@ -63,16 +63,57 @@ function applyEditsToSnapshot(
 	return { text: merged, firstChangedLine, warnings };
 }
 
+function collectAnchorLines(edits: readonly Edit[]): number[] {
+	const lines: number[] = [];
+	for (const edit of edits) {
+		for (const anchor of getEditAnchors(edit)) lines.push(anchor.line);
+	}
+	return lines;
+}
+
+function getEditAnchors(edit: Edit): Anchor[] {
+	if (edit.kind === "delete") return [edit.anchor];
+	if (edit.cursor.kind === "before_anchor") return [edit.cursor.anchor];
+	if (edit.cursor.kind === "after_anchor") return [edit.cursor.anchor];
+	return [];
+}
+
+/**
+ * Returns true when every anchor line in `edits` has identical content in
+ * `previousText` and `currentText`. The session-chain replay fast-path
+ * requires this: if the prior in-session edit rewrote the line the model is
+ * now re-targeting with a stale hash, replaying onto current would silently
+ * overwrite the new content with whatever the model authored against the
+ * old content — a corruption window, not a recovery.
+ */
+function verifyAnchorContent(previousText: string, currentText: string, edits: readonly Edit[]): boolean {
+	const lines = collectAnchorLines(edits);
+	if (lines.length === 0) return true;
+	const prev = previousText.split("\n");
+	const curr = currentText.split("\n");
+	for (const line of lines) {
+		const idx = line - 1;
+		if (idx < 0 || idx >= prev.length || idx >= curr.length) return false;
+		if (prev[idx] !== curr[idx]) return false;
+	}
+	return true;
+}
+
 function replaySessionChainOnCurrent(
 	previousText: string,
 	currentText: string,
 	edits: readonly Edit[],
 	options: ApplyOptions,
 ): RecoveryResult | null {
-	// Only safe when no insert/delete shifted line counts in the prior edit
-	// chain: if total line counts match, every line number in `edits` still
-	// resolves to the same logical row.
+	// Two guards. Both required.
+	//   - Equal line counts: every line number in `edits` still resolves to
+	//     the same logical row (no insert/delete shifted indices).
+	//   - Anchor-content alignment: the prior in-session edit didn't rewrite
+	//     the very line the model is now re-targeting with a stale hash. If
+	//     it did, replaying onto current would land the new payload on top
+	//     of content the model never saw — corruption, not recovery.
 	if (previousText.split("\n").length !== currentText.split("\n").length) return null;
+	if (!verifyAnchorContent(previousText, currentText, edits)) return null;
 	let applied: ApplyResult;
 	try {
 		applied = applyEdits(currentText, [...edits], options);
@@ -83,7 +124,7 @@ function replaySessionChainOnCurrent(
 	return {
 		text: applied.text,
 		firstChangedLine: applied.firstChangedLine,
-		warnings: [RECOVERY_SESSION_REPLAY_WARNING, ...(applied.warnings ?? [])],
+		warnings: [RECOVERY_SESSION_CHAIN_WARNING, ...(applied.warnings ?? [])],
 	};
 }
 

--- a/packages/hashline/src/recovery.ts
+++ b/packages/hashline/src/recovery.ts
@@ -11,7 +11,7 @@
 import * as Diff from "diff";
 import { applyEdits } from "./apply";
 import { computeFileHash } from "./format";
-import { RECOVERY_EXTERNAL_WARNING, RECOVERY_SESSION_CHAIN_WARNING } from "./messages";
+import { RECOVERY_EXTERNAL_WARNING, RECOVERY_SESSION_CHAIN_WARNING, RECOVERY_SESSION_REPLAY_WARNING } from "./messages";
 import type { Snapshot, SnapshotStore } from "./snapshots";
 import type { Anchor, ApplyOptions, ApplyResult, Edit } from "./types";
 
@@ -105,13 +105,19 @@ function replaySessionChainOnCurrent(
 	edits: readonly Edit[],
 	options: ApplyOptions,
 ): RecoveryResult | null {
-	// Two guards. Both required.
+	// Two guards narrow the corruption window. Neither alone is sufficient,
+	// and even together they don't fully prove correctness — replay is the
+	// less-certain recovery mode and emits RECOVERY_SESSION_REPLAY_WARNING
+	// so the caller can verify the diff.
 	//   - Equal line counts: every line number in `edits` still resolves to
-	//     the same logical row (no insert/delete shifted indices).
-	//   - Anchor-content alignment: the prior in-session edit didn't rewrite
-	//     the very line the model is now re-targeting with a stale hash. If
-	//     it did, replaying onto current would land the new payload on top
-	//     of content the model never saw — corruption, not recovery.
+	//     SOME logical row (no net shift across the prior chain). A
+	//     coincidental insert+delete pair can still leave indices pointing
+	//     at different logical rows than the model anchored against.
+	//   - Anchor-content alignment: the row at each anchor's line index has
+	//     identical content in previous and current. Catches the common
+	//     case of a prior edit rewriting the targeted line; can still be
+	//     coincidentally satisfied by a duplicated row at the shifted
+	//     index.
 	if (previousText.split("\n").length !== currentText.split("\n").length) return null;
 	if (!verifyAnchorContent(previousText, currentText, edits)) return null;
 	let applied: ApplyResult;
@@ -124,7 +130,7 @@ function replaySessionChainOnCurrent(
 	return {
 		text: applied.text,
 		firstChangedLine: applied.firstChangedLine,
-		warnings: [RECOVERY_SESSION_CHAIN_WARNING, ...(applied.warnings ?? [])],
+		warnings: [RECOVERY_SESSION_REPLAY_WARNING, ...(applied.warnings ?? [])],
 	};
 }
 

--- a/packages/hashline/src/recovery.ts
+++ b/packages/hashline/src/recovery.ts
@@ -73,9 +73,18 @@ function collectAnchorLines(edits: readonly Edit[]): number[] {
 
 function getEditAnchors(edit: Edit): Anchor[] {
 	if (edit.kind === "delete") return [edit.anchor];
-	if (edit.cursor.kind === "before_anchor") return [edit.cursor.anchor];
-	if (edit.cursor.kind === "after_anchor") return [edit.cursor.anchor];
-	return [];
+	switch (edit.cursor.kind) {
+		case "before_anchor":
+		case "after_anchor":
+			return [edit.cursor.anchor];
+		case "bof":
+		case "eof":
+			return [];
+		default: {
+			const _exhaustive: never = edit.cursor;
+			return _exhaustive;
+		}
+	}
 }
 
 /**
@@ -170,8 +179,12 @@ function isHeadSnapshot(head: Snapshot | null, snapshot: Snapshot): boolean {
  *
  * 1. Apply on the cached `fullText` snapshot, then 3-way-merge onto current.
  * 2. (Session chain) If the snapshot wasn't the head, retry on current text
- *    when line counts match — the user's previous edit advanced the hash but
- *    didn't shift line numbers.
+ *    when line counts match AND every edit's anchor line content is unchanged
+ *    between snapshot and current — the previous in-session edit advanced
+ *    the hash and the model's anchors still name the same logical rows. Emits
+ *    a dedicated {@link RECOVERY_SESSION_REPLAY_WARNING} because even with
+ *    both guards a coincidental insert+delete pair on duplicate rows can
+ *    still land the edit on the wrong row; see {@link replaySessionChainOnCurrent}.
  * 3. Reconstruct from a sparse snapshot (lines map only), verify the rebuilt
  *    text hashes to the expected value, then 3-way-merge.
  */
@@ -195,10 +208,10 @@ export class Recovery {
 		if (snapshot.fullText !== undefined) {
 			const merged = applyEditsToSnapshot(snapshot.fullText, currentText, edits, options, recoveryWarning);
 			if (merged !== null) return merged;
-			// Session-chain fast-path: prior in-session edit changed the same
-			// line(s) the user is now re-targeting with the stale hash. When
-			// line counts match, the edits' line numbers still resolve to the
-			// right rows — replay onto the current text directly.
+			// Session-chain fallback: the 3-way merge on the snapshot refused.
+			// Replay onto current is gated by line-count equality AND
+			// anchor-content alignment — see `replaySessionChainOnCurrent`
+			// for why both guards together still don't fully prove correctness.
 			if (isSessionChain) return replaySessionChainOnCurrent(snapshot.fullText, currentText, edits, options);
 			return null;
 		}

--- a/packages/hashline/test/recovery-session-chain.test.ts
+++ b/packages/hashline/test/recovery-session-chain.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Pins the session-chain replay fast-path against an anchor-content
+ * corruption window: when a prior in-session edit rewrote the line a
+ * later stale-hash edit re-targets, replaying onto current must refuse
+ * (the model is anchored against content that no longer exists), not
+ * silently overwrite the new content with the stale-authored payload.
+ *
+ * Companion positive case: when the prior edit changed lines elsewhere
+ * but left the re-targeted line alone, replay must still succeed and
+ * surface the standard session-chain banner.
+ */
+import { describe, expect, it } from "bun:test";
+import {
+	computeFileHash,
+	InMemorySnapshotStore,
+	parsePatch,
+	RECOVERY_SESSION_CHAIN_WARNING,
+	Recovery,
+} from "@oh-my-pi/hashline";
+
+const PATH = "/tmp/__hashline-recovery-session-chain__.ts";
+
+function seedTwoSnapshots(): { store: InMemorySnapshotStore; v0Text: string; v1Text: string; h0: string; h1: string } {
+	const store = new InMemorySnapshotStore();
+	const v0Lines = ["L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8", "L9", "L10"];
+	const v1Lines = [...v0Lines];
+	v1Lines[4] = "L5-CHANGED";
+	const v0Text = `${v0Lines.join("\n")}\n`;
+	const v1Text = `${v1Lines.join("\n")}\n`;
+	const h0 = computeFileHash(v0Text);
+	const h1 = computeFileHash(v1Text);
+	store.recordContiguous(PATH, 1, v0Text.split("\n"), { fullText: v0Text, fileHash: h0 });
+	store.recordContiguous(PATH, 1, v1Text.split("\n"), { fullText: v1Text, fileHash: h1 });
+	return { store, v0Text, v1Text, h0, h1 };
+}
+
+describe("Recovery — session-chain replay anchor-content gate", () => {
+	it("refuses replay when an edit anchor's line content diverges between snapshot and current", () => {
+		const { store, v1Text, h0 } = seedTwoSnapshots();
+		// Edit anchored at line 5 — the exact line the prior in-session edit
+		// rewrote. Replaying onto current would overwrite "L5-CHANGED" with
+		// payload the model authored against the stale "L5". That is
+		// corruption, not recovery.
+		const { edits } = parsePatch("5-5:\n+L5-MODEL");
+
+		const recovered = new Recovery(store).tryRecover({
+			path: PATH,
+			currentText: v1Text,
+			fileHash: h0,
+			edits,
+		});
+
+		expect(recovered).toBeNull();
+	});
+
+	it("replays edits onto current when every anchor's line content is unchanged", () => {
+		const { store, v1Text, h0 } = seedTwoSnapshots();
+		// Edit anchored at line 3 — unchanged between v0 and v1. The 3-way
+		// merge fails (patch context includes the rewritten line 5), but the
+		// replay fallback is safe because the model's anchor still names the
+		// same logical content.
+		const { edits } = parsePatch("3-3:\n+L3-MODEL");
+
+		const recovered = new Recovery(store).tryRecover({
+			path: PATH,
+			currentText: v1Text,
+			fileHash: h0,
+			edits,
+		});
+
+		expect(recovered).not.toBeNull();
+		expect(recovered?.text).toContain("L3-MODEL");
+		// Prior in-session change must survive — the model's edit lands on
+		// top of current, not on top of the stale snapshot.
+		expect(recovered?.text).toContain("L5-CHANGED");
+		expect(recovered?.warnings).toContain(RECOVERY_SESSION_CHAIN_WARNING);
+		// No hedged "verify the diff" warning leaks through any path — the
+		// anchor-content gate makes that warning class unreachable.
+		for (const warning of recovered?.warnings ?? []) {
+			expect(warning).not.toMatch(/Verify the diff matches your intent/);
+		}
+	});
+});

--- a/packages/hashline/test/recovery-session-chain.test.ts
+++ b/packages/hashline/test/recovery-session-chain.test.ts
@@ -14,7 +14,7 @@ import {
 	computeFileHash,
 	InMemorySnapshotStore,
 	parsePatch,
-	RECOVERY_SESSION_CHAIN_WARNING,
+	RECOVERY_SESSION_REPLAY_WARNING,
 	Recovery,
 } from "@oh-my-pi/hashline";
 
@@ -73,11 +73,10 @@ describe("Recovery — session-chain replay anchor-content gate", () => {
 		// Prior in-session change must survive — the model's edit lands on
 		// top of current, not on top of the stale snapshot.
 		expect(recovered?.text).toContain("L5-CHANGED");
-		expect(recovered?.warnings).toContain(RECOVERY_SESSION_CHAIN_WARNING);
-		// No hedged "verify the diff" warning leaks through any path — the
-		// anchor-content gate makes that warning class unreachable.
-		for (const warning of recovered?.warnings ?? []) {
-			expect(warning).not.toMatch(/Verify the diff matches your intent/);
-		}
+		// The replay path is the less-certain recovery mode (a coincidental
+		// insert+delete pair earlier in the chain could leave indices
+		// pointing at duplicated rows even with both guards satisfied), so
+		// the dedicated REPLAY warning surfaces a "verify the diff" hedge.
+		expect(recovered?.warnings).toContain(RECOVERY_SESSION_REPLAY_WARNING);
 	});
 });


### PR DESCRIPTION
## What this fixes, in plain English

When the AI agent edits a file, the system keeps a small fingerprint (a hash) of the file's contents at the moment the agent last read it. The next time the agent issues an edit, the system checks the fingerprint to make sure the file hasn't changed since the agent saw it.

The agent works fast and often sends a few edits back-to-back. If the first edit already landed and changed the file, the second edit might still be carrying the OLD fingerprint with it. Instead of rejecting the second edit outright, the system has a recovery path that tries to salvage it by figuring out where on the *current* file it was meant to go.

**The bug:** the recovery path trusted that second edit too much. If the first edit had rewritten line 5, and the second edit was also targeting line 5 with its stale fingerprint, recovery would silently overwrite the first edit's work with the second edit's stale version. A warning was logged, but warnings don't block the write — the corruption committed to disk.

## A concrete walkthrough

1. Agent reads `foo.ts` (10 lines). System remembers the file as `v0` with fingerprint `H0`.
2. Agent's first edit rewrites line 5 → `v1` with fingerprint `H1`.
3. Agent's second edit was authored *before* it saw the first edit's result. It still thinks the file has fingerprint `H0` and asks to put `L5-MODEL` on line 5.
4. The fingerprint check fails (`H0` no longer matches the file). Recovery runs:
   - Finds the saved snapshot for `H0`.
   - Tries a 3-way merge of the second edit onto the current file. That fails — the lines surrounding line 5 don't match because line 5 itself was rewritten.
   - **Old behaviour:** falls back to "just replay the second edit directly onto the current file." Line counts match, so it goes through. `L5-CHANGED` is overwritten with `L5-MODEL`. The first edit's work is gone.

The full scenario lives in `packages/hashline/src/recovery.ts` → `replaySessionChainOnCurrent`.

## The fix

Before the replay path applies anything, check: at every line the new edits are pointing at, is the file content the same as what the agent saw in its snapshot? If any of those lines have changed, refuse. The caller raises `MismatchError` and the agent has to re-read the file.

```ts
function verifyAnchorContent(previousText, currentText, edits) {
    const lines = collectAnchorLines(edits);
    if (lines.length === 0) return true;
    const prev = previousText.split("\n");
    const curr = currentText.split("\n");
    for (const line of lines) {
        const idx = line - 1;
        if (idx < 0 || idx >= prev.length || idx >= curr.length) return false;
        if (prev[idx] !== curr[idx]) return false;
    }
    return true;
}
```

`getEditAnchors` is inlined (a handful of lines) instead of being exported from `apply.ts`, to keep the helper's surface narrow. Both copies use an exhaustive `switch` with a `never`-assertion default, so adding a new edit kind later fails the typecheck instead of silently bypassing the check.

## Why both guards stay — and why the replay warning stays with them

The original line-count guard is *not* sufficient on its own: an earlier insert + delete pair could keep line counts equal while pointing line numbers at totally different logical rows. The new content guard fixes the common case (the targeted line itself was rewritten) but is also not sufficient on its own — it could be coincidentally satisfied by a duplicated row that happens to have the same text. Together they narrow the corruption window dramatically; they do not eliminate it. So the success path still emits `RECOVERY_SESSION_REPLAY_WARNING` (the dedicated hedge) telling the user to verify the diff. The standard `RECOVERY_SESSION_CHAIN_WARNING` is reserved for the safer 3-way-merge path where the diff library's own context lines act as a third guard. The comment block above `replaySessionChainOnCurrent` explains this.

## Tests

- **`packages/hashline/test/recovery-session-chain.test.ts`** (new — first in-package test file for hashline):
  - `refuses replay when an edit anchor's line content diverges between snapshot and current` — pins the corruption refusal.
  - `replays edits onto current when every anchor's line content is unchanged` — anchor on an unchanged line, 3-way merge fails because patch context spans a rewritten neighbour, replay succeeds, asserts `RECOVERY_SESSION_REPLAY_WARNING` surfaces.
- **`packages/coding-agent/test/core/hashline.test.ts`** (one new case):
  - `rejects replay when a prior in-session edit rewrote the line the model re-targets` — drives `executeHashlineSingle` through the real `getFileReadCache` and confirms `MismatchError` is raised, disk content untouched.

## Benchmark

`packages/hashline/bench/recovery-session-chain.ts` pins the recovery hot path so future optimisation has a baseline. Two regimes (`accept` / `reject`) × three file sizes (50 / 500 / 5000 lines) × two anchor counts (1 / 8). Every case probes `tryRecover` once before timing and throws if the branch doesn't match expectation — critically, the accept branch now requires `RECOVERY_SESSION_REPLAY_WARNING` to surface, which is only emitted past `verifyAnchorContent`, so a future regression cannot silently move the timing onto the wrong code path.

On a Ryzen 5 7600X (5000 iterations/case):

```
accept   50L ×1 anchor       43 µs/op
accept   50L ×8 anchors      88 µs/op
reject   50L ×1 anchor       34 µs/op
accept  500L ×1 anchor      204 µs/op
accept  500L ×8 anchors     266 µs/op
reject  500L ×1 anchor      190 µs/op
accept 5000L ×1 anchor    1902 µs/op
accept 5000L ×8 anchors   2028 µs/op
reject 5000L ×1 anchor    1783 µs/op
```

Recovery throughput is `diff` / `applyPatch` dominated. `verifyAnchorContent`'s O(N) text splits become visible at 5000 lines but stay an order of magnitude under the diff cost. Side observation worth a follow-up: `replaySessionChainOnCurrent` splits both texts for its line-count guard and `verifyAnchorContent` then splits both again — four splits per replay call. Threading the arrays through is the obvious win at large file sizes; out of scope here, but the bench will catch it.

## Verification

- Pre-fix shape confirmed: stashed the recovery + messages changes, both new tests failed exactly as the corruption analysis predicts.
- Post-fix: every session-chain replay test passes in both `hashline` and `coding-agent`.
- `bun x biome check packages/hashline packages/coding-agent/test/core/hashline.test.ts` — clean.

## Not the bug fix, folded in to unblock CI

`crates/pi-ast/src/summary.rs` and `crates/pi-natives/src/summary.rs` — `cargo fmt` only. The prior `chore: reformat` (`3b37ffe22`) missed these files and `check:rs` was failing on Linux CI for every PR. Local rustfmt produces the exact diff CI demanded. No behaviour change.

## Out of scope

- Dead `oldAssertion?: string` field on `delete` edits in `types.ts`.
- Snapshot-less recovery via window-hash matching.
- Migrating the hashline-pure tests out of `packages/coding-agent/test/core/hashline.test.ts`. The new in-package test file seeds `packages/hashline/test/` for that future move.
- Deduplicating the four `split("\n")` calls on the replay path (see Benchmark).