### PR TITLE
fix(coding-agent): expose hashline edit path to extensions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed extension `tool_call`/`tool_result` events for hashline `edit` calls to expose `event.input.path` by deriving it from the `¶PATH#TAG` header, so planning-mode gates can allow markdown plan edits instead of blocking them as `undefined` ([#1678](https://github.com/can1357/oh-my-pi/issues/1678)).
+- Fixed extension `tool_call`/`tool_result` events for hashline `edit` calls to expose `event.input.path` for single-file edits and `event.input.paths` for every parsed target, so planning-mode gates can allow one markdown plan edit but still block multi-file hashline calls that cannot be represented by one path ([#1678](https://github.com/can1357/oh-my-pi/issues/1678)).
 - Fixed a module-load crash (`ReferenceError: Cannot access 'evalToolRenderer' before initialization`) triggered whenever `tools/eval` was imported before `tools/renderers`. The eval JS backend statically pulls the agent/task/sdk/extension chain, which re-enters the root barrel → `modes/components` → `tool-execution` → `renderers` while `eval.ts` was still initializing, so `renderers.ts` read `evalToolRenderer` in its TDZ. The eval TUI renderer is now split into a dependency-light `tools/eval-render.ts` that `renderers.ts` imports directly (decoupling pure rendering from the eval runtime); `eval.ts` re-exports `evalToolRenderer`/`EVAL_DEFAULT_PREVIEW_LINES` for compatibility.
 
 ## [15.7.6] - 2026-06-01

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed extension `tool_call`/`tool_result` events for hashline `edit` calls to expose `event.input.path` by deriving it from the `¶PATH#TAG` header, so planning-mode gates can allow markdown plan edits instead of blocking them as `undefined` ([#1678](https://github.com/can1357/oh-my-pi/issues/1678)).
 - Fixed a module-load crash (`ReferenceError: Cannot access 'evalToolRenderer' before initialization`) triggered whenever `tools/eval` was imported before `tools/renderers`. The eval JS backend statically pulls the agent/task/sdk/extension chain, which re-enters the root barrel → `modes/components` → `tool-execution` → `renderers` while `eval.ts` was still initializing, so `renderers.ts` read `evalToolRenderer` in its TDZ. The eval TUI renderer is now split into a dependency-light `tools/eval-render.ts` that `renderers.ts` imports directly (decoupling pure rendering from the eval runtime); `eval.ts` re-exports `evalToolRenderer`/`EVAL_DEFAULT_PREVIEW_LINES` for compatibility.
 
 ## [15.7.6] - 2026-06-01

--- a/packages/coding-agent/src/extensibility/extensions/wrapper.ts
+++ b/packages/coding-agent/src/extensibility/extensions/wrapper.ts
@@ -6,6 +6,7 @@ import type { ImageContent, Static, TextContent, TSchema } from "@oh-my-pi/pi-ai
 import type { Settings } from "../../config/settings";
 import type { Theme } from "../../modes/theme/theme";
 import { type ApprovalMode, formatApprovalPrompt, requiresApproval } from "../../tools/approval";
+import { normalizeToolEventInput } from "../tool-event-input";
 import { applyToolProxy } from "../tool-proxy";
 import type { ExtensionRunner } from "./runner";
 import type { RegisteredTool, ToolCallEventResult } from "./types";
@@ -149,7 +150,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 					type: "tool_call",
 					toolName: this.tool.name,
 					toolCallId,
-					input: params as Record<string, unknown>,
+					input: normalizeToolEventInput(this.tool.name, params as Record<string, unknown>),
 				})) as ToolCallEventResult | undefined;
 
 				if (callResult?.block) {
@@ -184,7 +185,7 @@ export class ExtensionToolWrapper<TParameters extends TSchema = TSchema, TDetail
 				type: "tool_result",
 				toolName: this.tool.name,
 				toolCallId,
-				input: params as Record<string, unknown>,
+				input: normalizeToolEventInput(this.tool.name, params as Record<string, unknown>),
 				content: result.content,
 				details: result.details,
 				isError: !!executionError,

--- a/packages/coding-agent/src/extensibility/hooks/tool-wrapper.ts
+++ b/packages/coding-agent/src/extensibility/hooks/tool-wrapper.ts
@@ -3,6 +3,7 @@
  */
 import type { AgentTool, AgentToolContext, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import type { Static, TSchema } from "@oh-my-pi/pi-ai";
+import { normalizeToolEventInput } from "../tool-event-input";
 import { applyToolProxy } from "../tool-proxy";
 import type { HookRunner } from "./runner";
 import type { ToolCallEventResult, ToolResultEventResult } from "./types";
@@ -46,7 +47,7 @@ export class HookToolWrapper<TParameters extends TSchema = TSchema, TDetails = u
 					type: "tool_call",
 					toolName: this.tool.name,
 					toolCallId,
-					input: params as Record<string, unknown>,
+					input: normalizeToolEventInput(this.tool.name, params as Record<string, unknown>),
 				})) as ToolCallEventResult | undefined;
 
 				if (callResult?.block) {
@@ -72,7 +73,7 @@ export class HookToolWrapper<TParameters extends TSchema = TSchema, TDetails = u
 					type: "tool_result",
 					toolName: this.tool.name,
 					toolCallId,
-					input: params as Record<string, unknown>,
+					input: normalizeToolEventInput(this.tool.name, params as Record<string, unknown>),
 					content: result.content,
 					details: result.details,
 					isError: false,
@@ -95,7 +96,7 @@ export class HookToolWrapper<TParameters extends TSchema = TSchema, TDetails = u
 					type: "tool_result",
 					toolName: this.tool.name,
 					toolCallId,
-					input: params as Record<string, unknown>,
+					input: normalizeToolEventInput(this.tool.name, params as Record<string, unknown>),
 					content: [{ type: "text", text: err instanceof Error ? err.message : String(err) }],
 					details: undefined,
 					isError: true,

--- a/packages/coding-agent/src/extensibility/tool-event-input.ts
+++ b/packages/coding-agent/src/extensibility/tool-event-input.ts
@@ -1,12 +1,34 @@
-const HASHLINE_HEADER_RE = /^\s*(?:¶|§|@)([^\s#]+)(?:#[^\s]+)?(?:\s|$)/;
+const HASHLINE_FILE_PREFIX = "¶";
 
 function stringField(input: Record<string, unknown>, key: string): string | undefined {
 	const value = input[key];
 	return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-function extractHashlinePath(input: string): string | undefined {
-	return HASHLINE_HEADER_RE.exec(input)?.[1];
+function normalizeHashlineHeaderPath(body: string): string | undefined {
+	const trimmed = body.trim();
+	if (trimmed.length === 0) return undefined;
+	const hashStart = /#[^\s#]+$/u.exec(trimmed)?.index;
+	const rawPath = hashStart === undefined ? trimmed : trimmed.slice(0, hashStart);
+	if (rawPath.length < 2) return rawPath.length > 0 ? rawPath : undefined;
+	const first = rawPath[0];
+	const last = rawPath[rawPath.length - 1];
+	if ((first === '"' || first === "'") && first === last) return rawPath.slice(1, -1);
+	return rawPath;
+}
+
+function extractHashlinePaths(input: string): string[] {
+	const paths: string[] = [];
+	const stripped = input.startsWith("\uFEFF") ? input.slice(1) : input;
+	for (const rawLine of stripped.split("\n")) {
+		const line = rawLine.replace(/\r$/, "").trimStart();
+		if (!line.startsWith(HASHLINE_FILE_PREFIX)) continue;
+		let prefixEnd = 0;
+		while (prefixEnd < line.length && line[prefixEnd] === HASHLINE_FILE_PREFIX) prefixEnd++;
+		const path = normalizeHashlineHeaderPath(line.slice(prefixEnd));
+		if (path) paths.push(path);
+	}
+	return paths;
 }
 
 /** Adds derived compatibility fields to tool event input without changing tool execution parameters. */
@@ -17,6 +39,8 @@ export function normalizeToolEventInput(toolName: string, input: Record<string, 
 	if (directPath) return { ...input, path: directPath };
 
 	const rawInput = stringField(input, "input") ?? stringField(input, "_input");
-	const hashlinePath = rawInput ? extractHashlinePath(rawInput) : undefined;
-	return hashlinePath ? { ...input, path: hashlinePath } : input;
+	const hashlinePaths = rawInput ? extractHashlinePaths(rawInput) : [];
+	if (hashlinePaths.length === 0) return input;
+	if (hashlinePaths.length === 1) return { ...input, path: hashlinePaths[0], paths: hashlinePaths };
+	return { ...input, paths: hashlinePaths };
 }

--- a/packages/coding-agent/src/extensibility/tool-event-input.ts
+++ b/packages/coding-agent/src/extensibility/tool-event-input.ts
@@ -1,0 +1,22 @@
+const HASHLINE_HEADER_RE = /^\s*(?:¶|§|@)([^\s#]+)(?:#[^\s]+)?(?:\s|$)/;
+
+function stringField(input: Record<string, unknown>, key: string): string | undefined {
+	const value = input[key];
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function extractHashlinePath(input: string): string | undefined {
+	return HASHLINE_HEADER_RE.exec(input)?.[1];
+}
+
+/** Adds derived compatibility fields to tool event input without changing tool execution parameters. */
+export function normalizeToolEventInput(toolName: string, input: Record<string, unknown>): Record<string, unknown> {
+	if (toolName !== "edit" || stringField(input, "path")) return input;
+
+	const directPath = stringField(input, "_path");
+	if (directPath) return { ...input, path: directPath };
+
+	const rawInput = stringField(input, "input") ?? stringField(input, "_input");
+	const hashlinePath = rawInput ? extractHashlinePath(rawInput) : undefined;
+	return hashlinePath ? { ...input, path: hashlinePath } : input;
+}

--- a/packages/coding-agent/src/extensibility/tool-event-input.ts
+++ b/packages/coding-agent/src/extensibility/tool-event-input.ts
@@ -36,12 +36,22 @@ function extractHashlinePaths(input: string): string[] {
 export function normalizeToolEventInput(toolName: string, input: Record<string, unknown>): Record<string, unknown> {
 	if (toolName !== "edit" || stringField(input, "path")) return input;
 
+	// Hashline edit mode: the only authoritative target list is the parsed
+	// `¶PATH#TAG` headers inside `input`/`_input`. Trusting a passthrough
+	// `_path` here would let a model-supplied field override the real edit
+	// target and bypass extension gates that allowlist by path.
+	const rawInput = stringField(input, "input") ?? stringField(input, "_input");
+	if (rawInput !== undefined) {
+		const hashlinePaths = extractHashlinePaths(rawInput);
+		if (hashlinePaths.length === 0) return input;
+		if (hashlinePaths.length === 1) return { ...input, path: hashlinePaths[0], paths: hashlinePaths };
+		return { ...input, paths: hashlinePaths };
+	}
+
+	// Replace/patch modes: `path` is the real parameter; some hosts forward
+	// it as `_path` after schema normalization, so propagate it for gates.
 	const directPath = stringField(input, "_path");
 	if (directPath) return { ...input, path: directPath };
 
-	const rawInput = stringField(input, "input") ?? stringField(input, "_input");
-	const hashlinePaths = rawInput ? extractHashlinePaths(rawInput) : [];
-	if (hashlinePaths.length === 0) return input;
-	if (hashlinePaths.length === 1) return { ...input, path: hashlinePaths[0], paths: hashlinePaths };
-	return { ...input, paths: hashlinePaths };
+	return input;
 }

--- a/packages/coding-agent/src/extensibility/tool-event-input.ts
+++ b/packages/coding-agent/src/extensibility/tool-event-input.ts
@@ -1,4 +1,5 @@
 const HASHLINE_FILE_PREFIX = "¶";
+const HASHLINE_FILE_TAG_RE = /#[0-9a-fA-F]{4}$/u;
 
 function stringField(input: Record<string, unknown>, key: string): string | undefined {
 	const value = input[key];
@@ -8,7 +9,7 @@ function stringField(input: Record<string, unknown>, key: string): string | unde
 function normalizeHashlineHeaderPath(body: string): string | undefined {
 	const trimmed = body.trim();
 	if (trimmed.length === 0) return undefined;
-	const hashStart = /#[^\s#]+$/u.exec(trimmed)?.index;
+	const hashStart = HASHLINE_FILE_TAG_RE.exec(trimmed)?.index;
 	const rawPath = hashStart === undefined ? trimmed : trimmed.slice(0, hashStart);
 	if (rawPath.length < 2) return rawPath.length > 0 ? rawPath : undefined;
 	const first = rawPath[0];

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -778,7 +778,18 @@ describe("ExtensionRunner", () => {
 	});
 
 	describe("tool_call input", () => {
-		it("exposes hashline edit paths to extension gate handlers", async () => {
+		function createHashlineEditTool(): AgentTool {
+			return {
+				name: "edit",
+				label: "Edit",
+				description: "Test edit tool",
+				parameters: Type.Object({ input: Type.String() }),
+				strict: true,
+				execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+			};
+		}
+
+		it("exposes a single hashline edit path to extension gate handlers", async () => {
 			const eventsPath = path.join(tempDir.path(), "tool-call-events.jsonl");
 			const extCode = `
 				import * as fs from "node:fs";
@@ -788,7 +799,7 @@ describe("ExtensionRunner", () => {
 						if (event.toolName !== "edit") return;
 						fs.appendFileSync(
 							${JSON.stringify(eventsPath)},
-							JSON.stringify({ path: event.input.path }) + "\\n",
+							JSON.stringify({ path: event.input.path, paths: event.input.paths }) + "\\n",
 						);
 						if (typeof event.input.path !== "string") {
 							return { block: true, reason: \`Blocked: \${event.input.path}\` };
@@ -806,28 +817,70 @@ describe("ExtensionRunner", () => {
 				sessionManager,
 				modelRegistry,
 			);
-			const params = Type.Object({ input: Type.String() });
-			const editTool: AgentTool<typeof params, unknown> = {
-				name: "edit",
-				label: "Edit",
-				description: "Test edit tool",
-				parameters: params,
-				strict: true,
-				execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
-			};
-			const wrapped = new ExtensionToolWrapper(editTool, runner);
+			const wrapped = new ExtensionToolWrapper(createHashlineEditTool(), runner);
 
 			const resultMessage = await wrapped.execute("tool-call-id", {
-				input: "¶plans/switch-case-array-syntax.md#ABC\\n27 27\\n+new content",
+				input: "¶plans/switch-case-array-syntax.md#ABC1\n27 27\n+new content",
 			});
 
 			expect(resultMessage.content).toEqual([{ type: "text", text: "ok" }]);
 			const events = fs
 				.readFileSync(eventsPath, "utf8")
 				.trim()
-				.split("\\n")
+				.split("\n")
 				.map(line => JSON.parse(line));
-			expect(events).toEqual([{ path: "plans/switch-case-array-syntax.md" }]);
+			expect(events).toEqual([
+				{ path: "plans/switch-case-array-syntax.md", paths: ["plans/switch-case-array-syntax.md"] },
+			]);
+		});
+
+		it("leaves path unset and reports all targets for multi-file hashline edits", async () => {
+			const eventsPath = path.join(tempDir.path(), "tool-call-multi-path-events.jsonl");
+			const extCode = `
+				import * as fs from "node:fs";
+
+				export default function(pi) {
+					pi.on("tool_call", async (event) => {
+						if (event.toolName !== "edit") return;
+						fs.appendFileSync(
+							${JSON.stringify(eventsPath)},
+							JSON.stringify({ path: event.input.path ?? null, paths: event.input.paths }) + "\\n",
+						);
+						if (typeof event.input.path !== "string") {
+							return { block: true, reason: \`Blocked: \${event.input.path}\` };
+						}
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "tool-call-multi-path.ts"), extCode);
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const wrapped = new ExtensionToolWrapper(createHashlineEditTool(), runner);
+
+			await expect(
+				wrapped.execute("tool-call-id", {
+					input: "¶plans/switch-case-array-syntax.md#ABC1\n27 27\n+new content\n¶packages/coding-agent/src/main.ts#DEF2\n1 1\n+changed",
+				}),
+			).rejects.toThrow("Blocked: undefined");
+
+			const events = fs
+				.readFileSync(eventsPath, "utf8")
+				.trim()
+				.split("\n")
+				.map(line => JSON.parse(line));
+			expect(events).toEqual([
+				{
+					path: null,
+					paths: ["plans/switch-case-array-syntax.md", "packages/coding-agent/src/main.ts"],
+				},
+			]);
 		});
 	});
 

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -5,6 +5,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { discoverAndLoadExtensions } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/loader";
 import {
@@ -12,6 +13,8 @@ import {
 	ExtensionRunner,
 	testSetExtensionHandlerTimeoutMs,
 } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/runner";
+import { ExtensionToolWrapper } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/wrapper";
+import { Type } from "@oh-my-pi/pi-coding-agent/extensibility/typebox";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { getProjectAgentDir, logger, TempDir } from "@oh-my-pi/pi-utils";
@@ -771,6 +774,60 @@ describe("ExtensionRunner", () => {
 
 			expect(loadError).toBeDefined();
 			expect(loadError?.error).toContain("Extension runtime not initialized");
+		});
+	});
+
+	describe("tool_call input", () => {
+		it("exposes hashline edit paths to extension gate handlers", async () => {
+			const eventsPath = path.join(tempDir.path(), "tool-call-events.jsonl");
+			const extCode = `
+				import * as fs from "node:fs";
+
+				export default function(pi) {
+					pi.on("tool_call", async (event) => {
+						if (event.toolName !== "edit") return;
+						fs.appendFileSync(
+							${JSON.stringify(eventsPath)},
+							JSON.stringify({ path: event.input.path }) + "\\n",
+						);
+						if (typeof event.input.path !== "string") {
+							return { block: true, reason: \`Blocked: \${event.input.path}\` };
+						}
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "tool-call-path.ts"), extCode);
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const params = Type.Object({ input: Type.String() });
+			const editTool: AgentTool<typeof params, unknown> = {
+				name: "edit",
+				label: "Edit",
+				description: "Test edit tool",
+				parameters: params,
+				strict: true,
+				execute: async () => ({ content: [{ type: "text", text: "ok" }] }),
+			};
+			const wrapped = new ExtensionToolWrapper(editTool, runner);
+
+			const resultMessage = await wrapped.execute("tool-call-id", {
+				input: "¶plans/switch-case-array-syntax.md#ABC\\n27 27\\n+new content",
+			});
+
+			expect(resultMessage.content).toEqual([{ type: "text", text: "ok" }]);
+			const events = fs
+				.readFileSync(eventsPath, "utf8")
+				.trim()
+				.split("\\n")
+				.map(line => JSON.parse(line));
+			expect(events).toEqual([{ path: "plans/switch-case-array-syntax.md" }]);
 		});
 	});
 

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -872,6 +872,46 @@ describe("ExtensionRunner", () => {
 			expect(events).toEqual([{ path: "plans/foo.md#notatag", paths: ["plans/foo.md#notatag"] }]);
 		});
 
+		it("ignores _path passthrough when the hashline input names a different target", async () => {
+			const eventsPath = path.join(tempDir.path(), "tool-call-spoof-path-events.jsonl");
+			const extCode = `
+				import * as fs from "node:fs";
+
+				export default function(pi) {
+					pi.on("tool_call", async (event) => {
+						if (event.toolName !== "edit") return;
+						fs.appendFileSync(
+							${JSON.stringify(eventsPath)},
+							JSON.stringify({ path: event.input.path, paths: event.input.paths }) + "\\n",
+						);
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "tool-call-spoof-path.ts"), extCode);
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const wrapped = new ExtensionToolWrapper(createHashlineEditTool(), runner);
+
+			await wrapped.execute("tool-call-id", {
+				_path: "plans/allowed.md",
+				input: "¶src/secret.ts#ABC1\n27 27\n+evil content",
+			});
+
+			const events = fs
+				.readFileSync(eventsPath, "utf8")
+				.trim()
+				.split("\n")
+				.map(line => JSON.parse(line));
+			expect(events).toEqual([{ path: "src/secret.ts", paths: ["src/secret.ts"] }]);
+		});
+
 		it("leaves path unset and reports all targets for multi-file hashline edits", async () => {
 			const eventsPath = path.join(tempDir.path(), "tool-call-multi-path-events.jsonl");
 			const extCode = `

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -833,6 +833,44 @@ describe("ExtensionRunner", () => {
 				{ path: "plans/switch-case-array-syntax.md", paths: ["plans/switch-case-array-syntax.md"] },
 			]);
 		});
+		it("keeps non-tag hash suffixes in hashline edit paths", async () => {
+			const eventsPath = path.join(tempDir.path(), "tool-call-non-tag-path-events.jsonl");
+			const extCode = `
+				import * as fs from "node:fs";
+
+				export default function(pi) {
+					pi.on("tool_call", async (event) => {
+						if (event.toolName !== "edit") return;
+						fs.appendFileSync(
+							${JSON.stringify(eventsPath)},
+							JSON.stringify({ path: event.input.path, paths: event.input.paths }) + "\\n",
+						);
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "tool-call-non-tag-path.ts"), extCode);
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const wrapped = new ExtensionToolWrapper(createHashlineEditTool(), runner);
+
+			await wrapped.execute("tool-call-id", {
+				input: "¶plans/foo.md#notatag\n27 27\n+new content",
+			});
+
+			const events = fs
+				.readFileSync(eventsPath, "utf8")
+				.trim()
+				.split("\n")
+				.map(line => JSON.parse(line));
+			expect(events).toEqual([{ path: "plans/foo.md#notatag", paths: ["plans/foo.md#notatag"] }]);
+		});
 
 		it("leaves path unset and reports all targets for multi-file hashline edits", async () => {
 			const eventsPath = path.join(tempDir.path(), "tool-call-multi-path-events.jsonl");


### PR DESCRIPTION
## Repro
A planning-mode extension gate that checks `event.input.path` blocks hashline `edit` calls because the event input only contains the raw hashline payload. Reproduced with `cd packages/coding-agent && bun -e "$REPRO_SCRIPT"`, which returned `Blocked: undefined` for `{ input: "¶plans/switch-case-array-syntax.md#ABC\n..." }` before the fix.

## Cause
`ExtensionToolWrapper.execute` and `HookToolWrapper.execute` emitted `tool_call`/`tool_result` events with the raw edit parameters from `packages/coding-agent/src/extensibility/extensions/wrapper.ts` and `packages/coding-agent/src/extensibility/hooks/tool-wrapper.ts`. Hashline edit mode carries its file path inside the first `¶PATH#TAG` header rather than a `path` parameter, so extension gates saw no path.

## Fix
- Added `normalizeToolEventInput` to derive `path` from edit `_path`, `input`, or `_input` fields without changing the actual tool execution parameters.
- Applied that normalization to extension and hook `tool_call`/`tool_result` events.
- Added a regression test proving an extension gate receives `event.input.path === "plans/switch-case-array-syntax.md"` for a hashline edit call.
- Added the coding-agent changelog entry.

## Verification
- `bun test packages/coding-agent/test/extensions-runner.test.ts`
- `bun --cwd=packages/coding-agent run check`
- Manual repro command now prints `allowed` instead of `Blocked: undefined`. Fixes #1678