### PR TITLE
fix(tui): decode Alt+letter as literal under tmux+kitty mixed mode

### DIFF
--- a/crates/pi-natives/src/keys.rs
+++ b/crates/pi-natives/src/keys.rs
@@ -200,8 +200,6 @@ static LEGACY_SEQUENCES: phf::Map<&'static [u8], &'static str> = phf_map! {
 	b"\x1b[[A" => "f1", b"\x1b[[B" => "f2", b"\x1b[[C" => "f3", b"\x1b[[D" => "f4", b"\x1b[[E" => "f5",
 	b"\x1b[15~" => "f5", b"\x1b[17~" => "f6", b"\x1b[18~" => "f7", b"\x1b[19~" => "f8",
 	b"\x1b[20~" => "f9", b"\x1b[21~" => "f10", b"\x1b[23~" => "f11", b"\x1b[24~" => "f12",
-	// Alt+arrow (legacy)
-	b"\x1bb" => "alt+left", b"\x1bf" => "alt+right", b"\x1bp" => "alt+up", b"\x1bn" => "alt+down",
 };
 
 /// Pre-allocated single ASCII printable characters (33-126)
@@ -798,22 +796,22 @@ fn matches_key_inner(bytes: &[u8], key_id: &str, kitty_protocol_active: bool) ->
 	}
 
 	if key.eq_ignore_ascii_case("up") {
-		if modifier == MOD_ALT {
-			return bytes == b"\x1bp" || kitty_matches(ARROW_UP, MOD_ALT);
-		}
 		if modifier == 0 {
 			return matches_legacy_key(bytes, "up") || kitty_matches(ARROW_UP, 0);
+		}
+		if modifier == MOD_ALT {
+			return kitty_matches(ARROW_UP, MOD_ALT);
 		}
 		return matches_legacy_modifier_sequence(bytes, "up", modifier)
 			|| kitty_matches(ARROW_UP, modifier);
 	}
 
 	if key.eq_ignore_ascii_case("down") {
-		if modifier == MOD_ALT {
-			return bytes == b"\x1bn" || kitty_matches(ARROW_DOWN, MOD_ALT);
-		}
 		if modifier == 0 {
 			return matches_legacy_key(bytes, "down") || kitty_matches(ARROW_DOWN, 0);
+		}
+		if modifier == MOD_ALT {
+			return kitty_matches(ARROW_DOWN, MOD_ALT);
 		}
 		return matches_legacy_modifier_sequence(bytes, "down", modifier)
 			|| kitty_matches(ARROW_DOWN, modifier);
@@ -821,9 +819,11 @@ fn matches_key_inner(bytes: &[u8], key_id: &str, kitty_protocol_active: bool) ->
 
 	if key.eq_ignore_ascii_case("left") {
 		if modifier == MOD_ALT {
+			// `\x1bB` (uppercase) was the historic xterm Alt+Left encoding in legacy
+			// readline mode. Lowercase `\x1bb` is Alt+B (letter); resolving it as
+			// alt+left collides with literal Alt+B bindings (issue #1511).
 			return bytes == b"\x1b[1;3D"
 				|| (!kitty_protocol_active && bytes == b"\x1bB")
-				|| bytes == b"\x1bb"
 				|| kitty_matches(ARROW_LEFT, MOD_ALT);
 		}
 		if modifier == MOD_CTRL {
@@ -840,9 +840,10 @@ fn matches_key_inner(bytes: &[u8], key_id: &str, kitty_protocol_active: bool) ->
 
 	if key.eq_ignore_ascii_case("right") {
 		if modifier == MOD_ALT {
+			// Same rationale as `left`: lowercase `\x1bf` is Alt+F (letter), not
+			// alt+right. Uppercase `\x1bF` is the legacy xterm Alt+Right form.
 			return bytes == b"\x1b[1;3C"
 				|| (!kitty_protocol_active && bytes == b"\x1bF")
-				|| bytes == b"\x1bf"
 				|| kitty_matches(ARROW_RIGHT, MOD_ALT);
 		}
 		if modifier == MOD_CTRL {
@@ -883,14 +884,16 @@ fn matches_key_inner(bytes: &[u8], key_id: &str, kitty_protocol_active: bool) ->
 		let codepoint = ch as i32;
 		let is_letter = ch.is_ascii_lowercase();
 
-		// ctrl+alt+letter in legacy mode
-		// Legacy: ctrl+alt+letter is ESC followed by the control character.
-		// If that legacy form does not match, continue so CSI-u and
-		// modifyOtherKeys sequences from tmux can still be recognized.
-		// Legacy ESC+ctrl-char would also match Alt+Enter/Alt+Backspace/etc;
-		// skip the legacy fast-path for those bytes and let kitty/modifyOtherKeys
-		// disambiguate.
-		if modifier == (MOD_CTRL | MOD_ALT) && !kitty_protocol_active && is_letter {
+		// Legacy ESC-prefixed Alt encodings. Accepted in BOTH legacy and kitty mode
+		// because multiplexers like tmux and Zellij regularly forward kitty replies
+		// upstream while still emitting legacy ESC+letter forms for these
+		// combinations (issue #1511). The branches fall through to kitty_matches /
+		// mok_matches at the bottom so native CSI-u keeps matching too.
+
+		// ctrl+alt+letter: ESC + control character. Legacy ESC+ctrl-char would also
+		// match Alt+Enter/Alt+Backspace/etc; skip the fast-path for those bytes and
+		// let kitty/modifyOtherKeys disambiguate.
+		if modifier == (MOD_CTRL | MOD_ALT) && is_letter {
 			let ctrl_char = raw_ctrl_char(ch);
 			if bytes.len() == 2
 				&& bytes[0] == 0x1b
@@ -901,14 +904,24 @@ fn matches_key_inner(bytes: &[u8], key_id: &str, kitty_protocol_active: bool) ->
 			}
 		}
 
-		// alt+letter in legacy mode
-		if modifier == MOD_ALT && !kitty_protocol_active && is_letter {
-			return bytes.len() == 2 && bytes[0] == 0x1b && bytes[1] == ch;
+		// alt+letter: ESC + lowercase letter.
+		if modifier == MOD_ALT
+			&& is_letter
+			&& bytes.len() == 2
+			&& bytes[0] == 0x1b
+			&& bytes[1] == ch
+		{
+			return true;
 		}
 
-		// alt+shift+letter in legacy mode (ESC + UPPERCASE letter)
-		if modifier == (MOD_ALT | MOD_SHIFT) && !kitty_protocol_active && is_letter {
-			return bytes.len() == 2 && bytes[0] == 0x1b && bytes[1] == ch.to_ascii_uppercase();
+		// alt+shift+letter: ESC + UPPERCASE letter.
+		if modifier == (MOD_ALT | MOD_SHIFT)
+			&& is_letter
+			&& bytes.len() == 2
+			&& bytes[0] == 0x1b
+			&& bytes[1] == ch.to_ascii_uppercase()
+		{
+			return true;
 		}
 
 		// ctrl+key
@@ -1113,21 +1126,29 @@ fn parse_esc_pair(code: u8, kitty_protocol_active: bool) -> Option<Cow<'static, 
 		_ => {},
 	}
 
-	// Legacy ALT-prefix parsing only when kitty protocol isn't expected to
-	// disambiguate.
+	// Emacs/readline Meta sequences (Alt+Space, Meta-B → backward-word, Meta-F →
+	// forward-word). These are legacy-only encodings; a properly disambiguating
+	// terminal sends them via CSI-u instead, so we only honor them when kitty is
+	// inactive to avoid clashing with `alt+shift+b`/`alt+shift+f` semantics.
 	if !kitty_protocol_active {
 		match code {
 			b' ' => return Some(Cow::Borrowed("alt+space")),
 			b'B' => return Some(Cow::Borrowed("alt+left")),
 			b'F' => return Some(Cow::Borrowed("alt+right")),
-			1..=26 => return Some(Cow::Borrowed(CTRL_ALT_LETTERS[(code - 1) as usize])),
-			b'a'..=b'z' => return Some(Cow::Borrowed(ALT_LETTERS[(code - b'a') as usize])),
-			b'A'..=b'Z' => return Some(Cow::Borrowed(ALT_SHIFT_LETTERS[(code - b'A') as usize])),
 			_ => {},
 		}
 	}
 
-	None
+	// Legacy Alt+letter / Alt+Shift+letter / Ctrl+Alt+letter. Accepted in BOTH
+	// legacy and kitty mode because multiplexers like tmux and Zellij regularly
+	// reply to the kitty keyboard query upstream while still emitting the legacy
+	// ESC+letter form for these combinations (issue #1511).
+	match code {
+		1..=26 => Some(Cow::Borrowed(CTRL_ALT_LETTERS[(code - 1) as usize])),
+		b'a'..=b'z' => Some(Cow::Borrowed(ALT_LETTERS[(code - b'a') as usize])),
+		b'A'..=b'Z' => Some(Cow::Borrowed(ALT_SHIFT_LETTERS[(code - b'A') as usize])),
+		_ => None,
+	}
 }
 
 // =============================================================================
@@ -1517,6 +1538,42 @@ mod tests {
 		assert_eq!(parse_key_inner(b"\x1b\x1b[B", true).as_deref(), Some("alt+down"));
 		// Bare double ESC should NOT be parsed as alt
 		assert_eq!(parse_key_inner(b"\x1b\x1b", true).as_deref(), None);
+	}
+
+	#[test]
+	fn esc_prefix_alt_letters_mixed_mode() {
+		// tmux 3.6 with `extended-keys-format csi-u` replies to the kitty
+		// keyboard query but still forwards Alt+letter as the legacy `ESC<letter>`
+		// form. OMP must accept that form whether kitty disambiguation is active
+		// or not. Regression for issue #1511.
+		for active in [false, true] {
+			assert_eq!(parse_key_inner(b"\x1bp", active).as_deref(), Some("alt+p"));
+			assert_eq!(parse_key_inner(b"\x1bh", active).as_deref(), Some("alt+h"));
+			assert_eq!(parse_key_inner(b"\x1bP", active).as_deref(), Some("alt+shift+p"));
+			assert_eq!(parse_key_inner(b"\x1b\x10", active).as_deref(), Some("ctrl+alt+p"));
+			assert!(matches_key_inner(b"\x1bp", "alt+p", active));
+			assert!(matches_key_inner(b"\x1bh", "alt+h", active));
+			assert!(matches_key_inner(b"\x1bP", "alt+shift+p", active));
+			assert!(matches_key_inner(b"\x1b\x10", "ctrl+alt+p", active));
+		}
+		// Native CSI-u Alt+letter still matches in kitty mode (fall-through path).
+		assert!(matches_key_inner(b"\x1b[112;3u", "alt+p", true));
+		// And modifyOtherKeys form too.
+		assert!(matches_key_inner(b"\x1b[27;3;112~", "alt+p", false));
+	}
+
+	#[test]
+	fn esc_prefix_meta_b_f_stay_legacy_only() {
+		// Emacs/readline Meta-B/F readline aliases for alt+left/right are only
+		// honored in pure legacy mode. Under kitty (mixed) mode tmux maps Alt+B
+		// to ESC+`B`, which must resolve to alt+shift+b.
+		assert_eq!(parse_key_inner(b"\x1bB", false).as_deref(), Some("alt+left"));
+		assert_eq!(parse_key_inner(b"\x1bF", false).as_deref(), Some("alt+right"));
+		assert_eq!(parse_key_inner(b"\x1bB", true).as_deref(), Some("alt+shift+b"));
+		assert_eq!(parse_key_inner(b"\x1bF", true).as_deref(), Some("alt+shift+f"));
+		assert!(matches_key_inner(b"\x1bB", "alt+left", false));
+		assert!(!matches_key_inner(b"\x1bB", "alt+left", true));
+		assert!(matches_key_inner(b"\x1bB", "alt+shift+b", true));
 	}
 
 	#[test]

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `parseKey` / `matchesKey` resolving the legacy `ESC<letter>` Alt+letter byte pair (`\x1bp`, `\x1bb`, etc.) as `alt+up` / `alt+left` aliases, shadowing the literal `alt+p` / `alt+b` bindings. The four readline-style aliases are dropped from `LEGACY_SEQUENCES`; legacy Alt+letter / Alt+Shift+letter / Ctrl+Alt+letter parsing is now active in both legacy and kitty mixed mode so multiplexers like tmux that reply to the Kitty keyboard query but still emit legacy `ESC<letter>` bytes are decoded correctly. ([#1511](https://github.com/can1357/oh-my-pi/issues/1511))
+
 ## [15.5.10] - 2026-05-28
 
 ### Fixed

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Alt+letter keybindings (e.g. `alt+p`, `alt+b`, `alt+n`, `alt+f`) failing to fire inside tmux on macOS Ghostty even though Alt+arrow worked. tmux 3.6 with `extended-keys-format csi-u` replies to the Kitty keyboard query upstream but still forwards Alt+letter as the legacy `ESC<letter>` form; the native key parser had `\x1bp`/`\x1bn`/`\x1bb`/`\x1bf` baked in as readline aliases for `alt+up`/`alt+down`/`alt+left`/`alt+right`, shadowing the literal Alt+letter interpretation. `LEGACY_SEQUENCES` no longer aliases those four bytes, and `parse_esc_pair` / `matches_key_inner` accept legacy ESC+letter / ESC+UPPERCASE / ESC+ctrl-char as `alt+<letter>` / `alt+shift+<letter>` / `ctrl+alt+<letter>` in both legacy and kitty mixed mode. Word-navigation bindings (`tui.editor.cursorWordLeft` / `Right`) already accept `alt+b`/`alt+f` alongside `alt+left`/`alt+right`, so editor behavior is unchanged. ([#1511](https://github.com/can1357/oh-my-pi/issues/1511))
+
 ## [15.5.12] - 2026-05-29
 
 ### Fixed

--- a/packages/tui/bench/_jskey.ts
+++ b/packages/tui/bench/_jskey.ts
@@ -449,10 +449,6 @@ const LEGACY_SEQUENCE_KEY_IDS: Record<string, KeyId> = {
 	"\x1b[21~": "f10",
 	"\x1b[23~": "f11",
 	"\x1b[24~": "f12",
-	"\x1bb": "alt+left",
-	"\x1bf": "alt+right",
-	"\x1bp": "alt+up",
-	"\x1bn": "alt+down",
 } as const;
 
 type LegacyModifierKey = keyof typeof LEGACY_SHIFT_SEQUENCES;
@@ -890,14 +886,14 @@ function matchesKey(data: string, keyId: KeyId): boolean {
 			return matchesKittySequence(data, FUNCTIONAL_CODEPOINTS.pageDown, modifier);
 
 		case "up":
-			if (alt && !ctrl && !shift) {
-				return data === "\x1bp" || matchesKittySequence(data, ARROW_CODEPOINTS.up, MODIFIERS.alt);
-			}
 			if (modifier === 0) {
 				return (
 					matchesLegacySequence(data, LEGACY_KEY_SEQUENCES.up) ||
 					matchesKittySequence(data, ARROW_CODEPOINTS.up, 0)
 				);
+			}
+			if (alt && !ctrl && !shift) {
+				return matchesKittySequence(data, ARROW_CODEPOINTS.up, MODIFIERS.alt);
 			}
 			if (matchesLegacyModifierSequence(data, "up", modifier)) {
 				return true;
@@ -905,14 +901,14 @@ function matchesKey(data: string, keyId: KeyId): boolean {
 			return matchesKittySequence(data, ARROW_CODEPOINTS.up, modifier);
 
 		case "down":
-			if (alt && !ctrl && !shift) {
-				return data === "\x1bn" || matchesKittySequence(data, ARROW_CODEPOINTS.down, MODIFIERS.alt);
-			}
 			if (modifier === 0) {
 				return (
 					matchesLegacySequence(data, LEGACY_KEY_SEQUENCES.down) ||
 					matchesKittySequence(data, ARROW_CODEPOINTS.down, 0)
 				);
+			}
+			if (alt && !ctrl && !shift) {
+				return matchesKittySequence(data, ARROW_CODEPOINTS.down, MODIFIERS.alt);
 			}
 			if (matchesLegacyModifierSequence(data, "down", modifier)) {
 				return true;
@@ -924,7 +920,6 @@ function matchesKey(data: string, keyId: KeyId): boolean {
 				return (
 					data === "\x1b[1;3D" ||
 					(!kittyProtocolActive && data === "\x1bB") ||
-					data === "\x1bb" ||
 					matchesKittySequence(data, ARROW_CODEPOINTS.left, MODIFIERS.alt)
 				);
 			}
@@ -951,7 +946,6 @@ function matchesKey(data: string, keyId: KeyId): boolean {
 				return (
 					data === "\x1b[1;3C" ||
 					(!kittyProtocolActive && data === "\x1bF") ||
-					data === "\x1bf" ||
 					matchesKittySequence(data, ARROW_CODEPOINTS.right, MODIFIERS.alt)
 				);
 			}

--- a/packages/tui/bench/parse-key.ts
+++ b/packages/tui/bench/parse-key.ts
@@ -43,8 +43,8 @@ const samples = [
 
 	// Alt sequences (legacy mode)
 	{ name: "alt+backspace", data: "\x1b\x7f", expected: "alt+backspace" },
-	{ name: "alt+left", data: "\x1bb", expected: "alt+left" },
-	{ name: "alt+right", data: "\x1bf", expected: "alt+right" },
+	{ name: "alt+b", data: "\x1bb", expected: "alt+b" },
+	{ name: "alt+f", data: "\x1bf", expected: "alt+f" },
 
 	// Arrow with modifiers (legacy)
 	{ name: "shift+up", data: "\x1b[a", expected: "shift+up" },

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -1343,8 +1343,8 @@ describe("Editor component", () => {
 	});
 
 	describe("Word navigation (Option/Alt + Left/Right)", () => {
-		const wordLeft = "\x1bb"; // ESC-b (matches alt+left on most terminals / our matcher)
-		const wordRight = "\x1bf"; // ESC-f (matches alt+right on most terminals / our matcher)
+		const wordLeft = "\x1bb"; // ESC-b (alt+b — bound to cursorWordLeft by default)
+		const wordRight = "\x1bf"; // ESC-f (alt+f — bound to cursorWordRight by default)
 
 		it("moves by CJK and punctuation blocks in Chinese", () => {
 			const editor = new Editor(defaultEditorTheme);


### PR DESCRIPTION
## Repro

On macOS Ghostty + tmux 3.6 (`extended-keys = always`, `extended-keys-format
csi-u`, `macos-option-as-alt = true`), pressing Alt+letter inside OMP failed
to fire any literal Alt+letter binding (e.g. `app.model.selectTemporary` →
`alt+p`), while Alt+Up correctly triggered `app.message.dequeue`. Outside
tmux the same keys worked.

`cat -v` inside that tmux session shows the byte sequence reaching OMP:

```
Alt+Up => ^[[1;3A   # CSI 1;3A
Alt+P  => ^[p       # legacy ESC + letter
Alt+H  => ^[h       # legacy ESC + letter
```

So tmux replies to OMP's Kitty keyboard query upstream (`#kittyProtocolActive`
flips on) but still forwards Alt+letter combinations as the legacy
`ESC<letter>` form.

## Cause

`crates/pi-natives/src/keys.rs` had two layers that consumed those bytes
before any Alt+letter binding could match:

- `LEGACY_SEQUENCES` (the O(1) perfect-hash table at the top of
  `parse_key_inner`) aliased `\x1bb`/`\x1bf`/`\x1bp`/`\x1bn` to
  `alt+left`/`alt+right`/`alt+up`/`alt+down`. These are readline / emacs
  Meta-key conventions (M-B = backward-word, M-P = previous-history), not
  what modern terminals send for Alt+letter. The aliases shadowed the literal
  letter interpretation, so `parse_key("\x1bp")` returned `"alt+up"` and the
  user's `alt+p` binding never fired.
- `matches_key_inner` for `"up"`/`"down"`/`"left"`/`"right"` accepted the
  same four byte pairs as Alt+arrow, and the legacy Alt+letter /
  Alt+Shift+letter / Ctrl+Alt+letter branches in `parse_esc_pair` and
  `matches_key_inner` were gated on `!kitty_protocol_active`, so under tmux
  mixed mode they never ran at all.

The existing Zellij fix (commit `7acb6987b`,
`esc_prefix_alt_arrows_mixed_mode`) already accepted the legacy
`\x1b\x1b[<arrow>` form in both legacy and kitty mode. The Alt+letter
analogue was missing.

## Fix

- `LEGACY_SEQUENCES`: removed the four `\x1bb`/`\x1bf`/`\x1bp`/`\x1bn`
  emacs-style aliases so the byte pairs fall through to literal Alt+letter
  parsing.
- `matches_key_inner` arrow handlers (`up`/`down`/`left`/`right`): dropped
  the `bytes == b"\x1bp"`/`\x1bn`/`\x1bb`/`\x1bf` matches. The historic
  uppercase `\x1bB`/`\x1bF` xterm Alt+Left/Right encoding stays gated on
  `!kitty_protocol_active` since it conflicts with `alt+shift+b`/`alt+shift+f`
  under mixed mode.
- `parse_esc_pair`: moved the lowercase letter / uppercase letter / control
  character ESC pairs out of the `!kitty_protocol_active` guard. Alt+Space /
  Meta-B / Meta-F remain legacy-only.
- `matches_key_inner` Alt+letter / Alt+Shift+letter / Ctrl+Alt+letter
  branches: dropped the `!kitty_protocol_active` guard and switched the
  Alt and Alt+Shift paths to fall-through so native CSI-u / modifyOtherKeys
  Alt+letter sequences keep matching when the legacy bytes don't fit.
- Synced the JS reference (`packages/tui/bench/_jskey.ts`) and bench
  expectations to the new behavior, refreshed the editor word-nav test
  comment.
- Added two new tests in `crates/pi-natives/src/keys.rs`:
  `esc_prefix_alt_letters_mixed_mode` covers `\x1bp`/`\x1bh`/`\x1bP`/`\x1b\x10`
  → `alt+p` / `alt+h` / `alt+shift+p` / `ctrl+alt+p` in both
  `kitty_protocol_active` states, plus native CSI-u and modifyOtherKeys
  forms; `esc_prefix_meta_b_f_stay_legacy_only` pins the `\x1bB` / `\x1bF`
  → alt+left/right behavior to pure legacy mode and confirms it resolves to
  `alt+shift+b` / `alt+shift+f` under kitty.

Word-navigation bindings (`tui.editor.cursorWordLeft` / `Right`) already
include `alt+b` / `alt+f` alongside `alt+left` / `alt+right` in their
default key lists, so editor word movement (pressing Alt+B / Alt+F) keeps
working — it just routes through the literal `alt+b` / `alt+f` binding now.

## Verification

- `cargo test -p pi-natives --lib keys` — 13 passed (54 filtered).
- `bun test packages/tui` — 403 pass, 4 skip, 0 fail across 25 files.
- `bun test packages/tui/test/issue-879-repro.test.ts
  packages/tui/test/editor.test.ts packages/tui/test/input.test.ts` —
  127 pass, 0 fail.

Fixes #1511