### PR TITLE
fix(tui): honor todo auto-clear delay

### DIFF
--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -259,6 +259,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	loopPrompt: string | undefined = undefined;
 	loopLimit: LoopLimitRuntime | undefined = undefined;
 	#loopAutoSubmitTimer: NodeJS.Timeout | undefined;
+	#todoAutoClearTimer: NodeJS.Timeout | undefined;
 	todoPhases: TodoPhase[] = [];
 	hideThinkingBlock = false;
 	pendingImages: ImageContent[] = [];
@@ -554,6 +555,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			// subagent is doing the work for a still-pending todo) updates as
 			// subagents start, finish, or fail.
 			this.#reconcileTodosWithSubagents();
+			this.#syncTodoAutoClearTimer();
 			this.#renderTodoList();
 			this.ui.requestRender();
 		});
@@ -1042,6 +1044,47 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.session.setTodoPhases(next);
 	}
 
+	#cancelTodoAutoClearTimer(): void {
+		if (!this.#todoAutoClearTimer) return;
+		clearTimeout(this.#todoAutoClearTimer);
+		this.#todoAutoClearTimer = undefined;
+	}
+
+	#isClosedTodo(task: TodoItem): boolean {
+		return task.status === "completed" || task.status === "abandoned";
+	}
+
+	#hasClosedTodos(phases: TodoPhase[]): boolean {
+		return phases.some(phase => phase.tasks.some(task => this.#isClosedTodo(task)));
+	}
+
+	#removeClosedTodos(phases: TodoPhase[]): TodoPhase[] {
+		const next: TodoPhase[] = [];
+		for (const phase of phases) {
+			const tasks = phase.tasks.filter(task => !this.#isClosedTodo(task));
+			if (tasks.length > 0) next.push({ name: phase.name, tasks });
+		}
+		return next;
+	}
+
+	#syncTodoAutoClearTimer(): void {
+		this.#cancelTodoAutoClearTimer();
+		const delaySeconds = this.settings.get("tasks.todoClearDelay");
+		if (!Number.isFinite(delaySeconds) || delaySeconds < 0 || !this.#hasClosedTodos(this.todoPhases)) return;
+		if (delaySeconds === 0) {
+			this.todoPhases = this.#removeClosedTodos(this.todoPhases);
+			return;
+		}
+
+		this.#todoAutoClearTimer = setTimeout(() => {
+			this.#todoAutoClearTimer = undefined;
+			this.todoPhases = this.#removeClosedTodos(this.todoPhases);
+			this.#renderTodoList();
+			this.ui.requestRender();
+		}, delaySeconds * 1000);
+		this.#todoAutoClearTimer.unref?.();
+	}
+
 	#getActivePhase(phases: TodoPhase[]): TodoPhase | undefined {
 		const nonEmpty = phases.filter(phase => phase.tasks.length > 0);
 		const active = nonEmpty.find(phase =>
@@ -1097,6 +1140,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	async #loadTodoList(): Promise<void> {
 		this.todoPhases = this.session.getTodoPhases();
+		this.#syncTodoAutoClearTimer();
 		this.#renderTodoList();
 	}
 
@@ -2175,6 +2219,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			this.loadingAnimation = undefined;
 		}
 		this.#cleanupMicAnimation();
+		this.#cancelTodoAutoClearTimer();
 		this.#cancelGoalContinuation();
 		if (this.#sttController) {
 			this.#sttController.dispose();
@@ -2857,6 +2902,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				},
 			];
 		}
+		this.#syncTodoAutoClearTimer();
 		this.#renderTodoList();
 		this.ui.requestRender();
 	}

--- a/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
+++ b/packages/coding-agent/test/interactive-mode-todo-clear.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { ModelRegistry } from "../src/config/model-registry";
+import { InteractiveMode } from "../src/modes/interactive-mode";
+import { AgentSession } from "../src/session/agent-session";
+import { AuthStorage } from "../src/session/auth-storage";
+import { SessionManager } from "../src/session/session-manager";
+import type { TodoPhase } from "../src/tools/todo-write";
+
+function renderTodos(mode: InteractiveMode): string {
+	return Bun.stripANSI(mode.todoContainer.render(120).join("\n"));
+}
+
+describe("InteractiveMode todo auto-clear", () => {
+	let tempDir: TempDir;
+	let authStorage: AuthStorage;
+	let session: AgentSession;
+	let mode: InteractiveMode;
+
+	beforeAll(async () => {
+		await initTheme();
+	});
+
+	beforeEach(async () => {
+		resetSettingsForTest();
+		tempDir = TempDir.createSync("@pi-todo-clear-");
+	});
+
+	afterEach(async () => {
+		mode?.stop();
+		await session?.dispose();
+		authStorage?.close();
+		tempDir?.removeSync();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+		resetSettingsForTest();
+	});
+
+	async function createMode(todoClearDelay: number): Promise<void> {
+		await Settings.init({
+			inMemory: true,
+			cwd: tempDir.path(),
+			overrides: { "tasks.todoClearDelay": todoClearDelay },
+		});
+		authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		const modelRegistry = new ModelRegistry(authStorage);
+		const model = modelRegistry.find("anthropic", "claude-sonnet-4-5");
+		if (!model) throw new Error("Expected claude-sonnet-4-5 to exist in registry");
+
+		session = new AgentSession({
+			agent: new Agent({
+				initialState: {
+					model,
+					systemPrompt: ["Test"],
+					tools: [],
+					messages: [],
+				},
+			}),
+			sessionManager: SessionManager.create(tempDir.path(), tempDir.path()),
+			settings: Settings.isolated({ "tasks.todoClearDelay": todoClearDelay }),
+			modelRegistry,
+		});
+		mode = new InteractiveMode(session, "test");
+	}
+
+	it("clears closed todos from the panel instantly without mutating session history", async () => {
+		await createMode(0);
+		const phases: TodoPhase[] = [
+			{
+				name: "Implementation",
+				tasks: [
+					{ content: "done task", status: "completed" },
+					{ content: "abandoned task", status: "abandoned" },
+				],
+			},
+		];
+		session.setTodoPhases(phases);
+
+		mode.setTodos(session.getTodoPhases());
+
+		expect(renderTodos(mode)).not.toContain("done task");
+		expect(renderTodos(mode)).not.toContain("abandoned task");
+		expect(session.getTodoPhases()).toEqual(phases);
+	});
+
+	it("leaves closed todos visible when auto-clear is disabled", async () => {
+		await createMode(-1);
+
+		mode.setTodos([{ name: "Implementation", tasks: [{ content: "done task", status: "completed" }] }]);
+
+		expect(renderTodos(mode)).toContain("done task");
+	});
+
+	it("clears closed todos after the configured delay", async () => {
+		await createMode(1);
+		vi.useFakeTimers();
+
+		mode.setTodos([{ name: "Implementation", tasks: [{ content: "done task", status: "completed" }] }]);
+		expect(renderTodos(mode)).toContain("done task");
+
+		vi.advanceTimersByTime(999);
+		expect(renderTodos(mode)).toContain("done task");
+
+		vi.advanceTimersByTime(1);
+		expect(renderTodos(mode)).not.toContain("done task");
+	});
+});


### PR DESCRIPTION
## Repro
With `tasks.todoClearDelay=0`, a completed todo passed through `InteractiveMode.setTodos()` still rendered in the sticky Todos panel as `☑ done task`. Reproduced with `cd packages/coding-agent && bun --eval "$REPRO_SCRIPT"` before the fix.

## Cause
`packages/coding-agent/src/modes/interactive-mode.ts` rendered `todoPhases` directly in `#renderTodoList()` and refreshed them in `setTodos()` / `#loadTodoList()` without ever reading `tasks.todoClearDelay`. The only existing auto-clear path in `AgentSession` had been removed to avoid mutating canonical `#todoPhases`, so the UI setting was exposed but inert.

## Fix
- Added an interactive-mode auto-clear timer that removes completed/abandoned todos from the visible Todos panel only.
- Honored `0` as instant clear, positive values as delayed clear, and negative values as never clear.
- Left `AgentSession` todo history unchanged so the model-facing canonical todo state does not shrink behind the model's back.
- Added regression tests for instant clear, delayed clear, and disabled clear.

## Verification
`bun test packages/coding-agent/test/interactive-mode-todo-clear.test.ts packages/coding-agent/test/tools/todo-write.test.ts` passed. `bun run check` passed in `packages/coding-agent`. The repro script now prints `OK: completed todo hidden`. Fixes #1644