### PR TITLE
fix(coding-agent): enforce configured model scopes

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -372,7 +372,7 @@ So a model can exist in registry but not be selectable until auth is available.
 - exact canonical model id
 - exact model id (provider inferred)
 - fuzzy/substring matching
-- glob scope patterns in `--models` (e.g. `openai/*`, `*sonnet*`)
+- glob allow-list patterns in `--models` (e.g. `openai/*`, `*sonnet*`)
 - optional `:thinkingLevel` suffix (`off|minimal|low|medium|high|xhigh`)
 
 `--provider` is legacy; `--model` is preferred.
@@ -386,7 +386,9 @@ Resolution precedence for exact selectors:
 
 ### Initial model selection priority
 
-`findInitialModel(...)` uses this order:
+When `--models` or `enabledModels` defines a scope, model resolution is limited to that scope. Explicit `--model`, restored session models, role aliases, subagents, retry fallbacks, compaction fallbacks, context promotion, and model picker/RPC/ACP switches cannot select models outside it.
+
+`findInitialModel(...)` uses this order within the active scope:
 
 1. explicit CLI provider+model
 2. first scoped model (if not resuming)
@@ -422,6 +424,7 @@ For `enabledModels` and CLI `--models`:
 - exact canonical ids expand to all concrete variants in that canonical group
 - explicit `provider/modelId` entries stay exact
 - globs and fuzzy matches still operate on concrete models
+- matching models form a session allow-list, not only a cycling/menu list
 
 Global `enabledModels` and `disabledProviders` entries may also be scoped to a path prefix:
 

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -165,6 +165,8 @@ When no explicit `model`/`modelPattern` is provided:
 2. settings default model role (`default`)
 3. first available model with valid auth
 
+When `scopedModels` is provided, restore/default/fallback resolution and later model switches are limited to that list.
+
 If restore fails, `modelFallbackMessage` explains fallback.
 
 ### Auth priority

--- a/docs/tools/inspect_image.md
+++ b/docs/tools/inspect_image.md
@@ -39,8 +39,8 @@ TUI rendering adds presentation-only truncation from `packages/coding-agent/src/
 
 ## Flow
 1. `InspectImageTool.execute(...)` rejects immediately if `images.blockImages` is enabled in session settings.
-2. It reads `session.modelRegistry`; missing registry, empty registry, missing API key, or unresolved model each raise `ToolError` from `packages/coding-agent/src/tools/inspect-image.ts`.
-3. Model selection tries, in order, `pi/vision`, `pi/default`, the active model string from the session, then `availableModels[0]`. `expandRoleAlias(...)` and `resolveModelFromString(...)` handle each lookup.
+2. It reads `session.modelRegistry`; missing registry, empty scoped registry, missing API key, or unresolved model each raise `ToolError` from `packages/coding-agent/src/tools/inspect-image.ts`.
+3. Model selection tries, in order, `pi/vision`, `pi/default`, the active model string from the session, then `availableModels[0]`. The candidates come from `session.getAvailableModels()` when present, so `--models` / `enabledModels` scope is enforced. `expandRoleAlias(...)` and `resolveModelFromString(...)` handle each lookup.
 4. The chosen model must advertise `input.includes("image")`; otherwise execution fails before reading the file.
 5. `loadImageInput(...)` in `packages/coding-agent/src/utils/image-loading.ts` resolves the path with `resolveReadPath(...)`, detects MIME type with `readImageMetadata(...)`, and rejects files larger than `MAX_IMAGE_INPUT_BYTES` (`20 * 1024 * 1024`, 20 MiB) using `ImageInputTooLargeError`.
 6. `readImageMetadata(...)` in `packages/utils/src/mime.ts` inspects file headers only. Supported detected MIME types are `image/png`, `image/jpeg`, `image/gif`, and `image/webp`.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `--models` session scopes leaking through automatic model selection. Scoped sessions now keep startup defaults, role switches, task subagents, retry/compaction/context fallbacks, RPC/ACP model changes, and helper model selection inside the resolved scope. This completes the earlier selector-only scope behavior ([#255](https://github.com/badlogic/pi-mono/issues/255)) and aligns CLI scoping with the `enabledModels` fallback fix ([#1022](https://github.com/can1357/oh-my-pi/issues/1022)) plus prior subagent model-routing fixes ([#985](https://github.com/can1357/oh-my-pi/issues/985), [#1008](https://github.com/can1357/oh-my-pi/issues/1008)).
+- Fixed `--models` session scopes leaking through automatic model selection. Scoped sessions now keep startup defaults, role switches, task subagents, retry/compaction/context fallbacks, RPC/ACP model changes, helper model selection, and OpenRouter routed suffix selectors inside the resolved scope. This completes the earlier selector-only scope behavior ([#255](https://github.com/badlogic/pi-mono/issues/255)) and aligns CLI scoping with the `enabledModels` fallback fix ([#1022](https://github.com/can1357/oh-my-pi/issues/1022)) plus prior subagent model-routing fixes ([#985](https://github.com/can1357/oh-my-pi/issues/985), [#1008](https://github.com/can1357/oh-my-pi/issues/1008)).
 
 ## [15.7.4] - 2026-05-31
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `--models` session scopes leaking through automatic model selection. Scoped sessions now keep startup defaults, role switches, task subagents, retry/compaction/context fallbacks, RPC/ACP model changes, and helper model selection inside the resolved scope. This completes the earlier selector-only scope behavior ([#255](https://github.com/badlogic/pi-mono/issues/255)) and aligns CLI scoping with the `enabledModels` fallback fix ([#1022](https://github.com/can1357/oh-my-pi/issues/1022)) plus prior subagent model-routing fixes ([#985](https://github.com/can1357/oh-my-pi/issues/985), [#1008](https://github.com/can1357/oh-my-pi/issues/1008)).
+
 ## [15.7.4] - 2026-05-31
 
 ### Removed

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -72,7 +72,7 @@ export default class Index extends Command {
 			description: "Don't save session (ephemeral)",
 		}),
 		models: Flags.string({
-			description: "Comma-separated model patterns for Ctrl+P cycling",
+			description: "Comma-separated model patterns allowed for this session; Ctrl+P cycles within the scope",
 		}),
 		"no-tools": Flags.boolean({
 			description: "Disable all built-in tools",
@@ -145,7 +145,7 @@ export default class Index extends Command {
 		`# Non-interactive mode (process and exit)\n  ${APP_NAME} -p "List all .ts files in src/"`,
 		`# Continue previous session\n  ${APP_NAME} --continue "What did we discuss?"`,
 		`# Use different model (fuzzy matching)\n  ${APP_NAME} --model opus "Help me refactor this code"`,
-		`# Limit model cycling to specific models\n  ${APP_NAME} --models claude-sonnet,claude-haiku,gpt-4o`,
+		`# Restrict the session to specific models\n  ${APP_NAME} --models claude-sonnet,claude-haiku,gpt-4o`,
 		`# Export a session file to HTML\n  ${APP_NAME} --export ~/.omp/agent/sessions/--path--/session.jsonl`,
 	];
 

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -33,6 +33,52 @@ export interface ModelScopeEntry {
 	model: Model<Api>;
 }
 
+function getModelKey(model: Model<Api>): string {
+	return `${model.provider}/${model.id}`;
+}
+
+interface ResolvedScopedModel<T extends Model<Api>> {
+	model: T;
+	key: string;
+	candidateIndex: number;
+	scopeIndex: number;
+}
+
+function findScopedModelCandidateIndex<T extends Model<Api>>(
+	models: readonly T[],
+	scoped: ModelScopeEntry,
+	resolved: T,
+): number {
+	const exactIndex = models.findIndex(candidate => modelsAreEqual(candidate, resolved));
+	if (exactIndex !== -1) return exactIndex;
+
+	return models.findIndex(candidate => {
+		const resolvedFromCandidate = resolveProviderModelReference(scoped.model.provider, scoped.model.id, [candidate]);
+		return modelsAreEqual(resolvedFromCandidate, resolved);
+	});
+}
+
+function resolveScopedModels<T extends Model<Api>>(
+	models: readonly T[],
+	scopedModels: readonly ModelScopeEntry[],
+): ResolvedScopedModel<T>[] {
+	const resolved: ResolvedScopedModel<T>[] = [];
+	for (let scopeIndex = 0; scopeIndex < scopedModels.length; scopeIndex += 1) {
+		const scoped = scopedModels[scopeIndex];
+		const model = resolveProviderModelReference(scoped.model.provider, scoped.model.id, models);
+		if (!model) continue;
+		const candidateIndex = findScopedModelCandidateIndex(models, scoped, model);
+		if (candidateIndex === -1) continue;
+		resolved.push({
+			model,
+			key: getModelKey(model),
+			candidateIndex,
+			scopeIndex,
+		});
+	}
+	return resolved;
+}
+
 export function isModelInScope(model: Model<Api>, scopedModels: readonly ModelScopeEntry[] | undefined): boolean {
 	if (scopedModels === undefined) return true;
 	return scopedModels.some(scoped => modelsAreEqual(scoped.model, model));
@@ -43,7 +89,18 @@ export function filterModelsByScope<T extends Model<Api>>(
 	scopedModels: readonly ModelScopeEntry[] | undefined,
 ): T[] {
 	if (scopedModels === undefined) return [...models];
-	return models.filter(model => isModelInScope(model, scopedModels));
+	const result: T[] = [];
+	const seen = new Set<string>();
+	const resolved = resolveScopedModels(models, scopedModels).sort((a, b) => {
+		if (a.candidateIndex !== b.candidateIndex) return a.candidateIndex - b.candidateIndex;
+		return a.scopeIndex - b.scopeIndex;
+	});
+	for (const entry of resolved) {
+		if (seen.has(entry.key)) continue;
+		seen.add(entry.key);
+		result.push(entry.model);
+	}
+	return result;
 }
 
 export function filterModelsByScopeOrder<T extends Model<Api>>(
@@ -51,19 +108,12 @@ export function filterModelsByScopeOrder<T extends Model<Api>>(
 	scopedModels: readonly ModelScopeEntry[] | undefined,
 ): T[] {
 	if (scopedModels === undefined) return [...models];
-	const candidatesByKey = new Map<string, T>();
-	for (const model of models) {
-		candidatesByKey.set(`${model.provider}/${model.id}`, model);
-	}
 	const result: T[] = [];
 	const seen = new Set<string>();
-	for (const scoped of scopedModels) {
-		const key = `${scoped.model.provider}/${scoped.model.id}`;
-		if (seen.has(key)) continue;
-		const candidate = candidatesByKey.get(key);
-		if (!candidate) continue;
-		seen.add(key);
-		result.push(candidate);
+	for (const entry of resolveScopedModels(models, scopedModels)) {
+		if (seen.has(entry.key)) continue;
+		seen.add(entry.key);
+		result.push(entry.model);
 	}
 	return result;
 }
@@ -101,7 +151,7 @@ export function parseModelString(
  * Format a model as "provider/modelId" string.
  */
 export function formatModelString(model: Model<Api>): string {
-	return `${model.provider}/${model.id}`;
+	return getModelKey(model);
 }
 
 export function formatModelSelectorValue(selector: string, thinkingLevel: ThinkingLevel | undefined): string {
@@ -162,7 +212,7 @@ function getOpenRouterFallbackModelIds(modelId: string): string[] {
 	return orderedCandidates;
 }
 
-function cloneModelWithRequestedId(model: Model<Api>, requestedId: string): Model<Api> {
+function cloneModelWithRequestedId<T extends Model<Api>>(model: T, requestedId: string): T {
 	return {
 		...model,
 		id: requestedId,
@@ -171,15 +221,15 @@ function cloneModelWithRequestedId(model: Model<Api>, requestedId: string): Mode
 }
 
 const kProviderModelIndex = Symbol("model-resolver.providerIndex");
-type ModelsWithProviderIndex = readonly Model<Api>[] & {
-	[kProviderModelIndex]?: Map<string, Model<Api> | null>;
+type ModelsWithProviderIndex<T extends Model<Api>> = readonly T[] & {
+	[kProviderModelIndex]?: Map<string, T | null>;
 };
 
-function getProviderModelIndex(availableModels: readonly Model<Api>[]): Map<string, Model<Api> | null> {
-	const tagged = availableModels as ModelsWithProviderIndex;
+function getProviderModelIndex<T extends Model<Api>>(availableModels: readonly T[]): Map<string, T | null> {
+	const tagged = availableModels as ModelsWithProviderIndex<T>;
 	const cached = tagged[kProviderModelIndex];
 	if (cached) return cached;
-	const index = new Map<string, Model<Api> | null>();
+	const index = new Map<string, T | null>();
 	for (const m of availableModels) {
 		const key = `${m.provider.toLowerCase()}\u0000${m.id.toLowerCase()}`;
 		if (index.has(key)) {
@@ -192,11 +242,11 @@ function getProviderModelIndex(availableModels: readonly Model<Api>[]): Map<stri
 	return index;
 }
 
-export function resolveProviderModelReference(
+export function resolveProviderModelReference<T extends Model<Api>>(
 	provider: string,
 	modelId: string,
-	availableModels: readonly Model<Api>[],
-): Model<Api> | undefined {
+	availableModels: readonly T[],
+): T | undefined {
 	const normalizedProvider = provider.trim().toLowerCase();
 	const normalizedModelId = modelId.trim().toLowerCase();
 	if (!normalizedProvider || !normalizedModelId) {

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -29,6 +29,51 @@ export interface ScopedModel {
 	explicitThinkingLevel: boolean;
 }
 
+export interface ModelScopeEntry {
+	model: Model<Api>;
+}
+
+export function isModelInScope(model: Model<Api>, scopedModels: readonly ModelScopeEntry[] | undefined): boolean {
+	if (scopedModels === undefined) return true;
+	return scopedModels.some(scoped => modelsAreEqual(scoped.model, model));
+}
+
+export function filterModelsByScope<T extends Model<Api>>(
+	models: readonly T[],
+	scopedModels: readonly ModelScopeEntry[] | undefined,
+): T[] {
+	if (scopedModels === undefined) return [...models];
+	return models.filter(model => isModelInScope(model, scopedModels));
+}
+
+export function filterModelsByScopeOrder<T extends Model<Api>>(
+	models: readonly T[],
+	scopedModels: readonly ModelScopeEntry[] | undefined,
+): T[] {
+	if (scopedModels === undefined) return [...models];
+	const candidatesByKey = new Map<string, T>();
+	for (const model of models) {
+		candidatesByKey.set(`${model.provider}/${model.id}`, model);
+	}
+	const result: T[] = [];
+	const seen = new Set<string>();
+	for (const scoped of scopedModels) {
+		const key = `${scoped.model.provider}/${scoped.model.id}`;
+		if (seen.has(key)) continue;
+		const candidate = candidatesByKey.get(key);
+		if (!candidate) continue;
+		seen.add(key);
+		result.push(candidate);
+	}
+	return result;
+}
+
+export function formatModelScope(scopedModels: readonly ModelScopeEntry[] | undefined): string {
+	if (scopedModels === undefined) return "all available models";
+	if (scopedModels.length === 0) return "no models";
+	return scopedModels.map(scoped => formatModelString(scoped.model)).join(", ");
+}
+
 /**
  * Parse a model string in "provider/modelId" format.
  * Returns undefined if the format is invalid.
@@ -61,6 +106,14 @@ export function formatModelString(model: Model<Api>): string {
 
 export function formatModelSelectorValue(selector: string, thinkingLevel: ThinkingLevel | undefined): string {
 	return thinkingLevel && thinkingLevel !== ThinkingLevel.Inherit ? `${selector}:${thinkingLevel}` : selector;
+}
+
+function containsGlobCharacters(pattern: string): boolean {
+	return pattern.includes("*") || pattern.includes("?") || pattern.includes("[");
+}
+
+function shouldMatchBareModelIdForGlob(pattern: string): boolean {
+	return !pattern.includes("/");
 }
 
 function getOpenRouterRouteSuffix(modelId: string): { baseId: string; suffix: string } | undefined {
@@ -181,6 +234,10 @@ export interface ModelMatchPreferences {
 	usageOrder?: string[];
 	/** Providers to deprioritize when no recent usage is available. */
 	deprioritizeProviders?: string[];
+}
+
+export interface ResolveModelScopeOptions {
+	warnOnNoMatch?: boolean;
 }
 
 export type CanonicalModelRegistry = Partial<
@@ -717,9 +774,10 @@ export function resolveModelOverride(
 	modelPatterns: string[],
 	modelRegistry: ModelLookupRegistry,
 	settings?: Settings,
+	scopedModels?: readonly ModelScopeEntry[],
 ): { model?: Model<Api>; thinkingLevel?: ThinkingLevel; explicitThinkingLevel: boolean } {
 	if (modelPatterns.length === 0) return { explicitThinkingLevel: false };
-	const availableModels = modelRegistry.getAvailable();
+	const availableModels = filterModelsByScope(modelRegistry.getAvailable(), scopedModels);
 	const matchPreferences = { usageOrder: settings?.getStorage()?.getModelUsageOrder() };
 	for (const pattern of modelPatterns) {
 		const { model, thinkingLevel, explicitThinkingLevel } = resolveModelRoleValue(pattern, availableModels, {
@@ -760,14 +818,35 @@ export async function resolveModelOverrideWithAuthFallback(
 	parentActiveModelPattern: string | undefined,
 	modelRegistry: ModelLookupRegistry & Pick<ModelRegistry, "getApiKey">,
 	settings?: Settings,
+	scopedModels?: readonly ModelScopeEntry[],
 ): Promise<{
 	model?: Model<Api>;
 	thinkingLevel?: ThinkingLevel;
 	explicitThinkingLevel: boolean;
 	authFallbackUsed: boolean;
+	fallbackReason?: "auth" | "scope";
 }> {
-	const primary = resolveModelOverride(modelPatterns, modelRegistry, settings);
-	if (!primary.model || !parentActiveModelPattern) {
+	const primary = resolveModelOverride(modelPatterns, modelRegistry, settings, scopedModels);
+	if (!primary.model) {
+		if (scopedModels === undefined || !parentActiveModelPattern) {
+			return { ...primary, authFallbackUsed: false };
+		}
+		const unscopedPrimary = resolveModelOverride(modelPatterns, modelRegistry, settings);
+		if (!unscopedPrimary.model) {
+			return { ...primary, authFallbackUsed: false };
+		}
+		const fallback = resolveModelOverride([parentActiveModelPattern], modelRegistry, settings, scopedModels);
+		if (!fallback.model) {
+			return { ...primary, authFallbackUsed: false };
+		}
+		const fallbackKey = await modelRegistry.getApiKey(fallback.model);
+		if (fallbackKey !== kNoAuth && !isAuthenticated(fallbackKey)) {
+			return { ...primary, authFallbackUsed: false };
+		}
+		return { ...fallback, authFallbackUsed: false, fallbackReason: "scope" };
+	}
+
+	if (!parentActiveModelPattern) {
 		return { ...primary, authFallbackUsed: false };
 	}
 
@@ -776,7 +855,7 @@ export async function resolveModelOverrideWithAuthFallback(
 		return { ...primary, authFallbackUsed: false };
 	}
 
-	const fallback = resolveModelOverride([parentActiveModelPattern], modelRegistry, settings);
+	const fallback = resolveModelOverride([parentActiveModelPattern], modelRegistry, settings, scopedModels);
 	if (!fallback.model) {
 		return { ...primary, authFallbackUsed: false };
 	}
@@ -784,11 +863,11 @@ export async function resolveModelOverrideWithAuthFallback(
 		return { ...primary, authFallbackUsed: false };
 	}
 	const fallbackKey = await modelRegistry.getApiKey(fallback.model);
-	if (!isAuthenticated(fallbackKey)) {
+	if (fallbackKey !== kNoAuth && !isAuthenticated(fallbackKey)) {
 		return { ...primary, authFallbackUsed: false };
 	}
 
-	return { ...fallback, authFallbackUsed: true };
+	return { ...fallback, authFallbackUsed: true, fallbackReason: "auth" };
 }
 
 /**
@@ -855,18 +934,20 @@ function resolveExactCanonicalScopePattern(
  * The algorithm tries to match the full pattern first, then progressively
  * strips colon-suffixes to find a match.
  */
-export async function resolveModelScope(
+export function resolveModelScopeSync(
 	patterns: string[],
 	modelRegistry: Pick<ModelRegistry, "getAvailable" | "getCanonicalVariants">,
 	preferences?: ModelMatchPreferences,
-): Promise<ScopedModel[]> {
+	options?: ResolveModelScopeOptions,
+): ScopedModel[] {
 	const availableModels = modelRegistry.getAvailable();
 	const context = buildPreferenceContext(availableModels, preferences);
 	const scopedModels: ScopedModel[] = [];
+	const warnOnNoMatch = options?.warnOnNoMatch !== false;
 
 	for (const pattern of patterns) {
 		// Check if pattern contains glob characters
-		if (pattern.includes("*") || pattern.includes("?") || pattern.includes("[")) {
+		if (containsGlobCharacters(pattern)) {
 			// Extract optional thinking level suffix (e.g., "provider/*:high")
 			const colonIdx = pattern.lastIndexOf(":");
 			let globPattern = pattern;
@@ -883,16 +964,20 @@ export async function resolveModelScope(
 				}
 			}
 
-			// Match against "provider/modelId" format OR just model ID
-			// This allows "*sonnet*" to match without requiring "anthropic/*sonnet*"
+			const glob = new Bun.Glob(globPattern.toLowerCase());
+			const matchModelId = shouldMatchBareModelIdForGlob(globPattern);
+
+			// Slash globs match only "provider/modelId".
+			// Unqualified globs still match bare IDs, so "*sonnet*" works without "anthropic/*sonnet*".
 			const matchingModels = availableModels.filter(m => {
 				const fullId = `${m.provider}/${m.id}`;
-				const glob = new Bun.Glob(globPattern.toLowerCase());
-				return glob.match(fullId.toLowerCase()) || glob.match(m.id.toLowerCase());
+				return glob.match(fullId.toLowerCase()) || (matchModelId && glob.match(m.id.toLowerCase()));
 			});
 
 			if (matchingModels.length === 0) {
-				logger.warn(`No models match pattern "${pattern}"`);
+				if (warnOnNoMatch) {
+					logger.warn(`No models match pattern "${pattern}"`);
+				}
 				continue;
 			}
 
@@ -935,11 +1020,15 @@ export async function resolveModelScope(
 		);
 
 		if (warning) {
-			logger.warn(warning);
+			if (warnOnNoMatch) {
+				logger.warn(warning);
+			}
 		}
 
 		if (!model) {
-			logger.warn(`No models match pattern "${pattern}"`);
+			if (warnOnNoMatch) {
+				logger.warn(`No models match pattern "${pattern}"`);
+			}
 			continue;
 		}
 
@@ -956,6 +1045,15 @@ export async function resolveModelScope(
 	}
 
 	return scopedModels;
+}
+
+export async function resolveModelScope(
+	patterns: string[],
+	modelRegistry: Pick<ModelRegistry, "getAvailable" | "getCanonicalVariants">,
+	preferences?: ModelMatchPreferences,
+	options?: ResolveModelScopeOptions,
+): Promise<ScopedModel[]> {
+	return resolveModelScopeSync(patterns, modelRegistry, preferences, options);
 }
 
 /**
@@ -980,7 +1078,7 @@ export async function resolveAllowedModels(
 	if (!patterns || patterns.length === 0) {
 		return available;
 	}
-	const scoped = await resolveModelScope(patterns, modelRegistry, preferences);
+	const scoped = resolveModelScopeSync(patterns, modelRegistry, preferences);
 	if (scoped.length === 0) {
 		return [];
 	}

--- a/packages/coding-agent/src/extensibility/extensions/compact-handler.ts
+++ b/packages/coding-agent/src/extensibility/extensions/compact-handler.ts
@@ -23,6 +23,7 @@ export async function runExtensionCompact(
 }
 
 interface SetModelCapableSession {
+	getAvailableModels(): Model[];
 	modelRegistry: { getApiKey(model: Model): Promise<string | undefined> };
 	setModel(model: Model): Promise<unknown>;
 }
@@ -30,9 +31,13 @@ interface SetModelCapableSession {
 /**
  * Helper for wiring the `setModel` action of an {@link ExtensionContext}.
  *
- * Returns false when no API key is available for the requested model.
+ * Returns false when the requested model is outside the active scope or has no API key.
  */
 export async function runExtensionSetModel(session: SetModelCapableSession, model: Model): Promise<boolean> {
+	const allowed = session
+		.getAvailableModels()
+		.some(candidate => candidate.provider === model.provider && candidate.id === model.id);
+	if (!allowed) return false;
 	const key = await session.modelRegistry.getApiKey(model);
 	if (!key) return false;
 	await session.setModel(model);

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -515,6 +515,7 @@ function discoverAppendSystemPromptFile(): string | undefined {
 async function buildSessionOptions(
 	parsed: Args,
 	scopedModels: ScopedModel[],
+	explicitModelScopeConfigured: boolean,
 	sessionManager: SessionManager | undefined,
 	modelRegistry: ModelRegistry,
 	activeSettings: Settings,
@@ -571,7 +572,7 @@ async function buildSessionOptions(
 				options.thinkingLevel = resolved.thinkingLevel;
 			}
 		}
-	} else if (scopedModels.length > 0 && !parsed.continue && !parsed.resume) {
+	} else if (!explicitModelScopeConfigured && scopedModels.length > 0 && !parsed.continue && !parsed.resume) {
 		const remembered = activeSettings.getModelRole("default");
 		if (remembered) {
 			const rememberedSpec = resolveModelRoleValue(
@@ -608,14 +609,20 @@ async function buildSessionOptions(
 	} else if (
 		scopedModels.length > 0 &&
 		scopedModels[0].explicitThinkingLevel === true &&
+		!explicitModelScopeConfigured &&
 		!parsed.continue &&
 		!parsed.resume
 	) {
 		options.thinkingLevel = scopedModels[0].thinkingLevel;
 	}
 
-	// Scoped models for Ctrl+P cycling - fill in default thinking levels when not explicit
-	if (scopedModels.length > 0) {
+	// CLI scope patterns are resolved inside the session so extension-registered
+	// models can join the allow-list after extension startup.
+	if (explicitModelScopeConfigured) {
+		options.modelScopePatterns = parsed.models ?? [];
+		options.preferScopedModelOrder = !parsed.model && !parsed.continue && !parsed.resume;
+	} else if (scopedModels.length > 0) {
+		// Scoped models for Ctrl+P cycling - fill in default thinking levels when not explicit.
 		// `auto` is a session-level concept only; per-scoped-model (Ctrl+P) thinking
 		// overrides stay concrete, so coerce the auto default to "unset" here.
 		const defaultThinkingLevelSetting = activeSettings.get("defaultThinkingLevel");
@@ -823,17 +830,19 @@ export async function runRootCommand(
 	);
 
 	let scopedModels: ScopedModel[] = [];
-	const modelPatterns = parsedArgs.models ?? settingsInstance.get("enabledModels");
+	const modelPatterns = parsedArgs.models ?? [];
+	const explicitModelScopeConfigured = modelPatterns.length > 0;
 	const modelMatchPreferences = {
 		usageOrder: settingsInstance.getStorage()?.getModelUsageOrder(),
 	};
-	if (modelPatterns && modelPatterns.length > 0) {
+	if (explicitModelScopeConfigured) {
 		scopedModels = await logger.time(
 			"resolveModelScope",
 			resolveModelScope,
 			modelPatterns,
 			modelRegistry,
 			modelMatchPreferences,
+			{ warnOnNoMatch: false },
 		);
 	}
 
@@ -896,6 +905,7 @@ export async function runRootCommand(
 		buildSessionOptions,
 		parsedArgs,
 		scopedModels,
+		explicitModelScopeConfigured,
 		sessionManager,
 		modelRegistry,
 		settingsInstance,
@@ -907,7 +917,7 @@ export async function runRootCommand(
 
 	// Handle CLI --api-key as runtime override (not persisted)
 	if (parsedArgs.apiKey) {
-		if (!sessionOptions.model && !sessionOptions.modelPattern) {
+		if (!sessionOptions.model && !sessionOptions.modelPattern && !sessionOptions.modelScopePatterns) {
 			process.stderr.write(
 				`${chalk.red("--api-key requires a model to be specified via --model, --provider/--model, or --models")}\n`,
 			);
@@ -915,6 +925,8 @@ export async function runRootCommand(
 		}
 		if (sessionOptions.model) {
 			authStorage.setRuntimeApiKey(sessionOptions.model.provider, parsedArgs.apiKey);
+		} else if (sessionOptions.modelScopePatterns) {
+			sessionOptions.modelScopeApiKey = parsedArgs.apiKey;
 		}
 	}
 
@@ -1008,15 +1020,16 @@ export async function runRootCommand(
 			const versionCheckPromise = checkForNewVersion(VERSION).catch(() => undefined);
 			const changelogMarkdown = await logger.time("main:getChangelogForDisplay", getChangelogForDisplay, parsedArgs);
 
-			const scopedModelsForDisplay = sessionOptions.scopedModels ?? scopedModels;
-			if (scopedModelsForDisplay.length > 0) {
-				const modelList = scopedModelsForDisplay
-					.map(scopedModel => {
-						const thinkingStr = !scopedModel.thinkingLevel ? `:${scopedModel.thinkingLevel}` : "";
-						return `${scopedModel.model.id}${thinkingStr}`;
-					})
-					.join(", ");
-				process.stdout.write(`${chalk.dim(`Model scope: ${modelList} ${chalk.gray("(Ctrl+P to cycle)")}`)}\n`);
+			const scopedModelsForDisplay = session.scopedModels;
+			if (session.hasModelScope) {
+				const modelList =
+					scopedModelsForDisplay
+						.map(scopedModel => {
+							const thinkingStr = scopedModel.thinkingLevel ? `:${scopedModel.thinkingLevel}` : "";
+							return `${scopedModel.model.id}${thinkingStr}`;
+						})
+						.join(", ") || "no models";
+				process.stdout.write(`${chalk.dim(`Model scope: ${modelList} ${chalk.gray("(Ctrl+P cycles scope)")}`)}\n`);
 			}
 
 			if ($env.PI_TIMING) {

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -1077,16 +1077,25 @@ async function resolveMemoryModel(options: {
 	fallbackRole: string;
 }): Promise<Model | undefined> {
 	const { modelRegistry, session, fallbackRole } = options;
+	const availableModels =
+		typeof session.getAvailableModels === "function" ? session.getAvailableModels() : modelRegistry.getAll();
 	const requestedModel = session.settings.getModelRole(fallbackRole) || session.settings.getModelRole("default");
 	if (requestedModel) {
-		const resolved = resolveModelRoleValue(requestedModel, modelRegistry.getAll(), {
+		const resolved = resolveModelRoleValue(requestedModel, availableModels, {
 			settings: session.settings,
 			matchPreferences: { usageOrder: session.settings.getStorage()?.getModelUsageOrder() },
 			modelRegistry,
 		});
 		if (resolved.model) return resolved.model;
 	}
-	return session.model ?? modelRegistry.getAll()[0];
+	const activeModel = session.model;
+	if (
+		activeModel &&
+		availableModels.some(model => model.provider === activeModel.provider && model.id === activeModel.id)
+	) {
+		return activeModel;
+	}
+	return availableModels[0];
 }
 
 function loadMemoryConfig(settings: Settings): MemoryRuntimeConfig {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -48,7 +48,7 @@ import { disableProvider, enableProvider, reset as resetCapabilities } from "../
 import { Settings } from "../../config/settings";
 import { clearPluginRootsAndCaches, resolveActiveProjectRegistryPath } from "../../discovery/helpers";
 import type { ExtensionUIContext, ExtensionUIDialogOptions } from "../../extensibility/extensions";
-import { runExtensionCompact } from "../../extensibility/extensions/compact-handler";
+import { runExtensionCompact, runExtensionSetModel } from "../../extensibility/extensions/compact-handler";
 import { getSessionSlashCommands } from "../../extensibility/extensions/get-commands-handler";
 import { buildSkillPromptMessage, getSkillSlashCommandName } from "../../extensibility/skills";
 import { loadSlashCommands } from "../../extensibility/slash-commands";
@@ -1907,14 +1907,7 @@ export class AcpAgent implements Agent {
 				getAllTools: () => record.session.getAllToolNames(),
 				setActiveTools: toolNames => record.session.setActiveToolsByName(toolNames),
 				getCommands: () => getSessionSlashCommands(record.session),
-				setModel: async model => {
-					const apiKey = await record.session.modelRegistry.getApiKey(model);
-					if (!apiKey) {
-						return false;
-					}
-					await record.session.setModel(model);
-					return true;
-				},
+				setModel: model => runExtensionSetModel(record.session, model),
 				getThinkingLevel: () => record.session.thinkingLevel,
 				setThinkingLevel: level => record.session.setThinkingLevel(level),
 				getSessionName: () => record.session.sessionManager.getSessionName(),

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -146,6 +146,7 @@ export class ModelSelectorComponent extends Container {
 	#errorMessage?: unknown;
 	#tui: TUI;
 	#scopedModels: ReadonlyArray<ScopedModelItem>;
+	#modelScopeConfigured: boolean;
 	#temporaryOnly: boolean;
 
 	#menuRoleActions: MenuRoleAction[] = [];
@@ -172,7 +173,7 @@ export class ModelSelectorComponent extends Container {
 		scopedModels: ReadonlyArray<ScopedModelItem>,
 		onSelect: RoleSelectCallback,
 		onCancel: () => void,
-		options?: { temporaryOnly?: boolean; initialSearchInput?: string },
+		options?: { temporaryOnly?: boolean; initialSearchInput?: string; scopeConfigured?: boolean },
 	) {
 		super();
 
@@ -180,6 +181,7 @@ export class ModelSelectorComponent extends Container {
 		this.#settings = settings;
 		this.#modelRegistry = modelRegistry;
 		this.#scopedModels = scopedModels;
+		this.#modelScopeConfigured = options?.scopeConfigured ?? scopedModels.length > 0;
 		this.#onSelectCallback = onSelect;
 		this.#onCancelCallback = onCancel;
 		this.#temporaryOnly = options?.temporaryOnly ?? false;
@@ -196,10 +198,9 @@ export class ModelSelectorComponent extends Container {
 		this.addChild(new Spacer(1));
 
 		// Add hint about model filtering
-		const hintText =
-			scopedModels.length > 0
-				? "Showing models from --models scope"
-				: "Only showing models with configured API keys (see README for details)";
+		const hintText = this.#modelScopeConfigured
+			? "Showing models from the active model scope"
+			: "Only showing models with configured API keys (see README for details)";
 		this.addChild(new Text(theme.fg("warning", hintText), 0, 0));
 		this.addChild(new Spacer(1));
 
@@ -266,7 +267,9 @@ export class ModelSelectorComponent extends Container {
 	}
 
 	#loadRoleModels(): void {
-		const allModels = this.#modelRegistry.getAll();
+		const allModels = this.#modelScopeConfigured
+			? this.#scopedModels.map(scoped => scoped.model)
+			: this.#modelRegistry.getAll();
 		const matchPreferences = { usageOrder: this.#settings.getStorage()?.getModelUsageOrder() };
 		for (const role of getKnownRoleIds(this.#settings)) {
 			const roleValue = this.#settings.getModelRole(role);
@@ -385,7 +388,9 @@ export class ModelSelectorComponent extends Container {
 
 	#loadModelsFromCurrentRegistryState(): void {
 		let models: ModelItem[];
-		if (this.#scopedModels.length > 0) {
+
+		// Use scoped models if provided via --models flag
+		if (this.#modelScopeConfigured) {
 			models = this.#scopedModels.map(scoped => ({
 				kind: "provider",
 				provider: scoped.model.provider,
@@ -422,13 +427,13 @@ export class ModelSelectorComponent extends Container {
 
 		const candidates = models.map(item => item.model);
 		const canonicalRecords = this.#modelRegistry.getCanonicalModels({
-			availableOnly: this.#scopedModels.length === 0,
+			availableOnly: !this.#modelScopeConfigured,
 			candidates,
 		});
 		const canonicalModels = canonicalRecords
 			.map(record => {
 				const selectedModel = this.#modelRegistry.resolveCanonicalModel(record.id, {
-					availableOnly: this.#scopedModels.length === 0,
+					availableOnly: !this.#modelScopeConfigured,
 					candidates,
 				});
 				if (!selectedModel) return undefined;
@@ -550,7 +555,7 @@ export class ModelSelectorComponent extends Container {
 
 	#scheduleSelectedProviderRefresh(): void {
 		const providerId = this.#getActiveProviderId();
-		if (this.#scopedModels.length > 0 || !providerId) {
+		if (this.#modelScopeConfigured || !providerId) {
 			return;
 		}
 		if (this.#scheduledProviderRefreshes.has(providerId) || this.#refreshingProviders.has(providerId)) {

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -103,6 +103,10 @@ export class ExtensionUiController {
 			getAllTools: () => this.ctx.session.getAllToolNames(),
 			setActiveTools: toolNames => this.ctx.session.setActiveToolsByName(toolNames),
 			setModel: async model => {
+				const allowed = this.ctx.session
+					.getAvailableModels()
+					.some(candidate => candidate.provider === model.provider && candidate.id === model.id);
+				if (!allowed) return false;
 				const key = await this.ctx.session.modelRegistry.getApiKey(model);
 				if (!key) return false;
 				await this.ctx.session.setModel(model);
@@ -343,6 +347,10 @@ export class ExtensionUiController {
 			getAllTools: () => this.ctx.session.getAllToolNames(),
 			setActiveTools: toolNames => this.ctx.session.setActiveToolsByName(toolNames),
 			setModel: async model => {
+				const allowed = this.ctx.session
+					.getAvailableModels()
+					.some(candidate => candidate.provider === model.provider && candidate.id === model.id);
+				if (!allowed) return false;
 				const key = await this.ctx.session.modelRegistry.getApiKey(model);
 				if (!key) return false;
 				await this.ctx.session.setModel(model);

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -398,6 +398,7 @@ export class InputController {
 					this.ctx.session.sessionId,
 					this.ctx.session.model,
 					provider => this.ctx.session.agent.metadataForProvider(provider),
+					this.ctx.session.getAvailableModels(),
 				)
 					.then(async title => {
 						if (title) {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -459,7 +459,7 @@ export class SelectorController {
 					done();
 					this.ctx.ui.requestRender();
 				},
-				options,
+				{ ...options, scopeConfigured: this.ctx.session.hasModelScope },
 			);
 			return { component: selector, focus: selector };
 		});

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -41,11 +41,16 @@ import { type Rule, ruleCapability, setActiveRules } from "./capability/rule";
 import { bucketRules } from "./capability/rule-buckets";
 import { ModelRegistry } from "./config/model-registry";
 import {
+	filterModelsByScopeOrder,
+	formatModelScope,
 	formatModelString,
+	isModelInScope,
 	parseModelPattern,
 	parseModelString,
 	resolveAllowedModels,
 	resolveModelRoleValue,
+	resolveModelScopeSync,
+	type ScopedModel,
 } from "./config/model-resolver";
 import { loadPromptTemplates as loadPromptTemplatesInternal, type PromptTemplate } from "./config/prompt-templates";
 import { Settings, type SkillsSettings } from "./config/settings";
@@ -262,8 +267,14 @@ export interface CreateAgentSessionOptions {
 	modelPattern?: string;
 	/** Thinking selector. Default: from settings, else unset */
 	thinkingLevel?: ConfiguredThinkingLevel;
-	/** Models available for cycling (Ctrl+P in interactive mode) */
-	scopedModels?: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
+	/** Models allowed for this session; Ctrl+P cycles within this set. */
+	scopedModels?: ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }>;
+	/** Raw model scope patterns to resolve after extensions load. */
+	modelScopePatterns?: readonly string[];
+	/** Runtime API key supplied with a CLI model scope. @internal */
+	modelScopeApiKey?: string;
+	/** Prefer the first resolved scoped model after extension registration. */
+	preferScopedModelOrder?: boolean;
 
 	/** System prompt blocks. Array replaces default, function receives default blocks and returns final blocks. */
 	systemPrompt?: string[] | ((defaultPrompt: string[]) => string[]);
@@ -969,6 +980,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		modelApiKeyAvailability.set(availabilityKey, hasKey);
 		return hasKey;
 	};
+	const configuredScopedModels = options.scopedModels;
+	const configuredModelScopePatterns = options.modelScopePatterns;
+	const preferScopedModelOrder = options.preferScopedModelOrder === true;
 
 	// Load and create secret obfuscator early so resumed session state and prompt warnings
 	// reflect actual loaded secrets, not just the setting toggle.
@@ -996,9 +1010,62 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const modelMatchPreferences = {
 		usageOrder: settings.getStorage()?.getModelUsageOrder(),
 	};
-	const allowedModels = await logger.time("resolveAllowedModels", () =>
-		resolveAllowedModels(modelRegistry, settings, modelMatchPreferences),
-	);
+	const mapScopedModels = (
+		scopedModels: readonly ScopedModel[],
+	): ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }> => {
+		const defaultThinkingLevelSetting = settings.get("defaultThinkingLevel");
+		const defaultThinkingLevel =
+			defaultThinkingLevelSetting === AUTO_THINKING ? undefined : defaultThinkingLevelSetting;
+		return scopedModels.map(scopedModel => ({
+			model: scopedModel.model,
+			thinkingLevel: scopedModel.explicitThinkingLevel
+				? (scopedModel.thinkingLevel ?? defaultThinkingLevel)
+				: defaultThinkingLevel,
+		}));
+	};
+	const resolveScopedModelPatterns = (
+		patterns: readonly string[] | undefined,
+	): ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }> | undefined => {
+		if (!patterns || patterns.length === 0) return undefined;
+		return mapScopedModels(
+			resolveModelScopeSync([...patterns], modelRegistry, modelMatchPreferences, { warnOnNoMatch: false }),
+		);
+	};
+	const resolveScopedModelPatternsFromAllModels = (
+		patterns: readonly string[] | undefined,
+	): ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }> | undefined => {
+		if (!patterns || patterns.length === 0) return undefined;
+		const scopeRegistry = {
+			getAvailable: () => modelRegistry.getAll(),
+			getCanonicalVariants: (canonicalId: string, options?: Parameters<ModelRegistry["getCanonicalVariants"]>[1]) =>
+				modelRegistry.getCanonicalVariants(canonicalId, options),
+		};
+		return mapScopedModels(
+			resolveModelScopeSync([...patterns], scopeRegistry, modelMatchPreferences, { warnOnNoMatch: false }),
+		);
+	};
+	const getSettingsScopedModels = (): ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }> | undefined =>
+		resolveScopedModelPatterns(settings.get("enabledModels"));
+	const getPatternScopedModels = (): ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }> | undefined =>
+		resolveScopedModelPatterns(configuredModelScopePatterns);
+	const getSettingsScopedModelsFromAllModels = ():
+		| ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }>
+		| undefined => resolveScopedModelPatternsFromAllModels(settings.get("enabledModels"));
+	const getPatternScopedModelsFromAllModels = ():
+		| ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }>
+		| undefined => resolveScopedModelPatternsFromAllModels(configuredModelScopePatterns);
+	const getActiveScopedModels = () => configuredScopedModels ?? getPatternScopedModels() ?? getSettingsScopedModels();
+	const getActiveScopedModelsFromAllModels = () =>
+		configuredScopedModels ?? getPatternScopedModelsFromAllModels() ?? getSettingsScopedModelsFromAllModels();
+	const hasModelScope = () => getActiveScopedModels() !== undefined;
+	const getAvailableModelsInScope = () =>
+		filterModelsByScopeOrder(modelRegistry.getAvailable(), getActiveScopedModels());
+	const getAllModelsInScope = () => filterModelsByScopeOrder(modelRegistry.getAll(), getActiveScopedModels());
+	const resolveSessionAllowedModels = async (): Promise<Model[]> => {
+		if (hasModelScope()) return getAvailableModelsInScope();
+		return await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
+	};
+	const allowedModels = await logger.time("resolveAllowedModels", resolveSessionAllowedModels);
 	const defaultRoleSpec = logger.time("resolveDefaultModelRole", () =>
 		resolveModelRoleValue(settings.getModelRole("default"), allowedModels, {
 			settings,
@@ -1008,27 +1075,38 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	);
 	let model = options.model;
 	let modelFallbackMessage: string | undefined;
+	if (model && !isModelInScope(model, getActiveScopedModelsFromAllModels())) {
+		modelFallbackMessage = `Model ${formatModelString(model)} is outside active model scope (${formatModelScope(getActiveScopedModelsFromAllModels())})`;
+		model = undefined;
+	}
 	// If session has data, try to restore model from it.
 	// Skip restore when an explicit model was requested.
 	const defaultModelStr = existingSession.models.default;
-	if (!hasExplicitModel && !model && hasExistingSession && defaultModelStr) {
-		await logger.time("restoreSessionModel", async () => {
-			const parsedModel = parseModelString(defaultModelStr);
-			if (parsedModel) {
-				const restoredModel = modelRegistry.find(parsedModel.provider, parsedModel.id);
-				if (restoredModel && (await hasModelApiKey(restoredModel))) {
-					model = restoredModel;
-				}
+	const shouldRestoreSessionModel = (): boolean =>
+		!hasExplicitModel && !preferScopedModelOrder && !model && hasExistingSession && defaultModelStr !== undefined;
+	const tryRestoreSessionModel = async (candidateModels: readonly Model[]): Promise<boolean> => {
+		if (!defaultModelStr) return false;
+		const parsedModel = parseModelString(defaultModelStr);
+		if (parsedModel) {
+			const restoredModel = candidateModels.find(
+				candidate => candidate.provider === parsedModel.provider && candidate.id === parsedModel.id,
+			);
+			if (restoredModel && (await hasModelApiKey(restoredModel))) {
+				model = restoredModel;
+				modelFallbackMessage = undefined;
+				return true;
 			}
-			if (!model) {
-				modelFallbackMessage = `Could not restore model ${defaultModelStr}`;
-			}
-		});
+		}
+		modelFallbackMessage = `Could not restore model ${defaultModelStr}`;
+		return false;
+	};
+	if (shouldRestoreSessionModel()) {
+		await logger.time("restoreSessionModel", tryRestoreSessionModel, allowedModels);
 	}
 
 	// If still no model, try settings default.
 	// Skip settings fallback when an explicit model was requested.
-	if (!hasExplicitModel && !model && defaultRoleSpec.model) {
+	if (!hasExplicitModel && !preferScopedModelOrder && !model && defaultRoleSpec.model) {
 		const settingsDefaultModel = defaultRoleSpec.model;
 		logger.time("resolveSettingsDefaultModel", () => {
 			// defaultRoleSpec.model already comes from modelRegistry.getAvailable(),
@@ -1040,13 +1118,20 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const taskDepth = options.taskDepth ?? 0;
 
 	let thinkingLevel = options.thinkingLevel;
+	const preserveRequestedThinking = options.thinkingLevel !== undefined || (hasExistingSession && hasThinkingEntry);
 
 	// If session has data and includes a thinking entry, restore it
 	if (thinkingLevel === undefined && hasExistingSession && hasThinkingEntry) {
 		thinkingLevel = parseThinkingLevel(existingSession.thinkingLevel);
 	}
 
-	if (thinkingLevel === undefined && !hasExplicitModel && !hasThinkingEntry && defaultRoleSpec.explicitThinkingLevel) {
+	if (
+		thinkingLevel === undefined &&
+		!hasExplicitModel &&
+		!preferScopedModelOrder &&
+		!hasThinkingEntry &&
+		defaultRoleSpec.explicitThinkingLevel
+	) {
 		thinkingLevel = defaultRoleSpec.thinkingLevel;
 	}
 
@@ -1058,18 +1143,31 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	if (thinkingLevel === undefined) {
 		thinkingLevel = settings.get("defaultThinkingLevel");
 	}
-	const autoThinking = thinkingLevel === AUTO_THINKING;
-	// Concrete level the agent/session start with. With `auto` this is the
-	// provisional level shown until the first per-turn classification resolves;
-	// `auto` itself stays a session-only concept handled by AgentSession.
-	let effectiveThinkingLevel: ThinkingLevel | undefined = thinkingLevel === AUTO_THINKING ? undefined : thinkingLevel;
-	if (model) {
-		const resolvedModel = model;
+	let autoThinking = thinkingLevel === AUTO_THINKING;
+	let effectiveThinkingLevel: ThinkingLevel | undefined = autoThinking ? undefined : thinkingLevel;
+	const applySelectedModelThinking = (selectedModel: Model): void => {
+		if (!preserveRequestedThinking) {
+			const scopedModel = getActiveScopedModels()?.find(
+				scoped =>
+					scoped.model.provider === selectedModel.provider &&
+					scoped.model.id === selectedModel.id &&
+					scoped.thinkingLevel !== undefined,
+			);
+			if (scopedModel) {
+				thinkingLevel = scopedModel.thinkingLevel;
+			}
+		}
+		autoThinking = thinkingLevel === AUTO_THINKING;
+		effectiveThinkingLevel = autoThinking ? undefined : thinkingLevel;
 		effectiveThinkingLevel = logger.time("resolveThinkingLevelForModel", () =>
 			autoThinking
-				? resolveProvisionalAutoLevel(resolvedModel)
-				: resolveThinkingLevelForModel(resolvedModel, effectiveThinkingLevel),
+				? resolveProvisionalAutoLevel(selectedModel)
+				: resolveThinkingLevelForModel(selectedModel, effectiveThinkingLevel),
 		);
+	};
+	if (model) {
+		const resolvedModel = model;
+		applySelectedModelThinking(resolvedModel);
 		// Fire-and-forget TLS+H2 handshake to the model's host so it overlaps
 		// with the rest of session setup (extension/skill load, tool registry,
 		// system prompt build). Without this, the first `fetch(...)` pays the
@@ -1238,6 +1336,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			getSessionSpawns: () => options.spawns ?? "*",
 			getModelString: () => (hasExplicitModel && model ? formatModelString(model) : undefined),
 			getActiveModelString,
+			getAvailableModels: () => session?.getAvailableModels() ?? getAvailableModelsInScope(),
+			getScopedModels: () =>
+				session ? (session.hasModelScope ? session.scopedModels : undefined) : getActiveScopedModels(),
 			getPlanModeState: () => session?.getPlanModeState(),
 			getGoalModeState: () => session?.getGoalModeState(),
 			getGoalRuntime: () => session?.goalRuntime,
@@ -1367,12 +1468,6 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// to mirror the AsyncJobManager ownership rule.
 		if (mcpManager && !options.parentTaskPrefix) MCPManager.setInstance(mcpManager);
 
-		// Add image tools when the active model or configured image providers can generate images.
-		const imageGenTools = await logger.time("getImageGenTools", () => getImageGenTools(modelRegistry, model));
-		if (imageGenTools.length > 0) {
-			customTools.push(...(imageGenTools as unknown as CustomTool[]));
-		}
-
 		if (settings.get("tts.enabled")) {
 			customTools.push(ttsTool as unknown as CustomTool);
 		}
@@ -1444,9 +1539,53 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			extensionsResult.runtime.pendingProviderRegistrations = [];
 		}
 
+		if (options.modelScopeApiKey && configuredModelScopePatterns !== undefined) {
+			const scopedModelsForApiKey = resolveScopedModelPatternsFromAllModels(configuredModelScopePatterns) ?? [];
+			const providers = [...new Set(scopedModelsForApiKey.map(scopedModel => scopedModel.model.provider))].sort();
+			const provider = providers[0];
+			if (!provider) {
+				throw new Error(
+					"--api-key with --models requires a single resolvable provider; no provider could be resolved from the model scope.",
+				);
+			}
+			if (providers.length > 1) {
+				throw new Error(
+					`--api-key with --models requires a single provider; scope resolved multiple providers: ${providers.join(", ")}.`,
+				);
+			}
+			authStorage.setRuntimeApiKey(provider, options.modelScopeApiKey);
+			modelApiKeyAvailability.clear();
+		}
+
+		if (shouldRestoreSessionModel()) {
+			if (
+				await logger.time(
+					"restoreSessionModel:deferred",
+					tryRestoreSessionModel,
+					await resolveSessionAllowedModels(),
+				)
+			) {
+				const restoredModel = model;
+				if (restoredModel) {
+					applySelectedModelThinking(restoredModel);
+				}
+			}
+		}
+
+		if (!model && preferScopedModelOrder) {
+			for (const scopedModel of getActiveScopedModels() ?? []) {
+				if (await hasModelApiKey(scopedModel.model)) {
+					model = scopedModel.model;
+					applySelectedModelThinking(model);
+					modelFallbackMessage = undefined;
+					break;
+				}
+			}
+		}
+
 		// Resolve deferred --model pattern now that extension models are registered.
 		if (!model && options.modelPattern) {
-			const availableModels = modelRegistry.getAll();
+			const availableModels = hasModelScope() ? getAllModelsInScope() : modelRegistry.getAll();
 			const matchPreferences = {
 				usageOrder: settings.getStorage()?.getModelUsageOrder(),
 			};
@@ -1455,22 +1594,26 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			});
 			if (resolved) {
 				model = resolved;
+				applySelectedModelThinking(resolved);
 				modelFallbackMessage = undefined;
 			} else {
-				modelFallbackMessage = `Model "${options.modelPattern}" not found`;
+				modelFallbackMessage = hasModelScope()
+					? `Model "${options.modelPattern}" not found in active model scope (${formatModelScope(getActiveScopedModels())})`
+					: `Model "${options.modelPattern}" not found`;
 			}
 		}
 
 		// Fall back to first available model with a valid API key, honoring the
 		// path-scoped `enabledModels` allow-list when configured. Skip when the
 		// user explicitly requested a model via --model that wasn't found.
-		if (!model && !options.modelPattern) {
+		if (!model && !hasExplicitModel) {
 			// Re-resolve the allowed set: extension factories above may have
 			// registered providers/models that weren't visible at startup.
-			const fallbackCandidates = await resolveAllowedModels(modelRegistry, settings, modelMatchPreferences);
+			const fallbackCandidates = await resolveSessionAllowedModels();
 			for (const candidate of fallbackCandidates) {
 				if (await hasModelApiKey(candidate)) {
 					model = candidate;
+					applySelectedModelThinking(candidate);
 					break;
 				}
 			}
@@ -1480,11 +1623,26 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				}
 			} else {
 				const patterns = settings.get("enabledModels");
-				modelFallbackMessage =
-					patterns && patterns.length > 0
+				modelFallbackMessage = hasModelScope()
+					? `No model available in active model scope (${formatModelScope(getActiveScopedModels())}) with usable credentials. Adjust --models or configure credentials for an in-scope provider.`
+					: patterns && patterns.length > 0
 						? `No model available matching enabledModels (${patterns.join(", ")}) with usable credentials. Configure auth for an allowed provider or adjust enabledModels.`
 						: "No models available. Use /login or set an API key environment variable. Then use /model to select a model.";
 			}
+		}
+
+		// Add image tools after deferred model selection so model-backed image
+		// providers see the same active model the session starts with.
+		const imageGenTools = await logger.time("getImageGenTools", () => getImageGenTools(modelRegistry, model));
+		if (imageGenTools.length > 0) {
+			const loadedImageTools = await loadExtensionFromFactory(
+				createCustomToolsExtension(imageGenTools as unknown as CustomTool[]),
+				cwd,
+				eventBus,
+				extensionsResult.runtime,
+				"<image-tools>",
+			);
+			extensionsResult.extensions.push(loadedImageTools);
 		}
 
 		// Discover custom commands (TypeScript slash commands)
@@ -2010,7 +2168,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			// AsyncJobManager on teardown; subagents inherit the parent's and
 			// **MUST NOT** tear it down.
 			ownedAsyncJobManager: asyncJobManager,
-			scopedModels: options.scopedModels,
+			scopedModels: configuredScopedModels,
+			modelScopePatterns: configuredModelScopePatterns,
 			promptTemplates,
 			slashCommands,
 			extensionRunner,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1143,8 +1143,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	if (thinkingLevel === undefined) {
 		thinkingLevel = settings.get("defaultThinkingLevel");
 	}
+	const toEffectiveThinkingLevel = (level: ConfiguredThinkingLevel | undefined): ThinkingLevel | undefined =>
+		level === AUTO_THINKING ? undefined : level;
 	let autoThinking = thinkingLevel === AUTO_THINKING;
-	let effectiveThinkingLevel: ThinkingLevel | undefined = autoThinking ? undefined : thinkingLevel;
+	let effectiveThinkingLevel: ThinkingLevel | undefined = toEffectiveThinkingLevel(thinkingLevel);
 	const applySelectedModelThinking = (selectedModel: Model): void => {
 		if (!preserveRequestedThinking) {
 			const scopedModel = getActiveScopedModels()?.find(
@@ -1158,7 +1160,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			}
 		}
 		autoThinking = thinkingLevel === AUTO_THINKING;
-		effectiveThinkingLevel = autoThinking ? undefined : thinkingLevel;
+		effectiveThinkingLevel = toEffectiveThinkingLevel(thinkingLevel);
 		effectiveThinkingLevel = logger.time("resolveThinkingLevelForModel", () =>
 			autoThinking
 				? resolveProvisionalAutoLevel(selectedModel)

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -100,11 +100,15 @@ import type { Rule } from "../capability/rule";
 import { MODEL_ROLE_IDS, type ModelRegistry } from "../config/model-registry";
 import {
 	extractExplicitThinkingSelector,
+	filterModelsByScopeOrder,
+	formatModelScope,
 	formatModelSelectorValue,
 	formatModelString,
+	isModelInScope,
 	parseModelString,
 	type ResolvedModelRoleValue,
 	resolveModelRoleValue,
+	resolveModelScopeSync,
 } from "../config/model-resolver";
 import { expandPromptTemplate, type PromptTemplate } from "../config/prompt-templates";
 import type { Settings, SkillsSettings } from "../config/settings";
@@ -288,8 +292,10 @@ export interface AgentSessionConfig {
 	agent: Agent;
 	sessionManager: SessionManager;
 	settings: Settings;
-	/** Models to cycle through with Ctrl+P (from --models flag) */
-	scopedModels?: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
+	/** Models allowed for this session; Ctrl+P cycles within this set. */
+	scopedModels?: ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }>;
+	/** Raw model scope patterns resolved against the current registry. */
+	modelScopePatterns?: readonly string[];
 	/** Initial session thinking selector. */
 	thinkingLevel?: ConfiguredThinkingLevel;
 	/** Prompt templates for expansion */
@@ -807,7 +813,8 @@ export class AgentSession {
 
 	readonly configWarnings: string[] = [];
 
-	#scopedModels: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
+	#scopedModels: ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }> | undefined;
+	#modelScopePatterns: readonly string[] | undefined;
 	/** Effective, metadata-clamped thinking level applied to the agent (never `auto`). */
 	#thinkingLevel: ThinkingLevel | undefined;
 	/** True when the user configured `auto`; the effective level is resolved per turn. */
@@ -1071,7 +1078,8 @@ export class AgentSession {
 		this.#evalKernelOwnerId = config.evalKernelOwnerId ?? `agent-session:${Snowflake.next()}`;
 		this.#parentEvalSessionId = config.parentEvalSessionId;
 		this.#ownedAsyncJobManager = config.ownedAsyncJobManager;
-		this.#scopedModels = config.scopedModels ?? [];
+		this.#scopedModels = config.scopedModels;
+		this.#modelScopePatterns = config.modelScopePatterns;
 		if (config.thinkingLevel === AUTO_THINKING) {
 			// `auto` is session-level: keep the flag and show a provisional concrete
 			// level (the agent's initial effort was already set by the caller) until
@@ -3846,9 +3854,60 @@ export class AgentSession {
 		return this.sessionManager.getSessionName();
 	}
 
-	/** Scoped models for cycling (from --models flag) */
+	/** Scoped models for cycling and selection (from --models/enabledModels) */
 	get scopedModels(): ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }> {
-		return this.#scopedModels;
+		return this.#getActiveScopedModels() ?? [];
+	}
+
+	get hasModelScope(): boolean {
+		return this.#getActiveScopedModels() !== undefined;
+	}
+
+	#resolveScopedModelPatterns(
+		patterns: readonly string[] | undefined,
+	): ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }> | undefined {
+		if (!patterns || patterns.length === 0) return undefined;
+		const defaultThinkingLevelSetting = this.settings.get("defaultThinkingLevel");
+		const defaultThinkingLevel =
+			defaultThinkingLevelSetting === AUTO_THINKING ? undefined : defaultThinkingLevelSetting;
+		return resolveModelScopeSync(
+			[...patterns],
+			this.#modelRegistry,
+			{ usageOrder: this.settings.getStorage()?.getModelUsageOrder() },
+			{ warnOnNoMatch: false },
+		).map(scopedModel => ({
+			model: scopedModel.model,
+			thinkingLevel: scopedModel.explicitThinkingLevel
+				? (scopedModel.thinkingLevel ?? defaultThinkingLevel)
+				: defaultThinkingLevel,
+		}));
+	}
+
+	#getSettingsScopedModels(): ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }> | undefined {
+		return this.#resolveScopedModelPatterns(this.settings.get("enabledModels"));
+	}
+
+	#getPatternScopedModels(): ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }> | undefined {
+		return this.#resolveScopedModelPatterns(this.#modelScopePatterns);
+	}
+
+	#getActiveScopedModels(): ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }> | undefined {
+		return this.#scopedModels ?? this.#getPatternScopedModels() ?? this.#getSettingsScopedModels();
+	}
+
+	#isModelInScope(model: Model): boolean {
+		return isModelInScope(model, this.#getActiveScopedModels());
+	}
+
+	#assertModelInScope(model: Model): void {
+		if (this.#isModelInScope(model)) return;
+		throw new Error(
+			`Model ${formatModelString(model)} is outside active model scope (${formatModelScope(this.#getActiveScopedModels())}).`,
+		);
+	}
+
+	#getAvailableModelsInScope(): Model[] {
+		return filterModelsByScopeOrder(this.#modelRegistry.getAvailable(), this.#getActiveScopedModels());
 	}
 
 	/** Prompt templates */
@@ -3947,7 +4006,7 @@ export class AgentSession {
 	}
 
 	resolveRoleModel(role: string): Model | undefined {
-		return this.#resolveRoleModelFull(role, this.#modelRegistry.getAvailable(), this.model).model;
+		return this.#resolveRoleModelFull(role, this.#getAvailableModelsInScope(), this.model).model;
 	}
 
 	/**
@@ -3956,7 +4015,7 @@ export class AgentSession {
 	 * from role configuration (e.g., "anthropic/claude-sonnet-4-5:xhigh").
 	 */
 	resolveRoleModelWithThinking(role: string): ResolvedModelRoleValue {
-		return this.#resolveRoleModelFull(role, this.#modelRegistry.getAvailable(), this.model);
+		return this.#resolveRoleModelFull(role, this.#getAvailableModelsInScope(), this.model);
 	}
 
 	get promptTemplates(): ReadonlyArray<PromptTemplate> {
@@ -5122,6 +5181,7 @@ export class AgentSession {
 		role: string = "default",
 		options?: { selector?: string; thinkingLevel?: ThinkingLevel; persist?: boolean },
 	): Promise<void> {
+		this.#assertModelInScope(model);
 		const previousEditMode = this.#resolveActiveEditMode();
 		const apiKey = await this.#modelRegistry.getApiKey(model, this.sessionId);
 		if (!apiKey) {
@@ -5151,6 +5211,7 @@ export class AgentSession {
 	 * @throws Error if no API key available for the model
 	 */
 	async setModelTemporary(model: Model, thinkingLevel?: ThinkingLevel): Promise<void> {
+		this.#assertModelInScope(model);
 		const previousEditMode = this.#resolveActiveEditMode();
 		const apiKey = await this.#modelRegistry.getApiKey(model, this.sessionId);
 		if (!apiKey) {
@@ -5179,7 +5240,7 @@ export class AgentSession {
 	 * @returns The new model info, or undefined if only one model available
 	 */
 	async cycleModel(direction: "forward" | "backward" = "forward"): Promise<ModelCycleResult | undefined> {
-		if (this.#scopedModels.length > 0) {
+		if (this.#getActiveScopedModels() !== undefined) {
 			return this.#cycleScopedModel(direction);
 		}
 		return this.#cycleAvailableModel(direction);
@@ -5196,7 +5257,7 @@ export class AgentSession {
 	 * still guard on `models.length`).
 	 */
 	getRoleModelCycle(roleOrder: readonly string[]): RoleModelCycle | undefined {
-		const availableModels = this.#modelRegistry.getAvailable();
+		const availableModels = this.#getAvailableModelsInScope();
 		if (availableModels.length === 0) return undefined;
 
 		const currentModel = this.model;
@@ -5274,7 +5335,7 @@ export class AgentSession {
 		const apiKeysByProvider = new Map<string, string | undefined>();
 		const result: Array<{ model: Model; thinkingLevel?: ThinkingLevel }> = [];
 
-		for (const scoped of this.#scopedModels) {
+		for (const scoped of this.#getActiveScopedModels() ?? []) {
 			const provider = scoped.model.provider;
 			let apiKey: string | undefined;
 			if (apiKeysByProvider.has(provider)) {
@@ -5320,7 +5381,7 @@ export class AgentSession {
 
 	async #cycleAvailableModel(direction: "forward" | "backward"): Promise<ModelCycleResult | undefined> {
 		const previousEditMode = this.#resolveActiveEditMode();
-		const availableModels = this.#modelRegistry.getAvailable();
+		const availableModels = this.#getAvailableModelsInScope();
 		if (availableModels.length <= 1) return undefined;
 
 		const currentModel = this.model;
@@ -5348,10 +5409,10 @@ export class AgentSession {
 	}
 
 	/**
-	 * Get all available models with valid API keys.
+	 * Get all available models with valid API keys, filtered by active model scope.
 	 */
 	getAvailableModels(): Model[] {
-		return this.#modelRegistry.getAvailable();
+		return this.#getAvailableModelsInScope();
 	}
 
 	// =========================================================================
@@ -6490,7 +6551,7 @@ export class AgentSession {
 	}
 
 	async #resolveContextPromotionTarget(currentModel: Model, contextWindow: number): Promise<Model | undefined> {
-		const availableModels = this.#modelRegistry.getAvailable();
+		const availableModels = this.#getAvailableModelsInScope();
 		if (availableModels.length === 0) return undefined;
 
 		const candidate = this.#resolveContextPromotionConfiguredTarget(currentModel, availableModels);
@@ -6834,7 +6895,7 @@ export class AgentSession {
 		signal: AbortSignal,
 		options?: SummaryOptions,
 	): Promise<CompactionResult> {
-		const candidates = this.#getCompactionModelCandidates(this.#modelRegistry.getAvailable());
+		const candidates = this.#getCompactionModelCandidates(this.#getAvailableModelsInScope());
 		const telemetry = resolveTelemetry(this.agent.telemetry, this.sessionId);
 
 		for (const candidate of candidates) {
@@ -7037,7 +7098,7 @@ export class AgentSession {
 				return false;
 			}
 
-			const availableModels = this.#modelRegistry.getAvailable();
+			const availableModels = this.#getAvailableModelsInScope();
 			if (availableModels.length === 0) {
 				await this.#emitSessionEvent({
 					type: "auto_compaction_end",
@@ -7627,6 +7688,7 @@ export class AgentSession {
 		if (!candidate) {
 			throw new Error(`Retry fallback model not found: ${selector.raw}`);
 		}
+		this.#assertModelInScope(candidate);
 		const apiKey = await this.#modelRegistry.getApiKey(candidate, this.sessionId);
 		if (!apiKey) {
 			throw new Error(`No API key for retry fallback ${selector.raw}`);
@@ -7667,6 +7729,7 @@ export class AgentSession {
 			if (this.#isRetryFallbackSelectorSuppressed(selector)) continue;
 			const candidate = this.#modelRegistry.find(selector.provider, selector.id);
 			if (!candidate) continue;
+			if (!this.#isModelInScope(candidate)) continue;
 			const apiKey = await this.#modelRegistry.getApiKey(candidate, this.sessionId);
 			if (!apiKey) continue;
 			await this.#applyRetryFallbackCandidate(role, selector, currentSelector);
@@ -7704,6 +7767,10 @@ export class AgentSession {
 
 		const primaryModel = this.#modelRegistry.find(originalSelector.provider, originalSelector.id);
 		if (!primaryModel) return;
+		if (!this.#isModelInScope(primaryModel)) {
+			this.#clearActiveRetryFallback();
+			return;
+		}
 		const apiKey = await this.#modelRegistry.getApiKey(primaryModel, this.sessionId);
 		if (!apiKey) return;
 
@@ -8675,7 +8742,7 @@ export class AgentSession {
 				if (slashIdx > 0) {
 					const provider = defaultModelStr.slice(0, slashIdx);
 					const modelId = defaultModelStr.slice(slashIdx + 1);
-					const availableModels = this.#modelRegistry.getAvailable();
+					const availableModels = this.#getAvailableModelsInScope();
 					const match = availableModels.find(m => m.provider === provider && m.id === modelId);
 					if (match) {
 						const currentModel = this.model;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -4,9 +4,10 @@
  * Runs each subagent on the main thread and forwards AgentEvents for progress tracking.
  */
 
-import path from "node:path";
+import * as path from "node:path";
 import type { AgentEvent, AgentIdentity, AgentTelemetryConfig, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { recordHandoff, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
+import type { Model } from "@oh-my-pi/pi-ai";
 import { logger, prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import { ModelRegistry } from "../config/model-registry";
 import { resolveModelOverrideWithAuthFallback } from "../config/model-resolver";
@@ -156,6 +157,8 @@ export interface ExecutorOptions {
 	 * if the resolved subagent model has no working credentials. See #985.
 	 */
 	parentActiveModelPattern?: string;
+	/** Parent session model scope; subagents must not resolve outside it. */
+	scopedModels?: ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }>;
 	thinkingLevel?: ThinkingLevel;
 	outputSchema?: unknown;
 	/** Parent task recursion depth (0 = top-level, 1 = first child, etc.) */
@@ -1141,20 +1144,23 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				thinkingLevel: resolvedThinkingLevel,
 				explicitThinkingLevel,
 				authFallbackUsed,
+				fallbackReason,
 			} = await awaitAbortable(
 				resolveModelOverrideWithAuthFallback(
 					modelPatterns,
 					options.parentActiveModelPattern,
 					modelRegistry,
 					settings,
+					options.scopedModels,
 				),
 			);
-			if (authFallbackUsed && model) {
-				logger.warn("Subagent model has no working credentials; falling back to parent session model", {
+			if ((authFallbackUsed || fallbackReason === "scope") && model) {
+				logger.warn("Subagent model resolved through parent session fallback", {
 					requested: modelPatterns,
 					parentModel: options.parentActiveModelPattern,
 					resolvedProvider: model.provider,
 					resolvedModel: model.id,
+					reason: fallbackReason ?? "auth",
 				});
 			}
 			if (model?.contextWindow && model.contextWindow > 0) {
@@ -1218,6 +1224,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					modelRegistry,
 					settings: subagentSettings,
 					model,
+					scopedModels: options.scopedModels,
 					thinkingLevel: effectiveThinkingLevel,
 					toolNames,
 					outputSchema,

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -14,7 +14,7 @@
  */
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
-import path from "node:path";
+import * as path from "node:path";
 import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import type { Usage } from "@oh-my-pi/pi-ai";
 import { $env, prompt, Snowflake } from "@oh-my-pi/pi-utils";
@@ -773,6 +773,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 
 		// Initialize progress tracking
 		const progressMap = new Map<number, AgentProgress>();
+		const scopedModels = this.session.getScopedModels?.();
 
 		// Update callback
 		const emitProgress = () => {
@@ -903,6 +904,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						taskDepth,
 						modelOverride,
 						parentActiveModelPattern,
+						scopedModels,
 						thinkingLevel: thinkingLevelOverride,
 						outputSchema: effectiveOutputSchema,
 						sessionFile,
@@ -960,6 +962,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 						taskDepth,
 						modelOverride,
 						parentActiveModelPattern,
+						scopedModels,
 						thinkingLevel: thinkingLevelOverride,
 						outputSchema: effectiveOutputSchema,
 						sessionFile,
@@ -1001,6 +1004,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 												this.session.modelRegistry!,
 												this.session.settings,
 												this.session.getSessionId?.() ?? undefined,
+												this.session.getAvailableModels?.(),
 											);
 										}
 									: undefined;
@@ -1254,6 +1258,7 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 											this.session.modelRegistry!,
 											this.session.settings,
 											this.session.getSessionId?.() ?? undefined,
+											this.session.getAvailableModels?.(),
 										);
 									}
 								: undefined;

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -1,6 +1,6 @@
 import type { InMemorySnapshotStore } from "@oh-my-pi/hashline";
-import type { AgentTelemetryConfig, AgentTool } from "@oh-my-pi/pi-agent-core";
-import type { ToolChoice } from "@oh-my-pi/pi-ai";
+import type { AgentTelemetryConfig, AgentTool, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import type { Model, ToolChoice } from "@oh-my-pi/pi-ai";
 import { $env, $flag, logger } from "@oh-my-pi/pi-utils";
 import type { PromptTemplate } from "../config/prompt-templates";
 import type { Settings } from "../config/settings";
@@ -175,6 +175,10 @@ export interface ToolSession {
 	getModelString?: () => string | undefined;
 	/** Get the current session model string, regardless of how it was chosen */
 	getActiveModelString?: () => string | undefined;
+	/** Get available models after applying the active model scope. */
+	getAvailableModels?: () => Model[];
+	/** Get the active scoped models from --models/enabledModels. */
+	getScopedModels?: () => ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }> | undefined;
 	/** Auth storage for passing to subagents (avoids re-discovery) */
 	authStorage?: import("../session/auth-storage").AuthStorage;
 	/** Model registry for passing to subagents (avoids re-discovery) */

--- a/packages/coding-agent/src/tools/inspect-image.ts
+++ b/packages/coding-agent/src/tools/inspect-image.ts
@@ -66,7 +66,7 @@ export class InspectImageTool implements AgentTool<typeof inspectImageSchema, In
 			throw new ToolError("Model registry is unavailable for inspect_image.");
 		}
 
-		const availableModels = modelRegistry.getAvailable();
+		const availableModels = this.session.getAvailableModels?.() ?? modelRegistry.getAvailable();
 		if (availableModels.length === 0) {
 			throw new ToolError("No models available for inspect_image.");
 		}

--- a/packages/coding-agent/src/utils/commit-message-generator.ts
+++ b/packages/coding-agent/src/utils/commit-message-generator.ts
@@ -39,8 +39,9 @@ function filterDiffNoise(diff: string): string {
 function getSmolModelCandidates(
 	registry: ModelRegistry,
 	settings: Settings,
+	availableModelsOverride?: readonly Model<Api>[],
 ): Array<{ model: Model<Api>; thinkingLevel?: ThinkingLevel }> {
-	const availableModels = registry.getAvailable();
+	const availableModels = availableModelsOverride ? [...availableModelsOverride] : registry.getAvailable();
 	if (availableModels.length === 0) return [];
 
 	const candidates: Array<{ model: Model<Api>; thinkingLevel?: ThinkingLevel }> = [];
@@ -80,8 +81,9 @@ export async function generateCommitMessage(
 	registry: ModelRegistry,
 	settings: Settings,
 	sessionId?: string,
+	availableModels?: readonly Model<Api>[],
 ): Promise<string | null> {
-	const candidates = getSmolModelCandidates(registry, settings);
+	const candidates = getSmolModelCandidates(registry, settings, availableModels);
 	if (candidates.length === 0) {
 		logger.debug("commit-msg-generator: no smol model found");
 		return null;

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -152,7 +152,16 @@ export async function generateSessionTitle(
 ): Promise<string | null> {
 	const tinyModel = settings.get("providers.tinyModel");
 	if (tinyModel === ONLINE_TINY_TITLE_MODEL_KEY) {
-		return generateTitleOnline(firstMessage, registry, settings, sessionId, currentModel, metadataResolver, undefined, availableModels);
+		return generateTitleOnline(
+			firstMessage,
+			registry,
+			settings,
+			sessionId,
+			currentModel,
+			metadataResolver,
+			undefined,
+			availableModels,
+		);
 	}
 
 	const onlineAbortController = new AbortController();

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -39,8 +39,13 @@ const setTitleTool: Tool = {
 	},
 };
 
-function getTitleModel(registry: ModelRegistry, settings: Settings, currentModel?: Model<Api>): Model<Api> | undefined {
-	const availableModels = registry.getAvailable();
+function getTitleModel(
+	registry: ModelRegistry,
+	settings: Settings,
+	currentModel?: Model<Api>,
+	availableModelsOverride?: readonly Model<Api>[],
+): Model<Api> | undefined {
+	const availableModels = availableModelsOverride ? [...availableModelsOverride] : registry.getAvailable();
 	if (availableModels.length === 0) return undefined;
 
 	const titleModel = resolveRoleSelection(["commit", "smol"], settings, availableModels, registry)?.model;
@@ -143,10 +148,11 @@ export async function generateSessionTitle(
 	sessionId?: string,
 	currentModel?: Model<Api>,
 	metadataResolver?: (provider: string) => Record<string, unknown> | undefined,
+	availableModels?: readonly Model<Api>[],
 ): Promise<string | null> {
 	const tinyModel = settings.get("providers.tinyModel");
 	if (tinyModel === ONLINE_TINY_TITLE_MODEL_KEY) {
-		return generateTitleOnline(firstMessage, registry, settings, sessionId, currentModel, metadataResolver);
+		return generateTitleOnline(firstMessage, registry, settings, sessionId, currentModel, metadataResolver, undefined, availableModels);
 	}
 
 	const onlineAbortController = new AbortController();
@@ -163,6 +169,7 @@ export async function generateSessionTitle(
 			currentModel,
 			metadataResolver,
 			onlineAbortController.signal,
+			availableModels,
 		);
 
 	return raceFirstNonNull(localTitle, startOnline, TITLE_LOCAL_FALLBACK_DELAY_MS, () => {
@@ -178,8 +185,9 @@ export async function generateTitleOnline(
 	currentModel?: Model<Api>,
 	metadataResolver?: (provider: string) => Record<string, unknown> | undefined,
 	signal?: AbortSignal,
+	availableModels?: readonly Model<Api>[],
 ): Promise<string | null> {
-	const model = getTitleModel(registry, settings, currentModel);
+	const model = getTitleModel(registry, settings, currentModel, availableModels);
 	if (!model) {
 		logger.debug("title-generator: no title model found");
 		return null;

--- a/packages/coding-agent/test/acp-lazy-startup.test.ts
+++ b/packages/coding-agent/test/acp-lazy-startup.test.ts
@@ -13,7 +13,9 @@ import {
 import type { Model } from "@oh-my-pi/pi-ai";
 import { TempDir } from "@oh-my-pi/pi-utils";
 import { Settings } from "../src/config/settings";
+import { runRootCommand } from "../src/main";
 import { createAcpConnection } from "../src/modes/acp/acp-mode";
+import { createAgentSession } from "../src/sdk";
 import type { AgentSession } from "../src/session/agent-session";
 import { AuthStorage } from "../src/session/auth-storage";
 import { SessionManager } from "../src/session/session-manager";
@@ -234,8 +236,6 @@ describe("ACP lazy startup", () => {
 		const authStorage = await AuthStorage.create(path.join(cwd, "auth.db"));
 		try {
 			const settings = Settings.isolated({ "marketplace.autoUpdate": "off" });
-			const { runRootCommand } = await import("../src/main");
-			const { createAgentSession } = await import("../src/sdk");
 			let session: AgentSession | undefined;
 
 			const stopped = runRootCommand(
@@ -277,6 +277,271 @@ describe("ACP lazy startup", () => {
 			}
 			expect(session.model.provider).toBe("runtime-provider");
 			expect(await session.modelRegistry.getApiKey(session.model)).toBe("cli-runtime-key");
+			await session.dispose();
+		} finally {
+			authStorage.close();
+		}
+	}, 15_000);
+
+	it("applies CLI runtime API keys after ACP CLI scopes resolve extension models", async () => {
+		using tempDir = TempDir.createSync("@omp-acp-lazy-scope-api-key-");
+		const cwd = tempDir.path();
+
+		await Bun.write(
+			path.join(cwd, "runtime-provider.ts"),
+			`export default function(pi) {
+	pi.registerProvider("runtime-provider", {
+		baseUrl: "https://runtime.example.com/v1",
+		apiKey: "extension-key",
+		api: "openai-completions",
+		models: [{
+			id: "runtime-model",
+			name: "Runtime Model",
+			reasoning: false,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 128000,
+			maxTokens: 8192,
+		}],
+	});
+}
+`,
+		);
+
+		const authStorage = await AuthStorage.create(path.join(cwd, "auth.db"));
+		try {
+			const settings = Settings.isolated({ "marketplace.autoUpdate": "off" });
+			let session: AgentSession | undefined;
+
+			const stopped = runRootCommand(
+				{
+					mode: "acp",
+					apiKey: "cli-runtime-key",
+					messages: [],
+					fileArgs: [],
+					unknownFlags: new Map(),
+					noSkills: true,
+					noRules: true,
+					noTools: true,
+					noLsp: true,
+					sessionDir: cwd,
+					extensions: [path.join(cwd, "runtime-provider.ts")],
+					models: ["runtime-provider/runtime-model"],
+				},
+				[],
+				{
+					discoverAuthStorage: async () => authStorage,
+					createAgentSession,
+					settings,
+					runAcpMode: async createAcpSession => {
+						session = await createAcpSession(cwd);
+						throw new Error("stop test ACP mode");
+					},
+				},
+			);
+			await expect(stopped).rejects.toThrow("stop test ACP mode");
+
+			if (!session?.model) {
+				throw new Error("Expected extension-scoped model to resolve");
+			}
+			expect(session.model.provider).toBe("runtime-provider");
+			expect(session.model.id).toBe("runtime-model");
+			expect(await session.modelRegistry.getApiKey(session.model)).toBe("cli-runtime-key");
+			await session.dispose();
+		} finally {
+			authStorage.close();
+		}
+	}, 15_000);
+
+	it("applies CLI runtime API keys before resolving CLI model scopes", async () => {
+		using tempDir = TempDir.createSync("@omp-acp-model-scope-api-key-");
+		const cwd = tempDir.path();
+		const authStorage = await AuthStorage.create(path.join(cwd, "auth.db"));
+		try {
+			const settings = Settings.isolated({ "marketplace.autoUpdate": "off" });
+			let session: AgentSession | undefined;
+
+			const stopped = runRootCommand(
+				{
+					mode: "acp",
+					apiKey: "cli-runtime-key",
+					messages: [],
+					fileArgs: [],
+					unknownFlags: new Map(),
+					noSkills: true,
+					noRules: true,
+					noTools: true,
+					noLsp: true,
+					sessionDir: cwd,
+					models: ["openai/gpt-4o-mini"],
+				},
+				[],
+				{
+					discoverAuthStorage: async () => authStorage,
+					createAgentSession,
+					settings,
+					runAcpMode: async createAcpSession => {
+						session = await createAcpSession(cwd);
+						throw new Error("stop test ACP mode");
+					},
+				},
+			);
+			await expect(stopped).rejects.toThrow("stop test ACP mode");
+
+			if (!session?.model) {
+				throw new Error("Expected CLI-scoped model to resolve");
+			}
+			expect(session.model.provider).toBe("openai");
+			expect(session.model.id).toBe("gpt-4o-mini");
+			expect(await session.modelRegistry.getApiKey(session.model)).toBe("cli-runtime-key");
+			await session.dispose();
+		} finally {
+			authStorage.close();
+		}
+	}, 15_000);
+
+	it("resolves settings enabledModels after ACP cwd cloning and extension registration", async () => {
+		using tempDir = TempDir.createSync("@omp-acp-enabled-models-extension-");
+		const cwd = tempDir.path();
+
+		await Bun.write(
+			path.join(cwd, "runtime-provider.ts"),
+			`export default function(pi) {
+		pi.registerProvider("runtime-provider", {
+			baseUrl: "https://runtime.example.com/v1",
+			apiKey: "extension-key",
+			api: "openai-completions",
+			models: [{
+				id: "runtime-model",
+				name: "Runtime Model",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 8192,
+			}],
+		});
+	}
+	`,
+		);
+
+		const authStorage = await AuthStorage.create(path.join(cwd, "auth.db"));
+		try {
+			const settings = Settings.isolated({
+				"marketplace.autoUpdate": "off",
+				enabledModels: [{ path: cwd, models: ["runtime-provider/runtime-model"] }],
+			});
+			let session: AgentSession | undefined;
+
+			const stopped = runRootCommand(
+				{
+					mode: "acp",
+					messages: [],
+					fileArgs: [],
+					unknownFlags: new Map(),
+					noSkills: true,
+					noRules: true,
+					noTools: true,
+					noLsp: true,
+					sessionDir: cwd,
+					extensions: [path.join(cwd, "runtime-provider.ts")],
+				},
+				[],
+				{
+					discoverAuthStorage: async () => authStorage,
+					createAgentSession,
+					settings,
+					runAcpMode: async createAcpSession => {
+						session = await createAcpSession(cwd);
+						throw new Error("stop test ACP mode");
+					},
+				},
+			);
+			await expect(stopped).rejects.toThrow("stop test ACP mode");
+
+			if (!session?.model) {
+				throw new Error("Expected extension-scoped model to resolve");
+			}
+			expect(session.model.provider).toBe("runtime-provider");
+			expect(session.model.id).toBe("runtime-model");
+			expect(session.hasModelScope).toBe(true);
+			expect(session.scopedModels.map(model => `${model.model.provider}/${model.model.id}`)).toEqual([
+				"runtime-provider/runtime-model",
+			]);
+			await session.dispose();
+		} finally {
+			authStorage.close();
+		}
+	}, 15_000);
+
+	it("resolves CLI model scopes after ACP extension registration", async () => {
+		using tempDir = TempDir.createSync("@omp-acp-cli-model-scope-extension-");
+		const cwd = tempDir.path();
+
+		await Bun.write(
+			path.join(cwd, "runtime-provider.ts"),
+			`export default function(pi) {
+		pi.registerProvider("runtime-provider", {
+			baseUrl: "https://runtime.example.com/v1",
+			apiKey: "extension-key",
+			api: "openai-completions",
+			models: [{
+				id: "runtime-model",
+				name: "Runtime Model",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 128000,
+				maxTokens: 8192,
+			}],
+		});
+	}
+	`,
+		);
+
+		const authStorage = await AuthStorage.create(path.join(cwd, "auth.db"));
+		try {
+			authStorage.setRuntimeApiKey("openai", "openai-test-key");
+			const settings = Settings.isolated({ "marketplace.autoUpdate": "off" });
+			let session: AgentSession | undefined;
+
+			const stopped = runRootCommand(
+				{
+					mode: "acp",
+					messages: [],
+					fileArgs: [],
+					unknownFlags: new Map(),
+					noSkills: true,
+					noRules: true,
+					noTools: true,
+					noLsp: true,
+					sessionDir: cwd,
+					extensions: [path.join(cwd, "runtime-provider.ts")],
+					models: ["runtime-provider/runtime-model", "openai/gpt-4o-mini"],
+				},
+				[],
+				{
+					discoverAuthStorage: async () => authStorage,
+					createAgentSession,
+					settings,
+					runAcpMode: async createAcpSession => {
+						session = await createAcpSession(cwd);
+						throw new Error("stop test ACP mode");
+					},
+				},
+			);
+			await expect(stopped).rejects.toThrow("stop test ACP mode");
+
+			if (!session?.model) {
+				throw new Error("Expected extension-scoped model to resolve");
+			}
+			expect(session.model.provider).toBe("runtime-provider");
+			expect(session.model.id).toBe("runtime-model");
+			expect(session.hasModelScope).toBe(true);
+			expect(session.scopedModels.map(model => `${model.model.provider}/${model.model.id}`)).toEqual([
+				"runtime-provider/runtime-model",
+				"openai/gpt-4o-mini",
+			]);
 			await session.dispose();
 		} finally {
 			authStorage.close();

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -800,6 +800,37 @@ describe("resolveModelScope", () => {
 			"github-copilot/anthropic/claude-sonnet-4.5",
 		]);
 	});
+
+	test("keeps provider-qualified glob scopes within that provider", async () => {
+		const scoped = await resolveModelScope(["openai/*"], {
+			getAvailable: () => allModels,
+			getCanonicalVariants: () => [],
+		} as unknown as Parameters<typeof resolveModelScope>[1]);
+
+		expect(scoped.map(entry => `${entry.model.provider}/${entry.model.id}`)).toEqual(["openai/gpt-4o"]);
+	});
+
+	test("keeps slash glob scopes on provider/model strings even when the provider segment has globs", async () => {
+		const scoped = await resolveModelScope(["open*/gpt*"], {
+			getAvailable: () => allModels,
+			getCanonicalVariants: () => [],
+		} as unknown as Parameters<typeof resolveModelScope>[1]);
+
+		expect(scoped.map(entry => `${entry.model.provider}/${entry.model.id}`)).toEqual([
+			"openai/gpt-4o",
+			"openai-codex/gpt-5.3-codex",
+			"openai-codex/gpt-5.3-codex-spark",
+		]);
+	});
+
+	test("keeps unqualified glob scopes matching bare model IDs", async () => {
+		const scoped = await resolveModelScope(["*sonnet*"], {
+			getAvailable: () => allModels,
+			getCanonicalVariants: () => [],
+		} as unknown as Parameters<typeof resolveModelScope>[1]);
+
+		expect(scoped.map(entry => `${entry.model.provider}/${entry.model.id}`)).toEqual(["anthropic/claude-sonnet-4-5"]);
+	});
 });
 
 describe("parseModelString", () => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from "bun:test";
 import { Effort, type Model } from "@oh-my-pi/pi-ai";
 import {
 	expandRoleAlias,
+	filterModelsByScope,
+	filterModelsByScopeOrder,
 	parseModelPattern,
 	parseModelString,
 	resolveAgentModelPatterns,
@@ -787,6 +789,10 @@ describe("resolveCliModel", () => {
 });
 
 describe("resolveModelScope", () => {
+	function modelKeys(models: readonly Model[]): string[] {
+		return models.map(model => `${model.provider}/${model.id}`);
+	}
+
 	test("expands exact canonical ids into all concrete variants", async () => {
 		const scoped = await resolveModelScope(["claude-sonnet-4-5"], {
 			getAvailable: () => canonicalVariantModels,
@@ -830,6 +836,41 @@ describe("resolveModelScope", () => {
 		} as unknown as Parameters<typeof resolveModelScope>[1]);
 
 		expect(scoped.map(entry => `${entry.model.provider}/${entry.model.id}`)).toEqual(["anthropic/claude-sonnet-4-5"]);
+	});
+
+	test("keeps OpenRouter route-suffix clones in scope filters", async () => {
+		const scoped = await resolveModelScope(["openrouter/z-ai/glm-4.7-20251222:nitro"], {
+			getAvailable: () => allModels,
+			getCanonicalVariants: () => [],
+		} as unknown as Parameters<typeof resolveModelScope>[1]);
+
+		expect(scoped.map(entry => `${entry.model.provider}/${entry.model.id}`)).toEqual([
+			"openrouter/z-ai/glm-4.7-20251222:nitro",
+		]);
+		expect(modelKeys(filterModelsByScopeOrder(allModels, scoped))).toEqual([
+			"openrouter/z-ai/glm-4.7-20251222:nitro",
+		]);
+		expect(modelKeys(filterModelsByScope(allModels, scoped))).toEqual(["openrouter/z-ai/glm-4.7-20251222:nitro"]);
+		expect(modelKeys(filterModelsByScopeOrder(allModels, scoped))).not.toContain("openrouter/z-ai/glm-4.7");
+	});
+
+	test("keeps distinct OpenRouter route-suffix clones backed by one catalog model", async () => {
+		const scoped = await resolveModelScope(
+			[
+				"openrouter/z-ai/glm-4.7-20251222:nitro",
+				"openrouter/z-ai/glm-4.7-20251222:floor",
+				"openrouter/z-ai/glm-4.7-20251222:nitro",
+			],
+			{
+				getAvailable: () => allModels,
+				getCanonicalVariants: () => [],
+			} as unknown as Parameters<typeof resolveModelScope>[1],
+		);
+
+		const expectedModels = ["openrouter/z-ai/glm-4.7-20251222:nitro", "openrouter/z-ai/glm-4.7-20251222:floor"];
+		expect(scoped.map(entry => `${entry.model.provider}/${entry.model.id}`)).toEqual(expectedModels);
+		expect(modelKeys(filterModelsByScopeOrder(allModels, scoped))).toEqual(expectedModels);
+		expect(modelKeys(filterModelsByScope(allModels, scoped))).toEqual(expectedModels);
 	});
 });
 

--- a/packages/coding-agent/test/model-scope-enforcement.test.ts
+++ b/packages/coding-agent/test/model-scope-enforcement.test.ts
@@ -191,6 +191,51 @@ describe("model scope enforcement", () => {
 		});
 	});
 
+	it("keeps OpenRouter route-suffix scope clones available without broadening to the base model", async () => {
+		const baseModel: Model = {
+			id: "z-ai/glm-4.7",
+			name: "GLM 4.7",
+			api: "anthropic-messages",
+			provider: "openrouter",
+			baseUrl: "https://openrouter.ai/api/v1",
+			reasoning: true,
+			thinking: {
+				mode: "budget",
+				minLevel: Effort.Minimal,
+				maxLevel: Effort.High,
+			},
+			input: ["text"],
+			cost: { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 1 },
+			contextWindow: 128000,
+			maxTokens: 8192,
+		};
+		authStorage.setRuntimeApiKey("openrouter", "openrouter-test-key");
+		vi.spyOn(modelRegistry, "getAvailable").mockImplementation(() => [baseModel]);
+		vi.spyOn(modelRegistry, "getAll").mockImplementation(() => [baseModel]);
+
+		const result = await createAgentSession({
+			cwd: tempDir.path(),
+			authStorage,
+			modelRegistry,
+			settings: Settings.isolated({}),
+			sessionManager: SessionManager.inMemory(),
+			modelScopePatterns: ["openrouter/z-ai/glm-4.7-20251222:nitro"],
+			preferScopedModelOrder: true,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+		session = result.session;
+
+		expect(session.model ? modelKey(session.model) : undefined).toBe("openrouter/z-ai/glm-4.7-20251222:nitro");
+		expect(session.getAvailableModels().map(modelKey)).toEqual(["openrouter/z-ai/glm-4.7-20251222:nitro"]);
+		await expect(session.setModel(baseModel)).rejects.toThrow("outside active model scope");
+	});
+
 	it("restores saved scoped models after deferred CLI scope credentials are applied", async () => {
 		const firstScopedModel = requireModel("openai", "gpt-4o-mini");
 		const savedModel = requireModel("openai", "gpt-5");

--- a/packages/coding-agent/test/model-scope-enforcement.test.ts
+++ b/packages/coding-agent/test/model-scope-enforcement.test.ts
@@ -1,0 +1,496 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { Effort, type Model } from "@oh-my-pi/pi-ai";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { resolveModelOverrideWithAuthFallback } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { runExtensionSetModel } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/compact-handler";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { AgentSession, type AgentSessionEvent } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+function modelKey(model: Model): string {
+	return `${model.provider}/${model.id}`;
+}
+
+const IMAGE_PROVIDER_ENV_KEYS = [
+	"OPENAI_API_KEY",
+	"OPENROUTER_API_KEY",
+	"GEMINI_API_KEY",
+	"GOOGLE_API_KEY",
+	"XAI_API_KEY",
+	"XAI_OAUTH_TOKEN",
+] as const;
+
+async function withoutImageProviderEnv<T>(run: () => Promise<T>): Promise<T> {
+	const originalValues = new Map<string, string | undefined>();
+	for (const key of IMAGE_PROVIDER_ENV_KEYS) {
+		originalValues.set(key, Bun.env[key]);
+		delete Bun.env[key];
+	}
+	try {
+		return await run();
+	} finally {
+		for (const [key, value] of originalValues) {
+			if (value === undefined) {
+				delete Bun.env[key];
+			} else {
+				Bun.env[key] = value;
+			}
+		}
+	}
+}
+
+describe("model scope enforcement", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let modelRegistry: ModelRegistry;
+	let session: AgentSession | undefined;
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-model-scope-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "anthropic-test-key");
+		authStorage.setRuntimeApiKey("openai", "openai-test-key");
+		modelRegistry = new ModelRegistry(authStorage);
+	});
+
+	afterEach(async () => {
+		if (session) {
+			await session.dispose();
+			session = undefined;
+		}
+		vi.restoreAllMocks();
+		authStorage.close();
+		tempDir.removeSync();
+	});
+
+	function requireModel(provider: string, id: string): Model {
+		const model = modelRegistry.find(provider, id);
+		if (!model) throw new Error(`Expected bundled model ${provider}/${id}`);
+		return model;
+	}
+
+	function createScopedSession(options?: { modelRoles?: Record<string, string> }): AgentSession {
+		const scopedModel = requireModel("openai", "gpt-4o-mini");
+		session = new AgentSession({
+			agent: new Agent({
+				getApiKey: provider => `${provider}-test-key`,
+				initialState: { model: scopedModel, systemPrompt: ["Test"], tools: [], messages: [] },
+			}),
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({
+				"compaction.enabled": false,
+				"contextPromotion.enabled": false,
+				modelRoles: options?.modelRoles ?? {},
+			}),
+			modelRegistry,
+			scopedModels: [{ model: scopedModel }],
+		});
+		return session;
+	}
+
+	it("leaves model selection unrestricted when no scope is configured", async () => {
+		const initialModel = requireModel("openai", "gpt-4o-mini");
+		const otherModel = requireModel("anthropic", "claude-sonnet-4-5");
+		session = new AgentSession({
+			agent: new Agent({
+				getApiKey: provider => `${provider}-test-key`,
+				initialState: { model: initialModel, systemPrompt: ["Test"], tools: [], messages: [] },
+			}),
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({
+				"compaction.enabled": false,
+				"contextPromotion.enabled": false,
+			}),
+			modelRegistry,
+		});
+
+		expect(session.getAvailableModels().map(modelKey)).toContain(modelKey(otherModel));
+		await session.setModel(otherModel);
+		expect(session.model ? modelKey(session.model) : undefined).toBe(modelKey(otherModel));
+	});
+
+	it("filters available models and rejects direct switches outside scope", async () => {
+		const scopedModel = requireModel("openai", "gpt-4o-mini");
+		const outOfScopeModel = requireModel("anthropic", "claude-sonnet-4-5");
+		const scopedSession = createScopedSession();
+
+		expect(scopedSession.getAvailableModels().map(modelKey)).toEqual([modelKey(scopedModel)]);
+		await expect(scopedSession.setModel(outOfScopeModel)).rejects.toThrow("outside active model scope");
+		expect(modelKey(scopedSession.model!)).toBe(modelKey(scopedModel));
+	});
+
+	it("does not resolve role models outside scope", () => {
+		const scopedSession = createScopedSession({
+			modelRoles: { plan: "anthropic/claude-sonnet-4-5" },
+		});
+
+		const resolved = scopedSession.resolveRoleModelWithThinking("plan");
+
+		expect(resolved.model).toBeUndefined();
+	});
+
+	it("uses the scoped model instead of a default role outside scope during startup", async () => {
+		const scopedModel = requireModel("openai", "gpt-4o-mini");
+		const outOfScopeModel = requireModel("anthropic", "claude-sonnet-4-5");
+		const settings = Settings.isolated({
+			modelRoles: { default: modelKey(outOfScopeModel) },
+		});
+
+		const result = await createAgentSession({
+			cwd: tempDir.path(),
+			authStorage,
+			modelRegistry,
+			settings,
+			sessionManager: SessionManager.inMemory(),
+			scopedModels: [{ model: scopedModel }],
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+		session = result.session;
+
+		expect(session.model ? modelKey(session.model) : undefined).toBe(modelKey(scopedModel));
+		expect(session.getAvailableModels().map(modelKey)).toEqual([modelKey(scopedModel)]);
+	});
+
+	it("registers image generation tools after deferred CLI scope selection", async () => {
+		const scopedModel = requireModel("openai", "gpt-4o-mini");
+
+		await withoutImageProviderEnv(async () => {
+			const result = await createAgentSession({
+				cwd: tempDir.path(),
+				authStorage,
+				modelRegistry,
+				settings: Settings.isolated({}),
+				sessionManager: SessionManager.inMemory(),
+				modelScopePatterns: [modelKey(scopedModel)],
+				preferScopedModelOrder: true,
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+			});
+			session = result.session;
+
+			expect(session.model ? modelKey(session.model) : undefined).toBe(modelKey(scopedModel));
+			expect(session.getAllToolNames()).toContain("generate_image");
+			expect(session.getActiveToolNames()).toContain("generate_image");
+		});
+	});
+
+	it("restores saved scoped models after deferred CLI scope credentials are applied", async () => {
+		const firstScopedModel = requireModel("openai", "gpt-4o-mini");
+		const savedModel = requireModel("openai", "gpt-5");
+		authStorage.removeRuntimeApiKey("openai");
+		const sessionManager = SessionManager.inMemory(tempDir.path());
+		sessionManager.appendModelChange(modelKey(savedModel));
+
+		await withoutImageProviderEnv(async () => {
+			const result = await createAgentSession({
+				cwd: tempDir.path(),
+				authStorage,
+				modelRegistry,
+				settings: Settings.isolated({}),
+				sessionManager,
+				modelScopePatterns: [modelKey(firstScopedModel), modelKey(savedModel)],
+				modelScopeApiKey: "openai-cli-key",
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+			});
+			session = result.session;
+
+			expect(session.model ? modelKey(session.model) : undefined).toBe(modelKey(savedModel));
+			expect(result.modelFallbackMessage).toBeUndefined();
+		});
+	});
+
+	it("applies CLI runtime API keys to provider-qualified glob scopes", async () => {
+		authStorage.removeRuntimeApiKey("openai");
+
+		await withoutImageProviderEnv(async () => {
+			const result = await createAgentSession({
+				cwd: tempDir.path(),
+				authStorage,
+				modelRegistry,
+				settings: Settings.isolated({}),
+				sessionManager: SessionManager.inMemory(tempDir.path()),
+				modelScopePatterns: ["openai/*"],
+				modelScopeApiKey: "openai-cli-key",
+				preferScopedModelOrder: true,
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+			});
+			session = result.session;
+
+			const selectedModel = session.model;
+			expect(selectedModel?.provider).toBe("openai");
+			if (!selectedModel) throw new Error("Expected session to select an OpenAI scoped model");
+			expect(await modelRegistry.getApiKey(selectedModel)).toBe("openai-cli-key");
+			expect([...new Set(session.scopedModels.map(scoped => scoped.model.provider))]).toEqual(["openai"]);
+		});
+	});
+
+	it("preserves explicit scoped models before credentials are available", async () => {
+		const scopedModel = requireModel("openai", "gpt-4o-mini");
+		authStorage.removeRuntimeApiKey("openai");
+
+		await withoutImageProviderEnv(async () => {
+			const result = await createAgentSession({
+				cwd: tempDir.path(),
+				authStorage,
+				modelRegistry,
+				settings: Settings.isolated({}),
+				sessionManager: SessionManager.inMemory(tempDir.path()),
+				model: scopedModel,
+				modelScopePatterns: [modelKey(scopedModel)],
+				disableExtensionDiscovery: true,
+				skills: [],
+				contextFiles: [],
+				promptTemplates: [],
+				slashCommands: [],
+				enableMCP: false,
+				enableLsp: false,
+			});
+			session = result.session;
+
+			expect(session.model ? modelKey(session.model) : undefined).toBe(modelKey(scopedModel));
+			expect(result.modelFallbackMessage).toBeUndefined();
+		});
+	});
+
+	it("treats a configured empty scope as no usable model", async () => {
+		const result = await createAgentSession({
+			cwd: tempDir.path(),
+			authStorage,
+			modelRegistry,
+			settings: Settings.isolated({}),
+			sessionManager: SessionManager.inMemory(),
+			scopedModels: [],
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+		session = result.session;
+
+		expect(session.model).toBeUndefined();
+		expect(session.getAvailableModels()).toEqual([]);
+		expect(result.modelFallbackMessage).toContain("active model scope (no models)");
+	});
+
+	it("re-resolves settings enabledModels after model availability changes", async () => {
+		const scopedModel = requireModel("openai", "gpt-4o-mini");
+		let scopedModelAvailable = false;
+		vi.spyOn(modelRegistry, "getAvailable").mockImplementation(() => (scopedModelAvailable ? [scopedModel] : []));
+
+		const result = await createAgentSession({
+			cwd: tempDir.path(),
+			authStorage,
+			modelRegistry,
+			settings: Settings.isolated({
+				enabledModels: [modelKey(scopedModel)],
+			}),
+			sessionManager: SessionManager.inMemory(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+		session = result.session;
+
+		expect(session.hasModelScope).toBe(true);
+		expect(session.getAvailableModels()).toEqual([]);
+
+		scopedModelAvailable = true;
+		await modelRegistry.refresh("offline");
+
+		expect(session.getAvailableModels().map(modelKey)).toEqual([modelKey(scopedModel)]);
+		await session.setModel(scopedModel);
+		expect(session.model ? modelKey(session.model) : undefined).toBe(modelKey(scopedModel));
+	});
+
+	it("preserves enabledModels order during startup fallback", async () => {
+		const firstScopedModel = requireModel("openai", "gpt-4o-mini");
+		const secondScopedModel = requireModel("anthropic", "claude-sonnet-4-5");
+
+		const result = await createAgentSession({
+			cwd: tempDir.path(),
+			authStorage,
+			modelRegistry,
+			settings: Settings.isolated({
+				enabledModels: [modelKey(firstScopedModel), modelKey(secondScopedModel)],
+			}),
+			sessionManager: SessionManager.inMemory(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+		session = result.session;
+
+		expect(session.model ? modelKey(session.model) : undefined).toBe(modelKey(firstScopedModel));
+		expect(session.getAvailableModels().map(modelKey)).toEqual([
+			modelKey(firstScopedModel),
+			modelKey(secondScopedModel),
+		]);
+	});
+
+	it("applies scoped thinking when fallback selects an enabledModels model", async () => {
+		const scopedModel = requireModel("anthropic", "claude-sonnet-4-5");
+
+		const result = await createAgentSession({
+			cwd: tempDir.path(),
+			authStorage,
+			modelRegistry,
+			settings: Settings.isolated({
+				defaultThinkingLevel: Effort.High,
+				enabledModels: [`${modelKey(scopedModel)}:low`],
+			}),
+			sessionManager: SessionManager.inMemory(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+		});
+		session = result.session;
+
+		expect(session.model ? modelKey(session.model) : undefined).toBe(modelKey(scopedModel));
+		expect(session.thinkingLevel).toBe(Effort.Low);
+	});
+
+	it("keeps retry fallback chains inside scope", async () => {
+		const scopedModel = requireModel("openai", "gpt-4o-mini");
+		const outOfScopeFallback = requireModel("anthropic", "claude-sonnet-4-5");
+		const requestedModels: string[] = [];
+		const fallbackAppliedEvents: Array<Extract<AgentSessionEvent, { type: "retry_fallback_applied" }>> = [];
+		const mock = createMockModel();
+		let attempts = 0;
+
+		session = new AgentSession({
+			agent: new Agent({
+				getApiKey: provider => `${provider}-test-key`,
+				initialState: { model: scopedModel, systemPrompt: ["Test"], tools: [], messages: [] },
+				streamFn: (requestedModel, context, options) => {
+					requestedModels.push(modelKey(requestedModel));
+					if (attempts === 0) {
+						attempts += 1;
+						mock.push({ throw: "overloaded_error: provider returned error 503" });
+					} else {
+						mock.push({ content: ["Recovered in scope"] });
+					}
+					return mock.stream(requestedModel, context, options);
+				},
+			}),
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({
+				"compaction.enabled": false,
+				"contextPromotion.enabled": false,
+				"retry.baseDelayMs": 5,
+				"retry.maxRetries": 1,
+				"retry.fallbackChains": { default: [modelKey(outOfScopeFallback)] },
+				modelRoles: { default: modelKey(scopedModel) },
+			}),
+			modelRegistry,
+			scopedModels: [{ model: scopedModel }],
+		});
+		session.subscribe(event => {
+			if (event.type === "retry_fallback_applied") {
+				fallbackAppliedEvents.push(event);
+			}
+		});
+
+		await session.prompt("Retry without leaving scope");
+		await session.waitForIdle();
+
+		expect(requestedModels).toEqual([modelKey(scopedModel), modelKey(scopedModel)]);
+		expect(fallbackAppliedEvents).toEqual([]);
+		expect(session.model ? modelKey(session.model) : undefined).toBe(modelKey(scopedModel));
+	});
+
+	it("falls back task model resolution to the scoped parent model", async () => {
+		const scopedModel = requireModel("openai", "gpt-4o-mini");
+		const outOfScopeTaskModel = requireModel("anthropic", "claude-sonnet-4-5");
+
+		const result = await resolveModelOverrideWithAuthFallback(
+			[modelKey(outOfScopeTaskModel)],
+			modelKey(scopedModel),
+			modelRegistry,
+			Settings.isolated({}),
+			[{ model: scopedModel }],
+		);
+
+		expect(result.fallbackReason).toBe("scope");
+		expect(result.model ? modelKey(result.model) : undefined).toBe(modelKey(scopedModel));
+	});
+
+	it("does not fall back misspelled task model overrides to the scoped parent model", async () => {
+		const scopedModel = requireModel("openai", "gpt-4o-mini");
+
+		const result = await resolveModelOverrideWithAuthFallback(
+			["anthropic/not-a-real-model"],
+			modelKey(scopedModel),
+			modelRegistry,
+			Settings.isolated({}),
+			[{ model: scopedModel }],
+		);
+
+		expect(result.authFallbackUsed).toBe(false);
+		expect(result.fallbackReason).toBeUndefined();
+		expect(result.model).toBeUndefined();
+	});
+
+	it("returns false for extension model switches outside scope", async () => {
+		const scopedModel = requireModel("openai", "gpt-4o-mini");
+		const outOfScopeModel = requireModel("anthropic", "claude-sonnet-4-5");
+		const getApiKey = vi.fn(async (_model: Model) => "sk-test-token");
+		const setModel = vi.fn(async (_model: Model) => {});
+
+		const result = await runExtensionSetModel(
+			{
+				getAvailableModels: () => [scopedModel],
+				modelRegistry: { getApiKey },
+				setModel,
+			},
+			outOfScopeModel,
+		);
+
+		expect(result).toBe(false);
+		expect(getApiKey).not.toHaveBeenCalled();
+		expect(setModel).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { getBundledModel } from "@oh-my-pi/pi-ai";
+import { Effort, getBundledModel } from "@oh-my-pi/pi-ai";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { createAgentSession, type ExtensionFactory } from "@oh-my-pi/pi-coding-agent/sdk";
@@ -102,6 +102,20 @@ describe("createAgentSession deferred model pattern resolution", () => {
 		expect(session.model?.provider).toBe("runtime-provider");
 		expect(session.model?.id).toBe("runtime-reasoning-model");
 		expect(session.thinkingLevel).toBe("off");
+	});
+
+	test("applies scoped thinking when deferred modelPattern resolves", async () => {
+		const settings = Settings.isolated({ defaultThinkingLevel: "high" });
+
+		const { session } = await createAgentSession({
+			...buildSessionOptions("runtime-provider/runtime-reasoning-model"),
+			settings,
+			modelScopePatterns: ["runtime-provider/runtime-reasoning-model:low"],
+		});
+
+		expect(session.model?.provider).toBe("runtime-provider");
+		expect(session.model?.id).toBe("runtime-reasoning-model");
+		expect(session.thinkingLevel).toBe(Effort.Low);
 	});
 
 	test("selects the settings default model without synchronously validating auth", async () => {


### PR DESCRIPTION
  ## What

  This PR makes `--models` and `enabledModels` act as real session-wide model allow-lists instead of only
  influencing model cycling / selector UI.

  When a model scope is configured, the coding-agent now keeps model selection inside that scope across:

  - initial startup/default selection
  - resumed session model restore
  - explicit `--model` / deferred extension model resolution
  - `/model`, RPC, ACP, and extension model switching
  - task/subagent model overrides and fallbacks
  - retry fallback chains
  - compaction, context promotion, title generation, commit message generation, and image/vision helper
  model selection
  - `inspect_image` and memory startup model selection

  This also updates the docs and changelog to describe scoped models as an allow-list.

  ## Behavior changes

  Before this PR, `omp --models ...` could still launch work on a model outside the requested set through
  automatic paths. For example, a session scoped to OpenAI models could still route a task/subagent, retry
  fallback, compaction helper, or RPC/ACP model change to Claude if that path resolved models
  independently.

  After this PR, configured scopes are enforced consistently. If the scope is `--models openai/gpt-4o-
  mini,GPT-5.5`, automatic model selection and model switching must stay inside that resolved set.

  Provider glob behavior is also tightened:

  - `openai/*` now means models from provider `openai` only.
  - It no longer also matches gateway models whose bare model IDs start with `openai/`, such as
  `openrouter/openai/...` or Cloudflare gateway variants.
  - To target gateway IDs, use an explicit provider pattern such as `openrouter/openai/*`, or a cross-
  provider full selector glob such as `*/openai/*`.

  Other compatibility details:

  - Scope resolution is deferred where needed so extension-registered providers/models can participate
  after extensions load.
  - `--api-key --models openai/*` works for single-provider scoped startup.
  - Explicit models that match the configured scope are preserved even before credentials are available, so
  normal auth handling can surface instead of incorrectly dropping the model as out-of-scope.
  - Lightweight memory startup test harnesses remain compatible; real sessions use scoped
  `getAvailableModels()` when available.

  ## Why

  The documented intent of `--models` / `enabledModels` is to restrict model availability for the session.
  In practice, only some UI and cycling paths respected that restriction, while other runtime paths re-
  resolved models from the full registry.

  That created a surprising and risky mismatch: users could explicitly scope a session and still have the
  agent use a model they did not intend to make available.

  This completes the earlier selector-only scope behavior and aligns CLI scoping with the existing
  `enabledModels` fallback fix. It also keeps prior subagent model-routing fixes inside the active scope.

  Related issues referenced in the changelog:

  - #255
  - #1022
  - #985
  - #1008

  ## Testing

  Focused regression tests:

  - `bun --cwd=packages/coding-agent test test/model-resolver.test.ts test/model-scope-enforcement.test.ts
  test/memories-runtime.test.ts`

  Additional scoped/deferred model coverage was added in:

  - `test/model-scope-enforcement.test.ts`
  - `test/model-resolver.test.ts`
  - `test/acp-lazy-startup.test.ts`
  - `test/sdk-model-selection.test.ts`

  Validation:

  - `bun --cwd=packages/coding-agent run check`
  - `git diff --check`
  - `bun --cwd=packages/coding-agent run build`
  - `/home/pearpresha/.local/bin/omp --smoke-test`

  ---

  - [x] `bun check` passes
  - [x] Tested locally
  - [x] CHANGELOG updated (if user-facing)
