### PR TITLE
fix(tool): handle string paths in find renderer

### DIFF
--- a/packages/coding-agent/src/tools/find.ts
+++ b/packages/coding-agent/src/tools/find.ts
@@ -443,8 +443,12 @@ export class FindTool implements AgentTool<typeof findSchema, FindToolDetails> {
 // =============================================================================
 
 interface FindRenderArgs {
-	paths?: string[];
+	paths?: string | string[];
 	limit?: number;
+}
+
+function formatFindRenderPaths(paths: FindRenderArgs["paths"]): string | undefined {
+	return Array.isArray(paths) ? paths.join(", ") : paths;
 }
 
 const COLLAPSED_LIST_LIMIT = PREVIEW_LIMITS.COLLAPSED_ITEMS;
@@ -456,7 +460,7 @@ export const findToolRenderer = {
 		if (args.limit !== undefined) meta.push(`limit:${args.limit}`);
 
 		const text = renderStatusLine(
-			{ icon: "pending", title: "Find", description: args.paths?.join(", ") || "*", meta },
+			{ icon: "pending", title: "Find", description: formatFindRenderPaths(args.paths) || "*", meta },
 			uiTheme,
 		);
 		return new Text(text, 0, 0);
@@ -493,7 +497,7 @@ export const findToolRenderer = {
 				{
 					icon: "success",
 					title: "Find",
-					description: args?.paths?.join(", "),
+					description: formatFindRenderPaths(args?.paths),
 					meta: [formatCount("file", lines.length)],
 				},
 				uiTheme,
@@ -528,7 +532,7 @@ export const findToolRenderer = {
 
 		if (fileCount === 0) {
 			const header = renderStatusLine(
-				{ icon: "warning", title: "Find", description: args?.paths?.join(", "), meta: ["0 files"] },
+				{ icon: "warning", title: "Find", description: formatFindRenderPaths(args?.paths), meta: ["0 files"] },
 				uiTheme,
 			);
 			const lines = [header, formatEmptyMessage("No files found", uiTheme)];
@@ -539,7 +543,12 @@ export const findToolRenderer = {
 		if (details?.scopePath) meta.push(`in ${details.scopePath}`);
 		if (truncated) meta.push(uiTheme.fg("warning", "truncated"));
 		const header = renderStatusLine(
-			{ icon: truncated ? "warning" : "success", title: "Find", description: args?.paths?.join(", "), meta },
+			{
+				icon: truncated ? "warning" : "success",
+				title: "Find",
+				description: formatFindRenderPaths(args?.paths),
+				meta,
+			},
 			uiTheme,
 		);
 

--- a/packages/coding-agent/test/tools/find-validate-paths.test.ts
+++ b/packages/coding-agent/test/tools/find-validate-paths.test.ts
@@ -1,5 +1,25 @@
-import { describe, expect, it } from "bun:test";
-import { validateFindPathInputs } from "../../src/tools/find";
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { Component } from "@oh-my-pi/pi-tui";
+import type { RenderResultOptions } from "../../src/extensibility/custom-tools/types";
+import { getThemeByName, initTheme, type Theme } from "../../src/modes/theme/theme";
+import { findToolRenderer, validateFindPathInputs } from "../../src/tools/find";
+
+let uiTheme: Theme;
+
+beforeAll(async () => {
+	await initTheme(false, undefined, undefined, "dark", "light");
+	const theme = await getThemeByName("dark");
+	if (!theme) throw new Error("Missing dark theme");
+	uiTheme = theme;
+});
+const renderOptions: RenderResultOptions = {
+	expanded: false,
+	isPartial: true,
+};
+
+function renderText(component: Component): string {
+	return Bun.stripANSI(component.render(160).join("\n"));
+}
 
 describe("validateFindPathInputs", () => {
 	it("accepts a normal array of glob entries", () => {
@@ -38,5 +58,36 @@ describe("validateFindPathInputs", () => {
 		// behavior of the new escape-skip, which intentionally does NOT model glob
 		// brace semantics — it only mirrors search.ts's containsTopLevelComma.
 		expect(() => validateFindPathInputs(["\\{a,b}"])).toThrow(/paths is an array/);
+	});
+});
+
+describe("findToolRenderer", () => {
+	it("accepts a single string paths value before validation", async () => {
+		const args = { paths: "src/**/*.ts" };
+		const renderings = [
+			findToolRenderer.renderCall(args, renderOptions, uiTheme),
+			findToolRenderer.renderResult(
+				{ content: [{ type: "text", text: "src/index.ts\n" }] },
+				renderOptions,
+				uiTheme,
+				args,
+			),
+			findToolRenderer.renderResult(
+				{ content: [{ type: "text", text: "" }], details: { fileCount: 0, files: [] } },
+				renderOptions,
+				uiTheme,
+				args,
+			),
+			findToolRenderer.renderResult(
+				{ content: [{ type: "text", text: "src/index.ts" }], details: { fileCount: 1, files: ["src/index.ts"] } },
+				renderOptions,
+				uiTheme,
+				args,
+			),
+		];
+
+		for (const component of renderings) {
+			expect(renderText(component)).toContain("src/**/*.ts");
+		}
 	});
 });


### PR DESCRIPTION
## Repro
A raw pre-validation renderer call with `paths` as a string crashes: `bun -e "import { findToolRenderer } from './packages/coding-agent/src/tools/find.ts'; … findToolRenderer.renderCall({ paths: 'src/**/*.ts' }, …)"` previously threw `TypeError: args.paths?.join is not a function` from `packages/coding-agent/src/tools/find.ts:459`.

## Cause
`findToolRenderer` in `packages/coding-agent/src/tools/find.ts` typed render args as `string[]` and called `args.paths?.join(', ')` in pending, fallback result, empty result, and detailed result summaries. The renderer receives raw model JSON before Zod validation, so a string `paths` value reached those `.join()` calls unchanged.

## Fix
- Broadened `FindRenderArgs.paths` to `string | string[]` for renderer-only input.
- Added `formatFindRenderPaths()` and used it for every find renderer status-line path summary.
- Added a regression test that renders the pending, fallback, empty, and detailed result paths with a single string `paths` value.

## Verification
`bun test packages/coding-agent/test/tools/find-validate-paths.test.ts` passed: 8 pass, 0 fail. `bun run check` in `packages/coding-agent` passed. Manual repro command now renders `⏳ Find: src/**/*.ts` instead of throwing. Fixes #1622