### PR TITLE
fix(mcp): update completed tool status icons

### DIFF
--- a/packages/coding-agent/src/mcp/render.ts
+++ b/packages/coding-agent/src/mcp/render.ts
@@ -51,6 +51,9 @@ export function renderMCPResult(
 ): Component {
 	const { expanded } = options;
 	const lines: string[] = [];
+	const isError = result.isError ?? result.details?.isError ?? false;
+	const title = result.details ? `${result.details.serverName}/${result.details.mcpToolName}` : "MCP";
+	lines.push(renderStatusLine({ icon: isError ? "error" : "success", title }, theme));
 
 	// Args section (when expanded)
 	if (expanded && args && typeof args === "object" && Object.keys(args).length > 0) {

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -116,10 +116,12 @@ function buildResult(
 		provider,
 		providerName,
 	};
+	const contentText = result.isError ? `Error: ${text}` : text;
+	const toolResult: CustomToolResult<MCPToolDetails> = { content: [{ type: "text", text: contentText }], details };
 	if (result.isError) {
-		return { content: [{ type: "text", text: `Error: ${text}` }], details };
+		toolResult.isError = true;
 	}
-	return { content: [{ type: "text", text }], details };
+	return toolResult;
 }
 
 /** Build an error CustomToolResult from a caught exception. */
@@ -134,6 +136,7 @@ function buildErrorResult(
 	return {
 		content: [{ type: "text", text: `MCP error: ${message}` }],
 		details: { serverName, mcpToolName, isError: true, provider, providerName },
+		isError: true,
 	};
 }
 
@@ -217,6 +220,8 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	readonly mcpToolName: string;
 	/** Server name */
 	readonly mcpServerName: string;
+	/** Render completed MCP calls with the result header replacing the pending call header. */
+	readonly mergeCallAndResult = true;
 
 	/** Create MCPTool instances for all tools from an MCP server connection */
 	static fromTools(connection: MCPServerConnection, tools: MCPToolDefinition[], reconnect?: MCPReconnect): MCPTool[] {
@@ -300,6 +305,9 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	readonly mcpToolName: string;
 	/** Server name */
 	readonly mcpServerName: string;
+	/** Render completed MCP calls with the result header replacing the pending call header. */
+	readonly mergeCallAndResult = true;
+
 	readonly #fallbackProvider: string | undefined;
 	readonly #fallbackProviderName: string | undefined;
 

--- a/packages/coding-agent/test/mcp-render-status.test.ts
+++ b/packages/coding-agent/test/mcp-render-status.test.ts
@@ -1,0 +1,133 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { AgentTool } from "@oh-my-pi/pi-agent-core";
+import type { TSchema } from "@oh-my-pi/pi-ai";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ToolExecutionComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tool-execution";
+import { theme as activeTheme, getThemeByName, initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { formatStatusIcon } from "@oh-my-pi/pi-coding-agent/tools/render-utils";
+import { TUI } from "@oh-my-pi/pi-tui";
+import { VirtualTerminal } from "../../tui/test/virtual-terminal";
+import { DeferredMCPTool, MCPTool, type MCPToolDetails } from "../src/mcp/tool-bridge";
+import type { MCPServerConnection, MCPToolDefinition, MCPTransport } from "../src/mcp/types";
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true, cwd: process.cwd() });
+	await initTheme(false, undefined, undefined, "dark", "light");
+});
+
+async function getRequiredTheme() {
+	const uiTheme = await getThemeByName("dark");
+	if (!uiTheme) {
+		throw new Error("dark theme missing");
+	}
+	return uiTheme;
+}
+
+function makeConnection(): MCPServerConnection {
+	const transport: MCPTransport = {
+		connected: true,
+		request<T = unknown>(): Promise<T> {
+			return Promise.reject(new Error("transport is not used by renderer tests"));
+		},
+		notify(): Promise<void> {
+			return Promise.resolve();
+		},
+		close(): Promise<void> {
+			return Promise.resolve();
+		},
+	};
+
+	return {
+		name: "sentry",
+		config: { command: "sentry-mcp" },
+		transport,
+		serverInfo: { name: "sentry", version: "1.0.0" },
+		capabilities: { tools: {} },
+	};
+}
+
+function makeDefinition(): MCPToolDefinition {
+	return {
+		name: "search_events",
+		description: "Search Sentry events",
+		inputSchema: {
+			type: "object",
+			properties: { query: { type: "string" } },
+			required: ["query"],
+		},
+	};
+}
+
+function makeTool(): MCPTool {
+	return new MCPTool(makeConnection(), makeDefinition());
+}
+
+function makeDeferredTool(): DeferredMCPTool {
+	return new DeferredMCPTool("sentry", makeDefinition(), () => Promise.resolve(makeConnection()));
+}
+
+type RenderableMCPAgentTool = AgentTool<TSchema, MCPToolDetails> & { mergeCallAndResult: true };
+
+function makeAgentTool(mcpTool: MCPTool): RenderableMCPAgentTool {
+	return {
+		name: mcpTool.name,
+		label: mcpTool.label,
+		description: mcpTool.description,
+		parameters: mcpTool.parameters,
+		mergeCallAndResult: mcpTool.mergeCallAndResult,
+		execute(): Promise<never> {
+			return Promise.reject(new Error("MCP execution is not used by renderer tests"));
+		},
+		renderCall(args, options) {
+			return mcpTool.renderCall(args, options, activeTheme);
+		},
+		renderResult(result, options) {
+			return mcpTool.renderResult(result, options, activeTheme);
+		},
+	};
+}
+
+async function renderCompletedMCPTool(isError: boolean): Promise<string> {
+	const mcpTool = makeTool();
+	const tool = makeAgentTool(mcpTool);
+	const tui = new TUI(new VirtualTerminal(120, 20));
+	const component = new ToolExecutionComponent(tool.name, { query: "level:error" }, {}, tool, tui);
+
+	component.updateResult(
+		{
+			content: [{ type: "text", text: isError ? "Error: denied" : '{"ok":true}' }],
+			details: { serverName: "sentry", mcpToolName: "search_events", isError },
+			...(isError ? { isError: true } : {}),
+		},
+		false,
+	);
+
+	return Bun.stripANSI(component.render(160).join("\n"));
+}
+
+describe("MCP tool rendering", () => {
+	it("replaces the pending call header with a success header after completion", async () => {
+		const uiTheme = await getRequiredTheme();
+		const pendingIcon = Bun.stripANSI(formatStatusIcon("pending", uiTheme));
+		const successIcon = Bun.stripANSI(formatStatusIcon("success", uiTheme));
+
+		const rendered = await renderCompletedMCPTool(false);
+
+		expect(makeTool().mergeCallAndResult).toBe(true);
+		expect(makeDeferredTool().mergeCallAndResult).toBe(true);
+		expect(rendered).toContain(`${successIcon} sentry/search_events`);
+		expect(rendered).not.toContain(`${pendingIcon} sentry/search_events`);
+	});
+
+	it("replaces the pending call header with an error header for MCP errors", async () => {
+		const uiTheme = await getRequiredTheme();
+		const pendingIcon = Bun.stripANSI(formatStatusIcon("pending", uiTheme));
+		const errorIcon = Bun.stripANSI(formatStatusIcon("error", uiTheme));
+
+		const rendered = await renderCompletedMCPTool(true);
+
+		expect(rendered).toContain(`${errorIcon} sentry/search_events`);
+		expect(rendered).not.toContain(`${pendingIcon} sentry/search_events`);
+	});
+});


### PR DESCRIPTION
## Repro
Completed MCP tool blocks reproduced the stale pending header with `bun test packages/coding-agent/test/mcp-render-status.test.ts`: the success case had no merged result renderer, and the error case rendered `⏳ sentry/search_events` after result content was present.

## Cause
`packages/coding-agent/src/mcp/tool-bridge.ts` exposed MCP tools as custom renderers without `mergeCallAndResult`, so `ToolExecutionComponent` kept rendering `renderMCPCall()` after a result existed. `packages/coding-agent/src/mcp/render.ts` also rendered only the result body, so completed MCP results had no success/error status header of their own.

## Fix
- Mark active and deferred MCP tool wrappers as `mergeCallAndResult` so completed renders replace the pending call header.
- Render a completed MCP result header from `renderMCPResult()` using success or error status from the result/details.
- Preserve top-level `isError` on MCP protocol/error results for downstream status handling.
- Add regression coverage for completed MCP success and error render states.

## Verification
`bun test packages/coding-agent/test/mcp-render-status.test.ts` passed with 2 tests and 6 assertions. `bun run check` passed in `packages/coding-agent`. Fixes #1855