### PR TITLE
fix(hashline): add cross-call re-read guidance

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed hashline prompt guidance so agents re-read edited regions before reusing line anchors across edit calls ([#1436](https://github.com/can1357/oh-my-pi/issues/1436)).
+
 ## [15.5.4] - 2026-05-27
 
 ### Breaking Changes

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -242,6 +242,7 @@ Before declaring blocked:
 - Read sections, not snippets. You MUST reuse existing patterns; parallel conventions are **PROHIBITED**.
 {{#has tools "lsp"}}- You MUST run `{{toolRefs.lsp}} references` before modifying exported symbols. Missed callsites are bugs.{{/has}}
 - Re-read before acting if a tool fails or a file changes since you last read it.
+- After any edit, re-read affected regions before another edit to the same file. Frozen line numbers hold only within one `edit()` call; across calls, anchors are stale. File-cache re-reads are free.
 # 3. Decompose
 - Update todos as you progress; skip for trivial requests. Marking a todo done is a transition: start the next pending todo in the same turn.
 - NEVER abandon phases under scope pressure — delegate, don't shrink.

--- a/packages/coding-agent/test/system-prompt-templates.test.ts
+++ b/packages/coding-agent/test/system-prompt-templates.test.ts
@@ -7,6 +7,7 @@ import { buildSystemPrompt, buildSystemPromptToolMetadata } from "@oh-my-pi/pi-c
 import { prompt } from "@oh-my-pi/pi-utils";
 import Handlebars from "handlebars";
 import * as z from "zod/v4";
+import hashlinePrompt from "../../hashline/src/prompt.md" with { type: "text" };
 
 const baseGitContext = {
 	isRepo: true,
@@ -117,6 +118,15 @@ describe("system Handlebars prompt templates", () => {
 			expect(() => Handlebars.parse(template), `Failed parsing ${fileName}`).not.toThrow();
 			expect(() => Handlebars.compile(template), `Failed compiling ${fileName}`).not.toThrow();
 		}
+	});
+
+	test("edit prompts warn that hashline anchors are stale across calls", async () => {
+		const systemTemplate = await Bun.file(path.join(systemPromptsDir, "system-prompt.md")).text();
+
+		expect(systemTemplate).toContain("After any edit, re-read affected regions");
+		expect(systemTemplate).toContain("Frozen line numbers hold only within one `edit()` call");
+		expect(hashlinePrompt).toContain("Re-read between edit calls");
+		expect(hashlinePrompt).toContain("stale line numbers target wrong lines");
 	});
 
 	test("custom-system-prompt renders project section for context and git combinations", async () => {

--- a/packages/hashline/CHANGELOG.md
+++ b/packages/hashline/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 All notable changes to this package will be documented in this file.
 
+### Fixed
+
+- Fixed hashline prompt guidance so agents re-read edited regions before reusing line anchors across edit calls ([#1436](https://github.com/can1357/oh-my-pi/issues/1436)).
+
 ## [15.5.4] - 2026-05-27
 ### Added
 

--- a/packages/hashline/src/prompt.md
+++ b/packages/hashline/src/prompt.md
@@ -29,6 +29,7 @@ A-B!     delete A..B   (or A! == A..A)
 - **NEVER replay past your range.** Stop before B+1; extend B if needed.
 - **Read lines look like replace ops.** `84:content` = "make line 84 content" — and inline content is rejected. Don't echo read-style rows.
 - **NEVER fabricate file hashes.** Missing? Re-`read`.
+- **Re-read between edit calls.** Frozen line numbers apply within one `edit()` call only. Edited region again? Re-read first; stale line numbers target wrong lines.
 </common-failures>
 
 <example>


### PR DESCRIPTION
## Repro
The current prompt surfaces did not explicitly tell the agent that hashline line numbers are stale across separate `edit()` calls. Reproduced with: `bun -e 'const checks = [["packages/coding-agent/src/prompts/system/system-prompt.md", "After any edit, re-read the affected region"], ["packages/hashline/src/prompt.md", "Re-read between edit calls"]]; let missing = 0; for (const [path, needle] of checks) { const text = await Bun.file(path).text(); if (text.includes(needle)) { console.log(`${path}: guidance present`); } else { console.log(`${path}: missing ${JSON.stringify(needle)}`); missing++; } } process.exit(missing === 0 ? 0 : 1);'`, which reported both guidance strings missing before the fix.

## Cause
`packages/coding-agent/src/prompts/system/system-prompt.md` only had the generic stale-file re-read rule, and `packages/hashline/src/prompt.md` documented frozen line numbers only for later ops within the same hunk/call. Neither prompt named the cross-call failure mode, so the model could reuse anchors from the pre-edit coordinate space after a successful edit.

## Fix
- Added system workflow guidance to re-read affected regions before another edit to the same file after any edit.
- Added hashline common-failure guidance that frozen line numbers apply only within one `edit()` call and stale cross-call line numbers target wrong lines.
- Added prompt regression coverage in `packages/coding-agent/test/system-prompt-templates.test.ts`.
- Added changelog entries for `packages/coding-agent` and `packages/hashline`.

## Verification
`bun -e 'const checks = [["packages/coding-agent/src/prompts/system/system-prompt.md", "After any edit, re-read affected regions"], ["packages/hashline/src/prompt.md", "Re-read between edit calls"]]; let missing = 0; for (const [path, needle] of checks) { const text = await Bun.file(path).text(); if (text.includes(needle)) { console.log(`${path}: guidance present`); } else { console.log(`${path}: missing ${JSON.stringify(needle)}`); missing++; } } process.exit(missing === 0 ? 0 : 1);'` passes. `bun test test/system-prompt-templates.test.ts` passes from `packages/coding-agent`. `bun run check` passes in both `packages/coding-agent` and `packages/hashline`. Pre-publish `gh_push_branch` gate passed. Fixes #1436.