### PR TITLE
fix(fetch): cap the read-URL cache at an LRU bound

### DIFF
--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -1174,7 +1174,44 @@ interface ReadUrlCacheEntry {
 	output: string;
 }
 
+/**
+ * Cap the URL response cache at this many distinct entries. Each entry inserts
+ * up to two keys (requestedUrl + finalUrl), so the underlying Map can hold up
+ * to `READ_URL_CACHE_CAP * 2` keys before eviction. Entries can carry inline
+ * base64 image payloads up to ~300KB, so an unbounded cache is a real leak in
+ * long-lived sessions.
+ */
+export const READ_URL_CACHE_CAP = 32;
 const readUrlCache = new Map<string, ReadUrlCacheEntry>();
+
+/**
+ * LRU read: re-inserts the key so Map iteration order treats it as the most
+ * recently used. Returns undefined when the key is absent.
+ */
+function touchReadUrlCacheKey(key: string): ReadUrlCacheEntry | undefined {
+	const existing = readUrlCache.get(key);
+	if (existing === undefined) return undefined;
+	readUrlCache.delete(key);
+	readUrlCache.set(key, existing);
+	return existing;
+}
+
+/**
+ * LRU write: re-inserts the key at the back of the iteration order, then drops
+ * oldest keys until the cache is within the cap. The cap is applied to keys
+ * (not logical entries) for cheap deterministic bookkeeping; the worst case is
+ * that an entry's two keys age out one at a time.
+ */
+function insertReadUrlCacheKey(key: string, entry: ReadUrlCacheEntry): void {
+	if (readUrlCache.has(key)) readUrlCache.delete(key);
+	readUrlCache.set(key, entry);
+	const maxKeys = READ_URL_CACHE_CAP * 2;
+	while (readUrlCache.size > maxKeys) {
+		const oldestKey = readUrlCache.keys().next().value;
+		if (oldestKey === undefined) break;
+		readUrlCache.delete(oldestKey);
+	}
+}
 
 function getReadUrlCacheKey(session: ToolSession, requestedUrl: string, raw: boolean): string {
 	const scope = session.getSessionFile() ?? session.cwd;
@@ -1223,8 +1260,31 @@ async function ensureReadUrlCacheArtifact(session: ToolSession, entry: ReadUrlCa
 }
 
 function cacheReadUrlEntry(session: ToolSession, requestedUrl: string, raw: boolean, entry: ReadUrlCacheEntry): void {
-	readUrlCache.set(getReadUrlCacheKey(session, requestedUrl, raw), entry);
-	readUrlCache.set(getReadUrlCacheKey(session, entry.details.finalUrl, raw), entry);
+	insertReadUrlCacheKey(getReadUrlCacheKey(session, requestedUrl, raw), entry);
+	insertReadUrlCacheKey(getReadUrlCacheKey(session, entry.details.finalUrl, raw), entry);
+}
+
+/** Test-only helpers; kept inline to avoid an extra import path. */
+export function __getReadUrlCacheSize(): number {
+	return readUrlCache.size;
+}
+export function __resetReadUrlCache(): void {
+	readUrlCache.clear();
+}
+export function __primeReadUrlCacheForTest(
+	session: ToolSession,
+	requestedUrl: string,
+	raw: boolean,
+	entry: ReadUrlCacheEntry,
+): void {
+	cacheReadUrlEntry(session, requestedUrl, raw, entry);
+}
+export function __lookupReadUrlCache(
+	session: ToolSession,
+	url: string,
+	raw: boolean,
+): ReadUrlCacheEntry | undefined {
+	return touchReadUrlCacheKey(getReadUrlCacheKey(session, url, raw));
 }
 
 async function buildReadUrlCacheEntry(
@@ -1269,7 +1329,7 @@ export async function loadReadUrlCacheEntry(
 	options?: { ensureArtifact?: boolean; preferCached?: boolean },
 ): Promise<ReadUrlCacheEntry> {
 	const raw = params.raw ?? false;
-	const cached = readUrlCache.get(getReadUrlCacheKey(session, params.path, raw));
+	const cached = touchReadUrlCacheKey(getReadUrlCacheKey(session, params.path, raw));
 	if (options?.preferCached && cached) {
 		const prepared = options.ensureArtifact ? await ensureReadUrlCacheArtifact(session, cached) : cached;
 		const materialized = await materializeReadUrlCacheEntry(session, prepared);

--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -1279,11 +1279,7 @@ export function __primeReadUrlCacheForTest(
 ): void {
 	cacheReadUrlEntry(session, requestedUrl, raw, entry);
 }
-export function __lookupReadUrlCache(
-	session: ToolSession,
-	url: string,
-	raw: boolean,
-): ReadUrlCacheEntry | undefined {
+export function __lookupReadUrlCache(session: ToolSession, url: string, raw: boolean): ReadUrlCacheEntry | undefined {
 	return touchReadUrlCacheKey(getReadUrlCacheKey(session, url, raw));
 }
 

--- a/packages/coding-agent/test/tools/fetch-url-cache-cap.test.ts
+++ b/packages/coding-agent/test/tools/fetch-url-cache-cap.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import {
+	__getReadUrlCacheSize,
+	__lookupReadUrlCache,
+	__primeReadUrlCacheForTest,
+	__resetReadUrlCache,
+	READ_URL_CACHE_CAP,
+	type ReadUrlToolDetails,
+} from "@oh-my-pi/pi-coding-agent/tools/fetch";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+
+const makeDetails = (requestedUrl: string, finalUrl: string): ReadUrlToolDetails => ({
+	kind: "url",
+	url: requestedUrl,
+	finalUrl,
+	contentType: "text/plain",
+	method: "raw",
+	truncated: false,
+	notes: [],
+});
+
+const makeEntry = (requestedUrl: string, finalUrl: string = `${requestedUrl}#final`) => ({
+	details: makeDetails(requestedUrl, finalUrl),
+	output: `body for ${requestedUrl}`,
+});
+
+describe("read URL cache LRU cap", () => {
+	let testDir: string;
+
+	const createSession = (): ToolSession => {
+		const sessionFile = path.join(testDir, "session.jsonl");
+		const artifactsDir = sessionFile.slice(0, -6);
+		let nextArtifactId = 0;
+		return {
+			cwd: testDir,
+			hasUI: false,
+			getSessionFile: () => sessionFile,
+			getArtifactsDir: () => artifactsDir,
+			getSessionSpawns: () => null,
+			allocateOutputArtifact: async toolType => {
+				const id = String(nextArtifactId++);
+				return {
+					id,
+					path: path.join(artifactsDir, `${id}.${toolType}.log`),
+				};
+			},
+			settings: Settings.isolated({ "fetch.enabled": true }),
+		};
+	};
+
+	beforeEach(() => {
+		testDir = path.join(os.tmpdir(), `fetch-url-cache-cap-${Snowflake.next()}`);
+		fs.mkdirSync(testDir, { recursive: true });
+		__resetReadUrlCache();
+	});
+
+	afterEach(() => {
+		__resetReadUrlCache();
+		fs.rmSync(testDir, { recursive: true, force: true });
+	});
+
+	it("caps the URL cache at the LRU bound", () => {
+		const session = createSession();
+		const total = 100;
+		for (let i = 0; i < total; i++) {
+			const requested = `https://example.com/page-${i}`;
+			__primeReadUrlCacheForTest(session, requested, false, makeEntry(requested));
+		}
+		expect(READ_URL_CACHE_CAP).toBeGreaterThan(0);
+		// Each prime inserts two keys (requestedUrl + finalUrl).
+		expect(__getReadUrlCacheSize()).toBeLessThanOrEqual(READ_URL_CACHE_CAP * 2);
+	});
+
+	it("evicts the oldest entry first (LRU semantics)", () => {
+		const session = createSession();
+		const cap = READ_URL_CACHE_CAP;
+		// Prime exactly cap entries.
+		for (let i = 0; i < cap; i++) {
+			const requested = `https://example.com/lru-${i}`;
+			__primeReadUrlCacheForTest(session, requested, false, makeEntry(requested));
+		}
+		// All cap entries currently retrievable.
+		expect(__lookupReadUrlCache(session, "https://example.com/lru-0", false)).toBeDefined();
+		// Re-prime them all (lookups above re-ordered them; re-establish a known insertion order).
+		__resetReadUrlCache();
+		for (let i = 0; i < cap; i++) {
+			const requested = `https://example.com/lru-${i}`;
+			__primeReadUrlCacheForTest(session, requested, false, makeEntry(requested));
+		}
+		// Add one more — must evict entry 0 (the oldest).
+		const overflow = "https://example.com/lru-overflow";
+		__primeReadUrlCacheForTest(session, overflow, false, makeEntry(overflow));
+
+		expect(__lookupReadUrlCache(session, "https://example.com/lru-0", false)).toBeUndefined();
+		expect(__lookupReadUrlCache(session, overflow, false)).toBeDefined();
+	});
+
+	it("touching an entry via lookup keeps it warm", () => {
+		const session = createSession();
+		const cap = READ_URL_CACHE_CAP;
+		for (let i = 0; i < cap; i++) {
+			const requested = `https://example.com/warm-${i}`;
+			__primeReadUrlCacheForTest(session, requested, false, makeEntry(requested));
+		}
+		// Touch entry 0 so it becomes the most-recent.
+		expect(__lookupReadUrlCache(session, "https://example.com/warm-0", false)).toBeDefined();
+		// Prime 5 more entries — should evict the oldest untouched (entry 1, 2, ...), not entry 0.
+		for (let i = 0; i < 5; i++) {
+			const requested = `https://example.com/warm-extra-${i}`;
+			__primeReadUrlCacheForTest(session, requested, false, makeEntry(requested));
+		}
+		expect(__lookupReadUrlCache(session, "https://example.com/warm-0", false)).toBeDefined();
+		expect(__lookupReadUrlCache(session, "https://example.com/warm-1", false)).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Problem

`packages/coding-agent/src/tools/fetch.ts:1177` declares a module-level URL cache with no size cap and no eviction:

```ts
const readUrlCache = new Map<string, ReadUrlCacheEntry>();
```

Each entry is inserted under **two** keys per fetch (`requestedUrl` and `finalUrl` after redirect; see `cacheReadUrlEntry` at lines 1225-1228) and can carry up to ~300KB of inline base64 image data (`MAX_INLINE_IMAGE_OUTPUT_BYTES = 300 * 1024`).

### Real impact

Over a long OMP session that fetches many URLs the map grows without bound. Worst case: 1000 unique URLs × 2 keys × ~300KB ≈ **~600MB resident**. Worse, the cache is module-scoped, not session-scoped, so URLs cached in session A stay live in session B for the lifetime of the process. Long-lived daemons (ACP, watch modes) leak across the entire process lifetime.

There is no `.delete`, `.clear`, or eviction anywhere in the package.

## Fix

Cap the cache at `READ_URL_CACHE_CAP = 32` entries (≤64 keys after the dual-key insert). Use `Map`'s insertion-order iteration as LRU:

```ts
function touchReadUrlCacheKey(key: string): ReadUrlCacheEntry | undefined {
    // Re-insert to bump to the back of Map iteration order (LRU "most recent").
    const existing = readUrlCache.get(key);
    if (existing === undefined) return undefined;
    readUrlCache.delete(key);
    readUrlCache.set(key, existing);
    return existing;
}

function insertReadUrlCacheKey(key: string, entry: ReadUrlCacheEntry): void {
    if (readUrlCache.has(key)) readUrlCache.delete(key);
    readUrlCache.set(key, entry);
    const maxKeys = READ_URL_CACHE_CAP * 2;
    while (readUrlCache.size > maxKeys) {
        const oldestKey = readUrlCache.keys().next().value;
        if (oldestKey === undefined) break;
        readUrlCache.delete(oldestKey);
    }
}
```

- `cacheReadUrlEntry` routes through `insertReadUrlCacheKey` (bump + cap).
- `loadReadUrlCacheEntry`'s lookup routes through `touchReadUrlCacheKey` (bump on access).
- Public API unchanged — only the internal `Map.get` was swapped for a touch.

Cap is on **keys**, not entries: cheap, deterministic. Worst case: an entry's twin keys age out one at a time — acceptable for LRU.

## Test

`packages/coding-agent/test/tools/fetch-url-cache-cap.test.ts` — three cases:

| Case                                  | Asserts                                                                        |
| ------------------------------------- | ------------------------------------------------------------------------------ |
| caps the URL cache at the LRU bound   | priming 100 distinct URLs → `__getReadUrlCacheSize()` ≤ `2 * READ_URL_CACHE_CAP` |
| evicts the oldest entry first         | priming CAP+1 → entry 0 evicted, last entry still present                       |
| touching an entry via lookup keeps it warm | LRU bump on access: oldest *untouched* evicted, touched one survives             |

Before the fix: tests fail to import `__getReadUrlCacheSize` / `__lookupReadUrlCache` / `READ_URL_CACHE_CAP` (no cap, no exports).
After the fix: `bun test test/tools/fetch-url-cache-cap.test.ts` → **3 pass, 8 expect()**.

## Scope

- `packages/coding-agent/src/tools/fetch.ts` — +63 / -3 lines, cache region only
- `packages/coding-agent/test/tools/fetch-url-cache-cap.test.ts` — new test (~120 lines)
- Test-only helpers (`__getReadUrlCacheSize`, `__resetReadUrlCache`, `__primeReadUrlCacheForTest`, `__lookupReadUrlCache`) kept inline next to the cache, prefixed with `__` per project convention.
- No public API change, no new dependencies.

## Notes

The bound 32 is conservative — easy to tune up if telemetry shows hot URLs being re-fetched after eviction. Picking it small is safer than picking it large: agent flows that re-read the same URL typically do so within a handful of tool calls.
