### PR TITLE
fix(tui): defer VTE eager scrollback rebuilds

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Deferred eager live scrollback rebuilds on VTE terminals so GNOME-style Linux terminals do not flash or erase readable scrollback during streaming ([#1719](https://github.com/can1357/oh-my-pi/issues/1719)).
+
 ## [15.8.0] - 2026-06-02
 
 ### Fixed

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -140,14 +140,14 @@ export function shouldTrustNativeViewportProbe(
  *
  * A TUI history rebuild emits xterm ED3 (`CSI 3 J`, erase saved lines). On the
  * terminals below, ED3 can disturb a reader parked in native scrollback during
- * streaming: kitty/ghostty/alacritty clamp the scroll offset back to the active
- * tail when saved lines are erased, and WezTerm is the reported POSIX host for
- * #1682. Defer only the eager streaming opt-in on these hosts; direct
+ * streaming: kitty/ghostty/alacritty/VTE clamp the scroll offset back to the
+ * active tail when saved lines are erased, and WezTerm is the reported POSIX
+ * host for #1682. Defer only the eager streaming opt-in on these hosts; direct
  * user-input renders and explicit checkpoint rebuilds still pass their own
  * `allowUnknownViewportMutation` / `allowUnknownViewport` flags.
  *
  * Pure helper for unit testing; the runtime call site reads `$env` /
- * `process.platform`. See #1682.
+ * `process.platform`. See #1682 and #1719.
  */
 export function terminalHasEagerEraseScrollbackRisk(
 	env: {
@@ -155,12 +155,19 @@ export function terminalHasEagerEraseScrollbackRisk(
 		KITTY_WINDOW_ID?: string | undefined;
 		GHOSTTY_RESOURCES_DIR?: string | undefined;
 		ALACRITTY_WINDOW_ID?: string | undefined;
+		VTE_VERSION?: string | undefined;
 		TERM_PROGRAM?: string | undefined;
 	} = $env,
 	platform: NodeJS.Platform = process.platform,
 ): boolean {
 	if (platform === "win32") return false;
-	if (env.WEZTERM_PANE || env.KITTY_WINDOW_ID || env.GHOSTTY_RESOURCES_DIR || env.ALACRITTY_WINDOW_ID) {
+	if (
+		env.WEZTERM_PANE ||
+		env.KITTY_WINDOW_ID ||
+		env.GHOSTTY_RESOURCES_DIR ||
+		env.ALACRITTY_WINDOW_ID ||
+		env.VTE_VERSION
+	) {
 		return true;
 	}
 	const termProgram = env.TERM_PROGRAM?.toLowerCase();

--- a/packages/tui/test/issue-1682-repro.test.ts
+++ b/packages/tui/test/issue-1682-repro.test.ts
@@ -9,9 +9,9 @@ import { VirtualTerminal } from "./virtual-terminal";
 // `isNativeViewportAtBottom()` as `undefined`. The streaming eager-rebuild mode
 // intentionally used that unknown answer as permission to rewrite native
 // scrollback, but the rewrite emits xterm ED3 (`CSI 3 J`, erase saved lines).
-// On WezTerm/kitty/ghostty/alacritty this can disrupt a reader scrolled into
-// native history while assistant/tool output is still streaming. The eager flag
-// must therefore defer on those hosts, while ordinary POSIX terminals and
+// On WezTerm/kitty/ghostty/alacritty/VTE this can disrupt a reader scrolled
+// into native history while assistant/tool output is still streaming. The eager
+// flag must therefore defer on those hosts, while ordinary POSIX terminals and
 // direct user-input opt-ins keep their existing rebuild behavior.
 class LineList implements Component {
 	#lines: string[];
@@ -93,6 +93,7 @@ const CLEAR_TERMINAL_RISK_ENV: Record<string, string | undefined> = {
 	KITTY_WINDOW_ID: undefined,
 	GHOSTTY_RESOURCES_DIR: undefined,
 	ALACRITTY_WINDOW_ID: undefined,
+	VTE_VERSION: undefined,
 	TERM_PROGRAM: undefined,
 	TMUX: undefined,
 	STY: undefined,
@@ -110,6 +111,7 @@ describe("issue #1682: terminalHasEagerEraseScrollbackRisk", () => {
 		expect(terminalHasEagerEraseScrollbackRisk({ KITTY_WINDOW_ID: "1" }, "linux")).toBe(true);
 		expect(terminalHasEagerEraseScrollbackRisk({ GHOSTTY_RESOURCES_DIR: "/ghostty" }, "darwin")).toBe(true);
 		expect(terminalHasEagerEraseScrollbackRisk({ ALACRITTY_WINDOW_ID: "1" }, "darwin")).toBe(true);
+		expect(terminalHasEagerEraseScrollbackRisk({ VTE_VERSION: "7600" }, "linux")).toBe(true);
 		expect(terminalHasEagerEraseScrollbackRisk({ TERM_PROGRAM: "ghostty" }, "linux")).toBe(true);
 	});
 
@@ -126,33 +128,35 @@ describe("issue #1682: terminalHasEagerEraseScrollbackRisk", () => {
 
 describe("issue #1682: TUI eager scrollback rebuild", () => {
 	it("defers on ED3-risk POSIX terminals and rebuilds at the checkpoint", async () => {
-		await withPlatform("linux", async () => {
-			await withEnvPatch({ ...CLEAR_TERMINAL_RISK_ENV, WEZTERM_PANE: "pane-1" }, async () => {
-				const term = new VirtualTerminal(100, 24);
-				overrideProbe(term, undefined);
-				const tui = new TUI(term);
-				const component = new LineList(Array.from({ length: 80 }, (_value, index) => `init-${index}`));
-				tui.addChild(component);
+		for (const patch of [{ WEZTERM_PANE: "pane-1" }, { VTE_VERSION: "7600" }]) {
+			await withPlatform("linux", async () => {
+				await withEnvPatch({ ...CLEAR_TERMINAL_RISK_ENV, ...patch }, async () => {
+					const term = new VirtualTerminal(100, 24);
+					overrideProbe(term, undefined);
+					const tui = new TUI(term);
+					const component = new LineList(Array.from({ length: 80 }, (_value, index) => `init-${index}`));
+					tui.addChild(component);
 
-				try {
-					tui.start();
-					await settle(term);
-					const writes = capture(term);
-					tui.setEagerNativeScrollbackRebuild(true);
+					try {
+						tui.start();
+						await settle(term);
+						const writes = capture(term);
+						tui.setEagerNativeScrollbackRebuild(true);
 
-					component.setLines(Array.from({ length: 20 }, (_value, index) => `shrunk-${index}`));
-					tui.requestRender();
-					await settle(term);
+						component.setLines(Array.from({ length: 20 }, (_value, index) => `shrunk-${index}`));
+						tui.requestRender();
+						await settle(term);
 
-					expect(eraseScrollbackCount(writes)).toBe(0);
-					expect(tui.refreshNativeScrollbackIfDirty({ allowUnknownViewport: true })).toBe(true);
-					await settle(term);
-					expect(eraseScrollbackCount(writes)).toBe(1);
-				} finally {
-					tui.stop();
-				}
+						expect(eraseScrollbackCount(writes)).toBe(0);
+						expect(tui.refreshNativeScrollbackIfDirty({ allowUnknownViewport: true })).toBe(true);
+						await settle(term);
+						expect(eraseScrollbackCount(writes)).toBe(1);
+					} finally {
+						tui.stop();
+					}
+				});
 			});
-		});
+		}
 	});
 
 	it("keeps eager live rebuilds for other POSIX terminals", async () => {


### PR DESCRIPTION
## Repro
With a VTE-style POSIX terminal (`VTE_VERSION=7600`) whose native viewport position is unobservable, an eager streaming rebuild emitted xterm ED3 while output was live. The recorded repro used a Bun virtual-terminal harness (`bun --eval '<instantiate TUI, set VTE_VERSION=7600, force unknown viewport, enable setEagerNativeScrollbackRebuild(true), shrink an 80-line transcript to 20 lines, print ED3 count>'`) and returned `ed3=1` before the fix.

## Cause
`terminalHasEagerEraseScrollbackRisk` in `packages/tui/src/terminal.ts` only treated WezTerm, kitty, ghostty, and alacritty as unsafe for eager live native scrollback rebuilds. Debian’s default GNOME-style terminals are VTE-based and expose `VTE_VERSION`, so they stayed on the eager path; streaming structural changes could run `historyRebuild`, emitting `CSI 3 J` and disturbing scrollback.

## Fix
- Treat `VTE_VERSION` as an ED3-risk POSIX terminal identifier for eager live rebuilds.
- Extend the existing eager scrollback regression test so VTE defers during live streaming and rebuilds only at the explicit checkpoint.
- Add an Unreleased TUI changelog entry for #1719.

## Verification
- `bun test packages/tui/test/issue-1682-repro.test.ts` → 6 pass.
- `bun --cwd=packages/tui run check` → pass.
- Manual repro after the fix returned `ed3=0`. Fixes #1719