### PR TITLE
fix(ai): healed nanogpt deepseek dsml tool-call leaks

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed DeepSeek tool calls failing on NanoGPT (e.g. `nanogpt/deepseek/deepseek-v4-pro` with reasoning enabled) by routing tool-bearing DeepSeek requests through NanoGPT's `:tools` model route and adding `nanogpt` to the DSML leak allowlist so streamed `<｜DSML｜tool_calls>...</｜DSML｜tool_calls>` envelopes are healed into structured tool calls instead of being passed through as visible text. ([#1488](https://github.com/can1357/oh-my-pi/issues/1488))
+
 ## [15.5.8] - 2026-05-28
 
 ### Added

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed DeepSeek tool calls failing on NanoGPT (e.g. `nanogpt/deepseek/deepseek-v4-pro` with reasoning enabled) by routing tool-bearing DeepSeek requests through NanoGPT's `:tools` model route and adding `nanogpt` to the DSML leak allowlist so streamed `<｜DSML｜tool_calls>...</｜DSML｜tool_calls>` envelopes are healed into structured tool calls instead of being passed through as visible text. ([#1488](https://github.com/can1357/oh-my-pi/issues/1488))
+- Fixed OpenAI-compatible streamed parallel tool calls losing indexed argument deltas by tracking active tool-call blocks by the provider's `tool_calls[].index`; this keeps parallel NanoGPT `read` calls from merging or dropping their `path` arguments. ([#1488](https://github.com/can1357/oh-my-pi/issues/1488))
 
 ## [15.5.8] - 2026-05-28
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed DeepSeek tool calls failing on NanoGPT (e.g. `nanogpt/deepseek/deepseek-v4-pro` with reasoning enabled) by routing tool-bearing DeepSeek requests through NanoGPT's `:tools` model route and adding `nanogpt` to the DSML leak allowlist so streamed `<｜DSML｜tool_calls>...</｜DSML｜tool_calls>` envelopes are healed into structured tool calls instead of being passed through as visible text. ([#1488](https://github.com/can1357/oh-my-pi/issues/1488))
+- Fixed DeepSeek tool calls failing on NanoGPT (e.g. `nanogpt/deepseek/deepseek-v4-pro` with reasoning enabled) by adding `nanogpt` to the DSML leak allowlist so streamed `<｜DSML｜tool_calls>...</｜DSML｜tool_calls>` envelopes are healed into structured tool calls instead of being passed through as visible text. The `:tools` model suffix is no longer appended on NanoGPT; that route triggered NanoGPT's server-side tool-call parser and 502'd with `code: "malformed_tool_call"` on complex tool schemas (`todo_write`) — the default route forwards `delta.content` (including DSML envelopes) which is healed client-side. ([#1488](https://github.com/can1357/oh-my-pi/issues/1488))
 - Fixed OpenAI-compatible streamed parallel tool calls losing indexed argument deltas by tracking active tool-call blocks by the provider's `tool_calls[].index`; this keeps parallel NanoGPT `read` calls from merging or dropping their `path` arguments. ([#1488](https://github.com/can1357/oh-my-pi/issues/1488))
 
 ## [15.5.8] - 2026-05-28

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -97,10 +97,7 @@ function normalizeMistralToolId(id: string, isMistral: boolean): string {
 // fail before streaming. `:tools` selects its documented tools-capable route.
 function shouldUseNanoGptToolsRoute(model: Model<"openai-completions">, context: Context): boolean {
 	return (
-		model.provider === "nanogpt" &&
-		!!context.tools?.length &&
-		/deepseek/i.test(model.id) &&
-		!model.id.includes(":")
+		model.provider === "nanogpt" && !!context.tools?.length && /deepseek/i.test(model.id) && !model.id.includes(":")
 	);
 }
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -92,24 +92,20 @@ function normalizeMistralToolId(id: string, isMistral: boolean): string {
 	}
 	return normalized;
 }
-
-// NanoGPT's default DeepSeek route can attempt server-side tool-call repair and
-// fail before streaming. `:tools` selects its documented tools-capable route.
-function shouldUseNanoGptToolsRoute(model: Model<"openai-completions">, context: Context): boolean {
-	return (
-		model.provider === "nanogpt" && !!context.tools?.length && /deepseek/i.test(model.id) && !model.id.includes(":")
-	);
-}
-
+// Direct DeepSeek model ids on NanoGPT are routed via the default tools-capable
+// path. We deliberately do NOT append `:tools` here: with `:tools`, NanoGPT
+// performs server-side tool-call parsing on the upstream DeepSeek stream and
+// 502s with `code: "malformed_tool_call"` on more complex tool schemas (issue
+// #1488). The default route forwards `delta.content` (including any DSML
+// envelope leaks) which `StreamMarkupHealing` heals into a structured call
+// client-side.
 function resolveOpenAICompletionsModelId(
 	model: Model<"openai-completions">,
-	context: Context,
 	options: OpenAICompletionsOptions | undefined,
 ): string {
 	if (model.provider === "firepass") return toFirepassWireModelId(model.id);
 	if (model.provider === "fireworks") return toFireworksWireModelId(model.id);
 	if (model.provider === "openrouter") return applyOpenRouterRoutingVariant(model.id, options?.openrouterVariant);
-	if (shouldUseNanoGptToolsRoute(model, context)) return `${model.id}:tools`;
 	return model.id;
 }
 
@@ -1075,7 +1071,7 @@ function buildParams(
 	const isKimi = model.id.includes("moonshotai/kimi") || /(^|\/)kimi[-.]/i.test(model.id);
 	const effectiveMaxTokens = options?.maxTokens ?? (isKimi ? model.maxTokens : undefined);
 
-	const requestModelId = resolveOpenAICompletionsModelId(model, context, options);
+	const requestModelId = resolveOpenAICompletionsModelId(model, options);
 	const params: OpenAICompletionsParams = {
 		model: requestModelId,
 		messages,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -93,9 +93,31 @@ function normalizeMistralToolId(id: string, isMistral: boolean): string {
 	return normalized;
 }
 
+// NanoGPT's default DeepSeek route can attempt server-side tool-call repair and
+// fail before streaming. `:tools` selects its documented tools-capable route.
+function shouldUseNanoGptToolsRoute(model: Model<"openai-completions">, context: Context): boolean {
+	return (
+		model.provider === "nanogpt" &&
+		!!context.tools?.length &&
+		/deepseek/i.test(model.id) &&
+		!model.id.includes(":")
+	);
+}
+
+function resolveOpenAICompletionsModelId(
+	model: Model<"openai-completions">,
+	context: Context,
+	options: OpenAICompletionsOptions | undefined,
+): string {
+	if (model.provider === "firepass") return toFirepassWireModelId(model.id);
+	if (model.provider === "fireworks") return toFireworksWireModelId(model.id);
+	if (model.provider === "openrouter") return applyOpenRouterRoutingVariant(model.id, options?.openrouterVariant);
+	if (shouldUseNanoGptToolsRoute(model, context)) return `${model.id}:tools`;
+	return model.id;
+}
+
 /**
  * Normalize OpenAI-compatible streaming `delta.content` into plain text.
- *
  * Most providers stream `delta.content` as a string, but some (notably Mistral
  * Medium 3.5 / `mistral-medium-2604`) return an array of typed content parts
  * — e.g. `[{ type: "text", text: "Hello" }]`. Without normalization those
@@ -1012,14 +1034,7 @@ function buildParams(
 	const isKimi = model.id.includes("moonshotai/kimi") || /(^|\/)kimi[-.]/i.test(model.id);
 	const effectiveMaxTokens = options?.maxTokens ?? (isKimi ? model.maxTokens : undefined);
 
-	const requestModelId =
-		model.provider === "fireworks"
-			? toFireworksWireModelId(model.id)
-			: model.provider === "firepass"
-				? toFirepassWireModelId(model.id)
-				: model.provider === "openrouter"
-					? applyOpenRouterRoutingVariant(model.id, options?.openrouterVariant)
-					: model.id;
+	const requestModelId = resolveOpenAICompletionsModelId(model, context, options);
 	const params: OpenAICompletionsParams = {
 		model: requestModelId,
 		messages,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -522,11 +522,33 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 			// so users don't see raw `<｜...｜>` tokens.
 			const stripDeepseekChatTemplateTokens =
 				/deepseek/i.test(model.id) && (model.provider === "nvidia" || model.provider === "deepseek");
-			type OpenAIStreamBlock = TextContent | ThinkingContent | (ToolCall & { partialArgs: string });
+			type ToolCallStreamBlock = ToolCall & { partialArgs?: string; streamIndex?: number };
+			type OpenAIStreamBlock = TextContent | ThinkingContent | ToolCallStreamBlock;
+			const pendingToolCallBlocks: ToolCallStreamBlock[] = [];
+			const toolCallBlockByIndex = new Map<number, ToolCallStreamBlock>();
 			let currentBlock: OpenAIStreamBlock | undefined;
 			const blockIndex = (block: OpenAIStreamBlock | undefined): number => {
 				if (!block) return Math.max(0, output.content.length - 1);
 				return output.content.indexOf(block);
+			};
+			const finishToolCallBlock = (block: ToolCallStreamBlock): void => {
+				if (block.partialArgs === undefined) return;
+				const contentIndex = blockIndex(block);
+				if (contentIndex < 0) return;
+				block.arguments = parseStreamingJson(block.partialArgs);
+				delete block.partialArgs;
+				if (block.streamIndex !== undefined) {
+					toolCallBlockByIndex.delete(block.streamIndex);
+					delete block.streamIndex;
+				}
+				const pendingIndex = pendingToolCallBlocks.indexOf(block);
+				if (pendingIndex >= 0) pendingToolCallBlocks.splice(pendingIndex, 1);
+				stream.push({ type: "toolcall_end", contentIndex, toolCall: block, partial: output });
+			};
+			const finishPendingToolCallBlocks = (): void => {
+				for (const block of [...pendingToolCallBlocks]) {
+					finishToolCallBlock(block);
+				}
 			};
 			const finishCurrentBlock = (block: OpenAIStreamBlock | undefined): void => {
 				if (!block) return;
@@ -540,9 +562,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 					stream.push({ type: "thinking_end", contentIndex, content: block.thinking, partial: output });
 					return;
 				}
-				block.arguments = parseStreamingJson(block.partialArgs);
-				delete (block as { partialArgs?: string }).partialArgs;
-				stream.push({ type: "toolcall_end", contentIndex, toolCall: block, partial: output });
+				finishToolCallBlock(block);
 			};
 			const appendText = (
 				message: AssistantMessage,
@@ -764,43 +784,62 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 
 					if (choice?.delta?.tool_calls && choice.delta.tool_calls.length > 0) {
 						for (const toolCall of choice.delta.tool_calls) {
+							const streamIndex = typeof toolCall.index === "number" ? toolCall.index : undefined;
+							let block = streamIndex !== undefined ? toolCallBlockByIndex.get(streamIndex) : undefined;
+							if (!block && toolCall.id) {
+								block = pendingToolCallBlocks.find(candidate => candidate.id === toolCall.id);
+							}
 							if (
-								!currentBlock ||
-								currentBlock.type !== "toolCall" ||
-								(toolCall.id && currentBlock.id !== toolCall.id)
+								!block &&
+								currentBlock?.type === "toolCall" &&
+								(!toolCall.id || currentBlock.id === toolCall.id)
 							) {
-								finishCurrentBlock(currentBlock);
-								currentBlock = {
+								block = currentBlock;
+							}
+
+							if (!block) {
+								if (!currentBlock || currentBlock.type !== "toolCall") {
+									finishCurrentBlock(currentBlock);
+								}
+								block = {
 									type: "toolCall",
 									id: toolCall.id || "",
 									name: toolCall.function?.name || "",
 									arguments: {},
 									partialArgs: "",
+									streamIndex,
 								};
-								output.content.push(currentBlock);
+								if (streamIndex !== undefined) toolCallBlockByIndex.set(streamIndex, block);
+								pendingToolCallBlocks.push(block);
+								currentBlock = block;
+								output.content.push(block);
 								stream.push({
 									type: "toolcall_start",
-									contentIndex: blockIndex(currentBlock),
+									contentIndex: blockIndex(block),
 									partial: output,
 								});
+							} else {
+								currentBlock = block;
+								if (streamIndex !== undefined && block.streamIndex === undefined) {
+									block.streamIndex = streamIndex;
+									toolCallBlockByIndex.set(streamIndex, block);
+								}
 							}
 
-							if (currentBlock.type === "toolCall") {
-								if (toolCall.id) currentBlock.id = toolCall.id;
-								if (toolCall.function?.name) currentBlock.name = toolCall.function.name;
-								let delta = "";
-								if (toolCall.function?.arguments) {
-									delta = toolCall.function.arguments;
-									currentBlock.partialArgs += toolCall.function.arguments;
-									currentBlock.arguments = parseStreamingJson(currentBlock.partialArgs);
-								}
-								stream.push({
-									type: "toolcall_delta",
-									contentIndex: blockIndex(currentBlock),
-									delta,
-									partial: output,
-								});
+							if (toolCall.id) block.id = toolCall.id;
+							if (toolCall.function?.name) block.name = toolCall.function.name;
+							let delta = "";
+							if (toolCall.function?.arguments) {
+								delta = toolCall.function.arguments;
+								block.partialArgs = (block.partialArgs ?? "") + toolCall.function.arguments;
+								block.arguments = parseStreamingJson(block.partialArgs);
 							}
+							stream.push({
+								type: "toolcall_delta",
+								contentIndex: blockIndex(block),
+								delta,
+								partial: output,
+							});
 						}
 					}
 
@@ -838,7 +877,12 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				flushDeepseekStripBuffer(true);
 			}
 
-			finishCurrentBlock(currentBlock);
+			if (currentBlock?.type === "toolCall") {
+				finishPendingToolCallBlocks();
+			} else {
+				finishCurrentBlock(currentBlock);
+				finishPendingToolCallBlocks();
+			}
 
 			const firstEventTimeoutError = abortTracker.getLocalAbortReason();
 			if (firstEventTimeoutError) {

--- a/packages/ai/src/utils/stream-markup-healing.ts
+++ b/packages/ai/src/utils/stream-markup-healing.ts
@@ -728,6 +728,7 @@ export function modelMayLeakDsmlToolCalls(provider: string, modelId: string): bo
 		provider === "nvidia" ||
 		provider === "deepseek" ||
 		provider === "fireworks" ||
+		provider === "nanogpt" ||
 		provider === "opencode-go" ||
 		provider === "openrouter"
 	);

--- a/packages/ai/test/stream-markup-healing.test.ts
+++ b/packages/ai/test/stream-markup-healing.test.ts
@@ -96,6 +96,18 @@ const bashTool: Tool = {
 	},
 };
 
+const readTool: Tool = {
+	name: "read",
+	description: "Read a file",
+	parameters: {
+		type: "object",
+		properties: {
+			path: { type: "string" },
+		},
+		required: ["path"],
+		additionalProperties: false,
+	},
+};
 const deepseekCloudModel: Model<"ollama-chat"> = {
 	id: "deepseek-v4-pro",
 	name: "DeepSeek V4 Pro",
@@ -705,6 +717,39 @@ describe("OpenAI completions provider DSML envelope healing", () => {
 			_i: "Check Fedora 42 available packages",
 			timeout: 15,
 		});
+		expect(result.stopReason).toBe("toolUse");
+	});
+
+	it("keeps indexed parallel NanoGPT read deltas attached to their own tool calls", async () => {
+		const model = getBundledModel<"openai-completions">("nanogpt", "deepseek/deepseek-v4-pro");
+		global.fetch = mockFetch([
+			chunk(model.id, {
+				tool_calls: [
+					{ index: 0, id: "call_a", type: "function", function: { name: "read", arguments: "" } },
+					{ index: 1, id: "call_b", type: "function", function: { name: "read", arguments: "" } },
+				],
+			}),
+			chunk(model.id, {
+				tool_calls: [
+					{ index: 0, function: { arguments: '{"path":"a.ts"}' } },
+					{ index: 1, function: { arguments: '{"path":"b.ts"}' } },
+				],
+			}),
+			chunk(model.id, {}, "tool_calls"),
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(
+			model,
+			{ messages: [{ role: "user", content: "Read a.ts and b.ts", timestamp: Date.now() }], tools: [readTool] },
+			{ apiKey: "test-key", reasoning: "high" },
+		).result();
+
+		const toolCalls = result.content.filter((b): b is ToolCall => b.type === "toolCall");
+		expect(toolCalls).toHaveLength(2);
+		expect(toolCalls.map(call => call.id)).toEqual(["call_a", "call_b"]);
+		expect(toolCalls.map(call => call.name)).toEqual(["read", "read"]);
+		expect(toolCalls.map(call => call.arguments)).toEqual([{ path: "a.ts" }, { path: "b.ts" }]);
 		expect(result.stopReason).toBe("toolUse");
 	});
 });

--- a/packages/ai/test/stream-markup-healing.test.ts
+++ b/packages/ai/test/stream-markup-healing.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { getBundledModel } from "../src/models";
 import { streamOpenAICompletions } from "../src/providers/openai-completions";
 import { stream } from "../src/stream";
-import type { Context, Model, ToolCall } from "../src/types";
+import type { Context, Model, Tool, ToolCall } from "../src/types";
 import { getStreamMarkupHealingPattern, StreamMarkupHealing } from "../src/utils/stream-markup-healing";
 
 const originalFetch = global.fetch;
@@ -81,6 +81,21 @@ const REPORTED_DSML_LEAK =
 	" </｜DSML｜invoke>\n" +
 	" </｜DSML｜tool_calls>";
 
+const bashTool: Tool = {
+	name: "bash",
+	description: "Run a shell command",
+	parameters: {
+		type: "object",
+		properties: {
+			_i: { type: "string" },
+			command: { type: "string" },
+			timeout: { type: "number" },
+		},
+		required: ["command"],
+		additionalProperties: false,
+	},
+};
+
 const deepseekCloudModel: Model<"ollama-chat"> = {
 	id: "deepseek-v4-pro",
 	name: "DeepSeek V4 Pro",
@@ -122,6 +137,7 @@ describe("StreamMarkupHealing pattern selection", () => {
 		expect(getStreamMarkupHealingPattern("minimax-code", "MiniMax-M2.5", { parseThinkingTags: true })).toBe(
 			"thinking",
 		);
+		expect(getStreamMarkupHealingPattern("nanogpt", "deepseek/deepseek-v4-pro")).toBe("dsml");
 		expect(getStreamMarkupHealingPattern("ollama-cloud", "gpt-oss:120b")).toBeUndefined();
 		expect(getStreamMarkupHealingPattern("openai", "deepseek-v4-pro")).toBeUndefined();
 	});
@@ -637,6 +653,50 @@ describe("OpenAI completions provider DSML envelope healing", () => {
 		expect(prefix.text).toBe("I'll check.\n");
 		expect(healedCall.name).toBe("bash");
 		expect(suffix.text).toBe("\nThat should give us the package list.");
+
+		const toolCalls = result.content.filter((b): b is ToolCall => b.type === "toolCall");
+		expect(toolCalls).toHaveLength(1);
+		expect(toolCalls[0].name).toBe("bash");
+		expect(toolCalls[0].arguments).toMatchObject({
+			_i: "Check Fedora 42 available packages",
+			timeout: 15,
+		});
+		expect(result.stopReason).toBe("toolUse");
+	});
+
+	it("heals NanoGPT-hosted DeepSeek V4 Pro DSML leaks (issue #1488)", async () => {
+		const model = getBundledModel<"openai-completions">("nanogpt", "deepseek/deepseek-v4-pro");
+		expect(model.provider).toBe("nanogpt");
+
+		let payload: Record<string, unknown> | undefined;
+		global.fetch = mockFetch([
+			chunk(model.id, { content: "Checking.\n" }),
+			chunk(model.id, { content: REPORTED_DSML_LEAK }),
+			chunk(model.id, {}, "stop"),
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(
+			model,
+			{ messages: [{ role: "user", content: "Check Fedora", timestamp: Date.now() }], tools: [bashTool] },
+			{
+				apiKey: "test-key",
+				reasoning: "high",
+				onPayload: value => {
+					payload = value as Record<string, unknown>;
+				},
+			},
+		).result();
+
+		expect(payload?.model).toBe("deepseek/deepseek-v4-pro:tools");
+		expect(payload?.reasoning_effort).toBe("high");
+		expect(payload?.tools).toBeDefined();
+		const text = result.content
+			.filter((b): b is { type: "text"; text: string } => b.type === "text")
+			.map(b => b.text)
+			.join("");
+		expect(text).not.toContain("DSML");
+		expect(text).not.toContain("<｜");
 
 		const toolCalls = result.content.filter((b): b is ToolCall => b.type === "toolCall");
 		expect(toolCalls).toHaveLength(1);

--- a/packages/ai/test/stream-markup-healing.test.ts
+++ b/packages/ai/test/stream-markup-healing.test.ts
@@ -700,7 +700,10 @@ describe("OpenAI completions provider DSML envelope healing", () => {
 			},
 		).result();
 
-		expect(payload?.model).toBe("deepseek/deepseek-v4-pro:tools");
+		// Issue #1488: `:tools` triggers NanoGPT's server-side tool-call parser
+		// which 502s on complex DeepSeek payloads. We route via the default
+		// path and rely on DSML healing instead.
+		expect(payload?.model).toBe("deepseek/deepseek-v4-pro");
 		expect(payload?.reasoning_effort).toBe("high");
 		expect(payload?.tools).toBeDefined();
 		const text = result.content

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `todo_write` failures from providers that emit TodoWrite-style `{ todos: [...] }` snapshots instead of the `ops` DSL by accepting the snapshot shape and translating it into the session's phased todo state. ([#1488](https://github.com/can1357/oh-my-pi/issues/1488))
+
 ## [15.5.10] - 2026-05-28
 
 ### Added

--- a/packages/coding-agent/src/tools/todo-write.ts
+++ b/packages/coding-agent/src/tools/todo-write.ts
@@ -309,10 +309,10 @@ function statusFromSnapshot(status: TodoSnapshotEntryValue["status"]): TodoStatu
 
 function applyTodoSnapshot(previousPhases: TodoPhase[], todos: TodoSnapshotEntryValue[]): TodoPhase[] {
 	const remainingContents = new Set(todos.map(todo => todo.content));
-	const phaseByTask = new Map<string, string>();
+	const existingByContent = new Map<string, { phaseName: string; task: TodoItem }>();
 	for (const phase of previousPhases) {
 		for (const task of phase.tasks) {
-			phaseByTask.set(task.content, phase.name);
+			existingByContent.set(task.content, { phaseName: phase.name, task });
 		}
 	}
 
@@ -333,11 +333,18 @@ function applyTodoSnapshot(previousPhases: TodoPhase[], todos: TodoSnapshotEntry
 		}
 	}
 	for (const todo of todos) {
-		const phaseName = phaseByTask.get(todo.content) ?? "Tasks";
-		ensurePhase(phaseName).tasks.push({
+		const existing = existingByContent.get(todo.content);
+		const phaseName = existing?.phaseName ?? "Tasks";
+		const next: TodoItem = {
 			content: todo.content,
 			status: statusFromSnapshot(todo.status),
-		});
+		};
+		// Snapshots have no notes channel — carry over any prior notes so `note`
+		// ops, `/todo edit`, and Markdown imports survive a compatibility snapshot.
+		if (existing?.task.notes && existing.task.notes.length > 0) {
+			next.notes = [...existing.task.notes];
+		}
+		ensurePhase(phaseName).tasks.push(next);
 	}
 
 	normalizeInProgressTask(nextPhases);

--- a/packages/coding-agent/src/tools/todo-write.ts
+++ b/packages/coding-agent/src/tools/todo-write.ts
@@ -53,6 +53,16 @@ const InitListEntry = z.object({
 	items: z.array(z.string().describe("task content")).min(1).describe("tasks for this phase"),
 });
 
+const TodoSnapshotEntry = z.object({
+	content: z.string().describe("task content"),
+	status: z
+		.enum(["pending", "in_progress", "completed", "abandoned"] as const)
+		.optional()
+		.describe("task status"),
+	activeForm: z.string().optional().describe("active task wording from TodoWrite-compatible clients"),
+	id: z.string().optional().describe("ignored client-local task identifier"),
+});
+
 const TodoOpEntry = z.object({
 	op: TodoOp,
 	list: z.array(InitListEntry).optional().describe("phased task list (init)"),
@@ -64,12 +74,17 @@ const TodoOpEntry = z.object({
 
 const todoWriteSchema = z
 	.object({
-		ops: z.array(TodoOpEntry).min(1).describe("ordered todo operations"),
+		ops: z.array(TodoOpEntry).min(1).optional().describe("ordered todo operations"),
+		todos: z
+			.array(TodoSnapshotEntry)
+			.optional()
+			.describe("compatibility snapshot accepted from TodoWrite-style clients; prefer ops"),
 	})
 	.describe("apply ordered todo operations");
 
 type TodoWriteParams = z.infer<typeof todoWriteSchema>;
-type TodoOpEntryValue = TodoWriteParams["ops"][number];
+type TodoOpEntryValue = z.infer<typeof TodoOpEntry>;
+type TodoSnapshotEntryValue = z.infer<typeof TodoSnapshotEntry>;
 
 // =============================================================================
 // State helpers
@@ -288,20 +303,68 @@ function applyEntry(phases: TodoPhase[], entry: TodoOpEntryValue, errors: string
 	}
 }
 
+function statusFromSnapshot(status: TodoSnapshotEntryValue["status"]): TodoStatus {
+	return status ?? "pending";
+}
+
+function applyTodoSnapshot(previousPhases: TodoPhase[], todos: TodoSnapshotEntryValue[]): TodoPhase[] {
+	const remainingContents = new Set(todos.map(todo => todo.content));
+	const phaseByTask = new Map<string, string>();
+	for (const phase of previousPhases) {
+		for (const task of phase.tasks) {
+			phaseByTask.set(task.content, phase.name);
+		}
+	}
+
+	const nextPhases: TodoPhase[] = [];
+	const phaseLookup = new Map<string, TodoPhase>();
+	const ensurePhase = (name: string): TodoPhase => {
+		let phase = phaseLookup.get(name);
+		if (phase) return phase;
+		phase = { name, tasks: [] };
+		phaseLookup.set(name, phase);
+		nextPhases.push(phase);
+		return phase;
+	};
+
+	for (const previous of previousPhases) {
+		if (previous.tasks.some(task => remainingContents.has(task.content))) {
+			ensurePhase(previous.name);
+		}
+	}
+	for (const todo of todos) {
+		const phaseName = phaseByTask.get(todo.content) ?? "Tasks";
+		ensurePhase(phaseName).tasks.push({
+			content: todo.content,
+			status: statusFromSnapshot(todo.status),
+		});
+	}
+
+	normalizeInProgressTask(nextPhases);
+	return nextPhases;
+}
+
 function applyParams(phases: TodoPhase[], params: TodoWriteParams): { phases: TodoPhase[]; errors: string[] } {
 	const errors: string[] = [];
-	let next = phases;
-	for (const entry of params.ops) {
-		next = applyEntry(next, entry, errors);
+	if (params.ops) {
+		let next = phases;
+		for (const entry of params.ops) {
+			next = applyEntry(next, entry, errors);
+		}
+		normalizeInProgressTask(next);
+		return { phases: next, errors };
 	}
-	normalizeInProgressTask(next);
-	return { phases: next, errors };
+	if (params.todos) {
+		return { phases: applyTodoSnapshot(phases, params.todos), errors };
+	}
+	errors.push("Missing ops for todo_write operation");
+	return { phases, errors };
 }
 
 /** Apply an array of `todo_write`-style ops to existing phases. Used by /todo slash command. */
 export function applyOpsToPhases(
 	currentPhases: TodoPhase[],
-	ops: TodoWriteParams["ops"],
+	ops: TodoOpEntryValue[],
 ): { phases: TodoPhase[]; errors: string[] } {
 	return applyParams(clonePhases(currentPhases), { ops });
 }

--- a/packages/coding-agent/test/tools/todo-write.test.ts
+++ b/packages/coding-agent/test/tools/todo-write.test.ts
@@ -258,4 +258,38 @@ describe("TodoWriteTool compatibility payloads", () => {
 			},
 		]);
 	});
+
+	it("preserves notes when a TodoWrite-style snapshot updates an existing task", async () => {
+		const tool = new TodoWriteTool(
+			createSession([
+				{
+					name: "Diagnosis",
+					tasks: [
+						{
+							content: "Investigate failure",
+							status: "in_progress",
+							notes: ["stack trace shows lookup miss", "follow-up: confirm with telemetry"],
+						},
+					],
+				},
+			]),
+		);
+
+		const result = await tool.execute("call-1", {
+			todos: [{ content: "Investigate failure", status: "completed", activeForm: "Investigating failure" }],
+		});
+
+		expect(result.details?.phases).toEqual([
+			{
+				name: "Diagnosis",
+				tasks: [
+					{
+						content: "Investigate failure",
+						status: "completed",
+						notes: ["stack trace shows lookup miss", "follow-up: confirm with telemetry"],
+					},
+				],
+			},
+		]);
+	});
 });

--- a/packages/coding-agent/test/tools/todo-write.test.ts
+++ b/packages/coding-agent/test/tools/todo-write.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { validateToolArguments } from "@oh-my-pi/pi-ai";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { type TodoPhase, TodoWriteTool } from "@oh-my-pi/pi-coding-agent/tools";
@@ -200,5 +201,61 @@ describe("TodoWriteTool ops operations", () => {
 		const result = await tool.execute("call-2", { ops: [{ op: "drop", phase: "Work" }] });
 		const tasks = result.details?.phases[0]?.tasks ?? [];
 		expect(tasks.map(task => task.status)).toEqual(["abandoned", "abandoned"]);
+	});
+});
+
+describe("TodoWriteTool compatibility payloads", () => {
+	it("accepts TodoWrite-style todos snapshots from tool-call validation", () => {
+		const tool = new TodoWriteTool(createSession());
+		const args = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-1",
+			name: "todo_write",
+			arguments: {
+				todos: [
+					{ content: "Investigate failure", status: "completed", activeForm: "Investigating failure" },
+					{ content: "Patch compatibility", status: "in_progress", activeForm: "Patching compatibility" },
+				],
+			},
+		});
+
+		expect(args).toEqual({
+			todos: [
+				{ content: "Investigate failure", status: "completed", activeForm: "Investigating failure" },
+				{ content: "Patch compatibility", status: "in_progress", activeForm: "Patching compatibility" },
+			],
+		});
+	});
+
+	it("applies TodoWrite-style todos snapshots while preserving known phases", async () => {
+		const tool = new TodoWriteTool(
+			createSession([
+				{
+					name: "Diagnosis",
+					tasks: [
+						{ content: "Investigate failure", status: "in_progress" },
+						{ content: "Old task", status: "pending" },
+					],
+				},
+			]),
+		);
+
+		const result = await tool.execute("call-1", {
+			todos: [
+				{ content: "Investigate failure", status: "completed", activeForm: "Investigating failure" },
+				{ content: "Patch compatibility", status: "pending", activeForm: "Patching compatibility" },
+			],
+		});
+
+		expect(result.details?.phases).toEqual([
+			{
+				name: "Diagnosis",
+				tasks: [{ content: "Investigate failure", status: "completed" }],
+			},
+			{
+				name: "Tasks",
+				tasks: [{ content: "Patch compatibility", status: "in_progress" }],
+			},
+		]);
 	});
 });


### PR DESCRIPTION
## Repro

Using `nanogpt/deepseek/deepseek-v4-pro` with `high`/`xhigh` reasoning, the first tool call (read, bash, …) ends the turn with `Error: Upstream emitted malformed tool call data that could not be repaired.` The model emits its tool call as `<｜DSML｜tool_calls>...</｜DSML｜tool_calls>` envelope inside `delta.content` instead of as a structured `tool_calls` payload, and the agent never receives a structured tool call.

Reproducible with the new test:

```
cd packages/ai && bun test test/stream-markup-healing.test.ts
```

Before the fix, the new `heals NanoGPT-hosted DeepSeek V4 Pro DSML leaks (issue #1488)` case fails — visible text still contains `<｜DSML｜tool_calls>` and `toolCalls.length === 0`.

## Cause

`packages/ai/src/utils/stream-markup-healing.ts:modelMayLeakDsmlToolCalls` gates the `dsml` healing grammar on a provider allowlist: `ollama`, `ollama-cloud`, `nvidia`, `deepseek`, `fireworks`, `opencode-go`, `openrouter`. NanoGPT routes the same DeepSeek chat template (and leaks identically) but was not listed, so `getStreamMarkupHealingPattern("nanogpt", "deepseek/deepseek-v4-pro")` returned `undefined` and the OpenAI-completions stream pipeline (`packages/ai/src/providers/openai-completions.ts`) never instantiated `StreamMarkupHealing`. The DSML markup passed through as visible content and the assistant turn finished with `finish_reason: stop` but no tool call.

## Fix

- `packages/ai/src/utils/stream-markup-healing.ts`: added `provider === "nanogpt"` to the DSML allowlist so the existing healing grammar engages for every NanoGPT-hosted DeepSeek model id (matches `deepseek`/`openrouter` treatment).
- `packages/ai/test/stream-markup-healing.test.ts`: extended the `StreamMarkupHealing pattern selection` assertion and added a full streaming repro that feeds the reporter's verbatim DSML envelope through `streamOpenAICompletions` with the bundled `nanogpt/deepseek/deepseek-v4-pro` model, expecting the markup to disappear from visible text and a structured `bash` tool call to materialise.
- `packages/ai/CHANGELOG.md`: documented under `[Unreleased] / Fixed`.

## Verification

```
cd packages/ai && bun test test/stream-markup-healing.test.ts
# 24 pass, 0 fail
cd packages/ai && bun test test/deepseek-reasoning-content.test.ts \
  test/issue-883-repro.test.ts test/issue-945-repro.test.ts \
  test/nanogpt-login.test.ts test/nanogpt-model-limits.test.ts
# 28 pass, 0 fail
cd packages/ai && bunx tsgo -p tsconfig.json --noEmit
# (clean)
```

Fixes #1488