### PR TITLE
fix(coding-agent): resolve @oh-my-pi/pi-* imports on Windows compiled binaries

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed external extension loading on Windows compiled binaries: bare `@oh-my-pi/pi-*` value imports (e.g. `import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai"`) failed with `Cannot find package '\$bunfs\root\packages\…'` because `legacy-pi-compat.ts` built shim override paths from a hardcoded POSIX `/$bunfs/root/packages` literal. Win32 normalised the leading slash to a backslash and the resulting path never resolved against the real bunfs mount (`<drive>:\~BUN\root\…`). The bunfs package root is now derived from `import.meta.dir`, so override paths stay platform-native on Windows, Linux, and macOS ([#1514](https://github.com/can1357/oh-my-pi/issues/1514)).
+
 ## [15.5.13] - 2026-05-29
 ### Breaking Changes
 

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -68,10 +68,9 @@ const TYPEBOX_SPECIFIER_FILTER = /^@sinclair\/typebox$/;
 // as `/$bunfs/root/packages` so the prefix stays platform-native: on Windows
 // the bunfs mount appears as `<drive>:\~BUN\root\…` (see oven-sh/bun#15766),
 // and a hardcoded POSIX literal would normalize to `\$bunfs\root\…` and fail
-// to resolve. This file lives at
-// `<bunfs>/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.js`
-// inside the binary, so going up four directories lands on
-// `<bunfs>/packages` regardless of host OS.
+// to resolve. Compiled Bun modules currently report the bunfs root itself from
+// `import.meta.dir`, so appending `packages` lands on the `--root ../..`
+// package directory used by `scripts/build-binary.ts`.
 //
 // Every shim listed below must also be registered as an explicit `--compile`
 // entrypoint in `scripts/build-binary.ts` or release builds fail with
@@ -79,17 +78,25 @@ const TYPEBOX_SPECIFIER_FILTER = /^@sinclair\/typebox$/;
 // `Bun.resolveSync` (see `resolveCanonicalPiSpecifier`) outside compiled mode,
 // so they keep working when on-disk layout differs from the monorepo tree.
 /**
- * Compute the bunfs package root from this file's `import.meta.dir` (or any
- * stand-in supplied by tests). Going up four directories from
- * `<bunfs>/packages/coding-agent/src/extensibility/plugins` lands on
- * `<bunfs>/packages` and preserves the host OS's separators so the result
- * remains valid on Windows (`<drive>:\~BUN\root\packages`) as well as Linux
- * and macOS (`/$bunfs/root/packages`).
+ * Compute the bunfs package root from the compiled binary's `import.meta.dir`
+ * (or any stand-in supplied by tests). Bun 1.3 reports the bunfs mount root
+ * (`/$bunfs/root` or `<drive>:\~BUN\root`) for imported modules as well as the
+ * entrypoint, so the normal path is `<root>/packages`.
+ *
+ * The suffix branch preserves correctness if a future Bun release switches to
+ * module-specific `import.meta.dir` values inside compiled binaries, matching
+ * the source layout:
+ * `<bunfs>/packages/coding-agent/src/extensibility/plugins`.
  *
  * Exported for tests; production callers use `BUNFS_PACKAGE_ROOT` below.
  */
 export function __computeBunfsPackageRoot(metaDir: string, pathImpl: typeof path = path): string {
-	return pathImpl.resolve(metaDir, "..", "..", "..", "..");
+	const pluginsDirSuffix = pathImpl.join("packages", "coding-agent", "src", "extensibility", "plugins");
+	const normalizedMetaDir = pathImpl.normalize(metaDir);
+	if (normalizedMetaDir.endsWith(pluginsDirSuffix)) {
+		return pathImpl.resolve(metaDir, "..", "..", "..", "..");
+	}
+	return pathImpl.join(metaDir, "packages");
 }
 
 const BUNFS_PACKAGE_ROOT = IS_COMPILED_BINARY ? __computeBunfsPackageRoot(import.meta.dir) : null;

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -59,20 +59,50 @@ const resolvedSpecifierFallbacks = new Map<string, string>();
 const TYPEBOX_SPECIFIER = "@sinclair/typebox";
 const TYPEBOX_SPECIFIER_FILTER = /^@sinclair\/typebox$/;
 
-// Compat shim paths owned by this package. The dev branch resolves the sibling
-// source file via `import.meta.dir` (works in monorepo, source-link, and
-// node_modules installs alike, since each install layout ships the shim next
-// to this file). The compiled-binary branch points at the `--root`-relative
-// bunfs path produced by `scripts/build-binary.ts`; every shim listed below
-// must be registered there as an explicit `--compile` entrypoint or release
-// builds fail with missing-module errors. Non-shim bundled packages are
-// resolved via `Bun.resolveSync` (see `resolveCanonicalPiSpecifier`), so they
-// keep working in installed-package mode where the on-disk layout differs from
-// the monorepo source tree.
-const BUNFS_PACKAGE_ROOT = "/$bunfs/root/packages";
+// Compat shim and bundled-package paths used in compiled-binary mode. The shim
+// paths must point at files that ship inside the bunfs root; in dev /
+// source-link / installed-package mode the canonical specifier resolves via
+// `Bun.resolveSync` so only the shim files need explicit paths there.
+//
+// `BUNFS_PACKAGE_ROOT` is derived from `import.meta.dir` rather than hardcoded
+// as `/$bunfs/root/packages` so the prefix stays platform-native: on Windows
+// the bunfs mount appears as `<drive>:\~BUN\root\…` (see oven-sh/bun#15766),
+// and a hardcoded POSIX literal would normalize to `\$bunfs\root\…` and fail
+// to resolve. This file lives at
+// `<bunfs>/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.js`
+// inside the binary, so going up four directories lands on
+// `<bunfs>/packages` regardless of host OS.
+//
+// Every shim listed below must also be registered as an explicit `--compile`
+// entrypoint in `scripts/build-binary.ts` or release builds fail with
+// missing-module errors. Non-shim bundled packages are resolved via
+// `Bun.resolveSync` (see `resolveCanonicalPiSpecifier`) outside compiled mode,
+// so they keep working when on-disk layout differs from the monorepo tree.
+/**
+ * Compute the bunfs package root from this file's `import.meta.dir` (or any
+ * stand-in supplied by tests). Going up four directories from
+ * `<bunfs>/packages/coding-agent/src/extensibility/plugins` lands on
+ * `<bunfs>/packages` and preserves the host OS's separators so the result
+ * remains valid on Windows (`<drive>:\~BUN\root\packages`) as well as Linux
+ * and macOS (`/$bunfs/root/packages`).
+ *
+ * Exported for tests; production callers use `BUNFS_PACKAGE_ROOT` below.
+ */
+export function __computeBunfsPackageRoot(metaDir: string, pathImpl: typeof path = path): string {
+	return pathImpl.resolve(metaDir, "..", "..", "..", "..");
+}
 
-const TYPEBOX_SHIM_PATH = IS_COMPILED_BINARY
-	? `${BUNFS_PACKAGE_ROOT}/coding-agent/src/extensibility/typebox.js`
+const BUNFS_PACKAGE_ROOT = IS_COMPILED_BINARY ? __computeBunfsPackageRoot(import.meta.dir) : null;
+
+function bunfsPath(...segments: string[]): string {
+	if (!BUNFS_PACKAGE_ROOT) {
+		throw new Error("bunfsPath is only valid in compiled-binary mode");
+	}
+	return path.join(BUNFS_PACKAGE_ROOT, ...segments);
+}
+
+const TYPEBOX_SHIM_PATH = BUNFS_PACKAGE_ROOT
+	? bunfsPath("coding-agent", "src", "extensibility", "typebox.js")
 	: path.resolve(import.meta.dir, "../typebox.ts");
 
 // Legacy extensions historically imported `Type` (and `Static`/`TSchema`) from
@@ -83,8 +113,8 @@ const TYPEBOX_SHIM_PATH = IS_COMPILED_BINARY
 // plus the borrowed `Type` runtime from the Zod-backed TypeBox shim. Subpath
 // imports such as `@oh-my-pi/pi-ai/utils/oauth` continue to resolve directly
 // against the bundled pi-ai package.
-const LEGACY_PI_AI_SHIM_PATH = IS_COMPILED_BINARY
-	? `${BUNFS_PACKAGE_ROOT}/coding-agent/src/extensibility/legacy-pi-ai-shim.js`
+const LEGACY_PI_AI_SHIM_PATH = BUNFS_PACKAGE_ROOT
+	? bunfsPath("coding-agent", "src", "extensibility", "legacy-pi-ai-shim.js")
 	: path.resolve(import.meta.dir, "../legacy-pi-ai-shim.ts");
 
 // The coding-agent's own `./src/index.ts` cannot be listed as an extra
@@ -92,8 +122,8 @@ const LEGACY_PI_AI_SHIM_PATH = IS_COMPILED_BINARY
 // startup (issue #1474 follow-up). Legacy `@(scope)/pi-coding-agent` root
 // imports therefore resolve through a sibling shim whose distinct file path
 // avoids that collision while re-exporting the canonical package surface.
-const LEGACY_PI_CODING_AGENT_SHIM_PATH = IS_COMPILED_BINARY
-	? `${BUNFS_PACKAGE_ROOT}/coding-agent/src/extensibility/legacy-pi-coding-agent-shim.js`
+const LEGACY_PI_CODING_AGENT_SHIM_PATH = BUNFS_PACKAGE_ROOT
+	? bunfsPath("coding-agent", "src", "extensibility", "legacy-pi-coding-agent-shim.js")
 	: path.resolve(import.meta.dir, "../legacy-pi-coding-agent-shim.ts");
 
 // Package-root overrides. Shim entries are always applied because they replace
@@ -106,12 +136,12 @@ const LEGACY_PI_CODING_AGENT_SHIM_PATH = IS_COMPILED_BINARY
 const LEGACY_PI_PACKAGE_ROOT_OVERRIDES: Record<string, string> = {
 	[`${CANONICAL_PI_SCOPE}/pi-ai`]: LEGACY_PI_AI_SHIM_PATH,
 	[`${CANONICAL_PI_SCOPE}/pi-coding-agent`]: LEGACY_PI_CODING_AGENT_SHIM_PATH,
-	...(IS_COMPILED_BINARY
+	...(BUNFS_PACKAGE_ROOT
 		? {
-				[`${CANONICAL_PI_SCOPE}/pi-agent-core`]: `${BUNFS_PACKAGE_ROOT}/agent/src/index.js`,
-				[`${CANONICAL_PI_SCOPE}/pi-natives`]: `${BUNFS_PACKAGE_ROOT}/natives/native/index.js`,
-				[`${CANONICAL_PI_SCOPE}/pi-tui`]: `${BUNFS_PACKAGE_ROOT}/tui/src/index.js`,
-				[`${CANONICAL_PI_SCOPE}/pi-utils`]: `${BUNFS_PACKAGE_ROOT}/utils/src/index.js`,
+				[`${CANONICAL_PI_SCOPE}/pi-agent-core`]: bunfsPath("agent", "src", "index.js"),
+				[`${CANONICAL_PI_SCOPE}/pi-natives`]: bunfsPath("natives", "native", "index.js"),
+				[`${CANONICAL_PI_SCOPE}/pi-tui`]: bunfsPath("tui", "src", "index.js"),
+				[`${CANONICAL_PI_SCOPE}/pi-utils`]: bunfsPath("utils", "src", "index.js"),
 			}
 		: {}),
 };

--- a/packages/coding-agent/test/extensibility/legacy-pi-bunfs-root.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-bunfs-root.test.ts
@@ -4,13 +4,13 @@ import { __computeBunfsPackageRoot } from "../../src/extensibility/plugins/legac
 
 // Regression for issue #1514: legacy pi compat shim paths were built from a
 // hardcoded POSIX literal `/$bunfs/root/packages`. On Windows the bunfs root
-// actually mounts at `<drive>:\~BUN\root\…` (oven-sh/bun#15766) and the POSIX
-// literal normalises to `\$bunfs\root\…`, which is unresolvable. The fix
-// derives the bunfs root from `import.meta.dir`, so the host OS's separators
-// are preserved end-to-end.
+// mounts at `<drive>:\~BUN\root\…` (oven-sh/bun#15766) and the POSIX literal
+// normalises to `\$bunfs\root\…`, which is unresolvable. The fix derives the
+// package root from the compiled binary's `import.meta.dir`, so the host OS's
+// separators are preserved end-to-end.
 describe("legacy pi compat bunfs root computation (issue #1514)", () => {
-	it("preserves the Windows-native bunfs root and separators", () => {
-		const winMetaDir = "B:\\~BUN\\root\\packages\\coding-agent\\src\\extensibility\\plugins";
+	it("appends packages to the Windows-native compiled bunfs root", () => {
+		const winMetaDir = "B:\\~BUN\\root";
 		const root = __computeBunfsPackageRoot(winMetaDir, path.win32);
 		expect(root).toBe("B:\\~BUN\\root\\packages");
 		// The shim path joined from this root must still live under the bunfs
@@ -21,16 +21,19 @@ describe("legacy pi compat bunfs root computation (issue #1514)", () => {
 		);
 	});
 
-	it("preserves the POSIX bunfs root on Linux and macOS compiled binaries", () => {
+	it("appends packages to the POSIX compiled bunfs root on Linux and macOS", () => {
+		expect(__computeBunfsPackageRoot("/$bunfs/root", path.posix)).toBe("/$bunfs/root/packages");
+	});
+
+	it("also supports module-specific import.meta.dir values if Bun changes compiled semantics", () => {
+		const winMetaDir = "B:\\~BUN\\root\\packages\\coding-agent\\src\\extensibility\\plugins";
+		expect(__computeBunfsPackageRoot(winMetaDir, path.win32)).toBe("B:\\~BUN\\root\\packages");
 		const posixMetaDir = "/$bunfs/root/packages/coding-agent/src/extensibility/plugins";
 		expect(__computeBunfsPackageRoot(posixMetaDir, path.posix)).toBe("/$bunfs/root/packages");
 	});
 
-	it("strips four directories from the host's import.meta.dir regardless of platform", () => {
-		// Using the current host's `path` impl on a fabricated metaDir guards
-		// against drift in either the directory depth or the path helper
-		// choice (e.g. accidental `path.posix.resolve` on the runtime path).
-		const metaDir = path.join("/", "anywhere", "packages", "coding-agent", "src", "extensibility", "plugins");
-		expect(__computeBunfsPackageRoot(metaDir)).toBe(path.join("/", "anywhere", "packages"));
+	it("uses the current host path implementation for production calls", () => {
+		const metaDir = path.join("/", "anywhere", "root");
+		expect(__computeBunfsPackageRoot(metaDir)).toBe(path.join("/", "anywhere", "root", "packages"));
 	});
 });

--- a/packages/coding-agent/test/extensibility/legacy-pi-bunfs-root.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-bunfs-root.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { __computeBunfsPackageRoot } from "../../src/extensibility/plugins/legacy-pi-compat";
+
+// Regression for issue #1514: legacy pi compat shim paths were built from a
+// hardcoded POSIX literal `/$bunfs/root/packages`. On Windows the bunfs root
+// actually mounts at `<drive>:\~BUN\root\…` (oven-sh/bun#15766) and the POSIX
+// literal normalises to `\$bunfs\root\…`, which is unresolvable. The fix
+// derives the bunfs root from `import.meta.dir`, so the host OS's separators
+// are preserved end-to-end.
+describe("legacy pi compat bunfs root computation (issue #1514)", () => {
+	it("preserves the Windows-native bunfs root and separators", () => {
+		const winMetaDir = "B:\\~BUN\\root\\packages\\coding-agent\\src\\extensibility\\plugins";
+		const root = __computeBunfsPackageRoot(winMetaDir, path.win32);
+		expect(root).toBe("B:\\~BUN\\root\\packages");
+		// The shim path joined from this root must still live under the bunfs
+		// mount, never collapse onto the working drive (which is what
+		// `path.win32.resolve("/$bunfs/root/packages/...")` would produce).
+		expect(path.win32.join(root, "coding-agent", "src", "extensibility", "legacy-pi-ai-shim.js")).toBe(
+			"B:\\~BUN\\root\\packages\\coding-agent\\src\\extensibility\\legacy-pi-ai-shim.js",
+		);
+	});
+
+	it("preserves the POSIX bunfs root on Linux and macOS compiled binaries", () => {
+		const posixMetaDir = "/$bunfs/root/packages/coding-agent/src/extensibility/plugins";
+		expect(__computeBunfsPackageRoot(posixMetaDir, path.posix)).toBe("/$bunfs/root/packages");
+	});
+
+	it("strips four directories from the host's import.meta.dir regardless of platform", () => {
+		// Using the current host's `path` impl on a fabricated metaDir guards
+		// against drift in either the directory depth or the path helper
+		// choice (e.g. accidental `path.posix.resolve` on the runtime path).
+		const metaDir = path.join("/", "anywhere", "packages", "coding-agent", "src", "extensibility", "plugins");
+		expect(__computeBunfsPackageRoot(metaDir)).toBe(path.join("/", "anywhere", "packages"));
+	});
+});


### PR DESCRIPTION
## Repro

External extensions on Windows compiled binaries that import a runtime value from any bundled `@oh-my-pi/pi-*` package fail to load:

```ts
// extensions/my-ext/main.ts
import type { ExtensionAPI } from "@oh-my-pi/pi-coding-agent"; // ok (type-only)
import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai"; // ❌
```

```
Failed to load extension: ResolveMessage: Cannot find package
'$bunfs\root\packages\coding-agent\src\extensibility\legacy-pi-ai-shim.js'
```

Reported in #1514 (Windows native, omp 15.5.13, Bun 1.3.14). Reproduces analytically too — `path.win32.resolve("/$bunfs/root/packages/coding-agent/src/extensibility/legacy-pi-ai-shim.js")` returns `\$bunfs\root\packages\coding-agent\src\extensibility\legacy-pi-ai-shim.js`, which never exists on disk because the actual Windows bunfs mount is `<drive>:\~BUN\root\packages\…` (oven-sh/bun#15766).

## Cause

`packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` defined `BUNFS_PACKAGE_ROOT = "/$bunfs/root/packages"` as a hardcoded POSIX literal and built every entry in `LEGACY_PI_PACKAGE_ROOT_OVERRIDES` (plus `TYPEBOX_SHIM_PATH`, `LEGACY_PI_AI_SHIM_PATH`, `LEGACY_PI_CODING_AGENT_SHIM_PATH`) via template-string concatenation against that prefix. On Windows, `url.pathToFileURL` / `path.resolve` normalise the leading slash to a backslash, so the path bears no relation to the real bunfs mount and resolution fails. Linux and macOS happened to work because the POSIX literal matched the host bunfs path verbatim.

## Fix

- `legacy-pi-compat.ts`: introduced `__computeBunfsPackageRoot(metaDir, pathImpl)` and derived `BUNFS_PACKAGE_ROOT` from `import.meta.dir` (this file lives at `<bunfs>/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.js` inside the binary, so going up four directories lands on `<bunfs>/packages`). All override targets now go through a `bunfsPath(...segments)` helper backed by `path.join`, keeping separators platform-native on Windows, Linux, and macOS.
- `test/extensibility/legacy-pi-bunfs-root.test.ts` (new): regression test against `__computeBunfsPackageRoot` that asserts Windows-native (`B:\~BUN\root\packages`) and POSIX (`/$bunfs/root/packages`) bunfs roots are preserved end-to-end. Uses `path.win32` and `path.posix` so the contract holds on any host.
- `CHANGELOG.md` (`Unreleased`/`Fixed`): user-facing entry crediting #1514.

The first commit credit goes to @gitrealname, who diagnosed the platform-specific path normalisation and pointed at oven-sh/bun#15766.

## Verification

```
$ bun --cwd packages/coding-agent test test/extensibility/
 28 pass
 0 fail
 74 expect() calls
```

```
$ bun check:ts
… all workspaces Exited with code 0
```

Manual cross-platform path simulation in `node -e`: hardcoded `/$bunfs/root/packages/...` template under `path.win32.resolve` reproduces the broken `\$bunfs\root\packages\...` shape; the new `__computeBunfsPackageRoot` helper fed a Windows-style `import.meta.dir` returns `B:\~BUN\root\packages` and `path.join` preserves backslashes. I cannot exercise a real Windows compiled binary in this environment — the reporter verified the equivalent fix in `bun run dev` on Windows.

Fixes #1514
