### PR TITLE
feat(ai): add opt-in cache optimizer

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added opt-in CacheOptimizer prefix-cache block alignment for Anthropic and OpenAI Responses requests with caller-supplied token counters. ([#1699](https://github.com/can1357/oh-my-pi/issues/1699))
+
 ### Fixed
 
 - Fixed Cursor provider requests failing with `Cannot send empty user message to Cursor API` after tool-result history by selecting the latest user/developer turn instead of assuming the final context message is the active user turn.

--- a/packages/ai/src/cache-optimizer.ts
+++ b/packages/ai/src/cache-optimizer.ts
@@ -107,10 +107,12 @@ export function buildCacheAlignmentPadding(args: {
 export function calculateCacheHitRate(usage: {
 	readonly input?: number;
 	readonly cacheRead?: number;
+	readonly cacheWrite?: number;
 }): number | undefined {
 	const input = usage.input ?? 0;
 	const cacheRead = usage.cacheRead ?? 0;
-	const total = input + cacheRead;
+	const cacheWrite = usage.cacheWrite ?? 0;
+	const total = input + cacheRead + cacheWrite;
 	if (total <= 0) return undefined;
 	return cacheRead / total;
 }

--- a/packages/ai/src/cache-optimizer.ts
+++ b/packages/ai/src/cache-optimizer.ts
@@ -23,13 +23,13 @@ export interface CachePrefixSegment {
 /** Counts provider tokens for the complete prefix represented by ordered segments. */
 export type CacheTokenCounter = (segments: readonly CachePrefixSegment[], model: Model<Api>) => number;
 
-/** Opt-in provider prefix-cache alignment controls. */
+/** Prefix-cache alignment controls. Providing a token counter enables alignment unless `enabled` is false. */
 export interface CacheOptimizerOptions {
-	/** Enables block-boundary padding when a token counter is supplied. */
+	/** Disable block-boundary padding while preserving the rest of the option object. Default: true. */
 	readonly enabled?: boolean;
 	/** Provider/model tokenizer callback for the cumulative prefix being aligned. */
 	readonly countTokens?: CacheTokenCounter;
-	/** Override provider block size; defaults to Anthropic 128 or OpenAI Responses 64. */
+	/** Override provider block size; defaults to 128-token Anthropic and OpenAI Responses cache increments. */
 	readonly blockSize?: number;
 	/** Semantically inert text appended to the block being aligned. Defaults to a newline. */
 	readonly paddingText?: string;
@@ -55,7 +55,7 @@ function buildCacheOptimizerPlan(
 	options: CacheOptimizerOptions | undefined,
 	defaultBlockSize: number | undefined,
 ): CacheOptimizerPlan | undefined {
-	if (!options?.enabled || !options.countTokens) return undefined;
+	if (options?.enabled === false || !options?.countTokens) return undefined;
 	const resolvedBlockSize = options.blockSize ?? defaultBlockSize;
 	if (resolvedBlockSize === undefined || !Number.isSafeInteger(resolvedBlockSize) || resolvedBlockSize <= 1) {
 		return undefined;

--- a/packages/ai/src/cache-optimizer.ts
+++ b/packages/ai/src/cache-optimizer.ts
@@ -1,0 +1,109 @@
+import type { Api, Model } from "./types";
+
+/** Provider cache block sizes used when callers do not override alignment. */
+export const CACHE_OPTIMIZER_BLOCK_TOKENS = {
+	anthropic: 128,
+	openaiResponses: 64,
+} as const;
+
+/** A stable-prefix fragment as seen by provider-specific cache alignment. */
+export interface CachePrefixSegment {
+	readonly kind: "tool" | "system" | "message";
+	readonly role?: string;
+	readonly text: string;
+}
+
+/** Counts provider tokens for the complete prefix represented by ordered segments. */
+export type CacheTokenCounter = (segments: readonly CachePrefixSegment[], model: Model<Api>) => number;
+
+/** Opt-in provider prefix-cache alignment controls. */
+export interface CacheOptimizerOptions {
+	/** Enables block-boundary padding when a token counter is supplied. */
+	readonly enabled?: boolean;
+	/** Provider/model tokenizer callback for the cumulative prefix being aligned. */
+	readonly countTokens?: CacheTokenCounter;
+	/** Override provider block size; defaults to Anthropic 128 or OpenAI Responses 64. */
+	readonly blockSize?: number;
+	/** Semantically inert text appended to the block being aligned. Defaults to a newline. */
+	readonly paddingText?: string;
+	/** Maximum token increase allowed per aligned breakpoint. Defaults to one block minus one token. */
+	readonly maxPaddingTokens?: number;
+}
+
+interface CacheOptimizerPlan {
+	readonly countTokens: CacheTokenCounter;
+	readonly blockSize: number;
+	readonly paddingText: string;
+	readonly maxPaddingTokens: number;
+}
+
+/** Returns the provider default cache block size for a model. */
+export function getCacheOptimizerBlockSize(model: Model<Api>): number | undefined {
+	if (model.api === "anthropic-messages") return CACHE_OPTIMIZER_BLOCK_TOKENS.anthropic;
+	if (model.api === "openai-responses") return CACHE_OPTIMIZER_BLOCK_TOKENS.openaiResponses;
+	return undefined;
+}
+
+function buildCacheOptimizerPlan(
+	options: CacheOptimizerOptions | undefined,
+	defaultBlockSize: number | undefined,
+): CacheOptimizerPlan | undefined {
+	if (!options?.enabled || !options.countTokens) return undefined;
+	const resolvedBlockSize = options.blockSize ?? defaultBlockSize;
+	if (resolvedBlockSize === undefined || !Number.isSafeInteger(resolvedBlockSize) || resolvedBlockSize <= 1) {
+		return undefined;
+	}
+	const paddingText = options.paddingText ?? "\n";
+	if (paddingText.length === 0) return undefined;
+	const maxPaddingTokens = options.maxPaddingTokens ?? resolvedBlockSize - 1;
+	if (!Number.isSafeInteger(maxPaddingTokens) || maxPaddingTokens <= 0) return undefined;
+	return { countTokens: options.countTokens, blockSize: resolvedBlockSize, paddingText, maxPaddingTokens };
+}
+
+function withSegmentText(
+	segments: readonly CachePrefixSegment[],
+	segmentIndex: number,
+	text: string,
+): CachePrefixSegment[] {
+	return segments.map((segment, index) => (index === segmentIndex ? { ...segment, text } : segment));
+}
+
+/**
+ * Pads one mutable prefix segment until the cumulative provider token count lands
+ * exactly on a cache block boundary. Returns the appended padding, if any.
+ */
+export function buildCacheAlignmentPadding(args: {
+	readonly options: CacheOptimizerOptions | undefined;
+	readonly model: Model<Api>;
+	readonly segments: readonly CachePrefixSegment[];
+	readonly segmentIndex: number;
+}): string {
+	const plan = buildCacheOptimizerPlan(args.options, getCacheOptimizerBlockSize(args.model));
+	if (!plan) return "";
+	const segment = args.segments[args.segmentIndex];
+	if (!segment) return "";
+	const initialTokens = plan.countTokens(args.segments, args.model);
+	if (!Number.isFinite(initialTokens) || initialTokens <= 0 || initialTokens % plan.blockSize === 0) return "";
+	let padding = "";
+	for (let appendedUnits = 0; appendedUnits < plan.maxPaddingTokens; appendedUnits++) {
+		padding += plan.paddingText;
+		const candidateSegments = withSegmentText(args.segments, args.segmentIndex, segment.text + padding);
+		const candidateTokens = plan.countTokens(candidateSegments, args.model);
+		if (!Number.isFinite(candidateTokens) || candidateTokens <= initialTokens) continue;
+		if (candidateTokens - initialTokens > plan.maxPaddingTokens) return "";
+		if (candidateTokens % plan.blockSize === 0) return padding;
+	}
+	return "";
+}
+
+/** Computes cache hit-rate from normalized provider usage counters. */
+export function calculateCacheHitRate(usage: {
+	readonly input?: number;
+	readonly cacheRead?: number;
+}): number | undefined {
+	const input = usage.input ?? 0;
+	const cacheRead = usage.cacheRead ?? 0;
+	const total = input + cacheRead;
+	if (total <= 0) return undefined;
+	return cacheRead / total;
+}

--- a/packages/ai/src/cache-optimizer.ts
+++ b/packages/ai/src/cache-optimizer.ts
@@ -1,9 +1,16 @@
 import type { Api, Model } from "./types";
 
-/** Provider cache block sizes used when callers do not override alignment. */
+/**
+ * Provider cache block sizes used when callers do not override alignment.
+ *
+ * - `anthropic`: 128-token blocks per Anthropic prompt-caching docs.
+ * - `openaiResponses`: 128-token blocks. OpenAI prompt caching only reuses
+ *   prefixes in 128-token increments after a 1024-token floor — the smaller
+ *   64-token chunk boundary is not a cacheable reuse boundary.
+ */
 export const CACHE_OPTIMIZER_BLOCK_TOKENS = {
 	anthropic: 128,
-	openaiResponses: 64,
+	openaiResponses: 128,
 } as const;
 
 /** A stable-prefix fragment as seen by provider-specific cache alignment. */

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -4,6 +4,7 @@ export * from "./auth-broker";
 export { type AuthGatewayBootOptions, type ModelResolver, startAuthGateway } from "./auth-gateway/server";
 export * from "./auth-gateway/types";
 export * from "./auth-storage";
+export * from "./cache-optimizer";
 export * from "./model-cache";
 export * from "./model-manager";
 export * from "./model-thinking";

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1959,7 +1959,8 @@ function updateAnthropicTextSegment(segments: CachePrefixSegment[], segmentIndex
 	segments[segmentIndex] = { ...segment, text };
 }
 
-function optimizeAnthropicCacheAlignment(
+/** Aligns Anthropic cache breakpoints against the complete cumulative wire prefix. */
+export function optimizeAnthropicCacheAlignment(
 	params: MessageCreateParamsStreaming,
 	model: Model<"anthropic-messages">,
 	options?: AnthropicOptions,
@@ -1999,14 +2000,24 @@ function optimizeAnthropicCacheAlignment(
 		const blocks = message.content as Array<ContentBlockParam & CacheControlBlock>;
 		for (let index = 0; index < blocks.length; index++) {
 			const block = blocks[index];
-			if (block?.type !== "text") continue;
-			const segmentIndex = pushAnthropicTextSegment(segments, "message", block.text, message.role);
-			if (!block.cache_control) continue;
-			const padding = buildCacheAlignmentPadding({ options: cacheOptimizer, model, segments, segmentIndex });
-			if (!padding) continue;
-			const text = block.text + padding;
-			blocks[index] = { ...block, text };
-			updateAnthropicTextSegment(segments, segmentIndex, text);
+			if (!block) continue;
+			if (block.type === "text") {
+				const segmentIndex = pushAnthropicTextSegment(segments, "message", block.text, message.role);
+				if (!block.cache_control) continue;
+				const padding = buildCacheAlignmentPadding({ options: cacheOptimizer, model, segments, segmentIndex });
+				if (!padding) continue;
+				const text = block.text + padding;
+				blocks[index] = { ...block, text };
+				updateAnthropicTextSegment(segments, segmentIndex, text);
+				continue;
+			}
+			// Non-text blocks (image, tool_use, tool_result, document, …) are part of
+			// Anthropic's cumulative prefix even though we cannot append padding to
+			// them. Serialize them so the supplied tokenizer sees the same prefix the
+			// provider will hash. cache_control breakpoints are stripped because they
+			// are wire-only annotations, not part of the cached content.
+			const { cache_control: _cacheControl, ...wireBlock } = block;
+			segments.push({ kind: "message", role: message.role, text: JSON.stringify(wireBlock) });
 		}
 	}
 }

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1966,7 +1966,7 @@ export function optimizeAnthropicCacheAlignment(
 	options?: AnthropicOptions,
 ): void {
 	const cacheOptimizer = options?.cacheOptimizer;
-	if (!cacheOptimizer?.enabled) return;
+	if (!cacheOptimizer || cacheOptimizer.enabled === false) return;
 	const segments: CachePrefixSegment[] = [];
 
 	if (params.tools) {

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -21,6 +21,7 @@ import {
 	logger,
 	readSseEvents,
 } from "@oh-my-pi/pi-utils";
+import { buildCacheAlignmentPadding, type CachePrefixSegment } from "../cache-optimizer";
 import {
 	disablesParallelToolUse,
 	hasOpus47ApiRestrictions,
@@ -1941,6 +1942,75 @@ function applyPromptCaching(params: MessageCreateParamsStreaming, cacheControl?:
 	}
 }
 
+function pushAnthropicTextSegment(
+	segments: CachePrefixSegment[],
+	kind: CachePrefixSegment["kind"],
+	text: string,
+	role?: string,
+): number {
+	const segment: CachePrefixSegment = role ? { kind, role, text } : { kind, text };
+	segments.push(segment);
+	return segments.length - 1;
+}
+
+function updateAnthropicTextSegment(segments: CachePrefixSegment[], segmentIndex: number, text: string): void {
+	const segment = segments[segmentIndex];
+	if (!segment) return;
+	segments[segmentIndex] = { ...segment, text };
+}
+
+function optimizeAnthropicCacheAlignment(
+	params: MessageCreateParamsStreaming,
+	model: Model<"anthropic-messages">,
+	options?: AnthropicOptions,
+): void {
+	const cacheOptimizer = options?.cacheOptimizer;
+	if (!cacheOptimizer?.enabled) return;
+	const segments: CachePrefixSegment[] = [];
+
+	if (params.tools) {
+		for (const tool of params.tools as Array<Anthropic.Messages.Tool & CacheControlBlock>) {
+			const { cache_control: _cacheControl, ...promptTool } = tool;
+			segments.push({ kind: "tool", text: JSON.stringify(promptTool) });
+		}
+	}
+
+	if (params.system && Array.isArray(params.system)) {
+		const systemBlocks = params.system as Array<AnthropicSystemBlock & CacheControlBlock>;
+		for (let index = 0; index < systemBlocks.length; index++) {
+			const block = systemBlocks[index];
+			if (block?.type !== "text") continue;
+			const segmentIndex = pushAnthropicTextSegment(segments, "system", block.text);
+			if (!block.cache_control) continue;
+			const padding = buildCacheAlignmentPadding({ options: cacheOptimizer, model, segments, segmentIndex });
+			if (!padding) continue;
+			const text = block.text + padding;
+			systemBlocks[index] = { ...block, text };
+			updateAnthropicTextSegment(segments, segmentIndex, text);
+		}
+	}
+
+	for (const message of params.messages) {
+		if (typeof message.content === "string") {
+			pushAnthropicTextSegment(segments, "message", message.content, message.role);
+			continue;
+		}
+		if (!Array.isArray(message.content)) continue;
+		const blocks = message.content as Array<ContentBlockParam & CacheControlBlock>;
+		for (let index = 0; index < blocks.length; index++) {
+			const block = blocks[index];
+			if (block?.type !== "text") continue;
+			const segmentIndex = pushAnthropicTextSegment(segments, "message", block.text, message.role);
+			if (!block.cache_control) continue;
+			const padding = buildCacheAlignmentPadding({ options: cacheOptimizer, model, segments, segmentIndex });
+			if (!padding) continue;
+			const text = block.text + padding;
+			blocks[index] = { ...block, text };
+			updateAnthropicTextSegment(segments, segmentIndex, text);
+		}
+	}
+}
+
 function normalizeCacheControlBlockTtl(block: CacheControlBlock, seenFiveMinute: { value: boolean }): void {
 	const cacheControl = block.cache_control;
 	if (!cacheControl) return;
@@ -2220,6 +2290,7 @@ function buildParams(
 	disableThinkingIfToolChoiceForced(params);
 	ensureMaxTokensForThinking(params, model);
 	applyPromptCaching(params, cacheControl);
+	optimizeAnthropicCacheAlignment(params, model, options);
 	enforceCacheControlLimit(params, 4);
 	normalizeCacheControlTtlOrdering(params);
 

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -2301,8 +2301,10 @@ function buildParams(
 	disableThinkingIfToolChoiceForced(params);
 	ensureMaxTokensForThinking(params, model);
 	applyPromptCaching(params, cacheControl);
-	optimizeAnthropicCacheAlignment(params, model, options);
+	// Strip excess breakpoints before the optimizer pads, so it never appends
+	// alignment text to blocks whose cache_control is about to be removed.
 	enforceCacheControlLimit(params, 4);
+	optimizeAnthropicCacheAlignment(params, model, options);
 	normalizeCacheControlTtlOrdering(params);
 
 	return params;

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -119,7 +119,7 @@ function optimizeOpenAIResponsesCacheAlignment(
 ): string | undefined {
 	const cacheOptimizer = options?.cacheOptimizer;
 	const effectiveCacheKey = promptCacheKey ?? resolveOpenAIResponsesExtraBodyCacheKey(options);
-	if (!cacheOptimizer?.enabled || !effectiveCacheKey) return systemInstructions;
+	if (!cacheOptimizer || cacheOptimizer.enabled === false || !effectiveCacheKey) return systemInstructions;
 	const segments: CachePrefixSegment[] = [];
 	if (systemInstructions) {
 		const segmentIndex = segments.length;

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -105,6 +105,11 @@ function updateOpenAIResponsesSegment(segments: CachePrefixSegment[], segmentInd
 	segments[segmentIndex] = { ...segment, text };
 }
 
+function resolveOpenAIResponsesExtraBodyCacheKey(options: OpenAIResponsesOptions | undefined): string | undefined {
+	const candidate = options?.extraBody?.prompt_cache_key;
+	return typeof candidate === "string" && candidate.length > 0 ? candidate : undefined;
+}
+
 function optimizeOpenAIResponsesCacheAlignment(
 	model: Model<"openai-responses">,
 	messages: ResponseInput,
@@ -113,7 +118,8 @@ function optimizeOpenAIResponsesCacheAlignment(
 	promptCacheKey: string | undefined,
 ): string | undefined {
 	const cacheOptimizer = options?.cacheOptimizer;
-	if (!cacheOptimizer?.enabled || !promptCacheKey) return systemInstructions;
+	const effectiveCacheKey = promptCacheKey ?? resolveOpenAIResponsesExtraBodyCacheKey(options);
+	if (!cacheOptimizer?.enabled || !effectiveCacheKey) return systemInstructions;
 	const segments: CachePrefixSegment[] = [];
 	if (systemInstructions) {
 		const segmentIndex = segments.length;

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -5,6 +5,7 @@ import type {
 	ResponseCreateParamsStreaming,
 	ResponseInput,
 } from "openai/resources/responses/responses";
+import { buildCacheAlignmentPadding, type CachePrefixSegment } from "../cache-optimizer";
 import { getEnvApiKey } from "../stream";
 import type {
 	AssistantMessage,
@@ -85,6 +86,59 @@ export function normalizeOpenAIResponsesPromptCacheKey(sessionId: string | undef
 	const wellFormed = sessionId.toWellFormed();
 	if (wellFormed.length <= 64) return wellFormed;
 	return `pc_${Bun.hash(wellFormed).toString(36)}`;
+}
+function isResponseItemWithStringContent(
+	item: ResponseInput[number],
+): item is ResponseInput[number] & { role: string; content: string } {
+	return (
+		typeof item === "object" &&
+		item !== null &&
+		"role" in item &&
+		"content" in item &&
+		typeof item.content === "string"
+	);
+}
+
+function updateOpenAIResponsesSegment(segments: CachePrefixSegment[], segmentIndex: number, text: string): void {
+	const segment = segments[segmentIndex];
+	if (!segment) return;
+	segments[segmentIndex] = { ...segment, text };
+}
+
+function optimizeOpenAIResponsesCacheAlignment(
+	model: Model<"openai-responses">,
+	messages: ResponseInput,
+	systemInstructions: string | undefined,
+	options: OpenAIResponsesOptions | undefined,
+	promptCacheKey: string | undefined,
+): string | undefined {
+	const cacheOptimizer = options?.cacheOptimizer;
+	if (!cacheOptimizer?.enabled || !promptCacheKey) return systemInstructions;
+	const segments: CachePrefixSegment[] = [];
+	if (systemInstructions) {
+		const segmentIndex = segments.length;
+		segments.push({ kind: "system", text: systemInstructions });
+		const padding = buildCacheAlignmentPadding({ options: cacheOptimizer, model, segments, segmentIndex });
+		if (!padding) return systemInstructions;
+		return systemInstructions + padding;
+	}
+
+	for (let index = 0; index < messages.length; index++) {
+		const item = messages[index];
+		if (!isResponseItemWithStringContent(item)) continue;
+		const segmentIndex = segments.length;
+		segments.push({ kind: "message", role: item.role, text: item.content });
+		if (item.role !== "developer") continue;
+		const nextItem = messages[index + 1];
+		if (nextItem && isResponseItemWithStringContent(nextItem) && nextItem.role === "developer") continue;
+		const padding = buildCacheAlignmentPadding({ options: cacheOptimizer, model, segments, segmentIndex });
+		if (!padding) continue;
+		const content = item.content + padding;
+		item.content = content;
+		updateOpenAIResponsesSegment(segments, segmentIndex, content);
+	}
+
+	return systemInstructions;
 }
 
 // OpenAI Responses-specific options
@@ -452,6 +506,13 @@ function buildParams(
 
 	const cacheRetention = resolveCacheRetention(options?.cacheRetention);
 	const promptCacheKey = getOpenAIResponsesPromptCacheKey(options);
+	systemInstructions = optimizeOpenAIResponsesCacheAlignment(
+		model,
+		messages,
+		systemInstructions,
+		options,
+		promptCacheKey,
+	);
 	const params: OpenAIResponsesSamplingParams = {
 		model: model.id,
 		input: messages,

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -303,7 +303,7 @@ export interface StreamOptions {
 	 */
 	onAuthError?: (provider: string, apiKey: string, error: unknown) => Promise<string | undefined>;
 	cacheRetention?: CacheRetention;
-	/** Opt-in prefix-cache block alignment. Requires a provider/model token counter. */
+	/** Per-request prefix-cache alignment setting. Providing a token counter enables it by default. */
 	cacheOptimizer?: CacheOptimizerOptions;
 	/**
 	 * Additional headers to include in provider requests.

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -1,4 +1,5 @@
 import type { ZodType, z } from "zod/v4";
+import type { CacheOptimizerOptions } from "./cache-optimizer";
 import type { BedrockOptions } from "./providers/amazon-bedrock";
 import type { AnthropicOptions } from "./providers/anthropic";
 import type { AzureOpenAIResponsesOptions } from "./providers/azure-openai-responses";
@@ -302,6 +303,8 @@ export interface StreamOptions {
 	 */
 	onAuthError?: (provider: string, apiKey: string, error: unknown) => Promise<string | undefined>;
 	cacheRetention?: CacheRetention;
+	/** Opt-in prefix-cache block alignment. Requires a provider/model token counter. */
+	cacheOptimizer?: CacheOptimizerOptions;
 	/**
 	 * Additional headers to include in provider requests.
 	 * These are merged on top of model-defined headers.

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as tls from "node:tls";
+import type { MessageCreateParamsStreaming } from "@anthropic-ai/sdk/resources/messages";
 import { Effort } from "@oh-my-pi/pi-ai";
 import type { CacheOptimizerOptions } from "@oh-my-pi/pi-ai/cache-optimizer";
 import {
@@ -15,6 +16,7 @@ import {
 	isClaudeCloakingUserId,
 	mapStainlessArch,
 	mapStainlessOs,
+	optimizeAnthropicCacheAlignment,
 	streamAnthropic,
 	stripClaudeToolPrefix,
 } from "@oh-my-pi/pi-ai/providers/anthropic";
@@ -173,6 +175,49 @@ describe("Anthropic request fingerprint alignment", () => {
 		)) as { system?: Array<{ type: string; text?: string; cache_control?: unknown }> };
 
 		expect(payload.system).toEqual([{ type: "text", text: "stable..", cache_control: { type: "ephemeral" } }]);
+	});
+
+	it("passes non-text Anthropic blocks to the tokenizer before padding cached text breakpoints", () => {
+		const countedPrefixes: string[][] = [];
+		const params: MessageCreateParamsStreaming = {
+			model: ANTHROPIC_MODEL.id,
+			max_tokens: 1024,
+			stream: true,
+			messages: [
+				{
+					role: "user",
+					content: [
+						{
+							type: "image",
+							source: { type: "base64", media_type: "image/png", data: "AAAAAAAA" },
+						},
+						{
+							type: "text",
+							text: "describe",
+							cache_control: { type: "ephemeral" },
+						},
+					],
+				},
+			],
+		};
+
+		optimizeAnthropicCacheAlignment(params, ANTHROPIC_MODEL, {
+			cacheOptimizer: {
+				enabled: true,
+				blockSize: 64,
+				paddingText: ".",
+				countTokens: segments => {
+					countedPrefixes.push(segments.map(segment => segment.text));
+					return countCacheOptimizerCharacters(segments);
+				},
+			},
+		});
+
+		expect(
+			countedPrefixes.some(
+				prefix => prefix.some(segment => segment.includes('"type":"image"')) && prefix.includes("describe"),
+			),
+		).toBe(true);
 	});
 
 	it("uses Bearer auth for non-Anthropic API bases with api-key credentials", () => {

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -166,7 +166,6 @@ describe("Anthropic request fingerprint alignment", () => {
 			{
 				isOAuth: false,
 				cacheOptimizer: {
-					enabled: true,
 					blockSize: 8,
 					paddingText: ".",
 					countTokens: countCacheOptimizerCharacters,
@@ -203,7 +202,6 @@ describe("Anthropic request fingerprint alignment", () => {
 
 		optimizeAnthropicCacheAlignment(params, ANTHROPIC_MODEL, {
 			cacheOptimizer: {
-				enabled: true,
 				blockSize: 64,
 				paddingText: ".",
 				countTokens: segments => {

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as tls from "node:tls";
 import { Effort } from "@oh-my-pi/pi-ai";
+import type { CacheOptimizerOptions } from "@oh-my-pi/pi-ai/cache-optimizer";
 import {
 	applyClaudeToolPrefix,
 	buildAnthropicClientOptions,
@@ -59,6 +60,7 @@ type CaptureAnthropicOptions = {
 	topK?: number;
 	taskBudget?: TokenTaskBudget;
 	toolChoice?: "auto" | "any" | "none" | { type: "tool"; name: string };
+	cacheOptimizer?: CacheOptimizerOptions;
 };
 
 function captureAnthropicPayload(
@@ -80,8 +82,13 @@ function captureAnthropicPayload(
 		taskBudget: options?.taskBudget,
 		toolChoice: options?.toolChoice,
 		onPayload: payload => resolve(payload),
+		cacheOptimizer: options?.cacheOptimizer,
 	});
 	return promise;
+}
+
+function countCacheOptimizerCharacters(segments: readonly { readonly text: string }[]): number {
+	return segments.reduce((total, segment) => total + segment.text.length, 0);
 }
 
 describe("Anthropic request fingerprint alignment", () => {
@@ -145,6 +152,27 @@ describe("Anthropic request fingerprint alignment", () => {
 			{ type: "text", text: "stable system" },
 			{ type: "text", text: "stable durable context", cache_control: { type: "ephemeral" } },
 		]);
+	});
+
+	it("pads Anthropic cached system prefixes when CacheOptimizer is enabled", async () => {
+		const payload = (await captureAnthropicPayload(
+			ANTHROPIC_MODEL,
+			{
+				systemPrompt: ["stable"],
+				messages: [{ role: "user", content: "variable context", timestamp: Date.now() }],
+			},
+			{
+				isOAuth: false,
+				cacheOptimizer: {
+					enabled: true,
+					blockSize: 8,
+					paddingText: ".",
+					countTokens: countCacheOptimizerCharacters,
+				},
+			},
+		)) as { system?: Array<{ type: string; text?: string; cache_control?: unknown }> };
+
+		expect(payload.system).toEqual([{ type: "text", text: "stable..", cache_control: { type: "ephemeral" } }]);
 	});
 
 	it("uses Bearer auth for non-Anthropic API bases with api-key credentials", () => {

--- a/packages/ai/test/cache-optimizer.test.ts
+++ b/packages/ai/test/cache-optimizer.test.ts
@@ -59,8 +59,10 @@ describe("CacheOptimizer", () => {
 		expect(padding).toBe("");
 	});
 
-	it("computes cache hit rate from normalized usage counters", () => {
+	it("computes cache hit rate from all normalized prompt usage counters", () => {
 		expect(calculateCacheHitRate({ input: 25, cacheRead: 75 })).toBe(0.75);
-		expect(calculateCacheHitRate({ input: 0, cacheRead: 0 })).toBeUndefined();
+		expect(calculateCacheHitRate({ cacheRead: 50, cacheWrite: 50 })).toBe(0.5);
+		expect(calculateCacheHitRate({ cacheWrite: 50 })).toBe(0);
+		expect(calculateCacheHitRate({ input: 0, cacheRead: 0, cacheWrite: 0 })).toBeUndefined();
 	});
 });

--- a/packages/ai/test/cache-optimizer.test.ts
+++ b/packages/ai/test/cache-optimizer.test.ts
@@ -27,10 +27,23 @@ describe("CacheOptimizer", () => {
 			model,
 			segments,
 			segmentIndex: 0,
-			options: { enabled: true, blockSize: 8, paddingText: ".", countTokens: countCharacters },
+			options: { blockSize: 8, paddingText: ".", countTokens: countCharacters },
 		});
 
 		expect(padding).toBe("..");
+	});
+
+	it("does not pad when explicitly disabled", () => {
+		const segments: CachePrefixSegment[] = [{ kind: "system", text: "stable" }];
+
+		const padding = buildCacheAlignmentPadding({
+			model,
+			segments,
+			segmentIndex: 0,
+			options: { enabled: false, blockSize: 8, paddingText: ".", countTokens: countCharacters },
+		});
+
+		expect(padding).toBe("");
 	});
 
 	it("does not pad without an explicit tokenizer", () => {

--- a/packages/ai/test/cache-optimizer.test.ts
+++ b/packages/ai/test/cache-optimizer.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import { buildCacheAlignmentPadding, type CachePrefixSegment, calculateCacheHitRate } from "../src/cache-optimizer";
+import type { Model } from "../src/types";
+
+const model: Model<"openai-responses"> = {
+	id: "gpt-test",
+	name: "GPT Test",
+	api: "openai-responses",
+	provider: "openai",
+	input: ["text"],
+	baseUrl: "https://api.openai.com/v1",
+	reasoning: false,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128_000,
+	maxTokens: 4_096,
+};
+
+function countCharacters(segments: readonly CachePrefixSegment[]): number {
+	return segments.reduce((total, segment) => total + segment.text.length, 0);
+}
+
+describe("CacheOptimizer", () => {
+	it("pads a prefix segment to the next provider cache block boundary", () => {
+		const segments: CachePrefixSegment[] = [{ kind: "system", text: "stable" }];
+
+		const padding = buildCacheAlignmentPadding({
+			model,
+			segments,
+			segmentIndex: 0,
+			options: { enabled: true, blockSize: 8, paddingText: ".", countTokens: countCharacters },
+		});
+
+		expect(padding).toBe("..");
+	});
+
+	it("does not pad without an explicit tokenizer", () => {
+		const segments: CachePrefixSegment[] = [{ kind: "system", text: "stable" }];
+
+		const padding = buildCacheAlignmentPadding({
+			model,
+			segments,
+			segmentIndex: 0,
+			options: { enabled: true, blockSize: 8, paddingText: "." },
+		});
+
+		expect(padding).toBe("");
+	});
+
+	it("computes cache hit rate from normalized usage counters", () => {
+		expect(calculateCacheHitRate({ input: 25, cacheRead: 75 })).toBe(0.75);
+		expect(calculateCacheHitRate({ input: 0, cacheRead: 0 })).toBeUndefined();
+	});
+});

--- a/packages/ai/test/openai-responses-cache-affinity.test.ts
+++ b/packages/ai/test/openai-responses-cache-affinity.test.ts
@@ -144,7 +144,6 @@ describe("openai-responses cache affinity", () => {
 		const captured = await captureOpenAIResponseHeaders({
 			sessionId: "session-123",
 			cacheOptimizer: {
-				enabled: true,
 				blockSize: 8,
 				paddingText: ".",
 				countTokens: countCacheOptimizerCharacters,
@@ -163,7 +162,6 @@ describe("openai-responses cache affinity", () => {
 		const captured = await captureOpenAIResponseHeaders({
 			extraBody: { prompt_cache_key: "adapter-cache-key" },
 			cacheOptimizer: {
-				enabled: true,
 				blockSize: 8,
 				paddingText: ".",
 				countTokens: countCacheOptimizerCharacters,

--- a/packages/ai/test/openai-responses-cache-affinity.test.ts
+++ b/packages/ai/test/openai-responses-cache-affinity.test.ts
@@ -158,4 +158,24 @@ describe("openai-responses cache affinity", () => {
 
 		expect(paddedDeveloper?.content).toBe("stable durable context.....");
 	});
+
+	it("aligns prefixes when prompt cache key arrives via extraBody and sessionId is absent", async () => {
+		const captured = await captureOpenAIResponseHeaders({
+			extraBody: { prompt_cache_key: "adapter-cache-key" },
+			cacheOptimizer: {
+				enabled: true,
+				blockSize: 8,
+				paddingText: ".",
+				countTokens: countCacheOptimizerCharacters,
+			},
+		});
+		const input = captured.body?.input as Array<{ role?: string; content?: unknown }> | undefined;
+		const paddedDeveloper = input?.find(
+			item =>
+				item.role === "developer" && typeof item.content === "string" && item.content.startsWith("stable durable"),
+		);
+
+		expect(captured.body?.prompt_cache_key).toBe("adapter-cache-key");
+		expect(paddedDeveloper?.content).toBe("stable durable context.....");
+	});
 });

--- a/packages/ai/test/openai-responses-cache-affinity.test.ts
+++ b/packages/ai/test/openai-responses-cache-affinity.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { CachePrefixSegment } from "../src/cache-optimizer";
 import { getBundledModel } from "../src/models";
 import { type OpenAIResponsesOptions, streamOpenAIResponses } from "../src/providers/openai-responses";
 import type { Context, Model } from "../src/types";
@@ -16,6 +17,10 @@ function createSseResponse(events: unknown[]): Response {
 
 function getHeader(headers: RequestInit["headers"], name: string): string | null {
 	return new Headers(headers).get(name);
+}
+
+function countCacheOptimizerCharacters(segments: readonly CachePrefixSegment[]): number {
+	return segments.reduce((total, segment) => total + segment.text.length, 0);
 }
 
 async function captureOpenAIResponseHeaders(
@@ -133,5 +138,24 @@ describe("openai-responses cache affinity", () => {
 		expect(captured.sessionId).toBeNull();
 		expect(captured.clientRequestId).toBeNull();
 		expect(captured.body?.prompt_cache_key).toBeUndefined();
+	});
+
+	it("pads OpenAI Responses developer prefixes when CacheOptimizer is enabled", async () => {
+		const captured = await captureOpenAIResponseHeaders({
+			sessionId: "session-123",
+			cacheOptimizer: {
+				enabled: true,
+				blockSize: 8,
+				paddingText: ".",
+				countTokens: countCacheOptimizerCharacters,
+			},
+		});
+		const input = captured.body?.input as Array<{ role?: string; content?: unknown }> | undefined;
+		const paddedDeveloper = input?.find(
+			item =>
+				item.role === "developer" && typeof item.content === "string" && item.content.startsWith("stable durable"),
+		);
+
+		expect(paddedDeveloper?.content).toBe("stable durable context.....");
 	});
 });


### PR DESCRIPTION
## Repro
The requested scenario is an API caller that wants token-level provider cache block alignment for stable prefixes. Before this change there was no `StreamOptions` surface to supply a model tokenizer or ask Anthropic/OpenAI Responses request builders to pad cache breakpoints; the relevant exercised commands are `bun test packages/ai/test/cache-optimizer.test.ts packages/ai/test/anthropic-alignment.test.ts packages/ai/test/openai-responses-cache-affinity.test.ts` and `bun --cwd=packages/ai run check`.

## Cause
`packages/ai/src/providers/anthropic.ts` only placed cumulative `cache_control` breakpoints, `packages/ai/src/providers/openai-responses.ts` only forwarded `prompt_cache_key`, and `packages/ai/src/types.ts` had no opt-in cache alignment option carrying a provider/model token counter. Existing normalized usage counters could report cache hits, but there was no reusable optimizer module for safe block-boundary padding.

## Fix
- Added `packages/ai/src/cache-optimizer.ts` with provider block-size defaults, `CacheOptimizerOptions`, token-counter driven block-boundary padding, and a normalized cache hit-rate helper.
- Added `StreamOptions.cacheOptimizer` and exported the optimizer from `@oh-my-pi/pi-ai`.
- Wired Anthropic cached system/message text blocks to pad the cumulative prefix after automatic breakpoint placement while preserving the 4-breakpoint enforcement.
- Wired OpenAI Responses to pad top-level instructions or the last contiguous developer system prefix only when prompt caching is active.
- Added contract tests for the optimizer helper and Anthropic/OpenAI Responses payload alignment.

## Verification
Passed: `bun test packages/ai/test/cache-optimizer.test.ts packages/ai/test/anthropic-alignment.test.ts packages/ai/test/openai-responses-cache-affinity.test.ts` (51 pass, 0 fail). Passed: `bun --cwd=packages/ai run check`. Fixes #1699