### PR TITLE
fix(coding-agent): reopen approved plan on plan-mode reentry

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 - `generate_image` supports xAI Grok Imagine via `providers.image=xai`. Supports `grok-imagine-image` (default) and `grok-imagine-image-quality` at aspect ratios `1:1`, `16:9`, `9:16`, `4:3`, `3:4`, `3:2`, `2:3`. Uses the xAI Grok OAuth credential when available, otherwise `XAI_API_KEY`.
 - New `tts` tool synthesises speech via xAI Grok Voice behind the disabled-by-default `tts.enabled` setting. Built-in voices `ara`, `eve` (default), `leo`, `rex`, `sal`; custom voice IDs also accepted. Output codec inferred from the `output_path` suffix (`.wav` → `wav`, else `mp3`). Up to 15,000 characters per request.
 
+### Fixed
+
+- Fixed plan-mode re-entry after approval reopening a fresh `local://PLAN.md` instead of the approved titled plan artifact, which could duplicate plan content and fail approval on an existing destination.
+
 ## [15.5.6] - 2026-05-27
 ### Added
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1012,7 +1012,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	}
 
 	async #getPlanFilePath(): Promise<string> {
-		return "local://PLAN.md";
+		return this.session.getPlanReferencePath() || "local://PLAN.md";
 	}
 
 	#resolvePlanFilePath(planFilePath: string): string {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3758,6 +3758,10 @@ export class AgentSession {
 		this.#planReferencePath = path;
 	}
 
+	getPlanReferencePath(): string {
+		return this.#planReferencePath;
+	}
+
 	get clientBridge(): ClientBridge | undefined {
 		return this.#clientBridge;
 	}

--- a/packages/coding-agent/src/tools/plan-mode-guard.ts
+++ b/packages/coding-agent/src/tools/plan-mode-guard.ts
@@ -5,6 +5,8 @@ import { normalizeLocalScheme, resolveToCwd } from "./path-utils";
 import { ToolError } from "./tool-errors";
 
 const LOCAL_SCHEME_PREFIX = "local:";
+const PLAN_ALIAS_FILE = "PLAN.md";
+const LOCAL_PLAN_ALIAS = "local://PLAN.md";
 
 function resolveRawPath(session: ToolSession, targetPath: string): string {
 	const normalized = normalizeLocalScheme(targetPath);
@@ -18,15 +20,20 @@ function resolveRawPath(session: ToolSession, targetPath: string): string {
 	return resolveToCwd(normalized, session.cwd);
 }
 
+function isPlanAliasTarget(session: ToolSession, targetPath: string, resolved: string): boolean {
+	const normalized = normalizeLocalScheme(targetPath);
+	if (normalized === LOCAL_PLAN_ALIAS) return true;
+	return resolved === resolveToCwd(PLAN_ALIAS_FILE, session.cwd);
+}
+
 /**
  * Resolve a write/edit target to its absolute filesystem path.
  *
- * In plan mode, transparently redirects targets whose basename matches the
- * plan file's basename (e.g. a bare `PLAN.md` or `./PLAN.md`) to the canonical
- * plan file location at `state.planFilePath`. This lets `write` and `edit`
- * accept the unqualified plan filename and have the change land at the
- * session-scoped `local://PLAN.md` artifact instead of a stray cwd-relative
- * file the plan-mode guard would otherwise reject.
+ * In plan mode, transparently redirects `PLAN.md` aliases and targets whose
+ * basename matches the plan file's basename to the canonical plan file
+ * location at `state.planFilePath`. This lets `write` and `edit` accept the
+ * habitual plan filename after approval even when the active artifact has a
+ * titled path such as `local://APPROVED.md`.
  *
  * Outside plan mode (or when the basename does not match) this is a no-op.
  */
@@ -38,6 +45,7 @@ export function resolvePlanPath(session: ToolSession, targetPath: string): strin
 
 	const planResolved = resolveRawPath(session, state.planFilePath);
 	if (resolved === planResolved) return resolved;
+	if (isPlanAliasTarget(session, targetPath, resolved)) return planResolved;
 	if (path.basename(resolved) !== path.basename(planResolved)) return resolved;
 
 	return planResolved;

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -204,6 +204,39 @@ describe("InteractiveMode plan review rendering", () => {
 		});
 	});
 
+	it("re-enters plan mode on the approved titled artifact after approve-and-execute", async () => {
+		const planFilePath = "local://PLAN.md";
+		const finalPlanFilePath = "local://APPROVED.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nExecute then edit.");
+
+		await mode.handlePlanModeCommand();
+
+		vi.spyOn(mode, "showHookSelector").mockResolvedValue("Approve and execute");
+		vi.spyOn(mode, "handleClearCommand").mockResolvedValue();
+		vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+
+		await mode.handlePlanApproval({
+			planFilePath,
+			planExists: true,
+			title: "APPROVED",
+			finalPlanFilePath,
+		});
+
+		expect(mode.planModeEnabled).toBe(false);
+		expect(session.getPlanReferencePath()).toBe(finalPlanFilePath);
+
+		await mode.handlePlanModeCommand();
+		expect(session.getPlanModeState()).toMatchObject({
+			enabled: true,
+			planFilePath: finalPlanFilePath,
+			reentry: true,
+		});
+	});
+
 	it("Approve and compact context: ok outcome dispatches plan-approved after compaction", async () => {
 		const planFilePath = "local://PLAN.md";
 		const finalPlanFilePath = "local://APPROVED.md";
@@ -459,6 +492,50 @@ describe("InteractiveMode plan review rendering", () => {
 
 		expect(markSpy).not.toHaveBeenCalled();
 		expect(session.isPlanCompactAbortPending).toBe(false);
+	});
+
+	it("re-enters plan mode on the approved titled artifact after approval", async () => {
+		const planFilePath = "local://PLAN.md";
+		const finalPlanFilePath = "local://APPROVED.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nKeep editing this artifact.");
+
+		await mode.handlePlanModeCommand();
+		expect(session.getPlanModeState()?.planFilePath).toBe(planFilePath);
+
+		const selector = vi.spyOn(mode, "showHookSelector").mockResolvedValue("Approve and keep context");
+		const showError = vi.spyOn(mode, "showError");
+		vi.spyOn(session, "prompt").mockResolvedValue(undefined as never);
+
+		await mode.handlePlanApproval({
+			planFilePath,
+			planExists: true,
+			title: "APPROVED",
+			finalPlanFilePath,
+		});
+
+		expect(mode.planModeEnabled).toBe(false);
+		expect(session.getPlanReferencePath()).toBe(finalPlanFilePath);
+
+		await mode.handlePlanModeCommand();
+		expect(session.getPlanModeState()).toMatchObject({
+			enabled: true,
+			planFilePath: finalPlanFilePath,
+			reentry: true,
+		});
+
+		await mode.handlePlanApproval({
+			planFilePath: finalPlanFilePath,
+			planExists: true,
+			title: "APPROVED",
+			finalPlanFilePath,
+		});
+
+		expect(selector).toHaveBeenCalledTimes(2);
+		expect(showError).not.toHaveBeenCalled();
 	});
 
 	// ==========================================================================

--- a/packages/coding-agent/test/tools/plan-mode-guard-local.test.ts
+++ b/packages/coding-agent/test/tools/plan-mode-guard-local.test.ts
@@ -45,6 +45,7 @@ describe("resolvePlanPath local:// support", () => {
 
 describe("resolvePlanPath plan-mode redirect", () => {
 	const planMode: PlanModeState = { enabled: true, planFilePath: "local://PLAN.md" };
+	const approvedPlanMode: PlanModeState = { enabled: true, planFilePath: "local://APPROVED.md" };
 
 	it("redirects bare PLAN.md to the session plan path when plan mode is active", () => {
 		const session = makeSession({ artifactsDir: "/tmp/agent-artifacts", planMode });
@@ -72,10 +73,20 @@ describe("resolvePlanPath plan-mode redirect", () => {
 		const session = makeSession({ artifactsDir: "/tmp/agent-artifacts", planMode });
 		expect(resolvePlanPath(session, "local://PLAN.md")).toBe(path.join("/tmp/agent-artifacts", "local", "PLAN.md"));
 	});
+
+	it("redirects PLAN.md aliases to the active titled plan artifact", () => {
+		const session = makeSession({ artifactsDir: "/tmp/agent-artifacts", cwd: "/repo", planMode: approvedPlanMode });
+		const expected = path.join("/tmp/agent-artifacts", "local", "APPROVED.md");
+		expect(resolvePlanPath(session, "PLAN.md")).toBe(expected);
+		expect(resolvePlanPath(session, "./PLAN.md")).toBe(expected);
+		expect(resolvePlanPath(session, "/repo/PLAN.md")).toBe(expected);
+		expect(resolvePlanPath(session, "local://PLAN.md")).toBe(expected);
+	});
 });
 
 describe("enforcePlanModeWrite plan-mode redirect", () => {
 	const planMode: PlanModeState = { enabled: true, planFilePath: "local://PLAN.md" };
+	const approvedPlanMode: PlanModeState = { enabled: true, planFilePath: "local://APPROVED.md" };
 
 	it("accepts bare PLAN.md as a write to the plan file", () => {
 		const session = makeSession({ artifactsDir: "/tmp/agent-artifacts", planMode });
@@ -87,6 +98,11 @@ describe("enforcePlanModeWrite plan-mode redirect", () => {
 		expect(() => enforcePlanModeWrite(session, "src/foo.ts", { op: "update" })).toThrow(
 			/only the plan file may be modified/,
 		);
+	});
+
+	it("accepts bare PLAN.md as a write to a titled active plan file", () => {
+		const session = makeSession({ artifactsDir: "/tmp/agent-artifacts", planMode: approvedPlanMode });
+		expect(() => enforcePlanModeWrite(session, "PLAN.md", { op: "update" })).not.toThrow();
 	});
 
 	it("rejects deletes of PLAN.md even when basename matches", () => {


### PR DESCRIPTION
Summary
- Fixed plan-mode re-entry after approval so /plan reopens the approved titled artifact instead of starting from local://PLAN.md.
- Kept approval collision protection intact: same source/destination remains a no-op, existing different destinations still fail.
- Kept PLAN.md, ./PLAN.md, cwd-absolute PLAN.md, and local://PLAN.md as aliases for the active plan artifact while plan mode is active.

Tests
- env HOME=/tmp bun test packages/coding-agent/test/interactive-mode-plan-review.test.ts
- env HOME=/tmp bun test packages/coding-agent/test/plan-mode/approved-plan.test.ts
- env HOME=/tmp bun test packages/coding-agent/test/tools/plan-mode-guard-local.test.ts
- env HOME=/tmp bun test packages/coding-agent/test/slash-commands/plan-history.test.ts
- env HOME=/tmp bun test packages/coding-agent/test/issue-816-repro.test.ts
- env HOME=/tmp BUN_TMPDIR=/tmp bun --cwd=packages/coding-agent run check

Known unrelated failure
- env HOME=/tmp bun test packages/coding-agent/test/system-prompt-templates.test.ts currently fails because the prompt renders the cwd under /tmp as ~/pi-system-prompt-... while the test expects the absolute /tmp/... path.

Compression Ledger
- Patch axis: extend
- Displacement: net-zero; reuses existing plan reference state instead of adding persistence or overwriting approved artifacts
- Rule violations averted: no approved-plan overwrite, no transcript format migration, no public CLI/API expansion
- PASS/FAIL: PASS after plan-mode focused tests and package check; one unrelated system-prompt HOME-shortening expectation remains failing