### PR TITLE
fix(tui): keep slash autocomplete repainting on unknown viewport

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed slash-command autocomplete repaint requests so Windows Terminal sessions with unknown native viewport state keep updating the input box and candidate list. ([#1550](https://github.com/can1357/oh-my-pi/issues/1550))
+
 ## [15.6.0] - 2026-05-30
 ### Added
 

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -368,7 +368,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.ui.requestRender(true);
 		};
 		this.editor.onAutocompleteUpdate = () => {
-			this.ui.requestRender();
+			this.ui.requestRender(false, { allowUnknownViewportMutation: true });
 		};
 		this.#syncEditorMaxHeight();
 		this.#resizeHandler = () => {
@@ -2259,7 +2259,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.ui.requestRender(true);
 		};
 		nextEditor.onAutocompleteUpdate = () => {
-			this.ui.requestRender();
+			this.ui.requestRender(false, { allowUnknownViewportMutation: true });
 		};
 		nextEditor.setMaxHeight(this.#computeEditorMaxHeight());
 		if (this.historyStorage) {

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed slash-command autocomplete repainting when a Windows Terminal session cannot report native scrollback position; live input renders can now bypass the unknown-viewport deferral without weakening background scrollback protection. ([#1550](https://github.com/can1357/oh-my-pi/issues/1550))
+
 ## [15.6.0] - 2026-05-30
 ### Added
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -84,7 +84,17 @@ export interface Focusable {
 export interface RenderRequestOptions {
 	/** Clear terminal scrollback for intentional transcript replacement. */
 	clearScrollback?: boolean;
-	/** Render visible live UI edits even when Windows cannot report native scrollback position. */
+	/**
+	 * Bypass the unknown-Windows-viewport deferral for this render so the
+	 * caller's intentional live UI mutation reaches the terminal even when
+	 * `Terminal#isNativeViewportAtBottom()` cannot answer.
+	 *
+	 * Use only for renders driven by direct user interaction (autocomplete
+	 * updates, IME, etc.). Any background/offscreen transcript change that
+	 * coalesces into the same frame WILL also bypass the deferral and reach
+	 * native scrollback — that is the trade-off, and the reason ordinary
+	 * `requestRender()` calls must continue to omit this flag.
+	 */
 	allowUnknownViewportMutation?: boolean;
 }
 
@@ -1259,8 +1269,6 @@ export class TUI extends Container {
 		// repainting rewrites old buffer rows with newly bottom-anchored content,
 		// which looks like a jump upward.
 		const naturalViewportTop = Math.max(0, newLines.length - height);
-		const allowUnknownViewportVisibleMutation =
-			allowUnknownViewportMutation && diff.firstChanged !== -1 && diff.firstChanged >= prevViewportTop;
 		if (
 			diff.firstChanged !== -1 &&
 			newLines.length < this.#previousLines.length &&
@@ -1268,16 +1276,14 @@ export class TUI extends Container {
 			!isMultiplexerSession()
 		) {
 			if (widthChanged || heightChanged) {
-				if (
-					this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom(), allowUnknownViewportVisibleMutation)
-				) {
+				if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom(), allowUnknownViewportMutation)) {
 					this.#markNativeScrollbackDirty();
 					return { kind: "deferredShrink", paddedLength: this.#previousLines.length };
 				}
 				return { kind: "historyRebuild" };
 			}
 			this.#markNativeScrollbackDirty();
-			if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom(), allowUnknownViewportVisibleMutation)) {
+			if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom(), allowUnknownViewportMutation)) {
 				return { kind: "deferredShrink", paddedLength: this.#previousLines.length };
 			}
 			return { kind: "viewportRepaint" };
@@ -1309,9 +1315,7 @@ export class TUI extends Container {
 		// through to the diff path so the append handler scrolls them into history.
 		if (widthChanged) {
 			if (diff.firstChanged < prevViewportTop) {
-				if (
-					this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom(), allowUnknownViewportVisibleMutation)
-				) {
+				if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom(), allowUnknownViewportMutation)) {
 					this.#markNativeScrollbackDirty();
 					return { kind: "viewportRepaint" };
 				}
@@ -1326,7 +1330,7 @@ export class TUI extends Container {
 		const structuralMutation = newLines.length !== this.#previousLines.length || diff.firstChanged < prevViewportTop;
 		if (!pureAppend && structuralMutation && !isMultiplexerSession()) {
 			const nativeViewportAtBottom = this.#readNativeViewportAtBottom();
-			if (this.#nativeViewportIsScrolled(nativeViewportAtBottom, allowUnknownViewportVisibleMutation)) {
+			if (this.#nativeViewportIsScrolled(nativeViewportAtBottom, allowUnknownViewportMutation)) {
 				this.#markNativeScrollbackDirty();
 				return { kind: "deferredMutation" };
 			}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -84,6 +84,8 @@ export interface Focusable {
 export interface RenderRequestOptions {
 	/** Clear terminal scrollback for intentional transcript replacement. */
 	clearScrollback?: boolean;
+	/** Render live UI edits even when Windows cannot report native scrollback position. */
+	allowUnknownViewportMutation?: boolean;
 }
 
 /** Options for deferred native scrollback rebuild checkpoints. */
@@ -316,6 +318,7 @@ export class TUI extends Container {
 	#nativeScrollbackDirty = false;
 	#fullRedrawCount = 0;
 	#clearScrollbackOnNextRender = false;
+	#allowUnknownViewportMutationOnNextRender = false;
 	#hasEverRendered = false;
 	#stopped = false;
 
@@ -670,6 +673,7 @@ export class TUI extends Container {
 	}
 
 	requestRender(force = false, options?: RenderRequestOptions): void {
+		this.#allowUnknownViewportMutationOnNextRender ||= options?.allowUnknownViewportMutation === true;
 		if (force) {
 			this.#prepareForcedRender(options?.clearScrollback === true);
 			this.#renderRequested = true;
@@ -774,7 +778,7 @@ export class TUI extends Container {
 				return;
 			}
 			this.#focusedComponent.handleInput(data);
-			this.requestRender();
+			this.requestRender(false, { allowUnknownViewportMutation: true });
 		}
 	}
 
@@ -1138,11 +1142,19 @@ export class TUI extends Container {
 		const prevHardwareCursorRow = this.#hardwareCursorRow;
 		const widthChanged = this.#previousWidth > 0 && this.#previousWidth !== width;
 		const heightChanged = this.#previousHeight > 0 && this.#previousHeight !== height;
+		const allowUnknownViewportMutation = this.#allowUnknownViewportMutationOnNextRender;
+		this.#allowUnknownViewportMutationOnNextRender = false;
 
 		// 3. Classify intent.
-		const intent = this.#planRender(lines, widthChanged, heightChanged, prevViewportTop, height);
+		const intent = this.#planRender(
+			lines,
+			widthChanged,
+			heightChanged,
+			prevViewportTop,
+			height,
+			allowUnknownViewportMutation,
+		);
 		this.#logRedraw(intent, lines.length, height);
-
 		// 4. Execute.
 		switch (intent.kind) {
 			case "noop":
@@ -1219,6 +1231,7 @@ export class TUI extends Container {
 		heightChanged: boolean,
 		prevViewportTop: number,
 		height: number,
+		allowUnknownViewportMutation: boolean,
 	): RenderIntent {
 		// Initial paint after start(): scrollback must keep its prior shell
 		// content, but the viewport must be cleared so stale rows do not bleed
@@ -1253,14 +1266,14 @@ export class TUI extends Container {
 			!isMultiplexerSession()
 		) {
 			if (widthChanged || heightChanged) {
-				if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom())) {
+				if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom(), allowUnknownViewportMutation)) {
 					this.#markNativeScrollbackDirty();
 					return { kind: "deferredShrink", paddedLength: this.#previousLines.length };
 				}
 				return { kind: "historyRebuild" };
 			}
 			this.#markNativeScrollbackDirty();
-			if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom())) {
+			if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom(), allowUnknownViewportMutation)) {
 				return { kind: "deferredShrink", paddedLength: this.#previousLines.length };
 			}
 			return { kind: "viewportRepaint" };
@@ -1292,7 +1305,7 @@ export class TUI extends Container {
 		// through to the diff path so the append handler scrolls them into history.
 		if (widthChanged) {
 			if (diff.firstChanged < prevViewportTop) {
-				if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom())) {
+				if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom(), allowUnknownViewportMutation)) {
 					this.#markNativeScrollbackDirty();
 					return { kind: "viewportRepaint" };
 				}
@@ -1307,7 +1320,7 @@ export class TUI extends Container {
 		const structuralMutation = newLines.length !== this.#previousLines.length || diff.firstChanged < prevViewportTop;
 		if (!pureAppend && structuralMutation && !isMultiplexerSession()) {
 			const nativeViewportAtBottom = this.#readNativeViewportAtBottom();
-			if (this.#nativeViewportIsScrolled(nativeViewportAtBottom)) {
+			if (this.#nativeViewportIsScrolled(nativeViewportAtBottom, allowUnknownViewportMutation)) {
 				this.#markNativeScrollbackDirty();
 				return { kind: "deferredMutation" };
 			}
@@ -1430,8 +1443,14 @@ export class TUI extends Container {
 		return this.terminal.isNativeViewportAtBottom?.();
 	}
 
-	#nativeViewportIsScrolled(nativeViewportAtBottom: boolean | undefined): boolean {
-		return nativeViewportAtBottom === false || (nativeViewportAtBottom === undefined && process.platform === "win32");
+	#nativeViewportIsScrolled(
+		nativeViewportAtBottom: boolean | undefined,
+		allowUnknownViewportMutation = false,
+	): boolean {
+		return (
+			nativeViewportAtBottom === false ||
+			(nativeViewportAtBottom === undefined && process.platform === "win32" && !allowUnknownViewportMutation)
+		);
 	}
 
 	#nativeViewportIsAtBottom(nativeViewportAtBottom: boolean | undefined): boolean {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -84,7 +84,7 @@ export interface Focusable {
 export interface RenderRequestOptions {
 	/** Clear terminal scrollback for intentional transcript replacement. */
 	clearScrollback?: boolean;
-	/** Render live UI edits even when Windows cannot report native scrollback position. */
+	/** Render visible live UI edits even when Windows cannot report native scrollback position. */
 	allowUnknownViewportMutation?: boolean;
 }
 
@@ -778,7 +778,7 @@ export class TUI extends Container {
 				return;
 			}
 			this.#focusedComponent.handleInput(data);
-			this.requestRender(false, { allowUnknownViewportMutation: true });
+			this.requestRender();
 		}
 	}
 
@@ -1259,6 +1259,8 @@ export class TUI extends Container {
 		// repainting rewrites old buffer rows with newly bottom-anchored content,
 		// which looks like a jump upward.
 		const naturalViewportTop = Math.max(0, newLines.length - height);
+		const allowUnknownViewportVisibleMutation =
+			allowUnknownViewportMutation && diff.firstChanged !== -1 && diff.firstChanged >= prevViewportTop;
 		if (
 			diff.firstChanged !== -1 &&
 			newLines.length < this.#previousLines.length &&
@@ -1266,14 +1268,16 @@ export class TUI extends Container {
 			!isMultiplexerSession()
 		) {
 			if (widthChanged || heightChanged) {
-				if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom(), allowUnknownViewportMutation)) {
+				if (
+					this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom(), allowUnknownViewportVisibleMutation)
+				) {
 					this.#markNativeScrollbackDirty();
 					return { kind: "deferredShrink", paddedLength: this.#previousLines.length };
 				}
 				return { kind: "historyRebuild" };
 			}
 			this.#markNativeScrollbackDirty();
-			if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom(), allowUnknownViewportMutation)) {
+			if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom(), allowUnknownViewportVisibleMutation)) {
 				return { kind: "deferredShrink", paddedLength: this.#previousLines.length };
 			}
 			return { kind: "viewportRepaint" };
@@ -1305,7 +1309,9 @@ export class TUI extends Container {
 		// through to the diff path so the append handler scrolls them into history.
 		if (widthChanged) {
 			if (diff.firstChanged < prevViewportTop) {
-				if (this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom(), allowUnknownViewportMutation)) {
+				if (
+					this.#nativeViewportIsScrolled(this.#readNativeViewportAtBottom(), allowUnknownViewportVisibleMutation)
+				) {
 					this.#markNativeScrollbackDirty();
 					return { kind: "viewportRepaint" };
 				}
@@ -1320,7 +1326,7 @@ export class TUI extends Container {
 		const structuralMutation = newLines.length !== this.#previousLines.length || diff.firstChanged < prevViewportTop;
 		if (!pureAppend && structuralMutation && !isMultiplexerSession()) {
 			const nativeViewportAtBottom = this.#readNativeViewportAtBottom();
-			if (this.#nativeViewportIsScrolled(nativeViewportAtBottom, allowUnknownViewportMutation)) {
+			if (this.#nativeViewportIsScrolled(nativeViewportAtBottom, allowUnknownViewportVisibleMutation)) {
 				this.#markNativeScrollbackDirty();
 				return { kind: "deferredMutation" };
 			}

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -45,6 +45,25 @@ class WrappingLinesComponent implements Component {
 	}
 }
 
+class FocusedInputComponent implements Component, Focusable {
+	focused = false;
+	#onInput: () => void;
+
+	constructor(onInput: () => void) {
+		this.#onInput = onInput;
+	}
+
+	handleInput(): void {
+		this.#onInput();
+	}
+
+	invalidate(): void {}
+
+	render(): string[] {
+		return [this.focused ? `prompt>${CURSOR_MARKER}` : "prompt>"];
+	}
+}
+
 class UnknownViewportTerminal extends VirtualTerminal {
 	isNativeViewportAtBottom(): undefined {
 		return undefined;
@@ -1149,6 +1168,39 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 
+		it("keeps the unknown Windows viewport guard on ordinary focused input", async () => {
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+			const term = new UnknownViewportTerminal(32, 5);
+			const tui = new TUI(term);
+			const transcript = new MutableLinesComponent(rows("line-", 12));
+			const input = new FocusedInputComponent(() => {
+				transcript.setLines([...rows("line-", 6), "typed-token", ...rows("line-", 12).slice(6)]);
+			});
+			tui.addChild(transcript);
+			tui.addChild(input);
+			tui.setFocus(input);
+
+			try {
+				tui.start();
+				await settle(term);
+				term.scrollLines(-2);
+				const before = term.getBufferPosition();
+				const beforeViewport = visible(term).map(line => line.trim());
+				expect(before.viewportY).toBeGreaterThan(0);
+
+				term.sendInput("x");
+				await settle(term);
+
+				const after = term.getBufferPosition();
+				expect(after.viewportY).toBe(before.viewportY);
+				expect(visible(term).map(line => line.trim())).toEqual(beforeViewport);
+				expect(term.getScrollBuffer().join("\n")).not.toContain("typed-token");
+			} finally {
+				Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+				tui.stop();
+			}
+		});
 		it("renders streaming row inserts on WSL Windows Terminal even when viewport probe is unavailable", async () => {
 			const originalPlatform = process.platform;
 			Object.defineProperty(process, "platform", { configurable: true, value: "linux" });

--- a/packages/tui/test/slash-autocomplete-viewport.test.ts
+++ b/packages/tui/test/slash-autocomplete-viewport.test.ts
@@ -74,4 +74,45 @@ describe("slash command autocomplete with unknown native viewport state", () => 
 			else Bun.env.WT_SESSION = originalWtSession;
 		}
 	});
+
+	it("repaints autocomplete updates coalesced with offscreen background mutations", async () => {
+		const originalPlatform = process.platform;
+		const originalWtSession = Bun.env.WT_SESSION;
+		Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+		Bun.env.WT_SESSION = "wt-test";
+		const term = new UnknownViewportTerminal(40, 6);
+		const tui = new TUI(term);
+		const root = new Container();
+		let transcriptCounter = 0;
+		const transcriptLines = () => Array.from({ length: 8 }, (_v, i) => `chat-${i}-${transcriptCounter}`);
+		const transcript = { invalidate() {}, render: () => transcriptLines() };
+		root.addChild(transcript);
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(new SlashProvider());
+		editor.onAutocompleteUpdate = () => tui.requestRender(false, { allowUnknownViewportMutation: true });
+		root.addChild(editor);
+		tui.addChild(root);
+		tui.setFocus(editor);
+
+		try {
+			tui.start();
+			await settle(term);
+			for (const char of "/mo") {
+				// Bump a background row above the viewport in the same render tick as the
+				// autocomplete prefix change. `diff.firstChanged` will point at the
+				// background row, so the bypass MUST still kick in for the live UI rows.
+				transcriptCounter += 1;
+				term.sendInput(char);
+				await settle(term);
+				const viewport = term.getViewport().join("\n");
+				expect(viewport).toContain(editor.getText());
+			}
+			expect(editor.getText()).toBe("/mo");
+		} finally {
+			tui.stop();
+			Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+			if (originalWtSession === undefined) delete Bun.env.WT_SESSION;
+			else Bun.env.WT_SESSION = originalWtSession;
+		}
+	});
 });

--- a/packages/tui/test/slash-autocomplete-viewport.test.ts
+++ b/packages/tui/test/slash-autocomplete-viewport.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { Container, Editor, TUI } from "@oh-my-pi/pi-tui";
+import type { AutocompleteItem, AutocompleteProvider } from "@oh-my-pi/pi-tui/autocomplete";
+import { defaultEditorTheme } from "./test-themes";
+import { VirtualTerminal } from "./virtual-terminal";
+
+class SlashProvider implements AutocompleteProvider {
+	async getSuggestions(
+		lines: string[],
+		cursorLine: number,
+		cursorCol: number,
+	): Promise<{ items: AutocompleteItem[]; prefix: string } | null> {
+		const text = (lines[cursorLine] ?? "").slice(0, cursorCol);
+		if (!text.startsWith("/")) return null;
+		const prefix = text.slice(1).toLowerCase();
+		const commands = ["model", "settings", "skill:semantic-compression", "status", "stats", "stop"];
+		const items = commands
+			.filter(command => command.includes(prefix))
+			.map(command => ({ value: command, label: command }));
+		return items.length > 0 ? { prefix: text, items } : null;
+	}
+
+	applyCompletion(lines: string[], cursorLine: number, cursorCol: number, item: AutocompleteItem, prefix: string) {
+		const line = lines[cursorLine] ?? "";
+		const next = [...lines];
+		next[cursorLine] = `${line.slice(0, cursorCol - prefix.length)}/${item.value} ${line.slice(cursorCol)}`;
+		return { lines: next, cursorLine, cursorCol: item.value.length + 2 };
+	}
+}
+
+class UnknownViewportTerminal extends VirtualTerminal {
+	isNativeViewportAtBottom(): undefined {
+		return undefined;
+	}
+}
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	await new Promise<void>(resolve => process.nextTick(resolve));
+	await Bun.sleep(120);
+	await term.flush();
+}
+
+describe("slash command autocomplete with unknown native viewport state", () => {
+	it("keeps repainting the editor while the autocomplete list changes height", async () => {
+		const originalPlatform = process.platform;
+		const originalWtSession = Bun.env.WT_SESSION;
+		Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+		Bun.env.WT_SESSION = "wt-test";
+		const term = new UnknownViewportTerminal(40, 8);
+		const tui = new TUI(term);
+		const root = new Container();
+		root.addChild({ invalidate() {}, render: () => ["chat-0", "chat-1", "chat-2", "chat-3", "chat-4", "chat-5"] });
+		const editor = new Editor(defaultEditorTheme);
+		editor.setAutocompleteProvider(new SlashProvider());
+		editor.onAutocompleteUpdate = () => tui.requestRender(false, { allowUnknownViewportMutation: true });
+		root.addChild(editor);
+		tui.addChild(root);
+		tui.setFocus(editor);
+
+		try {
+			tui.start();
+			await settle(term);
+			for (const char of "/model") {
+				term.sendInput(char);
+				await settle(term);
+				const viewport = term.getViewport().join("\n");
+				expect(viewport).toContain(editor.getText());
+			}
+			expect(editor.getText()).toBe("/model");
+		} finally {
+			tui.stop();
+			Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+			if (originalWtSession === undefined) delete Bun.env.WT_SESSION;
+			else Bun.env.WT_SESSION = originalWtSession;
+		}
+	});
+});


### PR DESCRIPTION
## Repro
Typing a slash command prefix while autocomplete is active can change the prompt height before command submission. I reproduced the failure with `bun test packages/tui/test/slash-autocomplete-viewport.test.ts`: before the fix, the viewport still showed the empty prompt border after `/` because the live input render was classified as a deferred mutation.

## Cause
`packages/tui/src/tui.ts` treated unknown native viewport state on Windows as scrolled history for every structural mutation, so prompt/autocomplete row changes could return the `deferredMutation` intent and emit no bytes. `packages/coding-agent/src/modes/interactive-mode.ts` also requested ordinary renders for autocomplete updates, so those frames did not identify themselves as live input UI.

## Fix
- Added a one-shot `allowUnknownViewportMutation` render option for live UI input renders in `packages/tui/src/tui.ts`.
- Marked focused-component input renders and coding-agent autocomplete update renders with that option.
- Added a slash autocomplete regression test covering unknown native viewport state and changing autocomplete height.
- Added changelog entries for `packages/tui` and `packages/coding-agent`.

## Verification
Passed: `bun test packages/tui/test/slash-autocomplete-viewport.test.ts packages/tui/test/render-regressions.test.ts`; `bun --cwd=packages/tui run check`; `bun --cwd=packages/coding-agent run check`. `gh_push_branch` pre-publish gate also passed. Fixes #1550