### PR TITLE
fix(discovery): scan .github/skills via the github provider

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -89,6 +89,7 @@ Current registered skill providers:
    - `agents`
    - `codex`
 5. `opencode` (priority 55)
+6. `github` (priority 30) — `.github/skills/<name>/SKILL.md` (GitHub Agent Skills layout, project-only)
 
 Dedup key is skill name. First item with a given name wins.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `github` discovery provider silently ignoring `.github/skills/<name>/SKILL.md`, GitHub's documented Agent Skills layout. The provider now registers a `skills` capability (priority 30, project-only) that scans `.github/skills/` non-recursively via `scanSkillsFromDir` with `requireDescription: true`, matching the Agent Skills spec and the sibling `native`/`omp-plugins` providers ([#1906](https://github.com/can1357/oh-my-pi/issues/1906)).
+
 ## [15.9.1] - 2026-06-04
 
 ### Added

--- a/packages/coding-agent/src/discovery/github.ts
+++ b/packages/coding-agent/src/discovery/github.ts
@@ -10,6 +10,7 @@
  * Capabilities:
  * - context-files: copilot-instructions.md in .github/
  * - instructions: *.instructions.md in .github/instructions/ with applyTo frontmatter
+ * - skills: <name>/SKILL.md in .github/skills/ (GitHub Agent Skills layout)
  */
 import * as path from "node:path";
 import { parseFrontmatter } from "@oh-my-pi/pi-utils";
@@ -17,9 +18,10 @@ import { registerProvider } from "../capability";
 import { type ContextFile, contextFileCapability } from "../capability/context-file";
 import { readFile } from "../capability/fs";
 import { type Instruction, instructionCapability } from "../capability/instruction";
+import { type Skill, skillCapability } from "../capability/skill";
 import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
 
-import { calculateDepth, createSourceMeta, getProjectPath, loadFilesFromDir } from "./helpers";
+import { calculateDepth, createSourceMeta, getProjectPath, loadFilesFromDir, scanSkillsFromDir } from "./helpers";
 
 const PROVIDER_ID = "github";
 const DISPLAY_NAME = "GitHub Copilot";
@@ -98,6 +100,32 @@ function transformInstruction(name: string, content: string, filePath: string, s
 }
 
 // =============================================================================
+// Skills
+// =============================================================================
+
+/**
+ * Load skills from `.github/skills/<name>/SKILL.md`.
+ *
+ * GitHub documents this layout for Copilot Agent Skills and matches the
+ * non-recursive shape `scanSkillsFromDir` already expects. `requireDescription`
+ * is on to match the Agent Skills spec (name + description are mandatory) and
+ * the sibling `native`/`omp-plugins` providers.
+ *
+ * @see https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/add-skills
+ */
+async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
+	const skillsDir = getProjectPath(ctx, "github", "skills");
+	if (!skillsDir) return { items: [], warnings: [] };
+
+	return scanSkillsFromDir(ctx, {
+		dir: skillsDir,
+		providerId: PROVIDER_ID,
+		level: "project",
+		requireDescription: true,
+	});
+}
+
+// =============================================================================
 // Provider Registration
 // =============================================================================
 
@@ -115,4 +143,12 @@ registerProvider(instructionCapability.id, {
 	description: "Load *.instructions.md from .github/instructions/ with applyTo frontmatter",
 	priority: PRIORITY,
 	load: loadInstructions,
+});
+
+registerProvider<Skill>(skillCapability.id, {
+	id: PROVIDER_ID,
+	displayName: DISPLAY_NAME,
+	description: "Load skills from .github/skills/*/SKILL.md",
+	priority: PRIORITY,
+	load: loadSkills,
 });

--- a/packages/coding-agent/test/discovery/github-skills.test.ts
+++ b/packages/coding-agent/test/discovery/github-skills.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression for https://github.com/can1357/oh-my-pi/issues/1906
+ *
+ * The `github` discovery provider previously registered only context-files and
+ * instructions, leaving `.github/skills/<name>/SKILL.md` — the layout GitHub
+ * documents for agent skills — silently unscanned. This test pins the wiring:
+ * loading the `skills` capability with the github provider scoped to a cwd
+ * containing `.github/skills/<name>/SKILL.md` must surface the skill.
+ *
+ * @see https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/add-skills
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadCapability } from "@oh-my-pi/pi-coding-agent/capability";
+import { clearCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import type { Skill } from "@oh-my-pi/pi-coding-agent/capability/skill";
+import "@oh-my-pi/pi-coding-agent/capability/skill";
+import "@oh-my-pi/pi-coding-agent/discovery/github";
+
+function writeSkill(root: string, name: string, description: string | null): void {
+	const skillDir = path.join(root, name);
+	fs.mkdirSync(skillDir, { recursive: true });
+	const frontmatter =
+		description === null ? `---\nname: ${name}\n---\n` : `---\nname: ${name}\ndescription: ${description}\n---\n`;
+	fs.writeFileSync(path.join(skillDir, "SKILL.md"), `${frontmatter}\n# ${name}\n\nSkill body.\n`);
+}
+
+describe("github discovery — skills", () => {
+	let tempDir!: string;
+
+	beforeEach(() => {
+		clearCache();
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-github-skills-"));
+	});
+
+	afterEach(() => {
+		clearCache();
+		fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test("discovers .github/skills/<name>/SKILL.md via the github provider", async () => {
+		writeSkill(path.join(tempDir, ".github", "skills"), "demo-skill", "Demo skill for Copilot");
+
+		const result = await loadCapability<Skill>("skills", { cwd: tempDir, providers: ["github"] });
+
+		const found = result.all.find(skill => skill.name === "demo-skill");
+		expect(found).toBeDefined();
+		expect(found?.path).toBe(path.join(tempDir, ".github", "skills", "demo-skill", "SKILL.md"));
+		expect(found?.level).toBe("project");
+		expect(found?._source.provider).toBe("github");
+		expect(result.warnings).toEqual([]);
+	});
+
+	test("skips skills missing a description (matches GitHub agent-skills standard)", async () => {
+		writeSkill(path.join(tempDir, ".github", "skills"), "no-desc", null);
+
+		const result = await loadCapability<Skill>("skills", { cwd: tempDir, providers: ["github"] });
+
+		expect(result.all.find(skill => skill.name === "no-desc")).toBeUndefined();
+	});
+
+	test("returns no skills when .github/skills/ is absent", async () => {
+		const result = await loadCapability<Skill>("skills", { cwd: tempDir, providers: ["github"] });
+
+		expect(result.all).toEqual([]);
+		expect(result.warnings).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Repro

`.github/skills/<name>/SKILL.md` — GitHub's documented Copilot Agent Skills layout — was silently never discovered. With a valid SKILL.md at that path, `skill://<name>` resolved to `Available: none` and the skill never appeared in the system-prompt listing, even though `.github/copilot-instructions.md` and `.github/instructions/*.instructions.md` in the same project loaded fine.

```bash
bun test test/discovery/github-skills.test.ts   # baseline: 1 failing case
# (fail) discovers .github/skills/<name>/SKILL.md via the github provider
#        expect(received).toBeDefined() — received: undefined
```

## Cause

`packages/coding-agent/src/discovery/github.ts` registered the `github` provider only against `contextFileCapability` (`copilot-instructions.md`) and `instructionCapability` (`.github/instructions/*.instructions.md`). It never wired `skillCapability`, and nothing else under `src/discovery/` scans `.github/skills/`. The `github` source already maps to `.github` in `SOURCE_PATHS` (`helpers.ts`), and the existing non-recursive `scanSkillsFromDir` helper already matches GitHub's `<skills-root>/<name>/SKILL.md` shape — only the provider registration was missing.

## Fix

- Added a `loadSkills` function in `github.ts` that resolves `<cwd>/.github/skills` via `getProjectPath` and delegates to `scanSkillsFromDir` with `level: "project"` and `requireDescription: true` (matches the Agent Skills spec — name + description are mandatory — and the sibling `native`/`omp-plugins` providers).
- Registered the `github` provider against `skillCapability` at priority 30, project-only (`SOURCE_PATHS.github.userBase` stays `null` — `.github/skills` is repo-scoped by convention).
- Added a regression test `test/discovery/github-skills.test.ts` scoped to `providers: ["github"]` covering: discovery of `.github/skills/<name>/SKILL.md`, rejection of skills missing `description`, and a clean no-op when `.github/skills/` is absent.
- Updated `docs/skills.md` to list `github` (priority 30) in the registered skill providers, and appended a CHANGELOG entry under `[Unreleased]`.

The secondary gap the reporter flagged (`.github/agents/<name>/agent.md`) is intentionally left out of this diff and should be tracked separately.

## Verification

- `bun --cwd packages/coding-agent test test/discovery/github-skills.test.ts` — 3 pass, 0 fail.
- `bun --cwd packages/coding-agent test test/discovery/` — 105 pass, 0 fail.
- `bun check` — clean (`check:ts` + `check:rs`).

Fixes #1906