### PR TITLE
fix(session): keep auto thinking mode active across session resume

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 
+- Fixed `auto` thinking mode being silently dropped when a session is resumed (`--continue`/`--resume`/in-app switch). The session log persisted only the resolved per-turn effort, not the `auto` selector, so resume froze the session at the last concrete level and never reclassified again. The log now records the configured selector (`auto` vs concrete) alongside the resolved effort, so resumed `auto` sessions stay in auto (shown as pending until the next turn reclassifies) and manual concrete pins still restore as concrete — including a pin whose level matches the effort `auto` had just resolved to.
 - Fixed transcript scrollback stability on terminals with eager erase risk so completed assistant messages remain stable while new streaming lines are rendering
 - Fixed Ctrl+R history search results to remain globally sorted by prompt recency after merging FTS prefix matches with substring fallback matches.
 - Fixed Exa web search with no stored or environment credential to use the public Exa MCP fallback again, preserving the auth storage → `EXA_API_KEY` → `mcp.exa.ai` resolution order ([#1860](https://github.com/can1357/oh-my-pi/issues/1860)).

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -116,6 +116,7 @@ import { AgentOutputManager } from "./task/output-manager";
 import {
 	AUTO_THINKING,
 	type ConfiguredThinkingLevel,
+	parseConfiguredThinkingLevel,
 	parseThinkingLevel,
 	resolveProvisionalAutoLevel,
 	resolveThinkingLevelForModel,
@@ -1047,7 +1048,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 	const pickInitialThinkingLevel = (selectedModel: Model | undefined): ConfiguredThinkingLevel | undefined => {
 		let level = options.thinkingLevel;
 		if (level === undefined && hasExistingSession && hasThinkingEntry) {
-			level = parseThinkingLevel(existingSession.thinkingLevel);
+			level =
+				parseConfiguredThinkingLevel(existingSession.configuredThinkingLevel) ??
+				parseThinkingLevel(existingSession.thinkingLevel);
 		}
 		if (level === undefined && !hasExplicitModel && !hasThinkingEntry && defaultRoleSpec.explicitThinkingLevel) {
 			level = defaultRoleSpec.thinkingLevel;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5080,7 +5080,7 @@ export class AgentSession {
 		this.#pendingNextTurnMessages = [];
 		this.#scheduledHiddenNextTurnGeneration = undefined;
 
-		this.sessionManager.appendThinkingLevelChange(this.thinkingLevel);
+		this.sessionManager.appendThinkingLevelChange(this.thinkingLevel, this.configuredThinkingLevel());
 		this.sessionManager.appendServiceTierChange(this.serviceTier ?? null);
 		if (nextDiscoverySessionToolNames) {
 			await this.#applyActiveToolsByName(nextDiscoverySessionToolNames, { persistMCPSelection: false });
@@ -5457,16 +5457,20 @@ export class AgentSession {
 			return;
 		}
 
+		const wasAuto = this.#autoThinking;
 		this.#autoThinking = false;
 		this.#autoResolvedLevel = undefined;
 		const effectiveLevel = resolveThinkingLevelForModel(this.model, level);
-		const isChanging = effectiveLevel !== this.#thinkingLevel;
+		// Leaving auto must persist even when the resolved effort is unchanged (e.g.
+		// auto resolved to medium, then the user pins medium): otherwise the latest
+		// session entry keeps `configured: "auto"` and resume re-enables auto.
+		const isChanging = wasAuto || effectiveLevel !== this.#thinkingLevel;
 
 		this.#thinkingLevel = effectiveLevel;
 		this.agent.setThinkingLevel(toReasoningEffort(effectiveLevel));
 
 		if (isChanging) {
-			this.sessionManager.appendThinkingLevelChange(effectiveLevel);
+			this.sessionManager.appendThinkingLevelChange(effectiveLevel, effectiveLevel);
 			if (persist && effectiveLevel !== undefined && effectiveLevel !== ThinkingLevel.Off) {
 				this.settings.set("defaultThinkingLevel", effectiveLevel);
 			}
@@ -5555,7 +5559,7 @@ export class AgentSession {
 		this.#thinkingLevel = effort;
 		this.agent.setThinkingLevel(toReasoningEffort(effort));
 		if (shouldPersistResolution) {
-			this.sessionManager.appendThinkingLevelChange(effort);
+			this.sessionManager.appendThinkingLevelChange(effort, AUTO_THINKING);
 		}
 		this.#emit({
 			type: "thinking_level_changed",
@@ -8918,18 +8922,26 @@ export class AgentSession {
 				.some(entry => entry.type === "service_tier_change");
 			const defaultThinkingLevel = this.settings.get("defaultThinkingLevel");
 			const configuredServiceTier = this.settings.get("serviceTier");
-			// Session log entries store only concrete levels. When `auto` has resolved
-			// for a turn, the persisted context may already carry that concrete level
-			// even if the branch scan races a just-flushed thinking entry under isolated
-			// parallel test workers. Prefer the concrete context value in that case;
-			// otherwise keep the configured `auto` selector so fresh sessions still
-			// classify their first turn.
+			// Restore the thinking selector. Each change persists the configured
+			// selector (`auto` or a concrete level), so prefer it: an `auto` session
+			// resumes in auto mode (reclassifying the next turn) instead of freezing at
+			// the last resolved level. Entries written before the `configured` field
+			// existed fall back to the concrete level (legacy pin-on-resume behavior).
+			// With no thinking entry, fall back to the global default so fresh sessions
+			// still classify their first turn.
+			const restoredConfigured = sessionContext.configuredThinkingLevel;
 			const restoredThinkingLevel: ConfiguredThinkingLevel | undefined =
 				hasThinkingEntry || (defaultThinkingLevel === AUTO_THINKING && sessionContext.thinkingLevel !== "off")
-					? (sessionContext.thinkingLevel as ThinkingLevel | undefined)
+					? restoredConfigured === AUTO_THINKING
+						? AUTO_THINKING
+						: (sessionContext.thinkingLevel as ThinkingLevel | undefined)
 					: defaultThinkingLevel;
 			if (restoredThinkingLevel === AUTO_THINKING) {
 				this.#autoThinking = true;
+				// Resume in auto (pending) like a fresh auto session: the next user
+				// turn reclassifies. We intentionally do not seed the last resolved
+				// effort, so the cold (--continue) and in-app switch paths display
+				// identically as `auto` until then.
 				this.#autoResolvedLevel = undefined;
 				this.#thinkingLevel = resolveProvisionalAutoLevel(this.model);
 			} else {

--- a/packages/coding-agent/src/session/session-manager.ts
+++ b/packages/coding-agent/src/session/session-manager.ts
@@ -89,6 +89,12 @@ export interface SessionMessageEntry extends SessionEntryBase {
 export interface ThinkingLevelChangeEntry extends SessionEntryBase {
 	type: "thinking_level_change";
 	thinkingLevel?: string | null;
+	/**
+	 * The user-configured selector at the time of this change: `"auto"` when auto
+	 * mode was active, otherwise the concrete level. Absent on entries written
+	 * before auto-mode persistence existed; readers fall back to `thinkingLevel`.
+	 */
+	configured?: string | null;
 }
 
 export interface ModelChangeEntry extends SessionEntryBase {
@@ -239,6 +245,8 @@ export interface SessionTreeNode {
 export interface SessionContext {
 	messages: AgentMessage[];
 	thinkingLevel?: string;
+	/** Configured thinking selector (`"auto"` or a concrete level) from the latest change. */
+	configuredThinkingLevel?: string;
 	serviceTier?: ServiceTier;
 	/** Model roles: { default: "provider/modelId", small: "provider/modelId", ... } */
 	models: Record<string, string>;
@@ -600,6 +608,7 @@ export function buildSessionContext(
 
 	// Extract settings and find compaction
 	let thinkingLevel: string | undefined = "off";
+	let configuredThinkingLevel: string | undefined;
 	let serviceTier: ServiceTier | undefined;
 	const models: Record<string, string> = {};
 	let compaction: CompactionEntry | null = null;
@@ -620,6 +629,7 @@ export function buildSessionContext(
 	for (const entry of path) {
 		if (entry.type === "thinking_level_change") {
 			thinkingLevel = entry.thinkingLevel ?? "off";
+			configuredThinkingLevel = entry.configured ?? entry.thinkingLevel ?? undefined;
 		} else if (entry.type === "model_change") {
 			// New format: { model: "provider/id", role?: string }
 			if (entry.model) {
@@ -789,6 +799,7 @@ export function buildSessionContext(
 	return {
 		messages,
 		thinkingLevel,
+		configuredThinkingLevel,
 		serviceTier,
 		models,
 		injectedTtsrRules,
@@ -2850,13 +2861,14 @@ export class SessionManager {
 	}
 
 	/** Append a thinking level change as child of current leaf, then advance leaf. Returns entry id. */
-	appendThinkingLevelChange(thinkingLevel?: string): string {
+	appendThinkingLevelChange(thinkingLevel?: string, configured?: string): string {
 		const entry: ThinkingLevelChangeEntry = {
 			type: "thinking_level_change",
 			id: generateId(this.#byId),
 			parentId: this.#leafId,
 			timestamp: new Date().toISOString(),
 			thinkingLevel: thinkingLevel ?? null,
+			configured: configured ?? null,
 		};
 		this.#appendEntry(entry);
 		return entry.id;

--- a/packages/coding-agent/test/agent-session-role-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-role-thinking.test.ts
@@ -265,7 +265,7 @@ describe("AgentSession role model thinking behavior", () => {
 		expect(session.agent.state.thinkingLevel).toBe(Effort.Medium);
 	});
 
-	it("restores the last resolved auto effort instead of pending auto on resume", async () => {
+	it("keeps auto active on resume (pending until the next turn reclassifies)", async () => {
 		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
 		const agent = new Agent({
 			initialState: {
@@ -304,10 +304,106 @@ describe("AgentSession role model thinking behavior", () => {
 		await session.sessionManager.flush();
 
 		expect(await session.switchSession(sessionFile!)).toBe(true);
+		expect(session.isAutoThinking).toBe(true);
+		expect(session.configuredThinkingLevel()).toBe(AUTO_THINKING);
+		// Resumes in auto and pending — not frozen to the last resolved level, and
+		// not pre-seeded; the next user turn reclassifies.
+		expect(session.autoResolvedThinkingLevel()).toBeUndefined();
+	});
+
+	it("keeps a manual concrete pin (not auto) on resume even when the global default is auto", async () => {
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+				thinkingLevel: resolveProvisionalAutoLevel(model),
+			},
+		});
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth-manual-resume.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models-manual-resume.yml"));
+		const sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+		sessionSettings = Settings.isolated();
+		sessionSettings.set("defaultThinkingLevel", AUTO_THINKING);
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: sessionSettings,
+			modelRegistry,
+			thinkingLevel: AUTO_THINKING,
+		});
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+		const classifierSpy = vi.spyOn(autoThinkingClassifier, "classifyDifficulty").mockResolvedValue(Effort.Medium);
+
+		// User pins a concrete level mid-session; it must survive resume as-is and
+		// must not be reinterpreted as `auto` just because the global default is auto.
+		session.setThinkingLevel(Effort.Low);
+		expect(session.isAutoThinking).toBe(false);
+		await session.prompt("Pinned concrete turn");
+		expect(classifierSpy).not.toHaveBeenCalled();
+		session.sessionManager.appendMessage(createAssistantMessage("done"));
+
+		const sessionFile = session.sessionFile;
+		expect(sessionFile).toBeDefined();
+		await session.sessionManager.flush();
+
+		expect(await session.switchSession(sessionFile!)).toBe(true);
+		expect(session.isAutoThinking).toBe(false);
+		expect(session.configuredThinkingLevel()).toBe(Effort.Low);
+		expect(session.thinkingLevel).toBe(Effort.Low);
+	});
+
+	it("persists a concrete pin that matches the auto-resolved effort so resume stays concrete", async () => {
+		const model = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const agent = new Agent({
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+				thinkingLevel: resolveProvisionalAutoLevel(model),
+			},
+		});
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth-pin-eq.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models-pin-eq.yml"));
+		const sessionManager = SessionManager.create(tempDir.path(), tempDir.path());
+		sessionSettings = Settings.isolated();
+		sessionSettings.set("defaultThinkingLevel", AUTO_THINKING);
+		session = new AgentSession({
+			agent,
+			sessionManager,
+			settings: sessionSettings,
+			modelRegistry,
+			thinkingLevel: AUTO_THINKING,
+		});
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+		vi.spyOn(autoThinkingClassifier, "classifyDifficulty").mockResolvedValue(Effort.Medium);
+
+		// Auto resolves to medium.
+		await session.prompt("Implement a focused parser fix");
+		expect(session.autoResolvedThinkingLevel()).toBe(Effort.Medium);
+
+		// User then pins the *same* effort: selector changes auto -> medium even though
+		// the effort is unchanged, so it must persist as a concrete pin (entry +
+		// defaultThinkingLevel), not silently stay `configured: "auto"`.
+		session.setThinkingLevel(Effort.Medium, true);
+		expect(session.isAutoThinking).toBe(false);
+		expect(sessionSettings.get("defaultThinkingLevel")).toBe(Effort.Medium);
+		session.sessionManager.appendMessage(createAssistantMessage("done"));
+
+		const sessionFile = session.sessionFile;
+		expect(sessionFile).toBeDefined();
+		await session.sessionManager.flush();
+
+		expect(await session.switchSession(sessionFile!)).toBe(true);
 		expect(session.isAutoThinking).toBe(false);
 		expect(session.configuredThinkingLevel()).toBe(Effort.Medium);
-		expect(session.thinkingLevel).toBe(Effort.Medium);
-		expect(session.agent.state.thinkingLevel).toBe(Effort.Medium);
 	});
 
 	it("falls back to a concrete auto level when classification fails", async () => {


### PR DESCRIPTION
## Problem

Auto thinking is silently downgraded to a frozen concrete level whenever a session is resumed (`--continue` / `--resume` / in-app switch). The session log persists only the per-turn *resolved* effort, so on restore the code cannot distinguish "user pinned medium" from "auto resolved to medium this turn"; it clears `#autoThinking` and pins the level, and the next turn never reclassifies.

This is a regression introduced by `5344bcbc` ("persisted resolved auto thinking level on session resume"). Before that commit, `auto` sessions wrote no thinking entries, so `hasThinkingEntry` stayed false and resume fell back to `defaultThinkingLevel: auto` — auto survived. `5344bcbc` began writing the concrete effort per turn (to show the last resolved level instead of "pending auto" on resume), which flipped `hasThinkingEntry` true and routed resume into the concrete-pin branch as an unintended side effect. Its own stated goal was display-only.

## Fix

Persist the **configured selector** alongside the resolved level so resume can tell the two apart:

- `ThinkingLevelChangeEntry` gains an optional `configured` field (`"auto"` or a concrete level); `SessionContext` surfaces `configuredThinkingLevel`. Backward compatible: entries written before the field existed fall back to the concrete level (legacy pin-on-resume), so old sessions are unaffected.
- The three append sites record the configured selector; auto turns record `"auto"` while keeping the resolved effort in `thinkingLevel` for display.
- Both restore paths (`AgentSession.switchSession` and `sdk.ts` cold resume) prefer the configured selector, so an `auto` session resumes in auto mode and reclassifies the next turn. The last resolved effort is seeded as the displayed level until then — preserving `5344bcbc`'s display win without killing auto.
- A manual concrete pin still restores as concrete, even when the global default is `auto`.

## Tests

- Updated the existing resume test (was `"restores the last resolved auto effort instead of pending auto on resume"`) to assert auto stays active and the last resolved effort is preserved as the shown level.
- Added a test that a manual concrete pin is **not** reinterpreted as `auto` on resume even when `defaultThinkingLevel: auto`.
- `agent-session-role-thinking.test.ts` (13) + related suites (mcp-discovery, sdk-model-selection, issue-775, tree-traversal, model-persistence, auto-thinking-classifier — 78) pass; `tsgo` typecheck clean.

## Scope

Resume only. Does **not** add `:auto` as a config role suffix and does **not** change `/model` suffix-clearing on cold start — those are separate follow-ups.