### PR TITLE
fix(coding-agent): derived web-search selector from provider registry

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed the TUI/CLI web-search provider selector silently omitting and mis-ordering registered providers when its hand-maintained options list drifted from the provider registry. `providers.webSearch` schema values and `ui.options`, the setup wizard's selector, and the `omp web-search --provider` choices are now derived from a single `PROVIDER_META` table in `web/search/provider.ts` (with a compile-time exhaustiveness check), so registering a new web-search provider exposes it in every UI surface in chain order ([#1756](https://github.com/can1357/oh-my-pi/issues/1756)).
 - Fixed `/review`'s uncommitted-change mode in Jujutsu repositories to read `jj diff --git` from the current workspace, so non-default JJ workspaces include their working-copy changes instead of falling back to the colocated Git checkout.
 - Fixed empty assistant stop retry continuations preserving auto-retry state until a non-empty assistant turn completes or recovery reaches its retry cap.
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -23,6 +23,7 @@ import {
 	TINY_TITLE_MODEL_VALUES,
 } from "../tiny/models";
 import { EDIT_MODES } from "../utils/edit-mode";
+import { SEARCH_PROVIDER_OPTIONS, SEARCH_PROVIDER_PREFERENCES } from "../web/search/provider";
 
 /** Unified settings schema - single source of truth for all settings.
  * Unified settings schema - single source of truth for all settings.
@@ -2866,65 +2867,13 @@ export const SETTINGS_SCHEMA = {
 	// Provider selection
 	"providers.webSearch": {
 		type: "enum",
-		values: [
-			"auto",
-			"exa",
-			"brave",
-			"jina",
-			"kimi",
-			"zai",
-			"perplexity",
-			"anthropic",
-			"gemini",
-			"codex",
-			"tavily",
-			"kagi",
-			"synthetic",
-			"parallel",
-			"searxng",
-		] as const,
+		values: SEARCH_PROVIDER_PREFERENCES,
 		default: "auto",
 		ui: {
 			tab: "providers",
 			label: "Web Search Provider",
 			description: "Provider for web search tool",
-			options: [
-				{
-					value: "auto",
-					label: "Auto",
-					description: "Preferred web-search provider",
-				},
-				{ value: "exa", label: "Exa", description: "Requires EXA_API_KEY" },
-				{ value: "brave", label: "Brave", description: "Requires BRAVE_API_KEY" },
-				{ value: "jina", label: "Jina", description: "Requires JINA_API_KEY" },
-				{ value: "kimi", label: "Kimi", description: "Requires MOONSHOT_SEARCH_API_KEY or MOONSHOT_API_KEY" },
-				{
-					value: "perplexity",
-					label: "Perplexity",
-					description: "Requires PERPLEXITY_COOKIES or PERPLEXITY_API_KEY",
-				},
-				{
-					value: "anthropic",
-					label: "Anthropic",
-					description: "Claude's native web_search tool (uses Anthropic OAuth or ANTHROPIC_API_KEY)",
-				},
-				{
-					value: "codex",
-					label: "OpenAI",
-					description: "OpenAI's native web_search (uses ChatGPT OAuth via /login openai-codex)",
-				},
-				{
-					value: "gemini",
-					label: "Gemini",
-					description: "Google Search grounding via Gemini (uses google-gemini-cli or google-antigravity OAuth)",
-				},
-				{ value: "zai", label: "Z.AI", description: "Calls Z.AI webSearchPrime MCP" },
-				{ value: "tavily", label: "Tavily", description: "Requires TAVILY_API_KEY" },
-				{ value: "kagi", label: "Kagi", description: "Requires KAGI_API_KEY (Kagi V1 Search API)" },
-				{ value: "synthetic", label: "Synthetic", description: "Requires SYNTHETIC_API_KEY" },
-				{ value: "parallel", label: "Parallel", description: "Requires PARALLEL_API_KEY" },
-				{ value: "searxng", label: "SearXNG", description: "Requires SEARXNG_ENDPOINT or searxng.endpoint" },
-			],
+			options: SEARCH_PROVIDER_OPTIONS,
 		},
 	},
 	"providers.image": {

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -1,12 +1,16 @@
 // Lazy registry of web search providers.
 //
+// `PROVIDER_META` is the **single source of truth** for the web-search provider
+// chain: order, label, credential hint, and lazy loader all live here. The
+// settings schema (`providers.webSearch`), the TUI setup wizard, and the CLI
+// `omp web-search` command derive their option lists from this table, so a new
+// provider only needs an entry here (plus its module) to be exposed
+// everywhere.
+//
 // Each provider is loaded on first use; importing this module loads zero
 // provider implementations. Provider modules are heavy (each pulls in
 // fetch/parse/format helpers) and only one — at most — is needed per session,
 // so eager construction was wasted work at startup.
-//
-// The `label`/`id` metadata is kept inline so callers needing a display name
-// (error formatting, UI listings) do not force a load.
 
 import type { AuthStorage } from "@oh-my-pi/pi-ai";
 import type { SearchProvider } from "./providers/base";
@@ -16,90 +20,124 @@ export type { SearchParams } from "./providers/base";
 export { SearchProvider } from "./providers/base";
 
 interface ProviderMeta {
-	id: SearchProviderId;
-	label: string;
-	load: () => Promise<SearchProvider>;
+	readonly id: SearchProviderId;
+	readonly label: string;
+	/** Short credential/setup hint surfaced in the TUI selector. */
+	readonly description: string;
+	readonly load: () => Promise<SearchProvider>;
 }
 
-/** Lazy factories. Each `load()` dynamic-imports its provider module on first call. */
-const PROVIDER_META: Record<SearchProviderId, ProviderMeta> = {
-	exa: {
-		id: "exa",
-		label: "Exa",
-		load: async () => new (await import("./providers/exa")).ExaProvider(),
-	},
-	brave: {
-		id: "brave",
-		label: "Brave",
-		load: async () => new (await import("./providers/brave")).BraveProvider(),
-	},
-	jina: {
-		id: "jina",
-		label: "Jina",
-		load: async () => new (await import("./providers/jina")).JinaProvider(),
-	},
-	perplexity: {
-		id: "perplexity",
-		label: "Perplexity",
-		load: async () => new (await import("./providers/perplexity")).PerplexityProvider(),
-	},
-	kimi: {
-		id: "kimi",
-		label: "Kimi",
-		load: async () => new (await import("./providers/kimi")).KimiProvider(),
-	},
-	zai: {
-		id: "zai",
-		label: "Z.AI",
-		load: async () => new (await import("./providers/zai")).ZaiProvider(),
-	},
-	anthropic: {
-		id: "anthropic",
-		label: "Anthropic",
-		load: async () => new (await import("./providers/anthropic")).AnthropicProvider(),
-	},
-	gemini: {
-		id: "gemini",
-		label: "Gemini",
-		load: async () => new (await import("./providers/gemini")).GeminiProvider(),
-	},
-	codex: {
-		id: "codex",
-		label: "OpenAI",
-		load: async () => new (await import("./providers/codex")).CodexProvider(),
-	},
-	tavily: {
+/**
+ * Canonical chain order. `resolveProviderChain` walks providers in this order
+ * during `auto` resolution, and `SEARCH_PROVIDER_OPTIONS` mirrors it (after
+ * `auto`) so the TUI/CLI preference list reflects the same priority the
+ * resolver uses.
+ */
+const PROVIDER_META = [
+	{
 		id: "tavily",
 		label: "Tavily",
+		description: "Requires TAVILY_API_KEY",
 		load: async () => new (await import("./providers/tavily")).TavilyProvider(),
 	},
-	parallel: {
+	{
+		id: "perplexity",
+		label: "Perplexity",
+		description: "Requires PERPLEXITY_COOKIES or PERPLEXITY_API_KEY",
+		load: async () => new (await import("./providers/perplexity")).PerplexityProvider(),
+	},
+	{
+		id: "brave",
+		label: "Brave",
+		description: "Requires BRAVE_API_KEY",
+		load: async () => new (await import("./providers/brave")).BraveProvider(),
+	},
+	{
+		id: "jina",
+		label: "Jina",
+		description: "Requires JINA_API_KEY",
+		load: async () => new (await import("./providers/jina")).JinaProvider(),
+	},
+	{
+		id: "kimi",
+		label: "Kimi",
+		description: "Requires MOONSHOT_SEARCH_API_KEY or MOONSHOT_API_KEY",
+		load: async () => new (await import("./providers/kimi")).KimiProvider(),
+	},
+	{
+		id: "anthropic",
+		label: "Anthropic",
+		description: "Claude's native web_search tool (uses Anthropic OAuth or ANTHROPIC_API_KEY)",
+		load: async () => new (await import("./providers/anthropic")).AnthropicProvider(),
+	},
+	{
+		id: "gemini",
+		label: "Gemini",
+		description: "Google Search grounding via Gemini (uses google-gemini-cli or google-antigravity OAuth)",
+		load: async () => new (await import("./providers/gemini")).GeminiProvider(),
+	},
+	{
+		id: "codex",
+		label: "OpenAI",
+		description: "OpenAI's native web_search (uses ChatGPT OAuth via /login openai-codex)",
+		load: async () => new (await import("./providers/codex")).CodexProvider(),
+	},
+	{
+		id: "zai",
+		label: "Z.AI",
+		description: "Calls Z.AI webSearchPrime MCP",
+		load: async () => new (await import("./providers/zai")).ZaiProvider(),
+	},
+	{
+		id: "exa",
+		label: "Exa",
+		description: "Requires EXA_API_KEY",
+		load: async () => new (await import("./providers/exa")).ExaProvider(),
+	},
+	{
 		id: "parallel",
 		label: "Parallel",
+		description: "Requires PARALLEL_API_KEY",
 		load: async () => new (await import("./providers/parallel")).ParallelProvider(),
 	},
-	kagi: {
+	{
 		id: "kagi",
 		label: "Kagi",
+		description: "Requires KAGI_API_KEY (Kagi V1 Search API)",
 		load: async () => new (await import("./providers/kagi")).KagiProvider(),
 	},
-	synthetic: {
+	{
 		id: "synthetic",
 		label: "Synthetic",
+		description: "Requires SYNTHETIC_API_KEY",
 		load: async () => new (await import("./providers/synthetic")).SyntheticProvider(),
 	},
-	searxng: {
+	{
 		id: "searxng",
 		label: "SearXNG",
+		description: "Requires SEARXNG_ENDPOINT or searxng.endpoint",
 		load: async () => new (await import("./providers/searxng")).SearXNGProvider(),
 	},
-};
+] as const satisfies readonly ProviderMeta[];
+
+// Compile-time exhaustiveness: a new `SearchProviderId` without a
+// `PROVIDER_META` entry fails type-checking here, which in turn means it would
+// be missing from the TUI/CLI selectors.
+type _AllIdsRegistered = Exclude<SearchProviderId, (typeof PROVIDER_META)[number]["id"]> extends never
+	? true
+	: never;
+const _allIdsRegistered: _AllIdsRegistered = true;
+void _allIdsRegistered;
+
+const META_BY_ID: ReadonlyMap<SearchProviderId, ProviderMeta> = new Map(
+	PROVIDER_META.map(meta => [meta.id, meta]),
+);
 
 const instanceCache = new Map<SearchProviderId, SearchProvider>();
 
 /** Cheap, sync metadata accessor — never triggers a provider load. */
 export function getSearchProviderLabel(id: SearchProviderId): string {
-	return PROVIDER_META[id]?.label ?? id;
+	return META_BY_ID.get(id)?.label ?? id;
 }
 
 /**
@@ -109,7 +147,7 @@ export function getSearchProviderLabel(id: SearchProviderId): string {
 export async function getSearchProvider(id: SearchProviderId): Promise<SearchProvider> {
 	const cached = instanceCache.get(id);
 	if (cached) return cached;
-	const meta = PROVIDER_META[id];
+	const meta = META_BY_ID.get(id);
 	if (!meta) {
 		throw new Error(`Unknown search provider: ${id}`);
 	}
@@ -118,28 +156,37 @@ export async function getSearchProvider(id: SearchProviderId): Promise<SearchPro
 	return provider;
 }
 
-export const SEARCH_PROVIDER_ORDER: SearchProviderId[] = [
-	"tavily",
-	"perplexity",
-	"brave",
-	"jina",
-	"kimi",
-	"anthropic",
-	"gemini",
-	"codex",
-	"zai",
-	"exa",
-	"parallel",
-	"kagi",
-	"synthetic",
-	"searxng",
+/** Canonical provider chain — the order `auto` resolution walks providers. */
+export const SEARCH_PROVIDER_ORDER: readonly SearchProviderId[] = PROVIDER_META.map(meta => meta.id);
+
+/**
+ * Allowed values for `providers.webSearch`: `auto` followed by every registered
+ * provider id, in chain order. Used as the settings schema enum domain.
+ */
+export const SEARCH_PROVIDER_PREFERENCES = ["auto", ...PROVIDER_META.map(meta => meta.id)] as const;
+
+/** Stored preference value: `auto` or one of the registered provider ids. */
+export type SearchProviderPreference = (typeof SEARCH_PROVIDER_PREFERENCES)[number];
+
+/** UI option metadata for the TUI selector — `auto` first, then providers in chain order. */
+export const SEARCH_PROVIDER_OPTIONS: ReadonlyArray<{
+	readonly value: SearchProviderPreference;
+	readonly label: string;
+	readonly description: string;
+}> = [
+	{ value: "auto", label: "Auto", description: "Preferred web-search provider" },
+	...PROVIDER_META.map(meta => ({
+		value: meta.id,
+		label: meta.label,
+		description: meta.description,
+	})),
 ];
 
 /** Preferred provider set via settings (default: auto) */
-let preferredProvId: SearchProviderId | "auto" = "auto";
+let preferredProvId: SearchProviderPreference = "auto";
 
 /** Set the preferred web search provider from settings */
-export function setPreferredSearchProvider(provider: SearchProviderId | "auto"): void {
+export function setPreferredSearchProvider(provider: SearchProviderPreference): void {
 	preferredProvId = provider;
 }
 
@@ -150,7 +197,7 @@ export function setPreferredSearchProvider(provider: SearchProviderId | "auto"):
  */
 export async function resolveProviderChain(
 	authStorage: AuthStorage,
-	preferredProvider: SearchProviderId | "auto" = preferredProvId,
+	preferredProvider: SearchProviderPreference = preferredProvId,
 ): Promise<SearchProvider[]> {
 	const providers: SearchProvider[] = [];
 

--- a/packages/coding-agent/src/web/search/provider.ts
+++ b/packages/coding-agent/src/web/search/provider.ts
@@ -123,15 +123,11 @@ const PROVIDER_META = [
 // Compile-time exhaustiveness: a new `SearchProviderId` without a
 // `PROVIDER_META` entry fails type-checking here, which in turn means it would
 // be missing from the TUI/CLI selectors.
-type _AllIdsRegistered = Exclude<SearchProviderId, (typeof PROVIDER_META)[number]["id"]> extends never
-	? true
-	: never;
+type _AllIdsRegistered = Exclude<SearchProviderId, (typeof PROVIDER_META)[number]["id"]> extends never ? true : never;
 const _allIdsRegistered: _AllIdsRegistered = true;
 void _allIdsRegistered;
 
-const META_BY_ID: ReadonlyMap<SearchProviderId, ProviderMeta> = new Map(
-	PROVIDER_META.map(meta => [meta.id, meta]),
-);
+const META_BY_ID: ReadonlyMap<SearchProviderId, ProviderMeta> = new Map(PROVIDER_META.map(meta => [meta.id, meta]));
 
 const instanceCache = new Map<SearchProviderId, SearchProvider>();
 

--- a/packages/coding-agent/test/setup-wizard.test.ts
+++ b/packages/coding-agent/test/setup-wizard.test.ts
@@ -11,6 +11,11 @@ import {
 	selectSetupScenes,
 } from "../src/modes/setup-wizard";
 import { WebSearchTab } from "../src/modes/setup-wizard/scenes/web-search";
+import {
+	SEARCH_PROVIDER_OPTIONS,
+	SEARCH_PROVIDER_ORDER,
+	SEARCH_PROVIDER_PREFERENCES,
+} from "../src/web/search/provider";
 import { initTheme, theme } from "../src/modes/theme/theme";
 import type { InteractiveModeContext } from "../src/modes/types";
 
@@ -195,6 +200,26 @@ describe("setup wizard web search tab", () => {
 		const expected = SETTINGS_SCHEMA["providers.webSearch"].ui.options[1].value;
 		expect(expected).not.toBe("auto");
 		expect(settings.get("providers.webSearch")).toBe(expected);
+	});
+
+	it("offers auto plus every registered provider in chain order", () => {
+		const expected: string[] = ["auto", ...SEARCH_PROVIDER_ORDER];
+		const schemaValues: string[] = [...SETTINGS_SCHEMA["providers.webSearch"].values];
+		const schemaOptionValues: string[] = SETTINGS_SCHEMA["providers.webSearch"].ui.options.map(
+			o => o.value,
+		);
+
+		expect(schemaValues).toEqual(expected);
+		expect(schemaOptionValues).toEqual(expected);
+		expect<string[]>([...SEARCH_PROVIDER_PREFERENCES]).toEqual(expected);
+		expect(SEARCH_PROVIDER_OPTIONS.map<string>(o => o.value)).toEqual(expected);
+
+		// Every option carries a non-empty label and description so the TUI never
+		// renders a blank row for a newly registered provider.
+		for (const option of SEARCH_PROVIDER_OPTIONS) {
+			expect(option.label.length).toBeGreaterThan(0);
+			expect(option.description.length).toBeGreaterThan(0);
+		}
 	});
 });
 

--- a/packages/coding-agent/test/setup-wizard.test.ts
+++ b/packages/coding-agent/test/setup-wizard.test.ts
@@ -11,13 +11,13 @@ import {
 	selectSetupScenes,
 } from "../src/modes/setup-wizard";
 import { WebSearchTab } from "../src/modes/setup-wizard/scenes/web-search";
+import { initTheme, theme } from "../src/modes/theme/theme";
+import type { InteractiveModeContext } from "../src/modes/types";
 import {
 	SEARCH_PROVIDER_OPTIONS,
 	SEARCH_PROVIDER_ORDER,
 	SEARCH_PROVIDER_PREFERENCES,
 } from "../src/web/search/provider";
-import { initTheme, theme } from "../src/modes/theme/theme";
-import type { InteractiveModeContext } from "../src/modes/types";
 
 function fakeContextWithConfiguredModel(): InteractiveModeContext {
 	return {
@@ -205,9 +205,7 @@ describe("setup wizard web search tab", () => {
 	it("offers auto plus every registered provider in chain order", () => {
 		const expected: string[] = ["auto", ...SEARCH_PROVIDER_ORDER];
 		const schemaValues: string[] = [...SETTINGS_SCHEMA["providers.webSearch"].values];
-		const schemaOptionValues: string[] = SETTINGS_SCHEMA["providers.webSearch"].ui.options.map(
-			o => o.value,
-		);
+		const schemaOptionValues: string[] = SETTINGS_SCHEMA["providers.webSearch"].ui.options.map(o => o.value);
 
 		expect(schemaValues).toEqual(expected);
 		expect(schemaOptionValues).toEqual(expected);


### PR DESCRIPTION
## Repro

`providers.webSearch` and its TUI/CLI selectors were maintained in three separate places:

- `packages/coding-agent/src/web/search/provider.ts` — `PROVIDER_META` registry (lazy factory + label) and the hand-maintained `SEARCH_PROVIDER_ORDER` walked by `resolveProviderChain`.
- `packages/coding-agent/src/config/settings-schema.ts` — duplicate `values:` enum and `ui.options:` array hand-maintained for `providers.webSearch`.
- `packages/coding-agent/src/modes/setup-wizard/scenes/web-search.ts` and `packages/coding-agent/src/cli/web-search-cli.ts` — derived from the schema's `ui.options` and `SEARCH_PROVIDER_ORDER` respectively.

Because the schema's `values`/`ui.options` and the provider registry were independent, a provider could ship a `SearchProviderId` + `PROVIDER_META` entry and be picked up by `auto` resolution while still being absent from (or out of order in) the TUI selector users see under Setup → Web search and Settings → Providers → Web Search Provider. Verified by `bun test packages/coding-agent/test/setup-wizard.test.ts`.

## Cause

`SETTINGS_SCHEMA["providers.webSearch"].ui.options` and `.values` were string-literal arrays maintained by hand. The setup wizard reads from `SETTINGS_SCHEMA["providers.webSearch"].ui.options`, so any drift between that array and `PROVIDER_META` / `SEARCH_PROVIDER_ORDER` propagated directly into the UI. The ordering in `ui.options` also diverged from the chain order in `SEARCH_PROVIDER_ORDER`, so the TUI listed providers in a different priority than `auto` actually resolved them.

## Fix

- Promoted `PROVIDER_META` (in `packages/coding-agent/src/web/search/provider.ts`) to an **ordered** `as const satisfies readonly ProviderMeta[]` array carrying `{ id, label, description, load }`. The order is now the canonical chain order and `SEARCH_PROVIDER_ORDER`, `SEARCH_PROVIDER_PREFERENCES`, and `SEARCH_PROVIDER_OPTIONS` are derived from it. Internal lookups use a `META_BY_ID` `Map`.
- Added a compile-time exhaustiveness check (`Exclude<SearchProviderId, (typeof PROVIDER_META)[number]["id"]> extends never`) that rejects any new `SearchProviderId` without a `PROVIDER_META` entry.
- Renamed the public preference union to `SearchProviderPreference = SearchProviderId | "auto"` (`SEARCH_PROVIDER_PREFERENCES[number]`) and re-typed `setPreferredSearchProvider`/`resolveProviderChain`/the module-level `preferredProvId` accordingly. Existing `isSearchProviderPreference` callers in `sdk.ts`, `selector-controller.ts`, and the wizard remain assignment-compatible.
- Replaced the inline `values`/`ui.options` in `SETTINGS_SCHEMA["providers.webSearch"]` with `SEARCH_PROVIDER_PREFERENCES` / `SEARCH_PROVIDER_OPTIONS`, so the schema, the setup wizard's `WEB_SEARCH_ITEMS`, and the CLI's `["auto", ...SEARCH_PROVIDER_ORDER]` choices all derive from the same source in chain order.
- Added a regression test (`test/setup-wizard.test.ts` → `offers auto plus every registered provider in chain order`) that asserts the schema values, schema `ui.options`, `SEARCH_PROVIDER_PREFERENCES`, and `SEARCH_PROVIDER_OPTIONS` all equal `["auto", ...SEARCH_PROVIDER_ORDER]` and that every option has a non-empty label and description.

## Verification

- `cd packages/coding-agent && bun run check:types` → clean.
- `cd packages/coding-agent && bun test test/setup-wizard.test.ts` → 14 pass / 0 fail (the new test included).
- `cd packages/coding-agent && bun test test/setup-wizard.test.ts test/settings-manager.test.ts test/tools/web-search-tavily.test.ts test/tools/web-search-exa.test.ts test/tools/web-search-gemini.test.ts test/tools/web-search-codex.test.ts test/tools/web-search-kagi.test.ts test/tools/web-search-parallel.test.ts test/tools/web-search-searxng.test.ts test/tools/provider-schema-compatibility.test.ts` → 111 pass / 0 fail across 10 files.

Fixes #1756