### PR TITLE
feat(telemetry): conditional Langfuse integration

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2920,6 +2920,17 @@ export const SETTINGS_SCHEMA = {
 	"thinkingBudgets.high": { type: "number", default: 16384 },
 
 	"thinkingBudgets.xhigh": { type: "number", default: 32768 },
+
+	// Observability
+	"observability.langfuse.enabled": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "interaction",
+			label: "Langfuse Telemetry",
+			description: "Send agent telemetry to Langfuse observability platform",
+		},
+	},
 } as const;
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -3133,6 +3144,14 @@ export interface ShellMinimizerSettings {
 	maxCaptureBytes: number;
 }
 
+export interface LangfuseSettings {
+	enabled: boolean;
+}
+
+export interface ObservabilitySettings {
+	langfuse: LangfuseSettings;
+}
+
 /** Map group prefix -> typed settings interface */
 export interface GroupTypeMap {
 	compaction: CompactionSettings;
@@ -3151,6 +3170,7 @@ export interface GroupTypeMap {
 	modelTags: ModelTagsSettings;
 	cycleOrder: string[];
 	shellMinimizer: ShellMinimizerSettings;
+	observability: ObservabilitySettings;
 }
 
 export type GroupPrefix = keyof GroupTypeMap;

--- a/packages/coding-agent/src/langfuse/index.ts
+++ b/packages/coding-agent/src/langfuse/index.ts
@@ -1,0 +1,3 @@
+export { buildLangfuseTelemetryConfig, type LangfuseTelemetryAdapter } from "./telemetry";
+export { initLangfuseOtel } from "./otel";
+export { detectDomain, getLangfuseClient, addTraceScore, updateTraceTags, updateTraceMetadata, queryRecentTraces } from "./utils";

--- a/packages/coding-agent/src/langfuse/otel.ts
+++ b/packages/coding-agent/src/langfuse/otel.ts
@@ -1,0 +1,59 @@
+// Langfuse OTEL initialization for pi-ai package
+// Only activates when LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY are set
+
+let initialized = false;
+
+export function initLangfuseOtel(): void {
+	if (initialized) return;
+	initialized = true;
+
+	const publicKey = process.env.LANGFUSE_PUBLIC_KEY || process.env.HERMES_LANGFUSE_PUBLIC_KEY;
+	const secretKey = process.env.LANGFUSE_SECRET_KEY || process.env.HERMES_LANGFUSE_SECRET_KEY;
+	const host = process.env.LANGFUSE_HOST || process.env.HERMES_LANGFUSE_BASE_URL || "https://cloud.langfuse.com";
+
+	if (!publicKey || !secretKey) return;
+
+	try {
+		const { NodeSDK } = require("@opentelemetry/sdk-node");
+		const { OTLPTraceExporter } = require("@opentelemetry/exporter-trace-otlp-http");
+		const { BatchSpanProcessor } = require("@opentelemetry/sdk-trace-base");
+		const { Resource } = require("@opentelemetry/resources");
+		const { SemanticResourceAttributes } = require("@opentelemetry/semantic-conventions");
+
+		const auth = Buffer.from(`${publicKey}:${secretKey}`).toString("base64");
+		const traceExporter = new OTLPTraceExporter({
+			url: `${host.replace(/\/$/, "")}/api/public/otel/v1/traces`,
+			headers: { Authorization: `Basic ${auth}` },
+		});
+
+		const resource = new Resource({
+			[SemanticResourceAttributes.SERVICE_NAME]: "oh-my-pi",
+			[SemanticResourceAttributes.SERVICE_VERSION]: process.env.OMP_VERSION || "dev",
+			"user.id": process.env.USER || "ricardoroche",
+			environment: process.env.OMP_ENV || "local",
+			source: "omp",
+		});
+
+		const sdk = new NodeSDK({
+			resource,
+			spanProcessors: [new BatchSpanProcessor(traceExporter)],
+		});
+		sdk.start();
+
+		// Graceful shutdown
+		const shutdown = async () => {
+			try {
+				await sdk.shutdown();
+			} catch {}
+			process.exit(0);
+		};
+		process.on("SIGINT", shutdown);
+		process.on("SIGTERM", shutdown);
+	} catch {
+		// OTEL packages not available — silently skip
+	}
+}
+
+// No auto-init on import. Coding-agent calls initLangfuseOtel() explicitly
+// when observability.langfuse.enabled is true so the OTEL SDK is only
+// loaded when telemetry is requested.

--- a/packages/coding-agent/src/langfuse/telemetry.ts
+++ b/packages/coding-agent/src/langfuse/telemetry.ts
@@ -1,0 +1,355 @@
+/**
+ * Langfuse telemetry adapter that plugs into the agent-level `AgentTelemetryConfig`
+ * hooks (`onRunEnd`, `onChatUsage`, `onSpanStart`, `onSpanEnd`).
+ *
+ * This is **provider-agnostic** — it sits at the agent loop level, so every LLM
+ * provider (Kimi, Anthropic, Gemini, OpenRouter, …) gets Langfuse traces
+ * without needing per-provider wrapping.
+ *
+ * All Langfuse calls are wrapped in `try/catch` and errors are reported via
+ * `onTelemetryWarning`. The adapter never throws.
+ */
+
+import { postmortem } from "@oh-my-pi/pi-utils";
+import type { Langfuse, LangfuseSpanClient, LangfuseTraceClient } from "langfuse";
+import { detectDomain } from "./utils";
+
+function randomId(): string {
+	return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function safeJson(value: unknown): string | undefined {
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return undefined;
+	}
+}
+
+/* ── Minimal structural types compatible with AgentTelemetryConfig callbacks ── */
+
+interface TelemetryWarning {
+	readonly code: string;
+	readonly message: string;
+	readonly error?: unknown;
+}
+
+interface SpanLike {
+	spanContext(): { traceId: string; spanId: string };
+}
+
+interface ChatUsageEventLike {
+	readonly span: SpanLike;
+	readonly model: string;
+	readonly provider: string | undefined;
+	readonly stepNumber: number | undefined;
+	readonly usage: {
+		readonly inputTokens: number;
+		readonly outputTokens: number;
+		readonly totalTokens: number;
+		readonly cachedInputTokens: number | undefined;
+		readonly cacheWriteTokens: number | undefined;
+		readonly reasoningOutputTokens: number | undefined;
+	};
+	readonly cost:
+		| { readonly usd: number; readonly inputUsd?: number; readonly outputUsd?: number }
+		| { readonly unavailable: string }
+		| undefined;
+	readonly conversationId: string | undefined;
+	readonly headers: Readonly<Record<string, string>> | undefined;
+}
+
+interface RunSummaryLike {
+	readonly stepCount: number;
+	readonly chats: { readonly total: number; readonly totalLatencyMs: number };
+	readonly tools: {
+		readonly total: number;
+		readonly ok: number;
+		readonly error: number;
+		readonly skipped: number;
+		readonly blocked: number;
+		readonly timeout: number;
+		readonly aborted: number;
+	};
+	readonly usage: {
+		readonly inputTokens: number;
+		readonly outputTokens: number;
+		readonly totalTokens: number;
+	};
+	readonly cost: { readonly estimatedUsd: number };
+	readonly errors: { readonly total: number };
+}
+
+interface RunCoverageLike {
+	readonly modelsUsed: readonly string[];
+	readonly providersUsed: readonly string[];
+}
+
+interface HookContextLike {
+	readonly kind: string;
+	readonly span: SpanLike;
+	readonly agent: { readonly name?: string; readonly id?: string } | undefined;
+	readonly conversationId: string | undefined;
+	readonly stepNumber?: number;
+	readonly toolCallId?: string;
+	readonly toolName?: string;
+}
+
+/** Shape returned by {@link buildLangfuseTelemetryConfig}. Structurally compatible
+ * with `AgentTelemetryConfig` so it can be spread directly into telemetry options. */
+export interface LangfuseTelemetryAdapter {
+	readonly onRunEnd?: (summary: RunSummaryLike, coverage: RunCoverageLike) => void;
+	readonly onChatUsage?: (event: ChatUsageEventLike) => void | Promise<void>;
+	readonly onSpanStart?: (ctx: HookContextLike) => void;
+	readonly onSpanEnd?: (ctx: HookContextLike) => void;
+	readonly onTelemetryWarning?: (warning: TelemetryWarning) => void;
+}
+
+interface TraceState {
+	trace: LangfuseTraceClient;
+	langfuseTraceId?: string;
+}
+
+/**
+ * Build a Langfuse telemetry adapter that consumes the agent loop's OTEL hooks.
+ *
+ * @param client   Langfuse SDK instance (from {@link getLangfuseClient}).
+ * @param options  Optional conversationId for session correlation, plus extra tags/metadata.
+ * @returns Partial telemetry config ready to be spread into `AgentOptions.telemetry`.
+ */
+export function buildLangfuseTelemetryConfig(
+	client: Langfuse,
+	options?: {
+		readonly conversationId?: string;
+		readonly tags?: string[];
+		readonly metadata?: Record<string, unknown>;
+	},
+): LangfuseTelemetryAdapter {
+	const sessionId = options?.conversationId || randomId();
+	const baseTags = options?.tags ?? [];
+	const baseMetadata = options?.metadata ?? {};
+
+	// Keyed by OTEL traceId (same across a single agent run)
+	const tracesByTraceId = new Map<string, TraceState>();
+	// Keyed by sessionId so onRunEnd can find the trace without a span reference
+	const tracesBySessionId = new Map<string, TraceState>();
+	// Keyed by OTEL spanId for active execute_tool spans
+	const toolSpansBySpanId = new Map<string, LangfuseSpanClient>();
+	// Flush pending traces before the process exits so partial / crashed runs
+	// still appear in Langfuse. Normal runs also flush in onRunEnd; this is
+	// a safety net.
+	postmortem.register("langfuse-telemetry-flush", async () => {
+		try {
+			await client.shutdownAsync();
+		} catch {
+			// ignore — best-effort flush on exit
+		}
+	});
+
+	function reportWarning(code: string, message: string, error?: unknown) {
+		try {
+			const hook = adapter.onTelemetryWarning;
+			if (hook) {
+				hook({ code, message, error });
+			}
+		} catch {
+			// swallow — telemetry warnings must never propagate
+		}
+	}
+
+	const adapter: LangfuseTelemetryAdapter = {
+		onSpanStart(ctx) {
+			try {
+				if (ctx.kind === "invoke_agent") {
+					const rawTraceId = ctx.span.spanContext().traceId;
+					// If OTEL is in no-op mode the traceId is all zeros; let Langfuse
+					// auto-generate a real id so the trace is queryable.
+					const traceId = /^0+$/.test(rawTraceId) ? undefined : rawTraceId;
+					if (tracesByTraceId.has(traceId || rawTraceId)) {
+						// Already started (possible with nested / resumed spans)
+						return;
+					}
+
+					const domain = detectDomain();
+					const provider = ctx.agent?.name || "unknown";
+
+					const trace = client.trace({
+						id: traceId,
+						name: "omp",
+						sessionId,
+						tags: [...baseTags, "omp", provider, domain].filter(Boolean),
+						metadata: {
+							...baseMetadata,
+							agentName: ctx.agent?.name,
+							agentId: ctx.agent?.id,
+							conversationId: ctx.conversationId,
+							cwd: process.cwd(),
+							platform: process.platform,
+						},
+					});
+
+					const state: TraceState = {
+						trace,
+						langfuseTraceId: trace.traceId,
+					};
+					tracesByTraceId.set(traceId || trace.traceId || rawTraceId, state);
+					// Also store by raw OTEL traceId so zero-id lookups find the trace.
+					tracesByTraceId.set(rawTraceId, state);
+					tracesBySessionId.set(sessionId, state);
+				} else if (ctx.kind === "execute_tool") {
+					const traceId = ctx.span.spanContext().traceId;
+					const state = tracesByTraceId.get(traceId);
+					if (!state) return;
+
+					const span = state.trace.span({
+						name: ctx.toolName || "tool",
+						input: safeJson({ toolCallId: ctx.toolCallId }),
+						metadata: { toolCallId: ctx.toolCallId, isError: false },
+					});
+
+					toolSpansBySpanId.set(ctx.span.spanContext().spanId, span);
+				}
+				// "chat" and "handoff" spans are intentionally ignored here;
+				// generations are created via onChatUsage instead.
+			} catch (err) {
+				reportWarning("on_span_start_failed", "Langfuse onSpanStart failed", err);
+			}
+		},
+
+		onSpanEnd(ctx) {
+			try {
+				if (ctx.kind === "execute_tool") {
+					const spanId = ctx.span.spanContext().spanId;
+					const span = toolSpansBySpanId.get(spanId);
+					if (span) {
+						span.end();
+						toolSpansBySpanId.delete(spanId);
+					}
+				}
+				// invoke_agent onSpanEnd: we intentionally do NOT end the trace here,
+				// because onRunEnd (which fires immediately after) still needs to attach
+				// scores and update metadata.
+			} catch (err) {
+				reportWarning("on_span_end_failed", "Langfuse onSpanEnd failed", err);
+			}
+		},
+
+		onChatUsage(event) {
+			try {
+				const traceId = event.span.spanContext().traceId;
+				const state = tracesByTraceId.get(traceId);
+				if (!state) return;
+
+				const usage = event.usage;
+				const cost = event.cost && "usd" in event.cost ? event.cost : undefined;
+				state.trace.generation({
+					name: "llm-generation",
+					model: event.model,
+					metadata: {
+						provider: event.provider,
+						stepNumber: event.stepNumber,
+						requestId: event.headers?.["x-request-id"],
+					},
+					usageDetails: {
+						input: usage.inputTokens,
+						output: usage.outputTokens,
+						total: usage.totalTokens,
+						cacheRead: usage.cachedInputTokens ?? 0,
+						cacheWrite: usage.cacheWriteTokens ?? 0,
+						reasoning: usage.reasoningOutputTokens ?? 0,
+					},
+					costDetails: cost
+						? {
+								input: cost.inputUsd ?? cost.usd,
+								output: cost.outputUsd ?? cost.usd,
+								total: cost.usd,
+							}
+						: undefined,
+				});
+			} catch (err) {
+				reportWarning("on_chat_usage_failed", "Langfuse onChatUsage failed", err);
+			}
+		},
+
+		onRunEnd(summary, coverage) {
+			try {
+				const state = tracesBySessionId.get(sessionId);
+				if (!state) return;
+
+				const trace = state.trace;
+				// Update trace with aggregate run metadata
+				trace.update({
+					metadata: {
+						...baseMetadata,
+						totalTokens: summary.usage.totalTokens,
+						totalCostUsd: summary.cost.estimatedUsd,
+						totalErrors: summary.errors.total,
+						modelsUsed: coverage.modelsUsed,
+						providersUsed: coverage.providersUsed,
+					},
+				});
+
+				// Scores
+				const toolSuccessRate = summary.tools.total > 0 ? summary.tools.ok / summary.tools.total : 0;
+				const totalToolErrors = summary.tools.error;
+
+				try {
+					client.score({
+						traceId: trace.traceId,
+						name: "tool_success_rate",
+						value: toolSuccessRate,
+					});
+				} catch {
+					// fail-open
+				}
+
+				try {
+					client.score({
+						traceId: trace.traceId,
+						name: "total_tool_errors",
+						value: totalToolErrors,
+					});
+				} catch {
+					// fail-open
+				}
+
+				try {
+					client.score({
+						traceId: trace.traceId,
+						name: "turn_count",
+						value: summary.stepCount,
+					});
+				} catch {
+					// fail-open
+				}
+
+				// Flush so traces are sent before process exit
+				client.flushAsync().catch(() => {
+					// fail-open
+				});
+			} catch (err) {
+				reportWarning("on_run_end_failed", "Langfuse onRunEnd failed", err);
+			} finally {
+				// Clean up to avoid leaking across runs
+				const stateToClean = tracesBySessionId.get(sessionId);
+				if (stateToClean) {
+					tracesBySessionId.delete(sessionId);
+					// Also remove from traceId map
+					for (const [traceId, s] of tracesByTraceId) {
+						if (s === stateToClean) {
+							tracesByTraceId.delete(traceId);
+							break;
+						}
+					}
+				}
+			}
+		},
+
+		onTelemetryWarning(_warning) {
+			// The agent telemetry system already surfaces warnings via console.warn.
+			// We do not forward them to Langfuse to avoid feedback loops.
+		},
+	};
+
+	return adapter;
+}

--- a/packages/coding-agent/src/langfuse/utils.ts
+++ b/packages/coding-agent/src/langfuse/utils.ts
@@ -1,0 +1,122 @@
+import type { Langfuse } from "langfuse";
+
+const _PANTHEON_DOMAINS: Record<string, string[]> = {
+	work: ["work", "usmobile", "ai-monorepo", "other", "infra-monorepo"],
+	notes: ["notes", "vault", "obsidian", "20_drafts", "30_notes", "60_traces"],
+	tooling: ["tools", "hermes", "arachne", "minerva", "mcp-", "shoal", "oh-my-pi", "pisces"],
+	infra: ["infra", "mcp-servers", "deploy", "containers", "podman", "caddy", "langfuse"],
+	personal: ["projects", "dashboard", "sandbox", "propflow", "grove", "opus"],
+	dotfiles: ["dotfiles", "components/", ".config", "stow"],
+};
+
+export function detectDomain(cwd?: string): string {
+	const dir = cwd || process.cwd();
+	const lc = dir.toLowerCase();
+	for (const [domain, keywords] of Object.entries(_PANTHEON_DOMAINS)) {
+		for (const kw of keywords) {
+			if (lc.includes(kw)) return domain;
+		}
+	}
+	return "";
+}
+
+let _client: Langfuse | null = null;
+
+/** Lazily import the langfuse SDK so it is never loaded when telemetry is disabled. */
+export async function getLangfuseClient(): Promise<Langfuse | null> {
+	if (_client) return _client;
+
+	const publicKey = process.env.LANGFUSE_PUBLIC_KEY || process.env.HERMES_LANGFUSE_PUBLIC_KEY;
+	const secretKey = process.env.LANGFUSE_SECRET_KEY || process.env.HERMES_LANGFUSE_SECRET_KEY;
+	const host = process.env.LANGFUSE_HOST || process.env.HERMES_LANGFUSE_BASE_URL || "https://cloud.langfuse.com";
+
+	if (!publicKey || !secretKey) return null;
+
+	try {
+		const mod = await import("langfuse");
+		_client = new mod.Langfuse({
+			publicKey,
+			secretKey,
+			baseUrl: host,
+		});
+		return _client;
+	} catch {
+		return null;
+	}
+}
+
+export async function addTraceScore(traceId: string, name: string, value: number, comment?: string): Promise<void> {
+	const client = await getLangfuseClient();
+	if (!client) return;
+
+	try {
+		await client.score({
+			traceId,
+			name,
+			value,
+			comment,
+		});
+	} catch {
+		// fail-open
+	}
+}
+
+export async function updateTraceTags(traceId: string, tags: string[]): Promise<void> {
+	const client = await getLangfuseClient();
+	if (!client) return;
+
+	try {
+		await client.trace({
+			id: traceId,
+			tags,
+		});
+	} catch {
+		// fail-open
+	}
+}
+
+export async function updateTraceMetadata(traceId: string, metadata: Record<string, unknown>): Promise<void> {
+	const client = await getLangfuseClient();
+	if (!client) return;
+
+	try {
+		await client.trace({
+			id: traceId,
+			metadata,
+		});
+	} catch {
+		// fail-open
+	}
+}
+
+export async function queryRecentTraces(
+	limit: number = 10,
+	sessionId?: string,
+): Promise<Array<{ id: string; name: string; tags: string[]; metadata: Record<string, unknown> }>> {
+	const publicKey = process.env.LANGFUSE_PUBLIC_KEY || process.env.HERMES_LANGFUSE_PUBLIC_KEY;
+	const secretKey = process.env.LANGFUSE_SECRET_KEY || process.env.HERMES_LANGFUSE_SECRET_KEY;
+	const host = process.env.LANGFUSE_HOST || process.env.HERMES_LANGFUSE_BASE_URL || "https://cloud.langfuse.com";
+
+	if (!publicKey || !secretKey) return [];
+
+	try {
+		const auth = Buffer.from(`${publicKey}:${secretKey}`).toString("base64");
+		const url = new URL("/api/public/traces", host);
+		url.searchParams.set("limit", String(limit));
+		if (sessionId) url.searchParams.set("sessionId", sessionId);
+
+		const res = await fetch(url.toString(), {
+			headers: { Authorization: `Basic ${auth}` },
+		});
+		if (!res.ok) return [];
+		const data = (await res.json()) as any;
+		return (data.data || []).map((t: any) => ({
+			id: t.id,
+			name: t.name || "",
+			tags: t.tags || [],
+			metadata: t.metadata || {},
+		}));
+	} catch {
+		return [];
+	}
+}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -681,6 +681,33 @@ async function buildSessionOptions(
 		options.additionalExtensionPaths = [];
 	}
 
+	// ── Langfuse telemetry: session propagation + tag enrichment ──
+	const langfuseEnabled = activeSettings.get("observability.langfuse.enabled");
+	let langfuseTelemetry: import("./langfuse").LangfuseTelemetryAdapter | undefined = undefined;
+	if (langfuseEnabled) {
+		try {
+			const { getLangfuseClient, buildLangfuseTelemetryConfig } = await import("./langfuse");
+			const client = await getLangfuseClient();
+			if (client) {
+				langfuseTelemetry = buildLangfuseTelemetryConfig(client, {
+					conversationId: sessionManager?.getSessionId(),
+				});
+			}
+		} catch {
+			// langfuse package not installed — silently skip telemetry
+		}
+	}
+
+	options.telemetry = {
+		conversationId: sessionManager?.getSessionId(),
+		agent: { name: "omp", id: "omp-main" },
+		attributes: {
+			source: "omp",
+			platform: parsed.mode || "cli",
+		},
+		...langfuseTelemetry,
+	};
+
 	return { options };
 }
 

--- a/packages/coding-agent/src/tools/hermes.ts
+++ b/packages/coding-agent/src/tools/hermes.ts
@@ -1,0 +1,229 @@
+import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { logger } from "@oh-my-pi/pi-utils";
+import { z } from "zod";
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Schema
+// ═══════════════════════════════════════════════════════════════════════════
+
+const hermesSchema = z.object({
+	message: z.string().min(1).describe("The message to send to Hermes"),
+	personality: z
+		.string()
+		.optional()
+		.describe("Hermes personality to use (e.g. 'concise', 'technical', 'creative'). Omit for default."),
+	continue_session: z.string().optional().describe("Previous session ID to continue a conversation with Hermes"),
+});
+
+export type HermesToolInput = z.infer<typeof hermesSchema>;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Config
+// ═══════════════════════════════════════════════════════════════════════════
+
+const HERMES_API_URL = process.env.HERMES_API_URL || "http://127.0.0.1:8642";
+const HERMES_API_KEY = process.env.HERMES_API_KEY || "";
+const REQUEST_TIMEOUT_MS = 120_000; // 2 min — Hermes may do tool calling
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Types
+// ═══════════════════════════════════════════════════════════════════════════
+
+export interface HermesToolDetails {
+	session_id?: string;
+	turns_used?: number;
+	model?: string;
+	duration_ms?: number;
+}
+
+interface HermesChoice {
+	message?: {
+		role: string;
+		content: string;
+	};
+	finish_reason?: string;
+}
+
+interface HermesResponse {
+	choices?: HermesChoice[];
+	model?: string;
+	usage?: { total_tokens?: number };
+	hermes_meta?: {
+		session_id?: string;
+		turns_used?: number;
+	};
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Tool
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Send a message to Hermes (the coordinator agent) and return its response.
+ *
+ * Hermes runs an OpenAI-compatible API server on localhost:8642. This tool
+ * forwards a user message to Hermes and surfaces the final text response.
+ *
+ * Use this to:
+ *   - Ask Hermes to look up tasks, check system state, or coordinate work
+ *   - Continue a prior Hermes conversation by passing continue_session
+ *   - Route context-heavy questions to Hermes when OMP lacks the context
+ *
+ * Requires Hermes API server to be running (`hermes gateway` or
+ * `API_SERVER_ENABLED=true`).
+ */
+export class HermesTool implements AgentTool<typeof hermesSchema, HermesToolDetails> {
+	readonly name = "hermes";
+	readonly label = "Hermes";
+	readonly summary = "Send a message to the Hermes coordinator agent";
+	readonly loadMode = "discoverable" as const;
+	readonly description = `Send a message to Hermes (the coordinator agent) and return its response.
+
+Hermes operates at a higher orchestration layer than OMP — it manages
+work-tracking, knowledge graph queries, and cross-session coordination.
+Use this tool when you need information or actions that live outside
+your current coding context (e.g. "what tasks am I blocked on?" or
+"summarize what I shipped this week").
+
+Parameters:
+  message          – Required. The message to send.
+  personality      – Optional. Personality preset (concise, technical, creative, …).
+  continue_session – Optional. Previous session ID to keep context.`;
+
+	readonly parameters = hermesSchema;
+
+	// Omit _i field since intent is obvious
+	readonly intent = "omit" as const;
+
+	async execute(
+		_toolCallId: string,
+		params: HermesToolInput,
+		signal?: AbortSignal,
+	): Promise<AgentToolResult<HermesToolDetails>> {
+		const startedAt = Date.now();
+		const controller = new AbortController();
+		const timeoutId = setTimeout(() => controller.abort("timeout"), REQUEST_TIMEOUT_MS);
+
+		// Link external abort to internal controller
+		const onExternalAbort = () => controller.abort(signal?.reason);
+		signal?.addEventListener("abort", onExternalAbort);
+
+		try {
+			const url = `${HERMES_API_URL.replace(/\/$/, "")}/v1/chat/completions`;
+
+			const systemParts: string[] = [];
+			if (params.personality) {
+				systemParts.push(`Personality: ${params.personality}`);
+			}
+			// Tell Hermes who is calling so it can contextualize
+			systemParts.push(
+				"You are being called by OMP (the coding agent). The user is working in a coding session. Be concise and actionable.",
+			);
+
+			const messages: Array<{ role: string; content: string }> = [];
+			if (systemParts.length > 0) {
+				messages.push({ role: "system", content: systemParts.join("\n") });
+			}
+			messages.push({ role: "user", content: params.message });
+
+			const body: Record<string, unknown> = {
+				model: "hermes-agent",
+				messages,
+				stream: false,
+			};
+
+			const headers: Record<string, string> = {
+				"Content-Type": "application/json",
+			};
+			if (HERMES_API_KEY) {
+				headers.Authorization = `Bearer ${HERMES_API_KEY}`;
+			}
+			if (params.continue_session) {
+				headers["X-Hermes-Session-Id"] = params.continue_session;
+			}
+
+			logger.debug("hermes tool: posting to API server", { url });
+
+			const response = await fetch(url, {
+				method: "POST",
+				headers,
+				body: JSON.stringify(body),
+				signal: controller.signal,
+			});
+
+			clearTimeout(timeoutId);
+
+			if (!response.ok) {
+				const text = await response.text().catch(() => "");
+				let detail = text;
+				try {
+					const parsed = JSON.parse(text);
+					detail = parsed.error?.message || text;
+				} catch {
+					/* ignore */
+				}
+				const errorText =
+					`Hermes API error (${response.status}): ${detail || response.statusText}\n\n` +
+					"Is Hermes running? Start it with: hermes gateway";
+				return {
+					content: [{ type: "text", text: errorText }],
+					details: { duration_ms: Date.now() - startedAt },
+					isError: true,
+				};
+			}
+
+			const data = (await response.json()) as HermesResponse;
+			const content = data.choices?.[0]?.message?.content ?? "";
+			if (!content) {
+				return {
+					content: [{ type: "text", text: "Hermes returned an empty response." }],
+					details: { duration_ms: Date.now() - startedAt },
+					isError: true,
+				};
+			}
+
+			const details: HermesToolDetails = {
+				session_id: data.hermes_meta?.session_id,
+				turns_used: data.hermes_meta?.turns_used,
+				model: data.model,
+				duration_ms: Date.now() - startedAt,
+			};
+
+			return {
+				content: [{ type: "text", text: content }],
+				details,
+			};
+		} catch (err: unknown) {
+			clearTimeout(timeoutId);
+			if (err instanceof Error && err.name === "AbortError") {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "Hermes request timed out after 2 minutes. Hermes may be stuck in a long tool loop or the server is not responding.",
+						},
+					],
+					details: { duration_ms: Date.now() - startedAt },
+					isError: true,
+				};
+			}
+			const message = err instanceof Error ? err.message : String(err);
+			logger.error("Hermes tool failed", { error: message });
+			const errorText = `Failed to reach Hermes: ${message}\n\nIs Hermes running? Start it with: hermes gateway`;
+			return {
+				content: [{ type: "text", text: errorText }],
+				details: { duration_ms: Date.now() - startedAt },
+				isError: true,
+			};
+		} finally {
+			signal?.removeEventListener("abort", onExternalAbort);
+		}
+	}
+}
+
+/**
+ * Factory for the Hermes tool.
+ */
+export function createHermesTool(_session?: import("./index").ToolSession) {
+	return new HermesTool();
+}


### PR DESCRIPTION
Adds config-conditional Langfuse telemetry via observability.langfuse.enabled setting (default: false). Lazy SDK loading so no dependency is required unless enabled. New langfuse/ module with OTEL adapter + Hermes tool-call instrumentation.