### PR TITLE
fix(coding-agent): restore last active role model on resume

### DIFF
--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1056,26 +1056,29 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 
 	const taskDepth = options.taskDepth ?? 0;
 
-	let thinkingLevel = options.thinkingLevel;
-
-	// If session has data and includes a thinking entry, restore it
-	if (thinkingLevel === undefined && hasExistingSession && hasThinkingEntry) {
-		thinkingLevel = parseThinkingLevel(existingSession.thinkingLevel);
-	}
-
-	if (thinkingLevel === undefined && !hasExplicitModel && !hasThinkingEntry && defaultRoleSpec.explicitThinkingLevel) {
-		thinkingLevel = defaultRoleSpec.thinkingLevel;
-	}
-
-	// Prefer the selected model's configured defaultLevel, otherwise fall back
-	// to the global settings default.
-	if (thinkingLevel === undefined && model?.thinking?.defaultLevel !== undefined) {
-		thinkingLevel = model.thinking.defaultLevel;
-	}
-	if (thinkingLevel === undefined) {
-		thinkingLevel = settings.get("defaultThinkingLevel");
-	}
-	const autoThinking = thinkingLevel === AUTO_THINKING;
+	// Resolves the session/agent thinking level using the same precedence we
+	// apply at startup: explicit option → persisted session entry → default
+	// role's explicit selector → selected model's defaultLevel → global
+	// settings default. Run again after extension role reclaim so the final
+	// model's own defaults aren't masked by an earlier fallback model's.
+	const pickInitialThinkingLevel = (selectedModel: Model | undefined): ConfiguredThinkingLevel | undefined => {
+		let level = options.thinkingLevel;
+		if (level === undefined && hasExistingSession && hasThinkingEntry) {
+			level = parseThinkingLevel(existingSession.thinkingLevel);
+		}
+		if (level === undefined && !hasExplicitModel && !hasThinkingEntry && defaultRoleSpec.explicitThinkingLevel) {
+			level = defaultRoleSpec.thinkingLevel;
+		}
+		if (level === undefined && selectedModel?.thinking?.defaultLevel !== undefined) {
+			level = selectedModel.thinking.defaultLevel;
+		}
+		if (level === undefined) {
+			level = settings.get("defaultThinkingLevel");
+		}
+		return level;
+	};
+	let thinkingLevel = pickInitialThinkingLevel(model);
+	let autoThinking = thinkingLevel === AUTO_THINKING;
 	// Concrete level the agent/session start with. With `auto` this is the
 	// provisional level shown until the first per-turn classification resolves;
 	// `auto` itself stays a session-only concept handled by AgentSession.
@@ -1461,13 +1464,16 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			extensionsResult.runtime.pendingProviderRegistrations = [];
 		}
 
-		// Retry preferred session-model candidates now that extension providers
-		// are registered. The initial restore above runs before extensions load,
-		// so a role model supplied by an extension would have fallen back to the
-		// session's saved default; reclaim it here so resume honors the last
-		// active role.
-		if (!hasExplicitModel && restoredSessionModelIndex > 0 && sessionModelStrings.length > 0) {
-			for (let i = 0; i < restoredSessionModelIndex; i++) {
+		// Retry session-model candidates now that extension providers are
+		// registered. The initial restore runs before extensions load, so a role
+		// model supplied by an extension would have either fallen back to the
+		// saved default (`restoredSessionModelIndex > 0`) or failed entirely
+		// (`restoredSessionModelIndex === -1`, with the settings default or
+		// downstream fallback filling `model`). Reclaim it here so resume
+		// honors the last active role in either case.
+		const sessionRetryLimit = restoredSessionModelIndex >= 0 ? restoredSessionModelIndex : sessionModelStrings.length;
+		if (!hasExplicitModel && sessionRetryLimit > 0) {
+			for (let i = 0; i < sessionRetryLimit; i++) {
 				const sessionModelStr = sessionModelStrings[i];
 				const parsedModel = parseModelString(sessionModelStr);
 				if (!parsedModel) continue;
@@ -1476,6 +1482,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					model = restoredModel;
 					modelFallbackMessage = undefined;
 					restoredSessionModelIndex = i;
+					// Recompute thinking-level from scratch against the reclaimed
+					// model: any value derived from the earlier fallback model's
+					// `thinking.defaultLevel` must not become sticky.
+					thinkingLevel = pickInitialThinkingLevel(restoredModel);
+					autoThinking = thinkingLevel === AUTO_THINKING;
+					effectiveThinkingLevel = thinkingLevel === AUTO_THINKING ? undefined : thinkingLevel;
 					effectiveThinkingLevel = logger.time("resolveThinkingLevelForModel", () =>
 						autoThinking
 							? resolveProvisionalAutoLevel(restoredModel)

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1008,16 +1008,21 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	);
 	let model = options.model;
 	let modelFallbackMessage: string | undefined;
-	// If session has data, try to restore model from it.
-	// Skip restore when an explicit model was requested.
-	const sessionModelStrings = getRestorableSessionModels(
-		existingSession.models,
-		sessionManager.getLastModelChangeRole(),
-	);
-	if (!hasExplicitModel && !model && hasExistingSession && sessionModelStrings.length > 0) {
+	// Identify session model strings to restore in fallback order. We do an
+	// initial pass here so model-dependent setup (thinking-level resolution,
+	// host preconnect) can use the restored model; extension-registered
+	// providers aren't visible yet, so we retry the preferred candidates once
+	// extensions register below.
+	const sessionModelStrings =
+		!hasExplicitModel && hasExistingSession
+			? getRestorableSessionModels(existingSession.models, sessionManager.getLastModelChangeRole())
+			: [];
+	let restoredSessionModelIndex = -1;
+	if (!hasExplicitModel && !model && sessionModelStrings.length > 0) {
 		await logger.time("restoreSessionModel", async () => {
 			let failedSessionModel: string | undefined;
-			for (const sessionModelStr of sessionModelStrings) {
+			for (let i = 0; i < sessionModelStrings.length; i++) {
+				const sessionModelStr = sessionModelStrings[i];
 				const parsedModel = parseModelString(sessionModelStr);
 				if (!parsedModel) {
 					failedSessionModel ??= sessionModelStr;
@@ -1027,6 +1032,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				const restoredModel = modelRegistry.find(parsedModel.provider, parsedModel.id);
 				if (restoredModel && (await hasModelApiKey(restoredModel))) {
 					model = restoredModel;
+					restoredSessionModelIndex = i;
 					break;
 				}
 				failedSessionModel ??= sessionModelStr;
@@ -1455,6 +1461,31 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			extensionsResult.runtime.pendingProviderRegistrations = [];
 		}
 
+		// Retry preferred session-model candidates now that extension providers
+		// are registered. The initial restore above runs before extensions load,
+		// so a role model supplied by an extension would have fallen back to the
+		// session's saved default; reclaim it here so resume honors the last
+		// active role.
+		if (!hasExplicitModel && restoredSessionModelIndex > 0 && sessionModelStrings.length > 0) {
+			for (let i = 0; i < restoredSessionModelIndex; i++) {
+				const sessionModelStr = sessionModelStrings[i];
+				const parsedModel = parseModelString(sessionModelStr);
+				if (!parsedModel) continue;
+				const restoredModel = modelRegistry.find(parsedModel.provider, parsedModel.id);
+				if (restoredModel && (await hasModelApiKey(restoredModel))) {
+					model = restoredModel;
+					modelFallbackMessage = undefined;
+					restoredSessionModelIndex = i;
+					effectiveThinkingLevel = logger.time("resolveThinkingLevelForModel", () =>
+						autoThinking
+							? resolveProvisionalAutoLevel(restoredModel)
+							: resolveThinkingLevelForModel(restoredModel, effectiveThinkingLevel),
+					);
+					preconnectModelHost(restoredModel.baseUrl);
+					break;
+				}
+			}
+		}
 		// Resolve deferred --model pattern now that extension models are registered.
 		if (!model && options.modelPattern) {
 			const availableModels = modelRegistry.getAll();

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -102,7 +102,7 @@ import { AgentSession } from "./session/agent-session";
 import { resolveAuthBrokerConfig } from "./session/auth-broker-config";
 import { AuthBrokerClient, AuthStorage, RemoteAuthCredentialStore } from "./session/auth-storage";
 import { type CustomMessage, convertToLlm } from "./session/messages";
-import { getRestorableSessionModel, SessionManager } from "./session/session-manager";
+import { getRestorableSessionModels, SessionManager } from "./session/session-manager";
 import { closeAllConnections } from "./ssh/connection-manager";
 import { unmountAll } from "./ssh/sshfs-mount";
 import {
@@ -1010,18 +1010,29 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	let modelFallbackMessage: string | undefined;
 	// If session has data, try to restore model from it.
 	// Skip restore when an explicit model was requested.
-	const sessionModelStr = getRestorableSessionModel(existingSession.models, sessionManager.getLastModelChangeRole());
-	if (!hasExplicitModel && !model && hasExistingSession && sessionModelStr) {
+	const sessionModelStrings = getRestorableSessionModels(
+		existingSession.models,
+		sessionManager.getLastModelChangeRole(),
+	);
+	if (!hasExplicitModel && !model && hasExistingSession && sessionModelStrings.length > 0) {
 		await logger.time("restoreSessionModel", async () => {
-			const parsedModel = parseModelString(sessionModelStr);
-			if (parsedModel) {
+			let failedSessionModel: string | undefined;
+			for (const sessionModelStr of sessionModelStrings) {
+				const parsedModel = parseModelString(sessionModelStr);
+				if (!parsedModel) {
+					failedSessionModel ??= sessionModelStr;
+					continue;
+				}
+
 				const restoredModel = modelRegistry.find(parsedModel.provider, parsedModel.id);
 				if (restoredModel && (await hasModelApiKey(restoredModel))) {
 					model = restoredModel;
+					break;
 				}
+				failedSessionModel ??= sessionModelStr;
 			}
-			if (!model) {
-				modelFallbackMessage = `Could not restore model ${sessionModelStr}`;
+			if (failedSessionModel) {
+				modelFallbackMessage = `Could not restore model ${failedSessionModel}`;
 			}
 		});
 	}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -102,7 +102,7 @@ import { AgentSession } from "./session/agent-session";
 import { resolveAuthBrokerConfig } from "./session/auth-broker-config";
 import { AuthBrokerClient, AuthStorage, RemoteAuthCredentialStore } from "./session/auth-storage";
 import { type CustomMessage, convertToLlm } from "./session/messages";
-import { SessionManager } from "./session/session-manager";
+import { getRestorableSessionModel, SessionManager } from "./session/session-manager";
 import { closeAllConnections } from "./ssh/connection-manager";
 import { unmountAll } from "./ssh/sshfs-mount";
 import {
@@ -1010,10 +1010,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	let modelFallbackMessage: string | undefined;
 	// If session has data, try to restore model from it.
 	// Skip restore when an explicit model was requested.
-	const defaultModelStr = existingSession.models.default;
-	if (!hasExplicitModel && !model && hasExistingSession && defaultModelStr) {
+	const sessionModelStr = getRestorableSessionModel(existingSession.models, sessionManager.getLastModelChangeRole());
+	if (!hasExplicitModel && !model && hasExistingSession && sessionModelStr) {
 		await logger.time("restoreSessionModel", async () => {
-			const parsedModel = parseModelString(defaultModelStr);
+			const parsedModel = parseModelString(sessionModelStr);
 			if (parsedModel) {
 				const restoredModel = modelRegistry.find(parsedModel.provider, parsedModel.id);
 				if (restoredModel && (await hasModelApiKey(restoredModel))) {
@@ -1021,7 +1021,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				}
 			}
 			if (!model) {
-				modelFallbackMessage = `Could not restore model ${defaultModelStr}`;
+				modelFallbackMessage = `Could not restore model ${sessionModelStr}`;
 			}
 		});
 	}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1015,7 +1015,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	// extensions register below.
 	const sessionModelStrings =
 		!hasExplicitModel && hasExistingSession
-			? getRestorableSessionModels(existingSession.models, sessionManager.getLastModelChangeRole())
+			? getRestorableSessionModels(existingSession.models, sessionManager.getLastRestorableModelChangeRole())
 			: [];
 	let restoredSessionModelIndex = -1;
 	if (!hasExplicitModel && !model && sessionModelStrings.length > 0) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -227,7 +227,7 @@ import type {
 	SessionContext,
 	SessionManager,
 } from "./session-manager";
-import { getLatestCompactionEntry, getRestorableSessionModel } from "./session-manager";
+import { getLatestCompactionEntry, getRestorableSessionModels } from "./session-manager";
 import type { ShakeMode, ShakeResult } from "./shake-types";
 import { ToolChoiceQueue } from "./tool-choice-queue";
 import { YieldQueue } from "./yield-queue";
@@ -8723,31 +8723,34 @@ export class AgentSession {
 			}
 
 			// Restore model if saved
-			const targetModelStr = getRestorableSessionModel(
+			const targetModelStrings = getRestorableSessionModels(
 				sessionContext.models,
 				this.sessionManager.getLastModelChangeRole(),
 			);
-			if (targetModelStr) {
-				const slashIdx = targetModelStr.indexOf("/");
-				if (slashIdx > 0) {
+			if (targetModelStrings.length > 0) {
+				const availableModels = this.#modelRegistry.getAvailable();
+				let match: Model | undefined;
+				for (const targetModelStr of targetModelStrings) {
+					const slashIdx = targetModelStr.indexOf("/");
+					if (slashIdx <= 0) continue;
 					const provider = targetModelStr.slice(0, slashIdx);
 					const modelId = targetModelStr.slice(slashIdx + 1);
-					const availableModels = this.#modelRegistry.getAvailable();
-					const match = availableModels.find(m => m.provider === provider && m.id === modelId);
-					if (match) {
-						const currentModel = this.model;
-						const shouldResetProviderState =
-							switchingToDifferentSession ||
-							(currentModel !== undefined &&
-								(currentModel.provider !== match.provider ||
-									currentModel.id !== match.id ||
-									currentModel.api !== match.api));
-						if (shouldResetProviderState) {
-							this.#setModelWithProviderSessionReset(match);
-						} else {
-							this.agent.setModel(match);
-							this.#syncToolCallBatchCap(match);
-						}
+					match = availableModels.find(m => m.provider === provider && m.id === modelId);
+					if (match) break;
+				}
+				if (match) {
+					const currentModel = this.model;
+					const shouldResetProviderState =
+						switchingToDifferentSession ||
+						(currentModel !== undefined &&
+							(currentModel.provider !== match.provider ||
+								currentModel.id !== match.id ||
+								currentModel.api !== match.api));
+					if (shouldResetProviderState) {
+						this.#setModelWithProviderSessionReset(match);
+					} else {
+						this.agent.setModel(match);
+						this.#syncToolCallBatchCap(match);
 					}
 				}
 			}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -227,7 +227,7 @@ import type {
 	SessionContext,
 	SessionManager,
 } from "./session-manager";
-import { getLatestCompactionEntry } from "./session-manager";
+import { getLatestCompactionEntry, getRestorableSessionModel } from "./session-manager";
 import type { ShakeMode, ShakeResult } from "./shake-types";
 import { ToolChoiceQueue } from "./tool-choice-queue";
 import { YieldQueue } from "./yield-queue";
@@ -8723,12 +8723,15 @@ export class AgentSession {
 			}
 
 			// Restore model if saved
-			const defaultModelStr = sessionContext.models.default;
-			if (defaultModelStr) {
-				const slashIdx = defaultModelStr.indexOf("/");
+			const targetModelStr = getRestorableSessionModel(
+				sessionContext.models,
+				this.sessionManager.getLastModelChangeRole(),
+			);
+			if (targetModelStr) {
+				const slashIdx = targetModelStr.indexOf("/");
 				if (slashIdx > 0) {
-					const provider = defaultModelStr.slice(0, slashIdx);
-					const modelId = defaultModelStr.slice(slashIdx + 1);
+					const provider = targetModelStr.slice(0, slashIdx);
+					const modelId = targetModelStr.slice(slashIdx + 1);
 					const availableModels = this.#modelRegistry.getAvailable();
 					const match = availableModels.find(m => m.provider === provider && m.id === modelId);
 					if (match) {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5251,7 +5251,7 @@ export class AgentSession {
 
 		if (models.length === 0) return undefined;
 
-		const lastRole = this.sessionManager.getLastModelChangeRole();
+		const lastRole = this.sessionManager.getLastRestorableModelChangeRole();
 		let currentIndex = lastRole ? models.findIndex(entry => entry.role === lastRole) : -1;
 		if (currentIndex === -1) {
 			currentIndex = models.findIndex(entry => modelsAreEqual(entry.model, currentModel));
@@ -8725,7 +8725,7 @@ export class AgentSession {
 			// Restore model if saved
 			const targetModelStrings = getRestorableSessionModels(
 				sessionContext.models,
-				this.sessionManager.getLastModelChangeRole(),
+				this.sessionManager.getLastRestorableModelChangeRole(),
 			);
 			if (targetModelStrings.length > 0) {
 				const availableModels = this.#modelRegistry.getAvailable();

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -254,16 +254,20 @@ export interface SessionContext {
 	modeData?: Record<string, unknown>;
 }
 
-/** Selects the model string that should become active when restoring a session. */
-export function getRestorableSessionModel(
+/** Lists session model strings to try when restoring, in fallback order. */
+export function getRestorableSessionModels(
 	models: Readonly<Record<string, string>>,
 	lastModelChangeRole: string | undefined,
-): string | undefined {
-	if (lastModelChangeRole) {
-		const roleModel = models[lastModelChangeRole];
-		if (roleModel) return roleModel;
+): string[] {
+	const defaultModel = models.default;
+	if (!lastModelChangeRole || lastModelChangeRole === "default") {
+		return defaultModel ? [defaultModel] : [];
 	}
-	return models.default;
+
+	const roleModel = models[lastModelChangeRole];
+	if (!roleModel) return defaultModel ? [defaultModel] : [];
+	if (!defaultModel || roleModel === defaultModel) return [roleModel];
+	return [roleModel, defaultModel];
 }
 
 export interface SessionInfo {

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -260,7 +260,7 @@ export function getRestorableSessionModels(
 	lastModelChangeRole: string | undefined,
 ): string[] {
 	const defaultModel = models.default;
-	if (!lastModelChangeRole || lastModelChangeRole === "default") {
+	if (!lastModelChangeRole || lastModelChangeRole === "default" || lastModelChangeRole === "temporary") {
 		return defaultModel ? [defaultModel] : [];
 	}
 

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -254,6 +254,18 @@ export interface SessionContext {
 	modeData?: Record<string, unknown>;
 }
 
+/** Selects the model string that should become active when restoring a session. */
+export function getRestorableSessionModel(
+	models: Readonly<Record<string, string>>,
+	lastModelChangeRole: string | undefined,
+): string | undefined {
+	if (lastModelChangeRole) {
+		const roleModel = models[lastModelChangeRole];
+		if (roleModel) return roleModel;
+	}
+	return models.default;
+}
+
 export interface SessionInfo {
 	path: string;
 	id: string;

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -2977,10 +2977,25 @@ export class SessionManager {
 	 * Returns undefined if no model change has been recorded.
 	 */
 	getLastModelChangeRole(): string | undefined {
+		return this.#getLastModelChangeRole();
+	}
+
+	/**
+	 * Get the most recent non-temporary model role from the current session path.
+	 * Temporary model changes are transient fallbacks and must not be restored.
+	 */
+	getLastRestorableModelChangeRole(): string | undefined {
+		return this.#getLastModelChangeRole({ skipTemporary: true });
+	}
+
+	#getLastModelChangeRole(options?: { skipTemporary?: boolean }): string | undefined {
 		let current = this.getLeafEntry();
 		while (current) {
 			if (current.type === "model_change") {
-				return current.role ?? "default";
+				const role = current.role ?? "default";
+				if (!options?.skipTemporary || role !== "temporary") {
+					return role;
+				}
 			}
 			current = current.parentId ? this.#byId.get(current.parentId) : undefined;
 		}

--- a/packages/coding-agent/test/agent-session-model-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-model-persistence.test.ts
@@ -4,7 +4,7 @@ import { Agent } from "@oh-my-pi/pi-agent-core";
 import { type Api, Effort, getBundledModel, type Model } from "@oh-my-pi/pi-ai";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { createAgentSession, type CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
+import { type CreateAgentSessionResult, createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";

--- a/packages/coding-agent/test/agent-session-model-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-model-persistence.test.ts
@@ -4,7 +4,7 @@ import { Agent } from "@oh-my-pi/pi-agent-core";
 import { type Api, Effort, getBundledModel, type Model } from "@oh-my-pi/pi-ai";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
+import { createAgentSession, type CreateAgentSessionResult } from "@oh-my-pi/pi-coding-agent/sdk";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
@@ -119,6 +119,37 @@ describe("AgentSession model persistence", () => {
 		return { modelRegistry, settings: sessionSettings, session };
 	}
 
+	async function createStartupResumeSession(
+		targetSessionFile: string,
+		settings: Settings = Settings.isolated(),
+	): Promise<CreateAgentSessionResult> {
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), `testauth-${authStorages.length}.db`));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(
+			authStorage,
+			path.join(tempDir.path(), `models-${authStorages.length}.yml`),
+		);
+		const sessionManager = await SessionManager.open(targetSessionFile, path.join(tempDir.path(), "startup"));
+		const result = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			authStorage,
+			modelRegistry,
+			sessionManager,
+			settings,
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+		});
+		session = result.session;
+		return result;
+	}
 	it("switches the active model without persisting by default", async () => {
 		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
 		const nextModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
@@ -246,32 +277,37 @@ describe("AgentSession model persistence", () => {
 		const smolRoleValue = modelValue(smolModel);
 		const targetSessionFile = await writeRoleModelSession(defaultRoleValue, smolRoleValue);
 
-		const authStorage = await AuthStorage.create(path.join(tempDir.path(), `testauth-${authStorages.length}.db`));
-		authStorages.push(authStorage);
-		authStorage.setRuntimeApiKey("anthropic", "test-key");
-		const modelRegistry = new ModelRegistry(
-			authStorage,
-			path.join(tempDir.path(), `models-${authStorages.length}.yml`),
-		);
-		const sessionManager = await SessionManager.open(targetSessionFile, path.join(tempDir.path(), "startup"));
-		const result = await createAgentSession({
-			cwd: tempDir.path(),
-			agentDir: tempDir.path(),
-			authStorage,
-			modelRegistry,
-			sessionManager,
-			settings: Settings.isolated(),
-			disableExtensionDiscovery: true,
-			skills: [],
-			contextFiles: [],
-			promptTemplates: [],
-			slashCommands: [],
-			enableMCP: false,
-			enableLsp: false,
-			skipPythonPreflight: true,
-		});
-		session = result.session;
+		const result = await createStartupResumeSession(targetSessionFile);
 
 		expect(result.session.model?.id).toBe(smolModel.id);
+	});
+
+	it("falls back to the saved default model when switch-session role restore is unavailable", async () => {
+		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const previousModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+		const defaultRoleValue = modelValue(defaultModel);
+		const targetSessionFile = await writeRoleModelSession(defaultRoleValue, "anthropic/not-loaded-anymore");
+
+		const created = await createSession({
+			initialModel: previousModel,
+			modelRoles: { default: defaultRoleValue },
+			persist: true,
+		});
+
+		await expect(created.session.switchSession(targetSessionFile)).resolves.toBe(true);
+		expect(created.session.model?.id).toBe(defaultModel.id);
+	});
+
+	it("falls back to the saved default model when startup role restore is unavailable", async () => {
+		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const settingsFallbackModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+		const defaultRoleValue = modelValue(defaultModel);
+		const targetSessionFile = await writeRoleModelSession(defaultRoleValue, "anthropic/not-loaded-anymore");
+		const settings = Settings.isolated();
+		settings.setModelRole("default", modelValue(settingsFallbackModel));
+
+		const result = await createStartupResumeSession(targetSessionFile, settings);
+
+		expect(result.session.model?.id).toBe(defaultModel.id);
 	});
 });

--- a/packages/coding-agent/test/agent-session-model-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-model-persistence.test.ts
@@ -4,10 +4,10 @@ import { Agent } from "@oh-my-pi/pi-agent-core";
 import { type Api, Effort, getBundledModel, type Model } from "@oh-my-pi/pi-ai";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
-import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 describe("AgentSession model persistence", () => {
@@ -46,7 +46,7 @@ describe("AgentSession model persistence", () => {
 		const timestamp = "2026-06-01T00:00:00.000Z";
 		await Bun.write(
 			targetSessionFile,
-			[
+			`${[
 				{ type: "session", version: 3, id: "target-session", timestamp, cwd: tempDir.path() },
 				{
 					type: "model_change",
@@ -66,7 +66,7 @@ describe("AgentSession model persistence", () => {
 				},
 			]
 				.map(entry => JSON.stringify(entry))
-				.join("\n") + "\n",
+				.join("\n")}\n`,
 		);
 		return targetSessionFile;
 	}

--- a/packages/coding-agent/test/agent-session-model-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-model-persistence.test.ts
@@ -41,7 +41,11 @@ describe("AgentSession model persistence", () => {
 		return `${model.provider}/${model.id}`;
 	}
 
-	async function writeRoleModelSession(defaultRoleValue: string, smolRoleValue: string): Promise<string> {
+	async function writeRoleModelSession(
+		defaultRoleValue: string,
+		smolRoleValue: string,
+		lastRole = "smol",
+	): Promise<string> {
 		const targetSessionFile = path.join(tempDir.path(), `target-${Bun.nanoseconds()}.jsonl`);
 		const timestamp = "2026-06-01T00:00:00.000Z";
 		await Bun.write(
@@ -62,7 +66,7 @@ describe("AgentSession model persistence", () => {
 					parentId: "default-model",
 					timestamp,
 					model: smolRoleValue,
-					role: "smol",
+					role: lastRole,
 				},
 			]
 				.map(entry => JSON.stringify(entry))
@@ -298,6 +302,22 @@ describe("AgentSession model persistence", () => {
 		expect(created.session.model?.id).toBe(defaultModel.id);
 	});
 
+	it("restores the saved default model when switch-session last role is temporary", async () => {
+		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const temporaryModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+		const defaultRoleValue = modelValue(defaultModel);
+		const targetSessionFile = await writeRoleModelSession(defaultRoleValue, modelValue(temporaryModel), "temporary");
+
+		const created = await createSession({
+			initialModel: temporaryModel,
+			modelRoles: { default: defaultRoleValue },
+			persist: true,
+		});
+
+		await expect(created.session.switchSession(targetSessionFile)).resolves.toBe(true);
+		expect(created.session.model?.id).toBe(defaultModel.id);
+	});
+
 	it("falls back to the saved default model when startup role restore is unavailable", async () => {
 		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
 		const settingsFallbackModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
@@ -305,6 +325,19 @@ describe("AgentSession model persistence", () => {
 		const targetSessionFile = await writeRoleModelSession(defaultRoleValue, "anthropic/not-loaded-anymore");
 		const settings = Settings.isolated();
 		settings.setModelRole("default", modelValue(settingsFallbackModel));
+
+		const result = await createStartupResumeSession(targetSessionFile, settings);
+
+		expect(result.session.model?.id).toBe(defaultModel.id);
+	});
+
+	it("restores the saved default model when startup last role is temporary", async () => {
+		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const temporaryModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+		const defaultRoleValue = modelValue(defaultModel);
+		const targetSessionFile = await writeRoleModelSession(defaultRoleValue, modelValue(temporaryModel), "temporary");
+		const settings = Settings.isolated();
+		settings.setModelRole("default", modelValue(temporaryModel));
 
 		const result = await createStartupResumeSession(targetSessionFile, settings);
 

--- a/packages/coding-agent/test/agent-session-model-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-model-persistence.test.ts
@@ -7,6 +7,7 @@ import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
 describe("AgentSession model persistence", () => {
@@ -40,10 +41,40 @@ describe("AgentSession model persistence", () => {
 		return `${model.provider}/${model.id}`;
 	}
 
+	async function writeRoleModelSession(defaultRoleValue: string, smolRoleValue: string): Promise<string> {
+		const targetSessionFile = path.join(tempDir.path(), `target-${Bun.nanoseconds()}.jsonl`);
+		const timestamp = "2026-06-01T00:00:00.000Z";
+		await Bun.write(
+			targetSessionFile,
+			[
+				{ type: "session", version: 3, id: "target-session", timestamp, cwd: tempDir.path() },
+				{
+					type: "model_change",
+					id: "default-model",
+					parentId: null,
+					timestamp,
+					model: defaultRoleValue,
+					role: "default",
+				},
+				{
+					type: "model_change",
+					id: "smol-model",
+					parentId: "default-model",
+					timestamp,
+					model: smolRoleValue,
+					role: "smol",
+				},
+			]
+				.map(entry => JSON.stringify(entry))
+				.join("\n") + "\n",
+		);
+		return targetSessionFile;
+	}
 	async function createSession(options?: {
 		initialModel?: Model<Api>;
 		selectInitialModel?: (availableModels: Model<Api>[]) => Model<Api>;
 		modelRoles?: Record<string, string>;
+		persist?: boolean;
 	}): Promise<{ modelRegistry: ModelRegistry; settings: Settings; session: AgentSession }> {
 		const authStorage = await AuthStorage.create(path.join(tempDir.path(), `testauth-${authStorages.length}.db`));
 		authStorages.push(authStorage);
@@ -78,7 +109,9 @@ describe("AgentSession model persistence", () => {
 		}
 		session = new AgentSession({
 			agent,
-			sessionManager: SessionManager.inMemory(),
+			sessionManager: options?.persist
+				? SessionManager.create(tempDir.path(), path.join(tempDir.path(), `active-${authStorages.length}`))
+				: SessionManager.inMemory(),
 			settings: sessionSettings,
 			modelRegistry,
 		});
@@ -186,5 +219,59 @@ describe("AgentSession model persistence", () => {
 		if (!activeModel) throw new Error("Expected active model after cycleModel");
 		expect(modelValue(activeModel)).toBe(modelValue(result.model));
 		expect(created.settings.getModelRole("default")).toBe(defaultRoleValue);
+	});
+
+	it("restores the last active role model when switching sessions", async () => {
+		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const smolModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+		const defaultRoleValue = modelValue(defaultModel);
+		const smolRoleValue = modelValue(smolModel);
+
+		const targetSessionFile = await writeRoleModelSession(defaultRoleValue, smolRoleValue);
+
+		const created = await createSession({
+			initialModel: defaultModel,
+			modelRoles: { default: defaultRoleValue, smol: smolRoleValue },
+			persist: true,
+		});
+
+		await expect(created.session.switchSession(targetSessionFile)).resolves.toBe(true);
+		expect(created.session.model?.id).toBe(smolModel.id);
+	});
+
+	it("restores the last active role model during startup resume", async () => {
+		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const smolModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+		const defaultRoleValue = modelValue(defaultModel);
+		const smolRoleValue = modelValue(smolModel);
+		const targetSessionFile = await writeRoleModelSession(defaultRoleValue, smolRoleValue);
+
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), `testauth-${authStorages.length}.db`));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(
+			authStorage,
+			path.join(tempDir.path(), `models-${authStorages.length}.yml`),
+		);
+		const sessionManager = await SessionManager.open(targetSessionFile, path.join(tempDir.path(), "startup"));
+		const result = await createAgentSession({
+			cwd: tempDir.path(),
+			agentDir: tempDir.path(),
+			authStorage,
+			modelRegistry,
+			sessionManager,
+			settings: Settings.isolated(),
+			disableExtensionDiscovery: true,
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+		});
+		session = result.session;
+
+		expect(result.session.model?.id).toBe(smolModel.id);
 	});
 });

--- a/packages/coding-agent/test/agent-session-model-persistence.test.ts
+++ b/packages/coding-agent/test/agent-session-model-persistence.test.ts
@@ -45,33 +45,40 @@ describe("AgentSession model persistence", () => {
 		defaultRoleValue: string,
 		smolRoleValue: string,
 		lastRole = "smol",
+		tail?: { model: string; role: string },
 	): Promise<string> {
 		const targetSessionFile = path.join(tempDir.path(), `target-${Bun.nanoseconds()}.jsonl`);
 		const timestamp = "2026-06-01T00:00:00.000Z";
-		await Bun.write(
-			targetSessionFile,
-			`${[
-				{ type: "session", version: 3, id: "target-session", timestamp, cwd: tempDir.path() },
-				{
-					type: "model_change",
-					id: "default-model",
-					parentId: null,
-					timestamp,
-					model: defaultRoleValue,
-					role: "default",
-				},
-				{
-					type: "model_change",
-					id: "smol-model",
-					parentId: "default-model",
-					timestamp,
-					model: smolRoleValue,
-					role: lastRole,
-				},
-			]
-				.map(entry => JSON.stringify(entry))
-				.join("\n")}\n`,
-		);
+		const entries = [
+			{ type: "session", version: 3, id: "target-session", timestamp, cwd: tempDir.path() },
+			{
+				type: "model_change",
+				id: "default-model",
+				parentId: null,
+				timestamp,
+				model: defaultRoleValue,
+				role: "default",
+			},
+			{
+				type: "model_change",
+				id: "smol-model",
+				parentId: "default-model",
+				timestamp,
+				model: smolRoleValue,
+				role: lastRole,
+			},
+		];
+		if (tail) {
+			entries.push({
+				type: "model_change",
+				id: "tail-model",
+				parentId: "smol-model",
+				timestamp,
+				model: tail.model,
+				role: tail.role,
+			});
+		}
+		await Bun.write(targetSessionFile, `${entries.map(entry => JSON.stringify(entry)).join("\n")}\n`);
 		return targetSessionFile;
 	}
 	async function createSession(options?: {
@@ -318,6 +325,26 @@ describe("AgentSession model persistence", () => {
 		expect(created.session.model?.id).toBe(defaultModel.id);
 	});
 
+	it("restores the previous non-temporary role when switch-session tail is temporary", async () => {
+		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const smolModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+		const defaultRoleValue = modelValue(defaultModel);
+		const smolRoleValue = modelValue(smolModel);
+		const targetSessionFile = await writeRoleModelSession(defaultRoleValue, smolRoleValue, "smol", {
+			model: defaultRoleValue,
+			role: "temporary",
+		});
+
+		const created = await createSession({
+			initialModel: defaultModel,
+			modelRoles: { default: defaultRoleValue, smol: smolRoleValue },
+			persist: true,
+		});
+
+		await expect(created.session.switchSession(targetSessionFile)).resolves.toBe(true);
+		expect(created.session.model?.id).toBe(smolModel.id);
+	});
+
 	it("falls back to the saved default model when startup role restore is unavailable", async () => {
 		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
 		const settingsFallbackModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
@@ -342,5 +369,22 @@ describe("AgentSession model persistence", () => {
 		const result = await createStartupResumeSession(targetSessionFile, settings);
 
 		expect(result.session.model?.id).toBe(defaultModel.id);
+	});
+
+	it("restores the previous non-temporary role when startup tail is temporary", async () => {
+		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const smolModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+		const defaultRoleValue = modelValue(defaultModel);
+		const smolRoleValue = modelValue(smolModel);
+		const targetSessionFile = await writeRoleModelSession(defaultRoleValue, smolRoleValue, "smol", {
+			model: defaultRoleValue,
+			role: "temporary",
+		});
+		const settings = Settings.isolated();
+		settings.setModelRole("default", defaultRoleValue);
+
+		const result = await createStartupResumeSession(targetSessionFile, settings);
+
+		expect(result.session.model?.id).toBe(smolModel.id);
 	});
 });

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -214,4 +214,75 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			authStorage.close();
 		}
 	});
+
+	test("restores extension role model when saved default cannot be restored before extensions load", async () => {
+		const settingsDefaultModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!settingsDefaultModel) {
+			throw new Error("Expected bundled anthropic default model");
+		}
+
+		const authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
+		authStorage.setRuntimeApiKey(settingsDefaultModel.provider, "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+
+		// Saved default points at a provider that has no usable credentials. The
+		// last active role (`smol`) is supplied by the inline extension and is
+		// only resolvable once provider registrations are processed.
+		const targetSessionFile = path.join(tempDir, "resume-extension-default-missing.jsonl");
+		const timestamp = "2026-06-01T00:00:00.000Z";
+		await Bun.write(
+			targetSessionFile,
+			`${[
+				{ type: "session", version: 3, id: "resume-ext-no-default", timestamp, cwd: tempDir },
+				{
+					type: "model_change",
+					id: "default-model",
+					parentId: null,
+					timestamp,
+					model: "anthropic/not-available",
+					role: "default",
+				},
+				{
+					type: "model_change",
+					id: "smol-model",
+					parentId: "default-model",
+					timestamp,
+					model: "runtime-provider/runtime-model",
+					role: "smol",
+				},
+			]
+				.map(entry => JSON.stringify(entry))
+				.join("\n")}\n`,
+		);
+		const sessionManager = await SessionManager.open(targetSessionFile, path.join(tempDir, "sessions-no-default"));
+
+		const settings = Settings.isolated();
+		settings.setModelRole("default", `${settingsDefaultModel.provider}/${settingsDefaultModel.id}`);
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			sessionManager,
+			settings,
+			disableExtensionDiscovery: true,
+			extensions: [providerExtension],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+		});
+
+		try {
+			expect(session.model?.provider).toBe("runtime-provider");
+			expect(session.model?.id).toBe("runtime-model");
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
+	});
 });

--- a/packages/coding-agent/test/sdk-model-selection.test.ts
+++ b/packages/coding-agent/test/sdk-model-selection.test.ts
@@ -149,4 +149,69 @@ describe("createAgentSession deferred model pattern resolution", () => {
 			authStorage.close();
 		}
 	});
+
+	test("restores role model from extension provider after startup resume", async () => {
+		const defaultModel = getBundledModel("anthropic", "claude-sonnet-4-5");
+		if (!defaultModel) {
+			throw new Error("Expected bundled anthropic default model");
+		}
+
+		const authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
+		authStorage.setRuntimeApiKey(defaultModel.provider, "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, "models.yml"));
+
+		const targetSessionFile = path.join(tempDir, "resume-extension.jsonl");
+		const timestamp = "2026-06-01T00:00:00.000Z";
+		await Bun.write(
+			targetSessionFile,
+			`${[
+				{ type: "session", version: 3, id: "resume-ext", timestamp, cwd: tempDir },
+				{
+					type: "model_change",
+					id: "default-model",
+					parentId: null,
+					timestamp,
+					model: `${defaultModel.provider}/${defaultModel.id}`,
+					role: "default",
+				},
+				{
+					type: "model_change",
+					id: "smol-model",
+					parentId: "default-model",
+					timestamp,
+					model: "runtime-provider/runtime-model",
+					role: "smol",
+				},
+			]
+				.map(entry => JSON.stringify(entry))
+				.join("\n")}\n`,
+		);
+		const sessionManager = await SessionManager.open(targetSessionFile, path.join(tempDir, "sessions"));
+
+		const { session } = await createAgentSession({
+			cwd: tempDir,
+			agentDir: tempDir,
+			authStorage,
+			modelRegistry,
+			sessionManager,
+			settings: Settings.isolated(),
+			disableExtensionDiscovery: true,
+			extensions: [providerExtension],
+			skills: [],
+			contextFiles: [],
+			promptTemplates: [],
+			slashCommands: [],
+			enableMCP: false,
+			enableLsp: false,
+			skipPythonPreflight: true,
+		});
+
+		try {
+			expect(session.model?.provider).toBe("runtime-provider");
+			expect(session.model?.id).toBe("runtime-model");
+		} finally {
+			await session.dispose();
+			authStorage.close();
+		}
+	});
 });


### PR DESCRIPTION
## Repro
A focused regression test writes a session with `model_change` entries for `default` followed by `smol`, then resumes it through `AgentSession.switchSession()`. Before the fix, `bun test packages/coding-agent/test/agent-session-model-persistence.test.ts -t "restores the last active role model when switching sessions"` failed with `Expected: "claude-sonnet-4-6"` and `Received: "claude-sonnet-4-5"`.

## Cause
`AgentSession.switchSession()` in `packages/coding-agent/src/session/agent-session.ts` and startup resume in `packages/coding-agent/src/sdk.ts` restored only `sessionContext.models.default`. `SessionManager.buildSessionContext()` preserved role-scoped model changes, and `getLastModelChangeRole()` identified the active role, but neither restore path used that role when selecting the model to activate.

## Fix
- Added `getRestorableSessionModel()` in `packages/coding-agent/src/session/session-manager.ts` to select the last active role model with a default-role fallback.
- Updated `AgentSession.switchSession()` to restore that selected model.
- Updated `createAgentSession()` startup restore to use the same selection logic.
- Added regression coverage for both `/resume`/`switchSession()` and startup resume.

## Verification
Ran `bun test packages/coding-agent/test/agent-session-model-persistence.test.ts` (7 pass) and `bun run check:types` in `packages/coding-agent`. `gh_push_branch` completed the pre-publish gate and pushed the branch. Fixes #1649