### PR TITLE
fix(hashline): accept spaces in edit paths

### DIFF
--- a/packages/hashline/src/grammar.lark
+++ b/packages/hashline/src/grammar.lark
@@ -5,7 +5,7 @@ end_patch:   "*** End Patch" LF?
 file_patch: file_header hunk+
 file_header: "¶" filename "#" file_hash LF
 file_hash: /[0-9A-F]{4}/
-filename: /[^\s#]+/
+filename: /[^#\r\n]+/
 
 hunk: replace_hunk | replace_block_hunk | insert_hunk | delete_hunk | delete_block_hunk
 replace_hunk: replace_anchor LF emit_op*

--- a/packages/hashline/src/input.ts
+++ b/packages/hashline/src/input.ts
@@ -57,11 +57,30 @@ function tryParseRecoveryHeader(line: string, cwd?: string): RawSection | null {
 	if (!line.startsWith(HL_FILE_PREFIX)) return null;
 	const body = stripApplyPatchPathNoise(line.slice(HL_FILE_PREFIX.length).trim());
 	if (body.length === 0) return null;
-	const match = new RegExp(`^(.+?)(?:#([0-9A-Fa-f]{${HL_FILE_HASH_LENGTH}}))?\\s*$`).exec(body);
-	if (match === null) return null;
-	const path = normalizeHashlinePath(match[1], cwd);
+
+	// Trailing `#XXXX` is the tag; everything before it is the path. The
+	// path may contain whitespace (Windows OneDrive folders, Program Files,
+	// etc.), so we anchor the tag at end-of-body rather than scanning
+	// forward and stopping at the first space.
+	const trailing = new RegExp(`#([0-9A-Fa-f]{${HL_FILE_HASH_LENGTH}})\\s*$`).exec(body);
+	let pathText: string;
+	let fileHash: string | undefined;
+	if (trailing !== null) {
+		pathText = body.slice(0, trailing.index);
+		fileHash = trailing[1].toUpperCase();
+	} else {
+		pathText = body.replace(/\s+$/, "");
+	}
+
+	// Same anti-junk rule as the strict tokenizer: a `#XXXX` token followed
+	// by whitespace+content inside the path body is a malformed header (e.g.
+	// stale-tag copy-paste like `src/a.ts#1A2B copied from read`), not a
+	// path with an embedded hex fragment.
+	if (new RegExp(`#[0-9A-Fa-f]{${HL_FILE_HASH_LENGTH}}\\s`).test(pathText)) return null;
+
+	const path = normalizeHashlinePath(pathText, cwd);
 	if (path.length === 0) return null;
-	return match[2] !== undefined ? { path, fileHash: match[2].toUpperCase(), diff: "" } : { path, diff: "" };
+	return fileHash !== undefined ? { path, fileHash, diff: "" } : { path, diff: "" };
 }
 
 function normalizeHashlinePath(rawPath: string, cwd?: string): string {

--- a/packages/hashline/src/input.ts
+++ b/packages/hashline/src/input.ts
@@ -50,14 +50,14 @@ function stripApplyPatchPathNoise(pathText: string): string {
  * Best-effort recovery for `¶`-prefixed lines the strict tokenizer
  * rejects. Strips apply_patch keyword noise (`Update File:`, `Update:`,
  * etc.) and an extra leading `***` (some models emit a hybrid `¶***foo.ts`
- * shape), then expects `PATH(#HASH)?` with no embedded whitespace.
+ * shape), then expects `PATH(#HASH)?`.
  * Returns `null` when no clean path can be salvaged.
  */
 function tryParseRecoveryHeader(line: string, cwd?: string): RawSection | null {
 	if (!line.startsWith(HL_FILE_PREFIX)) return null;
 	const body = stripApplyPatchPathNoise(line.slice(HL_FILE_PREFIX.length).trim());
 	if (body.length === 0) return null;
-	const match = new RegExp(`^(\\S+?)(?:#([0-9A-Fa-f]{${HL_FILE_HASH_LENGTH}}))?\\s*$`).exec(body);
+	const match = new RegExp(`^(.+?)(?:#([0-9A-Fa-f]{${HL_FILE_HASH_LENGTH}}))?\\s*$`).exec(body);
 	if (match === null) return null;
 	const path = normalizeHashlinePath(match[1], cwd);
 	if (path.length === 0) return null;

--- a/packages/hashline/src/input.ts
+++ b/packages/hashline/src/input.ts
@@ -73,10 +73,11 @@ function tryParseRecoveryHeader(line: string, cwd?: string): RawSection | null {
 	}
 
 	// Same anti-junk rule as the strict tokenizer: a `#XXXX` token followed
-	// by whitespace+content inside the path body is a malformed header (e.g.
-	// stale-tag copy-paste like `src/a.ts#1A2B copied from read`), not a
-	// path with an embedded hex fragment.
-	if (new RegExp(`#[0-9A-Fa-f]{${HL_FILE_HASH_LENGTH}}\\s`).test(pathText)) return null;
+	// by whitespace+content or a line suffix inside the path body is a
+	// malformed header (e.g. stale-tag copy-paste like
+	// `src/a.ts#1A2B copied from read` or `src/a.ts#1A2B:42`), not a path
+	// with an embedded hex fragment.
+	if (new RegExp(`#[0-9A-Fa-f]{${HL_FILE_HASH_LENGTH}}(?:\\s|:)`).test(pathText)) return null;
 
 	const path = normalizeHashlinePath(pathText, cwd);
 	if (path.length === 0) return null;

--- a/packages/hashline/src/input.ts
+++ b/packages/hashline/src/input.ts
@@ -72,12 +72,12 @@ function tryParseRecoveryHeader(line: string, cwd?: string): RawSection | null {
 		pathText = body.replace(/\s+$/, "");
 	}
 
-	// Same anti-junk rule as the strict tokenizer: a `#XXXX` token followed
-	// by whitespace+content or a line suffix inside the path body is a
-	// malformed header (e.g. stale-tag copy-paste like
-	// `src/a.ts#1A2B copied from read` or `src/a.ts#1A2B:42`), not a path
-	// with an embedded hex fragment.
-	if (new RegExp(`#[0-9A-Fa-f]{${HL_FILE_HASH_LENGTH}}(?:\\s|:)`).test(pathText)) return null;
+	// Same rule as the strict tokenizer: the hashline header grammar uses
+	// `#` as the path/tag separator and does not allow `#` inside
+	// filenames. Anything `#` left in the path body — short tags, non-hex
+	// tags, over-long tags, stale-tag copy-paste, line-suffixed tags —
+	// means the header is malformed, not a path with an embedded hash.
+	if (pathText.includes("#")) return null;
 
 	const path = normalizeHashlinePath(pathText, cwd);
 	if (path.length === 0) return null;

--- a/packages/hashline/src/tokenizer.ts
+++ b/packages/hashline/src/tokenizer.ts
@@ -314,16 +314,42 @@ function tryParseHeader(line: string): { path: string; fileHash?: string } | nul
 	const end = trimEndIndex(line);
 	if (FILE_PREFIX_LENGTH >= end) return null;
 
+	// The snapshot tag, when present, is the trailing `#XXXX` block. We
+	// detect it from the suffix so the path may legitimately contain
+	// whitespace (e.g. `OneDrive - Company/file.ts`).
 	let pathEnd = end;
 	let fileHash: string | undefined;
-	const hashStart = end - HL_FILE_HASH_LENGTH - 1;
-	if (hashStart >= FILE_PREFIX_LENGTH && line.charCodeAt(hashStart) === CHAR_HASH) {
-		const tagStart = hashStart + 1;
-		for (let probe = tagStart; probe < end; probe++) {
-			if (!isHexDigitCode(line.charCodeAt(probe))) return null;
+	const trailingHashStart = end - HL_FILE_HASH_LENGTH - 1;
+	if (trailingHashStart >= FILE_PREFIX_LENGTH && line.charCodeAt(trailingHashStart) === CHAR_HASH) {
+		let allHex = true;
+		for (let probe = trailingHashStart + 1; probe < end; probe++) {
+			if (!isHexDigitCode(line.charCodeAt(probe))) {
+				allHex = false;
+				break;
+			}
 		}
-		pathEnd = hashStart;
-		fileHash = line.slice(tagStart, end).toUpperCase();
+		if (allHex) {
+			pathEnd = trailingHashStart;
+			fileHash = line.slice(trailingHashStart + 1, end).toUpperCase();
+		}
+	}
+
+	// Reject stale-tag copy-paste such as `¶src/a.ts#1A2B copied from read`:
+	// a `#XXXX` token followed by whitespace+more content in the path body
+	// is a malformed header, not a path-with-embedded-hash. Surface the
+	// focused diagnostic instead of silently mis-routing the edit.
+	for (let i = FILE_PREFIX_LENGTH; i + HL_FILE_HASH_LENGTH < pathEnd; i++) {
+		if (line.charCodeAt(i) !== CHAR_HASH) continue;
+		let allHex = true;
+		for (let k = 1; k <= HL_FILE_HASH_LENGTH; k++) {
+			if (!isHexDigitCode(line.charCodeAt(i + k))) {
+				allHex = false;
+				break;
+			}
+		}
+		if (!allHex) continue;
+		const after = i + HL_FILE_HASH_LENGTH + 1;
+		if (after < pathEnd && isWhitespaceCode(line.charCodeAt(after))) return null;
 	}
 
 	if (pathEnd === FILE_PREFIX_LENGTH) return null;

--- a/packages/hashline/src/tokenizer.ts
+++ b/packages/hashline/src/tokenizer.ts
@@ -312,28 +312,22 @@ function tryParseHunkHeader(line: string): ParsedHunkHeader | null {
 function tryParseHeader(line: string): { path: string; fileHash?: string } | null {
 	if (!line.startsWith(HL_FILE_PREFIX)) return null;
 	const end = trimEndIndex(line);
-	let index = FILE_PREFIX_LENGTH;
-	if (index >= end) return null;
-	const pathStart = index;
-	while (index < end) {
-		const code = line.charCodeAt(index);
-		if (code === CHAR_HASH || code === CHAR_SPACE || code === CHAR_TAB) break;
-		index++;
-	}
-	if (index === pathStart) return null;
-	const path = line.slice(pathStart, index);
+	if (FILE_PREFIX_LENGTH >= end) return null;
+
+	let pathEnd = end;
 	let fileHash: string | undefined;
-	if (index < end && line.charCodeAt(index) === CHAR_HASH) {
-		const hashStart = index + 1;
-		const hashEnd = hashStart + HL_FILE_HASH_LENGTH;
-		if (hashEnd > end) return null;
-		for (let probe = hashStart; probe < hashEnd; probe++) {
+	const hashStart = end - HL_FILE_HASH_LENGTH - 1;
+	if (hashStart >= FILE_PREFIX_LENGTH && line.charCodeAt(hashStart) === CHAR_HASH) {
+		const tagStart = hashStart + 1;
+		for (let probe = tagStart; probe < end; probe++) {
 			if (!isHexDigitCode(line.charCodeAt(probe))) return null;
 		}
-		fileHash = line.slice(hashStart, hashEnd).toUpperCase();
-		index = hashEnd;
+		pathEnd = hashStart;
+		fileHash = line.slice(tagStart, end).toUpperCase();
 	}
-	if (skipWhitespace(line, index, end) !== end) return null;
+
+	if (pathEnd === FILE_PREFIX_LENGTH) return null;
+	const path = line.slice(FILE_PREFIX_LENGTH, pathEnd);
 	return fileHash !== undefined ? { path, fileHash } : { path };
 }
 

--- a/packages/hashline/src/tokenizer.ts
+++ b/packages/hashline/src/tokenizer.ts
@@ -334,25 +334,15 @@ function tryParseHeader(line: string): { path: string; fileHash?: string } | nul
 		}
 	}
 
-	// Reject stale-tag copy-paste such as `¶src/a.ts#1A2B copied from read`
-	// and line-suffixed tags such as `¶src/a.ts#1A2B:42`: a `#XXXX`
-	// token followed by tag-tail junk in the path body is a malformed header,
-	// not a path-with-embedded-hash. Surface the focused diagnostic instead
-	// of silently mis-routing the edit.
-	for (let i = FILE_PREFIX_LENGTH; i + HL_FILE_HASH_LENGTH < pathEnd; i++) {
-		if (line.charCodeAt(i) !== CHAR_HASH) continue;
-		let allHex = true;
-		for (let k = 1; k <= HL_FILE_HASH_LENGTH; k++) {
-			if (!isHexDigitCode(line.charCodeAt(i + k))) {
-				allHex = false;
-				break;
-			}
-		}
-		if (!allHex) continue;
-		const after = i + HL_FILE_HASH_LENGTH + 1;
-		if (after < pathEnd && (isWhitespaceCode(line.charCodeAt(after)) || line.charCodeAt(after) === CHAR_COLON)) {
-			return null;
-		}
+	// The hashline header grammar uses `#` as the path/tag separator and
+	// does not allow `#` inside filenames. Anything `#` left in the path
+	// body — short tags (`#1A2`), non-hex tags (`#1A2G`), over-long tags
+	// (`#1A2B5`), stale-tag copy-paste (`#1A2B copied from read`), or
+	// line-suffixed tags (`#1A2B:42`) — means the header is malformed.
+	// Surface the focused diagnostic instead of silently mis-routing the
+	// edit or reporting a missing tag downstream.
+	for (let i = FILE_PREFIX_LENGTH; i < pathEnd; i++) {
+		if (line.charCodeAt(i) === CHAR_HASH) return null;
 	}
 
 	if (pathEnd === FILE_PREFIX_LENGTH) return null;

--- a/packages/hashline/src/tokenizer.ts
+++ b/packages/hashline/src/tokenizer.ts
@@ -334,10 +334,11 @@ function tryParseHeader(line: string): { path: string; fileHash?: string } | nul
 		}
 	}
 
-	// Reject stale-tag copy-paste such as `¶src/a.ts#1A2B copied from read`:
-	// a `#XXXX` token followed by whitespace+more content in the path body
-	// is a malformed header, not a path-with-embedded-hash. Surface the
-	// focused diagnostic instead of silently mis-routing the edit.
+	// Reject stale-tag copy-paste such as `¶src/a.ts#1A2B copied from read`
+	// and line-suffixed tags such as `¶src/a.ts#1A2B:42`: a `#XXXX`
+	// token followed by tag-tail junk in the path body is a malformed header,
+	// not a path-with-embedded-hash. Surface the focused diagnostic instead
+	// of silently mis-routing the edit.
 	for (let i = FILE_PREFIX_LENGTH; i + HL_FILE_HASH_LENGTH < pathEnd; i++) {
 		if (line.charCodeAt(i) !== CHAR_HASH) continue;
 		let allHex = true;
@@ -349,7 +350,9 @@ function tryParseHeader(line: string): { path: string; fileHash?: string } | nul
 		}
 		if (!allHex) continue;
 		const after = i + HL_FILE_HASH_LENGTH + 1;
-		if (after < pathEnd && isWhitespaceCode(line.charCodeAt(after))) return null;
+		if (after < pathEnd && (isWhitespaceCode(line.charCodeAt(after)) || line.charCodeAt(after) === CHAR_COLON)) {
+			return null;
+		}
 	}
 
 	if (pathEnd === FILE_PREFIX_LENGTH) return null;

--- a/packages/hashline/test/leniency.test.ts
+++ b/packages/hashline/test/leniency.test.ts
@@ -1,11 +1,29 @@
 import { describe, expect, it } from "bun:test";
-import { applyEdits, parsePatch } from "@oh-my-pi/hashline";
+import { applyEdits, Patch, parsePatch } from "@oh-my-pi/hashline";
 
 function applyPatch(text: string, diff: string): string {
 	return applyEdits(text, parsePatch(diff).edits).text;
 }
 
 const FILE = "a\nb\nc\nd\ne";
+
+describe("hashline section headers", () => {
+	it("accepts paths with spaces in anchored section headers", () => {
+		const section = Patch.parseSingle("¶dir with spaces/file.ts#1a2b\nreplace 1..1:\n+after");
+
+		expect(section.path).toBe("dir with spaces/file.ts");
+		expect(section.fileHash).toBe("1A2B");
+		expect(section.applyTo("before").text).toBe("after");
+	});
+
+	it("recovers apply_patch-contaminated headers whose paths contain spaces", () => {
+		const section = Patch.parseSingle("¶*** Update File: dir with spaces/file.ts#1A2B\nreplace 1..1:\n+after");
+
+		expect(section.path).toBe("dir with spaces/file.ts");
+		expect(section.fileHash).toBe("1A2B");
+		expect(section.applyTo("before").text).toBe("after");
+	});
+});
 
 describe("hashline core — verb header forms", () => {
 	it("rejects a bare single-number hunk header with verb guidance", () => {

--- a/packages/hashline/test/leniency.test.ts
+++ b/packages/hashline/test/leniency.test.ts
@@ -23,6 +23,18 @@ describe("hashline section headers", () => {
 		expect(section.fileHash).toBe("1A2B");
 		expect(section.applyTo("before").text).toBe("after");
 	});
+
+	it("rejects trailing junk after a snapshot tag", () => {
+		expect(() => Patch.parse("¶src/a.ts#1A2B copied from read\nreplace 1..1:\n+after")).toThrow(
+			/Input header must be/,
+		);
+	});
+
+	it("rejects trailing junk after a snapshot tag even with apply_patch noise", () => {
+		expect(() => Patch.parse("¶Update File: src/a.ts#1A2B copied from read\nreplace 1..1:\n+after")).toThrow(
+			/Input header must be/,
+		);
+	});
 });
 
 describe("hashline core — verb header forms", () => {

--- a/packages/hashline/test/leniency.test.ts
+++ b/packages/hashline/test/leniency.test.ts
@@ -39,6 +39,16 @@ describe("hashline section headers", () => {
 			/Input header must be/,
 		);
 	});
+
+	it("rejects malformed snapshot tags", () => {
+		expect(() => Patch.parse("¶src/a.ts#1A2\nreplace 1..1:\n+after")).toThrow(/Input header must be/);
+		expect(() => Patch.parse("¶src/a.ts#1A2G\nreplace 1..1:\n+after")).toThrow(/Input header must be/);
+		expect(() => Patch.parse("¶src/a.ts#1A2B5\nreplace 1..1:\n+after")).toThrow(/Input header must be/);
+	});
+
+	it("rejects malformed snapshot tags even with apply_patch noise", () => {
+		expect(() => Patch.parse("¶Update File: src/a.ts#1A2G\nreplace 1..1:\n+after")).toThrow(/Input header must be/);
+	});
 });
 
 describe("hashline core — verb header forms", () => {

--- a/packages/hashline/test/leniency.test.ts
+++ b/packages/hashline/test/leniency.test.ts
@@ -28,10 +28,14 @@ describe("hashline section headers", () => {
 		expect(() => Patch.parse("¶src/a.ts#1A2B copied from read\nreplace 1..1:\n+after")).toThrow(
 			/Input header must be/,
 		);
+		expect(() => Patch.parse("¶src/a.ts#1A2B:812\nreplace 1..1:\n+after")).toThrow(/Input header must be/);
 	});
 
 	it("rejects trailing junk after a snapshot tag even with apply_patch noise", () => {
 		expect(() => Patch.parse("¶Update File: src/a.ts#1A2B copied from read\nreplace 1..1:\n+after")).toThrow(
+			/Input header must be/,
+		);
+		expect(() => Patch.parse("¶Update File: src/a.ts#1A2B:812\nreplace 1..1:\n+after")).toThrow(
 			/Input header must be/,
 		);
 	});


### PR DESCRIPTION
## Repro
`Patch.parse("¶dir with spaces/file.ts#1A2B\nreplace 1..1:\n+after")` failed with `Input header must be ¶PATH or ¶PATH#TAG with a 4-hex content-hash tag`, matching edit tool failures for `read`/`search` headers whose paths contain spaces.

## Cause
`packages/hashline/src/tokenizer.ts` parsed the header path by scanning until `#`, space, or tab, so valid paths containing whitespace were downgraded to malformed `¶` headers; `packages/hashline/src/input.ts` had the same whitespace-only recovery regex for contaminated headers, and `packages/hashline/src/grammar.lark` documented the same restriction.

## Fix
- Parse hashline section headers by treating only a trailing `#TAG` as the snapshot delimiter, leaving spaces inside the path.
- Allow recovery parsing for apply_patch-contaminated headers with spaces in their paths.
- Update the formal grammar filename token to allow spaces.
- Add regression tests for canonical and recovered headers whose paths contain spaces.

## Verification
`bun --cwd packages/hashline -e 'import { Patch } from "./src/input.ts"; const section = Patch.parseSingle("¶dir with spaces/file.ts#1A2B\nreplace 1..1:\n+after"); console.log(`${section.path} ${section.fileHash} ${section.applyTo("before").text}`);'` now prints `dir with spaces/file.ts 1A2B after`; `bun run check` and `bun run test` pass in `packages/hashline`. Fixes #1634