### PR TITLE
fix(coding-agent): show execution context in plan approval

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -72,6 +72,10 @@
 
 - Fixed auto context maintenance to include the pending prompt in the pre-send token estimate, so large user turns compact history before the provider rejects an over-limit request ([#1618](https://github.com/can1357/oh-my-pi/issues/1618)).
 
+### Fixed
+
+- Fixed plan approval keep-context usage to use the execution model context window, avoid zero-usage aborted turns, and disable keeping context when preserved context exceeds 95%.
+
 ## [15.7.4] - 2026-05-31
 
 ### Removed

--- a/packages/coding-agent/src/modes/components/hook-selector.ts
+++ b/packages/coding-agent/src/modes/components/hook-selector.ts
@@ -68,6 +68,9 @@ export interface HookSelectorOptions {
 	onExternalEditor?: () => void;
 	helpText?: string;
 	slider?: HookSelectorSlider;
+	/** Indices into the original options that cannot be selected: they render
+	 *  dimmed, are skipped during navigation, and reject enter/timeout. */
+	disabledIndices?: readonly number[];
 }
 
 export interface HookSelectorOption {
@@ -127,11 +130,16 @@ class OutlinedList extends Container {
 	}
 }
 
+/** A filtered option paired with its index into the original options array, so
+ *  disabled-index lookups survive fuzzy filtering and reordering. */
+type FilteredOption = { option: HookSelectorOption; index: number };
+
 export class HookSelectorComponent extends Container {
 	#options: HookSelectorOption[];
-	#filteredOptions: HookSelectorOption[];
+	#filteredOptions: FilteredOption[];
 	#searchQuery = "";
 	#selectedIndex: number;
+	#disabledIndices: Set<number>;
 	#maxVisible: number;
 	#listContainer: Container | undefined;
 	#outlinedList: OutlinedList | undefined;
@@ -157,8 +165,13 @@ export class HookSelectorComponent extends Container {
 		super();
 
 		this.#options = options.map(normalizeHookSelectorOption);
-		this.#filteredOptions = this.#options;
-		this.#selectedIndex = Math.min(opts?.initialIndex ?? 0, this.#filteredOptions.length - 1);
+		this.#filteredOptions = this.#options.map((option, index) => ({ option, index }));
+		this.#disabledIndices = new Set(
+			(opts?.disabledIndices ?? []).filter(
+				index => Number.isInteger(index) && index >= 0 && index < this.#options.length,
+			),
+		);
+		this.#selectedIndex = this.#coerceSelectedIndex(opts?.initialIndex ?? 0);
 		this.#maxVisible = Math.max(3, opts?.maxVisible ?? 12);
 		this.#onSelectCallback = onSelect;
 		this.#onCancelCallback = onCancel;
@@ -191,9 +204,10 @@ export class HookSelectorComponent extends Container {
 				s => this.#titleComponent.setText(`${this.#baseTitle} (${s}s)`),
 				() => {
 					opts?.onTimeout?.();
+					// Auto-select current option on timeout (typically the first/recommended option)
 					const selected = this.#filteredOptions[this.#selectedIndex];
-					if (selected) {
-						this.#onSelectCallback(selected.label);
+					if (selected && !this.#isDisabled(selected.index)) {
+						this.#onSelectCallback(selected.option.label);
 					} else {
 						this.#onCancelCallback();
 					}
@@ -217,14 +231,62 @@ export class HookSelectorComponent extends Container {
 		this.#updateList();
 	}
 
-	#renderOptionLines(option: HookSelectorOption, isSelected: boolean, mdTheme: MarkdownTheme): string[] {
-		const label = isSelected
-			? renderInlineMarkdown(option.label, mdTheme, t => theme.fg("accent", t))
-			: renderInlineMarkdown(option.label, mdTheme, t => theme.fg("text", t));
-		const prefix = isSelected ? theme.fg("accent", `${theme.nav.cursor} `) : "  ";
+	#isDisabled(index: number): boolean {
+		return this.#disabledIndices.has(index);
+	}
+
+	/** Clamp `index` into range, then walk forward (and finally backward) to the
+	 *  nearest enabled option so the cursor never lands on a disabled row. */
+	#coerceSelectedIndex(index: number): number {
+		if (this.#filteredOptions.length === 0) return -1;
+		const maxIndex = this.#filteredOptions.length - 1;
+		const clamped = Math.max(0, Math.min(index, maxIndex));
+		const clampedOption = this.#filteredOptions[clamped];
+		if (clampedOption && !this.#isDisabled(clampedOption.index)) return clamped;
+		for (let i = clamped + 1; i <= maxIndex; i++) {
+			const option = this.#filteredOptions[i];
+			if (option && !this.#isDisabled(option.index)) return i;
+		}
+		for (let i = clamped - 1; i >= 0; i--) {
+			const option = this.#filteredOptions[i];
+			if (option && !this.#isDisabled(option.index)) return i;
+		}
+		return clamped;
+	}
+
+	/** Move the cursor by `delta`, skipping disabled rows, stopping at the first
+	 *  enabled option reached or at the list edge. */
+	#moveSelection(delta: number): void {
+		if (this.#filteredOptions.length === 0) return;
+		const maxIndex = this.#filteredOptions.length - 1;
+		let index = this.#selectedIndex;
+		while (true) {
+			const next = Math.max(0, Math.min(index + delta, maxIndex));
+			if (next === index) return;
+			index = next;
+			const option = this.#filteredOptions[index];
+			if (option && !this.#isDisabled(option.index)) {
+				this.#selectedIndex = index;
+				this.#updateList();
+				return;
+			}
+		}
+	}
+
+	#renderOptionLines(
+		option: HookSelectorOption,
+		isSelected: boolean,
+		isDisabled: boolean,
+		mdTheme: MarkdownTheme,
+	): string[] {
+		const textColor = isDisabled ? "dim" : isSelected ? "accent" : "text";
+		const prefixColor = isDisabled ? "dim" : "accent";
+		const label = renderInlineMarkdown(option.label, mdTheme, t => theme.fg(textColor, t));
+		const prefix = isSelected ? theme.fg(prefixColor, `${theme.nav.cursor} `) : "  ";
 		const lines = [prefix + label];
 		if (option.description) {
-			const description = renderInlineMarkdown(option.description, mdTheme, t => theme.fg("muted", t));
+			const descriptionColor = isDisabled ? "dim" : "muted";
+			const description = renderInlineMarkdown(option.description, mdTheme, t => theme.fg(descriptionColor, t));
 			lines.push(`    ${description}`);
 		}
 		return lines;
@@ -250,7 +312,7 @@ export class HookSelectorComponent extends Container {
 	): number {
 		if (renderWidth === undefined) return option.description ? 2 : 1;
 		let rows = 0;
-		for (const line of this.#renderOptionLines(option, isSelected, mdTheme)) {
+		for (const line of this.#renderOptionLines(option, isSelected, false, mdTheme)) {
 			rows += this.#renderedLineRowCount(line, renderWidth);
 		}
 		return rows;
@@ -276,12 +338,12 @@ export class HookSelectorComponent extends Container {
 		const selectedIndex = Math.max(0, Math.min(this.#selectedIndex, total - 1));
 		let startIndex = selectedIndex;
 		let endIndex = selectedIndex + 1;
-		let rows = this.#optionRowCount(this.#filteredOptions[selectedIndex]!, renderWidth, true, mdTheme);
+		let rows = this.#optionRowCount(this.#filteredOptions[selectedIndex]!.option, renderWidth, true, mdTheme);
 		let beforeRows = 0;
 		const targetBeforeRows = Math.max(0, Math.floor((rowBudget - rows) / 2));
 
 		while (startIndex > 0) {
-			const cost = this.#optionRowCount(this.#filteredOptions[startIndex - 1]!, renderWidth, false, mdTheme);
+			const cost = this.#optionRowCount(this.#filteredOptions[startIndex - 1]!.option, renderWidth, false, mdTheme);
 			if (beforeRows + cost > targetBeforeRows || rows + cost > rowBudget) break;
 			startIndex--;
 			beforeRows += cost;
@@ -289,14 +351,14 @@ export class HookSelectorComponent extends Container {
 		}
 
 		while (endIndex < total) {
-			const cost = this.#optionRowCount(this.#filteredOptions[endIndex]!, renderWidth, false, mdTheme);
+			const cost = this.#optionRowCount(this.#filteredOptions[endIndex]!.option, renderWidth, false, mdTheme);
 			if (rows + cost > rowBudget) break;
 			endIndex++;
 			rows += cost;
 		}
 
 		while (startIndex > 0) {
-			const cost = this.#optionRowCount(this.#filteredOptions[startIndex - 1]!, renderWidth, false, mdTheme);
+			const cost = this.#optionRowCount(this.#filteredOptions[startIndex - 1]!.option, renderWidth, false, mdTheme);
 			if (rows + cost > rowBudget) break;
 			startIndex--;
 			rows += cost;
@@ -312,9 +374,10 @@ export class HookSelectorComponent extends Container {
 		const { startIndex, endIndex } = this.#getVisibleOptionRange(total, renderWidth, mdTheme);
 
 		for (let i = startIndex; i < endIndex; i++) {
-			const option = this.#filteredOptions[i];
-			if (option === undefined) continue;
-			lines.push(...this.#renderOptionLines(option, i === this.#selectedIndex, mdTheme));
+			const filtered = this.#filteredOptions[i];
+			if (filtered === undefined) continue;
+			const isSelected = i === this.#selectedIndex;
+			lines.push(...this.#renderOptionLines(filtered.option, isSelected, this.#isDisabled(filtered.index), mdTheme));
 		}
 
 		if (total === 0) {
@@ -389,10 +452,11 @@ export class HookSelectorComponent extends Container {
 
 	#setSearchQuery(query: string): void {
 		this.#searchQuery = query;
+		const indexedOptions = this.#options.map((option, index) => ({ option, index }));
 		this.#filteredOptions = query.trim()
-			? fuzzyFilter(this.#options, query, option => `${option.label} ${option.description ?? ""}`)
-			: this.#options;
-		this.#selectedIndex = 0;
+			? fuzzyFilter(indexedOptions, query, item => `${item.option.label} ${item.option.description ?? ""}`)
+			: indexedOptions;
+		this.#selectedIndex = this.#coerceSelectedIndex(0);
 		this.#updateList();
 	}
 
@@ -429,18 +493,12 @@ export class HookSelectorComponent extends Container {
 		}
 
 		if (matchesSelectUp(keyData) || (!this.#isSearchEnabled() && keyData === "k")) {
-			if (this.#filteredOptions.length > 0) {
-				this.#selectedIndex = Math.max(0, this.#selectedIndex - 1);
-				this.#updateList();
-			}
+			this.#moveSelection(-1);
 		} else if (matchesSelectDown(keyData) || (!this.#isSearchEnabled() && keyData === "j")) {
-			if (this.#filteredOptions.length > 0) {
-				this.#selectedIndex = Math.min(this.#filteredOptions.length - 1, this.#selectedIndex + 1);
-				this.#updateList();
-			}
+			this.#moveSelection(1);
 		} else if (matchesKey(keyData, "enter") || matchesKey(keyData, "return") || keyData === "\n") {
 			const selected = this.#filteredOptions[this.#selectedIndex];
-			if (selected) this.#onSelectCallback(selected.label);
+			if (selected && !this.#isDisabled(selected.index)) this.#onSelectCallback(selected.option.label);
 		} else if (matchesKey(keyData, "left") || (this.#slider && !this.#isSearchEnabled() && keyData === "h")) {
 			if (this.#slider) this.#moveSlider(-1);
 			else this.#onLeftCallback?.();

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -22,7 +22,7 @@ import { HookEditorComponent } from "../../modes/components/hook-editor";
 import { HookInputComponent } from "../../modes/components/hook-input";
 import { HookSelectorComponent, type HookSelectorSlider } from "../../modes/components/hook-selector";
 import { getAvailableThemesWithPaths, getThemeByName, setTheme, type Theme, theme } from "../../modes/theme/theme";
-import type { InteractiveModeContext } from "../../modes/types";
+import type { InteractiveModeContext, InteractiveSelectorDialogOptions } from "../../modes/types";
 import { setSessionTerminalTitle, setTerminalTitle } from "../../utils/title-generator";
 
 const MAX_WIDGET_LINES = 10;
@@ -583,7 +583,7 @@ export class ExtensionUiController {
 	showHookSelector(
 		title: string,
 		options: ExtensionUISelectItem[],
-		dialogOptions?: ExtensionUIDialogOptions,
+		dialogOptions?: InteractiveSelectorDialogOptions,
 		extra?: { slider?: HookSelectorSlider },
 	): Promise<string | undefined> {
 		const { promise, finish, attachAbort } = this.#createHookDialogState(
@@ -624,6 +624,7 @@ export class ExtensionUiController {
 				onTimeout: dialogOptions?.onTimeout,
 				tui: this.ctx.ui,
 				outline: dialogOptions?.outline,
+				disabledIndices: dialogOptions?.disabledIndices,
 				maxVisible,
 				slider: extra?.slider,
 			},

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -35,6 +35,7 @@ import {
 import {
 	APP_NAME,
 	adjustHsv,
+	formatNumber,
 	getProjectDir,
 	hsvToRgb,
 	isEnoent,
@@ -50,6 +51,7 @@ import { MODEL_ROLES, type ModelRole } from "../config/model-registry";
 import { isSettingsInitialized, Settings, settings } from "../config/settings";
 import { clearClaudePluginRootsCache } from "../discovery/helpers";
 import type {
+	ContextUsage,
 	ExtensionUIContext,
 	ExtensionUIDialogOptions,
 	ExtensionUISelectItem,
@@ -135,6 +137,7 @@ import type {
 	CompactionQueuedMessage,
 	InteractiveModeContext,
 	InteractiveModeInitOptions,
+	InteractiveSelectorDialogOptions,
 	SubmittedUserInput,
 	TodoItem,
 	TodoPhase,
@@ -210,6 +213,8 @@ function formatHudNoteMarker(count: number): string {
 type GoalSubcommand = "set" | "show" | "pause" | "resume" | "drop" | "budget";
 
 const GOAL_SUBCOMMANDS = new Set<GoalSubcommand>(["set", "show", "pause", "resume", "drop", "budget"]);
+const PLAN_KEEP_CONTEXT_OPTION_INDEX = 2;
+const PLAN_KEEP_CONTEXT_DISABLE_THRESHOLD_PERCENT = 95;
 
 function parseGoalSubcommand(args: string): { sub: GoalSubcommand | undefined; rest: string } {
 	const trimmed = args.trim();
@@ -221,6 +226,10 @@ function parseGoalSubcommand(args: string): { sub: GoalSubcommand | undefined; r
 		return { sub: first as GoalSubcommand, rest: match[2]?.trim() ?? "" };
 	}
 	return { sub: undefined, rest: trimmed };
+}
+
+function formatContextTokenCount(value: number): string {
+	return formatNumber(Math.max(0, Math.round(value))).toLowerCase();
 }
 
 /** Options for creating an InteractiveMode instance (for future API use) */
@@ -1651,6 +1660,28 @@ export class InteractiveMode implements InteractiveModeContext {
 		return `up/down navigate  enter select  ${externalEditorKey.toLowerCase()} open in editor  esc cancel`;
 	}
 
+	#getPlanApprovalContextUsage(): ContextUsage | undefined {
+		const executionModel = this.#planModePreviousModelState?.model ?? this.session.model;
+		const contextWindow = executionModel?.contextWindow;
+		if (typeof contextWindow === "number") {
+			return this.session.getContextUsage({ contextWindow });
+		}
+		return this.session.getContextUsage();
+	}
+
+	#formatKeepContextLabel(contextUsage: ContextUsage | undefined): string {
+		if (contextUsage?.tokens == null) {
+			return "Approve and keep context";
+		}
+		const tokens = formatContextTokenCount(contextUsage.tokens);
+		const contextWindow = formatContextTokenCount(contextUsage.contextWindow);
+		return `Approve and keep context (~${tokens} / ${contextWindow})`;
+	}
+
+	#isKeepContextDisabled(contextUsage: ContextUsage | undefined): boolean {
+		return contextUsage?.percent != null && contextUsage.percent > PLAN_KEEP_CONTEXT_DISABLE_THRESHOLD_PERCENT;
+	}
+
 	async #openPlanInExternalEditor(planFilePath: string): Promise<void> {
 		const editorCmd = getEditorCommand();
 		if (!editorCmd) {
@@ -2117,11 +2148,9 @@ export class InteractiveMode implements InteractiveModeContext {
 		}
 
 		this.#renderPlanPreview(planContent, { append: true });
-		const contextUsage = this.session.getContextUsage();
-		const keepContextLabel =
-			contextUsage?.percent != null
-				? `Approve and keep context (${contextUsage.percent.toFixed(1)}%)`
-				: "Approve and keep context";
+		const contextUsage = this.#getPlanApprovalContextUsage();
+		const keepContextLabel = this.#formatKeepContextLabel(contextUsage);
+		const keepContextDisabled = this.#isKeepContextDisabled(contextUsage);
 
 		// Model-tier slider: let the operator pick which configured role model
 		// (smol/default/slow/…) executes the approved plan. The slider always starts
@@ -2156,6 +2185,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			{
 				helpText,
 				onExternalEditor: () => void this.#openPlanInExternalEditor(planFilePath),
+				disabledIndices: keepContextDisabled ? [PLAN_KEEP_CONTEXT_OPTION_INDEX] : undefined,
 			},
 			{ slider },
 		);
@@ -2978,7 +3008,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	showHookSelector(
 		title: string,
 		options: ExtensionUISelectItem[],
-		dialogOptions?: ExtensionUIDialogOptions,
+		dialogOptions?: InteractiveSelectorDialogOptions,
 		extra?: { slider?: HookSelectorSlider },
 	): Promise<string | undefined> {
 		return this.#extensionUiController.showHookSelector(title, options, dialogOptions, extra);

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -25,7 +25,7 @@ import type { CustomEditor } from "./components/custom-editor";
 import type { EvalExecutionComponent } from "./components/eval-execution";
 import type { HookEditorComponent } from "./components/hook-editor";
 import type { HookInputComponent } from "./components/hook-input";
-import type { HookSelectorComponent } from "./components/hook-selector";
+import type { HookSelectorComponent, HookSelectorOptions } from "./components/hook-selector";
 import type { StatusLineComponent } from "./components/status-line";
 import type { ToolExecutionHandle } from "./components/tool-execution";
 import type { LoopLimitRuntime } from "./loop-limit";
@@ -63,6 +63,8 @@ export type TodoPhase = {
 export interface InteractiveModeInitOptions {
 	suppressWelcomeIntro?: boolean;
 }
+
+export type InteractiveSelectorDialogOptions = ExtensionUIDialogOptions & Pick<HookSelectorOptions, "disabledIndices">;
 
 export interface InteractiveModeContext {
 	// UI access
@@ -300,7 +302,7 @@ export interface InteractiveModeContext {
 	showHookSelector(
 		title: string,
 		options: ExtensionUISelectItem[],
-		dialogOptions?: ExtensionUIDialogOptions,
+		dialogOptions?: InteractiveSelectorDialogOptions,
 	): Promise<string | undefined>;
 	hideHookSelector(): void;
 	showHookInput(title: string, placeholder?: string): Promise<string | undefined>;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -9202,12 +9202,10 @@ export class AgentSession {
 	 * Uses the last assistant message's usage data when available,
 	 * otherwise estimates tokens for all messages.
 	 */
-	getContextUsage(): ContextUsage | undefined {
+	getContextUsage(options?: { contextWindow?: number }): ContextUsage | undefined {
 		const model = this.model;
-		if (!model) return undefined;
-
-		const contextWindow = model.contextWindow ?? 0;
-		if (contextWindow <= 0) return undefined;
+		const contextWindow = options?.contextWindow ?? model?.contextWindow ?? 0;
+		if (!Number.isFinite(contextWindow) || contextWindow <= 0) return undefined;
 
 		// After compaction, the last assistant usage reflects pre-compaction context size.
 		// We can only trust usage from an assistant that responded after the latest compaction.
@@ -9265,7 +9263,7 @@ export class AgentSession {
 	} {
 		const messages = this.messages;
 
-		// Find last assistant message with usage
+		// Find last assistant message with valid usage.
 		let lastUsageIndex: number | null = null;
 		let lastUsage: Usage | undefined;
 		for (let i = messages.length - 1; i >= 0; i--) {

--- a/packages/coding-agent/test/hook-selector-overflow.test.ts
+++ b/packages/coding-agent/test/hook-selector-overflow.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import { HookSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/hook-selector";
-import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { getThemeByName, setThemeInstance, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { visibleWidth } from "@oh-my-pi/pi-tui";
 
 beforeAll(async () => {
@@ -171,5 +171,52 @@ describe("HookSelectorComponent", () => {
 		expect(plain).toContain("Path B");
 		expect(plain).toContain("Launch a browser flow");
 		expect(plain).not.toContain("Path A");
+	});
+
+	it("skips disabled options during keyboard navigation", () => {
+		let selected: string | undefined;
+		const component = new HookSelectorComponent(
+			"Pick one",
+			["First", "Disabled", "Third"],
+			option => {
+				selected = option;
+			},
+			() => {},
+			{ disabledIndices: [1] },
+		);
+
+		component.handleInput("j");
+		component.handleInput("\n");
+
+		expect(selected).toBe("Third");
+	});
+
+	it("does not select disabled options", () => {
+		let selected: string | undefined;
+		const component = new HookSelectorComponent(
+			"Pick one",
+			["Disabled"],
+			option => {
+				selected = option;
+			},
+			() => {},
+			{ disabledIndices: [0] },
+		);
+
+		component.handleInput("\n");
+
+		expect(selected).toBeUndefined();
+	});
+
+	it("renders disabled options dimmed", () => {
+		const component = new HookSelectorComponent(
+			"Pick one",
+			["First", "Disabled"],
+			() => {},
+			() => {},
+			{ disabledIndices: [1] },
+		);
+
+		expect(component.render(80).join("\n")).toContain(theme.fg("dim", "Disabled"));
 	});
 });

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -1,14 +1,14 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
-import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, Usage } from "@oh-my-pi/pi-ai";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
 import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { SILENT_ABORT_MARKER } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { Text } from "@oh-my-pi/pi-tui";
-import { TempDir } from "@oh-my-pi/pi-utils";
+import { formatNumber, TempDir } from "@oh-my-pi/pi-utils";
 import { ModelRegistry } from "../src/config/model-registry";
 import type { HookSelectorSlider } from "../src/modes/components/hook-selector";
 import { InteractiveMode } from "../src/modes/interactive-mode";
@@ -28,6 +28,35 @@ const isPlanApprovedCall = (args: unknown[]): boolean =>
 	args[1] !== null &&
 	(args[1] as { synthetic?: boolean }).synthetic === true;
 
+function usageWithInput(input: number): Usage {
+	return {
+		input,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: input,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+function assistantWithUsage(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "test",
+		usage: usageWithInput(0),
+		stopReason: "stop",
+		timestamp: Date.now(),
+		...overrides,
+	};
+}
+
+function compactNumber(value: number): string {
+	return formatNumber(value).toLowerCase();
+}
+
 describe("InteractiveMode plan review rendering", () => {
 	let tempDir: TempDir;
 	let authStorage: AuthStorage;
@@ -44,6 +73,7 @@ describe("InteractiveMode plan review rendering", () => {
 		tempDir = TempDir.createSync("@pi-plan-review-");
 		await Settings.init({ inMemory: true, cwd: tempDir.path() });
 		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
 		const modelRegistry = new ModelRegistry(authStorage);
 		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
 		if (!model) {
@@ -150,9 +180,141 @@ describe("InteractiveMode plan review rendering", () => {
 
 		expect(selector).toHaveBeenCalledWith(
 			"Plan mode - next step",
-			["Approve and execute", "Approve and compact context", "Approve and keep context (73.2%)", "Refine plan"],
+			[
+				"Approve and execute",
+				"Approve and compact context",
+				"Approve and keep context (~7.3k / 10k)",
+				"Refine plan",
+			],
 			expect.any(Object),
 			expect.any(Object),
+		);
+	});
+
+	it("ignores aborted zero-usage assistant messages when estimating context usage", () => {
+		session.agent.appendMessage(assistantWithUsage({ usage: usageWithInput(7320), stopReason: "stop" }));
+		session.agent.appendMessage(assistantWithUsage({ usage: usageWithInput(0), stopReason: "aborted" }));
+
+		expect(session.getContextUsage({ contextWindow: 10000 })).toMatchObject({
+			tokens: 7320,
+			contextWindow: 10000,
+			percent: 73.2,
+		});
+	});
+
+	it("measures keep-context approval against the execution model restored after plan mode", async () => {
+		mode.stop();
+		await session.dispose();
+
+		const modelRegistry = new ModelRegistry(authStorage);
+		const executionModel = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		const planModel = modelRegistry.find("anthropic", "claude-opus-4-6");
+		if (!executionModel?.contextWindow || !planModel?.contextWindow) {
+			throw new Error("Expected test models with context windows");
+		}
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model: executionModel,
+					systemPrompt: ["Test"],
+					tools: [],
+					messages: [],
+				},
+			}),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated({ modelRoles: { plan: `anthropic/${planModel.id}` } }),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+
+		await mode.handlePlanModeCommand();
+		expect(session.model?.id).toBe(planModel.id);
+
+		const planFilePath = mode.planModePlanFilePath ?? "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nUse execution context.");
+
+		const tokens = 180000;
+		const contextSpy = vi.spyOn(session, "getContextUsage").mockImplementation(options => {
+			const contextWindow = options?.contextWindow ?? 0;
+			return {
+				tokens,
+				contextWindow,
+				percent: (tokens / contextWindow) * 100,
+			};
+		});
+		const selector = vi.spyOn(mode, "showHookSelector").mockResolvedValue("Refine plan");
+
+		await mode.handlePlanApproval({
+			planFilePath,
+			planExists: true,
+			title: "PLAN",
+			finalPlanFilePath: "local://APPROVED.md",
+		});
+
+		expect(contextSpy).toHaveBeenCalledWith({ contextWindow: executionModel.contextWindow });
+		expect(selector.mock.calls[0]?.[1]).toEqual([
+			"Approve and execute",
+			"Approve and compact context",
+			`Approve and keep context (~${compactNumber(tokens)} / ${compactNumber(executionModel.contextWindow)})`,
+			"Refine plan",
+		]);
+	});
+
+	it("disables keep-context approval when execution context usage is above ninety-five percent", async () => {
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nToo much context.");
+
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+		vi.spyOn(session, "getContextUsage").mockReturnValue({ tokens: 9600, contextWindow: 10000, percent: 96 });
+		const selector = vi.spyOn(mode, "showHookSelector").mockResolvedValue("Refine plan");
+
+		await mode.handlePlanApproval({
+			planFilePath,
+			planExists: true,
+			title: "PLAN",
+			finalPlanFilePath: "local://APPROVED.md",
+		});
+
+		expect(selector.mock.calls[0]?.[2]).toEqual(
+			expect.objectContaining({
+				disabledIndices: [2],
+			}),
+		);
+	});
+
+	it("keeps keep-context approval enabled at exactly ninety-five percent", async () => {
+		const planFilePath = "local://PLAN.md";
+		const resolvedPlanPath = resolveLocalUrlToPath(planFilePath, {
+			getArtifactsDir: () => session.sessionManager.getArtifactsDir(),
+			getSessionId: () => session.sessionManager.getSessionId(),
+		});
+		await Bun.write(resolvedPlanPath, "# Plan\n\nAt the threshold.");
+
+		mode.planModeEnabled = true;
+		mode.planModePlanFilePath = planFilePath;
+		vi.spyOn(session, "getContextUsage").mockReturnValue({ tokens: 9500, contextWindow: 10000, percent: 95 });
+		const selector = vi.spyOn(mode, "showHookSelector").mockResolvedValue("Refine plan");
+
+		await mode.handlePlanApproval({
+			planFilePath,
+			planExists: true,
+			title: "PLAN",
+			finalPlanFilePath: "local://APPROVED.md",
+		});
+
+		expect(selector.mock.calls[0]?.[2]).toEqual(
+			expect.objectContaining({
+				disabledIndices: undefined,
+			}),
 		);
 	});
 


### PR DESCRIPTION
 ## What

  Updates the plan approval “Approve and keep context” option so it reports preserved context against the model that will actually execute the approved plan.

  Changes included:

  - Show keep-context usage as approximate token/window usage, e.g. `Approve and keep context (~250k / 262k)`, instead of a percentage.
  - Calculate that usage against the execution model restored after leaving plan mode, rather than the temporary plan-mode model.
  - Ignore aborted/error assistant messages when choosing the latest trusted usage baseline, preventing bogus `0.0%` context readings after the plan approval
  abort bookkeeping.
  - Disable and dim the keep-context option when projected usage is strictly above 95% of the execution model’s context window.
  - Add internal disabled-option support to the hook selector so disabled rows are visible, skipped during navigation, and cannot be selected.

  ## Why

  Plan mode can run on a larger-context model than the model used for execution. In that setup, the previous percentage label could make a preserved context look
  safe relative to the plan model even though it nearly filled the execution model.

  There was also a separate edge case where the approval flow’s abort could append a zero-usage aborted assistant message. The context estimator treated that as
  the latest valid usage, which could surface a clearly bogus `0.0%` reading despite substantial existing context.

  This makes the approval choice reflect the context budget the execution turn will actually have.

  ## Testing

  - `npx --yes bun@1.3.14 test packages/coding-agent/test/interactive-mode-plan-review.test.ts packages/coding-agent/test/hook-selector-overflow.test.ts`
  - `npx --yes bun@1.3.14 check`
  - Compiled a local `omp` binary from `dev` and installed it over `/Users/aurop/.local/bin/omp` for manual testing.

  ---

  - [x] `bun check` passes
  - [x] Tested locally
  - [x] CHANGELOG updated (if user-facing)
