### PR TITLE
fix: cargo-nextest fallback and PTY login shell syntax crash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4924,9 +4924,9 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",

--- a/packages/natives/test/native.test.ts
+++ b/packages/natives/test/native.test.ts
@@ -484,7 +484,8 @@ describe("pi-natives", () => {
 					session
 						.start(
 							{
-								command: 'bash -lc "set -m; sleep 30 & disown; sleep 30"',
+								command: 'bash -c "set -m; sleep 30 & disown; sleep 30"',
+								shell: 'bash',
 								cwd: testDir,
 								timeoutMs: 150,
 								cols: 120,

--- a/scripts/run-rs-task.ts
+++ b/scripts/run-rs-task.ts
@@ -53,7 +53,21 @@ if (taskName !== "fmt:rs" && !(isCI() || (await hasRustAffectingChanges()))) {
 	process.exit(0);
 }
 
-for (const command of TASK_COMMANDS[taskName]) {
+async function hasNextest(): Promise<boolean> {
+	try {
+		const res = await $`cargo nextest --version`.quiet().nothrow();
+		return res.exitCode === 0;
+	} catch {
+		return false;
+	}
+}
+
+let commands = TASK_COMMANDS[taskName];
+if (taskName === "test:rs" && !(await hasNextest())) {
+	commands = [["cargo", "test", "--workspace"]];
+}
+
+for (const command of commands) {
 	const exitCode = await runCommand(command);
 	if (exitCode !== 0) {
 		process.exit(exitCode);


### PR DESCRIPTION
This PR fixes environment issues in oh-my-pi tests:
1. Fallback to cargo test when cargo-nextest is missing.
2. Fix PTY test crashing due to non-compatible profiles when spawning bash -lc in UNIX.