### PR TITLE
fix(tui): defer async offscreen expansions on ED3-risk unknown viewports (#1823)

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed completed async offscreen expansions on ED3-risk terminals (Ghostty/kitty/Alacritty/iTerm2/WSL inside Windows Terminal) with an unobservable native viewport repainting the live window over stale scrollback, surfacing duplicated rows around the viewport boundary after an async `AssistantThinkingRenderer` finished above already-streamed formal output. The offscreen-edit branch of the render planner now mirrors the existing shrink-branch deferral: when the viewport probe is unavailable, the terminal is ED3-risk, no eager streaming rebuild is in progress, and the mutation is not a clean tail append, the planner defers to `deferredMutation` so the next explicit `refreshNativeScrollbackIfDirty` checkpoint replays the transcript once. Clean tail-appends, eager streaming, and multiplexer panes keep their existing repaint path so live output is never delayed ([#1823](https://github.com/can1357/oh-my-pi/issues/1823)).
+
 ## [15.9.0] - 2026-06-04
 
 ### Added

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1891,6 +1891,30 @@ export class TUI extends Container {
 				return { kind: "historyRebuild" };
 			}
 			this.#markNativeScrollbackDirty();
+			// Async-completion offscreen structural mutation on an ED3-risk
+			// terminal whose viewport position is unobservable. The fallback
+			// `viewportRepaint` below repaints the visible window in place but
+			// leaves whatever already landed in native scrollback alone — when a
+			// thinking renderer asynchronously expands above the live tail, that
+			// committed scrollback becomes stale and the next live mutate can
+			// surface duplicated rows around the boundary (issue #1823). Defer
+			// until the next explicit checkpoint where
+			// `refreshNativeScrollbackIfDirty` can rebuild the full transcript
+			// exactly once. Active eager streaming (`#eagerNativeScrollbackRebuild`)
+			// keeps its existing repaint path so streamed output is never delayed,
+			// and a clean tail-append still flows through `emitAppendTail` so newly
+			// appended rows reach scrollback. Multiplexer panes cannot rebuild
+			// history, so a deferral would freeze the UI — leave their repaint
+			// path alone.
+			if (
+				nativeViewportAtBottom === undefined &&
+				eagerEraseScrollbackRisk &&
+				!this.#eagerNativeScrollbackRebuild &&
+				!cleanTailAppend &&
+				!isMultiplexerSession()
+			) {
+				return { kind: "deferredMutation" };
+			}
 			return { kind: "viewportRepaint", appendFrom: cleanTailAppend ? this.#previousLines.length : undefined };
 		}
 

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -2202,6 +2202,121 @@ describe("TUI terminal-state regressions", () => {
 				Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
 			}
 		});
+
+		it("defers completed async offscreen expansions on ED3-risk unknown viewports", async () => {
+			// #1823: An async `AssistantThinkingRenderer` finishes after the formal
+			// assistant output has already overflowed the viewport — the next
+			// `requestRender()` is a structural mutation whose `firstChanged` lies
+			// above `prevViewportTop`. On an ED3-risk terminal the viewport probe
+			// is unobservable, so the planner cannot safely rebuild history; the
+			// previous fallback `viewportRepaint` repainted the visible window
+			// while leaving stale rows in native scrollback above it, producing the
+			// duplicate-row symptom around the viewport boundary. The fix defers
+			// until the next checkpoint, where `refreshNativeScrollbackIfDirty`
+			// rebuilds the full transcript exactly once.
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
+			try {
+				await withTerminalRisk(true, async () => {
+					const term = new UnknownViewportTerminal(40, 10);
+					const tui = new TUI(term);
+					const initialThinking = "thinking-placeholder";
+					const output = rows("output-", 18);
+					const component = new MutableLinesComponent([initialThinking, ...output, "prompt-row"]);
+					tui.addChild(component);
+
+					try {
+						tui.start();
+						await settle(term);
+
+						const beforeViewport = visible(term).map(line => line.trim());
+						expect(beforeViewport[beforeViewport.length - 1]).toBe("prompt-row");
+
+						// Capture every byte the renderer writes from the async render onwards.
+						const writes = captureWrites(term);
+
+						// Async thinking renderer completes: replace a single-row placeholder
+						// with a four-row block. firstChanged = 0, prevViewportTop = 10.
+						const expandedThinking = ["thinking-a", "thinking-b", "thinking-c", "thinking-d"];
+						component.setLines([...expandedThinking, ...output, "prompt-row"]);
+						tui.requestRender();
+						await settle(term);
+
+						// Pre-fix: planner returned `viewportRepaint`, emitting at least the
+						// synchronized-output preamble plus per-row clear/content bytes.
+						// Post-fix: `deferredMutation` is a no-op, so the terminal sees nothing
+						// until the next explicit checkpoint reconciles the transcript.
+						expect(writes.join("")).toBe("");
+
+						// Visible viewport stays anchored to the previously committed slice —
+						// no live repaint was applied.
+						expect(visible(term).map(line => line.trim())).toEqual(beforeViewport);
+
+						// Explicit checkpoint reconciles: the deferred 23-row transcript
+						// gets replayed and the bottom-anchored viewport now reflects the
+						// post-expansion slice. (The checkpoint's `historyRebuild` does
+						// not retroactively dedupe rows already in native scrollback —
+						// the contract enforced here is that NO live bytes hit the
+						// terminal between the async mutation and the checkpoint, so
+						// the planner cannot make the boundary worse on its own.)
+						expect(tui.refreshNativeScrollbackIfDirty({ allowUnknownViewport: true })).toBe(true);
+						await settle(term);
+
+						const after = visible(term).map(line => line.trim());
+						expect(after[after.length - 1]).toBe("prompt-row");
+						// Last visible non-prompt row matches the new bottom-anchored slice
+						// (one row of the expansion pushed everything down by three).
+						expect(after[after.length - 2]).toBe("output-17");
+					} finally {
+						tui.stop();
+					}
+				});
+			} finally {
+				Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+			}
+		});
+
+		it("keeps offscreen clean tail-appends streaming on ED3-risk unknown viewports", async () => {
+			// Counterpart guarantee for the #1823 deferral: a clean tail-append
+			// (the suffix of the previous frame is preserved verbatim and only
+			// new rows land below it) MUST keep flowing through `viewportRepaint`
+			// + `emitAppendTail` so streamed output is never delayed. The
+			// deferral guard above is gated on `!cleanTailAppend` precisely so
+			// this path stays live.
+			const originalPlatform = process.platform;
+			Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
+			try {
+				await withTerminalRisk(true, async () => {
+					const term = new UnknownViewportTerminal(40, 10);
+					const tui = new TUI(term);
+					const seed = rows("seed-", 12);
+					const component = new MutableLinesComponent(seed);
+					tui.addChild(component);
+
+					try {
+						tui.start();
+						await settle(term);
+
+						// Pure tail append: cleanTailAppend = true even though firstChanged
+						// lands above prevViewportTop (the previous tail still matches the
+						// new content suffix-wise after the append).
+						const writes = captureWrites(term);
+						component.setLines([...seed, "tail-row"]);
+						tui.requestRender();
+						await settle(term);
+
+						expect(writes.join("")).not.toBe("");
+						const after = visible(term).map(line => line.trim());
+						expect(after[after.length - 1]).toBe("tail-row");
+					} finally {
+						tui.stop();
+					}
+				});
+			} finally {
+				Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
+			}
+		});
+
 		it("rebuilds history when prior POSIX repaint left the padded viewport past the new tail", async () => {
 			const term = new UnknownViewportTerminal(40, 10);
 			const tui = new TUI(term);


### PR DESCRIPTION
## Repro

On terminals where the native viewport probe is unobservable (`isNativeViewportAtBottom()` → `undefined`) and the terminal is ED3-risk (`TERMINAL.eagerEraseScrollbackRisk = true` — Ghostty/kitty/Alacritty/iTerm2 and WSL inside Windows Terminal), an async `AssistantThinkingRenderer` that completes after the formal assistant output has already overflowed the viewport calls `requestRender()` with `diff.firstChanged < prevViewportTop` (structural mutation above the live viewport). Driven directly as a test:

```
bun test packages/tui/test/render-regressions.test.ts -t "defers completed async offscreen"
```

With the planner's pre-fix fallback at `packages/tui/src/tui.ts:1883`, `captureWrites(term)` shows the live repaint hitting the terminal:

```
expect(writes.join("")).toBe("");
- ""
+ "output-9
+ output-10
+ ...
+ output-17
+ prompt-row"
```

That live repaint is the byte stream that puts the renderer's state out of sync with what's already in native scrollback above, surfacing the duplicate-row symptom around the viewport boundary on the next live mutate.

## Cause

The offscreen-edit branch at `packages/tui/src/tui.ts:1883` (`diff.firstChanged < prevViewportTop`) tries `historyRebuild` first, then falls straight through to `viewportRepaint` whenever `canRebuildNativeScrollbackLive` is false. On ED3-risk terminals with an unobservable viewport that helper is gated off (the eager-rebuild opt-in is stripped at `tui.ts:1385` because `eagerEraseScrollbackRisk` is true), so the fallback always fires. The symmetric shrink branch at `tui.ts:1589` already defers via `{ kind: "deferredMutation" }` under the same conditions — the offscreen-edit branch was missing that guard, leaving completed async expansions to repaint over scrollback the planner cannot observe.

## Fix

- `packages/tui/src/tui.ts:1893–1918` — In the `diff.firstChanged < prevViewportTop` branch, after the failed `historyRebuild` attempt and the existing `markNativeScrollbackDirty`, return `{ kind: "deferredMutation" }` when `nativeViewportAtBottom === undefined && eagerEraseScrollbackRisk && !#eagerNativeScrollbackRebuild && !cleanTailAppend && !isMultiplexerSession()`. Active eager streaming, clean tail-appends, and multiplexer panes (whose pane history cannot be rebuilt) all keep the existing `viewportRepaint` path so streamed output is never delayed.
- `packages/tui/test/render-regressions.test.ts` — New `scrollback integrity > defers completed async offscreen expansions on ED3-risk unknown viewports` test drives the `UnknownViewportTerminal` + linux + ED3-risk shape directly: 20-row content overflowing a 10-row viewport, async expansion of a one-row placeholder into four rows, `captureWrites` asserts no bytes hit the terminal until `refreshNativeScrollbackIfDirty` runs. Companion `keeps offscreen clean tail-appends streaming on ED3-risk unknown viewports` pins the `!cleanTailAppend` carve-out so streaming output keeps flowing on the same terminals.
- `packages/tui/CHANGELOG.md` — Entry under `## [Unreleased] > ### Fixed`.

Independent of #1729 (extension-API PR) and complementary to #1764 (Windows Terminal streaming inserts above a fixed prompt/footer): #1764 hardens the streaming-insert path, this hardens the completed-async-mutation path. The fix only changes the planner's verdict on a single previously-unguarded branch — every other emit path is unaffected.

## Verification

```
$ bun test packages/tui/test/render-regressions.test.ts
 95 pass / 0 fail / 464 expect()

$ bun test packages/tui/test/issue-1610-repro.test.ts packages/tui/test/issue-1635-repro.test.ts packages/tui/test/issue-1682-repro.test.ts packages/tui/test/issue-1746-repro.test.ts packages/tui/test/issue-1765-repro.test.ts
 24 pass / 0 fail / 75 expect()

$ bun --cwd=packages/tui check
 # biome check + tsgo --noEmit clean
```

Also manually flipped the new deferral guard off (`if (false && nativeViewportAtBottom === undefined && ...)`) to confirm the new test genuinely fails without the fix — `writes.join("")` returned the offending `output-9..output-17` + `prompt-row` repaint bytes.

The package-wide `bun test packages/tui` run shows 6 pre-existing OSC 66 text-sizing failures in `packages/tui/test/markdown.test.ts` and `packages/tui/test/text-utils.test.ts`. They reproduce identically on the unchanged branch base (`git stash` confirmed) and are unrelated to the render planner — they assert OSC 66 width measurement and predate this branch.

Fixes #1823