### PR TITLE
fix(coding-agent): make Ctrl-D delete non-empty prompts

### DIFF
--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -200,10 +200,9 @@ export class CustomEditor extends Editor {
 			return;
 		}
 
-		// Intercept configured exit shortcut. Always consume the shortcut so it
-		// never reaches the parent handler; firing onExit is the controller's
-		// chance to snapshot the current text as a draft before shutting down.
-		if (this.#matchesAction(data, "app.exit")) {
+		// Ctrl+D exits only from a completely empty prompt. Otherwise it must
+		// fall through to the editor's Emacs-style forward delete binding.
+		if (this.#matchesAction(data, "app.exit") && this.getText() === "") {
 			this.onExit?.();
 			return;
 		}

--- a/packages/coding-agent/test/custom-editor-keybindings.test.ts
+++ b/packages/coding-agent/test/custom-editor-keybindings.test.ts
@@ -20,6 +20,45 @@ describe("CustomEditor literal question mark input", () => {
 	});
 });
 
+describe("CustomEditor Ctrl-D exit behavior", () => {
+	it("exits from a completely empty prompt", () => {
+		const editor = createEditor();
+		const onExit = vi.fn();
+		editor.onExit = onExit;
+
+		editor.handleInput(ctrl("d"));
+
+		expect(onExit).toHaveBeenCalledTimes(1);
+		expect(editor.getText()).toBe("");
+	});
+
+	it("deletes the character at the cursor instead of exiting when text is present", () => {
+		const editor = createEditor();
+		const onExit = vi.fn();
+		editor.onExit = onExit;
+		editor.setText("abc");
+		editor.moveToLineStart();
+
+		editor.handleInput(ctrl("d"));
+
+		expect(onExit).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("bc");
+	});
+
+	it("treats whitespace as non-empty text for Ctrl-D", () => {
+		const editor = createEditor();
+		const onExit = vi.fn();
+		editor.onExit = onExit;
+		editor.setText(" ");
+		editor.moveToLineStart();
+
+		editor.handleInput(ctrl("d"));
+
+		expect(onExit).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("");
+	});
+});
+
 describe("CustomEditor temporary model selector keybinding", () => {
 	it("triggers the temporary selector from a remapped action key instead of Alt+P", () => {
 		const editor = createEditor();


### PR DESCRIPTION
## Summary
- make Ctrl-D exit only when the prompt is completely empty
- let Ctrl-D fall through to forward delete when prompt text is present
- cover empty, non-empty, and whitespace-only prompt behavior

## Tests
- `bun test packages/coding-agent/test/custom-editor-keybindings.test.ts`