### PR TITLE
fix(ai): preserve MiniMax streamed tool arguments

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed MiniMax Coding Plan tool calls losing object-shaped streamed arguments, which could leave `bash`/`edit` calls executing with empty or malformed inputs. ([#1776](https://github.com/can1357/oh-my-pi/issues/1776))
 - Fixed `opencode-zen/minimax-m3-free` (and forward-compat `opencode-zen/minimax-m3`) and `opencode-go/minimax-m3` being routed to `anthropic-messages` despite the OpenCode Zen/Go gateways only serving these ids at `/v1/chat/completions`, which surfaced raw MiniMax/tool-call markup (`<invoke name="bash">`, `<tool_call>`, `<description>`, `<cwd>`, `<|minimax|>`) in the UI. Resolver overrides now pin these ids to `openai-completions` and the bundled `models.json` entries are flipped to match. ([#1617](https://github.com/can1357/oh-my-pi/issues/1617))
 - Fixed MiniMax Coding Plan China login opening the international `platform.minimax.io` subscription page instead of the China `platform.minimaxi.com` page.
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -169,6 +169,18 @@ function serializeToolArguments(value: unknown): string {
 	return "{}";
 }
 
+function serializeStreamingToolArgumentDelta(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (value && typeof value === "object" && !Array.isArray(value)) {
+		try {
+			return JSON.stringify(value);
+		} catch {
+			return "";
+		}
+	}
+	return "";
+}
+
 /**
  * Check if conversation messages contain tool calls or tool results.
  * This is needed because Anthropic (via proxy) requires the tools param
@@ -845,10 +857,11 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 
 							if (toolCall.id) block.id = toolCall.id;
 							if (toolCall.function?.name) block.name = toolCall.function.name;
+							const argumentDelta = serializeStreamingToolArgumentDelta(toolCall.function?.arguments);
 							let delta = "";
-							if (toolCall.function?.arguments) {
-								delta = toolCall.function.arguments;
-								block.partialArgs = (block.partialArgs ?? "") + toolCall.function.arguments;
+							if (argumentDelta.length > 0) {
+								delta = argumentDelta;
+								block.partialArgs = (block.partialArgs ?? "") + argumentDelta;
 								const throttled = parseStreamingJsonThrottled(block.partialArgs, block.lastParseLen ?? 0);
 								if (throttled) {
 									block.arguments = throttled.value;

--- a/packages/ai/test/issue-1776-repro.test.ts
+++ b/packages/ai/test/issue-1776-repro.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { getBundledModel } from "../src/models";
+import { streamOpenAICompletions } from "../src/providers/openai-completions";
+import type { Context, Model } from "../src/types";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+	global.fetch = originalFetch;
+});
+
+function createSseResponse(events: unknown[]): Response {
+	const payload = `${events
+		.map(event => `data: ${typeof event === "string" ? event : JSON.stringify(event)}`)
+		.join("\n\n")}\n\n`;
+	return new Response(payload, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+function createMockFetch(events: unknown[]): typeof fetch {
+	async function mockFetch(_input: string | URL | Request, _init?: RequestInit): Promise<Response> {
+		return createSseResponse(events);
+	}
+	return Object.assign(mockFetch, { preconnect: originalFetch.preconnect });
+}
+
+function baseContext(): Context {
+	return {
+		messages: [
+			{
+				role: "user",
+				content: "run a command",
+				timestamp: Date.now(),
+			},
+		],
+		tools: [
+			{
+				name: "bash",
+				description: "Run a shell command",
+				parameters: {
+					type: "object",
+					properties: {
+						command: { type: "string" },
+					},
+					required: ["command"],
+				},
+			},
+		],
+	};
+}
+
+function objectArgumentToolCallChunk(model: Model<"openai-completions">): unknown {
+	return {
+		id: "chatcmpl-minimax-cn",
+		object: "chat.completion.chunk",
+		created: 0,
+		model: model.id,
+		choices: [
+			{
+				index: 0,
+				delta: {
+					role: "assistant",
+					tool_calls: [
+						{
+							index: 0,
+							id: "call-minimax-1",
+							type: "function",
+							function: {
+								name: "bash",
+								arguments: { command: "printf '%s\\n' ok" },
+							},
+						},
+					],
+				},
+			},
+		],
+	};
+}
+
+function stopChunk(model: Model<"openai-completions">): unknown {
+	return {
+		id: "chatcmpl-minimax-cn",
+		object: "chat.completion.chunk",
+		created: 0,
+		model: model.id,
+		choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+	};
+}
+
+describe("issue #1776 - MiniMax object-shaped tool arguments", () => {
+	it("preserves object-shaped streamed tool arguments from MiniMax-compatible hosts", async () => {
+		const model = getBundledModel<"openai-completions">("minimax-code-cn", "MiniMax-M2.5");
+		global.fetch = createMockFetch([objectArgumentToolCallChunk(model), stopChunk(model), "[DONE]"]);
+
+		const result = await streamOpenAICompletions(model, baseContext(), { apiKey: "test-key" }).result();
+
+		expect(result.stopReason).toBe("toolUse");
+		expect(result.content).toEqual([
+			{
+				type: "toolCall",
+				id: "call-minimax-1",
+				name: "bash",
+				arguments: { command: "printf '%s\\n' ok" },
+			},
+		]);
+	});
+});


### PR DESCRIPTION
## Repro
A MiniMax-compatible OpenAI chat-completions stream can return `delta.tool_calls[].function.arguments` as an object instead of the OpenAI SDK's typed JSON string. `bun --cwd packages/ai test test/issue-1776-repro.test.ts` reproduced the failure before the fix: the streamed `bash` call reached the agent with `arguments: []` instead of `{ command: "printf '%s\\n' ok" }`.

## Cause
`packages/ai/src/providers/openai-completions.ts` appended `toolCall.function.arguments` directly to the streaming JSON buffer. When the provider supplied an object-shaped argument payload, JavaScript string concatenation coerced it to `[object Object]`; the final `parseStreamingJson` call then produced the wrong argument shape, so downstream `bash`/`edit` tool execution saw empty or malformed inputs.

## Fix
- Added `serializeStreamingToolArgumentDelta` to preserve normal string argument deltas while JSON-serializing object-shaped streamed argument payloads.
- Routed OpenAI-compatible streamed tool argument handling through that serializer before appending to `partialArgs` and emitting `toolcall_delta`.
- Added `packages/ai/test/issue-1776-repro.test.ts` covering MiniMax Coding Plan object-shaped streamed `bash` arguments.
- Updated `packages/ai/CHANGELOG.md` under `[Unreleased]`.

## Verification
Ran `bun test test/issue-1776-repro.test.ts test/issue-1203-repro.test.ts test/openai-completions-compat.test.ts && bun run check` from `packages/ai`; all 47 focused tests passed and `biome check`/`tsgo` passed. Fixes #1776