### PR TITLE
fix(coding-agent): resolve omp docs-prefixed URLs

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp://docs` and `omp://docs/...` internal documentation URLs in the distributed package to resolve through the embedded documentation index instead of failing with `Documentation file not found` ([#1898](https://github.com/can1357/oh-my-pi/issues/1898)).
+
 ## [15.9.1] - 2026-06-04
 
 ### Added
@@ -18,8 +22,6 @@
 - Changed Perplexity API-key web search to return more comprehensive results: `web_search_options.search_context_size` is now `high` (was `medium`) for maximum retrieval grounding, the default `num_search_results` is `20` (was `10`) so twice as many sources are surfaced, and `return_related_questions` is enabled with the response's `related_questions` now parsed into `relatedQuestions` (previously dropped). On an identical query this lifted the result from 10 sources / ~410 output tokens to 20 sources / ~1900 output tokens with a structured, multi-section answer; latency tracks model output length, not context size, so the 60s hard timeout headroom is unchanged.
 
 ### Fixed
-
-- Fixed `omp://docs` and `omp://docs/...` internal documentation URLs in the distributed package to resolve through the embedded documentation index instead of failing with `Documentation file not found` ([#1898](https://github.com/can1357/oh-my-pi/issues/1898)).
 
 - Fixed a streamed assistant message freezing at a partial prefix (e.g. only "Nat" of "Natives built, now…") on ED3-risk terminals (Ghostty/kitty/iTerm2/Alacritty), with the final text appearing only after a resize. `TranscriptContainer` freezes each non-live block by replaying its last live render, but render coalescing can finalize a block's content and append the next block within the same throttled frame — so the block was sealed at its stale mid-stream snapshot and never repainted until the next `thaw`. The block that was live on the previous render is now recomputed once on the live→frozen transition, sealing it at its final content.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### Fixed
 
+- Fixed `omp://docs` and `omp://docs/...` internal documentation URLs in the distributed package to resolve through the embedded documentation index instead of failing with `Documentation file not found` ([#1898](https://github.com/can1357/oh-my-pi/issues/1898)).
+
 - Fixed a streamed assistant message freezing at a partial prefix (e.g. only "Nat" of "Natives built, now…") on ED3-risk terminals (Ghostty/kitty/iTerm2/Alacritty), with the final text appearing only after a resize. `TranscriptContainer` freezes each non-live block by replaying its last live render, but render coalescing can finalize a block's content and append the next block within the same throttled frame — so the block was sealed at its stale mid-stream snapshot and never repainted until the next `thaw`. The block that was live on the previous render is now recomputed once on the live→frozen transition, sealing it at its final content.
 
 - Fixed ACP/RPC stdio startup so protocol frames are no longer consumed as one-shot piped prompt input before the JSON-RPC transport starts.

--- a/packages/coding-agent/src/internal-urls/omp-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/omp-protocol.ts
@@ -64,9 +64,15 @@ export class OmpProtocolHandler implements ProtocolHandler {
 			throw new Error("Path traversal (..) is not allowed in omp:// URLs");
 		}
 
-		const content = EMBEDDED_DOCS[normalized];
+		const docPath =
+			normalized === "docs" ? "" : normalized.startsWith("docs/") ? normalized.slice("docs/".length) : normalized;
+		if (!docPath) {
+			return this.#listDocs(url);
+		}
+
+		const content = EMBEDDED_DOCS[docPath];
 		if (content === undefined) {
-			const lookup = normalized.replace(/\.md$/, "");
+			const lookup = docPath.replace(/\.md$/, "");
 			const suggestions = EMBEDDED_DOC_FILENAMES.filter(
 				f => f.includes(lookup) || lookup.includes(f.replace(/\.md$/, "")),
 			).slice(0, 5);

--- a/packages/coding-agent/src/tools/search.ts
+++ b/packages/coding-agent/src/tools/search.ts
@@ -259,7 +259,7 @@ interface IndexedContentLines {
 }
 
 const INTERNAL_URL_DISPLAY_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
-const OMP_ROOT_URL_RE = /^omp:\/\/\/?$/i;
+const OMP_ROOT_URL_RE = /^omp:\/\/(?:\/?|docs\/?)$/i;
 
 function normalizeSearchLine(line: string): string {
 	return line.endsWith("\r") ? line.slice(0, -1) : line;

--- a/packages/coding-agent/test/internal-urls/omp-protocol.test.ts
+++ b/packages/coding-agent/test/internal-urls/omp-protocol.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test";
+import { InternalUrlRouter } from "@oh-my-pi/pi-coding-agent/internal-urls";
+
+describe("OmpProtocolHandler", () => {
+	it("treats omp://docs as the documentation root", async () => {
+		const resource = await InternalUrlRouter.instance().resolve("omp://docs");
+
+		expect(resource.content).toContain("# Documentation");
+		expect(resource.content).toContain("tools/read.md");
+	});
+
+	it("resolves docs-prefixed documentation paths", async () => {
+		const router = InternalUrlRouter.instance();
+		const direct = await router.resolve("omp://tools/read.md");
+		const prefixed = await router.resolve("omp://docs/tools/read.md");
+
+		expect(prefixed.content).toBe(direct.content);
+		expect(prefixed.content).toContain("# read");
+	});
+});

--- a/packages/coding-agent/test/tools/search-internal-urls.test.ts
+++ b/packages/coding-agent/test/tools/search-internal-urls.test.ts
@@ -183,6 +183,20 @@ describe("SearchTool internal URL resolution", () => {
 		expect(text).toContain("Search file contents with a regex across files");
 	});
 
+	it("expands omp://docs to grep embedded documentation files", async () => {
+		const session = createSession();
+		const tool = new SearchTool(session);
+
+		const result = await tool.execute("test-call", {
+			pattern: "Read files, directories, archives",
+			paths: ["omp://docs"],
+		});
+
+		const text = getResultText(result);
+		expect(text).toContain("# omp://tools/read.md");
+		expect(text).toContain("Read files, directories, archives");
+	});
+
 	it("throws when internal URL has no sourcePath", async () => {
 		const session = createSession();
 		const tool = new SearchTool(session);


### PR DESCRIPTION
## Repro
The published package resolves `omp://` and direct embedded doc names, but the documented `omp://docs/...` form fails. Reproduced in a temp install with `bun --eval 'import { InternalUrlRouter } from "@oh-my-pi/pi-coding-agent/internal-urls"; await InternalUrlRouter.instance().resolve("omp://docs/tools/read.md");'`, which exits 1 with `Documentation file not found: docs/tools/read.md`.

## Cause
`packages/coding-agent/src/internal-urls/omp-protocol.ts` indexes generated docs by repository-relative names like `tools/read.md`, but `OmpProtocolHandler.#readDoc` looked up the URL filename literally. Requests under `omp://docs/...` therefore searched for a nonexistent `docs/tools/read.md` key even though the generated package asset contained `tools/read.md`.

## Fix
- Treat `omp://docs` as the same documentation-root listing as `omp://`.
- Strip the compatibility `docs/` prefix before looking up embedded doc content.
- Add `packages/coding-agent/test/internal-urls/omp-protocol.test.ts` coverage for `omp://docs` and `omp://docs/tools/read.md`.
- Record the user-visible fix in `packages/coding-agent/CHANGELOG.md`.

## Verification
Ran `bun test packages/coding-agent/test/internal-urls/omp-protocol.test.ts packages/coding-agent/test/tools/search-internal-urls.test.ts` (15 pass), `bun --cwd=packages/coding-agent run check:types`, `bun --cwd=packages/coding-agent run fix`, and a local packed-package install resolving `omp://docs/tools/read.md` successfully. Fixes #1898