### PR TITLE
coding-agent: speed up `omp --help` and per-subcommand help cold start

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+
+- Sped up `omp --help` and every `omp <subcommand> --help` invocation. `--help` median wall time drops from ~1820 ms to ~1343 ms (-26%) on this host; per-subcommand help drops from ~1815 ms to ~533 ms (-71%). The root-help renderer no longer imports every command module just to read its description — descriptions are now lifted to the registry in `cli-commands.ts` and consumed statically. The `launch` command additionally defers its heavy runtime imports (`runRootCommand`, `parseArgs`, ACP terminal auth) into the `run()` body, and reads `THINKING_EFFORTS` from `@oh-my-pi/pi-ai/model-thinking` instead of the package barrel (the barrel re-exports models.json + every provider for the sake of one 5-string constant).
 
 ## [15.7.4] - 2026-05-31
 

--- a/packages/coding-agent/src/cli-commands.ts
+++ b/packages/coding-agent/src/cli-commands.ts
@@ -7,32 +7,134 @@
  * `runCli` route to it instead of forwarding the argv as a prompt to
  * `launch` — see #1496 for the original "args silently leak to the LLM"
  * regression that motivated the split.
+ *
+ * Each entry carries a static `description` so the root-help renderer can
+ * build its command table without importing every command module. The
+ * descriptions MUST match the `static description = ...` on the
+ * corresponding class in `commands/<name>.ts` (no runtime cross-check —
+ * keep them in sync). Without these, every `omp --help` invocation pays
+ * the full transitive import cost of all 19 commands (~1.5 s on this
+ * host, see autoresearch session "coding-agent-startup-latency").
  */
 import type { CommandEntry } from "@oh-my-pi/pi-utils/cli";
 
 export const commands: CommandEntry[] = [
-	{ name: "launch", load: () => import("./commands/launch").then(m => m.default) },
-	{ name: "acp", load: () => import("./commands/acp").then(m => m.default) },
-	{ name: "auth-broker", load: () => import("./commands/auth-broker").then(m => m.default) },
-	{ name: "auth-gateway", load: () => import("./commands/auth-gateway").then(m => m.default) },
-	{ name: "agents", load: () => import("./commands/agents").then(m => m.default) },
-	{ name: "commit", load: () => import("./commands/commit").then(m => m.default) },
-	{ name: "completions", load: () => import("./commands/completions").then(m => m.default) },
+	{
+		name: "launch",
+		default: true,
+		description: "AI coding assistant",
+		load: () => import("./commands/launch").then(m => m.default),
+	},
+	{
+		name: "acp",
+		description: "Run Oh My Pi as an ACP (Agent Client Protocol) server over stdio",
+		load: () => import("./commands/acp").then(m => m.default),
+	},
+	{
+		name: "auth-broker",
+		description: "Manage the omp auth-broker (credential vault)",
+		load: () => import("./commands/auth-broker").then(m => m.default),
+	},
+	{
+		name: "auth-gateway",
+		description: "Run an auth-gateway forward proxy backed by the configured broker",
+		load: () => import("./commands/auth-gateway").then(m => m.default),
+	},
+	{
+		name: "agents",
+		description: "Manage bundled task agents",
+		load: () => import("./commands/agents").then(m => m.default),
+	},
+	{
+		name: "commit",
+		description: "Generate a commit message and update changelogs",
+		load: () => import("./commands/commit").then(m => m.default),
+	},
+	{
+		name: "completions",
+		description: "Print a shell completion script (bash, zsh, or fish)",
+		load: () => import("./commands/completions").then(m => m.default),
+	},
+	// `__complete` is intentionally NOT given a static `description`: its class
+	// declares `static hidden = true` (it's an internal shell-completion helper)
+	// and we need the renderer to read that off the loaded class so the entry is
+	// excluded from the visible command list. The module is deliberately thin
+	// (see commands/complete.ts docstring) so paying its load on `--help` is
+	// cheap. If `complete.ts` ever grows, mark the entry `hidden: true` and add
+	// a CommandEntry-level hidden flag instead.
 	{ name: "__complete", load: () => import("./commands/complete").then(m => m.default) },
-	{ name: "config", load: () => import("./commands/config").then(m => m.default) },
-	{ name: "grep", load: () => import("./commands/grep").then(m => m.default) },
-	{ name: "grievances", load: () => import("./commands/grievances").then(m => m.default) },
-	{ name: "install", load: () => import("./commands/install").then(m => m.default) },
-	{ name: "plugin", load: () => import("./commands/plugin").then(m => m.default) },
-	{ name: "setup", load: () => import("./commands/setup").then(m => m.default) },
-	{ name: "shell", load: () => import("./commands/shell").then(m => m.default) },
-	{ name: "read", load: () => import("./commands/read").then(m => m.default) },
-	{ name: "ssh", load: () => import("./commands/ssh").then(m => m.default) },
-	{ name: "stats", load: () => import("./commands/stats").then(m => m.default) },
-	{ name: "update", load: () => import("./commands/update").then(m => m.default) },
-	{ name: "tiny-models", load: () => import("./commands/tiny-models").then(m => m.default) },
-	{ name: "worktree", load: () => import("./commands/worktree").then(m => m.default), aliases: ["wt"] },
-	{ name: "search", load: () => import("./commands/web-search").then(m => m.default), aliases: ["q"] },
+	{
+		name: "config",
+		description: "Manage configuration settings",
+		load: () => import("./commands/config").then(m => m.default),
+	},
+	{
+		name: "grep",
+		description: "Test grep tool",
+		load: () => import("./commands/grep").then(m => m.default),
+	},
+	{
+		name: "grievances",
+		description: "View, clean, or push reported tool issues (auto-QA grievances)",
+		load: () => import("./commands/grievances").then(m => m.default),
+	},
+	{
+		name: "install",
+		description: "Install or link an extension package (alias of `plugin install`/`plugin link`)",
+		load: () => import("./commands/install").then(m => m.default),
+	},
+	{
+		name: "plugin",
+		description: "Manage plugins (install, uninstall, list, etc.)",
+		load: () => import("./commands/plugin").then(m => m.default),
+	},
+	{
+		name: "setup",
+		description: "Run onboarding setup or install dependencies for optional features",
+		load: () => import("./commands/setup").then(m => m.default),
+	},
+	{
+		name: "shell",
+		description: "Interactive shell console",
+		load: () => import("./commands/shell").then(m => m.default),
+	},
+	{
+		name: "read",
+		description: "Show what the read tool will return for a path or URL",
+		load: () => import("./commands/read").then(m => m.default),
+	},
+	{
+		name: "ssh",
+		description: "Manage SSH host configurations",
+		load: () => import("./commands/ssh").then(m => m.default),
+	},
+	{
+		name: "stats",
+		description: "View usage statistics",
+		load: () => import("./commands/stats").then(m => m.default),
+	},
+	{
+		name: "update",
+		description: "Check for and install updates",
+		load: () => import("./commands/update").then(m => m.default),
+	},
+	{
+		name: "tiny-models",
+		description: "Download tiny local models (session titles + memory)",
+		load: () => import("./commands/tiny-models").then(m => m.default),
+	},
+	{
+		name: "worktree",
+		description: "List or clear agent-managed git worktrees (~/.omp/wt)",
+		aliases: ["wt"],
+		load: () => import("./commands/worktree").then(m => m.default),
+	},
+	{
+		name: "search",
+		description: "Test web search providers",
+		aliases: ["q"],
+		load: () => import("./commands/web-search").then(m => m.default),
+	},
 ];
 
 /**

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -2,12 +2,22 @@
  * Root command for the coding agent CLI.
  */
 
-import { THINKING_EFFORTS } from "@oh-my-pi/pi-ai";
+// Import THINKING_EFFORTS from the dedicated subpath instead of the package
+// barrel. The barrel re-exports the entire pi-ai surface (model registry,
+// providers, models.json — ~540 ms cold) for the sake of one 5-string
+// constant the help renderer needs at class-declaration time. The subpath
+// resolves the same value in ~7 ms.
+import { THINKING_EFFORTS } from "@oh-my-pi/pi-ai/model-thinking";
 import { APP_NAME } from "@oh-my-pi/pi-utils";
 import { Args, Command, Flags } from "@oh-my-pi/pi-utils/cli";
-import { parseArgs } from "../cli/args";
-import { runRootCommand } from "../main";
-import { prepareAcpTerminalAuthArgs } from "../modes/acp/terminal-auth";
+
+// Heavy imports — `parseArgs`, `runRootCommand`, and `prepareAcpTerminalAuthArgs`
+// transitively pull in the entire agent runtime (sdk, mcp, lsp, session-manager,
+// model registry, tool tree). Loading that graph eagerly costs ~1.5 s on cold
+// disk. The help renderer reads this module to display the default command's
+// inline body but never instantiates the class, so the heavy graph is paid for
+// no user-observable work on every `omp --help` / `omp <subcommand> --help`.
+// Deferred into `run()` they are only paid when the agent actually launches.
 
 export default class Index extends Command {
 	static description = "AI coding assistant";
@@ -152,6 +162,11 @@ export default class Index extends Command {
 	static strict = false;
 
 	async run(): Promise<void> {
+		const [{ parseArgs }, { runRootCommand }, { prepareAcpTerminalAuthArgs }] = await Promise.all([
+			import("../cli/args"),
+			import("../main"),
+			import("../modes/acp/terminal-auth"),
+		]);
 		const { args } = prepareAcpTerminalAuthArgs(this.argv);
 		const parsed = parseArgs(args);
 		await runRootCommand(parsed, args);

--- a/packages/coding-agent/test/cli-commands.test.ts
+++ b/packages/coding-agent/test/cli-commands.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Contract tests for the CLI command registry.
+ *
+ * Static command metadata (`description`, `default`) in `cli-commands.ts`
+ * exists to let the root-help renderer build its command list WITHOUT
+ * importing every command module — the dominant savings on `omp --help`
+ * cold start (~1.5 s on this host). The trade-off is duplication: each
+ * registry entry's `description` must match the class's
+ * `static description`, with no runtime cross-check.
+ *
+ * These tests load every module once at test time (the work we're
+ * intentionally avoiding at runtime) and assert the contract. They are
+ * the safety net against silent drift when someone updates a class
+ * description without touching the registry, or vice versa.
+ */
+import { describe, expect, it } from "bun:test";
+import { commands } from "../src/cli-commands";
+
+describe("cli-commands registry contract", () => {
+	it("every entry that declares a static `description` matches its class's `static description`", async () => {
+		const mismatches: string[] = [];
+		for (const entry of commands) {
+			if (entry.description === undefined) continue;
+			const Cmd = await entry.load();
+			const classDescription = Cmd.description;
+			if (classDescription !== entry.description) {
+				mismatches.push(
+					`  ${entry.name}: registry="${entry.description}" class="${classDescription ?? "<undefined>"}"`,
+				);
+			}
+		}
+		// Single combined message so all drifted entries surface in one run
+		// instead of a stop-on-first failure.
+		expect(mismatches.join("\n")).toBe("");
+	});
+
+	it("exactly one entry is marked `default: true` and its class is hidden", async () => {
+		const defaults = commands.filter(e => e.default === true);
+		expect(defaults).toHaveLength(1);
+		const Cmd = await defaults[0].load();
+		// The root-help renderer uses `find(C => C.hidden)` to locate the
+		// default command for inline body rendering; `default: true` and
+		// `static hidden = true` must agree or the renderer falls back to
+		// loading every module (loses the cold-start win).
+		expect(Cmd.hidden).toBe(true);
+	});
+
+	it("every non-default entry either carries a static description OR loads to a hidden class", async () => {
+		// Cold-start invariant: a non-default entry without a registry
+		// `description` forces the root-help renderer to import the module
+		// just to read `.description`/`.hidden`. The ONLY acceptable
+		// exception is an entry whose class is `static hidden = true` —
+		// e.g. `__complete`, a hidden internal helper not shown in the
+		// command list. For those, the module load IS the mechanism that
+		// tells the renderer "don't list me", and the module must be kept
+		// deliberately thin.
+		const offenders: string[] = [];
+		for (const entry of commands) {
+			if (entry.default === true) continue;
+			if (entry.description !== undefined) continue;
+			const Cmd = await entry.load();
+			if (Cmd.hidden !== true) {
+				offenders.push(`${entry.name} (no description AND class is not hidden)`);
+			}
+		}
+		expect(offenders.join(", ")).toBe("");
+	});
+
+	it("all entry names are unique (registry-level guarantee, not enforced elsewhere)", () => {
+		const seen = new Set<string>();
+		const dupes: string[] = [];
+		for (const e of commands) {
+			if (seen.has(e.name)) dupes.push(e.name);
+			seen.add(e.name);
+		}
+		expect(dupes).toEqual([]);
+	});
+});

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -16,3 +16,10 @@
 ### Added
 
 - Added an XDG-aware tiny-title model cache directory helper for coding-agent local title models.
+### Added
+
+- Added `description` and `default` fields to `CommandEntry` in `@oh-my-pi/pi-utils/cli`. When `description` is set, the root-help renderer skips importing the command module to read it — the dominant cost of `--help` cold start for any consumer that lazily loads commands. Exactly one entry should be marked `default: true`; its module is always imported so the renderer can inline its flags/args/examples.
+
+### Changed
+
+- Restructured `run()`'s per-subcommand help path to load ONLY the targeted subcommand instead of calling `loadAllCommands` and discarding the rest. Combined with the new metadata-only stub path, this turns `<bin> <subcommand> --help` into a one-module-load operation regardless of registry size.

--- a/packages/utils/src/cli.ts
+++ b/packages/utils/src/cli.ts
@@ -342,11 +342,36 @@ function renderCommandBody(lines: string[], Cmd: CommandCtor): void {
 // CLI entry point
 // ---------------------------------------------------------------------------
 
-/** A lazily-loaded command: canonical name, loader, and optional aliases. */
+/**
+ * A lazily-loaded command: canonical name, loader, and optional aliases.
+ *
+ * Provide `description` (and, for the one default command, `default: true`)
+ * to let the root-help renderer build its command list without importing
+ * every command module. Skipping those imports is the dominant savings on
+ * `<bin> --help` cold start — each command's transitive module graph is
+ * otherwise paid in full even though only its name + description appear in
+ * the help table.
+ */
 export interface CommandEntry {
 	name: string;
 	load: () => Promise<CommandCtor>;
 	aliases?: string[];
+	/**
+	 * Static description shown in the root-help command list. When set,
+	 * `loadAllCommands` does NOT import the command module during help
+	 * rendering. Keep this in sync with the command class's
+	 * `static description` — there is no runtime cross-check.
+	 */
+	description?: string;
+	/**
+	 * Marks the implicit default command — the one rendered inline with
+	 * its full flag/args/example body. Its module is always imported
+	 * during help rendering so the body can be displayed. At most one
+	 * entry should set this; the corresponding class should also carry
+	 * `static hidden = true` so it does not also appear in the command
+	 * list section.
+	 */
+	default?: boolean;
 }
 
 export interface RunOptions {
@@ -392,17 +417,20 @@ export async function run(opts: RunOptions): Promise<void> {
 		return;
 	}
 
-	// Per-command help
+	// Per-command help — load ONLY the targeted subcommand. `renderCommandHelp`
+	// reads the class's flags / args / examples, none of which live on the
+	// metadata stubs `loadAllCommands` synthesizes for unloaded entries; calling
+	// it here would also re-import every command in the registry just to throw
+	// the bulk away. One-entry load matches the work the renderer actually
+	// performs.
 	if (commandArgv.includes("--help") || commandArgv.includes("-h")) {
-		const config = await loadAllCommands(opts);
-		// Resolve aliases for help too
 		const entry = findEntry(opts.commands, commandId);
-		const Cmd = entry ? config.commands.get(entry.name) : undefined;
-		if (Cmd) {
-			renderCommandHelp(bin, entry!.name, Cmd);
-		} else {
+		if (!entry) {
 			process.stderr.write(`Unknown command: ${commandId}\n`);
+			return;
 		}
+		const Cmd = await entry.load();
+		renderCommandHelp(bin, entry.name, Cmd);
 		return;
 	}
 
@@ -421,12 +449,36 @@ export async function run(opts: RunOptions): Promise<void> {
 	await instance.run();
 }
 
-/** Resolve all command loaders for help/alias display. */
+/**
+ * Resolve commands for help / alias display.
+ *
+ * For each entry:
+ *  - if it carries a `description` AND is not the default, register a
+ *    metadata-only stub (no module import — saves the entry's transitive
+ *    module-graph load on every `<bin> --help` invocation);
+ *  - otherwise, import the module so its full `CommandCtor` is available
+ *    (the default command's body is rendered inline; entries without a
+ *    static description fall back to reading it off the loaded class).
+ *
+ * The stub satisfies the root-help renderer because it only reads
+ * `.description` and `.hidden` from non-default entries.
+ */
 async function loadAllCommands(opts: RunOptions): Promise<CliConfig> {
 	const commands = new Map<string, CommandCtor>();
-	const loaded = await Promise.all(opts.commands.map(async e => [e.name, await e.load()] as const));
-	for (const [name, Cmd] of loaded) {
-		commands.set(name, Cmd);
-	}
+	await Promise.all(
+		opts.commands.map(async e => {
+			if (e.default || e.description === undefined) {
+				commands.set(e.name, await e.load());
+			} else {
+				// Metadata-only stub. Cast through unknown because we
+				// satisfy only the runtime surface the renderer reads
+				// (`description`, `hidden`) — never `new`'d.
+				commands.set(e.name, {
+					description: e.description,
+					hidden: false,
+				} as unknown as CommandCtor);
+			}
+		}),
+	);
 	return { bin: opts.bin, version: opts.version, commands };
 }

--- a/packages/utils/test/cli.test.ts
+++ b/packages/utils/test/cli.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests the lazy-load contract on the CLI help renderer.
+ *
+ * The renderer reads only `static description` and `static hidden` from every
+ * non-default command. When an entry carries a static `description` in the
+ * registry, `loadAllCommands` MUST NOT call its `load()` — that's the
+ * entire point of the optimization. If a refactor accidentally re-introduces
+ * an unconditional `await e.load()`, every `<bin> --help` invocation will
+ * silently regress to importing the full transitive module graph for every
+ * subcommand.
+ */
+import { describe, expect, it } from "bun:test";
+import { Command, type CommandCtor, type CommandEntry, run } from "../src/cli";
+
+class FakeDefault extends Command {
+	static description = "default desc";
+	static hidden = true;
+	async run(): Promise<void> {}
+}
+
+class FakeLoaded extends Command {
+	static description = "loaded desc";
+	async run(): Promise<void> {}
+}
+
+function entry(name: string, opts: Partial<CommandEntry> & { Ctor?: CommandCtor } = {}): {
+	entry: CommandEntry;
+	loadCount: () => number;
+} {
+	let loaded = 0;
+	const Ctor = opts.Ctor ?? FakeLoaded;
+	return {
+		entry: {
+			name,
+			description: opts.description,
+			default: opts.default,
+			aliases: opts.aliases,
+			load: async () => {
+				loaded++;
+				return Ctor;
+			},
+		},
+		loadCount: () => loaded,
+	};
+}
+
+function captureStdout<T>(fn: () => Promise<T>): Promise<{ result: T; out: string }> {
+	const chunks: string[] = [];
+	const original = process.stdout.write.bind(process.stdout);
+	process.stdout.write = ((data: string | Uint8Array) => {
+		chunks.push(typeof data === "string" ? data : Buffer.from(data).toString("utf8"));
+		return true;
+	}) as typeof process.stdout.write;
+	return fn()
+		.then(result => ({ result, out: chunks.join("") }))
+		.finally(() => {
+			process.stdout.write = original;
+		});
+}
+
+describe("root-help lazy load", () => {
+	it("does NOT call load() for entries that carry a static description", async () => {
+		const def = entry("launch", { default: true, Ctor: FakeDefault });
+		const a = entry("acp", { description: "acp desc" });
+		const b = entry("stats", { description: "stats desc" });
+
+		await captureStdout(() =>
+			run({
+				bin: "omp",
+				version: "0.0.0",
+				argv: ["--help"],
+				commands: [def.entry, a.entry, b.entry],
+			}),
+		);
+
+		// Default is always loaded so its body can be rendered inline.
+		expect(def.loadCount()).toBe(1);
+		// Non-default entries with static description must be metadata-only.
+		expect(a.loadCount()).toBe(0);
+		expect(b.loadCount()).toBe(0);
+	});
+
+	it("falls back to load() for entries WITHOUT a static description (backward compat)", async () => {
+		const def = entry("launch", { default: true, Ctor: FakeDefault });
+		// `acp` has no description on the entry — renderer must load the module
+		// to read `static description` off the class. Preserves behavior for
+		// consumers that haven't migrated their registry yet.
+		const a = entry("acp");
+
+		await captureStdout(() =>
+			run({
+				bin: "omp",
+				version: "0.0.0",
+				argv: ["--help"],
+				commands: [def.entry, a.entry],
+			}),
+		);
+
+		expect(def.loadCount()).toBe(1);
+		expect(a.loadCount()).toBe(1);
+	});
+
+	it("renders the same command list regardless of metadata source", async () => {
+		const def = entry("launch", { default: true, Ctor: FakeDefault });
+		const fromMeta = entry("acp", { description: "loaded desc" }); // matches FakeLoaded.description
+		const { out } = await captureStdout(() =>
+			run({
+				bin: "omp",
+				version: "0.0.0",
+				argv: ["--help"],
+				commands: [def.entry, fromMeta.entry],
+			}),
+		);
+
+		// The command list section must show acp's description regardless of
+		// whether the renderer pulled it from the registry or the class.
+		expect(out).toContain("acp");
+		expect(out).toContain("loaded desc");
+	});
+
+	it("loads the default command's module so the renderer can show its body", async () => {
+		const def = entry("launch", { default: true, Ctor: FakeDefault });
+		const { out } = await captureStdout(() =>
+			run({
+				bin: "omp",
+				version: "0.0.0",
+				argv: ["--help"],
+				commands: [def.entry],
+			}),
+		);
+
+		expect(def.loadCount()).toBe(1);
+		// The default's body is rendered inline (FakeDefault has the
+		// `hidden = true` marker the renderer searches for).
+		expect(out).toContain("omp v0.0.0");
+		expect(out).toContain("USAGE");
+	});
+});
+
+describe("per-subcommand help", () => {
+	it("loads ONLY the targeted subcommand (no traversal of the registry)", async () => {
+		const def = entry("launch", { default: true, Ctor: FakeDefault });
+		const a = entry("acp", { description: "acp desc" });
+		const target = entry("stats", { description: "stats desc" });
+
+		await captureStdout(() =>
+			run({
+				bin: "omp",
+				version: "0.0.0",
+				argv: ["stats", "--help"],
+				commands: [def.entry, a.entry, target.entry],
+			}),
+		);
+
+		// Old behavior called `loadAllCommands` which would have loaded def
+		// alongside the target. The new behavior only loads the target — the
+		// renderer never reads anything off the other entries on this path.
+		expect(def.loadCount()).toBe(0);
+		expect(a.loadCount()).toBe(0);
+		expect(target.loadCount()).toBe(1);
+	});
+
+	it("resolves aliases when picking the target", async () => {
+		const def = entry("launch", { default: true, Ctor: FakeDefault });
+		const target = entry("search", { description: "search desc", aliases: ["q"] });
+
+		await captureStdout(() =>
+			run({
+				bin: "omp",
+				version: "0.0.0",
+				argv: ["q", "--help"],
+				commands: [def.entry, target.entry],
+			}),
+		);
+
+		expect(def.loadCount()).toBe(0);
+		expect(target.loadCount()).toBe(1);
+	});
+});


### PR DESCRIPTION
## Summary

Every interactive `omp` invocation, every subprocess agent, and every scripted use pays the cost of building the help renderer's command table. On this host the median `omp --help` wall time was ~1820 ms; `omp <subcommand> --help` ~1815 ms. Two avoidable hotspots accounted for nearly all of it.

| Path | Before | After | Δ |
|---|---:|---:|---:|
| `omp --help` | 1820 ms | **1343 ms** | **−26 %** |
| `omp stats --help` | 1816 ms | **533 ms** | **−71 %** |
| `omp launch --help` | 1802 ms | **480 ms** | **−73 %** |
| `omp --version` (floor) | 62 ms | 71 ms | noise |

Median of n=10 spawns for `--help`; secondaries n=6. Measurements taken on `main` HEAD (`8b619a2f4`). Win is reproducible across cold/warm disk cache after a 1-spawn warmup.

## Root causes

### 1. The root-help renderer imported every command module

`@oh-my-pi/pi-utils/cli`'s `loadAllCommands` did `Promise.all(commands.map(e => e.load()))` — pulling in the entire transitive graph of all 22 commands just to read each one's `static description` for the help table. A probe measured ~1.5 s attributable purely to those imports on cold disk.

**Fix.** Add `description` (and `default`) to `CommandEntry`. When an entry carries a description, the renderer registers a metadata-only stub instead of importing the module. The stub exposes only the surface `renderRootHelp` reads (`description`, `hidden`) — non-default entries are never instantiated by the renderer so the structural cast is safe.

Lift class `static description` strings into `packages/coding-agent/src/cli-commands.ts` and mark `launch` as the default. The one exception is `__complete` (an internal shell-completion helper marked `static hidden = true`); it's intentionally left without a registry description so the renderer reads the hidden flag off the loaded class and excludes it from the visible list. Its module is deliberately thin so paying its load is cheap.

A new contract test (`packages/coding-agent/test/cli-commands.test.ts`) loads every module once at test time and asserts each registry description matches its class description, so drift surfaces in CI rather than via wrong help output. (It already caught one drift during this PR's rebase — the `setup` command's description had been updated on main while the registry was being assembled.)

### 2. `launch.ts` eagerly imported the entire agent runtime

The default command's body IS rendered inline on `omp --help`, so its module is loaded. But `launch.ts` paid the full agent graph (`runRootCommand`, `parseArgs`, ACP terminal auth) at module-evaluation time — code only `run()` ever touches.

**Fix.** Defer those three imports into the `run()` body as a `Promise.all` of dynamic imports. They are only paid when the agent actually launches.

Separately, `launch.ts` imported `THINKING_EFFORTS` from the `@oh-my-pi/pi-ai` barrel (~540 ms cold) for the sake of one 5-string array used at class-declaration time for a flag constraint. Switch to `@oh-my-pi/pi-ai/model-thinking` (~7 ms cold) — the per-subpath export pattern was already in pi-ai's `package.json`.

### 3. Per-subcommand help walked the registry

`run()`'s `<subcommand> --help` branch previously called `loadAllCommands` and discarded all but the target. After (1) it would also receive metadata-only stubs for siblings, which `renderCommandHelp` cannot fully render — the stub lacks `flags`/`args`/`examples`.

**Fix.** Restructure to load ONLY the targeted entry — what the renderer actually consumes on this path. `omp stats --help` is now a one-module-load operation regardless of registry size.

## Architecture notes

`CommandEntry` gains two optional fields:

- `description?: string` — when set, root-help renderer skips `e.load()` and uses the registry string directly.
- `default?: boolean` — marks the implicit-default command whose flags/args/examples are rendered inline by `renderRootHelp`. Its module is always loaded so the body can be displayed; the class should also carry `static hidden = true` (the renderer uses `find(C => C.hidden)` to locate the default after load).

The metadata-only stub is a `{ description, hidden: false }` object cast through `unknown` to `CommandCtor`. It is **never instantiated** — only `description` and `hidden` are read off it by `renderRootHelp`. This is documented at the stub-creation site so a future refactor doesn't accidentally try to `new` it.

Adding a new command remains a one-line registry edit. The drift test catches mismatches between registry description and class description.

## Verification

- **`packages/utils/test/cli.test.ts`** (new, 6 tests):
  - does NOT call `load()` for entries with static description on `--help`
  - falls back to `load()` for entries without description (backward compat)
  - renders identical output regardless of metadata source
  - loads the default command's module so the renderer can show its body
  - per-subcommand help loads ONLY the targeted entry (no registry traversal)
  - resolves aliases when picking the target

- **`packages/coding-agent/test/cli-commands.test.ts`** (new, 4 tests):
  - every registry `description` matches its class's `static description` (drift detection — already caught the `setup` rename on main)
  - exactly one entry is marked `default: true` and its class is `hidden = true`
  - every non-default entry either carries a description OR loads to a hidden class (preserves the cold-start win; the `__complete` exception is encoded)
  - all entry names are unique

- `omp --help`, `omp --version`, `omp <subcommand> --help`, `omp --smoke-test` all exit 0 with output equivalent to the pre-change build.
- TypeScript clean on every touched file. `bun test` clean on the new suites.

## Files

- `packages/utils/src/cli.ts` — `CommandEntry.description`/`default`, `loadAllCommands` stub path, per-subcommand-help one-entry load
- `packages/utils/test/cli.test.ts` — framework-level lazy-load contract tests
- `packages/utils/CHANGELOG.md`
- `packages/coding-agent/src/cli-commands.ts` — lifted descriptions for 21 of 22 entries, marked `launch` as default
- `packages/coding-agent/src/commands/launch.ts` — deferred heavy imports into `run()`, switched to `pi-ai/model-thinking` subpath
- `packages/coding-agent/test/cli-commands.test.ts` — drift-detection contract tests
- `packages/coding-agent/CHANGELOG.md`
