### PR TITLE
fix(cli): gracefully exit when user declines to fork session from another project

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -412,7 +412,7 @@ async function createSessionManager(
 			if (normalizedCwd !== normalizedMatchCwd) {
 				const shouldFork = await promptForkSession(match.session);
 				if (!shouldFork) {
-					throw new Error(`Session "${sessionArg}" is in another project (${match.session.cwd}).`);
+					return undefined;
 				}
 				return await SessionManager.forkFrom(match.session.path, cwd, parsed.sessionDir);
 			}
@@ -852,7 +852,12 @@ export async function runRootCommand(
 		cwd,
 		settingsInstance,
 	);
-
+	// User declined to fork a session from another project — exit gracefully
+	if (typeof parsedArgs.resume === "string" && !sessionManager) {
+		process.stdout.write(`${chalk.dim(`Resume cancelled: session is in another project.`)}
+`);
+		return;
+	}
 	// Handle --resume (no value): show session picker
 	if (parsedArgs.resume === true && !parsedArgs.fork) {
 		const sessions = await logger.time("SessionManager.list", SessionManager.list, cwd, parsedArgs.sessionDir);


### PR DESCRIPTION
## Problem

When `omp --resume <session-id>` targets a session in a different project directory, the CLI prompts:

```
Session found in different project: C:\tmp. Fork into current directory? [y/N]
```

If the user answers **n**, the previous code threw an uncaught `Error` that bubbled up as an ugly stack trace:

```
[Uncaught Exception] Error: Session "019e84ed-b4cc-7000-9c87-5afe6df992c1" is in another project (C:\tmp).
    at createSessionManager (…/main.ts:407:16)
    at processTicksAndRejections (native:7:39)
```

## Fix

- **`createSessionManager`**: Return `undefined` instead of throwing when the user declines to fork.
- **`runRootCommand`**: Check if `parsedArgs.resume` is a string but `sessionManager` is `undefined`, then print a dimmed message and return cleanly:

```
Resume cancelled: session is in another project.
```

This matches the existing graceful-exit pattern already used for "No sessions found" and "No session selected" in the picker UI path.

## Changes

- `packages/coding-agent/src/main.ts` — 2 lines changed, 7 insertions