### PR TITLE
fix(agent,ai): gate forced tool_choice on per-turn active tools (#1701)

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `Agent.prompt()` forwarding a queued forced `toolChoice` whose target tool is no longer present in `state.tools`. `refreshToolChoiceForActiveTools` now runs on the choice returned by the caller-supplied `getToolChoice` hook (e.g. `AgentSession`'s tool-choice queue), not just `options.toolChoice`, so an MCP-scoped / subagent / restricted-toolset turn cannot send a `tool_choice` naming a function absent from the per-turn tool set ([#1701](https://github.com/can1357/oh-my-pi/issues/1701)).
+- Reverted the previous attempt to run `refreshToolChoiceForActiveTools` on the caller-supplied `getToolChoice` hook result. The hook is now responsible for filtering its own yields against the per-turn active tool set; the agent loop still gates `options?.toolChoice` (callers with no queue lifecycle) so that path remains unchanged. Necessary because filtering at the hook callsite consumed an `AgentSession` queue directive without serving it, which silently advanced `/force`-style sequences and discarded requeue-capable pending-action reminders on later `turn_end` ([#1701](https://github.com/can1357/oh-my-pi/issues/1701)).
 
 ## [15.8.0] - 2026-06-02
 

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `Agent.prompt()` forwarding a queued forced `toolChoice` whose target tool is no longer present in `state.tools`. `refreshToolChoiceForActiveTools` now runs on the choice returned by the caller-supplied `getToolChoice` hook (e.g. `AgentSession`'s tool-choice queue), not just `options.toolChoice`, so an MCP-scoped / subagent / restricted-toolset turn cannot send a `tool_choice` naming a function absent from the per-turn tool set ([#1701](https://github.com/can1357/oh-my-pi/issues/1701)).
+
 ## [15.8.0] - 2026-06-02
 
 ### Fixed

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -914,7 +914,7 @@ export class Agent {
 				: undefined;
 
 		const getToolChoice = () =>
-			this.#getToolChoice?.() ?? refreshToolChoiceForActiveTools(options?.toolChoice, this.#state.tools);
+			refreshToolChoiceForActiveTools(this.#getToolChoice?.() ?? options?.toolChoice, this.#state.tools);
 
 		const config: AgentLoopConfig = {
 			model,

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -913,8 +913,14 @@ export class Agent {
 					}
 				: undefined;
 
+		// The session-driven `#getToolChoice` hook is responsible for filtering its
+		// own yields against the active per-turn tools — running them through
+		// `refreshToolChoiceForActiveTools` here would consume the queued directive
+		// and resolve it on turn_end even though the model never saw the choice
+		// (PR #1707 review). The fallback caller-passed `options?.toolChoice` has
+		// no queue lifecycle, so it stays gated by the refresh.
 		const getToolChoice = () =>
-			refreshToolChoiceForActiveTools(this.#getToolChoice?.() ?? options?.toolChoice, this.#state.tools);
+			this.#getToolChoice?.() ?? refreshToolChoiceForActiveTools(options?.toolChoice, this.#state.tools);
 
 		const config: AgentLoopConfig = {
 			model,

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -198,48 +198,6 @@ describe("Agent", () => {
 		]);
 	});
 
-	it("prompt() drops queued forced toolChoice when its tool is absent from active state.tools", async () => {
-		// Regression for #1701. Eager-todo / `/force <name>` / yield reminders all
-		// push a forced `tool_choice` into AgentSession's toolChoiceQueue, which the
-		// Agent reads via `getToolChoice`. When the per-turn active tool set is a
-		// filtered subset that does not include the forced tool, the queued choice
-		// must be refreshed away — otherwise the wire body names a tool that is not
-		// in `params.tools`, which spec-strict OpenAI-compatible endpoints reject
-		// with a 400 invalid_parameter_error.
-		const toolSchema = z.object({ value: z.string() });
-		type Details = { value: string };
-
-		const betaTool: AgentTool<typeof toolSchema, Details> = {
-			name: "beta",
-			label: "Beta",
-			description: "Beta tool",
-			parameters: toolSchema,
-			async execute(_toolCallId, params) {
-				return { content: [{ type: "text", text: `beta:${params.value}` }], details: { value: params.value } };
-			},
-		};
-
-		const mock = createMockModel({ responses: [{ content: ["done"] }] });
-
-		// Queue a forced choice for a tool that is NOT in state.tools — the
-		// subagent / MCP-scoped scenario the bug describes.
-		const agent = new Agent({
-			initialState: {
-				model: mock.model,
-				tools: [betaTool],
-				messages: [],
-			},
-			streamFn: mock.stream,
-			getToolChoice: () => ({ type: "function", name: "todo_write" }),
-		});
-
-		await agent.prompt("subagent turn");
-
-		expect(mock.calls).toHaveLength(1);
-		expect(mock.calls[0]?.options?.toolChoice).toBeUndefined();
-		expect((mock.calls[0]?.context.tools ?? []).map(tool => tool.name)).toEqual(["beta"]);
-	});
-
 	it("re-reads thinking level for each model call within a run", async () => {
 		const toolSchema = z.object({ value: z.string() });
 		type Details = { value: string };

--- a/packages/agent/test/agent.test.ts
+++ b/packages/agent/test/agent.test.ts
@@ -198,6 +198,48 @@ describe("Agent", () => {
 		]);
 	});
 
+	it("prompt() drops queued forced toolChoice when its tool is absent from active state.tools", async () => {
+		// Regression for #1701. Eager-todo / `/force <name>` / yield reminders all
+		// push a forced `tool_choice` into AgentSession's toolChoiceQueue, which the
+		// Agent reads via `getToolChoice`. When the per-turn active tool set is a
+		// filtered subset that does not include the forced tool, the queued choice
+		// must be refreshed away — otherwise the wire body names a tool that is not
+		// in `params.tools`, which spec-strict OpenAI-compatible endpoints reject
+		// with a 400 invalid_parameter_error.
+		const toolSchema = z.object({ value: z.string() });
+		type Details = { value: string };
+
+		const betaTool: AgentTool<typeof toolSchema, Details> = {
+			name: "beta",
+			label: "Beta",
+			description: "Beta tool",
+			parameters: toolSchema,
+			async execute(_toolCallId, params) {
+				return { content: [{ type: "text", text: `beta:${params.value}` }], details: { value: params.value } };
+			},
+		};
+
+		const mock = createMockModel({ responses: [{ content: ["done"] }] });
+
+		// Queue a forced choice for a tool that is NOT in state.tools — the
+		// subagent / MCP-scoped scenario the bug describes.
+		const agent = new Agent({
+			initialState: {
+				model: mock.model,
+				tools: [betaTool],
+				messages: [],
+			},
+			streamFn: mock.stream,
+			getToolChoice: () => ({ type: "function", name: "todo_write" }),
+		});
+
+		await agent.prompt("subagent turn");
+
+		expect(mock.calls).toHaveLength(1);
+		expect(mock.calls[0]?.options?.toolChoice).toBeUndefined();
+		expect((mock.calls[0]?.context.tools ?? []).map(tool => tool.name)).toEqual(["beta"]);
+	});
+
 	it("re-reads thinking level for each model call within a run", async () => {
 		const toolSchema = z.object({ value: z.string() });
 		type Details = { value: string };

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed the openai-completions request builder emitting a forced `tool_choice` naming a function absent from `params.tools`. Symmetric to the existing `tool_choice: "none"` guard, `buildParams` now drops a forced named `tool_choice` whenever its tool is not in the serialized `tools` array, so the wire body cannot be internally inconsistent — spec-strict OpenAI-compatible endpoints would otherwise reject it with `400 invalid_parameter_error: The tool specified in tool_choice does not match any of the specified tools` ([#1701](https://github.com/can1357/oh-my-pi/issues/1701)).
+- Fixed OpenAI-family request builders emitting a forced `tool_choice` naming a function absent from the serialized `tools` array. `openai-completions`, `openai-responses`, Azure Responses, and OpenAI Codex Responses now drop mismatched forced named choices before sending, so the wire body cannot be internally inconsistent — spec-strict OpenAI-compatible endpoints reject this as `400 invalid_parameter_error`, and Codex can surface the same invalid shape as a generic `server_error` ([#1701](https://github.com/can1357/oh-my-pi/issues/1701)).
 
 ## [15.8.0] - 2026-06-02
 ### Added

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the openai-completions request builder emitting a forced `tool_choice` naming a function absent from `params.tools`. Symmetric to the existing `tool_choice: "none"` guard, `buildParams` now drops a forced named `tool_choice` whenever its tool is not in the serialized `tools` array, so the wire body cannot be internally inconsistent — spec-strict OpenAI-compatible endpoints would otherwise reject it with `400 invalid_parameter_error: The tool specified in tool_choice does not match any of the specified tools` ([#1701](https://github.com/can1357/oh-my-pi/issues/1701)).
+
 ## [15.8.0] - 2026-06-02
 ### Added
 

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -28,8 +28,11 @@ import {
 } from "../utils/idle-iterator";
 import { sanitizeSchemaForOpenAIResponses, toolWireSchema } from "../utils/schema";
 import { wrapFetchForSseDebug } from "../utils/sse-debug";
-import { mapToOpenAIResponsesToolChoice } from "../utils/tool-choice";
-import { normalizeOpenAIResponsesPromptCacheKey, supportsDeveloperRole } from "./openai-responses";
+import {
+	mapOpenAIResponsesToolChoiceForTools,
+	normalizeOpenAIResponsesPromptCacheKey,
+	supportsDeveloperRole,
+} from "./openai-responses";
 import {
 	appendResponsesToolResultMessages,
 	applyCommonResponsesSamplingParams,
@@ -301,7 +304,7 @@ function buildParams(
 	if (context.tools) {
 		params.tools = convertTools(context.tools);
 		if (options?.toolChoice) {
-			params.tool_choice = mapToOpenAIResponsesToolChoice(options.toolChoice);
+			params.tool_choice = mapOpenAIResponsesToolChoiceForTools(options.toolChoice, context.tools, model);
 		}
 	}
 

--- a/packages/ai/src/providers/openai-codex-responses.ts
+++ b/packages/ai/src/providers/openai-codex-responses.ts
@@ -490,13 +490,18 @@ export function normalizeCodexToolChoice(
 	if (!choice) return undefined;
 	if (typeof choice === "string") return choice;
 	const allowFreeform = model ? supportsFreeformApplyPatchCodex(model) : false;
-	const mapName = (name: string): Record<string, string> => {
-		const customTool = allowFreeform
-			? tools.find(tool => tool.customFormat && (tool.name === name || tool.customWireName === name))
-			: undefined;
-		return customTool
-			? { type: "custom", name: customTool.customWireName ?? customTool.name }
-			: { type: "function", name };
+	const mapName = (name: string): Record<string, string> | undefined => {
+		const directTool = tools.find(tool => tool.name === name);
+		if (directTool) {
+			return allowFreeform && directTool.customFormat
+				? { type: "custom", name: directTool.customWireName ?? directTool.name }
+				: { type: "function", name };
+		}
+		if (!allowFreeform) {
+			return undefined;
+		}
+		const customTool = tools.find(tool => tool.customFormat && tool.customWireName === name);
+		return customTool ? { type: "custom", name: customTool.customWireName ?? customTool.name } : undefined;
 	};
 	if (choice.type === "function") {
 		if ("function" in choice && choice.function?.name) {

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1227,6 +1227,25 @@ function buildParams(
 		delete params.tool_choice;
 	}
 
+	if (typeof params.tool_choice === "object" && params.tool_choice !== null && "function" in params.tool_choice) {
+		// Symmetric to the `tool_choice: "none"` guard above: a forced named
+		// `tool_choice` that points at a tool absent from `params.tools` is a
+		// self-inconsistent request. Spec-strict OpenAI-compatible endpoints
+		// reject it with `400 invalid_parameter_error: The tool specified in
+		// tool_choice does not match any of the specified tools`. The agent
+		// loop already refreshes ToolChoice against `state.tools`, so this is
+		// the request-builder's last line of defense against any other caller
+		// (e.g. raw `streamOpenAICompletions` use) emitting a mismatched pair.
+		// See issue #1701.
+		const forcedName = params.tool_choice.function.name;
+		const offered =
+			Array.isArray(params.tools) &&
+			params.tools.some(tool => tool.type === "function" && tool.function.name === forcedName);
+		if (!offered) {
+			delete params.tool_choice;
+		}
+	}
+
 	if (supportsReasoningParams && compat.thinkingFormat === "zai" && model.reasoning) {
 		// Z.ai uses binary thinking: { type: "enabled" | "disabled" }
 		// Must explicitly disable since z.ai defaults to thinking enabled.

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -624,7 +624,7 @@ function convertConversationMessages(
  * runtime path only consumes that metadata.
  * @internal Exported for tests.
  */
-export function supportsFreeformApplyPatch(model: Model<"openai-responses">): boolean {
+export function supportsFreeformApplyPatch(model: Pick<Model<"openai-responses">, "applyPatchToolType">): boolean {
 	return model.applyPatchToolType === "freeform";
 }
 
@@ -632,17 +632,26 @@ export function supportsFreeformApplyPatch(model: Model<"openai-responses">): bo
 export function mapOpenAIResponsesToolChoiceForTools(
 	choice: ToolChoice | undefined,
 	tools: Tool[],
-	model: Model<"openai-responses">,
+	model: Pick<Model<"openai-responses">, "applyPatchToolType">,
 ): OpenAIResponsesToolChoice {
 	const mapped = mapToOpenAIResponsesToolChoice(choice);
-	if (!mapped || typeof mapped === "string" || mapped.type !== "function" || !supportsFreeformApplyPatch(model)) {
+	if (!mapped || typeof mapped === "string" || mapped.type !== "function") {
 		return mapped;
 	}
 
-	const customTool = tools.find(
-		tool => tool.customFormat && (tool.name === mapped.name || tool.customWireName === mapped.name),
-	);
-	return customTool ? { type: "custom", name: customTool.customWireName ?? customTool.name } : mapped;
+	const directTool = tools.find(tool => tool.name === mapped.name);
+	if (directTool) {
+		return supportsFreeformApplyPatch(model) && directTool.customFormat
+			? { type: "custom", name: directTool.customWireName ?? directTool.name }
+			: mapped;
+	}
+
+	if (!supportsFreeformApplyPatch(model)) {
+		return undefined;
+	}
+
+	const customTool = tools.find(tool => tool.customFormat && tool.customWireName === mapped.name);
+	return customTool ? { type: "custom", name: customTool.customWireName ?? customTool.name } : undefined;
 }
 
 /** @internal Exported for tests. */

--- a/packages/ai/test/issue-1701-repro.test.ts
+++ b/packages/ai/test/issue-1701-repro.test.ts
@@ -15,7 +15,9 @@
  */
 import { describe, expect, it } from "bun:test";
 import { getBundledModel } from "@oh-my-pi/pi-ai/models";
+import { normalizeCodexToolChoice } from "@oh-my-pi/pi-ai/providers/openai-codex-responses";
 import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import { streamOpenAIResponses } from "@oh-my-pi/pi-ai/providers/openai-responses";
 import type { Context, Model, Tool } from "@oh-my-pi/pi-ai/types";
 import * as z from "zod/v4";
 
@@ -36,12 +38,50 @@ function openaiCompletionsModel(): Model<"openai-completions"> {
 	};
 }
 
-async function capturePayload(
+function openaiResponsesModel(): Model<"openai-responses"> {
+	return {
+		...getBundledModel("openai", "gpt-4o-mini"),
+		api: "openai-responses",
+		id: "gpt-5.5",
+		name: "GPT 5.5 (test)",
+		provider: "openai",
+		baseUrl: "https://api.openai.com/v1",
+	};
+}
+
+function openaiCodexResponsesModel(): Model<"openai-codex-responses"> {
+	return {
+		...getBundledModel("openai", "gpt-4o-mini"),
+		api: "openai-codex-responses",
+		id: "gpt-5.5-codex",
+		name: "GPT 5.5 Codex (test)",
+		provider: "openai-codex",
+		baseUrl: "https://chatgpt.com/backend-api",
+		reasoning: true,
+		preferWebsockets: false,
+	};
+}
+
+async function captureCompletionsPayload(
 	context: Context,
 	opts: Parameters<typeof streamOpenAICompletions>[2],
 ): Promise<Record<string, unknown>> {
 	const { promise, resolve } = Promise.withResolvers<unknown>();
 	streamOpenAICompletions(openaiCompletionsModel(), context, {
+		...opts,
+		apiKey: "test-key",
+		signal: abortedSignal(),
+		onPayload: payload => resolve(payload),
+	});
+	return (await promise) as Record<string, unknown>;
+}
+
+async function captureResponsesPayload(
+	context: Context,
+	opts: Parameters<typeof streamOpenAIResponses>[2],
+): Promise<Record<string, unknown>> {
+	const { promise, resolve } = Promise.withResolvers<unknown>();
+	streamOpenAIResponses(openaiResponsesModel(), context, {
 		...opts,
 		apiKey: "test-key",
 		signal: abortedSignal(),
@@ -69,12 +109,12 @@ const todoWriteTool: Tool = {
 };
 
 describe("issue #1701 — eager-todo forces tool_choice for a tool absent from tools", () => {
-	it("drops forced tool_choice when the named function is not in params.tools", async () => {
+	it("drops forced tool_choice in OpenAI Completions when the named function is not in params.tools", async () => {
 		// Reproduces the exact mismatch in the captured request body from the issue:
 		// a restricted active tool set [fork_agent, dataforseo_search] paired with
 		// a forced tool_choice naming todo_write. Without the guard, the wire body
 		// is internally inconsistent and strict providers return 400.
-		const body = await capturePayload(
+		const body = await captureCompletionsPayload(
 			{
 				messages: [{ role: "user", content: "do the thing", timestamp: Date.now() }],
 				tools: [forkAgentTool, dataforseoSearchTool],
@@ -90,10 +130,10 @@ describe("issue #1701 — eager-todo forces tool_choice for a tool absent from t
 		expect(body.tool_choice).toBeUndefined();
 	});
 
-	it("keeps forced tool_choice when the named function is present in params.tools", async () => {
+	it("keeps forced tool_choice in OpenAI Completions when the named function is present in params.tools", async () => {
 		// Sanity: when the named tool IS offered, the forced choice survives — the
 		// guard only drops self-inconsistent pairs.
-		const body = await capturePayload(
+		const body = await captureCompletionsPayload(
 			{
 				messages: [{ role: "user", content: "list everything", timestamp: Date.now() }],
 				tools: [forkAgentTool, todoWriteTool],
@@ -105,10 +145,10 @@ describe("issue #1701 — eager-todo forces tool_choice for a tool absent from t
 		expect(body.tool_choice).toMatchObject({ type: "function", function: { name: "todo_write" } });
 	});
 
-	it("drops forced tool_choice when params.tools is empty", async () => {
+	it("drops forced tool_choice in OpenAI Completions when params.tools is empty", async () => {
 		// Empty `tools` (e.g. /btw side channels with a stray forced choice) is the
 		// degenerate case of the mismatch. Belt-and-suspenders coverage.
-		const body = await capturePayload(
+		const body = await captureCompletionsPayload(
 			{
 				messages: [{ role: "user", content: "do the thing", timestamp: Date.now() }],
 				tools: [],
@@ -118,5 +158,52 @@ describe("issue #1701 — eager-todo forces tool_choice for a tool absent from t
 
 		expect(body.tools).toBeUndefined();
 		expect(body.tool_choice).toBeUndefined();
+	});
+
+	it("drops forced tool_choice in OpenAI Responses when the named function is not in params.tools", async () => {
+		const body = await captureResponsesPayload(
+			{
+				messages: [{ role: "user", content: "do the thing", timestamp: Date.now() }],
+				tools: [forkAgentTool, dataforseoSearchTool],
+			},
+			{ toolChoice: { type: "tool", name: "todo_write" } },
+		);
+
+		expect(Array.isArray(body.tools)).toBe(true);
+		expect((body.tools as { name: string }[]).map(tool => tool.name)).toEqual(["fork_agent", "dataforseo_search"]);
+		expect(body.tool_choice).toBeUndefined();
+	});
+
+	it("keeps forced tool_choice in OpenAI Responses when the named function is present in params.tools", async () => {
+		const body = await captureResponsesPayload(
+			{
+				messages: [{ role: "user", content: "list everything", timestamp: Date.now() }],
+				tools: [forkAgentTool, todoWriteTool],
+			},
+			{ toolChoice: { type: "tool", name: "todo_write" } },
+		);
+
+		expect(Array.isArray(body.tools)).toBe(true);
+		expect(body.tool_choice).toMatchObject({ type: "function", name: "todo_write" });
+	});
+
+	it("drops forced tool_choice in OpenAI Codex Responses when the named function is not in params.tools", () => {
+		expect(
+			normalizeCodexToolChoice(
+				{ type: "tool", name: "todo_write" },
+				[forkAgentTool, dataforseoSearchTool],
+				openaiCodexResponsesModel(),
+			),
+		).toBeUndefined();
+	});
+
+	it("keeps forced tool_choice in OpenAI Codex Responses when the named function is present in params.tools", () => {
+		expect(
+			normalizeCodexToolChoice(
+				{ type: "tool", name: "todo_write" },
+				[forkAgentTool, todoWriteTool],
+				openaiCodexResponsesModel(),
+			),
+		).toEqual({ type: "function", name: "todo_write" });
 	});
 });

--- a/packages/ai/test/issue-1701-repro.test.ts
+++ b/packages/ai/test/issue-1701-repro.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Repro for #1701 — omp emits a `tool_choice` naming a function that is
+ * absent from the same request's `tools` array, producing a self-inconsistent
+ * request body. Spec-strict OpenAI-compatible endpoints reject it with
+ * `400 invalid_parameter_error: The tool specified in tool_choice does not
+ * match any of the specified tools`.
+ *
+ * The fix is symmetric to the `tool_choice: "none"` guard handling #1227: the
+ * request builder drops a forced named `tool_choice` whenever its named
+ * function is not in `params.tools`. The primary defense lives in the agent
+ * loop (`refreshToolChoiceForActiveTools` now runs on the queued choice too,
+ * not just `options.toolChoice`), but the request builder is the last line of
+ * defense for any other caller of `streamOpenAICompletions` (raw SDK use,
+ * external callers) emitting a mismatched pair.
+ */
+import { describe, expect, it } from "bun:test";
+import { getBundledModel } from "@oh-my-pi/pi-ai/models";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import type { Context, Model, Tool } from "@oh-my-pi/pi-ai/types";
+import * as z from "zod/v4";
+
+function abortedSignal(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+function openaiCompletionsModel(): Model<"openai-completions"> {
+	return {
+		...getBundledModel("openai", "gpt-4o-mini"),
+		api: "openai-completions",
+		id: "glm-5.1",
+		name: "GLM 5.1 (test)",
+		provider: "alibaba-modelstudio",
+		baseUrl: "https://example.test/v1",
+	};
+}
+
+async function capturePayload(
+	context: Context,
+	opts: Parameters<typeof streamOpenAICompletions>[2],
+): Promise<Record<string, unknown>> {
+	const { promise, resolve } = Promise.withResolvers<unknown>();
+	streamOpenAICompletions(openaiCompletionsModel(), context, {
+		...opts,
+		apiKey: "test-key",
+		signal: abortedSignal(),
+		onPayload: payload => resolve(payload),
+	});
+	return (await promise) as Record<string, unknown>;
+}
+
+const forkAgentTool: Tool = {
+	name: "fork_agent",
+	description: "Fork a subagent",
+	parameters: z.object({ prompt: z.string() }),
+};
+
+const dataforseoSearchTool: Tool = {
+	name: "dataforseo_search",
+	description: "Search via DataForSEO",
+	parameters: z.object({ query: z.string() }),
+};
+
+const todoWriteTool: Tool = {
+	name: "todo_write",
+	description: "Manage a phased task list",
+	parameters: z.object({ ops: z.array(z.object({ op: z.string() })) }),
+};
+
+describe("issue #1701 — eager-todo forces tool_choice for a tool absent from tools", () => {
+	it("drops forced tool_choice when the named function is not in params.tools", async () => {
+		// Reproduces the exact mismatch in the captured request body from the issue:
+		// a restricted active tool set [fork_agent, dataforseo_search] paired with
+		// a forced tool_choice naming todo_write. Without the guard, the wire body
+		// is internally inconsistent and strict providers return 400.
+		const body = await capturePayload(
+			{
+				messages: [{ role: "user", content: "do the thing", timestamp: Date.now() }],
+				tools: [forkAgentTool, dataforseoSearchTool],
+			},
+			{ toolChoice: { type: "tool", name: "todo_write" } },
+		);
+
+		expect(Array.isArray(body.tools)).toBe(true);
+		expect((body.tools as { function: { name: string } }[]).map(tool => tool.function.name)).toEqual([
+			"fork_agent",
+			"dataforseo_search",
+		]);
+		expect(body.tool_choice).toBeUndefined();
+	});
+
+	it("keeps forced tool_choice when the named function is present in params.tools", async () => {
+		// Sanity: when the named tool IS offered, the forced choice survives — the
+		// guard only drops self-inconsistent pairs.
+		const body = await capturePayload(
+			{
+				messages: [{ role: "user", content: "list everything", timestamp: Date.now() }],
+				tools: [forkAgentTool, todoWriteTool],
+			},
+			{ toolChoice: { type: "tool", name: "todo_write" } },
+		);
+
+		expect(Array.isArray(body.tools)).toBe(true);
+		expect(body.tool_choice).toMatchObject({ type: "function", function: { name: "todo_write" } });
+	});
+
+	it("drops forced tool_choice when params.tools is empty", async () => {
+		// Empty `tools` (e.g. /btw side channels with a stray forced choice) is the
+		// degenerate case of the mismatch. Belt-and-suspenders coverage.
+		const body = await capturePayload(
+			{
+				messages: [{ role: "user", content: "do the thing", timestamp: Date.now() }],
+				tools: [],
+			},
+			{ toolChoice: { type: "tool", name: "todo_write" } },
+		);
+
+		expect(body.tools).toBeUndefined();
+		expect(body.tool_choice).toBeUndefined();
+	});
+});

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -874,6 +874,18 @@ describe("kimi model detection via detectCompat", () => {
 						timestamp: Date.now(),
 					},
 				],
+				// Provide the matching tool so the forced `tool_choice` is internally
+				// consistent. Without it, the request-builder's #1701 guard drops
+				// `tool_choice` and the disable-reasoning-on-forced-choice path
+				// never fires — but that is a request-shape issue, not the kimi
+				// reasoning-suppression behavior this test guards.
+				tools: [
+					{
+						name: "read",
+						description: "Read a file",
+						parameters: { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+					},
+				],
 			},
 			{
 				apiKey: "test-key",

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed eager-todo enforcement forcing `tool_choice: todo_write` on turns whose serialized tools omit `todo_write` (MCP-scoped, restricted-toolset, and subagent turns). The prelude now gates on the per-turn `agent.state.tools` rather than the global `#toolRegistry`, so it no longer queues a forced choice that produces a self-inconsistent request body (`tool_choice` naming a function absent from `tools`) and trips spec-strict OpenAI-compatible providers with `400 invalid_parameter_error: The tool specified in tool_choice does not match any of the specified tools` ([#1701](https://github.com/can1357/oh-my-pi/issues/1701)).
+
 ## [15.8.0] - 2026-06-02
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed eager-todo enforcement forcing `tool_choice: todo_write` on turns whose serialized tools omit `todo_write` (MCP-scoped, restricted-toolset, and subagent turns). The prelude now gates on the per-turn `agent.state.tools` rather than the global `#toolRegistry`, so it no longer queues a forced choice that produces a self-inconsistent request body (`tool_choice` naming a function absent from `tools`) and trips spec-strict OpenAI-compatible providers with `400 invalid_parameter_error: The tool specified in tool_choice does not match any of the specified tools` ([#1701](https://github.com/can1357/oh-my-pi/issues/1701)).
+- Fixed eager-todo enforcement forcing `tool_choice: todo_write` on turns whose serialized tools omit `todo_write` (MCP-scoped, restricted-toolset, and subagent turns). The prelude now gates on the per-turn `agent.state.tools` rather than the global `#toolRegistry`, and `AgentSession.nextToolChoice` filters dequeued named choices against the same active tool set — rejecting them with reason `"unavailable"` so the directive's `onRejected` policy (e.g. `/force` and pending-action reminders) can requeue rather than silently discard. Together these stop the queue from yielding a self-inconsistent request body (`tool_choice` naming a function absent from `tools`) and trip spec-strict OpenAI-compatible providers with `400 invalid_parameter_error: The tool specified in tool_choice does not match any of the specified tools` ([#1701](https://github.com/can1357/oh-my-pi/issues/1701)).
 
 ## [15.8.0] - 2026-06-02
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -6401,9 +6401,17 @@ export class AgentSession {
 			return undefined;
 		}
 
-		if (!this.#toolRegistry.has("todo_write")) {
-			logger.warn("Eager todo enforcement skipped because todo_write is unavailable", {
-				activeToolNames: this.agent.state.tools.map(tool => tool.name),
+		// Gate on the per-turn active tool set (what `context.tools` will serialize as),
+		// not the global registry. Registry membership is a superset: MCP-scoped /
+		// restricted-toolset / subagent turns can drop `todo_write` from the active set
+		// while the registry still carries it. Forcing a `tool_choice` for a tool that
+		// won't be in `params.tools` produces a self-inconsistent request that
+		// spec-strict OpenAI-compatible endpoints reject with 400 "tool_choice does
+		// not match any of the specified tools" (issue #1701).
+		const activeTools = this.agent.state.tools;
+		if (!activeTools.some(tool => tool.name === "todo_write")) {
+			logger.warn("Eager todo enforcement skipped because todo_write is not active for this turn", {
+				activeToolNames: activeTools.map(tool => tool.name),
 			});
 			return undefined;
 		}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -207,7 +207,7 @@ import { parseCommandArgs } from "../utils/command-args";
 import { type EditMode, resolveEditMode } from "../utils/edit-mode";
 import { resolveFileDisplayMode } from "../utils/file-display-mode";
 import { extractFileMentions, generateFileMentionMessages } from "../utils/file-mentions";
-import { buildNamedToolChoice } from "../utils/tool-choice";
+import { buildNamedToolChoice, isToolChoiceActive } from "../utils/tool-choice";
 import type { AuthStorage } from "./auth-storage";
 import type { ClientBridge, ClientBridgePermissionOption, ClientBridgePermissionOutcome } from "./client-bridge";
 import {
@@ -1238,9 +1238,24 @@ export class AgentSession {
 		return this.#modelRegistry;
 	}
 
-	/** Advance the tool-choice queue and return the next directive for the upcoming LLM call. */
+	/**
+	 * Advance the tool-choice queue and return the next directive for the upcoming LLM call.
+	 *
+	 * Filters dequeued named choices against the per-turn active tool set: if the head
+	 * directive's yield targets a tool that is not in `agent.state.tools`, reject it with
+	 * reason `"unavailable"` so the directive's `onRejected` policy (typically `requeue`
+	 * for `/force` and pending-action reminders) can decide whether to replay on a later
+	 * turn or drop. Returning the unservable choice would name a tool absent from the
+	 * serialized `tools` array — the exact wire-shape contract violation tracked in
+	 * #1701 — and resolving it via the normal `turn_end` path would silently discard
+	 * the directive (PR #1707 review).
+	 */
 	nextToolChoice(): ToolChoice | undefined {
-		return this.#toolChoiceQueue.nextToolChoice();
+		const choice = this.#toolChoiceQueue.nextToolChoice();
+		if (choice === undefined) return undefined;
+		if (isToolChoiceActive(choice, this.agent.state.tools)) return choice;
+		this.#toolChoiceQueue.reject("unavailable");
+		return undefined;
 	}
 
 	/**

--- a/packages/coding-agent/src/session/tool-choice-queue.ts
+++ b/packages/coding-agent/src/session/tool-choice-queue.ts
@@ -10,7 +10,7 @@ export interface ResolveInfo {
 export interface RejectInfo {
 	/** The ToolChoice that was yielded but never (or unsuccessfully) served. */
 	choice: ToolChoice;
-	reason: "aborted" | "error" | "cleared" | "removed";
+	reason: "aborted" | "error" | "cleared" | "removed" | "unavailable";
 }
 
 /** "requeue" replays the lost yield next turn; "drop" (or void/undefined) discards it. */

--- a/packages/coding-agent/src/utils/tool-choice.ts
+++ b/packages/coding-agent/src/utils/tool-choice.ts
@@ -31,3 +31,24 @@ export function buildNamedToolChoice(toolName: string, model?: Model<Api>): Tool
 
 	return undefined;
 }
+
+/**
+ * Whether the given tool-choice can be served against the per-turn active tool set.
+ * Non-named choices ("auto", "none", "any", "required", undefined) are always servable;
+ * named choices ({type:"tool",name} / {type:"function",name|function.name}) require the
+ * named tool to be present. Used by `AgentSession.nextToolChoice` to filter dequeued
+ * directives whose target tool isn't in the current turn's serialized tools (issue #1701).
+ */
+export function isToolChoiceActive(
+	toolChoice: ToolChoice | undefined,
+	tools: ReadonlyArray<{ name: string }>,
+): boolean {
+	if (!toolChoice || typeof toolChoice === "string") return true;
+	const name =
+		toolChoice.type === "tool"
+			? toolChoice.name
+			: "function" in toolChoice
+				? toolChoice.function.name
+				: toolChoice.name;
+	return tools.some(tool => tool.name === name);
+}

--- a/packages/coding-agent/test/agent-session-eager-todo.test.ts
+++ b/packages/coding-agent/test/agent-session-eager-todo.test.ts
@@ -280,4 +280,22 @@ describe("AgentSession eager todo enforcement", () => {
 			lastMessageText: "actually skip that, just fix the typo",
 		});
 	});
+
+	it("skips eager todo enforcement when todo_write is filtered out of the active tools", async () => {
+		// Regression for #1701. The eager-todo prelude must gate on the per-turn
+		// active tool set (what `context.tools` will serialize as), not the global
+		// `#toolRegistry`. MCP-scoped / restricted-toolset / subagent turns can drop
+		// `todo_write` from `agent.state.tools` while the registry still carries it.
+		// Forcing a tool_choice for a tool that is not in `params.tools` produces a
+		// self-inconsistent request that strict OpenAI-compatible endpoints reject
+		// with `400 invalid_parameter_error: The tool specified in tool_choice does
+		// not match any of the specified tools`.
+		session.agent.setTools(session.agent.state.tools.filter(tool => tool.name !== "todo_write"));
+
+		await session.prompt("refactor the parser module");
+
+		expect(observedCalls).toHaveLength(1);
+		expect(observedCalls[0]?.toolChoice).toBeUndefined();
+		expect(observedCalls[0]?.toolNames).toEqual(["bash"]);
+	});
 });

--- a/packages/coding-agent/test/agent-session-force-tool-choice.test.ts
+++ b/packages/coding-agent/test/agent-session-force-tool-choice.test.ts
@@ -90,3 +90,54 @@ it("forces specific tool, then transitions to none, then clears", () => {
 it("throws when forcing a non-active tool", () => {
 	expect(() => session.setForcedToolChoice("read")).toThrow('Tool "read" is not currently active.');
 });
+
+it("rejects (and lets the directive requeue) a queued named choice whose tool is filtered out of active state.tools", () => {
+	// Regression for #1707 review: queue lifecycle must NOT advance a forced choice
+	// the model never saw. AgentSession's `/force` pushes a [forced, "none"] sequence
+	// with `onRejected: () => "requeue"`. If the forced tool is filtered out of
+	// `agent.state.tools` mid-flight (MCP-scoped / subagent / restricted-toolset
+	// turn), `nextToolChoice` must reject the head yield so the directive replays —
+	// not return it (would cause a self-inconsistent wire body, #1701) and not
+	// silently resolve it on turn_end (would discard the directive).
+	session.setForcedToolChoice("write");
+	// Filter `write` out of the active per-turn tool set BEFORE nextToolChoice runs.
+	session.agent.setTools(session.agent.state.tools.filter(tool => tool.name !== "write"));
+
+	const first = session.nextToolChoice();
+	expect(first).toBeUndefined();
+	expect(session.toolChoiceQueue.hasInFlight).toBe(false);
+
+	// Restore `write` to the active set — the directive's onRejected: "requeue" must
+	// have replayed the lost yield, so the next call serves the forced choice.
+	session.agent.setTools([
+		...session.agent.state.tools,
+		{
+			name: "write",
+			label: "Write",
+			description: "Mock write tool",
+			parameters: z.object({}),
+			execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+		},
+	]);
+	const second = session.nextToolChoice();
+	expect(second).toEqual({ type: "tool", name: "write" });
+});
+
+it("drops a queued named choice whose directive policy is 'drop' when its tool is filtered out", () => {
+	// Eager-todo pushes with default reject policy (drop). When `todo_write` is
+	// filtered out of active tools by the time nextToolChoice runs, the directive
+	// must be discarded — no requeue, no resolve — and the queue must drain so
+	// subsequent turns do not see a stale in-flight entry.
+	session.toolChoiceQueue.pushOnce({ type: "tool", name: "todo_write" }, { label: "eager-todo" });
+	expect(session.nextToolChoice()).toBeUndefined();
+	expect(session.toolChoiceQueue.hasInFlight).toBe(false);
+	expect(session.nextToolChoice()).toBeUndefined();
+});
+
+it("passes through string-mode tool choices unchanged regardless of active tools", () => {
+	// "none" / "auto" / "any" / "required" are not named, so the active-tool gate
+	// must not touch them. Otherwise a `/btw`-style `"none"` directive would be
+	// silently dropped whenever the per-turn tool set is filtered.
+	session.toolChoiceQueue.pushOnce("none", { label: "btw" });
+	expect(session.nextToolChoice()).toBe("none");
+});


### PR DESCRIPTION
## Repro

On a turn whose serialized `tools` array does not include `todo_write`, omp's eager-todo enforcement still emits a forced `tool_choice: {type:"function", function:{name:"todo_write"}}`. The wire body is internally inconsistent before any provider sees it, and spec-strict OpenAI-compatible endpoints reject it with `400 invalid_parameter_error: The tool specified in tool_choice does not match any of the specified tools`. The new test `packages/ai/test/issue-1701-repro.test.ts` reproduces the exact captured request body from the issue (`tools: [fork_agent, dataforseo_search]` + forced `tool_choice` for `todo_write`); without the fix, the assertion `expect(body.tool_choice).toBeUndefined()` fails with the mismatched shape.

```
bun --cwd=packages/ai test test/issue-1701-repro.test.ts
```

## Cause

The eager-todo prelude in `packages/coding-agent/src/session/agent-session.ts` (`#createEagerTodoPrelude`) gated the forced `tool_choice` on `#toolRegistry.has("todo_write")` — registry membership — but the **serialized** tool set for a given turn (`context.tools` → `params.tools` in `packages/ai/src/providers/openai-completions.ts`) can be a filtered subset that omits `todo_write` (MCP-scoped / restricted-toolset / subagent turns).

The agent loop's existing `refreshToolChoiceForActiveTools` defense in `packages/agent/src/agent.ts` (line 917) was structured as `this.#getToolChoice?.() ?? refreshToolChoiceForActiveTools(options?.toolChoice, this.#state.tools)`, so any choice returned by the queue-driven `getToolChoice` hook bypassed the refresh entirely.

The `openai-completions` request builder at line 1218 already had the symmetric guard for `tool_choice: "none"` + empty `tools` (from #1227 / `/btw`), but did not cover the **named/forced** variant.

## Fix

Three layers, defense in depth:

- **coding-agent** — `agent-session.ts` `#createEagerTodoPrelude`: gate on `this.agent.state.tools` (what `context.tools` will serialize as) instead of `#toolRegistry`. Fixes the source of the bug.
- **agent** — `agent.ts` `getToolChoice`: `refreshToolChoiceForActiveTools` now runs on the choice returned by the caller-supplied `getToolChoice` hook too, not just `options.toolChoice`. Catches every queue label (eager-todo, user-force, yield retries, resolve reminders) and every provider downstream.
- **ai/openai-completions** — `buildParams`: extended the existing `tool_choice: "none"` guard to also drop a forced named `tool_choice` whose function is not in `params.tools`. Last line of defense for raw `streamOpenAICompletions` callers (external SDK use, etc.).

The kimi forced-tool reasoning-suppression test in `openai-completions-compat.test.ts` was implicitly depending on the bug (forced a `tool_choice` for a tool absent from `context.tools`). It now provides the matching tool so the test exercises the `disableReasoningOnForcedToolChoice` path on a well-formed request.

## Verification

```
bun --cwd=packages/ai test                                     # 1447 pass, 0 fail
bun --cwd=packages/agent test                                  # 216 pass, 0 fail
bun --cwd=packages/coding-agent test test/agent-session-eager-todo.test.ts \
  test/tool-choice-queue.test.ts test/agent-session-resolve-reminder.test.ts \
  test/slash-commands/force.test.ts                            # 27 pass, 0 fail
bun check                                                      # green
```

The new regression tests:
- `packages/ai/test/issue-1701-repro.test.ts` — three cases against the openai-completions guard (mismatched tools, matching tools, empty tools).
- `packages/agent/test/agent.test.ts` — queue-returned forced choice for an absent tool gets refreshed to `undefined`.
- `packages/coding-agent/test/agent-session-eager-todo.test.ts` — eager-todo skipped when `todo_write` is filtered out of active tools while still in the registry.

Pre-existing test failures in `packages/coding-agent` (acp-stdout, oauth network, eval/subprocess timeouts, fs permissions, etc.) are unrelated environmental failures present on `main` and confirmed against the same paths with this diff stashed.

Fixes #1701