### PR TITLE
fix(tui): defer bottom-anchored shrink on unknown POSIX viewports

### DIFF
--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1335,8 +1335,14 @@ export class TUI extends Container {
 			) {
 				return { kind: "historyRebuild" };
 			}
+			// POSIX terminals that cannot report viewport position fall through here
+			// (`canRebuildNativeScrollbackLive` is false): a viewport-only repaint would
+			// bottom-anchor `newLines` and re-emit the rows between the new and old
+			// viewport tops on top of the copies the terminal already kept in native
+			// scrollback. Pad to the previous row count instead and let the next
+			// checkpoint rebuild (e.g. prompt submit) clean up.
 			this.#markNativeScrollbackDirty();
-			return { kind: "viewportRepaint" };
+			return { kind: "deferredShrink", paddedLength: this.#previousLines.length };
 		}
 
 		const suppressSuffixScroll = this.#suppressNextSuffixScroll;

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1342,12 +1342,17 @@ export class TUI extends Container {
 			// previous row count so no committed row is re-emitted, and the next checkpoint
 			// rebuild (e.g. prompt submit -> `refreshNativeScrollbackIfDirty`) cleans up.
 			//
-			// That deferral only carries real content when `newLines.length > scrollbackHighWater`
-			// — otherwise the padded viewport rows fall entirely past the end of `newLines`
-			// and render as all blanks, hiding the prompt until the next checkpoint. For
-			// shrinks that large, yanking a scrolled reader (historyRebuild) is the lesser
-			// evil; do it unconditionally.
-			if (newLines.length <= this.#scrollbackHighWater) {
+			// That deferral only carries real content when `newLines.length` reaches the
+			// padded viewport top (`previousLines.length - height`) — otherwise every
+			// row the padded repaint draws is past the end of `newLines` and renders as
+			// blank, hiding the prompt until the next checkpoint. This can happen even
+			// when `scrollbackHighWater` is much lower than `previousLines.length - height`,
+			// because prior unknown-POSIX viewport repaints commit longer logical frames
+			// without moving the native scrollback boundary. For shrinks that large,
+			// yanking a scrolled reader (historyRebuild) is the lesser evil; do it
+			// unconditionally.
+			const paddedViewportTop = Math.max(0, this.#previousLines.length - height);
+			if (newLines.length <= paddedViewportTop) {
 				return { kind: "historyRebuild" };
 			}
 			this.#markNativeScrollbackDirty();

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1336,11 +1336,20 @@ export class TUI extends Container {
 				return { kind: "historyRebuild" };
 			}
 			// POSIX terminals that cannot report viewport position fall through here
-			// (`canRebuildNativeScrollbackLive` is false): a viewport-only repaint would
-			// bottom-anchor `newLines` and re-emit the rows between the new and old
-			// viewport tops on top of the copies the terminal already kept in native
-			// scrollback. Pad to the previous row count instead and let the next
-			// checkpoint rebuild (e.g. prompt submit) clean up.
+			// (`canRebuildNativeScrollbackLive` is false). A viewport-only repaint would
+			// re-emit the rows between the new and old viewport tops on top of the copies
+			// the terminal already kept in native scrollback. `deferredShrink` pads to the
+			// previous row count so no committed row is re-emitted, and the next checkpoint
+			// rebuild (e.g. prompt submit -> `refreshNativeScrollbackIfDirty`) cleans up.
+			//
+			// That deferral only carries real content when `newLines.length > scrollbackHighWater`
+			// — otherwise the padded viewport rows fall entirely past the end of `newLines`
+			// and render as all blanks, hiding the prompt until the next checkpoint. For
+			// shrinks that large, yanking a scrolled reader (historyRebuild) is the lesser
+			// evil; do it unconditionally.
+			if (newLines.length <= this.#scrollbackHighWater) {
+				return { kind: "historyRebuild" };
+			}
 			this.#markNativeScrollbackDirty();
 			return { kind: "deferredShrink", paddedLength: this.#previousLines.length };
 		}

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -1531,6 +1531,56 @@ describe("TUI terminal-state regressions", () => {
 				tui.stop();
 			}
 		});
+		it("defers bottom-anchored shrink when POSIX viewport state is unknown", async () => {
+			// Repro for #1566 follow-up (kitty/Linux): a bottom-anchored shrink across the
+			// viewport boundary used to fall through to `viewportRepaint`, which redrew the
+			// new transcript at `newLength - height` while leaving rows
+			// `[newLength - height .. prevLength - height - 1]` already in native
+			// scrollback — they reappeared at the top of the viewport, duplicating two rows
+			// at the boundary in the captured trace.
+			const term = new UnknownViewportTerminal(40, 6);
+			const tui = new TUI(term);
+			const body = rows("line-", 12);
+			const component = new MutableLinesComponent([...body, "spinner-row", "spacer-row", "prompt-row"]);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+
+				component.setLines([...body, "prompt-row"]);
+				tui.requestRender();
+				await settle(term);
+
+				const scrollback = term.getScrollBuffer();
+				for (let i = 0; i < body.length; i++) {
+					const pattern = new RegExp(`\\bline-${i}\\b`);
+					expect(
+						countMatches(scrollback, pattern),
+						`line-${i} must not duplicate at boundary`,
+					).toBeLessThanOrEqual(1);
+				}
+
+				expect(tui.refreshNativeScrollbackIfDirty({ allowUnknownViewport: true })).toBe(true);
+				await settle(term);
+				expect(visible(term).map(line => line.trim())).toEqual([
+					"line-7",
+					"line-8",
+					"line-9",
+					"line-10",
+					"line-11",
+					"prompt-row",
+				]);
+				const rebuilt = term.getScrollBuffer();
+				for (let i = 0; i < body.length; i++) {
+					const pattern = new RegExp(`\\bline-${i}\\b`);
+					expect(countMatches(rebuilt, pattern), `line-${i} appears once post-checkpoint`).toBe(1);
+				}
+			} finally {
+				tui.stop();
+			}
+		});
+
 		it("renders streaming row inserts on WSL Windows Terminal even when viewport probe is unavailable", async () => {
 			const originalPlatform = process.platform;
 			Object.defineProperty(process, "platform", { configurable: true, value: "linux" });

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -1625,6 +1625,61 @@ describe("TUI terminal-state regressions", () => {
 				tui.stop();
 			}
 		});
+		it("rebuilds history when prior POSIX repaint left the padded viewport past the new tail", async () => {
+			const term = new UnknownViewportTerminal(40, 10);
+			const tui = new TUI(term);
+			const initial = rows("line-", 19);
+			const component = new MutableLinesComponent([...initial, "prompt-row"]);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+
+				// Unknown-POSIX offscreen mutation: repainting the viewport commits the
+				// 120-row logical frame, but `#emitViewportRepaint` intentionally does not
+				// advance `#scrollbackHighWater` (it remains at the original 20-row frame's
+				// 10-row overflow). The later shrink must compare against the padded viewport
+				// top (`120 - height`) rather than the stale high-water mark.
+				const expanded = ["edited-line", ...rows("line-", 118), "prompt-row"];
+				component.setLines(expanded);
+				tui.requestRender();
+				await settle(term);
+				expect(visible(term).map(line => line.trim())).toEqual([
+					"line-109",
+					"line-110",
+					"line-111",
+					"line-112",
+					"line-113",
+					"line-114",
+					"line-115",
+					"line-116",
+					"line-117",
+					"prompt-row",
+				]);
+
+				const short = [...rows("short-", 14), "prompt-row"];
+				component.setLines(short);
+				tui.requestRender();
+				await settle(term);
+
+				expect(visible(term).map(line => line.trim())).toEqual([
+					"short-5",
+					"short-6",
+					"short-7",
+					"short-8",
+					"short-9",
+					"short-10",
+					"short-11",
+					"short-12",
+					"short-13",
+					"prompt-row",
+				]);
+				expect(term.getScrollBuffer().join("\n")).not.toContain("line-");
+			} finally {
+				tui.stop();
+			}
+		});
 
 		it("renders streaming row inserts on WSL Windows Terminal even when viewport probe is unavailable", async () => {
 			const originalPlatform = process.platform;

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -1580,6 +1580,51 @@ describe("TUI terminal-state regressions", () => {
 				tui.stop();
 			}
 		});
+		it("rebuilds history when a shrink leaves no real rows above the scrollback boundary", async () => {
+			// Reviewer scenario (#1599): a large completion-style collapse (e.g. a 100-row
+			// streamed transcript shrinking to a 20-row final cell in a 10-row viewport)
+			// must NOT use the padded `deferredShrink` — the viewport would fall entirely
+			// past the end of `newLines` and render as all blanks (no prompt visible) until
+			// the next checkpoint. Yank the scrollback instead so the new tail stays on
+			// screen.
+			const term = new UnknownViewportTerminal(40, 10);
+			const tui = new TUI(term);
+			const body = rows("line-", 99);
+			const component = new MutableLinesComponent([...body, "prompt-row"]);
+			tui.addChild(component);
+
+			try {
+				tui.start();
+				await settle(term);
+
+				const short = rows("short-", 19);
+				component.setLines([...short, "prompt-row"]);
+				tui.requestRender();
+				await settle(term);
+
+				const viewport = visible(term).map(line => line.trim());
+				expect(viewport).toEqual([
+					"short-10",
+					"short-11",
+					"short-12",
+					"short-13",
+					"short-14",
+					"short-15",
+					"short-16",
+					"short-17",
+					"short-18",
+					"prompt-row",
+				]);
+				const scrollback = term.getScrollBuffer();
+				for (let i = 0; i < short.length; i++) {
+					const pattern = new RegExp(`\\bshort-${i}\\b`);
+					expect(countMatches(scrollback, pattern), `short-${i} appears once`).toBe(1);
+				}
+				expect(scrollback.join("\n")).not.toContain("line-");
+			} finally {
+				tui.stop();
+			}
+		});
 
 		it("renders streaming row inserts on WSL Windows Terminal even when viewport probe is unavailable", async () => {
 			const originalPlatform = process.platform;


### PR DESCRIPTION
## Repro
On kitty/Linux (POSIX terminals that cannot report scrollback position), a bottom-anchored transcript shrink that crosses the viewport boundary duplicated rows at the scrollback/viewport edge. Distilled to a 6-row terminal: 12 body rows + spinner + spacer + prompt, then drop the two transient rows (`spinner`, `spacer`). Pre-fix scrollback held `[['line-7', 2], ['line-8', 2]]`, exactly matching @bjin's captured trace (`prev=1236, new=1234, height=58`, debug log line 60859) in #1566.

## Cause
`#planRender` (`packages/tui/src/tui.ts`) gates the bottom-anchored shrink branch on `naturalViewportTop < #scrollbackHighWater`. When `nativeViewportIsScrolled(undefined, false)` is `false` AND `canRebuildNativeScrollbackLive(undefined, false)` is also `false` (kitty/plain xterm: viewport position is `undefined` and not Windows), the planner fell through to `viewportRepaint`. That repaints bottom-anchored at `newLength - height`, leaving rows `[newLength - height .. prevLength - height - 1]` already in native scrollback — they reappeared as the first viewport rows.

## Fix
- In the unknown-POSIX fallthrough of the shrink branch, mark scrollback dirty and emit `deferredShrink` with `paddedLength = previousLines.length` instead of `viewportRepaint`. The active frame keeps the previous logical row count (padded with blank trailing rows) so no committed scrollback row is re-emitted; the next checkpoint rebuild (`refreshNativeScrollbackIfDirty`, e.g. prompt submit) bottom-anchors cleanly.
- Regression test: `defers bottom-anchored shrink when POSIX viewport state is unknown` reproduces the boundary duplicate shape and verifies the checkpoint repair.

## Verification
`bun test packages/tui/test/render-regressions.test.ts packages/tui/test/slash-autocomplete-viewport.test.ts` → 59/59 pass. `bun --cwd=packages/tui run check` → clean. `bun run check` still fails on `main` for unrelated `packages/coding-agent/test/model-registry-create.test.ts` references to removed `ConfigFile.warmup`, so the pre-publish gate was skipped. Fixes #1566