### PR TITLE
fix(tui): keep Ctrl+V image paste registered on Windows

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -22,23 +22,25 @@ app.stt.toggle: []
 
 ## Common action IDs
 
-| Action ID                   | Default                       | Meaning                                       |
-| --------------------------- | ----------------------------- | --------------------------------------------- |
-| `app.model.cycleForward`    | `Ctrl+P`                      | Cycle role models forward                     |
-| `app.model.cycleBackward`   | `Shift+Ctrl+P`                | Cycle role models in temporary mode           |
-| `app.model.selectTemporary` | `Alt+P`                       | Pick a model temporarily for this session     |
-| `app.model.select`          | `Ctrl+L`                      | Open the model selector and set roles         |
-| `app.plan.toggle`           | `Alt+Shift+P`                 | Toggle plan mode                              |
-| `app.history.search`        | `Ctrl+R`                      | Search prompt history                         |
-| `app.tools.expand`          | `Ctrl+O`                      | Toggle tool-output expansion                  |
-| `app.thinking.toggle`       | `Ctrl+T`                      | Toggle thinking-block visibility              |
-| `app.thinking.cycle`        | `Shift+Tab`                   | Cycle thinking level                          |
-| `app.editor.external`       | `Ctrl+G`                      | Edit the draft in `$VISUAL` / `$EDITOR`       |
-| `app.message.followUp`      | `Ctrl+Enter`                  | Queue a follow-up message                     |
-| `app.message.dequeue`       | `Alt+Up`                      | Dequeue a queued message back into the editor |
-| `app.clipboard.copyLine`    | `Alt+Shift+L`                 | Copy the current line                         |
-| `app.clipboard.copyPrompt`  | `Alt+Shift+C`                 | Copy the whole prompt                         |
-| `app.clipboard.pasteImage`  | `Ctrl+V` (`Alt+V` on Windows) | Paste an image from the clipboard             |
-| `app.stt.toggle`            | `Alt+H`                       | Toggle speech-to-text recording               |
+| Action ID                   | Default                                | Meaning                                       |
+| --------------------------- | -------------------------------------- | --------------------------------------------- |
+| `app.model.cycleForward`    | `Ctrl+P`                               | Cycle role models forward                     |
+| `app.model.cycleBackward`   | `Shift+Ctrl+P`                         | Cycle role models in temporary mode           |
+| `app.model.selectTemporary` | `Alt+P`                                | Pick a model temporarily for this session     |
+| `app.model.select`          | `Ctrl+L`                               | Open the model selector and set roles         |
+| `app.plan.toggle`           | `Alt+Shift+P`                          | Toggle plan mode                              |
+| `app.history.search`        | `Ctrl+R`                               | Search prompt history                         |
+| `app.tools.expand`          | `Ctrl+O`                               | Toggle tool-output expansion                  |
+| `app.thinking.toggle`       | `Ctrl+T`                               | Toggle thinking-block visibility              |
+| `app.thinking.cycle`        | `Shift+Tab`                            | Cycle thinking level                          |
+| `app.editor.external`       | `Ctrl+G`                               | Edit the draft in `$VISUAL` / `$EDITOR`       |
+| `app.message.followUp`      | `Ctrl+Enter`                           | Queue a follow-up message                     |
+| `app.message.dequeue`       | `Alt+Up`                               | Dequeue a queued message back into the editor |
+| `app.clipboard.copyLine`    | `Alt+Shift+L`                          | Copy the current line                         |
+| `app.clipboard.copyPrompt`  | `Alt+Shift+C`                          | Copy the whole prompt                         |
+| `app.clipboard.pasteImage`  | `Ctrl+V` (`Alt+V` fallback on Windows) | Paste an image from the clipboard             |
+| `app.stt.toggle`            | `Alt+H`                                | Toggle speech-to-text recording               |
+
+On Windows Terminal, `Ctrl+V` may be handled by the terminal paste command before `omp` sees it; use the `Alt+V` fallback when clipboard image paste appears to do nothing.
 
 Older unqualified action names are migrated when `keybindings.yml` is loaded, but new docs and new configs should use the namespaced action IDs above. Existing `keybindings.json` files are still accepted and migrated to `keybindings.yml`; `keybindings.yaml` is also accepted.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,8 @@
 
 ### Fixed
 
+- Fixed Windows clipboard-image paste keeping `Ctrl+V` unregistered by default. The TUI now registers `Ctrl+V` plus the Windows Terminal-safe `Alt+V` fallback, and the keybinding docs call out when to use the fallback ([#1708](https://github.com/can1357/oh-my-pi/issues/1708)).
+
 - Fixed `read`, `search`, `find`, `ast_grep`, and `ast_edit` recovering when a model flattens multiple existing paths into one comma-, semicolon-, or space-delimited string while preserving real paths that contain delimiters.
 - Fixed Exa web search reporting available without Exa credentials, which could route searches into the unauthenticated public MCP fallback and stall before trying the next provider. Availability and `searchExa()` now resolve through the standard `AuthStorage` cascade (`EXA_API_KEY` env or stored credential) ([#1695](https://github.com/can1357/oh-my-pi/issues/1695)).
 - Fixed Anthropic web search ignoring `ANTHROPIC_SEARCH_BASE_URL` when credentials came from stored Anthropic auth or generic Anthropic env fallback rather than `ANTHROPIC_SEARCH_API_KEY` ([#1694](https://github.com/can1357/oh-my-pi/issues/1694)).

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -59,6 +59,13 @@ declare module "@oh-my-pi/pi-tui" {
 }
 
 /**
+ * Resolve default image-paste shortcuts for the current terminal platform.
+ */
+export function getDefaultPasteImageKeys(platform: NodeJS.Platform = process.platform): KeyId[] {
+	return platform === "win32" ? ["ctrl+v", "alt+v"] : ["ctrl+v"];
+}
+
+/**
  * All keybindings definitions: TUI + app-specific.
  */
 export const KEYBINDINGS = {
@@ -120,7 +127,7 @@ export const KEYBINDINGS = {
 		description: "Dequeue message",
 	},
 	"app.clipboard.pasteImage": {
-		defaultKeys: process.platform === "win32" ? "alt+v" : "ctrl+v",
+		defaultKeys: getDefaultPasteImageKeys(),
 		description: "Paste image from clipboard",
 	},
 	"app.clipboard.pasteTextRaw": {

--- a/packages/coding-agent/test/keybindings-display.test.ts
+++ b/packages/coding-agent/test/keybindings-display.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { KeybindingsManager } from "../src/config/keybindings";
+import { KeybindingsManager, getDefaultPasteImageKeys } from "../src/config/keybindings";
 
 describe("KeybindingsManager.getDisplayString", () => {
 	it("formats a single binding as a human-readable key hint", () => {
@@ -24,5 +24,16 @@ describe("KeybindingsManager.getDisplayString", () => {
 		});
 
 		expect(keybindings.getDisplayString("app.clipboard.copyPrompt")).toBe("");
+	});
+});
+
+describe("getDefaultPasteImageKeys", () => {
+	it("keeps Ctrl+V registered for image paste on Windows alongside the terminal-safe fallback", () => {
+		expect(getDefaultPasteImageKeys("win32")).toEqual(["ctrl+v", "alt+v"]);
+	});
+
+	it("uses Ctrl+V as the image-paste shortcut on non-Windows platforms", () => {
+		expect(getDefaultPasteImageKeys("linux")).toEqual(["ctrl+v"]);
+		expect(getDefaultPasteImageKeys("darwin")).toEqual(["ctrl+v"]);
 	});
 });

--- a/packages/coding-agent/test/keybindings-display.test.ts
+++ b/packages/coding-agent/test/keybindings-display.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { KeybindingsManager, getDefaultPasteImageKeys } from "../src/config/keybindings";
+import { getDefaultPasteImageKeys, KeybindingsManager } from "../src/config/keybindings";
 
 describe("KeybindingsManager.getDisplayString", () => {
 	it("formats a single binding as a human-readable key hint", () => {


### PR DESCRIPTION
## Repro
On the issue branch before the fix, the Windows default for `app.clipboard.pasteImage` was `Alt+V` only. Repro command: `bun -e 'const src = await Bun.file("packages/coding-agent/src/config/keybindings.ts").text(); const missing = src.includes("process.platform === \"win32\" ? \"alt+v\" : \"ctrl+v\""); console.log(missing ? "reproduced: win32 image paste default is alt+v only; ctrl+v is not registered" : "not reproduced"); process.exit(missing ? 1 : 0);'`.

## Cause
`packages/coding-agent/src/config/keybindings.ts` computed `KEYBINDINGS["app.clipboard.pasteImage"].defaultKeys` with a win32-only replacement, so Windows registered `Alt+V` instead of registering `Ctrl+V` plus the Windows Terminal-safe fallback. `CustomEditor.handleInput()` only invokes `InputController.handleImagePaste()` for configured action keys, so `Ctrl+V` was not an OMP image-paste shortcut on Windows.

## Fix
- Added `getDefaultPasteImageKeys()` so Windows defaults include both `Ctrl+V` and `Alt+V`, while non-Windows platforms keep `Ctrl+V`.
- Added regression coverage for the platform-specific default key list.
- Updated `docs/keybindings.md` to document the Windows fallback and explain that Windows Terminal may consume `Ctrl+V` before `omp` sees it.
- Added the package changelog entry for #1708.

## Verification
Ran `bun test packages/coding-agent/test/keybindings-display.test.ts packages/coding-agent/test/custom-editor-keybindings.test.ts` (10 pass), `bun run check:types` in `packages/coding-agent`, and the pre-publish `bun run fix`/`bun check` gate via `gh_push_branch`. Fixes #1708.