### PR TITLE
feat(autoresearch): port population-guided evolutionary research loop

### DIFF
--- a/packages/coding-agent/src/autoresearch/assets/template.html
+++ b/packages/coding-agent/src/autoresearch/assets/template.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>Autoresearch Dashboard</title>
+	<style>
+		:root {
+			--bg: #0f0f1a;
+			--fg: #e0e0e0;
+			--accent: #58a6ff;
+			--success: #3fb950;
+			--warning: #d29922;
+			--error: #f85149;
+			--muted: #8b949e;
+			--border: #30363d;
+			--card: #161b22;
+		}
+		* { box-sizing: border-box; }
+		body {
+			font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+			background: var(--bg);
+			color: var(--fg);
+			margin: 0;
+			padding: 1rem;
+			line-height: 1.5;
+		}
+		h1 { margin: 0 0 1rem; font-size: 1.25rem; color: var(--accent); }
+		#status {
+			display: inline-flex;
+			align-items: center;
+			gap: 0.5rem;
+			font-size: 0.875rem;
+			color: var(--muted);
+			margin-bottom: 1rem;
+		}
+		#status .dot {
+			width: 8px;
+			height: 8px;
+			border-radius: 50%;
+			background: var(--muted);
+		}
+		#status.connected .dot { background: var(--success); }
+		#status.disconnected .dot { background: var(--error); }
+		#stats {
+			display: grid;
+			grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+			gap: 0.5rem;
+			margin-bottom: 1rem;
+		}
+		.stat-card {
+			background: var(--card);
+			border: 1px solid var(--border);
+			border-radius: 6px;
+			padding: 0.75rem;
+			font-size: 0.875rem;
+		}
+		.stat-card .label { color: var(--muted); font-size: 0.75rem; text-transform: uppercase; }
+		.stat-card .value { font-size: 1.125rem; font-weight: 600; }
+		#runs {
+			display: flex;
+			flex-direction: column;
+			gap: 0.5rem;
+		}
+		.run-card {
+			background: var(--card);
+			border: 1px solid var(--border);
+			border-radius: 6px;
+			padding: 0.75rem;
+			font-size: 0.875rem;
+		}
+		.run-card .run-header {
+			display: flex;
+			gap: 0.75rem;
+			align-items: center;
+			margin-bottom: 0.25rem;
+		}
+		.run-card .run-id { color: var(--muted); }
+		.run-card .status {
+			font-weight: 600;
+			padding: 0 0.375rem;
+			border-radius: 4px;
+			font-size: 0.75rem;
+			text-transform: uppercase;
+		}
+		.run-card .status.keep { background: rgba(63, 185, 80, 0.15); color: var(--success); }
+		.run-card .status.discard { background: rgba(210, 153, 34, 0.15); color: var(--warning); }
+		.run-card .status.crash { background: rgba(248, 81, 73, 0.15); color: var(--error); }
+		.run-card .status.checks_failed { background: rgba(248, 81, 73, 0.15); color: var(--error); }
+		.run-card .metric { color: var(--accent); font-weight: 600; }
+		.run-card .description { color: var(--muted); }
+		#empty {
+			color: var(--muted);
+			text-align: center;
+			padding: 2rem;
+			font-size: 0.875rem;
+		}
+	</style>
+</head>
+<body>
+	<h1>Autoresearch Dashboard</h1>
+	<div id="status"><span class="dot"></span><span class="text">Connecting...</span></div>
+	<div id="stats">
+		<div class="stat-card"><div class="label">Runs</div><div class="value" id="stat-runs">0</div></div>
+		<div class="stat-card"><div class="label">Kept</div><div class="value" id="stat-kept">0</div></div>
+		<div class="stat-card"><div class="label">Best</div><div class="value" id="stat-best">-</div></div>
+		<div class="stat-card"><div class="label">Confidence</div><div class="value" id="stat-conf">-</div></div>
+	</div>
+	<div id="runs"></div>
+	<div id="empty">No runs yet.</div>
+
+	<script>
+		const source = new EventSource('/events');
+		const statusEl = document.getElementById('status');
+		const statusText = statusEl.querySelector('.text');
+		const runsEl = document.getElementById('runs');
+		const emptyEl = document.getElementById('empty');
+
+		let runs = [];
+		let session = null;
+
+		function updateStats() {
+			const current = runs.filter(r => session && r.segment === session.currentSegment);
+			const kept = current.filter(r => r.status === 'keep' && !r.flagged);
+			const best = kept.length > 0
+				? kept.reduce((a, b) => session && session.bestDirection === 'lower' ? (a.metric < b.metric ? a : b) : (a.metric > b.metric ? a : b))
+				: null;
+			document.getElementById('stat-runs').textContent = current.length;
+			document.getElementById('stat-kept').textContent = kept.length;
+			document.getElementById('stat-best').textContent = best ? best.metric : '-';
+			document.getElementById('stat-conf').textContent = session && session.confidence !== null ? session.confidence.toFixed(1) + 'x' : '-';
+			emptyEl.style.display = runs.length === 0 ? 'block' : 'none';
+		}
+
+		function renderRuns() {
+			runsEl.innerHTML = '';
+			for (const run of runs.slice().reverse()) {
+				const card = document.createElement('div');
+				card.className = 'run-card';
+				const header = document.createElement('div');
+				header.className = 'run-header';
+				header.innerHTML = `<span class="run-id">#${run.runNumber}</span><span class="status ${run.status}">${run.status}</span><span class="metric">${run.metric}</span>`;
+				const desc = document.createElement('div');
+				desc.className = 'description';
+				desc.textContent = run.description;
+				card.appendChild(header);
+				card.appendChild(desc);
+				runsEl.appendChild(card);
+			}
+			updateStats();
+		}
+
+		source.onopen = () => {
+			statusEl.className = 'connected';
+			statusText.textContent = 'Connected';
+		};
+		source.onerror = () => {
+			statusEl.className = 'disconnected';
+			statusText.textContent = 'Disconnected';
+		};
+		source.onmessage = (e) => {
+			const data = JSON.parse(e.data);
+			if (data.type === 'init') {
+				session = data.data.state;
+				runs = session.results || [];
+				renderRuns();
+			} else if (data.type === 'run') {
+				runs.push(data.data);
+				renderRuns();
+			} else if (data.type === 'session') {
+				session = data.data;
+				runs = session.results || [];
+				renderRuns();
+			}
+		};
+	</script>
+</body>
+</html>

--- a/packages/coding-agent/src/autoresearch/browser-dashboard.ts
+++ b/packages/coding-agent/src/autoresearch/browser-dashboard.ts
@@ -1,0 +1,160 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { logger } from "@oh-my-pi/pi-utils";
+import type { BrowserDashboardState } from "./types";
+
+const DEFAULT_PORT = 8765;
+const SSE_HEARTBEAT_MS = 15_000;
+
+export interface BrowserDashboardController {
+	start(cwd: string): Promise<void>;
+	stop(): void;
+	broadcast(event: string, data: unknown): void;
+	isRunning(): boolean;
+	getUrl(): string | null;
+}
+
+export function createBrowserDashboardController(): BrowserDashboardController {
+	let server: ReturnType<typeof Bun.serve> | null = null;
+	const state: BrowserDashboardState = { connected: 0, events: [] };
+	const clients = new Set<ReadableStreamDefaultController>();
+	let heartbeatInterval: NodeJS.Timeout | undefined;
+
+	const start = async (_workDir: string): Promise<void> => {
+		if (server) return;
+		const htmlPath = path.join(import.meta.dir, "assets", "template.html");
+		const html = fs.existsSync(htmlPath) ? fs.readFileSync(htmlPath, "utf8") : fallbackHtml();
+
+		server = Bun.serve({
+			port: DEFAULT_PORT,
+			fetch(request) {
+				const url = new URL(request.url);
+				if (url.pathname === "/events") {
+					return handleSse(request);
+				}
+				return new Response(html, {
+					headers: { "Content-Type": "text/html" },
+				});
+			},
+		});
+
+		heartbeatInterval = setInterval(() => {
+			broadcastSse("heartbeat", { timestamp: Date.now() });
+		}, SSE_HEARTBEAT_MS);
+
+		logger.info("Browser dashboard started", { url: `http://localhost:${DEFAULT_PORT}` });
+	};
+
+	const stop = (): void => {
+		if (heartbeatInterval) {
+			clearInterval(heartbeatInterval);
+			heartbeatInterval = undefined;
+		}
+		for (const controller of clients) {
+			try {
+				controller.close();
+			} catch {
+				// ignore
+			}
+		}
+		clients.clear();
+		server?.stop();
+		server = null;
+	};
+
+	const broadcast = (event: string, data: unknown): void => {
+		state.events.push({ type: event, data, timestamp: Date.now() });
+		if (state.events.length > 500) {
+			state.events = state.events.slice(-400);
+		}
+		broadcastSse(event, data);
+	};
+
+	const isRunning = (): boolean => server !== null;
+
+	const getUrl = (): string | null => {
+		if (!server) return null;
+		return `http://localhost:${DEFAULT_PORT}`;
+	};
+
+	const handleSse = (request: Request): Response => {
+		const stream = new ReadableStream({
+			start(controller) {
+				clients.add(controller);
+				state.connected = clients.size;
+				// Send initial state
+				const encoder = new TextEncoder();
+				controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: "init", state })}\n\n`));
+				for (const event of state.events) {
+					controller.enqueue(
+						encoder.encode(`data: ${JSON.stringify({ type: event.type, data: event.data })}\n\n`),
+					);
+				}
+				request.signal.addEventListener("abort", () => {
+					clients.delete(controller);
+					state.connected = clients.size;
+					try {
+						controller.close();
+					} catch {
+						// ignore
+					}
+				});
+			},
+		});
+		return new Response(stream, {
+			headers: {
+				"Content-Type": "text/event-stream",
+				"Cache-Control": "no-cache",
+				Connection: "keep-alive",
+			},
+		});
+	};
+
+	const broadcastSse = (event: string, data: unknown): void => {
+		const message = `data: ${JSON.stringify({ type: event, data })}\n\n`;
+		const encoder = new TextEncoder();
+		for (const controller of clients) {
+			try {
+				controller.enqueue(encoder.encode(message));
+			} catch {
+				clients.delete(controller);
+				state.connected = clients.size;
+			}
+		}
+	};
+
+	return { start, stop, broadcast, isRunning, getUrl };
+}
+
+function fallbackHtml(): string {
+	return `<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>Autoresearch Dashboard</title>
+	<style>
+		body { font-family: monospace; background: #1a1a2e; color: #eee; padding: 2rem; }
+		#status { color: #0f0; }
+		#events { white-space: pre-wrap; }
+	</style>
+</head>
+<body>
+	<h1>Autoresearch Dashboard</h1>
+	<div id="status">Connecting...</div>
+	<div id="events"></div>
+	<script>
+		const source = new EventSource('/events');
+		const status = document.getElementById('status');
+		const events = document.getElementById('events');
+		source.onopen = () => { status.textContent = 'Connected'; };
+		source.onerror = () => { status.textContent = 'Disconnected'; };
+		source.onmessage = (e) => {
+			const data = JSON.parse(e.data);
+			const div = document.createElement('div');
+			div.textContent = new Date().toISOString() + ' ' + data.type + ': ' + JSON.stringify(data.data);
+			events.appendChild(div);
+		};
+	</script>
+</body>
+</html>`;
+}

--- a/packages/coding-agent/src/autoresearch/browser-dashboard.ts
+++ b/packages/coding-agent/src/autoresearch/browser-dashboard.ts
@@ -1,13 +1,20 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { logger } from "@oh-my-pi/pi-utils";
-import type { BrowserDashboardState } from "./types";
+import * as git from "../utils/git";
+import { buildExperimentState } from "./state";
+import { openAutoresearchStorageIfExists } from "./storage";
+import type { BrowserDashboardState, ExperimentResult, SessionSnapshot } from "./types";
 
 const DEFAULT_PORT = 8765;
 const SSE_HEARTBEAT_MS = 15_000;
 
+export interface BrowserDashboardStartOptions {
+	port?: number;
+}
+
 export interface BrowserDashboardController {
-	start(cwd: string): Promise<void>;
+	start(cwd: string, options?: BrowserDashboardStartOptions): Promise<void>;
 	stop(): void;
 	broadcast(event: string, data: unknown): void;
 	isRunning(): boolean;
@@ -17,16 +24,30 @@ export interface BrowserDashboardController {
 export function createBrowserDashboardController(): BrowserDashboardController {
 	let server: ReturnType<typeof Bun.serve> | null = null;
 	const state: BrowserDashboardState = { connected: 0, events: [] };
+	let latestSession: SessionSnapshot | null = null;
 	const clients = new Set<ReadableStreamDefaultController>();
 	let heartbeatInterval: NodeJS.Timeout | undefined;
 
-	const start = async (_workDir: string): Promise<void> => {
+	const start = async (cwd: string, options: BrowserDashboardStartOptions = {}): Promise<void> => {
 		if (server) return;
 		const htmlPath = path.join(import.meta.dir, "assets", "template.html");
 		const html = fs.existsSync(htmlPath) ? fs.readFileSync(htmlPath, "utf8") : fallbackHtml();
 
+		// Seed the cached session snapshot from storage if one already exists so
+		// new SSE clients see the recorded runs even when no live `broadcast`
+		// has fired yet. Tolerated to fail: tests start the dashboard against
+		// directories that aren't git repos.
+		try {
+			latestSession = await loadSessionSnapshotFromStorage(cwd);
+		} catch (err) {
+			logger.debug("Browser dashboard: storage seed skipped", {
+				cwd,
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+
 		server = Bun.serve({
-			port: DEFAULT_PORT,
+			port: options.port ?? DEFAULT_PORT,
 			fetch(request) {
 				const url = new URL(request.url);
 				if (url.pathname === "/events") {
@@ -42,7 +63,7 @@ export function createBrowserDashboardController(): BrowserDashboardController {
 			broadcastSse("heartbeat", { timestamp: Date.now() });
 		}, SSE_HEARTBEAT_MS);
 
-		logger.info("Browser dashboard started", { url: `http://localhost:${DEFAULT_PORT}` });
+		logger.info("Browser dashboard started", { url: getUrl() });
 	};
 
 	const stop = (): void => {
@@ -60,12 +81,19 @@ export function createBrowserDashboardController(): BrowserDashboardController {
 		clients.clear();
 		server?.stop();
 		server = null;
+		latestSession = null;
 	};
 
 	const broadcast = (event: string, data: unknown): void => {
 		state.events.push({ type: event, data, timestamp: Date.now() });
 		if (state.events.length > 500) {
 			state.events = state.events.slice(-400);
+		}
+		// The `session` broadcast IS the latest snapshot — cache it so new SSE
+		// clients can replay it via the `init` frame instead of waiting for the
+		// next state change.
+		if (event === "session" && isSessionSnapshotLike(data)) {
+			latestSession = data;
 		}
 		broadcastSse(event, data);
 	};
@@ -74,7 +102,7 @@ export function createBrowserDashboardController(): BrowserDashboardController {
 
 	const getUrl = (): string | null => {
 		if (!server) return null;
-		return `http://localhost:${DEFAULT_PORT}`;
+		return `http://localhost:${server.port}`;
 	};
 
 	const handleSse = (request: Request): Response => {
@@ -82,9 +110,18 @@ export function createBrowserDashboardController(): BrowserDashboardController {
 			start(controller) {
 				clients.add(controller);
 				state.connected = clients.size;
-				// Send initial state
+				// Init frame uses the wire shape the browser template parses:
+				// `data.data.state` is the session snapshot, and `data.data.results`
+				// is a flat copy of `state.results` so future client variants can
+				// read it without descending into state.
+				const sessionForInit = latestSession;
+				const results: ExperimentResult[] = sessionForInit?.results ?? [];
 				const encoder = new TextEncoder();
-				controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: "init", state })}\n\n`));
+				controller.enqueue(
+					encoder.encode(
+						`data: ${JSON.stringify({ type: "init", data: { state: sessionForInit, results } })}\n\n`,
+					),
+				);
 				for (const event of state.events) {
 					controller.enqueue(
 						encoder.encode(`data: ${JSON.stringify({ type: event.type, data: event.data })}\n\n`),
@@ -124,6 +161,36 @@ export function createBrowserDashboardController(): BrowserDashboardController {
 	};
 
 	return { start, stop, broadcast, isRunning, getUrl };
+}
+
+async function loadSessionSnapshotFromStorage(cwd: string): Promise<SessionSnapshot | null> {
+	const storage = await openAutoresearchStorageIfExists(cwd);
+	if (!storage) return null;
+	const branch = (await git.branch.current(cwd).catch(() => null)) ?? null;
+	const session = storage.getActiveSessionForBranch(branch) ?? storage.getActiveSession();
+	if (!session) return null;
+	const loggedRuns = storage.listLoggedRuns(session.id);
+	const state = buildExperimentState(session, loggedRuns);
+	return {
+		name: state.name,
+		goal: state.goal,
+		metricName: state.metricName,
+		metricUnit: state.metricUnit,
+		bestDirection: state.bestDirection,
+		currentSegment: state.currentSegment,
+		maxExperiments: state.maxExperiments,
+		results: state.results,
+		confidence: state.confidence,
+		branch: state.branch,
+		baselineCommit: state.baselineCommit,
+		notes: state.notes,
+	};
+}
+
+function isSessionSnapshotLike(value: unknown): value is SessionSnapshot {
+	if (typeof value !== "object" || value === null) return false;
+	const v = value as Partial<SessionSnapshot>;
+	return Array.isArray(v.results) && typeof v.metricName === "string";
 }
 
 function fallbackHtml(): string {

--- a/packages/coding-agent/src/autoresearch/command-resume.md
+++ b/packages/coding-agent/src/autoresearch/command-resume.md
@@ -12,3 +12,5 @@ Additional context from the user:
 - Inspect recent git history for context.
 - Continue the most promising unfinished direction.
 - Keep iterating until interrupted or until the configured iteration cap is reached.
+- Auto-resume is limited to 20 turns per session.
+- If `autoresearch.md` exists, follow its rules. If `autoresearch.population.json` exists, population guidance may suggest the next direction.

--- a/packages/coding-agent/src/autoresearch/compaction.ts
+++ b/packages/coding-agent/src/autoresearch/compaction.ts
@@ -1,0 +1,130 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { JSONL_FILENAME, readJsonlEntries, reconstructStateFromJsonl } from "./jsonl";
+import type { SessionSnapshot } from "./types";
+
+export function buildCompactionSummary(cwd: string): string | null {
+	const jsonlPath = path.join(cwd, JSONL_FILENAME);
+	if (!fs.existsSync(jsonlPath)) return null;
+
+	const entries = readJsonlEntries(cwd);
+	const snapshot = reconstructStateFromJsonl(entries);
+	if (!snapshot) return null;
+
+	const lines: string[] = [];
+	lines.push(`# Autoresearch Session Summary`);
+	lines.push("");
+	if (snapshot.name) lines.push(`**Name:** ${snapshot.name}`);
+	if (snapshot.goal) lines.push(`**Goal:** ${snapshot.goal}`);
+	lines.push(
+		`**Metric:** ${snapshot.metricName} (${snapshot.metricUnit || "unitless"}, ${snapshot.bestDirection} is better)`,
+	);
+	lines.push(`**Segment:** ${snapshot.currentSegment}`);
+	lines.push(`**Max experiments:** ${snapshot.maxExperiments ?? "unlimited"}`);
+	lines.push("");
+
+	const results = snapshot.results;
+	const current = results.filter(r => r.segment === snapshot.currentSegment);
+	const kept = current.filter(r => r.status === "keep" && !r.flagged);
+	const discarded = current.filter(r => r.status === "discard");
+	const crashed = current.filter(r => r.status === "crash" || r.status === "checks_failed");
+
+	lines.push(`## Current Segment Stats`);
+	lines.push(`- Total runs: ${current.length}`);
+	lines.push(`- Kept: ${kept.length}`);
+	lines.push(`- Discarded: ${discarded.length}`);
+	lines.push(`- Crashed: ${crashed.length}`);
+	if (snapshot.confidence !== null) {
+		lines.push(`- Confidence: ${snapshot.confidence.toFixed(1)}x noise floor`);
+	}
+	lines.push("");
+
+	if (kept.length > 0) {
+		lines.push(`## Kept Runs`);
+		for (const result of kept) {
+			lines.push(`- Run #${result.runNumber}: ${result.metric} — ${result.description}`);
+			if (result.asi && Object.keys(result.asi).length > 0) {
+				lines.push(`  ASI: ${JSON.stringify(result.asi)}`);
+			}
+		}
+		lines.push("");
+	}
+
+	if (results.length > current.length) {
+		lines.push(`## Archived Segments`);
+		lines.push(`- ${results.length - current.length} runs from earlier segments`);
+		lines.push("");
+	}
+
+	if (snapshot.notes) {
+		lines.push(`## Notes`);
+		lines.push(snapshot.notes);
+		lines.push("");
+	}
+
+	lines.push(`*Generated from ${entries.length} JSONL entries*`);
+	return lines.join("\n");
+}
+
+export function compactJsonl(cwd: string): void {
+	const jsonlPath = path.join(cwd, JSONL_FILENAME);
+	if (!fs.existsSync(jsonlPath)) return;
+
+	const entries = readJsonlEntries(cwd);
+	const snapshot = reconstructStateFromJsonl(entries);
+	if (!snapshot) return;
+
+	// Write a compacted version: config + latest session + all runs
+	const compacted: unknown[] = [];
+	const configEntry = entries.find(e => e.type === "config");
+	if (configEntry) compacted.push(configEntry);
+	compacted.push({
+		type: "session",
+		timestamp: Date.now(),
+		data: snapshot,
+	});
+	for (const result of snapshot.results) {
+		compacted.push({
+			type: "run",
+			timestamp: result.timestamp,
+			runId: result.runNumber ?? 0,
+			data: {
+				segment: result.segment,
+				command: "",
+				status: result.status,
+				metric: result.metric,
+				metrics: result.metrics,
+				description: result.description,
+				commit: result.commit,
+				modifiedPaths: result.modifiedPaths,
+				scopeDeviations: result.scopeDeviations,
+				justification: result.justification,
+				asi: result.asi ?? null,
+				confidence: result.confidence,
+				flagged: result.flagged,
+				flaggedReason: result.flaggedReason,
+			},
+		});
+	}
+
+	fs.writeFileSync(jsonlPath, `${compacted.map(e => JSON.stringify(e)).join("\n")}\n`, "utf8");
+}
+
+export function sessionSnapshotToMarkdown(snapshot: SessionSnapshot): string {
+	const lines: string[] = [];
+	lines.push(`# Autoresearch Summary`);
+	lines.push("");
+	if (snapshot.name) lines.push(`**Name:** ${snapshot.name}`);
+	if (snapshot.goal) lines.push(`**Goal:** ${snapshot.goal}`);
+	lines.push(
+		`**Metric:** ${snapshot.metricName} (${snapshot.metricUnit || "unitless"}, ${snapshot.bestDirection} is better)`,
+	);
+	lines.push(`**Segment:** ${snapshot.currentSegment}`);
+	lines.push("");
+	lines.push(`## Results`);
+	for (const result of snapshot.results) {
+		const emoji = result.status === "keep" ? "✅" : result.status === "discard" ? "❌" : "💥";
+		lines.push(`${emoji} Run #${result.runNumber}: ${result.metric} — ${result.description}`);
+	}
+	return lines.join("\n");
+}

--- a/packages/coding-agent/src/autoresearch/compaction.ts
+++ b/packages/coding-agent/src/autoresearch/compaction.ts
@@ -1,6 +1,6 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { JSONL_FILENAME, readJsonlEntries, reconstructStateFromJsonl } from "./jsonl";
+import { findLatestConfigEntry, JSONL_FILENAME, readJsonlEntries, reconstructStateFromJsonl } from "./jsonl";
 import type { SessionSnapshot } from "./types";
 
 export function buildCompactionSummary(cwd: string): string | null {
@@ -76,7 +76,7 @@ export function compactJsonl(cwd: string): void {
 
 	// Write a compacted version: config + latest session + all runs
 	const compacted: unknown[] = [];
-	const configEntry = entries.find(e => e.type === "config");
+	const configEntry = findLatestConfigEntry(entries);
 	if (configEntry) compacted.push(configEntry);
 	compacted.push({
 		type: "session",

--- a/packages/coding-agent/src/autoresearch/dashboard.ts
+++ b/packages/coding-agent/src/autoresearch/dashboard.ts
@@ -1,10 +1,10 @@
 import { matchesKey, replaceTabs, Text, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
 import type { Theme } from "../modes/theme/theme";
+import type { BrowserDashboardController } from "./browser-dashboard";
 import { formatElapsed, formatNum, isBetter } from "./helpers";
 import { currentResults, findBaselineMetric, findBaselineRunNumber, findBaselineSecondary } from "./state";
 import type { AutoresearchRuntime, DashboardController, ExperimentResult, ExperimentState } from "./types";
-
-export function createDashboardController(): DashboardController {
+export function createDashboardController(browserDashboard?: BrowserDashboardController): DashboardController {
 	let overlayTui: { requestRender(): void } | null = null;
 	let spinnerTimer: NodeJS.Timeout | undefined;
 	let spinnerFrame = 0;
@@ -21,6 +21,24 @@ export function createDashboardController(): DashboardController {
 		}
 	};
 
+	const broadcastToBrowser = (runtime: AutoresearchRuntime): void => {
+		if (!browserDashboard?.isRunning()) return;
+		browserDashboard.broadcast("session", {
+			name: runtime.state.name,
+			goal: runtime.state.goal,
+			metricName: runtime.state.metricName,
+			metricUnit: runtime.state.metricUnit,
+			bestDirection: runtime.state.bestDirection,
+			currentSegment: runtime.state.currentSegment,
+			maxExperiments: runtime.state.maxExperiments,
+			results: runtime.state.results,
+			confidence: runtime.state.confidence,
+			branch: runtime.state.branch,
+			baselineCommit: runtime.state.baselineCommit,
+			notes: runtime.state.notes,
+		});
+	};
+
 	return {
 		clear(ctx): void {
 			clear();
@@ -34,6 +52,7 @@ export function createDashboardController(): DashboardController {
 			const state = runtime.state;
 			if (!shouldShowDashboard(runtime, state)) {
 				ctx.ui.setWidget("autoresearch", undefined);
+				broadcastToBrowser(runtime);
 				return;
 			}
 
@@ -51,6 +70,7 @@ export function createDashboardController(): DashboardController {
 				}
 				return new Text(renderCollapsedLine(runtime, state, theme), 0, 0);
 			});
+			broadcastToBrowser(runtime);
 		},
 		async showOverlay(ctx, runtime): Promise<void> {
 			if (!ctx.hasUI || !shouldShowDashboard(runtime, runtime.state)) return;
@@ -119,6 +139,7 @@ export function createDashboardController(): DashboardController {
 				{ overlay: true },
 			);
 		},
+		browserDashboard,
 	};
 }
 

--- a/packages/coding-agent/src/autoresearch/helpers.ts
+++ b/packages/coding-agent/src/autoresearch/helpers.ts
@@ -216,3 +216,7 @@ export async function tryGitPrefix(cwd: string): Promise<string> {
 		return "";
 	}
 }
+export function isAutoresearchShCommand(command: string): boolean {
+	const trimmed = command.trim().toLowerCase();
+	return trimmed === "bash autoresearch.sh" || trimmed === "./autoresearch.sh" || trimmed.endsWith("autoresearch.sh");
+}

--- a/packages/coding-agent/src/autoresearch/hooks.ts
+++ b/packages/coding-agent/src/autoresearch/hooks.ts
@@ -1,0 +1,85 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { logger } from "@oh-my-pi/pi-utils";
+import type { HookPayload, HookResult } from "./types";
+
+export const HOOKS_DIR = "autoresearch.hooks";
+const MAX_HOOK_OUTPUT = 8 * 1024;
+
+export function listHooks(cwd: string, event: HookPayload["event"]): string[] {
+	const dir = path.join(cwd, HOOKS_DIR);
+	if (!fs.existsSync(dir)) return [];
+	const files = fs.readdirSync(dir).filter(name => name.endsWith(".sh"));
+	// Sort by name for deterministic order
+	files.sort();
+	const prefix = event.replace("_", "-");
+	return files.filter(name => name.startsWith(prefix)).map(name => path.join(dir, name));
+}
+
+export async function runHook(scriptPath: string, payload: HookPayload): Promise<HookResult> {
+	if (!fs.existsSync(scriptPath)) {
+		return { exitCode: 0, stdout: "", stderr: "", allowed: true, message: null };
+	}
+	const payloadJson = JSON.stringify(payload);
+	try {
+		const proc = Bun.spawn(["bash", scriptPath], {
+			cwd: payload.cwd,
+			stdin: new ReadableStream({
+				start(controller) {
+					controller.enqueue(new TextEncoder().encode(payloadJson));
+					controller.close();
+				},
+			}),
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const exitCode = await proc.exited;
+		const stdout = await new Response(proc.stdout).text();
+		const stderr = await new Response(proc.stderr).text();
+		const allowed = exitCode === 0;
+		let message: string | null = null;
+		try {
+			const parsed = JSON.parse(stdout.slice(0, MAX_HOOK_OUTPUT)) as unknown;
+			if (typeof parsed === "object" && parsed !== null && "message" in parsed) {
+				message = String((parsed as { message: unknown }).message);
+			}
+		} catch {
+			// Not JSON, ignore
+		}
+		return {
+			exitCode,
+			stdout: stdout.slice(0, MAX_HOOK_OUTPUT),
+			stderr: stderr.slice(0, MAX_HOOK_OUTPUT),
+			allowed,
+			message,
+		};
+	} catch (err) {
+		logger.warn("Hook execution failed", { scriptPath, error: err instanceof Error ? err.message : String(err) });
+		return {
+			exitCode: 1,
+			stdout: "",
+			stderr: err instanceof Error ? err.message : String(err),
+			allowed: false,
+			message: "Hook execution failed",
+		};
+	}
+}
+
+export async function runHooksForEvent(
+	cwd: string,
+	event: HookPayload["event"],
+	payload: HookPayload,
+): Promise<HookResult[]> {
+	const scripts = listHooks(cwd, event);
+	const results: HookResult[] = [];
+	for (const scriptPath of scripts) {
+		const result = await runHook(scriptPath, payload);
+		results.push(result);
+		if (!result.allowed) break;
+	}
+	return results;
+}
+
+export function hasHooks(cwd: string, event: HookPayload["event"]): boolean {
+	return listHooks(cwd, event).length > 0;
+}

--- a/packages/coding-agent/src/autoresearch/index.ts
+++ b/packages/coding-agent/src/autoresearch/index.ts
@@ -4,10 +4,14 @@ import type { AutocompleteItem } from "@oh-my-pi/pi-tui";
 import { logger, prompt } from "@oh-my-pi/pi-utils";
 import type { ExtensionContext, ExtensionFactory } from "../extensibility/extensions";
 import * as git from "../utils/git";
+import { createBrowserDashboardController } from "./browser-dashboard";
 import commandResumeTemplate from "./command-resume.md" with { type: "text" };
+import { compactJsonl } from "./compaction";
 import { createDashboardController } from "./dashboard";
 import { ensureAutoresearchBranch } from "./git";
 import { formatNum } from "./helpers";
+import { readEvoConfig } from "./jsonl";
+import { getRecommendation, populationStateFromJson } from "./population";
 import promptTemplate from "./prompt.md" with { type: "text" };
 import setupPromptTemplate from "./prompt-setup.md" with { type: "text" };
 import resumeMessageTemplate from "./resume-message.md" with { type: "text" };
@@ -29,10 +33,12 @@ import { createUpdateNotesTool } from "./tools/update-notes";
 import type { AutoresearchRuntime, ExperimentResult, PendingRunSummary } from "./types";
 
 const EXPERIMENT_TOOL_NAMES = ["init_experiment", "run_experiment", "log_experiment", "update_notes"];
+const MAX_AUTORESUME_TURNS = 20;
 
 export const createAutoresearchExtension: ExtensionFactory = api => {
 	const runtimeStore = createRuntimeStore();
-	const dashboard = createDashboardController();
+	const browserDashboard = createBrowserDashboardController();
+	const dashboard = createDashboardController(browserDashboard);
 
 	const getSessionKey = (ctx: ExtensionContext): string => ctx.sessionManager.getSessionId();
 	const getRuntime = (ctx: ExtensionContext): AutoresearchRuntime => runtimeStore.ensure(getSessionKey(ctx));
@@ -170,6 +176,20 @@ export const createAutoresearchExtension: ExtensionFactory = api => {
 				return;
 			}
 
+			if (trimmed === "export") {
+				try {
+					await browserDashboard.start(ctx.cwd);
+					const url = browserDashboard.getUrl();
+					ctx.ui.notify(`Browser dashboard: ${url}`, "info");
+				} catch (err) {
+					ctx.ui.notify(
+						`Failed to start browser dashboard: ${err instanceof Error ? err.message : String(err)}`,
+						"error",
+					);
+				}
+				return;
+			}
+
 			const goalArg = trimmed.length > 0 ? trimmed : null;
 			const branchResult = await ensureAutoresearchBranch(api, ctx.cwd, goalArg ?? runtime.goal);
 			if (!branchResult.ok) {
@@ -264,6 +284,11 @@ export const createAutoresearchExtension: ExtensionFactory = api => {
 			runtime.autoResumeArmed = false;
 			return;
 		}
+		// Auto-resume limit
+		if (runtime.experimentsThisSession >= MAX_AUTORESUME_TURNS) {
+			logger.info("Auto-resume limit reached", { experimentsThisSession: runtime.experimentsThisSession });
+			return;
+		}
 		const { session } = await loadActiveSession(ctx);
 		const storage = session ? await openAutoresearchStorageIfExists(ctx.cwd) : null;
 		const pendingRow = session && storage ? storage.getPendingRun(session.id) : null;
@@ -278,6 +303,7 @@ export const createAutoresearchExtension: ExtensionFactory = api => {
 		}
 		runtime.autoResumeArmed = false;
 		runtime.lastAutoResumePendingRunNumber = pendingRun?.runNumber ?? null;
+		runtime.experimentsThisSession += 1;
 		api.sendMessage(
 			{
 				customType: "autoresearch-resume",
@@ -310,16 +336,67 @@ export const createAutoresearchExtension: ExtensionFactory = api => {
 			await api.setActiveTools(api.getActiveTools().filter(name => !experimentTools.has(name)));
 			return;
 		}
+
 		const storage = await openAutoresearchStorageIfExists(ctx.cwd);
 		if (session && storage) {
 			runtime.state = buildExperimentState(session, storage.listLoggedRuns(session.id));
 		}
+		const state = runtime.state;
+
+		// Deterministic compaction before building prompt
+		if (session && storage) {
+			try {
+				compactJsonl(ctx.cwd);
+			} catch {
+				// Best effort
+			}
+		}
+
+		// Population guidance
+		let populationHint = "";
+		try {
+			const popPath = path.join(ctx.cwd, "autoresearch.population.json");
+			if (fs.existsSync(popPath)) {
+				const popJson = fs.readFileSync(popPath, "utf8");
+				const population = populationStateFromJson(popJson);
+				if (population) {
+					const rec = getRecommendation(population, state);
+					if (rec) {
+						populationHint = `Population guidance: ${rec.type} — ${rec.reason}`;
+					}
+				}
+			}
+		} catch {
+			// Best effort
+		}
+
+		// Read autoresearch.md and autoresearch.ideas.md
+		let autoresearchMd = "";
+		let autoresearchIdeasMd = "";
+		try {
+			const mdPath = path.join(ctx.cwd, "autoresearch.md");
+			if (fs.existsSync(mdPath)) {
+				autoresearchMd = fs.readFileSync(mdPath, "utf8");
+			}
+		} catch {
+			// Best effort
+		}
+		try {
+			const ideasPath = path.join(ctx.cwd, "autoresearch.ideas.md");
+			if (fs.existsSync(ideasPath)) {
+				autoresearchIdeasMd = fs.readFileSync(ideasPath, "utf8");
+			}
+		} catch {
+			// Best effort
+		}
+
+		// Read autoresearch.config.json
+		const evoConfig = readEvoConfig(ctx.cwd);
 		const pendingRow = session && storage ? storage.getPendingRun(session.id) : null;
 		const pendingRun = pendingRunSummaryFromRow(pendingRow);
 		runtime.lastRunSummary = pendingRun;
 		runtime.lastRunDuration = pendingRun?.durationSeconds ?? runtime.lastRunDuration;
 		runtime.lastRunAsi = pendingRun?.parsedAsi ?? runtime.lastRunAsi;
-		const state = runtime.state;
 		const currentSegmentResults = currentResults(state.results, state.currentSegment);
 		const baselineMetric = findBaselineMetric(state.results, state.currentSegment);
 		const baselineRunNumber = findBaselineRunNumber(state.results, state.currentSegment);
@@ -366,6 +443,10 @@ export const createAutoresearchExtension: ExtensionFactory = api => {
 						branch: currentBranch ?? "",
 						has_baseline_warning: baselineWarning !== null,
 						baseline_warning: baselineWarning ?? "",
+						has_autoresearch_md: autoresearchMd.trim().length > 0,
+						autoresearch_md: autoresearchMd,
+						has_autoresearch_ideas_md: autoresearchIdeasMd.trim().length > 0,
+						autoresearch_ideas_md: autoresearchIdeasMd,
 					}),
 				],
 			};
@@ -406,6 +487,14 @@ export const createAutoresearchExtension: ExtensionFactory = api => {
 						pendingRun?.parsedPrimary !== null && pendingRun?.parsedPrimary !== undefined
 							? formatNum(pendingRun.parsedPrimary, state.metricUnit)
 							: null,
+					has_autoresearch_md: autoresearchMd.trim().length > 0,
+					autoresearch_md: autoresearchMd,
+					has_autoresearch_ideas_md: autoresearchIdeasMd.trim().length > 0,
+					autoresearch_ideas_md: autoresearchIdeasMd,
+					has_population_hint: populationHint.length > 0,
+					population_hint: populationHint,
+					has_evo_config: evoConfig !== null,
+					evo_config: evoConfig ? JSON.stringify(evoConfig, null, 2) : "",
 				}),
 			],
 		};
@@ -462,8 +551,6 @@ const LEGACY_ARTIFACTS = [
 	"autoresearch.checks.sh",
 	"autoresearch.program.md",
 	"autoresearch.ideas.md",
-	"autoresearch.jsonl",
-	"autoresearch.config.json",
 	".autoresearch",
 ];
 

--- a/packages/coding-agent/src/autoresearch/index.ts
+++ b/packages/coding-agent/src/autoresearch/index.ts
@@ -545,14 +545,13 @@ export const createAutoresearchExtension: ExtensionFactory = api => {
 	}
 };
 
-const LEGACY_ARTIFACTS = [
-	"autoresearch.md",
-	"autoresearch.sh",
-	"autoresearch.checks.sh",
-	"autoresearch.program.md",
-	"autoresearch.ideas.md",
-	".autoresearch",
-];
+/**
+ * Files/dirs we own outright and remove on `/autoresearch clear`. Files the
+ * setup prompt invites the user to author (`autoresearch.md`,
+ * `autoresearch.checks.sh`, `autoresearch.ideas.md`) are intentionally NOT
+ * here — see prompt-setup.md.
+ */
+const LEGACY_ARTIFACTS = ["autoresearch.sh", "autoresearch.program.md", ".autoresearch"];
 
 function removeLegacyArtifacts(workDir: string): void {
 	for (const name of LEGACY_ARTIFACTS) {

--- a/packages/coding-agent/src/autoresearch/jsonl.ts
+++ b/packages/coding-agent/src/autoresearch/jsonl.ts
@@ -1,0 +1,170 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { ASIData, EvoResearchConfig, ExperimentResult, ExperimentStatus, SessionSnapshot } from "./types";
+
+export const JSONL_FILENAME = "autoresearch.jsonl";
+export const CONFIG_FILENAME = "autoresearch.config.json";
+export const POPULATION_FILENAME = "autoresearch.population.json";
+
+export type JsonlEntry =
+	| { type: "config"; timestamp: number; data: EvoResearchConfig }
+	| { type: "run"; timestamp: number; runId: number; data: JsonlRunEntry }
+	| { type: "session"; timestamp: number; data: SessionSnapshot };
+
+interface JsonlRunEntry {
+	segment: number;
+	command: string;
+	status: ExperimentStatus;
+	metric: number;
+	metrics: { [key: string]: number };
+	description: string;
+	commit: string;
+	modifiedPaths: string[];
+	scopeDeviations: string[];
+	justification: string | null;
+	asi: ASIData | null;
+	confidence: number | null;
+	flagged: boolean;
+	flaggedReason: string | null;
+}
+
+export function appendJsonlEntry(cwd: string, entry: JsonlEntry): void {
+	const jsonlPath = path.join(cwd, JSONL_FILENAME);
+	const line = `${JSON.stringify(entry)}\n`;
+	fs.appendFileSync(jsonlPath, line, "utf8");
+}
+
+export function writeJsonlConfig(cwd: string, config: EvoResearchConfig): void {
+	const entry: JsonlEntry = {
+		type: "config",
+		timestamp: Date.now(),
+		data: config,
+	};
+	appendJsonlEntry(cwd, entry);
+}
+
+export function writeJsonlRun(cwd: string, result: ExperimentResult, command: string): void {
+	const entry: JsonlEntry = {
+		type: "run",
+		timestamp: result.timestamp,
+		runId: result.runNumber ?? 0,
+		data: {
+			segment: result.segment,
+			command,
+			status: result.status,
+			metric: result.metric,
+			metrics: result.metrics,
+			description: result.description,
+			commit: result.commit,
+			modifiedPaths: result.modifiedPaths,
+			scopeDeviations: result.scopeDeviations,
+			justification: result.justification,
+			asi: result.asi ?? null,
+			confidence: result.confidence,
+			flagged: result.flagged,
+			flaggedReason: result.flaggedReason,
+		},
+	};
+	appendJsonlEntry(cwd, entry);
+}
+
+export function writeJsonlSession(cwd: string, snapshot: SessionSnapshot): void {
+	const entry: JsonlEntry = {
+		type: "session",
+		timestamp: Date.now(),
+		data: snapshot,
+	};
+	appendJsonlEntry(cwd, entry);
+}
+
+export function readJsonlEntries(cwd: string): JsonlEntry[] {
+	const jsonlPath = path.join(cwd, JSONL_FILENAME);
+	if (!fs.existsSync(jsonlPath)) return [];
+	const text = fs.readFileSync(jsonlPath, "utf8");
+	const entries: JsonlEntry[] = [];
+	for (const line of text.split("\n")) {
+		const trimmed = line.trim();
+		if (!trimmed) continue;
+		try {
+			const parsed = JSON.parse(trimmed) as unknown;
+			if (isJsonlEntry(parsed)) {
+				entries.push(parsed);
+			}
+		} catch {
+			// Skip corrupted lines
+		}
+	}
+	return entries;
+}
+
+export function reconstructStateFromJsonl(entries: JsonlEntry[]): SessionSnapshot | null {
+	const configEntries = entries.filter((e): e is JsonlEntry & { type: "config" } => e.type === "config");
+	const runEntries = entries.filter((e): e is JsonlEntry & { type: "run" } => e.type === "run");
+	const sessionEntries = entries.filter((e): e is JsonlEntry & { type: "session" } => e.type === "session");
+
+	const lastSession = sessionEntries[sessionEntries.length - 1];
+	const lastConfig = configEntries[configEntries.length - 1];
+
+	const results: ExperimentResult[] = [];
+	for (const run of runEntries) {
+		const r = run.data;
+		results.push({
+			runNumber: run.runId,
+			commit: r.commit,
+			metric: r.metric,
+			metrics: r.metrics,
+			status: r.status,
+			description: r.description,
+			timestamp: run.timestamp,
+			segment: r.segment,
+			confidence: r.confidence,
+			asi: r.asi ?? undefined,
+			modifiedPaths: r.modifiedPaths,
+			scopeDeviations: r.scopeDeviations,
+			justification: r.justification,
+			flagged: r.flagged,
+			flaggedReason: r.flaggedReason,
+		});
+	}
+
+	const snapshot: SessionSnapshot = {
+		name: lastSession?.data.name ?? null,
+		goal: lastSession?.data.goal ?? null,
+		metricName: lastSession?.data.metricName ?? "metric",
+		metricUnit: lastSession?.data.metricUnit ?? "",
+		bestDirection: lastSession?.data.bestDirection ?? "lower",
+		currentSegment: lastSession?.data.currentSegment ?? 0,
+		maxExperiments: lastConfig?.data.maxIterations ?? lastSession?.data.maxExperiments ?? null,
+		results,
+		confidence: lastSession?.data.confidence ?? null,
+		branch: lastSession?.data.branch ?? null,
+		baselineCommit: lastSession?.data.baselineCommit ?? null,
+		notes: lastSession?.data.notes ?? "",
+	};
+
+	return snapshot;
+}
+
+export function readEvoConfig(cwd: string): EvoResearchConfig | null {
+	const configPath = path.join(cwd, CONFIG_FILENAME);
+	if (!fs.existsSync(configPath)) return null;
+	try {
+		const text = fs.readFileSync(configPath, "utf8");
+		const parsed = JSON.parse(text) as unknown;
+		if (typeof parsed !== "object" || parsed === null) return null;
+		return parsed as EvoResearchConfig;
+	} catch {
+		return null;
+	}
+}
+
+export function writeEvoConfig(cwd: string, config: EvoResearchConfig): void {
+	const configPath = path.join(cwd, CONFIG_FILENAME);
+	fs.writeFileSync(configPath, JSON.stringify(config, null, 2), "utf8");
+}
+
+function isJsonlEntry(value: unknown): value is JsonlEntry {
+	if (typeof value !== "object" || value === null) return false;
+	const obj = value as { type?: unknown };
+	return obj.type === "config" || obj.type === "run" || obj.type === "session";
+}

--- a/packages/coding-agent/src/autoresearch/jsonl.ts
+++ b/packages/coding-agent/src/autoresearch/jsonl.ts
@@ -97,13 +97,29 @@ export function readJsonlEntries(cwd: string): JsonlEntry[] {
 	return entries;
 }
 
+export type ConfigJsonlEntry = JsonlEntry & { type: "config" };
+
+/**
+ * Return the most recent `config` entry from a JSONL history.
+ *
+ * The reconstruction path and the compaction path MUST agree on which config
+ * survives so reconstruct(compact(history)) is fixed-point. Centralizing the
+ * pick here is the only thing that keeps them in sync.
+ */
+export function findLatestConfigEntry(entries: readonly JsonlEntry[]): ConfigJsonlEntry | undefined {
+	let latest: ConfigJsonlEntry | undefined;
+	for (const entry of entries) {
+		if (entry.type === "config") latest = entry;
+	}
+	return latest;
+}
+
 export function reconstructStateFromJsonl(entries: JsonlEntry[]): SessionSnapshot | null {
-	const configEntries = entries.filter((e): e is JsonlEntry & { type: "config" } => e.type === "config");
 	const runEntries = entries.filter((e): e is JsonlEntry & { type: "run" } => e.type === "run");
 	const sessionEntries = entries.filter((e): e is JsonlEntry & { type: "session" } => e.type === "session");
 
 	const lastSession = sessionEntries[sessionEntries.length - 1];
-	const lastConfig = configEntries[configEntries.length - 1];
+	const lastConfig = findLatestConfigEntry(entries);
 
 	const results: ExperimentResult[] = [];
 	for (const run of runEntries) {

--- a/packages/coding-agent/src/autoresearch/population.ts
+++ b/packages/coding-agent/src/autoresearch/population.ts
@@ -1,0 +1,222 @@
+import * as crypto from "node:crypto";
+import type {
+	ExperimentResult,
+	ExperimentState,
+	MetricDirection,
+	PopulationCandidate,
+	PopulationFamily,
+	PopulationRecommendation,
+	PopulationState,
+} from "./types";
+
+const MAX_FAMILY_CANDIDATES = 50;
+const MAX_FAMILIES = 5;
+
+export function createPopulationState(): PopulationState {
+	return {
+		families: [],
+		candidates: [],
+		activeFamilyId: null,
+		generation: 0,
+	};
+}
+
+export function generateFamilyId(): string {
+	return `fam_${crypto.randomBytes(4).toString("hex")}`;
+}
+
+export function generateCandidateId(): string {
+	return `cand_${crypto.randomBytes(4).toString("hex")}`;
+}
+
+export function createFamily(name: string, direction: MetricDirection): PopulationFamily {
+	return {
+		id: generateFamilyId(),
+		name,
+		bestMetric: null,
+		bestCandidateId: null,
+		direction,
+		createdAt: Date.now(),
+		candidates: [],
+	};
+}
+
+export function createCandidate(
+	familyId: string,
+	result: ExperimentResult,
+	mutations: string[],
+	parentId: string | null = null,
+): PopulationCandidate {
+	return {
+		id: generateCandidateId(),
+		familyId,
+		metric: result.metric,
+		status: result.status,
+		commit: result.commit,
+		runNumber: result.runNumber ?? 0,
+		createdAt: result.timestamp,
+		parentId,
+		generation: 0,
+		mutations,
+		asi: result.asi,
+	};
+}
+
+export function addCandidateToPopulation(population: PopulationState, candidate: PopulationCandidate): void {
+	population.candidates.push(candidate);
+	const family = population.families.find(f => f.id === candidate.familyId);
+	if (family) {
+		family.candidates.push(candidate.id);
+		if (candidate.status === "keep") {
+			if (family.bestMetric === null || isBetter(candidate.metric, family.bestMetric, family.direction)) {
+				family.bestMetric = candidate.metric;
+				family.bestCandidateId = candidate.id;
+			}
+		}
+	}
+	// Prune old candidates if family exceeds max
+	if (family && family.candidates.length > MAX_FAMILY_CANDIDATES) {
+		const toRemove = family.candidates.slice(0, family.candidates.length - MAX_FAMILY_CANDIDATES);
+		family.candidates = family.candidates.slice(-MAX_FAMILY_CANDIDATES);
+		population.candidates = population.candidates.filter(c => !toRemove.includes(c.id));
+	}
+	population.generation = Math.max(population.generation, candidate.generation);
+}
+
+export function ensureActiveFamily(population: PopulationState, state: ExperimentState): PopulationFamily {
+	let family = population.activeFamilyId ? population.families.find(f => f.id === population.activeFamilyId) : null;
+	if (!family) {
+		family = createFamily(state.name ?? "default", state.bestDirection);
+		population.families.push(family);
+		population.activeFamilyId = family.id;
+	}
+	// Prune families if too many
+	if (population.families.length > MAX_FAMILIES) {
+		const activeId = population.activeFamilyId;
+		population.families = population.families.slice(-MAX_FAMILIES);
+		if (!population.families.some(f => f.id === activeId)) {
+			population.families.push(family);
+		}
+	}
+	return family;
+}
+
+export function getRecommendation(population: PopulationState, state: ExperimentState): PopulationRecommendation {
+	const family = ensureActiveFamily(population, state);
+	const current = state.results.filter(r => r.segment === state.currentSegment);
+	const recent = current.slice(-5);
+	const recentKept = recent.filter(r => r.status === "keep" && !r.flagged);
+	const recentDiscarded = recent.filter(r => r.status === "discard");
+	const recentCrashed = recent.filter(r => r.status === "crash" || r.status === "checks_failed");
+
+	// If too many crashes, suggest backtracking
+	if (recentCrashed.length >= 3) {
+		const bestCandidate = family.bestCandidateId
+			? population.candidates.find(c => c.id === family.bestCandidateId)
+			: null;
+		return {
+			type: "backtrack",
+			familyId: family.id,
+			candidateId: bestCandidate?.id ?? null,
+			reason: "Multiple recent crashes — backtrack to last known good candidate.",
+			suggestedMutations: bestCandidate?.mutations ?? [],
+		};
+	}
+
+	// If many consecutive discards, explore
+	if (recentDiscarded.length >= 4) {
+		return {
+			type: "explore",
+			familyId: family.id,
+			candidateId: null,
+			reason: "Many consecutive discards — try a different approach.",
+			suggestedMutations: collectDiverseMutations(population, family),
+		};
+	}
+
+	// If recent kept runs show improvement, continue
+	if (recentKept.length >= 2) {
+		const lastKept = recentKept[recentKept.length - 1];
+		const prevKept = recentKept[recentKept.length - 2];
+		if (lastKept && prevKept && isBetter(lastKept.metric, prevKept.metric, state.bestDirection)) {
+			return {
+				type: "continue",
+				familyId: family.id,
+				candidateId: null,
+				reason: "Recent kept runs show improvement — continue current direction.",
+				suggestedMutations: extractMutationHints(lastKept),
+			};
+		}
+	}
+
+	// If we have a best candidate, refine
+	if (family.bestCandidateId) {
+		const best = population.candidates.find(c => c.id === family.bestCandidateId);
+		if (best) {
+			return {
+				type: "refine",
+				familyId: family.id,
+				candidateId: best.id,
+				reason: `Refine best candidate (${best.metric}) with smaller mutations.`,
+				suggestedMutations: best.mutations.map(m => `tweak ${m}`),
+			};
+		}
+	}
+
+	// Default: explore
+	return {
+		type: "explore",
+		familyId: family.id,
+		candidateId: null,
+		reason: "No clear pattern yet — explore broadly.",
+		suggestedMutations: collectDiverseMutations(population, family),
+	};
+}
+
+function isBetter(current: number, best: number, direction: MetricDirection): boolean {
+	return direction === "lower" ? current < best : current > best;
+}
+
+function extractMutationHints(result: ExperimentResult): string[] {
+	const hints: string[] = [];
+	if (typeof result.asi?.hypothesis === "string") {
+		hints.push(`follow ${result.asi.hypothesis}`);
+	}
+	if (typeof result.asi?.next_action_hint === "string") {
+		hints.push(result.asi.next_action_hint);
+	}
+	if (hints.length === 0) {
+		hints.push("iterate on last change");
+	}
+	return hints;
+}
+
+function collectDiverseMutations(population: PopulationState, family: PopulationFamily): string[] {
+	const seen = new Set<string>();
+	const mutations: string[] = [];
+	for (const candidate of population.candidates.filter(c => c.familyId === family.id)) {
+		for (const m of candidate.mutations) {
+			if (!seen.has(m)) {
+				seen.add(m);
+				mutations.push(m);
+			}
+		}
+	}
+	return mutations.slice(0, 10);
+}
+
+export function populationStateToJson(population: PopulationState): string {
+	return JSON.stringify(population, null, 2);
+}
+
+export function populationStateFromJson(json: string): PopulationState | null {
+	try {
+		const parsed = JSON.parse(json) as unknown;
+		if (typeof parsed !== "object" || parsed === null) return null;
+		const candidate = parsed as PopulationState;
+		if (!Array.isArray(candidate.families) || !Array.isArray(candidate.candidates)) return null;
+		return candidate;
+	} catch {
+		return null;
+	}
+}

--- a/packages/coding-agent/src/autoresearch/prompt-setup.md
+++ b/packages/coding-agent/src/autoresearch/prompt-setup.md
@@ -40,4 +40,7 @@ You **may** edit anything else needed to make `autoresearch.sh` work — benchma
 
 - Do **not** call `run_experiment`, `log_experiment`, or `update_notes` yet. They will error with "no active autoresearch session" until `init_experiment` runs.
 - Do **not** treat a compile-only check as a benchmark. The harness must actually execute the workload and emit `METRIC`.
-- Do **not** create `autoresearch.md`, `autoresearch.checks.sh`, `autoresearch.program.md`, `autoresearch.ideas.md`, `autoresearch.jsonl`, `.autoresearch/`, or `autoresearch.config.json`. Session state is tracked for you.
+- Do **not** create `autoresearch.program.md`, `autoresearch.jsonl`, `.autoresearch/`, or `autoresearch.config.json`. Session state is tracked for you.
+- You **may** create `autoresearch.md` as an optional rules file that will be injected into your system prompt every iteration.
+- You **may** create `autoresearch.checks.sh` as an optional backpressure script that runs automatically after each passing benchmark to validate results.
+- You **may** create `autoresearch.ideas.md` as an optional ideas backlog.

--- a/packages/coding-agent/src/autoresearch/prompt.md
+++ b/packages/coding-agent/src/autoresearch/prompt.md
@@ -11,7 +11,7 @@ Primary goal:
 There is no goal recorded for this session yet. Infer what to optimize from the latest user message and the conversation; capture the goal in your notes (`update_notes`) once it is clear.
 {{/if}}
 
-Session state and run artifacts are managed for you. The benchmark entrypoint is `bash autoresearch.sh` (committed during Phase 1). Do not edit `autoresearch.sh` mid-segment unless you intentionally bump segment via `init_experiment new_segment: true`. Do not create `autoresearch.md` or `.autoresearch/` in this repo.
+Session state and run artifacts are managed for you. The benchmark entrypoint is `bash autoresearch.sh` (committed during Phase 1). Do not edit `autoresearch.sh` mid-segment unless you intentionally bump segment via `init_experiment new_segment: true`. You may create `autoresearch.md` and `autoresearch.ideas.md` as optional helper files. Do not create `.autoresearch/` in this repo.
 
 Working directory: `{{working_dir}}`
 {{#if has_branch}}Active branch: `{{branch}}`{{/if}}
@@ -21,10 +21,9 @@ You are running an autonomous experiment loop. Keep iterating until the user int
 
 ### Available tools
 - `init_experiment` — open or reconfigure the session. Pass `new_segment: true` to start a fresh baseline within the current session.
-- `run_experiment` — run the benchmark (`bash autoresearch.sh`). Output is captured automatically and `METRIC name=value` / `ASI key=value` lines printed by the harness are parsed back to you. The command is fixed; if you need a different workload, edit `autoresearch.sh` and bump segment via `init_experiment new_segment: true`.
-- `log_experiment` — record the result. On `keep`, modified files are committed for you; on `discard`/`crash`/`checks_failed`, the worktree is reverted. Pass `flag_runs` to mark earlier runs as suspect; flagged runs are excluded from baseline and best-metric math.
-- `update_notes` — replace the durable session playbook (`body`) or append to the ideas backlog (`append_idea`). The notes are injected into your system prompt every iteration.
-
+- `run_experiment` — run the benchmark (`bash autoresearch.sh`). If `autoresearch.checks.sh` exists, it runs automatically after a passing benchmark and can gate the keep status. Output is captured automatically and `METRIC name=value` / `ASI key=value` lines printed by the harness are parsed back to you. The command is fixed; if you need a different workload, edit `autoresearch.sh` and bump segment via `init_experiment new_segment: true`.
+- `log_experiment` — record the result. On `keep`, modified files are committed for you (including `autoresearch.*` files); on `discard`/`crash`/`checks_failed`, the worktree is reverted while preserving `autoresearch.*` files. Pass `flag_runs` to mark earlier runs as suspect; flagged runs are excluded from baseline and best-metric math.
+- `update_notes` — replace the durable session playbook (`body`) or append to the ideas backlog (`append_idea`). The notes are injected into your system prompt every iteration. You may also edit `autoresearch.ideas.md` directly.
 ### Operating protocol
 1. Understand the target before touching code: read source, identify the bottleneck, verify prerequisites and benchmark inputs.
 2. Update goal, scope, or constraints via another `init_experiment` call (no segment bump) or `update_notes`. Bump segment when you intentionally change `autoresearch.sh`.
@@ -94,6 +93,22 @@ An unlogged run is waiting:
 - result: {{#if pending_run_passed}}passed{{else}}failed{{/if}}
 
 Finish the `log_experiment` step before starting another benchmark.
+{{/if}}
+
+{{#if has_population_hint}}
+
+### Population guidance
+{{population_hint}}
+{{/if}}
+{{#if has_autoresearch_md}}
+
+### Rules file (autoresearch.md)
+{{autoresearch_md}}
+{{/if}}
+{{#if has_autoresearch_ideas_md}}
+
+### Ideas backlog (autoresearch.ideas.md)
+{{autoresearch_ideas_md}}
 {{/if}}
 
 ### Guardrails

--- a/packages/coding-agent/src/autoresearch/resume-message.md
+++ b/packages/coding-agent/src/autoresearch/resume-message.md
@@ -7,4 +7,5 @@ Continue the autoresearch loop now.
 {{/if}}
 - Continue from the most promising unfinished direction.
 - Keep iterating until interrupted or until the configured iteration cap is reached.
+- Auto-resume is limited to 20 turns per session to prevent infinite loops.
 - Preserve correctness and do not game the benchmark.

--- a/packages/coding-agent/src/autoresearch/state.ts
+++ b/packages/coding-agent/src/autoresearch/state.ts
@@ -50,6 +50,7 @@ export function createSessionRuntime(): AutoresearchRuntime {
 		runningExperiment: null,
 		state: createExperimentState(),
 		goal: null,
+		experimentsThisSession: 0,
 	};
 }
 

--- a/packages/coding-agent/src/autoresearch/storage.ts
+++ b/packages/coding-agent/src/autoresearch/storage.ts
@@ -449,6 +449,11 @@ export class AutoresearchStorage {
 		return this.getRunByIdRequired(runId);
 	}
 
+	updateRunCommitHash(runId: number, commitHash: string | null): RunRow {
+		this.#db.prepare("UPDATE runs SET commit_hash = ? WHERE id = ?").run(commitHash, runId);
+		return this.getRunByIdRequired(runId);
+	}
+
 	markRunCompleted(params: MarkRunCompletedParams): RunRow {
 		this.#db
 			.prepare(

--- a/packages/coding-agent/src/autoresearch/tools/init-experiment.ts
+++ b/packages/coding-agent/src/autoresearch/tools/init-experiment.ts
@@ -1,5 +1,4 @@
 import * as path from "node:path";
-
 import { Text } from "@oh-my-pi/pi-tui";
 import * as z from "zod/v4";
 import type { ToolDefinition } from "../../extensibility/extensions";
@@ -8,10 +7,11 @@ import { replaceTabs, truncateToWidth } from "../../tools/render-utils";
 import * as git from "../../utils/git";
 import { parseWorkDirDirtyPaths } from "../git";
 import { dedupeStrings, normalizePathSpec } from "../helpers";
+import { readEvoConfig, writeJsonlConfig } from "../jsonl";
+import { createFamily, createPopulationState, populationStateToJson } from "../population";
 import { buildExperimentState } from "../state";
 import { openAutoresearchStorage, type SessionRow } from "../storage";
 import type { AutoresearchToolFactoryOptions, ExperimentState } from "../types";
-
 export const HARNESS_FILENAME = "autoresearch.sh";
 export const DEFAULT_HARNESS_COMMAND = `bash ${HARNESS_FILENAME}`;
 const HARNESS_COMMIT_TITLE = "autoresearch: harness setup";
@@ -88,6 +88,16 @@ export function createInitExperimentTool(
 				}
 			}
 
+			// Pre-write population.json so it gets included in the harness auto-commit
+			const prePopulation = createPopulationState();
+			const preFamily = createFamily(params.name, direction);
+			prePopulation.families.push(preFamily);
+			prePopulation.activeFamilyId = preFamily.id;
+			try {
+				await Bun.write(path.join(ctx.cwd, "autoresearch.population.json"), populationStateToJson(prePopulation));
+			} catch {
+				// Best effort
+			}
 			let harnessCommitted = false;
 			let commitWarning: string | null = null;
 			if (requiresHarness && onAutoresearchBranch) {
@@ -165,6 +175,13 @@ export function createInitExperimentTool(
 			runtime.lastRunArtifactDir = null;
 			runtime.lastRunNumber = null;
 			runtime.lastRunSummary = null;
+
+			// Write JSONL config if present
+			const evoConfig = readEvoConfig(ctx.cwd);
+			const effectiveMaxIterations = maxIterations ?? evoConfig?.maxIterations ?? null;
+			if (evoConfig) {
+				writeJsonlConfig(ctx.cwd, { ...evoConfig, maxIterations: effectiveMaxIterations ?? undefined });
+			}
 			options.dashboard.updateWidget(ctx, runtime);
 			options.dashboard.requestRender();
 

--- a/packages/coding-agent/src/autoresearch/tools/log-experiment.ts
+++ b/packages/coding-agent/src/autoresearch/tools/log-experiment.ts
@@ -17,6 +17,14 @@ import {
 	tryGitPrefix,
 	tryGitStatus,
 } from "../helpers";
+import { runHooksForEvent } from "../hooks";
+import { writeJsonlRun } from "../jsonl";
+import {
+	addCandidateToPopulation,
+	createCandidate,
+	populationStateFromJson,
+	populationStateToJson,
+} from "../population";
 import {
 	buildExperimentState,
 	computeConfidence,
@@ -30,6 +38,7 @@ import type {
 	AutoresearchToolFactoryOptions,
 	ExperimentResult,
 	ExperimentState,
+	HookPayload,
 	LogDetails,
 	NumericMetricMap,
 } from "../types";
@@ -88,6 +97,16 @@ export function createLogExperimentTool(
 
 			const runtime = options.getRuntime(ctx);
 
+			// Fire before_log hooks
+			const preLogState = buildExperimentState(session, storage.listLoggedRuns(session.id));
+			const beforeHookPayload: HookPayload = {
+				event: "before_log",
+				state: preLogState,
+				cwd: ctx.cwd,
+				timestamp: Date.now(),
+			};
+			await runHooksForEvent(ctx.cwd, "before_log", beforeHookPayload);
+
 			const flaggedRuns: LogDetails["flaggedRuns"] = [];
 			for (const flag of params.flag_runs ?? []) {
 				const target = storage.getRunById(flag.run_id);
@@ -127,25 +146,7 @@ export function createLogExperimentTool(
 
 			let gitNote: string | null = null;
 			if (params.status === "keep") {
-				if (onAutoresearchBranch && allModified.length > 0) {
-					const commitResult = await commitKeptExperiment(
-						ctx.cwd,
-						params.description,
-						params.status,
-						params.metric,
-						params.metrics ?? {},
-						allModified,
-						session.primaryMetric,
-					);
-					if (commitResult.error) {
-						return {
-							content: [{ type: "text", text: `Error: ${commitResult.error}` }],
-						};
-					}
-					gitNote = commitResult.note ?? null;
-					const newSha = await tryReadHeadSha(ctx.cwd);
-					if (newSha) commitHash = newSha;
-				} else if (!onAutoresearchBranch) {
+				if (!onAutoresearchBranch) {
 					warnings.push(
 						"Auto-commit skipped: not on a dedicated autoresearch branch. Modified files remain in the worktree.",
 					);
@@ -245,6 +246,64 @@ export function createLogExperimentTool(
 				flaggedReason: null,
 			};
 
+			// Write JSONL run entry
+			writeJsonlRun(ctx.cwd, experiment, pendingRun.command);
+
+			// Update population
+			const populationPath = path.join(ctx.cwd, "autoresearch.population.json");
+			if (fs.existsSync(populationPath)) {
+				try {
+					const populationJson = fs.readFileSync(populationPath, "utf-8");
+					const population = populationStateFromJson(populationJson);
+					if (population) {
+						const family = population.activeFamilyId
+							? population.families.find(f => f.id === population.activeFamilyId)
+							: population.families[0];
+						if (family) {
+							const candidate = createCandidate(family.id, experiment, [], null);
+							addCandidateToPopulation(population, candidate);
+							fs.writeFileSync(populationPath, populationStateToJson(population));
+						}
+					}
+				} catch {
+					// Best effort
+				}
+			}
+
+			// Fire after_log hooks
+			const afterHookPayload: HookPayload = {
+				event: "after_log",
+				state: finalState,
+				cwd: ctx.cwd,
+				timestamp: Date.now(),
+			};
+			await runHooksForEvent(ctx.cwd, "after_log", afterHookPayload);
+
+			// Commit kept experiment after metadata writes so autoresearch files are included
+			if (params.status === "keep" && onAutoresearchBranch && allModified.length > 0) {
+				const commitResult = await commitKeptExperiment(
+					ctx.cwd,
+					params.description,
+					params.status,
+					params.metric,
+					params.metrics ?? {},
+					allModified,
+					session.primaryMetric,
+				);
+				if (commitResult.error) {
+					return {
+						content: [{ type: "text", text: `Error: ${commitResult.error}` }],
+					};
+				}
+				gitNote = commitResult.note ?? null;
+				const newSha = await tryReadHeadSha(ctx.cwd);
+				if (newSha) {
+					commitHash = newSha;
+					experiment.commit = newSha.slice(0, 12);
+					storage.updateRunCommitHash(tentativeRun.id, newSha);
+				}
+			}
+
 			const segmentRunCount = currentResults(finalState.results, finalState.currentSegment).length;
 			if (finalState.maxExperiments !== null && segmentRunCount >= finalState.maxExperiments) {
 				runtime.autoresearchMode = false;
@@ -318,11 +377,11 @@ async function commitKeptExperiment(
 ): Promise<KeepCommitResult> {
 	if (files.length === 0) return { note: "nothing to commit" };
 	try {
-		await git.stage.files(cwd, files);
+		await git.stage.files(cwd, []);
 	} catch (err) {
 		return { error: `git add failed: ${err instanceof Error ? err.message : String(err)}` };
 	}
-	if (!(await git.diff.has(cwd, { cached: true, files }))) {
+	if (!(await git.diff.has(cwd, { cached: true }))) {
 		return { note: "nothing to commit" };
 	}
 	const payload: { [key: string]: string | number } = {
@@ -334,7 +393,7 @@ async function commitKeptExperiment(
 	}
 	const commitMessage = `${description}\n\nResult: ${JSON.stringify(payload)}`;
 	try {
-		const commitResult = await git.commit(cwd, commitMessage, { files });
+		const commitResult = await git.commit(cwd, commitMessage);
 		const summary = `${commitResult.stdout}${commitResult.stderr}`.split("\n").find(line => line.trim().length > 0);
 		return { note: summary?.trim() ?? "committed" };
 	} catch (err) {
@@ -352,9 +411,22 @@ async function revertFailedExperiment(
 		// rewinds prior `keep` commits. Reset to HEAD so any kept improvements
 		// already on the branch survive.
 		try {
+			// Backup autoresearch metadata files
+			const autoresearchFiles = fs
+				.readdirSync(cwd)
+				.filter(name => name.startsWith("autoresearch.") && !fs.statSync(path.join(cwd, name)).isDirectory());
+			const backups: { filePath: string; content: Buffer }[] = [];
+			for (const fileName of autoresearchFiles) {
+				const filePath = path.join(cwd, fileName);
+				backups.push({ filePath, content: fs.readFileSync(filePath) });
+			}
 			await git.reset(cwd, { hard: true, target: "HEAD" });
 			await git.clean(cwd);
-			return { note: "worktree reset to HEAD" };
+			// Restore autoresearch metadata files
+			for (const backup of backups) {
+				fs.writeFileSync(backup.filePath, backup.content);
+			}
+			return { note: "worktree reset to HEAD (autoresearch files preserved)" };
 		} catch (err) {
 			return { error: `git reset/clean failed: ${err instanceof Error ? err.message : String(err)}` };
 		}

--- a/packages/coding-agent/src/autoresearch/tools/log-experiment.ts
+++ b/packages/coding-agent/src/autoresearch/tools/log-experiment.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 import { Text } from "@oh-my-pi/pi-tui";
+import { logger } from "@oh-my-pi/pi-utils";
 import * as z from "zod/v4";
 import type { ToolDefinition } from "../../extensibility/extensions";
 import type { Theme } from "../../modes/theme/theme";
@@ -39,6 +40,7 @@ import type {
 	ExperimentResult,
 	ExperimentState,
 	HookPayload,
+	HookResult,
 	LogDetails,
 	NumericMetricMap,
 } from "../types";
@@ -97,7 +99,10 @@ export function createLogExperimentTool(
 
 			const runtime = options.getRuntime(ctx);
 
-			// Fire before_log hooks
+			// Fire before_log hooks. A hook that exits non-zero blocks the log:
+			// we abandon the pending run, revert any worktree changes as if the
+			// agent had called discard, and surface an actionable error so the
+			// agent can adjust and try again.
 			const preLogState = buildExperimentState(session, storage.listLoggedRuns(session.id));
 			const beforeHookPayload: HookPayload = {
 				event: "before_log",
@@ -105,7 +110,37 @@ export function createLogExperimentTool(
 				cwd: ctx.cwd,
 				timestamp: Date.now(),
 			};
-			await runHooksForEvent(ctx.cwd, "before_log", beforeHookPayload);
+			const beforeHookResults = await runHooksForEvent(ctx.cwd, "before_log", beforeHookPayload);
+			const blockingHook = beforeHookResults.find(r => !r.allowed);
+			if (blockingHook) {
+				const onBranch = (await getCurrentAutoresearchBranch(options.pi, ctx.cwd)) !== null;
+				storage.abandonPendingRuns(session.id);
+				const revertResult = await revertFailedExperiment(ctx.cwd, pendingRun.preRunDirtyPaths, onBranch);
+				runtime.runningExperiment = null;
+				runtime.lastRunSummary = null;
+				runtime.lastRunDuration = null;
+				runtime.lastRunAsi = null;
+				runtime.lastRunArtifactDir = null;
+				runtime.lastRunNumber = null;
+				options.dashboard.updateWidget(ctx, runtime);
+				options.dashboard.requestRender();
+				const reason = blockingHook.message?.trim().length
+					? blockingHook.message.trim()
+					: blockingHook.stderr.trim() || `exit ${blockingHook.exitCode}`;
+				const revertNote = revertResult.error
+					? `; revert failed: ${revertResult.error}`
+					: revertResult.note
+						? `; ${revertResult.note}`
+						: "";
+				return {
+					content: [
+						{
+							type: "text",
+							text: `Error: before_log hook blocked logging (${reason}). Pending run reverted${revertNote}.`,
+						},
+					],
+				};
+			}
 
 			const flaggedRuns: LogDetails["flaggedRuns"] = [];
 			for (const flag of params.flag_runs ?? []) {
@@ -270,14 +305,21 @@ export function createLogExperimentTool(
 				}
 			}
 
-			// Fire after_log hooks
+			// Fire after_log hooks. These are observational — we never roll back
+			// the run that just persisted, but a blocked hook is still surfaced
+			// in the logger so the operator sees it.
 			const afterHookPayload: HookPayload = {
 				event: "after_log",
 				state: finalState,
 				cwd: ctx.cwd,
 				timestamp: Date.now(),
 			};
-			await runHooksForEvent(ctx.cwd, "after_log", afterHookPayload);
+			const afterHookResults = await runHooksForEvent(ctx.cwd, "after_log", afterHookPayload);
+			for (const result of afterHookResults) {
+				if (!result.allowed) {
+					afterLogHookBlocked(result, tentativeRun.id);
+				}
+			}
 
 			// Commit kept experiment after metadata writes so autoresearch files are included
 			if (params.status === "keep" && onAutoresearchBranch && allModified.length > 0) {
@@ -377,7 +419,7 @@ async function commitKeptExperiment(
 ): Promise<KeepCommitResult> {
 	if (files.length === 0) return { note: "nothing to commit" };
 	try {
-		await git.stage.files(cwd, []);
+		await git.stage.files(cwd, files);
 	} catch (err) {
 		return { error: `git add failed: ${err instanceof Error ? err.message : String(err)}` };
 	}
@@ -411,20 +453,15 @@ async function revertFailedExperiment(
 		// rewinds prior `keep` commits. Reset to HEAD so any kept improvements
 		// already on the branch survive.
 		try {
-			// Backup autoresearch metadata files
-			const autoresearchFiles = fs
-				.readdirSync(cwd)
-				.filter(name => name.startsWith("autoresearch.") && !fs.statSync(path.join(cwd, name)).isDirectory());
-			const backups: { filePath: string; content: Buffer }[] = [];
-			for (const fileName of autoresearchFiles) {
-				const filePath = path.join(cwd, fileName);
-				backups.push({ filePath, content: fs.readFileSync(filePath) });
-			}
+			// Snapshot every `autoresearch.*` path (files AND directories such as
+			// `autoresearch.hooks/`, `.autoresearch/`-style state etc.) before
+			// the destructive reset, then restore in place so user-authored
+			// hooks and metadata survive a discard.
+			const backups = collectAutoresearchSnapshots(cwd);
 			await git.reset(cwd, { hard: true, target: "HEAD" });
 			await git.clean(cwd);
-			// Restore autoresearch metadata files
 			for (const backup of backups) {
-				fs.writeFileSync(backup.filePath, backup.content);
+				restoreAutoresearchSnapshot(backup, cwd);
 			}
 			return { note: "worktree reset to HEAD (autoresearch files preserved)" };
 		} catch (err) {
@@ -593,4 +630,99 @@ function renderSummary(details: LogDetails, theme: Theme): string {
 		summary += ` ${theme.fg("warning", `deviations:${details.scopeDeviations.length}`)}`;
 	}
 	return summary;
+}
+
+interface AutoresearchPathSnapshot {
+	relPath: string;
+	files: Array<{ relPath: string; content: Buffer; mode: number }>;
+	dirs: string[];
+}
+
+function collectAutoresearchSnapshots(cwd: string): AutoresearchPathSnapshot[] {
+	const snapshots: AutoresearchPathSnapshot[] = [];
+	let entries: string[];
+	try {
+		entries = fs.readdirSync(cwd);
+	} catch {
+		return snapshots;
+	}
+	for (const name of entries) {
+		if (!name.startsWith("autoresearch.")) continue;
+		const absRoot = path.join(cwd, name);
+		let rootStat: fs.Stats;
+		try {
+			rootStat = fs.statSync(absRoot);
+		} catch {
+			continue;
+		}
+		const snapshot: AutoresearchPathSnapshot = { relPath: name, files: [], dirs: [] };
+		if (rootStat.isDirectory()) {
+			snapshot.dirs.push(name);
+			walkAutoresearchDir(absRoot, name, snapshot);
+		} else if (rootStat.isFile()) {
+			try {
+				snapshot.files.push({ relPath: name, content: fs.readFileSync(absRoot), mode: rootStat.mode });
+			} catch {
+				// best effort
+			}
+		}
+		snapshots.push(snapshot);
+	}
+	return snapshots;
+}
+
+function walkAutoresearchDir(absDir: string, relDir: string, snapshot: AutoresearchPathSnapshot): void {
+	let entries: fs.Dirent[];
+	try {
+		entries = fs.readdirSync(absDir, { withFileTypes: true });
+	} catch {
+		return;
+	}
+	for (const entry of entries) {
+		const absChild = path.join(absDir, entry.name);
+		const relChild = path.posix.join(relDir.split(path.sep).join("/"), entry.name);
+		if (entry.isDirectory()) {
+			snapshot.dirs.push(relChild);
+			walkAutoresearchDir(absChild, relChild, snapshot);
+		} else if (entry.isFile()) {
+			try {
+				const stat = fs.statSync(absChild);
+				snapshot.files.push({ relPath: relChild, content: fs.readFileSync(absChild), mode: stat.mode });
+			} catch {
+				// best effort
+			}
+		}
+	}
+}
+
+function restoreAutoresearchSnapshot(snapshot: AutoresearchPathSnapshot, cwd: string): void {
+	// Recreate directories first so file writes find their parents.
+	for (const relDir of snapshot.dirs) {
+		try {
+			fs.mkdirSync(path.join(cwd, ...relDir.split("/")), { recursive: true });
+		} catch {
+			// best effort
+		}
+	}
+	for (const file of snapshot.files) {
+		const dest = path.join(cwd, ...file.relPath.split("/"));
+		try {
+			fs.mkdirSync(path.dirname(dest), { recursive: true });
+			fs.writeFileSync(dest, file.content);
+			try {
+				fs.chmodSync(dest, file.mode);
+			} catch {
+				// chmod is best-effort (no-op on Windows for some modes).
+			}
+		} catch {
+			// best effort
+		}
+	}
+}
+
+function afterLogHookBlocked(result: HookResult, runId: number): void {
+	const reason = result.message?.trim().length
+		? result.message.trim()
+		: result.stderr.trim() || `exit ${result.exitCode}`;
+	logger.warn("after_log hook reported failure", { runId, reason });
 }

--- a/packages/coding-agent/src/autoresearch/tools/run-experiment.ts
+++ b/packages/coding-agent/src/autoresearch/tools/run-experiment.ts
@@ -176,24 +176,15 @@ export function createRunExperimentTool(
 
 			const passed = execution.exitCode === 0 && !execution.killed;
 
-			// Run backpressure checks if benchmark passed and checks script exists
+			// Run backpressure checks if benchmark passed and checks script exists.
 			let checksPassed: boolean | undefined;
 			let checksOutput: string | undefined;
 			if (passed) {
 				const checksPath = path.join(ctx.cwd, CHECKS_FILENAME);
 				if (fs.existsSync(checksPath)) {
-					try {
-						const checksProc = Bun.spawn(["bash", checksPath], {
-							cwd: ctx.cwd,
-							stdout: "pipe",
-							stderr: "pipe",
-						});
-						const checksExit = await checksProc.exited;
-						checksPassed = checksExit === 0;
-						checksOutput = (await new Response(checksProc.stdout).text()).slice(0, 4 * 1024);
-					} catch {
-						checksPassed = false;
-					}
+					const checksResult = await runChecksScript(ctx.cwd, checksPath);
+					checksPassed = checksResult.passed;
+					checksOutput = checksResult.output;
 				}
 			}
 
@@ -498,4 +489,42 @@ function isRunDetails(value: unknown): value is RunDetails {
 function isProgressDetails(value: unknown): value is RunExperimentProgressDetails {
 	if (typeof value !== "object" || value === null) return false;
 	return "phase" in value && (value as { phase: unknown }).phase === "running";
+}
+
+const CHECKS_OUTPUT_BUDGET = 4 * 1024;
+
+/**
+ * Spawn `bash <checksPath>` and return its pass/fail + captured output.
+ *
+ * Stdout AND stderr MUST be drained concurrently *before* awaiting the exit
+ * code. If we awaited `exited` first while only the stdout reader was active
+ * (the previous behaviour), any checks script that wrote more than the OS
+ * pipe buffer (typically 64 KiB on Linux, ~4 KiB on Windows) to stderr would
+ * block on the next write and the autoresearch loop would deadlock. Both
+ * buffers are capped after the read to keep error-summary output bounded.
+ */
+export async function runChecksScript(
+	cwd: string,
+	checksPath: string,
+	options: { bashCommand?: string } = {},
+): Promise<{ passed: boolean; output: string }> {
+	const bashCmd = options.bashCommand ?? "bash";
+	try {
+		const checksProc = Bun.spawn([bashCmd, checksPath], {
+			cwd,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [outBuf, errBuf] = await Promise.all([
+			new Response(checksProc.stdout).text(),
+			new Response(checksProc.stderr).text(),
+		]);
+		const checksExit = await checksProc.exited;
+		const stdoutCapped = outBuf.slice(0, CHECKS_OUTPUT_BUDGET);
+		const stderrCapped = errBuf.slice(0, CHECKS_OUTPUT_BUDGET).trim();
+		const output = stderrCapped.length > 0 ? `${stdoutCapped}\n[stderr] ${stderrCapped}` : stdoutCapped;
+		return { passed: checksExit === 0, output };
+	} catch {
+		return { passed: false, output: "" };
+	}
 }

--- a/packages/coding-agent/src/autoresearch/tools/run-experiment.ts
+++ b/packages/coding-agent/src/autoresearch/tools/run-experiment.ts
@@ -26,6 +26,8 @@ import { openAutoresearchStorageIfExists } from "../storage";
 import type { AutoresearchToolFactoryOptions, RunDetails, RunExperimentProgressDetails } from "../types";
 import { DEFAULT_HARNESS_COMMAND } from "./init-experiment";
 
+const CHECKS_FILENAME = "autoresearch.checks.sh";
+
 const runExperimentSchema = z.object({
 	timeout_seconds: z.number().describe("timeout in seconds (default 600)").optional(),
 });
@@ -173,6 +175,28 @@ export function createRunExperimentTool(
 			});
 
 			const passed = execution.exitCode === 0 && !execution.killed;
+
+			// Run backpressure checks if benchmark passed and checks script exists
+			let checksPassed: boolean | undefined;
+			let checksOutput: string | undefined;
+			if (passed) {
+				const checksPath = path.join(ctx.cwd, CHECKS_FILENAME);
+				if (fs.existsSync(checksPath)) {
+					try {
+						const checksProc = Bun.spawn(["bash", checksPath], {
+							cwd: ctx.cwd,
+							stdout: "pipe",
+							stderr: "pipe",
+						});
+						const checksExit = await checksProc.exited;
+						checksPassed = checksExit === 0;
+						checksOutput = (await new Response(checksProc.stdout).text()).slice(0, 4 * 1024);
+					} catch {
+						checksPassed = false;
+					}
+				}
+			}
+
 			const resultDetails: RunDetails = {
 				runNumber: insertedRun.id,
 				runDirectory,
@@ -193,6 +217,8 @@ export function createRunExperimentTool(
 				abandonedPriorRun,
 				truncation: llmTruncation.truncated ? llmTruncation : undefined,
 				fullOutputPath: execution.logPath,
+				checksPassed,
+				checksOutput,
 			};
 
 			runtime.lastRunSummary = {

--- a/packages/coding-agent/src/autoresearch/types.ts
+++ b/packages/coding-agent/src/autoresearch/types.ts
@@ -88,6 +88,8 @@ export interface RunDetails {
 	abandonedPriorRun: number | null;
 	truncation?: TruncationResult;
 	fullOutputPath?: string;
+	checksPassed?: boolean;
+	checksOutput?: string;
 }
 
 export interface LogDetails {
@@ -133,6 +135,7 @@ export interface AutoresearchRuntime {
 	runningExperiment: RunningExperiment | null;
 	state: ExperimentState;
 	goal: string | null;
+	experimentsThisSession: number;
 }
 
 export interface AutoresearchControlEntryData {
@@ -156,6 +159,7 @@ export interface DashboardController {
 	requestRender(): void;
 	showOverlay(ctx: ExtensionContext, runtime: AutoresearchRuntime): Promise<void>;
 	updateWidget(ctx: ExtensionContext, runtime: AutoresearchRuntime): void;
+	browserDashboard?: import("./browser-dashboard").BrowserDashboardController;
 }
 
 export interface AutoresearchToolFactoryOptions {
@@ -166,3 +170,85 @@ export interface AutoresearchToolFactoryOptions {
 
 export type AutoresearchToolResult<TDetails> = AgentToolResult<TDetails>;
 export type SessionEntries = SessionEntry[];
+// Population-based evolutionary research types
+export interface PopulationCandidate {
+	id: string;
+	familyId: string;
+	metric: number;
+	status: ExperimentStatus;
+	commit: string;
+	runNumber: number;
+	createdAt: number;
+	parentId: string | null;
+	generation: number;
+	mutations: string[];
+	asi?: ASIData;
+}
+export interface PopulationFamily {
+	id: string;
+	name: string;
+	bestMetric: number | null;
+	bestCandidateId: string | null;
+	direction: MetricDirection;
+	createdAt: number;
+	candidates: string[];
+}
+export interface PopulationState {
+	families: PopulationFamily[];
+	candidates: PopulationCandidate[];
+	activeFamilyId: string | null;
+	generation: number;
+}
+export interface PopulationRecommendation {
+	type: "continue" | "explore" | "backtrack" | "refine" | "segment";
+	familyId: string | null;
+	candidateId: string | null;
+	reason: string;
+	suggestedMutations: string[];
+}
+// Hook system types
+export interface HookPayload {
+	event: "before_run" | "after_run" | "before_log" | "after_log" | "session_before_compact";
+	state: ExperimentState;
+	run?: ExperimentResult;
+	cwd: string;
+	timestamp: number;
+}
+export interface HookResult {
+	exitCode: number;
+	stdout: string;
+	stderr: string;
+	allowed: boolean;
+	message: string | null;
+}
+// Session snapshot for compaction/resume
+export interface SessionSnapshot {
+	name: string | null;
+	goal: string | null;
+	metricName: string;
+	metricUnit: string;
+	bestDirection: MetricDirection;
+	currentSegment: number;
+	maxExperiments: number | null;
+	results: ExperimentResult[];
+	confidence: number | null;
+	branch: string | null;
+	baselineCommit: string | null;
+	notes: string;
+}
+// Evolutionary research config (autoresearch.config.json)
+export interface EvoResearchConfig {
+	maxIterations?: number;
+	workingDir?: string;
+	autoCommit?: boolean;
+	autoRevert?: boolean;
+	enablePopulation?: boolean;
+	enableHooks?: boolean;
+	enableChecks?: boolean;
+	enableBrowserDashboard?: boolean;
+}
+// Browser dashboard SSE state
+export interface BrowserDashboardState {
+	connected: number;
+	events: Array<{ type: string; data: unknown; timestamp: number }>;
+}

--- a/packages/coding-agent/test/autoresearch-roboomp-1562.test.ts
+++ b/packages/coding-agent/test/autoresearch-roboomp-1562.test.ts
@@ -1,0 +1,443 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+import { $ } from "bun";
+import { createBrowserDashboardController } from "../src/autoresearch/browser-dashboard";
+import { compactJsonl } from "../src/autoresearch/compaction";
+import {
+	findLatestConfigEntry,
+	JSONL_FILENAME,
+	type JsonlEntry,
+	readJsonlEntries,
+	reconstructStateFromJsonl,
+} from "../src/autoresearch/jsonl";
+import { createSessionRuntime } from "../src/autoresearch/state";
+import { closeAllAutoresearchStorages } from "../src/autoresearch/storage";
+import { createInitExperimentTool } from "../src/autoresearch/tools/init-experiment";
+import { createLogExperimentTool } from "../src/autoresearch/tools/log-experiment";
+import { createRunExperimentTool, runChecksScript } from "../src/autoresearch/tools/run-experiment";
+import type { ExperimentResult, SessionSnapshot } from "../src/autoresearch/types";
+import type { ExtensionAPI, ExtensionContext } from "../src/extensibility/extensions";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function makeTempDir(prefix: string): string {
+	const dir = path.join(os.tmpdir(), `${prefix}-${Snowflake.next()}`);
+	fs.mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+function dashboardStub() {
+	return {
+		clear(): void {},
+		requestRender(): void {},
+		showOverlay: async (): Promise<void> => {},
+		updateWidget(): void {},
+	};
+}
+
+function createCtx(cwd: string): ExtensionContext {
+	return { cwd, hasUI: false } as ExtensionContext;
+}
+
+interface PiHarness {
+	api: ExtensionAPI;
+}
+
+function createPiHarness(): PiHarness {
+	const activeTools: string[] = [];
+	const api = {
+		appendEntry: () => {},
+		exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+		getActiveTools: () => [...activeTools],
+		setActiveTools: async (toolNames: string[]) => {
+			activeTools.splice(0, activeTools.length, ...toolNames);
+		},
+	} as unknown as ExtensionAPI;
+	return { api };
+}
+
+async function initGitRepo(dir: string): Promise<void> {
+	await $`git init --initial-branch=main`.cwd(dir).quiet();
+	await $`git config user.email tester@example.com`.cwd(dir).quiet();
+	await $`git config user.name Tester`.cwd(dir).quiet();
+	await Bun.write(path.join(dir, "README.md"), "# baseline\n");
+	await $`git add -A`.cwd(dir).quiet();
+	await $`git commit -m baseline`.cwd(dir).quiet();
+}
+
+async function checkoutBranch(dir: string, name: string): Promise<void> {
+	await $`git checkout -b ${name}`.cwd(dir).quiet();
+}
+
+async function writeHarnessStub(dir: string, body = "echo METRIC m=1"): Promise<void> {
+	await Bun.write(path.join(dir, "autoresearch.sh"), `#!/usr/bin/env bash\n${body}\n`);
+}
+
+function syntheticResult(partial: Partial<ExperimentResult>): ExperimentResult {
+	return {
+		runNumber: partial.runNumber ?? null,
+		commit: partial.commit ?? "deadbeef",
+		metric: partial.metric ?? 0,
+		metrics: partial.metrics ?? {},
+		status: partial.status ?? "keep",
+		description: partial.description ?? "",
+		timestamp: partial.timestamp ?? 0,
+		segment: partial.segment ?? 0,
+		confidence: partial.confidence ?? null,
+		asi: partial.asi,
+		modifiedPaths: partial.modifiedPaths ?? [],
+		scopeDeviations: partial.scopeDeviations ?? [],
+		justification: partial.justification ?? null,
+		flagged: partial.flagged ?? false,
+		flaggedReason: partial.flaggedReason ?? null,
+	};
+}
+
+function writeSyntheticJsonl(cwd: string, entries: JsonlEntry[]): void {
+	const lines = entries.map(e => JSON.stringify(e)).join("\n");
+	fs.writeFileSync(path.join(cwd, JSONL_FILENAME), `${lines}\n`, "utf8");
+}
+
+describe("autoresearch jsonl multi-config symmetry (roboomp #1562)", () => {
+	it("reconstruct and compact agree on the latest config — compaction is fixed-point", () => {
+		const dir = makeTempDir("pi-autoresearch-1562-jsonl");
+		try {
+			const entries: JsonlEntry[] = [
+				{ type: "config", timestamp: 1, data: { maxIterations: 3 } },
+				{
+					type: "run",
+					timestamp: 10,
+					runId: 1,
+					data: {
+						segment: 0,
+						command: "bash autoresearch.sh",
+						status: "keep",
+						metric: 50,
+						metrics: { m: 50 },
+						description: "first",
+						commit: "aaaa",
+						modifiedPaths: [],
+						scopeDeviations: [],
+						justification: null,
+						asi: null,
+						confidence: null,
+						flagged: false,
+						flaggedReason: null,
+					},
+				},
+				// A newer config overrides the original maxIterations.
+				{ type: "config", timestamp: 20, data: { maxIterations: 9, enableHooks: true } },
+				{
+					type: "session",
+					timestamp: 30,
+					data: {
+						name: "speed",
+						goal: "make x fast",
+						metricName: "m",
+						metricUnit: "ms",
+						bestDirection: "lower",
+						currentSegment: 0,
+						maxExperiments: 9,
+						results: [],
+						confidence: null,
+						branch: "autoresearch/x",
+						baselineCommit: "aaaa",
+						notes: "",
+					},
+				},
+				{
+					type: "run",
+					timestamp: 40,
+					runId: 2,
+					data: {
+						segment: 0,
+						command: "bash autoresearch.sh",
+						status: "discard",
+						metric: 80,
+						metrics: { m: 80 },
+						description: "second",
+						commit: "bbbb",
+						modifiedPaths: [],
+						scopeDeviations: [],
+						justification: null,
+						asi: null,
+						confidence: null,
+						flagged: false,
+						flaggedReason: null,
+					},
+				},
+			];
+			writeSyntheticJsonl(dir, entries);
+
+			const allEntries = readJsonlEntries(dir);
+			expect(findLatestConfigEntry(allEntries)?.data.maxIterations).toBe(9);
+
+			const before = reconstructStateFromJsonl(allEntries) as SessionSnapshot;
+			expect(before.maxExperiments).toBe(9);
+			expect(before.results.map(r => r.runNumber)).toEqual([1, 2]);
+
+			compactJsonl(dir);
+
+			const afterEntries = readJsonlEntries(dir);
+			// Compaction drops stale configs but keeps the LAST one — so a second
+			// reconstruct yields the same snapshot.
+			const configs = afterEntries.filter(e => e.type === "config");
+			expect(configs).toHaveLength(1);
+			expect(findLatestConfigEntry(afterEntries)?.data.maxIterations).toBe(9);
+
+			const after = reconstructStateFromJsonl(afterEntries) as SessionSnapshot;
+			expect(after.maxExperiments).toBe(before.maxExperiments);
+			expect(after.results.map(r => r.runNumber)).toEqual(before.results.map(r => r.runNumber));
+			expect(after.results.map(r => r.status)).toEqual(before.results.map(r => r.status));
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("autoresearch browser dashboard SSE init (roboomp #1562)", () => {
+	it("emits {type:'init', data:{state, results}} that satisfies the client parser", async () => {
+		const dir = makeTempDir("pi-autoresearch-1562-sse");
+		const controller = createBrowserDashboardController();
+		try {
+			// Port 0 lets the OS assign a free port — required for parallel test runs.
+			await controller.start(dir, { port: 0 });
+			const url = controller.getUrl();
+			expect(url).not.toBeNull();
+
+			const sessionPayload: SessionSnapshot = {
+				name: "speed",
+				goal: "make x fast",
+				metricName: "runtime_ms",
+				metricUnit: "ms",
+				bestDirection: "lower",
+				currentSegment: 0,
+				maxExperiments: 5,
+				results: [syntheticResult({ runNumber: 1, metric: 42, status: "keep", description: "baseline" })],
+				confidence: null,
+				branch: null,
+				baselineCommit: null,
+				notes: "",
+			};
+			controller.broadcast("session", sessionPayload);
+
+			// Read the very first SSE data frame and parse it the way the
+			// browser client does.
+			const response = await fetch(`${url}/events`, { headers: { Accept: "text/event-stream" } });
+			expect(response.ok).toBe(true);
+			expect(response.body).not.toBeNull();
+			const reader = (response.body as ReadableStream<Uint8Array>).getReader();
+			const decoder = new TextDecoder();
+			let buffer = "";
+			let frame: string | null = null;
+			const deadline = Date.now() + 5000;
+			while (Date.now() < deadline) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				buffer += decoder.decode(value, { stream: true });
+				const idx = buffer.indexOf("\n\n");
+				if (idx !== -1) {
+					frame = buffer.slice(0, idx);
+					break;
+				}
+			}
+			try {
+				await reader.cancel();
+			} catch {
+				// ignore
+			}
+			expect(frame).not.toBeNull();
+			const dataLine = (frame ?? "").split("\n").find(line => line.startsWith("data:"));
+			expect(dataLine).toBeDefined();
+			const payload = JSON.parse((dataLine ?? "").slice("data:".length).trim()) as {
+				type: string;
+				data: { state: SessionSnapshot | null; results: ExperimentResult[] };
+			};
+			expect(payload.type).toBe("init");
+			// Exactly the parse the client does: `session = data.data.state; runs = session.results || []`.
+			const session = payload.data.state;
+			expect(session).not.toBeNull();
+			expect(session?.metricName).toBe("runtime_ms");
+			const runs = session?.results ?? [];
+			expect(runs).toHaveLength(1);
+			expect(runs[0].runNumber).toBe(1);
+			// Top-level `results` mirrors `state.results` so future client variants can read either.
+			expect(payload.data.results.map(r => r.runNumber)).toEqual(runs.map(r => r.runNumber));
+		} finally {
+			controller.stop();
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("autoresearch revert preserves autoresearch.hooks/ (roboomp #1562)", () => {
+	let dbOverride: string;
+
+	beforeEach(() => {
+		dbOverride = makeTempDir("pi-autoresearch-1562-revert-db");
+		process.env.OMP_AUTORESEARCH_DB_DIR = dbOverride;
+	});
+
+	afterEach(async () => {
+		delete process.env.OMP_AUTORESEARCH_DB_DIR;
+		closeAllAutoresearchStorages();
+		await Bun.sleep(500);
+		try {
+			fs.rmSync(dbOverride, { recursive: true, force: true });
+		} catch {
+			// Windows file locking is best-effort on cleanup.
+		}
+	});
+
+	it("restores autoresearch.hooks/ (and other autoresearch.* dirs) across a discard", async () => {
+		const dir = makeTempDir("pi-autoresearch-1562-revert");
+		try {
+			await initGitRepo(dir);
+			await writeHarnessStub(dir);
+			await $`git add -A`.cwd(dir).quiet();
+			await $`git commit -m harness`.cwd(dir).quiet();
+			await checkoutBranch(dir, "autoresearch/hooks-survival");
+
+			const runtime = createSessionRuntime();
+			const harness = createPiHarness();
+			const init = createInitExperimentTool({
+				dashboard: dashboardStub(),
+				getRuntime: () => runtime,
+				pi: harness.api,
+			});
+			await init.execute("i", { name: "x", primary_metric: "m" }, undefined, undefined, createCtx(dir));
+
+			// Author hook + a sibling autoresearch.* dir that the legacy implementation
+			// would have wiped because its filter rejected directories outright.
+			const hooksDir = path.join(dir, "autoresearch.hooks");
+			fs.mkdirSync(hooksDir, { recursive: true });
+			const hookPath = path.join(hooksDir, "before-log.sh");
+			await Bun.write(hookPath, "#!/usr/bin/env bash\nexit 0\n");
+			fs.chmodSync(hookPath, 0o755);
+			const sidecarDir = path.join(dir, "autoresearch.notes");
+			fs.mkdirSync(sidecarDir, { recursive: true });
+			await Bun.write(path.join(sidecarDir, "scratch.md"), "draft\n");
+
+			const run = createRunExperimentTool({
+				dashboard: dashboardStub(),
+				getRuntime: () => runtime,
+				pi: harness.api,
+			});
+			await run.execute("r", {}, undefined, undefined, createCtx(dir));
+
+			// Iteration edits that the discard will throw away.
+			await Bun.write(path.join(dir, "scratch.ts"), "// junk\n");
+
+			const log = createLogExperimentTool({
+				dashboard: dashboardStub(),
+				getRuntime: () => runtime,
+				pi: harness.api,
+			});
+			await log.execute(
+				"l",
+				{ metric: 99, status: "discard", description: "drop" },
+				undefined,
+				undefined,
+				createCtx(dir),
+			);
+			await Bun.sleep(200);
+
+			expect(fs.existsSync(hookPath)).toBe(true);
+			expect(fs.readFileSync(hookPath, "utf8")).toContain("exit 0");
+			expect(fs.existsSync(path.join(sidecarDir, "scratch.md"))).toBe(true);
+			// And the discarded scratch must be gone.
+			expect(fs.existsSync(path.join(dir, "scratch.ts"))).toBe(false);
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	}, 60_000);
+});
+
+describe("runChecksScript stderr flooding (roboomp #1562)", () => {
+	// On Windows, `bash` in PATH usually resolves to the WSL launcher; resolve
+	// an explicit Git-for-Windows bash so the test exercises the helper on a
+	// real shell. On Linux/macOS the default `bash` is fine.
+	const bashCommand = resolveBashForTests();
+
+	it.skipIf(!bashCommand)(
+		"returns within seconds when the checks script floods stderr past the OS pipe buffer",
+		async () => {
+			const dir = makeTempDir("pi-autoresearch-1562-checks");
+			try {
+				const checksPath = path.join(dir, "autoresearch.checks.sh");
+				// Pure-bash loop avoids relying on `seq`/`yes` and writes well past the
+				// Linux default 64 KiB pipe buffer and the Windows ~4 KiB one. With the
+				// pre-fix sequential-await pattern this would deadlock; the test caps
+				// itself at 15 s as a hard deadlock guard.
+				const checksScript = [
+					"#!/usr/bin/env bash",
+					"i=0",
+					"while [ $i -lt 1500 ]; do",
+					'  printf "flood line %d padding padding padding padding padding padding padding\\n" "$i" 1>&2',
+					"  i=$((i+1))",
+					"done",
+					"exit 0",
+				].join("\n");
+				await Bun.write(checksPath, `${checksScript}\n`);
+				fs.chmodSync(checksPath, 0o755);
+
+				const start = Date.now();
+				const result = await runChecksScript(dir, checksPath, { bashCommand: bashCommand as string });
+				const elapsed = Date.now() - start;
+				expect(elapsed).toBeLessThan(15_000);
+				expect(result.passed).toBe(true);
+				// Stderr is preserved (capped) so the script's signal isn't lost.
+				expect(result.output).toContain("flood line");
+				expect(result.output).toContain("[stderr]");
+				// Cap is applied — output stays under ~9 KiB (stdout cap + stderr cap + header).
+				expect(result.output.length).toBeLessThan(10 * 1024);
+			} finally {
+				fs.rmSync(dir, { recursive: true, force: true });
+			}
+		},
+		30_000,
+	);
+
+	it.skipIf(!bashCommand)("reports failure when the checks script exits non-zero", async () => {
+		const dir = makeTempDir("pi-autoresearch-1562-checks-fail");
+		try {
+			const checksPath = path.join(dir, "autoresearch.checks.sh");
+			await Bun.write(checksPath, "#!/usr/bin/env bash\necho hello\nexit 7\n");
+			fs.chmodSync(checksPath, 0o755);
+			const result = await runChecksScript(dir, checksPath, { bashCommand: bashCommand as string });
+			expect(result.passed).toBe(false);
+			expect(result.output).toContain("hello");
+		} finally {
+			fs.rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+function resolveBashForTests(): string | null {
+	if (process.platform !== "win32") {
+		return Bun.which("bash") ?? "bash";
+	}
+	// Bun.which("bash") on Windows returns the WSL launcher even when Git for
+	// Windows is installed; consult well-known locations first.
+	const candidates = [
+		"C:\\Program Files\\Git\\bin\\bash.exe",
+		"C:\\Program Files\\Git\\usr\\bin\\bash.exe",
+		"C:\\Program Files (x86)\\Git\\bin\\bash.exe",
+	];
+	for (const candidate of candidates) {
+		if (fs.existsSync(candidate)) return candidate;
+	}
+	// Fall back to scanning PATH explicitly for a non-System32 bash.
+	const pathDirs = (process.env.PATH ?? "").split(path.delimiter);
+	for (const dir of pathDirs) {
+		if (dir.toLowerCase().includes("system32")) continue;
+		const candidate = path.join(dir, "bash.exe");
+		if (fs.existsSync(candidate)) return candidate;
+	}
+	return null;
+}

--- a/packages/coding-agent/test/autoresearch-tools.test.ts
+++ b/packages/coding-agent/test/autoresearch-tools.test.ts
@@ -6,7 +6,7 @@ import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
 import { Snowflake } from "@oh-my-pi/pi-utils";
 import { $ } from "bun";
 import { createSessionRuntime } from "../src/autoresearch/state";
-import { openAutoresearchStorage } from "../src/autoresearch/storage";
+import { closeAllAutoresearchStorages, openAutoresearchStorage } from "../src/autoresearch/storage";
 import { createInitExperimentTool } from "../src/autoresearch/tools/init-experiment";
 import { createLogExperimentTool } from "../src/autoresearch/tools/log-experiment";
 import { createRunExperimentTool } from "../src/autoresearch/tools/run-experiment";
@@ -96,8 +96,10 @@ describe("init_experiment", () => {
 		process.env.OMP_AUTORESEARCH_DB_DIR = dbOverride;
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		delete process.env.OMP_AUTORESEARCH_DB_DIR;
+		closeAllAutoresearchStorages();
+		await Bun.sleep(500);
 		fs.rmSync(dbOverride, { recursive: true, force: true });
 	});
 
@@ -275,9 +277,10 @@ describe("run_experiment", () => {
 		dbOverride = makeTempDir("pi-autoresearch-run-db");
 		process.env.OMP_AUTORESEARCH_DB_DIR = dbOverride;
 	});
-
-	afterEach(() => {
+	afterEach(async () => {
 		delete process.env.OMP_AUTORESEARCH_DB_DIR;
+		closeAllAutoresearchStorages();
+		await Bun.sleep(500);
 		fs.rmSync(dbOverride, { recursive: true, force: true });
 	});
 
@@ -381,9 +384,10 @@ describe("log_experiment", () => {
 		dbOverride = makeTempDir("pi-autoresearch-log-db");
 		process.env.OMP_AUTORESEARCH_DB_DIR = dbOverride;
 	});
-
-	afterEach(() => {
+	afterEach(async () => {
 		delete process.env.OMP_AUTORESEARCH_DB_DIR;
+		closeAllAutoresearchStorages();
+		await Bun.sleep(500);
 		fs.rmSync(dbOverride, { recursive: true, force: true });
 	});
 
@@ -625,12 +629,14 @@ describe("log_experiment", () => {
 			undefined,
 			createCtx(dir),
 		);
+		await Bun.sleep(200);
 		// Pre-existing file untouched
 		expect(fs.readFileSync(path.join(dir, "preexisting.txt"), "utf8")).toBe("leave me\n");
 		// New untracked file removed
 		expect(fs.existsSync(path.join(dir, "src", "new.ts"))).toBe(false);
-		// Tracked edit reverted to baseline content
-		expect(fs.readFileSync(path.join(dir, "src", "edit-me.ts"), "utf8")).toBe("export const v = 1;\n");
+		expect(fs.readFileSync(path.join(dir, "src", "edit-me.ts"), "utf8").replace(/\r\n/g, "\n")).toBe(
+			"export const v = 1;\n",
+		);
 	});
 
 	it("on an autoresearch branch, discard reverts uncommitted changes but preserves prior commits", async () => {
@@ -677,14 +683,20 @@ describe("log_experiment", () => {
 			undefined,
 			createCtx(dir),
 		);
+		await Bun.sleep(200);
 		const headAfter = (await $`git rev-parse HEAD`.cwd(dir).text()).trim();
 		// Prior commits survive — discard does not rewind history.
 		expect(headAfter).toBe(headBeforeDiscard);
 		// Uncommitted iteration changes are gone.
-		expect(fs.readFileSync(path.join(dir, "src", "kept.ts"), "utf8")).toBe("export const v = 1;\n");
-		expect(fs.existsSync(path.join(dir, "scratch.ts"))).toBe(false);
+		expect(fs.readFileSync(path.join(dir, "src", "kept.ts"), "utf8").replace(/\r\n/g, "\n")).toBe(
+			"export const v = 1;\n",
+		);
 		const status = (await $`git status --porcelain`.cwd(dir).text()).trim();
-		expect(status).toBe("");
+		// autoresearch metadata files are updated/created even on discard
+		expect(status).toContain("autoresearch.population.json");
+		expect(status).toContain("autoresearch.jsonl");
+		expect(status).not.toContain("kept.ts");
+		expect(status).not.toContain("scratch.ts");
 	});
 
 	it("on an autoresearch branch, keep commits files that were dirty before run_experiment", async () => {
@@ -798,9 +810,10 @@ describe("update_notes", () => {
 		dbOverride = makeTempDir("pi-autoresearch-notes-db");
 		process.env.OMP_AUTORESEARCH_DB_DIR = dbOverride;
 	});
-
-	afterEach(() => {
+	afterEach(async () => {
 		delete process.env.OMP_AUTORESEARCH_DB_DIR;
+		closeAllAutoresearchStorages();
+		await Bun.sleep(500);
 		fs.rmSync(dbOverride, { recursive: true, force: true });
 	});
 


### PR DESCRIPTION
This PR ports the population-guided evolutionary research loop from `pi-evo-research` into the existing `autoresearch` system, keeping all `autoresearch` naming.

## Added
- **Population-based search** (`population.ts`): population scheduler, candidate/family management, recommendation logic
- **JSONL persistence** (`jsonl.ts`): JSONL log parser, state reconstruction, config/run entry detection
- **Deterministic compaction** (`compaction.ts`): compaction summary builder from disk state
- **Hooks system** (`hooks.ts`): before/after hook runner (bash scripts, JSON stdin, 8KB stdout cap)
- **Browser dashboard** (`browser-dashboard.ts` + `assets/template.html`): live browser dashboard HTTP server with SSE
- **Auto-resume limit** (`MAX_AUTORESUME_TURNS = 20`) in `index.ts`
- **Confidence scoring** already exists and is now integrated with population updates
- **Backpressure checks** via `autoresearch.checks.sh` in `run-experiment.ts`

## Updated
- `types.ts`: added `PopulationState`, `PopulationRecommendation`, `HookResult`, `HookPayload`, `SessionSnapshot`, `EvoResearchConfig`, `BrowserDashboardState`
- `state.ts`: added `experimentsThisSession: 0` to `createSessionRuntime()`
- `helpers.ts`: added `isAutoresearchShCommand()`
- `tools/init-experiment.ts`: JSONL config header writing, population init, `autoresearch.config.json` read, `max_iterations` support
- `tools/run-experiment.ts`: `autoresearch.checks.sh` execution (Bun.spawn), `checksPassed`/`checksOutput` in `RunDetails`
- `tools/log-experiment.ts`: JSONL run entry writing, population update, auto-commit with `git add -A`, auto-revert preserving `autoresearch.*` files, `before_log`/`after_log` hooks
- `dashboard.ts`: `browserDashboard` property, `broadcastToBrowser()` integration in `updateWidget()`
- `index.ts`: auto-resume, deterministic compaction, population integration, hooks, `autoresearch.md`/`autoresearch.ideas.md` injection, `autoresearch.config.json` support, `export` subcommand for browser dashboard
- `prompt.md`, `prompt-setup.md`, `resume-message.md`, `command-resume.md`: population/ASI/ideas.md/checks.sh references
- `storage.ts`: `updateRunCommitHash` for post-log commit sync
- `test/autoresearch-tools.test.ts`: account for `autoresearch.population.json` and `autoresearch.jsonl` in git status assertions

## Key decisions
- **SQLite remains primary**: JSONL is secondary for compaction/resume/dashboard; SQLite is source of truth
- **Git branches remain**: Auto-commit/revert happens within the branch
- **Handlebars prompts remain**: Population/evo-research fields added as optional conditional blocks
- **Keep `update_notes` tool**: `autoresearch.ideas.md` added as file-based alternative
- **Auto-resume limit**: `MAX_AUTORESUME_TURNS = 20` hard limit, gate on `experimentsThisSession > 0`
- **Checks.sh runs after benchmark**: If it exists and benchmark passes, it gates `keep` status
- **Revert preserves autoresearch.* files**: On autoresearch branch, backup files before `git reset --hard HEAD`, restore after `git clean`

## Verification
- `bun check` passes with zero errors
- All 19 autoresearch tests pass (0 fail)