### PR TITLE
fix(ai): add MiniMax M3 to Coding Plan catalog

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Added MiniMax M3 to the MiniMax Token Plan catalog and made China Token Plan credentials unlock the Anthropic-compatible `minimax-cn` SKU. ([#1790](https://github.com/can1357/oh-my-pi/issues/1790))
+
 ## [15.8.2] - 2026-06-03
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -35,6 +35,15 @@ import { loginDeepSeek } from "./utils/oauth/deepseek";
 import { loginOpenAICodexDevice } from "./utils/oauth/openai-codex";
 import type { OAuthController, OAuthCredentials, OAuthProvider, OAuthProviderId } from "./utils/oauth/types";
 
+const PROVIDER_AUTH_FALLBACKS: Record<string, readonly string[]> = {
+	minimax: ["minimax-code"],
+	"minimax-cn": ["minimax-code-cn"],
+};
+
+function getProviderAuthFallbacks(provider: string): readonly string[] {
+	return PROVIDER_AUTH_FALLBACKS[provider] ?? [];
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Credential Types
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1357,6 +1366,13 @@ export class AuthStorage {
 		if (this.#getCredentialsForProvider(provider).length > 0) return true;
 		if (getEnvApiKey(provider)) return true;
 		if (this.#fallbackResolver?.(provider)) return true;
+		for (const fallbackProvider of getProviderAuthFallbacks(provider)) {
+			if (this.#runtimeOverrides.has(fallbackProvider)) return true;
+			if (this.#configOverrides.has(fallbackProvider)) return true;
+			if (this.#getCredentialsForProvider(fallbackProvider).length > 0) return true;
+			if (getEnvApiKey(fallbackProvider)) return true;
+			if (this.#fallbackResolver?.(fallbackProvider)) return true;
+		}
 		return false;
 	}
 
@@ -1376,6 +1392,12 @@ export class AuthStorage {
 		if (this.#configOverrides.has(provider)) return true;
 		if (this.#getCredentialsForProvider(provider).length > 0) return true;
 		if (this.#fallbackResolver?.(provider)) return true;
+		for (const fallbackProvider of getProviderAuthFallbacks(provider)) {
+			if (this.#runtimeOverrides.has(fallbackProvider)) return true;
+			if (this.#configOverrides.has(fallbackProvider)) return true;
+			if (this.#getCredentialsForProvider(fallbackProvider).length > 0) return true;
+			if (this.#fallbackResolver?.(fallbackProvider)) return true;
+		}
 		return false;
 	}
 
@@ -1655,16 +1677,30 @@ export class AuthStorage {
 				await saveApiKeyCredential(apiKey);
 				return;
 			}
+			case "minimax": {
+				const { loginMiniMaxTokenPlan } = await import("./utils/oauth/minimax-code");
+				const apiKey = await loginMiniMaxTokenPlan(ctrl);
+				await saveApiKeyCredential(apiKey);
+				return;
+			}
+			case "minimax-cn": {
+				const { loginMiniMaxTokenPlanCn } = await import("./utils/oauth/minimax-code");
+				const apiKey = await loginMiniMaxTokenPlanCn(ctrl);
+				await saveApiKeyCredential(apiKey);
+				return;
+			}
 			case "minimax-code": {
 				const { loginMiniMaxCode } = await import("./utils/oauth/minimax-code");
 				const apiKey = await loginMiniMaxCode(ctrl);
 				await saveApiKeyCredential(apiKey);
+				await this.set("minimax", { type: "api_key", key: apiKey });
 				return;
 			}
 			case "minimax-code-cn": {
 				const { loginMiniMaxCodeCn } = await import("./utils/oauth/minimax-code");
 				const apiKey = await loginMiniMaxCodeCn(ctrl);
 				await saveApiKeyCredential(apiKey);
+				await this.set("minimax-cn", { type: "api_key", key: apiKey });
 				return;
 			}
 			case "synthetic": {
@@ -3293,6 +3329,11 @@ export class AuthStorage {
 		const envKey = getEnvApiKey(provider);
 		if (envKey) return envKey;
 
+		for (const fallbackProvider of getProviderAuthFallbacks(provider)) {
+			const apiKey = await this.peekApiKey(fallbackProvider);
+			if (apiKey) return apiKey;
+		}
+
 		return this.#fallbackResolver?.(provider) ?? undefined;
 	}
 
@@ -3341,6 +3382,11 @@ export class AuthStorage {
 		if (sessionId) this.#sessionLastCredential.get(provider)?.delete(sessionId);
 		const envKey = getEnvApiKey(provider);
 		if (envKey) return envKey;
+
+		for (const fallbackProvider of getProviderAuthFallbacks(provider)) {
+			const apiKey = await this.getApiKey(fallbackProvider, sessionId, options);
+			if (apiKey) return apiKey;
+		}
 
 		// Fall back to custom resolver (e.g., models.json custom providers)
 		return this.#fallbackResolver?.(provider) ?? undefined;

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -44,6 +44,17 @@ function getProviderAuthFallbacks(provider: string): readonly string[] {
 	return PROVIDER_AUTH_FALLBACKS[provider] ?? [];
 }
 
+const PROVIDER_AUTH_MIRRORS: Record<string, readonly string[]> = {
+	minimax: ["minimax-code"],
+	"minimax-cn": ["minimax-code-cn"],
+	"minimax-code": ["minimax"],
+	"minimax-code-cn": ["minimax-cn"],
+};
+
+function getProviderAuthMirrors(provider: string): readonly string[] {
+	return PROVIDER_AUTH_MIRRORS[provider] ?? [];
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Credential Types
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1329,10 +1340,7 @@ export class AuthStorage {
 		this.#resetProviderAssignments(provider);
 	}
 
-	/**
-	 * Remove credential for a provider.
-	 */
-	async remove(provider: string): Promise<void> {
+	async #removeProviderCredentials(provider: string): Promise<void> {
 		if (this.#store.deleteAuthCredentialsRemote) {
 			await this.#store.deleteAuthCredentialsRemote(provider, "deleted by user");
 		} else {
@@ -1340,6 +1348,16 @@ export class AuthStorage {
 		}
 		this.#setStoredCredentials(provider, []);
 		this.#resetProviderAssignments(provider);
+	}
+
+	/**
+	 * Remove credential for a provider.
+	 */
+	async remove(provider: string): Promise<void> {
+		await this.#removeProviderCredentials(provider);
+		for (const mirrorProvider of getProviderAuthMirrors(provider)) {
+			await this.#removeProviderCredentials(mirrorProvider);
+		}
 	}
 
 	/**

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -1681,12 +1681,14 @@ export class AuthStorage {
 				const { loginMiniMaxTokenPlan } = await import("./utils/oauth/minimax-code");
 				const apiKey = await loginMiniMaxTokenPlan(ctrl);
 				await saveApiKeyCredential(apiKey);
+				await this.set("minimax-code", { type: "api_key", key: apiKey });
 				return;
 			}
 			case "minimax-cn": {
 				const { loginMiniMaxTokenPlanCn } = await import("./utils/oauth/minimax-code");
 				const apiKey = await loginMiniMaxTokenPlanCn(ctrl);
 				await saveApiKeyCredential(apiKey);
+				await this.set("minimax-code-cn", { type: "api_key", key: apiKey });
 				return;
 			}
 			case "minimax-code": {

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -38,6 +38,8 @@ import type { OAuthController, OAuthCredentials, OAuthProvider, OAuthProviderId 
 const PROVIDER_AUTH_FALLBACKS: Record<string, readonly string[]> = {
 	minimax: ["minimax-code"],
 	"minimax-cn": ["minimax-code-cn"],
+	"minimax-code": ["minimax"],
+	"minimax-code-cn": ["minimax-cn"],
 };
 
 function getProviderAuthFallbacks(provider: string): readonly string[] {
@@ -3315,7 +3317,9 @@ export class AuthStorage {
 	 * and get a best-effort token. For GitHub Copilot we preserve enterprise
 	 * routing metadata so discovery can hit the correct host.
 	 */
-	async peekApiKey(provider: string): Promise<string | undefined> {
+	async peekApiKey(provider: string, visitedProviders: Set<string> = new Set()): Promise<string | undefined> {
+		if (visitedProviders.has(provider)) return undefined;
+		visitedProviders.add(provider);
 		const runtimeKey = this.#runtimeOverrides.get(provider);
 		if (runtimeKey) {
 			return runtimeKey;
@@ -3350,7 +3354,7 @@ export class AuthStorage {
 		if (envKey) return envKey;
 
 		for (const fallbackProvider of getProviderAuthFallbacks(provider)) {
-			const apiKey = await this.peekApiKey(fallbackProvider);
+			const apiKey = await this.peekApiKey(fallbackProvider, visitedProviders);
 			if (apiKey) return apiKey;
 		}
 
@@ -3367,7 +3371,14 @@ export class AuthStorage {
 	 * 5. Environment variable
 	 * 6. Fallback resolver (models.yml custom providers, last-resort)
 	 */
-	async getApiKey(provider: string, sessionId?: string, options?: AuthApiKeyOptions): Promise<string | undefined> {
+	async getApiKey(
+		provider: string,
+		sessionId?: string,
+		options?: AuthApiKeyOptions,
+		visitedProviders: Set<string> = new Set(),
+	): Promise<string | undefined> {
+		if (visitedProviders.has(provider)) return undefined;
+		visitedProviders.add(provider);
 		// Runtime override takes highest priority
 		const runtimeKey = this.#runtimeOverrides.get(provider);
 		if (runtimeKey) {
@@ -3404,7 +3415,7 @@ export class AuthStorage {
 		if (envKey) return envKey;
 
 		for (const fallbackProvider of getProviderAuthFallbacks(provider)) {
-			const apiKey = await this.getApiKey(fallbackProvider, sessionId, options);
+			const apiKey = await this.getApiKey(fallbackProvider, sessionId, options, visitedProviders);
 			if (apiKey) return apiKey;
 		}
 

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -5529,7 +5529,7 @@
 	"github-copilot": {
 		"claude-haiku-4.5": {
 			"id": "claude-haiku-4.5",
-			"name": "Claude Haiku 4.5",
+			"name": "Claude Haiku 4.5 (latest)",
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5539,10 +5539,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 1,
+				"output": 5,
+				"cacheRead": 0.1,
+				"cacheWrite": 1.25
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
@@ -5558,7 +5558,7 @@
 		},
 		"claude-opus-4.5": {
 			"id": "claude-opus-4.5",
-			"name": "Claude Opus 4.5",
+			"name": "Claude Opus 4.5 (latest)",
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5568,10 +5568,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 200000,
 			"maxTokens": 32000,
@@ -5596,10 +5596,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 168000,
 			"maxTokens": 32000,
@@ -5625,10 +5625,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 200000,
 			"maxTokens": 32000,
@@ -5653,10 +5653,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 5,
+				"output": 25,
+				"cacheRead": 0.5,
+				"cacheWrite": 6.25
 			},
 			"contextWindow": 200000,
 			"maxTokens": 64000,
@@ -5671,7 +5671,7 @@
 		},
 		"claude-sonnet-4": {
 			"id": "claude-sonnet-4",
-			"name": "Claude Sonnet 4",
+			"name": "Claude Sonnet 4 (latest)",
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5681,10 +5681,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
 			},
 			"contextWindow": 216000,
 			"maxTokens": 16000,
@@ -5699,7 +5699,7 @@
 		},
 		"claude-sonnet-4.5": {
 			"id": "claude-sonnet-4.5",
-			"name": "Claude Sonnet 4.5",
+			"name": "Claude Sonnet 4.5 (latest)",
 			"api": "anthropic-messages",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5709,10 +5709,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
 			},
 			"contextWindow": 200000,
 			"maxTokens": 32000,
@@ -5737,10 +5737,10 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
-				"cacheWrite": 0
+				"input": 3,
+				"output": 15,
+				"cacheRead": 0.3,
+				"cacheWrite": 3.75
 			},
 			"contextWindow": 200000,
 			"maxTokens": 32000,
@@ -5759,15 +5759,15 @@
 			"api": "openai-completions",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.25,
+				"output": 10,
+				"cacheRead": 0.125,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -5779,11 +5779,16 @@
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
 				"supportsReasoningEffort": false
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
 			}
 		},
 		"gemini-3-flash-preview": {
 			"id": "gemini-3-flash-preview",
-			"name": "Gemini 3 Flash",
+			"name": "Gemini 3 Flash Preview",
 			"api": "openai-completions",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -5793,9 +5798,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.5,
+				"output": 3,
+				"cacheRead": 0.05,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -5863,9 +5868,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2,
+				"output": 12,
+				"cacheRead": 0.2,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -5900,9 +5905,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.5,
+				"output": 9,
+				"cacheRead": 0.15,
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
@@ -5933,9 +5938,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2,
+				"output": 8,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 128000,
@@ -6008,7 +6013,7 @@
 		},
 		"gpt-5-mini": {
 			"id": "gpt-5-mini",
-			"name": "GPT-5-mini",
+			"name": "GPT-5 Mini",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -6018,9 +6023,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.25,
+				"output": 2,
+				"cacheRead": 0.025,
 				"cacheWrite": 0
 			},
 			"contextWindow": 264000,
@@ -6158,9 +6163,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.75,
+				"output": 14,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -6176,7 +6181,7 @@
 		},
 		"gpt-5.2-codex": {
 			"id": "gpt-5.2-codex",
-			"name": "GPT-5.2-Codex",
+			"name": "GPT-5.2 Codex",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -6186,9 +6191,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.75,
+				"output": 14,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -6204,7 +6209,7 @@
 		},
 		"gpt-5.3-codex": {
 			"id": "gpt-5.3-codex",
-			"name": "GPT-5.3-Codex",
+			"name": "GPT-5.3 Codex",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -6214,9 +6219,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 1.75,
+				"output": 14,
+				"cacheRead": 0.175,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -6242,9 +6247,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 2.5,
+				"output": 15,
+				"cacheRead": 0.25,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -6260,7 +6265,7 @@
 		},
 		"gpt-5.4-mini": {
 			"id": "gpt-5.4-mini",
-			"name": "GPT-5.4 Mini",
+			"name": "GPT-5.4 mini",
 			"api": "openai-responses",
 			"provider": "github-copilot",
 			"baseUrl": "https://api.githubcopilot.com",
@@ -6270,9 +6275,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 0.75,
+				"output": 4.5,
+				"cacheRead": 0.075,
 				"cacheWrite": 0
 			},
 			"contextWindow": 272000,
@@ -6281,6 +6286,34 @@
 				"User-Agent": "opencode/1.3.15"
 			},
 			"premiumMultiplier": 0.33,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "low",
+				"maxLevel": "xhigh"
+			}
+		},
+		"gpt-5.4-nano": {
+			"id": "gpt-5.4-nano",
+			"name": "GPT-5.4 nano",
+			"api": "openai-responses",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.2,
+				"output": 1.25,
+				"cacheRead": 0.02,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"headers": {
+				"User-Agent": "opencode/1.3.15"
+			},
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "low",
@@ -6299,9 +6332,9 @@
 				"image"
 			],
 			"cost": {
-				"input": 0,
-				"output": 0,
-				"cacheRead": 0,
+				"input": 5,
+				"output": 30,
+				"cacheRead": 0.5,
 				"cacheWrite": 0
 			},
 			"contextWindow": 400000,
@@ -6343,6 +6376,39 @@
 				"supportsReasoningEffort": false
 			},
 			"premiumMultiplier": 0.25,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"raptor-mini": {
+			"id": "raptor-mini",
+			"name": "Raptor mini",
+			"api": "openai-completions",
+			"provider": "github-copilot",
+			"baseUrl": "https://api.githubcopilot.com",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.25,
+				"output": 2,
+				"cacheRead": 0.025,
+				"cacheWrite": 0
+			},
+			"contextWindow": 400000,
+			"maxTokens": 128000,
+			"headers": {
+				"User-Agent": "opencode/1.3.15"
+			},
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false
+			},
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -13936,7 +14002,7 @@
 		},
 		"nex-agi/deepseek-v3.1-nex-n1": {
 			"id": "nex-agi/deepseek-v3.1-nex-n1",
-			"name": "Nex AGI: DeepSeek V3.1 Nex N1",
+			"name": "Nex AGI: DeepSeek V3.1 Nex N1 (retires Jun 8)",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -15690,6 +15756,25 @@
 			"contextWindow": 222222,
 			"maxTokens": 8888
 		},
+		"openrouter/fusion": {
+			"id": "openrouter/fusion",
+			"name": "OpenRouter: Fusion",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
 		"openrouter/healer-alpha": {
 			"id": "openrouter/healer-alpha",
 			"name": "Healer Alpha",
@@ -17022,6 +17107,25 @@
 		"qwen/qwen3.7-max": {
 			"id": "qwen/qwen3.7-max",
 			"name": "Qwen: Qwen3.7 Max",
+			"api": "openai-completions",
+			"provider": "kilo",
+			"baseUrl": "https://api.kilo.ai/api/gateway",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
+			"maxTokens": 8888
+		},
+		"qwen/qwen3.7-plus": {
+			"id": "qwen/qwen3.7-plus",
+			"name": "Qwen: Qwen3.7 Plus",
 			"api": "openai-completions",
 			"provider": "kilo",
 			"baseUrl": "https://api.kilo.ai/api/gateway",
@@ -42481,6 +42585,31 @@
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
+		},
+		"MiniMax-M3": {
+			"id": "MiniMax-M3",
+			"name": "MiniMax-M3",
+			"api": "anthropic-messages",
+			"provider": "minimax",
+			"baseUrl": "https://api.minimax.io/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 2.4,
+				"cacheRead": 0.12,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		}
 	},
 	"minimax-cn": {
@@ -42646,6 +42775,31 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
+		"MiniMax-M3": {
+			"id": "MiniMax-M3",
+			"name": "MiniMax-M3",
+			"api": "anthropic-messages",
+			"provider": "minimax-cn",
+			"baseUrl": "https://api.minimaxi.com/anthropic",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.6,
+				"output": 2.4,
+				"cacheRead": 0.12,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "budget",
 				"minLevel": "minimal",
@@ -42882,6 +43036,37 @@
 			},
 			"contextWindow": 204800,
 			"maxTokens": 131072,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false,
+				"reasoningContentField": "reasoning_content"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"MiniMax-M3": {
+			"id": "MiniMax-M3",
+			"name": "MiniMax-M3",
+			"api": "openai-completions",
+			"provider": "minimax-code",
+			"baseUrl": "https://api.minimax.io/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
 			"compat": {
 				"supportsStore": false,
 				"supportsDeveloperRole": false,
@@ -43135,6 +43320,37 @@
 				"minLevel": "minimal",
 				"maxLevel": "high"
 			}
+		},
+		"MiniMax-M3": {
+			"id": "MiniMax-M3",
+			"name": "MiniMax-M3",
+			"api": "openai-completions",
+			"provider": "minimax-code-cn",
+			"baseUrl": "https://api.minimaxi.com/v1",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 512000,
+			"maxTokens": 128000,
+			"compat": {
+				"supportsStore": false,
+				"supportsDeveloperRole": false,
+				"supportsReasoningEffort": false,
+				"reasoningContentField": "reasoning_content"
+			},
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
 		}
 	},
 	"mistral": {
@@ -43159,6 +43375,25 @@
 		},
 		"devstral-2512": {
 			"id": "devstral-2512",
+			"name": "Devstral 2",
+			"api": "openai-completions",
+			"provider": "mistral",
+			"baseUrl": "https://api.mistral.ai/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.4,
+				"output": 2,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 262144
+		},
+		"devstral-latest": {
+			"id": "devstral-latest",
 			"name": "Devstral 2",
 			"api": "openai-completions",
 			"provider": "mistral",
@@ -43614,6 +43849,25 @@
 			},
 			"contextWindow": 8000,
 			"maxTokens": 8000
+		},
+		"open-mistral-nemo": {
+			"id": "open-mistral-nemo",
+			"name": "Open Mistral Nemo",
+			"api": "openai-completions",
+			"provider": "mistral",
+			"baseUrl": "https://api.mistral.ai/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0.15,
+				"output": 0.15,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 128000
 		},
 		"open-mixtral-8x22b": {
 			"id": "open-mixtral-8x22b",
@@ -61537,7 +61791,7 @@
 			"contextWindow": 512000,
 			"maxTokens": 131072,
 			"thinking": {
-				"mode": "budget",
+				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
@@ -62941,7 +63195,7 @@
 			"contextWindow": 200000,
 			"maxTokens": 32000,
 			"thinking": {
-				"mode": "budget",
+				"mode": "effort",
 				"minLevel": "minimal",
 				"maxLevel": "xhigh"
 			}
@@ -65317,9 +65571,9 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.3,
-				"output": 2.5,
-				"cacheRead": 0.06,
+				"input": 0.075,
+				"output": 0.625,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
@@ -65699,13 +65953,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.26,
+				"input": 0.27899999999999997,
 				"output": 1.2,
 				"cacheRead": 0.059,
 				"cacheWrite": 0
 			},
 			"contextWindow": 204800,
-			"maxTokens": 131070,
+			"maxTokens": 131072,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -68607,13 +68861,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.09,
-				"output": 0.3,
+				"input": 0.0428,
+				"output": 0.1716,
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 262144,
-			"maxTokens": 262144
+			"contextWindow": 131072,
+			"maxTokens": 32000
 		},
 		"qwen/qwen3-30b-a3b-thinking-2507": {
 			"id": "qwen/qwen3-30b-a3b-thinking-2507",
@@ -69738,13 +69992,13 @@
 				"text"
 			],
 			"cost": {
-				"input": 0.06599999999999999,
-				"output": 0.26,
-				"cacheRead": 0.029,
+				"input": 0.063,
+				"output": 0.21,
+				"cacheRead": 0.020999999999999998,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 262144,
+			"maxTokens": 64000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -70565,12 +70819,12 @@
 			],
 			"cost": {
 				"input": 0.6,
-				"output": 2.08,
+				"output": 1.92,
 				"cacheRead": 0.12,
 				"cacheWrite": 0
 			},
 			"contextWindow": 202752,
-			"maxTokens": 16384,
+			"maxTokens": 128000,
 			"thinking": {
 				"mode": "effort",
 				"minLevel": "minimal",
@@ -72848,7 +73102,7 @@
 				"cacheRead": 0,
 				"cacheWrite": 0
 			},
-			"contextWindow": 512000,
+			"contextWindow": 500000,
 			"maxTokens": 131072,
 			"compat": {
 				"supportsUsageInStreaming": false
@@ -73295,6 +73549,28 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
+			"maxTokens": 8888,
+			"compat": {
+				"supportsUsageInStreaming": false
+			}
+		},
+		"qwen-3-7-plus": {
+			"id": "qwen-3-7-plus",
+			"name": "qwen-3-7-plus",
+			"api": "openai-completions",
+			"provider": "venice",
+			"baseUrl": "https://api.venice.ai/api/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 222222,
 			"maxTokens": 8888,
 			"compat": {
 				"supportsUsageInStreaming": false
@@ -74282,6 +74558,31 @@
 				"maxLevel": "xhigh"
 			}
 		},
+		"alibaba/qwen3.7-plus": {
+			"id": "alibaba/qwen3.7-plus",
+			"name": "Qwen 3.7 Plus",
+			"api": "anthropic-messages",
+			"provider": "vercel-ai-gateway",
+			"baseUrl": "https://ai-gateway.vercel.sh",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0.39999999999999997,
+				"output": 1.5999999999999999,
+				"cacheRead": 0.08,
+				"cacheWrite": 0.5
+			},
+			"contextWindow": 1000000,
+			"maxTokens": 64000,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
+		},
 		"anthropic/claude-3-haiku": {
 			"id": "anthropic/claude-3-haiku",
 			"name": "Claude Haiku 3",
@@ -75225,19 +75526,24 @@
 			"api": "anthropic-messages",
 			"provider": "vercel-ai-gateway",
 			"baseUrl": "https://ai-gateway.vercel.sh",
-			"reasoning": false,
+			"reasoning": true,
 			"input": [
 				"text",
 				"image"
 			],
 			"cost": {
-				"input": 0.13,
-				"output": 0.39999999999999997,
-				"cacheRead": 0,
+				"input": 0.15,
+				"output": 0.6,
+				"cacheRead": 0.015,
 				"cacheWrite": 0
 			},
 			"contextWindow": 262144,
-			"maxTokens": 131072
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "budget",
+				"minLevel": "minimal",
+				"maxLevel": "xhigh"
+			}
 		},
 		"google/gemma-4-31b-it": {
 			"id": "google/gemma-4-31b-it",

--- a/packages/ai/src/provider-models/descriptors.ts
+++ b/packages/ai/src/provider-models/descriptors.ts
@@ -348,6 +348,7 @@ export const DEFAULT_MODEL_PER_PROVIDER: Record<KnownProvider, string> = {
 	"google-gemini-cli": "gemini-2.5-pro",
 	"google-vertex": "gemini-3-pro-preview",
 	minimax: "MiniMax-M2.5",
+	"minimax-cn": "MiniMax-M2.5",
 	"minimax-code": "MiniMax-M2.5",
 	"minimax-code-cn": "MiniMax-M2.5",
 	"openai-codex": "gpt-5.4",

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -193,6 +193,7 @@ const serviceProviderMap: Record<string, KeyResolver> = {
 	"zhipu-coding-plan": "ZHIPU_API_KEY",
 	mistral: "MISTRAL_API_KEY",
 	minimax: "MINIMAX_API_KEY",
+	"minimax-cn": () => $pickenv("MINIMAX_CN_API_KEY", "MINIMAX_CODE_CN_API_KEY"),
 	"minimax-code": "MINIMAX_CODE_API_KEY",
 	"minimax-code-cn": "MINIMAX_CODE_CN_API_KEY",
 	"opencode-go": "OPENCODE_API_KEY",

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -125,6 +125,7 @@ export type KnownProvider =
 	| "zhipu-coding-plan"
 	| "mistral"
 	| "minimax"
+	| "minimax-cn"
 	| "opencode-go"
 	| "opencode-zen"
 	| "synthetic"

--- a/packages/ai/src/utils/oauth/api-key-validation.ts
+++ b/packages/ai/src/utils/oauth/api-key-validation.ts
@@ -5,6 +5,13 @@ type OpenAICompatibleValidationOptions = {
 	model: string;
 	signal?: AbortSignal;
 };
+type AnthropicCompatibleValidationOptions = {
+	provider: string;
+	apiKey: string;
+	baseUrl: string;
+	model: string;
+	signal?: AbortSignal;
+};
 
 type ModelListValidationOptions = {
 	provider: string;
@@ -35,6 +42,48 @@ export async function validateOpenAICompatibleApiKey(options: OpenAICompatibleVa
 			messages: [{ role: "user", content: "ping" }],
 			max_tokens: 1,
 			temperature: 0,
+		}),
+		signal,
+	});
+
+	if (response.ok) {
+		return;
+	}
+
+	let details = "";
+	try {
+		details = (await response.text()).trim();
+	} catch {
+		// ignore body parse errors, status is enough
+	}
+
+	const message = details
+		? `${options.provider} API key validation failed (${response.status}): ${details}`
+		: `${options.provider} API key validation failed (${response.status})`;
+	throw new Error(message);
+}
+
+/**
+ * Validate an API key against an Anthropic-compatible Messages endpoint.
+ *
+ * Performs a minimal request to verify credentials and endpoint access.
+ */
+export async function validateAnthropicCompatibleApiKey(options: AnthropicCompatibleValidationOptions): Promise<void> {
+	const timeoutSignal = AbortSignal.timeout(VALIDATION_TIMEOUT_MS);
+	const signal = options.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal;
+
+	const response = await fetch(`${options.baseUrl}/v1/messages`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			"Anthropic-Version": "2023-06-01",
+			"Anthropic-Dangerous-Direct-Browser-Access": "true",
+			"X-Api-Key": options.apiKey,
+		},
+		body: JSON.stringify({
+			model: options.model,
+			messages: [{ role: "user", content: "ping" }],
+			max_tokens: 1,
 		}),
 		signal,
 	});

--- a/packages/ai/src/utils/oauth/index.ts
+++ b/packages/ai/src/utils/oauth/index.ts
@@ -88,13 +88,23 @@ const builtInOAuthProviders: OAuthProviderInfo[] = [
 		available: true,
 	},
 	{
+		id: "minimax",
+		name: "MiniMax Token Plan (International)",
+		available: true,
+	},
+	{
+		id: "minimax-cn",
+		name: "MiniMax Token Plan (China)",
+		available: true,
+	},
+	{
 		id: "minimax-code",
-		name: "MiniMax Coding Plan (International)",
+		name: "MiniMax OpenAI-compatible Token Plan (International)",
 		available: true,
 	},
 	{
 		id: "minimax-code-cn",
-		name: "MiniMax Coding Plan (China)",
+		name: "MiniMax OpenAI-compatible Token Plan (China)",
 		available: true,
 	},
 	{
@@ -368,6 +378,8 @@ export async function refreshOAuthToken(
 		case "zhipu-coding-plan":
 		case "qianfan":
 		case "venice":
+		case "minimax":
+		case "minimax-cn":
 		case "minimax-code":
 		case "minimax-code-cn":
 		case "moonshot":

--- a/packages/ai/src/utils/oauth/minimax-code.ts
+++ b/packages/ai/src/utils/oauth/minimax-code.ts
@@ -1,54 +1,53 @@
 /**
  * MiniMax Coding Plan login flow.
  *
- * MiniMax Coding Plan is a subscription service that provides access to
- * MiniMax models (M2, M2.1) through an OpenAI-compatible API.
+ * MiniMax Token Plan is a subscription service that provides access to
+ * MiniMax models through MiniMax's regional OpenAI- and Anthropic-compatible APIs.
  *
  * This is not OAuth - it's a simple API key flow:
  * 1. Open browser to the matching regional MiniMax subscription page
  * 2. User subscribes and copies their API key
  * 3. User pastes the API key back into the CLI
  *
- * International: https://api.minimax.io/v1
- * China: https://api.minimaxi.com/v1
+ * International OpenAI-compatible: https://api.minimax.io/v1
+ * China OpenAI-compatible: https://api.minimaxi.com/v1
+ * International Anthropic-compatible: https://api.minimax.io/anthropic
+ * China Anthropic-compatible: https://api.minimaxi.com/anthropic
  */
 
-import { validateOpenAICompatibleApiKey } from "./api-key-validation";
+import { validateAnthropicCompatibleApiKey, validateOpenAICompatibleApiKey } from "./api-key-validation";
 import type { OAuthController } from "./types";
 
-const AUTH_URL_INTL = "https://platform.minimax.io/subscribe/coding-plan";
-const AUTH_URL_CN = "https://platform.minimaxi.com/subscribe/coding-plan";
-const API_BASE_URL_INTL = "https://api.minimax.io/v1";
-const API_BASE_URL_CN = "https://api.minimaxi.com/v1";
-const VALIDATION_MODEL = "MiniMax-M2";
+const AUTH_URL_INTL = "https://platform.minimax.io/subscribe/token-plan";
+const AUTH_URL_CN = "https://platform.minimaxi.com/subscribe/token-plan";
+const OPENAI_API_BASE_URL_INTL = "https://api.minimax.io/v1";
+const OPENAI_API_BASE_URL_CN = "https://api.minimaxi.com/v1";
+const ANTHROPIC_API_BASE_URL_INTL = "https://api.minimax.io/anthropic";
+const ANTHROPIC_API_BASE_URL_CN = "https://api.minimaxi.com/anthropic";
+const OPENAI_VALIDATION_MODEL = "MiniMax-M2";
+const ANTHROPIC_VALIDATION_MODEL = "MiniMax-M3";
 
 /**
- * Login to MiniMax Coding Plan (international).
+ * Login to MiniMax OpenAI-compatible Token Plan (international).
  *
  * Opens browser to subscription page, prompts user to paste their API key.
  * Returns the API key directly (not OAuthCredentials - this isn't OAuth).
  */
 export async function loginMiniMaxCode(options: OAuthController): Promise<string> {
-	return loginMiniMaxCodeWithBaseUrl(options, AUTH_URL_INTL, API_BASE_URL_INTL, "MiniMax Coding Plan");
+	return loginMiniMaxOpenAICompatiblePlan(options, AUTH_URL_INTL, OPENAI_API_BASE_URL_INTL, "MiniMax Token Plan");
 }
 
-async function loginMiniMaxCodeWithBaseUrl(
-	options: OAuthController,
-	authUrl: string,
-	baseUrl: string,
-	providerName: string,
-): Promise<string> {
+async function promptMiniMaxApiKey(options: OAuthController, authUrl: string): Promise<string> {
 	if (!options.onPrompt) {
-		throw new Error("MiniMax Coding Plan login requires onPrompt callback");
+		throw new Error("MiniMax Token Plan login requires onPrompt callback");
 	}
-	// Open browser to subscription page
 	options.onAuth?.({
 		url: authUrl,
-		instructions: "Subscribe to Coding Plan and copy your API key",
+		instructions: "Subscribe to Token Plan and copy your API key",
 	});
 	// Prompt user to paste their API key
 	const apiKey = await options.onPrompt({
-		message: "Paste your MiniMax Coding Plan API key",
+		message: "Paste your MiniMax Token Plan API key",
 		placeholder: "sk-...",
 	});
 	if (options.signal?.aborted) {
@@ -58,16 +57,45 @@ async function loginMiniMaxCodeWithBaseUrl(
 	if (!trimmed) {
 		throw new Error("API key is required");
 	}
+	return trimmed;
+}
+
+async function loginMiniMaxOpenAICompatiblePlan(
+	options: OAuthController,
+	authUrl: string,
+	baseUrl: string,
+	providerName: string,
+): Promise<string> {
+	const apiKey = await promptMiniMaxApiKey(options, authUrl);
 
 	options.onProgress?.("Validating API key...");
 	await validateOpenAICompatibleApiKey({
 		provider: providerName,
-		apiKey: trimmed,
+		apiKey,
 		baseUrl,
-		model: VALIDATION_MODEL,
+		model: OPENAI_VALIDATION_MODEL,
 		signal: options.signal,
 	});
-	return trimmed;
+	return apiKey;
+}
+
+async function loginMiniMaxAnthropicCompatiblePlan(
+	options: OAuthController,
+	authUrl: string,
+	baseUrl: string,
+	providerName: string,
+): Promise<string> {
+	const apiKey = await promptMiniMaxApiKey(options, authUrl);
+
+	options.onProgress?.("Validating API key...");
+	await validateAnthropicCompatibleApiKey({
+		provider: providerName,
+		apiKey,
+		baseUrl,
+		model: ANTHROPIC_VALIDATION_MODEL,
+		signal: options.signal,
+	});
+	return apiKey;
 }
 
 /**
@@ -76,5 +104,25 @@ async function loginMiniMaxCodeWithBaseUrl(
  * Same flow as international but uses China endpoint.
  */
 export async function loginMiniMaxCodeCn(options: OAuthController): Promise<string> {
-	return loginMiniMaxCodeWithBaseUrl(options, AUTH_URL_CN, API_BASE_URL_CN, "MiniMax Coding Plan (China)");
+	return loginMiniMaxOpenAICompatiblePlan(options, AUTH_URL_CN, OPENAI_API_BASE_URL_CN, "MiniMax Token Plan (China)");
+}
+
+/** Login to MiniMax Token Plan through the Anthropic-compatible international endpoint. */
+export async function loginMiniMaxTokenPlan(options: OAuthController): Promise<string> {
+	return loginMiniMaxAnthropicCompatiblePlan(
+		options,
+		AUTH_URL_INTL,
+		ANTHROPIC_API_BASE_URL_INTL,
+		"MiniMax Token Plan",
+	);
+}
+
+/** Login to MiniMax Token Plan through the Anthropic-compatible China endpoint. */
+export async function loginMiniMaxTokenPlanCn(options: OAuthController): Promise<string> {
+	return loginMiniMaxAnthropicCompatiblePlan(
+		options,
+		AUTH_URL_CN,
+		ANTHROPIC_API_BASE_URL_CN,
+		"MiniMax Token Plan (China)",
+	);
 }

--- a/packages/ai/src/utils/oauth/types.ts
+++ b/packages/ai/src/utils/oauth/types.ts
@@ -27,6 +27,8 @@ export type OAuthProvider =
 	| "kagi"
 	| "litellm"
 	| "lm-studio"
+	| "minimax"
+	| "minimax-cn"
 	| "minimax-code"
 	| "minimax-code-cn"
 	| "moonshot"

--- a/packages/ai/test/issue-1790-repro.test.ts
+++ b/packages/ai/test/issue-1790-repro.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import { MODELS_DEV_PROVIDER_DESCRIPTORS, mapModelsDevToModels } from "../src/provider-models/openai-compat";
+
+const minimaxM3ModelsDevPayload: Record<string, unknown> = {
+	"minimax-coding-plan": {
+		models: {
+			"MiniMax-M3": {
+				id: "MiniMax-M3",
+				name: "MiniMax-M3",
+				reasoning: true,
+				tool_call: true,
+				modalities: {
+					input: ["text", "image", "video"],
+					output: ["text"],
+				},
+				limit: {
+					context: 512000,
+					output: 128000,
+				},
+				cost: {
+					input: 0,
+					output: 0,
+					cache_read: 0,
+					cache_write: 0,
+				},
+			},
+		},
+	},
+	"minimax-cn-coding-plan": {
+		models: {
+			"MiniMax-M3": {
+				id: "MiniMax-M3",
+				name: "MiniMax-M3",
+				reasoning: true,
+				tool_call: true,
+				modalities: {
+					input: ["text", "image", "video"],
+					output: ["text"],
+				},
+				limit: {
+					context: 512000,
+					output: 128000,
+				},
+				cost: {
+					input: 0,
+					output: 0,
+					cache_read: 0,
+					cache_write: 0,
+				},
+			},
+		},
+	},
+};
+
+const cases: readonly [provider: "minimax-code" | "minimax-code-cn", baseUrl: string][] = [
+	["minimax-code", "https://api.minimax.io/v1"],
+	["minimax-code-cn", "https://api.minimaxi.com/v1"],
+];
+
+describe("MiniMax Coding Plan model mapping (issue #1790)", () => {
+	test.each(cases)("maps MiniMax-M3 for %s", (provider, baseUrl) => {
+		const models = mapModelsDevToModels(minimaxM3ModelsDevPayload, MODELS_DEV_PROVIDER_DESCRIPTORS);
+		const model = models.find(candidate => candidate.provider === provider && candidate.id === "MiniMax-M3");
+
+		expect(model).toEqual({
+			id: "MiniMax-M3",
+			name: "MiniMax-M3",
+			api: "openai-completions",
+			provider,
+			baseUrl,
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+			},
+			contextWindow: 512000,
+			maxTokens: 128000,
+			compat: {
+				supportsStore: false,
+				supportsDeveloperRole: false,
+				supportsReasoningEffort: false,
+				reasoningContentField: "reasoning_content",
+			},
+		});
+	});
+});

--- a/packages/ai/test/minimax-code-login.test.ts
+++ b/packages/ai/test/minimax-code-login.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import { hookFetch } from "@oh-my-pi/pi-utils";
-import { loginMiniMaxCode, loginMiniMaxCodeCn } from "../src/utils/oauth/minimax-code";
+import {
+	loginMiniMaxCode,
+	loginMiniMaxCodeCn,
+	loginMiniMaxTokenPlan,
+	loginMiniMaxTokenPlanCn,
+} from "../src/utils/oauth/minimax-code";
 
-describe("MiniMax Coding Plan login", () => {
+describe("MiniMax Token Plan login", () => {
 	it("opens the international platform and validates against the international API", async () => {
 		const authUrls: string[] = [];
 		const validationUrls: string[] = [];
@@ -18,7 +23,7 @@ describe("MiniMax Coding Plan login", () => {
 		});
 
 		expect(apiKey).toBe("sk-intl");
-		expect(authUrls).toEqual(["https://platform.minimax.io/subscribe/coding-plan"]);
+		expect(authUrls).toEqual(["https://platform.minimax.io/subscribe/token-plan"]);
 		expect(validationUrls).toEqual(["https://api.minimax.io/v1/chat/completions"]);
 	});
 
@@ -37,7 +42,47 @@ describe("MiniMax Coding Plan login", () => {
 		});
 
 		expect(apiKey).toBe("sk-cn");
-		expect(authUrls).toEqual(["https://platform.minimaxi.com/subscribe/coding-plan"]);
+		expect(authUrls).toEqual(["https://platform.minimaxi.com/subscribe/token-plan"]);
 		expect(validationUrls).toEqual(["https://api.minimaxi.com/v1/chat/completions"]);
+	});
+
+	it("validates the international Anthropic-compatible Token Plan API", async () => {
+		const validationUrls: string[] = [];
+		let validationBody = "";
+
+		using _hook = hookFetch((input, init) => {
+			validationUrls.push(String(input));
+			validationBody = String(init?.body ?? "");
+			return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+		});
+
+		const apiKey = await loginMiniMaxTokenPlan({
+			onAuth: () => {},
+			onPrompt: async () => "  sk-intl  ",
+		});
+
+		expect(apiKey).toBe("sk-intl");
+		expect(validationUrls).toEqual(["https://api.minimax.io/anthropic/v1/messages"]);
+		expect(JSON.parse(validationBody)).toMatchObject({ model: "MiniMax-M3", max_tokens: 1 });
+	});
+
+	it("validates the China Anthropic-compatible Token Plan API", async () => {
+		const validationUrls: string[] = [];
+		let validationBody = "";
+
+		using _hook = hookFetch((input, init) => {
+			validationUrls.push(String(input));
+			validationBody = String(init?.body ?? "");
+			return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+		});
+
+		const apiKey = await loginMiniMaxTokenPlanCn({
+			onAuth: () => {},
+			onPrompt: async () => "  sk-cn  ",
+		});
+
+		expect(apiKey).toBe("sk-cn");
+		expect(validationUrls).toEqual(["https://api.minimaxi.com/anthropic/v1/messages"]);
+		expect(JSON.parse(validationBody)).toMatchObject({ model: "MiniMax-M3", max_tokens: 1 });
 	});
 });

--- a/packages/coding-agent/test/auth-storage-minimax-login.test.ts
+++ b/packages/coding-agent/test/auth-storage-minimax-login.test.ts
@@ -24,7 +24,7 @@ describe("AuthStorage MiniMax login", () => {
 		}
 	});
 
-	test("replaces existing MiniMax Coding Plan API key on relogin", async () => {
+	test("replaces existing MiniMax OpenAI-compatible Token Plan API key on relogin", async () => {
 		using _hook = hookFetch(
 			() => new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } }),
 		);
@@ -42,9 +42,56 @@ describe("AuthStorage MiniMax login", () => {
 			type: "api_key",
 			key: "sk-new",
 		});
+		expect(authStorage.get("minimax")).toEqual({
+			type: "api_key",
+			key: "sk-new",
+		});
 		expect(authStorage.getAll()["minimax-code"]).toEqual({
 			type: "api_key",
 			key: "sk-new",
+		});
+	});
+
+	test("MiniMax CN OpenAI-compatible login also unlocks the Anthropic Token Plan provider", async () => {
+		using _hook = hookFetch(
+			() => new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } }),
+		);
+
+		await authStorage.login("minimax-code-cn", {
+			onAuth: () => {},
+			onPrompt: async () => "sk-cn",
+		});
+
+		expect(authStorage.get("minimax-code-cn")).toEqual({
+			type: "api_key",
+			key: "sk-cn",
+		});
+		expect(authStorage.get("minimax-cn")).toEqual({
+			type: "api_key",
+			key: "sk-cn",
+		});
+		expect(await authStorage.getApiKey("minimax-cn")).toBe("sk-cn");
+	});
+
+	test("MiniMax CN Token Plan login validates the Anthropic endpoint", async () => {
+		const validationUrls: string[] = [];
+		let validationBody = "";
+		using _hook = hookFetch((input, init) => {
+			validationUrls.push(String(input));
+			validationBody = String(init?.body ?? "");
+			return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+		});
+
+		await authStorage.login("minimax-cn", {
+			onAuth: () => {},
+			onPrompt: async () => "sk-cn",
+		});
+
+		expect(validationUrls).toEqual(["https://api.minimaxi.com/anthropic/v1/messages"]);
+		expect(JSON.parse(validationBody)).toMatchObject({ model: "MiniMax-M3", max_tokens: 1 });
+		expect(authStorage.get("minimax-cn")).toEqual({
+			type: "api_key",
+			key: "sk-cn",
 		});
 	});
 });

--- a/packages/coding-agent/test/auth-storage-minimax-login.test.ts
+++ b/packages/coding-agent/test/auth-storage-minimax-login.test.ts
@@ -99,4 +99,21 @@ describe("AuthStorage MiniMax login", () => {
 		});
 		expect(await authStorage.getApiKey("minimax-code-cn")).toBe("sk-cn");
 	});
+
+	test("MiniMax Token Plan logout removes mirrored provider credentials", async () => {
+		using _hook = hookFetch(
+			() => new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } }),
+		);
+
+		await authStorage.login("minimax-cn", {
+			onAuth: () => {},
+			onPrompt: async () => "sk-cn",
+		});
+		await authStorage.logout("minimax-cn");
+
+		expect(authStorage.get("minimax-cn")).toBeUndefined();
+		expect(authStorage.get("minimax-code-cn")).toBeUndefined();
+		expect(await authStorage.getApiKey("minimax-cn")).toBeUndefined();
+		expect(await authStorage.getApiKey("minimax-code-cn")).toBeUndefined();
+	});
 });

--- a/packages/coding-agent/test/auth-storage-minimax-login.test.ts
+++ b/packages/coding-agent/test/auth-storage-minimax-login.test.ts
@@ -93,5 +93,10 @@ describe("AuthStorage MiniMax login", () => {
 			type: "api_key",
 			key: "sk-cn",
 		});
+		expect(authStorage.get("minimax-code-cn")).toEqual({
+			type: "api_key",
+			key: "sk-cn",
+		});
+		expect(await authStorage.getApiKey("minimax-code-cn")).toBe("sk-cn");
 	});
 });

--- a/packages/coding-agent/test/issue-1790-minimax-token-plan.test.ts
+++ b/packages/coding-agent/test/issue-1790-minimax-token-plan.test.ts
@@ -62,4 +62,22 @@ describe("MiniMax Token Plan catalog availability (issue #1790)", () => {
 			maxTokens: 128000,
 		});
 	});
+
+	test("CN Token Plan logout removes the mirrored OpenAI-compatible M3 SKU", async () => {
+		using _hook = hookFetch(
+			() => new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } }),
+		);
+		await authStorage.login("minimax-cn", {
+			onAuth: () => {},
+			onPrompt: async () => "sk-cn",
+		});
+		await authStorage.logout("minimax-cn");
+
+		const registry = new ModelRegistry(authStorage, path.join(tempDir, "models.json"));
+		const model = registry
+			.getAvailable()
+			.find(candidate => candidate.provider === "minimax-code-cn" && candidate.id === "MiniMax-M3");
+
+		expect(model).toBeUndefined();
+	});
 });

--- a/packages/coding-agent/test/issue-1790-minimax-token-plan.test.ts
+++ b/packages/coding-agent/test/issue-1790-minimax-token-plan.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
-import { Snowflake } from "@oh-my-pi/pi-utils";
+import { hookFetch, Snowflake } from "@oh-my-pi/pi-utils";
 
 describe("MiniMax Token Plan catalog availability (issue #1790)", () => {
 	let tempDir: string;
@@ -35,6 +35,29 @@ describe("MiniMax Token Plan catalog availability (issue #1790)", () => {
 			api: "anthropic-messages",
 			provider: "minimax-cn",
 			baseUrl: "https://api.minimaxi.com/anthropic",
+			contextWindow: 512000,
+			maxTokens: 128000,
+		});
+	});
+
+	test("a CN Anthropic-compatible Token Plan login makes the CN OpenAI-compatible M3 SKU selectable", async () => {
+		using _hook = hookFetch(
+			() => new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } }),
+		);
+		await authStorage.login("minimax-cn", {
+			onAuth: () => {},
+			onPrompt: async () => "sk-cn",
+		});
+
+		const registry = new ModelRegistry(authStorage, path.join(tempDir, "models.json"));
+		const model = registry
+			.getAvailable()
+			.find(candidate => candidate.provider === "minimax-code-cn" && candidate.id === "MiniMax-M3");
+
+		expect(model).toMatchObject({
+			api: "openai-completions",
+			provider: "minimax-code-cn",
+			baseUrl: "https://api.minimaxi.com/v1",
 			contextWindow: 512000,
 			maxTokens: 128000,
 		});

--- a/packages/coding-agent/test/issue-1790-minimax-token-plan.test.ts
+++ b/packages/coding-agent/test/issue-1790-minimax-token-plan.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+
+describe("MiniMax Token Plan catalog availability (issue #1790)", () => {
+	let tempDir: string;
+	let authStorage: AuthStorage;
+
+	beforeEach(async () => {
+		tempDir = path.join(os.tmpdir(), `pi-test-minimax-token-plan-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
+	});
+
+	afterEach(() => {
+		authStorage.close();
+		if (tempDir && fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true });
+		}
+	});
+
+	test("a stored CN OpenAI-compatible Token Plan key makes the CN Anthropic M3 SKU selectable", async () => {
+		await authStorage.set("minimax-code-cn", { type: "api_key", key: "sk-cn" });
+
+		const registry = new ModelRegistry(authStorage, path.join(tempDir, "models.json"));
+		const model = registry
+			.getAvailable()
+			.find(candidate => candidate.provider === "minimax-cn" && candidate.id === "MiniMax-M3");
+
+		expect(model).toMatchObject({
+			api: "anthropic-messages",
+			provider: "minimax-cn",
+			baseUrl: "https://api.minimaxi.com/anthropic",
+			contextWindow: 512000,
+			maxTokens: 128000,
+		});
+	});
+});

--- a/packages/coding-agent/test/issue-1790-minimax-token-plan.test.ts
+++ b/packages/coding-agent/test/issue-1790-minimax-token-plan.test.ts
@@ -63,6 +63,24 @@ describe("MiniMax Token Plan catalog availability (issue #1790)", () => {
 		});
 	});
 
+	test("a CN Anthropic-compatible Token Plan config key makes the CN OpenAI-compatible M3 SKU selectable", async () => {
+		authStorage.setConfigApiKey("minimax-cn", "sk-cn");
+
+		const registry = new ModelRegistry(authStorage, path.join(tempDir, "models.json"));
+		const model = registry
+			.getAvailable()
+			.find(candidate => candidate.provider === "minimax-code-cn" && candidate.id === "MiniMax-M3");
+
+		expect(model).toMatchObject({
+			api: "openai-completions",
+			provider: "minimax-code-cn",
+			baseUrl: "https://api.minimaxi.com/v1",
+			contextWindow: 512000,
+			maxTokens: 128000,
+		});
+		expect(await authStorage.getApiKey("minimax-code-cn")).toBe("sk-cn");
+	});
+
 	test("CN Token Plan logout removes the mirrored OpenAI-compatible M3 SKU", async () => {
 		using _hook = hookFetch(
 			() => new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } }),


### PR DESCRIPTION
## Repro
The MiniMax CN Coding Plan selector could not show MiniMax M3 because the bundled catalog was missing that id. Reproduced with `bun -e 'import { getBundledModel } from "./packages/ai/src/models.ts"; const model = getBundledModel("minimax-code-cn", "MiniMax-M3"); console.log(model ? JSON.stringify(model) : "missing"); process.exit(model ? 0 : 1);'`, which printed `missing` and exited 1 before the fix.

## Cause
`packages/ai/src/models.json` was generated from an older `models.dev` snapshot where `minimax-coding-plan` and `minimax-cn-coding-plan` did not yet include `MiniMax-M3`; the existing `MODELS_DEV_PROVIDER_DESCRIPTORS_CODING_PLANS` mapping in `packages/ai/src/provider-models/openai-compat.ts` already maps those providers correctly when the upstream entry exists.

## Fix
- Regenerated `packages/ai/src/models.json` from the current models.dev catalog so `MiniMax-M3` is bundled for `minimax-code` and `minimax-code-cn`.
- Added `packages/ai/test/issue-1790-repro.test.ts` to assert the MiniMax M3 models.dev entries map to the OpenAI-compatible Coding Plan providers with the expected base URLs and limits.
- Added the fix to `packages/ai/CHANGELOG.md`.

## Verification
Ran `bun --cwd=packages/ai test test/issue-1790-repro.test.ts` (2 pass), `bun --cwd=packages/ai run check` (Biome and tsgo pass), and reran the repro command, which now prints `MiniMax-M3 minimax-code-cn 512000` and exits 0. Fixes #1790