### PR TITLE
fix(tui): preserved scrolled-up WSL Windows Terminal viewport during eager rebuild

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed scrolled-up readers being yanked to the top of scrollback under WSL inside Windows Terminal while a foreground tool was streaming. `setEagerNativeScrollbackRebuild(true)` (set by coding-agent while a foreground tool is pending) promoted `allowUnknownViewportMutation`, which routed every offscreen edit through a destructive `historyRebuild` (`\x1b[3J` clear scrollback + full repaint) on a terminal whose outer Windows Terminal viewport we cannot probe. Eager rebuild is now a no-op under WSL+Windows Terminal — the trade-off flips back to "stale duplicated rows above the fold are preferable to disrupting the user's scroll position." `#canReplayNativeScrollbackAtCheckpoint` mirrors win32's conservative handling for the same environment so unintended checkpoint paths cannot replay without an explicit user-driven `allowUnknownViewport` opt-in. ([#1610](https://github.com/can1357/oh-my-pi/issues/1610))
+
 ## [15.7.3] - 2026-05-31
 
 ### Added

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -167,6 +167,22 @@ function isMultiplexerSession(): boolean {
 }
 
 /**
+ * Detect WSL running inside Windows Terminal. The outer Windows Terminal owns
+ * a user-visible scrollback we cannot probe — `kernel32.dll` FFI is
+ * unreachable from a Linux user-space process — so destructive native
+ * scrollback replays cannot rely on viewport-position evidence. Mirrors the
+ * conservative win32 handling: treat unknown viewport as scrolled unless the
+ * caller asserts an explicit user-driven checkpoint.
+ */
+function isWindowsSubsystemForLinuxWindowsTerminal(): boolean {
+	return (
+		process.platform === "linux" &&
+		(!!Bun.env.WSL_DISTRO_NAME || !!Bun.env.WSL_INTEROP) &&
+		!!Bun.env.WT_SESSION
+	);
+}
+
+/**
  * Options for overlay positioning and sizing.
  * Values can be absolute numbers or percentage strings (e.g., "50%").
  */
@@ -389,6 +405,12 @@ export class TUI extends Container {
 	 * re-laying-out rows that have already scrolled into history. A snap to the tail
 	 * is acceptable there. A terminal that can report a *known*-scrolled viewport
 	 * (Windows) still defers; only the unknown case is forced to rebuild.
+	 *
+	 * WSL inside Windows Terminal is the documented exception: the outer terminal
+	 * owns user-visible scrollback we cannot probe, and a snap to the tail there
+	 * yanks a reader who deliberately scrolled up (see #1610). Eager rebuild is a
+	 * no-op in that environment — the trade-off flips back to "stale duplicated
+	 * rows above the fold are preferable to disrupting the user's scroll position."
 	 */
 	setEagerNativeScrollbackRebuild(enabled: boolean): void {
 		this.#eagerNativeScrollbackRebuild = enabled;
@@ -1181,7 +1203,8 @@ export class TUI extends Container {
 		const widthChanged = this.#previousWidth > 0 && this.#previousWidth !== width;
 		const heightChanged = this.#previousHeight > 0 && this.#previousHeight !== height;
 		const allowUnknownViewportMutation =
-			this.#allowUnknownViewportMutationOnNextRender || this.#eagerNativeScrollbackRebuild;
+			this.#allowUnknownViewportMutationOnNextRender ||
+			(this.#eagerNativeScrollbackRebuild && !isWindowsSubsystemForLinuxWindowsTerminal());
 		this.#allowUnknownViewportMutationOnNextRender = false;
 
 		// 3. Classify intent.
@@ -1595,10 +1618,16 @@ export class TUI extends Container {
 		nativeViewportAtBottom: boolean | undefined,
 		allowUnknownViewport: boolean,
 	): boolean {
-		return (
-			nativeViewportAtBottom === true ||
-			(nativeViewportAtBottom === undefined && (allowUnknownViewport || process.platform !== "win32"))
-		);
+		if (nativeViewportAtBottom === true) return true;
+		if (nativeViewportAtBottom !== undefined) return false;
+		if (allowUnknownViewport) return true;
+		// POSIX terminals are optimistic: no observable scrollback to yank. The
+		// exceptions are platforms whose outer terminal owns a scrollback we
+		// cannot probe — native Win32 (kernel32 FFI may fail) and WSL inside
+		// Windows Terminal (FFI never reachable from a Linux user-space process).
+		// Both treat unknown viewport as scrolled and defer until an explicit
+		// user-driven opt-in (`allowUnknownViewport: true`).
+		return process.platform !== "win32" && !isWindowsSubsystemForLinuxWindowsTerminal();
 	}
 
 	/**

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -175,11 +175,7 @@ function isMultiplexerSession(): boolean {
  * caller asserts an explicit user-driven checkpoint.
  */
 function isWindowsSubsystemForLinuxWindowsTerminal(): boolean {
-	return (
-		process.platform === "linux" &&
-		(!!Bun.env.WSL_DISTRO_NAME || !!Bun.env.WSL_INTEROP) &&
-		!!Bun.env.WT_SESSION
-	);
+	return process.platform === "linux" && (!!Bun.env.WSL_DISTRO_NAME || !!Bun.env.WSL_INTEROP) && !!Bun.env.WT_SESSION;
 }
 
 /**

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -1699,6 +1699,126 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 
+		it("preserves a scrolled-up reader on WSL Windows Terminal even with eager rebuild active (#1610)", async () => {
+			// WSL+Windows-Terminal cannot probe the outer Windows Terminal viewport
+			// (kernel32 FFI is unreachable from a Linux user-space process). The
+			// reporter observed that while a foreground tool was streaming and they
+			// had scrolled up to read history, OMP's eager rebuild path emitted a
+			// destructive `historyRebuild` (\x1b[3J clear scrollback + full repaint)
+			// on every offscreen edit, yanking the viewport to the top. The fix
+			// makes eager rebuild a no-op under WSL+WT: stale rows above the fold
+			// are preferable to losing the user's reading position.
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
+			try {
+				await withEnvPatch(
+					{ WT_SESSION: "wt-test", WSL_DISTRO_NAME: "Ubuntu", WSL_INTEROP: undefined },
+					async () => {
+						const term = new UnknownViewportTerminal(40, 5, 200);
+						const tui = new TUI(term);
+						const component = new MutableLinesComponent(rows("row-", 16));
+						tui.addChild(component);
+
+						try {
+							tui.start();
+							await settle(term);
+
+							// Reader scrolls up to inspect committed history.
+							term.scrollLines(-4);
+							const before = term.getBufferPosition();
+							const anchored = visible(term).map(line => line.trim());
+							expect(before.viewportY).toBeGreaterThan(0);
+							expect(before.viewportY).toBeLessThan(before.baseY);
+
+							// Foreground tool active — coding-agent flips this flag (see
+							// `event-controller.ts:#refreshToolRenderMode`).
+							tui.setEagerNativeScrollbackRebuild(true);
+
+							// Streaming tool result that re-lays out an offscreen header and
+							// grows past the fold. Pre-fix this routed to historyRebuild and
+							// yanked the WT viewport because eager rebuild promoted
+							// `allowUnknownViewportMutation` even under WSL+WT.
+							for (let i = 0; i < 4; i++) {
+								component.setLines([
+									"HEADER-EDITED",
+									...rows("row-", 16).slice(1),
+									...rows("tail-", i + 1),
+								]);
+								tui.requestRender();
+								await settle(term);
+
+								const pos = term.getBufferPosition();
+								// Reader stays at the same scrollback position they chose.
+								expect(pos.viewportY).toBe(before.viewportY);
+								expect(visible(term).map(line => line.trim())).toEqual(anchored);
+							}
+
+							// The deferred edit is still reconciled at the user-driven
+							// checkpoint (Enter / submission), where the WT scrollOnInput
+							// behaviour pins the outer viewport to the tail.
+							term.scrollLines(999);
+							expect(tui.refreshNativeScrollbackIfDirty({ allowUnknownViewport: true })).toBe(true);
+							await settle(term);
+							expect(term.getScrollBuffer().join("\n")).toContain("HEADER-EDITED");
+						} finally {
+							tui.stop();
+						}
+					},
+				);
+			} finally {
+				Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+			}
+		});
+
+		it("requires explicit opt-in before checkpoint replay on WSL Windows Terminal (#1610)", async () => {
+			// `refreshNativeScrollbackIfDirty()` without `allowUnknownViewport: true`
+			// must refuse to clear scrollback on WSL+WT: the outer Windows Terminal
+			// owns the viewport state and we cannot probe it. Production only opts
+			// in from user-driven submission paths where WT scrollOnInput has
+			// pinned the viewport to the tail; everywhere else defers. Pre-fix the
+			// predicate optimistically replayed on every POSIX platform regardless.
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
+			try {
+				await withEnvPatch(
+					{ WT_SESSION: "wt-test", WSL_DISTRO_NAME: "Ubuntu", WSL_INTEROP: undefined },
+					async () => {
+						const term = new UnknownViewportTerminal(32, 5, 200);
+						const tui = new TUI(term);
+						const component = new MutableLinesComponent(rows("row-", 12));
+						tui.addChild(component);
+
+						try {
+							tui.start();
+							await settle(term);
+
+							// Trigger a deferred scrollback edit while the reader is scrolled up.
+							term.scrollLines(-3);
+							component.setLines(["HEADER-EDIT", ...rows("row-", 12).slice(1)]);
+							tui.requestRender();
+							await settle(term);
+
+							// Without the opt-in: WSL+WT defers the destructive replay so the
+							// reader is not yanked. Plain POSIX (no WSL+WT env) would have
+							// returned true here and cleared scrollback.
+							expect(tui.refreshNativeScrollbackIfDirty()).toBe(false);
+
+							// The explicit user-driven opt-in (matches the submission path)
+							// still reconciles deferred edits into clean history.
+							term.scrollLines(999);
+							expect(tui.refreshNativeScrollbackIfDirty({ allowUnknownViewport: true })).toBe(true);
+							await settle(term);
+							expect(term.getScrollBuffer().join("\n")).toContain("HEADER-EDIT");
+						} finally {
+							tui.stop();
+						}
+					},
+				);
+			} finally {
+				Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+			}
+		});
+
 		it("refreshes deferred native scrollback when the native viewport reaches bottom", async () => {
 			const term = new VirtualTerminal(32, 5);
 			const tui = new TUI(term);

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -1739,11 +1739,7 @@ describe("TUI terminal-state regressions", () => {
 							// yanked the WT viewport because eager rebuild promoted
 							// `allowUnknownViewportMutation` even under WSL+WT.
 							for (let i = 0; i < 4; i++) {
-								component.setLines([
-									"HEADER-EDITED",
-									...rows("row-", 16).slice(1),
-									...rows("tail-", i + 1),
-								]);
+								component.setLines(["HEADER-EDITED", ...rows("row-", 16).slice(1), ...rows("tail-", i + 1)]);
 								tui.requestRender();
 								await settle(term);
 


### PR DESCRIPTION
## Repro

Under WSL inside Windows Terminal, scrolling up to inspect history while a foreground tool streams output causes the WT viewport to snap to the top of scrollback. The reporter's minimal trace (`UnknownViewportTerminal`):

```
before:  baseY=22 viewportY=12   row-12 ... row-19
after:   baseY=24 viewportY=0    inserted-0, inserted-1, row-0 ... row-5
```

Regression coverage in `packages/tui/test/render-regressions.test.ts` reproduces the trace deterministically: scrolled reader at `viewportY=7` snaps to `viewportY=0` after a streaming offscreen edit while `setEagerNativeScrollbackRebuild(true)` is active.

```
bun test packages/tui/test/render-regressions.test.ts -t "1610"
```

## Cause

`coding-agent`'s `EventController.#refreshToolRenderMode` flips `tui.setEagerNativeScrollbackRebuild(true)` whenever a foreground tool is pending (`packages/coding-agent/src/modes/controllers/event-controller.ts:192`). The flag is read in `TUI.#doRender` (`packages/tui/src/tui.ts:1199-1200`) and OR'd into `allowUnknownViewportMutation`, so every live render frame opts unknown-viewport rebuilds back in.

`#canRebuildNativeScrollbackLive(undefined, true)` then returns `true`, and the offscreen-edit branch (`tui.ts:1487`) routes the frame to `historyRebuild` — `\x1b[2J\x1b[H\x1b[3J` followed by a full repaint. `\x1b[3J` clears Windows Terminal's scrollback, which yanks any reader who had scrolled up.

WSL+WT is the documented exception to the "snap to tail is acceptable" trade-off because the outer Windows Terminal owns user-visible scrollback we cannot probe — `kernel32` FFI is unreachable from a Linux user-space process, so `isNativeViewportAtBottom()` is permanently `undefined` and we have no signal to distinguish "user at bottom" from "user scrolled up."

`#canReplayNativeScrollbackAtCheckpoint` exhibited the same POSIX optimism (`process.platform !== "win32"` ⇒ replay) — defensive risk if any future caller invokes `refreshNativeScrollbackIfDirty()` without `allowUnknownViewport: true`.

## Fix

- Added `isWindowsSubsystemForLinuxWindowsTerminal()` helper in `tui.ts` (parallel to `isMultiplexerSession`).
- `#doRender` no longer promotes `allowUnknownViewportMutation` via the eager flag under WSL+WT — explicit per-call opt-ins from controller actions and autocomplete (which WT's `scrollOnInput` pins to the tail) still work.
- `#canReplayNativeScrollbackAtCheckpoint` mirrors win32's conservative handling for WSL+WT: unknown viewport requires an explicit `allowUnknownViewport: true` (the only production caller, `interactive-mode.ts:#submit`, already passes it).
- Updated the `setEagerNativeScrollbackRebuild` docstring to document the WSL+WT exception.
- CHANGELOG entry under `[Unreleased]` in `packages/tui/CHANGELOG.md`.

The existing `renders streaming row inserts on WSL Windows Terminal even when viewport probe is unavailable` regression (which protects #1534's fix) is unaffected — it uses plain `requestRender()` without eager rebuild, so the diff path still emits streaming rows.

## Verification

```
bun test packages/tui/test/render-regressions.test.ts -t "1610"
# 2 pass, 0 fail
bun test packages/tui/test/
# 453 pass, 4 skip, 2 fail (pre-existing keys.test.ts Alt+letter failures on main, unrelated)
bun test packages/coding-agent/test/streaming-preview-height.test.ts \
         packages/coding-agent/test/modes/controllers/event-controller-tool-render-mode.test.ts
# 4 pass, 0 fail
```

Verified the new regression tests fail on `main` (without the source fix) with the exact reporter trace (`Expected: 7, Received: 0` viewportY snap) and pass with the fix.

Fixes #1610