### PR TITLE
fix(tui): distrust Windows ConPTY viewport probe

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Stopped trusting the native Windows viewport probe on unbranded ConPTY hosts such as Tabby so prompt-submit checkpoint rebuilds no longer clear scrollback from stale at-bottom results ([#1746](https://github.com/can1357/oh-my-pi/issues/1746)).
 - Fixed Ghostty/kitty/Alacritty-style ED3-risk terminals freezing the prompt after a deferred shrink; focused keyboard input now uses the same explicit user-input viewport opt-in as autocomplete and can repaint immediately instead of waiting for a resize.
 - Fixed emoji-presentation symbols (a default-text symbol followed by variation-selector-16 `U+FE0F`, e.g. `⚠️`, `ℹ️`, `❤️`, keycaps) measuring as 1 cell instead of 2 in the native width engine on macOS. The native scanner now keeps `UnicodeWidthStr` as the source of truth for multi-codepoint graphemes and applies only the local macOS Hangul Compatibility Jamo character-width delta, preserving VS16/keycap sequence widths without reintroducing jamo cursor drift.
 - Deferred eager live scrollback rebuilds on macOS Terminal.app and iTerm2 so assistant/tool streaming no longer emits ED3 (`CSI 3 J`) while their native viewport position is unobservable, preserving readers scrolled into terminal history ([#1300](https://github.com/can1357/oh-my-pi/issues/1300)).

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -116,22 +116,21 @@ function isWindowsSubsystemForLinux(): boolean {
 /**
  * Whether the native console viewport-position probe should be consulted.
  *
- * Returns `true` only on native Windows that is *not* fronted by Windows
- * Terminal. The kernel32 `GetConsoleScreenBufferInfo` API answers about the
- * ConPTY pseudo-console — which is always pinned to its tail — and not about
- * the user-visible scrollback in modern hosts. Treat any such host as
- * unreportable so the renderer falls back to the deferred-rebuild path.
+ * Returns `false` on Windows because modern hosts (Windows Terminal, Tabby,
+ * VS Code, Hyper, Alacritty, etc.) front the process with ConPTY. The kernel32
+ * `GetConsoleScreenBufferInfo` API answers about that pseudo-console — which is
+ * always pinned to its tail — and not about the user-visible host scrollback.
+ * Treat Windows as unreportable so the renderer falls back to the deferred
+ * rebuild path rather than clearing native scrollback from a stale positive.
  *
- * Pure helper for unit testing; the runtime call site reads `$env` /
- * `process.platform`. See #1635.
+ * Parameters are retained for callers/tests that model host environments. See
+ * #1635 and #1746.
  */
 export function shouldTrustNativeViewportProbe(
-	env: { WT_SESSION?: string | undefined } = $env,
-	platform: NodeJS.Platform = process.platform,
+	_env?: { WT_SESSION?: string | undefined },
+	_platform?: NodeJS.Platform,
 ): boolean {
-	if (platform !== "win32") return false;
-	if (env.WT_SESSION) return false;
-	return true;
+	return false;
 }
 
 /**
@@ -236,14 +235,13 @@ export class ProcessTerminal implements Terminal {
 	 * Returns true when Windows' active console viewport is at the scrollback tail.
 	 * POSIX terminals do not expose native scrollback position through a standard API.
 	 *
-	 * On native Windows running under Windows Terminal (the default modern
-	 * host), the `kernel32` probe answers about the ConPTY pseudo-console — not
-	 * the user-visible WT viewport — so it would always read "at bottom" while
-	 * the user is scrolled up. Return `undefined` there so the renderer falls
-	 * back to the POSIX-style deferred-rebuild path: streaming mutations stay
-	 * non-destructive (no `\x1b[3J`), and the rebuild fires at the next prompt
-	 * checkpoint via {@link TUI.refreshNativeScrollbackIfDirty} where the user
-	 * is already pinned to the bottom by the editor keystroke. See #1635.
+	 * On Windows, modern hosts commonly route `omp` through ConPTY. The kernel32
+	 * probe answers about the pseudo-console — not the user-visible host viewport
+	 * — so it can always read "at bottom" while the user is scrolled up. Return
+	 * `undefined` there so the renderer falls back to the POSIX-style
+	 * deferred-rebuild path: streaming mutations stay non-destructive (no
+	 * `\x1b[3J`), and checkpoint rebuilds do not trust stale ConPTY positives.
+	 * See #1635 and #1746.
 	 */
 	isNativeViewportAtBottom(): boolean | undefined {
 		if (!shouldTrustNativeViewportProbe()) return undefined;

--- a/packages/tui/test/issue-1635-repro.test.ts
+++ b/packages/tui/test/issue-1635-repro.test.ts
@@ -5,21 +5,22 @@ import { VirtualTerminal } from "./virtual-terminal";
 
 // Regression test for https://github.com/can1357/oh-my-pi/issues/1635
 //
-// Native Windows + Windows Terminal (ConPTY) routes `omp` through a
-// pseudo-console whose `GetConsoleScreenBufferInfo` answer always reports
-// "viewport at bottom" — it cannot see the WT host scrollback. When the user
-// scrolled up in WT and the renderer hit a `historyRebuild` intent (the
-// shrink-across-viewport branch), the destructive `\x1b[2J\x1b[H\x1b[3J`
-// sequence reset the WT viewport to the top of scrollback.
+// Native Windows terminals commonly route `omp` through ConPTY. The kernel32
+// `GetConsoleScreenBufferInfo` answer reports the pseudo-console viewport,
+// which is always pinned to its tail, not the user-visible host scrollback.
+// When the user scrolled up in a ConPTY host (Windows Terminal, Tabby, etc.)
+// and the renderer hit a `historyRebuild` intent (the shrink-across-viewport
+// branch), the destructive `\x1b[2J\x1b[H\x1b[3J` sequence reset the host
+// viewport to the top of scrollback.
 //
-// Fix: `shouldTrustNativeViewportProbe` returns false under WT_SESSION so the
-// probe falls back to `undefined`, and the renderer's existing
-// deferred-rebuild path keeps streaming-time mutations non-destructive.
+// Fix: `shouldTrustNativeViewportProbe` returns false on Windows so the probe
+// falls back to `undefined`, and the renderer's existing deferred-rebuild path
+// keeps streaming-time mutations non-destructive.
 //
 // The renderer assertions below override the VirtualTerminal probe to simulate
 // the two relevant post-fix outcomes:
 //
-//  - `undefined`: probe is unreportable (WT-hosted on win32, or any POSIX
+//  - `undefined`: probe is unreportable (Windows ConPTY hosts, or any POSIX
 //                 host where the probe never had an answer to begin with).
 //  - `false`:     the host can see scrollback and reports the user scrolled
 //                 up. Both must avoid `\x1b[3J`.
@@ -72,8 +73,8 @@ async function withPlatform<T>(platform: NodeJS.Platform, run: () => T | Promise
 const ERASE_SCROLLBACK = /\x1b\[3J/g;
 
 describe("issue #1635: shouldTrustNativeViewportProbe", () => {
-	it("returns true on bare native Windows (legacy console)", () => {
-		expect(shouldTrustNativeViewportProbe({}, "win32")).toBe(true);
+	it("returns false on unbranded native Windows ConPTY hosts", () => {
+		expect(shouldTrustNativeViewportProbe({}, "win32")).toBe(false);
 	});
 
 	it("returns false when running under Windows Terminal", () => {


### PR DESCRIPTION
## Repro
On the previous code, `bun --cwd packages/tui --eval 'import { shouldTrustNativeViewportProbe } from "./src/terminal.ts"; const actual = shouldTrustNativeViewportProbe({}, "win32"); if (actual !== false) { throw new Error(`expected unbranded win32 ConPTY hosts to be untrusted, got ${actual}`); }'` failed with `got true`, matching Tabby-style ConPTY hosts that do not set `WT_SESSION`.

## Cause
`packages/tui/src/terminal.ts` only made `ProcessTerminal.isNativeViewportAtBottom()` skip the kernel32 probe when `shouldTrustNativeViewportProbe()` saw `WT_SESSION`; unbranded ConPTY hosts therefore fed stale `true` viewport-at-bottom results into `TUI.refreshNativeScrollbackIfDirty()`, allowing the checkpoint render to emit a scrollback-clearing session replace.

## Fix
- Changed `shouldTrustNativeViewportProbe()` to never trust the native Windows viewport probe, treating Windows hosts as unreportable instead of risking stale ConPTY positives.
- Updated the issue #1635 regression test and comments to cover unbranded ConPTY hosts such as Tabby.
- Added the `packages/tui` changelog entry for #1746.

## Verification
`bun test packages/tui/test/issue-1635-repro.test.ts` passed with 9 tests; `bun run --cwd packages/tui check` passed; the focused repro command now exits successfully. Fixes #1746