### PR TITLE
feat: support DeepSeek prompt cache format and add cache hit rate segment

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1224,29 +1224,57 @@ export function parseChunkUsage(
 	const completionTokenDetails = getOptionalObjectProperty(rawUsage, "completion_tokens_details");
 	const cachedTokens =
 		getOptionalNumberProperty(rawUsage, "cached_tokens") ??
+		getOptionalNumberProperty(rawUsage, "prompt_cache_hit_tokens") ??
 		(promptTokenDetails ? getOptionalNumberProperty(promptTokenDetails, "cached_tokens") : undefined) ??
 		0;
 	// OpenRouter exposes cache writes via `prompt_tokens_details.cache_write_tokens`
-	// and INCLUDES them in `prompt_tokens`. Without subtracting, cache-write tokens
-	// leak into `input` (e.g. GLM/Anthropic via OpenRouter on a fresh cache).
+	// and INCLUDES them in `prompt_tokens` — they are billed on top of the input, so
+	// we subtract them to get the real billed input.
+	// DeepSeek exposes cache hit/miss via `prompt_cache_hit_tokens` /
+	// `prompt_cache_miss_tokens` at the top level where `prompt_tokens` equals their
+	// sum. The miss portion IS the billed input — we must NOT subtract it.
 	// Ref: https://openrouter.ai/docs/guides/best-practices/prompt-caching
-	const cacheWriteTokens = promptTokenDetails
-		? (getOptionalNumberProperty(promptTokenDetails, "cache_write_tokens") ?? 0)
-		: 0;
+	// Ref: https://api-docs.deepseek.com/api/create-chat-completion
+	//
+	// Resolve cacheWrite from both possible sources separately.
+	// They have different billing semantics: OpenRouter's cache_write is billed
+	// on top of prompt_tokens, while DeepSeek's miss IS the billed input.
+	const cacheWriteOpenRouter = promptTokenDetails
+		? getOptionalNumberProperty(promptTokenDetails, "cache_write_tokens")
+		: undefined;
+	const cacheWriteDeepSeek = getOptionalNumberProperty(rawUsage, "prompt_cache_miss_tokens");
+	// Prefer OpenRouter's value for the input subtraction; fall back to DeepSeek.
+	const cacheWriteTokens = cacheWriteOpenRouter ?? cacheWriteDeepSeek ?? 0;
+
 	const reasoningTokens =
 		(completionTokenDetails ? getOptionalNumberProperty(completionTokenDetails, "reasoning_tokens") : undefined) ?? 0;
 	const promptTokens = getOptionalNumberProperty(rawUsage, "prompt_tokens") ?? 0;
-	const input = Math.max(0, promptTokens - cachedTokens - cacheWriteTokens);
+
+	const isDeepSeekNative =
+		getOptionalNumberProperty(rawUsage, "prompt_cache_hit_tokens") !== undefined &&
+		cacheWriteDeepSeek !== undefined;
+	// Only use the DeepSeek input path when cacheWrite came from DeepSeek's
+	// miss field, not from prompt_tokens_details. Avoids false positives when
+	// DeepSeek models route through OpenRouter (which may pass through native
+	// fields alongside its own cache_write_tokens).
+	const isDeepSeekUsage = isDeepSeekNative && cacheWriteOpenRouter === undefined && cacheWriteDeepSeek > 0;
+	const input = isDeepSeekUsage
+		? Math.max(0, promptTokens - cachedTokens)
+		: Math.max(0, promptTokens - cachedTokens - cacheWriteTokens);
 	// Per OpenAI's CompletionUsage spec, `reasoning_tokens` is a subset of
 	// `completion_tokens` (which is the total billed output). Adding them would
 	// double-count.
 	const outputTokens = getOptionalNumberProperty(rawUsage, "completion_tokens") ?? 0;
+	// DeepSeek only exposes cache hit/miss (no cache-write data).
+	// Emitting miss tokens as cacheWrite would make downstream consumers
+	// double-count them (input already equals miss for DeepSeek).
+	const emittedCacheWrite = isDeepSeekUsage ? 0 : cacheWriteTokens;
 	const usage: AssistantMessage["usage"] = {
 		input,
 		output: outputTokens,
 		cacheRead: cachedTokens,
-		cacheWrite: cacheWriteTokens,
-		totalTokens: input + outputTokens + cachedTokens + cacheWriteTokens,
+		cacheWrite: emittedCacheWrite,
+		totalTokens: input + outputTokens + cachedTokens + emittedCacheWrite,
 		...(reasoningTokens > 0 ? { reasoningTokens } : {}),
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		...(premiumRequests !== undefined ? { premiumRequests } : {}),

--- a/packages/ai/test/usage-attribution.test.ts
+++ b/packages/ai/test/usage-attribution.test.ts
@@ -93,6 +93,113 @@ describe("openai-completions parseChunkUsage", () => {
 		expect(usage.cacheWrite).toBe(0);
 		expect(usage.totalTokens).toBe(6_250);
 	});
+
+	it("maps DeepSeek prompt_cache_hit_tokens + prompt_cache_miss_tokens correctly", () => {
+		// DeepSeek (https://api-docs.deepseek.com/api/create-chat-completion)
+		// exposes cache hit/miss at the top level where prompt_tokens = hit + miss.
+		// The miss portion IS the billed input.
+		const usage = parseChunkUsage(
+			{
+				prompt_tokens: 150,
+				completion_tokens: 200,
+				prompt_cache_hit_tokens: 100,
+				prompt_cache_miss_tokens: 50,
+			},
+			OPENAI_MODEL,
+			undefined,
+		);
+
+		// input = prompt_tokens - hit_tokens = 150 - 100 = 50 (miss = billed input)
+		expect(usage.input).toBe(50);
+		expect(usage.output).toBe(200);
+		expect(usage.cacheRead).toBe(100);
+		// DeepSeek does not expose cache creation data; cacheWrite must be 0
+		// to avoid downstream double-counting (input already equals miss).
+		expect(usage.cacheWrite).toBe(0);
+		expect(usage.totalTokens).toBe(350); // 50 + 200 + 100 + 0
+	});
+
+	it("handles DeepSeek with only cache hits (miss=0)", () => {
+		const usage = parseChunkUsage(
+			{
+				prompt_tokens: 100,
+				completion_tokens: 200,
+				prompt_cache_hit_tokens: 100,
+				prompt_cache_miss_tokens: 0,
+			},
+			OPENAI_MODEL,
+			undefined,
+		);
+
+		expect(usage.input).toBe(0);
+		expect(usage.cacheRead).toBe(100);
+		expect(usage.cacheWrite).toBe(0);
+		expect(usage.totalTokens).toBe(300);
+	});
+
+	it("handles DeepSeek with only cache misses (hit=0)", () => {
+		const usage = parseChunkUsage(
+			{
+				prompt_tokens: 100,
+				completion_tokens: 200,
+				prompt_cache_hit_tokens: 0,
+				prompt_cache_miss_tokens: 100,
+			},
+			OPENAI_MODEL,
+			undefined,
+		);
+
+		// input = prompt_tokens - hit_tokens = 100 - 0 = 100 (all billed)
+		expect(usage.input).toBe(100);
+		expect(usage.cacheRead).toBe(0);
+		expect(usage.cacheWrite).toBe(0);
+		expect(usage.totalTokens).toBe(300); // 100 + 200 + 0 + 0
+	});
+
+	it("does not confuse OpenRouter responses with DeepSeek format", () => {
+		// OpenRouter response where prompt_tokens_details exists but
+		// no top-level prompt_cache_* fields — must NOT trigger DeepSeek path.
+		const usage = parseChunkUsage(
+			{
+				prompt_tokens: 6_000,
+				completion_tokens: 250,
+				prompt_tokens_details: { cached_tokens: 200, cache_write_tokens: 5_000 },
+			},
+			OPENAI_MODEL,
+			undefined,
+		);
+
+		expect(usage.input).toBe(800); // 6000 - 200 - 5000
+		expect(usage.cacheRead).toBe(200);
+		expect(usage.cacheWrite).toBe(5_000);
+		expect(usage.totalTokens).toBe(6_250);
+	});
+
+	it("uses OpenRouter path when DeepSeek routes through OpenRouter with both field sets", () => {
+		// Hypothetical: DeepSeek model via OpenRouter where OpenRouter passes
+		// through native prompt_cache_* fields AND adds its own
+		// prompt_tokens_details.cache_write_tokens.
+		// Must NOT trigger DeepSeek path — cacheWrite came from OpenRouter,
+		// which bills it on top of prompt_tokens.
+		const usage = parseChunkUsage(
+			{
+				prompt_tokens: 6_000,
+				completion_tokens: 250,
+				prompt_cache_hit_tokens: 200,
+				prompt_cache_miss_tokens: 50,
+				prompt_tokens_details: { cached_tokens: 200, cache_write_tokens: 5_000 },
+			},
+			OPENAI_MODEL,
+			undefined,
+		);
+
+		// cacheWrite from OpenRouter (5000), not DeepSeek miss (50).
+		// input = 6000 - 200 - 5000 = 800 (OpenRouter formula).
+		expect(usage.input).toBe(800);
+		expect(usage.cacheRead).toBe(200);
+		expect(usage.cacheWrite).toBe(5_000);
+		expect(usage.totalTokens).toBe(6_250);
+	});
 });
 
 describe("anthropic applyAnthropicUsageExtras", () => {

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -81,6 +81,7 @@ export type StatusLineSegmentId =
 	| "hostname"
 	| "cache_read"
 	| "cache_write"
+	| "cache_hit"
 	| "session_name"
 	| "usage";
 

--- a/packages/coding-agent/src/modes/components/status-line/presets.ts
+++ b/packages/coding-agent/src/modes/components/status-line/presets.ts
@@ -3,7 +3,7 @@ import type { PresetDef, StatusLinePreset } from "./types";
 export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	default: {
 		leftSegments: ["pi", "model", "mode", "path", "git", "pr", "context_pct", "cost"],
-		rightSegments: ["session_name"],
+		rightSegments: ["session_name", "cache_hit"],
 		separator: "powerline-thin",
 		segmentOptions: {
 			model: { showThinkingLevel: true },
@@ -24,7 +24,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 
 	compact: {
 		leftSegments: ["model", "mode", "git", "pr"],
-		rightSegments: ["session_name", "cost", "context_pct"],
+		rightSegments: ["session_name", "cache_hit", "cost", "context_pct"],
 		separator: "powerline-thin",
 		segmentOptions: {
 			model: { showThinkingLevel: false },
@@ -36,6 +36,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 		leftSegments: ["pi", "hostname", "model", "mode", "path", "git", "pr", "subagents"],
 		rightSegments: [
 			"session_name",
+			"cache_hit",
 			"token_in",
 			"token_out",
 			"token_rate",

--- a/packages/coding-agent/src/modes/components/status-line/presets.ts
+++ b/packages/coding-agent/src/modes/components/status-line/presets.ts
@@ -3,7 +3,7 @@ import type { PresetDef, StatusLinePreset } from "./types";
 export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 	default: {
 		leftSegments: ["pi", "model", "mode", "path", "git", "pr", "context_pct", "cost"],
-		rightSegments: ["session_name", "cache_hit"],
+		rightSegments: ["session_name"],
 		separator: "powerline-thin",
 		segmentOptions: {
 			model: { showThinkingLevel: true },
@@ -24,7 +24,7 @@ export const STATUS_LINE_PRESETS: Record<StatusLinePreset, PresetDef> = {
 
 	compact: {
 		leftSegments: ["model", "mode", "git", "pr"],
-		rightSegments: ["session_name", "cache_hit", "cost", "context_pct"],
+		rightSegments: ["session_name", "cost", "context_pct"],
 		separator: "powerline-thin",
 		segmentOptions: {
 			model: { showThinkingLevel: false },

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -448,6 +448,27 @@ const cacheWriteSegment: StatusLineSegment = {
 	},
 };
 
+const cacheHitSegment: StatusLineSegment = {
+	id: "cache_hit",
+	render(ctx) {
+		const { cacheRead, cacheWrite, input } = ctx.usageStats;
+		if (!cacheRead) return { content: "", visible: false };
+
+		// DeepSeek doesn't expose cacheWrite; cache miss tokens = input.
+		// For other providers, cacheWrite tracks cache creation separately.
+		const denominator = cacheWrite > 0 ? cacheWrite : input;
+		const total = cacheRead + denominator;
+		if (!total) return { content: "", visible: false };
+
+		const rate = (cacheRead / total) * 100;
+		const rateStr = rate.toFixed(2);
+
+		const parts: string[] = [theme.icon.cache];
+		parts.push(theme.fg("statusLineSpend", `${rateStr}%`));
+		return { content: parts.join(" "), visible: true };
+	},
+};
+
 const sessionNameSegment: StatusLineSegment = {
 	id: "session_name",
 	render(ctx) {
@@ -537,6 +558,7 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 	hostname: hostnameSegment,
 	cache_read: cacheReadSegment,
 	cache_write: cacheWriteSegment,
+	cache_hit: cacheHitSegment,
 	session_name: sessionNameSegment,
 	usage: usageSegment,
 };

--- a/packages/coding-agent/test/issue-953-repro.test.ts
+++ b/packages/coding-agent/test/issue-953-repro.test.ts
@@ -60,3 +60,42 @@ describe("issue #953 cache status line icons", () => {
 		expect(cacheWrite.content).not.toContain(theme.icon.output);
 	});
 });
+
+describe("cache_hit segment", () => {
+	it("shows hit rate from cacheRead / (cacheRead + cacheWrite) when cacheWrite > 0", () => {
+		const segment = renderSegment("cache_hit", createCtx({ cacheRead: 7_500, cacheWrite: 2_500 }));
+
+		expect(segment.visible).toBe(true);
+		expect(segment.content).toContain(theme.icon.cache);
+		// 7500 / (7500 + 2500) = 75%
+		expect(segment.content).toContain("75.00%");
+	});
+
+	it("shows hit rate from cacheRead / (cacheRead + input) when cacheWrite = 0 (DeepSeek fallback)", () => {
+		// DeepSeek: cacheWrite=0, input=miss_tokens
+		const segment = renderSegment("cache_hit", createCtx({ cacheRead: 6_000, cacheWrite: 0, input: 4_000 }));
+
+		expect(segment.visible).toBe(true);
+		// 6000 / (6000 + 4000) = 60%
+		expect(segment.content).toContain("60.00%");
+	});
+
+	it("shows 100% when all input was cached (cacheWrite=0, input=0)", () => {
+		const segment = renderSegment("cache_hit", createCtx({ cacheRead: 5_000, cacheWrite: 0, input: 0 }));
+
+		expect(segment.visible).toBe(true);
+		expect(segment.content).toContain("100.00%");
+	});
+
+	it("is hidden when cacheRead is 0", () => {
+		const segment = renderSegment("cache_hit", createCtx({ cacheRead: 0, cacheWrite: 5_000 }));
+
+		expect(segment.visible).toBe(false);
+	});
+
+	it("is hidden when there is no cache activity at all", () => {
+		const segment = renderSegment("cache_hit", createCtx({ cacheRead: 0, cacheWrite: 0, input: 1_000 }));
+
+		expect(segment.visible).toBe(false);
+	});
+});


### PR DESCRIPTION
Cache calculation formula:

  **cacheHitRate = Σ cacheRead / Σ (cacheRead + cacheWrite)**

- Add `cache_hit` status line segment showing cumulative cache hit
  rate with 2 decimal places (e.g. `💾 82.69%`)
- Map DeepSeek API fields `prompt_cache_hit_tokens` /
  `prompt_cache_miss_tokens` in OpenAI-compat usage parser so
  cache stats work correctly for DeepSeek models
- Fix `input` billing for DeepSeek: unlike OpenRouter where
  `prompt_tokens = input + cacheRead + cacheWrite`, DeepSeek's
  `prompt_tokens = cacheRead + cacheWrite` (per official docs:
  https://api-docs.deepseek.com/api/create-chat-completion).
  Conditionally skip subtracting `cacheWriteTokens` from
  `promptTokens` when DeepSeek-style fields are detected.
- Register `cache_hit` segment in settings schema and add it
  to default/compact/full presets

## Testing

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)

----

<img width="1714" height="1114" alt="image" src="https://github.com/user-attachments/assets/62ea68a1-f56c-425e-bbbe-fed025ec1646" />


