### PR TITLE
fix(coding-agent): route local:// reads through the calling session

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `read local://<file>` resolving to the wrong session's artifacts directory in multi-session ACP hosts (e.g. cmux). `LocalProtocolHandler.resolve` now honors `context.localProtocolOptions` supplied by the calling tool before falling back to the process-wide override or the first `main`-kind session in the global `AgentRegistry`; `read`, `find`, `search`, `ast_grep`, and `ast_edit` thread their session's options through so a `local://PLAN.md` lookup hits the calling session's `local` root instead of a sibling session's ([#1608](https://github.com/can1357/oh-my-pi/issues/1608)).
+
 ## [15.7.4] - 2026-05-31
 
 ### Removed

--- a/packages/coding-agent/src/internal-urls/local-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/local-protocol.ts
@@ -5,7 +5,7 @@ import { isEnoent } from "@oh-my-pi/pi-utils";
 import { AgentRegistry } from "../registry/agent-registry";
 import { parseInternalUrl } from "./parse";
 import { validateRelativePath } from "./skill-protocol";
-import type { InternalResource, InternalUrl, ProtocolHandler, UrlCompletion } from "./types";
+import type { InternalResource, InternalUrl, ProtocolHandler, ResolveContext, UrlCompletion } from "./types";
 
 export interface LocalProtocolOptions {
 	getArtifactsDir?: () => string | null;
@@ -164,13 +164,25 @@ export class LocalProtocolHandler implements ProtocolHandler {
 	 * Returns the active local-protocol options.
 	 *
 	 * Resolution order:
-	 * 1. Explicit override installed via {@link setOverride} (used by subagents
-	 *    that share their parent's root and by SDK consumers with a custom
-	 *    artifacts/session id mapping).
-	 * 2. The main session in `AgentRegistry.global()`. Its `SessionManager`
-	 *    supplies both `getArtifactsDir` and `getSessionId`.
+	 * 1. **Caller-supplied** `context.localProtocolOptions` (the actual session
+	 *    that initiated the `read`/`find`/`search`/`router.resolve` call). This
+	 *    is what keeps `local://` reads pinned to the calling session in
+	 *    multi-session hosts (cmux/ACP, embedded SDK consumers) where every
+	 *    session registers as `kind: "main"` and "first one wins" would route
+	 *    to the wrong artifacts directory.
+	 * 2. Explicit process-global override installed via {@link setOverride}
+	 *    (used by SDK consumers with a custom artifacts/session-id mapping and
+	 *    by code paths that do not have a calling session, e.g. TUI hyperlink
+	 *    resolution).
+	 * 3. The first `main`-kind session in `AgentRegistry.global()`. Its
+	 *    `SessionManager` supplies both `getArtifactsDir` and `getSessionId`.
+	 *    Last-resort fallback — every caller that has a session reference
+	 *    SHOULD thread it through `context` so this branch is never taken in
+	 *    multi-session setups.
 	 */
-	static resolveOptions(): LocalProtocolOptions | undefined {
+	static resolveOptions(context?: ResolveContext): LocalProtocolOptions | undefined {
+		const fromContext = context?.localProtocolOptions;
+		if (fromContext) return fromContext;
 		const override = LocalProtocolHandler.#override;
 		if (override) return override;
 		const main = AgentRegistry.global()
@@ -184,8 +196,8 @@ export class LocalProtocolHandler implements ProtocolHandler {
 		};
 	}
 
-	async resolve(url: InternalUrl): Promise<InternalResource> {
-		const opts = LocalProtocolHandler.resolveOptions();
+	async resolve(url: InternalUrl, context?: ResolveContext): Promise<InternalResource> {
+		const opts = LocalProtocolHandler.resolveOptions(context);
 		if (!opts) {
 			throw new Error("No session - local:// unavailable");
 		}
@@ -247,8 +259,8 @@ export class LocalProtocolHandler implements ProtocolHandler {
 		};
 	}
 
-	async complete(): Promise<UrlCompletion[]> {
-		const opts = LocalProtocolHandler.resolveOptions();
+	async complete(_query?: string, context?: ResolveContext): Promise<UrlCompletion[]> {
+		const opts = LocalProtocolHandler.resolveOptions(context);
 		if (!opts) return [];
 		const localRoot = path.resolve(resolveLocalRoot(opts));
 		try {

--- a/packages/coding-agent/src/internal-urls/types.ts
+++ b/packages/coding-agent/src/internal-urls/types.ts
@@ -5,6 +5,8 @@
  * providing access to agent outputs and server resources without exposing filesystem paths.
  */
 
+import type { LocalProtocolOptions } from "./local-protocol";
+
 /**
  * Raw resource payload returned by protocol handlers. The `immutable` flag is
  * applied by the router from {@link ProtocolHandler.immutable}, so handlers do
@@ -77,6 +79,17 @@ export interface ResolveContext {
 	settings?: unknown;
 	/** Caller's abort signal. */
 	signal?: AbortSignal;
+	/**
+	 * Calling session's `local://` root mapping. When present, the local-protocol
+	 * handler resolves the URL against THIS session's artifacts dir instead of
+	 * picking the first `main`-kind session from the global `AgentRegistry`.
+	 *
+	 * Required for correctness in multi-session hosts (cmux/ACP, embedded SDK
+	 * consumers) where multiple sessions are registered as `main` and the
+	 * "first one wins" lookup picks the wrong artifacts directory — see
+	 * [#1608](https://github.com/can1357/oh-my-pi/issues/1608).
+	 */
+	localProtocolOptions?: LocalProtocolOptions;
 }
 
 /**
@@ -89,6 +102,8 @@ export interface WriteContext {
 	cwd?: string;
 	/** Caller's abort signal. */
 	signal?: AbortSignal;
+	/** Calling session's `local://` root mapping — see {@link ResolveContext.localProtocolOptions}. */
+	localProtocolOptions?: LocalProtocolOptions;
 }
 
 /**

--- a/packages/coding-agent/src/tools/ast-edit.ts
+++ b/packages/coding-agent/src/tools/ast-edit.ts
@@ -230,6 +230,9 @@ export class AstEditTool implements AgentTool<typeof astEditSchema, AstEditToolD
 				rawPaths: params.paths,
 				cwd: this.session.cwd,
 				internalUrlAction: "rewrite",
+				settings: this.session.settings,
+				signal,
+				localProtocolOptions: this.session.localProtocolOptions,
 			});
 			const { searchPath: resolvedSearchPath, scopePath, isDirectory, multiTargets, globFilter } = scope;
 

--- a/packages/coding-agent/src/tools/ast-grep.ts
+++ b/packages/coding-agent/src/tools/ast-grep.ts
@@ -155,6 +155,9 @@ export class AstGrepTool implements AgentTool<typeof astGrepSchema, AstGrepToolD
 				rawPaths: params.paths,
 				cwd: this.session.cwd,
 				internalUrlAction: "search",
+				settings: this.session.settings,
+				signal,
+				localProtocolOptions: this.session.localProtocolOptions,
 			});
 			const { searchPath: resolvedSearchPath, scopePath, isDirectory, multiTargets, globFilter } = scope;
 

--- a/packages/coding-agent/src/tools/find.ts
+++ b/packages/coding-agent/src/tools/find.ts
@@ -192,7 +192,12 @@ export class FindTool implements AgentTool<typeof findSchema, FindToolDetails> {
 				if (hasGlobPathChars(rawPattern)) {
 					throw new ToolError(`Glob patterns are not supported for internal URLs: ${rawPattern}`);
 				}
-				const resource = await internalRouter.resolve(rawPattern);
+				const resource = await internalRouter.resolve(rawPattern, {
+					cwd: this.session.cwd,
+					settings: this.session.settings,
+					signal,
+					localProtocolOptions: this.session.localProtocolOptions,
+				});
 				if (!resource.sourcePath) {
 					throw new ToolError(`Cannot find internal URL without a backing file: ${rawPattern}`);
 				}

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as url from "node:url";
 import { isEnoent } from "@oh-my-pi/pi-utils";
-import { InternalUrlRouter } from "../internal-urls";
+import { InternalUrlRouter, type LocalProtocolOptions } from "../internal-urls";
 import { ToolError } from "./tool-errors";
 
 const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
@@ -740,6 +740,12 @@ export interface ToolScopeOptions {
 	surfaceExactFilePaths?: boolean;
 	/** Extra hint appended to "Path not found" when stat fails and the user supplied multiple paths. */
 	multipathStatHint?: string;
+	/** Calling session's settings — forwarded to the internal-URL router so caller-aware handlers (issue://, pr://) honor it. */
+	settings?: unknown;
+	/** Caller's abort signal — forwarded to the internal-URL router. */
+	signal?: AbortSignal;
+	/** Calling session's `local://` root mapping — pins resolutions to the calling session. */
+	localProtocolOptions?: LocalProtocolOptions;
 }
 
 export interface ToolScopeResolution {
@@ -778,7 +784,12 @@ export async function resolveToolSearchScope(opts: ToolScopeOptions): Promise<To
 		if (hasGlobPathChars(rawPath)) {
 			throw new ToolError(`Glob patterns are not supported for internal URLs: ${rawPath}`);
 		}
-		const resource = await internalRouter.resolve(rawPath);
+		const resource = await internalRouter.resolve(rawPath, {
+			cwd,
+			settings: opts.settings,
+			signal: opts.signal,
+			localProtocolOptions: opts.localProtocolOptions,
+		});
 		if (!resource.sourcePath) {
 			throw new ToolError(`Cannot ${internalUrlAction} internal URL without a backing file: ${rawPath}`);
 		}

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -2141,6 +2141,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			cwd: this.session.cwd,
 			settings: this.session.settings,
 			signal,
+			localProtocolOptions: this.session.localProtocolOptions,
 		});
 		const details: ReadToolDetails = { resolvedPath: resource.sourcePath, contentType: resource.contentType };
 

--- a/packages/coding-agent/src/tools/search.ts
+++ b/packages/coding-agent/src/tools/search.ts
@@ -10,6 +10,7 @@ import { prompt, untilAborted } from "@oh-my-pi/pi-utils";
 import * as z from "zod/v4";
 import { recordFileSnapshot } from "../edit/file-snapshot-store";
 import type { RenderResultOptions } from "../extensibility/custom-tools/types";
+import type { LocalProtocolOptions } from "../internal-urls/local-protocol";
 import { InternalUrlRouter } from "../internal-urls/router";
 import type { InternalResource, ResolveContext } from "../internal-urls/types";
 import type { Theme } from "../modes/theme/theme";
@@ -543,6 +544,7 @@ async function resolveInternalSearchInputs(opts: {
 	settings: unknown;
 	signal?: AbortSignal;
 	archiveDisplayMap: ReadonlyMap<string, string>;
+	localProtocolOptions?: LocalProtocolOptions;
 }): Promise<InternalSearchInputResolution> {
 	const internalRouter = InternalUrlRouter.instance();
 	const paths = opts.resolvedPaths.slice();
@@ -551,7 +553,12 @@ async function resolveInternalSearchInputs(opts: {
 	const virtualInputIndexes = new Set<number>();
 	const immutableSourcePaths = new Set<string>();
 	let virtualScopePath: string | undefined;
-	const context: ResolveContext = { cwd: opts.cwd, settings: opts.settings, signal: opts.signal };
+	const context: ResolveContext = {
+		cwd: opts.cwd,
+		settings: opts.settings,
+		signal: opts.signal,
+		localProtocolOptions: opts.localProtocolOptions,
+	};
 
 	for (let idx = 0; idx < paths.length; idx++) {
 		const rawPath = paths[idx];
@@ -674,6 +681,7 @@ export class SearchTool implements AgentTool<typeof searchSchema, SearchToolDeta
 					settings: this.session.settings,
 					signal,
 					archiveDisplayMap,
+					localProtocolOptions: this.session.localProtocolOptions,
 				});
 				const searchablePaths = internalResolution.paths;
 				const { virtualResources, virtualPathSet, virtualInputIndexes } = internalResolution;
@@ -738,6 +746,9 @@ export class SearchTool implements AgentTool<typeof searchSchema, SearchToolDeta
 						trackImmutableSources: true,
 						surfaceExactFilePaths: true,
 						multipathStatHint: " (`paths` entries must each exist relative to cwd)",
+						settings: this.session.settings,
+						signal,
+						localProtocolOptions: this.session.localProtocolOptions,
 					});
 					searchPath = scope.searchPath;
 					isDirectory = scope.isDirectory;

--- a/packages/coding-agent/test/internal-urls/local-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/local-protocol.test.ts
@@ -110,4 +110,65 @@ describe("LocalProtocolHandler", () => {
 			await expect(router.resolve("local://linked/secret.txt")).rejects.toThrow("local:// URL escapes local root");
 		});
 	});
+
+	it("prefers caller-supplied context.localProtocolOptions over the installed override", async () => {
+		await withTempDir(async tempDir => {
+			const overrideArtifactsDir = path.join(tempDir, "override-artifacts");
+			const callerArtifactsDir = path.join(tempDir, "caller-artifacts");
+			await fs.mkdir(path.join(overrideArtifactsDir, "local"), { recursive: true });
+			await fs.mkdir(path.join(callerArtifactsDir, "local"), { recursive: true });
+			await Bun.write(path.join(overrideArtifactsDir, "local", "PLAN.md"), "# wrong session");
+			await Bun.write(path.join(callerArtifactsDir, "local", "PLAN.md"), "# caller session");
+
+			// Process-global override points at the WRONG session (simulates a
+			// stale override leaked from a prior subagent, or the multi-`main`
+			// AgentRegistry case in cmux/ACP where "first one wins" lookup
+			// picks a sibling session's artifacts dir — issue #1608).
+			LocalProtocolHandler.setOverride({
+				getArtifactsDir: () => overrideArtifactsDir,
+				getSessionId: () => "stale-session",
+			});
+
+			const router = InternalUrlRouter.instance();
+			const resource = await router.resolve("local://PLAN.md", {
+				localProtocolOptions: {
+					getArtifactsDir: () => callerArtifactsDir,
+					getSessionId: () => "caller-session",
+				},
+			});
+
+			const expectedSourcePath = await fs.realpath(path.join(callerArtifactsDir, "local", "PLAN.md"));
+
+			expect(resource.content).toBe("# caller session");
+			// `sourcePath` is canonicalized by the handler after symlink escape checks.
+			// On macOS this may turn `/var/...` into `/private/var/...`.
+			expect(resource.sourcePath).toBe(expectedSourcePath);
+		});
+	});
+
+	it("surfaces ENOENT against the caller's local root when the file is missing in that session", async () => {
+		await withTempDir(async tempDir => {
+			const overrideArtifactsDir = path.join(tempDir, "override-artifacts");
+			const callerArtifactsDir = path.join(tempDir, "caller-artifacts");
+			await fs.mkdir(path.join(overrideArtifactsDir, "local"), { recursive: true });
+			await fs.mkdir(path.join(callerArtifactsDir, "local"), { recursive: true });
+			// PLAN.md exists only in the override-pointed session.
+			await Bun.write(path.join(overrideArtifactsDir, "local", "PLAN.md"), "# wrong session");
+
+			LocalProtocolHandler.setOverride({
+				getArtifactsDir: () => overrideArtifactsDir,
+				getSessionId: () => "stale-session",
+			});
+
+			const router = InternalUrlRouter.instance();
+			await expect(
+				router.resolve("local://PLAN.md", {
+					localProtocolOptions: {
+						getArtifactsDir: () => callerArtifactsDir,
+						getSessionId: () => "caller-session",
+					},
+				}),
+			).rejects.toThrow("Local file not found: local://PLAN.md");
+		});
+	});
 });


### PR DESCRIPTION
## Repro

In cmux ACP mode, after a few `/plan` steps the agent's `read local://PLAN.md` fails with `Local file not found: local://PLAN.md` even though plan-mode `write` against the same URL just succeeded. Captured as a unit-level regression:

```sh
bun test packages/coding-agent/test/internal-urls/local-protocol.test.ts \
  -t "prefers caller-supplied"
```

The two new cases pin a "stale" override at one artifacts dir, hand the router a different caller's `localProtocolOptions`, and expect the resolved file to come from the caller's `local` root (or surface ENOENT against the caller's root when the file is genuinely missing there). Both fail against pre-fix `main` and pass after the patch.

## Cause

`LocalProtocolHandler.resolve(url, _context)` discarded the `ResolveContext` the router threads in. `resolveOptions()` consulted (1) a process-global `setOverride` slot — set unconditionally whenever `createAgentSession` is called with `localProtocolOptions` (subagents, SDK consumers) and never cleared — and then (2) `AgentRegistry.global().list().find(ref => ref.kind === "main")`, i.e. the **first** `main`-kind session in registration order. Multi-session ACP hosts like cmux register every `session/new` as `main`, so reads from session B routed to session A's `local` root and threw ENOENT, while plan-mode writes (which go through `plan-mode-guard` → `resolveLocalUrlToPath` with the calling session's options directly) landed correctly in session B's root.

The architectural smell is the one called out in `internal-urls/types.ts` for `issue://`/`pr://` — protocol handlers that depend on caller identity MUST consume `ResolveContext` instead of global state.

## Fix

- `packages/coding-agent/src/internal-urls/types.ts` — added `localProtocolOptions` to `ResolveContext` (and `WriteContext`) and documented why caller-aware handlers should prefer it.
- `packages/coding-agent/src/internal-urls/local-protocol.ts` — `resolveOptions(context?)` checks `context.localProtocolOptions` first, then the override slot, then the first-`main` `AgentRegistry` fallback (for context-less paths like TUI hyperlinks and autocomplete). `resolve` and `complete` accept the `ResolveContext` second arg.
- `packages/coding-agent/src/tools/{read,find,ast-edit,ast-grep,search}.ts` and `path-utils.ts` (`resolveToolSearchScope` + `resolveInternalSearchInputs`) — thread `this.session.localProtocolOptions` (plus `settings` and the abort `signal`) into every `internalRouter.resolve` callsite, so `local://`, `memory://`, `agent://`, `issue://`, `pr://`, … all see the calling session.

`bash-skill-urls.ts` already calls `resolveLocalUrlToPath` directly with the session's `localOptions`, so it was never affected.

## Verification

- `bun test packages/coding-agent/test/internal-urls/local-protocol.test.ts` → 7 pass / 0 fail (5 existing + 2 new regression tests).
- `bun test packages/coding-agent/test/internal-urls packages/coding-agent/test/tools` → 943 pass, 298 skip, 2 fail. The two failures are in `tools/gh.test.ts` (`pr-checkout` worktree path expectation) and reproduce identically on a clean `main` checkout against the same `gh.test.ts` — pre-existing breakage unrelated to this diff.
- `bun run check:ts` → clean across the workspace.

Fixes #1608
