### PR TITLE
fix(plugins): load extension package imports

### DIFF
--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -45,6 +45,10 @@ const LEGACY_PI_IMPORT_SPECIFIER_REGEX = new RegExp(
 	"g",
 );
 const resolvedSpecifierFallbacks = new Map<string, string>();
+const SOURCE_MODULE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"] as const;
+const PACKAGE_IMPORT_CONDITIONS = ["bun", "import", "default", "types"] as const;
+const packageRootCache = new Map<string, string | null>();
+const packageImportsCache = new Map<string, Record<string, unknown> | null>();
 
 // Extensions that imported `@sinclair/typebox` directly used to resolve against a
 // real `@sinclair/typebox` install. The runtime dep was replaced with the Zod-backed
@@ -224,30 +228,226 @@ function rewriteLegacyPiImports(source: string): string {
 const TYPEBOX_IMPORT_SPECIFIER_REGEX = /((?:from\s+|import\s*\(\s*)["'])(@sinclair\/typebox)(["'])/g;
 
 /**
- * Rewrite the legacy specifiers a Pi extension may import — `@(scope)/pi-*` and
- * the bare `@sinclair/typebox` root — to absolute `file://` URLs pointing at the
- * bundled package or compat shim. Every other specifier (relative siblings, the
- * extension's own bare dependencies) is left untouched so Bun resolves it
+ * Rewrite the extension-owned specifiers OMP must host-resolve — legacy
+ * `@(scope)/pi-*`, bare `@sinclair/typebox`, and package `imports` aliases like
+ * `#src/*` — to absolute `file://` URLs. Every other specifier (relative
+ * siblings and third-party dependencies) is left untouched so Bun resolves it
  * natively from the extension's real on-disk location.
  */
-function rewriteLegacyExtensionSource(source: string): string {
+async function rewriteLegacyExtensionSource(source: string, importerPath: string): Promise<string> {
 	const withPi = rewriteLegacyPiImports(source);
-	return withPi.replace(
+	const withTypeBox = withPi.replace(
 		TYPEBOX_IMPORT_SPECIFIER_REGEX,
 		(_match, prefix: string, _specifier: string, suffix: string) => {
 			return `${prefix}${toImportSpecifier(TYPEBOX_SHIM_PATH)}${suffix}`;
 		},
 	);
+	return rewriteExtensionPackageImports(withTypeBox, importerPath);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function pathExists(p: string): Promise<boolean> {
+	try {
+		await fs.stat(p);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function resolveSourceModuleFile(basePath: string): Promise<string | null> {
+	try {
+		const stats = await fs.stat(basePath);
+		if (stats.isFile()) {
+			return realpathOrSelf(basePath);
+		}
+		if (stats.isDirectory()) {
+			for (const extension of SOURCE_MODULE_EXTENSIONS) {
+				const resolved = await resolveSourceModuleFile(path.join(basePath, `index${extension}`));
+				if (resolved) return resolved;
+			}
+		}
+	} catch {
+		// Fall through to extension candidates below.
+	}
+
+	if (path.extname(basePath)) {
+		return null;
+	}
+
+	for (const extension of SOURCE_MODULE_EXTENSIONS) {
+		const resolved = await resolveSourceModuleFile(`${basePath}${extension}`);
+		if (resolved) return resolved;
+	}
+	return null;
+}
+
+async function findPackageRoot(importerPath: string): Promise<string | null> {
+	let dir = path.dirname(importerPath);
+	while (true) {
+		const cached = packageRootCache.get(dir);
+		if (cached !== undefined) {
+			return cached;
+		}
+
+		if (await pathExists(path.join(dir, "package.json"))) {
+			packageRootCache.set(path.dirname(importerPath), dir);
+			return dir;
+		}
+
+		const parent = path.dirname(dir);
+		if (parent === dir) {
+			packageRootCache.set(path.dirname(importerPath), null);
+			return null;
+		}
+		dir = parent;
+	}
+}
+
+async function readPackageImports(packageRoot: string): Promise<Record<string, unknown> | null> {
+	const cached = packageImportsCache.get(packageRoot);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	let imports: Record<string, unknown> | null = null;
+	try {
+		const pkg = await Bun.file(path.join(packageRoot, "package.json")).json();
+		if (isRecord(pkg) && isRecord(pkg.imports)) {
+			imports = pkg.imports;
+		}
+	} catch {
+		imports = null;
+	}
+	packageImportsCache.set(packageRoot, imports);
+	return imports;
+}
+
+function selectPackageImportTarget(entry: unknown): string | null {
+	if (typeof entry === "string") {
+		return entry;
+	}
+	if (Array.isArray(entry)) {
+		for (const item of entry) {
+			const target = selectPackageImportTarget(item);
+			if (target) return target;
+		}
+		return null;
+	}
+	if (!isRecord(entry)) {
+		return null;
+	}
+	for (const condition of PACKAGE_IMPORT_CONDITIONS) {
+		const target = selectPackageImportTarget(entry[condition]);
+		if (target) return target;
+	}
+	for (const value of Object.values(entry)) {
+		const target = selectPackageImportTarget(value);
+		if (target) return target;
+	}
+	return null;
+}
+
+async function resolvePackageImportTarget(
+	packageRoot: string,
+	target: string,
+	wildcard: string | null,
+): Promise<string | null> {
+	if (!target.startsWith("./")) {
+		return null;
+	}
+	const substituted = wildcard === null ? target : target.replaceAll("*", wildcard);
+	return resolveSourceModuleFile(path.resolve(packageRoot, substituted));
+}
+
+async function resolvePackageImportSpecifier(specifier: string, importerPath: string): Promise<string | null> {
+	if (!specifier.startsWith("#")) {
+		return null;
+	}
+
+	const packageRoot = await findPackageRoot(importerPath);
+	if (!packageRoot) {
+		return null;
+	}
+
+	const imports = await readPackageImports(packageRoot);
+	if (!imports) {
+		return null;
+	}
+
+	const exactTarget = selectPackageImportTarget(imports[specifier]);
+	if (exactTarget) {
+		return resolvePackageImportTarget(packageRoot, exactTarget, null);
+	}
+
+	let bestMatch: { keyLength: number; target: string; wildcard: string } | null = null;
+	for (const [key, entry] of Object.entries(imports)) {
+		const starIndex = key.indexOf("*");
+		if (starIndex === -1) continue;
+
+		const prefix = key.slice(0, starIndex);
+		const suffix = key.slice(starIndex + 1);
+		if (!specifier.startsWith(prefix) || !specifier.endsWith(suffix)) {
+			continue;
+		}
+
+		const target = selectPackageImportTarget(entry);
+		if (!target) {
+			continue;
+		}
+
+		if (!bestMatch || key.length > bestMatch.keyLength) {
+			bestMatch = {
+				keyLength: key.length,
+				target,
+				wildcard: specifier.slice(prefix.length, specifier.length - suffix.length),
+			};
+		}
+	}
+
+	if (!bestMatch) {
+		return null;
+	}
+	return resolvePackageImportTarget(packageRoot, bestMatch.target, bestMatch.wildcard);
+}
+
+const PACKAGE_IMPORT_SPECIFIER_REGEX = /((?:from\s+|import\s*\(\s*)["'])(#[^"'()\s]+)(["'])/g;
+
+async function rewriteExtensionPackageImports(source: string, importerPath: string): Promise<string> {
+	let rewritten = "";
+	let lastIndex = 0;
+	for (const match of source.matchAll(PACKAGE_IMPORT_SPECIFIER_REGEX)) {
+		const matchIndex = match.index;
+		if (matchIndex === undefined) continue;
+
+		const [fullMatch, prefix, specifier, suffix] = match;
+		if (!prefix || !specifier || !suffix) continue;
+
+		const resolved = await resolvePackageImportSpecifier(specifier, importerPath);
+		if (!resolved) continue;
+
+		rewritten += source.slice(lastIndex, matchIndex);
+		rewritten += `${prefix}${toImportSpecifier(resolved)}${suffix}`;
+		lastIndex = matchIndex + fullMatch.length;
+	}
+
+	if (lastIndex === 0) {
+		return source;
+	}
+	return `${rewritten}${source.slice(lastIndex)}`;
 }
 
 function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-// Match relative import specifiers (static `from "./…"` and dynamic
-// `import("./…")`). Used to walk an extension's own module graph; bare and
-// absolute specifiers are deliberately excluded.
-const RELATIVE_IMPORT_SPECIFIER_REGEX = /(?:from\s+|import\s*\(\s*)["'](\.\.?\/[^"']+)["']/g;
+// Match source modules in an extension graph (relative imports and package
+// `imports` aliases such as `#src/*`). Bare third-party dependencies remain
+// native Bun resolutions.
+const EXTENSION_GRAPH_SPECIFIER_REGEX = /(?:from\s+|import\s*\(\s*)["']((?:\.\.?\/|#)[^"']+)["']/g;
 
 // Extension entry realpaths that already have a load-time rewrite hook
 // installed. Each `Bun.plugin()` registration is process-global and permanent,
@@ -287,10 +487,14 @@ async function collectExtensionModules(entryRealPath: string): Promise<Set<strin
 		}
 		modules.add(file);
 		const dir = path.dirname(file);
-		for (const match of source.matchAll(RELATIVE_IMPORT_SPECIFIER_REGEX)) {
+		for (const match of source.matchAll(EXTENSION_GRAPH_SPECIFIER_REGEX)) {
+			const specifier = match[1];
+			if (!specifier) continue;
 			try {
-				const resolved = await realpathOrSelf(Bun.resolveSync(match[1], dir));
-				if (!modules.has(resolved)) {
+				const resolved = specifier.startsWith("#")
+					? await resolvePackageImportSpecifier(specifier, file)
+					: await realpathOrSelf(Bun.resolveSync(specifier, dir));
+				if (resolved && !modules.has(resolved)) {
 					queue.push(resolved);
 				}
 			} catch {
@@ -303,11 +507,12 @@ async function collectExtensionModules(entryRealPath: string): Promise<Set<strin
 
 /**
  * Install a `Bun.plugin()` `onLoad` hook scoped to exactly the modules in an
- * extension's relative-import graph, so their legacy `@(scope)/pi-*` and bare
- * `@sinclair/typebox` imports are rewritten at load time. A runtime `onLoad`
- * cannot fall through (Bun requires a result object), so the filter is an
- * exact-path alternation of the graph's realpaths — it never matches the host,
- * other extensions, `node_modules` deps, or unrelated project source.
+ * extension's source graph, so their legacy `@(scope)/pi-*`, bare
+ * `@sinclair/typebox`, and local package-import aliases are rewritten at load
+ * time. A runtime `onLoad` cannot fall through (Bun requires a result object),
+ * so the filter is an exact-path alternation of the graph's realpaths — it
+ * never matches the host, other extensions, `node_modules` deps, or unrelated
+ * project source.
  */
 async function ensureExtensionGraphHook(entryRealPath: string): Promise<void> {
 	if (hookedExtensionEntries.has(entryRealPath)) {
@@ -322,9 +527,8 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<void> {
 		name: `omp:legacy-pi-ext:${Bun.hash(entryRealPath).toString(36)}`,
 		setup(build) {
 			build.onLoad({ filter, namespace: "file" }, async args => {
-				// Re-read on every load so a `?mtime` reload picks up edited source.
 				const raw = await Bun.file(args.path).text();
-				return { contents: rewriteLegacyExtensionSource(raw), loader: getLoader(args.path) };
+				return { contents: await rewriteLegacyExtensionSource(raw, args.path), loader: getLoader(args.path) };
 			});
 		},
 	});
@@ -337,9 +541,8 @@ async function ensureExtensionGraphHook(entryRealPath: string): Promise<void> {
  * and `__dirname`-relative `readFileSync` asset loads (HTML/CSS bundled next to
  * the entry) resolve exactly as they do under the original Pi runtime — no
  * temp-directory mirroring and no asset copying. An `onLoad` hook scoped to the
- * entry's relative-import graph rewrites only the legacy `@(scope)/pi-*` and
- * `@sinclair/typebox` imports in the extension's own source; everything else
- * resolves natively.
+ * entry's source graph rewrites only host-resolved compatibility imports in the
+ * extension's own source; everything else resolves natively.
  */
 export async function loadLegacyPiModule(resolvedPath: string): Promise<unknown> {
 	// Bun reports the realpath of a loaded module to `onLoad` and exposes it as

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -258,11 +258,19 @@ async function pathExists(p: string): Promise<boolean> {
 	}
 }
 
+function hasSourceModuleExtension(p: string): boolean {
+	const ext = path.extname(p).toLowerCase();
+	return (SOURCE_MODULE_EXTENSIONS as readonly string[]).includes(ext);
+}
+
 async function resolveSourceModuleFile(basePath: string): Promise<string | null> {
 	try {
 		const stats = await fs.stat(basePath);
 		if (stats.isFile()) {
-			return realpathOrSelf(basePath);
+			// Non-source files (JSON, WASM, text assets, etc.) bypass the on-load
+			// rewrite hook so Bun's native loaders handle them; our hook would
+			// otherwise pass them through `getLoader()` which falls back to `js`.
+			return hasSourceModuleExtension(basePath) ? realpathOrSelf(basePath) : null;
 		}
 		if (stats.isDirectory()) {
 			for (const extension of SOURCE_MODULE_EXTENSIONS) {

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -46,7 +46,7 @@ const LEGACY_PI_IMPORT_SPECIFIER_REGEX = new RegExp(
 );
 const resolvedSpecifierFallbacks = new Map<string, string>();
 const SOURCE_MODULE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"] as const;
-const PACKAGE_IMPORT_CONDITIONS = ["bun", "import", "default", "types"] as const;
+const SUPPORTED_PACKAGE_IMPORT_CONDITIONS = new Set(["bun", "node", "import", "default"]);
 const packageRootCache = new Map<string, string | null>();
 const packageImportsCache = new Map<string, Record<string, unknown> | null>();
 
@@ -340,11 +340,10 @@ function selectPackageImportTarget(entry: unknown): string | null {
 	if (!isRecord(entry)) {
 		return null;
 	}
-	for (const condition of PACKAGE_IMPORT_CONDITIONS) {
-		const target = selectPackageImportTarget(entry[condition]);
-		if (target) return target;
-	}
-	for (const value of Object.values(entry)) {
+	for (const [condition, value] of Object.entries(entry)) {
+		if (!SUPPORTED_PACKAGE_IMPORT_CONDITIONS.has(condition)) {
+			continue;
+		}
 		const target = selectPackageImportTarget(value);
 		if (target) return target;
 	}

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -49,6 +49,7 @@ const SOURCE_MODULE_EXTENSIONS = [".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", 
 const SUPPORTED_PACKAGE_IMPORT_CONDITIONS = new Set(["bun", "node", "import", "default"]);
 const packageRootCache = new Map<string, string | null>();
 const packageImportsCache = new Map<string, Record<string, unknown> | null>();
+const PACKAGE_IMPORT_EXCLUDED = Symbol("packageImportExcluded");
 
 // Extensions that imported `@sinclair/typebox` directly used to resolve against a
 // real `@sinclair/typebox` install. The runtime dep was replaced with the Zod-backed
@@ -334,14 +335,20 @@ async function readPackageImports(packageRoot: string): Promise<Record<string, u
 	return imports;
 }
 
-function selectPackageImportTarget(entry: unknown): string | null {
+type PackageImportTargetSelection = string | typeof PACKAGE_IMPORT_EXCLUDED | null;
+type ResolvedPackageImportTargetSelection = string | typeof PACKAGE_IMPORT_EXCLUDED;
+
+function selectPackageImportTarget(entry: unknown): PackageImportTargetSelection {
+	if (entry === null) {
+		return PACKAGE_IMPORT_EXCLUDED;
+	}
 	if (typeof entry === "string") {
 		return entry;
 	}
 	if (Array.isArray(entry)) {
 		for (const item of entry) {
 			const target = selectPackageImportTarget(item);
-			if (target) return target;
+			if (target !== null) return target;
 		}
 		return null;
 	}
@@ -353,7 +360,7 @@ function selectPackageImportTarget(entry: unknown): string | null {
 			continue;
 		}
 		const target = selectPackageImportTarget(value);
-		if (target) return target;
+		if (target !== null) return target;
 	}
 	return null;
 }
@@ -386,11 +393,14 @@ async function resolvePackageImportSpecifier(specifier: string, importerPath: st
 	}
 
 	const exactTarget = selectPackageImportTarget(imports[specifier]);
-	if (exactTarget) {
+	if (exactTarget === PACKAGE_IMPORT_EXCLUDED) {
+		return null;
+	}
+	if (exactTarget !== null) {
 		return resolvePackageImportTarget(packageRoot, exactTarget, null);
 	}
 
-	let bestMatch: { keyLength: number; target: string; wildcard: string } | null = null;
+	let bestMatch: { keyLength: number; target: ResolvedPackageImportTargetSelection; wildcard: string } | null = null;
 	for (const [key, entry] of Object.entries(imports)) {
 		const starIndex = key.indexOf("*");
 		if (starIndex === -1) continue;
@@ -402,7 +412,7 @@ async function resolvePackageImportSpecifier(specifier: string, importerPath: st
 		}
 
 		const target = selectPackageImportTarget(entry);
-		if (!target) {
+		if (target === null) {
 			continue;
 		}
 
@@ -415,7 +425,7 @@ async function resolvePackageImportSpecifier(specifier: string, importerPath: st
 		}
 	}
 
-	if (!bestMatch) {
+	if (!bestMatch || bestMatch.target === PACKAGE_IMPORT_EXCLUDED) {
 		return null;
 	}
 	return resolvePackageImportTarget(packageRoot, bestMatch.target, bestMatch.wildcard);

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -41,7 +41,7 @@ const PI_SUBPATH_REMAPS: ReadonlyMap<string, string> = new Map<string, string>([
 
 const LEGACY_PI_SPECIFIER_FILTER = new RegExp(`^@(?:${PI_SCOPE_ALTERNATION})/(?:${PI_PACKAGE_ALTERNATION})(?:/.*)?$`);
 const LEGACY_PI_IMPORT_SPECIFIER_REGEX = new RegExp(
-	`((?:from\\s+|import\\s*\\(\\s*)["'])(@(?:${PI_SCOPE_ALTERNATION})/(?:${PI_PACKAGE_ALTERNATION})(?:/[^"'()\\s]+)?)(["'])`,
+	`((?:from\\s+|import\\s+|import\\s*\\(\\s*)["'])(@(?:${PI_SCOPE_ALTERNATION})/(?:${PI_PACKAGE_ALTERNATION})(?:/[^"'()\\s]+)?)(["'])`,
 	"g",
 );
 const resolvedSpecifierFallbacks = new Map<string, string>();
@@ -225,7 +225,7 @@ function rewriteLegacyPiImports(source: string): string {
 // Match the bare `@sinclair/typebox` import specifier (static + dynamic).
 // Subpath imports like `@sinclair/typebox/compiler` are intentionally excluded —
 // they expose TypeBox-only APIs the Zod-backed shim does not provide.
-const TYPEBOX_IMPORT_SPECIFIER_REGEX = /((?:from\s+|import\s*\(\s*)["'])(@sinclair\/typebox)(["'])/g;
+const TYPEBOX_IMPORT_SPECIFIER_REGEX = /((?:from\s+|import\s+|import\s*\(\s*)["'])(@sinclair\/typebox)(["'])/g;
 
 /**
  * Rewrite the extension-owned specifiers OMP must host-resolve — legacy
@@ -414,7 +414,7 @@ async function resolvePackageImportSpecifier(specifier: string, importerPath: st
 	return resolvePackageImportTarget(packageRoot, bestMatch.target, bestMatch.wildcard);
 }
 
-const PACKAGE_IMPORT_SPECIFIER_REGEX = /((?:from\s+|import\s*\(\s*)["'])(#[^"'()\s]+)(["'])/g;
+const PACKAGE_IMPORT_SPECIFIER_REGEX = /((?:from\s+|import\s+|import\s*\(\s*)["'])(#[^"'()\s]+)(["'])/g;
 
 async function rewriteExtensionPackageImports(source: string, importerPath: string): Promise<string> {
 	let rewritten = "";
@@ -447,7 +447,7 @@ function escapeRegExp(value: string): string {
 // Match source modules in an extension graph (relative imports and package
 // `imports` aliases such as `#src/*`). Bare third-party dependencies remain
 // native Bun resolutions.
-const EXTENSION_GRAPH_SPECIFIER_REGEX = /(?:from\s+|import\s*\(\s*)["']((?:\.\.?\/|#)[^"']+)["']/g;
+const EXTENSION_GRAPH_SPECIFIER_REGEX = /(?:from\s+|import\s+|import\s*\(\s*)["']((?:\.\.?\/|#)[^"']+)["']/g;
 
 // Extension entry realpaths that already have a load-time rewrite hook
 // installed. Each `Bun.plugin()` registration is process-global and permanent,

--- a/packages/coding-agent/test/plugin-extensions-discovery.test.ts
+++ b/packages/coding-agent/test/plugin-extensions-discovery.test.ts
@@ -259,6 +259,55 @@ describe("plugin extension discovery", () => {
 		expect(extension?.commands.has("import-conditional-ext")).toBe(false);
 	});
 
+	it("leaves package import aliases that point at non-source files for Bun's native loaders", async () => {
+		const pluginsDir = getPluginsDir();
+		const pluginDir = path.join(pluginsDir, "node_modules", "json-import-plugin");
+		const extensionPath = path.join(pluginDir, "src", "index.ts");
+		fs.rmSync(path.join(pluginsDir, "node_modules"), { recursive: true, force: true });
+		fs.mkdirSync(path.join(pluginDir, "src"), { recursive: true });
+		fs.writeFileSync(
+			path.join(pluginsDir, "package.json"),
+			JSON.stringify({
+				name: "omp-plugins",
+				private: true,
+				dependencies: {
+					"json-import-plugin": "1.0.0",
+				},
+			}),
+		);
+		fs.writeFileSync(
+			path.join(pluginDir, "package.json"),
+			JSON.stringify({
+				name: "json-import-plugin",
+				version: "1.0.0",
+				imports: {
+					"#schema": "./src/schema.json",
+				},
+				pi: {
+					extensions: ["./src/index.ts"],
+				},
+			}),
+		);
+		fs.writeFileSync(path.join(pluginDir, "src", "schema.json"), JSON.stringify({ commandName: "json-schema-ext" }));
+		fs.writeFileSync(
+			extensionPath,
+			[
+				'import schema from "#schema" with { type: "json" };',
+				"",
+				"export default function(pi) {",
+				"\tpi.registerCommand(schema.commandName, { handler: async () => {} });",
+				"}",
+			].join("\n"),
+		);
+
+		const result = await discoverAndLoadExtensions([], projectDir.path());
+		const extension = result.extensions.find(ext => ext.path === extensionPath);
+
+		expect(result.errors).toHaveLength(0);
+		expect(extension).toBeDefined();
+		expect(extension?.commands.has("json-schema-ext")).toBe(true);
+	});
+
 	it("rewrites side-effect imports of package-import aliases and legacy Pi scopes", async () => {
 		const pluginsDir = getPluginsDir();
 		const pluginDir = path.join(pluginsDir, "node_modules", "side-effect-plugin");

--- a/packages/coding-agent/test/plugin-extensions-discovery.test.ts
+++ b/packages/coding-agent/test/plugin-extensions-discovery.test.ts
@@ -139,6 +139,64 @@ describe("plugin extension discovery", () => {
 		expect(extension?.tools.has("legacy-pi-ext")).toBe(true);
 	});
 
+	it("loads installed legacy Pi plugin extensions that use package imports", async () => {
+		const pluginsDir = getPluginsDir();
+		const pluginDir = path.join(pluginsDir, "node_modules", "package-import-plugin");
+		const extensionPath = path.join(pluginDir, "src", "index.ts");
+		fs.rmSync(path.join(pluginsDir, "node_modules"), { recursive: true, force: true });
+		fs.mkdirSync(path.join(pluginDir, "src", "feature"), { recursive: true });
+		fs.writeFileSync(
+			path.join(pluginsDir, "package.json"),
+			JSON.stringify({
+				name: "omp-plugins",
+				private: true,
+				dependencies: {
+					"package-import-plugin": "1.0.0",
+				},
+			}),
+		);
+		fs.writeFileSync(
+			path.join(pluginDir, "package.json"),
+			JSON.stringify({
+				name: "package-import-plugin",
+				version: "1.0.0",
+				imports: {
+					"#src/*": "./src/*",
+				},
+				pi: {
+					extensions: ["./src/index.ts"],
+				},
+			}),
+		);
+		fs.writeFileSync(
+			extensionPath,
+			[
+				'import { commandName } from "#src/feature/command";',
+				"",
+				"export default function(pi) {",
+				"\tpi.registerCommand(commandName, { handler: async () => {} });",
+				"}",
+			].join("\n"),
+		);
+		fs.writeFileSync(
+			path.join(pluginDir, "src", "feature", "command.ts"),
+			[
+				'import { isToolCallEventType as legacyExtensions } from "@earendil-works/pi-coding-agent/extensibility/extensions";',
+				`import { isToolCallEventType as modernExtensions } from ${JSON.stringify(currentPiExtensionsPath)};`,
+				"",
+				'if (legacyExtensions !== modernExtensions) throw new Error("legacy extension import did not remap");',
+				'export const commandName = "package-import-ext";',
+			].join("\n"),
+		);
+
+		const result = await discoverAndLoadExtensions([], projectDir.path());
+		const extension = result.extensions.find(ext => ext.path === extensionPath);
+
+		expect(result.errors).toHaveLength(0);
+		expect(extension).toBeDefined();
+		expect(extension?.commands.has("package-import-ext")).toBe(true);
+	});
+
 	it("loads installed plugin extensions whose manifest entry points at a directory with index.ts", async () => {
 		const pluginsDir = getPluginsDir();
 		const pluginDir = path.join(pluginsDir, "node_modules", "dir-entry-plugin");

--- a/packages/coding-agent/test/plugin-extensions-discovery.test.ts
+++ b/packages/coding-agent/test/plugin-extensions-discovery.test.ts
@@ -197,6 +197,68 @@ describe("plugin extension discovery", () => {
 		expect(extension?.commands.has("package-import-ext")).toBe(true);
 	});
 
+	it("honors package import conditional object order", async () => {
+		const pluginsDir = getPluginsDir();
+		const pluginDir = path.join(pluginsDir, "node_modules", "conditional-import-plugin");
+		const extensionPath = path.join(pluginDir, "src", "index.ts");
+		fs.rmSync(path.join(pluginsDir, "node_modules"), { recursive: true, force: true });
+		fs.mkdirSync(path.join(pluginDir, "node"), { recursive: true });
+		fs.mkdirSync(path.join(pluginDir, "import"), { recursive: true });
+		fs.writeFileSync(
+			path.join(pluginsDir, "package.json"),
+			JSON.stringify({
+				name: "omp-plugins",
+				private: true,
+				dependencies: {
+					"conditional-import-plugin": "1.0.0",
+				},
+			}),
+		);
+		fs.writeFileSync(
+			path.join(pluginDir, "package.json"),
+			JSON.stringify({
+				name: "conditional-import-plugin",
+				version: "1.0.0",
+				imports: {
+					"#src/*": {
+						node: "./node/*",
+						import: "./import/*",
+					},
+				},
+				pi: {
+					extensions: ["./src/index.ts"],
+				},
+			}),
+		);
+		fs.mkdirSync(path.dirname(extensionPath), { recursive: true });
+		fs.writeFileSync(
+			extensionPath,
+			[
+				'import { commandName } from "#src/command";',
+				"",
+				"export default function(pi) {",
+				"\tpi.registerCommand(commandName, { handler: async () => {} });",
+				"}",
+			].join("\n"),
+		);
+		fs.writeFileSync(
+			path.join(pluginDir, "node", "command.ts"),
+			'export const commandName = "node-conditional-ext";',
+		);
+		fs.writeFileSync(
+			path.join(pluginDir, "import", "command.ts"),
+			'export const commandName = "import-conditional-ext";',
+		);
+
+		const result = await discoverAndLoadExtensions([], projectDir.path());
+		const extension = result.extensions.find(ext => ext.path === extensionPath);
+
+		expect(result.errors).toHaveLength(0);
+		expect(extension).toBeDefined();
+		expect(extension?.commands.has("node-conditional-ext")).toBe(true);
+		expect(extension?.commands.has("import-conditional-ext")).toBe(false);
+	});
+
 	it("rewrites side-effect imports of package-import aliases and legacy Pi scopes", async () => {
 		const pluginsDir = getPluginsDir();
 		const pluginDir = path.join(pluginsDir, "node_modules", "side-effect-plugin");

--- a/packages/coding-agent/test/plugin-extensions-discovery.test.ts
+++ b/packages/coding-agent/test/plugin-extensions-discovery.test.ts
@@ -308,6 +308,108 @@ describe("plugin extension discovery", () => {
 		expect(extension?.commands.has("json-schema-ext")).toBe(true);
 	});
 
+	it("preserves exact null package import exclusions ahead of wildcard fallbacks", async () => {
+		const pluginsDir = getPluginsDir();
+		const pluginDir = path.join(pluginsDir, "node_modules", "null-exact-import-plugin");
+		const extensionPath = path.join(pluginDir, "src", "index.ts");
+		fs.rmSync(path.join(pluginsDir, "node_modules"), { recursive: true, force: true });
+		fs.mkdirSync(path.join(pluginDir, "src"), { recursive: true });
+		fs.writeFileSync(
+			path.join(pluginsDir, "package.json"),
+			JSON.stringify({
+				name: "omp-plugins",
+				private: true,
+				dependencies: {
+					"null-exact-import-plugin": "1.0.0",
+				},
+			}),
+		);
+		fs.writeFileSync(
+			path.join(pluginDir, "package.json"),
+			JSON.stringify({
+				name: "null-exact-import-plugin",
+				version: "1.0.0",
+				imports: {
+					"#src/internal": null,
+					"#src/*": "./src/*",
+				},
+				pi: {
+					extensions: ["./src/index.ts"],
+				},
+			}),
+		);
+		fs.writeFileSync(path.join(pluginDir, "src", "internal.ts"), 'export const commandName = "null-exact-ext";');
+		fs.writeFileSync(
+			extensionPath,
+			[
+				'import { commandName } from "#src/internal";',
+				"",
+				"export default function(pi) {",
+				"\tpi.registerCommand(commandName, { handler: async () => {} });",
+				"}",
+			].join("\n"),
+		);
+
+		const result = await discoverAndLoadExtensions([], projectDir.path());
+		const extension = result.extensions.find(ext => ext.path === extensionPath);
+		const pluginError = result.errors.find(err => err.path === extensionPath);
+
+		expect(pluginError?.error).toContain("#src/internal");
+		expect(extension).toBeUndefined();
+	});
+
+	it("preserves active null conditional package import exclusions", async () => {
+		const pluginsDir = getPluginsDir();
+		const pluginDir = path.join(pluginsDir, "node_modules", "null-conditional-import-plugin");
+		const extensionPath = path.join(pluginDir, "src", "index.ts");
+		fs.rmSync(path.join(pluginsDir, "node_modules"), { recursive: true, force: true });
+		fs.mkdirSync(path.join(pluginDir, "src"), { recursive: true });
+		fs.writeFileSync(
+			path.join(pluginsDir, "package.json"),
+			JSON.stringify({
+				name: "omp-plugins",
+				private: true,
+				dependencies: {
+					"null-conditional-import-plugin": "1.0.0",
+				},
+			}),
+		);
+		fs.writeFileSync(
+			path.join(pluginDir, "package.json"),
+			JSON.stringify({
+				name: "null-conditional-import-plugin",
+				version: "1.0.0",
+				imports: {
+					"#blocked": {
+						node: null,
+						default: "./src/blocked.ts",
+					},
+				},
+				pi: {
+					extensions: ["./src/index.ts"],
+				},
+			}),
+		);
+		fs.writeFileSync(path.join(pluginDir, "src", "blocked.ts"), 'export const commandName = "null-conditional-ext";');
+		fs.writeFileSync(
+			extensionPath,
+			[
+				'import { commandName } from "#blocked";',
+				"",
+				"export default function(pi) {",
+				"\tpi.registerCommand(commandName, { handler: async () => {} });",
+				"}",
+			].join("\n"),
+		);
+
+		const result = await discoverAndLoadExtensions([], projectDir.path());
+		const extension = result.extensions.find(ext => ext.path === extensionPath);
+		const pluginError = result.errors.find(err => err.path === extensionPath);
+
+		expect(pluginError?.error).toContain("#blocked");
+		expect(extension).toBeUndefined();
+	});
+
 	it("rewrites side-effect imports of package-import aliases and legacy Pi scopes", async () => {
 		const pluginsDir = getPluginsDir();
 		const pluginDir = path.join(pluginsDir, "node_modules", "side-effect-plugin");

--- a/packages/coding-agent/test/plugin-extensions-discovery.test.ts
+++ b/packages/coding-agent/test/plugin-extensions-discovery.test.ts
@@ -197,6 +197,85 @@ describe("plugin extension discovery", () => {
 		expect(extension?.commands.has("package-import-ext")).toBe(true);
 	});
 
+	it("rewrites side-effect imports of package-import aliases and legacy Pi scopes", async () => {
+		const pluginsDir = getPluginsDir();
+		const pluginDir = path.join(pluginsDir, "node_modules", "side-effect-plugin");
+		const extensionPath = path.join(pluginDir, "src", "index.ts");
+		fs.rmSync(path.join(pluginsDir, "node_modules"), { recursive: true, force: true });
+		fs.mkdirSync(path.join(pluginDir, "src"), { recursive: true });
+		fs.writeFileSync(
+			path.join(pluginsDir, "package.json"),
+			JSON.stringify({
+				name: "omp-plugins",
+				private: true,
+				dependencies: {
+					"side-effect-plugin": "1.0.0",
+				},
+			}),
+		);
+		fs.writeFileSync(
+			path.join(pluginDir, "package.json"),
+			JSON.stringify({
+				name: "side-effect-plugin",
+				version: "1.0.0",
+				imports: {
+					"#src/*": "./src/*",
+				},
+				pi: {
+					extensions: ["./src/index.ts"],
+				},
+			}),
+		);
+		fs.writeFileSync(
+			extensionPath,
+			[
+				// Side-effect imports — no `from`, no dynamic `import()`. The
+				// regex matchers must walk and rewrite both shapes so the legacy
+				// `@earendil-works` import inside `register.ts` resolves to the
+				// host `@oh-my-pi` package.
+				'import "#src/register";',
+				'import "./marker";',
+				"",
+				"declare global { var __sideEffectMarker: { ok: boolean; runs: number } | undefined; }",
+				"",
+				"export default function(pi) {",
+				'\tif (!globalThis.__sideEffectMarker?.ok) throw new Error("register side-effect did not run");',
+				'\tpi.registerCommand("side-effect-ext", { handler: async () => {} });',
+				"}",
+			].join("\n"),
+		);
+		fs.writeFileSync(
+			path.join(pluginDir, "src", "register.ts"),
+			[
+				'import { isToolCallEventType as legacyExtensions } from "@earendil-works/pi-coding-agent/extensibility/extensions";',
+				`import { isToolCallEventType as modernExtensions } from ${JSON.stringify(currentPiExtensionsPath)};`,
+				"",
+				'if (legacyExtensions !== modernExtensions) throw new Error("legacy side-effect import did not remap");',
+				"(globalThis as { __sideEffectMarker?: { ok: boolean; runs: number } }).__sideEffectMarker = { ok: true, runs: 1 };",
+			].join("\n"),
+		);
+		fs.writeFileSync(
+			path.join(pluginDir, "src", "marker.ts"),
+			[
+				"const slot = (globalThis as { __sideEffectMarker?: { ok: boolean; runs: number } }).__sideEffectMarker;",
+				'if (!slot) throw new Error("relative side-effect import did not run before sibling");',
+				"slot.runs += 1;",
+			].join("\n"),
+		);
+
+		const result = await discoverAndLoadExtensions([], projectDir.path());
+		const extension = result.extensions.find(ext => ext.path === extensionPath);
+
+		expect(result.errors).toHaveLength(0);
+		expect(extension).toBeDefined();
+		expect(extension?.commands.has("side-effect-ext")).toBe(true);
+		expect((globalThis as { __sideEffectMarker?: { ok: boolean; runs: number } }).__sideEffectMarker).toEqual({
+			ok: true,
+			runs: 2,
+		});
+		delete (globalThis as { __sideEffectMarker?: unknown }).__sideEffectMarker;
+	});
+
 	it("loads installed plugin extensions whose manifest entry points at a directory with index.ts", async () => {
 		const pluginsDir = getPluginsDir();
 		const pluginDir = path.join(pluginsDir, "node_modules", "dir-entry-plugin");


### PR DESCRIPTION
## Repro
Installed `@gotgenes/pi-permission-system@9.0.0`, then loaded its declared `pi.extensions` entry with `bun -e 'import { loadExtensions } from "./packages/coding-agent/src/extensibility/extensions/loader.ts"; const entry = `${process.argv[1]}/node_modules/@gotgenes/pi-permission-system/src/index.ts`; const result = await loadExtensions([entry], process.cwd()); console.log(JSON.stringify({extensionCount: result.extensions.length, errors: result.errors}, null, 2));' /tmp/omp-1889-repro-2722`; before the fix it returned `extensionCount: 0` with `Cannot find module '#src/active-agent'` from `src/forwarded-permissions/polling.ts`.

## Cause
`packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` only walked relative imports when building the extension source graph, and only rewrote legacy Pi/TypeBox specifiers. The permission plugin ships TypeScript source that uses package `imports` aliases (`#src/*`), which Bun does not resolve to extensionless `.ts` files in this load path, so `loadLegacyPiModule()` failed before the extension factory registered any handlers.

## Fix
- Resolve package-local `imports` aliases while collecting an extension source graph, including extensionless TS/JS source candidates.
- Rewrite resolved `#...` package imports to absolute file URLs in the same on-load compatibility pass as legacy Pi and TypeBox specifiers.
- Add a plugin discovery regression for a legacy `pi.extensions` package that imports through `#src/*` and still needs `@earendil-works` scope remapping.

## Verification
`bun test packages/coding-agent/test/plugin-extensions-discovery.test.ts packages/coding-agent/test/issue-973-legacy-pi-plugin.test.ts` passed (5 tests). `bun --cwd=packages/coding-agent run check` passed. Re-running the actual package load returned `extensionCount: 1`, no errors, command `permission-system`, and registered `tool_call`/session handlers. Fixes #1889