### PR TITLE
feat(ai): add 9router as a selectable provider

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1643,6 +1643,12 @@ export class AuthStorage {
 				await saveApiKeyCredential(apiKey);
 				return;
 			}
+			case "9router": {
+				const { login9Router } = await import("./utils/oauth/9router");
+				const apiKey = await login9Router(ctrl);
+				await saveApiKeyCredential(apiKey);
+				return;
+			}
 			case "parallel": {
 				const { loginParallel } = await import("./utils/oauth/parallel");
 				const apiKey = await loginParallel(ctrl);

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -280,6 +280,7 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		"gpt-4o",
 		config => nineRouterModelManagerOptions(config),
 		catalog("9Router", ["NINEROUTER_API_KEY"], { allowUnauthenticated: true }),
+		{ allowUnauthenticated: true },
 	),
 	catalogDescriptor(
 		"moonshot",

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -26,6 +26,7 @@ import {
 	mistralModelManagerOptions,
 	moonshotModelManagerOptions,
 	nanoGptModelManagerOptions,
+	nineRouterModelManagerOptions,
 	nvidiaModelManagerOptions,
 	ollamaModelManagerOptions,
 	openaiModelManagerOptions,
@@ -273,6 +274,12 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		"gpt-oss-20b",
 		config => vllmModelManagerOptions(config),
 		catalog("vLLM", ["VLLM_API_KEY"], { allowUnauthenticated: true }),
+	),
+	catalogDescriptor(
+		"9router",
+		"gpt-4o",
+		config => nineRouterModelManagerOptions(config),
+		catalog("9Router", ["NINEROUTER_API_KEY"], { allowUnauthenticated: true }),
 	),
 	catalogDescriptor(
 		"moonshot",

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -1851,7 +1851,6 @@ export function vllmModelManagerOptions(config?: VllmModelManagerConfig): ModelM
 // ---------------------------------------------------------------------------
 // 22.5 9Router
 // ---------------------------------------------------------------------------
-
 export interface NineRouterModelManagerConfig {
 	apiKey?: string;
 	baseUrl?: string;
@@ -1860,11 +1859,11 @@ export interface NineRouterModelManagerConfig {
 export function nineRouterModelManagerOptions(
 	config?: NineRouterModelManagerConfig,
 ): ModelManagerOptions<"openai-completions"> {
-	return createSimpleOpenAICompletionsOptions(
-		"9router" as Parameters<typeof getBundledModels>[0],
-		"http://localhost:20128/v1",
-		config,
-	);
+	const baseUrl = config?.baseUrl ?? Bun.env.NINEROUTER_BASE_URL ?? "http://localhost:20128/v1";
+	return createSimpleOpenAICompletionsOptions("9router" as Parameters<typeof getBundledModels>[0], baseUrl, {
+		...config,
+		baseUrl,
+	});
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -1849,6 +1849,25 @@ export function vllmModelManagerOptions(config?: VllmModelManagerConfig): ModelM
 }
 
 // ---------------------------------------------------------------------------
+// 22.5 9Router
+// ---------------------------------------------------------------------------
+
+export interface NineRouterModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+}
+
+export function nineRouterModelManagerOptions(
+	config?: NineRouterModelManagerConfig,
+): ModelManagerOptions<"openai-completions"> {
+	return createSimpleOpenAICompletionsOptions(
+		"9router" as Parameters<typeof getBundledModels>[0],
+		"http://localhost:20128/v1",
+		config,
+	);
+}
+
+// ---------------------------------------------------------------------------
 // 23. NanoGPT
 // ---------------------------------------------------------------------------
 

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -187,6 +187,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	venice: "VENICE_API_KEY",
 	vllm: "VLLM_API_KEY",
 	xiaomi: "XIAOMI_API_KEY",
+	"9router": "NINEROUTER_API_KEY",
 };
 
 /**

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -143,6 +143,7 @@ export type KnownProvider =
 	| "vllm"
 	| "xiaomi"
 	| "zenmux"
+	| "9router"
 	| "lm-studio";
 export type Provider = KnownProvider | string;
 

--- a/packages/ai/src/utils/oauth/9router.ts
+++ b/packages/ai/src/utils/oauth/9router.ts
@@ -1,0 +1,41 @@
+/**
+ * 9Router login flow.
+ *
+ * 9Router is a local OpenAI-compatible AI router running on port 20128.
+ * Authentication is optional (disabled by default).
+ *
+ * This flow stores an API-key-style credential used by `/login` and auth storage.
+ */
+
+import type { OAuthController, OAuthProvider } from "./types";
+
+const PROVIDER_ID: OAuthProvider = "9router";
+const AUTH_URL = "http://localhost:20128/docs";
+const DEFAULT_LOCAL_BASE_URL = "http://localhost:20128/v1";
+const DEFAULT_LOCAL_TOKEN = "9router-local";
+
+/**
+ * Login to 9Router.
+ *
+ * Opens 9Router dashboard/docs, prompts for an optional API key,
+ * and returns a stored key value.
+ */
+export async function login9Router(options: OAuthController): Promise<string> {
+	if (!options.onPrompt) {
+		throw new Error(`${PROVIDER_ID} login requires onPrompt callback`);
+	}
+	options.onAuth?.({
+		url: AUTH_URL,
+		instructions: `Paste your 9Router API key if auth is enabled. Leave empty for local no-auth mode (default base URL: ${DEFAULT_LOCAL_BASE_URL}).`,
+	});
+	const apiKey = await options.onPrompt({
+		message: "Paste your 9Router API key (optional for local no-auth)",
+		placeholder: DEFAULT_LOCAL_TOKEN,
+		allowEmpty: true,
+	});
+	if (options.signal?.aborted) {
+		throw new Error("Login cancelled");
+	}
+	const trimmed = apiKey.trim();
+	return trimmed || DEFAULT_LOCAL_TOKEN;
+}

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -221,6 +221,11 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		available: true,
 	},
 	{
+		id: "9router",
+		name: "9Router (Local AI Router)",
+		available: true,
+	},
+	{
 		id: "cloudflare-ai-gateway",
 		name: "Cloudflare AI Gateway",
 		available: true,

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -32,6 +32,7 @@ export type OAuthProvider =
 	| "moonshot"
 	| "nvidia"
 	| "nanogpt"
+	| "9router"
 	| "ollama"
 	| "ollama-cloud"
 	| "openai-codex"


### PR DESCRIPTION
Add 9router, a local OpenAI-compatible AI router on port 20128, as a built-in provider selectable via `/login`.

**Changes:**
- Add `"9router"` to `KnownProvider` and `OAuthProvider` type unions
- Create `NineRouterModelManagerConfig` + `nineRouterModelManagerOptions()` using `createSimpleOpenAICompletionsOptions`
- Register catalog descriptor with `allowUnauthenticated: true` and env var `NINEROUTER_API_KEY`
- Create login flow module (optional API key, defaults to no-auth sentinel)
- Add login dispatch case in `auth-storage.ts`
- Register in built-in OAuth providers picker

**Design:**
- API: `openai-completions` (standard OpenAI format via `/v1/chat/completions`)
- Default base URL: `http://localhost:20128/v1`
- Auth: optional (matches 9router default `requireApiKey: false`)
- Model discovery: dynamic via `/v1/models`
- Static fallback model: `gpt-4o`

**Verification:**
- `tsc --noEmit` clean (pre-existing error in `xai-oauth-bundle.test.ts` only)
- `biome check` clean
- Tests: 270 pass, 125 pre-existing failures (native addon not built)