### PR TITLE
fix(rules): gate bundled language rules by workspace

### DIFF
--- a/docs/rulebook-matching-pipeline.md
+++ b/docs/rulebook-matching-pipeline.md
@@ -59,6 +59,8 @@ Consequence: precedence and deduplication are **name-based only**. Two different
 - `cline` (priority `40`)
 - `builtin-defaults` (priority `1`)
 
+`builtin-defaults` is workspace-aware: in `ttsr.builtinRuleMode: "auto"` (the default), it contributes Rust rules only when the workspace contains `*.rs` files and TypeScript rules only when the workspace contains `*.ts`/`*.tsx` files. Set `ttsr.builtinRuleMode: "always"` to force every bundled language pack on, `ttsr.builtinRuleMode: "off"` to suppress them at discovery time, or `ttsr.builtinRules: false` to disable the bundled provider's rules before bucketing.
+
 ### Native provider (`builtin.ts`)
 
 Loads `.omp` rules from:
@@ -175,7 +177,7 @@ Notable source-order differences:
 - `cursor` appends user then project results.
 - `windsurf` appends user `global_rules` first, then project rules.
 - `cline` loads only nearest `.clinerules` source.
-- `builtin-defaults` uses the embedded rule source order.
+- `builtin-defaults` uses the embedded rule source order after workspace language filtering.
 
 ## 5. Split into Rulebook, Always-Apply, and TTSR buckets
 

--- a/docs/rulebook-matching-pipeline.md
+++ b/docs/rulebook-matching-pipeline.md
@@ -59,7 +59,7 @@ Consequence: precedence and deduplication are **name-based only**. Two different
 - `cline` (priority `40`)
 - `builtin-defaults` (priority `1`)
 
-`builtin-defaults` is workspace-aware: in `ttsr.builtinRuleMode: "auto"` (the default), it contributes Rust rules only when the workspace contains `*.rs` files and TypeScript rules only when the workspace contains `*.ts`/`*.tsx` files. Set `ttsr.builtinRuleMode: "always"` to force every bundled language pack on, `ttsr.builtinRuleMode: "off"` to suppress them at discovery time, or `ttsr.builtinRules: false` to disable the bundled provider's rules before bucketing.
+`builtin-defaults` is opt-in. The default `ttsr.builtinRuleMode: "off"` keeps every bundled language pack out of session rule discovery, so OMP core ships no language-specific policy unless a project opts in. Set `ttsr.builtinRuleMode: "auto"` to contribute Rust rules only when the workspace contains `*.rs` files and TypeScript rules only when the workspace contains `*.ts`/`*.tsx` files, `ttsr.builtinRuleMode: "always"` to force every bundled language pack on, or `ttsr.builtinRules: false` to disable the bundled provider's rules before bucketing.
 
 ### Native provider (`builtin.ts`)
 

--- a/docs/ttsr-injection-lifecycle.md
+++ b/docs/ttsr-injection-lifecycle.md
@@ -22,7 +22,9 @@ At session creation, `createAgentSession()` loads discovered rules, constructs a
 ```ts
 const ttsrSettings = settings.getGroup("ttsr");
 const ttsrManager = new TtsrManager(ttsrSettings);
-const rulesResult = await loadCapability<Rule>(ruleCapability.id, { cwd });
+const builtinRuleMode =
+  ttsrSettings.builtinRules === false ? "off" : ttsrSettings.builtinRuleMode;
+const rulesResult = await loadCapability<Rule>(ruleCapability.id, { cwd, builtinRuleMode });
 const { rulebookRules, alwaysApplyRules } = bucketRules(
   rulesResult.items,
   ttsrManager,
@@ -33,7 +35,7 @@ const { rulebookRules, alwaysApplyRules } = bucketRules(
 );
 ```
 
-`bucketRules(...)` drops names listed in `ttsr.disabledRules`, drops embedded `builtin-defaults` rules when `ttsr.builtinRules === false`, registers accepted TTSR rules, and then routes the remaining rules to always-apply/rulebook buckets.
+`builtin-defaults` is filtered during discovery by `ttsr.builtinRuleMode`: `"auto"` loads bundled Rust rules only for workspaces with `*.rs` files and TypeScript rules only for `*.ts`/`*.tsx` files, `"always"` forces every bundled language pack on, and `"off"` suppresses them. `bucketRules(...)` then drops names listed in `ttsr.disabledRules`, drops embedded `builtin-defaults` rules when `ttsr.builtinRules === false`, registers accepted TTSR rules, and routes the remaining rules to always-apply/rulebook buckets.
 
 ### Pre-registration dedupe behavior
 

--- a/docs/ttsr-injection-lifecycle.md
+++ b/docs/ttsr-injection-lifecycle.md
@@ -35,7 +35,7 @@ const { rulebookRules, alwaysApplyRules } = bucketRules(
 );
 ```
 
-`builtin-defaults` is filtered during discovery by `ttsr.builtinRuleMode`: `"auto"` loads bundled Rust rules only for workspaces with `*.rs` files and TypeScript rules only for `*.ts`/`*.tsx` files, `"always"` forces every bundled language pack on, and `"off"` suppresses them. `bucketRules(...)` then drops names listed in `ttsr.disabledRules`, drops embedded `builtin-defaults` rules when `ttsr.builtinRules === false`, registers accepted TTSR rules, and routes the remaining rules to always-apply/rulebook buckets.
+`builtin-defaults` is opt-in: the default `ttsr.builtinRuleMode: "off"` keeps every bundled language pack out of session discovery. Set `"auto"` to load bundled Rust rules only for workspaces with `*.rs` files and TypeScript rules only for `*.ts`/`*.tsx` files, or `"always"` to force every bundled language pack on. `bucketRules(...)` then drops names listed in `ttsr.disabledRules`, drops embedded `builtin-defaults` rules when `ttsr.builtinRules === false`, registers accepted TTSR rules, and routes the remaining rules to always-apply/rulebook buckets.
 
 ### Pre-registration dedupe behavior
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Fixed `/review`'s uncommitted-change mode in Jujutsu repositories to read `jj diff --git` from the current workspace, so non-default JJ workspaces include their working-copy changes instead of falling back to the colocated Git checkout.
+- Fixed bundled Rust/TypeScript TTSR rule packs loading in unrelated workspaces by making `builtin-defaults` workspace-aware by default; `ttsr.builtinRuleMode: "always"` still forces the packs on, and `"off"` disables them at discovery time ([#1768](https://github.com/can1357/oh-my-pi/issues/1768)).
 - Fixed empty assistant stop retry continuations preserving auto-retry state until a non-empty assistant turn completes or recovery reaches its retry cap.
 
 ### Changed

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 
 - Fixed `/review`'s uncommitted-change mode in Jujutsu repositories to read `jj diff --git` from the current workspace, so non-default JJ workspaces include their working-copy changes instead of falling back to the colocated Git checkout.
-- Fixed bundled Rust/TypeScript TTSR rule packs loading in unrelated workspaces by making `builtin-defaults` workspace-aware by default; `ttsr.builtinRuleMode: "always"` still forces the packs on, and `"off"` disables them at discovery time ([#1768](https://github.com/can1357/oh-my-pi/issues/1768)).
+- Fixed bundled Rust/TypeScript TTSR rule packs loading in unrelated workspaces by making `builtin-defaults` opt-in. The new `ttsr.builtinRuleMode` setting defaults to `"off"` so OMP core ships no language-specific policy by default; set it to `"auto"` to load packs only when matching `.rs`/`.ts`/`.tsx` files exist, or `"always"` to force every pack on ([#1768](https://github.com/can1357/oh-my-pi/issues/1768)).
 - Fixed empty assistant stop retry continuations preserving auto-retry state until a non-empty assistant turn completes or recovery reaches its retry cap.
 
 ### Changed

--- a/packages/coding-agent/src/capability/index.ts
+++ b/packages/coding-agent/src/capability/index.ts
@@ -234,7 +234,7 @@ export async function loadCapability<T>(capabilityId: string, options: LoadOptio
 	const cwd = options.cwd ?? getProjectDir();
 	const home = os.homedir();
 	const repoRoot = await findRepoRoot(cwd);
-	const ctx: LoadContext = { cwd, home, repoRoot };
+	const ctx: LoadContext = { cwd, home, repoRoot, builtinRuleMode: options.builtinRuleMode };
 	const providers = filterProviders(capability, options);
 
 	return await loadImpl(capability, providers, ctx, options);

--- a/packages/coding-agent/src/capability/rule.ts
+++ b/packages/coding-agent/src/capability/rule.ts
@@ -10,10 +10,10 @@ import type { SourceMeta } from "./types";
 const CONDITION_GLOB_SCOPE_TOOLS = ["edit", "write"] as const;
 
 /**
- * Provider id for the bundled default rules shipped with the agent.
+ * Provider id for the bundled language rule packs shipped with the agent.
  * Lowest priority, so any user/project/tool rule of the same name overrides
- * a bundled default. Also used to gate the whole bundled set via
- * `ttsr.builtinRules`.
+ * a bundled default. Also used to gate the bundled set via `ttsr.builtinRules`
+ * and workspace-aware `ttsr.builtinRuleMode`.
  */
 export const BUILTIN_DEFAULTS_PROVIDER_ID = "builtin-defaults";
 

--- a/packages/coding-agent/src/capability/types.ts
+++ b/packages/coding-agent/src/capability/types.ts
@@ -6,6 +6,9 @@
  * a unified array of MCP servers.
  */
 
+/** Built-in rule pack loading behavior for workspace-scoped language defaults. */
+export type BuiltinRuleMode = "auto" | "always" | "off";
+
 /**
  * Context passed to every provider loader.
  */
@@ -16,6 +19,8 @@ export interface LoadContext {
 	home: string;
 	/** Git repository root (directory containing .git), or null if not in a repo */
 	repoRoot: string | null;
+	/** Built-in language rule pack loading behavior for providers that support it. */
+	builtinRuleMode?: BuiltinRuleMode;
 }
 
 /**
@@ -72,6 +77,8 @@ export interface LoadOptions {
 	includeDisabled?: boolean;
 	/** Explicit disabled extension IDs to apply instead of settings. */
 	disabledExtensions?: string[];
+	/** Built-in language rule pack loading behavior. Default: "auto". */
+	builtinRuleMode?: BuiltinRuleMode;
 }
 
 /**

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -213,6 +213,9 @@ const EMPTY_STRING_RECORD: Record<string, string> = {};
 const DEFAULT_CYCLE_ORDER: string[] = ["smol", "default", "slow"];
 const EMPTY_MODEL_TAGS_RECORD: ModelTagsSettings = {};
 const HINDSIGHT_RECALL_TYPES_DEFAULT: string[] = ["world", "experience"];
+export const BUILTIN_RULE_MODE_VALUES = ["auto", "always", "off"] as const;
+export type BuiltinRuleMode = (typeof BUILTIN_RULE_MODE_VALUES)[number];
+
 export const DEFAULT_BASH_INTERCEPTOR_RULES: BashInterceptorRule[] = [
 	{
 		pattern: "^\\s*(cat|head|tail|less|more)\\s+",
@@ -1733,7 +1736,27 @@ export const SETTINGS_SCHEMA = {
 		ui: {
 			tab: "context",
 			label: "Builtin Rules",
-			description: "Load the default rules shipped with the agent (override individually with ttsr.disabledRules)",
+			description: "Master switch for bundled language rule packs (fine-tune behavior with ttsr.builtinRuleMode)",
+		},
+	},
+
+	"ttsr.builtinRuleMode": {
+		type: "enum",
+		values: BUILTIN_RULE_MODE_VALUES,
+		default: "auto",
+		ui: {
+			tab: "context",
+			label: "Builtin Rule Mode",
+			description: "Load bundled language rules automatically for matching workspaces, always, or never",
+			options: [
+				{
+					value: "auto",
+					label: "auto",
+					description: "Load Rust/TypeScript built-ins only when matching files exist",
+				},
+				{ value: "always", label: "always", description: "Force all bundled Rust/TypeScript rule packs on" },
+				{ value: "off", label: "off", description: "Disable bundled Rust/TypeScript rule packs" },
+			],
 		},
 	},
 
@@ -3391,6 +3414,8 @@ export interface TtsrSettings {
 	repeatGap: number;
 	/** Bucketing-only (read by bucketRules, not the TtsrManager). */
 	builtinRules?: boolean;
+	/** Discovery-time loading behavior for bundled language rule packs. */
+	builtinRuleMode?: BuiltinRuleMode;
 	/** Bucketing-only (read by bucketRules, not the TtsrManager). */
 	disabledRules?: string[];
 }

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1743,16 +1743,17 @@ export const SETTINGS_SCHEMA = {
 	"ttsr.builtinRuleMode": {
 		type: "enum",
 		values: BUILTIN_RULE_MODE_VALUES,
-		default: "auto",
+		default: "off",
 		ui: {
 			tab: "context",
 			label: "Builtin Rule Mode",
-			description: "Load bundled language rules automatically for matching workspaces, always, or never",
+			description:
+				"Opt in to bundled Rust/TypeScript rule packs (off by default; auto loads packs for matching workspaces; always forces them on)",
 			options: [
 				{
 					value: "auto",
 					label: "auto",
-					description: "Load Rust/TypeScript built-ins only when matching files exist",
+					description: "Load Rust/TypeScript built-ins only when matching files exist (opt in)",
 				},
 				{ value: "always", label: "always", description: "Force all bundled Rust/TypeScript rule packs on" },
 				{ value: "off", label: "off", description: "Disable bundled Rust/TypeScript rule packs" },

--- a/packages/coding-agent/src/discovery/builtin-defaults.ts
+++ b/packages/coding-agent/src/discovery/builtin-defaults.ts
@@ -1,28 +1,68 @@
 /**
  * Builtin Defaults Provider
  *
- * Ships a curated set of default rules (mostly TTSR conventions) embedded into
- * the binary. Registered at the lowest priority so any user/project/tool rule
- * with the same `name` overrides the bundled copy (first-wins dedup by name).
+ * Ships bundled language-specific TTSR rule packs embedded into the binary.
+ * The provider defaults to workspace-aware loading so Rust/TypeScript rules do
+ * not appear in unrelated projects, while project/user/tool rules with the same
+ * `name` still override bundled copies through first-wins deduplication.
  *
- * Users disable bundled rules three ways:
- *   - flip `ttsr.builtinRules` off (drops the whole set),
- *   - list a name in `ttsr.disabledRules` (drops one rule),
- *   - define a same-named rule in any higher-priority source (overrides it).
- * The first two are enforced in `bucketRules` (see capability/rule-buckets.ts).
+ * Users control bundled rules three ways:
+ *   - set `ttsr.builtinRuleMode: "always"` to force every bundled language pack,
+ *   - set `ttsr.builtinRules: false` or `ttsr.builtinRuleMode: "off"` to drop the set,
+ *   - list a name in `ttsr.disabledRules` to drop one rule after discovery.
  */
+import { FileType, glob } from "@oh-my-pi/pi-natives";
 import { registerProvider } from "../capability";
 import { BUILTIN_DEFAULTS_PROVIDER_ID, type Rule, ruleCapability } from "../capability/rule";
 import type { LoadContext, LoadResult } from "../capability/types";
-import { BUILTIN_RULE_SOURCES } from "./builtin-rules";
+import { BUILTIN_RULE_SOURCES, type BuiltinRuleLanguage } from "./builtin-rules";
 import { buildRuleFromMarkdown, createSourceMeta } from "./helpers";
 
 const DISPLAY_NAME = "Builtin Defaults";
 // Lowest priority: every other rule provider wins a name conflict.
 const PRIORITY = 1;
+const AUTO_MODE = "auto";
+const BUILTIN_LANGUAGES: readonly BuiltinRuleLanguage[] = ["rust", "typescript"];
 
-async function loadRules(_ctx: LoadContext): Promise<LoadResult<Rule>> {
-	const items = BUILTIN_RULE_SOURCES.map(({ name, content }) => {
+const LANGUAGE_PATTERNS: Record<BuiltinRuleLanguage, string> = {
+	rust: "**/*.rs",
+	typescript: "**/*.{ts,tsx}",
+};
+
+async function hasWorkspaceFiles(ctx: LoadContext, language: BuiltinRuleLanguage): Promise<boolean> {
+	const root = ctx.repoRoot ?? ctx.cwd;
+	try {
+		const result = await glob({
+			pattern: LANGUAGE_PATTERNS[language],
+			path: root,
+			gitignore: true,
+			hidden: false,
+			fileType: FileType.File,
+			maxResults: 1,
+		});
+		return result.matches.length > 0;
+	} catch {
+		return false;
+	}
+}
+
+async function activeLanguages(ctx: LoadContext): Promise<Set<BuiltinRuleLanguage>> {
+	const mode = ctx.builtinRuleMode ?? AUTO_MODE;
+	if (mode === "off") return new Set<BuiltinRuleLanguage>();
+	if (mode === "always") return new Set(BUILTIN_LANGUAGES);
+
+	const entries = await Promise.all(
+		BUILTIN_LANGUAGES.map(async language => ({
+			language,
+			active: await hasWorkspaceFiles(ctx, language),
+		})),
+	);
+	return new Set(entries.filter(entry => entry.active).map(entry => entry.language));
+}
+
+async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
+	const languages = await activeLanguages(ctx);
+	const items = BUILTIN_RULE_SOURCES.filter(({ language }) => languages.has(language)).map(({ name, content }) => {
 		const virtualPath = `${BUILTIN_DEFAULTS_PROVIDER_ID}:${name}.md`;
 		const source = createSourceMeta(BUILTIN_DEFAULTS_PROVIDER_ID, virtualPath, "user");
 		return buildRuleFromMarkdown(name, content, virtualPath, source, { ruleName: name });
@@ -33,7 +73,7 @@ async function loadRules(_ctx: LoadContext): Promise<LoadResult<Rule>> {
 registerProvider<Rule>(ruleCapability.id, {
 	id: BUILTIN_DEFAULTS_PROVIDER_ID,
 	displayName: DISPLAY_NAME,
-	description: "Default rules shipped with the agent (disable via ttsr.builtinRules / ttsr.disabledRules)",
+	description: "Workspace-aware language rule packs shipped with the agent",
 	priority: PRIORITY,
 	load: loadRules,
 });

--- a/packages/coding-agent/src/discovery/builtin-defaults.ts
+++ b/packages/coding-agent/src/discovery/builtin-defaults.ts
@@ -2,13 +2,16 @@
  * Builtin Defaults Provider
  *
  * Ships bundled language-specific TTSR rule packs embedded into the binary.
- * The provider defaults to workspace-aware loading so Rust/TypeScript rules do
- * not appear in unrelated projects, while project/user/tool rules with the same
- * `name` still override bundled copies through first-wins deduplication.
+ * The provider is opt-in: the default `ttsr.builtinRuleMode: "off"` keeps
+ * bundled rules out of every session, so OMP core never implies style choices
+ * the project did not opt into. Project/user/tool rules with the same `name`
+ * still override bundled copies through first-wins deduplication.
  *
- * Users control bundled rules three ways:
- *   - set `ttsr.builtinRuleMode: "always"` to force every bundled language pack,
- *   - set `ttsr.builtinRules: false` or `ttsr.builtinRuleMode: "off"` to drop the set,
+ * Users opt in three ways:
+ *   - set `ttsr.builtinRuleMode: "auto"` to load packs only when matching
+ *     workspace files exist (`.rs`, `.ts`/`.tsx`),
+ *   - set `ttsr.builtinRuleMode: "always"` to force every bundled language
+ *     pack on,
  *   - list a name in `ttsr.disabledRules` to drop one rule after discovery.
  */
 import { FileType, glob } from "@oh-my-pi/pi-natives";
@@ -21,7 +24,7 @@ import { buildRuleFromMarkdown, createSourceMeta } from "./helpers";
 const DISPLAY_NAME = "Builtin Defaults";
 // Lowest priority: every other rule provider wins a name conflict.
 const PRIORITY = 1;
-const AUTO_MODE = "auto";
+const DEFAULT_MODE = "off";
 const BUILTIN_LANGUAGES: readonly BuiltinRuleLanguage[] = ["rust", "typescript"];
 
 const LANGUAGE_PATTERNS: Record<BuiltinRuleLanguage, string> = {
@@ -47,7 +50,7 @@ async function hasWorkspaceFiles(ctx: LoadContext, language: BuiltinRuleLanguage
 }
 
 async function activeLanguages(ctx: LoadContext): Promise<Set<BuiltinRuleLanguage>> {
-	const mode = ctx.builtinRuleMode ?? AUTO_MODE;
+	const mode = ctx.builtinRuleMode ?? DEFAULT_MODE;
 	if (mode === "off") return new Set<BuiltinRuleLanguage>();
 	if (mode === "always") return new Set(BUILTIN_LANGUAGES);
 
@@ -73,7 +76,7 @@ async function loadRules(ctx: LoadContext): Promise<LoadResult<Rule>> {
 registerProvider<Rule>(ruleCapability.id, {
 	id: BUILTIN_DEFAULTS_PROVIDER_ID,
 	displayName: DISPLAY_NAME,
-	description: "Workspace-aware language rule packs shipped with the agent",
+	description: "Opt-in language rule packs shipped with the agent",
 	priority: PRIORITY,
 	load: loadRules,
 });

--- a/packages/coding-agent/src/discovery/builtin-defaults.ts
+++ b/packages/coding-agent/src/discovery/builtin-defaults.ts
@@ -33,7 +33,7 @@ const LANGUAGE_PATTERNS: Record<BuiltinRuleLanguage, string> = {
 };
 
 async function hasWorkspaceFiles(ctx: LoadContext, language: BuiltinRuleLanguage): Promise<boolean> {
-	const root = ctx.repoRoot ?? ctx.cwd;
+	const root = ctx.cwd;
 	try {
 		const result = await glob({
 			pattern: LANGUAGE_PATTERNS[language],

--- a/packages/coding-agent/src/discovery/builtin-rules/index.ts
+++ b/packages/coding-agent/src/discovery/builtin-rules/index.ts
@@ -24,27 +24,31 @@ import tsNoTinyFunctions from "./ts-no-tiny-functions.md" with { type: "text" };
 import tsPromiseWithResolvers from "./ts-promise-with-resolvers.md" with { type: "text" };
 import tsSetMap from "./ts-set-map.md" with { type: "text" };
 
-/** A bundled rule's stable name and raw markdown (frontmatter + body). */
+/** Language family a bundled rule pack applies to. */
+export type BuiltinRuleLanguage = "rust" | "typescript";
+
+/** A bundled rule's stable name, language family, and raw markdown. */
 export interface BuiltinRuleSource {
 	name: string;
+	language: BuiltinRuleLanguage;
 	content: string;
 }
 
 /** All bundled default rules, ordered by name. */
 export const BUILTIN_RULE_SOURCES: readonly BuiltinRuleSource[] = [
-	{ name: "rs-box-leak", content: rsBoxLeak },
-	{ name: "rs-future-prelude", content: rsFuturePrelude },
-	{ name: "rs-lazylock", content: rsLazylock },
-	{ name: "rs-match-ergonomics", content: rsMatchErgonomics },
-	{ name: "rs-parking-lot", content: rsParkingLot },
-	{ name: "rs-result-type", content: rsResultType },
-	{ name: "ts-bare-catch", content: tsBareCatch },
-	{ name: "ts-import-type", content: tsImportType },
-	{ name: "ts-no-any", content: tsNoAny },
-	{ name: "ts-no-deprecated-leftovers", content: tsNoDeprecatedLeftovers },
-	{ name: "ts-no-dynamic-import", content: tsNoDynamicImport },
-	{ name: "ts-no-return-type", content: tsNoReturnType },
-	{ name: "ts-no-tiny-functions", content: tsNoTinyFunctions },
-	{ name: "ts-promise-with-resolvers", content: tsPromiseWithResolvers },
-	{ name: "ts-set-map", content: tsSetMap },
+	{ name: "rs-box-leak", language: "rust", content: rsBoxLeak },
+	{ name: "rs-future-prelude", language: "rust", content: rsFuturePrelude },
+	{ name: "rs-lazylock", language: "rust", content: rsLazylock },
+	{ name: "rs-match-ergonomics", language: "rust", content: rsMatchErgonomics },
+	{ name: "rs-parking-lot", language: "rust", content: rsParkingLot },
+	{ name: "rs-result-type", language: "rust", content: rsResultType },
+	{ name: "ts-bare-catch", language: "typescript", content: tsBareCatch },
+	{ name: "ts-import-type", language: "typescript", content: tsImportType },
+	{ name: "ts-no-any", language: "typescript", content: tsNoAny },
+	{ name: "ts-no-deprecated-leftovers", language: "typescript", content: tsNoDeprecatedLeftovers },
+	{ name: "ts-no-dynamic-import", language: "typescript", content: tsNoDynamicImport },
+	{ name: "ts-no-return-type", language: "typescript", content: tsNoReturnType },
+	{ name: "ts-no-tiny-functions", language: "typescript", content: tsNoTinyFunctions },
+	{ name: "ts-promise-with-resolvers", language: "typescript", content: tsPromiseWithResolvers },
+	{ name: "ts-set-map", language: "typescript", content: tsSetMap },
 ];

--- a/packages/coding-agent/src/export/ttsr.ts
+++ b/packages/coding-agent/src/export/ttsr.ts
@@ -55,6 +55,7 @@ const DEFAULT_SETTINGS: Required<TtsrSettings> = {
 	repeatMode: "once",
 	repeatGap: 10,
 	builtinRules: true,
+	builtinRuleMode: "auto",
 	disabledRules: [],
 };
 

--- a/packages/coding-agent/src/export/ttsr.ts
+++ b/packages/coding-agent/src/export/ttsr.ts
@@ -55,7 +55,7 @@ const DEFAULT_SETTINGS: Required<TtsrSettings> = {
 	repeatMode: "once",
 	repeatGap: 10,
 	builtinRules: true,
-	builtinRuleMode: "auto",
+	builtinRuleMode: "off",
 	disabledRules: [],
 };
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -835,7 +835,8 @@ export class AcpAgent implements Agent {
 				const cwd = typeof params.cwd === "string" ? (params.cwd as string) : undefined;
 				const sm = await Settings.init();
 				const disabledIds = (sm.get("disabledExtensions") as string[] | undefined) ?? [];
-				const extensions = await loadAllExtensions(cwd, disabledIds);
+				const builtinRuleMode = sm.get("ttsr.builtinRules") === false ? "off" : sm.get("ttsr.builtinRuleMode");
+				const extensions = await loadAllExtensions(cwd, disabledIds, builtinRuleMode);
 				return { extensions: extensions as unknown as Array<{ [key: string]: unknown }> };
 			}
 			case "_omp/extensions/toggle": {

--- a/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
+++ b/packages/coding-agent/src/modes/components/extensions/extension-dashboard.ts
@@ -21,6 +21,7 @@ import {
 	truncateToWidth,
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
+import type { BuiltinRuleMode } from "../../../capability/types";
 import { Settings } from "../../../config/settings";
 import { DynamicBorder } from "../../../modes/components/dynamic-border";
 import { theme } from "../../../modes/theme/theme";
@@ -36,6 +37,12 @@ import {
 	toggleProvider,
 } from "./state-manager";
 import type { DashboardState } from "./types";
+
+function getBuiltinRuleMode(settings: Settings | null): BuiltinRuleMode | undefined {
+	if (!settings) return undefined;
+	if (settings.get("ttsr.builtinRules") === false) return "off";
+	return settings.get("ttsr.builtinRuleMode");
+}
 
 export class ExtensionDashboard extends Container {
 	#state!: DashboardState;
@@ -67,7 +74,7 @@ export class ExtensionDashboard extends Container {
 	async #init(): Promise<void> {
 		const sm = this.settings ?? (await Settings.init());
 		const disabledIds = sm ? ((sm.get("disabledExtensions") as string[]) ?? []) : [];
-		this.#state = await createInitialState(this.cwd, disabledIds);
+		this.#state = await createInitialState(this.cwd, disabledIds, getBuiltinRuleMode(sm));
 
 		// Calculate max visible items based on terminal height
 		// Reserve ~10 lines for header, tabs, help text, borders
@@ -201,7 +208,7 @@ export class ExtensionDashboard extends Container {
 
 		const sm = this.settings ?? Settings.instance;
 		const disabledIds = sm ? ((sm.get("disabledExtensions") as string[]) ?? []) : [];
-		const nextState = await refreshState(this.#state, this.cwd, disabledIds);
+		const nextState = await refreshState(this.#state, this.cwd, disabledIds, getBuiltinRuleMode(sm));
 		if (refreshToken !== this.#refreshToken) return;
 		this.#state = nextState;
 

--- a/packages/coding-agent/src/modes/components/extensions/state-manager.ts
+++ b/packages/coding-agent/src/modes/components/extensions/state-manager.ts
@@ -14,7 +14,7 @@ import type { Rule } from "../../../capability/rule";
 import type { Skill } from "../../../capability/skill";
 import type { SlashCommand } from "../../../capability/slash-command";
 import type { CustomTool } from "../../../capability/tool";
-import type { SourceMeta } from "../../../capability/types";
+import type { BuiltinRuleMode, SourceMeta } from "../../../capability/types";
 import {
 	disableProvider,
 	enableProvider,
@@ -44,7 +44,11 @@ export interface ExtensionSettingsManager {
 /**
  * Load all extensions from all capabilities.
  */
-export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): Promise<Extension[]> {
+export async function loadAllExtensions(
+	cwd?: string,
+	disabledIds?: string[],
+	builtinRuleMode?: BuiltinRuleMode,
+): Promise<Extension[]> {
 	const extensions: Extension[] = [];
 	const disabledExtensions = new Set<string>(disabledIds ?? []);
 
@@ -98,7 +102,7 @@ export async function loadAllExtensions(cwd?: string, disabledIds?: string[]): P
 		}
 	}
 
-	const loadOpts = cwd ? { cwd, includeDisabled: true } : { includeDisabled: true };
+	const loadOpts = cwd ? { cwd, includeDisabled: true, builtinRuleMode } : { includeDisabled: true, builtinRuleMode };
 
 	// Load skills
 	try {
@@ -552,8 +556,12 @@ export function applyDisabledExtensionsToState(state: DashboardState, disabledId
 /**
  * Create initial dashboard state.
  */
-export async function createInitialState(cwd?: string, disabledIds?: string[]): Promise<DashboardState> {
-	const extensions = await loadAllExtensions(cwd, disabledIds);
+export async function createInitialState(
+	cwd?: string,
+	disabledIds?: string[],
+	builtinRuleMode?: BuiltinRuleMode,
+): Promise<DashboardState> {
+	const extensions = await loadAllExtensions(cwd, disabledIds, builtinRuleMode);
 	const tabs = buildProviderTabs(extensions);
 	const tabFiltered = extensions; // "all" tab by default
 	const searchFiltered = tabFiltered;
@@ -591,8 +599,9 @@ export async function refreshState(
 	state: DashboardState,
 	cwd?: string,
 	disabledIds?: string[],
+	builtinRuleMode?: BuiltinRuleMode,
 ): Promise<DashboardState> {
-	const extensions = await loadAllExtensions(cwd, disabledIds);
+	const extensions = await loadAllExtensions(cwd, disabledIds, builtinRuleMode);
 	const tabs = buildProviderTabs(extensions);
 
 	// Get current provider from tabs

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1114,10 +1114,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const { ttsrManager, rulebookRules, alwaysApplyRules } = await logger.time("discoverTtsrRules", async () => {
 		const ttsrSettings = settings.getGroup("ttsr");
 		const ttsrManager = new TtsrManager(ttsrSettings);
+		const builtinRuleMode = ttsrSettings.builtinRules === false ? "off" : ttsrSettings.builtinRuleMode;
 		const rulesResult =
 			options.rules !== undefined
 				? { items: options.rules, warnings: undefined }
-				: await loadCapability<Rule>(ruleCapability.id, { cwd });
+				: await loadCapability<Rule>(ruleCapability.id, { cwd, builtinRuleMode });
 		const { rulebookRules, alwaysApplyRules } = bucketRules(rulesResult.items, ttsrManager, {
 			builtinRules: ttsrSettings.builtinRules,
 			disabledRules: ttsrSettings.disabledRules,

--- a/packages/coding-agent/test/discovery/builtin-defaults.test.ts
+++ b/packages/coding-agent/test/discovery/builtin-defaults.test.ts
@@ -1,10 +1,13 @@
 /**
- * The bundled `builtin-defaults` rule provider ships a curated default rule set
- * embedded into the binary. These tests defend that the whole set loads and
- * parses, and that the provider sits at the lowest priority so any user/project
- * rule of the same name overrides a bundled default (first-wins dedup).
+ * The bundled `builtin-defaults` rule provider ships workspace-aware language
+ * rule packs embedded into the binary. These tests defend language gating,
+ * parsing, and provider priority.
  */
-import { describe, expect, it } from "bun:test";
+
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { getCapability } from "@oh-my-pi/pi-coding-agent/capability";
 import { BUILTIN_DEFAULTS_PROVIDER_ID, type Rule, ruleCapability } from "@oh-my-pi/pi-coding-agent/capability/rule";
 import type { LoadContext } from "@oh-my-pi/pi-coding-agent/capability/types";
@@ -29,31 +32,69 @@ const EXPECTED_RULE_NAMES = [
 	"ts-set-map",
 ].sort();
 
+const tempDirs: string[] = [];
+
+async function makeWorkspace(files: readonly string[] = []): Promise<string> {
+	const dir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-builtin-rules-"));
+	tempDirs.push(dir);
+	for (const file of files) {
+		const filePath = path.join(dir, file);
+		await fs.mkdir(path.dirname(filePath), { recursive: true });
+		await Bun.write(filePath, "");
+	}
+	return dir;
+}
+
+afterEach(async () => {
+	const dirs = tempDirs.splice(0);
+	await Promise.all(dirs.map(dir => fs.rm(dir, { recursive: true, force: true })));
+});
+
 function ruleProvider() {
-	const cap = getCapability(ruleCapability.id);
+	const cap = getCapability<Rule>(ruleCapability.id);
 	if (!cap) throw new Error("rules capability missing");
 	const provider = cap.providers.find(p => p.id === BUILTIN_DEFAULTS_PROVIDER_ID);
 	if (!provider) throw new Error("builtin-defaults provider missing");
 	return { cap, provider };
 }
 
-async function loadBuiltinRules(): Promise<Rule[]> {
+async function loadBuiltinRules(ctx: LoadContext): Promise<Rule[]> {
 	const { provider } = ruleProvider();
-	const ctx: LoadContext = { cwd: "/tmp", home: "/tmp/home", repoRoot: null };
-	const result = await (provider.load as (ctx: LoadContext) => Promise<{ items: Rule[] }>)(ctx);
+	const result = await provider.load(ctx);
 	return result.items;
 }
 
+async function loadFromWorkspace(
+	files: readonly string[] = [],
+	mode: LoadContext["builtinRuleMode"] = "auto",
+): Promise<Rule[]> {
+	const cwd = await makeWorkspace(files);
+	return await loadBuiltinRules({ cwd, home: cwd, repoRoot: null, builtinRuleMode: mode });
+}
+
 describe("builtin-defaults rule provider", () => {
-	it("loads exactly the bundled default rule set, all attributed to the provider", async () => {
-		const rules = await loadBuiltinRules();
+	it("loads every bundled rule when explicitly forced on", async () => {
+		const rules = await loadFromWorkspace([], "always");
 		const names = rules.map(r => r.name).sort();
 		expect(names).toEqual(EXPECTED_RULE_NAMES);
 		expect(rules.every(r => r._source.provider === BUILTIN_DEFAULTS_PROVIDER_ID)).toBe(true);
 	});
 
+	it("loads no bundled language rules for unrelated workspaces in auto mode", async () => {
+		const rules = await loadFromWorkspace(["app/main.py"]);
+		expect(rules).toEqual([]);
+	});
+
+	it("loads only language rule packs with matching workspace files in auto mode", async () => {
+		const tsRules = await loadFromWorkspace(["src/index.ts"]);
+		expect(tsRules.map(r => r.name).sort()).toEqual(EXPECTED_RULE_NAMES.filter(name => name.startsWith("ts-")));
+
+		const rustRules = await loadFromWorkspace(["src/main.rs"]);
+		expect(rustRules.map(r => r.name).sort()).toEqual(EXPECTED_RULE_NAMES.filter(name => name.startsWith("rs-")));
+	});
+
 	it("parses every bundled rule as a TTSR rule (non-empty condition and scope)", async () => {
-		const rules = await loadBuiltinRules();
+		const rules = await loadFromWorkspace([], "always");
 		for (const rule of rules) {
 			expect(rule.condition?.length, `${rule.name} condition`).toBeGreaterThan(0);
 			expect(rule.scope?.length, `${rule.name} scope`).toBeGreaterThan(0);
@@ -61,14 +102,14 @@ describe("builtin-defaults rule provider", () => {
 	});
 
 	it("parses YAML list-form conditions from the embedded text", async () => {
-		const rules = await loadBuiltinRules();
+		const rules = await loadFromWorkspace([], "always");
 		const lazylock = rules.find(r => r.name === "rs-lazylock");
 		// Frontmatter declares two condition patterns as a YAML sequence.
 		expect(lazylock?.condition).toHaveLength(2);
 	});
 
 	it("preserves a per-rule interruptMode override from frontmatter", async () => {
-		const rules = await loadBuiltinRules();
+		const rules = await loadFromWorkspace([], "always");
 		expect(rules.find(r => r.name === "ts-set-map")?.interruptMode).toBe("never");
 	});
 

--- a/packages/coding-agent/test/discovery/builtin-defaults.test.ts
+++ b/packages/coding-agent/test/discovery/builtin-defaults.test.ts
@@ -85,6 +85,20 @@ describe("builtin-defaults rule provider", () => {
 		expect(rules).toEqual([]);
 	});
 
+	it("returns no bundled rules when no builtinRuleMode is provided (opt-in default)", async () => {
+		const cwd = await makeWorkspace(["src/index.ts", "src/main.rs"]);
+		const rules = await loadBuiltinRules({ cwd, home: cwd, repoRoot: null });
+		expect(rules).toEqual([]);
+	});
+
+	it("returns no bundled rules when builtinRuleMode is explicitly off, even with matching files", async () => {
+		const tsRules = await loadFromWorkspace(["src/index.ts"], "off");
+		expect(tsRules).toEqual([]);
+
+		const rustRules = await loadFromWorkspace(["src/main.rs"], "off");
+		expect(rustRules).toEqual([]);
+	});
+
 	it("loads only language rule packs with matching workspace files in auto mode", async () => {
 		const tsRules = await loadFromWorkspace(["src/index.ts"]);
 		expect(tsRules.map(r => r.name).sort()).toEqual(EXPECTED_RULE_NAMES.filter(name => name.startsWith("ts-")));

--- a/packages/coding-agent/test/discovery/builtin-defaults.test.ts
+++ b/packages/coding-agent/test/discovery/builtin-defaults.test.ts
@@ -85,6 +85,16 @@ describe("builtin-defaults rule provider", () => {
 		expect(rules).toEqual([]);
 	});
 
+	it("limits auto language detection to cwd instead of the containing repo root", async () => {
+		const repoRoot = await makeWorkspace(["packages/web/src/index.ts", "packages/api/src/main.rs"]);
+		const cwd = path.join(repoRoot, "packages", "python");
+		await fs.mkdir(cwd, { recursive: true });
+		await Bun.write(path.join(cwd, "app.py"), "");
+
+		const rules = await loadBuiltinRules({ cwd, home: repoRoot, repoRoot, builtinRuleMode: "auto" });
+		expect(rules).toEqual([]);
+	});
+
 	it("returns no bundled rules when no builtinRuleMode is provided (opt-in default)", async () => {
 		const cwd = await makeWorkspace(["src/index.ts", "src/main.rs"]);
 		const rules = await loadBuiltinRules({ cwd, home: cwd, repoRoot: null });


### PR DESCRIPTION
## Repro
`builtin-defaults` loaded Rust/TypeScript rules for an unrelated workspace: `bun -e 'import "@oh-my-pi/pi-coding-agent/discovery"; import { getCapability } from "@oh-my-pi/pi-coding-agent/capability"; import { ruleCapability } from "@oh-my-pi/pi-coding-agent/capability/rule"; const cap = getCapability(ruleCapability.id); const provider = cap.providers.find(p => p.id === "builtin-defaults"); const result = await provider.load({ cwd: "/tmp/omp-python-only-project", home: "/tmp/omp-home", repoRoot: null }); console.log(JSON.stringify({ provider: provider.id, count: result.items.length, names: result.items.map(r => r.name).sort() }, null, 2));'` returned 14 `rs-*`/`ts-*` rules before the fix and returns an empty list after the fix.

## Cause
`packages/coding-agent/src/discovery/builtin-defaults.ts` mapped every `BUILTIN_RULE_SOURCES` entry into a rule without inspecting the `LoadContext`, while `packages/coding-agent/src/sdk.ts` only applied `ttsr.builtinRules` later in `bucketRules(...)`; discovery and extension UI therefore saw bundled language rules as universal defaults.

## Fix
- Added workspace-aware `builtin-defaults` loading that detects `.rs`, `.ts`, and `.tsx` files and only contributes matching language packs in auto mode.
- Added `ttsr.builtinRuleMode` with `auto`, `always`, and `off` behavior, and threaded it through session and extension discovery.
- Updated bundled-rule metadata, docs, changelog, and regression tests for unrelated, TypeScript, Rust, and forced-on workspaces.

## Verification
Passed: `bun test packages/coding-agent/test/capability/rule-buckets.test.ts packages/coding-agent/test/discovery/builtin-defaults.test.ts`; passed: `bun run --cwd packages/coding-agent check`; passed manual repro command above after the fix. Fixes #1768