### PR TITLE
fix(cursor): distinguish tool errors from successes in prompt history

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cursor provider formatting tool errors with the same `[Tool Result]` prefix as successful results, causing Composer models to misinterpret error messages (e.g. "Pattern must not be empty") as directives over long conversations. Errors now use a `[Tool Error]` prefix so the model can distinguish failures from successes in the prompt history. ([#1853](https://github.com/can1357/oh-my-pi/pull/1853))
+
 ## [15.9.0] - 2026-06-04
 
 ### Fixed

--- a/packages/ai/src/providers/cursor.ts
+++ b/packages/ai/src/providers/cursor.ts
@@ -2292,9 +2292,10 @@ function buildRootPromptMessagesJson(
 		} else if (msg.role === "toolResult") {
 			const text = toolResultToText(msg);
 			if (!text) continue;
+			const prefix = msg.isError ? "[Tool Error]" : "[Tool Result]";
 			pushJson({
 				role: "user",
-				content: [{ type: "text", text: `[Tool Result]\n${text}` }],
+				content: [{ type: "text", text: `${prefix}\n${text}` }],
 			});
 		}
 	}
@@ -2372,10 +2373,11 @@ function buildConversationTurns(
 				// Include tool results as assistant text for context
 				const text = toolResultToText(stepMsg);
 				if (text) {
+					const prefix = stepMsg.isError ? "[Tool Error]" : "[Tool Result]";
 					const step = create(ConversationStepSchema, {
 						message: {
 							case: "assistantMessage",
-							value: create(AssistantMessageSchema, { text: `[Tool Result]\n${text}` }),
+							value: create(AssistantMessageSchema, { text: `${prefix}\n${text}` }),
 						},
 					});
 					stepBlobIds.push(storeCursorBlob(blobStore, toBinary(ConversationStepSchema, step)));

--- a/packages/ai/test/cursor-exec-handlers.test.ts
+++ b/packages/ai/test/cursor-exec-handlers.test.ts
@@ -267,4 +267,64 @@ describe("Cursor history encoding", () => {
 			[expect.objectContaining({ assistantMessage: { text: "[Tool Result]\npackage contents" } })],
 		]);
 	});
+
+	it("formats tool errors with [Tool Error] prefix", () => {
+		const errorContext: Context = {
+			messages: [
+				{
+					role: "user",
+					content: "Search for nothing.",
+					timestamp: 1,
+				},
+				{
+					role: "assistant",
+					api: "cursor-agent",
+					provider: "cursor",
+					model: "cursor-composer-2.5",
+					content: [
+						{
+							type: "toolCall",
+							id: "call-search",
+							name: "search",
+							arguments: { pattern: "" },
+						},
+					],
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+					stopReason: "toolUse",
+					timestamp: 2,
+				},
+				{
+					role: "toolResult",
+					toolCallId: "call-search",
+					toolName: "search",
+					content: [{ type: "text", text: "Pattern must not be empty" }],
+					isError: true,
+					timestamp: 3,
+				},
+			],
+		};
+
+		const history = buildCursorHistoryForTest(errorContext.messages, -1);
+
+		expect(history.rootPromptMessagesJson).toEqual([
+			{
+				role: "user",
+				content: [{ type: "text", text: "Search for nothing." }],
+			},
+			{
+				role: "user",
+				content: [{ type: "text", text: "[Tool Error]\nPattern must not be empty" }],
+			},
+		]);
+		expect(history.turnStepMessagesJson).toEqual([
+			[expect.objectContaining({ assistantMessage: { text: "[Tool Error]\nPattern must not be empty" } })],
+		]);
+	});
 });


### PR DESCRIPTION
The Cursor provider formats all tool results — both successes and errors — with the identical `[Tool Result]` prefix when building the model's prompt history. Other providers (Anthropic, OpenAI) either use a structured `is_error` field or pass tool results as typed protocol messages, so the model always knows structurally whether a tool succeeded or failed.

Cursor's agent API has no native concept of third-party tool results. OMP bridges this by serializing tool results into unstructured text injected as synthetic user messages. Without any error signal, the model interprets failure text like "Pattern must not be empty" as a directive rather than an error, and over many turns starts parroting it in its own output.

## Changes
- `buildRootPromptMessagesJson` — uses `[Tool Error]` prefix when `msg.isError` is true
- `buildConversationTurns` — same treatment for conversation step messages
- Added test covering both success (`[Tool Result]`) and error (`[Tool Error]`) paths for both JSON and step output