### PR TITLE
fix(ai): derive GitHub Copilot OAuth context window from max_context_window_tokens

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed GitHub Copilot OAuth model discovery locking every model to ~128k context. The dynamic `/models` mapper now derives `contextWindow` from `capabilities.limits.max_context_window_tokens` (the model's true total window) instead of `max_prompt_tokens` (Copilot's ~128k prompt/summarization budget), matching opencode's Copilot loader. Per-model windows (e.g. Gemini 2.5 Pro 1M, GPT-5.4 400k, Claude 200k) now surface correctly instead of being clamped to the prompt budget.
+
 ## [15.5.15] - 2026-05-30
 
 ### Added

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -2146,21 +2146,24 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 					): Model<Api> => {
 						const reference = resolveReference(defaults.id);
 						const copilotLimits = extractCopilotLimits(entry);
-						// Copilot exposes token limits under capabilities.limits.*.
-						// max_prompt_tokens is the prompt capacity (what OMP calls contextWindow).
-						// max_context_window_tokens is the total window (prompt + output budget)
-						// and must NOT be used for contextWindow — it inflates the limit and
-						// breaks compaction thresholds, overflow detection, and promotion.
-						// The OpenAI-compatible root-level `context_length` field mirrors the
-						// total window (e.g. 400k for gpt-5.4), so Copilot's max_prompt_tokens
-						// (the true prompt budget) must take precedence whenever it is present.
-						const contextWindowFallback = toPositiveNumber(
-							entry.context_length,
-							reference?.contextWindow ?? defaults.contextWindow,
-						);
+						// Copilot exposes per-model token limits under capabilities.limits.*.
+						// contextWindow := max_context_window_tokens — the model's true total
+						// window. This matches opencode's Copilot loader, which maps
+						// limit.context = max_context_window_tokens. The OpenAI-compatible
+						// root-level context_length mirrors the same total window and is the
+						// next fallback. max_prompt_tokens is Copilot's prompt/summarization
+						// budget (~128k on most models); it UNDER-reports the real window, so it
+						// is a last-resort fallback only — driving contextWindow from it is what
+						// previously locked every Copilot model to ~128k.
 						const contextWindow = toPositiveNumber(
-							copilotLimits.maxPromptTokens,
-							reference ? Math.min(contextWindowFallback, reference.contextWindow) : contextWindowFallback,
+							copilotLimits.maxContextWindowTokens,
+							toPositiveNumber(
+								entry.context_length,
+								toPositiveNumber(
+									copilotLimits.maxPromptTokens,
+									reference?.contextWindow ?? defaults.contextWindow,
+								),
+							),
 						);
 						const maxTokens = toPositiveNumber(
 							entry.max_completion_tokens,

--- a/packages/ai/test/github-copilot-model-limits.test.ts
+++ b/packages/ai/test/github-copilot-model-limits.test.ts
@@ -84,7 +84,7 @@ describe("github copilot model limits mapping", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
-	it("uses capabilities.limits max_prompt_tokens as context window when context_length is absent", async () => {
+	it("uses capabilities.limits max_context_window_tokens as context window", async () => {
 		const { models, fetchMock } = await discoverCopilotModels({
 			data: [
 				{
@@ -103,12 +103,12 @@ describe("github copilot model limits mapping", () => {
 
 		const model = models.find(candidate => candidate.id === "gemini-2.5-pro");
 		expect(model).toBeDefined();
-		expect(model?.contextWindow).toBe(128_000);
+		expect(model?.contextWindow).toBe(1_048_576);
 		expect(model?.maxTokens).toBe(64_000);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
-	it("prefers explicit context_length/max_completion_tokens when max_prompt_tokens is absent", async () => {
+	it("prefers max_context_window_tokens over context_length for context window", async () => {
 		const { models } = await discoverCopilotModels({
 			data: [
 				{
@@ -129,7 +129,7 @@ describe("github copilot model limits mapping", () => {
 		const model = models.find(candidate => candidate.id === "gpt-5.2-codex");
 		expect(model).toBeDefined();
 		expect(model?.api).toBe("openai-responses");
-		expect(model?.contextWindow).toBe(250_000);
+		expect(model?.contextWindow).toBe(400_000);
 		expect(model?.maxTokens).toBe(120_000);
 	});
 
@@ -152,7 +152,7 @@ describe("github copilot model limits mapping", () => {
 
 		const model = models.find(candidate => candidate.id === "claude-opus-4.6");
 		expect(model).toBeDefined();
-		expect(model?.contextWindow).toBe(128_000);
+		expect(model?.contextWindow).toBe(200_000);
 		expect(model?.maxTokens).toBe(16_000);
 	});
 
@@ -197,9 +197,9 @@ describe("github copilot model limits mapping", () => {
 		expect(model).toBeDefined();
 		expect(model?.api).toBe("openai-responses");
 		expect(model?.reasoning).toBe(true);
-		// max_prompt_tokens is the true prompt budget; root-level context_length
-		// mirrors max_context_window_tokens (total window) and must not win.
-		expect(model?.contextWindow).toBe(272_000);
+		// max_context_window_tokens is the model's true total window and wins; the
+		// mirrored root context_length and max_prompt_tokens are only fallbacks.
+		expect(model?.contextWindow).toBe(400_000);
 		expect(model?.maxTokens).toBe(128_000);
 		expect(model?.premiumMultiplier).toBe(0.33);
 		expect(model?.thinking).toEqual({
@@ -209,7 +209,7 @@ describe("github copilot model limits mapping", () => {
 		});
 	});
 
-	it("does not use max_context_window_tokens for contextWindow", async () => {
+	it("uses max_context_window_tokens for contextWindow", async () => {
 		const { models } = await discoverCopilotModels({
 			data: [
 				{
@@ -227,10 +227,9 @@ describe("github copilot model limits mapping", () => {
 
 		const model = models.find(candidate => candidate.id === "gpt-5.4");
 		expect(model).toBeDefined();
-		// max_context_window_tokens is total window (prompt + output), not prompt capacity.
-		// Without max_prompt_tokens, contextWindow should fall back to bundled reference,
-		// NOT to max_context_window_tokens.
-		expect(model?.contextWindow).toBe(272_000);
+		// max_context_window_tokens is the model's true total window (opencode parity);
+		// it drives contextWindow even when max_prompt_tokens is absent.
+		expect(model?.contextWindow).toBe(400_000);
 		expect(model?.maxTokens).toBe(128_000);
 	});
 

--- a/packages/ai/test/github-copilot-model-limits.test.ts
+++ b/packages/ai/test/github-copilot-model-limits.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resolveProviderModels } from "../src/model-manager";
 import { Effort } from "../src/model-thinking";
 import { getBundledModel } from "../src/models";
 import { githubCopilotModelManagerOptions } from "../src/provider-models/openai-compat";
@@ -250,5 +254,47 @@ describe("github copilot model limits mapping", () => {
 		// Should use the Copilot-specific bundled reference (272k after models.json fix),
 		// not the OpenAI global reference (1050k).
 		expect(model?.contextWindow).toBe(272_000);
+	});
+
+	it("preserves the discovered window through full resolution for a generated-policy id", async () => {
+		// gpt-5.4 is one of the ids in COPILOT_GENERATED_LIMITS, so its bundled window
+		// is the stale generated-policy value (272k). Drive the FULL resolveProviderModels
+		// merge (static bundle + live discovery) to prove the generated policy does NOT
+		// run at runtime: the discovered 400k window must survive to callers rather than
+		// being reset to the bundled 272k. Regression guard for the PR #1536 review thread.
+		const bundled = getBundledModel("github-copilot", "gpt-5.4");
+		expect(bundled?.contextWindow).toBe(272_000);
+
+		const fetchMock = vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						data: [
+							{
+								id: "gpt-5.4",
+								name: "GPT-5.4",
+								capabilities: { limits: { max_context_window_tokens: 400_000, max_output_tokens: 128_000 } },
+							},
+						],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+		);
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		const cacheDir = await fs.mkdtemp(path.join(os.tmpdir(), "copilot-merge-"));
+		try {
+			const options = githubCopilotModelManagerOptions({ apiKey: "copilot-test-key" });
+			const result = await resolveProviderModels(
+				{ ...options, cacheDbPath: path.join(cacheDir, "models.db") },
+				"online",
+			);
+			const resolved = result.models.find(model => model.id === "gpt-5.4");
+			expect(resolved).toBeDefined();
+			// Discovery (400k) overrides the stale bundled generated-policy window (272k).
+			expect(resolved?.contextWindow).toBe(400_000);
+		} finally {
+			await fs.rm(cacheDir, { recursive: true, force: true });
+		}
 	});
 });


### PR DESCRIPTION
Closes #1539

## Problem

GitHub Copilot OAuth models always surface a ~128k context window regardless of the model's true window (Gemini 2.5 Pro 1M, GPT-5.4 400k, Claude 200k, …).

## Root cause

The live `/models` discovery mapper for `github-copilot` (`packages/ai/src/provider-models/openai-compat.ts`) derived `contextWindow` from `capabilities.limits.max_prompt_tokens` — Copilot's prompt/summarization budget, which is ~128k on most models — instead of `max_context_window_tokens` (the model's true total window).

Discovered values override the bundled catalog at runtime via `preferDiscoveryLimit` (`packages/ai/src/model-manager.ts`), so the correct, larger bundled windows were clamped down to the ~128k prompt cap.

## Fix

Derive `contextWindow` from `max_context_window_tokens`, falling back to root-level `context_length`, then `max_prompt_tokens`, then the bundled reference. `maxTokens` continues to come from `max_output_tokens`.

This matches opencode's Copilot loader, which maps `limit.context = max_context_window_tokens` (`packages/opencode/src/plugin/github-copilot/models.ts`), and hermes-agent's context-length resolution (which uses window keys, never the prompt cap).

## Verification

- `bun test packages/ai/test/github-copilot-model-limits.test.ts` — discovery tests updated to assert true windows; the offline-bundled and reference-fallback cases are unchanged and still green.
- `bun test packages/ai/test/model-thinking.test.ts packages/ai/test/nanogpt-model-limits.test.ts` — green (no regressions).
- `bun run check` in `packages/ai` (biome + tsgo) — clean.

## Out of scope

Bundled `models.json` / `COPILOT_GENERATED_LIMITS` offline fallback values still reflect prompt caps for a few ids; they are only used when discovery is unavailable and require a generator change. Online discovery (this PR) is authoritative and resolves the reported symptom.