### PR TITLE
fix(coding-agent): keep hidden resolve tool for plan mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Changed read to return verbatim contents for files shorter than `read.summarize.minTotalLines` instead of summarizing them
 - Changed `search` path line-range filtering to include only matches and context lines that fall inside the requested ranges
 
+### Fixed
+
+- Fixed `createAgentSession()` dropping the hidden `resolve` tool from the registry when no active tool sets `deferrable: true`, even though plan mode dispatches the plan-approval `resolve { action: "apply", ... }` call through a standing handler. Read-only plan-mode toolsets (e.g. `read`, `search`, `find`, `web_search`) silently activated plan mode without `resolve`, leaving the agent unable to submit the finalized plan and forcing the user to exit plan mode manually. `resolve` is now kept whenever `plan.enabled` is true, so the standing handler always has a callable tool ([#1428](https://github.com/can1357/oh-my-pi/issues/1428))
+
 ## [15.5.3] - 2026-05-27
 ### Breaking Changes
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1526,8 +1526,15 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			toolRegistry.delete("edit");
 		}
 
+		// `resolve` is hidden but must stay in the registry whenever any code path can invoke it:
+		// either a deferrable tool stages a preview action, or plan mode installs a standing handler
+		// that consumes `resolve { action: "apply" }` to submit the plan for approval (issue #1428).
+		// Dropping it on read-only sessions (e.g. plan-mode toolset `read`, `search`, `find`,
+		// `web_search`) leaves plan mode unable to exit through the intended path.
 		const hasDeferrableTools = Array.from(toolRegistry.values()).some(tool => tool.deferrable === true);
-		if (!hasDeferrableTools) {
+		const planModeAvailable = settings.get("plan.enabled");
+		const needsResolveTool = hasDeferrableTools || planModeAvailable;
+		if (!needsResolveTool) {
 			toolRegistry.delete("resolve");
 		} else if (!toolRegistry.has("resolve")) {
 			const resolveTool = await logger.time("createTools:resolve:session", HIDDEN_TOOLS.resolve, toolSession);

--- a/packages/coding-agent/test/sdk-tool-activation.test.ts
+++ b/packages/coding-agent/test/sdk-tool-activation.test.ts
@@ -140,4 +140,70 @@ describe("createAgentSession defaultInactive tool activation", () => {
 			await session.dispose();
 		}
 	});
+
+	it("keeps the hidden resolve tool registered for plan mode even when no deferrable tool is requested", async () => {
+		// Regression for #1428: plan mode submits its finalized plan via
+		// `resolve { action: "apply" }` dispatched through a standing handler
+		// (interactive-mode.ts: `setStandingResolveHandler`). With an explicit
+		// read-only `toolNames` (e.g. `read`, `search`, `find`, `web_search`)
+		// the registry has no `deferrable` tool, so the previous gate dropped
+		// `resolve` from the registry and plan mode silently activated without
+		// it — leaving the agent stuck after drafting the plan.
+		const tempDir = path.join(os.tmpdir(), `pi-sdk-tool-activation-${Snowflake.next()}`);
+		tempDirs.push(tempDir);
+		fs.mkdirSync(tempDir, { recursive: true });
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			toolNames: ["read", "search", "find", "web_search"],
+		});
+
+		try {
+			expect(session.getToolByName("resolve")).toBeDefined();
+		} finally {
+			await session.dispose();
+		}
+	});
+
+	it("drops the hidden resolve tool when neither a deferrable tool nor plan mode can use it", async () => {
+		const tempDir = path.join(os.tmpdir(), `pi-sdk-tool-activation-${Snowflake.next()}`);
+		tempDirs.push(tempDir);
+		fs.mkdirSync(tempDir, { recursive: true });
+
+		const settings = Settings.isolated();
+		settings.set("plan.enabled", false);
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			sessionManager: SessionManager.inMemory(),
+			settings,
+			model: getBundledModel("openai", "gpt-4o-mini"),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			toolNames: ["read", "search", "find", "web_search"],
+		});
+
+		try {
+			expect(session.getToolByName("resolve")).toBeUndefined();
+		} finally {
+			await session.dispose();
+		}
+	});
 });


### PR DESCRIPTION
## Repro

A plan-mode session started with an explicit read-only `toolNames` list — e.g. `["read", "search", "find", "web_search"]` — drafts `PLAN.md`, then needs to call `resolve { action: "apply", extra: { title } }` to submit the plan for approval. The call never happens because `resolve` is missing from the session's tool registry, so the agent stalls on the post-turn `plan-mode-tool-decision-reminder` loop until the user manually exits plan mode.

Reproducer (also added as a regression test): `bun --cwd=packages/coding-agent test test/sdk-tool-activation.test.ts -t "keeps the hidden resolve tool registered for plan mode"` fails on `main` with `session.getToolByName("resolve")` returning `undefined`.

## Cause

`createAgentSession()` in `packages/coding-agent/src/sdk.ts` ran a "deferrable audit" after assembling the tool registry: if no registered tool advertised `deferrable: true`, it deleted the hidden `resolve` tool. The audit dates back to the deferrable-tool / LIFO pending-action work (commit 6d00729250) and only considered the deferrable preview-apply path.

Plan mode does not use a deferrable tool. Instead, `InteractiveMode.#enterPlanMode` (`packages/coding-agent/src/modes/interactive-mode.ts:1258`) installs a *standing* resolve handler via `session.setStandingResolveHandler(...)`. The `ResolveTool` consumes that standing handler when the agent invokes `resolve` (`packages/coding-agent/src/tools/resolve.ts:188`). With read-only toolsets there is no deferrable tool, so the audit dropped `resolve` and the handler had nothing to dispatch to. `#enterPlanMode` even checks `getToolByName("resolve")` before activating it but proceeded silently when it was missing.

## Fix

- `packages/coding-agent/src/sdk.ts` — keep `resolve` in the registry whenever `settings.get("plan.enabled")` is true (in addition to the existing deferrable-tool check). The hidden flag still keeps it out of the default active set; plan mode (and deferrable previews) remain the only paths that activate it.
- `packages/coding-agent/test/sdk-tool-activation.test.ts` — two regression tests: one asserts `resolve` survives a read-only `toolNames` list while plan mode is enabled (the failure path on `main`); the other asserts the existing drop behavior still holds when `plan.enabled` is `false` and no deferrable tool is present.
- `packages/coding-agent/CHANGELOG.md` — `### Fixed` entry under `[Unreleased]` citing #1428.

## Verification

`bun --cwd=packages/coding-agent test test/sdk-tool-activation.test.ts` → 5 pass, 0 fail (the two new tests included). Confirmed the new "keeps the hidden resolve tool registered for plan mode" test fails on the unmodified `main` and passes with the fix applied.

Fixes #1428