### PR TITLE
docs: fix stale links and add missing CHANGELOGs

### DIFF
--- a/docs/bash-tool-runtime.md
+++ b/docs/bash-tool-runtime.md
@@ -27,7 +27,7 @@ Both eventually use `executeBash()` in `src/exec/bash-executor.ts` for non-PTY e
 - rejects `async: true` when `async.enabled` is false,
 - uses only explicit `head`/`tail` tool args for post-run filtering.
 
-`normalizeBashCommand()` still exists in `src/tools/bash-normalize.ts`, but `BashTool.execute()` does not call it in the current source. Trailing shell pipes such as `| head -n 50` remain part of the shell command unless the caller uses the structured `head`/`tail` args.
+`normalizeBashCommand()` was previously in `src/tools/bash-normalize.ts` but has been removed. Trailing shell pipes such as `| head -n 50` remain part of the shell command unless the caller uses the structured `head`/`tail` args.
 
 ## 2) Optional interception (blocked-command path)
 
@@ -256,7 +256,7 @@ This component is wired by `CommandController.handleBashCommand()` and fed from 
 ## Implementation files
 
 - [`src/tools/bash.ts`](../packages/coding-agent/src/tools/bash.ts) — tool entrypoint, input handling/interception, async and PTY/non-PTY selection, result/error mapping, bash tool renderer.
-- [`src/tools/bash-normalize.ts`](../packages/coding-agent/src/tools/bash-normalize.ts) — post-run head/tail filtering; also contains an unused command-normalization helper.
+- ~~`src/tools/bash-normalize.ts`~~ — removed (post-run head/tail filtering is now handled inline).
 - [`src/tools/bash-interceptor.ts`](../packages/coding-agent/src/tools/bash-interceptor.ts) — interceptor rule matching and blocked-command messages.
 - [`src/exec/bash-executor.ts`](../packages/coding-agent/src/exec/bash-executor.ts) — non-PTY executor, shell session reuse, cancellation wiring, output sink integration.
 - [`src/tools/bash-interactive.ts`](../packages/coding-agent/src/tools/bash-interactive.ts) — PTY runtime, overlay UI, input normalization, non-interactive env defaults.

--- a/docs/notebook-tool-runtime.md
+++ b/docs/notebook-tool-runtime.md
@@ -6,7 +6,7 @@ The critical distinction: **`notebook` is a JSON notebook editor, not a notebook
 
 ## Implementation files
 
-- [`src/tools/notebook.ts`](../packages/coding-agent/src/tools/notebook.ts)
+- [`src/edit/notebook.ts`](../packages/coding-agent/src/edit/notebook.ts)
 - [`src/eval/py/executor.ts`](../packages/coding-agent/src/eval/py/executor.ts)
 - [`src/eval/py/kernel.ts`](../packages/coding-agent/src/eval/py/kernel.ts)
 - [`src/session/streaming-output.ts`](../packages/coding-agent/src/session/streaming-output.ts)
@@ -14,7 +14,7 @@ The critical distinction: **`notebook` is a JSON notebook editor, not a notebook
 
 ## 1) Runtime boundary: editing vs executing
 
-## `notebook` tool (`src/tools/notebook.ts`)
+## `notebook` tool (`src/edit/notebook.ts`)
 
 - Supports `action: edit | insert | delete` on a `.ipynb` file.
 - Resolves path relative to session CWD (`resolveToCwd`).

--- a/docs/rulebook-matching-pipeline.md
+++ b/docs/rulebook-matching-pipeline.md
@@ -20,7 +20,7 @@ It reflects the current implementation, including partial semantics and metadata
 - [`../src/sdk.ts`](../packages/coding-agent/src/sdk.ts)
 - [`../src/system-prompt.ts`](../packages/coding-agent/src/system-prompt.ts)
 - [`../src/internal-urls/rule-protocol.ts`](../packages/coding-agent/src/internal-urls/rule-protocol.ts)
-- [`../src/utils/frontmatter.ts`](../packages/coding-agent/src/utils/frontmatter.ts)
+- [`../src/utils/frontmatter.ts`](../packages/utils/src/frontmatter.ts)
 
 ## 1. Canonical rule shape
 

--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -1187,7 +1187,7 @@ describe("Generate E2E Tests", () => {
 			it(
 				"should handle thinking mode",
 				async () => {
-					// FIXME Skip for now, getting a 422 stauts code, need to test with official SDK
+					// FIXME Skip for now, getting a 422 status code, need to test with official SDK
 					// const llm = getModel("mistral", "magistral-medium-latest");
 					// await handleThinking(llm, { reasoningEffort: "medium" });
 				},

--- a/packages/swarm-extension/CHANGELOG.md
+++ b/packages/swarm-extension/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+## [Unreleased]

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+## [Unreleased]


### PR DESCRIPTION
## What

- Fix typo "stauts" → "status" in `packages/ai/test/stream.test.ts` comment
- Update stale documentation links in 3 docs files:
  - `rulebook-matching-pipeline.md`: update `frontmatter.ts` link to `packages/utils/src/` (moved from `coding-agent`)
  - `notebook-tool-runtime.md`: update `notebook.ts` link to `src/edit/` (moved from `src/tools/`)
  - `bash-tool-runtime.md`: mark removed `bash-normalize.ts` and update description
- Add missing `CHANGELOG.md` for `packages/swarm-extension` and `packages/utils`

## Why

Several documentation files contain links to source files that have been moved or deleted. Two packages were missing `CHANGELOG.md` files that the release process expects.

## Testing

- `bun check` passes
- Verified all updated links point to existing files

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG not applicable (docs-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)