### PR TITLE
fix(ai): preserve latest Anthropic thinking signatures

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Anthropic adaptive-thinking replay preserving signed thinking blocks on the latest abandoned tool-use assistant message, avoiding `thinking blocks in the latest assistant message cannot be modified` 400s. ([#1531](https://github.com/can1357/oh-my-pi/issues/1531))
+
 ## [15.5.15] - 2026-05-30
 
 ### Added

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -68,27 +68,29 @@ export function transformMessages<TApi extends Api>(
 			// A partial signature is invalid and will be rejected by the API, so we must
 			// strip signatures from thinking blocks in these messages.
 			//
-			// Abandoned tool-use turns get the same treatment. When a turn carries
-			// toolCall blocks but did NOT request tool execution (stopReason !== "toolUse"
-			// — e.g. adaptive-thinking Opus emitting tool calls and then ending the turn
-			// on `end_turn`/`stop`), the agent loop pairs those calls with placeholder
-			// tool_results to keep the tool_use/tool_result contract valid. Replaying the
-			// turn's *signed* thinking in that tool_result continuation trips Anthropic's
-			// "`thinking` blocks in the latest assistant message cannot be modified" — the
-			// signature was bound to an end_turn context, not a tool-use one. Stripping it
-			// downgrades the thinking to plain text downstream, which the API accepts.
-			// Normal tool-use turns (stopReason "toolUse") never match this guard.
+			// Abandoned tool-use turns get the same treatment once they are no longer
+			// the latest assistant message. When a turn carries toolCall blocks but did
+			// NOT request tool execution (stopReason !== "toolUse" — e.g.
+			// adaptive-thinking Opus emitting tool calls and then ending the turn on
+			// `end_turn`/`stop`), the agent loop pairs those calls with placeholder
+			// tool_results to keep the tool_use/tool_result contract valid. Historical
+			// abandoned turns cannot safely replay their end_turn-bound signatures in
+			// that continuation, so stripping downgrades them to plain text downstream.
+			// Latest abandoned turns are exempt because Anthropic requires thinking
+			// blocks from its most recent response to remain byte-for-byte unmodified.
+			const invalidStopReason = assistantMsg.stopReason === "aborted" || assistantMsg.stopReason === "error";
 			const abandonedToolUse =
-				assistantMsg.stopReason !== "toolUse" && assistantMsg.content.some(b => b.type === "toolCall");
-			const hasInvalidSignatures =
-				assistantMsg.stopReason === "aborted" || assistantMsg.stopReason === "error" || abandonedToolUse;
+				!invalidStopReason &&
+				assistantMsg.stopReason !== "toolUse" &&
+				assistantMsg.content.some(b => b.type === "toolCall");
+			const hasInvalidSignatures = invalidStopReason || abandonedToolUse;
 
 			const transformedContent = assistantMsg.content.flatMap(block => {
 				if (block.type === "thinking") {
-					// Strip signature from aborted/errored messages — it's likely incomplete
+					// Strip untrustworthy signatures so the encoder can downgrade to text.
 					const sanitized =
 						hasInvalidSignatures && block.thinkingSignature ? { ...block, thinkingSignature: undefined } : block;
-					if (mustPreserveLatestAnthropicThinking) return sanitized;
+					if (mustPreserveLatestAnthropicThinking) return abandonedToolUse ? block : sanitized;
 					// For same model: keep thinking blocks with signatures (needed for replay)
 					// even if the thinking text is empty (OpenAI encrypted reasoning)
 					if (isSameModel && sanitized.thinkingSignature) return sanitized;

--- a/packages/ai/test/anthropic-abandoned-tooluse-replay.test.ts
+++ b/packages/ai/test/anthropic-abandoned-tooluse-replay.test.ts
@@ -11,13 +11,16 @@ import type { AssistantMessage, Message, Model, ToolResultMessage, UserMessage }
 //   * `stop_reason` is never replayed on the wire, so it does NOT constrain whether a
 //     continuation is valid — a tool_use turn replays fine with tool_results appended
 //     whether it ended on `tool_use` or `end_turn`.
-//   * Therefore the safe recovery for a turn whose signature is untrustworthy (abandoned
-//     `end_turn`+tool_use, or a half-streamed `aborted` turn) is to strip the signature
-//     and let the encoder downgrade the block to text — which the API accepts.
+//   * Therefore the safe recovery for a historical turn whose signature is untrustworthy
+//     (abandoned `end_turn`+tool_use, or a half-streamed `aborted` turn) is to strip the
+//     signature and let the encoder downgrade the block to text — which the API accepts.
+//   * The latest assistant message is different: Anthropic requires thinking blocks from
+//     its most recent response to remain unmodified, so valid signatures must be preserved
+//     even when the turn is abandoned.
 //
 // The agent loop relies on this: it now runs tool_use blocks under `stop`/`end_turn` and
-// continues. That continuation is only valid because the transform below keeps every
-// emitted `thinking` block signed and downgrades the rest.
+// continues. That continuation is valid only when the transform preserves latest signed
+// thinking and downgrades historical/invalid signed thinking.
 
 const model: Model<"anthropic-messages"> = {
 	api: "anthropic-messages",
@@ -94,10 +97,17 @@ describe("Anthropic abandoned/aborted tool-use replay", () => {
 		expect(blocks.some(b => b.type === "tool_use")).toBe(true);
 	});
 
-	it("downgrades thinking to text on an end_turn(stop) tool-use turn so the continuation stays wire-valid", () => {
+	it("preserves signed thinking on the latest end_turn(stop) tool-use turn", () => {
 		const blocks = assistantBlocks(buildHistory("stop", "sig_valid"));
 		expectNoUnsignedThinking(blocks);
-		// Signature stripped (abandoned tool-use) -> encoder downgrades to text; no thinking block survives.
+		expect(blocks.some(b => b.type === "thinking" && b.signature === "sig_valid")).toBe(true);
+		expect(blocks.some(b => b.type === "tool_use")).toBe(true);
+	});
+
+	it("downgrades historical end_turn(stop) tool-use thinking to text so the continuation stays wire-valid", () => {
+		const blocks = assistantBlocks(buildHistoryWithLaterAssistant("stop", "sig_valid"));
+		expectNoUnsignedThinking(blocks);
+		// Signature stripped (historical abandoned tool-use) -> encoder downgrades to text.
 		expect(blocks.some(b => b.type === "thinking")).toBe(false);
 		expect(blocks.some(b => b.type === "text" && b.text?.includes("deliberating"))).toBe(true);
 		// tool_use is preserved so it still pairs with the appended tool_result.
@@ -111,3 +121,23 @@ describe("Anthropic abandoned/aborted tool-use replay", () => {
 		expect(blocks.some(b => b.type === "tool_use")).toBe(true);
 	});
 });
+
+function buildHistoryWithLaterAssistant(
+	stopReason: AssistantMessage["stopReason"],
+	signature: string | undefined,
+): Message[] {
+	return [
+		...buildHistory(stopReason, signature),
+		{ role: "user", content: "continue after tool result", timestamp: 4 } satisfies UserMessage,
+		{
+			role: "assistant",
+			content: [{ type: "text", text: "done" }],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: model.id,
+			usage: emptyUsage,
+			stopReason: "stop",
+			timestamp: 5,
+		} satisfies AssistantMessage,
+	];
+}


### PR DESCRIPTION
## Repro
A direct fixture against `packages/ai/src/providers/transform-messages.ts` reproduced the bug with a latest Anthropic assistant message containing `stopReason: "stop"`, a signed `thinking` block, and a `toolCall`: `transformMessages` returned the thinking block without `thinkingSignature`, which is the mutation Anthropic rejects on the next replay.

## Cause
`transformMessages` treated abandoned tool-use turns (`stopReason !== "toolUse"` plus `toolCall`) the same as aborted/error turns and stripped `thinkingSignature` before checking whether the message was the latest Anthropic assistant message. That made the latest assistant response differ from Anthropic's prior signed thinking block.

## Fix
- Split aborted/error turns from abandoned tool-use turns so partial signatures still get downgraded.
- Preserve original signed `thinking` blocks when the abandoned tool-use turn is the latest Anthropic assistant message.
- Keep historical abandoned turns downgraded to text and add regression coverage for latest, historical, genuine tool-use, and aborted cases.
- Added an Unreleased changelog entry for `packages/ai`.

## Verification
- `bun -e "$REPRO"` against `./packages/ai/src/providers/transform-messages.ts` failed before the fix and preserves `thinkingSignature` after the fix.
- `bun --cwd=packages/ai run check && bun test packages/ai/test/anthropic-abandoned-tooluse-replay.test.ts` passed.

Fixes #1531