### PR TITLE
fix(coding-agent/acp): MCP tools registered but never activated for ACP sessions

### DIFF
--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1981,7 +1981,7 @@ export class AcpAgent implements Agent {
 		}
 		if (servers.length === 0) {
 			record.mcpManager = undefined;
-			await record.session.refreshMCPTools([]);
+			await record.session.refreshMCPTools([], { activateAll: true });
 			return;
 		}
 
@@ -2008,7 +2008,7 @@ export class AcpAgent implements Agent {
 		}
 
 		record.mcpManager = manager;
-		await record.session.refreshMCPTools(result.tools);
+		await record.session.refreshMCPTools(result.tools, { activateAll: true });
 	}
 
 	#toMcpConfig(server: McpServer): MCPServerConfig {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3617,8 +3617,13 @@ export class AgentSession {
 	/**
 	 * Replace MCP tools in the registry and recompute the visible MCP tool set immediately.
 	 * This allows /mcp add/remove/reauth to take effect without restarting the session.
+	 *
+	 * @param mcpTools The new MCP tools to register.
+	 * @param options.activateAll When true, force-activates every newly registered MCP tool
+	 *   regardless of prior selection state. Used when an ACP client provisions MCP servers
+	 *   for a session where MCP discovery is disabled.
 	 */
-	async refreshMCPTools(mcpTools: CustomTool[]): Promise<void> {
+	async refreshMCPTools(mcpTools: CustomTool[], options?: { activateAll?: boolean }): Promise<void> {
 		const previousSelectedMCPToolNames = this.getSelectedMCPToolNames();
 		const existingNames = Array.from(this.#toolRegistry.keys());
 		for (const name of existingNames) {
@@ -3658,6 +3663,18 @@ export class AgentSession {
 			this.sessionFile,
 			this.#getConfiguredDefaultSelectedMCPToolNames(),
 		);
+
+		if (options?.activateAll) {
+			// Force-activate every newly registered MCP tool. This path is used
+			// when an ACP client provisions MCP servers for a session where MCP
+			// discovery is disabled — without it, getSelectedMCPToolNames()
+			// returns only already-active tools (circular deadlock: tools can
+			// only become active if they're already active).
+			const newMcpNames = mcpTools.map(t => t.name);
+			const nextActive = [...new Set([...this.#getActiveNonMCPToolNames(), ...newMcpNames])];
+			await this.#applyActiveToolsByName(nextActive, { previousSelectedMCPToolNames });
+			return;
+		}
 
 		const nextActive = [...this.#getActiveNonMCPToolNames(), ...this.getSelectedMCPToolNames()];
 		await this.#applyActiveToolsByName(nextActive, { previousSelectedMCPToolNames });

--- a/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
+++ b/packages/coding-agent/test/agent-session-mcp-discovery.test.ts
@@ -228,6 +228,51 @@ describe("AgentSession MCP discovery", () => {
 		expect(session.systemPrompt).toEqual(["tools:read"]);
 	});
 
+	it("activates all new MCP tools when activateAll is true, even with discovery off", async () => {
+		const readTool = createBasicTool("read", "Read");
+		const toolRegistry = new Map([[readTool.name, readTool]]);
+		const agent = new Agent({
+			initialState: {
+				model: createModel(),
+				systemPrompt: ["initial"],
+				tools: [readTool],
+				messages: [],
+			},
+		});
+		const session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: Settings.isolated({ "mcp.discoveryMode": false }),
+			modelRegistry: {} as never,
+			toolRegistry,
+			mcpDiscoveryEnabled: false,
+			rebuildSystemPrompt: async toolNames => ({
+				systemPrompt: [`tools:${toolNames.join(",")}`],
+			}),
+		});
+		sessions.push(session);
+
+		// Start with only non-MCP tools active — no MCP tools in registry.
+		expect(session.getActiveToolNames()).toEqual(["read"]);
+		expect(session.getSelectedMCPToolNames()).toEqual([]);
+
+		// Load MCP tools via activateAll path (simulating ACP client provisioning).
+		await session.refreshMCPTools(
+			[
+				createMcpCustomTool("mcp__docs_search", "docs", "search", "Search internal docs", ["query"]),
+				createMcpCustomTool("mcp__slack_send_message", "slack", "send_message", "Send a Slack message", [
+					"channel",
+					"text",
+				]),
+			],
+			{ activateAll: true },
+		);
+
+		expect(session.getSelectedMCPToolNames()).toEqual(["mcp__docs_search", "mcp__slack_send_message"]);
+		expect(session.getActiveToolNames()).toEqual(["read", "mcp__docs_search", "mcp__slack_send_message"]);
+		expect(session.systemPrompt).toEqual(["tools:read,mcp__docs_search,mcp__slack_send_message"]);
+	});
+
 	it("preserves directly activated MCP tools across refreshes in discovery mode", async () => {
 		const readTool = createBasicTool("read", "Read");
 		const docsSearchTool = createMcpTool("mcp__docs_search", "docs", "search", "Search internal docs", ["query"]);


### PR DESCRIPTION
## Problem

When an ACP client (e.g. Zed, VS Code ACP extension) provisions MCP servers via `session/new.mcpServers`, OMP correctly connects and registers the tools, but they are never activated — the LLM never sees them.

## Root cause

`refreshMCPTools` builds the next active tool set from `getSelectedMCPToolNames()`. When `mcpDiscoveryEnabled` is `false` (the default), that method returns only MCP tools already present in the active set. ACP sessions start with no MCP tools, creating a circular deadlock:

> Tools could only become active if they were already active.

## Fix

Added an optional `{ activateAll?: boolean }` parameter to `refreshMCPTools`. When `true`, every newly registered tool is force-activated regardless of prior selection. `AcpAgent#configureMcpServers` passes `activateAll: true` on both call sites.

## Scope

- Only affects the ACP protocol path (`#configureMcpServers`)
- Interactive mode, command controller, SDK callbacks, and all other `refreshMCPTools` callers are unchanged
- Existing test "keeps manually deactivated MCP tools off after refresh" still passes
`



## Oh My Pi - ACP 
<img width="800" height="308" alt="image" src="https://github.com/user-attachments/assets/61d92381-5c43-49c6-94d3-018fb4683b01" />


## DEV - ACP
<img width="801" height="317" alt="image" src="https://github.com/user-attachments/assets/6644b411-629e-457f-ae6f-f955f6762c99" />





## Testing


- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
