### PR TITLE
fix(ai): disable Bun fetch timeout for streaming OpenAI-family providers

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Bun runtime's built-in 300s `fetch()` timeout killing long-running streaming requests to local models (LM Studio, Ollama, llama.cpp, vLLM) before pi-ai's watchdog layer could fire, making `PI_STREAM_FIRST_EVENT_TIMEOUT_MS=0` ineffective. The completions, responses, and Azure responses providers now pass `timeout: false` to Bun's `fetch()` so the pi-ai watchdog timers are the authoritative timeout layer. ([#602](https://github.com/can1357/oh-my-pi/issues/602))
+
 ## [15.9.1] - 2026-06-04
 
 ### Added

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -267,7 +267,13 @@ function createClient(model: Model<"azure-openai-responses">, apiKey: string, op
 
 	const { baseUrl, apiVersion } = resolveAzureConfig(model, options);
 
-	const baseFetch = options?.fetch ?? fetch;
+	const _rawFetch = options?.fetch ?? fetch;
+	const baseFetch = typeof (globalThis as any).Bun !== "undefined"
+		? Object.assign(
+			async (input: string | URL | Request, init?: RequestInit) => _rawFetch(input, { ...init, timeout: false } as any),
+			{ preconnect: _rawFetch.preconnect },
+		)
+		: _rawFetch;
 	const onSseEvent = options?.onSseEvent;
 	return new AzureOpenAI({
 		apiKey,

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1063,7 +1063,11 @@ async function createClient(
 	const baseFetch = fetchOverride ?? fetch;
 	const wrappedFetch = Object.assign(
 		async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
-			const response = await baseFetch(input, init);
+			const disableBunTimeout = typeof (globalThis as any).Bun !== "undefined";
+			const response = await baseFetch(
+				input,
+				disableBunTimeout ? ({ ...init, timeout: false } as any) : init,
+			);
 			if (response.ok) {
 				capturedErrorResponse = undefined;
 				return response;

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -379,7 +379,13 @@ function createClient(
 		headers.session_id ??= sessionId;
 		headers["x-client-request-id"] ??= sessionId;
 	}
-	const baseFetch = fetchOverride ?? fetch;
+	const _rawFetch = fetchOverride ?? fetch;
+	const baseFetch = typeof (globalThis as any).Bun !== "undefined"
+		? Object.assign(
+			async (input: string | URL | Request, init?: RequestInit) => _rawFetch(input, { ...init, timeout: false } as any),
+			{ preconnect: _rawFetch.preconnect },
+		)
+		: _rawFetch;
 	return {
 		client: new OpenAI({
 			apiKey,


### PR DESCRIPTION
Bun's fetch() has a built-in 300s timeout that fires below pi-ai's watchdog layer, killing long-running streaming requests to local models (LM Studio, Ollama, llama.cpp, vLLM) before PI_STREAM_FIRST_EVENT_TIMEOUT_MS can fire.

The completions, responses, and Azure responses providers now pass timeout: false to Bun's fetch() when running on Bun, so the pi-ai watchdog timers are the authoritative timeout layer. All changes are Bun-gated — Node runtimes are unaffected.

Closes #602