### PR TITLE
fix(mcp): clear stale OAuth credential on definitive refresh failure

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed remote MCP OAuth refresh failures leaving stale credentials in `agent.db`: when the token endpoint returns a definitive failure (`invalid_grant`, `invalid_token`, `revoked`, plain 401/403 not classified as transient), `MCPManager#resolveAuthConfig` now drops the credential via `AuthStorage.remove(credentialId)` and skips re-attaching the dead `Authorization: Bearer …` header. Previously a revoked refresh token kept producing `401 invalid_token` on every MCP request and survived restarts, so users had to hand-clear the credential row to recover; the next connect now surfaces a clean auth error and `/mcp reauth <server>` (or `/mcp unauth`) recovers without restarting. Transient refresh failures (network/`fetch failed`/`ECONNREFUSED`) still fall back to the existing access token ([#1908](https://github.com/can1357/oh-my-pi/issues/1908)).
+
 ## [15.9.1] - 2026-06-04
 
 ### Added

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -6,7 +6,7 @@
  */
 import * as path from "node:path";
 import * as url from "node:url";
-import type { TSchema } from "@oh-my-pi/pi-ai";
+import { isDefinitiveOAuthFailure, type TSchema } from "@oh-my-pi/pi-ai";
 import { logger } from "@oh-my-pi/pi-utils";
 import type { SourceMeta } from "../capability/types";
 import { resolveConfigValue } from "../config/resolve-config-value";
@@ -1184,29 +1184,48 @@ export class MCPManager {
 							await this.#authStorage.set(credentialId, refreshedCredential);
 							credential = refreshedCredential;
 						} catch (refreshError) {
-							logger.warn("MCP OAuth refresh failed, using existing token", {
-								credentialId,
-								error: refreshError,
-							});
+							const errorMsg = refreshError instanceof Error ? refreshError.message : String(refreshError);
+							if (isDefinitiveOAuthFailure(errorMsg)) {
+								// `invalid_grant` / `invalid_token` / 401 from the token endpoint means
+								// the server has retired this credential — keeping the stale access
+								// token would just re-fail with 401 on every MCP request and leave a
+								// poisoned row in agent.db that survives restarts. Drop it now so the
+								// next connect attempt surfaces a clean "needs reauth" failure and
+								// the user can recover with `/mcp reauth <server>` (or `/mcp unauth`
+								// to forget the server entirely).
+								logger.warn("MCP OAuth refresh failed definitively; cleared credential", {
+									credentialId,
+									error: errorMsg,
+								});
+								await this.#authStorage.remove(credentialId);
+								credential = undefined;
+							} else {
+								logger.warn("MCP OAuth refresh failed, using existing token", {
+									credentialId,
+									error: refreshError,
+								});
+							}
 						}
 					}
 
-					if (resolved.type === "http" || resolved.type === "sse") {
-						resolved = {
-							...resolved,
-							headers: {
-								...resolved.headers,
-								Authorization: `Bearer ${credential.access}`,
-							},
-						};
-					} else {
-						resolved = {
-							...resolved,
-							env: {
-								...resolved.env,
-								OAUTH_ACCESS_TOKEN: credential.access,
-							},
-						};
+					if (credential?.type === "oauth") {
+						if (resolved.type === "http" || resolved.type === "sse") {
+							resolved = {
+								...resolved,
+								headers: {
+									...resolved.headers,
+									Authorization: `Bearer ${credential.access}`,
+								},
+							};
+						} else {
+							resolved = {
+								...resolved,
+								env: {
+									...resolved.env,
+									OAUTH_ACCESS_TOKEN: credential.access,
+								},
+							};
+						}
 					}
 				}
 			} catch (error) {

--- a/packages/coding-agent/test/mcp-manager-oauth-refresh.test.ts
+++ b/packages/coding-agent/test/mcp-manager-oauth-refresh.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression tests for MCP OAuth refresh failure handling (issue #1908).
+ *
+ * Before the fix, a refresh that came back with `invalid_grant` was logged and
+ * the stale access token was re-attached as `Authorization: Bearer …` on every
+ * subsequent MCP request — producing a permanent 401 / reauth loop until the
+ * user hand-cleared the row in `agent.db`. The fix routes definitive failures
+ * (`invalid_grant`, `invalid_token`, `revoked`, plain 401/403 not classified as
+ * transient) through `AuthStorage.remove(credentialId)` and suppresses the
+ * Bearer injection, so the next request surfaces a clean auth error instead.
+ */
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import { AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai";
+import { MCPManager } from "../src/mcp/manager";
+import * as oauthFlow from "../src/mcp/oauth-flow";
+import type { MCPServerConfig } from "../src/mcp/types";
+
+const CREDENTIAL_ID = "mcp_oauth_test_1908";
+const TOKEN_URL = "https://example.com/oauth/token";
+const STALE_ACCESS = "stale-access-token";
+const STALE_REFRESH = "stale-refresh-token";
+
+/** Build a `Headers` snapshot from a prepared MCP config. */
+function getAuthorizationHeader(config: MCPServerConfig): string | undefined {
+	if (config.type !== "http" && config.type !== "sse") return undefined;
+	return config.headers?.Authorization;
+}
+
+describe("MCPManager OAuth refresh failure", () => {
+	let manager: MCPManager;
+	let authStorage: AuthStorage;
+	let serverConfig: MCPServerConfig;
+
+	beforeEach(async () => {
+		const store = new SqliteAuthCredentialStore(new Database(":memory:"));
+		authStorage = new AuthStorage(store);
+		await authStorage.reload();
+
+		// Seed an expired credential so `#resolveAuthConfig` decides to refresh
+		// (a non-expired credential takes the no-refresh branch and never reaches
+		// the bug).
+		await authStorage.set(CREDENTIAL_ID, {
+			type: "oauth",
+			access: STALE_ACCESS,
+			refresh: STALE_REFRESH,
+			expires: Date.now() - 60_000,
+		});
+
+		manager = new MCPManager(process.cwd());
+		manager.setAuthStorage(authStorage);
+
+		serverConfig = {
+			type: "http",
+			url: "https://logfire.example.com/mcp",
+			auth: {
+				type: "oauth",
+				credentialId: CREDENTIAL_ID,
+				tokenUrl: TOKEN_URL,
+			},
+		};
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	test("clears the credential and skips Bearer injection on invalid_grant", async () => {
+		const refreshSpy = vi.spyOn(oauthFlow, "refreshMCPOAuthToken").mockRejectedValue(
+			new Error(
+				'MCP OAuth refresh failed: 400 {"error":"invalid_grant","error_description":"Refresh token has been revoked"}',
+			),
+		);
+
+		const prepared = await manager.prepareConfig(serverConfig);
+
+		expect(refreshSpy).toHaveBeenCalledTimes(1);
+		// The poisoned Bearer must not be re-injected — that is the loop the user
+		// reported (#1908).
+		expect(getAuthorizationHeader(prepared)).toBeUndefined();
+		// The credential row is gone so neither this nor a future session keeps
+		// shipping the dead refresh token.
+		expect(authStorage.get(CREDENTIAL_ID)).toBeUndefined();
+	});
+
+	test("clears the credential when the token endpoint replies HTTP 401", async () => {
+		vi.spyOn(oauthFlow, "refreshMCPOAuthToken").mockRejectedValue(
+			new Error("MCP OAuth refresh failed: 401 Unauthorized"),
+		);
+
+		const prepared = await manager.prepareConfig(serverConfig);
+
+		expect(getAuthorizationHeader(prepared)).toBeUndefined();
+		expect(authStorage.get(CREDENTIAL_ID)).toBeUndefined();
+	});
+
+	test("keeps the credential and falls back to the existing token on transient failure", async () => {
+		// Network blip during refresh — the access token may still be live, so
+		// we preserve the prior behavior of one best-effort attempt with what we
+		// already have rather than tearing down the credential.
+		vi.spyOn(oauthFlow, "refreshMCPOAuthToken").mockRejectedValue(
+			new Error("MCP OAuth refresh failed: fetch failed ECONNREFUSED 127.0.0.1:443"),
+		);
+
+		const prepared = await manager.prepareConfig(serverConfig);
+
+		expect(getAuthorizationHeader(prepared)).toBe(`Bearer ${STALE_ACCESS}`);
+		const remaining = authStorage.get(CREDENTIAL_ID);
+		expect(remaining?.type).toBe("oauth");
+	});
+
+	test("persists rotated credential on successful refresh", async () => {
+		// Sanity: the happy path still rotates the row and attaches the fresh
+		// Bearer. Guards against accidentally short-circuiting refresh while
+		// fixing the failure path.
+		vi.spyOn(oauthFlow, "refreshMCPOAuthToken").mockResolvedValue({
+			access: "fresh-access",
+			refresh: "fresh-refresh",
+			expires: Date.now() + 3_600_000,
+		});
+
+		const prepared = await manager.prepareConfig(serverConfig);
+
+		expect(getAuthorizationHeader(prepared)).toBe("Bearer fresh-access");
+		const remaining = authStorage.get(CREDENTIAL_ID);
+		expect(remaining).toMatchObject({ type: "oauth", access: "fresh-access", refresh: "fresh-refresh" });
+	});
+});

--- a/packages/coding-agent/test/mcp-manager-oauth-refresh.test.ts
+++ b/packages/coding-agent/test/mcp-manager-oauth-refresh.test.ts
@@ -66,11 +66,13 @@ describe("MCPManager OAuth refresh failure", () => {
 	});
 
 	test("clears the credential and skips Bearer injection on invalid_grant", async () => {
-		const refreshSpy = vi.spyOn(oauthFlow, "refreshMCPOAuthToken").mockRejectedValue(
-			new Error(
-				'MCP OAuth refresh failed: 400 {"error":"invalid_grant","error_description":"Refresh token has been revoked"}',
-			),
-		);
+		const refreshSpy = vi
+			.spyOn(oauthFlow, "refreshMCPOAuthToken")
+			.mockRejectedValue(
+				new Error(
+					'MCP OAuth refresh failed: 400 {"error":"invalid_grant","error_description":"Refresh token has been revoked"}',
+				),
+			);
 
 		const prepared = await manager.prepareConfig(serverConfig);
 


### PR DESCRIPTION
## Repro

A remote HTTP MCP server rotates / revokes its refresh token. On the next session, `MCPManager#resolveAuthConfig` hits the proactive refresh window, the token endpoint replies `400 {"error":"invalid_grant","error_description":"Refresh token has been revoked"}`, and the catch block logs `MCP OAuth refresh failed, using existing token` and falls through. The (now revoked) access token is re-attached as `Authorization: Bearer …`, the next `tools/list` returns `401 invalid_token`, and the same loop repeats every session until the user hand-clears the row in `agent.db`. Reported against Logfire's remote MCP, but reproducible against any HTTP MCP that rotates or revokes refresh tokens.

Reproduce against the unit test before the fix:

```
git stash push -- packages/coding-agent/src/mcp/manager.ts
bun --cwd=packages/coding-agent test test/mcp-manager-oauth-refresh.test.ts
# (fail) clears the credential and skips Bearer injection on invalid_grant
#   Received: "Bearer stale-access-token"
# (fail) clears the credential when the token endpoint replies HTTP 401
#   Received: "Bearer stale-access-token"
git stash pop
```

## Cause

`packages/coding-agent/src/mcp/manager.ts` — `MCPManager.#resolveAuthConfig` wrapped `refreshMCPOAuthToken` in a catch that only logged the failure and then unconditionally injected `credential.access` into the resolved config. There was no distinction between transient failures (worth one best-effort retry with the old token) and definitive ones (`invalid_grant` / `invalid_token` / `revoked` / token-endpoint 401-403), so a dead refresh token poisoned `agent.db` and survived restarts. `pi-ai`'s `isDefinitiveOAuthFailure` classifier already gates this same decision for first-party providers via `AuthStorage` / `AuthBrokerRefresher`; MCP just wasn't using it.

## Fix

- `packages/coding-agent/src/mcp/manager.ts` — import `isDefinitiveOAuthFailure` from `@oh-my-pi/pi-ai`; on a refresh catch, classify the error. Definitive → `await this.#authStorage.remove(credentialId)`, log `MCP OAuth refresh failed definitively; cleared credential`, set `credential = undefined`. Transient → keep the existing warn-and-reuse behavior. Gate the Bearer/`OAUTH_ACCESS_TOKEN` injection on `credential?.type === "oauth"` again so the cleared case skips it cleanly.
- `packages/coding-agent/test/mcp-manager-oauth-refresh.test.ts` — new regression suite: `invalid_grant` clears + drops the Bearer; token-endpoint 401 same; transient (`ECONNREFUSED`) falls back to the existing token; happy-path refresh still rotates and persists.
- `packages/coding-agent/CHANGELOG.md` — `## [Unreleased]` → `### Fixed` entry referencing the issue.

The CLI surface the issue asks for (`omp mcp auth clear <server>`) already exists as `/mcp unauth <name>`, so the auto-clear puts the user back into the same recovery flow they would have driven by hand. The MCP 2025-06-18 `resource` parameter point is a separate enhancement and not folded into this fix.

## Verification

```
bun --cwd=packages/coding-agent test test/mcp-manager-oauth-refresh.test.ts \
  test/mcp-reconnect.test.ts test/mcp-reconnect-storm.test.ts \
  test/mcp-http-transport.test.ts test/mcp-manager-subscription-action.test.ts
# 45 pass, 0 fail, 76 expect() calls
```

Stash-and-rerun confirmed the new tests fail without the production change (`Received: "Bearer stale-access-token"` on both definitive-failure cases) and pass with it.

Fixes #1908