### PR TITLE
fix(swarm): reuse session auth storage

### DIFF
--- a/packages/swarm-extension/CHANGELOG.md
+++ b/packages/swarm-extension/CHANGELOG.md
@@ -1,3 +1,7 @@
 # Changelog
 
 ## [Unreleased]
+
+### Fixed
+
+- Fixed `/swarm run` reusing a separately discovered auth storage instead of the active session model registry's auth storage ([#1472](https://github.com/can1357/oh-my-pi/issues/1472)).

--- a/packages/swarm-extension/package.json
+++ b/packages/swarm-extension/package.json
@@ -26,6 +26,7 @@
 	"scripts": {
 		"check": "biome check . && bun run check:types",
 		"check:types": "tsgo -p tsconfig.json --noEmit",
+		"test": "bun test",
 		"lint": "biome lint .",
 		"fix": "biome check --write --unsafe .",
 		"fmt": "biome format --write ."

--- a/packages/swarm-extension/src/extension.ts
+++ b/packages/swarm-extension/src/extension.ts
@@ -11,7 +11,7 @@
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import type { AuthStorage, ExtensionAPI, ExtensionCommandContext } from "@oh-my-pi/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext } from "@oh-my-pi/pi-coding-agent";
 import { formatDuration } from "@oh-my-pi/pi-utils";
 import { buildDependencyGraph, buildExecutionWaves, detectCycles } from "./swarm/dag";
 import { PipelineController } from "./swarm/pipeline";
@@ -141,26 +141,17 @@ async function handleRun(yamlPath: string, ctx: ExtensionCommandContext, pi: Ext
 	};
 	updateWidget();
 
-	// 9. Resolve infrastructure for agent execution
-	let authStorage: AuthStorage | undefined;
-	try {
-		authStorage = await pi.pi.discoverAuthStorage();
-	} catch {
-		// Let runSubprocess discover auth per-agent as fallback
-	}
-
-	// 10. Run pipeline
+	// 9. Run pipeline
 	const controller = new PipelineController(def, waves, stateTracker);
 
 	const result = await controller.run({
 		workspace,
 		onProgress: () => updateWidget(),
-		authStorage,
 		modelRegistry: ctx.modelRegistry,
 		settings: pi.pi.settings,
 	});
 
-	// 11. Clear widget and show summary
+	// 10. Clear widget and show summary
 	ctx.ui.setWidget(widgetKey, undefined);
 
 	const elapsed = stateTracker.state.completedAt
@@ -185,7 +176,7 @@ async function handleRun(yamlPath: string, ctx: ExtensionCommandContext, pi: Ext
 		pi.logger.warn("Swarm completed with errors", { errors: result.errors });
 	}
 
-	// 12. Send summary to the conversation so the LLM knows what happened
+	// 11. Send summary to the conversation so the LLM knows what happened
 	const summaryMessage = buildSummaryMessage(def, result, stateTracker, workspace);
 	pi.sendMessage(
 		{

--- a/packages/swarm-extension/src/swarm/executor.ts
+++ b/packages/swarm-extension/src/swarm/executor.ts
@@ -58,6 +58,8 @@ export async function executeSwarmAgent(
 		stateTracker,
 	} = options;
 
+	const subprocessAuthStorage = modelRegistry?.authStorage ?? authStorage;
+
 	const agentId = `swarm-${swarmName}-${agent.name}-${iteration}`;
 
 	const agentDef: AgentDefinition = {
@@ -84,7 +86,7 @@ export async function executeSwarmAgent(
 			modelOverride,
 			signal,
 			onProgress: progress => onProgress?.(agent.name, progress),
-			authStorage,
+			authStorage: subprocessAuthStorage,
 			modelRegistry,
 			settings,
 			enableLsp: false,

--- a/packages/swarm-extension/test/executor-auth.test.ts
+++ b/packages/swarm-extension/test/executor-auth.test.ts
@@ -1,0 +1,74 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AuthStorage, ModelRegistry, Settings, SqliteAuthCredentialStore } from "@oh-my-pi/pi-coding-agent";
+import { PipelineController } from "../src/swarm/pipeline";
+import { parseSwarmYaml } from "../src/swarm/schema";
+import { StateTracker } from "../src/swarm/state";
+
+class AbortingModelRegistry extends ModelRegistry {
+	#abortController: AbortController;
+
+	constructor(authStorage: AuthStorage, abortController: AbortController) {
+		super(authStorage);
+		this.#abortController = abortController;
+	}
+
+	override getAvailable() {
+		this.#abortController.abort("registry reached");
+		return [];
+	}
+}
+
+describe("swarm executor auth storage", () => {
+	const tempDirs: string[] = [];
+	const authStorages: AuthStorage[] = [];
+
+	afterEach(async () => {
+		for (const authStorage of authStorages.splice(0)) {
+			authStorage.close();
+		}
+		await Promise.all(tempDirs.splice(0).map(tempDir => fs.rm(tempDir, { force: true, recursive: true })));
+	});
+
+	it("uses the model registry auth storage when both auth inputs are present", async () => {
+		const workspace = await fs.mkdtemp(path.join(os.tmpdir(), "omp-swarm-auth-"));
+		tempDirs.push(workspace);
+
+		const sessionAuthStorage = new AuthStorage(new SqliteAuthCredentialStore(new Database(":memory:")));
+		const discoveredAuthStorage = new AuthStorage(new SqliteAuthCredentialStore(new Database(":memory:")));
+		authStorages.push(sessionAuthStorage, discoveredAuthStorage);
+
+		const abortController = new AbortController();
+		const modelRegistry = new AbortingModelRegistry(sessionAuthStorage, abortController);
+		const def = parseSwarmYaml(`
+swarm:
+  name: auth-repro
+  workspace: .
+  mode: parallel
+  target_count: 1
+  model: dummy-model
+  agents:
+    inventory:
+      role: inventory
+      task: Inventory this repo.
+`);
+		const stateTracker = new StateTracker(workspace, def.name);
+		await stateTracker.init([...def.agents.keys()], def.targetCount, def.mode);
+
+		const controller = new PipelineController(def, [["inventory"]], stateTracker);
+		const result = await controller.run({
+			workspace,
+			signal: abortController.signal,
+			authStorage: discoveredAuthStorage,
+			modelRegistry,
+			settings: Settings.isolated(),
+		});
+
+		const errors = result.errors.join("\n");
+		expect(errors).not.toContain("options.authStorage and options.modelRegistry.authStorage");
+		expect(result.agentResults.get("inventory")?.[0]?.aborted).toBe(true);
+	});
+});


### PR DESCRIPTION
## Repro
Running the swarm executor with a separately discovered `authStorage` and the active session `modelRegistry` reproduces the reported failure: `bun .wt/repro-swarm-auth-mismatch.ts` returned `exitCode=1` with `options.authStorage and options.modelRegistry.authStorage must be the same instance when both are provided` before any swarm agent work could start.

## Cause
`packages/swarm-extension/src/extension.ts` called `pi.pi.discoverAuthStorage()` for `/swarm run` and passed that instance into `PipelineController.run` while also passing `ctx.modelRegistry`; `packages/swarm-extension/src/swarm/executor.ts` forwarded both values to `runSubprocess`, whose startup path requires `options.authStorage` and `options.modelRegistry.authStorage` to be the same object.

## Fix
- Removed the extra auth discovery from the TUI `/swarm run` path so the active session registry remains authoritative.
- Normalized swarm subprocess auth to `modelRegistry.authStorage` whenever a model registry is supplied.
- Added a swarm pipeline regression test covering mismatched auth inputs without tripping the subprocess identity invariant.
- Added the swarm extension test script and changelog entry.

## Verification
`bun --cwd=packages/swarm-extension test test/executor-auth.test.ts` passed. `bun --cwd=packages/swarm-extension run check` passed. Fixes #1472