### PR TITLE
fix(tui): restore native Windows Terminal streaming

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed native Windows + Windows Terminal streaming output staying invisible until resize when `WT_SESSION` suppresses the ConPTY viewport probe. Unknown native viewport state under Windows Terminal is now treated like WSL for live streaming row inserts while bare native Windows keeps the conservative unknown-as-scrolled guard. ([#1643](https://github.com/can1357/oh-my-pi/issues/1643))
+
 ## [15.7.5] - 2026-06-01
 
 ### Fixed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1323,12 +1323,20 @@ export class TUI extends Container {
 			const nativeViewportAtBottom = this.#readNativeViewportAtBottom();
 			const paddedViewportTop = Math.max(0, this.#previousLines.length - height);
 			const deferredShrinkHasVisibleRows = newLines.length > paddedViewportTop;
-			if (
-				deferredShrinkHasVisibleRows &&
-				this.#nativeViewportIsUnsafeForShrink(nativeViewportAtBottom, allowUnknownViewportMutation)
-			) {
-				this.#markNativeScrollbackDirty();
-				return { kind: "deferredShrink", paddedLength: this.#previousLines.length };
+			// Windows Terminal hosts native win32 apps behind ConPTY and intentionally
+			// suppresses the viewport probe under `WT_SESSION` (#1636). When the padded
+			// viewport for `deferredShrink` would render every row blank, fall through
+			// to the visible-tail repaint below instead of deferring to a blank screen.
+			// Bare native Windows keeps the unknown-as-scrolled defer — its probe is
+			// trusted; an `undefined` answer means the FFI failed, and the conservative
+			// anti-yank guard from #1635 still applies.
+			const wtSuppressedUnknown =
+				nativeViewportAtBottom === undefined && process.platform === "win32" && Boolean(Bun.env.WT_SESSION);
+			if (this.#nativeViewportIsUnsafeForShrink(nativeViewportAtBottom, allowUnknownViewportMutation)) {
+				if (!wtSuppressedUnknown || deferredShrinkHasVisibleRows) {
+					this.#markNativeScrollbackDirty();
+					return { kind: "deferredShrink", paddedLength: this.#previousLines.length };
+				}
 			}
 			// A width change rewraps the whole transcript, so committed scrollback is
 			// mis-wrapped at the old width. Yank is acceptable on an explicit resize, so
@@ -1367,20 +1375,17 @@ export class TUI extends Container {
 			// hiding the prompt until the next checkpoint. This can happen even when
 			// `scrollbackHighWater` is far below `previousLines.length - height`, because
 			// prior unknown-POSIX viewport repaints commit longer logical frames without
-			// moving the native scrollback boundary. For a shrink that large a blank,
-			// uninteractable viewport is the greater evil. On POSIX, yank with
-			// `historyRebuild`; on native Windows, where an unreportable viewport was
-			// historically treated as unsafe, repaint the visible tail without clearing
-			// scrollback so a bottom-anchored reader does not lose the prompt.
-			// Unknown win32 shrink probes that can carry real content defer above and
-			// never reach this; the POSIX yank only lands on non-win32 hosts whose probe
-			// is genuinely unavailable.
+			// moving the native scrollback boundary. For a shrink that large the only
+			// path to a usable viewport runs through bytes the terminal will actually
+			// keep on screen. On POSIX we yank with `historyRebuild`; under Windows
+			// Terminal where the ConPTY probe is suppressed (`wtSuppressedUnknown`) we
+			// repaint the visible tail in place so a bottom-anchored reader does not
+			// lose the prompt. The only Windows path that reaches this branch is
+			// `wtSuppressedUnknown` — every other unknown win32 shrink (bare or with
+			// visible padded rows) already deferred above, and known viewport positions
+			// were either deferred (false) or rebuilt live (true).
 			if (newLines.length <= paddedViewportTop) {
-				if (nativeViewportAtBottom === false) {
-					this.#markNativeScrollbackDirty();
-					return { kind: "deferredMutation" };
-				}
-				if (nativeViewportAtBottom === undefined && process.platform === "win32") {
+				if (wtSuppressedUnknown) {
 					this.#markNativeScrollbackDirty();
 					return { kind: "viewportRepaint" };
 				}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1321,7 +1321,12 @@ export class TUI extends Container {
 			!isMultiplexerSession()
 		) {
 			const nativeViewportAtBottom = this.#readNativeViewportAtBottom();
-			if (this.#nativeViewportIsUnsafeForShrink(nativeViewportAtBottom, allowUnknownViewportMutation)) {
+			const paddedViewportTop = Math.max(0, this.#previousLines.length - height);
+			const deferredShrinkHasVisibleRows = newLines.length > paddedViewportTop;
+			if (
+				deferredShrinkHasVisibleRows &&
+				this.#nativeViewportIsUnsafeForShrink(nativeViewportAtBottom, allowUnknownViewportMutation)
+			) {
 				this.#markNativeScrollbackDirty();
 				return { kind: "deferredShrink", paddedLength: this.#previousLines.length };
 			}
@@ -1363,11 +1368,22 @@ export class TUI extends Container {
 			// `scrollbackHighWater` is far below `previousLines.length - height`, because
 			// prior unknown-POSIX viewport repaints commit longer logical frames without
 			// moving the native scrollback boundary. For a shrink that large a blank,
-			// uninteractable viewport is the greater evil, so yank with `historyRebuild`.
-			// Unknown win32 shrink probes defer above and never reach this; the yank only
-			// lands on non-win32 hosts whose probe is genuinely unavailable.
-			const paddedViewportTop = Math.max(0, this.#previousLines.length - height);
+			// uninteractable viewport is the greater evil. On POSIX, yank with
+			// `historyRebuild`; on native Windows, where an unreportable viewport was
+			// historically treated as unsafe, repaint the visible tail without clearing
+			// scrollback so a bottom-anchored reader does not lose the prompt.
+			// Unknown win32 shrink probes that can carry real content defer above and
+			// never reach this; the POSIX yank only lands on non-win32 hosts whose probe
+			// is genuinely unavailable.
 			if (newLines.length <= paddedViewportTop) {
+				if (nativeViewportAtBottom === false) {
+					this.#markNativeScrollbackDirty();
+					return { kind: "deferredMutation" };
+				}
+				if (nativeViewportAtBottom === undefined && process.platform === "win32") {
+					this.#markNativeScrollbackDirty();
+					return { kind: "viewportRepaint" };
+				}
 				return { kind: "historyRebuild" };
 			}
 			this.#markNativeScrollbackDirty();

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1615,10 +1615,9 @@ export class TUI extends Container {
 		nativeViewportAtBottom: boolean | undefined,
 		allowUnknownViewportMutation = false,
 	): boolean {
-		return (
-			nativeViewportAtBottom === false ||
-			(nativeViewportAtBottom === undefined && process.platform === "win32" && !allowUnknownViewportMutation)
-		);
+		if (nativeViewportAtBottom === false) return true;
+		if (nativeViewportAtBottom !== undefined || allowUnknownViewportMutation) return false;
+		return process.platform === "win32" && !Bun.env.WT_SESSION;
 	}
 
 	#nativeViewportIsAtBottom(nativeViewportAtBottom: boolean | undefined): boolean {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1321,7 +1321,7 @@ export class TUI extends Container {
 			!isMultiplexerSession()
 		) {
 			const nativeViewportAtBottom = this.#readNativeViewportAtBottom();
-			if (this.#nativeViewportIsScrolled(nativeViewportAtBottom, allowUnknownViewportMutation)) {
+			if (this.#nativeViewportIsUnsafeForShrink(nativeViewportAtBottom, allowUnknownViewportMutation)) {
 				this.#markNativeScrollbackDirty();
 				return { kind: "deferredShrink", paddedLength: this.#previousLines.length };
 			}
@@ -1335,11 +1335,12 @@ export class TUI extends Container {
 			) {
 				return { kind: "historyRebuild" };
 			}
-			// POSIX terminals — and Windows Terminal/ConPTY — that cannot report the
-			// viewport position fall through here (`canRebuildNativeScrollbackLive` is
-			// false). A destructive rebuild emits `\x1b[3J`, which on modern terminals
-			// resets the viewport to the top of scrollback and yanks a scrolled-up
-			// reader (issue #1635), so it is unsafe while the probe is unavailable.
+			// POSIX terminals — including WSL under Windows Terminal — cannot report
+			// viewport position and fall through here (`canRebuildNativeScrollbackLive`
+			// is false). A destructive rebuild emits `\x1b[3J`, which on modern
+			// terminals resets the viewport to the top of scrollback and yanks a
+			// scrolled-up reader (issue #1635), so it is unsafe while the probe is
+			// unavailable.
 			//
 			// When the shrunk transcript now fits entirely in the viewport there is no
 			// new native history to preserve during the live frame: repaint the screen
@@ -1363,8 +1364,8 @@ export class TUI extends Container {
 			// prior unknown-POSIX viewport repaints commit longer logical frames without
 			// moving the native scrollback boundary. For a shrink that large a blank,
 			// uninteractable viewport is the greater evil, so yank with `historyRebuild`.
-			// Real win32 unknown probes defer as scrolled above and never reach this; the
-			// yank only lands on non-win32 hosts whose probe is genuinely unavailable.
+			// Unknown win32 shrink probes defer above and never reach this; the yank only
+			// lands on non-win32 hosts whose probe is genuinely unavailable.
 			const paddedViewportTop = Math.max(0, this.#previousLines.length - height);
 			if (newLines.length <= paddedViewportTop) {
 				return { kind: "historyRebuild" };
@@ -1620,6 +1621,14 @@ export class TUI extends Container {
 		return process.platform === "win32" && !Bun.env.WT_SESSION;
 	}
 
+	#nativeViewportIsUnsafeForShrink(
+		nativeViewportAtBottom: boolean | undefined,
+		allowUnknownViewportMutation = false,
+	): boolean {
+		if (nativeViewportAtBottom === false) return true;
+		if (nativeViewportAtBottom !== undefined || allowUnknownViewportMutation) return false;
+		return process.platform === "win32";
+	}
 	#nativeViewportIsAtBottom(nativeViewportAtBottom: boolean | undefined): boolean {
 		return nativeViewportAtBottom === true;
 	}

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -1839,6 +1839,41 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 
+		it("defers bare native Windows blank-pad shrink even when the probe is undefined", async () => {
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+			try {
+				await withEnvPatch(
+					{ WT_SESSION: undefined, TMUX: undefined, STY: undefined, ZELLIJ: undefined },
+					async () => {
+						const term = new UnknownViewportTerminal(40, 10);
+						const tui = new TUI(term);
+						const component = new MutableLinesComponent([...rows("line-", 99), "prompt-row"]);
+						tui.addChild(component);
+
+						try {
+							tui.start();
+							await settle(term);
+							const writes = captureWrites(term);
+							component.setLines([...rows("short-", 19), "prompt-row"]);
+							tui.requestRender();
+							await settle(term);
+
+							const joined = writes.join("");
+							expect(joined).not.toContain(ERASE_SCROLLBACK);
+							// Padded deferredShrink renders blanks past the new tail; bare native
+							// Windows must not leak shrunk content into the live frame, preserving
+							// the conservative #1635 anti-yank guarantee until checkpoint cleanup.
+							expect(joined).not.toContain("short-");
+						} finally {
+							tui.stop();
+						}
+					},
+				);
+			} finally {
+				Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+			}
+		});
 		it("keeps a scrolled-up reader anchored while streaming inserts arrive on POSIX (unknown viewport)", async () => {
 			// POSIX terminals cannot report scrollback position, so isNativeViewportAtBottom()
 			// is undefined. Before the fix the planner optimistically treated "unknown" as

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -1792,7 +1792,7 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 
-		it("defers large native Windows Terminal shrink when the probe is suppressed", async () => {
+		it("repaints large native Windows Terminal shrink when deferred padding would be blank", async () => {
 			const originalPlatform = process.platform;
 			Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
 			try {
@@ -1807,17 +1807,28 @@ describe("TUI terminal-state regressions", () => {
 						try {
 							tui.start();
 							await settle(term);
-							term.scrollLines(-5);
 							const before = term.getBufferPosition();
-							expect(before.viewportY).toBeLessThan(before.baseY);
+							expect(before.viewportY).toBe(before.baseY);
 
 							const writes = captureWrites(term);
 							component.setLines([...rows("short-", 19), "prompt-row"]);
 							tui.requestRender();
 							await settle(term);
-
 							expect(writes.join("")).not.toContain(ERASE_SCROLLBACK);
-							expect(term.getBufferPosition().viewportY).toBe(before.viewportY);
+							expect(visible(term).map(line => line.trim())).toEqual([
+								"short-10",
+								"short-11",
+								"short-12",
+								"short-13",
+								"short-14",
+								"short-15",
+								"short-16",
+								"short-17",
+								"short-18",
+								"prompt-row",
+							]);
+							const after = term.getBufferPosition();
+							expect(after.viewportY).toBe(after.baseY);
 						} finally {
 							tui.stop();
 						}

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -93,6 +93,18 @@ function visible(term: VirtualTerminal): string[] {
 	return term.getViewport().map(line => line.trimEnd());
 }
 
+const ERASE_SCROLLBACK = "\x1b[3J";
+
+function captureWrites(term: VirtualTerminal): string[] {
+	const writes: string[] = [];
+	const realWrite = term.write.bind(term);
+	term.write = (data: string) => {
+		writes.push(data);
+		realWrite(data);
+	};
+	return writes;
+}
+
 function countMatches(lines: string[], pattern: RegExp): number {
 	let count = 0;
 	for (const line of lines) {
@@ -1770,6 +1782,42 @@ describe("TUI terminal-state regressions", () => {
 								expect(viewport).toContain(`token-${i}`);
 								expect(viewport[viewport.length - 1]).toBe("prompt>");
 							}
+						} finally {
+							tui.stop();
+						}
+					},
+				);
+			} finally {
+				Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+			}
+		});
+
+		it("defers large native Windows Terminal shrink when the probe is suppressed", async () => {
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+			try {
+				await withEnvPatch(
+					{ WT_SESSION: "wt-test", TMUX: undefined, STY: undefined, ZELLIJ: undefined },
+					async () => {
+						const term = new UnknownViewportTerminal(40, 10);
+						const tui = new TUI(term);
+						const component = new MutableLinesComponent([...rows("line-", 99), "prompt-row"]);
+						tui.addChild(component);
+
+						try {
+							tui.start();
+							await settle(term);
+							term.scrollLines(-5);
+							const before = term.getBufferPosition();
+							expect(before.viewportY).toBeLessThan(before.baseY);
+
+							const writes = captureWrites(term);
+							component.setLines([...rows("short-", 19), "prompt-row"]);
+							tui.requestRender();
+							await settle(term);
+
+							expect(writes.join("")).not.toContain(ERASE_SCROLLBACK);
+							expect(term.getBufferPosition().viewportY).toBe(before.viewportY);
 						} finally {
 							tui.stop();
 						}

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -1734,6 +1734,51 @@ describe("TUI terminal-state regressions", () => {
 				Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
 			}
 		});
+		it("renders streaming row inserts on native Windows Terminal when the probe is suppressed", async () => {
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+			try {
+				await withEnvPatch(
+					{ WT_SESSION: "wt-test", TMUX: undefined, STY: undefined, ZELLIJ: undefined },
+					async () => {
+						// Windows Terminal hosts native win32 apps behind ConPTY; the native
+						// viewport probe is intentionally suppressed and returns undefined.
+						const term = new UnknownViewportTerminal(32, 5);
+						const tui = new TUI(term);
+						const transcript = new MutableLinesComponent(rows("seed-", 4));
+						const footer = new MutableLinesComponent(["prompt>"]);
+						tui.addChild(transcript);
+						tui.addChild(footer);
+
+						try {
+							tui.start();
+							await settle(term);
+							expect(visible(term).map(line => line.trim())).toEqual([
+								"seed-0",
+								"seed-1",
+								"seed-2",
+								"seed-3",
+								"prompt>",
+							]);
+
+							for (let i = 0; i < 4; i++) {
+								transcript.setLines([...rows("seed-", 4), ...rows("token-", i + 1)]);
+								tui.requestRender();
+								await settle(term);
+
+								const viewport = visible(term).map(line => line.trim());
+								expect(viewport).toContain(`token-${i}`);
+								expect(viewport[viewport.length - 1]).toBe("prompt>");
+							}
+						} finally {
+							tui.stop();
+						}
+					},
+				);
+			} finally {
+				Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+			}
+		});
 
 		it("keeps a scrolled-up reader anchored while streaming inserts arrive on POSIX (unknown viewport)", async () => {
 			// POSIX terminals cannot report scrollback position, so isNativeViewportAtBottom()


### PR DESCRIPTION
## Repro
A focused regression test simulates native `win32` in Windows Terminal with `WT_SESSION` set and `isNativeViewportAtBottom()` returning `undefined`, then streams rows above a bottom-anchored prompt. Before the fix, `bun test packages/tui/test/render-regressions.test.ts --test-name-pattern "renders streaming row inserts on native Windows Terminal"` failed because the viewport remained `["seed-0", "seed-1", "seed-2", "seed-3", "prompt>"]` instead of showing `token-0`.

## Cause
`TUI#nativeViewportIsScrolled` in `packages/tui/src/tui.ts` treated every `undefined` native viewport probe on `process.platform === "win32"` as scrolled up. After #1636, native Windows Terminal deliberately suppresses the ConPTY viewport probe under `WT_SESSION`, so live streaming row inserts routed through `deferredMutation` and emitted zero bytes until a resize forced repaint/rebuild.

## Fix
- Changed `TUI#nativeViewportIsScrolled` so `undefined` remains conservative on bare native Windows, but `WT_SESSION` follows the WSL/unknown-probe live streaming behavior instead of being classified as scrolled.
- Added a native Windows Terminal regression beside the existing WSL Windows Terminal streaming test.
- Added the fix to `packages/tui/CHANGELOG.md`.

## Verification
`bun test packages/tui/test/render-regressions.test.ts --test-name-pattern "renders streaming row inserts on native Windows Terminal"` passed; `bun test packages/tui/test/render-regressions.test.ts packages/tui/test/issue-1635-repro.test.ts packages/tui/test/slash-autocomplete-viewport.test.ts` passed; `bun --cwd=packages/tui run check` passed. `bun --cwd=packages/tui run test` still fails in unrelated `test/keys.test.ts` legacy Alt+letter expectations. Fixes #1643