### PR TITLE
fix(ttsr): honor ttsr.enabled across registration and matching

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed `ttsr.enabled: false` being ignored at runtime. `TtsrManager.addRule`/`hasRules`/`checkDelta` now short-circuit when TTSR is disabled, so condition-bearing rules never register and never trigger mid-stream injections. Rules that also carry `alwaysApply` or `description` still fall through to the always-apply or rulebook bucket via `bucketRules`, keeping non-TTSR behavior intact ([#1767](https://github.com/can1357/oh-my-pi/issues/1767)).
 - Fixed `/review`'s uncommitted-change mode in Jujutsu repositories to read `jj diff --git` from the current workspace, so non-default JJ workspaces include their working-copy changes instead of falling back to the colocated Git checkout.
 - Fixed empty assistant stop retry continuations preserving auto-retry state until a non-empty assistant turn completes or recovery reaches its retry cap.
 

--- a/packages/coding-agent/src/export/ttsr.ts
+++ b/packages/coding-agent/src/export/ttsr.ts
@@ -292,8 +292,11 @@ export class TtsrManager {
 		return false;
 	}
 
-	/** Add a TTSR rule to be monitored. */
+	/** Add a TTSR rule to be monitored. No-op when TTSR is globally disabled. */
 	addRule(rule: Rule): boolean {
+		if (!this.#settings.enabled) {
+			return false;
+		}
 		if (this.#rules.has(rule.name)) {
 			return false;
 		}
@@ -336,6 +339,9 @@ export class TtsrManager {
 	 * assistant prose, thinking text, and unrelated tool argument streams.
 	 */
 	checkDelta(delta: string, context: TtsrMatchContext): Rule[] {
+		if (!this.#settings.enabled) {
+			return [];
+		}
 		const bufferKey = this.#bufferKey(context);
 		const nextBuffer = `${this.#buffers.get(bufferKey) ?? ""}${delta}`;
 		this.#buffers.set(bufferKey, nextBuffer);
@@ -414,9 +420,9 @@ export class TtsrManager {
 		this.#buffers.clear();
 	}
 
-	/** Check if any TTSR rules are registered. */
+	/** Check if any TTSR rules are registered and TTSR is enabled. */
 	hasRules(): boolean {
-		return this.#rules.size > 0;
+		return this.#settings.enabled && this.#rules.size > 0;
 	}
 
 	/** Increment message counter (call after each turn). */

--- a/packages/coding-agent/test/capability/rule-buckets.test.ts
+++ b/packages/coding-agent/test/capability/rule-buckets.test.ts
@@ -96,4 +96,40 @@ describe("bucketRules", () => {
 
 		expect(mgr.checkDelta("contains FORBIDDEN token", { source: "text" }).map(r => r.name)).toEqual(["builtin-foo"]);
 	});
+
+	it("ttsr disabled lets condition rules fall through to always-apply/rulebook buckets", () => {
+		const mgr = new TtsrManager({
+			enabled: false,
+			contextMode: "discard",
+			interruptMode: "always",
+			repeatMode: "once",
+			repeatGap: 10,
+		});
+		// condition-only rule has nowhere to live once TTSR is off
+		const ttsrOnly = makeRule({ name: "ttsr-only", condition: ["FORBIDDEN"] });
+		// hybrid rules keep their non-TTSR semantics
+		const ttsrSticky = makeRule({
+			name: "ttsr-sticky",
+			condition: ["FORBIDDEN"],
+			alwaysApply: true,
+			description: "sticky desc",
+		});
+		const ttsrBook = makeRule({
+			name: "ttsr-book",
+			condition: ["FORBIDDEN"],
+			description: "rulebook desc",
+		});
+		const plainSticky = makeRule({ name: "plain-sticky", alwaysApply: true, description: "x" });
+		const plainBook = makeRule({ name: "plain-book", description: "y" });
+
+		const { rulebookRules, alwaysApplyRules } = bucketRules(
+			[ttsrOnly, ttsrSticky, ttsrBook, plainSticky, plainBook],
+			mgr,
+		);
+
+		expect(mgr.hasRules()).toBe(false);
+		expect(mgr.checkDelta("contains FORBIDDEN token", { source: "text" })).toHaveLength(0);
+		expect(alwaysApplyRules.map(r => r.name)).toEqual(["ttsr-sticky", "plain-sticky"]);
+		expect(rulebookRules.map(r => r.name)).toEqual(["ttsr-book", "plain-book"]);
+	});
 });

--- a/packages/coding-agent/test/ttsr.test.ts
+++ b/packages/coding-agent/test/ttsr.test.ts
@@ -397,3 +397,58 @@ describe("TtsrManager repeat behavior", () => {
 		expect(manager.checkDelta("forbidden", turnContext)).toEqual([rule]);
 	});
 });
+
+describe("TtsrManager enabled flag", () => {
+	const ttsrRule = makeRule({
+		name: "no-foo",
+		condition: ["FORBIDDEN"],
+		scope: ["text"],
+	});
+
+	it("treats the manager as inert when enabled:false", () => {
+		const manager = new TtsrManager({
+			enabled: false,
+			contextMode: "discard",
+			interruptMode: "always",
+			repeatMode: "once",
+			repeatGap: 10,
+		});
+
+		expect(manager.addRule(ttsrRule)).toBe(false);
+		expect(manager.hasRules()).toBe(false);
+		expect(manager.checkDelta("contains FORBIDDEN token", { source: "text" })).toEqual([]);
+	});
+
+	it("hides previously registered rules from matching once enabled flips off", () => {
+		// Manager constructed with default settings (enabled:true) then re-created
+		// disabled must not surface rules the on-instance ever held.
+		const enabledManager = new TtsrManager();
+		expect(enabledManager.addRule(ttsrRule)).toBe(true);
+		expect(enabledManager.hasRules()).toBe(true);
+
+		const disabledManager = new TtsrManager({
+			enabled: false,
+			contextMode: "discard",
+			interruptMode: "always",
+			repeatMode: "once",
+			repeatGap: 10,
+		});
+		expect(disabledManager.addRule(ttsrRule)).toBe(false);
+		expect(disabledManager.hasRules()).toBe(false);
+		expect(disabledManager.checkDelta("FORBIDDEN", { source: "text" })).toEqual([]);
+	});
+
+	it("matches normally when enabled:true is set explicitly", () => {
+		const manager = new TtsrManager({
+			enabled: true,
+			contextMode: "discard",
+			interruptMode: "always",
+			repeatMode: "once",
+			repeatGap: 10,
+		});
+
+		expect(manager.addRule(ttsrRule)).toBe(true);
+		expect(manager.hasRules()).toBe(true);
+		expect(manager.checkDelta("FORBIDDEN", { source: "text" }).map(r => r.name)).toEqual(["no-foo"]);
+	});
+});


### PR DESCRIPTION
## Repro

With `ttsr.enabled: false` in `~/.omp/settings.json`, bundled and user TTSR rules still register and still interrupt streams. Reproduced by enumerating call paths: `bucketRules` (`packages/coding-agent/src/capability/rule-buckets.ts:52`) calls `ttsrManager.addRule(rule)` for every rule with a `condition`, and `AgentSession` (`packages/coding-agent/src/session/agent-session.ts:1604`) guards stream matching only on `hasRules()`. Both ignored `#settings.enabled`, so the toggle had no effect on registration or matching. A new bun test fails on the previous code:

```
bun test test/ttsr.test.ts test/capability/rule-buckets.test.ts
```

## Cause

`TtsrManager.#settings.enabled` was stored but never read. `addRule`, `hasRules`, and `checkDelta` all skipped the flag. `bucketRules` had no signal to drop TTSR-only rules when disabled, and `agent-session.ts` had no way to short-circuit the per-delta match loop.

## Fix

Gate the three runtime surfaces inside `TtsrManager` so the manager is genuinely inert when disabled, leaving non-TTSR bucketing untouched:

- `addRule`: returns `false` early when `!enabled`. `bucketRules` then routes the rule through the normal fallback — `alwaysApply: true` → always bucket, `description` set → rulebook bucket, otherwise dropped. Condition-only rules vanish; hybrid rules keep their non-TTSR semantics.
- `hasRules`: returns `false` when `!enabled`, short-circuiting the `message_update` matcher loop in `agent-session.ts`.
- `checkDelta`: returns `[]` when `!enabled` as defense-in-depth.
- Tests in `packages/coding-agent/test/ttsr.test.ts` and `packages/coding-agent/test/capability/rule-buckets.test.ts` cover the new contract.
- CHANGELOG entry added under `[Unreleased] / Fixed`.

UI listing behavior when disabled: rules with `condition` no longer surface as TTSR-matched. Those that also have `description` still appear in the rulebook (`rule://`); pure TTSR rules are dropped. `ttsr.builtinRules` / `ttsr.disabledRules` continue to act on `bucketRules` filtering as before but are runtime-inert through the manager.

## Verification

```
bun test test/ttsr.test.ts test/capability/rule-buckets.test.ts test/slash-commands/omfg.test.ts test/modes/controllers/omfg-controller.test.ts test/modes/controllers/omfg-rule.test.ts
# 47 pass, 0 fail
```

Fixes #1767