### PR TITLE
fix(ai): buffer Opus 4.8 tool input to stop malformed tool_use JSON

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the agent loop re-prompting unbounded when a model repeatedly issues tool calls that all error (e.g. malformed `tool_use` JSON failing argument validation, seen with Claude Opus 4.8). After 6 consecutive tool turns where every tool call errors with zero successful tool calls, the loop now breaks with a terminal error instead of spamming further parallel calls. Any successful tool call (or a turn with no tool calls) resets the streak, so legitimate mixed success/error turns are unaffected.
+
 ## [15.5.15] - 2026-05-30
 ### Added
 

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -462,6 +462,17 @@ function cloneAssistantMessageForToolCallCap(message: AssistantMessage): Assista
 	};
 }
 
+/**
+ * Maximum consecutive tool turns where *every* tool call errored (zero
+ * successful tool calls). Past this, the model is stuck spamming invalid
+ * calls — most often malformed tool_use JSON (e.g. Claude Opus 4.8 truncated
+ * arguments) that fails arg validation — rather than making progress, so we
+ * break the loop instead of re-prompting unbounded. A streak of all-error
+ * turns is pathological; any successful tool call resets the counter, so
+ * legitimate mixed success/error work is never affected.
+ */
+const MAX_CONSECUTIVE_ALL_ERROR_TOOL_TURNS = 6;
+
 async function runLoopBody(
 	currentContext: AgentContext,
 	newMessages: AgentMessage[],
@@ -478,6 +489,7 @@ async function runLoopBody(
 	let pendingMessages: AgentMessage[] = (await config.getSteeringMessages?.()) || [];
 	let harmonyRetryAttempt = 0;
 	let harmonyTruncateResumeCount = 0;
+	let consecutiveAllErrorToolTurns = 0;
 
 	// Outer loop: continues when queued follow-up messages arrive after agent would stop
 	while (true) {
@@ -639,7 +651,22 @@ async function runLoopBody(
 				}
 			}
 
+			// Anti-spam brake: a turn where the model issued tool calls but every
+			// one errored makes no progress. Track consecutive all-error turns; any
+			// successful tool call (or a turn with no tool calls) resets the streak.
+			if (hasMoreToolCalls && toolResults.length > 0 && toolResults.every(result => result.isError)) {
+				consecutiveAllErrorToolTurns++;
+			} else {
+				consecutiveAllErrorToolTurns = 0;
+			}
+
 			stream.push({ type: "turn_end", message, toolResults });
+
+			if (consecutiveAllErrorToolTurns >= MAX_CONSECUTIVE_ALL_ERROR_TOOL_TURNS) {
+				throw new Error(
+					`Aborting after ${MAX_CONSECUTIVE_ALL_ERROR_TOOL_TURNS} consecutive turns where every tool call failed (no successful tool call). This usually means the model emitted malformed tool-call arguments, e.g. Claude Opus 4.8 truncated tool_use JSON.`,
+				);
+			}
 
 			pendingMessages = steeringMessagesFromExecution ?? ((await config.getSteeringMessages?.()) || []);
 		}

--- a/packages/agent/test/agent-loop-tool-error-brake.test.ts
+++ b/packages/agent/test/agent-loop-tool-error-brake.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "bun:test";
+import { agentLoop } from "@oh-my-pi/pi-agent-core/agent-loop";
+import type {
+	AgentContext,
+	AgentEvent,
+	AgentLoopConfig,
+	AgentMessage,
+	AgentTool,
+	StreamFn,
+} from "@oh-my-pi/pi-agent-core/types";
+import type { Message } from "@oh-my-pi/pi-ai";
+import type { MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
+import { createMockModel } from "@oh-my-pi/pi-ai/providers/mock";
+import * as z from "zod/v4";
+import { createUserMessage } from "./helpers";
+
+/**
+ * Anti-spam brake: when a model issues tool calls but every one errors (e.g.
+ * malformed tool_use JSON that fails arg validation), the loop must not
+ * re-prompt forever. After MAX_CONSECUTIVE_ALL_ERROR_TOOL_TURNS (6) all-error
+ * turns with zero successful tool calls, the loop breaks with a terminal error.
+ * Any successful tool call resets the streak, so mixed work is never affected.
+ */
+
+function identityConverter(messages: AgentMessage[]): Message[] {
+	return messages.filter(m => m.role === "user" || m.role === "assistant" || m.role === "toolResult") as Message[];
+}
+
+const emptySchema = z.object({});
+const boomTool: AgentTool<typeof emptySchema, Record<string, never>> = {
+	name: "boom",
+	label: "Boom",
+	description: "Always throws",
+	parameters: emptySchema,
+	async execute() {
+		throw new Error("kaboom");
+	},
+};
+
+const okTool: AgentTool<typeof emptySchema, Record<string, never>> = {
+	name: "ok",
+	label: "Ok",
+	description: "Always succeeds",
+	parameters: emptySchema,
+	async execute() {
+		return { content: [{ type: "text", text: "ok" }], details: {} };
+	},
+};
+
+async function drain(
+	context: AgentContext,
+	config: AgentLoopConfig,
+	streamFn: StreamFn,
+): Promise<{ events: AgentEvent[]; error: unknown }> {
+	const events: AgentEvent[] = [];
+	let error: unknown;
+	const stream = agentLoop([createUserMessage("go")], context, config, undefined, streamFn);
+	try {
+		for await (const event of stream) events.push(event);
+		await stream.result();
+	} catch (e) {
+		error = e;
+	}
+	return { events, error };
+}
+
+describe("agent loop — all-error tool-turn brake", () => {
+	it("halts an otherwise-infinite stream of failing tool calls at the budget", async () => {
+		// The model emits a failing tool call forever. Without the brake this
+		// loops unbounded; with it, the loop stops after exactly 6 all-error turns.
+		function* infiniteFailingCalls(): Generator<MockResponse> {
+			let i = 0;
+			while (true) {
+				yield { content: [{ type: "toolCall", id: `boom-${i++}`, name: "boom", arguments: {} }] };
+			}
+		}
+		const mock = createMockModel({ responses: infiniteFailingCalls() });
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [boomTool] };
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const { events, error } = await drain(context, config, mock.stream);
+
+		const toolEnds = events.filter(e => e.type === "tool_execution_end");
+		expect(toolEnds.length).toBe(6);
+		expect(toolEnds.every(e => e.type === "tool_execution_end" && e.isError)).toBe(true);
+		expect(mock.calls.length).toBe(6);
+		expect(error).toBeInstanceOf(Error);
+		expect((error as Error).message).toContain("every tool call failed");
+	});
+
+	it("does not trip when each turn mixes a failing and a successful tool call", async () => {
+		// Seven mixed turns (one success each) then a plain text turn. Every mixed
+		// turn resets the streak, so the loop completes normally despite errors.
+		const responses: MockResponse[] = [];
+		for (let i = 0; i < 7; i++) {
+			responses.push({
+				content: [
+					{ type: "toolCall", id: `boom-${i}`, name: "boom", arguments: {} },
+					{ type: "toolCall", id: `ok-${i}`, name: "ok", arguments: {} },
+				],
+			});
+		}
+		responses.push({ content: ["done"] });
+		const mock = createMockModel({ responses });
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [boomTool, okTool] };
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const { events, error } = await drain(context, config, mock.stream);
+
+		expect(error).toBeUndefined();
+		expect(events.map(e => e.type)).toContain("agent_end");
+		// All 8 turns ran — never short-circuited by the brake.
+		expect(mock.calls.length).toBe(8);
+	});
+
+	it("resets the streak after a single successful tool turn", async () => {
+		// 5 failing turns, then one fully-successful turn (resets), then text done.
+		// The streak never reaches 6, so no brake fires.
+		const responses: MockResponse[] = [];
+		for (let i = 0; i < 5; i++) {
+			responses.push({ content: [{ type: "toolCall", id: `boom-${i}`, name: "boom", arguments: {} }] });
+		}
+		responses.push({ content: [{ type: "toolCall", id: "ok-1", name: "ok", arguments: {} }] });
+		for (let i = 5; i < 10; i++) {
+			responses.push({ content: [{ type: "toolCall", id: `boom-${i}`, name: "boom", arguments: {} }] });
+		}
+		responses.push({ content: ["done"] });
+		const mock = createMockModel({ responses });
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [boomTool, okTool] };
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const { events, error } = await drain(context, config, mock.stream);
+
+		expect(error).toBeUndefined();
+		expect(events.map(e => e.type)).toContain("agent_end");
+		expect(mock.calls.length).toBe(12);
+	});
+});

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Claude Opus 4.8 emitting malformed / truncated `tool_use` JSON (unterminated strings, missing braces) that streamed back as `{}` or partial tool arguments and broke strict-schema tools like `todo_write`. Opus 4.8+ on the Messages API (first-party, OAuth/subscription, and GitHub-Copilot-routed Claude) now buffers tool input server-side — sending neither the per-tool `eager_input_streaming` flag nor the `fine-grained-tool-streaming-2025-05-14` beta — so the API validates and only streams complete tool JSON. Added `AnthropicCompat.bufferToolInput` (auto-detected for Opus 4.8+, overridable per model) and the exported `anthropicToolInputStreamingMode` resolver; earlier Claude models keep fast eager streaming. (refs anthropics/claude-code#63604)
+- Fixed an empty-text but signed `thinking` block being replayed to the Anthropic Messages API, which returns `400 ... thinking blocks ... cannot be modified` and permanently wedges long interleaved-thinking + tool sessions (notably over OAuth). `convertAnthropicMessages` now drops a signed thinking block whose text is empty while preserving non-empty signed blocks and the accompanying `tool_use`. (refs anthropics/claude-code#63147)
+
 ## [15.5.15] - 2026-05-30
 
 ### Added

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -379,6 +379,21 @@ export function supportsMidConversationSystemMessages(modelId: string): boolean 
 	return parsed.kind === "opus" && semverGte(parsed.version, "4.8");
 }
 
+/**
+ * Claude Opus 4.8 frequently emits malformed / truncated `tool_use` JSON
+ * (unterminated strings, missing braces) when tool input is streamed without
+ * server-side buffering. Sending neither `eager_input_streaming` nor the
+ * `fine-grained-tool-streaming` beta restores Anthropic's default buffered
+ * tool-JSON validation, so only complete, valid tool input streams back.
+ * Scoped to Opus 4.8+; earlier Claude models stream tool input fine.
+ * @see https://github.com/anthropics/claude-code/issues/63604
+ */
+export function anthropicModelNeedsBufferedToolInput(modelId: string): boolean {
+	const parsed = parseAnthropicModel(getCanonicalModelId(modelId));
+	if (!parsed) return false;
+	return parsed.kind === "opus" && semverGte(parsed.version, "4.8");
+}
+
 function anthropicModelHasRealXHighEffort<TApi extends Api>(model: ApiModel<TApi>): boolean {
 	if (model.api !== "anthropic-messages") return false;
 	const parsedModel = parseKnownModel(model.id);

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -22,6 +22,7 @@ import {
 	readSseEvents,
 } from "@oh-my-pi/pi-utils";
 import {
+	anthropicModelNeedsBufferedToolInput,
 	hasOpus47ApiRestrictions,
 	mapEffortToAnthropicAdaptiveEffort,
 	supportsMidConversationSystemMessages,
@@ -975,6 +976,7 @@ function getAnthropicCompat(
 		disableStrictTools: model.compat?.disableStrictTools ?? false,
 		disableAdaptiveThinking: model.compat?.disableAdaptiveThinking ?? false,
 		supportsEagerToolInputStreaming: model.compat?.supportsEagerToolInputStreaming ?? true,
+		bufferToolInput: model.compat?.bufferToolInput ?? anthropicModelNeedsBufferedToolInput(model.id),
 		supportsLongCacheRetention: model.compat?.supportsLongCacheRetention ?? true,
 		supportsMidConversationSystem:
 			model.compat?.supportsMidConversationSystem ??
@@ -983,6 +985,24 @@ function getAnthropicCompat(
 			// the canonical api.anthropic.com host plus an Opus 4.8+ model id.
 			(isAnthropicApiBaseUrl(model.baseUrl) && supportsMidConversationSystemMessages(model.id)),
 	};
+}
+
+/**
+ * Resolves how tool input is streamed for an Anthropic model:
+ * - `"buffered"`: server buffers + validates tool JSON, then streams the
+ *   complete input (neither `eager_input_streaming` nor fine-grained beta).
+ *   Used for models that emit malformed tool_use JSON (Opus 4.8+).
+ * - `"eager"`: per-tool `eager_input_streaming` flag (default for Claude).
+ * - `"fine-grained"`: `fine-grained-tool-streaming` beta header.
+ * `bufferToolInput` takes precedence over `supportsEagerToolInputStreaming`.
+ */
+export function anthropicToolInputStreamingMode(
+	model: Model<"anthropic-messages">,
+): "buffered" | "eager" | "fine-grained" {
+	const compat = getAnthropicCompat(model);
+	if (compat.bufferToolInput) return "buffered";
+	if (compat.supportsEagerToolInputStreaming) return "eager";
+	return "fine-grained";
 }
 
 const PROVIDER_MAX_RETRIES = 3;
@@ -1663,9 +1683,8 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		isOAuth,
 		onSseEvent,
 	} = args;
-	const compat = getAnthropicCompat(model);
 	const needsInterleavedBeta = interleavedThinking && !supportsAdaptiveThinkingDisplay(model.id);
-	const needsFineGrainedToolStreamingBeta = hasTools && !compat.supportsEagerToolInputStreaming;
+	const needsFineGrainedToolStreamingBeta = hasTools && anthropicToolInputStreamingMode(model) === "fine-grained";
 	const oauthToken = isOAuth ?? isAnthropicOAuthToken(apiKey);
 	const baseUrl = resolveAnthropicBaseUrl(model, apiKey);
 	const foundryCustomHeaders = resolveAnthropicCustomHeaders(model);
@@ -2069,7 +2088,7 @@ function buildParams(
 			context.tools,
 			isOAuthToken,
 			disableStrictTools || model.provider === "github-copilot",
-			getAnthropicCompat(model).supportsEagerToolInputStreaming,
+			anthropicToolInputStreamingMode(model) === "eager",
 		);
 	}
 
@@ -2276,6 +2295,11 @@ export function convertAnthropicMessages(
 							});
 							continue;
 						}
+						// A signed thinking block whose text is empty is provably dead:
+						// Anthropic rejects it with `400 ... thinking blocks ... cannot
+						// be modified` on the next turn. Drop it (interleaved-thinking +
+						// tool turns on long OAuth sessions emit these).
+						if (block.thinking.trim().length === 0) continue;
 						blocks.push({
 							type: "thinking",
 							thinking: block.thinking,

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -826,6 +826,15 @@ export interface AnthropicCompat {
 	disableAdaptiveThinking?: boolean;
 	/** Whether tools may include Anthropic's per-tool eager_input_streaming flag. Default: true. */
 	supportsEagerToolInputStreaming?: boolean;
+	/**
+	 * Buffer tool input server-side instead of streaming it, restoring
+	 * Anthropic's tool-JSON validation. Sends neither `eager_input_streaming`
+	 * nor the `fine-grained-tool-streaming` beta so only complete, valid tool
+	 * input streams back. Default: auto-detected (Claude Opus 4.8+, which
+	 * otherwise emits malformed `tool_use` JSON). Takes precedence over
+	 * `supportsEagerToolInputStreaming`.
+	 */
+	bufferToolInput?: boolean;
 	/** Whether long prompt-cache retention (`ttl: "1h"`) is supported. Default: true for canonical Anthropic API. */
 	supportsLongCacheRetention?: boolean;
 	/**

--- a/packages/ai/test/anthropic-opus-4-8-tool-streaming.test.ts
+++ b/packages/ai/test/anthropic-opus-4-8-tool-streaming.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "bun:test";
+import { anthropicModelNeedsBufferedToolInput } from "@oh-my-pi/pi-ai/model-thinking";
+import {
+	anthropicToolInputStreamingMode,
+	buildAnthropicClientOptions,
+	convertAnthropicMessages,
+	streamAnthropic,
+} from "@oh-my-pi/pi-ai/providers/anthropic";
+import type { AssistantMessage, Context, Model, TJsonSchema, Tool, UserMessage } from "@oh-my-pi/pi-ai/types";
+import { parseStreamingJson } from "@oh-my-pi/pi-ai/utils/json-parse";
+
+/**
+ * Claude Opus 4.8 frequently emits malformed / truncated tool_use JSON when
+ * tool input streams without server-side buffering. The fix routes Opus 4.8 to
+ * "buffered" tool-input mode (neither `eager_input_streaming` nor the
+ * fine-grained-tool-streaming beta), restoring Anthropic's JSON validation so
+ * only complete, valid tool input streams back. Earlier Claude models keep the
+ * fast "eager" streaming they tolerate.
+ * @see https://github.com/anthropics/claude-code/issues/63604
+ */
+
+const FINE_GRAINED_BETA = "fine-grained-tool-streaming-2025-05-14";
+
+function makeModel(overrides: Partial<Model<"anthropic-messages">> = {}): Model<"anthropic-messages"> {
+	return {
+		api: "anthropic-messages",
+		provider: "anthropic",
+		id: "claude-opus-4-8-20260528",
+		name: "Claude Opus 4.8",
+		baseUrl: "https://api.anthropic.com",
+		input: ["text"],
+		cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 },
+		maxTokens: 64000,
+		contextWindow: 1000000,
+		reasoning: true,
+		...overrides,
+	};
+}
+
+const SAMPLE_TOOL: Tool = {
+	name: "todo_write",
+	description: "Manage a phased task list",
+	parameters: {
+		type: "object",
+		properties: { ops: { type: "array", items: { type: "object" }, minItems: 1 } },
+		required: ["ops"],
+	} as TJsonSchema,
+};
+
+function createAbortedSignal(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+function capturePayload(model: Model<"anthropic-messages">): Promise<{ tools?: Array<Record<string, unknown>> }> {
+	const context: Context = {
+		messages: [{ role: "user", content: "Plan a 3-step task", timestamp: Date.now() }],
+		tools: [SAMPLE_TOOL],
+	};
+	const { promise, resolve } = Promise.withResolvers<{ tools?: Array<Record<string, unknown>> }>();
+	streamAnthropic(model, context, {
+		apiKey: "sk-ant-oat-test",
+		isOAuth: true,
+		signal: createAbortedSignal(),
+		onPayload: payload => resolve(payload as { tools?: Array<Record<string, unknown>> }),
+	});
+	return promise;
+}
+
+function betaHeader(model: Model<"anthropic-messages">, isOAuth: boolean): string {
+	const options = buildAnthropicClientOptions({
+		model,
+		apiKey: isOAuth ? "sk-ant-oat-test" : "sk-ant-api-test",
+		extraBetas: [],
+		stream: true,
+		interleavedThinking: false,
+		hasTools: true,
+		isOAuth,
+	});
+	return String(options.defaultHeaders["Anthropic-Beta"] ?? "");
+}
+
+describe("anthropicModelNeedsBufferedToolInput", () => {
+	it("flags Opus 4.8+ (canonical and dated, with or without provider prefix)", () => {
+		expect(anthropicModelNeedsBufferedToolInput("claude-opus-4-8")).toBe(true);
+		expect(anthropicModelNeedsBufferedToolInput("claude-opus-4-8-20260528")).toBe(true);
+		expect(anthropicModelNeedsBufferedToolInput("anthropic/claude-opus-4-8")).toBe(true);
+	});
+
+	it("does not flag earlier Claude models or non-Claude ids", () => {
+		expect(anthropicModelNeedsBufferedToolInput("claude-opus-4-7")).toBe(false);
+		expect(anthropicModelNeedsBufferedToolInput("claude-opus-4-6")).toBe(false);
+		expect(anthropicModelNeedsBufferedToolInput("claude-sonnet-4-5")).toBe(false);
+		expect(anthropicModelNeedsBufferedToolInput("gpt-5")).toBe(false);
+	});
+});
+
+describe("anthropicToolInputStreamingMode", () => {
+	it("buffers tool input for Opus 4.8", () => {
+		expect(anthropicToolInputStreamingMode(makeModel())).toBe("buffered");
+		expect(anthropicToolInputStreamingMode(makeModel({ id: "claude-opus-4-8" }))).toBe("buffered");
+	});
+
+	it("keeps eager streaming for Opus 4.7 and Sonnet", () => {
+		expect(anthropicToolInputStreamingMode(makeModel({ id: "claude-opus-4-7" }))).toBe("eager");
+		expect(anthropicToolInputStreamingMode(makeModel({ id: "claude-sonnet-4-5" }))).toBe("eager");
+	});
+
+	it("honors an explicit compat.bufferToolInput override on Opus 4.8", () => {
+		expect(anthropicToolInputStreamingMode(makeModel({ compat: { bufferToolInput: false } }))).toBe("eager");
+	});
+
+	it("falls back to fine-grained when eager is disabled and buffering is off", () => {
+		const model = makeModel({ id: "claude-sonnet-4-5", compat: { supportsEagerToolInputStreaming: false } });
+		expect(anthropicToolInputStreamingMode(model)).toBe("fine-grained");
+	});
+});
+
+describe("Opus 4.8 buffered tool streaming — wire behavior", () => {
+	it("omits eager_input_streaming on tools for Opus 4.8", async () => {
+		const payload = await capturePayload(makeModel());
+		expect(payload.tools?.length).toBeGreaterThan(0);
+		for (const tool of payload.tools ?? []) {
+			expect(tool.eager_input_streaming).toBeUndefined();
+		}
+	});
+
+	it("keeps eager_input_streaming on tools for Sonnet 4.5 (unchanged)", async () => {
+		const payload = await capturePayload(makeModel({ id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" }));
+		expect(payload.tools?.length).toBeGreaterThan(0);
+		expect(payload.tools?.[0]?.eager_input_streaming).toBe(true);
+	});
+
+	it("never sends the fine-grained-tool-streaming beta for Opus 4.8 (api key or OAuth)", () => {
+		expect(betaHeader(makeModel(), false)).not.toContain(FINE_GRAINED_BETA);
+		expect(betaHeader(makeModel(), true)).not.toContain(FINE_GRAINED_BETA);
+	});
+
+	it("resolves OAuth tokens while still buffering Opus 4.8 tool input", () => {
+		const options = buildAnthropicClientOptions({
+			model: makeModel(),
+			apiKey: "sk-ant-oat-test",
+			extraBetas: [],
+			stream: true,
+			interleavedThinking: false,
+			hasTools: true,
+			isOAuth: true,
+		});
+		expect(options.isOAuthToken).toBe(true);
+		expect(String(options.defaultHeaders["Anthropic-Beta"] ?? "")).not.toContain(FINE_GRAINED_BETA);
+	});
+
+	it("still sends the fine-grained beta when eager is disabled on a non-buffered model", () => {
+		const model = makeModel({ id: "claude-sonnet-4-5", compat: { supportsEagerToolInputStreaming: false } });
+		expect(betaHeader(model, false)).toContain(FINE_GRAINED_BETA);
+	});
+});
+
+describe("malformed tool_use JSON defect (why buffering matters)", () => {
+	it("recovers args that fail todo_write validation instead of throwing on truncated tool JSON", () => {
+		// A truncated input_json_delta stream (Opus 4.8's failure mode): the
+		// closing braces/array never arrive. parseStreamingJson never throws — it
+		// returns a best-effort object. Depending on where truncation lands, the
+		// recovered args either drop the required `ops` field entirely or yield an
+		// empty `ops` array. Either way todo_write's `ops: z.array(...).min(1)`
+		// schema rejects them, producing the error tool_result that drives the
+		// retry-nudge spam. Buffered mode removes this by only streaming complete
+		// JSON in the first place.
+		expect(parseStreamingJson<{ ops?: unknown[] }>('{"ops":')).toEqual({}); // value never arrived → no ops
+		expect(parseStreamingJson<{ ops?: unknown[] }>('{"ops":[')).toEqual({ ops: [] }); // empty array → fails .min(1)
+		expect(parseStreamingJson<{ ops?: unknown[] }>("")).toEqual({});
+	});
+});
+
+describe("convertAnthropicMessages — empty signed thinking blocks", () => {
+	const model = makeModel();
+
+	function assistant(content: AssistantMessage["content"]): AssistantMessage {
+		return {
+			role: "assistant",
+			content,
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: model.id,
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+	}
+
+	const user: UserMessage = { role: "user", content: "continue", timestamp: Date.now() };
+
+	it("drops an empty-text signed thinking block but keeps the tool_use", () => {
+		const msg = assistant([
+			{ type: "thinking", thinking: "", thinkingSignature: "sig_dead" },
+			{ type: "toolCall", id: "toolu_1", name: "read", arguments: { path: "README.md" } },
+		]);
+		const params = convertAnthropicMessages([user, msg], model, false);
+		const assistantParam = params.find(message => message.role === "assistant");
+		expect(assistantParam?.content).toEqual([
+			{ type: "tool_use", id: "toolu_1", name: "read", input: { path: "README.md" } },
+		]);
+	});
+
+	it("preserves a non-empty signed thinking block alongside the tool_use", () => {
+		const msg = assistant([
+			{ type: "thinking", thinking: "real analysis", thinkingSignature: "sig_live" },
+			{ type: "toolCall", id: "toolu_2", name: "read", arguments: { path: "a.ts" } },
+		]);
+		const params = convertAnthropicMessages([user, msg], model, false);
+		const assistantParam = params.find(message => message.role === "assistant");
+		expect(assistantParam?.content).toEqual([
+			{ type: "thinking", thinking: "real analysis", signature: "sig_live" },
+			{ type: "tool_use", id: "toolu_2", name: "read", input: { path: "a.ts" } },
+		]);
+	});
+
+	it("drops only the empty signed block when both empty and non-empty are present", () => {
+		const msg = assistant([
+			{ type: "thinking", thinking: "", thinkingSignature: "sig_dead" },
+			{ type: "thinking", thinking: "kept", thinkingSignature: "sig_live" },
+			{ type: "toolCall", id: "toolu_3", name: "read", arguments: { path: "b.ts" } },
+		]);
+		const params = convertAnthropicMessages([user, msg], model, false);
+		const assistantParam = params.find(message => message.role === "assistant");
+		expect(assistantParam?.content).toEqual([
+			{ type: "thinking", thinking: "kept", signature: "sig_live" },
+			{ type: "tool_use", id: "toolu_3", name: "read", input: { path: "b.ts" } },
+		]);
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `todo_write` failure nudge looping forever when a model keeps emitting malformed tool arguments (notably Claude Opus 4.8 truncated `tool_use` JSON). After 3 consecutive failures the session now sends a single terminal "known issue — stop retrying" reminder (naming the Opus 4.8 malformed-tool-JSON cause) and then goes silent, instead of re-injecting the fix-and-retry `<system-reminder>` on every failed call; a successful `todo_write` resets the counter.
+
 ## [15.5.15] - 2026-05-30
 ### Changed
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -464,6 +464,13 @@ export function resolveToolCallBatchCapForModel(model: Model | undefined): numbe
 }
 
 /**
+ * Consecutive failed todo_write calls after which we stop the "fix and retry"
+ * nudge and instead tell the model (and surface to the user) that the model is
+ * emitting malformed tool_use JSON — rather than re-prompting forever.
+ */
+const MAX_TODO_WRITE_RETRY_NUDGES = 3;
+
+/**
  * Collapse degenerate IRC ephemeral replies before they hit the relay.
  * Models occasionally loop on a single line (~16 reports of N-times-repeated
  * replies); compress runs longer than 3 down to one instance + `[…N×]`, then
@@ -817,6 +824,10 @@ export class AgentSession {
 	// Todo completion reminder state
 	#todoReminderCount = 0;
 	#todoPhases: TodoPhase[] = [];
+	// Consecutive todo_write failures (malformed args). Caps the auto-retry
+	// nudge so a model that keeps emitting bad tool_use JSON (e.g. Opus 4.8)
+	// is not re-prompted forever. Reset on any successful todo_write.
+	#todoWriteFailureStreak = 0;
 	#toolChoiceQueue = new ToolChoiceQueue();
 
 	// Bash execution state
@@ -1732,27 +1743,49 @@ export class AgentSession {
 				if (toolName === "edit" && details?.path) {
 					this.#invalidateFileCacheForPath(details.path);
 				}
-				if (toolName === "todo_write" && !isError && Array.isArray(details?.phases)) {
-					this.setTodoPhases(details.phases);
+				if (toolName === "todo_write" && !isError) {
+					this.#todoWriteFailureStreak = 0;
+					if (Array.isArray(details?.phases)) {
+						this.setTodoPhases(details.phases);
+					}
 				}
 				if (toolName === "todo_write" && isError) {
+					this.#todoWriteFailureStreak++;
 					const errorText = content?.find(part => part.type === "text")?.text;
-					const reminderText = [
-						"<system-reminder>",
-						"todo_write failed, so todo progress is not visible to the user.",
-						errorText ? `Failure: ${errorText}` : "Failure: todo_write returned an error.",
-						"Fix the todo payload and call todo_write again before continuing.",
-						"</system-reminder>",
-					].join("\n");
-					await this.sendCustomMessage(
-						{
-							customType: "todo-write-error-reminder",
-							content: reminderText,
-							display: false,
-							details: { toolName, errorText },
-						},
-						{ deliverAs: "nextTurn" },
-					);
+					const failureLine = errorText ? `Failure: ${errorText}` : "Failure: todo_write returned an error.";
+					// Up to MAX_TODO_WRITE_RETRY_NUDGES failures: nudge to fix and retry.
+					// On the Nth failure: switch to a terminal explanation (likely
+					// malformed tool_use JSON) so we stop looping silently. Past that:
+					// no further nudges — the model has been told to move on.
+					let reminderText: string | undefined;
+					if (this.#todoWriteFailureStreak < MAX_TODO_WRITE_RETRY_NUDGES) {
+						reminderText = [
+							"<system-reminder>",
+							"todo_write failed, so todo progress is not visible to the user.",
+							failureLine,
+							"Fix the todo payload and call todo_write again before continuing.",
+							"</system-reminder>",
+						].join("\n");
+					} else if (this.#todoWriteFailureStreak === MAX_TODO_WRITE_RETRY_NUDGES) {
+						reminderText = [
+							"<system-reminder>",
+							`todo_write has now failed ${this.#todoWriteFailureStreak} times in a row.`,
+							failureLine,
+							"This is a known issue where some models (notably Claude Opus 4.8) emit malformed or truncated tool_use JSON. Stop retrying todo_write; continue the task without it and tell the user the todo list could not be updated.",
+							"</system-reminder>",
+						].join("\n");
+					}
+					if (reminderText) {
+						await this.sendCustomMessage(
+							{
+								customType: "todo-write-error-reminder",
+								content: reminderText,
+								display: false,
+								details: { toolName, errorText },
+							},
+							{ deliverAs: "nextTurn" },
+						);
+					}
 				}
 				if (toolName === "checkpoint" && !isError) {
 					const checkpointEntryId = this.sessionManager.getEntries().at(-1)?.id ?? null;

--- a/packages/coding-agent/test/agent-session-todo-write-nudge.test.ts
+++ b/packages/coding-agent/test/agent-session-todo-write-nudge.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import type { ToolResultMessage } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-ai/models";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+/**
+ * A model that keeps emitting malformed todo_write args (e.g. Claude Opus 4.8
+ * truncated tool_use JSON) produces a stream of error tool_results. The session
+ * nudges the model to fix-and-retry, but must CAP that nudge: after
+ * MAX_TODO_WRITE_RETRY_NUDGES (3) consecutive failures it sends one terminal
+ * "known issue, stop retrying" reminder and then goes silent, instead of
+ * re-prompting forever. A successful todo_write resets the streak.
+ */
+
+function failingTodoResult(id: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: id,
+		toolName: "todo_write",
+		content: [{ type: "text", text: "ops: array must contain at least 1 element" }],
+		isError: true,
+		timestamp: Date.now(),
+	};
+}
+
+function succeedingTodoResult(id: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: id,
+		toolName: "todo_write",
+		content: [{ type: "text", text: "Phases set" }],
+		details: { phases: [{ name: "Phase 1", tasks: [{ content: "do work", status: "in_progress" }] }] },
+		isError: false,
+		timestamp: Date.now(),
+	};
+}
+
+describe("AgentSession todo_write nudge cap", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+	let nudges: string[];
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-todo-nudge-");
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage);
+		const sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected built-in anthropic model to exist");
+
+		const agent = new Agent({
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [] },
+		});
+		session = new AgentSession({ agent, sessionManager, settings: Settings.isolated(), modelRegistry });
+
+		nudges = [];
+		vi.spyOn(session, "sendCustomMessage").mockImplementation(async message => {
+			if (message.customType === "todo-write-error-reminder" && typeof message.content === "string") {
+				nudges.push(message.content);
+			}
+		});
+	});
+
+	afterEach(async () => {
+		await session.dispose();
+		authStorage.close();
+		try {
+			await tempDir.remove();
+		} catch {}
+		vi.restoreAllMocks();
+	});
+
+	async function emitToolResult(message: ToolResultMessage): Promise<void> {
+		session.agent.emitExternalEvent({ type: "message_end", message });
+		// #handleAgentEvent runs as an unawaited async listener; flush it.
+		await Bun.sleep(5);
+	}
+
+	it("caps retry nudges and emits a terminal known-issue reminder", async () => {
+		for (let i = 0; i < 5; i++) {
+			await emitToolResult(failingTodoResult(`fail-${i}`));
+		}
+
+		// Only 3 nudges total: 2 fix-and-retry, then 1 terminal — failures 4 & 5 are silent.
+		expect(nudges).toHaveLength(3);
+		expect(nudges[0]).toContain("Fix the todo payload");
+		expect(nudges[1]).toContain("Fix the todo payload");
+		expect(nudges[2]).toContain("Claude Opus 4.8");
+		expect(nudges[2]).toContain("Stop retrying todo_write");
+		expect(nudges[2]).not.toContain("Fix the todo payload and call todo_write again");
+	});
+
+	it("resets the streak after a successful todo_write", async () => {
+		// Exhaust the budget first.
+		for (let i = 0; i < 4; i++) {
+			await emitToolResult(failingTodoResult(`fail-${i}`));
+		}
+		expect(nudges).toHaveLength(3);
+
+		// A success resets the streak; the next failure nudges fix-and-retry again.
+		await emitToolResult(succeedingTodoResult("ok-1"));
+		await emitToolResult(failingTodoResult("fail-after-reset"));
+
+		expect(nudges).toHaveLength(4);
+		expect(nudges[3]).toContain("Fix the todo payload");
+		// The successful todo_write also updated the rendered phases.
+		expect(session.getTodoPhases().map(phase => phase.name)).toEqual(["Phase 1"]);
+	});
+});


### PR DESCRIPTION
## Problem

Running the coding-agent with **Claude Opus 4.8 over OAuth** broke `todo_write` and produced parallel-call spam — the model "hallucinates the tool being complete, doesn't emit a real tool end, then spams parallel calls."

Root cause is a **model-layer defect**: Opus 4.8 frequently emits **malformed / truncated `tool_use` JSON** (unterminated strings, missing braces). The Anthropic provider opts into unbuffered tool streaming by default (per-tool `eager_input_streaming`, or the `fine-grained-tool-streaming` beta), which Anthropic documents as streaming *without buffering / JSON validation*. The chain:

1. Unbuffered streaming exposes Opus 4.8's malformed JSON on the wire.
2. `parseStreamingJson` never throws → a malformed `tool_use` becomes `{}` / partial args.
3. `todo_write`'s schema requires `ops: z.array(...).min(1)`, so empty/partial args **throw** validation → synthetic error `tool_result`.
4. Each failed `todo_write` injects a "fix and retry" `<system-reminder>`, and the continue loop has **no retry cap** → unbounded spam.

(Opus 4.7 works under the same mode because it happens to emit valid JSON.)

## Fix

**Primary — restore Anthropic's server-side tool-JSON validation for Opus 4.8.** For `opus >= 4.8` on `anthropic-messages` (first-party, OAuth, and GitHub-Copilot-routed Claude), send **neither** `eager_input_streaming` **nor** the fine-grained beta → the API buffers and only streams complete, valid tool JSON. Scoped to Opus 4.8; other models keep fast streaming.

- `AnthropicCompat.bufferToolInput` (auto-detected for Opus 4.8+, overridable per model)
- exported `anthropicToolInputStreamingMode(model) → "buffered" | "eager" | "fine-grained"` resolver, wired into the fine-grained beta gate and the `convertTools` eager flag
- new `anthropicModelNeedsBufferedToolInput` gate alongside `hasOpus47ApiRestrictions` / `supportsMidConversationSystemMessages`

**Defensive — never replay a dead thinking block.** `convertAnthropicMessages` now drops a `thinking` block whose text is empty while signed, preventing the permanent `400 ... thinking blocks ... cannot be modified` landmine on long interleaved-thinking + tool sessions (refs anthropics/claude-code#63147).

**Defense-in-depth — bounded anti-spam.**
- `packages/agent`: break the loop after **6** consecutive tool turns where *every* call errored (zero successes); any successful call resets the streak, so mixed turns are unaffected. Covers other malformed-args paths (e.g. Bedrock Opus 4.8, `max_tokens` truncation).
- `packages/coding-agent`: cap the `todo_write` retry nudge at **3**, ending with a terminal "known Opus 4.8 malformed-JSON" reminder instead of looping; reset on success.

refs anthropics/claude-code#63604

## Verification

- **Live OAuth Opus 4.8 smoke** (`--provider anthropic --model claude-opus-4-8`, real subscription token): a `todo_write init` task → **1** call, **succeeded**, complete valid `ops` (3 phases × 2 tasks), phases set, single clean reply, **zero** malformed-JSON errors / retries / parallel-call spam.
- **Deterministic tests** (all green on current `main`):
  - `packages/ai` (15): `anthropicToolInputStreamingMode` + gate; Opus 4.8 carries no `eager_input_streaming` and no fine-grained beta (incl. OAuth); Sonnet/4.7 unchanged; truncated-JSON defect reproduction; `convertAnthropicMessages` drops empty-signed thinking while keeping non-empty + `tool_use`.
  - `packages/agent` (3): brake halts an infinite all-error stream at the budget; mixed success/error and post-success reset never trip it.
  - `packages/coding-agent` (2): nudge cap + terminal reminder; reset on success.
- `tsgo --noEmit` clean across `ai`, `agent`, `coding-agent`; biome clean on changed files. Rebased onto current `main`.

## Notes

- Buffered streaming removes incremental tool-arg preview for Opus 4.8 only — the correct trade for a model that otherwise emits garbage; gate is `>= 4.8`, so revisit if Anthropic fixes the model.
- Bedrock Opus 4.8 uses a different provider and isn't covered by the buffered-streaming change; the agent-loop brake is the safety net there.
