### PR TITLE
feat(model-selector): add "Set for all roles" action to /model

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 
 - Added deferred session-title generation so greetings no longer become the session title. A first user message that is only a greeting / acknowledgement / filler ("hi", "thanks", "ok", a bare number, emoji-only, etc.) is now detected deterministically and skips titling entirely — no title model is invoked. Title generation then retries on each subsequent user message while the session stays unnamed, so the title is deduced from the first message that actually describes work. A capable online title model may additionally answer `none` to decline a non-greeting taskless message (normalized to "no title").
+- Added a **Set for all roles** action at the top of the `/model` selector's action menu. Picking it applies the chosen model — and the thinking level selected in the next step — to every model role at once (default, fast, thinking, vision, architect, designer, commit, subtask, and any custom roles) instead of repeating the model selection once per role. The `default` role updates the live session model and persists like the single-role path; the remaining roles are written to settings; the session thinking level is applied once. The rest of the action menu is unchanged.
 
 ### Changed
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -150,6 +150,28 @@ export function getKnownRoleIds(settings: Settings): string[] {
 }
 
 /**
+ * Sentinel role id used by the model selector "Set for all roles" action.
+ *
+ * Namespaced so it can never collide with a real built-in or user-configured
+ * role id (even a custom role literally named "all"). It is never written to
+ * settings; it only marks the in-memory selector action and the per-selection
+ * callback so the controller can fan a single model choice out across every
+ * known role.
+ */
+export const ALL_ROLES_SELECTION = "__omp_all_roles__";
+
+/**
+ * Roles that the model-selector "Set for all roles" action applies a model to.
+ *
+ * Mirrors {@link getKnownRoleIds} ordering (built-ins first, then configured
+ * custom roles) while defensively excluding the synthetic sentinel so it can
+ * never be persisted as a real role.
+ */
+export function getAllRolesForSelection(settings: Settings): string[] {
+	return getKnownRoleIds(settings).filter(role => role !== ALL_ROLES_SELECTION);
+}
+
+/**
  * Get role info for a role name (built-in or custom).
  * Configured metadata overrides built-in defaults when present.
  */

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -16,8 +16,20 @@ import { fuzzyMatch } from "@oh-my-pi/pi-tui";
 import { logger } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
 import MODEL_PRIO from "../priority.json" with { type: "json" };
-import { parseThinkingLevel, resolveThinkingLevelForModel } from "../thinking";
-import { isAuthenticated, kNoAuth, MODEL_ROLE_IDS, type ModelRegistry, type ModelRole } from "./model-registry";
+import {
+	AUTO_THINKING,
+	type ConfiguredThinkingLevel,
+	parseThinkingLevel,
+	resolveThinkingLevelForModel,
+} from "../thinking";
+import {
+	getAllRolesForSelection,
+	isAuthenticated,
+	kNoAuth,
+	MODEL_ROLE_IDS,
+	type ModelRegistry,
+	type ModelRole,
+} from "./model-registry";
 import type { Settings } from "./settings";
 
 /** Default model IDs for each known provider */
@@ -61,6 +73,56 @@ export function formatModelString(model: Model<Api>): string {
 
 export function formatModelSelectorValue(selector: string, thinkingLevel: ThinkingLevel | undefined): string {
 	return thinkingLevel && thinkingLevel !== ThinkingLevel.Inherit ? `${selector}:${thinkingLevel}` : selector;
+}
+
+/**
+ * Minimal session surface needed to apply a model to every role. Declared
+ * structurally so {@link applyModelToAllRoles} stays decoupled from the full
+ * `AgentSession` and is unit-testable with a lightweight fake.
+ */
+export interface AllRolesModelTarget {
+	setModel(
+		model: Model,
+		role: string,
+		options: { selector?: string; thinkingLevel?: ThinkingLevel; persist?: boolean },
+	): Promise<void>;
+	setThinkingLevel(level: ConfiguredThinkingLevel | undefined, persist?: boolean): void;
+}
+
+/**
+ * Apply a single model+thinking choice to every known role at once — the
+ * behavior behind the model selector "Set for all roles" action.
+ *
+ * The `default` role updates the live session model and persists, mirroring the
+ * single-role path; the remaining roles are written straight to settings. The
+ * session thinking level is then applied once (auto persists; a concrete,
+ * non-inherit level is applied transiently) so the active session reflects the
+ * `default` choice exactly as picking `default` alone would.
+ */
+export async function applyModelToAllRoles(
+	target: AllRolesModelTarget,
+	settings: Settings,
+	model: Model,
+	thinkingLevel: ConfiguredThinkingLevel | undefined,
+	selector: string | undefined,
+): Promise<void> {
+	const isAuto = thinkingLevel === AUTO_THINKING;
+	const concreteThinking = isAuto ? undefined : thinkingLevel;
+	const fallbackSelector = selector ?? `${model.provider}/${model.id}`;
+
+	for (const role of getAllRolesForSelection(settings)) {
+		if (role === "default") {
+			await target.setModel(model, "default", { selector, thinkingLevel: concreteThinking, persist: true });
+		} else {
+			settings.setModelRole(role, formatModelSelectorValue(fallbackSelector, concreteThinking));
+		}
+	}
+
+	if (isAuto) {
+		target.setThinkingLevel(AUTO_THINKING, true);
+	} else if (concreteThinking && concreteThinking !== ThinkingLevel.Inherit) {
+		target.setThinkingLevel(concreteThinking);
+	}
 }
 
 function getOpenRouterRouteSuffix(modelId: string): { baseId: string; suffix: string } | undefined {

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -14,7 +14,14 @@ import {
 	visibleWidth,
 } from "@oh-my-pi/pi-tui";
 import type { ModelRegistry } from "../../config/model-registry";
-import { getKnownRoleIds, getRoleInfo, MODEL_ROLE_IDS, MODEL_ROLES } from "../../config/model-registry";
+import {
+	ALL_ROLES_SELECTION,
+	getAllRolesForSelection,
+	getKnownRoleIds,
+	getRoleInfo,
+	MODEL_ROLE_IDS,
+	MODEL_ROLES,
+} from "../../config/model-registry";
 import { resolveModelRoleValue } from "../../config/model-resolver";
 import type { Settings } from "../../config/settings";
 import { type ThemeColor, theme } from "../../modes/theme/theme";
@@ -255,7 +262,7 @@ export class ModelSelectorComponent extends Container {
 	}
 
 	#buildMenuRoleActions(): void {
-		this.#menuRoleActions = getKnownRoleIds(this.#settings).map(role => {
+		const roleActions = getAllRolesForSelection(this.#settings).map(role => {
 			const roleInfo = getRoleInfo(role, this.#settings);
 			const roleLabel = roleInfo.tag ? `${roleInfo.tag} (${roleInfo.name})` : roleInfo.name;
 			return {
@@ -263,6 +270,9 @@ export class ModelSelectorComponent extends Container {
 				role,
 			};
 		});
+		// "Set for all roles" sits at the top so a single choice can fan out to
+		// every role; the concrete roles follow in their normal order.
+		this.#menuRoleActions = [{ label: "Set for all roles", role: ALL_ROLES_SELECTION }, ...roleActions];
 	}
 
 	#loadRoleModels(): void {
@@ -925,7 +935,11 @@ export class ModelSelectorComponent extends Container {
 					return `${prefix}${action.label}`;
 				});
 
-		const selectedRoleName = this.#menuSelectedRole ? getRoleInfo(this.#menuSelectedRole, this.#settings).name : "";
+		const selectedRoleName = this.#menuSelectedRole
+			? this.#menuSelectedRole === ALL_ROLES_SELECTION
+				? "All roles"
+				: getRoleInfo(this.#menuSelectedRole, this.#settings).name
+			: "";
 		const headerText =
 			showingThinking && this.#menuSelectedRole
 				? `  Thinking for: ${selectedRoleName} (${selectedItem.id})`
@@ -1082,6 +1096,18 @@ export class ModelSelectorComponent extends Container {
 		// For temporary role, don't save to settings - just notify caller
 		if (role === null) {
 			this.#onSelectCallback(item.model, null, undefined, item.selector);
+			return;
+		}
+
+		// "Set for all roles": badge every role locally and notify the caller once
+		// with the sentinel so the controller can fan the choice out across roles.
+		if (role === ALL_ROLES_SELECTION) {
+			const allThinkingLevel = thinkingLevel ?? ThinkingLevel.Inherit;
+			for (const targetRole of getAllRolesForSelection(this.#settings)) {
+				this.#roles[targetRole] = { model: item.model, thinkingLevel: allThinkingLevel };
+			}
+			this.#onSelectCallback(item.model, ALL_ROLES_SELECTION, allThinkingLevel, item.selector);
+			this.#updateList();
 			return;
 		}
 

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -4,8 +4,8 @@ import type { OAuthProvider } from "@oh-my-pi/pi-ai/utils/oauth/types";
 import type { Component, OverlayHandle } from "@oh-my-pi/pi-tui";
 import { Input, Loader, Spacer, Text } from "@oh-my-pi/pi-tui";
 import { getAgentDbPath, getProjectDir, normalizePathForComparison } from "@oh-my-pi/pi-utils";
-import { getRoleInfo } from "../../config/model-registry";
-import { formatModelSelectorValue } from "../../config/model-resolver";
+import { ALL_ROLES_SELECTION, getRoleInfo } from "../../config/model-registry";
+import { applyModelToAllRoles, formatModelSelectorValue } from "../../config/model-resolver";
 import { settings } from "../../config/settings";
 import { DebugSelectorComponent } from "../../debug";
 import { disableProvider, enableProvider } from "../../discovery";
@@ -426,6 +426,13 @@ export class SelectorController {
 							this.ctx.showStatus(`Temporary model: ${selector ?? model.id}`);
 							done();
 							this.ctx.ui.requestRender();
+						} else if (role === ALL_ROLES_SELECTION) {
+							// Set for all roles: fan the single choice out to every known role.
+							await applyModelToAllRoles(this.ctx.session, this.ctx.settings, model, thinkingLevel, selector);
+							this.ctx.statusLine.invalidate();
+							this.ctx.updateEditorBorderColor();
+							this.ctx.showStatus(`All roles set to: ${selector ?? model.id}`);
+							// Don't call done() - selector stays open for further assignment
 						} else if (role === "default") {
 							// Default: update agent state and persist
 							await this.ctx.session.setModel(model, role, {

--- a/packages/coding-agent/test/model-selector-all-roles.test.ts
+++ b/packages/coding-agent/test/model-selector-all-roles.test.ts
@@ -1,0 +1,224 @@
+import { beforeAll, describe, expect, test, vi } from "bun:test";
+import { stripVTControlCharacters } from "node:util";
+import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import { getBundledModel, type Model } from "@oh-my-pi/pi-ai";
+import {
+	ALL_ROLES_SELECTION,
+	getAllRolesForSelection,
+	type ModelRegistry,
+} from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { type AllRolesModelTarget, applyModelToAllRoles } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { ModelSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/model-selector";
+import { getThemeByName, setThemeInstance } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { AUTO_THINKING, type ConfiguredThinkingLevel } from "@oh-my-pi/pi-coding-agent/thinking";
+import type { TUI } from "@oh-my-pi/pi-tui";
+
+function normalizeRenderedText(text: string): string {
+	return stripVTControlCharacters(text).replace(/\s+/g, " ").trim();
+}
+
+function getBundledSonnet(): Model {
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected bundled model anthropic/claude-sonnet-4-5");
+	return model;
+}
+
+interface RecordedTarget {
+	target: AllRolesModelTarget;
+	setModelCalls: Array<{
+		role: string;
+		options: { selector?: string; thinkingLevel?: ThinkingLevel; persist?: boolean };
+	}>;
+	thinkingCalls: Array<{ level: ConfiguredThinkingLevel | undefined; persist?: boolean }>;
+}
+
+function createRecordedTarget(): RecordedTarget {
+	const setModelCalls: RecordedTarget["setModelCalls"] = [];
+	const thinkingCalls: RecordedTarget["thinkingCalls"] = [];
+	const target: AllRolesModelTarget = {
+		async setModel(_model, role, options) {
+			setModelCalls.push({ role, options });
+		},
+		setThinkingLevel(level, persist) {
+			thinkingCalls.push({ level, persist });
+		},
+	};
+	return { target, setModelCalls, thinkingCalls };
+}
+
+let testTheme = await getThemeByName("dark");
+
+function installTestTheme(): void {
+	if (!testTheme) {
+		throw new Error("Failed to load dark theme for ModelSelector tests");
+	}
+	setThemeInstance(testTheme);
+}
+
+function createSelector(
+	model: Model,
+	settings: Settings,
+	onSelect: (
+		selectedModel: Model,
+		role: string | null,
+		thinkingLevel?: ConfiguredThinkingLevel,
+		selector?: string,
+	) => void,
+): ModelSelectorComponent {
+	const modelRegistry = {
+		getAll: () => [model],
+		getDiscoverableProviders: () => [],
+		getCanonicalModels: () => [],
+		resolveCanonicalModel: () => undefined,
+	} as unknown as ModelRegistry;
+	const ui = { requestRender: vi.fn() } as unknown as TUI;
+
+	return new ModelSelectorComponent(
+		ui,
+		model,
+		settings,
+		modelRegistry,
+		[{ model, thinkingLevel: "off" }],
+		onSelect,
+		() => {},
+	);
+}
+
+describe("getAllRolesForSelection", () => {
+	test("returns the known built-in roles in order without the sentinel", () => {
+		const settings = Settings.isolated();
+		expect(getAllRolesForSelection(settings)).toEqual([
+			"default",
+			"smol",
+			"slow",
+			"vision",
+			"plan",
+			"designer",
+			"commit",
+			"task",
+		]);
+	});
+
+	test("includes custom roles and excludes the sentinel even if configured", () => {
+		const settings = Settings.isolated({
+			cycleOrder: [ALL_ROLES_SELECTION, "custom-fast"],
+		});
+		const roles = getAllRolesForSelection(settings);
+		expect(roles).toContain("custom-fast");
+		expect(roles).not.toContain(ALL_ROLES_SELECTION);
+	});
+});
+
+describe("applyModelToAllRoles", () => {
+	test("applies a concrete thinking level to default (persisted) and every other role", async () => {
+		const model = getBundledSonnet();
+		const settings = Settings.isolated();
+		const { target, setModelCalls, thinkingCalls } = createRecordedTarget();
+		const selector = `${model.provider}/${model.id}`;
+
+		await applyModelToAllRoles(target, settings, model, ThinkingLevel.High, selector);
+
+		expect(setModelCalls).toEqual([
+			{ role: "default", options: { selector, thinkingLevel: ThinkingLevel.High, persist: true } },
+		]);
+		for (const role of ["smol", "slow", "vision", "plan", "designer", "commit", "task"]) {
+			expect(settings.getModelRole(role)).toBe(`${selector}:${ThinkingLevel.High}`);
+		}
+		// default is owned by setModel(persist) — the helper must not double-write it.
+		expect(settings.getModelRole("default")).toBeUndefined();
+		expect(thinkingCalls).toEqual([{ level: ThinkingLevel.High, persist: undefined }]);
+	});
+
+	test("persists auto session-wide and writes role values without a thinking suffix", async () => {
+		const model = getBundledSonnet();
+		const settings = Settings.isolated();
+		const { target, setModelCalls, thinkingCalls } = createRecordedTarget();
+		const selector = `${model.provider}/${model.id}`;
+
+		await applyModelToAllRoles(target, settings, model, AUTO_THINKING, selector);
+
+		expect(setModelCalls[0]?.options.thinkingLevel).toBeUndefined();
+		expect(settings.getModelRole("smol")).toBe(selector);
+		expect(thinkingCalls).toEqual([{ level: AUTO_THINKING, persist: true }]);
+	});
+
+	test("does not touch the session thinking level when inherit is chosen", async () => {
+		const model = getBundledSonnet();
+		const settings = Settings.isolated();
+		const { target, thinkingCalls } = createRecordedTarget();
+		const selector = `${model.provider}/${model.id}`;
+
+		await applyModelToAllRoles(target, settings, model, ThinkingLevel.Inherit, selector);
+
+		expect(settings.getModelRole("task")).toBe(selector);
+		expect(thinkingCalls).toEqual([]);
+	});
+
+	test("falls back to provider/id when no selector is given", async () => {
+		const model = getBundledSonnet();
+		const settings = Settings.isolated();
+		const { target } = createRecordedTarget();
+
+		await applyModelToAllRoles(target, settings, model, ThinkingLevel.Inherit, undefined);
+
+		expect(settings.getModelRole("smol")).toBe(`${model.provider}/${model.id}`);
+	});
+});
+
+describe("ModelSelector 'Set for all roles' action", () => {
+	beforeAll(async () => {
+		testTheme = await getThemeByName("dark");
+		if (!testTheme) {
+			throw new Error("Failed to load dark theme for ModelSelector tests");
+		}
+	});
+
+	test("offers 'Set for all roles' at the very top of the action menu", async () => {
+		installTestTheme();
+		const model = getBundledSonnet();
+		const settings = Settings.isolated();
+		const selector = createSelector(model, settings, () => {});
+		await Bun.sleep(0);
+		installTestTheme();
+
+		selector.handleInput("\n");
+		installTestTheme();
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+
+		expect(rendered).toContain("Set for all roles");
+		// It must sit above the concrete per-role actions.
+		expect(rendered.indexOf("Set for all roles")).toBeLessThan(rendered.indexOf("Set as"));
+	});
+
+	test("fans a single model+thinking choice out to every role via the callback", async () => {
+		installTestTheme();
+		const model = getBundledSonnet();
+		const settings = Settings.isolated();
+		const onSelect = vi.fn();
+		const selector = createSelector(model, settings, onSelect);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		// Enter: open action menu (cursor starts on "Set for all roles").
+		selector.handleInput("\n");
+		installTestTheme();
+		const actionView = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(actionView).toContain("Action for:");
+
+		// Enter: choose "Set for all roles" -> thinking step.
+		selector.handleInput("\n");
+		installTestTheme();
+		const thinkingView = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(thinkingView).toContain("Thinking for: All roles");
+
+		// Enter: confirm the preselected (inherit) thinking level.
+		selector.handleInput("\n");
+
+		expect(onSelect).toHaveBeenCalledTimes(1);
+		const [selectedModel, role, thinkingLevel] = onSelect.mock.calls[0] ?? [];
+		expect((selectedModel as Model).id).toBe(model.id);
+		expect(role).toBe(ALL_ROLES_SELECTION);
+		expect(thinkingLevel).toBe(ThinkingLevel.Inherit);
+	});
+});


### PR DESCRIPTION
## What

Adds a **Set for all roles** action at the very top of the `/model` selector's action menu. After you run `/model`, pick a model, and press Enter, the action page now lists:

```
  Set for all roles      <- new, at the top
  Set as DEFAULT (Default)
  Set as SMOL (Fast)
  Set as SLOW (Thinking)
  ... (vision, plan, designer, commit, task, + any custom roles)
```

Choosing it continues through the normal thinking-level step and then applies that one model + thinking choice to **every** known role at once, instead of reopening `/model` and repeating the pick per role. The rest of the menu and flow are unchanged.

## Why

Pointing one model at several roles (default / fast / thinking / architect / …) currently means repeating the whole `/model` selection once per role. This adds a single top-of-menu option to do it in one pass, while leaving the existing per-role behavior exactly as-is. Temporary selection (`/switch`, Ctrl+P) is intentionally untouched — the option only appears in the persistent `/model` menu.

## Testing

- New `packages/coding-agent/test/model-selector-all-roles.test.ts` (8 tests): role expansion + sentinel exclusion, thinking handling (concrete / `auto` / `inherit` / no-selector), menu placement at the top, and the selector callback contract.
- `bunx tsgo -p tsconfig.json --noEmit` (coding-agent) — clean.
- `biome check` on all changed files — clean.
- Existing model / role / resolver / selector suites (`model-registry`, `model-resolver`, `role-info`, `role-thinking-helper-propagation`, `model-selector-role-badge-thinking`, `agent-session-role-thinking`, `agent-session-model-persistence`, `commit-model-selection-role-thinking`, `sdk-model-selection`, …) — green.
- `bun run --cwd=packages/coding-agent build` — succeeds; `/model` shows the option and applies across roles.

### Implementation notes

- `config/model-registry`: `ALL_ROLES_SELECTION` sentinel (namespaced so it can't collide with a real or custom role id) + `getAllRolesForSelection()`.
- `config/model-resolver`: `applyModelToAllRoles()` — `default` updates the live session model and persists (mirrors the single-role path); the remaining roles are written to settings; the session thinking level is applied once (`auto` persists, a concrete non-inherit level is applied transiently). Declared against a small structural `AllRolesModelTarget` interface so it's unit-testable.
- `modes/components/model-selector`: prepend the action, label its thinking step "All roles", badge every role locally, and notify the caller once via the sentinel.
- `modes/controllers/selector-controller`: handle the sentinel by fanning out through the helper, with a single `All roles set to: <model>` status.

---

- [x] `bun check` passes (typecheck + biome clean for the change; verified per-file and via `tsgo`)
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
