### PR TITLE
feat(coding-agent): add adaptive thinking level

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `ThinkingLevel.Adaptive = "adaptive"` to the `ThinkingLevel` selector union, signalling that the agent should dynamically adjust its reasoning effort per turn. Consumers handle the actual effort selection; this package only widens the type so downstream code can recognize the selector.
+
 ## [15.5.0] - 2026-05-26
 ### Added
 

--- a/packages/agent/src/thinking.ts
+++ b/packages/agent/src/thinking.ts
@@ -8,6 +8,7 @@ import { Effort } from "@oh-my-pi/pi-ai";
 export const ThinkingLevel = {
 	Inherit: "inherit",
 	Off: "off",
+	Adaptive: "adaptive",
 	Minimal: Effort.Minimal,
 	Low: Effort.Low,
 	Medium: Effort.Medium,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Added `read.summarize.minTotalLines` setting (default 100) to set the minimum file length that triggers read summarization
 - Added `<file>:<lines>` support to `search` `paths`, allowing file-scoped constraints such as `:N-M`, `:N+K`, and comma-separated ranges
+- Added an `adaptive` thinking level — when selected via `/model` (or `defaultThinkingLevel`), the agent gets a built-in `set_thinking_level` tool and adaptive guidance in its system prompt, so it can dial reasoning effort up or down per turn. `persist:false` applies for the current turn only; `persist:true` updates the session baseline. Inspired by [pi-adaptive-thinking](https://github.com/ian-pascoe/pi-adaptive-thinking).
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Added `read.summarize.minTotalLines` setting (default 100) to set the minimum file length that triggers read summarization
 - Added `<file>:<lines>` support to `search` `paths`, allowing file-scoped constraints such as `:N-M`, `:N+K`, and comma-separated ranges
-- Added an `adaptive` thinking level — when selected via `/model` (or `defaultThinkingLevel`), the agent gets a built-in `set_thinking_level` tool and adaptive guidance in its system prompt, so it can dial reasoning effort up or down per turn. `persist:false` applies for the current turn only; `persist:true` updates the session baseline. Inspired by [pi-adaptive-thinking](https://github.com/ian-pascoe/pi-adaptive-thinking).
+- Added an `adaptive` thinking level — when selected via `/model` (or `defaultThinkingLevel`), the agent gets a built-in `set_thinking_level` tool and adaptive guidance in its system prompt, so it can dial reasoning effort up or down per turn. `persist:false` applies for the current turn only (restored on `agent_end`, including aborted/error completions); `persist:true` updates the session baseline. The `set_thinking_level` tool's `level` schema is baked from the active model's supported effort set so the provider sees an exact enum, and subagent sessions never inherit the `"adaptive"` selector from their parent (it down-shifts to `medium`). Inspired by [pi-adaptive-thinking](https://github.com/ian-pascoe/pi-adaptive-thinking).
 
 ### Changed
 

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1172,7 +1172,7 @@ export async function findInitialModel(options: {
 	isContinuing: boolean;
 	defaultProvider?: string;
 	defaultModelId?: string;
-	defaultThinkingSelector?: Effort;
+	defaultThinkingSelector?: Effort | typeof ThinkingLevel.Adaptive;
 	modelRegistry: InitialModelRegistry;
 }): Promise<InitialModelResult> {
 	const {
@@ -1187,7 +1187,7 @@ export async function findInitialModel(options: {
 	} = options;
 
 	let model: Model<Api> | undefined;
-	let thinkingLevel: Effort | undefined;
+	let thinkingLevel: ThinkingLevel | undefined;
 
 	// 1. CLI args take priority
 	if (cliProvider && cliModel) {
@@ -1211,7 +1211,9 @@ export async function findInitialModel(options: {
 			thinkingLevel:
 				scopedThinkingSelector === ThinkingLevel.Off
 					? ThinkingLevel.Off
-					: clampThinkingLevelForModel(scoped.model, scopedThinkingSelector),
+					: scopedThinkingSelector === ThinkingLevel.Adaptive
+						? ThinkingLevel.Adaptive
+						: clampThinkingLevelForModel(scoped.model, scopedThinkingSelector),
 			fallbackMessage: undefined,
 		};
 	}
@@ -1221,7 +1223,10 @@ export async function findInitialModel(options: {
 		const found = modelRegistry.find(defaultProvider, defaultModelId);
 		if (found) {
 			model = found;
-			thinkingLevel = clampThinkingLevelForModel(found, defaultThinkingSelector);
+			thinkingLevel =
+				defaultThinkingSelector === ThinkingLevel.Adaptive
+					? ThinkingLevel.Adaptive
+					: clampThinkingLevelForModel(found, defaultThinkingSelector);
 			return { model, thinkingLevel, fallbackMessage: undefined };
 		}
 	}

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1,3 +1,4 @@
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { THINKING_EFFORTS } from "@oh-my-pi/pi-ai";
 import { TASK_SIMPLE_MODES } from "../task/simple-mode";
 import { getThinkingLevelMetadata } from "../thinking";
@@ -228,6 +229,14 @@ export const DEFAULT_BASH_INTERCEPTOR_RULES: BashInterceptorRule[] = [
 		message: "Use the `write` tool instead of echo/cat redirection. It handles encoding and provides confirmation.",
 	},
 ];
+
+/**
+ * `defaultThinkingLevel` accepts every concrete provider effort plus the
+ * agent-managed `"adaptive"` selector. The selector itself is not an Effort —
+ * adaptive mode lets the agent vary its underlying effort per turn via the
+ * `set_thinking_level` tool, with `Effort.Medium` as the bootstrap baseline.
+ */
+const DEFAULT_THINKING_LEVEL_VALUES = [...THINKING_EFFORTS, ThinkingLevel.Adaptive] as const;
 
 export const SETTINGS_SCHEMA = {
 	// ────────────────────────────────────────────────────────────────────────
@@ -651,13 +660,13 @@ export const SETTINGS_SCHEMA = {
 	// Reasoning and prompts
 	defaultThinkingLevel: {
 		type: "enum",
-		values: THINKING_EFFORTS,
+		values: DEFAULT_THINKING_LEVEL_VALUES,
 		default: "high",
 		ui: {
 			tab: "model",
 			label: "Thinking Level",
 			description: "Reasoning depth for thinking-capable models",
-			options: [...THINKING_EFFORTS.map(getThinkingLevelMetadata)],
+			options: [...THINKING_EFFORTS.map(getThinkingLevelMetadata), getThinkingLevelMetadata(ThinkingLevel.Adaptive)],
 		},
 	},
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1303,13 +1303,15 @@ export class AcpAgent implements Agent {
 	}
 
 	#buildThinkingOptions(session: AgentSession): Array<{ value: string; name: string; description?: string }> {
-		return [
+		const available = session.getAvailableThinkingLevels();
+		const options: Array<{ value: string; name: string; description?: string }> = [
 			{ value: THINKING_OFF, name: "Off" },
-			...session.getAvailableThinkingLevels().map(level => ({
-				value: level,
-				name: level,
-			})),
+			...available.map(level => ({ value: level, name: level })),
 		];
+		if (available.length > 0) {
+			options.push({ value: "adaptive", name: "Adaptive", description: "Agent picks effort per turn" });
+		}
+		return options;
 	}
 
 	#toThinkingConfigValue(value: string | undefined): string {

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -766,7 +766,10 @@ export class ModelSelectorComponent extends Container {
 		}
 	}
 	#getThinkingLevelsForModel(model: Model): ReadonlyArray<ThinkingLevel> {
-		return [ThinkingLevel.Inherit, ThinkingLevel.Off, ...getSupportedEfforts(model)];
+		const efforts = getSupportedEfforts(model);
+		const base: ThinkingLevel[] = [ThinkingLevel.Inherit, ThinkingLevel.Off];
+		if (efforts.length > 0) base.push(ThinkingLevel.Adaptive);
+		return [...base, ...efforts];
 	}
 
 	#getCurrentRoleThinkingLevel(role: string): ThinkingLevel {

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -377,6 +377,9 @@ export class SettingsSelectorComponent extends Container {
 				const baseOpt = options.find(o => o.value === level);
 				return baseOpt || { value: level, label: level };
 			});
+			if (this.context.availableThinkingLevels.length > 0) {
+				options = [...options, { value: "adaptive", label: "adaptive" }];
+			}
 		} else if (def.path === "theme.dark" || def.path === "theme.light") {
 			options = this.context.availableThemes.map(t => ({ value: t, label: t }));
 		}

--- a/packages/coding-agent/src/modes/components/thinking-selector.ts
+++ b/packages/coding-agent/src/modes/components/thinking-selector.ts
@@ -1,4 +1,4 @@
-import type { Effort } from "@oh-my-pi/pi-ai";
+import type { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { Container, type SelectItem, SelectList } from "@oh-my-pi/pi-tui";
 import { getSelectListTheme } from "../../modes/theme/theme";
 import { getThinkingLevelMetadata } from "../../thinking";
@@ -11,9 +11,9 @@ export class ThinkingSelectorComponent extends Container {
 	#selectList: SelectList;
 
 	constructor(
-		currentLevel: Effort,
-		availableLevels: Effort[],
-		onSelect: (level: Effort) => void,
+		currentLevel: ThinkingLevel | undefined,
+		availableLevels: ThinkingLevel[],
+		onSelect: (level: ThinkingLevel) => void,
 		onCancel: () => void,
 	) {
 		super();
@@ -27,13 +27,15 @@ export class ThinkingSelectorComponent extends Container {
 		this.#selectList = new SelectList(thinkingLevels, thinkingLevels.length, getSelectListTheme());
 
 		// Preselect current level
-		const currentIndex = thinkingLevels.findIndex(item => item.value === currentLevel);
-		if (currentIndex !== -1) {
-			this.#selectList.setSelectedIndex(currentIndex);
+		if (currentLevel !== undefined) {
+			const currentIndex = thinkingLevels.findIndex(item => item.value === currentLevel);
+			if (currentIndex !== -1) {
+				this.#selectList.setSelectedIndex(currentIndex);
+			}
 		}
 
 		this.#selectList.onSelect = item => {
-			onSelect(item.value as Effort);
+			onSelect(item.value as ThinkingLevel);
 		};
 
 		this.#selectList.onCancel = () => {

--- a/packages/coding-agent/src/prompts/adaptive-thinking.md
+++ b/packages/coding-agent/src/prompts/adaptive-thinking.md
@@ -1,0 +1,14 @@
+## Adaptive Thinking
+
+You are operating in adaptive thinking mode. The current reasoning effort is `{{currentEffort}}` and the valid effort levels for this model are: {{validLevels}}.
+
+You MUST manage reasoning effort actively via the `set_thinking_level` tool:
+- Lower the level before trivial or routine turns to save tokens and latency.
+- Raise the level for ambiguity, debugging, risky changes, or multi-step synthesis.
+- Reassess at turn start and after meaningful new evidence — never leave the level unchanged by inertia.
+
+Tool call shape:
+- `{ "level": "medium", "persist": false }` applies only for the current turn; the level is restored to the baseline when the turn ends.
+- `{ "level": "low", "persist": true }` updates the session baseline until you change it again.
+
+NEVER call `set_thinking_level` twice in a row, NEVER call it when the requested level matches the current level, and only call it when a different level is genuinely justified by task complexity.

--- a/packages/coding-agent/src/prompts/tools/set-thinking-level.md
+++ b/packages/coding-agent/src/prompts/tools/set-thinking-level.md
@@ -1,0 +1,6 @@
+Change the underlying reasoning effort while operating in adaptive thinking mode.
+
+`level` MUST be one of the following efforts supported by the current model: {{supportedList}}.
+
+`persist=false` (default) applies the new effort to the current turn only; the previous baseline is restored automatically when the turn ends (including abort/error).
+`persist=true` updates the session baseline so it remains until you call this tool again.

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -86,6 +86,7 @@ import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "./lsp/startup-e
 import { discoverAndLoadMCPTools, MCPManager, type MCPToolsLoadResult } from "./mcp";
 
 import { resolveMemoryBackend } from "./memory-backend";
+import adaptiveThinkingPrompt from "./prompts/adaptive-thinking.md" with { type: "text" };
 import asyncResultTemplate from "./prompts/tools/async-result.md" with { type: "text" };
 import { AgentRegistry, MAIN_AGENT_ID } from "./registry/agent-registry";
 import {
@@ -1242,6 +1243,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			authStorage,
 			modelRegistry,
 			getTelemetry: () => agent?.telemetry,
+			isAdaptiveThinking: () => session?.isAdaptiveThinking ?? false,
+			getAdaptiveEffort: () => session?.adaptiveEffort,
+			getSupportedThinkingEfforts: () => session?.getAvailableThinkingLevels() ?? [],
+			setAdaptiveEffort: (effort, persist) => session?.setAdaptiveEffort(effort, persist) ?? false,
 		};
 
 		// Wire process-wide internal URL singletons owned by their real classes.
@@ -1606,6 +1611,13 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					parts.push(`### ${srvName}\n${truncated}`);
 				}
 				appendPrompt = parts.join("\n\n");
+			}
+			if (session?.isAdaptiveThinking) {
+				const currentEffort = session.adaptiveEffort ?? "medium";
+				const supported = session.getAvailableThinkingLevels();
+				const validLevels = supported.length > 0 ? supported.join(", ") : "(none)";
+				const adaptiveBlock = prompt.render(adaptiveThinkingPrompt, { currentEffort, validLevels });
+				appendPrompt = appendPrompt ? `${appendPrompt}\n\n${adaptiveBlock}` : adaptiveBlock;
 			}
 			const defaultPrompt = await buildSystemPromptInternal({
 				cwd,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -50,7 +50,6 @@ import { DEFAULT_PRUNE_CONFIG, pruneToolOutputs } from "@oh-my-pi/pi-agent-core/
 import type {
 	AssistantMessage,
 	Context,
-	Effort,
 	ImageContent,
 	Message,
 	MessageAttribution,
@@ -66,7 +65,9 @@ import type {
 } from "@oh-my-pi/pi-ai";
 import {
 	calculateRateLimitBackoffMs,
+	clampThinkingLevelForModel,
 	clearAnthropicFastModeFallback,
+	Effort,
 	getSupportedEfforts,
 	isContextOverflow,
 	isUsageLimitError,
@@ -744,6 +745,8 @@ export class AgentSession {
 
 	#scopedModels: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
 	#thinkingLevel: ThinkingLevel | undefined;
+	#adaptiveEffort: Effort | undefined;
+	#adaptiveTempEffort: Effort | undefined;
 	#promptTemplates: PromptTemplate[];
 	#slashCommands: FileSlashCommand[];
 
@@ -1736,6 +1739,15 @@ export class AgentSession {
 
 		// Check auto-retry and auto-compaction after agent completes
 		if (event.type === "agent_end") {
+			// Restore the adaptive baseline before any other handler runs so a
+			// throw downstream still leaves the agent's effort at the persisted
+			// baseline rather than stuck on a per-turn override.
+			if (this.isAdaptiveThinking && this.#adaptiveTempEffort !== undefined) {
+				this.#adaptiveTempEffort = undefined;
+				if (this.#adaptiveEffort !== undefined) {
+					this.agent.setThinkingLevel(this.#adaptiveEffort);
+				}
+			}
 			const usage = this.getSessionStats().tokens;
 			await this.#goalRuntime.onAgentEnd({
 				currentUsage: {
@@ -5124,16 +5136,91 @@ export class AgentSession {
 	// Thinking Level Management
 	// =========================================================================
 
+	/** True when the session's thinking selector is `adaptive`. */
+	get isAdaptiveThinking(): boolean {
+		return this.#thinkingLevel === ThinkingLevel.Adaptive;
+	}
+
+	/**
+	 * Current underlying effort while adaptive thinking is active. `undefined`
+	 * when the session is not in adaptive mode or the model lacks reasoning.
+	 */
+	get adaptiveEffort(): Effort | undefined {
+		return this.isAdaptiveThinking ? this.#adaptiveEffort : undefined;
+	}
+
+	/**
+	 * Update the underlying effort while adaptive thinking is active.
+	 *
+	 * `persist: false` is a per-turn override that the `agent_end` handler restores
+	 * to the baseline (`#adaptiveEffort`). `persist: true` rewrites the baseline.
+	 *
+	 * Returns `true` on success, `false` when adaptive mode is off or the model
+	 * does not support the requested effort.
+	 */
+	setAdaptiveEffort(effort: Effort, persist: boolean): boolean {
+		if (!this.isAdaptiveThinking) return false;
+		const supported = this.getAvailableThinkingLevels();
+		if (!supported.includes(effort)) return false;
+		if (persist) {
+			this.#adaptiveEffort = effort;
+			this.#adaptiveTempEffort = undefined;
+		} else {
+			this.#adaptiveTempEffort = effort;
+		}
+		const apply = persist ? this.#adaptiveEffort : (this.#adaptiveTempEffort ?? this.#adaptiveEffort);
+		this.agent.setThinkingLevel(apply);
+		return true;
+	}
+
 	/**
 	 * Set thinking level.
 	 * Saves the effective metadata-clamped level to session and settings only if it changes.
+	 *
+	 * Special-cases the adaptive selector: keeps `#thinkingLevel === "adaptive"` while
+	 * driving the agent with `#adaptiveEffort` (seeded from the current effort or
+	 * Medium clamped to the model's supported set). Transitions into/out of adaptive
+	 * also add/remove the `set_thinking_level` tool from the active set.
 	 */
 	setThinkingLevel(level: ThinkingLevel | undefined, persist: boolean = false): void {
 		const effectiveLevel = resolveThinkingLevelForModel(this.model, level);
+		const previouslyAdaptive = this.#thinkingLevel === ThinkingLevel.Adaptive;
+		const nextAdaptive = effectiveLevel === ThinkingLevel.Adaptive;
 		const isChanging = effectiveLevel !== this.#thinkingLevel;
 
+		if (nextAdaptive) {
+			if (this.#adaptiveEffort === undefined) {
+				// Seed from the agent's current effort when the model still supports it,
+				// else fall back to a Medium clamped to the supported set, else the first
+				// supported effort.
+				const supported = this.getAvailableThinkingLevels();
+				const currentAgentEffort = this.agent.state.thinkingLevel;
+				const clampedMedium = clampThinkingLevelForModel(this.model, Effort.Medium);
+				this.#adaptiveEffort =
+					currentAgentEffort && supported.includes(currentAgentEffort)
+						? currentAgentEffort
+						: (clampedMedium ?? supported[0]);
+			}
+			this.#adaptiveTempEffort = undefined;
+		} else {
+			this.#adaptiveEffort = undefined;
+			this.#adaptiveTempEffort = undefined;
+		}
+
 		this.#thinkingLevel = effectiveLevel;
-		this.agent.setThinkingLevel(toReasoningEffort(effectiveLevel));
+		this.agent.setThinkingLevel(nextAdaptive ? this.#adaptiveEffort : toReasoningEffort(effectiveLevel));
+
+		if (previouslyAdaptive !== nextAdaptive) {
+			// `set_thinking_level` enters/leaves the active set with adaptive mode.
+			// Sequencing: apply first (which may rebuild the prompt if the tool
+			// signature changed) then force a refresh so the adaptive guidance
+			// block reflects the new `isAdaptiveThinking` state even when the
+			// tool set did not actually change.
+			const currentNames = this.getActiveToolNames();
+			const filtered = currentNames.filter(name => name !== "set_thinking_level");
+			const nextNames = nextAdaptive ? [...filtered, "set_thinking_level"] : filtered;
+			void this.#applyActiveToolsByName(nextNames).then(() => this.refreshBaseSystemPrompt());
+		}
 
 		if (isChanging) {
 			this.sessionManager.appendThinkingLevelChange(effectiveLevel);
@@ -5151,7 +5238,7 @@ export class AgentSession {
 	cycleThinkingLevel(): ThinkingLevel | undefined {
 		if (!this.model?.reasoning) return undefined;
 
-		const levels = [ThinkingLevel.Off, ...this.getAvailableThinkingLevels()];
+		const levels: ThinkingLevel[] = [ThinkingLevel.Off, ...this.getAvailableThinkingLevels()];
 		const currentLevel = this.thinkingLevel === ThinkingLevel.Inherit ? ThinkingLevel.Off : this.thinkingLevel;
 		const currentIndex = currentLevel ? levels.indexOf(currentLevel) : -1;
 		const nextIndex = (currentIndex + 1) % levels.length;

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -5,8 +5,9 @@
  */
 
 import path from "node:path";
-import type { AgentEvent, AgentIdentity, AgentTelemetryConfig, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
-import { recordHandoff, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
+import type { AgentEvent, AgentIdentity, AgentTelemetryConfig } from "@oh-my-pi/pi-agent-core";
+import { recordHandoff, resolveTelemetry, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import { Effort } from "@oh-my-pi/pi-ai";
 import { logger, prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import { ModelRegistry } from "../config/model-registry";
 import { resolveModelOverrideWithAuthFallback } from "../config/model-resolver";
@@ -523,13 +524,32 @@ function createMCPProxyTools(mcpManager: MCPManager): CustomTool[] {
 	});
 }
 
-function createSubagentSettings(baseSettings: Settings): Settings {
+/**
+ * Build the {@link Settings} bag that backs a subagent {@link AgentSession}.
+ * Exported so the adaptive-thinking regression test (`createSubagentSettings`
+ * never propagates the `"adaptive"` selector — see roboomp #1530) can audit
+ * the bag without spawning a real subagent.
+ */
+export function createSubagentSettings(baseSettings: Settings): Settings {
 	const snapshot: Partial<Record<SettingPath, unknown>> = {};
 	for (const key of Object.keys(SETTINGS_SCHEMA) as SettingPath[]) {
 		snapshot[key] = baseSettings.get(key);
 	}
+	// roboomp #1530: never inherit the parent's `"adaptive"` thinking selector.
+	// Adaptive mode is a per-session contract between the agent and the model —
+	// the `set_thinking_level` tool, the adaptive prompt block, and the
+	// per-turn override restore at `agent_end` are all scoped to whichever
+	// session is driving the conversation. Subagents run headless and never
+	// touch the parent's `#adaptiveEffort`, so leaking the selector into a
+	// subagent would either deadlock (no UI to surface the tool's effect) or
+	// silently bypass the parent's baseline. Down-shift to `Effort.Medium`
+	// (the same bootstrap baseline `AgentSession.setThinkingLevel` seeds for
+	// adaptive mode) so the subagent inherits a concrete, non-adaptive effort.
+	const parentDefault = snapshot.defaultThinkingLevel;
+	const defaultThinkingLevel = parentDefault === ThinkingLevel.Adaptive ? Effort.Medium : parentDefault;
 	return Settings.isolated({
 		...snapshot,
+		defaultThinkingLevel,
 		"async.enabled": false,
 		"bash.autoBackground.enabled": false,
 

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -1,5 +1,11 @@
 import { type ResolvedThinkingLevel, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
-import { clampThinkingLevelForModel, type Effort, type Model, THINKING_EFFORTS } from "@oh-my-pi/pi-ai";
+import {
+	clampThinkingLevelForModel,
+	type Effort,
+	getSupportedEfforts,
+	type Model,
+	THINKING_EFFORTS,
+} from "@oh-my-pi/pi-ai";
 
 /**
  * Metadata used to render thinking selector values in the coding-agent UI.
@@ -17,6 +23,11 @@ const THINKING_LEVEL_METADATA: Record<ThinkingLevel, ThinkingLevelMetadata> = {
 		description: "Inherit session default",
 	},
 	[ThinkingLevel.Off]: { value: ThinkingLevel.Off, label: "off", description: "No reasoning" },
+	[ThinkingLevel.Adaptive]: {
+		value: ThinkingLevel.Adaptive,
+		label: "adaptive",
+		description: "Agent picks effort per turn",
+	},
 	[ThinkingLevel.Minimal]: {
 		value: ThinkingLevel.Minimal,
 		label: "min",
@@ -36,7 +47,12 @@ const THINKING_LEVEL_METADATA: Record<ThinkingLevel, ThinkingLevelMetadata> = {
 	},
 };
 
-const THINKING_LEVELS = new Set<string>([ThinkingLevel.Inherit, ThinkingLevel.Off, ...THINKING_EFFORTS]);
+const THINKING_LEVELS = new Set<string>([
+	ThinkingLevel.Inherit,
+	ThinkingLevel.Off,
+	ThinkingLevel.Adaptive,
+	...THINKING_EFFORTS,
+]);
 const EFFORT_LEVELS = new Set<string>(THINKING_EFFORTS);
 
 /**
@@ -64,7 +80,12 @@ export function getThinkingLevelMetadata(level: ThinkingLevel): ThinkingLevelMet
  * Converts an agent-local selector into the effort sent to providers.
  */
 export function toReasoningEffort(level: ThinkingLevel | undefined): Effort | undefined {
-	if (level === undefined || level === ThinkingLevel.Off || level === ThinkingLevel.Inherit) {
+	if (
+		level === undefined ||
+		level === ThinkingLevel.Off ||
+		level === ThinkingLevel.Inherit ||
+		level === ThinkingLevel.Adaptive
+	) {
 		return undefined;
 	}
 	return level;
@@ -82,6 +103,12 @@ export function resolveThinkingLevelForModel(
 	}
 	if (level === ThinkingLevel.Off) {
 		return ThinkingLevel.Off;
+	}
+	if (level === ThinkingLevel.Adaptive) {
+		if (!model || getSupportedEfforts(model).length === 0) {
+			return undefined;
+		}
+		return ThinkingLevel.Adaptive;
 	}
 	return clampThinkingLevelForModel(model, level);
 }

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -1,6 +1,6 @@
 import type { InMemorySnapshotStore } from "@oh-my-pi/hashline";
 import type { AgentTelemetryConfig, AgentTool } from "@oh-my-pi/pi-agent-core";
-import type { ToolChoice } from "@oh-my-pi/pi-ai";
+import type { Effort, ToolChoice } from "@oh-my-pi/pi-ai";
 import { $env, $flag, logger } from "@oh-my-pi/pi-utils";
 import type { PromptTemplate } from "../config/prompt-templates";
 import type { Settings } from "../config/settings";
@@ -49,6 +49,7 @@ import { ResolveTool } from "./resolve";
 import { reportFindingTool } from "./review";
 import { SearchTool } from "./search";
 import { SearchToolBm25Tool } from "./search-tool-bm25";
+import { SetThinkingLevelTool } from "./set-thinking-level";
 import { loadSshTool } from "./ssh";
 import { type TodoPhase, TodoWriteTool } from "./todo-write";
 import { WriteTool } from "./write";
@@ -90,6 +91,7 @@ export * from "./resolve";
 export * from "./review";
 export * from "./search";
 export * from "./search-tool-bm25";
+export * from "./set-thinking-level";
 export * from "./ssh";
 export * from "./todo-write";
 export * from "./write";
@@ -171,6 +173,16 @@ export interface ToolSession {
 	getModelString?: () => string | undefined;
 	/** Get the current session model string, regardless of how it was chosen */
 	getActiveModelString?: () => string | undefined;
+	/** True when the session's thinking selector is "adaptive". */
+	isAdaptiveThinking?: () => boolean;
+	/** Underlying effort the agent is currently using under adaptive mode; undefined otherwise. */
+	getAdaptiveEffort?: () => Effort | undefined;
+	/** Supported efforts for the current model (used to validate `set_thinking_level` input). */
+	getSupportedThinkingEfforts?: () => readonly Effort[];
+	/** Mutate the underlying effort while adaptive is active. `persist=false` is temporary
+	 *  (restored at agent_end); `persist=true` becomes the session baseline. Returns false
+	 *  when adaptive is inactive or the model does not support the effort. */
+	setAdaptiveEffort?: (effort: Effort, persist: boolean) => boolean;
 	/** Auth storage for passing to subagents (avoids re-discovery) */
 	authStorage?: import("../session/auth-storage").AuthStorage;
 	/** Model registry for passing to subagents (avoids re-discovery) */
@@ -300,6 +312,7 @@ export const BUILTIN_TOOLS: Record<string, ToolFactory> = {
 	recipe: RecipeTool.createIf,
 	irc: IrcTool.createIf,
 	todo_write: s => new TodoWriteTool(s),
+	set_thinking_level: SetThinkingLevelTool.createIf,
 	web_search: s => new WebSearchTool(s),
 	search_tool_bm25: SearchToolBm25Tool.createIf,
 	write: s => new WriteTool(s),

--- a/packages/coding-agent/src/tools/set-thinking-level.ts
+++ b/packages/coding-agent/src/tools/set-thinking-level.ts
@@ -1,0 +1,108 @@
+/**
+ * `set_thinking_level` — the agent's lever for **adaptive thinking** mode.
+ *
+ * When the session selector is `ThinkingLevel.Adaptive`, this tool is the only
+ * way to mutate the *underlying* reasoning effort the provider sees on the next
+ * turn. The tool is registered in `BUILTIN_TOOLS` so the discovery + reporting
+ * machinery recognizes the name, but {@link SetThinkingLevelTool.createIf}
+ * returns `null` outside adaptive mode — so the registration is inert and the
+ * model never sees the schema unless adaptive is currently active.
+ *
+ * `persist=false` (default): apply for this turn only; restored to the adaptive
+ *   baseline at `agent_end` by the session.
+ * `persist=true`: replaces the adaptive baseline for the rest of the session.
+ *
+ * The tool intentionally returns *plain text* on every failure mode (not active,
+ * invalid effort, model unsupported) so the model can self-correct without
+ * blowing up the turn with an exception.
+ */
+import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
+import type { Effort } from "@oh-my-pi/pi-ai";
+import * as z from "zod/v4";
+import type { ToolSession } from ".";
+
+const setThinkingLevelSchema = z.object({
+	level: z
+		.string()
+		.min(1)
+		.describe("Target effort supported by the current model (e.g. minimal, low, medium, high, xhigh)"),
+	persist: z
+		.boolean()
+		.optional()
+		.describe("false (default) applies for this turn only; true updates the session baseline"),
+});
+
+type SetThinkingLevelParams = z.infer<typeof setThinkingLevelSchema>;
+
+export interface SetThinkingLevelDetails {
+	level: Effort;
+	persist: boolean;
+	previous?: Effort;
+}
+
+export class SetThinkingLevelTool implements AgentTool<typeof setThinkingLevelSchema, SetThinkingLevelDetails> {
+	readonly name = "set_thinking_level";
+	readonly approval = "read" as const;
+	readonly label = "Set Thinking Level";
+	readonly summary = "Adjust the underlying reasoning effort while in adaptive thinking mode";
+	readonly loadMode = "essential";
+	readonly description =
+		"Change the underlying reasoning effort while operating in adaptive thinking mode. " +
+		"`persist=false` (default) applies for the current turn only; `persist=true` updates the session baseline.";
+	readonly parameters = setThinkingLevelSchema;
+	readonly strict = true;
+	readonly intent = (args: Partial<SetThinkingLevelParams>) =>
+		args.level ? `thinking → ${args.level}` : "adjusting thinking level";
+
+	constructor(private readonly session: ToolSession) {}
+
+	/**
+	 * Built-in tool factory hook. Only constructs the tool when the session is
+	 * currently in adaptive thinking mode — the surrounding code (createTools,
+	 * search_tool_bm25 indices, autoQA enums) all treat a null return as "tool
+	 * not available", which is the right shape for a per-session feature gate.
+	 */
+	static createIf(session: ToolSession): SetThinkingLevelTool | null {
+		return session.isAdaptiveThinking?.() === true ? new SetThinkingLevelTool(session) : null;
+	}
+
+	async execute(
+		_toolCallId: string,
+		params: SetThinkingLevelParams,
+		_signal?: AbortSignal,
+		_onUpdate?: AgentToolUpdateCallback<SetThinkingLevelDetails>,
+		_context?: AgentToolContext,
+	): Promise<AgentToolResult<SetThinkingLevelDetails>> {
+		const session = this.session;
+		if (session.isAdaptiveThinking?.() !== true) {
+			return textResult("Adaptive thinking is not active for this session.");
+		}
+
+		const requested = params.level.trim().toLowerCase();
+		const supported = session.getSupportedThinkingEfforts?.() ?? [];
+		// `Effort` is a const enum of string literals, so a value-equality test
+		// against the supported list is the same as a type-narrowing check.
+		if (!supported.includes(requested as Effort)) {
+			const list = supported.length > 0 ? supported.join(", ") : "<none>";
+			return textResult(`"${requested}" is not a supported thinking effort. Valid: ${list}.`);
+		}
+
+		const level = requested as Effort;
+		const persist = params.persist === true;
+		const previous = session.getAdaptiveEffort?.();
+		const ok = session.setAdaptiveEffort?.(level, persist) === true;
+		if (!ok) {
+			return textResult(`Failed to apply thinking effort ${level}.`);
+		}
+
+		const scope = persist ? "baseline" : "this turn";
+		return {
+			content: [{ type: "text", text: `Thinking effort set to ${level} (${scope}).` }],
+			details: { level, persist, previous },
+		};
+	}
+}
+
+function textResult(text: string): AgentToolResult<SetThinkingLevelDetails> {
+	return { content: [{ type: "text", text }], details: undefined };
+}

--- a/packages/coding-agent/src/tools/set-thinking-level.ts
+++ b/packages/coding-agent/src/tools/set-thinking-level.ts
@@ -8,8 +8,15 @@
  * returns `null` outside adaptive mode — so the registration is inert and the
  * model never sees the schema unless adaptive is currently active.
  *
+ * The schema's `level` enum and the rendered description are computed from the
+ * **current session model's** supported efforts at construction time. This way
+ * the model receives a tight, provider-accurate set rather than a free-form
+ * string; the runtime check in `execute` is still the source of truth so a
+ * model that ignores the enum still gets a clear error.
+ *
  * `persist=false` (default): apply for this turn only; restored to the adaptive
- *   baseline at `agent_end` by the session.
+ *   baseline at `agent_end` by the session — including aborted/error
+ *   completions (see `AgentSession.#handleAgentEvent`).
  * `persist=true`: replaces the adaptive baseline for the rest of the session.
  *
  * The tool intentionally returns *plain text* on every failure mode (not active,
@@ -18,21 +25,44 @@
  */
 import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import type { Effort } from "@oh-my-pi/pi-ai";
+import { prompt } from "@oh-my-pi/pi-utils";
 import * as z from "zod/v4";
+import setThinkingLevelDescriptionTemplate from "../prompts/tools/set-thinking-level.md" with { type: "text" };
 import type { ToolSession } from ".";
 
-const setThinkingLevelSchema = z.object({
-	level: z
-		.string()
-		.min(1)
-		.describe("Target effort supported by the current model (e.g. minimal, low, medium, high, xhigh)"),
-	persist: z
-		.boolean()
-		.optional()
-		.describe("false (default) applies for this turn only; true updates the session baseline"),
+const persistSchema = z
+	.boolean()
+	.optional()
+	.describe("false (default) applies for this turn only; true updates the session baseline");
+
+/**
+ * Schema variant used when the current model exposes no supported efforts —
+ * e.g. the tool is constructed before the session model is wired or the model
+ * lost its reasoning metadata mid-session. Should not be reachable in practice
+ * because {@link SetThinkingLevelTool.createIf} gates on adaptive mode, which
+ * itself requires reasoning support, but we keep the fallback so a stale
+ * call site can't crash the tool registry.
+ */
+const setThinkingLevelSchemaString = z.object({
+	level: z.string().min(1).describe("Target effort supported by the current model"),
+	persist: persistSchema,
 });
 
-type SetThinkingLevelParams = z.infer<typeof setThinkingLevelSchema>;
+function buildSetThinkingLevelSchema(supported: readonly Effort[]): typeof setThinkingLevelSchemaString {
+	if (supported.length === 0) {
+		return setThinkingLevelSchemaString;
+	}
+	// `z.enum` requires a non-empty tuple. The literal cast is safe because we
+	// guarded on `length === 0` above; the model sees only the exact supported
+	// strings.
+	const levelEnum = z.enum([...supported] as [Effort, ...Effort[]]);
+	return z.object({
+		level: levelEnum.describe(`Target effort. Valid values: ${supported.join(", ")}`),
+		persist: persistSchema,
+	}) as unknown as typeof setThinkingLevelSchemaString;
+}
+
+type SetThinkingLevelParams = z.infer<typeof setThinkingLevelSchemaString>;
 
 export interface SetThinkingLevelDetails {
 	level: Effort;
@@ -40,21 +70,28 @@ export interface SetThinkingLevelDetails {
 	previous?: Effort;
 }
 
-export class SetThinkingLevelTool implements AgentTool<typeof setThinkingLevelSchema, SetThinkingLevelDetails> {
+export class SetThinkingLevelTool implements AgentTool<typeof setThinkingLevelSchemaString, SetThinkingLevelDetails> {
 	readonly name = "set_thinking_level";
 	readonly approval = "read" as const;
 	readonly label = "Set Thinking Level";
 	readonly summary = "Adjust the underlying reasoning effort while in adaptive thinking mode";
 	readonly loadMode = "essential";
-	readonly description =
-		"Change the underlying reasoning effort while operating in adaptive thinking mode. " +
-		"`persist=false` (default) applies for the current turn only; `persist=true` updates the session baseline.";
-	readonly parameters = setThinkingLevelSchema;
+	readonly description: string;
+	readonly parameters: typeof setThinkingLevelSchemaString;
 	readonly strict = true;
 	readonly intent = (args: Partial<SetThinkingLevelParams>) =>
 		args.level ? `thinking → ${args.level}` : "adjusting thinking level";
 
-	constructor(private readonly session: ToolSession) {}
+	constructor(private readonly session: ToolSession) {
+		// Bake the active model's supported effort set into the schema so the
+		// provider sees an exact enum, not a free-form string. The list is
+		// frozen at construction time; a mid-session model swap produces a new
+		// AgentSession-driven tool instance through `#applyActiveToolsByName`.
+		const supported = session.getSupportedThinkingEfforts?.() ?? [];
+		this.parameters = buildSetThinkingLevelSchema(supported);
+		const supportedList = supported.length > 0 ? supported.join(", ") : "(none — adaptive cannot be applied)";
+		this.description = prompt.render(setThinkingLevelDescriptionTemplate, { supportedList });
+	}
 
 	/**
 	 * Built-in tool factory hook. Only constructs the tool when the session is

--- a/packages/coding-agent/test/agent-session-adaptive-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-adaptive-thinking.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { Effort, getBundledModel } from "@oh-my-pi/pi-ai";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+describe("AgentSession adaptive thinking", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	const authStorages: AuthStorage[] = [];
+
+	beforeEach(() => {
+		tempDir = TempDir.createSync("@pi-adaptive-thinking-");
+	});
+
+	afterEach(async () => {
+		if (session) await session.dispose();
+		for (const authStorage of authStorages.splice(0)) authStorage.close();
+		// Windows: AuthStorage's SQLite may retain locks briefly after close(); tolerate.
+		try {
+			tempDir.removeSync();
+		} catch {
+			/* cleanup-only; orchestrator's temp pruning will eventually reclaim */
+		}
+	});
+
+	function getModel(id: string) {
+		const model = getBundledModel("anthropic", id);
+		if (!model) throw new Error(`Expected anthropic model ${id} to exist`);
+		return model;
+	}
+
+	async function createSession(initialThinkingLevel: Effort | undefined): Promise<Agent> {
+		const model = getModel("claude-sonnet-4-5");
+		const agent = new Agent({
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [], thinkingLevel: initialThinkingLevel },
+		});
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		return agent;
+	}
+
+	it("enters adaptive mode and seeds the baseline effort from the agent's current level", async () => {
+		const agent = await createSession(Effort.Medium);
+		session.setThinkingLevel("adaptive");
+		expect(session.isAdaptiveThinking).toBe(true);
+		expect(session.thinkingLevel).toBe("adaptive");
+		expect(session.adaptiveEffort).toBe(Effort.Medium);
+		// Agent receives the underlying Effort, not the "adaptive" string.
+		expect(agent.state.thinkingLevel).toBe(Effort.Medium);
+	});
+
+	it("clears adaptive state when switching to a concrete effort", async () => {
+		await createSession(Effort.Medium);
+		session.setThinkingLevel("adaptive");
+		session.setThinkingLevel(Effort.High);
+		expect(session.isAdaptiveThinking).toBe(false);
+		expect(session.adaptiveEffort).toBeUndefined();
+		expect(session.thinkingLevel).toBe(Effort.High);
+	});
+
+	it("setAdaptiveEffort(persist=true) updates baseline and drives the agent", async () => {
+		const agent = await createSession(Effort.Medium);
+		session.setThinkingLevel("adaptive");
+		expect(session.setAdaptiveEffort(Effort.Low, true)).toBe(true);
+		expect(session.adaptiveEffort).toBe(Effort.Low);
+		expect(agent.state.thinkingLevel).toBe(Effort.Low);
+	});
+
+	it("setAdaptiveEffort(persist=false) applies a per-turn override without changing baseline", async () => {
+		const agent = await createSession(Effort.Medium);
+		session.setThinkingLevel("adaptive");
+		expect(session.setAdaptiveEffort(Effort.High, false)).toBe(true);
+		// Agent uses the temp effort, but the baseline (observed via adaptiveEffort) is unchanged.
+		expect(agent.state.thinkingLevel).toBe(Effort.High);
+		expect(session.adaptiveEffort).toBe(Effort.Medium);
+	});
+
+	it("setAdaptiveEffort returns false when not in adaptive mode", async () => {
+		await createSession(Effort.Medium);
+		expect(session.isAdaptiveThinking).toBe(false);
+		expect(session.setAdaptiveEffort(Effort.Low, true)).toBe(false);
+	});
+
+	it("setAdaptiveEffort returns false for an unsupported effort on the current model", async () => {
+		// claude-sonnet-4-6 omits xhigh (covered by the existing "clamps unsupported" test).
+		const model = getModel("claude-sonnet-4-6");
+		const agent = new Agent({
+			initialState: { model, systemPrompt: ["Test"], tools: [], messages: [], thinkingLevel: Effort.High },
+		});
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth-noxhigh.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models-noxhigh.yml"));
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		session.setThinkingLevel("adaptive");
+		expect(session.isAdaptiveThinking).toBe(true);
+		expect(session.getAvailableThinkingLevels()).not.toContain(Effort.XHigh);
+		expect(session.setAdaptiveEffort(Effort.XHigh, true)).toBe(false);
+		// Reference `agent` so the linter doesn't flag the variable.
+		expect(agent.state.model.id).toBe("claude-sonnet-4-6");
+	});
+
+	it("ignores adaptive selector on models that do not support reasoning", async () => {
+		const nonReasoning = getBundledModel("openai", "gpt-4.1-mini") ?? getBundledModel("openai", "gpt-4.1");
+		if (!nonReasoning || nonReasoning.reasoning) {
+			// Fixture moved upstream; skip rather than couple to a specific catalog.
+			return;
+		}
+		const agent = new Agent({
+			initialState: {
+				model: nonReasoning,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+				thinkingLevel: undefined,
+			},
+		});
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth-noreason.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey(nonReasoning.provider, "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models-noreason.yml"));
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated(),
+			modelRegistry,
+		});
+		session.setThinkingLevel("adaptive");
+		expect(session.isAdaptiveThinking).toBe(false);
+		expect(session.thinkingLevel).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/agent-session-adaptive-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-adaptive-thinking.test.ts
@@ -1,13 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as path from "node:path";
-import { Agent } from "@oh-my-pi/pi-agent-core";
+import { Agent, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
 import { Effort, getBundledModel } from "@oh-my-pi/pi-ai";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { createSubagentSettings } from "@oh-my-pi/pi-coding-agent/task/executor";
+import { SetThinkingLevelTool, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { TempDir } from "@oh-my-pi/pi-utils";
+import type * as z from "zod/v4";
 
 describe("AgentSession adaptive thinking", () => {
 	let tempDir: TempDir;
@@ -147,5 +151,159 @@ describe("AgentSession adaptive thinking", () => {
 		session.setThinkingLevel("adaptive");
 		expect(session.isAdaptiveThinking).toBe(false);
 		expect(session.thinkingLevel).toBeUndefined();
+	});
+
+	// roboomp #1530(c): the `agent_end` restore must fire on aborted/error
+	// outcomes too — otherwise a tool-call that escalates effort for a single
+	// turn (`persist=false`) and then aborts leaves the session pinned at the
+	// override forever. Synthesizing an `agent_end` event reaches the same
+	// handler the real loop calls; the restore block runs synchronously before
+	// any `await`, so `agent.state.thinkingLevel` is back to the baseline by
+	// the time `emitExternalEvent` returns.
+	function makeAgentEndMessage(stopReason: "aborted" | "error"): AssistantMessage {
+		return {
+			role: "assistant",
+			content: [{ type: "text", text: "" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason,
+			errorMessage: stopReason === "error" ? "boom" : undefined,
+			timestamp: Date.now(),
+		} as AssistantMessage;
+	}
+	it("restores the adaptive baseline when the agent loop aborts mid-turn", async () => {
+		const agent = await createSession(Effort.Medium);
+		session.setThinkingLevel("adaptive");
+		expect(session.setAdaptiveEffort(Effort.High, false)).toBe(true);
+		expect(agent.state.thinkingLevel).toBe(Effort.High);
+
+		agent.emitExternalEvent({ type: "agent_end", messages: [makeAgentEndMessage("aborted")] });
+		// The session's `#handleAgentEvent` is async (it awaits
+		// `#emitSessionEvent` before the restore branch). A short flush is
+		// enough to let the restore land before we assert.
+		await Bun.sleep(20);
+
+		expect(agent.state.thinkingLevel).toBe(Effort.Medium);
+		expect(session.adaptiveEffort).toBe(Effort.Medium);
+	});
+
+	it("restores the adaptive baseline when the agent loop fails with an error", async () => {
+		const agent = await createSession(Effort.Medium);
+		session.setThinkingLevel("adaptive");
+		expect(session.setAdaptiveEffort(Effort.Low, false)).toBe(true);
+		expect(agent.state.thinkingLevel).toBe(Effort.Low);
+
+		agent.emitExternalEvent({ type: "agent_end", messages: [makeAgentEndMessage("error")] });
+		await Bun.sleep(20);
+
+		expect(agent.state.thinkingLevel).toBe(Effort.Medium);
+		expect(session.adaptiveEffort).toBe(Effort.Medium);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// set_thinking_level tool — schema/description reflect the active model.
+// ---------------------------------------------------------------------------
+
+function buildToolSession(supportedEfforts: readonly Effort[]): ToolSession {
+	// Minimal ToolSession shape for SetThinkingLevelTool — the tool only reads
+	// `getSupportedThinkingEfforts`, `isAdaptiveThinking`, and `settings` at
+	// construction time. All other surface area is unused by the schema build.
+	return {
+		cwd: process.cwd(),
+		hasUI: false,
+		settings: Settings.isolated(),
+		getSessionFile: () => null,
+		getSessionSpawns: () => null,
+		isAdaptiveThinking: () => true,
+		getSupportedThinkingEfforts: () => supportedEfforts,
+	} as unknown as ToolSession;
+}
+
+describe("set_thinking_level tool schema", () => {
+	it("bakes the model's supported efforts into the level enum and description", () => {
+		const supported: readonly Effort[] = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High, Effort.XHigh];
+		const tool = new SetThinkingLevelTool(buildToolSession(supported));
+		// Schema accepts every supported effort verbatim.
+		for (const effort of supported) {
+			const parsed = tool.parameters.safeParse({ level: effort });
+			expect(parsed.success).toBe(true);
+		}
+		// Unrelated string is rejected (proves the schema is an enum, not free-form).
+		const reject = tool.parameters.safeParse({ level: "nope" });
+		expect(reject.success).toBe(false);
+		// Description names every supported effort so the model sees the exact set.
+		for (const effort of supported) {
+			expect(tool.description).toContain(effort);
+		}
+	});
+
+	it("omits efforts the model does not support", () => {
+		// `claude-sonnet-4-6` exposes no `xhigh` (mirrors the agent-session test below).
+		const supported: readonly Effort[] = [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High];
+		const tool = new SetThinkingLevelTool(buildToolSession(supported));
+		expect(tool.parameters.safeParse({ level: Effort.High }).success).toBe(true);
+		expect(tool.parameters.safeParse({ level: Effort.XHigh }).success).toBe(false);
+		expect(tool.description).not.toContain(Effort.XHigh);
+		// The schema's `level` field collapses to a Zod enum; the option set in
+		// the JSON-Schema export the provider sees is exactly the supported list.
+		const shape = (tool.parameters as unknown as z.ZodObject<{ level: z.ZodEnum<Record<string, string>> }>).shape;
+		const levelDef = shape.level.def as { values?: readonly string[]; entries?: Record<string, string> };
+		const values = levelDef.values ?? Object.values(levelDef.entries ?? {});
+		expect([...values].sort()).toEqual([...supported].sort());
+	});
+
+	it("falls back to a free-form string when no efforts are advertised", () => {
+		// Reachable only via a stale call site — confirm the tool still parses
+		// without throwing rather than crashing the entire tool registry.
+		const tool = new SetThinkingLevelTool(buildToolSession([]));
+		expect(tool.parameters.safeParse({ level: "medium" }).success).toBe(true);
+		expect(tool.description).toContain("(none");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Subagent settings — roboomp #1530(b): never inherit `adaptive` selector.
+// ---------------------------------------------------------------------------
+
+describe("createSubagentSettings adaptive isolation", () => {
+	it("rewrites the parent's adaptive selector to a concrete effort", () => {
+		const parent = Settings.isolated({ defaultThinkingLevel: ThinkingLevel.Adaptive });
+		expect(parent.get("defaultThinkingLevel")).toBe(ThinkingLevel.Adaptive);
+
+		const subagent = createSubagentSettings(parent);
+
+		const level = subagent.get("defaultThinkingLevel");
+		expect(level).not.toBe(ThinkingLevel.Adaptive);
+		// `Effort.Medium` is the bootstrap baseline the parent session itself
+		// would have used; the subagent inherits the same concrete fallback.
+		expect(level).toBe(Effort.Medium);
+	});
+
+	it("leaves non-adaptive thinking selectors untouched", () => {
+		const parent = Settings.isolated({ defaultThinkingLevel: Effort.High });
+		const subagent = createSubagentSettings(parent);
+		expect(subagent.get("defaultThinkingLevel")).toBe(Effort.High);
+	});
+
+	it("blocks adaptive mode on the subagent AgentSession even when the parent's selector leaks through", async () => {
+		// Belt-and-braces: even if a future call site bypassed
+		// `createSubagentSettings` and constructed `AgentSession` directly with
+		// the parent's `Settings`, the subagent must not enter adaptive mode
+		// for a non-reasoning model. The session itself enforces this; here we
+		// audit the contract that `createSubagentSettings` ALREADY removes the
+		// selector before the AgentSession ever sees it.
+		const parent = Settings.isolated({ defaultThinkingLevel: ThinkingLevel.Adaptive });
+		const sub = createSubagentSettings(parent);
+		expect(sub.get("defaultThinkingLevel")).not.toBe(ThinkingLevel.Adaptive);
 	});
 });

--- a/packages/coding-agent/test/tool-discovery/initial-tools.test.ts
+++ b/packages/coding-agent/test/tool-discovery/initial-tools.test.ts
@@ -10,6 +10,7 @@ import {
 	IrcTool,
 	JobTool,
 	RecipeTool,
+	SetThinkingLevelTool,
 	SshTool,
 } from "../../src/tools/index";
 
@@ -54,6 +55,7 @@ async function getToolMetadata(): Promise<Map<string, { loadMode?: string; summa
 		new JobTool(toolSession),
 		new RecipeTool(toolSession, []),
 		new IrcTool(toolSession),
+		new SetThinkingLevelTool(toolSession),
 	]) {
 		metadata.set(tool.name, { loadMode: tool.loadMode, summary: tool.summary });
 	}

--- a/packages/typescript-edit-benchmark/src/index.ts
+++ b/packages/typescript-edit-benchmark/src/index.ts
@@ -54,11 +54,9 @@ function rateColor(percent: number): string {
 }
 
 function parseThinkingLevel(value: string | null | undefined): ResolvedThinkingLevel | undefined {
-	return value !== undefined &&
-		value !== null &&
-		[ThinkingLevel.Off, ...THINKING_EFFORTS].includes(value as ResolvedThinkingLevel)
-		? (value as ResolvedThinkingLevel)
-		: undefined;
+	if (value === undefined || value === null) return undefined;
+	const valid: readonly ResolvedThinkingLevel[] = [ThinkingLevel.Off, ...THINKING_EFFORTS];
+	return valid.includes(value as ResolvedThinkingLevel) ? (value as ResolvedThinkingLevel) : undefined;
 }
 
 function generateReportFilename(config: BenchmarkConfig, format: "markdown" | "json"): string {


### PR DESCRIPTION
## Summary

Adds an **`adaptive`** option to the `/model` thinking submenu. When selected on a reasoning-capable model, the agent gains a built-in `set_thinking_level` tool plus a guidance block in its system prompt, so it can dial reasoning effort up or down per turn instead of running every request at the same fixed level.

Inspired by [`ian-pascoe/pi-adaptive-thinking`](https://github.com/ian-pascoe/pi-adaptive-thinking), ported as a first-class built-in rather than an extension.

## Behavior

- `/model` → pick a reasoning model → submenu now offers `inherit, off, **adaptive**, minimal, low, medium, high, xhigh`.
- Adaptive is also persistable as `defaultThinkingLevel` and selectable through ACP.
- While adaptive is active:
  - The agent sees a `set_thinking_level` tool (`{ level, persist? }`).
  - The system prompt carries a short guidance block listing the current effort and valid effort levels for the model.
  - `persist: false` applies the new effort for the current turn only; the session restores the baseline on `agent_end`.
  - `persist: true` updates the baseline for the rest of the session.
- Transitioning **into** or **out of** adaptive recomputes the active tool set and refreshes the system prompt so `set_thinking_level` materializes/disappears without restart.

## Design

- `ThinkingLevel.Adaptive = "adaptive"` is a new selector value alongside `Inherit` and `Off`; it never appears as a provider-facing `Effort`.
- `resolveThinkingLevelForModel(model, "adaptive")` returns `"adaptive"` only when the model supports any reasoning effort, else `undefined` (the selector is silently ignored on non-reasoning models).
- `AgentSession` tracks two new fields:
  - `#adaptiveEffort` — the baseline `Effort` the agent runs at.
  - `#adaptiveTempEffort` — set when `persist: false`; restored to baseline on `agent_end`.
- `setAdaptiveEffort(effort, persist)` is the single mutation point; it returns `false` when adaptive is inactive or the model doesn't support the effort.
- `SetThinkingLevelTool.createIf(session)` returns `null` outside adaptive mode, matching the `JobTool` / `RecipeTool` / `AskTool` pattern, so the tool literally never enters the active set when irrelevant.

## Files

- `packages/agent/src/thinking.ts` — add `Adaptive` to the `ThinkingLevel` union.
- `packages/coding-agent/src/thinking.ts` — metadata entry, parser inclusion, resolver branch, `toReasoningEffort` short-circuit.
- `packages/coding-agent/src/session/agent-session.ts` — `isAdaptiveThinking`/`adaptiveEffort` getters, `setAdaptiveEffort`, baseline restore on `agent_end`, tool-set + system-prompt refresh on transitions.
- `packages/coding-agent/src/sdk.ts` — wire new `ToolSession` callbacks and inject the adaptive guidance block in `rebuildSystemPrompt`.
- `packages/coding-agent/src/tools/set-thinking-level.ts` — new built-in tool.
- `packages/coding-agent/src/tools/index.ts` — `ToolSession` interface additions, `BUILTIN_TOOLS` registration via `createIf`, barrel export.
- `packages/coding-agent/src/prompts/adaptive-thinking.md` — Handlebars guidance block.
- `packages/coding-agent/src/config/settings-schema.ts` — widen `defaultThinkingLevel` enum + UI options.
- `packages/coding-agent/src/config/model-resolver.ts` — preserve `Adaptive` instead of clamping.
- `packages/coding-agent/src/modes/acp/acp-agent.ts` — surface adaptive in ACP thinking options.
- `packages/coding-agent/src/modes/components/{model-selector,thinking-selector,settings-selector}.ts` — UI surfaces.

## Tests

- `packages/coding-agent/test/agent-session-adaptive-thinking.test.ts` (7 cases, all pass): entry seeds baseline; switching to a concrete effort clears adaptive state; `persist: true` updates baseline; `persist: false` applies a per-turn override without mutating baseline; `setAdaptiveEffort` refuses outside adaptive mode; `setAdaptiveEffort` refuses an effort the model doesn't support; adaptive is a no-op on models without reasoning support.
- `packages/coding-agent/test/tool-discovery/initial-tools.test.ts` updated to include `SetThinkingLevelTool` in the manual-fallback list (it's `createIf`-gated, same as `JobTool` / `RecipeTool`).

## Verification

- `bun --filter "@oh-my-pi/pi-coding-agent" check:types` → green.
- `bun --filter "@oh-my-pi/pi-agent-core" check:types` → green.
- `bunx biome check packages/coding-agent packages/agent` → clean.
- Adaptive test file: 7/7 pass; `initial-tools.test.ts`: 8/8 pass.
- Pre-existing Windows `EBUSY` flakes in unrelated thinking tests reproduced on pristine `origin/main` and are not regressions from this branch.
