### PR TITLE
fix(ai): normalize thinking punctuation artifacts

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Fixed
 
+- Fixed OpenAI-compatible thinking streams from Chinese-origin models normalizing stray ` .` punctuation artifacts across reasoning fields and MiniMax `<think>` tags. ([#1688](https://github.com/can1357/oh-my-pi/issues/1688))
 - Fixed Cursor provider requests failing with `Cannot send empty user message to Cursor API` after tool-result history by selecting the latest user/developer turn instead of assuming the final context message is the active user turn.
 
 ### Fixed

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -339,23 +339,28 @@ function isCompiledGrammarTooLargeStrictError(
 	);
 }
 
-// Some Chinese-origin reasoning models emit a tokenizer/chat-template artifact as
-// a space followed by a period inside thinking streams. Normalize it to normal
-// punctuation while leaving ordinary text deltas untouched.
-function normalizeThinkingSpacePeriodArtifacts(text: string): string {
-	const firstArtifactIndex = text.indexOf(" .");
-	if (firstArtifactIndex < 0) return text;
+const THINKING_SPACE_PERIOD_ARTIFACT_REGEX = / \.(?=\s+[A-Z])/g;
+const THINKING_SPACE_PERIOD_ARTIFACT_AT_START_REGEX = /^ ?\.(?=\s+[A-Z])/;
 
-	let normalized = "";
-	let start = 0;
-	let artifactIndex = firstArtifactIndex;
-	do {
-		normalized += text.slice(start, artifactIndex);
-		normalized += ".";
-		start = artifactIndex + 2;
-		artifactIndex = text.indexOf(" .", start);
-	} while (artifactIndex >= 0);
-	return normalized + text.slice(start);
+function shouldNormalizeThinkingSpacePeriodArtifacts(model: Model<"openai-completions">): boolean {
+	return (
+		model.provider === "deepseek" ||
+		model.provider === "qwen-portal" ||
+		model.provider === "minimax-code" ||
+		model.provider === "minimax-code-cn" ||
+		/deepseek|qwen|qwq|minimax/i.test(model.id)
+	);
+}
+
+// Some Chinese-origin reasoning models emit a tokenizer/chat-template artifact as
+// a space followed by a period between English sentences inside thinking streams.
+function normalizeThinkingSpacePeriodArtifacts(text: string): string {
+	if (!text.includes(" .")) return text;
+	return text.replace(THINKING_SPACE_PERIOD_ARTIFACT_REGEX, ".");
+}
+
+function startsWithThinkingSpacePeriodArtifact(text: string): boolean {
+	return THINKING_SPACE_PERIOD_ARTIFACT_AT_START_REGEX.test(text);
 }
 
 // DeepSeek models leak chat-template special tokens (e.g. `<｜tool_calls_begin｜>`,
@@ -552,6 +557,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 			stream.push({ type: "start", partial: output });
 
 			const parseMiniMaxThinkTags = model.provider === "minimax-code" || model.provider === "minimax-code-cn";
+			const cleanupThinkingSpacePeriodArtifacts = shouldNormalizeThinkingSpacePeriodArtifacts(model);
 			// Some OpenAI-compatible DeepSeek hosts (including NVIDIA NIM and DeepSeek's
 			// native API) leak chat-template tool-call markers in `delta.content` even
 			// though tool calls are also surfaced structurally. Strip the leaked markers
@@ -669,11 +675,14 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 			};
 			const appendThinkingDelta = (thinking: string, signature?: string): void => {
 				if (!thinking) return;
+				if (!cleanupThinkingSpacePeriodArtifacts) {
+					if (!firstTokenTime) firstTokenTime = Date.now();
+					appendThinking(output, stream, thinking, signature);
+					return;
+				}
+
 				if (hasPendingThinkingSpace) {
-					if (
-						pendingThinkingSpaceSignature === signature &&
-						(thinking.startsWith(".") || thinking.startsWith(" ."))
-					) {
+					if (pendingThinkingSpaceSignature === signature && startsWithThinkingSpacePeriodArtifact(thinking)) {
 						hasPendingThinkingSpace = false;
 						pendingThinkingSpaceSignature = undefined;
 					} else {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -339,6 +339,25 @@ function isCompiledGrammarTooLargeStrictError(
 	);
 }
 
+// Some Chinese-origin reasoning models emit a tokenizer/chat-template artifact as
+// a space followed by a period inside thinking streams. Normalize it to normal
+// punctuation while leaving ordinary text deltas untouched.
+function normalizeThinkingSpacePeriodArtifacts(text: string): string {
+	const firstArtifactIndex = text.indexOf(" .");
+	if (firstArtifactIndex < 0) return text;
+
+	let normalized = "";
+	let start = 0;
+	let artifactIndex = firstArtifactIndex;
+	do {
+		normalized += text.slice(start, artifactIndex);
+		normalized += ".";
+		start = artifactIndex + 2;
+		artifactIndex = text.indexOf(" .", start);
+	} while (artifactIndex >= 0);
+	return normalized + text.slice(start);
+}
+
 // DeepSeek models leak chat-template special tokens (e.g. `<｜tool_calls_begin｜>`,
 // `<｜DSML｜tool_calls｜>`) into visible `content` deltas when hosted behind providers
 // (such as NVIDIA NIM) that don't strip them server-side. The structured `tool_calls`
@@ -544,6 +563,8 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 			const pendingToolCallBlocks: ToolCallStreamBlock[] = [];
 			const toolCallBlockByIndex = new Map<number, ToolCallStreamBlock>();
 			let currentBlock: OpenAIStreamBlock | undefined;
+			let hasPendingThinkingSpace = false;
+			let pendingThinkingSpaceSignature: string | undefined;
 			const blockIndex = (block: OpenAIStreamBlock | undefined): number => {
 				if (!block) return Math.max(0, output.content.length - 1);
 				return output.content.indexOf(block);
@@ -570,6 +591,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 			};
 			const finishCurrentBlock = (block: OpenAIStreamBlock | undefined): void => {
 				if (!block) return;
+				if (block.type === "thinking") flushPendingThinkingSpace();
 				const contentIndex = blockIndex(block);
 				if (contentIndex < 0) return;
 				if (block.type === "text") {
@@ -632,6 +654,14 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				});
 			};
 
+			function flushPendingThinkingSpace(): void {
+				if (!hasPendingThinkingSpace) return;
+				const signature = pendingThinkingSpaceSignature;
+				hasPendingThinkingSpace = false;
+				pendingThinkingSpaceSignature = undefined;
+				appendThinking(output, stream, " ", signature);
+			}
+
 			const appendTextDelta = (text: string): void => {
 				if (!text) return;
 				if (!firstTokenTime) firstTokenTime = Date.now();
@@ -639,8 +669,27 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 			};
 			const appendThinkingDelta = (thinking: string, signature?: string): void => {
 				if (!thinking) return;
+				if (hasPendingThinkingSpace) {
+					if (
+						pendingThinkingSpaceSignature === signature &&
+						(thinking.startsWith(".") || thinking.startsWith(" ."))
+					) {
+						hasPendingThinkingSpace = false;
+						pendingThinkingSpaceSignature = undefined;
+					} else {
+						flushPendingThinkingSpace();
+					}
+				}
+
+				let normalized = normalizeThinkingSpacePeriodArtifacts(thinking);
+				if (normalized.endsWith(" ")) {
+					normalized = normalized.slice(0, -1);
+					hasPendingThinkingSpace = true;
+					pendingThinkingSpaceSignature = signature;
+				}
+				if (!normalized) return;
 				if (!firstTokenTime) firstTokenTime = Date.now();
-				appendThinking(output, stream, thinking, signature);
+				appendThinking(output, stream, normalized, signature);
 			};
 
 			let deepseekStripBuffer = "";
@@ -897,6 +946,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 			if (stripDeepseekChatTemplateTokens) {
 				flushDeepseekStripBuffer(true);
 			}
+			flushPendingThinkingSpace();
 
 			if (currentBlock?.type === "toolCall") {
 				finishPendingToolCallBlocks();

--- a/packages/ai/test/issue-1203-repro.test.ts
+++ b/packages/ai/test/issue-1203-repro.test.ts
@@ -77,4 +77,23 @@ describe("issue #1203 - MiniMax Coding Plan CN think tags", () => {
 			{ type: "text", text: "visible answer" },
 		]);
 	});
+	it("normalizes MiniMax thinking punctuation artifacts across tag chunks", async () => {
+		const model = getBundledModel("minimax-code-cn", "MiniMax-M2.5") as Model<"openai-completions">;
+		global.fetch = createMockFetch([
+			minimaxChunk(model, "<think>Plan "),
+			minimaxChunk(model, ". Inspect files . Then answer.</think>"),
+			minimaxChunk(model, "visible answer"),
+			stopChunk(model),
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(model, baseContext(), { apiKey: "test-key" }).result();
+		const thinking = result.content
+			.filter((b): b is { type: "thinking"; thinking: string } => b.type === "thinking")
+			.map(b => b.thinking)
+			.join("");
+
+		expect(thinking).toBe("Plan. Inspect files. Then answer.");
+		expect(thinking).not.toContain(" .");
+	});
 });

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -1239,6 +1239,72 @@ describe("OpenAI-compatible reasoning artifact cleanup", () => {
 		expect(thinking).toBe("I need to analyze the request. First, inspect files. Then decide.");
 		expect(thinking).not.toContain(" .");
 	});
+	it("preserves command and dotfile text in affected reasoning streams", async () => {
+		const model = deepseekCompatModel();
+		global.fetch = createMockFetch([
+			{
+				id: "chatcmpl-reasoning-command",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [
+					{
+						index: 0,
+						delta: { reasoning_content: "Run `source .venv/bin/activate`, then inspect with `ls .`." },
+					},
+				],
+			},
+			{
+				id: "chatcmpl-reasoning-command",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+			},
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(model, baseContext(), { apiKey: "test-key" }).result();
+		const thinking = result.content
+			.filter((b): b is { type: "thinking"; thinking: string } => b.type === "thinking")
+			.map(b => b.thinking)
+			.join("");
+		expect(thinking).toBe("Run `source .venv/bin/activate`, then inspect with `ls .`.");
+	});
+
+	it("leaves non-affected provider reasoning punctuation untouched", async () => {
+		const model: Model<"openai-completions"> = {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+			provider: "openai",
+			id: "gpt-4o-mini",
+			reasoning: true,
+		};
+		global.fetch = createMockFetch([
+			{
+				id: "chatcmpl-reasoning-openai",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: { reasoning_content: "Keep this . Spacing unchanged." } }],
+			},
+			{
+				id: "chatcmpl-reasoning-openai",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+			},
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(model, baseContext(), { apiKey: "test-key" }).result();
+		const thinking = result.content
+			.filter((b): b is { type: "thinking"; thinking: string } => b.type === "thinking")
+			.map(b => b.thinking)
+			.join("");
+		expect(thinking).toBe("Keep this . Spacing unchanged.");
+	});
 });
 
 describe("NVIDIA NIM DeepSeek special-token stripping", () => {

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -1185,6 +1185,62 @@ describe("kimi model detection via detectCompat", () => {
 	});
 });
 
+describe("OpenAI-compatible reasoning artifact cleanup", () => {
+	function deepseekCompatModel(): Model<"openai-completions"> {
+		return {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+			provider: "deepseek",
+			baseUrl: "https://api.deepseek.com",
+			id: "deepseek-chat",
+			reasoning: true,
+		};
+	}
+
+	it("normalizes stray space-period artifacts across reasoning chunks", async () => {
+		const model = deepseekCompatModel();
+		global.fetch = createMockFetch([
+			{
+				id: "chatcmpl-reasoning-artifact",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: { reasoning_content: "I need to analyze the request " } }],
+			},
+			{
+				id: "chatcmpl-reasoning-artifact",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: { reasoning_content: ". First, inspect files . Then decide." } }],
+			},
+			{
+				id: "chatcmpl-reasoning-artifact",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: { content: "Done" } }],
+			},
+			{
+				id: "chatcmpl-reasoning-artifact",
+				object: "chat.completion.chunk",
+				created: 0,
+				model: model.id,
+				choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+			},
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(model, baseContext(), { apiKey: "test-key" }).result();
+		const thinking = result.content
+			.filter((b): b is { type: "thinking"; thinking: string } => b.type === "thinking")
+			.map(b => b.thinking)
+			.join("");
+		expect(thinking).toBe("I need to analyze the request. First, inspect files. Then decide.");
+		expect(thinking).not.toContain(" .");
+	});
+});
+
 describe("NVIDIA NIM DeepSeek special-token stripping", () => {
 	function nvidiaDeepseekModel(): Model<"openai-completions"> {
 		return {

--- a/packages/ai/test/xiaomi-tp-login-integration.test.ts
+++ b/packages/ai/test/xiaomi-tp-login-integration.test.ts
@@ -71,7 +71,7 @@ describe("loginXiaomi with tp- key", () => {
 	it("falls back SGP → AMS → CN during validation", async () => {
 		const seen: string[] = [];
 
-		using _hook = hookFetch((input) => {
+		using _hook = hookFetch(input => {
 			const url = String(input);
 			seen.push(url);
 			if (url.includes(TOKEN_PLAN_HOSTS.sgp) || url.includes(TOKEN_PLAN_HOSTS.ams)) {
@@ -94,7 +94,7 @@ describe("loginXiaomi with tp- key", () => {
 	});
 
 	it("throws when all three token-plan hosts return 401", async () => {
-		using _hook = hookFetch((_input) => {
+		using _hook = hookFetch(_input => {
 			return new Response("Invalid API Key", { status: 401 });
 		});
 
@@ -110,7 +110,7 @@ describe("loginXiaomi with tp- key", () => {
 	it("falls back through timeouts: SGP timeout → AMS timeout → CN success", async () => {
 		const seen: string[] = [];
 
-		using _hook = hookFetch((input) => {
+		using _hook = hookFetch(input => {
 			const url = String(input);
 			seen.push(url);
 			if (url.includes(TOKEN_PLAN_HOSTS.sgp) || url.includes(TOKEN_PLAN_HOSTS.ams)) {
@@ -135,7 +135,7 @@ describe("loginXiaomi with tp- key", () => {
 	it("does NOT hit the standard api.xiaomimimo.com for tp- keys", async () => {
 		const seen: string[] = [];
 
-		using _hook = hookFetch((input) => {
+		using _hook = hookFetch(input => {
 			seen.push(String(input));
 			return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
 		});
@@ -158,7 +158,7 @@ describe("xiaomiModelManagerOptions with tp- key", () => {
 	it("discovers models from SGP first", async () => {
 		const seen: string[] = [];
 
-		using _hook = hookFetch((input) => {
+		using _hook = hookFetch(input => {
 			seen.push(String(input));
 			return new Response(JSON.stringify({ data: [{ id: "mimo-v2.5" }] }), {
 				status: 200,
@@ -178,7 +178,7 @@ describe("xiaomiModelManagerOptions with tp- key", () => {
 	it("falls back SGP → AMS → CN during discovery", async () => {
 		const seen: string[] = [];
 
-		using _hook = hookFetch((input) => {
+		using _hook = hookFetch(input => {
 			const url = String(input);
 			seen.push(url);
 
@@ -217,7 +217,7 @@ describe("xiaomiModelManagerOptions with tp- key", () => {
 	it("does NOT use standard host for tp- key model discovery", async () => {
 		const seen: string[] = [];
 
-		using _hook = hookFetch((input) => {
+		using _hook = hookFetch(input => {
 			seen.push(String(input));
 			return new Response(JSON.stringify({ data: [] }), {
 				status: 200,
@@ -241,7 +241,7 @@ describe("Xiaomi tp- full round-trip", () => {
 		// Phase 1: Login
 		const loginUrls: string[] = [];
 
-		using _hook1 = hookFetch((input) => {
+		using _hook1 = hookFetch(input => {
 			loginUrls.push(String(input));
 			return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
 		});
@@ -262,7 +262,7 @@ describe("Xiaomi tp- full round-trip", () => {
 		// Phase 2: Model discovery with the returned key
 		const discoveryUrls: string[] = [];
 
-		using _hook2 = hookFetch((input) => {
+		using _hook2 = hookFetch(input => {
 			discoveryUrls.push(String(input));
 			return new Response(JSON.stringify({ data: [{ id: "mimo-v2.5" }] }), {
 				status: 200,


### PR DESCRIPTION
## Repro
A mocked OpenAI-compatible `reasoning_content` stream reproduced the issue with chunks containing `request ` followed by `. First`, which previously produced thinking text containing `request . First` (`bun test packages/ai/test/openai-completions-compat.test.ts`).

## Cause
`streamOpenAICompletions` in `packages/ai/src/providers/openai-completions.ts` appended raw thinking deltas from `reasoning_content` / `reasoning` / `reasoning_text` and MiniMax `<think>` tag healing without normalizing the Chinese-model space-period artifact, including when the space and period arrived on separate chunks.

## Fix
- Added thinking-only normalization for stray ` .` artifacts while preserving normal punctuation and visible text deltas.
- Buffered one trailing thinking-space across chunks so split ` ` + `.` artifacts normalize before appending.
- Added regression coverage for OpenAI-compatible reasoning fields and MiniMax think-tag parsing.
- Updated the `packages/ai` changelog.

## Verification
- `bun test packages/ai/test/openai-completions-compat.test.ts packages/ai/test/issue-1203-repro.test.ts` passed (48 tests).
- `bunx biome check packages/ai/src/providers/openai-completions.ts packages/ai/test/openai-completions-compat.test.ts packages/ai/test/issue-1203-repro.test.ts packages/ai/CHANGELOG.md` passed.
- `bun --cwd=packages/ai run check:types` passed.
- Pre-publish gate passed during `gh_push_branch`. Fixes #1688