### PR TITLE
fix(coding-agent): share Python kernel for `$`

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Fixed `eval` tool image rendering to resize displayed images before returning them and append image-dimension notes to text output
 - Fixed `write` tool output sanitation to strip malformed or loose hashline section headers before writing file content
 - Fixed `omp auth-broker serve` crashing at startup with `logger.setTransports is not a function` — switched the call site to `import { setTransports } from "@oh-my-pi/pi-utils/logger"`, bypassing the `logger` namespace re-export that some Bun versions failed to expose at runtime
+- Fixed user shortcut Python execution to namespace session IDs like eval, so both paths share one kernel
 
 ## [15.5.7] - 2026-05-27
 ### Added

--- a/packages/coding-agent/src/eval/py/index.ts
+++ b/packages/coding-agent/src/eval/py/index.ts
@@ -5,7 +5,7 @@ import { checkPythonKernelAvailability } from "./kernel";
 
 const PYTHON_SESSION_PREFIX = "python:";
 
-function namespaceSessionId(sessionId: string): string {
+export function namespaceSessionId(sessionId: string): string {
 	return sessionId.startsWith(PYTHON_SESSION_PREFIX) ? sessionId : `${PYTHON_SESSION_PREFIX}${sessionId}`;
 }
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -106,6 +106,7 @@ import { RawSseDebugBuffer } from "../debug/raw-sse-buffer";
 import { loadCapability } from "../discovery";
 import { expandApplyPatchToEntries, normalizeDiff, normalizeToLF, ParseError, previewPatch, stripBom } from "../edit";
 import { getFileSnapshotStore } from "../edit/file-snapshot-store";
+import { namespaceSessionId as namespacePythonSessionId } from "../eval/py";
 import {
 	disposeKernelSessionsByOwner,
 	executePython as executePythonCommand,
@@ -7525,7 +7526,7 @@ export class AgentSession {
 				});
 			const result = await executePythonCommand(code, {
 				cwd,
-				sessionId,
+				sessionId: namespacePythonSessionId(sessionId),
 				kernelOwnerId: this.#evalKernelOwnerId,
 				kernelMode: this.settings.get("python.kernelMode"),
 				onChunk,

--- a/packages/coding-agent/test/agent-session-user-shortcut-hooks.test.ts
+++ b/packages/coding-agent/test/agent-session-user-shortcut-hooks.test.ts
@@ -29,6 +29,7 @@ describe("AgentSession user shortcut hooks", () => {
 		if (session) {
 			await session.dispose();
 		}
+		await pythonExecutor.disposeAllKernelSessions();
 		authStorage?.close();
 		authStorage = undefined;
 		tempDir.removeSync();
@@ -49,7 +50,7 @@ describe("AgentSession user shortcut hooks", () => {
 
 		session = new AgentSession({
 			agent,
-			sessionManager: SessionManager.inMemory(),
+			sessionManager: SessionManager.inMemory(tempDir.path()),
 			settings: Settings.isolated({ "compaction.enabled": false }),
 			modelRegistry,
 			extensionRunner,
@@ -176,5 +177,22 @@ describe("AgentSession user shortcut hooks", () => {
 		expect(
 			session.messages.some(message => message.role === "pythonExecution" && message.excludeFromContext === false),
 		).toBe(true);
+	});
+
+	it("shares Python state between eval and user shortcut execution", async () => {
+		createSession();
+		const evalSessionId = session.getEvalSessionId();
+		if (!evalSessionId) throw new Error("Expected eval session ID");
+
+		await pythonExecutor.executePython("shared_value = 123", {
+			cwd: tempDir.path(),
+			sessionId: `python:${evalSessionId}`,
+			kernelMode: "session",
+		});
+
+		const result = await session.executePython("print(shared_value)");
+
+		expect(result.exitCode).toBe(0);
+		expect(result.output.trim()).toBe("123");
 	});
 });


### PR DESCRIPTION
## What

Allows the user to interact in the same Python kernel as the agent, which I believe is the intent of the code.

## Why

Fixes #1465

## Testing

<img width="2242" height="750" alt="Screenshot From 2026-05-27 21-58-50" src="https://github.com/user-attachments/assets/0b89682a-6b69-4d5b-a8f6-e7e360cfd711" />


---

- [x] `bun check` passes (well...actually, it doesn't, but it seems the failures are unrelated)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
