### PR TITLE
fix(ai): replay reasoning_content for opencode kimi when thinking is on

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenCode Zen Kimi `400 thinking is enabled but reasoning_content is missing in assistant tool call message` by reactivating `requiresReasoningContentForToolCalls` for `opencode-go`/`opencode-zen` Kimi requests whose runtime options enable thinking, while the static compat default still omits the field for thinking-disabled turns to preserve the `Extra inputs are not permitted` guard from #1071. ([#1484](https://github.com/can1357/oh-my-pi/issues/1484))
+
 ## [15.5.8] - 2026-05-28
 
 ### Added

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed OpenCode Zen Kimi `400 thinking is enabled but reasoning_content is missing in assistant tool call message` by reactivating `requiresReasoningContentForToolCalls` for `opencode-go`/`opencode-zen` Kimi requests whose runtime options enable thinking, while the static compat default still omits the field for thinking-disabled turns to preserve the `Extra inputs are not permitted` guard from #1071. The same gateway invariant also affected `opencode-go/deepseek-v4-flash` and `deepseek-v4-pro`, which now coerce the streamed `reasoning` signature onto `reasoning_content` instead of writing both fields. ([#1484](https://github.com/can1357/oh-my-pi/issues/1484))
+- Fixed OpenCode Zen `400 thinking is enabled but reasoning_content is missing in assistant tool call message` for every model behind `opencode-go`/`opencode-zen` (Kimi K2.x, DeepSeek V4 Pro/Flash, GLM-5.x, Qwen3.x, MiMo, MiniMax) by reactivating `requiresReasoningContentForToolCalls` and pinning the wire field to `reasoning_content` for any opencode request in thinking mode. The static compat default still omits the field for thinking-disabled turns to preserve the `Extra inputs are not permitted` guard from #1071; forced-tool turns also stay off because the existing `disableReasoningOnForcedToolChoice` guard strips thinking from the wire body. ([#1484](https://github.com/can1357/oh-my-pi/issues/1484))
 
 ## [15.5.8] - 2026-05-28
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed OpenCode Zen Kimi `400 thinking is enabled but reasoning_content is missing in assistant tool call message` by reactivating `requiresReasoningContentForToolCalls` for `opencode-go`/`opencode-zen` Kimi requests whose runtime options enable thinking, while the static compat default still omits the field for thinking-disabled turns to preserve the `Extra inputs are not permitted` guard from #1071. ([#1484](https://github.com/can1357/oh-my-pi/issues/1484))
+- Fixed OpenCode Zen Kimi `400 thinking is enabled but reasoning_content is missing in assistant tool call message` by reactivating `requiresReasoningContentForToolCalls` for `opencode-go`/`opencode-zen` Kimi requests whose runtime options enable thinking, while the static compat default still omits the field for thinking-disabled turns to preserve the `Extra inputs are not permitted` guard from #1071. The same gateway invariant also affected `opencode-go/deepseek-v4-flash` and `deepseek-v4-pro`, which now coerce the streamed `reasoning` signature onto `reasoning_content` instead of writing both fields. ([#1484](https://github.com/can1357/oh-my-pi/issues/1484))
 
 ## [15.5.8] - 2026-05-28
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -997,6 +997,22 @@ function buildParams(
 	toolStrictModeOverride?: ToolStrictModeOverride,
 ): { params: OpenAICompletionsParams; toolStrictMode: AppliedToolStrictMode } {
 	const compat = getCompat(model, resolvedBaseUrl);
+	// Opencode Zen's Kimi gateway gates `reasoning_content` on the request's
+	// thinking state: it 400s with `Extra inputs are not permitted` when
+	// thinking is off but the field is supplied (#1071), and 400s with
+	// `thinking is enabled but reasoning_content is missing in assistant tool
+	// call message at index N` (#1484) when thinking is on and the field is
+	// absent. `detectOpenAICompat` keeps `requiresReasoningContentForToolCalls`
+	// off for opencode kimi so the first case never fires; reactivate it per
+	// request when this turn is in thinking mode so prior tool-call turns
+	// replay reasoning_content.
+	const isKimiModelId = model.id.includes("moonshotai/kimi") || /(^|\/)kimi[-.]/i.test(model.id);
+	const isOpenCodeProvider = model.provider === "opencode-go" || model.provider === "opencode-zen";
+	const thinkingEnabledForRequest =
+		Boolean(options?.reasoning) && !options?.disableReasoning && Boolean(model.reasoning);
+	if (isKimiModelId && isOpenCodeProvider && thinkingEnabledForRequest) {
+		compat.requiresReasoningContentForToolCalls = true;
+	}
 	const messages = convertMessages(model, context, compat);
 	maybeAddOpenRouterAnthropicCacheControl(model, messages);
 	const supportsReasoningParams = model.provider !== "github-copilot";
@@ -1009,8 +1025,7 @@ function buildParams(
 	// before the final answer. Always send max_tokens — match the same
 	// Kimi-family regex used by the compat detector.
 	// Note: Direct kimi-code provider is handled by the dedicated Kimi provider in kimi.ts.
-	const isKimi = model.id.includes("moonshotai/kimi") || /(^|\/)kimi[-.]/i.test(model.id);
-	const effectiveMaxTokens = options?.maxTokens ?? (isKimi ? model.maxTokens : undefined);
+	const effectiveMaxTokens = options?.maxTokens ?? (isKimiModelId ? model.maxTokens : undefined);
 
 	const requestModelId =
 		model.provider === "fireworks"

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1502,7 +1502,9 @@ export function convertMessages(
 					const signature = nonEmptyThinkingBlocks[0].thinkingSignature;
 					const recognizedFields = ["reasoning_content", "reasoning", "reasoning_text"];
 					const wireField =
-						compat.allowsSyntheticReasoningContentForToolCalls && signature && recognizedFields.includes(signature)
+						compat.allowsSyntheticReasoningContentForToolCalls &&
+						signature &&
+						recognizedFields.includes(signature)
 							? signature
 							: signature && recognizedFields.includes(signature)
 								? (compat.reasoningContentField ?? "reasoning_content")

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1016,12 +1016,7 @@ function buildParams(
 	const forcedToolChoiceSuppressesThinking =
 		compat.disableReasoningOnForcedToolChoice &&
 		isForcedToolChoice(mapToOpenAICompletionsToolChoice(options?.toolChoice));
-	if (
-		isKimiModelId &&
-		isOpenCodeProvider &&
-		thinkingEnabledForRequest &&
-		!forcedToolChoiceSuppressesThinking
-	) {
+	if (isKimiModelId && isOpenCodeProvider && thinkingEnabledForRequest && !forcedToolChoiceSuppressesThinking) {
 		compat.requiresReasoningContentForToolCalls = true;
 	}
 	const messages = convertMessages(model, context, compat);

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1009,6 +1009,12 @@ function buildParams(
 	// later `disableReasoningOnForcedToolChoice` guard at the bottom of
 	// `buildParams` strips thinking from the wire body for Kimi — keeping the
 	// replay on under those conditions would resurrect the #1071 failure.
+	//
+	// `allowsSyntheticReasoningContentForToolCalls` is forced to `false` on
+	// the same path: the gateway specifically requires `reasoning_content`,
+	// and the default synthetic-friendly behavior would echo whichever field
+	// the upstream streamed (e.g. `reasoning` for many opencode Kimi turns),
+	// landing the replay in the wrong key and re-triggering the 400.
 	const isKimiModelId = model.id.includes("moonshotai/kimi") || /(^|\/)kimi[-.]/i.test(model.id);
 	const isOpenCodeProvider = model.provider === "opencode-go" || model.provider === "opencode-zen";
 	const thinkingEnabledForRequest =
@@ -1018,6 +1024,8 @@ function buildParams(
 		isForcedToolChoice(mapToOpenAICompletionsToolChoice(options?.toolChoice));
 	if (isKimiModelId && isOpenCodeProvider && thinkingEnabledForRequest && !forcedToolChoiceSuppressesThinking) {
 		compat.requiresReasoningContentForToolCalls = true;
+		compat.allowsSyntheticReasoningContentForToolCalls = false;
+		compat.reasoningContentField = "reasoning_content";
 	}
 	const messages = convertMessages(model, context, compat);
 	maybeAddOpenRouterAnthropicCacheControl(model, messages);
@@ -1486,13 +1494,21 @@ export function convertMessages(
 						assistantMsg.content = [{ type: "text", text: thinkingText }];
 					}
 				} else if (compat.requiresReasoningContentForToolCalls) {
-					// Use the signature from the first thinking block if available, but only for
-					// recognized OpenAI-compat reasoning field names. Opaque signatures from other
-					// providers (Anthropic encrypted, OpenAI Responses JSON) are not valid property names.
+					// Use the streamed signature when the backend accepts whichever
+					// recognized field name was emitted (allowsSynthetic=true). Backends
+					// like opencode-kimi-with-thinking and DeepSeek demand the exact
+					// configured `reasoningContentField` instead, so honor that here
+					// rather than echoing the upstream field name.
 					const signature = nonEmptyThinkingBlocks[0].thinkingSignature;
 					const recognizedFields = ["reasoning_content", "reasoning", "reasoning_text"];
-					if (signature && recognizedFields.includes(signature)) {
-						(assistantMsg as any)[signature] = nonEmptyThinkingBlocks.map(b => b.thinking).join("\n");
+					const wireField =
+						compat.allowsSyntheticReasoningContentForToolCalls && signature && recognizedFields.includes(signature)
+							? signature
+							: signature && recognizedFields.includes(signature)
+								? (compat.reasoningContentField ?? "reasoning_content")
+								: undefined;
+					if (wireField) {
+						(assistantMsg as any)[wireField] = nonEmptyThinkingBlocks.map(b => b.thinking).join("\n");
 					}
 				}
 			}

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -997,36 +997,39 @@ function buildParams(
 	toolStrictModeOverride?: ToolStrictModeOverride,
 ): { params: OpenAICompletionsParams; toolStrictMode: AppliedToolStrictMode } {
 	const compat = getCompat(model, resolvedBaseUrl);
-	// Opencode Zen's Kimi gateway gates `reasoning_content` on the request's
-	// thinking state: it 400s with `Extra inputs are not permitted` when
-	// thinking is off but the field is supplied (#1071), and 400s with
-	// `thinking is enabled but reasoning_content is missing in assistant tool
-	// call message at index N` (#1484) when thinking is on and the field is
-	// absent. `detectOpenAICompat` keeps `requiresReasoningContentForToolCalls`
-	// off for opencode kimi so the first case never fires; reactivate it per
-	// request when this turn is in thinking mode so prior tool-call turns
-	// replay reasoning_content. Forced-tool turns are excluded because the
-	// later `disableReasoningOnForcedToolChoice` guard at the bottom of
-	// `buildParams` strips thinking from the wire body for Kimi — keeping the
-	// replay on under those conditions would resurrect the #1071 failure.
+	// Opencode Zen's gateway (https://opencode.ai/zen/go/v1) gates
+	// `reasoning_content` on the request's thinking state for every model it
+	// fronts (Kimi K2.x, DeepSeek V4, GLM-5.x, Qwen3.x, MiMo, MiniMax, …): it
+	// 400s with `Extra inputs are not permitted` when thinking is off but the
+	// field is supplied (#1071), and 400s with `thinking is enabled but
+	// reasoning_content is missing in assistant tool call message at index N`
+	// (#1484) when thinking is on and the field is absent. `detectOpenAICompat`
+	// only set `requiresReasoningContentForToolCalls` for the DeepSeek family
+	// (and previously for Kimi until #1071 carved out opencode); reactivate it
+	// per request for every opencode model whenever this turn is in thinking
+	// mode so prior tool-call turns replay reasoning_content. Forced-tool
+	// turns are excluded because the later `disableReasoningOnForcedToolChoice`
+	// guard at the bottom of `buildParams` strips thinking from the wire body
+	// for Kimi-style models — keeping the replay on under those conditions
+	// would resurrect the #1071 failure.
 	//
 	// `allowsSyntheticReasoningContentForToolCalls` is forced to `false` on
 	// the same path: the gateway specifically requires `reasoning_content`,
 	// and the default synthetic-friendly behavior would echo whichever field
-	// the upstream streamed (e.g. `reasoning` for many opencode Kimi turns),
+	// the upstream streamed (e.g. `reasoning` for many opencode turns),
 	// landing the replay in the wrong key and re-triggering the 400.
-	const isKimiModelId = model.id.includes("moonshotai/kimi") || /(^|\/)kimi[-.]/i.test(model.id);
 	const isOpenCodeProvider = model.provider === "opencode-go" || model.provider === "opencode-zen";
 	const thinkingEnabledForRequest =
 		Boolean(options?.reasoning) && !options?.disableReasoning && Boolean(model.reasoning);
 	const forcedToolChoiceSuppressesThinking =
 		compat.disableReasoningOnForcedToolChoice &&
 		isForcedToolChoice(mapToOpenAICompletionsToolChoice(options?.toolChoice));
-	if (isKimiModelId && isOpenCodeProvider && thinkingEnabledForRequest && !forcedToolChoiceSuppressesThinking) {
+	if (isOpenCodeProvider && thinkingEnabledForRequest && !forcedToolChoiceSuppressesThinking) {
 		compat.requiresReasoningContentForToolCalls = true;
 		compat.allowsSyntheticReasoningContentForToolCalls = false;
 		compat.reasoningContentField = "reasoning_content";
 	}
+	const isKimiModelId = model.id.includes("moonshotai/kimi") || /(^|\/)kimi[-.]/i.test(model.id);
 	const messages = convertMessages(model, context, compat);
 	maybeAddOpenRouterAnthropicCacheControl(model, messages);
 	const supportsReasoningParams = model.provider !== "github-copilot";

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1005,12 +1005,23 @@ function buildParams(
 	// absent. `detectOpenAICompat` keeps `requiresReasoningContentForToolCalls`
 	// off for opencode kimi so the first case never fires; reactivate it per
 	// request when this turn is in thinking mode so prior tool-call turns
-	// replay reasoning_content.
+	// replay reasoning_content. Forced-tool turns are excluded because the
+	// later `disableReasoningOnForcedToolChoice` guard at the bottom of
+	// `buildParams` strips thinking from the wire body for Kimi — keeping the
+	// replay on under those conditions would resurrect the #1071 failure.
 	const isKimiModelId = model.id.includes("moonshotai/kimi") || /(^|\/)kimi[-.]/i.test(model.id);
 	const isOpenCodeProvider = model.provider === "opencode-go" || model.provider === "opencode-zen";
 	const thinkingEnabledForRequest =
 		Boolean(options?.reasoning) && !options?.disableReasoning && Boolean(model.reasoning);
-	if (isKimiModelId && isOpenCodeProvider && thinkingEnabledForRequest) {
+	const forcedToolChoiceSuppressesThinking =
+		compat.disableReasoningOnForcedToolChoice &&
+		isForcedToolChoice(mapToOpenAICompletionsToolChoice(options?.toolChoice));
+	if (
+		isKimiModelId &&
+		isOpenCodeProvider &&
+		thinkingEnabledForRequest &&
+		!forcedToolChoiceSuppressesThinking
+	) {
 		compat.requiresReasoningContentForToolCalls = true;
 	}
 	const messages = convertMessages(model, context, compat);

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -952,87 +952,84 @@ describe("kimi model detection via detectCompat", () => {
 		{ id: "glm-5.1", reasoning: undefined, expectReplay: false },
 		{ id: "qwen3.7-max", reasoning: "high" as const, expectReplay: true },
 		{ id: "mimo-v2-pro", reasoning: "high" as const, expectReplay: true },
-	])(
-		"opencode-go/%s reasoning=%s → replay=%s",
-		async ({ id, reasoning, expectReplay }) => {
-			const model: Model<"openai-completions"> = {
-				...getBundledModel("openai", "gpt-4o-mini"),
-				api: "openai-completions",
-				provider: "opencode-go",
-				baseUrl: "https://opencode.ai/zen/go/v1",
-				id,
-				reasoning: true,
-			};
-			const priorAssistant: AssistantMessage = {
-				role: "assistant",
-				content: [
+	])("opencode-go/%s reasoning=%s → replay=%s", async ({ id, reasoning, expectReplay }) => {
+		const model: Model<"openai-completions"> = {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+			id,
+			reasoning: true,
+		};
+		const priorAssistant: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{
+					type: "thinking",
+					thinking: "Plan before acting.",
+					thinkingSignature: "reasoning",
+				},
+				{
+					type: "toolCall",
+					id: "call_abc123",
+					name: "read",
+					arguments: { path: "README.md" },
+				},
+			],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		global.fetch = createMockFetch(["[DONE]"]);
+		streamOpenAICompletions(
+			model,
+			{
+				messages: [
+					{ role: "user", content: "Summarize the README", timestamp: Date.now() },
+					priorAssistant,
 					{
-						type: "thinking",
-						thinking: "Plan before acting.",
-						thinkingSignature: "reasoning",
-					},
-					{
-						type: "toolCall",
-						id: "call_abc123",
-						name: "read",
-						arguments: { path: "README.md" },
+						role: "toolResult",
+						toolCallId: "call_abc123",
+						toolName: "read",
+						content: [{ type: "text", text: "# Hello\n" }],
+						isError: false,
+						timestamp: Date.now(),
 					},
 				],
-				api: model.api,
-				provider: model.provider,
-				model: model.id,
-				usage: {
-					input: 0,
-					output: 0,
-					cacheRead: 0,
-					cacheWrite: 0,
-					totalTokens: 0,
-					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
-				},
-				stopReason: "toolUse",
-				timestamp: Date.now(),
-			};
+			},
+			{
+				apiKey: "test-key",
+				reasoning,
+				signal: createAbortedSignal(),
+				onPayload: payload => resolve(payload),
+			},
+		);
 
-			const { promise, resolve } = Promise.withResolvers<unknown>();
-			global.fetch = createMockFetch(["[DONE]"]);
-			streamOpenAICompletions(
-				model,
-				{
-					messages: [
-						{ role: "user", content: "Summarize the README", timestamp: Date.now() },
-						priorAssistant,
-						{
-							role: "toolResult",
-							toolCallId: "call_abc123",
-							toolName: "read",
-							content: [{ type: "text", text: "# Hello\n" }],
-							isError: false,
-							timestamp: Date.now(),
-						},
-					],
-				},
-				{
-					apiKey: "test-key",
-					reasoning,
-					signal: createAbortedSignal(),
-					onPayload: payload => resolve(payload),
-				},
-			);
-
-			const payload = (await promise) as { messages: Array<Record<string, unknown>> };
-			const assistant = payload.messages.find(m => m.role === "assistant");
-			expect(assistant).toBeDefined();
-			if (expectReplay) {
-				expect(Reflect.get(assistant as object, "reasoning_content")).toBe("Plan before acting.");
-				// The stale streamed `reasoning` key must never land in the wire body.
-				expect(Reflect.get(assistant as object, "reasoning")).toBeUndefined();
-			} else {
-				expect(Reflect.get(assistant as object, "reasoning_content")).toBeUndefined();
-				expect(Reflect.get(assistant as object, "reasoning")).toBeUndefined();
-				expect(Reflect.get(assistant as object, "reasoning_text")).toBeUndefined();
-			}
-		},
-	);
+		const payload = (await promise) as { messages: Array<Record<string, unknown>> };
+		const assistant = payload.messages.find(m => m.role === "assistant");
+		expect(assistant).toBeDefined();
+		if (expectReplay) {
+			expect(Reflect.get(assistant as object, "reasoning_content")).toBe("Plan before acting.");
+			// The stale streamed `reasoning` key must never land in the wire body.
+			expect(Reflect.get(assistant as object, "reasoning")).toBeUndefined();
+		} else {
+			expect(Reflect.get(assistant as object, "reasoning_content")).toBeUndefined();
+			expect(Reflect.get(assistant as object, "reasoning")).toBeUndefined();
+			expect(Reflect.get(assistant as object, "reasoning_text")).toBeUndefined();
+		}
+	});
 
 	it("injects reasoning_content placeholder when kimi-on-moonshot has tool calls without reasoning field", () => {
 		const model = kimiMoonshotModel("kimi-k2.5");

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -642,6 +642,140 @@ describe("kimi model detection via detectCompat", () => {
 		expect(Reflect.get(assistantObject, "reasoning_text")).toBeUndefined();
 	});
 
+	// #1484: OpenCode Zen's Kimi gateway now 400s with `thinking is enabled but
+	// reasoning_content is missing in assistant tool call message at index N`
+	// when a follow-up request has thinking on but the prior assistant tool-call
+	// turn lacks `reasoning_content`. `buildParams` must reactivate the
+	// `requiresReasoningContentForToolCalls` flag whenever the request itself is
+	// in thinking mode, even though static compat detection leaves it off.
+	it("emits reasoning_content on kimi opencode-go tool-call replays when thinking is enabled", async () => {
+		const model = kimiOpenCodeModel("kimi-k2.6");
+		const priorAssistant: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{
+					type: "thinking",
+					thinking: "Need to read the file before answering.",
+					thinkingSignature: "reasoning_content",
+				},
+				{
+					type: "toolCall",
+					id: "call_abc123",
+					name: "read",
+					arguments: { path: "README.md" },
+				},
+			],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		global.fetch = createMockFetch(["[DONE]"]);
+		streamOpenAICompletions(
+			model,
+			{
+				messages: [
+					{ role: "user", content: "Summarize the README", timestamp: Date.now() },
+					priorAssistant,
+					{
+						role: "toolResult",
+						toolCallId: "call_abc123",
+						toolName: "read",
+						content: [{ type: "text", text: "# Hello\n" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{
+				apiKey: "test-key",
+				reasoning: "high",
+				signal: createAbortedSignal(),
+				onPayload: payload => resolve(payload),
+			},
+		);
+
+		const payload = (await promise) as { messages: Array<Record<string, unknown>> };
+		const assistant = payload.messages.find(m => m.role === "assistant");
+		expect(assistant).toBeDefined();
+		expect(Reflect.get(assistant as object, "reasoning_content")).toBe("Need to read the file before answering.");
+	});
+
+	// #1071 regression guard alongside the #1484 fix: with thinking disabled the
+	// override stays off so the gateway's `Extra inputs are not permitted` error
+	// can never reappear on tool-call replays.
+	it("omits reasoning_content on kimi opencode-go tool-call replays when thinking is disabled", async () => {
+		const model = kimiOpenCodeModel("kimi-k2.6");
+		const priorAssistant: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "text", text: "Let me check." },
+				{
+					type: "toolCall",
+					id: "call_abc123",
+					name: "read",
+					arguments: { path: "README.md" },
+				},
+			],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		global.fetch = createMockFetch(["[DONE]"]);
+		streamOpenAICompletions(
+			model,
+			{
+				messages: [
+					{ role: "user", content: "Summarize the README", timestamp: Date.now() },
+					priorAssistant,
+					{
+						role: "toolResult",
+						toolCallId: "call_abc123",
+						toolName: "read",
+						content: [{ type: "text", text: "# Hello\n" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{
+				apiKey: "test-key",
+				signal: createAbortedSignal(),
+				onPayload: payload => resolve(payload),
+			},
+		);
+
+		const payload = (await promise) as { messages: Array<Record<string, unknown>> };
+		const assistant = payload.messages.find(m => m.role === "assistant");
+		expect(assistant).toBeDefined();
+		expect(Reflect.get(assistant as object, "reasoning_content")).toBeUndefined();
+		expect(Reflect.get(assistant as object, "reasoning")).toBeUndefined();
+		expect(Reflect.get(assistant as object, "reasoning_text")).toBeUndefined();
+	});
+
 	it("injects reasoning_content placeholder when kimi-on-moonshot has tool calls without reasoning field", () => {
 		const model = kimiMoonshotModel("kimi-k2.5");
 		const compat = detectCompat(model);

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -937,9 +937,7 @@ describe("kimi model detection via detectCompat", () => {
 		const payload = (await promise) as { messages: Array<Record<string, unknown>> };
 		const assistant = payload.messages.find(m => m.role === "assistant");
 		expect(assistant).toBeDefined();
-		expect(Reflect.get(assistant as object, "reasoning_content")).toBe(
-			"Need to read the file before answering.",
-		);
+		expect(Reflect.get(assistant as object, "reasoning_content")).toBe("Need to read the file before answering.");
 		// DeepSeek's allowsSynthetic=false must keep the stale `reasoning` key
 		// off the wire body so opencode's schema validation does not flag it.
 		expect(Reflect.get(assistant as object, "reasoning")).toBeUndefined();

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -656,7 +656,10 @@ describe("kimi model detection via detectCompat", () => {
 				{
 					type: "thinking",
 					thinking: "Need to read the file before answering.",
-					thinkingSignature: "reasoning_content",
+					// OpenCode Kimi streams reasoning under the `reasoning` field
+					// name; the override must coerce it into `reasoning_content`
+					// when replaying tool-call history.
+					thinkingSignature: "reasoning",
 				},
 				{
 					type: "toolCall",
@@ -710,6 +713,9 @@ describe("kimi model detection via detectCompat", () => {
 		const assistant = payload.messages.find(m => m.role === "assistant");
 		expect(assistant).toBeDefined();
 		expect(Reflect.get(assistant as object, "reasoning_content")).toBe("Need to read the file before answering.");
+		// The streamed `reasoning` key must NOT land in the wire body alongside
+		// `reasoning_content`; opencode's strict schema rejects unknown fields.
+		expect(Reflect.get(assistant as object, "reasoning")).toBeUndefined();
 	});
 
 	// #1071 regression guard alongside the #1484 fix: with thinking disabled the

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -862,6 +862,89 @@ describe("kimi model detection via detectCompat", () => {
 		expect(payload.reasoning_effort).toBeUndefined();
 	});
 
+	// #1484 follow-up: DeepSeek V4 on opencode-go exhibits the same gateway
+	// invariant as Kimi (same Zen gateway). DeepSeek emits reasoning under the
+	// `reasoning` signature, so the pre-fix code wrote both `reasoning` and
+	// `reasoning_content` to the wire body. The line-1488 fix in convertMessages
+	// now coerces the replay onto `reasoningContentField` whenever
+	// `allowsSyntheticReasoningContentForToolCalls=false`, so DeepSeek V4
+	// payloads carry only `reasoning_content`.
+	it("emits only reasoning_content on deepseek-v4-flash opencode-go tool-call replays", async () => {
+		const model: Model<"openai-completions"> = {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+			provider: "opencode-go",
+			baseUrl: "https://opencode.ai/zen/go/v1",
+			id: "deepseek-v4-flash",
+			reasoning: true,
+		};
+		const priorAssistant: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{
+					type: "thinking",
+					thinking: "Need to read the file before answering.",
+					thinkingSignature: "reasoning",
+				},
+				{
+					type: "toolCall",
+					id: "call_abc123",
+					name: "read",
+					arguments: { path: "README.md" },
+				},
+			],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		global.fetch = createMockFetch(["[DONE]"]);
+		streamOpenAICompletions(
+			model,
+			{
+				messages: [
+					{ role: "user", content: "Summarize the README", timestamp: Date.now() },
+					priorAssistant,
+					{
+						role: "toolResult",
+						toolCallId: "call_abc123",
+						toolName: "read",
+						content: [{ type: "text", text: "# Hello\n" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{
+				apiKey: "test-key",
+				reasoning: "high",
+				signal: createAbortedSignal(),
+				onPayload: payload => resolve(payload),
+			},
+		);
+
+		const payload = (await promise) as { messages: Array<Record<string, unknown>> };
+		const assistant = payload.messages.find(m => m.role === "assistant");
+		expect(assistant).toBeDefined();
+		expect(Reflect.get(assistant as object, "reasoning_content")).toBe(
+			"Need to read the file before answering.",
+		);
+		// DeepSeek's allowsSynthetic=false must keep the stale `reasoning` key
+		// off the wire body so opencode's schema validation does not flag it.
+		expect(Reflect.get(assistant as object, "reasoning")).toBeUndefined();
+	});
+
 	it("injects reasoning_content placeholder when kimi-on-moonshot has tool calls without reasoning field", () => {
 		const model = kimiMoonshotModel("kimi-k2.5");
 		const compat = detectCompat(model);

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -943,6 +943,97 @@ describe("kimi model detection via detectCompat", () => {
 		expect(Reflect.get(assistant as object, "reasoning")).toBeUndefined();
 	});
 
+	// #1484 follow-up: the Zen gateway invariant applies to every opencode-go
+	// model (GLM, Qwen, MiMo, MiniMax, Kimi, DeepSeek). Verify a non-Kimi
+	// non-DeepSeek opencode model also replays reasoning_content when thinking
+	// is enabled, and stays silent when thinking is disabled.
+	it.each([
+		{ id: "glm-5.1", reasoning: "high" as const, expectReplay: true },
+		{ id: "glm-5.1", reasoning: undefined, expectReplay: false },
+		{ id: "qwen3.7-max", reasoning: "high" as const, expectReplay: true },
+		{ id: "mimo-v2-pro", reasoning: "high" as const, expectReplay: true },
+	])(
+		"opencode-go/%s reasoning=%s → replay=%s",
+		async ({ id, reasoning, expectReplay }) => {
+			const model: Model<"openai-completions"> = {
+				...getBundledModel("openai", "gpt-4o-mini"),
+				api: "openai-completions",
+				provider: "opencode-go",
+				baseUrl: "https://opencode.ai/zen/go/v1",
+				id,
+				reasoning: true,
+			};
+			const priorAssistant: AssistantMessage = {
+				role: "assistant",
+				content: [
+					{
+						type: "thinking",
+						thinking: "Plan before acting.",
+						thinkingSignature: "reasoning",
+					},
+					{
+						type: "toolCall",
+						id: "call_abc123",
+						name: "read",
+						arguments: { path: "README.md" },
+					},
+				],
+				api: model.api,
+				provider: model.provider,
+				model: model.id,
+				usage: {
+					input: 0,
+					output: 0,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 0,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				stopReason: "toolUse",
+				timestamp: Date.now(),
+			};
+
+			const { promise, resolve } = Promise.withResolvers<unknown>();
+			global.fetch = createMockFetch(["[DONE]"]);
+			streamOpenAICompletions(
+				model,
+				{
+					messages: [
+						{ role: "user", content: "Summarize the README", timestamp: Date.now() },
+						priorAssistant,
+						{
+							role: "toolResult",
+							toolCallId: "call_abc123",
+							toolName: "read",
+							content: [{ type: "text", text: "# Hello\n" }],
+							isError: false,
+							timestamp: Date.now(),
+						},
+					],
+				},
+				{
+					apiKey: "test-key",
+					reasoning,
+					signal: createAbortedSignal(),
+					onPayload: payload => resolve(payload),
+				},
+			);
+
+			const payload = (await promise) as { messages: Array<Record<string, unknown>> };
+			const assistant = payload.messages.find(m => m.role === "assistant");
+			expect(assistant).toBeDefined();
+			if (expectReplay) {
+				expect(Reflect.get(assistant as object, "reasoning_content")).toBe("Plan before acting.");
+				// The stale streamed `reasoning` key must never land in the wire body.
+				expect(Reflect.get(assistant as object, "reasoning")).toBeUndefined();
+			} else {
+				expect(Reflect.get(assistant as object, "reasoning_content")).toBeUndefined();
+				expect(Reflect.get(assistant as object, "reasoning")).toBeUndefined();
+				expect(Reflect.get(assistant as object, "reasoning_text")).toBeUndefined();
+			}
+		},
+	);
+
 	it("injects reasoning_content placeholder when kimi-on-moonshot has tool calls without reasoning field", () => {
 		const model = kimiMoonshotModel("kimi-k2.5");
 		const compat = detectCompat(model);

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -776,6 +776,86 @@ describe("kimi model detection via detectCompat", () => {
 		expect(Reflect.get(assistant as object, "reasoning_text")).toBeUndefined();
 	});
 
+	// #1485 review: `disableReasoningOnForcedToolChoice` strips thinking from
+	// the wire body for Kimi when `toolChoice` is forced, so the per-request
+	// reasoning_content override must back off on the same path or the
+	// thinking-disabled payload reintroduces the #1071 `Extra inputs are not
+	// permitted` failure.
+	it("omits reasoning_content on kimi opencode-go forced-tool turns even when reasoning is requested", async () => {
+		const model = kimiOpenCodeModel("kimi-k2.6");
+		const priorAssistant: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{
+					type: "thinking",
+					thinking: "Plan first, then call the tool.",
+					thinkingSignature: "reasoning_content",
+				},
+				{
+					type: "toolCall",
+					id: "call_abc123",
+					name: "read",
+					arguments: { path: "README.md" },
+				},
+			],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		global.fetch = createMockFetch(["[DONE]"]);
+		streamOpenAICompletions(
+			model,
+			{
+				messages: [
+					{ role: "user", content: "Summarize the README", timestamp: Date.now() },
+					priorAssistant,
+					{
+						role: "toolResult",
+						toolCallId: "call_abc123",
+						toolName: "read",
+						content: [{ type: "text", text: "# Hello\n" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{
+				apiKey: "test-key",
+				reasoning: "high",
+				// Forced tool choice triggers `disableReasoningOnForcedToolChoice`
+				// for Kimi, suppressing reasoning_effort on the wire body.
+				toolChoice: { type: "tool", name: "read" },
+				signal: createAbortedSignal(),
+				onPayload: payload => resolve(payload),
+			},
+		);
+
+		const payload = (await promise) as {
+			messages: Array<Record<string, unknown>>;
+			reasoning_effort?: unknown;
+		};
+		const assistant = payload.messages.find(m => m.role === "assistant");
+		expect(assistant).toBeDefined();
+		expect(Reflect.get(assistant as object, "reasoning_content")).toBeUndefined();
+		expect(Reflect.get(assistant as object, "reasoning")).toBeUndefined();
+		expect(Reflect.get(assistant as object, "reasoning_text")).toBeUndefined();
+		// The forced-tool guard must still strip the request-level thinking
+		// signal so neither end of the wire mentions reasoning.
+		expect(payload.reasoning_effort).toBeUndefined();
+	});
+
 	it("injects reasoning_content placeholder when kimi-on-moonshot has tool calls without reasoning field", () => {
 		const model = kimiMoonshotModel("kimi-k2.5");
 		const compat = detectCompat(model);


### PR DESCRIPTION
## Repro

Selecting `opencode-go/kimi-k2.6` (or `kimi-k2.5`) with `--thinking` and triggering any tool call (e.g. `read`, `bash`) makes the follow-up request 400 against `https://opencode.ai/zen/go/v1/chat/completions`:

```
{"error":{"message":"thinking is enabled but reasoning_content is missing in assistant tool call message at index 3","type":"invalid_request_error"}}
```

A focused regression test (`packages/ai/test/openai-completions-compat.test.ts`) drives `streamOpenAICompletions` for `opencode-go/kimi-k2.6` with `options.reasoning: "high"` and a prior `thinking + toolCall` assistant turn, captures the wire payload via `onPayload`, and confirms the assistant message that replays the tool call carries no `reasoning_content`.

## Cause

`detectOpenAICompat` in `packages/ai/src/providers/openai-completions-compat.ts` gates `requiresReasoningContentForToolCalls` for Kimi behind `!isOpenCodeProvider` (PR #1071) to dodge the older OpenCode `Extra inputs are not permitted` error that fires when the gateway sees `reasoning_content` while thinking is off. The Zen gateway has since started enforcing the opposite invariant whenever `thinking` is enabled in the request, so both invariants are now real — gated on the per-request thinking state, which the static compat object cannot observe.

Because `buildParams` never reactivates the flag, the entire `reasoning_content` injection pipeline in `convertMessages` (`packages/ai/src/providers/openai-completions.ts:1467+`) skips opencode Kimi turns, and prior `thinking` blocks are dropped from the wire body even when thinking is engaged.

## Fix

- `packages/ai/src/providers/openai-completions.ts:buildParams` now recomputes the Kimi-on-OpenCode case after `getCompat` and flips `compat.requiresReasoningContentForToolCalls = true` iff this request is in thinking mode (`options.reasoning` set, `!options.disableReasoning`, `model.reasoning` true). The compat object is fresh per call (`resolveOpenAICompat` always returns a new object), so the mutation is request-scoped and cannot leak. Thinking-disabled turns keep the static default and preserve the #1071 guard.
- Folded the local `isKimi` alias into the new `isKimiModelId` to keep the family check single-sourced.
- Added two regression tests in `packages/ai/test/openai-completions-compat.test.ts` that drive `streamOpenAICompletions` end-to-end and assert on the wire payload via `onPayload`:
  - thinking enabled → assistant tool-call replay carries `reasoning_content` with the prior thinking text;
  - thinking disabled → no `reasoning_content` / `reasoning` / `reasoning_text` fields appear (matches #1071's contract).
- `packages/ai/CHANGELOG.md` — `[Unreleased] > Fixed` entry citing both #1484 and the #1071 invariant.

## Verification

- `bun --cwd=packages/ai test test/openai-completions-compat.test.ts` → 38 pass / 0 fail.
- `bun --cwd=packages/ai test` → 1330 pass / 337 skip / 0 fail across 161 files; no regressions.
- `bun check` ran clean via the pre-publish gate before push.

Fixes #1484