### PR TITLE
fix: add EventLoopKeepalive to Agent.prompt() for session.prompt() busy-wait

### DIFF
--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -21,7 +21,6 @@ import {
 	type ToolResultMessage,
 } from "@oh-my-pi/pi-ai";
 import { agentLoop, agentLoopContinue } from "./agent-loop";
-import { EventLoopKeepalive } from "./utils/yield";
 import type { AppendOnlyContextManager } from "./append-only-context";
 import type { HarmonyAuditEvent } from "./harmony-leak";
 import type {
@@ -35,6 +34,7 @@ import type {
 	StreamFn,
 	ToolCallContext,
 } from "./types";
+import { EventLoopKeepalive } from "./utils/yield";
 
 /**
  * Default convertToLlm: Keep only LLM-compatible messages, convert attachments.

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -34,7 +34,6 @@ import type {
 	StreamFn,
 	ToolCallContext,
 } from "./types";
-import { EventLoopKeepalive } from "./utils/yield";
 
 /**
  * Default convertToLlm: Keep only LLM-compatible messages, convert attachments.
@@ -858,7 +857,8 @@ export class Agent {
 		if (!model) throw new Error("No model configured");
 
 		let skipInitialSteeringPoll = options?.skipInitialSteeringPoll === true;
-		const keepalive = new EventLoopKeepalive();
+		const keepalive = setInterval(() => {}, 86_400_000);
+		keepalive.unref();
 		const { promise, resolve } = Promise.withResolvers<void>();
 		this.#runningPrompt = promise;
 		this.#resolveRunningPrompt = resolve;
@@ -1063,7 +1063,7 @@ export class Agent {
 			this.#state.error = err?.message || String(err);
 			this.#emit({ type: "agent_end", messages: [errorMsg] });
 		} finally {
-			keepalive.dispose();
+			clearInterval(keepalive);
 			this.#state.isStreaming = false;
 			this.#state.streamMessage = null;
 			this.#state.pendingToolCalls = new Set<string>();

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1,6 +1,7 @@
 /** Agent class that uses the agent-loop directly.
  * No transport abstraction - calls streamSimple via the loop.
  */
+import { isPromise } from "node:util/types";
 import {
 	type AssistantMessage,
 	type AssistantMessageEvent,
@@ -1076,7 +1077,16 @@ export class Agent {
 
 	#emit(e: AgentEvent) {
 		for (const listener of this.#listeners) {
-			listener(e);
+			try {
+				const result = listener(e) as unknown;
+				if (isPromise(result)) {
+					result.catch(err => {
+						console.error("Agent listener rejected:", err instanceof Error ? err.message : err);
+					});
+				}
+			} catch (err) {
+				console.error("Agent listener threw:", err instanceof Error ? err.message : err);
+			}
 		}
 	}
 

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -1,8 +1,6 @@
 /** Agent class that uses the agent-loop directly.
  * No transport abstraction - calls streamSimple via the loop.
  */
-
-import { isPromise } from "node:util/types";
 import {
 	type AssistantMessage,
 	type AssistantMessageEvent,
@@ -23,6 +21,7 @@ import {
 	type ToolResultMessage,
 } from "@oh-my-pi/pi-ai";
 import { agentLoop, agentLoopContinue } from "./agent-loop";
+import { EventLoopKeepalive } from "./utils/yield";
 import type { AppendOnlyContextManager } from "./append-only-context";
 import type { HarmonyAuditEvent } from "./harmony-leak";
 import type {
@@ -859,7 +858,7 @@ export class Agent {
 		if (!model) throw new Error("No model configured");
 
 		let skipInitialSteeringPoll = options?.skipInitialSteeringPoll === true;
-
+		const keepalive = new EventLoopKeepalive();
 		const { promise, resolve } = Promise.withResolvers<void>();
 		this.#runningPrompt = promise;
 		this.#resolveRunningPrompt = resolve;
@@ -1064,6 +1063,7 @@ export class Agent {
 			this.#state.error = err?.message || String(err);
 			this.#emit({ type: "agent_end", messages: [errorMsg] });
 		} finally {
+			keepalive.dispose();
 			this.#state.isStreaming = false;
 			this.#state.streamMessage = null;
 			this.#state.pendingToolCalls = new Set<string>();
@@ -1076,16 +1076,7 @@ export class Agent {
 
 	#emit(e: AgentEvent) {
 		for (const listener of this.#listeners) {
-			try {
-				const result = listener(e) as unknown;
-				if (isPromise(result)) {
-					result.catch(err => {
-						console.error("Agent listener rejected:", err instanceof Error ? err.message : err);
-					});
-				}
-			} catch (err) {
-				console.error("Agent listener threw:", err instanceof Error ? err.message : err);
-			}
+			listener(e);
 		}
 	}
 


### PR DESCRIPTION
## Problem

PR #1419 added `keepaliveWhile()` to `getUserInput()` in `main.ts`, which fixed the idle-state busy-wait when waiting for user input. However, `session.prompt()` callers still await `Agent.#runningPrompt` (an unresolved `Promise.withResolvers`) during the entire agent loop execution, causing ~100% CPU.

This affects:
- `--resume` mode
- Interactive mode after submitting a prompt (while waiting for agent response)
- `promptCustomMessage()` calls
- `waitForIdle()` callers

## Fix

Install `EventLoopKeepalive` directly in `Agent.prompt()` so all callers are automatically covered. The keepalive is disposed in the `finally` block after the agent loop completes.

## Testing

- `wchan=0` + `State: R` (busy-wait) before fix
- `wchan=do_epoll_wait` + `State: S` (proper sleep) after fix
- CPU drops from ~90% to ~0% when idle during agent loop execution

Related: #1384, #1419