### PR TITLE
fix(discovery): wire extension package sub-dirs + add top-level `install`

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the `omp-plugins` discovery provider, which scans every extension package directory configured via `extensions:` (in `~/.omp/agent/settings.json` or `<cwd>/.omp/settings.json`) or `--extension`/`-e` on the CLI for `skills/`, `hooks/pre|post/`, `tools/`, `commands/`, `rules/`, `prompts/`, and `.mcp.json`. Prior to this, only the extension's TypeScript factory module ran; every sibling capability the docs (https://omp.sh/docs/extension-authoring) advertised was silently ignored ([#1496](https://github.com/can1357/oh-my-pi/issues/1496)).
+- Added the top-level `omp install <target>` subcommand documented at https://omp.sh/docs/extension-authoring. Local paths route to `omp plugin link` (so the directory is symlinked into the plugin set), and npm/marketplace specs route to `omp plugin install`. Before this, `install` was not a registered subcommand and the CLI runner silently forwarded `install ./my-extension` to `launch` as an initial LLM prompt ([#1496](https://github.com/can1357/oh-my-pi/issues/1496)).
+
+### Changed
+
+- Extracted the top-level CLI command table from `src/cli.ts` into a side-effect-free `src/cli-commands.ts` so test code can introspect the registered subcommands without triggering the entrypoint's top-level await.
+
 ## [15.5.11] - 2026-05-29
 
 ### Added

--- a/packages/coding-agent/src/cli-commands.ts
+++ b/packages/coding-agent/src/cli-commands.ts
@@ -1,0 +1,44 @@
+/**
+ * Top-level CLI command table.
+ *
+ * Lives in its own module (importable without side effects) so that tests can
+ * inspect the registered subcommands without triggering the side-effectful
+ * top-level await in `cli.ts`. Adding a new subcommand here is enough to make
+ * `runCli` route to it instead of forwarding the argv as a prompt to
+ * `launch` — see #1496 for the original "args silently leak to the LLM"
+ * regression that motivated the split.
+ */
+import type { CommandEntry } from "@oh-my-pi/pi-utils/cli";
+
+export const commands: CommandEntry[] = [
+	{ name: "launch", load: () => import("./commands/launch").then(m => m.default) },
+	{ name: "acp", load: () => import("./commands/acp").then(m => m.default) },
+	{ name: "auth-broker", load: () => import("./commands/auth-broker").then(m => m.default) },
+	{ name: "auth-gateway", load: () => import("./commands/auth-gateway").then(m => m.default) },
+	{ name: "agents", load: () => import("./commands/agents").then(m => m.default) },
+	{ name: "commit", load: () => import("./commands/commit").then(m => m.default) },
+	{ name: "config", load: () => import("./commands/config").then(m => m.default) },
+	{ name: "grep", load: () => import("./commands/grep").then(m => m.default) },
+	{ name: "grievances", load: () => import("./commands/grievances").then(m => m.default) },
+	{ name: "install", load: () => import("./commands/install").then(m => m.default) },
+	{ name: "plugin", load: () => import("./commands/plugin").then(m => m.default) },
+	{ name: "setup", load: () => import("./commands/setup").then(m => m.default) },
+	{ name: "shell", load: () => import("./commands/shell").then(m => m.default) },
+	{ name: "read", load: () => import("./commands/read").then(m => m.default) },
+	{ name: "ssh", load: () => import("./commands/ssh").then(m => m.default) },
+	{ name: "stats", load: () => import("./commands/stats").then(m => m.default) },
+	{ name: "update", load: () => import("./commands/update").then(m => m.default) },
+	{ name: "worktree", load: () => import("./commands/worktree").then(m => m.default), aliases: ["wt"] },
+	{ name: "search", load: () => import("./commands/web-search").then(m => m.default), aliases: ["q"] },
+];
+
+/**
+ * Return true when `first` matches a registered subcommand name or alias.
+ *
+ * Flags (`-…`) and `@file` arguments are never subcommands; for those the CLI
+ * runner skips ahead to the default `launch` command.
+ */
+export function isSubcommand(first: string | undefined): boolean {
+	if (!first || first.startsWith("-") || first.startsWith("@")) return false;
+	return commands.some(entry => entry.name === first || entry.aliases?.includes(first));
+}

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -10,7 +10,8 @@ procmgr.scrubProcessEnv();
  * CLI entry point — registers all commands explicitly and delegates to the
  * lightweight CLI runner from pi-utils.
  */
-import { type CliConfig, type CommandEntry, run } from "@oh-my-pi/pi-utils/cli";
+import { type CliConfig, run } from "@oh-my-pi/pi-utils/cli";
+import { commands, isSubcommand } from "./cli-commands";
 
 if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0) {
 	process.stderr.write(
@@ -21,27 +22,6 @@ if (Bun.semver.order(Bun.version, MIN_BUN_VERSION) < 0) {
 
 process.title = APP_NAME;
 
-const commands: CommandEntry[] = [
-	{ name: "launch", load: () => import("./commands/launch").then(m => m.default) },
-	{ name: "acp", load: () => import("./commands/acp").then(m => m.default) },
-	{ name: "auth-broker", load: () => import("./commands/auth-broker").then(m => m.default) },
-	{ name: "auth-gateway", load: () => import("./commands/auth-gateway").then(m => m.default) },
-	{ name: "agents", load: () => import("./commands/agents").then(m => m.default) },
-	{ name: "commit", load: () => import("./commands/commit").then(m => m.default) },
-	{ name: "config", load: () => import("./commands/config").then(m => m.default) },
-	{ name: "grep", load: () => import("./commands/grep").then(m => m.default) },
-	{ name: "grievances", load: () => import("./commands/grievances").then(m => m.default) },
-	{ name: "plugin", load: () => import("./commands/plugin").then(m => m.default) },
-	{ name: "setup", load: () => import("./commands/setup").then(m => m.default) },
-	{ name: "shell", load: () => import("./commands/shell").then(m => m.default) },
-	{ name: "read", load: () => import("./commands/read").then(m => m.default) },
-	{ name: "ssh", load: () => import("./commands/ssh").then(m => m.default) },
-	{ name: "stats", load: () => import("./commands/stats").then(m => m.default) },
-	{ name: "update", load: () => import("./commands/update").then(m => m.default) },
-	{ name: "worktree", load: () => import("./commands/worktree").then(m => m.default), aliases: ["wt"] },
-	{ name: "search", load: () => import("./commands/web-search").then(m => m.default), aliases: ["q"] },
-];
-
 async function showHelp(config: CliConfig): Promise<void> {
 	const { renderRootHelp } = await import("@oh-my-pi/pi-utils/cli");
 	const { getExtraHelpText } = await import("./cli/args");
@@ -51,16 +31,6 @@ async function showHelp(config: CliConfig): Promise<void> {
 		process.stdout.write(`\n${extra}\n`);
 	}
 }
-
-/**
- * Determine whether argv[0] is a known subcommand name.
- * If not, the entire argv is treated as args to the default "launch" command.
- */
-function isSubcommand(first: string | undefined): boolean {
-	if (!first || first.startsWith("-") || first.startsWith("@")) return false;
-	return commands.some(e => e.name === first || e.aliases?.includes(first));
-}
-
 /**
  * Smoke-test entry. Spawns the stats sync worker, pings it, exits.
  *

--- a/packages/coding-agent/src/commands/install.ts
+++ b/packages/coding-agent/src/commands/install.ts
@@ -1,0 +1,107 @@
+/**
+ * `omp install <target>` — top-level convenience over `omp plugin install` /
+ * `omp plugin link`.
+ *
+ * The docs (omp.sh/docs/extension-authoring) advertise
+ *
+ *   omp install ./my-extension
+ *
+ * as a third loading mechanism that "symlinks the directory into the plugin
+ * set and watches it for changes". Before this command existed, `install` was
+ * not a registered subcommand, so the CLI runner forwarded the argv to the
+ * default `launch` command and the model received `install ./my-extension`
+ * as an initial prompt — see #1496.
+ *
+ * Local-path targets (`./foo`, `/abs/foo`, `~/foo`, or an existing directory)
+ * route to `plugin link` so they are symlinked into the plugin set, matching
+ * the documented behavior. Everything else (`pkg`, `pkg@1.2.3`,
+ * `name@marketplace`) routes to `plugin install`.
+ */
+
+import { existsSync } from "node:fs";
+import * as path from "node:path";
+import { Args, Command, Flags } from "@oh-my-pi/pi-utils/cli";
+import { type PluginAction, type PluginCommandArgs, runPluginCommand } from "../cli/plugin-cli";
+import { initTheme } from "../modes/theme/theme";
+
+/**
+ * Heuristic used to decide whether `omp install <target>` should `link` a
+ * local directory or `install` a remote spec. Exported for tests.
+ */
+export function looksLikeLocalPath(target: string): boolean {
+	if (target.startsWith(".") || target.startsWith("/") || target.startsWith("~")) return true;
+	// Windows drive prefix (e.g. `C:\foo`).
+	if (/^[a-zA-Z]:[\\/]/.test(target)) return true;
+	// Bare names that happen to exist as a local directory.
+	try {
+		return existsSync(path.resolve(target));
+	} catch {
+		return false;
+	}
+}
+
+export default class Install extends Command {
+	static description = "Install or link an extension package (alias of `plugin install`/`plugin link`)";
+
+	static args = {
+		targets: Args.string({
+			description: "Local path, npm spec, or marketplace ref (e.g. ./my-ext, my-pkg@1.2.3, name@marketplace)",
+			required: false,
+			multiple: true,
+		}),
+	};
+
+	static flags = {
+		json: Flags.boolean({ description: "Output JSON" }),
+		force: Flags.boolean({ description: "Force install" }),
+		"dry-run": Flags.boolean({ description: "Show actions without applying changes" }),
+		scope: Flags.string({
+			description: 'Install scope: "user" (default) or "project" (marketplace installs only)',
+			options: ["user", "project"],
+		}),
+	};
+
+	async run(): Promise<void> {
+		const { args, flags } = await this.parse(Install);
+		const targets = Array.isArray(args.targets) ? args.targets : args.targets ? [args.targets] : [];
+
+		if (targets.length === 0) {
+			process.stderr.write("Usage: omp install <path | npm-spec | name@marketplace> [...]\n");
+			process.exit(1);
+		}
+
+		await initTheme();
+
+		// Split into local-paths (→ link) and remote specs (→ install). Each batch
+		// preserves user-supplied order so progress output reads naturally.
+		const localPaths: string[] = [];
+		const remoteSpecs: string[] = [];
+		for (const target of targets) {
+			if (looksLikeLocalPath(target)) localPaths.push(target);
+			else remoteSpecs.push(target);
+		}
+
+		const baseFlags: PluginCommandArgs["flags"] = {
+			json: flags.json,
+			force: flags.force,
+			dryRun: flags["dry-run"],
+			scope: flags.scope as "user" | "project" | undefined,
+		};
+
+		for (const localPath of localPaths) {
+			await runPluginCommand({
+				action: "link" satisfies PluginAction,
+				args: [localPath],
+				flags: baseFlags,
+			});
+		}
+
+		if (remoteSpecs.length > 0) {
+			await runPluginCommand({
+				action: "install" satisfies PluginAction,
+				args: remoteSpecs,
+				flags: baseFlags,
+			});
+		}
+	}
+}

--- a/packages/coding-agent/src/discovery/index.ts
+++ b/packages/coding-agent/src/discovery/index.ts
@@ -32,6 +32,7 @@ import "./gemini";
 import "./opencode";
 import "./github";
 import "./mcp-json";
+import "./omp-plugins";
 import "./ssh";
 import "./vscode";
 import "./windsurf";

--- a/packages/coding-agent/src/discovery/omp-extension-roots.ts
+++ b/packages/coding-agent/src/discovery/omp-extension-roots.ts
@@ -1,0 +1,159 @@
+/**
+ * OMP extension package roots.
+ *
+ * An "extension package root" is a directory configured via either
+ * `extensions:` in user/project settings or the `--extension`/`-e` CLI flag
+ * that points to a packaged extension on disk. The package's standard
+ * sub-directories (`skills/`, `hooks/`, `tools/`, `commands/`, `rules/`,
+ * `prompts/`, `.mcp.json`) are wired into discovery by `omp-plugins.ts`.
+ *
+ * CLI-provided paths are injected via {@link injectOmpExtensionCliRoots}
+ * before discovery runs; settings paths are read lazily from
+ * `<scope>/settings.json` in {@link listOmpExtensionRoots} to mirror what
+ * `loadExtensionModules` already does.
+ *
+ * @see ./omp-plugins.ts
+ * @see ./builtin.ts `loadExtensionModules`
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { isEnoent, tryParseJson } from "@oh-my-pi/pi-utils";
+import { readDirEntries, readFile } from "../capability/fs";
+import type { LoadContext } from "../capability/types";
+import { expandTilde } from "../tools/path-utils";
+
+/** A resolved extension package directory wired into the discovery surfaces. */
+export interface OmpExtensionRoot {
+	/** Absolute path to the package directory. */
+	path: string;
+	/** Stable display name (basename of the package directory). */
+	name: string;
+	/** Scope from which the path was sourced. */
+	level: "user" | "project";
+}
+
+interface InjectedRoot {
+	path: string;
+	level: "user" | "project";
+}
+
+let injectedCliRoots: InjectedRoot[] = [];
+
+/**
+ * Register CLI-provided extension package paths (e.g. from `--extension`/`-e`)
+ * so the sub-discovery providers can find their sibling `skills/`, `hooks/`,
+ * etc. Paths that do not resolve to a directory are silently dropped — file
+ * entrypoints have no package sub-tree to scan.
+ *
+ * Call once during startup before any capability load. Repeated calls extend
+ * the registered set; {@link clearOmpExtensionCliRoots} resets for tests.
+ */
+export function injectOmpExtensionCliRoots(paths: readonly string[], home: string, cwd: string): void {
+	if (paths.length === 0) return;
+	const expanded = paths.map(raw => {
+		const tilde = expandTilde(raw, home);
+		return path.isAbsolute(tilde) ? tilde : path.resolve(cwd, tilde);
+	});
+	const merged = new Map<string, InjectedRoot>();
+	for (const root of injectedCliRoots) merged.set(root.path, root);
+	for (const resolved of expanded) {
+		// CLI scope mirrors how `--extension` is treated elsewhere — user-level overrides win.
+		if (!merged.has(resolved)) merged.set(resolved, { path: resolved, level: "user" });
+	}
+	injectedCliRoots = [...merged.values()];
+}
+
+/** Drop every CLI-injected root. Tests use this between cases. */
+export function clearOmpExtensionCliRoots(): void {
+	injectedCliRoots = [];
+}
+
+/** Inspect currently-injected CLI roots (read-only). Exposed for diagnostics + tests. */
+export function getInjectedOmpExtensionCliRoots(): readonly OmpExtensionRoot[] {
+	return injectedCliRoots.map(({ path: p, level }) => ({ path: p, level, name: path.basename(p) }));
+}
+
+interface ScopeDirs {
+	project: string;
+	user: string;
+}
+
+function scopeDirs(ctx: LoadContext): ScopeDirs {
+	return {
+		project: path.join(ctx.cwd, ".omp"),
+		user: path.join(ctx.home, ".omp", "agent"),
+	};
+}
+
+async function readSettingsExtensions(settingsPath: string): Promise<string[]> {
+	const content = await readFile(settingsPath);
+	if (!content) return [];
+	const parsed = tryParseJson<{ extensions?: unknown }>(content);
+	const raw = parsed?.extensions;
+	if (!Array.isArray(raw)) return [];
+	return raw.filter((entry): entry is string => typeof entry === "string" && entry.length > 0);
+}
+
+function resolveAgainst(raw: string, ctx: LoadContext): string {
+	const tilde = expandTilde(raw, ctx.home);
+	return path.isAbsolute(tilde) ? tilde : path.resolve(ctx.cwd, tilde);
+}
+
+async function isDirectory(p: string): Promise<boolean> {
+	const entries = await readDirEntries(p);
+	if (entries.length > 0) return true;
+	// Empty directory still counts; cache returns [] for both empty and missing.
+	// Disambiguate with a single stat — only hit when the cached listing is empty.
+	try {
+		const stat = await fs.stat(p);
+		return stat.isDirectory();
+	} catch (err) {
+		if (isEnoent(err)) return false;
+		throw err;
+	}
+}
+
+/**
+ * Resolve every configured extension package directory for the given context.
+ *
+ * Sources, in order of precedence (later entries with the same absolute path
+ * are dropped):
+ *
+ * 1. CLI roots injected via {@link injectOmpExtensionCliRoots}
+ * 2. Project `<cwd>/.omp/settings.json#extensions`
+ * 3. User `~/.omp/agent/settings.json#extensions`
+ *
+ * Only entries that resolve to a directory on disk are returned; file
+ * entrypoints contribute zero sub-discovery surface and are filtered out.
+ */
+export async function listOmpExtensionRoots(ctx: LoadContext): Promise<OmpExtensionRoot[]> {
+	const { project, user } = scopeDirs(ctx);
+	const [projectExtensions, userExtensions] = await Promise.all([
+		readSettingsExtensions(path.join(project, "settings.json")),
+		readSettingsExtensions(path.join(user, "settings.json")),
+	]);
+
+	const candidates: InjectedRoot[] = [
+		...injectedCliRoots,
+		...projectExtensions.map((raw): InjectedRoot => ({ path: resolveAgainst(raw, ctx), level: "project" })),
+		...userExtensions.map((raw): InjectedRoot => ({ path: resolveAgainst(raw, ctx), level: "user" })),
+	];
+
+	// First-seen-wins dedup preserves CLI > project > user precedence.
+	const seen = new Set<string>();
+	const unique: InjectedRoot[] = [];
+	for (const candidate of candidates) {
+		if (seen.has(candidate.path)) continue;
+		seen.add(candidate.path);
+		unique.push(candidate);
+	}
+
+	const directoryFlags = await Promise.all(unique.map(c => isDirectory(c.path)));
+	const roots: OmpExtensionRoot[] = [];
+	for (let i = 0; i < unique.length; i++) {
+		if (!directoryFlags[i]) continue;
+		const { path: p, level } = unique[i];
+		roots.push({ path: p, level, name: path.basename(p) });
+	}
+	return roots;
+}

--- a/packages/coding-agent/src/discovery/omp-extension-roots.ts
+++ b/packages/coding-agent/src/discovery/omp-extension-roots.ts
@@ -17,9 +17,10 @@
  */
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { isEnoent, tryParseJson } from "@oh-my-pi/pi-utils";
+import { isEnoent, logger, tryParseJson } from "@oh-my-pi/pi-utils";
 import { readDirEntries, readFile } from "../capability/fs";
 import type { LoadContext } from "../capability/types";
+import { getEnabledPlugins } from "../extensibility/plugins/loader";
 import { expandTilde } from "../tools/path-utils";
 
 /** A resolved extension package directory wired into the discovery surfaces. */
@@ -122,24 +123,31 @@ async function isDirectory(p: string): Promise<boolean> {
  * 1. CLI roots injected via {@link injectOmpExtensionCliRoots}
  * 2. Project `<cwd>/.omp/settings.json#extensions`
  * 3. User `~/.omp/agent/settings.json#extensions`
+ * 4. Enabled plugins installed under `<plugins>/node_modules/` (e.g. via
+ *    `omp install <pkg>` / `omp plugin install` / `omp plugin link`)
  *
  * Only entries that resolve to a directory on disk are returned; file
  * entrypoints contribute zero sub-discovery surface and are filtered out.
+ * Installed-plugin enumeration failures (missing lockfile, unreadable
+ * `package.json`, etc.) are logged at `debug` and degrade gracefully — the
+ * other sources still surface.
  */
 export async function listOmpExtensionRoots(ctx: LoadContext): Promise<OmpExtensionRoot[]> {
 	const { project, user } = scopeDirs(ctx);
-	const [projectExtensions, userExtensions] = await Promise.all([
+	const [projectExtensions, userExtensions, installedPlugins] = await Promise.all([
 		readSettingsExtensions(path.join(project, "settings.json")),
 		readSettingsExtensions(path.join(user, "settings.json")),
+		listInstalledPluginRoots(ctx),
 	]);
 
 	const candidates: InjectedRoot[] = [
 		...injectedCliRoots,
 		...projectExtensions.map((raw): InjectedRoot => ({ path: resolveAgainst(raw, ctx), level: "project" })),
 		...userExtensions.map((raw): InjectedRoot => ({ path: resolveAgainst(raw, ctx), level: "user" })),
+		...installedPlugins,
 	];
 
-	// First-seen-wins dedup preserves CLI > project > user precedence.
+	// First-seen-wins dedup preserves CLI > project-settings > user-settings > installed precedence.
 	const seen = new Set<string>();
 	const unique: InjectedRoot[] = [];
 	for (const candidate of candidates) {
@@ -156,4 +164,27 @@ export async function listOmpExtensionRoots(ctx: LoadContext): Promise<OmpExtens
 		roots.push({ path: p, level, name: path.basename(p) });
 	}
 	return roots;
+}
+
+/**
+ * Enumerate every enabled installed plugin's package directory so its
+ * conventional `skills/`, `hooks/`, `tools/`, `commands/`, `rules/`,
+ * `prompts/`, and `.mcp.json` are wired into discovery — mirrors how
+ * `getAllPluginExtensionPaths` already feeds the extension factory loader.
+ *
+ * Marketplace and `omp plugin link` installs write to the plugin manager's
+ * `node_modules` (or symlink into it) rather than to `extensions:` in
+ * settings; without this branch the sub-discovery provider would still miss
+ * everything those install paths produce.
+ */
+async function listInstalledPluginRoots(ctx: LoadContext): Promise<InjectedRoot[]> {
+	try {
+		const plugins = await getEnabledPlugins(ctx.cwd, { home: ctx.home });
+		// Installed plugins are always user-scope; project disablement is already
+		// honored by `getEnabledPlugins` via `loadProjectOverrides`.
+		return plugins.map(({ path: p }) => ({ path: p, level: "user" }));
+	} catch (err) {
+		logger.debug("listInstalledPluginRoots: enumeration failed", { error: String(err) });
+		return [];
+	}
 }

--- a/packages/coding-agent/src/discovery/omp-plugins.ts
+++ b/packages/coding-agent/src/discovery/omp-plugins.ts
@@ -1,0 +1,383 @@
+/**
+ * OMP extension-package sub-discovery provider.
+ *
+ * When a user configures an extension via `extensions:` (in settings) or
+ * `--extension`/`-e` (on the CLI), the docs promise that the package's
+ * sibling directories — `skills/`, `hooks/pre|post/`, `tools/`, `commands/`,
+ * `rules/`, `prompts/`, and `.mcp.json` — are picked up by omp's standard
+ * discovery surfaces. The native `omp` provider in `builtin.ts` only walks
+ * `.omp/` and `~/.omp/agent/`, so without this provider those sub-trees are
+ * silently ignored.
+ *
+ * Provider priority is set below the native `omp` provider (100) so an
+ * extension package never shadows the user's own `.omp/` configuration on
+ * dedup.
+ *
+ * @see ./omp-extension-roots.ts
+ * @see ../../docs/extension-loading.md
+ */
+import * as path from "node:path";
+import { logger, parseFrontmatter, tryParseJson } from "@oh-my-pi/pi-utils";
+import { registerProvider } from "../capability";
+import { readDirEntries, readFile } from "../capability/fs";
+import { type Hook, hookCapability } from "../capability/hook";
+import { type MCPServer, mcpCapability } from "../capability/mcp";
+import { type Prompt, promptCapability } from "../capability/prompt";
+import { type Rule, ruleCapability } from "../capability/rule";
+import { type Skill, skillCapability } from "../capability/skill";
+import { type SlashCommand, slashCommandCapability } from "../capability/slash-command";
+import { type CustomTool, toolCapability } from "../capability/tool";
+import type { LoadContext, LoadResult } from "../capability/types";
+import { buildRuleFromMarkdown, createSourceMeta, loadFilesFromDir, scanSkillsFromDir } from "./helpers";
+import { listOmpExtensionRoots, type OmpExtensionRoot } from "./omp-extension-roots";
+
+const PROVIDER_ID = "omp-plugins";
+const DISPLAY_NAME = "OMP Extension Packages";
+const DESCRIPTION =
+	"Sub-discovery (skills, hooks, tools, commands, rules, prompts, .mcp.json) inside extension packages";
+const PRIORITY = 90;
+
+// =============================================================================
+// Skills
+// =============================================================================
+
+async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
+	const roots = await listOmpExtensionRoots(ctx);
+	const results = await Promise.all(
+		roots.map(root =>
+			scanSkillsFromDir(ctx, {
+				dir: path.join(root.path, "skills"),
+				providerId: PROVIDER_ID,
+				level: root.level,
+				requireDescription: true,
+			}),
+		),
+	);
+	return {
+		items: results.flatMap(r => r.items),
+		warnings: results.flatMap(r => r.warnings ?? []),
+	};
+}
+
+// =============================================================================
+// Slash Commands
+// =============================================================================
+
+async function loadSlashCommands(ctx: LoadContext): Promise<LoadResult<SlashCommand>> {
+	const roots = await listOmpExtensionRoots(ctx);
+	const results = await Promise.all(
+		roots.map(root =>
+			loadFilesFromDir<SlashCommand>(ctx, path.join(root.path, "commands"), PROVIDER_ID, root.level, {
+				extensions: ["md"],
+				transform: (name, content, filePath, source) => ({
+					name: name.replace(/\.md$/, ""),
+					path: filePath,
+					content,
+					level: root.level,
+					_source: source,
+				}),
+			}),
+		),
+	);
+	return {
+		items: results.flatMap(r => r.items),
+		warnings: results.flatMap(r => r.warnings ?? []),
+	};
+}
+
+// =============================================================================
+// Rules
+// =============================================================================
+
+async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
+	const roots = await listOmpExtensionRoots(ctx);
+	const results = await Promise.all(
+		roots.map(root =>
+			loadFilesFromDir<Rule>(ctx, path.join(root.path, "rules"), PROVIDER_ID, root.level, {
+				extensions: ["md", "mdc"],
+				transform: (name, content, filePath, source) =>
+					buildRuleFromMarkdown(name, content, filePath, source, { stripNamePattern: /\.(md|mdc)$/ }),
+			}),
+		),
+	);
+	return {
+		items: results.flatMap(r => r.items),
+		warnings: results.flatMap(r => r.warnings ?? []),
+	};
+}
+
+// =============================================================================
+// Prompts
+// =============================================================================
+
+async function loadPrompts(ctx: LoadContext): Promise<LoadResult<Prompt>> {
+	const roots = await listOmpExtensionRoots(ctx);
+	const results = await Promise.all(
+		roots.map(root =>
+			loadFilesFromDir<Prompt>(ctx, path.join(root.path, "prompts"), PROVIDER_ID, root.level, {
+				extensions: ["md"],
+				transform: (name, content, filePath, source) => ({
+					name: name.replace(/\.md$/, ""),
+					path: filePath,
+					content,
+					_source: source,
+				}),
+			}),
+		),
+	);
+	return {
+		items: results.flatMap(r => r.items),
+		warnings: results.flatMap(r => r.warnings ?? []),
+	};
+}
+
+// =============================================================================
+// Hooks
+// =============================================================================
+
+const HOOK_TYPES: ReadonlyArray<"pre" | "post"> = ["pre", "post"];
+
+async function loadHooks(ctx: LoadContext): Promise<LoadResult<Hook>> {
+	const roots = await listOmpExtensionRoots(ctx);
+	const tasks: Array<{ root: OmpExtensionRoot; hookType: "pre" | "post" }> = [];
+	for (const root of roots) {
+		for (const hookType of HOOK_TYPES) {
+			tasks.push({ root, hookType });
+		}
+	}
+	const results = await Promise.all(
+		tasks.map(({ root, hookType }) =>
+			loadFilesFromDir<Hook>(ctx, path.join(root.path, "hooks", hookType), PROVIDER_ID, root.level, {
+				transform: (name, _content, filePath, source) => {
+					const baseName = name.includes(".") ? name.slice(0, name.lastIndexOf(".")) : name;
+					const tool = baseName === "*" ? "*" : baseName;
+					return {
+						name,
+						path: filePath,
+						type: hookType,
+						tool,
+						level: root.level,
+						_source: source,
+					};
+				},
+			}),
+		),
+	);
+	return {
+		items: results.flatMap(r => r.items),
+		warnings: results.flatMap(r => r.warnings ?? []),
+	};
+}
+
+// =============================================================================
+// Custom Tools
+// =============================================================================
+
+const TOOL_EXTENSIONS = ["json", "md", "ts", "js", "sh", "bash", "py"];
+
+async function loadTools(ctx: LoadContext): Promise<LoadResult<CustomTool>> {
+	const roots = await listOmpExtensionRoots(ctx);
+	const perRoot = await Promise.all(
+		roots.map(async root => {
+			const toolsDir = path.join(root.path, "tools");
+			const [filesResult, entries] = await Promise.all([
+				loadFilesFromDir<CustomTool>(ctx, toolsDir, PROVIDER_ID, root.level, {
+					extensions: TOOL_EXTENSIONS,
+					transform: (name, content, filePath, source) => {
+						if (name.endsWith(".json")) {
+							const data = tryParseJson<{ name?: string; description?: string }>(content);
+							const toolName = data?.name || name.replace(/\.json$/, "");
+							const description =
+								typeof data?.description === "string" && data.description.trim()
+									? data.description
+									: `${toolName} custom tool`;
+							return { name: toolName, path: filePath, description, level: root.level, _source: source };
+						}
+						if (name.endsWith(".md")) {
+							const { frontmatter } = parseFrontmatter(content, { source: filePath });
+							const toolName = (frontmatter.name as string) || name.replace(/\.md$/, "");
+							const description =
+								typeof frontmatter.description === "string" && frontmatter.description.trim()
+									? String(frontmatter.description)
+									: `${toolName} custom tool`;
+							return { name: toolName, path: filePath, description, level: root.level, _source: source };
+						}
+						const toolName = name.replace(/\.(ts|js|sh|bash|py)$/, "");
+						return {
+							name: toolName,
+							path: filePath,
+							description: `${toolName} custom tool`,
+							level: root.level,
+							_source: source,
+						};
+					},
+				}),
+				readDirEntries(toolsDir),
+			]);
+
+			// `<tools>/<name>/index.ts` sub-directory tools, mirroring `builtin.ts:loadTools`.
+			const indexCandidates = entries
+				.filter(e => !e.name.startsWith(".") && e.isDirectory())
+				.map(e => path.join(toolsDir, e.name, "index.ts"));
+			const indexContents = await Promise.all(indexCandidates.map(p => readFile(p)));
+			const indexItems: CustomTool[] = [];
+			for (let i = 0; i < indexCandidates.length; i++) {
+				if (indexContents[i] === null) continue;
+				const indexPath = indexCandidates[i];
+				const toolName = path.basename(path.dirname(indexPath));
+				indexItems.push({
+					name: toolName,
+					path: indexPath,
+					description: `${toolName} custom tool`,
+					level: root.level,
+					_source: createSourceMeta(PROVIDER_ID, indexPath, root.level),
+				});
+			}
+
+			return { filesResult, indexItems };
+		}),
+	);
+
+	const items: CustomTool[] = [];
+	const warnings: string[] = [];
+	for (const { filesResult, indexItems } of perRoot) {
+		items.push(...filesResult.items, ...indexItems);
+		if (filesResult.warnings) warnings.push(...filesResult.warnings);
+	}
+	return { items, warnings };
+}
+
+// =============================================================================
+// MCP Servers
+// =============================================================================
+
+const MCP_FILENAMES = [".mcp.json", "mcp.json"] as const;
+
+interface RawMcpServer {
+	enabled?: boolean;
+	timeout?: number;
+	command?: string;
+	args?: string[];
+	env?: Record<string, string>;
+	cwd?: string;
+	url?: string;
+	headers?: Record<string, string>;
+	auth?: MCPServer["auth"];
+	oauth?: MCPServer["oauth"];
+	type?: MCPServer["transport"];
+}
+
+async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> {
+	const roots = await listOmpExtensionRoots(ctx);
+	const items: MCPServer[] = [];
+	const warnings: string[] = [];
+
+	const tasks: Array<{ root: OmpExtensionRoot; mcpPath: string }> = [];
+	for (const root of roots) {
+		for (const filename of MCP_FILENAMES) {
+			tasks.push({ root, mcpPath: path.join(root.path, filename) });
+		}
+	}
+	const contents = await Promise.all(tasks.map(({ mcpPath }) => readFile(mcpPath)));
+
+	for (let i = 0; i < tasks.length; i++) {
+		const raw = contents[i];
+		if (raw === null) continue;
+		const { root, mcpPath } = tasks[i];
+
+		const parsed = tryParseJson<{ mcpServers?: Record<string, unknown> }>(raw);
+		if (!parsed) {
+			warnings.push(`[omp-plugins] Invalid JSON in ${mcpPath}`);
+			logger.warn(`[omp-plugins] Invalid JSON in ${mcpPath}`);
+			continue;
+		}
+		const servers = parsed.mcpServers;
+		if (!servers || typeof servers !== "object" || Array.isArray(servers)) continue;
+
+		for (const [serverName, serverCfg] of Object.entries(servers)) {
+			if (!serverCfg || typeof serverCfg !== "object" || Array.isArray(serverCfg)) continue;
+			const cfg = serverCfg as RawMcpServer;
+			if (typeof cfg.command !== "string" && typeof cfg.url !== "string") {
+				warnings.push(`[omp-plugins] Skipping MCP server "${serverName}" in ${mcpPath}: missing command or url`);
+				continue;
+			}
+			items.push({
+				name: serverName,
+				...(cfg.enabled !== undefined && { enabled: cfg.enabled }),
+				...(cfg.timeout !== undefined && { timeout: cfg.timeout }),
+				...(cfg.command !== undefined && { command: cfg.command }),
+				...(cfg.args !== undefined && { args: cfg.args }),
+				...(cfg.env !== undefined && { env: cfg.env }),
+				...(cfg.cwd !== undefined && { cwd: cfg.cwd }),
+				...(cfg.url !== undefined && { url: cfg.url }),
+				...(cfg.headers !== undefined && { headers: cfg.headers }),
+				...(cfg.auth !== undefined && { auth: cfg.auth }),
+				...(cfg.oauth !== undefined && { oauth: cfg.oauth }),
+				...(cfg.type !== undefined && { transport: cfg.type }),
+				_source: createSourceMeta(PROVIDER_ID, mcpPath, root.level),
+			});
+		}
+	}
+
+	return { items, warnings };
+}
+
+// =============================================================================
+// Provider Registration
+// =============================================================================
+
+registerProvider<Skill>(skillCapability.id, {
+	id: PROVIDER_ID,
+	displayName: DISPLAY_NAME,
+	description: DESCRIPTION,
+	priority: PRIORITY,
+	load: loadSkills,
+});
+
+registerProvider<SlashCommand>(slashCommandCapability.id, {
+	id: PROVIDER_ID,
+	displayName: DISPLAY_NAME,
+	description: DESCRIPTION,
+	priority: PRIORITY,
+	load: loadSlashCommands,
+});
+
+registerProvider<Rule>(ruleCapability.id, {
+	id: PROVIDER_ID,
+	displayName: DISPLAY_NAME,
+	description: DESCRIPTION,
+	priority: PRIORITY,
+	load: loadRules,
+});
+
+registerProvider<Prompt>(promptCapability.id, {
+	id: PROVIDER_ID,
+	displayName: DISPLAY_NAME,
+	description: DESCRIPTION,
+	priority: PRIORITY,
+	load: loadPrompts,
+});
+
+registerProvider<Hook>(hookCapability.id, {
+	id: PROVIDER_ID,
+	displayName: DISPLAY_NAME,
+	description: DESCRIPTION,
+	priority: PRIORITY,
+	load: loadHooks,
+});
+
+registerProvider<CustomTool>(toolCapability.id, {
+	id: PROVIDER_ID,
+	displayName: DISPLAY_NAME,
+	description: DESCRIPTION,
+	priority: PRIORITY,
+	load: loadTools,
+});
+
+registerProvider<MCPServer>(mcpCapability.id, {
+	id: PROVIDER_ID,
+	displayName: DISPLAY_NAME,
+	description: DESCRIPTION,
+	priority: PRIORITY,
+	load: loadMCPServers,
+});

--- a/packages/coding-agent/src/extensibility/plugins/loader.ts
+++ b/packages/coding-agent/src/extensibility/plugins/loader.ts
@@ -52,48 +52,63 @@ async function loadProjectOverrides(cwd: string): Promise<ProjectPluginOverrides
 /**
  * Get list of enabled plugins with their resolved configurations.
  *
- * Respects both global runtime config and project overrides. The optional
- * `home` parameter pins the plugins root for callers that need to enumerate
- * plugins relative to a non-default home (tests with a tempdir, discovery
- * loaders threaded with `LoadContext.home`).
+ * Respects both global runtime config and project overrides. Iterates the
+ * union of `<plugins>/package.json#dependencies` (`bun install`-installed
+ * packages) and `<plugins>/omp-plugins.lock.json#plugins` (so locally
+ * `plugin link`-symlinked extensions, which never get a dependency entry,
+ * are still discovered). The optional `home` parameter pins the plugins
+ * root for callers that need to enumerate plugins relative to a non-default
+ * home (tests with a tempdir, discovery loaders threaded with
+ * `LoadContext.home`).
  */
 export async function getEnabledPlugins(cwd: string, opts: { home?: string } = {}): Promise<InstalledPlugin[]> {
 	const { home } = opts;
-	const pkgJsonPath = getPluginsPackageJson(home);
-	let pkg: { dependencies?: Record<string, string> };
-	try {
-		pkg = await Bun.file(pkgJsonPath).json();
-	} catch (err) {
-		if (isEnoent(err)) return [];
-		throw err;
-	}
 
 	const nodeModulesPath = getPluginsNodeModules(home);
 	if (!fs.existsSync(nodeModulesPath)) {
 		return [];
 	}
 
-	const deps = pkg.dependencies || {};
+	let depsKeys: string[] = [];
+	const pkgJsonPath = getPluginsPackageJson(home);
+	try {
+		const pkg: { dependencies?: Record<string, string> } = await Bun.file(pkgJsonPath).json();
+		depsKeys = Object.keys(pkg.dependencies ?? {});
+	} catch (err) {
+		// Linked-only setups may have no `<plugins>/package.json` yet — that's
+		// fine, the lockfile still records the link.
+		if (!isEnoent(err)) throw err;
+	}
+
 	const runtimeConfig = await loadRuntimeConfig(home);
 	const projectOverrides = await loadProjectOverrides(cwd);
+
+	// Union: dependencies (npm/marketplace installs) ∪ runtime-config plugins
+	// (links + already-recorded installs). Set preserves first-seen order,
+	// putting deps before link-only entries for deterministic output.
+	const names = new Set<string>(depsKeys);
+	for (const name of Object.keys(runtimeConfig.plugins ?? {})) {
+		names.add(name);
+	}
+
 	const plugins: InstalledPlugin[] = [];
-	for (const [name] of Object.entries(deps)) {
+	for (const name of names) {
 		const pluginPkgPath = path.join(nodeModulesPath, name, "package.json");
 		let pluginPkg: { version: string; omp?: PluginManifest; pi?: PluginManifest };
 		try {
 			pluginPkg = await Bun.file(pluginPkgPath).json();
 		} catch (err) {
+			// Lockfile entry without a corresponding node_modules tree means the
+			// link was deleted out from under us; skip silently.
 			if (isEnoent(err)) continue;
 			throw err;
 		}
 
 		const manifest: PluginManifest | undefined = pluginPkg.omp || pluginPkg.pi;
-
 		if (!manifest) {
 			// Not an omp plugin, skip
 			continue;
 		}
-
 		manifest.version = pluginPkg.version;
 
 		const runtimeState = runtimeConfig.plugins[name];

--- a/packages/coding-agent/src/extensibility/plugins/loader.ts
+++ b/packages/coding-agent/src/extensibility/plugins/loader.ts
@@ -19,9 +19,14 @@ installLegacyPiSpecifierShim();
 
 /**
  * Load plugin runtime config from lock file.
+ *
+ * `home` controls which `<plugins>/omp-plugins.lock.json` is read — pass it
+ * through whenever the caller is loading plugins for a tempdir-rooted
+ * scenario (tests, discovery sub-surfaces that need to mirror an alternate
+ * `LoadContext.home`).
  */
-async function loadRuntimeConfig(): Promise<PluginRuntimeConfig> {
-	const lockPath = getPluginsLockfile();
+async function loadRuntimeConfig(home?: string): Promise<PluginRuntimeConfig> {
+	const lockPath = getPluginsLockfile(home);
 	try {
 		return await Bun.file(lockPath).json();
 	} catch (err) {
@@ -46,10 +51,15 @@ async function loadProjectOverrides(cwd: string): Promise<ProjectPluginOverrides
 }
 /**
  * Get list of enabled plugins with their resolved configurations.
- * Respects both global runtime config and project overrides.
+ *
+ * Respects both global runtime config and project overrides. The optional
+ * `home` parameter pins the plugins root for callers that need to enumerate
+ * plugins relative to a non-default home (tests with a tempdir, discovery
+ * loaders threaded with `LoadContext.home`).
  */
-export async function getEnabledPlugins(cwd: string): Promise<InstalledPlugin[]> {
-	const pkgJsonPath = getPluginsPackageJson();
+export async function getEnabledPlugins(cwd: string, opts: { home?: string } = {}): Promise<InstalledPlugin[]> {
+	const { home } = opts;
+	const pkgJsonPath = getPluginsPackageJson(home);
 	let pkg: { dependencies?: Record<string, string> };
 	try {
 		pkg = await Bun.file(pkgJsonPath).json();
@@ -58,13 +68,13 @@ export async function getEnabledPlugins(cwd: string): Promise<InstalledPlugin[]>
 		throw err;
 	}
 
-	const nodeModulesPath = getPluginsNodeModules();
+	const nodeModulesPath = getPluginsNodeModules(home);
 	if (!fs.existsSync(nodeModulesPath)) {
 		return [];
 	}
 
 	const deps = pkg.dependencies || {};
-	const runtimeConfig = await loadRuntimeConfig();
+	const runtimeConfig = await loadRuntimeConfig(home);
 	const projectOverrides = await loadProjectOverrides(cwd);
 	const plugins: InstalledPlugin[] = [];
 	for (const [name] of Object.entries(deps)) {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -36,6 +36,7 @@ import {
 	preloadPluginRoots,
 	resolveActiveProjectRegistryPath,
 } from "./discovery/helpers";
+import { injectOmpExtensionCliRoots } from "./discovery/omp-extension-roots";
 import { exportFromFile } from "./export/html";
 import type { ExtensionUIContext } from "./extensibility/extensions/types";
 import {
@@ -767,6 +768,17 @@ export async function runRootCommand(
 	// Mark the promise as handled so a synchronous failure does not surface as an unhandled-rejection
 	// warning before we reach the await site below.
 	pluginPreloadPromise.catch(() => {});
+
+	// Register CLI-provided extension package paths (`--extension`, `--hook`) so
+	// the `omp-plugins` discovery provider can surface their `skills/`, `hooks/`,
+	// `tools/`, `commands/`, `rules/`, `prompts/`, and `.mcp.json` sub-trees.
+	// `--no-extensions` short-circuits both the factory load and the sub-discovery.
+	if (!parsedArgs.noExtensions) {
+		const cliExtensions = [...(parsedArgs.extensions ?? []), ...(parsedArgs.hooks ?? [])];
+		if (cliExtensions.length > 0) {
+			injectOmpExtensionCliRoots(cliExtensions, home, getProjectDir());
+		}
+	}
 
 	const cwd = getProjectDir();
 	const settingsInstance = deps.settings ?? (await logger.time("settings:init", Settings.init, { cwd }));

--- a/packages/coding-agent/test/discovery/omp-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/omp-plugins.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Regression tests for #1496.
+ *
+ * The native `omp` discovery provider only walks `.omp/` and `~/.omp/agent/`.
+ * Extension packages registered via `extensions:` in settings or
+ * `--extension` on the CLI ship their own `skills/`, `hooks/`, `tools/`,
+ * `commands/`, `rules/`, `prompts/`, and `.mcp.json`. The `omp-plugins`
+ * provider (`src/discovery/omp-plugins.ts`) is what wires those sub-trees
+ * into the standard capability surfaces.
+ *
+ * The provider is invoked directly so the `LoadContext` uses a tempdir as
+ * `home` instead of `os.homedir()`. Module-level CLI injection state is
+ * reset between cases so they cannot poison each other.
+ */
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getCapability } from "@oh-my-pi/pi-coding-agent/capability";
+import { clearCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import { hookCapability } from "@oh-my-pi/pi-coding-agent/capability/hook";
+import { mcpCapability } from "@oh-my-pi/pi-coding-agent/capability/mcp";
+import { promptCapability } from "@oh-my-pi/pi-coding-agent/capability/prompt";
+import { ruleCapability } from "@oh-my-pi/pi-coding-agent/capability/rule";
+import { skillCapability } from "@oh-my-pi/pi-coding-agent/capability/skill";
+import { slashCommandCapability } from "@oh-my-pi/pi-coding-agent/capability/slash-command";
+import { toolCapability } from "@oh-my-pi/pi-coding-agent/capability/tool";
+import type { LoadContext, Provider } from "@oh-my-pi/pi-coding-agent/capability/types";
+// Register all discovery providers as a side effect.
+import "@oh-my-pi/pi-coding-agent/discovery";
+import {
+	clearOmpExtensionCliRoots,
+	injectOmpExtensionCliRoots,
+} from "@oh-my-pi/pi-coding-agent/discovery/omp-extension-roots";
+
+const PROVIDER_ID = "omp-plugins";
+
+let tempDir: string;
+let home: string;
+let project: string;
+let ext: string;
+
+function writeFile(filePath: string, content: string): void {
+	fs.mkdirSync(path.dirname(filePath), { recursive: true });
+	fs.writeFileSync(filePath, content);
+}
+
+function pluginProvider(capabilityId: string): Provider<unknown> {
+	const cap = getCapability(capabilityId);
+	if (!cap) throw new Error(`capability ${capabilityId} missing`);
+	const provider = cap.providers.find(p => p.id === PROVIDER_ID);
+	if (!provider) throw new Error(`provider ${PROVIDER_ID} not registered for ${capabilityId}`);
+	return provider as Provider<unknown>;
+}
+
+async function loadFromPlugin<T>(capabilityId: string, ctx: LoadContext): Promise<T[]> {
+	const result = await pluginProvider(capabilityId).load(ctx);
+	return result.items as T[];
+}
+
+function buildExtensionPackage(packageDir: string): void {
+	writeFile(
+		path.join(packageDir, "package.json"),
+		JSON.stringify({ name: path.basename(packageDir), omp: { extensions: ["./src/main.ts"] } }),
+	);
+	writeFile(path.join(packageDir, "src", "main.ts"), "export default function (_pi) {}\n");
+	writeFile(
+		path.join(packageDir, "skills", "my-skill", "SKILL.md"),
+		"---\nname: my-skill\ndescription: Hello from extension skill\n---\nbody\n",
+	);
+	writeFile(path.join(packageDir, "commands", "greet.md"), "---\ndescription: greet user\n---\nHello {{name}}\n");
+	writeFile(path.join(packageDir, "rules", "style.md"), "---\ndescription: style rule\n---\nUse tabs.\n");
+	writeFile(path.join(packageDir, "prompts", "review.md"), "Review this code.\n");
+	writeFile(path.join(packageDir, "hooks", "pre", "bash.sh"), "#!/bin/sh\necho pre\n");
+	writeFile(path.join(packageDir, "hooks", "post", "edit.sh"), "#!/bin/sh\necho post\n");
+	writeFile(path.join(packageDir, "tools", "wcount.sh"), "#!/bin/sh\nwc -w\n");
+	writeFile(path.join(packageDir, "tools", "deep-tool", "index.ts"), "export default { name: 'deep-tool' };\n");
+	writeFile(
+		path.join(packageDir, ".mcp.json"),
+		JSON.stringify({ mcpServers: { lsp: { command: "lsp-server", args: ["--stdio"] } } }),
+	);
+}
+
+beforeEach(() => {
+	clearCache();
+	clearOmpExtensionCliRoots();
+	tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-plugins-"));
+	home = path.join(tempDir, "home");
+	project = path.join(tempDir, "project");
+	ext = path.join(tempDir, "my-extension");
+	fs.mkdirSync(home, { recursive: true });
+	fs.mkdirSync(project, { recursive: true });
+	fs.mkdirSync(path.join(project, ".git"), { recursive: true });
+	buildExtensionPackage(ext);
+});
+
+afterEach(() => {
+	clearCache();
+	clearOmpExtensionCliRoots();
+	fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+function ctx(): LoadContext {
+	return { cwd: project, home, repoRoot: project };
+}
+
+test("project settings.json#extensions surfaces every sub-directory", async () => {
+	writeFile(path.join(project, ".omp", "settings.json"), JSON.stringify({ extensions: [ext] }));
+
+	const [skills, commands, rules, prompts, hooks, tools, mcps] = await Promise.all([
+		loadFromPlugin<{ name: string }>(skillCapability.id, ctx()),
+		loadFromPlugin<{ name: string }>(slashCommandCapability.id, ctx()),
+		loadFromPlugin<{ name: string }>(ruleCapability.id, ctx()),
+		loadFromPlugin<{ name: string }>(promptCapability.id, ctx()),
+		loadFromPlugin<{ name: string; type: "pre" | "post" }>(hookCapability.id, ctx()),
+		loadFromPlugin<{ name: string }>(toolCapability.id, ctx()),
+		loadFromPlugin<{ name: string; command?: string }>(mcpCapability.id, ctx()),
+	]);
+
+	expect(skills.map(s => s.name)).toContain("my-skill");
+	expect(commands.map(c => c.name)).toContain("greet");
+	expect(rules.map(r => r.name)).toContain("style");
+	expect(prompts.map(p => p.name)).toContain("review");
+	expect(hooks.some(h => h.name === "bash.sh" && h.type === "pre")).toBe(true);
+	expect(hooks.some(h => h.name === "edit.sh" && h.type === "post")).toBe(true);
+	expect(tools.map(t => t.name)).toEqual(expect.arrayContaining(["wcount", "deep-tool"]));
+	expect(mcps.find(m => m.name === "lsp")?.command).toBe("lsp-server");
+});
+
+test("user settings.json#extensions also feeds sub-discovery", async () => {
+	writeFile(path.join(home, ".omp", "agent", "settings.json"), JSON.stringify({ extensions: [ext] }));
+
+	const skills = await loadFromPlugin<{ name: string }>(skillCapability.id, ctx());
+	expect(skills.map(s => s.name)).toContain("my-skill");
+});
+
+test("`--extension` CLI injection is wired through the same provider", async () => {
+	// Empty settings on disk; rely purely on CLI injection.
+	injectOmpExtensionCliRoots([ext], home, project);
+
+	const skills = await loadFromPlugin<{ name: string }>(skillCapability.id, ctx());
+	const tools = await loadFromPlugin<{ name: string }>(toolCapability.id, ctx());
+	expect(skills.map(s => s.name)).toContain("my-skill");
+	expect(tools.map(t => t.name)).toEqual(expect.arrayContaining(["wcount", "deep-tool"]));
+});
+
+test("file-extension entrypoints contribute zero sub-surface (the file has no siblings to scan)", async () => {
+	const standaloneFile = path.join(tempDir, "standalone.ts");
+	fs.writeFileSync(standaloneFile, "export default function (_pi) {}\n");
+	writeFile(path.join(project, ".omp", "settings.json"), JSON.stringify({ extensions: [standaloneFile] }));
+
+	const skills = await loadFromPlugin<{ name: string }>(skillCapability.id, ctx());
+	expect(skills).toHaveLength(0);
+});
+
+test("relative paths in settings resolve against the project cwd", async () => {
+	// Move the extension under the project root so a relative path is meaningful.
+	const relative = "vendored/my-extension";
+	const target = path.join(project, relative);
+	fs.mkdirSync(path.dirname(target), { recursive: true });
+	fs.cpSync(ext, target, { recursive: true });
+	writeFile(path.join(project, ".omp", "settings.json"), JSON.stringify({ extensions: [`./${relative}`] }));
+
+	const skills = await loadFromPlugin<{ name: string }>(skillCapability.id, ctx());
+	expect(skills.map(s => s.name)).toContain("my-skill");
+});
+
+test(".mcp.json with bare entries (no command/url) records a warning and is skipped", async () => {
+	writeFile(
+		path.join(ext, ".mcp.json"),
+		JSON.stringify({ mcpServers: { broken: {}, ok: { command: "x", args: [] } } }),
+	);
+	writeFile(path.join(project, ".omp", "settings.json"), JSON.stringify({ extensions: [ext] }));
+
+	const result = await pluginProvider(mcpCapability.id).load(ctx());
+	expect(result.items.map(s => (s as { name: string }).name)).toEqual(["ok"]);
+	expect((result.warnings ?? []).some(w => w.includes('"broken"'))).toBe(true);
+});

--- a/packages/coding-agent/test/discovery/omp-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/omp-plugins.test.ts
@@ -176,3 +176,42 @@ test(".mcp.json with bare entries (no command/url) records a warning and is skip
 	expect(result.items.map(s => (s as { name: string }).name)).toEqual(["ok"]);
 	expect((result.warnings ?? []).some(w => w.includes('"broken"'))).toBe(true);
 });
+
+test("installed plugins under `<plugins>/node_modules/` are surfaced (e.g. via `omp plugin link`/`install`)", async () => {
+	// Simulate what `plugin install` / `plugin link` produces: a plugins root
+	// with `package.json#dependencies` and a populated `node_modules/<pkg>/`.
+	const pluginsDir = path.join(home, ".omp", "plugins");
+	const nodeModules = path.join(pluginsDir, "node_modules");
+	const installed = path.join(nodeModules, "my-installed-ext");
+	fs.mkdirSync(installed, { recursive: true });
+	fs.cpSync(ext, installed, { recursive: true });
+	writeFile(
+		path.join(pluginsDir, "package.json"),
+		JSON.stringify({ name: "omp-plugins", dependencies: { "my-installed-ext": "1.0.0" } }),
+	);
+	// Plugin's own package.json must carry an `omp`/`pi` manifest for the
+	// loader to recognise it; the buildExtensionPackage fixture already wrote
+	// one with `omp.extensions`, which is sufficient.
+
+	const skills = await loadFromPlugin<{ name: string; path: string }>(skillCapability.id, ctx());
+	const found = skills.find(s => s.name === "my-skill" && s.path.includes("my-installed-ext"));
+	expect(found).toBeDefined();
+});
+
+test("disabled installed plugins do not contribute sub-discovery", async () => {
+	const pluginsDir = path.join(home, ".omp", "plugins");
+	const installed = path.join(pluginsDir, "node_modules", "my-disabled-ext");
+	fs.mkdirSync(installed, { recursive: true });
+	fs.cpSync(ext, installed, { recursive: true });
+	writeFile(
+		path.join(pluginsDir, "package.json"),
+		JSON.stringify({ name: "omp-plugins", dependencies: { "my-disabled-ext": "1.0.0" } }),
+	);
+	writeFile(
+		path.join(pluginsDir, "omp-plugins.lock.json"),
+		JSON.stringify({ plugins: { "my-disabled-ext": { enabled: false } }, settings: {} }),
+	);
+
+	const skills = await loadFromPlugin<{ name: string; path: string }>(skillCapability.id, ctx());
+	expect(skills.find(s => s.path.includes("my-disabled-ext"))).toBeUndefined();
+});

--- a/packages/coding-agent/test/discovery/omp-plugins.test.ts
+++ b/packages/coding-agent/test/discovery/omp-plugins.test.ts
@@ -215,3 +215,31 @@ test("disabled installed plugins do not contribute sub-discovery", async () => {
 	const skills = await loadFromPlugin<{ name: string; path: string }>(skillCapability.id, ctx());
 	expect(skills.find(s => s.path.includes("my-disabled-ext"))).toBeUndefined();
 });
+
+test("linked plugins (only in lockfile, not in package.json#dependencies) are surfaced", async () => {
+	// `omp plugin link ./local-ext` creates a symlink under
+	// `<plugins>/node_modules/<pkg>` plus a lockfile entry, but it never
+	// touches `<plugins>/package.json#dependencies`. The discovery path must
+	// still find the package — otherwise the documented `omp install
+	// ./local-extension` workflow leaves the sibling skills/hooks/tools
+	// invisible (see PR #1498 review).
+	const pluginsDir = path.join(home, ".omp", "plugins");
+	const nodeModules = path.join(pluginsDir, "node_modules");
+	fs.mkdirSync(nodeModules, { recursive: true });
+	const linkTarget = path.join(nodeModules, "my-linked-ext");
+	fs.symlinkSync(ext, linkTarget);
+	// Intentionally NO `<plugins>/package.json` — matches a fresh `plugin link`
+	// against a setup that has never run `plugin install`.
+	writeFile(
+		path.join(pluginsDir, "omp-plugins.lock.json"),
+		JSON.stringify({
+			plugins: { "my-linked-ext": { version: "1.0.0", enabled: true, enabledFeatures: null } },
+			settings: {},
+		}),
+	);
+
+	const skills = await loadFromPlugin<{ name: string; path: string }>(skillCapability.id, ctx());
+	const tools = await loadFromPlugin<{ name: string; path: string }>(toolCapability.id, ctx());
+	expect(skills.find(s => s.name === "my-skill" && s.path.includes("my-linked-ext"))).toBeDefined();
+	expect(tools.find(t => t.name === "wcount" && t.path.includes("my-linked-ext"))).toBeDefined();
+});

--- a/packages/coding-agent/test/install-command.test.ts
+++ b/packages/coding-agent/test/install-command.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Regression test for #1496 (bug 2): `omp install ./my-extension` used to be
+ * silently rewritten to `launch install ./my-extension` and forwarded to the
+ * LLM as an initial prompt because no top-level `install` subcommand existed.
+ *
+ * These tests pin two invariants:
+ *
+ *  1. `install` is registered in the CLI command table, so the runner does
+ *     not prepend `launch` and the args never reach the model.
+ *  2. The local-path heuristic that routes `install ./foo` to `plugin link`
+ *     while routing remote specs to `plugin install` is correct for the
+ *     shapes users actually type.
+ */
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { looksLikeLocalPath } from "@oh-my-pi/pi-coding-agent/commands/install";
+
+describe("install command is registered as a top-level subcommand", () => {
+	test("CLI runner sees `install` as a known command", async () => {
+		const cli = await import("@oh-my-pi/pi-coding-agent/cli-commands");
+		expect(cli.commands.some(c => c.name === "install")).toBe(true);
+		expect(cli.isSubcommand("install")).toBe(true);
+	});
+});
+
+describe("looksLikeLocalPath", () => {
+	test("explicit relative paths are local", () => {
+		expect(looksLikeLocalPath("./my-extension")).toBe(true);
+		expect(looksLikeLocalPath("../sibling")).toBe(true);
+		expect(looksLikeLocalPath(".")).toBe(true);
+	});
+
+	test("absolute and home-relative paths are local", () => {
+		expect(looksLikeLocalPath("/usr/local/share/ext")).toBe(true);
+		expect(looksLikeLocalPath("~/extensions/foo")).toBe(true);
+	});
+
+	test("Windows drive-prefixed paths are local", () => {
+		expect(looksLikeLocalPath("C:\\extensions\\foo")).toBe(true);
+		expect(looksLikeLocalPath("D:/extensions/foo")).toBe(true);
+	});
+
+	test("npm specs and marketplace refs are remote", () => {
+		expect(looksLikeLocalPath("@oh-my-pi/exa")).toBe(false);
+		expect(looksLikeLocalPath("my-pkg")).toBe(false);
+		expect(looksLikeLocalPath("my-pkg@1.2.3")).toBe(false);
+		expect(looksLikeLocalPath("name@marketplace")).toBe(false);
+	});
+
+	test("bare names that exist as a local directory are treated as local", () => {
+		const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-install-test-"));
+		const cwd = process.cwd();
+		try {
+			process.chdir(tempDir);
+			fs.mkdirSync(path.join(tempDir, "vendored-ext"));
+			expect(looksLikeLocalPath("vendored-ext")).toBe(true);
+			expect(looksLikeLocalPath("missing-pkg")).toBe(false);
+		} finally {
+			process.chdir(cwd);
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/utils/src/dirs.ts
+++ b/packages/utils/src/dirs.ts
@@ -260,18 +260,18 @@ export function getPluginsDir(home?: string): string {
 }
 
 /** Where npm installs packages (~/.omp/plugins/node_modules). */
-export function getPluginsNodeModules(): string {
-	return path.join(getPluginsDir(), "node_modules");
+export function getPluginsNodeModules(home?: string): string {
+	return path.join(getPluginsDir(home), "node_modules");
 }
 
 /** Plugin manifest (~/.omp/plugins/package.json). */
-export function getPluginsPackageJson(): string {
-	return path.join(getPluginsDir(), "package.json");
+export function getPluginsPackageJson(home?: string): string {
+	return path.join(getPluginsDir(home), "package.json");
 }
 
 /** Plugin lock file (~/.omp/plugins/omp-plugins.lock.json). */
-export function getPluginsLockfile(): string {
-	return path.join(getPluginsDir(), "omp-plugins.lock.json");
+export function getPluginsLockfile(home?: string): string {
+	return path.join(getPluginsDir(home), "omp-plugins.lock.json");
 }
 
 /** Get the remote mount directory (~/.omp/remote). */


### PR DESCRIPTION
## Repro

Given a package laid out per the [extension-authoring docs](https://omp.sh/docs/extension-authoring):

```
my-extension/
  package.json          # { "omp": { "extensions": ["./src/main.ts"] } }
  src/main.ts
  skills/my-skill/SKILL.md
  hooks/pre/bash.sh
  tools/word-count/index.ts
  commands/greet.md
  rules/style.md
  prompts/review.md
  .mcp.json
```

- **Bug 1.** Register the package via `extensions:` in `~/.omp/agent/settings.json` / `<cwd>/.omp/settings.json` or `omp --extension ./my-extension`. The factory runs, but `skill://my-skill` is missing, the hook never fires, the tool is unregistered, etc.
- **Bug 2.** Run `omp install ./my-extension`. The docs advertise it as the local-dev workflow ("symlinks the directory into the plugin set and watches it for changes"). Instead, `install ./my-extension` is forwarded to the LLM as an initial prompt — no error, no warning.

## Cause

**Bug 1.** Every capability loader in `packages/coding-agent/src/discovery/builtin.ts` (`loadSkills` 265-291, `loadSlashCommands` 302-323, `loadRules` 334-366, `loadPrompts` 391-411, `loadHooks` 633-681, `loadTools` 692-797, `loadMCPServers` 98-214) only walks `getConfigDirs(ctx)` — the user/project `.omp/` directories. `loadExtensionModules` (422-520) resolves extension-factory paths but never hands the package directory to any other discovery surface, so sibling sub-trees are invisible.

**Bug 2.** `cli.ts` had no `install` entry in its `commands` table, so `isSubcommand("install")` returned `false` and `runCli` prepended `launch`, turning `install ./my-extension` into a model prompt.

## Fix

1. **New helper `discovery/omp-extension-roots.ts`** — resolves the union of CLI-injected extension paths (`injectOmpExtensionCliRoots`) and `extensions:` entries from project + user `settings.json`, filtered to directory targets. CLI precedence > project > user; first-seen-wins dedup.
2. **New provider `discovery/omp-plugins.ts`** — registers `Skill`/`SlashCommand`/`Rule`/`Prompt`/`Hook`/`CustomTool`/`MCPServer` providers at priority 90 (below native `omp` at 100). Each calls `listOmpExtensionRoots` and reuses the existing `loadFilesFromDir` / `scanSkillsFromDir` / hook-sub-dir / tool-sub-dir machinery — no new parsing code paths.
3. **`main.ts`** — calls `injectOmpExtensionCliRoots(parsedArgs.extensions + parsedArgs.hooks, ...)` next to the existing `injectPluginDirRoots`, respecting `--no-extensions`.
4. **New `commands/install.ts`** — top-level `omp install <target>`. Local paths (`.`, `/`, `~`, Windows drive, or an existing directory) → `omp plugin link`; everything else → `omp plugin install`. Matches the documented "symlinks into the plugin set" behavior for local-dev while preserving the existing npm / marketplace install path.
5. **Extracted `cli-commands.ts`** — the registered subcommand table lives in a side-effect-free module so tests can introspect `commands` / `isSubcommand` without triggering `cli.ts`'s top-level `await runCli(...)`.

## Verification

`bun run check`:
```
@oh-my-pi/pi-coding-agent check: Checked 1207 files in 248ms. No fixes applied.
@oh-my-pi/pi-coding-agent check: $ tsgo -p tsconfig.json --noEmit
@oh-my-pi/pi-coding-agent check: Exited with code 0
```

Targeted tests around the changed area:
```
bun test packages/coding-agent/test/discovery \
         packages/coding-agent/test/install-command.test.ts \
         packages/coding-agent/test/extensions-discovery.test.ts \
         packages/coding-agent/test/plugin-extensions-discovery.test.ts \
         packages/coding-agent/test/plugin-command.test.ts
→ 130 pass, 0 fail, 336 expect() calls
```

The new `test/discovery/omp-plugins.test.ts` covers:
- project `settings.json#extensions` surfacing every sub-dir (skill/command/rule/prompt/hook/tool/mcp);
- user `~/.omp/agent/settings.json#extensions` parity;
- `--extension` CLI injection through `injectOmpExtensionCliRoots`;
- file entrypoints contributing zero sub-surface (they have no siblings to scan);
- relative paths in settings resolving against project `cwd`;
- malformed `.mcp.json` entries (missing `command`/`url`) emitting a warning instead of registering a broken server.

`test/install-command.test.ts` pins:
- `install` is registered (so the args never leak to `launch`);
- the local-vs-remote heuristic for `.`, `/`, `~`, Windows drive paths, existing local directories, npm specs, and marketplace refs.

Fixes #1496