### PR TITLE
fix(ai): use Authorization Bearer header in Xiaomi login validation

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed Xiaomi MiMo `/login` validation sending `x-api-key` header instead of `Authorization: Bearer`, which caused 401 errors during API key validation. The runtime model discovery already used the correct header; only the login validation path had this inconsistency.
 - Fixed Anthropic stream idle-timeout retries after the provider stream has already begun.
 
 ## [15.7.3] - 2026-05-31

--- a/packages/ai/src/utils/oauth/xiaomi.ts
+++ b/packages/ai/src/utils/oauth/xiaomi.ts
@@ -51,7 +51,7 @@ async function validateXiaomiApiKey(apiKey: string, signal?: AbortSignal): Promi
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					"x-api-key": apiKey,
+					Authorization: `Bearer ${apiKey}`,
 				},
 				body: JSON.stringify({
 					model: ep.model,

--- a/packages/ai/test/xiaomi-oauth.test.ts
+++ b/packages/ai/test/xiaomi-oauth.test.ts
@@ -34,4 +34,35 @@ describe("xiaomi oauth validation", () => {
 		// And the AMS signal is not aborted (would be if the timeout signal were shared).
 		expect(capturedSignals[1]?.aborted).toBe(false);
 	});
+	it("sends Authorization Bearer header (not x-api-key) for sk- keys", async () => {
+		let capturedHeaders: Record<string, string> | undefined;
+		global.fetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+			capturedHeaders = init?.headers as Record<string, string> | undefined;
+			return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+		}) as unknown as typeof fetch;
+		await loginXiaomi({
+			onPrompt: async () => "sk-test-key-12345",
+			onAuth: () => {},
+		});
+		expect(capturedHeaders).toBeDefined();
+		expect(capturedHeaders?.Authorization).toBe("Bearer sk-test-key-12345");
+		expect(capturedHeaders?.["x-api-key"]).toBeUndefined();
+	});
+
+	it("sends Authorization Bearer header for tp- keys", async () => {
+		const capturedHeaders: Record<string, string>[] = [];
+		global.fetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+			capturedHeaders.push(init?.headers as Record<string, string>);
+			return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+		}) as unknown as typeof fetch;
+		await loginXiaomi({
+			onPrompt: async () => "tp-test-key-12345",
+			onAuth: () => {},
+		});
+		expect(capturedHeaders.length).toBeGreaterThanOrEqual(1);
+		for (const headers of capturedHeaders) {
+			expect(headers.Authorization).toBe("Bearer tp-test-key-12345");
+			expect(headers["x-api-key"]).toBeUndefined();
+		}
+	});
 });


### PR DESCRIPTION
## What

Fixes Xiaomi MiMo `/login` validation sending `x-api-key` header instead of `Authorization: Bearer`, which caused 401 errors during API key validation.

## Why

The Xiaomi MiMo API is OpenAI-compatible and expects `Authorization: Bearer` for authentication. The runtime model discovery (`fetchOpenAICompatibleModels`) already uses the correct header — only the login validation path in `packages/ai/src/utils/oauth/xiaomi.ts` had this inconsistency.

Fixes #1582

## Testing

- Added two new test cases in `packages/ai/test/xiaomi-oauth.test.ts`:
  - Verifies `sk-` keys send `Authorization: Bearer` (not `x-api-key`)
  - Verifies `tp-` keys send `Authorization: Bearer` for all endpoints
- `bun test packages/ai/test/xiaomi-oauth.test.ts` — 3/3 pass
- `bun check` (pi-ai) — clean

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated