### PR TITLE
fix(tui): defer eager scrollback rebuild on POSIX ED3-resetting terminals (#1682)

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed scrolled-up readers being yanked to the top of scrollback during streaming on POSIX terminals that reset the viewport on ED3 (WezTerm, kitty, ghostty, alacritty). `TUI.setEagerNativeScrollbackRebuild(true)` — which the coding agent enables for the full duration of every streaming event — promoted the eager opt-in into `allowUnknownViewportMutation`, bypassing the 15.7.3 unknown-viewport deferral and routing offscreen structural mutations through `historyRebuild` → `\x1b[2J\x1b[H\x1b[3J`. These terminals honor ECMA-48 ED3 by repositioning the viewport to the top of the (now-erased) scrollback, so the rebuild yanked the reader. The eager flag now defers on those hosts (detected via `WEZTERM_PANE` / `KITTY_WINDOW_ID` / `GHOSTTY_RESOURCES_DIR` / `ALACRITTY_WINDOW_ID` or `TERM_PROGRAM`); the destructive rebuild lands at the next checkpoint (`refreshNativeScrollbackIfDirty` on prompt submit) where the user's keystroke has pinned the viewport back to the bottom. Autocomplete/IME paths that opt in via `requestRender(..., { allowUnknownViewportMutation: true })` are unaffected. Other POSIX terminals keep the eager rebuild. ([#1682](https://github.com/can1357/oh-my-pi/issues/1682))
+
 ## [15.7.6] - 2026-06-01
 
 ### Fixed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -135,6 +135,44 @@ export function shouldTrustNativeViewportProbe(
 }
 
 /**
+ * Whether the host terminal resets the visible viewport to the top of
+ * scrollback when it receives ED3 (`\x1b[3J`).
+ *
+ * WezTerm, kitty, ghostty, and alacritty honor ECMA-48 ED3 by repositioning
+ * the viewport to the top of the (now-erased) scrollback. They also pin only
+ * on user input (no `scroll_to_bottom_on_output`), so a destructive native
+ * scrollback rebuild during streaming yanks a scrolled-up reader to the top.
+ * Caller uses this to gate the renderer's eager scrollback rebuild: when this
+ * returns true, the eager opt-in no longer overrides the unknown-viewport
+ * deferral and the destructive rebuild is held until the next checkpoint,
+ * where the user's keystroke has already pinned the terminal back to the
+ * bottom. Autocomplete/IME paths that pass `allowUnknownViewportMutation`
+ * explicitly are unaffected — the user is actively typing.
+ *
+ * Pure helper for unit testing; the runtime call site reads `$env` /
+ * `process.platform`. See #1682.
+ */
+export function terminalResetsViewportOnEraseScrollback(
+	env: {
+		WEZTERM_PANE?: string | undefined;
+		KITTY_WINDOW_ID?: string | undefined;
+		GHOSTTY_RESOURCES_DIR?: string | undefined;
+		ALACRITTY_WINDOW_ID?: string | undefined;
+		TERM_PROGRAM?: string | undefined;
+	} = $env,
+	platform: NodeJS.Platform = process.platform,
+): boolean {
+	if (platform === "win32") return false;
+	if (env.WEZTERM_PANE || env.KITTY_WINDOW_ID || env.GHOSTTY_RESOURCES_DIR || env.ALACRITTY_WINDOW_ID) {
+		return true;
+	}
+	const termProgram = env.TERM_PROGRAM?.toLowerCase();
+	return (
+		termProgram === "wezterm" || termProgram === "kitty" || termProgram === "ghostty" || termProgram === "alacritty"
+	);
+}
+
+/**
  * Real terminal using process.stdin/stdout
  */
 export class ProcessTerminal implements Terminal {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -6,7 +6,7 @@ import * as path from "node:path";
 import { performance } from "node:perf_hooks";
 import { $flag, getDebugLogPath } from "@oh-my-pi/pi-utils";
 import { isKeyRelease, matchesKey } from "./keys";
-import type { Terminal } from "./terminal";
+import { type Terminal, terminalResetsViewportOnEraseScrollback } from "./terminal";
 import { ImageProtocol, setCellDimensions, setTerminalImageProtocol, TERMINAL } from "./terminal-capabilities";
 import {
 	Ellipsis,
@@ -388,7 +388,11 @@ export class TUI extends Container {
 	 * is actively re-rendering — e.g. a tool whose result is still streaming and
 	 * re-laying-out rows that have already scrolled into history. A snap to the tail
 	 * is acceptable there. A terminal that can report a *known*-scrolled viewport
-	 * (Windows) still defers; only the unknown case is forced to rebuild.
+	 * (Windows) still defers; only the unknown case is forced to rebuild. POSIX
+	 * hosts whose terminal is known to reset the viewport on ED3 (WezTerm,
+	 * kitty, ghostty, alacritty — see #1682) also defer, since the destructive
+	 * `\x1b[3J` would yank a scrolled-up reader; the deferred rebuild lands at
+	 * the next checkpoint where input has pinned the viewport to the bottom.
 	 */
 	setEagerNativeScrollbackRebuild(enabled: boolean): void {
 		this.#eagerNativeScrollbackRebuild = enabled;
@@ -1180,8 +1184,18 @@ export class TUI extends Container {
 		const prevHardwareCursorRow = this.#hardwareCursorRow;
 		const widthChanged = this.#previousWidth > 0 && this.#previousWidth !== width;
 		const heightChanged = this.#previousHeight > 0 && this.#previousHeight !== height;
-		const allowUnknownViewportMutation =
-			this.#allowUnknownViewportMutationOnNextRender || this.#eagerNativeScrollbackRebuild;
+		// `setEagerNativeScrollbackRebuild(true)` (coding-agent enables it for the
+		// full duration of every streaming event) normally lets unknown-viewport
+		// frames take the destructive `historyRebuild` path so re-laying-out
+		// streamed output produces a clean, duplicate-free history. On terminals
+		// that reset the viewport to the top of scrollback on ED3 (WezTerm,
+		// kitty, ghostty, alacritty — see #1682) that snap-to-tail yanks any
+		// scrolled-up reader. Defer to the non-destructive viewport repaint
+		// there; the explicit autocomplete/IME opt-in via `requestRender(...,
+		// { allowUnknownViewportMutation: true })` still flows through because
+		// the user's keystroke has pinned the terminal back to the bottom.
+		const eagerRebuildAllowed = this.#eagerNativeScrollbackRebuild && !terminalResetsViewportOnEraseScrollback();
+		const allowUnknownViewportMutation = this.#allowUnknownViewportMutationOnNextRender || eagerRebuildAllowed;
 		this.#allowUnknownViewportMutationOnNextRender = false;
 
 		// 3. Classify intent.

--- a/packages/tui/test/issue-1682-repro.test.ts
+++ b/packages/tui/test/issue-1682-repro.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { type Component, TUI } from "@oh-my-pi/pi-tui";
+import { terminalResetsViewportOnEraseScrollback } from "@oh-my-pi/pi-tui/terminal";
+import { VirtualTerminal } from "./virtual-terminal";
+
+// Regression test for https://github.com/can1357/oh-my-pi/issues/1682
+//
+// POSIX counterpart of #1635. WezTerm, kitty, ghostty, and alacritty do not
+// scroll on program output; the only sequence that forcibly resets the visible
+// viewport is ED3 (`\x1b[3J`), which they honor per ECMA-48 by resetting to the
+// top of the (now-erased) scrollback. The 15.7.3 POSIX deferral keeps offscreen
+// edits non-destructive when `isNativeViewportAtBottom()` is `undefined`, but
+// the coding-agent EventController enables
+// `setEagerNativeScrollbackRebuild(true)` for every streaming event. `#doRender`
+// ORs that flag into `allowUnknownViewportMutation`, so the deferral is
+// bypassed and offscreen structural mutations during streaming route to
+// `historyRebuild` → `\x1b[2J\x1b[H\x1b[3J` → viewport yank.
+//
+// Fix: the eager flag no longer overrides the unknown-viewport deferral on
+// POSIX hosts that reset on ED3. The destructive rebuild is held until the
+// next checkpoint (`refreshNativeScrollbackIfDirty` on prompt submit, where the
+// user's keystroke has pinned the terminal back to the bottom). The
+// autocomplete/IME opt-in (`#allowUnknownViewportMutationOnNextRender`) is
+// unaffected because the user is actively typing into the prompt.
+
+class LineList implements Component {
+	#lines: string[];
+	constructor(lines: string[]) {
+		this.#lines = [...lines];
+	}
+	invalidate(): void {}
+	render(width: number): string[] {
+		return this.#lines.map(l => l.slice(0, width));
+	}
+	setLines(lines: string[]): void {
+		this.#lines = [...lines];
+	}
+}
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	await new Promise<void>(r => process.nextTick(r));
+	await new Promise<void>(r => setTimeout(r, 20));
+	await term.flush();
+}
+
+function capture(term: VirtualTerminal): string[] {
+	const writes: string[] = [];
+	const realWrite = term.write.bind(term);
+	(term as unknown as { write: (s: string) => void }).write = (data: string) => {
+		writes.push(data);
+		realWrite(data);
+	};
+	return writes;
+}
+
+function overrideProbe(term: VirtualTerminal, answer: boolean | undefined): void {
+	(term as unknown as { isNativeViewportAtBottom: () => boolean | undefined }).isNativeViewportAtBottom = () => answer;
+}
+
+const ERASE_SCROLLBACK = /\x1b\[3J/g;
+
+// Env keys the renderer's terminal-id probe consults. We clear all of them in
+// `beforeEach` so the control test has a clean baseline, and set the WezTerm
+// pane id in the WezTerm-flavored tests.
+const TERMINAL_ID_ENV_KEYS = [
+	"WEZTERM_PANE",
+	"KITTY_WINDOW_ID",
+	"GHOSTTY_RESOURCES_DIR",
+	"ALACRITTY_WINDOW_ID",
+	"ITERM_SESSION_ID",
+	"VSCODE_PID",
+	"TERM_PROGRAM",
+] as const;
+
+describe("issue #1682: terminalResetsViewportOnEraseScrollback", () => {
+	it("returns true for WezTerm/kitty/ghostty/alacritty on POSIX (env-id)", () => {
+		expect(terminalResetsViewportOnEraseScrollback({ WEZTERM_PANE: "0" }, "linux")).toBe(true);
+		expect(terminalResetsViewportOnEraseScrollback({ KITTY_WINDOW_ID: "1" }, "linux")).toBe(true);
+		expect(terminalResetsViewportOnEraseScrollback({ GHOSTTY_RESOURCES_DIR: "/x" }, "darwin")).toBe(true);
+		expect(terminalResetsViewportOnEraseScrollback({ ALACRITTY_WINDOW_ID: "abc" }, "linux")).toBe(true);
+	});
+
+	it("returns true when TERM_PROGRAM names one of them", () => {
+		expect(terminalResetsViewportOnEraseScrollback({ TERM_PROGRAM: "WezTerm" }, "darwin")).toBe(true);
+		expect(terminalResetsViewportOnEraseScrollback({ TERM_PROGRAM: "kitty" }, "linux")).toBe(true);
+		expect(terminalResetsViewportOnEraseScrollback({ TERM_PROGRAM: "ghostty" }, "linux")).toBe(true);
+		expect(terminalResetsViewportOnEraseScrollback({ TERM_PROGRAM: "alacritty" }, "linux")).toBe(true);
+	});
+
+	it("returns false on POSIX for unflagged terminals", () => {
+		expect(terminalResetsViewportOnEraseScrollback({}, "linux")).toBe(false);
+		expect(terminalResetsViewportOnEraseScrollback({ TERM_PROGRAM: "Apple_Terminal" }, "darwin")).toBe(false);
+	});
+
+	it("returns false on win32 regardless of env (those four are not the WT/ConPTY case)", () => {
+		expect(terminalResetsViewportOnEraseScrollback({ WEZTERM_PANE: "0" }, "win32")).toBe(false);
+		expect(terminalResetsViewportOnEraseScrollback({ TERM_PROGRAM: "kitty" }, "win32")).toBe(false);
+	});
+});
+
+describe("issue #1682: eager scrollback rebuild must defer on POSIX ED3-resetting terminals", () => {
+	let originalPlatform: NodeJS.Platform;
+	const originalEnv = new Map<(typeof TERMINAL_ID_ENV_KEYS)[number], string | undefined>();
+
+	beforeEach(() => {
+		originalPlatform = process.platform;
+		Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+		originalEnv.clear();
+		for (const key of TERMINAL_ID_ENV_KEYS) {
+			originalEnv.set(key, Bun.env[key]);
+			delete Bun.env[key];
+		}
+	});
+
+	afterEach(() => {
+		Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+		for (const key of TERMINAL_ID_ENV_KEYS) {
+			const prev = originalEnv.get(key);
+			if (prev === undefined) delete Bun.env[key];
+			else Bun.env[key] = prev;
+		}
+	});
+
+	it("WezTerm POSIX: offscreen structural mutation during eager rebuild emits no \\x1b[3J", async () => {
+		Bun.env.WEZTERM_PANE = "0";
+		const term = new VirtualTerminal(100, 24);
+		overrideProbe(term, undefined);
+		const tui = new TUI(term);
+		const list = new LineList(Array.from({ length: 80 }, (_, i) => `init-${i}`));
+		tui.addChild(list);
+		try {
+			tui.start();
+			await settle(term);
+			const writes = capture(term);
+			tui.setEagerNativeScrollbackRebuild(true);
+			list.setLines(Array.from({ length: 20 }, (_, i) => `shrunk-${i}`));
+			tui.requestRender();
+			await settle(term);
+			expect(writes.join("").match(ERASE_SCROLLBACK)).toBeNull();
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("kitty POSIX: same deferral applies", async () => {
+		Bun.env.KITTY_WINDOW_ID = "1";
+		const term = new VirtualTerminal(100, 24);
+		overrideProbe(term, undefined);
+		const tui = new TUI(term);
+		const list = new LineList(Array.from({ length: 80 }, (_, i) => `init-${i}`));
+		tui.addChild(list);
+		try {
+			tui.start();
+			await settle(term);
+			const writes = capture(term);
+			tui.setEagerNativeScrollbackRebuild(true);
+			list.setLines(Array.from({ length: 20 }, (_, i) => `shrunk-${i}`));
+			tui.requestRender();
+			await settle(term);
+			expect(writes.join("").match(ERASE_SCROLLBACK)).toBeNull();
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("control: unflagged POSIX terminal keeps the eager rebuild (still emits \\x1b[3J)", async () => {
+		// Ensures the fix is scoped: terminals that don't reset on ED3 still
+		// benefit from the eager rebuild's clean, duplicate-free history.
+		const term = new VirtualTerminal(100, 24);
+		overrideProbe(term, undefined);
+		const tui = new TUI(term);
+		const list = new LineList(Array.from({ length: 80 }, (_, i) => `init-${i}`));
+		tui.addChild(list);
+		try {
+			tui.start();
+			await settle(term);
+			const writes = capture(term);
+			tui.setEagerNativeScrollbackRebuild(true);
+			list.setLines(Array.from({ length: 20 }, (_, i) => `shrunk-${i}`));
+			tui.requestRender();
+			await settle(term);
+			expect(writes.join("").match(ERASE_SCROLLBACK)).not.toBeNull();
+		} finally {
+			tui.stop();
+		}
+	});
+
+	it("autocomplete/IME opt-in stays user-driven on WezTerm (still rebuilds)", async () => {
+		// `allowUnknownViewportMutationOnNextRender` is set by autocomplete and
+		// IME paths where the user is actively typing — the keystroke has
+		// pinned the terminal to the bottom, so a rebuild is safe. The fix
+		// must not regress that opt-in.
+		Bun.env.WEZTERM_PANE = "0";
+		const term = new VirtualTerminal(100, 24);
+		overrideProbe(term, undefined);
+		const tui = new TUI(term);
+		const list = new LineList(Array.from({ length: 80 }, (_, i) => `init-${i}`));
+		tui.addChild(list);
+		try {
+			tui.start();
+			await settle(term);
+			const writes = capture(term);
+			list.setLines(Array.from({ length: 20 }, (_, i) => `shrunk-${i}`));
+			tui.requestRender(false, { allowUnknownViewportMutation: true });
+			await settle(term);
+			expect(writes.join("").match(ERASE_SCROLLBACK)).not.toBeNull();
+		} finally {
+			tui.stop();
+		}
+	});
+});


### PR DESCRIPTION
## Repro

Headless renderer repro (`packages/tui/test/issue-1682-repro.test.ts`) using the same `TUI` + `VirtualTerminal` shape as `issue-1635-repro.test.ts`: pins `process.platform=linux`, sets `WEZTERM_PANE=0`, overrides `isNativeViewportAtBottom()` to `undefined` (POSIX), enables `setEagerNativeScrollbackRebuild(true)` (what the coding-agent `EventController` does for every streaming event), and triggers an offscreen content shrink (80→20 lines). On `main` the captured writes contain `\x1b[3J`; with the fix they do not. A non-flagged POSIX control still emits `\x1b[3J` (the intentional eager rebuild) — confirming the fix is scoped to the four terminals named in the issue.

```
bun test test/issue-1682-repro.test.ts
```

## Cause

`packages/tui/src/tui.ts` `#doRender`:

```ts
const allowUnknownViewportMutation =
    this.#allowUnknownViewportMutationOnNextRender || this.#eagerNativeScrollbackRebuild;
```

`EventController.#refreshToolRenderMode` flips `setEagerNativeScrollbackRebuild(true)` for the full duration of every streaming event. `#doRender` OR'd that flag into `allowUnknownViewportMutation`, so `#canRebuildNativeScrollbackLive(undefined, true)` returned `true` on POSIX (where the probe is always `undefined`) and every offscreen structural mutation routed to `historyRebuild` → `#emitFullPaint(..., { clearScrollback: !isMultiplexerSession() })` → `\x1b[2J\x1b[H\x1b[3J`. WezTerm/kitty/ghostty/alacritty honor ECMA-48 ED3 by repositioning the viewport to the top of the (now-erased) scrollback, yanking any scrolled-up reader. This is the destructive path #1635 closes for WT and the 15.7.3 POSIX deferral closes for the non-eager path; the eager streaming opt-in is the remaining hole on these terminals.

## Fix

- Add `terminalResetsViewportOnEraseScrollback(env, platform)` in `packages/tui/src/terminal.ts` next to `shouldTrustNativeViewportProbe`. Returns `true` on POSIX when `WEZTERM_PANE`, `KITTY_WINDOW_ID`, `GHOSTTY_RESOURCES_DIR`, `ALACRITTY_WINDOW_ID`, or a matching `TERM_PROGRAM` is set. Pure helper with the same env+platform signature as the existing one.
- In `#doRender`, gate the eager flag's contribution to `allowUnknownViewportMutation` on `!terminalResetsViewportOnEraseScrollback()`. `#allowUnknownViewportMutationOnNextRender` (autocomplete/IME opt-ins where the user is actively typing) is unchanged and still forces a rebuild — the keystroke has already pinned the viewport to the bottom.
- Result: on these four terminals, eager-flag offscreen edits during streaming defer to `viewportRepaint` + dirty mark, and the destructive rebuild lands at the next checkpoint (`refreshNativeScrollbackIfDirty` on prompt submit). Other POSIX terminals keep the eager rebuild's clean, duplicate-free history. Resize and checkpoint replays are unchanged.
- Update the `setEagerNativeScrollbackRebuild` docstring to document the ED3 carve-out.
- Add `packages/tui/test/issue-1682-repro.test.ts`: 4 unit tests on the helper + 4 renderer tests (WezTerm defers, kitty defers, unflagged POSIX still emits `\x1b[3J`, autocomplete opt-in still rebuilds).
- Add an `Unreleased` entry in `packages/tui/CHANGELOG.md`.

## Verification

```
bun test test/issue-1682-repro.test.ts test/issue-1635-repro.test.ts   # 16 pass / 0 fail
bun check                                                              # clean
```

Two pre-existing failures in `packages/tui/test/keys.test.ts` (`matches/parses legacy Alt+letter pairs in enhanced keyboard mixed mode`) reproduce on `main` against the unchanged paths and are unrelated to this diff.

Fixes #1682