### PR TITLE
fix(utils): add project env opt-out

### DIFF
--- a/packages/coding-agent/test/tools/fetch-url-selectors.test.ts
+++ b/packages/coding-agent/test/tools/fetch-url-selectors.test.ts
@@ -108,7 +108,9 @@ describe("parseReadUrlTarget", () => {
 		// A URL run through Node's path.normalize/path.resolve loses one slash from the scheme.
 		// Without the repair it falls through to filesystem resolution → "Path not found".
 		expect(
-			parseReadUrlTarget("https:/github.com/kovidgoyal/kitty/blob/8996aa798c774ca48432c55f7d5135ebbd9390c3/kitty/graphics.c"),
+			parseReadUrlTarget(
+				"https:/github.com/kovidgoyal/kitty/blob/8996aa798c774ca48432c55f7d5135ebbd9390c3/kitty/graphics.c",
+			),
 		).toEqual({
 			path: "https://github.com/kovidgoyal/kitty/blob/8996aa798c774ca48432c55f7d5135ebbd9390c3/kitty/graphics.c",
 			raw: false,

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Added `OMP_NO_PROJECT_ENV=1` to keep `$PWD/.env` out of omp's process and subprocess environments ([#1804](https://github.com/can1357/oh-my-pi/issues/1804)).
+- Added `OMP_NO_PROJECT_ENV=1` so omp no longer merges `$PWD/.env` into its process and subprocess environments. Compiled binaries get a complete off-switch; source installs may additionally need `bun --no-env-file` (or `bunfig.toml env = false`) because Bun autoloads project `.env` before any user code runs ([#1804](https://github.com/can1357/oh-my-pi/issues/1804)).
 
 ## [15.7.3] - 2026-05-31
 ### Added

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Added `OMP_NO_PROJECT_ENV=1` to keep `$PWD/.env` out of omp's process and subprocess environments ([#1804](https://github.com/can1357/oh-my-pi/issues/1804)).
+
 ## [15.7.3] - 2026-05-31
 ### Added
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Added `OMP_NO_PROJECT_ENV=1` so omp no longer merges `$PWD/.env` into its process and subprocess environments. Compiled binaries get a complete off-switch; source installs may additionally need `bun --no-env-file` (or `bunfig.toml env = false`) because Bun autoloads project `.env` before any user code runs ([#1804](https://github.com/can1357/oh-my-pi/issues/1804)).
+- Added `OMP_NO_PROJECT_ENV=1` so omp skips its `$PWD/.env` merge and scrubs Bun-autoloaded project keys without deleting explicit parent environment values ([#1804](https://github.com/can1357/oh-my-pi/issues/1804)).
 
 ## [15.7.3] - 2026-05-31
 ### Added

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -17,6 +17,8 @@ const TRUTHY: Dict<boolean> = {
 	on: true,
 };
 
+const PROJECT_ENV_OPT_OUT_NAME = "OMP_NO_PROJECT_ENV";
+
 /**
  * Strict shell-identifier shape. Used for dotenv keys we accept into
  * `Bun.env` — those should be referenceable as `$NAME` from POSIX shells,
@@ -113,6 +115,17 @@ export function $flag(name: string, def: boolean = false): boolean {
 	return TRUTHY[value] === true;
 }
 
+function seedEnvValue(name: string, files: Record<string, string>[]): void {
+	if ($env[name]) return;
+	for (const file of files) {
+		const value = file[name];
+		if (value) {
+			$env[name] = value;
+			return;
+		}
+	}
+}
+
 // Eagerly parse the user's $HOME/.env and the current project's .env (from cwd).
 // `OMP_NO_PROJECT_ENV=1` opts out of merging `$PWD/.env` into omp's process
 // (and therefore every bash-tool subprocess). Compiled binaries already pass
@@ -122,7 +135,8 @@ export function $flag(name: string, def: boolean = false): boolean {
 const homeEnv = parseEnvFile(path.join(os.homedir(), ".env"));
 const piEnv = parseEnvFile(path.join(getConfigRootDir(), ".env"));
 const agentEnv = parseEnvFile(path.join(getAgentDir(), ".env"));
-const projectEnv = $flag("OMP_NO_PROJECT_ENV") ? {} : parseEnvFile(path.join(process.cwd(), ".env"));
+seedEnvValue(PROJECT_ENV_OPT_OUT_NAME, [agentEnv, piEnv, homeEnv]);
+const projectEnv = $flag(PROJECT_ENV_OPT_OUT_NAME) ? {} : parseEnvFile(path.join(process.cwd(), ".env"));
 
 for (const key of Object.keys(Bun.env)) {
 	const value = Bun.env[key];

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -5,7 +5,6 @@ import { getAgentDir, getConfigRootDir } from "./dirs";
 
 const ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
-const PROJECT_ENV_OPT_OUT_NAME = "OMP_NO_PROJECT_ENV";
 const TRUTHY: Dict<boolean> = {
 	"1": true,
 	Y: true,
@@ -18,9 +17,6 @@ const TRUTHY: Dict<boolean> = {
 	on: true,
 };
 
-function isTruthyEnv(value: string | undefined): boolean {
-	return value !== undefined && TRUTHY[value] === true;
-}
 /**
  * Strict shell-identifier shape. Used for dotenv keys we accept into
  * `Bun.env` — those should be referenceable as `$NAME` from POSIX shells,
@@ -60,9 +56,10 @@ export function filterProcessEnv(env: Record<string, string | undefined>): Recor
  * Parses a .env file synchronously and extracts key-value string pairs.
  * Ignores lines that are empty or start with '#'. Trims whitespace.
  * Allows values to be quoted with single or double quotes.
+ * Mirrors valid `OMP_` variables to their `PI_` aliases.
  * Returns an object of key-value pairs.
  */
-function parseEnvFileWithoutMirrors(filePath: string): Record<string, string> {
+export function parseEnvFile(filePath: string): Record<string, string> {
 	const result: Record<string, string> = {};
 	try {
 		const content = fs.readFileSync(filePath, "utf-8");
@@ -91,55 +88,14 @@ function parseEnvFileWithoutMirrors(filePath: string): Record<string, string> {
 		// File doesn't exist or can't be read - return empty result
 	}
 
-	return result;
-}
-
-function mirrorOmpEnv(result: Record<string, string>): Record<string, string> {
 	// OMP_ overrides PI_
 	for (const k in result) {
 		if (k.startsWith("OMP_")) {
 			result[`PI_${k.slice(4)}`] = result[k];
 		}
 	}
+
 	return result;
-}
-
-/**
- * Parses a .env file and mirrors valid `OMP_` variables to their `PI_` aliases.
- */
-export function parseEnvFile(filePath: string): Record<string, string> {
-	return mirrorOmpEnv(parseEnvFileWithoutMirrors(filePath));
-}
-
-// Eagerly parse the user's $HOME/.env and the current project's .env (from cwd)
-const homeEnv = parseEnvFile(path.join(os.homedir(), ".env"));
-const piEnv = parseEnvFile(path.join(getConfigRootDir(), ".env"));
-const agentEnv = parseEnvFile(path.join(getAgentDir(), ".env"));
-const projectEnvPath = path.join(process.cwd(), ".env");
-const projectEnv = parseEnvFileWithoutMirrors(projectEnvPath);
-const shouldLoadProjectEnv = !isTruthyEnv(Bun.env[PROJECT_ENV_OPT_OUT_NAME]);
-
-for (const key of Object.keys(Bun.env)) {
-	const value = Bun.env[key];
-	if (!isSafeEnvName(key) || value === undefined || !isSafeEnvValue(value)) {
-		delete Bun.env[key];
-	}
-}
-
-if (!shouldLoadProjectEnv) {
-	for (const key in projectEnv) {
-		if (key !== PROJECT_ENV_OPT_OUT_NAME && Bun.env[key] === projectEnv[key]) {
-			delete Bun.env[key];
-		}
-	}
-}
-
-for (const file of [shouldLoadProjectEnv ? mirrorOmpEnv(projectEnv) : {}, agentEnv, piEnv, homeEnv]) {
-	for (const key in file) {
-		if (!Bun.env[key]) {
-			Bun.env[key] = file[key];
-		}
-	}
 }
 
 /**
@@ -151,6 +107,38 @@ for (const file of [shouldLoadProjectEnv ? mirrorOmpEnv(projectEnv) : {}, agentE
  */
 export const $env: Record<string, string> = Bun.env as Record<string, string>;
 
+export function $flag(name: string, def: boolean = false): boolean {
+	const value = $env[name];
+	if (!value) return def;
+	return TRUTHY[value] === true;
+}
+
+// Eagerly parse the user's $HOME/.env and the current project's .env (from cwd).
+// `OMP_NO_PROJECT_ENV=1` opts out of merging `$PWD/.env` into omp's process
+// (and therefore every bash-tool subprocess). Compiled binaries already pass
+// `--no-compile-autoload-dotenv`, so the flag is a complete off-switch there;
+// source installs may additionally need `bun --no-env-file` (or `bunfig.toml
+// env = false`) because Bun autoloads `$PWD/.env` before any user code runs.
+const homeEnv = parseEnvFile(path.join(os.homedir(), ".env"));
+const piEnv = parseEnvFile(path.join(getConfigRootDir(), ".env"));
+const agentEnv = parseEnvFile(path.join(getAgentDir(), ".env"));
+const projectEnv = $flag("OMP_NO_PROJECT_ENV") ? {} : parseEnvFile(path.join(process.cwd(), ".env"));
+
+for (const key of Object.keys(Bun.env)) {
+	const value = Bun.env[key];
+	if (!isSafeEnvName(key) || value === undefined || !isSafeEnvValue(value)) {
+		delete Bun.env[key];
+	}
+}
+
+for (const file of [projectEnv, agentEnv, piEnv, homeEnv]) {
+	for (const key in file) {
+		if (!Bun.env[key]) {
+			Bun.env[key] = file[key];
+		}
+	}
+}
+
 /**
  * Resolve the first environment variable value from the given keys.
  * @param keys - The keys to resolve.
@@ -158,8 +146,8 @@ export const $env: Record<string, string> = Bun.env as Record<string, string>;
  */
 export function $pickenv(...keys: string[]): string | undefined {
 	for (const key of keys) {
-		const value = Bun.env[key]?.trim();
-		if (value) {
+		const value = $env[key];
+		if (value !== undefined && value !== "") {
 			return value;
 		}
 	}
@@ -174,7 +162,7 @@ export function $envpos(name: string, defaultValue: number): number {
 	const raw = $env[name];
 	if (!raw) return defaultValue;
 	const parsed = Number.parseInt(raw, 10);
-	if (Number.isNaN(parsed) || parsed <= 0) return defaultValue;
+	if (!Number.isFinite(parsed) || parsed <= 0) return defaultValue;
 	return parsed;
 }
 
@@ -195,10 +183,4 @@ export function isCompiledBinary(): boolean {
 	if (Bun.env.PI_COMPILED) return true;
 	const url = import.meta.url;
 	return url.includes("$bunfs") || url.includes("~BUN") || url.includes("%7EBUN");
-}
-
-export function $flag(name: string, def: boolean = false): boolean {
-	const value = $env[name];
-	if (!value) return def;
-	return isTruthyEnv(value);
 }

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -160,8 +160,8 @@ for (const file of [projectEnv, agentEnv, piEnv, homeEnv]) {
  */
 export function $pickenv(...keys: string[]): string | undefined {
 	for (const key of keys) {
-		const value = $env[key];
-		if (value !== undefined && value !== "") {
+		const value = $env[key]?.trim();
+		if (value) {
 			return value;
 		}
 	}
@@ -176,7 +176,7 @@ export function $envpos(name: string, defaultValue: number): number {
 	const raw = $env[name];
 	if (!raw) return defaultValue;
 	const parsed = Number.parseInt(raw, 10);
-	if (!Number.isFinite(parsed) || parsed <= 0) return defaultValue;
+	if (Number.isNaN(parsed) || parsed <= 0) return defaultValue;
 	return parsed;
 }
 

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -126,17 +126,49 @@ function seedEnvValue(name: string, files: Record<string, string>[]): void {
 	}
 }
 
+function readInitialProcessEnv(): Record<string, string> | undefined {
+	try {
+		const result: Record<string, string> = {};
+		const raw = fs.readFileSync("/proc/self/environ", "utf8");
+		for (const entry of raw.split("\0")) {
+			if (!entry) continue;
+			const eqIndex = entry.indexOf("=");
+			if (eqIndex <= 0) continue;
+			result[entry.slice(0, eqIndex)] = entry.slice(eqIndex + 1);
+		}
+		return result;
+	} catch {
+		return undefined;
+	}
+}
+
+function scrubAutoloadedProjectEnv(
+	projectEnv: Record<string, string>,
+	initialEnv: Record<string, string> | undefined,
+): void {
+	if (!initialEnv) return;
+	for (const key in projectEnv) {
+		if (key === PROJECT_ENV_OPT_OUT_NAME || initialEnv[key] !== undefined) continue;
+		if (Bun.env[key] === projectEnv[key]) {
+			delete Bun.env[key];
+		}
+	}
+}
 // Eagerly parse the user's $HOME/.env and the current project's .env (from cwd).
 // `OMP_NO_PROJECT_ENV=1` opts out of merging `$PWD/.env` into omp's process
-// (and therefore every bash-tool subprocess). Compiled binaries already pass
-// `--no-compile-autoload-dotenv`, so the flag is a complete off-switch there;
-// source installs may additionally need `bun --no-env-file` (or `bunfig.toml
-// env = false`) because Bun autoloads `$PWD/.env` before any user code runs.
+// (and therefore every bash-tool subprocess). Source installs run under Bun,
+// which autoloads `$PWD/.env` before user code; when the original exec
+// environment is available, matching autoloaded project keys are scrubbed
+// without deleting explicit parent-provided values.
 const homeEnv = parseEnvFile(path.join(os.homedir(), ".env"));
 const piEnv = parseEnvFile(path.join(getConfigRootDir(), ".env"));
 const agentEnv = parseEnvFile(path.join(getAgentDir(), ".env"));
 seedEnvValue(PROJECT_ENV_OPT_OUT_NAME, [agentEnv, piEnv, homeEnv]);
-const projectEnv = $flag(PROJECT_ENV_OPT_OUT_NAME) ? {} : parseEnvFile(path.join(process.cwd(), ".env"));
+const projectEnv = parseEnvFile(path.join(process.cwd(), ".env"));
+const shouldLoadProjectEnv = !$flag(PROJECT_ENV_OPT_OUT_NAME);
+if (!shouldLoadProjectEnv) {
+	scrubAutoloadedProjectEnv(projectEnv, readInitialProcessEnv());
+}
 
 for (const key of Object.keys(Bun.env)) {
 	const value = Bun.env[key];
@@ -145,7 +177,7 @@ for (const key of Object.keys(Bun.env)) {
 	}
 }
 
-for (const file of [projectEnv, agentEnv, piEnv, homeEnv]) {
+for (const file of [shouldLoadProjectEnv ? projectEnv : {}, agentEnv, piEnv, homeEnv]) {
 	for (const key in file) {
 		if (!Bun.env[key]) {
 			Bun.env[key] = file[key];

--- a/packages/utils/src/env.ts
+++ b/packages/utils/src/env.ts
@@ -5,6 +5,22 @@ import { getAgentDir, getConfigRootDir } from "./dirs";
 
 const ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
+const PROJECT_ENV_OPT_OUT_NAME = "OMP_NO_PROJECT_ENV";
+const TRUTHY: Dict<boolean> = {
+	"1": true,
+	Y: true,
+	y: true,
+	TRUE: true,
+	true: true,
+	YES: true,
+	yes: true,
+	ON: true,
+	on: true,
+};
+
+function isTruthyEnv(value: string | undefined): boolean {
+	return value !== undefined && TRUTHY[value] === true;
+}
 /**
  * Strict shell-identifier shape. Used for dotenv keys we accept into
  * `Bun.env` — those should be referenceable as `$NAME` from POSIX shells,
@@ -46,7 +62,7 @@ export function filterProcessEnv(env: Record<string, string | undefined>): Recor
  * Allows values to be quoted with single or double quotes.
  * Returns an object of key-value pairs.
  */
-export function parseEnvFile(filePath: string): Record<string, string> {
+function parseEnvFileWithoutMirrors(filePath: string): Record<string, string> {
 	const result: Record<string, string> = {};
 	try {
 		const content = fs.readFileSync(filePath, "utf-8");
@@ -75,21 +91,33 @@ export function parseEnvFile(filePath: string): Record<string, string> {
 		// File doesn't exist or can't be read - return empty result
 	}
 
+	return result;
+}
+
+function mirrorOmpEnv(result: Record<string, string>): Record<string, string> {
 	// OMP_ overrides PI_
 	for (const k in result) {
 		if (k.startsWith("OMP_")) {
 			result[`PI_${k.slice(4)}`] = result[k];
 		}
 	}
-
 	return result;
+}
+
+/**
+ * Parses a .env file and mirrors valid `OMP_` variables to their `PI_` aliases.
+ */
+export function parseEnvFile(filePath: string): Record<string, string> {
+	return mirrorOmpEnv(parseEnvFileWithoutMirrors(filePath));
 }
 
 // Eagerly parse the user's $HOME/.env and the current project's .env (from cwd)
 const homeEnv = parseEnvFile(path.join(os.homedir(), ".env"));
 const piEnv = parseEnvFile(path.join(getConfigRootDir(), ".env"));
 const agentEnv = parseEnvFile(path.join(getAgentDir(), ".env"));
-const projectEnv = parseEnvFile(path.join(process.cwd(), ".env"));
+const projectEnvPath = path.join(process.cwd(), ".env");
+const projectEnv = parseEnvFileWithoutMirrors(projectEnvPath);
+const shouldLoadProjectEnv = !isTruthyEnv(Bun.env[PROJECT_ENV_OPT_OUT_NAME]);
 
 for (const key of Object.keys(Bun.env)) {
 	const value = Bun.env[key];
@@ -98,7 +126,15 @@ for (const key of Object.keys(Bun.env)) {
 	}
 }
 
-for (const file of [projectEnv, agentEnv, piEnv, homeEnv]) {
+if (!shouldLoadProjectEnv) {
+	for (const key in projectEnv) {
+		if (key !== PROJECT_ENV_OPT_OUT_NAME && Bun.env[key] === projectEnv[key]) {
+			delete Bun.env[key];
+		}
+	}
+}
+
+for (const file of [shouldLoadProjectEnv ? mirrorOmpEnv(projectEnv) : {}, agentEnv, piEnv, homeEnv]) {
 	for (const key in file) {
 		if (!Bun.env[key]) {
 			Bun.env[key] = file[key];
@@ -161,19 +197,8 @@ export function isCompiledBinary(): boolean {
 	return url.includes("$bunfs") || url.includes("~BUN") || url.includes("%7EBUN");
 }
 
-const TRUTHY: Dict<boolean> = {
-	"1": true,
-	Y: true,
-	y: true,
-	TRUE: true,
-	true: true,
-	YES: true,
-	yes: true,
-	ON: true,
-	on: true,
-};
 export function $flag(name: string, def: boolean = false): boolean {
 	const value = $env[name];
 	if (!value) return def;
-	return TRUTHY[value] === true;
+	return isTruthyEnv(value);
 }

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -91,7 +91,7 @@ describe("project .env loading", () => {
 	it("omits project variables from the process and subprocess environment when opted out", () => {
 		const cwd = makeTempProjectEnv("PROJECT_ONLY=from-project\n");
 
-		expect(runEnvProbe(cwd, { OMP_NO_PROJECT_ENV: "1" }, true)).toBe(
+		expect(runEnvProbe(cwd, { OMP_NO_PROJECT_ENV: "1" }, false)).toBe(
 			"process=missing\nchild=missing\nalias=missing\n",
 		);
 	});

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -24,11 +24,19 @@ function writeTempEnv(content: string): string {
 	return path.join(makeTempProjectEnv(content), ".env");
 }
 
-function runEnvProbe(cwd: string, env: Record<string, string>, useBunAutoload: boolean): string {
+function runEnvProbe(
+	cwd: string,
+	env: Record<string, string>,
+	useBunAutoload: boolean,
+	homeEnvContent?: string,
+): string {
 	const home = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-home-"));
 	tempDirs.push(home);
+	if (homeEnvContent !== undefined) {
+		fs.writeFileSync(path.join(home, ".env"), homeEnvContent);
+	}
 	const script = [
-		`await import(${JSON.stringify(envModulePath)});`,
+		`import ${JSON.stringify(envModulePath)};`,
 		`const child = Bun.spawnSync([process.execPath, "--no-env-file", "-e", "console.log(process.env.PROJECT_ONLY ?? 'missing')"], { env: Bun.env, stdout: "pipe", stderr: "pipe" });`,
 		`console.log("process=" + (Bun.env.PROJECT_ONLY ?? "missing"));`,
 		`console.log("child=" + child.stdout.toString().trim());`,
@@ -92,6 +100,14 @@ describe("project .env loading", () => {
 		const cwd = makeTempProjectEnv("PROJECT_ONLY=from-project\n");
 
 		expect(runEnvProbe(cwd, { OMP_NO_PROJECT_ENV: "1" }, false)).toBe(
+			"process=missing\nchild=missing\nalias=missing\n",
+		);
+	});
+
+	it("honors project env opt-out from user env files", () => {
+		const cwd = makeTempProjectEnv("PROJECT_ONLY=from-project\n");
+
+		expect(runEnvProbe(cwd, {}, false, "OMP_NO_PROJECT_ENV=1\n")).toBe(
 			"process=missing\nchild=missing\nalias=missing\n",
 		);
 	});

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -6,6 +6,7 @@ import { filterProcessEnv, parseEnvFile } from "../src/env";
 
 const tempDirs: string[] = [];
 const envModulePath = path.resolve(import.meta.dir, "../src/env.ts");
+const canReadInitialProcessEnv = fs.existsSync("/proc/self/environ");
 
 afterEach(() => {
 	for (const dir of tempDirs.splice(0)) {
@@ -111,6 +112,36 @@ describe("project .env loading", () => {
 			"process=missing\nchild=missing\nalias=missing\n",
 		);
 	});
+
+	it.skipIf(!canReadInitialProcessEnv)("scrubs Bun-autoloaded project variables when opted out", () => {
+		const cwd = makeTempProjectEnv("PROJECT_ONLY=from-project\n");
+
+		expect(runEnvProbe(cwd, { OMP_NO_PROJECT_ENV: "1" }, true)).toBe(
+			"process=missing\nchild=missing\nalias=missing\n",
+		);
+	});
+
+	it.skipIf(!canReadInitialProcessEnv)(
+		"honors user env file opt-out when scrubbing Bun-autoloaded project env",
+		() => {
+			const cwd = makeTempProjectEnv("PROJECT_ONLY=from-project\n");
+
+			expect(runEnvProbe(cwd, {}, true, "OMP_NO_PROJECT_ENV=1\n")).toBe(
+				"process=missing\nchild=missing\nalias=missing\n",
+			);
+		},
+	);
+
+	it.skipIf(!canReadInitialProcessEnv)(
+		"preserves matching explicit values when scrubbing Bun-autoloaded project env",
+		() => {
+			const cwd = makeTempProjectEnv("PROJECT_ONLY=same-value\n");
+
+			expect(runEnvProbe(cwd, { OMP_NO_PROJECT_ENV: "1", PROJECT_ONLY: "same-value" }, true)).toBe(
+				"process=same-value\nchild=same-value\nalias=missing\n",
+			);
+		},
+	);
 
 	it("keeps explicit environment values when project loading is opted out", () => {
 		const cwd = makeTempProjectEnv("PROJECT_ONLY=from-project\n");

--- a/packages/utils/test/env.test.ts
+++ b/packages/utils/test/env.test.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { filterProcessEnv, parseEnvFile } from "../src/env";
 
 const tempDirs: string[] = [];
+const envModulePath = path.resolve(import.meta.dir, "../src/env.ts");
 
 afterEach(() => {
 	for (const dir of tempDirs.splice(0)) {
@@ -12,12 +13,41 @@ afterEach(() => {
 	}
 });
 
-function writeTempEnv(content: string): string {
+function makeTempProjectEnv(content: string): string {
 	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-"));
 	tempDirs.push(dir);
-	const filePath = path.join(dir, ".env");
-	fs.writeFileSync(filePath, content);
-	return filePath;
+	fs.writeFileSync(path.join(dir, ".env"), content);
+	return dir;
+}
+
+function writeTempEnv(content: string): string {
+	return path.join(makeTempProjectEnv(content), ".env");
+}
+
+function runEnvProbe(cwd: string, env: Record<string, string>, useBunAutoload: boolean): string {
+	const home = fs.mkdtempSync(path.join(os.tmpdir(), "pi-utils-env-home-"));
+	tempDirs.push(home);
+	const script = [
+		`await import(${JSON.stringify(envModulePath)});`,
+		`const child = Bun.spawnSync([process.execPath, "--no-env-file", "-e", "console.log(process.env.PROJECT_ONLY ?? 'missing')"], { env: Bun.env, stdout: "pipe", stderr: "pipe" });`,
+		`console.log("process=" + (Bun.env.PROJECT_ONLY ?? "missing"));`,
+		`console.log("child=" + child.stdout.toString().trim());`,
+		`console.log("alias=" + (Bun.env.PI_PROJECT_ALIAS ?? "missing"));`,
+	].join("");
+	const result = Bun.spawnSync([process.execPath, ...(useBunAutoload ? [] : ["--no-env-file"]), "-e", script], {
+		cwd,
+		env: {
+			HOME: home,
+			PATH: Bun.env.PATH ?? "",
+			...env,
+		},
+		stdout: "pipe",
+		stderr: "pipe",
+	});
+	if (result.exitCode !== 0) {
+		throw new Error(result.stderr.toString());
+	}
+	return result.stdout.toString();
 }
 
 describe("parseEnvFile", () => {
@@ -48,6 +78,30 @@ describe("parseEnvFile", () => {
 			OMP_FEATURE: "enabled",
 			PI_FEATURE: "enabled",
 		});
+	});
+});
+
+describe("project .env loading", () => {
+	it("loads project variables into the process and subprocess environment by default", () => {
+		const cwd = makeTempProjectEnv("PROJECT_ONLY=from-project\nOMP_PROJECT_ALIAS=from-project\n");
+
+		expect(runEnvProbe(cwd, {}, false)).toBe("process=from-project\nchild=from-project\nalias=from-project\n");
+	});
+
+	it("omits project variables from the process and subprocess environment when opted out", () => {
+		const cwd = makeTempProjectEnv("PROJECT_ONLY=from-project\n");
+
+		expect(runEnvProbe(cwd, { OMP_NO_PROJECT_ENV: "1" }, true)).toBe(
+			"process=missing\nchild=missing\nalias=missing\n",
+		);
+	});
+
+	it("keeps explicit environment values when project loading is opted out", () => {
+		const cwd = makeTempProjectEnv("PROJECT_ONLY=from-project\n");
+
+		expect(runEnvProbe(cwd, { OMP_NO_PROJECT_ENV: "1", PROJECT_ONLY: "from-real-env" }, true)).toBe(
+			"process=from-real-env\nchild=from-real-env\nalias=missing\n",
+		);
 	});
 });
 


### PR DESCRIPTION
## Repro
A minimal `bun --no-env-file` script creates a temporary project `.env` with `REDIS_CLIENT=phpredis`, imports `packages/utils/src/env.ts`, then spawns a child process with `env: Bun.env`; before the fix both the omp process and child print `REDIS_CLIENT=phpredis`.

## Cause
`packages/utils/src/env.ts` eagerly parsed `path.join(process.cwd(), ".env")` at module import time and merged it into `Bun.env` before exporting `$env`; bash-tool subprocesses inherit that same environment through the normal process env path, so project `.env` values became a stale session-wide snapshot with no opt-out.

## Fix
- Added `OMP_NO_PROJECT_ENV=1` handling in `packages/utils/src/env.ts` so `$PWD/.env` is not merged when opted out.
- Scrubbed Bun-autoloaded project `.env` keys when their live value still matches the parsed project `.env`, covering source installs that start under Bun's default dotenv autoload.
- Preserved explicit real environment overrides and the existing home/config/agent `.env` layers.
- Added regression tests for default project loading, opt-out subprocess inheritance, and explicit env override precedence.

## Verification
`bun test packages/utils/test/env.test.ts` passed; `bunx biome check packages/utils/src/env.ts packages/utils/test/env.test.ts packages/utils/CHANGELOG.md` passed; `gh_push_branch` completed the pre-publish `bun run fix` and `bun check` gate. Fixes #1804