### PR TITLE
fix(coding-agent): strip extension flags from the initial prompt

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fixed `search` to handle internal URLs without source files without incorrectly reporting `Path not found`, returning matches from virtual content instead
 - Fixed `/omfg` parsing to tolerate fenced or noisy model output, normalize generated rule names, and reject invalid regex conditions before saving
 - Fixed auto-thinking sessions to persist the concrete resolved effort after classification, so resuming the session restores that level instead of returning to pending `auto`.
+- Fixed extension-registered CLI flags (e.g. `--spawn-peer <value>`) leaking into the initial prompt: argv is re-parsed once the extension flag set is known so flag values are consumed instead of becoming messages or being misread as `@file` arguments. Extension flags and `@file` arguments are now resolved before the session is created, so an unreadable initial `@file` exits without leaving a junk session/terminal breadcrumb behind. ([#1503](https://github.com/can1357/oh-my-pi/pull/1503))
 
 ## [15.7.2] - 2026-05-31
 ### Added

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -54,7 +54,12 @@ export interface Args {
 	unknownFlags: Map<string, boolean | string>;
 }
 
-export function parseArgs(args: string[], extensionFlags?: Map<string, { type: "boolean" | "string" }>): Args {
+export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { type: "boolean" | "string" }>): Args {
+	// Work on a copy: the `--option=value` handling below splices the value
+	// into the array, and callers reuse the same argv (the post-extension
+	// reparse in `runRootCommand` parses it a second time). Mutating the input
+	// would corrupt that later parse, so never touch the caller's array.
+	const args = [...inputArgs];
 	const result: Args = {
 		messages: [],
 		fileArgs: [],

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -54,54 +54,6 @@ export interface Args {
 	unknownFlags: Map<string, boolean | string>;
 }
 
-/**
- * Long names of every built-in CLI flag recognized by {@link parseArgs}.
- * Extension flags that would shadow one of these are rejected at registration
- * (see ExtensionAPI.registerFlag), because a built-in branch in parseArgs would
- * consume the flag before the extension ever sees it. Keep in sync with the
- * flag branches below.
- */
-export const BUILTIN_FLAG_NAMES: ReadonlySet<string> = new Set([
-	"help",
-	"version",
-	"allow-home",
-	"mode",
-	"continue",
-	"resume",
-	"session",
-	"fork",
-	"provider",
-	"model",
-	"smol",
-	"slow",
-	"plan",
-	"api-key",
-	"system-prompt",
-	"append-system-prompt",
-	"provider-session-id",
-	"no-session",
-	"session-dir",
-	"models",
-	"no-tools",
-	"no-lsp",
-	"no-pty",
-	"tools",
-	"thinking",
-	"print",
-	"export",
-	"hook",
-	"extension",
-	"plugin-dir",
-	"no-extensions",
-	"no-skills",
-	"no-rules",
-	"no-title",
-	"auto-approve",
-	"yolo",
-	"approval-mode",
-	"skills",
-	"list-models",
-]);
 export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { type: "boolean" | "string" }>): Args {
 	// Work on a copy: the `--option=value` handling below splices the value
 	// into the array, and callers reuse the same argv (the post-extension

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -54,6 +54,54 @@ export interface Args {
 	unknownFlags: Map<string, boolean | string>;
 }
 
+/**
+ * Long names of every built-in CLI flag recognized by {@link parseArgs}.
+ * Extension flags that would shadow one of these are rejected at registration
+ * (see ExtensionAPI.registerFlag), because a built-in branch in parseArgs would
+ * consume the flag before the extension ever sees it. Keep in sync with the
+ * flag branches below.
+ */
+export const BUILTIN_FLAG_NAMES: ReadonlySet<string> = new Set([
+	"help",
+	"version",
+	"allow-home",
+	"mode",
+	"continue",
+	"resume",
+	"session",
+	"fork",
+	"provider",
+	"model",
+	"smol",
+	"slow",
+	"plan",
+	"api-key",
+	"system-prompt",
+	"append-system-prompt",
+	"provider-session-id",
+	"no-session",
+	"session-dir",
+	"models",
+	"no-tools",
+	"no-lsp",
+	"no-pty",
+	"tools",
+	"thinking",
+	"print",
+	"export",
+	"hook",
+	"extension",
+	"plugin-dir",
+	"no-extensions",
+	"no-skills",
+	"no-rules",
+	"no-title",
+	"auto-approve",
+	"yolo",
+	"approval-mode",
+	"skills",
+	"list-models",
+]);
 export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { type: "boolean" | "string" }>): Args {
 	// Work on a copy: the `--option=value` handling below splices the value
 	// into the array, and callers reuse the same argv (the post-extension
@@ -216,7 +264,14 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 				if (extFlag.type === "boolean") {
 					result.unknownFlags.set(flagName, true);
 				} else if (extFlag.type === "string" && i + 1 < args.length) {
-					result.unknownFlags.set(flagName, args[++i]);
+					// Consume the value in `--flag=value` form, or when the next token
+					// is not flag-looking. A `-`-prefixed token in space form is left
+					// to be parsed as its own flag, so this extension-aware parse agrees
+					// with the extension-unaware startup parse on command shape; pass a
+					// flag-looking value as `--flag=value`.
+					if (equalsValueIndex !== -1 || !args[i + 1].startsWith("-")) {
+						result.unknownFlags.set(flagName, args[++i]);
+					}
 				}
 			}
 			// Unknown flags without extensionFlags are silently ignored (first pass)

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -68,14 +68,19 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 
 	for (let i = 0; i < args.length; i++) {
 		let arg = args[i];
+		const flagIndex = i;
 
-		// Support --flag=value syntax (e.g. --tools=ask,read)
+		// Support --flag=value syntax (e.g. --tools=ask,read). The value is
+		// spliced in as the next token so value-consuming flags pick it up via
+		// `args[++i]`; a non-consuming flag (e.g. a boolean) leaves it behind and
+		// the post-loop guard drops it so it is not mistaken for a message.
+		let equalsValueIndex = -1;
 		if (arg.startsWith("--") && arg.includes("=")) {
 			const eqIdx = arg.indexOf("=");
 			const value = arg.slice(eqIdx + 1);
 			arg = arg.slice(0, eqIdx);
-			// Insert the value so the existing "args[++i]" logic picks it up
 			args.splice(i + 1, 0, value);
+			equalsValueIndex = i + 1;
 		}
 
 		if (arg === "--help" || arg === "-h") {
@@ -217,6 +222,12 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 			// Unknown flags without extensionFlags are silently ignored (first pass)
 		} else if (!arg.startsWith("-")) {
 			result.messages.push(arg);
+		}
+		// Drop an unconsumed `--flag=value` value (e.g. a boolean flag): when no
+		// branch advanced past the spliced token, remove it so it does not fall
+		// through to a later iteration and become a positional message.
+		if (equalsValueIndex !== -1 && i === flagIndex) {
+			args.splice(equalsValueIndex, 1);
 		}
 	}
 

--- a/packages/coding-agent/src/cli/extension-flags.ts
+++ b/packages/coding-agent/src/cli/extension-flags.ts
@@ -1,0 +1,41 @@
+import { type Args, parseArgs } from "./args";
+
+/**
+ * Minimal extension-runner surface needed to resolve CLI flag values. The real
+ * `ExtensionRunner` satisfies this structurally; depending only on the surface
+ * keeps this module free of the heavier runner/session imports and unit-testable
+ * with a fake.
+ */
+export interface ExtensionFlagSink {
+	getFlags(): Map<string, { type: "boolean" | "string" }>;
+	setFlagValue(name: string, value: boolean | string): void;
+}
+
+/**
+ * Resolve extension-registered CLI flags from `rawArgs` once the runner's flag
+ * set is known, push the resolved values onto the runner, and return the parsed
+ * {@link Args}.
+ *
+ * The startup parse runs before extensions load, so it cannot recognise their
+ * flags: a string flag's value (`--spawn-peer reviewer` or `--spawn-peer=reviewer`)
+ * is otherwise left in `messages` and leaks into the initial prompt. Re-parsing
+ * here — through the *same* {@link parseArgs} the startup pass uses, now seeded
+ * with the registered flags — consumes every flag form (`--flag`, `--flag value`,
+ * `--flag=value`) identically, so no form can be handled by one parser and missed
+ * by another.
+ *
+ * Returns `null` when there is no runner or no registered extension flags, in
+ * which case the caller keeps its original startup parse (an extension-aware
+ * re-parse would be identical anyway).
+ */
+export function applyExtensionFlags(runner: ExtensionFlagSink | undefined, rawArgs: string[]): Args | null {
+	const extensionFlags = runner?.getFlags();
+	if (!runner || !extensionFlags || extensionFlags.size === 0) {
+		return null;
+	}
+	const parsed = parseArgs(rawArgs, extensionFlags);
+	for (const [name, value] of parsed.unknownFlags) {
+		runner.setFlagValue(name, value);
+	}
+	return parsed;
+}

--- a/packages/coding-agent/src/cli/extension-flags.ts
+++ b/packages/coding-agent/src/cli/extension-flags.ts
@@ -1,4 +1,4 @@
-import { type Args, BUILTIN_FLAG_NAMES, parseArgs } from "./args";
+import { type Args, parseArgs } from "./args";
 
 /**
  * Minimal extension-runner surface needed to resolve CLI flag values. The real
@@ -12,24 +12,25 @@ export interface ExtensionFlagSink {
 }
 
 /**
- * Recover a single extension flag's value from argv. Used only for flags whose
- * name collides with a built-in (e.g. the bundled plan-mode extension registers
- * `--plan`, which is also the built-in plan-model selector): {@link parseArgs}
- * routes those to the built-in branch, so they never reach `unknownFlags`, yet
- * the extension still needs the value delivered. Handles the same `--flag`,
- * `--flag value`, and `--flag=value` forms.
+ * Recover an extension flag's value directly from argv. {@link parseArgs}
+ * already surfaces every flag it consumes through `unknownFlags`; this fallback
+ * only matters for the cases it leaves out — chiefly a name that collides with a
+ * built-in (e.g. plan-mode registers `--plan`, which is also the built-in
+ * plan-model selector), which `parseArgs` routes to the built-in branch so it
+ * never reaches `unknownFlags`. Mirrors `parseArgs`'s consumption rules:
+ * `--flag`, `--flag value` (a flag-looking value in space form is left to be its
+ * own flag — pass it as `--flag=value`), and `--flag=value`. Returns `undefined`
+ * for a flag that was not passed, so it is a safe no-op for absent flags — which
+ * is what lets this work without a hand-maintained list of built-in flag names.
  */
-function resolveCollidingFlag(
-	rawArgs: string[],
-	name: string,
-	type: "boolean" | "string",
-): boolean | string | undefined {
+function recoverFlagValue(rawArgs: string[], name: string, type: "boolean" | "string"): boolean | string | undefined {
 	const eqPrefix = `--${name}=`;
 	for (let i = 0; i < rawArgs.length; i++) {
 		const arg = rawArgs[i];
 		if (arg === `--${name}`) {
 			if (type === "boolean") return true;
-			return i + 1 < rawArgs.length ? rawArgs[i + 1] : undefined;
+			const next = rawArgs[i + 1];
+			return next !== undefined && !next.startsWith("-") ? next : undefined;
 		}
 		if (arg.startsWith(eqPrefix)) {
 			return type === "boolean" ? true : arg.slice(eqPrefix.length);
@@ -39,8 +40,8 @@ function resolveCollidingFlag(
 }
 
 /**
- * Resolve extension-registered CLI flags from `rawArgs` once the runner's flag
- * set is known, push the resolved values onto the runner, and return the parsed
+ * Resolve extension-registered CLI flags from `rawArgs` once the flag set is
+ * known, push the resolved values onto the sink, and return the parsed
  * {@link Args}.
  *
  * The startup parse runs before extensions load, so it cannot recognise their
@@ -49,11 +50,15 @@ function resolveCollidingFlag(
  * here — through the *same* {@link parseArgs} the startup pass uses, now seeded
  * with the registered flags — consumes every flag form (`--flag`, `--flag value`,
  * `--flag=value`) identically, so no form can be handled by one parser and missed
- * by another. A flag whose name collides with a built-in is consumed by the
- * built-in branch instead of `unknownFlags`, so its value is recovered via
- * {@link resolveCollidingFlag} to preserve delivery (e.g. plan-mode's `--plan`).
+ * by another.
  *
- * Returns `null` when there is no runner or no registered extension flags, in
+ * A flag whose name collides with a built-in is consumed by the built-in branch
+ * instead of `unknownFlags`; for those the value is recovered straight from argv
+ * via {@link recoverFlagValue} (e.g. plan-mode's `--plan`). Because that recovery
+ * is a no-op for any flag `parseArgs` already surfaced or that was not passed,
+ * it can run unconditionally — no list of built-in flag names to keep in sync.
+ *
+ * Returns `null` when there is no sink or no registered extension flags, in
  * which case the caller keeps its original startup parse (an extension-aware
  * re-parse would be identical anyway).
  */
@@ -64,10 +69,7 @@ export function applyExtensionFlags(runner: ExtensionFlagSink | undefined, rawAr
 	}
 	const parsed = parseArgs(rawArgs, extensionFlags);
 	for (const [name, def] of extensionFlags) {
-		let value = parsed.unknownFlags.get(name);
-		if (value === undefined && BUILTIN_FLAG_NAMES.has(name)) {
-			value = resolveCollidingFlag(rawArgs, name, def.type);
-		}
+		const value = parsed.unknownFlags.get(name) ?? recoverFlagValue(rawArgs, name, def.type);
 		if (value !== undefined) {
 			runner.setFlagValue(name, value);
 		}

--- a/packages/coding-agent/src/cli/extension-flags.ts
+++ b/packages/coding-agent/src/cli/extension-flags.ts
@@ -1,4 +1,4 @@
-import { type Args, parseArgs } from "./args";
+import { type Args, BUILTIN_FLAG_NAMES, parseArgs } from "./args";
 
 /**
  * Minimal extension-runner surface needed to resolve CLI flag values. The real
@@ -12,6 +12,33 @@ export interface ExtensionFlagSink {
 }
 
 /**
+ * Recover a single extension flag's value from argv. Used only for flags whose
+ * name collides with a built-in (e.g. the bundled plan-mode extension registers
+ * `--plan`, which is also the built-in plan-model selector): {@link parseArgs}
+ * routes those to the built-in branch, so they never reach `unknownFlags`, yet
+ * the extension still needs the value delivered. Handles the same `--flag`,
+ * `--flag value`, and `--flag=value` forms.
+ */
+function resolveCollidingFlag(
+	rawArgs: string[],
+	name: string,
+	type: "boolean" | "string",
+): boolean | string | undefined {
+	const eqPrefix = `--${name}=`;
+	for (let i = 0; i < rawArgs.length; i++) {
+		const arg = rawArgs[i];
+		if (arg === `--${name}`) {
+			if (type === "boolean") return true;
+			return i + 1 < rawArgs.length ? rawArgs[i + 1] : undefined;
+		}
+		if (arg.startsWith(eqPrefix)) {
+			return type === "boolean" ? true : arg.slice(eqPrefix.length);
+		}
+	}
+	return undefined;
+}
+
+/**
  * Resolve extension-registered CLI flags from `rawArgs` once the runner's flag
  * set is known, push the resolved values onto the runner, and return the parsed
  * {@link Args}.
@@ -22,7 +49,9 @@ export interface ExtensionFlagSink {
  * here — through the *same* {@link parseArgs} the startup pass uses, now seeded
  * with the registered flags — consumes every flag form (`--flag`, `--flag value`,
  * `--flag=value`) identically, so no form can be handled by one parser and missed
- * by another.
+ * by another. A flag whose name collides with a built-in is consumed by the
+ * built-in branch instead of `unknownFlags`, so its value is recovered via
+ * {@link resolveCollidingFlag} to preserve delivery (e.g. plan-mode's `--plan`).
  *
  * Returns `null` when there is no runner or no registered extension flags, in
  * which case the caller keeps its original startup parse (an extension-aware
@@ -34,8 +63,14 @@ export function applyExtensionFlags(runner: ExtensionFlagSink | undefined, rawAr
 		return null;
 	}
 	const parsed = parseArgs(rawArgs, extensionFlags);
-	for (const [name, value] of parsed.unknownFlags) {
-		runner.setFlagValue(name, value);
+	for (const [name, def] of extensionFlags) {
+		let value = parsed.unknownFlags.get(name);
+		if (value === undefined && BUILTIN_FLAG_NAMES.has(name)) {
+			value = resolveCollidingFlag(rawArgs, name, def.type);
+		}
+		if (value !== undefined) {
+			runner.setFlagValue(name, value);
+		}
 	}
 	return parsed;
 }

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -10,7 +10,6 @@ import type { KeyId } from "@oh-my-pi/pi-tui";
 import { hasFsCode, isEacces, isEnoent, logger } from "@oh-my-pi/pi-utils";
 import * as Zod from "zod/v4";
 import { type ExtensionModule, extensionModuleCapability } from "../../capability/extension-module";
-import { BUILTIN_FLAG_NAMES } from "../../cli/args";
 import { loadCapability } from "../../discovery";
 import { getExtensionNameFromPath } from "../../discovery/helpers";
 import type { ExecOptions } from "../../exec/exec";
@@ -181,11 +180,6 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 		name: string,
 		options: { description?: string; type: "boolean" | "string"; default?: boolean | string },
 	): void {
-		if (BUILTIN_FLAG_NAMES.has(name)) {
-			throw new Error(
-				`Extension flag "--${name}" collides with a built-in CLI flag and cannot be registered; choose a different name.`,
-			);
-		}
 		this.extension.flags.set(name, { name, extensionPath: this.extension.path, ...options });
 		if (options.default !== undefined) {
 			this.runtime.flagValues.set(name, options.default);

--- a/packages/coding-agent/src/extensibility/extensions/loader.ts
+++ b/packages/coding-agent/src/extensibility/extensions/loader.ts
@@ -10,6 +10,7 @@ import type { KeyId } from "@oh-my-pi/pi-tui";
 import { hasFsCode, isEacces, isEnoent, logger } from "@oh-my-pi/pi-utils";
 import * as Zod from "zod/v4";
 import { type ExtensionModule, extensionModuleCapability } from "../../capability/extension-module";
+import { BUILTIN_FLAG_NAMES } from "../../cli/args";
 import { loadCapability } from "../../discovery";
 import { getExtensionNameFromPath } from "../../discovery/helpers";
 import type { ExecOptions } from "../../exec/exec";
@@ -180,6 +181,11 @@ class ConcreteExtensionAPI implements ExtensionAPI, IExtensionRuntime {
 		name: string,
 		options: { description?: string; type: "boolean" | "string"; default?: boolean | string },
 	): void {
+		if (BUILTIN_FLAG_NAMES.has(name)) {
+			throw new Error(
+				`Extension flag "--${name}" collides with a built-in CLI flag and cannot be registered; choose a different name.`,
+			);
+		}
 		this.extension.flags.set(name, { name, extensionPath: this.extension.path, ...options });
 		if (options.default !== undefined) {
 			this.runtime.flagValues.set(name, options.default);

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -315,14 +315,24 @@ export class ExtensionRunner {
 		return tools;
 	}
 
-	getFlags(): Map<string, ExtensionFlag> {
+	/**
+	 * Aggregate the registered CLI flags across a set of extensions (last write
+	 * wins on name collision). Static so callers that need the flag set before a
+	 * runner exists — e.g. the CLI resolving `@file`/flag args before session
+	 * creation — share this exact logic instead of duplicating it.
+	 */
+	static aggregateFlags(extensions: readonly Extension[]): Map<string, ExtensionFlag> {
 		const allFlags = new Map<string, ExtensionFlag>();
-		for (const ext of this.extensions) {
+		for (const ext of extensions) {
 			for (const [name, flag] of ext.flags) {
 				allFlags.set(name, flag);
 			}
 		}
 		return allFlags;
+	}
+
+	getFlags(): Map<string, ExtensionFlag> {
+		return ExtensionRunner.aggregateFlags(this.extensions);
 	}
 
 	getFlagValues(): Map<string, boolean | string> {

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -21,7 +21,8 @@ import {
 	VERSION,
 } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
-import { type Args, parseArgs } from "./cli/args";
+import type { Args } from "./cli/args";
+import { applyExtensionFlags } from "./cli/extension-flags";
 import { processFileArguments } from "./cli/file-processor";
 import { buildInitialMessage } from "./cli/initial-message";
 import { runListModelsCommand } from "./cli/list-models";
@@ -171,37 +172,6 @@ export async function submitInteractiveInput(
 	}
 }
 
-function applyExtensionFlagValues(session: AgentSession, rawArgs: string[]): Map<string, boolean | string> {
-	const extensionRunner = session.extensionRunner;
-	if (!extensionRunner) {
-		return new Map();
-	}
-
-	const extFlags = extensionRunner.getFlags();
-	if (extFlags.size > 0) {
-		for (let i = 0; i < rawArgs.length; i++) {
-			const arg = rawArgs[i];
-			if (!arg.startsWith("--")) {
-				continue;
-			}
-			const flagName = arg.slice(2);
-			const extFlag = extFlags.get(flagName);
-			if (!extFlag) {
-				continue;
-			}
-			if (extFlag.type === "boolean") {
-				extensionRunner.setFlagValue(flagName, true);
-				continue;
-			}
-			if (i + 1 < rawArgs.length) {
-				extensionRunner.setFlagValue(flagName, rawArgs[++i]);
-			}
-		}
-	}
-
-	return extensionRunner.getFlagValues();
-}
-
 type AcpSessionFactory = (cwd: string) => Promise<AgentSession>;
 
 export interface AcpSessionFactoryOptions {
@@ -244,7 +214,7 @@ export function createAcpSessionFactory(args: AcpSessionFactoryOptions): AcpSess
 		if (args.parsedArgs.apiKey && !args.baseOptions.model && nextSession.model) {
 			args.authStorage.setRuntimeApiKey(nextSession.model.provider, args.parsedArgs.apiKey);
 		}
-		applyExtensionFlagValues(nextSession, args.rawArgs);
+		applyExtensionFlags(nextSession.extensionRunner, args.rawArgs);
 		return nextSession;
 	};
 }
@@ -993,9 +963,7 @@ export async function runRootCommand(
 			notifs.push({ kind: "error", message: modelRegistryError.message });
 		}
 
-		const extensionFlags = applyExtensionFlagValues(session, rawArgs);
-		const initialArgs =
-			extensionFlags.size > 0 ? parseArgs(rawArgs, session.extensionRunner?.getFlags()) : parsedArgs;
+		const initialArgs = applyExtensionFlags(session.extensionRunner, rawArgs) ?? parsedArgs;
 		const { initialMessage, initialImages } = buildInitialMessage({
 			parsed: initialArgs,
 			fileText,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -995,7 +995,7 @@ export async function runRootCommand(
 
 		const extensionFlags = applyExtensionFlagValues(session, rawArgs);
 		const initialArgs =
-			extensionFlags.size > 0 ? parseArgs([...rawArgs], session.extensionRunner?.getFlags()) : parsedArgs;
+			extensionFlags.size > 0 ? parseArgs(rawArgs, session.extensionRunner?.getFlags()) : parsedArgs;
 		const { initialMessage, initialImages } = buildInitialMessage({
 			parsed: initialArgs,
 			fileText,

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -21,7 +21,7 @@ import {
 	VERSION,
 } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
-import type { Args } from "./cli/args";
+import { type Args, parseArgs } from "./cli/args";
 import { processFileArguments } from "./cli/file-processor";
 import { buildInitialMessage } from "./cli/initial-message";
 import { runListModelsCommand } from "./cli/list-models";
@@ -830,12 +830,6 @@ export async function runRootCommand(
 		});
 		return { pipedInput, fileText: processed.text, fileImages: processed.images };
 	});
-	const { initialMessage, initialImages } = buildInitialMessage({
-		parsed: parsedArgs,
-		fileText,
-		fileImages,
-		stdinContent: pipedInput,
-	});
 	const autoPrint = pipedInput !== undefined && !parsedArgs.print && parsedArgs.mode === undefined;
 	const isInteractive = !parsedArgs.print && !autoPrint && parsedArgs.mode === undefined;
 	const mode = parsedArgs.mode || "text";
@@ -999,7 +993,15 @@ export async function runRootCommand(
 			notifs.push({ kind: "error", message: modelRegistryError.message });
 		}
 
-		applyExtensionFlagValues(session, rawArgs);
+		const extensionFlags = applyExtensionFlagValues(session, rawArgs);
+		const initialArgs =
+			extensionFlags.size > 0 ? parseArgs([...rawArgs], session.extensionRunner?.getFlags()) : parsedArgs;
+		const { initialMessage, initialImages } = buildInitialMessage({
+			parsed: initialArgs,
+			fileText,
+			fileImages,
+			stdinContent: pipedInput,
+		});
 
 		if (!isInteractive && !session.model) {
 			if (modelFallbackMessage) {
@@ -1044,7 +1046,7 @@ export async function runRootCommand(
 				changelogMarkdown,
 				notifs,
 				versionCheckPromise,
-				parsedArgs.messages,
+				initialArgs.messages,
 				setToolUIContext,
 				lspServers,
 				mcpManager,
@@ -1057,7 +1059,7 @@ export async function runRootCommand(
 		} else {
 			await runPrintMode(session, {
 				mode,
-				messages: parsedArgs.messages,
+				messages: initialArgs.messages,
 				initialMessage,
 				initialImages,
 			});

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -790,16 +790,7 @@ export async function runRootCommand(
 	if (parsedArgs.noTitle || parsedArgs.mode === "rpc" || parsedArgs.mode === "rpc-ui" || parsedArgs.mode === "acp") {
 		Bun.env.PI_NO_TITLE = "1";
 	}
-	const { pipedInput, fileText, fileImages } = await logger.time("prepareInitialMessage", async () => {
-		const pipedInput = await readPipedInput();
-		if (parsedArgs.fileArgs.length === 0) {
-			return { pipedInput, fileText: undefined, fileImages: undefined };
-		}
-		const processed = await processFileArguments(parsedArgs.fileArgs, {
-			autoResizeImages: settingsInstance.get("images.autoResize"),
-		});
-		return { pipedInput, fileText: processed.text, fileImages: processed.images };
-	});
+	const pipedInput = await logger.time("readPipedInput", readPipedInput);
 	const autoPrint = pipedInput !== undefined && !parsedArgs.print && parsedArgs.mode === undefined;
 	const isInteractive = !parsedArgs.print && !autoPrint && parsedArgs.mode === undefined;
 	const mode = parsedArgs.mode || "text";
@@ -964,10 +955,22 @@ export async function runRootCommand(
 		}
 
 		const initialArgs = applyExtensionFlags(session.extensionRunner, rawArgs) ?? parsedArgs;
+		// Process @file args from the extension-aware parse, so an extension
+		// string-flag value such as `--target @notes.md` is consumed as the flag's
+		// value rather than read as a file into the prompt. File args are not
+		// needed earlier (session setup depends only on pipedInput/mode).
+		const processedFiles =
+			initialArgs.fileArgs.length > 0
+				? await logger.time("processFileArguments", () =>
+						processFileArguments(initialArgs.fileArgs, {
+							autoResizeImages: settingsInstance.get("images.autoResize"),
+						}),
+					)
+				: undefined;
 		const { initialMessage, initialImages } = buildInitialMessage({
 			parsed: initialArgs,
-			fileText,
-			fileImages,
+			fileText: processedFiles?.text,
+			fileImages: processedFiles?.images,
 			stdinContent: pipedInput,
 		});
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -22,7 +22,7 @@ import {
 } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
 import type { Args } from "./cli/args";
-import { applyExtensionFlags } from "./cli/extension-flags";
+import { applyExtensionFlags, type ExtensionFlagSink } from "./cli/extension-flags";
 import { processFileArguments } from "./cli/file-processor";
 import { buildInitialMessage } from "./cli/initial-message";
 import { runListModelsCommand } from "./cli/list-models";
@@ -40,6 +40,7 @@ import {
 } from "./discovery/helpers";
 import { injectOmpExtensionCliRoots } from "./discovery/omp-extension-roots";
 import { exportFromFile } from "./export/html";
+import { ExtensionRunner } from "./extensibility/extensions/runner";
 import type { ExtensionUIContext } from "./extensibility/extensions/types";
 import {
 	getInstalledPluginsRegistryPath,
@@ -58,6 +59,7 @@ import {
 	type CreateAgentSessionResult,
 	createAgentSession,
 	discoverAuthStorage,
+	loadSessionExtensions,
 } from "./sdk";
 import type { AgentSession } from "./session/agent-session";
 import type { AuthStorage } from "./session/auth-storage";
@@ -66,7 +68,7 @@ import { resolvePromptInput } from "./system-prompt";
 import { AUTO_THINKING } from "./thinking";
 import type { LspStartupServerInfo } from "./tools";
 import { getChangelogPath, getNewEntries, parseChangelog } from "./utils/changelog";
-import type { EventBus } from "./utils/event-bus";
+import { EventBus } from "./utils/event-bus";
 
 async function checkForNewVersion(currentVersion: string): Promise<string | undefined> {
 	if (!settings.get("startup.checkUpdate")) {
@@ -939,26 +941,22 @@ export async function runRootCommand(
 		});
 		await (deps.runAcpMode ?? runAcpMode)(createAcpSession);
 	} else {
-		const { session, setToolUIContext, modelFallbackMessage, lspServers, mcpManager, eventBus } =
-			await createSession(sessionOptions);
-		if (parsedArgs.apiKey && !sessionOptions.model && session.model) {
-			authStorage.setRuntimeApiKey(session.model.provider, parsedArgs.apiKey);
-		}
-
-		if (modelFallbackMessage) {
-			notifs.push({ kind: "warn", message: modelFallbackMessage });
-		}
-
-		const modelRegistryError = modelRegistry.getError();
-		if (modelRegistryError) {
-			notifs.push({ kind: "error", message: modelRegistryError.message });
-		}
-
-		const initialArgs = applyExtensionFlags(session.extensionRunner, rawArgs) ?? parsedArgs;
-		// Process @file args from the extension-aware parse, so an extension
-		// string-flag value such as `--target @notes.md` is consumed as the flag's
-		// value rather than read as a file into the prompt. File args are not
-		// needed earlier (session setup depends only on pipedInput/mode).
+		// Resolve extension-registered CLI flags before creating the session so a
+		// bad `@file` fails fast WITHOUT leaving a junk session/breadcrumb
+		// (createAgentSession writes the terminal breadcrumb eagerly). Loading the
+		// extensions here also makes `@file` classification extension-aware — e.g. a
+		// string-flag value such as `--target @notes.md` is the flag's value, not a
+		// file — and the same result is handed to createAgentSession via
+		// `preloadedExtensions` so the discovery work is not repeated.
+		const eventBus = new EventBus();
+		const extensionsResult = await loadSessionExtensions(sessionOptions, cwd, settingsInstance, eventBus);
+		const extensionFlagSink: ExtensionFlagSink = {
+			getFlags: () => ExtensionRunner.aggregateFlags(extensionsResult.extensions),
+			setFlagValue: (name, value) => {
+				extensionsResult.runtime.flagValues.set(name, value);
+			},
+		};
+		const initialArgs = applyExtensionFlags(extensionFlagSink, rawArgs) ?? parsedArgs;
 		const processedFiles =
 			initialArgs.fileArgs.length > 0
 				? await logger.time("processFileArguments", () =>
@@ -973,6 +971,24 @@ export async function runRootCommand(
 			fileImages: processedFiles?.images,
 			stdinContent: pipedInput,
 		});
+
+		const { session, setToolUIContext, modelFallbackMessage, lspServers, mcpManager } = await createSession({
+			...sessionOptions,
+			eventBus,
+			preloadedExtensions: extensionsResult,
+		});
+		if (parsedArgs.apiKey && !sessionOptions.model && session.model) {
+			authStorage.setRuntimeApiKey(session.model.provider, parsedArgs.apiKey);
+		}
+
+		if (modelFallbackMessage) {
+			notifs.push({ kind: "warn", message: modelFallbackMessage });
+		}
+
+		const modelRegistryError = modelRegistry.getError();
+		if (modelRegistryError) {
+			notifs.push({ kind: "error", message: modelRegistryError.message });
+		}
 
 		if (!isInteractive && !session.model) {
 			if (modelFallbackMessage) {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -465,6 +465,44 @@ export async function discoverExtensions(cwd?: string): Promise<LoadExtensionsRe
 }
 
 /**
+ * Load the discovered/configured extensions for a session — everything {@link
+ * createAgentSession} would load except the inline factory extensions it appends
+ * itself. Extracted so the CLI can resolve extension-registered flags (and thus
+ * classify `@file` arguments extension-aware) *before* a session — and its
+ * terminal breadcrumb — is created, then hand the result back through
+ * {@link CreateAgentSessionOptions.preloadedExtensions} so the work is not
+ * repeated. Keep this the single source of the discovery branch logic.
+ */
+export async function loadSessionExtensions(
+	options: Pick<CreateAgentSessionOptions, "disableExtensionDiscovery" | "additionalExtensionPaths">,
+	cwd: string,
+	settings: Settings,
+	eventBus: EventBus,
+): Promise<LoadExtensionsResult> {
+	let result: LoadExtensionsResult;
+	if (options.disableExtensionDiscovery) {
+		const configuredPaths = options.additionalExtensionPaths ?? [];
+		result = await logger.time("loadExtensions", loadExtensions, configuredPaths, cwd, eventBus);
+	} else {
+		// Merge CLI extension paths with settings extension paths.
+		const configuredPaths = [...(options.additionalExtensionPaths ?? []), ...(settings.get("extensions") ?? [])];
+		const disabledExtensionIds = settings.get("disabledExtensions") ?? [];
+		result = await logger.time(
+			"discoverAndLoadExtensions",
+			discoverAndLoadExtensions,
+			configuredPaths,
+			cwd,
+			eventBus,
+			disabledExtensionIds,
+		);
+	}
+	for (const { path, error } of result.errors) {
+		logger.error("Failed to load extension", { path, error });
+	}
+	return result;
+}
+
+/**
  * Discover skills from cwd and agentDir.
  */
 export async function discoverSkills(
@@ -1357,32 +1395,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			inlineExtensions.push(createCustomToolsExtension(customTools));
 		}
 
-		// Load extensions (discovers from standard locations + configured paths)
-		let extensionsResult: LoadExtensionsResult;
-		if (options.disableExtensionDiscovery) {
-			const configuredPaths = options.additionalExtensionPaths ?? [];
-			extensionsResult = await logger.time("loadExtensions", loadExtensions, configuredPaths, cwd, eventBus);
-			for (const { path, error } of extensionsResult.errors) {
-				logger.error("Failed to load extension", { path, error });
-			}
-		} else if (options.preloadedExtensions) {
-			extensionsResult = options.preloadedExtensions;
-		} else {
-			// Merge CLI extension paths with settings extension paths
-			const configuredPaths = [...(options.additionalExtensionPaths ?? []), ...(settings.get("extensions") ?? [])];
-			const disabledExtensionIds = settings.get("disabledExtensions") ?? [];
-			extensionsResult = await logger.time(
-				"discoverAndLoadExtensions",
-				discoverAndLoadExtensions,
-				configuredPaths,
-				cwd,
-				eventBus,
-				disabledExtensionIds,
-			);
-			for (const { path, error } of extensionsResult.errors) {
-				logger.error("Failed to load extension", { path, error });
-			}
-		}
+		// Load extensions. A preloaded result (e.g. resolved by the CLI before
+		// session creation so it can classify `@file` args extension-aware without
+		// a session/breadcrumb existing yet) is reused as-is; otherwise discover now
+		// through the shared helper. Preloaded wins over `disableExtensionDiscovery`
+		// because the preloaded result already reflects that choice — re-running the
+		// loader here would double-load.
+		const extensionsResult: LoadExtensionsResult =
+			options.preloadedExtensions ?? (await loadSessionExtensions(options, cwd, settings, eventBus));
 
 		// Load inline extensions from factories
 		if (inlineExtensions.length > 0) {

--- a/packages/coding-agent/test/extension-flag-initial-message.test.ts
+++ b/packages/coding-agent/test/extension-flag-initial-message.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { parseArgs } from "../src/cli/args";
+import { applyExtensionFlags, type ExtensionFlagSink } from "../src/cli/extension-flags";
 import { buildInitialMessage } from "../src/cli/initial-message";
 
 // Regression coverage for extension-registered flags leaking into the initial
@@ -62,5 +63,53 @@ describe("extension flags vs initial message", () => {
 		expect(reparsed.unknownFlags.get("spawn-peer")).toBe("reviewer");
 		expect(reparsed.messages).toEqual(["review the diff"]);
 		expect(argv).toEqual(snapshot);
+	});
+});
+
+describe("applyExtensionFlags (single-parser flag resolution)", () => {
+	function fakeRunner(
+		flags: Record<string, "boolean" | "string">,
+	): ExtensionFlagSink & { values: Map<string, boolean | string> } {
+		const flagMap = new Map(
+			Object.entries(flags).map(([name, type]) => [name, { type }] as [string, { type: "boolean" | "string" }]),
+		);
+		const values = new Map<string, boolean | string>();
+		return {
+			values,
+			getFlags: () => flagMap,
+			setFlagValue: (name, value) => {
+				values.set(name, value);
+			},
+		};
+	}
+	it("returns null when there is no runner", () => {
+		expect(applyExtensionFlags(undefined, ["--spawn-peer", "x", "task"])).toBeNull();
+	});
+	it("returns null when the runner registered no flags", () => {
+		expect(applyExtensionFlags(fakeRunner({}), ["--whatever", "task"])).toBeNull();
+	});
+	it("applies and strips a string flag in space form", () => {
+		const runner = fakeRunner({ "spawn-peer": "string" });
+		const args = applyExtensionFlags(runner, ["--spawn-peer", "reviewer", "review the diff"]);
+		expect(runner.values.get("spawn-peer")).toBe("reviewer");
+		expect(args?.messages).toEqual(["review the diff"]);
+	});
+	it("applies and strips a string flag in equals form (regression for r3323133381)", () => {
+		const runner = fakeRunner({ "spawn-peer": "string" });
+		const args = applyExtensionFlags(runner, ["--spawn-peer=reviewer", "review the diff"]);
+		expect(runner.values.get("spawn-peer")).toBe("reviewer");
+		expect(args?.messages).toEqual(["review the diff"]);
+	});
+	it("applies a boolean flag without consuming the following message", () => {
+		const runner = fakeRunner({ headless: "boolean" });
+		const args = applyExtensionFlags(runner, ["--headless", "do the task"]);
+		expect(runner.values.get("headless")).toBe(true);
+		expect(args?.messages).toEqual(["do the task"]);
+	});
+	it("re-parses whenever flags are registered, even if none were passed (gate = registered presence)", () => {
+		const runner = fakeRunner({ "spawn-peer": "string" });
+		const args = applyExtensionFlags(runner, ["just a prompt"]);
+		expect(args?.messages).toEqual(["just a prompt"]);
+		expect(runner.values.size).toBe(0);
 	});
 });

--- a/packages/coding-agent/test/extension-flag-initial-message.test.ts
+++ b/packages/coding-agent/test/extension-flag-initial-message.test.ts
@@ -46,4 +46,21 @@ describe("extension flags vs initial message", () => {
 		const { initialMessage } = buildInitialMessage({ parsed, stdinContent: "diff-context" });
 		expect(initialMessage).toBe("diff-context\nreviewer");
 	});
+	it("does not mutate the input argv, so the same array survives the two-pass parse (PR #1503 review)", () => {
+		// Reproduces the --option=value + extension flag combo: parseArgs splices
+		// the `=` value into its argv to reuse the `args[++i]` path. If it mutated
+		// the caller's array, the second (extension-aware) parse would re-splice
+		// and `sonnet` would leak into the prompt before "review the diff".
+		const argv = ["--model=sonnet", "--spawn-peer", "reviewer", "review the diff"];
+		const snapshot = [...argv];
+		// First pass: startup parse, before extensions load.
+		parseArgs(argv);
+		expect(argv).toEqual(snapshot);
+		// Second pass: extension-aware reparse on the same array.
+		const reparsed = parseArgs(argv, extFlags);
+		expect(reparsed.model).toBe("sonnet");
+		expect(reparsed.unknownFlags.get("spawn-peer")).toBe("reviewer");
+		expect(reparsed.messages).toEqual(["review the diff"]);
+		expect(argv).toEqual(snapshot);
+	});
 });

--- a/packages/coding-agent/test/extension-flag-initial-message.test.ts
+++ b/packages/coding-agent/test/extension-flag-initial-message.test.ts
@@ -158,21 +158,30 @@ describe("applyExtensionFlags (single-parser flag resolution)", () => {
 		expect(args?.messages).toEqual(["just a prompt"]);
 		expect(runner.values.size).toBe(0);
 	});
-});
-describe("registerFlag built-in collision guard (P2#3)", () => {
-	it("rejects an extension flag that shadows a built-in CLI flag", async () => {
-		await expect(
-			loadExtensionFromFactory(
-				api => {
-					api.registerFlag("model", { type: "string" });
-				},
-				process.cwd(),
-				new EventBus(),
-				new ExtensionRuntime(),
-			),
-		).rejects.toThrow(/collides with a built-in/);
+	it("delivers a built-in-colliding flag's value to the runner (preserves plan-mode --plan)", () => {
+		const runner = fakeRunner({ plan: "boolean" });
+		applyExtensionFlags(runner, ["--plan", "do the task"]);
+		expect(runner.values.get("plan")).toBe(true);
 	});
-	it("allows a non-colliding extension flag", async () => {
+	it("does not deliver a colliding flag that was not passed", () => {
+		const runner = fakeRunner({ plan: "boolean" });
+		applyExtensionFlags(runner, ["just a prompt"]);
+		expect(runner.values.has("plan")).toBe(false);
+	});
+});
+describe("registerFlag with built-in-named flags (r3323473227)", () => {
+	it("loads an extension that registers a built-in-named flag without throwing", async () => {
+		const ext = await loadExtensionFromFactory(
+			api => {
+				api.registerFlag("plan", { type: "boolean", default: false });
+			},
+			process.cwd(),
+			new EventBus(),
+			new ExtensionRuntime(),
+		);
+		expect(ext.flags.has("plan")).toBe(true);
+	});
+	it("loads a non-colliding extension flag", async () => {
 		const ext = await loadExtensionFromFactory(
 			api => {
 				api.registerFlag("spawn-peer", { type: "string" });

--- a/packages/coding-agent/test/extension-flag-initial-message.test.ts
+++ b/packages/coding-agent/test/extension-flag-initial-message.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { parseArgs } from "../src/cli/args";
+import { buildInitialMessage } from "../src/cli/initial-message";
+
+// Regression coverage for extension-registered flags leaking into the initial
+// prompt. The CLI parses argv twice: once at startup (before extensions load,
+// so their flag set is unknown) and once after the extension runner is ready.
+// `buildInitialMessage` must run on the second, extension-aware parse.
+describe("extension flags vs initial message", () => {
+	const extFlags = new Map<string, { type: "boolean" | "string" }>([
+		["spawn-peer", { type: "string" }],
+		["headless", { type: "boolean" }],
+	]);
+
+	it("consumes a string extension flag's value instead of leaking it into messages", () => {
+		const parsed = parseArgs(["--spawn-peer", "reviewer", "review the diff"], extFlags);
+
+		expect(parsed.unknownFlags.get("spawn-peer")).toBe("reviewer");
+		expect(parsed.messages).toEqual(["review the diff"]);
+	});
+
+	it("consumes a boolean extension flag without eating the following message", () => {
+		const parsed = parseArgs(["--headless", "do the task"], extFlags);
+
+		expect(parsed.unknownFlags.get("headless")).toBe(true);
+		expect(parsed.messages).toEqual(["do the task"]);
+	});
+
+	it("builds the initial prompt from the real message, not the flag value, when flags are known", () => {
+		const parsed = parseArgs(["--spawn-peer", "reviewer", "review the diff"], extFlags);
+
+		const { initialMessage } = buildInitialMessage({ parsed, stdinContent: "diff-context" });
+
+		expect(initialMessage).toBe("diff-context\nreview the diff");
+	});
+
+	it("documents the pre-fix leak: without the flag map the value becomes the first prompt", () => {
+		// This is exactly the startup parse: extensions have not loaded, so the
+		// flag map is absent. `--spawn-peer` is dropped (it starts with `-`) but
+		// its bare value `reviewer` is mis-read as the first positional message.
+		// Re-parsing with the extension flag map is what corrects this.
+		const parsed = parseArgs(["--spawn-peer", "reviewer", "review the diff"]);
+
+		expect(parsed.messages).toEqual(["reviewer", "review the diff"]);
+
+		const { initialMessage } = buildInitialMessage({ parsed, stdinContent: "diff-context" });
+		expect(initialMessage).toBe("diff-context\nreviewer");
+	});
+});

--- a/packages/coding-agent/test/extension-flag-initial-message.test.ts
+++ b/packages/coding-agent/test/extension-flag-initial-message.test.ts
@@ -3,6 +3,7 @@ import { parseArgs } from "../src/cli/args";
 import { applyExtensionFlags, type ExtensionFlagSink } from "../src/cli/extension-flags";
 import { buildInitialMessage } from "../src/cli/initial-message";
 import { ExtensionRuntime, loadExtensionFromFactory } from "../src/extensibility/extensions/loader";
+import { ExtensionRunner } from "../src/extensibility/extensions/runner";
 import { EventBus } from "../src/utils/event-bus";
 
 // Regression coverage for extension-registered flags leaking into the initial
@@ -168,6 +169,23 @@ describe("applyExtensionFlags (single-parser flag resolution)", () => {
 		applyExtensionFlags(runner, ["just a prompt"]);
 		expect(runner.values.has("plan")).toBe(false);
 	});
+	it("recovers any colliding built-in flag's value, with no hardcoded name list (--model)", () => {
+		// `--model` is a built-in string flag never present in the removed
+		// BUILTIN_FLAG_NAMES-style list lookup: parseArgs routes it to the built-in
+		// branch so it never reaches unknownFlags, yet recovery must still deliver
+		// it purely by scanning argv.
+		const runner = fakeRunner({ model: "string" });
+		applyExtensionFlags(runner, ["--model", "haiku", "do the task"]);
+		expect(runner.values.get("model")).toBe("haiku");
+	});
+	it("does not recover a non-colliding flag-looking value in space form (mirrors parseArgs P1#2)", () => {
+		// The recovery scan honors parseArgs's rule: a flag-looking value in space
+		// form stays its own flag in both passes, so it must not be swallowed as the
+		// extension flag's value (pass it as --flag=value instead).
+		const runner = fakeRunner({ "spawn-peer": "string" });
+		applyExtensionFlags(runner, ["--spawn-peer", "--print", "do the task"]);
+		expect(runner.values.has("spawn-peer")).toBe(false);
+	});
 });
 describe("registerFlag with built-in-named flags (r3323473227)", () => {
 	it("loads an extension that registers a built-in-named flag without throwing", async () => {
@@ -191,5 +209,39 @@ describe("registerFlag with built-in-named flags (r3323473227)", () => {
 			new ExtensionRuntime(),
 		);
 		expect(ext.flags.has("spawn-peer")).toBe(true);
+	});
+	it("resolves extension flags from a pre-session load (main.ts @file-before-session pattern)", async () => {
+		// main.ts now loads extensions and resolves their flags BEFORE creating the
+		// session (and its breadcrumb), building an ExtensionFlagSink straight from
+		// the loaded extensions + runtime with no ExtensionRunner/session yet. Prove
+		// that exact pattern resolves flag values and classifies `@file` args
+		// extension-aware — the reason file processing can safely run pre-session.
+		const runtime = new ExtensionRuntime();
+		const ext = await loadExtensionFromFactory(
+			api => {
+				api.registerFlag("spawn-peer", { type: "string" });
+			},
+			process.cwd(),
+			new EventBus(),
+			runtime,
+		);
+		const sink: ExtensionFlagSink = {
+			getFlags: () => ExtensionRunner.aggregateFlags([ext]),
+			setFlagValue: (name, value) => {
+				runtime.flagValues.set(name, value);
+			},
+		};
+
+		const args = applyExtensionFlags(sink, ["--spawn-peer", "reviewer", "review the diff"]);
+		expect(runtime.flagValues.get("spawn-peer")).toBe("reviewer");
+		expect(args?.messages).toEqual(["review the diff"]);
+
+		// A string flag's `@`-value is the flag's value, not a file arg (P1#1) — so
+		// classifying it requires this extension-aware parse, which is only possible
+		// once the flag set is known before the session exists.
+		const withFileLikeValue = applyExtensionFlags(sink, ["--spawn-peer", "@notes.md", "hello"]);
+		expect(runtime.flagValues.get("spawn-peer")).toBe("@notes.md");
+		expect(withFileLikeValue?.fileArgs).toEqual([]);
+		expect(withFileLikeValue?.messages).toEqual(["hello"]);
 	});
 });

--- a/packages/coding-agent/test/extension-flag-initial-message.test.ts
+++ b/packages/coding-agent/test/extension-flag-initial-message.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "bun:test";
 import { parseArgs } from "../src/cli/args";
 import { applyExtensionFlags, type ExtensionFlagSink } from "../src/cli/extension-flags";
 import { buildInitialMessage } from "../src/cli/initial-message";
+import { ExtensionRuntime, loadExtensionFromFactory } from "../src/extensibility/extensions/loader";
+import { EventBus } from "../src/utils/event-bus";
 
 // Regression coverage for extension-registered flags leaking into the initial
 // prompt. The CLI parses argv twice: once at startup (before extensions load,
@@ -35,6 +37,34 @@ describe("extension flags vs initial message", () => {
 		const parsed = parseArgs(["--no-tools=true", "do the task"]);
 		expect(parsed.noTools).toBe(true);
 		expect(parsed.messages).toEqual(["do the task"]);
+	});
+	it("does not consume a flag-looking string value in space form, keeping command shape (P1#2)", () => {
+		// `--print` after an extension flag (unknown at startup) must stay the
+		// built-in print flag in BOTH parses, so the reparse cannot silently flip
+		// command behavior. Flag-looking values must be passed as `--flag=value`.
+		const parsed = parseArgs(["--spawn-peer", "--print", "hello"], extFlags);
+		expect(parsed.unknownFlags.has("spawn-peer")).toBe(false);
+		expect(parsed.print).toBe(true);
+		expect(parsed.messages).toEqual(["hello"]);
+	});
+	it("consumes a flag-looking string value in equals form", () => {
+		const parsed = parseArgs(["--spawn-peer=--print", "hello"], extFlags);
+		expect(parsed.unknownFlags.get("spawn-peer")).toBe("--print");
+		expect(parsed.print).toBeUndefined();
+		expect(parsed.messages).toEqual(["hello"]);
+	});
+	it("treats an @-prefixed string value as the flag's value, not a file arg (P1#1)", () => {
+		const parsed = parseArgs(["--spawn-peer", "@notes.md", "hello"], extFlags);
+		expect(parsed.unknownFlags.get("spawn-peer")).toBe("@notes.md");
+		expect(parsed.fileArgs).toEqual([]);
+		expect(parsed.messages).toEqual(["hello"]);
+	});
+	it("documents the P1#1 startup-parse leak: without flags, an @-value is misread as a file arg", () => {
+		// This is the startup parse (extensions not loaded). `runRootCommand` must
+		// run processFileArguments on the extension-aware parse, not this one, or
+		// `@notes.md` gets read into the prompt as a file.
+		const parsed = parseArgs(["--spawn-peer", "@notes.md", "hello"]);
+		expect(parsed.fileArgs).toEqual(["notes.md"]);
 	});
 
 	it("builds the initial prompt from the real message, not the flag value, when flags are known", () => {
@@ -127,5 +157,30 @@ describe("applyExtensionFlags (single-parser flag resolution)", () => {
 		const args = applyExtensionFlags(runner, ["just a prompt"]);
 		expect(args?.messages).toEqual(["just a prompt"]);
 		expect(runner.values.size).toBe(0);
+	});
+});
+describe("registerFlag built-in collision guard (P2#3)", () => {
+	it("rejects an extension flag that shadows a built-in CLI flag", async () => {
+		await expect(
+			loadExtensionFromFactory(
+				api => {
+					api.registerFlag("model", { type: "string" });
+				},
+				process.cwd(),
+				new EventBus(),
+				new ExtensionRuntime(),
+			),
+		).rejects.toThrow(/collides with a built-in/);
+	});
+	it("allows a non-colliding extension flag", async () => {
+		const ext = await loadExtensionFromFactory(
+			api => {
+				api.registerFlag("spawn-peer", { type: "string" });
+			},
+			process.cwd(),
+			new EventBus(),
+			new ExtensionRuntime(),
+		);
+		expect(ext.flags.has("spawn-peer")).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/extension-flag-initial-message.test.ts
+++ b/packages/coding-agent/test/extension-flag-initial-message.test.ts
@@ -26,6 +26,16 @@ describe("extension flags vs initial message", () => {
 		expect(parsed.unknownFlags.get("headless")).toBe(true);
 		expect(parsed.messages).toEqual(["do the task"]);
 	});
+	it("drops a boolean extension flag's value in equals form (no leak into messages)", () => {
+		const parsed = parseArgs(["--headless=true", "do the task"], extFlags);
+		expect(parsed.unknownFlags.get("headless")).toBe(true);
+		expect(parsed.messages).toEqual(["do the task"]);
+	});
+	it("drops a built-in boolean flag's value in equals form too", () => {
+		const parsed = parseArgs(["--no-tools=true", "do the task"]);
+		expect(parsed.noTools).toBe(true);
+		expect(parsed.messages).toEqual(["do the task"]);
+	});
 
 	it("builds the initial prompt from the real message, not the flag value, when flags are known", () => {
 		const parsed = parseArgs(["--spawn-peer", "reviewer", "review the diff"], extFlags);
@@ -103,6 +113,12 @@ describe("applyExtensionFlags (single-parser flag resolution)", () => {
 	it("applies a boolean flag without consuming the following message", () => {
 		const runner = fakeRunner({ headless: "boolean" });
 		const args = applyExtensionFlags(runner, ["--headless", "do the task"]);
+		expect(runner.values.get("headless")).toBe(true);
+		expect(args?.messages).toEqual(["do the task"]);
+	});
+	it("drops a boolean flag's value in equals form (regression for r3323200058)", () => {
+		const runner = fakeRunner({ headless: "boolean" });
+		const args = applyExtensionFlags(runner, ["--headless=true", "do the task"]);
 		expect(runner.values.get("headless")).toBe(true);
 		expect(args?.messages).toEqual(["do the task"]);
 	});


### PR DESCRIPTION
## Problem

The root command parses `argv` twice — once at startup (before extensions load, so their registered flag set is unknown) and once after the extension runner is ready. `buildInitialMessage` was reading the **first**, extension-unaware parse.

For a string-valued extension flag this leaks the flag's value into the prompt:

```
omp --spawn-peer reviewer "review the diff"
```

sends `reviewer` as the first message instead of `review the diff`. In `parseArgs`, the `--spawn-peer` token is dropped (it starts with `-` and the extension flag map is absent on the first pass), but its bare value `reviewer` falls through to the positional-message branch and becomes `messages[0]`.

## Fix

Build the initial message from args **re-parsed with the extension flag map** (`session.extensionRunner.getFlags()`) whenever any extension flag was applied, so the flag *and its value* are consumed before the prompt is assembled. The re-parse is skipped entirely when no extension flags were applied, so there is no behavior change for sessions without flag-registering extensions.

The fix is generic across any flag-registering extension; it is not specific to any one extension.

## Testing

Adds `test/extension-flag-initial-message.test.ts` covering the `parseArgs` → `buildInitialMessage` pipeline:
- string extension flag consumes its value (not leaked into `messages`)
- boolean extension flag consumed without eating the following message
- initial prompt is built from the real message when flags are known
- documents the pre-fix leak that the second parse corrects

```
bun test test/extension-flag-initial-message.test.ts test/initial-message.test.ts
# 6 pass, 0 fail
```
