### PR TITLE
fix(cli): restore legacy pi package root remaps

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed compiled-binary legacy plugin loading for `@earendil-works/*` imports of bundled package roots such as `@earendil-works/pi-coding-agent`; compat now rewrites all bundled pi package roots to bunfs entrypoints and resolves fallback peer dependencies through the canonical `@oh-my-pi/*` specifier.
+
 ## [15.5.8] - 2026-05-28
 
 ### Breaking Changes
@@ -33,8 +37,6 @@
 - Removed the `edit.hashlineAutoDropPureInsertDuplicates` setting from configuration and execution paths
 
 ### Fixed
-
-- Fixed compiled-binary legacy plugin loading for `@earendil-works/*` imports of bundled package roots such as `@earendil-works/pi-coding-agent`; compat now rewrites all bundled pi package roots to bunfs entrypoints and resolves fallback peer dependencies through the canonical `@oh-my-pi/*` specifier.
 
 - Fixed agent yielding silently on `response.incomplete` (OpenAI Responses / Codex `stopReason: "length"`). The agent now treats output-side incompletion as a recovery case: drops the truncated/reasoning-only assistant turn, attempts context promotion to a larger model, and falls back to compaction or handoff. `AutoCompactionStartEvent.reason` and the custom-tool `auto_compaction_start.trigger` discriminator gain an `"incomplete"` value. The handoff strategy is honored for `"incomplete"` (unlike `"overflow"`, where the input is broken and handoff would hit the same wall).
 - Fixed `eval` tool to resize large displayed images and append dimension notes to text output

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -34,6 +34,8 @@
 
 ### Fixed
 
+- Fixed compiled-binary legacy plugin loading for `@earendil-works/*` imports of bundled package roots such as `@earendil-works/pi-coding-agent`; compat now rewrites all bundled pi package roots to bunfs entrypoints and resolves fallback peer dependencies through the canonical `@oh-my-pi/*` specifier.
+
 - Fixed agent yielding silently on `response.incomplete` (OpenAI Responses / Codex `stopReason: "length"`). The agent now treats output-side incompletion as a recovery case: drops the truncated/reasoning-only assistant turn, attempts context promotion to a larger model, and falls back to compaction or handoff. `AutoCompactionStartEvent.reason` and the custom-tool `auto_compaction_start.trigger` discriminator gain an `"incomplete"` value. The handoff strategy is honored for `"incomplete"` (unlike `"overflow"`, where the input is broken and handoff would hit the same wall).
 - Fixed `eval` tool to resize large displayed images and append dimension notes to text output
 - Fixed `write` tool to strip malformed or loose hashline section headers before writing file content

--- a/packages/coding-agent/scripts/build-binary.ts
+++ b/packages/coding-agent/scripts/build-binary.ts
@@ -56,15 +56,16 @@ async function main(): Promise<void> {
 					"../stats/src/sync-worker.ts",
 					"./src/tools/browser/tab-worker-entry.ts",
 					"./src/eval/js/worker-entry.ts",
-					// Legacy pi-* extension compat shims served by `legacy-pi-compat.ts`.
-					// Both are reached only via the computed `TYPEBOX_SHIM_PATH` /
-					// `LEGACY_PI_AI_SHIM_PATH` constants (which `--compile`'s static
-					// analyzer cannot trace), so each shim must be listed here to land
-					// in bunfs alongside the workers above. The bunfs entry path is
-					// `--root`-relative with a `.js` extension, e.g.
-					// `/$bunfs/root/packages/coding-agent/src/extensibility/typebox.js`,
-					// which is what the `isCompiledBinary()` branch in
-					// `legacy-pi-compat.ts` resolves to at runtime.
+					// Legacy pi-* extension compat entrypoints served by
+					// `legacy-pi-compat.ts`. These are reached via computed bunfs paths
+					// (which `--compile`'s static analyzer cannot trace), so each must be
+					// listed here to land in bunfs at
+					// `/$bunfs/root/packages/<pkg>/<entry>.js`.
+					"../agent/src/index.ts",
+					"../natives/native/index.js",
+					"../tui/src/index.ts",
+					"../utils/src/index.ts",
+					"./src/index.ts",
 					"./src/extensibility/typebox.ts",
 					"./src/extensibility/legacy-pi-ai-shim.ts",
 					"--outfile",

--- a/packages/coding-agent/scripts/build-binary.ts
+++ b/packages/coding-agent/scripts/build-binary.ts
@@ -60,14 +60,18 @@ async function main(): Promise<void> {
 					// `legacy-pi-compat.ts`. These are reached via computed bunfs paths
 					// (which `--compile`'s static analyzer cannot trace), so each must be
 					// listed here to land in bunfs at
-					// `/$bunfs/root/packages/<pkg>/<entry>.js`.
+					// `/$bunfs/root/packages/<pkg>/<entry>.js`. The coding-agent's own
+					// `./src/index.ts` is intentionally NOT listed: bun --compile silently
+					// breaks the CLI entry when the same package's barrel appears as an
+					// extra entrypoint (issue #1474), so legacy `pi-coding-agent` imports
+					// resolve through `legacy-pi-coding-agent-shim.ts` instead.
 					"../agent/src/index.ts",
 					"../natives/native/index.js",
 					"../tui/src/index.ts",
 					"../utils/src/index.ts",
-					"./src/index.ts",
 					"./src/extensibility/typebox.ts",
 					"./src/extensibility/legacy-pi-ai-shim.ts",
+					"./src/extensibility/legacy-pi-coding-agent-shim.ts",
 					"--outfile",
 					"dist/omp",
 				],

--- a/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
+++ b/packages/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.ts
@@ -1,0 +1,15 @@
+/**
+ * Compatibility shim for legacy extensions importing the package root of
+ * `@oh-my-pi/pi-coding-agent` (or one of its aliased scopes like
+ * `@earendil-works/pi-coding-agent` or `@mariozechner/pi-coding-agent`).
+ *
+ * The coding-agent package's own barrel (`./src/index.ts`) cannot be listed
+ * as a `bun --compile` extra entrypoint alongside the CLI entry without
+ * silently breaking the main binary's startup (see issue #1474 follow-up).
+ * Routing legacy plugin imports through this sibling shim sidesteps that
+ * conflict: bun bundles a distinct entry whose path differs from the CLI
+ * entry, while still re-exporting the canonical surface so plugins observe
+ * the same module identity as a direct `@oh-my-pi/pi-coding-agent` import.
+ */
+
+export * from "../index";

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -327,14 +327,20 @@ function resolveLegacyPiSpecifier(args: { path: string; importer: string }): { p
 		return { path: resolveCanonicalPiSpecifier(remappedSpecifier) };
 	} catch {
 		// Fallback for compiled binary mode: the bundled packages live inside
-		// /$bunfs/root and aren't reachable by filesystem resolution. Try the
-		// canonical specifier against the importing file's directory, which
-		// resolves to the plugin's installed @oh-my-pi peer dependency.
+		// /$bunfs/root and aren't reachable by filesystem resolution. Prefer the
+		// canonical specifier against the importing file's directory when the
+		// plugin installed @oh-my-pi peer deps, then try the original legacy
+		// specifier for plugins that still vendor only @mariozechner or
+		// @earendil-works peer deps.
 		const importerDir = path.dirname(args.importer);
 		try {
 			return { path: Bun.resolveSync(remappedSpecifier, importerDir) };
 		} catch {
-			return undefined;
+			try {
+				return { path: Bun.resolveSync(args.path, importerDir) };
+			} catch {
+				return undefined;
+			}
 		}
 	}
 }

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -4,6 +4,8 @@ import * as path from "node:path";
 import * as url from "node:url";
 import { isCompiledBinary } from "@oh-my-pi/pi-utils";
 
+const IS_COMPILED_BINARY = isCompiledBinary();
+
 // Canonical scope for in-process pi packages. Plugins published against any of
 // the aliased scopes below (mariozechner's original publish, earendil-works'
 // fork, or the canonical @oh-my-pi scope itself) are remapped to this scope and
@@ -14,10 +16,9 @@ import { isCompiledBinary } from "@oh-my-pi/pi-utils";
 const CANONICAL_PI_SCOPE = "@oh-my-pi";
 
 // Scopes that have historically been used to publish (or alias) the same set
-// of internal pi-* packages. `@oh-my-pi` is intentionally included so that
-// direct imports of the canonical name still flow through `Bun.resolveSync`
-// against the host binary, avoiding a duplicate copy being pulled in from a
-// plugin's own node_modules tree at install time.
+// of internal pi-* packages. `@oh-my-pi` is intentionally included so direct
+// canonical imports still pass through the same host-bundled package resolution
+// path instead of pulling a duplicate copy from plugin node_modules.
 const PI_SCOPE_ALIASES = ["oh-my-pi", "mariozechner", "earendil-works"] as const;
 
 // Internal pi-* package basenames bundled inside the omp binary.
@@ -58,19 +59,33 @@ const resolvedSpecifierFallbacks = new Map<string, string>();
 const TYPEBOX_SPECIFIER = "@sinclair/typebox";
 const TYPEBOX_SPECIFIER_FILTER = /^@sinclair\/typebox$/;
 
-// In-process compat shim paths. In dev `import.meta.dir` is the source folder of
-// this file, so the dev branches resolve to the real `.ts` source. In compiled
+// In-process compat paths. In dev `import.meta.dir` is the source folder of
+// this file, so the dev branches resolve to the real source files. In compiled
 // binaries `import.meta.dir` collapses to `/$bunfs/root`, so the runtime cannot
-// recover the source layout that way; instead, each shim file is registered as
-// a `--compile` entrypoint in `scripts/build-binary.ts`, which Bun emits into
-// bunfs at a deterministic `--root`-relative path with a `.js` extension. The
-// literals below must stay in sync with that listing — if either path drifts,
-// every legacy plugin loading the shim fails with a missing-module error in
-// release builds (without affecting `bun test`/dev).
-const TYPEBOX_SHIM_PATH = isCompiledBinary()
-	? "/$bunfs/root/packages/coding-agent/src/extensibility/typebox.js"
-	: path.resolve(import.meta.dir, "../typebox.ts");
+// recover the source layout that way; instead, each computed entrypoint path
+// below must be registered as a `--compile` entrypoint in
+// `scripts/build-binary.ts`, which Bun emits into bunfs at a deterministic
+// `--root`-relative path with a `.js` extension. If either side drifts, legacy
+// plugins fail with missing-module errors in release builds.
+const BUNFS_PACKAGE_ROOT = "/$bunfs/root/packages";
 
+type SourcePiPackageDir = "agent" | "coding-agent" | "tui" | "utils";
+
+function getBundledPackageIndexPath(packageDir: SourcePiPackageDir): string {
+	return IS_COMPILED_BINARY
+		? `${BUNFS_PACKAGE_ROOT}/${packageDir}/src/index.js`
+		: path.resolve(import.meta.dir, "../../../..", packageDir, "src/index.ts");
+}
+
+function getBundledNativesIndexPath(): string {
+	return IS_COMPILED_BINARY
+		? `${BUNFS_PACKAGE_ROOT}/natives/native/index.js`
+		: path.resolve(import.meta.dir, "../../../../natives/native/index.js");
+}
+
+const TYPEBOX_SHIM_PATH = IS_COMPILED_BINARY
+	? `${BUNFS_PACKAGE_ROOT}/coding-agent/src/extensibility/typebox.js`
+	: path.resolve(import.meta.dir, "../typebox.ts");
 // Legacy extensions historically imported `Type` (and `Static`/`TSchema`) from
 // the package root of `@(scope)/pi-ai`. pi-ai 15.1.0 removed the runtime `Type`
 // export (see `packages/ai/CHANGELOG.md`), so the bare canonical specifier no
@@ -79,11 +94,16 @@ const TYPEBOX_SHIM_PATH = isCompiledBinary()
 // plus the borrowed `Type` runtime from the Zod-backed TypeBox shim. Subpath
 // imports such as `@oh-my-pi/pi-ai/utils/oauth` continue to resolve directly
 // against the bundled pi-ai package.
-const LEGACY_PI_AI_SHIM_PATH = isCompiledBinary()
-	? "/$bunfs/root/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.js"
+const LEGACY_PI_AI_SHIM_PATH = IS_COMPILED_BINARY
+	? `${BUNFS_PACKAGE_ROOT}/coding-agent/src/extensibility/legacy-pi-ai-shim.js`
 	: path.resolve(import.meta.dir, "../legacy-pi-ai-shim.ts");
 const LEGACY_PI_PACKAGE_ROOT_OVERRIDES: Record<string, string> = {
+	[`${CANONICAL_PI_SCOPE}/pi-agent-core`]: getBundledPackageIndexPath("agent"),
 	[`${CANONICAL_PI_SCOPE}/pi-ai`]: LEGACY_PI_AI_SHIM_PATH,
+	[`${CANONICAL_PI_SCOPE}/pi-coding-agent`]: getBundledPackageIndexPath("coding-agent"),
+	[`${CANONICAL_PI_SCOPE}/pi-natives`]: getBundledNativesIndexPath(),
+	[`${CANONICAL_PI_SCOPE}/pi-tui`]: getBundledPackageIndexPath("tui"),
+	[`${CANONICAL_PI_SCOPE}/pi-utils`]: getBundledPackageIndexPath("utils"),
 };
 
 let isLegacyPiSpecifierShimInstalled = false;
@@ -298,11 +318,11 @@ function resolveLegacyPiSpecifier(args: { path: string; importer: string }): { p
 	} catch {
 		// Fallback for compiled binary mode: the bundled packages live inside
 		// /$bunfs/root and aren't reachable by filesystem resolution. Try the
-		// original (pre-remap) specifier against the importing file's directory,
-		// which resolves to the plugin's installed peer dep.
+		// canonical specifier against the importing file's directory, which
+		// resolves to the plugin's installed @oh-my-pi peer dependency.
 		const importerDir = path.dirname(args.importer);
 		try {
-			return { path: Bun.resolveSync(args.path, importerDir) };
+			return { path: Bun.resolveSync(remappedSpecifier, importerDir) };
 		} catch {
 			return undefined;
 		}

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -59,29 +59,17 @@ const resolvedSpecifierFallbacks = new Map<string, string>();
 const TYPEBOX_SPECIFIER = "@sinclair/typebox";
 const TYPEBOX_SPECIFIER_FILTER = /^@sinclair\/typebox$/;
 
-// In-process compat paths. In dev `import.meta.dir` is the source folder of
-// this file, so the dev branches resolve to the real source files. In compiled
-// binaries `import.meta.dir` collapses to `/$bunfs/root`, so the runtime cannot
-// recover the source layout that way; instead, each computed entrypoint path
-// below must be registered as a `--compile` entrypoint in
-// `scripts/build-binary.ts`, which Bun emits into bunfs at a deterministic
-// `--root`-relative path with a `.js` extension. If either side drifts, legacy
-// plugins fail with missing-module errors in release builds.
+// Compat shim paths owned by this package. The dev branch resolves the sibling
+// source file via `import.meta.dir` (works in monorepo, source-link, and
+// node_modules installs alike, since each install layout ships the shim next
+// to this file). The compiled-binary branch points at the `--root`-relative
+// bunfs path produced by `scripts/build-binary.ts`; every shim listed below
+// must be registered there as an explicit `--compile` entrypoint or release
+// builds fail with missing-module errors. Non-shim bundled packages are
+// resolved via `Bun.resolveSync` (see `resolveCanonicalPiSpecifier`), so they
+// keep working in installed-package mode where the on-disk layout differs from
+// the monorepo source tree.
 const BUNFS_PACKAGE_ROOT = "/$bunfs/root/packages";
-
-type SourcePiPackageDir = "agent" | "tui" | "utils";
-
-function getBundledPackageIndexPath(packageDir: SourcePiPackageDir): string {
-	return IS_COMPILED_BINARY
-		? `${BUNFS_PACKAGE_ROOT}/${packageDir}/src/index.js`
-		: path.resolve(import.meta.dir, "../../../..", packageDir, "src/index.ts");
-}
-
-function getBundledNativesIndexPath(): string {
-	return IS_COMPILED_BINARY
-		? `${BUNFS_PACKAGE_ROOT}/natives/native/index.js`
-		: path.resolve(import.meta.dir, "../../../../natives/native/index.js");
-}
 
 const TYPEBOX_SHIM_PATH = IS_COMPILED_BINARY
 	? `${BUNFS_PACKAGE_ROOT}/coding-agent/src/extensibility/typebox.js`
@@ -107,13 +95,25 @@ const LEGACY_PI_AI_SHIM_PATH = IS_COMPILED_BINARY
 const LEGACY_PI_CODING_AGENT_SHIM_PATH = IS_COMPILED_BINARY
 	? `${BUNFS_PACKAGE_ROOT}/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.js`
 	: path.resolve(import.meta.dir, "../legacy-pi-coding-agent-shim.ts");
+
+// Package-root overrides. Shim entries are always applied because they replace
+// (or augment) the canonical surface even in non-compiled installs. The bunfs
+// entries are added only in compiled-binary mode — in dev / source-link /
+// installed-package mode the canonical specifier resolves cleanly through
+// `Bun.resolveSync`, and hardcoding a relative source-tree path would break
+// installs where the bundled packages live at `node_modules/@oh-my-pi/pi-*`
+// rather than `packages/*`.
 const LEGACY_PI_PACKAGE_ROOT_OVERRIDES: Record<string, string> = {
-	[`${CANONICAL_PI_SCOPE}/pi-agent-core`]: getBundledPackageIndexPath("agent"),
 	[`${CANONICAL_PI_SCOPE}/pi-ai`]: LEGACY_PI_AI_SHIM_PATH,
 	[`${CANONICAL_PI_SCOPE}/pi-coding-agent`]: LEGACY_PI_CODING_AGENT_SHIM_PATH,
-	[`${CANONICAL_PI_SCOPE}/pi-natives`]: getBundledNativesIndexPath(),
-	[`${CANONICAL_PI_SCOPE}/pi-tui`]: getBundledPackageIndexPath("tui"),
-	[`${CANONICAL_PI_SCOPE}/pi-utils`]: getBundledPackageIndexPath("utils"),
+	...(IS_COMPILED_BINARY
+		? {
+				[`${CANONICAL_PI_SCOPE}/pi-agent-core`]: `${BUNFS_PACKAGE_ROOT}/agent/src/index.js`,
+				[`${CANONICAL_PI_SCOPE}/pi-natives`]: `${BUNFS_PACKAGE_ROOT}/natives/native/index.js`,
+				[`${CANONICAL_PI_SCOPE}/pi-tui`]: `${BUNFS_PACKAGE_ROOT}/tui/src/index.js`,
+				[`${CANONICAL_PI_SCOPE}/pi-utils`]: `${BUNFS_PACKAGE_ROOT}/utils/src/index.js`,
+			}
+		: {}),
 };
 
 let isLegacyPiSpecifierShimInstalled = false;

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -69,7 +69,7 @@ const TYPEBOX_SPECIFIER_FILTER = /^@sinclair\/typebox$/;
 // plugins fail with missing-module errors in release builds.
 const BUNFS_PACKAGE_ROOT = "/$bunfs/root/packages";
 
-type SourcePiPackageDir = "agent" | "coding-agent" | "tui" | "utils";
+type SourcePiPackageDir = "agent" | "tui" | "utils";
 
 function getBundledPackageIndexPath(packageDir: SourcePiPackageDir): string {
 	return IS_COMPILED_BINARY
@@ -86,6 +86,7 @@ function getBundledNativesIndexPath(): string {
 const TYPEBOX_SHIM_PATH = IS_COMPILED_BINARY
 	? `${BUNFS_PACKAGE_ROOT}/coding-agent/src/extensibility/typebox.js`
 	: path.resolve(import.meta.dir, "../typebox.ts");
+
 // Legacy extensions historically imported `Type` (and `Static`/`TSchema`) from
 // the package root of `@(scope)/pi-ai`. pi-ai 15.1.0 removed the runtime `Type`
 // export (see `packages/ai/CHANGELOG.md`), so the bare canonical specifier no
@@ -97,10 +98,19 @@ const TYPEBOX_SHIM_PATH = IS_COMPILED_BINARY
 const LEGACY_PI_AI_SHIM_PATH = IS_COMPILED_BINARY
 	? `${BUNFS_PACKAGE_ROOT}/coding-agent/src/extensibility/legacy-pi-ai-shim.js`
 	: path.resolve(import.meta.dir, "../legacy-pi-ai-shim.ts");
+
+// The coding-agent's own `./src/index.ts` cannot be listed as an extra
+// `bun --compile` entrypoint alongside the CLI entry without breaking binary
+// startup (issue #1474 follow-up). Legacy `@(scope)/pi-coding-agent` root
+// imports therefore resolve through a sibling shim whose distinct file path
+// avoids that collision while re-exporting the canonical package surface.
+const LEGACY_PI_CODING_AGENT_SHIM_PATH = IS_COMPILED_BINARY
+	? `${BUNFS_PACKAGE_ROOT}/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.js`
+	: path.resolve(import.meta.dir, "../legacy-pi-coding-agent-shim.ts");
 const LEGACY_PI_PACKAGE_ROOT_OVERRIDES: Record<string, string> = {
 	[`${CANONICAL_PI_SCOPE}/pi-agent-core`]: getBundledPackageIndexPath("agent"),
 	[`${CANONICAL_PI_SCOPE}/pi-ai`]: LEGACY_PI_AI_SHIM_PATH,
-	[`${CANONICAL_PI_SCOPE}/pi-coding-agent`]: getBundledPackageIndexPath("coding-agent"),
+	[`${CANONICAL_PI_SCOPE}/pi-coding-agent`]: LEGACY_PI_CODING_AGENT_SHIM_PATH,
 	[`${CANONICAL_PI_SCOPE}/pi-natives`]: getBundledNativesIndexPath(),
 	[`${CANONICAL_PI_SCOPE}/pi-tui`]: getBundledPackageIndexPath("tui"),
 	[`${CANONICAL_PI_SCOPE}/pi-utils`]: getBundledPackageIndexPath("utils"),

--- a/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
@@ -151,4 +151,31 @@ describe("legacy pi package root remaps (issue #1474)", () => {
 		};
 		expect(loaded.loadedMarker).toBe("legacy-oauth");
 	});
+
+	it("routes @earendil-works/pi-utils through canonical Bun.resolveSync in non-compiled mode", async () => {
+		// Regression: when omp runs from a node_modules install (not the monorepo
+		// and not a compiled binary), the bundled packages live at
+		// `node_modules/@oh-my-pi/pi-*`, not next to the source tree. Hardcoding
+		// a sibling `packages/<pkg>/src/index.ts` path would miss them, so the
+		// non-compiled branch must delegate to `Bun.resolveSync` against the
+		// canonical specifier.
+		const realResolveSync = Bun.resolveSync.bind(Bun);
+		let canonicalLookupSeen = false;
+		vi.spyOn(Bun, "resolveSync").mockImplementation((specifier: string, from: string) => {
+			if (specifier === "@oh-my-pi/pi-utils") {
+				canonicalLookupSeen = true;
+			}
+			return realResolveSync(specifier, from);
+		});
+		const entry = await writeFixtureExtension(
+			[
+				'import { isCompiledBinary } from "@earendil-works/pi-utils";',
+				"export const probe = isCompiledBinary;",
+			].join("\n"),
+		);
+
+		const loaded = (await loadLegacyPiModule(entry)) as { probe: () => boolean };
+		expect(typeof loaded.probe).toBe("function");
+		expect(canonicalLookupSeen).toBe(true);
+	});
 });

--- a/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import * as url from "node:url";
 import { installLegacyPiSpecifierShim, loadLegacyPiModule } from "../../src/extensibility/plugins/legacy-pi-compat";
 import { Type as TypeBoxShimType } from "../../src/extensibility/typebox";
 
@@ -117,5 +118,37 @@ describe("legacy pi package root remaps (issue #1474)", () => {
 
 		const loaded = (await loadLegacyPiModule(entry)) as { loadedVersion: string };
 		expect(loaded.loadedVersion).toMatch(/^\d+\.\d+\.\d+/);
+	});
+
+	it("falls back to legacy-scoped subpath peers for direct plugin imports", async () => {
+		const realResolveSync = Bun.resolveSync.bind(Bun);
+		vi.spyOn(Bun, "resolveSync").mockImplementation((specifier: string, from: string) => {
+			if (specifier === "@oh-my-pi/pi-ai/utils/oauth") {
+				throw new Error(`canonical peer unavailable from ${from}`);
+			}
+			return realResolveSync(specifier, from);
+		});
+
+		const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-legacy-direct-subpath-"));
+		tempRoots.push(dir);
+		const packageDir = path.join(dir, "node_modules", "@mariozechner", "pi-ai");
+		await fs.mkdir(packageDir, { recursive: true });
+		await fs.writeFile(
+			path.join(packageDir, "package.json"),
+			JSON.stringify({ type: "module", exports: { "./oauth": "./oauth.js" } }),
+			"utf8",
+		);
+		await fs.writeFile(path.join(packageDir, "oauth.js"), 'export const marker = "legacy-oauth";', "utf8");
+		const entry = path.join(dir, "index.ts");
+		await fs.writeFile(
+			entry,
+			['import { marker } from "@mariozechner/pi-ai/oauth";', "export const loadedMarker = marker;"].join("\n"),
+			"utf8",
+		);
+
+		const loaded = (await import(`${url.pathToFileURL(entry).href}?nonce=${Date.now()}`)) as {
+			loadedMarker: string;
+		};
+		expect(loaded.loadedMarker).toBe("legacy-oauth");
 	});
 });

--- a/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-ai-type-remap.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, it } from "bun:test";
+import { afterAll, afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -16,6 +16,10 @@ import { Type as TypeBoxShimType } from "../../src/extensibility/typebox";
 installLegacyPiSpecifierShim();
 
 const tempRoots: string[] = [];
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
 
 afterAll(async () => {
 	for (const dir of tempRoots) {
@@ -93,5 +97,25 @@ describe("legacy-pi @(scope)/pi-ai root `Type` remap (issue #1437)", () => {
 
 		const loaded = (await loadLegacyPiModule(entry)) as { fn: unknown };
 		expect(typeof loaded.fn).toBe("function");
+	});
+});
+
+describe("legacy pi package root remaps (issue #1474)", () => {
+	it("loads @earendil-works/pi-coding-agent root imports when host package resolution is unavailable", async () => {
+		const realResolveSync = Bun.resolveSync.bind(Bun);
+		vi.spyOn(Bun, "resolveSync").mockImplementation((specifier: string, from: string) => {
+			if (specifier === "@oh-my-pi/pi-coding-agent" && from.endsWith(path.join("src", "extensibility", "plugins"))) {
+				throw new Error("compiled binary host package resolution unavailable");
+			}
+			return realResolveSync(specifier, from);
+		});
+		const entry = await writeFixtureExtension(
+			['import { VERSION } from "@earendil-works/pi-coding-agent";', "export const loadedVersion = VERSION;"].join(
+				"\n",
+			),
+		);
+
+		const loaded = (await loadLegacyPiModule(entry)) as { loadedVersion: string };
+		expect(loaded.loadedVersion).toMatch(/^\d+\.\d+\.\d+/);
 	});
 });


### PR DESCRIPTION
## Repro
A focused compat test simulates compiled-binary mode by making host resolution of `@oh-my-pi/pi-coding-agent` fail from `legacy-pi-compat.ts`, then loads a legacy extension importing `@earendil-works/pi-coding-agent`. Before the fix, `bun test test/extensibility/legacy-pi-ai-type-remap.test.ts` from `packages/coding-agent` failed with `Cannot find module '@earendil-works/pi-coding-agent'`.

## Cause
`packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` only had a package-root override for `@oh-my-pi/pi-ai`. Other bundled root imports such as `@earendil-works/pi-coding-agent` were remapped to `@oh-my-pi/*` and then sent through `getResolvedSpecifier`, which cannot walk from `/$bunfs/root` to a reachable `node_modules` tree in compiled binaries. The `resolveLegacyPiSpecifier` fallback also retried the original legacy specifier instead of the canonical `@oh-my-pi/*` specifier.

## Fix
- Added bundled root overrides for `pi-agent-core`, `pi-coding-agent`, `pi-natives`, `pi-tui`, and `pi-utils`, alongside the existing `pi-ai` shim.
- Listed those computed bunfs entrypoints in `packages/coding-agent/scripts/build-binary.ts` so compiled binaries actually emit the paths used at runtime.
- Changed the legacy resolver fallback to resolve the canonical remapped specifier from the plugin importer directory.
- Added regression coverage for `@earendil-works/pi-coding-agent` root imports when host package resolution is unavailable.

## Verification
`bun test test/extensibility/legacy-pi-ai-type-remap.test.ts` in `packages/coding-agent` passes: 5 pass, 0 fail. `bun run check` in `packages/coding-agent` passes. `bun run build` was attempted, but this checkout has no linux-x64 native addon artifacts, so `packages/natives/scripts/embed-native.ts` stopped before the binary compile step. Fixes #1474