### PR TITLE
refactor(tui): improve multiplexer session detection for modern terminals

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added safe terminal emulator allowlist (`ghostty`, `kitty`, `wezterm`, `iterm2`, `vscode`) inside multiplexer sessions to safely enable normal scrollback and history clears for modern, highly compliant host terminals.
+
 ## [15.7.3] - 2026-05-31
 
 ### Added

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -163,7 +163,20 @@ function isTermuxSession(): boolean {
 
 /** Detect terminal multiplexers where scrollback clearing and height-change redraws are hostile. */
 function isMultiplexerSession(): boolean {
-	return Boolean(Bun.env.TMUX || Bun.env.STY || Bun.env.ZELLIJ);
+	const hasMultiplexer = Boolean(Bun.env.TMUX || Bun.env.STY || Bun.env.ZELLIJ);
+	if (!hasMultiplexer) {
+		return false;
+	}
+	// Modern, highly compliant terminal emulators correctly isolate multiplexer panes,
+	// support scrollback boundaries natively, and prevent escape leaks (such as \x1b[3J clearing parent history).
+	// We can safely allow normal scrollback for these.
+	const isSafeTerminal = ["ghostty", "kitty", "wezterm", "iterm2", "vscode"].includes(TERMINAL.id);
+	if (isSafeTerminal) {
+		return false;
+	}
+	// Legacy, low-spec, or non-compliant terminal emulators (like Apple Terminal.app or older Windows Terminals)
+	// are treated as hostile multiplexer hosts. We restrict them to viewport-only repaints to prevent history loss.
+	return true;
 }
 
 /**

--- a/packages/tui/test/overlay-scroll.test.ts
+++ b/packages/tui/test/overlay-scroll.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { type Component, CURSOR_MARKER, TUI } from "@oh-my-pi/pi-tui";
+import { type Component, CURSOR_MARKER, TERMINAL, TUI } from "@oh-my-pi/pi-tui";
 import { VirtualTerminal } from "./virtual-terminal";
 
 class LineComponent implements Component {
@@ -211,50 +211,90 @@ describe("TUI overlays", () => {
 		tui.stop();
 	});
 	it("preserves multiplexer scrollback when replacing terminal history", async () => {
-		await withEnv("TMUX", "1", async () => {
-			const term = new VirtualTerminal(40, 4);
-			const tui = new TUI(term);
-			const component = new MutableContentComponent(buildRows(120));
-			tui.addChild(component);
+		const originalId = TERMINAL.id;
+		Object.defineProperty(TERMINAL, "id", { value: "base", configurable: true });
+		try {
+			await withEnv("TMUX", "1", async () => {
+				const term = new VirtualTerminal(40, 4);
+				const tui = new TUI(term);
+				const component = new MutableContentComponent(buildRows(120));
+				tui.addChild(component);
 
-			tui.start();
-			await flushRender(term);
-			expect(term.getScrollBuffer().join("\n").includes("row-0")).toBeTruthy();
-
-			component.setLines(["new-session-0", "new-session-1", "new-session-2", "new-session-3"]);
-			tui.requestRender(true, { clearScrollback: true });
-			await flushRender(term);
-
-			const scrollback = term.getScrollBuffer().join("\n");
-			expect(scrollback.includes("row-0")).toBeTruthy();
-			expect(term.getViewport().join("\n").includes("new-session-3")).toBeTruthy();
-
-			tui.stop();
-		});
-	});
-	it("keeps hidden tmux overlays out of the viewport while preserving pane history", async () => {
-		await withEnv("TMUX", "1", async () => {
-			const term = new VirtualTerminal(16, 4);
-			const tui = new TUI(term);
-			tui.addChild(new MutableContentComponent(buildRows(80)));
-			try {
 				tui.start();
 				await flushRender(term);
-
-				const handle = tui.showOverlay(new LineComponent("OV_SENTINEL_", 2), { anchor: "top-left" });
-				await flushRender(term);
-				term.resize(14, 4);
-				await flushRender(term);
-
-				handle.hide();
-				await flushRender(term);
-
-				expect(term.getViewport().join("\n").includes("OV_SENTINEL_")).toBeFalsy();
 				expect(term.getScrollBuffer().join("\n").includes("row-0")).toBeTruthy();
-			} finally {
+
+				component.setLines(["new-session-0", "new-session-1", "new-session-2", "new-session-3"]);
+				tui.requestRender(true, { clearScrollback: true });
+				await flushRender(term);
+
+				const scrollback = term.getScrollBuffer().join("\n");
+				expect(scrollback.includes("row-0")).toBeTruthy();
+				expect(term.getViewport().join("\n").includes("new-session-3")).toBeTruthy();
+
 				tui.stop();
-			}
-		});
+			});
+		} finally {
+			Object.defineProperty(TERMINAL, "id", { value: originalId, configurable: true });
+		}
+	});
+	it("clears multiplexer scrollback when replacing terminal history on safe modern terminals", async () => {
+		const originalId = TERMINAL.id;
+		Object.defineProperty(TERMINAL, "id", { value: "ghostty", configurable: true });
+		try {
+			await withEnv("TMUX", "1", async () => {
+				const term = new VirtualTerminal(40, 4);
+				const tui = new TUI(term);
+				const component = new MutableContentComponent(buildRows(120));
+				tui.addChild(component);
+
+				tui.start();
+				await flushRender(term);
+				expect(term.getScrollBuffer().join("\n").includes("row-0")).toBeTruthy();
+
+				component.setLines(["new-session-0", "new-session-1", "new-session-2", "new-session-3"]);
+				tui.requestRender(true, { clearScrollback: true });
+				await flushRender(term);
+
+				const scrollback = term.getScrollBuffer().join("\n");
+				expect(scrollback.includes("row-0")).toBeFalsy();
+				expect(term.getViewport().join("\n").includes("new-session-3")).toBeTruthy();
+
+				tui.stop();
+			});
+		} finally {
+			Object.defineProperty(TERMINAL, "id", { value: originalId, configurable: true });
+		}
+	});
+	it("keeps hidden tmux overlays out of the viewport while preserving pane history", async () => {
+		const originalId = TERMINAL.id;
+		Object.defineProperty(TERMINAL, "id", { value: "base", configurable: true });
+		try {
+			await withEnv("TMUX", "1", async () => {
+				const term = new VirtualTerminal(16, 4);
+				const tui = new TUI(term);
+				tui.addChild(new MutableContentComponent(buildRows(80)));
+				try {
+					tui.start();
+					await flushRender(term);
+
+					const handle = tui.showOverlay(new LineComponent("OV_SENTINEL_", 2), { anchor: "top-left" });
+					await flushRender(term);
+					term.resize(14, 4);
+					await flushRender(term);
+
+					handle.hide();
+					await flushRender(term);
+
+					expect(term.getViewport().join("\n").includes("OV_SENTINEL_")).toBeFalsy();
+					expect(term.getScrollBuffer().join("\n").includes("row-0")).toBeTruthy();
+				} finally {
+					tui.stop();
+				}
+			});
+		} finally {
+			Object.defineProperty(TERMINAL, "id", { value: originalId, configurable: true });
+		}
 	});
 
 	it("does not duplicate transcript into scrollback on repeated forced redraws", async () => {


### PR DESCRIPTION
## What

Improve the terminal multiplexer (tmux) session/pane detection within the TUI renderer by adding an allowlist for modern, compliant terminal emulators (ghostty, kitty, wezterm, iterm2, vscode).

## Why

These modern terminals correctly isolate multiplexer sessions, manage scrollback boundaries properly, and can render overlays perfectly even when tmux is active. Legacy or non-compliant terminals (like Apple Terminal.app or older Windows Terminal versions) continue to be treated with standard safety fallback modes to prevent multiplexer UI corruption.

## Testing

- Verified on multiple terminal environments (including Ghostty, Alacritty, and Kitty).
- Verified `bun check` and standard layout checks.

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)