### PR TITLE
fix(swarm): remove redundant authStorage discovery from swarm pipeline (#1472)

### DIFF
--- a/packages/swarm-extension/CHANGELOG.md
+++ b/packages/swarm-extension/CHANGELOG.md
@@ -1,3 +1,6 @@
 # Changelog
 
 ## [Unreleased]
+
+### Fixed
+- Fixed swarm `/swarm run` failing with authStorage/modelRegistry identity error ([#1472](https://github.com/can1357/oh-my-pi/issues/1472))

--- a/packages/swarm-extension/src/cli.ts
+++ b/packages/swarm-extension/src/cli.ts
@@ -86,7 +86,6 @@ const result = await controller.run({
 			console.log();
 		}
 	},
-	authStorage,
 	modelRegistry,
 	settings,
 });

--- a/packages/swarm-extension/src/extension.ts
+++ b/packages/swarm-extension/src/extension.ts
@@ -11,7 +11,7 @@
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import type { AuthStorage, ExtensionAPI, ExtensionCommandContext } from "@oh-my-pi/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext } from "@oh-my-pi/pi-coding-agent";
 import { formatDuration } from "@oh-my-pi/pi-utils";
 import { buildDependencyGraph, buildExecutionWaves, detectCycles } from "./swarm/dag";
 import { PipelineController } from "./swarm/pipeline";
@@ -141,26 +141,17 @@ async function handleRun(yamlPath: string, ctx: ExtensionCommandContext, pi: Ext
 	};
 	updateWidget();
 
-	// 9. Resolve infrastructure for agent execution
-	let authStorage: AuthStorage | undefined;
-	try {
-		authStorage = await pi.pi.discoverAuthStorage();
-	} catch {
-		// Let runSubprocess discover auth per-agent as fallback
-	}
-
-	// 10. Run pipeline
+	// 9. Run pipeline
 	const controller = new PipelineController(def, waves, stateTracker);
 
 	const result = await controller.run({
 		workspace,
 		onProgress: () => updateWidget(),
-		authStorage,
 		modelRegistry: ctx.modelRegistry,
 		settings: pi.pi.settings,
 	});
 
-	// 11. Clear widget and show summary
+	// 10. Clear widget and show summary
 	ctx.ui.setWidget(widgetKey, undefined);
 
 	const elapsed = stateTracker.state.completedAt
@@ -185,7 +176,7 @@ async function handleRun(yamlPath: string, ctx: ExtensionCommandContext, pi: Ext
 		pi.logger.warn("Swarm completed with errors", { errors: result.errors });
 	}
 
-	// 12. Send summary to the conversation so the LLM knows what happened
+	// 11. Send summary to the conversation so the LLM knows what happened
 	const summaryMessage = buildSummaryMessage(def, result, stateTracker, workspace);
 	pi.sendMessage(
 		{

--- a/packages/swarm-extension/src/swarm/__tests__/executor.test.ts
+++ b/packages/swarm-extension/src/swarm/__tests__/executor.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { AuthStorage, ModelRegistry, SingleResult } from "@oh-my-pi/pi-coding-agent";
+import * as taskExecutor from "@oh-my-pi/pi-coding-agent";
+
+// Stub runSubprocess to capture options without actually running an agent
+const runSubprocessSpy = vi.spyOn(taskExecutor, "runSubprocess").mockResolvedValue({
+	index: 0,
+	id: "test-agent-0",
+	agent: "test",
+	agentSource: "project",
+	task: "test task",
+	exitCode: 0,
+	output: "ok",
+	stderr: "",
+	truncated: false,
+	durationMs: 100,
+	tokens: 0,
+} as SingleResult);
+
+afterEach(() => {
+	runSubprocessSpy.mockClear();
+});
+
+describe("executeSwarmAgent", () => {
+	it("does not pass authStorage to runSubprocess when modelRegistry is provided", async () => {
+		const { executeSwarmAgent } = await import("../executor");
+		const { StateTracker } = await import("../state");
+
+		const mockAuthStorage = { discover: vi.fn() } as unknown as AuthStorage;
+		const mockModelRegistry = {
+			authStorage: { discover: vi.fn() },
+		} as unknown as ModelRegistry;
+
+		const stateTracker = new StateTracker("/tmp/test-workspace", "test-swarm");
+		await stateTracker.init(["test-agent"], 1, "parallel");
+
+		const agent = {
+			name: "test-agent",
+			role: "tester",
+			task: "do something",
+			reportsTo: [],
+			waitsFor: [],
+		};
+
+		// Cast to allow passing authStorage to verify it is not forwarded
+		await executeSwarmAgent(agent, 0, {
+			workspace: "/tmp/test-workspace",
+			swarmName: "test-swarm",
+			iteration: 0,
+			authStorage: mockAuthStorage,
+			modelRegistry: mockModelRegistry,
+			stateTracker,
+		} as Parameters<typeof executeSwarmAgent>[2]);
+
+		expect(runSubprocessSpy).toHaveBeenCalledTimes(1);
+		const passedOptions = runSubprocessSpy.mock.calls[0][0];
+		expect(passedOptions.authStorage).toBeUndefined();
+		expect(passedOptions.modelRegistry).toBe(mockModelRegistry);
+	});
+});

--- a/packages/swarm-extension/src/swarm/__tests__/executor.test.ts
+++ b/packages/swarm-extension/src/swarm/__tests__/executor.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { ModelRegistry, SingleResult } from "@oh-my-pi/pi-coding-agent";
 import * as taskExecutor from "@oh-my-pi/pi-coding-agent";
+import { executeSwarmAgent } from "../executor";
+import { StateTracker } from "../state";
 
-// Stub runSubprocess to capture options without actually running an agent
-const runSubprocessSpy = vi.spyOn(taskExecutor, "runSubprocess").mockResolvedValue({
+const mockResult = {
 	index: 0,
 	id: "test-agent-0",
 	agent: "test",
@@ -17,22 +19,21 @@ const runSubprocessSpy = vi.spyOn(taskExecutor, "runSubprocess").mockResolvedVal
 	truncated: false,
 	durationMs: 100,
 	tokens: 0,
-} as SingleResult);
+} as SingleResult;
 
 afterEach(() => {
-	runSubprocessSpy.mockClear();
+	vi.restoreAllMocks();
 });
 
 describe("executeSwarmAgent", () => {
 	it("does not pass authStorage to runSubprocess when modelRegistry is provided", async () => {
-		const { executeSwarmAgent } = await import("../executor");
-		const { StateTracker } = await import("../state");
+		const runSubprocessSpy = vi.spyOn(taskExecutor, "runSubprocess").mockResolvedValue(mockResult);
 
 		const mockModelRegistry = {
 			authStorage: { discover: vi.fn() },
 		} as unknown as ModelRegistry;
 
-		const workspace = path.join(os.tmpdir(), "test-workspace");
+		const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "swarm-test-"));
 		const stateTracker = new StateTracker(workspace, "test-swarm");
 		await stateTracker.init(["test-agent"], 1, "parallel");
 

--- a/packages/swarm-extension/src/swarm/__tests__/executor.test.ts
+++ b/packages/swarm-extension/src/swarm/__tests__/executor.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
-import type { AuthStorage, ModelRegistry, SingleResult } from "@oh-my-pi/pi-coding-agent";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ModelRegistry, SingleResult } from "@oh-my-pi/pi-coding-agent";
 import * as taskExecutor from "@oh-my-pi/pi-coding-agent";
 
 // Stub runSubprocess to capture options without actually running an agent
@@ -26,12 +28,12 @@ describe("executeSwarmAgent", () => {
 		const { executeSwarmAgent } = await import("../executor");
 		const { StateTracker } = await import("../state");
 
-		const mockAuthStorage = { discover: vi.fn() } as unknown as AuthStorage;
 		const mockModelRegistry = {
 			authStorage: { discover: vi.fn() },
 		} as unknown as ModelRegistry;
 
-		const stateTracker = new StateTracker("/tmp/test-workspace", "test-swarm");
+		const workspace = path.join(os.tmpdir(), "test-workspace");
+		const stateTracker = new StateTracker(workspace, "test-swarm");
 		await stateTracker.init(["test-agent"], 1, "parallel");
 
 		const agent = {
@@ -42,15 +44,13 @@ describe("executeSwarmAgent", () => {
 			waitsFor: [],
 		};
 
-		// Cast to allow passing authStorage to verify it is not forwarded
 		await executeSwarmAgent(agent, 0, {
-			workspace: "/tmp/test-workspace",
+			workspace,
 			swarmName: "test-swarm",
 			iteration: 0,
-			authStorage: mockAuthStorage,
 			modelRegistry: mockModelRegistry,
 			stateTracker,
-		} as Parameters<typeof executeSwarmAgent>[2]);
+		});
 
 		expect(runSubprocessSpy).toHaveBeenCalledTimes(1);
 		const passedOptions = runSubprocessSpy.mock.calls[0][0];

--- a/packages/swarm-extension/src/swarm/__tests__/executor.test.ts
+++ b/packages/swarm-extension/src/swarm/__tests__/executor.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -21,8 +21,15 @@ const mockResult = {
 	tokens: 0,
 } as SingleResult;
 
-afterEach(() => {
+let workspace: string;
+
+beforeEach(async () => {
+	workspace = await fs.mkdtemp(path.join(os.tmpdir(), "swarm-test-"));
+});
+
+afterEach(async () => {
 	vi.restoreAllMocks();
+	await fs.rm(workspace, { recursive: true, force: true });
 });
 
 describe("executeSwarmAgent", () => {
@@ -33,7 +40,6 @@ describe("executeSwarmAgent", () => {
 			authStorage: { discover: vi.fn() },
 		} as unknown as ModelRegistry;
 
-		const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "swarm-test-"));
 		const stateTracker = new StateTracker(workspace, "test-swarm");
 		await stateTracker.init(["test-agent"], 1, "parallel");
 
@@ -55,7 +61,8 @@ describe("executeSwarmAgent", () => {
 
 		expect(runSubprocessSpy).toHaveBeenCalledTimes(1);
 		const passedOptions = runSubprocessSpy.mock.calls[0][0];
-		expect(passedOptions.authStorage).toBeUndefined();
-		expect(passedOptions.modelRegistry).toBe(mockModelRegistry);
+		const { authStorage, modelRegistry } = passedOptions;
+		expect(authStorage).toBeUndefined();
+		expect(modelRegistry).toBe(mockModelRegistry);
 	});
 });

--- a/packages/swarm-extension/src/swarm/executor.ts
+++ b/packages/swarm-extension/src/swarm/executor.ts
@@ -9,7 +9,6 @@ import type {
 	AgentDefinition,
 	AgentProgress,
 	AgentSource,
-	AuthStorage,
 	ModelRegistry,
 	Settings,
 	SingleResult,
@@ -25,7 +24,6 @@ export interface SwarmExecutorOptions {
 	modelOverride?: string;
 	signal?: AbortSignal;
 	onProgress?: (agentName: string, progress: AgentProgress) => void;
-	authStorage?: AuthStorage;
 	modelRegistry?: ModelRegistry;
 	settings?: Settings;
 	stateTracker: StateTracker;
@@ -45,18 +43,8 @@ export async function executeSwarmAgent(
 	index: number,
 	options: SwarmExecutorOptions,
 ): Promise<SingleResult> {
-	const {
-		workspace,
-		swarmName,
-		iteration,
-		modelOverride,
-		signal,
-		onProgress,
-		authStorage,
-		modelRegistry,
-		settings,
-		stateTracker,
-	} = options;
+	const { workspace, swarmName, iteration, modelOverride, signal, onProgress, modelRegistry, settings, stateTracker } =
+		options;
 
 	const agentId = `swarm-${swarmName}-${agent.name}-${iteration}`;
 
@@ -84,7 +72,6 @@ export async function executeSwarmAgent(
 			modelOverride,
 			signal,
 			onProgress: progress => onProgress?.(agent.name, progress),
-			authStorage,
 			modelRegistry,
 			settings,
 			enableLsp: false,

--- a/packages/swarm-extension/src/swarm/pipeline.ts
+++ b/packages/swarm-extension/src/swarm/pipeline.ts
@@ -6,7 +6,7 @@
  * - Waves execute sequentially (wave N+1 starts after wave N completes)
  * - For pipeline mode, iterations repeat the full DAG execution
  */
-import type { AgentSource, AuthStorage, ModelRegistry, Settings, SingleResult } from "@oh-my-pi/pi-coding-agent";
+import type { AgentSource, ModelRegistry, Settings, SingleResult } from "@oh-my-pi/pi-coding-agent";
 import { executeSwarmAgent } from "./executor";
 import type { SwarmDefinition } from "./schema";
 import type { StateTracker } from "./state";
@@ -19,7 +19,6 @@ export interface PipelineOptions {
 	workspace: string;
 	signal?: AbortSignal;
 	onProgress?: (state: PipelineProgress) => void;
-	authStorage?: AuthStorage;
 	modelRegistry?: ModelRegistry;
 	settings?: Settings;
 }
@@ -55,7 +54,7 @@ export class PipelineController {
 	}
 
 	async run(options: PipelineOptions): Promise<PipelineResult> {
-		const { workspace, signal, onProgress, authStorage, modelRegistry, settings } = options;
+		const { workspace, signal, onProgress, modelRegistry, settings } = options;
 		const allResults = new Map<string, SingleResult[]>();
 		const errors: string[] = [];
 
@@ -93,7 +92,6 @@ export class PipelineController {
 					workspace,
 					signal,
 					emitProgress,
-					authStorage,
 					modelRegistry,
 					settings,
 				});
@@ -127,7 +125,6 @@ export class PipelineController {
 			workspace: string;
 			signal?: AbortSignal;
 			emitProgress: (currentWave: number) => void;
-			authStorage?: AuthStorage;
 			modelRegistry?: ModelRegistry;
 			settings?: Settings;
 		},
@@ -169,7 +166,6 @@ export class PipelineController {
 							onProgress: (_name, _progress) => {
 								options.emitProgress(waveIdx);
 							},
-							authStorage: options.authStorage,
 							modelRegistry: options.modelRegistry,
 							settings: options.settings,
 							stateTracker: this.#stateTracker,


### PR DESCRIPTION
@## What

Fix #1472: remove redundant `authStorage` discovery from swarm pipeline.

`handleRun()` called `pi.pi.discoverAuthStorage()`, creating a **second** `AuthStorage` instance separate from the one already inside `ctx.modelRegistry`. Both were passed downstream to `runSubprocess()`, which enforces strict identity:

```
Error: options.authStorage and options.modelRegistry.authStorage must be the same instance when both are provided
```

## Why

`runSubprocess` requires `authStorage === modelRegistry.authStorage` — not by coincidence, but by design. The invariant ensures credential refresh events (`credential_disabled`, API key rotation) route through a single `AuthStorage` instance. Relaxing this check would mask real state divergence bugs.

The swarm extension violated this by discovering its own `AuthStorage` while the TUI session already held one inside `ctx.modelRegistry`. The fix is not to relax the invariant but to stop creating redundant state: remove the separate `discoverAuthStorage()` call and let `runSubprocess` resolve auth from `modelRegistry.authStorage` — which it already does when `authStorage` is not provided.

This matches how the built-in task tool works (`packages/coding-agent/src/task/index.ts`): it passes `this.session.authStorage` and `this.session.modelRegistry` from the same session, guaranteeing identity. The swarm TUI path has `ctx.modelRegistry` available — no need to discover auth independently.

## Testing

- Regression test: spy on `runSubprocess`, assert `authStorage` is `undefined` when `modelRegistry` is provided
- `bun check` passes
- `bun test packages/swarm-extension/` passes

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
@