### PR TITLE
fix(tui): differentiate /tree empty-state for fresh sessions

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `/tree` rendering a bare "No entries found" line on a fresh session where the only persisted entries are the `model_change` + `thinking_level_change` written by `sdk.ts` at startup — both are hidden by the tree-selector's default filter, so `#filteredNodes.length === 0` while `tree.length === 2` and the controller's `tree.length === 0` short-circuit never fired. The selector now splits the empty-state into three distinct shapes — truly empty tree, search query with no matches, and filter mode rejecting every entry — surfacing the cause and the recovery key (`Alt+A` to show all, `Backspace` to clear a stale search) so users on a fresh session can see immediately that the panel isn't broken ([#1909](https://github.com/can1357/oh-my-pi/issues/1909)).
+
 ## [15.9.1] - 2026-06-04
 
 ### Added

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -452,9 +452,7 @@ class TreeList implements Component {
 				lines.push(truncateToWidth(theme.fg("muted", "  No entries found"), width));
 				lines.push(truncateToWidth(theme.fg("muted", `  (0/0)${this.#getFilterLabel()}`), width));
 			} else if (this.#searchQuery.length > 0) {
-				lines.push(
-					truncateToWidth(theme.fg("muted", `  No entries match search "${this.#searchQuery}"`), width),
-				);
+				lines.push(truncateToWidth(theme.fg("muted", `  No entries match search "${this.#searchQuery}"`), width));
 				lines.push(truncateToWidth(theme.fg("muted", "  Press Backspace to clear the search"), width));
 				lines.push(
 					truncateToWidth(theme.fg("muted", `  (0/${this.#flatNodes.length})${this.#getFilterLabel()}`), width),

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -441,8 +441,37 @@ class TreeList implements Component {
 		const lines: string[] = [];
 
 		if (this.#filteredNodes.length === 0) {
-			lines.push(truncateToWidth(theme.fg("muted", "  No entries found"), width));
-			lines.push(truncateToWidth(theme.fg("muted", `  (0/0)${this.#getFilterLabel()}`), width));
+			// Three empty-state shapes:
+			//  - flatNodes empty               → no entries at all (truly fresh session).
+			//  - search query rejects everything → tell the user the search is the cause.
+			//  - filter mode rejects everything  → tell the user the filter is the cause and
+			//    how to widen it. Otherwise fresh sessions whose only persisted entries are
+			//    `model_change` + `thinking_level_change` (both hidden by the default filter)
+			//    read as "broken /tree" — see #1909.
+			if (this.#flatNodes.length === 0) {
+				lines.push(truncateToWidth(theme.fg("muted", "  No entries found"), width));
+				lines.push(truncateToWidth(theme.fg("muted", `  (0/0)${this.#getFilterLabel()}`), width));
+			} else if (this.#searchQuery.length > 0) {
+				lines.push(
+					truncateToWidth(theme.fg("muted", `  No entries match search "${this.#searchQuery}"`), width),
+				);
+				lines.push(truncateToWidth(theme.fg("muted", "  Press Backspace to clear the search"), width));
+				lines.push(
+					truncateToWidth(theme.fg("muted", `  (0/${this.#flatNodes.length})${this.#getFilterLabel()}`), width),
+				);
+			} else {
+				const filterLabel = this.#getFilterLabel().trim() || "[default]";
+				lines.push(
+					truncateToWidth(
+						theme.fg("muted", `  ${this.#flatNodes.length} entries hidden by the current filter ${filterLabel}`),
+						width,
+					),
+				);
+				lines.push(truncateToWidth(theme.fg("muted", "  Press Alt+A to show all, Alt+D for default"), width));
+				lines.push(
+					truncateToWidth(theme.fg("muted", `  (0/${this.#flatNodes.length})${this.#getFilterLabel()}`), width),
+				);
+			}
 			return lines;
 		}
 

--- a/packages/coding-agent/test/modes/components/tree-selector-empty-state-1909.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-empty-state-1909.test.ts
@@ -52,7 +52,13 @@ function renderSelector(selector: TreeSelectorComponent): string {
 
 describe("issue #1909: tree-selector empty-state messaging", () => {
 	it("explains that the filter — not missing data — is hiding entries on a fresh session", () => {
-		const selector = new TreeSelectorComponent(freshSessionTree(), "e2", 60, () => {}, () => {});
+		const selector = new TreeSelectorComponent(
+			freshSessionTree(),
+			"e2",
+			60,
+			() => {},
+			() => {},
+		);
 		const text = renderSelector(selector);
 
 		// Filter-hiding hint and recovery key must both be present so the user knows
@@ -66,7 +72,13 @@ describe("issue #1909: tree-selector empty-state messaging", () => {
 	});
 
 	it("explains a zero-result search as a search problem, not a filter problem", () => {
-		const selector = new TreeSelectorComponent(userMessageTree(), "e1", 60, () => {}, () => {});
+		const selector = new TreeSelectorComponent(
+			userMessageTree(),
+			"e1",
+			60,
+			() => {},
+			() => {},
+		);
 		// Type a character that won't match anything in the tree.
 		selector.handleInput("z");
 		const text = renderSelector(selector);
@@ -78,7 +90,13 @@ describe("issue #1909: tree-selector empty-state messaging", () => {
 	});
 
 	it("falls back to the bare 'No entries found' line when the tree is genuinely empty", () => {
-		const selector = new TreeSelectorComponent([], null, 60, () => {}, () => {});
+		const selector = new TreeSelectorComponent(
+			[],
+			null,
+			60,
+			() => {},
+			() => {},
+		);
 		const text = renderSelector(selector);
 
 		expect(text).toContain("No entries found");

--- a/packages/coding-agent/test/modes/components/tree-selector-empty-state-1909.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-empty-state-1909.test.ts
@@ -1,0 +1,89 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { TreeSelectorComponent } from "@oh-my-pi/pi-coding-agent/modes/components/tree-selector";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { SessionEntry, SessionTreeNode } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+
+beforeAll(async () => {
+	await initTheme(false, undefined, undefined, "dark", "light");
+});
+
+function freshSessionTree(): SessionTreeNode[] {
+	// Mirror what `sdk.ts` writes on session start: a `model_change` plus a
+	// `thinking_level_change`. Both are settings/bookkeeping entries that the
+	// tree selector's default filter hides — a fresh session contains nothing
+	// else, so the selector sees `flatNodes.length === 2`, `filteredNodes.length === 0`.
+	const modelChange: SessionEntry = {
+		type: "model_change",
+		id: "e1",
+		parentId: null,
+		timestamp: new Date().toISOString(),
+		model: "anthropic/claude-sonnet-4-20250514",
+	};
+	const thinkingChange: SessionEntry = {
+		type: "thinking_level_change",
+		id: "e2",
+		parentId: "e1",
+		timestamp: new Date().toISOString(),
+		thinkingLevel: "medium",
+	};
+	return [
+		{
+			entry: modelChange,
+			children: [{ entry: thinkingChange, children: [] }],
+		},
+	];
+}
+
+function userMessageTree(): SessionTreeNode[] {
+	const entry: SessionEntry = {
+		type: "message",
+		id: "e1",
+		parentId: null,
+		timestamp: new Date().toISOString(),
+		message: { role: "user", content: "hello there", timestamp: 1 },
+	};
+	return [{ entry, children: [] }];
+}
+
+function renderSelector(selector: TreeSelectorComponent): string {
+	const lines = (selector as unknown as { render: (w: number) => string[] }).render(120);
+	return Bun.stripANSI(lines.join("\n"));
+}
+
+describe("issue #1909: tree-selector empty-state messaging", () => {
+	it("explains that the filter — not missing data — is hiding entries on a fresh session", () => {
+		const selector = new TreeSelectorComponent(freshSessionTree(), "e2", 60, () => {}, () => {});
+		const text = renderSelector(selector);
+
+		// Filter-hiding hint and recovery key must both be present so the user knows
+		// the panel isn't broken and can widen the view without leaving the screen.
+		expect(text).toContain("hidden by the current filter");
+		expect(text).toContain("[default]");
+		expect(text.toLowerCase()).toContain("alt+a");
+		// Total count must reflect the real flatNodes count, not 0/0 (otherwise the
+		// "filter hides things" framing is unconvincing).
+		expect(text).toContain("(0/2)");
+	});
+
+	it("explains a zero-result search as a search problem, not a filter problem", () => {
+		const selector = new TreeSelectorComponent(userMessageTree(), "e1", 60, () => {}, () => {});
+		// Type a character that won't match anything in the tree.
+		selector.handleInput("z");
+		const text = renderSelector(selector);
+
+		expect(text).toContain('No entries match search "z"');
+		expect(text.toLowerCase()).toContain("backspace");
+		// Must NOT misattribute the empty result to the filter mode.
+		expect(text).not.toContain("hidden by the current filter");
+	});
+
+	it("falls back to the bare 'No entries found' line when the tree is genuinely empty", () => {
+		const selector = new TreeSelectorComponent([], null, 60, () => {}, () => {});
+		const text = renderSelector(selector);
+
+		expect(text).toContain("No entries found");
+		expect(text).toContain("(0/0)");
+		// Don't tell the user to widen the filter when there's nothing to widen to.
+		expect(text).not.toContain("hidden by the current filter");
+	});
+});


### PR DESCRIPTION
## Repro

`omp` 15.9.1, fresh session, no `/resume`:

```
$ omp
> /tree
Session Tree
…
  No entries found
  (0/0)
```

The recent-sessions list on the welcome screen is populated, so the
selector reads as broken. Regression test `tree-selector-empty-state-1909.test.ts`
captures the exact render with `bun --cwd packages/coding-agent test
test/modes/components/tree-selector-empty-state-1909.test.ts`.

## Cause

`sdk.ts` writes a `model_change` and a `thinking_level_change` at session
startup so the persisted model + thinking-level state survive resumes
(`packages/coding-agent/src/sdk.ts` ≈ L2028-L2034). The tree-selector's
default filter (`packages/coding-agent/src/modes/components/tree-selector.ts`
`#applyFilter`) treats `label` / `custom` / `model_change` /
`thinking_level_change` as settings/bookkeeping and hides them. On a
brand-new session that is everything in the tree, so
`#filteredNodes.length === 0` even though `tree.length === 2`. The
controller's `showTreeSelector` short-circuit (`if (tree.length === 0)`)
never fires, the selector opens, and `render()` falls into a single
empty-state branch that prints `No entries found` and `(0/0)` with no
hint that the filter is responsible.

## Fix

`TreeList.render`'s `#filteredNodes.length === 0` branch in
`packages/coding-agent/src/modes/components/tree-selector.ts` now splits
into three shapes so the panel matches the actual cause:

- `#flatNodes.length === 0` → unchanged `"No entries found"` + `(0/0)`.
- `#searchQuery` non-empty → `No entries match search "<query>"`,
  `Press Backspace to clear the search`, `(0/N)`.
- otherwise → `N entries hidden by the current filter [mode]`,
  `Press Alt+A to show all, Alt+D for default`, `(0/N)`.

The fresh-session case now lands in the third branch and explains itself
+ surfaces the recovery key. No filter behavior is changed; the rendered
text is the only thing that moves.

## Verification

`bun --cwd packages/coding-agent test test/modes/components/tree-selector-empty-state-1909.test.ts
test/modes/components/tree-selector-developer.test.ts
test/modes/components/tree-selector-overflow.test.ts` → 7 pass / 0 fail.
The new test file (`tree-selector-empty-state-1909.test.ts`) covers all
three empty-state shapes — fresh-session filter case, zero-match search,
and the truly-empty fallback — and asserts the actionable hint plus the
correct `(0/N)` total in each.

Fixes #1909