### PR TITLE
fix(tools): surface write/read paths during streaming on slow providers

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed `/review`'s uncommitted-change mode in Jujutsu repositories to read `jj diff --git` from the current workspace, so non-default JJ workspaces include their working-copy changes instead of falling back to the colocated Git checkout.
 - Fixed empty assistant stop retry continuations preserving auto-retry state until a non-empty assistant turn completes or recovery reaches its retry cap.
+- Fixed the `write` and `read` tool-call headers showing `…` instead of the target path during streaming on providers that emit small tool-call deltas (open-source, Chinese providers, local Ollama). `extractPartialJsonString` / `decodePartialJsonStringFragment` are now shared via `tools/render-utils.ts`, the write/read renderers fall back to the raw `__partialJson` buffer when the throttled structured `arguments` parse has not caught up, and the read-tool routing in `event-controller.ts` / `ui-helpers.ts` peeks `__partialJson` so the read group is created (and routed to URL vs filesystem) before the full JSON object closes ([#1738](https://github.com/can1357/oh-my-pi/issues/1738)).
 
 ### Changed
 

--- a/packages/coding-agent/src/edit/renderer.ts
+++ b/packages/coding-agent/src/edit/renderer.ts
@@ -12,6 +12,7 @@ import { renderDiff as renderDiffColored } from "../modes/components/diff";
 import { getLanguageFromPath, type Theme } from "../modes/theme/theme";
 import type { OutputMeta } from "../tools/output-meta";
 import {
+	extractPartialJsonString,
 	formatDiagnostics,
 	formatDiffStats,
 	formatExpandHint,
@@ -146,28 +147,6 @@ const CALL_TEXT_PREVIEW_WIDTH = 80;
 /** Extract file path from an edit entry. */
 function filePathFromEditEntry(p: string | undefined): string | undefined {
 	return p ?? undefined;
-}
-
-function decodePartialJsonStringFragment(fragment: string): string {
-	// Trim a trailing partial escape so JSON.parse sees a well-formed string.
-	let text = fragment.replace(/\\u[0-9a-fA-F]{0,3}$/, "");
-	const trailingBackslashes = text.match(/\\+$/)?.[0].length ?? 0;
-	if (trailingBackslashes % 2 === 1) text = text.slice(0, -1);
-	try {
-		return JSON.parse(`"${text}"`) as string;
-	} catch {
-		// Streaming fragment isn't a valid JSON string yet; surface it raw rather
-		// than ad-hoc unescaping that mishandles surrogates and partial escapes.
-		return text;
-	}
-}
-
-function extractPartialJsonString(partialJson: string | undefined, key: string): string | undefined {
-	if (!partialJson) return undefined;
-	const pattern = new RegExp(`"${key}"\\s*:\\s*"((?:\\\\.|[^"\\\\])*)`, "u");
-	const match = pattern.exec(partialJson);
-	if (!match) return undefined;
-	return decodePartialJsonStringFragment(match[1]);
 }
 
 function getPartialJsonEditPath(args: EditRenderArgs): string | undefined {

--- a/packages/coding-agent/src/internal-urls/router.ts
+++ b/packages/coding-agent/src/internal-urls/router.ts
@@ -66,6 +66,10 @@ export class InternalUrlRouter {
 		return this.#handlers.has(match[1].toLowerCase());
 	}
 
+	/** Registered internal URL scheme names, excluding the `://` suffix. */
+	schemes(): string[] {
+		return [...this.#handlers.keys()];
+	}
 	/** Schemes whose handler supports host/path autocomplete. */
 	completionSchemes(): string[] {
 		const schemes: string[] = [];

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -3,7 +3,7 @@ import { Container, Text } from "@oh-my-pi/pi-tui";
 import { InternalUrlRouter } from "../../internal-urls";
 import { getLanguageFromPath, theme } from "../../modes/theme/theme";
 import { splitPathAndSel } from "../../tools/path-utils";
-import { PREVIEW_LIMITS, shortenPath } from "../../tools/render-utils";
+import { extractPartialJsonString, PREVIEW_LIMITS, shortenPath } from "../../tools/render-utils";
 import { renderCodeCell } from "../../tui";
 import type { ToolExecutionHandle } from "./tool-execution";
 
@@ -16,11 +16,19 @@ import type { ToolExecutionHandle } from "./tool-execution";
 function readArgsTarget(args: unknown): string | undefined {
 	if (!args || typeof args !== "object" || Array.isArray(args)) return undefined;
 	const record = args as Record<string, unknown>;
-	return typeof record.path === "string"
-		? record.path
-		: typeof record.file_path === "string"
-			? record.file_path
-			: undefined;
+	if (typeof record.path === "string") return record.path;
+	if (typeof record.file_path === "string") return record.file_path;
+	// Streaming fallback: `event-controller.ts` forwards the raw partialJson
+	// buffer on the args so we can route the read (filesystem vs internal URL)
+	// before the throttled structured `arguments` parse catches up on providers
+	// that stream small tool-call deltas.
+	if (typeof record.__partialJson === "string") {
+		return (
+			extractPartialJsonString(record.__partialJson, "path") ??
+			extractPartialJsonString(record.__partialJson, "file_path")
+		);
+	}
+	return undefined;
 }
 
 export function readArgsHaveTarget(args: unknown): boolean {
@@ -38,6 +46,7 @@ type ReadRenderArgs = {
 	file_path?: string;
 	// Legacy field from the old schema; tolerated for rebuilt transcripts.
 	sel?: string;
+	__partialJson?: string;
 };
 
 type ReadToolSuffixResolution = {
@@ -92,7 +101,14 @@ export class ReadToolGroupComponent extends Container implements ToolExecutionHa
 
 	updateArgs(args: ReadRenderArgs, toolCallId?: string): void {
 		if (!toolCallId) return;
-		const basePath = args.file_path || args.path || "";
+		const basePath =
+			args.file_path ||
+			args.path ||
+			(args.__partialJson
+				? (extractPartialJsonString(args.__partialJson, "path") ??
+					extractPartialJsonString(args.__partialJson, "file_path") ??
+					"")
+				: "");
 		const rawPath = args.sel ? `${basePath}:${args.sel}` : basePath;
 		const entry: ReadEntry = this.#entries.get(toolCallId) ?? {
 			toolCallId,

--- a/packages/coding-agent/src/modes/components/read-tool-group.ts
+++ b/packages/coding-agent/src/modes/components/read-tool-group.ts
@@ -3,9 +3,34 @@ import { Container, Text } from "@oh-my-pi/pi-tui";
 import { InternalUrlRouter } from "../../internal-urls";
 import { getLanguageFromPath, theme } from "../../modes/theme/theme";
 import { splitPathAndSel } from "../../tools/path-utils";
-import { extractPartialJsonString, PREVIEW_LIMITS, shortenPath } from "../../tools/render-utils";
+import {
+	extractPartialJsonString,
+	PREVIEW_LIMITS,
+	partialJsonStringFieldIsComplete,
+	shortenPath,
+} from "../../tools/render-utils";
 import { renderCodeCell } from "../../tui";
 import type { ToolExecutionHandle } from "./tool-execution";
+
+const PARTIAL_JSON_READ_TARGET_KEYS = ["path", "file_path"] as const;
+
+function couldBecomeInternalUrl(targetPrefix: string): boolean {
+	const lower = targetPrefix.toLowerCase();
+	if (lower.length === 0) return true;
+	if (lower.includes("://")) return false;
+	return InternalUrlRouter.instance()
+		.schemes()
+		.some(scheme => `${scheme}://`.startsWith(lower));
+}
+
+function extractClassifiablePartialReadTarget(partialJson: string): string | undefined {
+	for (const key of PARTIAL_JSON_READ_TARGET_KEYS) {
+		const target = extractPartialJsonString(partialJson, key);
+		if (target === undefined) continue;
+		if (partialJsonStringFieldIsComplete(partialJson, key) || !couldBecomeInternalUrl(target)) return target;
+	}
+	return undefined;
+}
 
 /**
  * Read calls whose target is resolved through {@link InternalUrlRouter} are
@@ -21,12 +46,12 @@ function readArgsTarget(args: unknown): string | undefined {
 	// Streaming fallback: `event-controller.ts` forwards the raw partialJson
 	// buffer on the args so we can route the read (filesystem vs internal URL)
 	// before the throttled structured `arguments` parse catches up on providers
-	// that stream small tool-call deltas.
+	// that stream small tool-call deltas. Do not classify prefixes that could
+	// still become an internal URL (`s` -> `skill://...`); otherwise the first
+	// partial delta can lock the call into a read group that internal URL reads
+	// intentionally avoid.
 	if (typeof record.__partialJson === "string") {
-		return (
-			extractPartialJsonString(record.__partialJson, "path") ??
-			extractPartialJsonString(record.__partialJson, "file_path")
-		);
+		return extractClassifiablePartialReadTarget(record.__partialJson);
 	}
 	return undefined;
 }

--- a/packages/coding-agent/src/modes/controllers/event-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/event-controller.ts
@@ -341,21 +341,29 @@ export class EventController {
 
 			for (const content of this.ctx.streamingMessage.content) {
 				if (content.type !== "toolCall") continue;
+				// Preserve the raw partial JSON for renderers that need to surface fields before
+				// the JSON object closes. Bash uses this to show inline env assignments during
+				// streaming, and write/read/edit use it to surface the file path while a slow
+				// provider's small deltas keep the throttled structured args empty.
+				const renderArgs =
+					"partialJson" in content
+						? { ...content.arguments, __partialJson: content.partialJson }
+						: content.arguments;
 				if (content.name === "read") {
-					if (!readArgsHaveTarget(content.arguments)) {
+					if (!readArgsHaveTarget(renderArgs)) {
 						// Args still streaming — defer until path is parseable so we can route to the
 						// read group (regular files) vs ToolExecutionComponent (internal URLs).
 						// Creating either component now would lock the read into the wrong shape.
 						continue;
 					}
-					if (!readArgsTargetInternalUrl(content.arguments)) {
-						this.#trackReadToolCall(content.id, content.arguments);
+					if (!readArgsTargetInternalUrl(renderArgs)) {
+						this.#trackReadToolCall(content.id, renderArgs);
 						const component = this.ctx.pendingTools.get(content.id);
 						if (component) {
-							component.updateArgs(content.arguments, content.id);
+							component.updateArgs(renderArgs, content.id);
 						} else {
 							const group = this.#getReadGroup();
-							group.updateArgs(content.arguments, content.id);
+							group.updateArgs(renderArgs, content.id);
 							this.ctx.pendingTools.set(content.id, group);
 						}
 						continue;
@@ -363,12 +371,6 @@ export class EventController {
 					// Internal URL read falls through to ToolExecutionComponent below.
 				}
 
-				// Preserve the raw partial JSON for renderers that need to surface fields before the JSON object closes.
-				// Bash uses this to show inline env assignments during streaming instead of popping them in at completion.
-				const renderArgs =
-					"partialJson" in content
-						? { ...content.arguments, __partialJson: content.partialJson }
-						: content.arguments;
 				if (!this.ctx.pendingTools.has(content.id)) {
 					this.#resetReadGroup();
 					this.ctx.chatContainer.addChild(new Text("", 0, 0));

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -339,10 +339,17 @@ export class UiHelpers {
 						continue;
 					}
 
+					// Hoist renderArgs so the read-tool gating sees `__partialJson` too.
+					// Without this, transcripts rebuilt mid-stream skip the read group
+					// when only `__partialJson` carries the path (slow-provider deltas).
+					const renderArgs =
+						"partialJson" in content
+							? { ...content.arguments, __partialJson: content.partialJson }
+							: content.arguments;
 					if (
 						content.name === "read" &&
-						readArgsHaveTarget(content.arguments) &&
-						!readArgsTargetInternalUrl(content.arguments)
+						readArgsHaveTarget(renderArgs) &&
+						!readArgsTargetInternalUrl(renderArgs)
 					) {
 						if (hasErrorStop && errorMessage) {
 							if (!readGroup) {
@@ -352,7 +359,7 @@ export class UiHelpers {
 								readGroup.setExpanded(this.ctx.toolOutputExpanded);
 								this.ctx.chatContainer.addChild(readGroup);
 							}
-							readGroup.updateArgs(content.arguments, content.id);
+							readGroup.updateArgs(renderArgs, content.id);
 							readGroup.updateResult(
 								{ content: [{ type: "text", text: errorMessage }], isError: true },
 								false,
@@ -360,8 +367,8 @@ export class UiHelpers {
 							);
 						} else {
 							const normalizedArgs =
-								content.arguments && typeof content.arguments === "object" && !Array.isArray(content.arguments)
-									? (content.arguments as Record<string, unknown>)
+								renderArgs && typeof renderArgs === "object" && !Array.isArray(renderArgs)
+									? (renderArgs as Record<string, unknown>)
 									: {};
 							readToolCallArgs.set(content.id, normalizedArgs);
 							if (assistantComponent) {
@@ -373,10 +380,6 @@ export class UiHelpers {
 
 					readGroup = null;
 					const tool = this.ctx.session.getToolByName(content.name);
-					const renderArgs =
-						"partialJson" in content
-							? { ...content.arguments, __partialJson: content.partialJson }
-							: content.arguments;
 					const component = new ToolExecutionComponent(
 						content.name,
 						renderArgs,

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -73,7 +73,7 @@ import {
 	splitInternalUrlSel,
 	splitPathAndSel,
 } from "./path-utils";
-import { formatBytes, replaceTabs, shortenPath, wrapBrackets } from "./render-utils";
+import { extractPartialJsonFilePath, formatBytes, replaceTabs, shortenPath, wrapBrackets } from "./render-utils";
 import {
 	executeReadQuery,
 	getRowByKey,
@@ -2314,15 +2314,26 @@ interface ReadRenderArgs {
 	offset?: number;
 	limit?: number;
 	raw?: boolean;
+	/**
+	 * Raw in-flight `partialJson` buffer forwarded by `event-controller.ts`
+	 * so the renderer can surface the `path` field before the throttled
+	 * structured `arguments` parse catches up on slow providers. See
+	 * {@link extractPartialJsonFilePath}.
+	 */
+	__partialJson?: string;
 }
 
 export const readToolRenderer = {
 	renderCall(args: ReadRenderArgs, _options: RenderResultOptions, uiTheme: Theme): Component {
-		if (isReadableUrlPath(args.file_path || args.path || "")) {
-			return renderReadUrlCall(args, _options, uiTheme);
+		const targetPath = args.file_path || args.path || extractPartialJsonFilePath(args) || "";
+		if (isReadableUrlPath(targetPath)) {
+			// Resolve the URL on the args object so `renderReadUrlCall` sees it even
+			// when only `__partialJson` carries the path during streaming.
+			const urlArgs = args.path || args.file_path ? args : { ...args, path: targetPath };
+			return renderReadUrlCall(urlArgs, _options, uiTheme);
 		}
 
-		const rawPath = args.file_path || args.path || "";
+		const rawPath = targetPath;
 		const shortPath = shortenPath(rawPath);
 		const linkTarget = tryResolveInternalUrlSync(rawPath);
 		const filePath = linkTarget ? fileHyperlink(linkTarget, shortPath) : shortPath;

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -788,3 +788,57 @@ export function getLspBatchRequest(toolCall: ToolCallContext | undefined): LspBa
 	const hasLaterWrites = toolCall.toolCalls.slice(toolCall.index + 1).some(call => LSP_BATCH_TOOLS.has(call.name));
 	return { id: toolCall.batchId, flush: !hasLaterWrites };
 }
+
+// =============================================================================
+// Streaming Partial-JSON Helpers
+// =============================================================================
+
+/**
+ * Decode a JSON-string fragment that may have been cut mid-escape during
+ * streaming. Trims trailing partial `\uXXXX` and orphaned `\` so {@link JSON.parse}
+ * sees a well-formed string; falls back to the raw text if parsing still fails.
+ */
+export function decodePartialJsonStringFragment(fragment: string): string {
+	let text = fragment.replace(/\\u[0-9a-fA-F]{0,3}$/, "");
+	const trailingBackslashes = text.match(/\\+$/)?.[0].length ?? 0;
+	if (trailingBackslashes % 2 === 1) text = text.slice(0, -1);
+	try {
+		return JSON.parse(`"${text}"`) as string;
+	} catch {
+		// Streaming fragment isn't a valid JSON string yet; surface it raw rather
+		// than ad-hoc unescaping that mishandles surrogates and partial escapes.
+		return text;
+	}
+}
+
+/**
+ * Pull the value of a top-level string-typed JSON field out of an in-flight
+ * `partialJson` buffer (e.g. the `path` field of a tool-call argument blob)
+ * before the structured `arguments` parse has caught up. Returns `undefined`
+ * when the field is absent or its opening `"` has not arrived yet.
+ *
+ * Used by tool renderers (write, read, edit) to show file paths during
+ * streaming on providers that emit small deltas, where
+ * `parseStreamingJsonThrottled` blocks every mid-stream parse until the
+ * accumulated buffer grows ≥256 bytes — small write/read payloads finish
+ * below that threshold and only land in `content.arguments` at `toolcall_end`.
+ */
+export function extractPartialJsonString(partialJson: string | undefined, key: string): string | undefined {
+	if (!partialJson) return undefined;
+	const pattern = new RegExp(`"${key}"\\s*:\\s*"((?:\\\\.|[^"\\\\])*)`, "u");
+	const match = pattern.exec(partialJson);
+	if (!match) return undefined;
+	return decodePartialJsonStringFragment(match[1]);
+}
+
+/**
+ * Read a `path` (or legacy `file_path`) string out of `__partialJson` for
+ * renderers that take a `{ path?, file_path?, __partialJson? }` arg shape.
+ * Returns the first key with a recoverable value so callers can use it as the
+ * tail of a `args.file_path || args.path || extractPartialJsonFilePath(args)` chain.
+ */
+export function extractPartialJsonFilePath(args: { __partialJson?: string }): string | undefined {
+	const partial = args.__partialJson;
+	if (!partial) return undefined;
+	return extractPartialJsonString(partial, "path") ?? extractPartialJsonString(partial, "file_path");
+}

--- a/packages/coding-agent/src/tools/render-utils.ts
+++ b/packages/coding-agent/src/tools/render-utils.ts
@@ -832,6 +832,18 @@ export function extractPartialJsonString(partialJson: string | undefined, key: s
 }
 
 /**
+ * Return true once the closing quote for a string-typed JSON field is present
+ * in an in-flight `partialJson` buffer. Renderers may still display incomplete
+ * fragments, but routing code must know whether a prefix like `skill` is a
+ * complete filesystem path or an incomplete internal URL scheme.
+ */
+export function partialJsonStringFieldIsComplete(partialJson: string | undefined, key: string): boolean {
+	if (!partialJson) return false;
+	const pattern = new RegExp(`"${key}"\\s*:\\s*"((?:\\\\.|[^"\\\\])*)"`, "u");
+	return pattern.test(partialJson);
+}
+
+/**
  * Read a `path` (or legacy `file_path`) string out of `__partialJson` for
  * renderers that take a `{ path?, file_path?, __partialJson? }` arg shape.
  * Returns the first key with a recoverable value so callers can use it as the

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -36,6 +36,7 @@ import { type OutputMeta, outputMeta } from "./output-meta";
 import { formatPathRelativeToCwd, isInternalUrlPath } from "./path-utils";
 import { enforcePlanModeWrite, resolvePlanPath } from "./plan-mode-guard";
 import {
+	extractPartialJsonFilePath,
 	formatDiagnostics,
 	formatExpandHint,
 	formatMoreItems,
@@ -898,6 +899,13 @@ interface WriteRenderArgs {
 	path?: string;
 	file_path?: string;
 	content?: string;
+	/**
+	 * Raw in-flight `partialJson` buffer forwarded by `event-controller.ts`
+	 * so the renderer can surface the `path` field before the throttled
+	 * structured `arguments` parse catches up on slow providers. See
+	 * {@link extractPartialJsonFilePath}.
+	 */
+	__partialJson?: string;
 }
 
 const WRITE_PREVIEW_LINES = 6;
@@ -973,7 +981,7 @@ function renderContentPreview(
 
 export const writeToolRenderer = {
 	renderCall(args: WriteRenderArgs, options: RenderResultOptions, uiTheme: Theme): Component {
-		const rawPath = args.file_path || args.path || "";
+		const rawPath = args.file_path || args.path || extractPartialJsonFilePath(args) || "";
 		const filePath = shortenPath(rawPath);
 		const lang = getLanguageFromPath(rawPath) ?? "text";
 		const langIcon = uiTheme.fg("muted", uiTheme.getLangIcon(lang));

--- a/packages/coding-agent/test/tools/write-read-partial-json-path.test.ts
+++ b/packages/coding-agent/test/tools/write-read-partial-json-path.test.ts
@@ -1,0 +1,183 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import {
+	ReadToolGroupComponent,
+	readArgsTargetInternalUrl,
+} from "@oh-my-pi/pi-coding-agent/modes/components/read-tool-group";
+import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { readToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/read";
+import {
+	decodePartialJsonStringFragment,
+	extractPartialJsonFilePath,
+	extractPartialJsonString,
+} from "@oh-my-pi/pi-coding-agent/tools/render-utils";
+import { writeToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/write";
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true, cwd: process.cwd() });
+});
+
+async function getUiTheme() {
+	await themeModule.initTheme(false, undefined, undefined, "dark", "light");
+	const t = await themeModule.getThemeByName("dark");
+	expect(t).toBeDefined();
+	return t!;
+}
+
+describe("extractPartialJsonString", () => {
+	it("returns undefined for missing/empty buffer or absent key", () => {
+		expect(extractPartialJsonString(undefined, "path")).toBeUndefined();
+		expect(extractPartialJsonString("", "path")).toBeUndefined();
+		expect(extractPartialJsonString('{"other":"x"}', "path")).toBeUndefined();
+	});
+
+	it("recovers a complete string value", () => {
+		expect(extractPartialJsonString('{"path":"/tmp/foo.txt"}', "path")).toBe("/tmp/foo.txt");
+	});
+
+	it("recovers a value whose closing quote has not arrived yet", () => {
+		// Streaming chunk: opening `"` is in the buffer, closing `"` is not.
+		expect(extractPartialJsonString('{"path":"/tmp/foo.txt', "path")).toBe("/tmp/foo.txt");
+	});
+
+	it("decodes JSON escapes inside the recovered fragment", () => {
+		expect(extractPartialJsonString('{"path":"a\\nb\\tc"', "path")).toBe("a\nb\tc");
+	});
+
+	it("trims a trailing unfinished `\\uXXXX` escape", () => {
+		expect(decodePartialJsonStringFragment("abc\\u12")).toBe("abc");
+		expect(extractPartialJsonString('{"path":"abc\\u12', "path")).toBe("abc");
+	});
+
+	it("drops an orphaned trailing backslash", () => {
+		expect(decodePartialJsonStringFragment("abc\\")).toBe("abc");
+	});
+
+	it("falls back to raw text when JSON.parse cannot recover the fragment", () => {
+		// Unbalanced double-quote inside the fragment — JSON.parse throws.
+		// The regex peels the quote off before we get here; this guards the
+		// pathological direct call.
+		const raw = 'a"b';
+		expect(decodePartialJsonStringFragment(raw)).toBe(raw);
+	});
+});
+
+describe("extractPartialJsonFilePath", () => {
+	it("prefers `path` over `file_path` when both are present", () => {
+		expect(
+			extractPartialJsonFilePath({
+				__partialJson: '{"path":"/a","file_path":"/b"}',
+			}),
+		).toBe("/a");
+	});
+
+	it("falls back to legacy `file_path`", () => {
+		expect(extractPartialJsonFilePath({ __partialJson: '{"file_path":"/legacy"' })).toBe("/legacy");
+	});
+
+	it("returns undefined without __partialJson", () => {
+		expect(extractPartialJsonFilePath({})).toBeUndefined();
+	});
+});
+
+describe("writeToolRenderer.renderCall — streaming __partialJson fallback", () => {
+	it("surfaces the path from __partialJson before structured args parse", async () => {
+		const uiTheme = await getUiTheme();
+		const component = writeToolRenderer.renderCall(
+			{ __partialJson: '{"path":"/tmp/hello.sh","content":"#!/bin/sh\\necho' } as never,
+			{ expanded: false, isPartial: true, spinnerFrame: 0 } as never,
+			uiTheme,
+		);
+		const rendered = Bun.stripANSI(component.render(160).join("\n"));
+		expect(rendered).toContain("/tmp/hello.sh");
+	});
+
+	it("falls back to __partialJson for the legacy `file_path` key", async () => {
+		const uiTheme = await getUiTheme();
+		const component = writeToolRenderer.renderCall(
+			{ __partialJson: '{"file_path":"/tmp/legacy.md","content":"hi' } as never,
+			{ expanded: false, isPartial: true, spinnerFrame: 0 } as never,
+			uiTheme,
+		);
+		const rendered = Bun.stripANSI(component.render(160).join("\n"));
+		expect(rendered).toContain("/tmp/legacy.md");
+	});
+
+	it("prefers the structured `path` field when both sources are present", async () => {
+		const uiTheme = await getUiTheme();
+		const component = writeToolRenderer.renderCall(
+			{
+				path: "/tmp/structured.ts",
+				__partialJson: '{"path":"/tmp/partial.ts"',
+			} as never,
+			{ expanded: false, isPartial: true, spinnerFrame: 0 } as never,
+			uiTheme,
+		);
+		const rendered = Bun.stripANSI(component.render(160).join("\n"));
+		expect(rendered).toContain("/tmp/structured.ts");
+		expect(rendered).not.toContain("/tmp/partial.ts");
+	});
+});
+
+describe("readToolRenderer.renderCall — streaming __partialJson fallback", () => {
+	it("surfaces the path from __partialJson before structured args parse", async () => {
+		const uiTheme = await getUiTheme();
+		const component = readToolRenderer.renderCall(
+			{ __partialJson: '{"path":"/tmp/notes.txt"' } as never,
+			{} as never,
+			uiTheme,
+		);
+		const rendered = Bun.stripANSI(component.render(160).join("\n"));
+		expect(rendered).toContain("/tmp/notes.txt");
+	});
+
+	it("routes to the URL renderer when __partialJson reveals a URL target", async () => {
+		const uiTheme = await getUiTheme();
+		const component = readToolRenderer.renderCall(
+			{ __partialJson: '{"path":"https://example.com/docs"' } as never,
+			{} as never,
+			uiTheme,
+		);
+		const rendered = Bun.stripANSI(component.render(160).join("\n"));
+		// URL renderer surfaces the host; the file-read renderer would emit a `Read:` prefix.
+		expect(rendered).toContain("example.com");
+	});
+});
+
+describe("readArgsTargetInternalUrl — partial-json aware", () => {
+	it("recognises an internal URL streamed only via __partialJson", () => {
+		expect(readArgsTargetInternalUrl({ __partialJson: '{"path":"skill://my-skill"' })).toBe(true);
+		expect(readArgsTargetInternalUrl({ __partialJson: '{"file_path":"agent://abc"' })).toBe(true);
+	});
+
+	it("returns false for a filesystem path streamed only via __partialJson", () => {
+		expect(readArgsTargetInternalUrl({ __partialJson: '{"path":"/tmp/foo.txt"' })).toBe(false);
+	});
+
+	it("ignores __partialJson when structured fields already carry a target", () => {
+		// Structured path wins; partial buffer's stale value is irrelevant.
+		expect(
+			readArgsTargetInternalUrl({
+				path: "/tmp/real.txt",
+				__partialJson: '{"path":"skill://stale"',
+			}),
+		).toBe(false);
+	});
+});
+
+describe("ReadToolGroupComponent.updateArgs — partial-json fallback", () => {
+	it("renders the path from __partialJson when structured fields are still empty", () => {
+		const group = new ReadToolGroupComponent();
+		group.updateArgs({ __partialJson: '{"path":"/tmp/streamed.log"' } as never, "tc-1");
+		const rendered = Bun.stripANSI(group.render(160).join("\n"));
+		expect(rendered).toContain("/tmp/streamed.log");
+	});
+
+	it("appends `:sel` to the partial-json path", () => {
+		const group = new ReadToolGroupComponent();
+		group.updateArgs({ sel: "10-20", __partialJson: '{"path":"/tmp/range.log"' } as never, "tc-2");
+		const rendered = Bun.stripANSI(group.render(160).join("\n"));
+		expect(rendered).toContain("/tmp/range.log:10-20");
+	});
+});

--- a/packages/coding-agent/test/tools/write-read-partial-json-path.test.ts
+++ b/packages/coding-agent/test/tools/write-read-partial-json-path.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, it } from "bun:test";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
 	ReadToolGroupComponent,
+	readArgsHaveTarget,
 	readArgsTargetInternalUrl,
 } from "@oh-my-pi/pi-coding-agent/modes/components/read-tool-group";
 import * as themeModule from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
@@ -149,6 +150,26 @@ describe("readArgsTargetInternalUrl — partial-json aware", () => {
 	it("recognises an internal URL streamed only via __partialJson", () => {
 		expect(readArgsTargetInternalUrl({ __partialJson: '{"path":"skill://my-skill"' })).toBe(true);
 		expect(readArgsTargetInternalUrl({ __partialJson: '{"file_path":"agent://abc"' })).toBe(true);
+	});
+
+	it("defers incomplete prefixes that could still become an internal URL", () => {
+		for (const prefix of ["s", "skill", "skill:", "skill:/"]) {
+			const args = { __partialJson: `{"path":"${prefix}` };
+			expect(readArgsHaveTarget(args)).toBe(false);
+			expect(readArgsTargetInternalUrl(args)).toBe(false);
+		}
+	});
+
+	it("classifies an internal URL as soon as the scheme delimiter arrives", () => {
+		const args = { __partialJson: '{"path":"skill://' };
+		expect(readArgsHaveTarget(args)).toBe(true);
+		expect(readArgsTargetInternalUrl(args)).toBe(true);
+	});
+
+	it("classifies complete path strings even when they prefix an internal scheme", () => {
+		const args = { __partialJson: '{"path":"skill"' };
+		expect(readArgsHaveTarget(args)).toBe(true);
+		expect(readArgsTargetInternalUrl(args)).toBe(false);
 	});
 
 	it("returns false for a filesystem path streamed only via __partialJson", () => {


### PR DESCRIPTION
## Repro

On providers that stream tool-call JSON in small deltas (open-source/Chinese providers, local Ollama), `write` and `read` tool-call headers display `…` instead of the file path for the entire tool-call lifecycle — the path only appears when the tool starts executing. Models that emit large deltas (OpenAI, first-party Anthropic) are unaffected. Added `packages/coding-agent/test/tools/write-read-partial-json-path.test.ts` which exercises the same arg shape `event-controller.ts` injects mid-stream (only `__partialJson` populated). Reproduces 3/3 against current main:

```
writeToolRenderer.renderCall > shows the target path from __partialJson while args stream
  Received: "Write ⣾ 🗒 …"
writeToolRenderer.renderCall > falls back to __partialJson for file_path key
  Received: "Write ⣾ 🗒 …"
readToolRenderer.renderCall > shows the target path from __partialJson while args stream
  Received: "⏳ Read: …"
0 pass, 3 fail
```

## Cause

`parseStreamingJsonThrottled` (`packages/ai/src/utils/json-parse.ts:174-181`) blocks every mid-stream `block.arguments` parse until the partialJson buffer grows by ≥256 bytes since the last parse — a deliberate O(N²) guard added in #1507. Small `write`/`read` payloads (a single `path` + short `content`) finish well below that threshold, so the structured `content.arguments` field only catches up at the unconditional `toolcall_end` parse, exactly when the tool is about to execute. The raw partialJson buffer is updated unconditionally on every delta and `event-controller.ts:368-371` already forwards it through as `__partialJson`, but:

- `tools/write.ts` `renderCall` only reads `args.file_path || args.path` and falls back to `"…"`.
- `tools/read.ts` `renderCall` does the same — and even if it didn't, `event-controller.ts:345` gates the read-group creation on `readArgsHaveTarget(content.arguments)`, which itself uses the throttled structured args.

The edit renderer already worked around this via its private `getPartialJsonEditPath` (commit `d72c583ea`); write/read did not.

## Fix

- Hoisted `extractPartialJsonString` and `decodePartialJsonStringFragment` from `edit/renderer.ts` into `tools/render-utils.ts` and added a new `extractPartialJsonFilePath` helper for the `{ path?, file_path?, __partialJson? }` arg shape. The edit renderer now imports them instead of carrying private copies.
- `writeToolRenderer.renderCall` and `readToolRenderer.renderCall` fall back to `extractPartialJsonFilePath(args)` when the structured `file_path`/`path` fields are empty. The read renderer also forwards the resolved path into `renderReadUrlCall` so the URL routing surfaces the host during streaming.
- `read-tool-group.ts` `readArgsTarget` now peeks `__partialJson` so `readArgsHaveTarget` / `readArgsTargetInternalUrl` recognise the path before the structured args parse catches up. `ReadToolGroupComponent.updateArgs` mirrors the same fallback.
- `event-controller.ts` and `ui-helpers.ts` (transcript rebuild) hoist the `renderArgs` (with `__partialJson` attached) *before* the read-tool gating so the read group is created — and routed to filesystem vs internal URL — using the partialJson-aware view. The `__partialJson` then continues through `group.updateArgs` / `ToolExecutionComponent`, preserving the existing behavior for fully parsed args.

## Verification

- `bun test packages/coding-agent/test/tools/write-read-partial-json-path.test.ts` — 20/20 pass. New suite covers: the shared helpers (escape decoding, trailing `\uXX`, orphaned backslash, raw fallback), the renderer fallbacks (write `path` + legacy `file_path`, structured-wins-over-partial precedence), URL routing via `__partialJson`, internal-URL detection via `__partialJson`, and `ReadToolGroupComponent` partial-json rendering (with `:sel` suffix).
- `bun test packages/coding-agent/test/tools/ packages/coding-agent/test/read-tool-group.test.ts packages/coding-agent/test/modes/ …` — 1031 pass, 297 skip, 2 fail. The two failures are in `packages/coding-agent/test/tools/gh.test.ts` (`pr-checkout`-creates-worktree tests, `lstat` on a worktree path that doesn't exist in this sandbox) and are pre-existing on `main` — they don't touch any code modified by this diff (grep for `partialJson|render` in that file matches only an unrelated comment).
- `bun check` — clean.

Fixes #1738