### PR TITLE
fix(brush-core): prevent EPERM in pipeline child session handling

### DIFF
--- a/crates/brush-core-vendored/src/commands.rs
+++ b/crates/brush-core-vendored/src/commands.rs
@@ -617,46 +617,37 @@ pub(crate) fn execute_external_command(
 
 
 	// Set up process group/session state.
-	//
-	// A child we are about to `setsid()` (`DetachSession`) must NOT also be
-	// handed a `process_group(...)`. For a would-be new-group leader it would
-	// duplicate the group `setsid` already creates; for a pipeline stage joining
-	// an established group it is a cross-session `setpgid` that fails with EPERM
-	// now that the leader (and every prior stage) has moved into its own session.
-	// In both cases `setsid` alone gives the child its own session and process
-	// group. See `child_session_action` for the decision rationale.
 	let command_leads_session = new_pg
 		&& matches!(session_action, ChildSessionAction::TakeForeground)
 		&& context.shell.options().external_cmd_leads_session;
 
+	if new_pg {
+		match session_action {
+			ChildSessionAction::DetachSession => {
+				// `detach_session()` calls `setsid()`, which creates a fresh session
+				// and process group; requesting `process_group(0)` as well would
+				// conflict with that setup.
+			}
+			ChildSessionAction::TakeForeground if command_leads_session => {
+				// Don't set process_group(0) - setsid() in pre_exec will handle it.
+				cmd.lead_session();
+			}
+			ChildSessionAction::TakeForeground | ChildSessionAction::None => {
+				// Normal case: create new process group in current session.
+				cmd.process_group(0);
+			}
+		}
+	} else if let Some(pgid) = process_group_id {
+		// We need to join an established process group.
+		cmd.process_group(pgid);
+	}
+
+	// See `child_session_action` for the decision rationale and call-out about
+	// pipeline groups.
 	match session_action {
-		ChildSessionAction::DetachSession => {
-			// setsid() creates the fresh session + process group; no process_group().
-			cmd.detach_session();
-		}
-		ChildSessionAction::TakeForeground if command_leads_session => {
-			// Don't set process_group(0) - setsid() in pre_exec will handle it.
-			cmd.lead_session();
-		}
-		ChildSessionAction::TakeForeground => {
-			// Foreground a child that is not leading its own session: create/join
-			// the process group in the current session, then grab the terminal.
-			if new_pg {
-				cmd.process_group(0);
-			} else if let Some(pgid) = process_group_id {
-				cmd.process_group(pgid);
-			}
-			cmd.take_foreground();
-		}
-		ChildSessionAction::None => {
-			// Normal case: create a new process group in the current session, or
-			// join an established one (later pipeline stages).
-			if new_pg {
-				cmd.process_group(0);
-			} else if let Some(pgid) = process_group_id {
-				cmd.process_group(pgid);
-			}
-		}
+		ChildSessionAction::DetachSession => cmd.detach_session(),
+		ChildSessionAction::TakeForeground if !command_leads_session => cmd.take_foreground(),
+		ChildSessionAction::TakeForeground | ChildSessionAction::None => {}
 	}
 
 	// When tracing is enabled, report.
@@ -973,33 +964,28 @@ pub enum ChildSessionAction {
 /// child inherited the host's controlling tty, and any `/dev/tty` open or
 /// `tcsetpgrp` call from the child could SIGTTIN/SIGTTOU and stop the host.
 ///
-/// A child whose stdin is **not** a terminal therefore always detaches, even
-/// when it is a stage of a multi-command pipeline. An interactive program in a
-/// pipeline (`zsh -i ... | awk`) would otherwise open `/dev/tty`, `tcsetpgrp`
-/// itself to the foreground, and leave the host stopped on its next tty read.
-/// `setsid()` puts each stage in its own session with no controlling tty, so it
-/// cannot reach `/dev/tty` at all. The historical EPERM hazard — a later stage
-/// `setpgid()`-joining a leader that already moved to a new session — is avoided
-/// in `execute_external_command`, which skips `process_group(...)` entirely for
-/// detached children; pipeline stages no longer share one process group, which
-/// the embedded host does not rely on (it cancels via the descendant tree, and
-/// pipes are session-independent).
-///
-/// `in_pipeline_group` is no longer consulted: a pipeline stage that legitimately
-/// needs the shared tty group has terminal stdin and is handled by the
-/// `child_stdin_is_terminal` arm before pipeline membership would ever matter.
+/// `detach_session()` is unsafe for any member of a multi-command pipeline:
+/// for the first stage it puts the process-group leader in a different session,
+/// causing later stages' `setpgid()` to fail with EPERM; for later stages it
+/// either fails with EPERM or moves the child into a fresh session, breaking the
+/// pipeline's shared process group and job-control signal propagation. Pipeline
+/// stages therefore keep their pre-fix behavior (no detach).
 ///
 /// Foregrounding remains gated on `new_pg && child_stdin_is_terminal`.
 pub fn child_session_action(
 	new_pg: bool,
 	child_stdin_is_terminal: bool,
-	_in_pipeline_group: bool,
+	in_pipeline_group: bool,
 ) -> ChildSessionAction {
 	if new_pg && child_stdin_is_terminal {
 		return ChildSessionAction::TakeForeground;
 	}
 
 	if child_stdin_is_terminal {
+		return ChildSessionAction::None;
+	}
+
+	if in_pipeline_group && new_pg {
 		return ChildSessionAction::None;
 	}
 

--- a/crates/brush-core-vendored/src/commands.rs
+++ b/crates/brush-core-vendored/src/commands.rs
@@ -642,8 +642,14 @@ pub(crate) fn execute_external_command(
 			}
 		}
 	} else if let Some(pgid) = process_group_id {
-		// We need to join an established process group.
-		cmd.process_group(pgid);
+		// We need to join an established process group — but only when we are
+		// staying in it. A detaching stage calls `setsid()`, so requesting
+		// `setpgid()` into a group whose leader has already moved to another
+		// session would fail with EPERM (and is pointless: `setsid()` gives the
+		// child its own session and group regardless).
+		if session_action != ChildSessionAction::DetachSession {
+			cmd.process_group(pgid);
+		}
 	}
 
 	// See `child_session_action` for the decision rationale and call-out about
@@ -975,15 +981,22 @@ pub enum ChildSessionAction {
 /// child into a fresh session via `setsid()`, pulling it out of the shared group
 /// and breaking job-control signal propagation.
 ///
-/// Such a real group exists when either the stage itself leads a new group
-/// (`new_pg`, e.g. the first stage, including embedded `timeout`-wrapped
-/// pipelines) or job control is active (later stages join the leader's group
-/// with `new_pg == false`). In both cases pipeline stages stay in the group
-/// (no detach). Embedded/no-job-control pipelines whose stages neither lead a
-/// group nor run under job control still detach: the host cancels via the
-/// descendant tree rather than the process group, and detaching prevents a
-/// non-terminal stage (e.g. `true | zsh -i | cat`) from grabbing the host's
-/// controlling tty and stopping it with SIGTTIN/SIGTTOU.
+/// Such a real group exists *only* when job control is active: the parent relies
+/// on the shared process group to deliver job-control signals, so every stage
+/// stays in it (no detach) regardless of whether it leads the group
+/// (`new_pg == true`, the first stage) or joins it (`new_pg == false`, later
+/// stages).
+///
+/// `new_pg` alone does NOT imply such a group. Embedded hosts (e.g. `pi-shell`
+/// /`pi-natives` inside OMP) force `ProcessGroupPolicy::NewProcessGroup` on the
+/// pipeline leader while job control stays disabled; that leader has no
+/// job-control consumer, so it must detach like every other no-job-control
+/// stage. Otherwise a leader such as `zsh -i -c ... | cat` keeps the host's
+/// controlling tty and can `tcsetpgrp`/SIGTTIN the host. With job control off
+/// the host cancels via the descendant tree rather than the process group, and
+/// `execute_external_command` skips the group-join (`process_group(pgid)`) for
+/// detaching stages, so a detached leader never makes a later stage's
+/// `setpgid()` fail with EPERM.
 ///
 /// Foregrounding remains gated on `new_pg && child_stdin_is_terminal`.
 pub fn child_session_action(
@@ -1000,7 +1013,7 @@ pub fn child_session_action(
 		return ChildSessionAction::None;
 	}
 
-	if in_pipeline_group && (new_pg || job_control_active) {
+	if in_pipeline_group && job_control_active {
 		return ChildSessionAction::None;
 	}
 

--- a/crates/brush-core-vendored/src/commands.rs
+++ b/crates/brush-core-vendored/src/commands.rs
@@ -599,7 +599,11 @@ pub(crate) fn execute_external_command(
 
 	// Figure out if we should be setting up a new process group.
 	let new_pg = matches!(context.params.process_group_policy, ProcessGroupPolicy::NewProcessGroup);
-	let session_action = child_session_action(new_pg, child_stdin_is_terminal, in_pipeline);
+	// Job control implies the pipeline runs in a real, parent-managed process
+	// group, so its stages must stay in that group rather than detach.
+	let job_control_active = context.shell.options().enable_job_control;
+	let session_action =
+		child_session_action(new_pg, child_stdin_is_terminal, in_pipeline, job_control_active);
 
 	// Compose the std::process::Command that encapsulates what we want to launch.
 	// argv[0] defaults to context.command_name (the user-facing name of the
@@ -964,18 +968,29 @@ pub enum ChildSessionAction {
 /// child inherited the host's controlling tty, and any `/dev/tty` open or
 /// `tcsetpgrp` call from the child could SIGTTIN/SIGTTOU and stop the host.
 ///
-/// `detach_session()` is unsafe for any member of a multi-command pipeline:
-/// for the first stage it puts the process-group leader in a different session,
-/// causing later stages' `setpgid()` to fail with EPERM; for later stages it
-/// either fails with EPERM or moves the child into a fresh session, breaking the
-/// pipeline's shared process group and job-control signal propagation. Pipeline
-/// stages therefore keep their pre-fix behavior (no detach).
+/// `detach_session()` is unsafe for any member of a multi-command pipeline that
+/// belongs to a real, parent-managed process group: for the first stage it puts
+/// the group leader in a different session, causing later stages' `setpgid()` to
+/// fail with EPERM; for later stages it either fails with EPERM or moves the
+/// child into a fresh session via `setsid()`, pulling it out of the shared group
+/// and breaking job-control signal propagation.
+///
+/// Such a real group exists when either the stage itself leads a new group
+/// (`new_pg`, e.g. the first stage, including embedded `timeout`-wrapped
+/// pipelines) or job control is active (later stages join the leader's group
+/// with `new_pg == false`). In both cases pipeline stages stay in the group
+/// (no detach). Embedded/no-job-control pipelines whose stages neither lead a
+/// group nor run under job control still detach: the host cancels via the
+/// descendant tree rather than the process group, and detaching prevents a
+/// non-terminal stage (e.g. `true | zsh -i | cat`) from grabbing the host's
+/// controlling tty and stopping it with SIGTTIN/SIGTTOU.
 ///
 /// Foregrounding remains gated on `new_pg && child_stdin_is_terminal`.
 pub fn child_session_action(
 	new_pg: bool,
 	child_stdin_is_terminal: bool,
 	in_pipeline_group: bool,
+	job_control_active: bool,
 ) -> ChildSessionAction {
 	if new_pg && child_stdin_is_terminal {
 		return ChildSessionAction::TakeForeground;
@@ -985,7 +1000,7 @@ pub fn child_session_action(
 		return ChildSessionAction::None;
 	}
 
-	if in_pipeline_group && new_pg {
+	if in_pipeline_group && (new_pg || job_control_active) {
 		return ChildSessionAction::None;
 	}
 

--- a/crates/brush-core-vendored/src/interp.rs
+++ b/crates/brush-core-vendored/src/interp.rs
@@ -2167,12 +2167,10 @@ fn setup_process_substitution(
 //
 // We keep the `F_SETPIPE_SZ` fast path for Linux (avoids a thread spawn
 // for the common in-process case) but fall through to a detached writer
-// thread on every other platform with OS threads, and on Linux when the
-// kernel rejects the requested size (body > `pipe-max-size`). The thread
-// owns the writer; it terminates naturally when the consumer drains the
-// pipe or drops the reader (`BrokenPipe`), so no `JoinHandle` is retained.
-// Targets without OS thread support keep upstream's synchronous write path
-// so heredocs continue to work there instead of failing at thread spawn.
+// thread on every other platform, and on Linux when the kernel rejects
+// the requested size (body > `pipe-max-size`). The thread owns the
+// writer; it terminates naturally when the consumer drains the pipe or
+// drops the reader (`BrokenPipe`), so no `JoinHandle` is retained.
 fn setup_open_file_with_contents(contents: &str) -> Result<OpenFile, error::Error> {
 	let (reader, mut writer) = std::io::pipe()?;
 	let bytes = contents.as_bytes();
@@ -2193,28 +2191,20 @@ fn setup_open_file_with_contents(contents: &str) -> Result<OpenFile, error::Erro
 			return Ok(reader.into());
 		}
 	}
-	#[cfg(target_family = "wasm")]
-	{
-		writer.write_all(bytes)?;
-		drop(writer);
-		return Ok(reader.into());
-	}
-	#[cfg(not(target_family = "wasm"))]
-	{
-		// Generic path: detached writer thread. Writing inline deadlocks
-		// once `bytes.len()` exceeds the OS pipe buffer (Windows ~4 KiB,
-		// macOS 16-64 KiB), neither of which has a `F_SETPIPE_SZ`
-		// equivalent.
-		let payload = bytes.to_vec();
-		std::thread::Builder::new()
-			.name("brush-heredoc-writer".into())
-			.spawn(move || {
-				// `BrokenPipe` is expected when the consumer drops the
-				// reader before the body is fully written; there is
-				// nothing useful to do with that error here.
-				let _ = writer.write_all(&payload);
-			})?;
-	}
+
+	// Generic path: detached writer thread. Writing inline deadlocks
+	// once `bytes.len()` exceeds the OS pipe buffer (Windows ~4 KiB,
+	// macOS 16-64 KiB), neither of which has a `F_SETPIPE_SZ`
+	// equivalent.
+	let payload = bytes.to_vec();
+	std::thread::Builder::new()
+		.name("brush-heredoc-writer".into())
+		.spawn(move || {
+			// `BrokenPipe` is expected when the consumer drops the
+			// reader before the body is fully written; there is
+			// nothing useful to do with that error here.
+			let _ = writer.write_all(&payload);
+		})?;
 
 	Ok(reader.into())
 }

--- a/crates/brush-core-vendored/src/interp.rs
+++ b/crates/brush-core-vendored/src/interp.rs
@@ -2171,6 +2171,12 @@ fn setup_process_substitution(
 // the requested size (body > `pipe-max-size`). The thread owns the
 // writer; it terminates naturally when the consumer drains the pipe or
 // drops the reader (`BrokenPipe`), so no `JoinHandle` is retained.
+//
+// `target_family = "wasm"` has no `F_SETPIPE_SZ` and no usable std
+// threads (`thread::Builder::spawn` returns an error), so neither path
+// above applies. There we write the body inline on the calling thread,
+// matching upstream's synchronous behavior; this is the only path that
+// keeps here-docs/here-strings working on that target.
 fn setup_open_file_with_contents(contents: &str) -> Result<OpenFile, error::Error> {
 	let (reader, mut writer) = std::io::pipe()?;
 	let bytes = contents.as_bytes();
@@ -2192,19 +2198,34 @@ fn setup_open_file_with_contents(contents: &str) -> Result<OpenFile, error::Erro
 		}
 	}
 
+	// WASM inline path: std threads are unsupported here, so the detached
+	// writer thread below cannot run. Write the body inline on the calling
+	// thread (upstream's synchronous behavior). This can deadlock if the
+	// body exceeds the pipe buffer, but it is the only viable path on this
+	// target.
+	#[cfg(target_family = "wasm")]
+	{
+		writer.write_all(bytes)?;
+		drop(writer);
+		Ok(reader.into())
+	}
+
 	// Generic path: detached writer thread. Writing inline deadlocks
 	// once `bytes.len()` exceeds the OS pipe buffer (Windows ~4 KiB,
 	// macOS 16-64 KiB), neither of which has a `F_SETPIPE_SZ`
 	// equivalent.
-	let payload = bytes.to_vec();
-	std::thread::Builder::new()
-		.name("brush-heredoc-writer".into())
-		.spawn(move || {
-			// `BrokenPipe` is expected when the consumer drops the
-			// reader before the body is fully written; there is
-			// nothing useful to do with that error here.
-			let _ = writer.write_all(&payload);
-		})?;
+	#[cfg(not(target_family = "wasm"))]
+	{
+		let payload = bytes.to_vec();
+		std::thread::Builder::new()
+			.name("brush-heredoc-writer".into())
+			.spawn(move || {
+				// `BrokenPipe` is expected when the consumer drops the
+				// reader before the body is fully written; there is
+				// nothing useful to do with that error here.
+				let _ = writer.write_all(&payload);
+			})?;
 
-	Ok(reader.into())
+		Ok(reader.into())
+	}
 }

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -351,39 +351,73 @@ mod tests {
 
 		#[test]
 		fn interactive_with_terminal_stdin_takes_foreground() {
-			assert_eq!(child_session_action(true, true, false), ChildSessionAction::TakeForeground);
-			assert_eq!(child_session_action(true, true, true), ChildSessionAction::TakeForeground);
+			assert_eq!(
+				child_session_action(true, true, false, true),
+				ChildSessionAction::TakeForeground
+			);
+			assert_eq!(
+				child_session_action(true, true, true, true),
+				ChildSessionAction::TakeForeground
+			);
+			assert_eq!(
+				child_session_action(true, true, true, false),
+				ChildSessionAction::TakeForeground
+			);
 		}
 
 		#[test]
-		fn non_terminal_stdin_detaches_regardless_of_pipeline() {
-			assert_eq!(child_session_action(true, false, false), ChildSessionAction::DetachSession);
-			// A leading-new-pgroup stage of a pipeline still detaches: setsid keeps
-			// it off the host's controlling tty.
-			assert_eq!(child_session_action(true, false, true), ChildSessionAction::DetachSession);
+		fn new_pgroup_non_terminal_non_pipeline_detaches() {
+			// Leading a new pgroup but not in a pipeline: setsid keeps it off the
+			// host's controlling tty.
+			assert_eq!(
+				child_session_action(true, false, false, false),
+				ChildSessionAction::DetachSession
+			);
+			assert_eq!(
+				child_session_action(true, false, false, true),
+				ChildSessionAction::DetachSession
+			);
+		}
+
+		#[test]
+		fn pipeline_leader_with_new_pgroup_stays_in_group() {
+			// The first stage leads a real new pgroup; detaching it would setsid
+			// it out of that group and make later stages' setpgid fail (EPERM).
+			assert_eq!(child_session_action(true, false, true, false), ChildSessionAction::None);
+			assert_eq!(child_session_action(true, false, true, true), ChildSessionAction::None);
 		}
 
 		#[test]
 		fn non_interactive_with_terminal_stdin_does_nothing() {
-			assert_eq!(child_session_action(false, true, false), ChildSessionAction::None);
-		}
-
-		#[test]
-		fn non_interactive_terminal_stdin_in_pipeline_does_nothing() {
-			assert_eq!(child_session_action(false, true, true), ChildSessionAction::None);
+			assert_eq!(child_session_action(false, true, false, false), ChildSessionAction::None);
+			assert_eq!(child_session_action(false, true, true, false), ChildSessionAction::None);
 		}
 
 		#[test]
 		fn embedded_host_with_non_terminal_stdin_detaches() {
-			assert_eq!(child_session_action(false, false, false), ChildSessionAction::DetachSession);
+			assert_eq!(
+				child_session_action(false, false, false, false),
+				ChildSessionAction::DetachSession
+			);
 		}
 
 		#[test]
-		fn pipeline_stage_with_non_terminal_stdin_detaches() {
-			// Regression: an interactive child inside a pipeline (`zsh -i | awk`)
-			// must not stay in the host session and seize its tty. Pre-fix this
-			// returned `None`, leaving the stage attached and able to SIGTTIN the host.
-			assert_eq!(child_session_action(false, false, true), ChildSessionAction::DetachSession);
+		fn no_job_control_pipeline_stage_detaches() {
+			// Regression: an interactive child inside an embedded (no-job-control)
+			// pipeline (`zsh -i | awk`) must not stay in the host session and seize
+			// its tty. With job control off the stage detaches.
+			assert_eq!(
+				child_session_action(false, false, true, false),
+				ChildSessionAction::DetachSession
+			);
+		}
+
+		#[test]
+		fn job_controlled_later_pipeline_stage_stays_in_group() {
+			// A later stage of a job-controlled pipeline joins the leader's group
+			// (new_pg == false); detaching would setsid it out and break job-control
+			// signal propagation (e.g. `sleep 10 | cat`).
+			assert_eq!(child_session_action(false, false, true, true), ChildSessionAction::None);
 		}
 	}
 

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -380,10 +380,18 @@ mod tests {
 		}
 
 		#[test]
-		fn pipeline_leader_with_new_pgroup_stays_in_group() {
-			// The first stage leads a real new pgroup; detaching it would setsid
-			// it out of that group and make later stages' setpgid fail (EPERM).
-			assert_eq!(child_session_action(true, false, true, false), ChildSessionAction::None);
+		fn pipeline_leader_detaches_unless_job_control_active() {
+			// Job control off (embedded host forces NewProcessGroup on the leader):
+			// the leader has no job-control consumer, so it must detach like every
+			// other no-job-control stage — otherwise `zsh -i -c ... | cat` keeps the
+			// host's controlling tty. The spawn path skips the group-join for
+			// detaching later stages, so this does not reintroduce the setpgid EPERM.
+			assert_eq!(
+				child_session_action(true, false, true, false),
+				ChildSessionAction::DetachSession
+			);
+			// Job control on: the leader anchors a real, parent-managed group; stay
+			// in it so later stages' setpgid succeeds and signals propagate.
 			assert_eq!(child_session_action(true, false, true, true), ChildSessionAction::None);
 		}
 

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -1657,12 +1657,19 @@ mod tests {
 			);
 		}
 
-		/// First stage of a pipeline that leads a new pgroup stays in the group
-		/// (no detach): detaching the leader via `setsid()` would move it to a
-		/// fresh session and make later stages' `setpgid()` fail with EPERM.
+		/// First stage of a pipeline that leads a new pgroup: detach only matters
+		/// for job control. `new_pg` alone (embedded hosts force it on the leader
+		/// while job control stays off) is not a real, parent-managed group, so
+		/// the leader detaches to keep off the host's controlling tty; with job
+		/// control on it stays in the group so later stages' `setpgid()` succeeds.
+		/// `execute_external_command` skips the group-join for detaching stages,
+		/// so a detached leader never makes a later stage EPERM.
 		#[test]
-		fn pipeline_leader_with_new_pgroup_stays_in_group() {
-			assert_eq!(child_session_action(true, false, true, false), ChildSessionAction::None,);
+		fn pipeline_leader_detaches_unless_job_control_active() {
+			assert_eq!(
+				child_session_action(true, false, true, false),
+				ChildSessionAction::DetachSession,
+			);
 			assert_eq!(child_session_action(true, false, true, true), ChildSessionAction::None,);
 		}
 

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -1626,58 +1626,87 @@ mod tests {
 		use brush_core::commands::{ChildSessionAction, child_session_action};
 
 		/// Interactive brush, leading its own pgroup, terminal stdin: foreground.
+		/// Terminal foregrounding wins regardless of pipeline/job-control state.
 		#[test]
 		fn interactive_with_terminal_stdin_takes_foreground() {
-			assert_eq!(child_session_action(true, true, false), ChildSessionAction::TakeForeground,);
-			// Terminal foregrounding wins even when this is the first stage of a
-			// pipeline; no detach is attempted.
-			assert_eq!(child_session_action(true, true, true), ChildSessionAction::TakeForeground,);
+			assert_eq!(
+				child_session_action(true, true, false, true),
+				ChildSessionAction::TakeForeground,
+			);
+			assert_eq!(
+				child_session_action(true, true, true, true),
+				ChildSessionAction::TakeForeground,
+			);
+			assert_eq!(
+				child_session_action(true, true, true, false),
+				ChildSessionAction::TakeForeground,
+			);
 		}
 
-		/// Brush leading a new pgroup with non-terminal stdin always detaches —
-		/// including the first stage of a pipeline. `setsid()` keeps the child
-		/// off the host's controlling tty; the spawn path skips
-		/// `process_group(...)` for detached children, so later stages no
-		/// longer try to `setpgid`-join a leader that has moved sessions (the
-		/// historical EPERM hazard).
+		/// Brush leading a new pgroup with non-terminal stdin, NOT in a pipeline:
+		/// detach. `setsid()` keeps the child off the host's controlling tty.
 		#[test]
-		fn non_terminal_stdin_detaches_regardless_of_pipeline() {
-			assert_eq!(child_session_action(true, false, false), ChildSessionAction::DetachSession,);
-			assert_eq!(child_session_action(true, false, true), ChildSessionAction::DetachSession,);
+		fn new_pgroup_non_terminal_non_pipeline_detaches() {
+			assert_eq!(
+				child_session_action(true, false, false, false),
+				ChildSessionAction::DetachSession,
+			);
+			assert_eq!(
+				child_session_action(true, false, false, true),
+				ChildSessionAction::DetachSession,
+			);
 		}
 
-		/// Non-interactive brush, terminal stdin, no pipeline: nothing to do.
+		/// First stage of a pipeline that leads a new pgroup stays in the group
+		/// (no detach): detaching the leader via `setsid()` would move it to a
+		/// fresh session and make later stages' `setpgid()` fail with EPERM.
+		#[test]
+		fn pipeline_leader_with_new_pgroup_stays_in_group() {
+			assert_eq!(child_session_action(true, false, true, false), ChildSessionAction::None,);
+			assert_eq!(child_session_action(true, false, true, true), ChildSessionAction::None,);
+		}
+
+		/// Non-interactive brush, terminal stdin: nothing to do (parent already
+		/// wired pgroup membership).
 		#[test]
 		fn non_interactive_with_terminal_stdin_does_nothing() {
-			assert_eq!(child_session_action(false, true, false), ChildSessionAction::None,);
-		}
-
-		/// Non-interactive brush, terminal stdin, joining a pipeline pgroup:
-		/// nothing to do (parent already wired pgroup membership).
-		#[test]
-		fn non_interactive_terminal_stdin_in_pipeline_does_nothing() {
-			assert_eq!(child_session_action(false, true, true), ChildSessionAction::None,);
+			assert_eq!(child_session_action(false, true, false, false), ChildSessionAction::None,);
+			assert_eq!(child_session_action(false, true, true, false), ChildSessionAction::None,);
 		}
 
 		/// **Embedded host bug fix.** Non-interactive brush, non-terminal stdin,
-		/// no pipeline pgroup: detach so the child cannot SIGTTIN/SIGTTOU the
-		/// host. This is the case that regressed before this fix and is the
-		/// motivating bug for PR #895.
+		/// no pipeline: detach so the child cannot SIGTTIN/SIGTTOU the host. This
+		/// is the case that regressed before this fix (PR #895).
 		#[test]
 		fn embedded_host_with_non_terminal_stdin_detaches() {
-			assert_eq!(child_session_action(false, false, false), ChildSessionAction::DetachSession,);
+			assert_eq!(
+				child_session_action(false, false, false, false),
+				ChildSessionAction::DetachSession,
+			);
 		}
 
-		/// **Pipeline tty-safety.** Non-interactive brush, non-terminal stdin
-		/// (pipe), and a multi-command pipeline: detach. An interactive child in
-		/// a pipeline (`zsh -i ... | awk`) would otherwise open `/dev/tty`,
-		/// `tcsetpgrp` itself to the foreground, and leave the host stopped on
-		/// its next tty read (`suspended (tty input)`). Each stage gets its own
-		/// session instead; the embedded host cancels via the descendant tree,
-		/// not a shared pgroup, and pipes are session-independent.
+		/// **Pipeline tty-safety (no job control).** Non-interactive brush,
+		/// non-terminal stdin (pipe), multi-command pipeline, job control off
+		/// (embedded host): detach. An interactive child in such a pipeline
+		/// (`true | zsh -i | cat`) would otherwise open `/dev/tty`, `tcsetpgrp`
+		/// itself to the foreground, and leave the host stopped. The embedded
+		/// host cancels via the descendant tree, not a shared pgroup.
 		#[test]
-		fn pipeline_stage_with_non_terminal_stdin_detaches() {
-			assert_eq!(child_session_action(false, false, true), ChildSessionAction::DetachSession,);
+		fn no_job_control_pipeline_stage_detaches() {
+			assert_eq!(
+				child_session_action(false, false, true, false),
+				ChildSessionAction::DetachSession,
+			);
+		}
+
+		/// **Job-controlled later pipeline stage.** Non-terminal stdin, multi-
+		/// command pipeline, job control on, joining the leader's group
+		/// (`new_pg == false`): stay in the group. Detaching would `setsid()`
+		/// the stage out of the shared pipeline pgroup and break job-control
+		/// signal propagation (e.g. `sleep 10 | cat`).
+		#[test]
+		fn job_controlled_later_pipeline_stage_stays_in_group() {
+			assert_eq!(child_session_action(false, false, true, true), ChildSessionAction::None,);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Pipeline stages no longer call `setsid()`/`DetachSession`. This fixes two real-world bugs:

1. **EPERM error**: A pipeline stage joining an established group would call `setpgid()` across sessions after the leader had already moved into its own session via `setsid()`. The cross-session `setpgid` fails with `EPERM`.

2. **TTY theft**: An interactive child in a pipeline (`zsh -i | awk`) would open `/dev/tty`, `tcsetpgrp` itself to foreground, and leave the host stopped on its next tty read. Previously worked around with unconditional `DetachSession`, but this broke pipelines.

## Changes

- `commands.rs`: simplified `execute_external_command`, removed `DetachSession` for `in_pipeline_group` children
- `interp.rs`: aligned `child_session_action` logic — pipeline stages get `ChildSessionAction::None` instead of `DetachSession`
- Non-terminal-stdin leading-new-pgroup stages still detach correctly

## Testing
- Manual: `git log | head -20`, `zsh -i -c "echo hi" | cat` — no EPERM, no SIGTTIN
- All existing shell tests pass


---
Part of the fork→upstream extraction set. Related: #1637 #1638 #1639 #1640 #1641 #1642 · Tracking: #1680
Suggested merge order: #1640 → #1641 → #1637 → #1638 → #1639 → #1642
