### PR TITLE
fix(coding-agent): skip shallow clone when a specific SHA is requested

### DIFF
--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1261,7 +1261,7 @@ export async function clone(url: string, targetDir: string, options: CloneOption
 	const absoluteTarget = path.resolve(targetDir);
 	await fs.promises.mkdir(path.dirname(absoluteTarget), { recursive: true });
 
-	const args = ["clone", "--depth", "1"];
+	const args = ["clone", ...(options.sha ? [] : ["--depth", "1"])];
 	if (options.ref) args.push("--branch", options.ref, "--single-branch");
 	else args.push("--single-branch");
 	args.push(url, absoluteTarget);

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -1263,7 +1263,7 @@ export async function clone(url: string, targetDir: string, options: CloneOption
 
 	const args = ["clone", ...(options.sha ? [] : ["--depth", "1"])];
 	if (options.ref) args.push("--branch", options.ref, "--single-branch");
-	else args.push("--single-branch");
+	else if (!options.sha) args.push("--single-branch");
 	args.push(url, absoluteTarget);
 
 	try {


### PR DESCRIPTION
## Summary

Fixes #1589.

When `CloneOptions.sha` is set, two separate issues caused the checkout to fail:

1. **`--depth 1`** produced a shallow clone containing only the branch tip — any SHA elsewhere in history was absent.
2. **`--single-branch`** (without `--branch`) restricted the clone to the remote HEAD — any SHA reachable only from another branch was absent.

Both flags must be suppressed when `sha` is requested without a `ref`.

## Changes

`packages/coding-agent/src/utils/git.ts` — `clone()` function:

```ts
// Before
const args = ["clone", "--depth", "1"];
if (options.ref) args.push("--branch", options.ref, "--single-branch");
else args.push("--single-branch");

// After
const args = ["clone", ...(options.sha ? [] : ["--depth", "1"])];
if (options.ref) args.push("--branch", options.ref, "--single-branch");
else if (!options.sha) args.push("--single-branch");
```

**Behaviour matrix:**

| `ref` | `sha` | Clone flags | Rationale |
|-------|-------|-------------|-----------|
| set   | unset | `--depth 1 --branch ref --single-branch` | Shallow tip of known branch — unchanged |
| set   | set   | `--branch ref --single-branch` | Full history of known branch; SHA must be reachable from it |
| unset | unset | `--depth 1 --single-branch` | Shallow HEAD clone — unchanged |
| unset | set   | _(no depth, no single-branch)_ | Full clone of all refs; SHA reachable regardless of branch |

## Test plan

- [ ] Install a plugin pinned to a SHA on the default branch — should succeed.
- [ ] Install a plugin pinned to a SHA on a non-default branch (no `ref`) — should succeed.
- [ ] Install a plugin with `ref` + `sha` — should succeed.
- [ ] Install a plugin without `sha` — still uses `--depth 1 --single-branch` (no regression).