### PR TITLE
fix(search): wrap native regex-build errors in ToolError

### DIFF
--- a/packages/coding-agent/src/tools/search.ts
+++ b/packages/coding-agent/src/tools/search.ts
@@ -478,8 +478,8 @@ export class SearchTool implements AgentTool<typeof searchSchema, SearchToolDeta
 						);
 					}
 				} catch (err) {
-					if (err instanceof Error && err.message.startsWith("regex parse error")) {
-						throw new ToolError(err.message);
+					if (err instanceof Error && /^regex(?: parse)? error/i.test(err.message)) {
+						throw new ToolError(err.message.replace(/^regex(?: parse)? error:?\s*/i, "Invalid regex: "));
 					}
 					throw err;
 				}

--- a/packages/coding-agent/test/tools/search-invalid-regex.test.ts
+++ b/packages/coding-agent/test/tools/search-invalid-regex.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { SearchTool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { ToolError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
+
+function createTestSession(cwd: string, overrides: Partial<ToolSession> = {}): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated(),
+		...overrides,
+	};
+}
+
+describe("search tool invalid regex handling", () => {
+	let cwd: string;
+
+	beforeEach(async () => {
+		cwd = await fs.mkdtemp(path.join(os.tmpdir(), "pi-search-invalid-regex-"));
+		await Bun.write(path.join(cwd, "sample.txt"), "hello world\n");
+	});
+
+	afterEach(async () => {
+		await fs.rm(cwd, { recursive: true, force: true });
+	});
+
+	it("wraps invalid regex pattern errors in a ToolError", async () => {
+		const tool = new SearchTool(createTestSession(cwd));
+
+		let caught: unknown;
+		try {
+			await tool.execute("search-invalid-regex", {
+				pattern: "a[",
+				paths: [cwd],
+			});
+		} catch (err) {
+			caught = err;
+		}
+
+		expect(caught).toBeInstanceOf(ToolError);
+		expect((caught as Error).message).toMatch(/regex/i);
+	});
+});


### PR DESCRIPTION
## Problem

The `SearchTool.execute` catch block at `packages/coding-agent/src/tools/search.ts:480-485` tries to wrap native regex-build failures in a clean `ToolError`, but the prefix it checks for is wrong:

```ts
} catch (err) {
    if (err instanceof Error && err.message.startsWith("regex parse error")) {  // lowercase
        throw new ToolError(err.message);
    }
    throw err;
}
```

The native crate emits `"Regex error: "` (capital R, no "parse") — see `crates/pi-natives/src/grep.rs:1158,1161`:

```rust
Err(Error::from_reason(format!("Regex error: {message}")))
```

So the branch is dead. Invalid regex patterns from the agent (`"a["`, `"*"`, etc.) leak through as raw `Error` with a stack trace instead of being wrapped in a structured `ToolError` for the agent to feed back on.

## Fix

Match the actual native prefix case-insensitively, and rewrite it to `"Invalid regex: "` so the failure mode is obvious to the model:

```ts
} catch (err) {
    if (err instanceof Error && /^regex(?: parse)? error/i.test(err.message)) {
        throw new ToolError(err.message.replace(/^regex(?: parse)? error:?\s*/i, "Invalid regex: "));
    }
    throw err;
}
```

## Test

`packages/coding-agent/test/tools/search-invalid-regex.test.ts` constructs `SearchTool` directly (bypassing `wrapToolWithMetaNotice` which re-throws as plain `Error`) and asserts pattern `"a["` rejects with `instanceof ToolError` whose message matches `/regex/i`.

Before the fix: raw `Error` escapes the catch — `expect(err).toBeInstanceOf(ToolError)` fails.
After the fix: `bun test test/tools/search-invalid-regex.test.ts` → **1 pass, 2 expect()**.

## Scope

- `packages/coding-agent/src/tools/search.ts` — 2 line change inside the existing catch block
- `packages/coding-agent/test/tools/search-invalid-regex.test.ts` — new test (49 lines)
- No other files touched, no API change, no dependency change
