### PR TITLE
fix(legacy-pi-compat): resolve all bundled @oh-my-pi/* packages in compiled binary mode

### DIFF
--- a/packages/coding-agent/scripts/build-binary.ts
+++ b/packages/coding-agent/scripts/build-binary.ts
@@ -71,6 +71,7 @@ async function main(): Promise<void> {
 					"./src/extensibility/legacy-pi-tui-shim.ts",
 					"./src/extensibility/legacy-pi-agent-core-shim.ts",
 					"./src/extensibility/legacy-pi-utils-shim.ts",
+					"./src/extensibility/legacy-pi-natives-shim.ts",
 					"--outfile",
 					"dist/omp",
 				],

--- a/packages/coding-agent/scripts/build-binary.ts
+++ b/packages/coding-agent/scripts/build-binary.ts
@@ -67,6 +67,10 @@ async function main(): Promise<void> {
 					// `legacy-pi-compat.ts` resolves to at runtime.
 					"./src/extensibility/typebox.ts",
 					"./src/extensibility/legacy-pi-ai-shim.ts",
+					"./src/extensibility/legacy-pi-coding-agent-shim.ts",
+					"./src/extensibility/legacy-pi-tui-shim.ts",
+					"./src/extensibility/legacy-pi-agent-core-shim.ts",
+					"./src/extensibility/legacy-pi-utils-shim.ts",
 					"--outfile",
 					"dist/omp",
 				],

--- a/packages/coding-agent/src/extensibility/legacy-pi-agent-core-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-agent-core-shim.ts
@@ -1,0 +1,1 @@
+export * from "@oh-my-pi/pi-agent-core";

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -1,0 +1,1 @@
+export * from "@oh-my-pi/pi-coding-agent";

--- a/packages/coding-agent/src/extensibility/legacy-pi-natives-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-natives-shim.ts
@@ -1,0 +1,1 @@
+export * from "@oh-my-pi/pi-natives";

--- a/packages/coding-agent/src/extensibility/legacy-pi-tui-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-tui-shim.ts
@@ -1,0 +1,1 @@
+export * from "@oh-my-pi/pi-tui";

--- a/packages/coding-agent/src/extensibility/legacy-pi-utils-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-utils-shim.ts
@@ -1,0 +1,1 @@
+export * from "@oh-my-pi/pi-utils";

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -82,8 +82,24 @@ const TYPEBOX_SHIM_PATH = isCompiledBinary()
 const LEGACY_PI_AI_SHIM_PATH = isCompiledBinary()
 	? "/$bunfs/root/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.js"
 	: path.resolve(import.meta.dir, "../legacy-pi-ai-shim.ts");
+const LEGACY_PI_CODING_AGENT_SHIM_PATH = isCompiledBinary()
+	? "/$bunfs/root/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.js"
+	: path.resolve(import.meta.dir, "../legacy-pi-coding-agent-shim.ts");
+const LEGACY_PI_TUI_SHIM_PATH = isCompiledBinary()
+	? "/$bunfs/root/packages/coding-agent/src/extensibility/legacy-pi-tui-shim.js"
+	: path.resolve(import.meta.dir, "../legacy-pi-tui-shim.ts");
+const LEGACY_PI_AGENT_CORE_SHIM_PATH = isCompiledBinary()
+	? "/$bunfs/root/packages/coding-agent/src/extensibility/legacy-pi-agent-core-shim.js"
+	: path.resolve(import.meta.dir, "../legacy-pi-agent-core-shim.ts");
+const LEGACY_PI_UTILS_SHIM_PATH = isCompiledBinary()
+	? "/$bunfs/root/packages/coding-agent/src/extensibility/legacy-pi-utils-shim.js"
+	: path.resolve(import.meta.dir, "../legacy-pi-utils-shim.ts");
 const LEGACY_PI_PACKAGE_ROOT_OVERRIDES: Record<string, string> = {
 	[`${CANONICAL_PI_SCOPE}/pi-ai`]: LEGACY_PI_AI_SHIM_PATH,
+	[`${CANONICAL_PI_SCOPE}/pi-coding-agent`]: LEGACY_PI_CODING_AGENT_SHIM_PATH,
+	[`${CANONICAL_PI_SCOPE}/pi-tui`]: LEGACY_PI_TUI_SHIM_PATH,
+	[`${CANONICAL_PI_SCOPE}/pi-agent-core`]: LEGACY_PI_AGENT_CORE_SHIM_PATH,
+	[`${CANONICAL_PI_SCOPE}/pi-utils`]: LEGACY_PI_UTILS_SHIM_PATH,
 };
 
 let isLegacyPiSpecifierShimInstalled = false;
@@ -298,11 +314,11 @@ function resolveLegacyPiSpecifier(args: { path: string; importer: string }): { p
 	} catch {
 		// Fallback for compiled binary mode: the bundled packages live inside
 		// /$bunfs/root and aren't reachable by filesystem resolution. Try the
-		// original (pre-remap) specifier against the importing file's directory,
-		// which resolves to the plugin's installed peer dep.
+		// remapped canonical specifier against the importing file's directory,
+		// which resolves to the plugin's installed peer dep (e.g., @oh-my-pi/*).
 		const importerDir = path.dirname(args.importer);
 		try {
-			return { path: Bun.resolveSync(args.path, importerDir) };
+			return { path: Bun.resolveSync(remappedSpecifier, importerDir) };
 		} catch {
 			return undefined;
 		}

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -94,12 +94,16 @@ const LEGACY_PI_AGENT_CORE_SHIM_PATH = isCompiledBinary()
 const LEGACY_PI_UTILS_SHIM_PATH = isCompiledBinary()
 	? "/$bunfs/root/packages/coding-agent/src/extensibility/legacy-pi-utils-shim.js"
 	: path.resolve(import.meta.dir, "../legacy-pi-utils-shim.ts");
+const LEGACY_PI_NATIVES_SHIM_PATH = isCompiledBinary()
+	? "/$bunfs/root/packages/coding-agent/src/extensibility/legacy-pi-natives-shim.js"
+	: path.resolve(import.meta.dir, "../legacy-pi-natives-shim.ts");
 const LEGACY_PI_PACKAGE_ROOT_OVERRIDES: Record<string, string> = {
 	[`${CANONICAL_PI_SCOPE}/pi-ai`]: LEGACY_PI_AI_SHIM_PATH,
 	[`${CANONICAL_PI_SCOPE}/pi-coding-agent`]: LEGACY_PI_CODING_AGENT_SHIM_PATH,
 	[`${CANONICAL_PI_SCOPE}/pi-tui`]: LEGACY_PI_TUI_SHIM_PATH,
 	[`${CANONICAL_PI_SCOPE}/pi-agent-core`]: LEGACY_PI_AGENT_CORE_SHIM_PATH,
 	[`${CANONICAL_PI_SCOPE}/pi-utils`]: LEGACY_PI_UTILS_SHIM_PATH,
+	[`${CANONICAL_PI_SCOPE}/pi-natives`]: LEGACY_PI_NATIVES_SHIM_PATH,
 };
 
 let isLegacyPiSpecifierShimInstalled = false;
@@ -314,13 +318,18 @@ function resolveLegacyPiSpecifier(args: { path: string; importer: string }): { p
 	} catch {
 		// Fallback for compiled binary mode: the bundled packages live inside
 		// /$bunfs/root and aren't reachable by filesystem resolution. Try the
-		// remapped canonical specifier against the importing file's directory,
-		// which resolves to the plugin's installed peer dep (e.g., @oh-my-pi/*).
+		// remapped canonical specifier first (plugin installed @oh-my-pi/* as peer
+		// dep), then the original specifier (plugin installed @earendil-works/* or
+		// @mariozechner/* directly).
 		const importerDir = path.dirname(args.importer);
 		try {
 			return { path: Bun.resolveSync(remappedSpecifier, importerDir) };
 		} catch {
-			return undefined;
+			try {
+				return { path: Bun.resolveSync(args.path, importerDir) };
+			} catch {
+				return undefined;
+			}
 		}
 	}
 }

--- a/packages/coding-agent/test/earendil-works-pi-imports.test.ts
+++ b/packages/coding-agent/test/earendil-works-pi-imports.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { loadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const TOOL_NAME = "earendil_works_pi_coding_agent_test";
+
+describe("@earendil-works/pi-coding-agent and @earendil-works/pi-tui imports load in compiled binary mode", () => {
+	let projectDir: TempDir;
+	let extensionPath: string;
+
+	beforeEach(() => {
+		projectDir = TempDir.createSync("@earendil-works-import-");
+		const pluginDir = path.join(projectDir.path(), "earendil-works-like-plugin");
+		extensionPath = path.join(pluginDir, "index.ts");
+		fs.mkdirSync(pluginDir, { recursive: true });
+
+		// Mirrors the import pattern used by pi-provider-kiro@0.7.0 and other
+		// extensions that migrated from @mariozechner/* to @earendil-works/*.
+		// DynamicBorder is a runtime value from pi-coding-agent; importing it
+		// forces the module to actually be resolved and executed.
+		fs.writeFileSync(
+			extensionPath,
+			[
+				'import { DynamicBorder } from "@earendil-works/pi-coding-agent";',
+				"",
+				"export default function(pi) {",
+				"\tpi.registerTool({",
+				`\t\tname: ${JSON.stringify(TOOL_NAME)},`,
+				'\t\tdescription: "earendil-works scope regression test",',
+				"\t\tparameters: {},",
+				`\t\texecute: async () => ({ content: [{ type: "text", text: String(typeof DynamicBorder) }] }),`,
+				"\t});",
+				"}",
+			].join("\n"),
+		);
+	});
+
+	afterEach(() => {
+		projectDir.removeSync();
+	});
+
+	it("loads the extension and registers the tool", async () => {
+		const result = await loadExtensions([extensionPath], projectDir.path());
+
+		expect(result.errors).toEqual([]);
+		expect(result.extensions).toHaveLength(1);
+		expect(result.extensions[0].tools.has(TOOL_NAME)).toBe(true);
+	});
+});


### PR DESCRIPTION
## What

Add pass-through shims for `pi-coding-agent`, `pi-tui`, `pi-agent-core`, and `pi-utils`, register them as `--compile` entrypoints, and map them in `LEGACY_PI_PACKAGE_ROOT_OVERRIDES`. Also fix the fallback variable in `resolveLegacyPiSpecifier` from `args.path` to `remappedSpecifier`.

## Why

Fixes #1474, follow-up to #1215.

`LEGACY_PI_PACKAGE_ROOT_OVERRIDES` only covered `pi-ai`. The remaining bundled packages had no override, so `getResolvedSpecifier` was called for them and threw in compiled binary mode (no `node_modules` reachable from `/$bunfs/root`). This caused any plugin using `@earendil-works/*` or `@mariozechner/*` imports for packages other than `pi-ai` to silently fail.

The fallback in `resolveLegacyPiSpecifier` also passed `args.path` (original aliased specifier) to `Bun.resolveSync` instead of `remappedSpecifier` (`@oh-my-pi/*`), so it could never resolve even when the plugin had the canonical scope installed as a peer dep.

## Testing

- Added `test/earendil-works-pi-imports.test.ts` — passes with `bun test`
- Built binary locally and verified `pi-provider-kiro@0.7.0` (uses `@earendil-works/*`) loads without error and registers models under `omp --list-models`

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)