### PR TITLE
feat: auto routing — route to pro model based on difficulty

### DIFF
--- a/packages/coding-agent/src/commit/model-selection.ts
+++ b/packages/coding-agent/src/commit/model-selection.ts
@@ -29,7 +29,12 @@ export async function resolvePrimaryModel(
 	const matchPreferences = { usageOrder: settings.getStorage()?.getModelUsageOrder() };
 	const resolved = override
 		? resolveModelRoleValue(override, available, { settings, matchPreferences, modelRegistry })
-		: resolveRoleSelection(["commit", "smol", ...MODEL_ROLE_IDS], settings, available, modelRegistry);
+		: resolveRoleSelection(
+				["commit", "smol", ...MODEL_ROLE_IDS.filter(r => r !== "route")],
+				settings,
+				available,
+				modelRegistry,
+			);
 	const model = resolved?.model;
 	if (!model) {
 		throw new Error("No model available for commit generation");

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -91,7 +91,7 @@ export function isAuthenticated(apiKey: string | undefined | null): apiKey is st
 	return Boolean(apiKey) && apiKey !== kNoAuth;
 }
 
-export type ModelRole = "default" | "smol" | "slow" | "vision" | "plan" | "designer" | "commit" | "task";
+export type ModelRole = "default" | "smol" | "slow" | "vision" | "plan" | "designer" | "commit" | "task" | "route";
 
 export interface ModelRoleInfo {
 	tag?: string;
@@ -108,9 +108,20 @@ export const MODEL_ROLES: Record<ModelRole, ModelRoleInfo> = {
 	designer: { tag: "DESIGNER", name: "Designer", color: "muted" },
 	commit: { tag: "COMMIT", name: "Commit", color: "dim" },
 	task: { tag: "TASK", name: "Subtask", color: "muted" },
+	route: { tag: "ROUTE", name: "Route", color: "muted" },
 };
 
-export const MODEL_ROLE_IDS: ModelRole[] = ["default", "smol", "slow", "vision", "plan", "designer", "commit", "task"];
+export const MODEL_ROLE_IDS: ModelRole[] = [
+	"default",
+	"smol",
+	"slow",
+	"vision",
+	"plan",
+	"designer",
+	"commit",
+	"task",
+	"route",
+];
 
 /** Alias for ModelRoleInfo - used for both built-in and custom roles */
 export type RoleInfo = ModelRoleInfo;

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3020,6 +3020,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	// Auto routing
+	autoRouting: {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "model",
+			label: "Auto Routing",
+			description: "When auto thinking detects consecutive difficult prompts, route to the Route role model",
+		},
+	},
+
 	"providers.kimiApiFormat": {
 		type: "enum",
 		values: ["openai", "anthropic"] as const,

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -255,20 +255,23 @@ export class ModelSelectorComponent extends Container {
 	}
 
 	#buildMenuRoleActions(): void {
-		this.#menuRoleActions = getKnownRoleIds(this.#settings).map(role => {
-			const roleInfo = getRoleInfo(role, this.#settings);
-			const roleLabel = roleInfo.tag ? `${roleInfo.tag} (${roleInfo.name})` : roleInfo.name;
-			return {
-				label: `Set as ${roleLabel}`,
-				role,
-			};
-		});
+		this.#menuRoleActions = getKnownRoleIds(this.#settings)
+			.filter(role => role !== "route" || this.#settings.get("autoRouting"))
+			.map(role => {
+				const roleInfo = getRoleInfo(role, this.#settings);
+				const roleLabel = roleInfo.tag ? `${roleInfo.tag} (${roleInfo.name})` : roleInfo.name;
+				return {
+					label: `Set as ${roleLabel}`,
+					role,
+				};
+			});
 	}
 
 	#loadRoleModels(): void {
 		const allModels = this.#modelRegistry.getAll();
 		const matchPreferences = { usageOrder: this.#settings.getStorage()?.getModelUsageOrder() };
 		for (const role of getKnownRoleIds(this.#settings)) {
+			if (role === "route" && !this.#settings.get("autoRouting")) continue;
 			const roleValue = this.#settings.getModelRole(role);
 			if (!roleValue) continue;
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -106,6 +106,7 @@ import {
 	formatModelString,
 	parseModelString,
 	type ResolvedModelRoleValue,
+	resolveAllowedModels,
 	resolveModelRoleValue,
 } from "../config/model-resolver";
 import { expandPromptTemplate, type PromptTemplate } from "../config/prompt-templates";
@@ -816,6 +817,14 @@ export class AgentSession {
 	#autoThinking: boolean = false;
 	/** The level `auto` last resolved to (for UI); undefined until a turn is classified. */
 	#autoResolvedLevel: Effort | undefined;
+	/** True when auto-routing switched to a pro model for the current stretch. */
+	#autoRoutingActive: boolean = false;
+	/** Model saved before auto-routing; used to revert. */
+	#autoRoutingBaseModel: Model | undefined;
+	/** Consecutive ≥High turns; hits 3 → route to pro. Resets on ≤Medium. */
+	#autoRoutingCounter: number = 0;
+	/** Consecutive ≤Medium while routed; hits 2 → downgrade. */
+	#autoRoutingReverseCounter: number = 0;
 	#promptTemplates: PromptTemplate[];
 	#slashCommands: FileSlashCommand[];
 
@@ -5154,6 +5163,7 @@ export class AgentSession {
 		if (!apiKey) {
 			throw new Error(`No API key for ${model.provider}/${model.id}`);
 		}
+		this.#resetAutoRoutingState();
 
 		this.#clearActiveRetryFallback();
 		this.#setModelWithProviderSessionReset(model);
@@ -5177,13 +5187,19 @@ export class AgentSession {
 	 * Validates API key, saves to session log but NOT to settings.
 	 * @throws Error if no API key available for the model
 	 */
-	async setModelTemporary(model: Model, thinkingLevel?: ThinkingLevel): Promise<void> {
+	async setModelTemporary(
+		model: Model,
+		thinkingLevel?: ThinkingLevel,
+		options?: { _suppressAutoRoutingReset?: boolean },
+	): Promise<void> {
 		const previousEditMode = this.#resolveActiveEditMode();
 		const apiKey = await this.#modelRegistry.getApiKey(model, this.sessionId);
 		if (!apiKey) {
 			throw new Error(`No API key for ${model.provider}/${model.id}`);
 		}
-
+		if (!options?._suppressAutoRoutingReset) {
+			this.#resetAutoRoutingState();
+		}
 		this.#clearActiveRetryFallback();
 		this.#setModelWithProviderSessionReset(model);
 		this.sessionManager.appendModelChange(`${model.provider}/${model.id}`, "temporary");
@@ -5206,10 +5222,12 @@ export class AgentSession {
 	 * @returns The new model info, or undefined if only one model available
 	 */
 	async cycleModel(direction: "forward" | "backward" = "forward"): Promise<ModelCycleResult | undefined> {
-		if (this.#scopedModels.length > 0) {
-			return this.#cycleScopedModel(direction);
-		}
-		return this.#cycleAvailableModel(direction);
+		const result =
+			this.#scopedModels.length > 0
+				? await this.#cycleScopedModel(direction)
+				: await this.#cycleAvailableModel(direction);
+		if (result) this.#resetAutoRoutingState();
+		return result;
 	}
 
 	/**
@@ -5468,13 +5486,13 @@ export class AgentSession {
 	 */
 	async #applyAutoThinkingLevel(promptText: string, generation: number): Promise<void> {
 		const model = this.model;
-		if (!model?.reasoning) return;
-
+		if (!model) return;
+		if (!model.reasoning && !this.settings.get("autoRouting")) return;
 		let resolved: Effort | undefined;
+		let classificationSucceeded = false;
 		if (containsUltrathink(promptText)) {
-			// The user explicitly asked for maximum thinking; bypass the classifier
-			// and jump straight to the highest auto-supported level for this model.
 			resolved = clampAutoThinkingEffort(model, Effort.XHigh);
+			classificationSucceeded = true;
 		} else {
 			const controller = new AbortController();
 			const timer = setTimeout(() => controller.abort(), AgentSession.#AUTO_THINKING_TIMEOUT_MS);
@@ -5487,6 +5505,7 @@ export class AgentSession {
 					signal: controller.signal,
 					metadataResolver: provider => this.agent.metadataForProvider(provider),
 				});
+				classificationSucceeded = true;
 			} catch (error) {
 				logger.debug("auto-thinking: classification failed; using fallback level", {
 					error: error instanceof Error ? error.message : String(error),
@@ -5499,21 +5518,100 @@ export class AgentSession {
 		// Drop the result if the turn was aborted/superseded while classifying.
 		if (this.#promptGeneration !== generation || !this.#autoThinking) return;
 
-		const effort = resolved ?? resolveProvisionalAutoLevel(model);
+		let effort = resolved ?? resolveProvisionalAutoLevel(model);
 		if (effort === undefined) return;
-		const shouldPersistResolution = this.#autoResolvedLevel !== effort;
-		this.#autoResolvedLevel = effort;
-		this.#thinkingLevel = effort;
-		this.agent.setThinkingLevel(toReasoningEffort(effort));
-		if (shouldPersistResolution) {
-			this.sessionManager.appendThinkingLevelChange(effort);
+
+		// Auto-routing: switch model based on difficulty (counter-based)
+		if (model && this.settings.get("autoRouting")) {
+			if (this.#autoRoutingActive) {
+				if (classificationSucceeded && (effort === Effort.High || effort === Effort.XHigh)) {
+					this.#autoRoutingReverseCounter = 0;
+				} else if (classificationSucceeded) {
+					this.#autoRoutingReverseCounter++;
+					if (this.#autoRoutingReverseCounter >= 2) {
+						const baseModel = this.#autoRoutingBaseModel;
+						if (baseModel && !modelsAreEqual(baseModel, model)) {
+							try {
+								if (this.#promptGeneration !== generation) return;
+								await this.setModelTemporary(baseModel, undefined, { _suppressAutoRoutingReset: true });
+								if (this.#promptGeneration !== generation) return;
+								this.#autoRoutingActive = false;
+								this.#autoRoutingBaseModel = undefined;
+								this.#autoRoutingCounter = 0;
+								this.#autoRoutingReverseCounter = 0;
+							} catch (err) {
+								// Switch may have succeeded before post-switch refresh failed
+								if (modelsAreEqual(this.model, baseModel)) {
+									this.#autoRoutingActive = false;
+									this.#autoRoutingBaseModel = undefined;
+									this.#autoRoutingCounter = 0;
+									this.#autoRoutingReverseCounter = 0;
+								}
+								logger.debug("auto-routing: downgrade failed", { error: String(err) });
+							}
+						} else {
+							this.#autoRoutingActive = false;
+							this.#autoRoutingBaseModel = undefined;
+							this.#autoRoutingCounter = 0;
+							this.#autoRoutingReverseCounter = 0;
+						}
+					}
+				}
+			} else {
+				// Not routed: short-circuit if no viable target
+				const routeTarget = await this.#resolveAutoRoutingTarget();
+				if (this.#promptGeneration !== generation) return;
+				if (!routeTarget || modelsAreEqual(routeTarget, model)) {
+					this.#autoRoutingCounter = 0;
+				} else if (classificationSucceeded && (effort === Effort.High || effort === Effort.XHigh)) {
+					this.#autoRoutingCounter++;
+					if (this.#autoRoutingCounter >= 3) {
+						const target = await this.#resolveAutoRoutingTarget();
+						if (target && !modelsAreEqual(target, model)) {
+							try {
+								this.#autoRoutingActive = true;
+								this.#autoRoutingBaseModel = model;
+								if (this.#promptGeneration !== generation) {
+									this.#autoRoutingActive = false;
+									this.#autoRoutingBaseModel = undefined;
+									return;
+								}
+								await this.setModelTemporary(target, undefined, { _suppressAutoRoutingReset: true });
+							} catch (err) {
+								if (!modelsAreEqual(this.model, target)) {
+									this.#autoRoutingActive = false;
+									this.#autoRoutingBaseModel = undefined;
+								}
+								logger.debug("auto-routing: upgrade failed", { error: String(err) });
+							}
+						}
+						this.#autoRoutingCounter = 0;
+					}
+				} else if (classificationSucceeded) {
+					this.#autoRoutingCounter = 0;
+				}
+			}
 		}
-		this.#emit({
-			type: "thinking_level_changed",
-			thinkingLevel: effort,
-			configured: AUTO_THINKING,
-			resolved: effort,
-		});
+
+		// Re-clamp effort for the effective model after any routing switch
+		effort = clampAutoThinkingEffort(this.model, effort);
+
+		// Skip thinking level application for non-reasoning models
+		if (this.model?.reasoning) {
+			const shouldPersistResolution = this.#autoResolvedLevel !== effort;
+			this.#autoResolvedLevel = effort;
+			this.#thinkingLevel = effort;
+			this.agent.setThinkingLevel(toReasoningEffort(effort));
+			if (shouldPersistResolution) {
+				this.sessionManager.appendThinkingLevelChange(effort);
+			}
+			this.#emit({
+				type: "thinking_level_changed",
+				thinkingLevel: effort,
+				configured: AUTO_THINKING,
+				resolved: effort,
+			});
+		}
 	}
 
 	/**
@@ -6791,6 +6889,27 @@ export class AgentSession {
 		const thinkingLevel = extractExplicitThinkingSelector(existingRoleValue, this.settings);
 		return formatModelSelectorValue(modelKey, thinkingLevel);
 	}
+	/** Clear all auto-routing runtime state. Called on manual model switch and session restore. */
+	#resetAutoRoutingState(): void {
+		this.#autoRoutingActive = false;
+		this.#autoRoutingBaseModel = undefined;
+		this.#autoRoutingCounter = 0;
+		this.#autoRoutingReverseCounter = 0;
+	}
+
+	/** Resolve the target model for auto-routing — the configured `route` role, filtered through enabledModels. */
+	async #resolveAutoRoutingTarget(): Promise<Model | undefined> {
+		const allowed = await resolveAllowedModels(this.#modelRegistry, this.settings);
+		const routeRole = this.#resolveRoleModelFull("route", allowed, this.model);
+		if (!routeRole.model) return undefined;
+		// Honor --models scope when set
+		if (this.#scopedModels.length > 0) {
+			const scopedIds = new Set(this.#scopedModels.map(s => `${s.model.provider}/${s.model.id}`));
+			if (!scopedIds.has(`${routeRole.model.provider}/${routeRole.model.id}`)) return undefined;
+		}
+		return routeRole.model;
+	}
+
 	#resolveContextPromotionConfiguredTarget(currentModel: Model, availableModels: Model[]): Model | undefined {
 		const configuredTarget = currentModel.contextPromotionTarget?.trim();
 		if (!configuredTarget) return undefined;
@@ -6846,6 +6965,7 @@ export class AgentSession {
 		// as auth fallbacks when the current model has no usable credentials.
 		addCandidate(currentModel);
 		for (const role of MODEL_ROLE_IDS) {
+			if (role === "route") continue;
 			addCandidate(this.#resolveRoleModelFull(role, availableModels, currentModel).model);
 		}
 
@@ -8785,6 +8905,7 @@ export class AgentSession {
 				this.#thinkingLevel = resolveThinkingLevelForModel(this.model, restoredThinkingLevel);
 			}
 			this.agent.setThinkingLevel(toReasoningEffort(this.#thinkingLevel));
+			this.#resetAutoRoutingState();
 			this.agent.serviceTier = hasServiceTierEntry
 				? sessionContext.serviceTier
 				: configuredServiceTier === "none"

--- a/packages/coding-agent/test/agent-session-auto-routing.test.ts
+++ b/packages/coding-agent/test/agent-session-auto-routing.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { Effort, getBundledModel } from "@oh-my-pi/pi-ai";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import * as autoThinkingClassifier from "../src/auto-thinking/classifier";
+import { AUTO_THINKING } from "../src/thinking";
+
+describe("auto routing", () => {
+	let tempDir: TempDir;
+	let session: AgentSession;
+	let sessionSettings: Settings;
+	let modelRegistry: ModelRegistry;
+	const authStorages: AuthStorage[] = [];
+
+	beforeEach(async () => {
+		tempDir = TempDir.createSync("@pi-auto-routing-");
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+		sessionSettings = Settings.isolated();
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		if (session) {
+			await session.dispose();
+		}
+		for (const authStorage of authStorages.splice(0)) {
+			authStorage.close();
+		}
+		try {
+			tempDir.removeSync();
+		} catch {
+			/* EBUSY on Windows — temp dir will be cleaned up later */
+		}
+	});
+
+	function getModel(id: string) {
+		const model = getBundledModel("anthropic", id);
+		if (!model) throw new Error(`Expected anthropic model ${id} to exist`);
+		return model;
+	}
+
+	async function createAutoRoutingSession() {
+		const defaultModel = getModel("claude-sonnet-4-5");
+		const slowModel = getModel("claude-sonnet-4-6");
+
+		const agent = new Agent({
+			initialState: {
+				model: defaultModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+				thinkingLevel: undefined,
+			},
+		});
+
+		sessionSettings.set("autoRouting", true);
+		sessionSettings.setModelRole("default", `${defaultModel.provider}/${defaultModel.id}`);
+		sessionSettings.setModelRole("slow", `${slowModel.provider}/${slowModel.id}`);
+		sessionSettings.setModelRole("route", `${slowModel.provider}/${slowModel.id}`);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: sessionSettings,
+			modelRegistry,
+			thinkingLevel: AUTO_THINKING,
+		});
+
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+	}
+
+	it("upgrades after 3 consecutive >=High efforts", async () => {
+		await createAutoRoutingSession();
+		const classifierSpy = vi.spyOn(autoThinkingClassifier, "classifyDifficulty");
+		const setModelTemporarySpy = vi.spyOn(session, "setModelTemporary");
+
+		classifierSpy.mockResolvedValue(Effort.High);
+		await session.prompt("Implement a thread-safe LRU cache");
+		expect(setModelTemporarySpy).not.toHaveBeenCalled();
+
+		classifierSpy.mockResolvedValue(Effort.High);
+		await session.prompt("Refactor distributed lock service to use Raft");
+		expect(setModelTemporarySpy).not.toHaveBeenCalled();
+
+		classifierSpy.mockResolvedValue(Effort.High);
+		await session.prompt("Design multi-tenant PostgreSQL migration system");
+		expect(setModelTemporarySpy).toHaveBeenCalledTimes(1);
+		expect(setModelTemporarySpy.mock.calls[0]?.[0]?.id).toBe("claude-sonnet-4-6");
+	});
+
+	it("resets counter on a <=Medium interruption", async () => {
+		await createAutoRoutingSession();
+		const classifierSpy = vi.spyOn(autoThinkingClassifier, "classifyDifficulty");
+		const setModelTemporarySpy = vi.spyOn(session, "setModelTemporary");
+
+		classifierSpy.mockResolvedValue(Effort.High);
+		await session.prompt("Hard 1");
+		classifierSpy.mockResolvedValue(Effort.High);
+		await session.prompt("Hard 2");
+		classifierSpy.mockResolvedValue(Effort.Medium);
+		await session.prompt("Medium interruption");
+
+		classifierSpy.mockResolvedValue(Effort.High);
+		await session.prompt("Hard again");
+
+		expect(setModelTemporarySpy).not.toHaveBeenCalled();
+	});
+
+	it("XHigh also counts toward upgrade", async () => {
+		await createAutoRoutingSession();
+		const classifierSpy = vi.spyOn(autoThinkingClassifier, "classifyDifficulty");
+		const setModelTemporarySpy = vi.spyOn(session, "setModelTemporary");
+
+		classifierSpy.mockResolvedValue(Effort.High);
+		await session.prompt("Hard 1");
+		classifierSpy.mockResolvedValue(Effort.High);
+		await session.prompt("Hard 2");
+		classifierSpy.mockResolvedValue(Effort.XHigh);
+		await session.prompt("Very hard 3");
+
+		expect(setModelTemporarySpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("downgrades after 2 consecutive <=Medium turns while routed", async () => {
+		await createAutoRoutingSession();
+		const classifierSpy = vi.spyOn(autoThinkingClassifier, "classifyDifficulty");
+		const setModelTemporarySpy = vi.spyOn(session, "setModelTemporary");
+
+		for (let i = 0; i < 3; i++) {
+			classifierSpy.mockResolvedValue(Effort.High);
+			await session.prompt("Hard question");
+		}
+		expect(setModelTemporarySpy).toHaveBeenCalledTimes(1);
+
+		// 1st Medium → accumulate, no downgrade yet
+		classifierSpy.mockResolvedValue(Effort.Medium);
+		await session.prompt("Simple follow-up 1");
+		expect(setModelTemporarySpy).toHaveBeenCalledTimes(1);
+
+		// 2nd Medium → downgrade
+		classifierSpy.mockResolvedValue(Effort.Medium);
+		await session.prompt("Simple follow-up 2");
+		expect(setModelTemporarySpy).toHaveBeenCalledTimes(2);
+		expect(setModelTemporarySpy.mock.calls[1]?.[0]?.id).toBe("claude-sonnet-4-5");
+	});
+
+	it("reset reverse counter on High and stays routed", async () => {
+		await createAutoRoutingSession();
+		const classifierSpy = vi.spyOn(autoThinkingClassifier, "classifyDifficulty");
+		const setModelTemporarySpy = vi.spyOn(session, "setModelTemporary");
+
+		for (let i = 0; i < 3; i++) {
+			classifierSpy.mockResolvedValue(Effort.High);
+			await session.prompt("Hard question");
+		}
+		expect(setModelTemporarySpy).toHaveBeenCalledTimes(1);
+
+		// One Medium — reverse counter at 1
+		classifierSpy.mockResolvedValue(Effort.Medium);
+		await session.prompt("Medium 1");
+		expect(setModelTemporarySpy).toHaveBeenCalledTimes(1);
+
+		// A High resets reverse counter
+		classifierSpy.mockResolvedValue(Effort.High);
+		await session.prompt("Hard again");
+		expect(setModelTemporarySpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("resets counter on manual model switch", async () => {
+		await createAutoRoutingSession();
+		const classifierSpy = vi.spyOn(autoThinkingClassifier, "classifyDifficulty");
+
+		classifierSpy.mockResolvedValue(Effort.High);
+		await session.prompt("Hard 1");
+		classifierSpy.mockResolvedValue(Effort.High);
+		await session.prompt("Hard 2");
+
+		const otherModel = getModel("claude-sonnet-4-6");
+		await session.setModelTemporary(otherModel);
+		await session.setModel(getModel("claude-sonnet-4-5"));
+
+		const setModelTemporarySpy = vi.spyOn(session, "setModelTemporary");
+		classifierSpy.mockResolvedValue(Effort.High);
+		await session.prompt("Hard after switch");
+		await session.prompt("Hard 2");
+		await session.prompt("Hard 3");
+
+		expect(setModelTemporarySpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("routed model is affected by auto thinking independently", async () => {
+		await createAutoRoutingSession();
+		const classifierSpy = vi.spyOn(autoThinkingClassifier, "classifyDifficulty");
+
+		for (let i = 0; i < 3; i++) {
+			classifierSpy.mockResolvedValue(Effort.High);
+			await session.prompt("Hard question");
+		}
+
+		expect(session.isAutoThinking).toBe(true);
+		expect(session.thinkingLevel).toBe(Effort.High);
+
+		// 2 consecutive Low → downgrade
+		classifierSpy.mockResolvedValue(Effort.Low);
+		await session.prompt("Easy question 1");
+		classifierSpy.mockResolvedValue(Effort.Low);
+		await session.prompt("Easy question 2");
+
+		expect(session.model?.id).toBe("claude-sonnet-4-5");
+	});
+
+	it("does not trigger routing when setting is disabled", async () => {
+		const defaultModel = getModel("claude-sonnet-4-5");
+
+		const agent = new Agent({
+			initialState: {
+				model: defaultModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+				thinkingLevel: undefined,
+			},
+		});
+
+		sessionSettings.set("autoRouting", false);
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: sessionSettings,
+			modelRegistry,
+			thinkingLevel: AUTO_THINKING,
+		});
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+		const classifierSpy = vi.spyOn(autoThinkingClassifier, "classifyDifficulty");
+		const setModelTemporarySpy = vi.spyOn(session, "setModelTemporary");
+
+		for (let i = 0; i < 3; i++) {
+			classifierSpy.mockResolvedValue(Effort.High);
+			await session.prompt("Hard question");
+		}
+		expect(setModelTemporarySpy).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
When `autoRouting` is enabled and thinking is `auto`, the system tracks consecutive difficulty tiers and automatically switches to a more capable model (Route role) when the prompt is consistently complex.

### Settings
- `autoRouting` (boolean, default false) — enables auto-routing

### Built-in role
- `Route` — user configures the pro model via `/model` → Set as ROUTE. Hidden from the model selector when `autoRouting` is disabled.

### Rules

| State | Condition | Action |
|---|---|---|
| Not routed | >=High | counter++ (>=3 → upgrade to Route) |
| Not routed | <=Medium | counter = 0 |
| Routed | >=High | reverseCounter = 0 (debounce) |
| Routed | <=Medium | reverseCounter++ (>=2 → downgrade) |

Counters reset on manual model switch and session restore.
Thinking level is never modified by the routing logic.

### Change
1. **autoRouting**
<img width="381" height="356" alt="image" src="https://github.com/user-attachments/assets/a9ae8075-8dc0-45a4-8ce5-443bba6fc619" />


2. **modelRoles.route**
<img width="411" height="189" alt="image" src="https://github.com/user-attachments/assets/3796fa74-ec50-4fdf-bd72-d702e85424ac" />


3. **Set as ROUTE (Route)**
<img width="894" height="450" alt="image" src="https://github.com/user-attachments/assets/a0319c71-dca5-4959-9aa8-063fa2ba8d32" />



## Testing

<!-- How was this tested? -->

---

- [x] `bun check` passes
- [x] Tested locally
- [ ] CHANGELOG updated (if user-facing)
