### PR TITLE
Engage harmony leak detection on the committed assistant message

### DIFF
--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -959,6 +959,10 @@ async function streamAssistantResponse(
 			if (harmonyMitigationEnabled) {
 				const detection = detectHarmonyLeakInAssistantMessage(trailing);
 				if (detection) {
+					if (addedPartial) {
+						context.messages.pop();
+						addedPartial = false;
+					}
 					throw new HarmonyLeakInterruption(detection, extractHarmonyRemoved(trailing, detection));
 				}
 			}

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -17,6 +17,8 @@ import {
 import { sanitizeText } from "@oh-my-pi/pi-utils";
 import {
 	createHarmonyAuditEvent,
+	detectHarmonyLeakInAssistantMessage,
+	extractHarmonyRemoved,
 	type HarmonyDetection,
 	type HarmonyRecoveredToolCall,
 	isHarmonyLeakMitigationTarget,
@@ -924,6 +926,17 @@ async function streamAssistantResponse(
 						case "done":
 						case "error": {
 							const finalMessage = await response.result();
+							if (harmonyMitigationEnabled) {
+								const detection = detectHarmonyLeakInAssistantMessage(finalMessage);
+								if (detection) {
+									const removed = extractHarmonyRemoved(finalMessage, detection);
+									if (addedPartial) {
+										context.messages.pop();
+										addedPartial = false;
+									}
+									throw new HarmonyLeakInterruption(detection, removed);
+								}
+							}
 							if (addedPartial) {
 								context.messages[context.messages.length - 1] = finalMessage;
 							} else {
@@ -943,6 +956,12 @@ async function streamAssistantResponse(
 			}
 
 			const trailing = await response.result();
+			if (harmonyMitigationEnabled) {
+				const detection = detectHarmonyLeakInAssistantMessage(trailing);
+				if (detection) {
+					throw new HarmonyLeakInterruption(detection, extractHarmonyRemoved(trailing, detection));
+				}
+			}
 			await finishChat(trailing);
 			return trailing;
 		});

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -56,6 +56,37 @@ describe("agentLoop with AgentMessage", () => {
 		expect(eventTypes).toContain("agent_end");
 	});
 
+	it("retries when harmony leakage reaches the committed assistant message (openai-codex)", async () => {
+		const context: AgentContext = {
+			systemPrompt: ["You are helpful."],
+			messages: [],
+			tools: [],
+		};
+		// First response leaks a harmony payload as visible assistant text; the
+		// retry is clean. Mitigation only engages for openai-codex.
+		const leak = "Some prose. analysis to=functions.edit code 大发官网";
+		const mock = createMockModel({
+			provider: "openai-codex",
+			responses: [{ content: [leak] }, { content: ["clean retry response"] }],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("Hello")], context, config, undefined, mock.stream);
+		for await (const event of stream) {
+			events.push(event);
+		}
+		const messages = await stream.result();
+
+		// The leaked attempt was retried, not committed.
+		expect(mock.calls).toHaveLength(2);
+		expect(messages).toHaveLength(2);
+		const final = messages[1];
+		if (final.role !== "assistant") throw new Error("expected assistant message");
+		expect(final.content).toEqual([{ type: "text", text: "clean retry response" }]);
+		expect(JSON.stringify(messages)).not.toContain("to=functions.");
+	});
+
 	it("emits an aborted assistant message when cancellation happens before provider events", async () => {
 		const context: AgentContext = {
 			systemPrompt: ["You are helpful."],


### PR DESCRIPTION
## What I noticed

While debugging a case where the model printed a `to=functions.*` payload as plain text instead of doing a real tool call, i went looking for where the harmony mitigation actually runs. The machinery is all there in `packages/agent`:

- `HarmonyLeakInterruption` + the `runLoop` catch block (abort-retry / truncate-resume, escalate after 2, audit events)
- `harmonyAbortController`, the retry temperature bump
- `detectHarmonyLeakInAssistantMessage`, `extractHarmonyRemoved`, `recoverHarmonyToolCall`

But as far as i can tell, in the current tree nothing in the agent loop ever *calls* `detectHarmonyLeakInAssistantMessage` on a real response — it's only exercised from the tests. So the detector + retry path is wired up but never triggered in production, which means a leak in the final response just gets committed as-is.

## What this PR does

Calls `detectHarmonyLeakInAssistantMessage` on the assistant message right before it's committed (both the streamed `done`/`error` branch and the trailing fallback). On detection it throws `HarmonyLeakInterruption`, which the existing `runLoop` machinery already knows how to handle (abort-and-retry, escalate, audit). The contaminated partial is popped from `context.messages` first so the retry starts clean.

Gating is unchanged — still `isHarmonyLeakMitigationTarget` (openai-codex only), so this is a no-op for every other provider.

Added a regression test: an openai-codex mock that leaks on the first response and is clean on the retry. It asserts the loop retried (2 model calls) and the committed message is the clean one with no `to=functions.` left behind.

```
bun test packages/agent/test/agent-loop.test.ts packages/agent/test/harmony-leak.test.ts   # 49 pass
bun run --cwd packages/agent check:types
```

## Questions for you (you probably know better here)

1. Is the committed-message point the integration spot you intended, or is detection supposed to run somewhere else (provider stream layer / coding-agent session) and i'm just missing it? Didn't want to second-guess the architecture.
2. Why is mitigation gated to `openai-codex` only? My guess is it's deliberate — the detector is heuristic (marker + channel word + non-latin script), and only codex actually emits these leaks, so turning it on for other providers would only add false positives with no upside. Is that the reasoning, or would broadening it be welcome?
3. Related false-positive i hit: when an assistant *legitimately* authors content that contains `to=functions.X` next to a channel word / CJK (for example editing the harmony fixtures or this very test file), the `tool_arg` path detects it and the turn keeps retrying then escalates. Would you want to guard that — e.g. require the trailing-garbage `T` signal (marker after the structurally-valid args) for `tool_arg`, so embedded file content doesn't trip — or do you consider that out of scope?

Happy to adjust or split this however you prefer.