### PR TITLE
fix(mcp): cap automatic reconnect bursts to prevent fork-bomb

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed unbounded MCP reconnect loop that could fork-bomb the host when a stdio MCP server completes the `initialize`/`tools/list` handshake and then exits. `MCPManager` now enforces a per-server crash circuit breaker (5 reconnects per 30 s window) on the automatic `transport.onClose` path; manual `/mcp reconnect` resets the window so users can recover after fixing the misconfiguration ([#1592](https://github.com/can1357/oh-my-pi/issues/1592)).
+
 ## [15.7.4] - 2026-05-31
 
 ### Removed

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -59,6 +59,27 @@ type TrackedPromise<T> = {
 
 const STARTUP_TIMEOUT_MS = 250;
 
+/**
+ * Per-server reconnect-storm circuit breaker.
+ *
+ * `transport.onClose` (wired in {@link MCPManager.connectServers} and
+ * {@link MCPManager.#connectAndWireServer}) fires `reconnectServer` on every
+ * clean process exit, so a stdio MCP server that completes the
+ * `initialize` + `tools/list` handshake and then exits will pull the agent
+ * into a fork loop with no rate limit. That pathology shipped in issue #1592
+ * (a `php`-shebang MCP fork-bombing macOS, parented directly to the agent's
+ * `bun` PID via shebang exec).
+ *
+ * We keep the sliding window short — older crashes age out so a single
+ * transient failure stays cheap — but cap the burst tightly enough that the
+ * agent never spawns more than `RECONNECT_BURST_LIMIT * #doReconnect retries`
+ * (≤ 25) processes per stuck server per window. Manual `/mcp reconnect`
+ * resets the window so users can recover after fixing the underlying
+ * misconfiguration.
+ */
+const RECONNECT_BURST_WINDOW_MS = 30_000;
+const RECONNECT_BURST_LIMIT = 5;
+
 function trackPromise<T>(promise: Promise<T>): TrackedPromise<T> {
 	const tracked: TrackedPromise<T> = { promise, status: "pending" };
 	promise.then(
@@ -166,6 +187,11 @@ export class MCPManager {
 	#pendingReconnections = new Map<string, Promise<MCPServerConnection | null>>();
 	/** Preserved configs for reconnection after connection loss. */
 	#serverConfigs = new Map<string, MCPServerConfig>();
+	/**
+	 * Timestamps of recent `reconnectServer` invocations per server, used by the
+	 * crash-storm circuit breaker (see {@link RECONNECT_BURST_LIMIT}).
+	 */
+	#reconnectHistory = new Map<string, number[]>();
 	/** Monotonic epoch incremented on disconnectAll to invalidate stale reconnections. */
 	#epoch = 0;
 
@@ -666,6 +692,7 @@ export class MCPManager {
 		this.#sources.delete(name);
 		this.#serverConfigs.delete(name);
 		this.#pendingResourceRefresh.delete(name);
+		this.#reconnectHistory.delete(name);
 
 		const connection = this.#connections.get(name);
 
@@ -714,22 +741,67 @@ export class MCPManager {
 		this.#connections.clear();
 		this.#tools = [];
 		this.#subscribedResources.clear();
+		this.#reconnectHistory.clear();
 	}
 
 	/**
 	 * Reconnect to a server after a connection failure.
+	 *
 	 * Tears down the stale connection, re-resolves auth, establishes a new
-	 * connection, reloads tools, and notifies consumers.
-	 * Concurrent calls for the same server share one reconnection attempt.
-	 * Returns the new connection, or null if reconnection failed.
+	 * connection, reloads tools, and notifies consumers. Concurrent calls for
+	 * the same server share one reconnection attempt. Returns the new
+	 * connection, or `null` if reconnection failed or the per-server crash
+	 * burst limit (see {@link RECONNECT_BURST_LIMIT}) is exceeded.
+	 *
+	 * @param options.manual - When `true`, resets the crash-burst window so a
+	 *   user-driven retry (e.g. `/mcp reconnect`) is never blocked by an
+	 *   earlier storm. Defaults to `false`; the transport `onClose` callback
+	 *   and the per-tool-call retry path in `tool-bridge` MUST NOT set it.
 	 */
-	async reconnectServer(name: string): Promise<MCPServerConnection | null> {
+	async reconnectServer(name: string, options?: { manual?: boolean }): Promise<MCPServerConnection | null> {
+		if (options?.manual) {
+			this.#reconnectHistory.delete(name);
+		}
+
 		const pending = this.#pendingReconnections.get(name);
 		if (pending) return pending;
+
+		if (this.#tripReconnectBreaker(name)) {
+			return null;
+		}
 
 		const attempt = this.#doReconnect(name);
 		this.#pendingReconnections.set(name, attempt);
 		return attempt.finally(() => this.#pendingReconnections.delete(name));
+	}
+
+	/**
+	 * Record a reconnect attempt against the per-server crash window and report
+	 * whether the circuit breaker is now open. Sliding window: entries older
+	 * than {@link RECONNECT_BURST_WINDOW_MS} are pruned before the new
+	 * timestamp is appended, so a single transient failure ages out cheaply
+	 * but repeated rapid crashes accumulate until the limit is hit.
+	 */
+	#tripReconnectBreaker(name: string): boolean {
+		const now = Date.now();
+		const previous = this.#reconnectHistory.get(name) ?? [];
+		const recent = previous.filter(ts => now - ts < RECONNECT_BURST_WINDOW_MS);
+		recent.push(now);
+		this.#reconnectHistory.set(name, recent);
+
+		if (recent.length > RECONNECT_BURST_LIMIT) {
+			logger.error("MCP server crashed too many times; suspending automatic reconnects", {
+				path: `mcp:${name}`,
+				crashes: recent.length,
+				windowMs: RECONNECT_BURST_WINDOW_MS,
+			});
+			// Detach the closed connection's onClose so a late EOF event on a
+			// process we already gave up on cannot re-trigger this path.
+			const stale = this.#connections.get(name);
+			if (stale) stale.transport.onClose = undefined;
+			return true;
+		}
+		return false;
 	}
 
 	async #doReconnect(name: string): Promise<MCPServerConnection | null> {

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -795,10 +795,21 @@ export class MCPManager {
 				crashes: recent.length,
 				windowMs: RECONNECT_BURST_WINDOW_MS,
 			});
-			// Detach the closed connection's onClose so a late EOF event on a
-			// process we already gave up on cannot re-trigger this path.
+			// Tear down the stale connection so `getConnectionStatus()` no
+			// longer reports it as "connected" and `waitForConnection()` does
+			// not hand a closed transport to callers. Tools stay registered
+			// in `#tools` — the user can recover with `/mcp reconnect <name>`
+			// once they've fixed the underlying misconfiguration. Mirrors the
+			// teardown in `#doReconnect`: detach `onClose` first so the
+			// transport's own `close()` cannot re-arm this path.
 			const stale = this.#connections.get(name);
-			if (stale) stale.transport.onClose = undefined;
+			if (stale) {
+				stale.transport.onClose = undefined;
+				void stale.transport.close().catch(() => {});
+				this.#connections.delete(name);
+			}
+			this.#pendingConnections.delete(name);
+			this.#pendingToolLoads.delete(name);
 			return true;
 		}
 		return false;

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -1425,7 +1425,7 @@ export class MCPCommandController {
 		this.#showMessage(["", theme.fg("muted", `Reconnecting to "${name}"...`), ""].join("\n"));
 
 		try {
-			const connection = await this.ctx.mcpManager.reconnectServer(name);
+			const connection = await this.ctx.mcpManager.reconnectServer(name, { manual: true });
 			if (connection) {
 				// refreshMCPTools re-registers tools and preserves the user's prior
 				// MCP tool selection. No need to call activateDiscoveredMCPTools —

--- a/packages/coding-agent/test/fixtures/crash-after-init-mcp.ts
+++ b/packages/coding-agent/test/fixtures/crash-after-init-mcp.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env bun
+/**
+ * Test fixture: a minimal stdio MCP server that completes the initialize +
+ * tools/list handshake and then exits cleanly. Models a misconfigured PHP
+ * MCP server (e.g. Laravel Boost in a non-Laravel project) that successfully
+ * advertises tools and then dies on the very next event-loop tick.
+ *
+ * Reproduces issue #1592: without a crash circuit breaker, every exit fires
+ * `transport.onClose`, which triggers an unbounded reconnect storm — the
+ * spindump in the bug report shows 66 487 PHP processes parented to the
+ * agent's `bun` PID.
+ *
+ * Each invocation atomically appends the PID + timestamp to the path in
+ * `$OMP_TEST_SPAWN_LOG`, so the test can count spawns without racing.
+ */
+import * as fs from "node:fs";
+import * as readline from "node:readline";
+
+const spawnLog = Bun.env.OMP_TEST_SPAWN_LOG;
+if (spawnLog) {
+	fs.appendFileSync(spawnLog, `${process.pid} ${Date.now()}\n`);
+}
+
+const rl = readline.createInterface({ input: process.stdin });
+
+function send(message: Record<string, unknown>): void {
+	process.stdout.write(`${JSON.stringify(message)}\n`);
+}
+
+rl.on("line", line => {
+	let message: { id?: number | string; method?: string };
+	try {
+		message = JSON.parse(line);
+	} catch {
+		return;
+	}
+
+	if (message.method === "initialize" && message.id !== undefined) {
+		send({
+			jsonrpc: "2.0",
+			id: message.id,
+			result: {
+				protocolVersion: "2025-03-26",
+				capabilities: { tools: {} },
+				serverInfo: { name: "crash-after-init", version: "1.0.0" },
+			},
+		});
+		return;
+	}
+
+	if (message.method === "tools/list" && message.id !== undefined) {
+		send({ jsonrpc: "2.0", id: message.id, result: { tools: [] } });
+		// Exit on the next tick so the response is fully flushed before EOF.
+		setImmediate(() => process.exit(0));
+		return;
+	}
+});
+
+rl.on("close", () => process.exit(0));

--- a/packages/coding-agent/test/mcp-reconnect-storm.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect-storm.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Regression test for issue #1592: an MCP stdio server that exits immediately
+ * after completing initialize + tools/list must not trigger an unbounded
+ * respawn loop.
+ *
+ * The reporter's agent forked 66 487 PHP child processes in ~7 minutes
+ * (~158 spawns/sec) before macOS force-rebooted. The crashing fixture below
+ * models that pathology: each spawn answers the handshake and exits cleanly,
+ * which fires `transport.onClose` → `reconnectServer` with no rate limiter
+ * in the unpatched build.
+ *
+ * The contract this test defends: per-server crash bursts are capped so that
+ * even a fast-crashing stdio server stays well below the OS process budget.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { MCPManager } from "../src/mcp/manager";
+import type { MCPStdioServerConfig } from "../src/mcp/types";
+
+const FIXTURE_PATH = path.join(import.meta.dir, "fixtures", "crash-after-init-mcp.ts");
+const BUN_EXEC = process.execPath;
+
+describe("MCP reconnect storm (issue #1592)", () => {
+	let workDir: string;
+	let spawnLog: string;
+
+	beforeEach(() => {
+		workDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-mcp-storm-"));
+		spawnLog = path.join(workDir, "spawns.log");
+		fs.writeFileSync(spawnLog, "");
+	});
+
+	afterEach(() => {
+		fs.rmSync(workDir, { recursive: true, force: true });
+	});
+
+	function countSpawns(): number {
+		const text = fs.readFileSync(spawnLog, "utf8");
+		return text.split("\n").filter(line => line.trim().length > 0).length;
+	}
+
+	it("stops respawning after a burst of immediate exits", async () => {
+		const manager = new MCPManager(workDir);
+		const config: MCPStdioServerConfig = {
+			type: "stdio",
+			command: BUN_EXEC,
+			args: [FIXTURE_PATH],
+			env: { OMP_TEST_SPAWN_LOG: spawnLog },
+		};
+
+		try {
+			await manager.connectServers({ crashy: config }, {});
+			// Give the reconnect loop generous time to fire. With the bug this
+			// produced thousands of processes within a second; with the fix the
+			// circuit breaker caps the per-server spawn budget.
+			await Bun.sleep(3000);
+		} finally {
+			await manager.disconnectAll();
+		}
+
+		const spawns = countSpawns();
+		// `RECONNECT_BURST_LIMIT` (5) is the per-server reconnect cap inside
+		// the burst window. The initial connect from `connectServers` adds one
+		// more spawn. On the "initialize + tools/list succeed, then exit" path
+		// the inner retry-with-backoff in `#doReconnect` never fires, so the
+		// steady-state ceiling is `1 + RECONNECT_BURST_LIMIT + 1` ≈ 7 spawns.
+		// 10 leaves room for scheduling jitter without weakening the bound.
+		expect(spawns).toBeLessThanOrEqual(10);
+		// Sanity check: we did spawn at least once. If the fixture never ran
+		// the regression target is wrong and the test is meaningless.
+		expect(spawns).toBeGreaterThan(0);
+	}, 15_000);
+});

--- a/packages/coding-agent/test/mcp-reconnect-storm.test.ts
+++ b/packages/coding-agent/test/mcp-reconnect-storm.test.ts
@@ -56,20 +56,27 @@ describe("MCP reconnect storm (issue #1592)", () => {
 			// produced thousands of processes within a second; with the fix the
 			// circuit breaker caps the per-server spawn budget.
 			await Bun.sleep(3000);
+
+			const spawns = countSpawns();
+			// `RECONNECT_BURST_LIMIT` (5) is the per-server reconnect cap inside
+			// the burst window. The initial connect from `connectServers` adds
+			// one more spawn. On the "initialize + tools/list succeed, then
+			// exit" path the inner retry-with-backoff in `#doReconnect` never
+			// fires, so the steady-state ceiling is
+			// `1 + RECONNECT_BURST_LIMIT + 1` ≈ 7 spawns. 10 leaves room for
+			// scheduling jitter without weakening the bound.
+			expect(spawns).toBeLessThanOrEqual(10);
+			// Sanity check: we did spawn at least once. If the fixture never ran
+			// the regression target is wrong and the test is meaningless.
+			expect(spawns).toBeGreaterThan(0);
+
+			// Once the breaker trips, the stale connection must be torn down so
+			// `getConnectionStatus`/`waitForConnection` cannot hand callers a
+			// dead transport. Tools stay registered in the manager's tool list
+			// so the user can recover via `/mcp reconnect`.
+			expect(manager.getConnectionStatus("crashy")).toBe("disconnected");
 		} finally {
 			await manager.disconnectAll();
 		}
-
-		const spawns = countSpawns();
-		// `RECONNECT_BURST_LIMIT` (5) is the per-server reconnect cap inside
-		// the burst window. The initial connect from `connectServers` adds one
-		// more spawn. On the "initialize + tools/list succeed, then exit" path
-		// the inner retry-with-backoff in `#doReconnect` never fires, so the
-		// steady-state ceiling is `1 + RECONNECT_BURST_LIMIT + 1` ≈ 7 spawns.
-		// 10 leaves room for scheduling jitter without weakening the bound.
-		expect(spawns).toBeLessThanOrEqual(10);
-		// Sanity check: we did spawn at least once. If the fixture never ran
-		// the regression target is wrong and the test is meaningless.
-		expect(spawns).toBeGreaterThan(0);
 	}, 15_000);
 });


### PR DESCRIPTION
## Repro

A stdio MCP server that finishes the `initialize` + `tools/list` handshake and then exits cleanly fires `transport.onClose` on every clean exit. The reporter's setup — a `#!/usr/bin/env php` MCP entrypoint that crashed in a project the user opened the agent in — fed that signal back into `MCPManager.reconnectServer` with no rate limiter, and the agent forked 66 487 `php84` processes in ~7 minutes (parented directly to `bun` via shebang exec) until macOS force-rebooted. Modelled with a Bun stdio fixture (`packages/coding-agent/test/fixtures/crash-after-init-mcp.ts`) that answers the handshake then `process.exit(0)`:

```
$ bun --cwd packages/coding-agent test test/mcp-reconnect-storm.test.ts
Expected: <= 10
Received: 127
```

127 spawns in 3 s ≈ 42/sec, same order of magnitude as the reporter's 158/sec.

## Cause

`packages/coding-agent/src/mcp/manager.ts` wires `connection.transport.onClose` at line 389 (and again in `#connectAndWireServer` at 842) to call `reconnectServer(name)` unconditionally. The inner `#doReconnect` retry-with-backoff resets every time a reconnect *succeeds*, so a server that successfully replies and then exits hits the "happy path" reconnect over and over with no per-server throttle. `#pendingReconnections` dedup only collapses concurrent calls — it does not stop the next sequential one.

## Fix

- Add a per-server sliding-window circuit breaker in `MCPManager`: at most `RECONNECT_BURST_LIMIT` (5) reconnects per `RECONNECT_BURST_WINDOW_MS` (30 s). Sliding window so a single transient failure ages out cheaply, but rapid crashes accumulate until the breaker trips.
- When the breaker trips: log, detach the stale `onClose` so a late EOF cannot re-arm the loop, and return `null`. Tools stay registered as deferred so the user can recover.
- Add `reconnectServer(name, { manual })`. `/mcp reconnect` passes `{ manual: true }`, which clears the per-server history first. The `transport.onClose` callback and the per-tool-call retry in `tool-bridge` MUST NOT set it — those are the loops we are containing.
- Clear `#reconnectHistory` in `disconnectAll` and per-server `disconnectServer` so re-discovered configs start fresh.

Steady-state ceiling on the "init succeeds then exit" path is `1 + RECONNECT_BURST_LIMIT + 1` ≈ 7 spawns per stuck server per 30 s window. Inner `#doReconnect` retries are unaffected on the "init fails" path (bounded to 5 there already), so worst-case absolute ceiling is `RECONNECT_BURST_LIMIT × 5` ≈ 25 spawns per window.

## Verification

- `bun --cwd packages/coding-agent test test/mcp-reconnect-storm.test.ts` — passes (spawns ≤ 10). Without the fix the same test reports 127 spawns; I confirmed by temporarily disabling the breaker check and re-running.
- `bun --cwd packages/coding-agent test test/mcp` — all 65 existing MCP tests pass.
- `bun --cwd packages/coding-agent test test/sdk-mcp-discovery.test.ts test/agent-session-mcp-discovery.test.ts test/acp-mcp-isolation.test.ts test/internal-urls/mcp-protocol.test.ts test/discovery/mcp-json.test.ts test/mcp-reconnect-storm.test.ts` — all 48 cross-cutting MCP tests pass.

Fixes #1592