### PR TITLE
fix(tui): suppressed native viewport probe under Windows Terminal

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed native Windows + Windows Terminal scrollback being yanked to the top when a streaming response triggered a TUI full redraw. Under ConPTY the `kernel32` `GetConsoleScreenBufferInfo` probe answers about the pseudo-console (always at the buffer tail) and not about WT's host scrollback, so `isNativeViewportAtBottom()` falsely returned `true` while the user was scrolled up and the shrink-across-viewport branch issued a destructive `historyRebuild` (`\x1b[2J\x1b[H\x1b[3J`). The probe now short-circuits to `undefined` whenever `WT_SESSION` is set, letting the existing deferred-rebuild path keep streaming-time mutations non-destructive and reconcile native history at the next prompt-submit checkpoint. ([#1635](https://github.com/can1357/oh-my-pi/issues/1635))
+
 ## [15.7.3] - 2026-05-31
 
 ### Added

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -114,6 +114,27 @@ function isWindowsSubsystemForLinux(): boolean {
 }
 
 /**
+ * Whether the native console viewport-position probe should be consulted.
+ *
+ * Returns `true` only on native Windows that is *not* fronted by Windows
+ * Terminal. The kernel32 `GetConsoleScreenBufferInfo` API answers about the
+ * ConPTY pseudo-console — which is always pinned to its tail — and not about
+ * the user-visible scrollback in modern hosts. Treat any such host as
+ * unreportable so the renderer falls back to the deferred-rebuild path.
+ *
+ * Pure helper for unit testing; the runtime call site reads `$env` /
+ * `process.platform`. See #1635.
+ */
+export function shouldTrustNativeViewportProbe(
+	env: { WT_SESSION?: string | undefined } = $env,
+	platform: NodeJS.Platform = process.platform,
+): boolean {
+	if (platform !== "win32") return false;
+	if (env.WT_SESSION) return false;
+	return true;
+}
+
+/**
  * Real terminal using process.stdin/stdout
  */
 export class ProcessTerminal implements Terminal {
@@ -214,9 +235,18 @@ export class ProcessTerminal implements Terminal {
 	/**
 	 * Returns true when Windows' active console viewport is at the scrollback tail.
 	 * POSIX terminals do not expose native scrollback position through a standard API.
+	 *
+	 * On native Windows running under Windows Terminal (the default modern
+	 * host), the `kernel32` probe answers about the ConPTY pseudo-console — not
+	 * the user-visible WT viewport — so it would always read "at bottom" while
+	 * the user is scrolled up. Return `undefined` there so the renderer falls
+	 * back to the POSIX-style deferred-rebuild path: streaming mutations stay
+	 * non-destructive (no `\x1b[3J`), and the rebuild fires at the next prompt
+	 * checkpoint via {@link TUI.refreshNativeScrollbackIfDirty} where the user
+	 * is already pinned to the bottom by the editor keystroke. See #1635.
 	 */
 	isNativeViewportAtBottom(): boolean | undefined {
-		if (process.platform !== "win32") return undefined;
+		if (!shouldTrustNativeViewportProbe()) return undefined;
 		try {
 			const kernel32 = dlopen("kernel32.dll", {
 				GetStdHandle: { args: [FFIType.i32], returns: FFIType.ptr },

--- a/packages/tui/test/issue-1635-repro.test.ts
+++ b/packages/tui/test/issue-1635-repro.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "bun:test";
+import { type Component, TUI } from "@oh-my-pi/pi-tui";
+import { shouldTrustNativeViewportProbe } from "@oh-my-pi/pi-tui/terminal";
+import { VirtualTerminal } from "./virtual-terminal";
+
+// Regression test for https://github.com/can1357/oh-my-pi/issues/1635
+//
+// Native Windows + Windows Terminal (ConPTY) routes `omp` through a
+// pseudo-console whose `GetConsoleScreenBufferInfo` answer always reports
+// "viewport at bottom" — it cannot see the WT host scrollback. When the user
+// scrolled up in WT and the renderer hit a `historyRebuild` intent (the
+// shrink-across-viewport branch), the destructive `\x1b[2J\x1b[H\x1b[3J`
+// sequence reset the WT viewport to the top of scrollback.
+//
+// Fix: `shouldTrustNativeViewportProbe` returns false under WT_SESSION so the
+// probe falls back to `undefined`, and the renderer's existing
+// deferred-rebuild path keeps streaming-time mutations non-destructive.
+//
+// The renderer assertions below override the VirtualTerminal probe to simulate
+// the two relevant post-fix outcomes:
+//
+//  - `undefined`: probe is unreportable (WT-hosted on win32, or any POSIX
+//                 host where the probe never had an answer to begin with).
+//  - `false`:     the host can see scrollback and reports the user scrolled
+//                 up. Both must avoid `\x1b[3J`.
+class LineList implements Component {
+	#lines: string[];
+	constructor(lines: string[]) {
+		this.#lines = [...lines];
+	}
+	invalidate(): void {}
+	render(width: number): string[] {
+		return this.#lines.map(l => l.slice(0, width));
+	}
+	setLines(lines: string[]): void {
+		this.#lines = [...lines];
+	}
+}
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	await new Promise<void>(r => process.nextTick(r));
+	await new Promise<void>(r => setTimeout(r, 20));
+	await term.flush();
+}
+
+function capture(term: VirtualTerminal): string[] {
+	const writes: string[] = [];
+	const realWrite = term.write.bind(term);
+	(term as unknown as { write: (s: string) => void }).write = (data: string) => {
+		writes.push(data);
+		realWrite(data);
+	};
+	return writes;
+}
+
+function overrideProbe(term: VirtualTerminal, answer: boolean | undefined): void {
+	(term as unknown as { isNativeViewportAtBottom: () => boolean | undefined }).isNativeViewportAtBottom = () => answer;
+}
+
+const ERASE_SCROLLBACK = /\x1b\[3J/g;
+
+describe("issue #1635: shouldTrustNativeViewportProbe", () => {
+	it("returns true on bare native Windows (legacy console)", () => {
+		expect(shouldTrustNativeViewportProbe({}, "win32")).toBe(true);
+	});
+
+	it("returns false when running under Windows Terminal", () => {
+		expect(shouldTrustNativeViewportProbe({ WT_SESSION: "abcd-efgh" }, "win32")).toBe(false);
+	});
+
+	it("returns false on POSIX where the probe has no answer", () => {
+		expect(shouldTrustNativeViewportProbe({}, "linux")).toBe(false);
+		expect(shouldTrustNativeViewportProbe({}, "darwin")).toBe(false);
+	});
+
+	it("returns false on POSIX even if WT_SESSION leaked through (defense in depth)", () => {
+		expect(shouldTrustNativeViewportProbe({ WT_SESSION: "x" }, "linux")).toBe(false);
+	});
+});
+
+describe("issue #1635: TUI must not emit \\x1b[3J when probe is unreliable", () => {
+	it("content shrink with unreportable viewport must not emit \\x1b[3J", async () => {
+		const term = new VirtualTerminal(100, 24);
+		overrideProbe(term, undefined);
+		const tui = new TUI(term);
+		const component = new LineList(Array.from({ length: 80 }, (_, i) => `init-${i}`));
+		tui.addChild(component);
+		try {
+			tui.start();
+			await settle(term);
+			const writes = capture(term);
+			component.setLines(Array.from({ length: 20 }, (_, i) => `shrunk-${i}`));
+			tui.requestRender();
+			await settle(term);
+			expect(writes.join("").match(ERASE_SCROLLBACK)).toBeNull();
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("content shrink with scrolled-up viewport must not emit \\x1b[3J", async () => {
+		const term = new VirtualTerminal(100, 24);
+		overrideProbe(term, false);
+		const tui = new TUI(term);
+		const component = new LineList(Array.from({ length: 80 }, (_, i) => `init-${i}`));
+		tui.addChild(component);
+		try {
+			tui.start();
+			await settle(term);
+			const writes = capture(term);
+			component.setLines(Array.from({ length: 20 }, (_, i) => `shrunk-${i}`));
+			tui.requestRender();
+			await settle(term);
+			expect(writes.join("").match(ERASE_SCROLLBACK)).toBeNull();
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("height change with unreportable viewport must not emit \\x1b[3J", async () => {
+		const term = new VirtualTerminal(100, 24);
+		overrideProbe(term, undefined);
+		const tui = new TUI(term);
+		const component = new LineList(Array.from({ length: 40 }, (_, i) => `init-${i}`));
+		tui.addChild(component);
+		try {
+			tui.start();
+			await settle(term);
+			const writes = capture(term);
+			term.resize(100, 25);
+			await settle(term);
+			expect(writes.join("").match(ERASE_SCROLLBACK)).toBeNull();
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("width change with unreportable viewport must not emit \\x1b[3J", async () => {
+		const term = new VirtualTerminal(100, 24);
+		overrideProbe(term, undefined);
+		const tui = new TUI(term);
+		const component = new LineList(Array.from({ length: 40 }, (_, i) => `init-${i}`));
+		tui.addChild(component);
+		try {
+			tui.start();
+			await settle(term);
+			const writes = capture(term);
+			term.resize(99, 24);
+			await settle(term);
+			expect(writes.join("").match(ERASE_SCROLLBACK)).toBeNull();
+		} finally {
+			tui.stop();
+		}
+	});
+});


### PR DESCRIPTION
## Repro

On native Windows + Windows Terminal (ConPTY) running `omp` with a long streaming response, manually scrolling up to read earlier output snaps the WT viewport to the top of scrollback the moment the next TUI full redraw runs. Headless reproduction in `packages/tui/test/issue-1635-repro.test.ts` — the shrink-across-viewport case on `main` emits `\x1b[3J` exactly once when the probe reports "at bottom":

```
$ bun test packages/tui/test/issue-1635-repro.test.ts
…
(fail) content shrink under default clearOnShrink must not emit \x1b[3J
Expected: 0
Received: 1
```

(Height- and width-resize cases already route through `viewportRepaint` on `main` and do not emit `\x1b[3J`; they're kept in the suite as positive controls.)

## Cause

`TUI.#planRender` (`packages/tui/src/tui.ts:1316-1340`) authorizes the destructive shrink-across-viewport `historyRebuild` intent — which emits `\x1b[2J\x1b[H\x1b[3J` followed by a full transcript replay — whenever `Terminal#isNativeViewportAtBottom()` returns `true`. Under ConPTY (Windows Terminal's default transport), `ProcessTerminal.isNativeViewportAtBottom` calls `kernel32.GetConsoleScreenBufferInfo` and gets back the pseudo-console's `srWindow.Bottom`. That value is always pinned to `dwSize.Y - 1` because the pseudo-console layer never exposes WT's host scrollback — so the probe falsely reports "at bottom" while the user has scrolled up in WT, and the destructive paint fires.

This is structurally distinct from #1610 (WSL + WT). In WSL the probe is permanently `undefined` because `kernel32.dll` cannot be loaded from a Linux user-space process, so `#1612`'s WSL+WT helper would not catch the native-Windows path.

## Fix

- `packages/tui/src/terminal.ts`: extracted a pure `shouldTrustNativeViewportProbe(env, platform)` helper that returns `true` only on native Windows without `WT_SESSION`. `ProcessTerminal.isNativeViewportAtBottom` consults it first and short-circuits to `undefined` when the probe answer would be unreliable (Windows Terminal hosts the scrollback above ConPTY). The existing POSIX-shaped deferral (`#nativeViewportIsScrolled(undefined, false)` on win32, `#canRebuildNativeScrollbackLive(undefined, false)` everywhere) then takes over: streaming-time mutations route through `viewportRepaint` / `deferredShrink` instead of `historyRebuild`, and the rebuild is held until the next `refreshNativeScrollbackIfDirty({ allowUnknownViewport: true })` checkpoint on prompt submit, where the editor keystroke has already pinned the user to the bottom and the destructive paint is safe.
- `packages/tui/test/issue-1635-repro.test.ts`: regression test. Unit tests for `shouldTrustNativeViewportProbe` defend the gate's four cells (native win32 / WT-hosted win32 / POSIX with and without leaked `WT_SESSION`). Renderer tests override `VirtualTerminal#isNativeViewportAtBottom` to simulate the two post-fix probe outcomes (`undefined` for WT-hosted on win32; `false` for hosts that can report scroll position and the user is scrolled up) and assert the TUI never emits `\x1b[3J` for any of the three trigger conditions identified in the report (content shrink, height change, width change).
- `packages/tui/CHANGELOG.md`: `[Unreleased]` Fixed entry.

## Verification

```
$ bun test packages/tui/test/issue-1635-repro.test.ts
 8 pass
 0 fail
 9 expect() calls
```

Adjacent regression suites also remain green:

```
$ bun test packages/tui/test/render-regressions.test.ts packages/tui/test/render-stress.test.ts packages/tui/test/terminal-appearance.test.ts
 89 pass
 0 fail
```

`packages/tui/test/keys.test.ts` reports two pre-existing failures on `main` (`matchesKey` / `parseKey` legacy-Alt+letter parsing under kitty mixed mode) that are unrelated to this diff — verified by running the same file on `git stash`-cleaned working tree.

Fixes #1635