### PR TITLE
fix(tui): prevent coalesced forced render duplication

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -707,7 +707,7 @@ export class TUI extends Container {
 		this.#clearScrollbackOnNextRender ||= clearScrollback;
 		const droppedLines = this.#previousLines.length > 0;
 		this.#previousLines = [];
-		this.#previousLinesDroppedForForcedRender = droppedLines;
+		this.#previousLinesDroppedForForcedRender ||= droppedLines;
 		this.#previousWidth = -1; // -1 triggers widthChanged, forcing a full clear
 		this.#previousHeight = -1; // -1 triggers heightChanged, forcing a full clear
 		this.#cursorRow = 0;
@@ -1327,10 +1327,25 @@ export class TUI extends Container {
 		}
 
 		if (diff.firstChanged === -1) {
-			// Content unchanged. Width change still alters wrapping geometry;
-			// height change shifts the visible window. Either needs a repaint
-			// (outside hostile environments).
-			if (widthChanged) return { kind: "viewportRepaint" };
+			// Content unchanged. Width changes still reflow native terminal
+			// scrollback even when component rows are width-independent. If TUI has
+			// already pushed rows above the viewport, replay them at the new width
+			// when safe; otherwise repaint only the viewport so preexisting shell
+			// scrollback is preserved.
+			if (widthChanged) {
+				const nativeViewportAtBottom = this.#readNativeViewportAtBottom();
+				if (
+					this.#scrollbackHighWater > 0 &&
+					!isMultiplexerSession() &&
+					this.#canReplayNativeScrollbackAtCheckpoint(nativeViewportAtBottom, allowUnknownViewportMutation)
+				) {
+					return { kind: "historyRebuild" };
+				}
+				if (this.#nativeViewportIsScrolled(nativeViewportAtBottom, allowUnknownViewportMutation)) {
+					this.#markNativeScrollbackDirty();
+				}
+				return { kind: "viewportRepaint" };
+			}
 			if (heightChanged && !isTermuxSession() && !isMultiplexerSession()) return { kind: "viewportRepaint" };
 			return { kind: "noop" };
 		}

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -20,6 +20,20 @@ class MutableLinesComponent implements Component {
 	}
 }
 
+class FixedLinesComponent implements Component {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = [...lines];
+	}
+
+	invalidate(): void {}
+
+	render(): string[] {
+		return [...this.#lines];
+	}
+}
+
 class WrappingLinesComponent implements Component {
 	#lines: string[];
 
@@ -801,6 +815,27 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 
+		it("coalesced forced renders do not replay the transcript into scrollback", async () => {
+			const term = new VirtualTerminal(32, 5);
+			const tui = new TUI(term);
+			const component = new MutableLinesComponent(rows("line-", 20));
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+				const before = term.getScrollBuffer().map(line => line.trimEnd());
+
+				tui.requestRender(true);
+				tui.requestRender(true);
+				await settle(term);
+
+				expect(term.getScrollBuffer().map(line => line.trimEnd())).toEqual(before);
+			} finally {
+				tui.stop();
+			}
+		});
+
 		it("appending lines during aggressive resize does not duplicate history rows", async () => {
 			const term = new VirtualTerminal(80, 18);
 			const tui = new TUI(term);
@@ -835,6 +870,35 @@ describe("TUI terminal-state regressions", () => {
 				tui.stop();
 			}
 		}, 15_000);
+
+		it("rebuilds native scrollback on a width resize for width-independent rows", async () => {
+			const term = new VirtualTerminal(10, 3);
+			const tui = new TUI(term);
+			const lines = ["a00-alpha", "b01-bravo", "c02-charlie", "d03-delta", "e04-echo", "f05-foxtrot"];
+			const component = new FixedLinesComponent(lines);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+
+				term.resize(3, 3);
+				tui.requestRender();
+				await settle(term);
+
+				expect(term.getScrollBuffer().map(line => line.trimEnd())).toEqual([
+					"a00",
+					"b01",
+					"c02",
+					"d03",
+					"e04",
+					"f05",
+				]);
+				expect(tui.refreshNativeScrollbackIfDirty()).toBe(false);
+			} finally {
+				tui.stop();
+			}
+		});
 
 		it("rebuilds native scrollback on a width resize without duplicating rows", async () => {
 			// A width resize makes the terminal reflow its own committed scrollback


### PR DESCRIPTION
## What

Prevents coalesced forced renders from replaying an already-rendered transcript into native scrollback.

This covers a remaining duplicated-line path related to #1566. It is separate from the unknown-POSIX-viewport path handled by #1569.

## Why

`TUI.#prepareForcedRender()` clears `#previousLines` before the scheduled render runs. When multiple forced renders coalesce in the same tick, the first call records that prior lines were dropped, but a later forced render sees `#previousLines` already empty and can overwrite that state back to false.

The next render can then treat the full transcript as an append from an empty previous frame and write already-rendered rows into native scrollback again, causing visible duplicated assistant lines.

## Implementation

- Preserve `#previousLinesDroppedForForcedRender` once it has been set during a coalesced forced-render window.
- Rebuild native scrollback on width resize when TUI-owned overflow rows exist even if the logical component rows are unchanged, because the terminal may have reflowed its native scrollback independently.
- Add regression coverage for:
  - repeated forced renders before a paint settles
  - width resize with width-independent rendered rows

## Testing

```sh
bun --check packages/tui/src/tui.ts packages/tui/test/render-regressions.test.ts
bunx biome check packages/tui/src/tui.ts packages/tui/test/render-regressions.test.ts
bun test packages/tui/test/render-regressions.test.ts
```

Also verified the coalesced forced-render repro against current main and this branch:

- current main: scrollback length grows from 20 to 39
- this branch: scrollback remains unchanged at 20

Related to #1566
