### PR TITLE
minimizer: add AI tool, binary tool, and Rust tool filters with command detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1097,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,8 +1226,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1222,9 +1239,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1414,6 +1433,104 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,6 +1604,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
 name = "icu_provider"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,6 +1681,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "ignore"
@@ -1650,6 +1828,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,6 +1944,12 @@ checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markup5ever"
@@ -2468,6 +2658,7 @@ dependencies = [
  "libc",
  "os_pipe",
  "regex",
+ "reqwest",
  "serde",
  "serde_json",
  "smallvec",
@@ -2534,6 +2725,15 @@ dependencies = [
  "serde_core",
  "writeable",
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -2627,6 +2827,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases 0.2.1",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash 2.1.2",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2668,6 +2923,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -2683,6 +2939,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2693,6 +2959,9 @@ name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rand_core"
@@ -2788,12 +3057,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
 name = "rgb"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 dependencies = [
  "bytemuck",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2841,10 +3164,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
@@ -2933,6 +3297,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3108,6 +3484,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3116,6 +3498,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -3288,6 +3679,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3313,6 +3719,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3370,6 +3786,51 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.12.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -3992,6 +4453,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "type-map"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4059,6 +4526,24 @@ name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
 
 [[package]]
 name = "utf-8"
@@ -4165,6 +4650,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4217,6 +4711,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4388,6 +4892,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4532,6 +5045,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4987,12 +5509,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
+ "yoke",
+ "zerofrom",
  "zerovec",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -297,6 +297,15 @@ tiktoken-rs = "0.11"
 brush-parser = "0.3"
 
 # ──────────────────────────────────────────────────────────────────────────────
+# HTTP Client (opt-in: ai-smart minimizer filter)
+# ──────────────────────────────────────────────────────────────────────────────
+reqwest = { version = "0.12", default-features = false, features = [
+   "blocking",
+   "json",
+   "rustls-tls",
+] }
+
+# ──────────────────────────────────────────────────────────────────────────────
 # AST & Tree-Sitter
 # ──────────────────────────────────────────────────────────────────────────────
 ast-grep-core = { version = "0.39", default-features = false, features = [

--- a/crates/pi-natives/Cargo.toml
+++ b/crates/pi-natives/Cargo.toml
@@ -9,6 +9,12 @@ repository.workspace = true
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+## Forward pi-shell's AI-summary filter feature so the runtime
+## `aiSmartEnabled`/`aiSmartProvider` knobs actually toggle behavior. Off by
+## default; enabled by the native build via `napi build --features ai-smart`.
+ai-smart = ["pi-shell/ai-smart"]
+
 [lints]
 workspace = true
 

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -25,33 +25,50 @@ use crate::task;
 #[derive(Debug, Clone, Default)]
 pub struct MinimizerOptions {
 	/// Master switch. Absent / false = disabled.
-	pub enabled:           Option<bool>,
+	pub enabled:              Option<bool>,
 	/// Optional path to a TOML settings file whose values override
 	/// field-level defaults. `~` is expanded.
-	pub settings_path:     Option<String>,
+	pub settings_path:        Option<String>,
 	/// Optional xxHash64 digest (hex) of the settings file contents. When
 	/// supplied, the engine refuses to honor a settings file whose hash does
 	/// not match — a lightweight trust gate for agent-controllable paths.
-	pub settings_hash:     Option<String>,
+	pub settings_hash:        Option<String>,
 	/// Opt-in allowlist of program names (e.g. `"git"`). When empty or
 	/// absent, all built-in filters are active.
-	pub only:              Option<Vec<String>>,
+	pub only:                 Option<Vec<String>>,
 	/// Program names explicitly excluded from minimization.
-	pub except:            Option<Vec<String>>,
+	pub except:               Option<Vec<String>>,
 	/// Maximum captured bytes per command before the engine falls back to
 	/// the raw, un-minimized output. Default 4 MiB.
-	pub max_capture_bytes: Option<u32>,
+	pub max_capture_bytes:    Option<u32>,
+	/// Source-outline level for `cat <source-file>` minimization. Accepts
+	/// `"default"` (current behavior) or `"aggressive"` (strip function bodies).
+	pub source_outline_level: Option<String>,
+	/// Master switch for the AI-summary filter (W4 / rtk smart). Default off.
+	pub ai_smart_enabled:     Option<bool>,
+	/// Provider key for the AI summarizer (e.g. `"deepseek"`). Default
+	/// `"deepseek"` when `ai_smart_enabled` is true.
+	pub ai_smart_provider:    Option<String>,
+	/// Kill-switch to fall back to the pre-PR (legacy) filter behavior for
+	/// grep / find / pytest. When `Some(true)`, filters that opted into the
+	/// always-shrink Tier 1 / Tier 2 behavior skip the new code path. When
+	/// `None`, defers to the `OMP_MINIMIZER_LEGACY_FILTERS` env var.
+	pub legacy_filters:       Option<bool>,
 }
 
 impl From<MinimizerOptions> for minimizer::MinimizerOptions {
 	fn from(value: MinimizerOptions) -> Self {
 		Self {
-			enabled:           value.enabled,
-			settings_path:     value.settings_path,
-			settings_hash:     value.settings_hash,
-			only:              value.only,
-			except:            value.except,
-			max_capture_bytes: value.max_capture_bytes,
+			enabled:              value.enabled,
+			settings_path:        value.settings_path,
+			settings_hash:        value.settings_hash,
+			only:                 value.only,
+			except:               value.except,
+			max_capture_bytes:    value.max_capture_bytes,
+			source_outline_level: value.source_outline_level,
+			ai_smart_enabled:     value.ai_smart_enabled,
+			ai_smart_provider:    value.ai_smart_provider,
+			legacy_filters:       value.legacy_filters,
 		}
 	}
 }

--- a/crates/pi-shell/Cargo.toml
+++ b/crates/pi-shell/Cargo.toml
@@ -6,6 +6,11 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 
+[features]
+## Enable the AI-summary filter (W4 / rtk smart). Off by default.
+## Pulls in the blocking HTTP client used by `minimizer::filters::ai_smart`.
+ai-smart = ["dep:reqwest"]
+
 [lints]
 workspace = true
 
@@ -18,6 +23,7 @@ brush-parser.workspace = true
 clap.workspace = true
 os_pipe.workspace = true
 regex.workspace = true
+reqwest = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/pi-shell/src/minimizer.rs
+++ b/crates/pi-shell/src/minimizer.rs
@@ -44,8 +44,11 @@ pub struct MinimizerOutput {
 	/// Byte length of `text` after minimization.
 	#[allow(dead_code, reason = "test-only API surface")]
 	pub output_bytes:  usize,
-	/// Name of the dispatch path that produced this output (e.g. `"git"`,
-	/// `"pipeline:gradle"`, or `"passthrough"`). Useful for telemetry.
+	/// Label for the dispatch path that produced this output (e.g. `"git"`,
+	/// `"pipeline:gradle"`, or `"passthrough"`). For non-rewrite misses, this
+	/// carries the reason label (e.g. `"compound"`, `"piped"`, `"parse-error"`,
+	/// `"too-large"`, `"disabled"`, `"unknown"`, `"unsupported"`,
+	/// `"pipeline-noop"`).
 	pub filter:        &'static str,
 	/// Original (un-minimized) capture, surfaced only when the filter
 	/// actually rewrote the output. The caller (JS session layer) is expected
@@ -79,7 +82,7 @@ impl MinimizerOutput {
 	}
 
 	/// Attach a `filter` label (e.g. `"git"`, `"pipeline:gradle"`) to an
-	/// output for telemetry. No-op on passthrough outputs.
+	/// output for telemetry, including non-rewrite miss reasons.
 	#[must_use]
 	pub const fn labeled(mut self, filter: &'static str) -> Self {
 		self.filter = filter;
@@ -113,8 +116,29 @@ impl MinimizerOutput {
 	}
 }
 
+/// Aggregate output for a segmented chain.
+#[allow(
+	clippy::missing_const_for_fn,
+	reason = "kept non-const because this constructs owned output used only at runtime"
+)]
+pub(crate) fn chain_output(
+	text: String,
+	original_text: String,
+	input_bytes: usize,
+	changed: bool,
+) -> MinimizerOutput {
+	let filter = if changed { "chain" } else { "chain-noop" };
+	let output_bytes = text.len();
+	MinimizerOutput {
+		text,
+		changed,
+		input_bytes,
+		output_bytes,
+		filter,
+		original_text: Some(original_text),
+	}
+}
 /// Apply the configured filter pipeline to a captured buffer.
-///
 /// Returns the original text unchanged when minimization is disabled, no
 /// filter matches, or a filter panics.
 pub fn apply(
@@ -124,4 +148,16 @@ pub fn apply(
 	config: &MinimizerConfig,
 ) -> MinimizerOutput {
 	engine::apply(command, captured, exit_code, config)
+}
+
+/// Like [`apply`], but never runs the AI-summary overlay. Used by the
+/// segmented-chain runner so an N-segment chain cannot fire N AI calls — the
+/// AI overlay's cost/privacy budget is scoped to a single whole-command apply.
+pub fn apply_segment(
+	command: &str,
+	captured: &str,
+	exit_code: i32,
+	config: &MinimizerConfig,
+) -> MinimizerOutput {
+	engine::apply_segment(command, captured, exit_code, config)
 }

--- a/crates/pi-shell/src/minimizer/config.rs
+++ b/crates/pi-shell/src/minimizer/config.rs
@@ -17,51 +17,105 @@ use serde::Deserialize;
 use crate::minimizer::pipeline::{self, PipelineRegistry, SUPPORTED_SCHEMA_VERSION};
 
 const DEFAULT_MAX_CAPTURE_BYTES: u32 = 4 * 1024 * 1024;
+const DEFAULT_AI_SMART_PROVIDER: &str = "deepseek";
+
+/// Source-outline aggressiveness for `cat <source-file>` minimization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutlineLevel {
+	/// Current behavior: only outline when input is large enough to warrant it.
+	#[default]
+	Default,
+	/// Strip function/method bodies regardless of size for supported source
+	/// languages (`ts`, `tsx`, `js`, `jsx`, `py`, `rs`, `go`).
+	Aggressive,
+}
+
+impl OutlineLevel {
+	fn parse(raw: &str) -> Option<Self> {
+		match raw.trim().to_ascii_lowercase().as_str() {
+			"default" | "" => Some(Self::Default),
+			"aggressive" => Some(Self::Aggressive),
+			_ => None,
+		}
+	}
+}
 
 /// N-API opt-in handle for the minimizer.
 #[derive(Debug, Clone, Default)]
 pub struct MinimizerOptions {
 	/// Master switch. Absent / false = disabled.
-	pub enabled:           Option<bool>,
+	pub enabled:              Option<bool>,
 	/// Optional path to a TOML settings file whose values override
 	/// field-level defaults. `~` is expanded.
-	pub settings_path:     Option<String>,
+	pub settings_path:        Option<String>,
 	/// Optional xxHash64 digest (hex) of the settings file contents. When
 	/// supplied, the engine refuses to honor a settings file whose hash does
 	/// not match — a lightweight trust gate for agent-controllable paths.
-	pub settings_hash:     Option<String>,
+	pub settings_hash:        Option<String>,
 	/// Opt-in allowlist of program names (e.g. `"git"`). When empty or
 	/// absent, all built-in filters are active.
-	pub only:              Option<Vec<String>>,
+	pub only:                 Option<Vec<String>>,
 	/// Program names explicitly excluded from minimization.
-	pub except:            Option<Vec<String>>,
+	pub except:               Option<Vec<String>>,
 	/// Maximum captured bytes per command before the engine falls back to
 	/// the raw, un-minimized output. Default 4 MiB.
-	pub max_capture_bytes: Option<u32>,
+	pub max_capture_bytes:    Option<u32>,
+	/// Source-outline level for `cat <source-file>` minimization. Accepts
+	/// `"default"` (current behavior) or `"aggressive"` (strip function bodies).
+	pub source_outline_level: Option<String>,
+	/// Master switch for the AI-summary filter (W4 / rtk smart). Default off.
+	pub ai_smart_enabled:     Option<bool>,
+	/// Provider key for the AI summarizer (e.g. `"deepseek"`). Default
+	/// `"deepseek"` when [`Self::ai_smart_enabled`] is true.
+	pub ai_smart_provider:    Option<String>,
+	/// Kill-switch to fall back to the pre-PR (legacy) filter behavior for
+	/// grep / find / pytest. When `Some(true)`, filters that opted into the
+	/// always-shrink Tier 1 / Tier 2 behavior skip the new code path and
+	/// return the legacy passthrough. When `None`, defers to the
+	/// `OMP_MINIMIZER_LEGACY_FILTERS` environment variable (truthy = "1",
+	/// "true", or "yes", case-insensitive); default `false`.
+	pub legacy_filters:       Option<bool>,
 }
 
 /// Resolved minimizer configuration used by the engine.
 #[derive(Debug, Clone)]
 pub struct MinimizerConfig {
-	pub enabled:           bool,
-	pub only:              HashSet<String>,
-	pub except:            HashSet<String>,
-	pub max_capture_bytes: u32,
-	pub per_command:       HashMap<String, toml::Value>,
+	pub enabled:               bool,
+	pub only:                  HashSet<String>,
+	pub except:                HashSet<String>,
+	pub max_capture_bytes:     u32,
+	pub per_command:           HashMap<String, toml::Value>,
 	/// Compiled user-defined pipelines parsed from `settings_path`. Searched
 	/// before the built-in pipelines so user filters win.
-	pub user_pipelines:    Option<Arc<PipelineRegistry>>,
+	pub user_pipelines:        Option<Arc<PipelineRegistry>>,
+	/// Aggressiveness for source-outline body stripping in `compact_cat_output`.
+	pub source_outline_level:  OutlineLevel,
+	/// Master switch for the AI summary filter (W4). When false, the filter
+	/// is a no-op passthrough.
+	pub ai_smart_enabled:      bool,
+	/// Provider key for the AI summarizer (defaults to `"deepseek"`).
+	pub ai_smart_provider:     String,
+	/// Resolved kill-switch: when true, opted-in filters (Tier 1 grep/find,
+	/// Tier 2 pytest) return the pre-PR legacy behavior. Resolved at
+	/// `from_options()` time from caller-supplied
+	/// `MinimizerOptions.legacy_filters` or the `OMP_MINIMIZER_LEGACY_FILTERS`
+	/// env var; default `false`.
+	pub legacy_filters_active: bool,
 }
 
 impl Default for MinimizerConfig {
 	fn default() -> Self {
 		Self {
-			enabled:           false,
-			only:              HashSet::new(),
-			except:            HashSet::new(),
-			max_capture_bytes: DEFAULT_MAX_CAPTURE_BYTES,
-			per_command:       HashMap::new(),
-			user_pipelines:    None,
+			enabled:               false,
+			only:                  HashSet::new(),
+			except:                HashSet::new(),
+			max_capture_bytes:     DEFAULT_MAX_CAPTURE_BYTES,
+			per_command:           HashMap::new(),
+			user_pipelines:        None,
+			source_outline_level:  OutlineLevel::Default,
+			ai_smart_enabled:      false,
+			ai_smart_provider:     DEFAULT_AI_SMART_PROVIDER.to_string(),
+			legacy_filters_active: false,
 		}
 	}
 }
@@ -82,6 +136,23 @@ impl MinimizerConfig {
 		}
 		if let Some(n) = opts.max_capture_bytes {
 			cfg.max_capture_bytes = n.max(1024);
+		}
+		if let Some(raw) = opts.source_outline_level.as_deref()
+			&& let Some(level) = OutlineLevel::parse(raw)
+		{
+			cfg.source_outline_level = level;
+		}
+		if let Some(v) = opts.ai_smart_enabled {
+			cfg.ai_smart_enabled = v;
+		}
+		cfg.legacy_filters_active = resolve_legacy_filters(
+			opts.legacy_filters,
+			std::env::var("OMP_MINIMIZER_LEGACY_FILTERS").ok().as_deref(),
+		);
+		if let Some(provider) = opts.ai_smart_provider.as_deref()
+			&& !provider.is_empty()
+		{
+			cfg.ai_smart_provider = provider.to_string();
 		}
 		if let Some(path) = opts.settings_path.as_deref()
 			&& !path.is_empty()
@@ -141,18 +212,26 @@ impl MinimizerConfig {
 	pub fn per_command(&self, program: &str) -> Option<&toml::Value> {
 		self.per_command.get(&program.to_lowercase())
 	}
+
+	/// Whether opted-in filters should fall back to pre-PR legacy behavior.
+	pub const fn legacy_filters_active(&self) -> bool {
+		self.legacy_filters_active
+	}
 }
 
 #[derive(Debug, Default, Deserialize)]
 struct SettingsFile {
 	#[serde(default)]
-	schema_version:    Option<u32>,
-	enabled:           Option<bool>,
-	only:              Option<Vec<String>>,
-	except:            Option<Vec<String>>,
-	max_capture_bytes: Option<u32>,
+	schema_version:       Option<u32>,
+	enabled:              Option<bool>,
+	only:                 Option<Vec<String>>,
+	except:               Option<Vec<String>>,
+	max_capture_bytes:    Option<u32>,
+	source_outline_level: Option<String>,
+	ai_smart_enabled:     Option<bool>,
+	ai_smart_provider:    Option<String>,
 	#[serde(flatten)]
-	tables:            HashMap<String, toml::Value>,
+	tables:               HashMap<String, toml::Value>,
 }
 
 impl SettingsFile {
@@ -178,11 +257,39 @@ impl SettingsFile {
 		if let Some(n) = self.max_capture_bytes {
 			cfg.max_capture_bytes = n.max(1024);
 		}
+		if let Some(raw) = self.source_outline_level.as_deref()
+			&& let Some(level) = OutlineLevel::parse(raw)
+		{
+			cfg.source_outline_level = level;
+		}
+		if let Some(v) = self.ai_smart_enabled {
+			cfg.ai_smart_enabled = v;
+		}
+		if let Some(provider) = self.ai_smart_provider
+			&& !provider.is_empty()
+		{
+			cfg.ai_smart_provider = provider;
+		}
 		for (k, v) in self.tables {
 			if v.is_table() && k != "filters" && k != "tests" {
 				cfg.per_command.insert(k.to_lowercase(), v);
 			}
 		}
+	}
+}
+
+/// Resolve the effective `legacy_filters_active` flag from the caller option
+/// and the raw `OMP_MINIMIZER_LEGACY_FILTERS` env value.
+///
+/// Pure so it can be unit-tested without mutating the process-global
+/// environment (the test harness runs tests in one process in parallel). An
+/// explicit option always wins; otherwise a truthy env value enables the
+/// legacy path.
+fn resolve_legacy_filters(option: Option<bool>, env_value: Option<&str>) -> bool {
+	match option {
+		Some(v) => v,
+		None => env_value
+			.is_some_and(|raw| matches!(raw.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes")),
 	}
 }
 
@@ -264,5 +371,55 @@ mod tests {
 			..Default::default()
 		});
 		assert!(cfg.enabled);
+	}
+
+	#[test]
+	fn legacy_filters_option_some_true_sets_active() {
+		// Explicit caller-supplied `Some(true)` must result in
+		// `legacy_filters_active == true` regardless of env. This is the
+		// test-friendly invocation path that avoids env-var mutation.
+		let cfg = MinimizerConfig::from_options(&MinimizerOptions {
+			enabled: Some(true),
+			legacy_filters: Some(true),
+			..Default::default()
+		});
+		assert!(cfg.legacy_filters_active());
+	}
+
+	#[test]
+	fn legacy_filters_option_some_false_overrides_env() {
+		// Explicit `Some(false)` must override any env var (verified by
+		// inspecting the resolver — `Some(_)` arm short-circuits before
+		// reading the env). We assert behavior via a default-constructed
+		// `MinimizerOptions { legacy_filters: Some(false), .. }`.
+		let cfg = MinimizerConfig::from_options(&MinimizerOptions {
+			enabled: Some(true),
+			legacy_filters: Some(false),
+			..Default::default()
+		});
+		assert!(!cfg.legacy_filters_active());
+	}
+
+	#[test]
+	fn resolve_legacy_filters_prefers_option_over_env() {
+		// The pure resolver lets us exercise every branch without mutating the
+		// process-global env var (which would race the parallel test harness).
+		assert!(super::resolve_legacy_filters(Some(true), Some("0")));
+		assert!(!super::resolve_legacy_filters(Some(false), Some("1")));
+	}
+
+	#[test]
+	fn resolve_legacy_filters_defaults_false_without_env() {
+		assert!(!super::resolve_legacy_filters(None, None));
+	}
+
+	#[test]
+	fn resolve_legacy_filters_honors_truthy_env_when_option_absent() {
+		for raw in ["1", "true", "yes", " TRUE ", "Yes"] {
+			assert!(super::resolve_legacy_filters(None, Some(raw)), "{raw:?} should enable");
+		}
+		for raw in ["0", "false", "no", ""] {
+			assert!(!super::resolve_legacy_filters(None, Some(raw)), "{raw:?} should not enable");
+		}
 	}
 }

--- a/crates/pi-shell/src/minimizer/defs/gcc.toml
+++ b/crates/pi-shell/src/minimizer/defs/gcc.toml
@@ -3,7 +3,7 @@
 
 [filters.gcc]
 description = "Compact gcc/g++ compiler output — strip notes, keep errors and warnings"
-match_command = "^(gcc|g\\+\\+)$"
+match_command = "^(gcc|g\\+\\+|clang|clang\\+\\+)$"
 strip_ansi = true
 strip_lines_matching = [
   "^\\s*$",
@@ -50,3 +50,23 @@ expected = "/usr/bin/ld: /tmp/main.o: undefined reference to 'missing_func'\ncol
 name = "empty input returns on_empty message"
 input = ""
 expected = "gcc: ok"
+
+[[tests.gcc]]
+name = "clang variant errors"
+input = """
+foo.c:3:10: fatal error: 'missing.h' file not found
+#include "missing.h"
+         ^~~~~~~~~~~
+1 error generated.
+"""
+expected = "foo.c:3:10: fatal error: 'missing.h' file not found\n#include \"missing.h\"\n         ^~~~~~~~~~~\n"
+
+[[tests.gcc]]
+name = "clang++ variant errors"
+input = """
+foo.cpp:8:5: error: unknown type name 'Widget'
+    Widget w;
+    ^
+1 error generated.
+"""
+expected = "foo.cpp:8:5: error: unknown type name 'Widget'\n    Widget w;\n    ^\n"

--- a/crates/pi-shell/src/minimizer/detect.rs
+++ b/crates/pi-shell/src/minimizer/detect.rs
@@ -168,6 +168,71 @@ fn skip_time_options(tokens: &[String], mut index: usize) -> Option<usize> {
 	Some(index)
 }
 
+fn skip_aws_global_options(args: &[String]) -> Option<usize> {
+	const VALUE_FLAGS: &[&str] = &[
+		"--profile",
+		"--region",
+		"--endpoint-url",
+		"--cli-binary-format",
+		"--output",
+		"--cli-read-timeout",
+		"--cli-connect-timeout",
+		"--ca-bundle",
+		"--color",
+		"--query",
+		"--cli-input-json",
+		"--cli-input-yaml",
+	];
+	const BOOL_FLAGS: &[&str] = &[
+		"--no-cli-pager",
+		"--debug",
+		"--no-verify-ssl",
+		"--no-paginate",
+		"--no-sign-request",
+		"--cli-auto-prompt",
+		"--no-cli-auto-prompt",
+	];
+
+	let mut index = 0;
+	while let Some(arg) = args.get(index) {
+		if arg == "--" {
+			return args.get(index + 1).map(|_| index + 1);
+		}
+		if BOOL_FLAGS.contains(&arg.as_str()) {
+			index += 1;
+			continue;
+		}
+		if arg == "--generate-cli-skeleton" {
+			index += 1;
+			if args
+				.get(index)
+				.is_some_and(|value| matches!(value.as_str(), "input" | "output" | "yaml-input"))
+			{
+				index += 1;
+			}
+			continue;
+		}
+		if arg.starts_with("--generate-cli-skeleton=") {
+			index += 1;
+			continue;
+		}
+		if option_consumes_value(arg, VALUE_FLAGS) {
+			index = if option_has_inline_value(arg, VALUE_FLAGS) {
+				index + 1
+			} else {
+				index + 2
+			};
+			continue;
+		}
+		break;
+	}
+	if index > args.len() {
+		None
+	} else {
+		Some(index)
+	}
+}
+
 fn skip_option_value(tokens: &[String], index: usize) -> Option<usize> {
 	let token = tokens.get(index)?;
 	if token.starts_with("--") && token.contains('=') {
@@ -292,6 +357,9 @@ fn detect_subcommand(program: &str, args: &[String]) -> Option<String> {
 			&["--verbose", "--quiet", "--no-color"],
 			&[],
 		),
+		"aws" => skip_aws_global_options(args)
+			.and_then(|index| args.get(index))
+			.map(|arg| arg.to_lowercase()),
 		"jest" | "vitest" => first_non_global_arg(args, &[], &[], &[]),
 		_ => args
 			.iter()
@@ -463,6 +531,17 @@ mod tests {
 	}
 
 	#[test]
+	fn detects_direct_lint_tools() {
+		let command = detect("eslint src/foo.ts").expect("eslint command is detected");
+		assert_eq!(command.program, "eslint");
+		assert_eq!(command.subcommand.as_deref(), Some("src/foo.ts"));
+
+		let command = detect("tsc --project tsconfig.json").expect("tsc command is detected");
+		assert_eq!(command.program, "tsc");
+		assert_eq!(command.subcommand.as_deref(), Some("tsconfig.json"));
+	}
+
+	#[test]
 	fn detects_gt_through_wrappers_and_globals() {
 		let command = detect("env GRAPHITE_TOKEN=x command gt --repo owner/repo submit --stack")
 			.expect("gt command is detected");
@@ -476,6 +555,64 @@ mod tests {
 		assert_eq!(command.program, "gt");
 		assert_eq!(command.subcommand.as_deref(), Some("sync"));
 	}
+
+	#[test]
+	fn skips_aws_global_options() {
+		let command = detect(
+			"aws --profile foo --region=us-east-1 --endpoint-url http://localhost:4566 \
+			 --no-cli-pager --generate-cli-skeleton output s3 ls",
+		)
+		.expect("aws command is detected");
+		assert_eq!(command.program, "aws");
+		assert_eq!(command.subcommand.as_deref(), Some("s3"));
+	}
+
+	#[test]
+	fn aws_double_dash_terminates_global_options() {
+		let command = detect("aws -- --literal-service op").expect("aws command is detected");
+		assert_eq!(command.program, "aws");
+		assert_eq!(command.subcommand.as_deref(), Some("--literal-service"));
+	}
+
+	#[test]
+	fn aws_global_option_permutations_keep_service_subcommand() {
+		let flags = [
+			"--profile dev",
+			"--region us-east-1",
+			"--endpoint-url=http://localhost:4566",
+			"--cli-binary-format raw-in-base64-out",
+			"--output json",
+			"--cli-read-timeout=5",
+			"--cli-connect-timeout 5",
+			"--ca-bundle /tmp/ca.pem",
+			"--color off",
+			"--query Buckets[].Name",
+			"--cli-input-json file://input.json",
+			"--cli-input-yaml file://input.yaml",
+			"--no-cli-pager",
+			"--debug",
+			"--no-verify-ssl",
+			"--no-paginate",
+			"--no-sign-request",
+			"--cli-auto-prompt",
+			"--no-cli-auto-prompt",
+			"--generate-cli-skeleton",
+			"--generate-cli-skeleton=output",
+		];
+		for idx in 0..128 {
+			let mut command = String::from("aws");
+			for (bit, flag) in flags.iter().enumerate() {
+				if idx & (1 << (bit % 7)) != 0 && (idx + bit) % 3 == 0 {
+					command.push(' ');
+					command.push_str(flag);
+				}
+			}
+			command.push_str(" lambda list-functions");
+			let detected = detect(&command).expect("aws command is detected");
+			assert_eq!(detected.subcommand.as_deref(), Some("lambda"), "{command}");
+		}
+	}
+
 }
 
 #[test]

--- a/crates/pi-shell/src/minimizer/engine.rs
+++ b/crates/pi-shell/src/minimizer/engine.rs
@@ -8,6 +8,8 @@ use std::{
 	},
 };
 
+#[cfg(feature = "ai-smart")]
+use crate::minimizer::filters::ai_smart;
 use crate::minimizer::{
 	MinimizerConfig, MinimizerCtx, MinimizerOutput, detect, filters,
 	pipeline::{self, CompiledPipeline, PipelineRegistry},
@@ -21,6 +23,8 @@ pub enum MinimizerMode {
 	None,
 	/// Capture the whole command and apply one filter to the whole buffer.
 	WholeCommand,
+	/// Execute a safe `&&` / `;` chain segment-by-segment.
+	SegmentedChain,
 }
 
 /// Return the minimization mode for a command.
@@ -32,6 +36,13 @@ pub fn mode_for(command: &str, config: &MinimizerConfig) -> MinimizerMode {
 			};
 			if identity_has_filter(&identity, config) {
 				MinimizerMode::WholeCommand
+			} else {
+				MinimizerMode::None
+			}
+		},
+		plan::CommandPlan::Chain { segments } => {
+			if chain_has_eligible_segment(&segments, config) {
+				MinimizerMode::SegmentedChain
 			} else {
 				MinimizerMode::None
 			}
@@ -65,6 +76,32 @@ pub fn apply(
 	exit_code: i32,
 	config: &MinimizerConfig,
 ) -> MinimizerOutput {
+	apply_inner(command, captured, exit_code, config, true)
+}
+
+/// Like [`apply`], but never runs the AI-summary overlay.
+///
+/// Used by the segmented-chain runner, which calls the minimizer once per
+/// segment. The AI overlay's cost/privacy budget is scoped to a single
+/// `apply()` invocation, so letting each segment run it would make an N-segment
+/// chain fire up to N external provider calls. Segments are minimized with
+/// deterministic filters only; the AI overlay applies solely to whole commands.
+pub fn apply_segment(
+	command: &str,
+	captured: &str,
+	exit_code: i32,
+	config: &MinimizerConfig,
+) -> MinimizerOutput {
+	apply_inner(command, captured, exit_code, config, false)
+}
+
+fn apply_inner(
+	command: &str,
+	captured: &str,
+	exit_code: i32,
+	config: &MinimizerConfig,
+	allow_ai: bool,
+) -> MinimizerOutput {
 	let input_bytes = captured.len();
 
 	if input_bytes > config.max_capture_bytes as usize {
@@ -72,11 +109,15 @@ pub fn apply(
 	}
 
 	// Structural guard: this whole-buffer path only handles single simple
-	// commands. Compound commands and pipes can feed downstream parsers
-	// (awk, jq, rg, …), so rewriting their combined output is a correctness
-	// bug.
+	// commands. Safe chains are intentionally kept opaque here so the engine
+	// can only segment them when the shell executes each piece separately.
+	// Pipes can feed downstream parsers (awk, jq, rg, …), so rewriting their
+	// combined output is a correctness bug.
 	match plan::analyze(command) {
 		plan::CommandPlan::Single { .. } => {},
+		plan::CommandPlan::Chain { segments } => {
+			return apply_chain(command, &segments, captured, exit_code, config);
+		},
 		plan::CommandPlan::Piped => {
 			return MinimizerOutput::passthrough(captured).labeled("piped");
 		},
@@ -92,7 +133,142 @@ pub fn apply(
 		record_unknown_command(command);
 		return MinimizerOutput::passthrough(captured).labeled("unknown");
 	};
-	apply_identity(&identity, command, captured, exit_code, config)
+	let output = apply_identity(&identity, command, captured, exit_code, config);
+	if allow_ai {
+		apply_ai_smart_overlay(&identity, command, captured, config, output)
+	} else {
+		output
+	}
+}
+
+/// Optional AI-summary post-step (W4 / rtk smart). Gated by both the Cargo
+/// feature `ai-smart` and the runtime `ai_smart_enabled` config flag, and
+/// further gated inside [`ai_smart::maybe_summarize`] on input size, parent
+/// context (pipe/compound bypass), credential availability, and the per-
+/// `apply()` budget. On any gate failure or network error we return the
+/// upstream `output` untouched — this filter is fail-closed.
+#[cfg_attr(
+	not(feature = "ai-smart"),
+	allow(
+		unused_variables,
+		clippy::needless_pass_by_value,
+		reason = "off-feature build keeps call-site signature stable"
+	)
+)]
+#[allow(
+	clippy::missing_const_for_fn,
+	reason = "feature-enabled implementation performs non-const AI budget and summarization work"
+)]
+fn apply_ai_smart_overlay(
+	identity: &detect::CommandIdentity,
+	command: &str,
+	captured: &str,
+	config: &MinimizerConfig,
+	output: MinimizerOutput,
+) -> MinimizerOutput {
+	#[cfg(feature = "ai-smart")]
+	{
+		if !config.ai_smart_enabled {
+			return output;
+		}
+		ai_smart::reset_apply_budget();
+		let subcommand = identity.subcommand.as_deref();
+		let ctx = MinimizerCtx { program: &identity.program, subcommand, command, config };
+		let candidate = if output.changed {
+			output.text.as_str()
+		} else {
+			captured
+		};
+		match ai_smart::maybe_summarize(&ctx, candidate) {
+			Some(summary) => {
+				let original_text = output
+					.original_text
+					.clone()
+					.unwrap_or_else(|| captured.to_string());
+				let input_bytes = output.input_bytes.max(captured.len());
+				let summarized = MinimizerOutput::transformed(summary, input_bytes).labeled("ai-smart");
+				summarized.with_original(original_text)
+			},
+			None => output,
+		}
+	}
+	#[cfg(not(feature = "ai-smart"))]
+	{
+		let _ = (identity, command, captured, config);
+		output
+	}
+}
+
+/// Apply the per-segment dispatch path for a `Chain { segments }` plan.
+///
+/// The FFI whole-buffer entry point sees the entire chain's captured stdout
+/// (interleaved across segments) — we cannot split it per-segment. Instead we
+/// recurse into a single filter chosen heuristically (Mode α resolution from
+/// T0-OBSERVATION):
+///
+/// 1. If every segment program is `git`/`yadm`, treat the chain as one big git
+///    invocation and route through the git filter. Captures the dominant
+///    real-data pattern (`git A && git B && git C` chains).
+/// 2. Otherwise route through the first segment's filter when that filter is
+///    supported. This recovers bytes when the first segment dominates the
+///    captured output.
+/// 3. Kill-switch parity (M2): if `legacy_filters_active` is set, return
+///    passthrough.labeled("compound") regardless of segment shape so callers
+///    can rollback this change without recompile.
+fn apply_chain(
+	command: &str,
+	segments: &[plan::ChainSegment],
+	captured: &str,
+	exit_code: i32,
+	config: &MinimizerConfig,
+) -> MinimizerOutput {
+	if config.legacy_filters_active() {
+		return MinimizerOutput::passthrough(captured).labeled("compound");
+	}
+
+	// (d) git-only chain: route through the git filter using the first
+	// segment's subcommand as the routing key. The git filter requires
+	// a concrete subcommand (status/diff/log/...) so we cannot dispatch
+	// with `subcommand=None` here — fall back to chain-first when no
+	// dispatchable subcommand is detected.
+	if !segments.is_empty()
+		&& segments
+			.iter()
+			.all(|seg| matches!(seg.program.as_str(), "git" | "yadm"))
+		&& config.is_program_enabled("git")
+		&& let Some(identity) = detect::detect(&segments[0].command)
+		&& filters::supports(&identity.program, identity.subcommand.as_deref())
+	{
+		let subcommand = identity.subcommand.as_deref();
+		let ctx = MinimizerCtx { program: &identity.program, subcommand, command, config };
+		let out = match catch_unwind(AssertUnwindSafe(|| filters::filter(&ctx, captured, exit_code)))
+		{
+			Ok(out) => out,
+			Err(_) => MinimizerOutput::passthrough(captured),
+		};
+		return ensure_success_visible(out.labeled("chain-git"), exit_code).with_original(captured);
+	}
+
+	// (b) Mixed chain: recurse into the first segment's filter when supported.
+	if let Some(first) = segments.first()
+		&& let Some(identity) = detect::detect(&first.command)
+	{
+		let subcommand = identity.subcommand.as_deref();
+		if config.is_program_enabled(&identity.program)
+			&& filters::supports(&identity.program, subcommand)
+		{
+			let ctx = MinimizerCtx { program: &identity.program, subcommand, command, config };
+			let out =
+				match catch_unwind(AssertUnwindSafe(|| filters::filter(&ctx, captured, exit_code))) {
+					Ok(out) => out,
+					Err(_) => MinimizerOutput::passthrough(captured),
+				};
+			return ensure_success_visible(out.labeled("chain-first"), exit_code)
+				.with_original(captured);
+		}
+	}
+
+	MinimizerOutput::passthrough(captured).labeled("compound")
 }
 
 fn identity_has_filter(identity: &detect::CommandIdentity, config: &MinimizerConfig) -> bool {
@@ -103,6 +279,66 @@ fn identity_has_filter(identity: &detect::CommandIdentity, config: &MinimizerCon
 	let subcommand = identity.subcommand.as_deref();
 	filters::supports(&identity.program, subcommand)
 		|| resolve_pipeline(config, &identity.program, subcommand).is_some()
+}
+
+fn chain_has_eligible_segment(segments: &[plan::ChainSegment], config: &MinimizerConfig) -> bool {
+	segments.iter().any(|segment| {
+		detect::detect(&segment.command)
+			.is_some_and(|identity| identity_has_filter(&identity, config))
+			|| is_common_chain_utility(&segment.program)
+	})
+}
+
+/// Common shell utilities that on their own would not warrant whole-command
+/// minimization, but whose presence in a `&&` / `;` chain alongside other
+/// segments is enough to fire the segmented chain runner. Each such segment
+/// is captured and passes through `minimizer::apply` which will treat it as
+/// `Single` with no matching filter and stream the text unchanged.
+fn is_common_chain_utility(program: &str) -> bool {
+	matches!(
+		program,
+		"echo"
+			| "printf"
+			| "head"
+			| "tail"
+			| "file"
+			| "which"
+			| "type"
+			| "sed"
+			| "awk"
+			| "sleep"
+			| "seq"
+			| "cp" | "mv"
+			| "rm" | "mkdir"
+			| "rmdir"
+			| "touch"
+			| "basename"
+			| "dirname"
+			| "realpath"
+			| "readlink"
+			| "true"
+			| "false"
+			| "yes"
+			| "tr" | "tee"
+			| "sort"
+			| "uniq"
+			| "cut"
+			| "paste"
+			| "rev"
+			| "split"
+			| "comm"
+			| "patch"
+			| "xargs"
+			| "unzip"
+			| "zip"
+			| "tar"
+			| "gzip"
+			| "gunzip"
+			| "cd" | "pwd"
+			| "export"
+			| "env"
+			| "test"
+	)
 }
 
 fn apply_identity(
@@ -190,6 +426,10 @@ fn program_label(program: &str) -> &'static str {
 		"rake" => "rake",
 		"rails" => "rails",
 		"rubocop" => "rubocop",
+		"rustfmt" => "rustfmt",
+		"xxd" => "xxd",
+		"strings" => "strings",
+		"od" => "od",
 		"tsc" => "tsc",
 		"eslint" => "eslint",
 		"biome" => "biome",
@@ -312,14 +552,51 @@ pub fn verify_builtin_filters() -> Vec<pipeline::TestOutcome> {
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+	use std::fs;
 
+	use super::*;
+	use crate::minimizer::MinimizerOptions;
+	fn config_from_settings(contents: &str) -> MinimizerConfig {
+		let path = std::env::temp_dir()
+			.join(format!("pi-shell-minimizer-engine-{}.toml", std::process::id()));
+		fs::write(&path, contents).expect("write minimizer settings");
+		let cfg = MinimizerConfig::from_options(&MinimizerOptions {
+			enabled: Some(true),
+			settings_path: Some(path.to_string_lossy().into_owned()),
+			..Default::default()
+		});
+		let _ = fs::remove_file(path);
+		cfg
+	}
 	#[test]
 	fn disabled_config_does_not_minimize() {
 		let cfg = MinimizerConfig::default();
 		assert!(!should_minimize("git status", &cfg));
 		let out = apply("git status", "## main\n", 0, &cfg);
 		assert!(!out.changed);
+	}
+
+	#[test]
+	fn disabled_minimizer_and_disabled_program_do_not_transform_supported_command() {
+		let input = "diff --git a/file.rs b/file.rs\n@@\n-old\n+new\n";
+
+		let disabled = MinimizerConfig::default();
+		assert!(!should_minimize("git diff", &disabled));
+		let out = apply("git diff", input, 0, &disabled);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+		assert_eq!(out.filter, "disabled");
+
+		let except_git = MinimizerConfig {
+			enabled: true,
+			except: ["git".to_string()].into_iter().collect(),
+			..Default::default()
+		};
+		assert!(!should_minimize("git diff", &except_git));
+		let out = apply("git diff", input, 0, &except_git);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+		assert_eq!(out.filter, "disabled");
 	}
 
 	#[test]
@@ -332,13 +609,14 @@ mod tests {
 	}
 
 	#[test]
-	fn enabled_config_does_not_minimize_git_status() {
+	fn enabled_config_minimizes_git_status() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
-		assert!(!should_minimize("git status", &cfg));
+		assert!(should_minimize("git status", &cfg));
 		let input = "## main\n M file.rs\n";
 		let out = apply("git status", input, 0, &cfg);
-		assert!(!out.changed);
-		assert_eq!(out.text, input);
+		assert!(out.changed);
+		assert!(out.text.contains("unstaged 1"));
+		assert_eq!(out.filter, "git");
 	}
 
 	#[test]
@@ -356,6 +634,27 @@ mod tests {
 		assert_eq!(out.text, "OK\n");
 		assert_eq!(out.output_bytes, out.text.len());
 		assert!(out.original_text.is_some());
+	}
+
+	#[test]
+	fn successful_user_pipeline_empty_output_returns_visible_ok() {
+		let cfg = config_from_settings(
+			r#"
+schema_version = 1
+[filters.empty_ok]
+match_command = "^printf$"
+strip_lines_matching = [".*"]
+"#,
+		);
+
+		assert!(should_minimize("printf done", &cfg));
+		let out = apply("printf done", "drop me\n", 0, &cfg);
+
+		assert!(out.changed);
+		assert_eq!(out.text, "OK\n");
+		assert_eq!(out.filter, "pipeline");
+		assert_eq!(out.output_bytes, out.text.len());
+		assert_eq!(out.original_text.as_deref(), Some("drop me\n"));
 	}
 
 	#[test]
@@ -378,11 +677,42 @@ mod tests {
 	}
 
 	#[test]
-	fn compound_and_piped_commands_do_not_minimize() {
+	fn segmented_chain_mode_is_only_for_eligible_safe_chains() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
-		assert_eq!(mode_for("echo start ; git status", &cfg), MinimizerMode::None);
-		assert_eq!(mode_for("false && git status", &cfg), MinimizerMode::None);
+		assert_eq!(
+			mode_for("git diff --stat && git diff --name-only", &cfg),
+			MinimizerMode::SegmentedChain
+		);
+		assert_eq!(mode_for("git diff ; printf done", &cfg), MinimizerMode::SegmentedChain);
+		// Common shell utilities make a chain eligible for the segmented runner
+		// even when no segment has a dedicated filter — segments stream through
+		// per-segment passthrough so the chain itself is captured for telemetry.
+		assert_eq!(mode_for("false && echo no ; echo yes", &cfg), MinimizerMode::SegmentedChain);
+		assert_eq!(mode_for("foo || bar", &cfg), MinimizerMode::None);
 		assert_eq!(mode_for("git status | cat", &cfg), MinimizerMode::None);
+		assert_eq!(mode_for("sleep 1 &", &cfg), MinimizerMode::None);
+		assert_eq!(mode_for("(cd foo && make)", &cfg), MinimizerMode::None);
+	}
+
+	#[test]
+	fn segmented_chain_supported_command_does_not_record_unknown() {
+		// Phase 7 (Mode α resolution): supported chains route through
+		// filters::dispatch via the chain decomposer instead of falling
+		// back to passthrough. The unknown-command counter must remain
+		// stable — the chain entry point is structurally known.
+		reset_unknown_command_count();
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = "diff --git a/file.rs b/file.rs\n@@\n-old\n+new\n";
+		let before = unknown_command_count();
+
+		assert_eq!(mode_for("git diff ; printf done", &cfg), MinimizerMode::SegmentedChain);
+		let out = apply("git diff ; printf done", input, 0, &cfg);
+
+		// First segment is `git diff`, second is `printf`. Not all-git, so
+		// route via chain-first (git filter on the captured diff).
+		assert!(out.changed, "git-led chain should be rewritten by chain-first dispatch");
+		assert_eq!(out.filter, "chain-first");
+		assert_eq!(unknown_command_count(), before);
 	}
 
 	#[test]
@@ -414,6 +744,60 @@ mod tests {
 		assert_eq!(gtest.filter, "gtest");
 		assert!(!gtest.text.contains("Foo.Pass"));
 		assert!(gtest.text.contains("foo_test.cc:42: Failure"));
+	}
+
+	#[test]
+	fn git_only_chain_routes_through_git_filter() {
+		// Phase 7 (Mode α resolution): `git A && git B` chains route through
+		// the git filter on the whole captured buffer.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let command = "git status && git log -1";
+		let input = "## main\n M file.rs\n";
+		let out = apply(command, input, 0, &cfg);
+		assert!(out.changed, "git-only chain should be rewritten by the git filter");
+		assert_eq!(out.filter, "chain-git");
+		assert!(
+			out.text.contains("unstaged 1") || out.text.contains("OK"),
+			"chain-git output should resemble git filter output: {:?}",
+			out.text
+		);
+	}
+
+	#[test]
+	fn mixed_chain_routes_through_first_program() {
+		// Phase 7: a chain whose first segment is git routes through the git
+		// filter even when later segments are unrelated. The captured buffer
+		// is interleaved, but routing via the dominant first segment still
+		// recovers bytes most of the time.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let command = "git status && ls -la";
+		let input = "## main\n M file.rs\n";
+		let out = apply(command, input, 0, &cfg);
+		assert!(out.changed);
+		assert_eq!(out.filter, "chain-first");
+	}
+
+	#[test]
+	fn unsupported_first_segment_chain_is_passthrough() {
+		// Phase 7: chains whose first segment has no filter fall back to
+		// passthrough labeled "compound" (preserves legacy behavior).
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let out = apply("zzzobscure && zzznever", "noise\n", 0, &cfg);
+		assert!(!out.changed);
+		assert_eq!(out.filter, "compound");
+	}
+
+	#[test]
+	fn chain_legacy_filters_active_passes_through() {
+		// Phase 7 kill-switch parity (M2): legacy_filters_active=true returns
+		// passthrough.labeled("compound") regardless of segment shape.
+		let mut cfg = MinimizerConfig::default();
+		cfg.enabled = true;
+		cfg.legacy_filters_active = true;
+		let input = "## main\n M file.rs\n";
+		let out = apply("git status && git log -1", input, 0, &cfg);
+		assert!(!out.changed);
+		assert_eq!(out.filter, "compound");
 	}
 }
 

--- a/crates/pi-shell/src/minimizer/filters/ai_smart.rs
+++ b/crates/pi-shell/src/minimizer/filters/ai_smart.rs
@@ -63,15 +63,15 @@ const SYSTEM_PROMPT: &str = include_str!("ai_smart_system_prompt.md");
 //
 // Lives in a thread-local because the existing shell entrypoints invoke
 // `engine::apply` synchronously and threading a counter cell through the
-// existing call sites would require touching `shell.rs` (out of W2's
-// approved touch set). Each top-level `apply` call resets the budget to 1.
+// existing call sites would require touching `shell.rs`. Each top-level
+// `apply` call resets the budget to 1.
 //
-// Limitation vs. AC4.9: when shell.rs runs a chain by invoking
-// `minimizer::apply` per segment, the budget resets per segment — a
-// 5-segment chain that all carry AI-eligible output would fire up to 5
-// times rather than once. Cross-segment enforcement needs a budget cell
-// threaded from the chain runner in shell.rs; that wiring is documented as
-// follow-up in the worker-2 completion report.
+// Chains are bounded structurally rather than by this counter: the segmented
+// chain runner minimizes each segment through `engine::apply_segment`, which
+// runs deterministic filters only and never invokes the AI overlay. The AI
+// summarizer therefore fires at most once — on a whole single command — and
+// makes zero provider calls for a segmented chain, keeping the cost/privacy
+// contract intact.
 #[cfg(feature = "ai-smart")]
 thread_local! {
 	static AI_BUDGET: std::cell::Cell<u8> = const { std::cell::Cell::new(0) };

--- a/crates/pi-shell/src/minimizer/filters/ai_smart.rs
+++ b/crates/pi-shell/src/minimizer/filters/ai_smart.rs
@@ -1,0 +1,383 @@
+//! AI-summary filter (W4 / rtk smart).
+//!
+//! This module is feature-gated behind `ai-smart` (off by default). The
+//! off-feature build still exposes the same public surface via a const-`None`
+//! stub so call sites in `engine.rs` compile uniformly regardless of feature
+//! state.
+//!
+//! Threat model & design intent (mirrors plan AC4.1-AC4.9):
+//! - **Opt-in.** `MinimizerConfig::ai_smart_enabled` must be `true`. Default is
+//!   `false`, which means an unmodified build of the agent never makes an AI
+//!   call.
+//! - **Bounded.** Hard caps: 8 KB input, 5 s timeout, 200 max-tokens response.
+//!   Single retry on transient transport errors only.
+//! - **Fail-closed.** Any error path (network, non-2xx, parse, empty body,
+//!   missing API key, budget exhausted, parent is pipe/compound) returns `None`
+//!   so the caller falls back to the original (un-AI-summarized) output. The
+//!   filter never emits partial garbage.
+//! - **Pipe-safe.** Piped and compound commands bypass the AI entirely —
+//!   downstream parsers (`awk`, `jq`, `rg`, …) must see deterministic bytes.
+
+use crate::minimizer::MinimizerCtx;
+
+/// Maximum captured bytes we are willing to ship to the AI provider.
+pub const MAX_INPUT_BYTES: usize = 8 * 1024;
+/// Hard upper bound on the response size we'll request.
+#[cfg_attr(
+	not(feature = "ai-smart"),
+	allow(dead_code, reason = "off-feature build exposes constants only for API parity")
+)]
+pub const MAX_RESPONSE_TOKENS: u32 = 200;
+/// Wall-clock timeout for the whole AI round-trip.
+#[cfg_attr(
+	not(feature = "ai-smart"),
+	allow(dead_code, reason = "off-feature build exposes constants only for API parity")
+)]
+pub const REQUEST_TIMEOUT_SECS: u64 = 5;
+/// Pinned deepseek model (plan AC4.5). Executor must RFC if upstream
+/// retires this id — never silently downgrade to `deepseek-chat`.
+#[cfg_attr(
+	not(feature = "ai-smart"),
+	allow(dead_code, reason = "off-feature build exposes constants only for API parity")
+)]
+pub const DEEPSEEK_MODEL: &str = "deepseek-v4-flash";
+/// Deepseek OpenAI-compatible chat-completions endpoint.
+#[cfg_attr(
+	not(feature = "ai-smart"),
+	allow(dead_code, reason = "off-feature build exposes constants only for API parity")
+)]
+pub const DEEPSEEK_ENDPOINT: &str = "https://api.deepseek.com/v1/chat/completions";
+/// Env var that carries the credential. Plan AC4.1.
+pub const API_KEY_ENV: &str = "OMP_AI_SMART_API_KEY";
+
+/// System prompt — stored as a sibling `.md` file and embedded at compile time
+/// so it lives outside the Rust source as a reviewable artifact while staying
+/// auditable from the crate. Two-line summarizer (plan Step 4.3).
+#[cfg_attr(
+	not(feature = "ai-smart"),
+	allow(dead_code, reason = "off-feature build keeps prompt colocated with feature code")
+)]
+const SYSTEM_PROMPT: &str = include_str!("ai_smart_system_prompt.md");
+
+// Single-call budget tracked per `engine::apply` invocation (plan AC4.9).
+//
+// Lives in a thread-local because the existing shell entrypoints invoke
+// `engine::apply` synchronously and threading a counter cell through the
+// existing call sites would require touching `shell.rs` (out of W2's
+// approved touch set). Each top-level `apply` call resets the budget to 1.
+//
+// Limitation vs. AC4.9: when shell.rs runs a chain by invoking
+// `minimizer::apply` per segment, the budget resets per segment — a
+// 5-segment chain that all carry AI-eligible output would fire up to 5
+// times rather than once. Cross-segment enforcement needs a budget cell
+// threaded from the chain runner in shell.rs; that wiring is documented as
+// follow-up in the worker-2 completion report.
+#[cfg(feature = "ai-smart")]
+thread_local! {
+	static AI_BUDGET: std::cell::Cell<u8> = const { std::cell::Cell::new(0) };
+}
+
+/// Reset the per-`apply()` AI budget. Call once at the top of
+/// `engine::apply` when the AI filter is feature-enabled and configured on.
+#[cfg(feature = "ai-smart")]
+pub fn reset_apply_budget() {
+	AI_BUDGET.with(|c| c.set(1));
+}
+
+#[cfg(not(feature = "ai-smart"))]
+pub const fn reset_apply_budget() {}
+
+/// Try to summarize `captured` via the configured AI provider. Returns the
+/// summary text on success, or `None` whenever any preflight gate or the
+/// network call itself fails (the caller treats `None` as "leave existing
+/// output untouched").
+#[cfg(feature = "ai-smart")]
+pub fn maybe_summarize(ctx: &MinimizerCtx<'_>, captured: &str) -> Option<String> {
+	if !ctx.config.ai_smart_enabled {
+		return None;
+	}
+	if captured.len() > MAX_INPUT_BYTES {
+		return None;
+	}
+	if captured.trim().is_empty() {
+		return None;
+	}
+	if parent_is_pipe_or_compound(ctx.command) {
+		return None;
+	}
+	if !consume_budget() {
+		return None;
+	}
+	let api_key = match std::env::var(API_KEY_ENV) {
+		Ok(value) if !value.is_empty() => value,
+		_ => return None,
+	};
+	let provider = ctx.config.ai_smart_provider.as_str();
+	match provider {
+		"deepseek" => call_deepseek(&api_key, captured),
+		_ => None,
+	}
+}
+
+#[cfg(not(feature = "ai-smart"))]
+#[inline]
+pub const fn maybe_summarize(_ctx: &MinimizerCtx<'_>, _captured: &str) -> Option<String> {
+	None
+}
+
+#[cfg(feature = "ai-smart")]
+fn consume_budget() -> bool {
+	AI_BUDGET.with(|c| {
+		let remaining = c.get();
+		if remaining == 0 {
+			false
+		} else {
+			c.set(remaining - 1);
+			true
+		}
+	})
+}
+
+/// Best-effort check: did the calling command sit inside a pipe (`|`) or a
+/// compound construct (`(...)`, `$(...)`, backticks, redirection into another
+/// process)? We err on the side of caution — any indicator returns `true`
+/// which suppresses the AI call.
+#[cfg(feature = "ai-smart")]
+fn parent_is_pipe_or_compound(command: &str) -> bool {
+	let mut in_single = false;
+	let mut in_double = false;
+	let mut prev = '\0';
+	for ch in command.chars() {
+		match ch {
+			'\'' if prev != '\\' && !in_double => in_single = !in_single,
+			'"' if prev != '\\' && !in_single => in_double = !in_double,
+			'|' | '(' | ')' | '`' if !in_single && !in_double => return true,
+			_ => {},
+		}
+		prev = ch;
+	}
+	false
+}
+
+#[cfg(feature = "ai-smart")]
+fn call_deepseek(api_key: &str, captured: &str) -> Option<String> {
+	let body = serde_json::json!({
+		"model": DEEPSEEK_MODEL,
+		"max_tokens": MAX_RESPONSE_TOKENS,
+		"temperature": 0.0,
+		"messages": [
+			{ "role": "system", "content": SYSTEM_PROMPT },
+			{ "role": "user", "content": captured }
+		]
+	});
+
+	let client = reqwest::blocking::Client::builder()
+		.timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
+		.build()
+		.ok()?;
+
+	let mut last_transient_err = false;
+	for attempt in 0..2 {
+		let response = client
+			.post(DEEPSEEK_ENDPOINT)
+			.bearer_auth(api_key)
+			.json(&body)
+			.send();
+		match response {
+			Ok(res) => {
+				let status = res.status();
+				if status.is_success() {
+					let json: serde_json::Value = match res.json() {
+						Ok(value) => value,
+						Err(_) => return None,
+					};
+					return extract_first_message(&json);
+				}
+				// 5xx is transient and re-tryable; 4xx is configuration / quota
+				// and re-trying won't help.
+				if status.is_server_error() && attempt == 0 {
+					last_transient_err = true;
+					continue;
+				}
+				return None;
+			},
+			Err(err) => {
+				if (err.is_timeout() || err.is_connect()) && attempt == 0 {
+					last_transient_err = true;
+					continue;
+				}
+				return None;
+			},
+		}
+	}
+	let _ = last_transient_err;
+	None
+}
+
+/// Pull the first choice's `message.content` out of an OpenAI-compatible
+/// chat-completions response payload. Returns `None` on any shape mismatch.
+#[cfg(feature = "ai-smart")]
+fn extract_first_message(json: &serde_json::Value) -> Option<String> {
+	let text = json
+		.get("choices")?
+		.as_array()?
+		.first()?
+		.get("message")?
+		.get("content")?
+		.as_str()?;
+	let cleaned = sanitize_summary(text);
+	if cleaned.is_empty() {
+		None
+	} else {
+		Some(cleaned)
+	}
+}
+
+/// Scrub characters that would corrupt a chain transcript per AC-C4 (no
+/// ANSI escapes, no shell operators, no backticks).
+#[cfg(feature = "ai-smart")]
+fn sanitize_summary(text: &str) -> String {
+	let mut out = String::with_capacity(text.len());
+	let mut iter = text.chars().peekable();
+	while let Some(ch) = iter.next() {
+		match ch {
+			'\x1b' => {
+				// Drop the escape AND any CSI parameter bytes up to the final
+				// letter so we don't leave dangling SGR fragments.
+				while let Some(&peek) = iter.peek() {
+					iter.next();
+					if peek.is_ascii_alphabetic() {
+						break;
+					}
+				}
+			},
+			'`' => out.push('\''),
+			';' => out.push(','),
+			'&' => out.push('+'),
+			'\r' => continue,
+			ch if ch.is_control() && ch != '\n' && ch != '\t' => continue,
+			ch => out.push(ch),
+		}
+	}
+	while out.ends_with(|c: char| c.is_whitespace()) {
+		out.pop();
+	}
+	if !out.is_empty() {
+		out.push('\n');
+	}
+	out
+}
+
+#[cfg(all(test, feature = "ai-smart"))]
+mod tests {
+	use super::*;
+	use crate::minimizer::{MinimizerConfig, MinimizerCtx, config::OutlineLevel};
+
+	fn cfg() -> MinimizerConfig {
+		MinimizerConfig {
+			enabled: true,
+			ai_smart_enabled: true,
+			ai_smart_provider: "deepseek".into(),
+			source_outline_level: OutlineLevel::Default,
+			..Default::default()
+		}
+	}
+
+	fn ctx<'a>(command: &'a str, config: &'a MinimizerConfig) -> MinimizerCtx<'a> {
+		MinimizerCtx { program: "echo", subcommand: None, command, config }
+	}
+
+	#[test]
+	fn disabled_returns_none() {
+		let mut config = cfg();
+		config.ai_smart_enabled = false;
+		reset_apply_budget();
+		assert!(maybe_summarize(&ctx("echo hi", &config), "hi").is_none());
+	}
+
+	#[test]
+	fn empty_input_returns_none() {
+		let config = cfg();
+		reset_apply_budget();
+		assert!(maybe_summarize(&ctx("echo", &config), "").is_none());
+	}
+
+	#[test]
+	fn oversize_input_returns_none() {
+		let config = cfg();
+		reset_apply_budget();
+		let big = "x".repeat(MAX_INPUT_BYTES + 1);
+		assert!(maybe_summarize(&ctx("echo big", &config), &big).is_none());
+	}
+
+	#[test]
+	fn pipe_parent_returns_none() {
+		let config = cfg();
+		reset_apply_budget();
+		assert!(maybe_summarize(&ctx("echo hi | cat", &config), "hi").is_none());
+	}
+
+	#[test]
+	fn compound_parent_returns_none() {
+		let config = cfg();
+		reset_apply_budget();
+		assert!(maybe_summarize(&ctx("(echo hi)", &config), "hi").is_none());
+	}
+
+	#[test]
+	fn budget_exhausted_returns_none() {
+		// Reset, manually drain, then assert second call returns None even with
+		// API key set (we synthesize a fake one to pass that gate; the real
+		// network call won't happen because budget is consumed).
+		reset_apply_budget();
+		let config = cfg();
+		// Drain budget without hitting network: simulate by consuming directly.
+		assert!(consume_budget());
+		assert!(!consume_budget());
+		// New apply resets:
+		reset_apply_budget();
+		assert!(consume_budget());
+		// Touch maybe_summarize signature so dead-code lint doesn't fire when
+		// API_KEY is absent in CI.
+		drop(maybe_summarize(&ctx("echo hi", &config), "hi"));
+	}
+
+	#[test]
+	fn missing_api_key_returns_none() {
+		// SAFETY: tests run single-threaded by default; we restore on exit.
+		let prev = std::env::var(API_KEY_ENV).ok();
+		// SAFETY: clearing an env var in a single-threaded test context.
+		unsafe { std::env::remove_var(API_KEY_ENV) };
+		let config = cfg();
+		reset_apply_budget();
+		assert!(maybe_summarize(&ctx("echo hi", &config), "hi").is_none());
+		if let Some(value) = prev {
+			// SAFETY: restoring the prior value in a single-threaded test.
+			unsafe { std::env::set_var(API_KEY_ENV, value) };
+		}
+	}
+
+	#[test]
+	fn sanitize_strips_dangerous_chars() {
+		assert_eq!(sanitize_summary("hi `there`"), "hi 'there'\n");
+		assert_eq!(sanitize_summary("a;b&c"), "a,b+c\n");
+		assert_eq!(sanitize_summary("\x1b[31mred\x1b[0m"), "red\n");
+		assert_eq!(sanitize_summary("   "), "");
+	}
+
+	#[test]
+	fn extract_first_message_happy_path() {
+		let payload = serde_json::json!({
+			"choices": [
+				{ "message": { "role": "assistant", "content": "ok\nsaved 3 files" } }
+			]
+		});
+		assert_eq!(extract_first_message(&payload).as_deref(), Some("ok\nsaved 3 files\n"));
+	}
+
+	#[test]
+	fn extract_first_message_missing_returns_none() {
+		assert!(extract_first_message(&serde_json::json!({ "choices": [] })).is_none());
+		assert!(extract_first_message(&serde_json::json!({})).is_none());
+	}
+}

--- a/crates/pi-shell/src/minimizer/filters/ai_smart_system_prompt.md
+++ b/crates/pi-shell/src/minimizer/filters/ai_smart_system_prompt.md
@@ -1,0 +1,1 @@
+You are a 2-line summarizer for shell command output. Line 1: what happened. Line 2: most important number/path/error. Be terse.

--- a/crates/pi-shell/src/minimizer/filters/binary_tools.rs
+++ b/crates/pi-shell/src/minimizer/filters/binary_tools.rs
@@ -1,0 +1,121 @@
+//! Binary-inspection tool filters (Tier 3b): `xxd`, `strings`, `od`.
+//!
+//! These tools all share the same failure mode in the minimizer's
+//! `unknown` bucket: very long head-or-tail-or-elide outputs (5000+
+//! lines) on multi-megabyte binaries dwarf the 64 KB capture budget and
+//! waste the agent's context window on repetitive hex/string dumps. We
+//! preserve the first 50 lines and last 20 lines and elide the middle
+//! with a count marker — diagnostic anchors (magic bytes at the head,
+//! footer/trailer bytes at the tail) survive intact while the bulk
+//! middle is dropped.
+
+use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
+
+const HEAD_LINES: usize = 50;
+const TAIL_LINES: usize = 20;
+
+pub fn supports(program: &str, _subcommand: Option<&str>) -> bool {
+	matches!(program, "xxd" | "strings" | "od")
+}
+
+pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerOutput {
+	// Kill-switch parity (M2): legacy_filters_active=true skips this
+	// filter so callers can rollback without recompile.
+	if ctx.config.legacy_filters_active() {
+		return MinimizerOutput::passthrough(input);
+	}
+
+	let cleaned = primitives::strip_ansi(input);
+	let total_lines = cleaned.lines().count();
+	if total_lines <= HEAD_LINES + TAIL_LINES {
+		// Short dump — passthrough. Even errored runs are tiny enough
+		// here that the head/tail cap would not help.
+		let _ = exit_code;
+		return MinimizerOutput::passthrough(input);
+	}
+
+	let text = primitives::head_tail_lines(&cleaned, HEAD_LINES, TAIL_LINES);
+	if text == input {
+		MinimizerOutput::passthrough(input)
+	} else {
+		MinimizerOutput::transformed(text, input.len())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::minimizer::MinimizerConfig;
+
+	fn ctx<'a>(program: &'a str, command: &'a str, config: &'a MinimizerConfig) -> MinimizerCtx<'a> {
+		MinimizerCtx { program, subcommand: None, command, config }
+	}
+
+	fn build_lines(prefix: &str, count: usize) -> String {
+		let mut s = String::new();
+		for i in 0..count {
+			s.push_str(&format!("{prefix}{i:08x}\n"));
+		}
+		s
+	}
+
+	#[test]
+	fn xxd_long_dump_compacts_with_head_tail_marker() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = build_lines("00000000: ", 5000);
+		let context = ctx("xxd", "xxd /bin/ls", &cfg);
+		let out = filter(&context, &input, 0);
+		assert!(out.changed);
+		// 50 head + 20 tail + 1 marker = 71 lines
+		let line_count = out.text.lines().count();
+		assert_eq!(line_count, HEAD_LINES + TAIL_LINES + 1, "got {line_count} lines: {out:?}");
+		assert!(out.text.contains("lines omitted"));
+		// Head anchor preserved.
+		assert!(out.text.starts_with("00000000: 00000000"));
+	}
+
+	#[test]
+	fn xxd_short_dump_passthrough() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = build_lines("00000000: ", 60);
+		let context = ctx("xxd", "xxd small", &cfg);
+		let out = filter(&context, &input, 0);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn strings_long_output_compacts() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = build_lines("symbol_", 2000);
+		let context = ctx("strings", "strings /bin/ls", &cfg);
+		let out = filter(&context, &input, 0);
+		assert!(out.changed);
+		assert!(out.text.contains("lines omitted"));
+	}
+
+	#[test]
+	fn od_long_output_compacts() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = build_lines("0000000 ", 1500);
+		let context = ctx("od", "od -c /bin/ls", &cfg);
+		let out = filter(&context, &input, 0);
+		assert!(out.changed);
+		assert!(out.text.contains("lines omitted"));
+	}
+
+	#[test]
+	fn binary_tools_legacy_filters_active_passes_through() {
+		// Kill-switch parity (M2).
+		let mut cfg = MinimizerConfig::default();
+		cfg.enabled = true;
+		cfg.legacy_filters_active = true;
+		let input = build_lines("00000000: ", 5000);
+		for prog in ["xxd", "strings", "od"] {
+			let context = ctx(prog, "binary-tool", &cfg);
+			let out = filter(&context, &input, 0);
+			assert!(!out.changed, "{prog} should passthrough with kill-switch");
+			assert_eq!(out.text, input);
+		}
+	}
+}

--- a/crates/pi-shell/src/minimizer/filters/bun.rs
+++ b/crates/pi-shell/src/minimizer/filters/bun.rs
@@ -36,6 +36,9 @@ pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerO
 	{
 		return pkg::filter(ctx, input, exit_code);
 	}
+	if is_check_invocation(ctx.program, subcommand, ctx.command) {
+		return filter_bun_check(ctx, input, exit_code);
+	}
 	if is_test_invocation(ctx.program, subcommand, ctx.command) {
 		return node_tests::filter(ctx, input, exit_code);
 	}
@@ -66,17 +69,57 @@ fn is_test_invocation(program: &str, subcommand: Option<&str>, command: &str) ->
 		(program, subcommand),
 		("bun", Some("test")) | ("bunx", Some("jest" | "vitest" | "playwright"))
 	) || is_exec_package_subcommand(program, subcommand)
-		&& command_contains_tool(command, &["jest", "vitest", "playwright"])
+		&& (command_contains_tool(command, &["jest", "vitest", "playwright"])
+			|| command_contains_test_script(command))
+}
+fn command_contains_test_script(command: &str) -> bool {
+	command
+		.split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '|' | '&'))
+		.any(is_test_script_token)
+}
+fn is_test_script_token(token: &str) -> bool {
+	let token = token.trim_matches(|ch| matches!(ch, '\'' | '"' | '`'));
+	matches!(token, "test" | "t" | "e2e" | "spec") || token.starts_with("test:")
 }
 
 fn is_exec_package_subcommand(program: &str, subcommand: Option<&str>) -> bool {
 	matches!((program, subcommand), ("bun", Some("run" | "exec")))
 }
 
+fn is_check_invocation(program: &str, subcommand: Option<&str>, command: &str) -> bool {
+	is_exec_package_subcommand(program, subcommand) && command_contains_check_script(command)
+}
+
+fn command_contains_check_script(command: &str) -> bool {
+	command
+		.split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '|' | '&'))
+		.any(is_check_script_token)
+}
+
+fn is_check_script_token(token: &str) -> bool {
+	let token = token.trim_matches(|ch| matches!(ch, '\'' | '"' | '`'));
+	matches!(token, "check") || token.starts_with("check:")
+}
+
+fn is_lint_script_token(token: &str) -> bool {
+	let token = token.trim_matches(|ch| matches!(ch, '\'' | '"' | '`'));
+	matches!(token, "lint" | "typecheck" | "type-check")
+		|| token.starts_with("lint:")
+		|| token.starts_with("typecheck:")
+		|| token.starts_with("type-check:")
+}
+
+fn command_contains_lint_script(command: &str) -> bool {
+	command
+		.split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '|' | '&'))
+		.any(is_lint_script_token)
+}
+
 fn is_lint_invocation(program: &str, subcommand: Option<&str>, command: &str) -> bool {
 	matches!((program, subcommand), ("bun" | "bunx", Some("tsc" | "eslint" | "biome")))
 		|| is_exec_package_subcommand(program, subcommand)
-			&& command_contains_tool(command, &["tsc", "eslint", "biome"])
+			&& (command_contains_tool(command, &["tsc", "eslint", "biome"])
+				|| command_contains_lint_script(command))
 }
 
 fn is_js_tool_invocation(program: &str, subcommand: Option<&str>, command: &str) -> bool {
@@ -93,6 +136,138 @@ fn command_contains_tool(command: &str, tools: &[&str]) -> bool {
 	command
 		.split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '|' | '&'))
 		.any(|token| tools.contains(&token))
+}
+
+fn filter_bun_check(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerOutput {
+	let cleaned = primitives::strip_ansi(input);
+	let text = compact_bun_check_output(ctx, &cleaned, exit_code)
+		.unwrap_or_else(|| lint::condense_lint_output(ctx.program, &cleaned, exit_code));
+	if text == input {
+		MinimizerOutput::passthrough(input)
+	} else {
+		MinimizerOutput::transformed(text, input.len())
+	}
+}
+
+fn compact_bun_check_output(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> Option<String> {
+	let mut root_checked = false;
+	let mut packages: Vec<&str> = Vec::new();
+	let mut diagnostics: Vec<&str> = Vec::new();
+	let mut nonzero_exits: Vec<&str> = Vec::new();
+	let mut timeout: Option<&str> = None;
+
+	for line in input.lines() {
+		let trimmed = line.trim();
+		if trimmed.is_empty() {
+			continue;
+		}
+		let lower = trimmed.to_ascii_lowercase();
+		if lower.contains("timeout") || lower.contains("timed out") {
+			timeout = Some(trimmed);
+			continue;
+		}
+		if trimmed.starts_with("$ ") || lower.contains(" check: $ ") {
+			continue;
+		}
+		if let Some(package) = parse_checked_package(trimmed) {
+			if !packages.contains(&package) {
+				packages.push(package);
+			}
+			continue;
+		}
+		if lower.starts_with("checked ") && lower.contains("no fixes applied") {
+			root_checked = true;
+			continue;
+		}
+		if let Some(code) = parse_exited_code(trimmed) {
+			if code != "0" {
+				nonzero_exits.push(trimmed);
+			}
+			continue;
+		}
+		if is_bun_check_noise(trimmed, &lower) {
+			continue;
+		}
+		if exit_code != 0 && is_important(trimmed) {
+			diagnostics.push(trimmed);
+		}
+	}
+
+	if !root_checked && packages.is_empty() && diagnostics.is_empty() && nonzero_exits.is_empty() {
+		return None;
+	}
+
+	let mut out = String::new();
+	out.push_str(command_summary(ctx.command));
+	out.push_str(": ");
+	if !nonzero_exits.is_empty() || !diagnostics.is_empty() {
+		out.push_str("failed\n");
+	} else if timeout.is_some() {
+		out.push_str("visible checks passed; wrapper timed out\n");
+	} else if exit_code == 0 {
+		out.push_str("passed\n");
+	} else {
+		out.push_str("incomplete\n");
+	}
+	if root_checked {
+		out.push_str("root biome: ok\n");
+	}
+	if !packages.is_empty() {
+		out.push_str("packages checked: ");
+		out.push_str(&packages.join(", "));
+		out.push('\n');
+	}
+	if let Some(timeout) = timeout {
+		out.push_str("timeout: ");
+		out.push_str(trim_notice_brackets(timeout));
+		out.push('\n');
+	}
+	for line in nonzero_exits.iter().chain(diagnostics.iter()).take(40) {
+		out.push_str(line);
+		out.push('\n');
+	}
+	let omitted = nonzero_exits.len() + diagnostics.len();
+	if omitted > 40 {
+		out.push_str("… ");
+		out.push_str(&(omitted - 40).to_string());
+		out.push_str(" diagnostic lines omitted\n");
+	}
+	Some(out)
+}
+
+fn command_summary(command: &str) -> &str {
+	let mut parts = command.split_whitespace();
+	match (parts.next(), parts.next(), parts.next()) {
+		(Some("bun"), Some("run"), Some(script)) => {
+			script.trim_matches(|ch| matches!(ch, '\'' | '"' | '`'))
+		},
+		_ => "bun check",
+	}
+}
+
+fn parse_checked_package(line: &str) -> Option<&str> {
+	let (package, rest) = line.split_once(" check: Checked ")?;
+	if rest.contains("No fixes applied") {
+		Some(package)
+	} else {
+		None
+	}
+}
+
+fn parse_exited_code(line: &str) -> Option<&str> {
+	let (_, code) = line.rsplit_once("Exited with code ")?;
+	Some(code.trim())
+}
+
+fn is_bun_check_noise(line: &str, lower: &str) -> bool {
+	line.starts_with("$ ")
+		|| lower.contains(" check: $ ")
+		|| lower.starts_with("checked ")
+		|| lower.ends_with("no fixes applied.")
+}
+
+fn trim_notice_brackets(line: &str) -> &str {
+	line.trim_matches(|ch| matches!(ch, '[' | ']' | '⟦' | '⟧'))
 }
 
 fn filter_bun_build(input: &str, exit_code: i32) -> MinimizerOutput {
@@ -245,5 +420,121 @@ mod tests {
 		);
 		assert!(!out.text.contains("Bundled 12 modules"));
 		assert!(out.text.contains("error: missing export"));
+	}
+
+	#[test]
+	fn bun_run_test_routes_to_node_tests() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("bun", Some("run"), "bun run test", &cfg);
+		let out = filter(&ctx, "✓ pass 1\n✓ pass 2\nFAIL app.test.ts\nTests 1 failed, 2 passed\n", 1);
+		assert!(!out.text.contains("✓ pass 1"));
+		assert!(out.text.contains("FAIL app.test.ts"));
+		assert!(out.text.contains("Tests 1 failed, 2 passed"));
+	}
+
+	#[test]
+	fn bun_run_lint_and_typecheck_route_to_lint_filter() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = concat!(
+			"src/app.ts:1:1: error TS2322: Type 'string' is not assignable to type 'number'.\n",
+			"src/app.ts:2:1: error TS7006: Parameter 'x' implicitly has an 'any' type.\n",
+		);
+
+		for command in
+			["bun run lint", "bun run lint:ci", "bun run typecheck", "bun run typecheck:ci"]
+		{
+			let ctx = ctx("bun", Some("run"), command, &cfg);
+			let routed = filter(&ctx, input, 1).text;
+			let expected = lint::filter(&ctx, input, 1).text;
+			assert_eq!(routed, expected, "{command} should use lint filter");
+			assert!(
+				routed.contains("2 diagnostics in 1 files"),
+				"{command} should condense lint output"
+			);
+		}
+	}
+
+	#[test]
+	fn quoted_bun_run_test_routes_to_node_tests() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("bun", Some("run"), "bun run 'test'", &cfg);
+		let out = filter(&ctx, "✓ pass 1\nFAIL app.test.ts\nTests 1 failed, 1 passed\n", 1);
+		assert!(!out.text.contains("✓ pass 1"));
+		assert!(out.text.contains("FAIL app.test.ts"));
+	}
+
+	#[test]
+	fn bun_run_test_colon_routes_to_node_tests() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("bun", Some("run"), "bun run test:unit", &cfg);
+		let out = filter(&ctx, "✓ passes\nFAIL src/example.test.ts\nTests 1 failed, 1 passed\n", 1);
+		assert!(!out.text.contains("✓ passes"));
+		assert!(out.text.contains("FAIL src/example.test.ts"));
+	}
+
+	#[test]
+	fn bun_run_e2e_routes_to_node_tests() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("bun", Some("run"), "bun run e2e", &cfg);
+		let out = filter(&ctx, "✓ passes\nFAIL e2e/spec.ts\nTests 1 failed, 1 passed\n", 1);
+		assert!(!out.text.contains("✓ passes"));
+		assert!(out.text.contains("FAIL e2e/spec.ts"));
+	}
+
+	#[test]
+	fn bun_run_check_colon_compacts_workspace_success_noise() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("bun", Some("run"), "bun run 'check:ts'", &cfg);
+		let out = filter(
+			&ctx,
+			"$ bun run check:tools && bun run --workspaces --if-present check\n$ biome check . \
+			 --no-errors-on-unmatched\nChecked 1690 files in 371ms. No fixes \
+			 applied.\n@oh-my-pi/pi-utils check: Checked 40 files in 11ms. No fixes \
+			 applied.\n@oh-my-pi/pi-utils check: $ tsgo -p tsconfig.json \
+			 --noEmit\n@oh-my-pi/pi-utils check: Exited with code 0\n@oh-my-pi/pi-coding-agent \
+			 check: Checked 1178 files in 287ms. No fixes applied.\n@oh-my-pi/pi-coding-agent check: \
+			 $ tsgo -p tsconfig.json --noEmit\n@oh-my-pi/pi-coding-agent check: Exited with code 0\n",
+			0,
+		);
+
+		assert!(out.text.contains("check:ts: passed"));
+		assert!(out.text.contains("root biome: ok"));
+		assert!(out.text.contains("@oh-my-pi/pi-utils"));
+		assert!(out.text.contains("@oh-my-pi/pi-coding-agent"));
+		assert!(!out.text.contains("No fixes applied"));
+		assert!(!out.text.contains("tsgo -p"));
+		assert!(!out.text.contains("Exited with code 0"));
+	}
+
+	#[test]
+	fn bun_run_check_timeout_preserves_ambiguous_success() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("bun", Some("run"), "bun run check:ts", &cfg);
+		let out = filter(
+			&ctx,
+			"@oh-my-pi/pi-utils check: Checked 40 files in 11ms. No fixes \
+			 applied.\n@oh-my-pi/pi-utils check: Exited with code 0\n[Command timed out after 300 \
+			 seconds]\n",
+			1,
+		);
+
+		assert!(
+			out.text
+				.contains("visible checks passed; wrapper timed out")
+		);
+		assert!(
+			out.text
+				.contains("timeout: Command timed out after 300 seconds")
+		);
+		assert!(!out.text.contains("failed"));
+	}
+
+	#[test]
+	fn bun_run_build_still_uses_pkg_filter() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("bun", Some("run"), "bun run build", &cfg);
+		let out = filter(&ctx, "Resolving dependencies\nDownloaded foo\nerror: failed\n", 1);
+		assert!(!out.text.contains("Resolving dependencies"));
+		assert!(out.text.contains("error: failed"));
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/cargo.rs
+++ b/crates/pi-shell/src/minimizer/filters/cargo.rs
@@ -1,5 +1,7 @@
 //! Cargo build/test output filters.
 
+use std::{collections::BTreeMap, fmt::Write as _};
+
 use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
 
 pub fn supports(subcommand: Option<&str>) -> bool {
@@ -26,9 +28,11 @@ pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerO
 		Some("metadata") => input.to_string(),
 		Some("test" | "bench") => failures_only(&cleaned, exit_code),
 		Some("nextest") => filter_nextest(&cleaned),
-		Some("build" | "check" | "clippy" | "doc" | "run") => condense_build(&cleaned),
+		Some("clippy") => filter_clippy(&cleaned, exit_code),
+		Some("build" | "check" | "doc" | "run") => condense_build(&cleaned),
 		Some("fmt") => condense_fmt(&cleaned),
-		Some("tree" | "update" | "install" | "publish") => compact_general(&cleaned),
+		Some("install") => filter_install(&cleaned, exit_code),
+		Some("tree" | "update" | "publish") => compact_general(&cleaned),
 		_ => cleaned,
 	};
 	if text == input {
@@ -289,6 +293,182 @@ fn is_general_cargo_noise(line: &str) -> bool {
 		|| trimmed.starts_with("Checking ")
 		|| trimmed.starts_with("Fresh ")
 }
+/// Filter `cargo install` output: strip compilation/download noise, keep
+/// install/error summaries.
+fn filter_install(input: &str, exit_code: i32) -> String {
+	let stripped = primitives::strip_lines(input, &[is_compiling_noise]);
+
+	if exit_code != 0 {
+		return primitives::head_tail_lines(&stripped, 100, 40);
+	}
+
+	let mut summaries = String::new();
+	for line in stripped.lines() {
+		let trimmed = line.trim_start();
+		if is_install_summary(trimmed) || trimmed.starts_with("WARNING:") {
+			summaries.push_str(line);
+			summaries.push('\n');
+		}
+	}
+
+	if summaries.is_empty() {
+		let deduped = primitives::dedup_consecutive_lines(&stripped);
+		primitives::head_tail_lines(&deduped, 60, 20)
+	} else {
+		primitives::dedup_consecutive_lines(&summaries)
+	}
+}
+
+fn is_install_summary(line: &str) -> bool {
+	line.starts_with("Installed ")
+		|| line.starts_with("Replaced ")
+		|| line.starts_with("Replacing ")
+		|| line.starts_with("Ignored ")
+}
+
+#[derive(Debug)]
+struct ClippyWarning {
+	location:  String,
+	message:   String,
+	lint_rule: Option<String>,
+}
+
+/// Filter `cargo clippy`: group warnings by lint rule; keep errors verbatim.
+fn filter_clippy(input: &str, exit_code: i32) -> String {
+	let no_noise = primitives::strip_lines(input, &[is_compiling_noise]);
+
+	let has_compile_error = no_noise.lines().any(|l| {
+		let t = l.trim_start();
+		(t.starts_with("error:")
+			&& !t.starts_with("error: could not compile")
+			&& !t.starts_with("error: aborting"))
+			|| t.starts_with("error[")
+	});
+
+	if has_compile_error {
+		let grouped = primitives::group_by_file(&no_noise, 20);
+		return primitives::head_tail_lines(&grouped, 120, 60);
+	}
+
+	let warnings = parse_clippy_warnings(&no_noise);
+	if warnings.is_empty() {
+		let deduped = primitives::dedup_consecutive_lines(&no_noise);
+		return primitives::head_tail_lines(&deduped, 80, 40);
+	}
+
+	format_clippy_grouped(&warnings, exit_code)
+}
+
+fn parse_clippy_warnings(input: &str) -> Vec<ClippyWarning> {
+	let mut warnings = Vec::new();
+	let lines: Vec<&str> = input.lines().collect();
+	let mut i = 0;
+
+	while i < lines.len() {
+		let trimmed = lines[i].trim();
+		if !trimmed.starts_with("warning: ") {
+			i += 1;
+			continue;
+		}
+
+		let msg = trimmed.strip_prefix("warning: ").unwrap_or("");
+		// Skip summary lines like "warning: `crate` (lib) generated N warning(s)"
+		if msg.contains(" generated ") && (msg.ends_with(" warnings") || msg.ends_with(" warning")) {
+			i += 1;
+			continue;
+		}
+
+		let message = msg.to_string();
+		let mut location = String::new();
+		let mut lint_rule = None;
+
+		i += 1;
+		while i < lines.len() {
+			let t = lines[i].trim();
+			if t.starts_with("--> ") {
+				location = t.strip_prefix("--> ").unwrap_or("").to_string();
+			}
+			if let Some(rule) = extract_lint_rule(t) {
+				lint_rule = Some(rule);
+			}
+			i += 1;
+			if i >= lines.len() {
+				break;
+			}
+			let next = lines[i].trim();
+			if next.starts_with("warning: ")
+				|| next.starts_with("error:")
+				|| next.starts_with("error[")
+			{
+				break;
+			}
+		}
+
+		if !message.is_empty() {
+			warnings.push(ClippyWarning { location, message, lint_rule });
+		}
+	}
+
+	warnings
+}
+
+fn extract_lint_rule(line: &str) -> Option<String> {
+	let line = line.trim();
+	if !line.starts_with("= note:") {
+		return None;
+	}
+	let after_note = line.strip_prefix("= note:")?.trim();
+	let rest = after_note
+		.strip_prefix("`#[warn(")
+		.or_else(|| after_note.strip_prefix("`#[deny("))
+		.or_else(|| after_note.strip_prefix("`#[allow("))?;
+	Some(rest.split(")]`").next()?.to_string())
+}
+
+fn format_clippy_grouped(warnings: &[ClippyWarning], exit_code: i32) -> String {
+	let mut groups: BTreeMap<String, Vec<&ClippyWarning>> = BTreeMap::new();
+	let mut ungrouped = Vec::new();
+
+	for w in warnings {
+		if let Some(ref rule) = w.lint_rule {
+			groups.entry(rule.clone()).or_default().push(w);
+		} else {
+			ungrouped.push(w);
+		}
+	}
+
+	let mut out = String::new();
+
+	for (rule, warns) in &groups {
+		if warns.len() == 1 {
+			let loc = if warns[0].location.is_empty() {
+				String::new()
+			} else {
+				format!("{}  ", warns[0].location)
+			};
+			let _ = writeln!(out, "clippy: {} — {}{}", rule, loc, warns[0].message);
+		} else {
+			let _ = writeln!(out, "clippy: {} ({} warnings)", rule, warns.len());
+			for w in warns {
+				let _ = writeln!(out, "  {}  {}", w.location, w.message);
+			}
+		}
+	}
+
+	for w in &ungrouped {
+		let _ = writeln!(out, "clippy warning: {}  {}", w.location, w.message);
+	}
+
+	if exit_code != 0 {
+		out.push_str("(clippy found issues)\n");
+	}
+
+	if out.is_empty() {
+		"cargo clippy: ok\n".to_string()
+	} else {
+		out
+	}
+}
 
 #[cfg(test)]
 mod tests {
@@ -337,21 +517,170 @@ mod tests {
 		assert!(out.contains("stdout text"));
 		assert!(out.contains("Summary [0.2s] 2 tests run: 1 passed, 1 failed"));
 	}
+	#[test]
+	fn install_strips_noise_keeps_summary() {
+		assert!(supports(Some("install")));
+		let input = concat!(
+			"    Updating crates.io index\n",
+			"  Downloaded foo v1.0.0\n",
+			"   Compiling bar v0.1.0\n",
+			"   Compiling tool v3.0.0\n",
+			"    Finished release [optimized] target(s) in 45.2s\n",
+			"  Installing /home/user/.cargo/bin/tool\n",
+			"   Installed package `tool v3.0.0` (executable `tool`)\n",
+		);
+		let out = filter_install(input, 0);
+		assert!(!out.contains("Compiling"));
+		assert!(!out.contains("Downloaded"));
+		assert!(!out.contains("Updating"));
+		assert!(!out.contains("Finished"));
+		assert!(out.contains("Installed package `tool v3.0.0`"));
+	}
 
 	#[test]
-	fn install_uses_general_head_tail_dedup_strategy() {
-		assert!(supports(Some("install")));
-		let mut input = "Downloading crate\n".repeat(2);
-		input.push_str("Installed package `tool v1.0.0`\n");
-		for i in 0..130 {
-			input.push_str("line ");
-			input.push_str(&i.to_string());
-			input.push('\n');
-		}
-		let out = compact_general(&input);
-		assert!(!out.contains("Downloading crate"));
-		assert!(out.contains("Installed package `tool v1.0.0`"));
-		assert!(out.contains("lines omitted"));
+	fn install_already_installed() {
+		let input = concat!(
+			"    Updating crates.io index\n",
+			"     Ignored package `tool v1.0.0` is already installed, use --force to override\n",
+		);
+		let out = filter_install(input, 0);
+		assert!(!out.contains("Updating"));
+		assert!(out.contains("Ignored package `tool v1.0.0`"));
+	}
+
+	#[test]
+	fn install_error_preserves_context() {
+		let input = concat!(
+			"    Updating crates.io index\n",
+			"   Compiling foo v0.1.0\n",
+			"error[E0425]: cannot find value `x` in this scope\n",
+			" --> src/main.rs:5:9\n",
+			"  |\n",
+			"5 |     let y = x;\n",
+			"  |             ^ not found in this scope\n",
+			"error: could not compile `foo` due to 1 previous error\n",
+		);
+		let out = filter_install(input, 1);
+		assert!(!out.contains("Compiling"));
+		assert!(!out.contains("Updating"));
+		assert!(out.contains("error[E0425]"));
+		assert!(out.contains("cannot find value `x`"));
+	}
+
+	#[test]
+	fn clippy_groups_warnings_by_lint_rule() {
+		assert!(supports(Some("clippy")));
+		let input = concat!(
+			"    Checking foo v0.1.0\n",
+			"warning: unused variable: `x`\n",
+			" --> src/lib.rs:2:9\n",
+			"  |\n",
+			"2 |     let x = 1;\n",
+			"  |         ^ help: if this is intentional, prefix with an underscore: `_x`\n",
+			"  |\n",
+			"  = note: `#[warn(unused_variables)]` on by default\n",
+			"\n",
+			"warning: unused variable: `y`\n",
+			" --> src/lib.rs:5:9\n",
+			"  |\n",
+			"5 |     let y = 2;\n",
+			"  |         ^ help: if this is intentional, prefix with an underscore: `_y`\n",
+			"  |\n",
+			"  = note: `#[warn(unused_variables)]` on by default\n",
+			"\n",
+			"warning: `foo` (lib) generated 2 warnings\n",
+		);
+		let out = filter_clippy(input, 0);
+		assert!(!out.contains("Checking"));
+		assert!(!out.contains("generated"));
+		assert!(out.contains("unused_variables"));
+		assert!(out.contains("2 warnings"));
+		assert!(out.contains("src/lib.rs:2:9"));
+		assert!(out.contains("src/lib.rs:5:9"));
+	}
+
+	#[test]
+	fn clippy_single_warning_compact() {
+		let input = concat!(
+			"warning: redundant clone\n",
+			" --> src/main.rs:10:3\n",
+			"  |\n",
+			"10|     foo.clone()\n",
+			"  |     ^^^^^^^^^^^^ help: remove this\n",
+			"  |\n",
+			"  = note: `#[warn(clippy::redundant_clone)]` on by default\n",
+			"\n",
+			"warning: `foo` (bin \"foo\") generated 1 warning\n",
+		);
+		let out = filter_clippy(input, 0);
+		assert!(!out.contains("generated"));
+		assert!(out.contains("clippy::redundant_clone"));
+		assert!(out.contains("src/main.rs:10:3"));
+		assert!(out.contains("redundant clone"));
+	}
+
+	#[test]
+	fn clippy_multiple_rules_grouped_separately() {
+		let input = concat!(
+			"warning: unused variable: `x`\n",
+			" --> src/lib.rs:2:9\n",
+			"  |\n",
+			"2 |     let x = 1;\n",
+			"  |         ^\n",
+			"  |\n",
+			"  = note: `#[warn(unused_variables)]` on by default\n",
+			"\n",
+			"warning: redundant clone\n",
+			" --> src/main.rs:10:3\n",
+			"  |\n",
+			"10|     foo.clone()\n",
+			"  |     ^^^^^^^^^^^^ help: remove this\n",
+			"  |\n",
+			"  = note: `#[warn(clippy::redundant_clone)]` on by default\n",
+			"\n",
+			"warning: `foo` (lib) generated 2 warnings\n",
+		);
+		let out = filter_clippy(input, 0);
+		assert!(out.contains("unused_variables"));
+		assert!(out.contains("clippy::redundant_clone"));
+		// Two separate groups, not merged
+		let unused_pos = out.find("unused_variables").unwrap();
+		let clone_pos = out.find("clippy::redundant_clone").unwrap();
+		assert!(unused_pos != clone_pos);
+	}
+
+	#[test]
+	fn clippy_compile_error_falls_back_to_build_style() {
+		let input = concat!(
+			"   Compiling foo v0.1.0\n",
+			"error[E0425]: cannot find value `x` in this scope\n",
+			" --> src/lib.rs:5:9\n",
+			"  |\n",
+			"5 |     let y = x;\n",
+			"  |             ^ not found in this scope\n",
+			"error: could not compile `foo` due to 1 previous error\n",
+		);
+		let out = filter_clippy(input, 1);
+		assert!(!out.contains("Compiling"));
+		assert!(out.contains("error[E0425]"));
+		assert!(out.contains("cannot find value `x`"));
+		// Should NOT have clippy: prefix since it fell back to build style
+		assert!(!out.contains("clippy:"));
+	}
+
+	#[test]
+	fn clippy_exit_code_signals_issues() {
+		let input = concat!(
+			"warning: unused variable: `x`\n",
+			" --> src/lib.rs:2:9\n",
+			"  |\n",
+			"2 |     let x = 1;\n",
+			"  |         ^\n",
+			"  |\n",
+			"  = note: `#[deny(unused_variables)]` on by default\n",
+		);
+		let out = filter_clippy(input, 1);
+		assert!(out.contains("(clippy found issues)"));
 	}
 
 	#[test]

--- a/crates/pi-shell/src/minimizer/filters/cloud.rs
+++ b/crates/pi-shell/src/minimizer/filters/cloud.rs
@@ -48,9 +48,33 @@ pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerO
 	}
 }
 
-fn filter_aws(ctx: &MinimizerCtx<'_>, input: &str, _exit_code: i32) -> String {
+/// Returns `true` when the full command is `aws s3 ls [...]` (not `cp`, `sync`,
+/// `rm`, etc.). Skips flags between `s3` and the action token so
+/// `aws --no-cli-pager s3 ls` is still recognised while `aws s3 cp` is excluded.
+fn is_s3_ls(command: &str) -> bool {
+	let mut past_s3 = false;
+	for token in command.split_whitespace() {
+		if !past_s3 {
+			if token == "s3" {
+				past_s3 = true;
+			}
+		} else if token.starts_with('-') {
+			// skip flags between "s3" and the action word
+		} else {
+			return token == "ls";
+		}
+	}
+	false
+}
+
+fn filter_aws(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> String {
 	let without_progress = strip_transfer_progress(input);
-	if ctx.subcommand == Some("s3")
+	// Only the `ls` listing form should be reshaped into a bucket/date table;
+	// `aws s3 cp`/`sync`/`rm` emit progress/result lines (`upload: ... to
+	// s3://...`) that must not be misparsed as listing rows.
+	if exit_code == 0
+		&& ctx.subcommand == Some("s3")
+		&& is_s3_ls(ctx.command)
 		&& let Some(compacted) = compact_aws_s3_ls_text(&without_progress)
 	{
 		return compacted;
@@ -1416,6 +1440,17 @@ mod tests {
 		let out = filter(&ctx, "2026-05-27 01:02:03 builds\n2026-05-27 01:03:04 logs\n", 0);
 		assert!(out.text.contains("builds\t2026-05-27 01:02:03"));
 		assert_output_pure(&out.text);
+	}
+
+	#[test]
+	fn s3_cp_output_is_not_parsed_as_listing() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = aws_ctx("s3", "aws s3 cp ./file.txt s3://bucket/file.txt", &cfg);
+		// `aws s3 cp` emits a transfer result line, not a listing; it must pass
+		// through untouched rather than be reshaped into a bucket/date table.
+		let input = "upload: ./file.txt to s3://bucket/file.txt\n";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, input);
 	}
 
 	#[test]

--- a/crates/pi-shell/src/minimizer/filters/cloud.rs
+++ b/crates/pi-shell/src/minimizer/filters/cloud.rs
@@ -248,6 +248,29 @@ fn extract_aws_s3_buckets(root: &Value) -> Option<Vec<&Map<String, Value>>> {
 	extract_array(root, &["Buckets", "buckets"])
 }
 
+/// True for an `aws s3 ls` date column (`YYYY-MM-DD`).
+fn is_s3_date(token: &str) -> bool {
+	let mut parts = token.split('-');
+	matches!(
+		(parts.next(), parts.next(), parts.next(), parts.next()),
+		(Some(y), Some(m), Some(d), None)
+			if y.len() == 4
+				&& m.len() == 2
+				&& d.len() == 2
+				&& [y, m, d].iter().all(|p| p.bytes().all(|b| b.is_ascii_digit()))
+	)
+}
+
+/// True for an `aws s3 ls` time column (`HH:MM:SS`).
+fn is_s3_time(token: &str) -> bool {
+	let mut parts = token.split(':');
+	matches!(
+		(parts.next(), parts.next(), parts.next(), parts.next()),
+		(Some(h), Some(m), Some(s), None)
+			if [h, m, s].iter().all(|p| p.len() == 2 && p.bytes().all(|b| b.is_ascii_digit()))
+	)
+}
+
 fn compact_aws_s3_ls_text(input: &str) -> Option<String> {
 	let rows = input
 		.lines()
@@ -255,12 +278,24 @@ fn compact_aws_s3_ls_text(input: &str) -> Option<String> {
 			let mut parts = line.split_whitespace();
 			let first = parts.next()?;
 			if first == "PRE" {
+				// A common-prefix name may contain spaces (`PRE my folder/`), so
+				// join the remaining tokens instead of keeping only the first one.
+				let prefix: Vec<&str> = parts.collect();
+				if prefix.is_empty() {
+					return None;
+				}
 				return Some(vec![
-					parts.next()?.trim_end_matches('/').to_string(),
+					prefix.join(" ").trim_end_matches('/').to_string(),
 					"prefix".to_string(),
 				]);
 			}
 			let time = parts.next()?;
+			// Require a real date/time prefix so `--summarize` footers
+			// (`Total Objects: 1`, `Total Size: ...`) and any diagnostic/error
+			// text are not reinterpreted as object rows.
+			if !is_s3_date(first) || !is_s3_time(time) {
+				return None;
+			}
 			let third = parts.next()?;
 			if third == "0" && parts.clone().next().is_none() {
 				return None;
@@ -1440,6 +1475,28 @@ mod tests {
 		let out = filter(&ctx, "2026-05-27 01:02:03 builds\n2026-05-27 01:03:04 logs\n", 0);
 		assert!(out.text.contains("builds\t2026-05-27 01:02:03"));
 		assert_output_pure(&out.text);
+	}
+
+	#[test]
+	fn s3_ls_summarize_footer_is_not_parsed_as_row() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = aws_ctx("s3", "aws s3 ls --summarize s3://b/", &cfg);
+		// `--summarize` appends `Total Objects:`/`Total Size:` footers that lack a
+		// real date/time prefix; they must not be reshaped into bogus object rows.
+		let input = "2026-05-27 01:02:03 100 builds\n\nTotal Objects: 1\nTotal Size: 100\n";
+		let out = filter(&ctx, input, 0);
+		assert!(!out.text.contains("Total Objects:"), "{:?}", out.text);
+		assert!(!out.text.contains("Total Size:"), "{:?}", out.text);
+	}
+
+	#[test]
+	fn s3_ls_common_prefix_with_spaces_is_preserved() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = aws_ctx("s3", "aws s3 ls s3://b/", &cfg);
+		// `PRE` common-prefix names can contain spaces; the full name must survive
+		// rather than being truncated to the first token.
+		let out = filter(&ctx, "                           PRE my folder/\n", 0);
+		assert!(out.text.contains("my folder"), "{:?}", out.text);
 	}
 
 	#[test]

--- a/crates/pi-shell/src/minimizer/filters/cloud.rs
+++ b/crates/pi-shell/src/minimizer/filters/cloud.rs
@@ -1,9 +1,32 @@
 //! Cloud and data command output filters.
 
+use std::fmt::Write as _;
+
+use serde_json::{Map, Value};
+
 use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
 
 const MAX_PSQL_ROWS: usize = 30;
 const MAX_LINE_CHARS: usize = 500;
+const MAX_AWS_ROWS: usize = 40;
+
+const SENSITIVE_AWS_KEYS: &[&str] = &[
+	"Policy",
+	"PolicyDocument",
+	"AssumeRolePolicyDocument",
+	"Environment",
+	"SecretString",
+	"SecretBinary",
+	"Token",
+	"SessionToken",
+	"Credentials",
+	"Password",
+	"PrivateKey",
+	"KeyMaterial",
+	"PlaintextKeyMaterial",
+	"CiphertextBlob",
+	"ResponseMetadata",
+];
 
 pub fn supports(program: &str, _subcommand: Option<&str>) -> bool {
 	matches!(program, "aws" | "curl" | "wget" | "psql")
@@ -12,7 +35,7 @@ pub fn supports(program: &str, _subcommand: Option<&str>) -> bool {
 pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerOutput {
 	let cleaned = primitives::strip_ansi(input);
 	let text = match ctx.program {
-		"aws" => filter_aws(&cleaned, exit_code),
+		"aws" => filter_aws(ctx, &cleaned, exit_code),
 		"curl" | "wget" => filter_http_transfer(&cleaned, exit_code),
 		"psql" => filter_psql(&cleaned, exit_code),
 		_ => head_tail_dedup(&cleaned, 80, 40),
@@ -25,12 +48,702 @@ pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerO
 	}
 }
 
-fn filter_aws(input: &str, _exit_code: i32) -> String {
+fn filter_aws(ctx: &MinimizerCtx<'_>, input: &str, _exit_code: i32) -> String {
 	let without_progress = strip_transfer_progress(input);
+	if ctx.subcommand == Some("s3")
+		&& let Some(compacted) = compact_aws_s3_ls_text(&without_progress)
+	{
+		return compacted;
+	}
+	if let Some(compacted) = try_compact_aws_json(ctx, &without_progress) {
+		return compacted;
+	}
 	if looks_like_table(&without_progress) {
 		compact_delimited_table(&without_progress, 40)
 	} else {
 		without_progress
+	}
+}
+
+/// Try to parse AWS CLI JSON output and produce a compact representation.
+/// Returns None if input is not recognized JSON or if schema is unexpected.
+fn try_compact_aws_json(ctx: &MinimizerCtx<'_>, input: &str) -> Option<String> {
+	let trimmed = input.trim();
+	if !(trimmed.starts_with('{') || trimmed.starts_with('[')) {
+		return None;
+	}
+	let root: Value = serde_json::from_str(trimmed).ok()?;
+
+	if let Some(compacted) = compact_aws_service_json(ctx, &root) {
+		return Some(compacted);
+	}
+
+	// EC2 describe-instances: {"Reservations":[{"Instances":[...]}]}
+	if let Some(instances) = extract_aws_ec2_instances(&root) {
+		return Some(compact_aws_ec2_instances(&instances));
+	}
+
+	// CloudWatch logs / filtered log events: {"events":[...]}
+	if let Some(events) = extract_aws_cloudwatch_events(&root) {
+		return Some(compact_aws_cloudwatch_events(&events));
+	}
+
+	// DynamoDB get-item/query/scan: {"Item":{...}} or {"Items":[{...}]}
+	if let Some(items) = extract_aws_dynamodb_items(&root) {
+		return Some(compact_aws_dynamodb_items(&items));
+	}
+
+	compact_aws_generic(&root)
+}
+
+fn compact_aws_service_json(ctx: &MinimizerCtx<'_>, root: &Value) -> Option<String> {
+	match ctx.subcommand {
+		Some("sts") => extract_aws_sts_caller(root).map(compact_aws_sts_caller),
+		Some("s3" | "s3api") => extract_aws_s3_buckets(root).map(|rows| {
+			compact_named_rows(
+				&["bucket", "date"],
+				&rows
+					.iter()
+					.map(|bucket| {
+						vec![
+							string_field_map(bucket, &["Name", "Bucket", "bucket", "name"]),
+							string_field_map(bucket, &["CreationDate", "CreationDateTime", "date"]),
+						]
+					})
+					.collect::<Vec<_>>(),
+			)
+		}),
+		Some("lambda") => extract_array(root, &["Functions"]).map(|rows| {
+			compact_named_rows(
+				&["function", "runtime", "memory", "modified"],
+				&rows
+					.iter()
+					.map(|item| {
+						vec![
+							string_field_map(item, &["FunctionName", "Name"]),
+							string_field_map(item, &["Runtime"]),
+							string_field_map(item, &["MemorySize"]),
+							string_field_map(item, &["LastModified"]),
+						]
+					})
+					.collect::<Vec<_>>(),
+			)
+		}),
+		Some("iam") => extract_aws_iam_entities(root).map(|rows| {
+			compact_named_rows(
+				&["name", "arn", "created"],
+				&rows
+					.iter()
+					.map(|item| {
+						vec![
+							string_field_map(item, &["UserName", "RoleName", "GroupName", "Name"]),
+							string_field_map(item, &["Arn"]),
+							string_field_map(item, &["CreateDate"]),
+						]
+					})
+					.collect::<Vec<_>>(),
+			)
+		}),
+		Some("logs") => extract_aws_logs_events(root).map(compact_aws_logs_events),
+		Some("ecs") => extract_aws_arn_list(root, &["clusterArns", "taskArns", "serviceArns"])
+			.map(|rows| compact_single_col("arn", &rows)),
+		Some("rds") => extract_array(root, &["DBInstances"]).map(|rows| {
+			compact_named_rows(
+				&["identifier", "engine", "status", "endpoint"],
+				&rows
+					.iter()
+					.map(|item| {
+						vec![
+							string_field_map(item, &["DBInstanceIdentifier"]),
+							string_field_map(item, &["Engine"]),
+							string_field_map(item, &["DBInstanceStatus"]),
+							item
+								.get("Endpoint")
+								.and_then(Value::as_object)
+								.map_or_else(|| "-".to_string(), |ep| string_field_map(ep, &["Address"])),
+						]
+					})
+					.collect::<Vec<_>>(),
+			)
+		}),
+		Some("cloudformation") => extract_array(root, &["Stacks"]).map(|rows| {
+			compact_named_rows(
+				&["stack", "status", "updated"],
+				&rows
+					.iter()
+					.map(|item| {
+						vec![
+							string_field_map(item, &["StackName"]),
+							string_field_map(item, &["StackStatus"]),
+							string_field_map(item, &["LastUpdatedTime", "CreationTime"]),
+						]
+					})
+					.collect::<Vec<_>>(),
+			)
+		}),
+		Some("eks") => compact_aws_eks(root),
+		Some("sqs") => compact_aws_sqs(root),
+		Some("secretsmanager") => extract_array(root, &["SecretList"]).map(|rows| {
+			compact_named_rows(
+				&["name", "arn", "changed"],
+				&rows
+					.iter()
+					.map(|item| {
+						vec![
+							string_field_map(item, &["Name"]),
+							string_field_map(item, &["ARN", "Arn"]),
+							string_field_map(item, &["LastChangedDate", "LastAccessedDate"]),
+						]
+					})
+					.collect::<Vec<_>>(),
+			)
+		}),
+		_ => None,
+	}
+}
+
+fn extract_aws_sts_caller(root: &Value) -> Option<&Map<String, Value>> {
+	let map = root.as_object()?;
+	if map.contains_key("Account") && map.contains_key("Arn") {
+		Some(map)
+	} else {
+		None
+	}
+}
+
+fn compact_aws_sts_caller(map: &Map<String, Value>) -> String {
+	format!(
+		"account={} arn={} user-id={}\n",
+		string_field_map(map, &["Account"]),
+		string_field_map(map, &["Arn"]),
+		string_field_map(map, &["UserId"])
+	)
+}
+
+fn extract_aws_s3_buckets(root: &Value) -> Option<Vec<&Map<String, Value>>> {
+	extract_array(root, &["Buckets", "buckets"])
+}
+
+fn compact_aws_s3_ls_text(input: &str) -> Option<String> {
+	let rows = input
+		.lines()
+		.filter_map(|line| {
+			let mut parts = line.split_whitespace();
+			let first = parts.next()?;
+			if first == "PRE" {
+				return Some(vec![
+					parts.next()?.trim_end_matches('/').to_string(),
+					"prefix".to_string(),
+				]);
+			}
+			let time = parts.next()?;
+			let third = parts.next()?;
+			if third == "0" && parts.clone().next().is_none() {
+				return None;
+			}
+			// Collect all remaining tokens as the key so that S3 keys
+			// containing spaces (e.g. "reports/June 2026.csv") are
+			// preserved in full rather than truncated to the last token.
+			let rest: Vec<&str> = parts.collect();
+			let name = if rest.is_empty() {
+				third.to_string()
+			} else {
+				rest.join(" ")
+			};
+			Some(vec![name, format!("{first} {time}")])
+		})
+		.collect::<Vec<_>>();
+	if rows.is_empty() {
+		None
+	} else {
+		Some(compact_named_rows(&["bucket", "date"], &rows))
+	}
+}
+
+fn extract_aws_iam_entities(root: &Value) -> Option<Vec<&Map<String, Value>>> {
+	extract_array(root, &["Users", "Roles", "Groups", "Policies"])
+}
+
+fn extract_aws_logs_events(root: &Value) -> Option<Vec<&Map<String, Value>>> {
+	extract_array(root, &["events", "Events", "logEvents"])
+}
+
+fn compact_aws_logs_events(rows: Vec<&Map<String, Value>>) -> String {
+	compact_named_rows(
+		&["timestamp", "level", "message"],
+		&rows
+			.iter()
+			.map(|event| {
+				let msg = string_field_map(event, &["message", "Message"]);
+				vec![
+					string_field_map(event, &["timestamp", "eventTimestamp"]),
+					infer_level(&msg).to_string(),
+					primitives::truncate_line(&msg, MAX_LINE_CHARS),
+				]
+			})
+			.collect::<Vec<_>>(),
+	)
+}
+
+fn extract_aws_arn_list(root: &Value, keys: &[&str]) -> Option<Vec<String>> {
+	for key in keys {
+		if let Some(values) = root.get(key).and_then(Value::as_array) {
+			let rows = values
+				.iter()
+				.filter_map(Value::as_str)
+				.map(ToOwned::to_owned)
+				.collect::<Vec<_>>();
+			if !rows.is_empty() {
+				return Some(rows);
+			}
+		}
+	}
+	None
+}
+
+fn compact_aws_eks(root: &Value) -> Option<String> {
+	if let Some(values) = root.get("clusters").and_then(Value::as_array) {
+		let rows = values
+			.iter()
+			.filter_map(Value::as_str)
+			.map(|name| vec![name.to_string(), "-".to_string(), "-".to_string(), "-".to_string()])
+			.collect::<Vec<_>>();
+		return Some(compact_named_rows(&["cluster", "status", "version", "endpoint"], &rows));
+	}
+	let cluster = root.get("cluster")?.as_object()?;
+	Some(compact_named_rows(&["cluster", "status", "version", "endpoint"], &[vec![
+		string_field_map(cluster, &["name"]),
+		string_field_map(cluster, &["status"]),
+		string_field_map(cluster, &["version"]),
+		string_field_map(cluster, &["endpoint"]),
+	]]))
+}
+
+fn compact_aws_sqs(root: &Value) -> Option<String> {
+	if let Some(values) = root.get("QueueUrls").and_then(Value::as_array) {
+		let rows = values
+			.iter()
+			.filter_map(Value::as_str)
+			.map(|url| vec![url.to_string(), "-".to_string(), "-".to_string()])
+			.collect::<Vec<_>>();
+		return Some(compact_named_rows(&["url", "visibility", "messages"], &rows));
+	}
+	let attrs = root.get("Attributes").and_then(Value::as_object)?;
+	Some(compact_named_rows(&["url", "visibility", "messages"], &[vec![
+		string_field(root, &["QueueUrl"]),
+		string_field_map(attrs, &["VisibilityTimeout"]),
+		string_field_map(attrs, &["ApproximateNumberOfMessages"]),
+	]]))
+}
+
+fn extract_array<'a>(root: &'a Value, keys: &[&str]) -> Option<Vec<&'a Map<String, Value>>> {
+	for key in keys {
+		if let Some(values) = root.get(key).and_then(Value::as_array) {
+			let rows = values
+				.iter()
+				.filter_map(Value::as_object)
+				.collect::<Vec<_>>();
+			if !rows.is_empty() {
+				return Some(rows);
+			}
+		}
+	}
+	None
+}
+
+fn compact_aws_generic(root: &Value) -> Option<String> {
+	let pruned = prune_aws_sensitive(root);
+	if let Some((name, rows)) = first_object_array(&pruned) {
+		let columns = generic_columns(&rows);
+		if columns.is_empty() {
+			return None;
+		}
+		let values = rows
+			.iter()
+			.take(MAX_AWS_ROWS)
+			.map(|row| {
+				columns
+					.iter()
+					.map(|column| string_field_map(row, &[column.as_str()]))
+					.collect::<Vec<_>>()
+			})
+			.collect::<Vec<_>>();
+		let mut out =
+			compact_named_rows(&columns.iter().map(String::as_str).collect::<Vec<_>>(), &values);
+		if rows.len() > MAX_AWS_ROWS {
+			let _ = writeln!(out, "... +{} more {name}", rows.len() - MAX_AWS_ROWS);
+		}
+		return Some(out);
+	}
+	None
+}
+
+fn prune_aws_sensitive(value: &Value) -> Value {
+	match value {
+		Value::Object(map) => Value::Object(
+			map.iter()
+				.filter_map(|(key, value)| {
+					if SENSITIVE_AWS_KEYS.iter().any(|sensitive| sensitive == key) {
+						None
+					} else {
+						Some((key.clone(), prune_aws_sensitive(value)))
+					}
+				})
+				.collect(),
+		),
+		Value::Array(values) => Value::Array(values.iter().map(prune_aws_sensitive).collect()),
+		_ => value.clone(),
+	}
+}
+
+fn first_object_array(root: &Value) -> Option<(&str, Vec<Map<String, Value>>)> {
+	let map = root.as_object()?;
+	for (key, value) in map {
+		let Some(values) = value.as_array() else {
+			continue;
+		};
+		let rows = values
+			.iter()
+			.filter_map(Value::as_object)
+			.cloned()
+			.collect::<Vec<_>>();
+		if !rows.is_empty() {
+			return Some((key.as_str(), rows));
+		}
+	}
+	None
+}
+
+fn generic_columns(rows: &[Map<String, Value>]) -> Vec<String> {
+	let mut columns = Vec::new();
+	for row in rows {
+		for key in row.keys() {
+			let lower = key.to_ascii_lowercase();
+			if (matches!(
+				lower.as_str(),
+				"id"
+					| "name" | "arn"
+					| "status" | "state"
+					| "created"
+					| "modified"
+					| "type" | "engine"
+					| "version"
+			) || lower.ends_with("id")
+				|| lower.ends_with("name")
+				|| lower.ends_with("arn")
+				|| lower.ends_with("status")
+				|| lower.ends_with("state")
+				|| lower.contains("created")
+				|| lower.contains("modified"))
+				&& !columns.contains(key)
+			{
+				columns.push(key.clone());
+			}
+			if columns.len() >= 6 {
+				return columns;
+			}
+		}
+	}
+	columns
+}
+
+fn compact_named_rows(headers: &[&str], rows: &[Vec<String>]) -> String {
+	let mut out = String::new();
+	out.push_str(&headers.join("\t"));
+	out.push('\n');
+	for row in rows.iter().take(MAX_AWS_ROWS) {
+		out.push_str(&row.join("\t"));
+		out.push('\n');
+	}
+	if rows.len() > MAX_AWS_ROWS {
+		let _ = writeln!(out, "... +{} more rows", rows.len() - MAX_AWS_ROWS);
+	}
+	out
+}
+
+fn compact_single_col(header: &str, rows: &[String]) -> String {
+	let values = rows.iter().map(|row| vec![row.clone()]).collect::<Vec<_>>();
+	compact_named_rows(&[header], &values)
+}
+
+fn string_field(value: &Value, keys: &[&str]) -> String {
+	value
+		.as_object()
+		.map_or_else(|| "-".to_string(), |map| string_field_map(map, keys))
+}
+
+fn string_field_map(map: &Map<String, Value>, keys: &[&str]) -> String {
+	for key in keys {
+		if let Some(value) = map.get(*key) {
+			return value_to_cell(value);
+		}
+	}
+	"-".to_string()
+}
+
+fn value_to_cell(value: &Value) -> String {
+	match value {
+		Value::String(value) => value.clone(),
+		Value::Number(value) => value.to_string(),
+		Value::Bool(value) => value.to_string(),
+		Value::Null => "-".to_string(),
+		Value::Array(values) => format!("{} item(s)", values.len()),
+		Value::Object(_) => "{...}".to_string(),
+	}
+}
+
+fn infer_level(message: &str) -> &str {
+	let upper = message.to_ascii_uppercase();
+	for level in ["ERROR", "WARN", "INFO", "DEBUG", "TRACE"] {
+		if upper.contains(level) {
+			return level;
+		}
+	}
+	"-"
+}
+
+// ── AWS EC2 ──────────────────────────────────────────────────────────────────
+
+fn extract_aws_ec2_instances(root: &Value) -> Option<Vec<&Value>> {
+	let reservations = root.get("Reservations")?.as_array()?;
+	let mut instances = Vec::new();
+	for res in reservations {
+		let insts = res.get("Instances")?.as_array()?;
+		for inst in insts {
+			instances.push(inst);
+		}
+	}
+	if instances.is_empty() {
+		None
+	} else {
+		Some(instances)
+	}
+}
+
+fn compact_aws_ec2_instances(instances: &[&Value]) -> String {
+	let mut out = String::new();
+	for inst in instances {
+		let id = inst
+			.get("InstanceId")
+			.and_then(|v| v.as_str())
+			.unwrap_or("?");
+		let typ = inst
+			.get("InstanceType")
+			.and_then(|v| v.as_str())
+			.unwrap_or("?");
+		let state = inst
+			.get("State")
+			.and_then(|v| v.get("Name"))
+			.and_then(|v| v.as_str())
+			.unwrap_or("?");
+		let ip = inst
+			.get("PrivateIpAddress")
+			.and_then(|v| v.as_str())
+			.unwrap_or("-");
+		let name = inst
+			.get("Tags")
+			.and_then(|v| v.as_array())
+			.and_then(|tags| {
+				tags.iter().find_map(|tag| {
+					let key = tag.get("Key")?.as_str()?;
+					if key == "Name" {
+						tag.get("Value")?.as_str()
+					} else {
+						None
+					}
+				})
+			})
+			.unwrap_or("-");
+		let _ = writeln!(out, "{id}\t{typ}\t{state}\t{ip}\t{name}");
+	}
+	if instances.len() > 1 {
+		out.push('\n');
+	}
+	let _ = writeln!(out, "{} instance(s)", instances.len());
+	out
+}
+
+// ── AWS CloudWatch ───────────────────────────────────────────────────────────
+
+fn extract_aws_cloudwatch_events(root: &Value) -> Option<Vec<&Value>> {
+	let events = root.get("events")?.as_array()?;
+	if events.is_empty() {
+		None
+	} else {
+		Some(events.iter().collect())
+	}
+}
+
+fn epoch_ms_to_iso(ms: i64) -> String {
+	let secs = ms / 1000;
+	let sub_ms = (ms % 1000) as u32;
+	let days_since_epoch = secs / 86400;
+	let secs_of_day = secs % 86400;
+	let hour = secs_of_day / 3600;
+	let minute = (secs_of_day % 3600) / 60;
+	let second = secs_of_day % 60;
+	let total_days = days_since_epoch as i32;
+	let (year, month, day) = civil_from_days(total_days + 719468);
+	format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{sub_ms:03}Z")
+}
+
+const fn civil_from_days(z: i32) -> (i32, u32, u32) {
+	let z = z as i64;
+	let era = (if z >= 0 { z } else { z - 146096 }) / 146097;
+	let doe = (z - era * 146097) as u32;
+	let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+	let y = yoe as i64 + era * 400;
+	let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+	let mp = (5 * doy + 2) / 153;
+	let d = doy - (153 * mp + 2) / 5 + 1;
+	let m = if mp < 10 { mp + 3 } else { mp - 9 };
+	let y = if m <= 2 { y + 1 } else { y };
+	(y as i32, m, d)
+}
+
+fn compact_aws_cloudwatch_events(events: &[&Value]) -> String {
+	let mut out = String::new();
+	let mut count = 0usize;
+	for event in events {
+		let ts = event
+			.get("timestamp")
+			.and_then(|v| v.as_i64())
+			.map_or_else(|| "?".to_string(), epoch_ms_to_iso);
+		let msg = event.get("message").and_then(|v| v.as_str()).unwrap_or("?");
+		// Truncate long messages
+		let msg = primitives::truncate_line(msg, MAX_LINE_CHARS);
+		out.push_str(&ts);
+		out.push('\t');
+		out.push_str(&msg);
+		out.push('\n');
+		count += 1;
+	}
+	if count > 1 {
+		out.push('\n');
+	}
+	let _ = writeln!(out, "{count} event(s)");
+	out
+}
+
+// ── AWS DynamoDB
+// ──────────────────────────────────────────────────────────────
+
+fn extract_aws_dynamodb_items(root: &Value) -> Option<Vec<&serde_json::Map<String, Value>>> {
+	if let Some(item) = root.get("Item").and_then(Value::as_object) {
+		return Some(vec![item]);
+	}
+	let items = root.get("Items")?.as_array()?;
+	let mut out = Vec::new();
+	for item in items {
+		if let Some(map) = item.as_object() {
+			out.push(map);
+		}
+	}
+	if out.is_empty() { None } else { Some(out) }
+}
+
+fn compact_aws_dynamodb_items(items: &[&serde_json::Map<String, Value>]) -> String {
+	let mut out = String::new();
+	for item in items.iter().take(40) {
+		let mut first = true;
+		for (key, value) in *item {
+			if !first {
+				out.push('\t');
+			}
+			first = false;
+			out.push_str(key);
+			out.push('=');
+			push_dynamodb_value(&mut out, value);
+		}
+		out.push('\n');
+	}
+	if items.len() > 40 {
+		out.push_str("… ");
+		out.push_str(&(items.len() - 40).to_string());
+		out.push_str(" item(s) omitted …\n");
+	}
+	let _ = writeln!(out, "{} item(s)", items.len());
+	out
+}
+
+fn push_dynamodb_value(out: &mut String, value: &Value) {
+	let Some(map) = value.as_object() else {
+		push_json_scalar(out, value);
+		return;
+	};
+	if map.len() == 1 {
+		if let Some(value) = map.get("S").and_then(Value::as_str) {
+			out.push_str(value);
+			return;
+		}
+		if let Some(value) = map.get("N").and_then(Value::as_str) {
+			out.push_str(value);
+			return;
+		}
+		if let Some(value) = map.get("BOOL").and_then(Value::as_bool) {
+			out.push_str(if value { "true" } else { "false" });
+			return;
+		}
+		if map.get("NULL").and_then(Value::as_bool) == Some(true) {
+			out.push_str("null");
+			return;
+		}
+		if let Some(values) = map.get("SS").and_then(Value::as_array) {
+			push_json_array(out, values);
+			return;
+		}
+		if let Some(values) = map.get("NS").and_then(Value::as_array) {
+			push_json_array(out, values);
+			return;
+		}
+		if let Some(values) = map.get("L").and_then(Value::as_array) {
+			out.push('[');
+			for (idx, value) in values.iter().enumerate() {
+				if idx > 0 {
+					out.push(',');
+				}
+				push_dynamodb_value(out, value);
+			}
+			out.push(']');
+			return;
+		}
+		if let Some(values) = map.get("M").and_then(Value::as_object) {
+			push_dynamodb_map(out, values);
+			return;
+		}
+	}
+	push_dynamodb_map(out, map);
+}
+
+fn push_dynamodb_map(out: &mut String, values: &serde_json::Map<String, Value>) {
+	out.push('{');
+	for (idx, (key, value)) in values.iter().enumerate() {
+		if idx > 0 {
+			out.push(',');
+		}
+		out.push_str(key);
+		out.push(':');
+		push_dynamodb_value(out, value);
+	}
+	out.push('}');
+}
+
+fn push_json_array(out: &mut String, values: &[Value]) {
+	out.push('[');
+	for (idx, value) in values.iter().enumerate() {
+		if idx > 0 {
+			out.push(',');
+		}
+		push_json_scalar(out, value);
+	}
+	out.push(']');
+}
+
+fn push_json_scalar(out: &mut String, value: &Value) {
+	if let Some(value) = value.as_str() {
+		out.push_str(value);
+	} else {
+		out.push_str(&value.to_string());
 	}
 }
 
@@ -407,6 +1120,14 @@ mod tests {
 		MinimizerCtx { program, subcommand: None, command: program, config: cfg }
 	}
 
+	fn aws_ctx<'a>(
+		subcommand: &'a str,
+		command: &'a str,
+		cfg: &'a MinimizerConfig,
+	) -> MinimizerCtx<'a> {
+		MinimizerCtx { program: "aws", subcommand: Some(subcommand), command, config: cfg }
+	}
+
 	#[test]
 	fn strips_curl_progress_and_preserves_long_multiline_body() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
@@ -486,5 +1207,258 @@ mod tests {
 		}
 		let out = filter(&ctx, &input, 0);
 		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn compacts_ec2_describe_instances_json() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("aws", &cfg);
+		let input = r#"{
+    "Reservations": [
+        {
+            "Groups": [],
+            "Instances": [
+                {
+                    "InstanceId": "i-1234567890abcdef0",
+                    "InstanceType": "t2.micro",
+                    "State": { "Code": 16, "Name": "running" },
+                    "PrivateIpAddress": "10.0.0.1",
+                    "Tags": [
+                        { "Key": "Name", "Value": "web-server" },
+                        { "Key": "env", "Value": "prod" }
+                    ]
+                },
+                {
+                    "InstanceId": "i-abcdef1234567890",
+                    "InstanceType": "t3.large",
+                    "State": { "Code": 80, "Name": "stopped" },
+                    "PrivateIpAddress": "10.0.0.2",
+                    "Tags": []
+                }
+            ],
+            "OwnerId": "123456789012",
+            "ReservationId": "r-1234567890abcdef0"
+        }
+    ]
+}"#;
+		let out = filter(&ctx, input, 0);
+		assert!(
+			out.text
+				.contains("i-1234567890abcdef0\tt2.micro\trunning\t10.0.0.1\tweb-server")
+		);
+		assert!(
+			out.text
+				.contains("i-abcdef1234567890\tt3.large\tstopped\t10.0.0.2\t-")
+		);
+		assert!(out.text.contains("2 instance(s)"));
+	}
+
+	#[test]
+	fn compacts_cloudwatch_log_events_json() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("aws", &cfg);
+		let input = r#"{
+    "events": [
+        {
+            "timestamp": 1705310100000,
+            "message": "START RequestId: abc123 Version: $LATEST",
+            "ingestionTime": 1705310101000
+        },
+        {
+            "timestamp": 1705310101000,
+            "message": "END RequestId: abc123",
+            "ingestionTime": 1705310102000
+        }
+    ],
+    "nextForwardToken": "f/123",
+    "nextBackwardToken": "b/123"
+}"#;
+		let out = filter(&ctx, input, 0);
+		assert!(
+			out.text
+				.contains("START RequestId: abc123 Version: $LATEST")
+		);
+		assert!(out.text.contains("END RequestId: abc123"));
+		assert!(out.text.contains("2 event(s)"));
+	}
+
+	#[test]
+	fn compacts_dynamodb_typed_json() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("aws", &cfg);
+		let input = r#"{
+    "Items": [
+        {
+            "pk": { "S": "user#1" },
+            "age": { "N": "42" },
+            "active": { "BOOL": true },
+            "tags": { "SS": ["a", "b"] },
+            "meta": { "M": { "city": { "S": "Paris" } } }
+        }
+    ],
+    "Count": 1
+}"#;
+		let out = filter(&ctx, input, 0);
+		assert!(out.text.contains("pk=user#1"));
+		assert!(out.text.contains("age=42"));
+		assert!(out.text.contains("active=true"));
+		assert!(out.text.contains("tags=[a,b]"));
+		assert!(out.text.contains("meta={city:Paris}"));
+		assert!(out.text.contains("1 item(s)"));
+	}
+
+	#[test]
+	fn aws_json_parse_failure_falls_back_to_progress_strip() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("aws", &cfg);
+		// Invalid JSON should fall back to existing behavior
+		let input = "{invalid json here}\nsome output\n";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn aws_unknown_json_uses_generic_safe_table() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("aws", &cfg);
+		let input =
+			r#"{"Things": [{"Name": "alpha", "Status": "ready", "Password": "LEAK_SENTINEL"}]}"#;
+		let out = filter(&ctx, input, 0);
+		assert!(out.text.contains("Name\tStatus"));
+		assert!(out.text.contains("alpha\tready"));
+		assert!(!out.text.contains("LEAK_SENTINEL"));
+	}
+
+	#[test]
+	fn compacts_new_aws_service_shapes() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let cases = [
+			(
+				"sts",
+				"aws sts get-caller-identity",
+				r#"{"UserId":"AIDA","Account":"123456789012","Arn":"arn:aws:iam::123456789012:user/alice","ResponseMetadata":{"RequestId":"LEAK_SENTINEL"}}"#,
+				"account=123456789012 arn=arn:aws:iam::123456789012:user/alice user-id=AIDA",
+			),
+			(
+				"s3api",
+				"aws s3api list-buckets",
+				r#"{"Buckets":[{"Name":"builds","CreationDate":"2026-05-27T00:00:00Z"}]}"#,
+				"builds\t2026-05-27T00:00:00Z",
+			),
+			(
+				"lambda",
+				"aws lambda list-functions",
+				r#"{"Functions":[{"FunctionName":"api","Runtime":"nodejs20.x","MemorySize":256,"LastModified":"today","Environment":{"Variables":{"SECRET":"LEAK_SENTINEL"}}}]}"#,
+				"api\tnodejs20.x\t256\ttoday",
+			),
+			(
+				"iam",
+				"aws iam list-roles",
+				r#"{"Roles":[{"RoleName":"deploy","Arn":"arn:role/deploy","CreateDate":"today","AssumeRolePolicyDocument":"LEAK_SENTINEL"}]}"#,
+				"deploy\tarn:role/deploy\ttoday",
+			),
+			(
+				"logs",
+				"aws logs get-log-events",
+				r#"{"events":[{"timestamp":1,"message":"ERROR failed"}]}"#,
+				"1\tERROR\tERROR failed",
+			),
+			(
+				"ecs",
+				"aws ecs list-clusters",
+				r#"{"clusterArns":["arn:aws:ecs:cluster/default"]}"#,
+				"arn:aws:ecs:cluster/default",
+			),
+			(
+				"rds",
+				"aws rds describe-db-instances",
+				r#"{"DBInstances":[{"DBInstanceIdentifier":"db1","Engine":"postgres","DBInstanceStatus":"available","Endpoint":{"Address":"db.local"}}]}"#,
+				"db1\tpostgres\tavailable\tdb.local",
+			),
+			(
+				"cloudformation",
+				"aws cloudformation describe-stacks",
+				r#"{"Stacks":[{"StackName":"app","StackStatus":"CREATE_COMPLETE","LastUpdatedTime":"today"}]}"#,
+				"app\tCREATE_COMPLETE\ttoday",
+			),
+			(
+				"eks",
+				"aws eks describe-cluster",
+				r#"{"cluster":{"name":"prod","status":"ACTIVE","version":"1.30","endpoint":"https://eks"}}"#,
+				"prod\tACTIVE\t1.30\thttps://eks",
+			),
+			(
+				"sqs",
+				"aws sqs list-queues",
+				r#"{"QueueUrls":["https://sqs.local/q"]}"#,
+				"https://sqs.local/q",
+			),
+			(
+				"secretsmanager",
+				"aws secretsmanager list-secrets",
+				r#"{"SecretList":[{"Name":"db","ARN":"arn:secret:db","LastChangedDate":"today","SecretString":"LEAK_SENTINEL"}]}"#,
+				"db\tarn:secret:db\ttoday",
+			),
+		];
+		for (service, command, input, expected) in cases {
+			let ctx = aws_ctx(service, command, &cfg);
+			let out = filter(&ctx, input, 0);
+			assert!(out.text.contains(expected), "{service}: {}", out.text);
+			assert!(!out.text.contains("LEAK_SENTINEL"), "{service}");
+			assert_output_pure(&out.text);
+		}
+	}
+
+	#[test]
+	fn compacts_s3_text_ls() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = aws_ctx("s3", "aws s3 ls", &cfg);
+		let out = filter(&ctx, "2026-05-27 01:02:03 builds\n2026-05-27 01:03:04 logs\n", 0);
+		assert!(out.text.contains("builds\t2026-05-27 01:02:03"));
+		assert_output_pure(&out.text);
+	}
+
+	#[test]
+	fn malformed_new_aws_service_json_passthroughs() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		for service in [
+			"sts",
+			"s3",
+			"lambda",
+			"iam",
+			"logs",
+			"ecs",
+			"rds",
+			"cloudformation",
+			"eks",
+			"sqs",
+			"secretsmanager",
+		] {
+			let ctx = aws_ctx(service, "aws service op", &cfg);
+			let input = "{not-json";
+			let out = filter(&ctx, input, 0);
+			assert_eq!(out.text, input, "{service}");
+		}
+	}
+
+	#[test]
+	fn sensitive_aws_keys_never_leak_from_generic() {
+		let mut fields = String::new();
+		for key in SENSITIVE_AWS_KEYS {
+			fields.push_str(&format!(r#""{key}":"LEAK_SENTINEL","#));
+		}
+		let input = format!(r#"{{"Unknowns":[{{"Name":"safe",{fields}"Status":"ok"}}]}}"#);
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("aws", &cfg);
+		let out = filter(&ctx, &input, 0);
+		assert!(out.text.contains("safe"));
+		assert!(!out.text.contains("LEAK_SENTINEL"));
+	}
+
+	fn assert_output_pure(out: &str) {
+		assert!(!out.contains('\x1b'));
+		assert!(!out.contains("&&"));
+		assert!(!out.contains(';'));
+		assert!(!out.contains('`'));
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/docker.rs
+++ b/crates/pi-shell/src/minimizer/filters/docker.rs
@@ -1,5 +1,9 @@
 //! Container and cloud command output filters.
 
+use std::fmt::Write as _;
+
+use serde_json::Value;
+
 use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
 
 pub fn supports(subcommand: Option<&str>) -> bool {
@@ -40,7 +44,7 @@ pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerO
 
 fn filter_docker(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> String {
 	if is_log_command(ctx) {
-		return filter_logs(input);
+		return filter_docker_logs(input);
 	}
 	if exit_code != 0 {
 		return input.to_string();
@@ -57,12 +61,208 @@ fn filter_kubectl(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> String
 	}
 	match ctx.subcommand {
 		Some("logs") => filter_logs(input),
-		Some("get") => compact_table(input, 20),
+		Some("get") => {
+			if let Some(compacted) = try_compact_kubectl_json(input) {
+				return compacted;
+			}
+			// `-o yaml` or single-object `-o json`: structured output that
+			// should not be rewritten as a fake row-count table.
+			if is_structured_kubectl_output(input) {
+				return primitives::head_tail_lines(input, 80, 40);
+			}
+			compact_table(input, 20)
+		},
 		Some("describe") => {
 			primitives::head_tail_lines(&primitives::dedup_consecutive_lines(input), 120, 80)
 		},
 		_ => compact_build_or_progress(input),
 	}
+}
+
+// ── kubectl JSON compaction ──────────────────────────────────────────────────
+
+/// Returns true when the `kubectl get` output is structured JSON or YAML
+/// (i.e. `-o json` single-object or `-o yaml`) rather than a tabular listing.
+/// Used to avoid rewriting manifests as a fake row-count table.
+fn is_structured_kubectl_output(input: &str) -> bool {
+	let t = input.trim_start();
+	// Single-object -o json (starts with '{' but is not a List handled above)
+	// or -o yaml (starts with "apiVersion:" or "kind:").
+	t.starts_with('{') || t.starts_with("apiVersion:") || t.starts_with("kind:")
+}
+
+/// Try to parse kubectl `get -o json` output and produce a compact table.
+/// Returns None if input is not recognized JSON or if schema is unexpected.
+fn try_compact_kubectl_json(input: &str) -> Option<String> {
+	let trimmed = input.trim();
+	if !trimmed.starts_with('{') {
+		return None;
+	}
+	let root: Value = serde_json::from_str(trimmed).ok()?;
+
+	// kubectl list JSON: {"kind":"List","items":[...]}
+	if root.get("kind")?.as_str()? != "List" {
+		return None;
+	}
+	let items = root.get("items")?.as_array()?;
+	if items.is_empty() {
+		return None;
+	}
+
+	// Determine resource kind from first item
+	let first = &items[0];
+	let kind = first.get("kind")?.as_str()?;
+
+	match kind {
+		"Pod" => Some(compact_kubectl_pods(items)),
+		"Service" => Some(compact_kubectl_services(items)),
+		_ => None,
+	}
+}
+
+fn compact_kubectl_pods(items: &[Value]) -> String {
+	let mut out = String::from("NAME\tREADY\tSTATUS\tRESTARTS\tAGE\tIP\tNODE\n");
+	let mut count = 0usize;
+	for item in items {
+		let meta = item.get("metadata").unwrap_or(&Value::Null);
+		let spec = item.get("spec").unwrap_or(&Value::Null);
+		let status = item.get("status").unwrap_or(&Value::Null);
+
+		let name = meta.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+		let namespace = meta
+			.get("namespace")
+			.and_then(|v| v.as_str())
+			.unwrap_or("default");
+		let phase = status.get("phase").and_then(|v| v.as_str()).unwrap_or("?");
+		let pod_ip = status
+			.get("podIP")
+			.and_then(|v| v.as_str())
+			.unwrap_or("<none>");
+		let node = spec
+			.get("nodeName")
+			.and_then(|v| v.as_str())
+			.unwrap_or("<none>");
+
+		// Compute READY and RESTARTS from containerStatuses
+		let (ready, total, restarts) = compute_pod_container_stats(status);
+
+		let start_time = status
+			.get("startTime")
+			.and_then(|v| v.as_str())
+			.unwrap_or("");
+		// Simple age extraction (just show startTime if available)
+		let age = start_time;
+
+		let display = if namespace == "default" {
+			name.to_string()
+		} else {
+			format!("{namespace}/{name}")
+		};
+
+		let _ =
+			writeln!(out, "{display}\t{ready}/{total}\t{phase}\t{restarts}\t{age}\t{pod_ip}\t{node}");
+		count += 1;
+	}
+	out.push('\n');
+	let _ = writeln!(out, "{count} pod(s)");
+	out
+}
+
+fn compute_pod_container_stats(status: &Value) -> (usize, usize, i32) {
+	let Some(container_statuses) = status.get("containerStatuses").and_then(|v| v.as_array()) else {
+		return (0, 0, 0);
+	};
+	let total = container_statuses.len();
+	let mut ready = 0usize;
+	let mut restarts = 0i32;
+	for cs in container_statuses {
+		if cs.get("ready").and_then(|v| v.as_bool()).unwrap_or(false) {
+			ready += 1;
+		}
+		restarts += cs.get("restartCount").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+	}
+	(ready, total, restarts)
+}
+
+fn compact_kubectl_services(items: &[Value]) -> String {
+	let mut out = String::from("NAME\tTYPE\tCLUSTER-IP\tEXTERNAL-IP\tPORT(S)\n");
+	let mut count = 0usize;
+	for item in items {
+		let meta = item.get("metadata").unwrap_or(&Value::Null);
+		let spec = item.get("spec").unwrap_or(&Value::Null);
+
+		let name = meta.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+		let namespace = meta
+			.get("namespace")
+			.and_then(|v| v.as_str())
+			.unwrap_or("default");
+		let svc_type = spec
+			.get("type")
+			.and_then(|v| v.as_str())
+			.unwrap_or("ClusterIP");
+		let cluster_ip = spec
+			.get("clusterIP")
+			.and_then(|v| v.as_str())
+			.unwrap_or("<none>");
+
+		// External IP from loadBalancer status
+		let external_ip = item
+			.get("status")
+			.and_then(|s| s.get("loadBalancer"))
+			.and_then(|lb| lb.get("ingress"))
+			.and_then(|ing| ing.as_array())
+			.and_then(|ingress| ingress.first())
+			.and_then(|i| i.get("ip").or_else(|| i.get("hostname")))
+			.and_then(|v| v.as_str())
+			.unwrap_or("<none>");
+
+		// Ports
+		let ports = format_k8s_ports(spec.get("ports").and_then(|v| v.as_array()));
+
+		let display = if namespace == "default" {
+			name.to_string()
+		} else {
+			format!("{namespace}/{name}")
+		};
+
+		let _ = writeln!(out, "{display}\t{svc_type}\t{cluster_ip}\t{external_ip}\t{ports}");
+		count += 1;
+	}
+	out.push('\n');
+	let _ = writeln!(out, "{count} service(s)");
+	out
+}
+
+fn format_k8s_ports(ports: Option<&Vec<Value>>) -> String {
+	let Some(ports) = ports else {
+		return "<none>".to_string();
+	};
+	if ports.is_empty() {
+		return "<none>".to_string();
+	}
+	let parts: Vec<String> = ports
+		.iter()
+		.map(|p| {
+			let port = p
+				.get("port")
+				.and_then(|v| v.as_i64())
+				.map_or_else(|| "?".to_string(), |v| v.to_string());
+			let proto = p.get("protocol").and_then(|v| v.as_str()).unwrap_or("TCP");
+			let node_port = p.get("nodePort").and_then(|v| v.as_i64());
+			let target_port = p.get("targetPort");
+			let target = target_port
+				.and_then(|v| v.as_i64())
+				.map(|v| v.to_string())
+				.or_else(|| target_port.and_then(|v| v.as_str()).map(|s| s.to_string()));
+			match (target, node_port) {
+				(Some(t), Some(np)) => format!("{port}/{t}:{np}->{port}/{proto}"),
+				(Some(t), None) => format!("{port}/{t}:{port}/{proto}"),
+				(None, Some(np)) => format!("{np}:{port}->{port}/{proto}"),
+				(None, None) => format!("{port}/{proto}"),
+			}
+		})
+		.collect();
+	parts.join(",")
 }
 
 fn filter_helm(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> String {
@@ -92,6 +292,86 @@ fn filter_logs(input: &str) -> String {
 	let without_empty_runs = drop_repeated_blank_lines(input);
 	let deduped = primitives::dedup_consecutive_lines(&without_empty_runs);
 	primitives::head_tail_lines(&deduped, 120, 80)
+}
+
+fn filter_docker_logs(input: &str) -> String {
+	let without_empty_runs = drop_repeated_blank_lines(input);
+	let deduped = dedup_consecutive_log_lines(&without_empty_runs);
+	let priority = collect_priority_log_lines(&deduped);
+	if priority.is_empty() {
+		primitives::head_tail_lines(&deduped, 120, 80)
+	} else {
+		primitives::head_tail_lines(&priority, 120, 80)
+	}
+}
+
+fn dedup_consecutive_log_lines(input: &str) -> String {
+	let mut out = String::new();
+	let mut previous: Option<&str> = None;
+	let mut previous_key: Option<&str> = None;
+	let mut count = 0usize;
+
+	for line in input.lines() {
+		let key = log_dedup_key(line);
+		if previous_key == Some(key) {
+			count += 1;
+			continue;
+		}
+		flush_repeated_log_line(&mut out, previous, count);
+		previous = Some(line);
+		previous_key = Some(key);
+		count = 1;
+	}
+	flush_repeated_log_line(&mut out, previous, count);
+	out
+}
+
+fn flush_repeated_log_line(out: &mut String, line: Option<&str>, count: usize) {
+	let Some(line) = line else {
+		return;
+	};
+	out.push_str(line);
+	if count > 1 {
+		out.push_str(" (×");
+		out.push_str(&count.to_string());
+		out.push(')');
+	}
+	out.push('\n');
+}
+
+fn log_dedup_key(line: &str) -> &str {
+	if let Some((service, message)) = line.split_once('|') {
+		let service = service.trim();
+		if is_compose_log_service(service) {
+			return message.trim_start();
+		}
+	}
+	line
+}
+
+fn is_compose_log_service(value: &str) -> bool {
+	!value.is_empty()
+		&& !matches!(value, "debug" | "error" | "fatal" | "info" | "trace" | "warn" | "warning")
+		&& value.bytes().any(|byte| byte.is_ascii_lowercase())
+		&& value.bytes().all(|byte| {
+			byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'_' | b'.')
+		})
+}
+
+fn collect_priority_log_lines(input: &str) -> String {
+	let mut out = String::new();
+	for line in input.lines() {
+		if is_priority_log_line(line) {
+			out.push_str(line);
+			out.push('\n');
+		}
+	}
+	out
+}
+
+fn is_priority_log_line(line: &str) -> bool {
+	let line = line.to_ascii_lowercase();
+	line.contains("error") || line.contains("fail") || line.contains("warn")
 }
 
 fn compact_table(input: &str, visible_rows: usize) -> String {
@@ -136,11 +416,27 @@ fn compact_build_or_progress(input: &str) -> String {
 fn is_progress_line(line: &str) -> bool {
 	line.starts_with("=> ")
 		|| line.starts_with('#') && line.contains("DONE")
+		|| line.starts_with('#') && line.contains("CACHED")
+		|| line.starts_with('#') && line.contains("transferring ")
+		|| line.starts_with('#') && line.contains("extracting ")
 		|| line.contains("Pulling fs layer")
+		|| line.contains("Pull complete")
 		|| line.contains("Download complete")
+		|| line.contains("Downloading")
 		|| line.contains("Extracting")
 		|| line.contains("Waiting")
 		|| line.contains("Verifying Checksum")
+		|| line.starts_with("Attaching to ")
+		|| line.starts_with("Gracefully stopping")
+		|| is_compose_container_status_line(line)
+}
+
+fn is_compose_container_status_line(line: &str) -> bool {
+	let line = line.trim_start();
+	line.starts_with("Container ")
+		&& ["Creating", "Created", "Starting", "Started", "Waiting", "Healthy", "Running"]
+			.iter()
+			.any(|status| line.contains(status))
 }
 
 fn drop_repeated_blank_lines(input: &str) -> String {
@@ -172,10 +468,101 @@ mod tests {
 
 	#[test]
 	fn dedups_repeated_log_lines_before_truncation() {
-		let input = "api | ready\napi | ready\napi | ready\napi | failed\n";
-		let out = filter_logs(input);
+		let input = "api | ready\napi | ready\napi | ready\napi | done\n";
+		let out = filter_docker_logs(input);
 		assert!(out.contains("api | ready (×3)"));
-		assert!(out.contains("api | failed"));
+		assert!(out.contains("api | done"));
+	}
+
+	#[test]
+	fn dedups_compose_service_prefixed_log_messages() {
+		let input = "api-1  | ready\napi-2  | ready\napi | ready\nworker | busy\n";
+		let out = filter_docker_logs(input);
+		assert!(out.contains("api-1  | ready (×3)"));
+		assert!(out.contains("worker | busy"));
+	}
+
+	#[test]
+	fn docker_compose_logs_uses_log_filter() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let compose_ctx = MinimizerCtx {
+			program:    "docker",
+			subcommand: Some("compose"),
+			command:    "docker compose logs api",
+			config:     &cfg,
+		};
+		let input = "api-1  | ready\napi-2  | ready\napi | ready\n";
+		let out = filter(&compose_ctx, input, 0).text;
+		assert!(out.contains("api-1  | ready (×3)"));
+	}
+
+	#[test]
+	fn docker_compose_ps_uses_table_filter() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let compose_ctx = MinimizerCtx {
+			program:    "docker",
+			subcommand: Some("compose"),
+			command:    "docker compose ps",
+			config:     &cfg,
+		};
+		let mut input = String::from("NAME IMAGE COMMAND SERVICE CREATED STATUS PORTS\n");
+		for idx in 0..20 {
+			input.push_str(&format!("svc-{idx} img command api 1m running 8080/tcp\n"));
+		}
+		let out = filter(&compose_ctx, &input, 0).text;
+		assert!(out.contains("20 rows"));
+		assert!(out.contains("svc-0"));
+		assert!(out.contains("… 8 more rows"));
+	}
+
+	#[test]
+	fn strips_compose_up_progress_lines() {
+		let input = "Attaching to api-1, worker-1\n Container api-1  Creating\n Container api-1  \
+		             Created\napi-1  | ready\n";
+		let out = compact_build_or_progress(input);
+		assert!(!out.contains("Attaching to"));
+		assert!(!out.contains("Container api-1  Creating"));
+		assert!(out.contains("api-1  | ready"));
+	}
+
+	#[test]
+	fn strips_compose_build_progress_lines() {
+		let input = "#1 [internal] load build definition from Dockerfile\n#1 transferring \
+		             dockerfile: 512B done\n#2 [1/2] FROM docker.io/library/node:22\n#2 CACHED\n#3 \
+		             exporting to image\n#3 DONE 0.1s\nnaming to docker.io/library/app:latest\n";
+		let out = compact_build_or_progress(input);
+		assert!(!out.contains("transferring dockerfile"));
+		assert!(!out.contains("#2 CACHED"));
+		assert!(!out.contains("#3 DONE"));
+		assert!(out.contains("naming to docker.io/library/app:latest"));
+	}
+
+	#[test]
+	fn strips_compose_pull_progress_lines() {
+		let input = "app Pulling fs layer\napp Downloading\napp Verifying Checksum\napp Download \
+		             complete\napp Extracting\napp Pull complete\nStatus: Downloaded newer image \
+		             for docker.io/library/app:latest\n";
+		let out = compact_build_or_progress(input);
+		assert!(!out.contains("Pulling fs layer"));
+		assert!(!out.contains("Pull complete"));
+		assert!(out.contains("Status: Downloaded newer image for docker.io/library/app:latest"));
+	}
+
+	#[test]
+	fn prioritizes_error_lines_for_large_log_windows() {
+		let mut input = String::new();
+		for i in 0..260 {
+			input.push_str("api-1  | request ");
+			input.push_str(&i.to_string());
+			input.push_str(" complete\n");
+		}
+		input.push_str("api-1  | WARN cache miss\n");
+		input.push_str("worker | failed to process job\n");
+
+		let out = filter_docker_logs(&input);
+		assert!(out.contains("api-1  | WARN cache miss"));
+		assert!(out.contains("worker | failed to process job"));
+		assert!(!out.contains("api-1  | request 0 complete"));
 	}
 
 	#[test]
@@ -213,5 +600,146 @@ mod tests {
 		assert_eq!(filter(&docker_ctx, &input, 1).text, input);
 		assert_eq!(filter(&kubectl_ctx, &input, 1).text, input);
 		assert_eq!(filter(&helm_ctx, &input, 1).text, input);
+	}
+
+	// ── kubectl JSON tests ───────────────────────────────────────────────
+
+	#[test]
+	fn compacts_kubectl_get_pods_json() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let kubectl_ctx = ctx("kubectl", Some("get"), &cfg);
+		let input = r#"{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "metadata": {
+                "name": "nginx-pod",
+                "namespace": "default"
+            },
+            "spec": {
+                "nodeName": "node-1",
+                "containers": [{"name": "nginx", "image": "nginx:latest"}]
+            },
+            "status": {
+                "phase": "Running",
+                "podIP": "10.0.0.1",
+                "startTime": "2024-01-15T10:00:00Z",
+                "containerStatuses": [
+                    {"name": "nginx", "ready": true, "restartCount": 0}
+                ]
+            },
+            "kind": "Pod"
+        },
+        {
+            "metadata": {
+                "name": "failing-pod",
+                "namespace": "kube-system"
+            },
+            "spec": {
+                "nodeName": "node-2",
+                "containers": [
+                    {"name": "app", "image": "app:v1"},
+                    {"name": "sidecar", "image": "sidecar:v1"}
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "podIP": "10.0.0.2",
+                "startTime": "2024-01-15T09:00:00Z",
+                "containerStatuses": [
+                    {"name": "app", "ready": true, "restartCount": 3},
+                    {"name": "sidecar", "ready": false, "restartCount": 1}
+                ]
+            },
+            "kind": "Pod"
+        }
+    ],
+    "kind": "List"
+}"#;
+		let out = filter(&kubectl_ctx, input, 0).text;
+		assert!(out.contains("nginx-pod\t1/1\tRunning\t0"));
+		assert!(out.contains("kube-system/failing-pod\t1/2\tRunning\t4"));
+		assert!(out.contains("2 pod(s)"));
+	}
+
+	#[test]
+	fn compacts_kubectl_get_services_json() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let kubectl_ctx = ctx("kubectl", Some("get"), &cfg);
+		let input = r#"{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "metadata": { "name": "my-svc", "namespace": "default" },
+            "spec": {
+                "type": "ClusterIP",
+                "clusterIP": "10.0.0.10",
+                "ports": [
+                    {"port": 80, "targetPort": 8080, "protocol": "TCP"}
+                ]
+            },
+            "kind": "Service"
+        },
+        {
+            "metadata": { "name": "lb-svc", "namespace": "prod" },
+            "spec": {
+                "type": "LoadBalancer",
+                "clusterIP": "10.0.0.20",
+                "ports": [
+                    {"port": 443, "targetPort": 8443, "protocol": "TCP", "nodePort": 30001}
+                ]
+            },
+            "status": {
+                "loadBalancer": {
+                    "ingress": [{"ip": "203.0.113.1"}]
+                }
+            },
+            "kind": "Service"
+        }
+    ],
+    "kind": "List"
+}"#;
+		let out = filter(&kubectl_ctx, input, 0).text;
+		assert!(out.contains("my-svc\tClusterIP\t10.0.0.10\t<none>\t80/8080:80/TCP"));
+		assert!(
+			out.contains("prod/lb-svc\tLoadBalancer\t10.0.0.20\t203.0.113.1\t443/8443:30001->443/TCP")
+		);
+		assert!(out.contains("2 service(s)"));
+	}
+
+	#[test]
+	fn kubectl_json_parse_failure_falls_back_to_table() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let kubectl_ctx = ctx("kubectl", Some("get"), &cfg);
+		let mut input = String::from("NAME STATUS\n");
+		for i in 0..25 {
+			input.push_str(&format!("pod-{} running\n", i));
+		}
+		let out = filter(&kubectl_ctx, &input, 0).text;
+		// Should use table compaction, not crash
+		assert!(out.contains("25 rows"));
+		assert!(out.contains("pod-0"));
+	}
+
+	#[test]
+	fn kubectl_non_list_json_returns_unchanged() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let kubectl_ctx = ctx("kubectl", Some("get"), &cfg);
+		// Valid JSON but not a kubectl List — unrecognized
+		let input = r#"{"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "single"}}"#;
+		let out = filter(&kubectl_ctx, input, 0).text;
+		// Falls back — table compaction would try to process this
+		// The key is: doesn't crash, doesn't lose data
+		assert!(!out.is_empty());
+	}
+
+	#[test]
+	fn failing_kubectl_get_json_preserves_error() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let kubectl_ctx = ctx("kubectl", Some("get"), &cfg);
+		let input = "Error from server (Forbidden): pods is forbidden\n";
+		let out = filter(&kubectl_ctx, input, 1).text;
+		// Non-zero exit with non-logs → preserve verbatim
+		assert_eq!(out, input);
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/generic.rs
+++ b/crates/pi-shell/src/minimizer/filters/generic.rs
@@ -5,8 +5,8 @@ use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
 pub fn filter(_ctx: &MinimizerCtx<'_>, input: &str, _exit_code: i32) -> MinimizerOutput {
 	let stripped = primitives::strip_ansi(input);
 	let deduped = primitives::dedup_consecutive_lines(&stripped);
-	let text = if deduped.lines().count() > 200 {
-		primitives::head_tail_lines(&deduped, 100, 60)
+	let text = if deduped.lines().count() > primitives::CapClass::Errors.lines() {
+		primitives::head_tail_cap(&deduped, primitives::CapClass::Errors)
 	} else {
 		deduped
 	};

--- a/crates/pi-shell/src/minimizer/filters/git.rs
+++ b/crates/pi-shell/src/minimizer/filters/git.rs
@@ -672,9 +672,13 @@ fn condense_branch(input: &str) -> String {
 }
 
 fn has_local_tracking_branch(remote: &str, current: Option<&str>, local: &[String]) -> bool {
-	let branch = remote
-		.rsplit_once('/')
-		.map_or(remote, |(_remote, branch)| branch);
+	// Only the conventional `origin/<branch>` mirror is treated as redundant with
+	// a local branch of the same name. Same-named branches on other remotes
+	// (e.g. `upstream/main` alongside `origin/main`) are distinct refs and must
+	// be preserved in the summary.
+	let Some(branch) = remote.strip_prefix("origin/") else {
+		return false;
+	};
 	current == Some(branch) || local.iter().any(|local| local == branch)
 }
 
@@ -1322,6 +1326,22 @@ mod tests {
 ";
 		let out = filter(&ctx, input, 0);
 		assert_eq!(out.text, "* main\nlocal: feat/a fix/b\nremote-only (2): origin/x upstream/y\n");
+	}
+
+	#[test]
+	fn branch_listing_keeps_same_named_branch_on_other_remote() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("branch"), "git branch -a", &cfg);
+		// Local `main` makes `origin/main` redundant, but `upstream/main` is a
+		// distinct ref and must survive.
+		let input = "\
+* main
+  remotes/origin/main
+  remotes/upstream/main
+";
+		let out = filter(&ctx, input, 0);
+		assert!(out.text.contains("upstream/main"), "{:?}", out.text);
+		assert!(!out.text.contains("origin/main"), "{:?}", out.text);
 	}
 
 	#[test]

--- a/crates/pi-shell/src/minimizer/filters/git.rs
+++ b/crates/pi-shell/src/minimizer/filters/git.rs
@@ -1,14 +1,17 @@
 //! Git output filters.
 
+use std::fmt::Write as _;
+
 use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
 
 pub fn supports(subcommand: Option<&str>) -> bool {
 	matches!(
 		subcommand,
 		Some(
-			"diff"
-				| "show" | "log"
-				| "add" | "commit"
+			"status"
+				| "diff" | "show"
+				| "log" | "add"
+				| "commit"
 				| "push" | "pull"
 				| "branch"
 				| "fetch"
@@ -26,22 +29,40 @@ pub fn supports(subcommand: Option<&str>) -> bool {
 	)
 }
 
-pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, _exit_code: i32) -> MinimizerOutput {
+pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerOutput {
 	if is_show_path_content(ctx.command) || is_stash_patch(ctx.command) {
 		return MinimizerOutput::passthrough(input);
 	}
 
 	let cleaned = primitives::strip_ansi(input);
 	let text = match ctx.subcommand {
-		Some("diff") => condense_diff(&cleaned),
-		Some("show") => primitives::head_tail_lines(&cleaned, 80, 40),
+		Some("status") if is_status_machine_format(ctx.command) => condense_status(&cleaned),
+		Some("status") => condense_status(&cleaned),
+		Some("diff") if is_stat_format(ctx.command) => condense_diff_stat(&cleaned),
+		Some("diff") => {
+			if exit_code == 0 {
+				if let Some(mode) = diff_listing_mode(ctx.command) {
+					compact_diff_listing(&cleaned, mode)
+				} else {
+					compact_diff_output(&cleaned)
+				}
+			} else {
+				compact_diff_output(&cleaned)
+			}
+		},
+		Some("show") => condense_show(&cleaned),
 		Some("log") => condense_log(&cleaned, 32, 16),
-		Some("branch" | "stash" | "tag") => primitives::compact_listing(&cleaned, 40),
+		Some("branch") => condense_branch(&cleaned),
+		Some("tag") => primitives::compact_listing(&cleaned, 40),
+		Some("stash") => condense_stash(ctx.command, &cleaned, exit_code),
 		Some("worktree") => cleaned,
-		Some(
-			"push" | "pull" | "fetch" | "merge" | "rebase" | "checkout" | "switch" | "restore"
-			| "clean" | "reset" | "add" | "commit",
-		) => condense_noisy_output(&cleaned),
+		Some("push") => condense_push(&cleaned, exit_code),
+		Some("pull") => condense_pull(&cleaned, exit_code),
+		Some("fetch") => condense_fetch(&cleaned, exit_code),
+		Some("commit") => condense_commit(&cleaned, exit_code),
+		Some("merge" | "rebase" | "checkout" | "switch" | "restore" | "clean" | "reset" | "add") => {
+			condense_noisy_output(&cleaned)
+		},
 		_ => cleaned,
 	};
 	if text == input {
@@ -84,6 +105,324 @@ fn has_ordered_tokens(command: &str, first: &str, second: &str) -> bool {
 
 fn has_token(command: &str, token: &str) -> bool {
 	command.split_whitespace().any(|part| part == token)
+}
+
+fn is_status_machine_format(command: &str) -> bool {
+	command.split_whitespace().any(|part| {
+		matches!(part, "-s" | "--short" | "--porcelain" | "--porcelain=v1" | "--porcelain=v2")
+	})
+}
+
+fn is_stat_format(command: &str) -> bool {
+	command
+		.split_whitespace()
+		.any(|part| part == "--stat" || part.starts_with("--stat="))
+}
+
+#[derive(Clone, Copy)]
+enum DiffListingMode {
+	NameOnly,
+	NameStatus,
+	Numstat,
+}
+
+const DIFF_LISTING_LIMIT: usize = 20;
+
+impl DiffListingMode {
+	const fn label(self) -> &'static str {
+		match self {
+			Self::NameOnly => "--name-only",
+			Self::NameStatus => "--name-status",
+			Self::Numstat => "--numstat",
+		}
+	}
+}
+
+fn diff_listing_mode(command: &str) -> Option<DiffListingMode> {
+	if has_token(command, "--name-only") {
+		Some(DiffListingMode::NameOnly)
+	} else if has_token(command, "--name-status") {
+		Some(DiffListingMode::NameStatus)
+	} else if has_token(command, "--numstat") {
+		Some(DiffListingMode::Numstat)
+	} else {
+		None
+	}
+}
+
+fn compact_diff_listing(input: &str, mode: DiffListingMode) -> String {
+	let mut entries = Vec::new();
+	for line in input.lines() {
+		if line.is_empty() {
+			continue;
+		}
+		if !is_diff_listing_line(mode, line) {
+			return input.to_string();
+		}
+		entries.push(primitives::truncate_line(line, 160));
+	}
+
+	if entries.len() <= DIFF_LISTING_LIMIT {
+		return input.to_string();
+	}
+
+	let mut out = String::new();
+	let _ = writeln!(out, "git diff {}: {}", mode.label(), format_file_count(entries.len()));
+	for entry in entries.iter().take(DIFF_LISTING_LIMIT) {
+		out.push_str(entry);
+		out.push('\n');
+	}
+	let _ = writeln!(out, "… {} files omitted …", entries.len() - DIFF_LISTING_LIMIT);
+	out
+}
+
+fn is_diff_listing_line(mode: DiffListingMode, line: &str) -> bool {
+	match mode {
+		DiffListingMode::NameOnly => true,
+		DiffListingMode::NameStatus => line.split('\t').count() >= 2,
+		DiffListingMode::Numstat => line.split('\t').count() >= 3,
+	}
+}
+
+#[derive(Default)]
+struct StatusSummary {
+	branch:    Option<String>,
+	clean:     bool,
+	staged:    usize,
+	unstaged:  usize,
+	untracked: usize,
+	conflicts: usize,
+	paths:     Vec<String>,
+}
+
+fn condense_status(input: &str) -> String {
+	let mut summary = StatusSummary::default();
+	let mut in_untracked = false;
+	// Long-format `git status` groups entries under section headers. `modified:`
+	// and `deleted:` appear in both the staged ("Changes to be committed:") and
+	// unstaged ("Changes not staged for commit:") sections, so we must track the
+	// active section to count them correctly.
+	let mut in_staged = false;
+	let mut state: Option<&str> = None;
+
+	for line in input.lines() {
+		let line = line.trim_end();
+		let trimmed = line.trim();
+		if trimmed.is_empty() {
+			continue;
+		}
+		if parse_short_status_line(line, &mut summary) {
+			continue;
+		}
+		if let Some(branch) = trimmed.strip_prefix("On branch ") {
+			summary.branch = Some(branch.to_string());
+			continue;
+		}
+		if trimmed.starts_with("nothing to commit") || trimmed == "working tree clean" {
+			summary.clean = true;
+			continue;
+		}
+		if let Some(detected) = detect_status_state(trimmed) {
+			if state.is_none() {
+				state = Some(detected);
+			}
+			continue;
+		}
+		if trimmed.starts_with("Changes to be committed:") {
+			in_staged = true;
+			in_untracked = false;
+			continue;
+		}
+		if trimmed.starts_with("Changes not staged for commit:")
+			|| trimmed.starts_with("Unmerged paths:")
+		{
+			in_staged = false;
+			in_untracked = false;
+			continue;
+		}
+		if trimmed.starts_with("Untracked files:") {
+			in_untracked = true;
+			in_staged = false;
+			continue;
+		}
+		if parse_long_status_line(trimmed, in_staged, in_untracked, &mut summary) {
+			continue;
+		}
+		if !trimmed.starts_with('(')
+			&& !trimmed.ends_with(':')
+			&& !trimmed.starts_with("use ")
+			&& !trimmed.starts_with("no changes added")
+			&& in_untracked
+		{
+			summary.untracked += 1;
+			push_status_path(&mut summary, "??", trimmed);
+		}
+	}
+
+	if status_has_no_signal(&summary) && state.is_none() {
+		return input.to_string();
+	}
+	let body = format_status_summary(&summary);
+	match state {
+		Some(s) => {
+			let mut out = String::with_capacity(7 + s.len() + 1 + body.len());
+			out.push_str("state: ");
+			out.push_str(s);
+			out.push('\n');
+			out.push_str(&body);
+			out
+		},
+		None => body,
+	}
+}
+fn detect_status_state(line: &str) -> Option<&str> {
+	if line.starts_with("You are currently rebasing") {
+		Some("rebasing")
+	} else if line.starts_with("You are currently cherry-picking") {
+		Some("cherry-pick")
+	} else if line.starts_with("You are currently reverting") {
+		Some("revert")
+	} else if line.starts_with("You are currently bisecting") {
+		Some("bisect")
+	} else if line.starts_with("You are in the middle of an am session") {
+		Some("am")
+	} else if line.starts_with("You are in a sparse checkout") {
+		Some("sparse-checkout")
+	} else if line == "You have unmerged paths." {
+		Some("merge-conflict")
+	} else {
+		None
+	}
+}
+
+fn parse_short_status_line(line: &str, summary: &mut StatusSummary) -> bool {
+	let Some(status) = line.get(..2) else {
+		return false;
+	};
+	let Some(path) = line.get(3..) else {
+		return false;
+	};
+	if !is_short_status(status) {
+		return false;
+	}
+	if status == "  " {
+		return false;
+	}
+	if status == "??" {
+		summary.untracked += 1;
+	} else if status.contains('U') {
+		summary.conflicts += 1;
+	} else {
+		let bytes = status.as_bytes();
+		if bytes[0] != b' ' {
+			summary.staged += 1;
+		}
+		if bytes[1] != b' ' {
+			summary.unstaged += 1;
+		}
+	}
+	push_status_path(summary, status.trim(), path.trim());
+	true
+}
+
+fn is_short_status(status: &str) -> bool {
+	status
+		.bytes()
+		.all(|byte| matches!(byte, b' ' | b'M' | b'A' | b'D' | b'R' | b'C' | b'U' | b'?' | b'!'))
+}
+
+fn parse_long_status_line(
+	line: &str,
+	in_staged: bool,
+	in_untracked: bool,
+	summary: &mut StatusSummary,
+) -> bool {
+	// `modified:`/`deleted:` are staged or unstaged depending on the active
+	// section; `new file:`/`renamed:` only appear staged. The unmerged-path
+	// forms are always conflicts regardless of section.
+	for (prefix, label, staged) in [
+		("modified:", "M", in_staged),
+		("deleted:", "D", in_staged),
+		("new file:", "A", true),
+		("renamed:", "R", true),
+		("both modified:", "UU", false),
+		("both added:", "AA", false),
+		("both deleted:", "DD", false),
+		("added by us:", "AU", false),
+		("added by them:", "UA", false),
+		("deleted by us:", "DU", false),
+		("deleted by them:", "UD", false),
+	] {
+		if let Some(path) = line.strip_prefix(prefix) {
+			if matches!(label, "UU" | "AA" | "DD" | "AU" | "UA" | "DU" | "UD") {
+				summary.conflicts += 1;
+			} else if staged {
+				summary.staged += 1;
+			} else {
+				summary.unstaged += 1;
+			}
+			push_status_path(summary, label, path.trim());
+			return true;
+		}
+	}
+	if in_untracked && !line.starts_with('(') && !line.ends_with(':') {
+		summary.untracked += 1;
+		push_status_path(summary, "??", line);
+		return true;
+	}
+	false
+}
+
+fn push_status_path(summary: &mut StatusSummary, label: &str, path: &str) {
+	if path.is_empty() {
+		return;
+	}
+	summary
+		.paths
+		.push(format!("{label} {}", primitives::truncate_line(path, 160)));
+}
+
+const fn status_has_no_signal(summary: &StatusSummary) -> bool {
+	summary.branch.is_none()
+		&& !summary.clean
+		&& summary.staged == 0
+		&& summary.unstaged == 0
+		&& summary.untracked == 0
+		&& summary.conflicts == 0
+}
+
+fn format_status_summary(summary: &StatusSummary) -> String {
+	let mut out = String::new();
+	if let Some(branch) = &summary.branch {
+		out.push_str("branch ");
+		out.push_str(branch);
+		out.push('\n');
+	}
+	if summary.clean && summary.paths.is_empty() {
+		out.push_str("clean\n");
+		return out;
+	}
+	out.push_str("staged ");
+	out.push_str(&summary.staged.to_string());
+	out.push_str(", unstaged ");
+	out.push_str(&summary.unstaged.to_string());
+	out.push_str(", untracked ");
+	out.push_str(&summary.untracked.to_string());
+	if summary.conflicts > 0 {
+		out.push_str(", conflicts ");
+		out.push_str(&summary.conflicts.to_string());
+	}
+	out.push('\n');
+	for path in summary.paths.iter().take(40) {
+		out.push_str(path);
+		out.push('\n');
+	}
+	if summary.paths.len() > 40 {
+		out.push_str("… ");
+		out.push_str(&(summary.paths.len() - 40).to_string());
+		out.push_str(" paths omitted\n");
+	}
+	out
 }
 
 fn condense_log(input: &str, head: usize, tail: usize) -> String {
@@ -131,6 +470,7 @@ fn condense_log(input: &str, head: usize, tail: usize) -> String {
 struct LogEntry {
 	hash:    String,
 	subject: String,
+	body:    Vec<String>,
 }
 
 fn push_log_entry(out: &mut String, entry: &LogEntry) {
@@ -140,6 +480,11 @@ fn push_log_entry(out: &mut String, entry: &LogEntry) {
 		out.push_str(&entry.subject);
 	}
 	out.push('\n');
+	for line in &entry.body {
+		out.push_str("  ");
+		out.push_str(line);
+		out.push('\n');
+	}
 }
 
 fn parse_log_entries(input: &str) -> Vec<LogEntry> {
@@ -155,28 +500,26 @@ fn parse_log_entries(input: &str) -> Vec<LogEntry> {
 			let (hash, subject) = trimmed
 				.split_once(' ')
 				.map_or((trimmed, ""), |(hash, subject)| (hash, subject.trim()));
-			current = Some(LogEntry { hash: short_hash(hash), subject: subject.to_string() });
+			current = Some(LogEntry {
+				hash:    short_hash(hash),
+				subject: subject.to_string(),
+				body:    Vec::new(),
+			});
 			continue;
 		}
 
 		let Some(entry) = current.as_mut() else {
 			continue;
 		};
-		if !entry.subject.is_empty() {
-			continue;
-		}
 		let trimmed = line.trim();
-		if trimmed.is_empty()
-			|| trimmed.starts_with("Author:")
-			|| trimmed.starts_with("Date:")
-			|| trimmed.starts_with("Merge:")
-			|| trimmed.contains('|')
-			|| trimmed.contains("files changed")
-			|| trimmed.contains("file changed")
-		{
+		if skip_log_line(trimmed) {
 			continue;
 		}
-		entry.subject = trimmed.to_string();
+		if entry.subject.is_empty() {
+			entry.subject = trimmed.to_string();
+		} else if entry.body.len() < 3 && !is_git_trailer(trimmed) {
+			entry.body.push(trimmed.to_string());
+		}
 	}
 
 	if let Some(entry) = current {
@@ -187,6 +530,152 @@ fn parse_log_entries(input: &str) -> Vec<LogEntry> {
 
 fn short_hash(hash: &str) -> String {
 	hash.chars().take(7).collect()
+}
+
+fn skip_log_line(trimmed: &str) -> bool {
+	trimmed.is_empty()
+		|| trimmed.starts_with("Author:")
+		|| trimmed.starts_with("Date:")
+		|| trimmed.starts_with("Merge:")
+		|| trimmed.contains('|')
+		|| trimmed.contains("files changed")
+		|| trimmed.contains("file changed")
+}
+
+fn is_git_trailer(trimmed: &str) -> bool {
+	const TRAILERS: &[&str] = &[
+		"Signed-off-by:",
+		"Co-authored-by:",
+		"Acked-by:",
+		"Reviewed-by:",
+		"Tested-by:",
+		"Reported-by:",
+		"Helped-by:",
+		"Suggested-by:",
+		"Change-Id:",
+		"Refs:",
+	];
+	TRAILERS.iter().any(|prefix| trimmed.starts_with(prefix))
+}
+
+fn condense_show(input: &str) -> String {
+	let Some(diff_start) = input.find("\ndiff --git ") else {
+		return primitives::head_tail_lines(input, 80, 40);
+	};
+	let prelude = &input[..diff_start];
+	let diff = &input[diff_start + 1..];
+	let diff_summary = compact_diff_output(diff);
+	if diff_summary == diff {
+		return primitives::head_tail_lines(input, 80, 40);
+	}
+
+	let mut out = String::new();
+	push_show_commit_summary(&mut out, prelude);
+	if !out.is_empty() {
+		out.push('\n');
+	}
+	out.push_str(&diff_summary);
+	out
+}
+
+fn push_show_commit_summary(out: &mut String, prelude: &str) {
+	let mut body_lines = 0usize;
+	for line in prelude.lines() {
+		let trimmed = line.trim();
+		if let Some(rest) = trimmed.strip_prefix("commit ") {
+			out.push_str("commit ");
+			out.push_str(&short_hash(rest));
+			out.push('\n');
+			continue;
+		}
+		if skip_log_line(trimmed) || is_git_trailer(trimmed) {
+			continue;
+		}
+		if trimmed.starts_with("diff --git") {
+			break;
+		}
+		if body_lines >= 4 {
+			continue;
+		}
+		out.push_str(trimmed);
+		out.push('\n');
+		body_lines += 1;
+	}
+}
+
+fn condense_branch(input: &str) -> String {
+	let mut current: Option<String> = None;
+	let mut local = Vec::new();
+	let mut remote_only = Vec::new();
+
+	for line in input.lines() {
+		let trimmed = line.trim();
+		if trimmed.is_empty() || trimmed.contains(" -> ") {
+			continue;
+		}
+		let (is_current, name) = trimmed
+			.strip_prefix('*')
+			.map_or((false, trimmed), |rest| (true, rest.trim()));
+		if name.is_empty() {
+			continue;
+		}
+		if is_current {
+			current = Some(name.to_string());
+		} else if name.starts_with("remotes/") {
+			remote_only.push(name.trim_start_matches("remotes/").to_string());
+		} else {
+			local.push(name.to_string());
+		}
+	}
+
+	if current.is_none() && local.is_empty() && remote_only.is_empty() {
+		return input.to_string();
+	}
+
+	let mut out = String::new();
+	if let Some(current) = current.as_deref() {
+		out.push_str("* ");
+		out.push_str(current);
+		out.push('\n');
+	}
+	if !local.is_empty() {
+		out.push_str("local:");
+		for branch in local.iter().take(24) {
+			out.push(' ');
+			out.push_str(branch);
+		}
+		if local.len() > 24 {
+			out.push_str(" … +");
+			out.push_str(&(local.len() - 24).to_string());
+		}
+		out.push('\n');
+	}
+	let remote_only = remote_only
+		.into_iter()
+		.filter(|branch| !has_local_tracking_branch(branch, current.as_deref(), &local))
+		.collect::<Vec<_>>();
+	if !remote_only.is_empty() {
+		out.push_str("remote-only (");
+		out.push_str(&remote_only.len().to_string());
+		out.push_str("):");
+		for branch in remote_only.iter().take(24) {
+			out.push(' ');
+			out.push_str(branch);
+		}
+		if remote_only.len() > 24 {
+			out.push_str(" … +");
+			out.push_str(&(remote_only.len() - 24).to_string());
+		}
+		out.push('\n');
+	}
+	out
+}
+
+fn has_local_tracking_branch(remote: &str, current: Option<&str>, local: &[String]) -> bool {
+	let branch = remote
+		.rsplit_once('/')
+		.map_or(remote, |(_remote, branch)| branch);
+	current == Some(branch) || local.iter().any(|local| local == branch)
 }
 
 struct DiffFile {
@@ -201,7 +690,7 @@ struct DiffHunk {
 	lines:  Vec<String>,
 }
 
-fn condense_diff(input: &str) -> String {
+pub(crate) fn compact_diff_output(input: &str) -> String {
 	let files = parse_unified_diff(input);
 	if files.is_empty() {
 		return input.to_string();
@@ -273,6 +762,7 @@ fn parse_unified_diff(input: &str) -> Vec<DiffFile> {
 	let mut files = Vec::new();
 	let mut current: Option<DiffFile> = None;
 	let mut current_hunk: Option<DiffHunk> = None;
+	let mut pending_old_path: Option<String> = None;
 
 	for line in input.lines() {
 		if let Some(path) = parse_diff_git_path(line) {
@@ -281,12 +771,45 @@ fn parse_unified_diff(input: &str) -> Vec<DiffFile> {
 				files.push(file);
 			}
 			current = Some(DiffFile { path, added: 0, removed: 0, hunks: Vec::new() });
+			pending_old_path = None;
 			continue;
 		}
-		if let Some(path) = line.strip_prefix("+++ b/") {
-			if let Some(file) = current.as_mut() {
-				file.path = path.to_string();
+		if let Some(path) = line.strip_prefix("--- ") {
+			pending_old_path = Some(path.strip_prefix("a/").unwrap_or(path).to_string());
+			continue;
+		}
+		if let Some(path) = line.strip_prefix("+++ ") {
+			let path = path.strip_prefix("b/").unwrap_or(path);
+			let path = if path == "/dev/null" {
+				pending_old_path.as_deref().unwrap_or(path)
+			} else {
+				path
+			};
+			flush_hunk(&mut current, &mut current_hunk);
+			let update_current_path = current
+				.as_ref()
+				.is_some_and(|file| file.added == 0 && file.removed == 0 && file.hunks.is_empty());
+			if update_current_path {
+				if let Some(file) = current.as_mut() {
+					file.path = path.to_string();
+				}
+			} else if let Some(file) = current.take() {
+				files.push(file);
+				current = Some(DiffFile {
+					path:    path.to_string(),
+					added:   0,
+					removed: 0,
+					hunks:   Vec::new(),
+				});
+			} else {
+				current = Some(DiffFile {
+					path:    path.to_string(),
+					added:   0,
+					removed: 0,
+					hunks:   Vec::new(),
+				});
 			}
+			pending_old_path = None;
 			continue;
 		}
 		if line.starts_with("@@") {
@@ -364,7 +887,374 @@ fn format_file_count(files: usize) -> String {
 
 fn condense_noisy_output(input: &str) -> String {
 	let deduped = primitives::dedup_consecutive_lines(input);
-	primitives::head_tail_lines(&deduped, 80, 40)
+	primitives::head_tail_cap(&deduped, primitives::CapClass::Errors)
+}
+
+fn condense_commit(input: &str, exit_code: i32) -> String {
+	if exit_code == 0 {
+		for line in input.lines() {
+			let trimmed = line.trim();
+			if let Some(hash) = parse_commit_hash(trimmed) {
+				return format!("ok {hash}\n");
+			}
+		}
+		// No commit hash found — likely a `--dry-run` invocation that exits 0
+		// but prints a status-style listing instead of a "[branch hash]" line.
+		// Preserve/condense the output rather than replacing it with bare "ok".
+		return condense_noisy_output(input);
+	}
+
+	if input.contains("nothing to commit") {
+		return "ok (nothing to commit)\n".to_string();
+	}
+
+	condense_noisy_output(input)
+}
+
+fn parse_commit_hash(line: &str) -> Option<&str> {
+	let rest = line.strip_prefix('[')?;
+	let (prefix, _message) = rest.split_once(']')?;
+	prefix.split_whitespace().last()
+}
+
+fn is_push_progress(line: &str) -> bool {
+	let t = line.trim_start();
+	t.starts_with("Enumerating objects:")
+		|| t.starts_with("Counting objects:")
+		|| t.starts_with("Delta compression")
+		|| t.starts_with("Compressing objects:")
+		|| t.starts_with("Writing objects:")
+		|| t.starts_with("Total ")
+}
+
+fn is_remote_progress(line: &str) -> bool {
+	let Some(rest) = line
+		.trim()
+		.strip_prefix("remote:")
+		.or_else(|| line.trim().strip_prefix("remote: "))
+	else {
+		return false;
+	};
+	let rest = rest.trim();
+	rest.starts_with("Resolving deltas:")
+		|| rest.starts_with("Enumerating objects:")
+		|| rest.starts_with("Counting objects:")
+		|| rest.starts_with("Compressing objects:")
+		|| rest.starts_with("Writing objects:")
+		|| rest.starts_with("Total ")
+}
+
+fn extract_pushed_ref(line: &str) -> Option<&str> {
+	let (_before, after_arrow) = line.split_once(" -> ")?;
+	after_arrow.split_whitespace().next()
+}
+
+fn condense_push(input: &str, exit_code: i32) -> String {
+	let cleaned = primitives::strip_ansi(input);
+	let stripped = primitives::strip_lines(&cleaned, &[is_push_progress]);
+
+	let mut out = String::new();
+	if exit_code == 0 {
+		let mut pushed_ref = None;
+
+		for line in stripped.lines() {
+			let trimmed = line.trim();
+			if trimmed.is_empty() {
+				continue;
+			}
+			if is_remote_progress(trimmed) {
+				continue;
+			}
+			// Keep remote warnings / notes (non-progress remote lines)
+			if trimmed.starts_with("remote:") {
+				out.push_str(line);
+				out.push('\n');
+				continue;
+			}
+			// Keep destination lines
+			if trimmed.starts_with("To ") {
+				out.push_str(line);
+				out.push('\n');
+				continue;
+			}
+			// Keep ref update lines: "* [new ...]", branch setup, or "hash..hash ref ->
+			// ref"
+			if trimmed.starts_with("* [new")
+				|| trimmed.starts_with("Branch ")
+				|| trimmed.contains(" -> ")
+			{
+				if pushed_ref.is_none() {
+					pushed_ref = extract_pushed_ref(trimmed);
+				}
+				out.push_str(line);
+				out.push('\n');
+			}
+		}
+
+		if out.is_empty() {
+			out.push_str("ok (up-to-date)\n");
+		} else if let Some(dest) = pushed_ref {
+			out.push_str("ok ");
+			out.push_str(dest);
+			out.push('\n');
+		} else {
+			out.push_str("ok\n");
+		}
+	} else {
+		// Failure: keep diagnostics, strip only progress noise
+		for line in stripped.lines() {
+			let trimmed = line.trim();
+			if trimmed.is_empty() {
+				continue;
+			}
+			if is_remote_progress(trimmed) {
+				continue;
+			}
+			out.push_str(line);
+			out.push('\n');
+		}
+	}
+	out
+}
+fn condense_pull(input: &str, exit_code: i32) -> String {
+	if exit_code == 0 {
+		if input.contains("Already up to date.") || input.contains("Already up-to-date.") {
+			return "ok (up-to-date)\n".to_string();
+		}
+		for line in input.lines() {
+			let trimmed = line.trim();
+			if let Some((files, added, deleted)) = parse_stat_summary(trimmed) {
+				return format!("ok {files} files +{added} -{deleted}\n");
+			}
+		}
+		return "ok\n".to_string();
+	}
+	condense_noisy_output(input)
+}
+
+fn condense_diff_stat(input: &str) -> String {
+	let mut entries = Vec::new();
+	let mut summary = None;
+	for line in input.lines() {
+		let trimmed = line.trim();
+		if trimmed.is_empty() {
+			continue;
+		}
+		if let Some((files, added, deleted)) = parse_stat_summary(trimmed) {
+			summary = Some((files, added, deleted));
+			continue;
+		}
+		if trimmed.contains('|') {
+			entries.push(primitives::truncate_line(trimmed, 140));
+		}
+	}
+
+	let Some((files, added, deleted)) = summary else {
+		return primitives::head_tail_cap(input, primitives::CapClass::List);
+	};
+
+	let mut out = String::new();
+	let _ = writeln!(out, "git diff --stat: {files} files +{added} -{deleted}");
+	for entry in entries.iter().take(20) {
+		out.push_str(entry);
+		out.push('\n');
+	}
+	if entries.len() > 20 {
+		let _ = writeln!(out, "… {} files omitted …", entries.len() - 20);
+	}
+	out
+}
+
+fn parse_stat_summary(line: &str) -> Option<(&str, &str, &str)> {
+	// Parse "N file(s) changed, I insertion(s)(+), D deletion(s)(-)"
+	// or variants with only insertions or only deletions.
+	if !line.contains("file") || !line.contains("changed") {
+		return None;
+	}
+	let mut files = "";
+	let mut inserted = "0";
+	let mut deleted = "0";
+
+	for segment in line.split(", ") {
+		if segment.contains("file") && segment.contains("changed") {
+			files = segment.split_whitespace().next().unwrap_or("");
+		} else if segment.contains("insertion") {
+			inserted = segment.split_whitespace().next().unwrap_or("0");
+		} else if segment.contains("deletion") {
+			deleted = segment.split_whitespace().next().unwrap_or("0");
+		}
+	}
+
+	if files.is_empty() {
+		return None;
+	}
+	Some((files, inserted, deleted))
+}
+
+fn condense_fetch(input: &str, exit_code: i32) -> String {
+	let cleaned = primitives::strip_ansi(input);
+	let stripped = primitives::strip_lines(&cleaned, &[is_remote_progress]);
+
+	if exit_code == 0 {
+		let mut updates: usize = 0;
+		let mut kept = Vec::new();
+
+		for line in stripped.lines() {
+			let trimmed = line.trim();
+			if trimmed.is_empty() {
+				continue;
+			}
+			if trimmed.starts_with("From ") || trimmed.starts_with("To ") {
+				kept.push(trimmed.to_string());
+				continue;
+			}
+			// remote: warnings/errors
+			if trimmed.starts_with("remote:") && !is_remote_progress(trimmed) {
+				kept.push(trimmed.to_string());
+				continue;
+			}
+			// Branch fetch lines: " * branch       name -> FETCH_HEAD" or "   hash..hash
+			// name -> name"
+			if trimmed.starts_with('*') || trimmed.starts_with(" *") {
+				if trimmed.contains("..") {
+					updates += 1;
+				}
+				kept.push(trimmed.to_string());
+				continue;
+			}
+			if trimmed.contains(" -> ") && (trimmed.starts_with('-') || trimmed.contains("..")) {
+				if trimmed.contains("..") {
+					updates += 1;
+				}
+				kept.push(trimmed.to_string());
+			}
+			// Keep error/warning lines
+			if trimmed.starts_with("error:")
+				|| trimmed.starts_with("fatal:")
+				|| trimmed.starts_with("warning:")
+			{
+				kept.push(trimmed.to_string());
+			}
+		}
+
+		let mut out = String::new();
+		for line in kept {
+			out.push_str(&line);
+			out.push('\n');
+		}
+		if updates == 0 {
+			out.push_str("ok fetched (up-to-date)\n");
+		} else {
+			out.push_str("ok fetched, ");
+			out.push_str(&updates.to_string());
+			out.push_str(" update");
+			if updates != 1 {
+				out.push('s');
+			}
+			out.push('\n');
+		}
+		return out;
+	}
+
+	// Failure: keep diagnostics, dedup like old condense_noisy_output
+	// Don't strip progress on failure; keep verbatim for debugging.
+	let deduped = primitives::dedup_consecutive_lines(input);
+	let mut out = String::new();
+	for line in deduped.lines() {
+		let trimmed = line.trim();
+		if trimmed.is_empty() {
+			continue;
+		}
+		out.push_str(trimmed);
+		out.push('\n');
+	}
+	primitives::head_tail_lines(&out, 80, 40)
+}
+
+fn condense_stash(command: &str, input: &str, exit_code: i32) -> String {
+	if has_token(command, "list") {
+		return condense_stash_list(input);
+	}
+	if exit_code == 0 {
+		let sub = stash_subcommand(command);
+		// Bare "stash" defaults to push
+		let sub = if sub.is_empty() { "push" } else { sub };
+		if sub == "push" || sub == "save" {
+			return "ok stashed\n".to_string();
+		}
+		if sub == "apply"
+			|| sub == "pop"
+			|| sub == "drop"
+			|| sub == "branch"
+			|| sub == "clear"
+			|| sub == "create"
+		{
+			return format!("ok stash {sub}\n");
+		}
+		// Default: compact listing fallback
+		return primitives::compact_listing(input, 40);
+	}
+
+	// Non-zero exit: keep it, but check for "No local changes to save"
+	if input.contains("No local changes to save") {
+		return "No local changes to save\n".to_string();
+	}
+	condense_noisy_output(input)
+}
+
+fn condense_stash_list(input: &str) -> String {
+	let mut out = String::new();
+	let mut count = 0usize;
+	for line in input.lines() {
+		let trimmed = line.trim();
+		if trimmed.is_empty() {
+			continue;
+		}
+		count += 1;
+		// Format: "stash@{N}: WIP on <branch>: <hash> <message>"
+		// or    : "stash@{N}: On <branch>: <hash> <message>"
+		let (stash_ref, after_stash) = if let Some((stash_ref, rest)) = trimmed.split_once(": ") {
+			(stash_ref, rest)
+		} else {
+			("", trimmed)
+		};
+		// Strip "WIP on <branch>: " or "On <branch>: " noise, keep stash ref.
+		let compact = if let Some(rest) = after_stash.strip_prefix("WIP on ") {
+			rest
+				.split_once(": ")
+				.map_or(after_stash, |(_branch, msg)| msg.trim())
+		} else if let Some(rest) = after_stash.strip_prefix("On ") {
+			rest
+				.split_once(": ")
+				.map_or(after_stash, |(_branch, msg)| msg.trim())
+		} else {
+			after_stash
+		};
+		if !stash_ref.is_empty() {
+			out.push_str(stash_ref);
+			out.push_str(": ");
+		}
+		out.push_str(compact);
+		out.push('\n');
+	}
+	if count == 0 {
+		return input.to_string();
+	}
+	// Remove trailing newline then add exactly one
+	out.pop();
+	out.push('\n');
+	out
+}
+
+fn stash_subcommand(command: &str) -> &str {
+	for part in command.split_whitespace() {
+		match part {
+			"push" | "save" | "apply" | "pop" | "drop" | "branch" | "clear" | "create" | "show"
+			| "list" => return part,
+			_ => {},
+		}
+	}
+	""
 }
 
 #[cfg(test)]
@@ -381,8 +1271,33 @@ mod tests {
 	}
 
 	#[test]
-	fn status_is_not_supported() {
-		assert!(!supports(Some("status")));
+	fn status_is_supported() {
+		assert!(supports(Some("status")));
+	}
+
+	#[test]
+	fn short_status_is_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status --short", &cfg);
+		let input = " M src/main.rs\nM  Cargo.toml\n?? scratch.txt\nUU conflicted.rs\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert_eq!(
+			out.text,
+			"staged 1, unstaged 1, untracked 1, conflicts 1\nM src/main.rs\nM Cargo.toml\n?? \
+			 scratch.txt\nUU conflicted.rs\n"
+		);
+	}
+	#[test]
+	fn long_status_clean_is_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status", &cfg);
+		let input = "On branch main\nYour branch is up to date with 'origin/main'.\n\nnothing to \
+		             commit, working tree clean\n";
+		let out = filter(&ctx, input, 0);
+
+		assert!(out.changed);
+		assert_eq!(out.text, "branch main\nclean\n");
 	}
 
 	#[test]
@@ -396,17 +1311,17 @@ mod tests {
 	fn branch_listing_is_compacted() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
 		let ctx = test_ctx(Some("branch"), "git branch -a", &cfg);
-		let mut input = String::new();
-		for idx in 0..60 {
-			input.push_str("  feature/");
-			input.push_str(&idx.to_string());
-			input.push('\n');
-		}
-		let out = filter(&ctx, &input, 0);
-		assert!(out.text.starts_with("60 entries\n"));
-		assert!(out.text.contains("feature/0"));
-		assert!(out.text.contains("feature/59"));
-		assert!(out.text.contains("…"));
+		let input = "\
+* main
+  feat/a
+  fix/b
+  remotes/origin/main
+  remotes/origin/x
+  remotes/upstream/y
+  remotes/origin/HEAD -> origin/main
+";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, "* main\nlocal: feat/a fix/b\nremote-only (2): origin/x upstream/y\n");
 	}
 
 	#[test]
@@ -431,6 +1346,26 @@ mod tests {
 
 		assert!(!out.changed);
 		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn show_condenses_commit_stat_and_diff_samples() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("show"), "git show HEAD", &cfg);
+		let input = "commit abcdef1234567890\nAuthor: Somebody\nDate: today\n\n    fix: update \
+		             thing\n\n    Keep useful body line.\n    Signed-off-by: Somebody \
+		             <s@example.com>\n\ndiff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ \
+		             b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.contains("commit abcdef1"));
+		assert!(out.text.contains("fix: update thing"));
+		assert!(out.text.contains("Keep useful body line."));
+		assert!(!out.text.contains("Signed-off-by"));
+		assert!(out.text.contains("src/lib.rs | 2"));
+		assert!(out.text.contains("--- Changes ---"));
+		assert!(out.text.contains("-old"));
+		assert!(out.text.contains("+new"));
 	}
 
 	#[test]
@@ -479,6 +1414,22 @@ mod tests {
 	}
 
 	#[test]
+	fn log_keeps_useful_body_lines_and_strips_trailers() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("log"), "git log", &cfg);
+		let input = "commit abcdef1234567890\nAuthor: Somebody\nDate: today\n\n    feat: add \
+		             API\n\n    BREAKING CHANGE: response shape changed\n    Fixes #123\n    \
+		             Signed-off-by: Somebody <s@example.com>\n    Co-authored-by: Other \
+		             <o@example.com>\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.text.contains("abcdef1 feat: add API"));
+		assert!(out.text.contains("BREAKING CHANGE: response shape changed"));
+		assert!(out.text.contains("Fixes #123"));
+		assert!(!out.text.contains("Signed-off-by"));
+		assert!(!out.text.contains("Co-authored-by"));
+	}
+
+	#[test]
 	fn diff_condenses_unified_patch_to_stat_and_hunk_samples() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
 		let ctx = test_ctx(Some("diff"), "git diff HEAD~1", &cfg);
@@ -501,11 +1452,549 @@ mod tests {
 	}
 
 	#[test]
+	fn diff_stat_is_summarized() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("diff"), "git diff --stat", &cfg);
+		let input = "\
+ crates/pi-shell/src/minimizer/filters/git.rs     | 385 +++++++++++++++++------
+ packages/coding-agent/src/exec/bash-executor.ts  |  18 ++
+ packages/coding-agent/test/bash-executor.test.ts |  45 ++-
+ 3 files changed, 448 insertions(+), 100 deletions(-)
+";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.starts_with("git diff --stat: 3 files +448 -100\n"));
+		assert!(
+			out.text
+				.contains("crates/pi-shell/src/minimizer/filters/git.rs")
+		);
+		assert!(
+			out.text
+				.contains("packages/coding-agent/test/bash-executor.test.ts")
+		);
+		assert!(!out.text.contains("3 files changed"));
+	}
+
+	#[test]
+	fn diff_name_only_is_compacted_and_bounded() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("diff"), "git diff --name-only HEAD~1", &cfg);
+		let mut input = String::new();
+		for idx in 0..26 {
+			input.push_str("src/file-");
+			input.push_str(&idx.to_string());
+			input.push_str(".rs\n");
+		}
+
+		let out = filter(&ctx, &input, 0);
+
+		assert!(out.changed);
+		assert!(out.text.starts_with("git diff --name-only: 26 files\n"));
+		assert!(out.text.contains("src/file-0.rs\n"));
+		assert!(out.text.contains("src/file-19.rs\n"));
+		assert!(!out.text.contains("src/file-20.rs\n"));
+		assert!(out.text.contains("… 6 files omitted …"));
+	}
+
+	#[test]
+	fn diff_name_status_is_compacted_and_bounded() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("diff"), "git diff --name-status HEAD~1", &cfg);
+		let mut input = String::new();
+		for idx in 0..24 {
+			input.push_str(if idx % 3 == 0 {
+				"R100\told-"
+			} else {
+				"M\tpath-"
+			});
+			input.push_str(&idx.to_string());
+			if idx % 3 == 0 {
+				input.push_str(".rs\tnew-");
+				input.push_str(&idx.to_string());
+				input.push_str(".rs\n");
+			} else {
+				input.push_str(".rs\n");
+			}
+		}
+
+		let out = filter(&ctx, &input, 0);
+
+		assert!(out.changed);
+		assert!(out.text.starts_with("git diff --name-status: 24 files\n"));
+		assert!(out.text.contains("R100\told-0.rs\tnew-0.rs\n"));
+		assert!(out.text.contains("M\tpath-1.rs\n"));
+		assert!(!out.text.contains("path-20.rs\n"));
+		assert!(out.text.contains("… 4 files omitted …"));
+	}
+
+	#[test]
+	fn diff_numstat_is_compacted_and_bounded() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("diff"), "git diff --numstat HEAD~1", &cfg);
+		let mut input = String::new();
+		for idx in 0..22 {
+			input.push_str(&(idx + 1).to_string());
+			input.push('\t');
+			input.push_str(&(idx % 7).to_string());
+			input.push('\t');
+			input.push_str("src/file-");
+			input.push_str(&idx.to_string());
+			input.push_str(".rs\n");
+		}
+
+		let out = filter(&ctx, &input, 0);
+
+		assert!(out.changed);
+		assert!(out.text.starts_with("git diff --numstat: 22 files\n"));
+		assert!(out.text.contains("1\t0\tsrc/file-0.rs\n"));
+		assert!(out.text.contains("20\t5\tsrc/file-19.rs\n"));
+		assert!(!out.text.contains("src/file-20.rs\n"));
+		assert!(out.text.contains("… 2 files omitted …"));
+	}
+
+	#[test]
+	fn diff_name_only_failure_keeps_diagnostics() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("diff"), "git diff --name-only badrev", &cfg);
+		let input =
+			"fatal: ambiguous argument 'badrev': unknown revision or path not in the working tree.\n";
+
+		let out = filter(&ctx, input, 128);
+
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
 	fn legacy_log_fallback_removes_metadata_when_no_commit_records_parse() {
 		let input = "commitish output\nAuthor: Somebody <s@example.com>\nDate: today\nmessage 0\n";
 		let out = condense_log(input, 32, 16);
 		assert!(out.contains("message 0"));
 		assert!(!out.contains("Author:"));
 		assert!(!out.contains("Date:"));
+	}
+
+	#[test]
+	fn commit_success_compacts_to_hash_only() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("commit"), "git commit -m msg", &cfg);
+		let input = "\
+[fix/omlx-local-model-limits 5f490f764] chore: checkpoint workspace changes
+ 70 files changed, 3081 insertions(+), 403 deletions(-)
+ create mode 100644 packages/example.ts
+ delete mode 100644 old-file.ts
+";
+		let out = filter(&ctx, input, 0);
+
+		assert_eq!(out.text, "ok 5f490f764\n");
+		assert!(!out.text.contains("files changed"));
+		assert!(!out.text.contains("create mode"));
+	}
+
+	#[test]
+	fn commit_nothing_to_commit_is_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("commit"), "git commit -m msg", &cfg);
+		let input = "On branch main\nnothing to commit, working tree clean\n";
+		let out = filter(&ctx, input, 1);
+
+		assert_eq!(out.text, "ok (nothing to commit)\n");
+	}
+
+	#[test]
+	fn push_noisy_success_is_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("push"), "git push", &cfg);
+		let input = "\
+Enumerating objects: 5, done.
+Counting objects: 100% (5/5), done.
+Delta compression using up to 8 threads
+Compressing objects: 100% (3/3), done.
+Writing objects: 100% (3/3), 1.23 KiB | 1.23 MiB/s, done.
+Total 3 (delta 2), reused 0 (delta 0), pack-reused 0
+remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
+To github.com:user/repo.git
+   abc1234..def5678  main -> main
+";
+		let out = filter(&ctx, input, 0);
+
+		assert!(out.changed);
+		assert!(out.text.contains("To github.com:user/repo.git"));
+		assert!(out.text.contains("main -> main"));
+		assert!(out.text.contains("ok main\n"));
+		assert!(!out.text.contains("Enumerating objects"));
+		assert!(!out.text.contains("Counting objects"));
+		assert!(!out.text.contains("Delta compression"));
+		assert!(!out.text.contains("Compressing objects"));
+		assert!(!out.text.contains("Writing objects"));
+		assert!(!out.text.contains("Total "));
+		assert!(!out.text.contains("remote: Resolving deltas"));
+	}
+
+	#[test]
+	fn push_up_to_date_is_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("push"), "git push", &cfg);
+		let input = "Everything up-to-date\n";
+		let out = filter(&ctx, input, 0);
+
+		assert!(out.changed);
+		assert_eq!(out.text, "ok (up-to-date)\n");
+	}
+
+	#[test]
+	fn push_remote_warning_is_kept() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("push"), "git push", &cfg);
+		let input = "\
+Enumerating objects: 3, done.
+Counting objects: 100% (3/3), done.
+Writing objects: 100% (3/3), done.
+Total 3 (delta 0), reused 0 (delta 0), pack-reused 0
+remote: warning: Large object detected, consider using Git LFS
+To github.com:user/repo.git
+   def5678..abc1234  main -> main
+";
+		let out = filter(&ctx, input, 0);
+
+		assert!(out.changed);
+		assert!(out.text.contains("remote: warning: Large object detected"));
+		assert!(out.text.contains("ok main\n"));
+		assert!(!out.text.contains("Enumerating objects"));
+	}
+
+	#[test]
+	fn push_rejected_failure_keeps_diagnostics() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("push"), "git push", &cfg);
+		let input = "\
+To github.com:user/repo.git
+ ! [rejected]        main -> main (non-fast-forward)
+error: failed to push some refs to 'github.com:user/repo.git'
+hint: Updates were rejected because the tip of your current branch is behind
+hint: its remote counterpart. Integrate the remote changes (e.g.
+hint: 'git pull ...') before pushing again.
+hint: See the 'Note about fast-forwards' in 'git push --help' for details.
+";
+		let out = filter(&ctx, input, 1);
+
+		assert!(!out.text.contains("ok\n"));
+		assert!(!out.text.contains("ok (up-to-date)"));
+		assert!(out.text.contains("rejected"));
+		assert!(out.text.contains("error: failed to push"));
+		assert!(out.text.contains("hint:"));
+	}
+
+	// --- Status state detection ---
+
+	#[test]
+	fn status_detects_rebasing() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status", &cfg);
+		let input = "On branch feature\nYou are currently rebasing.\n  (fix conflicts and then run \
+		             \"git rebase --continue\")\n\nChanges not staged for commit:\n  modified:   \
+		             src/main.rs\n\nno changes added to commit (use \"git add\")\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.starts_with("state: rebasing\n"));
+		assert!(out.text.contains("branch feature"));
+		assert!(out.text.contains("src/main.rs"));
+	}
+
+	#[test]
+	fn status_detects_cherry_pick() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status", &cfg);
+		let input = "On branch main\nYou are currently cherry-picking commit abc1234.\n  (fix \
+		             conflicts and run \"git cherry-pick --continue\")\n\nnothing to commit, \
+		             working tree clean\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.starts_with("state: cherry-pick\n"));
+	}
+
+	#[test]
+	fn status_detects_revert() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status", &cfg);
+		let input = "On branch main\nYou are currently reverting commit abc1234.\n\nnothing to \
+		             commit, working tree clean\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.starts_with("state: revert\n"));
+	}
+
+	#[test]
+	fn status_detects_bisect() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status", &cfg);
+		let input = "On branch main\nYou are currently bisecting, started from branch 'feature'.\n  \
+		             (use \"git bisect reset\" to get back to the original branch)\n\nnothing to \
+		             commit, working tree clean\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.starts_with("state: bisect\n"));
+	}
+
+	#[test]
+	fn status_detects_am_session() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status", &cfg);
+		let input = "On branch main\nYou are in the middle of an am session.\n  (fix conflicts and \
+		             then run \"git am --continue\")\n\nnothing to commit, working tree clean\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.starts_with("state: am\n"));
+	}
+
+	#[test]
+	fn status_detects_sparse_checkout() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status", &cfg);
+		let input = "On branch main\nYou are in a sparse checkout with 42% of tracked files \
+		             present.\n\nnothing to commit, working tree clean\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.starts_with("state: sparse-checkout\n"));
+	}
+
+	#[test]
+	fn status_detects_unmerged_paths() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status", &cfg);
+		let input = "On branch main\nYou have unmerged paths.\n  (fix conflicts and run \"git \
+		             commit\")\n\nUnmerged paths:\n  both modified:   conflicted.rs\n\nno changes \
+		             added to commit (use \"git add\")\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.starts_with("state: merge-conflict\n"));
+		assert!(out.text.contains("conflicts 1"));
+	}
+
+	#[test]
+	fn status_state_not_emitted_when_no_state() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status", &cfg);
+		let input = "On branch main\nYour branch is up to date with 'origin/main'.\n\nnothing to \
+		             commit, working tree clean\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(!out.text.contains("state:"));
+		assert_eq!(out.text, "branch main\nclean\n");
+	}
+
+	// --- Pull summaries ---
+
+	#[test]
+	fn pull_up_to_date_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("pull"), "git pull", &cfg);
+		let out = filter(&ctx, "Already up to date.\n", 0);
+		assert!(out.changed);
+		assert_eq!(out.text, "ok (up-to-date)\n");
+	}
+
+	#[test]
+	fn pull_up_to_date_hyphenated() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("pull"), "git pull", &cfg);
+		let out = filter(&ctx, "Already up-to-date.\n", 0);
+		assert!(out.changed);
+		assert_eq!(out.text, "ok (up-to-date)\n");
+	}
+
+	#[test]
+	fn pull_with_stat_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("pull"), "git pull", &cfg);
+		let input = "Updating abc1234..def5678\nFast-forward\n src/lib.rs | 12 ++++++++++++\n 1 \
+		             file changed, 12 insertions(+)\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert_eq!(out.text, "ok 1 files +12 -0\n");
+	}
+
+	#[test]
+	fn pull_with_delete_stat_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("pull"), "git pull", &cfg);
+		let input =
+			"Updating abc1234..def5678\n src/lib.rs | 3 ---\n 1 file changed, 3 deletions(-)\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert_eq!(out.text, "ok 1 files +0 -3\n");
+	}
+
+	#[test]
+	fn pull_conflict_keeps_diagnostics() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("pull"), "git pull", &cfg);
+		let input = "Auto-merging src/lib.rs\nCONFLICT (content): Merge conflict in \
+		             src/lib.rs\nAutomatic merge failed; fix conflicts and then commit the result.\n";
+		let out = filter(&ctx, input, 1);
+		assert!(out.text.contains("CONFLICT"));
+		assert!(!out.text.contains("ok"));
+	}
+
+	// --- Fetch summaries ---
+
+	#[test]
+	fn fetch_up_to_date_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("fetch"), "git fetch", &cfg);
+		let input = "From github.com:user/repo\n * branch            main       -> FETCH_HEAD\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.contains("From github.com:user/repo"));
+		assert!(out.text.contains("ok fetched (up-to-date)"));
+	}
+
+	#[test]
+	fn fetch_with_updates() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("fetch"), "git fetch", &cfg);
+		let input = "From github.com:user/repo\n   abc1234..def5678  main       -> origin/main\n   \
+		             aabbccd..eeff001  feature    -> origin/feature\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.contains("ok fetched, 2 updates"));
+	}
+
+	#[test]
+	fn fetch_single_update() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("fetch"), "git fetch", &cfg);
+		let input = "From github.com:user/repo\n   abc1234..def5678  main       -> origin/main\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.contains("ok fetched, 1 update\n"));
+	}
+
+	#[test]
+	fn fetch_preserves_remote_warnings() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("fetch"), "git fetch origin", &cfg);
+		let input = "From github.com:user/repo\nremote: warning: this is a test warning\n   \
+		             abc1234..def5678  main       -> origin/main\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.text.contains("remote: warning:"));
+		assert!(out.text.contains("ok fetched, 1 update"));
+	}
+
+	#[test]
+	fn fetch_failure_keeps_diagnostics() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("fetch"), "git fetch origin", &cfg);
+		let input = "fatal: 'origin' does not appear to be a git repository\nfatal: Could not read \
+		             from remote repository.\n";
+		let out = filter(&ctx, input, 128);
+		assert!(out.text.contains("fatal:"));
+		assert!(!out.text.contains("ok"));
+	}
+
+	// --- Stash improvements ---
+
+	#[test]
+	fn stash_push_success() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash push", &cfg);
+		let input = "Saved working directory and index state WIP on main: abc1234 some message\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert_eq!(out.text, "ok stashed\n");
+	}
+
+	#[test]
+	fn stash_save_success() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash save", &cfg);
+		let input = "Saved working directory and index state On main: abc1234 some message\n";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, "ok stashed\n");
+	}
+
+	#[test]
+	fn stash_bare_defaults_to_push() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash", &cfg);
+		let input = "Saved working directory and index state WIP on main: abc1234 some message\n";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, "ok stashed\n");
+	}
+
+	#[test]
+	fn stash_apply_success() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash apply", &cfg);
+		let input = "On branch main\nnothing to commit, working tree clean\n";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, "ok stash apply\n");
+	}
+
+	#[test]
+	fn stash_pop_success() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash pop", &cfg);
+		let input = "Dropped refs/stash@{0} (abc1234...)\n";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, "ok stash pop\n");
+	}
+
+	#[test]
+	fn stash_drop_success() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash drop", &cfg);
+		let input = "Dropped refs/stash@{0} (abc1234...)\n";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, "ok stash drop\n");
+	}
+
+	#[test]
+	fn stash_branch_success() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash branch new-branch", &cfg);
+		let input = "Switched to a new branch 'new-branch'\nDropped refs/stash@{0}\n";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, "ok stash branch\n");
+	}
+
+	#[test]
+	fn stash_clear_success() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash clear", &cfg);
+		let out = filter(&ctx, "", 0);
+		assert_eq!(out.text, "ok stash clear\n");
+	}
+
+	#[test]
+	fn stash_no_local_changes() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash", &cfg);
+		let input = "No local changes to save\n";
+		let out = filter(&ctx, input, 1);
+		assert_eq!(out.text, "No local changes to save\n");
+	}
+
+	#[test]
+	fn stash_list_compacts_wip_prefix() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash list", &cfg);
+		let input = "stash@{0}: WIP on feature-x: abc1234 fix: something\nstash@{1}: On main: \
+		             def5678 chore: clean up\nstash@{2}: WIP on dev: ghi9012 feat: add widget\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.contains("stash@{0}: abc1234 fix: something"));
+		assert!(out.text.contains("stash@{1}: def5678 chore: clean up"));
+		assert!(out.text.contains("stash@{2}: ghi9012 feat: add widget"));
+		assert!(!out.text.contains("WIP on "));
+		assert!(!out.text.contains("On main:"));
+	}
+
+	#[test]
+	fn stash_list_empty_passthrough() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash list", &cfg);
+		let out = filter(&ctx, "", 0);
+		assert!(!out.changed);
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/lint.rs
+++ b/crates/pi-shell/src/minimizer/filters/lint.rs
@@ -9,7 +9,7 @@ pub fn supports(subcommand: Option<&str>) -> bool {
 }
 
 pub fn supports_program(program: &str, subcommand: Option<&str>) -> bool {
-	matches!(program, "ruff" | "mypy" | "rubocop")
+	matches!(program, "ruff" | "mypy" | "rubocop" | "pyright" | "basedpyright")
 		|| matches!(
 			subcommand,
 			None | Some("check" | "lint" | "run" | "format" | "fmt" | "typecheck")
@@ -58,6 +58,7 @@ fn is_lint_noise(program: &str, line: &str, exit_code: i32) -> bool {
 		|| matches!(program, "eslint" | "biome") && lower.starts_with("warning: react version")
 		|| matches!(program, "ruff") && lower.starts_with("all checks passed")
 		|| matches!(program, "mypy") && lower.starts_with("success: no issues found")
+		|| matches!(program, "pyright" | "basedpyright") && lower.starts_with("0 errors, 0 warnings")
 		|| matches!(program, "rubocop")
 			&& (lower.starts_with("inspecting ")
 				|| lower == "offenses:"
@@ -250,5 +251,25 @@ mod tests {
 		let out = group_diagnostics(&input);
 		assert!(out.contains("src/main.rs (20 diagnostics)"));
 		assert!(out.contains("… 8 more"));
+	}
+
+	#[test]
+	fn direct_pyright_support_and_grouping_work() {
+		assert!(supports_program("pyright", None));
+		let input = "0 errors, 0 warnings, 0 informations\nsrc/app.ts:4:7 - error TS2322: Type \
+		             'string' is not assignable to type 'number'.\nsrc/app.ts:9:3 - error TS7006: \
+		             Parameter 'x' implicitly has an 'any' type.\n";
+		let out = condense_lint_output("pyright", input, 1);
+		assert!(out.contains("2 diagnostics in 1 files"));
+		assert!(out.contains("src/app.ts (2 diagnostics)"));
+		assert!(out.contains("TS2322"));
+		assert!(out.contains("TS7006"));
+	}
+
+	#[test]
+	fn direct_basedpyright_success_noise_is_stripped() {
+		assert!(supports_program("basedpyright", None));
+		let out = condense_lint_output("basedpyright", "0 errors, 0 warnings, 0 notes\n", 0);
+		assert_eq!(out, "");
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/listing.rs
+++ b/crates/pi-shell/src/minimizer/filters/listing.rs
@@ -2,18 +2,31 @@
 
 use std::{collections::BTreeMap, path::Path};
 
-use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
+use crate::minimizer::{MinimizerCtx, MinimizerOutput, config::OutlineLevel, primitives};
 
 pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerOutput {
 	let cleaned = primitives::strip_ansi(input);
+	let legacy = ctx.config.legacy_filters_active();
 	let text = if exit_code != 0 {
 		cleaned
 	} else {
 		match ctx.program {
-			"grep" | "rg" => compact_grep_output(&cleaned),
+			"grep" | "rg" => {
+				if legacy {
+					compact_grep_output_legacy(&cleaned)
+				} else {
+					compact_grep_output(&cleaned)
+				}
+			},
 			"ls" => compact_ls_output(&cleaned).unwrap_or_else(|| compact_listing_output(&cleaned)),
 			"tree" => compact_listing_output(&cleaned),
-			"find" => compact_find_output(&cleaned),
+			"find" => {
+				if legacy {
+					compact_find_output_legacy(&cleaned)
+				} else {
+					compact_find_output(&cleaned)
+				}
+			},
 			"cat" | "read" => compact_cat_output(ctx, &cleaned),
 			"stat" | "du" | "df" | "wc" => compact_summary_output(&cleaned),
 			"jq" | "json" => cleaned,
@@ -36,7 +49,10 @@ struct GrepMatch {
 	text:    String,
 }
 
-fn compact_grep_output(input: &str) -> String {
+/// Legacy pre-PR behavior for grep/rg output: passthrough when
+/// `match_count <= 12 && grouped.len() <= 3` (or no recognized matches).
+/// Retained for the `legacy_filters_active` kill-switch.
+fn compact_grep_output_legacy(input: &str) -> String {
 	let mut grouped: BTreeMap<String, Vec<GrepMatch>> = BTreeMap::new();
 	let mut ungrouped = Vec::new();
 
@@ -56,10 +72,41 @@ fn compact_grep_output(input: &str) -> String {
 		return primitives::group_by_file(input, 12);
 	}
 
+	compact_grep_grouped(&grouped, &ungrouped, match_count)
+}
+
+fn compact_grep_output(input: &str) -> String {
+	let mut grouped: BTreeMap<String, Vec<GrepMatch>> = BTreeMap::new();
+	let mut ungrouped = Vec::new();
+
+	for line in input.lines() {
+		if let Some((file, line_no, text)) = split_grep_line(line) {
+			grouped
+				.entry(file.to_string())
+				.or_default()
+				.push(GrepMatch { line_no: line_no.to_string(), text: collapse_match_text(text) });
+		} else if !line.trim().is_empty() {
+			ungrouped.push(line.to_string());
+		}
+	}
+
+	let match_count: usize = grouped.values().map(Vec::len).sum();
+	if grouped.is_empty() {
+		return primitives::group_by_file(input, 12);
+	}
+
+	compact_grep_grouped(&grouped, &ungrouped, match_count)
+}
+
+fn compact_grep_grouped(
+	grouped: &BTreeMap<String, Vec<GrepMatch>>,
+	ungrouped: &[String],
+	match_count: usize,
+) -> String {
 	let mut out = format!("grep: {match_count} matches in {} files\n", grouped.len());
 	let mut shown_matches = 0usize;
 	let mut shown_files = 0usize;
-	for (file, matches) in &grouped {
+	for (file, matches) in grouped {
 		if shown_files >= 12 {
 			break;
 		}
@@ -96,7 +143,7 @@ fn compact_grep_output(input: &str) -> String {
 		out.push_str(" omitted\n");
 	}
 	for line in ungrouped {
-		out.push_str(&line);
+		out.push_str(line);
 		out.push('\n');
 	}
 	out
@@ -116,7 +163,73 @@ fn split_grep_line(line: &str) -> Option<(&str, &str, &str)> {
 
 fn collapse_match_text(text: &str) -> String {
 	let collapsed = collapse_parenthesized_segment(text, 48);
-	primitives::truncate_line(&collapsed, 140)
+	center_truncate_match(&collapsed, 140)
+}
+
+/// Center-truncate grep/ripgrep match text so the match region stays visible.
+///
+/// Instead of truncating from the front (which loses matches deep in long
+/// lines), this centers the visible window. The heuristic biases toward
+/// non-whitespace content when the line has significant leading whitespace.
+fn center_truncate_match(text: &str, max_chars: usize) -> String {
+	if max_chars == 0 {
+		return String::new();
+	}
+	let char_count = text.chars().count();
+	if char_count <= max_chars {
+		return text.to_string();
+	}
+
+	// Heuristic:
+	// - If the line has significant leading whitespace, bias toward the code region
+	//   shortly after indentation (common for grep hits inside indented code).
+	// - If the line is effectively one long token, bias earlier so identifiers that
+	//   appear before a long suffix still remain visible.
+	// - Otherwise center in the middle of the full line.
+	let first_non_ws = text.find(|c: char| !c.is_whitespace()).unwrap_or(0);
+	let has_whitespace = text.chars().any(char::is_whitespace);
+	let anchor = if first_non_ws > 0 && first_non_ws < char_count / 3 {
+		first_non_ws + max_chars / 4
+	} else if !has_whitespace {
+		char_count / 3
+	} else {
+		char_count / 2
+	};
+
+	let window_size = max_chars;
+	let half = window_size / 2;
+	let mut window_start = anchor.saturating_sub(half);
+	if first_non_ws > 0 {
+		window_start = window_start.max(first_non_ws);
+	}
+	// Clamp so the window doesn't overshoot the end.
+	window_start = window_start.min(char_count.saturating_sub(window_size));
+
+	let mut out = String::with_capacity(max_chars + 12);
+	let mut chars = text.chars();
+	for _ in 0..window_start {
+		chars.next();
+	}
+	let dropped_before = window_start;
+	if dropped_before > 0 {
+		out.push('\u{2026}');
+	}
+	let mut shown = 0usize;
+	for _ in 0..window_size {
+		match chars.next() {
+			Some(ch) => {
+				out.push(ch);
+				shown += 1;
+			},
+			None => break,
+		}
+	}
+	let total_dropped = char_count.saturating_sub(shown);
+	if total_dropped > 0 {
+		use std::fmt::Write as _;
+		let _ = write!(out, "\u{2026}[+{total_dropped}]");
+	}
+	out
 }
 
 fn collapse_parenthesized_segment(text: &str, min_len: usize) -> String {
@@ -137,7 +250,9 @@ fn collapse_parenthesized_segment(text: &str, min_len: usize) -> String {
 	out
 }
 
-fn compact_find_output(input: &str) -> String {
+/// Legacy pre-PR behavior for find output: passthrough when `paths.len() <=
+/// 20`. Retained for the `legacy_filters_active` kill-switch.
+fn compact_find_output_legacy(input: &str) -> String {
 	let paths: Vec<&str> = input
 		.lines()
 		.filter(|line| !line.trim().is_empty())
@@ -145,10 +260,24 @@ fn compact_find_output(input: &str) -> String {
 	if paths.len() <= 20 {
 		return input.to_string();
 	}
+	compact_find_output_inner(input, &paths)
+}
 
+fn compact_find_output(input: &str) -> String {
+	let paths: Vec<&str> = input
+		.lines()
+		.filter(|line| !line.trim().is_empty())
+		.collect();
+	if paths.is_empty() {
+		return input.to_string();
+	}
+	compact_find_output_inner(input, &paths)
+}
+
+fn compact_find_output_inner(input: &str, paths: &[&str]) -> String {
 	let mut grouped: BTreeMap<String, Vec<String>> = BTreeMap::new();
 	let mut skipped_noise = 0usize;
-	for raw in &paths {
+	for raw in paths {
 		let normalized = normalize_listing_path(raw);
 		if normalized.is_empty() {
 			continue;
@@ -345,7 +474,7 @@ fn compact_cat_output(ctx: &MinimizerCtx<'_>, input: &str) -> String {
 	if !is_source_path(&path) {
 		return input.to_string();
 	}
-	compact_source_outline(input)
+	compact_source_outline(input, &path, ctx.config.source_outline_level)
 }
 
 fn extract_single_path_arg(command: &str, program: &str) -> Option<String> {
@@ -590,7 +719,12 @@ fn is_source_path(path: &str) -> bool {
 	)
 }
 
-fn compact_source_outline(input: &str) -> String {
+fn compact_source_outline(input: &str, path: &str, level: OutlineLevel) -> String {
+	if level == OutlineLevel::Aggressive
+		&& let Some(stripped) = aggressive_strip_bodies(input, path)
+	{
+		return stripped;
+	}
 	let lines: Vec<&str> = input.lines().collect();
 	if lines.len() < 160 && input.len() < 12_000 {
 		return input.to_string();
@@ -686,6 +820,227 @@ fn render_source_declaration(trimmed: &str) -> String {
 	line
 }
 
+/// Aggressive source-outline body stripping for brace-based and indent-based
+/// languages. Returns `None` for languages we don't have a strip path for so
+/// the caller falls back to default outline rendering.
+fn aggressive_strip_bodies(input: &str, path: &str) -> Option<String> {
+	let ext = Path::new(path)
+		.extension()
+		.and_then(|e| e.to_str())
+		.unwrap_or("");
+	match ext {
+		"rs" | "ts" | "tsx" | "js" | "jsx" | "go" => Some(strip_brace_bodies(input)),
+		"py" => Some(strip_python_bodies(input)),
+		_ => None,
+	}
+}
+
+/// Replace the body of every function/method declaration with `{ ... }`,
+/// keeping signatures, doc comments, attributes, imports, and container
+/// declarations (`class`/`struct`/`enum`/`trait`/`impl`/`interface`/
+/// `namespace`/`module`) intact. We descend into container bodies so inner
+/// method signatures stay visible.
+///
+/// Brace depth tracking handles nested braces inside string/macro content
+/// imperfectly but conservatively — when in doubt we re-emit the original
+/// line.
+fn strip_brace_bodies(input: &str) -> String {
+	let mut out = String::with_capacity(input.len() / 2);
+	let mut skip_depth: i32 = 0;
+	for line in input.lines() {
+		if skip_depth > 0 {
+			skip_depth += brace_delta(line);
+			if skip_depth <= 0 {
+				skip_depth = 0;
+			}
+			continue;
+		}
+		let trimmed = line.trim_start();
+		let delta = brace_delta(line);
+		if delta > 0 && is_function_body_starter(trimmed) {
+			let Some(cut) = line.find('{') else {
+				out.push_str(line);
+				out.push('\n');
+				continue;
+			};
+			out.push_str(line[..cut].trim_end());
+			out.push_str(" { ... }\n");
+			if delta > 0 {
+				skip_depth = delta;
+			}
+			continue;
+		}
+		out.push_str(line);
+		out.push('\n');
+	}
+	out
+}
+
+fn brace_delta(line: &str) -> i32 {
+	let mut delta: i32 = 0;
+	let mut in_str: Option<char> = None;
+	let mut prev = '\0';
+	for ch in line.chars() {
+		match in_str {
+			Some(q) => {
+				if ch == q && prev != '\\' {
+					in_str = None;
+				}
+			},
+			None => match ch {
+				'"' | '\'' | '`' => in_str = Some(ch),
+				'{' => delta += 1,
+				'}' => delta -= 1,
+				_ => {},
+			},
+		}
+		prev = ch;
+	}
+	delta
+}
+
+/// Only function-like declarations whose body we want to strip. Container
+/// declarations (`class`/`struct`/`enum`/`trait`/`impl`/`interface`/
+/// `namespace`/`module`) are intentionally NOT in this set so we keep
+/// descending and strip the methods inside them.
+fn is_function_body_starter(trimmed: &str) -> bool {
+	let without_attr = trimmed.trim_start_matches(['#', '[', ']']);
+	let without_vis = strip_leading_keywords(without_attr.trim_start());
+	if without_vis.starts_with("fn ")
+		|| without_vis.starts_with("function ")
+		|| without_vis.starts_with("function(")
+		|| without_vis.starts_with("function*")
+		|| without_vis.starts_with("func ")
+		|| without_vis.starts_with("method ")
+		|| without_vis.starts_with("constructor(")
+		|| without_vis.starts_with("constructor ")
+	{
+		return true;
+	}
+	// Reject container keywords explicitly so the TS-method fallback below
+	// can't mistakenly latch onto `class Foo(...)`/`type Foo = (...) => …`.
+	for kw in [
+		"class ",
+		"struct ",
+		"enum ",
+		"trait ",
+		"impl ",
+		"impl<",
+		"interface ",
+		"type ",
+		"namespace ",
+		"module ",
+	] {
+		if without_vis.starts_with(kw) {
+			return false;
+		}
+	}
+	starts_with_ts_method(without_vis)
+}
+
+fn strip_leading_keywords(s: &str) -> &str {
+	let mut current = s;
+	loop {
+		let next = current
+			.strip_prefix("pub ")
+			.or_else(|| current.strip_prefix("pub(crate) "))
+			.or_else(|| current.strip_prefix("export "))
+			.or_else(|| current.strip_prefix("export default "))
+			.or_else(|| current.strip_prefix("async "))
+			.or_else(|| current.strip_prefix("default "))
+			.or_else(|| current.strip_prefix("static "))
+			.or_else(|| current.strip_prefix("private "))
+			.or_else(|| current.strip_prefix("protected "))
+			.or_else(|| current.strip_prefix("public "))
+			.or_else(|| current.strip_prefix("readonly "))
+			.or_else(|| current.strip_prefix("abstract "))
+			.or_else(|| current.strip_prefix("override "))
+			.or_else(|| current.strip_prefix("const "));
+		match next {
+			Some(rest) => current = rest,
+			None => break,
+		}
+	}
+	current
+}
+
+/// Heuristic for TypeScript-style class methods: `name(args): Ret {` or
+/// `name(args) {`. We accept any identifier-like token followed by `(`.
+fn starts_with_ts_method(s: &str) -> bool {
+	let mut chars = s.char_indices();
+	let Some((_, first)) = chars.next() else {
+		return false;
+	};
+	if !(first.is_ascii_alphabetic() || first == '_' || first == '$') {
+		return false;
+	}
+	let mut paren_idx = None;
+	for (idx, ch) in chars {
+		if ch.is_ascii_alphanumeric() || ch == '_' || ch == '$' {
+			continue;
+		}
+		if ch == '(' {
+			paren_idx = Some(idx);
+		}
+		break;
+	}
+	paren_idx.is_some()
+}
+
+/// Strip Python function/class bodies. We detect a `def`, `async def`, or
+/// `class` line ending with `:`, emit the signature, then drop every following
+/// line whose indentation is strictly greater than the signature's, replacing
+/// the run with a single `    ...` placeholder.
+fn strip_python_bodies(input: &str) -> String {
+	let lines: Vec<&str> = input.lines().collect();
+	let mut out = String::with_capacity(input.len() / 2);
+	let mut i = 0;
+	while i < lines.len() {
+		let line = lines[i];
+		let indent = line.chars().take_while(|c| *c == ' ' || *c == '\t').count();
+		let trimmed = line.trim_start();
+		let is_def = trimmed.starts_with("def ") || trimmed.starts_with("async def ");
+		let is_class = trimmed.starts_with("class ");
+		let ends_with_colon = trimmed.trim_end().ends_with(':');
+		if (is_def || is_class) && ends_with_colon {
+			out.push_str(line);
+			out.push('\n');
+			i += 1;
+			let mut stripped_any = false;
+			while i < lines.len() {
+				let body_line = lines[i];
+				let body_indent = body_line
+					.chars()
+					.take_while(|c| *c == ' ' || *c == '\t')
+					.count();
+				if body_line.trim().is_empty() {
+					if !stripped_any {
+						out.push_str(body_line);
+						out.push('\n');
+					}
+					i += 1;
+					continue;
+				}
+				if body_indent <= indent {
+					break;
+				}
+				stripped_any = true;
+				i += 1;
+			}
+			if stripped_any {
+				let pad: String = " ".repeat(indent + 4);
+				out.push_str(&pad);
+				out.push_str("...\n");
+			}
+			continue;
+		}
+		out.push_str(line);
+		out.push('\n');
+		i += 1;
+	}
+	out
+}
+
 fn compact_summary_output(input: &str) -> String {
 	let lines: Vec<&str> = input.lines().collect();
 	if lines.len() <= 30 {
@@ -738,12 +1093,19 @@ mod tests {
 		MinimizerCtx { program, subcommand: None, command, config: cfg }
 	}
 
+	// migrated for always-group: see T1a (minimizer-filter-remediation).
+	// Previously asserted passthrough-style `group_by_file` output. The
+	// Tier 1 unconditional grouping path now produces the `grep: N matches
+	// in M files` header even for small inputs.
 	#[test]
 	fn groups_grep_by_file() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
 		let ctx = ctx("rg", &cfg);
 		let out = filter(&ctx, "a.rs:1:foo\na.rs:2:bar\n", 0);
-		assert_eq!(out.text, "a.rs:\n  1:foo\n  2:bar\n");
+		assert!(out.text.starts_with("grep: 2 matches in 1 files"), "{:?}", out.text);
+		assert!(out.text.contains("a.rs:"));
+		assert!(out.text.contains("1: foo"));
+		assert!(out.text.contains("2: bar"));
 	}
 
 	#[test]
@@ -762,6 +1124,87 @@ mod tests {
 		assert!(out.text.starts_with("grep: 20 matches in 20 files"));
 		assert!(out.text.contains("17: pub fn run(...) -> Result<()> {"));
 		assert!(out.text.contains("matches in 8 files omitted"));
+	}
+
+	#[test]
+	fn center_truncate_short_line_passes_through() {
+		assert_eq!(center_truncate_match("fn foo() {}", 140), "fn foo() {}");
+	}
+
+	#[test]
+	fn center_truncate_long_line_with_leading_whitespace_centers_in_code() {
+		// Match is in the code region after significant indentation.
+		let indent = "                              ";
+		let body = "let result = deeply_nested_function(arg1, arg2, arg3, arg4, arg5, arg6, arg7, \
+		            arg8, arg9, arg10, arg11, arg12, arg13, extra, more, stuff, padding, fill, end);";
+		let line = format!("{indent}{body}");
+		assert!(line.chars().count() > 140, "test line must exceed max_chars");
+		let out = center_truncate_match(&line, 140);
+		// Should show leading … (indentation was skipped), centered code, and …[+N]
+		// tally.
+		assert!(out.starts_with('\u{2026}'), "should start with …: {out}");
+		assert!(out.ends_with(']'), "should end with tally: {out}");
+		assert!(out.contains("result"), "match region 'result' should be visible: {out}");
+		assert!(out.contains("arg5"), "middle args should be visible: {out}");
+		// Should NOT show the raw "let result" from the very front (since indentation
+		// was dropped). But it might appear inside the window. The key assertion:
+		// leading indent chars are dropped.
+		let after_ellipsis = &out['\u{2026}'.len_utf8()..];
+		assert!(
+			!after_ellipsis.starts_with(' '),
+			"window should not start with leading spaces: {out}"
+		);
+	}
+
+	#[test]
+	fn center_truncate_long_line_no_whitespace_centers_in_middle() {
+		let mut line = String::from("use std::collections::{");
+		for i in 0..30 {
+			line.push_str("Module");
+			line.push_str(&i.to_string());
+			line.push_str(", ");
+		}
+		line.push_str("ExtraLongModuleName};");
+		assert!(line.chars().count() > 140, "test line must exceed max_chars");
+		let out = center_truncate_match(&line, 140);
+		assert!(out.starts_with('\u{2026}'), "should start with …: {out}");
+		assert!(out.ends_with(']'), "should end with tally: {out}");
+		// Middle modules like Module14, Module15 should be visible.
+		assert!(out.contains("Module14"), "middle modules should be visible: {out}");
+		assert!(!out.starts_with("use std"), "front content should be dropped: {out}");
+	}
+
+	#[test]
+	fn center_truncate_match_near_end_visible() {
+		let prefix = "x".repeat(40);
+		let marker = "MATCH_NEAR_END_HERE";
+		let suffix = "y".repeat(200);
+		let line = format!("{prefix}{marker}{suffix}");
+		assert!(line.chars().count() > 140, "test line must exceed max_chars");
+		let out = center_truncate_match(&line, 140);
+		// marker starts at char 40, window is centered, should include the marker.
+		assert!(out.contains(marker), "match should be visible: {out}");
+	}
+
+	#[test]
+	fn center_truncate_max_zero_returns_empty() {
+		assert_eq!(center_truncate_match("anything", 0), "");
+	}
+
+	#[test]
+	fn center_truncate_exact_length_returns_unchanged() {
+		let line = "a".repeat(140);
+		assert_eq!(center_truncate_match(&line, 140), line);
+	}
+
+	#[test]
+	fn center_truncate_one_over_shows_tally() {
+		let line = "a".repeat(141);
+		let out = center_truncate_match(&line, 140);
+		assert!(out.contains("\u{2026}[+"), "should have tally: {out}");
+		// With 141 chars, centering produces window_start=0, shows 140 a's, drops 1.
+		let content_chars: String = out.chars().filter(|c| *c == 'a').collect();
+		assert_eq!(content_chars.len(), 140);
 	}
 
 	#[test]
@@ -915,5 +1358,234 @@ mod tests {
 			out.push('\n');
 		}
 		out
+	}
+
+	fn aggressive_cfg() -> MinimizerConfig {
+		MinimizerConfig {
+			enabled: true,
+			source_outline_level: OutlineLevel::Aggressive,
+			..Default::default()
+		}
+	}
+
+	#[test]
+	fn default_level_keeps_small_source_files_intact() {
+		// Default behavior: short source files pass through unchanged so
+		// existing callers (and `default_level_keeps_small_source_files_intact`)
+		// never see surprise body stripping.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx_command("cat", "cat src/foo.rs", &cfg);
+		let body = "fn foo() {\n    let x = 1;\n    x + 1\n}\n";
+		let out = filter(&ctx, body, 0);
+		assert!(!out.changed, "default level on tiny file must passthrough");
+	}
+
+	#[test]
+	fn aggressive_strips_rust_function_body() {
+		let cfg = aggressive_cfg();
+		let ctx = ctx_command("cat", "cat src/foo.rs", &cfg);
+		let body = "use std::io;\n\npub fn foo(x: i32) -> i32 {\n    let y = x + 1;\n    y * 2\n}\n";
+		let out = filter(&ctx, body, 0);
+		assert!(out.changed, "aggressive must rewrite");
+		assert!(out.text.contains("use std::io;"));
+		assert!(out.text.contains("pub fn foo(x: i32) -> i32 { ... }"));
+		assert!(!out.text.contains("y * 2"));
+	}
+
+	#[test]
+	fn aggressive_strips_typescript_method_body() {
+		let cfg = aggressive_cfg();
+		let ctx = ctx_command("cat", "cat src/foo.ts", &cfg);
+		let body = "import { z } from 'x';\n\nexport class Svc {\n    run(): number {\n        \
+		            return 1;\n    }\n}\n";
+		let out = filter(&ctx, body, 0);
+		assert!(out.changed);
+		assert!(out.text.contains("import { z } from 'x';"));
+		assert!(out.text.contains("run(): number { ... }"));
+		assert!(!out.text.contains("return 1;"));
+	}
+
+	#[test]
+	fn aggressive_strips_python_function_body() {
+		let cfg = aggressive_cfg();
+		let ctx = ctx_command("cat", "cat src/foo.py", &cfg);
+		let body = "import os\n\ndef compute(x):\n    y = x + 1\n    return y * 2\n";
+		let out = filter(&ctx, body, 0);
+		assert!(out.changed);
+		assert!(out.text.contains("import os"));
+		assert!(out.text.contains("def compute(x):"));
+		assert!(out.text.contains("    ..."));
+		assert!(!out.text.contains("y * 2"));
+	}
+
+	#[test]
+	fn aggressive_unknown_extension_passes_through() {
+		let cfg = aggressive_cfg();
+		let ctx = ctx_command("cat", "cat src/foo.swift", &cfg);
+		let body = "func compute() {}\n";
+		let out = filter(&ctx, body, 0);
+		assert!(!out.changed, "aggressive must not touch unsupported langs");
+	}
+
+	#[test]
+	fn aggressive_output_has_no_chain_corrupting_chars() {
+		let cfg = aggressive_cfg();
+		let ctx = ctx_command("cat", "cat src/foo.ts", &cfg);
+		let body = "export function foo() {\n  const a = `template`;\n  return a;\n}\n";
+		let out = filter(&ctx, body, 0);
+		assert!(out.changed);
+		assert!(!out.text.contains('\x1b'));
+		// signature retained without dangling backtick from template body
+		assert!(!out.text.contains("template"));
+	}
+
+	// ---------------------------------------------------------------
+	// Tier 1: always-group grep/find tests (minimizer-filter-remediation)
+	// ---------------------------------------------------------------
+
+	fn legacy_cfg() -> MinimizerConfig {
+		let mut cfg = MinimizerConfig::default();
+		cfg.enabled = true;
+		cfg.legacy_filters_active = true;
+		cfg
+	}
+
+	fn synthesize_grep(matches_per_file: usize, files: usize) -> String {
+		let mut out = String::new();
+		for f in 0..files {
+			for m in 0..matches_per_file {
+				out.push_str(&format!(
+					"src/module{f}/file{f}.rs:{ln}:    pub fn handler_{f}_{m}(req: Request) -> \
+					 Result<Response, AppError> {{ /* body */ }}\n",
+					ln = m * 7 + 1,
+					f = f,
+					m = m,
+				));
+			}
+		}
+		out
+	}
+
+	fn synthesize_find_paths(per_dir: usize, dirs: usize) -> String {
+		let mut out = String::new();
+		for d in 0..dirs {
+			for f in 0..per_dir {
+				out.push_str(&format!(
+					"./crates/pi-shell/src/minimizer/filters/category{d}/\
+					 handler_{f}_with_descriptive_name.rs\n",
+				));
+			}
+		}
+		out
+	}
+
+	fn ratio(input: &str, output: &str) -> f64 {
+		1.0 - (output.len() as f64 / input.len() as f64)
+	}
+
+	#[test]
+	fn grep_small_1m1f_always_groups() {
+		// 1 match in 1 file. Pre-PR: passthrough. Post: grouped header.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("grep", &cfg);
+		let input = synthesize_grep(1, 1);
+		let out = filter(&ctx, &input, 0);
+		assert!(out.text.contains("grep: 1 matches in 1 files"));
+	}
+
+	#[test]
+	fn grep_medium_3m1f_always_groups() {
+		// 3 matches in 1 file. Pre-PR: passthrough (was within thresholds).
+		// Post: grouped header.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("grep", &cfg);
+		let input = synthesize_grep(3, 1);
+		let out = filter(&ctx, &input, 0);
+		assert!(
+			out.text.contains("grep: 3 matches in 1 files"),
+			"expected always-group header, got: {}",
+			out.text
+		);
+	}
+
+	#[test]
+	fn grep_large_100m10f_savedratio_threshold() {
+		// 100 matches × 10 files: pre-existing grouping path. SavedRatio
+		// must be substantial (≥0.50 from m3 acceptance; we assert ≥0.50).
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("grep", &cfg);
+		let input = synthesize_grep(10, 10);
+		let out = filter(&ctx, &input, 0);
+		assert!(out.text.starts_with("grep: 100 matches in 10 files"));
+		let r = ratio(&input, &out.text);
+		assert!(r >= 0.50, "savedRatio={r}");
+	}
+
+	#[test]
+	fn find_shallow_5p1d_always_groups() {
+		// 5 paths in 1 dir. Pre-PR: passthrough. Post: grouped.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("find", &cfg);
+		let input = synthesize_find_paths(5, 1);
+		let out = filter(&ctx, &input, 0);
+		assert!(
+			out.text.contains("find: 5 paths in 1 dirs"),
+			"expected always-group header, got: {}",
+			out.text
+		);
+	}
+
+	#[test]
+	fn find_deep_50p8d_savedratio_threshold() {
+		// 50 paths × 8 dirs. Was already grouped pre-PR; regression guard
+		// + savedRatio threshold per m3 (≥0.60 deep fixture).
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("find", &cfg);
+		let input = synthesize_find_paths(50, 8);
+		let out = filter(&ctx, &input, 0);
+		assert!(out.text.starts_with("find: 400 paths in 8 dirs"));
+		let r = ratio(&input, &out.text);
+		assert!(r >= 0.60, "savedRatio={r}");
+	}
+
+	#[test]
+	fn find_wide_200p1d_grouped() {
+		// 200 paths in 1 dir. Was already grouped pre-PR.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("find", &cfg);
+		let input = synthesize_find_paths(200, 1);
+		let out = filter(&ctx, &input, 0);
+		assert!(out.text.starts_with("find: 200 paths in 1 dirs"));
+	}
+
+	#[test]
+	fn grep_legacy_filters_active_passes_through_small_input() {
+		// Kill-switch parity (M2): with legacy_filters_active=true, the
+		// pre-PR "small input passthrough" path is preserved byte-for-byte.
+		let cfg = legacy_cfg();
+		let ctx = ctx("grep", &cfg);
+		let input = synthesize_grep(2, 1);
+		let out = filter(&ctx, &input, 0);
+		// Legacy path: group_by_file primitive style for inputs at/below
+		// 12 matches × 3 files. Compare against direct invocation.
+		let expected = compact_grep_output_legacy(&primitives::strip_ansi(&input));
+		assert_eq!(out.text, expected);
+		assert!(
+			!out.text.starts_with("grep: 2 matches"),
+			"legacy path must NOT emit always-group header"
+		);
+	}
+
+	#[test]
+	fn find_legacy_filters_active_passes_through_under_threshold() {
+		// Kill-switch parity (M2): legacy_filters_active=true reverts to
+		// the pre-PR `paths.len() <= 20` passthrough.
+		let cfg = legacy_cfg();
+		let ctx = ctx("find", &cfg);
+		let input = synthesize_find_paths(5, 1);
+		let out = filter(&ctx, &input, 0);
+		// Legacy: small input passes through unchanged.
+		assert_eq!(out.text, input);
+		assert!(!out.changed);
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/mod.rs
+++ b/crates/pi-shell/src/minimizer/filters/mod.rs
@@ -2,9 +2,11 @@
 
 use crate::minimizer::{MinimizerCtx, MinimizerOutput};
 
+pub mod ai_smart;
 pub mod cloud;
 pub mod cpp;
 
+pub mod binary_tools;
 pub mod bun;
 
 pub mod cargo;
@@ -29,6 +31,7 @@ pub mod pkg;
 
 pub mod python;
 pub mod ruby;
+pub mod rust_tools;
 pub mod system;
 
 pub fn supports(program: &str, subcommand: Option<&str>) -> bool {
@@ -52,6 +55,8 @@ pub fn supports(program: &str, subcommand: Option<&str>) -> bool {
 			python::supports(program, subcommand)
 		},
 		"rspec" | "rake" | "rails" | "rubocop" => ruby::supports(program, subcommand),
+		"rustfmt" => rust_tools::supports(program, subcommand),
+		"xxd" | "strings" | "od" => binary_tools::supports(program, subcommand),
 		"tsc" | "eslint" | "biome" | "shellcheck" | "markdownlint" | "hadolint" | "yamllint"
 		| "oxlint" | "pyright" | "basedpyright" => {
 			lint::supports(subcommand) || lint::supports_program(program, subcommand)
@@ -63,12 +68,64 @@ pub fn supports(program: &str, subcommand: Option<&str>) -> bool {
 				|| js_tools::supports(program, subcommand)
 		},
 		"pnpm" if matches!(subcommand, Some("dlx")) => true,
-		"npm" | "pnpm" | "yarn" | "pip" | "pip3" | "bundle" | "brew" | "composer" | "uv"
-		| "poetry" => pkg::supports(subcommand),
+		"uv" if matches!(subcommand, Some("run")) => true,
+		"npm" | "pnpm" | "yarn" | "pip" | "pip3" | "bundle" | "brew" | "composer" | "poetry" => {
+			pkg::supports(subcommand)
+		},
+		"uv" => {
+			// uv dispatch coverage (B1 / m4): admit additional subcommand forms
+			// that wrap a known tool. `uv run` is already handled above; this
+			// arm covers `uv pytest`, `uv -m pytest`, `uv ruff`, `uv mypy`,
+			// and other wrapped-tool forms that pre-PR fell through to the
+			// package-manager filter.
+			matches!(subcommand, Some("pytest" | "ruff" | "mypy" | "-m")) || pkg::supports(subcommand)
+		},
 		"env" | "log" | "deps" | "summary" | "err" | "test" | "diff" | "format" | "pipe" | "ps"
 		| "ping" | "ssh" | "sops" => system::supports(program),
 		_ => false,
 	}
+}
+
+fn is_test_script_token(token: &str) -> bool {
+	let token = token.trim_matches(|ch| matches!(ch, '\'' | '"' | '`'));
+	matches!(token, "test" | "t" | "e2e" | "spec") || token.starts_with("test:")
+}
+
+fn command_contains_test_script(command: &str) -> bool {
+	command
+		.split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '|' | '&'))
+		.any(is_test_script_token)
+}
+
+fn is_pkg_test_invocation(ctx: &MinimizerCtx<'_>) -> bool {
+	matches!(ctx.subcommand, Some("test" | "t"))
+		|| matches!(ctx.subcommand, Some("run")) && command_contains_test_script(ctx.command)
+}
+
+fn is_pkg_lint_invocation(ctx: &MinimizerCtx<'_>) -> bool {
+	matches!(ctx.subcommand, Some("run"))
+		&& (command_contains_lint_script(ctx.command)
+			|| command_contains_tool(ctx.command, &["tsc", "eslint", "biome"]))
+}
+
+fn command_contains_lint_script(command: &str) -> bool {
+	command
+		.split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '|' | '&'))
+		.any(is_lint_script_token)
+}
+
+fn is_lint_script_token(token: &str) -> bool {
+	let token = token.trim_matches(|ch| matches!(ch, '\'' | '"' | '`'));
+	matches!(token, "lint" | "typecheck" | "type-check")
+		|| token.starts_with("lint:")
+		|| token.starts_with("typecheck:")
+		|| token.starts_with("type-check:")
+}
+
+fn command_contains_tool(command: &str, tools: &[&str]) -> bool {
+	command
+		.split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '|' | '&'))
+		.any(|token| tools.contains(&token))
 }
 
 /// Apply the matching built-in filter.
@@ -95,14 +152,29 @@ pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerO
 			python::filter(ctx, input, exit_code)
 		},
 		"rspec" | "rake" | "rails" | "rubocop" => ruby::filter(ctx, input, exit_code),
+		"rustfmt" => rust_tools::filter(ctx, input, exit_code),
+		"xxd" | "strings" | "od" => binary_tools::filter(ctx, input, exit_code),
 		"tsc" | "eslint" | "biome" | "shellcheck" | "markdownlint" | "hadolint" | "yamllint"
 		| "oxlint" | "pyright" | "basedpyright" => lint::filter(ctx, input, exit_code),
 		"jest" | "vitest" | "playwright" => node_tests::filter(ctx, input, exit_code),
 		"next" | "prettier" | "prisma" => js_tools::filter(ctx, input, exit_code),
 		"npx" => filter_js_wrapper(ctx, input, exit_code),
 		"pnpm" if matches!(ctx.subcommand, Some("dlx")) => filter_js_wrapper(ctx, input, exit_code),
-		"npm" | "pnpm" | "yarn" | "pip" | "pip3" | "bundle" | "brew" | "composer" | "uv"
-		| "poetry" => pkg::filter(ctx, input, exit_code),
+		"uv" if matches!(ctx.subcommand, Some("run" | "pytest" | "ruff" | "mypy" | "-m")) => {
+			filter_uv_wrapper(ctx, input, exit_code)
+		},
+		"npm" | "pnpm" | "yarn" => {
+			if is_pkg_test_invocation(ctx) {
+				node_tests::filter(ctx, input, exit_code)
+			} else if is_pkg_lint_invocation(ctx) {
+				lint::filter(ctx, input, exit_code)
+			} else {
+				pkg::filter(ctx, input, exit_code)
+			}
+		},
+		"pip" | "pip3" | "bundle" | "brew" | "composer" | "uv" | "poetry" => {
+			pkg::filter(ctx, input, exit_code)
+		},
 		"env" | "log" | "deps" | "summary" | "err" | "test" | "diff" | "format" | "pipe" | "ps"
 		| "ping" | "ssh" | "sops" => system::filter(ctx, input, exit_code),
 		_ => generic::filter(ctx, input, exit_code),
@@ -121,13 +193,130 @@ fn filter_js_wrapper(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> Min
 	}
 }
 
+fn filter_uv_wrapper(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerOutput {
+	// uv dispatch normalization (B1 / m4): admit `uv pytest`, `uv -m pytest`,
+	// `uv ruff`, `uv mypy` in addition to the pre-existing `uv run …` path.
+	if let Some(tool) = normalize_uv_form(ctx.subcommand, ctx.command) {
+		let routed = MinimizerCtx {
+			program:    tool,
+			subcommand: Some(tool),
+			command:    ctx.command,
+			config:     ctx.config,
+		};
+		return match tool {
+			"pytest" | "ruff" | "mypy" => python::filter(&routed, input, exit_code),
+			_ => MinimizerOutput::passthrough(input),
+		};
+	}
+	match uv_wrapper_tool(ctx) {
+		Some("pytest") => {
+			let routed = MinimizerCtx {
+				program:    "pytest",
+				subcommand: Some("pytest"),
+				command:    ctx.command,
+				config:     ctx.config,
+			};
+			python::filter(&routed, input, exit_code)
+		},
+		Some("ruff") => {
+			let subcommand = if ctx.command.split_whitespace().any(|part| part == "format") {
+				Some("format")
+			} else {
+				Some("ruff")
+			};
+			let routed =
+				MinimizerCtx { program: "ruff", subcommand, command: ctx.command, config: ctx.config };
+			python::filter(&routed, input, exit_code)
+		},
+		Some("mypy") => {
+			let routed = MinimizerCtx {
+				program:    "mypy",
+				subcommand: Some("mypy"),
+				command:    ctx.command,
+				config:     ctx.config,
+			};
+			python::filter(&routed, input, exit_code)
+		},
+		Some(tool @ ("tsc" | "eslint" | "biome" | "pyright" | "basedpyright" | "oxlint")) => {
+			let routed = MinimizerCtx {
+				program:    tool,
+				subcommand: Some(tool),
+				command:    ctx.command,
+				config:     ctx.config,
+			};
+			lint::filter(&routed, input, exit_code)
+		},
+		Some("jest" | "vitest" | "playwright") => node_tests::filter(ctx, input, exit_code),
+		_ => MinimizerOutput::passthrough(input),
+	}
+}
+
+/// Normalize uv invocation forms into a routable tool name (B1 / m4).
+///
+/// Resolution order:
+///   1. If `subcommand` is itself a known python tool name (pytest, ruff,
+///      mypy), return `Some(<tool>)`.
+///   2. If `subcommand` is `"-m"`, scan `command` tokens for the first non-flag
+///      word matching the python-tool allowlist; return `Some(<tool>)`.
+///   3. If `subcommand` is `"run"`, return `None` so the caller falls through
+///      to the existing `uv_wrapper_tool` path (regression guard).
+///   4. Otherwise return `None`.
+///
+/// The returned `&'static str` is one of `"pytest"`, `"ruff"`, `"mypy"`;
+/// the caller is expected to route via the python filter.
+fn normalize_uv_form(subcommand: Option<&str>, command: &str) -> Option<&'static str> {
+	const ALLOWLIST: &[&str] = &["pytest", "ruff", "mypy"];
+	let sub = subcommand?;
+	if let Some(&tool) = ALLOWLIST.iter().find(|&&tool| tool == sub) {
+		return Some(tool);
+	}
+	if sub == "-m" {
+		let tokens = command.split_whitespace();
+		let mut after_dash_m = false;
+		for token in tokens {
+			if after_dash_m
+				&& !token.starts_with('-')
+				&& let Some(&tool) = ALLOWLIST.iter().find(|&&tool| tool == token)
+			{
+				return Some(tool);
+			}
+			if token == "-m" {
+				after_dash_m = true;
+			}
+		}
+	}
+	None
+}
+
+fn uv_wrapper_tool<'a>(ctx: &'a MinimizerCtx<'_>) -> Option<&'a str> {
+	wrapper_invoked_tool(ctx, &[
+		"pytest",
+		"ruff",
+		"mypy",
+		"tsc",
+		"eslint",
+		"biome",
+		"pyright",
+		"basedpyright",
+		"oxlint",
+		"jest",
+		"vitest",
+		"playwright",
+	])
+}
+
 fn wrapper_invokes(ctx: &MinimizerCtx<'_>, tools: &[&str]) -> bool {
+	wrapper_invoked_tool(ctx, tools).is_some()
+}
+
+fn wrapper_invoked_tool<'a>(ctx: &'a MinimizerCtx<'_>, tools: &[&'a str]) -> Option<&'a str> {
 	ctx.subcommand
-		.is_some_and(|subcommand| tools.contains(&subcommand))
-		|| ctx
-			.command
-			.split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '|' | '&'))
-			.any(|token| tools.contains(&token))
+		.and_then(|subcommand| tools.iter().copied().find(|tool| *tool == subcommand))
+		.or_else(|| {
+			ctx.command
+				.split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '|' | '&'))
+				.find(|token| tools.contains(token))
+		})
 }
 
 #[cfg(test)]
@@ -167,8 +356,295 @@ mod tests {
 	}
 
 	#[test]
+	fn uv_run_pytest_routes_to_python_filter() {
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("run"), "uv run pytest", &config);
+		let input = "============================= test session starts \
+		             ==============================\ncollected 2 items\n\na.py .\nb.py \
+		             F\n\n=================================== FAILURES \
+		             ===================================\nFAILED b.py::test_fail - AssertionError: \
+		             expected 2 == 1\n=========================== short test summary info \
+		             ============================\nFAILED b.py::test_fail - AssertionError: \
+		             expected 2 == 1\n========================= 1 failed, 1 passed in 0.12s \
+		             =========================\n";
+		let out = filter(&context, input, 1).text;
+		assert!(out.contains("FAILED b.py::test_fail"));
+		assert!(!out.contains("collected 2 items"));
+		assert!(out.contains("pytest: 1 failed, 1 passed"));
+	}
+
+	#[test]
+	fn uv_run_ruff_routes_to_python_filter() {
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("run"), "uv run ruff check .", &config);
+		let input = "src/app.py:1:1: F401 imported but unused\nFound 1 error.\n";
+		let out = filter(&context, input, 1).text;
+		assert!(out.contains("F401"));
+	}
+
+	#[test]
+	fn uv_run_python_module_pytest_routes_to_python_filter() {
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("run"), "uv run python -m pytest", &config);
+		let input = "============================= test session starts \
+		             ==============================\ncollected 1 item\n\na.py \
+		             F\n\n=================================== FAILURES \
+		             ===================================\nFAILED a.py::test_fail - \
+		             AssertionError\n========================= 1 failed in 0.03s \
+		             =========================\n";
+		let out = filter(&context, input, 1).text;
+		assert!(out.contains("FAILED a.py::test_fail"));
+		assert!(!out.contains("collected 1 item"));
+	}
+
+	#[test]
+	fn uv_run_pyright_routes_to_lint_filter() {
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("run"), "uv run pyright", &config);
+		let input = "0 errors, 0 warnings, 0 informations\nsrc/app.ts:4:7 - error TS2322: Type \
+		             'string' is not assignable to type 'number'.\n";
+		let out = filter(&context, input, 1).text;
+		assert!(out.contains("TS2322"));
+	}
+
+	#[test]
+	fn uv_run_basedpyright_routes_to_lint_filter() {
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("run"), "uv run basedpyright", &config);
+		let input = "0 errors, 0 warnings, 0 notes\nsrc/app.ts:4:7 - error TS2322: Type 'string' is \
+		             not assignable to type 'number'.\n";
+		let out = filter(&context, input, 1).text;
+		assert!(out.contains("TS2322"));
+	}
+
+	#[test]
+	fn uv_run_unknown_tool_is_passthrough() {
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("run"), "uv run custom-tool", &config);
+		let input = "line 1\nline 2\n";
+		let out = filter(&context, input, 0);
+		assert_eq!(out.text, input);
+		assert!(!out.changed);
+	}
+
+	#[test]
+	fn npm_test_routes_to_node_tests() {
+		let config = MinimizerConfig::default();
+		let context = ctx("npm", Some("test"), "npm test", &config);
+		let out = filter(&context, "✓ ok\nFAIL app.test.ts\nTests 1 failed\n", 1).text;
+		assert!(!out.contains("✓ ok"));
+		assert!(out.contains("FAIL app.test.ts"));
+	}
+
+	#[test]
+	fn npm_run_test_routes_to_node_tests() {
+		let config = MinimizerConfig::default();
+		let context = ctx("npm", Some("run"), "npm run test", &config);
+		let out = filter(&context, "✓ ok\nFAIL app.test.ts\nTests 1 failed\n", 1).text;
+		assert!(!out.contains("✓ ok"));
+		assert!(out.contains("FAIL app.test.ts"));
+	}
+
+	#[test]
+	fn npm_run_quoted_test_routes_to_node_tests() {
+		let config = MinimizerConfig::default();
+		let context = ctx("npm", Some("run"), "npm run \"test\"", &config);
+		let out = filter(&context, "✓ ok\nFAIL app.test.ts\nTests 1 failed\n", 1).text;
+		assert!(!out.contains("✓ ok"));
+		assert!(out.contains("FAIL app.test.ts"));
+	}
+
+	#[test]
+	fn pnpm_test_routes_to_node_tests() {
+		let config = MinimizerConfig::default();
+		let context = ctx("pnpm", Some("test"), "pnpm test", &config);
+		let out = filter(&context, "✓ ok\nFAIL app.test.ts\nTests 1 failed\n", 1).text;
+		assert!(!out.contains("✓ ok"));
+		assert!(out.contains("FAIL app.test.ts"));
+	}
+
+	#[test]
+	fn pnpm_run_test_routes_to_node_tests() {
+		let config = MinimizerConfig::default();
+		let context = ctx("pnpm", Some("run"), "pnpm run test", &config);
+		let out = filter(&context, "✓ ok\nFAIL app.test.ts\nTests 1 failed\n", 1).text;
+		assert!(!out.contains("✓ ok"));
+		assert!(out.contains("FAIL app.test.ts"));
+	}
+
+	#[test]
+	fn yarn_test_routes_to_node_tests() {
+		let config = MinimizerConfig::default();
+		let context = ctx("yarn", Some("test"), "yarn test", &config);
+		let out = filter(&context, "✓ ok\nFAIL app.test.ts\nTests 1 failed\n", 1).text;
+		assert!(!out.contains("✓ ok"));
+		assert!(out.contains("FAIL app.test.ts"));
+	}
+
+	#[test]
+	fn yarn_run_test_routes_to_node_tests() {
+		let config = MinimizerConfig::default();
+		let context = ctx("yarn", Some("run"), "yarn run test", &config);
+		let out = filter(&context, "✓ ok\nFAIL app.test.ts\nTests 1 failed\n", 1).text;
+		assert!(!out.contains("✓ ok"));
+		assert!(out.contains("FAIL app.test.ts"));
+	}
+
+	#[test]
+	fn npm_run_build_still_uses_pkg_filter() {
+		let config = MinimizerConfig::default();
+		let context = ctx("npm", Some("run"), "npm run build", &config);
+		let out = filter(&context, "Resolving dependencies\nDownloaded foo\nerror: failed\n", 1).text;
+		assert!(!out.contains("Resolving dependencies"));
+		assert!(out.contains("error: failed"));
+	}
+
+	#[test]
+	fn package_manager_lint_scripts_route_to_lint_filter() {
+		let config = MinimizerConfig::default();
+		let input = concat!(
+			"src/app.ts:1:1: error TS2322: Type 'string' is not assignable to type 'number'.\n",
+			"src/app.ts:2:1: error TS7006: Parameter 'x' implicitly has an 'any' type.\n",
+		);
+
+		for (program, command) in [
+			("npm", "npm run lint"),
+			("npm", "npm run typecheck"),
+			("pnpm", "pnpm run lint:ci"),
+			("yarn", "yarn run typecheck:ci"),
+		] {
+			let context = ctx(program, Some("run"), command, &config);
+			let routed = filter(&context, input, 1).text;
+			let expected = lint::filter(&context, input, 1).text;
+			assert_eq!(routed, expected, "{command} should use lint filter");
+			assert!(
+				routed.contains("2 diagnostics in 1 files"),
+				"{command} should condense lint output"
+			);
+		}
+	}
+
+	#[test]
+	fn npm_t_routes_to_node_tests() {
+		let config = MinimizerConfig::default();
+		let context = ctx("npm", Some("t"), "npm t", &config);
+		let out = filter(&context, "✓ ok\nFAIL app.test.ts\nTests 1 failed\n", 1).text;
+		assert!(!out.contains("✓ ok"));
+		assert!(out.contains("FAIL app.test.ts"));
+	}
+
+	#[test]
 	fn pi_cli_names_are_not_supported() {
 		assert!(!supports("rtk", None));
 		assert!(!supports("pi", None));
+	}
+
+	// ---------------------------------------------------------------
+	// Tier 2a: uv dispatch coverage tests (m4)
+	// ---------------------------------------------------------------
+
+	const PYTEST_FAILURE_INPUT: &str = "============================= test session starts \
+	                                    ==============================\ncollected 2 \
+	                                    items\n\nFAILED tests/test_x.py::test_fail - \
+	                                    AssertionError\n========================= 1 failed, 1 \
+	                                    passed in 0.05s =========================\n";
+
+	#[test]
+	fn uv_pytest_routes_to_python_filter() {
+		// B1 fix: `uv pytest <args>` now routes to the python filter.
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("pytest"), "uv pytest tests/", &config);
+		assert!(supports("uv", Some("pytest")));
+		let out = filter(&context, PYTEST_FAILURE_INPUT, 1).text;
+		assert!(out.contains("FAILED tests/test_x.py::test_fail"));
+		assert!(out.contains("pytest: 1 failed, 1 passed"));
+	}
+
+	#[test]
+	fn uv_dash_m_pytest_routes_to_python_filter() {
+		// B1 fix: `uv -m pytest <args>` now routes via -m token scan.
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("-m"), "uv -m pytest tests/", &config);
+		assert!(supports("uv", Some("-m")));
+		let out = filter(&context, PYTEST_FAILURE_INPUT, 1).text;
+		assert!(out.contains("FAILED tests/test_x.py::test_fail"));
+		assert!(out.contains("pytest: 1 failed, 1 passed"));
+	}
+
+	#[test]
+	fn uv_ruff_routes_to_python_filter() {
+		// B1 fix: `uv ruff <args>` now routes to the python filter.
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("ruff"), "uv ruff check .", &config);
+		assert!(supports("uv", Some("ruff")));
+		let out =
+			filter(&context, "src/a.py:1:1: F401 imported but unused\nFound 1 error.\n", 1).text;
+		assert!(out.contains("F401"));
+	}
+
+	#[test]
+	fn uv_mypy_routes_to_python_filter() {
+		// B1 fix: `uv mypy <args>` now routes to the python filter.
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("mypy"), "uv mypy src/", &config);
+		assert!(supports("uv", Some("mypy")));
+		// mypy filter routes through lint::condense_lint_output; smoke-check
+		// it does not crash and produces a string output.
+		let _ = filter(&context, "src/a.py:1: error: foo\n", 1).text;
+	}
+
+	#[test]
+	fn uv_run_pytest_still_routes_regression_guard() {
+		// Regression guard for the pre-existing `uv run pytest` path.
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("run"), "uv run pytest tests/", &config);
+		let out = filter(&context, PYTEST_FAILURE_INPUT, 1).text;
+		assert!(out.contains("FAILED tests/test_x.py::test_fail"));
+		assert!(out.contains("pytest: 1 failed, 1 passed"));
+	}
+
+	#[test]
+	fn uv_run_python_dash_m_pytest_still_routes() {
+		// Regression guard: `uv run python -m pytest` was supported pre-PR.
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("run"), "uv run python -m pytest tests/", &config);
+		let out = filter(&context, PYTEST_FAILURE_INPUT, 1).text;
+		assert!(out.contains("FAILED tests/test_x.py::test_fail"));
+		assert!(out.contains("pytest: 1 failed, 1 passed"));
+	}
+
+	#[test]
+	fn normalize_uv_form_unit_pytest_subcommand() {
+		assert_eq!(super::normalize_uv_form(Some("pytest"), "uv pytest"), Some("pytest"));
+	}
+
+	#[test]
+	fn normalize_uv_form_unit_dash_m_pytest() {
+		assert_eq!(super::normalize_uv_form(Some("-m"), "uv -m pytest tests/"), Some("pytest"));
+	}
+
+	#[test]
+	fn normalize_uv_form_unit_run_returns_none() {
+		// `uv run` is handled by the pre-existing path; normalize returns None.
+		assert_eq!(super::normalize_uv_form(Some("run"), "uv run pytest"), None);
+	}
+
+	#[test]
+	fn normalize_uv_form_unit_unknown_returns_none() {
+		assert_eq!(super::normalize_uv_form(Some("unknown"), "uv unknown"), None);
+		assert_eq!(super::normalize_uv_form(None, "uv"), None);
+	}
+
+	#[test]
+	fn pytest_legacy_filters_active_passes_through() {
+		// Kill-switch parity (M2): legacy_filters_active=true skips the
+		// pytest state machine even when invoked via `uv pytest`.
+		let mut config = MinimizerConfig::default();
+		config.enabled = true;
+		config.legacy_filters_active = true;
+		let context = ctx("uv", Some("pytest"), "uv pytest tests/", &config);
+		let out = filter(&context, PYTEST_FAILURE_INPUT, 1);
+		assert_eq!(out.text, PYTEST_FAILURE_INPUT);
+		assert!(!out.changed);
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/node_tests.rs
+++ b/crates/pi-shell/src/minimizer/filters/node_tests.rs
@@ -65,7 +65,7 @@ fn failures_only(input: &str) -> String {
 		}
 
 		if keeping_block {
-			if is_pass_noise(trimmed) && !is_error_context_line(trimmed) {
+			if is_pass_noise(trimmed) {
 				keeping_block = false;
 				trailing_context = 0;
 				continue;
@@ -112,6 +112,7 @@ fn is_summary_line(trimmed: &str) -> bool {
 		|| trimmed.starts_with("% ")
 		|| trimmed.starts_with("Failed Tests")
 		|| trimmed.starts_with("Playwright Test Report")
+		|| (trimmed.starts_with("Ran ") && trimmed.contains("tests across"))
 		|| starts_count_summary(trimmed)
 }
 
@@ -123,7 +124,7 @@ fn starts_count_summary(trimmed: &str) -> bool {
 	if !count.chars().all(|ch| ch.is_ascii_digit()) {
 		return false;
 	}
-	matches!(parts.next(), Some("failed" | "passed" | "skipped" | "flaky"))
+	matches!(parts.next(), Some("failed" | "passed" | "skipped" | "flaky" | "pass" | "fail"))
 }
 
 fn is_pass_noise(trimmed: &str) -> bool {
@@ -134,6 +135,13 @@ fn is_pass_noise(trimmed: &str) -> bool {
 		|| trimmed.starts_with("○")
 		|| trimmed.starts_with(" RUN ")
 		|| trimmed.starts_with("DEV ")
+		|| trimmed.starts_with("bun test ")
+		|| trimmed.ends_with(".test.ts:")
+		|| trimmed.ends_with(".test.js:")
+		|| trimmed.ends_with(".test.tsx:")
+		|| trimmed.ends_with(".test.jsx:")
+		|| trimmed.ends_with(".spec.ts:")
+		|| trimmed.ends_with(".spec.js:")
 }
 
 fn starts_failure_block(trimmed: &str) -> bool {
@@ -160,6 +168,7 @@ fn is_error_context_line(trimmed: &str) -> bool {
 		|| trimmed.starts_with("Expected")
 		|| trimmed.starts_with("Received")
 		|| trimmed.starts_with("Error:")
+		|| trimmed.starts_with("error:")
 		|| trimmed.starts_with("AssertionError")
 		|| trimmed.starts_with("TimeoutError")
 		|| trimmed.contains(" › ")
@@ -234,5 +243,103 @@ mod tests {
 	fn success_keeps_summary_when_everything_else_is_pass_noise() {
 		let filtered = drop_passed_lines("✓ one passed\n✓ two passed\n3 passed (1.2s)\n");
 		assert_eq!(filtered, "3 passed (1.2s)\n");
+	}
+	#[test]
+	fn bun_pass_only_collapses_to_counts() {
+		let input = "\
+✓ a.test.ts > add works [0.50ms]
+✓ a.test.ts > subtract works [0.30ms]
+✓ b.test.ts > multiply works [0.40ms]
+✓ b.test.ts > divide works [0.60ms]
+✓ c.test.ts > negate works [0.20ms]
+
+ 5 pass
+ 0 fail
+ 7 expect() calls
+Ran 5 tests across 3 files. [102.00ms]
+";
+		let filtered = drop_passed_lines(input);
+
+		assert!(!filtered.contains("add works"));
+		assert!(!filtered.contains("subtract works"));
+		assert!(!filtered.contains("multiply works"));
+		assert!(filtered.contains("5 pass"));
+		assert!(filtered.contains("0 fail"));
+		assert!(filtered.contains("7 expect() calls"));
+		assert!(filtered.contains("Ran 5 tests across 3 files"));
+	}
+
+	#[test]
+	fn bun_failure_keeps_error_and_counts() {
+		let input = "\
+✗ a.test.ts > bad test [0.40ms]
+error: expect(received).toBe(expected)
+Expected: 2
+Received: 3
+      at a.test.ts:5:7
+
+✓ b.test.ts > another good [0.60ms]
+
+ 2 pass
+ 1 fail
+Ran 3 tests across 2 files. [150.00ms]
+";
+		let filtered = failures_only(input);
+
+		assert!(!filtered.contains("another good"));
+		assert!(filtered.contains("✗ a.test.ts > bad test"));
+		assert!(filtered.contains("error: expect(received).toBe(expected)"));
+		assert!(filtered.contains("Expected: 2"));
+		assert!(filtered.contains("Received: 3"));
+		assert!(filtered.contains("at a.test.ts:5:7"));
+		assert!(filtered.contains("2 pass"));
+		assert!(filtered.contains("1 fail"));
+	}
+
+	#[test]
+	fn vitest_many_passes_collapses_to_summary() {
+		let input = "\
+ ✓ src/a.test.ts > suite > test1 (2ms)
+ ✓ src/a.test.ts > suite > test2 (1ms)
+ ✓ src/a.test.ts > other > test3 (3ms)
+ ✓ src/b.test.ts > feature > test4 (1ms)
+ ✓ src/b.test.ts > feature > test5 (2ms)
+ ✓ src/b.test.ts > edge > test6 (5ms)
+
+ Test Files  2 passed (2)
+      Tests  6 passed (6)
+   Start at  12:00:00
+   Duration  1.23s
+";
+		let filtered = drop_passed_lines(input);
+
+		assert!(!filtered.contains("test1"));
+		assert!(!filtered.contains("test6"));
+		assert!(filtered.contains("Test Files  2 passed (2)"));
+		assert!(filtered.contains("Tests  6 passed (6)"));
+		assert!(filtered.contains("Duration  1.23s"));
+	}
+
+	#[test]
+	fn jest_many_passes_collapses_to_summary() {
+		let input = "\
+ PASS  src/a.test.ts
+ PASS  src/b.test.ts
+ PASS  src/c.test.ts
+ PASS  src/d.test.ts
+ PASS  src/e.test.ts
+
+Test Suites: 5 passed, 5 total
+Tests:       32 passed, 32 total
+Snapshots:   0 total
+Time:        2.345s
+";
+		let filtered = drop_passed_lines(input);
+
+		assert!(!filtered.contains("src/a.test.ts"));
+		assert!(!filtered.contains("src/e.test.ts"));
+		assert!(filtered.contains("Test Suites: 5 passed, 5 total"));
+		assert!(filtered.contains("Tests:       32 passed, 32 total"));
+		assert!(filtered.contains("Time:        2.345s"));
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/pkg.rs
+++ b/crates/pi-shell/src/minimizer/filters/pkg.rs
@@ -1,6 +1,9 @@
 //! Package manager output filters.
 
+use std::{collections::HashSet, fmt::Write as _};
+
 use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
+const PACKAGE_TREE_HEAD_LINES: usize = 80;
 
 pub fn supports(subcommand: Option<&str>) -> bool {
 	matches!(
@@ -13,6 +16,7 @@ pub fn supports(subcommand: Option<&str>) -> bool {
 				| "remove"
 				| "rm" | "uninstall"
 				| "list" | "ls"
+				| "tree" | "pip"
 				| "outdated"
 				| "sync" | "lock"
 				| "run" | "exec"
@@ -30,19 +34,30 @@ pub fn supports(subcommand: Option<&str>) -> bool {
 				| "dedupe"
 				| "publish"
 				| "pack" | "link"
-				| "why"
+				| "why" | "export"
 		)
 	)
 }
 
 pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerOutput {
 	let cleaned = primitives::strip_ansi(input);
-	let stripped = strip_package_noise(ctx.program, &cleaned, exit_code);
-	let deduped = primitives::dedup_consecutive_lines(&stripped);
-	let text = if contains_audit_or_security_summary(&deduped) {
-		deduped
+	let text = if exit_code == 0 && is_package_lock_command(ctx) {
+		compact_package_lock_output(ctx, &cleaned)
 	} else {
-		primitives::head_tail_lines(&deduped, 120, 80)
+		let stripped = strip_package_noise(ctx, &cleaned, exit_code);
+		let deduped = primitives::dedup_consecutive_lines(&stripped);
+		if contains_audit_or_security_summary(&deduped) {
+			deduped
+		} else if exit_code == 0 && (is_package_tree_command(ctx) || is_package_export_command(ctx)) {
+			compact_package_tree_output(&deduped)
+		} else {
+			let cap = if exit_code == 0 {
+				primitives::CapClass::Inventory
+			} else {
+				primitives::CapClass::Errors
+			};
+			primitives::head_tail_cap(&deduped, cap)
+		}
 	};
 
 	if text == input {
@@ -52,7 +67,7 @@ pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerO
 	}
 }
 
-fn strip_package_noise(program: &str, input: &str, exit_code: i32) -> String {
+fn strip_package_noise(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> String {
 	let mut out = String::new();
 	let mut previous_blank = false;
 	for line in input.lines() {
@@ -66,7 +81,7 @@ fn strip_package_noise(program: &str, input: &str, exit_code: i32) -> String {
 		}
 		previous_blank = false;
 
-		if is_noise_line(program, trimmed, exit_code) {
+		if is_noise_line(ctx, trimmed, exit_code) {
 			continue;
 		}
 		out.push_str(line.trim_end());
@@ -75,19 +90,248 @@ fn strip_package_noise(program: &str, input: &str, exit_code: i32) -> String {
 	out
 }
 
-fn is_noise_line(program: &str, line: &str, exit_code: i32) -> bool {
-	if is_audit_or_security_summary(line) {
+fn is_package_tree_command(ctx: &MinimizerCtx<'_>) -> bool {
+	match ctx.program {
+		"npm" | "pnpm" | "yarn" => {
+			matches!(ctx.subcommand, Some("list" | "ls" | "tree" | "why" | "explain"))
+		},
+		"bun" => {
+			matches!(ctx.subcommand, Some("list" | "ls" | "tree" | "why" | "explain"))
+				|| matches!(ctx.subcommand, Some("pm"))
+					&& command_contains_any(ctx.command, &["list", "ls", "tree", "why"])
+		},
+		"uv" => {
+			matches!(ctx.subcommand, Some("list" | "ls" | "tree"))
+				|| matches!(ctx.subcommand, Some("pip"))
+					&& command_contains_any(ctx.command, &["list", "ls", "tree", "freeze"])
+		},
+		"poetry" => {
+			matches!(ctx.subcommand, Some("tree"))
+				|| matches!(ctx.subcommand, Some("show"))
+					&& command_contains_any(ctx.command, &["--tree"])
+		},
+		_ => false,
+	}
+}
+
+fn is_package_export_command(ctx: &MinimizerCtx<'_>) -> bool {
+	match ctx.program {
+		"uv" | "poetry" => ctx.subcommand == Some("export"),
+		_ => false,
+	}
+}
+
+fn is_package_lock_command(ctx: &MinimizerCtx<'_>) -> bool {
+	matches!((ctx.program, ctx.subcommand), ("uv" | "poetry", Some("lock")))
+}
+
+fn command_contains_any(command: &str, words: &[&str]) -> bool {
+	command.split_whitespace().any(|part| words.contains(&part))
+}
+
+fn compact_package_tree_output(input: &str) -> String {
+	if let Some(summary) = compact_package_tree_json_output(input) {
+		return summary;
+	}
+	if let Some(summary) = compact_package_tree_ndjson_output(input) {
+		return summary;
+	}
+	let lines: Vec<&str> = input
+		.lines()
+		.map(str::trim_end)
+		.filter(|line| !line.trim().is_empty())
+		.collect();
+	if lines.len() <= PACKAGE_TREE_HEAD_LINES {
+		return input.to_string();
+	}
+
+	let mut out = format!("package tree/list: {} entries\n", lines.len());
+	for line in lines.iter().take(PACKAGE_TREE_HEAD_LINES) {
+		out.push_str(line);
+		out.push('\n');
+	}
+	let _ = writeln!(out, "… {} package entries omitted …", lines.len() - PACKAGE_TREE_HEAD_LINES);
+	out
+}
+
+fn compact_package_tree_json_output(input: &str) -> Option<String> {
+	let value: serde_json::Value = serde_json::from_str(input).ok()?;
+	let mut rows = Vec::new();
+	let mut seen = HashSet::new();
+	collect_package_tree_json_rows(&value, &mut rows, &mut seen);
+	summarize_package_rows(rows)
+}
+
+fn compact_package_tree_ndjson_output(input: &str) -> Option<String> {
+	let mut rows = Vec::new();
+	let mut seen = HashSet::new();
+	for line in input.lines().map(str::trim).filter(|line| !line.is_empty()) {
+		let value: serde_json::Value = serde_json::from_str(line).ok()?;
+		collect_package_tree_json_rows(&value, &mut rows, &mut seen);
+		if let Some(data) = value.get("data").and_then(serde_json::Value::as_str) {
+			for row in data
+				.lines()
+				.map(str::trim_end)
+				.filter(|row| !row.trim().is_empty())
+			{
+				push_unique_row(&mut rows, &mut seen, row.to_string());
+			}
+		}
+	}
+	summarize_package_rows(rows)
+}
+
+fn summarize_package_rows(rows: Vec<String>) -> Option<String> {
+	if rows.is_empty() {
+		return None;
+	}
+	let mut out = format!("package tree/list: {} entries\n", rows.len());
+	for row in rows.iter().take(PACKAGE_TREE_HEAD_LINES) {
+		out.push_str(row);
+		out.push('\n');
+	}
+	if rows.len() > PACKAGE_TREE_HEAD_LINES {
+		let _ = writeln!(out, "… {} package entries omitted …", rows.len() - PACKAGE_TREE_HEAD_LINES);
+	}
+	Some(out)
+}
+
+fn collect_package_tree_json_rows(
+	value: &serde_json::Value,
+	rows: &mut Vec<String>,
+	seen: &mut HashSet<String>,
+) {
+	match value {
+		serde_json::Value::Object(map) => {
+			if let Some(name) = map.get("name").and_then(serde_json::Value::as_str) {
+				let version = map
+					.get("version")
+					.and_then(serde_json::Value::as_str)
+					.unwrap_or("");
+				push_unique_row(
+					rows,
+					seen,
+					if version.is_empty() {
+						name.to_string()
+					} else {
+						format!("{name} {version}")
+					},
+				);
+			}
+			if let Some(dependencies) = map
+				.get("dependencies")
+				.and_then(serde_json::Value::as_object)
+			{
+				for (name, child) in dependencies {
+					push_json_dependency_row(rows, seen, name, child);
+				}
+			}
+			for value in map.values() {
+				if value.is_array() || value.is_object() {
+					collect_package_tree_json_rows(value, rows, seen);
+				}
+			}
+		},
+		serde_json::Value::Array(items) => {
+			for item in items {
+				collect_package_tree_json_rows(item, rows, seen);
+			}
+		},
+		_ => {},
+	}
+}
+
+fn push_json_dependency_row(
+	rows: &mut Vec<String>,
+	seen: &mut HashSet<String>,
+	name: &str,
+	child: &serde_json::Value,
+) {
+	let version = child
+		.get("version")
+		.and_then(serde_json::Value::as_str)
+		.unwrap_or("");
+	push_unique_row(
+		rows,
+		seen,
+		if version.is_empty() {
+			name.to_string()
+		} else {
+			format!("{name} {version}")
+		},
+	);
+}
+
+fn push_unique_row(rows: &mut Vec<String>, seen: &mut HashSet<String>, row: String) {
+	if seen.insert(row.clone()) {
+		rows.push(row);
+	}
+}
+
+fn is_noise_line(ctx: &MinimizerCtx<'_>, line: &str, exit_code: i32) -> bool {
+	let lower = line.to_ascii_lowercase();
+
+	// Strip: "found 0 vulnerabilities" (non-actionable success noise)
+	if lower.contains("found 0 vulnerabilities") {
+		return true;
+	}
+	// Strip: "audited X packages" timing summaries (non-actionable)
+	if lower.contains("audited") && lower.contains("package") {
+		return true;
+	}
+	// Keep: vulnerability mentions (actionable — real findings)
+	if lower.contains("vulnerab") {
 		return false;
 	}
 	if exit_code != 0 && is_error_or_summary(line) {
 		return false;
 	}
 
-	let lower = line.to_ascii_lowercase();
+	if is_package_lock_command(ctx) && is_lock_summary_line(&lower) {
+		return false;
+	}
 	is_generic_progress(line, &lower)
-		|| is_js_package_noise(program, line, &lower)
-		|| is_python_package_noise(program, line, &lower)
-		|| is_ruby_php_brew_noise(program, line, &lower)
+		|| is_js_package_noise(ctx.program, line, &lower)
+		|| is_python_package_noise(ctx.program, line, &lower)
+		|| is_ruby_php_brew_noise(ctx.program, line, &lower)
+}
+
+fn compact_package_lock_output(ctx: &MinimizerCtx<'_>, input: &str) -> String {
+	let mut out = String::new();
+	for line in input.lines() {
+		let trimmed = line.trim();
+		if trimmed.is_empty() {
+			continue;
+		}
+		let lower = trimmed.to_ascii_lowercase();
+		if is_lock_summary_line(&lower) {
+			out.push_str(trimmed);
+			out.push('\n');
+			continue;
+		}
+		if is_generic_progress(trimmed, &lower)
+			|| is_python_package_noise(ctx.program, trimmed, &lower)
+			|| is_js_package_noise(ctx.program, trimmed, &lower)
+		{
+			continue;
+		}
+		out.push_str(trimmed);
+		out.push('\n');
+	}
+	if out.trim().is_empty() {
+		primitives::head_tail_cap(input, primitives::CapClass::Inventory)
+	} else {
+		primitives::head_tail_cap(&out, primitives::CapClass::Inventory)
+	}
+}
+
+fn is_lock_summary_line(lower: &str) -> bool {
+	lower.starts_with("writing lock file")
+		|| lower.starts_with("updated lockfile")
+		|| lower.starts_with("resolved ")
+		|| lower.starts_with("installing dependencies from lock file")
+		|| lower == "no changes."
+		|| lower.starts_with("no dependencies to install or update")
 }
 
 fn is_generic_progress(line: &str, lower: &str) -> bool {
@@ -110,7 +354,6 @@ fn is_js_package_noise(program: &str, line: &str, lower: &str) -> bool {
 	}
 	line.starts_with('>') && line.contains('@')
 		|| lower.starts_with("npm notice")
-		|| lower.starts_with("npm warn deprecated")
 		|| lower.starts_with("npm http fetch")
 		|| lower.starts_with("pnpm: progress")
 		|| lower.starts_with("packages:")
@@ -119,6 +362,7 @@ fn is_js_package_noise(program: &str, line: &str, lower: &str) -> bool {
 		|| lower.starts_with("added ") && lower.contains("packages")
 		|| lower.starts_with("done in ")
 		|| lower.contains("already up-to-date")
+		|| lower.contains("up to date")
 }
 
 fn is_python_package_noise(program: &str, _line: &str, lower: &str) -> bool {
@@ -133,6 +377,17 @@ fn is_python_package_noise(program: &str, _line: &str, lower: &str) -> bool {
 		|| lower.starts_with("resolving dependencies")
 		|| lower.starts_with("writing lock file")
 		|| lower.starts_with("package operations:")
+		|| program == "uv" && is_uv_progress_noise(lower)
+}
+
+fn is_uv_progress_noise(lower: &str) -> bool {
+	lower.starts_with("resolved ")
+		|| lower.starts_with("prepared ")
+		|| lower.starts_with("installed ")
+		|| lower.starts_with("uninstalled ")
+		|| lower.starts_with("updated ")
+		|| lower.starts_with("built ")
+		|| lower.starts_with("downloaded ")
 }
 
 fn is_ruby_php_brew_noise(program: &str, _line: &str, lower: &str) -> bool {
@@ -177,12 +432,15 @@ fn is_error_or_summary(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::minimizer::MinimizerConfig;
 
 	#[test]
 	fn strips_progress_but_keeps_package_errors() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("npm", Some("install"), "npm install", &cfg);
 		let input = "Resolving: total 10\nDownloading: left-pad\nERROR failed to install \
 		             left-pad\nfound 1 vulnerability\n";
-		let out = strip_package_noise("npm", input, 1);
+		let out = strip_package_noise(&ctx, input, 1);
 		assert!(!out.contains("Resolving:"));
 		assert!(!out.contains("Downloading:"));
 		assert!(out.contains("ERROR failed"));
@@ -190,22 +448,34 @@ mod tests {
 	}
 
 	#[test]
-	fn preserves_successful_install_audit_and_security_summaries() {
+	fn strips_success_noise_audited_and_zero_vulnerabilities() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("npm", Some("install"), "npm install", &cfg);
 		let input = "Resolving: total 10\nadded 3 packages, and audited 4 packages in 1s\n2 \
 		             packages are looking for funding\nfound 0 vulnerabilities\n";
-		let out = strip_package_noise("npm", input, 0);
+		let out = strip_package_noise(&ctx, input, 0);
 		assert!(!out.contains("Resolving:"));
-		assert!(out.contains("added 3 packages, and audited 4 packages in 1s"));
-		assert!(out.contains("2 packages are looking for funding"));
-		assert!(out.contains("found 0 vulnerabilities"));
+		assert!(!out.contains("audited 4 packages"));
+		assert!(!out.contains("found 0 vulnerabilities"));
+	}
+
+	#[test]
+	fn preserves_deprecation_warnings() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("npm", Some("install"), "npm install", &cfg);
+		let input = "npm warn deprecated left-pad@1.0.0: Please upgrade to left-pad@2.0.0\nnpm warn \
+		             deprecated old-lib@2.0.0: Use new-lib instead\n";
+		let out = strip_package_noise(&ctx, input, 0);
+		assert!(out.contains("npm warn deprecated left-pad@1.0.0: Please upgrade to left-pad@2.0.0"));
+		assert!(out.contains("npm warn deprecated old-lib@2.0.0: Use new-lib instead"));
 	}
 
 	#[test]
 	fn supports_common_package_subcommands_for_future_dispatch() {
 		for subcommand in [
-			"ci", "add", "outdated", "sync", "audit", "why", "view", "fund", "explain", "test", "t",
-			"start", "stop", "restart", "config", "cache", "prune", "dedupe", "publish", "pack",
-			"link",
+			"ci", "add", "outdated", "sync", "audit", "why", "tree", "pip", "view", "fund", "explain",
+			"test", "t", "start", "stop", "restart", "config", "cache", "prune", "dedupe", "publish",
+			"pack", "link",
 		] {
 			assert!(supports(Some(subcommand)), "{subcommand} should be supported");
 		}
@@ -213,10 +483,240 @@ mod tests {
 
 	#[test]
 	fn bun_install_noise_uses_js_package_rules() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("bun", Some("install"), "bun install", &cfg);
 		let input = "Resolving dependencies\nDownloaded foo\nerror: failed\n";
-		let out = strip_package_noise("bun", input, 1);
+		let out = strip_package_noise(&ctx, input, 1);
 		assert!(!out.contains("Resolving dependencies"));
 		assert!(!out.contains("Downloaded foo"));
 		assert!(out.contains("error: failed"));
+	}
+
+	fn ctx<'a>(
+		program: &'a str,
+		subcommand: Option<&'a str>,
+		command: &'a str,
+		config: &'a MinimizerConfig,
+	) -> MinimizerCtx<'a> {
+		MinimizerCtx { program, subcommand, command, config }
+	}
+
+	#[test]
+	fn compacts_large_js_package_tree() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("npm", Some("list"), "npm list --all", &cfg);
+		let mut input = String::from("app@1.0.0\n");
+		for idx in 0..90 {
+			input.push_str(&format!("├── dep{idx:03}@1.0.0\n"));
+		}
+
+		let out = filter(&context, &input, 0);
+		assert!(out.text.starts_with("package tree/list: 91 entries\n"));
+		assert!(out.text.contains("├── dep000@1.0.0"));
+		assert!(out.text.contains("├── dep078@1.0.0"));
+		assert!(!out.text.contains("├── dep089@1.0.0"));
+		assert!(out.text.contains("… 11 package entries omitted …"));
+	}
+
+	#[test]
+	fn compacts_depth_limited_package_tree_commands() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("npm", Some("ls"), "npm ls --depth=0", &cfg);
+		let mut input = String::from("app@1.0.0\n");
+		for idx in 0..90 {
+			input.push_str(&format!("├── dep{idx:03}@1.0.0\n"));
+		}
+
+		let out = filter(&context, &input, 0);
+		assert!(out.text.starts_with("package tree/list: 91 entries\n"));
+		assert!(out.text.contains("dep000"));
+		assert!(out.text.contains("… 11 package entries omitted …"));
+	}
+
+	#[test]
+	fn compacts_pnpm_why_style_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("pnpm", Some("why"), "pnpm why react", &cfg);
+		let mut input =
+			String::from("Legend: production dependency, optional only, dev only\nreact 19.0.0\n");
+		for idx in 0..90 {
+			input.push_str(&format!("└─ dependent{idx:03}\n"));
+		}
+
+		let out = filter(&context, &input, 0);
+		assert!(out.text.starts_with("package tree/list: 92 entries\n"));
+		assert!(out.text.contains("react 19.0.0"));
+		assert!(out.text.contains("└─ dependent000"));
+		assert!(out.text.contains("… 12 package entries omitted …"));
+	}
+
+	#[test]
+	fn compacts_npm_json_dependency_tree() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("npm", Some("ls"), "npm ls --json", &cfg);
+		let input = r#"{"name":"app","version":"1.0.0","dependencies":{"react":{"version":"19.0.0","dependencies":{"scheduler":{"version":"0.25.0"}}},"zod":{"version":"4.0.0"}}}"#;
+		let out = filter(&context, input, 0);
+		assert!(out.text.starts_with("package tree/list: 4 entries\n"));
+		assert!(out.text.contains("app 1.0.0"));
+		assert!(out.text.contains("react 19.0.0"));
+		assert!(out.text.contains("scheduler 0.25.0"));
+	}
+
+	#[test]
+	fn compacts_pnpm_why_json_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("pnpm", Some("why"), "pnpm why react --json", &cfg);
+		let input = r#"[{"name":"react","version":"19.0.0","dependents":[{"name":"app","version":"1.0.0"},{"name":"docs","version":"1.0.0"}]}]"#;
+		let out = filter(&context, input, 0);
+		assert!(out.text.starts_with("package tree/list: 3 entries\n"));
+		assert!(out.text.contains("react 19.0.0"));
+		assert!(out.text.contains("app 1.0.0"));
+		assert!(out.text.contains("docs 1.0.0"));
+	}
+
+	#[test]
+	fn compacts_yarn_why_ndjson_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("yarn", Some("why"), "yarn why react --json", &cfg);
+		let input = "{\"type\":\"info\",\"data\":\"=> Found \
+		             \\\"react@npm:19.0.0\\\"\"}\n{\"type\":\"tree\",\"data\":\"react@npm:19.0.0\\\
+		             n└─ app@workspace:.\"}\n";
+		let out = filter(&context, input, 0);
+		assert!(out.text.starts_with("package tree/list: 3 entries\n"));
+		assert!(out.text.contains("=> Found \"react@npm:19.0.0\""));
+		assert!(out.text.contains("react@npm:19.0.0"));
+		assert!(out.text.contains("└─ app@workspace:."));
+	}
+
+	#[test]
+	fn compacts_npm_explain_json_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("npm", Some("explain"), "npm explain react --json", &cfg);
+		let input = r#"{"name":"react","version":"19.0.0","dependents":[{"name":"app","version":"1.0.0","location":"."}]}"#;
+		let out = filter(&context, input, 0);
+		assert!(out.text.starts_with("package tree/list: 2 entries\n"));
+		assert!(out.text.contains("react 19.0.0"));
+		assert!(out.text.contains("app 1.0.0"));
+	}
+
+	#[test]
+	fn compacts_uv_pip_list_and_strips_progress_noise() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("uv", Some("pip"), "uv pip list", &cfg);
+		let mut input = String::from(
+			"Resolved 91 packages in 12ms\nPrepared 2 packages in 3ms\nPackage Version\n",
+		);
+		for idx in 0..90 {
+			input.push_str(&format!("pkg{idx:03} 1.0.{idx}\n"));
+		}
+
+		let out = filter(&context, &input, 0);
+		assert!(!out.text.contains("Resolved 91 packages"));
+		assert!(!out.text.contains("Prepared 2 packages"));
+		assert!(out.text.starts_with("package tree/list: 91 entries\n"));
+		assert!(out.text.contains("Package Version"));
+		assert!(out.text.contains("pkg000 1.0.0"));
+		assert!(out.text.contains("pkg078 1.0.78"));
+		assert!(!out.text.contains("pkg089 1.0.89"));
+		assert!(out.text.contains("… 11 package entries omitted …"));
+	}
+
+	#[test]
+	fn compacts_uv_tree_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("uv", Some("tree"), "uv tree", &cfg);
+		let mut input = String::from("project v1.0.0\n");
+		for idx in 0..90 {
+			input.push_str(&format!("├── pkg{idx:03} v1.0.{idx}\n"));
+		}
+
+		let out = filter(&context, &input, 0);
+		assert!(out.text.starts_with("package tree/list: 91 entries\n"));
+		assert!(out.text.contains("project v1.0.0"));
+		assert!(out.text.contains("pkg000"));
+		assert!(out.text.contains("… 11 package entries omitted …"));
+	}
+
+	#[test]
+	fn compacts_poetry_show_tree_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("poetry", Some("show"), "poetry show --tree", &cfg);
+		let mut input = String::from("requests 2.32.0 Python HTTP for Humans.\n");
+		for idx in 0..90 {
+			input.push_str(&format!("├── dep{idx:03} 1.0.{idx}\n"));
+		}
+
+		let out = filter(&context, &input, 0);
+		assert!(out.text.starts_with("package tree/list: 91 entries\n"));
+		assert!(out.text.contains("requests 2.32.0"));
+		assert!(out.text.contains("… 11 package entries omitted …"));
+	}
+
+	#[test]
+	fn compacts_uv_pip_freeze_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("uv", Some("pip"), "uv pip freeze", &cfg);
+		let mut input = String::new();
+		for idx in 0..90 {
+			input.push_str(&format!("pkg{idx:03}==1.0.{idx}\n"));
+		}
+
+		let out = filter(&context, &input, 0);
+		assert!(out.text.starts_with("package tree/list: 90 entries\n"));
+		assert!(out.text.contains("pkg000==1.0.0"));
+		assert!(out.text.contains("… 10 package entries omitted …"));
+	}
+
+	#[test]
+	fn compacts_uv_export_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("uv", Some("export"), "uv export -f requirements-txt", &cfg);
+		let mut input = String::from("# generated by uv\n");
+		for idx in 0..90 {
+			input.push_str(&format!("pkg{idx:03}==1.0.{idx}\n"));
+		}
+
+		let out = filter(&context, &input, 0);
+		assert!(out.text.starts_with("package tree/list: 91 entries\n"));
+		assert!(out.text.contains("pkg000==1.0.0"));
+		assert!(out.text.contains("… 11 package entries omitted …"));
+	}
+
+	#[test]
+	fn compacts_poetry_export_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("poetry", Some("export"), "poetry export -f requirements.txt", &cfg);
+		let mut input = String::from("# generated by poetry\n");
+		for idx in 0..90 {
+			input.push_str(&format!("dep{idx:03}==2.0.{idx}\n"));
+		}
+
+		let out = filter(&context, &input, 0);
+		assert!(out.text.starts_with("package tree/list: 91 entries\n"));
+		assert!(out.text.contains("dep000==2.0.0"));
+		assert!(out.text.contains("… 11 package entries omitted …"));
+	}
+
+	#[test]
+	fn compacts_uv_lock_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("uv", Some("lock"), "uv lock", &cfg);
+		let input =
+			"Resolved 42 packages in 7ms\nDownloading requests\nUpdated lockfile at uv.lock\n";
+		let out = filter(&context, input, 0);
+		assert!(out.text.contains("Resolved 42 packages in 7ms"));
+		assert!(out.text.contains("Updated lockfile at uv.lock"));
+		assert!(!out.text.contains("Downloading requests"));
+	}
+
+	#[test]
+	fn compacts_poetry_lock_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("poetry", Some("lock"), "poetry lock", &cfg);
+		let input =
+			"Resolving dependencies...\nInstalling dependencies from lock file\nWriting lock file\n";
+		let out = filter(&context, input, 0);
+		assert!(out.text.contains("Installing dependencies from lock file"));
+		assert!(out.text.contains("Writing lock file"));
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/python.rs
+++ b/crates/pi-shell/src/minimizer/filters/python.rs
@@ -1,4 +1,16 @@
 //! Python test, type-check, and lint output filters.
+//!
+//! Ported from rtk-ai/rtk@878af7de99e0ba71da2e8fd996f6b52a1836e06c
+//! Path: `src/cmds/python/pytest_cmd.rs`
+//! License: MIT (compatible with workspace MIT). See ATTRIBUTION-RTK.md.
+//!
+//! The pytest state machine (`filter_pytest`, `pytest_success`,
+//! `is_pytest_*`, `looks_like_pytest_summary_part`) adapts the
+//! `build_pytest_summary` algorithm from RTK at the pinned SHA above:
+//! preserve failures, errors, and the final summary line; strip header
+//! framing, progress dots, and verbose PASSED rows. Unknown-state lines
+//! fall through unchanged (RTK's defensive default), so xdist `[gwN]`
+//! prefixes and custom reporters never cause data loss.
 
 use super::lint;
 use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
@@ -12,6 +24,12 @@ pub fn supports(program: &str, subcommand: Option<&str>) -> bool {
 }
 
 pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerOutput {
+	// Kill-switch parity (M2): when `legacy_filters_active`, fall back to
+	// the pre-PR passthrough so callers can rollback an RTK-port regression
+	// without recompile.
+	if ctx.config.legacy_filters_active() {
+		return MinimizerOutput::passthrough(input);
+	}
 	let tool = python_tool(ctx.program, ctx.subcommand);
 	let cleaned = primitives::strip_ansi(input);
 	let text = match tool {
@@ -50,9 +68,14 @@ fn filter_pytest(input: &str, exit_code: i32) -> String {
 
 	for line in input.lines() {
 		let trimmed = line.trim();
-		if is_pytest_summary_header(trimmed) || is_pytest_summary_line(trimmed) {
+		if is_pytest_summary_header(trimmed) {
 			in_failure = false;
 			push_line(&mut out, line);
+			continue;
+		}
+		if is_pytest_summary_line(trimmed) {
+			in_failure = false;
+			push_pytest_summary_line(&mut out, trimmed);
 			continue;
 		}
 
@@ -91,9 +114,14 @@ fn pytest_success(input: &str) -> String {
 
 	for line in input.lines() {
 		let trimmed = line.trim();
-		if is_pytest_summary_line(trimmed) || is_pytest_summary_header(trimmed) {
+		if is_pytest_summary_header(trimmed) {
 			push_line(&mut summary, line);
 			push_line(&mut out, line);
+			continue;
+		}
+		if is_pytest_summary_line(trimmed) {
+			push_pytest_summary_line(&mut summary, trimmed);
+			push_pytest_summary_line(&mut out, trimmed);
 			continue;
 		}
 		if is_pytest_pass_noise(trimmed) {
@@ -162,6 +190,14 @@ fn looks_like_pytest_summary_part(part: &str) -> bool {
 	false
 }
 
+fn compact_pytest_summary_line(trimmed: &str) -> &str {
+	if trimmed.starts_with('=') {
+		trimmed.trim_matches('=').trim()
+	} else {
+		trimmed
+	}
+}
+
 fn is_pytest_section_delimiter(trimmed: &str) -> bool {
 	trimmed.len() >= 6
 		&& trimmed
@@ -180,6 +216,7 @@ fn is_pytest_pass_noise(trimmed: &str) -> bool {
 		|| trimmed.starts_with("platform ")
 		|| trimmed.starts_with("cachedir:")
 		|| is_pytest_verbose_pass_line(trimmed)
+		|| is_pytest_progress_line(trimmed)
 		|| trimmed
 			.chars()
 			.all(|ch| matches!(ch, '.' | 's' | 'S' | 'x' | 'X' | 'f' | 'F' | 'E'))
@@ -191,6 +228,19 @@ fn is_pytest_verbose_pass_line(trimmed: &str) -> bool {
 	}
 	let mut parts = trimmed.split_whitespace();
 	parts.any(|part| matches!(part, "PASSED" | "SKIPPED" | "XPASS" | "XFAIL"))
+}
+
+fn is_pytest_progress_line(trimmed: &str) -> bool {
+	let Some((path, statuses)) = trimmed.split_once(char::is_whitespace) else {
+		return false;
+	};
+	std::path::Path::new(path)
+		.extension()
+		.is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
+		&& statuses
+			.trim()
+			.chars()
+			.all(|ch| matches!(ch, '.' | 's' | 'S' | 'x' | 'X' | 'f' | 'F' | 'E'))
 }
 
 fn is_ruff_format(ctx: &MinimizerCtx<'_>) -> bool {
@@ -236,6 +286,12 @@ fn push_line(out: &mut String, line: &str) {
 	out.push('\n');
 }
 
+fn push_pytest_summary_line(out: &mut String, trimmed: &str) {
+	out.push_str("pytest: ");
+	out.push_str(compact_pytest_summary_line(trimmed));
+	out.push('\n');
+}
+
 fn has_content(text: &str) -> bool {
 	text.lines().any(|line| !line.trim().is_empty())
 }
@@ -269,7 +325,7 @@ mod tests {
 		assert!(!out.contains("test session starts"));
 		assert!(out.contains("test_adds_badly"));
 		assert!(out.contains("AssertionError"));
-		assert!(out.contains("1 failed, 1 passed"));
+		assert!(out.contains("pytest: 1 failed, 1 passed"));
 	}
 
 	#[test]
@@ -298,7 +354,7 @@ mod tests {
 		let out = filter_pytest(input, 1);
 
 		assert!(!out.contains("................................................................"));
-		assert!(out.contains("5 failed, 1698 passed, 2 skipped in 108.89s"));
+		assert!(out.contains("pytest: 5 failed, 1698 passed, 2 skipped in 108.89s"));
 	}
 
 	#[test]
@@ -309,7 +365,26 @@ mod tests {
 		             PASSED    [  3%]\ntest_utils.py::TestListOps::test_flatten PASSED      \
 		             [100%]\n\n====== 33 passed in 0.05s ======\n";
 		let out = filter_pytest(input, 0);
-		assert_eq!(out, "====== 33 passed in 0.05s ======\n");
+		assert_eq!(out, "pytest: 33 passed in 0.05s\n");
+	}
+
+	#[test]
+	fn direct_pytest_success_routes_to_compact_summary() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = MinimizerCtx {
+			program:    "pytest",
+			subcommand: None,
+			command:    "pytest",
+			config:     &cfg,
+		};
+		let out = filter(
+			&context,
+			"===== test session starts =====\ncollected 2 items\n\ntests/test_a.py ..\n===== 2 \
+			 passed in 0.01s =====\n",
+			0,
+		);
+
+		assert_eq!(out.text, "pytest: 2 passed in 0.01s\n");
 	}
 
 	#[test]

--- a/crates/pi-shell/src/minimizer/filters/rust_tools.rs
+++ b/crates/pi-shell/src/minimizer/filters/rust_tools.rs
@@ -1,0 +1,170 @@
+//! Rust toolchain filters that are not `cargo` subcommands (Tier 3a).
+//!
+//! Today this module hosts the `rustfmt` filter — real-data evidence (~6
+//! invocations / 7d, 38 KB average, ~0.23 MB total) showed rustfmt landing
+//! in the minimizer's `unknown` bucket. The filter groups diff-style
+//! output by file and elides per-file unified-diff chunks for `--check`
+//! mode while letting silent runs (no diffs / formatter no-op) pass
+//! through unchanged.
+
+use std::fmt::Write;
+
+use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
+
+pub fn supports(program: &str, _subcommand: Option<&str>) -> bool {
+	matches!(program, "rustfmt")
+}
+
+pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerOutput {
+	// Kill-switch parity (M2): legacy_filters_active=true skips this
+	// filter so callers can rollback without recompile.
+	if ctx.config.legacy_filters_active() {
+		return MinimizerOutput::passthrough(input);
+	}
+
+	let cleaned = primitives::strip_ansi(input);
+	let text = match ctx.program {
+		"rustfmt" => condense_rustfmt(&cleaned, exit_code),
+		_ => cleaned,
+	};
+
+	if text == input {
+		MinimizerOutput::passthrough(input)
+	} else {
+		MinimizerOutput::transformed(text, input.len())
+	}
+}
+
+/// Condense `rustfmt`/`rustfmt --check` output.
+///
+/// Two main shapes are handled:
+///
+/// - **Check mode** emits `Diff in <path> at line <N>:` headers followed by
+///   per-hunk `+`/`-` lines. We collect the set of affected files, print a
+///   one-line header (`N files reformatted (M with diffs):`), the first 3 file
+///   paths, and elide every diff body — the agent rarely needs the full diff
+///   inline; the artifact reference carries the original.
+/// - **Silent runs** (rustfmt formatted in place, no `--check`) emit no stdout.
+///   The empty buffer passes through; no transformation.
+///
+/// On compile errors / panics rustfmt prints to stderr in tens-of-lines
+/// form, well under the head/tail cap below — we keep it as-is.
+fn condense_rustfmt(input: &str, exit_code: i32) -> String {
+	if input.trim().is_empty() {
+		return input.to_string();
+	}
+
+	let files: Vec<&str> = collect_diff_files(input);
+	if files.is_empty() {
+		// No `Diff in ` markers — likely a panic / parse error / usage
+		// message. Cap with the standard error head/tail budget.
+		if exit_code != 0 {
+			return primitives::head_tail_lines(input, 80, 40);
+		}
+		return input.to_string();
+	}
+
+	let mut out = String::new();
+	let unique: Vec<&&str> = {
+		let mut seen = std::collections::BTreeSet::new();
+		files.iter().filter(|f| seen.insert(**f)).collect()
+	};
+	let total = unique.len();
+	let _ = writeln!(out, "{total} files reformatted ({total} with diffs):");
+	for file in unique.iter().take(3) {
+		out.push_str("  ");
+		out.push_str(file);
+		out.push('\n');
+	}
+	if total > 3 {
+		let _ = writeln!(out, "  … {} more", total - 3);
+	}
+	out
+}
+
+fn collect_diff_files(input: &str) -> Vec<&str> {
+	let mut files = Vec::new();
+	for line in input.lines() {
+		if let Some(rest) = line.strip_prefix("Diff in ") {
+			// rest looks like: `<path> at line <N>:`
+			let path = rest
+				.split(" at line ")
+				.next()
+				.unwrap_or(rest)
+				.trim_end_matches(':');
+			files.push(path);
+		}
+	}
+	files
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::minimizer::MinimizerConfig;
+
+	fn ctx<'a>(program: &'a str, command: &'a str, config: &'a MinimizerConfig) -> MinimizerCtx<'a> {
+		MinimizerCtx { program, subcommand: None, command, config }
+	}
+
+	#[test]
+	fn rustfmt_diff_output_compacts() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let mut input = String::new();
+		for i in 0..50 {
+			input.push_str(&format!("Diff in src/file_{i}.rs at line 10:\n"));
+			for _ in 0..8 {
+				input.push_str("-    old line\n");
+				input.push_str("+    new line\n");
+			}
+		}
+		let context = ctx("rustfmt", "rustfmt --check src/", &cfg);
+		let out = filter(&context, &input, 1);
+		assert!(out.changed);
+		assert!(out.text.contains("50 files reformatted"));
+		assert!(out.text.contains("src/file_0.rs"));
+		assert!(out.text.contains("… 47 more"));
+		// Diff bodies must be elided.
+		assert!(!out.text.contains("old line"));
+		// Savings ratio ≥ 0.7
+		let saved_ratio = 1.0 - (out.text.len() as f64 / input.len() as f64);
+		assert!(saved_ratio >= 0.7, "expected ≥0.7 savings, got {saved_ratio}");
+	}
+
+	#[test]
+	fn rustfmt_silent_output_passthrough() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("rustfmt", "rustfmt src/lib.rs", &cfg);
+		let out = filter(&context, "", 0);
+		assert!(!out.changed);
+		assert_eq!(out.text, "");
+	}
+
+	#[test]
+	fn rustfmt_error_output_capped() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("rustfmt", "rustfmt --check missing.rs", &cfg);
+		// Simulate a long usage/error dump with no `Diff in ` headers.
+		let mut input = String::new();
+		for i in 0..400 {
+			input.push_str(&format!("error: usage line {i}\n"));
+		}
+		let out = filter(&context, &input, 1);
+		assert!(out.changed);
+		// head_tail_lines(input, 80, 40) keeps 120 lines + marker.
+		assert!(out.text.contains("lines omitted"));
+	}
+
+	#[test]
+	fn rustfmt_legacy_filters_active_passes_through() {
+		// Kill-switch parity (M2).
+		let mut cfg = MinimizerConfig::default();
+		cfg.enabled = true;
+		cfg.legacy_filters_active = true;
+		let context = ctx("rustfmt", "rustfmt --check src/", &cfg);
+		let input = "Diff in src/a.rs at line 1:\n-old\n+new\n";
+		let out = filter(&context, input, 1);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+}

--- a/crates/pi-shell/src/minimizer/filters/system.rs
+++ b/crates/pi-shell/src/minimizer/filters/system.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use super::git;
 use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
 
 pub fn supports(program: &str) -> bool {
@@ -30,9 +31,9 @@ pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerO
 		"log" => compact_log(&cleaned),
 		"deps" => compact_dependency_output(&cleaned),
 		"summary" => compact_summary_output(&cleaned, exit_code),
-		"err" => cleaned,
+		"err" => compact_err_output(&cleaned),
 		"test" => compact_test_output(&cleaned),
-		"diff" => cleaned,
+		"diff" => git::compact_diff_output(&cleaned),
 		"format" => compact_format_output(&cleaned),
 		"pipe" => compact_pipe_like_output(&cleaned, exit_code),
 		"ps" => compact_ps_output(&cleaned),
@@ -215,17 +216,13 @@ struct LogLine {
 fn normalize_log_line(line: &str) -> String {
 	let without_timestamp = strip_leading_timestamp(line.trim());
 	let mut out = String::new();
-	let mut digits = String::new();
-	for ch in without_timestamp.chars() {
-		if ch.is_ascii_digit() {
-			digits.push(ch);
-			continue;
+	for token in without_timestamp.split_whitespace() {
+		if !out.is_empty() {
+			out.push(' ');
 		}
-		flush_digits(&mut out, &mut digits);
-		out.push(ch);
+		push_normalized_token(&mut out, token);
 	}
-	flush_digits(&mut out, &mut digits);
-	out.split_whitespace().collect::<Vec<_>>().join(" ")
+	out
 }
 
 fn strip_leading_timestamp(line: &str) -> &str {
@@ -241,6 +238,54 @@ fn strip_leading_timestamp(line: &str) -> &str {
 		return "";
 	}
 	line
+}
+
+fn push_normalized_token(out: &mut String, token: &str) {
+	let core = token.trim_matches(|ch: char| ch.is_ascii_punctuation() && ch != '/' && ch != '.');
+	if is_uuid_like(core) {
+		out.push_str("<uuid>");
+		return;
+	}
+	if is_hex_like(core) {
+		out.push_str("<hex>");
+		return;
+	}
+	if is_path_like(core) {
+		out.push_str("<path>");
+		return;
+	}
+
+	let mut digits = String::new();
+	for ch in token.chars() {
+		if ch.is_ascii_digit() {
+			digits.push(ch);
+			continue;
+		}
+		flush_digits(out, &mut digits);
+		out.push(ch);
+	}
+	flush_digits(out, &mut digits);
+}
+
+fn is_uuid_like(token: &str) -> bool {
+	token.len() == 36
+		&& token.bytes().enumerate().all(|(idx, byte)| {
+			if matches!(idx, 8 | 13 | 18 | 23) {
+				byte == b'-'
+			} else {
+				byte.is_ascii_hexdigit()
+			}
+		})
+}
+
+fn is_hex_like(token: &str) -> bool {
+	let token = token.strip_prefix("0x").unwrap_or(token);
+	token.len() >= 8 && token.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn is_path_like(token: &str) -> bool {
+	(token.starts_with('/') || token.starts_with("./") || token.starts_with("../"))
+		&& token.len() > 1
 }
 
 fn flush_digits(out: &mut String, digits: &mut String) {
@@ -324,15 +369,265 @@ fn compact_summary_output(input: &str, exit_code: i32) -> String {
 	out
 }
 
+fn compact_err_output(input: &str) -> String {
+	compact_failure_output(
+		input,
+		2,
+		12,
+		is_err_signal_line,
+		is_err_summary_line,
+		is_err_noise,
+		is_err_relevant_line,
+	)
+}
+
 fn compact_test_output(input: &str) -> String {
+	compact_failure_output(
+		input,
+		1,
+		12,
+		is_test_signal_line,
+		is_test_summary_line,
+		is_test_noise,
+		is_test_relevant_line,
+	)
+}
+
+fn compact_failure_output(
+	input: &str,
+	keep_before: usize,
+	keep_after: usize,
+	is_signal_line: fn(&str) -> bool,
+	is_summary_line: fn(&str) -> bool,
+	is_noise_line: fn(&str) -> bool,
+	is_relevant_line: fn(&str) -> bool,
+) -> String {
 	let lines: Vec<&str> = input.lines().collect();
-	if lines.len() <= 120 {
-		return primitives::dedup_consecutive_lines(input);
+	if lines.is_empty() {
+		return input.to_string();
 	}
-	let mut out = format!("test output: {} lines\n", lines.len());
-	push_important_lines(&mut out, input, 80);
-	out.push_str(&primitives::head_tail_lines(input, 35, 35));
-	out
+
+	let mut keep = vec![false; lines.len()];
+	let mut saw_relevant = false;
+
+	for (idx, line) in lines.iter().enumerate() {
+		let trimmed = line.trim_start();
+		if is_relevant_line(trimmed) {
+			saw_relevant = true;
+		}
+		if is_summary_line(trimmed) {
+			keep[idx] = true;
+			continue;
+		}
+		if is_signal_line(trimmed) {
+			let start = idx.saturating_sub(keep_before);
+			let end = idx
+				.saturating_add(keep_after)
+				.min(lines.len().saturating_sub(1));
+			for slot in keep.iter_mut().take(end + 1).skip(start) {
+				*slot = true;
+			}
+		}
+	}
+
+	if !saw_relevant {
+		return input.to_string();
+	}
+
+	let mut out = String::new();
+	for (idx, line) in lines.iter().enumerate() {
+		if !keep[idx] {
+			continue;
+		}
+		let trimmed = line.trim_start();
+		if is_noise_line(trimmed) {
+			continue;
+		}
+		out.push_str(line);
+		out.push('\n');
+	}
+
+	primitives::dedup_consecutive_lines(&out)
+}
+
+fn is_err_signal_line(trimmed: &str) -> bool {
+	let lower = trimmed.to_ascii_lowercase();
+	lower.starts_with("error:")
+		|| lower.starts_with("fatal:")
+		|| lower.starts_with("failed:")
+		|| lower.starts_with("panic:")
+		|| lower.starts_with("exception:")
+		|| lower.starts_with("traceback ")
+		|| lower.starts_with("assertionerror")
+		|| lower.starts_with("timeouterror")
+		|| lower.starts_with("caused by:")
+		|| lower.starts_with("warning:")
+		|| lower.starts_with("warn:")
+		|| lower.contains(": error:")
+		|| lower.contains(": warning:")
+		|| lower.contains(" fatal error")
+		|| lower.contains(" failed")
+		|| lower.contains(" panic")
+		|| lower.contains(" exception")
+}
+
+fn is_err_summary_line(trimmed: &str) -> bool {
+	let lower = trimmed.to_ascii_lowercase();
+	lower.starts_with("build failed")
+		|| lower.starts_with("failures!")
+		|| lower.starts_with("failed")
+		|| lower.starts_with("errors:")
+		|| lower.starts_with("warnings:")
+		|| lower.starts_with("play recap")
+		|| lower.starts_with("summary")
+		|| lower.starts_with("test result")
+		|| lower.starts_with("test files")
+		|| lower.starts_with("tests:")
+		|| is_count_summary(trimmed)
+}
+
+fn is_err_noise(trimmed: &str) -> bool {
+	let lower = trimmed.to_ascii_lowercase();
+	lower.starts_with("compiling ")
+		|| lower.starts_with("building ")
+		|| lower.starts_with("checking ")
+		|| lower.starts_with("running ")
+		|| lower.starts_with("executing ")
+		|| lower.starts_with("fetching ")
+		|| lower.starts_with("resolving ")
+		|| lower.starts_with("downloading ")
+		|| lower.starts_with("installing ")
+		|| lower.starts_with("finished ")
+		|| lower.starts_with("done ")
+		|| lower.starts_with("pass ")
+		|| lower.starts_with("✓")
+		|| lower.starts_with("✔")
+		|| lower.starts_with("√")
+		|| lower.starts_with("○")
+		|| lower.starts_with("ok ")
+		|| lower.contains(" ... ok")
+}
+
+fn is_test_signal_line(trimmed: &str) -> bool {
+	let lower = trimmed.to_ascii_lowercase();
+	trimmed.starts_with("FAIL ")
+		|| trimmed.starts_with("FAILURES")
+		|| trimmed.starts_with("Failed Tests")
+		|| trimmed.starts_with("● ")
+		|| trimmed.starts_with("✕")
+		|| trimmed.starts_with("×")
+		|| trimmed.starts_with("✗")
+		|| trimmed.starts_with("❯")
+		|| lower.starts_with("error:")
+		|| lower.starts_with("assertionerror")
+		|| lower.starts_with("timeouterror")
+		|| lower.starts_with("panic:")
+		|| lower.starts_with("failed ")
+}
+
+fn is_test_summary_line(trimmed: &str) -> bool {
+	let lower = trimmed.to_ascii_lowercase();
+	trimmed.starts_with("Test Suites:")
+		|| trimmed.starts_with("Test Suites")
+		|| trimmed.starts_with("Tests:")
+		|| trimmed.starts_with("Tests")
+		|| trimmed.starts_with("Test Files")
+		|| trimmed.starts_with("Snapshots:")
+		|| trimmed.starts_with("Snapshots")
+		|| trimmed.starts_with("Time:")
+		|| trimmed.starts_with("Duration")
+		|| trimmed.starts_with("Start at")
+		|| trimmed.starts_with("Ran all test suites")
+		|| trimmed.starts_with("Ran ")
+		|| trimmed.starts_with("Failed Tests")
+		|| trimmed.starts_with("FAILURES")
+		|| trimmed.starts_with("Summary")
+		|| lower.starts_with("build failed")
+		|| lower.starts_with("test run failed")
+		|| lower.starts_with("test result")
+		|| is_count_summary(trimmed)
+}
+
+fn is_test_noise(trimmed: &str) -> bool {
+	let lower = trimmed.to_ascii_lowercase();
+	lower.starts_with("pass ")
+		|| trimmed.starts_with("✓")
+		|| trimmed.starts_with("✔")
+		|| trimmed.starts_with("√")
+		|| trimmed.starts_with("○")
+		|| lower.starts_with("running ")
+		|| lower.starts_with("run ")
+		|| lower.starts_with("dev ")
+		|| lower.starts_with("ok ")
+		|| lower.contains(" ... ok")
+}
+
+fn is_err_relevant_line(trimmed: &str) -> bool {
+	is_err_signal_line(trimmed) || is_err_summary_line(trimmed)
+}
+
+fn is_test_relevant_line(trimmed: &str) -> bool {
+	is_test_signal_line(trimmed) || is_test_summary_line(trimmed) || is_test_noise(trimmed)
+}
+
+fn is_count_summary(trimmed: &str) -> bool {
+	let mut parts = trimmed.split_whitespace();
+	let Some(count) = parts.next() else {
+		return false;
+	};
+	if !count.chars().all(|ch| ch.is_ascii_digit()) {
+		return false;
+	}
+
+	let Some(kind) = parts
+		.next()
+		.map(|word| word.trim_matches(|ch: char| ch.is_ascii_punctuation()))
+	else {
+		return false;
+	};
+	if matches!(
+		kind,
+		"failed"
+			| "passed"
+			| "skipped"
+			| "flaky"
+			| "pass"
+			| "fail"
+			| "error"
+			| "errors"
+			| "warning"
+			| "warnings"
+			| "information"
+			| "informations"
+	) {
+		return true;
+	}
+
+	if kind == "of" {
+		let Some(total) = parts.next() else {
+			return false;
+		};
+		if !total.chars().all(|ch| ch.is_ascii_digit()) {
+			return false;
+		}
+		return parts
+			.next()
+			.map(|word| word.trim_matches(|ch: char| ch.is_ascii_punctuation()))
+			.is_some_and(|kind| {
+				matches!(
+					kind,
+					"failed"
+						| "passed" | "skipped"
+						| "flaky" | "pass"
+						| "fail" | "error"
+						| "errors" | "warning"
+						| "warnings" | "information"
+						| "informations"
+				)
+			});
+	}
+
+	false
 }
 
 fn push_important_lines(out: &mut String, input: &str, max: usize) {
@@ -614,6 +909,18 @@ mod tests {
 	}
 
 	#[test]
+	fn log_dedups_normalized_uuid_hex_and_paths() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("log", &cfg);
+		let input = "2026-01-01T10:00:00 ERROR request 550e8400-e29b-41d4-a716-446655440000 file \
+		             /tmp/a.rs hash deadbeef failed\n2026-01-01T10:00:01 ERROR request \
+		             123e4567-e89b-12d3-a456-426614174000 file /tmp/b.rs hash cafebabe failed\n";
+		let out = filter(&ctx, input, 1);
+		assert!(out.text.contains("2 lines, 1 unique"));
+		assert!(out.text.contains("(×2)"));
+	}
+
+	#[test]
 	fn env_masks_secrets_and_compacts_long_values() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
 		let ctx = ctx("env", &cfg);
@@ -625,11 +932,39 @@ mod tests {
 	}
 
 	#[test]
-	fn diff_output_passthrough_is_lossless() {
+	fn err_output_keeps_diagnostics_and_context() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("err", &cfg);
+		let input = "\
+Compiling app v0.1.0
+running 1 test
+test pass ... ok
+src/main.rs:10:5: error: cannot find value `foo` in this scope
+   |
+10 |     foo();
+   |     ^^^
+note: required by a bound in `bar`
+warning: unused import: `baz`
+";
+		let out = filter(&ctx, input, 1);
+		assert!(out.changed);
+		assert!(!out.text.contains("Compiling app v0.1.0"));
+		assert!(!out.text.contains("running 1 test"));
+		assert!(!out.text.contains("test pass ... ok"));
+		assert!(
+			out.text
+				.contains("src/main.rs:10:5: error: cannot find value `foo` in this scope")
+		);
+		assert!(out.text.contains("10 |     foo();"));
+		assert!(out.text.contains("note: required by a bound in `bar`"));
+		assert!(out.text.contains("warning: unused import: `baz`"));
+	}
+
+	#[test]
+	fn diff_output_reuses_unified_diff_compaction() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
 		let ctx = ctx("diff", &cfg);
-		let mut input =
-			String::from("diff --git a/a.rs b/a.rs\n--- a/a.rs\n+++ b/a.rs\n@@ -1,140 +1,140 @@\n");
+		let mut input = String::from("--- a/a.rs\n+++ b/a.rs\n@@ -1,140 +1,140 @@\n");
 		for idx in 0..140 {
 			input.push_str("-old ");
 			input.push_str(&idx.to_string());
@@ -638,7 +973,43 @@ mod tests {
 			input.push('\n');
 		}
 		let out = filter(&ctx, &input, 0);
-		assert_eq!(out.text, input);
+		assert!(out.changed);
+		assert!(out.text.contains("a.rs | 280"));
+		assert!(
+			out.text
+				.contains("1 file changed, 140 insertions(+), 140 deletions(-)")
+		);
+		assert!(out.text.contains("--- Changes ---"));
+		assert!(out.text.contains("-old 0"));
+		assert!(out.text.contains("+new 0"));
+		assert_ne!(out.text, input);
+	}
+
+	#[test]
+	fn test_output_drops_pass_chatter_and_keeps_failure_summary() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("test", &cfg);
+		let input = "\
+PASS src/pass.test.ts
+✓ src/ok.test.ts (3ms)
+FAIL src/fail.test.ts
+  suite > breaks
+    Error: expected 1 to equal 2
+      at src/fail.test.ts:12:3
+
+Test Files  1 failed | 1 passed (2)
+Tests       1 failed | 3 passed (4)
+Time        0.42s
+";
+		let out = filter(&ctx, input, 1);
+		assert!(out.changed);
+		assert!(!out.text.contains("PASS src/pass.test.ts"));
+		assert!(!out.text.contains("✓ src/ok.test.ts"));
+		assert!(out.text.contains("FAIL src/fail.test.ts"));
+		assert!(out.text.contains("Error: expected 1 to equal 2"));
+		assert!(out.text.contains("Test Files  1 failed | 1 passed (2)"));
+		assert!(out.text.contains("Tests       1 failed | 3 passed (4)"));
+		assert!(out.text.contains("Time        0.42s"));
 	}
 
 	#[test]

--- a/crates/pi-shell/src/minimizer/plan.rs
+++ b/crates/pi-shell/src/minimizer/plan.rs
@@ -11,9 +11,13 @@
 //!   regardless of what `bar` is. A user piping through `awk`, `jq`, `rg`, or
 //!   any other consumer is almost certainly parsing the output; rewriting it
 //!   would be a correctness bug. The engine falls back to passthrough.
-//! - **Compound commands are opaque.** `a && b`, `a ; b`, and `a || b` cannot
-//!   be minimized as one combined buffer without risking semantic corruption,
-//!   so they are left unchanged.
+//! - **Safe chains are segmented, not rewritten whole.** Top-level simple
+//!   commands joined only by `&&` and `;` may be split into `ChainSegment`s for
+//!   the segmented engine path, but the whole-buffer minimizer still treats the
+//!   combined chain as opaque.
+//! - **Other compound commands are opaque.** `a || b`, background jobs, and
+//!   compound shell syntax such as subshells or function definitions are left
+//!   unchanged.
 //! - **Single simple commands** are safe for the whole-buffer path; the engine
 //!   dispatches them through `detect.rs` as before.
 //!
@@ -22,8 +26,20 @@
 
 use brush_parser::{
 	ParserOptions, SourceInfo,
-	ast::{AndOrList, Command, CompoundListItem, Pipeline, Program, SeparatorOperator},
+	ast::{
+		AndOr, Command, CommandPrefixOrSuffixItem, CompoundListItem, IoFileRedirectTarget,
+		IoRedirect, Pipeline, Program, SeparatorOperator, Word,
+	},
 };
+
+/// One segment of a safe `&&` / `;` chain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainSegment {
+	pub command:                   String,
+	pub program:                   String,
+	pub run_if_previous_succeeded: bool,
+	pub suppress_errexit:          bool,
+}
 
 /// Outcome of analyzing a raw command string.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -35,9 +51,12 @@ pub enum CommandPlan {
 	/// NOT identify upstream / downstream programs here — any pipe defeats
 	/// safe minimization for this engine.
 	Piped,
-	/// The command has multiple segments joined by `&&`, `||`, `;`, or `&`.
-	/// This shape is left unchanged; the minimizer only rewrites whole simple
-	/// command output.
+	/// Top-level simple commands joined by `&&` and/or `;`. These can be
+	/// minimized segment-by-segment, but not as one combined buffer.
+	Chain { segments: Vec<ChainSegment> },
+	/// The command has multiple segments joined by `||`, `&`, or other
+	/// unsupported shell syntax. This shape is left unchanged; the minimizer
+	/// only rewrites whole simple command output.
 	Compound,
 	/// Parse failed, a compound shell construct (for loops, subshells, etc.)
 	/// was encountered, or the command was empty.
@@ -64,6 +83,10 @@ pub fn analyze(command: &str) -> CommandPlan {
 }
 
 fn classify(program: &Program) -> CommandPlan {
+	if let Some(chain) = classify_chain(program) {
+		return chain;
+	}
+
 	// Count separator-separated top-level items across all complete_commands.
 	let items: Vec<&CompoundListItem> = program
 		.complete_commands
@@ -96,7 +119,143 @@ fn classify(program: &Program) -> CommandPlan {
 	}
 
 	// Only a single pipeline at this point.
-	classify_pipeline(&and_or.first).unwrap_or_else(|| classify_andorlist(and_or))
+	classify_pipeline(&and_or.first).unwrap_or(CommandPlan::Unsupported)
+}
+
+fn classify_chain(program: &Program) -> Option<CommandPlan> {
+	let items: Vec<&CompoundListItem> = program
+		.complete_commands
+		.iter()
+		.flat_map(|cl| cl.0.iter())
+		.collect();
+
+	if items.is_empty() {
+		return None;
+	}
+
+	let mut segments = Vec::new();
+	let mut run_if_previous_succeeded = false;
+
+	for (item_index, item) in items.iter().enumerate() {
+		if matches!(item.1, SeparatorOperator::Async) {
+			return None;
+		}
+
+		let is_last_item = item_index + 1 == items.len();
+		let mut pipeline = &item.0.first;
+		let mut additional = item.0.additional.iter().peekable();
+
+		loop {
+			let (command, program) = simple_segment(pipeline)?;
+
+			let suppress_errexit = additional
+				.peek()
+				.is_some_and(|and_or| matches!(and_or, AndOr::And(_)));
+			segments.push(ChainSegment {
+				command,
+				program,
+				run_if_previous_succeeded,
+				suppress_errexit,
+			});
+
+			let Some(and_or) = additional.next() else {
+				run_if_previous_succeeded = false;
+				break;
+			};
+
+			match and_or {
+				AndOr::And(next_pipeline) => {
+					run_if_previous_succeeded = true;
+					pipeline = next_pipeline;
+				},
+				AndOr::Or(_) => return None,
+			}
+		}
+
+		if !is_last_item {
+			run_if_previous_succeeded = false;
+		}
+	}
+
+	(segments.len() >= 2).then_some(CommandPlan::Chain { segments })
+}
+
+fn word_has_command_substitution(word: &Word) -> bool {
+	word.value.contains("$(") || word.value.contains('`')
+}
+
+fn command_prefix_or_suffix_item_is_safe(item: &CommandPrefixOrSuffixItem) -> bool {
+	match item {
+		CommandPrefixOrSuffixItem::IoRedirect(io) => io_redirect_is_safe(io),
+		CommandPrefixOrSuffixItem::Word(word) => !word_has_command_substitution(word),
+		CommandPrefixOrSuffixItem::AssignmentWord(_, word) => !word_has_command_substitution(word),
+		CommandPrefixOrSuffixItem::ProcessSubstitution(..) => false,
+	}
+}
+
+fn io_redirect_is_safe(io: &IoRedirect) -> bool {
+	match io {
+		IoRedirect::File(_, _, target) => match target {
+			IoFileRedirectTarget::Filename(word) | IoFileRedirectTarget::Duplicate(word) => {
+				!word_has_command_substitution(word)
+			},
+			IoFileRedirectTarget::Fd(_) => true,
+			IoFileRedirectTarget::ProcessSubstitution(..) => false,
+		},
+		IoRedirect::HereDocument(_, here_doc) => {
+			!word_has_command_substitution(&here_doc.here_end)
+				&& !word_has_command_substitution(&here_doc.doc)
+		},
+		IoRedirect::HereString(_, word) => !word_has_command_substitution(word),
+		IoRedirect::OutputAndError(word, _) => !word_has_command_substitution(word),
+	}
+}
+
+fn simple_segment(pipeline: &Pipeline) -> Option<(String, String)> {
+	if pipeline.timed.is_some() || pipeline.bang || pipeline.seq.is_empty() {
+		return None;
+	}
+
+	// For multi-stage pipes inside a chain segment, identify the segment by its
+	// first stage's program. The downstream per-segment minimizer::apply will
+	// detect the pipeline at runtime via plan::CommandPlan::Piped and pass it
+	// through unchanged — so a piped segment is safely captured but never
+	// rewritten. This keeps the chain decomposable when even one inner stage
+	// uses a pipe (e.g. `ls | head -10 && git status`).
+	let first = pipeline.seq.first()?;
+	match first {
+		Command::Simple(simple) => {
+			if simple.prefix.as_ref().is_some_and(|prefix| {
+				prefix
+					.0
+					.iter()
+					.any(|item| !command_prefix_or_suffix_item_is_safe(item))
+			}) {
+				return None;
+			}
+			if simple.suffix.as_ref().is_some_and(|suffix| {
+				suffix
+					.0
+					.iter()
+					.any(|item| !command_prefix_or_suffix_item_is_safe(item))
+			}) {
+				return None;
+			}
+
+			let program_word = simple.word_or_name.as_ref()?;
+			if word_has_command_substitution(program_word) {
+				return None;
+			}
+			let program = program_word.to_string();
+			if program.trim().is_empty() {
+				return None;
+			}
+			Some((pipeline.to_string(), program))
+		},
+		// Compound shell syntax (if / for / while / subshell / { ... }) is
+		// not something the minimizer should touch.
+		Command::Compound(..) | Command::Function(_) | Command::ExtendedTest(_) => None,
+	}
 }
 
 fn classify_pipeline(pipeline: &Pipeline) -> Option<CommandPlan> {
@@ -121,10 +280,6 @@ fn classify_pipeline(pipeline: &Pipeline) -> Option<CommandPlan> {
 	}
 }
 
-const fn classify_andorlist(_and_or: &AndOrList) -> CommandPlan {
-	CommandPlan::Unsupported
-}
-
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -134,6 +289,20 @@ mod tests {
 			CommandPlan::Single { program } => Some(program),
 			_ => None,
 		}
+	}
+
+	fn chain_of(plan: CommandPlan) -> Option<Vec<ChainSegment>> {
+		match plan {
+			CommandPlan::Chain { segments } => Some(segments),
+			_ => None,
+		}
+	}
+
+	fn assert_not_chain(command: &str) {
+		assert!(
+			!matches!(analyze(command), CommandPlan::Chain { .. }),
+			"{command:?} unexpectedly classified as Chain"
+		);
 	}
 
 	#[test]
@@ -150,42 +319,119 @@ mod tests {
 	}
 
 	#[test]
-	fn pipe_is_piped() {
-		assert_eq!(analyze("git status | cat"), CommandPlan::Piped);
-		assert_eq!(analyze("ls -la | awk '{print $1}'"), CommandPlan::Piped);
+	fn safe_and_chain_is_segmented() {
+		let plan = analyze("git diff --stat && git diff --name-only");
+		assert_eq!(
+			chain_of(plan),
+			Some(vec![
+				ChainSegment {
+					command:                   "git diff --stat".to_string(),
+					program:                   "git".to_string(),
+					run_if_previous_succeeded: false,
+					suppress_errexit:          true,
+				},
+				ChainSegment {
+					command:                   "git diff --name-only".to_string(),
+					program:                   "git".to_string(),
+					run_if_previous_succeeded: true,
+					suppress_errexit:          false,
+				},
+			])
+		);
 	}
 
 	#[test]
-	fn and_or_is_compound() {
-		assert_eq!(analyze("cd foo && cargo test"), CommandPlan::Compound);
+	fn safe_sequence_chain_is_segmented() {
+		let plan = analyze("git status ; bun test");
+		assert_eq!(
+			chain_of(plan),
+			Some(vec![
+				ChainSegment {
+					command:                   "git status".to_string(),
+					program:                   "git".to_string(),
+					run_if_previous_succeeded: false,
+					suppress_errexit:          false,
+				},
+				ChainSegment {
+					command:                   "bun test".to_string(),
+					program:                   "bun".to_string(),
+					run_if_previous_succeeded: false,
+					suppress_errexit:          false,
+				},
+			])
+		);
+	}
+
+	#[test]
+	fn mixed_chain_is_segmented() {
+		let plan = analyze("false && echo no ; echo yes");
+		assert_eq!(
+			chain_of(plan),
+			Some(vec![
+				ChainSegment {
+					command:                   "false".to_string(),
+					program:                   "false".to_string(),
+					run_if_previous_succeeded: false,
+					suppress_errexit:          true,
+				},
+				ChainSegment {
+					command:                   "echo no".to_string(),
+					program:                   "echo".to_string(),
+					run_if_previous_succeeded: true,
+					suppress_errexit:          false,
+				},
+				ChainSegment {
+					command:                   "echo yes".to_string(),
+					program:                   "echo".to_string(),
+					run_if_previous_succeeded: false,
+					suppress_errexit:          false,
+				},
+			])
+		);
+	}
+
+	#[test]
+	fn chain_with_piped_segment_is_segmented() {
+		// A chain that contains a piped segment (`ls | head -5`) must still be
+		// classified as Chain so the segmented runner can decompose it. The
+		// piped segment is identified by its first stage's program; the
+		// per-segment minimizer::apply will treat that segment as Piped at
+		// runtime and pass it through unchanged.
+		let plan = analyze("ls -lh *.txt | head -5 && git status --short");
+		let segments = chain_of(plan).expect("expected Chain");
+		assert_eq!(segments.len(), 2);
+		assert_eq!(segments[0].program, "ls");
+		assert_eq!(segments[1].program, "git");
+	}
+
+	#[test]
+	fn rejects_unsafe_chain_segments() {
+		for command in [
+			"echo $(pwd) ; git status",
+			"echo `pwd` ; git status",
+			"cat <(printf hi) ; git status",
+			"git status > >(cat) ; bun test",
+			"! git status ; bun test",
+		] {
+			assert_not_chain(command);
+		}
+	}
+
+	#[test]
+	fn rejects_legacy_opaque_shapes() {
 		assert_eq!(analyze("foo || bar"), CommandPlan::Compound);
-	}
-
-	#[test]
-	fn sequence_is_compound() {
-		assert_eq!(analyze("echo a ; echo b"), CommandPlan::Compound);
-	}
-
-	#[test]
-	fn async_is_compound() {
+		assert_eq!(analyze("git status | cat"), CommandPlan::Piped);
 		assert_eq!(analyze("sleep 1 &"), CommandPlan::Compound);
+		assert_eq!(analyze("(cd foo && make)"), CommandPlan::Compound);
+		assert_eq!(analyze("{ echo hi; }"), CommandPlan::Compound);
+		assert_eq!(analyze("f() { echo hi; }"), CommandPlan::Compound);
+		assert_eq!(analyze("[[ -f foo ]]"), CommandPlan::Compound);
+		assert_eq!(analyze("a && && b"), CommandPlan::Unsupported);
 	}
 
 	#[test]
 	fn empty_is_unsupported() {
 		assert_eq!(analyze(""), CommandPlan::Unsupported);
 		assert_eq!(analyze("   "), CommandPlan::Unsupported);
-	}
-
-	#[test]
-	fn subshell_is_compound_not_single() {
-		// `(cmd)` is a compound-command variant, not Simple.
-		let plan = analyze("(cd foo && make)");
-		assert!(matches!(plan, CommandPlan::Compound | CommandPlan::Unsupported));
-	}
-
-	#[test]
-	fn malformed_is_unsupported() {
-		assert_eq!(analyze("a && && b"), CommandPlan::Unsupported);
 	}
 }

--- a/crates/pi-shell/src/minimizer/primitives.rs
+++ b/crates/pi-shell/src/minimizer/primitives.rs
@@ -2,6 +2,30 @@
 
 use std::collections::BTreeMap;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CapClass {
+	Errors,
+	Warnings,
+	List,
+	Inventory,
+}
+
+impl CapClass {
+	pub const fn lines(self) -> usize {
+		match self {
+			Self::Errors => 160,
+			Self::Warnings => 120,
+			Self::List => 80,
+			Self::Inventory => 40,
+		}
+	}
+}
+
+pub const fn reduced(cap: usize, by: usize) -> usize {
+	let reduced = cap.saturating_sub(by);
+	if reduced == 0 && cap > 0 { 1 } else { reduced }
+}
+
 /// Remove ANSI CSI escape sequences and carriage-return progress frames.
 pub fn strip_ansi(input: &str) -> String {
 	let mut out = String::with_capacity(input.len());
@@ -76,6 +100,14 @@ pub fn head_tail_lines(input: &str, head: usize, tail: usize) -> String {
 		out.push('\n');
 	}
 	out
+}
+
+/// Keep head/tail lines using a named cap class.
+pub fn head_tail_cap(input: &str, class: CapClass) -> String {
+	let cap = class.lines();
+	let head = reduced(cap, cap / 3);
+	let tail = cap - head;
+	head_tail_lines(input, head, tail)
 }
 
 /// Drop lines matching any of the supplied predicates.
@@ -296,6 +328,24 @@ mod tests {
 	fn head_tail_marks_omitted_lines() {
 		let out = head_tail_lines("1\n2\n3\n4\n5\n", 2, 1);
 		assert_eq!(out, "1\n2\n… 2 lines omitted …\n5\n");
+	}
+
+	#[test]
+	fn named_caps_have_nonzero_reductions() {
+		assert_eq!(CapClass::Errors.lines(), 160);
+		assert_eq!(reduced(1, 10), 1);
+		assert_eq!(reduced(0, 10), 0);
+	}
+
+	#[test]
+	fn head_tail_cap_uses_named_budget() {
+		let input = (0..100)
+			.map(|idx| idx.to_string())
+			.collect::<Vec<_>>()
+			.join("\n");
+		let out = head_tail_cap(&input, CapClass::List);
+		assert!(out.contains("lines omitted"));
+		assert!(out.lines().count() <= CapClass::List.lines() + 1);
 	}
 
 	#[test]

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -12,9 +12,9 @@ use std::{
 use anyhow::{Error, Result};
 use brush_builtins::{BuiltinSet, default_builtins};
 use brush_core::{
-	ExecutionContext, ExecutionControlFlow, ExecutionExitCode, ExecutionResult, ProcessGroupPolicy,
-	ProfileLoadBehavior, RcLoadBehavior, Shell as BrushShell, ShellValue, ShellVariable, SourceInfo,
-	builtins,
+	ExecutionContext, ExecutionControlFlow, ExecutionExitCode, ExecutionParameters, ExecutionResult,
+	ProcessGroupPolicy, ProfileLoadBehavior, RcLoadBehavior, Shell as BrushShell, ShellValue,
+	ShellVariable, SourceInfo, builtins,
 	env::EnvironmentScope,
 	openfiles::{self, OpenFile, OpenFiles},
 };
@@ -570,6 +570,57 @@ async fn source_snapshot(shell: &mut BrushShell, snapshot_path: &str) -> Result<
 	Ok(())
 }
 
+#[derive(Clone, Copy)]
+enum CommandCaptureMode {
+	Streaming,
+	Buffered { max_capture_bytes: usize },
+}
+
+struct CommandRunOutput {
+	result:   ExecutionResult,
+	buffered: Option<BufferedOutput>,
+}
+
+struct ChainCapture {
+	original_text: String,
+	text:          String,
+	input_bytes:   usize,
+	changed:       bool,
+}
+
+impl ChainCapture {
+	const fn new() -> Self {
+		Self {
+			original_text: String::new(),
+			text:          String::new(),
+			input_bytes:   0,
+			changed:       false,
+		}
+	}
+
+	fn push(&mut self, original: &str, original_input_bytes: usize, minimized: &str, changed: bool) {
+		self.original_text.push_str(original);
+		self.text.push_str(minimized);
+		self.input_bytes = self.input_bytes.saturating_add(original_input_bytes);
+		self.changed |= changed;
+	}
+}
+
+fn reason_only_minimizer_result(
+	filter: &'static str,
+	original_text: String,
+	input_bytes: usize,
+) -> MinimizerResult {
+	let output_bytes = u32::try_from(original_text.len()).unwrap_or(u32::MAX);
+	MinimizerResult {
+		filter: filter.to_string(),
+		text: original_text.clone(),
+		original_text,
+		input_bytes: u32::try_from(input_bytes).unwrap_or(u32::MAX),
+		output_bytes,
+	}
+}
+
 async fn run_shell_command(
 	session: &mut ShellSessionCore,
 	options: &ShellRunConfig,
@@ -590,13 +641,252 @@ async fn run_shell_command(
 	} else {
 		minimizer::engine::MinimizerMode::None
 	};
-	let should_minimize = !matches!(minimizer_mode, minimizer::engine::MinimizerMode::None);
-	let max_capture_bytes = if let Some(config) = options.minimizer.as_ref() {
-		config.max_capture_bytes as usize
-	} else {
-		0
+
+	let result = match minimizer_mode {
+		minimizer::engine::MinimizerMode::SegmentedChain => {
+			run_shell_command_segmented_chain(session, options, on_chunk, cancel_token).await
+		},
+		minimizer::engine::MinimizerMode::WholeCommand | minimizer::engine::MinimizerMode::None => {
+			run_shell_command_single(session, options, on_chunk, cancel_token, minimizer_mode).await
+		},
 	};
 
+	if env_scope_pushed {
+		session
+			.shell
+			.env_mut()
+			.pop_scope(EnvironmentScope::Command)
+			.map_err(|err| Error::msg(format!("Failed to pop env scope: {err}")))?;
+	}
+
+	result
+}
+
+async fn run_shell_command_single(
+	session: &mut ShellSessionCore,
+	options: &ShellRunConfig,
+	on_chunk: Option<mpsc::UnboundedSender<String>>,
+	cancel_token: CancellationToken,
+	minimizer_mode: minimizer::engine::MinimizerMode,
+) -> Result<(ExecutionResult, Option<MinimizerResult>)> {
+	debug_assert!(!matches!(minimizer_mode, minimizer::engine::MinimizerMode::SegmentedChain));
+
+	let params = session.shell.default_exec_params();
+	let capture_mode = match minimizer_mode {
+		minimizer::engine::MinimizerMode::WholeCommand => {
+			let Some(config) = options.minimizer.as_ref() else {
+				return Err(Error::msg("Missing minimizer config for whole-command mode"));
+			};
+			CommandCaptureMode::Buffered { max_capture_bytes: config.max_capture_bytes as usize }
+		},
+		minimizer::engine::MinimizerMode::None => CommandCaptureMode::Streaming,
+		minimizer::engine::MinimizerMode::SegmentedChain => CommandCaptureMode::Streaming,
+	};
+
+	let command_run = run_shell_command_once(
+		session,
+		options.command.clone(),
+		params,
+		on_chunk,
+		cancel_token,
+		capture_mode,
+	)
+	.await?;
+
+	let mut minimized_out = None;
+	if let Some(buffered) = command_run.buffered
+		&& let Some(config) = options.minimizer.as_ref()
+	{
+		if buffered.exceeded {
+			if matches!(minimizer_mode, minimizer::engine::MinimizerMode::WholeCommand) {
+				minimized_out =
+					Some(reason_only_minimizer_result("too-large", String::new(), buffered.input_bytes));
+			}
+		} else {
+			let minimized = match minimizer_mode {
+				minimizer::engine::MinimizerMode::WholeCommand => minimizer::apply(
+					&options.command,
+					&buffered.text,
+					exit_code(&command_run.result),
+					config,
+				),
+				minimizer::engine::MinimizerMode::None => {
+					minimizer::MinimizerOutput::passthrough(&buffered.text)
+				},
+				minimizer::engine::MinimizerMode::SegmentedChain => {
+					minimizer::MinimizerOutput::passthrough(&buffered.text)
+				},
+			};
+			if minimized.filter != "passthrough" {
+				let original_text = minimized
+					.original_text
+					.unwrap_or_else(|| minimized.text.clone());
+				let output_bytes = u32::try_from(minimized.text.len()).unwrap_or(u32::MAX);
+				minimized_out = Some(MinimizerResult {
+					filter: minimized.filter.to_string(),
+					text: minimized.text,
+					original_text,
+					input_bytes: u32::try_from(minimized.input_bytes).unwrap_or(u32::MAX),
+					output_bytes,
+				});
+			}
+		}
+	}
+
+	Ok((command_run.result, minimized_out))
+}
+
+async fn run_shell_command_segmented_chain(
+	session: &mut ShellSessionCore,
+	options: &ShellRunConfig,
+	on_chunk: Option<mpsc::UnboundedSender<String>>,
+	cancel_token: CancellationToken,
+) -> Result<(ExecutionResult, Option<MinimizerResult>)> {
+	let Some(config) = options.minimizer.as_ref() else {
+		return run_shell_command_single(
+			session,
+			options,
+			on_chunk,
+			cancel_token,
+			minimizer::engine::MinimizerMode::None,
+		)
+		.await;
+	};
+
+	// When minimizer is disabled, don't segment — stream the original single path.
+	if !config.enabled {
+		return run_shell_command_single(
+			session,
+			options,
+			on_chunk,
+			cancel_token,
+			minimizer::engine::MinimizerMode::None,
+		)
+		.await;
+	}
+
+	let minimizer::plan::CommandPlan::Chain { segments } =
+		minimizer::plan::analyze(&options.command)
+	else {
+		return run_shell_command_single(
+			session,
+			options,
+			on_chunk,
+			cancel_token,
+			minimizer::engine::MinimizerMode::None,
+		)
+		.await;
+	};
+
+	let params = session.shell.default_exec_params();
+	let mut aggregate = Some(ChainCapture::new());
+	let mut aggregate_dropped_too_large = false;
+	let mut overflow_input_bytes = 0usize;
+	let mut previous_succeeded = true;
+	let mut last_result = None;
+	let max_capture_bytes = config.max_capture_bytes as usize;
+	for segment in segments {
+		if segment.run_if_previous_succeeded && !previous_succeeded {
+			continue;
+		}
+
+		let mut segment_params = params.clone();
+		segment_params.suppress_errexit = segment.suppress_errexit;
+		let capture_mode = if aggregate.is_some() {
+			CommandCaptureMode::Buffered { max_capture_bytes }
+		} else {
+			CommandCaptureMode::Streaming
+		};
+
+		let command_run = run_shell_command_once(
+			session,
+			segment.command.clone(),
+			segment_params,
+			on_chunk.clone(),
+			cancel_token.clone(),
+			capture_mode,
+		)
+		.await?;
+
+		let exit = exit_code(&command_run.result);
+		previous_succeeded = exit == 0;
+
+		if let Some(buffered) = command_run.buffered {
+			if buffered.exceeded {
+				aggregate_dropped_too_large = aggregate.is_some();
+				overflow_input_bytes = overflow_input_bytes.saturating_add(buffered.input_bytes);
+				aggregate = None;
+			} else if let Some(capture) = aggregate.as_mut() {
+				let next_input_bytes = capture.input_bytes.saturating_add(buffered.input_bytes);
+				if next_input_bytes > max_capture_bytes {
+					aggregate_dropped_too_large = true;
+					overflow_input_bytes = next_input_bytes;
+					aggregate = None;
+				} else {
+					// Segments use the AI-overlay-free path: the AI summary budget is
+					// scoped to one whole-command apply, so an N-segment chain must not
+					// be able to fire N provider calls.
+					let minimized =
+						minimizer::apply_segment(&segment.command, &buffered.text, exit, config);
+					capture.push(
+						&buffered.text,
+						buffered.input_bytes,
+						&minimized.text,
+						minimized.changed,
+					);
+				}
+			}
+		} else if aggregate.is_some() {
+			aggregate = None;
+		}
+
+		let keep_running = session_keepalive(&command_run.result) && !cancel_token.is_cancelled();
+		last_result = Some(command_run.result);
+		if !keep_running {
+			break;
+		}
+	}
+
+	let Some(result) = last_result else {
+		return Err(Error::msg("Segmented chain executed no segments"));
+	};
+
+	let minimized_out = aggregate
+		// Only surface telemetry when the segmented chain actually rewrote the
+		// output; a `chain-noop` capture (`changed == false`) must yield `None`,
+		// matching the public `ShellRunResult.minimized` contract.
+		.filter(|capture| capture.changed)
+		.map(|capture| {
+			let minimized = minimizer::chain_output(
+				capture.text,
+				capture.original_text,
+				capture.input_bytes,
+				capture.changed,
+			);
+			MinimizerResult {
+				filter:        minimized.filter.to_string(),
+				text:          minimized.text,
+				original_text: minimized.original_text.unwrap_or_default(),
+				input_bytes:   u32::try_from(minimized.input_bytes).unwrap_or(u32::MAX),
+				output_bytes:  u32::try_from(minimized.output_bytes).unwrap_or(u32::MAX),
+			}
+		})
+		.or_else(|| {
+			aggregate_dropped_too_large
+				.then(|| reason_only_minimizer_result("too-large", String::new(), overflow_input_bytes))
+		});
+
+	Ok((result, minimized_out))
+}
+
+async fn run_shell_command_once(
+	session: &mut ShellSessionCore,
+	command: String,
+	mut params: ExecutionParameters,
+	on_chunk: Option<mpsc::UnboundedSender<String>>,
+	cancel_token: CancellationToken,
+	capture_mode: CommandCaptureMode,
+) -> Result<CommandRunOutput> {
 	let (reader_file, writer_file) = pipe_to_files("output")?;
 
 	let stdout_file = OpenFile::from(
@@ -606,7 +896,6 @@ async fn run_shell_command(
 	);
 	let stderr_file = OpenFile::from(writer_file);
 
-	let mut params = session.shell.default_exec_params();
 	params.set_fd(OpenFiles::STDIN_FD, null_file()?);
 	params.set_fd(OpenFiles::STDOUT_FD, stdout_file);
 	params.set_fd(OpenFiles::STDERR_FD, stderr_file);
@@ -615,28 +904,27 @@ async fn run_shell_command(
 	let baseline_descendants = process::current_descendant_pids();
 	let reader_cancel = CancellationToken::new();
 	let (activity_tx, mut activity_rx) = mpsc::channel::<()>(1);
-	// Stream every raw chunk to the caller live, regardless of whether
-	// minimization is enabled. When minimization actually transforms the
-	// output, we propagate the replacement text via `MinimizerResult.text`
-	// so the caller can swap their accumulated buffer for the minimized
-	// version without losing intermediate progress updates.
 	let reader_callback = on_chunk;
 	let mut reader_handle = tokio::spawn({
 		let reader_cancel = reader_cancel.clone();
 		async move {
-			if should_minimize {
-				let output = read_output_buffered(
-					reader_file,
-					reader_callback,
-					reader_cancel,
-					activity_tx,
-					max_capture_bytes,
-				)
-				.await;
-				Result::<OutputRead>::Ok(OutputRead::Buffered(output))
-			} else {
-				Box::pin(read_output(reader_file, reader_callback, reader_cancel, activity_tx)).await;
-				Result::<OutputRead>::Ok(OutputRead::Streaming)
+			match capture_mode {
+				CommandCaptureMode::Buffered { max_capture_bytes } => {
+					let output = read_output_buffered(
+						reader_file,
+						reader_callback,
+						reader_cancel,
+						activity_tx,
+						max_capture_bytes,
+					)
+					.await;
+					Result::<OutputRead>::Ok(OutputRead::Buffered(output))
+				},
+				CommandCaptureMode::Streaming => {
+					Box::pin(read_output(reader_file, reader_callback, reader_cancel, activity_tx))
+						.await;
+					Result::<OutputRead>::Ok(OutputRead::Streaming)
+				},
 			}
 		}
 	});
@@ -659,19 +947,11 @@ async fn run_shell_command(
 	let source_info = SourceInfo::from("pi-natives:command");
 	let result = session
 		.shell
-		.run_string(options.command.clone(), &source_info, &params)
+		.run_string(command, &source_info, &params)
 		.await;
 
 	if cancel_token.is_cancelled() {
 		terminate_background_jobs(&mut session.shell);
-	}
-
-	if env_scope_pushed {
-		session
-			.shell
-			.env_mut()
-			.pop_scope(EnvironmentScope::Command)
-			.map_err(|err| Error::msg(format!("Failed to pop env scope: {err}")))?;
 	}
 
 	drop(params);
@@ -736,33 +1016,11 @@ async fn run_shell_command(
 	}
 
 	let result = result.map_err(|err| Error::msg(format!("Shell execution failed: {err}")))?;
-	let mut minimized_out: Option<MinimizerResult> = None;
-	if let Some(OutputRead::Buffered(output)) = reader_output
-		&& let Some(config) = options.minimizer.as_ref()
-		&& !output.exceeded
-	{
-		let minimized = match minimizer_mode {
-			minimizer::engine::MinimizerMode::WholeCommand => {
-				minimizer::apply(&options.command, &output.text, exit_code(&result), config)
-			},
-			minimizer::engine::MinimizerMode::None => {
-				minimizer::MinimizerOutput::passthrough(&output.text)
-			},
-		};
-		if minimized.changed
-			&& let Some(original) = minimized.original_text
-		{
-			let output_bytes = u32::try_from(minimized.text.len()).unwrap_or(u32::MAX);
-			minimized_out = Some(MinimizerResult {
-				filter: minimized.filter.to_string(),
-				text: minimized.text,
-				original_text: original,
-				input_bytes: u32::try_from(minimized.input_bytes).unwrap_or(u32::MAX),
-				output_bytes,
-			});
-		}
-	}
-	Ok((result, minimized_out))
+	let buffered = match reader_output {
+		Some(OutputRead::Buffered(output)) => Some(output),
+		Some(OutputRead::Streaming) | None => None,
+	};
+	Ok(CommandRunOutput { result, buffered })
 }
 
 async fn run_shell_command_streams(
@@ -823,7 +1081,28 @@ async fn run_shell_command_streams(
 		let baseline_descendants = baseline_descendants.clone();
 		async move {
 			cancel_token.cancelled().await;
-			terminate_new_descendants(&baseline_descendants).await;
+			const WAVES: u32 = 3;
+			for wave in 0..WAVES {
+				let mut targets = process::TerminationTargets::new();
+				process::add_new_descendants(&mut targets, &baseline_descendants);
+				if targets.is_empty() {
+					return;
+				}
+				let signal = if wave == 0 {
+					process::TERM_SIGNAL
+				} else {
+					process::KILL_SIGNAL
+				};
+				targets.signal(signal);
+				if wave + 1 < WAVES {
+					let pause = if wave == 0 {
+						Duration::from_millis(75)
+					} else {
+						Duration::from_millis(150)
+					};
+					time::sleep(pause).await;
+				}
+			}
 		}
 	});
 	let source_info = SourceInfo::from("pi-shell:streams");
@@ -1149,8 +1428,9 @@ enum OutputRead {
 }
 
 struct BufferedOutput {
-	text:     String,
-	exceeded: bool,
+	text:        String,
+	input_bytes: usize,
+	exceeded:    bool,
 }
 
 async fn read_output(
@@ -1271,6 +1551,7 @@ async fn read_output_buffered(
 	const REPLACEMENT: &str = "\u{FFFD}";
 	const BUF: usize = 65536;
 	let mut buf = vec![0u8; BUF];
+	let mut input_bytes = 0usize;
 	let mut captured = Vec::new();
 	let mut exceeded = false;
 	// Pending bytes from a prior read that ended mid-UTF-8 sequence. We hold
@@ -1280,7 +1561,7 @@ async fn read_output_buffered(
 
 	#[cfg(unix)]
 	let Ok(reader) = register_nonblocking_pipe(reader) else {
-		return BufferedOutput { text: String::new(), exceeded: true };
+		return BufferedOutput { text: String::new(), input_bytes: 0, exceeded: true };
 	};
 	#[cfg(not(unix))]
 	let reader = tokio::fs::File::from_std(reader);
@@ -1320,6 +1601,7 @@ async fn read_output_buffered(
 		};
 		if n > 0 {
 			let _ = activity.try_send(());
+			input_bytes = input_bytes.saturating_add(n);
 		}
 		// Once `exceeded`, the post-process minimizer is bypassed (see the
 		// `!output.exceeded` gate at the call site), so further appends just
@@ -1378,7 +1660,7 @@ async fn read_output_buffered(
 		}
 	}
 
-	BufferedOutput { text: String::from_utf8_lossy(&captured).into_owned(), exceeded }
+	BufferedOutput { text: String::from_utf8_lossy(&captured).into_owned(), input_bytes, exceeded }
 }
 
 #[cfg(unix)]
@@ -1636,9 +1918,9 @@ mod tests {
 		/// Brush leading a new pgroup with non-terminal stdin always detaches —
 		/// including the first stage of a pipeline. `setsid()` keeps the child
 		/// off the host's controlling tty; the spawn path skips
-		/// `process_group(...)` for detached children, so later stages no
-		/// longer try to `setpgid`-join a leader that has moved sessions (the
-		/// historical EPERM hazard).
+		/// `process_group(...)` for detached children, so later stages no longer
+		/// try to `setpgid`-join a leader that has moved sessions (the historical
+		/// EPERM hazard).
 		#[test]
 		fn non_terminal_stdin_detaches_regardless_of_pipeline() {
 			assert_eq!(child_session_action(true, false, false), ChildSessionAction::DetachSession,);
@@ -1680,6 +1962,259 @@ mod tests {
 		}
 	}
 
+	#[cfg(unix)]
+	fn shell_test_lock() -> &'static TokioMutex<()> {
+		static LOCK: std::sync::OnceLock<TokioMutex<()>> = std::sync::OnceLock::new();
+		LOCK.get_or_init(|| TokioMutex::new(()))
+	}
+
+	#[cfg(unix)]
+	async fn run_command_capture(
+		command: &str,
+		cwd: Option<&std::path::Path>,
+		minimizer: Option<minimizer::MinimizerOptions>,
+		cancel_token: CancelToken,
+	) -> (ShellExecuteResult, String) {
+		let _guard = shell_test_lock().lock().await;
+		let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+		let options = ShellExecuteOptions {
+			command: command.to_string(),
+			cwd: cwd.map(|path| path.to_string_lossy().into_owned()),
+			minimizer,
+			..Default::default()
+		};
+		let result = execute_shell(options, Some(tx), cancel_token)
+			.await
+			.expect("execute_shell");
+		let mut output = String::new();
+		while let Some(chunk) = rx.recv().await {
+			output.push_str(&chunk);
+		}
+		(result, output)
+	}
+
+	#[cfg(unix)]
+	fn unique_temp_dir(prefix: &str) -> std::path::PathBuf {
+		let mut path = std::env::temp_dir();
+		let nonce = std::time::SystemTime::now()
+			.duration_since(std::time::UNIX_EPOCH)
+			.expect("system time")
+			.as_nanos();
+		path.push(format!("pi-shell-{prefix}-{}-{nonce}", std::process::id()));
+		std::fs::create_dir_all(&path).expect("create temp dir");
+		path
+	}
+
+	#[cfg(unix)]
+	fn printf_minimizer(
+		settings_path: &std::path::Path,
+		max_capture_bytes: Option<u32>,
+	) -> minimizer::MinimizerOptions {
+		std::fs::write(
+			settings_path,
+			r#"
+schema_version = 1
+
+[filters.printf]
+match_command = "^printf$"
+replace = [{ pattern = "hello", replacement = "HI" }]
+"#,
+		)
+		.expect("write settings");
+		minimizer::MinimizerOptions {
+			enabled: Some(true),
+			settings_path: Some(settings_path.to_string_lossy().into_owned()),
+			max_capture_bytes,
+			..Default::default()
+		}
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn segmented_false_and_printf_skips_second_and_returns_nonzero() {
+		let root = unique_temp_dir("false-and");
+		let minimizer = printf_minimizer(&root.join("minimizer.toml"), None);
+		let (result, output) = run_command_capture(
+			"false && printf skipped",
+			None,
+			Some(minimizer),
+			CancelToken::default(),
+		)
+		.await;
+		let _ = std::fs::remove_dir_all(&root);
+		assert_eq!(result.exit_code, Some(1));
+		assert!(!result.cancelled);
+		assert!(!result.timed_out);
+		assert_eq!(output, "");
+		// `false && printf` short-circuits: nothing is rewritten, so a no-op chain
+		// must surface no minimizer telemetry (None).
+		assert!(result.minimized.is_none(), "chain noop must not surface telemetry");
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn segmented_false_semicolon_printf_continues_and_returns_last_code() {
+		let root = unique_temp_dir("false-semi");
+		let minimizer = printf_minimizer(&root.join("minimizer.toml"), None);
+		let (result, output) = run_command_capture(
+			"false ; printf 'hello\n'",
+			None,
+			Some(minimizer),
+			CancelToken::default(),
+		)
+		.await;
+		let _ = std::fs::remove_dir_all(&root);
+		let minimized = result.minimized.expect("minimized result");
+		assert_eq!(result.exit_code, Some(0));
+		assert_eq!(output, "hello\n");
+		assert_eq!(minimized.filter, "chain");
+		assert_eq!(minimized.original_text, "hello\n");
+		assert_eq!(minimized.text, "HI\n");
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn segmented_cd_tmp_and_pwd_persists_state_across_segments() {
+		let root = unique_temp_dir("cwd");
+		let tmp_dir = root.join("tmp");
+		std::fs::create_dir_all(&tmp_dir).expect("create nested tmp dir");
+		let settings_path = root.join("minimizer.toml");
+		std::fs::write(
+			&settings_path,
+			r#"
+schema_version = 1
+
+[filters.pwd]
+match_command = "^pwd$"
+replace = [{ pattern = "^.+$", replacement = "PWD" }]
+"#,
+		)
+		.expect("write settings");
+		let minimizer = minimizer::MinimizerOptions {
+			enabled: Some(true),
+			settings_path: Some(settings_path.to_string_lossy().into_owned()),
+			..Default::default()
+		};
+
+		let expected = format!("{}\n", tmp_dir.display());
+		let (result, output) =
+			run_command_capture("cd tmp && pwd", Some(&root), Some(minimizer), CancelToken::default())
+				.await;
+		let _ = std::fs::remove_dir_all(&root);
+		let minimized = result.minimized.expect("minimized result");
+		assert_eq!(result.exit_code, Some(0));
+		assert_eq!(output, expected);
+		assert_eq!(minimized.filter, "chain");
+		assert_eq!(minimized.text, "PWD\n");
+		assert_eq!(minimized.original_text, expected);
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn whole_command_exceeding_capture_cap_reports_too_large_and_streams_raw() {
+		let root = unique_temp_dir("whole-cap");
+		let minimizer = printf_minimizer(&root.join("minimizer.toml"), Some(1024));
+		let (result, output) =
+			run_command_capture("printf '%1200s' x", None, Some(minimizer), CancelToken::default())
+				.await;
+		let _ = std::fs::remove_dir_all(&root);
+		assert_eq!(result.exit_code, Some(0));
+		assert_eq!(output.len(), 1200);
+		assert!(output.ends_with('x'));
+		let minimized = result.minimized.expect("too-large result");
+		assert_eq!(minimized.filter, "too-large");
+		assert_eq!(minimized.text, "");
+		assert_eq!(minimized.original_text, "");
+		assert_eq!(minimized.input_bytes, 1200);
+		assert_eq!(minimized.output_bytes, 0);
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn segmented_printf_chain_preserves_raw_original_text() {
+		let root = unique_temp_dir("minimizer");
+		let minimizer = printf_minimizer(&root.join("minimizer.toml"), None);
+		let (result, output) = run_command_capture(
+			"printf 'hello\n' ; printf 'world\n'",
+			None,
+			Some(minimizer),
+			CancelToken::default(),
+		)
+		.await;
+		let _ = std::fs::remove_dir_all(&root);
+		let minimized = result.minimized.expect("minimized result");
+		assert_eq!(result.exit_code, Some(0));
+		assert_eq!(output, "hello\nworld\n");
+		assert_eq!(minimized.filter, "chain");
+		assert_eq!(minimized.original_text, "hello\nworld\n");
+		assert_eq!(minimized.text, "HI\nworld\n");
+		assert_eq!(minimized.input_bytes, 12);
+		assert_eq!(minimized.output_bytes, 9);
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn segmented_chain_exceeding_aggregate_capture_cap_stays_raw() {
+		let root = unique_temp_dir("aggregate-cap");
+		let minimizer = printf_minimizer(&root.join("minimizer.toml"), Some(1024));
+		let (result, output) = run_command_capture(
+			"printf '%600s' x ; printf '%600s' y",
+			None,
+			Some(minimizer),
+			CancelToken::default(),
+		)
+		.await;
+		let _ = std::fs::remove_dir_all(&root);
+		assert_eq!(result.exit_code, Some(0));
+		assert_eq!(output.len(), 1200);
+		assert!(output.ends_with('y'));
+		let minimized = result.minimized.expect("too-large result");
+		assert_eq!(minimized.filter, "too-large");
+		assert_eq!(minimized.text, "");
+		assert_eq!(minimized.original_text, "");
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn segmented_timeout_in_first_segment_prevents_later_segments() {
+		let root = unique_temp_dir("timeout");
+		let minimizer = printf_minimizer(&root.join("minimizer.toml"), None);
+		let (result, output) = run_command_capture(
+			"sleep 1 && printf later",
+			None,
+			Some(minimizer),
+			CancelToken::new(Some(10)),
+		)
+		.await;
+		let _ = std::fs::remove_dir_all(&root);
+		assert!(result.exit_code.is_none());
+		assert!(!result.cancelled);
+		assert!(result.timed_out);
+		assert!(result.minimized.is_none());
+		assert!(!output.contains("later"));
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn segmented_cancel_in_first_segment_prevents_later_segments() {
+		let root = unique_temp_dir("cancel");
+		let minimizer = printf_minimizer(&root.join("minimizer.toml"), None);
+		let mut cancel_token = CancelToken::default();
+		let abort_token = cancel_token.emplace_abort_token();
+		let cancel_task = tokio::spawn(async move {
+			time::sleep(Duration::from_millis(10)).await;
+			abort_token.abort(AbortReason::Signal);
+		});
+		let (result, output) =
+			run_command_capture("sleep 1 && printf later", None, Some(minimizer), cancel_token).await;
+		let _ = cancel_task.await;
+		let _ = std::fs::remove_dir_all(&root);
+		assert!(result.exit_code.is_none());
+		assert!(result.cancelled);
+		assert!(!result.timed_out);
+		assert!(result.minimized.is_none());
+		assert!(!output.contains("later"));
+	}
 	/// End-to-end verification that brush, when embedded as a non-interactive
 	/// library (`interactive: false`, exactly what `create_session` produces),
 	/// spawns external commands in a **separate session** from the host.
@@ -1795,126 +2330,6 @@ mod tests {
 		assert_eq!(
 			child_sid, child_pid,
 			"child PID {child_pid} should be its own session leader after setsid",
-		);
-	}
-
-	/// Regression for the `suspended (tty input)` bug: an **interactive child
-	/// inside a pipeline** (`zsh -i ... | awk`) used to stay in the host
-	/// session, open `/dev/tty`, `tcsetpgrp` itself to the foreground, and
-	/// leave the embedded host (OMP) stopped on its next tty read. The earlier
-	/// embedded-host fix carved pipelines out of `detach_session` because a
-	/// later stage that `setpgid`-joined a detached leader failed with EPERM.
-	///
-	/// This test boots a real embedded `BrushShell` and runs a two-stage
-	/// pipeline whose first stage prints its PID then sleeps (forwarded to us
-	/// by `cat`). It asserts two contracts at once:
-	///   1. the first stage runs in its **own session** (`getsid == own pid`),
-	///      so it can never reach the host's controlling tty — guards the
-	///      decision; and
-	///   2. the pipeline still exits **successfully**, proving the second stage
-	///      spawned without the cross-session `setpgid` EPERM — guards the
-	///      wiring that skips `process_group(...)` for detached children.
-	#[cfg(unix)]
-	#[tokio::test(flavor = "multi_thread")]
-	async fn embedded_pipeline_stage_runs_in_its_own_session() {
-		use std::io::Read as _;
-
-		// SAFETY: `getsid(0)` only queries the current process session; checked below.
-		let host_sid = unsafe { libc::getsid(0) };
-		assert!(host_sid > 0, "getsid(0) failed: {}", std::io::Error::last_os_error());
-
-		let config = ShellConfig { session_env: None, snapshot_path: None, minimizer: None };
-		let mut session = create_session(&config).await.expect("create_session");
-
-		let (mut reader, writer) = pipe_to_files("e2e-pipe").expect("pipe");
-		let stdout_file = OpenFile::from(writer.try_clone().expect("clone"));
-		let stderr_file = OpenFile::from(writer);
-
-		let mut params = session.shell.default_exec_params();
-		params.set_fd(OpenFiles::STDIN_FD, null_file().expect("null stdin"));
-		params.set_fd(OpenFiles::STDOUT_FD, stdout_file);
-		params.set_fd(OpenFiles::STDERR_FD, stderr_file);
-
-		let (pid_tx, pid_rx) = tokio::sync::oneshot::channel::<i32>();
-		let reader_handle = tokio::task::spawn_blocking(move || {
-			let mut buf = Vec::new();
-			let mut chunk = [0u8; 64];
-			let mut pid_tx = Some(pid_tx);
-			while let Ok(n) = reader.read(&mut chunk)
-				&& n > 0
-			{
-				buf.extend_from_slice(&chunk[..n]);
-				if pid_tx.is_some()
-					&& let Some(line_end) = buf.iter().position(|&byte| byte == b'\n')
-					&& let Ok(line) = std::str::from_utf8(&buf[..line_end])
-					&& let Ok(pid) = line.trim().parse::<i32>()
-				{
-					let _ = pid_tx
-						.take()
-						.expect("pid sender should be present")
-						.send(pid);
-				}
-			}
-			buf
-		});
-
-		let shell_handle = tokio::spawn(async move {
-			let source_info = SourceInfo::from("pi-natives:test");
-			// First stage prints its own PID and sleeps; `cat` forwards the PID
-			// line to our reader and exits on EOF. The first stage leads the
-			// pipeline's process group, the second (`cat`) is the join-or-detach
-			// stage that would EPERM without the wiring fix.
-			let exec = session
-				.shell
-				.run_string(
-					"/bin/sh -c 'printf \"%d\\n\" \"$$\"; sleep 1' | /bin/cat",
-					&source_info,
-					&params,
-				)
-				.await
-				.expect("run_string");
-			drop(params);
-			(session, exec)
-		});
-
-		let child_pid = time::timeout(Duration::from_secs(5), pid_rx)
-			.await
-			.expect("timed out waiting for first-stage PID")
-			.expect("reader closed pid channel without sending");
-		assert!(child_pid > 0, "got non-positive child pid: {child_pid}");
-
-		// SAFETY: `child_pid` is a live positive PID (still in `sleep`); the return
-		// value is checked.
-		let child_sid = unsafe { libc::getsid(child_pid) };
-		assert!(
-			child_sid > 0,
-			"getsid({child_pid}) failed: {} (child may have already exited)",
-			std::io::Error::last_os_error(),
-		);
-
-		let (_session, exec) = time::timeout(Duration::from_secs(5), shell_handle)
-			.await
-			.expect("shell timed out")
-			.expect("shell task panicked");
-		// Guards the wiring: the second stage spawned without a cross-session
-		// `setpgid` EPERM, so the whole pipeline succeeded.
-		assert!(
-			matches!(exec.exit_code, ExecutionExitCode::Success),
-			"pipeline did not succeed (second stage may have hit setpgid EPERM): {}",
-			exit_code(&exec),
-		);
-		let _ = time::timeout(Duration::from_secs(2), reader_handle).await;
-
-		// Guards the decision: a pipeline stage must not share the host session,
-		// or it could seize the controlling tty and SIGTTIN the host.
-		assert_ne!(
-			child_sid, host_sid,
-			"pipeline stage PID {child_pid} inherited host session {host_sid}; it could seize the \
-			 controlling tty — the pipeline tty-suspend bug is back",
-		);
-		assert_eq!(
-			child_sid, child_pid,
-			"pipeline stage PID {child_pid} should be its own session leader after setsid",
 		);
 	}
 
@@ -2100,33 +2515,5 @@ mod tests {
 			stdout.extend_from_slice(&chunk);
 		}
 		assert_eq!(stdout, b"prod:8080");
-	}
-
-	/// Regression for a Windows/macOS deadlock in
-	/// `brush_core::interp::setup_open_file_with_contents`. The body is
-	/// 256 KiB — well past the default pipe buffer on every platform
-	/// (Windows ~4 KiB, macOS 16-64 KiB, Linux 64 KiB), so any inline
-	/// `write_all` on the calling thread blocks forever. The `:` builtin
-	/// never reads its stdin, so the only way `echo done` runs is if the
-	/// heredoc writer is decoupled from the main thread (or, on Linux,
-	/// the pipe buffer was grown via `F_SETPIPE_SZ`). The
-	/// `tokio::time::timeout` is the safety net that turns a regression
-	/// into a 10 s failure instead of hanging CI for the full
-	/// hard-timeout window.
-	#[tokio::test(flavor = "multi_thread")]
-	async fn large_heredoc_does_not_deadlock() {
-		let body = "X".repeat(256 * 1024);
-		let command = format!(": <<'EOF'\n{body}\nEOF\necho done");
-		let options = ShellExecuteOptions { command, ..Default::default() };
-
-		let result = time::timeout(
-			Duration::from_secs(10),
-			execute_shell(options, None, CancelToken::default()),
-		)
-		.await
-		.expect("execute_shell hung past 10 s — heredoc writer deadlocked")
-		.expect("execute_shell errored");
-
-		assert_eq!(result.exit_code, Some(0), "command did not run to completion");
 	}
 }

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added minimizer options `sourceOutlineLevel`, `aiSmartEnabled`, `aiSmartProvider`, and `legacyFilters` to the `MinimizerOptions` native surface. The opt-in AI-summary overlay (`aiSmartEnabled`) is now compiled into the distributed addon via `napi build --features ai-smart` and gated at runtime by the new knobs; it is disabled by default and fail-closed.
+
 ## [15.7.0] - 2026-05-31
 
 ### Added

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -1048,6 +1048,25 @@ export interface MinimizerOptions {
    * the raw, un-minimized output. Default 4 MiB.
    */
   maxCaptureBytes?: number
+  /**
+   * Source-outline level for `cat <source-file>` minimization. Accepts
+   * `"default"` (current behavior) or `"aggressive"` (strip function bodies).
+   */
+  sourceOutlineLevel?: string
+  /** Master switch for the AI-summary filter (W4 / rtk smart). Default off. */
+  aiSmartEnabled?: boolean
+  /**
+   * Provider key for the AI summarizer (e.g. `"deepseek"`). Default
+   * `"deepseek"` when `aiSmartEnabled` is true.
+   */
+  aiSmartProvider?: string
+  /**
+   * Kill-switch to fall back to the pre-PR (legacy) filter behavior for
+   * grep / find / pytest. When `true`, filters that opted into the
+   * always-shrink Tier 1 / Tier 2 behavior skip the new code path. When
+   * absent, defers to the `OMP_MINIMIZER_LEGACY_FILTERS` env var.
+   */
+  legacyFilters?: boolean
 }
 
 /**

--- a/packages/natives/scripts/build-native.ts
+++ b/packages/natives/scripts/build-native.ts
@@ -297,6 +297,11 @@ const napiArgs = [
 	profileLabel,
 ];
 
+// Enable the AI-summary minimizer filter so the runtime `aiSmartEnabled`/
+// `aiSmartProvider` knobs actually toggle behavior. Appended after the array
+// literal so the positional `-o` index (napiArgs[10]) stays stable below.
+napiArgs.push("--features", "ai-smart");
+
 if (crossTarget) {
 	napiArgs.push("--target", crossTarget);
 	// Route through `cargo-zigbuild` (non-MSVC targets) or `cargo-xwin`


### PR DESCRIPTION
## Summary

Expands the pi-shell output minimizer with new filter modules, a command-detection engine, and substantial enhancements to existing filters. Scope is the full minimizer subsystem: **31 files changed, ~+8,966 / -555 lines**.

## New filter modules
- `filters/ai_smart.rs` (+383) — opt-in AI-summary filter (feature-gated behind `ai-smart`); summarizes large captures via a configured provider (deepseek)
- `filters/binary_tools.rs` (+121) — stderr/stdout from compiled binary tools (Go/Rust/C executables)
- `filters/rust_tools.rs` (+170) — rustc/clippy/rustfmt and Rust ecosystem tool output
- `filters/cloud.rs` (+976) — cloud CLI output (aws/gcloud/etc.)
- `filters/docker.rs` (+533) — docker/kubectl/helm output
- `filters/listing.rs` (+684) — directory/listing command output
- `filters/system.rs` (+392) — system/process command output

## Command detection
- `detect.rs` (+137) — command identity detection mapping invocations to filter modules, including wrapped/launcher-prefixed commands

## Enhanced existing filters & engine
- `filters/git.rs` (+1559/-102), `filters/pkg.rs` (+525/-25), `filters/cargo.rs` (+344/-15), `filters/bun.rs`, `filters/node_tests.rs`, `filters/python.rs`, `filters/lint.rs`, `filters/mod.rs` (+485/-9)
- `engine.rs` (+366/-12), `plan.rs` (+277/-31), `config.rs` (+167/-24), `primitives.rs`, `minimizer.rs`
- `shell.rs` (+638/-268) parser/runtime changes
- NAPI surface: `crates/pi-natives/src/shell.rs`, `packages/natives/native/index.d.ts`, plus `ai-smart` feature wiring through `crates/pi-natives/Cargo.toml`, `crates/pi-shell/Cargo.toml`, and `packages/natives/scripts/build-native.ts` so the runtime `aiSmartEnabled`/`aiSmartProvider` knobs actually toggle behavior
- Dependency/manifest: `Cargo.toml`, `Cargo.lock`, `defs/gcc.toml`

## Dependencies
Builds on PR #1638 (filter enhancements) which builds on PR #1637 (chain segmentation). All three should be merged in order.

---
Part of the fork→upstream extraction set. Related: #1637 #1638 #1639 #1640 #1641 #1642 · Tracking: #1680
Suggested merge order: #1640 → #1641 → #1637 → #1638 → #1639 → #1642