### PR TITLE
fix(xiaomi): map models.dev descriptor to OpenAI API, not Anthropic

### DIFF
--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -71685,9 +71685,9 @@
 		"mimo-v2-flash": {
 			"id": "mimo-v2-flash",
 			"name": "MiMo-V2-Flash",
-			"api": "anthropic-messages",
+			"api": "openai-completions",
 			"provider": "xiaomi",
-			"baseUrl": "https://api.xiaomimimo.com/anthropic",
+			"baseUrl": "https://api.xiaomimimo.com/v1",
 			"reasoning": true,
 			"input": [
 				"text"
@@ -71700,18 +71700,25 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 65536,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false
+			},
 			"thinking": {
-				"mode": "budget",
+				"mode": "effort",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "high"
 			}
 		},
 		"mimo-v2-omni": {
 			"id": "mimo-v2-omni",
 			"name": "MiMo-V2-Omni",
-			"api": "anthropic-messages",
+			"api": "openai-completions",
 			"provider": "xiaomi",
-			"baseUrl": "https://api.xiaomimimo.com/anthropic",
+			"baseUrl": "https://api.xiaomimimo.com/v1",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -71725,18 +71732,25 @@
 			},
 			"contextWindow": 262144,
 			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false
+			},
 			"thinking": {
-				"mode": "budget",
+				"mode": "effort",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "high"
 			}
 		},
 		"mimo-v2-pro": {
 			"id": "mimo-v2-pro",
 			"name": "MiMo-V2-Pro",
-			"api": "anthropic-messages",
+			"api": "openai-completions",
 			"provider": "xiaomi",
-			"baseUrl": "https://api.xiaomimimo.com/anthropic",
+			"baseUrl": "https://api.xiaomimimo.com/v1",
 			"reasoning": true,
 			"input": [
 				"text"
@@ -71749,18 +71763,25 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false
+			},
 			"thinking": {
-				"mode": "budget",
+				"mode": "effort",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "high"
 			}
 		},
 		"mimo-v2.5": {
 			"id": "mimo-v2.5",
 			"name": "MiMo-V2.5",
-			"api": "anthropic-messages",
+			"api": "openai-completions",
 			"provider": "xiaomi",
-			"baseUrl": "https://api.xiaomimimo.com/anthropic",
+			"baseUrl": "https://api.xiaomimimo.com/v1",
 			"reasoning": true,
 			"input": [
 				"text",
@@ -71774,18 +71795,25 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false
+			},
 			"thinking": {
-				"mode": "budget",
+				"mode": "effort",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "high"
 			}
 		},
 		"mimo-v2.5-pro": {
 			"id": "mimo-v2.5-pro",
 			"name": "MiMo-V2.5-Pro",
-			"api": "anthropic-messages",
+			"api": "openai-completions",
 			"provider": "xiaomi",
-			"baseUrl": "https://api.xiaomimimo.com/anthropic",
+			"baseUrl": "https://api.xiaomimimo.com/v1",
 			"reasoning": true,
 			"input": [
 				"text"
@@ -71798,10 +71826,17 @@
 			},
 			"contextWindow": 1048576,
 			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false
+			},
 			"thinking": {
-				"mode": "budget",
+				"mode": "effort",
 				"minLevel": "minimal",
-				"maxLevel": "xhigh"
+				"maxLevel": "high"
 			}
 		}
 	},

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -2643,9 +2643,16 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS: readonly ModelsDevProviderDe
 	// --- zAI ---
 	anthropicMessagesDescriptor("zai-coding-plan", "zai", "https://api.z.ai/api/anthropic"),
 	// --- Xiaomi ---
-	anthropicMessagesDescriptor("xiaomi", "xiaomi", "https://api.xiaomimimo.com/anthropic", {
+	openAiCompletionsDescriptor("xiaomi", "xiaomi", "https://api.xiaomimimo.com/v1", {
 		defaultContextWindow: 262144,
 		defaultMaxTokens: 8192,
+		compat: {
+			supportsStore: false,
+			thinkingFormat: "zai",
+			reasoningContentField: "reasoning_content",
+			requiresReasoningContentForToolCalls: true,
+			allowsSyntheticReasoningContentForToolCalls: false,
+		},
 	}),
 	// --- MiniMax Coding Plan ---
 	openAiCompletionsDescriptor("minimax-coding-plan", "minimax-code", "https://api.minimax.io/v1", {


### PR DESCRIPTION
The `models.dev` upstream returns Xiaomi models; the descriptor was set to `anthropicMessagesDescriptor` causing every `bun run generate-models` to regenerate `models.json` with `api=anthropic-messages` and `baseUrl=/anthropic`, overwriting the intentional switch to OpenAI Chat Completions API from [PR #1336](https://github.com/can1357/oh-my-pi/pull/1336).

Changed to `openAiCompletionsDescriptor("/v1")` so Xiaomi models consistently use the OpenAI-compatible endpoint that supports `reasoning_effort`, avoids the unsigned thinking-signature leak problem, and matches how Kilo, OpenRouter, NanoGPT, and ZenMux route Xiaomi traffic.

**Changes:**
- `openai-compat.ts`: `anthropicMessagesDescriptor` → `openAiCompletionsDescriptor` with `/v1` baseUrl
- `models.json`: regenerated via `bun run generate-models`, xiaomi/* models now use `api=openai-completions`, `baseUrl=https://api.xiaomimimo.com/v1`