### PR TITLE
fix(agent): surface max_tokens truncation cause on skipped tool calls (#1785)

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Added optional `AgentTool.matcherDigest(args)` hook: tools whose streamed arguments encode content in a wire grammar (patch formats, escaped strings) can expose the real content they introduce, so stream-content matchers (e.g. TTSR rules) run against plain source text instead of the wire format.
 
+### Fixed
+
+- Fixed the agent loop wedging the model when a `write`/`edit` tool call is truncated by `stop_reason: length` (e.g. an OpenCode Zen / Claude-3.5-Haiku turn that emits >~1000 lines of code, blowing past the 8K `max_tokens` output cap). The skipped tool result now surfaces an actionable hint — naming `stop_reason: length` and telling the model to split the payload into multiple smaller calls — instead of the generic "Tool call was not executed because the assistant ended its turn" placeholder, which left the auto-continue loop re-emitting the same oversized payload until the user gave up. Tools are still NOT executed when the arguments are truncated. ([#1785](https://github.com/can1357/oh-my-pi/issues/1785))
+
 ## [15.8.0] - 2026-06-02
 
 ### Fixed

--- a/packages/agent/src/agent-loop.ts
+++ b/packages/agent/src/agent-loop.ts
@@ -627,9 +627,12 @@ async function runLoopBody(
 				// toolCall blocks behind. The trailing call's arguments may be incomplete,
 				// so don't execute or continue — pair each with a placeholder result to keep
 				// the tool_use/tool_result contract valid for any later request that
-				// replays this turn.
+				// replays this turn. When the truncation was `length`, surface an actionable
+				// hint so the model doesn't loop by re-emitting the same oversized payload
+				// (e.g. 1000+ line `write` content blowing past the model's output cap).
+				const skipReason = message.stopReason === "length" ? "length" : "skipped";
 				for (const toolCall of toolCalls) {
-					const result = createAbortedToolResult(toolCall, stream, "skipped");
+					const result = createAbortedToolResult(toolCall, stream, skipReason);
 					currentContext.messages.push(result);
 					newMessages.push(result);
 					toolResults.push(result);
@@ -1360,15 +1363,17 @@ async function executeToolCalls(
 function createAbortedToolResult(
 	toolCall: Extract<AssistantMessage["content"][number], { type: "toolCall" }>,
 	stream: EventStream<AgentEvent, AgentMessage[]>,
-	reason: "aborted" | "error" | "skipped",
+	reason: "aborted" | "error" | "skipped" | "length",
 	errorMessage?: string,
 ): ToolResultMessage {
 	const message =
 		reason === "aborted"
 			? "Tool execution was aborted"
-			: reason === "skipped"
-				? "Tool call was not executed because the assistant ended its turn"
-				: "Tool execution failed due to an error";
+			: reason === "length"
+				? "Tool call was not executed because the assistant hit its output token limit (stop_reason: length) before the arguments could complete; the recorded arguments are truncated and unsafe to run. Do NOT retry by re-emitting the same large payload — split the work into several smaller tool calls (e.g. for `write`/`edit`, write the first chunk then append the rest with subsequent `edit` insert ops, or break the file into multiple `write` targets)"
+				: reason === "skipped"
+					? "Tool call was not executed because the assistant ended its turn"
+					: "Tool execution failed due to an error";
 	const result: AgentToolResult<any> = {
 		content: [{ type: "text", text: errorMessage ? `${message}: ${errorMessage}` : `${message}.` }],
 		details: {},

--- a/packages/agent/test/agent-loop.test.ts
+++ b/packages/agent/test/agent-loop.test.ts
@@ -1135,4 +1135,73 @@ describe("agentLoopContinue with AgentMessage", () => {
 		expect(messages.map(message => message.role)).toEqual(["user", "assistant", "user", "assistant"]);
 		expect(messages[2]).toMatchObject({ role: "user", content: "follow-up" });
 	});
+
+	it("skips tool calls when the assistant turn was truncated by max_tokens (stop_reason: length) and tells the model to chunk", async () => {
+		// Regression for issue #1785 (`write` tool crash on >1020-line content).
+		// When a model emits a `write` call whose `content` argument exceeds the
+		// model's `max_tokens` output cap, the provider cuts the stream off mid-
+		// arguments and reports `stop_reason: length`. The agent must NOT execute
+		// the truncated call (its `content` is a partial string), AND the synthetic
+		// tool result must guide the model towards a chunked retry — otherwise the
+		// auto-continue loop re-emits the same oversized payload and the file never
+		// gets written ("write tool crash" from the reporter's POV).
+		const writeSchema = z.object({ path: z.string(), content: z.string() });
+		const executed: { path: string; content: string }[] = [];
+		const writeTool: AgentTool<typeof writeSchema, { path: string }> = {
+			name: "write",
+			label: "Write",
+			description: "Write tool",
+			parameters: writeSchema,
+			async execute(_id, params) {
+				executed.push({ path: params.path, content: params.content });
+				return { content: [{ type: "text", text: "ok" }], details: { path: params.path } };
+			},
+		};
+		const context: AgentContext = { systemPrompt: [""], messages: [], tools: [writeTool] };
+
+		// The model emits one write tool call, then the stream ends with
+		// stop_reason: "length". The arguments field carries a truncated content
+		// payload — exactly what the streaming JSON parser produces when the
+		// closing quote/brace never arrive.
+		const truncatedContent = "line 1\nline 2\n... (cut off mid-string"; // no closing quote
+		const mock = createMockModel({
+			responses: [
+				{
+					content: [
+						{
+							type: "toolCall",
+							id: "tc-write-1",
+							name: "write",
+							arguments: { path: "/tmp/huge.ts", content: truncatedContent },
+						},
+					],
+					stopReason: "length",
+				},
+			],
+		});
+		const config: AgentLoopConfig = { model: mock.model, convertToLlm: identityConverter };
+		const stream = agentLoop([createUserMessage("write huge file")], context, config, undefined, mock.stream);
+		for await (const _event of stream) {
+			// drain
+		}
+		const messages = await stream.result();
+
+		// The tool MUST NOT have been executed — the arguments are mid-string and
+		// running them would persist a half-written file.
+		expect(executed).toEqual([]);
+
+		// The synthetic tool result must surface the truncation cause so the model
+		// can recover by chunking instead of re-emitting the same payload.
+		const toolResult = messages.find(m => m.role === "toolResult");
+		expect(toolResult).toBeDefined();
+		if (toolResult?.role !== "toolResult") throw new Error("expected tool result");
+		expect(toolResult.toolCallId).toBe("tc-write-1");
+		expect(toolResult.isError).toBe(true);
+		const text = toolResult.content
+			.filter((c): c is { type: "text"; text: string } => c.type === "text")
+			.map(c => c.text)
+			.join("\n");
+		expect(text).toContain("stop_reason: length");
+		expect(text).toMatch(/split|chunk/i);
+	});
 });


### PR DESCRIPTION
## Repro

On macOS, `omp` 15.7.6, provider OpenCode Zen, the reporter asked the model to implement a feature in a single file that grew past ~1020 lines. The `write` tool call's `content` argument hits the model's per-turn output cap, the provider cuts the stream off mid-`input_json_delta` and ends it with `stop_reason: length`, and the agent never persists the file. Auto-continue re-prompts the model, which re-emits the same oversized payload, hits `length` again, and the user sees "file writing failure and loss of the target file, the same problem persists after retries."

Reproduced locally with a mock stream that carries the truncated `content` field plus `done: { reason: "length" }`:

```
cd packages/agent && bun test test/agent-loop.test.ts -t "stop_reason: length"
```

Pre-fix the test fails on the placeholder text "Tool call was not executed because the assistant ended its turn."; post-fix it passes.

## Cause

OpenCode Zen's `claude-3-5-haiku` advertises `maxTokens: 8192` in `packages/ai/src/models.json:61663` — roughly 800–1024 lines of code depending on density, exactly the threshold the reporter hit. `packages/ai/src/utils/json-parse.ts:132` (`parseStreamingJson`) repairs the truncated buffer into a half-string `content` field, and `packages/agent/src/agent-loop.ts:625` correctly refuses to execute the call because its arguments are unsafe. The problem was the *recovery hint*: `createAbortedToolResult` (`packages/agent/src/agent-loop.ts:1360`) attached the same generic placeholder it uses for non-runnable non-tool turns — "Tool call was not executed because the assistant ended its turn." — with no signal that the cause was `stop_reason: length` or that the payload itself was the problem. The model retried the identical write, hit the cap again, and the loop repeated.

## Fix

- `createAbortedToolResult` now accepts a `"length"` reason and emits a message that names `stop_reason: length` and prescribes a chunked recovery: write the first portion, append the rest with `edit` insert ops, or break the file into multiple `write` targets.
- The skip branch in `agentLoop` forwards `message.stopReason === "length"` so the new reason actually reaches the model on the next continuation; non-length skips keep their existing copy.
- The execution guard is unchanged — tools with truncated arguments are still NOT run.
- Regression test in `packages/agent/test/agent-loop.test.ts` builds the failing scenario via the `mock` provider (single `write` tool call with a mid-string `content` and `stopReason: "length"`) and asserts:
  - `executed === []` (the half-written content never reaches disk),
  - the synthetic tool result is an error,
  - its text contains the literal `stop_reason: length` plus chunking guidance.

## Verification

- `cd packages/agent && bun test` → `216 pass, 0 fail, 717 expect() calls`.
- `cd packages/agent && bun test test/agent-loop.test.ts -t "stop_reason: length"` → fails pre-fix (placeholder text), passes post-fix.

Fixes #1785