### PR TITLE
fix(ai): use bearer auth for OpenCode Anthropic models

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenCode Go Anthropic-format models such as `qwen3.7-max` sending Anthropic `X-Api-Key` auth alongside the OpenCode bearer token, avoiding spurious Alibaba `401 Invalid API-key provided` errors. ([#1661](https://github.com/can1357/oh-my-pi/issues/1661))
+
 ## [15.7.5] - 2026-06-01
 
 ### Added

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1768,6 +1768,23 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		};
 	}
 
+	// OpenCode's Anthropic-compatible gateway accepts bearer auth only; leaving
+	// apiKey set lets the SDK add X-Api-Key, which upstream Alibaba rejects.
+	if (model.provider === "opencode-go" || model.provider === "opencode-zen") {
+		return {
+			isOAuthToken: false,
+			apiKey: null,
+			authToken: null,
+			baseURL: baseUrl,
+			maxRetries: 5,
+			dangerouslyAllowBrowser: true,
+			defaultHeaders,
+			logLevel: ANTHROPIC_SDK_LOG_LEVEL,
+			...(debugFetch ? { fetch: debugFetch } : {}),
+			...(tlsFetchOptions ? { fetchOptions: tlsFetchOptions } : {}),
+		};
+	}
+
 	return {
 		isOAuthToken: oauthToken,
 		apiKey: oauthToken ? null : apiKey,

--- a/packages/ai/test/github-copilot-anthropic-auth.test.ts
+++ b/packages/ai/test/github-copilot-anthropic-auth.test.ts
@@ -26,6 +26,20 @@ function makeCopilotClaudeModel(): Model<"anthropic-messages"> {
 		maxTokens: 16000,
 	};
 }
+function makeOpenCodeGoQwen37Model(): Model<"anthropic-messages"> {
+	return {
+		id: "qwen3.7-max",
+		name: "Qwen3.7 Max",
+		api: "anthropic-messages",
+		provider: "opencode-go",
+		baseUrl: "https://opencode.ai/zen/go",
+		reasoning: true,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 1_000_000,
+		maxTokens: 65_536,
+	};
+}
 
 const testContext: Context = {
 	messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
@@ -58,6 +72,22 @@ describe("Anthropic Copilot auth config", () => {
 		});
 
 		expect(options.apiKey).toBeNull();
+		expect(options.defaultHeaders.Authorization).toBe(`Bearer ${token}`);
+	});
+
+	it("uses bearer-only auth for OpenCode Go Anthropic models", () => {
+		const model = makeOpenCodeGoQwen37Model();
+		const token = "opencode_test_key";
+		const options = buildAnthropicClientOptions({
+			model,
+			apiKey: token,
+			extraBetas: [],
+			stream: true,
+			dynamicHeaders: {},
+		});
+
+		expect(options.apiKey).toBeNull();
+		expect(options.authToken).toBeNull();
 		expect(options.defaultHeaders.Authorization).toBe(`Bearer ${token}`);
 	});
 


### PR DESCRIPTION
## Repro
Selecting `opencode-go/qwen3.7-max` uses the Anthropic Messages transport; before the fix, `bun test packages/ai/test/github-copilot-anthropic-auth.test.ts` failed because `buildAnthropicClientOptions()` kept `apiKey` set for that OpenCode model, allowing the Anthropic SDK to add `X-Api-Key` alongside the OpenCode bearer token.

## Cause
`packages/ai/src/providers/anthropic.ts` only used bearer-only Anthropic client configuration for GitHub Copilot and Cloudflare AI Gateway. OpenCode Go/Zen Anthropic-format models fell through to the generic Anthropic client options, so the SDK could emit Anthropic API-key auth against `https://opencode.ai/zen/go`, which OpenCode forwards to Alibaba for Qwen and surfaces as `401 Invalid API-key provided`.

## Fix
- Return bearer-only Anthropic client options for `opencode-go` and `opencode-zen` models, clearing SDK `apiKey` and `authToken` while preserving the explicit `Authorization: Bearer` header.
- Added regression coverage for `opencode-go/qwen3.7-max` auth configuration.
- Documented the fix in `packages/ai/CHANGELOG.md`.

## Verification
Passed: `bun test packages/ai/test/github-copilot-anthropic-auth.test.ts packages/ai/test/issue-887-repro.test.ts`; passed: `bun run check` in `packages/ai`. Fixes #1661