### PR TITLE
fix(ai): widen Xiaomi MiMo Pro first-event timeout

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed Xiaomi MiMo Pro and Alibaba Coding Plan OpenAI-completions streams using the generic 120s first-event watchdog, which could abort slow-but-valid `mimo-v2.5-pro` and `qwen3.7-plus` turns before the provider emitted its first token. ([#1770](https://github.com/can1357/oh-my-pi/issues/1770))
 - Fixed `opencode-zen/minimax-m3-free` (and forward-compat `opencode-zen/minimax-m3`) and `opencode-go/minimax-m3` being routed to `anthropic-messages` despite the OpenCode Zen/Go gateways only serving these ids at `/v1/chat/completions`, which surfaced raw MiniMax/tool-call markup (`<invoke name="bash">`, `<tool_call>`, `<description>`, `<cwd>`, `<|minimax|>`) in the UI. Resolver overrides now pin these ids to `openai-completions` and the bundled `models.json` entries are flipped to match. ([#1617](https://github.com/can1357/oh-my-pi/issues/1617))
 - Fixed MiniMax Coding Plan China login opening the international `platform.minimax.io` subscription page instead of the China `platform.minimaxi.com` page.
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -382,20 +382,32 @@ function getTrailingPartialDeepseekToken(text: string): string {
 const OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE =
 	"OpenAI completions stream timed out while waiting for the first event";
 
-const GLM_CODING_PLAN_STREAM_IDLE_TIMEOUT_MS = 600_000;
+const CODING_PLAN_STREAM_IDLE_TIMEOUT_MS = 600_000;
 const GLM_CODING_PLAN_MODEL_PATTERN = /^glm-5(?:[.-]|$)/i;
+const XIAOMI_MIMO_PRO_STREAM_IDLE_TIMEOUT_MS = 300_000;
+const XIAOMI_MIMO_PRO_MODEL_PATTERN = /^mimo-v2\.5-pro$/i;
 
-/** Returns the widened OpenAI stream watchdog floor for slow GLM coding-plan reasoning models. */
+/** Returns the widened OpenAI stream watchdog floor for slow provider/model combinations. */
 export function getOpenAICompletionsStreamIdleTimeoutFallbackMs(
 	model: Model<"openai-completions">,
 ): number | undefined {
-	if (!GLM_CODING_PLAN_MODEL_PATTERN.test(model.id)) return undefined;
-	if (model.provider === "zhipu-coding-plan" || model.provider === "zai")
-		return GLM_CODING_PLAN_STREAM_IDLE_TIMEOUT_MS;
+	if (GLM_CODING_PLAN_MODEL_PATTERN.test(model.id)) {
+		if (model.provider === "zhipu-coding-plan" || model.provider === "zai") {
+			return CODING_PLAN_STREAM_IDLE_TIMEOUT_MS;
+		}
 
-	const baseUrl = model.baseUrl.toLowerCase();
-	if (baseUrl.includes("open.bigmodel.cn") || baseUrl.includes("api.z.ai")) {
-		return GLM_CODING_PLAN_STREAM_IDLE_TIMEOUT_MS;
+		const baseUrl = model.baseUrl.toLowerCase();
+		if (baseUrl.includes("open.bigmodel.cn") || baseUrl.includes("api.z.ai")) {
+			return CODING_PLAN_STREAM_IDLE_TIMEOUT_MS;
+		}
+	}
+
+	if (model.provider === "alibaba-coding-plan") {
+		return CODING_PLAN_STREAM_IDLE_TIMEOUT_MS;
+	}
+
+	if (model.provider === "xiaomi" && XIAOMI_MIMO_PRO_MODEL_PATTERN.test(model.id)) {
+		return XIAOMI_MIMO_PRO_STREAM_IDLE_TIMEOUT_MS;
 	}
 
 	return undefined;

--- a/packages/ai/test/openai-completions-progress-chunk.test.ts
+++ b/packages/ai/test/openai-completions-progress-chunk.test.ts
@@ -108,6 +108,25 @@ describe("getOpenAICompletionsStreamIdleTimeoutFallbackMs", () => {
 		expect(getOpenAICompletionsStreamIdleTimeoutFallbackMs(model)).toBe(600_000);
 	});
 
+	it("widens Alibaba Coding Plan stream watchdogs", () => {
+		const model = {
+			...openAICompletionsModel,
+			id: "qwen3.7-plus",
+			name: "Qwen3.7 Plus",
+			provider: "alibaba-coding-plan",
+			baseUrl: "https://coding-intl.dashscope.aliyuncs.com/v1",
+			reasoning: true,
+		} satisfies Model<"openai-completions">;
+
+		expect(getOpenAICompletionsStreamIdleTimeoutFallbackMs(model)).toBe(600_000);
+	});
+
+	it("widens Xiaomi MiMo Pro stream watchdogs", () => {
+		const model = getBundledModel("xiaomi", "mimo-v2.5-pro") as Model<"openai-completions">;
+
+		expect(getOpenAICompletionsStreamIdleTimeoutFallbackMs(model)).toBe(300_000);
+	});
+
 	it("keeps ordinary OpenAI-compatible models on the global timeout", () => {
 		expect(getOpenAICompletionsStreamIdleTimeoutFallbackMs(openAICompletionsModel)).toBeUndefined();
 	});


### PR DESCRIPTION
## Repro
`xiaomi/mimo-v2.5-pro` resolves through the OpenAI completions provider without a provider/model timeout fallback, so the default OpenAI stream idle and first-event budgets both resolve to 120000 ms. Reproduced with: `bun --cwd=packages/ai -e 'import { getBundledModel } from "./src/models"; import { getOpenAICompletionsStreamIdleTimeoutFallbackMs } from "./src/providers/openai-completions"; import { getOpenAIStreamIdleTimeoutMs, getOpenAIStreamFirstEventTimeoutMs } from "./src/utils/idle-iterator"; const model = getBundledModel("xiaomi", "mimo-v2.5-pro"); const fallback = getOpenAICompletionsStreamIdleTimeoutFallbackMs(model); const idle = getOpenAIStreamIdleTimeoutMs(fallback); const first = getOpenAIStreamFirstEventTimeoutMs(idle); console.log(JSON.stringify({provider:model.provider,id:model.id,api:model.api,baseUrl:model.baseUrl,fallback,idle,first})); if (fallback !== undefined) process.exit(1);'`.

## Cause
`packages/ai/src/providers/openai-completions.ts#getOpenAICompletionsStreamIdleTimeoutFallbackMs` only widened the OpenAI completions watchdog floor for GLM coding-plan models. Direct Xiaomi MiMo Pro models (`provider: "xiaomi"`, `id: "mimo-v2.5-pro"`) therefore fell through to the generic OpenAI-family default, allowing the first-event watchdog to abort slow-but-valid provider startup at roughly two minutes.

## Fix
- Added a targeted 300000 ms watchdog floor for direct `xiaomi/mimo-v2.5-pro` OpenAI completions streams.
- Kept the existing GLM coding-plan 600000 ms fallback intact while making the fallback helper handle multiple provider/model cases.
- Added regression coverage for the Xiaomi MiMo Pro timeout policy and documented the fix in `packages/ai/CHANGELOG.md`.

## Verification
`bun test packages/ai/test/openai-completions-progress-chunk.test.ts` passed (21 tests). `bun check` passed. After the fix, the repro command reports `fallback`, `idle`, and `first` as 300000 for `xiaomi/mimo-v2.5-pro`. Fixes #1770