### PR TITLE
Fix plan mode resolve tool registration

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Changed read to return verbatim contents for files shorter than `read.summarize.minTotalLines` instead of summarizing them
 - Changed `search` path line-range filtering to include only matches and context lines that fall inside the requested ranges
 
+### Fixed
+
+- Fixed plan mode losing the hidden `resolve` tool when sessions were created with an explicit non-deferrable tool list, leaving agents unable to submit completed plans for approval ([#1428](https://github.com/can1357/oh-my-pi/issues/1428))
+
 ## [15.5.3] - 2026-05-27
 ### Breaking Changes
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1527,9 +1527,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		}
 
 		const hasDeferrableTools = Array.from(toolRegistry.values()).some(tool => tool.deferrable === true);
-		if (!hasDeferrableTools) {
-			toolRegistry.delete("resolve");
-		} else if (!toolRegistry.has("resolve")) {
+		// `resolve` is not only the apply/discard companion for deferrable tools. Plan mode
+		// also activates it on demand through a standing resolve handler. Keep it registered
+		// even when no deferrable tool is active, otherwise plan-mode sessions can instruct the
+		// model to call `resolve` while `InteractiveMode.#enterPlanMode()` has no tool to add.
+		if (!toolRegistry.has("resolve")) {
 			const resolveTool = await logger.time("createTools:resolve:session", HIDDEN_TOOLS.resolve, toolSession);
 			if (resolveTool) {
 				toolRegistry.set(resolveTool.name, wrapToolWithMetaNotice(resolveTool));
@@ -1668,7 +1670,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		const defaultInactiveToolNames = new Set(
 			registeredTools.filter(tool => tool.definition.defaultInactive).map(tool => tool.definition.name),
 		);
-		const requestedActiveToolNames = normalizedRequested.filter(name => name !== "goal");
+		const resolveExplicitlyRequested = explicitlyRequestedToolNames?.includes("resolve") ?? false;
+		const requestedActiveToolNames = normalizedRequested.filter(
+			name => name !== "goal" && (name !== "resolve" || hasDeferrableTools || resolveExplicitlyRequested),
+		);
 		const initialRequestedActiveToolNames = options.toolNames
 			? requestedActiveToolNames
 			: requestedActiveToolNames.filter(name => !defaultInactiveToolNames.has(name));

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -140,4 +140,37 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			await session.dispose();
 		}
 	});
+
+	it("keeps resolve registered for explicit tool lists without making it active", async () => {
+		const tempDir = path.join(os.tmpdir(), `pi-sdk-tool-activation-${Snowflake.next()}`);
+		tempDirs.push(tempDir);
+		fs.mkdirSync(tempDir, { recursive: true });
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			toolNames: ["read", "search", "find", "web_search"],
+		});
+
+		try {
+			expect(session.getToolByName("resolve")).toBeDefined();
+			expect(session.getAllToolNames()).toContain("resolve");
+			expect(session.getActiveToolNames()).not.toContain("resolve");
+
+			await session.setActiveToolsByName([...session.getActiveToolNames(), "resolve"]);
+			expect(session.getActiveToolNames()).toContain("resolve");
+		} finally {
+			await session.dispose();
+		}
+	});
 });


### PR DESCRIPTION
## Summary
- keep the hidden `resolve` tool registered even when no deferrable tools are present
- keep `resolve` inactive by default unless deferrable tools exist or it is explicitly requested
- add regression coverage for explicit non-deferrable tool lists so plan mode can activate `resolve`

Fixes #1428.

## Verification
- `bun --cwd packages/coding-agent test test/sdk-tool-activation.test.ts`
- `bunx biome check packages/coding-agent/src/sdk.ts packages/coding-agent/test/sdk-tool-activation.test.ts packages/coding-agent/CHANGELOG.md --no-errors-on-unmatched`
- `git diff --check -- packages/coding-agent/src/sdk.ts packages/coding-agent/test/sdk-tool-activation.test.ts packages/coding-agent/CHANGELOG.md`