### PR TITLE
fix(natives): search symlinked file targets

### DIFF
--- a/crates/pi-natives/src/grep.rs
+++ b/crates/pi-natives/src/grep.rs
@@ -701,6 +701,29 @@ struct GrepConfig {
 	mode:           Option<GrepOutputMode>,
 }
 
+fn cached_entry_is_searchable_file(root: &Path, entry: &fs_cache::GlobMatch) -> bool {
+	if entry.file_type == fs_cache::FileType::File {
+		return true;
+	}
+	if entry.file_type != fs_cache::FileType::Symlink {
+		return false;
+	}
+	std::fs::metadata(root.join(&entry.path)).is_ok_and(|metadata| metadata.is_file())
+}
+
+fn walk_entry_is_searchable_file(entry: &ignore::DirEntry) -> bool {
+	let Some(file_type) = entry.file_type() else {
+		return false;
+	};
+	if file_type.is_file() {
+		return true;
+	}
+	if !file_type.is_symlink() {
+		return false;
+	}
+	std::fs::metadata(entry.path()).is_ok_and(|metadata| metadata.is_file())
+}
+
 fn collect_files(
 	root: &Path,
 	scanned_entries: &[fs_cache::GlobMatch],
@@ -709,7 +732,7 @@ fn collect_files(
 ) -> Vec<FileEntry> {
 	let mut entries = Vec::new();
 	for entry in scanned_entries {
-		if entry.file_type != fs_cache::FileType::File {
+		if !cached_entry_is_searchable_file(root, entry) {
 			continue;
 		}
 		if let Some(glob_set) = glob_set
@@ -918,7 +941,10 @@ fn build_regex_matcher(
 #[cfg(test)]
 mod tests {
 	#[cfg(unix)]
-	use std::{ffi::CString, os::unix::ffi::OsStrExt};
+	use std::{
+		ffi::CString,
+		os::unix::{ffi::OsStrExt, fs::symlink},
+	};
 	use std::{
 		fs,
 		path::{Path, PathBuf},
@@ -1055,6 +1081,25 @@ mod tests {
 		assert_eq!(result.files_searched, 1);
 		assert_eq!(result.matches.len(), 1);
 		assert_eq!(result.matches[0].path, "regular.txt");
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn grep_directory_searches_symlinked_file_targets() {
+		let root = TempDirGuard::new();
+		let target_root = TempDirGuard::new();
+		let target = target_root.path().join("target.txt");
+		write_file(&target, "needle through link\n");
+		symlink(&target, root.path().join("linked.txt")).expect("create symlinked file");
+
+		let result = grep_sync(base_grep_config(root.path()), None, task::CancelToken::default())
+			.expect("directory grep should search symlinked file targets");
+
+		assert_eq!(result.total_matches, 1);
+		assert_eq!(result.files_with_matches, 1);
+		assert_eq!(result.files_searched, 1);
+		assert_eq!(result.matches.len(), 1);
+		assert_eq!(result.matches[0].path, "linked.txt");
 	}
 
 	#[cfg(unix)]
@@ -1256,10 +1301,7 @@ impl ParallelVisitor for StreamingGrepVisitor<'_> {
 		let Ok(entry) = entry else {
 			return WalkState::Continue;
 		};
-		if !entry
-			.file_type()
-			.is_some_and(|file_type| file_type.is_file())
-		{
+		if !walk_entry_is_searchable_file(&entry) {
 			return WalkState::Continue;
 		}
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed tool argument validation to parse JSON-stringified arrays/objects even when a permissive union branch also accepts strings, preventing providers that serialize array tool parameters as strings from turning path arrays into literal paths. ([#1518](https://github.com/can1357/oh-my-pi/issues/1518))
+
 ## [15.5.12] - 2026-05-29
+
 ### Removed
 
 - Removed ANTML stream markup healing for `antml:function_calls` and `antml:thinking` envelopes, so Anthropic-compatible providers no longer parse those tags into `toolCall`/`thinking` events

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -1032,6 +1032,13 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): ToolCall[
 	if (initialContainerNormalization.changed) {
 		normalizedArgs = initialContainerNormalization.value;
 		changed = true;
+		// Parsing a stringified container can expose nested null/"null" values that
+		// the first null-normalization pass could not see; rerun it so optional
+		// nullable fields are stripped before validation rejects them.
+		const postContainerNullNormalization = normalizeOptionalNullsForSchema(json, normalizedArgs);
+		if (postContainerNullNormalization.changed) {
+			normalizedArgs = postContainerNullNormalization.value;
+		}
 	}
 
 	let result = validateContext(ctx, normalizedArgs);
@@ -1053,6 +1060,12 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): ToolCall[
 		if (containerNormalization.changed) {
 			normalizedArgs = containerNormalization.value;
 			changed = true;
+			// Same reasoning as the initial pass: re-strip optional nulls that became
+			// visible only after the stringified container was parsed into real shape.
+			const postContainerNullNormalization = normalizeOptionalNullsForSchema(json, normalizedArgs);
+			if (postContainerNullNormalization.changed) {
+				normalizedArgs = postContainerNullNormalization.value;
+			}
 		}
 
 		result = validateContext(ctx, normalizedArgs);

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -584,8 +584,13 @@ function normalizeStringifiedContainersForSchema(
 		for (const propertySchema of propertySchemas) {
 			const normalized = normalizeStringifiedContainersForSchema(propertySchema, current);
 			if (!normalized.changed) continue;
-			if (!next) next = { ...value };
-			next[key] = normalized.value;
+			// Speculatively apply the rewrite and verify it does not break the
+			// surrounding schema. With anyOf/oneOf variants this prevents pulling
+			// `{kind:"text", value:"[...]"}` into the array branch's shape just
+			// because some sibling branch declares `value` as an array.
+			const candidate = { ...(next ?? value), [key]: normalized.value };
+			if (!isJsonSchemaValueValid(schema, candidate)) continue;
+			next = candidate;
 			changed = true;
 			break;
 		}

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -546,6 +546,54 @@ function deleteAtSegment(node: unknown, segments: string[], depth: number): unkn
 // JSON-Schema-driven normalization passes (LLM quirks).
 // ============================================================================
 
+function tryParseJsonContainerForSchema(schema: unknown, value: unknown): { value: unknown; changed: boolean } {
+	if (typeof value !== "string") return { value, changed: false };
+	const parsed = tryParseJsonForTypes(value, ["array", "object"]);
+	if (!parsed.changed) return { value, changed: false };
+	return isJsonSchemaValueValid(schema, parsed.value) ? parsed : { value, changed: false };
+}
+
+function collectPropertySchemas(schema: unknown, property: string, out: unknown[] = []): unknown[] {
+	if (!isPlainRecord(schema)) return out;
+	const properties = schema.properties;
+	if (isPlainRecord(properties) && Object.hasOwn(properties, property)) {
+		out.push(properties[property]);
+	}
+	for (const key of ["anyOf", "oneOf", "allOf"] as const) {
+		const branches = schema[key];
+		if (!Array.isArray(branches)) continue;
+		for (const branch of branches) collectPropertySchemas(branch, property, out);
+	}
+	return out;
+}
+
+function normalizeStringifiedContainersForSchema(
+	schema: unknown,
+	value: unknown,
+): { value: unknown; changed: boolean } {
+	const direct = tryParseJsonContainerForSchema(schema, value);
+	if (direct.changed) return direct;
+
+	if (!isPlainRecord(value)) return { value, changed: false };
+
+	let changed = false;
+	let next: Record<string, unknown> | undefined;
+	for (const [key, current] of Object.entries(value)) {
+		const propertySchemas = collectPropertySchemas(schema, key);
+		if (propertySchemas.length === 0) continue;
+		for (const propertySchema of propertySchemas) {
+			const normalized = normalizeStringifiedContainersForSchema(propertySchema, current);
+			if (!normalized.changed) continue;
+			if (!next) next = { ...value };
+			next[key] = normalized.value;
+			changed = true;
+			break;
+		}
+	}
+
+	return changed ? { value: next ?? value, changed: true } : { value, changed: false };
+}
+
 /**
  * Test a JSON-Schema branch during nullable normalization. Kept deliberately
  * small and synchronous so validation does not need to compile legacy schemas
@@ -971,13 +1019,18 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): ToolCall[
 	const { json } = ctx;
 
 	// Always normalize first — strip null and string "null" from optional
-	// fields and substitute defaults. Handles LLM outputting string "null"
-	// to mean "no value" even when validation would otherwise pass.
+	// fields and substitute defaults. Then parse JSON-stringified containers
+	// that would otherwise pass through a permissive string union branch.
 	let normalizedArgs: unknown = originalArgs;
 	let changed = false;
-	const initialNormalization = normalizeOptionalNullsForSchema(json, normalizedArgs);
-	if (initialNormalization.changed) {
-		normalizedArgs = initialNormalization.value;
+	const initialNullNormalization = normalizeOptionalNullsForSchema(json, normalizedArgs);
+	if (initialNullNormalization.changed) {
+		normalizedArgs = initialNullNormalization.value;
+		changed = true;
+	}
+	const initialContainerNormalization = normalizeStringifiedContainersForSchema(json, normalizedArgs);
+	if (initialContainerNormalization.changed) {
+		normalizedArgs = initialContainerNormalization.value;
 		changed = true;
 	}
 
@@ -994,6 +1047,12 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): ToolCall[
 		const nullNormalization = normalizeOptionalNullsForSchema(json, normalizedArgs);
 		if (nullNormalization.changed) {
 			normalizedArgs = nullNormalization.value;
+			changed = true;
+		}
+		const containerNormalization = normalizeStringifiedContainersForSchema(json, normalizedArgs);
+		if (containerNormalization.changed) {
+			normalizedArgs = containerNormalization.value;
+			changed = true;
 		}
 
 		result = validateContext(ctx, normalizedArgs);

--- a/packages/ai/test/tool-argument-coercion.test.ts
+++ b/packages/ai/test/tool-argument-coercion.test.ts
@@ -122,6 +122,26 @@ describe("Tool argument coercion", () => {
 		expect(result.label).toBe('["literal"]');
 	});
 
+	it("does not pull a JSON-looking string into a sibling union branch's array shape", () => {
+		const tool: Tool = {
+			name: "tagged-union",
+			description: "",
+			parameters: z.union([
+				z.object({ kind: z.literal("text"), value: z.string() }),
+				z.object({ kind: z.literal("array"), value: z.array(z.string()) }),
+			]),
+		};
+
+		const result = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-tagged-union",
+			name: "tagged-union",
+			arguments: { kind: "text", value: '["literal"]' },
+		}) as { kind: string; value: string };
+
+		expect(result).toEqual({ kind: "text", value: '["literal"]' });
+	});
+
 	it("preserves unknown root fields after Zod validation so tools can reject disabled arguments", () => {
 		const tool: Tool = {
 			name: "t4b",

--- a/packages/ai/test/tool-argument-coercion.test.ts
+++ b/packages/ai/test/tool-argument-coercion.test.ts
@@ -78,6 +78,50 @@ describe("Tool argument coercion", () => {
 		expect(result.payload).toEqual({ a: 1 });
 	});
 
+	it("parses JSON arrays in string values when a union also accepts strings", () => {
+		const tool: Tool = {
+			name: "search-like",
+			description: "",
+			parameters: z.object({
+				paths: z.union([z.string(), z.array(z.string()).min(1)]),
+				pattern: z.string(),
+			}),
+		};
+
+		const toolCall: ToolCall = {
+			type: "toolCall",
+			id: "call-search-like",
+			name: "search-like",
+			arguments: {
+				paths: '["D:/WorkSpace/test_search.py"]',
+				pattern: "def greet",
+			},
+		};
+
+		const result = validateToolArguments(tool, toolCall) as { paths: string[]; pattern: string };
+		expect(result).toEqual({
+			paths: ["D:/WorkSpace/test_search.py"],
+			pattern: "def greet",
+		});
+	});
+
+	it("preserves JSON-looking strings when no container branch is valid", () => {
+		const tool: Tool = {
+			name: "string-only",
+			description: "",
+			parameters: z.object({ label: z.string() }),
+		};
+
+		const result = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-string-only",
+			name: "string-only",
+			arguments: { label: '["literal"]' },
+		}) as { label: string };
+
+		expect(result.label).toBe('["literal"]');
+	});
+
 	it("preserves unknown root fields after Zod validation so tools can reject disabled arguments", () => {
 		const tool: Tool = {
 			name: "t4b",

--- a/packages/coding-agent/test/tools/search-path-lists.test.ts
+++ b/packages/coding-agent/test/tools/search-path-lists.test.ts
@@ -178,6 +178,32 @@ describe("tool path arrays", () => {
 		expect(details?.scopePath).toBe("folder with spaces");
 	});
 
+	it("search coerces JSON-stringified path arrays from tool validation", async () => {
+		const tools = await createTools(createTestSession(tempDir));
+		const tool = tools.find(entry => entry.name === "search");
+		expect(tool).toBeDefined();
+		if (!tool) throw new Error("Missing search tool");
+
+		const args = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "search-json-string-path-array",
+			name: tool.name,
+			arguments: {
+				pattern: "shared-needle",
+				paths: JSON.stringify(["apps/", "packages/"]),
+			},
+		});
+		const result = await tool.execute("search-json-string-path-array", args);
+		const text = getText(result);
+		const details = result.details as { fileCount?: number; scopePath?: string } | undefined;
+
+		expect(text).toContain("shared-needle apps");
+		expect(text).toContain("shared-needle packages");
+		expect(text).not.toContain("shared-needle phases");
+		expect(details?.fileCount).toBe(2);
+		expect(details?.scopePath).toBe("apps/, packages/");
+	});
+
 	it("search pending renderer accepts a single string path", () => {
 		const component = searchToolRenderer.renderCall(
 			{ pattern: "space-needle", paths: "folder with spaces/" },

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed native `grep` directory scans skipping symlinked regular-file targets, which made the coding-agent `search` tool report `No matches found` for directories whose searchable files were surfaced as symlinks. ([#1518](https://github.com/can1357/oh-my-pi/issues/1518))
+
 ## [15.5.10] - 2026-05-28
 
 ### Fixed


### PR DESCRIPTION
## Repro
A native directory grep over a directory whose only searchable entry is a symlinked regular file returned zero searched files and zero matches, which the coding-agent `search` tool renders as `No matches found`. Reproduced against 15.5.13 with `bunx @oh-my-pi/pi-coding-agent@15.5.13 grep needle .wt/issue1518-symlink-files --limit 5 --no-gitignore`, which reported `Total matches: 0`, `Files with matches: 0`, and `Files searched: 0`.

## Cause
`crates/pi-natives/src/grep.rs` filtered directory-walk entries with `entry.file_type().is_file()` before calling `read_file_bytes()`. That skipped symlink directory entries even when `std::fs::metadata()` would resolve the target to a regular readable file; the cached-scan path had the same regular-file-only filter in `collect_files()`.

## Fix
- Added shared file-searchability checks for streaming walk entries and cached scan entries that accept regular files and symlinks whose targets are regular files.
- Updated native grep directory collection to use those checks before glob/type filtering and file reads.
- Added a Unix regression test covering directory grep through a symlinked regular-file target.
- Added an Unreleased changelog entry for `@oh-my-pi/pi-natives`.

## Verification
`cargo test -p pi-natives grep_` passed (6 tests). `cargo check -p pi-natives` passed. Fixes #1518