### PR TITLE
fix(notebook): escape source lines that collide with the cell marker

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `.ipynb` notebook round-trip corruption where a source line that collides with the cell-marker pattern (a body line that itself reads like `# %%`) was misparsed as a cell boundary on reserialize. Such lines are now escaped on write and symmetrically unescaped on read, with an escape-the-escape branch so content that legitimately begins with a backslash round-trips unchanged ([#1836](https://github.com/can1357/oh-my-pi/pull/1836) by [@Mubashirrrr](https://github.com/Mubashirrrr)).
+
 ## [15.9.0] - 2026-06-04
 
 ### Breaking Changes

--- a/packages/coding-agent/src/edit/notebook.ts
+++ b/packages/coding-agent/src/edit/notebook.ts
@@ -22,6 +22,30 @@ export interface NotebookDocument {
 
 const CELL_MARKER_RE = /^# %% \[(code|markdown|raw)\](?: cell:(\d+))?$/;
 
+/**
+ * A source line collides with the virtual-cell delimiter when, after removing
+ * any leading run of backslash escapes, the remainder is a cell marker. Such a
+ * line must be escaped on serialize so it is not mistaken for a cell boundary
+ * on the round-trip back (which would split one cell into several and drop the
+ * line's content). Escaping the escape keeps the transform reversible for
+ * content that already begins with a backslash.
+ */
+function bodyLineCollidesWithMarker(line: string): boolean {
+	let unescaped = line;
+	while (unescaped.startsWith("\\")) unescaped = unescaped.slice(1);
+	return CELL_MARKER_RE.test(unescaped);
+}
+
+/** Prefix one backslash to a source line that would otherwise read as a cell marker. */
+function escapeBodyLine(line: string): string {
+	return bodyLineCollidesWithMarker(line) ? `\\${line}` : line;
+}
+
+/** Reverse {@link escapeBodyLine}: strip the single backslash this serializer added. */
+function unescapeBodyLine(line: string): string {
+	return line.startsWith("\\") && bodyLineCollidesWithMarker(line.slice(1)) ? line.slice(1) : line;
+}
+
 export function isNotebookPath(filePath: string): boolean {
 	return path.extname(filePath).toLowerCase() === ".ipynb";
 }
@@ -101,9 +125,12 @@ export function notebookToEditableText(notebook: NotebookDocument): string {
 	return notebook.cells
 		.map((cell, index) => {
 			const source = sourceToText(cell.source);
-			return source.length > 0
-				? `# %% [${cell.cell_type}] cell:${index}\n${source}`
-				: `# %% [${cell.cell_type}] cell:${index}`;
+			const marker = `# %% [${cell.cell_type}] cell:${index}`;
+			if (source.length === 0) return marker;
+			// Escape any body line that would itself read as a cell marker so the
+			// round-trip back does not split this cell at its own content.
+			const escaped = source.split("\n").map(escapeBodyLine).join("\n");
+			return `${marker}\n${escaped}`;
 		})
 		.join("\n");
 }
@@ -156,7 +183,7 @@ function parseNotebookEditableText(text: string, displayPath: string): ParsedVir
 				`Invalid notebook editable representation for ${displayPath}: expected first line to be "# %% [code] cell:0", "# %% [markdown] cell:0", or "# %% [raw] cell:0".`,
 			);
 		}
-		current.lines.push(line);
+		current.lines.push(unescapeBodyLine(line));
 	}
 	flush();
 	return cells;

--- a/packages/coding-agent/test/notebook-roundtrip.test.ts
+++ b/packages/coding-agent/test/notebook-roundtrip.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { applyNotebookEditableText, type NotebookDocument, notebookToEditableText } from "../src/edit/notebook";
+
+function makeNotebook(cells: NotebookDocument["cells"]): NotebookDocument {
+	return { cells, metadata: {}, nbformat: 4, nbformat_minor: 5 };
+}
+
+function sourceText(cell: NotebookDocument["cells"][number]): string {
+	const { source } = cell;
+	if (source === undefined) return "";
+	return typeof source === "string" ? source : source.join("");
+}
+
+describe("notebook editable-text round-trip", () => {
+	test("preserves a cell whose source contains a line that looks like a cell marker", () => {
+		// A markdown/doc cell that quotes the percent-cell syntax. Before the fix
+		// this line was parsed back as a real cell boundary, splitting the cell
+		// and dropping the quoted line.
+		const notebook = makeNotebook([
+			{
+				cell_type: "markdown",
+				source: ["Start a cell with:\n", "# %% [code]\n", "and write code below.\n"],
+				metadata: { tag: "intro" },
+			},
+			{
+				cell_type: "code",
+				source: ["print('second cell')\n"],
+				metadata: {},
+				execution_count: 7,
+				outputs: [{ output_type: "stream", text: "second cell\n" }],
+			},
+		]);
+
+		const editable = notebookToEditableText(notebook);
+		const roundTripped = applyNotebookEditableText(notebook, editable, "demo.ipynb");
+
+		// Cell count is unchanged: the marker-like body line did not split the cell.
+		expect(roundTripped.cells).toHaveLength(2);
+
+		// The first cell keeps its type, full source (including the quoted marker
+		// line), and metadata.
+		expect(roundTripped.cells[0].cell_type).toBe("markdown");
+		expect(sourceText(roundTripped.cells[0])).toBe("Start a cell with:\n# %% [code]\nand write code below.\n");
+		expect(roundTripped.cells[0].metadata).toEqual({ tag: "intro" });
+
+		// The second cell is untouched: its execution count and outputs survive,
+		// confirming nothing shifted onto the wrong original cell.
+		expect(roundTripped.cells[1].cell_type).toBe("code");
+		expect(sourceText(roundTripped.cells[1])).toBe("print('second cell')\n");
+		expect(roundTripped.cells[1].execution_count).toBe(7);
+		expect(roundTripped.cells[1].outputs).toEqual([{ output_type: "stream", text: "second cell\n" }]);
+	});
+
+	test("handles a source line that already starts with the escape character", () => {
+		// Content that itself begins with `\# %% [code]` must survive verbatim
+		// (escape-the-escape), and a leading backslash on an ordinary line must
+		// not be stripped.
+		const notebook = makeNotebook([
+			{
+				cell_type: "code",
+				source: ["\\# %% [code]\n", "\\n is a newline\n", "# %% [raw] cell:3\n"],
+				metadata: {},
+			},
+		]);
+
+		const editable = notebookToEditableText(notebook);
+		const roundTripped = applyNotebookEditableText(notebook, editable, "demo.ipynb");
+
+		expect(roundTripped.cells).toHaveLength(1);
+		expect(sourceText(roundTripped.cells[0])).toBe("\\# %% [code]\n\\n is a newline\n# %% [raw] cell:3\n");
+	});
+
+	test("still allows adding a new cell via an unindexed marker", () => {
+		// The unindexed `# %% [code]` form remains a supported way for an edit to
+		// introduce a brand-new cell; only marker-like *body* lines are escaped.
+		const notebook = makeNotebook([{ cell_type: "code", source: ["a = 1\n"], metadata: {} }]);
+		const edited = "# %% [code] cell:0\na = 1\n# %% [markdown]\nnew cell\n";
+		const roundTripped = applyNotebookEditableText(notebook, edited, "demo.ipynb");
+
+		expect(roundTripped.cells).toHaveLength(2);
+		expect(roundTripped.cells[1].cell_type).toBe("markdown");
+		expect(sourceText(roundTripped.cells[1])).toBe("new cell\n");
+	});
+});


### PR DESCRIPTION
## Bug

`read`-ing an `.ipynb` returns a percent-format editable text where each cell is delimited by a `# %% [type] cell:N` marker (`notebookToEditableText`). On write-back, `parseNotebookEditableText` treats **any** line matching that marker as a cell boundary — including lines that are actually *cell content*.

So a notebook whose source contains a marker-like line (a Jupytext / VS Code `# %%` marker quoted in a markdown or code cell — common in real notebooks and docs) gets corrupted on the read → edit → write round-trip, **even when the agent never edits that cell**:

- one cell is split into several,
- the marker-like line is silently dropped,
- `execution_count` / `outputs` / `metadata` shift onto the wrong original cells.

### Repro (before this PR)

```ts
import { notebookToEditableText, applyNotebookEditableText } from "@oh-my-pi/coding-agent/edit/notebook";

const nb = {
  cells: [
    { cell_type: "markdown", source: ["Start a cell with:\n", "# %% [code]\n", "and write code below.\n"], metadata: { tag: "intro" } },
    { cell_type: "code", source: ["print('second cell')\n"], metadata: {}, execution_count: 7, outputs: [{ output_type: "stream", text: "second cell\n" }] },
  ],
  metadata: {}, nbformat: 4, nbformat_minor: 5,
};

const back = applyNotebookEditableText(nb, notebookToEditableText(nb), "demo.ipynb");
// back.cells.length === 3   (expected 2)
// cell[0] loses "and write code below." and the "# %% [code]" line is gone
// cell[1]'s execution_count/outputs land on the wrong cell
```

## Root cause

The editable-text format has no escaping for source lines that collide with the cell-marker syntax. The serializer emits such lines verbatim, and the parser cannot tell a content line from a real boundary.

## Fix

Escape body lines that would read as a cell marker on serialize, and strip the escape on parse:

- A line is escaped (prefixed with one `\`) iff, after removing any leading run of backslashes, it matches `CELL_MARKER_RE`.
- Escaping the escape keeps the transform reversible for content that already begins with a backslash.
- Only marker-colliding lines are touched, so ordinary source is byte-for-byte unchanged.
- Adding a new cell via an unindexed `# %% [code]` marker still works — only *body* lines are escaped.

Surgical: +31/-4 in `notebook.ts`, three small pure helpers plus the serialize/parse hooks.

## Test

Adds `packages/coding-agent/test/notebook-roundtrip.test.ts` (3 cases):

1. a cell whose source quotes `# %% [code]` survives the round-trip (count, source, metadata, and the neighbour cell's outputs all preserved),
2. content that already starts with the escape char round-trips verbatim (escape-the-escape),
3. the unindexed-marker "add a new cell" path still works.

Verified fail-before / pass-after:

- On `main`: cases 1 and 2 fail (cell count 3 vs 2, 2 vs 1); case 3 (pre-existing behavior) passes.
- With this fix: all 3 pass.

Existing `@oh-my-pi/hashline` suite stays green (82/82); `biome check` is clean on both files.