### PR TITLE
feat(coding-agent): support per-task task agents

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2133,6 +2133,9 @@
 
 - Changed the JJ utility API to mirror Git's scoped helpers: repository operations now live under `jj.repo` (`root`, `resolve`, `is`, `clearRootCache`), and diff file listing is available as `jj.diff.changedFiles`.
 - Changed the `search_tool_bm25` tool description to name the hidden discoverable built-in tools (e.g. `write`, `find`, `search`, `lsp`, `task`) when `tools.discoveryMode: "all"` is active, so a model can form a targeted discovery query by name instead of guessing or falling back to shell. `mcp-only` mode is unchanged (no built-ins are advertised) and the `Total discoverable tools available: N` count still includes them.
+### Added
+
+- Added per-task agent overrides to the `task` tool so mixed batches can resolve each task's agent independently while preserving the top-level default agent ([#1403](https://github.com/can1357/oh-my-pi/issues/1403)).
 
 ## [15.8.1] - 2026-06-02
 

--- a/packages/coding-agent/src/prompts/tools/task.md
+++ b/packages/coding-agent/src/prompts/tools/task.md
@@ -17,6 +17,7 @@
 {{#if batchEnabled}}
 - `context`: shared background prepended to every assignment — goal, constraints, shared contract (see context-fmt); REQUIRED, session-specific only
 - `tasks`: tasks to spawn — one subagent per item, all in parallel:
+  - `agent`: optional agent type override for this item; defaults to the top-level `agent`
   - `assignment`: complete self-contained instructions; one-liners and missing acceptance criteria are PROHIBITED
   - `id`: stable agent id, CamelCase, ≤32 chars; generated when omitted
   - `description`: UI label only — subagent never sees it

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -314,7 +314,7 @@ function resolveSpawnItems(params: TaskParams): TaskItem[] {
  * item's `isolated` (batch form) wins over the top-level flag (flat form).
  */
 function spawnParamsFor(params: TaskParams, item: TaskItem): TaskParams {
-	const spawn: TaskParams = { agent: params.agent };
+	const spawn: TaskParams = { agent: effectiveTaskAgentName(params, item) };
 	if (item.id !== undefined) spawn.id = item.id;
 	if (item.description !== undefined) spawn.description = item.description;
 	if (item.role !== undefined) spawn.role = item.role;
@@ -434,6 +434,123 @@ function discoverAgentsForCreate(cwd: string): Promise<DiscoveryResult> {
 	}
 	return pending;
 }
+interface TaskAgentResolution {
+	agents: AgentDefinition[];
+	error?: undefined;
+}
+
+interface TaskAgentResolutionError {
+	agents?: undefined;
+	error: string;
+}
+
+function isTaskAgentResolutionError(
+	resolution: TaskAgentResolution | TaskAgentResolutionError,
+): resolution is TaskAgentResolutionError {
+	return resolution.error !== undefined;
+}
+
+function effectiveTaskAgentName(params: TaskParams, task: TaskItem): string {
+	return task.agent ?? params.agent ?? "";
+}
+
+function taskAgentTarget(task: TaskItem, index: number): string {
+	const id = typeof task.id === "string" && task.id.trim() ? task.id : `index ${index}`;
+	return `task ${id}`;
+}
+
+function formatResolvedAgentBatchLabel(agents: readonly AgentDefinition[]): string {
+	if (agents.length === 0) return "none";
+	const counts = new Map<string, number>();
+	for (const agent of agents) {
+		counts.set(agent.name, (counts.get(agent.name) ?? 0) + 1);
+	}
+	if (counts.size === 1) return agents[0]?.name ?? "none";
+	return `mixed (${Array.from(counts, ([name, count]) => `${name}×${count}`).join(", ")})`;
+}
+
+function formatApprovalAgentSummary(
+	defaultAgent: string | undefined,
+	tasks: readonly (Partial<TaskItem> | undefined)[],
+): { label: string; mixed: boolean } | undefined {
+	const counts = new Map<string, number>();
+	if (tasks.length === 0) {
+		if (defaultAgent) counts.set(defaultAgent, 1);
+	} else {
+		for (const task of tasks) {
+			const agent = task?.agent ?? defaultAgent;
+			if (!agent) continue;
+			counts.set(agent, (counts.get(agent) ?? 0) + 1);
+		}
+	}
+	if (counts.size === 0) return undefined;
+	if (counts.size === 1) {
+		return { label: truncateForPrompt(Array.from(counts.keys())[0] ?? ""), mixed: false };
+	}
+	return {
+		label: `mixed (${Array.from(counts, ([agent, count]) => `${truncateForPrompt(agent)}×${count}`).join(", ")})`,
+		mixed: true,
+	};
+}
+
+function resolveTaskAgents(
+	params: TaskParams,
+	tasks: readonly TaskItem[],
+	agents: readonly AgentDefinition[],
+	options: {
+		disabledAgents: readonly string[];
+		blockedAgent: string | undefined;
+		parentSpawns: string;
+	},
+): TaskAgentResolution | TaskAgentResolutionError {
+	const available = agents.map(agent => agent.name).join(", ") || "none";
+	const enabled =
+		options.disabledAgents.length > 0
+			? agents.filter(agent => !options.disabledAgents.includes(agent.name)).map(agent => agent.name)
+			: agents.map(agent => agent.name);
+	const allowedSpawns =
+		options.parentSpawns === "" || options.parentSpawns === "*"
+			? null
+			: new Set(
+					options.parentSpawns
+						.split(",")
+						.map(name => name.trim())
+						.filter(Boolean),
+				);
+
+	const isSpawnAllowed = (agentName: string): boolean => {
+		if (options.parentSpawns === "") return false;
+		if (options.parentSpawns === "*") return true;
+		return allowedSpawns?.has(agentName) ?? false;
+	};
+
+	const resolvedAgents: AgentDefinition[] = [];
+	for (let index = 0; index < tasks.length; index++) {
+		const task = tasks[index];
+		const agentName = effectiveTaskAgentName(params, task);
+		const target = taskAgentTarget(task, index);
+		const agent = agents.find(agent => agent.name === agentName);
+		if (!agent) {
+			return { error: `Unknown agent "${agentName}" for ${target}. Available: ${available}` };
+		}
+		if (options.disabledAgents.length > 0 && options.disabledAgents.includes(agentName)) {
+			return {
+				error: `Agent "${agentName}" for ${target} is disabled in settings. Enable it via /agents, or use a different agent type.${enabled.length > 0 ? ` Available: ${enabled.join(", ")}` : ""}`,
+			};
+		}
+		if (options.blockedAgent && agentName === options.blockedAgent) {
+			return {
+				error: `Cannot spawn ${options.blockedAgent} agent for ${target} from within itself (recursion prevention). Use a different agent type.`,
+			};
+		}
+		if (!isSpawnAllowed(agentName)) {
+			const allowed = options.parentSpawns === "" ? "none (spawns disabled for this agent)" : options.parentSpawns;
+			return { error: `Cannot spawn '${agentName}' for ${target}. Allowed: ${allowed}` };
+		}
+		resolvedAgents.push(agent);
+	}
+	return { agents: resolvedAgents };
+}
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Tool Class
@@ -452,36 +569,48 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 	readonly formatApprovalDetails = (args: unknown): string[] => {
 		const params = args as Partial<TaskParams>;
 		const lines: string[] = [];
-		if (typeof params.agent === "string") {
-			lines.push(`Agent: ${truncateForPrompt(params.agent)}`);
-		}
-		if (typeof params.role === "string" && params.role.trim()) {
-			lines.push(`Role: ${truncateForPrompt(params.role)}`);
-		}
-		if (typeof params.id === "string" && params.id.trim()) {
-			lines.push(`Task: ${truncateForPrompt(params.id)}`);
-		}
-		if (typeof params.assignment === "string") {
-			lines.push(`Assignment:\n${truncateForPrompt(params.assignment)}`);
+		const defaultAgent = typeof params.agent === "string" ? params.agent : undefined;
+		const tasks = Array.isArray(params.tasks) ? params.tasks : [];
+		const agentSummary = formatApprovalAgentSummary(defaultAgent, tasks);
+		if (agentSummary) {
+			lines.push(`${agentSummary.mixed ? "Agents" : "Agent"}: ${agentSummary.label}`);
 		}
 		if (typeof params.context === "string" && params.context.trim()) {
 			lines.push(`Context:\n${truncateForPrompt(params.context)}`);
 		}
-		const tasks = Array.isArray(params.tasks) ? params.tasks : [];
 		const firstTask = tasks[0];
-		if (firstTask) {
-			if (typeof firstTask.id === "string" && firstTask.id.trim()) {
-				lines.push(`Task: ${truncateForPrompt(firstTask.id)}`);
+		if (!firstTask) {
+			if (typeof params.role === "string" && params.role.trim()) {
+				lines.push(`Role: ${truncateForPrompt(params.role)}`);
 			}
-			if (typeof firstTask.role === "string" && firstTask.role.trim()) {
-				lines.push(`Role: ${truncateForPrompt(firstTask.role)}`);
+			if (typeof params.id === "string" && params.id.trim()) {
+				lines.push(`Task: ${truncateForPrompt(params.id)}`);
 			}
-			if (typeof firstTask.assignment === "string") {
-				lines.push(`Assignment:\n${truncateForPrompt(firstTask.assignment)}`);
+			if (typeof params.assignment === "string") {
+				lines.push(`Assignment:\n${truncateForPrompt(params.assignment)}`);
 			}
-			if (tasks.length > 1) {
-				lines.push(`+${tasks.length - 1} more task${tasks.length === 2 ? "" : "s"}`);
-			}
+			return lines;
+		}
+		const taskId = typeof firstTask.id === "string" && firstTask.id.trim() ? firstTask.id : "(missing)";
+		const firstTaskAgent = firstTask.agent ?? defaultAgent;
+		const taskAgentSuffix =
+			firstTaskAgent && (agentSummary?.mixed === true || firstTask.agent !== undefined)
+				? ` (agent: ${truncateForPrompt(firstTaskAgent)})`
+				: "";
+		lines.push(`Task: ${truncateForPrompt(taskId)}${taskAgentSuffix}`);
+		if (typeof firstTask.role === "string" && firstTask.role.trim()) {
+			lines.push(`Role: ${truncateForPrompt(firstTask.role)}`);
+		}
+		const assignment = typeof firstTask.assignment === "string" ? firstTask.assignment : "(missing)";
+		lines.push(`Assignment:\n${truncateForPrompt(assignment)}`);
+		if (tasks.length > 1) {
+			const hiddenTasks = tasks.slice(1);
+			const hiddenAgentSummary = formatApprovalAgentSummary(defaultAgent, hiddenTasks);
+			const hiddenAgentSuffix =
+				hiddenAgentSummary && (agentSummary?.mixed === true || hiddenTasks.some(task => task?.agent))
+					? ` (${hiddenAgentSummary.mixed ? "agents" : "agent"}: ${hiddenAgentSummary.label})`
+					: "";
+			lines.push(`+${tasks.length - 1} more task${tasks.length === 2 ? "" : "s"}${hiddenAgentSuffix}`);
 		}
 		return lines;
 	};
@@ -567,7 +696,17 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		}
 
 		const spawnItems = resolveSpawnItems(params);
-		const selectedAgent = this.#discoveredAgents.find(agent => agent.name === params.agent);
+		const { agents } = await discoverAgents(this.session.cwd);
+		const agentResolution = resolveTaskAgents(params, spawnItems, agents, {
+			disabledAgents: this.session.settings.get("task.disabledAgents") as string[],
+			blockedAgent: this.#blockedAgent,
+			parentSpawns: this.session.getSessionSpawns() ?? "*",
+		});
+		if (isTaskAgentResolutionError(agentResolution)) {
+			return createTaskModeError(agentResolution.error);
+		}
+		const resolvedAgents = agentResolution.agents;
+		const hasBlockingAgent = resolvedAgents.some(agent => agent.blocking === true);
 		const asyncEnabled = this.session.settings.get("async.enabled");
 		const manager = asyncEnabled ? this.session.asyncJobManager : undefined;
 		const depthCapacity = canSpawnAtDepth(
@@ -578,11 +717,11 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		// Coordination only makes sense when the siblings keep running after this
 		// call returns (async). In the sync fallback they have already completed,
 		// so a "coordinate while they run" hint would misfire.
-		const willRunAsync = !!manager && selectedAgent?.blocking !== true;
+		const willRunAsync = !!manager && !hasBlockingAgent;
 		const advisory = this.session.suppressSpawnAdvisory
 			? undefined
 			: composeSpawnAdvisory({
-					agentName: params.agent,
+					agentName: resolvedAgents.length === 1 ? resolvedAgents[0]?.name : params.agent,
 					items: spawnItems,
 					depthCapacity,
 					ircEnabled,
@@ -604,9 +743,9 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			if (!appended) content.push({ type: "text", text: advisory });
 			return { ...result, content };
 		};
-		if (!asyncEnabled || !manager || selectedAgent?.blocking === true) {
+		if (!asyncEnabled || !manager || hasBlockingAgent) {
 			// Sync fallback: async execution disabled, orphaned host that never
-			// wired a job manager, or an agent definition that declares
+			// wired a job manager, or any resolved agent definition that declares
 			// `blocking: true`. The session-scoped semaphore still bounds fan-out
 			// across parallel task calls.
 			if (asyncEnabled && !manager) {
@@ -618,21 +757,25 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		// Resolve agent ids up front so the immediate result can name them.
 		const outputManager =
 			this.session.agentOutputManager ?? new AgentOutputManager(this.session.getArtifactsDir ?? (() => null));
-		const agentLabel = params.agent ?? "task";
-		const agentSource = selectedAgent?.source ?? "bundled";
-		const spawns: Array<{ agentId: string; item: TaskItem; progress: AgentProgress }> = [];
+		const agentLabel = formatResolvedAgentBatchLabel(resolvedAgents);
+		const spawns: Array<{ agentId: string; item: TaskItem; agent: AgentDefinition; progress: AgentProgress }> = [];
 		for (let index = 0; index < spawnItems.length; index++) {
 			const item = spawnItems[index];
+			const agent = resolvedAgents[index];
+			if (!agent) {
+				throw new Error(`Missing resolved agent for ${taskAgentTarget(item, index)}`);
+			}
 			const agentId = await outputManager.allocate(item.id?.trim() || generateTaskName());
 			const assignment = (item.assignment ?? "").trim();
 			spawns.push({
 				agentId,
 				item,
+				agent,
 				progress: {
 					index,
 					id: agentId,
-					agent: agentLabel,
-					agentSource,
+					agent: agent.name,
+					agentSource: agent.source,
 					status: "pending",
 					task: renderSubagentUserPrompt(assignment),
 					assignment,
@@ -668,7 +811,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 			},
 		});
 
-		const started: Array<{ agentId: string; jobId: string; description?: string }> = [];
+		const started: Array<{ agentId: string; jobId: string; agentName: string; description?: string }> = [];
 		const failedSchedules: string[] = [];
 		for (const spawn of spawns) {
 			try {
@@ -687,10 +830,15 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					},
 				});
 				if (started.length === 0) primaryJobId = jobId;
-				started.push({ agentId: spawn.agentId, jobId, description: spawn.item.description });
+				started.push({
+					agentId: spawn.agentId,
+					jobId,
+					agentName: spawn.agent.name,
+					description: spawn.item.description,
+				});
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
-				failedSchedules.push(`${spawn.agentId}: ${message}`);
+				failedSchedules.push(`${spawn.agentId} (${spawn.agent.name}): ${message}`);
 				spawn.progress.status = "failed";
 				settledCount += 1;
 				failedCount += 1;
@@ -710,7 +858,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 		}
 
 		if (single) {
-			const { agentId, jobId, description } = started[0];
+			const { agentId, jobId, agentName, description } = started[0];
 			const coordinationHint = ircEnabled
 				? `DM \`${agentId}\` via \`irc\` to coordinate while it runs; use \`job\` only to inspect (\`list\`), wait (\`poll\`), or cancel a stuck task.`
 				: `Use \`job\` to inspect (\`list\`), wait (\`poll\`), or cancel a stuck task.`;
@@ -723,7 +871,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				content: [
 					{
 						type: "text",
-						text: `Spawned agent \`${agentId}\` (job \`${jobId}\`)${descriptionSuffix}. The result will be delivered when it yields. ${coordinationHint}`,
+						text: `Spawned agent \`${agentId}\` using ${agentName} (job \`${jobId}\`)${descriptionSuffix}. The result will be delivered when it yields. ${coordinationHint}`,
 					},
 				],
 				details: buildAsyncDetails("running", jobId),
@@ -738,8 +886,8 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 				? ` Failed to schedule ${failedSchedules.length} spawn${failedSchedules.length === 1 ? "" : "s"}: ${failedSchedules.join("; ")}.`
 				: "";
 		const startedListing = started
-			.map(({ agentId, jobId, description }) => {
-				const prefix = `- \`${agentId}\` (job \`${jobId}\`)`;
+			.map(({ agentId, jobId, agentName, description }) => {
+				const prefix = `- \`${agentId}\` (${agentName}, job \`${jobId}\`)`;
 				return description ? `${prefix} — ${description}` : prefix;
 			})
 			.join("\n");
@@ -1182,7 +1330,6 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 					details: { projectAgentsDir, results: [], totalDurationMs: Date.now() - startTime },
 				};
 			}
-
 			await fs.mkdir(effectiveArtifactsDir, { recursive: true });
 
 			// Allocate a unique ID across the session to prevent artifact collisions

--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -20,6 +20,7 @@ import {
 	formatStatusIcon,
 	replaceTabs,
 	type ToolUIStatus,
+	TRUNCATE_LENGTHS,
 	truncateToWidth,
 } from "../tools/render-utils";
 import {
@@ -177,6 +178,34 @@ export function formatTaskId(id: string): string {
 	// (e.g. "Anna.Bob"). Render the hierarchy with a ">" breadcrumb.
 	const segments = id.split(".");
 	return segments.length < 2 ? id : segments.join(">");
+}
+
+function formatAgentName(agent: string | undefined): string {
+	return agent ? truncateToWidth(replaceTabs(agent), TRUNCATE_LENGTHS.SHORT) : "";
+}
+
+const MIXED_AGENT_BATCH_LIMIT = 3;
+
+function formatCallAgentBatch(args: TaskParams): string {
+	const tasks = Array.isArray(args.tasks) ? args.tasks : [];
+	if (tasks.length === 0) return formatAgentName(args.agent);
+	const counts = new Map<string, number>();
+	for (const task of tasks) {
+		if (!task) continue;
+		const agent = task.agent ?? args.agent;
+		if (!agent) continue;
+		counts.set(agent, (counts.get(agent) ?? 0) + 1);
+	}
+	if (counts.size === 0) return formatAgentName(args.agent);
+	if (counts.size === 1) return formatAgentName(Array.from(counts.keys())[0] ?? args.agent);
+	const entries = Array.from(counts);
+	const visible = entries
+		.slice(0, MIXED_AGENT_BATCH_LIMIT)
+		.map(([agent, count]) => `${formatAgentName(agent)}×${count}`);
+	if (entries.length > MIXED_AGENT_BATCH_LIMIT) {
+		visible.push(formatMoreItems(entries.length - MIXED_AGENT_BATCH_LIMIT, "agent"));
+	}
+	return truncateToWidth(`mixed (${visible.join(", ")})`, TRUNCATE_LENGTHS.LINE);
 }
 
 const MISSING_YIELD_WARNING_PREFIX = "SYSTEM WARNING: Subagent exited without calling yield tool";
@@ -545,7 +574,7 @@ function renderTaskCallLines(args: Partial<TaskParams> | undefined, theme: Theme
 		}
 		lines.push(line);
 	}
-	lines.push(...renderTaskItemLines(args.tasks, theme));
+	lines.push(...renderTaskItemLines(args.tasks, theme, args.agent));
 	return lines;
 }
 
@@ -561,11 +590,14 @@ const COLLAPSED_AGENT_LIMIT = 4;
  * over time and trailing entries may be partially parsed — every field access
  * is defensive.
  */
-function renderTaskItemLines(tasks: TaskItem[] | undefined, theme: Theme): string[] {
+function renderTaskItemLines(tasks: TaskItem[] | undefined, theme: Theme, defaultAgent?: string): string[] {
 	if (!Array.isArray(tasks) || tasks.length === 0) return [];
 
 	const bullet = theme.fg("dim", "•");
 	const cap = Math.min(tasks.length, COLLAPSED_AGENT_LIMIT);
+	const defaultAgentName = typeof defaultAgent === "string" ? defaultAgent.trim() : "";
+	const hasPerTaskAgent = tasks.some(task => typeof task?.agent === "string" && task.agent.trim().length > 0);
+	const showAgent = hasPerTaskAgent || defaultAgentName.length === 0;
 	const lines: string[] = [];
 	for (let i = 0; i < cap; i++) {
 		const task = tasks[i] as Partial<TaskItem> | undefined;
@@ -575,6 +607,13 @@ function renderTaskItemLines(tasks: TaskItem[] | undefined, theme: Theme): strin
 		const desc = typeof task?.description === "string" ? task.description.trim() : "";
 		if (desc) {
 			line += `: ${theme.fg("muted", truncateToWidth(replaceTabs(desc), 64))}`;
+		}
+		if (showAgent) {
+			const taskAgent = typeof task?.agent === "string" ? task.agent.trim() : "";
+			const agentLabel = formatAgentName(taskAgent || defaultAgentName);
+			if (agentLabel) {
+				line += theme.fg("dim", ` [${agentLabel}]`);
+			}
 		}
 		if (task?.isolated === true) {
 			line += theme.fg("dim", " [isolated]");
@@ -644,7 +683,11 @@ export function renderCall(args: TaskParams, options: TaskRenderOptions, theme: 
 	// pending/hourglass icon would misread the call as something the turn
 	// waits on.
 	const header = renderStatusLine(
-		{ iconOverride: theme.styledSymbol("tool.task", "accent"), title: "Task", description: args.agent },
+		{
+			iconOverride: theme.styledSymbol("tool.task", "accent"),
+			title: "Task",
+			description: formatCallAgentBatch(args),
+		},
 		theme,
 	);
 	const assignmentSection = createAssignmentSectionRenderer(args, theme);
@@ -755,6 +798,7 @@ function renderAgentProgress(
 	} else if (progress.status === "completed") {
 		statusLine = appendAgentStats(statusLine, { ...progress, showResolvedModelBadge: showBadge }, theme);
 	}
+	statusLine += `${theme.sep.dot}${theme.fg("dim", formatAgentName(progress.agent))}`;
 
 	lines.push(statusLine);
 
@@ -1051,6 +1095,7 @@ function renderAgentResult(
 		theme,
 	);
 	statusLine += `${theme.sep.dot}${theme.fg("dim", formatDuration(result.durationMs))}`;
+	statusLine += `${theme.sep.dot}${theme.fg("dim", formatAgentName(result.agent))}`;
 
 	if (result.truncated) {
 		statusLine += ` ${theme.fg("warning", "[truncated]")}`;

--- a/packages/coding-agent/src/task/types.ts
+++ b/packages/coding-agent/src/task/types.ts
@@ -83,6 +83,7 @@ const ROLE_INPUT_SCHEMA = `string <= ${ROLE_INPUT_MAX}` as const;
 export const taskItemSchema = type({
 	"id?": "string",
 	"description?": "string",
+	"agent?": "string",
 	"role?": ROLE_INPUT_SCHEMA,
 	assignment: "string",
 	"+": "delete",
@@ -90,6 +91,7 @@ export const taskItemSchema = type({
 const taskItemSchemaIsolated = type({
 	"id?": "string",
 	"description?": "string",
+	"agent?": "string",
 	"role?": ROLE_INPUT_SCHEMA,
 	assignment: "string",
 	"isolated?": "boolean",
@@ -102,6 +104,8 @@ export interface TaskItem {
 	id?: string;
 	/** UI label, not seen by the subagent. */
 	description?: string;
+	/** Agent type override for this item; default = top-level `agent`. */
+	agent?: string;
 	/** Specialist role/expertise this subagent embodies; shapes its system-prompt identity and display name. */
 	role?: string;
 	/** The work; required by the schema. */

--- a/packages/coding-agent/test/task/per-task-agent-overrides.test.ts
+++ b/packages/coding-agent/test/task/per-task-agent-overrides.test.ts
@@ -1,0 +1,533 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { toolWireSchema } from "@oh-my-pi/pi-ai/utils/schema";
+import { AsyncJobManager } from "../../src/async";
+import type { ModelRegistry } from "../../src/config/model-registry";
+import { resetSettingsForTest, Settings } from "../../src/config/settings";
+import type { LoadExtensionsResult } from "../../src/extensibility/extensions/types";
+import { getThemeByName } from "../../src/modes/theme/theme";
+import type { CreateAgentSessionOptions, CreateAgentSessionResult } from "../../src/sdk";
+import * as sdkModule from "../../src/sdk";
+import type { AgentSession, AgentSessionEvent, PromptOptions } from "../../src/session/agent-session";
+import { TaskTool } from "../../src/task";
+import * as discoveryModule from "../../src/task/discovery";
+import { taskToolRenderer } from "../../src/task/render";
+import type { AgentDefinition, TaskParams } from "../../src/task/types";
+import type { ToolSession } from "../../src/tools";
+import "../../src/tools/yield";
+import { EventBus } from "../../src/utils/event-bus";
+
+const okSchema = {
+	type: "object",
+	required: ["ok"],
+	properties: { ok: { type: "boolean" } },
+};
+
+const exploreOutputSchema = { ...okSchema, title: "explore-output" };
+const librarianOutputSchema = { ...okSchema, title: "librarian-output" };
+
+function createAssistantStopMessage(text: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: text ? [{ type: "text", text }] : [],
+		api: "openai-responses",
+		provider: "openai",
+		model: "mock",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+function createYieldingSession(): AgentSession {
+	const listeners: Array<(event: AgentSessionEvent) => void> = [];
+	const state = { messages: [] as AssistantMessage[] };
+
+	const emit = (event: AgentSessionEvent) => {
+		for (const listener of listeners) listener(event);
+	};
+
+	return {
+		state,
+		agent: { state: { systemPrompt: ["test"] } },
+		model: undefined,
+		extensionRunner: undefined,
+		sessionManager: {
+			appendSessionInit: () => {},
+		},
+		getActiveToolNames: () => ["yield"],
+		setActiveToolsByName: async () => {},
+		subscribe: (listener: (event: AgentSessionEvent) => void) => {
+			listeners.push(listener);
+			return () => {
+				const index = listeners.indexOf(listener);
+				if (index >= 0) listeners.splice(index, 1);
+			};
+		},
+		prompt: async (_text: string, _options?: PromptOptions) => {
+			state.messages.push(createAssistantStopMessage("done"));
+			emit({
+				type: "tool_execution_end",
+				toolCallId: "yield-call",
+				toolName: "yield",
+				result: {
+					content: [{ type: "text", text: "Result submitted." }],
+					details: { status: "success", data: { ok: true } },
+				},
+				isError: false,
+			});
+		},
+		waitForIdle: async () => {},
+		getLastAssistantMessage: () => state.messages[state.messages.length - 1],
+		abort: async () => {},
+		dispose: async () => {},
+	} as unknown as AgentSession;
+}
+
+function createSession(
+	options: { asyncEnabled?: boolean; disabledAgents?: string[]; parentSpawns?: string } = {},
+): ToolSession {
+	const modelRegistry = {
+		authStorage: undefined,
+		refresh: async () => {},
+		getAvailable: () => [],
+		getApiKey: async () => null,
+	} as unknown as ModelRegistry;
+
+	return {
+		cwd: "/tmp",
+		hasUI: false,
+		enableLsp: false,
+		settings: Settings.isolated({
+			"async.enabled": options.asyncEnabled ?? false,
+			"task.isolation.mode": "none",
+			"task.maxConcurrency": 1,
+			"task.disabledAgents": options.disabledAgents ?? [],
+		}),
+		getSessionFile: () => null,
+		getSessionSpawns: () => options.parentSpawns ?? "*",
+		getModelString: () => "openai/default",
+		getActiveModelString: () => "openai/default",
+		modelRegistry,
+	} as unknown as ToolSession;
+}
+
+function createAgent(overrides: Partial<AgentDefinition> & Pick<AgentDefinition, "name">): AgentDefinition {
+	const { name, ...rest } = overrides;
+	return {
+		name,
+		description: `${name} agent`,
+		systemPrompt: `${name} prompt`,
+		source: "bundled",
+		...rest,
+	};
+}
+
+function createExploreAgent(): AgentDefinition {
+	return createAgent({
+		name: "explore",
+		tools: ["read"],
+		model: ["openai/gpt-explore"],
+		output: exploreOutputSchema,
+	});
+}
+
+function createLibrarianAgent(overrides: Partial<AgentDefinition> = {}): AgentDefinition {
+	return createAgent({
+		name: "librarian",
+		tools: ["web_search"],
+		model: ["anthropic/claude-librarian"],
+		output: librarianOutputSchema,
+		...overrides,
+	});
+}
+
+function mockAgents(agents: AgentDefinition[]): void {
+	vi.spyOn(discoveryModule, "discoverAgents").mockResolvedValue({
+		agents,
+		projectAgentsDir: null,
+	});
+}
+
+function mockCreateAgentSession(): { capturedOptions: CreateAgentSessionOptions[] } {
+	const capturedOptions: CreateAgentSessionOptions[] = [];
+	vi.spyOn(sdkModule, "createAgentSession").mockImplementation(async (options = {}) => {
+		capturedOptions.push(options);
+		return {
+			session: createYieldingSession(),
+			extensionsResult: {} as LoadExtensionsResult,
+			setToolUIContext: () => {},
+			eventBus: new EventBus(),
+		} satisfies CreateAgentSessionResult;
+	});
+	return { capturedOptions };
+}
+
+function textContent(result: { content: Array<{ type: string; text?: string }> }): string {
+	return result.content.find(part => part.type === "text")?.text ?? "";
+}
+
+type MinimalTaskResult = { agent: string; modelOverride?: string | string[] };
+
+function resultAgents(result: { details?: { results: MinimalTaskResult[] } }): string[] | undefined {
+	return result.details?.results.map(taskResult => taskResult.agent);
+}
+
+function resultModelOverrides(result: {
+	details?: { results: MinimalTaskResult[] };
+}): Array<string | string[] | undefined> | undefined {
+	return result.details?.results.map(taskResult => taskResult.modelOverride);
+}
+
+const originalBlockedAgent = Bun.env.PI_BLOCKED_AGENT;
+
+describe("task tool per-task agent overrides", () => {
+	beforeEach(async () => {
+		resetSettingsForTest();
+		await Settings.init({ inMemory: true, cwd: "/tmp", overrides: { "task.showResolvedModelBadge": false } });
+		AsyncJobManager.resetForTests();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+		AsyncJobManager.resetForTests();
+		resetSettingsForTest();
+		if (originalBlockedAgent === undefined) {
+			delete Bun.env.PI_BLOCKED_AGENT;
+		} else {
+			Bun.env.PI_BLOCKED_AGENT = originalBlockedAgent;
+		}
+	});
+
+	it("exposes optional per-task agent overrides in the task item schema", async () => {
+		mockAgents([createExploreAgent(), createLibrarianAgent()]);
+
+		const tool = await TaskTool.create(createSession());
+		const wire = toolWireSchema(tool) as { properties?: Record<string, unknown> };
+		const tasksSchema = wire.properties?.tasks as
+			| { items?: { properties?: Record<string, unknown>; required?: string[] } }
+			| undefined;
+		const itemSchema = tasksSchema?.items;
+
+		expect(itemSchema?.properties?.agent).toBeDefined();
+		expect(itemSchema?.required ?? []).not.toContain("agent");
+	});
+
+	it("keeps legacy same-agent batches on the top-level agent", async () => {
+		mockAgents([createExploreAgent()]);
+		const { capturedOptions } = mockCreateAgentSession();
+		const params: TaskParams = {
+			agent: "explore",
+			tasks: [
+				{ id: "ReadOne", description: "Read one", assignment: "Read the first file." },
+				{ id: "ReadTwo", description: "Read two", assignment: "Read the second file." },
+			],
+		};
+
+		const tool = await TaskTool.create(createSession());
+		const result = await tool.execute("tool-call", params);
+
+		expect(capturedOptions.map(options => options.agentDisplayName)).toEqual(["explore", "explore"]);
+		expect(capturedOptions.map(options => options.toolNames)).toEqual([
+			["read", "irc"],
+			["read", "irc"],
+		]);
+		expect(capturedOptions.map(options => options.outputSchema)).toEqual([exploreOutputSchema, exploreOutputSchema]);
+		expect(resultAgents(result)).toEqual(["explore", "explore"]);
+	});
+
+	it("runs mixed explore and librarian batches with each agent's own config", async () => {
+		mockAgents([createExploreAgent(), createLibrarianAgent()]);
+		const { capturedOptions } = mockCreateAgentSession();
+		const params: TaskParams = {
+			agent: "explore",
+			tasks: [
+				{ id: "Scout", description: "Scout code", assignment: "Inspect local code." },
+				{
+					id: "Research",
+					description: "Research docs",
+					assignment: "Read external docs.",
+					agent: "librarian",
+				},
+			],
+		};
+
+		const tool = await TaskTool.create(createSession());
+		const result = await tool.execute("tool-call", params);
+
+		expect(capturedOptions.map(options => options.agentDisplayName)).toEqual(["explore", "librarian"]);
+		expect(capturedOptions.map(options => options.toolNames)).toEqual([
+			["read", "irc"],
+			["web_search", "irc"],
+		]);
+		expect(capturedOptions.map(options => options.outputSchema)).toEqual([
+			exploreOutputSchema,
+			librarianOutputSchema,
+		]);
+		expect(resultAgents(result)).toEqual(["explore", "librarian"]);
+		expect(resultModelOverrides(result)).toEqual([["openai/gpt-explore"], ["anthropic/claude-librarian"]]);
+
+		const theme = (await getThemeByName("dark"))!;
+		const callText = Bun.stripANSI(
+			taskToolRenderer.renderCall(params, { expanded: false, isPartial: false }, theme).render(160).join("\n"),
+		);
+		expect(callText).toContain("mixed (explore×1, librarian×1)");
+
+		const resultText = Bun.stripANSI(
+			taskToolRenderer
+				.renderResult(
+					{ content: result.content, details: result.details },
+					{ expanded: false, isPartial: false },
+					theme,
+				)
+				.render(160)
+				.join("\n"),
+		);
+		expect(resultText).toContain("explore");
+		expect(resultText).toContain("librarian");
+	});
+
+	it("includes per-task agent overrides in approval details", async () => {
+		mockAgents([createExploreAgent(), createLibrarianAgent()]);
+		const tool = await TaskTool.create(createSession());
+
+		const lines = tool.formatApprovalDetails({
+			agent: "explore",
+			tasks: [
+				{ id: "Scout", description: "Scout code", assignment: "Inspect local code." },
+				{
+					id: "Research",
+					description: "Research docs",
+					assignment: "Read external docs.",
+					agent: "librarian",
+				},
+			],
+		});
+
+		expect(lines).toContain("Agents: mixed (explore×1, librarian×1)");
+		expect(lines).toContain("Task: Scout (agent: explore)");
+		expect(lines).toContain("+1 more task (agent: librarian)");
+	});
+
+	it("uses fresh discovery before synchronous fallback validation", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents")
+			.mockResolvedValueOnce({ agents: [createExploreAgent()], projectAgentsDir: null })
+			.mockResolvedValue({ agents: [createExploreAgent(), createLibrarianAgent()], projectAgentsDir: null });
+		const { capturedOptions } = mockCreateAgentSession();
+		const tool = await TaskTool.create(createSession({ asyncEnabled: false }));
+
+		const result = await tool.execute("tool-call", {
+			agent: "explore",
+			tasks: [
+				{ id: "Scout", description: "Scout code", assignment: "Inspect local code." },
+				{
+					id: "Research",
+					description: "Research docs",
+					assignment: "Read external docs.",
+					agent: "librarian",
+				},
+			],
+		});
+
+		expect(capturedOptions.map(options => options.agentDisplayName)).toEqual(["explore", "librarian"]);
+		expect(resultAgents(result)).toEqual(["explore", "librarian"]);
+	});
+
+	it("uses fresh discovery for async per-task agent preflight", async () => {
+		vi.spyOn(discoveryModule, "discoverAgents")
+			.mockResolvedValueOnce({ agents: [createExploreAgent()], projectAgentsDir: null })
+			.mockResolvedValue({ agents: [createExploreAgent(), createLibrarianAgent()], projectAgentsDir: null });
+		const { capturedOptions } = mockCreateAgentSession();
+		const deliveries: Array<{ jobId: string; text: string }> = [];
+		const manager = new AsyncJobManager({
+			onJobComplete: async (jobId, text) => {
+				deliveries.push({ jobId, text });
+			},
+		});
+		AsyncJobManager.setInstance(manager);
+
+		try {
+			const tool = await TaskTool.create(createSession({ asyncEnabled: true }));
+			const result = await tool.execute("tool-call", {
+				agent: "explore",
+				tasks: [
+					{ id: "Scout", description: "Scout code", assignment: "Inspect local code." },
+					{
+						id: "Research",
+						description: "Research docs",
+						assignment: "Read external docs.",
+						agent: "librarian",
+					},
+				],
+			});
+
+			expect(textContent(result)).toContain("using mixed (explore×1, librarian×1)");
+			expect(result.details?.progress?.map(progress => progress.agent)).toEqual(["explore", "librarian"]);
+
+			await manager.waitForAll();
+			expect(await manager.drainDeliveries({ timeoutMs: 2_000 })).toBe(true);
+			expect(capturedOptions.map(options => options.agentDisplayName)).toEqual(["explore", "librarian"]);
+			expect(deliveries.map(delivery => delivery.jobId)).toEqual(["Scout", "Research"]);
+		} finally {
+			await manager.dispose({ timeoutMs: 2_000 });
+		}
+	});
+
+	it("rejects an invalid per-task agent before dispatch", async () => {
+		mockAgents([createExploreAgent()]);
+		const { capturedOptions } = mockCreateAgentSession();
+		const tool = await TaskTool.create(createSession({ asyncEnabled: true }));
+
+		const result = await tool.execute("tool-call", {
+			agent: "explore",
+			tasks: [
+				{ id: "Scout", description: "Scout code", assignment: "Inspect local code." },
+				{ id: "Missing", description: "Missing agent", assignment: "Use a missing agent.", agent: "ghost" },
+			],
+		});
+
+		expect(textContent(result)).toContain('Unknown agent "ghost" for task Missing');
+		expect(capturedOptions).toHaveLength(0);
+		expect(result.details?.results).toEqual([]);
+	});
+
+	it("rejects disabled per-task agents before dispatch", async () => {
+		mockAgents([createExploreAgent(), createLibrarianAgent()]);
+		const { capturedOptions } = mockCreateAgentSession();
+		const tool = await TaskTool.create(createSession({ asyncEnabled: true, disabledAgents: ["librarian"] }));
+
+		const result = await tool.execute("tool-call", {
+			agent: "explore",
+			tasks: [
+				{ id: "Scout", description: "Scout code", assignment: "Inspect local code." },
+				{
+					id: "Research",
+					description: "Research docs",
+					assignment: "Read external docs.",
+					agent: "librarian",
+				},
+			],
+		});
+
+		expect(textContent(result)).toContain('Agent "librarian" for task Research is disabled');
+		expect(capturedOptions).toHaveLength(0);
+		expect(result.details?.results).toEqual([]);
+	});
+
+	it("rejects self-recursive per-task agents before dispatch", async () => {
+		Bun.env.PI_BLOCKED_AGENT = "librarian";
+		mockAgents([createExploreAgent(), createLibrarianAgent()]);
+		const { capturedOptions } = mockCreateAgentSession();
+		const tool = await TaskTool.create(createSession({ asyncEnabled: true }));
+
+		const result = await tool.execute("tool-call", {
+			agent: "explore",
+			tasks: [
+				{ id: "Scout", description: "Scout code", assignment: "Inspect local code." },
+				{
+					id: "Research",
+					description: "Research docs",
+					assignment: "Read external docs.",
+					agent: "librarian",
+				},
+			],
+		});
+
+		expect(textContent(result)).toContain("Cannot spawn librarian agent for task Research from within itself");
+		expect(capturedOptions).toHaveLength(0);
+		expect(result.details?.results).toEqual([]);
+	});
+
+	it("rejects spawn-disallowed per-task agents before dispatch", async () => {
+		mockAgents([createExploreAgent(), createLibrarianAgent()]);
+		const { capturedOptions } = mockCreateAgentSession();
+		const tool = await TaskTool.create(createSession({ asyncEnabled: true, parentSpawns: "explore" }));
+
+		const result = await tool.execute("tool-call", {
+			agent: "explore",
+			tasks: [
+				{ id: "Scout", description: "Scout code", assignment: "Inspect local code." },
+				{
+					id: "Research",
+					description: "Research docs",
+					assignment: "Read external docs.",
+					agent: "librarian",
+				},
+			],
+		});
+
+		expect(textContent(result)).toContain("Cannot spawn 'librarian' for task Research. Allowed: explore");
+		expect(capturedOptions).toHaveLength(0);
+		expect(result.details?.results).toEqual([]);
+	});
+
+	it("starts async mixed batches with resolved per-task agents", async () => {
+		mockAgents([createExploreAgent(), createLibrarianAgent()]);
+		const { capturedOptions } = mockCreateAgentSession();
+		const deliveries: Array<{ jobId: string; text: string }> = [];
+		const manager = new AsyncJobManager({
+			onJobComplete: async (jobId, text) => {
+				deliveries.push({ jobId, text });
+			},
+		});
+		AsyncJobManager.setInstance(manager);
+
+		try {
+			const tool = await TaskTool.create(createSession({ asyncEnabled: true }));
+			const result = await tool.execute("tool-call", {
+				agent: "explore",
+				tasks: [
+					{ id: "Scout", description: "Scout code", assignment: "Inspect local code." },
+					{
+						id: "Research",
+						description: "Research docs",
+						assignment: "Read external docs.",
+						agent: "librarian",
+					},
+				],
+			});
+
+			expect(textContent(result)).toContain("using mixed (explore×1, librarian×1)");
+			expect(result.details?.progress?.map(progress => progress.agent)).toEqual(["explore", "librarian"]);
+			expect(manager.getAllJobs().map(job => job.id)).toEqual(["Scout", "Research"]);
+
+			await manager.waitForAll();
+			expect(await manager.drainDeliveries({ timeoutMs: 2_000 })).toBe(true);
+
+			expect(capturedOptions.map(options => options.agentDisplayName)).toEqual(["explore", "librarian"]);
+			expect(deliveries.map(delivery => delivery.jobId)).toEqual(["Scout", "Research"]);
+		} finally {
+			await manager.dispose({ timeoutMs: 2_000 });
+		}
+	});
+
+	it("uses the synchronous path when any resolved agent is blocking", async () => {
+		mockAgents([createExploreAgent(), createLibrarianAgent({ blocking: true })]);
+		const { capturedOptions } = mockCreateAgentSession();
+		const tool = await TaskTool.create(createSession({ asyncEnabled: true }));
+
+		const result = await tool.execute("tool-call", {
+			agent: "explore",
+			tasks: [
+				{ id: "Scout", description: "Scout code", assignment: "Inspect local code." },
+				{
+					id: "Research",
+					description: "Research docs",
+					assignment: "Read external docs.",
+					agent: "librarian",
+				},
+			],
+		});
+
+		expect(textContent(result)).not.toContain("Async execution is enabled but no async job manager is available");
+		expect(capturedOptions.map(options => options.agentDisplayName)).toEqual(["explore", "librarian"]);
+		expect(resultAgents(result)).toEqual(["explore", "librarian"]);
+	});
+});

--- a/packages/coding-agent/test/task/render-call.test.ts
+++ b/packages/coding-agent/test/task/render-call.test.ts
@@ -55,6 +55,47 @@ describe("task renderer: streaming call preview", () => {
 		expect(out).toContain("task");
 	});
 
+	it("uses task agent overrides in the header and task row before the default agent streams", () => {
+		const args = {
+			tasks: [{ id: "Research", agent: "librarian", assignment: "Read external docs." }],
+		} as unknown as TaskParams;
+		const out = render(args);
+		const lines = out.split("\n");
+		const firstLine = lines[0] ?? "";
+		const row = lines.find(line => line.includes("Research")) ?? "";
+
+		expect(firstLine).toContain("librarian");
+		expect(firstLine).not.toContain("undefined");
+		expect(row).toContain("librarian");
+		expect(row).not.toContain("undefined");
+	});
+
+	it("summarizes mixed effective task agents in the header", () => {
+		const args = {
+			agent: "explore",
+			context: "# Goal\nDispatch mixed agents.",
+			tasks: [
+				{ id: "Scout", description: "Scout code", assignment: "Inspect local code." },
+				{
+					id: "Research",
+					description: "Research docs",
+					assignment: "Read external docs.",
+					agent: "librarian",
+				},
+			],
+		} as unknown as TaskParams;
+		const out = render(args);
+		const lines = out.split("\n");
+		const firstLine = lines[0] ?? "";
+		const scoutLine = lines.find(line => line.includes("Scout")) ?? "";
+		const researchLine = lines.find(line => line.includes("Research")) ?? "";
+
+		expect(firstLine).toContain("mixed (explore×1, librarian×1)");
+		expect(out).not.toContain("undefined");
+		expect(scoutLine).toContain("explore");
+		expect(researchLine).toContain("librarian");
+	});
+
 	it("always renders the full assignment markdown, collapsed or expanded", () => {
 		const assignmentLines = Array.from({ length: 6 }, (_, i) => `Step ${i + 1}: do the thing.`);
 		const args: TaskParams = {


### PR DESCRIPTION
## Summary
Adds optional per-task agent overrides to `task`: `tasks[].agent ?? agent`.

Mixed batches now:
- validate every effective agent before dispatch
- use each resolved agent's tools/model/output schema
- fall back to sync if any resolved agent is blocking
- show mixed headers plus per-task resolved agents
- preserve the current `task.batch` shape and no per-call `schema` behavior after merging latest `main`

Closes #1403

## Verified
- `bun --cwd=packages/coding-agent run check`
- `bun test packages/coding-agent/test/task/render-call.test.ts packages/coding-agent/test/task/per-task-agent-overrides.test.ts` attempted; blocked before tests by missing `pi_natives` addon. `bun --cwd=packages/natives run build` also blocked because `cargo` is not installed in this environment.