### PR TITLE
fix(coding-agent): made slash-command handlers compatible with TypeScript 5.x

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `tsc --noEmit` against `packages/coding-agent/tsconfig.json` reporting 56 errors under TypeScript 5.x (`builtin-registry.ts` × 46, `agent-session-openai-responses-replay.test.ts` × 10). The repo's own gate (`tsgo` / TypeScript 6.x) already accepted the `() => void` slash-command handlers, but 5.x rejects them because it does not coerce a `void`-returning function value into a `() => T | undefined` slot. The `SlashCommandSpec.handle` / `handleTui` signatures and the test's `createPersistedSession` `populate` callback are now expressed as a union of two function types (one returning a `SlashCommandResult` / target, one returning `void`), so the existing handler bodies typecheck on both compilers ([#1821](https://github.com/can1357/oh-my-pi/issues/1821)).
+
 ## [15.9.0] - 2026-06-04
 
 ### Breaking Changes

--- a/packages/coding-agent/src/slash-commands/types.ts
+++ b/packages/coding-agent/src/slash-commands/types.ts
@@ -31,7 +31,11 @@ export interface ParsedSlashCommand {
 /**
  * Result returned by a slash-command handler.
  *
- * - `void` / `undefined` — command was handled and consumed; no further input.
+ * - `undefined` (and the implicit `void` return) — command was handled and
+ *   consumed; no further input. Handlers may simply omit a `return` rather than
+ *   building `{ consumed: true }`; `void` is accepted in the handler signatures
+ *   below so the contract typechecks under TypeScript 5.x (which does not
+ *   coerce `() => void` to `() => T | undefined`) as well as 6.x / tsgo.
  * - `{ consumed: true }` — explicit equivalent of the above (ACP shape).
  * - `{ prompt: string }` — command handled, pass `prompt` through as the new
  *   user input (e.g. `/force <tool> <prompt>` keeps `<prompt>` as the message).
@@ -100,20 +104,33 @@ export interface SlashCommandSpec extends BuiltinSlashCommand {
 	/**
 	 * Text/ACP-mode handler. The same body is invoked from the ACP dispatcher
 	 * and, via the TUI adapter, when no `handleTui` override is provided.
+	 *
+	 * Expressed as a union of two function types — one returning a
+	 * `SlashCommandResult`, one returning `void` — so handlers that simply
+	 * `return` (or omit the return) typecheck under TypeScript 5.x as well as
+	 * 6.x / tsgo. TS 5.x does not coerce a `() => void` value into a
+	 * `() => T | undefined` slot, so the two return shapes must be siblings
+	 * rather than a `T | void` union inside one function type (which Biome's
+	 * `noConfusingVoidType` also rejects).
 	 */
-	handle?: (
-		command: ParsedSlashCommand,
-		runtime: SlashCommandRuntime,
-	) => Promise<SlashCommandResult> | SlashCommandResult;
+	handle?:
+		| ((
+				command: ParsedSlashCommand,
+				runtime: SlashCommandRuntime,
+		  ) => SlashCommandResult | Promise<SlashCommandResult>)
+		| ((command: ParsedSlashCommand, runtime: SlashCommandRuntime) => void | Promise<void>);
 	/**
 	 * TUI-only handler that supersedes `handle` when both are present. Use for
 	 * selectors, wizards, dashboards, and anything else that requires
-	 * `InteractiveModeContext`.
+	 * `InteractiveModeContext`. See `handle` for the rationale behind the
+	 * function-type union shape.
 	 */
-	handleTui?: (
-		command: ParsedSlashCommand,
-		runtime: TuiSlashCommandRuntime,
-	) => Promise<SlashCommandResult> | SlashCommandResult;
+	handleTui?:
+		| ((
+				command: ParsedSlashCommand,
+				runtime: TuiSlashCommandRuntime,
+		  ) => SlashCommandResult | Promise<SlashCommandResult>)
+		| ((command: ParsedSlashCommand, runtime: TuiSlashCommandRuntime) => void | Promise<void>);
 }
 
 /** Result returned by `executeAcpBuiltinSlashCommand`. */

--- a/packages/coding-agent/test/agent-session-openai-responses-replay.test.ts
+++ b/packages/coding-agent/test/agent-session-openai-responses-replay.test.ts
@@ -189,7 +189,14 @@ function expectAssistantReplayMetadataSanitized(message: AssistantMessage): void
 
 async function createPersistedSession(
 	tempDir: string,
-	populate: (sessionManager: SessionManager) => { treeTargetId?: string } | undefined,
+	// Function-type union so callbacks that just mutate the SessionManager and
+	// fall off the end (TS infers `() => void`) typecheck under TypeScript 5.x
+	// alongside callbacks that explicitly return a tree target. TS 5.x does not
+	// coerce a `void`-returning function value into a `() => T | undefined` slot
+	// the way 6.x / tsgo does, so the two return shapes have to be siblings.
+	populate:
+		| ((sessionManager: SessionManager) => { treeTargetId?: string } | undefined)
+		| ((sessionManager: SessionManager) => void),
 ): Promise<{ sessionFile: string; treeTargetId?: string }> {
 	const sessionManager = SessionManager.create(tempDir, tempDir);
 	const result = populate(sessionManager);


### PR DESCRIPTION
## Repro

Run vanilla `tsc --noEmit` (TypeScript 5.9.3) against the coding-agent package — i.e. exactly the command the issue ran via `npx tsc --noEmit --project packages/coding-agent/tsconfig.json`:

```sh
bun /tmp/.../typescript/lib/tsc.js --noEmit -p packages/coding-agent/tsconfig.json
```

Produces 56 errors:

| File | Count | Code |
|---|---|---|
| `src/slash-commands/builtin-registry.ts` | 46 | TS2322 |
| `test/agent-session-openai-responses-replay.test.ts` | 10 | TS2345 |

The repo's own gate (`packages/coding-agent/package.json` `"check:types": "tsgo -p tsconfig.json --noEmit"`, which runs `@typescript/native-preview` aliased as TypeScript 6.x) reports zero, which is why `bun run check:ts` passes workspace-wide and these never surfaced.

The issue also lists `src/telemetry-export.ts` × 2 and `packages/tui/test/virtual-terminal.ts` × 1; neither reproduces on this checkout — the catalog already declares `@opentelemetry/exporter-trace-otlp-proto`, `@opentelemetry/sdk-trace-node`, and `ghostty-web`, and `bun install` resolves them. Likely a stale `node_modules` when the issue was filed.

## Cause

`SlashCommandSpec.handle` and `handleTui` in `packages/coding-agent/src/slash-commands/types.ts` were typed as `(...) => Promise<SlashCommandResult> | SlashCommandResult`, with `SlashCommandResult = undefined | { consumed: true } | { prompt: string }`. The 46 affected handlers in `builtin-registry.ts` are plain arrow functions that fall off the end, so TypeScript infers their return type as `void` / `Promise<void>`. TypeScript 6.x / `tsgo` coerce a `() => void` value into a `() => T | undefined` slot; TypeScript 5.x does not. Same root cause for the 10 callbacks the test passes to `createPersistedSession`, whose `populate` parameter was typed `(sessionManager) => { treeTargetId?: string } | undefined`.

## Fix

- Rewrote both handler signatures in `packages/coding-agent/src/slash-commands/types.ts` as a **union of two function types** — one returning `SlashCommandResult | Promise<SlashCommandResult>`, one returning `void | Promise<void>` — so a handler may either return a result or fall off the end. The `T | void` shape inside a single function-return position also trips Biome's `noConfusingVoidType`; making the `void` branch its own sibling function type passes both compilers and the linter.
- Applied the same union shape to `createPersistedSession`'s `populate` parameter in `test/agent-session-openai-responses-replay.test.ts`.
- Updated the `SlashCommandResult` JSDoc to spell out the rationale, and cross-referenced it from the handler JSDocs.
- No handler body, no dispatcher (`builtin-registry.ts` `executeBuiltinSlashCommand`, `acp-builtins.ts` `executeAcpBuiltinSlashCommand`), and no test call site changed — the runtime contract (`if (result === undefined) ...` / `if (result && 'prompt' in result) ...`) is unchanged.
- Added an Unreleased CHANGELOG entry.

## Verification

- `bun /tmp/.../typescript/lib/tsc.js --noEmit -p packages/coding-agent/tsconfig.json` → **0 errors** (was 56).
- `bun --cwd=packages/coding-agent run check:types` (`tsgo`) → 0 errors.
- `bun run check:ts` (biome + per-package `tsgo` across the workspace) → 0 errors.
- `bun --cwd=packages/coding-agent test test/agent-session-openai-responses-replay.test.ts` → **14/14 pass**.
- `bun --cwd=packages/coding-agent test test/slash-commands` → **36/36 pass**.

Fixes #1821