### PR TITLE
fix(task): fallback to sync when AsyncJobManager is unavailable

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `task` tool returning a hard `Async execution is enabled but no async job manager is available.` error when `async.enabled` was true but `AsyncJobManager.instance()` returned `undefined`, leaving `task` non-functional for the rest of the session. The tool now falls back to the existing synchronous execution path (which still runs subagents concurrently via `mapWithConcurrencyLimit`), and logs a warning so the missing-manager state stays diagnosable ([#1922](https://github.com/can1357/oh-my-pi/issues/1922)).
+
 ## [15.9.1] - 2026-06-04
 
 ### Added

--- a/packages/coding-agent/src/task/index.ts
+++ b/packages/coding-agent/src/task/index.ts
@@ -17,7 +17,7 @@ import * as os from "node:os";
 import path from "node:path";
 import type { AgentTool, AgentToolResult, AgentToolUpdateCallback } from "@oh-my-pi/pi-agent-core";
 import type { Usage } from "@oh-my-pi/pi-ai";
-import { $env, prompt, Snowflake } from "@oh-my-pi/pi-utils";
+import { $env, logger, prompt, Snowflake } from "@oh-my-pi/pi-utils";
 import type { ToolSession } from "..";
 import { AsyncJobManager } from "../async";
 import { resolveAgentModelPatterns } from "../config/model-resolver";
@@ -345,10 +345,12 @@ export class TaskTool implements AgentTool<TaskToolSchemaInstance, TaskToolDetai
 
 		const manager = AsyncJobManager.instance();
 		if (!manager) {
-			return {
-				content: [{ type: "text", text: "Async execution is enabled but no async job manager is available." }],
-				details: { projectAgentsDir: null, results: [], totalDurationMs: 0 },
-			};
+			// Async was requested but no manager is registered (e.g. an
+			// orphaned session whose host never wired one up). Falling back
+			// to the sync path keeps the tool usable; only background/job-poll
+			// semantics are lost.
+			logger.warn("task: async.enabled but no AsyncJobManager registered; falling back to sync execution");
+			return this.#executeSync(_toolCallId, params, signal, onUpdate);
 		}
 
 		const taskItems = params.tasks ?? [];

--- a/packages/coding-agent/test/tools/task-async-fallback.test.ts
+++ b/packages/coding-agent/test/tools/task-async-fallback.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { AsyncJobManager } from "../../src/async";
+import { Settings } from "../../src/config/settings";
+import { TaskTool } from "../../src/task";
+import * as discoveryModule from "../../src/task/discovery";
+import type { TaskParams } from "../../src/task/types";
+import type { ToolSession } from "../../src/tools";
+
+function createSession(overrides: Partial<Record<string, unknown>> = {}): ToolSession {
+	return {
+		cwd: "/tmp",
+		hasUI: false,
+		settings: Settings.isolated(overrides),
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+	} as unknown as ToolSession;
+}
+
+function getFirstText(result: { content: Array<{ type: string; text?: string }> }): string {
+	const content = result.content.find(part => part.type === "text");
+	return content?.type === "text" ? (content.text ?? "") : "";
+}
+
+describe("task.async-fallback", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		AsyncJobManager.resetForTests();
+	});
+
+	it("falls back to sync execution when async is enabled but no manager is registered", async () => {
+		// Two-stage spy: the initial discovery during `TaskTool.create` advertises
+		// `task` so the tool builds; the executor's later call (inside
+		// `#executeSync`) advertises *nothing*, forcing the unique "Unknown agent"
+		// message — which is only reachable from the sync codepath. Hitting it
+		// proves we fell back instead of returning the old hard error.
+		const discoverSpy = vi.spyOn(discoveryModule, "discoverAgents");
+		discoverSpy.mockResolvedValueOnce({
+			agents: [
+				{
+					name: "task",
+					description: "General-purpose task agent",
+					systemPrompt: "You are a task agent.",
+					source: "bundled",
+				},
+			],
+			projectAgentsDir: null,
+		});
+		discoverSpy.mockResolvedValue({ agents: [], projectAgentsDir: null });
+
+		AsyncJobManager.resetForTests();
+		expect(AsyncJobManager.instance()).toBeUndefined();
+
+		const tool = await TaskTool.create(createSession({ "async.enabled": true }));
+
+		const result = await tool.execute("tool-1", {
+			agent: "task",
+			tasks: [{ id: "One", description: "label", assignment: "Do the thing." }],
+		} as TaskParams);
+
+		const text = getFirstText(result);
+		expect(text).toContain('Unknown agent "task"');
+		expect(text).not.toContain("no async job manager is available");
+	});
+});


### PR DESCRIPTION
## Repro

With `async.enabled` set to `true` in settings but no `AsyncJobManager` registered on the process (e.g. an orphaned session whose host never wired one up — see the companion report referenced in the issue), every `task` tool call fails with the hard error:

> Async execution is enabled but no async job manager is available.

The condition is unrecoverable from the agent side until the process restarts: settings and manager wiring are both fixed at process construction. A focused regression test (`packages/coding-agent/test/tools/task-async-fallback.test.ts`) reproduces it by calling `AsyncJobManager.resetForTests()` and invoking `TaskTool.execute` with `async.enabled: true`.

## Cause

`TaskTool.execute` in `packages/coding-agent/src/task/index.ts` (lines ~340-352) checked `AsyncJobManager.instance()` after the sync short-circuit and returned a synthetic error result when it was `undefined`, even though the synchronous fallback path `#executeSync` (still concurrent via `mapWithConcurrencyLimit`) was already used unconditionally for `!asyncEnabled || selectedAgent.blocking` and for empty task lists.

## Fix

- Replace the hard error branch in `TaskTool.execute` with a `#executeSync(...)` call so the tool degrades gracefully when no async manager is registered.
- Emit `logger.warn(...)` so the missing-manager state remains diagnosable in `~/.omp/logs/`.
- Add `test/tools/task-async-fallback.test.ts`, which uses a two-stage `discoverAgents` spy to assert the unique "Unknown agent" message produced by `#executeSync` — proving the fallback path was taken (and not the prior error path).
- CHANGELOG entry under `[Unreleased] > Fixed`.

Background/job-poll semantics are lost in this degraded mode (the manager is gone, so there is nothing to poll), but the tool keeps working — matching the behavior the reporter requested.

## Verification

- `bun test test/tools/task-async-fallback.test.ts` → 1 pass, 3 expect() calls.
- `bun test test/tools/task-async-fallback.test.ts test/tools/task-simple-mode.test.ts test/tools/task-repair-args.test.ts test/tools/task-agent-capabilities.test.ts` → 17 pass / 0 fail.
- Confirmed the new test fails on `main` with `Received: "Async execution is enabled but no async job manager is available."`, then passes with the fix applied.

Fixes #1922