### PR TITLE
fix(ai/openai-responses): route streaming events by item_id for parallel tool calls

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed parallel `function_call` items on the OpenAI Responses API losing arguments on every call except the last when the upstream server interleaves their stream events (observed against llama.cpp and other local Responses-compat hosts). `processResponsesStream` no longer routes `function_call_arguments.{delta,done}`, `output_item.done`, content_part/text/refusal/reasoning events through a singleton `currentItem`/`currentBlock` reference; it now tracks every open item in registries keyed by `output_index` and `item_id` so each event is folded into the matching block and the emitted `toolcall_end` carries the correct `contentIndex`. ([#1880](https://github.com/can1357/oh-my-pi/issues/1880))
+
 ## [15.9.1] - 2026-06-04
 
 ### Added

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -395,19 +395,54 @@ export async function processResponsesStream<TApi extends Api>(
 	model: Model<TApi>,
 	options?: ProcessResponsesStreamOptions,
 ): Promise<void> {
-	let currentItem:
-		| ResponseReasoningItem
-		| ResponseOutputMessage
-		| ResponseFunctionToolCall
-		| ResponseCustomToolCall
-		| null = null;
-	let currentBlock:
-		| ThinkingContent
-		| TextContent
-		| (ToolCall & { partialJson: string; lastParseLen?: number })
-		| null = null;
-	const blocks = output.content;
-	const blockIndex = () => blocks.length - 1;
+	type StreamingToolCallBlock = ToolCall & { partialJson: string; lastParseLen?: number };
+	interface StreamingItem {
+		item: ResponseReasoningItem | ResponseOutputMessage | ResponseFunctionToolCall | ResponseCustomToolCall;
+		block: ThinkingContent | TextContent | StreamingToolCallBlock;
+	}
+
+	// Multiple items (parallel function_calls in particular) can be open at the same
+	// time. OpenAI's spec routes every per-item event by `output_index`/`item_id`;
+	// see https://github.com/can1357/oh-my-pi/issues/1880 — llama.cpp emits parallel
+	// function_call deltas interleaved, and a singleton `current` reference would
+	// fold them into the wrong block and drop arguments on every call but the last.
+	const openItemsByOutputIndex = new Map<number, StreamingItem>();
+	const openItemsByItemId = new Map<string, StreamingItem>();
+	let lastOpenItem: StreamingItem | null = null;
+
+	const registerOpenItem = (
+		outputIndex: number | undefined,
+		itemId: string | undefined,
+		entry: StreamingItem,
+	): void => {
+		if (typeof outputIndex === "number") openItemsByOutputIndex.set(outputIndex, entry);
+		if (itemId) openItemsByItemId.set(itemId, entry);
+		lastOpenItem = entry;
+	};
+	const lookupOpenItem = (event: { output_index?: number; item_id?: string }): StreamingItem | undefined => {
+		if (typeof event.output_index === "number") {
+			const found = openItemsByOutputIndex.get(event.output_index);
+			if (found) return found;
+		}
+		if (event.item_id) {
+			const found = openItemsByItemId.get(event.item_id);
+			if (found) return found;
+		}
+		// Fallback for tests / mock providers that omit identifiers on stream events.
+		return lastOpenItem ?? undefined;
+	};
+	const closeOpenItem = (
+		outputIndex: number | undefined,
+		itemId: string | undefined,
+		entry: StreamingItem | undefined,
+	): void => {
+		if (typeof outputIndex === "number") openItemsByOutputIndex.delete(outputIndex);
+		if (itemId) openItemsByItemId.delete(itemId);
+		if (entry && lastOpenItem === entry) lastOpenItem = null;
+	};
+	const contentIndexOf = (block: ThinkingContent | TextContent | StreamingToolCallBlock): number =>
+		output.content.indexOf(block);
+
 	let sawFirstToken = false;
 
 	for await (const event of openaiStream) {
@@ -420,29 +455,28 @@ export async function processResponsesStream<TApi extends Api>(
 			}
 			const item = event.item;
 			if (item.type === "reasoning") {
-				currentItem = item;
-				currentBlock = { type: "thinking", thinking: "", itemId: item.id };
-				output.content.push(currentBlock);
-				stream.push({ type: "thinking_start", contentIndex: blockIndex(), partial: output });
+				const block: ThinkingContent = { type: "thinking", thinking: "", itemId: item.id };
+				output.content.push(block);
+				registerOpenItem(event.output_index, item.id, { item, block });
+				stream.push({ type: "thinking_start", contentIndex: contentIndexOf(block), partial: output });
 			} else if (item.type === "message") {
-				currentItem = item;
-				currentBlock = { type: "text", text: "" };
-				output.content.push(currentBlock);
-				stream.push({ type: "text_start", contentIndex: blockIndex(), partial: output });
+				const block: TextContent = { type: "text", text: "" };
+				output.content.push(block);
+				registerOpenItem(event.output_index, item.id, { item, block });
+				stream.push({ type: "text_start", contentIndex: contentIndexOf(block), partial: output });
 			} else if (item.type === "function_call") {
-				currentItem = item;
-				currentBlock = {
+				const block: StreamingToolCallBlock = {
 					type: "toolCall",
 					id: encodeResponsesToolCallId(item.call_id, item.id),
 					name: item.name,
 					arguments: {},
 					partialJson: item.arguments || "",
 				};
-				output.content.push(currentBlock);
-				stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
+				output.content.push(block);
+				registerOpenItem(event.output_index, item.id, { item, block });
+				stream.push({ type: "toolcall_start", contentIndex: contentIndexOf(block), partial: output });
 			} else if (item.type === "custom_tool_call") {
-				currentItem = item;
-				currentBlock = {
+				const block: StreamingToolCallBlock = {
 					type: "toolCall",
 					id: encodeResponsesToolCallId(item.call_id, item.id),
 					// Preserve the raw wire name (e.g. `apply_patch`). The agent-loop
@@ -456,39 +490,43 @@ export async function processResponsesStream<TApi extends Api>(
 					// accumulation buffer so later code that inspects the field still works.
 					partialJson: item.input ?? "",
 				};
-				output.content.push(currentBlock);
-				stream.push({ type: "toolcall_start", contentIndex: blockIndex(), partial: output });
+				output.content.push(block);
+				registerOpenItem(event.output_index, item.id, { item, block });
+				stream.push({ type: "toolcall_start", contentIndex: contentIndexOf(block), partial: output });
 			}
 		} else if (event.type === "response.reasoning_summary_part.added") {
-			if (currentItem?.type === "reasoning") {
-				currentItem.summary = currentItem.summary || [];
-				currentItem.summary.push(event.part);
+			const entry = lookupOpenItem(event);
+			if (entry?.item.type === "reasoning") {
+				entry.item.summary = entry.item.summary || [];
+				entry.item.summary.push(event.part);
 			}
 		} else if (event.type === "response.reasoning_summary_text.delta") {
-			if (currentItem?.type === "reasoning" && currentBlock?.type === "thinking") {
-				currentItem.summary = currentItem.summary || [];
-				const lastPart = currentItem.summary[currentItem.summary.length - 1];
+			const entry = lookupOpenItem(event);
+			if (entry?.item.type === "reasoning" && entry.block.type === "thinking") {
+				entry.item.summary = entry.item.summary || [];
+				const lastPart = entry.item.summary[entry.item.summary.length - 1];
 				if (lastPart) {
-					currentBlock.thinking += event.delta;
+					entry.block.thinking += event.delta;
 					lastPart.text += event.delta;
 					stream.push({
 						type: "thinking_delta",
-						contentIndex: blockIndex(),
+						contentIndex: contentIndexOf(entry.block),
 						delta: event.delta,
 						partial: output,
 					});
 				}
 			}
 		} else if (event.type === "response.reasoning_summary_part.done") {
-			if (currentItem?.type === "reasoning" && currentBlock?.type === "thinking") {
-				currentItem.summary = currentItem.summary || [];
-				const lastPart = currentItem.summary[currentItem.summary.length - 1];
+			const entry = lookupOpenItem(event);
+			if (entry?.item.type === "reasoning" && entry.block.type === "thinking") {
+				entry.item.summary = entry.item.summary || [];
+				const lastPart = entry.item.summary[entry.item.summary.length - 1];
 				if (lastPart) {
-					currentBlock.thinking += "\n\n";
+					entry.block.thinking += "\n\n";
 					lastPart.text += "\n\n";
 					stream.push({
 						type: "thinking_delta",
-						contentIndex: blockIndex(),
+						contentIndex: contentIndexOf(entry.block),
 						delta: "\n\n",
 						partial: output,
 					});
@@ -497,91 +535,103 @@ export async function processResponsesStream<TApi extends Api>(
 		} else if (event.type === "response.reasoning_text.delta") {
 			// Raw reasoning text delta from local providers that stream thinking
 			// directly rather than via the OpenAI summary tracking protocol.
-			if (currentItem?.type === "reasoning" && currentBlock?.type === "thinking") {
-				currentBlock.thinking += event.delta;
+			const entry = lookupOpenItem(event);
+			if (entry?.item.type === "reasoning" && entry.block.type === "thinking") {
+				entry.block.thinking += event.delta;
 				stream.push({
 					type: "thinking_delta",
-					contentIndex: blockIndex(),
+					contentIndex: contentIndexOf(entry.block),
 					delta: event.delta,
 					partial: output,
 				});
 			}
 		} else if (event.type === "response.content_part.added") {
-			if (currentItem?.type === "message") {
-				currentItem.content = currentItem.content || [];
+			const entry = lookupOpenItem(event);
+			if (entry?.item.type === "message") {
+				entry.item.content = entry.item.content || [];
 				if (event.part.type === "output_text" || event.part.type === "refusal") {
-					currentItem.content.push(event.part);
+					entry.item.content.push(event.part);
 				}
 			}
 		} else if (event.type === "response.output_text.delta") {
-			if (currentItem?.type === "message" && currentBlock?.type === "text") {
-				const lastPart = currentItem.content?.[currentItem.content.length - 1];
+			const entry = lookupOpenItem(event);
+			if (entry?.item.type === "message" && entry.block.type === "text") {
+				const lastPart = entry.item.content?.[entry.item.content.length - 1];
 				if (lastPart?.type === "output_text") {
-					currentBlock.text += event.delta;
+					entry.block.text += event.delta;
 					lastPart.text += event.delta;
 					stream.push({
 						type: "text_delta",
-						contentIndex: blockIndex(),
+						contentIndex: contentIndexOf(entry.block),
 						delta: event.delta,
 						partial: output,
 					});
 				}
 			}
 		} else if (event.type === "response.refusal.delta") {
-			if (currentItem?.type === "message" && currentBlock?.type === "text") {
-				const lastPart = currentItem.content?.[currentItem.content.length - 1];
+			const entry = lookupOpenItem(event);
+			if (entry?.item.type === "message" && entry.block.type === "text") {
+				const lastPart = entry.item.content?.[entry.item.content.length - 1];
 				if (lastPart?.type === "refusal") {
-					currentBlock.text += event.delta;
+					entry.block.text += event.delta;
 					lastPart.refusal += event.delta;
 					stream.push({
 						type: "text_delta",
-						contentIndex: blockIndex(),
+						contentIndex: contentIndexOf(entry.block),
 						delta: event.delta,
 						partial: output,
 					});
 				}
 			}
 		} else if (event.type === "response.function_call_arguments.delta") {
-			if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {
-				currentBlock.partialJson += event.delta;
-				const throttled = parseStreamingJsonThrottled(currentBlock.partialJson, currentBlock.lastParseLen ?? 0);
+			const entry = lookupOpenItem(event);
+			if (entry?.item.type === "function_call" && entry.block.type === "toolCall") {
+				const block = entry.block;
+				block.partialJson += event.delta;
+				const throttled = parseStreamingJsonThrottled(block.partialJson, block.lastParseLen ?? 0);
 				if (throttled) {
-					currentBlock.arguments = throttled.value;
-					currentBlock.lastParseLen = throttled.parsedLen;
+					block.arguments = throttled.value;
+					block.lastParseLen = throttled.parsedLen;
 				}
 				stream.push({
 					type: "toolcall_delta",
-					contentIndex: blockIndex(),
+					contentIndex: contentIndexOf(block),
 					delta: event.delta,
 					partial: output,
 				});
 			}
 		} else if (event.type === "response.function_call_arguments.done") {
-			if (currentItem?.type === "function_call" && currentBlock?.type === "toolCall") {
-				currentBlock.partialJson = event.arguments;
-				currentBlock.arguments = parseStreamingJson(currentBlock.partialJson);
-				delete (currentBlock as { partialJson?: string }).partialJson;
-				delete (currentBlock as { lastParseLen?: number }).lastParseLen;
+			const entry = lookupOpenItem(event);
+			if (entry?.item.type === "function_call" && entry.block.type === "toolCall") {
+				const block = entry.block;
+				block.partialJson = event.arguments;
+				block.arguments = parseStreamingJson(block.partialJson);
+				delete (block as { partialJson?: string }).partialJson;
+				delete (block as { lastParseLen?: number }).lastParseLen;
 			}
 		} else if (event.type === "response.custom_tool_call_input.delta") {
-			if (currentItem?.type === "custom_tool_call" && currentBlock?.type === "toolCall") {
-				currentBlock.partialJson += event.delta;
-				currentBlock.arguments = { input: currentBlock.partialJson };
+			const entry = lookupOpenItem(event);
+			if (entry?.item.type === "custom_tool_call" && entry.block.type === "toolCall") {
+				const block = entry.block;
+				block.partialJson += event.delta;
+				block.arguments = { input: block.partialJson };
 				stream.push({
 					type: "toolcall_delta",
-					contentIndex: blockIndex(),
+					contentIndex: contentIndexOf(block),
 					delta: event.delta,
 					partial: output,
 				});
 			}
 		} else if (event.type === "response.custom_tool_call_input.done") {
-			if (currentItem?.type === "custom_tool_call" && currentBlock?.type === "toolCall") {
-				currentBlock.partialJson = event.input;
-				currentBlock.arguments = { input: event.input };
+			const entry = lookupOpenItem(event);
+			if (entry?.item.type === "custom_tool_call" && entry.block.type === "toolCall") {
+				entry.block.partialJson = event.input;
+				entry.block.arguments = { input: event.input };
 			}
 		} else if (event.type === "response.output_item.done") {
 			const item = structuredCloneJSON(event.item);
 			options?.onOutputItemDone?.(item);
+			const entry = lookupOpenItem({ output_index: event.output_index, item_id: item.id });
 			if (item.type === "reasoning") {
 				const thinking =
 					item.summary?.length > 0
@@ -595,54 +645,53 @@ export async function processResponsesStream<TApi extends Api>(
 				if (reasoningBlock) {
 					reasoningBlock.thinking = thinking;
 					reasoningBlock.thinkingSignature = JSON.stringify(item);
-					const reasoningBlockIndex = output.content.indexOf(reasoningBlock);
 					stream.push({
 						type: "thinking_end",
-						contentIndex: reasoningBlockIndex,
+						contentIndex: contentIndexOf(reasoningBlock),
 						content: thinking,
 						partial: output,
 					});
 				}
-				if ((currentBlock as ThinkingContent | null)?.itemId === item.id) currentBlock = null;
-			} else if (item.type === "message" && currentBlock?.type === "text") {
-				currentBlock.text = item.content
+				closeOpenItem(event.output_index, item.id, entry);
+			} else if (item.type === "message" && entry?.block.type === "text") {
+				const block = entry.block;
+				block.text = item.content
 					.map(part => (part.type === "output_text" ? (part.text ?? "") : (part.refusal ?? "")))
 					.join("");
-				currentBlock.textSignature = encodeTextSignatureV1(item.id, item.phase ?? undefined);
+				block.textSignature = encodeTextSignatureV1(item.id, item.phase ?? undefined);
 				stream.push({
 					type: "text_end",
-					contentIndex: blockIndex(),
-					content: currentBlock.text,
+					contentIndex: contentIndexOf(block),
+					content: block.text,
 					partial: output,
 				});
-				currentBlock = null;
+				closeOpenItem(event.output_index, item.id, entry);
 			} else if (item.type === "function_call") {
-				const args =
-					currentBlock?.type === "toolCall" && currentBlock.partialJson
-						? parseStreamingJson(currentBlock.partialJson)
-						: parseStreamingJson(item.arguments || "{}");
+				const block = entry?.block.type === "toolCall" ? entry.block : undefined;
+				const args = block?.partialJson
+					? parseStreamingJson(block.partialJson)
+					: parseStreamingJson(item.arguments || "{}");
 				const toolCall: ToolCall = {
 					type: "toolCall",
 					id: encodeResponsesToolCallId(item.call_id, item.id),
 					name: item.name,
 					arguments: args,
 				};
-				if (currentBlock?.type === "toolCall") {
+				if (block) {
 					// Persist the authoritative final args on the stored block. The
 					// throttled delta parser may have skipped the last partial parse,
-					// leaving currentBlock.arguments stale (often `{}`); the emitted
-					// toolCall and the persisted block must agree.
-					currentBlock.arguments = args;
-					delete (currentBlock as { partialJson?: string }).partialJson;
-					delete (currentBlock as { lastParseLen?: number }).lastParseLen;
+					// leaving block.arguments stale (often `{}`); the emitted toolCall
+					// and the persisted block must agree.
+					block.arguments = args;
+					delete (block as { partialJson?: string }).partialJson;
+					delete (block as { lastParseLen?: number }).lastParseLen;
 				}
-				currentBlock = null;
-				stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
+				const contentIndex = block ? contentIndexOf(block) : output.content.length - 1;
+				closeOpenItem(event.output_index, item.id, entry);
+				stream.push({ type: "toolcall_end", contentIndex, toolCall, partial: output });
 			} else if (item.type === "custom_tool_call") {
-				const rawInput =
-					currentBlock?.type === "toolCall" && currentBlock.partialJson
-						? currentBlock.partialJson
-						: (item.input ?? "");
+				const block = entry?.block.type === "toolCall" ? entry.block : undefined;
+				const rawInput = block?.partialJson ? block.partialJson : (item.input ?? "");
 				const toolCall: ToolCall = {
 					type: "toolCall",
 					id: encodeResponsesToolCallId(item.call_id, item.id),
@@ -650,8 +699,9 @@ export async function processResponsesStream<TApi extends Api>(
 					arguments: { input: rawInput },
 					customWireName: item.name,
 				};
-				currentBlock = null;
-				stream.push({ type: "toolcall_end", contentIndex: blockIndex(), toolCall, partial: output });
+				const contentIndex = block ? contentIndexOf(block) : output.content.length - 1;
+				closeOpenItem(event.output_index, item.id, entry);
+				stream.push({ type: "toolcall_end", contentIndex, toolCall, partial: output });
 			}
 		} else if (event.type === "response.completed") {
 			const response = event.response;

--- a/packages/ai/test/openai-responses-parallel-tool-calls.test.ts
+++ b/packages/ai/test/openai-responses-parallel-tool-calls.test.ts
@@ -1,0 +1,205 @@
+// Regression for https://github.com/can1357/oh-my-pi/issues/1880.
+//
+// llama.cpp (and any OpenAI-Responses-compatible host that interleaves
+// multiple function_call items) emits `output_item.added` for every parallel
+// call before the deltas arrive, then routes deltas via `item_id`/`output_index`
+// instead of relying on a single in-flight item. `processResponsesStream`
+// previously kept a singleton `currentBlock` reference and ignored those
+// identifiers, so deltas for the first call were folded into the buffer of the
+// most-recently-added block. The dispatcher then received empty `{}` arguments
+// for every call except the last one.
+//
+// These tests pin the contract: each `function_call_arguments.{delta,done}` and
+// `output_item.done` event must be routed by `output_index`/`item_id`, not by
+// arrival order.
+import { describe, expect, test } from "bun:test";
+import { processResponsesStream } from "@oh-my-pi/pi-ai/providers/openai-responses-shared";
+import type { AssistantMessage, Model } from "@oh-my-pi/pi-ai/types";
+import type { ResponseStreamEvent } from "openai/resources/responses/responses";
+
+function makeModel(): Model<"openai-responses"> {
+	return {
+		api: "openai-responses",
+		name: "Llama",
+		id: "llama-3",
+		provider: "llama.cpp",
+		baseUrl: "http://127.0.0.1:8080/v1",
+		contextWindow: 8192,
+		maxTokens: 2048,
+		input: ["text"],
+		reasoning: false,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	};
+}
+
+function makeOutput(): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [],
+		timestamp: Date.now(),
+		provider: "llama.cpp",
+		model: "llama-3",
+		api: "openai-responses",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+	};
+}
+
+async function* makeStream(events: unknown[]): AsyncIterable<ResponseStreamEvent> {
+	for (const e of events) yield e as ResponseStreamEvent;
+}
+
+type EmittedEvent = { type?: string } & Record<string, unknown>;
+
+describe("processResponsesStream: parallel function_call items", () => {
+	test("routes deltas to the correct block when both items are added before any delta", async () => {
+		const output = makeOutput();
+		const emitted: EmittedEvent[] = [];
+		const stream = { push: (e: unknown) => emitted.push(e as EmittedEvent), end: () => {} } as never;
+
+		const argsA = JSON.stringify({ _i: "Reading test", path: "test.txt" });
+		const argsB = JSON.stringify({ _i: "Reading test", path: "test.md" });
+
+		await processResponsesStream(
+			makeStream([
+				{
+					type: "response.output_item.added",
+					output_index: 0,
+					item: { type: "function_call", id: "fc_a", call_id: "call_a", name: "read", arguments: "" },
+				},
+				{
+					type: "response.output_item.added",
+					output_index: 1,
+					item: { type: "function_call", id: "fc_b", call_id: "call_b", name: "read", arguments: "" },
+				},
+				{
+					type: "response.function_call_arguments.delta",
+					output_index: 0,
+					item_id: "fc_a",
+					delta: argsA,
+				},
+				{
+					type: "response.function_call_arguments.delta",
+					output_index: 1,
+					item_id: "fc_b",
+					delta: argsB,
+				},
+				{
+					type: "response.function_call_arguments.done",
+					output_index: 0,
+					item_id: "fc_a",
+					arguments: argsA,
+				},
+				{
+					type: "response.function_call_arguments.done",
+					output_index: 1,
+					item_id: "fc_b",
+					arguments: argsB,
+				},
+				{
+					type: "response.output_item.done",
+					output_index: 0,
+					item: { type: "function_call", id: "fc_a", call_id: "call_a", name: "read", arguments: argsA },
+				},
+				{
+					type: "response.output_item.done",
+					output_index: 1,
+					item: { type: "function_call", id: "fc_b", call_id: "call_b", name: "read", arguments: argsB },
+				},
+			]),
+			output,
+			stream,
+			makeModel(),
+		);
+
+		expect(output.content).toHaveLength(2);
+		const [blockA, blockB] = output.content;
+		expect(blockA?.type).toBe("toolCall");
+		expect(blockB?.type).toBe("toolCall");
+		if (blockA?.type !== "toolCall" || blockB?.type !== "toolCall") throw new Error("expected toolCalls");
+		expect(blockA.arguments).toEqual({ _i: "Reading test", path: "test.txt" });
+		expect(blockB.arguments).toEqual({ _i: "Reading test", path: "test.md" });
+
+		const ends = emitted.filter(e => e.type === "toolcall_end") as Array<{
+			toolCall: { id: string; arguments: Record<string, unknown> };
+			contentIndex: number;
+		}>;
+		expect(ends).toHaveLength(2);
+		const byCallId = new Map(ends.map(e => [e.toolCall.id.split("|")[0], e]));
+		expect(byCallId.get("call_a")?.toolCall.arguments).toEqual({ _i: "Reading test", path: "test.txt" });
+		expect(byCallId.get("call_b")?.toolCall.arguments).toEqual({ _i: "Reading test", path: "test.md" });
+		expect(byCallId.get("call_a")?.contentIndex).toBe(0);
+		expect(byCallId.get("call_b")?.contentIndex).toBe(1);
+
+		// Delta events must also carry the per-block contentIndex — otherwise the
+		// streaming UI updates the wrong block while args are still arriving.
+		const deltas = emitted.filter(e => e.type === "toolcall_delta") as Array<{
+			delta: string;
+			contentIndex: number;
+		}>;
+		expect(deltas).toHaveLength(2);
+		const deltaForA = deltas.find(d => d.delta === argsA);
+		const deltaForB = deltas.find(d => d.delta === argsB);
+		expect(deltaForA?.contentIndex).toBe(0);
+		expect(deltaForB?.contentIndex).toBe(1);
+	});
+
+	test("routes done-only finalization to the correct block when arguments stream as a single chunk on each item", async () => {
+		// Some local Responses-compat hosts skip the per-delta protocol entirely
+		// and stash the full arguments string on `output_item.added`/`done`.
+		const output = makeOutput();
+		const emitted: EmittedEvent[] = [];
+		const stream = { push: (e: unknown) => emitted.push(e as EmittedEvent), end: () => {} } as never;
+
+		const argsA = JSON.stringify({ path: "test.txt" });
+		const argsB = JSON.stringify({ path: "test.md" });
+
+		await processResponsesStream(
+			makeStream([
+				{
+					type: "response.output_item.added",
+					output_index: 0,
+					item: { type: "function_call", id: "fc_a", call_id: "call_a", name: "read", arguments: argsA },
+				},
+				{
+					type: "response.output_item.added",
+					output_index: 1,
+					item: { type: "function_call", id: "fc_b", call_id: "call_b", name: "read", arguments: argsB },
+				},
+				{
+					type: "response.output_item.done",
+					output_index: 0,
+					item: { type: "function_call", id: "fc_a", call_id: "call_a", name: "read", arguments: argsA },
+				},
+				{
+					type: "response.output_item.done",
+					output_index: 1,
+					item: { type: "function_call", id: "fc_b", call_id: "call_b", name: "read", arguments: argsB },
+				},
+			]),
+			output,
+			stream,
+			makeModel(),
+		);
+
+		const [blockA, blockB] = output.content;
+		if (blockA?.type !== "toolCall" || blockB?.type !== "toolCall") throw new Error("expected toolCalls");
+		expect(blockA.arguments).toEqual({ path: "test.txt" });
+		expect(blockB.arguments).toEqual({ path: "test.md" });
+
+		const ends = emitted.filter(e => e.type === "toolcall_end") as Array<{
+			toolCall: { id: string; arguments: Record<string, unknown> };
+		}>;
+		expect(ends).toHaveLength(2);
+		const byCallId = new Map(ends.map(e => [e.toolCall.id.split("|")[0], e]));
+		expect(byCallId.get("call_a")?.toolCall.arguments).toEqual({ path: "test.txt" });
+		expect(byCallId.get("call_b")?.toolCall.arguments).toEqual({ path: "test.md" });
+	});
+});


### PR DESCRIPTION
## Repro

Prompt `gemma3-e4b` (or any model behind llama.cpp's `/v1/responses` endpoint) to call a tool twice in parallel:

```
Use the `read` tool, to read test.txt and test.md in parallel.
```

The model emits two `function_call` items in one turn. The provider payload saved on the assistant message preserves both `arguments` strings verbatim, but every call except the last is dispatched with `{}`:

```
### Tool Result: read
(error)
Validation failed for tool "read":
  - path: Invalid input: expected string, received undefined
Received arguments:
{}
```

Synthetic stream reproducing the same failure (no llama.cpp required) lives at `packages/ai/test/openai-responses-parallel-tool-calls.test.ts`; running it against `main` fails with `Received: {}` on the first call.

## Cause

`processResponsesStream` in `packages/ai/src/providers/openai-responses-shared.ts` kept a singleton `currentItem` / `currentBlock` reference and dispatched every per-item event (`function_call_arguments.{delta,done}`, `output_item.done`, content_part / text / refusal / reasoning summary events) through it. Each event in the OpenAI Responses spec already carries `item_id` and `output_index`, but the code ignored both.

OpenAI's own API serialises function-call items, so the bug stayed latent there. llama.cpp emits the parallel items interleaved — both `output_item.added` events fire before the deltas — which is legal per spec. The second `output_item.added` overwrote `currentBlock` to the fc_b block; the delta event labelled `item_id=fc_a` then appended fc_a's arguments string onto fc_b's `partialJson` buffer. The resulting `{...test.txt...}{...test.md...}` blob is invalid JSON, so `parseStreamingJson` returned `{}` when fc_a's `output_item.done` arrived. fc_b succeeded only because its `output_item.done` fell back to `parseStreamingJson(item.arguments)` once `currentBlock` had been cleared.

`blockIndex()` (`output.content.length - 1`) suffered the same problem: deltas for an earlier item reported the `contentIndex` of the latest item, so streaming UI deltas would update the wrong block too.

## Fix

- Replace the singleton `currentItem` / `currentBlock` references in `processResponsesStream` with `openItemsByOutputIndex` and `openItemsByItemId` maps populated on `response.output_item.added` and cleared on `response.output_item.done`.
- Resolve every per-item event through a new `lookupOpenItem` helper that prefers `output_index`, falls back to `item_id`, and only falls back to the most-recently-added item when neither is present (covers tests / minimal mock providers that omit identifiers).
- Compute `contentIndex` on every emitted stream event from `output.content.indexOf(block)` via a `contentIndexOf` helper instead of `blocks.length - 1`, so delta / done events for earlier parallel items report the correct array index.
- `output_item.done` for `function_call` / `custom_tool_call` now persists the authoritative final args on the matched block (preserves the existing throttled-parse fix-up) and only then clears the registry entry; the singleton `currentBlock = null` reset that handled this implicitly is gone.

## Verification

- `bun --cwd packages/ai test test/openai-responses-parallel-tool-calls.test.ts test/apply-patch-freeform.test.ts` — 27 pass, 82 expectations (regression on `main` shows the new file failing with `Received: {}` on the first call).
- `bun --cwd packages/ai test test/` — 1477 pass, 337 skip (only `[skip]` are E2E suites gated on credentials).
- `bun --cwd packages/agent test test/` — 216 pass.
- New regression `packages/ai/test/openai-responses-parallel-tool-calls.test.ts` covers (a) interleaved `function_call_arguments.delta` events routed by `item_id`, (b) done-only finalisation when arguments ship as a single chunk on each parallel item, (c) `contentIndex` correctness on both `toolcall_delta` and `toolcall_end` events for earlier blocks.

Fixes #1880