### PR TITLE
fix(extensibility): restore `Type` for legacy `@(scope)/pi-ai` root imports

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed legacy pi-* extension loading regression where `import { Type } from "@(scope)/pi-ai"` (e.g. `@earendil-works/pi-ai` used by `@plannotator/pi-extension`) failed with `Export named 'Type' not found` after pi-ai 15.1.0 removed the root `Type` runtime export; the legacy-pi compat layer now redirects bare `@oh-my-pi/pi-ai` root imports through a sibling shim that re-exports the canonical pi-ai surface plus the Zod-backed `Type` runtime from the same TypeBox shim served to `@sinclair/typebox` imports ([#1437](https://github.com/can1357/oh-my-pi/issues/1437))
+
 ## [15.5.4] - 2026-05-27
 
 ### Breaking Changes
-
 - Removed the package root `hashline` export so imports from the top-level entrypoint can no longer access `hashline` helpers directly
 
 ### Added

--- a/packages/coding-agent/scripts/build-binary.ts
+++ b/packages/coding-agent/scripts/build-binary.ts
@@ -56,6 +56,17 @@ async function main(): Promise<void> {
 					"../stats/src/sync-worker.ts",
 					"./src/tools/browser/tab-worker-entry.ts",
 					"./src/eval/js/worker-entry.ts",
+					// Legacy pi-* extension compat shims served by `legacy-pi-compat.ts`.
+					// Both are reached only via the computed `TYPEBOX_SHIM_PATH` /
+					// `LEGACY_PI_AI_SHIM_PATH` constants (which `--compile`'s static
+					// analyzer cannot trace), so each shim must be listed here to land
+					// in bunfs alongside the workers above. The bunfs entry path is
+					// `--root`-relative with a `.js` extension, e.g.
+					// `/$bunfs/root/packages/coding-agent/src/extensibility/typebox.js`,
+					// which is what the `isCompiledBinary()` branch in
+					// `legacy-pi-compat.ts` resolves to at runtime.
+					"./src/extensibility/typebox.ts",
+					"./src/extensibility/legacy-pi-ai-shim.ts",
 					"--outfile",
 					"dist/omp",
 				],

--- a/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts
@@ -1,0 +1,24 @@
+/**
+ * Compatibility shim for legacy extensions importing the package root of
+ * `@oh-my-pi/pi-ai` (or one of its aliased scopes like `@earendil-works/pi-ai`
+ * or `@mariozechner/pi-ai`).
+ *
+ * pi-ai 15.1.0 removed the historical TypeBox root exports (`Type`, plus the
+ * runtime-relevant half of the `Static`/`TSchema` pair) from the package
+ * entrypoint. Legacy extensions still author parameter schemas as
+ * `Type.Object({ ... })`, so this file is served by `legacy-pi-compat.ts` in
+ * place of the real pi-ai entrypoint whenever a legacy extension imports the
+ * bare package root. Subpath imports (`@oh-my-pi/pi-ai/utils/oauth`, etc.)
+ * continue to resolve directly against the bundled pi-ai package.
+ *
+ * The `Type` runtime is borrowed from the Zod-backed TypeBox shim that
+ * already serves bare `@sinclair/typebox` imports for the same extension
+ * class, keeping the legacy-compat surface internally consistent.
+ *
+ * Type-level `Static` and `TSchema` continue to come from pi-ai's own
+ * `types.ts` via the `export *` below — pi-ai still exports both as types,
+ * only the runtime `Type` builder was removed.
+ */
+
+export * from "@oh-my-pi/pi-ai";
+export { Type } from "./typebox";

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
+import { isCompiledBinary } from "@oh-my-pi/pi-utils";
 
 // Canonical scope for in-process pi packages. Plugins published against any of
 // the aliased scopes below (mariozechner's original publish, earendil-works'
@@ -56,7 +57,19 @@ const resolvedSpecifierFallbacks = new Map<string, string>();
 // relying on them must vendor `@sinclair/typebox` directly.
 const TYPEBOX_SPECIFIER = "@sinclair/typebox";
 const TYPEBOX_SPECIFIER_FILTER = /^@sinclair\/typebox$/;
-const TYPEBOX_SHIM_PATH = path.resolve(import.meta.dir, "../typebox.ts");
+
+// In-process compat shim paths. In dev `import.meta.dir` is the source folder of
+// this file, so the dev branches resolve to the real `.ts` source. In compiled
+// binaries `import.meta.dir` collapses to `/$bunfs/root`, so the runtime cannot
+// recover the source layout that way; instead, each shim file is registered as
+// a `--compile` entrypoint in `scripts/build-binary.ts`, which Bun emits into
+// bunfs at a deterministic `--root`-relative path with a `.js` extension. The
+// literals below must stay in sync with that listing — if either path drifts,
+// every legacy plugin loading the shim fails with a missing-module error in
+// release builds (without affecting `bun test`/dev).
+const TYPEBOX_SHIM_PATH = isCompiledBinary()
+	? "/$bunfs/root/packages/coding-agent/src/extensibility/typebox.js"
+	: path.resolve(import.meta.dir, "../typebox.ts");
 
 // Legacy extensions historically imported `Type` (and `Static`/`TSchema`) from
 // the package root of `@(scope)/pi-ai`. pi-ai 15.1.0 removed the runtime `Type`
@@ -66,7 +79,9 @@ const TYPEBOX_SHIM_PATH = path.resolve(import.meta.dir, "../typebox.ts");
 // plus the borrowed `Type` runtime from the Zod-backed TypeBox shim. Subpath
 // imports such as `@oh-my-pi/pi-ai/utils/oauth` continue to resolve directly
 // against the bundled pi-ai package.
-const LEGACY_PI_AI_SHIM_PATH = path.resolve(import.meta.dir, "../legacy-pi-ai-shim.ts");
+const LEGACY_PI_AI_SHIM_PATH = isCompiledBinary()
+	? "/$bunfs/root/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.js"
+	: path.resolve(import.meta.dir, "../legacy-pi-ai-shim.ts");
 const LEGACY_PI_PACKAGE_ROOT_OVERRIDES: Record<string, string> = {
 	[`${CANONICAL_PI_SCOPE}/pi-ai`]: LEGACY_PI_AI_SHIM_PATH,
 };

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -58,6 +58,19 @@ const TYPEBOX_SPECIFIER = "@sinclair/typebox";
 const TYPEBOX_SPECIFIER_FILTER = /^@sinclair\/typebox$/;
 const TYPEBOX_SHIM_PATH = path.resolve(import.meta.dir, "../typebox.ts");
 
+// Legacy extensions historically imported `Type` (and `Static`/`TSchema`) from
+// the package root of `@(scope)/pi-ai`. pi-ai 15.1.0 removed the runtime `Type`
+// export (see `packages/ai/CHANGELOG.md`), so the bare canonical specifier no
+// longer satisfies those imports. The override below redirects only the bare
+// pi-ai package root onto a sibling shim that re-exports the canonical surface
+// plus the borrowed `Type` runtime from the Zod-backed TypeBox shim. Subpath
+// imports such as `@oh-my-pi/pi-ai/utils/oauth` continue to resolve directly
+// against the bundled pi-ai package.
+const LEGACY_PI_AI_SHIM_PATH = path.resolve(import.meta.dir, "../legacy-pi-ai-shim.ts");
+const LEGACY_PI_PACKAGE_ROOT_OVERRIDES: Record<string, string> = {
+	[`${CANONICAL_PI_SCOPE}/pi-ai`]: LEGACY_PI_AI_SHIM_PATH,
+};
+
 let isLegacyPiSpecifierShimInstalled = false;
 
 function remapLegacyPiSpecifier(specifier: string): string | null {
@@ -85,6 +98,22 @@ function getResolvedSpecifier(specifier: string): string {
 	return resolved;
 }
 
+/**
+ * Resolve a canonical `@oh-my-pi/*` specifier to a filesystem path, preferring
+ * a bundled compat shim when one is registered for the package root.
+ *
+ * Falls back to `getResolvedSpecifier` (which may throw under compiled binary
+ * mode); callers handle that the same way they would for non-overridden
+ * specifiers.
+ */
+function resolveCanonicalPiSpecifier(remappedSpecifier: string): string {
+	const override = LEGACY_PI_PACKAGE_ROOT_OVERRIDES[remappedSpecifier];
+	if (override) {
+		return override;
+	}
+	return getResolvedSpecifier(remappedSpecifier);
+}
+
 function toImportSpecifier(resolvedPath: string): string {
 	return url.pathToFileURL(resolvedPath).href;
 }
@@ -99,7 +128,7 @@ function rewriteLegacyPiImports(source: string): string {
 			}
 
 			try {
-				return `${prefix}${toImportSpecifier(getResolvedSpecifier(remappedSpecifier))}${suffix}`;
+				return `${prefix}${toImportSpecifier(resolveCanonicalPiSpecifier(remappedSpecifier))}${suffix}`;
 			} catch {
 				// Resolution failed — typically in compiled binary mode where
 				// Bun.resolveSync cannot walk up from /$bunfs/root to find the
@@ -250,7 +279,7 @@ function resolveLegacyPiSpecifier(args: { path: string; importer: string }): { p
 	// Primary: resolve the canonical @oh-my-pi/* specifier from the host binary
 	// location. Works in dev mode and in source-link installs.
 	try {
-		return { path: getResolvedSpecifier(remappedSpecifier) };
+		return { path: resolveCanonicalPiSpecifier(remappedSpecifier) };
 	} catch {
 		// Fallback for compiled binary mode: the bundled packages live inside
 		// /$bunfs/root and aren't reachable by filesystem resolution. Try the

--- a/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
@@ -1,0 +1,97 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { installLegacyPiSpecifierShim, loadLegacyPiModule } from "../../src/extensibility/plugins/legacy-pi-compat";
+import { Type as TypeBoxShimType } from "../../src/extensibility/typebox";
+
+// pi-ai 15.1.0 removed the runtime `Type` export from `@oh-my-pi/pi-ai`'s
+// package root. Legacy extensions (and their aliased-scope variants such as
+// `@earendil-works/pi-ai`) still author parameter schemas as
+// `import { Type } from "@earendil-works/pi-ai"` and then `Type.Object(...)`.
+// `legacy-pi-compat.ts` patches that gap by redirecting bare pi-ai root
+// imports through `legacy-pi-ai-shim.ts`, which re-exports the canonical
+// pi-ai surface plus the Zod-backed `Type` runtime from the same TypeBox shim
+// `@sinclair/typebox` is served from.
+installLegacyPiSpecifierShim();
+
+const tempRoots: string[] = [];
+
+afterAll(async () => {
+	for (const dir of tempRoots) {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+});
+
+async function writeFixtureExtension(source: string): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-pi-ai-type-remap-"));
+	tempRoots.push(dir);
+	const entry = path.join(dir, "index.ts");
+	await fs.writeFile(entry, source, "utf8");
+	return entry;
+}
+
+describe("legacy-pi @(scope)/pi-ai root `Type` remap (issue #1437)", () => {
+	it('redirects `import { Type } from "@earendil-works/pi-ai"` to the TypeBox shim', async () => {
+		const entry = await writeFixtureExtension(
+			[
+				'import { Type } from "@earendil-works/pi-ai";',
+				"export const probe = Type;",
+				"export const schema = Type.Object({ name: Type.String() }, { additionalProperties: false });",
+			].join("\n"),
+		);
+
+		const loaded = (await loadLegacyPiModule(entry)) as {
+			probe: typeof TypeBoxShimType;
+			schema: { safeParse: (input: unknown) => { success: boolean } };
+		};
+
+		expect(loaded.probe).toBe(TypeBoxShimType);
+		expect(loaded.schema.safeParse({ name: "ok" }).success).toBe(true);
+		expect(loaded.schema.safeParse({}).success).toBe(false);
+		expect(loaded.schema.safeParse({ name: "ok", extra: 1 }).success).toBe(false);
+	});
+
+	it('redirects `import { Type } from "@oh-my-pi/pi-ai"` for plugins published against the canonical scope', async () => {
+		const entry = await writeFixtureExtension(
+			['import { Type } from "@oh-my-pi/pi-ai";', "export const probe = Type;"].join("\n"),
+		);
+
+		const loaded = (await loadLegacyPiModule(entry)) as { probe: typeof TypeBoxShimType };
+		expect(loaded.probe).toBe(TypeBoxShimType);
+	});
+
+	it("preserves canonical pi-ai exports alongside the shimmed Type (z is still re-exported)", async () => {
+		const entry = await writeFixtureExtension(
+			[
+				'import { Type, z } from "@earendil-works/pi-ai";',
+				"export const obj = Type.Object({ name: Type.String() });",
+				"export const zodObj = z.object({ name: z.string() });",
+			].join("\n"),
+		);
+
+		const loaded = (await loadLegacyPiModule(entry)) as {
+			obj: { safeParse: (input: unknown) => { success: boolean } };
+			zodObj: { safeParse: (input: unknown) => { success: boolean } };
+		};
+
+		expect(loaded.obj.safeParse({ name: "ok" }).success).toBe(true);
+		expect(loaded.zodObj.safeParse({ name: "ok" }).success).toBe(true);
+		expect(loaded.zodObj.safeParse({}).success).toBe(false);
+	});
+
+	it("does not redirect subpath imports such as @oh-my-pi/pi-ai/utils/schema", async () => {
+		const entry = await writeFixtureExtension(
+			[
+				// `zodToWireSchema` is only exported from the subpath, not the root,
+				// so a successful import proves the subpath still resolves directly
+				// against the bundled pi-ai package rather than the shim.
+				'import { zodToWireSchema } from "@oh-my-pi/pi-ai/utils/schema";',
+				"export const fn = zodToWireSchema;",
+			].join("\n"),
+		);
+
+		const loaded = (await loadLegacyPiModule(entry)) as { fn: unknown };
+		expect(typeof loaded.fn).toBe("function");
+	});
+});


### PR DESCRIPTION
## Repro

`@plannotator/pi-extension@0.19.23` installs cleanly (`omp plugin doctor --json` reports `status: ok`) but its load fails at runtime because the entry imports `Type` from `@earendil-works/pi-ai`, which `legacy-pi-compat` remaps to `@oh-my-pi/pi-ai`. pi-ai 15.1.0 dropped the root `Type` runtime export, so Bun reports `SyntaxError: Export named 'Type' not found in module '.../@oh-my-pi/pi-ai/src/index.ts'` and the extension is discarded before `/plannotator` registers.

Minimal isolated repro (mirrors the user's command):

```bash
bun -e '
import { loadLegacyPiModule, installLegacyPiSpecifierShim } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-compat";
installLegacyPiSpecifierShim();
await loadLegacyPiModule("/path/to/plugin/index.ts");
'
# SyntaxError: Export named 'Type' not found in module '.../@oh-my-pi/pi-ai/src/index.ts'.
```

## Cause

`packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` rewrites legacy `@(oh-my-pi|mariozechner|earendil-works)/pi-*` specifiers to `@oh-my-pi/pi-*` and then resolves them against the host binary via `Bun.resolveSync`. The canonical pi-ai entrypoint (`packages/ai/src/index.ts`) no longer re-exports the TypeBox `Type` builder — that was removed as a documented breaking change in pi-ai 15.1.0 — so any legacy extension authored against `import { Type } from "@(scope)/pi-ai"` fails at import time. The existing Zod-backed TypeBox shim handles only the symmetric `@sinclair/typebox` specifier; the pi-ai root case had no counterpart.

## Fix

- Added `packages/coding-agent/src/extensibility/legacy-pi-ai-shim.ts`, a one-screen file that does `export * from "@oh-my-pi/pi-ai"` and `export { Type } from "./typebox"`, borrowing the `Type` runtime from the same Zod-backed shim already used for `@sinclair/typebox`. Type-level `Static`/`TSchema` already survive via pi-ai's own `types.ts`, so they need no extra wiring.
- Threaded a `LEGACY_PI_PACKAGE_ROOT_OVERRIDES` record plus a `resolveCanonicalPiSpecifier()` helper into `legacy-pi-compat.ts`. Both resolution paths — the static rewriter (`rewriteLegacyPiImports`) and the `Bun.plugin` `onResolve` hook (`resolveLegacyPiSpecifier`) — now consult the override before falling back to `getResolvedSpecifier`, so the redirect fires consistently for mirrored extension files and Bun's bundler.
- Override is keyed on the canonical bare package root (`@oh-my-pi/pi-ai`) only; subpath imports such as `@oh-my-pi/pi-ai/utils/oauth` continue to resolve directly against the bundled pi-ai package.
- Added `packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts` covering: aliased-scope import, canonical-scope import, mixed `Type + z` import (proves the canonical surface is preserved), and a subpath-import sanity test (proves we did not over-redirect).
- `packages/coding-agent/CHANGELOG.md` Unreleased entry under `### Fixed`.

## Verification

```
$ bun test packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts \
           packages/coding-agent/test/extensibility/typebox-remap.test.ts \
           packages/coding-agent/test/extensibility/typebox-shim.test.ts \
           packages/coding-agent/test/issue-1215-legacy-pi-ai-import.test.ts \
           packages/coding-agent/test/issue-973-legacy-pi-plugin.test.ts
 17 pass / 0 fail (50 expect() calls)

$ bun run check:ts
# clean across all workspaces
```

Manual: the original `bun -e` repro now returns `LOADED [ "default" ]` and the registered tool's `Type.Object({ name: Type.String() })` schema validates `{ name: "ok" }` and rejects `{}`.

Fixes #1437