### PR TITLE
fix(tui): defer eager scrollback rebuild on ED3-reset POSIX terminals (WezTerm/kitty/ghostty/alacritty)

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed scrolled-up readers being yanked to the **top** of scrollback on POSIX terminals that reset the viewport on ED3 (`\x1b[3J`) — WezTerm, kitty, ghostty, alacritty — while a foreground tool or the assistant was streaming. `setEagerNativeScrollbackRebuild` (the active-tool/streaming opt-in added in 15.7.3) promotes an unknown viewport back into a destructive `historyRebuild`; on these terminals erasing scrollback snaps the viewport to the top rather than tolerably to the tail, so #1635's POSIX deferral was still bypassed for them. The eager flag is no longer promoted for these terminals (`isNativeScrollbackClearHostile`), so streaming offscreen edits defer to a non-destructive viewport repaint and reconcile native scrollback at the next prompt-submit checkpoint (where input has pinned the terminal to the bottom). Other POSIX terminals keep the eager rebuild; explicit autocomplete/IME opt-ins, resize, and checkpoint replays are unchanged. ([#1682](https://github.com/can1357/oh-my-pi/issues/1682)) Companion to the Windows Terminal fix in [#1635](https://github.com/can1357/oh-my-pi/issues/1635).
+
 ## [15.7.6] - 2026-06-01
 
 ### Fixed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -167,6 +167,28 @@ function isMultiplexerSession(): boolean {
 }
 
 /**
+ * Detect terminals that reset the visible viewport to the TOP of the scrollback
+ * when they erase it via ED3 (`\x1b[3J`). On these hosts the eager native
+ * scrollback rebuild that runs during streaming — which clears scrollback and
+ * repaints — yanks a scrolled-up reader to the top instead of (tolerably)
+ * snapping to the tail. The renderer cannot probe the viewport position on POSIX
+ * (`isNativeViewportAtBottom()` is `undefined`), so for these terminals the eager
+ * rebuild must defer to the next checkpoint instead of clearing scrollback live.
+ * Keyed on the same env markers `TERMINAL_ID` (terminal-capabilities.ts) uses for
+ * WezTerm, kitty, ghostty, and alacritty. Issue #1635 fixed the same yank for
+ * Windows Terminal; this is the POSIX counterpart.
+ */
+function isNativeScrollbackClearHostile(): boolean {
+	return Boolean(
+		Bun.env.WEZTERM_PANE ||
+			Bun.env.KITTY_WINDOW_ID ||
+			Bun.env.GHOSTTY_RESOURCES_DIR ||
+			Bun.env.ALACRITTY_WINDOW_ID ||
+			Bun.env.ALACRITTY_SOCKET,
+	);
+}
+
+/**
  * Options for overlay positioning and sizing.
  * Values can be absolute numbers or percentage strings (e.g., "50%").
  */
@@ -1181,7 +1203,8 @@ export class TUI extends Container {
 		const widthChanged = this.#previousWidth > 0 && this.#previousWidth !== width;
 		const heightChanged = this.#previousHeight > 0 && this.#previousHeight !== height;
 		const allowUnknownViewportMutation =
-			this.#allowUnknownViewportMutationOnNextRender || this.#eagerNativeScrollbackRebuild;
+			this.#allowUnknownViewportMutationOnNextRender ||
+			(this.#eagerNativeScrollbackRebuild && !isNativeScrollbackClearHostile());
 		this.#allowUnknownViewportMutationOnNextRender = false;
 
 		// 3. Classify intent.

--- a/packages/tui/test/issue-1682-repro.test.ts
+++ b/packages/tui/test/issue-1682-repro.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { type Component, TUI } from "@oh-my-pi/pi-tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+// Regression test for https://github.com/can1357/oh-my-pi/issues/1682
+// (the POSIX counterpart of #1635).
+//
+// #1635 fixed the "scroll up while streaming -> viewport snaps to the top of
+// scrollback" yank for Windows Terminal by routing its viewport probe to
+// `undefined`. On POSIX the probe is *already* `undefined`, but the eager native
+// scrollback rebuild enabled for unknown POSIX viewports (commit 5f543b957) opts
+// streaming-time mutations back into the destructive `historyRebuild` intent,
+// which emits `\x1b[2J\x1b[H\x1b[3J`. On terminals that reset the viewport to the
+// TOP of scrollback on ED3 (`\x1b[3J`) — WezTerm, kitty, ghostty, alacritty —
+// that yanks a scrolled-up reader to the top instead of snapping to the tail.
+//
+// Fix: `isNativeScrollbackClearHostile()` gates the eager-flag promotion in
+// `#doRender`, so on those terminals streaming offscreen edits defer to a
+// non-destructive viewport repaint + dirty mark, and the destructive rebuild is
+// held until the next checkpoint (`refreshNativeScrollbackIfDirty` on prompt
+// submit) where the editor keystroke has already pinned the terminal to the
+// bottom.
+class LineList implements Component {
+	#lines: string[];
+	constructor(lines: string[]) {
+		this.#lines = [...lines];
+	}
+	invalidate(): void {}
+	render(width: number): string[] {
+		return this.#lines.map(l => l.slice(0, width));
+	}
+	setLines(lines: string[]): void {
+		this.#lines = [...lines];
+	}
+}
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	await new Promise<void>(r => process.nextTick(r));
+	await new Promise<void>(r => setTimeout(r, 20));
+	await term.flush();
+}
+
+function capture(term: VirtualTerminal): string[] {
+	const writes: string[] = [];
+	const realWrite = term.write.bind(term);
+	(term as unknown as { write: (s: string) => void }).write = (data: string) => {
+		writes.push(data);
+		realWrite(data);
+	};
+	return writes;
+}
+
+function overrideProbe(term: VirtualTerminal, answer: boolean | undefined): void {
+	(term as unknown as { isNativeViewportAtBottom: () => boolean | undefined }).isNativeViewportAtBottom = () => answer;
+}
+
+const ERASE_SCROLLBACK = /\x1b\[3J/g;
+
+// Terminal-identifying / multiplexer env that would change the routing under test.
+const ENV_KEYS = [
+	"WEZTERM_PANE",
+	"KITTY_WINDOW_ID",
+	"GHOSTTY_RESOURCES_DIR",
+	"ALACRITTY_WINDOW_ID",
+	"ALACRITTY_SOCKET",
+	"TMUX",
+	"STY",
+	"ZELLIJ",
+	"TERMUX_VERSION",
+] as const;
+
+describe("issue #1635 (POSIX): eager rebuild must not yank ED3-reset terminals", () => {
+	let savedEnv: Record<string, string | undefined>;
+	let savedPlatform: PropertyDescriptor | undefined;
+
+	beforeEach(() => {
+		savedEnv = {};
+		for (const k of ENV_KEYS) {
+			savedEnv[k] = Bun.env[k];
+			delete Bun.env[k];
+		}
+		// Pin a POSIX platform so the scenario is deterministic on any CI host.
+		savedPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+		Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+	});
+
+	afterEach(() => {
+		for (const k of ENV_KEYS) {
+			if (savedEnv[k] === undefined) delete Bun.env[k];
+			else Bun.env[k] = savedEnv[k];
+		}
+		if (savedPlatform) Object.defineProperty(process, "platform", savedPlatform);
+	});
+
+	// Drives the streaming shape: an offscreen structural mutation while the eager
+	// rebuild flag is set (the coding-agent sets it for every streaming event).
+	async function streamMutation(term: VirtualTerminal): Promise<{ tui: TUI; writes: string[] }> {
+		overrideProbe(term, undefined);
+		const tui = new TUI(term);
+		const component = new LineList(Array.from({ length: 80 }, (_, i) => `init-${i}`));
+		tui.addChild(component);
+		tui.start();
+		await settle(term);
+		const writes = capture(term);
+		tui.setEagerNativeScrollbackRebuild(true); // foreground tool / assistant streaming
+		component.setLines(Array.from({ length: 20 }, (_, i) => `shrunk-${i}`));
+		tui.requestRender();
+		await settle(term);
+		return { tui, writes };
+	}
+
+	it("WezTerm (WEZTERM_PANE): streaming rebuild must not emit \\x1b[3J", async () => {
+		Bun.env.WEZTERM_PANE = "0";
+		const term = new VirtualTerminal(100, 24);
+		const { tui, writes } = await streamMutation(term);
+		try {
+			expect(writes.join("").match(ERASE_SCROLLBACK)).toBeNull();
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("kitty (KITTY_WINDOW_ID): streaming rebuild must not emit \\x1b[3J", async () => {
+		Bun.env.KITTY_WINDOW_ID = "1";
+		const term = new VirtualTerminal(100, 24);
+		const { tui, writes } = await streamMutation(term);
+		try {
+			expect(writes.join("").match(ERASE_SCROLLBACK)).toBeNull();
+		} finally {
+			tui.stop();
+		}
+	});
+
+	// Control: a POSIX terminal NOT known to reset-to-top keeps the intentional
+	// eager rebuild (commit 5f543b957) — proves the gate, not a blanket disable,
+	// is what suppresses the sequence on hostile terminals.
+	it("non-hostile POSIX control: streaming rebuild still emits \\x1b[3J", async () => {
+		const term = new VirtualTerminal(100, 24);
+		const { tui, writes } = await streamMutation(term);
+		try {
+			expect(writes.join("").match(ERASE_SCROLLBACK)).not.toBeNull();
+		} finally {
+			tui.stop();
+		}
+	});
+
+	// The deferral is not silent data loss: at the next checkpoint (prompt submit,
+	// where scroll_to_bottom_on_input has pinned the viewport to the tail) the
+	// dirty scrollback is reconciled with the destructive rebuild.
+	it("WezTerm: deferred scrollback is reconciled at the checkpoint", async () => {
+		Bun.env.WEZTERM_PANE = "0";
+		const term = new VirtualTerminal(100, 24);
+		const { tui, writes } = await streamMutation(term);
+		try {
+			expect(writes.join("").match(ERASE_SCROLLBACK)).toBeNull();
+			const checkpointStart = writes.length;
+			const rebuilt = tui.refreshNativeScrollbackIfDirty({ allowUnknownViewport: true });
+			await settle(term);
+			expect(rebuilt).toBe(true);
+			expect(writes.slice(checkpointStart).join("").match(ERASE_SCROLLBACK)).not.toBeNull();
+		} finally {
+			tui.stop();
+		}
+	});
+});

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -125,6 +125,21 @@ async function withEnvPatch<T>(patch: Record<string, string | undefined>, run: (
 	}
 }
 
+// Multiplexers plus terminals that reset the viewport to scrollback-top on ED3
+// (`\x1b[3J`). Eager-rebuild tests that assert the destructive rebuild path must
+// clear these so they stay deterministic when the suite is run from a hostile
+// terminal (e.g. WezTerm/kitty), where the rebuild now defers instead.
+const NON_HOSTILE_TERMINAL_ENV: Record<string, string | undefined> = {
+	TMUX: undefined,
+	STY: undefined,
+	ZELLIJ: undefined,
+	WEZTERM_PANE: undefined,
+	KITTY_WINDOW_ID: undefined,
+	GHOSTTY_RESOURCES_DIR: undefined,
+	ALACRITTY_WINDOW_ID: undefined,
+	ALACRITTY_SOCKET: undefined,
+};
+
 describe("TUI terminal-state regressions", () => {
 	let monotonicNow = 0;
 	// Keep TUI's 16ms render throttle deterministic without sleeping a real frame per render.
@@ -1815,7 +1830,7 @@ describe("TUI terminal-state regressions", () => {
 			const originalPlatform = process.platform;
 			Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
 			try {
-				await withEnvPatch({ TMUX: undefined, STY: undefined, ZELLIJ: undefined }, async () => {
+				await withEnvPatch(NON_HOSTILE_TERMINAL_ENV, async () => {
 					const term = new UnknownViewportTerminal(40, 5, 200);
 					const tui = new TUI(term);
 					const component = new MutableLinesComponent(rows("row-", 16));


### PR DESCRIPTION
Fixes #1682

## Repro

On macOS/Linux in WezTerm (also kitty/ghostty/alacritty), scrolling up while the assistant or a foreground tool streams snaps the viewport to the **top** of scrollback. New deterministic regression in `packages/tui/test/issue-1682-repro.test.ts` reproduces it at the renderer level (pin POSIX platform, `WEZTERM_PANE` set, `setEagerNativeScrollbackRebuild(true)`, offscreen structural mutation → `\x1b[3J` emitted on `main`).

```
bun test packages/tui/test/issue-1682-repro.test.ts
```

Pre-fix: the WezTerm/kitty and checkpoint cases fail with `Received: [ "\u001B[3J" ]`. Post-fix: 4 pass.

## Cause

`#doRender` (`packages/tui/src/tui.ts`):

```ts
const allowUnknownViewportMutation =
    this.#allowUnknownViewportMutationOnNextRender || this.#eagerNativeScrollbackRebuild;
```

`EventController.#refreshToolRenderMode` sets `setEagerNativeScrollbackRebuild(true)` for every streaming event. That flag is OR'd into `allowUnknownViewportMutation`, so `#canRebuildNativeScrollbackLive(undefined, true)` returns `true` on POSIX and offscreen streaming edits route to `historyRebuild` → `#emitFullPaint(..., { clearScrollback: !isMultiplexerSession() })` → `\x1b[2J\x1b[H\x1b[3J`.

`\x1b[3J` (ED3, erase-scrollback) resets the viewport to the **top** on WezTerm/kitty/ghostty/alacritty. These terminals don't scroll on output (only on input), so ED3 is the *only* thing that moves a scrolled-up reader. The "snap to the tail is acceptable mid-tool" trade-off behind the eager rebuild (15.7.3) holds only on terminals that don't reset to top on ED3 — #1635 closed the same yank for Windows Terminal, but the eager streaming opt-in still bypasses the 15.7.3 POSIX deferral for these terminals.

## Fix

- Added `isNativeScrollbackClearHostile()` in `tui.ts` (parallel to `isMultiplexerSession`), keyed on the same env markers `TERMINAL_ID` (`terminal-capabilities.ts`) uses for WezTerm, kitty, ghostty, alacritty.
- `#doRender` no longer promotes the eager flag into `allowUnknownViewportMutation` on those terminals:

  ```ts
  const allowUnknownViewportMutation =
      this.#allowUnknownViewportMutationOnNextRender ||
      (this.#eagerNativeScrollbackRebuild && !isNativeScrollbackClearHostile());
  ```

  Streaming offscreen edits now defer to a non-destructive `viewportRepaint` + dirty mark; the destructive rebuild is held until the next checkpoint (`refreshNativeScrollbackIfDirty` on prompt submit), where `scroll_to_bottom_on_input` has already pinned the terminal to the tail so the rebuild is harmless. This mirrors the WSL+WT approach in #1612 (gate the eager promotion, not the explicit opt-ins).

### Deliberately unchanged

- **Other POSIX terminals** keep the eager rebuild (15.7.3) — this is a gate, not a blanket disable (the non-hostile POSIX control test proves it still emits `\x1b[3J`).
- **Explicit `allowUnknownViewportMutation` opt-ins** (autocomplete/IME) still rebuild — the user is typing, so `scroll_to_bottom_on_input` pins them to the bottom.
- **Resize and checkpoint replays** (`#canReplayNativeScrollbackAtCheckpoint`) are untouched.
- **`/clear` / `sessionReplace`** still wipes scrollback via its own path.

## Tests

- `packages/tui/test/issue-1682-repro.test.ts` (new): WezTerm and kitty must not emit `\x1b[3J` during streaming; a non-hostile POSIX control still does (proves the gate); and the deferred scrollback is reconciled at the checkpoint (proves it is not silent data loss).
- `packages/tui/test/render-regressions.test.ts`: the eager-rebuild destructive-path test ("rebuilds offscreen edits into clean scrollback while eager rebuild is enabled") now pins a non-hostile terminal env (`NON_HOSTILE_TERMINAL_ENV`) so it is deterministic when the suite is run from a hostile terminal (WezTerm/kitty/…). Without this, the test fails on a developer's WezTerm because the new gate defers the rebuild it asserts.
- `packages/tui/CHANGELOG.md`: `[Unreleased]` entry.

## Verification

```
bun test packages/tui/test/issue-1682-repro.test.ts   # 4 pass
bun test packages/tui/test/render-regressions.test.ts \
         packages/tui/test/issue-1635-repro.test.ts \
         packages/tui/test/slash-autocomplete-viewport.test.ts \
         packages/tui/test/overlay-scroll.test.ts                     # 98 pass
bun --cwd=packages/tui run check                                      # biome + tsgo clean
```

Confirmed the new test catches the regression: `git stash push -- packages/tui/src/tui.ts` → the WezTerm/kitty/checkpoint cases fail with `Received: [ "\u001B[3J" ]`; restoring the fix makes them pass.

## Notes

- Scope = the four terminals `TERMINAL_ID` already recognizes as resetting to top on ED3. iTerm2/VS Code/Terminal.app are left on the eager path; if any of them are confirmed to reset on ED3, add their marker to `isNativeScrollbackClearHostile`.
- The regression test is named `issue-1682-repro.test.ts` and the `#1635` references are annotated as the companion fix.