### PR TITLE
fix(agent): compaction reasoning effort — fallback to off when reasoning unsupported

### DIFF
--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -969,6 +969,12 @@ export async function compact(
 		metadata: options?.metadata,
 		convertToLlm: options?.convertToLlm,
 		telemetry: options?.telemetry,
+		// Honor /model thinking selection on every fan-out summarizer.
+		// Without this propagation, generateSummary / generateTurnPrefixSummary
+		// see options?.thinkingLevel === undefined and resolveCompactionEffort
+		// silently falls back to Effort.High — the same defect e07b47ee4 fixed
+		// at the call sites, leaked back in here. See resolveCompactionEffort.
+		thinkingLevel: options?.thinkingLevel,
 	};
 
 	let preserveData = withOpenAiRemoteCompactionPreserveData(previousPreserveData, undefined);
@@ -1059,6 +1065,9 @@ export async function compact(
 			initiatorOverride: summaryOptions.initiatorOverride,
 			metadata: summaryOptions.metadata,
 			telemetry: summaryOptions.telemetry,
+			// Same propagation as summaryOptions above — generateShortSummary
+			// resolves its own reasoning via resolveCompactionEffort.
+			thinkingLevel: options?.thinkingLevel,
 		},
 	);
 

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -7,6 +7,7 @@
 
 import {
 	type AssistantMessage,
+	clampThinkingLevelForModel,
 	Effort,
 	type Message,
 	type MessageAttribution,
@@ -16,6 +17,7 @@ import {
 import { countTokens } from "@oh-my-pi/pi-natives";
 import { logger, prompt } from "@oh-my-pi/pi-utils";
 import { type AgentTelemetry, instrumentedCompleteSimple } from "../telemetry";
+import { ThinkingLevel } from "../thinking";
 import type { AgentMessage, AgentTool } from "../types";
 import type { CompactionEntry, SessionEntry } from "./entries";
 import { type ConvertToLlm, convertToLlm, createBranchSummaryMessage, createCustomMessage } from "./messages";
@@ -503,6 +505,52 @@ function formatAdditionalContext(context: string[] | undefined): string {
 }
 
 /**
+ * Maps the non-special `ThinkingLevel` values to their `Effort` counterparts.
+ * Exhaustive over the union; throws for `Off`/`Inherit` to surface logic
+ * errors in callers that forgot to filter those out. Never use a TS cast for
+ * this — `ThinkingLevel` is a string-union over distinct concepts (Off /
+ * Inherit are not Efforts), and a cast hides the contract.
+ */
+function effortFromThinkingLevel(level: ThinkingLevel): Effort {
+	switch (level) {
+		case ThinkingLevel.Minimal:
+			return Effort.Minimal;
+		case ThinkingLevel.Low:
+			return Effort.Low;
+		case ThinkingLevel.Medium:
+			return Effort.Medium;
+		case ThinkingLevel.High:
+			return Effort.High;
+		case ThinkingLevel.XHigh:
+			return Effort.XHigh;
+		case ThinkingLevel.Off:
+		case ThinkingLevel.Inherit:
+			throw new Error(`effortFromThinkingLevel: ${level} must be handled by caller`);
+	}
+}
+
+/**
+ * Resolves the reasoning effort to send on a compaction LLM call.
+ *
+ * - Explicit `Off` → `undefined` (omit reasoning entirely; the user said no thinking).
+ * - `undefined` / `Inherit` → historical `Effort.High` default → clamped per model
+ *   (preserves current behavior for users who never touched the dial).
+ * - Explicit effort → respect user choice → clamped per model.
+ *
+ * The clamp routes through `clampThinkingLevelForModel`, which returns
+ * `undefined` for models with `compat.supportsReasoningEffort: false`
+ * (e.g. `xai-oauth/grok-build`). That `undefined` then flows through to the
+ * openai-responses mapper where `modelOmitsReasoningEffort` short-circuits
+ * the wire param — no `requireSupportedEffort` throw.
+ */
+function resolveCompactionEffort(model: Model, level: ThinkingLevel | undefined): Effort | undefined {
+	if (level === ThinkingLevel.Off) return undefined;
+	const requested: Effort =
+		level === undefined || level === ThinkingLevel.Inherit ? Effort.High : effortFromThinkingLevel(level);
+	return clampThinkingLevelForModel(model, requested);
+}
+
+/**
  * Generate a summary of the conversation using the LLM.
  * If previousSummary is provided, uses the update prompt to merge.
  */
@@ -521,6 +569,15 @@ export interface SummaryOptions {
 	 * or `compaction_turn_prefix`). `undefined` keeps the call paths zero-cost.
 	 */
 	telemetry?: AgentTelemetry;
+	/**
+	 * Active session thinking level. Threaded from `agent-session.ts` so
+	 * compaction honors the user's `/model` thinking selection instead of
+	 * silently overriding it with `Effort.High` (the historical default).
+	 * `undefined` / `ThinkingLevel.Inherit` falls back to that historical
+	 * default; `ThinkingLevel.Off` omits reasoning entirely. See
+	 * `resolveCompactionEffort` for the conversion contract.
+	 */
+	thinkingLevel?: ThinkingLevel;
 }
 
 export async function generateSummary(
@@ -584,7 +641,7 @@ export async function generateSummary(
 			maxTokens,
 			signal,
 			apiKey,
-			reasoning: Effort.High,
+			reasoning: resolveCompactionEffort(model, options?.thinkingLevel),
 			initiatorOverride: options?.initiatorOverride,
 			metadata: options?.metadata,
 		},
@@ -621,6 +678,13 @@ export interface HandoffOptions {
 	 * wrapped in an OTEL chat span tagged with `pi.gen_ai.oneshot.kind = "handoff"`.
 	 */
 	telemetry?: AgentTelemetry;
+	/**
+	 * Active session thinking level. Threaded from `agent-session.ts` so
+	 * handoff generation honors the user's `/model` thinking selection
+	 * instead of silently overriding it with `Effort.High`. See
+	 * `resolveCompactionEffort` for the conversion contract.
+	 */
+	thinkingLevel?: ThinkingLevel;
 }
 
 export function renderHandoffPrompt(customInstructions?: string): string {
@@ -658,7 +722,7 @@ export async function generateHandoff(
 		{
 			apiKey,
 			signal,
-			reasoning: Effort.High,
+			reasoning: resolveCompactionEffort(model, options.thinkingLevel),
 			toolChoice: "none",
 			initiatorOverride: options.initiatorOverride,
 			metadata: options.metadata,
@@ -718,7 +782,7 @@ async function generateShortSummary(
 			maxTokens,
 			signal,
 			apiKey,
-			reasoning: Effort.High,
+			reasoning: resolveCompactionEffort(model, options?.thinkingLevel),
 			initiatorOverride: options?.initiatorOverride,
 			metadata: options?.metadata,
 		},
@@ -1047,7 +1111,7 @@ async function generateTurnPrefixSummary(
 			maxTokens,
 			signal,
 			apiKey,
-			reasoning: Effort.High,
+			reasoning: resolveCompactionEffort(model, options?.thinkingLevel),
 			initiatorOverride: options?.initiatorOverride,
 			metadata: options?.metadata,
 		},

--- a/packages/agent/test/compaction-thinking-level.test.ts
+++ b/packages/agent/test/compaction-thinking-level.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, test, vi } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { generateHandoff } from "@oh-my-pi/pi-agent-core/compaction";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core/thinking";
+import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
+import * as ai from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-ai/models";
+
+// Pins fix #1 of the compaction effort-override bug. Before this fix,
+// `generateHandoff` (and the three other compaction summarizers) hardcoded
+// `reasoning: Effort.High`, ignoring the user's `/model` thinking selection.
+// On a model with `compat.supportsReasoningEffort: false` (xai-oauth/grok-build),
+// this produced "Compaction failed: Thinking effort high is not supported by
+// xai-oauth/grok-build" — but the underlying defect (silent user-intent
+// override) was present on every model, just invisible because most models
+// silently accept the override.
+//
+// `resolveCompactionEffort` is the per-call resolver:
+// - `Off`              → `undefined` (user said no thinking; honored)
+// - `undefined`/`Inherit` → `Effort.High` default → clamped per model
+// - explicit Effort    → respect it → clamped per model
+//
+// `generateHandoff` is chosen as the test vehicle because it issues exactly
+// one LLM call per invocation (simpler to assert than `compact()` which fans
+// out into summary + short-summary + turn-prefix). The contract under test
+// (`resolveCompactionEffort`) is shared across all four call sites in
+// `packages/agent/src/compaction/compaction.ts`.
+
+function createAssistantMessage(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		timestamp: Date.now(),
+		provider: "mock",
+		model: "mock",
+		api: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+	};
+}
+
+function getAnthropicModel(): Model {
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected built-in anthropic/claude-sonnet-4-5 to exist");
+	return model;
+}
+
+function getGrokBuildModel(): Model {
+	const model = getBundledModel("xai-oauth", "grok-build");
+	if (!model) throw new Error("Expected built-in xai-oauth/grok-build to exist");
+	return model;
+}
+
+const messages: AgentMessage[] = [
+	{ role: "user", content: "start work", timestamp: 1 },
+	createAssistantMessage([{ type: "text", text: "started" }]),
+];
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("compaction thinking-level resolution (regression)", () => {
+	test("undefined thinkingLevel on Anthropic → reasoning=high (historical default preserved)", async () => {
+		const spy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValue(createAssistantMessage([{ type: "text", text: "handoff" }]));
+		await generateHandoff(messages, getAnthropicModel(), "test-key", {
+			systemPrompt: ["sp"],
+			tools: [],
+			// thinkingLevel omitted — must default to high
+		});
+		const call = spy.mock.calls[0];
+		if (!call) throw new Error("expected completeSimple call");
+		expect(call[2]?.reasoning).toBe(ai.Effort.High);
+	});
+
+	test("ThinkingLevel.Off on Anthropic → reasoning=undefined (user intent honored)", async () => {
+		const spy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValue(createAssistantMessage([{ type: "text", text: "handoff" }]));
+		await generateHandoff(messages, getAnthropicModel(), "test-key", {
+			systemPrompt: ["sp"],
+			tools: [],
+			thinkingLevel: ThinkingLevel.Off,
+		});
+		const call = spy.mock.calls[0];
+		if (!call) throw new Error("expected completeSimple call");
+		// Codex-caught defect: Off MUST NOT be silently coerced to High.
+		expect(call[2]?.reasoning).toBeUndefined();
+	});
+
+	test("ThinkingLevel.Low on Anthropic → reasoning=low (explicit user choice)", async () => {
+		const spy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValue(createAssistantMessage([{ type: "text", text: "handoff" }]));
+		await generateHandoff(messages, getAnthropicModel(), "test-key", {
+			systemPrompt: ["sp"],
+			tools: [],
+			thinkingLevel: ThinkingLevel.Low,
+		});
+		const call = spy.mock.calls[0];
+		if (!call) throw new Error("expected completeSimple call");
+		expect(call[2]?.reasoning).toBe(ai.Effort.Low);
+	});
+
+	test("ThinkingLevel.High on xai-oauth/grok-build → reasoning=undefined (clamp)", async () => {
+		const spy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValue(createAssistantMessage([{ type: "text", text: "handoff" }]));
+		await generateHandoff(messages, getGrokBuildModel(), "test-key", {
+			systemPrompt: ["sp"],
+			tools: [],
+			thinkingLevel: ThinkingLevel.High,
+		});
+		const call = spy.mock.calls[0];
+		if (!call) throw new Error("expected completeSimple call");
+		// clampThinkingLevelForModel(grokBuild, High) === undefined because
+		// supportsReasoningEffort: false ⇒ getSupportedEfforts returns [] ⇒
+		// no clamp target. The omitReasoningEffort gate at the wire layer is
+		// the actual strip; this just ensures the upstream throw doesn't fire.
+		expect(call[2]?.reasoning).toBeUndefined();
+	});
+
+	test("ThinkingLevel.Inherit on Anthropic → reasoning=high (Inherit folds to historical default)", async () => {
+		const spy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValue(createAssistantMessage([{ type: "text", text: "handoff" }]));
+		await generateHandoff(messages, getAnthropicModel(), "test-key", {
+			systemPrompt: ["sp"],
+			tools: [],
+			thinkingLevel: ThinkingLevel.Inherit,
+		});
+		const call = spy.mock.calls[0];
+		if (!call) throw new Error("expected completeSimple call");
+		expect(call[2]?.reasoning).toBe(ai.Effort.High);
+	});
+});

--- a/packages/agent/test/compaction-thinking-level.test.ts
+++ b/packages/agent/test/compaction-thinking-level.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, describe, expect, test, vi } from "bun:test";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
-import { generateHandoff } from "@oh-my-pi/pi-agent-core/compaction";
+import {
+	type CompactionPreparation,
+	compact,
+	createFileOps,
+	DEFAULT_COMPACTION_SETTINGS,
+	generateHandoff,
+} from "@oh-my-pi/pi-agent-core/compaction";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core/thinking";
 import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
 import * as ai from "@oh-my-pi/pi-ai";
@@ -141,5 +147,108 @@ describe("compaction thinking-level resolution (regression)", () => {
 		const call = spy.mock.calls[0];
 		if (!call) throw new Error("expected completeSimple call");
 		expect(call[2]?.reasoning).toBe(ai.Effort.High);
+	});
+});
+
+// ============================================================================
+// compact() end-to-end regression coverage.
+//
+// The handoff tests above were the test vehicle e07b47ee4 used because handoff
+// issues exactly one LLM call. They prove `resolveCompactionEffort` works at
+// each call site in isolation. They do NOT prove `compact()` forwards
+// `options.thinkingLevel` into the fan-out struct (`summaryOptions`) that
+// reaches generateSummary / generateTurnPrefixSummary / generateShortSummary.
+// That gap is what dropped the field at compaction.ts:963 and 1056 — every
+// downstream summarizer saw `undefined` and fell back to Effort.High.
+//
+// These tests drive compact() with `isSplitTurn: true` so all three
+// summarizers fire, then assert the captured `reasoning` on each
+// `completeSimple` call. The contract is: every fan-out call receives the
+// SAME resolved effort as a single handoff call would.
+// ============================================================================
+
+function makeUserMessage(text: string, timestamp = Date.now()): AgentMessage {
+	return { role: "user", content: text, timestamp };
+}
+
+function makePreparation(overrides: Partial<CompactionPreparation> = {}): CompactionPreparation {
+	return {
+		firstKeptEntryId: "kept-1",
+		messagesToSummarize: [
+			makeUserMessage("history msg"),
+			createAssistantMessage([{ type: "text", text: "history reply" }]),
+		],
+		turnPrefixMessages: [makeUserMessage("turn prefix msg")],
+		recentMessages: [makeUserMessage("recent msg")],
+		isSplitTurn: true,
+		tokensBefore: 12_345,
+		fileOps: createFileOps(),
+		settings: { ...DEFAULT_COMPACTION_SETTINGS, remoteEnabled: false },
+		...overrides,
+	};
+}
+
+describe("compact() propagates thinkingLevel to all three summarizers (regression)", () => {
+	test("ThinkingLevel.Off → every fan-out call gets reasoning=undefined", async () => {
+		const spy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValue(createAssistantMessage([{ type: "text", text: "summary" }]));
+
+		await compact(makePreparation(), getAnthropicModel(), "test-key", undefined, undefined, {
+			thinkingLevel: ThinkingLevel.Off,
+		});
+
+		// Split-turn preparation fans out into history + turn-prefix + short.
+		expect(spy).toHaveBeenCalledTimes(3);
+		for (const [, , opts] of spy.mock.calls) {
+			expect(opts?.reasoning).toBeUndefined();
+		}
+	});
+
+	test("ThinkingLevel.Low → every fan-out call gets reasoning=low", async () => {
+		const spy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValue(createAssistantMessage([{ type: "text", text: "summary" }]));
+
+		await compact(makePreparation(), getAnthropicModel(), "test-key", undefined, undefined, {
+			thinkingLevel: ThinkingLevel.Low,
+		});
+
+		expect(spy).toHaveBeenCalledTimes(3);
+		for (const [, , opts] of spy.mock.calls) {
+			expect(opts?.reasoning).toBe(ai.Effort.Low);
+		}
+	});
+
+	test("undefined thinkingLevel → every fan-out call still gets reasoning=high (historical default)", async () => {
+		const spy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValue(createAssistantMessage([{ type: "text", text: "summary" }]));
+
+		await compact(makePreparation(), getAnthropicModel(), "test-key", undefined, undefined);
+
+		expect(spy).toHaveBeenCalledTimes(3);
+		for (const [, , opts] of spy.mock.calls) {
+			expect(opts?.reasoning).toBe(ai.Effort.High);
+		}
+	});
+
+	test("xai-oauth/grok-build + ThinkingLevel.High → every fan-out call gets reasoning=undefined (clamp)", async () => {
+		const spy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValue(createAssistantMessage([{ type: "text", text: "summary" }]));
+
+		await compact(makePreparation(), getGrokBuildModel(), "test-key", undefined, undefined, {
+			thinkingLevel: ThinkingLevel.High,
+		});
+
+		expect(spy).toHaveBeenCalledTimes(3);
+		for (const [, , opts] of spy.mock.calls) {
+			// Without the propagation fix at compaction.ts:971 / 1061, the
+			// three summarizers would see undefined → fall back to High and
+			// trip requireSupportedEffort. The fix + the wire-side strip in
+			// fix #2 keep this clean.
+			expect(opts?.reasoning).toBeUndefined();
+		}
 	});
 });

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -199,6 +199,28 @@ export function linkOpenAIPromotionTargets(models: ApiModel<Api>[]): void {
 }
 
 /**
+ * True when the model reasons natively but rejects the wire `reasoning.effort`
+ * param (compat.supportsReasoningEffort: false on openai-responses*). Callers
+ * are expected to omit the effort field; the wire-side omitReasoningEffort
+ * gate (providers/xai-responses.ts:78) is the actual strip, and this
+ * predicate is the upstream check that prevents a redundant
+ * requireSupportedEffort throw from defeating that gate.
+ *
+ * Scoped to openai-responses* because that's the only API surface where
+ * `compat.supportsReasoningEffort: false` is meaningful today. The
+ * `in`-narrowed access is necessary because Model.compat is
+ * `AnthropicCompat | OpenAICompat` and the api gate doesn't narrow the
+ * union for TS.
+ */
+export function modelOmitsReasoningEffort<TApi extends Api>(model: ApiModel<TApi>): boolean {
+	if (model.api !== "openai-responses" && model.api !== "openai-codex-responses") {
+		return false;
+	}
+	const compat = model.compat;
+	return Boolean(compat && "supportsReasoningEffort" in compat && compat.supportsReasoningEffort === false);
+}
+
+/**
  * Returns the supported thinking efforts declared on the model metadata.
  *
  * Catalog enrichment is responsible for normalizing bundled model metadata up front.
@@ -209,6 +231,16 @@ export function linkOpenAIPromotionTargets(models: ApiModel<Api>[]): void {
  */
 export function getSupportedEfforts<TApi extends Api>(model: ApiModel<TApi>): readonly Effort[] {
 	if (!model.reasoning) {
+		return [];
+	}
+	// Models that reason natively but reject the `reasoning.effort` wire param
+	// (xAI Grok off the GROK_EFFORT_CAPABLE_PREFIXES allowlist in
+	// providers/xai-responses.ts: grok-build, grok-4.20-0309-reasoning) hide the
+	// picker's effort dial. Scoped to openai-responses* by
+	// `modelOmitsReasoningEffort` — openai-completions has its own
+	// supportsReasoningEffort consultation at inferFallbackEfforts L536 and
+	// changing that path's semantics is out-of-scope.
+	if (modelOmitsReasoningEffort(model)) {
 		return [];
 	}
 	if (!model.thinking) {

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -7,6 +7,7 @@ import type { Effort } from "./model-thinking";
 import {
 	mapEffortToAnthropicAdaptiveEffort,
 	mapEffortToGoogleThinkingLevel,
+	modelOmitsReasoningEffort,
 	requireSupportedEffort,
 } from "./model-thinking";
 import type { BedrockOptions } from "./providers/amazon-bedrock";
@@ -567,6 +568,14 @@ function resolveOpenAiReasoningEffort<TApi extends Api>(
 ): Effort | undefined {
 	const reasoning = options?.reasoning;
 	if (!reasoning || !model.reasoning) return undefined;
+	// Models with compat.supportsReasoningEffort: false reason natively but
+	// reject the wire effort param. The wire-side omitReasoningEffort gate
+	// (providers/xai-responses.ts:78) is the actual strip; returning
+	// undefined here avoids a redundant requireSupportedEffort throw that
+	// would defeat the gate and surface a confusing
+	// "Compaction failed: Thinking effort high is not supported by..." to
+	// the user.
+	if (modelOmitsReasoningEffort(model)) return undefined;
 	return requireSupportedEffort(model, reasoning);
 }
 

--- a/packages/ai/test/xai-oauth-effort-strip.test.ts
+++ b/packages/ai/test/xai-oauth-effort-strip.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { getBundledModel } from "@oh-my-pi/pi-ai/models";
+import { modelOmitsReasoningEffort } from "../src/model-thinking";
+
+// Pins fix #2 of the compaction effort-override bug. Before this fix,
+// `resolveOpenAiReasoningEffort` called `requireSupportedEffort` which threw
+// for any model with `compat.supportsReasoningEffort: false` (e.g.
+// `xai-oauth/grok-build`) — producing the user-visible "Compaction failed:
+// Thinking effort high is not supported by xai-oauth/grok-build. Supported
+// efforts:" (empty list). The fix routes through the explicit
+// `modelOmitsReasoningEffort` predicate, which lets the wire-side
+// `omitReasoningEffort` gate (providers/xai-responses.ts:78) remain the
+// single source of truth for the actual strip.
+describe("modelOmitsReasoningEffort (regression)", () => {
+	test("returns true for xai-oauth/grok-build (supportsReasoningEffort: false)", () => {
+		const grokBuild = getBundledModel("xai-oauth", "grok-build");
+		if (!grokBuild) throw new Error("xai-oauth/grok-build must be in bundled models.json");
+		expect(modelOmitsReasoningEffort(grokBuild)).toBe(true);
+	});
+
+	test("returns false for xai-oauth/grok-4.3 (effort-capable)", () => {
+		const grok43 = getBundledModel("xai-oauth", "grok-4.3");
+		if (!grok43) throw new Error("xai-oauth/grok-4.3 must be in bundled models.json");
+		expect(modelOmitsReasoningEffort(grok43)).toBe(false);
+	});
+
+	test("returns true for xai-oauth/grok-4.20-0309-reasoning (supportsReasoningEffort: false)", () => {
+		const grokR = getBundledModel("xai-oauth", "grok-4.20-0309-reasoning");
+		if (!grokR) throw new Error("xai-oauth/grok-4.20-0309-reasoning must be in bundled models.json");
+		expect(modelOmitsReasoningEffort(grokR)).toBe(true);
+	});
+
+	test("returns false for an Anthropic model (different api surface)", () => {
+		const claude = getBundledModel("anthropic", "claude-sonnet-4-6");
+		if (!claude) throw new Error("anthropic/claude-sonnet-4-6 must be in bundled models.json");
+		expect(modelOmitsReasoningEffort(claude)).toBe(false);
+	});
+
+	test("returns false for an openai-completions model (out of scope)", () => {
+		const openai = getBundledModel("openai", "gpt-4o-mini");
+		if (!openai) throw new Error("openai/gpt-4o-mini must be in bundled models.json");
+		// gpt-4o-mini is openai-completions, not openai-responses* — predicate
+		// must return false even if compat had supportsReasoningEffort: false.
+		expect(modelOmitsReasoningEffort(openai)).toBe(false);
+	});
+});

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5575,6 +5575,11 @@ export class AgentSession {
 					initiatorOverride: "agent",
 					metadata: this.agent.metadataForProvider(model.provider),
 					telemetry: resolveTelemetry(this.agent.telemetry, this.sessionId),
+					// Honor the user's /model thinking selection on the handoff
+					// path. Clamped per-model inside generateHandoff via
+					// resolveCompactionEffort so unsupported-effort models don't
+					// trip requireSupportedEffort.
+					thinkingLevel: this.thinkingLevel,
 				},
 				handoffSignal,
 			);
@@ -6345,6 +6350,11 @@ export class AgentSession {
 					metadata: this.agent.metadataForProvider(candidate.provider),
 					convertToLlm,
 					telemetry,
+					// Honor the user's /model thinking selection (incl. `off`) on
+					// the manual `/compact` path. Clamped per-model inside compact()
+					// via resolveCompactionEffort so unsupported-effort models
+					// (xai-oauth/grok-build) don't trip requireSupportedEffort.
+					thinkingLevel: this.thinkingLevel,
 				});
 			} catch (error) {
 				if (!this.#isCompactionAuthFailure(error)) {
@@ -6617,6 +6627,11 @@ export class AgentSession {
 								initiatorOverride: "agent",
 								convertToLlm,
 								telemetry,
+								// Honor the user's /model thinking selection on the
+								// auto-compaction path — the most-fired compaction
+								// site. Clamped per-model inside compact() via
+								// resolveCompactionEffort.
+								thinkingLevel: this.thinkingLevel,
 							});
 							break;
 						} catch (error) {

--- a/packages/coding-agent/test/agent-session-compaction-thinking-threading.test.ts
+++ b/packages/coding-agent/test/agent-session-compaction-thinking-threading.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test";
+
+// Audit gate for the compaction-effort fix. The plan calls out three
+// production call sites in `agent-session.ts` that MUST thread
+// `thinkingLevel: this.thinkingLevel` into the compaction LLM options:
+//
+//   - `compact(...)` at the manual `/compact` site (`#compactWithFallbackModel`)
+//   - `compact(...)` at the auto-compaction site (the most-fired path)
+//   - `generateHandoff(...)` at the handoff site
+//
+// `SummaryOptions.thinkingLevel` is optional, so a future contributor adding
+// a new `compact(...)` or `generateHandoff(...)` call without threading it
+// would silently fall back to the historical `Effort.High` default — exactly
+// the regression Codex caught during plan review (auto-compaction was
+// initially missed). The typecheck won't catch this; this test does.
+
+const AGENT_SESSION_PATH = `${import.meta.dir}/../src/session/agent-session.ts`;
+
+// Lines that are NOT direct LLM call sites and don't need threading:
+// - The `async compact(...)` method declaration itself.
+// - `this.compact(...)` invocations that route through the method (and from
+//   there into the threaded `#compactWithFallbackModel`).
+const NON_LLM_CALL_PATTERNS = [
+	/async compact\(customInstructions/, // method declaration
+	/await this\.compact\(/, // self-invocation routes to threaded site
+];
+
+interface CallSite {
+	line: number;
+	headerLine: string;
+	callExpression: string;
+}
+
+/**
+ * Scan source for `compact(` / `generateHandoff(` and extract the
+ * brace-balanced call expression for each match. Skips comments,
+ * string contents, and non-LLM lines (method declarations, self-calls).
+ */
+function findCompactionCallSites(src: string): CallSite[] {
+	const lines = src.split("\n");
+	const sites: CallSite[] = [];
+
+	for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
+		const line = lines[lineIdx];
+		if (!line) continue;
+		const headerMatch = /\b(compact|generateHandoff)\(/.exec(line);
+		if (!headerMatch) continue;
+		if (NON_LLM_CALL_PATTERNS.some(rx => rx.test(line))) continue;
+		// Skip lines that are themselves comments
+		const trimmed = line.trim();
+		if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) continue;
+
+		// Compute absolute offset of the opening `(` after the matched name
+		let offset = 0;
+		for (let l = 0; l < lineIdx; l++) {
+			offset += (lines[l]?.length ?? 0) + 1; // +1 for newline
+		}
+		const openParenIdx = offset + headerMatch.index + headerMatch[0].length - 1;
+
+		// Walk forward, balancing parens. Track string / comment context to
+		// avoid counting `(`/`)` inside literals.
+		let depth = 0;
+		let i = openParenIdx;
+		let inString: '"' | "'" | "`" | null = null;
+		let inLineComment = false;
+		let inBlockComment = false;
+		let end = -1;
+		for (; i < src.length; i++) {
+			const ch = src[i];
+			const next = src[i + 1];
+
+			if (inLineComment) {
+				if (ch === "\n") inLineComment = false;
+				continue;
+			}
+			if (inBlockComment) {
+				if (ch === "*" && next === "/") {
+					inBlockComment = false;
+					i++;
+				}
+				continue;
+			}
+			if (inString) {
+				if (ch === "\\") {
+					i++;
+					continue;
+				}
+				if (ch === inString) inString = null;
+				continue;
+			}
+			if (ch === "/" && next === "/") {
+				inLineComment = true;
+				continue;
+			}
+			if (ch === "/" && next === "*") {
+				inBlockComment = true;
+				i++;
+				continue;
+			}
+			if (ch === '"' || ch === "'" || ch === "`") {
+				inString = ch;
+				continue;
+			}
+			if (ch === "(") depth++;
+			else if (ch === ")") {
+				depth--;
+				if (depth === 0) {
+					end = i;
+					break;
+				}
+			}
+		}
+
+		if (end === -1) {
+			throw new Error(`Unterminated call expression at agent-session.ts:${lineIdx + 1}`);
+		}
+
+		sites.push({
+			line: lineIdx + 1,
+			headerLine: line.trim(),
+			callExpression: src.slice(openParenIdx + 1, end),
+		});
+	}
+
+	return sites;
+}
+
+function expressionThreadsThinkingLevel(callExpression: string): boolean {
+	// `thinkingLevel:` must appear as a property key — i.e. preceded by `{`
+	// or `,` or whitespace + `,` or start of expression, and followed by a
+	// value. Loose check via the substring is sufficient because the call
+	// expression is brace-balanced (we extracted only one call's contents).
+	// We also require the value to be the session field, to defend against
+	// `thinkingLevel: undefined` accidentally satisfying the gate.
+	return /\bthinkingLevel\s*:\s*this\.thinkingLevel\b/.test(callExpression);
+}
+
+describe("agent-session.ts compaction threading (audit gate)", () => {
+	test("every direct compact()/generateHandoff() call threads thinkingLevel: this.thinkingLevel", async () => {
+		const src = await Bun.file(AGENT_SESSION_PATH).text();
+		const sites = findCompactionCallSites(src);
+		const offenders = sites.filter(s => !expressionThreadsThinkingLevel(s.callExpression));
+
+		expect(
+			offenders,
+			`Found ${offenders.length} compaction call site(s) missing 'thinkingLevel: this.thinkingLevel':\n${offenders
+				.map(o => `  agent-session.ts:${o.line} — ${o.headerLine}`)
+				.join(
+					"\n",
+				)}\n\nFix: add 'thinkingLevel: this.thinkingLevel' to the options object on every direct compact()/generateHandoff() call. The historical Effort.High default lives in resolveCompactionEffort (packages/agent/src/compaction/compaction.ts) and applies when thinkingLevel is undefined.`,
+		).toEqual([]);
+	});
+
+	test("at least 3 threaded sites exist (manual /compact + auto-compaction + handoff)", async () => {
+		const src = await Bun.file(AGENT_SESSION_PATH).text();
+		const sites = findCompactionCallSites(src);
+		const threaded = sites.filter(s => expressionThreadsThinkingLevel(s.callExpression));
+		// Floor at 3 — the plan explicitly enumerates three sites. If the
+		// production surface grows new entry points, the first test fails
+		// until they thread too; this guards against accidental removal of
+		// any of the original three. Count is derived from the same
+		// brace-balanced scanner as the offender check above.
+		expect(threaded.length).toBeGreaterThanOrEqual(3);
+	});
+});


### PR DESCRIPTION
## Problem

Triple-stacked failure whenever the active model was a curated xAI catalog entry with `compat.supportsReasoningEffort: false` (e.g. `xai-oauth/grok-build`):

```
Error: Compaction failed: Thinking effort high is not supported by
       xai-oauth/grok-build. Supported efforts:
```
(empty list after the colon)

## Root causes

Three defects lined up on the same axis:

1. **Behavior** — four call sites in `compaction.ts` hardcoded `reasoning: Effort.High` and never threaded `session.thinkingLevel`. The user's `/model :off` selection (and any explicit low/medium) was silently overridden on every compaction.

2. **Validation** — `requireSupportedEffort` threw at the openai-flavored mapper layer *before* the wire-side `omitReasoningEffort` gate in `providers/xai-responses.ts` ever ran; two contradictory guards on the same wire param.

3. **Message** — when `getSupportedEfforts` returned `[]`, the rendered error tail was `Supported efforts: ` with nothing after the colon — disappears as a side-effect of fix #2.

## Fix

Cherry-picked from `OutlineDriven:feat/xai-grok-oauth` (original authors: `cognitive`/METAeuPHORIC):
- `e07b47ee4` — adds `resolveCompactionEffort` helper with exhaustive three-way switch, exports `modelOmitsReasoningEffort` predicate, threads `thinkingLevel` through all four summarizer call sites, inserts mapper-layer early-return.
- `9b501e369` — fixes follow-up bug where `compact()` dropped `thinkingLevel` during field-by-field option rebuild.

### Effort resolution after this fix

| Session setting | Wire value |
|---|---|
| Off (`/model :off`) | `undefined` (field omitted) |
| Unset / Inherit | `Effort.High` → clamp per model |
| Explicit Low/Medium/High | respect → clamp per model |

## Files changed

- `packages/agent/src/compaction/compaction.ts` — `resolveCompactionEffort`, `effortFromThinkingLevel`, four call-site patches, `compact()` rebuild fix
- `packages/coding-agent/src/session/agent-session.ts` — threads `this.thinkingLevel` into three production entry points (manual `/compact`, auto-compaction, direct `generateHandoff`)
- `packages/ai/src/model-thinking.ts` — exports `modelOmitsReasoningEffort<TApi>` (conflict resolved against upstream changes to effort-resolution logic)
- `packages/ai/src/stream.ts` — early-return in effort mapper for models that omit the effort field

New test files:
- `packages/agent/test/compaction-thinking-level.test.ts` — Off / Low / unset / grok-build+High→undefined cases
- `packages/ai/test/xai-oauth-effort-strip.test.ts` — mapper-layer strip
- `packages/coding-agent/test/agent-session-compaction-thinking-threading.test.ts` — audit-gate refusing unthreaded call sites

## ⚠️ Known test failures (catalog dependency)

5 tests reference `getBundledModel("xai-oauth", "grok-build")` and siblings. These fail because `xai-oauth` is not yet in `packages/ai/src/models.json` on `main`. The production code and all non-xai-oauth tests pass. These tests will pass once the xAI Grok OAuth stabilization PR (which adds the `xai-oauth` curated catalog) merges.

**Suggested merge order:** xAI Grok OAuth stabilization PR #1446 → this PR.

## Layering

`packages/ai` does not import from `packages/agent` — dependency goes downward only.