### PR TITLE
feat(coding-agent): show context usage in plan review help text

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1481,10 +1481,12 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	#getPlanReviewHelpText(): string {
 		const externalEditorKey = this.keybindings.getDisplayString("app.editor.external");
+		const contextUsage = this.session.getContextUsage();
+		const contextLine = contextUsage?.percent != null ? `  context: ${contextUsage.percent.toFixed(1)}% used` : "";
 		if (!externalEditorKey) {
-			return "up/down navigate  enter select  esc cancel";
+			return `up/down navigate  enter select  esc cancel${contextLine}`;
 		}
-		return `up/down navigate  enter select  ${externalEditorKey.toLowerCase()} open in editor  esc cancel`;
+		return `up/down navigate  enter select  ${externalEditorKey.toLowerCase()} open in editor  esc cancel${contextLine}`;
 	}
 
 	async #openPlanInExternalEditor(planFilePath: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Append context usage percentage to the plan review selector's help text
- Users can see at a glance whether they have room to keep context or should compact
- Usage is omitted when unknown (e.g. right after compaction, before next LLM response)

## Why
The plan review selector hides the footer where context usage is normally displayed. This makes "Approve and keep context" a blind choice when the user has lost track of context consumption.

## How
Uses the existing `session.getContextUsage()` API (same method used by the footer component). Adds `context: XX.X% used` to the help text line, formatted with one decimal place.

## Test plan
- [x] `bun --cwd=packages/coding-agent run check` passes
- [x] All 3756 tests pass

Fixes #1458

🤖 Generated with [Claude Code](https://claude.com/claude-code)