### PR TITLE
fix(coding-agent): repair compiled tiny model runtime deps

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Fixed compiled `omp tiny-models download` and local `providers.memoryModel` startup resolving `@huggingface/transformers` runtime metadata from `/$bunfs`, so catalog-based Transformers.js installs use the bundled catalog spec and create the runtime lock parent before installing ([#1763](https://github.com/can1357/oh-my-pi/issues/1763)).
 - Fixed `/review`'s uncommitted-change mode in Jujutsu repositories to read `jj diff --git` from the current workspace, so non-default JJ workspaces include their working-copy changes instead of falling back to the colocated Git checkout.
 - Fixed empty assistant stop retry continuations preserving auto-retry state until a non-empty assistant turn completes or recovery reaches its retry cap.
 

--- a/packages/coding-agent/scripts/build-binary.ts
+++ b/packages/coding-agent/scripts/build-binary.ts
@@ -4,9 +4,64 @@ import * as path from "node:path";
 
 const packageDir = path.join(import.meta.dir, "..");
 const outputPath = path.join(packageDir, "dist", "omp");
+const repoRoot = path.join(packageDir, "..", "..");
+const TRANSFORMERS_PACKAGE = "@huggingface/transformers";
+
+interface PackageManifest {
+	dependencies?: Record<string, string>;
+	optionalDependencies?: Record<string, string>;
+	workspaces?: {
+		catalog?: Record<string, string>;
+	};
+}
 
 function shouldAdhocSignDarwinBinary(): boolean {
 	return process.platform === "darwin";
+}
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function readStringMap(value: unknown): Record<string, string> | undefined {
+	if (!isRecord(value)) return undefined;
+	const map: Record<string, string> = {};
+	for (const [key, entry] of Object.entries(value)) {
+		if (typeof entry === "string") map[key] = entry;
+	}
+	return map;
+}
+
+async function readPackageManifest(filePath: string): Promise<PackageManifest> {
+	const value: unknown = await Bun.file(filePath).json();
+	if (!isRecord(value)) throw new Error(`Invalid package manifest: ${filePath}`);
+
+	const manifest: PackageManifest = {};
+	const dependencies = readStringMap(value.dependencies);
+	const optionalDependencies = readStringMap(value.optionalDependencies);
+	if (dependencies) manifest.dependencies = dependencies;
+	if (optionalDependencies) manifest.optionalDependencies = optionalDependencies;
+
+	if (isRecord(value.workspaces)) {
+		const catalog = readStringMap(value.workspaces.catalog);
+		if (catalog) manifest.workspaces = { catalog };
+	}
+	return manifest;
+}
+
+function dependencyVersionSpec(manifest: PackageManifest, packageName: string): string | undefined {
+	return manifest.optionalDependencies?.[packageName] ?? manifest.dependencies?.[packageName];
+}
+
+async function resolveTransformersBuildVersionSpec(): Promise<string> {
+	const manifest = await readPackageManifest(path.join(packageDir, "package.json"));
+	const versionSpec = dependencyVersionSpec(manifest, TRANSFORMERS_PACKAGE);
+	if (!versionSpec) throw new Error(`${TRANSFORMERS_PACKAGE} is missing from package.json optionalDependencies`);
+	if (!versionSpec.startsWith("catalog:")) return versionSpec;
+
+	const rootManifest = await readPackageManifest(path.join(repoRoot, "package.json"));
+	const catalogSpec = rootManifest.workspaces?.catalog?.[TRANSFORMERS_PACKAGE];
+	if (!catalogSpec) throw new Error(`${TRANSFORMERS_PACKAGE} is missing from the root workspace catalog`);
+	return catalogSpec;
 }
 
 async function runCommand(command: string[], env: NodeJS.ProcessEnv = Bun.env): Promise<void> {
@@ -28,6 +83,7 @@ async function main(): Promise<void> {
 		await runCommand(["bun", "--cwd=../natives", "run", "embed:native"]);
 		try {
 			const buildEnv = shouldAdhocSignDarwinBinary() ? { ...Bun.env, BUN_NO_CODESIGN_MACHO_BINARY: "1" } : Bun.env;
+			const transformersVersionSpec = await resolveTransformersBuildVersionSpec();
 			await runCommand(
 				[
 					"bun",
@@ -40,6 +96,8 @@ async function main(): Promise<void> {
 					"--keep-names",
 					"--define",
 					'process.env.PI_COMPILED="true"',
+					"--define",
+					`process.env.PI_COMPILED_TRANSFORMERS_VERSION_SPEC=${JSON.stringify(transformersVersionSpec)}`,
 					"--external",
 					"mupdf",
 					"--root",

--- a/packages/coding-agent/src/tiny/worker.ts
+++ b/packages/coding-agent/src/tiny/worker.ts
@@ -1,3 +1,4 @@
+import * as nodeFs from "node:fs";
 import * as fs from "node:fs/promises";
 import { createRequire } from "node:module";
 import * as path from "node:path";
@@ -28,6 +29,7 @@ const STOP_DECODE_WINDOW_TOKENS = 32;
 const MEMORY_COMPLETION_MAX_NEW_TOKENS = 256;
 const TINY_TITLE_SYSTEM_PROMPT = prompt.render(tinyTitleSystemPrompt);
 const TRANSFORMERS_PACKAGE = "@huggingface/transformers";
+const COMPILED_TRANSFORMERS_VERSION_SPEC = process.env.PI_COMPILED_TRANSFORMERS_VERSION_SPEC;
 const sourceRequire = createRequire(import.meta.url);
 const INSTALL_LOCK_ATTEMPTS = 240;
 const INSTALL_LOCK_SLEEP_MS = 250;
@@ -58,17 +60,43 @@ interface TransformersRuntime {
 
 const pipelines = new Map<TinyLocalModelKey, Promise<TextGenerationPipeline>>();
 
-function resolveTransformersVersionSpec(): string {
-	const manifest = packageJson as {
-		optionalDependencies?: Record<string, string>;
-		dependencies?: Record<string, string>;
-	};
+interface TransformersVersionManifest {
+	optionalDependencies?: Record<string, string>;
+	dependencies?: Record<string, string>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+/** Resolves the Transformers.js semver spec used for compiled runtime installs. */
+export function resolveTransformersVersionSpecFromManifest(
+	manifest: TransformersVersionManifest,
+	compiledVersionSpec: string | undefined,
+	readInstalledVersion: () => string,
+): string {
 	const versionSpec =
 		manifest.optionalDependencies?.[TRANSFORMERS_PACKAGE] ?? manifest.dependencies?.[TRANSFORMERS_PACKAGE];
 	if (!versionSpec) throw new Error(`${TRANSFORMERS_PACKAGE} is missing from package.json optionalDependencies`);
 	if (!versionSpec.startsWith("catalog:")) return versionSpec;
-	const installed = sourceRequire(`${TRANSFORMERS_PACKAGE}/package.json`) as { version: string };
+	if (compiledVersionSpec) return compiledVersionSpec;
+	return readInstalledVersion();
+}
+
+function readInstalledTransformersVersion(): string {
+	const installed: unknown = sourceRequire(`${TRANSFORMERS_PACKAGE}/package.json`);
+	if (!isRecord(installed) || typeof installed.version !== "string") {
+		throw new Error(`${TRANSFORMERS_PACKAGE}/package.json is missing a string version`);
+	}
 	return installed.version;
+}
+
+function resolveTransformersVersionSpec(): string {
+	return resolveTransformersVersionSpecFromManifest(
+		packageJson,
+		COMPILED_TRANSFORMERS_VERSION_SPEC,
+		readInstalledTransformersVersion,
+	);
 }
 let cachedTransformersVersionSpec: string | undefined;
 /**
@@ -115,8 +143,9 @@ function getTinyTitleRuntimeDir(): string {
 	);
 }
 
-async function acquireInstallLock(runtimeDir: string): Promise<() => Promise<void>> {
+export async function acquireTinyRuntimeInstallLock(runtimeDir: string): Promise<() => Promise<void>> {
 	const lockDir = `${runtimeDir}.lock`;
+	await fs.mkdir(path.dirname(lockDir), { recursive: true });
 	for (let attempt = 0; attempt < INSTALL_LOCK_ATTEMPTS; attempt++) {
 		try {
 			await fs.mkdir(lockDir);
@@ -129,6 +158,79 @@ async function acquireInstallLock(runtimeDir: string): Promise<() => Promise<voi
 		}
 	}
 	throw new Error(`Timed out waiting for tiny title runtime install lock: ${lockDir}`);
+}
+
+/** Returns the absolute CommonJS entrypoint for the compiled runtime's installed Transformers.js package. */
+export function compiledTransformersEntrypoint(runtimeDir: string): string {
+	return path.join(runtimeDir, "node_modules", "@huggingface", "transformers", "dist", "transformers.node.cjs");
+}
+
+function compiledSharpStubEntrypoint(runtimeDir: string): string {
+	return path.join(runtimeDir, "omp-sharp-stub.cjs");
+}
+const RUNTIME_REQUIRE_REWRITES: readonly string[] = ["onnxruntime-node", "onnxruntime-common", "sharp"];
+
+function splitPackageSpecifier(specifier: string): { packageName: string; subpath: string | undefined } {
+	if (specifier.startsWith("@")) {
+		const firstSlash = specifier.indexOf("/");
+		if (firstSlash < 0) return { packageName: specifier, subpath: undefined };
+		const secondSlash = specifier.indexOf("/", firstSlash + 1);
+		if (secondSlash < 0) return { packageName: specifier, subpath: undefined };
+		return { packageName: specifier.slice(0, secondSlash), subpath: specifier.slice(secondSlash + 1) };
+	}
+	const slash = specifier.indexOf("/");
+	if (slash < 0) return { packageName: specifier, subpath: undefined };
+	return { packageName: specifier.slice(0, slash), subpath: specifier.slice(slash + 1) };
+}
+
+function packageEntrypoint(packageDir: string): string {
+	const manifestText = nodeFs.readFileSync(path.join(packageDir, "package.json"), "utf8");
+	const manifest: unknown = JSON.parse(manifestText);
+	if (isRecord(manifest) && typeof manifest.main === "string") return path.join(packageDir, manifest.main);
+	return path.join(packageDir, "index.js");
+}
+function runtimePackageEntrypoint(runtimeDir: string, specifier: string): string {
+	const { packageName, subpath } = splitPackageSpecifier(specifier);
+	const packageDir = path.join(runtimeDir, "node_modules", ...packageName.split("/"));
+	return subpath ? path.join(packageDir, subpath) : packageEntrypoint(packageDir);
+}
+
+/** Rewrites compiled runtime bare requires to absolute paths Bun app-mode can resolve. */
+export function rewriteCompiledRuntimeRequires(source: string, runtimeDir: string): string {
+	let rewritten = source;
+	for (const specifier of RUNTIME_REQUIRE_REWRITES) {
+		const entrypoint =
+			specifier === "sharp"
+				? compiledSharpStubEntrypoint(runtimeDir)
+				: runtimePackageEntrypoint(runtimeDir, specifier);
+		rewritten = rewritten.replaceAll(`require("${specifier}")`, `require(${JSON.stringify(entrypoint)})`);
+	}
+	rewritten = rewritten.replaceAll(
+		`require(${JSON.stringify(runtimePackageEntrypoint(runtimeDir, "sharp"))})`,
+		`require(${JSON.stringify(compiledSharpStubEntrypoint(runtimeDir))})`,
+	);
+	return rewritten;
+}
+
+async function patchRuntimeRequireFile(filePath: string, runtimeDir: string): Promise<void> {
+	const file = Bun.file(filePath);
+	if (!(await file.exists())) return;
+	const source = await file.text();
+	const rewritten = rewriteCompiledRuntimeRequires(source, runtimeDir);
+	if (rewritten !== source) await Bun.write(filePath, rewritten);
+}
+
+async function patchCompiledRuntimeRequires(runtimeDir: string): Promise<void> {
+	await Bun.write(compiledSharpStubEntrypoint(runtimeDir), "module.exports = {};\n");
+	await patchRuntimeRequireFile(compiledTransformersEntrypoint(runtimeDir), runtimeDir);
+	await patchRuntimeRequireFile(
+		path.join(runtimeDir, "node_modules", "onnxruntime-node", "dist", "index.js"),
+		runtimeDir,
+	);
+	await patchRuntimeRequireFile(
+		path.join(runtimeDir, "node_modules", "onnxruntime-node", "dist", "binding.js"),
+		runtimeDir,
+	);
 }
 
 async function isCompiledRuntimeInstalled(runtimeDir: string): Promise<boolean> {
@@ -159,9 +261,29 @@ async function readPipe(stream: ReadableStream<Uint8Array> | null): Promise<stri
 	return new Response(stream).text();
 }
 
+interface RuntimeInstallCommand {
+	cmd: string[];
+	cwd: string;
+	env: Record<string, string | undefined>;
+}
+
+/** Builds the Bun install invocation used for compiled Transformers.js runtime dependencies. */
+export function createRuntimeInstallCommand(
+	runtimeDir: string,
+	env: Record<string, string | undefined>,
+): RuntimeInstallCommand {
+	return {
+		cmd: [process.execPath, "install", "--production", "--force", "--backend=copyfile"],
+		cwd: runtimeDir,
+		env: { ...env, BUN_BE_BUN: "1" },
+	};
+}
+
 async function runRuntimeInstall(runtimeDir: string): Promise<void> {
-	const proc = Bun.spawn([process.execPath, "install", "--cwd", runtimeDir, "--production"], {
-		env: { ...Bun.env, BUN_BE_BUN: "1" },
+	const install = createRuntimeInstallCommand(runtimeDir, Bun.env);
+	const proc = Bun.spawn(install.cmd, {
+		cwd: install.cwd,
+		env: install.env,
 		stdout: "pipe",
 		stderr: "pipe",
 	});
@@ -200,15 +322,22 @@ async function ensureCompiledTransformersRuntime(
 	modelKey: TinyLocalModelKey,
 ): Promise<string> {
 	const runtimeDir = getTinyTitleRuntimeDir();
-	if (await isCompiledRuntimeInstalled(runtimeDir)) return runtimeDir;
+	if (await isCompiledRuntimeInstalled(runtimeDir)) {
+		await patchCompiledRuntimeRequires(runtimeDir);
+		return runtimeDir;
+	}
 
 	sendRuntimeInstallProgress(transport, requestId, modelKey, "initiate");
-	const releaseLock = await acquireInstallLock(runtimeDir);
+	const releaseLock = await acquireTinyRuntimeInstallLock(runtimeDir);
 	try {
-		if (await isCompiledRuntimeInstalled(runtimeDir)) return runtimeDir;
+		if (await isCompiledRuntimeInstalled(runtimeDir)) {
+			await patchCompiledRuntimeRequires(runtimeDir);
+			return runtimeDir;
+		}
 		await writeRuntimeManifest(runtimeDir);
 		sendRuntimeInstallProgress(transport, requestId, modelKey, "download");
 		await runRuntimeInstall(runtimeDir);
+		await patchCompiledRuntimeRequires(runtimeDir);
 		sendRuntimeInstallProgress(transport, requestId, modelKey, "done");
 		return runtimeDir;
 	} finally {
@@ -232,8 +361,9 @@ async function loadTransformers(
 	transformersRuntime = (async () => {
 		if (!isCompiledBinary()) return configureTransformers(sourceRequire(TRANSFORMERS_PACKAGE) as TransformersRuntime);
 		const runtimeDir = await ensureCompiledTransformersRuntime(transport, requestId, modelKey);
-		const require_ = createRequire(path.join(runtimeDir, "package.json"));
-		return configureTransformers(require_(TRANSFORMERS_PACKAGE) as TransformersRuntime);
+		const entrypoint = compiledTransformersEntrypoint(runtimeDir);
+		const require_ = createRequire(entrypoint);
+		return configureTransformers(require_(entrypoint) as TransformersRuntime);
 	})().catch(error => {
 		transformersRuntime = null;
 		throw error;

--- a/packages/coding-agent/src/tiny/worker.ts
+++ b/packages/coding-agent/src/tiny/worker.ts
@@ -220,17 +220,35 @@ async function patchRuntimeRequireFile(filePath: string, runtimeDir: string): Pr
 	if (rewritten !== source) await Bun.write(filePath, rewritten);
 }
 
-async function patchCompiledRuntimeRequires(runtimeDir: string): Promise<void> {
+const RUNTIME_PATCH_ROOTS: readonly string[] = [
+	path.join("node_modules", "@huggingface", "transformers", "dist"),
+	path.join("node_modules", "onnxruntime-node", "dist"),
+];
+const RUNTIME_PATCH_EXTENSIONS: ReadonlySet<string> = new Set([".js", ".cjs", ".mjs"]);
+
+async function* walkRuntimeJsFiles(root: string): AsyncGenerator<string> {
+	let entries: nodeFs.Dirent[];
+	try {
+		entries = await fs.readdir(root, { withFileTypes: true });
+	} catch (error: unknown) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+		throw error;
+	}
+	for (const entry of entries) {
+		const entryPath = path.join(root, entry.name);
+		if (entry.isDirectory()) yield* walkRuntimeJsFiles(entryPath);
+		else if (entry.isFile() && RUNTIME_PATCH_EXTENSIONS.has(path.extname(entry.name))) yield entryPath;
+	}
+}
+
+export async function patchCompiledRuntimeRequires(runtimeDir: string): Promise<void> {
 	await Bun.write(compiledSharpStubEntrypoint(runtimeDir), "module.exports = {};\n");
-	await patchRuntimeRequireFile(compiledTransformersEntrypoint(runtimeDir), runtimeDir);
-	await patchRuntimeRequireFile(
-		path.join(runtimeDir, "node_modules", "onnxruntime-node", "dist", "index.js"),
-		runtimeDir,
-	);
-	await patchRuntimeRequireFile(
-		path.join(runtimeDir, "node_modules", "onnxruntime-node", "dist", "binding.js"),
-		runtimeDir,
-	);
+	for (const relativeRoot of RUNTIME_PATCH_ROOTS) {
+		const root = path.join(runtimeDir, relativeRoot);
+		for await (const filePath of walkRuntimeJsFiles(root)) {
+			await patchRuntimeRequireFile(filePath, runtimeDir);
+		}
+	}
 }
 
 async function isCompiledRuntimeInstalled(runtimeDir: string): Promise<boolean> {

--- a/packages/coding-agent/test/tiny-transformers-runtime.test.ts
+++ b/packages/coding-agent/test/tiny-transformers-runtime.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	acquireTinyRuntimeInstallLock,
+	compiledTransformersEntrypoint,
+	createRuntimeInstallCommand,
+	resolveTransformersVersionSpecFromManifest,
+	rewriteCompiledRuntimeRequires,
+} from "../src/tiny/worker";
+
+const TRANSFORMERS_PACKAGE = "@huggingface/transformers";
+
+describe("resolveTransformersVersionSpecFromManifest", () => {
+	it("uses the compiled catalog spec without resolving source node_modules", () => {
+		let installedVersionRead = false;
+		const spec = resolveTransformersVersionSpecFromManifest(
+			{ optionalDependencies: { [TRANSFORMERS_PACKAGE]: "catalog:" } },
+			"^4.2.0",
+			() => {
+				installedVersionRead = true;
+				return "4.2.0";
+			},
+		);
+
+		expect(spec).toBe("^4.2.0");
+		expect(installedVersionRead).toBe(false);
+	});
+
+	it("falls back to the installed package version for source catalog deps", () => {
+		const spec = resolveTransformersVersionSpecFromManifest(
+			{ optionalDependencies: { [TRANSFORMERS_PACKAGE]: "catalog:" } },
+			undefined,
+			() => "4.2.0",
+		);
+
+		expect(spec).toBe("4.2.0");
+	});
+
+	it("keeps explicit semver specs unchanged", () => {
+		const spec = resolveTransformersVersionSpecFromManifest(
+			{ dependencies: { [TRANSFORMERS_PACKAGE]: "4.2.0" } },
+			"^4.2.0",
+			() => "4.3.0",
+		);
+
+		expect(spec).toBe("4.2.0");
+	});
+});
+
+describe("compiledTransformersEntrypoint", () => {
+	it("targets the installed CommonJS entrypoint without package-name resolution", () => {
+		expect(compiledTransformersEntrypoint("/tmp/omp-runtime")).toBe(
+			path.join("/tmp/omp-runtime", "node_modules", "@huggingface", "transformers", "dist", "transformers.node.cjs"),
+		);
+	});
+});
+
+describe("rewriteCompiledRuntimeRequires", () => {
+	it("rewrites runtime dependency requires to absolute entrypoints", async () => {
+		const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-tiny-runtime-"));
+		const packages = {
+			"onnxruntime-node": "dist/index.js",
+			"onnxruntime-common": "dist/cjs/index.js",
+			sharp: "lib/index.js",
+		};
+
+		try {
+			for (const [name, main] of Object.entries(packages)) {
+				const packageDir = path.join(tmpDir, "node_modules", name);
+				await fs.mkdir(packageDir, { recursive: true });
+				await Bun.write(path.join(packageDir, "package.json"), JSON.stringify({ main }));
+			}
+
+			const rewritten = rewriteCompiledRuntimeRequires(
+				`const fs = require("fs"); const ort = require("onnxruntime-node"); const common = require("onnxruntime-common"); const sharp = require("sharp"); const oldSharp = require(${JSON.stringify(path.join(tmpDir, "node_modules", "sharp", "lib", "index.js"))});`,
+				tmpDir,
+			);
+
+			expect(rewritten).toContain(
+				`require(${JSON.stringify(path.join(tmpDir, "node_modules", "onnxruntime-node", "dist", "index.js"))})`,
+			);
+			expect(rewritten).toContain(
+				`require(${JSON.stringify(path.join(tmpDir, "node_modules", "onnxruntime-common", "dist", "cjs", "index.js"))})`,
+			);
+			expect(rewritten).toContain(`require(${JSON.stringify(path.join(tmpDir, "omp-sharp-stub.cjs"))})`);
+			expect(rewritten).not.toContain(path.join("node_modules", "sharp", "lib", "index.js"));
+			expect(rewritten).toContain('require("fs")');
+		} finally {
+			await fs.rm(tmpDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("createRuntimeInstallCommand", () => {
+	it("runs bun install from the runtime directory instead of the parent workspace", () => {
+		const command = createRuntimeInstallCommand("/tmp/omp-runtime", { PATH: "/bin" });
+		expect(command.cmd).toEqual([process.execPath, "install", "--production", "--force", "--backend=copyfile"]);
+		expect(command.cwd).toBe("/tmp/omp-runtime");
+		expect(command.env).toMatchObject({ PATH: "/bin", BUN_BE_BUN: "1" });
+		expect(command.cmd).not.toContain("--cwd");
+	});
+});
+
+describe("acquireTinyRuntimeInstallLock", () => {
+	it("creates the runtime parent directory before acquiring the lock", async () => {
+		const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-tiny-runtime-"));
+		const runtimeDir = path.join(tmpDir, "cache", "tiny-title-runtime", "transformers-test");
+		const lockDir = `${runtimeDir}.lock`;
+		const release = await acquireTinyRuntimeInstallLock(runtimeDir);
+
+		try {
+			const stats = await fs.stat(lockDir);
+			expect(stats.isDirectory()).toBe(true);
+		} finally {
+			await release();
+			await fs.rm(tmpDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/packages/coding-agent/test/tiny-transformers-runtime.test.ts
+++ b/packages/coding-agent/test/tiny-transformers-runtime.test.ts
@@ -6,6 +6,7 @@ import {
 	acquireTinyRuntimeInstallLock,
 	compiledTransformersEntrypoint,
 	createRuntimeInstallCommand,
+	patchCompiledRuntimeRequires,
 	resolveTransformersVersionSpecFromManifest,
 	rewriteCompiledRuntimeRequires,
 } from "../src/tiny/worker";
@@ -116,6 +117,54 @@ describe("acquireTinyRuntimeInstallLock", () => {
 		} finally {
 			await release();
 			await fs.rm(tmpDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("patchCompiledRuntimeRequires", () => {
+	it("rewrites bare runtime requires recursively under installed dist directories", async () => {
+		const runtimeDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-tiny-runtime-"));
+
+		const layout: Record<string, { main: string; files: Record<string, string> }> = {
+			"@huggingface/transformers": {
+				main: "dist/transformers.node.cjs",
+				files: { "dist/transformers.node.cjs": 'require("onnxruntime-node"); require("sharp");' },
+			},
+			"onnxruntime-node": {
+				main: "dist/index.js",
+				files: {
+					"dist/index.js": 'require("./backend"); require("onnxruntime-common");',
+					"dist/backend.js": 'require("./binding"); require("onnxruntime-common");',
+					"dist/binding.js": 'require("onnxruntime-common");',
+				},
+			},
+			"onnxruntime-common": { main: "dist/cjs/index.js", files: { "dist/cjs/index.js": "" } },
+			sharp: { main: "lib/index.js", files: { "lib/index.js": "" } },
+		};
+
+		try {
+			for (const [name, pkg] of Object.entries(layout)) {
+				const packageDir = path.join(runtimeDir, "node_modules", ...name.split("/"));
+				await fs.mkdir(packageDir, { recursive: true });
+				await Bun.write(path.join(packageDir, "package.json"), JSON.stringify({ main: pkg.main }));
+				for (const [relativePath, contents] of Object.entries(pkg.files)) {
+					const filePath = path.join(packageDir, relativePath);
+					await fs.mkdir(path.dirname(filePath), { recursive: true });
+					await Bun.write(filePath, contents);
+				}
+			}
+
+			await patchCompiledRuntimeRequires(runtimeDir);
+
+			const backend = await Bun.file(
+				path.join(runtimeDir, "node_modules", "onnxruntime-node", "dist", "backend.js"),
+			).text();
+			expect(backend).toContain(
+				`require(${JSON.stringify(path.join(runtimeDir, "node_modules", "onnxruntime-common", "dist", "cjs", "index.js"))})`,
+			);
+			expect(backend).not.toContain('require("onnxruntime-common")');
+		} finally {
+			await fs.rm(runtimeDir, { recursive: true, force: true });
 		}
 	});
 });


### PR DESCRIPTION
## Repro
The compiled binary failed before model loading: `PI_TINY_DEVICE=cpu OMP_NO_UPDATE_NOTIFIER=1 ./dist/omp tiny-models download lfm2-350m --json` returned `{"results":[{"model":"lfm2-350m","ok":false}]}` and exited with `One or more tiny title models failed to download` while preparing/loading the Transformers.js runtime.

## Cause
`packages/coding-agent/src/tiny/worker.ts` resolved `catalog:` by requiring `@huggingface/transformers/package.json` from the compiled bunfs entrypoint, which is not available in release binaries. The compiled runtime install path also invoked `bun install --cwd ...`, which did not materialize runtime `node_modules`, and Bun compiled app-mode could not resolve bare CommonJS dependencies loaded from the installed Transformers.js files.

## Fix
- Embed the resolved `@huggingface/transformers` catalog spec in `packages/coding-agent/scripts/build-binary.ts` via a compile-time define.
- Create the runtime lock parent, run runtime `bun install` from the cache directory with copyfile linking, and load Transformers.js from its installed CommonJS entrypoint.
- Rewrite installed runtime CommonJS requires to absolute cache paths and stub `sharp` for text-generation-only tiny model use.
- Add regression coverage for catalog resolution, runtime install command construction, require rewriting, and lock parent creation.

## Verification
Ran `bun test test/tiny-transformers-runtime.test.ts test/tiny-worker-env.test.ts`, `bun run check`, `bun run build`, and verified `PI_TINY_DEVICE=cpu OMP_NO_UPDATE_NOTIFIER=1 ./dist/omp tiny-models download lfm2-350m --json` returns `{"results":[{"model":"lfm2-350m","ok":true}]}` after a clean runtime cache. Fixes #1763