### PR TITLE
fix(providers): load special provider model caches at startup

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 
+- Fixed startup model resolution ignoring cached discovery rows for special built-in providers (`google-antigravity`, `google-gemini-cli`, `openai-codex`) until the background refresh completed ([#1721](https://github.com/can1357/oh-my-pi/issues/1721)).
 - Fixed `read`, `search`, `find`, `ast_grep`, and `ast_edit` recovering when a model flattens multiple existing paths into one comma-, semicolon-, or space-delimited string while preserving real paths that contain delimiters.
 - Fixed Exa web search reporting available without Exa credentials, which could route searches into the unauthenticated public MCP fallback and stall before trying the next provider. Availability and `searchExa()` now resolve through the standard `AuthStorage` cascade (`EXA_API_KEY` env or stored credential) ([#1695](https://github.com/can1357/oh-my-pi/issues/1695)).
 - Fixed Anthropic web search ignoring `ANTHROPIC_SEARCH_BASE_URL` when credentials came from stored Anthropic auth or generic Anthropic env fallback rather than `ANTHROPIC_SEARCH_API_KEY` ([#1694](https://github.com/can1357/oh-my-pi/issues/1694)).

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -53,6 +53,17 @@ function discoveryDefaultMaxTokens(api: Api | undefined): number {
 	return api === "anthropic-messages" ? DISCOVERY_DEFAULT_MAX_TOKENS_ANTHROPIC : DISCOVERY_DEFAULT_MAX_TOKENS;
 }
 
+const SPECIAL_MODEL_MANAGER_PROVIDER_IDS: readonly string[] = [
+	"google-antigravity",
+	"google-gemini-cli",
+	"openai-codex",
+];
+
+const STARTUP_MODEL_CACHE_PROVIDER_IDS: readonly string[] = [
+	...PROVIDER_DESCRIPTORS.map(descriptor => descriptor.providerId),
+	...SPECIAL_MODEL_MANAGER_PROVIDER_IDS,
+];
+
 import { registerOAuthProvider, unregisterOAuthProviders } from "@oh-my-pi/pi-ai/utils/oauth";
 import type { OAuthCredentials, OAuthLoginCallbacks } from "@oh-my-pi/pi-ai/utils/oauth/types";
 import { isRecord, logger } from "@oh-my-pi/pi-utils";
@@ -1133,28 +1144,28 @@ export class ModelRegistry {
 		const configuredDiscoveryProviders = new Set(this.#discoverableProviders.map(provider => provider.provider));
 		const cachedModels: Model<Api>[] = [];
 		const authoritativeFreshProviders = new Set<string>();
-		for (const descriptor of PROVIDER_DESCRIPTORS) {
-			if (configuredDiscoveryProviders.has(descriptor.providerId)) {
+		for (const providerId of STARTUP_MODEL_CACHE_PROVIDER_IDS) {
+			if (configuredDiscoveryProviders.has(providerId)) {
 				continue;
 			}
-			const cache = readModelCache<Api>(descriptor.providerId, 24 * 60 * 60 * 1000, Date.now, this.#cacheDbPath);
+			const cache = readModelCache<Api>(providerId, 24 * 60 * 60 * 1000, Date.now, this.#cacheDbPath);
 			if (!cache) {
 				continue;
 			}
 			if (cache.fresh && cache.authoritative) {
-				authoritativeFreshProviders.add(descriptor.providerId);
+				authoritativeFreshProviders.add(providerId);
 			}
 			const models = cache.models.map(model =>
-				model.provider === descriptor.providerId ? model : { ...model, provider: descriptor.providerId },
+				model.provider === providerId ? model : { ...model, provider: providerId },
 			);
-			const providerOverride = this.#providerOverrides.get(descriptor.providerId);
+			const providerOverride = this.#providerOverrides.get(providerId);
 			const withTransport = providerOverride
 				? models.map(model => this.#applyProviderTransportOverride(model, providerOverride))
 				: models;
 			const withCompat = providerOverride?.compat
 				? withTransport.map(model => ({ ...model, compat: mergeCompat(model.compat, providerOverride.compat) }))
 				: withTransport;
-			cachedModels.push(...this.#applyProviderModelOverrides(descriptor.providerId, withCompat));
+			cachedModels.push(...this.#applyProviderModelOverrides(providerId, withCompat));
 		}
 		return { models: cachedModels, authoritativeFreshProviders };
 	}

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -2268,6 +2268,56 @@ describe("ModelRegistry", () => {
 		expect(registry.find("ollama-cloud", "deepseek-v4-pro")?.maxTokens).toBe(384_000);
 	});
 
+	test("loads cached special provider discovery models on startup", () => {
+		const cachedModels: Model[] = [
+			{
+				id: "gemini-3.5-flash-low",
+				name: "Gemini 3.5 Flash Low",
+				api: "google-gemini-cli",
+				provider: "google-antigravity",
+				baseUrl: "https://cloudcode-pa.googleapis.com",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 1_000_000,
+				maxTokens: 8_192,
+			},
+			{
+				id: "gemini-3.5-flash",
+				name: "Gemini 3.5 Flash",
+				api: "google-gemini-cli",
+				provider: "google-gemini-cli",
+				baseUrl: "https://cloudcode-pa.googleapis.com",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 1_000_000,
+				maxTokens: 16_384,
+			},
+			{
+				id: "gpt-5.4-codex-pro",
+				name: "GPT-5.4 Codex Pro",
+				api: "openai-codex-responses",
+				provider: "openai-codex",
+				baseUrl: "https://chatgpt.com/backend-api/codex",
+				reasoning: true,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 400_000,
+				maxTokens: 128_000,
+			},
+		];
+		for (const cachedModel of cachedModels) {
+			writeModelCache(cachedModel.provider, Date.now(), [cachedModel], true, "", cacheDbPath);
+		}
+
+		const registry = new ModelRegistry(authStorage, modelsJsonPath);
+
+		expect(registry.find("google-antigravity", "gemini-3.5-flash-low")?.maxTokens).toBe(8_192);
+		expect(registry.find("google-gemini-cli", "gemini-3.5-flash")?.maxTokens).toBe(16_384);
+		expect(registry.find("openai-codex", "gpt-5.4-codex-pro")?.maxTokens).toBe(128_000);
+	});
+
 	test("replaces bundled google-vertex models with authoritative Vertex project discovery", () => {
 		const cachedModel: Model<"openai-completions"> = {
 			id: "zai-org/glm-4.7-maas",


### PR DESCRIPTION
## Repro
A fresh `ModelRegistry` constructed with a `models.db` row for `google-antigravity/gemini-3.5-flash-low` returned no model before refresh: `bun --cwd=packages/coding-agent --eval '...writeModelCache("google-antigravity", ...); new ModelRegistry(...); registry.find("google-antigravity", "gemini-3.5-flash-low")...'` printed `missing` and exited 1.

## Cause
`packages/coding-agent/src/config/model-registry.ts` loaded startup cache rows in `ModelRegistry.#loadCachedStandardProviderModels()` by iterating only `PROVIDER_DESCRIPTORS`. Special built-in model-manager providers (`google-antigravity`, `google-gemini-cli`, `openai-codex`) are discovered by `#collectBuiltInModelManagerOptions()` but are not in `PROVIDER_DESCRIPTORS`, so their cached rows were ignored until the asynchronous refresh path ran.

## Fix
- Added the special built-in provider ids to the provider-id list used for synchronous startup cache loading.
- Kept the existing cache normalization, provider override, compat, and model override handling shared for standard and special providers.
- Added a regression test that writes cached rows for `google-antigravity`, `google-gemini-cli`, and `openai-codex`, then asserts a new registry can resolve them immediately.
- Added the coding-agent changelog entry.

## Verification
Reproduced before the fix with the one-off `bun --cwd=packages/coding-agent --eval ...` cache script (`missing`, exit 1), then reran it after the fix (`loaded`, exit 0). Ran `bun --cwd=packages/coding-agent test test/model-registry.test.ts` (94 pass) and `bun --cwd=packages/coding-agent run check:types` (pass). `gh_push_branch` pre-publish gate completed before pushing. Fixes #1721