### PR TITLE
feat(statusline): show Hindsight status and tiered usage

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a `hindsight` status-line segment that shows the active Hindsight backend's cached connection state inline with the existing status-line segments.
+
+### Fixed
+
+- Fixed the `usage` status-line segment to render provider-level quota windows when usage scopes include an account tier, matching OpenAI Codex subscription usage reports.
+
 ## [15.9.0] - 2026-06-04
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -105,7 +105,8 @@ export type StatusLineSegmentId =
 	| "cache_write"
 	| "cache_hit"
 	| "session_name"
-	| "usage";
+	| "usage"
+	| "hindsight";
 
 /** Submenu choice metadata. */
 export type SubmenuOption<V extends string = string> = {

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -50,7 +50,6 @@ export type HindsightConnectionState = "pending" | "ok" | "error";
 export interface HindsightStatus {
 	state: HindsightConnectionState;
 	bankId: string;
-	error?: string;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -521,9 +520,7 @@ export class StatusLineComponent implements Component {
 	 * the Hindsight server on every render.
 	 */
 	refreshHindsightInBackground(): void {
-		const state = (
-			this.session as { getHindsightSessionState?: AgentSession["getHindsightSessionState"] }
-		).getHindsightSessionState?.();
+		const state = this.session.getHindsightSessionState();
 		const primary = state?.aliasOf ?? state;
 		if (!primary) {
 			this.#cachedHindsight = null;
@@ -542,19 +539,22 @@ export class StatusLineComponent implements Component {
 		if (this.#hindsightFetchedAt > 0 && now - this.#hindsightFetchedAt < 5 * 60_000) return;
 
 		this.#hindsightInFlight = true;
+		const probeState = primary;
+		const cacheProbeResult = (status: HindsightConnectionState) => {
+			const latestState = this.session.getHindsightSessionState();
+			const latestPrimary = latestState?.aliasOf ?? latestState;
+			if (latestPrimary !== probeState || latestPrimary?.bankId !== bankId) return;
+			this.#cachedHindsight = { state: status, bankId };
+			this.#hindsightFetchedAt = Date.now();
+		};
+
 		void primary.client
 			.listMemories(bankId, { limit: 1 })
 			.then(() => {
-				this.#cachedHindsight = { state: "ok", bankId };
-				this.#hindsightFetchedAt = Date.now();
+				cacheProbeResult("ok");
 			})
-			.catch(error => {
-				this.#cachedHindsight = {
-					state: "error",
-					bankId,
-					error: error instanceof Error ? error.message : String(error),
-				};
-				this.#hindsightFetchedAt = Date.now();
+			.catch(() => {
+				cacheProbeResult("error");
 			})
 			.finally(() => {
 				this.#hindsightInFlight = false;

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -484,14 +484,16 @@ export class StatusLineComponent implements Component {
 			for (const limit of limits) {
 				if (!limit || typeof limit !== "object") continue;
 				const l = limit as {
-					scope?: { windowId?: string; modelId?: string };
+					scope?: { windowId?: string; modelId?: string; tier?: string; shared?: boolean };
 					window?: { resetsAt?: number };
 					amount?: { usedFraction?: number };
 				};
 				const fraction = l.amount?.usedFraction;
 				if (typeof fraction !== "number") continue;
-				if (typeof l.scope?.modelId === "string") continue;
-				const windowId = l.scope?.windowId;
+				const scope = l.scope;
+				if (typeof scope?.modelId === "string") continue;
+				if (typeof scope?.tier === "string" && scope.tier.length > 0 && scope.shared !== true) continue;
+				const windowId = scope?.windowId;
 				const resetsAt = l.window?.resetsAt;
 				if (windowId === "5h" && !fiveHour) {
 					fiveHour = {

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -40,6 +40,19 @@ export interface StatusLineSettings {
 	sessionAccent?: boolean;
 }
 
+type ResolvedStatusLineSettings = Required<
+	Pick<StatusLineSettings, "leftSegments" | "rightSegments" | "separator" | "segmentOptions">
+> &
+	StatusLineSettings;
+
+export type HindsightConnectionState = "pending" | "ok" | "error";
+
+export interface HindsightStatus {
+	state: HindsightConnectionState;
+	bankId: string;
+	error?: string;
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Per-message token cache
 // ═══════════════════════════════════════════════════════════════════════════
@@ -168,13 +181,18 @@ export class StatusLineComponent implements Component {
 	#lastTokensPerSecond: number | null = null;
 	#lastTokensPerSecondTimestamp: number | null = null;
 
-	// Anthropic usage caching (5-min TTL, OAuth/sub only)
+	// Provider quota usage caching (5-min TTL, OAuth/sub only)
 	#cachedUsage: {
 		fiveHour?: { percent: number; resetMinutes?: number };
 		sevenDay?: { percent: number; resetHours?: number };
 	} | null = null;
 	#usageFetchedAt = 0;
 	#usageInFlight = false;
+
+	// Hindsight connection-status caching (5-min TTL)
+	#cachedHindsight: HindsightStatus | null = null;
+	#hindsightFetchedAt = 0;
+	#hindsightInFlight = false;
 	// Context breakdown — incremental cache. Replaces the previous 2-second
 	// TTL design (which re-walked every message on each refresh and produced
 	// ~1.1 s sync freezes on 2,000+ message sessions because `updateEditorTopBorder`
@@ -467,22 +485,22 @@ export class StatusLineComponent implements Component {
 			for (const limit of limits) {
 				if (!limit || typeof limit !== "object") continue;
 				const l = limit as {
-					scope?: { windowId?: string; tier?: string };
+					scope?: { windowId?: string; modelId?: string };
 					window?: { resetsAt?: number };
 					amount?: { usedFraction?: number };
 				};
 				const fraction = l.amount?.usedFraction;
 				if (typeof fraction !== "number") continue;
+				if (typeof l.scope?.modelId === "string") continue;
 				const windowId = l.scope?.windowId;
-				const tier = l.scope?.tier;
 				const resetsAt = l.window?.resetsAt;
-				if (windowId === "5h" && !tier && !fiveHour) {
+				if (windowId === "5h" && !fiveHour) {
 					fiveHour = {
 						percent: fraction * 100,
 						resetMinutes:
 							typeof resetsAt === "number" ? Math.max(0, Math.round((resetsAt - now) / 60_000)) : undefined,
 					};
-				} else if (windowId === "7d" && !tier && !sevenDay) {
+				} else if (windowId === "7d" && !sevenDay) {
 					sevenDay = {
 						percent: fraction * 100,
 						resetHours:
@@ -493,6 +511,54 @@ export class StatusLineComponent implements Component {
 		}
 		if (!fiveHour && !sevenDay) return null;
 		return { fiveHour, sevenDay };
+	}
+
+	/**
+	 * Background-refresh the active Hindsight connection status. The status line
+	 * stays synchronous: renders use the cached value while this probes a small,
+	 * authenticated list endpoint in the background. A failed probe is cached
+	 * with the same 5-minute backoff as quota usage so an outage does not hammer
+	 * the Hindsight server on every render.
+	 */
+	refreshHindsightInBackground(): void {
+		const state = (
+			this.session as { getHindsightSessionState?: AgentSession["getHindsightSessionState"] }
+		).getHindsightSessionState?.();
+		const primary = state?.aliasOf ?? state;
+		if (!primary) {
+			this.#cachedHindsight = null;
+			this.#hindsightFetchedAt = 0;
+			return;
+		}
+
+		const bankId = primary.bankId;
+		if (this.#cachedHindsight?.bankId !== bankId) {
+			this.#cachedHindsight = { state: "pending", bankId };
+			this.#hindsightFetchedAt = 0;
+		}
+
+		const now = Date.now();
+		if (this.#hindsightInFlight) return;
+		if (this.#hindsightFetchedAt > 0 && now - this.#hindsightFetchedAt < 5 * 60_000) return;
+
+		this.#hindsightInFlight = true;
+		void primary.client
+			.listMemories(bankId, { limit: 1 })
+			.then(() => {
+				this.#cachedHindsight = { state: "ok", bankId };
+				this.#hindsightFetchedAt = Date.now();
+			})
+			.catch(error => {
+				this.#cachedHindsight = {
+					state: "error",
+					bankId,
+					error: error instanceof Error ? error.message : String(error),
+				};
+				this.#hindsightFetchedAt = Date.now();
+			})
+			.finally(() => {
+				this.#hindsightInFlight = false;
+			});
 	}
 
 	/**
@@ -546,11 +612,17 @@ export class StatusLineComponent implements Component {
 		return `${modelId}|${sp.length}:${sp[0]?.length ?? 0}|${tools.length}|${skills.length}`;
 	}
 
-	#buildSegmentContext(width: number): SegmentContext {
+	#buildSegmentContext(width: number, effectiveSettings: ResolvedStatusLineSettings): SegmentContext {
 		const state = this.session.state;
+		const enabledSegments = new Set<StatusLineSegmentId>([
+			...effectiveSettings.leftSegments,
+			...effectiveSettings.rightSegments,
+		]);
 
-		// Trigger background fetch (5-min TTL); render uses cached value
-		this.refreshUsageInBackground();
+		// Trigger background fetches (5-min TTL); render uses cached values.
+		// Only probe provider/Hindsight endpoints when their segments are enabled.
+		if (enabledSegments.has("usage")) this.refreshUsageInBackground();
+		if (enabledSegments.has("hindsight")) this.refreshHindsightInBackground();
 
 		// Get usage statistics
 		const aggregateUsageStats = this.session.sessionManager?.getUsageStatistics() ?? {
@@ -575,7 +647,7 @@ export class StatusLineComponent implements Component {
 		return {
 			session: this.session,
 			width,
-			options: this.#resolveSettings().segmentOptions ?? {},
+			options: effectiveSettings.segmentOptions ?? {},
 			planMode: this.#planModeStatus,
 			loopMode: this.#loopModeStatus,
 			goalMode: this.#goalModeStatus,
@@ -591,13 +663,10 @@ export class StatusLineComponent implements Component {
 				pr: this.#lookupPr(),
 			},
 			usage: this.#cachedUsage,
+			hindsight: this.#cachedHindsight,
 		};
 	}
-
-	#resolveSettings(): Required<
-		Pick<StatusLineSettings, "leftSegments" | "rightSegments" | "separator" | "segmentOptions">
-	> &
-		StatusLineSettings {
+	#resolveSettings(): ResolvedStatusLineSettings {
 		const preset = this.#settings.preset ?? "default";
 		const presetDef = getPreset(preset);
 		const useCustomSegments = preset === "custom";
@@ -632,8 +701,8 @@ export class StatusLineComponent implements Component {
 	}
 
 	#buildStatusLine(width: number): string {
-		const ctx = this.#buildSegmentContext(width);
 		const effectiveSettings = this.#resolveSettings();
+		const ctx = this.#buildSegmentContext(width, effectiveSettings);
 		const separatorDef = getSeparator(effectiveSettings.separator ?? "powerline-thin", theme);
 
 		const bgAnsi = theme.getBgAnsi("statusLineBg");

--- a/packages/coding-agent/src/modes/components/status-line/segments.ts
+++ b/packages/coding-agent/src/modes/components/status-line/segments.ts
@@ -543,6 +543,23 @@ const usageSegment: StatusLineSegment = {
 	},
 };
 
+const hindsightSegment: StatusLineSegment = {
+	id: "hindsight",
+	render(ctx) {
+		const status = ctx.hindsight;
+		if (!status) return { content: "", visible: false };
+
+		switch (status.state) {
+			case "ok":
+				return { content: theme.fg("success", `mem ${theme.status.success}`), visible: true };
+			case "error":
+				return { content: theme.fg("error", `mem ${theme.status.error}`), visible: true };
+			case "pending":
+				return { content: theme.fg("muted", `mem ${theme.status.pending}`), visible: true };
+		}
+	},
+};
+
 // ═══════════════════════════════════════════════════════════════════════════
 // Segment Registry
 // ═══════════════════════════════════════════════════════════════════════════
@@ -571,6 +588,7 @@ export const SEGMENTS: Record<StatusLineSegmentId, StatusLineSegment> = {
 	cache_hit: cacheHitSegment,
 	session_name: sessionNameSegment,
 	usage: usageSegment,
+	hindsight: hindsightSegment,
 };
 
 export function renderSegment(id: StatusLineSegmentId, ctx: SegmentContext): RenderedSegment {

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -1,6 +1,6 @@
 import type { StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle } from "../../../config/settings-schema";
 import type { AgentSession } from "../../../session/agent-session";
-import type { StatusLineSegmentOptions, StatusLineSettings } from "../status-line";
+import type { HindsightStatus, StatusLineSegmentOptions, StatusLineSettings } from "../status-line";
 
 export type {
 	StatusLinePreset,
@@ -55,6 +55,7 @@ export interface SegmentContext {
 		fiveHour?: { percent: number; resetMinutes?: number };
 		sevenDay?: { percent: number; resetHours?: number };
 	} | null;
+	hindsight?: HindsightStatus | null;
 }
 
 export interface RenderedSegment {

--- a/packages/coding-agent/test/status-line-context-cache.test.ts
+++ b/packages/coding-agent/test/status-line-context-cache.test.ts
@@ -256,4 +256,60 @@ describe("StatusLineComponent incremental context breakdown cache", () => {
 		expect(rendered).toContain("mem");
 		expect(rendered).toContain(theme.status.success);
 	});
+
+	it("renders Hindsight pending status while the background probe is in flight", async () => {
+		const session = makeSession({ messages: [userMessage("hi")] });
+		const probe = Promise.withResolvers<{ results: unknown[] }>();
+		const state = {
+			bankId: "test-bank",
+			client: {
+				listMemories: () => probe.promise,
+			},
+		} as unknown as HindsightSessionState;
+		(session as { getHindsightSessionState: () => HindsightSessionState | undefined }).getHindsightSessionState =
+			() => state;
+		const comp = new StatusLineComponent(session);
+		comp.updateSettings({
+			preset: "custom",
+			leftSegments: ["hindsight"],
+			rightSegments: [],
+			separator: "pipe",
+		});
+
+		comp.refreshHindsightInBackground();
+
+		const rendered = comp.getTopBorder(120).content;
+		expect(rendered).toContain("mem");
+		expect(rendered).toContain(theme.status.pending);
+
+		probe.resolve({ results: [] });
+		await Bun.sleep(0);
+	});
+
+	it("renders generic Hindsight error status after a failed background probe", async () => {
+		const session = makeSession({ messages: [userMessage("hi")] });
+		const state = {
+			bankId: "test-bank",
+			client: {
+				listMemories: () => Promise.reject(new Error("secret-token-timeout")),
+			},
+		} as unknown as HindsightSessionState;
+		(session as { getHindsightSessionState: () => HindsightSessionState | undefined }).getHindsightSessionState =
+			() => state;
+		const comp = new StatusLineComponent(session);
+		comp.updateSettings({
+			preset: "custom",
+			leftSegments: ["hindsight"],
+			rightSegments: [],
+			separator: "pipe",
+		});
+
+		comp.refreshHindsightInBackground();
+		await Bun.sleep(0);
+
+		const rendered = comp.getTopBorder(120).content;
+		expect(rendered).toContain("mem");
+		expect(rendered).toContain(theme.status.error);
+		expect(rendered).not.toContain("secret-token-timeout");
+	});
 });

--- a/packages/coding-agent/test/status-line-context-cache.test.ts
+++ b/packages/coding-agent/test/status-line-context-cache.test.ts
@@ -195,12 +195,17 @@ describe("StatusLineComponent incremental context breakdown cache", () => {
 				{
 					limits: [
 						{
-							scope: { windowId: "5h", tier: "prolite" },
+							scope: { windowId: "5h", tier: "prolite", shared: true },
 							amount: { usedFraction: 0.13 },
 							window: { resetsAt: Date.now() + 90 * 60_000 },
 						},
 						{
-							scope: { windowId: "7d", tier: "prolite" },
+							scope: { windowId: "7d", tier: "opus" },
+							amount: { usedFraction: 0.77 },
+							window: { resetsAt: Date.now() + 20 * 60 * 60_000 },
+						},
+						{
+							scope: { windowId: "7d", tier: "prolite", shared: true },
 							amount: { usedFraction: 0.03 },
 							window: { resetsAt: Date.now() + 25 * 60 * 60_000 },
 						},
@@ -228,6 +233,7 @@ describe("StatusLineComponent incremental context breakdown cache", () => {
 		expect(rendered).toContain("13%");
 		expect(rendered).toContain("7d");
 		expect(rendered).toContain("3%");
+		expect(rendered).not.toContain("77%");
 		expect(rendered).not.toContain("99%");
 	});
 

--- a/packages/coding-agent/test/status-line-context-cache.test.ts
+++ b/packages/coding-agent/test/status-line-context-cache.test.ts
@@ -16,8 +16,9 @@
  */
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { resetSettingsForTest, Settings } from "../src/config/settings";
+import type { HindsightSessionState } from "../src/hindsight";
 import { StatusLineComponent } from "../src/modes/components/status-line";
-import { initTheme } from "../src/modes/theme/theme";
+import { initTheme, theme } from "../src/modes/theme/theme";
 import type { AgentSession } from "../src/session/agent-session";
 
 beforeAll(async () => {
@@ -38,12 +39,16 @@ function makeSession(opts: {
 	contextWindow?: number;
 	modelId?: string;
 }): AgentSession {
+	const model = { id: opts.modelId ?? "test-model", contextWindow: opts.contextWindow ?? 200_000 };
 	return {
 		messages: opts.messages,
+		state: { messages: opts.messages, model },
 		systemPrompt: opts.systemPrompt ?? ["You are a helpful assistant."],
 		agent: { state: { tools: opts.tools ?? [] } },
 		skills: opts.skills ?? [],
-		model: { id: opts.modelId ?? "test-model", contextWindow: opts.contextWindow ?? 200_000 },
+		model,
+		isStreaming: false,
+		getAsyncJobSnapshot: () => ({ running: [] }),
 	} as unknown as AgentSession;
 }
 
@@ -181,5 +186,74 @@ describe("StatusLineComponent incremental context breakdown cache", () => {
 		comp.refreshUsageInBackground();
 		await Bun.sleep(0);
 		expect(calls).toBe(1);
+	});
+
+	it("renders provider-level subscription usage when the quota scope includes a tier", async () => {
+		const session = makeSession({ messages: [userMessage("hi")] });
+		(session as { fetchUsageReports?: () => Promise<unknown> }).fetchUsageReports = () =>
+			Promise.resolve([
+				{
+					limits: [
+						{
+							scope: { windowId: "5h", tier: "prolite" },
+							amount: { usedFraction: 0.13 },
+							window: { resetsAt: Date.now() + 90 * 60_000 },
+						},
+						{
+							scope: { windowId: "7d", tier: "prolite" },
+							amount: { usedFraction: 0.03 },
+							window: { resetsAt: Date.now() + 25 * 60 * 60_000 },
+						},
+						{
+							scope: { windowId: "5h", tier: "spark", modelId: "GPT-5.3-Codex-Spark" },
+							amount: { usedFraction: 0.99 },
+							window: { resetsAt: Date.now() + 30 * 60_000 },
+						},
+					],
+				},
+			]);
+		const comp = new StatusLineComponent(session);
+		comp.updateSettings({
+			preset: "custom",
+			leftSegments: ["usage"],
+			rightSegments: [],
+			separator: "pipe",
+		});
+
+		comp.refreshUsageInBackground();
+		await Bun.sleep(0);
+
+		const rendered = comp.getTopBorder(120).content;
+		expect(rendered).toContain("5h");
+		expect(rendered).toContain("13%");
+		expect(rendered).toContain("7d");
+		expect(rendered).toContain("3%");
+		expect(rendered).not.toContain("99%");
+	});
+
+	it("renders Hindsight connection status after a successful background probe", async () => {
+		const session = makeSession({ messages: [userMessage("hi")] });
+		const state = {
+			bankId: "test-bank",
+			client: {
+				listMemories: () => Promise.resolve({ results: [] }),
+			},
+		} as unknown as HindsightSessionState;
+		(session as { getHindsightSessionState?: () => HindsightSessionState | undefined }).getHindsightSessionState =
+			() => state;
+		const comp = new StatusLineComponent(session);
+		comp.updateSettings({
+			preset: "custom",
+			leftSegments: ["hindsight"],
+			rightSegments: [],
+			separator: "pipe",
+		});
+
+		comp.refreshHindsightInBackground();
+		await Bun.sleep(0);
+
+		const rendered = comp.getTopBorder(120).content;
+		expect(rendered).toContain("mem");
+		expect(rendered).toContain(theme.status.success);
 	});
 });


### PR DESCRIPTION
## What

- Add a `hindsight` status-line segment that renders the active Hindsight backend connection state inline.
- Make the existing `usage` segment render provider-level quota windows even when the usage scope carries an account tier, while still ignoring model-specific quota windows.
- Add regression coverage for OpenAI Codex tiered subscription usage and Hindsight status rendering.
- Update the coding-agent changelog.

## Why

OpenAI Codex subscription usage reports can include `tier` on the provider-level 5h/7d windows. `/usage` shows those reports, but the status line previously filtered them out because it only accepted untiered scopes.

There was also no first-class way to put Hindsight connection state on the same status-line row as the built-in segments; extension `setStatus` renders as hook/status text rather than as a status-line segment.

## Testing

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)

Commands run:

```
PATH="$HOME/.cargo/bin:$PATH" npx --yes bun@1.3.14 run check
PATH="$HOME/.cargo/bin:$PATH" npx --yes bun@1.3.14 test packages/coding-agent/test/status-line-context-cache.test.ts packages/coding-agent/test/status-line-overflow.test.ts packages/coding-agent/test/status-line-path.test.ts packages/coding-agent/test/issue-953-repro.test.ts packages/coding-agent/test/status-line-cache-hit.test.ts
```