### PR TITLE
fix(ai): normalize nullable scalar tool schemas

### DIFF
--- a/packages/ai/src/utils/schema/wire.ts
+++ b/packages/ai/src/utils/schema/wire.ts
@@ -68,7 +68,13 @@ const kJsonWireSchema = Symbol("pi.schema.json.wire");
  */
 function postProcess(schema: Record<string, unknown>): Record<string, unknown> {
 	delete schema.$schema;
-	walk(schema);
+	walk(schema, true);
+	normalizeEmptySchemas(schema);
+	return schema;
+}
+
+function postProcessJsonSchema(schema: Record<string, unknown>): Record<string, unknown> {
+	walk(schema, false);
 	normalizeEmptySchemas(schema);
 	return schema;
 }
@@ -176,40 +182,42 @@ function isEmptyObject(val: unknown): val is Record<string, never> {
 	return Object.keys(val).length === 0;
 }
 
-function walk(node: unknown): void {
+function walk(node: unknown, zodCleanup: boolean): void {
 	if (Array.isArray(node)) {
-		for (const child of node) walk(child);
+		for (const child of node) walk(child, zodCleanup);
 		return;
 	}
 	if (!node || typeof node !== "object") return;
 	const obj = node as Record<string, unknown>;
 	rewriteNullableScalarAnyOf(obj);
 
-	// Drop noise injected for `z.number().int()`.
-	if (hasIntegerType(obj.type)) {
-		if (obj.minimum === SAFE_INTEGER_MIN) delete obj.minimum;
-		if (obj.maximum === SAFE_INTEGER_MAX) delete obj.maximum;
-	}
+	if (zodCleanup) {
+		// Drop noise injected for `z.number().int()`.
+		if (hasIntegerType(obj.type)) {
+			if (obj.minimum === SAFE_INTEGER_MIN) delete obj.minimum;
+			if (obj.maximum === SAFE_INTEGER_MAX) delete obj.maximum;
+		}
 
-	// Make defaulted properties non-required.
-	if (Array.isArray(obj.required) && obj.properties && typeof obj.properties === "object") {
-		const properties = obj.properties as Record<string, unknown>;
-		const required = obj.required as string[];
-		const filtered = required.filter(name => {
-			const propertySchema = properties[name];
-			if (!propertySchema || typeof propertySchema !== "object") return true;
-			return !("default" in (propertySchema as Record<string, unknown>));
-		});
-		if (filtered.length !== required.length) {
-			if (filtered.length === 0) {
-				delete obj.required;
-			} else {
-				obj.required = filtered;
+		// Make defaulted properties non-required.
+		if (Array.isArray(obj.required) && obj.properties && typeof obj.properties === "object") {
+			const properties = obj.properties as Record<string, unknown>;
+			const required = obj.required as string[];
+			const filtered = required.filter(name => {
+				const propertySchema = properties[name];
+				if (!propertySchema || typeof propertySchema !== "object") return true;
+				return !("default" in (propertySchema as Record<string, unknown>));
+			});
+			if (filtered.length !== required.length) {
+				if (filtered.length === 0) {
+					delete obj.required;
+				} else {
+					obj.required = filtered;
+				}
 			}
 		}
 	}
 
-	for (const k in obj) walk(obj[k]);
+	for (const k in obj) walk(obj[k], zodCleanup);
 }
 
 /**
@@ -272,8 +280,7 @@ export function zodToWireSchema(schema: ZodType): Record<string, unknown> {
  * over the wire. Zod schemas are converted (and cached); legacy TypeBox / raw
  * JSON Schema parameters are upgraded to draft 2020-12 (and cached).
  *
- * Both branches finish with `postProcess` so every provider — OpenAI,
- * Anthropic, Google, Ollama, Bedrock, Cursor — sees the same normalized
+ * Zod schemas also receive Zod-artifact cleanup; both branches normalize
  * schema-valued positions and nullable scalar unions.
  */
 export function toolWireSchema(tool: Tool): Record<string, unknown> {
@@ -281,6 +288,6 @@ export function toolWireSchema(tool: Tool): Record<string, unknown> {
 	if (isZodSchema(params)) return zodToWireSchema(params);
 	return stamp(params as Record<string, unknown>, kJsonWireSchema, p => {
 		const upgraded = upgradeJsonSchemaTo202012(p) as Record<string, unknown>;
-		return postProcess(upgraded);
+		return postProcessJsonSchema(upgraded);
 	});
 }

--- a/packages/ai/src/utils/schema/wire.ts
+++ b/packages/ai/src/utils/schema/wire.ts
@@ -75,6 +75,80 @@ function postProcess(schema: Record<string, unknown>): Record<string, unknown> {
 
 const SAFE_INTEGER_MAX = Number.MAX_SAFE_INTEGER;
 const SAFE_INTEGER_MIN = Number.MIN_SAFE_INTEGER;
+const NULLABLE_SCALAR_TYPES = new Set(["string", "number", "integer", "boolean"]);
+
+const SCHEMA_DEFINING_SIBLING_KEYS = new Set([
+	"$ref",
+	"additionalProperties",
+	"allOf",
+	"anyOf",
+	"const",
+	"contains",
+	"enum",
+	"if",
+	"items",
+	"not",
+	"oneOf",
+	"patternProperties",
+	"prefixItems",
+	"properties",
+	"propertyNames",
+	"then",
+	"else",
+	"unevaluatedItems",
+	"unevaluatedProperties",
+]);
+
+function isSchemaRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasSchemaDefiningSibling(schema: Record<string, unknown>): boolean {
+	for (const key in schema) {
+		if (key !== "anyOf" && SCHEMA_DEFINING_SIBLING_KEYS.has(key)) return true;
+	}
+	return false;
+}
+
+function isNullVariant(schema: Record<string, unknown>): boolean {
+	return schema.type === "null" && Object.keys(schema).length === 1;
+}
+
+function isScalarVariant(schema: Record<string, unknown>): schema is Record<string, unknown> & { type: string } {
+	return typeof schema.type === "string" && NULLABLE_SCALAR_TYPES.has(schema.type);
+}
+
+function hasIntegerType(type: unknown): boolean {
+	return type === "integer" || (Array.isArray(type) && type.includes("integer"));
+}
+
+function rewriteNullableScalarAnyOf(schema: Record<string, unknown>): void {
+	if (hasSchemaDefiningSibling(schema)) return;
+	const variants = schema.anyOf;
+	if (!Array.isArray(variants) || variants.length !== 2) return;
+
+	let scalarVariant: Record<string, unknown> | undefined;
+	let scalarType: string | undefined;
+	let sawNull = false;
+	for (const variant of variants) {
+		if (!isSchemaRecord(variant)) return;
+		if (isNullVariant(variant)) {
+			if (sawNull) return;
+			sawNull = true;
+			continue;
+		}
+		if (!isScalarVariant(variant) || scalarVariant) return;
+		scalarVariant = variant;
+		scalarType = variant.type;
+	}
+	if (!sawNull || !scalarVariant || !scalarType) return;
+
+	delete schema.anyOf;
+	for (const key in scalarVariant) {
+		if (key !== "type" && !Object.hasOwn(schema, key)) schema[key] = scalarVariant[key];
+	}
+	schema.type = [scalarType, "null"];
+}
 
 /** Keys whose values are a single JSON Schema (not an array or map). */
 const SCHEMA_VALUE_KEYS = [
@@ -109,9 +183,10 @@ function walk(node: unknown): void {
 	}
 	if (!node || typeof node !== "object") return;
 	const obj = node as Record<string, unknown>;
+	rewriteNullableScalarAnyOf(obj);
 
 	// Drop noise injected for `z.number().int()`.
-	if (obj.type === "integer") {
+	if (hasIntegerType(obj.type)) {
 		if (obj.minimum === SAFE_INTEGER_MIN) delete obj.minimum;
 		if (obj.maximum === SAFE_INTEGER_MAX) delete obj.maximum;
 	}
@@ -197,16 +272,15 @@ export function zodToWireSchema(schema: ZodType): Record<string, unknown> {
  * over the wire. Zod schemas are converted (and cached); legacy TypeBox / raw
  * JSON Schema parameters are upgraded to draft 2020-12 (and cached).
  *
- * Both branches finish with `normalizeEmptySchemas` so every provider —
- * OpenAI, Anthropic, Google, Ollama, Bedrock, Cursor — sees `{}` normalized
- * to `true` in schema-valued positions (issue #1179).
+ * Both branches finish with `postProcess` so every provider — OpenAI,
+ * Anthropic, Google, Ollama, Bedrock, Cursor — sees the same normalized
+ * schema-valued positions and nullable scalar unions.
  */
 export function toolWireSchema(tool: Tool): Record<string, unknown> {
 	const params: TSchema = tool.parameters;
 	if (isZodSchema(params)) return zodToWireSchema(params);
 	return stamp(params as Record<string, unknown>, kJsonWireSchema, p => {
 		const upgraded = upgradeJsonSchemaTo202012(p) as Record<string, unknown>;
-		normalizeEmptySchemas(upgraded);
-		return upgraded;
+		return postProcess(upgraded);
 	});
 }

--- a/packages/ai/test/schema-wire.test.ts
+++ b/packages/ai/test/schema-wire.test.ts
@@ -203,6 +203,27 @@ describe("toolWireSchema — empty-schema normalization across both paths", () =
 			minimum: 0,
 		});
 	});
+
+	it("preserves raw JSON Schema required defaults and safe-integer bounds", () => {
+		const wire = toolWireSchema(
+			jsonTool({
+				type: "object",
+				properties: {
+					mode: { type: "string", default: "fast" },
+					limit: {
+						type: "integer",
+						minimum: Number.MIN_SAFE_INTEGER,
+						maximum: Number.MAX_SAFE_INTEGER,
+					},
+				},
+				required: ["mode", "limit"],
+			}),
+		);
+		expect(wire.required).toEqual(["mode", "limit"]);
+		const limit = (wire.properties as Record<string, unknown>).limit as Record<string, unknown>;
+		expect(limit.minimum).toBe(Number.MIN_SAFE_INTEGER);
+		expect(limit.maximum).toBe(Number.MAX_SAFE_INTEGER);
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/ai/test/schema-wire.test.ts
+++ b/packages/ai/test/schema-wire.test.ts
@@ -90,6 +90,33 @@ describe("zodToWireSchema — empty-schema normalization", () => {
 	});
 });
 
+describe("zodToWireSchema — nullable scalar normalization", () => {
+	it("rewrites nullable scalar anyOf to a type array while preserving metadata", () => {
+		const schema = z.object({ skip: z.number().nullable().describe("matches to skip") });
+		const wire = zodToWireSchema(schema);
+		const skip = (wire.properties as Record<string, unknown>).skip as Record<string, unknown>;
+		expect(skip).toEqual({
+			type: ["number", "null"],
+			description: "matches to skip",
+		});
+	});
+
+	it("keeps nullable integers free of Zod safe-integer bounds", () => {
+		const schema = z.object({ count: z.number().int().nullable() });
+		const wire = zodToWireSchema(schema);
+		const count = (wire.properties as Record<string, unknown>).count as Record<string, unknown>;
+		expect(count).toEqual({ type: ["integer", "null"] });
+	});
+
+	it("leaves mixed nullable unions as anyOf", () => {
+		const schema = z.object({ value: z.union([z.string(), z.number()]).nullable() });
+		const wire = zodToWireSchema(schema);
+		const value = (wire.properties as Record<string, unknown>).value as Record<string, unknown>;
+		expect(value.type).toBeUndefined();
+		expect(Array.isArray(value.anyOf)).toBe(true);
+	});
+});
+
 // ---------------------------------------------------------------------------
 // normalizeEmptySchemas — provider-agnostic post-pipeline normalization
 // ---------------------------------------------------------------------------
@@ -154,6 +181,27 @@ describe("toolWireSchema — empty-schema normalization across both paths", () =
 		);
 		const extra = (wire.properties as Record<string, unknown>).extra as Record<string, unknown>;
 		expect(extra.additionalProperties).toBe(true);
+	});
+
+	it("normalizes nullable scalar anyOf for TypeBox / raw JSON Schema tools", () => {
+		const wire = toolWireSchema(
+			jsonTool({
+				type: "object",
+				properties: {
+					skip: {
+						anyOf: [{ type: "number", minimum: 0 }, { type: "null" }],
+						description: "matches to skip",
+					},
+				},
+				required: ["skip"],
+			}),
+		);
+		const skip = (wire.properties as Record<string, unknown>).skip as Record<string, unknown>;
+		expect(skip).toEqual({
+			type: ["number", "null"],
+			description: "matches to skip",
+			minimum: 0,
+		});
 	});
 });
 


### PR DESCRIPTION
## Repro
`bun -e 'import { z } from "zod/v4"; import { zodToWireSchema } from "@oh-my-pi/pi-ai/utils/schema"; const wire = zodToWireSchema(z.object({ skip: z.number().nullable().describe("matches to skip") })); console.log(JSON.stringify(wire.properties.skip, null, 2)); process.exit(wire.properties.skip.anyOf && !wire.properties.skip.type ? 0 : 1);'` reproduced the failing wire shape: nullable scalar properties emitted `anyOf: [{ type: "number" }, { type: "null" }]` with no sibling `type`.

## Cause
`packages/ai/src/utils/schema/wire.ts` only normalized empty schemas and a few Zod artifacts after `z.toJSONSchema`, so nullable scalar schemas authored through Zod or raw JSON Schema kept provider-visible `anyOf` wrappers. DeepSeek's OpenRouter validator rejects those property schemas because the `anyOf` node has no sibling `type`.

## Fix
- Added wire post-processing for nullable scalar `anyOf` nodes, rewriting exactly one scalar branch plus one `{ type: "null" }` branch into `type: [<scalar>, "null"]` while preserving metadata and scalar constraints.
- Ran the same wire post-processing on upgraded raw/TypeBox JSON Schema parameters so extension tools are covered too.
- Added regression coverage for Zod nullable scalars, Zod nullable integers, raw JSON Schema nullable scalars, and mixed nullable unions that must stay as `anyOf`.

## Verification
`bun test packages/ai/test/schema-wire.test.ts packages/ai/test/google-tool-schema.test.ts packages/ai/test/anthropic-tool-schema.test.ts packages/ai/test/openai-tool-strict-mode.test.ts` passed with 88 tests. `bun run check` passed in `packages/ai`. The repro command now emits `type: ["number", "null"]` and no `anyOf`. Fixes #1712