### PR TITLE
fix(providers): use api key auth for OpenCode Go Anthropic models

### DIFF
--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -1933,9 +1933,26 @@ export function buildAnthropicClientOptions(args: AnthropicClientOptionsArgs): A
 		};
 	}
 
-	// OpenCode's Anthropic-compatible gateway accepts bearer auth only; leaving
-	// apiKey set lets the SDK add X-Api-Key, which upstream Alibaba rejects.
-	if (model.provider === "opencode-go" || model.provider === "opencode-zen") {
+	// OpenCode Go's Anthropic-compatible gateway validates API-key auth through
+	// `X-Api-Key`; bearer-only requests reach the endpoint but return
+	// `Missing API key` before token validation.
+	if (model.provider === "opencode-go") {
+		delete defaultHeaders.Authorization;
+		return {
+			isOAuthToken: false,
+			apiKey,
+			authToken: null,
+			baseURL: baseUrl,
+			maxRetries: 5,
+			defaultHeaders,
+			...(debugFetch ? { fetch: debugFetch } : {}),
+			...(tlsFetchOptions ? { fetchOptions: tlsFetchOptions } : {}),
+		};
+	}
+
+	// OpenCode Zen's Anthropic-compatible gateway accepts bearer auth only;
+	// leaving apiKey set lets the client add X-Api-Key, which upstream Alibaba rejects.
+	if (model.provider === "opencode-zen") {
 		return {
 			isOAuthToken: false,
 			apiKey: null,

--- a/packages/ai/test/github-copilot-anthropic-auth.test.ts
+++ b/packages/ai/test/github-copilot-anthropic-auth.test.ts
@@ -75,7 +75,7 @@ describe("Anthropic Copilot auth config", () => {
 		expect(options.defaultHeaders.Authorization).toBe(`Bearer ${token}`);
 	});
 
-	it("uses bearer-only auth for OpenCode Go Anthropic models", () => {
+	it("uses X-Api-Key auth for OpenCode Go Anthropic models", () => {
 		const model = makeOpenCodeGoQwen37Model();
 		const token = "opencode_test_key";
 		const options = buildAnthropicClientOptions({
@@ -86,9 +86,30 @@ describe("Anthropic Copilot auth config", () => {
 			dynamicHeaders: {},
 		});
 
-		expect(options.apiKey).toBeNull();
+		expect(options.apiKey).toBe(token);
 		expect(options.authToken).toBeNull();
-		expect(options.defaultHeaders.Authorization).toBe(`Bearer ${token}`);
+		expect(options.defaultHeaders.Authorization).toBeUndefined();
+	});
+
+	it("sends OpenCode Go Anthropic requests with X-Api-Key", async () => {
+		const requestedApiKeys: Array<string | null> = [];
+		const requestedAuthorizations: Array<string | null> = [];
+		global.fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+			requestedApiKeys.push(getRequestHeader(input, init, "X-Api-Key"));
+			requestedAuthorizations.push(getRequestHeader(input, init, "Authorization"));
+			return new Response(JSON.stringify({ error: { type: "authentication_error", message: "Unauthorized" } }), {
+				status: 401,
+				headers: { "Content-Type": "application/json" },
+			});
+		}) as unknown as typeof fetch;
+
+		const result = await streamAnthropic(makeOpenCodeGoQwen37Model(), testContext, {
+			apiKey: "opencode_test_key",
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(requestedApiKeys[0]).toBe("opencode_test_key");
+		expect(requestedAuthorizations[0]).toBeNull();
 	});
 
 	it("unwraps structured Copilot credentials before setting Authorization", () => {


### PR DESCRIPTION
## Repro
OpenCode Go `qwen3.7-max` and `minimax-m3` route through `https://opencode.ai/zen/go/v1/messages`; posting a minimal Anthropic request with `Authorization: Bearer dummy` reproduces the reporter's `401 {"type":"error","error":{"type":"AuthError","message":"Missing API key."}}`, while the same request with `X-Api-Key: dummy` reaches token validation and returns `Invalid API key.`.

## Cause
`buildAnthropicClientOptions` in `packages/ai/src/providers/anthropic.ts` grouped `opencode-go` with `opencode-zen` and forced bearer-only auth for Anthropic-compatible requests. OpenCode Go's `/v1/messages` endpoint requires API-key auth through `X-Api-Key`, so valid Go keys were omitted from the header the endpoint validates.

## Fix
- Split the OpenCode Go and OpenCode Zen Anthropic auth paths in `packages/ai/src/providers/anthropic.ts`.
- Send OpenCode Go Anthropic requests with `X-Api-Key` and no bearer `Authorization` header.
- Preserve OpenCode Zen's existing bearer-only behavior.
- Update `packages/ai/test/github-copilot-anthropic-auth.test.ts` to assert both the client options and emitted request headers for OpenCode Go.

## Verification
Reproduced the failing header behavior with `bun -e ...` against `https://opencode.ai/zen/go/v1/messages`; ran `bun --cwd=packages/ai test test/github-copilot-anthropic-auth.test.ts test/issue-887-repro.test.ts` (18 pass) and `bun --cwd=packages/ai run check` (Biome and tsgo pass). `gh_push_branch` also completed the pre-publish gate. Fixes #1736