### PR TITLE
fix(ai): normalize OpenAI-compatible tool-call replay content

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed Anthropic stream idle-timeout retries after the provider stream has already begun.
+- Fixed OpenAI-compatible tool-call replay to send empty assistant content instead of `null`, avoiding strict custom backends that crash with `str`/`NoneType` concatenation after subagent tool results. ([#1585](https://github.com/can1357/oh-my-pi/issues/1585))
 
 ## [15.7.3] - 2026-05-31
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1582,10 +1582,9 @@ export function convertMessages(
 				});
 			}
 		} else if (msg.role === "assistant") {
-			// Some providers (e.g. Mistral) don't accept null content, use empty string instead
 			const assistantMsg: ChatCompletionAssistantMessageParam = {
 				role: "assistant",
-				content: compat.requiresAssistantAfterToolResult ? "" : null,
+				content: null,
 			};
 
 			const textBlocks = msg.content.filter(b => b.type === "text") as TextContent[];
@@ -1757,8 +1756,10 @@ export function convertMessages(
 					(assistantMsg as any).reasoning_details = reasoningDetails;
 				}
 			}
-			// DeepSeek requires non-null content when reasoning_content is present
-			if (assistantMsg.content === null && hasReasoningField) {
+			// Some OpenAI-compatible backends concatenate assistant content as a
+			// string even for tool-call replay. OpenAI accepts an empty string here;
+			// null trips strict/proxy implementations before the tool result is read.
+			if (assistantMsg.content === null && (hasReasoningField || assistantMsg.tool_calls)) {
 				assistantMsg.content = "";
 			}
 			// Skip assistant messages that have no content, no tool calls, and no reasoning payload.

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -97,6 +97,48 @@ describe("openai-completions convertMessages", () => {
 		const imageParts = (imageMessage.content as Array<{ type?: string }>).filter(part => part?.type === "image_url");
 		expect(imageParts.length).toBe(2);
 	});
+	it("serializes assistant tool-call turns with string content for strict OpenAI-compatible backends", () => {
+		const baseModel = getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">;
+		const model: Model<"openai-completions"> = {
+			...baseModel,
+			api: "openai-completions",
+			input: ["text"],
+		};
+
+		const now = Date.now();
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Read missing file", timestamp: now - 1 },
+				{
+					role: "assistant",
+					content: [{ type: "toolCall", id: "tool-1", name: "read", arguments: { path: "missing.txt" } }],
+					api: model.api,
+					provider: model.provider,
+					model: model.id,
+					usage: emptyUsage,
+					stopReason: "toolUse",
+					timestamp: now,
+				},
+				{
+					role: "toolResult",
+					toolCallId: "tool-1",
+					toolName: "read",
+					content: [{ type: "text", text: "" }],
+					isError: false,
+					timestamp: now + 1,
+				},
+			],
+		};
+
+		const messages = convertMessages(model, context, compat);
+		const assistantParam = messages.find(message => message.role === "assistant") as
+			| { role: "assistant"; content: unknown; tool_calls?: Array<{ id: string }> }
+			| undefined;
+
+		expect(assistantParam?.tool_calls).toHaveLength(1);
+		expect(assistantParam?.content).toBe("");
+	});
+
 	it("uses generated tool_call_id values when assistant/tool IDs are empty", () => {
 		const baseModel = getBundledModel("openai", "gpt-4o-mini") as Model<"openai-completions">;
 		const model: Model<"openai-completions"> = {


### PR DESCRIPTION
## Repro
A strict OpenAI-compatible backend can fail after a subagent tool call with an empty result because the replayed assistant tool-call message contains `content: null`. Reproduced with `bun test packages/ai/test/openai-completions-tool-result-images.test.ts -t "serializes assistant tool-call turns"`, which failed before the fix with `Expected: "" Received: null`.

## Cause
`convertMessages` in `packages/ai/src/providers/openai-completions.ts` initialized assistant messages with `content: null` and only converted that to a string when reasoning metadata was present or a provider-specific non-empty placeholder was required. Custom OpenAI-compatible servers that concatenate assistant content as a Python string hit `str + None` during tool-call replay before reading the following tool result.

## Fix
- Normalize OpenAI-compatible assistant tool-call replay messages from `null` content to an empty string while preserving the existing non-empty placeholder path for providers that require it.
- Add regression coverage in `packages/ai/test/openai-completions-tool-result-images.test.ts` for assistant tool-call history followed by an empty tool result.
- Document the fix in `packages/ai/CHANGELOG.md`.

## Verification
`bun test packages/ai/test/openai-completions-tool-result-images.test.ts -t "serializes assistant tool-call turns"` passed. `bun test packages/ai/test/openai-completions-tool-result-images.test.ts` passed. `bun run check:types` in `packages/ai` passed. Pre-publish `gh_push_branch` checks passed. Fixes #1585