### PR TITLE
fix(tui): defer VTE SSH scrollback erases

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changed
 
-- Changed native-scrollback safety defaults to treat unknown POSIX, SSH, and multiplexer-shaped terminals as ED3-risk for passive rendering; checkpoint replay now requires a positive at-tail viewport proof instead of assuming prompt submit makes host scrollback safe.
+- Changed native-scrollback safety defaults to treat unknown POSIX, SSH, and multiplexer-shaped terminals as ED3-risk for passive rendering; checkpoint replay now requires a positive at-tail viewport proof instead of assuming prompt submit makes host scrollback safe ([#1799](https://github.com/can1357/oh-my-pi/issues/1799)).
 - Changed synchronized-output defaults to a conservative opt-in profile: DEC 2026 paint wrappers stay disabled for remote/multiplexer/VTE/unknown terminals unless explicitly forced, while the autowrap guards remain active.
 
 ### Fixed


### PR DESCRIPTION
## Repro
A Linux session that has only `COLORTERM=truecolor` from a VTE/Ptyxis-style terminal missed ED3-risk detection: `bun -e 'import { detectTerminalEagerEraseScrollbackRisk } from "./packages/tui/src/terminal-capabilities.ts"; const risk = detectTerminalEagerEraseScrollbackRisk({ COLORTERM: "truecolor" }, "linux"); console.log(`risk=${risk}`); if (risk !== true) process.exit(1);'` printed `risk=false` before the fix.

## Cause
`detectTerminalEagerEraseScrollbackRisk()` in `packages/tui/src/terminal-capabilities.ts` only treated explicit terminal variables such as `VTE_VERSION`, `KITTY_WINDOW_ID`, or `TERM_PROGRAM` values as unsafe for eager ED3 scrollback rebuilds. SSH sessions can drop `VTE_VERSION`, so Linux VTE/Ptyxis-style sessions that still expose only `COLORTERM=truecolor` fell through to `false`, allowing `TUI` render planning in `packages/tui/src/tui.ts` to emit eager `CSI 3 J` rebuilds during streaming.

## Fix
- Added a shared `COLORTERM` truecolor helper and used it for terminal ID fallback parsing.
- Treat Linux `COLORTERM=truecolor`/`24bit` sessions as ED3-risk after stronger terminal identifiers have been checked, while keeping native Windows and explicit VS Code sessions off that path.
- Added regression coverage for the Linux truecolor fallback, Windows opt-out, and non-Linux behavior.
- Added the `packages/tui` changelog entry for #1799.

## Verification
Ran `bun test packages/tui/test/issue-1682-repro.test.ts`, the focused repro command above after the fix (`risk=true`), and `bun run check` from `packages/tui`; all passed. Fixes #1799