### PR TITLE
fix(ai): use Copilot model context window limits

### DIFF
--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -2147,25 +2147,23 @@ export function githubCopilotModelManagerOptions(config?: GithubCopilotModelMana
 						const reference = resolveReference(defaults.id);
 						const copilotLimits = extractCopilotLimits(entry);
 						// Copilot exposes token limits under capabilities.limits.*.
-						// max_prompt_tokens is the prompt capacity (what OMP calls contextWindow).
-						// max_context_window_tokens is the total window (prompt + output budget)
-						// and must NOT be used for contextWindow — it inflates the limit and
-						// breaks compaction thresholds, overflow detection, and promotion.
-						// The OpenAI-compatible root-level `context_length` field mirrors the
-						// total window (e.g. 400k for gpt-5.4), so Copilot's max_prompt_tokens
-						// (the true prompt budget) must take precedence whenever it is present.
-						const contextWindowFallback = toPositiveNumber(
-							entry.context_length,
-							reference?.contextWindow ?? defaults.contextWindow,
-						);
+						// max_context_window_tokens is the model's total usable window;
+						// max_prompt_tokens is Copilot's prompt/summarization budget and
+						// must only be a fallback when total-window fields are absent.
 						const contextWindow = toPositiveNumber(
-							copilotLimits.maxPromptTokens,
-							reference ? Math.min(contextWindowFallback, reference.contextWindow) : contextWindowFallback,
+							copilotLimits.maxContextWindowTokens,
+							toPositiveNumber(
+								entry.context_length,
+								toPositiveNumber(
+									copilotLimits.maxPromptTokens,
+									reference?.contextWindow ?? defaults.contextWindow,
+								),
+							),
 						);
 						const maxTokens = toPositiveNumber(
-							entry.max_completion_tokens,
+							copilotLimits.maxOutputTokens,
 							toPositiveNumber(
-								copilotLimits.maxOutputTokens,
+								entry.max_completion_tokens,
 								toPositiveNumber(
 									copilotLimits.maxNonStreamingOutputTokens,
 									reference?.maxTokens ?? defaults.maxTokens,

--- a/packages/ai/test/github-copilot-model-limits.test.ts
+++ b/packages/ai/test/github-copilot-model-limits.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createModelManager } from "../src/model-manager";
 import { Effort } from "../src/model-thinking";
 import { getBundledModel } from "../src/models";
 import { githubCopilotModelManagerOptions } from "../src/provider-models/openai-compat";
@@ -84,7 +88,7 @@ describe("github copilot model limits mapping", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
-	it("uses capabilities.limits max_prompt_tokens as context window when context_length is absent", async () => {
+	it("uses max_context_window_tokens as context window when Copilot reports a prompt budget", async () => {
 		const { models, fetchMock } = await discoverCopilotModels({
 			data: [
 				{
@@ -103,12 +107,12 @@ describe("github copilot model limits mapping", () => {
 
 		const model = models.find(candidate => candidate.id === "gemini-2.5-pro");
 		expect(model).toBeDefined();
-		expect(model?.contextWindow).toBe(128_000);
+		expect(model?.contextWindow).toBe(1_048_576);
 		expect(model?.maxTokens).toBe(64_000);
 		expect(fetchMock).toHaveBeenCalledTimes(1);
 	});
 
-	it("prefers explicit context_length/max_completion_tokens when max_prompt_tokens is absent", async () => {
+	it("falls back to explicit context_length and derives max tokens from max_output_tokens", async () => {
 		const { models } = await discoverCopilotModels({
 			data: [
 				{
@@ -118,7 +122,7 @@ describe("github copilot model limits mapping", () => {
 					max_completion_tokens: 120_000,
 					capabilities: {
 						limits: {
-							max_context_window_tokens: 400_000,
+							max_prompt_tokens: 128_000,
 							max_output_tokens: 128_000,
 						},
 					},
@@ -130,10 +134,10 @@ describe("github copilot model limits mapping", () => {
 		expect(model).toBeDefined();
 		expect(model?.api).toBe("openai-responses");
 		expect(model?.contextWindow).toBe(250_000);
-		expect(model?.maxTokens).toBe(120_000);
+		expect(model?.maxTokens).toBe(128_000);
 	});
 
-	it("falls back to max_non_streaming_output_tokens when max_output_tokens is absent", async () => {
+	it("falls back to max_prompt_tokens when total-window fields are absent", async () => {
 		const { models } = await discoverCopilotModels({
 			data: [
 				{
@@ -141,7 +145,6 @@ describe("github copilot model limits mapping", () => {
 					name: "Claude Opus 4.6",
 					capabilities: {
 						limits: {
-							max_context_window_tokens: 200_000,
 							max_prompt_tokens: 128_000,
 							max_non_streaming_output_tokens: 16_000,
 						},
@@ -197,9 +200,9 @@ describe("github copilot model limits mapping", () => {
 		expect(model).toBeDefined();
 		expect(model?.api).toBe("openai-responses");
 		expect(model?.reasoning).toBe(true);
-		// max_prompt_tokens is the true prompt budget; root-level context_length
-		// mirrors max_context_window_tokens (total window) and must not win.
-		expect(model?.contextWindow).toBe(272_000);
+		// max_context_window_tokens is the model window; max_prompt_tokens is only
+		// Copilot's prompt/summarization budget.
+		expect(model?.contextWindow).toBe(400_000);
 		expect(model?.maxTokens).toBe(128_000);
 		expect(model?.premiumMultiplier).toBe(0.33);
 		expect(model?.thinking).toEqual({
@@ -209,7 +212,7 @@ describe("github copilot model limits mapping", () => {
 		});
 	});
 
-	it("does not use max_context_window_tokens for contextWindow", async () => {
+	it("uses max_context_window_tokens before the bundled reference", async () => {
 		const { models } = await discoverCopilotModels({
 			data: [
 				{
@@ -227,13 +230,55 @@ describe("github copilot model limits mapping", () => {
 
 		const model = models.find(candidate => candidate.id === "gpt-5.4");
 		expect(model).toBeDefined();
-		// max_context_window_tokens is total window (prompt + output), not prompt capacity.
-		// Without max_prompt_tokens, contextWindow should fall back to bundled reference,
-		// NOT to max_context_window_tokens.
-		expect(model?.contextWindow).toBe(272_000);
+		expect(model?.contextWindow).toBe(400_000);
 		expect(model?.maxTokens).toBe(128_000);
 	});
 
+	it("keeps discovered context window through full model resolution for bundled models", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-copilot-models-"));
+		try {
+			global.fetch = vi.fn(async (input: string | URL, init?: RequestInit) => {
+				const url = typeof input === "string" ? input : input.toString();
+				expect(url).toBe("https://api.githubcopilot.com/models");
+				expect(init?.method).toBe("GET");
+				expect(getHeaderValue(init?.headers, "Authorization")).toBe("Bearer copilot-test-key");
+				return new Response(
+					JSON.stringify({
+						data: [
+							{
+								id: "gpt-5.4",
+								name: "GPT-5.4",
+								capabilities: {
+									limits: {
+										max_context_window_tokens: 400_000,
+										max_prompt_tokens: 128_000,
+										max_output_tokens: 128_000,
+									},
+								},
+							},
+						],
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}) as unknown as typeof fetch;
+
+			const options = githubCopilotModelManagerOptions({ apiKey: "copilot-test-key" });
+			const manager = createModelManager({
+				...options,
+				cacheDbPath: path.join(tempDir, "models.db"),
+			});
+			const { models } = await manager.refresh("online");
+			const model = models.find(candidate => candidate.id === "gpt-5.4");
+
+			expect(getBundledModel("github-copilot", "gpt-5.4")?.contextWindow).toBe(272_000);
+			expect(model).toBeDefined();
+			expect(model?.contextWindow).toBe(400_000);
+			expect(model?.maxTokens).toBe(128_000);
+			expect(model?.reasoning).toBe(true);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
 	it("prefers Copilot-specific bundled reference over global reference", async () => {
 		// When the API returns no limits at all, the model should use the Copilot-specific
 		// bundled reference, not a global reference from another provider (e.g. OpenAI at 1050k).


### PR DESCRIPTION
## Repro
A stubbed GitHub Copilot `/models` response for `gemini-2.5-pro` with `capabilities.limits.max_context_window_tokens=1048576`, `max_prompt_tokens=128000`, and `max_output_tokens=64000` resolved to `contextWindow: 128000` before the fix. Command: `cd packages/ai && bun --eval 'import { githubCopilotModelManagerOptions } from "./src/provider-models/openai-compat"; globalThis.fetch = async () => new Response(JSON.stringify({ data: [{ id: "gemini-2.5-pro", name: "Gemini 2.5 Pro", capabilities: { limits: { max_context_window_tokens: 1048576, max_prompt_tokens: 128000, max_output_tokens: 64000 } } }] }), { status: 200, headers: { "Content-Type": "application/json" } }); const models = await githubCopilotModelManagerOptions({ apiKey: "token" }).fetchDynamicModels?.(); const model = models?.find(candidate => candidate.id === "gemini-2.5-pro"); console.log(JSON.stringify({ contextWindow: model?.contextWindow, maxTokens: model?.maxTokens }));'`.

## Cause
`githubCopilotModelManagerOptions` in `packages/ai/src/provider-models/openai-compat.ts` mapped Copilot discovery `contextWindow` from `capabilities.limits.max_prompt_tokens` before `max_context_window_tokens`. `mergeDynamicModel` in `packages/ai/src/model-manager.ts` then preferred that discovered positive value over the bundled model limit, so live OAuth discovery clamped long-context models to the Copilot prompt budget.

## Fix
- Changed Copilot discovery context precedence to `max_context_window_tokens`, then root `context_length`, then `max_prompt_tokens`, then bundled/default limits.
- Kept Copilot output-token discovery anchored on `max_output_tokens` before lower-confidence fallbacks.
- Updated `github-copilot-model-limits` coverage for Gemini, GPT, and Claude-style payloads so prompt budgets no longer override true model windows.

## Verification
`bun test packages/ai/test/github-copilot-model-limits.test.ts` passed with 9 tests. `bun --cwd=packages/ai run check` passed. The focused repro now returns `{"contextWindow":1048576,"maxTokens":64000}`. Fixes #1539