### PR TITLE
fix(coding-agent/mcp): handle async broken-pipe rejections in stdio transport

### DIFF
--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -25,22 +25,42 @@ interface FrameSink {
 	flush(): unknown;
 }
 
+/** Narrow a value to a thenable so a rejection handler can be attached. */
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+	return (
+		value != null &&
+		(typeof value === "object" || typeof value === "function") &&
+		typeof (value as { then?: unknown }).then === "function"
+	);
+}
+
 /**
  * Write a newline-delimited JSON-RPC frame to the subprocess's stdin sink,
- * swallowing synchronous errors so the caller can decide how to react.
+ * swallowing both synchronous throws and asynchronous rejections so the caller
+ * can decide how to react.
  *
- * Bun's `FileSink` may throw synchronously (most reliably on Windows) when
- * the read end of the pipe has been closed by a subprocess that exited
- * between read-loop ticks. Letting that throw escape an `async` method
- * surfaces as an unhandled promise rejection at the call site.
+ * Bun's `FileSink.write()`/`flush()` can fail two ways once the read end of the
+ * pipe has been closed by a subprocess that exited between read-loop ticks:
+ *   - a synchronous throw (most reliably observed on Windows), and
+ *   - a *rejected Promise* returned from `write()`/`flush()`, i.e. the EPIPE is
+ *     surfaced asynchronously (note the `processTicksAndRejections` frame in the
+ *     stack traces on #1710 and the follow-up report).
  *
- * Returns `true` when the frame was accepted by the sink, `false` when the
- * sink threw — callers signal transport closure on `false`.
+ * A sibling `async` method's `try/catch` only catches the synchronous case; an
+ * un-awaited rejected Promise escapes as a fatal unhandled rejection. So we both
+ * catch the throw and neutralize any returned promise's rejection.
+ *
+ * Returns `true` when the frame was accepted synchronously, `false` when the
+ * sink threw — callers signal transport closure on `false`. An asynchronous
+ * failure cannot be reflected in the return value; it is neutralized here and
+ * the dead transport is detected by the read loop / request timeout instead.
  */
 export function writeFrame(stdin: FrameSink, frame: string): boolean {
 	try {
-		stdin.write(frame);
-		stdin.flush();
+		const wrote = stdin.write(frame);
+		const flushed = stdin.flush();
+		if (isThenable(wrote)) wrote.then(undefined, () => {});
+		if (isThenable(flushed)) flushed.then(undefined, () => {});
 		return true;
 	} catch {
 		return false;
@@ -287,11 +307,16 @@ export class StdioTransport implements MCPTransport {
 			}, timeout);
 		}
 
+		const stdin = this.#process.stdin;
 		const message = `${JSON.stringify(request)}\n`;
 		try {
-			// Bun's FileSink has write() method directly
-			this.#process.stdin.write(message);
-			this.#process.stdin.flush();
+			// Await both: Bun's FileSink can surface a broken pipe either as a
+			// synchronous throw or as a rejected Promise (the EPIPE arrives on a
+			// processTicksAndRejections tick). Awaiting funnels both into this catch
+			// so the request rejects cleanly instead of leaving a floating rejected
+			// promise that crashes the process via the unhandledRejection handler.
+			await stdin.write(message);
+			await stdin.flush();
 		} catch (error: unknown) {
 			cleanup();
 			reject(error instanceof Error ? error : new Error(String(error)));

--- a/packages/coding-agent/test/mcp-stdio-transport.test.ts
+++ b/packages/coding-agent/test/mcp-stdio-transport.test.ts
@@ -2,9 +2,10 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { StdioTransport, writeFrame } from "../src/mcp/transports/stdio";
 
 // ---------------------------------------------------------------------------
-// writeFrame — the seam that catches synchronous FileSink failures so the
-// async `notify` / `#sendResponse` paths can decide whether to swallow or
-// surface the error. See issue #1710.
+// writeFrame — the seam that catches synchronous FileSink throws AND neutralizes
+// asynchronous (Promise) rejections, so the async `notify` / `#sendResponse` /
+// `request` paths never let an un-awaited broken-pipe rejection escape as a fatal
+// unhandled rejection. See issue #1710 and its async follow-up.
 // ---------------------------------------------------------------------------
 
 describe("writeFrame", () => {
@@ -64,6 +65,50 @@ describe("writeFrame", () => {
 		};
 
 		expect(writeFrame(sink, "x")).toBe(false);
+	});
+
+	it("returns true and neutralizes an asynchronous write rejection (broken pipe surfaced as a Promise)", async () => {
+		const sink = {
+			flushed: 0,
+			write() {
+				return Promise.reject(new Error("EPIPE: broken pipe, write"));
+			},
+			flush() {
+				this.flushed++;
+			},
+		};
+
+		const tracker = trackUnhandled();
+		try {
+			// No synchronous throw, so the frame is "accepted"; the async rejection
+			// must be neutralized rather than escaping as an unhandled rejection.
+			expect(writeFrame(sink, "frame\n")).toBe(true);
+			await Bun.sleep(50);
+			expect(tracker.capture()).toEqual([]);
+		} finally {
+			tracker.release();
+		}
+	});
+
+	it("returns true and neutralizes an asynchronous flush rejection", async () => {
+		const sink = {
+			writes: [] as string[],
+			write(chunk: string) {
+				this.writes.push(chunk);
+			},
+			flush() {
+				return Promise.reject(new Error("EPIPE: broken pipe, flush"));
+			},
+		};
+
+		const tracker = trackUnhandled();
+		try {
+			expect(writeFrame(sink, "frame\n")).toBe(true);
+			await Bun.sleep(50);
+			expect(tracker.capture()).toEqual([]);
+		} finally {
+			tracker.release();
+		}
 	});
 });
 


### PR DESCRIPTION
Closes #1782. Follow-up to #1710 / #1711.

## Problem

On Windows, an MCP stdio server that exits mid-handshake still crashes OMP with a fatal unhandled `EPIPE`. #1711's `writeFrame()` catches only **synchronous** `FileSink` throws, but Bun surfaces the broken pipe **asynchronously** as a rejected `Promise`, and `request()` was never routed through `writeFrame` (it wrote stdin without awaiting). The floating rejection hits the postmortem handler → `process.exit(1)`.

The user crash is in `request()` (the `initialize` call), which *already had* a sync `try/catch` in 15.8.0 — yet the rejection escaped via `processTicksAndRejections`. A sync throw would have been caught there, so the failure is necessarily an **async** rejection. (Same logic for the #1710 `notify()` trace: `notify()` is awaited inside a `try/catch`, so only an async rejection can go unhandled.)

## Fix

- **`writeFrame()`** — attach a rejection handler (`.then(undefined, …)`) to any `Promise` returned by `write()`/`flush()`, in addition to the existing sync `catch`. Covers `notify()` + `#sendResponse()`.
- **`request()`** — `await` `write()`/`flush()` so an async rejection lands in its existing `try/catch` and rejects the request instead of floating.
- Adds `isThenable` helper + tests for the async-rejection path.

## Verification (Windows 11 x64, Bun 1.3.14)

- `bun test test/mcp-stdio-transport.test.ts` → **11 pass**.
- `tsgo --noEmit` clean for the changed file; `biome check` clean.
- **Mutation check:** reverting the async neutralization in-place makes the two new tests **and** the pre-existing `notify` mid-handshake test fail with a real async `EPIPE` (`errno: -32`) propagating out of `writeFrame` — direct proof the rejection is asynchronous and that `main` is still affected on Windows. On Linux Bun absorbs the broken pipe, so CI stays green there.

## Notes / open questions

- `request()` uses `await` (fail-fast) rather than routing through `writeFrame`, because the boolean seam can't reflect an async failure (the request would otherwise wait for the timeout). Happy to unify on `writeFrame` instead if you prefer a single seam — at the cost of a timeout-delayed rejection on the async path.
- An async failure can't be reflected in `writeFrame`'s boolean return; it's neutralized and the dead transport is detected by the read loop / request timeout. Documented in the helper's doc comment.
