### PR TITLE
feat: per-role :auto thinking selector

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ### Added
 
+- Added per-role `:auto` as a first-class thinking selector. Any `modelRoles` entry can now be suffixed with `:auto` (e.g. `default: anthropic/claude-opus-4-8:auto`) to put that role in auto-thinking mode, instead of `auto` being expressible only through the global `defaultThinkingLevel`. This decouples the two: `defaultThinkingLevel` reverts to meaning just the inherited default for bare (suffix-less) roles, so you can have e.g. `default: …:auto` while `slow` inherits a concrete `defaultThinkingLevel: low`. `:auto` is honored across the default role (cold start), Ctrl+P scoped-model cycling, role cycling, and subagent roles; selecting auto in `/model` now persists `:auto` on the role rather than flipping the global default. The `auto` selector stays on the config→session side and is never passed to the provider/effort layer (it resolves to a concrete per-turn effort as before).
 - Added deferred session-title generation so greetings no longer become the session title. A first user message that is only a greeting / acknowledgement / filler ("hi", "thanks", "ok", a bare number, emoji-only, etc.) is now detected deterministically and skips titling entirely — no title model is invoked. Title generation then retries on each subsequent user message while the session stays unnamed, so the title is deduced from the first message that actually describes work. A capable online title model may additionally answer `none` to decline a non-greeting taskless message (normalized to "no title").
 
 ### Changed

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -540,9 +540,10 @@ function resolveConfiguredRolePattern(value: string, settings?: Settings): strin
 	if (!normalized) return undefined;
 
 	const lastColonIndex = normalized.lastIndexOf(":");
-	const thinkingLevel =
-		lastColonIndex > PREFIX_MODEL_ROLE.length ? parseThinkingLevel(normalized.slice(lastColonIndex + 1)) : undefined;
-	const aliasCandidate = thinkingLevel ? normalized.slice(0, lastColonIndex) : normalized;
+	const suffix = lastColonIndex > PREFIX_MODEL_ROLE.length ? normalized.slice(lastColonIndex + 1) : undefined;
+	const thinkingLevel = suffix ? parseThinkingLevel(suffix) : undefined;
+	const autoSuffix = suffix === AUTO_THINKING;
+	const aliasCandidate = thinkingLevel !== undefined || autoSuffix ? normalized.slice(0, lastColonIndex) : normalized;
 	const role = getModelRoleAlias(aliasCandidate);
 	if (!role) return [normalized];
 
@@ -553,7 +554,8 @@ function resolveConfiguredRolePattern(value: string, settings?: Settings): strin
 		return undefined;
 	}
 
-	return thinkingLevel ? resolved.map(pattern => `${pattern}:${thinkingLevel}`) : resolved;
+	const appendedSuffix = autoSuffix ? AUTO_THINKING : thinkingLevel;
+	return appendedSuffix ? resolved.map(pattern => `${pattern}:${appendedSuffix}`) : resolved;
 }
 
 /**

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -16,7 +16,12 @@ import { fuzzyMatch } from "@oh-my-pi/pi-tui";
 import { logger } from "@oh-my-pi/pi-utils";
 import chalk from "chalk";
 import MODEL_PRIO from "../priority.json" with { type: "json" };
-import { parseThinkingLevel, resolveThinkingLevelForModel } from "../thinking";
+import {
+	AUTO_THINKING,
+	type ConfiguredThinkingLevel,
+	parseThinkingLevel,
+	resolveThinkingLevelForModel,
+} from "../thinking";
 import { isAuthenticated, kNoAuth, MODEL_ROLE_IDS, type ModelRegistry, type ModelRole } from "./model-registry";
 import type { Settings } from "./settings";
 
@@ -27,6 +32,7 @@ export interface ScopedModel {
 	model: Model<Api>;
 	thinkingLevel?: ThinkingLevel;
 	explicitThinkingLevel: boolean;
+	auto?: boolean;
 }
 
 /**
@@ -59,7 +65,12 @@ export function formatModelString(model: Model<Api>): string {
 	return `${model.provider}/${model.id}`;
 }
 
-export function formatModelSelectorValue(selector: string, thinkingLevel: ThinkingLevel | undefined): string {
+/**
+ * Format a `selector:level` model value. `inherit`/`undefined` yield the bare
+ * selector; `auto` (the session-global selector) round-trips as `selector:auto`.
+ * The resolver decodes `:auto` back into the `auto` flag (never a concrete level).
+ */
+export function formatModelSelectorValue(selector: string, thinkingLevel: ConfiguredThinkingLevel | undefined): string {
 	return thinkingLevel && thinkingLevel !== ThinkingLevel.Inherit ? `${selector}:${thinkingLevel}` : selector;
 }
 
@@ -413,6 +424,8 @@ export interface ParsedModelResult {
 	thinkingLevel?: ThinkingLevel;
 	warning: string | undefined;
 	explicitThinkingLevel: boolean;
+	/** True when the thinking suffix was `:auto` (session-global; never a concrete level). */
+	auto?: boolean;
 }
 
 /**
@@ -449,19 +462,22 @@ function parseModelPatternWithContext(
 
 	const prefix = pattern.substring(0, lastColonIndex);
 	const suffix = pattern.substring(lastColonIndex + 1);
-
+	// A valid concrete level OR the `:auto` selector. `:auto` is session-global — it
+	// can't be a concrete `ThinkingLevel`, so it surfaces as the `auto` flag with
+	// `thinkingLevel` left undefined (the clamp/provider path must never receive it).
 	const parsedThinkingLevel = parseThinkingLevel(suffix);
-	if (parsedThinkingLevel) {
-		// Valid thinking level - recurse on prefix and use this level
+	const isAutoSuffix = suffix === AUTO_THINKING;
+	if (parsedThinkingLevel || isAutoSuffix) {
 		const result = parseModelPatternWithContext(prefix, availableModels, context, options);
 		if (result.model) {
-			// Only use this thinking level if no warning from inner recursion
-			const explicitThinkingLevel = !result.warning;
+			// Honor the suffix only if the inner recursion produced no warning.
+			const valid = !result.warning;
 			return {
 				model: result.model,
-				thinkingLevel: explicitThinkingLevel ? parsedThinkingLevel : undefined,
+				thinkingLevel: !isAutoSuffix && valid ? parsedThinkingLevel : undefined,
+				auto: isAutoSuffix && valid,
 				warning: result.warning,
-				explicitThinkingLevel,
+				explicitThinkingLevel: !isAutoSuffix && valid,
 			};
 		}
 		return result;
@@ -595,6 +611,8 @@ export interface ResolvedModelRoleValue {
 	model: Model<Api> | undefined;
 	thinkingLevel?: ThinkingLevel;
 	explicitThinkingLevel: boolean;
+	/** True when the role value used `:auto`. Routed to session auto mode, never the provider. */
+	auto?: boolean;
 	warning: string | undefined;
 }
 
@@ -629,6 +647,7 @@ export function resolveModelRoleValue(
 					? (resolveThinkingLevelForModel(resolved.model, resolved.thinkingLevel) ?? resolved.thinkingLevel)
 					: resolved.thinkingLevel,
 				explicitThinkingLevel: resolved.explicitThinkingLevel,
+				auto: resolved.auto,
 				warning: resolved.warning,
 			};
 		}
@@ -717,18 +736,18 @@ export function resolveModelOverride(
 	modelPatterns: string[],
 	modelRegistry: ModelLookupRegistry,
 	settings?: Settings,
-): { model?: Model<Api>; thinkingLevel?: ThinkingLevel; explicitThinkingLevel: boolean } {
+): { model?: Model<Api>; thinkingLevel?: ThinkingLevel; explicitThinkingLevel: boolean; auto?: boolean } {
 	if (modelPatterns.length === 0) return { explicitThinkingLevel: false };
 	const availableModels = modelRegistry.getAvailable();
 	const matchPreferences = { usageOrder: settings?.getStorage()?.getModelUsageOrder() };
 	for (const pattern of modelPatterns) {
-		const { model, thinkingLevel, explicitThinkingLevel } = resolveModelRoleValue(pattern, availableModels, {
+		const { model, thinkingLevel, explicitThinkingLevel, auto } = resolveModelRoleValue(pattern, availableModels, {
 			settings,
 			matchPreferences,
 			modelRegistry,
 		});
 		if (model) {
-			return { model, thinkingLevel, explicitThinkingLevel };
+			return { model, thinkingLevel, explicitThinkingLevel, auto };
 		}
 	}
 	return { explicitThinkingLevel: false };
@@ -764,6 +783,7 @@ export async function resolveModelOverrideWithAuthFallback(
 	model?: Model<Api>;
 	thinkingLevel?: ThinkingLevel;
 	explicitThinkingLevel: boolean;
+	auto?: boolean;
 	authFallbackUsed: boolean;
 }> {
 	const primary = resolveModelOverride(modelPatterns, modelRegistry, settings);
@@ -799,7 +819,7 @@ export function resolveRoleSelection(
 	settings: Settings,
 	availableModels: Model<Api>[],
 	modelRegistry?: CanonicalModelRegistry,
-): { model: Model<Api>; thinkingLevel?: ThinkingLevel } | undefined {
+): { model: Model<Api>; thinkingLevel?: ThinkingLevel; auto?: boolean } | undefined {
 	const matchPreferences = { usageOrder: settings.getStorage()?.getModelUsageOrder() };
 	for (const role of roles) {
 		const resolved = resolveModelRoleValue(settings.getModelRole(role), availableModels, {
@@ -808,7 +828,7 @@ export function resolveRoleSelection(
 			modelRegistry,
 		});
 		if (resolved.model) {
-			return { model: resolved.model, thinkingLevel: resolved.thinkingLevel };
+			return { model: resolved.model, thinkingLevel: resolved.thinkingLevel, auto: resolved.auto };
 		}
 	}
 	return undefined;
@@ -818,19 +838,25 @@ function resolveExactCanonicalScopePattern(
 	pattern: string,
 	modelRegistry: Pick<ModelRegistry, "getCanonicalVariants">,
 	availableModels: Model<Api>[],
-): { models: Model<Api>[]; thinkingLevel?: ThinkingLevel; explicitThinkingLevel: boolean } | undefined {
+): { models: Model<Api>[]; thinkingLevel?: ThinkingLevel; explicitThinkingLevel: boolean; auto?: boolean } | undefined {
 	const lastColonIndex = pattern.lastIndexOf(":");
 	let canonicalId = pattern;
 	let thinkingLevel: ThinkingLevel | undefined;
 	let explicitThinkingLevel = false;
+	let auto = false;
 
 	if (lastColonIndex !== -1) {
 		const suffix = pattern.substring(lastColonIndex + 1);
-		const parsedThinkingLevel = parseThinkingLevel(suffix);
-		if (parsedThinkingLevel) {
+		if (suffix === AUTO_THINKING) {
 			canonicalId = pattern.substring(0, lastColonIndex);
-			thinkingLevel = parsedThinkingLevel;
-			explicitThinkingLevel = true;
+			auto = true;
+		} else {
+			const parsedThinkingLevel = parseThinkingLevel(suffix);
+			if (parsedThinkingLevel) {
+				canonicalId = pattern.substring(0, lastColonIndex);
+				thinkingLevel = parsedThinkingLevel;
+				explicitThinkingLevel = true;
+			}
 		}
 	}
 
@@ -841,7 +867,7 @@ function resolveExactCanonicalScopePattern(
 		return undefined;
 	}
 
-	return { models: variants, thinkingLevel, explicitThinkingLevel };
+	return { models: variants, thinkingLevel, explicitThinkingLevel, auto };
 }
 
 /**
@@ -872,14 +898,20 @@ export async function resolveModelScope(
 			let globPattern = pattern;
 			let thinkingLevel: ThinkingLevel | undefined;
 			let explicitThinkingLevel = false;
+			let auto = false;
 
 			if (colonIdx !== -1) {
 				const suffix = pattern.substring(colonIdx + 1);
-				const parsedThinkingLevel = parseThinkingLevel(suffix);
-				if (parsedThinkingLevel) {
-					thinkingLevel = parsedThinkingLevel;
-					explicitThinkingLevel = true;
+				if (suffix === AUTO_THINKING) {
+					auto = true;
 					globPattern = pattern.substring(0, colonIdx);
+				} else {
+					const parsedThinkingLevel = parseThinkingLevel(suffix);
+					if (parsedThinkingLevel) {
+						thinkingLevel = parsedThinkingLevel;
+						explicitThinkingLevel = true;
+						globPattern = pattern.substring(0, colonIdx);
+					}
 				}
 			}
 
@@ -904,6 +936,7 @@ export async function resolveModelScope(
 							? (resolveThinkingLevelForModel(model, thinkingLevel) ?? thinkingLevel)
 							: thinkingLevel,
 						explicitThinkingLevel,
+						auto,
 					});
 				}
 			}
@@ -921,13 +954,14 @@ export async function resolveModelScope(
 								exactCanonical.thinkingLevel)
 							: exactCanonical.thinkingLevel,
 						explicitThinkingLevel: exactCanonical.explicitThinkingLevel,
+						auto: exactCanonical.auto,
 					});
 				}
 			}
 			continue;
 		}
 
-		const { model, thinkingLevel, warning, explicitThinkingLevel } = parseModelPatternWithContext(
+		const { model, thinkingLevel, warning, explicitThinkingLevel, auto } = parseModelPatternWithContext(
 			pattern,
 			availableModels,
 			context,
@@ -951,6 +985,7 @@ export async function resolveModelScope(
 					? (resolveThinkingLevelForModel(model, thinkingLevel) ?? thinkingLevel)
 					: thinkingLevel,
 				explicitThinkingLevel,
+				auto,
 			});
 		}
 	}

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1029,6 +1029,7 @@ export interface ResolveCliModelResult {
 	model: Model<Api> | undefined;
 	selector?: string;
 	thinkingLevel?: ThinkingLevel;
+	auto?: boolean;
 	warning: string | undefined;
 	error: string | undefined;
 }
@@ -1148,7 +1149,7 @@ export function resolveCliModel(options: {
 	}
 
 	const candidates = provider ? availableModels.filter(model => model.provider === provider) : availableModels;
-	const { model, thinkingLevel, warning } = parseModelPattern(pattern, candidates, preferences, {
+	const { model, thinkingLevel, auto, warning } = parseModelPattern(pattern, candidates, preferences, {
 		allowInvalidThinkingSelectorFallback: false,
 		modelRegistry,
 	});
@@ -1183,6 +1184,7 @@ export function resolveCliModel(options: {
 		model,
 		selector,
 		thinkingLevel,
+		auto,
 		warning,
 		error: undefined,
 	};

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -624,6 +624,11 @@ async function buildSessionOptions(
 				// Apply explicit thinking level from remembered role value
 				if (!parsed.thinking && rememberedSpec.explicitThinkingLevel && rememberedSpec.thinkingLevel) {
 					options.thinkingLevel = rememberedSpec.thinkingLevel;
+				} else if (!parsed.thinking && rememberedSpec.auto) {
+					// A remembered `:auto` default must set the initial selector to auto;
+					// options.model is set below (→ hasExplicitModel), which would otherwise
+					// skip the role's auto in createAgentSession.
+					options.thinkingLevel = AUTO_THINKING;
 				}
 			}
 		}
@@ -633,13 +638,12 @@ async function buildSessionOptions(
 	// Thinking level
 	if (parsed.thinking) {
 		options.thinkingLevel = parsed.thinking;
-	} else if (
-		scopedModels.length > 0 &&
-		scopedModels[0].explicitThinkingLevel === true &&
-		!parsed.continue &&
-		!parsed.resume
-	) {
-		options.thinkingLevel = scopedModels[0].thinkingLevel;
+	} else if (scopedModels.length > 0 && options.thinkingLevel === undefined && !parsed.continue && !parsed.resume) {
+		if (scopedModels[0].explicitThinkingLevel === true) {
+			options.thinkingLevel = scopedModels[0].thinkingLevel;
+		} else if (scopedModels[0].auto) {
+			options.thinkingLevel = AUTO_THINKING;
+		}
 	}
 
 	// Scoped models for Ctrl+P cycling - fill in default thinking levels when not explicit

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -597,10 +597,13 @@ async function buildSessionOptions(
 			});
 			if (!parsed.thinking && resolved.thinkingLevel) {
 				options.thinkingLevel = resolved.thinkingLevel;
+			} else if (!parsed.thinking && resolved.auto) {
+				options.thinkingLevel = AUTO_THINKING;
 			}
 		}
 	} else if (scopedModels.length > 0 && !parsed.continue && !parsed.resume) {
 		const remembered = activeSettings.getModelRole("default");
+		let selectedScoped: ScopedModel | undefined;
 		if (remembered) {
 			const rememberedSpec = resolveModelRoleValue(
 				remembered,
@@ -612,38 +615,30 @@ async function buildSessionOptions(
 				},
 			);
 			const rememberedResolvedModel = rememberedSpec.model;
-			const rememberedModel = rememberedResolvedModel
+			selectedScoped = rememberedResolvedModel
 				? scopedModels.find(
 						scopedModel =>
 							scopedModel.model.provider === rememberedResolvedModel.provider &&
 							scopedModel.model.id === rememberedResolvedModel.id,
 					)
 				: scopedModels.find(scopedModel => scopedModel.model.id.toLowerCase() === remembered.toLowerCase());
-			if (rememberedModel) {
-				options.model = rememberedModel.model;
-				// Apply explicit thinking level from remembered role value
-				if (!parsed.thinking && rememberedSpec.explicitThinkingLevel && rememberedSpec.thinkingLevel) {
-					options.thinkingLevel = rememberedSpec.thinkingLevel;
-				} else if (!parsed.thinking && rememberedSpec.auto) {
-					// A remembered `:auto` default must set the initial selector to auto;
-					// options.model is set below (→ hasExplicitModel), which would otherwise
-					// skip the role's auto in createAgentSession.
-					options.thinkingLevel = AUTO_THINKING;
-				}
+		}
+		selectedScoped ??= scopedModels[0];
+		options.model = selectedScoped.model;
+		// Pin thinking from the selected entry, not always scopedModels[0]: setting
+		// options.model flips hasExplicitModel, which skips the role selector at startup.
+		if (!parsed.thinking) {
+			if (selectedScoped.explicitThinkingLevel && selectedScoped.thinkingLevel !== undefined) {
+				options.thinkingLevel = selectedScoped.thinkingLevel;
+			} else if (selectedScoped.auto) {
+				options.thinkingLevel = AUTO_THINKING;
 			}
 		}
-		if (!options.model) options.model = scopedModels[0].model;
 	}
 
 	// Thinking level
 	if (parsed.thinking) {
 		options.thinkingLevel = parsed.thinking;
-	} else if (scopedModels.length > 0 && options.thinkingLevel === undefined && !parsed.continue && !parsed.resume) {
-		if (scopedModels[0].explicitThinkingLevel === true) {
-			options.thinkingLevel = scopedModels[0].thinkingLevel;
-		} else if (scopedModels[0].auto) {
-			options.thinkingLevel = AUTO_THINKING;
-		}
 	}
 
 	// Scoped models for Ctrl+P cycling - fill in default thinking levels when not explicit

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -644,16 +644,19 @@ async function buildSessionOptions(
 
 	// Scoped models for Ctrl+P cycling - fill in default thinking levels when not explicit
 	if (scopedModels.length > 0) {
-		// `auto` is a session-level concept only; per-scoped-model (Ctrl+P) thinking
-		// overrides stay concrete, so coerce the auto default to "unset" here.
+		// Per-scoped-model (Ctrl+P) `:auto` is carried via the `auto` flag below; the
+		// global `auto` default is still coerced to "unset" for the concrete level so a
+		// bare scoped entry doesn't silently inherit auto.
 		const defaultThinkingLevelSetting = activeSettings.get("defaultThinkingLevel");
 		const defaultThinkingLevel =
 			defaultThinkingLevelSetting === AUTO_THINKING ? undefined : defaultThinkingLevelSetting;
+
 		options.scopedModels = scopedModels.map(scopedModel => ({
 			model: scopedModel.model,
 			thinkingLevel: scopedModel.explicitThinkingLevel
 				? (scopedModel.thinkingLevel ?? defaultThinkingLevel)
 				: defaultThinkingLevel,
+			auto: scopedModel.auto,
 		}));
 	}
 

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -280,8 +280,9 @@ export class ModelSelectorComponent extends Container {
 			if (resolved.model) {
 				this.#roles[role] = {
 					model: resolved.model,
-					thinkingLevel:
-						resolved.explicitThinkingLevel && resolved.thinkingLevel !== undefined
+					thinkingLevel: resolved.auto
+						? AUTO_THINKING
+						: resolved.explicitThinkingLevel && resolved.thinkingLevel !== undefined
 							? resolved.thinkingLevel
 							: ThinkingLevel.Inherit,
 				};

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -415,32 +415,37 @@ export class SelectorController {
 				this.ctx.session.modelRegistry,
 				this.ctx.session.scopedModels,
 				async (model, role, thinkingLevel, selector) => {
-					// `auto` is session-global: never baked into a per-role model value
-					// (it can't round-trip through `model:<level>`). Apply it to the session
-					// separately and persist via `defaultThinkingLevel`.
 					const isAuto = thinkingLevel === AUTO_THINKING;
 					const concreteThinking = isAuto ? undefined : thinkingLevel;
+					const selectorValue = selector ?? `${model.provider}/${model.id}`;
+					// `:auto` is a first-class per-role selector: persist it on the role and
+					// enter auto in-session without writing the global `defaultThinkingLevel`
+					// (which stays the inherited default for bare roles).
+					const roleValue = formatModelSelectorValue(selectorValue, thinkingLevel);
 					try {
 						if (role === null) {
-							// Temporary: update agent state but don't persist the model to settings
+							// Temporary: session-only model swap, nothing persisted.
+							// setModelTemporary re-resolves the thinking level for the new model.
 							await this.ctx.session.setModelTemporary(model);
-							if (isAuto) {
-								this.ctx.session.setThinkingLevel(AUTO_THINKING, true);
-							}
 							this.ctx.statusLine.invalidate();
 							this.ctx.updateEditorBorderColor();
 							this.ctx.showStatus(`Temporary model: ${selector ?? model.id}`);
 							done();
 							this.ctx.ui.requestRender();
 						} else if (role === "default") {
-							// Default: update agent state and persist
+							// NOTE: live-apply is keyed on "default" assuming it's the active role;
+							// ctrl+p cycling can make another role active, so editing it won't update live.
+							// Default: switch the live model and persist the role value
+							// (including `:auto`). setModel persists for concrete/inherit; for
+							// auto we write `:auto` explicitly and enter auto in-session.
 							await this.ctx.session.setModel(model, role, {
 								selector,
 								thinkingLevel: concreteThinking,
-								persist: true,
+								persist: !isAuto,
 							});
 							if (isAuto) {
-								this.ctx.session.setThinkingLevel(AUTO_THINKING, true);
+								this.ctx.settings.setModelRole(role, roleValue);
+								this.ctx.session.setThinkingLevel(AUTO_THINKING, false);
 							} else if (concreteThinking && concreteThinking !== ThinkingLevel.Inherit) {
 								this.ctx.session.setThinkingLevel(concreteThinking);
 							}
@@ -449,14 +454,9 @@ export class SelectorController {
 							this.ctx.showStatus(`Default model: ${selector ?? model.id}`);
 							// Don't call done() - selector stays open for role assignment
 						} else {
-							// Other roles (smol, slow): just update settings, not current model
-							this.ctx.settings.setModelRole(
-								role,
-								formatModelSelectorValue(selector ?? `${model.provider}/${model.id}`, concreteThinking),
-							);
-							if (isAuto) {
-								this.ctx.session.setThinkingLevel(AUTO_THINKING, true);
-							}
+							// Other roles (smol, slow, ...): persist only; `:auto` lives on the
+							// role and doesn't affect the active session or global default.
+							this.ctx.settings.setModelRole(role, roleValue);
 							const roleInfo = getRoleInfo(role, settings);
 							const roleLabel = roleInfo?.name ?? role;
 							this.ctx.showStatus(`${roleLabel} model: ${selector ?? model.id}`);

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -446,7 +446,11 @@ export class SelectorController {
 							if (isAuto) {
 								this.ctx.settings.setModelRole(role, roleValue);
 								this.ctx.session.setThinkingLevel(AUTO_THINKING, false);
-							} else if (concreteThinking && concreteThinking !== ThinkingLevel.Inherit) {
+							} else if (concreteThinking === ThinkingLevel.Inherit) {
+								// Inherit follows the global default and clears any live per-role
+								// override (incl. auto) that setModel's re-apply would otherwise keep.
+								this.ctx.session.setThinkingLevel(this.ctx.settings.get("defaultThinkingLevel"));
+							} else if (concreteThinking) {
 								this.ctx.session.setThinkingLevel(concreteThinking);
 							}
 							this.ctx.statusLine.invalidate();

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -82,6 +82,7 @@ import { getRecentSessions } from "../session/session-manager";
 import type { ShakeMode } from "../session/shake-types";
 import { formatDuration } from "../slash-commands/helpers/format";
 import { STTController, type SttState } from "../stt";
+import { AUTO_THINKING, type ConfiguredThinkingLevel } from "../thinking";
 import type { LspStartupServerInfo } from "../tools";
 import { normalizeLocalScheme } from "../tools/path-utils";
 import { setAutoQaConsentHandler } from "../tools/report-tool-issue";
@@ -336,7 +337,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	#goalContinuationTurnInFlight = false;
 	#goalSuppressNextContinuation = false;
 	#planModePreviousModelState: { model: Model; thinkingLevel?: ThinkingLevel } | undefined;
-	#pendingModelSwitch: { model: Model; thinkingLevel?: ThinkingLevel } | undefined;
+	#pendingModelSwitch: { model: Model; thinkingLevel?: ConfiguredThinkingLevel } | undefined;
 	#planModeHasEntered = false;
 	#planReviewContainer: Container | undefined;
 	readonly lspServers: LspStartupServerInfo[] | undefined = undefined;
@@ -1334,7 +1335,11 @@ export class InteractiveMode implements InteractiveModeContext {
 
 		const currentModel = this.session.model;
 		const sameModel = modelsAreEqual(currentModel, resolved.model);
-		const planThinkingLevel = resolved.explicitThinkingLevel ? resolved.thinkingLevel : undefined;
+		const planThinkingLevel: ConfiguredThinkingLevel | undefined = resolved.auto
+			? AUTO_THINKING
+			: resolved.explicitThinkingLevel
+				? resolved.thinkingLevel
+				: undefined;
 
 		this.#planModePreviousModelState = currentModel
 			? { model: currentModel, thinkingLevel: this.session.thinkingLevel }

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1102,6 +1102,9 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		if (level === undefined && hasExistingSession && hasThinkingEntry) {
 			level = parseThinkingLevel(existingSession.thinkingLevel);
 		}
+		if (level === undefined && !hasExplicitModel && !hasThinkingEntry && defaultRoleSpec.auto) {
+			level = AUTO_THINKING;
+		}
 		if (level === undefined && !hasExplicitModel && !hasThinkingEntry && defaultRoleSpec.explicitThinkingLevel) {
 			level = defaultRoleSpec.thinkingLevel;
 		}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -300,7 +300,7 @@ export interface AgentSessionConfig {
 	sessionManager: SessionManager;
 	settings: Settings;
 	/** Models to cycle through with Ctrl+P (from --models flag) */
-	scopedModels?: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
+	scopedModels?: Array<{ model: Model; thinkingLevel?: ThinkingLevel; auto?: boolean }>;
 	/** Initial session thinking selector. */
 	thinkingLevel?: ConfiguredThinkingLevel;
 	/** Prompt templates for expansion */
@@ -441,6 +441,7 @@ export interface ResolvedRoleModel {
 	model: Model;
 	thinkingLevel?: ThinkingLevel;
 	explicitThinkingLevel: boolean;
+	auto?: boolean;
 }
 
 /** The set of resolvable role models plus the index of the currently active
@@ -826,7 +827,7 @@ export class AgentSession {
 
 	readonly configWarnings: string[] = [];
 
-	#scopedModels: Array<{ model: Model; thinkingLevel?: ThinkingLevel }>;
+	#scopedModels: Array<{ model: Model; thinkingLevel?: ThinkingLevel; auto?: boolean }>;
 	/** Effective, metadata-clamped thinking level applied to the agent (never `auto`). */
 	#thinkingLevel: ThinkingLevel | undefined;
 	/** True when the user configured `auto`; the effective level is resolved per turn. */
@@ -3982,7 +3983,7 @@ export class AgentSession {
 	}
 
 	/** Scoped models for cycling (from --models flag) */
-	get scopedModels(): ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel }> {
+	get scopedModels(): ReadonlyArray<{ model: Model; thinkingLevel?: ThinkingLevel; auto?: boolean }> {
 		return this.#scopedModels;
 	}
 
@@ -5372,6 +5373,7 @@ export class AgentSession {
 				model: resolved.model,
 				thinkingLevel: resolved.thinkingLevel,
 				explicitThinkingLevel: resolved.explicitThinkingLevel,
+				auto: resolved.auto,
 			});
 		}
 
@@ -5393,7 +5395,9 @@ export class AgentSession {
 	 */
 	async applyRoleModel(entry: ResolvedRoleModel): Promise<void> {
 		await this.setModel(entry.model, entry.role);
-		if (entry.explicitThinkingLevel && entry.thinkingLevel !== undefined) {
+		if (entry.auto) {
+			this.setThinkingLevel(AUTO_THINKING);
+		} else if (entry.explicitThinkingLevel && entry.thinkingLevel !== undefined) {
 			this.setThinkingLevel(entry.thinkingLevel);
 		}
 	}
@@ -5419,9 +5423,9 @@ export class AgentSession {
 		return { model: next.model, thinkingLevel: this.thinkingLevel, role: next.role };
 	}
 
-	async #getScopedModelsWithApiKey(): Promise<Array<{ model: Model; thinkingLevel?: ThinkingLevel }>> {
+	async #getScopedModelsWithApiKey(): Promise<Array<{ model: Model; thinkingLevel?: ThinkingLevel; auto?: boolean }>> {
 		const apiKeysByProvider = new Map<string, string | undefined>();
-		const result: Array<{ model: Model; thinkingLevel?: ThinkingLevel }> = [];
+		const result: Array<{ model: Model; thinkingLevel?: ThinkingLevel; auto?: boolean }> = [];
 
 		for (const scoped of this.#scopedModels) {
 			const provider = scoped.model.provider;
@@ -5461,7 +5465,7 @@ export class AgentSession {
 		this.settings.getStorage()?.recordModelUsage(`${next.model.provider}/${next.model.id}`);
 
 		// Apply the scoped model's configured thinking level, preserving auto.
-		this.setThinkingLevel(this.#autoThinking ? AUTO_THINKING : next.thinkingLevel);
+		this.setThinkingLevel(next.auto || this.#autoThinking ? AUTO_THINKING : next.thinkingLevel);
 		await this.#syncEditToolModeAfterModelChange(previousEditMode);
 
 		return { model: next.model, thinkingLevel: this.thinkingLevel, isScoped: true };

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5464,8 +5464,10 @@ export class AgentSession {
 		this.sessionManager.appendModelChange(`${next.model.provider}/${next.model.id}`);
 		this.settings.getStorage()?.recordModelUsage(`${next.model.provider}/${next.model.id}`);
 
-		// Apply the scoped model's configured thinking level, preserving auto.
-		this.setThinkingLevel(next.auto || this.#autoThinking ? AUTO_THINKING : next.thinkingLevel);
+		// Apply the scoped entry's own configured thinking: `:auto` enters auto, a
+		// concrete level uses that level. The entry is authoritative — auto does not
+		// "stick" from the previous entry onto a later concrete one.
+		this.setThinkingLevel(next.auto ? AUTO_THINKING : next.thinkingLevel);
 		await this.#syncEditToolModeAfterModelChange(previousEditMode);
 
 		return { model: next.model, thinkingLevel: this.thinkingLevel, isScoped: true };

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5399,6 +5399,8 @@ export class AgentSession {
 			this.setThinkingLevel(AUTO_THINKING);
 		} else if (entry.explicitThinkingLevel && entry.thinkingLevel !== undefined) {
 			this.setThinkingLevel(entry.thinkingLevel);
+		} else if (this.#autoThinking) {
+			this.setThinkingLevel(this.settings.get("defaultThinkingLevel"));
 		}
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5295,7 +5295,7 @@ export class AgentSession {
 	 */
 	async setModelTemporary(
 		model: Model,
-		thinkingLevel?: ThinkingLevel,
+		thinkingLevel?: ConfiguredThinkingLevel,
 		options?: { ephemeral?: boolean },
 	): Promise<void> {
 		const previousEditMode = this.#resolveActiveEditMode();

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -32,6 +32,7 @@ import type { AuthStorage } from "../session/auth-storage";
 import { SKILL_PROMPT_MESSAGE_TYPE } from "../session/messages";
 import { SessionManager } from "../session/session-manager";
 import { truncateTail } from "../session/streaming-output";
+import { AUTO_THINKING, type ConfiguredThinkingLevel } from "../thinking";
 import type { ContextFileEntry } from "../tools";
 import { normalizeSchema } from "../tools/jtd-to-json-schema";
 import { buildOutputValidator, summarizeValidationFailure } from "../tools/output-schema-validator";
@@ -1150,6 +1151,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				model,
 				thinkingLevel: resolvedThinkingLevel,
 				explicitThinkingLevel,
+				auto,
 				authFallbackUsed,
 			} = await awaitAbortable(
 				resolveModelOverrideWithAuthFallback(
@@ -1171,13 +1173,17 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 				progress.contextWindow = model.contextWindow;
 			}
 			if (model) {
-				progress.resolvedModel = explicitThinkingLevel
-					? `${model.provider}/${model.id}:${resolvedThinkingLevel}`
-					: `${model.provider}/${model.id}`;
+				let thinkingSuffix = "";
+				if (auto) thinkingSuffix = ":auto";
+				else if (explicitThinkingLevel) thinkingSuffix = `:${resolvedThinkingLevel}`;
+				progress.resolvedModel = `${model.provider}/${model.id}${thinkingSuffix}`;
 			}
-			const effectiveThinkingLevel = explicitThinkingLevel
+			let effectiveThinkingLevel: ConfiguredThinkingLevel | undefined = explicitThinkingLevel
 				? resolvedThinkingLevel
 				: (thinkingLevel ?? resolvedThinkingLevel);
+			if (auto) {
+				effectiveThinkingLevel = AUTO_THINKING;
+			}
 
 			const sessionManager = sessionFile
 				? await awaitAbortable(SessionManager.open(sessionFile))

--- a/packages/coding-agent/test/agent-session-role-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-role-thinking.test.ts
@@ -161,6 +161,22 @@ describe("AgentSession role model thinking behavior", () => {
 		expect(session.thinkingLevel).toBe(Effort.Low);
 	});
 
+	it("setModelTemporary enters auto thinking when given AUTO_THINKING", async () => {
+		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const planModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+
+		await createSession({
+			initialModelId: defaultModel.id,
+			initialThinkingLevel: Effort.High,
+			modelRoles: { default: `${defaultModel.provider}/${defaultModel.id}:high` },
+		});
+		expect(session.isAutoThinking).toBe(false);
+
+		await session.setModelTemporary(planModel, AUTO_THINKING);
+		expect(session.model?.id).toBe(planModel.id);
+		expect(session.isAutoThinking).toBe(true);
+	});
+
 	it("scoped model cycle applies each entry's own auto/level, not sticky auto", async () => {
 		const autoModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
 		const highModel = getAnthropicModelOrThrow("claude-sonnet-4-6");

--- a/packages/coding-agent/test/agent-session-role-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-role-thinking.test.ts
@@ -133,6 +133,49 @@ describe("AgentSession role model thinking behavior", () => {
 		expect(session.thinkingLevel).toBe(Effort.High);
 	});
 
+	it("scoped model cycle applies each entry's own auto/level, not sticky auto", async () => {
+		const autoModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const highModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+		const agent = new Agent({
+			initialState: {
+				model: autoModel,
+				systemPrompt: ["Test"],
+				tools: [],
+				messages: [],
+				thinkingLevel: resolveProvisionalAutoLevel(autoModel),
+			},
+		});
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "testauth-scoped-cycle.db"));
+		authStorages.push(authStorage);
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models-scoped-cycle.yml"));
+		sessionSettings = Settings.isolated();
+		session = new AgentSession({
+			agent,
+			sessionManager: SessionManager.inMemory(),
+			settings: sessionSettings,
+			modelRegistry,
+			thinkingLevel: AUTO_THINKING,
+			scopedModels: [
+				{ model: autoModel, auto: true },
+				{ model: highModel, thinkingLevel: Effort.High },
+			],
+		});
+
+		expect(session.isAutoThinking).toBe(true);
+
+		// Cycle onto the concrete `:high` entry — must apply high, not keep auto sticky.
+		const toHigh = await session.cycleModel("forward");
+		expect(toHigh?.model.id).toBe(highModel.id);
+		expect(session.isAutoThinking).toBe(false);
+		expect(session.thinkingLevel).toBe(Effort.High);
+
+		// Cycle back onto the `:auto` entry — re-enters auto.
+		const toAuto = await session.cycleModel("forward");
+		expect(toAuto?.model.id).toBe(autoModel.id);
+		expect(session.isAutoThinking).toBe(true);
+	});
+
 	it("preserves current thinking when switching into default/no-suffix role", async () => {
 		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
 		const slowModel = getAnthropicModelOrThrow("claude-sonnet-4-6");

--- a/packages/coding-agent/test/agent-session-role-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-role-thinking.test.ts
@@ -133,6 +133,34 @@ describe("AgentSession role model thinking behavior", () => {
 		expect(session.thinkingLevel).toBe(Effort.High);
 	});
 
+	it("resets per-role auto to the inherited default when cycling onto a bare role", async () => {
+		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const slowModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+
+		await createSession({
+			initialModelId: defaultModel.id,
+			initialThinkingLevel: Effort.High,
+			modelRoles: {
+				default: `${defaultModel.provider}/${defaultModel.id}:auto`,
+				slow: `${slowModel.provider}/${slowModel.id}`, // bare — inherits defaultThinkingLevel
+			},
+		});
+		sessionSettings.set("defaultThinkingLevel", Effort.Low);
+
+		// Enter auto via the default role.
+		await session.cycleRoleModels(["default", "slow"]); // → slow (bare)
+		const toAuto = await session.cycleRoleModels(["default", "slow"]); // → default (:auto)
+		expect(toAuto?.role).toBe("default");
+		expect(session.isAutoThinking).toBe(true);
+
+		// Cycling onto the bare role must drop auto and inherit defaultThinkingLevel,
+		// not leak the previous per-role auto.
+		const toBare = await session.cycleRoleModels(["default", "slow"]); // → slow (bare)
+		expect(toBare?.role).toBe("slow");
+		expect(session.isAutoThinking).toBe(false);
+		expect(session.thinkingLevel).toBe(Effort.Low);
+	});
+
 	it("scoped model cycle applies each entry's own auto/level, not sticky auto", async () => {
 		const autoModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
 		const highModel = getAnthropicModelOrThrow("claude-sonnet-4-6");

--- a/packages/coding-agent/test/agent-session-role-thinking.test.ts
+++ b/packages/coding-agent/test/agent-session-role-thinking.test.ts
@@ -105,6 +105,34 @@ describe("AgentSession role model thinking behavior", () => {
 		expect(session.thinkingLevel).toBe("off");
 	});
 
+	it("enters auto mode when cycling into a role configured with :auto", async () => {
+		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
+		const slowModel = getAnthropicModelOrThrow("claude-sonnet-4-6");
+
+		await createSession({
+			initialModelId: defaultModel.id,
+			initialThinkingLevel: Effort.High,
+			modelRoles: {
+				default: `${defaultModel.provider}/${defaultModel.id}:high`,
+				slow: `${slowModel.provider}/${slowModel.id}:auto`,
+			},
+		});
+
+		expect(session.isAutoThinking).toBe(false);
+
+		const toSlow = await session.cycleRoleModels(["default", "slow"]);
+		expect(toSlow?.role).toBe("slow");
+		expect(toSlow?.model.id).toBe(slowModel.id);
+		expect(session.isAutoThinking).toBe(true);
+		expect(session.configuredThinkingLevel()).toBe(AUTO_THINKING);
+
+		// Cycling back into a concrete role leaves auto.
+		const toDefault = await session.cycleRoleModels(["default", "slow"]);
+		expect(toDefault?.role).toBe("default");
+		expect(session.isAutoThinking).toBe(false);
+		expect(session.thinkingLevel).toBe(Effort.High);
+	});
+
 	it("preserves current thinking when switching into default/no-suffix role", async () => {
 		const defaultModel = getAnthropicModelOrThrow("claude-sonnet-4-5");
 		const slowModel = getAnthropicModelOrThrow("claude-sonnet-4-6");

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { Effort, type Model } from "@oh-my-pi/pi-ai";
 import {
 	expandRoleAlias,
+	formatModelSelectorValue,
 	parseModelPattern,
 	parseModelString,
 	resolveAgentModelPatterns,
@@ -12,6 +13,7 @@ import {
 	resolveModelScope,
 } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AUTO_THINKING } from "../src/thinking";
 
 // Mock models for testing
 const mockModels: Model<"anthropic-messages">[] = [
@@ -496,6 +498,67 @@ describe("resolveModelRoleValue", () => {
 		expect(result.model?.id).toBe("claude-sonnet-4-5");
 		expect(result.thinkingLevel).toBe(Effort.High);
 		expect(result.explicitThinkingLevel).toBe(true);
+	});
+});
+
+describe(":auto thinking selector", () => {
+	test("parseModelPattern surfaces :auto as the auto flag, not a concrete level, with no warning", () => {
+		const result = parseModelPattern("sonnet:auto", allModels);
+		expect(result.model?.id).toBe("claude-sonnet-4-5");
+		expect(result.auto).toBe(true);
+		expect(result.thinkingLevel).toBeUndefined();
+		expect(result.explicitThinkingLevel).toBe(false);
+		expect(result.warning).toBeUndefined();
+	});
+
+	test("resolveModelRoleValue surfaces :auto as the auto flag, never a concrete thinkingLevel", () => {
+		const result = resolveModelRoleValue("anthropic/claude-sonnet-4-5:auto", allModels);
+		expect(result.model?.id).toBe("claude-sonnet-4-5");
+		expect(result.auto).toBe(true);
+		expect(result.thinkingLevel).toBeUndefined();
+		expect(result.explicitThinkingLevel).toBe(false);
+		expect(result.warning).toBeUndefined();
+	});
+
+	test("default :auto resolves to auto while a bare role carries neither auto nor an explicit level", () => {
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: "anthropic/claude-sonnet-4-5:auto",
+				slow: "anthropic/claude-sonnet-4-5",
+			},
+		});
+		const def = resolveModelRoleValue(settings.getModelRole("default"), allModels, { settings });
+		expect(def.auto).toBe(true);
+		expect(def.explicitThinkingLevel).toBe(false);
+		expect(def.thinkingLevel).toBeUndefined();
+
+		const slow = resolveModelRoleValue(settings.getModelRole("slow"), allModels, { settings });
+		expect(slow.auto).toBeFalsy();
+		expect(slow.explicitThinkingLevel).toBe(false);
+		expect(slow.thinkingLevel).toBeUndefined();
+	});
+
+	test("formatModelSelectorValue round-trips :auto back to the auto flag", () => {
+		const value = formatModelSelectorValue("anthropic/claude-sonnet-4-5", AUTO_THINKING);
+		expect(value).toBe("anthropic/claude-sonnet-4-5:auto");
+		const parsed = resolveModelRoleValue(value, allModels);
+		expect(parsed.auto).toBe(true);
+		expect(parsed.thinkingLevel).toBeUndefined();
+	});
+
+	test("a concrete suffix still clamps to a level and is not auto", () => {
+		const result = resolveModelRoleValue("anthropic/claude-sonnet-4-5:high", allModels);
+		expect(result.thinkingLevel).toBe(Effort.High);
+		expect(result.explicitThinkingLevel).toBe(true);
+		expect(result.auto).toBeFalsy();
+	});
+
+	test("resolveModelOverride surfaces :auto for subagent role overrides", () => {
+		const result = resolveModelOverride(["anthropic/claude-sonnet-4-5:auto"], { getAvailable: () => allModels });
+		expect(result.model?.id).toBe("claude-sonnet-4-5");
+		expect(result.auto).toBe(true);
+		expect(result.thinkingLevel).toBeUndefined();
+		expect(result.explicitThinkingLevel).toBe(false);
 	});
 });
 describe("resolveAgentModelPatterns", () => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -742,6 +742,23 @@ describe("resolveCliModel", () => {
 		expect(result.model?.id).toBe("gpt-4o");
 	});
 
+	test("surfaces :auto from --model as the auto flag, not a concrete level", () => {
+		const registry = {
+			getAll: () => allModels,
+		} as unknown as Parameters<typeof resolveCliModel>[0]["modelRegistry"];
+
+		const result = resolveCliModel({
+			cliModel: "anthropic/claude-sonnet-4-5:auto",
+			modelRegistry: registry,
+		});
+
+		expect(result.error).toBeUndefined();
+		expect(result.model?.provider).toBe("anthropic");
+		expect(result.model?.id).toBe("claude-sonnet-4-5");
+		expect(result.auto).toBe(true);
+		expect(result.thinkingLevel).toBeUndefined();
+	});
+
 	test("resolves fuzzy patterns within an explicit provider", () => {
 		const registry = {
 			getAll: () => allModels,

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -463,6 +463,20 @@ describe("resolveModelRoleValue", () => {
 		expect(result.explicitThinkingLevel).toBe(true);
 	});
 
+	test("resolves pi/<role>:auto by expanding the alias and surfacing the auto flag", () => {
+		const settings = {
+			getModelRole: (role: string) => (role === "smol" ? "anthropic/claude-sonnet-4-5" : undefined),
+		} as NonNullable<Parameters<typeof resolveModelRoleValue>[2]>["settings"];
+
+		const result = resolveModelRoleValue("pi/smol:auto", allModels, { settings });
+
+		expect(result.model?.provider).toBe("anthropic");
+		expect(result.model?.id).toBe("claude-sonnet-4-5");
+		expect(result.auto).toBe(true);
+		expect(result.thinkingLevel).toBeUndefined();
+		expect(result.explicitThinkingLevel).toBe(false);
+	});
+
 	test("resolves pi/default through configured default role alias", () => {
 		const settings = {
 			getModelRole: (role: string) => (role === "default" ? "openrouter/qwen/qwen3-coder:exacto" : undefined),


### PR DESCRIPTION
## Summary

Makes `:auto` a first-class **per-role** thinking selector. Any `modelRoles` entry can be suffixed with `:auto`, instead of `auto` being expressible only via the global `defaultThinkingLevel`. This decouples them — `defaultThinkingLevel` now means *only* the inherited default for bare roles:

```yaml
modelRoles:
  default: anthropic/claude-opus-4-8:auto   # auto, classified per turn
  slow:    anthropic/claude-opus-4-8        # inherits ↓
defaultThinkingLevel: low                   # bare-role default; default role no longer touches it
```

## Fixed

- **`/model` → "auto" sticks.** Selecting auto used to revert to the previous concrete level on next launch; it's now persisted as `:auto` on the role, so a cold start re-enters auto.
- **Selecting auto no longer rewrites the global default.** Picking auto for the default role used to set `defaultThinkingLevel: auto` globally, flipping every bare role (e.g. `designer`, `vision`) to auto. It now sets `:auto` on that role only.
- **Ctrl+P model cycling honors auto.** Cycling onto an `:auto` role (the `smol ◄default► slow` track, and the `--models` scoped list) now enters auto instead of using the previously resolved level.
- **Picker shows auto, not inherit.** The `/model` badge and thinking-submenu preselect now show **auto** for an `:auto` role.

## Added

- **Per-role `:auto`, independent of the global default** (example above).
- **Honored everywhere a role thinking level applies:** default model (cold start), Ctrl+P role cycling, the `--models` scoped cycle, and subagent roles (a subagent classifies its assignment per dispatch).
- **Self-documenting config** — `:auto` appears literally in `modelRoles`.
- **`defaultThinkingLevel` has one clear meaning** — the inherited default for bare roles — instead of being overloaded as both "the auto strategy" and "the inherited default."

## Implementation note

`auto` stays on the **config→session** side and never reaches the provider/effort layer — carried as an additive flag while `thinkingLevel` stays concrete-or-`undefined`, resolving to a concrete per-turn effort.

## Known limitation (pre-existing)

The selector applies a change to the live session only when `role === "default"`. Since Ctrl+P cycling can make another role active, editing a *cycled-onto* role only persists (no live change until you re-cycle), while editing `default` always switches live. Predates this PR; the fix (key on the active role) touches live-session behavior, so it's left as a follow-up (flagged with an in-code `NOTE`).

## Testing

`bun test` (resolver, session role/thinking, model persistence, sdk model selection, scope aliases), typecheck, and biome all pass; new tests cover `:auto` round-trip, `default:auto`/`slow:bare` resolution, no-clamp, role-cycling-into-auto, and the subagent override path.