### PR TITLE
fix(mcp-stdio): swallowed EPIPE from notify and sendResponse stdin writes

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed an unhandled `EPIPE` rejection when an MCP stdio server exits between returning the `initialize` response and the client's `notifications/initialized` send. `StdioTransport.notify()` and `#sendResponse()` now route stdin writes through a shared helper that catches synchronous sink failures: `notify()` tears the transport down (firing `onClose`) and surfaces a `Transport closed while sending notification` rejection so `connectToServer()` treats the handshake as a failed connection instead of returning a "connected" handle wrapping a dead transport; `#sendResponse()` stays silent because a dead subprocess has no use for the response ([#1710](https://github.com/can1357/oh-my-pi/issues/1710)).
+- Fixed an unhandled `EPIPE` rejection when an MCP stdio server exits between returning the `initialize` response and the client's `notifications/initialized` send. `StdioTransport.notify()` and `#sendResponse()` now route stdin writes through a shared helper that catches synchronous sink failures: `notify()` tears the transport down (firing `onClose`) and surfaces a `Transport closed while sending notification` rejection so `connectToServer()` treats the handshake as a failed connection instead of returning a "connected" handle wrapping a dead transport; `#sendResponse()` stays silent because a dead subprocess has no use for the response. `StdioTransport.close()` is now the authoritative resource teardown — it no longer early-returns when `#handleClose()` has already flipped `#connected`, so the subprocess and read loop are always cleaned up (including in the `connectToServer()` failure path) ([#1710](https://github.com/can1357/oh-my-pi/issues/1710)).
 
 ## [15.8.0] - 2026-06-02
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed an unhandled `EPIPE` rejection when an MCP stdio server exits between returning the `initialize` response and the client's `notifications/initialized` send. `StdioTransport.notify()` and `#sendResponse()` route stdin writes through a shared helper that swallows synchronous sink failures; `notify()` additionally tears the transport down so the reconnect machinery engages instead of leaking a rejection ([#1710](https://github.com/can1357/oh-my-pi/issues/1710)).
+- Fixed an unhandled `EPIPE` rejection when an MCP stdio server exits between returning the `initialize` response and the client's `notifications/initialized` send. `StdioTransport.notify()` and `#sendResponse()` now route stdin writes through a shared helper that catches synchronous sink failures: `notify()` tears the transport down (firing `onClose`) and surfaces a `Transport closed while sending notification` rejection so `connectToServer()` treats the handshake as a failed connection instead of returning a "connected" handle wrapping a dead transport; `#sendResponse()` stays silent because a dead subprocess has no use for the response ([#1710](https://github.com/can1357/oh-my-pi/issues/1710)).
 
 ## [15.8.0] - 2026-06-02
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an unhandled `EPIPE` rejection when an MCP stdio server exits between returning the `initialize` response and the client's `notifications/initialized` send. `StdioTransport.notify()` and `#sendResponse()` route stdin writes through a shared helper that swallows synchronous sink failures; `notify()` additionally tears the transport down so the reconnect machinery engages instead of leaking a rejection ([#1710](https://github.com/can1357/oh-my-pi/issues/1710)).
+
 ## [15.8.0] - 2026-06-02
 
 ### Added

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -328,28 +328,26 @@ export class StdioTransport implements MCPTransport {
 	}
 
 	async close(): Promise<void> {
-		if (!this.#connected) return;
-		this.#connected = false;
-
-		// Reject pending requests
-		for (const [, pending] of this.#pendingRequests) {
-			pending.reject(new Error("Transport closed"));
+		// `close()` is the authoritative resource teardown. `#handleClose()`
+		// may have already run (read-loop EOF, or a notify() write failure
+		// that surfaces the dead transport to the caller) and flipped
+		// `#connected` to false — but the subprocess and read loop are still
+		// alive in that path, so we MUST keep cleaning up regardless. Each
+		// step is individually guarded so this remains idempotent across
+		// repeat calls.
+		if (this.#connected) {
+			this.#handleClose();
 		}
-		this.#pendingRequests.clear();
 
-		// Kill subprocess
 		if (this.#process) {
 			this.#process.kill();
 			this.#process = null;
 		}
 
-		// Wait for read loop to finish
 		if (this.#readLoop) {
 			await this.#readLoop.catch(() => {});
 			this.#readLoop = null;
 		}
-
-		this.onClose?.();
 	}
 }
 

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -314,11 +314,16 @@ export class StdioTransport implements MCPTransport {
 		// Bun's FileSink can throw EPIPE synchronously on Windows when the
 		// subprocess has exited between the last read-loop tick and this
 		// write (e.g. an MCP server that dies after returning `initialize`
-		// but before `notifications/initialized` is delivered). Treat any
-		// such failure as transport closure so the reconnect machinery
-		// engages instead of leaking an unhandled rejection — see #1710.
+		// but before `notifications/initialized` is delivered). Tear the
+		// transport down so any wired `onClose` (and reconnect machinery)
+		// engages, then surface the failure to the caller so a write that
+		// dropped on the floor is never silently treated as delivered —
+		// `initializeConnection()` runs before the manager installs its
+		// `onClose` handler, so a swallowed failure there would yield a
+		// "connected" handle wrapping a dead transport. See #1710.
 		if (!writeFrame(this.#process.stdin, `${JSON.stringify(notification)}\n`)) {
 			this.#handleClose();
+			throw new Error(`Transport closed while sending notification "${method}"`);
 		}
 	}
 

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -19,6 +19,34 @@ import type {
 import { toJsonRpcError } from "../../mcp/types";
 import { isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "../timeout";
 
+/** Minimal write surface of `Subprocess.stdin` we need for framed sends. */
+interface FrameSink {
+	write(chunk: string): unknown;
+	flush(): unknown;
+}
+
+/**
+ * Write a newline-delimited JSON-RPC frame to the subprocess's stdin sink,
+ * swallowing synchronous errors so the caller can decide how to react.
+ *
+ * Bun's `FileSink` may throw synchronously (most reliably on Windows) when
+ * the read end of the pipe has been closed by a subprocess that exited
+ * between read-loop ticks. Letting that throw escape an `async` method
+ * surfaces as an unhandled promise rejection at the call site.
+ *
+ * Returns `true` when the frame was accepted by the sink, `false` when the
+ * sink threw — callers signal transport closure on `false`.
+ */
+export function writeFrame(stdin: FrameSink, frame: string): boolean {
+	try {
+		stdin.write(frame);
+		stdin.flush();
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 /**
  * Stdio transport for MCP servers.
  * Spawns a subprocess and communicates via stdin/stdout.
@@ -162,11 +190,7 @@ export class StdioTransport implements MCPTransport {
 			const result = await this.onRequest(request.method, request.params);
 			this.#sendResponse(request.id, result);
 		} catch (error) {
-			try {
-				this.#sendResponse(request.id, undefined, toJsonRpcError(error));
-			} catch {
-				// Best-effort — process may have exited
-			}
+			this.#sendResponse(request.id, undefined, toJsonRpcError(error));
 		}
 	}
 
@@ -175,8 +199,9 @@ export class StdioTransport implements MCPTransport {
 		const response = error
 			? { jsonrpc: "2.0" as const, id, error }
 			: { jsonrpc: "2.0" as const, id, result: result ?? {} };
-		this.#process.stdin.write(`${JSON.stringify(response)}\n`);
-		this.#process.stdin.flush();
+		// Silent on failure — a dead subprocess has no use for the response,
+		// and the read loop will close the transport on EOF.
+		writeFrame(this.#process.stdin, `${JSON.stringify(response)}\n`);
 	}
 
 	#handleClose(): void {
@@ -286,10 +311,15 @@ export class StdioTransport implements MCPTransport {
 			params: params ?? {},
 		};
 
-		const message = `${JSON.stringify(notification)}\n`;
-		// Bun's FileSink has write() method directly
-		this.#process.stdin.write(message);
-		this.#process.stdin.flush();
+		// Bun's FileSink can throw EPIPE synchronously on Windows when the
+		// subprocess has exited between the last read-loop tick and this
+		// write (e.g. an MCP server that dies after returning `initialize`
+		// but before `notifications/initialized` is delivered). Treat any
+		// such failure as transport closure so the reconnect machinery
+		// engages instead of leaking an unhandled rejection — see #1710.
+		if (!writeFrame(this.#process.stdin, `${JSON.stringify(notification)}\n`)) {
+			this.#handleClose();
+		}
 	}
 
 	async close(): Promise<void> {

--- a/packages/coding-agent/test/mcp-stdio-transport.test.ts
+++ b/packages/coding-agent/test/mcp-stdio-transport.test.ts
@@ -180,3 +180,83 @@ describe("StdioTransport.notify", () => {
 		}
 	});
 });
+
+// ---------------------------------------------------------------------------
+// StdioTransport.close — authoritative resource teardown that must keep
+// cleaning up the subprocess and read loop even when `#handleClose()` has
+// already flipped `#connected` (read-loop EOF, or a notify() write failure
+// in the connectToServer() failure path). See PR #1711 follow-up.
+//
+// Bun's parent-side stdout reader only sees EOF when the subprocess
+// actually exits, so the "subprocess closed its stdout but stayed alive"
+// state we'd love to test directly cannot be reproduced through a real
+// subprocess on this platform. Instead we exercise the post-handleClose
+// code path via the natural read-loop-EOF route and pair it with explicit
+// idempotency checks; the reviewer-flagged leak surfaces on Windows where
+// the notify() write actually throws.
+// ---------------------------------------------------------------------------
+
+describe("StdioTransport.close", () => {
+	let transport: StdioTransport | undefined;
+
+	afterEach(async () => {
+		await transport?.close().catch(() => {});
+		transport = undefined;
+	});
+
+	it("completes cleanup when called after the read loop has already torn down", async () => {
+		// Subprocess exits cleanly; the read loop sees EOF and fires
+		// `#handleClose()`, flipping `#connected` to false. `close()` then
+		// runs in exactly the state the reviewer flagged — `#connected`
+		// already false, `#process` and `#readLoop` still set — and must
+		// still null them out instead of early-returning.
+		transport = new StdioTransport({
+			type: "stdio",
+			command: "bun",
+			args: ["-e", "process.exit(0)"],
+		});
+
+		let closeCount = 0;
+		transport.onClose = () => {
+			closeCount++;
+		};
+
+		await transport.connect();
+
+		// Wait for the read loop to observe EOF and fire #handleClose.
+		for (let i = 0; i < 100 && transport.connected; i++) {
+			await Bun.sleep(10);
+		}
+		expect(transport.connected).toBe(false);
+		expect(closeCount).toBe(1);
+
+		// Must not throw and must not re-fire onClose.
+		await transport.close();
+		expect(closeCount).toBe(1);
+
+		// Second close is a no-op too — every resource is already released.
+		await transport.close();
+		expect(closeCount).toBe(1);
+	});
+
+	it("is idempotent — repeat close() calls fire onClose exactly once", async () => {
+		transport = new StdioTransport({
+			type: "stdio",
+			command: "bun",
+			args: ["-e", "await Bun.sleep(60_000)"],
+		});
+
+		let closeCount = 0;
+		transport.onClose = () => {
+			closeCount++;
+		};
+
+		await transport.connect();
+		await transport.close();
+		await transport.close();
+		await transport.close();
+
+		expect(closeCount).toBe(1);
+		expect(transport.connected).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/mcp-stdio-transport.test.ts
+++ b/packages/coding-agent/test/mcp-stdio-transport.test.ts
@@ -2,9 +2,9 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { StdioTransport, writeFrame } from "../src/mcp/transports/stdio";
 
 // ---------------------------------------------------------------------------
-// writeFrame — the seam that swallows synchronous FileSink failures so the
-// async `notify` / `#sendResponse` paths can never leak unhandled rejections
-// when an MCP subprocess exits between read-loop ticks. See issue #1710.
+// writeFrame — the seam that catches synchronous FileSink failures so the
+// async `notify` / `#sendResponse` paths can decide whether to swallow or
+// surface the error. See issue #1710.
 // ---------------------------------------------------------------------------
 
 describe("writeFrame", () => {
@@ -68,12 +68,19 @@ describe("writeFrame", () => {
 });
 
 // ---------------------------------------------------------------------------
-// StdioTransport.notify — guards and end-to-end behavior with a real
-// subprocess that exits between the `initialize` response and the
-// `notifications/initialized` send. The harness can't directly reproduce the
-// Windows EPIPE on Linux (Bun's FileSink absorbs it), but the contract we
-// defend is platform-independent: no unhandled rejection ever escapes
-// notify(), even when the read loop hasn't yet flipped #connected.
+// StdioTransport.notify — end-to-end behavior against a real subprocess that
+// exits between the `initialize` response and the `notifications/initialized`
+// send. Contract defended here:
+//
+//   1. notify() always settles — no unhandled rejection ever escapes when
+//      the underlying FileSink throws synchronously.
+//   2. A failed write tears the transport down (`onClose` fires) AND surfaces
+//      a rejection to the caller so `initializeConnection()` doesn't return a
+//      "connected" handle wrapping a dead transport.
+//
+// On Linux, Bun's FileSink absorbs the EPIPE so the only failure surfaced is
+// the "Transport not connected" guard on subsequent calls; on Windows the
+// write actually throws. Either way the tracker must stay empty.
 // ---------------------------------------------------------------------------
 
 function trackUnhandled(): { release: () => unknown[]; capture: () => unknown[] } {
@@ -152,24 +159,22 @@ describe("StdioTransport.notify", () => {
 		try {
 			await transport.connect();
 			await transport.request("initialize", {});
-
 			// Fire several notifies — covers both the "subprocess just exited"
-			// race and the "already torn down" guard path. None may yield an
-			// unhandled rejection.
+			// race (write may fail) and the "already torn down" guard path
+			// (subsequent calls reject with `Transport not connected`). Every
+			// rejection is handled here; the contract under test is that none
+			// of them leak as an unhandled rejection.
 			for (let i = 0; i < 5; i++) {
-				await transport.notify("notifications/initialized").catch(err => {
-					// Re-throwing "Transport not connected" is fine (handled).
-					if (!(err instanceof Error) || err.message !== "Transport not connected") {
-						throw err;
-					}
-				});
+				await transport.notify("notifications/initialized").catch(() => {});
 			}
 
-			// Let any deferred microtasks settle.
+			// Let any deferred microtasks settle so an escaped rejection has
+			// a chance to fire `unhandledRejection` before we assert.
 			await Bun.sleep(50);
 
 			expect(tracker.capture()).toEqual([]);
 			expect(closed).toBe(true);
+			expect(transport.connected).toBe(false);
 		} finally {
 			tracker.release();
 		}

--- a/packages/coding-agent/test/mcp-stdio-transport.test.ts
+++ b/packages/coding-agent/test/mcp-stdio-transport.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { StdioTransport, writeFrame } from "../src/mcp/transports/stdio";
+
+// ---------------------------------------------------------------------------
+// writeFrame — the seam that swallows synchronous FileSink failures so the
+// async `notify` / `#sendResponse` paths can never leak unhandled rejections
+// when an MCP subprocess exits between read-loop ticks. See issue #1710.
+// ---------------------------------------------------------------------------
+
+describe("writeFrame", () => {
+	it("writes and flushes, returning true on success", () => {
+		const sink = {
+			writes: [] as string[],
+			flushed: 0,
+			write(chunk: string) {
+				this.writes.push(chunk);
+			},
+			flush() {
+				this.flushed++;
+			},
+		};
+
+		expect(writeFrame(sink, '{"k":1}\n')).toBe(true);
+		expect(sink.writes).toEqual(['{"k":1}\n']);
+		expect(sink.flushed).toBe(1);
+	});
+
+	it("returns false when write() throws synchronously (broken pipe)", () => {
+		const sink = {
+			flushed: 0,
+			write() {
+				throw new Error("EPIPE: broken pipe, write");
+			},
+			flush() {
+				this.flushed++;
+			},
+		};
+
+		expect(writeFrame(sink, "anything\n")).toBe(false);
+		expect(sink.flushed).toBe(0);
+	});
+
+	it("returns false when flush() throws after a successful write", () => {
+		const sink = {
+			writes: [] as string[],
+			write(chunk: string) {
+				this.writes.push(chunk);
+			},
+			flush() {
+				throw new Error("EPIPE: broken pipe, flush");
+			},
+		};
+
+		expect(writeFrame(sink, "anything\n")).toBe(false);
+		expect(sink.writes).toEqual(["anything\n"]);
+	});
+
+	it("does not propagate non-Error throws either", () => {
+		const sink = {
+			write() {
+				throw "string-thrown-non-error";
+			},
+			flush() {},
+		};
+
+		expect(writeFrame(sink, "x")).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// StdioTransport.notify — guards and end-to-end behavior with a real
+// subprocess that exits between the `initialize` response and the
+// `notifications/initialized` send. The harness can't directly reproduce the
+// Windows EPIPE on Linux (Bun's FileSink absorbs it), but the contract we
+// defend is platform-independent: no unhandled rejection ever escapes
+// notify(), even when the read loop hasn't yet flipped #connected.
+// ---------------------------------------------------------------------------
+
+function trackUnhandled(): { release: () => unknown[]; capture: () => unknown[] } {
+	const seen: unknown[] = [];
+	const listener = (reason: unknown) => {
+		seen.push(reason);
+	};
+	process.on("unhandledRejection", listener);
+	return {
+		release: () => {
+			process.off("unhandledRejection", listener);
+			return seen.slice();
+		},
+		capture: () => seen.slice(),
+	};
+}
+
+describe("StdioTransport.notify", () => {
+	let transport: StdioTransport | undefined;
+
+	afterEach(async () => {
+		await transport?.close().catch(() => {});
+		transport = undefined;
+	});
+
+	it("rejects synchronously when called before connect()", async () => {
+		transport = new StdioTransport({
+			type: "stdio",
+			command: "bun",
+			args: ["-e", "process.exit(0)"],
+		});
+
+		await expect(transport.notify("noop")).rejects.toThrow("Transport not connected");
+	});
+
+	it("rejects with 'Transport not connected' after close()", async () => {
+		transport = new StdioTransport({
+			type: "stdio",
+			command: "bun",
+			args: ["-e", "await Bun.sleep(60_000)"],
+		});
+
+		await transport.connect();
+		await transport.close();
+
+		await expect(transport.notify("noop")).rejects.toThrow("Transport not connected");
+	});
+
+	it("does not surface unhandled rejections when the subprocess exits mid-handshake", async () => {
+		// Subprocess that responds to a single line on stdin, echoes a stock
+		// initialize response, then exits. Mirrors the real-world MCP server
+		// that crashes between the initialize response and the
+		// notifications/initialized that the client sends right after.
+		const script = [
+			'let buf = "";',
+			'process.stdin.on("data", (chunk) => {',
+			"  buf += chunk;",
+			'  const nl = buf.indexOf("\\n");',
+			"  if (nl < 0) return;",
+			"  const line = buf.slice(0, nl);",
+			"  const msg = JSON.parse(line);",
+			"  process.stdout.write(",
+			'    JSON.stringify({ jsonrpc: "2.0", id: msg.id, result: {} }) + "\\n",',
+			"  );",
+			"  process.exit(0);",
+			"});",
+		].join("\n");
+
+		const tracker = trackUnhandled();
+		transport = new StdioTransport({ type: "stdio", command: "bun", args: ["-e", script] });
+		let closed = false;
+		transport.onClose = () => {
+			closed = true;
+		};
+
+		try {
+			await transport.connect();
+			await transport.request("initialize", {});
+
+			// Fire several notifies — covers both the "subprocess just exited"
+			// race and the "already torn down" guard path. None may yield an
+			// unhandled rejection.
+			for (let i = 0; i < 5; i++) {
+				await transport.notify("notifications/initialized").catch(err => {
+					// Re-throwing "Transport not connected" is fine (handled).
+					if (!(err instanceof Error) || err.message !== "Transport not connected") {
+						throw err;
+					}
+				});
+			}
+
+			// Let any deferred microtasks settle.
+			await Bun.sleep(50);
+
+			expect(tracker.capture()).toEqual([]);
+			expect(closed).toBe(true);
+		} finally {
+			tracker.release();
+		}
+	});
+});


### PR DESCRIPTION
## Repro

When an MCP stdio server exits between returning the `initialize` response and receiving the client's `notifications/initialized`, `StdioTransport.notify()` writes to a broken pipe. On Bun-Windows, the underlying `FileSink.write()` throws `EPIPE: broken pipe, write` synchronously, and because the call is inside an `async` method without a `try/catch`, the rejection escapes the caller chain in `initializeConnection()` and shows up as `[Unhandled Rejection]`. Reproduced in the wild on Windows 11 with `@modelcontextprotocol/server-github` and `@playwright/mcp` discovered from `~/.claude.json`.

## Cause

`packages/coding-agent/src/mcp/transports/stdio.ts`:

- `notify()` (the pre-fix `:278`) and `#sendResponse()` (the pre-fix `:173`) wrote to `this.#process.stdin` with no error handling, while the sibling `request()` (the pre-fix `:266`) already wrapped the same `write`/`flush` pair.
- The `#connected` guard cannot close the race: `connect()` sets it synchronously; `#handleClose()` only clears it from the read loop's `finally` after EOF on stdout — strictly later than the parent's next stdin write. Bun-Linux's `FileSink` happens to absorb the error, which is why the bug only manifested on Bun-Windows; the defect is platform-independent.

## Fix

- Add a top-level `writeFrame(stdin, frame): boolean` helper that wraps `write` + `flush` in a `try/catch` and reports success/failure to the caller.
- `notify()` routes through `writeFrame`; on failure it calls `#handleClose()` so the reconnect machinery engages instead of leaving an unhandled rejection (and a stuck `#connected = true`).
- `#sendResponse()` routes through `writeFrame` and stays silent on failure — a dead subprocess has no use for the response and the read loop will tear down on EOF.
- Drop the now-redundant inner `try/catch` that wrapped `#sendResponse` inside `#handleServerRequest()`.
- New test file `test/mcp-stdio-transport.test.ts` covers (a) the `writeFrame` helper directly (success, `write`-throws, `flush`-throws, non-`Error` throws) and (b) `StdioTransport.notify()` end-to-end against a real subprocess that exits between `initialize` and `notifications/initialized` — asserting zero unhandled rejections and that `onClose` fires.

## Verification

- `bun test test/mcp-stdio-transport.test.ts` → 7 pass.
- `bun test test/mcp-stdio-transport.test.ts test/mcp-reconnect.test.ts test/mcp-reconnect-storm.test.ts test/mcp-http-transport.test.ts test/mcp-timeout.test.ts test/mcp-tool-ordering.test.ts test/mcp-roots-list.test.ts test/mcp-manager-subscription-action.test.ts` → 72 pass.
- `bun --cwd=packages/coding-agent run check` → clean.

Fixes #1710