### PR TITLE
Add jj status line support

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Jujutsu status-line support for colocated `.jj` repositories, showing the active bookmark/change id and jj dirty/untracked counts instead of the underlying git branch.
+
 ## [15.7.4] - 2026-05-31
 
 ### Removed

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -9,6 +9,7 @@ import type { StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle } 
 import { theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
 import * as git from "../../utils/git";
+import * as jj from "../../utils/jj";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../utils/session-color";
 import { sanitizeStatusText } from "../shared";
 import { computeNonMessageTokens } from "../utils/context-usage";
@@ -143,8 +144,10 @@ function tokensForMessage(msg: AgentMessage): number {
 
 export class StatusLineComponent implements Component {
 	#settings: StatusLineSettings = {};
+	#cachedVcsKind: "git" | "jj" | null | undefined = undefined;
 	#cachedBranch: string | null | undefined = undefined;
 	#cachedBranchRepoId: string | null | undefined = undefined;
+	#vcsLabelInFlight = false;
 	#gitWatcher: fs.FSWatcher | null = null;
 	#onBranchChange: (() => void) | null = null;
 	#autoCompactEnabled: boolean = true;
@@ -240,20 +243,22 @@ export class StatusLineComponent implements Component {
 
 	watchBranch(onBranchChange: () => void): void {
 		this.#onBranchChange = onBranchChange;
-		this.#setupGitWatcher();
+		this.#setupVcsWatcher();
 	}
 
-	#setupGitWatcher(): void {
+	#setupVcsWatcher(): void {
 		if (this.#gitWatcher) {
 			this.#gitWatcher.close();
 			this.#gitWatcher = null;
 		}
 
-		const gitHeadPath = git.repo.resolveSync(getProjectDir())?.headPath ?? null;
-		if (!gitHeadPath) return;
+		const projectDir = getProjectDir();
+		const watchPath =
+			jj.resolveSync(projectDir)?.workingCopyPath ?? git.repo.resolveSync(projectDir)?.headPath ?? null;
+		if (!watchPath) return;
 
 		try {
-			this.#gitWatcher = fs.watch(gitHeadPath, () => {
+			this.#gitWatcher = fs.watch(watchPath, () => {
 				this.#invalidateGitCaches();
 				if (this.#onBranchChange) {
 					this.#onBranchChange();
@@ -276,17 +281,63 @@ export class StatusLineComponent implements Component {
 	}
 
 	#invalidateGitCaches(): void {
+		this.#cachedVcsKind = undefined;
 		this.#cachedBranch = undefined;
 		this.#cachedBranchRepoId = undefined;
 		this.#cachedPrContext = undefined;
 	}
-	#getCurrentBranch(): string | null {
-		const head = git.head.resolveSync(getProjectDir());
-		const gitHeadPath = head?.headPath ?? null;
-		if (this.#cachedBranch !== undefined && this.#cachedBranchRepoId === gitHeadPath) {
-			return this.#cachedBranch;
+
+	#formatJjLabel(workingCopy: jj.JjWorkingCopy | null): string | null {
+		if (!workingCopy) return null;
+		return workingCopy.bookmarks[0] ?? workingCopy.changeId;
+	}
+
+	#getCurrentVcs(): { kind: "git" | "jj"; label: string | null; repoId: string | null } | null {
+		const projectDir = getProjectDir();
+		const jjRepo = jj.available() ? jj.resolveSync(projectDir) : null;
+		if (jjRepo) {
+			const repoId = jjRepo.workingCopyPath;
+			if (this.#cachedVcsKind === "jj" && this.#cachedBranch !== undefined && this.#cachedBranchRepoId === repoId) {
+				return { kind: "jj", label: this.#cachedBranch, repoId };
+			}
+			this.#cachedVcsKind = "jj";
+			this.#cachedBranchRepoId = repoId;
+			this.#cachedBranch = null;
+			if (!this.#vcsLabelInFlight) {
+				this.#vcsLabelInFlight = true;
+				void jj
+					.workingCopy(projectDir)
+					.then(workingCopy => {
+						if (this.#cachedVcsKind === "jj" && this.#cachedBranchRepoId === repoId) {
+							this.#cachedBranch = this.#formatJjLabel(workingCopy);
+						}
+					})
+					.catch(() => {
+						if (this.#cachedVcsKind === "jj" && this.#cachedBranchRepoId === repoId) {
+							this.#cachedBranch = null;
+						}
+					})
+					.finally(() => {
+						this.#vcsLabelInFlight = false;
+						if (this.#onBranchChange) {
+							this.#onBranchChange();
+						}
+					});
+			}
+			return { kind: "jj", label: this.#cachedBranch, repoId };
 		}
 
+		const head = git.head.resolveSync(projectDir);
+		const gitHeadPath = head?.headPath ?? null;
+		if (
+			this.#cachedVcsKind === "git" &&
+			this.#cachedBranch !== undefined &&
+			this.#cachedBranchRepoId === gitHeadPath
+		) {
+			return { kind: "git", label: this.#cachedBranch, repoId: gitHeadPath };
+		}
+
+		this.#cachedVcsKind = head ? "git" : null;
 		this.#cachedBranchRepoId = gitHeadPath;
 		if (!head) {
 			this.#cachedBranch = null;
@@ -294,8 +345,7 @@ export class StatusLineComponent implements Component {
 		}
 
 		this.#cachedBranch = head.kind === "ref" ? (head.branchName ?? head.ref) : "detached";
-
-		return this.#cachedBranch ?? null;
+		return { kind: "git", label: this.#cachedBranch, repoId: gitHeadPath };
 	}
 
 	#isDefaultBranch(branch: string): boolean {
@@ -320,10 +370,12 @@ export class StatusLineComponent implements Component {
 		}
 
 		this.#gitStatusInFlight = true;
+		const projectDir = getProjectDir();
+		const useJj = Boolean(jj.available() && jj.resolveSync(projectDir));
 
 		(async () => {
 			try {
-				this.#cachedGitStatus = await git.status.summary(getProjectDir());
+				this.#cachedGitStatus = useJj ? await jj.status.summary(projectDir) : await git.status.summary(projectDir);
 			} catch {
 				this.#cachedGitStatus = null;
 			} finally {
@@ -336,8 +388,14 @@ export class StatusLineComponent implements Component {
 	}
 
 	#lookupPr(): { number: number; url: string } | null {
-		const branch = this.#getCurrentBranch();
-		const currentContext = branch ? createPrCacheContext(branch, this.#cachedBranchRepoId ?? null) : null;
+		const vcs = this.#getCurrentVcs();
+		const branch = vcs?.kind === "git" ? vcs.label : null;
+		const currentContext = branch ? createPrCacheContext(branch, vcs?.repoId ?? null) : null;
+		if (!branch) {
+			this.#cachedPr = null;
+			this.#cachedPrContext = undefined;
+			return null;
+		}
 
 		if (canReuseCachedPr(this.#cachedPr, this.#cachedPrContext, currentContext)) {
 			return this.#cachedPr ?? null;
@@ -357,9 +415,10 @@ export class StatusLineComponent implements Component {
 		(async () => {
 			// Helper: only write cache if branch/repo context hasn't changed since launch
 			const setCachedPr = (value: { number: number; url: string } | null) => {
-				const latestBranch = this.#getCurrentBranch();
+				const latestVcs = this.#getCurrentVcs();
+				const latestBranch = latestVcs?.kind === "git" ? latestVcs.label : null;
 				const latestContext = latestBranch
-					? createPrCacheContext(latestBranch, this.#cachedBranchRepoId ?? null)
+					? createPrCacheContext(latestBranch, latestVcs?.repoId ?? null)
 					: undefined;
 				if (lookupContext && isSamePrCacheContext(latestContext, lookupContext)) {
 					this.#cachedPr = value;
@@ -585,8 +644,8 @@ export class StatusLineComponent implements Component {
 			autoCompactEnabled: this.#autoCompactEnabled,
 			subagentCount: this.#subagentCount,
 			sessionStartTime: this.#sessionStartTime,
-			git: {
-				branch: this.#getCurrentBranch(),
+			vcs: {
+				...(this.#getCurrentVcs() ?? { kind: "git" as const, label: null, repoId: null }),
 				status: this.#getGitStatus(),
 				pr: this.#lookupPr(),
 			},

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -217,8 +217,8 @@ const pathSegment: StatusLineSegment = {
 const gitSegment: StatusLineSegment = {
 	id: "git",
 	render(ctx) {
-		const { branch, status } = ctx.git;
-		if (!branch && !status) return { content: "", visible: false };
+		const { kind, label, status } = ctx.vcs;
+		if (!label && !status) return { content: "", visible: false };
 
 		const opts = ctx.options.git ?? {};
 		const gitStatus = status;
@@ -226,8 +226,8 @@ const gitSegment: StatusLineSegment = {
 
 		const showBranch = opts.showBranch !== false;
 		let content = "";
-		if (showBranch && branch) {
-			content = withIcon(theme.icon.branch, branch);
+		if (showBranch && label) {
+			content = withIcon(kind === "jj" ? "jj" : theme.icon.branch, label);
 		}
 
 		// Add status indicators
@@ -262,7 +262,7 @@ const gitSegment: StatusLineSegment = {
 const prSegment: StatusLineSegment = {
 	id: "pr",
 	render(ctx) {
-		const { pr } = ctx.git;
+		const { pr } = ctx.vcs;
 		if (!pr) return { content: "", visible: false };
 
 		const label = withIcon(theme.icon.pr, `#${pr.number}`);

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -16,6 +16,8 @@ export type {
 
 export type RGB = readonly [number, number, number];
 
+export type VcsKind = "git" | "jj";
+
 export interface SegmentContext {
 	session: AgentSession;
 	width: number;
@@ -46,8 +48,9 @@ export interface SegmentContext {
 	autoCompactEnabled: boolean;
 	subagentCount: number;
 	sessionStartTime: number;
-	git: {
-		branch: string | null;
+	vcs: {
+		kind: VcsKind;
+		label: string | null;
 		status: { staged: number; unstaged: number; untracked: number } | null;
 		pr: { number: number; url: string } | null;
 	};

--- a/packages/coding-agent/src/utils/jj.ts
+++ b/packages/coding-agent/src/utils/jj.ts
@@ -1,0 +1,139 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+export interface JjRepository {
+	jjDir: string;
+	repoRoot: string;
+	workingCopyPath: string;
+}
+
+export interface JjStatusSummary {
+	staged: number;
+	unstaged: number;
+	untracked: number;
+}
+
+export interface JjWorkingCopy {
+	bookmarks: string[];
+	changeId: string;
+	commitId: string;
+	description: string;
+}
+
+function commandExists(command: string): boolean {
+	const pathValue = process.env.PATH;
+	if (!pathValue) return false;
+	const extensions = process.platform === "win32" ? (process.env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";") : [""];
+	for (const dir of pathValue.split(path.delimiter)) {
+		for (const ext of extensions) {
+			const candidate = path.join(dir || ".", `${command}${ext}`);
+			if (fs.existsSync(candidate)) return true;
+		}
+	}
+	return false;
+}
+
+export function available(): boolean {
+	return commandExists("jj");
+}
+
+export function resolveSync(cwd: string): JjRepository | null {
+	let dir = path.resolve(cwd);
+	while (true) {
+		const jjDir = path.join(dir, ".jj");
+		if (fs.existsSync(jjDir)) {
+			return {
+				jjDir,
+				repoRoot: dir,
+				workingCopyPath: path.join(jjDir, "working_copy", "checkout"),
+			};
+		}
+		if (fs.existsSync(path.join(dir, ".git"))) return null;
+		const parent = path.dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+async function runText(cwd: string, args: readonly string[], signal?: AbortSignal): Promise<string | null> {
+	if (!available()) return null;
+	const child = Bun.spawn(["jj", "--no-pager", ...args], {
+		cwd,
+		signal,
+		stdout: "pipe",
+		stderr: "ignore",
+		windowsHide: true,
+	});
+	if (!child.stdout) return null;
+	const [stdout, exitCode] = await Promise.all([new Response(child.stdout).text(), child.exited]);
+	return exitCode === 0 ? stdout : null;
+}
+
+export function parseStatus(text: string): JjStatusSummary {
+	let unstaged = 0;
+	let untracked = 0;
+	let section: "changes" | "untracked" | null = null;
+	for (const rawLine of text.split("\n")) {
+		const line = rawLine.trimEnd();
+		if (!line) continue;
+		if (line === "Working copy changes:") {
+			section = "changes";
+			continue;
+		}
+		if (line === "Untracked paths:") {
+			section = "untracked";
+			continue;
+		}
+		if (line === "The working copy is clean") {
+			section = null;
+			continue;
+		}
+		if (line.startsWith("Working copy ") || line.startsWith("Parent commit ")) {
+			section = null;
+			continue;
+		}
+		if (section === "changes") {
+			if (line.startsWith("? ")) untracked += 1;
+			else unstaged += 1;
+		} else if (section === "untracked" && line.startsWith("? ")) {
+			untracked += 1;
+		}
+	}
+	return { staged: 0, unstaged, untracked };
+}
+
+export function parseWorkingCopy(text: string): JjWorkingCopy | null {
+	const [changeId = "", commitId = "", description = "", bookmarks = ""] = text.trimEnd().split("\n");
+	if (!changeId) return null;
+	return {
+		bookmarks: bookmarks.split(" ").filter(Boolean),
+		changeId,
+		commitId,
+		description,
+	};
+}
+
+export const status = {
+	async summary(cwd: string, signal?: AbortSignal): Promise<JjStatusSummary | null> {
+		const output = await runText(cwd, ["status", "--color", "never"], signal);
+		return output === null ? null : parseStatus(output);
+	},
+};
+
+export async function workingCopy(cwd: string, signal?: AbortSignal): Promise<JjWorkingCopy | null> {
+	const output = await runText(
+		cwd,
+		[
+			"log",
+			"-r",
+			"@",
+			"--no-graph",
+			"--color",
+			"never",
+			"-T",
+			'change_id.shortest(8) ++ "\\n" ++ commit_id.shortest(8) ++ "\\n" ++ description.first_line() ++ "\\n" ++ bookmarks.join(" ")',
+		],
+		signal,
+	);
+	return output === null ? null : parseWorkingCopy(output);
+}

--- a/packages/coding-agent/test/issue-953-repro.test.ts
+++ b/packages/coding-agent/test/issue-953-repro.test.ts
@@ -35,8 +35,9 @@ function createCtx(usage: Partial<SegmentContext["usageStats"]>): SegmentContext
 		autoCompactEnabled: false,
 		subagentCount: 0,
 		sessionStartTime: Date.now(),
-		git: {
-			branch: null,
+		vcs: {
+			kind: "git",
+			label: null,
 			status: null,
 			pr: null,
 		},

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -59,8 +59,9 @@ function createCtx(overrides?: { pathMaxLength?: number; branch?: string | null 
 		autoCompactEnabled: false,
 		subagentCount: 0,
 		sessionStartTime: Date.now(),
-		git: {
-			branch: overrides?.branch ?? null,
+		vcs: {
+			kind: "git",
+			label: overrides?.branch ?? null,
 			status: null,
 			pr: null,
 		},

--- a/packages/coding-agent/test/status-line-path.test.ts
+++ b/packages/coding-agent/test/status-line-path.test.ts
@@ -46,8 +46,9 @@ function createPathContext(): SegmentContext {
 		autoCompactEnabled: false,
 		subagentCount: 0,
 		sessionStartTime: Date.now(),
-		git: {
-			branch: null,
+		vcs: {
+			kind: "git",
+			label: null,
 			status: null,
 			pr: null,
 		},

--- a/packages/coding-agent/test/utils/jj.test.ts
+++ b/packages/coding-agent/test/utils/jj.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { parseStatus, parseWorkingCopy, resolveSync } from "@oh-my-pi/pi-coding-agent/utils/jj";
+
+describe("jj status helpers", () => {
+	test("parses clean working copy status", () => {
+		expect(
+			parseStatus(`The working copy is clean
+Working copy  (@) : abcdef12 empty (no description set)
+Parent commit (@-): 12345678 main | initial
+`),
+		).toEqual({ staged: 0, unstaged: 0, untracked: 0 });
+	});
+
+	test("counts modified and untracked files from jj status", () => {
+		expect(
+			parseStatus(`Working copy changes:
+M src/index.ts
+A src/new.ts
+Untracked paths:
+? scratch.txt
+Working copy  (@) : abcdef12 dirty (no description set)
+Parent commit (@-): 12345678 main | initial
+`),
+		).toEqual({ staged: 0, unstaged: 2, untracked: 1 });
+	});
+
+	test("counts repositories with only untracked paths", () => {
+		expect(
+			parseStatus(`Untracked paths:
+? scratch.txt
+Working copy  (@) : abcdef12 dirty (no description set)
+Parent commit (@-): 12345678 main | initial
+`),
+		).toEqual({ staged: 0, unstaged: 0, untracked: 1 });
+	});
+
+	test("parses working copy identity", () => {
+		expect(parseWorkingCopy("rwnytppy\n983a49b5\nUpdate dependencies\nmain feature\n")).toEqual({
+			bookmarks: ["main", "feature"],
+			changeId: "rwnytppy",
+			commitId: "983a49b5",
+			description: "Update dependencies",
+		});
+	});
+});
+
+describe("jj repository resolution", () => {
+	test("uses colocated jj metadata at the nearest root", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-jj-resolve-"));
+		try {
+			await fs.mkdir(path.join(root, ".jj", "working_copy"), { recursive: true });
+			await fs.mkdir(path.join(root, ".git"), { recursive: true });
+			await fs.mkdir(path.join(root, "src"), { recursive: true });
+			expect(resolveSync(path.join(root, "src"))).toMatchObject({ repoRoot: root });
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+
+	test("stops at a nearer standalone git repository", async () => {
+		const root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-jj-resolve-"));
+		try {
+			await fs.mkdir(path.join(root, ".jj", "working_copy"), { recursive: true });
+			const nested = path.join(root, "vendor", "project");
+			await fs.mkdir(path.join(nested, ".git"), { recursive: true });
+			await fs.mkdir(path.join(nested, "src"), { recursive: true });
+			expect(resolveSync(path.join(nested, "src"))).toBeNull();
+		} finally {
+			await fs.rm(root, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## What

Add first-class status-line awareness for colocated Jujutsu repositories:
- detect .jj repositories before falling back to git
- render the active jj bookmark/change id in the existing git segment
- count dirty/untracked files via jj status
- skip GitHub PR lookup for jj change ids to avoid stale PR badges

## Why

Issue #1136 discussed possible Jujutsu integration. This is a small, non-orchestration first step: OMP should accurately reflect repos already managed by jj without requiring JJ-Sync or workspace changes.

## Testing

- [x] `bun --cwd=packages/coding-agent run check` passes
- [x] `bun test packages/coding-agent/test/utils/jj.test.ts` passes
- [x] Tested locally against a real colocated jj repo
- [x] CHANGELOG updated

Note: broader status-line UI tests were attempted, but this local checkout is missing the pi_natives addon. Building it failed because rustup ran out of disk space while installing the pinned nightly toolchain.