### PR TITLE
fix(ai): heal DSML envelope leak on DeepSeek V4 via Ollama Cloud

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed DeepSeek V4 Pro leaking the full DSML chat-template tool-call envelope (`<｜DSML｜tool_calls><｜DSML｜invoke name="…">…</｜DSML｜tool_calls>`) into `chunk.message.content` on Ollama Cloud and into `delta.content` on the direct DeepSeek API / NVIDIA NIM / OpenRouter / Fireworks / OpenCode Zen. A new streaming envelope healer (`packages/ai/src/utils/dsml-tool-call-healing.ts`) parses the envelope into structured `tool_calls`, suppresses the leaked text, and promotes `done_reason: "stop"` to `"toolUse"` so the agent loop dispatches the healed call instead of ending the turn ([#1462](https://github.com/can1357/oh-my-pi/issues/1462))
+
 ## [15.5.7] - 2026-05-27
 ### Added
 - `SimpleStreamOptions.openrouterVariant` (`"nitro"`, `"floor"`, `"online"`, `"exacto"`, …) — when set, appends `:<variant>` to OpenRouter model IDs at request time, leaving ids that already carry an explicit `:suffix` untouched. Plumbed through `openai-completions` and the pi-native gateway forwarder.

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -15,6 +15,11 @@ import type {
 	UserMessage,
 } from "../types";
 import { normalizeSystemPrompts } from "../utils";
+import {
+	DsmlToolCallHealer,
+	type HealedDsmlToolCall,
+	modelMayLeakDsmlToolCalls,
+} from "../utils/dsml-tool-call-healing";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
 import { parseStreamingJson } from "../utils/json-parse";
@@ -373,6 +378,72 @@ export const streamOllama: StreamFunction<"ollama-chat"> = (
 		let activeThinkingIndex: number | undefined;
 		let activeTextIndex: number | undefined;
 		const activeToolIndices = new Set<number>();
+		const dsmlHealer = modelMayLeakDsmlToolCalls(model.provider, model.id)
+			? new DsmlToolCallHealer()
+			: undefined;
+		let dsmlHealedEmitted = false;
+
+		const endActiveTextBlock = (): void => {
+			if (activeTextIndex !== undefined) {
+				endTextBlock(stream, output, activeTextIndex);
+				activeTextIndex = undefined;
+			}
+		};
+		const endActiveThinkingBlock = (): void => {
+			if (activeThinkingIndex !== undefined) {
+				endThinkingBlock(stream, output, activeThinkingIndex);
+				activeThinkingIndex = undefined;
+			}
+		};
+		const appendVisibleText = (text: string): void => {
+			if (text.length === 0) return;
+			endActiveThinkingBlock();
+			if (activeTextIndex === undefined) {
+				output.content.push({ type: "text", text: "" });
+				activeTextIndex = output.content.length - 1;
+				stream.push({ type: "text_start", contentIndex: activeTextIndex, partial: output });
+			}
+			const block = output.content[activeTextIndex];
+			if (block?.type === "text") {
+				block.text += text;
+				stream.push({
+					type: "text_delta",
+					contentIndex: activeTextIndex,
+					delta: text,
+					partial: output,
+				});
+			}
+			if (!firstTokenTime) firstTokenTime = Date.now();
+		};
+		const emitHealedDsmlToolCall = (call: HealedDsmlToolCall): void => {
+			endActiveThinkingBlock();
+			endActiveTextBlock();
+			const args = parseStreamingJson<Record<string, unknown>>(call.arguments);
+			const toolCall: InternalToolCallBlock = {
+				type: "toolCall",
+				id: call.id,
+				name: call.name,
+				arguments: args,
+				partialJson: call.arguments,
+			};
+			output.content.push(toolCall);
+			const index = output.content.length - 1;
+			stream.push({ type: "toolcall_start", contentIndex: index, partial: output });
+			stream.push({
+				type: "toolcall_delta",
+				contentIndex: index,
+				delta: call.arguments,
+				partial: output,
+			});
+			endToolCallBlock(stream, output, index);
+			dsmlHealedEmitted = true;
+			if (!firstTokenTime) firstTokenTime = Date.now();
+		};
+		const drainHealedDsmlCalls = (): void => {
+			if (!dsmlHealer) return;
+			const calls = dsmlHealer.drainCompleted();
+			for (const call of calls) emitHealedDsmlToolCall(call);
+		};
 		try {
 			const apiKey = options.apiKey || getEnvApiKey(model.provider);
 			if (!apiKey) {
@@ -437,40 +508,23 @@ export const streamOllama: StreamFunction<"ollama-chat"> = (
 						firstTokenTime = Date.now();
 					}
 				}
-				if (chunk.message?.content) {
-					if (activeThinkingIndex !== undefined) {
-						endThinkingBlock(stream, output, activeThinkingIndex);
-						activeThinkingIndex = undefined;
-					}
-					if (activeTextIndex === undefined) {
-						output.content.push({ type: "text", text: "" });
-						activeTextIndex = output.content.length - 1;
-						stream.push({ type: "text_start", contentIndex: activeTextIndex, partial: output });
-					}
-					const block = output.content[activeTextIndex];
-					if (block?.type === "text") {
-						block.text += chunk.message.content;
-						stream.push({
-							type: "text_delta",
-							contentIndex: activeTextIndex,
-							delta: chunk.message.content,
-							partial: output,
-						});
-					}
-					if (!firstTokenTime) {
-						firstTokenTime = Date.now();
+				const chunkContent = chunk.message?.content;
+				const structuredCalls = chunk.message?.tool_calls?.length ? chunk.message.tool_calls : undefined;
+				if (chunkContent) {
+					if (dsmlHealer) {
+						const cleaned = structuredCalls
+							? dsmlHealer.consumeWithoutCalls(chunkContent)
+							: dsmlHealer.feed(chunkContent);
+						appendVisibleText(cleaned);
+						drainHealedDsmlCalls();
+					} else {
+						appendVisibleText(chunkContent);
 					}
 				}
-				if (chunk.message?.tool_calls?.length) {
-					if (activeThinkingIndex !== undefined) {
-						endThinkingBlock(stream, output, activeThinkingIndex);
-						activeThinkingIndex = undefined;
-					}
-					if (activeTextIndex !== undefined) {
-						endTextBlock(stream, output, activeTextIndex);
-						activeTextIndex = undefined;
-					}
-					for (const call of chunk.message.tool_calls) {
+				if (structuredCalls) {
+					endActiveThinkingBlock();
+					endActiveTextBlock();
+					for (const call of structuredCalls) {
 						const name = call.function?.name ?? "unknown_tool";
 						const rawArgs = call.function?.arguments;
 						const partialJson = typeof rawArgs === "string" ? rawArgs : JSON.stringify(rawArgs ?? {});
@@ -497,24 +551,39 @@ export const streamOllama: StreamFunction<"ollama-chat"> = (
 					}
 				}
 				if (chunk.done) {
-					if (activeThinkingIndex !== undefined) {
-						endThinkingBlock(stream, output, activeThinkingIndex);
-						activeThinkingIndex = undefined;
+					if (dsmlHealer) {
+						const trailing = dsmlHealer.flushPending();
+						appendVisibleText(trailing);
+						drainHealedDsmlCalls();
 					}
-					if (activeTextIndex !== undefined) {
-						endTextBlock(stream, output, activeTextIndex);
-						activeTextIndex = undefined;
-					}
+					endActiveThinkingBlock();
+					endActiveTextBlock();
 					for (const index of activeToolIndices) {
 						endToolCallBlock(stream, output, index);
 					}
 					activeToolIndices.clear();
 					output.stopReason = mapDoneReason(chunk.done_reason, output);
+					if (dsmlHealedEmitted && output.stopReason === "stop") {
+						// Envelope leak typically coincides with `done_reason: "stop"`
+						// because the host treats the XML as plain text. Promote the
+						// stop so downstream agent loops dispatch the healed call.
+						output.stopReason = "toolUse";
+					}
 					output.usage.input = chunk.prompt_eval_count ?? 0;
 					output.usage.output = chunk.eval_count ?? 0;
 					output.usage.totalTokens = output.usage.input + output.usage.output;
 				}
 			}
+			if (dsmlHealer) {
+				const trailing = dsmlHealer.flushPending();
+				appendVisibleText(trailing);
+				drainHealedDsmlCalls();
+				if (dsmlHealedEmitted && output.stopReason === "stop") {
+					output.stopReason = "toolUse";
+				}
+			}
+			endActiveThinkingBlock();
+			endActiveTextBlock();
 			output.duration = Date.now() - startTime;
 			if (firstTokenTime) {
 				output.ttft = firstTokenTime - startTime;

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -378,9 +378,7 @@ export const streamOllama: StreamFunction<"ollama-chat"> = (
 		let activeThinkingIndex: number | undefined;
 		let activeTextIndex: number | undefined;
 		const activeToolIndices = new Set<number>();
-		const dsmlHealer = modelMayLeakDsmlToolCalls(model.provider, model.id)
-			? new DsmlToolCallHealer()
-			: undefined;
+		const dsmlHealer = modelMayLeakDsmlToolCalls(model.provider, model.id) ? new DsmlToolCallHealer() : undefined;
 		let dsmlHealedEmitted = false;
 
 		const endActiveTextBlock = (): void => {

--- a/packages/ai/src/providers/ollama.ts
+++ b/packages/ai/src/providers/ollama.ts
@@ -510,11 +510,17 @@ export const streamOllama: StreamFunction<"ollama-chat"> = (
 				const structuredCalls = chunk.message?.tool_calls?.length ? chunk.message.tool_calls : undefined;
 				if (chunkContent) {
 					if (dsmlHealer) {
-						const cleaned = structuredCalls
-							? dsmlHealer.consumeWithoutCalls(chunkContent)
-							: dsmlHealer.feed(chunkContent);
-						appendVisibleText(cleaned);
-						drainHealedDsmlCalls();
+						if (structuredCalls) {
+							appendVisibleText(dsmlHealer.consumeWithoutCalls(chunkContent));
+						} else {
+							for (const event of dsmlHealer.feedEvents(chunkContent)) {
+								if (event.type === "text") {
+									appendVisibleText(event.text);
+								} else {
+									emitHealedDsmlToolCall(event.call);
+								}
+							}
+						}
 					} else {
 						appendVisibleText(chunkContent);
 					}

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -57,6 +57,11 @@ import { notifyProviderResponse } from "../utils/provider-response";
 import { callWithCopilotModelRetry } from "../utils/retry";
 import { adaptSchemaForStrict, NO_STRICT, toolWireSchema } from "../utils/schema";
 import { wrapFetchForSseDebug } from "../utils/sse-debug";
+import {
+	DsmlToolCallHealer,
+	type HealedDsmlToolCall,
+	modelMayLeakDsmlToolCalls,
+} from "../utils/dsml-tool-call-healing";
 import { type HealedToolCall, modelMayLeakKimiToolCalls, ToolCallHealer } from "../utils/tool-call-healing";
 import { isForcedToolChoice, mapToOpenAICompletionsToolChoice } from "../utils/tool-choice";
 import {
@@ -702,6 +707,36 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				const calls = kimiHealer.drainCompleted();
 				for (const call of calls) emitHealedToolCall(call);
 			};
+			const dsmlHealer = modelMayLeakDsmlToolCalls(model.provider, model.id)
+				? new DsmlToolCallHealer()
+				: undefined;
+			const emitHealedDsmlToolCall = (call: HealedDsmlToolCall): void => {
+				finishCurrentBlock(currentBlock);
+				const block: ToolCall & { partialArgs: string } = {
+					type: "toolCall",
+					id: call.id,
+					name: call.name,
+					arguments: parseStreamingJson(call.arguments),
+					partialArgs: call.arguments,
+				};
+				currentBlock = block;
+				output.content.push(block);
+				stream.push({ type: "toolcall_start", contentIndex: blockIndex(block), partial: output });
+				stream.push({
+					type: "toolcall_delta",
+					contentIndex: blockIndex(block),
+					delta: call.arguments,
+					partial: output,
+				});
+				finishCurrentBlock(block);
+				currentBlock = undefined;
+				healedToolCallEmitted = true;
+			};
+			const flushHealedDsmlToolCalls = (): void => {
+				if (!dsmlHealer) return;
+				const calls = dsmlHealer.drainCompleted();
+				for (const call of calls) emitHealedDsmlToolCall(call);
+			};
 
 			for await (const chunk of iterateWithIdleTimeout(openaiStream, {
 				idleTimeoutMs,
@@ -745,11 +780,25 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 					const normalizedDeltaText = normalizeStreamingContentText(choice.delta.content);
 					if (normalizedDeltaText.length > 0) {
 						if (!firstTokenTime) firstTokenTime = Date.now();
-						if (parseMiniMaxThinkTags) {
-							taggedTextBuffer += normalizedDeltaText;
+						// Step 1 — DSML envelope healer: extracts structured tool calls and
+						// returns the visible-text remainder. Runs even when other healers
+						// are active so the envelope is removed before downstream stripping.
+						let processedText = normalizedDeltaText;
+						if (dsmlHealer) {
+							const hasStructuredToolCalls =
+								Array.isArray(choice.delta.tool_calls) && choice.delta.tool_calls.length > 0;
+							processedText = hasStructuredToolCalls
+								? dsmlHealer.consumeWithoutCalls(normalizedDeltaText)
+								: dsmlHealer.feed(normalizedDeltaText);
+							if (!hasStructuredToolCalls) flushHealedDsmlToolCalls();
+						}
+						if (processedText.length === 0) {
+							// Healer consumed the chunk entirely (e.g. inside an envelope).
+						} else if (parseMiniMaxThinkTags) {
+							taggedTextBuffer += processedText;
 							flushTaggedTextBuffer();
 						} else if (stripDeepseekChatTemplateTokens) {
-							deepseekStripBuffer += normalizedDeltaText;
+							deepseekStripBuffer += processedText;
 							flushDeepseekStripBuffer(false);
 						} else if (kimiHealer) {
 							const hasStructuredToolCalls =
@@ -759,15 +808,15 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 								// Strip the marker text from visible output, but drop any
 								// synthesized calls so the structured payload stays the
 								// single source of truth (avoids double-dispatch).
-								const clean = kimiHealer.consumeWithoutCalls(normalizedDeltaText);
+								const clean = kimiHealer.consumeWithoutCalls(processedText);
 								if (clean.length > 0) appendTextDelta(clean);
 							} else {
-								const clean = kimiHealer.feed(normalizedDeltaText);
+								const clean = kimiHealer.feed(processedText);
 								if (clean.length > 0) appendTextDelta(clean);
 								flushHealedToolCalls();
 							}
 						} else {
-							appendTextDelta(normalizedDeltaText);
+							appendTextDelta(processedText);
 						}
 					}
 
@@ -875,6 +924,17 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 					// `finish_reason: stop` for the surrounding turn. Promote
 					// only that natural-completion finish — leave `error`,
 					// `length`, `aborted`, etc. untouched.
+					output.stopReason = "toolUse";
+				}
+			}
+			if (dsmlHealer) {
+				const trailing = dsmlHealer.flushPending();
+				if (trailing.length > 0) appendTextDelta(trailing);
+				flushHealedDsmlToolCalls();
+				if (healedToolCallEmitted && output.stopReason === "stop") {
+					// Envelope leak typically coincides with `finish_reason:"stop"`
+					// because the host treats the XML as plain text. Promote only
+					// natural-completion finishes; leave error/length/aborted alone.
 					output.stopReason = "toolUse";
 				}
 			}

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -37,6 +37,11 @@ import {
 } from "../types";
 import { normalizeSystemPrompts } from "../utils";
 import { createAbortSourceTracker } from "../utils/abort";
+import {
+	DsmlToolCallHealer,
+	type HealedDsmlToolCall,
+	modelMayLeakDsmlToolCalls,
+} from "../utils/dsml-tool-call-healing";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { toFirepassWireModelId, toFireworksWireModelId } from "../utils/fireworks-model-id";
 import {
@@ -57,11 +62,6 @@ import { notifyProviderResponse } from "../utils/provider-response";
 import { callWithCopilotModelRetry } from "../utils/retry";
 import { adaptSchemaForStrict, NO_STRICT, toolWireSchema } from "../utils/schema";
 import { wrapFetchForSseDebug } from "../utils/sse-debug";
-import {
-	DsmlToolCallHealer,
-	type HealedDsmlToolCall,
-	modelMayLeakDsmlToolCalls,
-} from "../utils/dsml-tool-call-healing";
 import { type HealedToolCall, modelMayLeakKimiToolCalls, ToolCallHealer } from "../utils/tool-call-healing";
 import { isForcedToolChoice, mapToOpenAICompletionsToolChoice } from "../utils/tool-choice";
 import {
@@ -707,9 +707,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				const calls = kimiHealer.drainCompleted();
 				for (const call of calls) emitHealedToolCall(call);
 			};
-			const dsmlHealer = modelMayLeakDsmlToolCalls(model.provider, model.id)
-				? new DsmlToolCallHealer()
-				: undefined;
+			const dsmlHealer = modelMayLeakDsmlToolCalls(model.provider, model.id) ? new DsmlToolCallHealer() : undefined;
 			const emitHealedDsmlToolCall = (call: HealedDsmlToolCall): void => {
 				finishCurrentBlock(currentBlock);
 				const block: ToolCall & { partialArgs: string } = {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -778,43 +778,48 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 					const normalizedDeltaText = normalizeStreamingContentText(choice.delta.content);
 					if (normalizedDeltaText.length > 0) {
 						if (!firstTokenTime) firstTokenTime = Date.now();
-						// Step 1 — DSML envelope healer: extracts structured tool calls and
-						// returns the visible-text remainder. Runs even when other healers
-						// are active so the envelope is removed before downstream stripping.
-						let processedText = normalizedDeltaText;
-						if (dsmlHealer) {
-							const hasStructuredToolCalls =
-								Array.isArray(choice.delta.tool_calls) && choice.delta.tool_calls.length > 0;
-							processedText = hasStructuredToolCalls
-								? dsmlHealer.consumeWithoutCalls(normalizedDeltaText)
-								: dsmlHealer.feed(normalizedDeltaText);
-							if (!hasStructuredToolCalls) flushHealedDsmlToolCalls();
-						}
-						if (processedText.length === 0) {
-							// Healer consumed the chunk entirely (e.g. inside an envelope).
-						} else if (parseMiniMaxThinkTags) {
-							taggedTextBuffer += processedText;
-							flushTaggedTextBuffer();
-						} else if (stripDeepseekChatTemplateTokens) {
-							deepseekStripBuffer += processedText;
-							flushDeepseekStripBuffer(false);
-						} else if (kimiHealer) {
-							const hasStructuredToolCalls =
-								Array.isArray(choice.delta.tool_calls) && choice.delta.tool_calls.length > 0;
-							if (hasStructuredToolCalls) {
-								// Same chunk leaks markers AND carries structured tool_calls.
-								// Strip the marker text from visible output, but drop any
-								// synthesized calls so the structured payload stays the
-								// single source of truth (avoids double-dispatch).
-								const clean = kimiHealer.consumeWithoutCalls(processedText);
-								if (clean.length > 0) appendTextDelta(clean);
+						const hasStructuredDeltaToolCalls =
+							Array.isArray(choice.delta.tool_calls) && choice.delta.tool_calls.length > 0;
+						const appendProcessedText = (processedText: string): void => {
+							if (processedText.length === 0) {
+								// Healer consumed the chunk entirely (e.g. inside an envelope).
+							} else if (parseMiniMaxThinkTags) {
+								taggedTextBuffer += processedText;
+								flushTaggedTextBuffer();
+							} else if (stripDeepseekChatTemplateTokens) {
+								deepseekStripBuffer += processedText;
+								flushDeepseekStripBuffer(false);
+							} else if (kimiHealer) {
+								if (hasStructuredDeltaToolCalls) {
+									// Same chunk leaks markers AND carries structured tool_calls.
+									// Strip the marker text from visible output, but drop any
+									// synthesized calls so the structured payload stays the
+									// single source of truth (avoids double-dispatch).
+									const clean = kimiHealer.consumeWithoutCalls(processedText);
+									if (clean.length > 0) appendTextDelta(clean);
+								} else {
+									const clean = kimiHealer.feed(processedText);
+									if (clean.length > 0) appendTextDelta(clean);
+									flushHealedToolCalls();
+								}
 							} else {
-								const clean = kimiHealer.feed(processedText);
-								if (clean.length > 0) appendTextDelta(clean);
-								flushHealedToolCalls();
+								appendTextDelta(processedText);
+							}
+						};
+
+						if (dsmlHealer && !hasStructuredDeltaToolCalls) {
+							for (const event of dsmlHealer.feedEvents(normalizedDeltaText)) {
+								if (event.type === "text") {
+									appendProcessedText(event.text);
+								} else {
+									emitHealedDsmlToolCall(event.call);
+								}
 							}
 						} else {
-							appendTextDelta(processedText);
+							const processedText = dsmlHealer
+								? dsmlHealer.consumeWithoutCalls(normalizedDeltaText)
+								: normalizedDeltaText;
+							appendProcessedText(processedText);
 						}
 					}
 

--- a/packages/ai/src/utils/dsml-tool-call-healing.ts
+++ b/packages/ai/src/utils/dsml-tool-call-healing.ts
@@ -51,6 +51,11 @@ export interface HealedDsmlToolCall {
 	readonly arguments: string;
 }
 
+/** Ordered output produced while stripping a DSML envelope from streamed text. */
+export type DsmlToolCallHealerEvent =
+	| { readonly type: "text"; readonly text: string }
+	| { readonly type: "toolCall"; readonly call: HealedDsmlToolCall };
+
 type State =
 	| { kind: "idle" }
 	| { kind: "section" }
@@ -86,10 +91,26 @@ export class DsmlToolCallHealer {
 	 * until the next {@link feed} call or {@link flushPending}.
 	 */
 	feed(text: string): string {
-		if (text.length === 0) return "";
+		let clean = "";
+		for (const event of this.feedEvents(text)) {
+			if (event.type === "text") {
+				clean += event.text;
+			} else {
+				this.#completed.push(event.call);
+			}
+		}
+		return clean;
+	}
+
+	/**
+	 * Feed a chunk of streamed text. Returns visible text and healed tool calls
+	 * in the order they appeared in the stream.
+	 */
+	feedEvents(text: string): DsmlToolCallHealerEvent[] {
+		if (text.length === 0) return [];
 		this.#compact();
 		this.#buffer += text;
-		return this.#consume();
+		return this.#consumeEvents();
 	}
 
 	/**
@@ -99,8 +120,10 @@ export class DsmlToolCallHealer {
 	 * output, but the structured payload remains the single source of truth.
 	 */
 	consumeWithoutCalls(text: string): string {
-		const clean = this.feed(text);
-		if (this.#completed.length > 0) this.#completed.length = 0;
+		let clean = "";
+		for (const event of this.feedEvents(text)) {
+			if (event.type === "text") clean += event.text;
+		}
 		return clean;
 	}
 
@@ -144,8 +167,15 @@ export class DsmlToolCallHealer {
 		this.#offset = 0;
 	}
 
-	#consume(): string {
+	#consumeEvents(): DsmlToolCallHealerEvent[] {
+		const events: DsmlToolCallHealerEvent[] = [];
 		let clean = "";
+		const flushClean = (): void => {
+			if (clean.length === 0) return;
+			events.push({ type: "text", text: clean });
+			clean = "";
+		};
+
 		while (this.#offset < this.#buffer.length) {
 			const state = this.#state;
 
@@ -172,7 +202,9 @@ export class DsmlToolCallHealer {
 				}
 			} else if (state.kind === "invoke") {
 				if (this.#tryMatch(INVOKE_CLOSE_RE)) {
-					this.#finalizeCall(state.name, state.args);
+					const call = this.#finalizeCall(state.name, state.args);
+					flushClean();
+					events.push({ type: "toolCall", call });
 					this.#state = { kind: "section" };
 					continue;
 				}
@@ -224,7 +256,8 @@ export class DsmlToolCallHealer {
 			}
 			// section / invoke: swallow inter-tag whitespace and stray text.
 		}
-		return clean;
+		flushClean();
+		return events;
 	}
 
 	#tryMatch(pattern: RegExp): boolean {
@@ -264,13 +297,12 @@ export class DsmlToolCallHealer {
 		return true;
 	}
 
-	#finalizeCall(name: string, args: Record<string, unknown>): void {
-		const id = generateHealedDsmlCallId();
-		this.#completed.push({
-			id,
+	#finalizeCall(name: string, args: Record<string, unknown>): HealedDsmlToolCall {
+		return {
+			id: generateHealedDsmlCallId(),
 			name: name.trim(),
 			arguments: JSON.stringify(args),
-		});
+		};
 	}
 }
 

--- a/packages/ai/src/utils/dsml-tool-call-healing.ts
+++ b/packages/ai/src/utils/dsml-tool-call-healing.ts
@@ -1,0 +1,312 @@
+/**
+ * Streaming-safe filter for the DeepSeek "DSML" chat-template tool-call
+ * envelope.
+ *
+ * DeepSeek's V4 family is occasionally served by hosts (Ollama Cloud, NVIDIA
+ * NIM, the native DeepSeek API, …) that don't strip the chat-template envelope
+ * before forwarding `delta.content` / `message.content`. The leak looks like:
+ *
+ *     <｜DSML｜tool_calls>
+ *       <｜DSML｜invoke name="bash">
+ *         <｜DSML｜parameter name="_i" string="true">Check Fedora packages</｜DSML｜parameter>
+ *         <｜DSML｜parameter name="timeout" string="false">15</｜DSML｜parameter>
+ *       </｜DSML｜invoke>
+ *     </｜DSML｜tool_calls>
+ *
+ * Without healing, users see the raw XML and the agent loop never gets a
+ * structured tool call — the turn ends right after the envelope. This module
+ * reconstructs the embedded calls and strips the envelope from visible text.
+ * It is stream-aware: any partial tag at the end of a chunk is held back
+ * until the next chunk arrives.
+ *
+ * The healer is grammar-specific (DSML envelope only) and is independent of
+ * the single-token stripper in {@link openai-completions.ts}, which handles
+ * solitary `<｜DSML｜tool_calls｜>` style markers leaked without an envelope.
+ */
+
+import { parseJsonWithRepair } from "./json-parse";
+
+/** Both fullwidth (U+FF5C) and ASCII pipes are observed in the wild. */
+const PIPE = "[｜|]";
+
+const TC_OPEN_RE = new RegExp(String.raw`<${PIPE}DSML${PIPE}tool_calls>`, "y");
+const TC_CLOSE_RE = new RegExp(String.raw`</${PIPE}DSML${PIPE}tool_calls>`, "y");
+const INVOKE_OPEN_RE = new RegExp(String.raw`<${PIPE}DSML${PIPE}invoke\s+name="([^"]*)"\s*>`, "y");
+const INVOKE_CLOSE_RE = new RegExp(String.raw`</${PIPE}DSML${PIPE}invoke>`, "y");
+const PARAM_OPEN_RE = new RegExp(
+	String.raw`<${PIPE}DSML${PIPE}parameter\s+name="([^"]*)"(?:\s+string="(true|false)")?\s*>`,
+	"y",
+);
+const PARAM_CLOSE_RE = new RegExp(String.raw`</${PIPE}DSML${PIPE}parameter>`, "y");
+
+/** Cap held-back buffer length so a stray `<` in normal prose can't grow it unboundedly. */
+const MAX_PARTIAL_HOLD = 256;
+
+/** Maximum bytes of parameter value we'll accumulate before bailing on the call. */
+const MAX_PARAM_VALUE_LENGTH = 1_000_000;
+
+export interface HealedDsmlToolCall {
+	readonly id: string;
+	readonly name: string;
+	readonly arguments: string;
+}
+
+type State =
+	| { kind: "idle" }
+	| { kind: "section" }
+	| { kind: "invoke"; name: string; args: Record<string, unknown> }
+	| {
+			kind: "parameter";
+			invokeName: string;
+			args: Record<string, unknown>;
+			paramName: string;
+			isString: boolean;
+			value: string;
+	  };
+
+/**
+ * State machine that consumes streamed text, emits visible text with the
+ * DSML envelope stripped, and accumulates the embedded tool calls for the
+ * caller to drain after each {@link feed} call.
+ *
+ * One instance per stream. Feed only the visible-text channel (e.g.
+ * `delta.content` / `message.content`); reasoning text never carries the
+ * envelope and mixing channels corrupts the held-back buffer.
+ */
+export class DsmlToolCallHealer {
+	#buffer = "";
+	#offset = 0;
+	#state: State = { kind: "idle" };
+	#sectionTerminated = false;
+	readonly #completed: HealedDsmlToolCall[] = [];
+
+	/**
+	 * Feed a chunk of streamed text. Returns the portion safe to emit
+	 * downstream (envelope stripped). Any partial tag suffix is held back
+	 * until the next {@link feed} call or {@link flushPending}.
+	 */
+	feed(text: string): string {
+		if (text.length === 0) return "";
+		this.#compact();
+		this.#buffer += text;
+		return this.#consume();
+	}
+
+	/**
+	 * Like {@link feed}, but discards any tool calls that the chunk completes.
+	 * Used when the upstream provider also emits structured `tool_calls` for
+	 * the same chunk: the healer still strips envelope markup from visible
+	 * output, but the structured payload remains the single source of truth.
+	 */
+	consumeWithoutCalls(text: string): string {
+		const clean = this.feed(text);
+		if (this.#completed.length > 0) this.#completed.length = 0;
+		return clean;
+	}
+
+	/**
+	 * Drain accumulated tool calls. Internal list is cleared so a subsequent
+	 * envelope in the same stream (rare) yields fresh calls.
+	 */
+	drainCompleted(): HealedDsmlToolCall[] {
+		if (this.#completed.length === 0) return [];
+		return this.#completed.splice(0, this.#completed.length);
+	}
+
+	/**
+	 * Flush any held-back fragment when the stream ends. If we were mid-call
+	 * the partial is dropped (surfacing half-tags would re-leak markers);
+	 * otherwise the fragment is returned verbatim so a literal `<｜DSML` in
+	 * unrelated prose is not silently lost.
+	 */
+	flushPending(): string {
+		const tail = this.#remaining();
+		this.#buffer = "";
+		this.#offset = 0;
+		const state = this.#state;
+		this.#state = { kind: "idle" };
+		if (state.kind === "idle") return tail;
+		return "";
+	}
+
+	/** True once any DSML envelope in this stream has fully closed. */
+	get sectionClosed(): boolean {
+		return this.#sectionTerminated;
+	}
+
+	#remaining(): string {
+		return this.#offset === 0 ? this.#buffer : this.#buffer.slice(this.#offset);
+	}
+
+	#compact(): void {
+		if (this.#offset === 0) return;
+		this.#buffer = this.#buffer.slice(this.#offset);
+		this.#offset = 0;
+	}
+
+	#consume(): string {
+		let clean = "";
+		while (this.#offset < this.#buffer.length) {
+			const state = this.#state;
+
+			// Try state-specific complete tag matches first.
+			if (state.kind === "idle") {
+				if (this.#tryMatch(TC_OPEN_RE)) {
+					this.#state = { kind: "section" };
+					continue;
+				}
+			} else if (state.kind === "section") {
+				if (this.#tryMatch(TC_CLOSE_RE)) {
+					this.#state = { kind: "idle" };
+					this.#sectionTerminated = true;
+					continue;
+				}
+				const invokeMatch = this.#tryMatchCapture(INVOKE_OPEN_RE);
+				if (invokeMatch) {
+					this.#state = {
+						kind: "invoke",
+						name: invokeMatch[1] ?? "",
+						args: {},
+					};
+					continue;
+				}
+			} else if (state.kind === "invoke") {
+				if (this.#tryMatch(INVOKE_CLOSE_RE)) {
+					this.#finalizeCall(state.name, state.args);
+					this.#state = { kind: "section" };
+					continue;
+				}
+				const paramMatch = this.#tryMatchCapture(PARAM_OPEN_RE);
+				if (paramMatch) {
+					const isString = paramMatch[2] !== "false";
+					this.#state = {
+						kind: "parameter",
+						invokeName: state.name,
+						args: state.args,
+						paramName: paramMatch[1] ?? "",
+						isString,
+						value: "",
+					};
+					continue;
+				}
+			} else {
+				// parameter
+				if (this.#tryMatch(PARAM_CLOSE_RE)) {
+					state.args[state.paramName] = coerceParamValue(state.value, state.isString);
+					this.#state = {
+						kind: "invoke",
+						name: state.invokeName,
+						args: state.args,
+					};
+					continue;
+				}
+			}
+
+			// No complete tag matched at the current offset.
+			// If the unconsumed tail might still complete into a tag once more
+			// bytes arrive, hold back until the next chunk.
+			if (this.#startsWithPartialTag()) break;
+
+			// Consume one char as state-appropriate output.
+			const ch = this.#buffer[this.#offset]!;
+			this.#offset += 1;
+			if (state.kind === "idle") {
+				clean += ch;
+				continue;
+			}
+			if (state.kind === "parameter") {
+				if (state.value.length >= MAX_PARAM_VALUE_LENGTH) {
+					// Pathological output — abandon the call rather than blow up memory.
+					this.#state = { kind: "idle" };
+					continue;
+				}
+				state.value += ch;
+				continue;
+			}
+			// section / invoke: swallow inter-tag whitespace and stray text.
+		}
+		return clean;
+	}
+
+	#tryMatch(pattern: RegExp): boolean {
+		pattern.lastIndex = this.#offset;
+		const match = pattern.exec(this.#buffer);
+		if (!match) return false;
+		this.#offset += match[0].length;
+		return true;
+	}
+
+	#tryMatchCapture(pattern: RegExp): RegExpExecArray | undefined {
+		pattern.lastIndex = this.#offset;
+		const match = pattern.exec(this.#buffer);
+		if (!match) return undefined;
+		this.#offset += match[0].length;
+		return match;
+	}
+
+	/**
+	 * True if the buffer at the current offset starts with `<` but does not
+	 * yet contain `>`. The consume loop has already attempted every
+	 * state-specific regex match; reaching this point means either the tag
+	 * is still incomplete (hold back) or the `<` is literal prose / value
+	 * content (consume it). The `>` lookahead disambiguates.
+	 *
+	 * Capped so a stray `<` followed by many bytes without `>` (e.g. shell
+	 * comparison `a < b`, never closed) doesn't grow the holdback
+	 * unboundedly.
+	 */
+	#startsWithPartialTag(): boolean {
+		if (this.#buffer[this.#offset] !== "<") return false;
+		const tailLength = this.#buffer.length - this.#offset;
+		if (tailLength > MAX_PARTIAL_HOLD) return false;
+		for (let i = this.#offset + 1; i < this.#buffer.length; i++) {
+			if (this.#buffer[i] === ">") return false;
+		}
+		return true;
+	}
+
+	#finalizeCall(name: string, args: Record<string, unknown>): void {
+		const id = generateHealedDsmlCallId();
+		this.#completed.push({
+			id,
+			name: name.trim(),
+			arguments: JSON.stringify(args),
+		});
+	}
+}
+
+
+
+function coerceParamValue(raw: string, isString: boolean): unknown {
+	if (isString) return raw;
+	const trimmed = raw.trim();
+	if (trimmed.length === 0) return raw;
+	try {
+		return parseJsonWithRepair<unknown>(trimmed);
+	} catch {
+		return raw;
+	}
+}
+
+function generateHealedDsmlCallId(): string {
+	return `call_${crypto.randomUUID().replace(/-/g, "").slice(0, 24)}`;
+}
+
+/**
+ * Cheap test for whether a model is known to leak DSML chat-template envelopes
+ * into visible text. Gated to DeepSeek family on hosts observed in the wild;
+ * other providers do not pay for the per-chunk scan.
+ */
+export function modelMayLeakDsmlToolCalls(provider: string, modelId: string): boolean {
+	const isDeepseekId = /deepseek/i.test(modelId);
+	if (!isDeepseekId) return false;
+	return (
+		provider === "ollama" ||
+		provider === "ollama-cloud" ||
+		provider === "nvidia" ||
+		provider === "deepseek" ||
+		provider === "fireworks" ||
+		provider === "opencode-go" ||
+		provider === "openrouter"
+	);
+}

--- a/packages/ai/src/utils/dsml-tool-call-healing.ts
+++ b/packages/ai/src/utils/dsml-tool-call-healing.ts
@@ -29,15 +29,15 @@ import { parseJsonWithRepair } from "./json-parse";
 /** Both fullwidth (U+FF5C) and ASCII pipes are observed in the wild. */
 const PIPE = "[｜|]";
 
-const TC_OPEN_RE = new RegExp(String.raw`<${PIPE}DSML${PIPE}tool_calls>`, "y");
-const TC_CLOSE_RE = new RegExp(String.raw`</${PIPE}DSML${PIPE}tool_calls>`, "y");
-const INVOKE_OPEN_RE = new RegExp(String.raw`<${PIPE}DSML${PIPE}invoke\s+name="([^"]*)"\s*>`, "y");
-const INVOKE_CLOSE_RE = new RegExp(String.raw`</${PIPE}DSML${PIPE}invoke>`, "y");
+const TC_OPEN_RE = new RegExp(`<${PIPE}DSML${PIPE}tool_calls>`, "y");
+const TC_CLOSE_RE = new RegExp(`</${PIPE}DSML${PIPE}tool_calls>`, "y");
+const INVOKE_OPEN_RE = new RegExp(`<${PIPE}DSML${PIPE}invoke\\s+name="([^"]*)"\\s*>`, "y");
+const INVOKE_CLOSE_RE = new RegExp(`</${PIPE}DSML${PIPE}invoke>`, "y");
 const PARAM_OPEN_RE = new RegExp(
-	String.raw`<${PIPE}DSML${PIPE}parameter\s+name="([^"]*)"(?:\s+string="(true|false)")?\s*>`,
+	`<${PIPE}DSML${PIPE}parameter\\s+name="([^"]*)"(?:\\s+string="(true|false)")?\\s*>`,
 	"y",
 );
-const PARAM_CLOSE_RE = new RegExp(String.raw`</${PIPE}DSML${PIPE}parameter>`, "y");
+const PARAM_CLOSE_RE = new RegExp(`</${PIPE}DSML${PIPE}parameter>`, "y");
 
 /** Cap held-back buffer length so a stray `<` in normal prose can't grow it unboundedly. */
 const MAX_PARTIAL_HOLD = 256;
@@ -221,7 +221,6 @@ export class DsmlToolCallHealer {
 					continue;
 				}
 				state.value += ch;
-				continue;
 			}
 			// section / invoke: swallow inter-tag whitespace and stray text.
 		}
@@ -274,8 +273,6 @@ export class DsmlToolCallHealer {
 		});
 	}
 }
-
-
 
 function coerceParamValue(raw: string, isString: boolean): unknown {
 	if (isString) return raw;

--- a/packages/ai/test/issue-1462-repro.test.ts
+++ b/packages/ai/test/issue-1462-repro.test.ts
@@ -1,12 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import { getBundledModel } from "../src/models";
 import { streamOpenAICompletions } from "../src/providers/openai-completions";
 import { stream } from "../src/stream";
 import type { Context, Model, ToolCall } from "../src/types";
-import {
-	DsmlToolCallHealer,
-	modelMayLeakDsmlToolCalls,
-} from "../src/utils/dsml-tool-call-healing";
+import { DsmlToolCallHealer, modelMayLeakDsmlToolCalls } from "../src/utils/dsml-tool-call-healing";
 
 const originalFetch = global.fetch;
 
@@ -100,14 +96,9 @@ describe("DSML envelope healer (unit)", () => {
 
 	it("strips the envelope from surrounding prose without losing the prose", () => {
 		const healer = new DsmlToolCallHealer();
-		const leaked =
-			"Sure, running it now:\n" +
-			REPORTED_LEAK +
-			"\nThat should give us the package list.";
+		const leaked = `Sure, running it now:\n${REPORTED_LEAK}\nThat should give us the package list.`;
 		const clean = healer.feed(leaked) + healer.flushPending();
-		expect(clean).toBe(
-			"Sure, running it now:\n\nThat should give us the package list.",
-		);
+		expect(clean).toBe("Sure, running it now:\n\nThat should give us the package list.");
 		expect(healer.drainCompleted()).toHaveLength(1);
 	});
 
@@ -135,10 +126,7 @@ describe("DSML envelope healer (unit)", () => {
 		healer.feed(xml);
 		const calls = healer.drainCompleted();
 		expect(calls.map(c => c.name)).toEqual(["read", "read"]);
-		expect(calls.map(c => JSON.parse(c.arguments))).toEqual([
-			{ path: "a.ts" },
-			{ path: "b.ts" },
-		]);
+		expect(calls.map(c => JSON.parse(c.arguments))).toEqual([{ path: "a.ts" }, { path: "b.ts" }]);
 		expect(calls[0].id).not.toBe(calls[1].id);
 	});
 
@@ -305,7 +293,18 @@ function deepseekChunk(delta: SseChoiceDelta, finish: SseChunk["choices"][0]["fi
 
 describe("openai-completions provider — DSML envelope on direct DeepSeek API", () => {
 	it("heals the envelope into a structured tool call and suppresses leaked text", async () => {
-		const model = getBundledModel("deepseek", "deepseek-v4-pro");
+		const model: Model<"openai-completions"> = {
+			id: "deepseek-v4-pro",
+			name: "DeepSeek V4 Pro",
+			api: "openai-completions",
+			provider: "deepseek",
+			baseUrl: "https://api.deepseek.com",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 131_072,
+			maxTokens: 8_192,
+		};
 		global.fetch = mockOpenAIFetch([
 			deepseekChunk({ content: "I'll check.\n" }),
 			deepseekChunk({ content: REPORTED_LEAK }),

--- a/packages/ai/test/issue-1462-repro.test.ts
+++ b/packages/ai/test/issue-1462-repro.test.ts
@@ -1,0 +1,340 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { getBundledModel } from "../src/models";
+import { streamOpenAICompletions } from "../src/providers/openai-completions";
+import { stream } from "../src/stream";
+import type { Context, Model, ToolCall } from "../src/types";
+import {
+	DsmlToolCallHealer,
+	modelMayLeakDsmlToolCalls,
+} from "../src/utils/dsml-tool-call-healing";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+	global.fetch = originalFetch;
+	vi.restoreAllMocks();
+});
+
+const deepseekCloudModel: Model<"ollama-chat"> = {
+	id: "deepseek-v4-pro",
+	name: "DeepSeek V4 Pro",
+	api: "ollama-chat",
+	provider: "ollama-cloud",
+	baseUrl: "https://ollama.com",
+	reasoning: true,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 131_072,
+	maxTokens: 8_192,
+};
+
+function createNdjsonResponse(lines: ReadonlyArray<unknown>): Response {
+	const body = `${lines.map(line => JSON.stringify(line)).join("\n")}\n`;
+	const encoder = new TextEncoder();
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(encoder.encode(body));
+			controller.close();
+		},
+	});
+	return new Response(stream, {
+		status: 200,
+		headers: { "content-type": "application/x-ndjson" },
+	});
+}
+
+const REPORTED_LEAK =
+	"<｜DSML｜tool_calls>\n" +
+	' <｜DSML｜invoke name="bash">\n' +
+	' <｜DSML｜parameter name="_i" string="true">Check Fedora 42 available packages</｜DSML｜parameter>\n' +
+	' <｜DSML｜parameter name="command" string="true">docker run --rm --platform linux/arm64 fedora:42 bash -c \'type python3; type git; type sed; type cp; ls /usr/bin/python3 2>/dev/null; rpm -qa | grep -E "^python3|^git-|^sed-|^bash-" | sort\'</｜DSML｜parameter>\n' +
+	' <｜DSML｜parameter name="timeout" string="false">15</｜DSML｜parameter>\n' +
+	" </｜DSML｜invoke>\n" +
+	" </｜DSML｜tool_calls>";
+
+describe("DSML envelope healer (unit)", () => {
+	it("parses the reporter's verbatim leak into a structured tool call", () => {
+		const healer = new DsmlToolCallHealer();
+		const clean = healer.feed(REPORTED_LEAK);
+		expect(clean).toBe("");
+
+		const calls = healer.drainCompleted();
+		expect(calls).toHaveLength(1);
+		const call = calls[0];
+		expect(call.name).toBe("bash");
+		expect(call.id).toMatch(/^call_[0-9a-f]+$/);
+
+		const args = JSON.parse(call.arguments) as Record<string, unknown>;
+		expect(args._i).toBe("Check Fedora 42 available packages");
+		// `string="false"` should coerce numeric value
+		expect(args.timeout).toBe(15);
+		// Command body must preserve raw `>` from shell redirection
+		expect(String(args.command)).toContain("2>/dev/null");
+		expect(String(args.command)).toContain('grep -E "^python3|^git-|^sed-|^bash-"');
+	});
+
+	it("reconstructs the envelope when split across many chunks (including mid-tag)", () => {
+		const healer = new DsmlToolCallHealer();
+		// Slice every 7 characters to stress partial-tag holdback.
+		let visible = "";
+		for (let i = 0; i < REPORTED_LEAK.length; i += 7) {
+			visible += healer.feed(REPORTED_LEAK.slice(i, i + 7));
+		}
+		visible += healer.flushPending();
+		expect(visible).toBe("");
+
+		const calls = healer.drainCompleted();
+		expect(calls).toHaveLength(1);
+		expect(calls[0].name).toBe("bash");
+		const args = JSON.parse(calls[0].arguments) as Record<string, unknown>;
+		expect(args.timeout).toBe(15);
+	});
+
+	it("passes prose through unchanged when no envelope is present", () => {
+		const healer = new DsmlToolCallHealer();
+		const out = healer.feed("Sure, I'll check that. The path is foo<bar>.\n");
+		const tail = healer.flushPending();
+		expect(out + tail).toBe("Sure, I'll check that. The path is foo<bar>.\n");
+		expect(healer.drainCompleted()).toHaveLength(0);
+	});
+
+	it("strips the envelope from surrounding prose without losing the prose", () => {
+		const healer = new DsmlToolCallHealer();
+		const leaked =
+			"Sure, running it now:\n" +
+			REPORTED_LEAK +
+			"\nThat should give us the package list.";
+		const clean = healer.feed(leaked) + healer.flushPending();
+		expect(clean).toBe(
+			"Sure, running it now:\n\nThat should give us the package list.",
+		);
+		expect(healer.drainCompleted()).toHaveLength(1);
+	});
+
+	it("drops partial calls when the stream ends mid-envelope", () => {
+		const healer = new DsmlToolCallHealer();
+		const truncated = REPORTED_LEAK.slice(0, REPORTED_LEAK.length - 30);
+		const clean = healer.feed(truncated);
+		const tail = healer.flushPending();
+		expect(clean).toBe("");
+		expect(tail).toBe("");
+		expect(healer.drainCompleted()).toHaveLength(0);
+	});
+
+	it("handles multiple invokes inside one envelope", () => {
+		const healer = new DsmlToolCallHealer();
+		const xml =
+			"<｜DSML｜tool_calls>" +
+			'<｜DSML｜invoke name="read">' +
+			'<｜DSML｜parameter name="path" string="true">a.ts</｜DSML｜parameter>' +
+			"</｜DSML｜invoke>" +
+			'<｜DSML｜invoke name="read">' +
+			'<｜DSML｜parameter name="path" string="true">b.ts</｜DSML｜parameter>' +
+			"</｜DSML｜invoke>" +
+			"</｜DSML｜tool_calls>";
+		healer.feed(xml);
+		const calls = healer.drainCompleted();
+		expect(calls.map(c => c.name)).toEqual(["read", "read"]);
+		expect(calls.map(c => JSON.parse(c.arguments))).toEqual([
+			{ path: "a.ts" },
+			{ path: "b.ts" },
+		]);
+		expect(calls[0].id).not.toBe(calls[1].id);
+	});
+
+	it("accepts ASCII pipe variant `<|DSML|...>`", () => {
+		const healer = new DsmlToolCallHealer();
+		const xml =
+			"<|DSML|tool_calls>" +
+			'<|DSML|invoke name="bash">' +
+			'<|DSML|parameter name="cmd" string="true">ls -la</|DSML|parameter>' +
+			"</|DSML|invoke>" +
+			"</|DSML|tool_calls>";
+		healer.feed(xml);
+		const calls = healer.drainCompleted();
+		expect(calls).toHaveLength(1);
+		expect(calls[0].name).toBe("bash");
+		expect(JSON.parse(calls[0].arguments)).toEqual({ cmd: "ls -la" });
+	});
+
+	it("gates by provider+model so non-DeepSeek streams skip the scan", () => {
+		expect(modelMayLeakDsmlToolCalls("ollama-cloud", "deepseek-v4-pro")).toBe(true);
+		expect(modelMayLeakDsmlToolCalls("ollama-cloud", "gpt-oss:120b")).toBe(false);
+		expect(modelMayLeakDsmlToolCalls("openai", "deepseek-v4-pro")).toBe(false);
+	});
+});
+
+describe("Ollama provider — DSML envelope leaked on deepseek-v4-pro", () => {
+	it("emits a healed tool call and suppresses the leaked text", async () => {
+		global.fetch = vi.fn(async () =>
+			createNdjsonResponse([
+				{
+					model: "deepseek-v4-pro",
+					message: { role: "assistant", content: " 精神精神\n\n" },
+					done: false,
+				},
+				{
+					model: "deepseek-v4-pro",
+					message: { role: "assistant", content: REPORTED_LEAK },
+					done: false,
+				},
+				{
+					model: "deepseek-v4-pro",
+					done: true,
+					done_reason: "stop",
+					prompt_eval_count: 12,
+					eval_count: 200,
+				},
+			]),
+		) as unknown as typeof fetch;
+
+		const context: Context = {
+			messages: [{ role: "user", content: "Check Fedora packages", timestamp: Date.now() }],
+		};
+		const response = stream(deepseekCloudModel, context, { apiKey: "test-key" });
+		const result = await response.result();
+
+		const visibleText = result.content
+			.filter((b): b is { type: "text"; text: string } => b.type === "text")
+			.map(b => b.text)
+			.join("");
+		expect(visibleText).not.toContain("DSML");
+		expect(visibleText).not.toContain("<｜");
+		expect(visibleText).not.toContain("<invoke");
+
+		const toolCalls = result.content.filter((b): b is ToolCall => b.type === "toolCall");
+		expect(toolCalls).toHaveLength(1);
+		expect(toolCalls[0].name).toBe("bash");
+		const args = toolCalls[0].arguments as Record<string, unknown>;
+		expect(args._i).toBe("Check Fedora 42 available packages");
+		expect(args.timeout).toBe(15);
+		expect(String(args.command)).toContain("docker run");
+
+		// `done_reason:"stop"` must be promoted: the agent loop depends on
+		// `toolUse` to dispatch the call instead of ending the turn.
+		expect(result.stopReason).toBe("toolUse");
+	});
+
+	it("does not run the healer when the model is not DeepSeek", async () => {
+		const ollamaGptOss: Model<"ollama-chat"> = {
+			...deepseekCloudModel,
+			id: "gpt-oss:120b",
+			name: "GPT OSS 120B",
+		};
+		global.fetch = vi.fn(async () =>
+			createNdjsonResponse([
+				{
+					model: "gpt-oss:120b",
+					message: { role: "assistant", content: "Inline `<｜literal｜>` token in prose." },
+					done: false,
+				},
+				{
+					model: "gpt-oss:120b",
+					done: true,
+					done_reason: "stop",
+					prompt_eval_count: 1,
+					eval_count: 1,
+				},
+			]),
+		) as unknown as typeof fetch;
+
+		const result = await stream(
+			ollamaGptOss,
+			{ messages: [{ role: "user", content: "hi", timestamp: Date.now() }] },
+			{ apiKey: "test-key" },
+		).result();
+
+		const text = result.content
+			.filter((b): b is { type: "text"; text: string } => b.type === "text")
+			.map(b => b.text)
+			.join("");
+		// Without the healer, prose passes through verbatim.
+		expect(text).toBe("Inline `<｜literal｜>` token in prose.");
+		expect(result.stopReason).toBe("stop");
+	});
+});
+
+interface SseToolCallDelta {
+	index: number;
+	id?: string;
+	type?: "function";
+	function?: { name?: string; arguments?: string };
+}
+
+interface SseChoiceDelta {
+	content?: string;
+	tool_calls?: SseToolCallDelta[];
+}
+
+interface SseChunk {
+	id: string;
+	object: "chat.completion.chunk";
+	created: number;
+	model: string;
+	choices: ReadonlyArray<{
+		index: number;
+		delta: SseChoiceDelta;
+		finish_reason?: "stop" | "tool_calls" | "length" | "content_filter" | null;
+	}>;
+}
+
+function sseResponse(events: ReadonlyArray<SseChunk | "[DONE]">): Response {
+	const payload = `${events
+		.map(event => `data: ${typeof event === "string" ? event : JSON.stringify(event)}`)
+		.join("\n\n")}\n\n`;
+	return new Response(payload, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function mockOpenAIFetch(events: ReadonlyArray<SseChunk | "[DONE]">): typeof fetch {
+	const fn = async (): Promise<Response> => sseResponse(events);
+	return Object.assign(fn, { preconnect: originalFetch.preconnect });
+}
+
+function deepseekChunk(delta: SseChoiceDelta, finish: SseChunk["choices"][0]["finish_reason"] = null): SseChunk {
+	return {
+		id: "chatcmpl-deepseek-dsml",
+		object: "chat.completion.chunk",
+		created: 0,
+		model: "deepseek-v4-pro",
+		choices: [{ index: 0, delta, finish_reason: finish }],
+	};
+}
+
+describe("openai-completions provider — DSML envelope on direct DeepSeek API", () => {
+	it("heals the envelope into a structured tool call and suppresses leaked text", async () => {
+		const model = getBundledModel("deepseek", "deepseek-v4-pro");
+		global.fetch = mockOpenAIFetch([
+			deepseekChunk({ content: "I'll check.\n" }),
+			deepseekChunk({ content: REPORTED_LEAK }),
+			deepseekChunk({}, "stop"),
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(
+			model,
+			{ messages: [{ role: "user", content: "Check Fedora", timestamp: Date.now() }] },
+			{ apiKey: "test-key" },
+		).result();
+
+		const text = result.content
+			.filter((b): b is { type: "text"; text: string } => b.type === "text")
+			.map(b => b.text)
+			.join("");
+		expect(text).not.toContain("DSML");
+		expect(text).not.toContain("<｜");
+		expect(text.startsWith("I'll check.")).toBe(true);
+
+		const toolCalls = result.content.filter((b): b is ToolCall => b.type === "toolCall");
+		expect(toolCalls).toHaveLength(1);
+		expect(toolCalls[0].name).toBe("bash");
+		const args = toolCalls[0].arguments as Record<string, unknown>;
+		expect(args._i).toBe("Check Fedora 42 available packages");
+		expect(args.timeout).toBe(15);
+
+		// finish_reason:"stop" must be promoted so the agent loop dispatches.
+		expect(result.stopReason).toBe("toolUse");
+	});
+});

--- a/packages/ai/test/issue-1462-repro.test.ts
+++ b/packages/ai/test/issue-1462-repro.test.ts
@@ -102,6 +102,20 @@ describe("DSML envelope healer (unit)", () => {
 		expect(healer.drainCompleted()).toHaveLength(1);
 	});
 
+	it("preserves prose/tool-call/prose order for a single mixed chunk", () => {
+		const healer = new DsmlToolCallHealer();
+		const events = healer.feedEvents(`Before\n${REPORTED_LEAK}\nAfter`);
+		expect(events.map(event => event.type)).toEqual(["text", "toolCall", "text"]);
+
+		const [before, call, after] = events;
+		if (before?.type !== "text" || call?.type !== "toolCall" || after?.type !== "text") {
+			throw new Error("DSML healer emitted unexpected event order");
+		}
+		expect(before.text).toBe("Before\n");
+		expect(call.call.name).toBe("bash");
+		expect(after.text).toBe("\nAfter");
+	});
+
 	it("drops partial calls when the stream ends mid-envelope", () => {
 		const healer = new DsmlToolCallHealer();
 		const truncated = REPORTED_LEAK.slice(0, REPORTED_LEAK.length - 30);
@@ -163,7 +177,7 @@ describe("Ollama provider — DSML envelope leaked on deepseek-v4-pro", () => {
 				},
 				{
 					model: "deepseek-v4-pro",
-					message: { role: "assistant", content: REPORTED_LEAK },
+					message: { role: "assistant", content: `${REPORTED_LEAK}\nThat should give us the package list.` },
 					done: false,
 				},
 				{
@@ -198,11 +212,18 @@ describe("Ollama provider — DSML envelope leaked on deepseek-v4-pro", () => {
 		expect(args.timeout).toBe(15);
 		expect(String(args.command)).toContain("docker run");
 
+		const [prefix, healedCall, suffix] = result.content;
+		if (prefix?.type !== "text" || healedCall?.type !== "toolCall" || suffix?.type !== "text") {
+			throw new Error("Ollama DSML healing emitted unexpected content order");
+		}
+		expect(prefix.text).toBe(" 精神精神\n\n");
+		expect(healedCall.name).toBe("bash");
+		expect(suffix.text).toBe("\nThat should give us the package list.");
+
 		// `done_reason:"stop"` must be promoted: the agent loop depends on
 		// `toolUse` to dispatch the call instead of ending the turn.
 		expect(result.stopReason).toBe("toolUse");
 	});
-
 	it("does not run the healer when the model is not DeepSeek", async () => {
 		const ollamaGptOss: Model<"ollama-chat"> = {
 			...deepseekCloudModel,
@@ -307,7 +328,7 @@ describe("openai-completions provider — DSML envelope on direct DeepSeek API",
 		};
 		global.fetch = mockOpenAIFetch([
 			deepseekChunk({ content: "I'll check.\n" }),
-			deepseekChunk({ content: REPORTED_LEAK }),
+			deepseekChunk({ content: `${REPORTED_LEAK}\nThat should give us the package list.` }),
 			deepseekChunk({}, "stop"),
 			"[DONE]",
 		]);
@@ -332,6 +353,14 @@ describe("openai-completions provider — DSML envelope on direct DeepSeek API",
 		const args = toolCalls[0].arguments as Record<string, unknown>;
 		expect(args._i).toBe("Check Fedora 42 available packages");
 		expect(args.timeout).toBe(15);
+
+		const [prefix, healedCall, suffix] = result.content;
+		if (prefix?.type !== "text" || healedCall?.type !== "toolCall" || suffix?.type !== "text") {
+			throw new Error("OpenAI DSML healing emitted unexpected content order");
+		}
+		expect(prefix.text).toBe("I'll check.\n");
+		expect(healedCall.name).toBe("bash");
+		expect(suffix.text).toBe("\nThat should give us the package list.");
 
 		// finish_reason:"stop" must be promoted so the agent loop dispatches.
 		expect(result.stopReason).toBe("toolUse");


### PR DESCRIPTION
## Repro

Run DeepSeek V4 Pro via Ollama Cloud (`provider: "ollama-cloud"`, `api: "ollama-chat"`, `baseUrl: "https://ollama.com"`) with any tool-using prompt. After a few turns the model emits its chat-template tool-call envelope into `chunk.message.content` instead of structured `tool_calls`:

```
<｜DSML｜tool_calls>
  <｜DSML｜invoke name="bash">
    <｜DSML｜parameter name="_i" string="true">…</｜DSML｜parameter>
    <｜DSML｜parameter name="command" string="true">docker run … 2>/dev/null …</｜DSML｜parameter>
    <｜DSML｜parameter name="timeout" string="false">15</｜DSML｜parameter>
  </｜DSML｜invoke>
</｜DSML｜tool_calls>
```

The XML renders as visible text, the response carries no `tool_calls`, and `done_reason:"stop"` ends the turn without dispatching the call. Reproduced as a streaming NDJSON unit test in `packages/ai/test/issue-1462-repro.test.ts` (the reporter's verbatim leak is replayed; before this change the leaked XML survives to `result.content[…].text` and `stopReason === "stop"`).

## Cause

The single-token stripper added in #798 (`packages/ai/src/providers/openai-completions.ts:367-380`) only matches `<｜…｜>` literals with no whitespace, no attributes, and a trailing `｜>` — none of the envelope's tags (`<｜DSML｜tool_calls>`, `</｜DSML｜invoke>`, `<｜DSML｜parameter name="…" string="…">…</｜DSML｜parameter>`) match that shape. It also only runs on `provider === "nvidia" || "deepseek"`. Ollama Cloud routes through the `ollama-chat` provider (`packages/ai/src/providers/ollama.ts`), which has no stripping at all, so even the existing single-token regex never executes.

## Fix

- Add `packages/ai/src/utils/dsml-tool-call-healing.ts`: a streaming state-machine envelope healer (`DsmlToolCallHealer`). Parses the four DSML tags (with both fullwidth `｜` and ASCII `|` pipe variants), tolerates partial tags at chunk boundaries, finalizes one `HealedDsmlToolCall` per `<｜DSML｜invoke>` block, drops mid-stream partials on stream end, and coerces `string="false"` parameter values via the shared `parseJsonWithRepair` path so numeric/boolean args survive the round-trip. Gated by `modelMayLeakDsmlToolCalls(provider, modelId)` — DeepSeek family on `ollama` / `ollama-cloud` / `nvidia` / `deepseek` / `fireworks` / `opencode-go` / `openrouter`.
- Wire the healer into `packages/ai/src/providers/ollama.ts`: factor the content / thinking / tool-call emission into `appendVisibleText`, `endActiveTextBlock`, `endActiveThinkingBlock`, and `emitHealedDsmlToolCall` closures so the loop and the post-loop flush share the same path. When a chunk carries structured `tool_calls` alongside leaked content, use `consumeWithoutCalls` so the structured payload stays the single source of truth (mirrors the Kimi healer's existing pattern).
- Wire the healer into `packages/ai/src/providers/openai-completions.ts` as a pre-step ahead of the MiniMax / Deepseek-token / Kimi pipeline, with a parallel `emitHealedDsmlToolCall` / `flushHealedDsmlToolCalls` pair and a post-loop `flushPending` flush.
- In both providers: when the healer emitted at least one call and the host reported `done_reason / finish_reason: "stop"`, promote the stop to `"toolUse"` so the agent loop dispatches the healed call instead of treating the leaked envelope as the end of the turn.

## Verification

- `bun --cwd=packages/ai test test/issue-1462-repro.test.ts` — 11 pass, exercises the unit healer (reporter's verbatim leak, 7-char chunk splits stressing partial-tag holdback, prose passthrough, surrounding prose preservation, mid-stream truncation drop, multiple invokes per envelope, ASCII pipe variant, gating predicate) plus end-to-end Ollama and openai-completions streams.
- `bun --cwd=packages/ai test test/ollama-cloud-provider.test.ts test/ollama-provider.test.ts test/kimi-tool-call-healing.test.ts test/openai-completions-compat.test.ts test/issue-1462-repro.test.ts` — 73 pass, confirming the refactored Ollama provider and the inserted DSML pre-step do not regress structured tool-call emission, Kimi healing, or single-token stripping.
- `bun --cwd=packages/ai run test` — 1290 pass, 337 skip (E2E), 0 fail.
- `bun --cwd=packages/ai run check:types` — clean.

Fixes #1462