### PR TITLE
fix: prevent Windows ORT preload crash

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -103,6 +103,7 @@
       "dependencies": {
         "@oh-my-pi/pi-ai": "catalog:",
         "fastembed": "catalog:",
+        "onnxruntime-node": "catalog:",
       },
       "devDependencies": {
         "@types/bun": "catalog:",
@@ -278,6 +279,7 @@
     "lucide-react": "^1.16.0",
     "marked": "^18.0.4",
     "markit-ai": "0.5.3",
+    "onnxruntime-node": "1.24.3",
     "openai": "^6.39.0",
     "partial-json": "^0.1.7",
     "postcss": "^8.5.15",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
       "lucide-react": "^1.16.0",
       "marked": "^18.0.4",
       "markit-ai": "0.5.3",
+      "onnxruntime-node": "1.24.3",
       "openai": "^6.39.0",
       "partial-json": "^0.1.7",
       "postcss": "^8.5.15",

--- a/packages/mnemosyne/CHANGELOG.md
+++ b/packages/mnemosyne/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Windows startup crashes by keeping fastembed's older ONNX Runtime binding lazy until local embeddings are used.
+
 ## [15.6.0] - 2026-05-30
 
 ### Added

--- a/packages/mnemosyne/package.json
+++ b/packages/mnemosyne/package.json
@@ -40,7 +40,8 @@
 	},
 	"dependencies": {
 		"@oh-my-pi/pi-ai": "catalog:",
-		"fastembed": "catalog:"
+		"fastembed": "catalog:",
+		"onnxruntime-node": "catalog:"
 	},
 	"devDependencies": {
 		"@types/bun": "catalog:"

--- a/packages/mnemosyne/src/core/embeddings.ts
+++ b/packages/mnemosyne/src/core/embeddings.ts
@@ -1,5 +1,6 @@
 import { mkdirSync } from "node:fs";
-import { EmbeddingModel, FlagEmbedding } from "fastembed";
+import { createRequire } from "node:module";
+import type { EmbeddingModel, FlagEmbedding } from "fastembed";
 import { getMnemosyneRuntimeOptions, resolveEmbeddingProvider } from "./runtime-options";
 
 export type Vector = number[];
@@ -24,8 +25,14 @@ type LocalModelInitOptions = {
 };
 type LocalModelInitializer = (options: LocalModelInitOptions) => Promise<LocalEmbeddingModel>;
 
+interface FastembedRuntime {
+	EmbeddingModel: typeof EmbeddingModel;
+	FlagEmbedding: typeof FlagEmbedding;
+}
+
 const FASTEMBED_CACHE_DIR = `${process.env.HOME ?? ""}/.hermes/cache/fastembed`;
 const QUERY_CACHE_MAX = 512;
+const sourceRequire = createRequire(import.meta.url);
 
 let providerOverride: EmbeddingProvider | null = null;
 let localModelPromise: Promise<LocalEmbeddingModel> | null = null;
@@ -33,8 +40,14 @@ let localModelInitializer: LocalModelInitializer = defaultLocalModelInitializer;
 let apiCallCount = 0;
 const queryCache = new Map<string, Vector>();
 
+function loadFastembedRuntime(): FastembedRuntime {
+	// Preload ORT 1.24 before fastembed's ORT 1.21 binding to avoid Windows DLL reuse crashes.
+	sourceRequire("onnxruntime-node");
+	return sourceRequire("fastembed") as FastembedRuntime;
+}
+
 function defaultLocalModelInitializer(options: LocalModelInitOptions): Promise<LocalEmbeddingModel> {
-	return FlagEmbedding.init(options) as Promise<LocalEmbeddingModel>;
+	return loadFastembedRuntime().FlagEmbedding.init(options);
 }
 
 function activeEmbeddingOptions() {
@@ -243,6 +256,7 @@ function cacheSet(key: string, value: Vector): void {
 }
 
 function fastembedModelName(modelName: string): StandardEmbeddingModel | null {
+	const { EmbeddingModel } = loadFastembedRuntime();
 	const known: Record<string, StandardEmbeddingModel> = {
 		"BAAI/bge-small-en-v1.5": EmbeddingModel.BGESmallENV15,
 		"BAAI/bge-base-en-v1.5": EmbeddingModel.BGEBaseENV15,


### PR DESCRIPTION
## What

Fixes a Windows startup crash caused by fastembed eagerly loading its pinned onnxruntime-node@1.21 native binding at
module import time.

Mnemosyne now keeps fastembed lazy and preloads the root onnxruntime-node@1.24.3 binding before loading fastembed when
local embeddings are actually used.

## Why

On Windows, loading fastembed’s older ORT native DLL before transformers.js / local smol tooling can cause native
runtime reuse/version conflicts and segfault the process during startup.

This keeps startup clean while preserving existing local embedding behavior.

## Testing

- bun --cwd=packages/mnemosyne run check
- bun --cwd=packages/mnemosyne test test/optional-embeddings.test.ts
- Verified importing packages/mnemosyne/src/core/embeddings.ts does not load fastembed or onnxruntime-node at startup.

---

- [ x ] `bun check` passes
- [ x ] Tested locally
- [ x ] CHANGELOG updated (if user-facing)
