### PR TITLE
fix(tui): removed 20-result hard cap on @-file fuzzy completion

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed the hard-coded 20-result cap on `@`-prefixed fuzzy file completion in `CombinedAutocompleteProvider.#getFuzzyFileSuggestions`. The dropdown now honors the existing `maxResults: 100` ceiling already configured for `fuzzyFind`, so projects with many files sharing a common stem (e.g. `@controller`, `@test`) surface all relevant matches instead of being silently truncated. ([#1652](https://github.com/can1357/oh-my-pi/issues/1652))
+
 ## [15.7.5] - 2026-06-01
 
 ### Fixed

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -736,7 +736,9 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				}
 				return lowerQuery.length === 0 || fuzzyMatch(lowerQuery, normalized.toLowerCase());
 			});
-			const topEntries = filteredMatches.slice(0, 20);
+			// `fuzzyFind` is already capped via `maxResults` in
+			// `buildAutocompleteFuzzyDiscoveryProfile`; no extra slice here.
+			const topEntries = filteredMatches;
 			const suggestions: AutocompleteItem[] = [];
 			for (const { path: entryPath, isDirectory } of topEntries) {
 				const pathWithoutSlash = isDirectory ? entryPath.slice(0, -1) : entryPath;

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -98,6 +98,23 @@ describe("CombinedAutocompleteProvider", () => {
 			expect(values).toContain("@.github/");
 			expect(values.some(value => value === "@.git" || value.startsWith("@.git/"))).toBe(false);
 		});
+
+		it("returns more than 20 fuzzy matches when the project contains them", async () => {
+			// Regression: previously hard-capped at 20 by `slice(0, 20)`.
+			const total = 30;
+			for (let i = 0; i < total; i += 1) {
+				fs.writeFileSync(path.join(baseDir, `controller-${i}.ts`), "export {};\n");
+			}
+
+			const provider = new CombinedAutocompleteProvider([], baseDir);
+			const line = "@controller";
+			const result = await provider.getSuggestions([line], 0, line.length);
+
+			expect(result).not.toBeNull();
+			const values = result?.items.map(item => item.value) ?? [];
+			expect(values.length).toBeGreaterThan(20);
+			expect(values.length).toBeGreaterThanOrEqual(total);
+		});
 	});
 
 	describe("@ paths outside cwd", () => {


### PR DESCRIPTION
## Repro

In a project containing more than 20 files sharing a common name stem, typing `@<stem>` into the prompt editor shows at most 20 suggestions even when many more match. The correct file may never appear in the dropdown. Added a regression test that creates 30 `controller-N.ts` files, types `@controller`, and asserts more than 20 suggestions are returned:

```
bun test packages/tui/test/autocomplete.test.ts -t "more than 20 fuzzy matches"
```

## Cause

`CombinedAutocompleteProvider.#getFuzzyFileSuggestions` in `packages/tui/src/autocomplete.ts:739` post-truncated the fuzzy match list with `filteredMatches.slice(0, 20)`. The upstream `fuzzyFind` call already runs with `maxResults: 100` (see `buildAutocompleteFuzzyDiscoveryProfile`), so the inner slice was a redundant cap that silently hid correct results. The sibling direct-prefix path (`#getFileSuggestions`) has no such cap, leaving the two completion modes inconsistent.

## Fix

- `packages/tui/src/autocomplete.ts` — dropped the `.slice(0, 20)`; the natural `maxResults: 100` ceiling now applies.
- `packages/tui/test/autocomplete.test.ts` — added a regression test that creates 30 matching files and asserts the suggestion list exceeds 20 entries.
- `packages/tui/CHANGELOG.md` — `Unreleased / Fixed` entry.

## Verification

`bun test packages/tui/test/autocomplete.test.ts` → 20 pass, 0 fail (43 assertions). The new `returns more than 20 fuzzy matches when the project contains them` case fails on `main` and passes after the slice removal.

Fixes #1652