### PR TITLE
fix(acp): auto-select client-provided MCP tools

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ACP client-provided `mcpServers` connecting without their tools being auto-selected for the model ([#1525](https://github.com/can1357/oh-my-pi/issues/1525)).
+
 ## [15.5.15] - 2026-05-30
 ### Changed
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1999,8 +1999,18 @@ export class AcpAgent implements Agent {
 		}
 
 		record.mcpManager = manager;
-		record.session.setDefaultSelectedMCPServers(result.connectedServers);
+		record.session.setDefaultSelectedMCPServers(this.#getMcpServerNamesWithTools(result.tools));
 		await record.session.refreshMCPTools(result.tools);
+	}
+
+	#getMcpServerNamesWithTools(tools: ReadonlyArray<{ mcpServerName?: string }>): string[] {
+		const serverNames = new Set<string>();
+		for (const tool of tools) {
+			if (tool.mcpServerName) {
+				serverNames.add(tool.mcpServerName);
+			}
+		}
+		return [...serverNames];
 	}
 
 	#toMcpConfig(server: McpServer): MCPServerConfig {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1970,6 +1970,7 @@ export class AcpAgent implements Agent {
 			await record.mcpManager.disconnectAll();
 		}
 		if (servers.length === 0) {
+			record.session.setDefaultSelectedMCPServers([]);
 			record.mcpManager = undefined;
 			await record.session.refreshMCPTools([]);
 			return;
@@ -1998,6 +1999,7 @@ export class AcpAgent implements Agent {
 		}
 
 		record.mcpManager = manager;
+		record.session.setDefaultSelectedMCPServers(result.connectedServers);
 		await record.session.refreshMCPTools(result.tools);
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3070,6 +3070,11 @@ export class AgentSession {
 		return this.#filterSelectableMCPToolNames(this.#selectedMCPToolNames);
 	}
 
+	/** Replace the MCP servers whose tools seed automatic selection on refresh. */
+	setDefaultSelectedMCPServers(serverNames: Iterable<string>): void {
+		this.#defaultSelectedMCPServerNames = new Set(serverNames);
+	}
+
 	async activateDiscoveredMCPTools(toolNames: string[]): Promise<string[]> {
 		const nextSelectedMCPToolNames = new Set(this.#selectedMCPToolNames);
 		const activated: string[] = [];
@@ -3554,18 +3559,23 @@ export class AgentSession {
 
 		this.#setDiscoverableMCPTools(this.#collectDiscoverableMCPToolsFromRegistry());
 		this.#pruneSelectedMCPToolNames();
+		const configuredDefaultSelectedMCPToolNames = this.#getConfiguredDefaultSelectedMCPToolNames();
 		if (!this.buildDisplaySessionContext().hasPersistedMCPToolSelection) {
 			this.#selectedMCPToolNames = new Set([
 				...this.#selectedMCPToolNames,
-				...this.#getConfiguredDefaultSelectedMCPToolNames(),
+				...configuredDefaultSelectedMCPToolNames,
 			]);
 		}
-		this.#rememberSessionDefaultSelectedMCPToolNames(
-			this.sessionFile,
-			this.#getConfiguredDefaultSelectedMCPToolNames(),
-		);
+		this.#rememberSessionDefaultSelectedMCPToolNames(this.sessionFile, configuredDefaultSelectedMCPToolNames);
 
-		const nextActive = [...this.#getActiveNonMCPToolNames(), ...this.getSelectedMCPToolNames()];
+		const selectedMCPToolNames = this.#mcpDiscoveryEnabled
+			? this.getSelectedMCPToolNames()
+			: this.#filterSelectableMCPToolNames([
+					...previousSelectedMCPToolNames,
+					...configuredDefaultSelectedMCPToolNames,
+				]);
+
+		const nextActive = [...this.#getActiveNonMCPToolNames(), ...selectedMCPToolNames];
 		await this.#applyActiveToolsByName(nextActive, { previousSelectedMCPToolNames });
 	}
 

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -476,7 +476,7 @@ describe("ACP agent", () => {
 		} as unknown as CustomTool;
 	}
 
-	it("auto-selects tools from ACP client-provided MCP servers", async () => {
+	it("auto-selects deferred tools from ACP client-provided MCP servers", async () => {
 		const harness = await createHarness();
 		const tools = [
 			createMcpTool("mcp__codegraph_search", "codegraph"),
@@ -485,7 +485,7 @@ describe("ACP agent", () => {
 		const connectSpy = spyOn(MCPManager.prototype, "connectServers").mockResolvedValue({
 			tools,
 			errors: new Map(),
-			connectedServers: ["codegraph"],
+			connectedServers: [],
 			exaApiKeys: [],
 		});
 		try {

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -20,6 +20,8 @@ import {
 import type { Model } from "@oh-my-pi/pi-ai";
 import { getConfigRootDir, setAgentDir } from "@oh-my-pi/pi-utils";
 import { resetSettingsForTest, Settings } from "../src/config/settings";
+import type { CustomTool } from "../src/extensibility/custom-tools/types";
+import { MCPManager } from "../src/mcp/manager";
 import { ACP_BOOTSTRAP_RACE_GUARD_MS, AcpAgent, createAcpExtensionUiContext } from "../src/modes/acp/acp-agent";
 import type { PlanModeState } from "../src/plan-mode/state";
 import type { AgentSession, AgentSessionEvent } from "../src/session/agent-session";
@@ -106,6 +108,8 @@ class FakeAgentSession {
 	waitForIdleBlocker: (() => Promise<void>) | undefined;
 	asyncJobDrain: ((options?: { timeoutMs?: number }) => Promise<boolean>) | undefined;
 	#listeners = new Set<(event: AgentSessionEvent) => void>();
+	defaultSelectedMCPServerNames = new Set<string>();
+	activeToolNames: string[] = [];
 
 	constructor(
 		cwd: string,
@@ -230,7 +234,13 @@ class FakeAgentSession {
 		this.isStreaming = false;
 	}
 
-	async refreshMCPTools(_tools: unknown[]): Promise<void> {}
+	async refreshMCPTools(tools: Array<{ name: string; mcpServerName?: string }>): Promise<void> {
+		const selectedMCPTools = tools
+			.filter(tool => tool.mcpServerName && this.defaultSelectedMCPServerNames.has(tool.mcpServerName))
+			.map(tool => tool.name);
+		const activeNonMCPTools = this.activeToolNames.filter(name => !name.startsWith("mcp__"));
+		this.activeToolNames = [...activeNonMCPTools, ...selectedMCPTools];
+	}
 
 	getContextUsage(): undefined {
 		return undefined;
@@ -266,14 +276,20 @@ class FakeAgentSession {
 	}
 
 	getActiveToolNames(): string[] {
-		return [];
+		return this.activeToolNames;
 	}
 
 	getAllToolNames(): string[] {
-		return [];
+		return this.activeToolNames;
 	}
 
-	setActiveToolsByName(_toolNames: string[]): void {}
+	setActiveToolsByName(toolNames: string[]): void {
+		this.activeToolNames = toolNames;
+	}
+
+	setDefaultSelectedMCPServers(serverNames: string[]): void {
+		this.defaultSelectedMCPServerNames = new Set(serverNames);
+	}
 
 	setClientBridge(_bridge: unknown): void {}
 
@@ -443,6 +459,49 @@ async function waitForBootstrapGuard(): Promise<void> {
 }
 
 describe("ACP agent", () => {
+	function createMcpTool(name: string, serverName: string): CustomTool {
+		return {
+			name,
+			label: `${serverName}/${name}`,
+			description: `${serverName} ${name}`,
+			parameters: {
+				type: "object",
+				properties: {},
+			},
+			mcpServerName: serverName,
+			mcpToolName: name.replace(`mcp__${serverName}_`, ""),
+			async execute() {
+				return { content: [{ type: "text", text: `${name} executed` }] };
+			},
+		} as unknown as CustomTool;
+	}
+
+	it("auto-selects tools from ACP client-provided MCP servers", async () => {
+		const harness = await createHarness();
+		const tools = [
+			createMcpTool("mcp__codegraph_search", "codegraph"),
+			createMcpTool("mcp__codegraph_context", "codegraph"),
+		];
+		const connectSpy = spyOn(MCPManager.prototype, "connectServers").mockResolvedValue({
+			tools,
+			errors: new Map(),
+			connectedServers: ["codegraph"],
+			exaApiKeys: [],
+		});
+		try {
+			const created = await harness.agent.newSession({
+				cwd: harness.cwdA,
+				mcpServers: [{ name: "codegraph", command: "bunx", args: ["codegraph", "serve", "--mcp"], env: [] }],
+			});
+			const session = harness.findSession(created.sessionId)!;
+
+			expect(connectSpy).toHaveBeenCalledTimes(1);
+			expect(session.getActiveToolNames()).toEqual(["mcp__codegraph_search", "mcp__codegraph_context"]);
+		} finally {
+			connectSpy.mockRestore();
+		}
+	});
+
 	it("supports multiple live ACP sessions with model and lifecycle handlers", async () => {
 		const harness = await createHarness();
 		const first = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });

--- a/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
@@ -228,6 +228,41 @@ describe("AgentSession MCP discovery", () => {
 		expect(session.systemPrompt).toEqual(["tools:read"]);
 	});
 
+	it("activates caller-selected MCP servers after refresh in non-discovery sessions", async () => {
+		const readTool = createBasicTool("read", "Read");
+		const toolRegistry = new Map([[readTool.name, readTool]]);
+		const agent = new Agent({
+			initialState: {
+				model: createModel(),
+				systemPrompt: ["initial"],
+				tools: [readTool],
+				messages: [],
+			},
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "mcp.discoveryMode": false }),
+			modelRegistry: {} as never,
+			toolRegistry,
+			mcpDiscoveryEnabled: false,
+			rebuildSystemPrompt: async toolNames => ({
+				systemPrompt: [`tools:${toolNames.join(",")}`],
+			}),
+		});
+		sessions.push(session);
+
+		session.setDefaultSelectedMCPServers(["codegraph"]);
+		await session.refreshMCPTools([
+			createMcpCustomTool("mcp__codegraph_search", "codegraph", "search", "Search codegraph", ["query"]),
+			createMcpCustomTool("mcp__docs_search", "docs", "search", "Search docs", ["query"]),
+		]);
+
+		expect(session.getSelectedMCPToolNames()).toEqual(["mcp__codegraph_search"]);
+		expect(session.getActiveToolNames()).toEqual(["read", "mcp__codegraph_search"]);
+		expect(session.systemPrompt).toEqual(["tools:read,mcp__codegraph_search"]);
+	});
+
 	it("preserves directly activated MCP tools across refreshes in discovery mode", async () => {
 		const readTool = createBasicTool("read", "Read");
 		const docsSearchTool = createMcpTool("mcp__docs_search", "docs", "search", "Search internal docs", ["query"]);


### PR DESCRIPTION
## Repro
A focused ACP regression test stubs `MCPManager.connectServers()` to return two `codegraph` tools for `session/new.mcpServers`; before the fix, `bun test packages/coding-agent/test/acp-agent.test.ts --test-name-pattern "auto-selects tools from ACP client-provided MCP servers"` failed because the session active tool list was `[]`.

## Cause
`AcpAgent#configureMcpServers` connected ACP-provided servers and passed their tools into `AgentSession.refreshMCPTools()`, but it never told the session which connected server names should seed selection. In non-discovery ACP sessions, `AgentSession.refreshMCPTools()` preserved only already-active MCP tools, so newly registered client-provided tools stayed discoverable but never reached `agent.state.tools`.

## Fix
- Added `AgentSession.setDefaultSelectedMCPServers()` so explicit callers can update the server baseline before a tool refresh.
- Updated `AgentSession.refreshMCPTools()` to apply configured server defaults even when MCP discovery is disabled, while preserving manually deactivated non-default refresh behavior.
- Updated `AcpAgent#configureMcpServers` to clear defaults when no ACP servers are supplied and set connected ACP server names before refreshing MCP tools.
- Added ACP and AgentSession regression tests for client-provided MCP server auto-selection in non-discovery sessions.

## Verification
`bun test packages/coding-agent/test/acp-agent.test.ts packages/coding-agent/test/agent-session-mcp-discovery.test.ts` passed: 62 tests, 284 assertions. `bun --cwd=packages/coding-agent run check` passed. Fixes #1525