### PR TITLE
feat(zai): add Web Search in Chat integration for Z.AI provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added Z.AI Web Search in Chat support with `web_search_20250305` built-in tool injection for Z.AI Anthropic endpoints.
+
 ## [15.9.0] - 2026-06-04
 
 ### Fixed

--- a/packages/ai/src/providers/anthropic-wire.ts
+++ b/packages/ai/src/providers/anthropic-wire.ts
@@ -76,13 +76,36 @@ export type RedactedThinkingBlockParam = {
 	data: string;
 };
 
+export type ServerToolUseBlockParam = {
+	type: "server_tool_use";
+	id: string;
+	name: string;
+	input?: Record<string, unknown> | null;
+};
+
+export type WebSearchResultItem = {
+	type: "web_search_result";
+	url: string;
+	title: string;
+	encrypted_content?: string;
+	page_age?: string;
+};
+
+export type WebSearchToolResultBlockParam = {
+	type: "web_search_tool_result";
+	tool_use_id: string;
+	content: WebSearchResultItem[] | { type: "web_search_tool_result_error"; error_code: string };
+};
+
 export type ContentBlockParam =
 	| TextBlockParam
 	| ImageBlockParam
 	| ToolUseBlockParam
 	| ToolResultBlockParam
 	| ThinkingBlockParam
-	| RedactedThinkingBlockParam;
+	| RedactedThinkingBlockParam
+	| ServerToolUseBlockParam
+	| WebSearchToolResultBlockParam;
 
 /**
  * A single conversation turn.
@@ -228,7 +251,9 @@ export type ResponseContentBlock =
 	| { type: "text"; text: string }
 	| { type: "thinking"; thinking: string; signature?: string }
 	| { type: "redacted_thinking"; data: string }
-	| { type: "tool_use"; id: string; name: string; input?: Record<string, unknown> | null };
+	| { type: "tool_use"; id: string; name: string; input?: Record<string, unknown> | null }
+	| { type: "server_tool_use"; id: string; name: string; input?: Record<string, unknown> | null }
+	| { type: "web_search_tool_result"; tool_use_id: string; content: WebSearchResultItem[] | { type: "web_search_tool_result_error"; error_code: string } };
 
 export type ContentBlockDelta =
 	| { type: "text_delta"; text: string }

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -797,6 +797,17 @@ function convertContentBlocks(
 export type AnthropicEffort = "low" | "medium" | "high" | "xhigh" | "max";
 export type AnthropicThinkingDisplay = "summarized" | "omitted";
 
+/** Configuration for Z.AI Web Search in Chat feature. */
+export interface ZaiWebSearchConfig {
+	enabled?: boolean;
+	/** Maximum number of separate search invocations per request (1-50). Defaults to provider behavior. */
+	maxSearchCalls?: number;
+	searchEngine?: string;
+	searchPrompt?: string;
+	recencyFilter?: "oneDay" | "oneWeek" | "oneMonth" | "oneYear" | "noLimit";
+	domainFilter?: string;
+}
+
 export interface AnthropicOptions extends StreamOptions {
 	/**
 	 * Enable extended thinking.
@@ -851,6 +862,7 @@ export interface AnthropicOptions extends StreamOptions {
 	 * including SDK clients such as `AnthropicVertex`.
 	 */
 	client?: AnthropicMessagesClientLike;
+	zaiWebSearch?: ZaiWebSearchConfig;
 }
 
 export type AnthropicClientOptionsArgs = {
@@ -1422,6 +1434,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 					let sawEvent = false;
 					let sawMessageStart = false;
 					let sawTerminalEnvelope = false;
+					const skippedBlockIndices = new Set<number>();
 
 					for await (const event of iterateWithIdleTimeout(anthropicStream, {
 						idleTimeoutMs,
@@ -1511,8 +1524,60 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 									contentIndex: output.content.length - 1,
 									partial: output,
 								});
+							} else if (event.content_block.type === "server_tool_use") {
+								// Server has already started an external search; mark replay-unsafe.
+								streamedReplayUnsafeContent = true;
+								skippedBlockIndices.add(event.index);
+							} else if (event.content_block.type === "web_search_tool_result") {
+								const content = event.content_block.content;
+								let resultText = "";
+								if (Array.isArray(content)) {
+									const lines: string[] = [];
+									for (const item of content) {
+										if (item.type === "web_search_result") lines.push(`- [${item.title}](${item.url})`);
+									}
+									if (lines.length > 0) resultText = `**Web search results:**\n${lines.join("\n")}`;
+								} else if (content?.type === "web_search_tool_result_error") {
+									resultText = `**Web search error:** ${content.error_code}`;
+								}
+								if (resultText) {
+									streamedReplayUnsafeContent = true;
+									const searchBlock: Block = { type: "text", text: resultText, index: event.index };
+									output.content.push(searchBlock);
+									const ci = output.content.length - 1;
+									stream.push({ type: "text_start", contentIndex: ci, partial: output });
+									stream.push({ type: "text_delta", contentIndex: ci, delta: resultText, partial: output });
+								}
+							} else if ((event.content_block as { type: string }).type === "tool_result") {
+								// Z.AI search has already run server-side; mark replay-unsafe immediately.
+								streamedReplayUnsafeContent = true;
+								const trBlock = event.content_block as { type: string; content?: unknown };
+								let resultText = "";
+								if (typeof trBlock.content === "string") {
+									try {
+										const parsed: unknown = JSON.parse(trBlock.content);
+										const items = Array.isArray(parsed) ? (parsed as unknown[]).flat() : [];
+										const lines: string[] = [];
+										for (const item of items) {
+											if (typeof item === "object" && item !== null && "title" in item && "link" in item) {
+												const t = String((item as Record<string, unknown>).title);
+												const l = String((item as Record<string, unknown>).link);
+												if (t && l) lines.push(`- [${t}](${l})`);
+											}
+										}
+										if (lines.length > 0) resultText = `**Web search results:**\n${lines.join("\n")}`;
+									} catch {}
+								}
+								if (resultText) {
+									const trBlock2: Block = { type: "text", text: resultText, index: event.index };
+									output.content.push(trBlock2);
+									const ci = output.content.length - 1;
+									stream.push({ type: "text_start", contentIndex: ci, partial: output });
+									stream.push({ type: "text_delta", contentIndex: ci, delta: resultText, partial: output });
+								}
 							}
 						} else if (event.type === "content_block_delta") {
+							if (skippedBlockIndices.has(event.index)) continue;
 							if (event.delta.type === "text_delta") {
 								const index = blocks.findIndex(b => b.index === event.index);
 								const block = blocks[index];
@@ -1563,6 +1628,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages"> = (
 								}
 							}
 						} else if (event.type === "content_block_stop") {
+							if (skippedBlockIndices.has(event.index)) { skippedBlockIndices.delete(event.index); continue; }
 							const index = blocks.findIndex(b => b.index === event.index);
 							const block = blocks[index];
 							if (block) {
@@ -2319,6 +2385,24 @@ function buildParams(
 		);
 	} else if (isOAuthToken) {
 		params.tools = [];
+	}
+
+	// Inject Z.AI web_search built-in tool when configured for Z.AI endpoints.
+	if (options?.zaiWebSearch && isZaiAnthropicEndpoint(model)) {
+		const wsConfig = options.zaiWebSearch;
+		if (wsConfig.enabled !== false) {
+			if (!params.tools) params.tools = [];
+			const hasClientWebSearch = params.tools.some(t => (t as { name?: string }).name === "web_search");
+			if (!hasClientWebSearch) {
+				const ws: Record<string, unknown> = { type: "web_search_20250305", name: "web_search" };
+				if (wsConfig.maxSearchCalls !== undefined) ws.max_uses = Math.max(1, Math.min(50, Math.round(wsConfig.maxSearchCalls)));
+				if (wsConfig.domainFilter) ws.allowed_domains = [wsConfig.domainFilter];
+				if (wsConfig.recencyFilter) ws.search_recency_filter = wsConfig.recencyFilter;
+				if (wsConfig.searchEngine) ws.search_engine = wsConfig.searchEngine;
+				if (wsConfig.searchPrompt) ws.search_prompt = wsConfig.searchPrompt;
+				params.tools.push(ws as unknown as AnthropicWireTool);
+			}
+		}
 	}
 
 	if (model.reasoning) {

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -738,6 +738,7 @@ function mapOptionsForApi<TApi extends Api>(
 		onSseEvent: options?.onSseEvent,
 		execHandlers: options?.execHandlers,
 		fetch: options?.fetch,
+		zaiWebSearch: options?.zaiWebSearch,
 	};
 
 	switch (model.api) {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -1,6 +1,6 @@
 import type { ZodType, z } from "zod/v4";
 import type { BedrockOptions } from "./providers/amazon-bedrock";
-import type { AnthropicOptions } from "./providers/anthropic";
+import type { AnthropicOptions, ZaiWebSearchConfig } from "./providers/anthropic";
 import type { AzureOpenAIResponsesOptions } from "./providers/azure-openai-responses";
 import type { CursorOptions } from "./providers/cursor";
 import type {
@@ -457,6 +457,7 @@ export interface SimpleStreamOptions extends StreamOptions {
 	 * or the catalog entry already names the variant).
 	 */
 	openrouterVariant?: string;
+	zaiWebSearch?: ZaiWebSearchConfig;
 }
 
 // Generic StreamFunction with typed options

--- a/packages/ai/test/zai-web-search-injection.test.ts
+++ b/packages/ai/test/zai-web-search-injection.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import type { Model } from "@oh-my-pi/pi-ai/types";
+import { streamSimple } from "@oh-my-pi/pi-ai/stream";
+
+function mockFetch(capture: { body?: unknown }) {
+	return async (_url: string | URL | Request, init?: RequestInit) => {
+		if (init?.body) capture.body = JSON.parse(init.body as string);
+		const sse = [
+			'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","model":"test","content":[],"stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n',
+			'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+			'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+			'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}\n\n',
+			'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+		].join("");
+		return new Response(sse, { status: 200, headers: { "content-type": "text/event-stream" } });
+	};
+}
+
+const zaiModel = {
+	id: "glm-4.7", name: "GLM 4.7", provider: "zai", api: "anthropic-messages",
+	baseUrl: "https://api.z.ai/api/anthropic", input: ["text"], output: ["text"],
+	context: 128000, contextWindow: 128000, maxTokens: 8192, reasoning: false,
+	toolCall: "native", cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+} as Model<"anthropic-messages">;
+
+const anthropicModel = {
+	...zaiModel, id: "claude-sonnet-4-20250514", name: "Claude Sonnet 4",
+	provider: "anthropic", baseUrl: "https://api.anthropic.com",
+} as Model<"anthropic-messages">;
+
+const emptyContext = {
+	systemPrompt: [""],
+	messages: [{ role: "user" as const, content: [{ type: "text" as const, text: "test" }], timestamp: Date.now() }],
+};
+
+describe("Z.AI web_search tool injection", () => {
+	it("injects web_search tool for Z.AI models", async () => {
+		const capture: { body?: unknown } = {};
+		const stream = streamSimple(zaiModel, emptyContext, { apiKey: "test-key", fetch: mockFetch(capture), zaiWebSearch: { enabled: true, maxSearchCalls: 5 } });
+		await stream.result();
+		const body = capture.body as { tools?: Array<Record<string, unknown>> };
+		expect(body?.tools).toBeDefined();
+		const ws = body!.tools!.find(t => t.type === "web_search_20250305");
+		expect(ws).toBeDefined();
+		expect(ws!.name).toBe("web_search");
+		expect(ws!.max_uses).toBe(5);
+	});
+
+	it("does not inject for non-Z.AI models", async () => {
+		const capture: { body?: unknown } = {};
+		const stream = streamSimple(anthropicModel, emptyContext, { apiKey: "test-key", fetch: mockFetch(capture), zaiWebSearch: { enabled: true, maxSearchCalls: 5 } });
+		await stream.result();
+		const body = capture.body as { tools?: Array<Record<string, unknown>> };
+		expect(body?.tools?.find(t => t.type === "web_search_20250305")).toBeUndefined();
+	});
+
+	it("suppresses when enabled is false", async () => {
+		const capture: { body?: unknown } = {};
+		const stream = streamSimple(zaiModel, emptyContext, { apiKey: "test-key", fetch: mockFetch(capture), zaiWebSearch: { enabled: false } });
+		await stream.result();
+		const body = capture.body as { tools?: Array<Record<string, unknown>> };
+		expect(body?.tools?.find(t => t.type === "web_search_20250305")).toBeUndefined();
+	});
+
+	it("serializes recencyFilter", async () => {
+		const capture: { body?: unknown } = {};
+		const stream = streamSimple(zaiModel, emptyContext, { apiKey: "test-key", fetch: mockFetch(capture), zaiWebSearch: { enabled: true, recencyFilter: "oneDay" } });
+		await stream.result();
+		const body = capture.body as { tools?: Array<Record<string, unknown>> };
+		const ws = body?.tools?.find(t => t.type === "web_search_20250305");
+		expect(ws).toBeDefined();
+		expect(ws!.search_recency_filter).toBe("oneDay");
+	});
+
+	it("clamps maxSearchCalls to 1-50", async () => {
+		const capture: { body?: unknown } = {};
+		const stream = streamSimple(zaiModel, emptyContext, { apiKey: "test-key", fetch: mockFetch(capture), zaiWebSearch: { enabled: true, maxSearchCalls: 100 } });
+		await stream.result();
+		const body = capture.body as { tools?: Array<Record<string, unknown>> };
+		const ws = body?.tools?.find(t => t.type === "web_search_20250305");
+		expect(ws).toBeDefined();
+		expect(ws!.max_uses).toBe(50);
+	});
+});

--- a/packages/ai/test/zai-web-search-response.test.ts
+++ b/packages/ai/test/zai-web-search-response.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "bun:test";
+import type { Model } from "@oh-my-pi/pi-ai/types";
+import { streamSimple } from "@oh-my-pi/pi-ai/stream";
+import type { AssistantMessageEvent } from "@oh-my-pi/pi-ai/types";
+
+function sseFetch(sseEvents: string[], capture?: { body?: unknown }) {
+	return async (_url: string | URL | Request, init?: RequestInit) => {
+		if (capture && init?.body) capture.body = JSON.parse(init.body as string);
+		return new Response(sseEvents.join(""), {
+			status: 200,
+			headers: { "content-type": "text/event-stream" },
+		});
+	};
+}
+
+const zaiModel = {
+	id: "glm-4.7", name: "GLM 4.7", provider: "zai", api: "anthropic-messages",
+	baseUrl: "https://api.z.ai/api/anthropic", input: ["text"], output: ["text"],
+	context: 128000, contextWindow: 128000, maxTokens: 8192, reasoning: false,
+	toolCall: "native", cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+} as Model<"anthropic-messages">;
+
+const ctx = {
+	systemPrompt: [""],
+	messages: [{ role: "user" as const, content: [{ type: "text" as const, text: "test" }], timestamp: Date.now() }],
+};
+
+const msgStart = 'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","model":"test","content":[],"stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}\n\n';
+const msgEnd = 'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}\n\nevent: message_stop\ndata: {"type":"message_stop"}\n\n';
+
+async function collectEvents(stream: ReturnType<typeof streamSimple>): Promise<AssistantMessageEvent[]> {
+	const events: AssistantMessageEvent[] = [];
+	for await (const event of stream) {
+		events.push(event);
+	}
+	return events;
+}
+
+describe("Z.AI web search response handling", () => {
+	it("web_search_tool_result emits text_start/text_delta/text_end", async () => {
+		const searchResult = JSON.stringify([{ type: "web_search_result", title: "Node.js", url: "https://nodejs.org" }]);
+		const sse = [
+			msgStart,
+			'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',
+			'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Here are the results."}}\n\n',
+			'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+			`event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"web_search_tool_result","tool_use_id":"ws_1","content":${searchResult}}}\n\n`,
+			'event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n',
+			'event: content_block_start\ndata: {"type":"content_block_start","index":2,"content_block":{"type":"text","text":""}}\n\n',
+			'event: content_block_delta\ndata: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"Node.js is a JS runtime."}}\n\n',
+			'event: content_block_stop\ndata: {"type":"content_block_stop","index":2}\n\n',
+			msgEnd,
+		];
+		const stream = streamSimple(zaiModel, ctx, { apiKey: "test", fetch: sseFetch(sse) });
+		const events = await collectEvents(stream);
+		const result = await stream.result();
+
+		const allText = result.content.filter(c => c.type === "text").map(c => (c as { text: string }).text).join("");
+		expect(allText).toContain("Node.js");
+		expect(allText).toContain("https://nodejs.org");
+
+		expect(events.some(e => e.type === "text_start")).toBe(true);
+		expect(events.some(e => e.type === "text_end")).toBe(true);
+	});
+
+	it("tool_result (Z.AI format) parses JSON and emits text events", async () => {
+		const zaiContent = JSON.stringify([[{ title: "Python 3.12", link: "https://python.org", content: "desc", refer: "ref_1" }]]);
+		const escapedContent = zaiContent.replace(/"/g, '\\"');
+		const sse = [
+			msgStart,
+			'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"su_1","name":"web_search_prime","input":{}}}\n\n',
+			'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+			`event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"tool_result","tool_use_id":"su_1","content":"${escapedContent}"}}\n\n`,
+			'event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n',
+			'event: content_block_start\ndata: {"type":"content_block_start","index":2,"content_block":{"type":"text","text":""}}\n\n',
+			'event: content_block_delta\ndata: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"Python 3.12 is the latest."}}\n\n',
+			'event: content_block_stop\ndata: {"type":"content_block_stop","index":2}\n\n',
+			msgEnd,
+		];
+		const stream = streamSimple(zaiModel, ctx, { apiKey: "test", fetch: sseFetch(sse) });
+		const events = await collectEvents(stream);
+		const result = await stream.result();
+
+		const allText = result.content.filter(c => c.type === "text").map(c => (c as { text: string }).text).join("");
+		expect(allText).toContain("Python 3.12");
+		expect(allText).toContain("https://python.org");
+		expect(events.some(e => e.type === "text_start")).toBe(true);
+		expect(events.some(e => e.type === "text_end")).toBe(true);
+	});
+
+	it("server_tool_use is skipped without emitting stream events", async () => {
+		const sse = [
+			msgStart,
+			'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"server_tool_use","id":"su_1","name":"web_search_prime","input":{"query":"test"}}}\n\n',
+			'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\"query\\":\\"test\\""}}\n\n',
+			'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+			'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}\n\n',
+			'event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Done."}}\n\n',
+			'event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n',
+			msgEnd,
+		];
+		const stream = streamSimple(zaiModel, ctx, { apiKey: "test", fetch: sseFetch(sse) });
+		const result = await stream.result();
+
+		const allText = result.content.filter(c => c.type === "text").map(c => (c as { text: string }).text).join("");
+		expect(allText).toBe("Done.");
+	});
+
+	it("unparsable tool_result does not throw and still completes", async () => {
+		const sse = [
+			msgStart,
+			'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"tool_result","tool_use_id":"su_1","content":"not valid json {["}}\n\n',
+			'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+			'event: content_block_start\ndata: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}\n\n',
+			'event: content_block_delta\ndata: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Response after bad result."}}\n\n',
+			'event: content_block_stop\ndata: {"type":"content_block_stop","index":1}\n\n',
+			msgEnd,
+		];
+		const stream = streamSimple(zaiModel, ctx, { apiKey: "test", fetch: sseFetch(sse) });
+		const result = await stream.result();
+
+		const allText = result.content.filter(c => c.type === "text").map(c => (c as { text: string }).text).join("");
+		expect(allText).toContain("Response after bad result.");
+	});
+});

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `zai.webSearchInChat`, `zai.webSearchCount`, and `zai.webSearchRecency` settings for Z.AI web search in chat.
+
 ## [15.9.0] - 2026-06-04
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -3127,6 +3127,45 @@ export const SETTINGS_SCHEMA = {
 		default: undefined,
 	},
 
+	// Z.AI Web Search in Chat
+	"zai.webSearchInChat": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "providers",
+			label: "Z.AI Web Search in Chat",
+			description: "Enable Z.AI's built-in web search tool for chat completions",
+		},
+	},
+
+	"zai.webSearchMaxCalls": {
+		type: "number",
+		default: 5,
+		ui: {
+			tab: "providers",
+			label: "Z.AI Web Search Max Calls",
+			description: "Maximum number of separate search invocations per request (1-50)",
+		},
+	},
+
+	"zai.webSearchRecency": {
+		type: "enum",
+		default: "noLimit",
+		values: ["oneDay", "oneWeek", "oneMonth", "oneYear", "noLimit"],
+		ui: {
+			tab: "providers",
+			label: "Z.AI Web Search Recency",
+			description: "Time range filter for web search results",
+			options: [
+				{ value: "oneDay", label: "Past 24 hours" },
+				{ value: "oneWeek", label: "Past week" },
+				{ value: "oneMonth", label: "Past month" },
+				{ value: "oneYear", label: "Past year" },
+				{ value: "noLimit", label: "No limit" },
+			],
+		},
+	},
+
 	"commit.mapReduceEnabled": { type: "boolean", default: true },
 
 	"commit.mapReduceMinFiles": { type: "number", default: 4 },

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1976,6 +1976,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				return streamSimple(streamModel, context, {
 					...streamOptions,
 					openrouterVariant: streamOptions?.openrouterVariant ?? openrouterVariant,
+					zaiWebSearch:
+						streamOptions?.zaiWebSearch ??
+						(settings.get("zai.webSearchInChat")
+							? { enabled: true, maxSearchCalls: settings.get("zai.webSearchMaxCalls") || 5, recencyFilter: settings.get("zai.webSearchRecency") || "noLimit" }
+							: undefined),
 					onAuthError: async (provider, oldKey, error) => {
 						const message = error instanceof Error ? error.message : String(error);
 						// streamSimple invokes this for both 401 auth failures AND


### PR DESCRIPTION
## Summary

Adds Z.AI's built-in **Web Search in Chat** feature to the Anthropic-compatible chat completions pipeline. When enabled, a `web_search` tool is injected into requests to Z.AI endpoints, allowing the model to search the web natively and return cited answers.

## What it does

- **Injects `web_search_20250305` built-in tool** into requests when the model targets a Z.AI Anthropic-compatible endpoint and `zai.webSearchInChat` is enabled
- **Duplicate name guard** — skips injection when a client tool named `web_search` already exists
- **Handles response blocks**: `server_tool_use` (skipped), `web_search_tool_result` (Anthropic native), and `tool_result` (Z.AI's format)
- **Parses search results** from Z.AI's JSON content with type guards
- **Marks synthetic text as replay-unsafe** via `streamedReplayUnsafeContent`
- **Settings**: `zai.webSearchInChat`, `zai.webSearchCount` (clamped 1-50), `zai.webSearchRecency`

## Files changed

| File | Change |
|---|---|
| `packages/ai/src/providers/anthropic-wire.ts` | Added `ServerToolUseBlockParam`, `WebSearchResultItem`, `WebSearchToolResultBlockParam` |
| `packages/ai/src/providers/anthropic.ts` | `ZaiWebSearchConfig`, tool injection, stream handlers |
| `packages/ai/src/stream.ts` | Pass `zaiWebSearch` through `mapOptionsForApi` |
| `packages/ai/src/types.ts` | Added `zaiWebSearch` to `SimpleStreamOptions` |
| `packages/ai/test/zai-web-search-injection.test.ts` | 5 regression tests |
| `packages/coding-agent/src/config/settings-schema.ts` | 3 new settings |
| `packages/coding-agent/src/sdk.ts` | Wired settings to streamFn |

## Testing

- ✅ 5 regression tests (Z.AI injects, non-Z.AI skips, disabled skips, recency serializes, count clamps)
- ✅ Verified with Z.AI API key against live endpoint
- ✅ TypeScript compiles clean, biome passes