### PR TITLE
fix(coding-agent): add internal-URI examples and stronger empty-args guard to read prompt

### DIFF
--- a/packages/coding-agent/src/prompts/tools/read.md
+++ b/packages/coding-agent/src/prompts/tools/read.md
@@ -8,7 +8,7 @@ Read files, directories, archives, SQLite databases, images, documents, internal
 
 ## Parameters
 
-- `path` — required. Local path, internal URI (`skill://`, `agent://`, `artifact://`, `memory://`, `rule://`, `local://`, `vault://`, `mcp://`), or URL. Append `:<sel>` for line ranges, raw mode, or special modes (e.g. `src/foo.ts:50-200`, `src/foo.ts:raw`, `db.sqlite:users:42`).
+- `path` — required. Local path, internal URI (`skill://`, `agent://`, `artifact://`, `memory://`, `rule://`, `local://`, `vault://`, `mcp://`), or URL. Append `:<sel>` for line ranges, raw mode, or special modes (e.g. `src/foo.ts:50-200`, `src/foo.ts:raw`, `db.sqlite:users:42`). Examples: `read(path="rule://development-rules")`, `read(path="skill://ck:debug")`, `read(path="memory://root")`.
 
 ## Selectors
 
@@ -75,7 +75,7 @@ For `.sqlite`, `.sqlite3`, `.db`, `.db3`:
 <critical>
 - You MUST use `read` for every file, directory, archive, and URL inspection. `cat`, `head`, `tail`, `less`, `more`, `ls`, `tar`, `unzip`, `curl`, `wget` are FORBIDDEN — any such bash call is a bug, regardless of how short or convenient it looks.
 - You MUST prefer `read` over a browser/puppeteer tool for URL content; only reach for a browser when `read` cannot deliver reasonable content.
-- You MUST always include `path`. NEVER call `read` with `{}`.
+- You MUST always include `path`. NEVER call `read` with `{}` or any empty argument object.
 - For line ranges, append the selector to `path` (`path="src/foo.ts:50-200"`, `path="src/foo.ts:50+150"`). NEVER substitute `sed -n`, `awk NR`, or `head`/`tail` pipelines.
 - Summary footer says `read <path>:raw …`? Re-issue the exact selector it names. NEVER guess what's inside `..` / `…` markers — they carry no content.
 - You MAY combine selectors with URL reads and internal URIs; both paginate the cached resolved output.


### PR DESCRIPTION
## Summary
- Add concrete internal-URI examples (`rule://`, `skill://`, `memory://`) to the `read` tool's `path` parameter description so weaker models see correct call shapes
- Strengthen the empty-args critical guard from `NEVER call read with {}` to `NEVER call read with {} or any empty argument object`

## Why
Weaker models loop on invalid `read` calls, emitting `{}` instead of including the required `path` parameter. This is a prompting gap — the prompt lacked concrete internal-URI examples near the parameter definition, and the guardrail didn't cover all empty-argument shapes.

## Test plan
- [x] `bun --cwd=packages/coding-agent run check` passes
- [x] 227 read-related tests pass (0 failures)

Fixes #1459

🤖 Generated with [Claude Code](https://claude.com/claude-code)