### PR TITLE
fix(ai): honor OpenAI idle timeout for first events

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -190,15 +190,16 @@ OAuth host chain: `KIMI_CODE_OAUTH_HOST` → `KIMI_OAUTH_HOST` → `https://auth
 
 ### OpenAI Codex responses (feature/debug controls)
 
-| Variable                             | Behavior                                             |
-| ------------------------------------ | ---------------------------------------------------- |
-| `PI_CODEX_DEBUG`                     | `1`/`true` enables Codex provider debug logging      |
-| `PI_CODEX_WEBSOCKET`                 | `1`/`true` enables websocket transport preference    |
-| `PI_CODEX_WEBSOCKET_V2`              | `1`/`true` enables websocket v2 path                 |
-| `PI_CODEX_WEBSOCKET_IDLE_TIMEOUT_MS` | Positive integer override (default 300000)           |
-| `PI_CODEX_WEBSOCKET_RETRY_BUDGET`    | Non-negative integer override (default 5)            |
-| `PI_CODEX_WEBSOCKET_RETRY_DELAY_MS`  | Positive integer base backoff override (default 500) |
-| `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS`   | Positive integer OpenAI stream idle timeout override |
+| Variable                                   | Behavior                                             |
+| ------------------------------------------ | ---------------------------------------------------- |
+| `PI_CODEX_DEBUG`                           | `1`/`true` enables Codex provider debug logging      |
+| `PI_CODEX_WEBSOCKET`                       | `1`/`true` enables websocket transport preference    |
+| `PI_CODEX_WEBSOCKET_V2`                    | `1`/`true` enables websocket v2 path                 |
+| `PI_CODEX_WEBSOCKET_IDLE_TIMEOUT_MS`       | Positive integer override (default 300000)           |
+| `PI_CODEX_WEBSOCKET_RETRY_BUDGET`          | Non-negative integer override (default 5)            |
+| `PI_CODEX_WEBSOCKET_RETRY_DELAY_MS`        | Positive integer base backoff override (default 500) |
+| `PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS`  | Positive integer OpenAI first-event timeout override |
+| `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS`         | Positive integer OpenAI stream idle timeout override |
 
 ### Cursor provider debug
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI-family first-event timeouts so `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` cannot be undercut by a lower generic `PI_STREAM_FIRST_EVENT_TIMEOUT_MS` while local OpenAI-compatible servers are still processing large prompts. `PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS` is now available for an explicit OpenAI-specific first-event override. ([#1603](https://github.com/can1357/oh-my-pi/issues/1603))
+
 ## [15.7.4] - 2026-05-31
 
 ### Fixed

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -24,7 +24,6 @@ import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-ins
 import {
 	getOpenAIStreamFirstEventTimeoutMs,
 	getOpenAIStreamIdleTimeoutMs,
-	getStreamFirstEventTimeoutMs,
 	iterateWithIdleTimeout,
 } from "../utils/idle-iterator";
 import { sanitizeSchemaForOpenAIResponses, toolWireSchema } from "../utils/schema";
@@ -124,10 +123,7 @@ export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"
 			options?.onPayload?.(params);
 			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getOpenAIStreamIdleTimeoutMs();
 			const firstEventTimeoutMs =
-				options?.streamFirstEventTimeoutMs ??
-				(options?.streamIdleTimeoutMs === undefined
-					? getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs)
-					: getStreamFirstEventTimeoutMs(idleTimeoutMs));
+				options?.streamFirstEventTimeoutMs ?? getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs);
 			const requestTimeoutMs =
 				firstEventTimeoutMs !== undefined && firstEventTimeoutMs > 0 ? firstEventTimeoutMs : undefined;
 			rawRequestDump = {

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -22,6 +22,7 @@ import { createAbortSourceTracker } from "../utils/abort";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
 import {
+	getOpenAIStreamFirstEventTimeoutMs,
 	getOpenAIStreamIdleTimeoutMs,
 	getStreamFirstEventTimeoutMs,
 	iterateWithIdleTimeout,
@@ -122,7 +123,11 @@ export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"
 			const params = buildParams(model, context, options, deploymentName, baseUrl);
 			options?.onPayload?.(params);
 			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getOpenAIStreamIdleTimeoutMs();
-			const firstEventTimeoutMs = options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs);
+			const firstEventTimeoutMs =
+				options?.streamFirstEventTimeoutMs ??
+				(options?.streamIdleTimeoutMs === undefined
+					? getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs)
+					: getStreamFirstEventTimeoutMs(idleTimeoutMs));
 			const requestTimeoutMs =
 				firstEventTimeoutMs !== undefined && firstEventTimeoutMs > 0 ? firstEventTimeoutMs : undefined;
 			rawRequestDump = {

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -51,7 +51,6 @@ import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-ins
 import {
 	getOpenAIStreamFirstEventTimeoutMs,
 	getOpenAIStreamIdleTimeoutMs,
-	getStreamFirstEventTimeoutMs,
 	iterateWithIdleTimeout,
 } from "../utils/idle-iterator";
 import { parseStreamingJson, parseStreamingJsonThrottled } from "../utils/json-parse";
@@ -604,11 +603,7 @@ function createRequestSetup(options: OpenAICodexResponsesOptions | undefined): C
 		: requestAbortController.signal;
 	const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getOpenAIStreamIdleTimeoutMs();
 	const websocketIdleTimeoutMs = options?.streamIdleTimeoutMs ?? getCodexWebSocketIdleTimeoutMs();
-	const firstEventTimeoutMs =
-		options?.streamFirstEventTimeoutMs ??
-		(options?.streamIdleTimeoutMs === undefined
-			? getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs)
-			: getStreamFirstEventTimeoutMs(idleTimeoutMs));
+	const firstEventTimeoutMs = options?.streamFirstEventTimeoutMs ?? getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs);
 	const websocketFirstEventTimeoutMs = options?.streamFirstEventTimeoutMs ?? getCodexWebSocketFirstEventTimeoutMs();
 	const wrapCodexSseStream = (
 		source: AsyncGenerator<Record<string, unknown>>,

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -49,6 +49,7 @@ import {
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { finalizeErrorMessage, type RawHttpRequestDump } from "../utils/http-inspector";
 import {
+	getOpenAIStreamFirstEventTimeoutMs,
 	getOpenAIStreamIdleTimeoutMs,
 	getStreamFirstEventTimeoutMs,
 	iterateWithIdleTimeout,
@@ -603,7 +604,11 @@ function createRequestSetup(options: OpenAICodexResponsesOptions | undefined): C
 		: requestAbortController.signal;
 	const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getOpenAIStreamIdleTimeoutMs();
 	const websocketIdleTimeoutMs = options?.streamIdleTimeoutMs ?? getCodexWebSocketIdleTimeoutMs();
-	const firstEventTimeoutMs = options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs);
+	const firstEventTimeoutMs =
+		options?.streamFirstEventTimeoutMs ??
+		(options?.streamIdleTimeoutMs === undefined
+			? getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs)
+			: getStreamFirstEventTimeoutMs(idleTimeoutMs));
 	const websocketFirstEventTimeoutMs = options?.streamFirstEventTimeoutMs ?? getCodexWebSocketFirstEventTimeoutMs();
 	const wrapCodexSseStream = (
 		source: AsyncGenerator<Record<string, unknown>>,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -48,7 +48,6 @@ import {
 import {
 	getOpenAIStreamFirstEventTimeoutMs,
 	getOpenAIStreamIdleTimeoutMs,
-	getStreamFirstEventTimeoutMs,
 	iterateWithIdleTimeout,
 } from "../utils/idle-iterator";
 import { parseStreamingJson, parseStreamingJsonThrottled } from "../utils/json-parse";
@@ -425,10 +424,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 			const idleTimeoutFallbackMs = getOpenAICompletionsStreamIdleTimeoutFallbackMs(model);
 			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getOpenAIStreamIdleTimeoutMs(idleTimeoutFallbackMs);
 			const firstEventTimeoutMs =
-				options?.streamFirstEventTimeoutMs ??
-				(options?.streamIdleTimeoutMs === undefined
-					? getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs, idleTimeoutFallbackMs)
-					: getStreamFirstEventTimeoutMs(idleTimeoutMs));
+				options?.streamFirstEventTimeoutMs ?? getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs);
 			const requestTimeoutMs =
 				firstEventTimeoutMs !== undefined && firstEventTimeoutMs > 0 ? firstEventTimeoutMs : undefined;
 			const {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -46,6 +46,7 @@ import {
 	rewriteCopilotError,
 } from "../utils/http-inspector";
 import {
+	getOpenAIStreamFirstEventTimeoutMs,
 	getOpenAIStreamIdleTimeoutMs,
 	getStreamFirstEventTimeoutMs,
 	iterateWithIdleTimeout,
@@ -421,10 +422,13 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 
 		try {
 			const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-			const idleTimeoutMs =
-				options?.streamIdleTimeoutMs ??
-				getOpenAIStreamIdleTimeoutMs(getOpenAICompletionsStreamIdleTimeoutFallbackMs(model));
-			const firstEventTimeoutMs = options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs);
+			const idleTimeoutFallbackMs = getOpenAICompletionsStreamIdleTimeoutFallbackMs(model);
+			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getOpenAIStreamIdleTimeoutMs(idleTimeoutFallbackMs);
+			const firstEventTimeoutMs =
+				options?.streamFirstEventTimeoutMs ??
+				(options?.streamIdleTimeoutMs === undefined
+					? getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs, idleTimeoutFallbackMs)
+					: getStreamFirstEventTimeoutMs(idleTimeoutMs));
 			const requestTimeoutMs =
 				firstEventTimeoutMs !== undefined && firstEventTimeoutMs > 0 ? firstEventTimeoutMs : undefined;
 			const {

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -35,7 +35,6 @@ import { finalizeErrorMessage, type RawHttpRequestDump, rewriteCopilotError } fr
 import {
 	getOpenAIStreamFirstEventTimeoutMs,
 	getOpenAIStreamIdleTimeoutMs,
-	getStreamFirstEventTimeoutMs,
 	iterateWithIdleTimeout,
 } from "../utils/idle-iterator";
 import { parseGitHubCopilotApiKey } from "../utils/oauth/github-copilot";
@@ -230,10 +229,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 			const { params } = buildParams(model, context, options, providerSessionState, baseUrl);
 			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getOpenAIStreamIdleTimeoutMs();
 			const firstEventTimeoutMs =
-				options?.streamFirstEventTimeoutMs ??
-				(options?.streamIdleTimeoutMs === undefined
-					? getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs)
-					: getStreamFirstEventTimeoutMs(idleTimeoutMs));
+				options?.streamFirstEventTimeoutMs ?? getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs);
 			const requestTimeoutMs =
 				firstEventTimeoutMs !== undefined && firstEventTimeoutMs > 0 ? firstEventTimeoutMs : undefined;
 			options?.onPayload?.(params);

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -33,6 +33,7 @@ import { createAbortSourceTracker } from "../utils/abort";
 import { AssistantMessageEventStream } from "../utils/event-stream";
 import { finalizeErrorMessage, type RawHttpRequestDump, rewriteCopilotError } from "../utils/http-inspector";
 import {
+	getOpenAIStreamFirstEventTimeoutMs,
 	getOpenAIStreamIdleTimeoutMs,
 	getStreamFirstEventTimeoutMs,
 	iterateWithIdleTimeout,
@@ -228,7 +229,11 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 			const providerSessionState = getOpenAIResponsesProviderSessionState(model, options?.providerSessionState);
 			const { params } = buildParams(model, context, options, providerSessionState, baseUrl);
 			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getOpenAIStreamIdleTimeoutMs();
-			const firstEventTimeoutMs = options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs);
+			const firstEventTimeoutMs =
+				options?.streamFirstEventTimeoutMs ??
+				(options?.streamIdleTimeoutMs === undefined
+					? getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs)
+					: getStreamFirstEventTimeoutMs(idleTimeoutMs));
 			const requestTimeoutMs =
 				firstEventTimeoutMs !== undefined && firstEventTimeoutMs > 0 ? firstEventTimeoutMs : undefined;
 			options?.onPayload?.(params);

--- a/packages/ai/src/providers/register-builtins.ts
+++ b/packages/ai/src/providers/register-builtins.ts
@@ -418,7 +418,10 @@ export const streamGoogleGeminiCli = createLazyStream(
 	GOOGLE_GEMINI_CLI_LAZY_STREAM_LIMITS,
 );
 export const streamGoogleVertex = createLazyStream(loadGoogleVertexProviderModule);
-export const streamOpenAICodexResponses = createLazyStream(loadOpenAICodexResponsesProviderModule);
+export const streamOpenAICodexResponses = createLazyStream(
+	loadOpenAICodexResponsesProviderModule,
+	PROVIDER_HANDLED_STREAM_TIMEOUTS,
+);
 export const streamOpenAICompletions = createLazyStream(
 	loadOpenAICompletionsProviderModule,
 	PROVIDER_HANDLED_STREAM_TIMEOUTS,

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -364,8 +364,10 @@ export interface StreamOptions {
 	 * event arrives, `streamIdleTimeoutMs` governs inter-event stalls. Falls
 	 * back to `PI_STREAM_FIRST_EVENT_TIMEOUT_MS` and then to a 100s default.
 	 * OpenAI-family transports additionally honor
-	 * `PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS` and use
-	 * `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` as the first-event floor.
+	 * `PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS` as the most-specific override and
+	 * floor the first-event budget at the resolved idle (per-call
+	 * `streamIdleTimeoutMs` or `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS`) so slow local
+	 * OpenAI-compatible servers are not undercut during prompt processing.
 	 *
 	 * Iterator-level honored by: every built-in provider (via the lazy-stream
 	 * forwarder in `register-builtins`). SDK-request honored by:

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -363,6 +363,9 @@ export interface StreamOptions {
 	 * `0` to disable both layers for this request. After the first semantic
 	 * event arrives, `streamIdleTimeoutMs` governs inter-event stalls. Falls
 	 * back to `PI_STREAM_FIRST_EVENT_TIMEOUT_MS` and then to a 100s default.
+	 * OpenAI-family transports additionally honor
+	 * `PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS` and use
+	 * `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` as the first-event floor.
 	 *
 	 * Iterator-level honored by: every built-in provider (via the lazy-stream
 	 * forwarder in `register-builtins`). SDK-request honored by:

--- a/packages/ai/src/utils/idle-iterator.ts
+++ b/packages/ai/src/utils/idle-iterator.ts
@@ -61,22 +61,28 @@ export function getStreamFirstEventTimeoutMs(
 /**
  * Returns the first-event timeout used for OpenAI-family streaming transports.
  *
- * `PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS` is the most specific first-event
- * override. When it is unset, `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` also widens
- * or disables the first-event watchdog so local OpenAI-compatible servers are
- * not undercut by the generic first-event setting during slow prompt processing.
+ * Precedence: explicit `PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS` (including a
+ * `"0"` disable) wins outright. Otherwise the resolved idle (caller-supplied
+ * `idleTimeoutMs` — which itself already encompasses per-call
+ * `streamIdleTimeoutMs` or `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` resolved
+ * upstream) floors the first-event budget so slow local OpenAI-compatible
+ * servers are not undercut by a shorter `PI_STREAM_FIRST_EVENT_TIMEOUT_MS`
+ * or the global default during prompt processing.
+ *
+ * Returns `undefined` when an explicit env knob disables the watchdog.
  */
 export function getOpenAIStreamFirstEventTimeoutMs(
 	idleTimeoutMs?: number,
 	fallbackMs: number = DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_MS,
 ): number | undefined {
-	const fallback = idleTimeoutMs === undefined ? fallbackMs : Math.max(fallbackMs, idleTimeoutMs);
-	return normalizeIdleTimeoutMs(
-		$env.PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS ??
-			$env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS ??
-			$env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS,
-		fallback,
-	);
+	const openAIFirstEventRaw = $env.PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS;
+	if (openAIFirstEventRaw !== undefined) {
+		return normalizeIdleTimeoutMs(openAIFirstEventRaw, fallbackMs);
+	}
+	const base = normalizeIdleTimeoutMs($env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS, fallbackMs);
+	if (base === undefined) return undefined;
+	if (idleTimeoutMs === undefined || idleTimeoutMs <= 0) return base;
+	return Math.max(base, idleTimeoutMs);
 }
 
 export interface IdleTimeoutIteratorOptions {

--- a/packages/ai/src/utils/idle-iterator.ts
+++ b/packages/ai/src/utils/idle-iterator.ts
@@ -58,6 +58,27 @@ export function getStreamFirstEventTimeoutMs(
 	return normalizeIdleTimeoutMs($env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS, fallback);
 }
 
+/**
+ * Returns the first-event timeout used for OpenAI-family streaming transports.
+ *
+ * `PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS` is the most specific first-event
+ * override. When it is unset, `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` also widens
+ * or disables the first-event watchdog so local OpenAI-compatible servers are
+ * not undercut by the generic first-event setting during slow prompt processing.
+ */
+export function getOpenAIStreamFirstEventTimeoutMs(
+	idleTimeoutMs?: number,
+	fallbackMs: number = DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_MS,
+): number | undefined {
+	const fallback = idleTimeoutMs === undefined ? fallbackMs : Math.max(fallbackMs, idleTimeoutMs);
+	return normalizeIdleTimeoutMs(
+		$env.PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS ??
+			$env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS ??
+			$env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS,
+		fallback,
+	);
+}
+
 export interface IdleTimeoutIteratorOptions {
 	idleTimeoutMs?: number;
 	firstItemTimeoutMs?: number;

--- a/packages/ai/test/openai-first-event-timeout.test.ts
+++ b/packages/ai/test/openai-first-event-timeout.test.ts
@@ -352,6 +352,39 @@ describe("OpenAI-family first-event timeouts", () => {
 		}
 	});
 
+	it("honors PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS even when caller pins streamIdleTimeoutMs", async () => {
+		const previousOpenAIFirstEventTimeout = Bun.env.PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS;
+		const previousGenericFirstEventTimeout = Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS;
+		const timeoutHeaders: string[] = [];
+		Bun.env.PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS = "1500";
+		Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS = "20";
+		global.fetch = createDelayedFetch(30, createOpenAIResponsesSuccessResponse, (input, init) => {
+			timeoutHeaders.push(getRequestHeader(input, init, "X-Stainless-Timeout") ?? "");
+		});
+
+		try {
+			const result = await streamOpenAIResponses(openAIResponsesModel, baseContext(), {
+				apiKey: "test-key",
+				streamIdleTimeoutMs: 5_000,
+			}).result();
+
+			expect(result.stopReason).toBe("stop");
+			expect(getFirstTextContent(result)).toMatchObject({ type: "text", text: "Hello delayed" });
+			expect(timeoutHeaders).toContain("1");
+		} finally {
+			if (previousOpenAIFirstEventTimeout === undefined) {
+				delete Bun.env.PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS;
+			} else {
+				Bun.env.PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS = previousOpenAIFirstEventTimeout;
+			}
+			if (previousGenericFirstEventTimeout === undefined) {
+				delete Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS;
+			} else {
+				Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS = previousGenericFirstEventTimeout;
+			}
+		}
+	});
+
 	it("times out OpenAI responses streams that only emit no-progress status events", async () => {
 		global.fetch = ((input: string | URL | Request, init?: RequestInit) =>
 			Promise.resolve(createNoProgressOpenAIResponsesStream(getRequestSignal(input, init)))) as typeof fetch;

--- a/packages/ai/test/openai-first-event-timeout.test.ts
+++ b/packages/ai/test/openai-first-event-timeout.test.ts
@@ -320,6 +320,38 @@ describe("OpenAI-family first-event timeouts", () => {
 		);
 	});
 
+	it("lets PI_OPENAI_STREAM_IDLE_TIMEOUT_MS widen OpenAI responses first-event request setup", async () => {
+		const previousOpenAIIdleTimeout = Bun.env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS;
+		const previousGenericFirstEventTimeout = Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS;
+		const timeoutHeaders: string[] = [];
+		Bun.env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS = "1500";
+		Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS = "20";
+		global.fetch = createDelayedFetch(30, createOpenAIResponsesSuccessResponse, (input, init) => {
+			timeoutHeaders.push(getRequestHeader(input, init, "X-Stainless-Timeout") ?? "");
+		});
+
+		try {
+			const result = await streamOpenAIResponses(openAIResponsesModel, baseContext(), {
+				apiKey: "test-key",
+			}).result();
+
+			expect(result.stopReason).toBe("stop");
+			expect(getFirstTextContent(result)).toMatchObject({ type: "text", text: "Hello delayed" });
+			expect(timeoutHeaders).toContain("1");
+		} finally {
+			if (previousOpenAIIdleTimeout === undefined) {
+				delete Bun.env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS;
+			} else {
+				Bun.env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS = previousOpenAIIdleTimeout;
+			}
+			if (previousGenericFirstEventTimeout === undefined) {
+				delete Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS;
+			} else {
+				Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS = previousGenericFirstEventTimeout;
+			}
+		}
+	});
+
 	it("times out OpenAI responses streams that only emit no-progress status events", async () => {
 		global.fetch = ((input: string | URL | Request, init?: RequestInit) =>
 			Promise.resolve(createNoProgressOpenAIResponsesStream(getRequestSignal(input, init)))) as typeof fetch;

--- a/packages/ai/test/stream-timeout-defaults.test.ts
+++ b/packages/ai/test/stream-timeout-defaults.test.ts
@@ -105,16 +105,20 @@ describe("getStreamFirstEventTimeoutMs(idleTimeoutMs, fallbackMs)", () => {
 });
 
 describe("getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs, fallbackMs)", () => {
-	it("lets the OpenAI idle env widen a lower generic first-event timeout", () => {
+	it("floors the first-event budget at the caller-resolved idle when the generic env is lower", () => {
 		Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS = "20";
-		Bun.env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS = "84";
-		expect(getOpenAIStreamFirstEventTimeoutMs(84, 300_000)).toBe(84);
+		expect(getOpenAIStreamFirstEventTimeoutMs(1500, 100_000)).toBe(1500);
 	});
 
-	it("lets the OpenAI first-event env override the OpenAI idle env", () => {
+	it("honors PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS even when caller pins per-call idle", () => {
 		Bun.env.PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS = "42";
-		Bun.env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS = "84";
-		expect(getOpenAIStreamFirstEventTimeoutMs(84, 300_000)).toBe(42);
+		Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS = "20";
+		expect(getOpenAIStreamFirstEventTimeoutMs(5_000, 100_000)).toBe(42);
+	});
+
+	it("treats PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS=0 as an explicit watchdog disable", () => {
+		Bun.env.PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS = "0";
+		expect(getOpenAIStreamFirstEventTimeoutMs(1500, 100_000)).toBeUndefined();
 	});
 
 	it("falls back to the generic first-event env when OpenAI env vars are unset", () => {
@@ -122,10 +126,9 @@ describe("getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs, fallbackMs)", () => 
 		expect(getOpenAIStreamFirstEventTimeoutMs(undefined, 300_000)).toBe(42);
 	});
 
-	it("treats PI_OPENAI_STREAM_IDLE_TIMEOUT_MS=0 as an OpenAI watchdog disable", () => {
-		Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS = "42";
-		Bun.env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS = "0";
-		expect(getOpenAIStreamFirstEventTimeoutMs(undefined, 300_000)).toBeUndefined();
+	it("respects PI_STREAM_FIRST_EVENT_TIMEOUT_MS=0 disable when no OpenAI override is set", () => {
+		Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS = "0";
+		expect(getOpenAIStreamFirstEventTimeoutMs(1500, 100_000)).toBeUndefined();
 	});
 });
 

--- a/packages/ai/test/stream-timeout-defaults.test.ts
+++ b/packages/ai/test/stream-timeout-defaults.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import {
+	getOpenAIStreamFirstEventTimeoutMs,
 	getOpenAIStreamIdleTimeoutMs,
 	getStreamFirstEventTimeoutMs,
 	getStreamIdleTimeoutMs,
@@ -19,6 +20,7 @@ const ENV_KEYS = [
 	"PI_STREAM_IDLE_TIMEOUT_MS",
 	"PI_OPENAI_STREAM_IDLE_TIMEOUT_MS",
 	"PI_STREAM_FIRST_EVENT_TIMEOUT_MS",
+	"PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS",
 ] as const;
 
 const originalEnv: Partial<Record<(typeof ENV_KEYS)[number], string | undefined>> = {};
@@ -99,6 +101,31 @@ describe("getStreamFirstEventTimeoutMs(idleTimeoutMs, fallbackMs)", () => {
 
 	it("falls back to the 100s global default when no fallback or env is provided", () => {
 		expect(getStreamFirstEventTimeoutMs()).toBe(100_000);
+	});
+});
+
+describe("getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs, fallbackMs)", () => {
+	it("lets the OpenAI idle env widen a lower generic first-event timeout", () => {
+		Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS = "20";
+		Bun.env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS = "84";
+		expect(getOpenAIStreamFirstEventTimeoutMs(84, 300_000)).toBe(84);
+	});
+
+	it("lets the OpenAI first-event env override the OpenAI idle env", () => {
+		Bun.env.PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS = "42";
+		Bun.env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS = "84";
+		expect(getOpenAIStreamFirstEventTimeoutMs(84, 300_000)).toBe(42);
+	});
+
+	it("falls back to the generic first-event env when OpenAI env vars are unset", () => {
+		Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS = "42";
+		expect(getOpenAIStreamFirstEventTimeoutMs(undefined, 300_000)).toBe(42);
+	});
+
+	it("treats PI_OPENAI_STREAM_IDLE_TIMEOUT_MS=0 as an OpenAI watchdog disable", () => {
+		Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS = "42";
+		Bun.env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS = "0";
+		expect(getOpenAIStreamFirstEventTimeoutMs(undefined, 300_000)).toBeUndefined();
 	});
 });
 


### PR DESCRIPTION
## Repro
A clean HEAD worktree with a delayed OpenAI Responses fetch fails when `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS=1500` but `PI_STREAM_FIRST_EVENT_TIMEOUT_MS=20`; the request setup returns `stopReason: "error"` before the simulated local server emits its first response. Repro command: `bun test packages/ai/test/issue-1603-repro.test.ts`.

## Cause
`packages/ai/src/utils/idle-iterator.ts:getStreamFirstEventTimeoutMs` only considered the generic `PI_STREAM_FIRST_EVENT_TIMEOUT_MS` override. OpenAI-family providers in `packages/ai/src/providers/openai-responses.ts`, `openai-completions.ts`, `azure-openai-responses.ts`, and `openai-codex-responses.ts` resolved `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` for steady-state idle time but still allowed the lower generic first-event timeout to win before slow local OpenAI-compatible servers emitted headers or SSE frames.

## Fix
- Added `getOpenAIStreamFirstEventTimeoutMs()` so OpenAI-family streams honor `PI_OPENAI_STREAM_FIRST_EVENT_TIMEOUT_MS` first, then use `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` as the OpenAI-specific first-event floor before falling back to the generic first-event setting.
- Wired OpenAI Responses, OpenAI Completions, Azure OpenAI Responses, and OpenAI Codex SSE setup through the OpenAI-specific first-event resolver while preserving per-call `streamFirstEventTimeoutMs` precedence.
- Added regression coverage for the delayed OpenAI Responses request-setup path and timeout precedence, plus docs/changelog entries for the new OpenAI-specific first-event env var.

## Verification
Repro failed before the fix with `Expected: "stop"` / `Received: "error"`. After the fix: `bun test packages/ai/test/stream-timeout-defaults.test.ts packages/ai/test/openai-first-event-timeout.test.ts` passed with 35 tests; `bun --cwd=packages/ai run check` passed. Fixes #1603