### PR TITLE
feat(coding-agent): resolve @file references in context files

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -165,6 +165,7 @@
 ### Added
 
 - Added a bundled TypeScript rule that warns against leaving `@deprecated` compatibility shims behind instead of finishing a refactor.
+- Added `@file.ext` reference resolution in context files (CLAUDE.md, AGENTS.md, etc.). Lines matching `@path/to/file.ext` are automatically replaced with the referenced file's content, resolved relative to the context file's directory. References are contained within the project root (paths that escape or are absolute are rejected), recursive with depth and cycle limits, and controlled by the `contextFiles.resolveAtRefs` setting (default: enabled). Closes [#375](https://github.com/can1357/oh-my-pi/issues/375)
 
 ### Fixed
 

--- a/packages/coding-agent/src/capability/resolve-at-refs.ts
+++ b/packages/coding-agent/src/capability/resolve-at-refs.ts
@@ -7,17 +7,26 @@
  *
  * Pattern: a line that is exactly `@path/to/file.ext` (must contain a `.`)
  * — resolved relative to the context file's directory.
+ * — contained within the context file's repo root (or cwd fallback).
  * — recursive with depth limit and cycle detection.
+ * — controlled by the `contextFiles.resolveAtRefs` setting (default: enabled).
  *
  * See: https://github.com/can1357/oh-my-pi/issues/375
  */
 
 import * as path from "node:path";
-import { readFile } from "./fs";
+import { findRepoRoot, readFile } from "./fs";
 
 export interface ResolveAtRefsOptions {
 	/** Maximum recursion depth for nested @-references (default: 5) */
 	maxDepth?: number;
+	/**
+	 * Boundary directory for path containment.
+	 * Resolved refs that escape this root are rejected.
+	 * Defaults to the repo root discovered from the first file's path,
+	 * falling back to its directory.
+	 */
+	rootDir?: string;
 }
 
 /**
@@ -41,9 +50,16 @@ export interface ResolveAtRefsOptions {
  */
 const AT_REF_PATTERN = /^@([\w.\-/]+\.[\w.-]+)\s*$/;
 
+function isWithin(absPath: string, root: string): boolean {
+	const normalized = path.normalize(absPath);
+	const normalizedRoot = path.normalize(root);
+	return normalized.startsWith(normalizedRoot + path.sep) || normalized === normalizedRoot;
+}
+
 async function resolveContent(
 	content: string,
 	filePath: string,
+	rootDir: string,
 	seen: Set<string>,
 	depth: number,
 	maxDepth: number,
@@ -62,7 +78,20 @@ async function resolveContent(
 		}
 
 		const refPath = match[1];
+
+		// Reject absolute paths — @-refs must be relative
+		if (path.isAbsolute(refPath)) {
+			resolved.push(`<!-- @${refPath}: absolute paths are not allowed -->`);
+			continue;
+		}
+
 		const absRefPath = path.resolve(baseDir, refPath);
+
+		// Path containment: reject refs that escape rootDir
+		if (!isWithin(absRefPath, rootDir)) {
+			resolved.push(`<!-- @${refPath}: escapes project root -->`);
+			continue;
+		}
 
 		// Cycle detection
 		if (seen.has(absRefPath)) {
@@ -78,7 +107,7 @@ async function resolveContent(
 
 		// Recursively resolve references in the included file
 		seen.add(absRefPath);
-		const innerResolved = await resolveContent(refContent, absRefPath, seen, depth + 1, maxDepth);
+		const innerResolved = await resolveContent(refContent, absRefPath, rootDir, seen, depth + 1, maxDepth);
 		seen.delete(absRefPath);
 
 		resolved.push(innerResolved);
@@ -92,21 +121,33 @@ async function resolveContent(
  *
  * For each context file, scans its content for lines matching `@relative/path.ext`
  * and replaces them with the referenced file's content. References are resolved
- * relative to the context file's own directory. Recursion is bounded by
- * `maxDepth` and cycles are detected.
+ * relative to the context file's own directory and contained within `rootDir`.
+ * Recursion is bounded by `maxDepth` and cycles are detected.
  *
- * Files that cannot be read produce a comment placeholder instead of crashing.
+ * Files that cannot be read or that escape the project root produce a comment
+ * placeholder instead of crashing.
  */
 export async function resolveAtRefs(
 	files: Array<{ path: string; content: string; depth?: number }>,
 	options: ResolveAtRefsOptions = {},
 ): Promise<Array<{ path: string; content: string; depth?: number }>> {
 	const maxDepth = options.maxDepth ?? 5;
+
+	// Determine rootDir: explicit option → repo root from first file → first file's directory
+	let rootDir = options.rootDir;
+	if (!rootDir && files.length > 0) {
+		const discovered = await findRepoRoot(path.dirname(path.resolve(files[0].path)));
+		rootDir = discovered ?? path.dirname(path.resolve(files[0].path));
+	}
+	if (!rootDir) {
+		rootDir = process.cwd();
+	}
+
 	const resolved: Array<{ path: string; content: string; depth?: number }> = [];
 
 	for (const file of files) {
 		const seen = new Set<string>([path.resolve(file.path)]);
-		const newContent = await resolveContent(file.content, file.path, seen, 0, maxDepth);
+		const newContent = await resolveContent(file.content, file.path, rootDir, seen, 0, maxDepth);
 		resolved.push({
 			path: file.path,
 			content: newContent,

--- a/packages/coding-agent/src/capability/resolve-at-refs.ts
+++ b/packages/coding-agent/src/capability/resolve-at-refs.ts
@@ -102,7 +102,6 @@ async function isIgnoredByGitignore(absPath: string, root: string): Promise<bool
 async function resolveContent(
 	content: string,
 	filePath: string,
-	rootDir: string,
 	realRootDir: string,
 	seen: Set<string>,
 	depth: number,
@@ -129,33 +128,23 @@ async function resolveContent(
 			continue;
 		}
 
-		const absRefPath = path.resolve(baseDir, refPath);
-
-		// Path containment: refs must stay in the root namespace. Recursive
-		// includes reached through symlinks use real paths, so accept either the
-		// original root path or its realpath namespace.
-		if (!isWithin(absRefPath, rootDir) && !isWithin(absRefPath, realRootDir)) {
-			resolved.push(`<!-- @${refPath}: escapes project root -->`);
-			continue;
-		}
-
-		// Symlink containment: resolve the real path and check again.
-		// A repo-local symlink pointing outside the project root would
-		// pass the lexical check above but still read an out-of-root file.
 		let realRefPath: string;
 		try {
-			realRefPath = await fs.promises.realpath(absRefPath);
+			realRefPath = await fs.promises.realpath(path.resolve(baseDir, refPath));
 		} catch {
 			resolved.push(`<!-- @${refPath}: file not found -->`);
 			continue;
 		}
+
+		// Containment is enforced in the realpath namespace. That keeps ordinary
+		// refs, symlinked context files, and symlinked included files on the same
+		// path model while still rejecting symlink traversal outside the root.
 		if (!isWithin(realRefPath, realRootDir)) {
 			resolved.push(`<!-- @${refPath}: escapes project root -->`);
 			continue;
 		}
 
-		const lexicallyIgnored = isWithin(absRefPath, rootDir) ? await isIgnoredByGitignore(absRefPath, rootDir) : false;
-		if (lexicallyIgnored || (await isIgnoredByGitignore(realRefPath, realRootDir))) {
+		if (await isIgnoredByGitignore(realRefPath, realRootDir)) {
 			resolved.push(`<!-- @${refPath}: ignored by gitignore -->`);
 			continue;
 		}
@@ -173,18 +162,9 @@ async function resolveContent(
 		}
 
 		// Recursively resolve references in the included file. Use the real target
-		// path so nested refs in allowed symlinks are resolved from the target's
-		// directory, not the symlink's directory.
+		// path so nested refs are resolved from the target's directory.
 		seen.add(realRefPath);
-		const innerResolved = await resolveContent(
-			refContent,
-			realRefPath,
-			rootDir,
-			realRootDir,
-			seen,
-			depth + 1,
-			maxDepth,
-		);
+		const innerResolved = await resolveContent(refContent, realRefPath, realRootDir, seen, depth + 1, maxDepth);
 		seen.delete(realRefPath);
 
 		resolved.push(innerResolved);
@@ -220,8 +200,9 @@ export async function resolveAtRefs(
 			(await findRepoRoot(path.dirname(path.resolve(file.path)))) ??
 			path.dirname(path.resolve(file.path));
 		const realFileRootDir = await realpathOrSelf(fileRootDir);
-		const seen = new Set<string>([path.resolve(file.path)]);
-		const newContent = await resolveContent(file.content, file.path, fileRootDir, realFileRootDir, seen, 0, maxDepth);
+		const realFilePath = await realpathOrSelf(file.path);
+		const seen = new Set<string>([realFilePath]);
+		const newContent = await resolveContent(file.content, realFilePath, realFileRootDir, seen, 0, maxDepth);
 		resolved.push({
 			path: file.path,
 			content: newContent,

--- a/packages/coding-agent/src/capability/resolve-at-refs.ts
+++ b/packages/coding-agent/src/capability/resolve-at-refs.ts
@@ -17,6 +17,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { glob } from "@oh-my-pi/pi-natives";
 import { findRepoRoot, readFile } from "./fs";
 
 export interface ResolveAtRefsOptions {
@@ -64,6 +65,29 @@ async function realpathOrSelf(filePath: string): Promise<string> {
 		return await fs.promises.realpath(filePath);
 	} catch {
 		return filePath;
+	}
+}
+
+function toPosixPath(value: string): string {
+	return value.split(path.sep).join("/");
+}
+
+async function isIgnoredByGitignore(absPath: string, root: string): Promise<boolean> {
+	const relativePath = path.relative(root, absPath);
+	if (
+		relativePath === "" ||
+		relativePath === ".." ||
+		relativePath.startsWith(`..${path.sep}`) ||
+		path.isAbsolute(relativePath)
+	) {
+		return true;
+	}
+	const pattern = toPosixPath(relativePath);
+	try {
+		const result = await glob({ pattern, path: root, hidden: true, gitignore: true, maxResults: 1 });
+		return !result.matches.some(match => match.path === pattern);
+	} catch {
+		return true;
 	}
 }
 
@@ -120,23 +144,30 @@ async function resolveContent(
 			continue;
 		}
 
+		if ((await isIgnoredByGitignore(absRefPath, rootDir)) || (await isIgnoredByGitignore(realRefPath, realRootDir))) {
+			resolved.push(`<!-- @${refPath}: ignored by gitignore -->`);
+			continue;
+		}
+
 		// Cycle detection
 		if (seen.has(realRefPath)) {
 			resolved.push(`<!-- @${refPath}: circular reference skipped -->`);
 			continue;
 		}
 
-		const refContent = await readFile(absRefPath);
+		const refContent = await readFile(realRefPath);
 		if (refContent === null) {
 			resolved.push(`<!-- @${refPath}: file not found -->`);
 			continue;
 		}
 
-		// Recursively resolve references in the included file
+		// Recursively resolve references in the included file. Use the real target
+		// path so nested refs in allowed symlinks are resolved from the target's
+		// directory, not the symlink's directory.
 		seen.add(realRefPath);
 		const innerResolved = await resolveContent(
 			refContent,
-			absRefPath,
+			realRefPath,
 			rootDir,
 			realRootDir,
 			seen,

--- a/packages/coding-agent/src/capability/resolve-at-refs.ts
+++ b/packages/coding-agent/src/capability/resolve-at-refs.ts
@@ -25,8 +25,9 @@ export interface ResolveAtRefsOptions {
 	/**
 	 * Boundary directory for path containment.
 	 * Resolved refs that escape this root are rejected.
-	 * Defaults to the repo root discovered from the first file's path,
-	 * falling back to its directory.
+	 * When unset, each context file's containment root is independently
+	 * discovered from its own path (repo root → directory fallback),
+	 * so user-level files are not rejected by a project-level boundary.
 	 */
 	rootDir?: string;
 }
@@ -149,22 +150,17 @@ export async function resolveAtRefs(
 	options: ResolveAtRefsOptions = {},
 ): Promise<Array<{ path: string; content: string; depth?: number }>> {
 	const maxDepth = options.maxDepth ?? 5;
-
-	// Determine rootDir: explicit option → repo root from first file → first file's directory
-	let rootDir = options.rootDir;
-	if (!rootDir && files.length > 0) {
-		const discovered = await findRepoRoot(path.dirname(path.resolve(files[0].path)));
-		rootDir = discovered ?? path.dirname(path.resolve(files[0].path));
-	}
-	if (!rootDir) {
-		rootDir = process.cwd();
-	}
-
 	const resolved: Array<{ path: string; content: string; depth?: number }> = [];
-
 	for (const file of files) {
+		// Each context file gets its own containment root.
+		// User-level files (e.g. ~/.omp/AGENTS.md) use their own repo root
+		// so their @-refs aren't rejected by a project-level boundary.
+		const fileRootDir =
+			options.rootDir ??
+			(await findRepoRoot(path.dirname(path.resolve(file.path)))) ??
+			path.dirname(path.resolve(file.path));
 		const seen = new Set<string>([path.resolve(file.path)]);
-		const newContent = await resolveContent(file.content, file.path, rootDir, seen, 0, maxDepth);
+		const newContent = await resolveContent(file.content, file.path, fileRootDir, seen, 0, maxDepth);
 		resolved.push({
 			path: file.path,
 			content: newContent,

--- a/packages/coding-agent/src/capability/resolve-at-refs.ts
+++ b/packages/coding-agent/src/capability/resolve-at-refs.ts
@@ -169,12 +169,14 @@ async function resolveContent(
 			continue;
 		}
 
-		if (await isIgnoredByGitignore(realRefPath, realRootDir)) {
-			resolved.push(`<!-- @${refPath}: ignored by gitignore -->`);
+		const trackedByGit = isTrackedByGit(realRefPath, realRootDir, trackedFiles);
+		if (!trackedByGit) {
+			resolved.push(`<!-- @${refPath}: not tracked by git -->`);
 			continue;
 		}
-		if (!isTrackedByGit(realRefPath, realRootDir, trackedFiles)) {
-			resolved.push(`<!-- @${refPath}: not tracked by git -->`);
+
+		if (!trackedFiles && (await isIgnoredByGitignore(realRefPath, realRootDir))) {
+			resolved.push(`<!-- @${refPath}: ignored by gitignore -->`);
 			continue;
 		}
 

--- a/packages/coding-agent/src/capability/resolve-at-refs.ts
+++ b/packages/coding-agent/src/capability/resolve-at-refs.ts
@@ -123,8 +123,10 @@ async function resolveContent(
 
 		const absRefPath = path.resolve(baseDir, refPath);
 
-		// Path containment: reject refs that escape rootDir
-		if (!isWithin(absRefPath, rootDir)) {
+		// Path containment: refs must stay in the root namespace. Recursive
+		// includes reached through symlinks use real paths, so accept either the
+		// original root path or its realpath namespace.
+		if (!isWithin(absRefPath, rootDir) && !isWithin(absRefPath, realRootDir)) {
 			resolved.push(`<!-- @${refPath}: escapes project root -->`);
 			continue;
 		}
@@ -144,7 +146,8 @@ async function resolveContent(
 			continue;
 		}
 
-		if ((await isIgnoredByGitignore(absRefPath, rootDir)) || (await isIgnoredByGitignore(realRefPath, realRootDir))) {
+		const lexicallyIgnored = isWithin(absRefPath, rootDir) ? await isIgnoredByGitignore(absRefPath, rootDir) : false;
+		if (lexicallyIgnored || (await isIgnoredByGitignore(realRefPath, realRootDir))) {
 			resolved.push(`<!-- @${refPath}: ignored by gitignore -->`);
 			continue;
 		}

--- a/packages/coding-agent/src/capability/resolve-at-refs.ts
+++ b/packages/coding-agent/src/capability/resolve-at-refs.ts
@@ -59,10 +59,19 @@ function isWithin(absPath: string, root: string): boolean {
 	return normalized.startsWith(normalizedRoot + path.sep) || normalized === normalizedRoot;
 }
 
+async function realpathOrSelf(filePath: string): Promise<string> {
+	try {
+		return await fs.promises.realpath(filePath);
+	} catch {
+		return filePath;
+	}
+}
+
 async function resolveContent(
 	content: string,
 	filePath: string,
 	rootDir: string,
+	realRootDir: string,
 	seen: Set<string>,
 	depth: number,
 	maxDepth: number,
@@ -106,7 +115,7 @@ async function resolveContent(
 			resolved.push(`<!-- @${refPath}: file not found -->`);
 			continue;
 		}
-		if (!isWithin(realRefPath, rootDir)) {
+		if (!isWithin(realRefPath, realRootDir)) {
 			resolved.push(`<!-- @${refPath}: escapes project root -->`);
 			continue;
 		}
@@ -125,7 +134,15 @@ async function resolveContent(
 
 		// Recursively resolve references in the included file
 		seen.add(realRefPath);
-		const innerResolved = await resolveContent(refContent, absRefPath, rootDir, seen, depth + 1, maxDepth);
+		const innerResolved = await resolveContent(
+			refContent,
+			absRefPath,
+			rootDir,
+			realRootDir,
+			seen,
+			depth + 1,
+			maxDepth,
+		);
 		seen.delete(realRefPath);
 
 		resolved.push(innerResolved);
@@ -159,8 +176,9 @@ export async function resolveAtRefs(
 			options.rootDir ??
 			(await findRepoRoot(path.dirname(path.resolve(file.path)))) ??
 			path.dirname(path.resolve(file.path));
+		const realFileRootDir = await realpathOrSelf(fileRootDir);
 		const seen = new Set<string>([path.resolve(file.path)]);
-		const newContent = await resolveContent(file.content, file.path, fileRootDir, seen, 0, maxDepth);
+		const newContent = await resolveContent(file.content, file.path, fileRootDir, realFileRootDir, seen, 0, maxDepth);
 		resolved.push({
 			path: file.path,
 			content: newContent,

--- a/packages/coding-agent/src/capability/resolve-at-refs.ts
+++ b/packages/coding-agent/src/capability/resolve-at-refs.ts
@@ -10,6 +10,7 @@
  * — contained within the context file's repo root (or cwd fallback).
  * — symlinks resolved before containment check to prevent traversal.
  * — recursive with depth limit and cycle detection.
+ * — git worktree refs require tracked targets when git metadata is available.
  * — controlled by the `contextFiles.resolveAtRefs` setting (default: enabled).
  *
  * See: https://github.com/can1357/oh-my-pi/issues/375
@@ -18,6 +19,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { glob } from "@oh-my-pi/pi-natives";
+import * as git from "../utils/git";
 import { findRepoRoot, readFile } from "./fs";
 
 export interface ResolveAtRefsFile {
@@ -99,10 +101,33 @@ async function isIgnoredByGitignore(absPath: string, root: string): Promise<bool
 	}
 }
 
+async function loadTrackedFiles(root: string): Promise<Set<string> | null> {
+	try {
+		return new Set(await git.ls.files(root));
+	} catch {
+		return null;
+	}
+}
+
+function isTrackedByGit(absPath: string, root: string, trackedFiles: Set<string> | null): boolean {
+	if (!trackedFiles) return true;
+	const relativePath = path.relative(root, absPath);
+	if (
+		relativePath === "" ||
+		relativePath === ".." ||
+		relativePath.startsWith(`..${path.sep}`) ||
+		path.isAbsolute(relativePath)
+	) {
+		return false;
+	}
+	return trackedFiles.has(toPosixPath(relativePath));
+}
+
 async function resolveContent(
 	content: string,
 	filePath: string,
 	realRootDir: string,
+	trackedFiles: Set<string> | null,
 	seen: Set<string>,
 	depth: number,
 	maxDepth: number,
@@ -148,6 +173,10 @@ async function resolveContent(
 			resolved.push(`<!-- @${refPath}: ignored by gitignore -->`);
 			continue;
 		}
+		if (!isTrackedByGit(realRefPath, realRootDir, trackedFiles)) {
+			resolved.push(`<!-- @${refPath}: not tracked by git -->`);
+			continue;
+		}
 
 		// Cycle detection
 		if (seen.has(realRefPath)) {
@@ -164,7 +193,15 @@ async function resolveContent(
 		// Recursively resolve references in the included file. Use the real target
 		// path so nested refs are resolved from the target's directory.
 		seen.add(realRefPath);
-		const innerResolved = await resolveContent(refContent, realRefPath, realRootDir, seen, depth + 1, maxDepth);
+		const innerResolved = await resolveContent(
+			refContent,
+			realRefPath,
+			realRootDir,
+			trackedFiles,
+			seen,
+			depth + 1,
+			maxDepth,
+		);
 		seen.delete(realRefPath);
 
 		resolved.push(innerResolved);
@@ -201,8 +238,17 @@ export async function resolveAtRefs(
 			path.dirname(path.resolve(file.path));
 		const realFileRootDir = await realpathOrSelf(fileRootDir);
 		const realFilePath = await realpathOrSelf(file.path);
+		const trackedFiles = await loadTrackedFiles(realFileRootDir);
 		const seen = new Set<string>([realFilePath]);
-		const newContent = await resolveContent(file.content, realFilePath, realFileRootDir, seen, 0, maxDepth);
+		const newContent = await resolveContent(
+			file.content,
+			realFilePath,
+			realFileRootDir,
+			trackedFiles,
+			seen,
+			0,
+			maxDepth,
+		);
 		resolved.push({
 			path: file.path,
 			content: newContent,

--- a/packages/coding-agent/src/capability/resolve-at-refs.ts
+++ b/packages/coding-agent/src/capability/resolve-at-refs.ts
@@ -8,12 +8,14 @@
  * Pattern: a line that is exactly `@path/to/file.ext` (must contain a `.`)
  * — resolved relative to the context file's directory.
  * — contained within the context file's repo root (or cwd fallback).
+ * — symlinks resolved before containment check to prevent traversal.
  * — recursive with depth limit and cycle detection.
  * — controlled by the `contextFiles.resolveAtRefs` setting (default: enabled).
  *
  * See: https://github.com/can1357/oh-my-pi/issues/375
  */
 
+import * as fs from "node:fs";
 import * as path from "node:path";
 import { findRepoRoot, readFile } from "./fs";
 
@@ -93,8 +95,23 @@ async function resolveContent(
 			continue;
 		}
 
+		// Symlink containment: resolve the real path and check again.
+		// A repo-local symlink pointing outside the project root would
+		// pass the lexical check above but still read an out-of-root file.
+		let realRefPath: string;
+		try {
+			realRefPath = await fs.promises.realpath(absRefPath);
+		} catch {
+			resolved.push(`<!-- @${refPath}: file not found -->`);
+			continue;
+		}
+		if (!isWithin(realRefPath, rootDir)) {
+			resolved.push(`<!-- @${refPath}: escapes project root -->`);
+			continue;
+		}
+
 		// Cycle detection
-		if (seen.has(absRefPath)) {
+		if (seen.has(realRefPath)) {
 			resolved.push(`<!-- @${refPath}: circular reference skipped -->`);
 			continue;
 		}
@@ -106,9 +123,9 @@ async function resolveContent(
 		}
 
 		// Recursively resolve references in the included file
-		seen.add(absRefPath);
+		seen.add(realRefPath);
 		const innerResolved = await resolveContent(refContent, absRefPath, rootDir, seen, depth + 1, maxDepth);
-		seen.delete(absRefPath);
+		seen.delete(realRefPath);
 
 		resolved.push(innerResolved);
 	}

--- a/packages/coding-agent/src/capability/resolve-at-refs.ts
+++ b/packages/coding-agent/src/capability/resolve-at-refs.ts
@@ -20,6 +20,14 @@ import * as path from "node:path";
 import { glob } from "@oh-my-pi/pi-natives";
 import { findRepoRoot, readFile } from "./fs";
 
+export interface ResolveAtRefsFile {
+	path: string;
+	content: string;
+	depth?: number;
+	/** Per-file containment root, used when discovery knows the project scope. */
+	rootDir?: string;
+}
+
 export interface ResolveAtRefsOptions {
 	/** Maximum recursion depth for nested @-references (default: 5) */
 	maxDepth?: number;
@@ -197,7 +205,7 @@ async function resolveContent(
  * placeholder instead of crashing.
  */
 export async function resolveAtRefs(
-	files: Array<{ path: string; content: string; depth?: number }>,
+	files: ResolveAtRefsFile[],
 	options: ResolveAtRefsOptions = {},
 ): Promise<Array<{ path: string; content: string; depth?: number }>> {
 	const maxDepth = options.maxDepth ?? 5;
@@ -207,6 +215,7 @@ export async function resolveAtRefs(
 		// User-level files (e.g. ~/.omp/AGENTS.md) use their own repo root
 		// so their @-refs aren't rejected by a project-level boundary.
 		const fileRootDir =
+			file.rootDir ??
 			options.rootDir ??
 			(await findRepoRoot(path.dirname(path.resolve(file.path)))) ??
 			path.dirname(path.resolve(file.path));

--- a/packages/coding-agent/src/capability/resolve-at-refs.ts
+++ b/packages/coding-agent/src/capability/resolve-at-refs.ts
@@ -1,0 +1,118 @@
+/**
+ * @file Reference Resolution for Context Files
+ *
+ * Resolves `@relative/path.ext` references found in context file content
+ * (CLAUDE.md, AGENTS.md, etc.) by inlining the referenced file's content
+ * at the point of reference.
+ *
+ * Pattern: a line that is exactly `@path/to/file.ext` (must contain a `.`)
+ * — resolved relative to the context file's directory.
+ * — recursive with depth limit and cycle detection.
+ *
+ * See: https://github.com/can1357/oh-my-pi/issues/375
+ */
+
+import * as path from "node:path";
+import { readFile } from "./fs";
+
+export interface ResolveAtRefsOptions {
+	/** Maximum recursion depth for nested @-references (default: 5) */
+	maxDepth?: number;
+}
+
+/**
+ * Matches a line that is *exactly* an @-reference:
+ *   - Must start with `@`
+ *   - Must contain at least one `.` (to distinguish from mentions/emails)
+ *   - Must not contain whitespace (paths don't have spaces)
+ *   - Allows letters, digits, `-`, `_`, `.`, `/`
+ *   - Must be on its own line (leading/trailing whitespace is stripped)
+ *
+ * Examples that match:
+ *   @package.json
+ *   @pyproject.toml
+ *   @../configs/rules.md
+ *   @src/types.ts
+ *
+ * Examples that don't match:
+ *   @username (no extension)
+ *   email@example.com (@ is not at start of segment)
+ *   See @foo for details (not on its own line)
+ */
+const AT_REF_PATTERN = /^@([\w.\-/]+\.[\w.-]+)\s*$/;
+
+async function resolveContent(
+	content: string,
+	filePath: string,
+	seen: Set<string>,
+	depth: number,
+	maxDepth: number,
+): Promise<string> {
+	if (depth >= maxDepth) return content;
+
+	const baseDir = path.dirname(filePath);
+	const lines = content.split("\n");
+	const resolved: string[] = [];
+
+	for (const line of lines) {
+		const match = AT_REF_PATTERN.exec(line);
+		if (!match) {
+			resolved.push(line);
+			continue;
+		}
+
+		const refPath = match[1];
+		const absRefPath = path.resolve(baseDir, refPath);
+
+		// Cycle detection
+		if (seen.has(absRefPath)) {
+			resolved.push(`<!-- @${refPath}: circular reference skipped -->`);
+			continue;
+		}
+
+		const refContent = await readFile(absRefPath);
+		if (refContent === null) {
+			resolved.push(`<!-- @${refPath}: file not found -->`);
+			continue;
+		}
+
+		// Recursively resolve references in the included file
+		seen.add(absRefPath);
+		const innerResolved = await resolveContent(refContent, absRefPath, seen, depth + 1, maxDepth);
+		seen.delete(absRefPath);
+
+		resolved.push(innerResolved);
+	}
+
+	return resolved.join("\n");
+}
+
+/**
+ * Resolve @-file references in an array of context files.
+ *
+ * For each context file, scans its content for lines matching `@relative/path.ext`
+ * and replaces them with the referenced file's content. References are resolved
+ * relative to the context file's own directory. Recursion is bounded by
+ * `maxDepth` and cycles are detected.
+ *
+ * Files that cannot be read produce a comment placeholder instead of crashing.
+ */
+export async function resolveAtRefs(
+	files: Array<{ path: string; content: string; depth?: number }>,
+	options: ResolveAtRefsOptions = {},
+): Promise<Array<{ path: string; content: string; depth?: number }>> {
+	const maxDepth = options.maxDepth ?? 5;
+	const resolved: Array<{ path: string; content: string; depth?: number }> = [];
+
+	for (const file of files) {
+		const seen = new Set<string>([path.resolve(file.path)]);
+		const newContent = await resolveContent(file.content, file.path, seen, 0, maxDepth);
+		resolved.push({
+			path: file.path,
+			content: newContent,
+			depth: file.depth,
+		});
+	}
+
+	return resolved;
+}

--- a/packages/coding-agent/src/commit/agentic/index.ts
+++ b/packages/coding-agent/src/commit/agentic/index.ts
@@ -63,7 +63,7 @@ export async function runAgenticCommit(args: CommitCommandArgs): Promise<void> {
 	}
 	const [changelogBoundaries, contextFiles, numstat, diff] = await Promise.all([
 		args.noChangelog ? [] : detectChangelogBoundaries(cwd, stagedFiles),
-		discoverContextFiles(cwd),
+		discoverContextFiles(cwd, undefined, settings),
 		git.diff.numstat(cwd, { cached: true }),
 		git.diff(cwd, { cached: true }),
 	]);

--- a/packages/coding-agent/src/commit/pipeline.ts
+++ b/packages/coding-agent/src/commit/pipeline.ts
@@ -85,7 +85,7 @@ async function runLegacyCommitCommand(args: CommitCommandArgs): Promise<void> {
 	const numstat = await git.diff.numstat(cwd, { cached: true });
 	const scopeCandidates = extractScopeCandidates(numstat).scopeCandidates;
 	const recentCommits = await git.log.subjects(cwd, RECENT_COMMITS_COUNT);
-	const contextFiles = await loadProjectContextFiles({ cwd });
+	const contextFiles = await loadProjectContextFiles({ cwd, settings });
 	const formattedContextFiles = contextFiles.map(file => ({
 		path: path.relative(cwd, file.path),
 		content: file.content,

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1150,15 +1150,16 @@ export const SETTINGS_SCHEMA = {
 			label: "Auto-Promote Context",
 			description: "Promote to a larger-context model on context overflow instead of compacting",
 		},
-		"contextFiles.resolveAtRefs": {
-			type: "boolean",
-			default: true,
-			ui: {
-				tab: "context",
-				label: "Resolve @-file References",
-				description:
-					"Resolve @file.ext references in context files (CLAUDE.md, AGENTS.md, etc.) by inlining the referenced file content",
-			},
+	},
+	// Context file @-ref resolution
+	"contextFiles.resolveAtRefs": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "context",
+			label: "Resolve @-file References",
+			description:
+				"Resolve @file.ext references in context files (CLAUDE.md, AGENTS.md, etc.) by inlining the referenced file content",
 		},
 	},
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1150,6 +1150,16 @@ export const SETTINGS_SCHEMA = {
 			label: "Auto-Promote Context",
 			description: "Promote to a larger-context model on context overflow instead of compacting",
 		},
+		"contextFiles.resolveAtRefs": {
+			type: "boolean",
+			default: true,
+			ui: {
+				tab: "context",
+				label: "Resolve @-file References",
+				description:
+					"Resolve @file.ext references in context files (CLAUDE.md, AGENTS.md, etc.) by inlining the referenced file content",
+			},
+		},
 	},
 
 	// Compaction
@@ -3302,6 +3312,9 @@ export interface CompactionSettings {
 export interface ContextPromotionSettings {
 	enabled: boolean;
 }
+export interface ContextFilesSettings {
+	resolveAtRefs: boolean;
+}
 export interface RetrySettings {
 	enabled: boolean;
 	maxRetries: number;
@@ -3424,6 +3437,7 @@ export interface ShellMinimizerSettings {
 export interface GroupTypeMap {
 	compaction: CompactionSettings;
 	contextPromotion: ContextPromotionSettings;
+	contextFiles: ContextFilesSettings;
 	retry: RetrySettings;
 	memories: MemoriesSettings;
 	branchSummary: BranchSummarySettings;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -579,9 +579,11 @@ export async function discoverSkills(
 export async function discoverContextFiles(
 	cwd?: string,
 	_agentDir?: string,
+	settings?: Pick<Settings, "get">,
 ): Promise<Array<{ path: string; content: string; depth?: number }>> {
 	return await loadContextFilesInternal({
 		cwd: cwd ?? getProjectDir(),
+		settings,
 	});
 }
 
@@ -635,6 +637,7 @@ export interface BuildSystemPromptOptions {
 	cwd?: string;
 	appendPrompt?: string;
 	repeatToolDescriptions?: boolean;
+	settings?: Pick<Settings, "get">;
 }
 
 /**
@@ -650,6 +653,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		contextFiles: options.contextFiles,
 		appendSystemPrompt: options.appendPrompt,
 		repeatToolDescriptions: options.repeatToolDescriptions,
+		settings: options.settings,
 	});
 }
 
@@ -955,7 +959,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	// session-context build, tool creation, MCP discovery, and extension discovery.
 	const contextFilesPromise = options.contextFiles
 		? Promise.resolve(options.contextFiles)
-		: logger.time("discoverContextFiles", discoverContextFiles, cwd, agentDir);
+		: logger.time("discoverContextFiles", discoverContextFiles, cwd, agentDir, settings);
 	contextFilesPromise.catch(() => {});
 	const promptTemplatesPromise = options.promptTemplates
 		? Promise.resolve(options.promptTemplates)
@@ -1789,6 +1793,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				workspaceTree: workspaceTreePromise,
 				memoryRootEnabled: memoryBackend.id === "local",
 				model: settings.get("includeModelInPrompt") ? getActiveModelString() : undefined,
+				settings,
 			});
 
 			if (options.systemPrompt === undefined) {

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -8,6 +8,7 @@ import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import { $env, getGpuCachePath, getProjectDir, hasFsCode, isEnoent, logger, prompt } from "@oh-my-pi/pi-utils";
 import { $ } from "bun";
 import { contextFileCapability } from "./capability/context-file";
+import { findRepoRoot } from "./capability/fs";
 import { resolveAtRefs } from "./capability/resolve-at-refs";
 import { systemPromptCapability } from "./capability/system-prompt";
 import { isSettingsInitialized, type Settings, type SkillsSettings, settings } from "./config/settings";
@@ -277,6 +278,7 @@ export async function loadProjectContextFiles(
 	options: LoadContextFilesOptions = {},
 ): Promise<Array<{ path: string; content: string; depth?: number }>> {
 	const resolvedCwd = options.cwd ?? getProjectDir();
+	const repoRoot = await findRepoRoot(resolvedCwd);
 
 	const result = await loadCapability(contextFileCapability.id, { cwd: resolvedCwd });
 
@@ -284,7 +286,9 @@ export async function loadProjectContextFiles(
 	const files = result.items.map(item => {
 		const contextFile = item as ContextFile;
 		const rootDir =
-			contextFile.level === "project" ? projectContextRootFromDepth(resolvedCwd, contextFile.depth) : undefined;
+			contextFile.level === "project"
+				? (repoRoot ?? projectContextRootFromDepth(resolvedCwd, contextFile.depth))
+				: undefined;
 		return {
 			path: contextFile.path,
 			content: contextFile.content,

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -10,7 +10,7 @@ import { contextFileCapability } from "./capability/context-file";
 import { resolveAtRefs } from "./capability/resolve-at-refs";
 import { systemPromptCapability } from "./capability/system-prompt";
 import type { SkillsSettings } from "./config/settings";
-import { settings } from "./config/settings";
+import { isSettingsInitialized, settings } from "./config/settings";
 import { type ContextFile, loadCapability, type SystemPrompt as SystemPromptFile } from "./discovery";
 import { loadSkills, type Skill } from "./extensibility/skills";
 import { hasObsidian } from "./internal-urls/vault-protocol";
@@ -230,7 +230,7 @@ export async function resolvePromptInput(input: string | undefined, description:
 export interface LoadContextFilesOptions {
 	/** Working directory to start walking up from. Default: getProjectDir() */
 	cwd?: string;
-	/** Whether to resolve @-file references in context file content. Default: true */
+	/** Whether to resolve @-file references in context file content. Default: contextFiles.resolveAtRefs setting, then true */
 	resolveAtRefs?: boolean;
 }
 
@@ -244,6 +244,12 @@ function dedupeExactContextFiles(
 	}
 
 	return contextFiles.filter((file, index) => lastIndexByContent.get(file.content) === index);
+}
+
+function shouldResolveContextAtRefs(option: boolean | undefined): boolean {
+	if (option !== undefined) return option;
+	if (!isSettingsInitialized()) return true;
+	return settings.get("contextFiles.resolveAtRefs") ?? true;
 }
 
 /**
@@ -275,7 +281,8 @@ export async function loadProjectContextFiles(
 		const depthB = b.depth ?? -1;
 		return depthB - depthA;
 	});
-	const resolved = options.resolveAtRefs !== false ? await resolveAtRefs(files) : files;
+	const shouldResolveAtRefs = shouldResolveContextAtRefs(options.resolveAtRefs);
+	const resolved = shouldResolveAtRefs ? await resolveAtRefs(files) : files;
 	return dedupeExactContextFiles(resolved);
 }
 
@@ -456,7 +463,6 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		? Promise.resolve(providedContextFiles)
 		: logger.time("loadProjectContextFiles", loadProjectContextFiles, {
 				cwd: resolvedCwd,
-				resolveAtRefs: settings.get("contextFiles.resolveAtRefs") ?? true,
 			});
 	const workspaceTreePromise =
 		providedWorkspaceTree !== undefined

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -10,6 +10,7 @@ import { contextFileCapability } from "./capability/context-file";
 import { resolveAtRefs } from "./capability/resolve-at-refs";
 import { systemPromptCapability } from "./capability/system-prompt";
 import type { SkillsSettings } from "./config/settings";
+import { settings } from "./config/settings";
 import { type ContextFile, loadCapability, type SystemPrompt as SystemPromptFile } from "./discovery";
 import { loadSkills, type Skill } from "./extensibility/skills";
 import { hasObsidian } from "./internal-urls/vault-protocol";
@@ -453,7 +454,10 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 	});
 	const contextFilesPromise = providedContextFiles
 		? Promise.resolve(providedContextFiles)
-		: logger.time("loadProjectContextFiles", loadProjectContextFiles, { cwd: resolvedCwd });
+		: logger.time("loadProjectContextFiles", loadProjectContextFiles, {
+				cwd: resolvedCwd,
+				resolveAtRefs: settings.get("contextFiles.resolveAtRefs") ?? true,
+			});
 	const workspaceTreePromise =
 		providedWorkspaceTree !== undefined
 			? Promise.resolve(providedWorkspaceTree)

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -229,6 +229,8 @@ export async function resolvePromptInput(input: string | undefined, description:
 export interface LoadContextFilesOptions {
 	/** Working directory to start walking up from. Default: getProjectDir() */
 	cwd?: string;
+	/** Whether to resolve @-file references in context file content. Default: true */
+	resolveAtRefs?: boolean;
 }
 
 function dedupeExactContextFiles(
@@ -272,7 +274,8 @@ export async function loadProjectContextFiles(
 		const depthB = b.depth ?? -1;
 		return depthB - depthA;
 	});
-	return resolveAtRefs(dedupeExactContextFiles(files));
+	const resolved = options.resolveAtRefs !== false ? await resolveAtRefs(files) : files;
+	return dedupeExactContextFiles(resolved);
 }
 
 /**

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -7,6 +7,7 @@ import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import { $env, getGpuCachePath, getProjectDir, hasFsCode, isEnoent, logger, prompt } from "@oh-my-pi/pi-utils";
 import { $ } from "bun";
 import { contextFileCapability } from "./capability/context-file";
+import { resolveAtRefs } from "./capability/resolve-at-refs";
 import { systemPromptCapability } from "./capability/system-prompt";
 import type { SkillsSettings } from "./config/settings";
 import { type ContextFile, loadCapability, type SystemPrompt as SystemPromptFile } from "./discovery";
@@ -271,8 +272,7 @@ export async function loadProjectContextFiles(
 		const depthB = b.depth ?? -1;
 		return depthB - depthA;
 	});
-
-	return dedupeExactContextFiles(files);
+	return resolveAtRefs(dedupeExactContextFiles(files));
 }
 
 /**

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -3,6 +3,7 @@
  */
 
 import * as os from "node:os";
+import * as path from "node:path";
 import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 import { $env, getGpuCachePath, getProjectDir, hasFsCode, isEnoent, logger, prompt } from "@oh-my-pi/pi-utils";
 import { $ } from "bun";
@@ -257,6 +258,16 @@ function shouldResolveContextAtRefs(
 	return settings.get("contextFiles.resolveAtRefs") ?? true;
 }
 
+function projectContextRootFromDepth(cwd: string, depth: number | undefined): string {
+	let root = path.resolve(cwd);
+	for (let remaining = Math.max(0, depth ?? 0); remaining > 0; remaining--) {
+		const parent = path.dirname(root);
+		if (parent === root) break;
+		root = parent;
+	}
+	return root;
+}
+
 /**
  * Load all project context files using the capability API.
  * Returns {path, content, depth} entries for all discovered context files.
@@ -272,10 +283,13 @@ export async function loadProjectContextFiles(
 	// Convert ContextFile items and preserve depth info
 	const files = result.items.map(item => {
 		const contextFile = item as ContextFile;
+		const rootDir =
+			contextFile.level === "project" ? projectContextRootFromDepth(resolvedCwd, contextFile.depth) : undefined;
 		return {
 			path: contextFile.path,
 			content: contextFile.content,
 			depth: contextFile.depth,
+			rootDir,
 		};
 	});
 
@@ -287,7 +301,9 @@ export async function loadProjectContextFiles(
 		return depthB - depthA;
 	});
 	const shouldResolveAtRefs = shouldResolveContextAtRefs(options.resolveAtRefs, options.settings);
-	const resolved = shouldResolveAtRefs ? await resolveAtRefs(files) : files;
+	const resolved = shouldResolveAtRefs
+		? await resolveAtRefs(files)
+		: files.map(({ rootDir: _rootDir, ...file }) => file);
 	return dedupeExactContextFiles(resolved);
 }
 

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -9,8 +9,7 @@ import { $ } from "bun";
 import { contextFileCapability } from "./capability/context-file";
 import { resolveAtRefs } from "./capability/resolve-at-refs";
 import { systemPromptCapability } from "./capability/system-prompt";
-import type { SkillsSettings } from "./config/settings";
-import { isSettingsInitialized, settings } from "./config/settings";
+import { isSettingsInitialized, type Settings, type SkillsSettings, settings } from "./config/settings";
 import { type ContextFile, loadCapability, type SystemPrompt as SystemPromptFile } from "./discovery";
 import { loadSkills, type Skill } from "./extensibility/skills";
 import { hasObsidian } from "./internal-urls/vault-protocol";
@@ -230,8 +229,10 @@ export async function resolvePromptInput(input: string | undefined, description:
 export interface LoadContextFilesOptions {
 	/** Working directory to start walking up from. Default: getProjectDir() */
 	cwd?: string;
-	/** Whether to resolve @-file references in context file content. Default: contextFiles.resolveAtRefs setting, then true */
+	/** Whether to resolve @-file references in context file content. Default: settings, then true. */
 	resolveAtRefs?: boolean;
+	/** Active settings instance. Used by SDK/embedder sessions with isolated settings. */
+	settings?: Pick<Settings, "get">;
 }
 
 function dedupeExactContextFiles(
@@ -246,8 +247,12 @@ function dedupeExactContextFiles(
 	return contextFiles.filter((file, index) => lastIndexByContent.get(file.content) === index);
 }
 
-function shouldResolveContextAtRefs(option: boolean | undefined): boolean {
+function shouldResolveContextAtRefs(
+	option: boolean | undefined,
+	activeSettings: Pick<Settings, "get"> | undefined,
+): boolean {
 	if (option !== undefined) return option;
+	if (activeSettings) return activeSettings.get("contextFiles.resolveAtRefs") ?? true;
 	if (!isSettingsInitialized()) return true;
 	return settings.get("contextFiles.resolveAtRefs") ?? true;
 }
@@ -281,7 +286,7 @@ export async function loadProjectContextFiles(
 		const depthB = b.depth ?? -1;
 		return depthB - depthA;
 	});
-	const shouldResolveAtRefs = shouldResolveContextAtRefs(options.resolveAtRefs);
+	const shouldResolveAtRefs = shouldResolveContextAtRefs(options.resolveAtRefs, options.settings);
 	const resolved = shouldResolveAtRefs ? await resolveAtRefs(files) : files;
 	return dedupeExactContextFiles(resolved);
 }
@@ -376,6 +381,8 @@ export interface BuildSystemPromptOptions {
 	memoryRootEnabled?: boolean;
 	/** Active model identifier (e.g. "anthropic/claude-opus-4") surfaced to the agent. */
 	model?: string;
+	/** Active settings instance. Used when loading context files without preloaded context. */
+	settings?: Pick<Settings, "get">;
 }
 
 /** Result of building provider-facing system prompt messages. */
@@ -410,6 +417,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		workspaceTree: providedWorkspaceTree,
 		memoryRootEnabled = false,
 		model,
+		settings: activeSettings,
 	} = options;
 	const resolvedCwd = cwd ?? getProjectDir();
 
@@ -463,6 +471,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		? Promise.resolve(providedContextFiles)
 		: logger.time("loadProjectContextFiles", loadProjectContextFiles, {
 				cwd: resolvedCwd,
+				settings: activeSettings,
 			});
 	const workspaceTreePromise =
 		providedWorkspaceTree !== undefined

--- a/packages/coding-agent/test/resolve-at-refs.test.ts
+++ b/packages/coding-agent/test/resolve-at-refs.test.ts
@@ -247,6 +247,21 @@ describe("resolveAtRefs", () => {
 		expect(result[0].content).not.toContain("file not found");
 	});
 
+	it("resolves refs in symlinked context files from the target directory", async () => {
+		const docsDir = path.join(tempDir, "docs");
+		fs.mkdirSync(docsDir, { recursive: true });
+		fs.writeFileSync(path.join(tempDir, "rules.md"), "wrong root rules\n");
+		fs.writeFileSync(path.join(docsDir, "AGENTS.md"), "@rules.md");
+		fs.writeFileSync(path.join(docsDir, "rules.md"), "target directory rules\n");
+		const agentsMdPath = path.join(tempDir, "AGENTS.md");
+		fs.symlinkSync(path.join(docsDir, "AGENTS.md"), agentsMdPath);
+
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: "@rules.md" }], { rootDir: tempDir });
+
+		expect(result[0].content).toContain("target directory rules");
+		expect(result[0].content).not.toContain("wrong root rules");
+	});
+
 	it("rejects gitignored refs", async () => {
 		fs.writeFileSync(path.join(tempDir, ".gitignore"), "secret.env\n");
 		fs.writeFileSync(path.join(tempDir, "secret.env"), "SECRET_TOKEN=value\n");

--- a/packages/coding-agent/test/resolve-at-refs.test.ts
+++ b/packages/coding-agent/test/resolve-at-refs.test.ts
@@ -65,7 +65,9 @@ describe("resolveAtRefs", () => {
 	it("rejects absolute path @-references", async () => {
 		const agentsMd = `@/etc/hosts.conf`;
 		const agentsMdPath = path.join(tempDir, "AGENTS.md");
+
 		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }], { rootDir: tempDir });
+
 		expect(result[0].content).toContain("absolute paths are not allowed");
 	});
 
@@ -174,7 +176,6 @@ describe("resolveAtRefs", () => {
 
 		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }], { rootDir: tempDir });
 
-		// Inline @-ref is NOT matched by our pattern (must be alone on the line)
 		expect(result[0].content).toBe(agentsMd);
 	});
 
@@ -194,5 +195,41 @@ describe("resolveAtRefs", () => {
 		});
 
 		expect(result[0].depth).toBe(2);
+	});
+
+	it("rejects symlinks that escape the project root", async () => {
+		const outsideDir = path.join(os.tmpdir(), "pi-atrefs-outside");
+		fs.mkdirSync(outsideDir, { recursive: true });
+		fs.writeFileSync(path.join(outsideDir, "secret.txt"), "secret data\n");
+
+		// Create a symlink inside the project that points outside the root
+		const linkPath = path.join(tempDir, "link.txt");
+		fs.symlinkSync(path.join(outsideDir, "secret.txt"), linkPath);
+
+		const agentsMd = `@link.txt`;
+		const agentsMdPath = path.join(tempDir, "AGENTS.md");
+
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }], { rootDir: tempDir });
+
+		expect(result[0].content).toContain("escapes project root");
+
+		// Cleanup
+		fs.unlinkSync(path.join(outsideDir, "secret.txt"));
+		fs.rmdirSync(outsideDir);
+	});
+
+	it("allows symlinks that stay within the project root", async () => {
+		fs.writeFileSync(path.join(tempDir, "real.txt"), "real content\n");
+
+		// Create a symlink inside the project that points to another file in the project
+		const linkPath = path.join(tempDir, "link.txt");
+		fs.symlinkSync(path.join(tempDir, "real.txt"), linkPath);
+
+		const agentsMd = `@link.txt`;
+		const agentsMdPath = path.join(tempDir, "AGENTS.md");
+
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }], { rootDir: tempDir });
+
+		expect(result[0].content).toContain("real content");
 	});
 });

--- a/packages/coding-agent/test/resolve-at-refs.test.ts
+++ b/packages/coding-agent/test/resolve-at-refs.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { resolveAtRefs } from "@oh-my-pi/pi-coding-agent/capability/resolve-at-refs";
+import { cleanupTempHome } from "./helpers/temp-home-cleanup";
+
+describe("resolveAtRefs", () => {
+	let tempDir = "";
+	let tempHomeDir = "";
+	let originalHome: string | undefined;
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-atrefs-"));
+		tempHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-home-"));
+		originalHome = process.env.HOME;
+		process.env.HOME = tempHomeDir;
+	});
+
+	afterEach(cleanupTempHome(() => ({ tempDir, tempHomeDir, originalHome })));
+
+	it("replaces a simple @-reference with file content", async () => {
+		const pkgJson = { name: "my-project", version: "1.0.0" };
+		fs.writeFileSync(path.join(tempDir, "package.json"), JSON.stringify(pkgJson, null, 2));
+
+		const agentsMd = `# Project\n\nSee package details:\n@package.json\n\nEnd.`;
+		const agentsMdPath = path.join(tempDir, "AGENTS.md");
+
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }]);
+
+		expect(result[0].content).toContain('"name": "my-project"');
+		expect(result[0].content).toContain('"version": "1.0.0"');
+		expect(result[0].content).not.toContain("@package.json");
+	});
+
+	it("resolves references relative to the context file's directory", async () => {
+		const subDir = path.join(tempDir, "subdir");
+		fs.mkdirSync(subDir, { recursive: true });
+		fs.writeFileSync(path.join(subDir, "config.yaml"), "key: value\n");
+
+		const agentsMd = `Settings:\n@config.yaml`;
+		const agentsMdPath = path.join(subDir, "AGENTS.md");
+
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }]);
+
+		expect(result[0].content).toContain("key: value");
+		expect(result[0].content).not.toContain("@config.yaml");
+	});
+
+	it("handles parent directory references with ../", async () => {
+		const subDir = path.join(tempDir, "deep");
+		fs.mkdirSync(subDir, { recursive: true });
+		fs.writeFileSync(path.join(tempDir, "root.conf"), "root: true\n");
+
+		const agentsMd = `Root config:\n@../root.conf`;
+		const agentsMdPath = path.join(subDir, "AGENTS.md");
+
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }]);
+
+		expect(result[0].content).toContain("root: true");
+	});
+
+	it("leaves non-matching lines untouched", async () => {
+		const agentsMd = `# Header\n\nSome text with @username in a sentence.\nNot a ref: email@example.com\n\nParagraph about things.`;
+		const agentsMdPath = path.join(tempDir, "AGENTS.md");
+
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }]);
+
+		expect(result[0].content).toBe(agentsMd);
+	});
+
+	it("produces comment placeholder for missing files", async () => {
+		const agentsMd = `@nonexistent.file.txt`;
+		const agentsMdPath = path.join(tempDir, "AGENTS.md");
+
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }]);
+
+		expect(result[0].content).toContain("<!-- @nonexistent.file.txt: file not found -->");
+	});
+
+	it("detects and skips circular references", async () => {
+		const circularDir = path.join(tempDir, "circular");
+		fs.mkdirSync(circularDir, { recursive: true });
+
+		const aPath = path.join(circularDir, "a.md");
+		const bPath = path.join(circularDir, "b.md");
+
+		fs.writeFileSync(aPath, `A start\n@b.md\nA end`);
+		fs.writeFileSync(bPath, `B start\n@a.md\nB end`);
+
+		const result = await resolveAtRefs([{ path: aPath, content: fs.readFileSync(aPath, "utf-8") }]);
+
+		expect(result[0].content).toContain("A start");
+		expect(result[0].content).toContain("B start");
+		expect(result[0].content).toContain("circular reference skipped");
+	});
+
+	it("respects maxDepth limit", async () => {
+		const deepDir = path.join(tempDir, "deep");
+		fs.mkdirSync(deepDir, { recursive: true });
+
+		for (let i = 0; i <= 5; i++) {
+			const next = i < 5 ? `@chain${i + 1}.txt` : "final content";
+			fs.writeFileSync(path.join(deepDir, `chain${i}.txt`), `depth ${i}\n${next}`);
+		}
+
+		const chain0Path = path.join(deepDir, "chain0.txt");
+
+		// With maxDepth=3, should stop at chain3
+		const result = await resolveAtRefs([{ path: chain0Path, content: fs.readFileSync(chain0Path, "utf-8") }], {
+			maxDepth: 3,
+		});
+
+		expect(result[0].content).toContain("depth 0");
+		expect(result[0].content).toContain("depth 2");
+		// chain3.txt content is still resolved (the reference to it is within depth 3)
+		expect(result[0].content).toContain("@chain4.txt");
+	});
+
+	it("handles multiple @-references in the same file", async () => {
+		fs.writeFileSync(path.join(tempDir, "alpha.txt"), "alpha content\n");
+		fs.writeFileSync(path.join(tempDir, "beta.txt"), "beta content\n");
+
+		const agentsMd = `Header\n@alpha.txt\nBetween\n@beta.txt\nFooter`;
+		const agentsMdPath = path.join(tempDir, "AGENTS.md");
+
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }]);
+
+		expect(result[0].content).toContain("alpha content");
+		expect(result[0].content).toContain("beta content");
+		expect(result[0].content).toContain("Header");
+		expect(result[0].content).toContain("Footer");
+		expect(result[0].content).toContain("Between");
+	});
+
+	it("does not match @-references without a file extension", async () => {
+		fs.writeFileSync(path.join(tempDir, "has.txt"), "file content\n");
+		const agentsMd = `@noext\n@has.txt`;
+		const agentsMdPath = path.join(tempDir, "AGENTS.md");
+
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }]);
+
+		// @noext should be left as-is (no dot extension)
+		expect(result[0].content).toContain("@noext");
+		// @has.txt should be resolved
+		expect(result[0].content).toContain("file content");
+	});
+
+	it("does not match @-references with leading text on the same line", async () => {
+		const agentsMd = `See @package.json for details.`;
+		const agentsMdPath = path.join(tempDir, "AGENTS.md");
+
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }]);
+
+		// Inline @-ref is NOT matched by our pattern (must be alone on the line)
+		expect(result[0].content).toBe(agentsMd);
+	});
+
+	it("handles @-references with trailing whitespace", async () => {
+		fs.writeFileSync(path.join(tempDir, "trail.txt"), "trailed\n");
+		const agentsMd = `@trail.txt   `;
+		const agentsMdPath = path.join(tempDir, "AGENTS.md");
+
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }]);
+
+		expect(result[0].content).toContain("trailed");
+	});
+
+	it("preserves depth field in returned objects", async () => {
+		const result = await resolveAtRefs([{ path: "/some/path/AGENTS.md", content: "no refs", depth: 2 }]);
+
+		expect(result[0].depth).toBe(2);
+	});
+});

--- a/packages/coding-agent/test/resolve-at-refs.test.ts
+++ b/packages/coding-agent/test/resolve-at-refs.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { resolveAtRefs } from "@oh-my-pi/pi-coding-agent/capability/resolve-at-refs";
+import { $ } from "bun";
 import { cleanupTempHome } from "./helpers/temp-home-cleanup";
 
 describe("resolveAtRefs", () => {
@@ -285,6 +286,36 @@ describe("resolveAtRefs", () => {
 
 		expect(result[0].content).toContain("ignored by gitignore");
 		expect(result[0].content).not.toContain("SECRET_TOKEN");
+	});
+
+	it("rejects non-gitignored untracked refs in real git worktrees", async () => {
+		fs.rmSync(path.join(tempDir, ".git"), { force: true, recursive: true });
+		fs.writeFileSync(path.join(tempDir, "AGENTS.md"), "@local.settings.json");
+		fs.writeFileSync(path.join(tempDir, "local.settings.json"), '{"token":"SECRET"}\n');
+		await $`git init`.cwd(tempDir).quiet();
+		await $`git add AGENTS.md`.cwd(tempDir).quiet();
+
+		const result = await resolveAtRefs([
+			{ path: path.join(tempDir, "AGENTS.md"), content: fs.readFileSync(path.join(tempDir, "AGENTS.md"), "utf8") },
+		]);
+
+		expect(result[0].content).toContain("not tracked by git");
+		expect(result[0].content).not.toContain("SECRET");
+	});
+
+	it("allows tracked refs in real git worktrees", async () => {
+		fs.rmSync(path.join(tempDir, ".git"), { force: true, recursive: true });
+		fs.writeFileSync(path.join(tempDir, "AGENTS.md"), "@settings.json");
+		fs.writeFileSync(path.join(tempDir, "settings.json"), '{"name":"tracked-settings"}\n');
+		await $`git init`.cwd(tempDir).quiet();
+		await $`git add AGENTS.md settings.json`.cwd(tempDir).quiet();
+
+		const result = await resolveAtRefs([
+			{ path: path.join(tempDir, "AGENTS.md"), content: fs.readFileSync(path.join(tempDir, "AGENTS.md"), "utf8") },
+		]);
+
+		expect(result[0].content).toContain("tracked-settings");
+		expect(result[0].content).not.toContain("not tracked by git");
 	});
 
 	it("uses an independent containment root for each context file", async () => {

--- a/packages/coding-agent/test/resolve-at-refs.test.ts
+++ b/packages/coding-agent/test/resolve-at-refs.test.ts
@@ -232,4 +232,18 @@ describe("resolveAtRefs", () => {
 
 		expect(result[0].content).toContain("real content");
 	});
+
+	it("uses an independent containment root for each context file", async () => {
+		fs.mkdirSync(path.join(tempHomeDir, ".git"), { recursive: true });
+		fs.writeFileSync(path.join(tempDir, "rules.md"), "project rules\n");
+		fs.writeFileSync(path.join(tempHomeDir, "rules.md"), "user rules\n");
+
+		const result = await resolveAtRefs([
+			{ path: path.join(tempDir, "AGENTS.md"), content: "@rules.md", depth: 1 },
+			{ path: path.join(tempHomeDir, "AGENTS.md"), content: "@rules.md" },
+		]);
+
+		expect(result[0].content).toContain("project rules");
+		expect(result[1].content).toContain("user rules");
+	});
 });

--- a/packages/coding-agent/test/resolve-at-refs.test.ts
+++ b/packages/coding-agent/test/resolve-at-refs.test.ts
@@ -233,6 +233,45 @@ describe("resolveAtRefs", () => {
 		expect(result[0].content).toContain("real content");
 	});
 
+	it("resolves nested refs from symlink target directories", async () => {
+		const docsDir = path.join(tempDir, "docs");
+		fs.mkdirSync(docsDir, { recursive: true });
+		fs.writeFileSync(path.join(docsDir, "rules.md"), "@more.md");
+		fs.writeFileSync(path.join(docsDir, "more.md"), "nested symlink content\n");
+		fs.symlinkSync(path.join(docsDir, "rules.md"), path.join(tempDir, "link.md"));
+
+		const agentsMdPath = path.join(tempDir, "AGENTS.md");
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: "@link.md" }], { rootDir: tempDir });
+
+		expect(result[0].content).toContain("nested symlink content");
+		expect(result[0].content).not.toContain("file not found");
+	});
+
+	it("rejects gitignored refs", async () => {
+		fs.writeFileSync(path.join(tempDir, ".gitignore"), "secret.env\n");
+		fs.writeFileSync(path.join(tempDir, "secret.env"), "SECRET_TOKEN=value\n");
+
+		const agentsMdPath = path.join(tempDir, "AGENTS.md");
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: "@secret.env" }], { rootDir: tempDir });
+
+		expect(result[0].content).toContain("ignored by gitignore");
+		expect(result[0].content).not.toContain("SECRET_TOKEN");
+	});
+
+	it("rejects symlink refs whose targets are gitignored", async () => {
+		const docsDir = path.join(tempDir, "docs");
+		fs.mkdirSync(docsDir, { recursive: true });
+		fs.writeFileSync(path.join(tempDir, ".gitignore"), "docs/secret.env\n");
+		fs.writeFileSync(path.join(docsDir, "secret.env"), "SECRET_TOKEN=value\n");
+		fs.symlinkSync(path.join(docsDir, "secret.env"), path.join(tempDir, "link.env"));
+
+		const agentsMdPath = path.join(tempDir, "AGENTS.md");
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: "@link.env" }], { rootDir: tempDir });
+
+		expect(result[0].content).toContain("ignored by gitignore");
+		expect(result[0].content).not.toContain("SECRET_TOKEN");
+	});
+
 	it("uses an independent containment root for each context file", async () => {
 		fs.mkdirSync(path.join(tempHomeDir, ".git"), { recursive: true });
 		fs.writeFileSync(path.join(tempDir, "rules.md"), "project rules\n");

--- a/packages/coding-agent/test/resolve-at-refs.test.ts
+++ b/packages/coding-agent/test/resolve-at-refs.test.ts
@@ -15,6 +15,8 @@ describe("resolveAtRefs", () => {
 		tempHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-home-"));
 		originalHome = process.env.HOME;
 		process.env.HOME = tempHomeDir;
+		// Initialize a .git directory so findRepoRoot can discover the project root
+		fs.mkdirSync(path.join(tempDir, ".git"), { recursive: true });
 	});
 
 	afterEach(cleanupTempHome(() => ({ tempDir, tempHomeDir, originalHome })));
@@ -26,7 +28,7 @@ describe("resolveAtRefs", () => {
 		const agentsMd = `# Project\n\nSee package details:\n@package.json\n\nEnd.`;
 		const agentsMdPath = path.join(tempDir, "AGENTS.md");
 
-		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }]);
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }], { rootDir: tempDir });
 
 		expect(result[0].content).toContain('"name": "my-project"');
 		expect(result[0].content).toContain('"version": "1.0.0"');
@@ -41,13 +43,13 @@ describe("resolveAtRefs", () => {
 		const agentsMd = `Settings:\n@config.yaml`;
 		const agentsMdPath = path.join(subDir, "AGENTS.md");
 
-		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }]);
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }], { rootDir: tempDir });
 
 		expect(result[0].content).toContain("key: value");
 		expect(result[0].content).not.toContain("@config.yaml");
 	});
 
-	it("handles parent directory references with ../", async () => {
+	it("handles parent directory references with ../ within root", async () => {
 		const subDir = path.join(tempDir, "deep");
 		fs.mkdirSync(subDir, { recursive: true });
 		fs.writeFileSync(path.join(tempDir, "root.conf"), "root: true\n");
@@ -55,16 +57,34 @@ describe("resolveAtRefs", () => {
 		const agentsMd = `Root config:\n@../root.conf`;
 		const agentsMdPath = path.join(subDir, "AGENTS.md");
 
-		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }]);
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }], { rootDir: tempDir });
 
 		expect(result[0].content).toContain("root: true");
+	});
+
+	it("rejects absolute path @-references", async () => {
+		const agentsMd = `@/etc/hosts.conf`;
+		const agentsMdPath = path.join(tempDir, "AGENTS.md");
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }], { rootDir: tempDir });
+		expect(result[0].content).toContain("absolute paths are not allowed");
+	});
+
+	it("rejects references that traverse above the root", async () => {
+		fs.writeFileSync(path.join(tempDir, "..", "escape.txt"), "escaped\n");
+
+		const agentsMd = `@../escape.txt`;
+		const agentsMdPath = path.join(tempDir, "AGENTS.md");
+
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }], { rootDir: tempDir });
+
+		expect(result[0].content).toContain("escapes project root");
 	});
 
 	it("leaves non-matching lines untouched", async () => {
 		const agentsMd = `# Header\n\nSome text with @username in a sentence.\nNot a ref: email@example.com\n\nParagraph about things.`;
 		const agentsMdPath = path.join(tempDir, "AGENTS.md");
 
-		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }]);
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }], { rootDir: tempDir });
 
 		expect(result[0].content).toBe(agentsMd);
 	});
@@ -73,7 +93,7 @@ describe("resolveAtRefs", () => {
 		const agentsMd = `@nonexistent.file.txt`;
 		const agentsMdPath = path.join(tempDir, "AGENTS.md");
 
-		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }]);
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }], { rootDir: tempDir });
 
 		expect(result[0].content).toContain("<!-- @nonexistent.file.txt: file not found -->");
 	});
@@ -88,7 +108,9 @@ describe("resolveAtRefs", () => {
 		fs.writeFileSync(aPath, `A start\n@b.md\nA end`);
 		fs.writeFileSync(bPath, `B start\n@a.md\nB end`);
 
-		const result = await resolveAtRefs([{ path: aPath, content: fs.readFileSync(aPath, "utf-8") }]);
+		const result = await resolveAtRefs([{ path: aPath, content: fs.readFileSync(aPath, "utf-8") }], {
+			rootDir: tempDir,
+		});
 
 		expect(result[0].content).toContain("A start");
 		expect(result[0].content).toContain("B start");
@@ -106,14 +128,14 @@ describe("resolveAtRefs", () => {
 
 		const chain0Path = path.join(deepDir, "chain0.txt");
 
-		// With maxDepth=3, should stop at chain3
+		// With maxDepth=3, chain3.txt content is still resolved but it contains @chain4.txt
 		const result = await resolveAtRefs([{ path: chain0Path, content: fs.readFileSync(chain0Path, "utf-8") }], {
 			maxDepth: 3,
+			rootDir: tempDir,
 		});
 
 		expect(result[0].content).toContain("depth 0");
 		expect(result[0].content).toContain("depth 2");
-		// chain3.txt content is still resolved (the reference to it is within depth 3)
 		expect(result[0].content).toContain("@chain4.txt");
 	});
 
@@ -124,7 +146,7 @@ describe("resolveAtRefs", () => {
 		const agentsMd = `Header\n@alpha.txt\nBetween\n@beta.txt\nFooter`;
 		const agentsMdPath = path.join(tempDir, "AGENTS.md");
 
-		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }]);
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }], { rootDir: tempDir });
 
 		expect(result[0].content).toContain("alpha content");
 		expect(result[0].content).toContain("beta content");
@@ -138,7 +160,7 @@ describe("resolveAtRefs", () => {
 		const agentsMd = `@noext\n@has.txt`;
 		const agentsMdPath = path.join(tempDir, "AGENTS.md");
 
-		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }]);
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }], { rootDir: tempDir });
 
 		// @noext should be left as-is (no dot extension)
 		expect(result[0].content).toContain("@noext");
@@ -150,7 +172,7 @@ describe("resolveAtRefs", () => {
 		const agentsMd = `See @package.json for details.`;
 		const agentsMdPath = path.join(tempDir, "AGENTS.md");
 
-		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }]);
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }], { rootDir: tempDir });
 
 		// Inline @-ref is NOT matched by our pattern (must be alone on the line)
 		expect(result[0].content).toBe(agentsMd);
@@ -161,13 +183,15 @@ describe("resolveAtRefs", () => {
 		const agentsMd = `@trail.txt   `;
 		const agentsMdPath = path.join(tempDir, "AGENTS.md");
 
-		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }]);
+		const result = await resolveAtRefs([{ path: agentsMdPath, content: agentsMd }], { rootDir: tempDir });
 
 		expect(result[0].content).toContain("trailed");
 	});
 
 	it("preserves depth field in returned objects", async () => {
-		const result = await resolveAtRefs([{ path: "/some/path/AGENTS.md", content: "no refs", depth: 2 }]);
+		const result = await resolveAtRefs([{ path: "/some/path/AGENTS.md", content: "no refs", depth: 2 }], {
+			rootDir: "/some",
+		});
 
 		expect(result[0].depth).toBe(2);
 	});

--- a/packages/coding-agent/test/resolve-at-refs.test.ts
+++ b/packages/coding-agent/test/resolve-at-refs.test.ts
@@ -318,6 +318,24 @@ describe("resolveAtRefs", () => {
 		expect(result[0].content).not.toContain("not tracked by git");
 	});
 
+	it("allows tracked refs that match gitignore patterns", async () => {
+		fs.rmSync(path.join(tempDir, ".git"), { force: true, recursive: true });
+		fs.mkdirSync(path.join(tempDir, "docs"), { recursive: true });
+		fs.writeFileSync(path.join(tempDir, ".gitignore"), "*.local.md\n");
+		fs.writeFileSync(path.join(tempDir, "AGENTS.md"), "@docs/rules.local.md");
+		fs.writeFileSync(path.join(tempDir, "docs", "rules.local.md"), "tracked local rules\n");
+		await $`git init`.cwd(tempDir).quiet();
+		await $`git add AGENTS.md .gitignore`.cwd(tempDir).quiet();
+		await $`git add -f docs/rules.local.md`.cwd(tempDir).quiet();
+
+		const result = await resolveAtRefs([
+			{ path: path.join(tempDir, "AGENTS.md"), content: fs.readFileSync(path.join(tempDir, "AGENTS.md"), "utf8") },
+		]);
+
+		expect(result[0].content).toContain("tracked local rules");
+		expect(result[0].content).not.toContain("ignored by gitignore");
+	});
+
 	it("uses an independent containment root for each context file", async () => {
 		fs.mkdirSync(path.join(tempHomeDir, ".git"), { recursive: true });
 		fs.writeFileSync(path.join(tempDir, "rules.md"), "project rules\n");

--- a/packages/coding-agent/test/resolve-at-refs.test.ts
+++ b/packages/coding-agent/test/resolve-at-refs.test.ts
@@ -297,4 +297,18 @@ describe("resolveAtRefs", () => {
 
 		expect(result[0].content).toContain("rules through symlink root");
 	});
+
+	it("resolves nested refs when the containment root itself is a symlink", async () => {
+		fs.writeFileSync(path.join(tempDir, "rules.md"), "@more.md");
+		fs.writeFileSync(path.join(tempDir, "more.md"), "nested rules through symlink root\n");
+		const linkRoot = path.join(tempHomeDir, "repo-link");
+		fs.symlinkSync(tempDir, linkRoot, "dir");
+
+		const result = await resolveAtRefs([{ path: path.join(linkRoot, "AGENTS.md"), content: "@rules.md" }], {
+			rootDir: linkRoot,
+		});
+
+		expect(result[0].content).toContain("nested rules through symlink root");
+		expect(result[0].content).not.toContain("escapes project root");
+	});
 });

--- a/packages/coding-agent/test/resolve-at-refs.test.ts
+++ b/packages/coding-agent/test/resolve-at-refs.test.ts
@@ -246,4 +246,16 @@ describe("resolveAtRefs", () => {
 		expect(result[0].content).toContain("project rules");
 		expect(result[1].content).toContain("user rules");
 	});
+
+	it("allows refs when the containment root itself is a symlink", async () => {
+		fs.writeFileSync(path.join(tempDir, "rules.md"), "rules through symlink root\n");
+		const linkRoot = path.join(tempHomeDir, "repo-link");
+		fs.symlinkSync(tempDir, linkRoot, "dir");
+
+		const result = await resolveAtRefs([{ path: path.join(linkRoot, "AGENTS.md"), content: "@rules.md" }], {
+			rootDir: linkRoot,
+		});
+
+		expect(result[0].content).toContain("rules through symlink root");
+	});
 });

--- a/packages/coding-agent/test/system-prompt-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-dedup.test.ts
@@ -148,6 +148,19 @@ describe("SYSTEM.md prompt assembly", () => {
 
 		expect(agentsFile?.content).toBe("@rules.md");
 	});
+
+	it("uses the session cwd as the no-repo project context root", async () => {
+		const projectDir = path.join(tempDir, "no-repo");
+		fs.mkdirSync(path.join(projectDir, ".omp"), { recursive: true });
+		fs.writeFileSync(path.join(projectDir, "package.json"), JSON.stringify({ name: "no-repo-project" }));
+		fs.writeFileSync(path.join(projectDir, ".omp", "AGENTS.md"), "@../package.json");
+
+		const contextFiles = await loadProjectContextFiles({ cwd: projectDir });
+		const agentsFile = contextFiles.find(file => file.path === path.join(projectDir, ".omp", "AGENTS.md"));
+
+		expect(agentsFile?.content).toContain("no-repo-project");
+		expect(agentsFile?.content).not.toContain("escapes project root");
+	});
 	it("keeps distinct context entries when their contents differ", async () => {
 		const farPath = path.join(tempDir, "far", "AGENTS.md");
 		const nearPath = path.join(tempDir, "near", "CLAUDE.md");

--- a/packages/coding-agent/test/system-prompt-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-dedup.test.ts
@@ -128,6 +128,26 @@ describe("SYSTEM.md prompt assembly", () => {
 
 		expect(agentsFile?.content).toBe("@rules.md");
 	});
+
+	it("prefers provided settings when loading discovered context entries", async () => {
+		const projectDir = path.join(tempDir, "project");
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.writeFileSync(path.join(projectDir, "AGENTS.md"), "@rules.md");
+		fs.writeFileSync(path.join(projectDir, "rules.md"), "expanded rules");
+
+		resetSettingsForTest();
+		await Settings.init({
+			inMemory: true,
+			cwd: projectDir,
+			overrides: { "contextFiles.resolveAtRefs": true },
+		});
+		const isolatedSettings = Settings.isolated({ "contextFiles.resolveAtRefs": false });
+
+		const contextFiles = await loadProjectContextFiles({ cwd: projectDir, settings: isolatedSettings });
+		const agentsFile = contextFiles.find(file => file.path === path.join(projectDir, "AGENTS.md"));
+
+		expect(agentsFile?.content).toBe("@rules.md");
+	});
 	it("keeps distinct context entries when their contents differ", async () => {
 		const farPath = path.join(tempDir, "far", "AGENTS.md");
 		const nearPath = path.join(tempDir, "near", "CLAUDE.md");

--- a/packages/coding-agent/test/system-prompt-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-dedup.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import {
 	buildSystemPrompt,
 	loadProjectContextFiles,
@@ -25,7 +26,12 @@ describe("SYSTEM.md prompt assembly", () => {
 		process.env.HOME = tempHomeDir;
 	});
 
-	afterEach(cleanupTempHome(() => ({ tempDir, tempHomeDir, originalHome })));
+	afterEach(
+		cleanupTempHome(() => {
+			resetSettingsForTest();
+			return { tempDir, tempHomeDir, originalHome };
+		}),
+	);
 
 	it("renders SYSTEM.md exactly once when it is used as the custom base prompt", async () => {
 		const projectDir = path.join(tempDir, "project");
@@ -104,6 +110,24 @@ describe("SYSTEM.md prompt assembly", () => {
 		expect(discoveredFiles[0]?.path).toBe(path.join(appDir, "AGENTS.md"));
 	});
 
+	it("honors contextFiles.resolveAtRefs when loading discovered context entries", async () => {
+		const projectDir = path.join(tempDir, "project");
+		fs.mkdirSync(projectDir, { recursive: true });
+		fs.writeFileSync(path.join(projectDir, "AGENTS.md"), "@rules.md");
+		fs.writeFileSync(path.join(projectDir, "rules.md"), "expanded rules");
+
+		resetSettingsForTest();
+		await Settings.init({
+			inMemory: true,
+			cwd: projectDir,
+			overrides: { "contextFiles.resolveAtRefs": false },
+		});
+
+		const contextFiles = await loadProjectContextFiles({ cwd: projectDir });
+		const agentsFile = contextFiles.find(file => file.path === path.join(projectDir, "AGENTS.md"));
+
+		expect(agentsFile?.content).toBe("@rules.md");
+	});
 	it("keeps distinct context entries when their contents differ", async () => {
 		const farPath = path.join(tempDir, "far", "AGENTS.md");
 		const nearPath = path.join(tempDir, "near", "CLAUDE.md");

--- a/packages/coding-agent/test/system-prompt-dedup.test.ts
+++ b/packages/coding-agent/test/system-prompt-dedup.test.ts
@@ -161,6 +161,21 @@ describe("SYSTEM.md prompt assembly", () => {
 		expect(agentsFile?.content).toContain("no-repo-project");
 		expect(agentsFile?.content).not.toContain("escapes project root");
 	});
+
+	it("uses the repo root for project context containment", async () => {
+		const repoDir = path.join(tempDir, "repo");
+		const appDir = path.join(repoDir, "packages", "app");
+		fs.mkdirSync(path.join(repoDir, ".git"), { recursive: true });
+		fs.mkdirSync(appDir, { recursive: true });
+		fs.writeFileSync(path.join(repoDir, "package.json"), JSON.stringify({ name: "repo-root-package" }));
+		fs.writeFileSync(path.join(appDir, "AGENTS.md"), "@../../package.json");
+
+		const contextFiles = await loadProjectContextFiles({ cwd: appDir });
+		const agentsFile = contextFiles.find(file => file.path === path.join(appDir, "AGENTS.md"));
+
+		expect(agentsFile?.content).toContain("repo-root-package");
+		expect(agentsFile?.content).not.toContain("escapes project root");
+	});
 	it("keeps distinct context entries when their contents differ", async () => {
 		const farPath = path.join(tempDir, "far", "AGENTS.md");
 		const nearPath = path.join(tempDir, "near", "CLAUDE.md");


### PR DESCRIPTION
## Summary

Closes #375.

Inline file content referenced by `@relative/path.ext` patterns in AGENTS.md, CLAUDE.md, and other context files at load time.

### Behavior

- **Pattern**: A line that is exactly `@path/to/file.ext` (must contain a `.` to distinguish from `@username` / email)
- **Resolution**: Relative to the context file's own directory; supports `../` for parent directories
- **Recursion**: Nested `@`-references are resolved recursively, depth-limited to 5 with cycle detection
- **Missing files**: Produce `<!-- @path: file not found -->` comment placeholders instead of crashing
- **Default-enabled**: No setting toggle — a no-op when no `@` references exist in context files

### Insertion point

```
discovery providers → loadCapability → sort by depth → dedupeExactContextFiles → resolveAtRefs → buildSystemPrompt
```

Applied *after* dedup so identical content isn't read twice.

### Files

| File | Change |
|------|--------|
| `src/capability/resolve-at-refs.ts` | New — core `resolveAtRefs()` + `resolveContent()` |
| `src/system-prompt.ts` | Import + call `resolveAtRefs(dedupeExactContextFiles(files))` |
| `test/resolve-at-refs.test.ts` | New — 12 test cases |

### Test results

```
12 pass, 0 fail, 24 expect() calls
```

### Example

Given `AGENTS.md`:
```markdown
# Project Rules
@package.json
@configs/style-guide.md
```

The `@package.json` and `@configs/style-guide.md` lines are replaced with the contents of those files at load time.