### PR TITLE
feat: enable bedrock-converse-stream for custom providers

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -64,6 +64,12 @@
 - Fixed Google Gemini tool calls with `toolChoice: "auto"` serializing an explicit `toolConfig` AUTO mode, which can cause Gemini-3 models to leak raw planning JSON instead of executing tools. ([#2776](https://github.com/can1357/oh-my-pi/issues/2776))
 - Fixed OpenAI-compatible Ollama completions that return empty `finish_reason:length` after filling `num_ctx` so they surface an actionable context-window error instead of an empty length stop. ([#2774](https://github.com/can1357/oh-my-pi/issues/2774))
 - Fixed Codex browser login issuing credentials for the `opencode` OAuth originator while OMP requests identify as `pi`, which could make the first authenticated Codex request return 401 ([#2696](https://github.com/can1357/oh-my-pi/issues/2696)).
+- Bedrock tool names are sanitized for the `[a-zA-Z0-9_-]+` wire format, with reverse mapping so tools like `foo.bar` still dispatch correctly — including the `toolChoice: "none"` path where tool specs are still sent because the history contains prior tool use.
+- Extended thinking-signature detection to bare `claude-*` model IDs on custom providers.
+- An explicit `bearerToken` is now honored for no-auth (`auth: "none"`) Bedrock providers instead of being shadowed by the no-auth path.
+- Caller-supplied Bedrock auth headers (`Authorization`/`X-Api-Key` on `model.headers`/`options.headers`) now outrank the `AWS_BEARER_TOKEN_BEDROCK` env fallback, so a custom gateway's configured header is no longer overwritten by the ambient env token.
+- Bedrock request headers are merged case-insensitively, so a differently-cased per-request header (e.g. `authorization`) replaces the model-level one instead of being sent as a comma-joined duplicate.
+- Stale Bedrock credentials are invalidated under the region actually used for signing (the host region for custom AWS endpoints), so a 401/403 retry re-resolves them.
 
 ## [16.0.1] - 2026-06-15
 
@@ -79,6 +85,18 @@
 - Fixed Cursor provider formatting tool errors with the same `[Tool Result]` prefix as successful results, causing Composer models to misinterpret error messages (e.g. "Pattern must not be empty") as directives over long conversations. Errors now use a `[Tool Error]` prefix so the model can distinguish failures from successes in the prompt history. ([#1853](https://github.com/can1357/oh-my-pi/pull/1853))
 - Fixed `validateToolArguments` silently accepting JSON-encoded array strings (e.g. `'["a","b"]'`) against `union(string, array<string>)` schemas — providers that double-serialize tool-call arguments (Z.AI / GLM) caused tools like `search` to receive the literal `["a","b"]` as a single path, producing zero matches (single element) or glob parse errors (multi-element). A new pre-validation pass parses JSON-array-shaped strings when the schema explicitly accepts both shapes. ([#1788](https://github.com/can1357/oh-my-pi/issues/1788))
 - Fixed Anthropic thinking summaries that arrive wrapped in literal `<thinking>` tags so advisor/raw transcript dumps do not render nested thinking tags ([#2695](https://github.com/can1357/oh-my-pi/issues/2695)).
+### Added
+
+- Custom `bedrock-converse-stream` providers via `models.yml` (`baseUrl`, optional `headers`, `auth: "none"`) for Bedrock-compatible gateways and proxies. AWS hosts use SigV4; non-AWS endpoints use caller headers or no auth.
+
+### Fixed
+
+- Bedrock tool names are sanitized for the `[a-zA-Z0-9_-]+` wire format, with reverse mapping so tools like `foo.bar` still dispatch correctly — including the `toolChoice: "none"` path where tool specs are still sent because the history contains prior tool use.
+- Extended thinking-signature detection to bare `claude-*` model IDs on custom providers.
+- An explicit `bearerToken` is now honored for no-auth (`auth: "none"`) Bedrock providers instead of being shadowed by the no-auth path.
+- Caller-supplied Bedrock auth headers (`Authorization`/`X-Api-Key` on `model.headers`/`options.headers`) now outrank the `AWS_BEARER_TOKEN_BEDROCK` env fallback, so a custom gateway's configured header is no longer overwritten by the ambient env token.
+- Bedrock request headers are merged case-insensitively, so a differently-cased per-request header (e.g. `authorization`) replaces the model-level one instead of being sent as a comma-joined duplicate.
+- Stale Bedrock credentials are invalidated under the region actually used for signing (the host region for custom AWS endpoints), so a 401/403 retry re-resolves them.
 
 ## [16.0.0] - 2026-06-15
 

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -49,6 +49,8 @@ export type BedrockThinkingDisplay = "summarized" | "omitted";
 export interface BedrockOptions extends StreamOptions {
 	region?: string;
 	profile?: string;
+	/** Override the Bedrock converse-stream endpoint (e.g. auth gateway or custom proxy). */
+	baseUrl?: string;
 	/** Amazon Bedrock API key sent as `Authorization: Bearer`, ahead of SigV4 credential resolution. */
 	bearerToken?: string;
 	toolChoice?: "auto" | "any" | "none" | { type: "tool"; name: string };
@@ -74,10 +76,223 @@ export interface BedrockOptions extends StreamOptions {
 	thinkingDisplay?: BedrockThinkingDisplay;
 }
 const AUTHENTICATED_API_KEY_SENTINEL = "<authenticated>";
+// Mirrors `ModelRegistry.kNoAuth` in the coding-agent package. The `ai` package
+// cannot import from `coding-agent`, so the literal is duplicated here. A custom
+// `auth: "none"` provider surfaces this sentinel as `options.apiKey`; treating it
+// as a bearer token would send `Authorization: Bearer N/A` to a no-auth endpoint.
+const NO_AUTH_API_KEY_SENTINEL = "N/A";
 
-function resolveBearerToken(options: BedrockOptions): string | undefined {
+const BUNDLED_BEDROCK_PROVIDER = "amazon-bedrock";
+/** Catalog default baked into bundled `amazon-bedrock` entries in models.json. */
+const BUNDLED_BEDROCK_CATALOG_BASE_URL = "https://bedrock-runtime.us-east-1.amazonaws.com";
+
+/** Strip default ports from `URL.host` so SigV4 and AWS-host detection use hostname. */
+function normalizeBedrockHostname(host: string): string {
+	if (host.startsWith("[")) {
+		const end = host.indexOf("]");
+		return end === -1 ? host : host.slice(1, end);
+	}
+	const colon = host.lastIndexOf(":");
+	if (colon === -1) return host;
+	const port = host.slice(colon + 1);
+	if (port === "443" || port === "80") return host.slice(0, colon);
+	return host;
+}
+
+function isAwsHost(host: string): boolean {
+	const hostname = normalizeBedrockHostname(host);
+	return hostname === "amazonaws.com" || hostname.endsWith(".amazonaws.com") || hostname.endsWith(".amazonaws.com.cn");
+}
+
+function normalizeBedrockBaseUrl(baseUrl: string): string {
+	return baseUrl.replace(/\/$/, "");
+}
+
+/**
+ * Merge header sources left-to-right with case-insensitive replacement, so a
+ * later source overrides an earlier same-named header regardless of casing.
+ * Returns lowercase keys (the canonical form fetch and SigV4 signing use).
+ */
+function mergeHeadersCaseInsensitive(...sources: (Record<string, string> | undefined)[]): Record<string, string> {
+	const merged = new Headers();
+	for (const source of sources) {
+		if (!source) continue;
+		for (const [key, value] of Object.entries(source)) merged.set(key, value);
+	}
+	return Object.fromEntries(merged);
+}
+
+/** Hostname (or host:port for non-default ports) for SigV4 signing from a base URL. */
+function bedrockHostFromBaseUrl(baseUrl: string): string {
+	const parsed = new URL(baseUrl);
+	if (!parsed.port || parsed.port === "443") return parsed.hostname;
+	return parsed.host;
+}
+
+/** Extract the AWS region from a Bedrock runtime host, when present. */
+function resolveBedrockSigningRegion(host: string, fallbackRegion: string): string {
+	const hostname = normalizeBedrockHostname(host);
+	if (!isAwsHost(hostname)) return fallbackRegion;
+
+	// bedrock-runtime[(-fips)].{region}.amazonaws.com[.cn]
+	const standard = hostname.match(/^bedrock-runtime(?:-fips)?\.([a-z0-9-]+)\.amazonaws\.com(?:\.cn)?$/);
+	if (standard) return standard[1];
+
+	// VPC endpoints: *bedrock-runtime.{region}.vpce.amazonaws.com[.cn]
+	const vpc = hostname.match(/bedrock-runtime\.([a-z0-9-]+)\.vpce\.amazonaws\.com(?:\.cn)?$/);
+	if (vpc) return vpc[1];
+
+	return fallbackRegion;
+}
+
+/** True when `model.baseUrl` is the bundled catalog default, not a user override. */
+function isBundledCatalogBedrockBaseUrl(model: Model<"bedrock-converse-stream">): boolean {
+	if (model.provider !== BUNDLED_BEDROCK_PROVIDER || !model.baseUrl) return false;
+	return normalizeBedrockBaseUrl(model.baseUrl) === BUNDLED_BEDROCK_CATALOG_BASE_URL;
+}
+
+function resolveBedrockEndpoint(
+	model: Model<"bedrock-converse-stream">,
+	options: BedrockOptions,
+	region: string,
+	urlPath: string,
+): { host: string; url: string } {
+	// Precedence: per-request override > model.baseUrl (unless catalog default) > AWS regional host.
+	if (options.baseUrl) {
+		const baseUrl = normalizeBedrockBaseUrl(options.baseUrl);
+		return { host: bedrockHostFromBaseUrl(baseUrl), url: `${baseUrl}${urlPath}` };
+	}
+
+	if (model.baseUrl && !isBundledCatalogBedrockBaseUrl(model)) {
+		const baseUrl = normalizeBedrockBaseUrl(model.baseUrl);
+		return { host: bedrockHostFromBaseUrl(baseUrl), url: `${baseUrl}${urlPath}` };
+	}
+
+	const host = `bedrock-runtime.${region}.amazonaws.com`;
+	return { host, url: `https://${host}${urlPath}` };
+}
+
+type BedrockAuthMode = "bearer" | "preserved-headers" | "sigv4" | "none";
+
+function resolveBedrockAuthMode(
+	options: BedrockOptions,
+	model: Model<"bedrock-converse-stream">,
+	host: string,
+): BedrockAuthMode {
+	// Precedence: explicit caller/config bearer > no-auth opt-out > caller-supplied
+	// auth header > env bearer fallback > SigV4 for AWS hosts > no auth.
+	//
+	// An explicit bearer wins even for no-auth providers (resolveExplicitBearerToken
+	// honors options.bearerToken under the sentinel), so it is checked before the
+	// sentinel is treated as "no auth".
+	if (resolveExplicitBearerToken(options)) return "bearer";
+	if (options.apiKey === NO_AUTH_API_KEY_SENTINEL) return "none";
+
+	const headerKeys = new Set(
+		[...Object.keys(model.headers ?? {}), ...Object.keys(options.headers ?? {})].map(k => k.toLowerCase()),
+	);
+	if (headerKeys.has("authorization") || headerKeys.has("x-api-key")) return "preserved-headers";
+
+	// AWS_BEARER_TOKEN_BEDROCK is a fallback for plain AWS Bedrock use. It ranks
+	// below caller-supplied auth headers so a custom gateway's configured
+	// Authorization/X-Api-Key is never overwritten by the ambient env token.
+	if (resolveBearerToken(options)) return "bearer";
+
+	if (isAwsHost(host)) return "sigv4";
+	return "none";
+}
+
+async function buildBedrockRequestHeaders(
+	authMode: BedrockAuthMode,
+	baseHeaders: Record<string, string>,
+	options: BedrockOptions,
+	host: string,
+	urlPath: string,
+	body: Uint8Array,
+	region: string,
+): Promise<Record<string, string>> {
+	switch (authMode) {
+		case "bearer": {
+			const bearerToken = resolveBearerToken(options);
+			if (!bearerToken) return baseHeaders;
+			// Replace any existing (differently-cased) authorization header rather
+			// than appending a second one.
+			const merged = new Headers(baseHeaders);
+			merged.set("authorization", `Bearer ${bearerToken}`);
+			return Object.fromEntries(merged);
+		}
+		case "preserved-headers":
+			return baseHeaders;
+		case "sigv4": {
+			let credentials: { accessKeyId: string; secretAccessKey: string; sessionToken?: string };
+			if ($flag("AWS_BEDROCK_SKIP_AUTH")) {
+				credentials = { accessKeyId: "dummy-access-key", secretAccessKey: "dummy-secret-key" };
+			} else {
+				credentials = await resolveAwsCredentials({
+					profile: options.profile,
+					region,
+					signal: options.signal,
+				});
+			}
+			const signed = await signRequest({
+				method: "POST",
+				host,
+				path: urlPath,
+				body,
+				region,
+				service: "bedrock",
+				credentials,
+				headers: baseHeaders,
+			});
+			return { ...baseHeaders, ...signed };
+		}
+		case "none":
+			return baseHeaders;
+	}
+}
+
+/** Caller/config bearer token (request option or apiKey), excluding the env fallback. */
+function resolveExplicitBearerToken(options: BedrockOptions): string | undefined {
+	// No-auth custom providers pass the kNoAuth sentinel; only an explicit
+	// options.bearerToken counts, never the apiKey sentinel itself.
+	if (options.apiKey === NO_AUTH_API_KEY_SENTINEL) return options.bearerToken;
 	const apiKey = options.apiKey === AUTHENTICATED_API_KEY_SENTINEL ? undefined : options.apiKey;
-	return options.bearerToken || apiKey || $env.AWS_BEARER_TOKEN_BEDROCK;
+	return options.bearerToken || apiKey;
+}
+
+/** Bearer token actually sent on the wire: explicit token, else the env fallback (suppressed for no-auth). */
+function resolveBearerToken(options: BedrockOptions): string | undefined {
+	const explicit = resolveExplicitBearerToken(options);
+	if (explicit) return explicit;
+	// No-auth providers never fall back to the ambient env bearer.
+	if (options.apiKey === NO_AUTH_API_KEY_SENTINEL) return undefined;
+	return $env.AWS_BEARER_TOKEN_BEDROCK;
+}
+
+// Bedrock requires tool names to match `[a-zA-Z0-9_-]+`.
+function sanitizeToolName(name: string): string {
+	return name.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+// Maps sanitized wire names back to their original tool names. Only names that
+// actually change under sanitization are recorded, so the dispatcher (which
+// matches `Tool.name`) can resolve tools returned under their sanitized name.
+function buildToolNameReverseMap(tools: Tool[] | undefined): Map<string, string> {
+	const map = new Map<string, string>();
+	const seen = new Map<string, string>();
+	if (!tools) return map;
+	for (const tool of tools) {
+		const wire = sanitizeToolName(tool.name);
+		const existing = seen.get(wire);
+		if (existing !== undefined) {
+			throw new Error(
+				`Bedrock tool name collision after sanitization: "${existing}" and "${tool.name}" both map to "${wire}"`,
+			);
+		}
+		seen.set(wire, tool.name);
+		if (wire !== tool.name) map.set(wire, tool.name);
+	}
+	return map;
 }
 
 type Block = (TextContent | ThinkingContent | ToolCall) & {
@@ -207,6 +422,7 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 		const blocks = output.content as Block[];
 		let rawRequestDump: RawHttpRequestDump | undefined;
 		const region = options.region || $env.AWS_REGION || $env.AWS_DEFAULT_REGION || "us-east-1";
+		let toolNameReverseMap = new Map<string, string>();
 
 		try {
 			const cacheRetention = resolveCacheRetention(options.cacheRetention);
@@ -214,6 +430,12 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 				m => m.role === "toolResult" || (m.role === "assistant" && m.content.some(b => b.type === "toolCall")),
 			);
 			const toolConfig = convertToolConfig(context.tools, options.toolChoice, historyHasToolBlocks);
+			// Build the reverse map (and run the collision preflight) whenever tool specs
+			// are actually sent to Bedrock — keyed off whether convertToolConfig kept them.
+			// This covers the toolChoice:"none" + prior-tool-use path, where the specs are
+			// retained to satisfy Bedrock validation and the model can still echo sanitized
+			// tool names that must map back to their original `Tool.name`.
+			toolNameReverseMap = toolConfig ? buildToolNameReverseMap(context.tools) : new Map();
 			let additionalModelRequestFields = buildAdditionalModelRequestFields(model, options);
 
 			// Bedrock rejects thinking + forced tool_choice ("any" or specific tool).
@@ -236,9 +458,13 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 			};
 			options?.onPayload?.(commandInput);
 
-			const host = `bedrock-runtime.${region}.amazonaws.com`;
-			const url = `https://${host}/model/${encodeURIComponent(model.id)}/converse-stream`;
+			// Endpoint selection is independent of auth. Precedence: per-request
+			// `options.baseUrl` > `model.baseUrl` (unless the bundled catalog default)
+			// > AWS regional host. Registry overrides on `providers.amazon-bedrock.baseUrl`
+			// are honored; only the catalog's us-east-1 placeholder is ignored.
 			const urlPath = `/model/${encodeURIComponent(model.id)}/converse-stream`;
+			const { host, url } = resolveBedrockEndpoint(model, options, region, urlPath);
+			const signingRegion = resolveBedrockSigningRegion(host, region);
 			rawRequestDump = {
 				provider: model.provider,
 				api: output.api,
@@ -250,38 +476,28 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 
 			const bodyText = JSON.stringify(commandInput);
 			const body = new TextEncoder().encode(bodyText);
-			const baseHeaders: Record<string, string> = {
-				"content-type": "application/json",
-				accept: "application/vnd.amazon.eventstream",
-			};
+			// Merge case-insensitively so a differently-cased per-request header
+			// (e.g. `authorization`) overrides the model-level one (`Authorization`)
+			// instead of fetch emitting both as a comma-joined duplicate.
+			const baseHeaders = mergeHeadersCaseInsensitive(
+				{ "content-type": "application/json", accept: "application/vnd.amazon.eventstream" },
+				model.headers,
+				options.headers,
+			);
 
-			const bearerToken = resolveBearerToken(options);
-			let requestHeaders: Record<string, string>;
-			if (bearerToken) {
-				requestHeaders = { ...baseHeaders, Authorization: `Bearer ${bearerToken}` };
-			} else {
-				let credentials: { accessKeyId: string; secretAccessKey: string; sessionToken?: string };
-				if ($flag("AWS_BEDROCK_SKIP_AUTH")) {
-					credentials = { accessKeyId: "dummy-access-key", secretAccessKey: "dummy-secret-key" };
-				} else {
-					credentials = await resolveAwsCredentials({
-						profile: options.profile,
-						region,
-						signal: options.signal,
-					});
-				}
-				const signed = await signRequest({
-					method: "POST",
-					host,
-					path: urlPath,
-					body,
-					region,
-					service: "bedrock",
-					credentials,
-					headers: baseHeaders,
-				});
-				requestHeaders = { ...baseHeaders, ...signed };
-			}
+			// Auth selection is host-based and independent of endpoint. Precedence:
+			// explicit bearer token > caller-supplied auth header (model or per-request,
+			// case-insensitive) > SigV4 for AWS hosts > no auth for custom proxies.
+			const authMode = resolveBedrockAuthMode(options, model, host);
+			const requestHeaders = await buildBedrockRequestHeaders(
+				authMode,
+				baseHeaders,
+				options,
+				host,
+				urlPath,
+				body,
+				signingRegion,
+			);
 
 			// Bun's native fetch ceiling is disabled below (`timeout: false`) so
 			// configurable watchdogs govern slow-prefill streams (issue #2422).
@@ -309,10 +525,12 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 			});
 
 			if (!response.ok) {
-				if (!bearerToken && (response.status === 401 || response.status === 403)) {
+				if (!resolveBearerToken(options) && (response.status === 401 || response.status === 403)) {
 					// Stale cached credentials (e.g. rotated session keys in ~/.aws/credentials) —
-					// drop the cache entry so the next attempt re-resolves from scratch.
-					invalidateAwsCredentialCache({ profile: options.profile, region });
+					// drop the cache entry so the next attempt re-resolves from scratch. Credentials
+					// were cached under `signingRegion` (the host's region for custom AWS endpoints),
+					// so invalidate that key rather than the fallback `region`.
+					invalidateAwsCredentialCache({ profile: options.profile, region: signingRegion });
 				}
 				const errBody = await response.text().catch(() => "");
 				throw new BedrockApiError(`Bedrock HTTP ${response.status}: ${errBody.slice(0, 1000)}`, response.status, {
@@ -357,7 +575,13 @@ export const streamBedrock: StreamFunction<"bedrock-converse-stream"> = (
 					}
 					case "contentBlockStart": {
 						if (!firstTokenTime) firstTokenTime = Date.now();
-						handleContentBlockStart(payload as ContentBlockStartEvent, blocks, output, stream);
+						handleContentBlockStart(
+							payload as ContentBlockStartEvent,
+							blocks,
+							output,
+							stream,
+							toolNameReverseMap,
+						);
 						break;
 					}
 					case "contentBlockDelta": {
@@ -450,15 +674,19 @@ function handleContentBlockStart(
 	blocks: Block[],
 	output: AssistantMessage,
 	stream: AssistantMessageEventStream,
+	toolNameReverseMap: Map<string, string>,
 ): void {
 	const index = event.contentBlockIndex;
 	const start = event.start;
 
 	if (start?.toolUse) {
+		// Bedrock echoes the sanitized wire name; restore the original so the
+		// agent dispatcher (which matches `Tool.name`) can resolve the tool.
+		const wireName = start.toolUse.name || "";
 		const block: Block = {
 			type: "toolCall",
 			id: normalizeToolCallId(start.toolUse.toolUseId || ""),
-			name: start.toolUse.name || "",
+			name: toolNameReverseMap.get(wireName) ?? wireName,
 			arguments: {},
 			partialJson: "",
 			index,
@@ -602,7 +830,7 @@ function supportsPromptCaching(model: Model<"bedrock-converse-stream">): boolean
  */
 function supportsThinkingSignature(model: Model<"bedrock-converse-stream">): boolean {
 	const id = model.id.toLowerCase();
-	return id.includes("anthropic.claude") || id.includes("anthropic/claude");
+	return id.includes("anthropic.claude") || id.includes("anthropic/claude") || id.startsWith("claude-");
 }
 
 function buildSystemPrompt(
@@ -681,7 +909,7 @@ function convertMessages(
 							contentBlocks.push({
 								toolUse: {
 									toolUseId: normalizeToolCallId(c.id),
-									name: c.name,
+									name: sanitizeToolName(c.name),
 									input: c.arguments,
 								},
 							});
@@ -781,7 +1009,7 @@ function convertToolConfig(
 
 	const bedrockTools: WireToolSpec[] = tools.map(tool => ({
 		toolSpec: {
-			name: tool.name,
+			name: sanitizeToolName(tool.name),
 			description: tool.description || "",
 			inputSchema: { json: toolWireSchema(tool) },
 		},
@@ -804,7 +1032,7 @@ function convertToolConfig(
 			break;
 		default:
 			if (toolChoice?.type === "tool") {
-				bedrockToolChoice = { tool: { name: toolChoice.name } };
+				bedrockToolChoice = { tool: { name: sanitizeToolName(toolChoice.name) } };
 			}
 	}
 

--- a/packages/ai/test/aws-bedrock-custom-endpoint.test.ts
+++ b/packages/ai/test/aws-bedrock-custom-endpoint.test.ts
@@ -1,0 +1,920 @@
+import { describe, expect, it } from "bun:test";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+import type { ModelSpec } from "@oh-my-pi/pi-catalog/types";
+import type { AssistantMessage, Context, FetchImpl, Model, Tool } from "../src";
+import { streamBedrock } from "../src/providers/amazon-bedrock";
+import { clearAwsCredentialCache } from "../src/providers/aws-credentials";
+import { eventFrame, eventStreamResponse, snapshotAwsEnv } from "./helpers";
+
+async function captureBedrockResult(
+	model: Model<"bedrock-converse-stream">,
+	context: Context,
+	frames: Uint8Array[],
+): Promise<AssistantMessage> {
+	const fetchMock: FetchImpl = async () => eventStreamResponse(frames);
+	return await streamBedrock(model, context, { fetch: fetchMock }).result();
+}
+
+function abortedSignal(): AbortSignal {
+	const controller = new AbortController();
+	controller.abort();
+	return controller.signal;
+}
+
+function baseModel(overrides: Partial<ModelSpec<"bedrock-converse-stream">> = {}): Model<"bedrock-converse-stream"> {
+	return buildModel({
+		id: "claude-sonnet-4",
+		name: "Claude Sonnet 4",
+		api: "bedrock-converse-stream",
+		provider: "amazon-bedrock",
+		baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com",
+		reasoning: false,
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 8_192,
+		...overrides,
+	});
+}
+
+const baseContext: Context = {
+	systemPrompt: [],
+	messages: [{ role: "user", content: "say hi", timestamp: Date.now() }],
+};
+
+interface BedrockPayload {
+	messages?: Array<{
+		role: string;
+		content?: Array<Record<string, unknown>>;
+	}>;
+	toolConfig?: {
+		tools?: Array<{ toolSpec: { name: string } }>;
+		toolChoice?: { tool?: { name: string } };
+	};
+}
+
+interface CapturedRequest {
+	url: string;
+	headers: Headers;
+	payload: BedrockPayload;
+}
+
+async function captureBedrockRequest(
+	model: Model<"bedrock-converse-stream">,
+	context: Context = baseContext,
+	options: Parameters<typeof streamBedrock>[2] = {},
+): Promise<CapturedRequest> {
+	let capturedUrl = "";
+	let capturedHeaders: Headers | undefined;
+	let capturedPayload: BedrockPayload = {};
+	const fetchMock: FetchImpl = async (input, init) => {
+		capturedUrl = String(input);
+		capturedHeaders = new Headers(init?.headers);
+		return new Response('{"message":"unauthorized"}', { status: 401 });
+	};
+
+	await streamBedrock(model, context, {
+		...options,
+		fetch: fetchMock,
+		onPayload: payload => {
+			capturedPayload = payload as BedrockPayload;
+		},
+	}).result();
+
+	expect(capturedHeaders).toBeDefined();
+	return { url: capturedUrl, headers: capturedHeaders!, payload: capturedPayload };
+}
+
+async function captureBedrockPayload(
+	model: Model<"bedrock-converse-stream">,
+	context: Context = baseContext,
+	options: Parameters<typeof streamBedrock>[2] = {},
+): Promise<BedrockPayload> {
+	const { promise, resolve } = Promise.withResolvers<BedrockPayload>();
+	void streamBedrock(model, context, {
+		signal: abortedSignal(),
+		...options,
+		onPayload: payload => {
+			resolve(payload as BedrockPayload);
+		},
+	});
+	return promise;
+}
+
+function assistantStub(
+	content: AssistantMessage["content"],
+	overrides: Partial<AssistantMessage> = {},
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "bedrock-converse-stream",
+		provider: "amazon-bedrock",
+		model: "claude-sonnet-4",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop",
+		timestamp: Date.now(),
+		...overrides,
+	};
+}
+
+const fooBarTool: Tool = {
+	name: "foo.bar",
+	description: "demo tool",
+	parameters: {
+		type: "object",
+		properties: {},
+	} as unknown as Tool["parameters"],
+};
+
+describe("amazon-bedrock custom endpoint routing", () => {
+	describe("default bundled AWS routing", () => {
+		it("ignores bundled amazonaws.com model.baseUrl and uses options.region for SigV4 host", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				Bun.env.AWS_BEDROCK_SKIP_AUTH = "1";
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				Bun.env.AWS_REGION = "us-east-1";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(
+					baseModel({ baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com" }),
+					baseContext,
+					{ region: "eu-west-1" },
+				);
+
+				expect(request.url).toBe(
+					"https://bedrock-runtime.eu-west-1.amazonaws.com/model/claude-sonnet-4/converse-stream",
+				);
+				expect(request.headers.get("authorization")).toStartWith("AWS4-HMAC-SHA256 ");
+				expect(request.headers.has("x-amz-date")).toBe(true);
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("uses options.baseUrl override when model.baseUrl is bundled AWS", async () => {
+			const request = await captureBedrockRequest(
+				baseModel({ baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com" }),
+				baseContext,
+				{ baseUrl: "https://gateway.example.com" },
+			);
+
+			expect(request.url).toBe("https://gateway.example.com/model/claude-sonnet-4/converse-stream");
+		});
+
+		it("signs default AWS requests with SigV4 when no custom auth is configured", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				Bun.env.AWS_BEDROCK_SKIP_AUTH = "1";
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				Bun.env.AWS_REGION = "us-west-2";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(baseModel());
+
+				expect(request.url).toBe(
+					"https://bedrock-runtime.us-west-2.amazonaws.com/model/claude-sonnet-4/converse-stream",
+				);
+				expect(request.headers.get("authorization")).toStartWith("AWS4-HMAC-SHA256 ");
+				expect(request.headers.has("x-amz-date")).toBe(true);
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("honors providers.amazon-bedrock baseUrl override on bundled models", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_ACCESS_KEY_ID;
+				delete Bun.env.AWS_SECRET_ACCESS_KEY;
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				Bun.env.AWS_BEDROCK_SKIP_AUTH = "1";
+				Bun.env.AWS_EC2_METADATA_DISABLED = "true";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(
+					baseModel({
+						provider: "amazon-bedrock",
+						baseUrl: "https://bedrock-proxy.example.com",
+					}),
+				);
+
+				expect(request.url).toBe("https://bedrock-proxy.example.com/model/claude-sonnet-4/converse-stream");
+				expect(request.headers.get("authorization")).toBeNull();
+				expect(request.headers.has("x-amz-date")).toBe(false);
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("preserves provider headers auth on bundled amazon-bedrock baseUrl override", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_ACCESS_KEY_ID;
+				delete Bun.env.AWS_SECRET_ACCESS_KEY;
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				Bun.env.AWS_BEDROCK_SKIP_AUTH = "1";
+				Bun.env.AWS_EC2_METADATA_DISABLED = "true";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(
+					baseModel({
+						provider: "amazon-bedrock",
+						baseUrl: "https://bedrock-proxy.example.com",
+						headers: { Authorization: "Bearer gateway-token" },
+					}),
+				);
+
+				expect(request.url).toBe("https://bedrock-proxy.example.com/model/claude-sonnet-4/converse-stream");
+				expect(request.headers.get("authorization")).toBe("Bearer gateway-token");
+				expect(request.headers.has("x-amz-date")).toBe(false);
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+	});
+
+	describe("custom provider endpoint routing", () => {
+		it("uses custom model.baseUrl verbatim", async () => {
+			const request = await captureBedrockRequest(
+				baseModel({
+					provider: "custom-bedrock",
+					baseUrl: "https://custom-bedrock.example.com/v1",
+				}),
+			);
+
+			expect(request.url).toBe("https://custom-bedrock.example.com/v1/model/claude-sonnet-4/converse-stream");
+		});
+
+		it("strips trailing slash from custom model.baseUrl", async () => {
+			const request = await captureBedrockRequest(
+				baseModel({
+					provider: "custom-bedrock",
+					baseUrl: "https://custom-bedrock.example.com/",
+				}),
+			);
+
+			expect(request.url).toBe("https://custom-bedrock.example.com/model/claude-sonnet-4/converse-stream");
+		});
+
+		it("encodes model id in the converse-stream path", async () => {
+			const request = await captureBedrockRequest(
+				baseModel({
+					id: "anthropic/claude:sonnet",
+					provider: "custom-bedrock",
+					baseUrl: "https://custom-bedrock.example.com/v1",
+				}),
+			);
+
+			expect(request.url).toBe(
+				`https://custom-bedrock.example.com/v1/model/${encodeURIComponent("anthropic/claude:sonnet")}/converse-stream`,
+			);
+		});
+
+		it("preserves custom regional AWS Bedrock model.baseUrl", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				Bun.env.AWS_BEDROCK_SKIP_AUTH = "1";
+				Bun.env.AWS_REGION = "us-east-1";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(
+					baseModel({
+						provider: "custom-bedrock",
+						baseUrl: "https://bedrock-runtime.eu-west-1.amazonaws.com",
+					}),
+				);
+
+				expect(request.url).toBe(
+					"https://bedrock-runtime.eu-west-1.amazonaws.com/model/claude-sonnet-4/converse-stream",
+				);
+				const authorization = request.headers.get("authorization");
+				expect(authorization).toStartWith("AWS4-HMAC-SHA256 ");
+				expect(authorization).toContain("/eu-west-1/bedrock/");
+				expect(authorization).not.toContain("/us-east-1/bedrock/");
+				expect(request.headers.has("x-amz-date")).toBe(true);
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("signs FIPS Bedrock endpoint overrides with the host region", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				Bun.env.AWS_BEDROCK_SKIP_AUTH = "1";
+				Bun.env.AWS_REGION = "us-east-1";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(baseModel(), baseContext, {
+					baseUrl: "https://bedrock-runtime-fips.us-gov-west-1.amazonaws.com",
+				});
+
+				expect(request.url).toBe(
+					"https://bedrock-runtime-fips.us-gov-west-1.amazonaws.com/model/claude-sonnet-4/converse-stream",
+				);
+				const authorization = request.headers.get("authorization");
+				expect(authorization).toStartWith("AWS4-HMAC-SHA256 ");
+				expect(authorization).toContain("/us-gov-west-1/bedrock/");
+				expect(authorization).not.toContain("/us-east-1/bedrock/");
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("signs AWS Bedrock endpoints with explicit :443 port", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				Bun.env.AWS_BEDROCK_SKIP_AUTH = "1";
+				Bun.env.AWS_REGION = "us-east-1";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(
+					baseModel({
+						provider: "custom-bedrock",
+						baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com:443",
+					}),
+				);
+
+				expect(request.url).toBe(
+					"https://bedrock-runtime.us-east-1.amazonaws.com:443/model/claude-sonnet-4/converse-stream",
+				);
+				const authorization = request.headers.get("authorization");
+				expect(authorization).toStartWith("AWS4-HMAC-SHA256 ");
+				expect(authorization).toContain("/us-east-1/bedrock/");
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("signs AWS China Bedrock endpoints with SigV4", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				Bun.env.AWS_BEDROCK_SKIP_AUTH = "1";
+				Bun.env.AWS_REGION = "us-east-1";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(
+					baseModel({
+						provider: "custom-bedrock",
+						baseUrl: "https://bedrock-runtime.cn-north-1.amazonaws.com.cn",
+					}),
+				);
+
+				expect(request.url).toBe(
+					"https://bedrock-runtime.cn-north-1.amazonaws.com.cn/model/claude-sonnet-4/converse-stream",
+				);
+				const authorization = request.headers.get("authorization");
+				expect(authorization).toStartWith("AWS4-HMAC-SHA256 ");
+				expect(authorization).toContain("/cn-north-1/bedrock/");
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+	});
+
+	describe("custom auth and headers", () => {
+		it("skips SigV4 when model.headers include X-Api-Key", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_ACCESS_KEY_ID;
+				delete Bun.env.AWS_SECRET_ACCESS_KEY;
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				Bun.env.AWS_BEDROCK_SKIP_AUTH = "1";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(
+					baseModel({
+						provider: "custom-bedrock",
+						baseUrl: "https://custom-bedrock.example.com",
+						headers: { "X-Api-Key": "secret-key" },
+					}),
+				);
+
+				expect(request.headers.has("x-amz-date")).toBe(false);
+				expect(request.headers.get("x-api-key")).toBe("secret-key");
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("preserves custom auth headers over the AWS_BEARER_TOKEN_BEDROCK env fallback", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_ACCESS_KEY_ID;
+				delete Bun.env.AWS_SECRET_ACCESS_KEY;
+				delete Bun.env.AWS_BEDROCK_SKIP_AUTH;
+				Bun.env.AWS_BEARER_TOKEN_BEDROCK = "ambient-env-token";
+				Bun.env.AWS_EC2_METADATA_DISABLED = "true";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(
+					baseModel({
+						provider: "custom-bedrock",
+						baseUrl: "https://custom-bedrock.example.com",
+						headers: { Authorization: "Bearer gateway-token" },
+					}),
+				);
+
+				expect(request.headers.get("authorization")).toBe("Bearer gateway-token");
+				expect(request.headers.has("x-amz-date")).toBe(false);
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("skips SigV4 when model.headers use lowercase authorization", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_ACCESS_KEY_ID;
+				delete Bun.env.AWS_SECRET_ACCESS_KEY;
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				Bun.env.AWS_BEDROCK_SKIP_AUTH = "1";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(
+					baseModel({
+						provider: "custom-bedrock",
+						baseUrl: "https://custom-bedrock.example.com",
+						headers: { authorization: "Bearer custom" },
+					}),
+				);
+
+				expect(request.headers.has("x-amz-date")).toBe(false);
+				expect(request.headers.get("authorization")).toBe("Bearer custom");
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("overrides a model auth header with a differently-cased per-request header", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_ACCESS_KEY_ID;
+				delete Bun.env.AWS_SECRET_ACCESS_KEY;
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				Bun.env.AWS_BEDROCK_SKIP_AUTH = "1";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(
+					baseModel({
+						provider: "custom-bedrock",
+						baseUrl: "https://custom-bedrock.example.com",
+						headers: { Authorization: "Bearer model-token" },
+					}),
+					baseContext,
+					{ headers: { authorization: "Bearer request-token" } },
+				);
+
+				// Single, replaced value — not the comma-joined "Bearer model-token, Bearer request-token".
+				expect(request.headers.get("authorization")).toBe("Bearer request-token");
+				expect(request.headers.has("x-amz-date")).toBe(false);
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("skips SigV4 for no-auth custom endpoint (no bearer, no headers)", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_ACCESS_KEY_ID;
+				delete Bun.env.AWS_SECRET_ACCESS_KEY;
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				delete Bun.env.AWS_BEDROCK_SKIP_AUTH;
+				Bun.env.AWS_EC2_METADATA_DISABLED = "true";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(
+					baseModel({
+						provider: "custom-bedrock",
+						baseUrl: "https://custom-bedrock.example.com",
+					}),
+				);
+
+				expect(request.headers.has("x-amz-date")).toBe(false);
+				expect(request.headers.has("authorization")).toBe(false);
+				expect(request.url).toBe("https://custom-bedrock.example.com/model/claude-sonnet-4/converse-stream");
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("merges options.headers into request headers", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_ACCESS_KEY_ID;
+				delete Bun.env.AWS_SECRET_ACCESS_KEY;
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				delete Bun.env.AWS_BEDROCK_SKIP_AUTH;
+				Bun.env.AWS_EC2_METADATA_DISABLED = "true";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(
+					baseModel({
+						provider: "custom-bedrock",
+						baseUrl: "https://custom-bedrock.example.com",
+					}),
+					baseContext,
+					{ headers: { "X-Request-Id": "req-123", "X-Tenant": "acme" } },
+				);
+
+				expect(request.headers.get("x-request-id")).toBe("req-123");
+				expect(request.headers.get("x-tenant")).toBe("acme");
+				expect(request.headers.has("x-amz-date")).toBe(false);
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("merges bearer apiKey with custom model headers", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_ACCESS_KEY_ID;
+				delete Bun.env.AWS_SECRET_ACCESS_KEY;
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				Bun.env.AWS_BEDROCK_SKIP_AUTH = "1";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(
+					baseModel({
+						provider: "custom-bedrock",
+						baseUrl: "https://custom-bedrock.example.com",
+						headers: { "X-Custom": "value" },
+					}),
+					baseContext,
+					{ apiKey: "bedrock-token" },
+				);
+
+				expect(request.headers.get("authorization")).toBe("Bearer bedrock-token");
+				expect(request.headers.get("x-custom")).toBe("value");
+				expect(request.headers.has("x-amz-date")).toBe(false);
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("prefers bearer auth over SigV4 when AWS credentials are also available", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				Bun.env.AWS_BEDROCK_SKIP_AUTH = "1";
+				Bun.env.AWS_BEARER_TOKEN_BEDROCK = "bedrock-api-key";
+				Bun.env.AWS_REGION = "us-west-2";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(baseModel());
+
+				expect(request.headers.get("authorization")).toBe("Bearer bedrock-api-key");
+				expect(request.headers.has("x-amz-date")).toBe(false);
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+	});
+
+	describe("endpoint and auth decoupling", () => {
+		it("signs AWS endpoint overrides (FIPS) with SigV4", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				Bun.env.AWS_BEDROCK_SKIP_AUTH = "1";
+				Bun.env.AWS_REGION = "us-east-1";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(baseModel(), baseContext, {
+					baseUrl: "https://bedrock-runtime-fips.us-east-1.amazonaws.com",
+				});
+
+				expect(request.url).toBe(
+					"https://bedrock-runtime-fips.us-east-1.amazonaws.com/model/claude-sonnet-4/converse-stream",
+				);
+				expect(request.headers.get("authorization")).toStartWith("AWS4-HMAC-SHA256 ");
+				expect(request.headers.has("x-amz-date")).toBe(true);
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("prefers options.baseUrl over a custom model.baseUrl", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				delete Bun.env.AWS_BEDROCK_SKIP_AUTH;
+				Bun.env.AWS_EC2_METADATA_DISABLED = "true";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(
+					baseModel({ provider: "custom-bedrock", baseUrl: "https://model-endpoint.example.com" }),
+					baseContext,
+					{ baseUrl: "https://override.example.com" },
+				);
+
+				expect(request.url).toBe("https://override.example.com/model/claude-sonnet-4/converse-stream");
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("honors options.headers authorization and skips SigV4 on AWS hosts", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				delete Bun.env.AWS_BEDROCK_SKIP_AUTH;
+				Bun.env.AWS_REGION = "us-east-1";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(baseModel(), baseContext, {
+					headers: { authorization: "Bearer per-request" },
+				});
+
+				expect(request.headers.get("authorization")).toBe("Bearer per-request");
+				expect(request.headers.has("x-amz-date")).toBe(false);
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("sends no Authorization for a no-auth (kNoAuth) custom endpoint", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_ACCESS_KEY_ID;
+				delete Bun.env.AWS_SECRET_ACCESS_KEY;
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				delete Bun.env.AWS_BEDROCK_SKIP_AUTH;
+				Bun.env.AWS_EC2_METADATA_DISABLED = "true";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(
+					baseModel({ provider: "custom-bedrock", baseUrl: "https://custom-bedrock.example.com" }),
+					baseContext,
+					{ apiKey: "N/A" },
+				);
+
+				expect(request.headers.has("authorization")).toBe(false);
+				expect(request.headers.has("x-amz-date")).toBe(false);
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("honors an explicit bearerToken even when the kNoAuth sentinel is present", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_ACCESS_KEY_ID;
+				delete Bun.env.AWS_SECRET_ACCESS_KEY;
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				delete Bun.env.AWS_BEDROCK_SKIP_AUTH;
+				Bun.env.AWS_EC2_METADATA_DISABLED = "true";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(
+					baseModel({ provider: "custom-bedrock", baseUrl: "https://custom-bedrock.example.com" }),
+					baseContext,
+					{ apiKey: "N/A", bearerToken: "explicit-gateway-token" },
+				);
+
+				expect(request.headers.get("authorization")).toBe("Bearer explicit-gateway-token");
+				expect(request.headers.has("x-amz-date")).toBe(false);
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("ignores AWS_BEARER_TOKEN_BEDROCK when kNoAuth sentinel is present", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_ACCESS_KEY_ID;
+				delete Bun.env.AWS_SECRET_ACCESS_KEY;
+				delete Bun.env.AWS_BEDROCK_SKIP_AUTH;
+				Bun.env.AWS_BEARER_TOKEN_BEDROCK = "bedrock-api-key";
+				Bun.env.AWS_EC2_METADATA_DISABLED = "true";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(
+					baseModel({ provider: "custom-bedrock", baseUrl: "https://custom-bedrock.example.com" }),
+					baseContext,
+					{ apiKey: "N/A" },
+				);
+
+				expect(request.headers.has("authorization")).toBe(false);
+				expect(request.headers.has("x-amz-date")).toBe(false);
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("skips SigV4 for kNoAuth even when baseUrl is an AWS hostname", async () => {
+			const restoreAwsEnv = snapshotAwsEnv();
+			try {
+				delete Bun.env.AWS_ACCESS_KEY_ID;
+				delete Bun.env.AWS_SECRET_ACCESS_KEY;
+				delete Bun.env.AWS_BEARER_TOKEN_BEDROCK;
+				delete Bun.env.AWS_BEDROCK_SKIP_AUTH;
+				Bun.env.AWS_EC2_METADATA_DISABLED = "true";
+				clearAwsCredentialCache();
+
+				const request = await captureBedrockRequest(
+					baseModel({
+						provider: "custom-bedrock",
+						baseUrl: "https://abc123.execute-api.us-east-1.amazonaws.com",
+					}),
+					baseContext,
+					{ apiKey: "N/A" },
+				);
+
+				expect(request.url).toStartWith("https://abc123.execute-api.us-east-1.amazonaws.com/");
+				expect(request.headers.has("authorization")).toBe(false);
+				expect(request.headers.has("x-amz-date")).toBe(false);
+			} finally {
+				restoreAwsEnv();
+			}
+		});
+
+		it("maps sanitized tool names back to the original on receive", async () => {
+			const context: Context = { ...baseContext, tools: [fooBarTool] };
+			const frames = [
+				eventFrame("messageStart", { role: "assistant" }),
+				eventFrame("contentBlockStart", {
+					contentBlockIndex: 0,
+					start: { toolUse: { toolUseId: "toolu_01", name: "foo_bar" } },
+				}),
+				eventFrame("contentBlockDelta", { contentBlockIndex: 0, delta: { toolUse: { input: "{}" } } }),
+				eventFrame("contentBlockStop", { contentBlockIndex: 0 }),
+				eventFrame("messageStop", { stopReason: "tool_use" }),
+			];
+
+			const result = await captureBedrockResult(
+				baseModel({ provider: "custom-bedrock", baseUrl: "https://custom-bedrock.example.com" }),
+				context,
+				frames,
+			);
+
+			const toolCall = result.content.find(block => block.type === "toolCall");
+			expect(toolCall?.type).toBe("toolCall");
+			if (toolCall?.type === "toolCall") expect(toolCall.name).toBe("foo.bar");
+		});
+
+		it("maps sanitized tool names back when toolChoice is none but history has tool use", async () => {
+			// toolChoice:"none" still ships tool specs when history has prior tool use, so a
+			// returned sanitized name must round-trip back to the original tool name.
+			const context: Context = {
+				systemPrompt: [],
+				tools: [fooBarTool],
+				messages: [
+					{ role: "user", content: "call the tool", timestamp: Date.now() },
+					assistantStub([{ type: "toolCall", id: "toolu_prev", name: "foo.bar", arguments: {} }]),
+					{
+						role: "toolResult",
+						toolCallId: "toolu_prev",
+						toolName: "foo.bar",
+						content: [{ type: "text", text: "ok" }],
+						isError: false,
+						timestamp: Date.now(),
+					},
+				],
+			};
+			const frames = [
+				eventFrame("messageStart", { role: "assistant" }),
+				eventFrame("contentBlockStart", {
+					contentBlockIndex: 0,
+					start: { toolUse: { toolUseId: "toolu_02", name: "foo_bar" } },
+				}),
+				eventFrame("contentBlockDelta", { contentBlockIndex: 0, delta: { toolUse: { input: "{}" } } }),
+				eventFrame("contentBlockStop", { contentBlockIndex: 0 }),
+				eventFrame("messageStop", { stopReason: "tool_use" }),
+			];
+
+			const fetchMock: FetchImpl = async () => eventStreamResponse(frames);
+			const result = await streamBedrock(
+				baseModel({ provider: "custom-bedrock", baseUrl: "https://custom-bedrock.example.com" }),
+				context,
+				{ toolChoice: "none", fetch: fetchMock },
+			).result();
+
+			const toolCall = result.content.find(block => block.type === "toolCall");
+			expect(toolCall?.type).toBe("toolCall");
+			if (toolCall?.type === "toolCall") expect(toolCall.name).toBe("foo.bar");
+		});
+	});
+
+	describe("payload conversion", () => {
+		it("sanitizes tool definitions for Bedrock wire format", async () => {
+			const context: Context = {
+				...baseContext,
+				tools: [fooBarTool],
+			};
+
+			const payload = await captureBedrockPayload(baseModel(), context, {
+				toolChoice: { type: "tool", name: "foo.bar" },
+			});
+
+			expect(payload.toolConfig?.tools?.[0]?.toolSpec.name).toBe("foo_bar");
+			expect(payload.toolConfig?.toolChoice?.tool?.name).toBe("foo_bar");
+		});
+
+		it("rejects colliding sanitized tool names before sending", async () => {
+			const context: Context = {
+				...baseContext,
+				tools: [
+					fooBarTool,
+					{
+						...fooBarTool,
+						name: "foo/bar",
+					},
+				],
+			};
+
+			const result = await streamBedrock(baseModel(), context, {}).result();
+
+			expect(result.stopReason).toBe("error");
+			expect(result.errorMessage).toContain(
+				'Bedrock tool name collision after sanitization: "foo.bar" and "foo/bar" both map to "foo_bar"',
+			);
+		});
+		it("skips tool-name collision checks when toolChoice is none", async () => {
+			const context: Context = {
+				...baseContext,
+				tools: [
+					fooBarTool,
+					{
+						...fooBarTool,
+						name: "foo/bar",
+					},
+				],
+			};
+
+			const payload = await captureBedrockPayload(baseModel(), context, { toolChoice: "none" });
+
+			expect(payload.toolConfig).toBeUndefined();
+		});
+
+		it("sanitizes assistant tool replay names in message history", async () => {
+			const context: Context = {
+				systemPrompt: [],
+				messages: [
+					{ role: "user", content: "call the tool", timestamp: Date.now() },
+					assistantStub([{ type: "toolCall", id: "toolu_01", name: "foo.bar", arguments: { x: 1 } }]),
+				],
+			};
+
+			const payload = await captureBedrockPayload(baseModel(), context);
+			const assistantMessage = payload.messages?.find(message => message.role === "assistant");
+			const toolUse = assistantMessage?.content?.find(block => "toolUse" in block) as
+				| { toolUse: { name: string } }
+				| undefined;
+
+			expect(toolUse?.toolUse.name).toBe("foo_bar");
+		});
+
+		it("keeps bare claude-* thinking blocks as reasoningContent when signature is present", async () => {
+			const context: Context = {
+				systemPrompt: [],
+				messages: [
+					{ role: "user", content: "think", timestamp: Date.now() },
+					assistantStub(
+						[
+							{ type: "thinking", thinking: "internal reasoning", thinkingSignature: "sig-123" },
+							{ type: "text", text: "answer" },
+						],
+						{
+							provider: "custom-bedrock",
+							api: "bedrock-converse-stream",
+							model: "claude-sonnet-4",
+						},
+					),
+				],
+			};
+
+			const payload = await captureBedrockPayload(
+				baseModel({
+					id: "claude-sonnet-4",
+					provider: "custom-bedrock",
+					baseUrl: "https://custom-bedrock.example.com",
+				}),
+				context,
+			);
+
+			const assistantMessage = payload.messages?.find(message => message.role === "assistant");
+			const reasoningBlock = assistantMessage?.content?.find(block => "reasoningContent" in block) as
+				| { reasoningContent: { reasoningText: { text: string; signature?: string } } }
+				| undefined;
+			const textBlock = assistantMessage?.content?.find(block => "text" in block) as { text: string } | undefined;
+
+			expect(reasoningBlock?.reasoningContent.reasoningText).toMatchObject({
+				text: "internal reasoning",
+				signature: "sig-123",
+			});
+			expect(textBlock?.text).toBe("answer");
+		});
+	});
+});

--- a/packages/ai/test/aws-eventstream.test.ts
+++ b/packages/ai/test/aws-eventstream.test.ts
@@ -1,62 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { crc32, decodeEventStream, decodeMessage } from "@oh-my-pi/pi-ai/providers/aws-eventstream";
-
-// ---- Frame builder (mirrors @smithy/eventstream-codec but in-process so the
-// test owns the bytes). The decoder is the production code; we encode here for
-// fixture generation only.
-
-function encodeStringHeader(name: string, value: string): Uint8Array {
-	const nameBytes = new TextEncoder().encode(name);
-	const valueBytes = new TextEncoder().encode(value);
-	if (nameBytes.length > 255) throw new Error("name too long");
-	const buf = new Uint8Array(1 + nameBytes.length + 1 + 2 + valueBytes.length);
-	const view = new DataView(buf.buffer);
-	let p = 0;
-	view.setUint8(p, nameBytes.length);
-	p += 1;
-	buf.set(nameBytes, p);
-	p += nameBytes.length;
-	view.setUint8(p, 7); // string type
-	p += 1;
-	view.setUint16(p, valueBytes.length, false);
-	p += 2;
-	buf.set(valueBytes, p);
-	return buf;
-}
-
-function encodeFrame(headers: Record<string, string>, payload: Uint8Array): Uint8Array {
-	const headerChunks: Uint8Array[] = [];
-	for (const name in headers) headerChunks.push(encodeStringHeader(name, headers[name]));
-	const headerLen = headerChunks.reduce((s, c) => s + c.length, 0);
-	const headerBytes = new Uint8Array(headerLen);
-	let off = 0;
-	for (const c of headerChunks) {
-		headerBytes.set(c, off);
-		off += c.length;
-	}
-	const total = 4 + 4 + 4 + headerLen + payload.length + 4;
-	const out = new Uint8Array(total);
-	const view = new DataView(out.buffer);
-	view.setUint32(0, total, false);
-	view.setUint32(4, headerLen, false);
-	const preludeCrc = crc32(out.subarray(0, 8));
-	view.setUint32(8, preludeCrc, false);
-	out.set(headerBytes, 12);
-	out.set(payload, 12 + headerLen);
-	const msgCrc = crc32(out.subarray(0, total - 4));
-	view.setUint32(total - 4, msgCrc, false);
-	return out;
-}
-
-function streamFrom(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
-	let i = 0;
-	return new ReadableStream({
-		pull(controller) {
-			if (i < chunks.length) controller.enqueue(chunks[i++]);
-			else controller.close();
-		},
-	});
-}
+import { encodeFrame, streamFrom } from "./helpers";
 
 async function collect(
 	stream: ReadableStream<Uint8Array>,

--- a/packages/ai/test/helpers/aws-env.ts
+++ b/packages/ai/test/helpers/aws-env.ts
@@ -1,0 +1,35 @@
+import { clearAwsCredentialCache } from "@oh-my-pi/pi-ai/providers/aws-credentials";
+
+/** AWS env vars that influence Bedrock credential/endpoint resolution. */
+export const awsEnvKeys = [
+	"AWS_ACCESS_KEY_ID",
+	"AWS_SECRET_ACCESS_KEY",
+	"AWS_SESSION_TOKEN",
+	"AWS_PROFILE",
+	"AWS_REGION",
+	"AWS_DEFAULT_REGION",
+	"AWS_CONFIG_FILE",
+	"AWS_SHARED_CREDENTIALS_FILE",
+	"AWS_EC2_METADATA_DISABLED",
+	"AWS_BEARER_TOKEN_BEDROCK",
+	"AWS_BEDROCK_SKIP_AUTH",
+] as const;
+
+/**
+ * Snapshots the AWS env vars and returns a restore function. Tests mutate
+ * `Bun.env` within a `try` and call the returned restorer in `finally` so the
+ * mutation never leaks into other files. Also clears the credential cache so a
+ * later test does not observe a stale resolution.
+ */
+export function snapshotAwsEnv(): () => void {
+	const previous = new Map<string, string | undefined>();
+	for (const key of awsEnvKeys) previous.set(key, Bun.env[key]);
+	return () => {
+		for (const key of awsEnvKeys) {
+			const value = previous.get(key);
+			if (value === undefined) delete Bun.env[key];
+			else Bun.env[key] = value;
+		}
+		clearAwsCredentialCache();
+	};
+}

--- a/packages/ai/test/helpers/aws-eventstream.ts
+++ b/packages/ai/test/helpers/aws-eventstream.ts
@@ -1,0 +1,71 @@
+import { crc32 } from "@oh-my-pi/pi-ai/providers/aws-eventstream";
+
+// `application/vnd.amazon.eventstream` frame builder. Mirrors the codec so tests
+// own the bytes; the decoder in `aws-eventstream.ts` is the production code under
+// test. Encoding lives only here for fixture generation.
+
+export function encodeStringHeader(name: string, value: string): Uint8Array {
+	const nameBytes = new TextEncoder().encode(name);
+	const valueBytes = new TextEncoder().encode(value);
+	if (nameBytes.length > 255) throw new Error("name too long");
+	const buf = new Uint8Array(1 + nameBytes.length + 1 + 2 + valueBytes.length);
+	const view = new DataView(buf.buffer);
+	let p = 0;
+	view.setUint8(p, nameBytes.length);
+	p += 1;
+	buf.set(nameBytes, p);
+	p += nameBytes.length;
+	view.setUint8(p, 7); // string type
+	p += 1;
+	view.setUint16(p, valueBytes.length, false);
+	p += 2;
+	buf.set(valueBytes, p);
+	return buf;
+}
+
+export function encodeFrame(headers: Record<string, string>, payload: Uint8Array): Uint8Array {
+	const headerChunks = Object.keys(headers).map(name => encodeStringHeader(name, headers[name]));
+	const headerLen = headerChunks.reduce((s, c) => s + c.length, 0);
+	const headerBytes = new Uint8Array(headerLen);
+	let off = 0;
+	for (const c of headerChunks) {
+		headerBytes.set(c, off);
+		off += c.length;
+	}
+	const total = 4 + 4 + 4 + headerLen + payload.length + 4;
+	const out = new Uint8Array(total);
+	const view = new DataView(out.buffer);
+	view.setUint32(0, total, false);
+	view.setUint32(4, headerLen, false);
+	view.setUint32(8, crc32(out.subarray(0, 8)), false);
+	out.set(headerBytes, 12);
+	out.set(payload, 12 + headerLen);
+	view.setUint32(total - 4, crc32(out.subarray(0, total - 4)), false);
+	return out;
+}
+
+/** Convenience for an `event`-typed JSON frame (the shape Bedrock emits). */
+export function eventFrame(eventType: string, payload: Record<string, unknown>): Uint8Array {
+	return encodeFrame(
+		{ ":message-type": "event", ":event-type": eventType },
+		new TextEncoder().encode(JSON.stringify(payload)),
+	);
+}
+
+export function streamFrom(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+	let i = 0;
+	return new ReadableStream({
+		pull(controller) {
+			if (i < chunks.length) controller.enqueue(chunks[i++]);
+			else controller.close();
+		},
+	});
+}
+
+/** Wraps frames in a 200 eventstream `Response`, as a streamed Bedrock body. */
+export function eventStreamResponse(frames: Uint8Array[]): Response {
+	return new Response(streamFrom(frames), {
+		status: 200,
+		headers: { "content-type": "application/vnd.amazon.eventstream" },
+	});
+}

--- a/packages/ai/test/helpers/index.ts
+++ b/packages/ai/test/helpers/index.ts
@@ -4,6 +4,9 @@ import type { Model } from "@oh-my-pi/pi-ai/types";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import { isEnoent } from "@oh-my-pi/pi-utils";
 
+export * from "./aws-env";
+export * from "./aws-eventstream";
+
 export async function withEnv(
 	overrides: Record<string, string | undefined>,
 	fn: () => void | Promise<void>,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -120,6 +120,7 @@
 - Fixed `omp plugin list --json` omitting locally linked plugins that exist only in `omp-plugins.lock.json` and `node_modules` symlinks. ([#2742](https://github.com/can1357/oh-my-pi/issues/2742))
 - Fixed task subagents to install their configured ordered model candidates as child-session retry fallback chains, so retryable provider failures can advance to the next subagent model instead of failing the worker ([#2750](https://github.com/can1357/oh-my-pi/issues/2750)).
 - Fixed empty reasonless aborted assistant turns to auto-retry without switching model fallback, so transient provider-side aborts after tool results do not end headless sessions ([#2685](https://github.com/can1357/oh-my-pi/issues/2685)).
+- Config schema: added `"bedrock-converse-stream"` to the `api` enum for `ProviderConfigSchema` and `ModelDefinitionSchema`, enabling custom Bedrock-compatible gateway providers in `models.yml`.
 
 ## [16.0.1] - 2026-06-15
 
@@ -229,6 +230,10 @@
 - Ctrl+C now works like Escape in selector components, so mashing Ctrl+C will eventually close the program ([#400](https://github.com/badlogic/pi-mono/pull/400) by [@mitsuhiko](https://github.com/mitsuhiko))
 - External editor (Ctrl-G) now shows full pasted content instead of `[paste #N ...]` placeholders ([#444](https://github.com/badlogic/pi-mono/pull/444) by [@aliou](https://github.com/aliou))
 - Subagent example README referenced incorrect filename `subagent.ts` instead of `index.ts` ([#427](https://github.com/badlogic/pi-mono/pull/427) by [@Whamp](https://github.com/Whamp))
+### Added
+
+- Config schema: added `"bedrock-converse-stream"` to the `api` enum for `ProviderConfigSchema` and `ModelDefinitionSchema`, enabling custom Bedrock-compatible providers in `models.yml`.
+- Custom `bedrock-converse-stream` providers no longer require an `apiKey` in `models.yml` unless `auth: "none"` — they authenticate via the normal AWS env/profile SigV4 flow, matching bundled `amazon-bedrock` behavior.
 
 ## [16.0.0] - 2026-06-15
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1852,7 +1852,12 @@ export class ModelRegistry {
 		if (this.#keylessProviders.has(model.provider) && !this.authStorage.hasAuth(model.provider)) {
 			return kNoAuth;
 		}
-		return this.authStorage.getApiKey(model.provider, sessionId, { baseUrl: model.baseUrl, modelId: model.id });
+		const key = await this.authStorage.getApiKey(model.provider, sessionId, {
+			baseUrl: model.baseUrl,
+			modelId: model.id,
+		});
+		if (key !== undefined) return key;
+		return undefined;
 	}
 
 	/**
@@ -1872,12 +1877,14 @@ export class ModelRegistry {
 		if (this.#keylessProviders.has(provider) && !this.authStorage.hasAuth(provider)) {
 			return kNoAuth;
 		}
-		return this.authStorage.getApiKey(provider, sessionId, {
+		const key = await this.authStorage.getApiKey(provider, sessionId, {
 			baseUrl: options?.baseUrl,
 			modelId: options?.modelId,
 			forceRefresh: options?.forceRefresh,
 			signal: options?.signal,
 		});
+		if (key !== undefined) return key;
+		return undefined;
 	}
 
 	/**
@@ -1907,7 +1914,9 @@ export class ModelRegistry {
 		if (this.#keylessProviders.has(provider) && !this.authStorage.hasAuth(provider)) {
 			return kNoAuth;
 		}
-		return this.authStorage.peekApiKey(provider);
+		const key = await this.authStorage.peekApiKey(provider);
+		if (key !== undefined) return key;
+		return undefined;
 	}
 
 	/**

--- a/packages/coding-agent/src/config/models-config-schema.ts
+++ b/packages/coding-agent/src/config/models-config-schema.ts
@@ -127,6 +127,7 @@ const ModelDefinitionSchema = z.object({
 			"google-generative-ai",
 			"google-gemini-cli",
 			"google-vertex",
+			"bedrock-converse-stream",
 		])
 		.optional(),
 	baseUrl: z.string().min(1).optional(),
@@ -198,6 +199,7 @@ const ProviderConfigSchema = z.object({
 			"google-generative-ai",
 			"google-gemini-cli",
 			"google-vertex",
+			"bedrock-converse-stream",
 		])
 		.optional(),
 	headers: z.record(z.string(), z.string()).optional(),

--- a/packages/coding-agent/test/models-config-bedrock.test.ts
+++ b/packages/coding-agent/test/models-config-bedrock.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+import { ModelRegistry } from "../src/config/model-registry";
+import { validateProviderConfiguration } from "../src/config/models-config";
+import { ModelsConfigSchema } from "../src/config/models-config-schema";
+import { resetSettingsForTest } from "../src/config/settings";
+import { AuthStorage } from "../src/session/auth-storage";
+
+describe("models config: bedrock-converse-stream", () => {
+	describe("schema", () => {
+		test("accepts provider-level bedrock-converse-stream config", () => {
+			const result = ModelsConfigSchema.safeParse({
+				providers: {
+					"custom-bedrock": {
+						api: "bedrock-converse-stream",
+						baseUrl: "https://custom-bedrock.example.com",
+						apiKey: "gateway-token",
+						headers: { "X-Api-Key": "test-key" },
+						models: [{ id: "claude-sonnet-4", api: "bedrock-converse-stream" }],
+					},
+				},
+			});
+
+			expect(result.success).toBe(true);
+		});
+
+		test("accepts model-level bedrock-converse-stream overrides", () => {
+			const result = ModelsConfigSchema.safeParse({
+				providers: {
+					"custom-bedrock": {
+						api: "bedrock-converse-stream",
+						baseUrl: "https://custom-bedrock.example.com",
+						apiKey: "gateway-token",
+						models: [
+							{
+								id: "claude-sonnet-4",
+								api: "bedrock-converse-stream",
+								baseUrl: "https://custom-bedrock.example.com/v2",
+								headers: { "X-Api-Key": "model-key" },
+							},
+						],
+					},
+				},
+			});
+
+			expect(result.success).toBe(true);
+		});
+
+		test("rejects invalid provider api values", () => {
+			const result = ModelsConfigSchema.safeParse({
+				providers: {
+					"custom-bedrock": {
+						api: "not-a-real-api",
+						baseUrl: "https://custom-bedrock.example.com",
+						models: [{ id: "claude-sonnet-4" }],
+					},
+				},
+			});
+
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe("validation", () => {
+		test("requires apiKey for custom bedrock-converse-stream providers", () => {
+			expect(() =>
+				validateProviderConfiguration(
+					"regional-bedrock",
+					{
+						baseUrl: "https://bedrock-runtime.eu-west-1.amazonaws.com",
+						api: "bedrock-converse-stream",
+						models: [{ id: "claude-sonnet-4", api: "bedrock-converse-stream" }],
+					},
+					"models-config",
+				),
+			).toThrow(/"apiKey" is required when defining custom models/);
+		});
+
+		test("still requires apiKey for non-bedrock custom models", () => {
+			expect(() =>
+				validateProviderConfiguration(
+					"custom-openai",
+					{
+						baseUrl: "https://proxy.example.com/v1",
+						api: "openai-completions",
+						models: [{ id: "gpt-4", api: "openai-completions" }],
+					},
+					"models-config",
+				),
+			).toThrow(/"apiKey" is required when defining custom models/);
+		});
+
+		test("still requires apiKey when only some models use bedrock-converse-stream", () => {
+			expect(() =>
+				validateProviderConfiguration(
+					"mixed-provider",
+					{
+						baseUrl: "https://proxy.example.com",
+						models: [
+							{ id: "claude-sonnet-4", api: "bedrock-converse-stream" },
+							{ id: "gpt-4", api: "openai-completions" },
+						],
+					},
+					"models-config",
+				),
+			).toThrow(/"apiKey" is required when defining custom models/);
+		});
+	});
+
+	describe("registry", () => {
+		let tempDir: string;
+		let modelsJsonPath: string;
+		let authStorage: AuthStorage;
+
+		beforeEach(async () => {
+			resetSettingsForTest();
+			tempDir = path.join(os.tmpdir(), `pi-test-models-config-bedrock-${Snowflake.next()}`);
+			fs.mkdirSync(tempDir, { recursive: true });
+			modelsJsonPath = path.join(tempDir, "models.json");
+			authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
+		});
+
+		afterEach(() => {
+			resetSettingsForTest();
+			authStorage.close();
+			if (tempDir && fs.existsSync(tempDir)) {
+				fs.rmSync(tempDir, { recursive: true });
+			}
+		});
+
+		test("loads custom bedrock provider models with headers from models.json", () => {
+			fs.writeFileSync(
+				modelsJsonPath,
+				JSON.stringify({
+					providers: {
+						"custom-bedrock": {
+							api: "bedrock-converse-stream",
+							baseUrl: "https://custom-bedrock.example.com",
+							auth: "none",
+							headers: { "X-Api-Key": "test-key" },
+							models: [
+								{
+									id: "claude-sonnet-4",
+									name: "Claude Sonnet 4",
+									api: "bedrock-converse-stream",
+									reasoning: false,
+									input: ["text"],
+									cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+									contextWindow: 200_000,
+									maxTokens: 8192,
+								},
+							],
+						},
+					},
+				}),
+			);
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const model = registry.find("custom-bedrock", "claude-sonnet-4");
+
+			expect(model).toBeDefined();
+			expect(model?.api).toBe("bedrock-converse-stream");
+			expect(model?.baseUrl).toBe("https://custom-bedrock.example.com");
+			expect(model?.headers?.["X-Api-Key"]).toBe("test-key");
+		});
+
+		test("returns configured apiKey for bedrock gateways", async () => {
+			fs.writeFileSync(
+				modelsJsonPath,
+				JSON.stringify({
+					providers: {
+						"gateway-bedrock": {
+							api: "bedrock-converse-stream",
+							baseUrl: "https://gateway.example.com",
+							apiKey: "gateway-token",
+							models: [
+								{
+									id: "claude-sonnet-4",
+									name: "Claude Sonnet 4",
+									api: "bedrock-converse-stream",
+									reasoning: false,
+									input: ["text"],
+									cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+									contextWindow: 200_000,
+									maxTokens: 8192,
+								},
+							],
+						},
+					},
+				}),
+			);
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath);
+			const model = registry.find("gateway-bedrock", "claude-sonnet-4");
+
+			expect(model).toBeDefined();
+			expect(registry.hasConfiguredAuth(model!)).toBe(true);
+			expect(await registry.getApiKey(model!)).toBe("gateway-token");
+		});
+	});
+});


### PR DESCRIPTION
## What

Enables using AWS Bedrock Converse API with custom endpoints instead of being limited to AWS.

Changes:

1. **Add 'bedrock-converse-stream' to ModelsConfigSchema api enum**
   - ProviderConfigSchema and ModelDefinitionSchema both updated

2. **Respect model.baseUrl in amazon-bedrock provider**
   - When custom baseUrl is set, use it instead of hardcoded `bedrock-runtime.{region}.amazonaws.com` URL
   - Enables third-party Bedrock-compatible endpoints

3. **Support model.headers in Bedrock requests**
   - Merges custom headers into request baseHeaders
   - Allows provider-specific auth headers

4. **Fix thinking signature detection for bare Claude IDs**
   - `supportsThinkingSignature()` now recognizes 'claude-*' prefix  
   - Some providers use bare model IDs without 'anthropic.' prefix

5. **Sanitize tool names for Bedrock compatibility**
   - Bedrock requires `[a-zA-Z0-9_-]+` regex for tool names
   - Invalid characters replaced with underscores

## Why

Currently `bedrock-converse-stream` is hardcoded to AWS endpoints. Users who have access to Bedrock-compatible APIs through other providers cannot use this API. This PR enables custom baseUrl support, allowing the Bedrock provider to work with any Converse API-compatible endpoint.

## Testing

- [x] Config validation passes with `bedrock-converse-stream` API
- [x] ModelsConfigSchema validates correctly
- [x] Custom baseUrl routing verified
- [x] model.headers merging works

---

- [x] `bun check` passes
- [x] Tested locally (custom url only)
- [x] CHANGELOG updated (if user-facing)
