### PR TITLE
fix(tui): hide plain text markdown fences

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Kept streaming lines outside the declared stable prefix out of native scrollback so only newly stable output is committed without clearing existing terminal history
+- Render fenced `text`/`plain` Markdown blocks without visible backtick markers so plain assistant examples read as preformatted text instead of code fences.
 
 ## [15.9.0] - 2026-06-04
 

--- a/packages/tui/src/components/markdown.ts
+++ b/packages/tui/src/components/markdown.ts
@@ -278,6 +278,12 @@ function codespanSwatch(code: string, glyph: string): string {
 	return colorSwatch(match[1], glyph);
 }
 
+function isPlainTextCodeBlockLanguage(lang: string | undefined): boolean {
+	if (!lang) return false;
+	const normalized = lang.trim().toLowerCase();
+	return normalized === "text" || normalized === "txt" || normalized === "plain" || normalized === "plaintext";
+}
+
 export class Markdown implements Component {
 	#text: string;
 	#paddingX: number; // Left/right padding
@@ -603,7 +609,10 @@ export class Markdown implements Component {
 				}
 
 				const codeIndent = padding(this.#codeBlockIndent);
-				lines.push(this.#theme.codeBlockBorder(`\`\`\`${token.lang || ""}`));
+				const plainTextCodeBlock = isPlainTextCodeBlockLanguage(token.lang);
+				if (!plainTextCodeBlock) {
+					lines.push(this.#theme.codeBlockBorder(`\`\`\`${token.lang || ""}`));
+				}
 				if (this.#theme.highlightCode) {
 					const highlightedLines = this.#theme.highlightCode(token.text, token.lang);
 					for (const hlLine of highlightedLines) {
@@ -616,7 +625,9 @@ export class Markdown implements Component {
 						lines.push(`${codeIndent}${this.#theme.codeBlock(codeLine)}`);
 					}
 				}
-				lines.push(this.#theme.codeBlockBorder("```"));
+				if (!plainTextCodeBlock) {
+					lines.push(this.#theme.codeBlockBorder("```"));
+				}
 				if (nextTokenType && nextTokenType !== "space") {
 					lines.push(""); // Add spacing after code blocks (unless space token follows)
 				}
@@ -888,7 +899,10 @@ export class Markdown implements Component {
 			} else if (token.type === "code") {
 				// Code block in list item
 				const codeIndent = padding(this.#codeBlockIndent);
-				lines.push(this.#theme.codeBlockBorder(`\`\`\`${token.lang || ""}`));
+				const plainTextCodeBlock = isPlainTextCodeBlockLanguage(token.lang);
+				if (!plainTextCodeBlock) {
+					lines.push(this.#theme.codeBlockBorder(`\`\`\`${token.lang || ""}`));
+				}
 				if (this.#theme.highlightCode) {
 					const highlightedLines = this.#theme.highlightCode(token.text, token.lang);
 					for (const hlLine of highlightedLines) {
@@ -900,7 +914,9 @@ export class Markdown implements Component {
 						lines.push(`${codeIndent}${this.#theme.codeBlock(codeLine)}`);
 					}
 				}
-				lines.push(this.#theme.codeBlockBorder("```"));
+				if (!plainTextCodeBlock) {
+					lines.push(this.#theme.codeBlockBorder("```"));
+				}
 			} else {
 				// Other token types - try to render as inline
 				const text = this.#renderInlineTokens([token], styleContext);

--- a/packages/tui/test/markdown.test.ts
+++ b/packages/tui/test/markdown.test.ts
@@ -678,6 +678,38 @@ more text`,
 		});
 	});
 
+	describe("Plain text fenced blocks", () => {
+		it("hides markdown fence markers for text blocks", () => {
+			const markdown = new Markdown("```text\nplain output\n```", 0, 0, defaultMarkdownTheme);
+			const lines = markdown.render(80);
+			const plainLines = lines.map(line => stripVTControlCharacters(line).trimEnd());
+
+			expect(plainLines).toEqual(["  plain output"]);
+		});
+
+		it("hides markdown fence markers for text blocks inside list items", () => {
+			const markdown = new Markdown("- Item\n\n  ```text\n  plain output\n  ```", 0, 0, defaultMarkdownTheme);
+			const lines = markdown.render(80);
+			const plainLines = lines.map(line => stripVTControlCharacters(line).trimEnd());
+
+			expect(plainLines).toEqual(["- Item", "    plain output"]);
+		});
+
+		it("keeps markdown fence markers for syntax-highlightable blocks", () => {
+			const markdown = new Markdown(
+				"```yaml\nmodelRoles:\n  default: openai/gpt-5.5:high\n```",
+				0,
+				0,
+				defaultMarkdownTheme,
+			);
+			const lines = markdown.render(80);
+			const plainLines = lines.map(line => stripVTControlCharacters(line).trimEnd());
+
+			expect(plainLines[0]).toBe("```yaml");
+			expect(plainLines.at(-1)).toBe("```");
+		});
+	});
+
 	describe("Mermaid fenced blocks", () => {
 		const renderMermaidLines = (text: string, resolveMermaidAscii: (source: string) => string | null) => {
 			const markdown = new Markdown(text, 0, 0, { ...defaultMarkdownTheme, resolveMermaidAscii });


### PR DESCRIPTION
## What

Render fenced Markdown blocks tagged as `text`, `txt`, `plain`, or `plaintext` without the visible opening/closing backtick marker lines.

## Why

Assistant responses often use `text` fences for plain prose/examples. Showing the literal ` ```text ` and closing fence adds visual noise in the TUI even though the language tag carries no syntax-highlighting value.

## Testing

- [x] `npm exec --yes bun@1.3.14 -- --cwd=packages/tui test test/markdown.test.ts`
- [x] `npm exec --yes bun@1.3.14 -- --cwd=packages/tui run check`
- [x] CHANGELOG updated