### PR TITLE
fix(tui): repaint visible window when native viewport probe is unknown

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed native Windows + Windows Terminal freezing the editor on the wrap keystroke, on `/plan`/`/resume`/model-switch/status-line toggles, and on any other offscreen structural mutation until the next prompt submit. The `15.7.5` `#1635` fix routed every viewport-saturating pure-append and structural mutation through `deferredMutation` (a literal no-op) whenever `isNativeViewportAtBottom()` returned `undefined` — which it always does under `WT_SESSION` because the kernel32 probe can't see WT host scrollback. The deferral was only ever meant for the *confirmed-scrolled* case; an unknown viewport now falls back to a non-destructive `viewportRepaint` instead, so the live UI keeps updating without emitting `\x1b[3J` and without yanking a possibly-scrolled reader. Confirmed-scrolled frames (probe returns `false`) still defer.
+
 ## [15.7.5] - 2026-06-01
 
 ### Fixed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1439,14 +1439,32 @@ export class TUI extends Container {
 			const nativeViewportAtBottom = this.#readNativeViewportAtBottom();
 			if (this.#nativeViewportIsScrolled(nativeViewportAtBottom, allowUnknownViewportMutation)) {
 				this.#markNativeScrollbackDirty();
-				return { kind: "deferredMutation" };
+				// Confirmed scrolled (probe returned `false`): the reader is parked in
+				// scrollback and writing the live frame is wasted bytes — defer until
+				// the next checkpoint reconciles. Unknown viewport (e.g. native Windows
+				// Terminal where the probe cannot see WT host scrollback) is a
+				// different case: a no-op there freezes the editor on the keystroke
+				// that grows `lines.length` past the viewport (the wrap keystroke).
+				// Fall through to a non-destructive viewport repaint instead so the
+				// live UI keeps updating without yanking a possibly-scrolled reader.
+				if (this.#nativeViewportIsKnownScrolled(nativeViewportAtBottom)) {
+					return { kind: "deferredMutation" };
+				}
+				return { kind: "viewportRepaint" };
 			}
 		}
 		if (!pureAppend && structuralMutation && !isMultiplexerSession()) {
 			const nativeViewportAtBottom = this.#readNativeViewportAtBottom();
 			if (this.#nativeViewportIsScrolled(nativeViewportAtBottom, allowUnknownViewportMutation)) {
 				this.#markNativeScrollbackDirty();
-				return { kind: "deferredMutation" };
+				// See the matching comment on the pure-append branch above: confirmed
+				// scrolled stays a no-op; unknown viewport repaints the visible window
+				// so slash-command transitions and offscreen chrome edits paint on the
+				// same frame instead of stalling until the next prompt submit.
+				if (this.#nativeViewportIsKnownScrolled(nativeViewportAtBottom)) {
+					return { kind: "deferredMutation" };
+				}
+				return { kind: "viewportRepaint" };
 			}
 			// The append-tail path can only scroll a clean pure-tail append over an
 			// offscreen edit into history: the rows it pushes must equal the net
@@ -1619,6 +1637,10 @@ export class TUI extends Container {
 			nativeViewportAtBottom === false ||
 			(nativeViewportAtBottom === undefined && process.platform === "win32" && !allowUnknownViewportMutation)
 		);
+	}
+
+	#nativeViewportIsKnownScrolled(nativeViewportAtBottom: boolean | undefined): boolean {
+		return nativeViewportAtBottom === false;
 	}
 
 	#nativeViewportIsAtBottom(nativeViewportAtBottom: boolean | undefined): boolean {

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -1849,6 +1849,176 @@ describe("TUI terminal-state regressions", () => {
 			}
 		});
 
+		it("paints a viewport-saturating pure-append on native Windows Terminal (no \\x1b[3J)", async () => {
+			// Regression: under `WT_SESSION` on native Windows the kernel32 probe is
+			// suppressed and `isNativeViewportAtBottom()` returns `undefined`. The
+			// `15.7.5` #1635 fix routed pure-append-over-saturated-viewport frames to
+			// `deferredMutation` here, which is a literal no-op. That froze the editor
+			// on the very keystroke that grows `lines.length` past the viewport (the
+			// wrap keystroke) until the next prompt-submit checkpoint flushed.
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+			try {
+				await withEnvPatch(
+					{ WT_SESSION: "wt-test", TMUX: undefined, STY: undefined, ZELLIJ: undefined },
+					async () => {
+						const term = new UnknownViewportTerminal(32, 5);
+						const tui = new TUI(term);
+						// Five-row transcript + one editor row saturates the viewport (height = 5).
+						// The user is at the tail — no scroll — but the probe still answers `undefined`.
+						const transcript = new MutableLinesComponent(rows("seed-", 5));
+						const editor = new MutableLinesComponent(["prompt> a"]);
+						tui.addChild(transcript);
+						tui.addChild(editor);
+
+						try {
+							tui.start();
+							await settle(term);
+
+							const writes: string[] = [];
+							const realWrite = term.write.bind(term);
+							(term as unknown as { write: (s: string) => void }).write = (data: string) => {
+								writes.push(data);
+								realWrite(data);
+							};
+
+							// The wrap keystroke: editor grows from one to two visual rows. This is a
+							// pure append (`firstChanged === previousLines.length`, content grew) over
+							// a viewport already at capacity — exactly the branch that used to defer.
+							editor.setLines(["prompt> a", "wrap-row"]);
+							tui.requestRender();
+							await settle(term);
+
+							// The #1635 anti-yank guarantee must survive: no destructive scrollback erase.
+							expect(writes.join("")).not.toContain("\x1b[3J");
+							// The wrap row paints in the same frame — viewportRepaint is non-destructive
+							// but writes the visible window, so the editor's new visual row is on screen.
+							expect(visible(term).map(line => line.trim())).toContain("wrap-row");
+							// And the deferred-cleanup checkpoint is queued for the next prompt submit.
+							expect(tui.refreshNativeScrollbackIfDirty({ allowUnknownViewport: true })).toBe(true);
+						} finally {
+							tui.stop();
+						}
+					},
+				);
+			} finally {
+				Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+			}
+		});
+
+		it("paints a slash-command-shaped structural mutation on native Windows Terminal (no \\x1b[3J)", async () => {
+			// Sibling regression: `/plan`, `/resume`, model switches, role-badge flips,
+			// status-line toggles — any structural offscreen mutation — also routed to
+			// `deferredMutation` under WT, so the toggle never painted until the next
+			// checkpoint. After the fix the planner falls back to `viewportRepaint`
+			// instead, painting the visible window without emitting `\x1b[3J`.
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+			try {
+				await withEnvPatch(
+					{ WT_SESSION: "wt-test", TMUX: undefined, STY: undefined, ZELLIJ: undefined },
+					async () => {
+						const term = new UnknownViewportTerminal(32, 5);
+						const tui = new TUI(term);
+						// Transcript + status + prompt; total six rows over a five-row viewport.
+						const transcript = new MutableLinesComponent(rows("seed-", 4));
+						const status = new MutableLinesComponent(["STATUS-OLD"]);
+						const prompt = new MutableLinesComponent(["prompt>"]);
+						tui.addChild(transcript);
+						tui.addChild(status);
+						tui.addChild(prompt);
+
+						try {
+							tui.start();
+							await settle(term);
+
+							const writes: string[] = [];
+							const realWrite = term.write.bind(term);
+							(term as unknown as { write: (s: string) => void }).write = (data: string) => {
+								writes.push(data);
+								realWrite(data);
+							};
+
+							// Slash-command toggle: an existing offscreen row flips its content and a
+							// new chrome row is inserted. firstChanged lands above the viewport top,
+							// length grew by one — a structural mutation, not a pure append.
+							status.setLines(["STATUS-NEW", "EXTRA"]);
+							tui.requestRender();
+							await settle(term);
+
+							expect(writes.join("")).not.toContain("\x1b[3J");
+							const view = visible(term).map(line => line.trim());
+							expect(view).toContain("STATUS-NEW");
+							expect(view).toContain("EXTRA");
+							expect(tui.refreshNativeScrollbackIfDirty({ allowUnknownViewport: true })).toBe(true);
+						} finally {
+							tui.stop();
+						}
+					},
+				);
+			} finally {
+				Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+			}
+		});
+
+		it("still defers when the native viewport probe confirms a scrolled-up reader", async () => {
+			// Counterpart to the two paints above: when the probe is *reliable* and reports
+			// `false`, the reader is parked in scrollback and a live-frame write is wasted.
+			// `deferredMutation` (a no-op) must stay in place so the next checkpoint can
+			// reconcile cleanly, and no bytes hit the terminal during the deferred frame.
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, "platform", { configurable: true, value: "win32" });
+			try {
+				await withEnvPatch(
+					{ WT_SESSION: undefined, TMUX: undefined, STY: undefined, ZELLIJ: undefined },
+					async () => {
+						const term = new VirtualTerminal(32, 5);
+						const tui = new TUI(term);
+						const transcript = new MutableLinesComponent(rows("seed-", 5));
+						const status = new MutableLinesComponent(["STATUS-OLD"]);
+						const prompt = new MutableLinesComponent(["prompt>"]);
+						tui.addChild(transcript);
+						tui.addChild(status);
+						tui.addChild(prompt);
+
+						try {
+							tui.start();
+							await settle(term);
+
+							// Pin the probe to a confirmed-scrolled answer (host reports `false`).
+							(term as unknown as { isNativeViewportAtBottom: () => boolean }).isNativeViewportAtBottom = () =>
+								false;
+
+							const writes: string[] = [];
+							const realWrite = term.write.bind(term);
+							(term as unknown as { write: (s: string) => void }).write = (data: string) => {
+								writes.push(data);
+								realWrite(data);
+							};
+
+							// Same structural mutation as the slash-command test — but with the probe
+							// telling us the user can't see the live frame, the planner stays a no-op.
+							status.setLines(["STATUS-NEW", "EXTRA"]);
+							tui.requestRender();
+							await settle(term);
+
+							// Zero bytes written — the deferral is intentional and protects the reader.
+							expect(writes.join("")).toBe("");
+							// Scrollback was marked dirty by the deferral; once the reader returns to
+							// the tail (probe reports `true`) the next checkpoint reconciles cleanly.
+							(term as unknown as { isNativeViewportAtBottom: () => boolean }).isNativeViewportAtBottom = () =>
+								true;
+							expect(tui.refreshNativeScrollbackIfDirty()).toBe(true);
+						} finally {
+							tui.stop();
+						}
+					},
+				);
+			} finally {
+				Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+			}
+		});
+
 		it("refreshes deferred native scrollback when the native viewport reaches bottom", async () => {
 			const term = new VirtualTerminal(32, 5);
 			const tui = new TUI(term);


### PR DESCRIPTION
## What

`#planRender` now returns `viewportRepaint` (non-destructive, no `\x1b[3J`) when an offscreen mutation lands and the native viewport probe is *unknown*. The deferral (`deferredMutation`) is preserved for the *confirmed-scrolled* case where the probe answers `false`.

## Why

Fixes #1643.

#1636 suppressed the kernel32 viewport probe under `WT_SESSION` so `isNativeViewportAtBottom()` returns `undefined` on native Windows Terminal. The two `deferredMutation` gates inside `#planRender` (pure-append over a saturated viewport; structural mutation above the fold) treat `undefined` the same as `false` on win32, so every wrap keystroke, every `/plan`/`/resume` toggle, every status-line flip — anything that mutates an offscreen row — became a zero-byte frame. The screen stayed frozen until the next prompt submit ran `refreshNativeScrollbackIfDirty({ allowUnknownViewport: true })`.

The deferral was only meaningful for the confirmed-scrolled case: writing a live frame to a reader parked in scrollback is wasted bytes. For an unknown viewport a destructive rebuild is unsafe (the #1635 anti-yank guarantee), but a `viewportRepaint` is not — it writes the visible window in place (no `\x1b[3J`, no growth into native scrollback), so a possibly-scrolled WT reader is not yanked and the live UI keeps updating. This mirrors the parallel `deferredShrink` precedent at `tui.ts:1348-1350` where an unknown-viewport shrink that fits in the viewport already falls back to `viewportRepaint`.

Alternative to #1645. That PR modifies `#nativeViewportIsScrolled` so `undefined` + `WT_SESSION` is reported as "not scrolled," which triggered the two Codex review notes on its diff (shrink-path destructive clear, bare-Windows unknown losing protection). This PR leaves `#nativeViewportIsScrolled` and the shrink branch alone; the only change is at the two `deferredMutation` gates, and the new `#nativeViewportIsKnownScrolled(x) => x === false` predicate makes the intent explicit at the call site.

## Testing

`packages/tui/test/render-regressions.test.ts` gains three tests under `scrollback integrity`:

- `paints a viewport-saturating pure-append on native Windows Terminal (no \x1b[3J)` — `process.platform = "win32"` + `WT_SESSION` + unknown probe; transcript saturates the viewport and the editor grows by one row (the wrap keystroke). The wrap row paints and `\x1b[3J` is not emitted.
- `paints a slash-command-shaped structural mutation on native Windows Terminal (no \x1b[3J)` — same setup, but a status row flips its content and inserts an additional row. Both new rows are in the visible frame on the same render; no `\x1b[3J`.
- `still defers when the native viewport probe confirms a scrolled-up reader` — probe pinned to `false`, structural mutation runs. Zero bytes are written; once the probe transitions back to `true`, `refreshNativeScrollbackIfDirty()` returns `true`, confirming the dirty flag was set so the next checkpoint reconciles.

Run targets that all stay green:

- `bun test render-regressions.test.ts -t "native"` → 12 pass (3 new + 9 existing native-related)
- `bun test issue-1635-repro.test.ts` → 8 pass
- `bun test slash-autocomplete-viewport.test.ts` → 2 pass
- `bun test render-stress.test.ts` → 9 pass
- `bun check:ts` and `bun lint:ts` clean across all 14 workspaces

Full `packages/tui` suite: 463 pass, 4 fail. All four failures are pre-existing on the Windows host (verified by stashing the diff and re-running): two `rebuilds history when …` shrink tests assume POSIX semantics (on win32 they take the `deferredShrink` branch and render padded blanks), and two `@ paths outside cwd` autocomplete tests assume POSIX path separators.

Manual smoke on native Windows Terminal (planned per the original repro in #1643): overflow the viewport, type a wrapping prompt, issue `/plan` — the wrap row and the mode toggle paint on the same frame instead of stalling until the next prompt submit.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated

Closes #1643
