### PR TITLE
fix(ai): use bearer auth for Xiaomi MiMo login validation

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed Anthropic stream idle-timeout retries after the provider stream has already begun.
+- Fixed Xiaomi MiMo `/login` validation to send `Authorization: Bearer` instead of `x-api-key`, matching runtime OpenAI-compatible requests. ([#1582](https://github.com/can1357/oh-my-pi/issues/1582))
 
 ## [15.7.3] - 2026-05-31
 

--- a/packages/ai/src/utils/oauth/xiaomi.ts
+++ b/packages/ai/src/utils/oauth/xiaomi.ts
@@ -51,7 +51,7 @@ async function validateXiaomiApiKey(apiKey: string, signal?: AbortSignal): Promi
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
-					"x-api-key": apiKey,
+					Authorization: `Bearer ${apiKey}`,
 				},
 				body: JSON.stringify({
 					model: ep.model,

--- a/packages/ai/test/xiaomi-oauth.test.ts
+++ b/packages/ai/test/xiaomi-oauth.test.ts
@@ -1,25 +1,47 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { loginXiaomi } from "../src/utils/oauth/xiaomi";
 
-const originalFetch = global.fetch;
+function fetchImplementation(
+	handler: (input: string | URL | Request, init?: RequestInit | BunFetchRequestInit) => Promise<Response>,
+): typeof fetch {
+	return Object.assign(handler, { preconnect: globalThis.fetch.preconnect });
+}
 
 afterEach(() => {
-	global.fetch = originalFetch;
 	vi.restoreAllMocks();
 });
 
 describe("xiaomi oauth validation", () => {
+	it("validates standard API keys with Bearer authorization", async () => {
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+			fetchImplementation(async (_input, init) => {
+				const headers = new Headers(init?.headers);
+				return headers.get("Authorization") === "Bearer sk-valid" && !headers.has("x-api-key")
+					? new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } })
+					: new Response("Invalid API Key", { status: 401 });
+			}),
+		);
+
+		await loginXiaomi({
+			onPrompt: async () => "sk-valid",
+			onAuth: () => {},
+		});
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
 	it("uses a fresh AbortSignal per endpoint so SGP timeout doesn't abort AMS fallback", async () => {
 		const capturedSignals: (AbortSignal | undefined)[] = [];
-		const fetchMock = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
-			capturedSignals.push(init?.signal ?? undefined);
-			if (capturedSignals.length === 1) {
-				// Simulate SGP timing out: throw an AbortError as AbortSignal.timeout would.
-				throw new DOMException("The operation was aborted due to timeout.", "AbortError");
-			}
-			return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
-		});
-		global.fetch = fetchMock as unknown as typeof fetch;
+		const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
+			fetchImplementation(async (_input, init) => {
+				capturedSignals.push(init?.signal ?? undefined);
+				if (capturedSignals.length === 1) {
+					// Simulate SGP timing out: throw an AbortError as AbortSignal.timeout would.
+					throw new DOMException("The operation was aborted due to timeout.", "AbortError");
+				}
+				return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+			}),
+		);
 
 		await loginXiaomi({
 			onPrompt: async () => "tp-test-key",


### PR DESCRIPTION
## Repro
A focused `bun --eval "$SCRIPT"` repro stubs `fetch` to accept only `Authorization: Bearer sk-valid`; before the fix, `loginXiaomi()` sent `{ "Content-Type": "application/json", "x-api-key": "sk-valid" }` and failed with `Xiaomi MiMo API key validation failed (401): Invalid API Key`.

## Cause
`validateXiaomiApiKey()` in `packages/ai/src/utils/oauth/xiaomi.ts` validated Xiaomi MiMo keys with an `x-api-key` header, while Xiaomi MiMo's OpenAI-compatible endpoint and `fetchOpenAICompatibleModels` use `Authorization: Bearer`.

## Fix
- Switched Xiaomi MiMo `/login` validation requests to `Authorization: Bearer ${apiKey}`.
- Added a regression test that accepts the validation request only when it uses Bearer auth and omits `x-api-key`.
- Recorded the fix in `packages/ai/CHANGELOG.md`.

## Verification
`bun test packages/ai/test/xiaomi-oauth.test.ts` passed with 2 tests; `bun run check` in `packages/ai` passed; the focused repro now succeeds and prints `Authorization: Bearer sk-valid`. Fixes #1582