### PR TITLE
fix(mcp): bound optional HTTP SSE startup

### DIFF
--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -19,10 +19,17 @@ import { toJsonRpcError } from "../../mcp/types";
 import { createMCPTimeout, getNeverAbortSignal, isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "../timeout";
 
 const HTTP_SSE_CONNECT_TIMEOUT_MS = 1_000;
-
-function resolveSSEConnectTimeoutMs(configTimeout?: number): number {
+/**
+ * Best-effort startup deadline for the optional Streamable HTTP GET SSE listener.
+ *
+ * Returns `0` (disabled) when the operator has explicitly disabled MCP client-side
+ * timeouts via `timeout: 0` or `OMP_MCP_TIMEOUT_MS=0`, mirroring the rest of the
+ * MCP timeout surface. Otherwise caps the wait at one second and scales below
+ * short request timeouts so connect-time never exceeds the request budget.
+ */
+export function resolveSSEConnectTimeoutMs(configTimeout?: number): number {
 	const requestTimeout = resolveMCPTimeoutMs(configTimeout);
-	if (!isMCPTimeoutEnabled(requestTimeout)) return HTTP_SSE_CONNECT_TIMEOUT_MS;
+	if (!isMCPTimeoutEnabled(requestTimeout)) return 0;
 	const boundedTimeout = Math.min(HTTP_SSE_CONNECT_TIMEOUT_MS, Math.floor(requestTimeout / 4));
 	return Math.max(1, boundedTimeout);
 }
@@ -82,10 +89,14 @@ export class HttpTransport implements MCPTransport {
 
 		let response: Response;
 		let timedOut = false;
-		const timeoutId = setTimeout(() => {
-			timedOut = true;
-			this.#sseConnection?.abort();
-		}, resolveSSEConnectTimeoutMs(this.config.timeout));
+		const startupTimeoutMs = resolveSSEConnectTimeoutMs(this.config.timeout);
+		const timeoutId =
+			startupTimeoutMs > 0
+				? setTimeout(() => {
+						timedOut = true;
+						this.#sseConnection?.abort();
+					}, startupTimeoutMs)
+				: null;
 		try {
 			response = await fetch(this.config.url, {
 				method: "GET",
@@ -99,7 +110,7 @@ export class HttpTransport implements MCPTransport {
 			}
 			return;
 		} finally {
-			clearTimeout(timeoutId);
+			if (timeoutId !== null) clearTimeout(timeoutId);
 		}
 
 		if (response.status === 405 || !response.ok || !response.body) {

--- a/packages/coding-agent/src/mcp/transports/http.ts
+++ b/packages/coding-agent/src/mcp/transports/http.ts
@@ -16,8 +16,16 @@ import type {
 	MCPTransport,
 } from "../../mcp/types";
 import { toJsonRpcError } from "../../mcp/types";
-import { createMCPTimeout, getNeverAbortSignal, resolveMCPTimeoutMs } from "../timeout";
+import { createMCPTimeout, getNeverAbortSignal, isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "../timeout";
 
+const HTTP_SSE_CONNECT_TIMEOUT_MS = 1_000;
+
+function resolveSSEConnectTimeoutMs(configTimeout?: number): number {
+	const requestTimeout = resolveMCPTimeoutMs(configTimeout);
+	if (!isMCPTimeoutEnabled(requestTimeout)) return HTTP_SSE_CONNECT_TIMEOUT_MS;
+	const boundedTimeout = Math.min(HTTP_SSE_CONNECT_TIMEOUT_MS, Math.floor(requestTimeout / 4));
+	return Math.max(1, boundedTimeout);
+}
 /**
  * HTTP transport for MCP servers.
  * Uses POST for requests, supports SSE responses.
@@ -73,6 +81,11 @@ export class HttpTransport implements MCPTransport {
 		}
 
 		let response: Response;
+		let timedOut = false;
+		const timeoutId = setTimeout(() => {
+			timedOut = true;
+			this.#sseConnection?.abort();
+		}, resolveSSEConnectTimeoutMs(this.config.timeout));
 		try {
 			response = await fetch(this.config.url, {
 				method: "GET",
@@ -81,13 +94,16 @@ export class HttpTransport implements MCPTransport {
 			});
 		} catch (error) {
 			this.#sseConnection = null;
-			if (error instanceof Error && error.name !== "AbortError") {
+			if (error instanceof Error && error.name !== "AbortError" && !timedOut) {
 				this.onError?.(error);
 			}
 			return;
+		} finally {
+			clearTimeout(timeoutId);
 		}
 
 		if (response.status === 405 || !response.ok || !response.body) {
+			await response.body?.cancel();
 			this.#sseConnection = null;
 			return;
 		}

--- a/packages/coding-agent/test/mcp-http-transport.test.ts
+++ b/packages/coding-agent/test/mcp-http-transport.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import type { Server } from "bun";
 import { connectToServer } from "../src/mcp/client";
+import { resolveSSEConnectTimeoutMs } from "../src/mcp/transports/http";
 import type { MCPServerConnection } from "../src/mcp/types";
 
 let activeServer: Server<undefined> | undefined;
@@ -65,5 +66,35 @@ describe("HTTP MCP transport", () => {
 		} finally {
 			await connection?.transport.close();
 		}
+	});
+
+	describe("resolveSSEConnectTimeoutMs", () => {
+		const originalEnv = process.env.OMP_MCP_TIMEOUT_MS;
+
+		beforeEach(() => {
+			delete process.env.OMP_MCP_TIMEOUT_MS;
+		});
+
+		afterEach(() => {
+			if (originalEnv === undefined) delete process.env.OMP_MCP_TIMEOUT_MS;
+			else process.env.OMP_MCP_TIMEOUT_MS = originalEnv;
+		});
+
+		it("returns 0 when the server config disables the MCP timeout", () => {
+			expect(resolveSSEConnectTimeoutMs(0)).toBe(0);
+		});
+
+		it("returns 0 when OMP_MCP_TIMEOUT_MS disables the MCP timeout", () => {
+			process.env.OMP_MCP_TIMEOUT_MS = "0";
+			expect(resolveSSEConnectTimeoutMs(undefined)).toBe(0);
+		});
+
+		it("caps the startup deadline at one second for the default request budget", () => {
+			expect(resolveSSEConnectTimeoutMs(30_000)).toBe(1_000);
+		});
+
+		it("scales below short request budgets so connect-time never exceeds them", () => {
+			expect(resolveSSEConnectTimeoutMs(200)).toBe(50);
+		});
 	});
 });

--- a/packages/coding-agent/test/mcp-http-transport.test.ts
+++ b/packages/coding-agent/test/mcp-http-transport.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { Server } from "bun";
+import { connectToServer } from "../src/mcp/client";
+import type { MCPServerConnection } from "../src/mcp/types";
+
+let activeServer: Server<undefined> | undefined;
+
+afterEach(() => {
+	activeServer?.stop(true);
+	activeServer = undefined;
+});
+
+describe("HTTP MCP transport", () => {
+	it("continues initialization when the optional GET SSE listener does not respond", async () => {
+		let getRequests = 0;
+		let initializedNotifications = 0;
+		let connection: MCPServerConnection | undefined;
+
+		activeServer = Bun.serve({
+			port: 0,
+			async fetch(request) {
+				if (request.method === "GET") {
+					getRequests++;
+					return new Promise<Response>(() => {});
+				}
+
+				if (request.method === "DELETE") {
+					return new Response(null, { status: 204 });
+				}
+				const body = (await request.json()) as { id?: string | number; method?: string };
+				if (body.method === "initialize") {
+					return Response.json(
+						{
+							jsonrpc: "2.0",
+							id: body.id,
+							result: {
+								protocolVersion: "2025-03-26",
+								capabilities: { tools: {} },
+								serverInfo: { name: "storybook-repro", version: "0.0.0" },
+							},
+						},
+						{ headers: { "Mcp-Session-Id": "session-1" } },
+					);
+				}
+
+				if (body.method === "notifications/initialized") {
+					initializedNotifications++;
+					return new Response(null, { status: 202 });
+				}
+
+				return Response.json({ jsonrpc: "2.0", id: body.id, result: {} });
+			},
+		});
+
+		try {
+			connection = await connectToServer("storybook", {
+				type: "http",
+				url: String(activeServer.url),
+				timeout: 200,
+			});
+
+			expect(connection.serverInfo.name).toBe("storybook-repro");
+			expect(getRequests).toBe(1);
+			expect(initializedNotifications).toBe(1);
+		} finally {
+			await connection?.transport.close();
+		}
+	});
+});


### PR DESCRIPTION
## Repro
A minimal Streamable HTTP MCP server accepts `POST /mcp` initialize and returns a session id, but leaves the optional `GET /mcp` SSE listener pending forever. Running `bun .wt/repro-1460.ts` before the fix reproduced the failure with `Connection to MCP server "storybook" timed out after 100ms` and `{"getRequests":1,"initializedNotifications":0}`.

## Cause
`HttpTransport.startSSEListener()` in `packages/coding-agent/src/mcp/transports/http.ts` awaited the optional GET SSE `fetch()` without any startup deadline. `connectToServer()` calls that method from the initialize hook in `packages/coding-agent/src/mcp/client.ts` before sending `notifications/initialized`, so an unresponsive optional GET stream blocked the whole connection path.

## Fix
- Added a bounded startup timeout for the optional HTTP SSE GET listener, capped at one second and scaled below short MCP request timeouts.
- Treat the optional GET timeout like unsupported SSE by clearing the listener and continuing initialization.
- Added a regression test covering a POST-capable MCP server whose optional GET SSE listener never responds.

## Verification
`bun --cwd=packages/coding-agent test test/mcp-http-transport.test.ts` passed. `bun --cwd=packages/coding-agent test test/mcp-http-transport.test.ts test/mcp-timeout.test.ts test/mcp-roots-list.test.ts test/mcp-reconnect.test.ts test/mcp-tool-ordering.test.ts test/mcp-manager-subscription-action.test.ts` passed. `bun --cwd=packages/coding-agent run check` passed. Fixes #1460