### PR TITLE
fix(legacy-pi-compat): mirror sibling html/css assets so __dirname reads resolve

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed a module-load crash (`ReferenceError: Cannot access 'evalToolRenderer' before initialization`) triggered whenever `tools/eval` was imported before `tools/renderers`. The eval JS backend statically pulls the agent/task/sdk/extension chain, which re-enters the root barrel → `modes/components` → `tool-execution` → `renderers` while `eval.ts` was still initializing, so `renderers.ts` read `evalToolRenderer` in its TDZ. The eval TUI renderer is now split into a dependency-light `tools/eval-render.ts` that `renderers.ts` imports directly (decoupling pure rendering from the eval runtime); `eval.ts` re-exports `evalToolRenderer`/`EVAL_DEFAULT_PREVIEW_LINES` for compatibility.
+- Fixed legacy Pi extensions losing access to sibling UI assets after `loadLegacyPiModule` mirrors their JS/TS modules into a flat temp dir. Mirrored modules' `__dirname` resolves to the mirror root, so `readFileSync(join(__dirname, "foo.html"))` ENOENTed and consumers silently fell back to "no UI support" paths (e.g. Plannotator auto-approving plans without a review browser). `mirrorLegacyPiFile` now also copies `.html`/`.css` siblings of every mirrored module into the mirror root, scanning each source directory at most once and skipping collisions with `COPYFILE_EXCL` ([#1674](https://github.com/can1357/oh-my-pi/issues/1674)).
 
 ## [15.7.6] - 2026-06-01
 ### Added

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -269,7 +269,20 @@ function rewriteBareImportsForLegacyExtension(source: string, importerPath: stri
 interface LegacyPiMirrorState {
 	root: string;
 	seen: Map<string, string>;
+	// Source directories whose sibling assets have already been mirrored. Keyed
+	// by the absolute source directory path; entries are added once the first
+	// module from that directory is mirrored.
+	mirroredAssetDirs: Set<string>;
 }
+
+// Asset extensions copied alongside mirrored JS/TS modules. Legacy Pi
+// extensions load these via `readFileSync(join(__dirname, …))`, and the
+// rewritten module's `__dirname` resolves to the flat mirror root rather than
+// the original source directory. Restricted to known UI asset types to avoid
+// pulling in `package.json`, lockfiles, or VCS metadata from the extension
+// package. Extend cautiously — every entry adds a `readdir` per unique source
+// directory and risks name collisions across siblings in the flat mirror.
+const MIRRORED_ASSET_EXTENSIONS: readonly string[] = [".html", ".css"];
 
 function getMirrorPath(sourcePath: string, state: LegacyPiMirrorState): string {
 	const extension = path.extname(sourcePath) || ".js";
@@ -328,13 +341,54 @@ async function mirrorLegacyPiFile(sourcePath: string, state: LegacyPiMirrorState
 	const raw = await Bun.file(resolvedPath).text();
 	const rewritten = await rewriteLegacyPiImportsForRuntime(raw, resolvedPath, state);
 	await Bun.write(mirrorPath, rewritten);
+	await mirrorSiblingAssets(resolvedPath, state);
 	return mirrorPath;
 }
 
+// Copy known UI asset siblings from a mirrored module's source directory into
+// the flat mirror root so `readFileSync(join(__dirname, "foo.html"))` in
+// rewritten extension code still resolves. Each source directory is scanned
+// at most once per `loadLegacyPiModule` call; collisions in the flat root
+// keep the first-copied bytes (later modules with a same-named sibling lose).
+async function mirrorSiblingAssets(modulePath: string, state: LegacyPiMirrorState): Promise<void> {
+	const sourceDir = path.dirname(modulePath);
+	if (state.mirroredAssetDirs.has(sourceDir)) {
+		return;
+	}
+	state.mirroredAssetDirs.add(sourceDir);
+
+	let entries: string[];
+	try {
+		entries = await fs.readdir(sourceDir);
+	} catch {
+		// Source directory vanished between resolution and scan — nothing to do.
+		return;
+	}
+
+	for (const entry of entries) {
+		const ext = path.extname(entry).toLowerCase();
+		if (!MIRRORED_ASSET_EXTENSIONS.includes(ext)) {
+			continue;
+		}
+		const destination = path.join(state.root, entry);
+		try {
+			// `COPYFILE_EXCL` makes the first writer win deterministically; later
+			// modules with a same-named sibling silently keep the existing copy
+			// instead of corrupting the asset another module is already using.
+			await fs.copyFile(path.join(sourceDir, entry), destination, fs.constants.COPYFILE_EXCL);
+		} catch {
+			// EEXIST (collision) or asset removed mid-scan — non-fatal.
+		}
+	}
+}
 export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown> {
 	const root = path.join(os.tmpdir(), "omp-legacy-pi-file", `entry-${Bun.hash(resolvedPath).toString(36)}`);
 	await fs.rm(root, { recursive: true, force: true });
-	const state: LegacyPiMirrorState = { root, seen: new Map() };
+	const state: LegacyPiMirrorState = {
+		root,
+		seen: new Map(),
+		mirroredAssetDirs: new Set(),
+	};
 	const mirroredEntry = await mirrorLegacyPiFile(resolvedPath, state);
 	return import(`${toImportSpecifier(mirroredEntry)}?mtime=${Date.now()}`);
 }

--- a/packages/coding-agent/test/extensibility/legacy-pi-asset-mirror.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-asset-mirror.test.ts
@@ -1,0 +1,103 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadLegacyPiModule } from "../../src/extensibility/plugins/legacy-pi-compat";
+
+// Regression for issue #1674. Legacy Pi extensions historically read sibling
+// asset files via `readFileSync(join(__dirname, "foo.html"))` at module load
+// time. `loadLegacyPiModule` mirrors JS/TS modules into a flat temp dir under
+// hashed names, so `__dirname` in rewritten code resolves to the mirror root —
+// not the extension's source directory. Without explicit asset mirroring the
+// `readFileSync` ENOENTs, and consumers like Plannotator silently fall back to
+// the "no UI support" path. `mirrorSiblingAssets` now copies `.html`/`.css`
+// siblings of every mirrored module into the mirror root.
+const tempRoots: string[] = [];
+
+afterAll(async () => {
+	for (const dir of tempRoots) {
+		await fs.rm(dir, { recursive: true, force: true });
+	}
+});
+
+async function makeExtensionDir(prefix: string): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), `omp-legacy-pi-asset-${prefix}-`));
+	tempRoots.push(dir);
+	return dir;
+}
+
+describe("legacy pi compat sibling-asset mirroring (issue #1674)", () => {
+	it("copies .html siblings so __dirname-relative readFileSync resolves after mirroring", async () => {
+		const dir = await makeExtensionDir("html");
+		await fs.writeFile(
+			path.join(dir, "index.ts"),
+			[
+				`import { readFileSync } from "node:fs";`,
+				`import { fileURLToPath } from "node:url";`,
+				`import * as path from "node:path";`,
+				`const here = path.dirname(fileURLToPath(import.meta.url));`,
+				`export const content = readFileSync(path.join(here, "ui.html"), "utf8");`,
+			].join("\n"),
+			"utf8",
+		);
+		const expected = "<!doctype html><title>plan</title>";
+		await fs.writeFile(path.join(dir, "ui.html"), expected, "utf8");
+
+		const mod = (await loadLegacyPiModule(path.join(dir, "index.ts"))) as { content: string };
+
+		expect(mod.content).toBe(expected);
+	});
+
+	it("copies .css siblings discovered through transitive relative imports", async () => {
+		const dir = await makeExtensionDir("css");
+		await fs.mkdir(path.join(dir, "ui"), { recursive: true });
+		await fs.writeFile(
+			path.join(dir, "index.ts"),
+			`export { theme } from "./ui/theme";`,
+			"utf8",
+		);
+		await fs.writeFile(
+			path.join(dir, "ui", "theme.ts"),
+			[
+				`import { readFileSync } from "node:fs";`,
+				`import { fileURLToPath } from "node:url";`,
+				`import * as path from "node:path";`,
+				`const here = path.dirname(fileURLToPath(import.meta.url));`,
+				`export const theme = readFileSync(path.join(here, "theme.css"), "utf8");`,
+			].join("\n"),
+			"utf8",
+		);
+		const expectedCss = ":root { --bg: #000; }";
+		await fs.writeFile(path.join(dir, "ui", "theme.css"), expectedCss, "utf8");
+
+		const mod = (await loadLegacyPiModule(path.join(dir, "index.ts"))) as { theme: string };
+
+		expect(mod.theme).toBe(expectedCss);
+	});
+
+	it("does not mirror non-asset siblings such as package.json", async () => {
+		const dir = await makeExtensionDir("filter");
+		await fs.writeFile(
+			path.join(dir, "index.ts"),
+			[
+				`import { readFileSync, existsSync } from "node:fs";`,
+				`import { fileURLToPath } from "node:url";`,
+				`import * as path from "node:path";`,
+				`const here = path.dirname(fileURLToPath(import.meta.url));`,
+				`export const pkgPresent = existsSync(path.join(here, "package.json"));`,
+				`export const html = readFileSync(path.join(here, "ui.html"), "utf8");`,
+			].join("\n"),
+			"utf8",
+		);
+		await fs.writeFile(path.join(dir, "ui.html"), "<p>ok</p>", "utf8");
+		await fs.writeFile(path.join(dir, "package.json"), `{ "name": "fixture" }`, "utf8");
+
+		const mod = (await loadLegacyPiModule(path.join(dir, "index.ts"))) as {
+			pkgPresent: boolean;
+			html: string;
+		};
+
+		expect(mod.html).toBe("<p>ok</p>");
+		expect(mod.pkgPresent).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/extensibility/legacy-pi-asset-mirror.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-asset-mirror.test.ts
@@ -51,11 +51,7 @@ describe("legacy pi compat sibling-asset mirroring (issue #1674)", () => {
 	it("copies .css siblings discovered through transitive relative imports", async () => {
 		const dir = await makeExtensionDir("css");
 		await fs.mkdir(path.join(dir, "ui"), { recursive: true });
-		await fs.writeFile(
-			path.join(dir, "index.ts"),
-			`export { theme } from "./ui/theme";`,
-			"utf8",
-		);
+		await fs.writeFile(path.join(dir, "index.ts"), `export { theme } from "./ui/theme";`, "utf8");
 		await fs.writeFile(
 			path.join(dir, "ui", "theme.ts"),
 			[


### PR DESCRIPTION
## Repro

A minimal legacy Pi extension that reads a sibling HTML file via `readFileSync(join(__dirname, "ui.html"))` returns empty content after `loadLegacyPiModule` mirrors it:

```ts
// /tmp/repro-1674/ext/index.ts
import { readFileSync } from "node:fs";
import { fileURLToPath } from "node:url";
import * as path from "node:path";
const here = path.dirname(fileURLToPath(import.meta.url));
let content = "";
try { content = readFileSync(path.join(here, "assets.html"), "utf8"); } catch {}
export const hasAssets = content.length > 0;
```

```
$ bun run /tmp/repro-1674/repro.ts
{"hasAssets":false,"preview":""}
```

Matches the Plannotator symptom — `plannotator.html`/`review-editor.html` never make it into the mirror root, `planHtmlContent` stays `""`, and the extension drops into the "no UI support" path.

## Cause

`mirrorLegacyPiFile` in `packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` mirrors only JS/TS modules — every module discovered through the import graph is hashed and written into `state.root` (the flat `omp-legacy-pi-file/entry-<hash>/` temp dir). The rewritten files run from that flat root, so their `import.meta.url` (and therefore `__dirname`) resolves to `state.root`, not the extension's source directory. Asset siblings (`.html`, `.css`) loaded at runtime via `readFileSync` are never copied across, so the calls ENOENT and the calling extension's `catch {}` strands consumers with empty content.

## Fix

- Add `mirroredAssetDirs: Set<string>` to `LegacyPiMirrorState` and a small `MIRRORED_ASSET_EXTENSIONS = [".html", ".css"]` whitelist so we never pick up `package.json`, lockfiles, or VCS metadata.
- New `mirrorSiblingAssets(modulePath, state)` helper: `readdir`s each source directory once per `loadLegacyPiModule` call and `fs.copyFile`s every whitelisted sibling into `state.root`, using `fs.constants.COPYFILE_EXCL` so the first writer wins deterministically on cross-subdirectory name collisions.
- `mirrorLegacyPiFile` invokes the helper after `Bun.write(mirrorPath, …)`. Every mirrored JS/TS module — entry or transitive — gets its siblings staged alongside it.
- `loadLegacyPiModule` initialises the new state field.
- Regression test `test/extensibility/legacy-pi-asset-mirror.test.ts` covers three contracts: top-level `.html` resolves after mirroring, `.css` siblings of a relative-imported submodule resolve, and `package.json` is not pulled in by the asset scan.

## Verification

```
$ bun test test/extensibility/   # in packages/coding-agent
 32 pass
 0 fail
 80 expect() calls
Ran 32 tests across 7 files. [894.00ms]
```

The repro script above now prints `{"hasAssets":true,…}` against the patched module.

Fixes #1674