### PR TITLE
fix(tui): respect selector navigation keybindings

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed selector-style UI components to honor `tui.select.up` and `tui.select.down` keybindings instead of hard-coding raw Up/Down arrow bytes ([#1535](https://github.com/can1357/oh-my-pi/issues/1535)).
+
 ## [15.5.15] - 2026-05-30
 ### Changed
 

--- a/packages/coding-agent/src/modes/components/agent-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/agent-dashboard.ts
@@ -49,7 +49,7 @@ import { discoverAgents } from "../../task/discovery";
 import type { AgentDefinition, AgentSource } from "../../task/types";
 import { shortenPath } from "../../tools/render-utils";
 import { theme } from "../theme/theme";
-import { matchesAppInterrupt } from "../utils/keybinding-matchers";
+import { matchesAppInterrupt, matchesSelectDown, matchesSelectUp } from "../utils/keybinding-matchers";
 import { DynamicBorder } from "./dynamic-border";
 
 type SourceTabId = "all" | AgentSource;
@@ -1073,11 +1073,11 @@ export class AgentDashboard extends Container {
 			return;
 		}
 
-		if (matchesKey(data, "up") || data === "k") {
+		if (matchesSelectUp(data) || data === "k") {
 			this.#moveSelection(-1);
 			return;
 		}
-		if (matchesKey(data, "down") || data === "j") {
+		if (matchesSelectDown(data) || data === "j") {
 			this.#moveSelection(1);
 			return;
 		}

--- a/packages/coding-agent/src/modes/components/extensions/extension-list.ts
+++ b/packages/coding-agent/src/modes/components/extensions/extension-list.ts
@@ -15,6 +15,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import { isProviderEnabled } from "../../../discovery";
 import { theme } from "../../../modes/theme/theme";
+import { matchesSelectDown, matchesSelectUp } from "../../utils/keybinding-matchers";
 import { applyFilter } from "./state-manager";
 import type { Extension, ExtensionKind, ExtensionState } from "./types";
 
@@ -400,12 +401,12 @@ export class ExtensionList implements Component {
 
 	handleInput(data: string): void {
 		// Navigation
-		if (matchesKey(data, "up") || data === "k") {
+		if (matchesSelectUp(data) || data === "k") {
 			this.#moveSelectionUp();
 			return;
 		}
 
-		if (matchesKey(data, "down") || data === "j") {
+		if (matchesSelectDown(data) || data === "j") {
 			this.#moveSelectionDown();
 			return;
 		}

--- a/packages/coding-agent/src/modes/components/history-search.ts
+++ b/packages/coding-agent/src/modes/components/history-search.ts
@@ -11,7 +11,7 @@ import {
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
 import { theme } from "../../modes/theme/theme";
-import { matchesAppInterrupt } from "../../modes/utils/keybinding-matchers";
+import { matchesAppInterrupt, matchesSelectDown, matchesSelectUp } from "../../modes/utils/keybinding-matchers";
 import type { HistoryEntry, HistoryStorage } from "../../session/history-storage";
 import { DynamicBorder } from "./dynamic-border";
 
@@ -116,14 +116,14 @@ export class HistorySearchComponent extends Container {
 	}
 
 	handleInput(keyData: string): void {
-		if (matchesKey(keyData, "up")) {
+		if (matchesSelectUp(keyData)) {
 			if (this.#results.length === 0) return;
 			this.#selectedIndex = Math.max(0, this.#selectedIndex - 1);
 			this.#resultsList.setSelectedIndex(this.#selectedIndex);
 			return;
 		}
 
-		if (matchesKey(keyData, "down")) {
+		if (matchesSelectDown(keyData)) {
 			if (this.#results.length === 0) return;
 			this.#selectedIndex = Math.min(this.#results.length - 1, this.#selectedIndex + 1);
 			this.#resultsList.setSelectedIndex(this.#selectedIndex);

--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -16,7 +16,12 @@ import {
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
-import { matchesAppExternalEditor, matchesSelectCancel } from "../../modes/utils/keybinding-matchers";
+import {
+	matchesAppExternalEditor,
+	matchesSelectCancel,
+	matchesSelectDown,
+	matchesSelectUp,
+} from "../../modes/utils/keybinding-matchers";
 import { CountdownTimer } from "./countdown-timer";
 import { DynamicBorder } from "./dynamic-border";
 
@@ -164,10 +169,10 @@ export class HookSelectorComponent extends Container {
 		// Reset countdown on any interaction
 		this.#countdown?.reset();
 
-		if (matchesKey(keyData, "up") || keyData === "k") {
+		if (matchesSelectUp(keyData) || keyData === "k") {
 			this.#selectedIndex = Math.max(0, this.#selectedIndex - 1);
 			this.#updateList();
-		} else if (matchesKey(keyData, "down") || keyData === "j") {
+		} else if (matchesSelectDown(keyData) || keyData === "j") {
 			this.#selectedIndex = Math.min(this.#options.length - 1, this.#selectedIndex + 1);
 			this.#updateList();
 		} else if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {

--- a/packages/coding-agent/src/modes/components/mcp-add-wizard.ts
+++ b/packages/coding-agent/src/modes/components/mcp-add-wizard.ts
@@ -19,7 +19,7 @@ import { analyzeAuthError, discoverOAuthEndpoints } from "../../mcp/oauth-discov
 import type { MCPHttpServerConfig, MCPServerConfig, MCPSseServerConfig, MCPStdioServerConfig } from "../../mcp/types";
 import { shortenPath } from "../../tools/render-utils";
 import { theme } from "../theme/theme";
-import { matchesAppInterrupt } from "../utils/keybinding-matchers";
+import { matchesAppInterrupt, matchesSelectDown, matchesSelectUp } from "../utils/keybinding-matchers";
 import { DynamicBorder } from "./dynamic-border";
 
 type TransportType = "stdio" | "http" | "sse";
@@ -501,11 +501,11 @@ export class MCPAddWizard extends Container {
 		}
 
 		// Handle up/down arrows for selectors
-		if (matchesKey(keyData, "up")) {
+		if (matchesSelectUp(keyData)) {
 			this.#moveSelection(-1);
 			return;
 		}
-		if (matchesKey(keyData, "down")) {
+		if (matchesSelectDown(keyData)) {
 			this.#moveSelection(1);
 			return;
 		}

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -18,6 +18,7 @@ import { getKnownRoleIds, getRoleInfo, MODEL_ROLE_IDS, MODEL_ROLES } from "../..
 import { resolveModelRoleValue } from "../../config/model-resolver";
 import type { Settings } from "../../config/settings";
 import { type ThemeColor, theme } from "../../modes/theme/theme";
+import { matchesSelectDown, matchesSelectUp } from "../../modes/utils/keybinding-matchers";
 import { getThinkingLevelMetadata } from "../../thinking";
 import { getTabBarTheme } from "../shared";
 import { DynamicBorder } from "./dynamic-border";
@@ -971,7 +972,7 @@ export class ModelSelectorComponent extends Container {
 		}
 
 		// Up arrow - navigate list (wrap to bottom when at top)
-		if (matchesKey(keyData, "up")) {
+		if (matchesSelectUp(keyData)) {
 			const itemCount = this.#isCanonicalTab() ? this.#filteredCanonicalModels.length : this.#filteredModels.length;
 			if (itemCount === 0) return;
 			this.#selectedIndex = this.#selectedIndex === 0 ? itemCount - 1 : this.#selectedIndex - 1;
@@ -980,7 +981,7 @@ export class ModelSelectorComponent extends Container {
 		}
 
 		// Down arrow - navigate list (wrap to top when at bottom)
-		if (matchesKey(keyData, "down")) {
+		if (matchesSelectDown(keyData)) {
 			const itemCount = this.#isCanonicalTab() ? this.#filteredCanonicalModels.length : this.#filteredModels.length;
 			if (itemCount === 0) return;
 			this.#selectedIndex = this.#selectedIndex === itemCount - 1 ? 0 : this.#selectedIndex + 1;
@@ -1022,13 +1023,13 @@ export class ModelSelectorComponent extends Container {
 				: this.#menuRoleActions.length;
 		if (optionCount === 0) return;
 
-		if (matchesKey(keyData, "up")) {
+		if (matchesSelectUp(keyData)) {
 			this.#menuSelectedIndex = (this.#menuSelectedIndex - 1 + optionCount) % optionCount;
 			this.#updateMenu();
 			return;
 		}
 
-		if (matchesKey(keyData, "down")) {
+		if (matchesSelectDown(keyData)) {
 			this.#menuSelectedIndex = (this.#menuSelectedIndex + 1) % optionCount;
 			this.#updateMenu();
 			return;

--- a/packages/coding-agent/src/modes/components/oauth-selector.ts
+++ b/packages/coding-agent/src/modes/components/oauth-selector.ts
@@ -2,7 +2,7 @@ import { getOAuthProviders } from "@oh-my-pi/pi-ai/utils/oauth";
 import type { OAuthProviderInfo } from "@oh-my-pi/pi-ai/utils/oauth/types";
 import { Container, matchesKey, Spacer, TruncatedText } from "@oh-my-pi/pi-tui";
 import { theme } from "../../modes/theme/theme";
-import { matchesSelectCancel } from "../../modes/utils/keybinding-matchers";
+import { matchesSelectCancel, matchesSelectDown, matchesSelectUp } from "../../modes/utils/keybinding-matchers";
 import type { AuthStorage } from "../../session/auth-storage";
 import { DynamicBorder } from "./dynamic-border";
 
@@ -193,7 +193,7 @@ export class OAuthSelectorComponent extends Container {
 	}
 	handleInput(keyData: string): void {
 		// Up arrow
-		if (matchesKey(keyData, "up")) {
+		if (matchesSelectUp(keyData)) {
 			if (this.#allProviders.length > 0) {
 				this.#selectedIndex = this.#selectedIndex === 0 ? this.#allProviders.length - 1 : this.#selectedIndex - 1;
 			}
@@ -201,7 +201,7 @@ export class OAuthSelectorComponent extends Container {
 			this.#updateList();
 		}
 		// Down arrow
-		else if (matchesKey(keyData, "down")) {
+		else if (matchesSelectDown(keyData)) {
 			if (this.#allProviders.length > 0) {
 				this.#selectedIndex = this.#selectedIndex === this.#allProviders.length - 1 ? 0 : this.#selectedIndex + 1;
 			}

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -25,6 +25,7 @@ import { PREVIEW_LIMITS, replaceTabs, TRUNCATE_LENGTHS, truncateToWidth } from "
 import { toPathList } from "../../tools/search";
 import type { ObservableSession, SessionObserverRegistry } from "../session-observer-registry";
 import { getMarkdownTheme, theme } from "../theme/theme";
+import { matchesSelectDown, matchesSelectUp } from "../utils/keybinding-matchers";
 import { DynamicBorder } from "./dynamic-border";
 
 /** Max thinking characters in collapsed state */
@@ -660,7 +661,7 @@ export class SessionObserverOverlayComponent extends Container {
 		}
 
 		// j / down — move selection down
-		if (keyData === "j" || matchesKey(keyData, "down")) {
+		if (keyData === "j" || matchesSelectDown(keyData)) {
 			if (entryCount > 0) {
 				this.#selectedEntryIndex = Math.min(this.#selectedEntryIndex + 1, entryCount - 1);
 			}
@@ -669,7 +670,7 @@ export class SessionObserverOverlayComponent extends Container {
 		}
 
 		// k / up — move selection up
-		if (keyData === "k" || matchesKey(keyData, "up")) {
+		if (keyData === "k" || matchesSelectUp(keyData)) {
 			if (entryCount > 0) {
 				this.#selectedEntryIndex = Math.max(this.#selectedEntryIndex - 1, 0);
 			}

--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -13,7 +13,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import { formatBytes } from "@oh-my-pi/pi-utils";
 import { theme } from "../../modes/theme/theme";
-import { matchesAppInterrupt } from "../../modes/utils/keybinding-matchers";
+import { matchesAppInterrupt, matchesSelectDown, matchesSelectUp } from "../../modes/utils/keybinding-matchers";
 import type { SessionInfo } from "../../session/session-manager";
 import { DynamicBorder } from "./dynamic-border";
 import { HookSelectorComponent } from "./hook-selector";
@@ -192,12 +192,12 @@ class SessionList implements Component {
 		}
 
 		// Up arrow
-		if (matchesKey(keyData, "up")) {
+		if (matchesSelectUp(keyData)) {
 			this.#selectedIndex = Math.max(0, this.#selectedIndex - 1);
 			return;
 		}
 		// Down arrow
-		if (matchesKey(keyData, "down")) {
+		if (matchesSelectDown(keyData)) {
 			this.#selectedIndex = Math.min(this.#filteredSessions.length - 1, this.#selectedIndex + 1);
 			return;
 		}

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -12,7 +12,7 @@ import {
 } from "@oh-my-pi/pi-tui";
 import type { TreeFilterMode } from "../../config/settings-schema";
 import { theme } from "../../modes/theme/theme";
-import { matchesAppInterrupt } from "../../modes/utils/keybinding-matchers";
+import { matchesAppInterrupt, matchesSelectDown, matchesSelectUp } from "../../modes/utils/keybinding-matchers";
 import type { SessionTreeNode } from "../../session/session-manager";
 import { shortenPath } from "../../tools/render-utils";
 import { toPathList } from "../../tools/search";
@@ -718,9 +718,9 @@ class TreeList implements Component {
 	}
 
 	handleInput(keyData: string): void {
-		if (matchesKey(keyData, "up")) {
+		if (matchesSelectUp(keyData)) {
 			this.#selectedIndex = this.#selectedIndex === 0 ? this.#filteredNodes.length - 1 : this.#selectedIndex - 1;
-		} else if (matchesKey(keyData, "down")) {
+		} else if (matchesSelectDown(keyData)) {
 			this.#selectedIndex = this.#selectedIndex === this.#filteredNodes.length - 1 ? 0 : this.#selectedIndex + 1;
 		} else if (matchesKey(keyData, "left")) {
 			// Page up

--- a/packages/coding-agent/src/modes/components/user-message-selector.ts
+++ b/packages/coding-agent/src/modes/components/user-message-selector.ts
@@ -1,6 +1,6 @@
 import { type Component, Container, matchesKey, Spacer, Text, truncateToWidth } from "@oh-my-pi/pi-tui";
 import { theme } from "../../modes/theme/theme";
-import { matchesSelectCancel } from "../../modes/utils/keybinding-matchers";
+import { matchesSelectCancel, matchesSelectDown, matchesSelectUp } from "../../modes/utils/keybinding-matchers";
 import { DynamicBorder } from "./dynamic-border";
 
 interface UserMessageItem {
@@ -78,11 +78,11 @@ class UserMessageList implements Component {
 
 	handleInput(keyData: string): void {
 		// Up arrow - go to previous (older) message, wrap to bottom when at top
-		if (matchesKey(keyData, "up")) {
+		if (matchesSelectUp(keyData)) {
 			this.#selectedIndex = this.#selectedIndex === 0 ? this.messages.length - 1 : this.#selectedIndex - 1;
 		}
 		// Down arrow - go to next (newer) message, wrap to top when at bottom
-		else if (matchesKey(keyData, "down")) {
+		else if (matchesSelectDown(keyData)) {
 			this.#selectedIndex = this.#selectedIndex === this.messages.length - 1 ? 0 : this.#selectedIndex + 1;
 		}
 		// Enter - select message and branch

--- a/packages/coding-agent/src/modes/utils/keybinding-matchers.ts
+++ b/packages/coding-agent/src/modes/utils/keybinding-matchers.ts
@@ -16,8 +16,19 @@ export function matchesAppInterrupt(data: string): boolean {
 	return matchesKey(data, "escape") || matchesKey(data, "esc");
 }
 
+/** Match the generic selector cancel keybinding. */
 export function matchesSelectCancel(data: string): boolean {
 	return getKeybindings().matches(data, "tui.select.cancel");
+}
+
+/** Match the generic selector up-navigation keybinding. */
+export function matchesSelectUp(data: string): boolean {
+	return getKeybindings().matches(data, "tui.select.up");
+}
+
+/** Match the generic selector down-navigation keybinding. */
+export function matchesSelectDown(data: string): boolean {
+	return getKeybindings().matches(data, "tui.select.down");
 }
 
 export function matchesAppExternalEditor(data: string): boolean {

--- a/packages/coding-agent/test/keybindings-selector-navigation.test.ts
+++ b/packages/coding-agent/test/keybindings-selector-navigation.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
+import { ExtensionList } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/extension-list";
+import type { Extension } from "@oh-my-pi/pi-coding-agent/modes/components/extensions/types";
+import { HistorySearchComponent } from "@oh-my-pi/pi-coding-agent/modes/components/history-search";
+import { OAuthSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/oauth-selector";
+import { SessionSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/session-selector";
+import { TreeSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tree-selector";
+import { UserMessageSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/user-message-selector";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import {
+	type AuthCredential,
+	type AuthCredentialStore,
+	AuthStorage,
+	type StoredAuthCredential,
+} from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { HistoryStorage } from "@oh-my-pi/pi-coding-agent/session/history-storage";
+import type { SessionInfo, SessionTreeNode } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { setKeybindings } from "@oh-my-pi/pi-tui";
+
+const CTRL_N = "\x0e";
+const CTRL_P = "\x10";
+const TEST_KEYBINDINGS = KeybindingsManager.inMemory({
+	"tui.select.up": "ctrl+p",
+	"tui.select.down": "ctrl+n",
+});
+
+const tempDirs: string[] = [];
+
+class EmptyCredentialStore implements AuthCredentialStore {
+	close(): void {}
+
+	listAuthCredentials(_provider?: string): StoredAuthCredential[] {
+		return [];
+	}
+
+	updateAuthCredential(_id: number, _credential: AuthCredential): void {}
+
+	deleteAuthCredential(_id: number, _disabledCause: string): void {}
+
+	tryDisableAuthCredentialIfMatches(_id: number, _expectedData: string, _disabledCause: string): boolean {
+		return false;
+	}
+
+	replaceAuthCredentialsForProvider(_provider: string, _credentials: AuthCredential[]): StoredAuthCredential[] {
+		return [];
+	}
+
+	upsertAuthCredentialForProvider(_provider: string, _credential: AuthCredential): StoredAuthCredential[] {
+		return [];
+	}
+
+	deleteAuthCredentialsForProvider(_provider: string, _disabledCause: string): void {}
+
+	getCache(_key: string, _options?: { includeExpired?: boolean }): string | null {
+		return null;
+	}
+
+	setCache(_key: string, _value: string, _expiresAtSec: number): void {}
+
+	cleanExpiredCache(): void {}
+}
+
+beforeAll(() => {
+	initTheme();
+});
+
+afterEach(async () => {
+	setKeybindings(KeybindingsManager.inMemory());
+	HistoryStorage.resetInstance();
+	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+function createSession(id: string, title: string): SessionInfo {
+	return {
+		path: `/tmp/${id}.jsonl`,
+		id,
+		cwd: "/tmp",
+		title,
+		created: new Date("2024-01-01T00:00:00Z"),
+		modified: new Date("2024-01-02T00:00:00Z"),
+		messageCount: 1,
+		size: 0,
+		firstMessage: `${title} first message`,
+		allMessagesText: `${title} first message`,
+	};
+}
+
+function createMessageNode(id: string, parentId: string | null, content: string): SessionTreeNode {
+	const message: AgentMessage = { role: "user", content, timestamp: 1 };
+	return {
+		entry: {
+			type: "message",
+			id,
+			parentId,
+			timestamp: "2024-01-01T00:00:00Z",
+			message,
+		},
+		children: [],
+	};
+}
+
+function createExtension(id: string, displayName: string): Extension {
+	return {
+		id,
+		kind: "tool",
+		name: id,
+		displayName,
+		description: displayName,
+		path: `/tmp/${id}.md`,
+		source: {
+			provider: "test-provider",
+			providerName: "Test Provider",
+			level: "project",
+		},
+		state: "active",
+		raw: {},
+	};
+}
+
+async function createHistoryStorage(prompts: string[]): Promise<HistoryStorage> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-history-nav-"));
+	tempDirs.push(dir);
+	HistoryStorage.resetInstance();
+	const storage = HistoryStorage.open(path.join(dir, "history.db"));
+	for (const prompt of prompts) {
+		await storage.add(prompt);
+	}
+	return storage;
+}
+
+function createAuthStorage(): AuthStorage {
+	return new AuthStorage(new EmptyCredentialStore());
+}
+
+describe("selector navigation keybindings", () => {
+	it("uses tui.select.down in the session selector", () => {
+		setKeybindings(TEST_KEYBINDINGS);
+		const selected: string[] = [];
+		const selector = new SessionSelectorComponent(
+			[createSession("session-a", "Alpha"), createSession("session-b", "Beta")],
+			path => selected.push(path),
+			() => {},
+			() => {},
+		);
+
+		selector.handleInput(CTRL_N);
+		selector.handleInput("\n");
+
+		expect(selected).toEqual(["/tmp/session-b.jsonl"]);
+	});
+
+	it("uses tui.select.down in the session tree", () => {
+		setKeybindings(TEST_KEYBINDINGS);
+		const root = createMessageNode("root", null, "Root");
+		const child = createMessageNode("child", "root", "Child");
+		root.children.push(child);
+		const selected: string[] = [];
+		const selector = new TreeSelectorComponent(
+			[root],
+			"root",
+			40,
+			id => selected.push(id),
+			() => {},
+		);
+		selector.handleInput(CTRL_N);
+		selector.handleInput("\n");
+
+		expect(selected).toEqual(["child"]);
+	});
+
+	it("uses tui.select.up in the user message selector", () => {
+		setKeybindings(TEST_KEYBINDINGS);
+		const selected: string[] = [];
+		const selector = new UserMessageSelectorComponent(
+			[
+				{ id: "first", text: "First" },
+				{ id: "second", text: "Second" },
+				{ id: "third", text: "Third" },
+			],
+			id => selected.push(id),
+			() => {},
+		);
+
+		selector.getMessageList().handleInput(CTRL_P);
+		selector.getMessageList().handleInput("\n");
+
+		expect(selected).toEqual(["second"]);
+	});
+
+	it("uses tui.select.down in the extension list", () => {
+		setKeybindings(TEST_KEYBINDINGS);
+		const list = new ExtensionList([createExtension("tool-a", "Tool A"), createExtension("tool-b", "Tool B")]);
+
+		list.handleInput(CTRL_N);
+
+		expect(list.getSelectedExtension()?.id).toBe("tool-a");
+	});
+
+	it("uses tui.select.down in the OAuth selector", () => {
+		setKeybindings(TEST_KEYBINDINGS);
+		const selected: string[] = [];
+		const selector = new OAuthSelectorComponent(
+			"login",
+			createAuthStorage(),
+			id => selected.push(id),
+			() => {},
+		);
+
+		selector.handleInput(CTRL_N);
+		selector.handleInput("\n");
+
+		expect(selected).toEqual(["alibaba-coding-plan"]);
+	});
+
+	it("uses tui.select.down in history search", async () => {
+		setKeybindings(TEST_KEYBINDINGS);
+		const selected: string[] = [];
+		const storage = await createHistoryStorage(["old prompt", "middle prompt", "new prompt"]);
+		const selector = new HistorySearchComponent(
+			storage,
+			prompt => selected.push(prompt),
+			() => {},
+		);
+		selector.handleInput(CTRL_N);
+		selector.handleInput("\n");
+
+		expect(selected).toEqual(["middle prompt"]);
+	});
+});


### PR DESCRIPTION
## Repro
With `tui.select.up` and `tui.select.down` rebound to `ctrl+p` and `ctrl+n`, the reported selector components ignored Ctrl+P/Ctrl+N because they still matched raw Up/Down bytes. Reproduced with `bun test packages/coding-agent/test/keybindings-selector-navigation.test.ts`, which failed all six component cases before the fix.

## Cause
Selector-style handlers in `packages/coding-agent/src/modes/components/*` called `matchesKey(data, "up")` / `matchesKey(data, "down")` directly, bypassing the global `KeybindingsManager`; the editor path works because it calls `getKeybindings().matches(...)`. The shared `packages/coding-agent/src/modes/utils/keybinding-matchers.ts` only exposed cancel/interrupt helpers, so components kept reimplementing raw navigation checks.

## Fix
- Added shared `matchesSelectUp` and `matchesSelectDown` helpers that dispatch through `tui.select.up` and `tui.select.down`.
- Replaced raw Up/Down checks in the reported session tree, session selector, user message selector, extension list, OAuth selector, and history search components, plus adjacent selector-style navigation handlers.
- Added regression tests covering the reported components with `ctrl+p` / `ctrl+n` remaps.
- Added an Unreleased changelog entry for the selector keybinding fix.

## Verification
`bun test packages/coding-agent/test/keybindings-selector-navigation.test.ts` passed. `bun test packages/coding-agent/test/keybindings-escape-components.test.ts packages/tui/test/keybindings.test.ts` passed. `bun run check` in `packages/coding-agent` passed. Fixes #1535