### PR TITLE
fix(task): demote subagent reminder-loop abort log

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed subagent yield-reminder loop logging benign user/compaction aborts as `ERROR`. The catch around `session.prompt`/`waitForIdle` in `task/executor.ts` now demotes `ToolAbortError` and signal-aborted exits to `debug` and keeps `ERROR` for genuine prompt failures only ([#1623](https://github.com/can1357/oh-my-pi/issues/1623)).
+
 ## [15.7.4] - 2026-05-31
 
 ### Removed

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1446,9 +1446,19 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 					);
 					await awaitAbortable(session.waitForIdle());
 				} catch (err) {
-					logger.error("Subagent prompt failed", {
-						error: err instanceof Error ? err.message : String(err),
-					});
+					if (abortSignal.aborted || err instanceof ToolAbortError) {
+						// Benign control-flow exit — user cancel (^C) or compaction aborting
+						// pending operations both surface here as ToolAbortError. The outer
+						// catch and finally already mark the run aborted; logging at ERROR
+						// would spam operator dashboards with non-failures.
+						logger.debug("Subagent prompt aborted", {
+							reason: abortReason ?? "signal",
+						});
+					} else {
+						logger.error("Subagent prompt failed", {
+							error: err instanceof Error ? err.message : String(err),
+						});
+					}
 				}
 			}
 

--- a/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
+++ b/packages/coding-agent/test/task/executor-subagent-reminders.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import { AgentBusyError, type AgentTelemetryConfig, type Tracer } from "@oh-my-pi/pi-agent-core";
 import { type AssistantMessage, Effort } from "@oh-my-pi/pi-ai";
+import { logger } from "@oh-my-pi/pi-utils";
 import { Settings } from "../../src/config/settings";
 import type { ExtensionActions, LoadExtensionsResult } from "../../src/extensibility/extensions/types";
 import type { CreateAgentSessionResult } from "../../src/sdk";
@@ -520,6 +521,42 @@ describe("runSubprocess yield reminders", () => {
 		expect(result.exitCode).toBe(1);
 		expect(result.stderr).toMatch(/options\.authStorage.*modelRegistry\.authStorage/);
 		expect(createAgentSessionSpy).not.toHaveBeenCalled();
+	});
+
+	it("logs reminder-loop aborts at debug, not error (issue #1623)", async () => {
+		// Repro: user ^C or compaction aborts pending operations while the
+		// yield-reminder loop is awaiting session.prompt. awaitAbortable rejects
+		// with ToolAbortError, which previously surfaced as logger.error and
+		// polluted operator dashboards.
+		const abortController = new AbortController();
+		const debugSpy = vi.spyOn(logger, "debug").mockImplementation(() => {});
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		const session = createMockSession(({ promptIndex, emit, state }) => {
+			if (promptIndex === 1) {
+				// Initial prompt: stop without yielding so the reminder loop kicks in.
+				const assistant = createAssistantStopMessage("no yield yet");
+				state.messages.push(assistant);
+				emit({ type: "message_end", message: assistant });
+				return;
+			}
+			// Reminder prompt: abort the run while it is in flight. The follow-up
+			// awaitAbortable(session.waitForIdle()) then throws ToolAbortError into
+			// the catch we are guarding.
+			abortController.abort();
+		});
+
+		mockCreateAgentSession(session);
+
+		const result = await runSubprocess({
+			...baseOptions,
+			id: "subagent-abort-during-reminder",
+			signal: abortController.signal,
+		});
+
+		expect(result.aborted).toBe(true);
+		expect(errorSpy).not.toHaveBeenCalledWith("Subagent prompt failed", expect.anything());
+		expect(debugSpy).toHaveBeenCalledWith("Subagent prompt aborted", expect.anything());
 	});
 });
 


### PR DESCRIPTION
## Repro

User ^C or compaction-aborted operations during the subagent yield-reminder
loop in `packages/coding-agent/src/task/executor.ts` reject `awaitAbortable`
with `ToolAbortError("Operation aborted")`. The surrounding `try/catch` then
logs every exception as `ERROR`, polluting operator dashboards with benign
control-flow events (9 hits over 2 days in the reporter's instance, all with
the same "Operation aborted" message).

Regression test:

```
cd packages/coding-agent && bun test test/task/executor-subagent-reminders.test.ts -t "logs reminder-loop aborts at debug"
```

aborts the run while the reminder prompt is in flight and asserts
`logger.error("Subagent prompt failed", …)` is never called.

## Cause

`executor.ts:1448-1451` treats the catch block as the failure path without
inspecting the signal or the error type. `awaitAbortable` rejects with
`ToolAbortError` whenever `abortSignal.aborted` flips (user cancel, compaction,
runtime-limit), so the catch saw both real prompt failures and expected aborts
on the same code path. The outer `catch`/`finally` already promotes the result
to `aborted`, making the inner `ERROR` log purely cosmetic noise.

## Fix

- `packages/coding-agent/src/task/executor.ts`: gate the `logger.error` branch
  on `!abortSignal.aborted && !(err instanceof ToolAbortError)` and route the
  abort path through `logger.debug("Subagent prompt aborted", { reason })`.
- `packages/coding-agent/test/task/executor-subagent-reminders.test.ts`: new
  regression test that triggers an abort during the reminder loop and asserts
  the catch never calls `logger.error("Subagent prompt failed", …)` while
  `logger.debug("Subagent prompt aborted", …)` is observed.
- `packages/coding-agent/CHANGELOG.md`: `[Unreleased] / Fixed` entry.

## Verification

`cd packages/coding-agent && bun test test/task/executor-subagent-reminders.test.ts` — 16 pass / 0 fail (60 expect calls).

Fixes #1623