### PR TITLE
fix(tools): isolate read URL reader-mode fallback chain from remote stalls

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed plan-mode re-entry after approval reopening a fresh `local://PLAN.md` instead of the approved titled plan artifact, which could duplicate plan content and fail approval on an existing destination.
+- Fixed `read` URL reader mode aborting after a stalled Jina request instead of falling back to trafilatura/lynx/native: Jina (and Parallel extract) now have their own per-attempt sub-budget capped at 10s, the catch handler honours only real user cancellation, and the in-process native renderer is always attempted on already-loaded HTML ([#1449](https://github.com/can1357/oh-my-pi/issues/1449))
 
 ## [15.5.6] - 2026-05-27
 ### Added

--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -562,9 +562,22 @@ function parseFeedToMarkdown(content: string, maxItems = 10): string {
 }
 
 /**
- * Render HTML to markdown using Parallel, jina, trafilatura, lynx (in order of preference)
+ * Cap on any single remote reader-mode request (Parallel, Jina) so a stalled
+ * remote endpoint cannot consume the whole reader-mode budget and starve the
+ * local fallback renderers (trafilatura, lynx, native). See #1449.
  */
-async function renderHtmlToText(
+const REMOTE_READER_MAX_MS = 10_000;
+
+/**
+ * Render HTML to markdown using Parallel, jina, trafilatura, lynx, then the
+ * in-process native converter. The overall `timeout` budget bounds the call,
+ * but remote reader requests are additionally capped at `REMOTE_READER_MAX_MS`
+ * so that a hung remote endpoint cannot prevent local fallbacks from running.
+ * Only a real `userSignal` cancellation aborts the chain — remote per-attempt
+ * timeouts and the overall reader-mode timeout still allow later renderers
+ * (especially the purely-local native converter) to be tried.
+ */
+export async function renderHtmlToText(
 	url: string,
 	html: string,
 	timeout: number,
@@ -572,14 +585,15 @@ async function renderHtmlToText(
 	userSignal: AbortSignal | undefined,
 	storage: AgentStorage | null,
 ): Promise<{ content: string; ok: boolean; method: string }> {
-	const signal = ptree.combineSignals(userSignal, timeout * 1000);
+	const overallSignal = ptree.combineSignals(userSignal, timeout * 1000);
 	const execOptions = {
 		mode: "group" as const,
 		allowNonZero: true,
 		allowAbort: true,
 		stderr: "full" as const,
-		signal,
+		signal: overallSignal,
 	};
+	const remoteBudgetMs = Math.min(timeout * 1000, REMOTE_READER_MAX_MS);
 
 	// Try Parallel extract first when credentials are configured
 	if (settings.get("providers.parallelFetch") && findParallelApiKey(storage)) {
@@ -590,7 +604,7 @@ async function renderHtmlToText(
 					objective: "Extract the main content",
 					excerpts: true,
 					fullContent: false,
-					signal,
+					signal: ptree.combineSignals(userSignal, remoteBudgetMs),
 				},
 				storage,
 			);
@@ -602,17 +616,18 @@ async function renderHtmlToText(
 				}
 			}
 		} catch {
-			// Parallel extract failed, continue to next method
-			signal?.throwIfAborted();
+			// Parallel extract failed or stalled; honour real cancellation only.
+			userSignal?.throwIfAborted();
 		}
 	}
 
-	// Try jina first (reader API)
+	// Try jina reader API with its own sub-budget so a stall cannot starve
+	// later fallbacks (#1449).
 	try {
 		const jinaUrl = `https://r.jina.ai/${url}`;
 		const response = await fetch(jinaUrl, {
 			headers: { Accept: "text/markdown" },
-			signal,
+			signal: ptree.combineSignals(userSignal, remoteBudgetMs),
 		});
 		if (response.ok) {
 			const content = await response.text();
@@ -621,37 +636,50 @@ async function renderHtmlToText(
 			}
 		}
 	} catch {
-		// Jina failed, continue to next method
-		signal?.throwIfAborted();
+		// Jina failed or stalled; honour real cancellation only.
+		userSignal?.throwIfAborted();
 	}
 
 	// Try trafilatura (auto-install via uv/pip)
-	const trafilatura = await ensureTool("trafilatura", { signal, silent: true });
-	if (trafilatura) {
-		const result = await ptree.exec([trafilatura, "-u", url, "--output-format", "markdown"], execOptions);
-		if (result.ok && result.stdout.trim().length > 100) {
-			return { content: result.stdout, ok: true, method: "trafilatura" };
+	try {
+		const trafilatura = await ensureTool("trafilatura", { signal: overallSignal, silent: true });
+		if (trafilatura) {
+			const result = await ptree.exec([trafilatura, "-u", url, "--output-format", "markdown"], execOptions);
+			if (result.ok && result.stdout.trim().length > 100) {
+				return { content: result.stdout, ok: true, method: "trafilatura" };
+			}
 		}
+	} catch {
+		// trafilatura unavailable or stalled; continue to next method.
+		userSignal?.throwIfAborted();
 	}
 
 	// Try lynx (can't auto-install, system package)
-	const lynx = hasCommand("lynx");
-	if (lynx) {
-		const result = await ptree.exec(["lynx", "-dump", "-nolist", "-width", "250", url], execOptions);
-		if (result.ok) {
-			return { content: result.stdout, ok: true, method: "lynx" };
+	try {
+		const lynx = hasCommand("lynx");
+		if (lynx) {
+			const result = await ptree.exec(["lynx", "-dump", "-nolist", "-width", "250", url], execOptions);
+			if (result.ok) {
+				return { content: result.stdout, ok: true, method: "lynx" };
+			}
 		}
+	} catch {
+		// lynx failed or stalled; continue to native converter.
+		userSignal?.throwIfAborted();
 	}
 
-	// Fall back to native converter (fastest, no network/subprocess)
+	// Fall back to native converter (purely local, no network/subprocess).
+	// Always attempted: even if remote renderers and subprocesses were aborted
+	// by the overall reader-mode timeout, this still works on already-loaded
+	// HTML (#1449).
 	try {
 		const content = await htmlToMarkdown(html, { cleanContent: true });
 		if (content.trim().length > 100 && !isLowQualityOutput(content)) {
 			return { content, ok: true, method: "native" };
 		}
 	} catch {
-		// Native converter failed, continue to next method
-		signal?.throwIfAborted();
+		// Native converter failed; nothing else to try.
+		userSignal?.throwIfAborted();
 	}
 	return { content: "", ok: false, method: "none" };
 }

--- a/packages/coding-agent/src/tools/fetch.ts
+++ b/packages/coding-agent/src/tools/fetch.ts
@@ -570,12 +570,13 @@ const REMOTE_READER_MAX_MS = 10_000;
 
 /**
  * Render HTML to markdown using Parallel, jina, trafilatura, lynx, then the
- * in-process native converter. The overall `timeout` budget bounds the call,
- * but remote reader requests are additionally capped at `REMOTE_READER_MAX_MS`
- * so that a hung remote endpoint cannot prevent local fallbacks from running.
- * Only a real `userSignal` cancellation aborts the chain — remote per-attempt
- * timeouts and the overall reader-mode timeout still allow later renderers
- * (especially the purely-local native converter) to be tried.
+ * in-process native converter. The overall `timeout` budget is the hard ceiling
+ * for the whole call (`overallSignal`); each remote reader attempt is further
+ * capped at `REMOTE_READER_MAX_MS` AND tied to `overallSignal`, so sequential
+ * remote stalls can never collectively exceed the reader-mode budget. Only a
+ * real `userSignal` cancellation aborts the chain — remote per-attempt timeouts
+ * and the overall reader-mode timeout still allow later renderers (especially
+ * the purely-local native converter) to be tried.
  */
 export async function renderHtmlToText(
 	url: string,
@@ -604,7 +605,7 @@ export async function renderHtmlToText(
 					objective: "Extract the main content",
 					excerpts: true,
 					fullContent: false,
-					signal: ptree.combineSignals(userSignal, remoteBudgetMs),
+					signal: ptree.combineSignals(overallSignal, remoteBudgetMs),
 				},
 				storage,
 			);
@@ -627,7 +628,7 @@ export async function renderHtmlToText(
 		const jinaUrl = `https://r.jina.ai/${url}`;
 		const response = await fetch(jinaUrl, {
 			headers: { Accept: "text/markdown" },
-			signal: ptree.combineSignals(userSignal, remoteBudgetMs),
+			signal: ptree.combineSignals(overallSignal, remoteBudgetMs),
 		});
 		if (response.ok) {
 			const content = await response.text();

--- a/packages/coding-agent/test/tools/fetch-jina-stall.test.ts
+++ b/packages/coding-agent/test/tools/fetch-jina-stall.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { renderHtmlToText } from "@oh-my-pi/pi-coding-agent/tools/fetch";
+import { hookFetch } from "@oh-my-pi/pi-utils";
+
+/**
+ * Regression test for #1449: a stalled Jina reader request must not prevent
+ * local fallback renderers (trafilatura/lynx/native) from running within the
+ * overall reader-mode budget.
+ */
+describe("renderHtmlToText: jina stall does not starve local fallbacks (#1449)", () => {
+	afterEach(() => {
+		// Nothing to restore — `using` handles fetch hook cleanup per-test.
+	});
+
+	it("falls back to native renderer when jina hangs until aborted", async () => {
+		const settings = Settings.isolated({ "providers.parallelFetch": false });
+		// Substantive HTML so the native converter produces >100 chars and
+		// `isLowQualityOutput` does not reject it.
+		const paragraphs = Array.from({ length: 6 }, (_, i) => `<p>Paragraph number ${i + 1} carries some real content for the article body so the native renderer has enough text to satisfy the length threshold.</p>`).join("");
+		const html = `<!doctype html><html><head><title>Example</title></head><body><article><h1>Example article</h1>${paragraphs}</article></body></html>`;
+
+		using _hook = hookFetch((input, _init, _next) => {
+			const url = String(input);
+			// Hang on the Jina reader endpoint until aborted, mirroring the
+			// real bug: r.jina.ai stalls indefinitely.
+			if (url.startsWith("https://r.jina.ai/")) {
+				return new Promise<Response>((_resolve, reject) => {
+					const signal = _init?.signal;
+					if (!signal) return; // never settles
+					if (signal.aborted) {
+						reject(new DOMException("aborted", "AbortError"));
+						return;
+					}
+					signal.addEventListener("abort", () => {
+						reject(new DOMException("aborted", "AbortError"));
+					});
+				});
+			}
+			return new Response("", { status: 404 });
+		});
+
+		const started = Date.now();
+		// `timeout: 2` keeps the overall budget tight — the test must complete
+		// within ~2s even though Jina would otherwise hang for the full budget.
+		const result = await renderHtmlToText(
+			"https://example.com/article",
+			html,
+			2,
+			settings,
+			undefined,
+			null,
+		);
+		const elapsedMs = Date.now() - started;
+
+		expect(result.ok).toBe(true);
+		// Native converter is the only deterministic local fallback; trafilatura
+		// and lynx may or may not be installed in CI, but native always works.
+		// If trafilatura or lynx happened to succeed first, that's also a valid
+		// non-aborted outcome.
+		expect(["native", "trafilatura", "lynx"]).toContain(result.method);
+		// Must finish well before the overall budget elapses: the remote
+		// sub-budget caps Jina at min(timeout, REMOTE_READER_MAX_MS), so the
+		// remaining ~1s of the 2s budget is enough for the native renderer.
+		expect(elapsedMs).toBeLessThan(2_500);
+	});
+
+	it("re-throws when the user signal is aborted, not when Jina sub-budget expires", async () => {
+		const settings = Settings.isolated({ "providers.parallelFetch": false });
+		const html = "<html><body><p>short</p></body></html>";
+
+		using _hook = hookFetch((_input, init, _next) => {
+			return new Promise<Response>((_resolve, reject) => {
+				const signal = init?.signal;
+				if (!signal) return; // Defensive: never settles otherwise.
+				if (signal.aborted) {
+					reject(new DOMException("aborted", "AbortError"));
+					return;
+				}
+				signal.addEventListener("abort", () => {
+					reject(new DOMException("aborted", "AbortError"));
+				});
+			});
+		});
+
+		const controller = new AbortController();
+		const pending = renderHtmlToText(
+			"https://example.com/article",
+			html,
+			30,
+			settings,
+			controller.signal,
+			null,
+		).catch(err => err);
+
+		controller.abort();
+		const outcome = await pending;
+		expect(outcome).toBeInstanceOf(Error);
+		expect((outcome as Error).name === "AbortError" || (outcome as Error).message.toLowerCase().includes("abort")).toBe(true);
+	});
+});

--- a/packages/coding-agent/test/tools/fetch-jina-stall.test.ts
+++ b/packages/coding-agent/test/tools/fetch-jina-stall.test.ts
@@ -17,7 +17,11 @@ describe("renderHtmlToText: jina stall does not starve local fallbacks (#1449)",
 		const settings = Settings.isolated({ "providers.parallelFetch": false });
 		// Substantive HTML so the native converter produces >100 chars and
 		// `isLowQualityOutput` does not reject it.
-		const paragraphs = Array.from({ length: 6 }, (_, i) => `<p>Paragraph number ${i + 1} carries some real content for the article body so the native renderer has enough text to satisfy the length threshold.</p>`).join("");
+		const paragraphs = Array.from(
+			{ length: 6 },
+			(_, i) =>
+				`<p>Paragraph number ${i + 1} carries some real content for the article body so the native renderer has enough text to satisfy the length threshold.</p>`,
+		).join("");
 		const html = `<!doctype html><html><head><title>Example</title></head><body><article><h1>Example article</h1>${paragraphs}</article></body></html>`;
 
 		using _hook = hookFetch((input, _init, _next) => {
@@ -43,14 +47,7 @@ describe("renderHtmlToText: jina stall does not starve local fallbacks (#1449)",
 		const started = Date.now();
 		// `timeout: 2` keeps the overall budget tight — the test must complete
 		// within ~2s even though Jina would otherwise hang for the full budget.
-		const result = await renderHtmlToText(
-			"https://example.com/article",
-			html,
-			2,
-			settings,
-			undefined,
-			null,
-		);
+		const result = await renderHtmlToText("https://example.com/article", html, 2, settings, undefined, null);
 		const elapsedMs = Date.now() - started;
 
 		expect(result.ok).toBe(true);
@@ -96,6 +93,8 @@ describe("renderHtmlToText: jina stall does not starve local fallbacks (#1449)",
 		controller.abort();
 		const outcome = await pending;
 		expect(outcome).toBeInstanceOf(Error);
-		expect((outcome as Error).name === "AbortError" || (outcome as Error).message.toLowerCase().includes("abort")).toBe(true);
+		expect(
+			(outcome as Error).name === "AbortError" || (outcome as Error).message.toLowerCase().includes("abort"),
+		).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/tools/fetch-jina-stall.test.ts
+++ b/packages/coding-agent/test/tools/fetch-jina-stall.test.ts
@@ -1,100 +1,115 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { renderHtmlToText } from "@oh-my-pi/pi-coding-agent/tools/fetch";
+import * as parallel from "@oh-my-pi/pi-coding-agent/web/parallel";
 import { hookFetch } from "@oh-my-pi/pi-utils";
 
 /**
- * Regression test for #1449: a stalled Jina reader request must not prevent
+ * Regression tests for #1449: a stalled remote reader request must not prevent
  * local fallback renderers (trafilatura/lynx/native) from running within the
- * overall reader-mode budget.
+ * overall reader-mode budget, and sequential remote stalls must not exceed it.
  */
-describe("renderHtmlToText: jina stall does not starve local fallbacks (#1449)", () => {
+
+/** Hang until the supplied AbortSignal fires; mirrors a stalled remote endpoint. */
+function hangUntilAborted<T>(signal: AbortSignal | undefined | null): Promise<T> {
+	const { promise, reject } = Promise.withResolvers<T>();
+	if (!signal) return promise; // Defensive: caller did not wire one — never settles.
+	const fail = () => reject(new DOMException("aborted", "AbortError"));
+	if (signal.aborted) fail();
+	else signal.addEventListener("abort", fail);
+	return promise;
+}
+
+const SUBSTANTIVE_HTML = (() => {
+	const paragraphs = Array.from(
+		{ length: 6 },
+		(_, i) =>
+			`<p>Paragraph number ${i + 1} carries some real content for the article body so the native renderer has enough text to satisfy the length threshold.</p>`,
+	).join("");
+	return `<!doctype html><html><head><title>Example</title></head><body><article><h1>Example article</h1>${paragraphs}</article></body></html>`;
+})();
+
+describe("renderHtmlToText: remote stalls do not starve local fallbacks (#1449)", () => {
 	afterEach(() => {
-		// Nothing to restore — `using` handles fetch hook cleanup per-test.
+		vi.restoreAllMocks();
 	});
 
 	it("falls back to native renderer when jina hangs until aborted", async () => {
 		const settings = Settings.isolated({ "providers.parallelFetch": false });
-		// Substantive HTML so the native converter produces >100 chars and
-		// `isLowQualityOutput` does not reject it.
-		const paragraphs = Array.from(
-			{ length: 6 },
-			(_, i) =>
-				`<p>Paragraph number ${i + 1} carries some real content for the article body so the native renderer has enough text to satisfy the length threshold.</p>`,
-		).join("");
-		const html = `<!doctype html><html><head><title>Example</title></head><body><article><h1>Example article</h1>${paragraphs}</article></body></html>`;
 
-		using _hook = hookFetch((input, _init, _next) => {
-			const url = String(input);
-			// Hang on the Jina reader endpoint until aborted, mirroring the
-			// real bug: r.jina.ai stalls indefinitely.
-			if (url.startsWith("https://r.jina.ai/")) {
-				return new Promise<Response>((_resolve, reject) => {
-					const signal = _init?.signal;
-					if (!signal) return; // never settles
-					if (signal.aborted) {
-						reject(new DOMException("aborted", "AbortError"));
-						return;
-					}
-					signal.addEventListener("abort", () => {
-						reject(new DOMException("aborted", "AbortError"));
-					});
-				});
+		using _hook = hookFetch((input, init, _next) => {
+			if (String(input).startsWith("https://r.jina.ai/")) {
+				return hangUntilAborted<Response>(init?.signal);
 			}
 			return new Response("", { status: 404 });
 		});
 
 		const started = Date.now();
 		// `timeout: 2` keeps the overall budget tight — the test must complete
-		// within ~2s even though Jina would otherwise hang for the full budget.
-		const result = await renderHtmlToText("https://example.com/article", html, 2, settings, undefined, null);
+		// well within ~2s even though Jina would otherwise consume it whole.
+		const result = await renderHtmlToText("https://example.com/article", SUBSTANTIVE_HTML, 2, settings, undefined, null);
 		const elapsedMs = Date.now() - started;
 
 		expect(result.ok).toBe(true);
-		// Native converter is the only deterministic local fallback; trafilatura
-		// and lynx may or may not be installed in CI, but native always works.
-		// If trafilatura or lynx happened to succeed first, that's also a valid
-		// non-aborted outcome.
+		// Native always works. trafilatura/lynx may also win if installed.
 		expect(["native", "trafilatura", "lynx"]).toContain(result.method);
-		// Must finish well before the overall budget elapses: the remote
-		// sub-budget caps Jina at min(timeout, REMOTE_READER_MAX_MS), so the
-		// remaining ~1s of the 2s budget is enough for the native renderer.
 		expect(elapsedMs).toBeLessThan(2_500);
 	});
 
-	it("re-throws when the user signal is aborted, not when Jina sub-budget expires", async () => {
+	it("re-throws when the user signal is aborted, not when sub-budget expires", async () => {
 		const settings = Settings.isolated({ "providers.parallelFetch": false });
-		const html = "<html><body><p>short</p></body></html>";
 
-		using _hook = hookFetch((_input, init, _next) => {
-			return new Promise<Response>((_resolve, reject) => {
-				const signal = init?.signal;
-				if (!signal) return; // Defensive: never settles otherwise.
-				if (signal.aborted) {
-					reject(new DOMException("aborted", "AbortError"));
-					return;
-				}
-				signal.addEventListener("abort", () => {
-					reject(new DOMException("aborted", "AbortError"));
-				});
-			});
-		});
+		using _hook = hookFetch((_input, init, _next) => hangUntilAborted<Response>(init?.signal));
 
 		const controller = new AbortController();
 		const pending = renderHtmlToText(
 			"https://example.com/article",
-			html,
+			"<html><body><p>short</p></body></html>",
 			30,
 			settings,
 			controller.signal,
 			null,
-		).catch(err => err);
+		).catch(err => err as Error);
 
 		controller.abort();
 		const outcome = await pending;
 		expect(outcome).toBeInstanceOf(Error);
-		expect(
-			(outcome as Error).name === "AbortError" || (outcome as Error).message.toLowerCase().includes("abort"),
-		).toBe(true);
+		const err = outcome as Error;
+		expect(err.name === "AbortError" || err.message.toLowerCase().includes("abort")).toBe(true);
+	});
+
+	it("sequential remote stalls (Parallel + Jina) stay within the overall reader-mode budget", async () => {
+		// Reviewer concern from PR #1453: a stalled Parallel attempt followed
+		// by a stalled Jina attempt must not each consume a fresh
+		// `remoteBudgetMs`. The remote sub-signals are tied to `overallSignal`,
+		// so the second remote attempt must abort as soon as the overall
+		// budget is exhausted — total remote time ≤ overall budget.
+		const settings = Settings.isolated({ "providers.parallelFetch": true });
+
+		vi.spyOn(parallel, "findParallelApiKey").mockReturnValue("test-key");
+		vi.spyOn(parallel, "extractWithParallel").mockImplementation(async (_urls, options, _storage) =>
+			hangUntilAborted<parallel.ParallelExtractResult>(options.signal),
+		);
+
+		using _hook = hookFetch((input, init, _next) => {
+			if (String(input).startsWith("https://r.jina.ai/")) {
+				return hangUntilAborted<Response>(init?.signal);
+			}
+			return new Response("", { status: 404 });
+		});
+
+		const started = Date.now();
+		// `timeout: 3` → overall budget = 3s, REMOTE_READER_MAX_MS = 10s.
+		// Pre-fix: each remote attempt had a fresh 3s timer → ~6s total.
+		// Post-fix: sub-signal combines `overallSignal` + 10s timer, so the
+		// second attempt aborts immediately once the 3s overall budget hits.
+		const result = await renderHtmlToText("https://example.com/article", SUBSTANTIVE_HTML, 3, settings, undefined, null);
+		const elapsedMs = Date.now() - started;
+
+		expect(result.ok).toBe(true);
+		expect(["native", "trafilatura", "lynx"]).toContain(result.method);
+		// Must stay under the overall budget plus a small native-render margin —
+		// crucially well below `2 * timeout` (the pre-fix worst case).
+		expect(elapsedMs).toBeLessThan(3_800);
 	});
 });


### PR DESCRIPTION
## Repro

`read(path=<html-url>)` reader mode aborts before trying local fallback renderers when the Jina reader endpoint stalls. With `https://r.jina.ai/` unreachable, a 20s reader-mode budget is consumed entirely by the hung Jina fetch and `read` returns `Operation aborted` instead of running trafilatura, lynx, or the in-process native renderer.

Reproduced with a focused test that mocks `globalThis.fetch` via `hookFetch` so `https://r.jina.ai/*` hangs until aborted, then drives `renderHtmlToText` with a 2 s reader-mode budget:

```
bun --cwd=packages/coding-agent test test/tools/fetch-jina-stall.test.ts
```

Before the fix the call would reject with an `AbortError`; with the fix it returns `{ ok: true, method: "native" }` well within the 2 s budget.

## Cause

`packages/coding-agent/src/tools/fetch.ts` `renderHtmlToText` built one `AbortSignal` (`ptree.combineSignals(userSignal, timeout * 1000)`) and reused it for every renderer — Parallel extract, Jina, trafilatura, lynx, native — plus the catch handler's `signal?.throwIfAborted()`. When Jina hung until the overall timer fired, the shared signal aborted and the catch immediately re-threw, so trafilatura/lynx/native were never reached. The native converter is purely in-process and would otherwise have succeeded on the already-loaded HTML.

## Fix

- Add `REMOTE_READER_MAX_MS = 10_000` and pass each remote renderer (Parallel extract, Jina) its own combined signal of `userSignal + min(timeout * 1000, REMOTE_READER_MAX_MS)`, so a stalled remote endpoint can no longer consume the entire reader-mode budget.
- In every renderer catch handler, rethrow only on real `userSignal` cancellation (`userSignal?.throwIfAborted()`), not on remote sub-budget or overall budget expiry.
- Wrap trafilatura and lynx in their own try/catch so an `ensureTool`/subprocess abort does not skip the native fallback.
- Keep the overall reader-mode budget unchanged via `overallSignal` for trafilatura/lynx subprocesses; the native renderer (purely local, no network/subprocess) is always attempted last and works on the already-loaded HTML even when the overall budget has elapsed.
- Export `renderHtmlToText` for the regression test.

## Verification

- `bun --cwd=packages/coding-agent test test/tools/fetch-jina-stall.test.ts test/tools/fetch-raw-mode.test.ts test/tools/fetch-url-selectors.test.ts test/tools/fetch-kagi-toggle.test.ts` → 33 pass / 0 fail.
- `bun --cwd=packages/coding-agent run check:types` → clean.
- Skipped the pre-publish gate: `bun check` fails on `main` for an unrelated `@oh-my-pi/pi-ai` typecheck error in `test/xai-oauth-bundle.test.ts` (`Property 'supportsReasoningEffort' does not exist on type 'AnthropicCompat | OpenAICompat'`, introduced by upstream commit `bd62a903a`); this diff touches neither `packages/ai` nor that assertion.

Fixes #1449