### PR TITLE
fix(ai): detect Kimi thinking format across all providers, not just native hosts

### DIFF
--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -213,9 +213,11 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 				? "zai"
 				: provider === "openrouter" || baseUrl.includes("openrouter.ai")
 					? "openrouter"
-					: isAlibaba || isQwen
-						? "qwen"
-						: "openai",
+					: isKimiModel
+						? "zai"
+						: isAlibaba || isQwen
+							? "qwen"
+							: "openai",
 		reasoningContentField: "reasoning_content",
 		// Backends that 400 follow-up requests when prior assistant tool-call turns lack `reasoning_content`:
 		//   - Kimi: documented invariant on its native API.


### PR DESCRIPTION
`isMoonshotKimi` only matched direct Moonshot/Kimi-code providers (`api.moonshot.ai`, `api.kimi.com`), leaving `kimi-*` models routed through OpenCode Go, OpenRouter, Kilo, and other proxies with `thinkingFormat: "openai"` → `reasoning_effort` instead of the `thinking: { type: "enabled" }` zai binary format the Kimi backend expects.

## Fix

Extend `thinkingFormat` detection to `isKimiModel` so the zai format applies regardless of which provider routes the model. Compat blocks already set by individual providers (`kimi-code` mapModel, descriptor `transformModel`) take precedence via `resolveOpenAICompat` overlay, so existing bundled entries are unchanged.

## Change

`openai-completions-compat.ts`: add `|| isKimiModel` to the `thinkingFormat` ternary.