### PR TITLE
fix(ai/anthropic): request current Claude Code OAuth scopes

### DIFF
--- a/packages/ai/src/utils/oauth/anthropic.ts
+++ b/packages/ai/src/utils/oauth/anthropic.ts
@@ -11,7 +11,7 @@ const AUTHORIZE_URL = "https://claude.ai/oauth/authorize";
 const TOKEN_URL = "https://api.anthropic.com/v1/oauth/token";
 const CALLBACK_PORT = 54545;
 const CALLBACK_PATH = "/callback";
-const SCOPES = "org:create_api_key user:profile user:inference";
+const SCOPES = "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
 
 function formatErrorDetails(error: unknown): string {
 	if (error instanceof Error) {

--- a/packages/ai/test/anthropic-oauth.test.ts
+++ b/packages/ai/test/anthropic-oauth.test.ts
@@ -20,7 +20,9 @@ describe("anthropic oauth alignment", () => {
 		const authUrl = new URL(url);
 
 		expect(authUrl.origin + authUrl.pathname).toBe("https://claude.ai/oauth/authorize");
-		expect(authUrl.searchParams.get("scope")).toBe("org:create_api_key user:profile user:inference");
+		expect(authUrl.searchParams.get("scope")).toBe(
+			"user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload",
+		);
 		expect(authUrl.searchParams.get("state")).toBe(state);
 		expect(authUrl.searchParams.get("redirect_uri")).toBe(redirectUri);
 		expect(authUrl.searchParams.get("code_challenge_method")).toBe("S256");


### PR DESCRIPTION
## Problem

The Anthropic OAuth login requests an outdated scope set, so its consent screen no longer matches recent Claude Code versions. Logging in with omp shows only:

- Access your Anthropic profile information (`user:profile`)
- Contribute to your Claude subscription usage (`user:inference`)

whereas current Claude Code requests:

- Access your Anthropic profile information (`user:profile`)
- Contribute to your Claude subscription usage (`user:inference`)
- **Access your Claude Code sessions** (`user:sessions:claude_code`)
- **Use and manage your connectors** (`user:mcp_servers`)
- **Upload files on your behalf** (`user:file_upload`)

The omitted scopes mean omp's OAuth grant doesn't carry the Claude Code session, MCP connector, and file-upload capabilities the current first-party client's grant does. (CLIProxyAPI requests this exact set for the same reason.)

## Change

`SCOPES` in `packages/ai/src/utils/oauth/anthropic.ts`:

```diff
-const SCOPES = "org:create_api_key user:profile user:inference";
+const SCOPES = "user:profile user:inference user:sessions:claude_code user:mcp_servers user:file_upload";
```

`org:create_api_key` is dropped because the Anthropic flow authenticates with the OAuth access token (`sk-ant-oat…`) directly and never exchanges the grant for a minted API key — the only `createApiKey*` helpers in the tree are the unrelated API-key-paste login flows for other providers, so the scope was unused. Removing it also makes the consent match the current Claude Code screen exactly.

Refresh is unaffected (`grant_type=refresh_token` sends no `scope`), so existing stored credentials keep working; the new scope set applies to new logins only.

## Verification

`bun test test/anthropic-oauth.test.ts` → **14 pass / 0 fail** (the scope assertion in `test/anthropic-oauth.test.ts` is updated to the new string).