### PR TITLE
fix(tui): distrust Windows viewport probe

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed Tabby and other non-Windows Terminal ConPTY hosts clearing scrollback and jumping after prompt submit by treating native Windows viewport probes as unreportable instead of trusting the pseudo-console tail position ([#1744](https://github.com/can1357/oh-my-pi/issues/1744)).
 - Fixed Ghostty/kitty/Alacritty-style ED3-risk terminals freezing the prompt after a deferred shrink; focused keyboard input now uses the same explicit user-input viewport opt-in as autocomplete and can repaint immediately instead of waiting for a resize.
 - Fixed emoji-presentation symbols (a default-text symbol followed by variation-selector-16 `U+FE0F`, e.g. `⚠️`, `ℹ️`, `❤️`, keycaps) measuring as 1 cell instead of 2 in the native width engine on macOS. The native scanner now keeps `UnicodeWidthStr` as the source of truth for multi-codepoint graphemes and applies only the local macOS Hangul Compatibility Jamo character-width delta, preserving VS16/keycap sequence widths without reintroducing jamo cursor drift.
 - Deferred eager live scrollback rebuilds on macOS Terminal.app and iTerm2 so assistant/tool streaming no longer emits ED3 (`CSI 3 J`) while their native viewport position is unobservable, preserving readers scrolled into terminal history ([#1300](https://github.com/can1357/oh-my-pi/issues/1300)).

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -116,22 +116,19 @@ function isWindowsSubsystemForLinux(): boolean {
 /**
  * Whether the native console viewport-position probe should be consulted.
  *
- * Returns `true` only on native Windows that is *not* fronted by Windows
- * Terminal. The kernel32 `GetConsoleScreenBufferInfo` API answers about the
- * ConPTY pseudo-console — which is always pinned to its tail — and not about
- * the user-visible scrollback in modern hosts. Treat any such host as
- * unreportable so the renderer falls back to the deferred-rebuild path.
- *
- * Pure helper for unit testing; the runtime call site reads `$env` /
- * `process.platform`. See #1635.
+ * Returns `false` on Windows because modern hosts (Windows Terminal, Tabby,
+ * Hyper, VS Code, Alacritty, and similar) are fronted by ConPTY. The kernel32
+ * `GetConsoleScreenBufferInfo` API answers about the pseudo-console — which is
+ * always pinned to its tail — and not about the user-visible scrollback. Treat
+ * Windows as unreportable so the renderer falls back to the deferred-rebuild
+ * path.
+ * Pure helper for unit testing. See #1635 and #1744.
  */
 export function shouldTrustNativeViewportProbe(
-	env: { WT_SESSION?: string | undefined } = $env,
-	platform: NodeJS.Platform = process.platform,
+	_env?: { WT_SESSION?: string | undefined },
+	_platform?: NodeJS.Platform,
 ): boolean {
-	if (platform !== "win32") return false;
-	if (env.WT_SESSION) return false;
-	return true;
+	return false;
 }
 
 /**

--- a/packages/tui/test/issue-1635-repro.test.ts
+++ b/packages/tui/test/issue-1635-repro.test.ts
@@ -3,18 +3,19 @@ import { type Component, TUI } from "@oh-my-pi/pi-tui";
 import { shouldTrustNativeViewportProbe } from "@oh-my-pi/pi-tui/terminal";
 import { VirtualTerminal } from "./virtual-terminal";
 
-// Regression test for https://github.com/can1357/oh-my-pi/issues/1635
+// Regression test for https://github.com/can1357/oh-my-pi/issues/1635 and
+// https://github.com/can1357/oh-my-pi/issues/1744.
 //
-// Native Windows + Windows Terminal (ConPTY) routes `omp` through a
+// Native Windows terminals backed by ConPTY route `omp` through a
 // pseudo-console whose `GetConsoleScreenBufferInfo` answer always reports
-// "viewport at bottom" — it cannot see the WT host scrollback. When the user
-// scrolled up in WT and the renderer hit a `historyRebuild` intent (the
+// "viewport at bottom" — it cannot see the host scrollback. When the user
+// scrolled up and the renderer hit a `historyRebuild` intent (the
 // shrink-across-viewport branch), the destructive `\x1b[2J\x1b[H\x1b[3J`
-// sequence reset the WT viewport to the top of scrollback.
+// sequence reset the host viewport to the top of scrollback.
 //
-// Fix: `shouldTrustNativeViewportProbe` returns false under WT_SESSION so the
-// probe falls back to `undefined`, and the renderer's existing
-// deferred-rebuild path keeps streaming-time mutations non-destructive.
+// Fix: `shouldTrustNativeViewportProbe` returns false on Windows so the probe
+// falls back to `undefined`, and the renderer's existing deferred-rebuild path
+// keeps streaming-time mutations non-destructive.
 //
 // The renderer assertions below override the VirtualTerminal probe to simulate
 // the two relevant post-fix outcomes:
@@ -71,9 +72,9 @@ async function withPlatform<T>(platform: NodeJS.Platform, run: () => T | Promise
 
 const ERASE_SCROLLBACK = /\x1b\[3J/g;
 
-describe("issue #1635: shouldTrustNativeViewportProbe", () => {
-	it("returns true on bare native Windows (legacy console)", () => {
-		expect(shouldTrustNativeViewportProbe({}, "win32")).toBe(true);
+describe("issues #1635/#1744: shouldTrustNativeViewportProbe", () => {
+	it("returns false on native Windows because ConPTY hosts cannot report visible scrollback", () => {
+		expect(shouldTrustNativeViewportProbe({}, "win32")).toBe(false);
 	});
 
 	it("returns false when running under Windows Terminal", () => {


### PR DESCRIPTION
## Repro
On `packages/tui`, the focused repro `bun -e 'import { shouldTrustNativeViewportProbe } from "./src/terminal.ts"; const trusted = shouldTrustNativeViewportProbe({}, "win32"); if (trusted !== false) { console.error(`Tabby/non-WT ConPTY repro: expected false, got ${trusted}`); process.exit(1); }'` failed before the fix with `Tabby/non-WT ConPTY repro: expected false, got true`, matching Tabby/non-WT ConPTY hosts that do not set `WT_SESSION`.

## Cause
`packages/tui/src/terminal.ts` kept `shouldTrustNativeViewportProbe()` true for native Windows sessions without `WT_SESSION`, so `ProcessTerminal.isNativeViewportAtBottom()` could trust `GetConsoleScreenBufferInfo`; under ConPTY that API reports the pseudo-console tail rather than the host terminal's visible scrollback, letting prompt-submit checkpoints replay native scrollback destructively.

## Fix
- Changed `shouldTrustNativeViewportProbe()` to make Windows viewport position unreportable by default.
- Updated the #1635 regression test to cover #1744 and assert native Windows probes are untrusted even without `WT_SESSION`.
- Added a `packages/tui` changelog entry for Tabby/non-WT ConPTY scrollback clears.

## Verification
`bun test test/issue-1635-repro.test.ts` passed with 9 tests and 10 assertions; `bun run check` in `packages/tui` passed. `gh_push_branch` pre-publish checks also passed before pushing. Fixes #1744