### PR TITLE
fix: recognize disable-model-invocation from Agent Skills spec

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added support for `disable-model-invocation: true` frontmatter field from the [Agent Skills standard](https://agentskills.io/specification). Skills using this field are now hidden from the system prompt listing, matching the behavior of `hide: true`.
+
 ## [15.8.3] - 2026-06-03
 ### Fixed
 

--- a/packages/coding-agent/src/capability/skill.ts
+++ b/packages/coding-agent/src/capability/skill.ts
@@ -21,6 +21,13 @@ export interface SkillFrontmatter {
 	 * rather than ones the model should auto-discover.
 	 */
 	hide?: boolean;
+	/**
+	 * Agent Skills standard equivalent of `hide`.
+	 * When `true`, the skill is excluded from the system prompt listing.
+	 * Normalized from kebab-case `disable-model-invocation` in YAML frontmatter.
+	 * @see https://agentskills.io/specification
+	 */
+	disableModelInvocation?: boolean;
 	[key: string]: unknown;
 }
 

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -82,7 +82,7 @@ export async function loadSkillsFromDir(options: LoadSkillsFromDirOptions): Prom
 			filePath: capSkill.path,
 			baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 			source: options.source,
-			hide: capSkill.frontmatter?.hide === true,
+			hide: capSkill.frontmatter?.hide === true || capSkill.frontmatter?.disableModelInvocation === true,
 			_source: capSkill._source,
 		})),
 		warnings: (result.warnings ?? []).map(message => ({ skillPath: options.dir, message })),
@@ -197,7 +197,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 				filePath: capSkill.path,
 				baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 				source: `${capSkill._source.provider}:${capSkill.level}`,
-				hide: capSkill.frontmatter?.hide === true,
+				hide: capSkill.frontmatter?.hide === true || capSkill.frontmatter?.disableModelInvocation === true,
 				_source: capSkill._source,
 			});
 			realPathSet.add(resolvedPath);
@@ -234,7 +234,7 @@ export async function loadSkills(options: LoadSkillsOptions = {}): Promise<LoadS
 					filePath: capSkill.path,
 					baseDir: capSkill.path.replace(/[\\/]SKILL\.md$/, ""),
 					source: "custom:user",
-					hide: capSkill.frontmatter?.hide === true,
+					hide: capSkill.frontmatter?.hide === true || capSkill.frontmatter?.disableModelInvocation === true,
 					_source: { ...capSkill._source, providerName: "Custom" },
 				},
 				path: capSkill.path,

--- a/packages/coding-agent/test/skills.test.ts
+++ b/packages/coding-agent/test/skills.test.ts
@@ -248,7 +248,32 @@ enabled: false
 			}
 		});
 
-		it("should have ignoredSkills take precedence over includeSkills", async () => {
+		it("should hide skills with disable-model-invocation frontmatter (Agent Skills spec)", async () => {
+			const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-dmi-skill-"));
+			const skillDir = path.join(tempDir, "hidden-by-spec");
+			await fs.mkdir(skillDir, { recursive: true });
+			await fs.writeFile(
+				path.join(skillDir, "SKILL.md"),
+				`---\nname: hidden-by-spec\ndescription: Should be hidden via Agent Skills standard field.\ndisable-model-invocation: true\n---\n\n# Hidden Skill\n`,
+			);
+
+			try {
+				const { skills } = await loadSkills({
+					enableCodexUser: false,
+					enableClaudeUser: false,
+					enableClaudeProject: false,
+					enablePiUser: false,
+					enablePiProject: false,
+					customDirectories: [tempDir],
+				});
+				const skill = skills.find(s => s.name === "hidden-by-spec");
+				expect(skill).toBeDefined();
+				expect(skill!.hide).toBe(true);
+			} finally {
+				await fs.rm(tempDir, { recursive: true, force: true });
+			}
+		});
+
 			const { skills } = await loadSkills({
 				enableCodexUser: false,
 				enableClaudeUser: false,


### PR DESCRIPTION
## Problem

OMP only recognizes `hide: true` in skill frontmatter to exclude skills from the system prompt. The [Agent Skills standard](https://agentskills.io/specification#frontmatter-required) defines `disable-model-invocation: true` for the same purpose. This field is used by Pi, Claude Code, and other harnesses.

Skills authored following the standard don't get hidden in OMP, causing unnecessary prompt bloat.

## Fix

Treat `disable-model-invocation: true` as equivalent to `hide: true` in all 3 places where skill visibility is resolved.

```typescript
// Before
hide: capSkill.frontmatter?.hide === true,

// After
hide: capSkill.frontmatter?.hide === true || capSkill.frontmatter?.["disable-model-invocation"] === true,
```

## Ref
- https://agentskills.io/specification
- Backwards compatible — `hide: true` still works