### PR TITLE
fix(codex): prefer gpt-5.5 for web search

### DIFF
--- a/packages/coding-agent/src/web/search/providers/codex.ts
+++ b/packages/coding-agent/src/web/search/providers/codex.ts
@@ -19,8 +19,9 @@ import { classifyProviderHttpError, withHardTimeout } from "./utils";
 
 const CODEX_BASE_URL = "https://chatgpt.com/backend-api";
 const CODEX_RESPONSES_PATH = "/codex/responses";
-const FALLBACK_MODEL = "gpt-5.4";
+const FALLBACK_MODEL = "gpt-5.5";
 const DEFAULT_MODEL_PREFERENCES = [
+	"gpt-5.5",
 	"gpt-5.4",
 	"gpt-5-codex",
 	"gpt-5",

--- a/packages/coding-agent/test/tools/web-search-codex.test.ts
+++ b/packages/coding-agent/test/tools/web-search-codex.test.ts
@@ -223,27 +223,28 @@ describe("searchCodex model selection", () => {
 
 	it("uses the built-in default model when PI_CODEX_WEB_SEARCH_MODEL is unset", async () => {
 		delete process.env.PI_CODEX_WEB_SEARCH_MODEL;
-		using _hook = mockCodexFetch("gpt-5.4");
+		using _hook = mockCodexFetch("gpt-5.5");
 
 		const result = await searchCodex(makeSearchParams("default codex model"));
 
 		expect(capturedRequest).not.toBeNull();
 		expect(capturedRequest?.url).toBe("https://chatgpt.com/backend-api/codex/responses");
-		expect(capturedRequest?.body?.model).toBe("gpt-5.4");
-		expect(result.model).toBe("gpt-5.4");
+		expect(capturedRequest?.body?.model).toBe("gpt-5.5");
+		expect(result.model).toBe("gpt-5.5");
 		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
 	});
 
 	it("falls back to the default model when PI_CODEX_WEB_SEARCH_MODEL is blank", async () => {
 		process.env.PI_CODEX_WEB_SEARCH_MODEL = "   ";
-		using _hook = mockCodexFetch("gpt-5.4");
+		using _hook = mockCodexFetch("gpt-5.5");
 
 		const result = await searchCodex(makeSearchParams("blank codex model"));
 
 		expect(capturedRequest).not.toBeNull();
-		expect(capturedRequest?.body?.model).toBe("gpt-5.4");
-		expect(result.model).toBe("gpt-5.4");
+		expect(capturedRequest?.body?.model).toBe("gpt-5.5");
+		expect(result.model).toBe("gpt-5.5");
 	});
+
 	it("retries the next bundled default when Codex rejects a model for ChatGPT accounts", async () => {
 		delete process.env.PI_CODEX_WEB_SEARCH_MODEL;
 		let calls = 0;
@@ -258,17 +259,17 @@ describe("searchCodex model selection", () => {
 
 			const requestedModel = capturedRequest.body?.model;
 			if (calls === 1) {
-				expect(requestedModel).toBe("gpt-5.4");
+				expect(requestedModel).toBe("gpt-5.5");
 				return new Response(
 					JSON.stringify({
-						detail: "The 'gpt-5.4' model is not supported when using Codex with a ChatGPT account.",
+						detail: "The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account.",
 					}),
 					{ status: 400, headers: { "Content-Type": "application/json" } },
 				);
 			}
 
-			expect(requestedModel).toBe("gpt-5-codex");
-			return new Response(makeSseResponse("gpt-5-codex"), {
+			expect(requestedModel).toBe("gpt-5.4");
+			return new Response(makeSseResponse("gpt-5.4"), {
 				status: 200,
 				headers: { "Content-Type": "text/event-stream" },
 			});
@@ -277,7 +278,7 @@ describe("searchCodex model selection", () => {
 		const result = await searchCodex(makeSearchParams("retry unsupported default"));
 
 		expect(calls).toBe(2);
-		expect(result.model).toBe("gpt-5-codex");
+		expect(result.model).toBe("gpt-5.4");
 		expect(result.sources).toEqual([{ title: "Example Article", url: "https://example.com/article" }]);
 	});
 
@@ -290,6 +291,31 @@ describe("searchCodex model selection", () => {
 		expect(capturedRequest).not.toBeNull();
 		expect(capturedRequest?.body?.model).toBe("gpt-5.4-mini");
 		expect(result.model).toBe("gpt-5.4-mini");
+	});
+
+	it("does not retry default candidates when PI_CODEX_WEB_SEARCH_MODEL is explicitly unsupported", async () => {
+		process.env.PI_CODEX_WEB_SEARCH_MODEL = "gpt-5.5";
+		let calls = 0;
+		capturedRequest = null;
+		using _hook = hookFetch((url, init) => {
+			calls += 1;
+			capturedRequest = {
+				url: typeof url === "string" ? url : url.toString(),
+				headers: init?.headers,
+				body: init?.body ? (JSON.parse(init.body as string) as Record<string, unknown>) : null,
+			};
+
+			expect(capturedRequest.body?.model).toBe("gpt-5.5");
+			return new Response(
+				JSON.stringify({
+					detail: "The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account.",
+				}),
+				{ status: 400, headers: { "Content-Type": "application/json" } },
+			);
+		});
+
+		await expect(searchCodex(makeSearchParams("explicit unsupported model"))).rejects.toThrow("gpt-5.5");
+		expect(calls).toBe(1);
 	});
 
 	it("forces web_search tool choice and extracts markdown link citations when annotations are absent", async () => {


### PR DESCRIPTION
## Summary
- prefer `gpt-5.5` before `gpt-5.4` for Codex `web_search` default model selection
- update fallback model to `gpt-5.5` when bundled model metadata is unavailable
- add regression coverage for `gpt-5.5` default selection, unsupported-model fallback to `gpt-5.4`, and explicit `PI_CODEX_WEB_SEARCH_MODEL` no-retry behavior

Fixes #1469.

## Verification
- `bun test packages/coding-agent/test/tools/web-search-codex.test.ts`
- `bun run check` from `packages/coding-agent` currently fails on pre-existing type errors in `../ai/src/providers/anthropic.ts` and ACP SDK types (`src/modes/acp/acp-agent.ts`, `test/acp-agent.test.ts`), unrelated to this change.