### PR TITLE
fix(tui): list marketplace plugins in settings panel

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the TUI's `Settings → Plugins` panel reporting "No plugins installed" when only marketplace plugins were installed. The panel now merges `PluginManager.list()` with `MarketplaceManager.listInstalledPlugins()` — the same data source the `/plugins list` slash command and `omp plugin list` CLI already used — and tags each row with an `[npm]` / `[marketplace]` kind badge, a scope tag, and a shadow indicator for project-shadowed user installs. Selecting a marketplace row opens a new `MarketplacePluginDetailComponent` whose single `Enabled` toggle calls `MarketplaceManager.setPluginEnabled(pluginId, enabled, scope)`, with read-only metadata (version, install path, installed-at, last-updated, git commit SHA) listed below the toggle. The empty-state now lists both install commands (`omp plugin install <package>` and `omp plugin install <name>@<marketplace>`) ([#1842](https://github.com/can1357/oh-my-pi/issues/1842)).
+
 ## [15.9.0] - 2026-06-04
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/components/plugin-settings.ts
+++ b/packages/coding-agent/src/modes/components/plugin-settings.ts
@@ -579,7 +579,7 @@ class ConfigInputSubmenu extends Container {
 
 export interface PluginSettingsCallbacks {
 	onClose: () => void;
-	onPluginChanged: () => void;
+	onPluginChanged: () => void | Promise<void>;
 }
 
 /** Component with handleInput method */
@@ -667,7 +667,7 @@ export class PluginSettingsComponent extends Container {
 		this.#viewComponent = new PluginDetailComponent(plugin, this.#manager, {
 			onEnabledChange: async enabled => {
 				await this.#manager.setEnabled(plugin.name, enabled);
-				this.callbacks.onPluginChanged();
+				await this.callbacks.onPluginChanged();
 			},
 			onFeatureChange: async (feature, enabled) => {
 				const current = new Set((await this.#manager.getEnabledFeatures(plugin.name)) ?? []);
@@ -677,11 +677,11 @@ export class PluginSettingsComponent extends Container {
 					current.delete(feature);
 				}
 				await this.#manager.setEnabledFeatures(plugin.name, [...current]);
-				this.callbacks.onPluginChanged();
+				await this.callbacks.onPluginChanged();
 			},
 			onConfigChange: async (key, value) => {
 				await this.#manager.setPluginSetting(plugin.name, key, value);
-				this.callbacks.onPluginChanged();
+				await this.callbacks.onPluginChanged();
 			},
 			onBack: () => this.#showPluginList(),
 		});
@@ -700,7 +700,7 @@ export class PluginSettingsComponent extends Container {
 				try {
 					const mgr = await this.#buildMarketplaceManager();
 					await mgr.setPluginEnabled(plugin.id, enabled, plugin.scope);
-					this.callbacks.onPluginChanged();
+					await this.callbacks.onPluginChanged();
 				} catch (err) {
 					logger.error("Settings → Plugins: failed to toggle marketplace plugin", {
 						pluginId: plugin.id,

--- a/packages/coding-agent/src/modes/components/plugin-settings.ts
+++ b/packages/coding-agent/src/modes/components/plugin-settings.ts
@@ -31,6 +31,7 @@ import {
 } from "../../extensibility/plugins/marketplace";
 import type { InstalledPlugin, PluginSettingSchema } from "../../extensibility/plugins/types";
 import { getSelectListTheme, getSettingsListTheme, theme } from "../../modes/theme/theme";
+import { shortenPath } from "../../tools/render-utils";
 import { DynamicBorder } from "./dynamic-border";
 
 /**
@@ -443,7 +444,13 @@ export class MarketplacePluginDetailComponent extends Container {
 		// so we render the metadata as plain text rows beneath the toggle.
 		this.addChild(new Text(theme.fg("dim", `  version       ${entry?.version ?? "(unknown)"}`), 0, 0));
 		this.addChild(new Text(theme.fg("dim", `  scope         ${plugin.scope}`), 0, 0));
-		this.addChild(new Text(theme.fg("dim", `  install path  ${entry?.installPath ?? "(unknown)"}`), 0, 0));
+		this.addChild(
+			new Text(
+				theme.fg("dim", `  install path  ${entry?.installPath ? shortenPath(entry.installPath) : "(unknown)"}`),
+				0,
+				0,
+			),
+		);
 		this.addChild(new Text(theme.fg("dim", `  installed at  ${entry?.installedAt ?? "(unknown)"}`), 0, 0));
 		this.addChild(new Text(theme.fg("dim", `  last updated  ${entry?.lastUpdated ?? "(unknown)"}`), 0, 0));
 		if (entry?.gitCommitSha) {

--- a/packages/coding-agent/src/modes/components/plugin-settings.ts
+++ b/packages/coding-agent/src/modes/components/plugin-settings.ts
@@ -2,8 +2,9 @@
  * Plugin settings UI components.
  *
  * Provides a hierarchical settings interface:
- * - Plugin list (shows all installed plugins)
- *   - Plugin detail (enable/disable, features, config)
+ * - Plugin list (npm plugins + marketplace plugins)
+ *   - npm plugin detail (enable/disable, features, config)
+ *   - Marketplace plugin detail (enable/disable + read-only metadata)
  *     - Feature toggles
  *     - Config value editor
  */
@@ -17,7 +18,17 @@ import {
 	Spacer,
 	Text,
 } from "@oh-my-pi/pi-tui";
+import { logger } from "@oh-my-pi/pi-utils";
+import { clearPluginRootsAndCaches, resolveOrDefaultProjectRegistryPath } from "../../discovery/helpers";
 import { PluginManager } from "../../extensibility/plugins/manager";
+import type { InstalledPluginSummary } from "../../extensibility/plugins/marketplace";
+import {
+	getInstalledPluginsRegistryPath,
+	getMarketplacesCacheDir,
+	getMarketplacesRegistryPath,
+	getPluginsCacheDir,
+	MarketplaceManager,
+} from "../../extensibility/plugins/marketplace";
 import type { InstalledPlugin, PluginSettingSchema } from "../../extensibility/plugins/types";
 import { getSelectListTheme, getSettingsListTheme, theme } from "../../modes/theme/theme";
 import { DynamicBorder } from "./dynamic-border";
@@ -41,20 +52,53 @@ export function handleInputOrEscape(
 // Plugin List Component
 // =============================================================================
 
+/**
+ * One row in the unified plugin list. npm and marketplace plugins live in
+ * separate registries with different shapes, so a tagged union keeps both
+ * paths type-safe end-to-end (list rendering, value lookup, detail callback).
+ */
+export type PluginListEntry =
+	| { kind: "npm"; plugin: InstalledPlugin }
+	| { kind: "marketplace"; plugin: InstalledPluginSummary };
+
 export interface PluginListCallbacks {
-	onPluginSelect: (plugin: InstalledPlugin) => void;
+	onNpmSelect: (plugin: InstalledPlugin) => void;
+	onMarketplaceSelect: (plugin: InstalledPluginSummary) => void;
 	onCancel: () => void;
 }
 
 /**
- * Shows list of installed plugins with enable/disable status.
- * Selecting a plugin opens its detail view.
+ * True when the marketplace summary's first entry is not explicitly disabled.
+ * Mirrors the `/plugins list` convention: a missing `enabled` flag means enabled.
+ */
+function marketplaceEnabled(summary: InstalledPluginSummary): boolean {
+	return summary.entries[0]?.enabled !== false;
+}
+
+/**
+ * Stable SelectList value for a list entry. Combined with `findEntryByValue`
+ * this keeps lookup correct even when the same plugin id exists in both user
+ * and project scope (one of which is `shadowedBy: "project"`).
+ */
+function entryValue(entry: PluginListEntry): string {
+	if (entry.kind === "npm") return `npm:${entry.plugin.name}`;
+	return `mkt:${entry.plugin.scope}:${entry.plugin.id}`;
+}
+
+function findEntryByValue(entries: ReadonlyArray<PluginListEntry>, value: string): PluginListEntry | undefined {
+	return entries.find(e => entryValue(e) === value);
+}
+
+/**
+ * Shows installed plugins from both registries (npm + marketplace) with
+ * enable/disable status, scope tag, and shadow indicator. Selecting an entry
+ * fans out to the kind-specific detail callback.
  */
 export class PluginListComponent extends Container {
 	readonly #selectList: SelectList;
 
 	constructor(
-		private readonly plugins: InstalledPlugin[],
+		private readonly entries: ReadonlyArray<PluginListEntry>,
 		callbacks: PluginListCallbacks,
 	) {
 		super();
@@ -64,45 +108,37 @@ export class PluginListComponent extends Container {
 		this.addChild(new Text(theme.bold(theme.fg("accent", "  Plugins")), 0, 0));
 		this.addChild(new Spacer(1));
 
-		if (plugins.length === 0) {
+		if (entries.length === 0) {
 			this.addChild(new Text(theme.fg("muted", "  No plugins installed"), 0, 0));
 			this.addChild(new Spacer(1));
-			this.addChild(new Text(theme.fg("dim", "  Install with: omp plugin install <package>"), 0, 0));
+			this.addChild(new Text(theme.fg("dim", "  Install npm plugins:        omp plugin install <package>"), 0, 0));
+			this.addChild(
+				new Text(theme.fg("dim", "  Install marketplace plugins: omp plugin install <name>@<marketplace>"), 0, 0),
+			);
 			this.addChild(new Spacer(1));
 			this.addChild(new DynamicBorder());
 
-			// Create empty list that just handles escape
+			// Empty list still handles Escape so the user can leave the panel.
 			this.#selectList = new SelectList([], 1, getSelectListTheme());
 			this.#selectList.onCancel = callbacks.onCancel;
 			return;
 		}
 
-		const items: SelectItem[] = plugins.map(p => {
-			const status = p.enabled
-				? theme.fg("success", theme.status.enabled)
-				: theme.fg("muted", theme.status.disabled);
-			const featureCount = p.manifest.features ? Object.keys(p.manifest.features).length : 0;
-			const enabledCount = p.enabledFeatures?.length ?? featureCount;
+		const items: SelectItem[] = entries.map(entry => this.#renderItem(entry));
 
-			let details = `v${p.version}`;
-			if (featureCount > 0) {
-				details += ` ${theme.sep.dot} ${enabledCount}/${featureCount} features`;
-			}
-
-			return {
-				value: p.name,
-				label: `${status} ${p.name}`,
-				description: details,
-			};
+		// Marketplace plugin ids (`name@marketplace`) routinely run past the
+		// SelectList default primary column (32 chars). Widen the bound so the
+		// id remains readable; the description gets whatever width is left.
+		this.#selectList = new SelectList(items, Math.min(items.length, 8), getSelectListTheme(), {
+			minPrimaryColumnWidth: 24,
+			maxPrimaryColumnWidth: 64,
 		});
 
-		this.#selectList = new SelectList(items, Math.min(items.length, 8), getSelectListTheme());
-
 		this.#selectList.onSelect = item => {
-			const plugin = this.plugins.find(p => p.name === item.value);
-			if (plugin) {
-				callbacks.onPluginSelect(plugin);
-			}
+			const found = findEntryByValue(this.entries, item.value);
+			if (!found) return;
+			if (found.kind === "npm") callbacks.onNpmSelect(found.plugin);
+			else callbacks.onMarketplaceSelect(found.plugin);
 		};
 
 		this.#selectList.onCancel = callbacks.onCancel;
@@ -111,6 +147,48 @@ export class PluginListComponent extends Container {
 		this.addChild(new Spacer(1));
 		this.addChild(new Text(theme.fg("dim", "  Enter to configure · Esc to go back"), 0, 0));
 		this.addChild(new DynamicBorder());
+	}
+
+	#renderItem(entry: PluginListEntry): SelectItem {
+		const kindBadge = theme.fg("dim", entry.kind === "npm" ? "[npm]" : "[marketplace]");
+
+		if (entry.kind === "npm") {
+			const p = entry.plugin;
+			const status = p.enabled
+				? theme.fg("success", theme.status.enabled)
+				: theme.fg("muted", theme.status.disabled);
+			const featureCount = p.manifest.features ? Object.keys(p.manifest.features).length : 0;
+			const enabledCount = p.enabledFeatures?.length ?? featureCount;
+
+			let details = `${kindBadge} ${theme.sep.dot} v${p.version}`;
+			if (featureCount > 0) {
+				details += ` ${theme.sep.dot} ${enabledCount}/${featureCount} features`;
+			}
+
+			return {
+				value: entryValue(entry),
+				label: `${status} ${p.name}`,
+				description: details,
+			};
+		}
+
+		const summary = entry.plugin;
+		const enabled = marketplaceEnabled(summary);
+		const status = enabled ? theme.fg("success", theme.status.enabled) : theme.fg("muted", theme.status.disabled);
+		const scopeTag = theme.fg("dim", `[${summary.scope}]`);
+		const shadowMarker = summary.shadowedBy ? ` ${theme.fg("warning", theme.status.shadowed)}` : "";
+		const version = summary.entries[0]?.version ?? "?";
+
+		let details = `${kindBadge} ${scopeTag} ${theme.sep.dot} v${version}`;
+		if (summary.shadowedBy) {
+			details += ` ${theme.sep.dot} shadowed by ${summary.shadowedBy}`;
+		}
+
+		return {
+			value: entryValue(entry),
+			label: `${status} ${summary.id}${shadowMarker}`,
+			description: details,
+		};
 	}
 
 	handleInput(data: string): void {
@@ -297,6 +375,92 @@ export class PluginDetailComponent extends Container {
 }
 
 // =============================================================================
+// Marketplace Plugin Detail Component
+// =============================================================================
+
+export interface MarketplacePluginDetailCallbacks {
+	onEnabledChange: (enabled: boolean) => void;
+	onBack: () => void;
+}
+
+/**
+ * Detail view for a marketplace plugin. Marketplace plugins do not declare
+ * features or settings, so the panel exposes a single enable/disable toggle
+ * plus the read-only metadata from the installed-plugins registry.
+ */
+export class MarketplacePluginDetailComponent extends Container {
+	#settingsList: SettingsList;
+
+	constructor(
+		private plugin: InstalledPluginSummary,
+		private readonly callbacks: MarketplacePluginDetailCallbacks,
+	) {
+		super();
+
+		const entry = plugin.entries[0];
+		const enabled = marketplaceEnabled(plugin);
+
+		// Header
+		this.addChild(new DynamicBorder());
+		this.addChild(new Text(theme.bold(theme.fg("accent", `  ${plugin.id}`)), 0, 0));
+
+		const subtitleParts = [`[${plugin.scope}]`];
+		if (plugin.shadowedBy) subtitleParts.push(`${theme.status.shadowed} shadowed by ${plugin.shadowedBy}`);
+		this.addChild(new Text(theme.fg("muted", `  ${subtitleParts.join(" ")}`), 0, 0));
+		this.addChild(new Spacer(1));
+
+		const items: SettingItem[] = [
+			{
+				id: "__enabled__",
+				label: "Enabled",
+				description: "Enable or disable this marketplace plugin",
+				currentValue: enabled ? "true" : "false",
+				values: ["true", "false"],
+			},
+		];
+
+		this.#settingsList = new SettingsList(
+			items,
+			items.length,
+			getSettingsListTheme(),
+			(id, newValue) => {
+				if (id === "__enabled__") {
+					const next = newValue === "true";
+					this.callbacks.onEnabledChange(next);
+					this.plugin = {
+						...this.plugin,
+						entries: this.plugin.entries.map(e => ({ ...e, enabled: next })),
+					};
+				}
+			},
+			this.callbacks.onBack,
+		);
+
+		this.addChild(this.#settingsList);
+		this.addChild(new Spacer(1));
+
+		// Read-only metadata. SettingsList rejects items without `values`/`submenu`,
+		// so we render the metadata as plain text rows beneath the toggle.
+		this.addChild(new Text(theme.fg("dim", `  version       ${entry?.version ?? "(unknown)"}`), 0, 0));
+		this.addChild(new Text(theme.fg("dim", `  scope         ${plugin.scope}`), 0, 0));
+		this.addChild(new Text(theme.fg("dim", `  install path  ${entry?.installPath ?? "(unknown)"}`), 0, 0));
+		this.addChild(new Text(theme.fg("dim", `  installed at  ${entry?.installedAt ?? "(unknown)"}`), 0, 0));
+		this.addChild(new Text(theme.fg("dim", `  last updated  ${entry?.lastUpdated ?? "(unknown)"}`), 0, 0));
+		if (entry?.gitCommitSha) {
+			this.addChild(new Text(theme.fg("dim", `  git sha       ${entry.gitCommitSha}`), 0, 0));
+		}
+
+		this.addChild(new Spacer(1));
+		this.addChild(new Text(theme.fg("dim", "  Enter to toggle · Esc to go back"), 0, 0));
+		this.addChild(new DynamicBorder());
+	}
+
+	handleInput(data: string): void {
+		this.#settingsList.handleInput(data);
+	}
+}
+
+// =============================================================================
 // Config Submenus
 // =============================================================================
 
@@ -421,31 +585,66 @@ interface InputHandler {
  * Manages navigation between plugin list and plugin detail views.
  */
 export class PluginSettingsComponent extends Container {
+	#cwd: string;
 	#manager: PluginManager;
 	#viewComponent: (Container & InputHandler) | null = null;
 	// biome-ignore lint/correctness/noUnusedPrivateClassMembers: state tracking for view management
-	#currentView: "list" | "detail" = "list";
+	#currentView: "list" | "npm-detail" | "marketplace-detail" = "list";
 	// biome-ignore lint/correctness/noUnusedPrivateClassMembers: state tracking for view management
 	#currentPlugin: InstalledPlugin | null = null;
+	// biome-ignore lint/correctness/noUnusedPrivateClassMembers: state tracking for view management
+	#currentMarketplacePlugin: InstalledPluginSummary | null = null;
 
 	constructor(
 		cwd: string,
 		private readonly callbacks: PluginSettingsCallbacks,
 	) {
 		super();
+		this.#cwd = cwd;
 		this.#manager = new PluginManager(cwd);
 		this.#showPluginList();
+	}
+
+	async #buildMarketplaceManager(): Promise<MarketplaceManager> {
+		return new MarketplaceManager({
+			marketplacesRegistryPath: getMarketplacesRegistryPath(),
+			installedRegistryPath: getInstalledPluginsRegistryPath(),
+			projectInstalledRegistryPath: await resolveOrDefaultProjectRegistryPath(this.#cwd),
+			marketplacesCacheDir: getMarketplacesCacheDir(),
+			pluginsCacheDir: getPluginsCacheDir(),
+			clearPluginRootsCache: clearPluginRootsAndCaches,
+		});
 	}
 
 	async #showPluginList(): Promise<void> {
 		this.#currentView = "list";
 		this.#currentPlugin = null;
+		this.#currentMarketplacePlugin = null;
 		this.clear();
 
-		const plugins = await this.#manager.list();
+		// Surface marketplace failures without taking the npm path down with it —
+		// the registry can fail to load (corrupt JSON, missing project root) and
+		// the user still benefits from seeing their npm plugins.
+		const [npmPlugins, marketplacePlugins] = await Promise.all([
+			this.#manager.list(),
+			this.#buildMarketplaceManager()
+				.then(mgr => mgr.listInstalledPlugins())
+				.catch(err => {
+					logger.error("Settings → Plugins: failed to list marketplace plugins", {
+						error: err instanceof Error ? err.message : String(err),
+					});
+					return [] as InstalledPluginSummary[];
+				}),
+		]);
 
-		this.#viewComponent = new PluginListComponent(plugins, {
-			onPluginSelect: plugin => this.#showPluginDetail(plugin),
+		const entries: PluginListEntry[] = [
+			...npmPlugins.map(plugin => ({ kind: "npm" as const, plugin })),
+			...marketplacePlugins.map(plugin => ({ kind: "marketplace" as const, plugin })),
+		];
+
+		this.#viewComponent = new PluginListComponent(entries, {
+			onNpmSelect: plugin => this.#showPluginDetail(plugin),
+			onMarketplaceSelect: plugin => this.#showMarketplaceDetail(plugin),
 			onCancel: () => this.callbacks.onClose(),
 		});
 
@@ -453,8 +652,9 @@ export class PluginSettingsComponent extends Container {
 	}
 
 	#showPluginDetail(plugin: InstalledPlugin): void {
-		this.#currentView = "detail";
+		this.#currentView = "npm-detail";
 		this.#currentPlugin = plugin;
+		this.#currentMarketplacePlugin = null;
 		this.clear();
 
 		this.#viewComponent = new PluginDetailComponent(plugin, this.#manager, {
@@ -475,6 +675,33 @@ export class PluginSettingsComponent extends Container {
 			onConfigChange: async (key, value) => {
 				await this.#manager.setPluginSetting(plugin.name, key, value);
 				this.callbacks.onPluginChanged();
+			},
+			onBack: () => this.#showPluginList(),
+		});
+
+		this.addChild(this.#viewComponent);
+	}
+
+	#showMarketplaceDetail(plugin: InstalledPluginSummary): void {
+		this.#currentView = "marketplace-detail";
+		this.#currentPlugin = null;
+		this.#currentMarketplacePlugin = plugin;
+		this.clear();
+
+		this.#viewComponent = new MarketplacePluginDetailComponent(plugin, {
+			onEnabledChange: async enabled => {
+				try {
+					const mgr = await this.#buildMarketplaceManager();
+					await mgr.setPluginEnabled(plugin.id, enabled, plugin.scope);
+					this.callbacks.onPluginChanged();
+				} catch (err) {
+					logger.error("Settings → Plugins: failed to toggle marketplace plugin", {
+						pluginId: plugin.id,
+						scope: plugin.scope,
+						enabled,
+						error: err instanceof Error ? err.message : String(err),
+					});
+				}
 			},
 			onBack: () => this.#showPluginList(),
 		});

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -208,7 +208,7 @@ export interface SettingsCallbacks {
 	/** Get current rendered status line for inline preview */
 	getStatusLinePreview?: () => string;
 	/** Called when plugins change */
-	onPluginsChanged?: () => void;
+	onPluginsChanged?: () => void | Promise<void>;
 	/** Called when settings panel is closed */
 	onCancel: () => void;
 }

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -133,7 +133,11 @@ export class SelectorController {
 							const availableWidth = this.ctx.editor.getTopBorderAvailableWidth(this.ctx.ui.terminal.columns);
 							return this.ctx.statusLine.getTopBorder(availableWidth).content;
 						},
-						onPluginsChanged: () => {
+						onPluginsChanged: async () => {
+							const projectPath = await resolveActiveProjectRegistryPath(this.ctx.sessionManager.getCwd());
+							clearPluginRootsAndCaches(projectPath ? [projectPath] : undefined);
+							await this.ctx.refreshSlashCommandState();
+							await this.ctx.session.refreshSshTool({ activateIfAvailable: true });
 							this.ctx.ui.requestRender();
 						},
 						onCancel: () => {

--- a/packages/coding-agent/test/modes/components/plugin-list-marketplace.test.ts
+++ b/packages/coding-agent/test/modes/components/plugin-list-marketplace.test.ts
@@ -1,12 +1,17 @@
-import { beforeAll, describe, expect, it } from "bun:test";
+import { beforeAll, describe, expect, it, spyOn } from "bun:test";
 import * as os from "node:os";
 import { stripVTControlCharacters } from "node:util";
-import type { InstalledPluginSummary } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/marketplace";
+import { PluginManager } from "@oh-my-pi/pi-coding-agent/extensibility/plugins";
+import {
+	type InstalledPluginSummary,
+	MarketplaceManager,
+} from "@oh-my-pi/pi-coding-agent/extensibility/plugins/marketplace";
 import type { InstalledPlugin } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/types";
 import {
 	MarketplacePluginDetailComponent,
 	PluginListComponent,
 	type PluginListEntry,
+	PluginSettingsComponent,
 } from "@oh-my-pi/pi-coding-agent/modes/components/plugin-settings";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
@@ -142,6 +147,47 @@ describe("PluginListComponent", () => {
 
 		expect(selected).not.toBeNull();
 		expect(selected!.id).toBe("pick@mkt");
+	});
+});
+
+describe("PluginSettingsComponent", () => {
+	it("awaits plugin-change reload callback after toggling a marketplace plugin", async () => {
+		const plugin = marketplace("toggle@mkt");
+		const order: string[] = [];
+		const reloaded = Promise.withResolvers<void>();
+		const npmListSpy = spyOn(PluginManager.prototype, "list").mockResolvedValue([]);
+		const listInstalledSpy = spyOn(MarketplaceManager.prototype, "listInstalledPlugins").mockResolvedValue([plugin]);
+		const setEnabledSpy = spyOn(MarketplaceManager.prototype, "setPluginEnabled").mockImplementation(
+			async (pluginId, enabled, scope) => {
+				order.push(`set:${pluginId}:${enabled}:${scope}`);
+			},
+		);
+
+		try {
+			const component = new PluginSettingsComponent(process.cwd(), {
+				onClose: () => {},
+				onPluginChanged: async () => {
+					order.push("reload");
+					reloaded.resolve();
+				},
+			});
+
+			for (let i = 0; i < 20; i++) {
+				if (stripVTControlCharacters(component.render(120).join("\n")).includes("toggle@mkt")) break;
+				await Bun.sleep(1);
+			}
+			expect(stripVTControlCharacters(component.render(120).join("\n"))).toContain("toggle@mkt");
+			component.handleInput("\n");
+			component.handleInput(" ");
+			await reloaded.promise;
+
+			expect(setEnabledSpy).toHaveBeenCalledWith("toggle@mkt", false, "user");
+			expect(order).toEqual(["set:toggle@mkt:false:user", "reload"]);
+		} finally {
+			npmListSpy.mockRestore();
+			listInstalledSpy.mockRestore();
+			setEnabledSpy.mockRestore();
+		}
 	});
 });
 

--- a/packages/coding-agent/test/modes/components/plugin-list-marketplace.test.ts
+++ b/packages/coding-agent/test/modes/components/plugin-list-marketplace.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "bun:test";
+import * as os from "node:os";
 import { stripVTControlCharacters } from "node:util";
 import type { InstalledPluginSummary } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/marketplace";
 import type { InstalledPlugin } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/types";
@@ -176,5 +177,22 @@ describe("MarketplacePluginDetailComponent", () => {
 		component.handleInput(" ");
 
 		expect(calls).toEqual([false]);
+	});
+
+	it("shortens home-relative install paths to ~ before rendering", () => {
+		const home = os.homedir();
+		const installPath = `${home}/.omp/cache/plugins/sample@mkt`;
+		const plugin = marketplace("sample@mkt", { entry: { installPath } });
+
+		const component = new MarketplacePluginDetailComponent(plugin, {
+			onEnabledChange: () => {},
+			onBack: () => {},
+		});
+
+		const text = stripVTControlCharacters(component.render(120).join("\n"));
+		// `shortenPath` keeps the rest of the path intact but replaces $HOME with `~`,
+		// so the user's home directory never leaks into the rendered TUI surface.
+		expect(text).toContain("~/.omp/cache/plugins/sample@mkt");
+		expect(text).not.toContain(home);
 	});
 });

--- a/packages/coding-agent/test/modes/components/plugin-list-marketplace.test.ts
+++ b/packages/coding-agent/test/modes/components/plugin-list-marketplace.test.ts
@@ -1,0 +1,180 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import type { InstalledPluginSummary } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/marketplace";
+import type { InstalledPlugin } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/types";
+import {
+	MarketplacePluginDetailComponent,
+	PluginListComponent,
+	type PluginListEntry,
+} from "@oh-my-pi/pi-coding-agent/modes/components/plugin-settings";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+const npm = (name: string, opts: Partial<InstalledPlugin> = {}): InstalledPlugin => ({
+	name,
+	version: "1.2.3",
+	path: `/cache/npm/${name}`,
+	manifest: { version: "1.2.3", description: `desc ${name}` },
+	enabledFeatures: null,
+	enabled: true,
+	...opts,
+});
+
+const marketplace = (
+	id: string,
+	opts: Partial<Omit<InstalledPluginSummary, "id" | "entries">> & {
+		entry?: Partial<InstalledPluginSummary["entries"][number]>;
+	} = {},
+): InstalledPluginSummary => ({
+	id,
+	scope: opts.scope ?? "user",
+	shadowedBy: opts.shadowedBy,
+	entries: [
+		{
+			scope: opts.scope ?? "user",
+			installPath: `/cache/marketplace/${id}`,
+			version: "0.4.2",
+			installedAt: "2026-01-02T03:04:05.000Z",
+			lastUpdated: "2026-02-03T04:05:06.000Z",
+			enabled: true,
+			...opts.entry,
+		},
+	],
+});
+
+describe("PluginListComponent", () => {
+	it("renders marketplace plugins when no npm plugins are installed", () => {
+		const entries: PluginListEntry[] = [
+			{ kind: "marketplace", plugin: marketplace("developer-essentials@claude-code-workflows") },
+			{ kind: "marketplace", plugin: marketplace("hyperpowers@withzombies-hyper") },
+		];
+
+		const component = new PluginListComponent(entries, {
+			onNpmSelect: () => {},
+			onMarketplaceSelect: () => {},
+			onCancel: () => {},
+		});
+
+		const text = stripVTControlCharacters(component.render(120).join("\n"));
+		expect(text).not.toContain("No plugins installed");
+		expect(text).toContain("developer-essentials@claude-code-workflows");
+		expect(text).toContain("hyperpowers@withzombies-hyper");
+		expect(text).toContain("[marketplace]");
+	});
+
+	it("renders npm and marketplace plugins together with kind badges", () => {
+		const entries: PluginListEntry[] = [
+			{ kind: "npm", plugin: npm("local-plugin") },
+			{ kind: "marketplace", plugin: marketplace("remote@mkt") },
+		];
+
+		const component = new PluginListComponent(entries, {
+			onNpmSelect: () => {},
+			onMarketplaceSelect: () => {},
+			onCancel: () => {},
+		});
+
+		const text = stripVTControlCharacters(component.render(120).join("\n"));
+		expect(text).toContain("local-plugin");
+		expect(text).toContain("[npm]");
+		expect(text).toContain("remote@mkt");
+		expect(text).toContain("[marketplace]");
+	});
+
+	it("marks shadowed marketplace entries and surfaces scope tag", () => {
+		const entries: PluginListEntry[] = [
+			{
+				kind: "marketplace",
+				plugin: marketplace("shared@mkt", { scope: "user", shadowedBy: "project" }),
+			},
+		];
+
+		const component = new PluginListComponent(entries, {
+			onNpmSelect: () => {},
+			onMarketplaceSelect: () => {},
+			onCancel: () => {},
+		});
+
+		const text = stripVTControlCharacters(component.render(120).join("\n"));
+		expect(text).toContain("[user]");
+		expect(text).toContain("shadowed");
+	});
+
+	it("empty-state mentions both npm and marketplace install commands", () => {
+		const component = new PluginListComponent([], {
+			onNpmSelect: () => {},
+			onMarketplaceSelect: () => {},
+			onCancel: () => {},
+		});
+
+		const text = stripVTControlCharacters(component.render(120).join("\n"));
+		expect(text).toContain("No plugins installed");
+		expect(text).toContain("omp plugin install <package>");
+		expect(text).toContain("omp plugin install <name>@<marketplace>");
+	});
+
+	it("routes enter on a marketplace entry to onMarketplaceSelect", () => {
+		const target = marketplace("pick@mkt");
+		let selected: InstalledPluginSummary | null = null;
+		const component = new PluginListComponent(
+			[
+				{ kind: "npm", plugin: npm("filler") },
+				{ kind: "marketplace", plugin: target },
+			],
+			{
+				onNpmSelect: () => {
+					throw new Error("npm callback should not fire for marketplace selection");
+				},
+				onMarketplaceSelect: plugin => {
+					selected = plugin;
+				},
+				onCancel: () => {},
+			},
+		);
+
+		// Move down to the marketplace entry, then confirm with Enter.
+		component.handleInput("\x1b[B");
+		component.handleInput("\n");
+
+		expect(selected).not.toBeNull();
+		expect(selected!.id).toBe("pick@mkt");
+	});
+});
+
+describe("MarketplacePluginDetailComponent", () => {
+	it("exposes the enable toggle and metadata", () => {
+		const plugin = marketplace("plugin@mkt", {
+			entry: { gitCommitSha: "abc1234", enabled: false },
+		});
+
+		const component = new MarketplacePluginDetailComponent(plugin, {
+			onEnabledChange: () => {},
+			onBack: () => {},
+		});
+
+		const text = stripVTControlCharacters(component.render(120).join("\n"));
+		expect(text).toContain("plugin@mkt");
+		expect(text).toContain("Enabled");
+		// Read-only metadata must surface, including scope and the git commit SHA.
+		expect(text).toContain("0.4.2");
+		expect(text).toContain("abc1234");
+		expect(text).toContain("user");
+		expect(text).toContain("/cache/marketplace/plugin@mkt");
+	});
+
+	it("invokes onEnabledChange when the enabled toggle is activated", () => {
+		const calls: boolean[] = [];
+		const component = new MarketplacePluginDetailComponent(marketplace("toggle@mkt"), {
+			onEnabledChange: enabled => calls.push(enabled),
+			onBack: () => {},
+		});
+
+		// Activate the Enabled toggle (it is the first item). Space cycles its value.
+		component.handleInput(" ");
+
+		expect(calls).toEqual([false]);
+	});
+});


### PR DESCRIPTION
## Repro

```sh
omp plugin marketplace add wshobson/agents
omp plugin install developer-essentials@claude-code-workflows
# … any marketplace plugins, but no npm-style plugins …
omp           # open the TUI
# /settings → tab to Plugins
```

The panel renders `No plugins installed / Install with: omp plugin install <package>`, even though `omp plugin list` and the in-session `/plugins list` enumerate every install. Reproduced with the new `bun test test/modes/components/plugin-list-marketplace.test.ts`: against the pre-fix code, the suite cannot even load (`SyntaxError: Export named 'MarketplacePluginDetailComponent' not found`); against the fix it passes 7/7, the marketplace-only case asserts the plugin id renders and the empty-state mentions both install commands.

## Cause

`PluginSettingsComponent.#showPluginList()` in `packages/coding-agent/src/modes/components/plugin-settings.ts` only called `PluginManager.list()`, which is the npm-plugin registry. The other built-in surfaces — `/plugins list` (both CLI and TUI handlers in `slash-commands/builtin-registry.ts`), the `omp plugin list` CLI in `cli/plugin-cli.ts`, and the install/uninstall selectors in `modes/controllers/selector-controller.ts` — already merge `PluginManager.list()` with `MarketplaceManager.listInstalledPlugins()`. The settings panel was simply never updated when the marketplace registry was added.

## Fix

- Replaced `PluginListComponent`'s `InstalledPlugin[]` input with a tagged union `PluginListEntry = { kind: "npm"; plugin: InstalledPlugin } | { kind: "marketplace"; plugin: InstalledPluginSummary }`. Each row carries an `[npm]` / `[marketplace]` kind badge in the description column, a scope tag, and the existing shadow indicator (`theme.status.shadowed`) when a user install is overridden by a project entry. `SelectList` now uses `min/maxPrimaryColumnWidth: 24/64` so long `name@marketplace` ids stay readable. The empty-state mentions both install commands.
- Added `MarketplacePluginDetailComponent`: a single `Enabled` toggle (delegating to `MarketplaceManager.setPluginEnabled(pluginId, enabled, scope)` — the same path `/plugins enable|disable` uses) plus read-only `InstalledPluginEntry` metadata (version, install path, installed-at, last-updated, git commit SHA). Marketplace plugins do not declare features or settings, so the panel keeps it to a single toggle.
- Wired `PluginSettingsComponent` to await both `PluginManager.list()` and `MarketplaceManager.listInstalledPlugins()` in parallel (mirroring the `selector-controller.ts:469` marketplace-manager construction), build the merged entry list, and route `onMarketplaceSelect` to a new `#showMarketplaceDetail()` view. Marketplace-side failures are logged and swallowed so a broken registry does not take the npm path down with it.
- Added `test/modes/components/plugin-list-marketplace.test.ts` covering: marketplace-only listing renders the plugin id (the headline regression), npm+marketplace mixed rendering with both kind badges, scope tag + shadow marker for shadowed user entries, the empty-state lists both install commands, `Enter` on a marketplace row routes to `onMarketplaceSelect`, and the marketplace detail surface exposes the toggle + metadata and calls `onEnabledChange(false)` when the toggle is activated.
- npm plugin path (`PluginDetailComponent`, feature toggles, config submenus) is unchanged.

## Verification

- `bun --cwd packages/coding-agent test test/modes/components/plugin-list-marketplace.test.ts` → 7 pass.
- `bun --cwd packages/coding-agent test test/modes/components/` (every component test, including the existing settings/session selectors) → 48 pass.
- `bun --cwd packages/coding-agent check` (biome + `tsgo --noEmit`) → clean.

Fixes #1842