### PR TITLE
fix(coding-agent): clamp memory phase1/phase2 reasoning effort to the model's supported range

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Autonomous Memory phase 1/phase 2 failing with `Thinking effort low is not supported by <provider>/<model>` on models whose supported reasoning efforts exclude `low`/`medium` (e.g. `deepseek/deepseek-v4-pro`). Both stage1 (`Effort.Low`) and consolidation (`Effort.Medium`) call sites in `packages/coding-agent/src/memories/index.ts` now route through `clampThinkingLevelForModel`, lifting the requested effort to the model's lowest supported level instead of letting `requireSupportedEffort` throw ([#1480](https://github.com/can1357/oh-my-pi/issues/1480)).
+
 ## [15.5.10] - 2026-05-28
 
 ### Added

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -744,7 +744,12 @@ async function runConsolidationModel(options: {
 		{
 			messages: [{ role: "user", content: [{ type: "text", text: input }], timestamp: Date.now() }],
 		},
-		{ apiKey, metadata: options.metadata, maxTokens: 8192, reasoning: clampThinkingLevelForModel(model, Effort.Medium) },
+		{
+			apiKey,
+			metadata: options.metadata,
+			maxTokens: 8192,
+			reasoning: clampThinkingLevelForModel(model, Effort.Medium),
+		},
 	);
 	if (response.stopReason === "error") {
 		throw new Error(response.errorMessage || "phase2 model error");

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -3,7 +3,7 @@ import type * as fsNode from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
-import { completeSimple, Effort, type Model } from "@oh-my-pi/pi-ai";
+import { clampThinkingLevelForModel, completeSimple, Effort, type Model } from "@oh-my-pi/pi-ai";
 import { getAgentDbPath, getMemoriesDir, logger, parseJsonlLenient, prompt } from "@oh-my-pi/pi-utils";
 import type { ModelRegistry } from "../config/model-registry";
 import { resolveModelRoleValue } from "../config/model-resolver";
@@ -612,7 +612,7 @@ async function runStage1Job(options: {
 				apiKey,
 				metadata: options.metadata,
 				maxTokens: Math.max(1024, Math.min(4096, Math.floor(modelMaxTokens * 0.2))),
-				reasoning: Effort.Low,
+				reasoning: clampThinkingLevelForModel(model, Effort.Low),
 			},
 		);
 
@@ -744,7 +744,7 @@ async function runConsolidationModel(options: {
 		{
 			messages: [{ role: "user", content: [{ type: "text", text: input }], timestamp: Date.now() }],
 		},
-		{ apiKey, metadata: options.metadata, maxTokens: 8192, reasoning: Effort.Medium },
+		{ apiKey, metadata: options.metadata, maxTokens: 8192, reasoning: clampThinkingLevelForModel(model, Effort.Medium) },
 	);
 	if (response.stopReason === "error") {
 		throw new Error(response.errorMessage || "phase2 model error");

--- a/packages/coding-agent/test/memories-runtime.test.ts
+++ b/packages/coding-agent/test/memories-runtime.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { Effort, type Model } from "@oh-my-pi/pi-ai";
 import * as ai from "@oh-my-pi/pi-ai";
+import { Effort, type Model } from "@oh-my-pi/pi-ai";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
 	buildMemoryToolDeveloperInstructions,

--- a/packages/coding-agent/test/memories-runtime.test.ts
+++ b/packages/coding-agent/test/memories-runtime.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import type { Model } from "@oh-my-pi/pi-ai";
+import { Effort, type Model } from "@oh-my-pi/pi-ai";
 import * as ai from "@oh-my-pi/pi-ai";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
@@ -226,6 +226,79 @@ describe("memories runtime", () => {
 		expect(fx.session.refreshBaseSystemPrompt).toHaveBeenCalledTimes(1);
 		expect(ai.completeSimple).toHaveBeenCalled();
 		expect(ai.completeSimple).toHaveBeenCalledTimes(2);
+	});
+
+	test("clamps stage1 and phase2 reasoning effort against the model's supported range", async () => {
+		// Regression for #1480: memory pipeline hardcoded `Effort.Low`/`Effort.Medium`,
+		// which `requireSupportedEffort` rejects on models whose supported range starts
+		// above `low` (e.g. deepseek-v4-pro → [high, xhigh]). The fix routes both call
+		// sites through `clampThinkingLevelForModel`, lifting the requested effort to
+		// the model's floor instead of throwing.
+		const fx = await createFixture();
+		const constrainedModel: Model = {
+			...fx.model,
+			reasoning: true,
+			thinking: { mode: "effort", minLevel: Effort.High, maxLevel: Effort.XHigh },
+		};
+		fx.session.model = constrainedModel;
+		fx.modelRegistry.find = vi.fn(() => constrainedModel);
+		fx.modelRegistry.getAll = vi.fn(() => [constrainedModel]);
+
+		const rolloutPath = path.join(fx.sessionDir, "thread-constrained.jsonl");
+		const rolloutRows = [
+			{ type: "session", id: "thread-constrained", cwd: fx.agentDir },
+			{ type: "message", message: { role: "user", content: "summarize this rollout" } },
+		];
+		await fs.writeFile(rolloutPath, `${rolloutRows.map(row => JSON.stringify(row)).join("\n")}\n`);
+
+		const spy = vi
+			.spyOn(ai, "completeSimple")
+			.mockResolvedValueOnce({
+				stopReason: "end_turn",
+				content: [
+					{
+						type: "text",
+						text: JSON.stringify({
+							rollout_summary: "Rollout summary",
+							rollout_slug: "thread-constrained",
+							raw_memory: "Raw memory",
+						}),
+					},
+				],
+				usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, totalTokens: 2 },
+			} as any)
+			.mockResolvedValueOnce({
+				stopReason: "end_turn",
+				content: [
+					{
+						type: "text",
+						text: JSON.stringify({
+							memory_md: "# Memory\n\nBody",
+							memory_summary: "Summary",
+							skills: [],
+						}),
+					},
+				],
+			} as any);
+
+		startMemoryStartupTask({
+			session: fx.session,
+			settings: fx.settings,
+			modelRegistry: fx.modelRegistry,
+			agentDir: fx.agentDir,
+			taskDepth: 0,
+		});
+
+		const memoryRoot = getMemoryRoot(fx.agentDir, fx.session.sessionManager.getCwd());
+		await waitFor(async () => {
+			expect((await fs.readFile(path.join(memoryRoot, "MEMORY.md"), "utf8")).trim()).toBe("# Memory\n\nBody");
+		});
+
+		expect(spy).toHaveBeenCalledTimes(2);
+		// stage1 requested `low`, phase2 requested `medium`; both must clamp up to the
+		// model's floor (`high`) instead of being passed through and throwing.
+		expect(spy.mock.calls[0]?.[2]?.reasoning).toBe(Effort.High);
+		expect(spy.mock.calls[1]?.[2]?.reasoning).toBe(Effort.High);
 	});
 
 	test("phase2 sync prunes stale summaries and preserves raw memory ordering", async () => {


### PR DESCRIPTION
## Repro

With `memory.backend: local` and the `default` model role set to a reasoning model whose supported efforts exclude `low`/`medium` (the reporter's case: `deepseek/deepseek-v4-pro` → `[high, xhigh]`), every Phase 1 stage1 job logs

```
Memory phase1 stage1 job failed
reason: "Thinking effort low is not supported by deepseek/deepseek-v4-pro. Supported efforts: high, xhigh"
```

Phase 1 closes with `succeeded: 0`, Phase 2 never runs, and `~/.omp/agent/memories/` is never populated. Reproduced by a unit test driving `startMemoryStartupTask` with a model carrying `thinking: { mode: "effort", minLevel: "high", maxLevel: "xhigh" }`; before the fix the spy captured `reasoning: "low"` on the stage1 call and the unmocked path throws on the same effort string.

`bun test packages/coding-agent/test/memories-runtime.test.ts -t "clamps stage1 and phase2 reasoning effort"`

## Cause

`packages/coding-agent/src/memories/index.ts` hardcoded:

- `runStage1Job` → `reasoning: Effort.Low` (line 615).
- `runConsolidationModel` → `reasoning: Effort.Medium` (line 747).

`completeSimple → mapOptionsForApi → resolveOpenAiReasoningEffort` calls `requireSupportedEffort(model, effort)`, which throws when the resolved memory model's `getSupportedEfforts(...)` does not include the requested level. The throw bubbles into `runStage1Job`'s catch and marks the claim failed; the consolidation throw fails Phase 2 the same way. Compaction already solved the same class of bug (#1182) by routing requested effort through `clampThinkingLevelForModel`.

## Fix

- Import `clampThinkingLevelForModel` from `@oh-my-pi/pi-ai`.
- Replace `reasoning: Effort.Low` with `reasoning: clampThinkingLevelForModel(model, Effort.Low)` at the stage1 call site.
- Replace `reasoning: Effort.Medium` with `reasoning: clampThinkingLevelForModel(model, Effort.Medium)` at the consolidation call site.

The clamp lifts the requested effort to the model's lowest supported level (for `[high, xhigh]`, both `low` and `medium` resolve to `high`); non-reasoning models continue to receive `undefined` (the helper's `!model.reasoning` early-return), preserving prior behaviour. `modelOmitsReasoningEffort` models (e.g. `xai-oauth/grok-build`) also receive `undefined` for the same reason compaction does, deferring to the wire-side `omitReasoningEffort` gate.

## Verification

- `bun test packages/coding-agent/test/memories-runtime.test.ts` → 8 pass / 0 fail.
- New `clamps stage1 and phase2 reasoning effort against the model's supported range` test pins both call sites; flipping either back to the hardcoded `Effort.Low`/`Effort.Medium` makes the new assertions fail with the exact effort mismatch.

Fixes #1480