### PR TITLE
fix(xiaomi): use Authorization: Bearer for /login validation

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed Anthropic stream idle-timeout retries after the provider stream has already begun.
+- Fixed Xiaomi MiMo `/login` rejecting token-plan (`tp-`) keys with `401 Invalid API Key`. The validation request was still sending the legacy Anthropic `x-api-key` header against the OpenAI-compatible `/v1/chat/completions` endpoint; switched to `Authorization: Bearer`, matching the runtime path. ([#1580](https://github.com/can1357/oh-my-pi/issues/1580))
 
 ## [15.7.3] - 2026-05-31
 

--- a/packages/ai/src/utils/oauth/xiaomi.ts
+++ b/packages/ai/src/utils/oauth/xiaomi.ts
@@ -51,7 +51,7 @@ async function validateXiaomiApiKey(apiKey: string, signal?: AbortSignal): Promi
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					"x-api-key": apiKey,
+					Authorization: `Bearer ${apiKey}`,
 				},
 				body: JSON.stringify({
 					model: ep.model,

--- a/packages/ai/test/xiaomi-oauth.test.ts
+++ b/packages/ai/test/xiaomi-oauth.test.ts
@@ -34,4 +34,49 @@ describe("xiaomi oauth validation", () => {
 		// And the AMS signal is not aborted (would be if the timeout signal were shared).
 		expect(capturedSignals[1]?.aborted).toBe(false);
 	});
+
+	it("sends Authorization: Bearer header (not Anthropic-style x-api-key) for tp- keys", async () => {
+		// Regression: commit 92e8ac06b moved validation from /anthropic/v1/messages to
+		// /v1/chat/completions but kept the Anthropic-style `x-api-key` header. Xiaomi's
+		// OpenAI-compatible endpoint requires Bearer auth and rejects x-api-key as 401
+		// "Invalid API Key" — see issue #1580.
+		const capturedHeaders: Record<string, string>[] = [];
+		const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+			capturedHeaders.push((init?.headers ?? {}) as Record<string, string>);
+			return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+		});
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		await loginXiaomi({
+			onPrompt: async () => "tp-test-key",
+			onAuth: () => {},
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const headers = capturedHeaders[0];
+		expect(headers.Authorization).toBe("Bearer tp-test-key");
+		expect(headers["x-api-key"]).toBeUndefined();
+	});
+
+	it("sends Authorization: Bearer for standard sk- keys as well", async () => {
+		const capturedHeaders: Record<string, string>[] = [];
+		const capturedUrls: string[] = [];
+		const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			capturedUrls.push(typeof input === "string" ? input : input.toString());
+			capturedHeaders.push((init?.headers ?? {}) as Record<string, string>);
+			return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+		});
+		global.fetch = fetchMock as unknown as typeof fetch;
+
+		await loginXiaomi({
+			onPrompt: async () => "sk-test-key",
+			onAuth: () => {},
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(capturedUrls[0]).toBe("https://api.xiaomimimo.com/v1/chat/completions");
+		const headers = capturedHeaders[0];
+		expect(headers.Authorization).toBe("Bearer sk-test-key");
+		expect(headers["x-api-key"]).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## Repro

`/login` → `Xiaomi MiMo` → paste a token-plan (`tp-`) key. Validation fails with:

```
Error: Login failed: Xiaomi MiMo API key validation failed (401): {
  "error": { "message": "Invalid API Key", "param": "Please provide valid API Key",
             "code": "401", "type": "invalid_key" }
}
```

Reproduced in isolation by stubbing `fetch` and calling `loginXiaomi({ onPrompt: () => "tp-…" })`; both captured calls (`token-plan-sgp` then `token-plan-ams`) carry `x-api-key: tp-…` and no `Authorization` header.

## Cause

Commit `92e8ac06b` ("refactor(xiaomi): switch from Anthropic to OpenAI Chat Completions API") moved the validation request from `/anthropic/v1/messages` to `/v1/chat/completions` but left the Anthropic auth header in place:

```ts
// packages/ai/src/utils/oauth/xiaomi.ts
headers: {
  "Content-Type": "application/json",
  "x-api-key": apiKey,          // ← Anthropic convention
},
```

Xiaomi's OpenAI-compatible endpoint requires `Authorization: Bearer <key>` (same scheme used by the streaming runtime — `fetchOpenAICompatibleModels` in `utils/discovery/openai-compatible.ts:120` and the OpenAI SDK call in `providers/openai-completions.ts:1070`). The standard `sk-` host may tolerate `x-api-key`, but the token-plan clusters (`token-plan-sgp/ams/cn`) reject it as `401 Invalid API Key`, blocking login for every `tp-` user.

## Fix

- `packages/ai/src/utils/oauth/xiaomi.ts`: replace `x-api-key` with `Authorization: Bearer ${apiKey}` in the validation request.
- `packages/ai/test/xiaomi-oauth.test.ts`: add two regression tests asserting Bearer auth (and no `x-api-key`) for both `tp-` and `sk-` paths, plus the standard-host URL for `sk-`.
- `packages/ai/CHANGELOG.md`: entry under `[Unreleased] > Fixed`.

The browser-auto-open suggestion from the report is a separate UX concern and is intentionally not touched here.

## Verification

```
$ bun test packages/ai/test/xiaomi-oauth.test.ts
 3 pass, 0 fail, 12 expect() calls

$ cd packages/ai && bun run check
Checked 345 files in 97ms. No fixes applied.
$ tsgo -p tsconfig.json --noEmit   # clean
```

Manual `fetch` stub repro before/after:
- before: 2 calls, both `x-api-key`, both 401 — matches the reporter's stack.
- after: 1 call, `Authorization: Bearer tp-…`, returns the validated key.

Fixes #1580