### PR TITLE
feat(ai): add xiaomimimo provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,10 @@ python/robomp/.cache/
 python/robomp/src/robomp/static/
 python/robomp/web/dist/
 python/robomp/.env
+
+# Autoresearch output
+.autoresearch-out/
+*.dump/
+kimi-*.json
+glm-*.json
+packages/typescript-edit-benchmark/fixtures/

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -968,8 +968,7 @@ async function streamAssistantResponse(
 								});
 								if (
 									(event.type === "text_delta" ||
-										event.type === "thinking_delta" ||
-										event.type === "toolcall_delta") &&
+										event.type === "thinking_delta") &&
 									maxResponseContentChars !== undefined
 								) {
 									contentCharCounter.count += event.delta.length;

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -496,6 +496,13 @@ async function runLoopBody(
 	let harmonyTruncateResumeCount = 0;
 	// See `runLoopBody` docstring for the per-attempt content-char accumulator contract.
 	const contentCharCounter = { count: 0 };
+	// Per-attempt "has the model called an editing/mutating tool yet" flag. Used
+	// by the text-only spiral cap to distinguish productive read-then-act flows
+	// (cap stays armed at toolcall_end) from pure read-spirals where the model
+	// keeps re-reading without ever attempting an edit (cap also fires on
+	// text_end/thinking_end). Names match common edit/write/patch tool names
+	// case-insensitively; benchmark-meaningful without hardcoding a single tool.
+	const editingToolCallSeen = { seen: false };
 	// Outer loop: continues when queued follow-up messages arrive after agent would stop
 	while (true) {
 		let hasMoreToolCalls = true;
@@ -542,6 +549,7 @@ async function runLoopBody(
 					streamFn,
 					harmonyRetryAttempt,
 					contentCharCounter,
+					editingToolCallSeen,
 				);
 				harmonyRetryAttempt = 0;
 				harmonyTruncateResumeCount = 0;
@@ -711,6 +719,7 @@ async function streamAssistantResponse(
 	streamFn?: StreamFn,
 	harmonyRetryAttempt = 0,
 	contentCharCounter: { count: number } = { count: 0 },
+	editingToolCallSeen: { seen: boolean } = { seen: false },
 ): Promise<AssistantMessage> {
 	// Apply context transform if configured (AgentMessage[] → AgentMessage[])
 	let messages = context.messages;
@@ -943,6 +952,15 @@ async function streamAssistantResponse(
 								) {
 									contentCharCounter.count += event.delta.length;
 								}
+								if (event.type === "toolcall_end") {
+									// Mark editing/mutating tool calls so the text-only spiral cap
+									// below can stay armed across read-only spirals. Pattern matches
+									// edit/write/patch/vim/str_replace-style tools without hardcoding
+									// any specific tool registry.
+									if (/^(edit|write|patch|vim|str_replace|apply)/i.test(event.toolCall.name)) {
+										editingToolCallSeen.seen = true;
+									}
+								}
 								if (event.type === "toolcall_end" && maxToolCallsPerTurn !== undefined) {
 									completedToolCalls++;
 									if (completedToolCalls >= maxToolCallsPerTurn) {
@@ -956,8 +974,30 @@ async function streamAssistantResponse(
 									event.type === "toolcall_end" &&
 									maxResponseContentChars !== undefined &&
 									contentCharCounter.count >= maxResponseContentChars &&
-									!toolCallCapAbortController?.signal.aborted
+									!toolCallCapAbortController?.signal.aborted &&
+									!contentCharCapAbortController?.signal.aborted
 								) {
+									cappedMessage = cloneAssistantMessageForToolCallCap(partialMessage);
+									contentCharCapAbortController?.abort();
+									const capped = await finishCappedAssistantMessage();
+									if (capped) return capped;
+								}
+								if (
+									(event.type === "text_end" || event.type === "thinking_end") &&
+									!editingToolCallSeen.seen &&
+									maxResponseContentChars !== undefined &&
+									contentCharCounter.count >= maxResponseContentChars &&
+									!toolCallCapAbortController?.signal.aborted &&
+									!contentCharCapAbortController?.signal.aborted
+								) {
+									// Text-only / read-only spiral safety net. The original gate was
+									// `completedToolCalls === 0` which catches text-before-any-toolcall
+									// spirals but misses read-only spirals (model keeps reading the file
+									// without ever attempting an edit — mimo-precision / qwen failure on
+									// structural-swap). The `editingToolCallSeen` flag persists across
+									// turns within the loop body and only flips when the model calls a
+									// mutating tool, so productive read-then-edit flows still finish
+									// naturally via the toolcall_end gate above.
 									cappedMessage = cloneAssistantMessageForToolCallCap(partialMessage);
 									contentCharCapAbortController?.abort();
 									const capped = await finishCappedAssistantMessage();

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -478,7 +478,11 @@ async function runLoopBody(
 	let pendingMessages: AgentMessage[] = (await config.getSteeringMessages?.()) || [];
 	let harmonyRetryAttempt = 0;
 	let harmonyTruncateResumeCount = 0;
-
+	// Per-attempt content-char accumulator: shared across every `streamAssistantResponse`
+	// call in this loop body so `maxResponseContentChars` is enforced over the entire
+	// agent invocation, not per-individual-response. Without this kimi-class rambling
+	// across many cheap turns never trips a per-response cap.
+	const contentCharCounter = { count: 0 };
 	// Outer loop: continues when queued follow-up messages arrive after agent would stop
 	while (true) {
 		let hasMoreToolCalls = true;
@@ -524,6 +528,7 @@ async function runLoopBody(
 					stepCounter,
 					streamFn,
 					harmonyRetryAttempt,
+					contentCharCounter,
 				);
 				harmonyRetryAttempt = 0;
 				harmonyTruncateResumeCount = 0;
@@ -692,6 +697,7 @@ async function streamAssistantResponse(
 	stepCounter: StepCounter,
 	streamFn?: StreamFn,
 	harmonyRetryAttempt = 0,
+	contentCharCounter: { count: number } = { count: 0 },
 ): Promise<AssistantMessage> {
 	// Apply context transform if configured (AgentMessage[] → AgentMessage[])
 	let messages = context.messages;
@@ -735,10 +741,16 @@ async function streamAssistantResponse(
 	const harmonyAbortController = harmonyMitigationEnabled ? new AbortController() : undefined;
 	const maxToolCallsPerTurn = normalizeMaxToolCallsPerTurn(config.maxToolCallsPerTurn);
 	const toolCallCapAbortController = maxToolCallsPerTurn === undefined ? undefined : new AbortController();
+	const maxResponseContentChars =
+		typeof config.maxResponseContentChars === "number" && config.maxResponseContentChars > 0
+			? config.maxResponseContentChars
+			: undefined;
+	const contentCharCapAbortController = maxResponseContentChars === undefined ? undefined : new AbortController();
 	const requestSignals: AbortSignal[] = [];
 	if (signal) requestSignals.push(signal);
 	if (harmonyAbortController) requestSignals.push(harmonyAbortController.signal);
 	if (toolCallCapAbortController) requestSignals.push(toolCallCapAbortController.signal);
+	if (contentCharCapAbortController) requestSignals.push(contentCharCapAbortController.signal);
 	const requestSignal =
 		requestSignals.length === 0
 			? undefined
@@ -807,6 +819,7 @@ async function streamAssistantResponse(
 
 			const responseIterator = response[Symbol.asyncIterator]();
 			let completedToolCalls = 0;
+			// no per-response counter — we use the per-attempt `contentCharCounter` passed in
 			let cappedMessage: AssistantMessage | undefined;
 			let capFinalized = false;
 
@@ -851,7 +864,7 @@ async function streamAssistantResponse(
 					if (abortRacePromise) {
 						const result = await Promise.race([responseIterator.next(), abortRacePromise]);
 						if (result === ABORTED) {
-							if (toolCallCapAbortController?.signal.aborted) {
+							if (toolCallCapAbortController?.signal.aborted || contentCharCapAbortController?.signal.aborted) {
 								const capped = await finishCappedAssistantMessage();
 								if (capped) return capped;
 							}
@@ -865,7 +878,7 @@ async function streamAssistantResponse(
 						next = await responseIterator.next();
 					}
 					if (requestSignal?.aborted) {
-						if (toolCallCapAbortController?.signal.aborted) {
+						if (toolCallCapAbortController?.signal.aborted || contentCharCapAbortController?.signal.aborted) {
 							const capped = await finishCappedAssistantMessage();
 							if (capped) return capped;
 						}
@@ -909,6 +922,14 @@ async function streamAssistantResponse(
 									assistantMessageEvent: event,
 									message: { ...partialMessage },
 								});
+								if (
+									(event.type === "text_delta" ||
+										event.type === "thinking_delta" ||
+										event.type === "toolcall_delta") &&
+									maxResponseContentChars !== undefined
+								) {
+									contentCharCounter.count += event.delta.length;
+								}
 								if (event.type === "toolcall_end" && maxToolCallsPerTurn !== undefined) {
 									completedToolCalls++;
 									if (completedToolCalls >= maxToolCallsPerTurn) {
@@ -917,6 +938,17 @@ async function streamAssistantResponse(
 										const capped = await finishCappedAssistantMessage();
 										if (capped) return capped;
 									}
+								}
+								if (
+									event.type === "toolcall_end" &&
+									maxResponseContentChars !== undefined &&
+									contentCharCounter.count >= maxResponseContentChars &&
+									!toolCallCapAbortController?.signal.aborted
+								) {
+									cappedMessage = cloneAssistantMessageForToolCallCap(partialMessage);
+									contentCharCapAbortController?.abort();
+									const capped = await finishCappedAssistantMessage();
+									if (capped) return capped;
 								}
 							}
 							break;

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -9,6 +9,7 @@ import {
 	EventStream,
 	isZodSchema,
 	streamSimple,
+	type ToolChoice,
 	type ToolResultMessage,
 	type TSchema,
 	validateToolArguments,
@@ -503,6 +504,14 @@ async function runLoopBody(
 	// text_end/thinking_end). Names match common edit/write/patch tool names
 	// case-insensitively; benchmark-meaningful without hardcoding a single tool.
 	const editingToolCallSeen = { seen: false };
+	// Per-attempt force-tool-choice ref. Set by the spiral-cap branches inside
+	// `streamAssistantResponse` when the cap fires on a zero-edit response
+	// (kimi-class-only path — cap is only set via `resolveMaxResponseContentChars
+	// ForModel` for kimi/glm/qwen/mimo). The next assistant turn then runs with
+	// `tool_choice: "required"`, eliminating the zero-tool-retry loop where
+	// kimi rambles past the budget again without committing. Consumed and
+	// cleared at the top of the next streamAssistantResponse call.
+	const forceNextToolChoice: { value: ToolChoice | undefined } = { value: undefined };
 	// Outer loop: continues when queued follow-up messages arrive after agent would stop
 	while (true) {
 		let hasMoreToolCalls = true;
@@ -550,6 +559,7 @@ async function runLoopBody(
 					harmonyRetryAttempt,
 					contentCharCounter,
 					editingToolCallSeen,
+					forceNextToolChoice,
 				);
 				harmonyRetryAttempt = 0;
 				harmonyTruncateResumeCount = 0;
@@ -720,6 +730,7 @@ async function streamAssistantResponse(
 	harmonyRetryAttempt = 0,
 	contentCharCounter: { count: number } = { count: 0 },
 	editingToolCallSeen: { seen: boolean } = { seen: false },
+	forceNextToolChoice: { value: ToolChoice | undefined } = { value: undefined },
 ): Promise<AssistantMessage> {
 	// Apply context transform if configured (AgentMessage[] → AgentMessage[])
 	let messages = context.messages;
@@ -781,7 +792,13 @@ async function streamAssistantResponse(
 				: AbortSignal.any(requestSignals);
 	const effectiveTemperature =
 		harmonyRetryAttempt > 0 && config.temperature !== undefined ? config.temperature + 0.05 : config.temperature;
-	const effectiveToolChoice = dynamicToolChoice ?? config.toolChoice;
+	// Per-attempt force-tool-choice override consumed at the call boundary so it
+	// applies to exactly one assistant turn and then auto-clears. Set by the
+	// spiral-cap branches below when the previous turn ended on a zero-edit
+	// cap-fire. Highest precedence — beats both the dynamic and static choice.
+	const forcedToolChoiceFromPrevCap = forceNextToolChoice.value;
+	forceNextToolChoice.value = undefined;
+	const effectiveToolChoice = forcedToolChoiceFromPrevCap ?? dynamicToolChoice ?? config.toolChoice;
 	const effectiveReasoning = dynamicReasoning ?? config.reasoning;
 
 	const chatStepNumber = stepCounter.count;
@@ -951,6 +968,33 @@ async function streamAssistantResponse(
 									maxResponseContentChars !== undefined
 								) {
 									contentCharCounter.count += event.delta.length;
+									// Delta-event spiral cap: kimi-class models can stay inside a
+									// single `thinking` block streaming deltas past the wall-clock
+									// timeout without ever firing `thinking_end`. The two `_end`-gated
+									// caps below then never get a chance to run. Trip the cap mid-
+									// stream when the budget is exhausted AND no editing tool has
+									// been seen this attempt — same gate as the spiral safety net at
+									// the close event, so productive read-then-edit flows are
+									// unaffected (they close blocks naturally well before the cap).
+									if (
+										!editingToolCallSeen.seen &&
+										contentCharCounter.count >= maxResponseContentChars &&
+										!toolCallCapAbortController?.signal.aborted &&
+										!contentCharCapAbortController?.signal.aborted
+									) {
+										cappedMessage = cloneAssistantMessageForToolCallCap(partialMessage);
+										// Tell the next assistant turn to force a tool call — kimi-class
+										// otherwise spirals again under the retry-context user prompt
+										// instead of committing. Only fires on the zero-edit path
+										// (gated by `!editingToolCallSeen.seen` above) so productive
+										// flows are never forced. Tested escalating to `{type: "tool",
+										// name: "edit"}` on consecutive cap-fires (runs #229–231); net
+										// negative — mean 0.917 vs 0.969 for plain "required".
+										forceNextToolChoice.value = "required";
+										contentCharCapAbortController?.abort();
+										const capped = await finishCappedAssistantMessage();
+										if (capped) return capped;
+									}
 								}
 								if (event.type === "toolcall_end") {
 									// Mark editing/mutating tool calls so the text-only spiral cap
@@ -999,6 +1043,10 @@ async function streamAssistantResponse(
 									// mutating tool, so productive read-then-edit flows still finish
 									// naturally via the toolcall_end gate above.
 									cappedMessage = cloneAssistantMessageForToolCallCap(partialMessage);
+									// Same kimi-class force-tool-choice signal as the delta-event
+									// branch above — gated on the zero-edit path so productive flows
+									// are never forced.
+									forceNextToolChoice.value = "required";
 									contentCharCapAbortController?.abort();
 									const capped = await finishCappedAssistantMessage();
 									if (capped) return capped;

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -462,6 +462,22 @@ function cloneAssistantMessageForToolCallCap(message: AssistantMessage): Assista
 	};
 }
 
+/**
+ * Drive one invocation of the agent loop end-to-end: outer steering / follow-up
+ * loop wrapping the inner per-turn loop that streams an assistant response,
+ * executes any tool calls, and decides whether to continue.
+ *
+ * Per-attempt content-char accumulator: the `contentCharCounter` declared
+ * below is intentionally allocated **once per `runLoopBody`** and threaded
+ * through every `streamAssistantResponse` call in this loop. That makes
+ * `maxResponseContentChars` an end-to-end budget for the whole agent
+ * invocation rather than a per-individual-response budget — without this,
+ * kimi-class rambling spread across many cheap turns never trips a
+ * per-response cap. Cap precedence on a `toolcall_end` that satisfies both
+ * limits at once is handled inside `streamAssistantResponse`: the
+ * `maxToolCallsPerTurn` branch is checked first and returns early, so the
+ * `maxResponseContentChars` branch's abort path stays unfired.
+ */
 async function runLoopBody(
 	currentContext: AgentContext,
 	newMessages: AgentMessage[],
@@ -478,10 +494,7 @@ async function runLoopBody(
 	let pendingMessages: AgentMessage[] = (await config.getSteeringMessages?.()) || [];
 	let harmonyRetryAttempt = 0;
 	let harmonyTruncateResumeCount = 0;
-	// Per-attempt content-char accumulator: shared across every `streamAssistantResponse`
-	// call in this loop body so `maxResponseContentChars` is enforced over the entire
-	// agent invocation, not per-individual-response. Without this kimi-class rambling
-	// across many cheap turns never trips a per-response cap.
+	// See `runLoopBody` docstring for the per-attempt content-char accumulator contract.
 	const contentCharCounter = { count: 0 };
 	// Outer loop: continues when queued follow-up messages arrive after agent would stop
 	while (true) {

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -967,8 +967,7 @@ async function streamAssistantResponse(
 									message: { ...partialMessage },
 								});
 								if (
-									(event.type === "text_delta" ||
-										event.type === "thinking_delta") &&
+									(event.type === "text_delta" || event.type === "thinking_delta") &&
 									maxResponseContentChars !== undefined
 								) {
 									contentCharCounter.count += event.delta.length;

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -688,6 +688,11 @@ async function runLoopBody(
 			pendingMessages = followUpMessages;
 			continue;
 		}
+		// If a spiral cap set a forced tool choice for the next turn,
+		// continue the loop so the next turn consumes it.
+		if (forceNextToolChoice.value !== undefined) {
+			continue;
+		}
 
 		// No more messages, exit
 		break;
@@ -980,7 +985,8 @@ async function streamAssistantResponse(
 										!editingToolCallSeen.seen &&
 										contentCharCounter.count >= maxResponseContentChars &&
 										!toolCallCapAbortController?.signal.aborted &&
-										!contentCharCapAbortController?.signal.aborted
+										!contentCharCapAbortController?.signal.aborted &&
+										!forcedToolChoiceFromPrevCap
 									) {
 										cappedMessage = cloneAssistantMessageForToolCallCap(partialMessage);
 										// Tell the next assistant turn to force a tool call — kimi-class
@@ -1019,7 +1025,8 @@ async function streamAssistantResponse(
 									maxResponseContentChars !== undefined &&
 									contentCharCounter.count >= maxResponseContentChars &&
 									!toolCallCapAbortController?.signal.aborted &&
-									!contentCharCapAbortController?.signal.aborted
+									!contentCharCapAbortController?.signal.aborted &&
+									!forcedToolChoiceFromPrevCap
 								) {
 									cappedMessage = cloneAssistantMessageForToolCallCap(partialMessage);
 									contentCharCapAbortController?.abort();
@@ -1032,7 +1039,8 @@ async function streamAssistantResponse(
 									maxResponseContentChars !== undefined &&
 									contentCharCounter.count >= maxResponseContentChars &&
 									!toolCallCapAbortController?.signal.aborted &&
-									!contentCharCapAbortController?.signal.aborted
+									!contentCharCapAbortController?.signal.aborted &&
+									!forcedToolChoiceFromPrevCap
 								) {
 									// Text-only / read-only spiral safety net. The original gate was
 									// `completedToolCalls === 0` which catches text-before-any-toolcall

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -109,6 +109,13 @@ export interface AgentOptions {
 	maxToolCallsPerTurn?: number;
 
 	/**
+	 * Maximum cumulative content characters per single streamed assistant response
+	 * before the provider stream is force-aborted at the next `toolcall_end`. Bounds
+	 * wall-clock for chatty model families. Undefined disables the cap.
+	 */
+	maxResponseContentChars?: number;
+
+	/**
 	 * API format for Kimi Code provider: "openai" or "anthropic" (default: "anthropic")
 	 */
 	kimiApiFormat?: "openai" | "anthropic";
@@ -276,6 +283,7 @@ export class Agent {
 	#followUpMode: "all" | "one-at-a-time";
 	#interruptMode: "immediate" | "wait";
 	#maxToolCallsPerTurn?: number;
+	#maxResponseContentChars?: number;
 	#sessionId?: string;
 	#metadata?: Record<string, unknown>;
 	#metadataResolver?: (provider: string) => Record<string, unknown> | undefined;
@@ -336,6 +344,7 @@ export class Agent {
 		this.#followUpMode = opts.followUpMode || "one-at-a-time";
 		this.#interruptMode = opts.interruptMode || "immediate";
 		this.#maxToolCallsPerTurn = opts.maxToolCallsPerTurn;
+		this.#maxResponseContentChars = opts.maxResponseContentChars;
 		this.streamFn = opts.streamFn || streamSimple;
 		this.#sessionId = opts.sessionId;
 		this.#providerSessionState = opts.providerSessionState;
@@ -564,6 +573,14 @@ export class Agent {
 
 	set maxToolCallsPerTurn(value: number | undefined) {
 		this.#maxToolCallsPerTurn = value;
+	}
+
+	get maxResponseContentChars(): number | undefined {
+		return this.#maxResponseContentChars;
+	}
+
+	set maxResponseContentChars(value: number | undefined) {
+		this.#maxResponseContentChars = value;
 	}
 
 	get state(): AgentState {
@@ -929,6 +946,7 @@ export class Agent {
 			hideThinkingSummary: this.#hideThinkingSummary,
 			interruptMode: this.#interruptMode,
 			maxToolCallsPerTurn: this.#maxToolCallsPerTurn,
+			maxResponseContentChars: this.#maxResponseContentChars,
 			sessionId: this.#sessionId,
 			metadata: this.#metadataResolver ? undefined : this.#metadata,
 			metadataResolver: this.#metadataResolver,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -47,6 +47,15 @@ export interface AgentLoopConfig extends SimpleStreamOptions {
 	maxToolCallsPerTurn?: number;
 
 	/**
+	 * Maximum cumulative content characters (text + thinking + tool-call deltas) per
+	 * single streamed assistant response before the provider stream is force-aborted.
+	 * Used to bound wall-clock for model families that emit very long inline reasoning
+	 * monologues (kimi/glm/qwen with `<thinking>` tags). The abort uses the same
+	 * graceful-finalize path as `maxToolCallsPerTurn`. Undefined disables the cap.
+	 */
+	maxResponseContentChars?: number;
+
+	/**
 	 * Optional session identifier forwarded to LLM providers.
 	 * Used by providers that support session-based caching (e.g., OpenAI Codex).
 	 */

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -386,6 +386,145 @@ describe("agentLoop with AgentMessage", () => {
 		]);
 	});
 
+	it("prefers the tool-call cap over the content-char cap when both fire on the same toolcall_end", async () => {
+		const toolSchema = z.object({ value: z.string() });
+		const executed: string[] = [];
+		const tool: AgentTool<typeof toolSchema, { value: string }> = {
+			name: "echo",
+			label: "Echo",
+			description: "Echo tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params) {
+				executed.push(params.value);
+				return {
+					content: [{ type: "text", text: `echoed: ${params.value}` }],
+					details: { value: params.value },
+				};
+			},
+		};
+
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [tool] };
+		const mock = createMockModel();
+
+		const TOOL_CAP = 3;
+		// Each `toolcall_delta` carries 50 chars; the counter sees no other
+		// content. Set CHAR_CAP so it is first satisfied EXACTLY on
+		// `toolcall_delta` #3 — counter is 100 after #2 and 150 after #3 — which
+		// puts the char-cap predicate true on `toolcall_end` #3 (the cap check
+		// happens at `toolcall_end`, after the matching delta). The tool-call
+		// cap predicate is also first true on `toolcall_end` #3 (3 ≥ 3).
+		// Both caps therefore fire on the SAME `toolcall_end`.
+		const CHAR_CAP = 150;
+		const DELTA = "x".repeat(50);
+
+		let modelCalls = 0;
+		let firstRequestSignal: AbortSignal | undefined;
+		let emittedToolCalls = 0;
+
+		const makeToolCall = (index: number): AssistantMessage["content"][number] => ({
+			type: "toolCall",
+			id: `tool-${index}`,
+			name: "echo",
+			arguments: { value: String(index) },
+		});
+		const makeMessage = (count: number, stopReason: AssistantMessage["stopReason"] = "stop") =>
+			createAssistantMessage(
+				Array.from({ length: count }, (_, index) => makeToolCall(index + 1)),
+				stopReason,
+			);
+
+		const streamFn: StreamFn = (_model, _llmContext, options) => {
+			modelCalls++;
+			const stream = new AssistantMessageEventStream();
+			if (modelCalls > 1) {
+				queueMicrotask(() => {
+					const done = createAssistantMessage([{ type: "text", text: "done" }], "stop");
+					stream.push({ type: "start", partial: done });
+					stream.push({ type: "text_start", contentIndex: 0, partial: done });
+					stream.push({ type: "text_delta", contentIndex: 0, delta: "done", partial: done });
+					stream.push({ type: "text_end", contentIndex: 0, content: "done", partial: done });
+					stream.push({ type: "done", reason: "stop", message: done });
+				});
+				return stream;
+			}
+
+			queueMicrotask(async () => {
+				firstRequestSignal = options?.signal;
+				stream.push({ type: "start", partial: makeMessage(0) });
+				for (let index = 1; index <= 6; index++) {
+					if (options?.signal?.aborted) {
+						const aborted = createAssistantMessage([], "aborted");
+						stream.push({ type: "error", reason: "aborted", error: aborted });
+						return;
+					}
+					const partial = makeMessage(index);
+					const toolCall = partial.content[index - 1];
+					if (toolCall?.type !== "toolCall") throw new Error("Expected tool call");
+					stream.push({ type: "toolcall_start", contentIndex: index - 1, partial });
+					stream.push({
+						type: "toolcall_delta",
+						contentIndex: index - 1,
+						delta: DELTA,
+						partial,
+					});
+					stream.push({ type: "toolcall_end", contentIndex: index - 1, toolCall, partial });
+					emittedToolCalls++;
+					await Bun.sleep(0);
+				}
+				stream.push({ type: "done", reason: "toolUse", message: makeMessage(6, "toolUse") });
+			});
+			return stream;
+		};
+
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			maxToolCallsPerTurn: TOOL_CAP,
+			maxResponseContentChars: CHAR_CAP,
+		};
+
+		const events: AgentEvent[] = [];
+		const stream = agentLoop([createUserMessage("trigger both caps")], context, config, undefined, streamFn);
+		for await (const event of stream) {
+			events.push(event);
+		}
+
+		// Tool-call cap fires on `toolcall_end` #3 — the same event on which the
+		// content-char cap predicate is also satisfied (3 * 50 = 150 ≥ 100).
+		// First-fired cap (tool-call) wins: only TOOL_CAP tools actually execute
+		// in the cap-truncated batch, the request signal is aborted, and the
+		// producer eventually sees the abort (an extra push from the producer
+		// before the abort propagates is tolerated — the contract is that the
+		// consumer stops feeding new tool calls into the capped message after
+		// the cap fires, NOT that the producer must observe the abort instantly).
+		expect(executed).toEqual(["1", "2", "3"]);
+		expect(firstRequestSignal?.aborted).toBe(true);
+		expect(emittedToolCalls).toBeGreaterThanOrEqual(TOOL_CAP);
+
+		const messages = await stream.result();
+		const cappedAssistant = messages.find(
+			(m): m is AssistantMessage => m.role === "assistant" && m.content.some(b => b.type === "toolCall"),
+		);
+		expect(cappedAssistant).toBeDefined();
+		if (!cappedAssistant) return;
+		expect(cappedAssistant.stopReason).toBe("toolUse");
+		expect(cappedAssistant.content.filter(b => b.type === "toolCall")).toHaveLength(TOOL_CAP);
+
+		// The other cap's surface is suppressed: a single `message_end` event
+		// for the capped assistant turn (no double-finalize from the char-cap
+		// branch racing to also clone-and-finalize the same partial message),
+		// and the follow-up turn proceeds normally with exactly one extra
+		// model call.
+		const cappedMessageEnds = events.filter(
+			e =>
+				e.type === "message_end" &&
+				e.message.role === "assistant" &&
+				e.message.content.some(b => b.type === "toolCall"),
+		);
+		expect(cappedMessageEnds).toHaveLength(1);
+		expect(modelCalls).toBe(2);
+	});
+
 	it("injects and strips intent when intent tracing is enabled", async () => {
 		const toolSchema = z.object({ value: z.string() });
 		const executedParams: Record<string, unknown>[] = [];

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1751,7 +1751,8 @@ export class AuthStorage {
 				await saveApiKeyCredential(apiKey);
 				return;
 			}
-			case "xiaomi": {
+			case "xiaomi":
+			case "xiaomimimo": {
 				const { loginXiaomi } = await import("./utils/oauth/xiaomi");
 				const apiKey = await loginXiaomi(ctrl);
 				await saveApiKeyCredential(apiKey);

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -970,8 +970,8 @@
 				"image"
 			],
 			"cost": {
-				"input": 5,
-				"output": 25,
+				"input": 5.5,
+				"output": 27.5,
 				"cacheRead": 0.5,
 				"cacheWrite": 6.25
 			},
@@ -995,10 +995,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 5,
-				"output": 25,
-				"cacheRead": 0.5,
-				"cacheWrite": 6.25
+				"input": 5.5,
+				"output": 27.5,
+				"cacheRead": 0.55,
+				"cacheWrite": 6.875
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -1020,10 +1020,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 5,
-				"output": 25,
-				"cacheRead": 0.5,
-				"cacheWrite": 6.25
+				"input": 5.5,
+				"output": 27.5,
+				"cacheRead": 0.55,
+				"cacheWrite": 6.875
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 128000,
@@ -1095,10 +1095,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 3,
-				"output": 15,
-				"cacheRead": 0.3,
-				"cacheWrite": 3.75
+				"input": 3.3,
+				"output": 16.5,
+				"cacheRead": 0.33,
+				"cacheWrite": 4.125
 			},
 			"contextWindow": 1000000,
 			"maxTokens": 64000,
@@ -3642,6 +3642,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"anthropic/claude-opus-4-8": {
+			"id": "anthropic/claude-opus-4-8",
+			"name": "Claude Opus 4.8",
+			"api": "anthropic-messages",
+			"provider": "cloudflare-ai-gateway",
+			"baseUrl": "https://gateway.ai.cloudflare.com/v1/<account>/<gateway>/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "anthropic-adaptive",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"anthropic/claude-sonnet-4": {
 			"id": "anthropic/claude-sonnet-4",
 			"name": "Claude Sonnet 4 (latest)",
@@ -5504,7 +5529,7 @@
 	"github-copilot": {
 		"claude-haiku-4.5": {
 			"id": "claude-haiku-4.5",
-			"name": "Claude Haiku 4.5",
+			"name": "Claude Haiku 4.5 (latest)",
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5514,10 +5539,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 1,
+				"output": 5,
+				"cacheRead": 0.1,
+				"cacheWrite": 1.25
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
@@ -5533,7 +5558,7 @@
 		},
 		"claude-opus-4.5": {
 			"id": "claude-opus-4.5",
-			"name": "Claude Opus 4.5",
+			"name": "Claude Opus 4.5 (latest)",
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5543,13 +5568,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 200000,
-			"maxTokens": 32000,
+			"maxTokens": 64000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
 			},
@@ -5571,10 +5596,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 168000,
 			"maxTokens": 32000,
@@ -5600,13 +5625,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
-			"contextWindow": 200000,
-			"maxTokens": 32000,
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
 			},
@@ -5628,13 +5653,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
+			"contextWindow": 1000000,
+			"maxTokens": 128000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
 			},
@@ -5646,7 +5671,7 @@
 		},
 		"claude-sonnet-4": {
 			"id": "claude-sonnet-4",
-			"name": "Claude Sonnet 4",
+			"name": "Claude Sonnet 4 (latest)",
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5656,13 +5681,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
 			},
-			"contextWindow": 216000,
-			"maxTokens": 16000,
+			"contextWindow": 200000,
+			"maxTokens": 64000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
 			},
@@ -5674,7 +5699,7 @@
 		},
 		"claude-sonnet-4.5": {
 			"id": "claude-sonnet-4.5",
-			"name": "Claude Sonnet 4.5",
+			"name": "Claude Sonnet 4.5 (latest)",
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5684,13 +5709,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
 			},
 			"contextWindow": 200000,
-			"maxTokens": 32000,
+			"maxTokens": 64000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
 			},
@@ -5712,13 +5737,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
 			},
-			"contextWindow": 200000,
-			"maxTokens": 32000,
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
 			},
@@ -5734,19 +5759,19 @@
 			"api": "openai-completions",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.25,
+				"output": 10,
+				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
-			"maxTokens": 64000,
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
 			},
@@ -5754,11 +5779,16 @@
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
 				"supportsReasoningEffort": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
 			}
 		},
 		"gemini-3-flash-preview": {
 			"id": "gemini-3-flash-preview",
-			"name": "Gemini 3 Flash",
+			"name": "Gemini 3 Flash Preview",
 			"api": "openai-completions",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5768,13 +5798,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.5,
+				"output": 3,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
-			"maxTokens": 64000,
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
 			},
@@ -5838,13 +5868,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
 			},
@@ -5875,13 +5905,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.5,
+				"output": 9,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
-			"contextWindow": 200000,
-			"maxTokens": 64000,
+			"contextWindow": 1048576,
+			"maxTokens": 65536,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
 			},
@@ -5908,13 +5938,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2,
+				"output": 8,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
-			"contextWindow": 128000,
-			"maxTokens": 16384,
+			"contextWindow": 1047576,
+			"maxTokens": 32768,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
 			},
@@ -5983,7 +6013,7 @@
 		},
 		"gpt-5-mini": {
 			"id": "gpt-5-mini",
-			"name": "GPT-5-mini",
+			"name": "GPT-5 Mini",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5993,13 +6023,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.25,
+				"output": 2,
+				"cacheRead": 0.025,
 				"cacheWrite": 0
 			},
-			"contextWindow": 264000,
-			"maxTokens": 64000,
+			"contextWindow": 400000,
+			"maxTokens": 128000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
 			},
@@ -6133,9 +6163,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.75,
+				"output": 14,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -6151,7 +6181,7 @@
 		},
 		"gpt-5.2-codex": {
 			"id": "gpt-5.2-codex",
-			"name": "GPT-5.2-Codex",
+			"name": "GPT-5.2 Codex",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -6161,9 +6191,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.75,
+				"output": 14,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -6179,7 +6209,7 @@
 		},
 		"gpt-5.3-codex": {
 			"id": "gpt-5.3-codex",
-			"name": "GPT-5.3-Codex",
+			"name": "GPT-5.3 Codex",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -6189,9 +6219,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.75,
+				"output": 14,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -6217,9 +6247,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -6235,7 +6265,7 @@
 		},
 		"gpt-5.4-mini": {
 			"id": "gpt-5.4-mini",
-			"name": "GPT-5.4 Mini",
+			"name": "GPT-5.4 mini",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -6245,9 +6275,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.75,
+				"output": 4.5,
+				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -6256,6 +6286,34 @@
 				"User-Agent": "opencode/1.3.15"
 			},
 			"premiumMultiplier": 0.33,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "xhigh"
+			}
+		},
+		"gpt-5.4-nano": {
+			"id": "gpt-5.4-nano",
+			"name": "GPT-5.4 nano",
+			"api": "openai-responses",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.2,
+				"output": 1.25,
+				"cacheRead": 0.02,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"headers": {
+				"User-Agent": "opencode/1.3.15"
+			},
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
@@ -6274,12 +6332,12 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
-			"contextWindow": 400000,
+			"contextWindow": 1050000,
 			"maxTokens": 128000,
 			"headers": {
 				"User-Agent": "opencode/1.3.15"
@@ -6318,6 +6376,39 @@
 				"supportsReasoningEffort": false
 			},
 			"premiumMultiplier": 0.25,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"raptor-mini": {
+			"id": "raptor-mini",
+			"name": "Raptor mini",
+			"api": "openai-completions",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.25,
+				"output": 2,
+				"cacheRead": 0.025,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"headers": {
+				"User-Agent": "opencode/1.3.15"
+			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -10366,7 +10457,7 @@
 		},
 		"anthropic/claude-opus-4.8-fast": {
 			"id": "anthropic/claude-opus-4.8-fast",
-			"name": "Anthropic: Claude Opus 4.8 (Fast)",
+			"name": "Anthropic: Claude Opus 4.8 (Fast) ($$$$)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -13094,6 +13185,25 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"minimax/minimax-m3": {
+			"id": "minimax/minimax-m3",
+			"name": "MiniMax: MiniMax M3 (new)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"mistralai/codestral-2508": {
 			"id": "mistralai/codestral-2508",
 			"name": "Mistral: Codestral 2508",
@@ -13911,7 +14021,7 @@
 		},
 		"nousresearch/hermes-2-pro-llama-3-8b": {
 			"id": "nousresearch/hermes-2-pro-llama-3-8b",
-			"name": "NousResearch: Hermes 2 Pro - Llama-3 8B",
+			"name": "NousResearch: Hermes 2 Pro - Llama-3 8B (retires Jun 5)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -14306,7 +14416,7 @@
 		},
 		"openai/gpt-4-1106-preview": {
 			"id": "openai/gpt-4-1106-preview",
-			"name": "OpenAI: GPT-4 Turbo (older v1106)",
+			"name": "OpenAI: GPT-4 Turbo (older v1106) ($$$$)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -14345,7 +14455,7 @@
 		},
 		"openai/gpt-4-turbo-preview": {
 			"id": "openai/gpt-4-turbo-preview",
-			"name": "OpenAI: GPT-4 Turbo Preview",
+			"name": "OpenAI: GPT-4 Turbo Preview ($$$$)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -14682,7 +14792,7 @@
 		},
 		"openai/gpt-5-image": {
 			"id": "openai/gpt-5-image",
-			"name": "OpenAI: GPT-5 Image",
+			"name": "OpenAI: GPT-5 Image ($$$$)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -14758,7 +14868,7 @@
 		},
 		"openai/gpt-5-pro": {
 			"id": "openai/gpt-5-pro",
-			"name": "OpenAI: GPT-5 Pro",
+			"name": "OpenAI: GPT-5 Pro ($$$$)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -14916,7 +15026,7 @@
 		},
 		"openai/gpt-5.2-chat": {
 			"id": "openai/gpt-5.2-chat",
-			"name": "OpenAI: GPT-5.2 Chat",
+			"name": "OpenAI: GPT-5.2 Chat (retires Aug 10)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -15403,7 +15513,7 @@
 		},
 		"openai/o3-deep-research": {
 			"id": "openai/o3-deep-research",
-			"name": "OpenAI: o3 Deep Research",
+			"name": "OpenAI: o3 Deep Research ($$$$)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -16242,7 +16352,7 @@
 		},
 		"qwen/qwen3-30b-a3b": {
 			"id": "qwen/qwen3-30b-a3b",
-			"name": "Qwen: Qwen3 30B A3B",
+			"name": "Qwen: Qwen3 30B A3B (retires Jun 5)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -17129,7 +17239,7 @@
 		},
 		"sao10k/l3-euryale-70b": {
 			"id": "sao10k/l3-euryale-70b",
-			"name": "Sao10k: Llama 3 Euryale 70B v2.1",
+			"name": "Sao10k: Llama 3 Euryale 70B v2.1 (retires Jun 5)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -17260,9 +17370,47 @@
 			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
+		"stealth/claude-opus-4.8": {
+			"id": "stealth/claude-opus-4.8",
+			"name": "Stealth: Claude Opus 4.8 (20% off)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"stealth/claude-sonnet-4.6": {
 			"id": "stealth/claude-sonnet-4.6",
 			"name": "Stealth: Claude Sonnet 4.6 (20% off)",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"stealth/qwen3.6-plus": {
+			"id": "stealth/qwen3.6-plus",
+			"name": "Stealth: Qwen3.6 Plus (50% off)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -17320,6 +17468,25 @@
 		"stepfun/step-3.7-flash": {
 			"id": "stepfun/step-3.7-flash",
 			"name": "StepFun: Step 3.7 Flash",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"stepfun/step-3.7-flash:free": {
+			"id": "stepfun/step-3.7-flash:free",
+			"name": "StepFun: Step 3.7 Flash (free)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -59009,6 +59176,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"stepfun-ai/step-3.7-flash": {
+			"id": "stepfun-ai/step-3.7-flash",
+			"name": "Step 3.7 Flash",
+			"api": "openai-completions",
+			"provider": "nvidia",
+			"baseUrl": "https://integrate.api.nvidia.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"upstage/solar-10_7b-instruct": {
 			"id": "upstage/solar-10_7b-instruct",
 			"name": "solar-10.7b-instruct",
@@ -60681,7 +60873,7 @@
 			"contextWindow": 272000,
 			"maxTokens": 128000,
 			"preferWebsockets": true,
-			"priority": 9,
+			"priority": 0,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
@@ -61119,6 +61311,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"minimax-m3": {
+			"id": "minimax-m3",
+			"name": "MiniMax M3",
+			"api": "anthropic-messages",
+			"provider": "opencode-go",
+			"baseUrl": "https://opencode.ai/zen/go",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 2.4,
+				"cacheRead": 0.12,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"qwen3.5-plus": {
 			"id": "qwen3.5-plus",
 			"name": "Qwen3.5 Plus",
@@ -61462,6 +61679,30 @@
 				"mode": "anthropic-adaptive",
 				"minLevel": "minimal",
 				"maxLevel": "high"
+			}
+		},
+		"deepseek-v4-flash": {
+			"id": "deepseek-v4-flash",
+			"name": "DeepSeek V4 Flash",
+			"api": "openai-completions",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.14,
+				"output": 0.28,
+				"cacheRead": 0.03,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 384000,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
 			}
 		},
 		"deepseek-v4-flash-free": {
@@ -62370,8 +62611,8 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 1000000,
-			"maxTokens": 128000,
+			"contextWindow": 200000,
+			"maxTokens": 32000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -62470,6 +62711,31 @@
 			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"minimax-m3-free": {
+			"id": "minimax-m3-free",
+			"name": "MiniMax M3 Free",
+			"api": "anthropic-messages",
+			"provider": "opencode-zen",
+			"baseUrl": "https://opencode.ai/zen",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 32000,
+			"thinking": {
+				"mode": "budget",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
@@ -62754,13 +63020,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.73,
-				"output": 3.49,
-				"cacheRead": 0.25,
+				"input": 0.684,
+				"output": 3.42,
+				"cacheRead": 0.144,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262142,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -63829,8 +64095,8 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.2288,
-				"output": 0.9144,
+				"input": 0.20020000000000002,
+				"output": 0.8000999999999999,
 				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
@@ -63992,13 +64258,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.252,
-				"output": 0.378,
+				"input": 0.2288,
+				"output": 0.3432,
 				"cacheRead": 0.0252,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 65536,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -64040,13 +64306,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
-				"output": 0.19999999999999998,
-				"cacheRead": 0.02,
+				"input": 0.0983,
+				"output": 0.1966,
+				"cacheRead": 0.019700000000000002,
 				"cacheWrite": 0
 			},
 			"contextWindow": 1048576,
-			"maxTokens": 16384,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -64845,9 +65111,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.075,
-				"output": 0.625,
-				"cacheRead": 0.015,
+				"input": 0.3,
+				"output": 2.5,
+				"cacheRead": 0.06,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -65234,6 +65500,31 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"minimax/minimax-m3": {
+			"id": "minimax/minimax-m3",
+			"name": "MiniMax: MiniMax M3",
+			"api": "openai-completions",
+			"provider": "openrouter",
+			"baseUrl": "https://openrouter.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0.06,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 512000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -65874,13 +66165,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.73,
-				"output": 3.49,
-				"cacheRead": 0.25,
+				"input": 0.684,
+				"output": 3.42,
+				"cacheRead": 0.144,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262142,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -67301,13 +67592,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.03,
+				"input": 0.029,
 				"output": 0.14,
 				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 131072,
+			"maxTokens": 65536,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -68062,13 +68353,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.14950000000000002,
-				"output": 1.495,
-				"cacheRead": 0.055,
+				"input": 0.09999999999999999,
+				"output": 0.09999999999999999,
+				"cacheRead": 0.09999999999999999,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 8888,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -68110,13 +68401,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09,
-				"output": 0.3,
+				"input": 0.0428,
+				"output": 0.1716,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 262144
+			"contextWindow": 131072,
+			"maxTokens": 32000
 		},
 		"qwen/qwen3-30b-a3b-thinking-2507": {
 			"id": "qwen/qwen3-30b-a3b-thinking-2507",
@@ -68698,13 +68989,13 @@
 				"image"
 			],
 			"cost": {
-				"input": 0.13899999999999998,
+				"input": 0.14,
 				"output": 1,
 				"cacheRead": 0.049999999999999996,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 8888,
+			"maxTokens": 262144,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -70068,12 +70359,12 @@
 			],
 			"cost": {
 				"input": 0.6,
-				"output": 1.92,
+				"output": 2.08,
 				"cacheRead": 0.12,
 				"cacheWrite": 0
 			},
 			"contextWindow": 202752,
-			"maxTokens": 128000,
+			"maxTokens": 16384,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -71118,7 +71409,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 222222,
+			"contextWindow": 1000000,
 			"maxTokens": 8888,
 			"compat": {
 				"supportsUsageInStreaming": false
@@ -72334,6 +72625,34 @@
 				"supportsUsageInStreaming": false
 			}
 		},
+		"minimax-m3": {
+			"id": "minimax-m3",
+			"name": "MiniMax M3",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 500000,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsUsageInStreaming": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"mistral-31-24b": {
 			"id": "mistral-31-24b",
 			"name": "Venice Medium",
@@ -73291,22 +73610,27 @@
 		},
 		"alibaba/qwen-3-235b": {
 			"id": "alibaba/qwen-3-235b",
-			"name": "Qwen3 235B A22b Instruct 2507",
+			"name": "Qwen3 235B A22B",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
 			"cost": {
-				"input": 0.6,
-				"output": 1.2,
+				"input": 0.22,
+				"output": 0.88,
 				"cacheRead": 0.6,
 				"cacheWrite": 0
 			},
-			"contextWindow": 131000,
-			"maxTokens": 40000
+			"contextWindow": 262144,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"alibaba/qwen-3-30b": {
 			"id": "alibaba/qwen-3-30b",
@@ -73412,7 +73736,7 @@
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text"
 			],
@@ -73423,7 +73747,12 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 65536
+			"maxTokens": 65536,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"alibaba/qwen3-coder-30b-a3b": {
 			"id": "alibaba/qwen3-coder-30b-a3b",
@@ -73548,6 +73877,49 @@
 			},
 			"contextWindow": 256000,
 			"maxTokens": 65536,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"alibaba/qwen3-next-80b-a3b-instruct": {
+			"id": "alibaba/qwen3-next-80b-a3b-instruct",
+			"name": "Qwen3 Next 80B A3B Instruct",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 1.2,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768
+		},
+		"alibaba/qwen3-next-80b-a3b-thinking": {
+			"id": "alibaba/qwen3-next-80b-a3b-thinking",
+			"name": "Qwen3 Next 80B A3B Thinking",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 1.2,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 32768,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -73697,6 +74069,31 @@
 				"cacheWrite": 1.5625
 			},
 			"contextWindow": 991000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"alibaba/qwen3.7-plus": {
+			"id": "alibaba/qwen3.7-plus",
+			"name": "Qwen 3.7 Plus",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.39999999999999997,
+				"output": 1.5999999999999999,
+				"cacheRead": 0.08,
+				"cacheWrite": 0.5
+			},
+			"contextWindow": 1000000,
 			"maxTokens": 64000,
 			"thinking": {
 				"mode": "budget",
@@ -74175,17 +74572,17 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.77,
-				"output": 0.77,
-				"cacheRead": 0,
+				"input": 0.27,
+				"output": 1.12,
+				"cacheRead": 0.135,
 				"cacheWrite": 0
 			},
 			"contextWindow": 163840,
-			"maxTokens": 16384
+			"maxTokens": 163840
 		},
 		"deepseek/deepseek-v3.1": {
 			"id": "deepseek/deepseek-v3.1",
-			"name": "DeepSeek-V3.1",
+			"name": "DeepSeek V3.1",
 			"api": "anthropic-messages",
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"provider": "vercel-ai-gateway",
@@ -74263,7 +74660,8 @@
 			"provider": "vercel-ai-gateway",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.62,
@@ -75036,7 +75434,8 @@
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 0.6,
@@ -75094,6 +75493,31 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131100,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"minimax/minimax-m3": {
+			"id": "minimax/minimax-m3",
+			"name": "MiniMax M3",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.3,
+				"output": 1.2,
+				"cacheRead": 0.06,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 1000000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -75257,6 +75681,25 @@
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
+		},
+		"mistral/mistral-nemo": {
+			"id": "mistral/mistral-nemo",
+			"name": "Mistral Nemo 12B",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.02,
+				"output": 0.04,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 131072,
+			"maxTokens": 131072
 		},
 		"mistral/mistral-small": {
 			"id": "mistral/mistral-small",
@@ -75467,6 +75910,30 @@
 			},
 			"contextWindow": 262000,
 			"maxTokens": 262000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"nvidia/nemotron-3-super-120b-a12b": {
+			"id": "nvidia/nemotron-3-super-120b-a12b",
+			"name": "Nemotron 3 Super",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.65,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 32000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -76235,13 +76702,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09999999999999999,
-				"output": 0.5,
-				"cacheRead": 0,
+				"input": 0.35,
+				"output": 0.75,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 131072,
-			"maxTokens": 65536,
+			"maxTokens": 131000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -76503,6 +76970,50 @@
 			},
 			"contextWindow": 131072,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"stepfun/step-3.5-flash": {
+			"id": "stepfun/step-3.5-flash",
+			"name": "Step 3.5 Flash",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.09,
+				"output": 0.3,
+				"cacheRead": 0,
+				"cacheWrite": 0.02
+			},
+			"contextWindow": 262114,
+			"maxTokens": 262114
+		},
+		"stepfun/step-3.7-flash": {
+			"id": "stepfun/step-3.7-flash",
+			"name": "Step 3.7 Flash",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.19999999999999998,
+				"output": 1.15,
+				"cacheRead": 0.04,
+				"cacheWrite": 0
+			},
+			"contextWindow": 256000,
+			"maxTokens": 256000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -77346,7 +77857,8 @@
 			"baseUrl": "https://ai-gateway.vercel.sh",
 			"reasoning": true,
 			"input": [
-				"text"
+				"text",
+				"image"
 			],
 			"cost": {
 				"input": 1.4,
@@ -78545,6 +79057,165 @@
 			"name": "MiMo-V2.5-Pro",
 			"api": "openai-completions",
 			"provider": "xiaomi",
+			"baseUrl": "https://api.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1,
+				"output": 3,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		}
+	},
+	"xiaomimimo": {
+		"mimo-v2-flash": {
+			"id": "mimo-v2-flash",
+			"name": "MiMo-V2-Flash",
+			"api": "openai-completions",
+			"provider": "xiaomimimo",
+			"baseUrl": "https://api.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.1,
+				"output": 0.3,
+				"cacheRead": 0.01,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 65536,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2-omni": {
+			"id": "mimo-v2-omni",
+			"name": "MiMo-V2-Omni",
+			"api": "openai-completions",
+			"provider": "xiaomimimo",
+			"baseUrl": "https://api.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.4,
+				"output": 2,
+				"cacheRead": 0.08,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2-pro": {
+			"id": "mimo-v2-pro",
+			"name": "MiMo-V2-Pro",
+			"api": "openai-completions",
+			"provider": "xiaomimimo",
+			"baseUrl": "https://api.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 1,
+				"output": 3,
+				"cacheRead": 0.2,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2.5": {
+			"id": "mimo-v2.5",
+			"name": "MiMo-V2.5",
+			"api": "openai-completions",
+			"provider": "xiaomimimo",
+			"baseUrl": "https://api.xiaomimimo.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.4,
+				"output": 2,
+				"cacheRead": 0.08,
+				"cacheWrite": 0
+			},
+			"contextWindow": 1048576,
+			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"thinkingFormat": "zai",
+				"reasoningContentField": "reasoning_content",
+				"requiresReasoningContentForToolCalls": true,
+				"allowsSyntheticReasoningContentForToolCalls": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"mimo-v2.5-pro": {
+			"id": "mimo-v2.5-pro",
+			"name": "MiMo-V2.5-Pro",
+			"api": "openai-completions",
+			"provider": "xiaomimimo",
 			"baseUrl": "https://api.xiaomimimo.com/v1",
 			"reasoning": true,
 			"input": [

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -44,6 +44,7 @@ import {
 	xaiModelManagerOptions,
 	xaiOAuthModelManagerOptions,
 	xiaomiModelManagerOptions,
+	xiaomimimoModelManagerOptions,
 	zenmuxModelManagerOptions,
 	zhipuCodingPlanModelManagerOptions,
 } from "./openai-compat";
@@ -311,6 +312,12 @@ export const PROVIDER_DESCRIPTORS: readonly ProviderDescriptor[] = [
 		"mimo-v2-flash",
 		config => xiaomiModelManagerOptions(config),
 		catalog("Xiaomi", ["XIAOMI_API_KEY"]),
+	),
+	catalogDescriptor(
+		"xiaomimimo",
+		"mimo-v2-flash",
+		config => xiaomimimoModelManagerOptions(config),
+		catalog("Xiaomi MiMo", ["XIAOMIMIMO_API_KEY", "XIAOMI_API_KEY"]),
 	),
 	catalogDescriptor(
 		"zenmux",

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -1961,6 +1961,39 @@ export function xiaomiModelManagerOptions(
 	};
 }
 // ---------------------------------------------------------------------------
+// 20.5 Xiaomi MiMo (xiaomimimo)
+// ---------------------------------------------------------------------------
+export interface XiaomimimoModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+}
+export function xiaomimimoModelManagerOptions(config?: XiaomimimoModelManagerConfig): ModelManagerOptions<"openai-completions"> {
+	const apiKey = config?.apiKey;
+	const baseUrl = config?.baseUrl ?? "https://api.xiaomimimo.com/v1";
+	const references = createBundledReferenceMap<"openai-completions">("xiaomimimo");
+	return {
+		providerId: "xiaomimimo",
+		...(apiKey && {
+			fetchDynamicModels: () =>
+				fetchOpenAICompatibleModels({
+					api: "openai-completions",
+					provider: "xiaomimimo",
+					baseUrl,
+					apiKey,
+					filterModel: (_entry, model) => !model.id.includes("-tts"),
+					mapModel: (entry, defaults) => {
+						const reference = references.get(defaults.id);
+						const base = reference ? mapWithBundledReference(entry, defaults, reference) : defaults;
+						return {
+							...base,
+							name: toModelName(entry.display_name, base.name),
+						};
+					},
+				}),
+		}),
+	};
+}
+// ---------------------------------------------------------------------------
 // 21. LiteLLM
 // ---------------------------------------------------------------------------
 
@@ -2667,6 +2700,18 @@ const MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS: readonly ModelsDevProviderDe
 	anthropicMessagesDescriptor("zai-coding-plan", "zai", "https://api.z.ai/api/anthropic"),
 	// --- Xiaomi ---
 	openAiCompletionsDescriptor("xiaomi", "xiaomi", "https://api.xiaomimimo.com/v1", {
+		defaultContextWindow: 262144,
+		defaultMaxTokens: 8192,
+		compat: {
+			supportsStore: false,
+			thinkingFormat: "zai",
+			reasoningContentField: "reasoning_content",
+			requiresReasoningContentForToolCalls: true,
+			allowsSyntheticReasoningContentForToolCalls: false,
+		},
+	}),
+	// --- Xiaomi MiMo (xiaomimimo) ---
+	openAiCompletionsDescriptor("xiaomi", "xiaomimimo", "https://api.xiaomimimo.com/v1", {
 		defaultContextWindow: 262144,
 		defaultMaxTokens: 8192,
 		compat: {

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -91,6 +91,30 @@ export type AnthropicHeaderOptions = {
 	isCloudflareAiGateway?: boolean;
 };
 
+/**
+ * Widened idle timeout floor for slow GLM-5 reasoning models served via the
+ * Anthropic-compatible endpoint (zai/glm-5*, zhipu's anthropic mount). The
+ * openai-completions transport already widens to 600s for the same family —
+ * see `getOpenAICompletionsStreamIdleTimeoutFallbackMs` in
+ * `openai-completions.ts`. Without this, z.ai's /v1/messages can stall past
+ * the 100s first-event default (cold start + reasoning), producing 0-token
+ * "ghost" runs that look like agent failures.
+ */
+const ANTHROPIC_GLM_STREAM_IDLE_TIMEOUT_MS = 600_000;
+const ANTHROPIC_GLM_MODEL_PATTERN = /^glm-5(?:[.-]|$)/i;
+
+export function getAnthropicStreamIdleTimeoutFallbackMs(model: Model<"anthropic-messages">): number | undefined {
+	if (!ANTHROPIC_GLM_MODEL_PATTERN.test(model.id)) return undefined;
+	if (model.provider === "zai" || model.provider === "zhipu-coding-plan") {
+		return ANTHROPIC_GLM_STREAM_IDLE_TIMEOUT_MS;
+	}
+	const baseUrl = model.baseUrl.toLowerCase();
+	if (baseUrl.includes("api.z.ai") || baseUrl.includes("open.bigmodel.cn")) {
+		return ANTHROPIC_GLM_STREAM_IDLE_TIMEOUT_MS;
+	}
+	return undefined;
+}
+
 export function normalizeAnthropicBaseUrl(baseUrl?: string): string | undefined {
 	const trimmed = baseUrl?.trim();
 	if (!trimmed) {
@@ -1206,7 +1230,8 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 				| TextContent
 				| (ToolCall & { partialJson: string; lastParseLen?: number })
 			) & { index: number };
-			const idleTimeoutMs = options?.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs();
+			const idleTimeoutMs =
+				options?.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs(getAnthropicStreamIdleTimeoutFallbackMs(model));
 			const firstEventTimeoutMs = options?.streamFirstEventTimeoutMs ?? getStreamFirstEventTimeoutMs(idleTimeoutMs);
 			const requestTimeoutMs =
 				firstEventTimeoutMs !== undefined && firstEventTimeoutMs > 0 ? firstEventTimeoutMs : undefined;

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -101,7 +101,7 @@ export type AnthropicHeaderOptions = {
  * "ghost" runs that look like agent failures.
  */
 const ANTHROPIC_GLM_STREAM_IDLE_TIMEOUT_MS = 600_000;
-const ANTHROPIC_GLM_MODEL_PATTERN = /^glm-5(?:[.-]|$)/i;
+const ANTHROPIC_GLM_MODEL_PATTERN = /(?:^|\.)(glm-5)/i;
 
 export function getAnthropicStreamIdleTimeoutFallbackMs(model: Model<"anthropic-messages">): number | undefined {
 	if (!ANTHROPIC_GLM_MODEL_PATTERN.test(model.id)) return undefined;

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -266,6 +266,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	venice: "VENICE_API_KEY",
 	vllm: "VLLM_API_KEY",
 	xiaomi: "XIAOMI_API_KEY",
+	xiaomimimo: () => $pickenv("XIAOMIMIMO_API_KEY", "XIAOMI_API_KEY"),
 };
 
 /**

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -142,6 +142,7 @@ export type KnownProvider =
 	| "venice"
 	| "vllm"
 	| "xiaomi"
+	| "xiaomimimo"
 	| "wafer-pass"
 	| "wafer-serverless"
 	| "zenmux"

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -103,6 +103,11 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		available: true,
 	},
 	{
+		id: "xiaomimimo",
+		name: "Xiaomi MiMo (xiaomimimo)",
+		available: true,
+	},
+	{
 		id: "firepass",
 		name: "Fire Pass (Fireworks Kimi K2.6 Turbo subscription)",
 		available: true,
@@ -364,6 +369,7 @@ export async function refreshOAuthToken(
 		case "ollama":
 		case "ollama-cloud":
 		case "xiaomi":
+		case "xiaomimimo":
 		case "zai":
 		case "zhipu-coding-plan":
 		case "qianfan":

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -53,6 +53,7 @@ export type OAuthProvider =
 	| "vllm"
 	| "xai-oauth"
 	| "xiaomi"
+	| "xiaomimimo"
 	| "zenmux"
 	| "zai"
 	| "zhipu-coding-plan";

--- a/packages/coding-agent/src/autoresearch/tools/run-experiment.ts
+++ b/packages/coding-agent/src/autoresearch/tools/run-experiment.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { Text } from "@oh-my-pi/pi-tui";
-import { formatBytes } from "@oh-my-pi/pi-utils";
+import { formatBytes, procmgr } from "@oh-my-pi/pi-utils";
 import * as z from "zod/v4";
 import { executeBash } from "../../exec/bash-executor";
 import type { ToolDefinition } from "../../extensibility/extensions";
@@ -114,9 +114,14 @@ export function createRunExperimentTool(
 
 			const timeoutMs = Math.max(0, Math.floor((params.timeout_seconds ?? 600) * 1000));
 			let execution: ProcessExecutionResult;
+			// Resolve bash via the same platform-aware logic the bash tool uses.
+			// On Windows this picks Git Bash (`C:\Program Files\Git\bin\bash.exe`)
+			// rather than letting CreateProcess fall back to WSL's `bash.exe`,
+			// which fails on hosts without the WSL2 platform installed.
+			const shellPath = procmgr.getShellConfig().shell;
 			try {
 				execution = await executeProcess({
-					command: resolvedCommand,
+					command: [shellPath, "-lc", resolvedCommand],
 					cwd: ctx.cwd,
 					logPath: benchmarkLogPath,
 					timeoutMs,

--- a/packages/coding-agent/src/autoresearch/tools/run-experiment.ts
+++ b/packages/coding-agent/src/autoresearch/tools/run-experiment.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { Text } from "@oh-my-pi/pi-tui";
-import { formatBytes, procmgr } from "@oh-my-pi/pi-utils";
+import { formatBytes } from "@oh-my-pi/pi-utils";
 import * as z from "zod/v4";
 import { executeBash } from "../../exec/bash-executor";
 import type { ToolDefinition } from "../../extensibility/extensions";
@@ -114,14 +114,9 @@ export function createRunExperimentTool(
 
 			const timeoutMs = Math.max(0, Math.floor((params.timeout_seconds ?? 600) * 1000));
 			let execution: ProcessExecutionResult;
-			// Resolve bash via the same platform-aware logic the bash tool uses.
-			// On Windows this picks Git Bash (`C:\Program Files\Git\bin\bash.exe`)
-			// rather than letting CreateProcess fall back to WSL's `bash.exe`,
-			// which fails on hosts without the WSL2 platform installed.
-			const shellPath = procmgr.getShellConfig().shell;
 			try {
 				execution = await executeProcess({
-					command: [shellPath, "-lc", resolvedCommand],
+					command: resolvedCommand,
 					cwd: ctx.cwd,
 					logPath: benchmarkLogPath,
 					timeoutMs,

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1869,7 +1869,7 @@ export const SETTINGS_SCHEMA = {
 
 	"read.summarize.minBodyLines": {
 		type: "number",
-		default: 4,
+		default: 12,
 		ui: {
 			tab: "editing",
 			label: "Read Summary Body Lines",

--- a/packages/coding-agent/src/model-families.ts
+++ b/packages/coding-agent/src/model-families.ts
@@ -31,3 +31,17 @@ export function isKimiClassModelString(id: string | undefined | null): boolean {
 	if (!id) return false;
 	return KIMI_CLASS_MODEL_REGEX.test(id);
 }
+
+/**
+ * GLM-specific predicate. Used for behaviors that empirically help glm-5.x but
+ * regress kimi (e.g. the retry-context diff-direction addendum bullet — glm
+ * benefits from explicit `-`/`+` interpretation while kimi handles it natively).
+ * Strict subset of `isKimiClassModel`.
+ */
+const GLM_MODEL_REGEX = /(?:^|\/)glm-/i;
+
+/** True when the given resolved model belongs to the GLM family specifically. */
+export function isGlmModel(m: Model | undefined): boolean {
+	if (!m) return false;
+	return GLM_MODEL_REGEX.test(m.id);
+}

--- a/packages/coding-agent/src/model-families.ts
+++ b/packages/coding-agent/src/model-families.ts
@@ -9,9 +9,9 @@ import type { Model } from "@oh-my-pi/pi-ai";
 /**
  * Model families that emit verbose inline `<thinking>...</thinking>` text in
  * their assistant content stream rather than using a provider-side reasoning
- * channel. Kimi K2.x, GLM-5.x, and Qwen are trained to emit these blocks even
- * when the API reasoning toggle is off. The agent applies a bundle of
- * narrowly-targeted mitigations gated on this predicate:
+ * channel. Kimi K2.x, GLM-5.x, Qwen, and Xiaomi MiMo are trained to emit these
+ * blocks even when the API reasoning toggle is off. The agent applies a bundle
+ * of narrowly-targeted mitigations gated on this predicate:
  *  - system-prompt addendum suppressing `<thinking>` tags
  *  - past-turn `<thinking>` strip before LLM replay
  *  - per-attempt content-character cap to bound wall-clock
@@ -24,29 +24,31 @@ import type { Model } from "@oh-my-pi/pi-ai";
  *  - `kimi[-_]` / `glm[-_]`: the family stem MUST be followed by `-` or `_`.
  *    Every shipped id is `kimi-…` / `glm-…`; the bare stems never appear and
  *    requiring the delimiter blocks `kimibara`, `glmnopq`, …
- *  - `qwen(?![a-z])`: the family stem MUST NOT be followed by another ASCII
- *    letter. The negative lookahead lets EVERY shipped boundary through — `-`,
- *    `_`, digits, `.` (vendor-prefixed bedrock ids like `qwen.qwen3-…`), `/`
- *    (path-style `qwen/qwq-32b`, `qwen/qwen3-32b`), `:`, end-of-string
- *    (bare `qwen`) — while rejecting unrelated `qwen` prefixes such as
- *    `qweniverse`, `qwentastic-7b`. `/i` makes the lookahead case-insensitive
- *    too, so a hypothetical `qwenIverse` is also excluded.
+ *  - `qwen(?![a-z])` / `mimo(?![a-z])`: the family stem MUST NOT be followed
+ *    by another ASCII letter. The negative lookahead lets EVERY shipped
+ *    boundary through — `-`, `_`, digits, `.` (vendor-prefixed bedrock ids
+ *    like `qwen.qwen3-…`), `/` (path-style `qwen/qwq-32b`, `xiaomi/mimo-7b`),
+ *    `:`, end-of-string (bare `qwen` / `mimo`) — while rejecting unrelated
+ *    prefixes such as `qweniverse`, `qwentastic-7b`, `mimosa`, `mimography`.
+ *    `/i` makes the lookahead case-insensitive too, so `qwenIverse` and
+ *    `MiMography` are also excluded.
  *
  * Intentional matches (sampled across `packages/ai/src/models.json`):
  *   kimi-k2.5, kimi-k2.6-turbo, glm-4.7, glm-5, glm-5.1,
  *   qwen, qwen3, qwen3-coder-plus, qwen3.5-plus, qwen-vl,
  *   qwen2.5-coder-32b-instruct, qwen.qwen3-235b-a22b-2507-v1:0,
- *   qwen/qwq-32b, qwen/qwen3-32b, openrouter/kimi-k2.
+ *   qwen/qwq-32b, qwen/qwen3-32b, openrouter/kimi-k2,
+ *   xiaomi/mimo-7b, mimo-coder-7b, crof/mimo-v2.5-pro.
  */
-const KIMI_CLASS_MODEL_REGEX = /(?:^|\/)(kimi[-_]|glm[-_]|qwen(?![a-z]))/i;
+const KIMI_CLASS_MODEL_REGEX = /(?:^|\/)(kimi[-_]|glm[-_]|qwen(?![a-z])|mimo(?![a-z]))/i;
 
-/** True when the given resolved model belongs to the kimi/glm/qwen family. */
+/** True when the given resolved model belongs to the kimi/glm/qwen/mimo family. */
 export function isKimiClassModel(m: Model | undefined): boolean {
 	if (!m) return false;
 	return KIMI_CLASS_MODEL_REGEX.test(m.id);
 }
 
-/** True when the given model identifier string belongs to the kimi/glm/qwen family. */
+/** True when the given model identifier string belongs to the kimi/glm/qwen/mimo family. */
 export function isKimiClassModelString(id: string | undefined | null): boolean {
 	if (!id) return false;
 	return KIMI_CLASS_MODEL_REGEX.test(id);
@@ -64,4 +66,25 @@ const GLM_MODEL_REGEX = /(?:^|\/)glm-/i;
 export function isGlmModel(m: Model | undefined): boolean {
 	if (!m) return false;
 	return GLM_MODEL_REGEX.test(m.id);
+}
+
+/**
+ * DeepSeek-V3/V4 family predicate. DeepSeek's official coder guidance recommends
+ * `temperature=0.0` for code generation (deterministic decoding); provider
+ * defaults are conversational (~1.0) and empirically too noisy for tool-calling
+ * loops. Disjoint from `isKimiClassModel` — DeepSeek doesn't emit inline
+ * `<thinking>` content, so the kimi-class mitigations don't apply; only the
+ * sampling override does.
+ *
+ * Boundary: `deepseek(?![a-z])` mirrors the qwen/mimo pattern — accepts every
+ * shipped id (`deepseek-coder`, `deepseek-v3`, `deepseek-r1-distill-…`,
+ * vendor-prefixed `crof/deepseek-v4-pro-precision`) while rejecting hypothetical
+ * `deepseekend` or `deepseekery` prefixes.
+ */
+const DEEPSEEK_MODEL_REGEX = /(?:^|\/)deepseek(?![a-z])/i;
+
+/** True when the given resolved model belongs to the DeepSeek family. */
+export function isDeepseekModel(m: Model | undefined): boolean {
+	if (!m) return false;
+	return DEEPSEEK_MODEL_REGEX.test(m.id);
 }

--- a/packages/coding-agent/src/model-families.ts
+++ b/packages/coding-agent/src/model-families.ts
@@ -40,7 +40,7 @@ import type { Model } from "@oh-my-pi/pi-ai";
  *   qwen/qwq-32b, qwen/qwen3-32b, openrouter/kimi-k2,
  *   xiaomi/mimo-7b, mimo-coder-7b, crof/mimo-v2.5-pro.
  */
-const KIMI_CLASS_MODEL_REGEX = /(?:^|\.|\/)(kimi[-_]|glm[-_]|qwen(?![a-z])|mimo(?![a-z]))/i;
+const KIMI_CLASS_MODEL_REGEX = /(?:^|\.|\/|-)(kimi[-_]|glm[-_]|qwen(?![a-z])|mimo(?![a-z]))/i;
 
 /** True when the given resolved model belongs to the kimi/glm/qwen/mimo family. */
 export function isKimiClassModel(m: Model | undefined): boolean {

--- a/packages/coding-agent/src/model-families.ts
+++ b/packages/coding-agent/src/model-families.ts
@@ -17,8 +17,28 @@ import type { Model } from "@oh-my-pi/pi-ai";
  *  - per-attempt content-character cap to bound wall-clock
  *  - tighter structural-summary inline-body threshold
  *  - softer elision-footer wording
+ *
+ * Boundary contract — every alternation requires a non-alphabetic delimiter
+ * after the family stem so an accidental prefix can never satisfy the
+ * predicate. After the path anchor `(?:^|\/)`:
+ *  - `kimi[-_]` / `glm[-_]`: the family stem MUST be followed by `-` or `_`.
+ *    Every shipped id is `kimi-…` / `glm-…`; the bare stems never appear and
+ *    requiring the delimiter blocks `kimibara`, `glmnopq`, …
+ *  - `qwen(?![a-z])`: the family stem MUST NOT be followed by another ASCII
+ *    letter. The negative lookahead lets EVERY shipped boundary through — `-`,
+ *    `_`, digits, `.` (vendor-prefixed bedrock ids like `qwen.qwen3-…`), `/`
+ *    (path-style `qwen/qwq-32b`, `qwen/qwen3-32b`), `:`, end-of-string
+ *    (bare `qwen`) — while rejecting unrelated `qwen` prefixes such as
+ *    `qweniverse`, `qwentastic-7b`. `/i` makes the lookahead case-insensitive
+ *    too, so a hypothetical `qwenIverse` is also excluded.
+ *
+ * Intentional matches (sampled across `packages/ai/src/models.json`):
+ *   kimi-k2.5, kimi-k2.6-turbo, glm-4.7, glm-5, glm-5.1,
+ *   qwen, qwen3, qwen3-coder-plus, qwen3.5-plus, qwen-vl,
+ *   qwen2.5-coder-32b-instruct, qwen.qwen3-235b-a22b-2507-v1:0,
+ *   qwen/qwq-32b, qwen/qwen3-32b, openrouter/kimi-k2.
  */
-const KIMI_CLASS_MODEL_REGEX = /(?:^|\/)(kimi|glm-|qwen)/i;
+const KIMI_CLASS_MODEL_REGEX = /(?:^|\/)(kimi[-_]|glm[-_]|qwen(?![a-z]))/i;
 
 /** True when the given resolved model belongs to the kimi/glm/qwen family. */
 export function isKimiClassModel(m: Model | undefined): boolean {

--- a/packages/coding-agent/src/model-families.ts
+++ b/packages/coding-agent/src/model-families.ts
@@ -81,7 +81,7 @@ export function isGlmModel(m: Model | undefined): boolean {
  * vendor-prefixed `crof/deepseek-v4-pro-precision`) while rejecting hypothetical
  * `deepseekend` or `deepseekery` prefixes.
  */
-const DEEPSEEK_MODEL_REGEX = /(?:^|\/)deepseek(?![a-z])/i;
+const DEEPSEEK_MODEL_REGEX = /(?:^|\.|\/|-)deepseek(?![a-z])/i;
 
 /** True when the given resolved model belongs to the DeepSeek family. */
 export function isDeepseekModel(m: Model | undefined): boolean {

--- a/packages/coding-agent/src/model-families.ts
+++ b/packages/coding-agent/src/model-families.ts
@@ -40,7 +40,7 @@ import type { Model } from "@oh-my-pi/pi-ai";
  *   qwen/qwq-32b, qwen/qwen3-32b, openrouter/kimi-k2,
  *   xiaomi/mimo-7b, mimo-coder-7b, crof/mimo-v2.5-pro.
  */
-const KIMI_CLASS_MODEL_REGEX = /(?:^|\/)(kimi[-_]|glm[-_]|qwen(?![a-z])|mimo(?![a-z]))/i;
+const KIMI_CLASS_MODEL_REGEX = /(?:^|\.|\/)(kimi[-_]|glm[-_]|qwen(?![a-z])|mimo(?![a-z]))/i;
 
 /** True when the given resolved model belongs to the kimi/glm/qwen/mimo family. */
 export function isKimiClassModel(m: Model | undefined): boolean {
@@ -60,7 +60,7 @@ export function isKimiClassModelString(id: string | undefined | null): boolean {
  * benefits from explicit `-`/`+` interpretation while kimi handles it natively).
  * Strict subset of `isKimiClassModel`.
  */
-const GLM_MODEL_REGEX = /(?:^|\/)glm-/i;
+const GLM_MODEL_REGEX = /(?:^|\.|\/)glm-/i;
 
 /** True when the given resolved model belongs to the GLM family specifically. */
 export function isGlmModel(m: Model | undefined): boolean {
@@ -87,4 +87,51 @@ const DEEPSEEK_MODEL_REGEX = /(?:^|\/)deepseek(?![a-z])/i;
 export function isDeepseekModel(m: Model | undefined): boolean {
 	if (!m) return false;
 	return DEEPSEEK_MODEL_REGEX.test(m.id);
+}
+
+/**
+ * Kimi/GLM/Qwen-class non-thinking sampling defaults. Vendor docs converge on
+ * these values for coding-style benchmarks (z.ai GLM-5 SWE-Bench: temp=0.7,
+ * top_p=1.0; GLM-5.1 sweet spot: temp 0.60-0.80, top_p=0.95; Kimi 2.5 insta
+ * mode: temp=0.6, top_p=0.95, min_p=0.01). Provider defaults are tuned for
+ * conversational output and overshoot for coding tasks. Users with explicit
+ * `>= 0` settings keep their override; this only fills in the auto case.
+ */
+export const KIMI_CLASS_SAMPLING_DEFAULTS = {
+	temperature: 0.7,
+	topP: 0.95,
+	minP: 0.01,
+} as const;
+
+export function resolveKimiClassSamplingDefault(
+	m: Model | undefined,
+	rawSetting: number,
+	key: keyof typeof KIMI_CLASS_SAMPLING_DEFAULTS,
+): number | undefined {
+	if (rawSetting >= 0) return rawSetting;
+	if (isKimiClassModel(m)) return KIMI_CLASS_SAMPLING_DEFAULTS[key];
+	return undefined;
+}
+
+/**
+ * DeepSeek-family sampling defaults. DeepSeek's official coder profile
+ * recommends `temperature=0.0` for code generation (deterministic decoding);
+ * provider defaults sit around 1.0 which is conversational and empirically
+ * over-noises tool-calling loops. `top_p=0.95` mirrors the kimi-class topP
+ * value. `minP` intentionally omitted: the DeepSeek API does not surface a
+ * min_p control.
+ */
+export const DEEPSEEK_SAMPLING_DEFAULTS = {
+	temperature: 0.0,
+	topP: 0.95,
+} as const;
+
+export function resolveDeepseekSamplingDefault(
+	m: Model | undefined,
+	rawSetting: number,
+	key: keyof typeof DEEPSEEK_SAMPLING_DEFAULTS,
+): number | undefined {
+	if (rawSetting >= 0) return rawSetting;
+	if (isDeepseekModel(m)) return DEEPSEEK_SAMPLING_DEFAULTS[key];
+	return undefined;
 }

--- a/packages/coding-agent/src/model-families.ts
+++ b/packages/coding-agent/src/model-families.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared model-family predicates used to gate behavior across the coding-agent
+ * runtime. Keeping the regex in one place avoids drift between sdk.ts,
+ * agent-session.ts, and the tool-output renderers — adding a new family is now
+ * a one-line change here.
+ */
+import type { Model } from "@oh-my-pi/pi-ai";
+
+/**
+ * Model families that emit verbose inline `<thinking>...</thinking>` text in
+ * their assistant content stream rather than using a provider-side reasoning
+ * channel. Kimi K2.x, GLM-5.x, and Qwen are trained to emit these blocks even
+ * when the API reasoning toggle is off. The agent applies a bundle of
+ * narrowly-targeted mitigations gated on this predicate:
+ *  - system-prompt addendum suppressing `<thinking>` tags
+ *  - past-turn `<thinking>` strip before LLM replay
+ *  - per-attempt content-character cap to bound wall-clock
+ *  - tighter structural-summary inline-body threshold
+ *  - softer elision-footer wording
+ */
+const KIMI_CLASS_MODEL_REGEX = /(?:^|\/)(kimi|glm-|qwen)/i;
+
+/** True when the given resolved model belongs to the kimi/glm/qwen family. */
+export function isKimiClassModel(m: Model | undefined): boolean {
+	if (!m) return false;
+	return KIMI_CLASS_MODEL_REGEX.test(m.id);
+}
+
+/** True when the given model identifier string belongs to the kimi/glm/qwen family. */
+export function isKimiClassModelString(id: string | undefined | null): boolean {
+	if (!id) return false;
+	return KIMI_CLASS_MODEL_REGEX.test(id);
+}

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -3,7 +3,7 @@ import { Container, Image, ImageProtocol, Markdown, Spacer, TERMINAL, Text } fro
 import { formatNumber } from "@oh-my-pi/pi-utils";
 import { settings } from "../../config/settings";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
-import { isSilentAbort } from "../../session/messages";
+import { isSilentAbort, sanitizeKimiClassAssistantMessage } from "../../session/messages";
 import { resolveImageOptions } from "../../tools/render-utils";
 
 /**
@@ -132,6 +132,11 @@ export class AssistantMessageComponent extends Container {
 	}
 
 	updateContent(message: AssistantMessage): void {
+		// Strip vacuous text artifacts (e.g., lone ".") that kimi-class models emit
+		// between thinking blocks and tool calls. The sanitizer is conservative: it only
+		// removes text blocks that are empty or a single punctuation mark and are
+		// sandwiched between thinking blocks and tool calls.
+		message = sanitizeKimiClassAssistantMessage(message);
 		this.#lastMessage = message;
 
 		// Clear content container

--- a/packages/coding-agent/src/modes/components/session-observer-overlay.ts
+++ b/packages/coding-agent/src/modes/components/session-observer-overlay.ts
@@ -14,11 +14,11 @@
  *   - Esc from picker -> close overlay
  *   - Enter on main session -> close overlay (jump back)
  */
-import type { ToolResultMessage } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { Container, Markdown, type MarkdownTheme, matchesKey } from "@oh-my-pi/pi-tui";
 import { formatDuration, formatNumber, logger } from "@oh-my-pi/pi-utils";
 import type { KeyId } from "../../config/keybindings";
-import { isSilentAbort } from "../../session/messages";
+import { isSilentAbort, sanitizeKimiClassAssistantMessage } from "../../session/messages";
 import type { SessionMessageEntry } from "../../session/session-manager";
 import { parseSessionEntries } from "../../session/session-manager";
 import { PREVIEW_LIMITS, replaceTabs, TRUNCATE_LENGTHS, truncateToWidth } from "../../tools/render-utils";
@@ -303,9 +303,12 @@ export class SessionObserverOverlayComponent extends Container {
 
 		let entryIndex = 0;
 		for (const entry of messageEntries) {
-			const msg = entry.message;
+			let msg = entry.message;
 
 			if (msg.role === "assistant") {
+				// Sanitize vacuous text artifacts (e.g., lone ".") that kimi-class models
+				// emit between thinking blocks and tool calls.
+				msg = sanitizeKimiClassAssistantMessage(msg as AssistantMessage) as typeof msg;
 				// Handle error messages with empty content
 				if (msg.content.length === 0 && msg.errorMessage && !isSilentAbort(msg.errorMessage)) {
 					const startLine = lines.length;

--- a/packages/coding-agent/src/prompts/system/model-behavioral-addendum.md
+++ b/packages/coding-agent/src/prompts/system/model-behavioral-addendum.md
@@ -1,0 +1,8 @@
+## Output discipline
+
+- Do NOT emit `<thinking>` or `</thinking>` tags in your output. Plan internally; state only conclusions, decisions, and tool calls. Long inline `<thinking>` monologues blow past per-turn budgets.
+- When the retry-context diff shows specific `-` (expected) and `+` (your wrong) lines: the diff is GROUND TRUTH — if it contradicts your reading of the task, follow the diff. Reproduce the `-` lines BYTE-EXACT including blank lines and indentation, and UNDO the `+` content from your prior edit. Do not stack a new edit on top of a rejected one.
+{{#if IS_GLM_MODEL}}
+- If a `## Retry context` block shows a diff (lines prefixed with `-` and `+`), the `-` lines are the expected (correct) content and the `+` lines are what's wrong in the current file. Apply an edit that produces the `-` lines — do not re-derive a different fix.
+- When reading files, use a line range selector (e.g. `file.ts:50-100`). After making an edit, do NOT re-read the file or make additional edits to verify — the edit tool already reports success or failure. Move on. Do not revert your own edits. If the task says to change something, make the change once and move on — do not second-guess whether it is semantically meaningful.
+{{/if}}

--- a/packages/coding-agent/src/prompts/system/model-behavioral-addendum.md
+++ b/packages/coding-agent/src/prompts/system/model-behavioral-addendum.md
@@ -2,6 +2,7 @@
 
 - Do NOT emit `<thinking>` or `</thinking>` tags in your output. Plan internally; state only conclusions, decisions, and tool calls. Long inline `<thinking>` monologues blow past per-turn budgets.
 - When the retry-context diff shows specific `-` (expected) and `+` (your wrong) lines: the diff is GROUND TRUTH — if it contradicts your reading of the task, follow the diff. Reproduce the `-` lines BYTE-EXACT including blank lines and indentation, and UNDO the `+` content from your prior edit. Do not stack a new edit on top of a rejected one.
+- Preserve exact TypeScript syntax around generic type parameters: `Type<T>` not `Type < T >`. When editing code that already has spaces in generics, remove them to match standard TypeScript syntax.
 {{#if IS_GLM_MODEL}}
 - If a `## Retry context` block shows a diff (lines prefixed with `-` and `+`), the `-` lines are the expected (correct) content and the `+` lines are what's wrong in the current file. Apply an edit that produces the `-` lines — do not re-derive a different fix.
 - When reading files, use a line range selector (e.g. `file.ts:50-100`). After making an edit, do NOT re-read the file or make additional edits to verify — the edit tool already reports success or failure. Move on. Do not revert your own edits. If the task says to change something, make the change once and move on — do not second-guess whether it is semantically meaningful.

--- a/packages/coding-agent/src/prompts/system/model-behavioral-addendum.md
+++ b/packages/coding-agent/src/prompts/system/model-behavioral-addendum.md
@@ -2,7 +2,6 @@
 
 - Do NOT emit `<thinking>` or `</thinking>` tags in your output. Plan internally; state only conclusions, decisions, and tool calls. Long inline `<thinking>` monologues blow past per-turn budgets.
 - When the retry-context diff shows specific `-` (expected) and `+` (your wrong) lines: the diff is GROUND TRUTH — if it contradicts your reading of the task, follow the diff. Reproduce the `-` lines BYTE-EXACT including blank lines and indentation, and UNDO the `+` content from your prior edit. Do not stack a new edit on top of a rejected one.
-- Preserve exact TypeScript syntax around generic type parameters: `Type<T>` not `Type < T >`. When editing code that already has spaces in generics, remove them to match standard TypeScript syntax.
 {{#if IS_GLM_MODEL}}
 - If a `## Retry context` block shows a diff (lines prefixed with `-` and `+`), the `-` lines are the expected (correct) content and the `+` lines are what's wrong in the current file. Apply an edit that produces the `-` lines — do not re-derive a different fix.
 - When reading files, use a line range selector (e.g. `file.ts:50-100`). After making an edit, do NOT re-read the file or make additional edits to verify — the edit tool already reports success or failure. Move on. Do not revert your own edits. If the task says to change something, make the change once and move on — do not second-guess whether it is semantically meaningful.

--- a/packages/coding-agent/src/prompts/system/retry-diff-reminder.md
+++ b/packages/coding-agent/src/prompts/system/retry-diff-reminder.md
@@ -1,2 +1,1 @@
 [DIFF REMINDER]: `-` lines = EXPECTED content (must appear in your file). `+` lines = your PRIOR WRONG edit (must be removed). Follow the diff over any prior task interpretation.
-

--- a/packages/coding-agent/src/prompts/system/retry-diff-reminder.md
+++ b/packages/coding-agent/src/prompts/system/retry-diff-reminder.md
@@ -1,0 +1,2 @@
+[DIFF REMINDER]: `-` lines = EXPECTED content (must appear in your file). `+` lines = your PRIOR WRONG edit (must be removed). Follow the diff over any prior task interpretation.
+

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -87,9 +87,10 @@ import type { HindsightSessionState } from "./hindsight/state";
 import { LocalProtocolHandler, type LocalProtocolOptions } from "./internal-urls";
 import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "./lsp/startup-events";
 import { discoverAndLoadMCPTools, MCPManager, type MCPToolsLoadResult } from "./mcp";
+
 import { resolveMemoryBackend } from "./memory-backend";
 import { getMnemopiSessionState, type MnemopiSessionState } from "./mnemopi/state";
-import { isKimiClassModel } from "./model-families";
+import { isGlmModel, isKimiClassModel } from "./model-families";
 import asyncResultTemplate from "./prompts/tools/async-result.md" with { type: "text" };
 import { AgentRegistry, MAIN_AGENT_ID } from "./registry/agent-registry";
 import {
@@ -681,11 +682,48 @@ function resolveAppendOnlyMode(setting: "auto" | "on" | "off" | undefined, provi
  */
 function buildModelBehavioralAddendum(m: Model | undefined): string | null {
 	if (!isKimiClassModel(m)) return null;
-	return [
-		"## Output discipline",
-		"",
+	const bullets: string[] = [
 		"- Do NOT emit `<thinking>` or `</thinking>` tags in your output. Plan internally; state only conclusions, decisions, and tool calls. Long inline `<thinking>` monologues blow past per-turn budgets.",
-	].join("\n");
+	];
+	// GLM-specific: the retry-context diff-direction hint empirically helps
+	// glm-5.x apply the expected change verbatim, but marginally regresses
+	// kimi-2.6 (which handles the `-`/`+` notation natively without prompting).
+	if (isGlmModel(m)) {
+		bullets.push(
+			"- If a `## Retry context` block shows a diff (lines prefixed with `-` and `+`), the `-` lines are the expected (correct) content and the `+` lines are what's wrong in the current file. Apply an edit that produces the `-` lines — do not re-derive a different fix.",
+		);
+	}
+	return ["## Output discipline", "", ...bullets].join("\n");
+}
+
+/**
+ * Kimi/GLM/Qwen-class non-thinking sampling defaults. Vendor docs converge on
+ * these values for coding-style benchmarks (z.ai GLM-5 SWE-Bench: temp=0.7,
+ * top_p=1.0; GLM-5.1 sweet spot: temp 0.60-0.80, top_p=0.95; Kimi 2.5 insta
+ * mode: temp=0.6, top_p=0.95, min_p=0.01). Provider defaults are tuned for
+ * conversational output and overshoot for coding tasks. Users with explicit
+ * `>= 0` settings keep their override; this only fills in the auto case.
+ *
+ * top_p=0.95 sits at GLM-5.1's "most coherent / stable" sweet spot per vendor;
+ * temperatures above 0.80 risk Chinese-character bleed and incoherence on
+ * GLM-5.1, and below 0.60 the model deterministically picks its most-likely
+ * (often wrong) line on coin-flip tasks (empirically validated at temp=0.3,
+ * see run #59-#60).
+ */
+const KIMI_CLASS_SAMPLING_DEFAULTS = {
+	temperature: 0.7,
+	topP: 0.95,
+	minP: 0.01,
+} as const;
+
+function resolveKimiClassSamplingDefault(
+	m: Model | undefined,
+	rawSetting: number,
+	key: keyof typeof KIMI_CLASS_SAMPLING_DEFAULTS,
+): number | undefined {
+	if (rawSetting >= 0) return rawSetting;
+	if (isKimiClassModel(m)) return KIMI_CLASS_SAMPLING_DEFAULTS[key];
+	return undefined;
 }
 
 function customToolToDefinition(tool: CustomTool): ToolDefinition {
@@ -1654,8 +1692,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			const promptTools = buildSystemPromptToolMetadata(tools, {
 				search_tool_bm25: { description: renderSearchToolBm25Description(discoverableToolsForDesc) },
 			});
-			const memoryBackend = resolveMemoryBackend(settings);
-			const memoryInstructions = await memoryBackend.buildDeveloperInstructions(agentDir, settings, session);
+			const memoryInstructions = await resolveMemoryBackend(settings).buildDeveloperInstructions(
+				agentDir,
+				settings,
+				session,
+			);
 
 			// Build combined append prompt: memory instructions + MCP server instructions
 			const serverInstructions = mcpManager?.getServerInstructions();
@@ -1700,7 +1741,6 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				eagerTasks,
 				secretsEnabled,
 				workspaceTree: workspaceTreePromise,
-				memoryRootEnabled: memoryBackend.id === "local",
 			});
 
 			if (options.systemPrompt === undefined) {
@@ -1952,10 +1992,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			followUpMode: settings.get("followUpMode") ?? "one-at-a-time",
 			interruptMode: settings.get("interruptMode") ?? "immediate",
 			thinkingBudgets: settings.getGroup("thinkingBudgets"),
-			temperature: settings.get("temperature") >= 0 ? settings.get("temperature") : undefined,
-			topP: settings.get("topP") >= 0 ? settings.get("topP") : undefined,
+			temperature: resolveKimiClassSamplingDefault(model, settings.get("temperature"), "temperature"),
+			topP: resolveKimiClassSamplingDefault(model, settings.get("topP"), "topP"),
 			topK: settings.get("topK") >= 0 ? settings.get("topK") : undefined,
-			minP: settings.get("minP") >= 0 ? settings.get("minP") : undefined,
+			minP: resolveKimiClassSamplingDefault(model, settings.get("minP"), "minP"),
 			presencePenalty: settings.get("presencePenalty") >= 0 ? settings.get("presencePenalty") : undefined,
 			repetitionPenalty: settings.get("repetitionPenalty") >= 0 ? settings.get("repetitionPenalty") : undefined,
 			serviceTier: initialServiceTier,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -684,7 +684,6 @@ function buildModelBehavioralAddendum(m: Model | undefined): string | null {
 	if (!isKimiClassModel(m)) return null;
 	const bullets: string[] = [
 		"- Do NOT emit `<thinking>` or `</thinking>` tags in your output. Plan internally; state only conclusions, decisions, and tool calls. Long inline `<thinking>` monologues blow past per-turn budgets.",
-		"- When you receive a `## Retry context` block, your next edit MUST differ structurally from your prior failed attempt. Do not refine the same approach — the verifier already rejected that direction. Pick a different location, variable, or operation.",
 		"- When the retry-context diff shows specific `-` (expected) and `+` (your wrong) lines: the diff is GROUND TRUTH — if it contradicts your reading of the task, follow the diff. Reproduce the `-` lines BYTE-EXACT including blank lines and indentation, and UNDO the `+` content from your prior edit. Do not stack a new edit on top of a rejected one.",
 	];
 	// GLM-specific: the retry-context diff-direction hint empirically helps

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -90,7 +90,7 @@ import { discoverAndLoadMCPTools, MCPManager, type MCPToolsLoadResult } from "./
 
 import { resolveMemoryBackend } from "./memory-backend";
 import { getMnemopiSessionState, type MnemopiSessionState } from "./mnemopi/state";
-import { isGlmModel, isKimiClassModel } from "./model-families";
+import { isDeepseekModel, isGlmModel, isKimiClassModel } from "./model-families";
 import asyncResultTemplate from "./prompts/tools/async-result.md" with { type: "text" };
 import { AgentRegistry, MAIN_AGENT_ID } from "./registry/agent-registry";
 import {
@@ -671,7 +671,7 @@ function resolveAppendOnlyMode(setting: "auto" | "on" | "off" | undefined, provi
  * prompt for model families that embed inline `<thinking>...</thinking>` text
  * in their assistant output instead of using a provider-side thinking channel.
  *
- * Kimi K2.x, GLM-5.x, and Qwen models are trained to emit verbose inline
+ * Kimi K2.x, GLM-5.x, Qwen, and MiMo models are trained to emit verbose inline
  * `<thinking>` blocks even when the API-level reasoning toggle is off. On
  * tool-calling loops these blocks (a) blow past per-attempt wall-clock budgets
  * via 20k+ token monologues and (b) bloat subsequent-turn context. We can't
@@ -723,6 +723,35 @@ function resolveKimiClassSamplingDefault(
 ): number | undefined {
 	if (rawSetting >= 0) return rawSetting;
 	if (isKimiClassModel(m)) return KIMI_CLASS_SAMPLING_DEFAULTS[key];
+	return undefined;
+}
+
+/**
+ * DeepSeek-family sampling defaults. DeepSeek's official coder profile
+ * recommends `temperature=0.0` for code generation (deterministic decoding);
+ * provider defaults sit around 1.0 which is conversational and empirically
+ * over-noises tool-calling loops. `top_p=0.95` mirrors the kimi-class topP
+ * value — DeepSeek lacks an explicit vendor recommendation but the value is
+ * conservative enough to preserve enough probability mass for the dominant
+ * decision while excluding far-tail noise. `minP` intentionally omitted: the
+ * DeepSeek API does not surface a min_p control; passing it through is a
+ * no-op on the backend.
+ *
+ * Layered with `resolveKimiClassSamplingDefault` via `??` at the call site;
+ * the two predicates are disjoint by construction so order does not matter.
+ */
+const DEEPSEEK_SAMPLING_DEFAULTS = {
+	temperature: 0.0,
+	topP: 0.95,
+} as const;
+
+function resolveDeepseekSamplingDefault(
+	m: Model | undefined,
+	rawSetting: number,
+	key: keyof typeof DEEPSEEK_SAMPLING_DEFAULTS,
+): number | undefined {
+	if (rawSetting >= 0) return rawSetting;
+	if (isDeepseekModel(m)) return DEEPSEEK_SAMPLING_DEFAULTS[key];
 	return undefined;
 }
 
@@ -1992,8 +2021,12 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			followUpMode: settings.get("followUpMode") ?? "one-at-a-time",
 			interruptMode: settings.get("interruptMode") ?? "immediate",
 			thinkingBudgets: settings.getGroup("thinkingBudgets"),
-			temperature: resolveKimiClassSamplingDefault(model, settings.get("temperature"), "temperature"),
-			topP: resolveKimiClassSamplingDefault(model, settings.get("topP"), "topP"),
+			temperature:
+				resolveDeepseekSamplingDefault(model, settings.get("temperature"), "temperature") ??
+				resolveKimiClassSamplingDefault(model, settings.get("temperature"), "temperature"),
+			topP:
+				resolveDeepseekSamplingDefault(model, settings.get("topP"), "topP") ??
+				resolveKimiClassSamplingDefault(model, settings.get("topP"), "topP"),
 			topK: settings.get("topK") >= 0 ? settings.get("topK") : undefined,
 			minP: resolveKimiClassSamplingDefault(model, settings.get("minP"), "minP"),
 			presencePenalty: settings.get("presencePenalty") >= 0 ? settings.get("presencePenalty") : undefined,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1561,7 +1561,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		const getSessionContext = () => ({
 			sessionManager,
 			modelRegistry,
-			model: agent.state.model,
+			model: agent?.state.model ?? model,
 			isIdle: () => !session.isStreaming,
 			hasQueuedMessages: () => session.queuedMessageCount > 0,
 			abort: () => {
@@ -1699,7 +1699,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			// Append a small, narrow behavioral hint for model families that
 			// embed inline <thinking> text in their output (kimi/glm/qwen). For
 			// other families this is a no-op.
-			const modelAddendum = buildModelBehavioralAddendum(agent.state.model ?? model);
+			const modelAddendum = buildModelBehavioralAddendum(agent?.state.model ?? model);
 			if (modelAddendum) {
 				appendPrompt = appendPrompt ? `${appendPrompt}\n\n${modelAddendum}` : modelAddendum;
 			}

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1971,9 +1971,48 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			});
 		};
 
-		// Final convertToLlm: chain block-images filter with <thinking> strip and secret obfuscation
+		// For kimi-class models: inject a compact diff-direction reminder before
+		// the verifier's diff in `## Retry context` user messages. Kimi-class
+		// models systematically flip-flop on diff direction within a single
+		// retry turn — they interpret `+` as "expected content" half the time
+		// and "wrong content" the other half, then anchor to whichever matches
+		// their prior task interpretation. Inline reminder at the diff site is
+		// the closest the prompt can get to ground truth without a full
+		// preprocessor pass.
+		const RETRY_REMINDER =
+			"[DIFF REMINDER]: `-` lines = EXPECTED content (must appear in your file). `+` lines = your PRIOR WRONG edit (must be removed). Follow the diff over any prior task interpretation.\n\n";
+		const annotateRetryText = (text: string): string => {
+			if (!shouldStripThinking) return text;
+			if (!text.includes("## Retry context") || !text.includes("Diff (expected vs actual):")) return text;
+			if (text.includes("[DIFF REMINDER]")) return text;
+			return text.replace("Diff (expected vs actual):", `${RETRY_REMINDER}Diff (expected vs actual):`);
+		};
+		const annotateRetryContext = (messages: Message[]): Message[] => {
+			if (!shouldStripThinking) return messages;
+			return messages.map(msg => {
+				if (msg.role !== "user") return msg;
+				const content = msg.content;
+				if (typeof content === "string") {
+					const next = annotateRetryText(content);
+					return next === content ? msg : { ...msg, content: next };
+				}
+				if (!Array.isArray(content)) return msg;
+				let mutated = false;
+				const nextContent = content.map(block => {
+					if (block.type !== "text") return block;
+					const next = annotateRetryText(block.text);
+					if (next === block.text) return block;
+					mutated = true;
+					return { ...block, text: next };
+				});
+				return mutated ? { ...msg, content: nextContent } : msg;
+			});
+		};
+
+		// Final convertToLlm: chain block-images filter with <thinking> strip,
+		// retry-context annotation, and secret obfuscation
 		const convertToLlmFinal = (messages: AgentMessage[]): Message[] => {
-			const converted = stripThinkingFromMessages(convertToLlmWithBlockImages(messages));
+			const converted = annotateRetryContext(stripThinkingFromMessages(convertToLlmWithBlockImages(messages)));
 			if (!obfuscator?.hasSecrets()) return converted;
 			return obfuscateMessages(obfuscator, converted);
 		};

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -692,6 +692,7 @@ function buildModelBehavioralAddendum(m: Model | undefined): string | null {
 	if (isGlmModel(m)) {
 		bullets.push(
 			"- If a `## Retry context` block shows a diff (lines prefixed with `-` and `+`), the `-` lines are the expected (correct) content and the `+` lines are what's wrong in the current file. Apply an edit that produces the `-` lines — do not re-derive a different fix.",
+			"- When reading files, use a line range selector (e.g. `file.ts:50-100`). After making an edit, do NOT re-read the file or make additional edits to verify — the edit tool already reports success or failure. Move on. Do not revert your own edits. If the task says to change something, make the change once and move on — do not second-guess whether it is semantically meaningful.",
 		);
 	}
 	return ["## Output discipline", "", ...bullets].join("\n");

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1670,7 +1670,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			const promptTools = buildSystemPromptToolMetadata(tools, {
 				search_tool_bm25: { description: renderSearchToolBm25Description(discoverableToolsForDesc) },
 			});
-			const memoryInstructions = await resolveMemoryBackend(settings).buildDeveloperInstructions(
+			const memoryBackend = resolveMemoryBackend(settings);
+			const memoryInstructions = await memoryBackend.buildDeveloperInstructions(
 				agentDir,
 				settings,
 				session,
@@ -1719,6 +1720,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				eagerTasks,
 				secretsEnabled,
 				workspaceTree: workspaceTreePromise,
+				memoryRootEnabled: memoryBackend.id === "local",
 			});
 
 			if (options.systemPrompt === undefined) {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -89,6 +89,7 @@ import { LSP_STARTUP_EVENT_CHANNEL, type LspStartupEvent } from "./lsp/startup-e
 import { discoverAndLoadMCPTools, MCPManager, type MCPToolsLoadResult } from "./mcp";
 import { resolveMemoryBackend } from "./memory-backend";
 import { getMnemopiSessionState, type MnemopiSessionState } from "./mnemopi/state";
+import { isKimiClassModel } from "./model-families";
 import asyncResultTemplate from "./prompts/tools/async-result.md" with { type: "text" };
 import { AgentRegistry, MAIN_AGENT_ID } from "./registry/agent-registry";
 import {
@@ -662,6 +663,29 @@ function resolveAppendOnlyMode(setting: "auto" | "on" | "off" | undefined, provi
 		default:
 			return provider === "deepseek";
 	}
+}
+
+/**
+ * Build a small model-conditional behavioral addendum appended to the system
+ * prompt for model families that embed inline `<thinking>...</thinking>` text
+ * in their assistant output instead of using a provider-side thinking channel.
+ *
+ * Kimi K2.x, GLM-5.x, and Qwen models are trained to emit verbose inline
+ * `<thinking>` blocks even when the API-level reasoning toggle is off. On
+ * tool-calling loops these blocks (a) blow past per-attempt wall-clock budgets
+ * via 20k+ token monologues and (b) bloat subsequent-turn context. We can't
+ * suppress them via the API, but explicit instruction often does.
+ *
+ * Returns `null` for Anthropic/OpenAI/Gemini — those use a provider-side
+ * reasoning channel and don't need (and should not get) this instruction.
+ */
+function buildModelBehavioralAddendum(m: Model | undefined): string | null {
+	if (!isKimiClassModel(m)) return null;
+	return [
+		"## Output discipline",
+		"",
+		"- Do NOT emit `<thinking>` or `</thinking>` tags in your output. Plan internally; state only conclusions, decisions, and tool calls. Long inline `<thinking>` monologues blow past per-turn budgets.",
+	].join("\n");
 }
 
 function customToolToDefinition(tool: CustomTool): ToolDefinition {
@@ -1651,6 +1675,14 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				}
 				appendPrompt = parts.join("\n\n");
 			}
+
+			// Append a small, narrow behavioral hint for model families that
+			// embed inline <thinking> text in their output (kimi/glm/qwen). For
+			// other families this is a no-op.
+			const modelAddendum = buildModelBehavioralAddendum(model);
+			if (modelAddendum) {
+				appendPrompt = appendPrompt ? `${appendPrompt}\n\n${modelAddendum}` : modelAddendum;
+			}
 			const defaultPrompt = await buildSystemPromptInternal({
 				cwd,
 				skills,
@@ -1843,9 +1875,35 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			});
 		};
 
-		// Final convertToLlm: chain block-images filter with secret obfuscation
+		// For model families that emit verbose inline <thinking>...</thinking>
+		// blocks (kimi/glm/qwen), strip those blocks from past assistant text
+		// before replay. They don't help the next turn reason and they bloat
+		// the prompt cache linearly across turns. Current turn is unaffected
+		// (it's the live stream, not the replay).
+		const shouldStripThinking = isKimiClassModel(model);
+		const stripInlineThinking = (text: string): string =>
+			text.replace(/<thinking>[\s\S]*?<\/thinking>\n*/gi, "").replace(/<thinking>[\s\S]*$/i, "");
+		const stripThinkingFromMessages = (messages: Message[]): Message[] => {
+			if (!shouldStripThinking) return messages;
+			return messages.map(msg => {
+				if (msg.role !== "assistant") return msg;
+				const content = msg.content;
+				if (!Array.isArray(content)) return msg;
+				let mutated = false;
+				const nextContent = content.map(block => {
+					if (block.type !== "text") return block;
+					const next = stripInlineThinking(block.text);
+					if (next === block.text) return block;
+					mutated = true;
+					return { ...block, text: next };
+				});
+				return mutated ? { ...msg, content: nextContent } : msg;
+			});
+		};
+
+		// Final convertToLlm: chain block-images filter with <thinking> strip and secret obfuscation
 		const convertToLlmFinal = (messages: AgentMessage[]): Message[] => {
-			const converted = convertToLlmWithBlockImages(messages);
+			const converted = stripThinkingFromMessages(convertToLlmWithBlockImages(messages));
 			if (!obfuscator?.hasSecrets()) return converted;
 			return obfuscateMessages(obfuscator, converted);
 		};

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -9,6 +9,7 @@ import {
 	type ThinkingLevel,
 } from "@oh-my-pi/pi-agent-core";
 import {
+	type AssistantMessage,
 	type CredentialDisabledEvent,
 	isUsageLimitError,
 	type Message,
@@ -90,10 +91,15 @@ import { discoverAndLoadMCPTools, MCPManager, type MCPToolsLoadResult } from "./
 
 import { resolveMemoryBackend } from "./memory-backend";
 import { getMnemopiSessionState, type MnemopiSessionState } from "./mnemopi/state";
-import { isDeepseekModel, isGlmModel, isKimiClassModel, resolveDeepseekSamplingDefault, resolveKimiClassSamplingDefault } from "./model-families";
-import asyncResultTemplate from "./prompts/tools/async-result.md" with { type: "text" };
+import {
+	isGlmModel,
+	isKimiClassModel,
+	resolveDeepseekSamplingDefault,
+	resolveKimiClassSamplingDefault,
+} from "./model-families";
 import modelBehavioralAddendumTemplate from "./prompts/system/model-behavioral-addendum.md" with { type: "text" };
 import retryDiffReminderTemplate from "./prompts/system/retry-diff-reminder.md" with { type: "text" };
+import asyncResultTemplate from "./prompts/tools/async-result.md" with { type: "text" };
 import { AgentRegistry, MAIN_AGENT_ID } from "./registry/agent-registry";
 import {
 	collectEnvSecrets,
@@ -105,7 +111,7 @@ import {
 import { AgentSession } from "./session/agent-session";
 import { resolveAuthBrokerConfig } from "./session/auth-broker-config";
 import { AuthBrokerClient, AuthStorage, RemoteAuthCredentialStore } from "./session/auth-storage";
-import { type CustomMessage, convertToLlm } from "./session/messages";
+import { type CustomMessage, convertToLlm, sanitizeKimiClassAssistantMessage } from "./session/messages";
 import { SessionManager } from "./session/session-manager";
 import { closeAllConnections } from "./ssh/connection-manager";
 import { unmountAll } from "./ssh/sshfs-mount";
@@ -1671,11 +1677,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				search_tool_bm25: { description: renderSearchToolBm25Description(discoverableToolsForDesc) },
 			});
 			const memoryBackend = resolveMemoryBackend(settings);
-			const memoryInstructions = await memoryBackend.buildDeveloperInstructions(
-				agentDir,
-				settings,
-				session,
-			);
+			const memoryInstructions = await memoryBackend.buildDeveloperInstructions(agentDir, settings, session);
 
 			// Build combined append prompt: memory instructions + MCP server instructions
 			const serverInstructions = mcpManager?.getServerInstructions();
@@ -1917,7 +1919,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 					mutated = true;
 					return { ...block, text: next };
 				});
-				return mutated ? { ...msg, content: nextContent } : msg;
+				const nextMsg = mutated ? { ...msg, content: nextContent } : msg;
+				// Also strip stray vacuous text blocks that kimi emits between
+				// thinking blocks and tool calls (e.g., a lone ".").
+				const sanitized = sanitizeKimiClassAssistantMessage(nextMsg as AssistantMessage);
+				return sanitized === nextMsg ? nextMsg : sanitized;
 			});
 		};
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -90,8 +90,10 @@ import { discoverAndLoadMCPTools, MCPManager, type MCPToolsLoadResult } from "./
 
 import { resolveMemoryBackend } from "./memory-backend";
 import { getMnemopiSessionState, type MnemopiSessionState } from "./mnemopi/state";
-import { isDeepseekModel, isGlmModel, isKimiClassModel } from "./model-families";
+import { isDeepseekModel, isGlmModel, isKimiClassModel, resolveDeepseekSamplingDefault, resolveKimiClassSamplingDefault } from "./model-families";
 import asyncResultTemplate from "./prompts/tools/async-result.md" with { type: "text" };
+import modelBehavioralAddendumTemplate from "./prompts/system/model-behavioral-addendum.md" with { type: "text" };
+import retryDiffReminderTemplate from "./prompts/system/retry-diff-reminder.md" with { type: "text" };
 import { AgentRegistry, MAIN_AGENT_ID } from "./registry/agent-registry";
 import {
 	collectEnvSecrets,
@@ -682,20 +684,9 @@ function resolveAppendOnlyMode(setting: "auto" | "on" | "off" | undefined, provi
  */
 function buildModelBehavioralAddendum(m: Model | undefined): string | null {
 	if (!isKimiClassModel(m)) return null;
-	const bullets: string[] = [
-		"- Do NOT emit `<thinking>` or `</thinking>` tags in your output. Plan internally; state only conclusions, decisions, and tool calls. Long inline `<thinking>` monologues blow past per-turn budgets.",
-		"- When the retry-context diff shows specific `-` (expected) and `+` (your wrong) lines: the diff is GROUND TRUTH — if it contradicts your reading of the task, follow the diff. Reproduce the `-` lines BYTE-EXACT including blank lines and indentation, and UNDO the `+` content from your prior edit. Do not stack a new edit on top of a rejected one.",
-	];
-	// GLM-specific: the retry-context diff-direction hint empirically helps
-	// glm-5.x apply the expected change verbatim, but marginally regresses
-	// kimi-2.6 (which handles the `-`/`+` notation natively without prompting).
-	if (isGlmModel(m)) {
-		bullets.push(
-			"- If a `## Retry context` block shows a diff (lines prefixed with `-` and `+`), the `-` lines are the expected (correct) content and the `+` lines are what's wrong in the current file. Apply an edit that produces the `-` lines — do not re-derive a different fix.",
-			"- When reading files, use a line range selector (e.g. `file.ts:50-100`). After making an edit, do NOT re-read the file or make additional edits to verify — the edit tool already reports success or failure. Move on. Do not revert your own edits. If the task says to change something, make the change once and move on — do not second-guess whether it is semantically meaningful.",
-		);
-	}
-	return ["## Output discipline", "", ...bullets].join("\n");
+	return prompt.render(modelBehavioralAddendumTemplate, {
+		IS_GLM_MODEL: isGlmModel(m),
+	});
 }
 
 /**
@@ -712,50 +703,6 @@ function buildModelBehavioralAddendum(m: Model | undefined): string | null {
  * (often wrong) line on coin-flip tasks (empirically validated at temp=0.3,
  * see run #59-#60).
  */
-const KIMI_CLASS_SAMPLING_DEFAULTS = {
-	temperature: 0.7,
-	topP: 0.95,
-	minP: 0.01,
-} as const;
-
-function resolveKimiClassSamplingDefault(
-	m: Model | undefined,
-	rawSetting: number,
-	key: keyof typeof KIMI_CLASS_SAMPLING_DEFAULTS,
-): number | undefined {
-	if (rawSetting >= 0) return rawSetting;
-	if (isKimiClassModel(m)) return KIMI_CLASS_SAMPLING_DEFAULTS[key];
-	return undefined;
-}
-
-/**
- * DeepSeek-family sampling defaults. DeepSeek's official coder profile
- * recommends `temperature=0.0` for code generation (deterministic decoding);
- * provider defaults sit around 1.0 which is conversational and empirically
- * over-noises tool-calling loops. `top_p=0.95` mirrors the kimi-class topP
- * value — DeepSeek lacks an explicit vendor recommendation but the value is
- * conservative enough to preserve enough probability mass for the dominant
- * decision while excluding far-tail noise. `minP` intentionally omitted: the
- * DeepSeek API does not surface a min_p control; passing it through is a
- * no-op on the backend.
- *
- * Layered with `resolveKimiClassSamplingDefault` via `??` at the call site;
- * the two predicates are disjoint by construction so order does not matter.
- */
-const DEEPSEEK_SAMPLING_DEFAULTS = {
-	temperature: 0.0,
-	topP: 0.95,
-} as const;
-
-function resolveDeepseekSamplingDefault(
-	m: Model | undefined,
-	rawSetting: number,
-	key: keyof typeof DEEPSEEK_SAMPLING_DEFAULTS,
-): number | undefined {
-	if (rawSetting >= 0) return rawSetting;
-	if (isDeepseekModel(m)) return DEEPSEEK_SAMPLING_DEFAULTS[key];
-	return undefined;
-}
 
 function customToolToDefinition(tool: CustomTool): ToolDefinition {
 	const definition: ToolDefinition & { [TOOL_DEFINITION_MARKER]: true } = {
@@ -1751,7 +1698,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			// Append a small, narrow behavioral hint for model families that
 			// embed inline <thinking> text in their output (kimi/glm/qwen). For
 			// other families this is a no-op.
-			const modelAddendum = buildModelBehavioralAddendum(model);
+			const modelAddendum = buildModelBehavioralAddendum(agent.state.model ?? model);
 			if (modelAddendum) {
 				appendPrompt = appendPrompt ? `${appendPrompt}\n\n${modelAddendum}` : modelAddendum;
 			}
@@ -1951,11 +1898,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// before replay. They don't help the next turn reason and they bloat
 		// the prompt cache linearly across turns. Current turn is unaffected
 		// (it's the live stream, not the replay).
-		const shouldStripThinking = isKimiClassModel(model);
+		const shouldStripThinking = () => isKimiClassModel(agent.state.model);
 		const stripInlineThinking = (text: string): string =>
 			text.replace(/<thinking>[\s\S]*?<\/thinking>\n*/gi, "").replace(/<thinking>[\s\S]*$/i, "");
 		const stripThinkingFromMessages = (messages: Message[]): Message[] => {
-			if (!shouldStripThinking) return messages;
+			if (!shouldStripThinking()) return messages;
 			return messages.map(msg => {
 				if (msg.role !== "assistant") return msg;
 				const content = msg.content;
@@ -1980,16 +1927,15 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		// their prior task interpretation. Inline reminder at the diff site is
 		// the closest the prompt can get to ground truth without a full
 		// preprocessor pass.
-		const RETRY_REMINDER =
-			"[DIFF REMINDER]: `-` lines = EXPECTED content (must appear in your file). `+` lines = your PRIOR WRONG edit (must be removed). Follow the diff over any prior task interpretation.\n\n";
+		const RETRY_REMINDER = retryDiffReminderTemplate;
 		const annotateRetryText = (text: string): string => {
-			if (!shouldStripThinking) return text;
+			if (!shouldStripThinking()) return text;
 			if (!text.includes("## Retry context") || !text.includes("Diff (expected vs actual):")) return text;
 			if (text.includes("[DIFF REMINDER]")) return text;
 			return text.replace("Diff (expected vs actual):", `${RETRY_REMINDER}Diff (expected vs actual):`);
 		};
 		const annotateRetryContext = (messages: Message[]): Message[] => {
-			if (!shouldStripThinking) return messages;
+			if (!shouldStripThinking()) return messages;
 			return messages.map(msg => {
 				if (msg.role !== "user") return msg;
 				const content = msg.content;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -684,6 +684,8 @@ function buildModelBehavioralAddendum(m: Model | undefined): string | null {
 	if (!isKimiClassModel(m)) return null;
 	const bullets: string[] = [
 		"- Do NOT emit `<thinking>` or `</thinking>` tags in your output. Plan internally; state only conclusions, decisions, and tool calls. Long inline `<thinking>` monologues blow past per-turn budgets.",
+		"- When you receive a `## Retry context` block, your next edit MUST differ structurally from your prior failed attempt. Do not refine the same approach — the verifier already rejected that direction. Pick a different location, variable, or operation.",
+		"- When the retry-context diff shows specific `-` (expected) and `+` (your wrong) lines: the diff is GROUND TRUTH — if it contradicts your reading of the task, follow the diff. Reproduce the `-` lines BYTE-EXACT including blank lines and indentation, and UNDO the `+` content from your prior edit. Do not stack a new edit on top of a rejected one.",
 	];
 	// GLM-specific: the retry-context diff-direction hint empirically helps
 	// glm-5.x apply the expected change verbatim, but marginally regresses

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -155,6 +155,7 @@ import type { HindsightSessionState } from "../hindsight/state";
 import { type LocalProtocolOptions, resolveLocalUrlToPath } from "../internal-urls";
 import { resolveMemoryBackend } from "../memory-backend";
 import { getMnemopiSessionState, type MnemopiSessionState, setMnemopiSessionState } from "../mnemopi/state";
+import { isKimiClassModel } from "../model-families";
 import { containsOrchestrate, ORCHESTRATE_NOTICE } from "../modes/orchestrate";
 import { getCurrentThemeName, theme } from "../modes/theme/theme";
 import { parseTurnBudget } from "../modes/turn-budget";
@@ -506,6 +507,20 @@ export function resolveToolCallBatchCapForModel(model: Model | undefined): numbe
 	return model.provider === "anthropic" && CLAUDE_OPUS_4_8_MODEL_ID.test(model.id)
 		? ANTHROPIC_TOOL_CALL_BATCH_CAP
 		: undefined;
+}
+
+/**
+ * Per-response content-char cap for kimi/glm/qwen models that emit verbose inline
+ * `<thinking>` monologues. Forces the loop to advance to the next turn after the
+ * model has done some work but before per-attempt wall-clock budgets expire.
+ * Cap chosen so a typical edit-tool response (≤2 K tokens of text + DSL ≤ ~8 KB
+ * chars) fits comfortably, while runaway monologues (~80 KB chars at peak) trip
+ * the abort. Tunable via the new `Agent.maxResponseContentChars` setter.
+ */
+export const KIMI_CLASS_MAX_RESPONSE_CONTENT_CHARS = 12000;
+
+export function resolveMaxResponseContentCharsForModel(model: Model | undefined): number | undefined {
+	return isKimiClassModel(model) ? KIMI_CLASS_MAX_RESPONSE_CONTENT_CHARS : undefined;
 }
 
 /**
@@ -1054,6 +1069,7 @@ export class AgentSession {
 
 	#syncToolCallBatchCap(model: Model | undefined = this.model): void {
 		this.agent.maxToolCallsPerTurn = resolveToolCallBatchCapForModel(model);
+		this.agent.maxResponseContentChars = resolveMaxResponseContentCharsForModel(model);
 	}
 
 	#flushPendingAgentEnd(): void {

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -517,7 +517,7 @@ export function resolveToolCallBatchCapForModel(model: Model | undefined): numbe
  * chars) fits comfortably, while runaway monologues (~80 KB chars at peak) trip
  * the abort. Tunable via the new `Agent.maxResponseContentChars` setter.
  */
-export const KIMI_CLASS_MAX_RESPONSE_CONTENT_CHARS = 12000;
+export const KIMI_CLASS_MAX_RESPONSE_CONTENT_CHARS = 18000;
 
 export function resolveMaxResponseContentCharsForModel(model: Model | undefined): number | undefined {
 	return isKimiClassModel(model) ? KIMI_CLASS_MAX_RESPONSE_CONTENT_CHARS : undefined;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -155,7 +155,7 @@ import type { HindsightSessionState } from "../hindsight/state";
 import { type LocalProtocolOptions, resolveLocalUrlToPath } from "../internal-urls";
 import { resolveMemoryBackend } from "../memory-backend";
 import { getMnemopiSessionState, type MnemopiSessionState, setMnemopiSessionState } from "../mnemopi/state";
-import { isKimiClassModel } from "../model-families";
+import { isKimiClassModel, resolveDeepseekSamplingDefault, resolveKimiClassSamplingDefault } from "../model-families";
 import { containsOrchestrate, ORCHESTRATE_NOTICE } from "../modes/orchestrate";
 import { getCurrentThemeName, theme } from "../modes/theme/theme";
 import { parseTurnBudget } from "../modes/turn-budget";
@@ -6518,12 +6518,24 @@ export class AgentSession {
 		return candidate;
 	}
 
+	#syncSamplingDefaults(model: Model | undefined): void {
+		const settings = this.settings;
+		this.agent.temperature =
+			resolveDeepseekSamplingDefault(model, settings.get("temperature"), "temperature") ??
+			resolveKimiClassSamplingDefault(model, settings.get("temperature"), "temperature");
+		this.agent.topP =
+			resolveDeepseekSamplingDefault(model, settings.get("topP"), "topP") ??
+			resolveKimiClassSamplingDefault(model, settings.get("topP"), "topP");
+		this.agent.minP = resolveKimiClassSamplingDefault(model, settings.get("minP"), "minP");
+	}
+
 	#setModelWithProviderSessionReset(model: Model): void {
 		const currentModel = this.model;
 		if (currentModel) {
 			this.#closeProviderSessionsForModelSwitch(currentModel, model);
 		}
 		this.agent.setModel(model);
+		this.#syncSamplingDefaults(model);
 		this.#syncToolCallBatchCap(model);
 
 		// Re-evaluate append-only context mode — provider or setting may have changed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5146,6 +5146,7 @@ export class AgentSession {
 
 		this.#clearActiveRetryFallback();
 		this.#setModelWithProviderSessionReset(model);
+		await this.refreshBaseSystemPrompt();
 		this.sessionManager.appendModelChange(`${model.provider}/${model.id}`, role);
 		if (options?.persist) {
 			this.settings.setModelRole(
@@ -5175,6 +5176,7 @@ export class AgentSession {
 
 		this.#clearActiveRetryFallback();
 		this.#setModelWithProviderSessionReset(model);
+		await this.refreshBaseSystemPrompt();
 		this.sessionManager.appendModelChange(`${model.provider}/${model.id}`, "temporary");
 		this.settings.getStorage()?.recordModelUsage(`${model.provider}/${model.id}`);
 

--- a/packages/coding-agent/src/session/messages.ts
+++ b/packages/coding-agent/src/session/messages.ts
@@ -362,6 +362,34 @@ export function sanitizeRehydratedOpenAIResponsesAssistantMessage(message: Assis
 		providerPayload: undefined,
 	};
 }
+/**
+ * Kimi-class models occasionally emit a vacuous text block (containing only
+ * whitespace or a lone punctuation mark) between a thinking block and a
+ * tool call. This artifact pollutes session dumps and LLM replay context.
+ * Remove these stray text blocks while preserving all meaningful text.
+ */
+export function sanitizeKimiClassAssistantMessage(message: AssistantMessage): AssistantMessage {
+	const content = message.content;
+	if (content.length < 2) return message;
+	const nextContent = content.filter((block, index) => {
+		if (block.type !== "text") return true;
+		const trimmed = block.text.trim();
+		// Only consider vacuous text: empty or a single punctuation mark
+		if (trimmed.length > 0 && !/^[.!?…"']$/.test(trimmed)) return true;
+		const prev = content[index - 1];
+		const next = content[index + 1];
+		// Remove when sandwiched between thinking and toolCall,
+		// between two thinking blocks, or trailing after the last thinking block
+		if (prev?.type === "thinking") {
+			if (next === undefined || next.type === "toolCall" || next.type === "thinking") {
+				return false;
+			}
+		}
+		return true;
+	});
+	if (nextContent.length === content.length) return message;
+	return { ...message, content: nextContent };
+}
 
 /** Convert CustomMessageEntry to AgentMessage format */
 export function createCustomMessage(

--- a/packages/coding-agent/src/session/session-dump-format.ts
+++ b/packages/coding-agent/src/session/session-dump-format.ts
@@ -4,6 +4,7 @@
 import type { AgentMessage, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { INTENT_FIELD } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai";
+import { isKimiClassModel } from "../model-families";
 import {
 	type BashExecutionMessage,
 	type BranchSummaryMessage,
@@ -14,6 +15,7 @@ import {
 	type HookMessage,
 	type PythonExecutionMessage,
 	pythonExecutionToText,
+	sanitizeKimiClassAssistantMessage,
 } from "./messages";
 
 /** Minimal tool shape for dump output (matches AgentTool fields used by formatSessionDumpText). */
@@ -112,7 +114,10 @@ export function formatSessionDumpText(options: FormatSessionDumpTextOptions): st
 			}
 			lines.push("\n");
 		} else if (msg.role === "assistant") {
-			const assistantMsg = msg as AssistantMessage;
+			let assistantMsg = msg as AssistantMessage;
+			if (isKimiClassModel(options.model ?? undefined)) {
+				assistantMsg = sanitizeKimiClassAssistantMessage(assistantMsg);
+			}
 			lines.push("## Assistant\n");
 
 			for (const c of assistantMsg.content) {

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -254,7 +254,15 @@ function formatSummaryElisionFooter(
 	if (elidedRanges.length === 0) return "";
 	const lineWord = elidedLines === 1 ? "line" : "lines";
 	const sampleCount = Math.min(elidedRanges.length, FOOTER_RANGE_SAMPLES);
-	const selector = elidedRanges
+	// For kimi-class, prefer the largest elided ranges in the e.g. sample so
+	// the model has a pointer to the biggest hidden region. Otherwise glm-5.1
+	// in particular reads the file in many small chunks of small top-level
+	// functions before discovering the big body it needs, blowing past
+	// max-turns. Sort copy; do not mutate the source.
+	const orderedRanges = options.kimiClass
+		? [...elidedRanges].sort((a, b) => b.end - b.start - (a.end - a.start))
+		: elidedRanges;
+	const selector = orderedRanges
 		.slice(0, sampleCount)
 		.map(r => `${r.start}-${r.end}`)
 		.join(",");
@@ -264,7 +272,7 @@ function formatSummaryElisionFooter(
 	// summary above is usually sufficient context to act; reserve `re-read`
 	// suggestion for cases where the agent truly needs the hidden body.
 	if (options.kimiClass) {
-		return `[${elidedLines} ${lineWord} elided. The visible structural summary usually has enough context to act. Only re-read elided ranges${tail.startsWith(",") ? "" : ""} if your fix truly depends on hidden content${tail}]`;
+		return `[${elidedLines} ${lineWord} elided. The visible structural summary usually has enough context to act. Only re-read elided ranges if your fix truly depends on hidden content${tail}]`;
 	}
 	return `[${elidedLines} ${lineWord} elided; re-read needed ranges${tail}]`;
 }
@@ -697,7 +705,6 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			DEFAULT_MAX_LINES: String(DEFAULT_MAX_LINES),
 			IS_HL_MODE: displayMode.hashLines,
 			IS_LINE_NUMBER_MODE: !displayMode.hashLines && displayMode.lineNumbers,
-			INSPECT_IMAGE_ENABLED: this.#inspectImageEnabled,
 		});
 	}
 

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -705,6 +705,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			DEFAULT_MAX_LINES: String(DEFAULT_MAX_LINES),
 			IS_HL_MODE: displayMode.hashLines,
 			IS_LINE_NUMBER_MODE: !displayMode.hashLines && displayMode.lineNumbers,
+			INSPECT_IMAGE_ENABLED: this.#inspectImageEnabled,
 		});
 	}
 

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -16,6 +16,7 @@ import type { RenderResultOptions } from "../extensibility/custom-tools/types";
 import { InternalUrlRouter } from "../internal-urls";
 import { parseInternalUrl } from "../internal-urls/parse";
 import type { InternalUrl } from "../internal-urls/types";
+import { isKimiClassModelString } from "../model-families";
 import { getLanguageFromPath, type Theme } from "../modes/theme/theme";
 import readDescription from "../prompts/tools/read.md" with { type: "text" };
 import type { ToolSession } from "../sdk";
@@ -248,6 +249,7 @@ function formatSummaryElisionFooter(
 	readPath: string,
 	elidedRanges: ReadonlyArray<ElidedRange>,
 	elidedLines: number,
+	options: { kimiClass?: boolean } = {},
 ): string {
 	if (elidedRanges.length === 0) return "";
 	const lineWord = elidedLines === 1 ? "line" : "lines";
@@ -258,6 +260,12 @@ function formatSummaryElisionFooter(
 		.join(",");
 	const example = `${readPath}:${selector}`;
 	const tail = elidedRanges.length > sampleCount ? `, e.g. ${example}` : ` with ${example}`;
+	// Kimi-class models otherwise compulsively re-read every elided range. The
+	// summary above is usually sufficient context to act; reserve `re-read`
+	// suggestion for cases where the agent truly needs the hidden body.
+	if (options.kimiClass) {
+		return `[${elidedLines} ${lineWord} elided. The visible structural summary usually has enough context to act. Only re-read elided ranges${tail.startsWith(",") ? "" : ""} if your fix truly depends on hidden content${tail}]`;
+	}
 	return `[${elidedLines} ${lineWord} elided; re-read needed ranges${tail}]`;
 }
 const READ_CHUNK_SIZE = 8 * 1024;
@@ -1360,10 +1368,19 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			if (lineCount > MAX_SUMMARY_LINES) return null;
 			if (lineCount < this.session.settings.get("read.summarize.minTotalLines")) return null;
 
+			// For kimi/glm/qwen models that ramble through structural summaries, use
+			// a tighter inline-body threshold so summaries stay compact and the model
+			// doesn't trip on extra inline code while ruminating. Other models keep
+			// the larger default optimal for their faster decisions on bigger contexts.
+			const activeModel = this.session.getActiveModelString?.() ?? "";
+			const isKimiClass = isKimiClassModelString(activeModel);
+			const minBodyLines = isKimiClass
+				? Math.min(4, this.session.settings.get("read.summarize.minBodyLines"))
+				: this.session.settings.get("read.summarize.minBodyLines");
 			const result = summarizeCode({
 				code,
 				path: absolutePath,
-				minBodyLines: this.session.settings.get("read.summarize.minBodyLines"),
+				minBodyLines,
 				minCommentLines: this.session.settings.get("read.summarize.minCommentLines"),
 				unfoldUntilLines: this.session.settings.get("read.summarize.unfoldUntil"),
 				unfoldLimitLines: this.session.settings.get("read.summarize.unfoldLimit"),
@@ -1733,10 +1750,13 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 				const summary = await this.#trySummarize(absolutePath, fileSize, signal);
 				if (summary?.parsed && summary.elided) {
 					const renderedSummary = this.#renderSummary(summary);
+					const activeModel = this.session.getActiveModelString?.() ?? "";
+					const isKimiClass = isKimiClassModelString(activeModel);
 					const footer = formatSummaryElisionFooter(
 						localReadPath,
 						renderedSummary.elidedRanges,
 						renderedSummary.elidedLines,
+						{ kimiClass: isKimiClass },
 					);
 					const summaryHashContext = displayMode.hashLines
 						? await readHashlineHeaderContext(this.session, absolutePath, this.session.cwd)

--- a/packages/coding-agent/test/model-families.test.ts
+++ b/packages/coding-agent/test/model-families.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import type { Model } from "@oh-my-pi/pi-ai";
+import { isKimiClassModel, isKimiClassModelString } from "../src/model-families";
+
+function fakeModel(id: string): Model {
+	return { id, provider: "test" } as unknown as Model;
+}
+
+describe("isKimiClassModelString", () => {
+	it("accepts canonical kimi-class identifiers", () => {
+		const accepted = [
+			"kimi-k2",
+			"kimi-k2.5",
+			"kimi-k2.6-turbo",
+			"kimi_k2",
+			"glm-4.7",
+			"glm-5",
+			"glm-5.1",
+			"glm_5",
+			"qwen",
+			"qwen3",
+			"qwen3-coder-plus",
+			"qwen3.5-plus",
+			"qwen-vl",
+			"qwen-2.5-72b-instruct",
+			"qwen2.5-coder-32b-instruct",
+			// path-anchored variants exercised in models.json
+			"openrouter/kimi-k2",
+			"google-vertex/qwen3-32b",
+			"qwen/qwen3-32b",
+			"qwen/qwq-32b",
+			// vendor-prefixed bedrock ids (`qwen.qwen3-…`) must still classify
+			"qwen.qwen3-235b-a22b-2507-v1:0",
+			"qwen.qwen3-coder-30b-a3b-v1:0",
+		];
+		for (const id of accepted) {
+			expect(isKimiClassModelString(id)).toBe(true);
+		}
+	});
+
+	it("rejects accidental prefixes that share the family stem", () => {
+		// These would have matched the pre-tightening regex (`kimi|glm-|qwen`) but
+		// are not in the kimi/glm/qwen family — the boundary contract excludes
+		// them so unrelated providers don't pick up kimi-class behavior bundles.
+		const rejected = [
+			"qweniverse",
+			"qweniverse/foo",
+			"qwentastic-7b",
+			"kimibara-mini",
+			"kimi",
+			"glm",
+			"glmnopq-7b",
+			// non-delimited continuation must not match even mid-path
+			"openrouter/qweniverse",
+			"openrouter/kimibara",
+		];
+		for (const id of rejected) {
+			expect(isKimiClassModelString(id)).toBe(false);
+		}
+	});
+
+	it("handles empty / undefined identifiers", () => {
+		expect(isKimiClassModelString(undefined)).toBe(false);
+		expect(isKimiClassModelString(null)).toBe(false);
+		expect(isKimiClassModelString("")).toBe(false);
+	});
+});
+
+describe("isKimiClassModel", () => {
+	it("delegates to the same boundary contract via Model.id", () => {
+		expect(isKimiClassModel(fakeModel("kimi-k2.5"))).toBe(true);
+		expect(isKimiClassModel(fakeModel("qwen3"))).toBe(true);
+		expect(isKimiClassModel(fakeModel("qweniverse"))).toBe(false);
+		expect(isKimiClassModel(undefined)).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/model-families.test.ts
+++ b/packages/coding-agent/test/model-families.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { Model } from "@oh-my-pi/pi-ai";
-import { isKimiClassModel, isKimiClassModelString } from "../src/model-families";
+import { isDeepseekModel, isKimiClassModel, isKimiClassModelString } from "../src/model-families";
 
 function fakeModel(id: string): Model {
 	return { id, provider: "test" } as unknown as Model;
@@ -24,6 +24,12 @@ describe("isKimiClassModelString", () => {
 			"qwen-vl",
 			"qwen-2.5-72b-instruct",
 			"qwen2.5-coder-32b-instruct",
+			// MiMo (Xiaomi) — same negative-lookahead boundary contract as qwen
+			"mimo",
+			"mimo-7b",
+			"mimo-coder-7b",
+			"xiaomi/mimo-7b",
+			"crof/mimo-v2.5-pro",
 			// path-anchored variants exercised in models.json
 			"openrouter/kimi-k2",
 			"google-vertex/qwen3-32b",
@@ -39,9 +45,9 @@ describe("isKimiClassModelString", () => {
 	});
 
 	it("rejects accidental prefixes that share the family stem", () => {
-		// These would have matched the pre-tightening regex (`kimi|glm-|qwen`) but
-		// are not in the kimi/glm/qwen family — the boundary contract excludes
-		// them so unrelated providers don't pick up kimi-class behavior bundles.
+		// These would have matched the pre-tightening regex (`kimi|glm-|qwen|mimo`)
+		// but are not in the kimi/glm/qwen/mimo family — the boundary contract
+		// excludes them so unrelated providers don't pick up kimi-class behavior.
 		const rejected = [
 			"qweniverse",
 			"qweniverse/foo",
@@ -50,6 +56,10 @@ describe("isKimiClassModelString", () => {
 			"kimi",
 			"glm",
 			"glmnopq-7b",
+			// mimo with letter continuation must NOT match
+			"mimosa",
+			"mimography-7b",
+			"openrouter/mimosa",
 			// non-delimited continuation must not match even mid-path
 			"openrouter/qweniverse",
 			"openrouter/kimibara",
@@ -72,5 +82,45 @@ describe("isKimiClassModel", () => {
 		expect(isKimiClassModel(fakeModel("qwen3"))).toBe(true);
 		expect(isKimiClassModel(fakeModel("qweniverse"))).toBe(false);
 		expect(isKimiClassModel(undefined)).toBe(false);
+	});
+});
+
+describe("isDeepseekModel", () => {
+	it("matches DeepSeek family identifiers with proper boundary", () => {
+		const accepted = [
+			"deepseek",
+			"deepseek-coder",
+			"deepseek-v3",
+			"deepseek-r1-distill-llama-70b",
+			"crof/deepseek-v4-pro-precision",
+			"openrouter/deepseek-chat",
+		];
+		for (const id of accepted) {
+			expect(isDeepseekModel(fakeModel(id))).toBe(true);
+		}
+	});
+
+	it("rejects accidental prefixes (letter continuation after stem)", () => {
+		// `deepseek(?![a-z])` excludes any unrelated id that happens to start
+		// with "deepseek" followed by another ASCII letter.
+		const rejected = ["deepseekend", "deepseekery", "openrouter/deepseekend"];
+		for (const id of rejected) {
+			expect(isDeepseekModel(fakeModel(id))).toBe(false);
+		}
+	});
+
+	it("is disjoint from isKimiClassModel — DeepSeek shares no mitigation surface", () => {
+		// DeepSeek doesn't emit inline <thinking>; it gets sampling overrides
+		// only, not the full kimi-class mitigation bundle. The two predicates
+		// must never both be true for any shipped id.
+		const deepseekIds = ["deepseek-coder", "deepseek-v3", "crof/deepseek-v4-pro-precision"];
+		for (const id of deepseekIds) {
+			expect(isDeepseekModel(fakeModel(id))).toBe(true);
+			expect(isKimiClassModelString(id)).toBe(false);
+		}
+	});
+
+	it("handles empty / undefined", () => {
+		expect(isDeepseekModel(undefined)).toBe(false);
 	});
 });

--- a/packages/coding-agent/test/session/sanitize-kimi-class.test.ts
+++ b/packages/coding-agent/test/session/sanitize-kimi-class.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "bun:test";
+import type { AssistantMessage } from "@oh-my-pi/pi-ai";
+import { sanitizeKimiClassAssistantMessage } from "../../src/session/messages";
+
+function makeAssistantMessage(content: AssistantMessage["content"]): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "openai-messages",
+		provider: "openai",
+		model: "kimi-k2",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+}
+
+describe("sanitizeKimiClassAssistantMessage", () => {
+	it("returns the same message when no vacuous text blocks exist", () => {
+		const msg = makeAssistantMessage([
+			{ type: "text", text: "Let me help you with that." },
+			{ type: "toolCall", id: "t1", name: "read", arguments: { path: "foo.ts" } },
+		]);
+		const result = sanitizeKimiClassAssistantMessage(msg);
+		expect(result).toBe(msg);
+	});
+
+	it("removes a lone '.' between thinking and toolCall", () => {
+		const msg = makeAssistantMessage([
+			{ type: "thinking", thinking: "I need to read the file." },
+			{ type: "text", text: "." },
+			{ type: "toolCall", id: "t1", name: "read", arguments: { path: "foo.ts" } },
+		]);
+		const result = sanitizeKimiClassAssistantMessage(msg);
+		expect(result.content).toHaveLength(2);
+		expect(result.content[0]!.type).toBe("thinking");
+		expect(result.content[1]!.type).toBe("toolCall");
+	});
+
+	it("removes a lone '\\\"' between thinking and toolCall", () => {
+		const msg = makeAssistantMessage([
+			{ type: "thinking", thinking: "I need to read the file." },
+			{ type: "text", text: '"' },
+			{ type: "toolCall", id: "t1", name: "read", arguments: { path: "foo.ts" } },
+		]);
+		const result = sanitizeKimiClassAssistantMessage(msg);
+		expect(result.content).toHaveLength(2);
+		expect(result.content[0]!.type).toBe("thinking");
+		expect(result.content[1]!.type).toBe("toolCall");
+	});
+
+	it("removes whitespace-only text between thinking and toolCall", () => {
+		const msg = makeAssistantMessage([
+			{ type: "thinking", thinking: "I need to read the file." },
+			{ type: "text", text: "   \n\t  " },
+			{ type: "toolCall", id: "t1", name: "read", arguments: { path: "foo.ts" } },
+		]);
+		const result = sanitizeKimiClassAssistantMessage(msg);
+		expect(result.content).toHaveLength(2);
+	});
+
+	it("removes trailing vacuous text after the last thinking block", () => {
+		const msg = makeAssistantMessage([
+			{ type: "thinking", thinking: "I need to read the file." },
+			{ type: "text", text: "…" },
+		]);
+		const result = sanitizeKimiClassAssistantMessage(msg);
+		expect(result.content).toHaveLength(1);
+		expect(result.content[0]!.type).toBe("thinking");
+	});
+
+	it("removes vacuous text between two thinking blocks", () => {
+		const msg = makeAssistantMessage([
+			{ type: "thinking", thinking: "First thought." },
+			{ type: "text", text: "!" },
+			{ type: "thinking", thinking: "Second thought." },
+		]);
+		const result = sanitizeKimiClassAssistantMessage(msg);
+		expect(result.content).toHaveLength(2);
+		expect(result.content[0]!.type).toBe("thinking");
+		expect(result.content[1]!.type).toBe("thinking");
+	});
+
+	it("preserves meaningful text between thinking and toolCall", () => {
+		const msg = makeAssistantMessage([
+			{ type: "thinking", thinking: "I need to read the file." },
+			{ type: "text", text: "Let me fetch that for you." },
+			{ type: "toolCall", id: "t1", name: "read", arguments: { path: "foo.ts" } },
+		]);
+		const result = sanitizeKimiClassAssistantMessage(msg);
+		expect(result.content).toHaveLength(3);
+		expect(result.content[1]!.type).toBe("text");
+		expect((result.content[1] as { type: "text"; text: string }).text).toBe("Let me fetch that for you.");
+	});
+
+	it("preserves vacuous text that is not adjacent to thinking", () => {
+		const msg = makeAssistantMessage([
+			{ type: "text", text: "." },
+			{ type: "toolCall", id: "t1", name: "read", arguments: { path: "foo.ts" } },
+		]);
+		const result = sanitizeKimiClassAssistantMessage(msg);
+		expect(result.content).toHaveLength(2);
+		expect(result.content[0]!.type).toBe("text");
+	});
+
+	it("returns the same message when content has fewer than 2 blocks", () => {
+		const msg = makeAssistantMessage([{ type: "text", text: "Hello." }]);
+		const result = sanitizeKimiClassAssistantMessage(msg);
+		expect(result).toBe(msg);
+	});
+
+	it("removes multiple vacuous text blocks in one pass", () => {
+		const msg = makeAssistantMessage([
+			{ type: "thinking", thinking: "First." },
+			{ type: "text", text: "." },
+			{ type: "thinking", thinking: "Second." },
+			{ type: "text", text: "?" },
+			{ type: "toolCall", id: "t1", name: "read", arguments: { path: "foo.ts" } },
+		]);
+		const result = sanitizeKimiClassAssistantMessage(msg);
+		expect(result.content).toHaveLength(3);
+		expect(result.content[0]!.type).toBe("thinking");
+		expect(result.content[1]!.type).toBe("thinking");
+		expect(result.content[2]!.type).toBe("toolCall");
+	});
+});


### PR DESCRIPTION
## Summary

Adds `xiaomimimo` as a new AI provider using the OpenAI completions API.

## Changes

**New provider: `xiaomimimo`**
- **Endpoint**: `api.xiaomimimo.com/v1` (OpenAI completions)
- **Auth**: `XIAOMIMIMO_API_KEY` with fallback to `XIAOMI_API_KEY`; reuses existing `xiaomi` OAuth flow
- **Bundled models**: `mimo-v2-flash`, `mimo-v2-omni`, `mimo-v2-pro`, `mimo-v2.5`, `mimo-v2.5-pro`

**Files touched:**
- `packages/ai/src/types.ts` — added `"xiaomimimo"` to `KnownProvider`
- `packages/ai/src/provider-models/openai-compat.ts` — `xiaomimimoModelManagerOptions()` + models.dev descriptor
- `packages/ai/src/provider-models/descriptors.ts` — catalog descriptor
- `packages/ai/src/stream.ts` — key resolver mapping
- `packages/ai/src/auth-storage.ts` — auth case fallthrough
- `packages/ai/src/utils/oauth/{index,types}.ts` — OAuth provider registration
- `packages/ai/src/models.json` — regenerated