### PR TITLE
fix(ai): honor Anthropic cache-control compat for OpenAI-compatible providers

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Anthropic prompt caching for OpenAI-compatible Claude proxies by honoring `compat.cacheControlFormat: "anthropic"` outside OpenRouter. ([#1845](https://github.com/can1357/oh-my-pi/issues/1845))
+
 ## [15.9.0] - 2026-06-04
 
 ### Fixed

--- a/packages/ai/src/providers/openai-completions-compat.ts
+++ b/packages/ai/src/providers/openai-completions-compat.ts
@@ -4,11 +4,15 @@ type OpenAIReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh";
 type ResolvedToolStrictMode = NonNullable<OpenAICompat["toolStrictMode"]> | "mixed";
 
 export type ResolvedOpenAICompat = Required<
-	Omit<OpenAICompat, "openRouterRouting" | "vercelGatewayRouting" | "extraBody" | "toolStrictMode">
+	Omit<
+		OpenAICompat,
+		"openRouterRouting" | "vercelGatewayRouting" | "extraBody" | "toolStrictMode" | "cacheControlFormat"
+	>
 > & {
 	openRouterRouting?: OpenAICompat["openRouterRouting"];
 	vercelGatewayRouting?: OpenAICompat["vercelGatewayRouting"];
 	extraBody?: OpenAICompat["extraBody"];
+	cacheControlFormat?: OpenAICompat["cacheControlFormat"];
 	toolStrictMode: ResolvedToolStrictMode;
 };
 
@@ -240,6 +244,7 @@ export function detectOpenAICompat(model: Model<"openai-completions">, resolvedB
 		// Kimi and OpenRouter accept them when actual reasoning is unavailable.
 		allowsSyntheticReasoningContentForToolCalls: !isDeepseekFamily || !model.reasoning,
 		requiresAssistantContentForToolCalls: isKimiModel || isDirectDeepseekReasoning,
+		cacheControlFormat: isOpenRouter && model.id.startsWith("anthropic/") ? "anthropic" : undefined,
 		openRouterRouting: undefined,
 		vercelGatewayRouting: undefined,
 		supportsStrictMode: detectStrictModeSupport(provider, baseUrl),
@@ -288,6 +293,7 @@ export function resolveOpenAICompat(
 			detected.allowsSyntheticReasoningContentForToolCalls,
 		requiresAssistantContentForToolCalls:
 			model.compat.requiresAssistantContentForToolCalls ?? detected.requiresAssistantContentForToolCalls,
+		cacheControlFormat: model.compat.cacheControlFormat ?? detected.cacheControlFormat,
 		disableReasoningOnForcedToolChoice:
 			model.compat.disableReasoningOnForcedToolChoice ?? detected.disableReasoningOnForcedToolChoice,
 		disableReasoningOnToolChoice: model.compat.disableReasoningOnToolChoice ?? detected.disableReasoningOnToolChoice,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1147,7 +1147,7 @@ function buildParams(
 	}
 	const isKimiModelId = model.id.includes("moonshotai/kimi") || /(^|\/)kimi[-.]/i.test(model.id);
 	const messages = convertMessages(model, context, compat);
-	maybeAddOpenRouterAnthropicCacheControl(model, messages);
+	maybeAddAnthropicCacheControl(compat, messages);
 	const supportsReasoningParams = model.provider !== "github-copilot";
 
 	// Kimi (including via OpenRouter and Fireworks router-form IDs such as
@@ -1430,12 +1430,8 @@ function mapReasoningEffort(
 	return reasoningEffortMap[effort] ?? effort;
 }
 
-function maybeAddOpenRouterAnthropicCacheControl(
-	model: Model<"openai-completions">,
-	messages: ChatCompletionMessageParam[],
-): void {
-	if (model.provider !== "openrouter" || !model.id.startsWith("anthropic/")) return;
-
+function maybeAddAnthropicCacheControl(compat: ResolvedOpenAICompat, messages: ChatCompletionMessageParam[]): void {
+	if (compat.cacheControlFormat !== "anthropic") return;
 	// Anthropic-style caching requires cache_control on a text part. Add a breakpoint
 	// on the last user/assistant message (walking backwards until we find text content).
 	for (let i = messages.length - 1; i >= 0; i--) {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -815,6 +815,8 @@ export interface OpenAICompat {
 	vercelGatewayRouting?: VercelGatewayRouting;
 	/** Extra fields to include in request body (e.g. gateway routing hints for OpenClaw-style proxies). */
 	extraBody?: Record<string, unknown>;
+	/** Whether chat-completions payloads should include provider-specific prompt-cache markers. */
+	cacheControlFormat?: "anthropic" | undefined;
 	/** Whether the provider supports the `strict` field in tool definitions. Default: auto-detected per provider/baseUrl (conservative for unknown providers). */
 	supportsStrictMode?: boolean;
 	/** Whether tool schemas must be sent either all strict or all non-strict. Undefined keeps the existing per-tool mixed behavior. */

--- a/packages/ai/test/issue-967-vision-guard.test.ts
+++ b/packages/ai/test/issue-967-vision-guard.test.ts
@@ -3,12 +3,13 @@ import { convertAnthropicMessages } from "../src/providers/anthropic";
 import { convertMessages as convertGoogleMessages } from "../src/providers/google-shared";
 import { convertCodexResponsesMessages } from "../src/providers/openai-codex-responses";
 import { convertMessages as convertOpenAICompletionsMessages } from "../src/providers/openai-completions";
+import type { ResolvedOpenAICompat } from "../src/providers/openai-completions-compat";
 import {
 	appendResponsesToolResultMessages,
 	convertResponsesInputContent,
 } from "../src/providers/openai-responses-shared";
 import { NON_VISION_IMAGE_PLACEHOLDER } from "../src/providers/vision-guard";
-import type { Api, AssistantMessage, Context, Model, OpenAICompat, ToolResultMessage, Usage } from "../src/types";
+import type { Api, AssistantMessage, Context, Model, ToolResultMessage, Usage } from "../src/types";
 
 const emptyUsage: Usage = {
 	input: 0,
@@ -19,7 +20,7 @@ const emptyUsage: Usage = {
 	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 };
 
-const compat: Required<OpenAICompat> = {
+const compat: ResolvedOpenAICompat = {
 	supportsStore: true,
 	supportsDeveloperRole: true,
 	supportsMultipleSystemMessages: true,

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -6,7 +6,7 @@ import {
 	detectCompat,
 	streamOpenAICompletions,
 } from "../src/providers/openai-completions";
-import { resolveOpenAICompat } from "../src/providers/openai-completions-compat";
+import { type ResolvedOpenAICompat, resolveOpenAICompat } from "../src/providers/openai-completions-compat";
 import type { AssistantMessage, Context, Model, OpenAICompat } from "../src/types";
 
 const originalFetch = global.fetch;
@@ -66,6 +66,46 @@ function baseContext(): Context {
 	};
 }
 
+async function captureOpenAICompletionsPayload(
+	model: Model<"openai-completions">,
+	context: Context = baseContext(),
+): Promise<unknown> {
+	const { promise, resolve } = Promise.withResolvers<unknown>();
+	global.fetch = createMockFetch(["[DONE]"]);
+	streamOpenAICompletions(model, context, {
+		apiKey: "test-key",
+		signal: createAbortedSignal(),
+		onPayload: payload => resolve(payload),
+	});
+	return promise;
+}
+
+function getPayloadMessages(payload: unknown): object[] {
+	const payloadObject = toObject(payload);
+	const messages = payloadObject ? Reflect.get(payloadObject, "messages") : undefined;
+	if (!Array.isArray(messages)) throw new Error("payload messages missing");
+	return messages.map(message => {
+		const messageObject = toObject(message);
+		if (!messageObject) throw new Error("payload message is not an object");
+		return messageObject;
+	});
+}
+
+function getLastPayloadContent(payload: unknown): unknown {
+	const lastMessage = getPayloadMessages(payload).at(-1);
+	if (!lastMessage) throw new Error("payload has no messages");
+	return Reflect.get(lastMessage, "content");
+}
+
+function getLastTextPart(content: unknown): object | undefined {
+	if (!Array.isArray(content)) return undefined;
+	for (let index = content.length - 1; index >= 0; index--) {
+		const part = toObject(content[index]);
+		if (part && Reflect.get(part, "type") === "text") return part;
+	}
+	return undefined;
+}
+
 describe("openai-completions compatibility", () => {
 	it("serializes assistant text content as a plain string", () => {
 		const model: Model<"openai-completions"> = {
@@ -97,7 +137,7 @@ describe("openai-completions compatibility", () => {
 			extraBody: {},
 			supportsStrictMode: true,
 			toolStrictMode: "none",
-		} satisfies Required<OpenAICompat>;
+		} satisfies ResolvedOpenAICompat;
 		const assistantMessage: AssistantMessage = {
 			role: "assistant",
 			content: [
@@ -1363,6 +1403,49 @@ describe("applyOpenRouterRoutingVariant", () => {
 	});
 });
 
+describe("anthropic cache control for OpenAI-compatible chat completions", () => {
+	function claudeProxyModel(compat?: OpenAICompat): Model<"openai-completions"> {
+		return {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+			provider: "litellm",
+			baseUrl: "https://litellm.example/v1",
+			id: "claude-opus-4-8",
+			compat,
+		};
+	}
+
+	function cacheContext(): Context {
+		return { messages: [{ role: "user", content: "cache me", timestamp: 0 }] };
+	}
+
+	it("injects Anthropic cache_control when compat requests Anthropic cache markers", async () => {
+		const payload = await captureOpenAICompletionsPayload(
+			claudeProxyModel({ cacheControlFormat: "anthropic" }),
+			cacheContext(),
+		);
+		const content = getLastPayloadContent(payload);
+		const textPart = getLastTextPart(content);
+
+		expect(Reflect.get(textPart ?? {}, "text")).toBe("cache me");
+		expect(Reflect.get(textPart ?? {}, "cache_control")).toEqual({ type: "ephemeral" });
+	});
+
+	it("preserves OpenRouter Anthropic cache_control detection", async () => {
+		const model = getBundledModel("openrouter", "anthropic/claude-sonnet-4") as Model<"openai-completions">;
+		const payload = await captureOpenAICompletionsPayload(model, cacheContext());
+		const content = getLastPayloadContent(payload);
+		const textPart = getLastTextPart(content);
+
+		expect(Reflect.get(textPart ?? {}, "cache_control")).toEqual({ type: "ephemeral" });
+	});
+
+	it("does not infer Anthropic cache_control for custom Claude ids without compat", async () => {
+		const payload = await captureOpenAICompletionsPayload(claudeProxyModel(), cacheContext());
+
+		expect(getLastPayloadContent(payload)).toBe("cache me");
+	});
+});
 describe("openrouterVariant request integration", () => {
 	it("appends the configured variant suffix to params.model for OpenRouter requests", async () => {
 		const model = getBundledModel("openrouter", "anthropic/claude-sonnet-4") as Model<"openai-completions">;

--- a/packages/ai/test/openai-completions-tool-result-images.test.ts
+++ b/packages/ai/test/openai-completions-tool-result-images.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import { getBundledModel } from "@oh-my-pi/pi-ai/models";
 import { convertMessages } from "@oh-my-pi/pi-ai/providers/openai-completions";
-import type { AssistantMessage, Context, Model, OpenAICompat, ToolResultMessage, Usage } from "@oh-my-pi/pi-ai/types";
+import type { ResolvedOpenAICompat } from "@oh-my-pi/pi-ai/providers/openai-completions-compat";
+import type { AssistantMessage, Context, Model, ToolResultMessage, Usage } from "@oh-my-pi/pi-ai/types";
 
 const emptyUsage: Usage = {
 	input: 0,
@@ -12,7 +13,7 @@ const emptyUsage: Usage = {
 	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 };
 
-const compat: Required<OpenAICompat> = {
+const compat: ResolvedOpenAICompat = {
 	supportsStore: true,
 	supportsDeveloperRole: true,
 	supportsMultipleSystemMessages: true,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `models.yml` compatibility parsing to preserve `compat.cacheControlFormat: "anthropic"` for custom OpenAI-compatible Claude proxies. ([#1845](https://github.com/can1357/oh-my-pi/issues/1845))
+
 ## [15.9.0] - 2026-06-04
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -41,6 +41,7 @@ export const OpenAICompatSchema = z.object({
 	openRouterRouting: OpenRouterRoutingSchema.optional(),
 	vercelGatewayRouting: VercelGatewayRoutingSchema.optional(),
 	extraBody: z.record(z.string(), z.unknown()).optional(),
+	cacheControlFormat: z.enum(["anthropic"]).optional(),
 	supportsStrictMode: z.boolean().optional(),
 	toolStrictMode: z.enum(["all_strict", "none"]).optional(),
 });

--- a/packages/coding-agent/test/model-registry.test.ts
+++ b/packages/coding-agent/test/model-registry.test.ts
@@ -632,6 +632,7 @@ describe("ModelRegistry", () => {
 					compat: {
 						supportsUsageInStreaming: false,
 						maxTokensField: "max_tokens",
+						cacheControlFormat: "anthropic",
 					},
 					models: [
 						{
@@ -651,6 +652,7 @@ describe("ModelRegistry", () => {
 			const compat = getOpenAICompat(model);
 			expect(compat?.supportsUsageInStreaming).toBe(false);
 			expect(compat?.maxTokensField).toBe("max_tokens");
+			expect(compat?.cacheControlFormat).toBe("anthropic");
 		});
 
 		test("model-level compat overrides provider-level compat for custom models", () => {


### PR DESCRIPTION
## Repro
A custom `openai-completions` model with provider `litellm`, id `claude-opus-4-8`, and `compat.cacheControlFormat: "anthropic"` reproduced the bug with `bun -e ...`: the captured chat-completions payload sent `content: "cache me"` and `hasCacheControl: false` before the fix.

## Cause
`packages/ai/src/providers/openai-completions.ts` only called `maybeAddOpenRouterAnthropicCacheControl`, whose guard required `model.provider === "openrouter"` and an `anthropic/` model id. `packages/coding-agent/src/config/models-config-schema.ts` also did not preserve `cacheControlFormat`, so custom `models.yml` providers could not carry that compat declaration into `resolveOpenAICompat`.

## Fix
- Added `OpenAICompat.cacheControlFormat` and model-config schema support for `"anthropic"`.
- Resolved OpenRouter Anthropic cache-control behavior through compat detection, preserving the existing default.
- Switched OpenAI-completions request building to inject `cache_control` whenever resolved compat declares Anthropic cache markers.
- Added regression coverage for custom LiteLLM-style Claude proxies, OpenRouter preservation, and model-registry compat parsing.

## Verification
Ran `bun --cwd=packages/ai test test/openai-completions-compat.test.ts`, `bun --cwd=packages/coding-agent test test/model-registry.test.ts`, `bun --cwd=packages/ai run check`, `bun --cwd=packages/coding-agent run check`, and reran the minimal `bun -e ...` payload repro, which now reports `hasCacheControl: true`. Fixes #1845