### PR TITLE
fix(tui): guarded Windows scrollback replay

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -849,7 +849,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.#pendingSubmissionDispose = undefined;
 		}
 		this.editor.setText("");
-		this.ui.refreshNativeScrollbackIfDirty();
+		this.ui.refreshNativeScrollbackIfDirty({ allowUnknownViewport: true });
 		this.ensureLoadingAnimation();
 		this.ui.requestRender();
 		return submission;

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -18,6 +18,7 @@ let activeTerminal: ProcessTerminal | null = null;
 let terminalEverStarted = false;
 
 const STD_INPUT_HANDLE = -10;
+const STD_OUTPUT_HANDLE = -11;
 const ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200;
 /**
  * Emergency terminal restore - call this from signal/crash handlers
@@ -93,12 +94,17 @@ export interface Terminal {
 	setProgress(active: boolean): void;
 
 	/**
+	 * Returns whether the native terminal viewport is at the scrollback tail when
+	 * the host exposes that state. `undefined` means the terminal cannot report it.
+	 */
+	isNativeViewportAtBottom?(): boolean | undefined;
+
+	/**
 	 * Register a callback for terminal appearance (dark/light) changes.
 	 * Detection uses OSC 11 background color query with Mode 2031 as a change trigger.
 	 * Fires when the detected appearance changes, including the initial detection.
 	 */
 	onAppearanceChange(callback: (appearance: TerminalAppearance) => void): void;
-
 	/** The last detected terminal appearance, or undefined if not yet known. */
 	get appearance(): TerminalAppearance | undefined;
 }
@@ -202,6 +208,33 @@ export class ProcessTerminal implements Terminal {
 		// but avoid background polling there.
 		if (!isWindowsSubsystemForLinux()) {
 			this.#startOsc11Poll();
+		}
+	}
+
+	/**
+	 * Returns true when Windows' active console viewport is at the scrollback tail.
+	 * POSIX terminals do not expose native scrollback position through a standard API.
+	 */
+	isNativeViewportAtBottom(): boolean | undefined {
+		if (process.platform !== "win32") return undefined;
+		try {
+			const kernel32 = dlopen("kernel32.dll", {
+				GetStdHandle: { args: [FFIType.i32], returns: FFIType.ptr },
+				GetConsoleScreenBufferInfo: { args: [FFIType.ptr, FFIType.ptr], returns: FFIType.bool },
+			});
+			try {
+				const handle = kernel32.symbols.GetStdHandle(STD_OUTPUT_HANDLE);
+				const info = new Uint8Array(22);
+				const infoPtr = ptr(info);
+				if (!infoPtr || !kernel32.symbols.GetConsoleScreenBufferInfo(handle, infoPtr)) return undefined;
+				const viewBottom = new DataView(info.buffer, info.byteOffset, info.byteLength).getInt16(16, true);
+				const bufferHeight = new DataView(info.buffer, info.byteOffset, info.byteLength).getInt16(2, true);
+				return viewBottom >= bufferHeight - 1;
+			} finally {
+				kernel32.close();
+			}
+		} catch {
+			return undefined;
 		}
 	}
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -259,6 +259,8 @@ export class Container implements Component {
  * - `deferredShrink`: pure content shrink would re-expose rows already in
  *   native history. Keep row indices stable with blank tail padding, repaint
  *   only the viewport, and defer the real shorter replay to a checkpoint.
+ * - `deferredMutation`: a row-inserting edit would reindex native scrollback
+ *   while the user is scrolled. Defer all bytes until a safe rebuild checkpoint.
  * - `shrink`: trailing rows were dropped — clear extras inline.
  * - `diff`: differential repaint of visible rows / append new rows below.
  */
@@ -269,6 +271,7 @@ type RenderIntent =
 	| { kind: "historyRebuild" }
 	| { kind: "viewportRepaint"; appendFrom?: number }
 	| { kind: "deferredShrink"; paddedLength: number }
+	| { kind: "deferredMutation" }
 	| { kind: "shrink" }
 	| { kind: "diff"; firstChanged: number; lastChanged: number; appendedLines: boolean };
 
@@ -1174,6 +1177,8 @@ export class TUI extends Container {
 				}
 				this.#emitViewportRepaint(lines, width, height, cursorPos);
 				return;
+			case "deferredMutation":
+				return;
 			case "deferredShrink":
 				this.#emitViewportRepaint(
 					this.#padDeferredShrinkLines(lines, intent.paddedLength),
@@ -1299,6 +1304,12 @@ export class TUI extends Container {
 		}
 
 		const contentGrew = newLines.length > this.#previousLines.length;
+		if (contentGrew && diff.firstChanged < this.#previousLines.length && !isMultiplexerSession()) {
+			if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom())) {
+				this.#markNativeScrollbackDirty();
+				return { kind: "deferredMutation" };
+			}
+		}
 
 		// Height changes shift the visible window. Repaint when content didn't
 		// grow, but skip in Termux (software keyboard toggles height) and inside

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -242,6 +242,9 @@ export class Container implements Component {
  * - `viewportRepaint`: rewrite the visible viewport in place. If `appendFrom`
  *   is set, emit those tail rows as scrollback growth first so streaming
  *   output reaches terminal history before the corrected viewport is drawn.
+ * - `deferredShrink`: pure content shrink would re-expose rows already in
+ *   native history. Keep row indices stable with blank tail padding, repaint
+ *   only the viewport, and defer the real shorter replay to a checkpoint.
  * - `shrink`: trailing rows were dropped — clear extras inline.
  * - `diff`: differential repaint of visible rows / append new rows below.
  */
@@ -251,6 +254,7 @@ type RenderIntent =
 	| { kind: "sessionReplace" }
 	| { kind: "historyRebuild" }
 	| { kind: "viewportRepaint"; appendFrom?: number }
+	| { kind: "deferredShrink"; paddedLength: number }
 	| { kind: "shrink" }
 	| { kind: "diff"; firstChanged: number; lastChanged: number; appendedLines: boolean };
 
@@ -636,6 +640,8 @@ export class TUI extends Container {
 	 */
 	refreshNativeScrollbackIfDirty(): boolean {
 		if (!this.#nativeScrollbackDirty || this.#stopped) return false;
+		const nativeViewportAtBottom = this.#readNativeViewportAtBottom();
+		if (!this.#canReplayNativeScrollbackAtCheckpoint(nativeViewportAtBottom)) return false;
 		this.#prepareForcedRender(true);
 		this.#renderRequested = false;
 		this.#lastRenderAt = performance.now();
@@ -1114,7 +1120,15 @@ export class TUI extends Container {
 		const heightChanged = this.#previousHeight > 0 && this.#previousHeight !== height;
 
 		// 3. Classify intent.
-		const intent = this.#planRender(lines, widthChanged, heightChanged, prevViewportTop, height);
+		const nativeViewportAtBottom = this.#readNativeViewportAtBottom();
+		const intent = this.#planRender(
+			lines,
+			widthChanged,
+			heightChanged,
+			prevViewportTop,
+			height,
+			nativeViewportAtBottom,
+		);
 		this.#logRedraw(intent, lines.length, height);
 
 		// 4. Execute.
@@ -1131,14 +1145,14 @@ export class TUI extends Container {
 				return;
 			case "sessionReplace":
 				this.#clearScrollbackOnNextRender = false;
-				this.#nativeScrollbackDirty = false;
+				this.#clearNativeScrollbackDirty();
 				this.#emitFullPaint(lines, width, height, cursorPos, {
 					clearViewport: true,
 					clearScrollback: !isMultiplexerSession(),
 				});
 				return;
 			case "historyRebuild":
-				this.#nativeScrollbackDirty = false;
+				this.#clearNativeScrollbackDirty();
 				this.#emitFullPaint(lines, width, height, cursorPos, {
 					clearViewport: true,
 					clearScrollback: !isMultiplexerSession(),
@@ -1149,6 +1163,14 @@ export class TUI extends Container {
 					this.#emitAppendTail(lines, intent.appendFrom, height, prevViewportTop, prevHardwareCursorRow);
 				}
 				this.#emitViewportRepaint(lines, width, height, cursorPos);
+				return;
+			case "deferredShrink":
+				this.#emitViewportRepaint(
+					this.#padDeferredShrinkLines(lines, intent.paddedLength),
+					width,
+					height,
+					cursorPos,
+				);
 				return;
 			case "shrink":
 				this.#emitShrink(lines, width, height, cursorPos, prevHardwareCursorRow, prevViewportTop);
@@ -1183,6 +1205,7 @@ export class TUI extends Container {
 		heightChanged: boolean,
 		prevViewportTop: number,
 		height: number,
+		nativeViewportAtBottom: boolean | undefined,
 	): RenderIntent {
 		// Initial paint after start(): scrollback must keep its prior shell
 		// content, but the viewport must be cleared so stale rows do not bleed
@@ -1196,14 +1219,19 @@ export class TUI extends Container {
 		// lines were dropped, so no diff is possible. Repaint visible rows only
 		// — emitting the transcript here would duplicate it into scrollback.
 		if (this.#previousLines.length === 0) return { kind: "viewportRepaint" };
+		if (this.#nativeScrollbackDirty && this.#nativeViewportIsAtBottom(nativeViewportAtBottom)) {
+			return { kind: "historyRebuild" };
+		}
 
 		const diff = this.#diffLines(newLines);
-
 		// Shrink across the viewport boundary: the new transcript would re-expose
 		// rows already committed to native scrollback. A real resize already
 		// reflowed history, so rebuild it now; a pure content shrink (e.g. a
-		// streaming tail cell collapsing) defers the clear+replay so a user
-		// scrolled into history is not yanked to the bottom mid-stream.
+		// streaming tail cell collapsing) defers the clear+replay. When the terminal
+		// can report that the user is scrolled into history, the live repaint keeps
+		// the previous row count with blank tail padding; otherwise cursor-home
+		// repainting rewrites old buffer rows with newly bottom-anchored content,
+		// which looks like a jump upward.
 		const naturalViewportTop = Math.max(0, newLines.length - height);
 		if (
 			diff.firstChanged !== -1 &&
@@ -1211,8 +1239,17 @@ export class TUI extends Container {
 			naturalViewportTop < this.#scrollbackHighWater &&
 			!isMultiplexerSession()
 		) {
-			if (widthChanged || heightChanged) return { kind: "historyRebuild" };
-			this.#nativeScrollbackDirty = true;
+			if (widthChanged || heightChanged) {
+				if (this.#nativeViewportIsScrolled(nativeViewportAtBottom)) {
+					this.#markNativeScrollbackDirty();
+					return { kind: "deferredShrink", paddedLength: this.#previousLines.length };
+				}
+				return { kind: "historyRebuild" };
+			}
+			this.#markNativeScrollbackDirty();
+			if (this.#nativeViewportIsScrolled(nativeViewportAtBottom)) {
+				return { kind: "deferredShrink", paddedLength: this.#previousLines.length };
+			}
 			return { kind: "viewportRepaint" };
 		}
 
@@ -1241,7 +1278,13 @@ export class TUI extends Container {
 		// reflowed and the user is at the terminal to resize. Pure appends fall
 		// through to the diff path so the append handler scrolls them into history.
 		if (widthChanged) {
-			if (diff.firstChanged < prevViewportTop) return { kind: "historyRebuild" };
+			if (diff.firstChanged < prevViewportTop) {
+				if (this.#nativeViewportIsScrolled(nativeViewportAtBottom)) {
+					this.#markNativeScrollbackDirty();
+					return { kind: "viewportRepaint" };
+				}
+				return { kind: "historyRebuild" };
+			}
 			const pureAppend = diff.appendedLines && diff.firstChanged === this.#previousLines.length;
 			if (!pureAppend) return { kind: "viewportRepaint" };
 		}
@@ -1337,6 +1380,34 @@ export class TUI extends Container {
 		return bestEnd === -1 ? newLines.length : bestEnd + 1;
 	}
 
+	#markNativeScrollbackDirty(): void {
+		this.#nativeScrollbackDirty = true;
+	}
+
+	#clearNativeScrollbackDirty(): void {
+		this.#nativeScrollbackDirty = false;
+	}
+
+	#readNativeViewportAtBottom(): boolean | undefined {
+		return this.terminal.isNativeViewportAtBottom?.();
+	}
+
+	#nativeViewportIsScrolled(nativeViewportAtBottom: boolean | undefined): boolean {
+		return nativeViewportAtBottom === false || (nativeViewportAtBottom === undefined && process.platform === "win32");
+	}
+
+	#nativeViewportIsAtBottom(nativeViewportAtBottom: boolean | undefined): boolean {
+		return nativeViewportAtBottom === true;
+	}
+
+	#canReplayNativeScrollbackAtCheckpoint(nativeViewportAtBottom: boolean | undefined): boolean {
+		return nativeViewportAtBottom === true || (nativeViewportAtBottom === undefined && process.platform !== "win32");
+	}
+
+	#padDeferredShrinkLines(lines: string[], paddedLength: number): string[] {
+		if (lines.length >= paddedLength) return lines;
+		return [...lines, ...new Array<string>(paddedLength - lines.length).fill("")];
+	}
 	/**
 	 * Truncate a line to the visible viewport width. Image lines are left
 	 * alone, narrow lines pass through unchanged. Truncation re-appends the

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1304,7 +1304,9 @@ export class TUI extends Container {
 		}
 
 		const contentGrew = newLines.length > this.#previousLines.length;
-		if (contentGrew && diff.firstChanged < this.#previousLines.length && !isMultiplexerSession()) {
+		const pureAppend = diff.appendedLines && diff.firstChanged === this.#previousLines.length;
+		const structuralMutation = newLines.length !== this.#previousLines.length || diff.firstChanged < prevViewportTop;
+		if (!pureAppend && structuralMutation && !isMultiplexerSession()) {
 			if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom())) {
 				this.#markNativeScrollbackDirty();
 				return { kind: "deferredMutation" };
@@ -1329,9 +1331,8 @@ export class TUI extends Container {
 			return { kind: "shrink" };
 		}
 
-		// Offscreen edit: viewport repaint corrects the shifted rows. If new
-		// rows also appended in the same frame, emit them as scrollback growth
-		// first so streaming output is not lost from terminal history.
+		// Offscreen edit: viewport repaint corrects shifted rows when the native
+		// viewport is at the tail. Scrolled native-history cases are deferred above.
 		if (diff.firstChanged < prevViewportTop) {
 			const appendFrom = diff.appendedLines ? this.#findAppendedTailStart(newLines) : undefined;
 			return { kind: "viewportRepaint", appendFrom };

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -76,6 +76,11 @@ export interface RenderRequestOptions {
 	clearScrollback?: boolean;
 }
 
+/** Options for deferred native scrollback rebuild checkpoints. */
+export interface NativeScrollbackRefreshOptions {
+	/** Allow replay when the terminal cannot report viewport state. Use only for explicit user submit checkpoints. */
+	allowUnknownViewport?: boolean;
+}
 /** Type guard to check if a component implements Focusable */
 export function isFocusable(component: Component | null): component is Component & Focusable {
 	return component !== null && "focused" in component;
@@ -647,10 +652,14 @@ export class TUI extends Container {
 	 * Callers should only invoke this at checkpoints where the user is expected to be
 	 * at the terminal bottom, such as after submitting a new prompt.
 	 */
-	refreshNativeScrollbackIfDirty(): boolean {
+	refreshNativeScrollbackIfDirty(options?: NativeScrollbackRefreshOptions): boolean {
 		if (!this.#nativeScrollbackDirty || this.#stopped) return false;
 		const nativeViewportAtBottom = this.#readNativeViewportAtBottom();
-		if (!this.#canReplayNativeScrollbackAtCheckpoint(nativeViewportAtBottom)) return false;
+		if (
+			!this.#canReplayNativeScrollbackAtCheckpoint(nativeViewportAtBottom, options?.allowUnknownViewport === true)
+		) {
+			return false;
+		}
 		this.#prepareForcedRender(true);
 		this.#renderRequested = false;
 		this.#lastRenderAt = performance.now();
@@ -1412,10 +1421,13 @@ export class TUI extends Container {
 		return nativeViewportAtBottom === true;
 	}
 
-	#canReplayNativeScrollbackAtCheckpoint(nativeViewportAtBottom: boolean | undefined): boolean {
+	#canReplayNativeScrollbackAtCheckpoint(
+		nativeViewportAtBottom: boolean | undefined,
+		allowUnknownViewport: boolean,
+	): boolean {
 		return (
 			nativeViewportAtBottom === true ||
-			(nativeViewportAtBottom === undefined && !requiresNativeViewportProofForReplay())
+			(nativeViewportAtBottom === undefined && (allowUnknownViewport || !requiresNativeViewportProofForReplay()))
 		);
 	}
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -139,6 +139,15 @@ function isMultiplexerSession(): boolean {
 	return Boolean(Bun.env.TMUX || Bun.env.STY || Bun.env.ZELLIJ);
 }
 
+function requiresNativeViewportProofForReplay(): boolean {
+	return (
+		process.platform === "win32" ||
+		(process.platform === "linux" &&
+			Boolean(Bun.env.WT_SESSION) &&
+			Boolean(Bun.env.WSL_DISTRO_NAME || Bun.env.WSL_INTEROP))
+	);
+}
+
 /**
  * Options for overlay positioning and sizing.
  * Values can be absolute numbers or percentage strings (e.g., "50%").
@@ -1393,7 +1402,10 @@ export class TUI extends Container {
 	}
 
 	#nativeViewportIsScrolled(nativeViewportAtBottom: boolean | undefined): boolean {
-		return nativeViewportAtBottom === false || (nativeViewportAtBottom === undefined && process.platform === "win32");
+		return (
+			nativeViewportAtBottom === false ||
+			(nativeViewportAtBottom === undefined && requiresNativeViewportProofForReplay())
+		);
 	}
 
 	#nativeViewportIsAtBottom(nativeViewportAtBottom: boolean | undefined): boolean {
@@ -1401,7 +1413,10 @@ export class TUI extends Container {
 	}
 
 	#canReplayNativeScrollbackAtCheckpoint(nativeViewportAtBottom: boolean | undefined): boolean {
-		return nativeViewportAtBottom === true || (nativeViewportAtBottom === undefined && process.platform !== "win32");
+		return (
+			nativeViewportAtBottom === true ||
+			(nativeViewportAtBottom === undefined && !requiresNativeViewportProofForReplay())
+		);
 	}
 
 	#padDeferredShrinkLines(lines: string[], paddedLength: number): string[] {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1138,15 +1138,7 @@ export class TUI extends Container {
 		const heightChanged = this.#previousHeight > 0 && this.#previousHeight !== height;
 
 		// 3. Classify intent.
-		const nativeViewportAtBottom = this.#readNativeViewportAtBottom();
-		const intent = this.#planRender(
-			lines,
-			widthChanged,
-			heightChanged,
-			prevViewportTop,
-			height,
-			nativeViewportAtBottom,
-		);
+		const intent = this.#planRender(lines, widthChanged, heightChanged, prevViewportTop, height);
 		this.#logRedraw(intent, lines.length, height);
 
 		// 4. Execute.
@@ -1223,7 +1215,6 @@ export class TUI extends Container {
 		heightChanged: boolean,
 		prevViewportTop: number,
 		height: number,
-		nativeViewportAtBottom: boolean | undefined,
 	): RenderIntent {
 		// Initial paint after start(): scrollback must keep its prior shell
 		// content, but the viewport must be cleared so stale rows do not bleed
@@ -1237,7 +1228,7 @@ export class TUI extends Container {
 		// lines were dropped, so no diff is possible. Repaint visible rows only
 		// — emitting the transcript here would duplicate it into scrollback.
 		if (this.#previousLines.length === 0) return { kind: "viewportRepaint" };
-		if (this.#nativeScrollbackDirty && this.#nativeViewportIsAtBottom(nativeViewportAtBottom)) {
+		if (this.#nativeScrollbackDirty && this.#nativeViewportIsAtBottom(this.#readNativeViewportAtBottom())) {
 			return { kind: "historyRebuild" };
 		}
 
@@ -1258,14 +1249,14 @@ export class TUI extends Container {
 			!isMultiplexerSession()
 		) {
 			if (widthChanged || heightChanged) {
-				if (this.#nativeViewportIsScrolled(nativeViewportAtBottom)) {
+				if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom())) {
 					this.#markNativeScrollbackDirty();
 					return { kind: "deferredShrink", paddedLength: this.#previousLines.length };
 				}
 				return { kind: "historyRebuild" };
 			}
 			this.#markNativeScrollbackDirty();
-			if (this.#nativeViewportIsScrolled(nativeViewportAtBottom)) {
+			if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom())) {
 				return { kind: "deferredShrink", paddedLength: this.#previousLines.length };
 			}
 			return { kind: "viewportRepaint" };
@@ -1297,7 +1288,7 @@ export class TUI extends Container {
 		// through to the diff path so the append handler scrolls them into history.
 		if (widthChanged) {
 			if (diff.firstChanged < prevViewportTop) {
-				if (this.#nativeViewportIsScrolled(nativeViewportAtBottom)) {
+				if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom())) {
 					this.#markNativeScrollbackDirty();
 					return { kind: "viewportRepaint" };
 				}

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -59,6 +59,7 @@ class CountingViewportTerminal extends VirtualTerminal {
 		return super.isNativeViewportAtBottom();
 	}
 }
+
 function rows(prefix: string, count: number): string[] {
 	return Array.from({ length: count }, (_v, i) => `${prefix}${i}`);
 }
@@ -975,6 +976,40 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 
+		it("defers offscreen expansion while native scrollback is scrolled", async () => {
+			const term = new VirtualTerminal(32, 5);
+			const tui = new TUI(term);
+			const component = new MutableLinesComponent(rows("line-", 12));
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				term.scrollLines(-2);
+				const before = term.getBufferPosition();
+				expect(before.viewportY).toBeGreaterThan(0);
+				expect(visible(term).map(line => line.trim())).toEqual(["line-5", "line-6", "line-7", "line-8", "line-9"]);
+
+				component.setLines(["line-0", "line-1", "expanded-0", "expanded-1", ...rows("line-", 12).slice(2)]);
+				tui.requestRender();
+				await settle(term);
+
+				const after = term.getBufferPosition();
+				expect(after.viewportY).toBe(before.viewportY);
+				expect(visible(term).map(line => line.trim())).toEqual(["line-5", "line-6", "line-7", "line-8", "line-9"]);
+				expect(term.getScrollBuffer().join("\n")).not.toContain("expanded-0");
+
+				term.scrollLines(999);
+				tui.requestRender();
+				await settle(term);
+
+				const finalPosition = term.getBufferPosition();
+				expect(finalPosition.viewportY).toBe(finalPosition.baseY);
+				expect(term.getScrollBuffer().join("\n")).toContain("expanded-0");
+			} finally {
+				tui.stop();
+			}
+		});
 		it("treats unknown Windows viewport state as scrolled", async () => {
 			const originalPlatform = process.platform;
 			Object.defineProperty(process, "platform", { configurable: true, value: "win32" });

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -971,6 +971,49 @@ describe("TUI terminal-state regressions", () => {
 				tui.stop();
 			}
 		});
+
+		it("treats unknown WSL Windows Terminal viewport state as scrolled", async () => {
+			const originalPlatform = process.platform;
+			const originalWtSession = Bun.env.WT_SESSION;
+			const originalWslDistroName = Bun.env.WSL_DISTRO_NAME;
+			const originalWslInterop = Bun.env.WSL_INTEROP;
+			Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
+			Bun.env.WT_SESSION = "wt-test";
+			Bun.env.WSL_DISTRO_NAME = "Ubuntu";
+			delete Bun.env.WSL_INTEROP;
+
+			const term = new UnknownViewportTerminal(32, 5);
+			const tui = new TUI(term);
+			const component = new MutableLinesComponent(rows("line-", 12));
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				term.scrollLines(-2);
+				const before = term.getBufferPosition();
+				expect(before.viewportY).toBeGreaterThan(0);
+
+				component.setLines(rows("line-", 8));
+				tui.requestRender();
+				await settle(term);
+
+				const after = term.getBufferPosition();
+				expect(after.viewportY).toBe(before.viewportY);
+				expect(visible(term).map(line => line.trim())).toEqual(["line-5", "line-6", "line-7", "", ""]);
+				expect(tui.refreshNativeScrollbackIfDirty()).toBe(false);
+				expect(term.getBufferPosition().viewportY).toBe(before.viewportY);
+			} finally {
+				Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+				if (originalWtSession === undefined) delete Bun.env.WT_SESSION;
+				else Bun.env.WT_SESSION = originalWtSession;
+				if (originalWslDistroName === undefined) delete Bun.env.WSL_DISTRO_NAME;
+				else Bun.env.WSL_DISTRO_NAME = originalWslDistroName;
+				if (originalWslInterop === undefined) delete Bun.env.WSL_INTEROP;
+				else Bun.env.WSL_INTEROP = originalWslInterop;
+				tui.stop();
+			}
+		});
 		it("refreshes deferred native scrollback when the native viewport reaches bottom", async () => {
 			const term = new VirtualTerminal(32, 5);
 			const tui = new TUI(term);

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -45,6 +45,11 @@ class WrappingLinesComponent implements Component {
 	}
 }
 
+class UnknownViewportTerminal extends VirtualTerminal {
+	isNativeViewportAtBottom(): undefined {
+		return undefined;
+	}
+}
 function rows(prefix: string, count: number): string[] {
 	return Array.from({ length: count }, (_v, i) => `${prefix}${i}`);
 }
@@ -768,6 +773,32 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 
+		it("defers resize rebuild while native scrollback is scrolled", async () => {
+			const term = new VirtualTerminal(32, 5);
+			const tui = new TUI(term);
+			const component = new MutableLinesComponent(rows("line-", 12));
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				term.scrollLines(-2);
+				const before = term.getBufferPosition();
+				expect(before.viewportY).toBeGreaterThan(0);
+
+				component.setLines(rows("line-", 8));
+				term.resize(28, 5);
+				await settle(term);
+
+				const after = term.getBufferPosition();
+				expect(after.viewportY).toBe(before.viewportY);
+				expect(visible(term).map(line => line.trim())).toEqual(["line-5", "line-6", "line-7", "", ""]);
+				expect(tui.refreshNativeScrollbackIfDirty()).toBe(false);
+			} finally {
+				tui.stop();
+			}
+		});
+
 		it("keeps viewport aligned when offscreen header changes during overflow growth", async () => {
 			const term = new VirtualTerminal(32, 6);
 			const tui = new TUI(term);
@@ -896,6 +927,7 @@ describe("TUI terminal-state regressions", () => {
 				term.scrollLines(-2);
 				const before = term.getBufferPosition();
 				expect(before.viewportY).toBeGreaterThan(0);
+				expect(visible(term).map(line => line.trim())).toEqual(["line-5", "line-6", "line-7", "line-8", "line-9"]);
 
 				component.setLines(rows("line-", 8));
 				tui.requestRender();
@@ -903,13 +935,43 @@ describe("TUI terminal-state regressions", () => {
 
 				const after = term.getBufferPosition();
 				expect(after.viewportY).toBe(before.viewportY);
-				expect(tui.refreshNativeScrollbackIfDirty()).toBe(true);
+				expect(visible(term).map(line => line.trim())).toEqual(["line-5", "line-6", "line-7", "", ""]);
+				expect(tui.refreshNativeScrollbackIfDirty()).toBe(false);
 			} finally {
 				tui.stop();
 			}
 		});
 
-		it("refreshes deferred native scrollback at an explicit bottom checkpoint", async () => {
+		it("treats unknown Windows viewport state as scrolled", async () => {
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+			const term = new UnknownViewportTerminal(32, 5);
+			const tui = new TUI(term);
+			const component = new MutableLinesComponent(rows("line-", 12));
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				term.scrollLines(-2);
+				const before = term.getBufferPosition();
+				expect(before.viewportY).toBeGreaterThan(0);
+
+				component.setLines(rows("line-", 8));
+				tui.requestRender();
+				await settle(term);
+
+				const after = term.getBufferPosition();
+				expect(after.viewportY).toBe(before.viewportY);
+				expect(visible(term).map(line => line.trim())).toEqual(["line-5", "line-6", "line-7", "", ""]);
+				expect(tui.refreshNativeScrollbackIfDirty()).toBe(false);
+				expect(term.getBufferPosition().viewportY).toBe(before.viewportY);
+			} finally {
+				Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+				tui.stop();
+			}
+		});
+		it("refreshes deferred native scrollback when the native viewport reaches bottom", async () => {
 			const term = new VirtualTerminal(32, 5);
 			const tui = new TUI(term);
 			const component = new MutableLinesComponent(rows("line-", 12));
@@ -925,7 +987,7 @@ describe("TUI terminal-state regressions", () => {
 				await settle(term);
 
 				term.scrollLines(999);
-				expect(tui.refreshNativeScrollbackIfDirty()).toBe(true);
+				tui.requestRender();
 				await settle(term);
 
 				const position = term.getBufferPosition();

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -1010,6 +1010,41 @@ describe("TUI terminal-state regressions", () => {
 				tui.stop();
 			}
 		});
+
+		it("defers height-changing tail preview while native scrollback is scrolled", async () => {
+			const term = new VirtualTerminal(32, 5);
+			const tui = new TUI(term);
+			const component = new MutableLinesComponent(rows("line-", 12));
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				term.scrollLines(-2);
+				const before = term.getBufferPosition();
+				expect(before.viewportY).toBeGreaterThan(0);
+				expect(visible(term).map(line => line.trim())).toEqual(["line-5", "line-6", "line-7", "line-8", "line-9"]);
+
+				component.setLines([...rows("line-", 9), "preview-appeared", ...rows("line-", 12).slice(9)]);
+				tui.requestRender();
+				await settle(term);
+
+				const after = term.getBufferPosition();
+				expect(after.viewportY).toBe(before.viewportY);
+				expect(visible(term).map(line => line.trim())).toEqual(["line-5", "line-6", "line-7", "line-8", "line-9"]);
+				expect(term.getScrollBuffer().join("\n")).not.toContain("preview-appeared");
+
+				term.scrollLines(999);
+				tui.requestRender();
+				await settle(term);
+
+				const finalPosition = term.getBufferPosition();
+				expect(finalPosition.viewportY).toBe(finalPosition.baseY);
+				expect(term.getScrollBuffer().join("\n")).toContain("preview-appeared");
+			} finally {
+				tui.stop();
+			}
+		});
 		it("treats unknown Windows viewport state as scrolled", async () => {
 			const originalPlatform = process.platform;
 			Object.defineProperty(process, "platform", { configurable: true, value: "win32" });

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -1014,6 +1014,49 @@ describe("TUI terminal-state regressions", () => {
 				tui.stop();
 			}
 		});
+
+		it("refreshes unknown WSL Windows Terminal scrollback at a submit checkpoint", async () => {
+			const originalPlatform = process.platform;
+			const originalWtSession = Bun.env.WT_SESSION;
+			const originalWslDistroName = Bun.env.WSL_DISTRO_NAME;
+			const originalWslInterop = Bun.env.WSL_INTEROP;
+			Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
+			Bun.env.WT_SESSION = "wt-test";
+			Bun.env.WSL_DISTRO_NAME = "Ubuntu";
+			delete Bun.env.WSL_INTEROP;
+
+			const term = new UnknownViewportTerminal(32, 5);
+			const tui = new TUI(term);
+			const component = new MutableLinesComponent(rows("line-", 12));
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				term.scrollLines(-2);
+
+				component.setLines(rows("line-", 8));
+				tui.requestRender();
+				await settle(term);
+				term.scrollLines(999);
+
+				expect(tui.refreshNativeScrollbackIfDirty({ allowUnknownViewport: true })).toBe(true);
+				await settle(term);
+
+				const position = term.getBufferPosition();
+				expect(position.viewportY).toBe(position.baseY);
+				expect(visible(term).map(line => line.trim())).toEqual(["line-3", "line-4", "line-5", "line-6", "line-7"]);
+			} finally {
+				Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+				if (originalWtSession === undefined) delete Bun.env.WT_SESSION;
+				else Bun.env.WT_SESSION = originalWtSession;
+				if (originalWslDistroName === undefined) delete Bun.env.WSL_DISTRO_NAME;
+				else Bun.env.WSL_DISTRO_NAME = originalWslDistroName;
+				if (originalWslInterop === undefined) delete Bun.env.WSL_INTEROP;
+				else Bun.env.WSL_INTEROP = originalWslInterop;
+				tui.stop();
+			}
+		});
 		it("refreshes deferred native scrollback when the native viewport reaches bottom", async () => {
 			const term = new VirtualTerminal(32, 5);
 			const tui = new TUI(term);

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -50,6 +50,15 @@ class UnknownViewportTerminal extends VirtualTerminal {
 		return undefined;
 	}
 }
+
+class CountingViewportTerminal extends VirtualTerminal {
+	viewportProbeCount = 0;
+
+	isNativeViewportAtBottom(): boolean | undefined {
+		this.viewportProbeCount += 1;
+		return super.isNativeViewportAtBottom();
+	}
+}
 function rows(prefix: string, count: number): string[] {
 	return Array.from({ length: count }, (_v, i) => `${prefix}${i}`);
 }
@@ -683,6 +692,30 @@ describe("TUI terminal-state regressions", () => {
 	});
 
 	describe("scrollback integrity", () => {
+		it("does not probe native viewport state during pure appends", async () => {
+			const term = new CountingViewportTerminal(32, 5);
+			const tui = new TUI(term);
+			const lines = rows("line-", 3);
+			const component = new MutableLinesComponent(lines);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+
+				for (let i = 3; i < 20; i++) {
+					lines.push(`line-${i}`);
+					component.setLines(lines);
+					tui.requestRender();
+					await settle(term);
+				}
+
+				expect(term.viewportProbeCount).toBe(0);
+			} finally {
+				tui.stop();
+			}
+		});
+
 		it("overflow content appears once across buffer without duplicate row IDs", async () => {
 			const term = new VirtualTerminal(32, 5);
 			const tui = new TUI(term);

--- a/packages/tui/test/virtual-terminal.ts
+++ b/packages/tui/test/virtual-terminal.ts
@@ -138,6 +138,12 @@ export class VirtualTerminal implements Terminal {
 		this.xterm.scrollLines(lines);
 	}
 
+	/** Return whether the virtual viewport is at the scrollback tail. */
+	isNativeViewportAtBottom(): boolean | undefined {
+		const buffer = this.xterm.buffer.active;
+		return buffer.viewportY >= buffer.baseY;
+	}
+
 	/** Get the terminal buffer's scrollback and viewport offsets. */
 	getBufferPosition(): { baseY: number; viewportY: number } {
 		const buffer = this.xterm.buffer.active;


### PR DESCRIPTION
## What

Guarded deferred TUI native scrollback rebuilds so Windows only takes the destructive clear/replay path when the terminal explicitly reports that the native viewport is at the bottom. If Windows viewport state is unavailable, the TUI now treats it as unsafe/scrolled and keeps the row-stable deferred repaint path.

## Why

Windows Terminal can jump the scrollbar to the top when CSI 3J clear/replay runs while the user may be scrolled into native history. The previous guard failed open when isNativeViewportAtBottom() returned undefined, so unavailable viewport state could still trigger the destructive rebuild.

## Testing

- bun run check
 - bun test packages/tui/test/render-regressions.test.ts
 
---

- [x ] `bun check` passes
- [x ] Tested locally
- [ NA] CHANGELOG updated (if user-facing)
