### PR TITLE
fix(coding-agent): keep local plan writes off ACP bridge

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixed
 
+- Fixed ACP plan-mode writes to `local://PLAN.md` so session-local plan artifacts are written to OMP's local artifact root instead of being routed through the editor `writeTextFile` bridge, avoiding Zen's `Internal error` and making the plan readable after creation ([#1863](https://github.com/can1357/oh-my-pi/issues/1863)).
+
 - Fixed `provider.appendOnlyContext: "auto"` staying inactive for Xiaomi Token Plan/SGLang endpoints, preserving prefix-cache hits without forcing append-only mode globally ([#1851](https://github.com/can1357/oh-my-pi/issues/1851)).
 - Fixed `models.yml` compatibility parsing to preserve `compat.cacheControlFormat: "anthropic"` for custom OpenAI-compatible Claude proxies. ([#1845](https://github.com/can1357/oh-my-pi/issues/1845))
 - Fixed the TUI's `Settings → Plugins` panel reporting "No plugins installed" when only marketplace plugins were installed. The panel now merges `PluginManager.list()` with `MarketplaceManager.listInstalledPlugins()` — the same data source the `/plugins list` slash command and `omp plugin list` CLI already used — and tags each row with an `[npm]` / `[marketplace]` kind badge, a scope tag, and a shadow indicator for project-shadowed user installs. Selecting a marketplace row opens a new `MarketplacePluginDetailComponent` whose single `Enabled` toggle calls `MarketplaceManager.setPluginEnabled(pluginId, enabled, scope)`, with read-only metadata (version, install path, installed-at, last-updated, git commit SHA) listed below the toggle. The empty-state now lists both install commands (`omp plugin install <package>` and `omp plugin install <name>@<marketplace>`) ([#1842](https://github.com/can1357/oh-my-pi/issues/1842)).

--- a/packages/coding-agent/src/tools/write.ts
+++ b/packages/coding-agent/src/tools/write.ts
@@ -135,6 +135,15 @@ function maybeWriteSnapshotHeader(session: ToolSession, absolutePath: string, co
 	return formatHashlineHeader(formatPathRelativeToCwd(absolutePath, session.cwd), tag);
 }
 
+function shouldRouteWriteThroughBridge(session: ToolSession, requestedPath: string, absolutePath: string): boolean {
+	if (isInternalUrlPath(requestedPath)) return false;
+
+	const state = session.getPlanModeState?.();
+	if (!state?.enabled || !isInternalUrlPath(state.planFilePath)) return true;
+
+	return absolutePath !== resolvePlanPath(session, state.planFilePath);
+}
+
 /**
  * Append a trailing note line to the first text block of a tool result.
  * Mutates `result` in place (the result object is owned by this call).
@@ -845,8 +854,11 @@ export class WriteTool implements AgentTool<typeof writeSchema, WriteToolDetails
 				await assertEditableFile(absolutePath, path);
 			}
 
-			// Try ACP bridge first — no disk write when client handles it
-			const bridgePromise = this.#routeWriteThroughBridge(absolutePath, cleanContent);
+			// Try ACP bridge first for editor-visible filesystem paths. Internal
+			// artifacts such as local:// plans are owned by OMP, not the editor.
+			const bridgePromise = shouldRouteWriteThroughBridge(this.session, path, absolutePath)
+				? this.#routeWriteThroughBridge(absolutePath, cleanContent)
+				: undefined;
 			if (bridgePromise !== undefined) {
 				try {
 					await bridgePromise;

--- a/packages/coding-agent/test/write-acp-fs.test.ts
+++ b/packages/coding-agent/test/write-acp-fs.test.ts
@@ -3,22 +3,35 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
+import type { PlanModeState } from "@oh-my-pi/pi-coding-agent/plan-mode/state";
 import type { ClientBridge } from "@oh-my-pi/pi-coding-agent/session/client-bridge";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { WriteTool } from "@oh-my-pi/pi-coding-agent/tools/write";
 
 const FILE_CONTENT = "bridge write content\n";
 
-function createSession(cwd: string, bridge?: ClientBridge): ToolSession {
+interface SessionOptions {
+	bridge?: ClientBridge;
+	planMode?: PlanModeState;
+}
+
+function createSession(cwd: string, options: SessionOptions = {}): ToolSession {
+	const getArtifactsDir = () => path.join(cwd, "artifacts");
+	const getSessionId = () => "session-a";
 	return {
 		cwd,
 		hasUI: false,
+		enableLsp: false,
 		getSessionFile: () => path.join(cwd, "session.jsonl"),
 		getSessionSpawns: () => "*",
-		getArtifactsDir: () => path.join(cwd, "artifacts"),
+		getArtifactsDir,
+		getSessionId,
+		localProtocolOptions: { getArtifactsDir, getSessionId },
 		allocateOutputArtifact: async () => ({ id: "artifact-1", path: path.join(cwd, "artifact-1.log") }),
 		settings: Settings.isolated(),
-		getClientBridge: bridge ? () => bridge : undefined,
+		getClientBridge: options.bridge ? () => options.bridge : undefined,
+		getPlanModeState: options.planMode ? () => options.planMode : undefined,
 	};
 }
 
@@ -45,7 +58,7 @@ describe("write tool ACP fs routing", () => {
 		const bunWriteSpy = spyOn(Bun, "write");
 
 		try {
-			const session = createSession(tmpDir, bridge);
+			const session = createSession(tmpDir, { bridge });
 			const tool = new WriteTool(session);
 
 			await tool.execute("call-1", { path: filePath, content: FILE_CONTENT });
@@ -58,5 +71,33 @@ describe("write tool ACP fs routing", () => {
 		} finally {
 			bunWriteSpy.mockRestore();
 		}
+	});
+
+	it("writes local plan artifacts to disk instead of the ACP bridge", async () => {
+		const planPath = "local://PLAN.md";
+		const planContent = "# Plan\n\nhello world\n";
+		const bridge: ClientBridge = {
+			capabilities: { writeTextFile: true },
+			writeTextFile: async () => {
+				throw new Error("Internal error");
+			},
+		};
+		const bridgeSpy = spyOn(bridge, "writeTextFile");
+		const session = createSession(tmpDir, {
+			bridge,
+			planMode: { enabled: true, planFilePath: planPath, workflow: "parallel", reentry: false },
+		});
+
+		await new WriteTool(session).execute("call-plan", { path: planPath, content: planContent });
+
+		expect(bridgeSpy).not.toHaveBeenCalled();
+		expect(
+			await Bun.file(
+				resolveLocalUrlToPath(planPath, {
+					getArtifactsDir: session.getArtifactsDir,
+					getSessionId: session.getSessionId,
+				}),
+			).text(),
+		).toBe(planContent);
 	});
 });


### PR DESCRIPTION
## Repro
In an ACP plan-mode session with `planFilePath` set to `local://PLAN.md` and a connected editor advertising `fs.writeTextFile`, a focused `WriteTool`/`ReadTool` harness reproduced the reporter's failure: `write local://PLAN.md` surfaced the editor bridge's `Internal error`, then `read local://PLAN.md` failed with `Local file not found: local://PLAN.md` because no OMP local artifact had been written.

## Cause
`packages/coding-agent/src/tools/write.ts` resolved `local://PLAN.md` through `resolvePlanPath`, then unconditionally preferred `#routeWriteThroughBridge` for the resulting absolute path whenever ACP `writeTextFile` was available. That bridge is for editor-visible filesystem files; session-local `local://` plan artifacts are owned by OMP's artifact root, so Zen rejected the bridged write and the local protocol read had no file to open.

## Fix
- Added `shouldRouteWriteThroughBridge` so direct internal URL writes and plan-mode writes redirected to an internal plan artifact bypass the ACP editor bridge.
- Preserved ACP bridge routing for ordinary editor-visible file writes.
- Added regression coverage for `local://PLAN.md` plan writes with a failing bridge, asserting the bridge is not called and the plan is persisted under the session local root.
- Updated the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/write-acp-fs.test.ts packages/coding-agent/test/read-acp-fs.test.ts` passed (4 tests). `bun check` passed. Fixes #1863