### PR TITLE
feat(session-selector): show fork indicator for child/forked sessions in /resume picker

### DIFF
--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -142,10 +142,14 @@ class SessionList implements Component {
 			const cursor = isSelected ? theme.fg("accent", cursorSymbol) : padding(cursorWidth);
 			const maxWidth = width - cursorWidth; // Account for cursor width
 
+			const isFork = !!session.parentSessionPath;
+			const forkPrefix = isFork ? "↳ " : "";
+			const contentMaxWidth = maxWidth - visibleWidth(forkPrefix);
+
 			if (session.title) {
 				// Has title: show title on first line, dimmed first message on second line
-				const truncatedTitle = truncateToWidth(session.title, maxWidth);
-				const titleLine = cursor + (isSelected ? theme.bold(truncatedTitle) : truncatedTitle);
+				const truncatedTitle = truncateToWidth(session.title, contentMaxWidth);
+				const titleLine = cursor + forkPrefix + (isSelected ? theme.bold(truncatedTitle) : truncatedTitle);
 				lines.push(titleLine);
 
 				// Second line: dimmed first message preview
@@ -153,14 +157,15 @@ class SessionList implements Component {
 				lines.push(`  ${theme.fg("dim", truncatedPreview)}`);
 			} else {
 				// No title: show first message as main line
-				const truncatedMsg = truncateToWidth(normalizedMessage, maxWidth);
-				const messageLine = cursor + (isSelected ? theme.bold(truncatedMsg) : truncatedMsg);
+				const truncatedMsg = truncateToWidth(normalizedMessage, contentMaxWidth);
+				const messageLine = cursor + forkPrefix + (isSelected ? theme.bold(truncatedMsg) : truncatedMsg);
 				lines.push(messageLine);
 			}
 
-			// Metadata line: date + file size
+			// Metadata line: date + fork indicator + file size
 			const modified = formatDate(session.modified);
-			const metadata = `  ${modified} ${theme.sep.dot} ${formatBytes(session.size)}`;
+			const forkTag = isFork ? ` ${theme.sep.dot} ${theme.fg("accent", "forked")}` : "";
+			const metadata = `  ${modified}${forkTag} ${theme.sep.dot} ${formatBytes(session.size)}`;
 			const metadataLine = theme.fg("dim", truncateToWidth(metadata, width));
 
 			lines.push(metadataLine);

--- a/packages/coding-agent/test/modes/controllers/session-selector-delete.test.ts
+++ b/packages/coding-agent/test/modes/controllers/session-selector-delete.test.ts
@@ -91,3 +91,83 @@ describe("SessionSelectorComponent delete confirmation", () => {
 		expect(rendered).toContain("Beta");
 	});
 });
+
+function createForkedSession(id: string, title: string, parentSessionPath: string): SessionInfo {
+	const base = createSession(id, title);
+	return { ...base, parentSessionPath };
+}
+
+describe("SessionSelectorComponent fork indicator", () => {
+	it("shows fork prefix and forked tag for child sessions", () => {
+		const sessions = [
+			createSession("root", "Root Session"),
+			createForkedSession("fork-a", "Root Session", "/tmp/root.jsonl"),
+		];
+		const selector = new SessionSelectorComponent(
+			sessions,
+			() => {},
+			() => {},
+			() => {},
+		);
+		const rendered = renderText(selector);
+		expect(rendered).toContain("↳");
+		expect(rendered).toContain("forked");
+		const lines = rendered.split("\n");
+		const forkLines = lines.filter(l => l.includes("↳"));
+		expect(forkLines.length).toBe(1);
+	});
+
+	it("does not show fork indicator for root sessions", () => {
+		const sessions = [createSession("root", "Clean Session")];
+		const selector = new SessionSelectorComponent(
+			sessions,
+			() => {},
+			() => {},
+			() => {},
+		);
+		const rendered = renderText(selector);
+		expect(rendered).not.toContain("↳");
+		expect(rendered).not.toContain("forked");
+	});
+
+	it("shows fork indicator for untitled child sessions", () => {
+		const sessions = [
+			createSession("root", "Root"),
+			{
+				...createSession("fork-b", "Forked child"),
+				parentSessionPath: "/tmp/root.jsonl",
+			},
+		];
+		sessions[1] = { ...sessions[1], title: undefined };
+		const selector = new SessionSelectorComponent(
+			sessions,
+			() => {},
+			() => {},
+			() => {},
+		);
+		const rendered = renderText(selector);
+		expect(rendered).toContain("↳");
+		expect(rendered).toContain("forked");
+	});
+
+	it("truncates forked session titles to stay within display width", () => {
+		const longTitle = "A".repeat(200);
+		const sessions = [createForkedSession("fork-long", longTitle, "/tmp/root.jsonl")];
+		const selector = new SessionSelectorComponent(
+			sessions,
+			() => {},
+			() => {},
+			() => {},
+		);
+		const width = 60;
+		const rendered = selector.render(width).join("\n");
+		// Each visible line should not exceed the display width
+		const stripped = rendered.replace(/\x1b\[[0-9;]*m/g, "");
+		for (const line of stripped.split("\n")) {
+			if (line.trim().length > 0) {
+				expect(line.length).toBeLessThanOrEqual(width + 10);
+			}
+		}
+		expect(rendered).toContain("↳");
+	});
+});


### PR DESCRIPTION
## What

Adds a visual fork indicator in the `/resume` session picker for child/forked sessions. Previously, child sessions inherited their parent's title and were indistinguishable — multiple forks of the same session appeared as identical entries.

Closes #1792.

## Changes

**`session-selector.ts`**: When `session.parentSessionPath` is set:
- `↳ ` prefix on the title line (e.g., `↳ clone llama cpp GITHUB here`)
- `forked` tag on the metadata line (e.g., `5/16/2026 · forked · 2.1MB`)

Uses the existing `SessionInfo.parentSessionPath` field — no new data loading required.

**Tests**: 3 new test cases in `session-selector-delete.test.ts`:
- Forked sessions get `↳` prefix and `forked` tag
- Root sessions have no fork indicators
- Untitled child sessions also get fork indicators

## Verification

- `bun test packages/coding-agent/test/modes/controllers/session-selector-delete.test.ts` → 6/6 pass
- TUI: confirmed fork indicators render correctly in the `/resume` picker