### PR TITLE
fix(ai): parse JSON-encoded array strings against union(string, array) tool schemas

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `validateToolArguments` silently accepting JSON-encoded array strings (e.g. `'["a","b"]'`) against `union(string, array<string>)` schemas — providers that double-serialize tool-call arguments (Z.AI / GLM) caused tools like `search` to receive the literal `["a","b"]` as a single path, producing zero matches (single element) or glob parse errors (multi-element). A new pre-validation pass parses JSON-array-shaped strings when the schema explicitly accepts both shapes. ([#1788](https://github.com/can1357/oh-my-pi/issues/1788))
+
 ## [15.8.2] - 2026-06-03
 
 ### Fixed

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -1152,9 +1152,9 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): ToolCall[
 		}
 
 		// Re-run the union-string coercion because `coerceArgsFromIssues` may
-		// have just unwrapped a root JSON-string into the real arguments
-		// object — exposing inner `string | string[]` fields the initial
-		// pre-validation pass never reached.
+		// have just unwrapped a JSON-stringified object at the root or inside a
+		// nested field — exposing `string | string[]` descendants the initial
+		// pre-validation pass could not reach.
 		const stringEncodedArrayNormPass = normalizeStringEncodedArrayUnions(json, normalizedArgs);
 		if (stringEncodedArrayNormPass.changed) {
 			normalizedArgs = stringEncodedArrayNormPass.value;

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -769,10 +769,7 @@ function schemaAcceptsStringAndArray(schema: Record<string, unknown>): boolean {
  *
  * See https://github.com/can1357/oh-my-pi/issues/1788.
  */
-function normalizeStringEncodedArrayUnions(
-	schema: unknown,
-	value: unknown,
-): { value: unknown; changed: boolean } {
+function normalizeStringEncodedArrayUnions(schema: unknown, value: unknown): { value: unknown; changed: boolean } {
 	if (value === null || value === undefined) return { value, changed: false };
 	if (schema === null || typeof schema !== "object") return { value, changed: false };
 

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -717,6 +717,126 @@ function normalizeOptionalNullsForSchema(
 }
 
 // ============================================================================
+// String-encoded array coercion for union(string, array) schemas.
+// ============================================================================
+
+/**
+ * Detects whether a schema node accepts BOTH the `string` and `array` JSON
+ * Schema types. Recognizes:
+ *   - `{ "type": ["string", "array"] }` (multi-type),
+ *   - `{ "anyOf": [...] }` / `{ "oneOf": [...] }` with at least one string
+ *     branch and one array branch.
+ */
+function schemaAcceptsStringAndArray(schema: Record<string, unknown>): boolean {
+	if (Array.isArray(schema.type) && schema.type.includes("string") && schema.type.includes("array")) {
+		return true;
+	}
+
+	for (const key of ["anyOf", "oneOf"] as const) {
+		const branches = schema[key];
+		if (!Array.isArray(branches)) continue;
+		let hasString = false;
+		let hasArray = false;
+		for (const branch of branches) {
+			if (!branch || typeof branch !== "object") continue;
+			const branchType = (branch as Record<string, unknown>).type;
+			if (branchType === "string" || (Array.isArray(branchType) && branchType.includes("string"))) {
+				hasString = true;
+			}
+			if (branchType === "array" || (Array.isArray(branchType) && branchType.includes("array"))) {
+				hasArray = true;
+			}
+			if (hasString && hasArray) return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Pre-validation normalization: when a schema field accepts BOTH `string` and
+ * `array`, providers that double-serialize tool arguments (e.g. Z.AI / GLM)
+ * deliver array values as JSON-encoded strings like `'["a","b"]'`. Zod's
+ * `union([string, array])` happily accepts that string against the string
+ * branch, so the type-error driven coercion in {@link coerceArgsFromIssues}
+ * never fires, and downstream tools treat the literal `["a","b"]` as a path
+ * (silently producing zero matches or glob parse errors).
+ *
+ * Walk the schema; when both shapes are accepted AND the incoming value is a
+ * JSON-array-shaped string, substitute the parsed array. Conservative: only
+ * fires when the schema explicitly allows both shapes AND parsing yields an
+ * Array — anything else falls through to the regular validator, which can
+ * still surface a clean type error.
+ *
+ * See https://github.com/can1357/oh-my-pi/issues/1788.
+ */
+function normalizeStringEncodedArrayUnions(
+	schema: unknown,
+	value: unknown,
+): { value: unknown; changed: boolean } {
+	if (value === null || value === undefined) return { value, changed: false };
+	if (schema === null || typeof schema !== "object") return { value, changed: false };
+
+	const schemaObject = schema as Record<string, unknown>;
+
+	// Leaf case: this schema node accepts both string and array.
+	if (typeof value === "string" && schemaAcceptsStringAndArray(schemaObject)) {
+		const trimmed = value.trim();
+		if (!trimmed.startsWith("[")) return { value, changed: false };
+		try {
+			const parsed = JSON.parse(trimmed) as unknown;
+			if (Array.isArray(parsed)) {
+				return { value: parsed, changed: true };
+			}
+		} catch {
+			// Not valid JSON — leave the string alone for the validator to handle.
+		}
+		return { value, changed: false };
+	}
+
+	// Recurse into array items.
+	if (Array.isArray(value)) {
+		const itemSchema = schemaObject.items;
+		if (!itemSchema || typeof itemSchema !== "object" || Array.isArray(itemSchema)) {
+			return { value, changed: false };
+		}
+		let changed = false;
+		let nextValue = value;
+		for (let i = 0; i < value.length; i += 1) {
+			const normalized = normalizeStringEncodedArrayUnions(itemSchema, value[i]);
+			if (!normalized.changed) continue;
+			if (!changed) {
+				nextValue = [...value];
+				changed = true;
+			}
+			nextValue[i] = normalized.value;
+		}
+		return { value: changed ? nextValue : value, changed };
+	}
+
+	// Recurse into object properties.
+	if (schemaObject.type !== "object") return { value, changed: false };
+	if (typeof value !== "object" || value === null) return { value, changed: false };
+	const properties = schemaObject.properties;
+	if (!properties || typeof properties !== "object") return { value, changed: false };
+
+	const propsObject = properties as Record<string, unknown>;
+	const valueObject = value as Record<string, unknown>;
+	let changed = false;
+	let nextValue = valueObject;
+	for (const [key, propertySchema] of Object.entries(propsObject)) {
+		if (!(key in nextValue)) continue;
+		const normalized = normalizeStringEncodedArrayUnions(propertySchema, nextValue[key]);
+		if (!normalized.changed) continue;
+		if (!changed) {
+			nextValue = { ...nextValue };
+			changed = true;
+		}
+		nextValue[key] = normalized.value;
+	}
+	return { value: changed ? nextValue : valueObject, changed };
+}
+
+// ============================================================================
 // Zod issue → coercion bridge
 // ============================================================================
 
@@ -983,6 +1103,16 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): ToolCall[
 	const initialNormalization = normalizeOptionalNullsForSchema(json, normalizedArgs);
 	if (initialNormalization.changed) {
 		normalizedArgs = initialNormalization.value;
+		changed = true;
+	}
+
+	// Then re-shape JSON-stringified arrays whose schema accepts both string
+	// and array (e.g. `paths: string | string[]`). Without this, zod accepts
+	// the literal `'["a","b"]'` as a string and downstream tools treat it as
+	// a single path with embedded glob brackets — silent zero results.
+	const stringEncodedArrayNorm = normalizeStringEncodedArrayUnions(json, normalizedArgs);
+	if (stringEncodedArrayNorm.changed) {
+		normalizedArgs = stringEncodedArrayNorm.value;
 		changed = true;
 	}
 

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -752,6 +752,30 @@ function schemaAcceptsStringAndArray(schema: Record<string, unknown>): boolean {
 	return false;
 }
 
+function schemaNodeAcceptsArray(schema: unknown): schema is Record<string, unknown> {
+	if (!schema || typeof schema !== "object") return false;
+	const schemaObject = schema as Record<string, unknown>;
+	const schemaType = schemaObject.type;
+	return schemaType === "array" || (Array.isArray(schemaType) && schemaType.includes("array"));
+}
+
+function parsedArrayMatchesArrayBranch(schema: Record<string, unknown>, value: unknown[]): boolean {
+	if (schemaNodeAcceptsArray(schema)) {
+		return isJsonSchemaValueValid(schema, value);
+	}
+
+	for (const key of ["anyOf", "oneOf"] as const) {
+		const branches = schema[key];
+		if (!Array.isArray(branches)) continue;
+		const branchList: unknown[] = branches;
+		for (const branch of branchList) {
+			if (!schemaNodeAcceptsArray(branch)) continue;
+			if (isJsonSchemaValueValid(branch, value)) return true;
+		}
+	}
+	return false;
+}
+
 /**
  * Pre-validation normalization: when a schema field accepts BOTH `string` and
  * `array`, providers that double-serialize tool arguments (e.g. Z.AI / GLM)
@@ -762,10 +786,9 @@ function schemaAcceptsStringAndArray(schema: Record<string, unknown>): boolean {
  * (silently producing zero matches or glob parse errors).
  *
  * Walk the schema; when both shapes are accepted AND the incoming value is a
- * JSON-array-shaped string, substitute the parsed array. Conservative: only
- * fires when the schema explicitly allows both shapes AND parsing yields an
- * Array — anything else falls through to the regular validator, which can
- * still surface a clean type error.
+ * JSON-array-shaped string, substitute the parsed array only if it validates
+ * against the schema's array branch. Conservative: array-shaped strings like
+ * `"[1]"` stay on the string branch when the array branch is `string[]`.
  *
  * See https://github.com/can1357/oh-my-pi/issues/1788.
  */
@@ -781,7 +804,7 @@ function normalizeStringEncodedArrayUnions(schema: unknown, value: unknown): { v
 		if (!trimmed.startsWith("[")) return { value, changed: false };
 		try {
 			const parsed = JSON.parse(trimmed) as unknown;
-			if (Array.isArray(parsed)) {
+			if (Array.isArray(parsed) && parsedArrayMatchesArrayBranch(schemaObject, parsed)) {
 				return { value: parsed, changed: true };
 			}
 		} catch {

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -1151,6 +1151,15 @@ export function validateToolArguments(tool: Tool, toolCall: ToolCall): ToolCall[
 			normalizedArgs = nullNormalization.value;
 		}
 
+		// Re-run the union-string coercion because `coerceArgsFromIssues` may
+		// have just unwrapped a root JSON-string into the real arguments
+		// object — exposing inner `string | string[]` fields the initial
+		// pre-validation pass never reached.
+		const stringEncodedArrayNormPass = normalizeStringEncodedArrayUnions(json, normalizedArgs);
+		if (stringEncodedArrayNormPass.changed) {
+			normalizedArgs = stringEncodedArrayNormPass.value;
+		}
+
 		result = validateContext(ctx, normalizedArgs);
 		if (result.success) return result.value as ToolCall["arguments"];
 	}

--- a/packages/ai/test/tool-argument-coercion.test.ts
+++ b/packages/ai/test/tool-argument-coercion.test.ts
@@ -1108,5 +1108,28 @@ describe("Tool argument coercion", () => {
 			expect(result.pattern).toBe("name");
 			expect(result.paths).toEqual(["package.json"]);
 		});
+
+		it("re-runs union coercion after a nested object field is JSON-parsed", () => {
+			const nestedTool: Tool = {
+				name: "nested_search",
+				description: "",
+				parameters: z.object({
+					payload: z.object({
+						paths: z.union([z.string(), z.array(z.string()).min(1)]),
+					}),
+				}),
+			};
+			const result = validateToolArguments(nestedTool, {
+				type: "toolCall",
+				id: "u10",
+				name: "nested_search",
+				arguments: {
+					payload: JSON.stringify({
+						paths: '["package.json"]',
+					}),
+				},
+			}) as { payload: { paths: unknown } };
+			expect(result.payload.paths).toEqual(["package.json"]);
+		});
 	});
 });

--- a/packages/ai/test/tool-argument-coercion.test.ts
+++ b/packages/ai/test/tool-argument-coercion.test.ts
@@ -988,4 +988,96 @@ describe("Tool argument coercion", () => {
 		const result = validateToolArguments(tool, toolCall) as Record<string, unknown>;
 		expect(result.op).toBe("fix");
 	});
+
+	describe("string|array union (regression: #1788)", () => {
+		// `search` and `gh` tools declare `paths`/`pr` as `union(string, array<string>)`
+		// so the LLM can pass a single path or many. Some providers (Z.AI / GLM)
+		// double-serialize array tool-call arguments into JSON strings, which the
+		// union accepts as a string — silently feeding the downstream tool a literal
+		// `["a","b"]` path string.
+		const unionTool: Tool = {
+			name: "search",
+			description: "",
+			parameters: z.object({
+				pattern: z.string(),
+				paths: z.union([z.string(), z.array(z.string()).min(1)]),
+			}),
+		};
+
+		it("parses a JSON-encoded single-element array into a real array", () => {
+			const result = validateToolArguments(unionTool, {
+				type: "toolCall",
+				id: "u1",
+				name: "search",
+				arguments: { pattern: "name", paths: '["package.json"]' },
+			}) as { paths: unknown };
+			expect(result.paths).toEqual(["package.json"]);
+		});
+
+		it("parses a JSON-encoded multi-element array into a real array", () => {
+			const result = validateToolArguments(unionTool, {
+				type: "toolCall",
+				id: "u2",
+				name: "search",
+				arguments: { pattern: "name", paths: '["package.json","App.tsx"]' },
+			}) as { paths: unknown };
+			expect(result.paths).toEqual(["package.json", "App.tsx"]);
+		});
+
+		it("parses a JSON-encoded array containing an absolute path", () => {
+			const result = validateToolArguments(unionTool, {
+				type: "toolCall",
+				id: "u3",
+				name: "search",
+				arguments: { pattern: "name", paths: '["/home/user/project/package.json"]' },
+			}) as { paths: unknown };
+			expect(result.paths).toEqual(["/home/user/project/package.json"]);
+		});
+
+		it("preserves a plain string path (no brackets) untouched", () => {
+			const result = validateToolArguments(unionTool, {
+				type: "toolCall",
+				id: "u4",
+				name: "search",
+				arguments: { pattern: "name", paths: "package.json" },
+			}) as { paths: unknown };
+			expect(result.paths).toBe("package.json");
+		});
+
+		it("preserves a real array path untouched", () => {
+			const result = validateToolArguments(unionTool, {
+				type: "toolCall",
+				id: "u5",
+				name: "search",
+				arguments: { pattern: "name", paths: ["package.json", "App.tsx"] },
+			}) as { paths: unknown };
+			expect(result.paths).toEqual(["package.json", "App.tsx"]);
+		});
+
+		it("leaves a glob-style string with brackets untouched when it does not parse as JSON", () => {
+			// `[abc]` is a glob char class; not valid JSON without quoted members.
+			const result = validateToolArguments(unionTool, {
+				type: "toolCall",
+				id: "u6",
+				name: "search",
+				arguments: { pattern: "name", paths: "[abc]" },
+			}) as { paths: unknown };
+			expect(result.paths).toBe("[abc]");
+		});
+
+		it("does not coerce JSON-shape strings when the schema only accepts string", () => {
+			const stringOnly: Tool = {
+				name: "string_only",
+				description: "",
+				parameters: z.object({ value: z.string() }),
+			};
+			const result = validateToolArguments(stringOnly, {
+				type: "toolCall",
+				id: "u7",
+				name: "string_only",
+				arguments: { value: '["not-a-list"]' },
+			}) as { value: unknown };
+			expect(result.value).toBe('["not-a-list"]');
+		});
+	});
 });

--- a/packages/ai/test/tool-argument-coercion.test.ts
+++ b/packages/ai/test/tool-argument-coercion.test.ts
@@ -1065,6 +1065,16 @@ describe("Tool argument coercion", () => {
 			expect(result.paths).toBe("[abc]");
 		});
 
+		it("preserves JSON-array-shaped strings that do not satisfy the array branch", () => {
+			const result = validateToolArguments(unionTool, {
+				type: "toolCall",
+				id: "u7",
+				name: "search",
+				arguments: { pattern: "name", paths: "[1]" },
+			}) as { paths: unknown };
+			expect(result.paths).toBe("[1]");
+		});
+
 		it("does not coerce JSON-shape strings when the schema only accepts string", () => {
 			const stringOnly: Tool = {
 				name: "string_only",
@@ -1073,7 +1083,7 @@ describe("Tool argument coercion", () => {
 			};
 			const result = validateToolArguments(stringOnly, {
 				type: "toolCall",
-				id: "u7",
+				id: "u8",
 				name: "string_only",
 				arguments: { value: '["not-a-list"]' },
 			}) as { value: unknown };

--- a/packages/ai/test/tool-argument-coercion.test.ts
+++ b/packages/ai/test/tool-argument-coercion.test.ts
@@ -1089,5 +1089,24 @@ describe("Tool argument coercion", () => {
 			}) as { value: unknown };
 			expect(result.value).toBe('["not-a-list"]');
 		});
+
+		it("re-runs union coercion after the root arguments object is JSON-parsed", () => {
+			// Some providers double-encode the entire arguments object — the call
+			// arrives with `arguments` as the JSON string of an object whose own
+			// `paths` field is itself a JSON-encoded array. Both layers must
+			// unwind for the search bug fix (#1788) to actually take effect.
+			const rootStringArgs = JSON.stringify({
+				pattern: "name",
+				paths: '["package.json"]',
+			}) as unknown as Record<string, unknown>;
+			const result = validateToolArguments(unionTool, {
+				type: "toolCall",
+				id: "u9",
+				name: "search",
+				arguments: rootStringArgs,
+			}) as { pattern: string; paths: unknown };
+			expect(result.pattern).toBe("name");
+			expect(result.paths).toEqual(["package.json"]);
+		});
 	});
 });


### PR DESCRIPTION
## Repro

The `search` tool silently returns "No matches found" when the model passes `paths` as a JSON array on providers that double-serialize tool-call arguments (Z.AI / GLM). Reproduced against `SearchTool.execute()` after threading args through `validateToolArguments`:

```
1. paths=["package.json"] (real array)               matchCount: 1 fileCount: 1  ✔
2. paths='["package.json"]' (JSON-encoded string)    matchCount: 0 fileCount: 0  ← silent
3. paths="package.json" (plain string)               matchCount: 1 fileCount: 1  ✔
4. paths='["package.json","README.md"]'              ERROR: unclosed character class
5. paths='["/abs/path/package.json"]'                matchCount: 0 fileCount: 0  ← silent
```

## Cause

The `search` (and `gh`) tools declare their array-friendly fields as `z.union([z.string(), z.array(z.string()).min(1)])`. When a provider delivers `paths: ["a","b"]` as the *string* `'["a","b"]'`, zod accepts it against the string branch — no `invalid_type` issue fires, so the existing JSON→array coercion in `coerceArgsFromIssues` (`packages/ai/src/utils/validation.ts`) never runs. The literal `["a","b"]` then flows downstream where `parseSearchPath` sees `[` / `]` as glob characters and ripgrep parses it as a character class: single-element matches nothing silently (`["package.json"]` ≈ char class `p|a|c|k|g|e|.|j|s|o|n`), multi-element parse-errors on the comma, and absolute paths range-error on out-of-order chars.

## Fix

`packages/ai/src/utils/validation.ts`:

- Added `schemaAcceptsStringAndArray()` — detects schema nodes that allow both via `type: ["string","array"]` or `anyOf`/`oneOf` branches.
- Added `normalizeStringEncodedArrayUnions()` — walks the JSON schema (mirroring `normalizeOptionalNullsForSchema`) and, when both shapes are accepted *and* the value is a JSON-array-shaped string, `JSON.parse`s and substitutes.
- Wired the pass into `validateToolArguments` immediately after the existing nulls-and-defaults normalization, so the substituted array reaches zod with no type error needed.

Conservative scope:
- Only fires when the schema explicitly accepts both shapes — single-type schemas (`find`, `ast-grep`, `ast-edit`) still get coerced via the existing type-error path.
- Only substitutes when `JSON.parse` yields an `Array`; non-array or unparseable strings fall through to the validator unchanged.
- Strings without a leading `[` (e.g. glob char classes like `"[abc]"`, plain paths) are left alone.

`packages/ai/test/tool-argument-coercion.test.ts`:

- 7 regression tests in a new `string|array union (regression: #1788)` block — single-element, multi-element, absolute-in-array, plain-string preservation, real-array preservation, glob-bracket preservation, and a negative case verifying string-only schemas aren't affected.

`packages/ai/CHANGELOG.md`: `Unreleased` entry under `Fixed`.

## Verification

- `bun test test/tool-argument-coercion.test.ts` (packages/ai): **46 pass / 0 fail** — 7 new tests for the bug, 39 existing tests unchanged.
- `bun test` (packages/ai full suite): **1465 pass / 0 fail / 337 skipped** (skips are E2E paths requiring env).
- `bun test test/tools/{multi-search-path,search-internal-urls,search-invalid-regex,search-path-lists,search-renderer}.test.ts` (packages/coding-agent): **45 pass / 0 fail**.
- End-to-end re-run of the original repro through `validateToolArguments` → `SearchTool.execute()`: all five cases (real array, JSON-string single, plain string, JSON-string multi, JSON-string absolute) now return `matchCount: 1 fileCount: 1`.

Fixes #1788