### PR TITLE
coding-agent: add workflow tool for dynamic multi-agent orchestration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -64,6 +64,7 @@
         "@puppeteer/browsers": "catalog:",
         "@types/turndown": "catalog:",
         "@xterm/headless": "catalog:",
+        "acorn": "catalog:",
         "chalk": "catalog:",
         "diff": "catalog:",
         "fflate": "catalog:",
@@ -264,6 +265,7 @@
     "@types/turndown": "5.0.6",
     "@typescript/native-preview": "7.0.0-dev.20260527.1",
     "@xterm/headless": "^6.0.0",
+    "acorn": "^8.16.0",
     "beautiful-mermaid": "^1.1.3",
     "chalk": "^5.6.2",
     "chart.js": "^4.5.1",
@@ -794,6 +796,8 @@
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
 
     "@xterm/headless": ["@xterm/headless@6.0.0", "", {}, "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
       "python/robomp/web"
     ],
     "catalog": {
+      "acorn": "^8.16.0",
       "@agentclientprotocol/sdk": "0.22.1",
       "@anthropic-ai/sdk": "^0.99.0",
       "@babel/generator": "^7.29.7",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,15 +4,37 @@
 
 ### Added
 - Added a `workflow` tool that lets the model write deterministic JavaScript scripts to orchestrate multiple subagents with `agent()`, `parallel()`, `pipeline()`, `phase()`, and `log()` primitives. Scripts are sandboxed in `node:vm` and validated with `acorn` AST parsing. The tool is discoverable (`loadMode: discoverable`) and gated by the `workflow.enabled` setting (default true). ([#1544](https://github.com/can1357/oh-my-pi/issues/1544))
+
+## [15.7.0] - 2026-05-31
+
+### Added
+- Added a `Web search` setup tab that lets users choose the preferred `providers.webSearch` provider during onboarding
+- Added manual authorization-code/redirect URL prompts for OAuth providers that require non-callback login in the setup wizard
 - Added an `omp completions <bash|zsh|fish>` command that prints a shell completion script generated from the live command/flag metadata, so completions never drift from the actual CLI. Subcommands, flags, and enum values complete statically; `--model`/`--smol`/`--slow`/`--plan` resolve against the bundled model catalog and `--resume` against on-disk sessions via a hidden `__complete` helper.
+- Added a `/switch` slash command that opens the temporary model selector for the current session, mirroring the `alt+p` keybinding.
+- Added `replace block N:` and `delete block N` operators to the `edit` tool: they resolve the syntactic block beginning on line N via tree-sitter (native `blockRangeAt`) and replace or delete its full line span, so a construct can be rewritten or removed without counting its closing line. Unresolvable blocks (unsupported language, blank/closing-delimiter line, or a parse error) are rejected with guidance to use an explicit `replace N..M:` / `delete N..M` range.
+- Added an animated pending border for `bash` and `eval` execution blocks: while a command/cell is running, a single dark segment glides clockwise around the block's outer edge (top → right → bottom → left), replacing the previous static accent border. Motion is eased per edge (decelerating into each corner) and timed against a fixed lap duration mapped onto the live perimeter, so streaming a new output line or resizing the terminal nudges the segment proportionally instead of resetting its position. Driven by the existing spinner cadence and gated on the `display.shimmer` setting (no motion when `disabled`).
+- Added `providers.tinyModelDevice` and `providers.tinyModelDtype` settings (Providers tab) controlling local tiny-model acceleration for session titles and Mnemosyne memory tasks. `providers.tinyModelDevice` selects the ONNX execution provider (`default` keeps the platform pick — DirectML on Windows, CUDA on Linux x64, CPU elsewhere); `providers.tinyModelDtype` selects quantization/precision (`default` keeps each model's shipped `q4`, e.g. `fp16` trades speed for fidelity). The `PI_TINY_DEVICE` / `PI_TINY_DTYPE` env vars override the matching setting. Also added `PI_TINY_DTYPE` as the env counterpart to `PI_TINY_DEVICE`; an unrecognized device/precision fails loudly at worker startup instead of silently loading a different one.
+- Added a bundled set of default rules shipped with the agent (TypeScript/Rust convention rules registered as TTSR conditions). They load via the new lowest-priority `builtin-defaults` discovery provider, so any user/project/tool rule of the same name overrides the bundled copy. Disable the whole set with `ttsr.builtinRules: false`, or drop individual rules (bundled or your own) by name via `ttsr.disabledRules`.
+
+### Changed
+- Changed setup onboarding to a tabbed `Set up your providers` scene with dedicated `Sign in` and `Web search` panels
+- Changed the glyph mode picker to preselect the currently configured symbol preset instead of always defaulting to Unicode and to show live glyph samples in the picker rows
+- Changed OAuth sign-in flow in the setup wizard so users can authenticate multiple providers before leaving with Escape
+- Changed the plan-approval model-tier slider and the `ctrl+p`/`alt+p` role-cycle status to share one status-line-style chip track: each tier renders in its own role color and the active tier is filled as a powerline chip with a luminance-matched label. The role-cycle status now shows only the chip track — the resolved model and thinking level already live on the status line — instead of the verbose `Switched to <role>: <model> (cycle: …)` line.
+- Changed the in-flight `bash` tool-call preview to render as a full bordered block as soon as the call appears, instead of a one-line `Bash: $ …` status that only expanded into a block once the command produced its first output chunk. Silent commands (e.g. `sleep 30`) now show the framed command block — with the animated pending border — for their whole runtime.
+- Changed local tiny-model inference to request a worker-safe accelerated ONNX execution provider where available (DirectML on Windows, CUDA on Linux x64), with CPU retry if acceleration cannot initialize. `PI_TINY_DEVICE=cpu` restores CPU-only behavior; `PI_TINY_DEVICE=metal` is accepted as a WebGPU alias but guarded back to CPU in the production macOS worker because WebGPU currently hard-crashes Bun on worker teardown.
 
 ### Fixed
-
+- Used the native block resolver for hashline operations so `replace block` edits now derive block ranges from file-aware parsing
+- Fixed OAuth login handling to cancel cleanly when users press Esc or Ctrl+C during authentication
 - Fixed the `read` tool description advertising `inspect_image` ("for visual analysis, call `inspect_image`") even when the `inspect_image` tool was disabled, which left the model hunting for a tool absent from its function list. The image section is now gated on `inspect_image.enabled`: when disabled it instead states that reading an image path returns the decoded image inline.
-
-### Fixed
-
+- Fixed session-title generation latching onto literal text inside fenced code blocks — a pasted UI mockup containing "Welcome to Claude Code v2.1.158" titled the session "Setup Screen for Claude Code v2.1.158" instead of capturing the actual request. The first user message now has fenced code blocks stripped before titling (both the online `pi/smol` and local on-device model paths share the same preprocessing), with a fallback to the original message when stripping would leave too little to title from (e.g. a message that is essentially just a code block).
 - Fixed slash-command autocomplete repaint requests so Windows Terminal sessions with unknown native viewport state keep updating the input box and candidate list. ([#1550](https://github.com/can1357/oh-my-pi/issues/1550))
+- Fixed Python `eval` failing the whole session when the managed `~/.omp/python-env` interpreter exists on disk but no longer runs (e.g. a stale `uv`-managed Python that was removed or upgraded). Availability resolution now enumerates every candidate — active/project venv, the managed env, then the system interpreter — and probes each in priority order, falling through to the first that actually executes instead of failing fast on the first resolved path. The kernel spawns whichever interpreter the probe selected, so a working system Python takes over transparently.
+
+### Removed
+- Removed the `recipe` tool and its `recipe.enabled` setting. Task-runner targets (just/package.json/Cargo/make/Taskfile) are invoked directly through `bash`.
 
 ## [15.6.0] - 2026-05-30
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-
+- Added a `workflow` tool that lets the model write deterministic JavaScript scripts to orchestrate multiple subagents with `agent()`, `parallel()`, `pipeline()`, `phase()`, and `log()` primitives. Scripts are sandboxed in `node:vm` and validated with `acorn` AST parsing. The tool is discoverable (`loadMode: discoverable`) and gated by the `workflow.enabled` setting (default true). ([#1544](https://github.com/can1357/oh-my-pi/issues/1544))
 - Added an `omp completions <bash|zsh|fish>` command that prints a shell completion script generated from the live command/flag metadata, so completions never drift from the actual CLI. Subcommands, flags, and enum values complete statically; `--model`/`--smol`/`--slow`/`--plan` resolve against the bundled model catalog and `--resume` against on-disk sessions via a hidden `__complete` helper.
 
 ### Fixed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Added a `workflow` tool that lets the model write deterministic JavaScript scripts to orchestrate multiple subagents with `agent()`, `parallel()`, `pipeline()`, `phase()`, and `log()` primitives. Scripts are sandboxed in `node:vm`, validated with `acorn` AST parsing, bounded by `workflow.maxConcurrency` / `workflow.scriptTimeoutMs`, and gated by the disabled-by-default `workflow.enabled` setting. ([#1544](https://github.com/can1357/oh-my-pi/issues/1544))
+- Added a `workflow` tool that lets the model write deterministic JavaScript scripts to orchestrate multiple subagents with `agent()`, `parallel()`, `pipeline()`, `phase()`, and `log()` primitives. Scripts are sandboxed in `node:vm`, validated with `acorn` AST parsing, bounded by `workflow.maxConcurrency` / `workflow.scriptTimeoutMs`, and gated by the disabled-by-default `workflow.enabled` setting. `parallel()` and `pipeline()` return per-slot results as `{ ok: true, value } | { ok: false, error: string }` so partial failures stay observable (and `null` remains a valid `value` for agents that intentionally return nothing). The subagent `structured_output` tool now surfaces the resolved JSON Schema inside its description so the model sees the expected payload shape on first attempt. The per-call MCP timeout for workflow proxy tools is sourced from the new `workflow.mcpCallTimeoutMs` setting (default 60_000ms; `0` disables) so long-running MCP tools can be granted more headroom without affecting non-workflow MCP callers. ([#1544](https://github.com/can1357/oh-my-pi/issues/1544))
 
 ## [15.7.0] - 2026-05-31
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Added
-- Added a `workflow` tool that lets the model write deterministic JavaScript scripts to orchestrate multiple subagents with `agent()`, `parallel()`, `pipeline()`, `phase()`, and `log()` primitives. Scripts are sandboxed in `node:vm` and validated with `acorn` AST parsing. The tool is discoverable (`loadMode: discoverable`) and gated by the `workflow.enabled` setting (default true). ([#1544](https://github.com/can1357/oh-my-pi/issues/1544))
+- Added a `workflow` tool that lets the model write deterministic JavaScript scripts to orchestrate multiple subagents with `agent()`, `parallel()`, `pipeline()`, `phase()`, and `log()` primitives. Scripts are sandboxed in `node:vm`, validated with `acorn` AST parsing, bounded by `workflow.maxConcurrency` / `workflow.scriptTimeoutMs`, and gated by the disabled-by-default `workflow.enabled` setting. ([#1544](https://github.com/can1357/oh-my-pi/issues/1544))
 
 ## [15.7.0] - 2026-05-31
 

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -58,6 +58,7 @@
 		"@puppeteer/browsers": "catalog:",
 		"@types/turndown": "catalog:",
 		"@xterm/headless": "catalog:",
+		"acorn": "catalog:",
 		"chalk": "catalog:",
 		"diff": "catalog:",
 		"fflate": "catalog:",

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2300,11 +2300,31 @@ export const SETTINGS_SCHEMA = {
 	},
 	"workflow.enabled": {
 		type: "boolean",
-		default: true,
+		default: false,
 		ui: {
 			tab: "tools",
 			label: "Workflow",
 			description: "Enable the workflow tool for dynamic multi-agent orchestration",
+		},
+	},
+
+	"workflow.maxConcurrency": {
+		type: "number",
+		default: 4,
+		ui: {
+			tab: "tools",
+			label: "Workflow max concurrency",
+			description: "Maximum number of workflow subagents that can run concurrently",
+		},
+	},
+
+	"workflow.scriptTimeoutMs": {
+		type: "number",
+		default: 5000,
+		ui: {
+			tab: "tools",
+			label: "Workflow script timeout (ms)",
+			description: "Maximum synchronous execution time for a workflow script",
 		},
 	},
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2328,6 +2328,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"workflow.mcpCallTimeoutMs": {
+		type: "number",
+		default: 60_000,
+		ui: {
+			tab: "tools",
+			label: "Workflow MCP call timeout (ms)",
+			description:
+				"Maximum duration for any MCP tool call invoked through a workflow subagent. Does not affect non-workflow MCP callers. Set to 0 to disable the per-call timeout.",
+		},
+	},
+
 	"browser.enabled": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2301,7 +2301,11 @@ export const SETTINGS_SCHEMA = {
 	"workflow.enabled": {
 		type: "boolean",
 		default: true,
-		ui: { tab: "tools", label: "Workflow", description: "Enable the workflow tool for dynamic multi-agent orchestration" },
+		ui: {
+			tab: "tools",
+			label: "Workflow",
+			description: "Enable the workflow tool for dynamic multi-agent orchestration",
+		},
 	},
 
 	"browser.enabled": {

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2293,11 +2293,15 @@ export const SETTINGS_SCHEMA = {
 				"Past soft TTL but within hard TTL, the tool returns the cached row and refreshes it in the background. Past hard TTL, the row is dropped. Default 7 days.",
 		},
 	},
-
 	"web_search.enabled": {
 		type: "boolean",
 		default: true,
 		ui: { tab: "tools", label: "Web Search", description: "Enable the web_search tool for web searching" },
+	},
+	"workflow.enabled": {
+		type: "boolean",
+		default: true,
+		ui: { tab: "tools", label: "Workflow", description: "Enable the workflow tool for dynamic multi-agent orchestration" },
 	},
 
 	"browser.enabled": {

--- a/packages/coding-agent/src/mcp/proxy-tools.ts
+++ b/packages/coding-agent/src/mcp/proxy-tools.ts
@@ -3,15 +3,22 @@ import { ToolAbortError } from "../tools/tool-errors";
 import { callTool } from "./client";
 import type { MCPManager } from "./manager";
 
-const MCP_CALL_TIMEOUT_MS = 60_000;
+const DEFAULT_MCP_CALL_TIMEOUT_MS = 60_000;
 
 /**
  * Create proxy tools that reuse an existing MCP manager's live connections.
  *
  * Subagents receive these as custom tools when they inherit a parent MCP manager;
  * createAgentSession only discovers MCP tools when it owns discovery itself.
+ *
+ * `timeoutMs` bounds each individual MCP `tools/call`. Callers that have their own
+ * timeout source (e.g. a settings-driven workflow value) pass it in; everyone else
+ * gets the legacy 60s default. Pass `0` to disable the per-call timeout entirely.
  */
-export function createMCPProxyTools(mcpManager: MCPManager): CustomTool[] {
+export function createMCPProxyTools(
+	mcpManager: MCPManager,
+	timeoutMs: number = DEFAULT_MCP_CALL_TIMEOUT_MS,
+): CustomTool[] {
 	return mcpManager.getTools().map(tool => {
 		const mcpTool = tool as { mcpToolName?: string; mcpServerName?: string };
 		return {
@@ -31,7 +38,7 @@ export function createMCPProxyTools(mcpManager: MCPManager): CustomTool[] {
 							const connection = await mcpManager.waitForConnection(serverName);
 							return callTool(connection, mcpToolName, params as Record<string, unknown>, { signal });
 						})(),
-						MCP_CALL_TIMEOUT_MS,
+						timeoutMs,
 						signal,
 					);
 					return {
@@ -65,6 +72,10 @@ function withAbortTimeout<T>(promise: Promise<T>, timeoutMs: number, signal?: Ab
 	if (signal?.aborted) {
 		return Promise.reject(new ToolAbortError());
 	}
+	if (timeoutMs <= 0) {
+		// No timeout: still honor abort, but never reject for elapsed time.
+		return signal ? attachAbortOnly(promise, signal) : promise;
+	}
 
 	const { promise: wrappedPromise, resolve, reject } = Promise.withResolvers<T>();
 	let settled = false;
@@ -90,5 +101,21 @@ function withAbortTimeout<T>(promise: Promise<T>, timeoutMs: number, signal?: Ab
 		clearTimeout(timeoutId);
 	});
 
+	return wrappedPromise;
+}
+
+function attachAbortOnly<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+	const { promise: wrappedPromise, resolve, reject } = Promise.withResolvers<T>();
+	let settled = false;
+	const onAbort = () => {
+		if (settled) return;
+		settled = true;
+		reject(new ToolAbortError());
+	};
+	signal.addEventListener("abort", onAbort, { once: true });
+	promise.then(resolve, reject).finally(() => {
+		settled = true;
+		signal.removeEventListener("abort", onAbort);
+	});
 	return wrappedPromise;
 }

--- a/packages/coding-agent/src/mcp/proxy-tools.ts
+++ b/packages/coding-agent/src/mcp/proxy-tools.ts
@@ -1,0 +1,94 @@
+import type { CustomTool } from "../extensibility/custom-tools/types";
+import { ToolAbortError } from "../tools/tool-errors";
+import { callTool } from "./client";
+import type { MCPManager } from "./manager";
+
+const MCP_CALL_TIMEOUT_MS = 60_000;
+
+/**
+ * Create proxy tools that reuse an existing MCP manager's live connections.
+ *
+ * Subagents receive these as custom tools when they inherit a parent MCP manager;
+ * createAgentSession only discovers MCP tools when it owns discovery itself.
+ */
+export function createMCPProxyTools(mcpManager: MCPManager): CustomTool[] {
+	return mcpManager.getTools().map(tool => {
+		const mcpTool = tool as { mcpToolName?: string; mcpServerName?: string };
+		return {
+			name: tool.name,
+			label: tool.label ?? tool.name,
+			description: tool.description ?? "",
+			parameters: tool.parameters,
+			execute: async (_toolCallId, params, _onUpdate, _ctx, signal) => {
+				if (signal?.aborted) {
+					throw new ToolAbortError();
+				}
+				const serverName = mcpTool.mcpServerName ?? "";
+				const mcpToolName = mcpTool.mcpToolName ?? "";
+				try {
+					const result = await withAbortTimeout(
+						(async () => {
+							const connection = await mcpManager.waitForConnection(serverName);
+							return callTool(connection, mcpToolName, params as Record<string, unknown>, { signal });
+						})(),
+						MCP_CALL_TIMEOUT_MS,
+						signal,
+					);
+					return {
+						content: (result.content ?? []).map(item =>
+							item.type === "text"
+								? { type: "text" as const, text: item.text ?? "" }
+								: { type: "text" as const, text: JSON.stringify(item) },
+						),
+						details: { serverName, mcpToolName, isError: result.isError },
+					};
+				} catch (error) {
+					if (error instanceof ToolAbortError) {
+						throw error;
+					}
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `MCP error: ${error instanceof Error ? error.message : String(error)}`,
+							},
+						],
+						details: { serverName, mcpToolName, isError: true },
+					};
+				}
+			},
+		};
+	});
+}
+
+function withAbortTimeout<T>(promise: Promise<T>, timeoutMs: number, signal?: AbortSignal): Promise<T> {
+	if (signal?.aborted) {
+		return Promise.reject(new ToolAbortError());
+	}
+
+	const { promise: wrappedPromise, resolve, reject } = Promise.withResolvers<T>();
+	let settled = false;
+	const timeoutId = setTimeout(() => {
+		if (settled) return;
+		settled = true;
+		reject(new Error(`MCP tool call timed out after ${timeoutMs}ms`));
+	}, timeoutMs);
+
+	const onAbort = () => {
+		if (settled) return;
+		settled = true;
+		clearTimeout(timeoutId);
+		reject(new ToolAbortError());
+	};
+
+	if (signal) {
+		signal.addEventListener("abort", onAbort, { once: true });
+	}
+
+	promise.then(resolve, reject).finally(() => {
+		if (signal) signal.removeEventListener("abort", onAbort);
+		clearTimeout(timeoutId);
+	});
+
+	return wrappedPromise;
+}

--- a/packages/coding-agent/src/prompts/system/workflow-subagent-prompt.md
+++ b/packages/coding-agent/src/prompts/system/workflow-subagent-prompt.md
@@ -1,0 +1,15 @@
+{{#if instructions}}
+{{instructions}}
+{{/if}}
+{{#if taskInstructions}}
+{{taskInstructions}}
+{{/if}}
+{{#if label}}Task label: {{label}}{{/if}}
+{{prompt}}
+{{#if structured}}
+Final output contract:
+- Your final action MUST be a structured_output tool call.
+- The structured_output arguments are the return value of this subagent.
+- Do not emit a prose final answer instead of structured_output.
+- If you need to inspect files or run commands first, do so, then call structured_output exactly once.
+{{/if}}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1262,6 +1262,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			LocalProtocolHandler.setOverride(options.localProtocolOptions);
 		}
 		toolSession.getArtifactsDir = getArtifactsDir;
+		toolSession.localProtocolOptions = options.localProtocolOptions ?? {
+			getArtifactsDir,
+			getSessionId: () => sessionManager.getSessionId?.() ?? null,
+		};
 		toolSession.agentOutputManager = new AgentOutputManager(
 			getArtifactsDir,
 			options.parentTaskPrefix ? { parentPrefix: options.parentTaskPrefix } : undefined,
@@ -1272,6 +1276,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 		// Discover MCP tools from .mcp.json files
 		let mcpManager: MCPManager | undefined = options.mcpManager;
+		toolSession.mcpManager = mcpManager;
 		const enableMCP = options.enableMCP ?? true;
 		const customTools: CustomTool[] = [];
 		if (enableMCP && !mcpManager) {
@@ -1290,6 +1295,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				authStorage,
 			});
 			mcpManager = mcpResult.manager;
+			toolSession.mcpManager = mcpManager;
 
 			if (settings.get("mcp.notifications")) {
 				mcpManager.setNotificationsEnabled(true);

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -13,14 +13,13 @@ import { resolveModelOverrideWithAuthFallback } from "../config/model-resolver";
 import type { PromptTemplate } from "../config/prompt-templates";
 import { Settings } from "../config/settings";
 import { SETTINGS_SCHEMA, type SettingPath } from "../config/settings-schema";
-import type { CustomTool } from "../extensibility/custom-tools/types";
 import { runExtensionCompact, runExtensionSetModel } from "../extensibility/extensions/compact-handler";
 import { getSessionSlashCommands } from "../extensibility/extensions/get-commands-handler";
 import { buildSkillPromptMessage, type Skill } from "../extensibility/skills";
 import type { HindsightSessionState } from "../hindsight/state";
 import type { LocalProtocolOptions } from "../internal-urls";
-import { callTool } from "../mcp/client";
 import type { MCPManager } from "../mcp/manager";
+import { createMCPProxyTools } from "../mcp/proxy-tools";
 import type { MnemosyneSessionState } from "../mnemosyne/state";
 import subagentSystemPromptTemplate from "../prompts/system/subagent-system-prompt.md" with { type: "text" };
 import submitReminderTemplate from "../prompts/system/subagent-yield-reminder.md" with { type: "text" };
@@ -54,8 +53,6 @@ import {
 	TASK_SUBAGENT_PROGRESS_CHANNEL,
 	type TaskToolDetails,
 } from "./types";
-
-const MCP_CALL_TIMEOUT_MS = 60_000;
 
 /** Agent event types to forward for progress tracking. */
 const agentEventTypes = new Set<AgentEvent["type"]>([
@@ -91,38 +88,6 @@ function renderIrcPeerRoster(selfId: string): string {
 		.filter(ref => ref.id !== selfId && (ref.status === "running" || ref.status === "idle"));
 	if (peers.length === 0) return "- (no other live agents)";
 	return peers.map(peer => `- \`${peer.id}\` — ${peer.displayName} (${peer.kind}, ${peer.status})`).join("\n");
-}
-
-function withAbortTimeout<T>(promise: Promise<T>, timeoutMs: number, signal?: AbortSignal): Promise<T> {
-	if (signal?.aborted) {
-		return Promise.reject(new ToolAbortError());
-	}
-
-	const { promise: wrappedPromise, resolve, reject } = Promise.withResolvers<T>();
-	let settled = false;
-	const timeoutId = setTimeout(() => {
-		if (settled) return;
-		settled = true;
-		reject(new Error(`MCP tool call timed out after ${timeoutMs}ms`));
-	}, timeoutMs);
-
-	const onAbort = () => {
-		if (settled) return;
-		settled = true;
-		clearTimeout(timeoutId);
-		reject(new ToolAbortError());
-	};
-
-	if (signal) {
-		signal.addEventListener("abort", onAbort, { once: true });
-	}
-
-	promise.then(resolve, reject).finally(() => {
-		if (signal) signal.removeEventListener("abort", onAbort);
-		clearTimeout(timeoutId);
-	});
-
-	return wrappedPromise;
 }
 
 function getReportFindingKey(value: unknown): string | null {
@@ -470,59 +435,6 @@ function getUsageTokens(usage: unknown): number {
 	// field breakdown. This total includes cacheRead, but returning it is still better
 	// than silently showing 0 for those providers.
 	return firstNumberField(record, ["totalTokens", "total_tokens"]) ?? 0;
-}
-
-/**
- * Create proxy tools that reuse the parent's MCP connections.
- */
-function createMCPProxyTools(mcpManager: MCPManager): CustomTool[] {
-	return mcpManager.getTools().map(tool => {
-		const mcpTool = tool as { mcpToolName?: string; mcpServerName?: string };
-		return {
-			name: tool.name,
-			label: tool.label ?? tool.name,
-			description: tool.description ?? "",
-			parameters: tool.parameters,
-			execute: async (_toolCallId, params, _onUpdate, _ctx, signal) => {
-				if (signal?.aborted) {
-					throw new ToolAbortError();
-				}
-				const serverName = mcpTool.mcpServerName ?? "";
-				const mcpToolName = mcpTool.mcpToolName ?? "";
-				try {
-					const result = await withAbortTimeout(
-						(async () => {
-							const connection = await mcpManager.waitForConnection(serverName);
-							return callTool(connection, mcpToolName, params as Record<string, unknown>, { signal });
-						})(),
-						MCP_CALL_TIMEOUT_MS,
-						signal,
-					);
-					return {
-						content: (result.content ?? []).map(item =>
-							item.type === "text"
-								? { type: "text" as const, text: item.text ?? "" }
-								: { type: "text" as const, text: JSON.stringify(item) },
-						),
-						details: { serverName, mcpToolName, isError: result.isError },
-					};
-				} catch (error) {
-					if (error instanceof ToolAbortError) {
-						throw error;
-					}
-					return {
-						content: [
-							{
-								type: "text" as const,
-								text: `MCP error: ${error instanceof Error ? error.message : String(error)}`,
-							},
-						],
-						details: { serverName, mcpToolName, isError: true },
-					};
-				}
-			},
-		};
-	});
 }
 
 function createSubagentSettings(baseSettings: Settings): Settings {

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -52,9 +52,9 @@ import { SearchTool } from "./search";
 import { SearchToolBm25Tool } from "./search-tool-bm25";
 import { loadSshTool } from "./ssh";
 import { type TodoPhase, TodoWriteTool } from "./todo-write";
+import { WorkflowTool } from "./workflow";
 import { WriteTool } from "./write";
 import { YieldTool } from "./yield";
-import { WorkflowTool } from "./workflow";
 
 // Exa MCP tools (22 tools)
 
@@ -95,9 +95,9 @@ export * from "./search-tool-bm25";
 export * from "./ssh";
 export * from "./todo-write";
 export * from "./tts";
+export * from "./workflow";
 export * from "./write";
 export * from "./yield";
-export * from "./workflow";
 
 /** Tool type (AgentTool from pi-ai) */
 export type Tool = AgentTool<any, any, any>;

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -10,7 +10,9 @@ import type { Skill } from "../extensibility/skills";
 import type { GoalModeState, GoalRuntime } from "../goals";
 import { GoalTool } from "../goals/tools/goal-tool";
 import type { HindsightSessionState } from "../hindsight/state";
+import type { LocalProtocolOptions } from "../internal-urls";
 import { LspTool } from "../lsp";
+import type { MCPManager } from "../mcp";
 import type { MnemosyneSessionState } from "../mnemosyne/state";
 import type { PlanModeState } from "../plan-mode/state";
 import { type AgentRegistry, MAIN_AGENT_ID } from "../registry/agent-registry";
@@ -201,6 +203,10 @@ export interface ToolSession {
 	setTodoPhases?: (phases: TodoPhase[]) => void;
 	/** Whether MCP tool discovery is active for this session. */
 	isMCPDiscoveryEnabled?: () => boolean;
+	/** Parent MCP manager for headless subagents that proxy the parent's MCP tools instead of rediscovering. */
+	mcpManager?: MCPManager;
+	/** Parent local:// protocol root/session wiring for subagents. */
+	localProtocolOptions?: LocalProtocolOptions;
 	/** Get MCP tools activated by prior search_tool_bm25 calls. */
 	getSelectedMCPToolNames?: () => string[];
 	/** Merge MCP tool selections into the active session tool set. */

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -54,6 +54,7 @@ import { loadSshTool } from "./ssh";
 import { type TodoPhase, TodoWriteTool } from "./todo-write";
 import { WriteTool } from "./write";
 import { YieldTool } from "./yield";
+import { WorkflowTool } from "./workflow";
 
 // Exa MCP tools (22 tools)
 
@@ -96,6 +97,7 @@ export * from "./todo-write";
 export * from "./tts";
 export * from "./write";
 export * from "./yield";
+export * from "./workflow";
 
 /** Tool type (AgentTool from pi-ai) */
 export type Tool = AgentTool<any, any, any>;
@@ -310,6 +312,7 @@ export const BUILTIN_TOOLS: Record<string, ToolFactory> = {
 	retain: MemoryRetainTool.createIf,
 	recall: MemoryRecallTool.createIf,
 	reflect: MemoryReflectTool.createIf,
+	workflow: WorkflowTool.createIf,
 };
 
 export const HIDDEN_TOOLS: Record<string, ToolFactory> = {
@@ -456,6 +459,7 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		if (name === "render_mermaid") return session.settings.get("renderMermaid.enabled");
 		if (name === "inspect_image") return session.settings.get("inspect_image.enabled");
 		if (name === "web_search") return session.settings.get("web_search.enabled");
+		if (name === "workflow") return session.settings.get("workflow.enabled");
 		// search_tool_bm25 is allowed when either legacy mcp.discoveryMode or new tools.discoveryMode is active.
 		if (name === "search_tool_bm25") return discoveryActive;
 		if (name === "browser") return session.settings.get("browser.enabled");

--- a/packages/coding-agent/src/tools/workflow/agent.ts
+++ b/packages/coding-agent/src/tools/workflow/agent.ts
@@ -1,0 +1,145 @@
+import type { AssistantMessage, TextContent } from "@oh-my-pi/pi-ai";
+import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
+import { createAgentSession, type CreateAgentSessionOptions } from "../../sdk";
+import { SessionManager } from "../../session/session-manager";
+import { Settings } from "../../config/settings";
+import type { CustomTool } from "../../extensibility/custom-tools/types";
+import { z } from "zod";
+
+export interface WorkflowAgentOptions {
+	cwd?: string;
+	/** Extra tools available to the subagent in addition to the structured output tool. */
+	tools?: CustomTool[];
+	/** Override any createAgentSession option (model, authStorage, resourceLoader, etc.). */
+	session?: Partial<CreateAgentSessionOptions>;
+	/** Extra system guidance prepended to every subagent task. */
+	instructions?: string;
+}
+
+export interface AgentRunOptions {
+	label?: string;
+	schema?: unknown;
+	tools?: CustomTool[];
+	instructions?: string;
+	signal?: AbortSignal;
+}
+
+export type AgentRunResult = unknown;
+
+export interface StructuredOutputCapture<T = unknown> {
+	value: T | undefined;
+	called: boolean;
+}
+
+function createStructuredOutputTool(capture: StructuredOutputCapture): CustomTool {
+	return {
+		name: "structured_output",
+		label: "Structured Output",
+		description: "Return the final machine-readable result for this subagent task.",
+		parameters: z.object({}).passthrough(),
+		async execute(_toolCallId, params) {
+			capture.value = params;
+			capture.called = true;
+			return {
+				content: [{ type: "text", text: "Structured output received." }],
+				details: params,
+			};
+		},
+	};
+}
+
+export class WorkflowAgent {
+	readonly #cwd: string;
+	readonly #baseTools: CustomTool[];
+	readonly #sessionOptions: Partial<CreateAgentSessionOptions>;
+	readonly #instructions?: string;
+
+	constructor(options: WorkflowAgentOptions = {}) {
+		this.#cwd = options.cwd ?? process.cwd();
+		this.#baseTools = options.tools ?? [];
+		this.#sessionOptions = options.session ?? {};
+		this.#instructions = options.instructions;
+	}
+
+	async run(prompt: string, options: AgentRunOptions = {}): Promise<AgentRunResult> {
+		const capture: StructuredOutputCapture = { called: false, value: undefined };
+		const customTools: CustomTool[] = [...this.#baseTools, ...(options.tools ?? [])];
+
+		if (options.schema) {
+			customTools.push(createStructuredOutputTool(capture));
+		}
+
+		const { session } = await createAgentSession({
+			cwd: this.#cwd,
+			settings: Settings.isolated({
+				"compaction.enabled": false,
+			}),
+			sessionManager: SessionManager.inMemory(),
+			customTools,
+			...this.#sessionOptions,
+		});
+
+		let removeAbortListener: (() => void) | undefined;
+		try {
+			if (options.signal?.aborted) throw new Error("Subagent was aborted");
+			if (options.signal) {
+				const onAbort = () => void session.abort();
+				options.signal.addEventListener("abort", onAbort, { once: true });
+				removeAbortListener = () => options.signal?.removeEventListener("abort", onAbort);
+			}
+
+			await session.prompt(this.#buildPrompt(prompt, options, Boolean(options.schema)));
+			await session.waitForIdle();
+
+			if (options.signal?.aborted) throw new Error("Subagent was aborted");
+
+			if (options.schema) {
+				if (!capture.called) {
+					throw new Error("Subagent finished without calling structured_output");
+				}
+				return capture.value;
+			}
+
+			return this.#lastAssistantText(session.messages);
+		} finally {
+			removeAbortListener?.();
+			void session.dispose();
+		}
+	}
+
+	#buildPrompt(prompt: string, options: AgentRunOptions, structured: boolean): string {
+		const parts = [
+			this.#instructions,
+			options.instructions,
+			options.label ? `Task label: ${options.label}` : undefined,
+			prompt,
+		].filter(Boolean);
+
+		if (structured) {
+			parts.push(
+				[
+					"Final output contract:",
+					"- Your final action MUST be a structured_output tool call.",
+					"- The structured_output arguments are the return value of this subagent.",
+					"- Do not emit a prose final answer instead of structured_output.",
+					"- If you need to inspect files or run commands first, do so, then call structured_output exactly once.",
+				].join("\n"),
+			);
+		}
+
+		return parts.join("\n\n");
+	}
+
+	#lastAssistantText(messages: unknown[]): string {
+		for (let i = messages.length - 1; i >= 0; i--) {
+			const message = messages[i] as Partial<AssistantMessage> | undefined;
+			if (message?.role !== "assistant" || !Array.isArray(message.content)) continue;
+			const text = message.content
+				.filter((part): part is TextContent => part.type === "text")
+				.map((part) => part.text)
+				.join("");
+			if (text.trim()) return text;
+		}
+		return "";
+	}
+}

--- a/packages/coding-agent/src/tools/workflow/agent.ts
+++ b/packages/coding-agent/src/tools/workflow/agent.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { Settings } from "../../config/settings";
 import { SETTINGS_SCHEMA, type SettingPath } from "../../config/settings-schema";
 import type { CustomTool } from "../../extensibility/custom-tools/types";
+import { createMCPProxyTools } from "../../mcp/proxy-tools";
 import workflowSubagentPrompt from "../../prompts/system/workflow-subagent-prompt.md" with { type: "text" };
 import { type CreateAgentSessionOptions, createAgentSession } from "../../sdk";
 import type { AgentSession } from "../../session/agent-session";
@@ -97,7 +98,7 @@ export class WorkflowAgent {
 		const capture: StructuredOutputCapture = { called: false, value: undefined };
 		const customTools: CustomTool[] = [...this.#baseTools, ...(options.tools ?? [])];
 
-		if (options.schema) {
+		if (options.schema !== undefined) {
 			customTools.push(createStructuredOutputTool(capture, options.schema));
 		}
 
@@ -105,19 +106,22 @@ export class WorkflowAgent {
 		const agentDisplayName = options.label ?? `workflow agent ${runIndex}`;
 		const parentTaskPrefix = this.#sessionOptions.parentTaskPrefix;
 		const agentId = `${parentTaskPrefix ? `${parentTaskPrefix}-` : ""}${sanitizeAgentId(agentDisplayName, runIndex)}`;
+		const inheritedCustomTools = this.#sessionOptions.customTools ?? [];
 
+		const mcpProxyTools = this.#sessionOptions.mcpManager ? createMCPProxyTools(this.#sessionOptions.mcpManager) : [];
 		const { session } = await createAgentSession({
 			...this.#sessionOptions,
 			cwd: this.#cwd,
 			settings: createSubagentSettings(this.#sessionOptions.settings),
 			sessionManager: SessionManager.inMemory(),
-			customTools,
+			customTools: [...mcpProxyTools, ...inheritedCustomTools, ...customTools],
 			requireYieldTool: true,
 			taskDepth: this.#sessionOptions.taskDepth ?? 0,
 			hasUI: false,
 			parentTaskPrefix,
 			agentId,
 			agentDisplayName,
+			enableMCP: !this.#sessionOptions.mcpManager,
 			telemetry: createWorkflowSubagentTelemetry(this.#sessionOptions.telemetry, {
 				id: agentId,
 				name: agentDisplayName,
@@ -148,16 +152,17 @@ export class WorkflowAgent {
 					taskInstructions: options.instructions,
 					label: options.label,
 					prompt: promptText,
-					structured: Boolean(options.schema),
+					structured: options.schema !== undefined,
 				}),
 			);
 			await session.waitForIdle();
 
 			if (options.signal?.aborted) throw new Error("Subagent was aborted");
 
-			const result = options.schema
-				? this.#structuredOutputValue(capture)
-				: this.#lastAssistantText(session.messages);
+			const result =
+				options.schema !== undefined
+					? this.#structuredOutputValue(capture)
+					: this.#lastAssistantText(session.messages);
 			emitLifecycle(this.#sessionOptions, {
 				id: agentId,
 				agent: agentDisplayName,

--- a/packages/coding-agent/src/tools/workflow/agent.ts
+++ b/packages/coding-agent/src/tools/workflow/agent.ts
@@ -1,10 +1,12 @@
 import type { AssistantMessage, TextContent } from "@oh-my-pi/pi-ai";
-import type { AgentToolResult } from "@oh-my-pi/pi-agent-core";
-import { createAgentSession, type CreateAgentSessionOptions } from "../../sdk";
-import { SessionManager } from "../../session/session-manager";
-import { Settings } from "../../config/settings";
-import type { CustomTool } from "../../extensibility/custom-tools/types";
+import { prompt } from "@oh-my-pi/pi-utils";
 import { z } from "zod";
+import { Settings } from "../../config/settings";
+import { SETTINGS_SCHEMA, type SettingPath } from "../../config/settings-schema";
+import type { CustomTool } from "../../extensibility/custom-tools/types";
+import workflowSubagentPrompt from "../../prompts/system/workflow-subagent-prompt.md" with { type: "text" };
+import { type CreateAgentSessionOptions, createAgentSession } from "../../sdk";
+import { SessionManager } from "../../session/session-manager";
 
 export interface WorkflowAgentOptions {
 	cwd?: string;
@@ -48,12 +50,26 @@ function createStructuredOutputTool(capture: StructuredOutputCapture): CustomToo
 	};
 }
 
+function createSubagentSettings(baseSettings: Settings | undefined): Settings {
+	if (!baseSettings) return Settings.isolated({ "compaction.enabled": false });
+	const snapshot: Partial<Record<SettingPath, unknown>> = {};
+	for (const key of Object.keys(SETTINGS_SCHEMA) as SettingPath[]) {
+		snapshot[key] = baseSettings.get(key);
+	}
+	return Settings.isolated({
+		...snapshot,
+		"async.enabled": false,
+		"bash.autoBackground.enabled": false,
+		"tools.approvalMode": "yolo",
+		"compaction.enabled": false,
+	});
+}
+
 export class WorkflowAgent {
 	readonly #cwd: string;
 	readonly #baseTools: CustomTool[];
 	readonly #sessionOptions: Partial<CreateAgentSessionOptions>;
 	readonly #instructions?: string;
-
 	constructor(options: WorkflowAgentOptions = {}) {
 		this.#cwd = options.cwd ?? process.cwd();
 		this.#baseTools = options.tools ?? [];
@@ -61,7 +77,7 @@ export class WorkflowAgent {
 		this.#instructions = options.instructions;
 	}
 
-	async run(prompt: string, options: AgentRunOptions = {}): Promise<AgentRunResult> {
+	async run(promptText: string, options: AgentRunOptions = {}): Promise<AgentRunResult> {
 		const capture: StructuredOutputCapture = { called: false, value: undefined };
 		const customTools: CustomTool[] = [...this.#baseTools, ...(options.tools ?? [])];
 
@@ -71,11 +87,11 @@ export class WorkflowAgent {
 
 		const { session } = await createAgentSession({
 			cwd: this.#cwd,
-			settings: Settings.isolated({
-				"compaction.enabled": false,
-			}),
+			settings: createSubagentSettings(this.#sessionOptions.settings),
 			sessionManager: SessionManager.inMemory(),
 			customTools,
+			requireYieldTool: true,
+			taskDepth: this.#sessionOptions.taskDepth ?? 0,
 			...this.#sessionOptions,
 		});
 
@@ -88,7 +104,15 @@ export class WorkflowAgent {
 				removeAbortListener = () => options.signal?.removeEventListener("abort", onAbort);
 			}
 
-			await session.prompt(this.#buildPrompt(prompt, options, Boolean(options.schema)));
+			await session.prompt(
+				prompt.render(workflowSubagentPrompt, {
+					instructions: this.#instructions,
+					taskInstructions: options.instructions,
+					label: options.label,
+					prompt: promptText,
+					structured: Boolean(options.schema),
+				}),
+			);
 			await session.waitForIdle();
 
 			if (options.signal?.aborted) throw new Error("Subagent was aborted");
@@ -107,36 +131,13 @@ export class WorkflowAgent {
 		}
 	}
 
-	#buildPrompt(prompt: string, options: AgentRunOptions, structured: boolean): string {
-		const parts = [
-			this.#instructions,
-			options.instructions,
-			options.label ? `Task label: ${options.label}` : undefined,
-			prompt,
-		].filter(Boolean);
-
-		if (structured) {
-			parts.push(
-				[
-					"Final output contract:",
-					"- Your final action MUST be a structured_output tool call.",
-					"- The structured_output arguments are the return value of this subagent.",
-					"- Do not emit a prose final answer instead of structured_output.",
-					"- If you need to inspect files or run commands first, do so, then call structured_output exactly once.",
-				].join("\n"),
-			);
-		}
-
-		return parts.join("\n\n");
-	}
-
 	#lastAssistantText(messages: unknown[]): string {
 		for (let i = messages.length - 1; i >= 0; i--) {
 			const message = messages[i] as Partial<AssistantMessage> | undefined;
 			if (message?.role !== "assistant" || !Array.isArray(message.content)) continue;
 			const text = message.content
 				.filter((part): part is TextContent => part.type === "text")
-				.map((part) => part.text)
+				.map(part => part.text)
 				.join("");
 			if (text.trim()) return text;
 		}

--- a/packages/coding-agent/src/tools/workflow/agent.ts
+++ b/packages/coding-agent/src/tools/workflow/agent.ts
@@ -1,3 +1,5 @@
+import type { AgentIdentity, AgentTelemetryConfig } from "@oh-my-pi/pi-agent-core";
+import { recordHandoff, resolveTelemetry } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, TextContent } from "@oh-my-pi/pi-ai";
 import { prompt } from "@oh-my-pi/pi-utils";
 import { z } from "zod";
@@ -6,7 +8,10 @@ import { SETTINGS_SCHEMA, type SettingPath } from "../../config/settings-schema"
 import type { CustomTool } from "../../extensibility/custom-tools/types";
 import workflowSubagentPrompt from "../../prompts/system/workflow-subagent-prompt.md" with { type: "text" };
 import { type CreateAgentSessionOptions, createAgentSession } from "../../sdk";
+import type { AgentSession } from "../../session/agent-session";
 import { SessionManager } from "../../session/session-manager";
+import { TASK_SUBAGENT_LIFECYCLE_CHANNEL } from "../../task";
+import { buildOutputValidator, summarizeValidationFailure } from "../output-schema-validator";
 
 export interface WorkflowAgentOptions {
 	cwd?: string;
@@ -33,13 +38,22 @@ export interface StructuredOutputCapture<T = unknown> {
 	called: boolean;
 }
 
-function createStructuredOutputTool(capture: StructuredOutputCapture): CustomTool {
+function createStructuredOutputTool(capture: StructuredOutputCapture, schema: unknown): CustomTool {
+	const { validator, error } = buildOutputValidator(schema);
+	if (error) throw new Error(`Invalid structured_output schema: ${error}`);
 	return {
 		name: "structured_output",
 		label: "Structured Output",
 		description: "Return the final machine-readable result for this subagent task.",
 		parameters: z.object({}).passthrough(),
 		async execute(_toolCallId, params) {
+			if (validator) {
+				const result = validator.validate(params);
+				if (!result.success) {
+					const summary = summarizeValidationFailure(result, params, validator.requiredFields);
+					throw new Error(`structured_output failed schema validation: ${summary.message}`);
+				}
+			}
 			capture.value = params;
 			capture.called = true;
 			return {
@@ -70,6 +84,8 @@ export class WorkflowAgent {
 	readonly #baseTools: CustomTool[];
 	readonly #sessionOptions: Partial<CreateAgentSessionOptions>;
 	readonly #instructions?: string;
+	#runIndex = 0;
+
 	constructor(options: WorkflowAgentOptions = {}) {
 		this.#cwd = options.cwd ?? process.cwd();
 		this.#baseTools = options.tools ?? [];
@@ -82,17 +98,39 @@ export class WorkflowAgent {
 		const customTools: CustomTool[] = [...this.#baseTools, ...(options.tools ?? [])];
 
 		if (options.schema) {
-			customTools.push(createStructuredOutputTool(capture));
+			customTools.push(createStructuredOutputTool(capture, options.schema));
 		}
 
+		const runIndex = ++this.#runIndex;
+		const agentDisplayName = options.label ?? `workflow agent ${runIndex}`;
+		const parentTaskPrefix = this.#sessionOptions.parentTaskPrefix;
+		const agentId = `${parentTaskPrefix ? `${parentTaskPrefix}-` : ""}${sanitizeAgentId(agentDisplayName, runIndex)}`;
+
 		const { session } = await createAgentSession({
+			...this.#sessionOptions,
 			cwd: this.#cwd,
 			settings: createSubagentSettings(this.#sessionOptions.settings),
 			sessionManager: SessionManager.inMemory(),
 			customTools,
 			requireYieldTool: true,
 			taskDepth: this.#sessionOptions.taskDepth ?? 0,
-			...this.#sessionOptions,
+			hasUI: false,
+			parentTaskPrefix,
+			agentId,
+			agentDisplayName,
+			telemetry: createWorkflowSubagentTelemetry(this.#sessionOptions.telemetry, {
+				id: agentId,
+				name: agentDisplayName,
+				description: "Workflow subagent",
+			}),
+		});
+
+		await removeParentOwnedTools(session);
+		emitLifecycle(this.#sessionOptions, {
+			id: agentId,
+			agent: agentDisplayName,
+			status: "started",
+			index: runIndex - 1,
 		});
 
 		let removeAbortListener: (() => void) | undefined;
@@ -117,18 +155,35 @@ export class WorkflowAgent {
 
 			if (options.signal?.aborted) throw new Error("Subagent was aborted");
 
-			if (options.schema) {
-				if (!capture.called) {
-					throw new Error("Subagent finished without calling structured_output");
-				}
-				return capture.value;
-			}
-
-			return this.#lastAssistantText(session.messages);
+			const result = options.schema
+				? this.#structuredOutputValue(capture)
+				: this.#lastAssistantText(session.messages);
+			emitLifecycle(this.#sessionOptions, {
+				id: agentId,
+				agent: agentDisplayName,
+				status: "completed",
+				index: runIndex - 1,
+			});
+			return result;
+		} catch (error) {
+			emitLifecycle(this.#sessionOptions, {
+				id: agentId,
+				agent: agentDisplayName,
+				status: options.signal?.aborted ? "aborted" : "failed",
+				index: runIndex - 1,
+			});
+			throw error;
 		} finally {
 			removeAbortListener?.();
 			void session.dispose();
 		}
+	}
+
+	#structuredOutputValue(capture: StructuredOutputCapture): unknown {
+		if (!capture.called) {
+			throw new Error("Subagent finished without calling structured_output");
+		}
+		return capture.value;
 	}
 
 	#lastAssistantText(messages: unknown[]): string {
@@ -143,4 +198,51 @@ export class WorkflowAgent {
 		}
 		return "";
 	}
+}
+
+function createWorkflowSubagentTelemetry(
+	parentTelemetry: AgentTelemetryConfig | undefined,
+	agent: AgentIdentity,
+): AgentTelemetryConfig | undefined {
+	if (!parentTelemetry) return undefined;
+	const parentTelemetryHandle = resolveTelemetry(parentTelemetry, parentTelemetry.conversationId);
+	recordHandoff(parentTelemetryHandle, {
+		fromAgent: parentTelemetry.agent,
+		toAgent: agent,
+	});
+	return {
+		...parentTelemetry,
+		agent,
+		conversationId: undefined,
+	};
+}
+
+async function removeParentOwnedTools(session: AgentSession): Promise<void> {
+	const parentOwnedToolNames = new Set(["todo_write"]);
+	const activeToolNames = session.getActiveToolNames();
+	const filteredToolNames = activeToolNames.filter(name => !parentOwnedToolNames.has(name));
+	if (filteredToolNames.length !== activeToolNames.length) {
+		await session.setActiveToolsByName(filteredToolNames);
+	}
+}
+
+function emitLifecycle(
+	sessionOptions: Partial<CreateAgentSessionOptions>,
+	event: { id: string; agent: string; status: "started" | "completed" | "failed" | "aborted"; index: number },
+): void {
+	sessionOptions.eventBus?.emit(TASK_SUBAGENT_LIFECYCLE_CHANNEL, {
+		id: event.id,
+		agent: event.agent,
+		agentSource: "bundled",
+		status: event.status,
+		index: event.index,
+	});
+}
+
+function sanitizeAgentId(label: string, index: number): string {
+	const slug = label
+		.replace(/[^A-Za-z0-9_-]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 40);
+	return `${index}-${slug || "workflow-agent"}`;
 }

--- a/packages/coding-agent/src/tools/workflow/agent.ts
+++ b/packages/coding-agent/src/tools/workflow/agent.ts
@@ -40,12 +40,16 @@ export interface StructuredOutputCapture<T = unknown> {
 }
 
 function createStructuredOutputTool(capture: StructuredOutputCapture, schema: unknown): CustomTool {
-	const { validator, error } = buildOutputValidator(schema);
+	const { validator, jsonSchema, error } = buildOutputValidator(schema);
 	if (error) throw new Error(`Invalid structured_output schema: ${error}`);
+	const baseDescription = "Return the final machine-readable result for this subagent task.";
+	const description = jsonSchema
+		? `${baseDescription} The arguments MUST conform to this JSON Schema:\n${JSON.stringify(jsonSchema, null, 2)}`
+		: baseDescription;
 	return {
 		name: "structured_output",
 		label: "Structured Output",
-		description: "Return the final machine-readable result for this subagent task.",
+		description,
 		parameters: z.object({}).passthrough(),
 		async execute(_toolCallId, params) {
 			if (validator) {
@@ -98,50 +102,59 @@ export class WorkflowAgent {
 		const capture: StructuredOutputCapture = { called: false, value: undefined };
 		const customTools: CustomTool[] = [...this.#baseTools, ...(options.tools ?? [])];
 
-		if (options.schema !== undefined) {
-			customTools.push(createStructuredOutputTool(capture, options.schema));
-		}
-
 		const runIndex = ++this.#runIndex;
 		const agentDisplayName = options.label ?? `workflow agent ${runIndex}`;
 		const parentTaskPrefix = this.#sessionOptions.parentTaskPrefix;
 		const agentId = `${parentTaskPrefix ? `${parentTaskPrefix}-` : ""}${sanitizeAgentId(agentDisplayName, runIndex)}`;
 		const inheritedCustomTools = this.#sessionOptions.customTools ?? [];
 
-		const mcpProxyTools = this.#sessionOptions.mcpManager ? createMCPProxyTools(this.#sessionOptions.mcpManager) : [];
-		const { session } = await createAgentSession({
-			...this.#sessionOptions,
-			cwd: this.#cwd,
-			settings: createSubagentSettings(this.#sessionOptions.settings),
-			sessionManager: SessionManager.inMemory(),
-			customTools: [...mcpProxyTools, ...inheritedCustomTools, ...customTools],
-			requireYieldTool: true,
-			taskDepth: this.#sessionOptions.taskDepth ?? 0,
-			hasUI: false,
-			parentTaskPrefix,
-			agentId,
-			agentDisplayName,
-			enableMCP: !this.#sessionOptions.mcpManager,
-			telemetry: createWorkflowSubagentTelemetry(this.#sessionOptions.telemetry, {
-				id: agentId,
-				name: agentDisplayName,
-				description: "Workflow subagent",
-			}),
-		});
-
-		await removeParentOwnedTools(session);
-		emitLifecycle(this.#sessionOptions, {
-			id: agentId,
-			agent: agentDisplayName,
-			status: "started",
-			index: runIndex - 1,
-		});
-
+		let session: AgentSession | undefined;
 		let removeAbortListener: (() => void) | undefined;
 		try {
+			// Build the structured-output tool inside the lifecycle scope so a bad
+			// user schema becomes a typed Error that workflow's agent() catch sees as
+			// a slot failure, instead of crashing run() before any "failed" lifecycle
+			// event is emitted.
+			if (options.schema !== undefined) {
+				customTools.push(createStructuredOutputTool(capture, options.schema));
+			}
+
+			const mcpProxyTools = this.#sessionOptions.mcpManager
+				? createMCPProxyTools(this.#sessionOptions.mcpManager, this.#mcpCallTimeoutMs())
+				: [];
+			const created = await createAgentSession({
+				...this.#sessionOptions,
+				cwd: this.#cwd,
+				settings: createSubagentSettings(this.#sessionOptions.settings),
+				sessionManager: SessionManager.inMemory(),
+				customTools: [...mcpProxyTools, ...inheritedCustomTools, ...customTools],
+				requireYieldTool: true,
+				taskDepth: this.#sessionOptions.taskDepth ?? 0,
+				hasUI: false,
+				parentTaskPrefix,
+				agentId,
+				agentDisplayName,
+				enableMCP: !this.#sessionOptions.mcpManager,
+				telemetry: createWorkflowSubagentTelemetry(this.#sessionOptions.telemetry, {
+					id: agentId,
+					name: agentDisplayName,
+					description: "Workflow subagent",
+				}),
+			});
+			session = created.session;
+
+			await removeParentOwnedTools(session);
+			emitLifecycle(this.#sessionOptions, {
+				id: agentId,
+				agent: agentDisplayName,
+				status: "started",
+				index: runIndex - 1,
+			});
+
 			if (options.signal?.aborted) throw new Error("Subagent was aborted");
 			if (options.signal) {
-				const onAbort = () => void session.abort();
+				const activeSession = session;
+				const onAbort = () => void activeSession.abort();
 				options.signal.addEventListener("abort", onAbort, { once: true });
 				removeAbortListener = () => options.signal?.removeEventListener("abort", onAbort);
 			}
@@ -180,8 +193,14 @@ export class WorkflowAgent {
 			throw error;
 		} finally {
 			removeAbortListener?.();
-			void session.dispose();
+			if (session) void session.dispose();
 		}
+	}
+
+	#mcpCallTimeoutMs(): number {
+		const settings = this.#sessionOptions.settings;
+		const value = settings?.get("workflow.mcpCallTimeoutMs");
+		return typeof value === "number" && value >= 0 ? value : 60_000;
 	}
 
 	#structuredOutputValue(capture: StructuredOutputCapture): unknown {

--- a/packages/coding-agent/src/tools/workflow/display.ts
+++ b/packages/coding-agent/src/tools/workflow/display.ts
@@ -1,0 +1,186 @@
+import type { AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
+import { Text } from "@oh-my-pi/pi-tui";
+import type { WorkflowMeta } from "./workflow.js";
+
+export type WorkflowAgentStatus = "queued" | "running" | "done" | "error" | "skipped";
+
+export interface WorkflowAgentSnapshot {
+	id: number;
+	label: string;
+	phase?: string;
+	prompt: string;
+	status: WorkflowAgentStatus;
+	resultPreview?: string;
+	error?: string;
+}
+
+export interface WorkflowSnapshot {
+	name: string;
+	description?: string;
+	phases: string[];
+	currentPhase?: string;
+	logs: string[];
+	agents: WorkflowAgentSnapshot[];
+	agentCount: number;
+	runningCount: number;
+	doneCount: number;
+	errorCount: number;
+	durationMs?: number;
+	result?: unknown;
+}
+
+export interface WorkflowDisplay {
+	update(snapshot: WorkflowSnapshot): void;
+	complete(snapshot: WorkflowSnapshot): void;
+	clear(): void;
+}
+
+export interface WorkflowDisplayOptions {
+	key?: string;
+	placement?: "aboveEditor" | "belowEditor";
+	maxAgents?: number;
+	maxLogs?: number;
+	showStatus?: boolean;
+	showResultPreviews?: boolean;
+}
+
+export function createWorkflowSnapshot(meta: WorkflowMeta): WorkflowSnapshot {
+	return {
+		name: meta.name,
+		description: meta.description,
+		phases: meta.phases?.map((phase) => phase.title) ?? [],
+		logs: [],
+		agents: [],
+		agentCount: 0,
+		runningCount: 0,
+		doneCount: 0,
+		errorCount: 0,
+	};
+}
+
+export function recomputeWorkflowSnapshot(snapshot: WorkflowSnapshot): WorkflowSnapshot {
+	const runningCount = snapshot.agents.filter((agent) => agent.status === "running").length;
+	const doneCount = snapshot.agents.filter((agent) => agent.status === "done").length;
+	const errorCount = snapshot.agents.filter((agent) => agent.status === "error").length;
+	return { ...snapshot, agentCount: snapshot.agents.length, runningCount, doneCount, errorCount };
+}
+
+export function createToolUpdateWorkflowDisplay(
+	onUpdate: AgentToolUpdateCallback | undefined,
+	options: WorkflowDisplayOptions & { streamToolUpdates?: boolean } = {},
+): WorkflowDisplay {
+	const streamToolUpdates = options.streamToolUpdates ?? true;
+
+	const emit = (snapshot: WorkflowSnapshot, completed = false) => {
+		if (streamToolUpdates) {
+			onUpdate?.({
+				content: [{ type: "text", text: renderWorkflowText(snapshot, completed) }],
+				details: snapshot,
+			});
+		}
+	};
+
+	return {
+		update(snapshot) {
+			emit(snapshot, false);
+		},
+		complete(snapshot) {
+			emit(snapshot, true);
+		},
+		clear() {
+			// No-op for streaming-only display
+		},
+	};
+}
+
+export function renderWorkflowLines(snapshot: WorkflowSnapshot, options: WorkflowDisplayOptions = {}): string[] {
+	const maxAgents = options.maxAgents ?? 8;
+	const maxLogs = options.maxLogs ?? 2;
+	const showResultPreviews = options.showResultPreviews ?? false;
+	const state =
+		snapshot.errorCount > 0
+			? `, ${snapshot.errorCount} errors`
+			: snapshot.runningCount > 0
+				? `, ${snapshot.runningCount} running`
+				: "";
+	const lines = [`◆ Workflow: ${snapshot.name} (${snapshot.doneCount}/${snapshot.agentCount} done${state})`];
+
+	const phaseNames = snapshot.phases.length
+		? snapshot.phases
+		: unique(snapshot.agents.map((agent) => agent.phase).filter(Boolean) as string[]);
+	const rendered = new Set<WorkflowAgentSnapshot>();
+
+	for (const phase of phaseNames) {
+		const agents = snapshot.agents.filter((agent) => agent.phase === phase);
+		for (const agent of agents) rendered.add(agent);
+		const done = agents.filter((agent) => agent.status === "done").length;
+		const running = agents.filter((agent) => agent.status === "running").length;
+		const errors = agents.filter((agent) => agent.status === "error").length;
+		const skipped = agents.filter((agent) => agent.status === "skipped").length;
+		const complete = agents.length > 0 && done + errors + skipped === agents.length;
+		const marker = running > 0 || (!complete && snapshot.currentPhase === phase) ? "▶" : complete ? "✓" : " ";
+		lines.push(
+			`  ${marker} ${phase} ${done}/${agents.length}${running ? ` · ${running} running` : ""}${errors ? ` · ${errors} errors` : ""}${skipped ? ` · ${skipped} skipped` : ""}`,
+		);
+
+		const visibleAgents = agents.slice(-maxAgents);
+		for (const agent of visibleAgents) {
+			const order = `#${agent.id}`;
+			const result = showResultPreviews && agent.resultPreview ? ` — ${agent.resultPreview}` : "";
+			lines.push(`    ${order} ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${result}`);
+		}
+		if (agents.length > visibleAgents.length)
+			lines.push(`    … ${agents.length - visibleAgents.length} earlier agents`);
+	}
+
+	const unphased = snapshot.agents.filter((agent) => !rendered.has(agent));
+	if (unphased.length) {
+		lines.push("  Unphased");
+		for (const agent of unphased.slice(-maxAgents)) {
+			const result = showResultPreviews && agent.resultPreview ? ` — ${agent.resultPreview}` : "";
+			lines.push(`    #${agent.id} ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${result}`);
+		}
+	}
+
+	for (const log of snapshot.logs.slice(-maxLogs)) lines.push(`  log: ${log}`);
+	return lines;
+}
+
+export function renderWorkflowText(snapshot: WorkflowSnapshot, completed = false): string {
+	const header = completed ? "Workflow completed" : "Workflow running";
+	return [header, ...renderWorkflowLines(snapshot)].join("\n");
+}
+
+export function renderWorkflowComponent(snapshot: WorkflowSnapshot, completed = false): Text {
+	return new Text(renderWorkflowText(snapshot, completed), 0, 0);
+}
+
+function statusIcon(status: WorkflowAgentStatus): string {
+	switch (status) {
+		case "queued":
+			return "○";
+		case "running":
+			return "●";
+		case "done":
+			return "✓";
+		case "error":
+			return "✗";
+		case "skipped":
+			return "-";
+	}
+}
+
+function unique(values: string[]): string[] {
+	return [...new Set(values)];
+}
+
+function shorten(value: string, max: number): string {
+	const text = value.replace(/\s+/g, " ").trim();
+	return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+export function preview(value: unknown, max = 80): string {
+	const text = typeof value === "string" ? value : JSON.stringify(value);
+	if (!text) return "";
+	return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}

--- a/packages/coding-agent/src/tools/workflow/display.ts
+++ b/packages/coding-agent/src/tools/workflow/display.ts
@@ -48,7 +48,7 @@ export function createWorkflowSnapshot(meta: WorkflowMeta): WorkflowSnapshot {
 	return {
 		name: meta.name,
 		description: meta.description,
-		phases: meta.phases?.map((phase) => phase.title) ?? [],
+		phases: meta.phases?.map(phase => phase.title) ?? [],
 		logs: [],
 		agents: [],
 		agentCount: 0,
@@ -59,9 +59,9 @@ export function createWorkflowSnapshot(meta: WorkflowMeta): WorkflowSnapshot {
 }
 
 export function recomputeWorkflowSnapshot(snapshot: WorkflowSnapshot): WorkflowSnapshot {
-	const runningCount = snapshot.agents.filter((agent) => agent.status === "running").length;
-	const doneCount = snapshot.agents.filter((agent) => agent.status === "done").length;
-	const errorCount = snapshot.agents.filter((agent) => agent.status === "error").length;
+	const runningCount = snapshot.agents.filter(agent => agent.status === "running").length;
+	const doneCount = snapshot.agents.filter(agent => agent.status === "done").length;
+	const errorCount = snapshot.agents.filter(agent => agent.status === "error").length;
 	return { ...snapshot, agentCount: snapshot.agents.length, runningCount, doneCount, errorCount };
 }
 
@@ -107,16 +107,16 @@ export function renderWorkflowLines(snapshot: WorkflowSnapshot, options: Workflo
 
 	const phaseNames = snapshot.phases.length
 		? snapshot.phases
-		: unique(snapshot.agents.map((agent) => agent.phase).filter(Boolean) as string[]);
+		: unique(snapshot.agents.map(agent => agent.phase).filter(Boolean) as string[]);
 	const rendered = new Set<WorkflowAgentSnapshot>();
 
 	for (const phase of phaseNames) {
-		const agents = snapshot.agents.filter((agent) => agent.phase === phase);
+		const agents = snapshot.agents.filter(agent => agent.phase === phase);
 		for (const agent of agents) rendered.add(agent);
-		const done = agents.filter((agent) => agent.status === "done").length;
-		const running = agents.filter((agent) => agent.status === "running").length;
-		const errors = agents.filter((agent) => agent.status === "error").length;
-		const skipped = agents.filter((agent) => agent.status === "skipped").length;
+		const done = agents.filter(agent => agent.status === "done").length;
+		const running = agents.filter(agent => agent.status === "running").length;
+		const errors = agents.filter(agent => agent.status === "error").length;
+		const skipped = agents.filter(agent => agent.status === "skipped").length;
 		const complete = agents.length > 0 && done + errors + skipped === agents.length;
 		const marker = running > 0 || (!complete && snapshot.currentPhase === phase) ? "▶" : complete ? "✓" : " ";
 		lines.push(
@@ -133,7 +133,7 @@ export function renderWorkflowLines(snapshot: WorkflowSnapshot, options: Workflo
 			lines.push(`    … ${agents.length - visibleAgents.length} earlier agents`);
 	}
 
-	const unphased = snapshot.agents.filter((agent) => !rendered.has(agent));
+	const unphased = snapshot.agents.filter(agent => !rendered.has(agent));
 	if (unphased.length) {
 		lines.push("  Unphased");
 		for (const agent of unphased.slice(-maxAgents)) {

--- a/packages/coding-agent/src/tools/workflow/display.ts
+++ b/packages/coding-agent/src/tools/workflow/display.ts
@@ -1,5 +1,6 @@
 import type { AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import { Text } from "@oh-my-pi/pi-tui";
+import { replaceTabs, shortenPath, TRUNCATE_LENGTHS, truncateToWidth } from "../render-utils";
 import type { WorkflowMeta } from "./workflow.js";
 
 export type WorkflowAgentStatus = "queued" | "running" | "done" | "error" | "skipped";
@@ -120,7 +121,7 @@ export function renderWorkflowLines(snapshot: WorkflowSnapshot, options: Workflo
 		const complete = agents.length > 0 && done + errors + skipped === agents.length;
 		const marker = running > 0 || (!complete && snapshot.currentPhase === phase) ? "▶" : complete ? "✓" : " ";
 		lines.push(
-			`  ${marker} ${phase} ${done}/${agents.length}${running ? ` · ${running} running` : ""}${errors ? ` · ${errors} errors` : ""}${skipped ? ` · ${skipped} skipped` : ""}`,
+			`  ${marker} ${sanitizeLine(phase, TRUNCATE_LENGTHS.TITLE)} ${done}/${agents.length}${running ? ` · ${running} running` : ""}${errors ? ` · ${errors} errors` : ""}${skipped ? ` · ${skipped} skipped` : ""}`,
 		);
 
 		const visibleAgents = agents.slice(-maxAgents);
@@ -142,7 +143,7 @@ export function renderWorkflowLines(snapshot: WorkflowSnapshot, options: Workflo
 		}
 	}
 
-	for (const log of snapshot.logs.slice(-maxLogs)) lines.push(`  log: ${log}`);
+	for (const log of snapshot.logs.slice(-maxLogs)) lines.push(`  log: ${sanitizeLine(log, TRUNCATE_LENGTHS.LINE)}`);
 	return lines;
 }
 
@@ -175,12 +176,16 @@ function unique(values: string[]): string[] {
 }
 
 function shorten(value: string, max: number): string {
-	const text = value.replace(/\s+/g, " ").trim();
-	return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+	return sanitizeLine(value, max);
 }
 
-export function preview(value: unknown, max = 80): string {
+export function preview(value: unknown, max = TRUNCATE_LENGTHS.CONTENT): string {
 	const text = typeof value === "string" ? value : JSON.stringify(value);
 	if (!text) return "";
-	return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+	return sanitizeLine(text, max);
+}
+
+function sanitizeLine(value: string, max: number): string {
+	const text = replaceTabs(shortenPath(value)).replace(/\s+/g, " ").trim();
+	return truncateToWidth(text, max);
 }

--- a/packages/coding-agent/src/tools/workflow/index.ts
+++ b/packages/coding-agent/src/tools/workflow/index.ts
@@ -1,0 +1,22 @@
+export type { AgentRunOptions, AgentRunResult, WorkflowAgentOptions } from "./agent.js";
+export { WorkflowAgent } from "./agent.js";
+export type {
+	WorkflowAgentSnapshot,
+	WorkflowAgentStatus,
+	WorkflowDisplay,
+	WorkflowDisplayOptions,
+	WorkflowSnapshot,
+} from "./display.js";
+export {
+	createToolUpdateWorkflowDisplay,
+	createWorkflowSnapshot,
+	preview,
+	recomputeWorkflowSnapshot,
+	renderWorkflowComponent,
+	renderWorkflowLines,
+	renderWorkflowText,
+} from "./display.js";
+export type { AgentOptions, WorkflowMeta, WorkflowMetaPhase, WorkflowRunOptions, WorkflowRunResult } from "./workflow.js";
+export { parseWorkflowScript, runWorkflow } from "./workflow.js";
+export type { WorkflowToolDetails, WorkflowToolInput } from "./workflow-tool.js";
+export { WorkflowTool } from "./workflow-tool.js";

--- a/packages/coding-agent/src/tools/workflow/index.ts
+++ b/packages/coding-agent/src/tools/workflow/index.ts
@@ -16,7 +16,13 @@ export {
 	renderWorkflowLines,
 	renderWorkflowText,
 } from "./display.js";
-export type { AgentOptions, WorkflowMeta, WorkflowMetaPhase, WorkflowRunOptions, WorkflowRunResult } from "./workflow.js";
+export type {
+	AgentOptions,
+	WorkflowMeta,
+	WorkflowMetaPhase,
+	WorkflowRunOptions,
+	WorkflowRunResult,
+} from "./workflow.js";
 export { parseWorkflowScript, runWorkflow } from "./workflow.js";
 export type { WorkflowToolDetails, WorkflowToolInput } from "./workflow-tool.js";
 export { WorkflowTool } from "./workflow-tool.js";

--- a/packages/coding-agent/src/tools/workflow/index.ts
+++ b/packages/coding-agent/src/tools/workflow/index.ts
@@ -18,6 +18,7 @@ export {
 } from "./display.js";
 export type {
 	AgentOptions,
+	SlotResult,
 	WorkflowMeta,
 	WorkflowMetaPhase,
 	WorkflowRunOptions,

--- a/packages/coding-agent/src/tools/workflow/workflow-tool.ts
+++ b/packages/coding-agent/src/tools/workflow/workflow-tool.ts
@@ -1,9 +1,4 @@
-import type {
-	AgentTool,
-	AgentToolContext,
-	AgentToolResult,
-	AgentToolUpdateCallback,
-} from "@oh-my-pi/pi-agent-core";
+import type { AgentTool, AgentToolContext, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import { Text } from "@oh-my-pi/pi-tui";
 import { z } from "zod";
 import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
@@ -15,10 +10,10 @@ import {
 	preview,
 	recomputeWorkflowSnapshot,
 	renderWorkflowComponent,
-	renderWorkflowText,
 	type WorkflowSnapshot,
 } from "./display.js";
 import { parseWorkflowScript, runWorkflow, type WorkflowRunResult } from "./workflow.js";
+
 const workflowSchema = z.object({
 	script: z
 		.string()
@@ -41,7 +36,7 @@ export interface WorkflowToolDetails {
 	logs: string[];
 	result: unknown;
 	durationMs: number;
-	[ key: string ]: unknown;
+	[key: string]: unknown;
 }
 
 export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowToolDetails, Theme> {
@@ -108,6 +103,12 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 				cwd: this.#session.cwd,
 				args: params.args,
 				signal,
+				session: {
+					settings: this.#session.settings,
+					authStorage: this.#session.authStorage,
+					modelRegistry: this.#session.modelRegistry,
+					taskDepth: (this.#session.taskDepth ?? 0) + 1,
+				},
 				onLog(message) {
 					snapshot.logs.push(message);
 					update();
@@ -131,9 +132,10 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 				onAgentEnd(event) {
 					const agent = [...snapshot.agents]
 						.reverse()
-						.find((item) => item.label === event.label && item.status === "running");
+						.find(item => item.label === event.label && item.status === "running");
 					if (agent) {
-						agent.status = event.result === null ? "error" : "done";
+						agent.status = event.error ? "error" : "done";
+						if (event.error) agent.error = event.error;
 						agent.resultPreview = preview(event.result);
 					}
 					update();
@@ -183,15 +185,11 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 		};
 	}
 
-	renderCall(args: WorkflowToolInput, _options: RenderResultOptions, theme: Theme) {
+	renderCall(_args: WorkflowToolInput, _options: RenderResultOptions, theme: Theme) {
 		return new Text(theme.fg("toolTitle", theme.bold("workflow")), 0, 0);
 	}
 
-	renderResult(
-		result: AgentToolResult<WorkflowToolDetails>,
-		options: RenderResultOptions,
-		_theme: Theme,
-	) {
+	renderResult(result: AgentToolResult<WorkflowToolDetails>, options: RenderResultOptions, _theme: Theme) {
 		const snapshot = result.details as WorkflowSnapshot | undefined;
 		if (snapshot?.name) {
 			return renderWorkflowComponent(snapshot, !options.isPartial);

--- a/packages/coding-agent/src/tools/workflow/workflow-tool.ts
+++ b/packages/coding-agent/src/tools/workflow/workflow-tool.ts
@@ -59,7 +59,7 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 		return workflowSchema;
 	}
 
-	private constructor(session: ToolSession) {
+	constructor(session: ToolSession) {
 		this.#session = session;
 	}
 

--- a/packages/coding-agent/src/tools/workflow/workflow-tool.ts
+++ b/packages/coding-agent/src/tools/workflow/workflow-tool.ts
@@ -1,0 +1,214 @@
+import type {
+	AgentTool,
+	AgentToolContext,
+	AgentToolResult,
+	AgentToolUpdateCallback,
+} from "@oh-my-pi/pi-agent-core";
+import { Text } from "@oh-my-pi/pi-tui";
+import { z } from "zod";
+import type { RenderResultOptions } from "../../extensibility/custom-tools/types";
+import type { Theme } from "../../modes/theme/theme";
+import type { ToolSession } from "../index";
+import {
+	createToolUpdateWorkflowDisplay,
+	createWorkflowSnapshot,
+	preview,
+	recomputeWorkflowSnapshot,
+	renderWorkflowComponent,
+	renderWorkflowText,
+	type WorkflowSnapshot,
+} from "./display.js";
+import { parseWorkflowScript, runWorkflow, type WorkflowRunResult } from "./workflow.js";
+const workflowSchema = z.object({
+	script: z
+		.string()
+		.describe(
+			[
+				"Required raw JavaScript workflow script, with no Markdown fences.",
+				"First statement: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] }",
+				"Use phase('Name'), agent(prompt, opts), parallel(arrayOfFunctions), pipeline(items, ...stages), log(message), args, and budget. The workflow must call agent() at least once.",
+				"parallel() requires functions, not promises: await parallel(items.map(item => () => agent(...))).",
+			].join(" "),
+		),
+	args: z.any().optional().describe("Optional JSON value exposed to the workflow script as global `args`."),
+});
+
+export type WorkflowToolInput = z.infer<typeof workflowSchema>;
+
+export interface WorkflowToolDetails {
+	meta: WorkflowRunResult["meta"];
+	phases: string[];
+	logs: string[];
+	result: unknown;
+	durationMs: number;
+	[ key: string ]: unknown;
+}
+
+export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowToolDetails, Theme> {
+	readonly name = "workflow";
+	readonly label = "Workflow";
+	readonly summary = "Execute a deterministic JavaScript workflow that orchestrates multiple subagents";
+	readonly approval = "exec" as const;
+	readonly loadMode = "discoverable" as const;
+	readonly strict = true;
+	readonly #session: ToolSession;
+
+	get description(): string {
+		return [
+			"Execute a deterministic JavaScript workflow that orchestrates multiple subagents with agent(), parallel(), and pipeline().",
+			"script is required raw JavaScript. It must start with export const meta = { name, description, phases? } and must call agent() at least once.",
+		].join(" ");
+	}
+
+	get parameters(): typeof workflowSchema {
+		return workflowSchema;
+	}
+
+	private constructor(session: ToolSession) {
+		this.#session = session;
+	}
+
+	static createIf(session: ToolSession): WorkflowTool | null {
+		if (!session.settings.get("workflow.enabled")) return null;
+		return new WorkflowTool(session);
+	}
+
+	formatApprovalDetails(args: unknown): string[] {
+		const params = args as Partial<WorkflowToolInput>;
+		const script = params.script ?? "";
+		const firstLine = script.split("\n")[0] ?? "";
+		return [firstLine];
+	}
+
+	async execute(
+		_toolCallId: string,
+		params: WorkflowToolInput,
+		signal?: AbortSignal,
+		onUpdate?: AgentToolUpdateCallback<WorkflowToolDetails>,
+		_context?: AgentToolContext,
+	): Promise<AgentToolResult<WorkflowToolDetails>> {
+		const script = normalizeWorkflowScript(params.script);
+		const parsed = parseWorkflowScript(script);
+		let snapshot: WorkflowSnapshot = createWorkflowSnapshot(parsed.meta);
+		const display = createToolUpdateWorkflowDisplay(onUpdate, {
+			streamToolUpdates: true,
+			maxAgents: 4,
+			maxLogs: 1,
+			showResultPreviews: false,
+		});
+
+		const update = () => {
+			snapshot = recomputeWorkflowSnapshot(snapshot);
+			display.update(snapshot);
+		};
+
+		let result: WorkflowRunResult;
+		try {
+			result = await runWorkflow(script, {
+				cwd: this.#session.cwd,
+				args: params.args,
+				signal,
+				onLog(message) {
+					snapshot.logs.push(message);
+					update();
+				},
+				onPhase(title) {
+					snapshot.currentPhase = title;
+					if (!snapshot.phases.includes(title)) snapshot.phases.push(title);
+					update();
+				},
+				onAgentStart(event) {
+					if (signal?.aborted) throw new Error("Workflow was aborted");
+					snapshot.agents.push({
+						id: snapshot.agents.length + 1,
+						label: event.label,
+						phase: event.phase,
+						prompt: event.prompt,
+						status: "running",
+					});
+					update();
+				},
+				onAgentEnd(event) {
+					const agent = [...snapshot.agents]
+						.reverse()
+						.find((item) => item.label === event.label && item.status === "running");
+					if (agent) {
+						agent.status = event.result === null ? "error" : "done";
+						agent.resultPreview = preview(event.result);
+					}
+					update();
+				},
+			});
+		} catch (error) {
+			if (signal?.aborted || isAbortError(error)) {
+				for (const agent of snapshot.agents) {
+					if (agent.status === "running") {
+						agent.status = "skipped";
+						agent.error = "aborted";
+					}
+				}
+				snapshot = recomputeWorkflowSnapshot(snapshot);
+				display.complete(snapshot);
+				throw new Error("Workflow was aborted");
+			}
+			throw error;
+		}
+
+		if (result.agentCount === 0) {
+			throw new Error(
+				"workflow scripts must call agent() at least once; this workflow declared phases but did not run any subagents",
+			);
+		}
+
+		snapshot.result = result.result;
+		snapshot.durationMs = result.durationMs;
+		snapshot = recomputeWorkflowSnapshot(snapshot);
+		display.complete(snapshot);
+
+		return {
+			content: [
+				{
+					type: "text",
+					text: `Workflow ${result.meta.name} completed with ${result.agentCount} agent(s).\n\nResult:\n${JSON.stringify(result.result, null, 2)}`,
+				},
+			],
+			details: {
+				...snapshot,
+				meta: result.meta,
+				phases: result.phases,
+				logs: result.logs,
+				result: result.result,
+				durationMs: result.durationMs,
+			},
+		};
+	}
+
+	renderCall(args: WorkflowToolInput, _options: RenderResultOptions, theme: Theme) {
+		return new Text(theme.fg("toolTitle", theme.bold("workflow")), 0, 0);
+	}
+
+	renderResult(
+		result: AgentToolResult<WorkflowToolDetails>,
+		options: RenderResultOptions,
+		_theme: Theme,
+	) {
+		const snapshot = result.details as WorkflowSnapshot | undefined;
+		if (snapshot?.name) {
+			return renderWorkflowComponent(snapshot, !options.isPartial);
+		}
+		const text = result.content?.[0];
+		return new Text(text?.type === "text" ? text.text : "workflow", 0, 0);
+	}
+}
+
+function normalizeWorkflowScript(script: string): string {
+	let text = script.trim();
+	const fence = text.match(/^```(?:js|javascript)?\s*\n([\s\S]*?)\n```$/i);
+	if (fence) text = fence[1].trim();
+	return text;
+}
+
+function isAbortError(error: unknown): boolean {
+	if (!(error instanceof Error)) return false;
+	return /\babort(?:ed)?\b/i.test(error.message);
+}

--- a/packages/coding-agent/src/tools/workflow/workflow-tool.ts
+++ b/packages/coding-agent/src/tools/workflow/workflow-tool.ts
@@ -23,6 +23,7 @@ const workflowSchema = z.object({
 				"First statement: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] }",
 				"Use phase('Name'), agent(prompt, opts), parallel(arrayOfFunctions), pipeline(items, ...stages), log(message), args, and budget. The workflow must call agent() at least once.",
 				"parallel() requires functions, not promises: await parallel(items.map(item => () => agent(...))).",
+				"parallel() and pipeline() return per-slot results as { ok: true, value } | { ok: false, error: string }. Inspect r.ok before using r.value; null is a valid value (not a failure sentinel).",
 			].join(" "),
 		),
 	args: z.any().optional().describe("Optional JSON value exposed to the workflow script as global `args`."),
@@ -52,6 +53,7 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 		return [
 			"Execute a deterministic JavaScript workflow that orchestrates multiple subagents with agent(), parallel(), and pipeline().",
 			"script is required raw JavaScript. It must start with export const meta = { name, description, phases? } and must call agent() at least once.",
+			"parallel() and pipeline() return per-slot results shaped as { ok: true, value } | { ok: false, error: string }. The model must inspect r.ok before reading r.value because null is a valid value (an agent that intentionally returned nothing).",
 		].join(" ");
 	}
 

--- a/packages/coding-agent/src/tools/workflow/workflow-tool.ts
+++ b/packages/coding-agent/src/tools/workflow/workflow-tool.ts
@@ -70,9 +70,18 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 
 	formatApprovalDetails(args: unknown): string[] {
 		const params = args as Partial<WorkflowToolInput>;
-		const script = params.script ?? "";
-		const firstLine = script.split("\n")[0] ?? "";
-		return [firstLine];
+		const script = normalizeWorkflowScript(params.script ?? "");
+		try {
+			const { meta } = parseWorkflowScript(script);
+			const lines = [`${meta.name}: ${meta.description}`];
+			if (meta.phases?.length) {
+				lines.push(`Phases: ${meta.phases.map(phase => phase.title).join(" → ")}`);
+			}
+			return lines;
+		} catch {
+			const firstLine = script.split("\n")[0] ?? "";
+			return [firstLine];
+		}
 	}
 
 	async execute(
@@ -103,11 +112,25 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 				cwd: this.#session.cwd,
 				args: params.args,
 				signal,
+				concurrency: this.#session.settings.get("workflow.maxConcurrency"),
+				scriptTimeoutMs: this.#session.settings.get("workflow.scriptTimeoutMs"),
 				session: {
 					settings: this.#session.settings,
 					authStorage: this.#session.authStorage,
 					modelRegistry: this.#session.modelRegistry,
 					taskDepth: (this.#session.taskDepth ?? 0) + 1,
+					hasUI: false,
+					eventBus: this.#session.eventBus,
+					agentRegistry: this.#session.agentRegistry,
+					parentTaskPrefix: this.#session.getAgentId?.() ?? undefined,
+					parentHindsightSessionState: this.#session.getHindsightSessionState?.(),
+					parentMnemosyneSessionState: this.#session.getMnemosyneSessionState?.(),
+					parentEvalSessionId: this.#session.getEvalSessionId?.() ?? undefined,
+					enableLsp: this.#session.enableLsp,
+					enableMCP: !this.#session.mcpManager,
+					mcpManager: this.#session.mcpManager,
+					localProtocolOptions: this.#session.localProtocolOptions,
+					telemetry: this.#session.getTelemetry?.(),
 				},
 				onLog(message) {
 					snapshot.logs.push(message);
@@ -134,7 +157,7 @@ export class WorkflowTool implements AgentTool<typeof workflowSchema, WorkflowTo
 						.reverse()
 						.find(item => item.label === event.label && item.status === "running");
 					if (agent) {
-						agent.status = event.error ? "error" : "done";
+						agent.status = event.failed ? "error" : "done";
 						if (event.error) agent.error = event.error;
 						agent.resultPreview = preview(event.result);
 					}

--- a/packages/coding-agent/src/tools/workflow/workflow.ts
+++ b/packages/coding-agent/src/tools/workflow/workflow.ts
@@ -54,11 +54,58 @@ interface RuntimeState {
 
 type AnyNode = Node & { [key: string]: any; start: number; end: number };
 
-const DETERMINISM_BLOCKLIST = /\bDate\s*\.\s*now\b|\bMath\s*\.\s*random\b|\bnew\s+Date\s*\(\s*\)/;
 const DEFAULT_WORKFLOW_CONCURRENCY = 4;
 const DEFAULT_SCRIPT_TIMEOUT_MS = 5000;
 const SUPPORTED_AGENT_OPTION_KEYS = new Set<keyof AgentOptions>(["label", "phase", "schema", "agentType"]);
-const HARDEN_INTRINSICS_SCRIPT = `
+const DISALLOWED_GLOBALS = new Set(["Atomics", "Date", "eval", "Function", "globalThis", "SharedArrayBuffer"]);
+const DISALLOWED_LOOP_TYPES = new Set([
+	"DoWhileStatement",
+	"ForInStatement",
+	"ForOfStatement",
+	"ForStatement",
+	"WhileStatement",
+]);
+const BOOTSTRAP_CONTEXT_SCRIPT = `
+function __workflowDeepFreeze(value) {
+	if (!value || (typeof value !== "object" && typeof value !== "function")) return value;
+	if (Array.isArray(value)) {
+		for (const item of value) __workflowDeepFreeze(item);
+		Object.freeze(value);
+		return value;
+	}
+	if (Object.getPrototypeOf(value) === Object.prototype) Object.setPrototypeOf(value, null);
+	for (const key of Reflect.ownKeys(value)) __workflowDeepFreeze(value[key]);
+	Object.freeze(value);
+	return value;
+}
+const __workflowMath = Object.create(null);
+for (const key of Object.getOwnPropertyNames(Math)) {
+	if (key === "random") continue;
+	Object.defineProperty(__workflowMath, key, Object.getOwnPropertyDescriptor(Math, key));
+}
+Object.freeze(__workflowMath);
+Object.defineProperty(globalThis, "Math", {
+	value: __workflowMath,
+	configurable: false,
+	enumerable: false,
+	writable: false,
+});
+Object.defineProperty(globalThis, "Date", {
+	value: undefined,
+	configurable: false,
+	enumerable: false,
+	writable: false,
+});
+for (const key of ["Atomics", "SharedArrayBuffer"]) {
+	Object.defineProperty(globalThis, key, {
+		value: undefined,
+		configurable: false,
+		enumerable: false,
+		writable: false,
+	});
+}
+`;
+const FINALIZE_CONTEXT_SCRIPT = `
 for (const value of [
 	Array,
 	Boolean,
@@ -88,9 +135,13 @@ for (const value of [
 	String.prototype,
 	TypeError.prototype,
 ]) Object.freeze(value);
-Object.freeze(console);
-Object.freeze(process);
-Object.freeze(budget);
+delete globalThis.__workflowDeepFreeze;
+Object.defineProperty(globalThis, "globalThis", {
+	value: undefined,
+	configurable: false,
+	enumerable: false,
+	writable: false,
+});
 `;
 
 export async function runWorkflow<T = unknown>(
@@ -216,14 +267,14 @@ export async function runWorkflow<T = unknown>(
 		phase,
 		args: options.args,
 		cwd: options.cwd ?? process.cwd(),
-		process: Object.freeze({ cwd: hardenCallable(() => options.cwd ?? process.cwd()) }),
+		process: { cwd: () => options.cwd ?? process.cwd() },
 		budget,
-		console: Object.freeze({
-			log: hardenCallable((message: unknown) => log(String(message))),
-			info: hardenCallable((message: unknown) => log(String(message))),
-			warn: hardenCallable((message: unknown) => log(`[warn] ${String(message)}`)),
-			error: hardenCallable((message: unknown) => log(`[error] ${String(message)}`)),
-		}),
+		console: {
+			log: (message: unknown) => log(String(message)),
+			info: (message: unknown) => log(String(message)),
+			warn: (message: unknown) => log(`[warn] ${String(message)}`),
+			error: (message: unknown) => log(`[error] ${String(message)}`),
+		},
 	});
 
 	const wrapped = `(async () => {\n${body}\n})()`;
@@ -241,10 +292,6 @@ export async function runWorkflow<T = unknown>(
 }
 
 export function parseWorkflowScript(script: string): { meta: WorkflowMeta; body: string } {
-	if (DETERMINISM_BLOCKLIST.test(script)) {
-		throw new Error("Workflow scripts must be deterministic: Date.now()/Math.random()/new Date() are unavailable");
-	}
-
 	const ast = parse(script, {
 		ecmaVersion: "latest",
 		sourceType: "module",
@@ -274,7 +321,7 @@ export function parseWorkflowScript(script: string): { meta: WorkflowMeta; body:
 
 	const meta = evaluateLiteral(declarator.init, "meta");
 	validateMeta(meta);
-
+	validateWorkflowBody(ast, first);
 	return {
 		meta,
 		body: script.slice(0, first.start) + script.slice(first.end),
@@ -344,17 +391,153 @@ function validateMeta(meta: unknown): asserts meta is WorkflowMeta {
 	}
 }
 
+function validateWorkflowBody(ast: AnyNode, metaExport: AnyNode): void {
+	for (const statement of ast.body as AnyNode[]) {
+		if (statement === metaExport) continue;
+		validateWorkflowNode(statement);
+	}
+}
+
+function validateWorkflowNode(node: AnyNode): void {
+	if (DISALLOWED_LOOP_TYPES.has(node.type)) {
+		throw new Error("Workflow scripts cannot use synchronous loops; use parallel() or pipeline() instead");
+	}
+	if (node.type === "Identifier" && DISALLOWED_GLOBALS.has(node.name)) {
+		throw new Error(`Workflow scripts must be deterministic: ${node.name} is unavailable`);
+	}
+	if (node.type === "MemberExpression") {
+		const property = staticMemberProperty(node);
+		if (isIdentifierNode(node.object, "Date") && property === "now") {
+			throw new Error("Workflow scripts must be deterministic: Date.now() is unavailable");
+		}
+		if (isIdentifierNode(node.object, "Math") && property === "random") {
+			throw new Error("Workflow scripts must be deterministic: Math.random() is unavailable");
+		}
+	}
+
+	for (const [key, value] of Object.entries(node)) {
+		if (key === "start" || key === "end" || key === "loc" || key === "range") continue;
+		if (node.type === "Property" && key === "key" && !node.computed) continue;
+		if (node.type === "MemberExpression" && key === "property" && !node.computed) continue;
+		if (Array.isArray(value)) {
+			for (const item of value) {
+				if (isAstNode(item)) validateWorkflowNode(item);
+			}
+			continue;
+		}
+		if (isAstNode(value)) validateWorkflowNode(value);
+	}
+}
+
+function isAstNode(value: unknown): value is AnyNode {
+	return !!value && typeof value === "object" && typeof (value as { type?: unknown }).type === "string";
+}
+
+function isIdentifierNode(value: unknown, name: string): boolean {
+	return isAstNode(value) && value.type === "Identifier" && value.name === name;
+}
+
+function staticMemberProperty(node: AnyNode): string | null {
+	const property = node.property as AnyNode | undefined;
+	if (!property) return null;
+	if (!node.computed && property.type === "Identifier") return property.name;
+	if (property.type === "Literal" && (typeof property.value === "string" || typeof property.value === "number")) {
+		return String(property.value);
+	}
+	return null;
+}
+
 function createWorkflowContext(globals: Record<string, unknown>): vm.Context {
 	const context = vm.createContext(Object.create(null), {
 		codeGeneration: { strings: false, wasm: false },
 	});
+	new vm.Script(BOOTSTRAP_CONTEXT_SCRIPT, { filename: "workflow-bootstrap.js" }).runInContext(context, {
+		timeout: 100,
+	});
 	for (const [key, value] of Object.entries(globals)) {
-		context[key] = typeof value === "function" ? hardenCallable(value) : value;
+		installWorkflowGlobal(context, key, value);
 	}
-	new vm.Script(HARDEN_INTRINSICS_SCRIPT, { filename: "workflow-intrinsics.js" }).runInContext(context, {
+	new vm.Script(FINALIZE_CONTEXT_SCRIPT, { filename: "workflow-finalize.js" }).runInContext(context, {
 		timeout: 100,
 	});
 	return context;
+}
+
+function installWorkflowGlobal(context: vm.Context, key: string, value: unknown): void {
+	switch (key) {
+		case "args":
+		case "cwd":
+			installJsonGlobal(context, key, value);
+			return;
+		case "budget": {
+			const budget = value as { total: unknown; spent: () => number; remaining: () => number };
+			context.__workflowBudgetSpent = hardenCallable(budget.spent);
+			context.__workflowBudgetRemaining = hardenCallable(budget.remaining);
+			installJsonGlobal(context, "__workflowBudgetTotal", budget.total);
+			new vm.Script(
+				`globalThis.budget = __workflowDeepFreeze(Object.assign(Object.create(null), {
+					total: __workflowBudgetTotal,
+					spent() { return __workflowBudgetSpent(); },
+					remaining() { return __workflowBudgetRemaining(); },
+				}));
+				delete globalThis.__workflowBudgetTotal;
+				delete globalThis.__workflowBudgetSpent;
+				delete globalThis.__workflowBudgetRemaining;`,
+				{ filename: "workflow-budget.js" },
+			).runInContext(context, { timeout: 100 });
+			return;
+		}
+		case "process": {
+			const processShim = value as { cwd: () => string };
+			context.__workflowProcessCwd = hardenCallable(processShim.cwd);
+			new vm.Script(
+				`globalThis.process = __workflowDeepFreeze(Object.assign(Object.create(null), {
+					cwd() { return __workflowProcessCwd(); },
+				}));
+				delete globalThis.__workflowProcessCwd;`,
+				{ filename: "workflow-process.js" },
+			).runInContext(context, { timeout: 100 });
+			return;
+		}
+		case "console": {
+			const consoleShim = value as Record<string, (message: unknown) => void>;
+			context.__workflowConsoleLog = hardenCallable(consoleShim.log);
+			context.__workflowConsoleInfo = hardenCallable(consoleShim.info);
+			context.__workflowConsoleWarn = hardenCallable(consoleShim.warn);
+			context.__workflowConsoleError = hardenCallable(consoleShim.error);
+			new vm.Script(
+				`globalThis.console = __workflowDeepFreeze(Object.assign(Object.create(null), {
+					log(message) { return __workflowConsoleLog(message); },
+					info(message) { return __workflowConsoleInfo(message); },
+					warn(message) { return __workflowConsoleWarn(message); },
+					error(message) { return __workflowConsoleError(message); },
+				}));
+				delete globalThis.__workflowConsoleLog;
+				delete globalThis.__workflowConsoleInfo;
+				delete globalThis.__workflowConsoleWarn;
+				delete globalThis.__workflowConsoleError;`,
+				{ filename: "workflow-console.js" },
+			).runInContext(context, { timeout: 100 });
+			return;
+		}
+		default:
+			context[key] = typeof value === "function" ? hardenCallable(value) : value;
+	}
+}
+
+function installJsonGlobal(context: vm.Context, key: string, value: unknown): void {
+	if (value === undefined) {
+		context[key] = undefined;
+		return;
+	}
+	const json = JSON.stringify(value);
+	if (json === undefined) {
+		context[key] = undefined;
+		return;
+	}
+	new vm.Script(`globalThis[${JSON.stringify(key)}] = __workflowDeepFreeze(JSON.parse(${JSON.stringify(json)}));`, {
+		filename: "workflow-json-global.js",
+	}).runInContext(context, { timeout: 100 });
 }
 
 function hardenCallable<T>(fn: T): T {

--- a/packages/coding-agent/src/tools/workflow/workflow.ts
+++ b/packages/coding-agent/src/tools/workflow/workflow.ts
@@ -1,0 +1,350 @@
+import vm from "node:vm";
+import type { Node } from "acorn";
+import { parse } from "acorn";
+import type { WorkflowAgent, WorkflowAgentOptions } from "./agent.js";
+export interface WorkflowMetaPhase {
+	title: string;
+	detail?: string;
+	model?: string;
+}
+
+export interface WorkflowMeta {
+	name: string;
+	description: string;
+	whenToUse?: string;
+	phases?: WorkflowMetaPhase[];
+}
+
+export interface WorkflowRunOptions extends WorkflowAgentOptions {
+	args?: unknown;
+	agent?: Pick<WorkflowAgent, "run">;
+	concurrency?: number;
+	tokenBudget?: number | null;
+	signal?: AbortSignal;
+	onLog?: (message: string) => void;
+	onPhase?: (title: string) => void;
+	onAgentStart?: (event: { label: string; phase?: string; prompt: string }) => void;
+	onAgentEnd?: (event: { label: string; phase?: string; result: unknown }) => void;
+}
+
+export interface WorkflowRunResult<T = unknown> {
+	meta: WorkflowMeta;
+	result: T;
+	logs: string[];
+	phases: string[];
+	agentCount: number;
+	durationMs: number;
+}
+
+export interface AgentOptions {
+	label?: string;
+	phase?: string;
+	schema?: unknown;
+	model?: string;
+	isolation?: "worktree";
+	agentType?: string;
+}
+
+interface RuntimeState {
+	currentPhase?: string;
+	logs: string[];
+	phases: string[];
+	agentCount: number;
+	spent: number;
+}
+
+type AnyNode = Node & { [key: string]: any; start: number; end: number };
+
+const DETERMINISM_BLOCKLIST = /\bDate\s*\.\s*now\b|\bMath\s*\.\s*random\b|\bnew\s+Date\s*\(\s*\)/;
+
+export async function runWorkflow<T = unknown>(
+	script: string,
+	options: WorkflowRunOptions = {},
+): Promise<WorkflowRunResult<T>> {
+	const started = Date.now();
+	const { meta, body } = parseWorkflowScript(script);
+	const state: RuntimeState = { logs: [], phases: [], agentCount: 0, spent: 0 };
+	const agentRunner = options.agent ?? new (await import("./agent.js")).WorkflowAgent(options);
+	const concurrency = Math.max(
+		1,
+		Math.min(options.concurrency ?? Math.max(1, (globalThis.navigator?.hardwareConcurrency ?? 8) - 2), 16),
+	);
+	const limiter = createLimiter(concurrency);
+
+	const log = (message: string) => {
+		const text = String(message);
+		state.logs.push(text);
+		options.onLog?.(text);
+	};
+
+	const phase = (title: string) => {
+		state.currentPhase = title;
+		if (!state.phases.includes(title)) state.phases.push(title);
+		options.onPhase?.(title);
+	};
+
+	const budget = Object.freeze({
+		total: options.tokenBudget ?? null,
+		spent: () => state.spent,
+		remaining: () => (options.tokenBudget == null ? Infinity : Math.max(0, options.tokenBudget - state.spent)),
+	});
+
+	const throwIfAborted = () => {
+		if (options.signal?.aborted) throw new Error("workflow aborted");
+	};
+
+	const agent = async (prompt: string, agentOptions: AgentOptions = {}) => {
+		throwIfAborted();
+		if (budget.total !== null && budget.remaining() <= 0) throw new Error("workflow token budget exhausted");
+		const assignedPhase = agentOptions.phase ?? state.currentPhase;
+		const requestedLabel = agentOptions.label?.trim();
+		return limiter(async () => {
+			state.agentCount++;
+			const label = requestedLabel || defaultAgentLabel(assignedPhase, state.agentCount);
+			options.onAgentStart?.({ label, phase: assignedPhase, prompt });
+			try {
+				throwIfAborted();
+				const result = await agentRunner.run(prompt, {
+					label,
+					schema: agentOptions.schema,
+					signal: options.signal,
+					instructions: buildAgentInstructions(assignedPhase, agentOptions),
+				});
+				throwIfAborted();
+				state.spent += estimateTokens(result);
+				options.onAgentEnd?.({ label, phase: assignedPhase, result });
+				return result;
+			} catch (error) {
+				if (options.signal?.aborted) throw error;
+				log(`agent ${label} failed: ${error instanceof Error ? error.message : String(error)}`);
+				options.onAgentEnd?.({ label, phase: assignedPhase, result: null });
+				return null;
+			}
+		});
+	};
+
+	const parallel = async (thunks: Array<() => Promise<unknown>>) => {
+		throwIfAborted();
+		if (!Array.isArray(thunks)) throw new TypeError("parallel() expects an array of functions");
+		if (thunks.some((thunk) => typeof thunk !== "function")) {
+			throw new TypeError("parallel() expects an array of functions, not promises. Wrap each call: () => agent(...)");
+		}
+		return Promise.all(
+			thunks.map(async (thunk, index) => {
+				try {
+					return await thunk();
+				} catch (error) {
+					if (options.signal?.aborted) throw error;
+					log(`parallel[${index}] failed: ${error instanceof Error ? error.message : String(error)}`);
+					return null;
+				}
+			}),
+		);
+	};
+
+	const pipeline = async (
+		items: unknown[],
+		...stages: Array<(prev: unknown, original: unknown, index: number) => unknown>
+	) => {
+		throwIfAborted();
+		if (!Array.isArray(items)) throw new TypeError("pipeline() expects an array as the first argument");
+		if (stages.some((stage) => typeof stage !== "function")) {
+			throw new TypeError("pipeline() stages must be functions: pipeline(items, item => ..., result => ...)");
+		}
+		return Promise.all(
+			items.map(async (item, index) => {
+				let value: unknown = item;
+				for (const stage of stages) {
+					try {
+						throwIfAborted();
+						value = await stage(value, item, index);
+						throwIfAborted();
+					} catch (error) {
+						if (options.signal?.aborted) throw error;
+						log(`pipeline[${index}] failed: ${error instanceof Error ? error.message : String(error)}`);
+						return null;
+					}
+				}
+				return value;
+			}),
+		);
+	};
+
+	const context = vm.createContext({
+		agent,
+		parallel,
+		pipeline,
+		log,
+		phase,
+		args: options.args,
+		cwd: options.cwd ?? process.cwd(),
+		process: Object.freeze({ cwd: () => options.cwd ?? process.cwd() }),
+		budget,
+		console: {
+			log,
+			info: log,
+			warn: (m: unknown) => log(`[warn] ${String(m)}`),
+			error: (m: unknown) => log(`[error] ${String(m)}`),
+		},
+		JSON,
+		Math,
+		Array,
+		Object,
+		String,
+		Number,
+		Boolean,
+		Set,
+		Map,
+		Promise,
+	});
+
+	const wrapped = `(async () => {\n${body}\n})()`;
+	const result = await new vm.Script(wrapped, { filename: `${meta.name || "workflow"}.js` }).runInContext(context);
+	return {
+		meta,
+		result: result as T,
+		logs: state.logs,
+		phases: state.phases,
+		agentCount: state.agentCount,
+		durationMs: Date.now() - started,
+	};
+}
+
+export function parseWorkflowScript(script: string): { meta: WorkflowMeta; body: string } {
+	if (DETERMINISM_BLOCKLIST.test(script)) {
+		throw new Error("Workflow scripts must be deterministic: Date.now()/Math.random()/new Date() are unavailable");
+	}
+
+	const ast = parse(script, {
+		ecmaVersion: "latest",
+		sourceType: "module",
+		allowAwaitOutsideFunction: true,
+		allowReturnOutsideFunction: true,
+		ranges: false,
+	}) as AnyNode;
+
+	const first = ast.body?.[0] as AnyNode | undefined;
+	if (first?.type !== "ExportNamedDeclaration") {
+		throw new Error("`export const meta = { name, description, phases }` must be the first statement in the script");
+	}
+
+	const declaration = first.declaration as AnyNode | null;
+	if (declaration?.type !== "VariableDeclaration" || declaration.kind !== "const") {
+		throw new Error("meta export must be `export const meta = ...`");
+	}
+	if (declaration.declarations.length !== 1) {
+		throw new Error("meta export must declare only `meta`");
+	}
+
+	const declarator = declaration.declarations[0] as AnyNode;
+	if (declarator.id?.type !== "Identifier" || declarator.id.name !== "meta") {
+		throw new Error("meta export must declare `meta`");
+	}
+	if (!declarator.init) throw new Error("meta must have a literal value");
+
+	const meta = evaluateLiteral(declarator.init, "meta");
+	validateMeta(meta);
+
+	return {
+		meta,
+		body: script.slice(0, first.start) + script.slice(first.end),
+	};
+}
+
+function evaluateLiteral(node: AnyNode, path: string): unknown {
+	switch (node.type) {
+		case "ObjectExpression": {
+			const out: Record<string, unknown> = {};
+			for (const prop of node.properties as AnyNode[]) {
+				if (prop.type === "SpreadElement") throw new Error(`spread not allowed in ${path}`);
+				if (prop.type !== "Property") throw new Error(`only plain properties allowed in ${path}`);
+				if (prop.computed) throw new Error(`computed keys not allowed in ${path}`);
+				if (prop.kind !== "init" || prop.method) throw new Error(`methods/accessors not allowed in ${path}`);
+				const key = propertyKey(prop.key as AnyNode, path);
+				if (key === "__proto__" || key === "constructor" || key === "prototype") {
+					throw new Error(`reserved key name not allowed in ${path}: ${key}`);
+				}
+				out[key] = evaluateLiteral(prop.value as AnyNode, `${path}.${key}`);
+			}
+			return out;
+		}
+		case "ArrayExpression":
+			return (node.elements as Array<AnyNode | null>).map((element, index) => {
+				if (!element) throw new Error(`sparse arrays not allowed in ${path}`);
+				if (element.type === "SpreadElement") throw new Error(`spread not allowed in ${path}`);
+				return evaluateLiteral(element, `${path}[${index}]`);
+			});
+		case "Literal":
+			return node.value;
+		case "TemplateLiteral":
+			if (node.expressions.length > 0) throw new Error(`template interpolation not allowed in ${path}`);
+			return node.quasis.map((quasi: AnyNode) => quasi.value.cooked ?? quasi.value.raw).join("");
+		case "UnaryExpression":
+			if (node.operator === "-" && node.argument?.type === "Literal" && typeof node.argument.value === "number") {
+				return -node.argument.value;
+			}
+			throw new Error(`only negative-number unary allowed in ${path}`);
+		default:
+			throw new Error(`non-literal node type in ${path}: ${node.type}`);
+	}
+}
+
+function propertyKey(node: AnyNode, path: string): string {
+	if (node.type === "Identifier") return node.name;
+	if (node.type === "Literal" && (typeof node.value === "string" || typeof node.value === "number"))
+		return String(node.value);
+	throw new Error(`unsupported key type in ${path}: ${node.type}`);
+}
+
+function validateMeta(meta: unknown): asserts meta is WorkflowMeta {
+	if (!meta || typeof meta !== "object") throw new Error("meta must be an object");
+	const value = meta as WorkflowMeta;
+	if (typeof value.name !== "string" || !value.name.trim()) throw new Error("meta.name must be a non-empty string");
+	if (typeof value.description !== "string" || !value.description.trim())
+		throw new Error("meta.description must be a non-empty string");
+	if (value.whenToUse !== undefined && typeof value.whenToUse !== "string")
+		throw new Error("meta.whenToUse must be a string");
+	if (value.phases !== undefined) {
+		if (!Array.isArray(value.phases)) throw new Error("meta.phases must be an array");
+		for (const phase of value.phases) {
+			if (!phase || typeof phase !== "object" || typeof (phase as WorkflowMetaPhase).title !== "string") {
+				throw new Error("each meta phase must have a title string");
+			}
+		}
+	}
+}
+
+function createLimiter(limit: number) {
+	let active = 0;
+	const queue: Array<() => void> = [];
+	const next = () => {
+		active--;
+		queue.shift()?.();
+	};
+	return async <T>(fn: () => Promise<T>): Promise<T> => {
+		if (active >= limit) await new Promise<void>((resolve) => queue.push(resolve));
+		active++;
+		try {
+			return await fn();
+		} finally {
+			next();
+		}
+	};
+}
+
+function defaultAgentLabel(phase: string | undefined, index: number): string {
+	return phase ? `${phase} agent ${index}` : `agent ${index}`;
+}
+
+function buildAgentInstructions(phase: string | undefined, options: AgentOptions): string | undefined {
+	const lines = [];
+	if (phase) lines.push(`Workflow phase: ${phase}`);
+	if (options.agentType) lines.push(`Act as workflow subagent type: ${options.agentType}`);
+	if (options.isolation) lines.push(`Requested isolation: ${options.isolation}`);
+	if (options.model) lines.push(`Requested model: ${options.model}`);
+	return lines.length ? lines.join("\n") : undefined;
+}
+
+function estimateTokens(value: unknown): number {
+	return Math.ceil(JSON.stringify(value ?? "").length / 4);
+}

--- a/packages/coding-agent/src/tools/workflow/workflow.ts
+++ b/packages/coding-agent/src/tools/workflow/workflow.ts
@@ -44,6 +44,14 @@ export interface AgentOptions {
 	agentType?: string;
 }
 
+/**
+ * Per-slot outcome returned by `parallel()` and `pipeline()`. The model MUST
+ * inspect `.ok` before reading `.value` — `null` is a valid `value` for an agent
+ * that intentionally returned nothing, so `result === null` cannot be used as a
+ * failure sentinel.
+ */
+export type SlotResult<T = unknown> = { ok: true; value: T } | { ok: false; error: string };
+
 interface RuntimeState {
 	currentPhase?: string;
 	logs: string[];
@@ -202,7 +210,7 @@ export async function runWorkflow<T = unknown>(
 				return result;
 			} catch (error) {
 				if (options.signal?.aborted) throw error;
-				const errorMessage = error instanceof Error ? error.message : String(error);
+				const errorMessage = extractErrorMessage(error);
 				log(`agent ${label} failed: ${errorMessage}`);
 				options.onAgentEnd?.({ label, phase: assignedPhase, result: null, failed: true, error: errorMessage });
 				return null;
@@ -210,7 +218,7 @@ export async function runWorkflow<T = unknown>(
 		});
 	};
 
-	const parallel = async (thunks: Array<() => Promise<unknown>>) => {
+	const parallel = async (thunks: Array<() => Promise<unknown>>): Promise<SlotResult[]> => {
 		throwIfAborted();
 		if (!Array.isArray(thunks)) throw new TypeError("parallel() expects an array of functions");
 		if (thunks.some(thunk => typeof thunk !== "function")) {
@@ -219,13 +227,14 @@ export async function runWorkflow<T = unknown>(
 			);
 		}
 		return Promise.all(
-			thunks.map(async (thunk, index) => {
+			thunks.map(async (thunk, index): Promise<SlotResult> => {
 				try {
-					return await thunk();
+					return { ok: true, value: await thunk() };
 				} catch (error) {
 					if (options.signal?.aborted) throw error;
-					log(`parallel[${index}] failed: ${error instanceof Error ? error.message : String(error)}`);
-					return null;
+					const message = extractErrorMessage(error);
+					log(`parallel[${index}] failed: ${message}`);
+					return { ok: false, error: message };
 				}
 			}),
 		);
@@ -234,14 +243,14 @@ export async function runWorkflow<T = unknown>(
 	const pipeline = async (
 		items: unknown[],
 		...stages: Array<(prev: unknown, original: unknown, index: number) => unknown>
-	) => {
+	): Promise<SlotResult[]> => {
 		throwIfAborted();
 		if (!Array.isArray(items)) throw new TypeError("pipeline() expects an array as the first argument");
 		if (stages.some(stage => typeof stage !== "function")) {
 			throw new TypeError("pipeline() stages must be functions: pipeline(items, item => ..., result => ...)");
 		}
 		return Promise.all(
-			items.map(async (item, index) => {
+			items.map(async (item, index): Promise<SlotResult> => {
 				let value: unknown = item;
 				for (const stage of stages) {
 					try {
@@ -250,11 +259,12 @@ export async function runWorkflow<T = unknown>(
 						throwIfAborted();
 					} catch (error) {
 						if (options.signal?.aborted) throw error;
-						log(`pipeline[${index}] failed: ${error instanceof Error ? error.message : String(error)}`);
-						return null;
+						const message = extractErrorMessage(error);
+						log(`pipeline[${index}] failed: ${message}`);
+						return { ok: false, error: message };
 					}
 				}
-				return value;
+				return { ok: true, value };
 			}),
 		);
 	};
@@ -278,6 +288,15 @@ export async function runWorkflow<T = unknown>(
 	});
 
 	const wrapped = `(async () => {\n${body}\n})()`;
+	// vm.Script's `timeout` only bounds *synchronous* execution within runInContext.
+	// Async continuations (await, microtasks, setTimeout) are not interrupted by it,
+	// so a script that awaits forever — `for (;;) await null` — would never be killed.
+	// The user-body loop ban (DISALLOWED_LOOP_TYPES, validated in validateWorkflowBody)
+	// is what prevents that async-bypass DoS: with no synchronous `for`/`while`/`do`/
+	// `for...of`/`for...in`, a malicious script cannot construct an unbounded await loop
+	// at all. Future contributors lifting the loop ban MUST add an alternate budget
+	// (e.g. a wall-clock deadline checked via signal, or cooperative cancellation
+	// through the agent/parallel/pipeline helpers) before re-enabling user loops.
 	const result = await new vm.Script(wrapped, { filename: `${meta.name || "workflow"}.js` }).runInContext(context, {
 		timeout: scriptTimeoutMs,
 	});
@@ -582,6 +601,22 @@ function createLimiter(limit: number) {
 			next();
 		}
 	};
+}
+
+/**
+ * Extract a string error message from any thrown value, including cross-realm
+ * `Error` instances. `instanceof Error` returns false for an Error constructed
+ * inside the workflow vm context (different realm), so a plain `String(error)`
+ * fallback produces `"Error: <message>"` instead of `<message>`. Use this when
+ * surfacing errors that may originate from user-script code.
+ */
+function extractErrorMessage(error: unknown): string {
+	if (error instanceof Error) return error.message;
+	if (error !== null && typeof error === "object") {
+		const message = (error as { message?: unknown }).message;
+		if (typeof message === "string") return message;
+	}
+	return String(error);
 }
 
 function defaultAgentLabel(phase: string | undefined, index: number): string {

--- a/packages/coding-agent/src/tools/workflow/workflow.ts
+++ b/packages/coding-agent/src/tools/workflow/workflow.ts
@@ -19,12 +19,13 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
 	args?: unknown;
 	agent?: Pick<WorkflowAgent, "run">;
 	concurrency?: number;
+	scriptTimeoutMs?: number;
 	tokenBudget?: number | null;
 	signal?: AbortSignal;
 	onLog?: (message: string) => void;
 	onPhase?: (title: string) => void;
 	onAgentStart?: (event: { label: string; phase?: string; prompt: string }) => void;
-	onAgentEnd?: (event: { label: string; phase?: string; result: unknown; error?: string }) => void;
+	onAgentEnd?: (event: { label: string; phase?: string; result: unknown; failed: boolean; error?: string }) => void;
 }
 
 export interface WorkflowRunResult<T = unknown> {
@@ -40,8 +41,6 @@ export interface AgentOptions {
 	label?: string;
 	phase?: string;
 	schema?: unknown;
-	model?: string;
-	isolation?: "worktree";
 	agentType?: string;
 }
 
@@ -56,6 +55,43 @@ interface RuntimeState {
 type AnyNode = Node & { [key: string]: any; start: number; end: number };
 
 const DETERMINISM_BLOCKLIST = /\bDate\s*\.\s*now\b|\bMath\s*\.\s*random\b|\bnew\s+Date\s*\(\s*\)/;
+const DEFAULT_WORKFLOW_CONCURRENCY = 4;
+const DEFAULT_SCRIPT_TIMEOUT_MS = 5000;
+const SUPPORTED_AGENT_OPTION_KEYS = new Set<keyof AgentOptions>(["label", "phase", "schema", "agentType"]);
+const HARDEN_INTRINSICS_SCRIPT = `
+for (const value of [
+	Array,
+	Boolean,
+	Error,
+	JSON,
+	Map,
+	Math,
+	Number,
+	Object,
+	Promise,
+	Reflect,
+	RegExp,
+	Set,
+	String,
+	TypeError,
+]) Object.freeze(value);
+for (const value of [
+	Array.prototype,
+	Boolean.prototype,
+	Error.prototype,
+	Map.prototype,
+	Number.prototype,
+	Object.prototype,
+	Promise.prototype,
+	RegExp.prototype,
+	Set.prototype,
+	String.prototype,
+	TypeError.prototype,
+]) Object.freeze(value);
+Object.freeze(console);
+Object.freeze(process);
+Object.freeze(budget);
+`;
 
 export async function runWorkflow<T = unknown>(
 	script: string,
@@ -65,10 +101,8 @@ export async function runWorkflow<T = unknown>(
 	const { meta, body } = parseWorkflowScript(script);
 	const state: RuntimeState = { logs: [], phases: [], agentCount: 0, spent: 0 };
 	const agentRunner = options.agent ?? new WorkflowAgent(options);
-	const concurrency = Math.max(
-		1,
-		Math.min(options.concurrency ?? Math.max(1, (globalThis.navigator?.hardwareConcurrency ?? 8) - 2), 16),
-	);
+	const concurrency = Math.max(1, Math.min(options.concurrency ?? DEFAULT_WORKFLOW_CONCURRENCY, 16));
+	const scriptTimeoutMs = Math.max(1, Math.trunc(options.scriptTimeoutMs ?? DEFAULT_SCRIPT_TIMEOUT_MS));
 	const limiter = createLimiter(concurrency);
 
 	const log = (message: string) => {
@@ -103,6 +137,7 @@ export async function runWorkflow<T = unknown>(
 			const label = requestedLabel || defaultAgentLabel(assignedPhase, state.agentCount);
 			options.onAgentStart?.({ label, phase: assignedPhase, prompt });
 			try {
+				validateAgentOptions(agentOptions);
 				throwIfAborted();
 				const result = await agentRunner.run(prompt, {
 					label,
@@ -112,13 +147,13 @@ export async function runWorkflow<T = unknown>(
 				});
 				throwIfAborted();
 				state.spent += estimateTokens(result);
-				options.onAgentEnd?.({ label, phase: assignedPhase, result });
+				options.onAgentEnd?.({ label, phase: assignedPhase, result, failed: false });
 				return result;
 			} catch (error) {
 				if (options.signal?.aborted) throw error;
 				const errorMessage = error instanceof Error ? error.message : String(error);
 				log(`agent ${label} failed: ${errorMessage}`);
-				options.onAgentEnd?.({ label, phase: assignedPhase, result: null, error: errorMessage });
+				options.onAgentEnd?.({ label, phase: assignedPhase, result: null, failed: true, error: errorMessage });
 				return null;
 			}
 		});
@@ -173,7 +208,7 @@ export async function runWorkflow<T = unknown>(
 		);
 	};
 
-	const context = vm.createContext({
+	const context = createWorkflowContext({
 		agent,
 		parallel,
 		pipeline,
@@ -181,28 +216,20 @@ export async function runWorkflow<T = unknown>(
 		phase,
 		args: options.args,
 		cwd: options.cwd ?? process.cwd(),
-		process: Object.freeze({ cwd: () => options.cwd ?? process.cwd() }),
+		process: Object.freeze({ cwd: hardenCallable(() => options.cwd ?? process.cwd()) }),
 		budget,
-		console: {
-			log,
-			info: log,
-			warn: (m: unknown) => log(`[warn] ${String(m)}`),
-			error: (m: unknown) => log(`[error] ${String(m)}`),
-		},
-		JSON,
-		Math,
-		Array,
-		Object,
-		String,
-		Number,
-		Boolean,
-		Set,
-		Map,
-		Promise,
+		console: Object.freeze({
+			log: hardenCallable((message: unknown) => log(String(message))),
+			info: hardenCallable((message: unknown) => log(String(message))),
+			warn: hardenCallable((message: unknown) => log(`[warn] ${String(message)}`)),
+			error: hardenCallable((message: unknown) => log(`[error] ${String(message)}`)),
+		}),
 	});
 
 	const wrapped = `(async () => {\n${body}\n})()`;
-	const result = await new vm.Script(wrapped, { filename: `${meta.name || "workflow"}.js` }).runInContext(context);
+	const result = await new vm.Script(wrapped, { filename: `${meta.name || "workflow"}.js` }).runInContext(context, {
+		timeout: scriptTimeoutMs,
+	});
 	return {
 		meta,
 		result: result as T,
@@ -317,6 +344,41 @@ function validateMeta(meta: unknown): asserts meta is WorkflowMeta {
 	}
 }
 
+function createWorkflowContext(globals: Record<string, unknown>): vm.Context {
+	const context = vm.createContext(Object.create(null), {
+		codeGeneration: { strings: false, wasm: false },
+	});
+	for (const [key, value] of Object.entries(globals)) {
+		context[key] = typeof value === "function" ? hardenCallable(value) : value;
+	}
+	new vm.Script(HARDEN_INTRINSICS_SCRIPT, { filename: "workflow-intrinsics.js" }).runInContext(context, {
+		timeout: 100,
+	});
+	return context;
+}
+
+function hardenCallable<T>(fn: T): T {
+	if (typeof fn === "function") {
+		Object.defineProperty(fn, "constructor", {
+			value: undefined,
+			configurable: false,
+			enumerable: false,
+			writable: false,
+		});
+		Object.setPrototypeOf(fn, null);
+		Object.freeze(fn);
+	}
+	return fn;
+}
+
+function validateAgentOptions(options: AgentOptions): void {
+	for (const key of Object.keys(options)) {
+		if (!SUPPORTED_AGENT_OPTION_KEYS.has(key as keyof AgentOptions)) {
+			throw new Error(`agent() option "${key}" is not supported by workflow`);
+		}
+	}
+}
+
 function createLimiter(limit: number) {
 	let active = 0;
 	const queue: Array<() => void> = [];
@@ -325,7 +387,11 @@ function createLimiter(limit: number) {
 		queue.shift()?.();
 	};
 	return async <T>(fn: () => Promise<T>): Promise<T> => {
-		if (active >= limit) await new Promise<void>(resolve => queue.push(resolve));
+		if (active >= limit) {
+			const { promise, resolve } = Promise.withResolvers<void>();
+			queue.push(resolve);
+			await promise;
+		}
 		active++;
 		try {
 			return await fn();
@@ -343,8 +409,6 @@ function buildAgentInstructions(phase: string | undefined, options: AgentOptions
 	const lines = [];
 	if (phase) lines.push(`Workflow phase: ${phase}`);
 	if (options.agentType) lines.push(`Act as workflow subagent type: ${options.agentType}`);
-	if (options.isolation) lines.push(`Requested isolation: ${options.isolation}`);
-	if (options.model) lines.push(`Requested model: ${options.model}`);
 	return lines.length ? lines.join("\n") : undefined;
 }
 

--- a/packages/coding-agent/src/tools/workflow/workflow.ts
+++ b/packages/coding-agent/src/tools/workflow/workflow.ts
@@ -1,7 +1,7 @@
 import vm from "node:vm";
 import type { Node } from "acorn";
 import { parse } from "acorn";
-import type { WorkflowAgent, WorkflowAgentOptions } from "./agent.js";
+import { WorkflowAgent, type WorkflowAgentOptions } from "./agent.js";
 export interface WorkflowMetaPhase {
 	title: string;
 	detail?: string;
@@ -24,7 +24,7 @@ export interface WorkflowRunOptions extends WorkflowAgentOptions {
 	onLog?: (message: string) => void;
 	onPhase?: (title: string) => void;
 	onAgentStart?: (event: { label: string; phase?: string; prompt: string }) => void;
-	onAgentEnd?: (event: { label: string; phase?: string; result: unknown }) => void;
+	onAgentEnd?: (event: { label: string; phase?: string; result: unknown; error?: string }) => void;
 }
 
 export interface WorkflowRunResult<T = unknown> {
@@ -64,7 +64,7 @@ export async function runWorkflow<T = unknown>(
 	const started = Date.now();
 	const { meta, body } = parseWorkflowScript(script);
 	const state: RuntimeState = { logs: [], phases: [], agentCount: 0, spent: 0 };
-	const agentRunner = options.agent ?? new (await import("./agent.js")).WorkflowAgent(options);
+	const agentRunner = options.agent ?? new WorkflowAgent(options);
 	const concurrency = Math.max(
 		1,
 		Math.min(options.concurrency ?? Math.max(1, (globalThis.navigator?.hardwareConcurrency ?? 8) - 2), 16),
@@ -116,8 +116,9 @@ export async function runWorkflow<T = unknown>(
 				return result;
 			} catch (error) {
 				if (options.signal?.aborted) throw error;
-				log(`agent ${label} failed: ${error instanceof Error ? error.message : String(error)}`);
-				options.onAgentEnd?.({ label, phase: assignedPhase, result: null });
+				const errorMessage = error instanceof Error ? error.message : String(error);
+				log(`agent ${label} failed: ${errorMessage}`);
+				options.onAgentEnd?.({ label, phase: assignedPhase, result: null, error: errorMessage });
 				return null;
 			}
 		});
@@ -126,8 +127,10 @@ export async function runWorkflow<T = unknown>(
 	const parallel = async (thunks: Array<() => Promise<unknown>>) => {
 		throwIfAborted();
 		if (!Array.isArray(thunks)) throw new TypeError("parallel() expects an array of functions");
-		if (thunks.some((thunk) => typeof thunk !== "function")) {
-			throw new TypeError("parallel() expects an array of functions, not promises. Wrap each call: () => agent(...)");
+		if (thunks.some(thunk => typeof thunk !== "function")) {
+			throw new TypeError(
+				"parallel() expects an array of functions, not promises. Wrap each call: () => agent(...)",
+			);
 		}
 		return Promise.all(
 			thunks.map(async (thunk, index) => {
@@ -148,7 +151,7 @@ export async function runWorkflow<T = unknown>(
 	) => {
 		throwIfAborted();
 		if (!Array.isArray(items)) throw new TypeError("pipeline() expects an array as the first argument");
-		if (stages.some((stage) => typeof stage !== "function")) {
+		if (stages.some(stage => typeof stage !== "function")) {
 			throw new TypeError("pipeline() stages must be functions: pipeline(items, item => ..., result => ...)");
 		}
 		return Promise.all(
@@ -322,7 +325,7 @@ function createLimiter(limit: number) {
 		queue.shift()?.();
 	};
 	return async <T>(fn: () => Promise<T>): Promise<T> => {
-		if (active >= limit) await new Promise<void>((resolve) => queue.push(resolve));
+		if (active >= limit) await new Promise<void>(resolve => queue.push(resolve));
 		active++;
 		try {
 			return await fn();

--- a/packages/coding-agent/test/workflow/workflow-mcp-timeout.test.ts
+++ b/packages/coding-agent/test/workflow/workflow-mcp-timeout.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, spyOn, test, vi } from "bun:test";
+import { Settings } from "../../src/config/settings";
+import * as mcpClient from "../../src/mcp/client";
+import type { MCPManager } from "../../src/mcp/manager";
+import * as proxyTools from "../../src/mcp/proxy-tools";
+import * as sdkModule from "../../src/sdk";
+import { WorkflowAgent } from "../../src/tools/workflow/agent";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function makeFakeManager(): MCPManager {
+	return {
+		getTools: () => [
+			{
+				name: "slow_tool",
+				label: "slow_tool",
+				description: "slow tool",
+				parameters: {} as never,
+				mcpServerName: "fake",
+				mcpToolName: "slow_tool",
+			},
+		],
+		waitForConnection: async () => ({}) as never,
+	} as unknown as MCPManager;
+}
+
+describe("createMCPProxyTools timeoutMs argument", () => {
+	test("applies the passed-in timeoutMs when the underlying MCP call hangs", async () => {
+		const fakeManager = makeFakeManager();
+		const neverResolving = new Promise(() => {});
+		const callToolSpy = spyOn(mcpClient, "callTool").mockImplementation(() => neverResolving as never);
+
+		try {
+			const tools = proxyTools.createMCPProxyTools(fakeManager, 25);
+			expect(tools).toHaveLength(1);
+
+			const before = Date.now();
+			const result = await tools[0].execute("call-1", {}, undefined as never, undefined as never, undefined);
+			const elapsed = Date.now() - before;
+
+			// The timeout produces a CustomTool error result (per the proxy-tools error
+			// handler), not a thrown error — so we assert on `details.isError` and the
+			// formatted message.
+			expect(result.details?.isError).toBe(true);
+			expect(result.content[0]?.type).toBe("text");
+			expect((result.content[0] as { text: string }).text).toMatch(/MCP tool call timed out after 25ms/);
+			// Elapsed should be near the 25ms budget, definitely under 1s.
+			expect(elapsed).toBeLessThan(1_000);
+		} finally {
+			callToolSpy.mockRestore();
+		}
+	});
+
+	test("defaults to the legacy 60_000ms timeout when no argument is supplied", async () => {
+		const fakeManager = makeFakeManager();
+		const callToolSpy = spyOn(mcpClient, "callTool").mockResolvedValue({
+			content: [{ type: "text", text: "ok" }],
+		} as never);
+
+		try {
+			// No explicit timeout argument — falls back to the default.
+			const tools = proxyTools.createMCPProxyTools(fakeManager);
+			const result = await tools[0].execute("call-2", {}, undefined as never, undefined as never, undefined);
+
+			// Did not time out — call resolved normally with the mocked content.
+			expect(result.details?.isError).toBeUndefined();
+			expect(result.content[0]).toEqual({ type: "text", text: "ok" });
+			expect(callToolSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			callToolSpy.mockRestore();
+		}
+	});
+});
+
+describe("WorkflowAgent reads workflow.mcpCallTimeoutMs from settings", () => {
+	test("forwards the configured timeout value to createMCPProxyTools", async () => {
+		const fakeManager = {
+			getTools: () => [],
+			waitForConnection: async () => ({}) as never,
+		} as unknown as MCPManager;
+
+		const proxySpy = spyOn(proxyTools, "createMCPProxyTools").mockReturnValue([]);
+		// Bail before createAgentSession does any real work; we only need to prove
+		// that createMCPProxyTools sees the workflow-scoped setting first.
+		const sessionSpy = spyOn(sdkModule, "createAgentSession").mockImplementation(async () => {
+			throw new Error("test-stop");
+		});
+
+		try {
+			const settings = Settings.isolated({ "workflow.mcpCallTimeoutMs": 12_345 });
+			const agent = new WorkflowAgent({ session: { settings, mcpManager: fakeManager } });
+
+			await expect(agent.run("hello")).rejects.toThrow(/test-stop/);
+
+			expect(proxySpy).toHaveBeenCalledTimes(1);
+			expect(proxySpy.mock.calls[0]).toEqual([fakeManager, 12_345]);
+			expect(sessionSpy).toHaveBeenCalledTimes(1);
+		} finally {
+			proxySpy.mockRestore();
+			sessionSpy.mockRestore();
+		}
+	});
+
+	test("falls back to the schema default (60_000) when the setting is unset", async () => {
+		const fakeManager = {
+			getTools: () => [],
+			waitForConnection: async () => ({}) as never,
+		} as unknown as MCPManager;
+
+		const proxySpy = spyOn(proxyTools, "createMCPProxyTools").mockReturnValue([]);
+		const sessionSpy = spyOn(sdkModule, "createAgentSession").mockImplementation(async () => {
+			throw new Error("test-stop");
+		});
+
+		try {
+			// Empty isolated settings has no workflow.mcpCallTimeoutMs override; the
+			// schema default (60_000) is what get() returns.
+			const settings = Settings.isolated();
+			const agent = new WorkflowAgent({ session: { settings, mcpManager: fakeManager } });
+
+			await expect(agent.run("hello")).rejects.toThrow(/test-stop/);
+
+			expect(proxySpy.mock.calls[0]).toEqual([fakeManager, 60_000]);
+		} finally {
+			proxySpy.mockRestore();
+			sessionSpy.mockRestore();
+		}
+	});
+});

--- a/packages/coding-agent/test/workflow/workflow-parser.test.ts
+++ b/packages/coding-agent/test/workflow/workflow-parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { parseWorkflowScript } from "../../src/tools/workflow/workflow";
+import { renderWorkflowLines } from "../../src/tools/workflow/display";
+import { parseWorkflowScript, runWorkflow } from "../../src/tools/workflow/workflow";
 
 const validScript = `export const meta = {
   name: 'demo_workflow',
@@ -76,9 +77,8 @@ describe("parseWorkflowScript", () => {
 	});
 
 	test("rejects template interpolation", () => {
-		expect(() => parseWorkflowScript("export const meta = { name: `demo_${id}`, description: 'desc' }")).toThrow(
-			/template interpolation not allowed/,
-		);
+		const interpolation = "export const meta = { name: `demo_$" + "{id}`, description: 'desc' }";
+		expect(() => parseWorkflowScript(interpolation)).toThrow(/template interpolation not allowed/);
 	});
 
 	test("rejects nondeterministic APIs", () => {
@@ -91,5 +91,71 @@ describe("parseWorkflowScript", () => {
 		expect(() =>
 			parseWorkflowScript("export const meta = { name: 'demo', description: 'desc' }\nreturn new Date()"),
 		).toThrow(/must be deterministic/);
+	});
+});
+
+describe("runWorkflow", () => {
+	const script = (body: string) => `export const meta = { name: 'runtime_demo', description: 'desc' }\n${body}`;
+
+	test("reports intentional null agent results as success", async () => {
+		const events: Array<{ failed: boolean; result: unknown }> = [];
+		const result = await runWorkflow(script("return await agent('return null')"), {
+			agent: { run: async () => null },
+			onAgentEnd: event => events.push({ failed: event.failed, result: event.result }),
+		});
+
+		expect(result.result).toBeNull();
+		expect(events).toEqual([{ failed: false, result: null }]);
+	});
+
+	test("rejects unsupported per-agent options instead of silently prompting", async () => {
+		const events: Array<{ failed: boolean; error?: string }> = [];
+		const result = await runWorkflow(script("return await agent('x', { model: 'slow' })"), {
+			agent: {
+				run: async () => {
+					throw new Error("agent should not run");
+				},
+			},
+			onAgentEnd: event => events.push({ failed: event.failed, error: event.error }),
+		});
+
+		expect(result.result).toBeNull();
+		expect(events[0]).toEqual({ failed: true, error: 'agent() option "model" is not supported by workflow' });
+	});
+
+	test("does not expose host process through constructors", async () => {
+		await expect(
+			runWorkflow(script("return Object.constructor('return process')()"), {
+				agent: { run: async () => "unused" },
+				scriptTimeoutMs: 100,
+			}),
+		).rejects.toThrow(/Code generation from strings disallowed|not defined/);
+	});
+
+	test("bounds synchronous script execution", async () => {
+		await expect(
+			runWorkflow(script("while (true) {}"), {
+				agent: { run: async () => "unused" },
+				scriptTimeoutMs: 10,
+			}),
+		).rejects.toThrow(/Script execution timed out|timed out/);
+	});
+});
+
+describe("renderWorkflowLines", () => {
+	test("sanitizes log lines before rendering", () => {
+		const [line] = renderWorkflowLines({
+			name: "demo",
+			phases: [],
+			logs: ["a\t".repeat(80)],
+			agents: [],
+			agentCount: 0,
+			runningCount: 0,
+			doneCount: 0,
+			errorCount: 0,
+		}).slice(-1);
+
+		expect(line).not.toContain("\t");
+		expect(line.length).toBeLessThanOrEqual(120);
 	});
 });

--- a/packages/coding-agent/test/workflow/workflow-parser.test.ts
+++ b/packages/coding-agent/test/workflow/workflow-parser.test.ts
@@ -29,9 +29,9 @@ describe("parseWorkflowScript", () => {
 	});
 
 	test("requires meta export first", () => {
-		expect(() => parseWorkflowScript("const x = 1\nexport const meta = { name: 'demo', description: 'desc' }")).toThrow(
-			/must be the first statement/,
-		);
+		expect(() =>
+			parseWorkflowScript("const x = 1\nexport const meta = { name: 'demo', description: 'desc' }"),
+		).toThrow(/must be the first statement/);
 	});
 
 	test("requires name and description", () => {
@@ -55,9 +55,9 @@ describe("parseWorkflowScript", () => {
 		expect(() => parseWorkflowScript("export const meta = { ...base, name: 'demo', description: 'desc' }")).toThrow(
 			/spread not allowed/,
 		);
-		expect(() =>
-			parseWorkflowScript("export const meta = { ['name']: 'demo', description: 'desc' }"),
-		).toThrow(/computed keys not allowed/);
+		expect(() => parseWorkflowScript("export const meta = { ['name']: 'demo', description: 'desc' }")).toThrow(
+			/computed keys not allowed/,
+		);
 		expect(() =>
 			parseWorkflowScript("export const meta = { __proto__: {}, name: 'demo', description: 'desc' }"),
 		).toThrow(/reserved key name/);
@@ -76,9 +76,9 @@ describe("parseWorkflowScript", () => {
 	});
 
 	test("rejects template interpolation", () => {
-		expect(() =>
-			parseWorkflowScript("export const meta = { name: `demo_${id}`, description: 'desc' }"),
-		).toThrow(/template interpolation not allowed/);
+		expect(() => parseWorkflowScript("export const meta = { name: `demo_${id}`, description: 'desc' }")).toThrow(
+			/template interpolation not allowed/,
+		);
 	});
 
 	test("rejects nondeterministic APIs", () => {

--- a/packages/coding-agent/test/workflow/workflow-parser.test.ts
+++ b/packages/coding-agent/test/workflow/workflow-parser.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import { parseWorkflowScript } from "../../src/tools/workflow/workflow";
+
+const validScript = `export const meta = {
+  name: 'demo_workflow',
+  description: 'A useful workflow',
+  whenToUse: 'When testing parser behavior',
+  phases: [{ title: 'Scan', detail: 'Collect inputs', model: 'default' }]
+}
+
+phase('Scan')
+return { ok: true }
+`;
+
+describe("parseWorkflowScript", () => {
+	test("accepts literal workflow metadata", () => {
+		const parsed = parseWorkflowScript(validScript);
+		expect(parsed.meta.name).toBe("demo_workflow");
+		expect(parsed.meta.description).toBe("A useful workflow");
+		expect(parsed.meta.phases).toEqual([{ title: "Scan", detail: "Collect inputs", model: "default" }]);
+		expect(parsed.body).toContain("phase('Scan')");
+		expect(parsed.body).not.toContain("export const meta");
+	});
+
+	test("accepts static template literals", () => {
+		const parsed = parseWorkflowScript("export const meta = { name: `demo`, description: `static` }\nreturn true");
+		expect(parsed.meta.name).toBe("demo");
+		expect(parsed.meta.description).toBe("static");
+	});
+
+	test("requires meta export first", () => {
+		expect(() => parseWorkflowScript("const x = 1\nexport const meta = { name: 'demo', description: 'desc' }")).toThrow(
+			/must be the first statement/,
+		);
+	});
+
+	test("requires name and description", () => {
+		expect(() => parseWorkflowScript("export const meta = { name: 'demo' }")).toThrow(/meta.description/);
+		expect(() => parseWorkflowScript("export const meta = { description: 'desc' }")).toThrow(/meta.name/);
+	});
+
+	test("rejects non-literal metadata", () => {
+		expect(() => parseWorkflowScript("export const meta = { name: makeName(), description: 'desc' }")).toThrow(
+			/non-literal node type.*CallExpression/,
+		);
+		expect(() =>
+			parseWorkflowScript("const name = 'demo'; export const meta = { name, description: 'desc' }"),
+		).toThrow(/must be the first statement/);
+		expect(() => parseWorkflowScript("export const meta = { name: name, description: 'desc' }")).toThrow(
+			/non-literal node type.*Identifier/,
+		);
+	});
+
+	test("rejects object hazards", () => {
+		expect(() => parseWorkflowScript("export const meta = { ...base, name: 'demo', description: 'desc' }")).toThrow(
+			/spread not allowed/,
+		);
+		expect(() =>
+			parseWorkflowScript("export const meta = { ['name']: 'demo', description: 'desc' }"),
+		).toThrow(/computed keys not allowed/);
+		expect(() =>
+			parseWorkflowScript("export const meta = { __proto__: {}, name: 'demo', description: 'desc' }"),
+		).toThrow(/reserved key name/);
+		expect(() =>
+			parseWorkflowScript("export const meta = { get name() { return 'demo' }, description: 'desc' }"),
+		).toThrow(/methods\/accessors not allowed/);
+	});
+
+	test("rejects array hazards", () => {
+		expect(() =>
+			parseWorkflowScript("export const meta = { name: 'demo', description: 'desc', phases: [,,] }"),
+		).toThrow(/sparse arrays not allowed/);
+		expect(() =>
+			parseWorkflowScript("export const meta = { name: 'demo', description: 'desc', phases: [...items] }"),
+		).toThrow(/spread not allowed/);
+	});
+
+	test("rejects template interpolation", () => {
+		expect(() =>
+			parseWorkflowScript("export const meta = { name: `demo_${id}`, description: 'desc' }"),
+		).toThrow(/template interpolation not allowed/);
+	});
+
+	test("rejects nondeterministic APIs", () => {
+		expect(() =>
+			parseWorkflowScript("export const meta = { name: 'demo', description: 'desc' }\nreturn Date.now()"),
+		).toThrow(/must be deterministic/);
+		expect(() =>
+			parseWorkflowScript("export const meta = { name: 'demo', description: 'desc' }\nreturn Math.random()"),
+		).toThrow(/must be deterministic/);
+		expect(() =>
+			parseWorkflowScript("export const meta = { name: 'demo', description: 'desc' }\nreturn new Date()"),
+		).toThrow(/must be deterministic/);
+	});
+});

--- a/packages/coding-agent/test/workflow/workflow-parser.test.ts
+++ b/packages/coding-agent/test/workflow/workflow-parser.test.ts
@@ -82,15 +82,31 @@ describe("parseWorkflowScript", () => {
 	});
 
 	test("rejects nondeterministic APIs", () => {
+		for (const body of [
+			"return Date()",
+			"return Date.now()",
+			"return Date['now']()",
+			"return Math.random()",
+			"return Math['random']()",
+			"return globalThis.Date()",
+			"return globalThis.Math.random()",
+			"return new Date()",
+		]) {
+			expect(() =>
+				parseWorkflowScript(`export const meta = { name: 'demo', description: 'desc' }\n${body}`),
+			).toThrow(/must be deterministic/);
+		}
+	});
+
+	test("rejects synchronous loops before they can run after awaits", () => {
 		expect(() =>
-			parseWorkflowScript("export const meta = { name: 'demo', description: 'desc' }\nreturn Date.now()"),
-		).toThrow(/must be deterministic/);
+			parseWorkflowScript("export const meta = { name: 'demo', description: 'desc' }\nwhile (true) {}"),
+		).toThrow(/cannot use synchronous loops/);
 		expect(() =>
-			parseWorkflowScript("export const meta = { name: 'demo', description: 'desc' }\nreturn Math.random()"),
-		).toThrow(/must be deterministic/);
-		expect(() =>
-			parseWorkflowScript("export const meta = { name: 'demo', description: 'desc' }\nreturn new Date()"),
-		).toThrow(/must be deterministic/);
+			parseWorkflowScript(
+				"export const meta = { name: 'demo', description: 'desc' }\nawait agent('ok')\nwhile (true) {}",
+			),
+		).toThrow(/cannot use synchronous loops/);
 	});
 });
 
@@ -130,15 +146,12 @@ describe("runWorkflow", () => {
 				scriptTimeoutMs: 100,
 			}),
 		).rejects.toThrow(/Code generation from strings disallowed|not defined/);
-	});
-
-	test("bounds synchronous script execution", async () => {
 		await expect(
-			runWorkflow(script("while (true) {}"), {
+			runWorkflow(script("return budget.constructor.constructor('return process')()"), {
 				agent: { run: async () => "unused" },
-				scriptTimeoutMs: 10,
+				scriptTimeoutMs: 100,
 			}),
-		).rejects.toThrow(/Script execution timed out|timed out/);
+		).rejects.toThrow(/undefined|null/);
 	});
 });
 

--- a/packages/coding-agent/test/workflow/workflow-parser.test.ts
+++ b/packages/coding-agent/test/workflow/workflow-parser.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { WorkflowAgent } from "../../src/tools/workflow/agent";
 import { renderWorkflowLines } from "../../src/tools/workflow/display";
 import { parseWorkflowScript, runWorkflow } from "../../src/tools/workflow/workflow";
 
@@ -152,6 +153,67 @@ describe("runWorkflow", () => {
 				scriptTimeoutMs: 100,
 			}),
 		).rejects.toThrow(/undefined|null/);
+	});
+});
+
+describe("runWorkflow parallel/pipeline slot results", () => {
+	const script = (body: string) => `export const meta = { name: 'slot_demo', description: 'desc' }\n${body}`;
+
+	test("parallel surfaces per-slot failures as {ok:false,error} and preserves null as a valid value", async () => {
+		const result = await runWorkflow(
+			script(`return await parallel([
+				() => null,
+				async () => { throw new Error('boom'); },
+				() => 'fine',
+			])`),
+			{ agent: { run: async () => "unused" } },
+		);
+
+		expect(result.result).toEqual([
+			{ ok: true, value: null },
+			{ ok: false, error: "boom" },
+			{ ok: true, value: "fine" },
+		]);
+	});
+
+	test("pipeline surfaces per-slot failures as {ok:false,error} and preserves null as a valid value", async () => {
+		const result = await runWorkflow(
+			script(`return await pipeline([1, 2, 3], (n) => {
+				if (n === 1) return null;
+				if (n === 2) throw new Error('two-bad');
+				return n * 10;
+			})`),
+			{ agent: { run: async () => "unused" } },
+		);
+
+		expect(result.result).toEqual([
+			{ ok: true, value: null },
+			{ ok: false, error: "two-bad" },
+			{ ok: true, value: 30 },
+		]);
+	});
+});
+
+describe("WorkflowAgent structured_output schema validation", () => {
+	test("rejects with typed Error when options.schema is invalid (boolean false rejects all)", async () => {
+		const agent = new WorkflowAgent();
+		await expect(agent.run("hello", { schema: false })).rejects.toThrow(/Invalid structured_output schema/);
+	});
+
+	test("workflow agent() catches the schema error as a slot failure without crashing the script", async () => {
+		const events: Array<{ failed: boolean; error?: string }> = [];
+		const agent = new WorkflowAgent();
+		const result = await runWorkflow(
+			`export const meta = { name: 'schema_runtime', description: 'desc' }\nreturn await agent('x', { schema: false })`,
+			{
+				agent,
+				onAgentEnd: event => events.push({ failed: event.failed, error: event.error }),
+			},
+		);
+
+		expect(result.result).toBeNull();
+		expect(events[0]?.failed).toBe(true);
+		expect(events[0]?.error).toMatch(/Invalid structured_output schema/);
 	});
 });
 


### PR DESCRIPTION
## Summary

Adds a disabled-by-default `workflow` tool that lets the model write deterministic JavaScript scripts to orchestrate multiple subagents with `agent()`, `parallel()`, `pipeline()`, `phase()`, and `log()` primitives. Ports the `pi-dynamic-workflows` extension pattern into omp core while reusing omp's existing headless-subagent runtime defenses.

## Key design decisions

- **Scripts are sandboxed** in `node:vm`, validated with `acorn` AST parsing, run in a hardened context, and blocked from `Date.now()`, `Math.random()`, `new Date()`, string code generation, and host-realm constructors.
- **Execution is bounded** by `workflow.maxConcurrency` (default 4) and `workflow.scriptTimeoutMs` (default 5000ms).
- **Subagents reuse parent runtime state** for settings, auth/model registry, MCP manager, memory state, telemetry, local URLs, eval session, and agent registry lifecycle.
- **Structured output is validated** with the shared output-schema validator before being accepted.
- **Tool placement**: `discoverable` and gated by `workflow.enabled`, which now defaults to `false` until explicitly enabled.

## Files added

- `src/tools/workflow/workflow.ts` — parser + vm runtime
- `src/tools/workflow/agent.ts` — `WorkflowAgent` for omp
- `src/tools/workflow/display.ts` — sanitized TUI rendering
- `src/tools/workflow/workflow-tool.ts` — tool class
- `src/tools/workflow/index.ts` — barrel exports
- `src/prompts/system/workflow-subagent-prompt.md` — workflow subagent prompt template
- `test/workflow/workflow-parser.test.ts` — parser and runtime tests

## Files modified

- `package.json` (root): added `acorn` to workspace catalog
- `package.json` (coding-agent): added `acorn` dependency
- `src/config/settings-schema.ts`: added `workflow.enabled`, `workflow.maxConcurrency`, and `workflow.scriptTimeoutMs`
- `src/sdk.ts` / `src/tools/index.ts`: expose parent MCP/local protocol context to tools for subagent reuse
- `CHANGELOG.md`: added entry

## Validation

- `bun test packages/coding-agent/test/workflow/workflow-parser.test.ts` — 14/14 pass
- `bun run check:ts` — pass
- Local merge with `origin/main` — clean

Fixes #1544
