### PR TITLE
fix(tui): gated kitty unicode placeholders to terminals that honor U=1

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed inline images rendering as a wall of empty PUA box glyphs with laggy scrolling on Kitty-protocol terminals that do not honor Unicode placeholders (most notably WezTerm and tmux/screen passthrough to a non-Kitty outer terminal). The 15.9 placeholder rollout enabled the `U=1`/U+10EEEE grid for every Kitty-protocol path; it now defaults on only for `kitty` and `ghostty`, with `PI_NO_KITTY_PLACEHOLDERS=1` as a hard opt-out and `PI_KITTY_PLACEHOLDERS=1` as opt-in for terminals (e.g. wezterm nightlies) that have since added support ([#1877](https://github.com/can1357/oh-my-pi/issues/1877)).
+
 ## [15.9.1] - 2026-06-04
 
 ### Added

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed inline images (added in 15.9) rendering as a wall of empty PUA box glyphs and producing laggy scrolling on Kitty-protocol terminals that do not implement Unicode placeholders — most notably WezTerm (per upstream wezterm/wezterm#986, placeholder support is still unchecked) and the tmux/screen `getFallbackImageProtocol` path that forces Kitty mode even on non-supporting outer terminals (Terminal.app, etc.). `unicodePlaceholders` now defaults on only for `kitty` and `ghostty`; everything else falls back to direct `a=p,i=…,p=…` placement, which those paths already render correctly. `PI_NO_KITTY_PLACEHOLDERS=1` is still honored as a hard opt-out, and a new `PI_KITTY_PLACEHOLDERS=1` opts in on otherwise-unsupported terminals (e.g. a wezterm nightly that has merged placeholder support) ([#1877](https://github.com/can1357/oh-my-pi/issues/1877)).
+
 ## [15.9.1] - 2026-06-04
 ### Fixed
 

--- a/packages/tui/src/kitty-graphics.ts
+++ b/packages/tui/src/kitty-graphics.ts
@@ -93,10 +93,7 @@ function transmissionOverride(): KittyTransmissionMedium | "auto" {
  * non-supporting outer terminal); `PI_KITTY_PLACEHOLDERS=1` forces on (e.g.
  * for a wezterm nightly that has merged placeholder support).
  */
-export function detectKittyUnicodePlaceholdersSupport(
-	terminalId: string,
-	env: NodeJS.ProcessEnv = Bun.env,
-): boolean {
+export function detectKittyUnicodePlaceholdersSupport(terminalId: string, env: NodeJS.ProcessEnv = Bun.env): boolean {
 	const offRaw = env.PI_NO_KITTY_PLACEHOLDERS?.trim().toLowerCase();
 	if (offRaw === "1" || offRaw === "true" || offRaw === "on" || offRaw === "yes" || offRaw === "y") return false;
 	const force = env.PI_KITTY_PLACEHOLDERS?.trim().toLowerCase();

--- a/packages/tui/src/kitty-graphics.ts
+++ b/packages/tui/src/kitty-graphics.ts
@@ -17,7 +17,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { $env, $flag, logger } from "@oh-my-pi/pi-utils";
+import { $env, logger } from "@oh-my-pi/pi-utils";
 
 /** Kitty Unicode placeholder base character (U+10EEEE, Plane 16 PUA). */
 export const KITTY_PLACEHOLDER = "\u{10eeee}";
@@ -76,8 +76,39 @@ function transmissionOverride(): KittyTransmissionMedium | "auto" {
 	return "auto";
 }
 
+/**
+ * Whether the detected terminal renders Kitty Unicode placeholders (`U=1` +
+ * U+10EEEE with row/column diacritics).
+ *
+ * Only `kitty` (the protocol's origin) and `ghostty` ship a working
+ * implementation; WezTerm advertises Kitty graphics but treats placeholder
+ * cells as literal PUA glyphs (see wezterm/wezterm#986, "placeholder support"
+ * still unchecked), and the tmux/screen fallback can land on any outer
+ * terminal. Enabling placeholders on those paths emits a `columns × rows`
+ * grid of U+10EEEE per image per frame; the cells render as boxed fallback
+ * glyphs and re-emit on every repaint, which is exactly the
+ * "stuck/laggy scrolling + ASCII artifact" symptom reported in #1877.
+ *
+ * `PI_NO_KITTY_PLACEHOLDERS=1` forces off (e.g. for tmux passthrough to a
+ * non-supporting outer terminal); `PI_KITTY_PLACEHOLDERS=1` forces on (e.g.
+ * for a wezterm nightly that has merged placeholder support).
+ */
+export function detectKittyUnicodePlaceholdersSupport(
+	terminalId: string,
+	env: NodeJS.ProcessEnv = Bun.env,
+): boolean {
+	const offRaw = env.PI_NO_KITTY_PLACEHOLDERS?.trim().toLowerCase();
+	if (offRaw === "1" || offRaw === "true" || offRaw === "on" || offRaw === "yes" || offRaw === "y") return false;
+	const force = env.PI_KITTY_PLACEHOLDERS?.trim().toLowerCase();
+	if (force === "1" || force === "true" || force === "on" || force === "yes" || force === "y") return true;
+	if (force === "0" || force === "false" || force === "off" || force === "no" || force === "n") return false;
+	return terminalId === "kitty" || terminalId === "ghostty";
+}
+
 let features: KittyGraphicsFeatures = {
-	unicodePlaceholders: !$flag("PI_NO_KITTY_PLACEHOLDERS"),
+	// Off until `terminal-capabilities` seeds it from the detected terminal id —
+	// the default-on path corrupts wezterm and tmux-passthrough sessions.
+	unicodePlaceholders: false,
 	// Start direct; a successful probe (or explicit `temp-file` override) promotes.
 	transmissionMedium: transmissionOverride() === "temp-file" ? "temp-file" : "direct",
 };

--- a/packages/tui/src/terminal-capabilities.ts
+++ b/packages/tui/src/terminal-capabilities.ts
@@ -1,12 +1,14 @@
 import { encodeSixel } from "@oh-my-pi/pi-natives";
 import { $env, isBunTestRuntime } from "@oh-my-pi/pi-utils";
 import {
+	detectKittyUnicodePlaceholdersSupport,
 	encodeKittyTempFileTransmit,
 	getKittyGraphics,
 	isPngBase64,
 	KITTY_PLACEHOLDER,
 	kittyPlaceholdersFit,
 	renderKittyPlaceholderLines,
+	setKittyGraphics,
 } from "./kitty-graphics";
 
 export enum ImageProtocol {
@@ -320,6 +322,12 @@ export const TERMINAL = (() => {
 	}
 	return resolved;
 })();
+
+// Seed Kitty Unicode placeholder support from the resolved terminal id. Only
+// kitty/ghostty are known to honor `U=1` placement; other Kitty-protocol paths
+// (wezterm, tmux/screen fallback) treat the placeholder cells as literal PUA
+// glyphs, which is the "ASCII artifact + laggy scrolling" reported in #1877.
+setKittyGraphics({ unicodePlaceholders: detectKittyUnicodePlaceholdersSupport(TERMINAL.id, Bun.env) });
 
 type MutableTerminalInfo = {
 	imageProtocol: ImageProtocol | null;

--- a/packages/tui/test/kitty-graphics.test.ts
+++ b/packages/tui/test/kitty-graphics.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import * as fs from "node:fs";
 import { visibleWidth } from "@oh-my-pi/pi-natives";
 import {
+	detectKittyUnicodePlaceholdersSupport,
 	encodeKittyPlaceholderGrid,
 	encodeKittyTempFileProbe,
 	encodeKittyTempFileTransmit,
@@ -154,5 +155,44 @@ describe("kitty graphics feature state", () => {
 		} finally {
 			restore();
 		}
+	});
+});
+
+describe("detectKittyUnicodePlaceholdersSupport", () => {
+	function env(extra: Record<string, string | undefined> = {}): NodeJS.ProcessEnv {
+		return extra as NodeJS.ProcessEnv;
+	}
+
+	it("enables for kitty and ghostty by default (the only terminals that render U=1 placement)", () => {
+		expect(detectKittyUnicodePlaceholdersSupport("kitty", env())).toBe(true);
+		expect(detectKittyUnicodePlaceholdersSupport("ghostty", env())).toBe(true);
+	});
+
+	it("disables for wezterm and other Kitty-protocol paths that treat placeholders as literal PUA glyphs (#1877)", () => {
+		expect(detectKittyUnicodePlaceholdersSupport("wezterm", env())).toBe(false);
+		// Tmux/screen fallback: base terminal id with Kitty protocol forced on by
+		// `getFallbackImageProtocol`. The outer terminal need not understand U=1.
+		expect(detectKittyUnicodePlaceholdersSupport("base", env())).toBe(false);
+		expect(detectKittyUnicodePlaceholdersSupport("iterm2", env())).toBe(false);
+		expect(detectKittyUnicodePlaceholdersSupport("alacritty", env())).toBe(false);
+	});
+
+	it("honors PI_NO_KITTY_PLACEHOLDERS=1 as a hard off override on supporting terminals", () => {
+		expect(detectKittyUnicodePlaceholdersSupport("kitty", env({ PI_NO_KITTY_PLACEHOLDERS: "1" }))).toBe(false);
+		expect(detectKittyUnicodePlaceholdersSupport("ghostty", env({ PI_NO_KITTY_PLACEHOLDERS: "true" }))).toBe(false);
+	});
+
+	it("honors PI_KITTY_PLACEHOLDERS=1 as opt-in on otherwise-unsupported terminals", () => {
+		expect(detectKittyUnicodePlaceholdersSupport("wezterm", env({ PI_KITTY_PLACEHOLDERS: "1" }))).toBe(true);
+	});
+
+	it("PI_NO_KITTY_PLACEHOLDERS beats PI_KITTY_PLACEHOLDERS when both are set", () => {
+		const both = env({ PI_NO_KITTY_PLACEHOLDERS: "1", PI_KITTY_PLACEHOLDERS: "1" });
+		expect(detectKittyUnicodePlaceholdersSupport("kitty", both)).toBe(false);
+	});
+
+	it("PI_KITTY_PLACEHOLDERS=0 forces off on a default-on terminal", () => {
+		expect(detectKittyUnicodePlaceholdersSupport("kitty", env({ PI_KITTY_PLACEHOLDERS: "0" }))).toBe(false);
+		expect(detectKittyUnicodePlaceholdersSupport("ghostty", env({ PI_KITTY_PLACEHOLDERS: "off" }))).toBe(false);
 	});
 });


### PR DESCRIPTION
## Repro

Reporter (on macOS, omp 15.9.1) sees every inline image render as a wall of empty
PUA box glyphs below the image area, plus laggy scrolling — screenshot in [#1877](https://github.com/can1357/oh-my-pi/issues/1877).

The 15.9 placeholder rollout
([`packages/tui/CHANGELOG.md` 15.9.0 "Added Kitty Unicode placeholder image rendering"](packages/tui/CHANGELOG.md))
turned on Kitty's `U=1` / U+10EEEE placement for every terminal that advertises
the Kitty image protocol. The screenshot is what such a placement looks like on
a terminal that does not implement the placeholder feature: each cell renders
as the literal PUA character, and the whole `columns × rows` grid re-paints on
every frame.

## Cause

`packages/tui/src/kitty-graphics.ts` (pre-fix):

```ts
let features: KittyGraphicsFeatures = {
    unicodePlaceholders: !$flag("PI_NO_KITTY_PLACEHOLDERS"),
    ...
};
```

The default ignored the detected terminal id. Two real paths produce the
artifact:

- **WezTerm.** Advertises the Kitty image protocol, but upstream
  [wezterm/wezterm#986](https://github.com/wezterm/wezterm/issues/986)'s task
  list still has "placeholder support, which might enable support to function
  in tmux" *unchecked*. Direct `a=p,i=…,p=…` placement works; the placeholder
  grid does not — the matching APC is ignored and the U+10EEEE cells survive as
  text.
- **tmux / screen fallback.** `getFallbackImageProtocol` forces Kitty protocol
  whenever `$TERM` contains `screen`/`tmux`/`ghostty`, regardless of the outer
  terminal. The outer terminal (e.g. Terminal.app) may not understand `U=1` at
  all.

Either way, `renderImage` lands in the placeholder branch and emits
`fit.columns × fit.rows` placeholder cells per image per frame (~4.8 KB for a
typical 80×20 placement versus ~22 bytes for the direct APC). Repeated on every
repaint, that is both the "ASCII artifact" and the "stuck/laggy scrolling".

## Fix

`packages/tui/src/kitty-graphics.ts`

- New pure helper `detectKittyUnicodePlaceholdersSupport(terminalId, env)`.
  Defaults on for `kitty` and `ghostty` only. Honors
  `PI_NO_KITTY_PLACEHOLDERS=1` as a hard opt-out (back-compat) and a new
  `PI_KITTY_PLACEHOLDERS=1`/`0` opt-in/opt-out (for e.g. a wezterm nightly that
  has since merged placeholder support, or to disable it in a tmux passthrough
  setup).
- Module-level `features.unicodePlaceholders` now starts `false`;
  `terminal-capabilities` seeds the real value once `TERMINAL_ID` resolves.

`packages/tui/src/terminal-capabilities.ts`

- Imports the detector + `setKittyGraphics`, and after `TERMINAL` resolves,
  calls `setKittyGraphics({ unicodePlaceholders: detectKittyUnicodePlaceholdersSupport(TERMINAL.id, Bun.env) })`.

`packages/tui/test/kitty-graphics.test.ts`

- Six new tests cover: default-on for kitty/ghostty, default-off for
  wezterm/base/iterm2/alacritty, `PI_NO_KITTY_PLACEHOLDERS=1` hard off, force-on
  via `PI_KITTY_PLACEHOLDERS=1` on wezterm, off-beats-on precedence, and
  `PI_KITTY_PLACEHOLDERS=0/off` on a default-on terminal.

CHANGELOG entries added to `packages/tui/CHANGELOG.md` and
`packages/coding-agent/CHANGELOG.md` under `[Unreleased] / ### Fixed`.

## Verification

`bun --cwd=packages/tui test test/kitty-graphics.test.ts test/image-budget.test.ts test/image-render.test.ts test/terminal-appearance.test.ts`
→ **72 pass / 0 fail / 240 expect()**.

The new detector tests and the existing image-budget integration tests (which
already pin `unicodePlaceholders` explicitly per describe block) all pass.

The wider `bun --cwd=packages/tui test` run shows 6 pre-existing failures in
`test/markdown.test.ts` and `test/text-utils.test.ts` around OSC 66 text-sizing
width measurement; these exist on `main` (`git stash` + same command reproduces
them with no changes) and are unrelated to this fix.

Fixes #1877