### PR TITLE
fix(config): remove trailing spaces from config yaml

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Fixed `config.yml` saves leaving a trailing space after object-valued root keys such as `theme:` and `modelRoles:` ([#1670](https://github.com/can1357/oh-my-pi/issues/1670)).
+
 - Fixed a module-load crash (`ReferenceError: Cannot access 'evalToolRenderer' before initialization`) triggered whenever `tools/eval` was imported before `tools/renderers`. The eval JS backend statically pulls the agent/task/sdk/extension chain, which re-enters the root barrel → `modes/components` → `tool-execution` → `renderers` while `eval.ts` was still initializing, so `renderers.ts` read `evalToolRenderer` in its TDZ. The eval TUI renderer is now split into a dependency-light `tools/eval-render.ts` that `renderers.ts` imports directly (decoupling pure rendering from the eval runtime); `eval.ts` re-exports `evalToolRenderer`/`EVAL_DEFAULT_PREVIEW_LINES` for compatibility.
 
 ## [15.7.6] - 2026-06-01

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -99,7 +99,12 @@ function setByPath(obj: RawSettings, segments: string[], value: unknown): void {
 	current[segments[segments.length - 1]] = value;
 }
 
+function stringifySettingsYaml(value: RawSettings): string {
+	return YAML.stringify(value, null, 2).replaceAll(": \n", ":\n");
+}
+
 const PATH_SCOPED_ARRAY_SETTINGS = new Set<SettingPath>(["enabledModels", "disabledProviders"]);
+
 type PathScopedStringArrayEntry = {
 	path?: unknown;
 	paths?: unknown;
@@ -582,7 +587,7 @@ export class Settings {
 		// 3. Write merged settings
 		if (migrated && Object.keys(settings).length > 0) {
 			try {
-				await Bun.write(this.#configPath, YAML.stringify(settings, null, 2));
+				await Bun.write(this.#configPath, stringifySettingsYaml(settings));
 				logger.debug("Settings: migrated to config.yml", { path: this.#configPath });
 			} catch {}
 		}
@@ -786,7 +791,7 @@ export class Settings {
 
 				// Update our global with any external changes we preserved
 				this.#global = current;
-				await Bun.write(configPath, YAML.stringify(this.#global, null, 2));
+				await Bun.write(configPath, stringifySettingsYaml(this.#global));
 			});
 		} catch (error) {
 			logger.warn("Settings: save failed", { error: String(error) });

--- a/packages/coding-agent/test/settings-save.test.ts
+++ b/packages/coding-agent/test/settings-save.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resetSettingsForTest, Settings } from "../src/config/settings";
+
+const tempDirs: string[] = [];
+
+async function makeTempDir(): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-settings-save-test-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(async () => {
+	resetSettingsForTest();
+	await Promise.all(tempDirs.splice(0).map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
+describe("settings config.yml persistence", () => {
+	it("writes nested root settings without trailing spaces", async () => {
+		const agentDir = await makeTempDir();
+		const settings = await Settings.init({ agentDir, cwd: agentDir });
+
+		settings.set("theme.dark", "titanium");
+		settings.set("edit.mode", "hashline");
+		await settings.flush();
+
+		const content = await Bun.file(path.join(agentDir, "config.yml")).text();
+
+		expect(content).toContain("theme:\n  dark: titanium\n");
+		expect(content).toContain("edit:\n  mode: hashline");
+		expect(content).not.toMatch(/[ \t]+$/m);
+	});
+});


### PR DESCRIPTION
## Repro
Running `bun -e 'const { YAML } = require("bun"); process.stdout.write(YAML.stringify({theme:{dark:"titanium",light:"light"},symbolPreset:"unicode",modelRoles:{default:"gateway/opencode-go/deepseek-v4-flash"}}, null, 2));'` prints `theme: ` and `modelRoles: ` lines with trailing spaces, matching the saved `config.yml` output reported after changing settings.

## Cause
`Settings.#saveNow()` and the legacy migration path in `packages/coding-agent/src/config/settings.ts` wrote `Bun.YAML.stringify(..., null, 2)` directly to `config.yml`; Bun currently serializes object-valued mapping keys as `key: ` before the child block, leaving trailing whitespace on root blocks.

## Fix
- Added settings YAML serialization that normalizes empty mapping-value lines from `key: ` to `key:` before writing `config.yml`.
- Routed both normal settings saves and legacy settings migration through that serializer.
- Added a persistence regression test that writes nested root settings and rejects trailing whitespace in `config.yml`.
- Added the `coding-agent` changelog entry.

## Verification
`bun test test/settings-save.test.ts` in `packages/coding-agent`: 1 pass. `bun run check` in `packages/coding-agent`: passed. Fixes #1670