### PR TITLE
fix(coding-agent): mark forked sessions in resume picker

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/resume` rendering forked child sessions without a fork tag, making them indistinguishable from their parent when titles match ([#1792](https://github.com/can1357/oh-my-pi/issues/1792)).
+
 ## [15.8.2] - 2026-06-03
 
 ### Added

--- a/packages/coding-agent/src/modes/components/session-selector.ts
+++ b/packages/coding-agent/src/modes/components/session-selector.ts
@@ -230,6 +230,9 @@ class SessionList implements Component {
 			// Metadata line: date + file size (+ project dir in all-projects scope)
 			const modified = formatDate(session.modified);
 			let metadata = `  ${modified} ${theme.sep.dot} ${formatBytes(session.size)}`;
+			if (session.parentSessionPath) {
+				metadata += ` ${theme.sep.dot} ${theme.icon.branch} fork`;
+			}
 			if (this.#showCwd && session.cwd) {
 				metadata += ` ${theme.sep.dot} ${shortenPath(session.cwd)}`;
 			}

--- a/packages/coding-agent/test/modes/components/session-selector-scope.test.ts
+++ b/packages/coding-agent/test/modes/components/session-selector-scope.test.ts
@@ -3,11 +3,11 @@ import { SessionSelectorComponent } from "../../../src/modes/components/session-
 import { initTheme } from "../../../src/modes/theme/theme";
 import type { SessionInfo } from "../../../src/session/session-manager";
 
-beforeAll(() => {
-	initTheme();
+beforeAll(async () => {
+	await initTheme();
 });
 
-function createSession(id: string, title: string, cwd: string): SessionInfo {
+function createSession(id: string, title: string, cwd: string, parentSessionPath?: string): SessionInfo {
 	return {
 		path: `${cwd}/${id}.jsonl`,
 		id,
@@ -19,6 +19,7 @@ function createSession(id: string, title: string, cwd: string): SessionInfo {
 		size: 0,
 		firstMessage: `${title} first message`,
 		allMessagesText: `${title} first message`,
+		...(parentSessionPath ? { parentSessionPath } : {}),
 	};
 }
 
@@ -103,5 +104,22 @@ describe("SessionSelectorComponent scope toggle", () => {
 		const rendered = selector.render(120).join("\n");
 		expect(rendered).toContain("(all projects)");
 		expect(rendered).toContain("other-project");
+	});
+
+	it("marks forked child sessions in the rendered list", () => {
+		const parent = createSession("root", "Incident", "/work/current");
+		const child = createSession("child", "Incident", "/work/current", parent.path);
+		const selector = new SessionSelectorComponent(
+			[parent, child],
+			() => {},
+			() => {},
+			() => {},
+		);
+
+		const rendered = selector.render(120).join("\n");
+		const forkLines = rendered.split("\n").filter(line => line.includes("fork"));
+
+		expect(forkLines).toHaveLength(1);
+		expect(forkLines[0]).toContain("fork");
 	});
 });


### PR DESCRIPTION
## Repro
A parent and child `SessionInfo` with the same title render as identical `/resume` picker rows even when the child has `parentSessionPath` set. Reproduced with `bun --eval "$REPRO"`, which printed two identical `Investigate outage` entries and `fork indicator present: false` before the fix.

## Cause
`packages/coding-agent/src/modes/components/session-selector.ts` builds each picker row in `SessionList.render()` from title/preview/date/size/cwd only. The session loader already maps the header parent into `SessionInfo.parentSessionPath`, but the renderer never consulted that field.

## Fix
- Added a fork metadata tag for rows whose `SessionInfo.parentSessionPath` is populated.
- Added a focused component test proving only the child row renders the fork marker when parent and child titles match.
- Added the fix to the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/modes/components/session-selector-scope.test.ts` passed with 4 tests. The original `bun --eval "$REPRO"` scenario now prints `fork indicator present: true`. Fixes #1792