### PR TITLE
fix(coding-agent): preserve setup login URLs

### DIFF
--- a/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
@@ -82,15 +82,15 @@ export class SignInTab implements SetupTab {
 		} else {
 			lines.push(...this.#selector.render(width));
 		}
-		if (this.#statusLines.length > 0) {
-			lines.push("", ...this.#statusLines.flatMap(line => wrapTextWithAnsi(line, width)));
-		}
 		if (this.#prompt) {
 			lines.push("", theme.fg("warning", this.#prompt.message));
 			if (this.#prompt.placeholder) {
 				lines.push(theme.fg("dim", this.#prompt.placeholder));
 			}
 			lines.push(this.#prompt.input.render(width)[0] ?? "");
+		}
+		if (this.#statusLines.length > 0) {
+			lines.push("", ...this.#statusLines.flatMap(line => wrapTextWithAnsi(line, width)));
 		}
 		return lines;
 	}

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
@@ -37,6 +37,7 @@ export class SignInTab implements SetupTab {
 	#authStorage: AuthStorage;
 	#selector: OAuthSelectorComponent;
 	#statusLines: string[] = [];
+	#authUrl: string | undefined;
 	#prompt: PromptState | undefined;
 	#promptResolve: ((value: string) => void) | undefined;
 	#loginAbort: AbortController | undefined;
@@ -78,9 +79,14 @@ export class SignInTab implements SetupTab {
 	render(width: number): string[] {
 		const lines = [theme.fg("muted", "Pick a provider to sign in — you can connect more than one."), ""];
 		if (this.#loggingInProvider) {
-			lines.push(theme.bold(`Signing in to ${this.#loggingInProvider}`), "");
+			lines.push(theme.bold(`Signing in to ${this.#loggingInProvider}`));
 		} else {
 			lines.push(...this.#selector.render(width));
+		}
+		if (this.#authUrl) {
+			// Always-visible actionable row — wizard body clipping cannot push it
+			// off-screen even when the wrapped URL below would not fit.
+			lines.push("", theme.fg("accent", `Browser login: ${loginUrlLink(this.#authUrl)}`));
 		}
 		if (this.#prompt) {
 			lines.push("", theme.fg("warning", this.#prompt.message));
@@ -88,6 +94,11 @@ export class SignInTab implements SetupTab {
 				lines.push(theme.fg("dim", this.#prompt.placeholder));
 			}
 			lines.push(this.#prompt.input.render(width)[0] ?? "");
+		}
+		if (this.#authUrl) {
+			// Plain-text URL for terminals without OSC 8 support. May clip on tiny
+			// terminals; the OSC 8 row above remains the always-visible fallback.
+			lines.push("", ...wrapTextWithAnsi(theme.fg("dim", this.#authUrl), width));
 		}
 		if (this.#statusLines.length > 0) {
 			lines.push("", ...this.#statusLines.flatMap(line => wrapTextWithAnsi(line, width)));
@@ -113,6 +124,7 @@ export class SignInTab implements SetupTab {
 		this.#selector.stopValidation();
 		this.#loggingInProvider = providerId;
 		this.#statusLines = [theme.fg("dim", "Starting OAuth flow…")];
+		this.#authUrl = undefined;
 		this.#loginAbort = new AbortController();
 		this.host.restoreFocus();
 		this.host.requestRender();
@@ -120,9 +132,8 @@ export class SignInTab implements SetupTab {
 			await this.#authStorage.login(providerId as OAuthProvider, {
 				signal: this.#loginAbort.signal,
 				onAuth: info => {
-					this.#statusLines.push(theme.fg("accent", "Open this URL in your browser:"));
-					this.#statusLines.push(theme.fg("accent", info.url));
-					this.#statusLines.push(theme.fg("dim", loginUrlLink(info.url)));
+					this.#authUrl = info.url;
+					this.#statusLines = [];
 					if (info.instructions) {
 						this.#statusLines.push(theme.fg("warning", info.instructions));
 					}
@@ -146,6 +157,7 @@ export class SignInTab implements SetupTab {
 				theme.fg("success", `${theme.status.success} Signed in to ${providerId}`),
 				theme.fg("dim", `Credentials saved to ${getAgentDbPath()}`),
 			];
+			this.#authUrl = undefined;
 			this.#loggingInProvider = undefined;
 			this.#loginAbort = undefined;
 			this.#selector.stopValidation();
@@ -156,12 +168,14 @@ export class SignInTab implements SetupTab {
 			if (this.#disposed) return;
 			if (this.#loginAbort?.signal.aborted) {
 				this.#statusLines = [theme.fg("dim", "Login cancelled.")];
+				this.#authUrl = undefined;
 			} else {
 				const message = error instanceof Error ? error.message : String(error);
 				this.#statusLines = [
 					theme.fg("error", `Login failed: ${message}`),
 					theme.fg("dim", "Choose another provider or press Esc to continue."),
 				];
+				this.#authUrl = undefined;
 			}
 			this.#loggingInProvider = undefined;
 			this.#loginAbort = undefined;

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
@@ -1,6 +1,6 @@
 import type { AuthStorage } from "@oh-my-pi/pi-ai";
 import type { OAuthProvider } from "@oh-my-pi/pi-ai/utils/oauth/types";
-import { Input, matchesKey, truncateToWidth } from "@oh-my-pi/pi-tui";
+import { Input, matchesKey, wrapTextWithAnsi } from "@oh-my-pi/pi-tui";
 import { getAgentDbPath } from "@oh-my-pi/pi-utils";
 import { OAuthSelectorComponent } from "../../components/oauth-selector";
 import { theme } from "../../theme/theme";
@@ -14,6 +14,10 @@ const CALLBACK_SERVER_PROVIDERS: Partial<Record<OAuthProvider, true>> = {
 	"google-gemini-cli": true,
 	"google-antigravity": true,
 };
+
+function loginUrlLink(url: string): string {
+	return `\x1b]8;;${url}\x07Open login URL\x1b]8;;\x07`;
+}
 
 interface PromptState {
 	message: string;
@@ -79,7 +83,7 @@ export class SignInTab implements SetupTab {
 			lines.push(...this.#selector.render(width));
 		}
 		if (this.#statusLines.length > 0) {
-			lines.push("", ...this.#statusLines.map(line => truncateToWidth(line, width)));
+			lines.push("", ...this.#statusLines.flatMap(line => wrapTextWithAnsi(line, width)));
 		}
 		if (this.#prompt) {
 			lines.push("", theme.fg("warning", this.#prompt.message));
@@ -116,7 +120,9 @@ export class SignInTab implements SetupTab {
 			await this.#authStorage.login(providerId as OAuthProvider, {
 				signal: this.#loginAbort.signal,
 				onAuth: info => {
-					this.#statusLines.push(theme.fg("accent", `Open this URL: ${info.url}`));
+					this.#statusLines.push(theme.fg("accent", "Open this URL in your browser:"));
+					this.#statusLines.push(theme.fg("accent", info.url));
+					this.#statusLines.push(theme.fg("dim", loginUrlLink(info.url)));
 					if (info.instructions) {
 						this.#statusLines.push(theme.fg("warning", info.instructions));
 					}
@@ -174,6 +180,7 @@ export class SignInTab implements SetupTab {
 			this.#resolvePrompt(value);
 		};
 		input.onEscape = () => {
+			this.#loginAbort?.abort();
 			this.#resolvePrompt("");
 		};
 		this.host.setFocus(input);

--- a/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts
@@ -77,31 +77,30 @@ export class SignInTab implements SetupTab {
 	}
 
 	render(width: number): string[] {
-		const lines = [theme.fg("muted", "Pick a provider to sign in — you can connect more than one."), ""];
+		const lines: string[] = [];
 		if (this.#loggingInProvider) {
 			lines.push(theme.bold(`Signing in to ${this.#loggingInProvider}`));
 		} else {
+			lines.push(theme.fg("muted", "Pick a provider to sign in — you can connect more than one."), "");
 			lines.push(...this.#selector.render(width));
 		}
+
+		const urlLines = this.#authUrl ? wrapTextWithAnsi(theme.fg("dim", this.#authUrl), width) : [];
 		if (this.#authUrl) {
-			// Always-visible actionable row — wizard body clipping cannot push it
-			// off-screen even when the wrapped URL below would not fit.
-			lines.push("", theme.fg("accent", `Browser login: ${loginUrlLink(this.#authUrl)}`));
+			lines.push(theme.fg("accent", `Browser login: ${loginUrlLink(this.#authUrl)}`), ...urlLines.slice(0, 2));
 		}
 		if (this.#prompt) {
-			lines.push("", theme.fg("warning", this.#prompt.message));
+			lines.push(theme.fg("warning", this.#prompt.message));
 			if (this.#prompt.placeholder) {
 				lines.push(theme.fg("dim", this.#prompt.placeholder));
 			}
 			lines.push(this.#prompt.input.render(width)[0] ?? "");
 		}
-		if (this.#authUrl) {
-			// Plain-text URL for terminals without OSC 8 support. May clip on tiny
-			// terminals; the OSC 8 row above remains the always-visible fallback.
-			lines.push("", ...wrapTextWithAnsi(theme.fg("dim", this.#authUrl), width));
+		if (urlLines.length > 2) {
+			lines.push(...urlLines);
 		}
 		if (this.#statusLines.length > 0) {
-			lines.push("", ...this.#statusLines.flatMap(line => wrapTextWithAnsi(line, width)));
+			lines.push(...this.#statusLines.flatMap(line => wrapTextWithAnsi(line, width)));
 		}
 		return lines;
 	}

--- a/packages/coding-agent/test/setup-wizard-sign-in.test.ts
+++ b/packages/coding-agent/test/setup-wizard-sign-in.test.ts
@@ -20,7 +20,9 @@ describe("SignInTab", () => {
 			hasAuth: (_providerId: string) => false,
 			async login(_provider: OAuthProviderId, ctrl: OAuthLoginCallbacks): Promise<void> {
 				ctrl.onAuth({ url });
+				const prompt = ctrl.onManualCodeInput?.();
 				await loginGate.promise;
+				await prompt;
 			},
 		} as unknown as AuthStorage;
 
@@ -57,6 +59,10 @@ describe("SignInTab", () => {
 			expect(compact.slice(urlStart, urlStart + url.length + 8)).not.toContain("…");
 			expect(rendered.join("\n")).toContain(`\x1b]8;;${url}\x07Open login URL\x1b]8;;\x07`);
 			expect(openedUrls).toEqual([url]);
+
+			const clippedBody = rendered.slice(0, 7).map(line => Bun.stripANSI(line).trim());
+			expect(clippedBody).toContain("Paste the authorization code (or full redirect URL):");
+			expect(clippedBody.some(line => line.startsWith(">"))).toBe(true);
 		} finally {
 			tab.dispose();
 			loginGate.resolve();

--- a/packages/coding-agent/test/setup-wizard-sign-in.test.ts
+++ b/packages/coding-agent/test/setup-wizard-sign-in.test.ts
@@ -58,15 +58,16 @@ describe("SignInTab", () => {
 			expect(rendered.join("\n")).toContain(`\x1b]8;;${url}\x07Open login URL\x1b]8;;\x07`);
 			expect(openedUrls).toEqual([url]);
 
-			// On a ~24-row terminal the wizard body ends up ~8 rows; both the
-			// OSC8 link row and the focused input must survive that clip.
+			// On a ~24-row terminal the wizard body ends up ~8 rows; the OSC8
+			// link, a plain URL row, and the focused input must survive that clip.
 			const clippedBody = rendered.slice(0, 8).map(line => Bun.stripANSI(line).trim());
+			const plainUrlIndex = clippedBody.findIndex(line => line.startsWith("https://example.com/oauth/authorize?"));
+			const inputIndex = clippedBody.findIndex(line => line.startsWith(">"));
 			expect(clippedBody.some(line => line === "Browser login: Open login URL")).toBe(true);
+			expect(plainUrlIndex).toBeGreaterThanOrEqual(0);
 			expect(clippedBody).toContain("Paste the authorization code (or full redirect URL):");
-			expect(clippedBody.some(line => line.startsWith(">"))).toBe(true);
-			expect(clippedBody.indexOf("Browser login: Open login URL")).toBeLessThan(
-				clippedBody.findIndex(line => line.startsWith(">")),
-			);
+			expect(inputIndex).toBeGreaterThanOrEqual(0);
+			expect(plainUrlIndex).toBeLessThan(inputIndex);
 		} finally {
 			tab.dispose();
 			loginGate.resolve();

--- a/packages/coding-agent/test/setup-wizard-sign-in.test.ts
+++ b/packages/coding-agent/test/setup-wizard-sign-in.test.ts
@@ -1,0 +1,66 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { AuthStorage } from "@oh-my-pi/pi-ai";
+import type { OAuthLoginCallbacks, OAuthProviderId } from "@oh-my-pi/pi-ai/utils/oauth/types";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { SignInTab } from "../src/modes/setup-wizard/scenes/sign-in";
+import type { SetupSceneHost } from "../src/modes/setup-wizard/scenes/types";
+
+beforeAll(async () => {
+	await initTheme();
+});
+
+describe("SignInTab", () => {
+	it("wraps the full OAuth URL and keeps a full OSC8 link at narrow widths", async () => {
+		const url = `https://example.com/oauth/authorize?client_id=omp&redirect_uri=http%3A%2F%2Flocalhost%3A45454%2Fcallback&state=${"a".repeat(96)}`;
+		const loginGate = Promise.withResolvers<void>();
+		const openedUrls: string[] = [];
+
+		const authStorage = {
+			has: (_providerId: string) => false,
+			hasAuth: (_providerId: string) => false,
+			async login(_provider: OAuthProviderId, ctrl: OAuthLoginCallbacks): Promise<void> {
+				ctrl.onAuth({ url });
+				await loginGate.promise;
+			},
+		} as unknown as AuthStorage;
+
+		const host = {
+			ctx: {
+				openInBrowser(openedUrl: string): void {
+					openedUrls.push(openedUrl);
+				},
+				session: {
+					modelRegistry: {
+						authStorage,
+						async refresh(): Promise<void> {},
+					},
+				},
+			},
+			requestRender(): void {},
+			finish(): void {},
+			setFocus(): void {},
+			restoreFocus(): void {},
+		} as unknown as SetupSceneHost;
+
+		const tab = new SignInTab(host);
+		try {
+			for (const char of "anthropic") {
+				tab.handleInput(char);
+			}
+			tab.handleInput("\n");
+
+			const rendered = tab.render(36);
+			const compact = rendered.map(line => Bun.stripANSI(line).trim()).join("");
+			const urlStart = compact.indexOf(url.slice(0, 24));
+			expect(urlStart).toBeGreaterThanOrEqual(0);
+			expect(compact.slice(urlStart)).toContain(url);
+			expect(compact.slice(urlStart, urlStart + url.length + 8)).not.toContain("…");
+			expect(rendered.join("\n")).toContain(`\x1b]8;;${url}\x07Open login URL\x1b]8;;\x07`);
+			expect(openedUrls).toEqual([url]);
+		} finally {
+			tab.dispose();
+			loginGate.resolve();
+			await loginGate.promise;
+		}
+	});
+});

--- a/packages/coding-agent/test/setup-wizard-sign-in.test.ts
+++ b/packages/coding-agent/test/setup-wizard-sign-in.test.ts
@@ -10,7 +10,7 @@ beforeAll(async () => {
 });
 
 describe("SignInTab", () => {
-	it("wraps the full OAuth URL and keeps a full OSC8 link at narrow widths", async () => {
+	it("keeps the OSC8 login link and manual-code prompt above clipped wizard rows", async () => {
 		const url = `https://example.com/oauth/authorize?client_id=omp&redirect_uri=http%3A%2F%2Flocalhost%3A45454%2Fcallback&state=${"a".repeat(96)}`;
 		const loginGate = Promise.withResolvers<void>();
 		const openedUrls: string[] = [];
@@ -53,16 +53,20 @@ describe("SignInTab", () => {
 
 			const rendered = tab.render(36);
 			const compact = rendered.map(line => Bun.stripANSI(line).trim()).join("");
-			const urlStart = compact.indexOf(url.slice(0, 24));
-			expect(urlStart).toBeGreaterThanOrEqual(0);
-			expect(compact.slice(urlStart)).toContain(url);
-			expect(compact.slice(urlStart, urlStart + url.length + 8)).not.toContain("…");
+			expect(compact).toContain(url);
+			expect(compact).not.toContain("…");
 			expect(rendered.join("\n")).toContain(`\x1b]8;;${url}\x07Open login URL\x1b]8;;\x07`);
 			expect(openedUrls).toEqual([url]);
 
-			const clippedBody = rendered.slice(0, 7).map(line => Bun.stripANSI(line).trim());
+			// On a ~24-row terminal the wizard body ends up ~8 rows; both the
+			// OSC8 link row and the focused input must survive that clip.
+			const clippedBody = rendered.slice(0, 8).map(line => Bun.stripANSI(line).trim());
+			expect(clippedBody.some(line => line === "Browser login: Open login URL")).toBe(true);
 			expect(clippedBody).toContain("Paste the authorization code (or full redirect URL):");
 			expect(clippedBody.some(line => line.startsWith(">"))).toBe(true);
+			expect(clippedBody.indexOf("Browser login: Open login URL")).toBeLessThan(
+				clippedBody.findIndex(line => line.startsWith(">")),
+			);
 		} finally {
 			tab.dispose();
 			loginGate.resolve();


### PR DESCRIPTION
## Repro
In the setup sign-in screen, a long provider OAuth URL was rendered through `truncateToWidth`, which reproduced at narrow width with `bun --cwd packages/coding-agent --eval 'import { truncateToWidth } from "@oh-my-pi/pi-tui"; const url = "https://example.com/oauth/authorize?client_id=omp&redirect_uri=http%3A%2F%2Flocalhost%3A45454%2Fcallback&state=" + "a".repeat(96); const rendered = truncateToWidth("Open this URL: " + url, 36); console.log(rendered); console.log(`contains-full-url=${rendered.includes(url)}`);'` and output `Open this URL: https://example.com/…` plus `contains-full-url=false`.

## Cause
`packages/coding-agent/src/modes/setup-wizard/scenes/sign-in.ts` stored the setup OAuth URL as a single status line (`Open this URL: ${info.url}`) and `SignInTab.render()` mapped all status lines through `truncateToWidth`, so the visible and terminal-detected URL contained an ellipsis instead of the auth URL.

## Fix
- Render sign-in status lines with `wrapTextWithAnsi` so long URLs wrap instead of being ellipsized.
- Emit the auth URL on its own line and add an OSC8 `Open login URL` link whose payload is the complete URL.
- Abort an in-progress setup login when the focused manual-code prompt receives the cancel binding.
- Add a setup sign-in regression test covering narrow rendering, full URL preservation, OSC8 payload preservation, and browser-open forwarding.

## Verification
`bun --cwd packages/coding-agent test test/setup-wizard-sign-in.test.ts` passed (1 test, 5 assertions). Pre-publish `gh_push_branch` completed its formatter/check gate before pushing. Fixes #1919