### PR TITLE
fix(coding-agent): sync pi-natives on omp update

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp update` leaving `@oh-my-pi/pi-natives` and the platform-specific `@oh-my-pi/pi-natives-<tag>` leaf at the previous version on `bun install -g` updates, so the next launch loaded a stale `.node` file and aborted at `validateLoadedBindings` with `The .node file on disk is from a different release than this loader`. `omp update` now pins the native addon core and the platform leaf to the same version it installs for `@oh-my-pi/pi-coding-agent` ([#1824](https://github.com/can1357/oh-my-pi/issues/1824)).
+
 ## [15.9.0] - 2026-06-04
 
 ### Breaking Changes

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -27,6 +27,33 @@ const PACKAGE = "@oh-my-pi/pi-coding-agent";
  */
 const NPM_REGISTRY = "https://registry.npmjs.org/";
 
+/**
+ * Core native addon package. Bumped in lock-step with {@link PACKAGE} so the
+ * version sentinel the loader looks up at runtime matches the `.node` on
+ * disk; see {@link buildBunInstallArgs} for why this must be installed
+ * explicitly rather than inherited as a transitive dependency.
+ */
+const NATIVES_PACKAGE = "@oh-my-pi/pi-natives";
+
+/**
+ * Platform tags the release pipeline publishes as
+ * `@oh-my-pi/pi-natives-<tag>` leaves. Mirrors `SUPPORTED_PLATFORMS` in
+ * `packages/natives/native/loader-state.js` and `LEAF_TARGETS` in
+ * `packages/natives/scripts/gen-npm-packages.ts`; kept here as the local
+ * source of truth so the update path stays free of cross-package imports.
+ */
+const SUPPORTED_NATIVE_TAGS: ReadonlySet<string> = new Set([
+	"linux-x64",
+	"linux-arm64",
+	"darwin-x64",
+	"darwin-arm64",
+	"win32-x64",
+]);
+
+function currentNativeTag(): string {
+	return `${process.platform}-${process.arch}`;
+}
+
 interface ReleaseInfo {
 	tag: string;
 	version: string;
@@ -319,9 +346,37 @@ export async function replaceBinaryForUpdate(options: BinaryReplacementOptions):
  *
  * Together these two flags make `omp update` produce exactly the registry
  * lookup the version check just performed. See #1686.
+ *
+ * Also pins {@link NATIVES_PACKAGE} and the platform-specific
+ * `@oh-my-pi/pi-natives-<tag>` leaf to `expectedVersion`. `bun install -g`
+ * does not reliably refresh transitive `optionalDependencies` when the
+ * top-level package is the only one bumped, so the native addon and its
+ * version sentinel can drift out of sync with the freshly installed
+ * `@oh-my-pi/pi-coding-agent` and the loader aborts at
+ * `validateLoadedBindings` on the next launch
+ * (`The .node file on disk is from a different release than this loader`).
+ * Listing the natives explicitly forces bun to replace them in lock-step.
+ * The leaf is added only on tags the release pipeline actually publishes
+ * ({@link SUPPORTED_NATIVE_TAGS}) so unsupported platforms still fail with
+ * the original "no matching version" message instead of `EBADPLATFORM`.
+ * See #1824.
  */
-export function buildBunInstallArgs(expectedVersion: string): string[] {
-	return ["install", "-g", "--no-cache", `--registry=${NPM_REGISTRY}`, `${PACKAGE}@${expectedVersion}`];
+export function buildBunInstallArgs(
+	expectedVersion: string,
+	nativeTag: string = currentNativeTag(),
+): string[] {
+	const args = [
+		"install",
+		"-g",
+		"--no-cache",
+		`--registry=${NPM_REGISTRY}`,
+		`${PACKAGE}@${expectedVersion}`,
+		`${NATIVES_PACKAGE}@${expectedVersion}`,
+	];
+	if (SUPPORTED_NATIVE_TAGS.has(nativeTag)) {
+		args.push(`${NATIVES_PACKAGE}-${nativeTag}@${expectedVersion}`);
+	}
+	return args;
 }
 
 /**

--- a/packages/coding-agent/src/cli/update-cli.ts
+++ b/packages/coding-agent/src/cli/update-cli.ts
@@ -361,10 +361,7 @@ export async function replaceBinaryForUpdate(options: BinaryReplacementOptions):
  * the original "no matching version" message instead of `EBADPLATFORM`.
  * See #1824.
  */
-export function buildBunInstallArgs(
-	expectedVersion: string,
-	nativeTag: string = currentNativeTag(),
-): string[] {
+export function buildBunInstallArgs(expectedVersion: string, nativeTag: string = currentNativeTag()): string[] {
 	const args = [
 		"install",
 		"-g",

--- a/packages/coding-agent/test/update-cli.test.ts
+++ b/packages/coding-agent/test/update-cli.test.ts
@@ -45,13 +45,39 @@ describe("update-cli bun install command", () => {
 		//     is already pointed at the official registry but its cache predates
 		//     the release.
 		// See https://github.com/can1357/oh-my-pi/issues/1686.
-		expect(buildBunInstallArgs("15.7.6")).toEqual([
+		const args = buildBunInstallArgs("15.7.6", "linux-x64");
+		expect(args.slice(0, 5)).toEqual([
 			"install",
 			"-g",
 			"--no-cache",
 			"--registry=https://registry.npmjs.org/",
 			"@oh-my-pi/pi-coding-agent@15.7.6",
 		]);
+	});
+
+	it("pins the native addon core and the platform-specific leaf to the same version so the loader sentinel cannot drift on supported tags", () => {
+		// Regression: bun install -g <pkg>@<v> would update only the top-level
+		// package, leaving @oh-my-pi/pi-natives and @oh-my-pi/pi-natives-<tag>
+		// at their previous version. The next launch then loaded a stale .node
+		// file and aborted at validateLoadedBindings with `The .node file on
+		// disk is from a different release than this loader`. See
+		// https://github.com/can1357/oh-my-pi/issues/1824.
+		for (const tag of ["linux-x64", "linux-arm64", "darwin-x64", "darwin-arm64", "win32-x64"]) {
+			const args = buildBunInstallArgs("15.9.0", tag);
+			expect(args).toContain("@oh-my-pi/pi-natives@15.9.0");
+			expect(args).toContain(`@oh-my-pi/pi-natives-${tag}@15.9.0`);
+		}
+	});
+
+	it("omits the leaf on unsupported platform tags so an EBADPLATFORM swap does not mask the underlying `no matching version` error", () => {
+		// Defensive: an unsupported tag (e.g. linux-arm32) still installs the
+		// core natives package — which will fail at module load if the platform
+		// truly is unsupported — but we never request a leaf the release
+		// pipeline doesn't publish, otherwise bun aborts with EBADPLATFORM
+		// and hides the real diagnostic from `loadNative`'s aggregated error.
+		const args = buildBunInstallArgs("15.9.0", "linux-arm");
+		expect(args).toContain("@oh-my-pi/pi-natives@15.9.0");
+		expect(args.some(arg => arg.startsWith("@oh-my-pi/pi-natives-"))).toBe(false);
 	});
 });
 


### PR DESCRIPTION
## Repro

On Windows 11 (reporter), after `omp update` from `15.8.3` → `15.9.0` the next launch crashes:

```
Error: Failed to load pi_natives native addon for win32-x64 (baseline).
The .node file on disk is from a different release than this loader — reinstall to re-sync.
```

The loader (`packages/natives/native/loader-state.js::validateLoadedBindings`) expects `__piNativesV15_9_0` but the `.node` on disk still exposes `__piNativesV15_8_3`. Inspecting the install: `@oh-my-pi/pi-coding-agent` was bumped, `@oh-my-pi/pi-natives` and `@oh-my-pi/pi-natives-win32-x64` were not. Reporter's workaround was a manual `bun add @oh-my-pi/pi-natives@latest @oh-my-pi/pi-natives-win32-x64@latest --force` (issue #1824).

Synthetic repro of the underlying argv builder:

```bash
bun --print 'import { buildBunInstallArgs } from "./packages/coding-agent/src/cli/update-cli"; \
  console.log(buildBunInstallArgs("15.9.0", "win32-x64").join(" "))'
```

Before this PR that printed just `… @oh-my-pi/pi-coding-agent@15.9.0`, which is exactly what `omp update` was handing to bun.

## Cause

`packages/coding-agent/src/cli/update-cli.ts::buildBunInstallArgs` only listed `@oh-my-pi/pi-coding-agent@<v>`. The published `pi-coding-agent` pins `@oh-my-pi/pi-natives` and that package lists each `@oh-my-pi/pi-natives-<tag>` as an `optionalDependency`, but `bun install -g <pkg>@<v>` does not reliably re-resolve transitive optional deps that are already on disk at an older version. `scripts/release.ts` bumps the `js_name = "__piNativesV…"` sentinel in `crates/pi-natives/src/lib.rs` in lock-step with the package version, so the drift turns into a fatal load-time error instead of a silent `<sym> is not a function` deeper in tool execution.

## Fix

- `buildBunInstallArgs` now also pins `@oh-my-pi/pi-natives@<v>` and — when the running `process.platform-process.arch` is one of the published leaves (`SUPPORTED_NATIVE_TAGS` mirrors `SUPPORTED_PLATFORMS` in the loader and `LEAF_TARGETS` in `packages/natives/scripts/gen-npm-packages.ts`) — `@oh-my-pi/pi-natives-<tag>@<v>`. bun is forced to update all three together.
- The leaf is omitted on unsupported tags so an `EBADPLATFORM` swap does not mask the original `no matching version` diagnostic from `loadNative`'s aggregated error.
- The loader's per-version cache directory is keyed off the `@oh-my-pi/pi-natives` version (`~/.omp/natives/<v>/`), so the next genuine release after this PR stages a fresh `.node` into a fresh dir; any cache poisoned by a prior broken update is naturally bypassed.
- Existing test extended to cover the new args, plus two new tests pin the supported-tag matrix and the unsupported-tag fallback.
- CHANGELOG entry under `[Unreleased] / Fixed`.
- Binary update path (`updateViaBinaryAt`) and compiled-binary loader path are unchanged — they ship the addon embedded.

## Verification

- `bun --cwd=packages/coding-agent test test/update-cli.test.ts` → 8/8 pass (23 expects).
- `lsp diagnostics` on `packages/coding-agent/src/cli/update-cli.ts` and `packages/coding-agent/test/update-cli.test.ts` → OK.
- After fix, `buildBunInstallArgs("15.9.0", "win32-x64")` prints `… @oh-my-pi/pi-coding-agent@15.9.0 @oh-my-pi/pi-natives@15.9.0 @oh-my-pi/pi-natives-win32-x64@15.9.0`.

Fixes #1824