### PR TITLE
fix(agent): handle string systemPrompt in telemetry content capture

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `@oh-my-pi/pi-agent-core` telemetry content capture crashing every chat turn with `TypeError: systemPrompt.map is not a function` when `captureMessageContent` is enabled (`OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true`). `ChatRequestSnapshot.systemPrompt` now accepts `string | readonly string[]` and the telemetry serializers normalize a bare string to a single-element array — previously the full-system serializer called `.map` on a string (the `.length` guard passed, so it threw) and the request-message serializer iterated the string into one `system` message per character.
+
 ## [15.8.3] - 2026-06-03
 ### Added
 

--- a/packages/agent/src/telemetry.ts
+++ b/packages/agent/src/telemetry.ts
@@ -729,7 +729,7 @@ export interface ChatRequestSnapshot {
 	readonly reasoningEffort?: string;
 	readonly toolChoice?: ToolChoice;
 	readonly tools?: readonly { readonly name: string }[];
-	readonly systemPrompt?: readonly string[];
+	readonly systemPrompt?: string | readonly string[];
 	readonly messages?: readonly Message[];
 }
 
@@ -794,6 +794,11 @@ function applyContentCaptureForResponse(telemetry: AgentTelemetry, span: Span, m
 	}
 }
 
+function normalizeSystemPromptParts(systemPrompt: string | readonly string[] | undefined): readonly string[] {
+	if (!systemPrompt) return [];
+	return typeof systemPrompt === "string" ? [systemPrompt] : systemPrompt;
+}
+
 function serializeRequestMessagesForTelemetry(
 	telemetry: AgentTelemetry,
 	request: ChatRequestSnapshot,
@@ -801,10 +806,8 @@ function serializeRequestMessagesForTelemetry(
 	const serializer = telemetry.config.contentSerializer?.requestMessages;
 	if (serializer) return callContentSerializer(telemetry, "requestMessages", () => serializer(request));
 	const messages: TelemetryMessageSummary[] = [];
-	if (request.systemPrompt) {
-		for (const text of request.systemPrompt)
-			messages.push({ role: "system", content: summarizeTelemetryValue(text) });
-	}
+	for (const text of normalizeSystemPromptParts(request.systemPrompt))
+		messages.push({ role: "system", content: summarizeTelemetryValue(text) });
 	if (request.messages) {
 		for (const message of request.messages) {
 			messages.push({ role: message.role, content: summarizeTelemetryValue(message.content) });
@@ -872,8 +875,8 @@ interface OtelOutputMessage extends OtelInputMessage {
 }
 
 function serializeFullSystemInstructionsForTelemetry(request: ChatRequestSnapshot): string | undefined {
-	const systemPrompt = request.systemPrompt;
-	if (!systemPrompt || systemPrompt.length === 0) return undefined;
+	const systemPrompt = normalizeSystemPromptParts(request.systemPrompt);
+	if (systemPrompt.length === 0) return undefined;
 	return stringifyJsonAttribute(systemPrompt.map(text => ({ type: "text", content: text }) satisfies OtelMessagePart));
 }
 

--- a/packages/agent/test/otel.test.ts
+++ b/packages/agent/test/otel.test.ts
@@ -364,6 +364,32 @@ describe("agent-loop OTEL instrumentation", () => {
 		expect(JSON.parse(systemAttr!)).toEqual([{ type: "text", content: "sys-instruction" }]);
 	});
 
+	it("captures string systemPrompt without crashing when captureMessageContent is true", async () => {
+		const mock = createMockModel({
+			...MOCK_IDENT,
+			responses: [{ content: ["hi back"], stopReason: "stop" }],
+		});
+		const config: AgentLoopConfig = {
+			model: mock.model,
+			convertToLlm: identityConverter,
+			telemetry: { captureMessageContent: true },
+		};
+		// Providers normalize systemPrompt to `string | string[]`; telemetry must accept a bare string.
+		const ctx: AgentContext = { systemPrompt: "sys-as-string" as unknown as string[], messages: [], tools: [] };
+		await runAndDrain(agentLoop([createUserMessage("hi")], ctx, config, undefined, mock.stream));
+
+		const chat = findSpan(exporter.getFinishedSpans(), "chat mock-model");
+		expect(chat).toBeDefined();
+		expect(chat?.status.code).not.toBe(SpanStatusCode.ERROR);
+		const systemAttr = chat?.attributes[GenAIAttr.SystemInstructions] as string | undefined;
+		expect(JSON.parse(systemAttr!)).toEqual([{ type: "text", content: "sys-as-string" }]);
+		const request = JSON.parse(chat?.attributes[PiGenAIAttr.RequestMessages] as string) as Array<{
+			content: unknown;
+			role: string;
+		}>;
+		expect(request.filter(message => message.role === "system")).toHaveLength(1);
+	});
+
 	it("captures bounded dashboard summary content when requested", async () => {
 		const mock = createMockModel({
 			...MOCK_IDENT,


### PR DESCRIPTION
## Symptom

With content capture enabled (`OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true`, i.e. `captureMessageContent` resolving to `"full"`), every chat turn throws and the turn dies before producing a response:

```
TypeError: systemPrompt.map is not a function
    at serializeFullSystemInstructionsForTelemetry (packages/agent/src/telemetry.ts:877)
    at applyContentCaptureForRequest (packages/agent/src/telemetry.ts)
    at startChatSpan (packages/agent/src/telemetry.ts)
    at streamAssistantResponse (packages/agent/src/agent-loop.ts)
```

## Root cause

`ChatRequestSnapshot.systemPrompt` is typed `readonly string[]`, but at runtime it can be a bare `string`. Providers already normalize `systemPrompt` (`string | readonly string[] | undefined | null`) via `normalizeSystemPrompts` before use — the telemetry serializers were the only consumers that assumed an array:

- `serializeFullSystemInstructionsForTelemetry` calls `systemPrompt.map(...)`. The `.length` guard passes for a non-empty string, then `.map` is `undefined` → `TypeError`, killing the turn.
- `serializeRequestMessagesForTelemetry` does `for (const text of request.systemPrompt)`. On a string this doesn't throw but iterates characters, emitting one bogus `system` message per character.

Both paths are only reachable when content capture is on (`startChatSpan` → `applyContentCaptureForRequest`), which is why the crash only surfaces with `captureMessageContent`.

## Fix

Widen `ChatRequestSnapshot.systemPrompt` to `string | readonly string[]` and route both serializers through a small local `normalizeSystemPromptParts` helper that coerces a string to a single-element array. Kept the normalizer local to `telemetry.ts` rather than reusing `normalizeSystemPrompts` to avoid widening the `@oh-my-pi/pi-ai` public API.

## Test

Added a regression test in `packages/agent/test/otel.test.ts` mirroring the existing full-capture test but with a string `systemPrompt`. It asserts the chat span is not `ERROR` and that `GenAIAttr.SystemInstructions` serializes to `[{ type: "text", content: "sys-as-string" }]`, plus exactly one `system` message in `PiGenAIAttr.RequestMessages` (guarding the character-split path). Red before the fix — reproduces the exact `TypeError` at `telemetry.ts:877` — green after.

Verification: full `packages/agent/test/otel.test.ts` suite passes (37/37) and `check:types` is clean.