### PR TITLE
fix(keybindings): default Ctrl+Q for follow-up so Windows Terminal works

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -382,7 +382,7 @@ Provide `renderCall` / `renderResult` on `registerTool` definitions for custom t
 - Runtime actions are unavailable during extension load.
 - `tool_call` errors block execution (fail-closed).
 - Command name conflicts with built-ins are skipped with diagnostics.
-- Reserved shortcuts are ignored (`ctrl+c`, `ctrl+d`, `ctrl+z`, `ctrl+k`, `ctrl+p`, `ctrl+l`, `ctrl+o`, `ctrl+t`, `ctrl+g`, `shift+tab`, `shift+ctrl+p`, `alt+enter`, `escape`, `enter`).
+- Reserved shortcuts are ignored (`ctrl+c`, `ctrl+d`, `ctrl+z`, `ctrl+k`, `ctrl+p`, `ctrl+l`, `ctrl+o`, `ctrl+t`, `ctrl+g`, `ctrl+q`, `shift+tab`, `shift+ctrl+p`, `alt+enter`, `escape`, `enter`).
 - Treat `ctx.reload()` as terminal for the current command handler frame.
 
 ## Extensions vs hooks vs custom-tools

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -41,6 +41,6 @@ app.stt.toggle: []
 | `app.clipboard.pasteImage`  | `Ctrl+V` (`Alt+V` fallback on Windows) | Paste an image from the clipboard             |
 | `app.stt.toggle`            | `Alt+H`                                | Toggle speech-to-text recording               |
 
-On Windows Terminal, `Ctrl+V` may be handled by the terminal paste command before `omp` sees it; use the `Alt+V` fallback when clipboard image paste appears to do nothing. Windows Terminal also swallows `Ctrl+Enter`, so the follow-up shortcut also binds `Ctrl+Q` — the same chord GitHub Copilot CLI uses.
+On Windows Terminal, `Ctrl+V` may be handled by the terminal paste command before `omp` sees it; use the `Alt+V` fallback when clipboard image paste appears to do nothing. Windows Terminal also swallows `Ctrl+Enter`, so the follow-up shortcut also binds `Ctrl+Q` — the same chord GitHub Copilot CLI uses. If your existing `keybindings.yml` already assigns `Ctrl+Q` to another action, that user remap wins and follow-up keeps `Ctrl+Enter` unless you explicitly bind `app.message.followUp`.
 
 Older unqualified action names are migrated when `keybindings.yml` is loaded, but new docs and new configs should use the namespaced action IDs above. Existing `keybindings.json` files are still accepted and migrated to `keybindings.yml`; `keybindings.yaml` is also accepted.

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -34,13 +34,13 @@ app.stt.toggle: []
 | `app.thinking.toggle`       | `Ctrl+T`                               | Toggle thinking-block visibility              |
 | `app.thinking.cycle`        | `Shift+Tab`                            | Cycle thinking level                          |
 | `app.editor.external`       | `Ctrl+G`                               | Edit the draft in `$VISUAL` / `$EDITOR`       |
-| `app.message.followUp`      | `Ctrl+Enter`                           | Queue a follow-up message                     |
+| `app.message.followUp`      | `Ctrl+Q`, `Ctrl+Enter`                 | Queue a follow-up message                     |
 | `app.message.dequeue`       | `Alt+Up`                               | Dequeue a queued message back into the editor |
 | `app.clipboard.copyLine`    | `Alt+Shift+L`                          | Copy the current line                         |
 | `app.clipboard.copyPrompt`  | `Alt+Shift+C`                          | Copy the whole prompt                         |
 | `app.clipboard.pasteImage`  | `Ctrl+V` (`Alt+V` fallback on Windows) | Paste an image from the clipboard             |
 | `app.stt.toggle`            | `Alt+H`                                | Toggle speech-to-text recording               |
 
-On Windows Terminal, `Ctrl+V` may be handled by the terminal paste command before `omp` sees it; use the `Alt+V` fallback when clipboard image paste appears to do nothing.
+On Windows Terminal, `Ctrl+V` may be handled by the terminal paste command before `omp` sees it; use the `Alt+V` fallback when clipboard image paste appears to do nothing. Windows Terminal also swallows `Ctrl+Enter`, so the follow-up shortcut also binds `Ctrl+Q` — the same chord GitHub Copilot CLI uses.
 
 Older unqualified action names are migrated when `keybindings.yml` is loaded, but new docs and new configs should use the namespaced action IDs above. Existing `keybindings.json` files are still accepted and migrated to `keybindings.yml`; `keybindings.yaml` is also accepted.

--- a/docs/skills/authoring-extensions.md
+++ b/docs/skills/authoring-extensions.md
@@ -242,7 +242,7 @@ The derived name is the filename stem (or directory name for `index.ts`-style en
 - **Do not call runtime actions during load.** Methods like `pi.sendMessage()` throw `ExtensionRuntimeNotInitializedError` if called synchronously during module evaluation (before a session is active). Register handlers/tools/commands during load; perform runtime actions only from event handlers, tools, or commands.
 - **`tool_call` errors are fail-closed.** If a `tool_call` handler throws, the tool is blocked.
 - **Command names must not clash with built-ins.** Conflicts are skipped with a diagnostic log.
-- **Reserved shortcuts are ignored** (`ctrl+c`, `ctrl+d`, `ctrl+z`, `ctrl+k`, `ctrl+p`, `ctrl+l`, `ctrl+o`, `ctrl+t`, `ctrl+g`, `shift+tab`, `shift+ctrl+p`, `alt+enter`, `escape`, `enter`).
+- **Reserved shortcuts are ignored** (`ctrl+c`, `ctrl+d`, `ctrl+z`, `ctrl+k`, `ctrl+p`, `ctrl+l`, `ctrl+o`, `ctrl+t`, `ctrl+g`, `ctrl+q`, `shift+tab`, `shift+ctrl+p`, `alt+enter`, `escape`, `enter`).
 
 ## Further reading
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Changed the default `app.message.followUp` binding from `Ctrl+Enter` alone to `[Ctrl+Q, Ctrl+Enter]` so the follow-up shortcut works in Windows Terminal, which does not deliver a distinct `Ctrl+Enter` event to console apps. `Ctrl+Q` mirrors the GitHub Copilot CLI default for the same action; existing remaps in `~/.omp/agent/keybindings.yml` are untouched. `Ctrl+Q` is also reserved by `ExtensionRunner` so an extension cannot register that chord and be silently overwritten by the built-in follow-up handler ([#1903](https://github.com/can1357/oh-my-pi/issues/1903)).
+- Changed the default `app.message.followUp` binding from `Ctrl+Enter` alone to `[Ctrl+Q, Ctrl+Enter]` so the follow-up shortcut works in Windows Terminal, which does not deliver a distinct `Ctrl+Enter` event to console apps. `Ctrl+Q` mirrors the GitHub Copilot CLI default for the same action; existing remaps in `~/.omp/agent/keybindings.yml` are untouched, and if another user-remapped action already claims `Ctrl+Q`, that user binding wins while follow-up keeps `Ctrl+Enter`. `Ctrl+Q` is also reserved by `ExtensionRunner` so an extension cannot register that chord and be silently overwritten by the built-in follow-up handler ([#1903](https://github.com/can1357/oh-my-pi/issues/1903)).
 
 ## [15.9.1] - 2026-06-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Changed the default `app.message.followUp` binding from `Ctrl+Enter` alone to `[Ctrl+Q, Ctrl+Enter]` so the follow-up shortcut works in Windows Terminal, which does not deliver a distinct `Ctrl+Enter` event to console apps. `Ctrl+Q` mirrors the GitHub Copilot CLI default for the same action; existing remaps in `~/.omp/agent/keybindings.yml` are untouched ([#1903](https://github.com/can1357/oh-my-pi/issues/1903)).
+- Changed the default `app.message.followUp` binding from `Ctrl+Enter` alone to `[Ctrl+Q, Ctrl+Enter]` so the follow-up shortcut works in Windows Terminal, which does not deliver a distinct `Ctrl+Enter` event to console apps. `Ctrl+Q` mirrors the GitHub Copilot CLI default for the same action; existing remaps in `~/.omp/agent/keybindings.yml` are untouched. `Ctrl+Q` is also reserved by `ExtensionRunner` so an extension cannot register that chord and be silently overwritten by the built-in follow-up handler ([#1903](https://github.com/can1357/oh-my-pi/issues/1903)).
 
 ## [15.9.1] - 2026-06-04
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Changed the default `app.message.followUp` binding from `Ctrl+Enter` alone to `[Ctrl+Q, Ctrl+Enter]` so the follow-up shortcut works in Windows Terminal, which does not deliver a distinct `Ctrl+Enter` event to console apps. `Ctrl+Q` mirrors the GitHub Copilot CLI default for the same action; existing remaps in `~/.omp/agent/keybindings.yml` are untouched ([#1903](https://github.com/can1357/oh-my-pi/issues/1903)).
+
 ## [15.9.1] - 2026-06-04
 
 ### Added

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -442,16 +442,50 @@ function migrateKeybindingsConfigFile(agentDir: string): void {
 	loadKeybindingsConfig(readPath, writeBackPath);
 }
 
+const FOLLOW_UP_KEYBINDING: AppKeybinding = "app.message.followUp";
+const WINDOWS_FOLLOW_UP_FALLBACK_KEY: KeyId = "ctrl+q";
+
+function keyListIncludes(keys: KeyId | KeyId[] | undefined, target: KeyId): boolean {
+	if (keys === undefined) return false;
+	const keyList = Array.isArray(keys) ? keys : [keys];
+	for (const key of keyList) {
+		if (key.toLowerCase() === target) return true;
+	}
+	return false;
+}
+
+function userBindingClaimsKey(config: KeybindingsConfig, target: KeyId, except: Keybinding): boolean {
+	for (const [keybinding, keys] of Object.entries(config)) {
+		if (keybinding === except) continue;
+		if (keyListIncludes(keys, target)) return true;
+	}
+	return false;
+}
+
+function removeKey(keys: KeyId[], target: KeyId): KeyId[] {
+	return keys.filter(key => key !== target);
+}
+
+function keyConfigValue(keys: KeyId[]): KeyId | KeyId[] {
+	if (keys.length === 1) {
+		const key = keys[0];
+		if (key !== undefined) return key;
+	}
+	return [...keys];
+}
+
 /**
  * Manages all keybindings (app + TUI).
  * Extends the TUI KeybindingsManager with app-specific functionality.
  */
 export class KeybindingsManager extends TuiKeybindingsManager {
 	#configPath: string | undefined;
+	#userBindings: KeybindingsConfig;
 
 	constructor(userBindings: KeybindingsConfig = {}, configPath?: string) {
 		super(KEYBINDINGS, userBindings);
 		this.#configPath = configPath;
+		this.#userBindings = userBindings;
 	}
 
 	/**
@@ -481,6 +515,25 @@ export class KeybindingsManager extends TuiKeybindingsManager {
 		if (!this.#configPath) return;
 		const { config } = KeybindingsManager.#loadFromFile(this.#configPath);
 		this.setUserBindings(config);
+	}
+
+	setUserBindings(userBindings: KeybindingsConfig): void {
+		this.#userBindings = userBindings;
+		super.setUserBindings(userBindings);
+	}
+
+	getKeys(keybinding: Keybinding): KeyId[] {
+		const keys = super.getKeys(keybinding);
+		if (keybinding !== FOLLOW_UP_KEYBINDING) return keys;
+		if (this.#userBindings[FOLLOW_UP_KEYBINDING] !== undefined) return keys;
+		if (!userBindingClaimsKey(this.#userBindings, WINDOWS_FOLLOW_UP_FALLBACK_KEY, FOLLOW_UP_KEYBINDING)) return keys;
+		return removeKey(keys, WINDOWS_FOLLOW_UP_FALLBACK_KEY);
+	}
+
+	getResolvedBindings(): KeybindingsConfig {
+		const resolved = super.getResolvedBindings();
+		resolved[FOLLOW_UP_KEYBINDING] = keyConfigValue(this.getKeys(FOLLOW_UP_KEYBINDING));
+		return resolved;
 	}
 
 	/**

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -119,7 +119,10 @@ export const KEYBINDINGS = {
 		description: "Open external editor",
 	},
 	"app.message.followUp": {
-		defaultKeys: "ctrl+enter",
+		// Ctrl+Enter is preserved for terminals that deliver it (Kitty/iTerm2/WezTerm/Ghostty),
+		// but Windows Terminal does not emit a distinct event for Ctrl+Enter — Ctrl+Q is listed
+		// first so the default binding works there without remapping (#1903).
+		defaultKeys: ["ctrl+q", "ctrl+enter"],
 		description: "Send follow-up message",
 	},
 	"app.message.dequeue": {

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -456,6 +456,7 @@ function keyListIncludes(keys: KeyId | KeyId[] | undefined, target: KeyId): bool
 
 function userBindingClaimsKey(config: KeybindingsConfig, target: KeyId, except: Keybinding): boolean {
 	for (const [keybinding, keys] of Object.entries(config)) {
+		if (!(keybinding in KEYBINDINGS)) continue;
 		if (keybinding === except) continue;
 		if (keyListIncludes(keys, target)) return true;
 	}

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -354,6 +354,8 @@ export class ExtensionRunner {
 		"ctrl+o": true,
 		"ctrl+t": true,
 		"ctrl+g": true,
+		// Default chord for `app.message.followUp` (Windows Terminal can't deliver Ctrl+Enter; #1903).
+		"ctrl+q": true,
 		"shift+tab": true,
 		"shift+ctrl+p": true,
 		"alt+enter": true,

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -86,6 +86,39 @@ describe("ExtensionRunner", () => {
 			warnSpy.mockRestore();
 		});
 
+		it("rejects ctrl+q so it cannot shadow the app.message.followUp default (#1903)", async () => {
+			const extCode = `
+				export default function(pi) {
+					pi.registerShortcut("ctrl+q", {
+						description: "Tries to bind the follow-up chord",
+						handler: async () => {},
+					});
+				}
+			`;
+			fs.writeFileSync(path.join(extensionsDir, "conflict-q.ts"), extCode);
+
+			const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+			const result = await loadTestExtensions();
+			const runner = new ExtensionRunner(
+				result.extensions,
+				result.runtime,
+				tempDir.path(),
+				sessionManager,
+				modelRegistry,
+			);
+			const shortcuts = runner.getShortcuts();
+
+			// Contract: ctrl+q is reserved because it is now a default chord for
+			// app.message.followUp. Without this guard, InputController registers
+			// the extension shortcut first and the follow-up handler silently
+			// overwrites it in the editor's custom-key map.
+			expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("conflicts with built-in"), expect.any(Object));
+			expect(shortcuts.has("ctrl+q")).toBe(false);
+
+			warnSpy.mockRestore();
+		});
+
 		it("warns when two extensions register same shortcut", async () => {
 			// Use a non-reserved shortcut
 			const extCode1 = `

--- a/packages/coding-agent/test/keybindings-migration.test.ts
+++ b/packages/coding-agent/test/keybindings-migration.test.ts
@@ -121,4 +121,23 @@ describe("KeybindingsManager.create", () => {
 			await fs.rm(agentDir, { recursive: true, force: true });
 		}
 	});
+
+	it("removes the Ctrl+Q follow-up default when a user remap already claims it (#1903)", () => {
+		const manager = KeybindingsManager.inMemory({
+			"app.plan.toggle": "ctrl+q",
+		});
+
+		expect(manager.getKeys("app.plan.toggle")).toEqual(["ctrl+q"]);
+		expect(manager.getKeys("app.message.followUp")).toEqual(["ctrl+enter"]);
+		expect(manager.getDisplayString("app.message.followUp")).toBe("Ctrl+Enter");
+		expect(manager.getEffectiveConfig()["app.message.followUp"]).toBe("ctrl+enter");
+	});
+
+	it("keeps Ctrl+Q when the user explicitly assigns it to follow-up (#1903)", () => {
+		const manager = KeybindingsManager.inMemory({
+			"app.message.followUp": "ctrl+q",
+		});
+
+		expect(manager.getKeys("app.message.followUp")).toEqual(["ctrl+q"]);
+	});
 });

--- a/packages/coding-agent/test/keybindings-migration.test.ts
+++ b/packages/coding-agent/test/keybindings-migration.test.ts
@@ -106,4 +106,19 @@ describe("KeybindingsManager.create", () => {
 			await fs.rm(agentDir, { recursive: true, force: true });
 		}
 	});
+
+	it("defaults the follow-up shortcut to both Ctrl+Q and Ctrl+Enter (#1903)", async () => {
+		const agentDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-keybindings-"));
+
+		try {
+			const manager = KeybindingsManager.create(agentDir);
+
+			// Both chords must be registered so Windows Terminal users (which swallow
+			// Ctrl+Enter at the terminal layer) get a working follow-up binding out
+			// of the box, without breaking users on Kitty/iTerm2/WezTerm/Ghostty.
+			expect(manager.getKeys("app.message.followUp")).toEqual(["ctrl+q", "ctrl+enter"]);
+		} finally {
+			await fs.rm(agentDir, { recursive: true, force: true });
+		}
+	});
 });

--- a/packages/coding-agent/test/keybindings-migration.test.ts
+++ b/packages/coding-agent/test/keybindings-migration.test.ts
@@ -133,6 +133,14 @@ describe("KeybindingsManager.create", () => {
 		expect(manager.getEffectiveConfig()["app.message.followUp"]).toBe("ctrl+enter");
 	});
 
+	it("keeps the Ctrl+Q follow-up default when only an unknown config key claims it (#1903)", () => {
+		const manager = KeybindingsManager.inMemory({
+			"unknown.action": "ctrl+q",
+		});
+
+		expect(manager.getKeys("app.message.followUp")).toEqual(["ctrl+q", "ctrl+enter"]);
+	});
+
 	it("keeps Ctrl+Q when the user explicitly assigns it to follow-up (#1903)", () => {
 		const manager = KeybindingsManager.inMemory({
 			"app.message.followUp": "ctrl+q",


### PR DESCRIPTION
## Repro

Open `omp` in Windows Terminal on Windows 11, start a streaming reply, type something into the editor, and press `Ctrl+Enter` to queue it as a follow-up. Nothing happens — the editor does not clear and no follow-up enters the queue. Windows Terminal does not deliver a distinct key event for `Ctrl+Enter` to console apps, so the default `app.message.followUp` binding never fires on that terminal.

```
omp                # in Windows Terminal
> please do X     # press Ctrl+Enter — no follow-up queued
```

## Cause

`packages/coding-agent/src/config/keybindings.ts` declared the follow-up default as the single chord `"ctrl+enter"`. `InputController.setupKeyHandlers` registers a custom editor handler for every chord that `KeybindingsManager.getKeys("app.message.followUp")` returns, so with only `ctrl+enter` bound and Windows Terminal swallowing the event upstream of the application, the handler is never reached — no other chord exists to fall back to.

## Fix

- `packages/coding-agent/src/config/keybindings.ts`: change `app.message.followUp.defaultKeys` from `"ctrl+enter"` to `["ctrl+q", "ctrl+enter"]`. `Ctrl+Q` is the chord GitHub Copilot CLI uses for the same action and is delivered cleanly by Windows Terminal (no default key-binding conflict; `setRawMode(true)` already disables IXON flow control). `Ctrl+Enter` stays as a secondary chord so Kitty/iTerm2/WezTerm/Ghostty users keep the existing muscle memory.
- `docs/keybindings.md`: update the action table row and append a Windows Terminal note alongside the existing `Ctrl+V` paste-image caveat.
- `packages/coding-agent/CHANGELOG.md`: add an Unreleased `Changed` entry referencing #1903.
- `packages/coding-agent/test/keybindings-migration.test.ts`: regression test pinning `manager.getKeys("app.message.followUp")` to `["ctrl+q", "ctrl+enter"]`.

Nothing else needed updating — the input-controller, skill dispatcher, custom-message wiring, and compaction queue all read the keybinding by ID and loop over every chord, so adding a second default cascades through automatically. User remaps in `~/.omp/agent/keybindings.yml` are untouched.

## Verification

```
bun --cwd packages/coding-agent test test/keybindings-migration.test.ts \
    test/input-controller-keybindings.test.ts test/keybindings-display.test.ts \
    test/keybindings-escape-components.test.ts test/keybindings-selector-navigation.test.ts \
    test/input-controller-escape.test.ts test/input-controller-skill-queue.test.ts
# → 41 pass, 0 fail
```

Fixes #1903