### PR TITLE
fix(tool): show formal PR reviews in pr:// views

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `pr://` PR views omitting formal review submissions and approvals when comments are enabled ([#1600](https://github.com/can1357/oh-my-pi/issues/1600)).
+
 ## [15.7.4] - 2026-05-31
 
 ### Removed

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -75,6 +75,7 @@ const GH_PR_FIELDS = [
 	"labels",
 	"mergeStateStatus",
 	"number",
+	"reviews",
 	"reviewDecision",
 	"state",
 	"title",

--- a/packages/coding-agent/test/internal-urls/issue-pr-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/issue-pr-protocol.test.ts
@@ -66,7 +66,16 @@ function issuePayload(number: number, body: string, commentBodies: string[] = []
 	};
 }
 
+interface PrPayloadReview {
+	author: { login: string };
+	body: string;
+	commit: { oid: string };
+	state: string;
+	submittedAt: string;
+}
+
 function prPayload(number: number, body: string) {
+	const reviews: PrPayloadReview[] = [];
 	return {
 		number,
 		title: `PR #${number}`,
@@ -81,9 +90,32 @@ function prPayload(number: number, body: string) {
 		url: `https://github.com/owner/example/pull/${number}`,
 		labels: [],
 		files: [],
-		reviews: [],
+		reviews,
 		comments: [],
 	};
+}
+
+function requestedJsonFields(args: string[]): Set<string> {
+	const jsonIndex = args.indexOf("--json");
+	const fieldsArg = jsonIndex >= 0 ? args[jsonIndex + 1] : undefined;
+	return new Set((fieldsArg ?? "").split(",").filter(Boolean));
+}
+
+function prPayloadWithRequestedFields(args: string[], number: number, body: string) {
+	const payload = prPayload(number, body);
+	const fields = requestedJsonFields(args);
+	if (fields.has("reviews")) {
+		payload.reviews = [
+			{
+				author: { login: "approver" },
+				body: "Approved from the formal review flow.",
+				commit: { oid: "1234567890abcdef1234567890abcdef12345678" },
+				state: "APPROVED",
+				submittedAt: "2026-04-01T12:00:00Z",
+			},
+		];
+	}
+	return payload;
 }
 
 interface DiffFileSpec {
@@ -191,6 +223,22 @@ describe("pr:// protocol handler", () => {
 		expect(second.notes?.[0]).toMatch(/^Cached:/);
 		// Second call is a soft-TTL hit — no further gh invocations.
 		expect(spy).toHaveBeenCalledTimes(2);
+	});
+
+	it("requests and renders formal reviews when comments are enabled", async () => {
+		vi.spyOn(git.github, "json").mockImplementation(async (_cwd, args) => {
+			if (args.includes("/repos/owner/example/pulls/78/comments")) {
+				return [] as never;
+			}
+			return prPayloadWithRequestedFields(args, 78, "pr body") as never;
+		});
+
+		const router = InternalUrlRouter.instance();
+		const resource = await router.resolve("pr://owner/example/78");
+
+		expect(resource.content).toContain("## Reviews (1)");
+		expect(resource.content).toContain("### @approver - 2026-04-01T12:00:00Z [APPROVED]");
+		expect(resource.content).toContain("Approved from the formal review flow.");
 	});
 
 	it("rejects invalid pr:// URLs with a friendly message", async () => {


### PR DESCRIPTION
## Repro
`pr://owner/example/78` with comments enabled rendered PR metadata and body but no `## Reviews` section when the mocked `gh pr view --json ...` response only included fields requested by the tool. Reproduced with `bun test packages/coding-agent/test/internal-urls/issue-pr-protocol.test.ts` before the fix.

## Cause
`packages/coding-agent/src/tools/gh.ts` used `GH_PR_FIELDS` for comments-enabled PR views, but that field list requested `comments` and omitted `reviews`. `formatPrView()` already rendered `data.reviews`, so `pr://` could only show formal reviews in the comments-disabled path where `GH_PR_FIELDS_NO_COMMENTS` included `reviews`.

## Fix
- Added `reviews` to the comments-enabled `GH_PR_FIELDS` list.
- Added a `pr://` protocol regression test that emulates `gh --json` field selection and asserts the rendered approval section.
- Added a coding-agent changelog entry for #1600.

## Verification
`bun test packages/coding-agent/test/internal-urls/issue-pr-protocol.test.ts` passed: 21 tests, 83 expectations. `bun --cwd=packages/coding-agent run check` passed. Fixes #1600