### PR TITLE
fix(ai): include reasoning_content for OpenCode Go Kimi tool-call turns

### DIFF
--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -378,6 +378,20 @@ function applyGeneratedModelPolicy(model: ApiModel<Api>): void {
 	}
 	if (
 		model.api === "openai-completions" &&
+		model.reasoning &&
+		(model.provider === "opencode-go" || model.provider === "opencode-zen") &&
+		(model.id.toLowerCase().includes("kimi") || model.name.toLowerCase().includes("kimi"))
+	) {
+		model.compat = {
+			...(model.compat ?? {}),
+			reasoningContentField: "reasoning_content",
+			requiresReasoningContentForToolCalls: true,
+			allowsSyntheticReasoningContentForToolCalls: false,
+			requiresAssistantContentForToolCalls: true,
+		};
+	}
+	if (
+		model.api === "openai-completions" &&
 		model.provider === "opencode-go" &&
 		(model.id === "deepseek-v4-flash" || model.id === "deepseek-v4-pro")
 	) {

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -54487,6 +54487,12 @@
 				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
+			},
+			"compat": {
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"requiresAssistantContentForToolCalls": true
 			}
 		},
 		"kimi-k2.6": {
@@ -54512,6 +54518,12 @@
 				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
+			},
+			"compat": {
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"requiresAssistantContentForToolCalls": true
 			}
 		},
 		"mimo-v2-omni": {
@@ -55725,6 +55737,12 @@
 				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
+			},
+			"compat": {
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"requiresAssistantContentForToolCalls": true
 			}
 		},
 		"kimi-k2.5": {
@@ -55750,6 +55768,12 @@
 				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
+			},
+			"compat": {
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"requiresAssistantContentForToolCalls": true
 			}
 		},
 		"kimi-k2.6": {
@@ -55775,6 +55799,12 @@
 				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
+			},
+			"compat": {
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false,
+				"requiresAssistantContentForToolCalls": true
 			}
 		},
 		"ling-2.6-flash-free": {

--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -105,6 +105,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		provider === "opencode-go" ||
 		baseUrl.includes("opencode.ai");
 	const isOpenCodeProvider = provider === "opencode-go" || provider === "opencode-zen";
+	const kimiRequiresReasoningContent = isKimiModel && (!isOpenCodeProvider || Boolean(model.reasoning));
 
 	const useMaxTokens =
 		provider === "mistral" ||
@@ -218,22 +219,24 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 						: "openai",
 		reasoningContentField: "reasoning_content",
 		// Backends that 400 follow-up requests when prior assistant tool-call turns lack `reasoning_content`:
-		//   - Kimi: documented invariant on its native API.
+		//   - Kimi: documented invariant on native and OpenCode Go/Zen gateways.
 		//   - DeepSeek-family reasoning models, including aliased OpenCode Zen models
 		//     like `big-pickle`, validate exact thinking-mode replay.
 		//   - Any reasoning-capable model reached through OpenRouter can enforce this
 		//     server-side whenever the request is in thinking mode. We can't translate
 		//     Anthropic's redacted/encrypted reasoning into provider-native plaintext,
 		//     so cross-provider continuations rely on a placeholder.
-		// OpenCode Kimi aliases handle reasoning content internally and reject
-		// client-sent `reasoning_content`, so exclude only that Kimi-on-OpenCode path.
 		requiresReasoningContentForToolCalls:
-			(isKimiModel && !isOpenCodeProvider) ||
+			kimiRequiresReasoningContent ||
 			(isDeepseekFamily && Boolean(model.reasoning)) ||
 			((provider === "openrouter" || baseUrl.includes("openrouter.ai")) && Boolean(model.reasoning)),
-		// DeepSeek V4 rejects synthetic reasoning_content placeholders (".") on tool-call turns.
-		// Kimi and OpenRouter accept them when actual reasoning is unavailable.
-		allowsSyntheticReasoningContentForToolCalls: !isDeepseekFamily || !model.reasoning,
+		// DeepSeek V4 and OpenCode-hosted Kimi reject synthetic reasoning_content
+		// placeholders (".") on tool-call turns. Native Kimi and OpenRouter accept
+		// them when actual reasoning is unavailable.
+		allowsSyntheticReasoningContentForToolCalls: !(
+			(isDeepseekFamily && model.reasoning) ||
+			(isKimiModel && isOpenCodeProvider && model.reasoning)
+		),
 		requiresAssistantContentForToolCalls: isKimiModel || isDirectDeepseekReasoning,
 		openRouterRouting: undefined,
 		vercelGatewayRouting: undefined,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1491,8 +1491,10 @@ export function convertMessages(
 					const reasoningText = (assistantMsg as any).reasoning_text;
 					if (reasoning && reasoningField !== "reasoning") {
 						(assistantMsg as any)[reasoningField] = reasoning;
+						delete (assistantMsg as any).reasoning;
 					} else if (reasoningText && reasoningField !== "reasoning_text") {
 						(assistantMsg as any)[reasoningField] = reasoningText;
+						delete (assistantMsg as any).reasoning_text;
 					} else if (nonEmptyThinkingBlocks.length > 0) {
 						(assistantMsg as any)[reasoningField] = nonEmptyThinkingBlocks.map(b => b.thinking).join("\n");
 					}

--- a/packages/ai/test/deepseek-reasoning-content.test.ts
+++ b/packages/ai/test/deepseek-reasoning-content.test.ts
@@ -415,6 +415,71 @@ describe("DeepSeek reasoning_content tool-call replay", () => {
 			expect((assistant as { content: unknown }).content).toBe("");
 		});
 
+		it("sets reasoning_content to empty string for OpenCode Go Kimi K2.6 tool-call turns", () => {
+			const model = getBundledModel("opencode-go", "kimi-k2.6") as Model<"openai-completions">;
+			const compat = detectCompat(model);
+			expect(compat.requiresReasoningContentForToolCalls).toBe(true);
+			expect(compat.allowsSyntheticReasoningContentForToolCalls).toBe(false);
+
+			const msg = assistantToolCall(model, [
+				{
+					type: "toolCall",
+					id: "call_kimi_k26",
+					name: "read",
+					arguments: { path: "package.json" },
+				} as ToolCall,
+			]);
+			const messages = convertMessages(model, { messages: [msg] }, compat);
+			const assistant = messages.find(m => m.role === "assistant");
+			expect(assistant).toBeDefined();
+			expect(Reflect.get(assistant as object, "reasoning_content")).toBe("");
+			expect((assistant as { content: unknown }).content).toBe(".");
+		});
+
+		it("drops alternate reasoning field when normalizing to reasoning_content for OpenCode Go Kimi", () => {
+			const model = getBundledModel("opencode-go", "kimi-k2.6") as Model<"openai-completions">;
+			const compat = detectCompat(model);
+			expect(compat.requiresReasoningContentForToolCalls).toBe(true);
+			expect(compat.allowsSyntheticReasoningContentForToolCalls).toBe(false);
+
+			const msg: AssistantMessage = {
+				role: "assistant",
+				content: [
+					{
+						type: "thinking",
+						thinking: "I should read the file.",
+						thinkingSignature: "reasoning",
+					} as ThinkingContent,
+					{
+						type: "toolCall",
+						id: "call_kimi_k26",
+						name: "read",
+						arguments: { path: "package.json" },
+					} as ToolCall,
+				],
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "toolUse",
+				timestamp: Date.now(),
+			};
+			const messages = convertMessages(model, { messages: [msg] }, compat);
+			const assistant = messages.find(m => m.role === "assistant");
+			expect(assistant).toBeDefined();
+			// Must normalize to reasoning_content — the gateway-required field
+			expect(Reflect.get(assistant as object, "reasoning_content")).toBe("I should read the file.");
+			// Must NOT leak the alternate reasoning field that was only used as a source
+			expect(Reflect.get(assistant as object, "reasoning")).toBeUndefined();
+		});
+
 		it("sets content to empty string (not null) when reasoning_content is present", () => {
 			const model = deepseekModel({
 				provider: "nvidia",


### PR DESCRIPTION
Closes #1484

## Problem

When using reasoning-capable Kimi models (K2.5, K2.6) through the **OpenCode Go** provider with thinking enabled, the API returns a 400 error on follow-up requests after tool calls:

> thinking is enabled but reasoning_content is missing in assistant tool call message at index N

## Root Cause

The compat detection in openai-completions-compat.ts excluded OpenCode-hosted Kimi models from the "requires reasoning_content on tool-call turns" path, assuming the gateway handled it internally. In reality, the OpenCode Go and OpenCode Zen gateways enforce the same invariant as native Kimi: assistant tool-call messages must include reasoning_content when thinking is enabled. They also reject synthetic placeholders (".") for reasoning_content.

## Changes

- **model-thinking.ts**: Apply compat flags for Kimi models on opencode-go/opencode-zen
- **openai-completions-compat.ts**: Update detectOpenAICompat so OpenCode Kimi models with reasoning enabled require reasoning_content on tool-call turns and disallow synthetic placeholders
- **deepseek-reasoning-content.test.ts**: Add test coverage for opencode-go/kimi-k2.6 tool-call replay behavior
- **models.json**: Regenerated compat flags for affected Kimi entries

## Verification

- New unit test: "sets reasoning_content to empty string for OpenCode Go Kimi K2.6 tool-call turns"
- Existing DeepSeek reasoning_content tests continue to pass