### PR TITLE
Fix TUI width, editor inserts, and Ghostty cursor trails

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -361,7 +361,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.todoContainer = new Container();
 		this.btwContainer = new Container();
 		this.editor = new CustomEditor(getEditorTheme());
-		this.editor.setUseTerminalCursor(this.ui.getShowHardwareCursor());
+		this.editor.setUseTerminalCursor(this.ui.getUseTerminalCursorMarker());
 		this.editor.setAutocompleteMaxVisible(settings.get("autocompleteMaxVisible"));
 		this.editor.onAutocompleteCancel = () => {
 			this.ui.requestRender(true);
@@ -2139,7 +2139,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			? factory(this.ui, getEditorTheme(), this.keybindings)
 			: new CustomEditor(getEditorTheme());
 
-		nextEditor.setUseTerminalCursor(this.ui.getShowHardwareCursor());
+		nextEditor.setUseTerminalCursor(this.ui.getUseTerminalCursorMarker());
 		nextEditor.setAutocompleteMaxVisible(this.settings.get("autocompleteMaxVisible"));
 		nextEditor.onAutocompleteCancel = () => {
 			this.ui.requestRender(true);

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1484,20 +1484,7 @@ export class Editor implements Component, Focusable {
 
 	/** Insert text at the current cursor position */
 	insertText(text: string): void {
-		this.#exitHistoryForEditing();
-		this.#resetKillSequence();
-		this.#recordUndoState();
-
-		const line = this.#state.lines[this.#state.cursorLine] || "";
-		const before = line.slice(0, this.#state.cursorCol);
-		const after = line.slice(this.#state.cursorCol);
-
-		this.#state.lines[this.#state.cursorLine] = before + text + after;
-		this.#setCursorCol(this.#state.cursorCol + text.length);
-
-		if (this.onChange) {
-			this.onChange(this.getText());
-		}
+		this.#insertTextAtCursor(text);
 	}
 
 	// All the editor methods from before...

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -596,7 +596,9 @@ export class Editor implements Component, Focusable {
 
 	#getStyledInputCursor(): { text: string; width: number } {
 		const cursorChar = this.#theme.symbols.inputCursor;
-		return { text: `\x1b[5m${cursorChar}\x1b[0m`, width: visibleWidth(cursorChar) };
+		// Keep the software cursor steady. Ghostty/cmux can leave visual
+		// afterimages for SGR blink cells during rapid input-row repaints.
+		return { text: cursorChar, width: visibleWidth(cursorChar) };
 	}
 
 	#renderEndOfLineCursorAtWidthLimit(
@@ -1484,6 +1486,7 @@ export class Editor implements Component, Focusable {
 
 	/** Insert text at the current cursor position */
 	insertText(text: string): void {
+		this.#exitHistoryForEditing();
 		this.#insertTextAtCursor(text);
 	}
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -152,12 +152,12 @@ function isGhosttySession(): boolean {
 	);
 }
 
-function resolveHardwareCursorPreference(enabled: boolean): boolean {
-	if (!enabled) return false;
+function resolveHardwareCursorPreference(requested: boolean): boolean {
+	if (!requested) return false;
 	// Ghostty currently leaves bar-cursor afterimages when a TUI repeatedly
-	// repaints the row under a visible hardware cursor. Fall back to the
-	// software cursor there unless a developer explicitly opts back in while
-	// testing a terminal-side fix.
+	// repaints the row under a visible hardware cursor. Keep the editor in
+	// terminal-cursor-marker mode, but hide the actual terminal cursor unless a
+	// developer explicitly opts back in while testing a terminal-side fix.
 	if (isGhosttySession() && !$flag("PI_FORCE_HARDWARE_CURSOR")) return false;
 	return true;
 }
@@ -307,6 +307,7 @@ export class TUI extends Container {
 	#sixelProbeTimeout?: NodeJS.Timeout;
 	#sixelProbeUnsubscribe?: () => void;
 	#showHardwareCursor = $flag("PI_HARDWARE_CURSOR");
+	#useTerminalCursorMarker = this.#showHardwareCursor;
 	#clearOnShrink = $flag("PI_CLEAR_ON_SHRINK"); // Clear empty rows when content shrinks (default: off)
 	#maxLinesRendered = 0; // Line count from last render, used for viewport calculation
 	// Highest count of content rows currently sitting in terminal scrollback
@@ -334,9 +335,9 @@ export class TUI extends Container {
 	constructor(terminal: Terminal, showHardwareCursor?: boolean) {
 		super();
 		this.terminal = terminal;
-		this.#showHardwareCursor = resolveHardwareCursorPreference(
-			showHardwareCursor === undefined ? this.#showHardwareCursor : showHardwareCursor,
-		);
+		const requested = showHardwareCursor === undefined ? this.#showHardwareCursor : showHardwareCursor;
+		this.#showHardwareCursor = resolveHardwareCursorPreference(requested);
+		this.#useTerminalCursorMarker = requested;
 	}
 
 	get fullRedraws(): number {
@@ -347,11 +348,17 @@ export class TUI extends Container {
 		return this.#showHardwareCursor;
 	}
 
+	getUseTerminalCursorMarker(): boolean {
+		return this.#useTerminalCursorMarker;
+	}
+
 	setShowHardwareCursor(enabled: boolean): void {
-		const next = resolveHardwareCursorPreference(enabled);
-		if (this.#showHardwareCursor === next) return;
-		this.#showHardwareCursor = next;
-		if (!next) {
+		const nextShow = resolveHardwareCursorPreference(enabled);
+		const nextMarker = enabled;
+		if (this.#showHardwareCursor === nextShow && this.#useTerminalCursorMarker === nextMarker) return;
+		this.#showHardwareCursor = nextShow;
+		this.#useTerminalCursorMarker = nextMarker;
+		if (!nextShow) {
 			this.terminal.hideCursor();
 		}
 		this.requestRender();

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -26,6 +26,13 @@ const SEGMENT_RESET = "\x1b[0m";
  * diffing so `#previousLines` mirrors what was actually written.
  */
 const LINE_TERMINATOR = "\x1b[0m\x1b]8;;\x07";
+// Paint with terminal autowrap disabled. Several terminals keep a "pending
+// wrap" flag after an exact-width row; a following cursor move can first wrap
+// to the next row, producing staircase trails during animated/differential
+// repaints. The TUI emits explicit CRLFs, so autowrap is not needed while
+// painting and is restored before leaving synchronized output mode.
+const PAINT_BEGIN = "\x1b[?2026h\x1b[?7l";
+const PAINT_END = "\x1b[?7h\x1b[?2026l";
 
 type InputListenerResult = { consume?: boolean; data?: string } | undefined;
 type InputListener = (data: string) => InputListenerResult;
@@ -1350,7 +1357,7 @@ export class TUI extends Container {
 		options: { clearViewport: boolean; clearScrollback: boolean },
 	): void {
 		this.#fullRedrawCount += 1;
-		let buffer = "\x1b[?2026h";
+		let buffer = PAINT_BEGIN;
 		if (options.clearViewport) {
 			buffer += options.clearScrollback ? "\x1b[2J\x1b[H\x1b[3J" : "\x1b[2J\x1b[H";
 		}
@@ -1361,7 +1368,7 @@ export class TUI extends Container {
 		const finalRow = Math.max(0, lines.length - 1);
 		const { seq, toRow } = this.#cursorControlSequence(cursorPos, lines.length, finalRow);
 		buffer += seq;
-		buffer += "\x1b[?2026l";
+		buffer += PAINT_END;
 		this.terminal.write(buffer);
 
 		this.#maxLinesRendered = options.clearViewport ? lines.length : Math.max(this.#maxLinesRendered, lines.length);
@@ -1388,7 +1395,7 @@ export class TUI extends Container {
 	): void {
 		this.#fullRedrawCount += 1;
 		const viewportTop = Math.max(0, lines.length - height);
-		let buffer = "\x1b[?2026h\x1b[H";
+		let buffer = `${PAINT_BEGIN}\x1b[H`;
 		for (let screenRow = 0; screenRow < height; screenRow++) {
 			if (screenRow > 0) buffer += "\r\n";
 			buffer += "\x1b[2K";
@@ -1405,7 +1412,7 @@ export class TUI extends Container {
 		const finalRow = viewportTop + height - 1;
 		const { seq, toRow } = this.#cursorControlSequence(cursorPos, lines.length, finalRow);
 		buffer += seq;
-		buffer += "\x1b[?2026l";
+		buffer += PAINT_END;
 		this.terminal.write(buffer);
 
 		this.#maxLinesRendered = lines.length;
@@ -1426,7 +1433,7 @@ export class TUI extends Container {
 		prevHardwareCursorRow: number,
 	): void {
 		if (start >= lines.length) return;
-		let buffer = "\x1b[?2026h";
+		let buffer = PAINT_BEGIN;
 		// Clamp tracked cursor to the visible viewport bottom — terminals clamp
 		// on resize, so a prior frame may have committed a row that no longer
 		// exists. Without this the scroll math points outside the viewport.
@@ -1438,7 +1445,7 @@ export class TUI extends Container {
 			buffer += "\r\n";
 			buffer += lines[i];
 		}
-		buffer += "\x1b[?2026l";
+		buffer += PAINT_END;
 		this.terminal.write(buffer);
 		const pushedNow = Math.max(0, lines.length - height);
 		if (pushedNow > this.#scrollbackHighWater) {
@@ -1474,7 +1481,7 @@ export class TUI extends Container {
 		const viewportTop = Math.max(0, this.#maxLinesRendered - height);
 		const targetRow = Math.max(0, lines.length - 1);
 
-		let buffer = "\x1b[?2026h";
+		let buffer = PAINT_BEGIN;
 
 		const clampedCursor = Math.min(prevHardwareCursorRow, prevViewportTop + height - 1);
 		const currentScreenRow = clampedCursor - prevViewportTop;
@@ -1499,7 +1506,7 @@ export class TUI extends Container {
 
 		const { seq, toRow } = this.#cursorControlSequence(cursorPos, lines.length, targetRow);
 		buffer += seq;
-		buffer += "\x1b[?2026l";
+		buffer += PAINT_END;
 		this.terminal.write(buffer);
 
 		this.#maxLinesRendered = lines.length;
@@ -1533,7 +1540,7 @@ export class TUI extends Container {
 		const appendStart = appendedLines && firstChanged === this.#previousLines.length && firstChanged > 0;
 		const moveTargetRow = appendStart ? firstChanged - 1 : firstChanged;
 
-		let buffer = "\x1b[?2026h";
+		let buffer = PAINT_BEGIN;
 
 		// Scroll-down branch: target row is past the bottom of the previous
 		// viewport (a pure append). Emit `\r\n`s so the terminal pushes the
@@ -1584,7 +1591,7 @@ export class TUI extends Container {
 
 		const { seq, toRow } = this.#cursorControlSequence(cursorPos, lines.length, finalCursorRow);
 		buffer += seq;
-		buffer += "\x1b[?2026l";
+		buffer += PAINT_END;
 
 		this.#writeDiffDebug(
 			lines,

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -144,6 +144,24 @@ function isTermuxSession(): boolean {
 	return Boolean(process.env.TERMUX_VERSION);
 }
 
+function isGhosttySession(): boolean {
+	return (
+		Bun.env.TERM_PROGRAM?.toLowerCase() === "ghostty" ||
+		Bun.env.TERM?.toLowerCase() === "xterm-ghostty" ||
+		Boolean(Bun.env.GHOSTTY_RESOURCES_DIR || Bun.env.GHOSTTY_SURFACE_ID)
+	);
+}
+
+function resolveHardwareCursorPreference(enabled: boolean): boolean {
+	if (!enabled) return false;
+	// Ghostty currently leaves bar-cursor afterimages when a TUI repeatedly
+	// repaints the row under a visible hardware cursor. Fall back to the
+	// software cursor there unless a developer explicitly opts back in while
+	// testing a terminal-side fix.
+	if (isGhosttySession() && !$flag("PI_FORCE_HARDWARE_CURSOR")) return false;
+	return true;
+}
+
 /** Detect terminal multiplexers where scrollback clearing and height-change redraws are hostile. */
 function isMultiplexerSession(): boolean {
 	return Boolean(Bun.env.TMUX || Bun.env.STY || Bun.env.ZELLIJ);
@@ -316,9 +334,9 @@ export class TUI extends Container {
 	constructor(terminal: Terminal, showHardwareCursor?: boolean) {
 		super();
 		this.terminal = terminal;
-		if (showHardwareCursor !== undefined) {
-			this.#showHardwareCursor = showHardwareCursor;
-		}
+		this.#showHardwareCursor = resolveHardwareCursorPreference(
+			showHardwareCursor === undefined ? this.#showHardwareCursor : showHardwareCursor,
+		);
 	}
 
 	get fullRedraws(): number {
@@ -330,9 +348,10 @@ export class TUI extends Container {
 	}
 
 	setShowHardwareCursor(enabled: boolean): void {
-		if (this.#showHardwareCursor === enabled) return;
-		this.#showHardwareCursor = enabled;
-		if (!enabled) {
+		const next = resolveHardwareCursorPreference(enabled);
+		if (this.#showHardwareCursor === next) return;
+		this.#showHardwareCursor = next;
+		if (!next) {
 			this.terminal.hideCursor();
 		}
 		this.requestRender();

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -26,12 +26,15 @@ const SEGMENT_RESET = "\x1b[0m";
  * diffing so `#previousLines` mirrors what was actually written.
  */
 const LINE_TERMINATOR = "\x1b[0m\x1b]8;;\x07";
-// Paint with terminal autowrap disabled. Several terminals keep a "pending
-// wrap" flag after an exact-width row; a following cursor move can first wrap
-// to the next row, producing staircase trails during animated/differential
-// repaints. The TUI emits explicit CRLFs, so autowrap is not needed while
-// painting and is restored before leaving synchronized output mode.
-const PAINT_BEGIN = "\x1b[?2026h\x1b[?7l";
+// Hide the hardware cursor before each paint/move write. Ghostty-style bar
+// cursors can otherwise leave visual afterimages while the TUI repaints the
+// row under a visible cursor. Paint writes also disable terminal autowrap:
+// several terminals keep a "pending wrap" flag after an exact-width row, so a
+// following cursor move can first wrap to the next row and produce staircase
+// trails. The TUI emits explicit CRLFs and restores autowrap before leaving
+// synchronized output mode.
+const HIDE_CURSOR = "\x1b[?25l";
+const PAINT_BEGIN = `${HIDE_CURSOR}\x1b[?2026h\x1b[?7l`;
 const PAINT_END = "\x1b[?7h\x1b[?2026l";
 
 type InputListenerResult = { consume?: boolean; data?: string } | undefined;
@@ -1721,6 +1724,6 @@ export class TUI extends Container {
 		}
 		const { seq, toRow } = this.#cursorControlSequence(cursorPos, totalLines, this.#hardwareCursorRow);
 		this.#hardwareCursorRow = toRow;
-		this.terminal.write(`\x1b[?2026h${seq}\x1b[?2026l`);
+		this.terminal.write(`${HIDE_CURSOR}\x1b[?2026h${seq}\x1b[?2026l`);
 	}
 }

--- a/packages/tui/src/utils.ts
+++ b/packages/tui/src/utils.ts
@@ -4,6 +4,7 @@ import {
 	extractSegments as nativeExtractSegments,
 	sliceWithWidth as nativeSliceWithWidth,
 	truncateToWidth as nativeTruncateToWidth,
+	visibleWidth as nativeVisibleWidth,
 	wrapTextWithAnsi as nativeWrapTextWithAnsi,
 	type SliceResult,
 } from "@oh-my-pi/pi-natives";
@@ -96,30 +97,17 @@ export function visibleWidthRaw(str: string): number {
 		return 0;
 	}
 
-	// Fast path: pure ASCII printable
-	let tabLength = 0;
-	const tabWidth = getDefaultTabWidth();
-	let isPureAscii = true;
-	let jamoOvercount = 0;
-	const isMacOS = process.platform === "darwin";
+	// Fast path: printable ASCII has one cell per code unit. Defer every
+	// control/non-ASCII case (tabs, ANSI/OSC, combining marks, CJK) to the
+	// native text engine so all width/slice/wrap helpers share one Unicode
+	// model instead of mixing Bun.stringWidth quirks with Rust truncation.
 	for (let i = 0; i < str.length; i++) {
 		const code = str.charCodeAt(i);
-		if (code === 9) {
-			tabLength += tabWidth;
-		} else if (code < 0x20 || code > 0x7e) {
-			isPureAscii = false;
-			// Hangul Compatibility Jamo (U+3131..U+318E) is EAW=W per UAX#11,
-			// but macOS terminals render them as 1 cell. WezTerm and others
-			// follow UAX#11 at 2 cells. Only correct on macOS.
-			if (isMacOS && code >= 0x3131 && code <= 0x318e) {
-				jamoOvercount++;
-			}
+		if (code < 0x20 || code > 0x7e) {
+			return nativeVisibleWidth(str, getDefaultTabWidth());
 		}
 	}
-	if (isPureAscii) {
-		return str.length + tabLength;
-	}
-	return Bun.stringWidth(str) - jamoOvercount + tabLength;
+	return str.length;
 }
 
 /**

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -508,6 +508,18 @@ describe("Editor component", () => {
 			expect(text).toBe("äöü\nÄÖÜ");
 		});
 
+		it("splits public insertText newlines into logical editor rows", () => {
+			const editor = new Editor(defaultEditorTheme);
+
+			editor.insertText("a\nb");
+
+			expect(editor.getText()).toBe("a\nb");
+			expect(editor.getCursor()).toEqual({ line: 1, col: 1 });
+			for (const renderedLine of editor.render(80)) {
+				expect(renderedLine).not.toContain("\n");
+			}
+		});
+
 		it("replaces the entire document with unicode text via setText (paste simulation)", () => {
 			const editor = new Editor(defaultEditorTheme);
 

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -113,6 +113,19 @@ describe("Editor component", () => {
 			expect(editor.getText()).toBe("second");
 		});
 
+		it("exits history mode at the history edit anchor before public insertText", () => {
+			const editor = new Editor(defaultEditorTheme);
+
+			editor.addToHistory("line1\nline2");
+			editor.handleInput("\x1b[A"); // Up - recalls at the top edit anchor
+			expect(editor.getCursor()).toEqual({ line: 0, col: 0 });
+
+			editor.insertText("[Image #1] ");
+
+			expect(editor.getText()).toBe("line1\nline2[Image #1] ");
+			expect(editor.getCursor()).toEqual({ line: 1, col: "line2[Image #1] ".length });
+		});
+
 		it("does not add empty strings to history", () => {
 			const editor = new Editor(defaultEditorTheme);
 
@@ -727,10 +740,11 @@ describe("Editor component", () => {
 			// Cursor should be at end (after B)
 			const lines = editor.render(width);
 
-			// The cursor (blinking bar) should be visible
+			// The software cursor should be visible without SGR blink; Ghostty/cmux
+			// can leave afterimages for blinking cells during rapid row repaints.
 			const contentLine = lines[1]!;
-			expect(contentLine.includes("\x1b[5m")).toBeTruthy();
-
+			expect(contentLine).toContain(defaultEditorTheme.symbols.inputCursor);
+			expect(contentLine).not.toContain("\x1b[5m");
 			// Line should still be correct width
 			expect(visibleWidth(contentLine)).toBeLessThanOrEqual(width);
 		});
@@ -741,7 +755,7 @@ describe("Editor component", () => {
 				const width = 20;
 				const contentWidth = width - 2 * (paddingX + 1);
 				const layoutWidth = Math.max(1, contentWidth - (paddingX === 0 ? 1 : 0));
-				const cursorToken = `\x1b[5m${defaultEditorTheme.symbols.inputCursor}\x1b[0m`;
+				const cursorToken = defaultEditorTheme.symbols.inputCursor;
 
 				for (let i = 0; i < layoutWidth; i++) {
 					editor.handleInput("a");
@@ -818,13 +832,13 @@ describe("Editor component", () => {
 			let lines = editor.render(2);
 			expect(lines).toHaveLength(2);
 			expect(lines[0]).toBe("> ");
-			expect(lines[1]).toBe(` \x1b[5m${defaultEditorTheme.symbols.inputCursor}\x1b[0m${CURSOR_MARKER}`);
+			expect(lines[1]).toBe(` ${defaultEditorTheme.symbols.inputCursor}${CURSOR_MARKER}`);
 
 			editor.handleInput("\x1b[A");
 
 			expect(editor.getCursor()).toEqual({ line: 1, col: 1 });
 			lines = editor.render(2);
-			expect(lines).toEqual([`>\x1b[5m${defaultEditorTheme.symbols.inputCursor}\x1b[0m${CURSOR_MARKER}`, "  "]);
+			expect(lines).toEqual([`>${defaultEditorTheme.symbols.inputCursor}${CURSOR_MARKER}`, "  "]);
 		});
 
 		it("keeps the prompt gutter visible at the borderless width limit", () => {

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -1083,7 +1083,7 @@ describe("TUI terminal-state regressions", () => {
 		});
 	});
 	describe("hardware cursor terminal fallback", () => {
-		it("falls back to the software cursor on Ghostty even when hardware cursor was requested", async () => {
+		it("uses cursor markers but hides the hardware cursor on Ghostty when hardware cursor was requested", async () => {
 			await withEnvPatch(
 				{
 					TERM_PROGRAM: "ghostty",
@@ -1095,6 +1095,7 @@ describe("TUI terminal-state regressions", () => {
 				() => {
 					const tui = new TUI(new VirtualTerminal(20, 4), true);
 					expect(tui.getShowHardwareCursor()).toBe(false);
+					expect(tui.getUseTerminalCursorMarker()).toBe(true);
 				},
 			);
 		});
@@ -1111,6 +1112,7 @@ describe("TUI terminal-state regressions", () => {
 				() => {
 					const tui = new TUI(new VirtualTerminal(20, 4), true);
 					expect(tui.getShowHardwareCursor()).toBe(true);
+					expect(tui.getUseTerminalCursorMarker()).toBe(true);
 				},
 			);
 		});
@@ -1127,6 +1129,24 @@ describe("TUI terminal-state regressions", () => {
 				() => {
 					const tui = new TUI(new VirtualTerminal(20, 4), true);
 					expect(tui.getShowHardwareCursor()).toBe(true);
+					expect(tui.getUseTerminalCursorMarker()).toBe(true);
+				},
+			);
+		});
+
+		it("keeps software cursor mode when hardware cursor is explicitly disabled", async () => {
+			await withEnvPatch(
+				{
+					TERM_PROGRAM: "ghostty",
+					TERM: "xterm-ghostty",
+					GHOSTTY_RESOURCES_DIR: "/tmp/ghostty",
+					GHOSTTY_SURFACE_ID: "0x1",
+					PI_FORCE_HARDWARE_CURSOR: undefined,
+				},
+				() => {
+					const tui = new TUI(new VirtualTerminal(20, 4), false);
+					expect(tui.getShowHardwareCursor()).toBe(false);
+					expect(tui.getUseTerminalCursorMarker()).toBe(false);
 				},
 			);
 		});

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -1063,6 +1063,7 @@ describe("TUI terminal-state regressions", () => {
 		const CURSOR_SEQ = /\x1b\[\?(?:25[hl]|\d+[A-G])/g;
 		const BSU = "\x1b[?2026h";
 		const ESU = "\x1b[?2026l";
+		const HIDE_CURSOR = "\x1b[?25l";
 		const DISABLE_AUTOWRAP = "\x1b[?7l";
 		const ENABLE_AUTOWRAP = "\x1b[?7h";
 
@@ -1136,6 +1137,8 @@ describe("TUI terminal-state regressions", () => {
 				expect(paintWrites.length).toBeGreaterThan(0);
 				for (const write of paintWrites) {
 					const begin = write.indexOf(BSU);
+					expect(write.startsWith(HIDE_CURSOR)).toBe(true);
+					expect(begin).toBe(HIDE_CURSOR.length);
 					const disable = write.indexOf(DISABLE_AUTOWRAP, begin + BSU.length);
 					const enable = write.lastIndexOf(ENABLE_AUTOWRAP);
 					const end = write.lastIndexOf(ESU);
@@ -1194,13 +1197,14 @@ describe("TUI terminal-state regressions", () => {
 
 		/**
 		 * Assert that every cursor escape sequence in every write call appears
-		 * strictly between a matched BSU/ESU pair, or is the sole payload of a
-		 * standalone hideCursor call (from a no-change path).
+		 * strictly between a matched BSU/ESU pair, is the leading hideCursor that
+		 * intentionally happens just before BSU, or is the sole payload of a
+		 * standalone hideCursor call (from a no-change/no-cursor path).
 		 */
 		function assertCursorSequencesInsideSyncBlocks(writes: string[]): void {
 			for (const write of writes) {
-				if (write === "\x1b[?25l") {
-					// Standalone hideCursor — allowed (no-change path)
+				if (write === HIDE_CURSOR) {
+					// Standalone hideCursor — allowed (no-change/no-cursor path)
 					continue;
 				}
 				// Walk through the write, tracking BSU/ESU nesting
@@ -1226,6 +1230,10 @@ describe("TUI terminal-state regressions", () => {
 						}
 					}
 
+					if (match[0] === HIDE_CURSOR && write.startsWith(HIDE_CURSOR + BSU) && matchIdx === 0) {
+						idx = matchIdx + match[0].length;
+						continue;
+					}
 					expect(depth).toBeGreaterThan(0);
 
 					idx = matchIdx + match[0].length;

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -67,6 +67,30 @@ function countMatches(lines: string[], pattern: RegExp): number {
 	return count;
 }
 
+async function withEnvPatch<T>(patch: Record<string, string | undefined>, run: () => T | Promise<T>): Promise<T> {
+	const saved = new Map<string, string | undefined>();
+	for (const key of Object.keys(patch)) {
+		saved.set(key, Bun.env[key]);
+		const value = patch[key];
+		if (value === undefined) {
+			delete Bun.env[key];
+		} else {
+			Bun.env[key] = value;
+		}
+	}
+	try {
+		return await run();
+	} finally {
+		for (const [key, value] of saved) {
+			if (value === undefined) {
+				delete Bun.env[key];
+			} else {
+				Bun.env[key] = value;
+			}
+		}
+	}
+}
+
 describe("TUI terminal-state regressions", () => {
 	let monotonicNow = 0;
 	// Keep TUI's 16ms render throttle deterministic without sleeping a real frame per render.
@@ -1058,6 +1082,56 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 	});
+	describe("hardware cursor terminal fallback", () => {
+		it("falls back to the software cursor on Ghostty even when hardware cursor was requested", async () => {
+			await withEnvPatch(
+				{
+					TERM_PROGRAM: "ghostty",
+					TERM: "xterm-ghostty",
+					GHOSTTY_RESOURCES_DIR: "/tmp/ghostty",
+					GHOSTTY_SURFACE_ID: "0x1",
+					PI_FORCE_HARDWARE_CURSOR: undefined,
+				},
+				() => {
+					const tui = new TUI(new VirtualTerminal(20, 4), true);
+					expect(tui.getShowHardwareCursor()).toBe(false);
+				},
+			);
+		});
+
+		it("keeps the hardware cursor available outside Ghostty", async () => {
+			await withEnvPatch(
+				{
+					TERM_PROGRAM: "Apple_Terminal",
+					TERM: "xterm-256color",
+					GHOSTTY_RESOURCES_DIR: undefined,
+					GHOSTTY_SURFACE_ID: undefined,
+					PI_FORCE_HARDWARE_CURSOR: undefined,
+				},
+				() => {
+					const tui = new TUI(new VirtualTerminal(20, 4), true);
+					expect(tui.getShowHardwareCursor()).toBe(true);
+				},
+			);
+		});
+
+		it("allows explicit Ghostty hardware cursor opt-in for terminal-side testing", async () => {
+			await withEnvPatch(
+				{
+					TERM_PROGRAM: "ghostty",
+					TERM: "xterm-ghostty",
+					GHOSTTY_RESOURCES_DIR: "/tmp/ghostty",
+					GHOSTTY_SURFACE_ID: "0x1",
+					PI_FORCE_HARDWARE_CURSOR: "1",
+				},
+				() => {
+					const tui = new TUI(new VirtualTerminal(20, 4), true);
+					expect(tui.getShowHardwareCursor()).toBe(true);
+				},
+			);
+		});
+	});
+
 	describe("cursor escape sequences stay inside synchronized output blocks", () => {
 		// Cursor placement sequences that must not leak outside \x1b[?2026h…\x1b[?2026l
 		const CURSOR_SEQ = /\x1b\[\?(?:25[hl]|\d+[A-G])/g;

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -1063,6 +1063,8 @@ describe("TUI terminal-state regressions", () => {
 		const CURSOR_SEQ = /\x1b\[\?(?:25[hl]|\d+[A-G])/g;
 		const BSU = "\x1b[?2026h";
 		const ESU = "\x1b[?2026l";
+		const DISABLE_AUTOWRAP = "\x1b[?7l";
+		const ENABLE_AUTOWRAP = "\x1b[?7h";
 
 		function getWrites(term: VirtualTerminal): string[] {
 			const writes: string[] = [];
@@ -1110,6 +1112,37 @@ describe("TUI terminal-state regressions", () => {
 				tui.requestRender();
 				await settle(term);
 				assertCursorSequencesInsideSyncBlocks(writes);
+			} finally {
+				tui.stop();
+			}
+		});
+
+		it("disables terminal autowrap inside paint writes", async () => {
+			const term = new VirtualTerminal(12, 6);
+			const tui = new TUI(term);
+			const component = new MutableLinesComponent(["ABCDEFGHIJKL", "tail"]);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+
+				const writes = getWrites(term);
+				component.setLines(["XXXXEFGHIJKL", "tail"]);
+				tui.requestRender();
+				await settle(term);
+
+				const paintWrites = writes.filter(write => write.includes(BSU));
+				expect(paintWrites.length).toBeGreaterThan(0);
+				for (const write of paintWrites) {
+					const begin = write.indexOf(BSU);
+					const disable = write.indexOf(DISABLE_AUTOWRAP, begin + BSU.length);
+					const enable = write.lastIndexOf(ENABLE_AUTOWRAP);
+					const end = write.lastIndexOf(ESU);
+					expect(disable).toBe(begin + BSU.length);
+					expect(enable).toBeGreaterThan(disable);
+					expect(end).toBeGreaterThan(enable);
+				}
 			} finally {
 				tui.stop();
 			}

--- a/packages/tui/test/text-utils.test.ts
+++ b/packages/tui/test/text-utils.test.ts
@@ -7,6 +7,13 @@ describe("text utils", () => {
 		expect(visibleWidth(text)).toBe(2 + 3 + 5);
 	});
 
+	it("does not double-count pure ASCII tabs", () => {
+		expect(visibleWidth("a\tb")).toBe(1 + 3 + 1);
+	});
+
+	it("treats Arabic combining marks as zero-width", () => {
+		expect(visibleWidth("بَسِمَ")).toBe(3);
+	});
 	it("ignores OSC hyperlinks in visible width", () => {
 		const text = "\x1b]8;;https://example.com\x07link\x1b]8;;\x07";
 		expect(visibleWidth(text)).toBe(4);


### PR DESCRIPTION
## Summary
- delegate non-ASCII/control text width to native visibleWidth while keeping the printable-ASCII fast path
- make programmatic editor inserts split embedded newlines through the same line-safe path as typed input
- preserve history-anchor exit before public insertText, matching typed-character behavior for image/STT inserts
- wrap TUI paint writes with cursor-hide + synchronized output + autowrap-disable/restore to avoid pending-wrap staircase trails
- separate “editor should emit a cursor marker” from “terminal hardware cursor is visible”; Ghostty keeps marker mode but hides the hardware cursor so no hardware or software cursor glyph is emitted during input-row repaint

## Diagnosis
The user-visible issue had multiple overlapping failure modes:
1. exact-width paint writes could leave terminal autowrap pending, so the next cursor move wrapped first and produced staircase trails
2. Ghostty/cmux left bar-cursor afterimages while OMP repainted the editor row under a visible hardware cursor
3. after hardware cursor fallback, OMP emitted a blinking software cursor glyph instead; that glyph could also leave repeated bar trails, so Ghostty now uses cursor-marker mode with the actual cursor hidden

## PR feedback addressed
- fixed the review comment on `Editor.insertText()`: public inserts now call `#exitHistoryForEditing()` before delegating to the multiline helper, so recalled history anchored at the top is edited at the same end position as typed characters

## Tests
- bun test packages/tui/test/editor.test.ts packages/tui/test/render-regressions.test.ts
- bun test packages/tui/test/editor.test.ts packages/tui/test/text-utils.test.ts
- bun test packages/tui/test/*.test.ts
- bun run check
- PTY capture of installed omp under Ghostty env while typing abcdef: zero cursor-show writes, zero blink SGR, and zero input-cursor glyph bytes before shell restore