### PR TITLE
fix(coding-agent): guard custom tool process exits during load

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed custom tool discovery treating `process.exit()` from an imported tool module as a host process exit instead of a recoverable tool load failure ([#1704](https://github.com/can1357/oh-my-pi/issues/1704)).
+
 ## [15.8.0] - 2026-06-02
 
 ### Added

--- a/packages/coding-agent/src/extensibility/custom-tools/loader.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/loader.ts
@@ -18,25 +18,61 @@ import * as typebox from "../typebox";
 import { createNoOpUIContext, resolvePath } from "../utils";
 import type { CustomToolAPI, CustomToolFactory, LoadedCustomTool, ToolLoadError } from "./types";
 
-class CustomToolProcessExitError extends Error {
-	constructor(code: string | number | null | undefined) {
-		const suffix = code == null ? "" : ` with code ${code}`;
-		super(`Custom tool attempted to exit the process during load${suffix}`);
-		this.name = "CustomToolProcessExitError";
-	}
+/**
+ * Depth counter for the surrounding `loadCustomTools` batch. While greater
+ * than zero, any `process.exit()` call is logged and dropped instead of
+ * terminating the host. The batch stays open through every awaited
+ * `loadTool` and through the microtask drain that happens at each `await`
+ * point, so deferred exits scheduled by a tool's import or factory (for
+ * example `void main().catch(() => process.exit(1))`) fire while the guard
+ * is still active.
+ */
+let activeBatchDepth = 0;
+/** Captured reference to the original `process.exit`, set when the guard is first installed. */
+let originalProcessExit: typeof process.exit | null = null;
+
+/**
+ * Install a permanent `process.exit` interceptor on the first custom tool load.
+ *
+ * The interceptor logs and drops any `process.exit` call made while a batch is
+ * open (`activeBatchDepth > 0`). Outside the batch window the call delegates
+ * to the original `process.exit` so omp's own shutdown paths behave normally.
+ *
+ * The guard is intentionally never restored: tool-scheduled microtask work
+ * runs across `await` points inside the batch (Bun's dynamic import body runs
+ * on a separate microtask), and once installed the wrapper costs one extra
+ * function call per exit. It does *not* attempt to catch exits scheduled by
+ * `setTimeout`/`queueMicrotask` that fire after the batch has resolved —
+ * those require process isolation, which is out of scope here.
+ */
+function installExitGuardOnce(): void {
+	if (originalProcessExit !== null) return;
+	const captured = process.exit;
+	originalProcessExit = captured;
+	const guarded: typeof process.exit = code => {
+		if (activeBatchDepth > 0) {
+			logger.error("Custom tool attempted to exit the process during load; call ignored", { code });
+			return undefined as never;
+		}
+		return captured(code);
+	};
+	process.exit = guarded;
 }
 
-async function withProcessExitGuard<T>(operation: () => T | Promise<T>): Promise<T> {
-	const originalExit = process.exit;
-	const interceptedExit: typeof process.exit = code => {
-		throw new CustomToolProcessExitError(code);
-	};
-
-	process.exit = interceptedExit;
+/**
+ * Run a `loadCustomTools` batch under the exit guard. Sync exits from a
+ * tool's import body or factory and async microtask follow-ups scheduled
+ * during the batch are both intercepted while the batch is open, because the
+ * microtask drain at each `await` point happens before the surrounding batch
+ * promise resolves.
+ */
+async function withCustomToolBatch<T>(operation: () => Promise<T>): Promise<T> {
+	installExitGuardOnce();
+	activeBatchDepth++;
 	try {
 		return await operation();
 	} finally {
-		process.exit = originalExit;
+		activeBatchDepth--;
 	}
 }
 
@@ -64,14 +100,14 @@ async function loadTool(
 	}
 
 	try {
-		const module = await withProcessExitGuard(() => import(resolvedPath));
+		const module = await import(resolvedPath);
 		const factory = (module.default ?? module) as CustomToolFactory;
 
 		if (typeof factory !== "function") {
 			return { tools: null, error: { path: toolPath, error: "Tool must export a default function", source } };
 		}
 
-		const toolResult = await withProcessExitGuard(() => factory(sharedApi));
+		const toolResult = await factory(sharedApi);
 		const toolsArray = Array.isArray(toolResult) ? toolResult : [toolResult];
 
 		const loadedTools: LoadedCustomTool[] = toolsArray.map(tool => ({
@@ -200,7 +236,7 @@ export async function loadCustomTools(
 		builtInToolNames,
 		pushPendingAction,
 	);
-	await loader.load(pathsWithSources);
+	await withCustomToolBatch(() => loader.load(pathsWithSources));
 	return {
 		tools: loader.tools,
 		errors: loader.errors,

--- a/packages/coding-agent/src/extensibility/custom-tools/loader.ts
+++ b/packages/coding-agent/src/extensibility/custom-tools/loader.ts
@@ -18,6 +18,28 @@ import * as typebox from "../typebox";
 import { createNoOpUIContext, resolvePath } from "../utils";
 import type { CustomToolAPI, CustomToolFactory, LoadedCustomTool, ToolLoadError } from "./types";
 
+class CustomToolProcessExitError extends Error {
+	constructor(code: string | number | null | undefined) {
+		const suffix = code == null ? "" : ` with code ${code}`;
+		super(`Custom tool attempted to exit the process during load${suffix}`);
+		this.name = "CustomToolProcessExitError";
+	}
+}
+
+async function withProcessExitGuard<T>(operation: () => T | Promise<T>): Promise<T> {
+	const originalExit = process.exit;
+	const interceptedExit: typeof process.exit = code => {
+		throw new CustomToolProcessExitError(code);
+	};
+
+	process.exit = interceptedExit;
+	try {
+		return await operation();
+	} finally {
+		process.exit = originalExit;
+	}
+}
+
 /**
  * Load a single tool module using native Bun import.
  */
@@ -42,14 +64,14 @@ async function loadTool(
 	}
 
 	try {
-		const module = await import(resolvedPath);
+		const module = await withProcessExitGuard(() => import(resolvedPath));
 		const factory = (module.default ?? module) as CustomToolFactory;
 
 		if (typeof factory !== "function") {
 			return { tools: null, error: { path: toolPath, error: "Tool must export a default function", source } };
 		}
 
-		const toolResult = await factory(sharedApi);
+		const toolResult = await withProcessExitGuard(() => factory(sharedApi));
 		const toolsArray = Array.isArray(toolResult) ? toolResult : [toolResult];
 
 		const loadedTools: LoadedCustomTool[] = toolsArray.map(tool => ({

--- a/packages/coding-agent/test/extensibility/custom-tool-loader.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-tool-loader.test.ts
@@ -1,12 +1,14 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { logger } from "@oh-my-pi/pi-utils";
 import { loadCustomTools } from "../../src/extensibility/custom-tools/loader";
 
 let tempRoot: string | undefined;
 
 afterEach(async () => {
+	vi.restoreAllMocks();
 	if (tempRoot) {
 		await fs.rm(tempRoot, { recursive: true, force: true });
 		tempRoot = undefined;
@@ -20,11 +22,17 @@ async function writeTool(name: string, source: string): Promise<string> {
 	return filePath;
 }
 
+function requireTempRoot(): string {
+	if (!tempRoot) throw new Error("Temporary custom tool root was not created.");
+	return tempRoot;
+}
+
 describe("custom tool loader", () => {
-	it("turns process.exit during module import into a load error without stopping later tools", async () => {
-		const originalExit = process.exit;
+	it("survives a tool that calls process.exit synchronously at import time and still loads later valid tools", async () => {
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
 		const exitingTool = await writeTool(
-			"exiting.js",
+			"sync-exit.js",
 			[
 				"function main() {",
 				"\ttry {",
@@ -51,16 +59,67 @@ describe("custom tool loader", () => {
 			].join("\n"),
 		);
 
-		if (!tempRoot) {
-			throw new Error("Temporary custom tool root was not created.");
-		}
+		const result = await loadCustomTools([{ path: exitingTool }, { path: validTool }], requireTempRoot(), []);
 
-		const result = await loadCustomTools([{ path: exitingTool }, { path: validTool }], tempRoot, []);
-
-		expect(process.exit).toBe(originalExit);
 		expect(result.tools.map(tool => tool.tool.name)).toEqual(["safe_custom_tool"]);
 		expect(result.errors).toHaveLength(1);
 		expect(result.errors[0]?.path).toBe(exitingTool);
-		expect(result.errors[0]?.error).toContain("attempted to exit the process during load with code 1");
+
+		const loggedExit = errorSpy.mock.calls.find(
+			call =>
+				typeof call[0] === "string" && call[0].startsWith("Custom tool attempted to exit the process during load"),
+		);
+		expect(loggedExit).toBeDefined();
+		expect(loggedExit?.[1]).toMatchObject({ code: 1 });
+	});
+
+	it("survives a tool that schedules a deferred process.exit via void promise.catch and still registers it", async () => {
+		const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+
+		const signalKey = `__omp1704_async_signal_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		(globalThis as Record<string, unknown>)[signalKey] = resolve;
+
+		try {
+			const asyncTool = await writeTool(
+				"async-exit.js",
+				[
+					`const signal = globalThis[${JSON.stringify(signalKey)}];`,
+					"async function main() { throw new Error('startup failure'); }",
+					"void main().catch(() => {",
+					"\tprocess.exit(7);",
+					"\tsignal('survived');",
+					"});",
+					"export default api => ({",
+					'\tname: "async_exit_tool",',
+					'\tlabel: "Async Exit Tool",',
+					'\tdescription: "Schedules a deferred exit during import",',
+					"\tparameters: api.zod.object({}),",
+					"\tasync execute() {",
+					'\t\treturn { content: [{ type: "text", text: "ok" }] };',
+					"\t},",
+					"});",
+				].join("\n"),
+			);
+
+			const result = await loadCustomTools([{ path: asyncTool }], requireTempRoot(), []);
+
+			// The tool's deferred exit attempt fires after the import promise settles.
+			// If the guard did not intercept it, the test process would die before this resolves.
+			const outcome = await promise;
+			expect(outcome).toBe("survived");
+			expect(result.tools.map(tool => tool.tool.name)).toEqual(["async_exit_tool"]);
+			expect(result.errors).toEqual([]);
+
+			const loggedExit = errorSpy.mock.calls.find(
+				call =>
+					typeof call[0] === "string" &&
+					call[0].startsWith("Custom tool attempted to exit the process during load"),
+			);
+			expect(loggedExit).toBeDefined();
+			expect(loggedExit?.[1]).toMatchObject({ code: 7 });
+		} finally {
+			delete (globalThis as Record<string, unknown>)[signalKey];
+		}
 	});
 });

--- a/packages/coding-agent/test/extensibility/custom-tool-loader.test.ts
+++ b/packages/coding-agent/test/extensibility/custom-tool-loader.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadCustomTools } from "../../src/extensibility/custom-tools/loader";
+
+let tempRoot: string | undefined;
+
+afterEach(async () => {
+	if (tempRoot) {
+		await fs.rm(tempRoot, { recursive: true, force: true });
+		tempRoot = undefined;
+	}
+});
+
+async function writeTool(name: string, source: string): Promise<string> {
+	tempRoot ??= await fs.mkdtemp(path.join(os.tmpdir(), "omp-custom-tool-loader-"));
+	const filePath = path.join(tempRoot, name);
+	await Bun.write(filePath, source);
+	return filePath;
+}
+
+describe("custom tool loader", () => {
+	it("turns process.exit during module import into a load error without stopping later tools", async () => {
+		const originalExit = process.exit;
+		const exitingTool = await writeTool(
+			"exiting.js",
+			[
+				"function main() {",
+				"\ttry {",
+				"\t\tdoWork();",
+				"\t} catch {",
+				"\t\tprocess.exit(1);",
+				"\t}",
+				"}",
+				"main();",
+			].join("\n"),
+		);
+		const validTool = await writeTool(
+			"valid.js",
+			[
+				"export default api => ({",
+				'\tname: "safe_custom_tool",',
+				'\tlabel: "Safe Custom Tool",',
+				'\tdescription: "Returns a fixed response",',
+				"\tparameters: api.zod.object({}),",
+				"\tasync execute() {",
+				'\t\treturn { content: [{ type: "text", text: "ok" }] };',
+				"\t},",
+				"});",
+			].join("\n"),
+		);
+
+		if (!tempRoot) {
+			throw new Error("Temporary custom tool root was not created.");
+		}
+
+		const result = await loadCustomTools([{ path: exitingTool }, { path: validTool }], tempRoot, []);
+
+		expect(process.exit).toBe(originalExit);
+		expect(result.tools.map(tool => tool.tool.name)).toEqual(["safe_custom_tool"]);
+		expect(result.errors).toHaveLength(1);
+		expect(result.errors[0]?.path).toBe(exitingTool);
+		expect(result.errors[0]?.error).toContain("attempted to exit the process during load with code 1");
+	});
+});


### PR DESCRIPTION
## Repro
A project with `.claude/tools/hello.js` that calls `main();` at module top level and reaches `process.exit(1)` during its catch path aborts `omp -p "say hi"` before session startup completes. Reproduced with `bun /data/workspaces/can1357__oh-my-pi__1704/repo/packages/coding-agent/src/cli.ts -p "say hi"` from `/tmp/omp-1704-repro`, which printed `some error` and exited with code 1 before the fix.

## Cause
`packages/coding-agent/src/extensibility/custom-tools/loader.ts` loaded every custom tool with an in-process dynamic import in `loadTool`, then immediately ran the exported factory. Top-level throws were caught by the loader, but `process.exit()` terminated the host process before the `catch` in `loadTool` could convert the failure into a skipped-tool error.

## Fix
- Added a scoped `process.exit` guard around custom tool module import and factory execution so exit attempts become recoverable load errors and the original process exit function is always restored.
- Kept the existing custom tool factory API unchanged, so successfully loaded tools still run in-process with the same `CustomToolAPI` injection.
- Added a regression test covering a CLI-style tool that calls `main()` at import time and exits on failure, while a later valid custom tool still loads.
- Added an Unreleased changelog entry for the coding-agent package.

## Verification
Ran `bun test packages/coding-agent/test/extensibility/custom-tool-loader.test.ts` (1 pass) and `bun --cwd=packages/coding-agent run check` (biome check and `tsgo` passed). Re-ran the repro after the fix; the custom tool printed `some error` but `omp` continued past tool discovery to the model request instead of exiting from `process.exit(1)`. Fixes #1704