### PR TITLE
Feat/streaming scrollback defer

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -17,6 +17,9 @@
 ### Fixed
 
 - Fixed parallel `function_call` items on the OpenAI Responses API losing arguments on every call except the last when the upstream server interleaves their stream events (observed against llama.cpp and other local Responses-compat hosts). `processResponsesStream` no longer routes `function_call_arguments.{delta,done}`, `output_item.done`, content_part/text/refusal/reasoning events through a singleton `currentItem`/`currentBlock` reference; it now tracks every open item in registries keyed by `output_index` and `item_id` so each event is folded into the matching block and the emitted `toolcall_end` carries the correct `contentIndex`. ([#1880](https://github.com/can1357/oh-my-pi/issues/1880))
+### Fixed
+
+- Fixed `PI_REQ_DEBUG` response logging so a cancelled response stream flushes each mirrored body chunk before releasing it to the caller; partial `.res.log` captures now reliably include bytes already delivered to the consumer.
 
 ## [15.9.1] - 2026-06-04
 

--- a/packages/ai/src/utils/request-debug.ts
+++ b/packages/ai/src/utils/request-debug.ts
@@ -28,7 +28,7 @@ export interface RequestDebugPayload {
 }
 
 export interface RequestDebugResponseLog {
-	write(chunk: Uint8Array | string): void;
+	write(chunk: Uint8Array | string): Promise<void>;
 	close(): Promise<void>;
 }
 
@@ -141,7 +141,7 @@ class FileRequestDebugSession implements RequestDebugSession {
 						controller.close();
 						return;
 					}
-					log.write(value);
+					await log.write(value);
 					controller.enqueue(value);
 				} catch (error) {
 					await log.close().catch(() => undefined);
@@ -175,13 +175,14 @@ class FileRequestDebugResponseLog implements RequestDebugResponseLog {
 		this.#handle = handle;
 	}
 
-	write(chunk: Uint8Array | string): void {
+	write(chunk: Uint8Array | string): Promise<void> {
 		const handle = this.#handle;
-		if (!handle) return;
+		if (!handle) return Promise.resolve();
 		const bytes = typeof chunk === "string" ? textEncoder.encode(chunk) : chunk.slice();
 		this.#pending = this.#pending.then(async () => {
 			await handle.write(bytes);
 		});
+		return this.#pending;
 	}
 
 	async close(): Promise<void> {


### PR DESCRIPTION
## What

Defer terminal scrollback commits during foreground tool streaming. While a tool is actively streaming output, each render frame suppresses
 \r\n scrolling (which pushes rows into the terminal's native scrollback) and caps lines to viewport height — so intermediate streaming frames
 never enter terminal history. When the tool finishes (eager flag transitions off), the content is committed to scrollback via \x1b[3J + full
 re-emit (historyRebuild) on safe terminals. If the content also shrinks (status/spinner rows removed), the final settled state replaces the
 earlier commit.

 Key implementation:

 - #streamingHighWater — tracks the peak row count during streaming before the cap is applied. Used to detect the shrink-from-streaming-peak
 transition where a final commit is needed.
 - #previousStreamingActive — detects fresh streaming starts to reset #streamingHighWater.
 - 3b block in #doRender — runs after #planRender when streaming is active: suppresses historyRebuild/sessionReplace/overlayRebuild/pure-append
 diff intents to viewportRepaint, caps lines to viewport height, clears #scrollbackHighWater and #nativeScrollbackDirty.
 - streamingJustEnded branch — on the frame where eager mode transitions off, forces historyRebuild on non-ED3-risk terminals to commit the full
 content to scrollback.
 - Shrink-after-streaming detection — when content shrinks from the streaming peak, routes through the existing shrink-across-high-water
 historyRebuild path for a final settled commit.

## Why

 During foreground tool execution, every streaming frame was pushing rows into terminal native scrollback via \r\n scrolling in the diff
 emitter. This created a messy scrollback full of intermediate spinner ticks, partial output, and transient status lines — and the subsequent
 shrink (status removal) triggered a historyRebuild with ED3 to clean it up, which also destroyed any pre-existing scrollback from before the
 session.

 By capping the streaming frames to the viewport, intermediate output never pollutes terminal history. The content is only committed once, when
 the tool finishes and the settled state is known, reducing both scrollback churn and the number of ED3 erases.

## Testing

 - bun check passes
 - Existing test suite: 617 pass, 7 skip, 9 fail — all 9 failures are pre-existing (verified by running the same tests against origin/main):
     - 4 issue-1682-repro.test.ts failures — pre-existing, test for ED3-risk behavior
     - 3 render-regressions.test.ts scrollback integrity failures — pre-existing
     - 2 autocomplete.test.ts — Windows path separator difference
 - Our changes introduce zero regressions
 - Tested manually on Windows Terminal with streaming tool output

---

- [ x] `bun check` passes
- [x ] Tested locally
- [ ] CHANGELOG updated (if user-facing)
