### PR TITLE
fix(hashline): reject pure inserts whose payload echoes the anchor

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed `/review`'s uncommitted-change mode in Jujutsu repositories to read `jj diff --git` from the current workspace, so non-default JJ workspaces include their working-copy changes instead of falling back to the colocated Git checkout.
 - Fixed empty assistant stop retry continuations preserving auto-retry state until a non-empty assistant turn completes or recovery reaches its retry cap.
+- Fixed the `edit` tool silently duplicating a line when an `insert before N:` payload ended with the anchor text or an `insert after N:` payload began with it. Hashline now rejects those pure anchor-targeted inserts with a diagnostic that names the echoed line and points at the canonical `replace N..N:` re-authoring; head/tail inserts, mid-payload duplicates, and inserts combined with a delete or replacement at the same anchor are unaffected ([#1759](https://github.com/can1357/oh-my-pi/issues/1759)).
 
 ### Changed
 

--- a/packages/coding-agent/test/core/hashline.test.ts
+++ b/packages/coding-agent/test/core/hashline.test.ts
@@ -373,25 +373,57 @@ describe("hashline parser — range-anchor syntax", () => {
 		expect(applyDiff(source, diff)).toBe(["if ok {", "   keep();", "   }", "   added();", "   }"].join("\n"));
 	});
 
-	it("preserves an intentional non-structural duplicate for after insert", () => {
+	it("rejects insert-after payload whose first line echoes the anchor", () => {
 		const source = ["aaa", "bbb", "ccc"].join("\n");
 		const diff = [`insert after ${tag(2, "bbb")}:`, repl("bbb"), repl("NEW")].join("\n");
 
-		expect(applyDiff(source, diff)).toBe("aaa\nbbb\nbbb\nNEW\nccc");
+		expect(() => applyDiff(source, diff)).toThrow(/`insert after 2:` payload starts with the anchor line/);
 	});
 
-	it("preserves an intentional non-structural duplicate for before insert", () => {
+	it("rejects insert-before payload whose last line echoes the anchor", () => {
 		const source = ["aaa", "bbb", "ccc"].join("\n");
 		const diff = [`insert before ${tag(2, "bbb")}:`, repl("NEW"), repl("bbb")].join("\n");
 
-		expect(applyDiff(source, diff)).toBe("aaa\nNEW\nbbb\nbbb\nccc");
+		expect(() => applyDiff(source, diff)).toThrow(/`insert before 2:` payload ends with the anchor line/);
 	});
 
-	it("keeps a single structural pure-insert suffix when it preserves balance", () => {
+	it("rejects single-line insert payload that exactly equals the anchor", () => {
+		const source = ["aaa", "bbb", "ccc"].join("\n");
+		const afterDiff = [`insert after ${tag(2, "bbb")}:`, repl("bbb")].join("\n");
+		expect(() => applyDiff(source, afterDiff)).toThrow(/`insert after 2:` payload starts with the anchor line/);
+
+		const beforeDiff = [`insert before ${tag(2, "bbb")}:`, repl("bbb")].join("\n");
+		expect(() => applyDiff(source, beforeDiff)).toThrow(/`insert before 2:` payload ends with the anchor line/);
+	});
+
+	it("rejects structural insert-before payload whose last line echoes the anchor closer", () => {
 		const source = ["if outer {", "}"].join("\n");
 		const diff = [`insert before ${tag(2, "}")}:`, repl("if inner {"), repl("}")].join("\n");
 
+		expect(() => applyDiff(source, diff)).toThrow(/`insert before 2:` payload ends with the anchor line/);
+	});
+
+	it("accepts the canonical replace re-authoring of an intentional anchor duplicate", () => {
+		const source = ["if outer {", "}"].join("\n");
+		const diff = [`${sameLineRange(tag(2, "}"))}`, repl("if inner {"), repl("}"), repl("}")].join("\n");
+
 		expect(applyDiff(source, diff)).toBe(["if outer {", "if inner {", "}", "}"].join("\n"));
+	});
+
+	it("accepts non-adjacent payload lines that happen to equal the anchor", () => {
+		const source = ["aaa", "bbb", "ccc"].join("\n");
+		const afterDiff = [`insert after ${tag(2, "bbb")}:`, repl("NEW"), repl("bbb")].join("\n");
+		expect(applyDiff(source, afterDiff)).toBe("aaa\nbbb\nNEW\nbbb\nccc");
+
+		const beforeDiff = [`insert before ${tag(2, "bbb")}:`, repl("bbb"), repl("NEW")].join("\n");
+		expect(applyDiff(source, beforeDiff)).toBe("aaa\nbbb\nNEW\nbbb\nccc");
+	});
+
+	it("does not fire on insert combined with a delete at the same anchor", () => {
+		const source = ["aaa", "bbb", "ccc"].join("\n");
+		const diff = [`delete ${tag(2, "bbb")}`, `insert after ${tag(2, "bbb")}:`, repl("bbb")].join("\n");
+
+		expect(applyDiff(source, diff)).toBe("aaa\nbbb\nccc");
 	});
 
 	it("preserves payload text exactly", () => {

--- a/packages/hashline/CHANGELOG.md
+++ b/packages/hashline/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed delimiter-balance boundary repair to also drop a single duplicated structural opener (e.g. a restated `foo(` / `if (x) {` signature line surviving just above the range), not only duplicated closers. Zero-balance duplicates remain untouched.
+- Fixed `insert before N:` / `insert after N:` silently duplicating the anchor line when the payload's adjacent edge re-stated it (e.g. `insert after 2:\n+bbb\n+NEW` on `bbb` yielded `bbb\nbbb\nNEW`). The applier now rejects pure anchor-targeted inserts whose adjacent payload line equals the anchor with a focused diagnostic that names the offender and points at the canonical `replace N..N:` re-authoring; mid-payload duplicates, head/tail inserts, and inserts combined with a delete or replacement at the same anchor are unaffected ([#1759](https://github.com/can1357/oh-my-pi/issues/1759)).
 
 ## [15.8.0] - 2026-06-02
 

--- a/packages/hashline/src/apply.ts
+++ b/packages/hashline/src/apply.ts
@@ -7,7 +7,7 @@
  * which absorbs common model mistakes where a payload restates unchanged range
  * boundaries or duplicates/drops structural closers.
  */
-import { UNRESOLVED_BLOCK_INTERNAL } from "./messages";
+import { insertAnchorEchoMessage, UNRESOLVED_BLOCK_INTERNAL } from "./messages";
 import { cloneCursor } from "./tokenizer";
 import type { Anchor, ApplyResult, Cursor, Edit } from "./types";
 
@@ -45,6 +45,60 @@ function validateLineBounds(edits: AppliedEdit[], fileLines: string[]): void {
 			if (anchor.line < 1 || anchor.line > fileLines.length) {
 				throw new Error(`Line ${anchor.line} does not exist (file has ${fileLines.length} lines)`);
 			}
+		}
+	}
+}
+
+/**
+ * Reject pure anchor-targeted inserts whose payload edge exactly echoes the
+ * anchor line. The applier inserts payloads literally, so `insert after N:`
+ * with a first payload line equal to line N (or `insert before N:` with a last
+ * payload line equal to line N) silently duplicates the anchor — a common
+ * mistake when an author pastes the anchor as adjacent context inside the
+ * payload. Replacement groups and delete+insert combinations are exempt
+ * because their semantics already consume or restate the anchor.
+ */
+function validateInsertAnchorEcho(edits: AppliedEdit[], fileLines: string[]): void {
+	interface Slot {
+		firstAfter?: InsertEdit;
+		lastBefore?: InsertEdit;
+		hasDeleteOrReplacement: boolean;
+	}
+	const slots = new Map<number, Slot>();
+	const ensure = (line: number): Slot => {
+		let slot = slots.get(line);
+		if (!slot) {
+			slot = { hasDeleteOrReplacement: false };
+			slots.set(line, slot);
+		}
+		return slot;
+	};
+	for (const edit of edits) {
+		if (edit.kind === "delete") {
+			ensure(edit.anchor.line).hasDeleteOrReplacement = true;
+			continue;
+		}
+		const cursor = edit.cursor;
+		if (cursor.kind !== "before_anchor" && cursor.kind !== "after_anchor") continue;
+		const slot = ensure(cursor.anchor.line);
+		if (isReplacementInsert(edit)) {
+			slot.hasDeleteOrReplacement = true;
+			continue;
+		}
+		if (cursor.kind === "after_anchor") {
+			if (slot.firstAfter === undefined) slot.firstAfter = edit;
+		} else {
+			slot.lastBefore = edit;
+		}
+	}
+	for (const [line, slot] of slots) {
+		if (slot.hasDeleteOrReplacement) continue;
+		const anchorText = fileLines[line - 1] ?? "";
+		if (slot.firstAfter && slot.firstAfter.text === anchorText) {
+			throw new Error(`line ${slot.firstAfter.lineNum}: ${insertAnchorEchoMessage("after", line, anchorText)}`);
+		}
+		if (slot.lastBefore && slot.lastBefore.text === anchorText) {
+			throw new Error(`line ${slot.lastBefore.lineNum}: ${insertAnchorEchoMessage("before", line, anchorText)}`);
 		}
 	}
 }
@@ -508,6 +562,7 @@ export function applyEdits(text: string, edits: readonly Edit[]): ApplyResult {
 
 	const targetEdits = appliedEdits.map((edit, index) => cloneAppliedEdit(edit, index));
 	validateLineBounds(targetEdits, fileLines);
+	validateInsertAnchorEcho(targetEdits, fileLines);
 	const { edits: repaired, warnings } = repairReplacementBoundaries(targetEdits, fileLines);
 
 	// Partition edits into bof, eof, and anchor-targeted buckets.

--- a/packages/hashline/src/messages.ts
+++ b/packages/hashline/src/messages.ts
@@ -126,3 +126,21 @@ export const HEADTAIL_DRIFT_WARNING =
 export function missingSnapshotTagMessage(sectionPath: string): string {
 	return `Missing hashline snapshot tag for edit to ${sectionPath}; use \`${HL_FILE_PREFIX}${sectionPath}${HL_FILE_HASH_SEP}tag\` from your latest read/search output. To create a new file, use the write tool.`;
 }
+
+/**
+ * Error text emitted when a pure `insert before N:` or `insert after N:`
+ * payload echoes the anchor line on the side adjacent to the anchor. Hashline
+ * inserts the payload literally, so an echoed anchor line silently duplicates
+ * the surrounding context — the common mistake is pasting the anchor as
+ * leading/trailing context inside the payload. Surface the precise offender so
+ * the author can drop the echo or re-author as `replace N..N:` when the
+ * duplicate is intentional.
+ */
+export function insertAnchorEchoMessage(side: "before" | "after", anchorLine: number, anchorText: string): string {
+	const edge = side === "after" ? "starts with" : "ends with";
+	return (
+		`\`insert ${side} ${anchorLine}:\` payload ${edge} the anchor line ${JSON.stringify(anchorText)}, ` +
+		`which would silently duplicate it. Insert payloads must contain only new lines — drop the echoed copy, ` +
+		`or use \`replace ${anchorLine}..${anchorLine}:\` listing both copies if the duplicate is intentional.`
+	);
+}

--- a/packages/hashline/src/prompt.md
+++ b/packages/hashline/src/prompt.md
@@ -99,6 +99,16 @@ replace 3..3:
 # RIGHT
 replace 3..3:
 +   return msg
+
+# WRONG — pure-insert payload includes the anchor line as adjacent context.
+# `insert after N:` starting with line N (or `insert before N:` ending with line N)
+# is rejected; the anchor stays untouched, the body is ONLY the new lines.
+insert after 2:
++bbb
++NEW
+# RIGHT
+insert after 2:
++NEW
 </anti-patterns>
 
 <critical>

--- a/packages/hashline/test/leniency.test.ts
+++ b/packages/hashline/test/leniency.test.ts
@@ -94,9 +94,31 @@ describe("hashline apply — duplicate boundary payloads", () => {
 		expect(applyPatch(text, diff)).toBe(["// one", "// two", "// one", "// two", "new();"].join("\n"));
 	});
 
-	it("keeps pure-insert context echoes literal", () => {
+	it("keeps head/tail pure-insert context echoes literal (no anchor to echo)", () => {
 		const text = ["aaa", "bbb", "ccc"].join("\n");
-		const diff = "insert tail:\n+bbb\n+ccc\n+NEW";
-		expect(applyPatch(text, diff)).toBe("aaa\nbbb\nccc\nbbb\nccc\nNEW");
+		expect(applyPatch(text, "insert tail:\n+bbb\n+ccc\n+NEW")).toBe("aaa\nbbb\nccc\nbbb\nccc\nNEW");
+		expect(applyPatch(text, "insert head:\n+NEW\n+aaa\n+bbb")).toBe("NEW\naaa\nbbb\naaa\nbbb\nccc");
+	});
+});
+
+describe("hashline apply — insert anchor echo rejection", () => {
+	it("rejects `insert after N:` whose first payload line equals the anchor", () => {
+		const text = ["aaa", "bbb", "ccc"].join("\n");
+		expect(() => applyPatch(text, "insert after 2:\n+bbb\n+NEW")).toThrow(
+			/`insert after 2:` payload starts with the anchor line "bbb".*replace 2\.\.2:/s,
+		);
+	});
+
+	it("rejects `insert before N:` whose last payload line equals the anchor", () => {
+		const text = ["aaa", "bbb", "ccc"].join("\n");
+		expect(() => applyPatch(text, "insert before 2:\n+NEW\n+bbb")).toThrow(
+			/`insert before 2:` payload ends with the anchor line "bbb".*replace 2\.\.2:/s,
+		);
+	});
+
+	it("allows mid-payload duplicates that do not touch the anchor", () => {
+		const text = ["aaa", "bbb", "ccc"].join("\n");
+		expect(applyPatch(text, "insert after 2:\n+NEW\n+bbb")).toBe("aaa\nbbb\nNEW\nbbb\nccc");
+		expect(applyPatch(text, "insert before 2:\n+bbb\n+NEW")).toBe("aaa\nbbb\nNEW\nbbb\nccc");
 	});
 });


### PR DESCRIPTION
## Repro

```text
aaa
bbb
ccc
```

Applying `insert after 2:\n+bbb\n+NEW` (or the symmetric `insert before 2:\n+NEW\n+bbb`) silently duplicated the anchor: `aaa\nbbb\nbbb\nNEW\nccc`. Reproduced via:

```sh
bun --eval "import { applyEdits, parsePatch } from '@oh-my-pi/hashline'; const s = ['aaa','bbb','ccc'].join('\\n'); console.log(applyEdits(s, parsePatch('insert after 2:\\n+bbb\\n+NEW').edits).text);"
# => "aaa\nbbb\nbbb\nNEW\nccc"
```

## Cause

`applyEdits` in `packages/hashline/src/apply.ts` inserted pure anchor-targeted payloads literally. The `repairReplacementBoundaries` pass only runs on replacement groups (`replace N..M:` + body), so a pure `insert before`/`insert after` whose payload edge re-stated the anchor line dropped through with no warning. The `edit.hashlineAutoDropPureInsertDuplicates` knob that previously gated an auto-drop attempt for this case was removed earlier; nothing replaced it, so the failure class regressed.

## Fix

- `packages/hashline/src/apply.ts`: added `validateInsertAnchorEcho`, invoked right after `validateLineBounds`. It buckets edits per anchor line and throws when a pure-insert anchor's adjacent payload edge (first `after_anchor` insert or last `before_anchor` insert) equals the anchor text. Anchors that also receive a `delete` or a replacement insert are skipped — those semantics already consume or restate the anchor.
- `packages/hashline/src/messages.ts`: new `insertAnchorEchoMessage(side, line, text)` builder. The diagnostic names the offender and points at `replace N..N:` as the canonical re-authoring for an intentional duplicate.
- `packages/hashline/src/prompt.md`: added a WRONG/RIGHT entry to the anti-patterns block so future agent-authored patches steer clear.
- `packages/hashline/test/leniency.test.ts`: rejection coverage for both sides, plus negative tests for `insert head:` / `insert tail:` echoes (no anchor to echo) and mid-payload duplicates that intentionally don't touch the anchor.
- `packages/coding-agent/test/core/hashline.test.ts`: replaced the three "preserves duplicate"/"keeps structural suffix" tests at the old `insert before`/`after` echo behavior with rejection assertions, plus new positive coverage for the canonical `replace N..N:` re-authoring of an intentional structural duplicate, non-adjacent echoes, and insert+delete combinations at the same anchor.
- `CHANGELOG.md` entries under `[Unreleased]` for both packages.

## Verification

```sh
bun test packages/hashline/test
# 84 pass, 0 fail

bun test packages/coding-agent/test/core/hashline.test.ts
# 95 pass, 0 fail

bun --cwd packages/hashline run check        # biome + tsgo: clean
bun --cwd packages/coding-agent run check    # biome + tsgo: clean
```

Manual re-run of the reporter's repro now throws:

```text
line 1: `insert after 2:` payload starts with the anchor line "bbb", which would silently duplicate it. Insert payloads must contain only new lines — drop the echoed copy, or use `replace 2..2:` listing both copies if the duplicate is intentional.
```

Fixes #1759