### PR TITLE
feat(tree): add Ctrl+B to branch from the selected entry in /tree

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a `Ctrl+B` shortcut in the `/tree` session-tree selector that branches from the highlighted entry. It moves the active leaf to that entry without the "Summarize branch?" prompt and drops you there, so your next message forks a new child while the line you left stays in the tree to return to. Pairs with the existing `Enter` (navigate, with optional summary) and `Shift+L` (label) actions, and the tree header now advertises it ([#1931](https://github.com/can1357/oh-my-pi/pull/1931) by [@AbdulazizAFM](https://github.com/AbdulazizAFM)).
+
 ## [15.9.2] - 2026-06-05
 
 ### Added

--- a/packages/coding-agent/src/modes/components/tree-selector.ts
+++ b/packages/coding-agent/src/modes/components/tree-selector.ts
@@ -66,6 +66,7 @@ class TreeList implements Component {
 	onSelect?: (entryId: string) => void;
 	onCancel?: () => void;
 	onLabelEdit?: (entryId: string, currentLabel: string | undefined) => void;
+	onBranch?: (entryId: string) => void;
 
 	constructor(
 		tree: SessionTreeNode[],
@@ -807,6 +808,11 @@ class TreeList implements Component {
 			if (selected && this.onLabelEdit) {
 				this.onLabelEdit(selected.node.entry.id, selected.node.label);
 			}
+		} else if (matchesKey(keyData, "ctrl+b")) {
+			const selected = this.#filteredNodes[this.#selectedIndex];
+			if (selected && this.onBranch) {
+				this.onBranch(selected.node.entry.id);
+			}
 		} else {
 			const printableText = extractPrintableText(keyData);
 			if (printableText) {
@@ -891,6 +897,7 @@ export class TreeSelectorComponent extends Container {
 		onCancel: () => void,
 		private readonly onLabelChangeCallback?: (entryId: string, label: string | undefined) => void,
 		initialFilterMode: FilterMode = "default",
+		onBranch?: (entryId: string) => void,
 	) {
 		super();
 		const maxVisibleLines = Math.max(5, Math.floor(terminalHeight / 2));
@@ -899,6 +906,7 @@ export class TreeSelectorComponent extends Container {
 		this.#treeList.onSelect = onSelect;
 		this.#treeList.onCancel = onCancel;
 		this.#treeList.onLabelEdit = (entryId, currentLabel) => this.#showLabelInput(entryId, currentLabel);
+		this.#treeList.onBranch = onBranch;
 
 		this.#treeContainer = new Container();
 		this.#treeContainer.addChild(this.#treeList);
@@ -912,7 +920,7 @@ export class TreeSelectorComponent extends Container {
 			new TruncatedText(
 				theme.fg(
 					"muted",
-					"Up/Down: move. Left/Right: page. Shift+L: label. Ctrl+O/Shift+Ctrl+O: filter. Alt+D/T/U/L/A: filter. Type to search",
+					"Up/Down: move. Left/Right: page. Ctrl+B: branch here. Shift+L: label. Ctrl+O/Shift+Ctrl+O: filter. Alt+D/T/U/L/A: filter. Type to search",
 				),
 				0,
 				0,

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -720,6 +720,33 @@ export class SelectorController {
 					this.ctx.ui.requestRender();
 				},
 				settings.get("treeFilterMode"),
+				async entryId => {
+					// Ctrl+B: instant in-file branch — move the leaf here with no summary
+					// prompt, drop the user at this point. The next message forks a new child,
+					// and the abandoned line stays in the tree to return to.
+					if (entryId === realLeafId) {
+						done();
+						this.ctx.showStatus("Already at this point");
+						return;
+					}
+					done();
+					try {
+						const result = await this.ctx.session.navigateTree(entryId, { summarize: false });
+						if (result.cancelled) {
+							this.ctx.showStatus("Branch cancelled");
+							return;
+						}
+						this.ctx.chatContainer.clear();
+						this.ctx.renderInitialMessages(result.sessionContext, { clearTerminalHistory: true });
+						await this.ctx.reloadTodos();
+						if (result.editorText && !this.ctx.editor.getText().trim()) {
+							this.ctx.editor.setText(result.editorText);
+						}
+						this.ctx.showStatus("Branched from selected point — continue here");
+					} catch (error) {
+						this.ctx.showError(error instanceof Error ? error.message : String(error));
+					}
+				},
 			);
 			return { component: selector, focus: selector };
 		});

--- a/packages/coding-agent/test/modes/components/tree-selector-branch.test.ts
+++ b/packages/coding-agent/test/modes/components/tree-selector-branch.test.ts
@@ -1,0 +1,66 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { TreeSelectorComponent } from "../../../src/modes/components/tree-selector";
+import * as themeModule from "../../../src/modes/theme/theme";
+import type { SessionEntry, SessionTreeNode } from "../../../src/session/session-manager";
+
+// Ctrl+B is delivered as the legacy control byte; protocol-independent (no kitty state needed).
+const CTRL_B = "\x02";
+const ARROW_UP = "\x1b[A";
+
+let counter = 0;
+function makeMessageNode(message: AgentMessage, parentId: string | null = null): SessionTreeNode {
+	const id = `entry-${counter++}`;
+	const entry: SessionEntry = {
+		type: "message",
+		id,
+		parentId,
+		timestamp: new Date().toISOString(),
+		message,
+	};
+	return { entry, children: [] };
+}
+
+function buildSelector(onBranch: (entryId: string) => void): {
+	selector: TreeSelectorComponent;
+	rootId: string;
+	leafId: string;
+} {
+	const root = makeMessageNode({ role: "user", content: "first", timestamp: 1 });
+	const child = makeMessageNode({ role: "user", content: "reply", timestamp: 2 }, root.entry.id);
+	root.children.push(child);
+	const selector = new TreeSelectorComponent(
+		[root],
+		child.entry.id,
+		60,
+		() => {},
+		() => {},
+		undefined,
+		"default",
+		onBranch,
+	);
+	return { selector, rootId: root.entry.id, leafId: child.entry.id };
+}
+
+describe("TreeSelectorComponent Ctrl+B branch shortcut", () => {
+	beforeAll(async () => {
+		await themeModule.initTheme(false, undefined, undefined, "dark", "light");
+	});
+
+	it("invokes onBranch with the highlighted entry, not the active leaf", () => {
+		const branched: string[] = [];
+		const { selector, rootId, leafId } = buildSelector(entryId => branched.push(entryId));
+		// Selection starts on the leaf; move up to the root entry, then branch from it.
+		selector.handleInput(ARROW_UP);
+		selector.handleInput(CTRL_B);
+		expect(branched).toEqual([rootId]);
+		expect(branched).not.toContain(leafId);
+	});
+
+	it("does not branch on a plain printable key (it stays search input)", () => {
+		const branched: string[] = [];
+		const { selector } = buildSelector(entryId => branched.push(entryId));
+		selector.handleInput("B");
+		expect(branched).toEqual([]);
+	});
+});


### PR DESCRIPTION
## What

Adds a `Ctrl+B` shortcut to the `/tree` session-tree selector that branches from the highlighted entry.

Highlight any entry in the tree and press `Ctrl+B`: the active leaf moves to that entry (a pure in-file leaf move via `navigateTree`, no summary prompt), the conversation is rebuilt at that point, and you're dropped there to continue. The next message you send forks a new child, while the line you left stays in the tree to return to. The tree header now advertises the shortcut.

## Why

`/tree` already navigates within the current session file, and `Enter` does an in-file leaf move — but it routes through the "Summarize branch?" decision flow. There was no single-key "drop me at this point and continue on a fresh branch" affordance. `Ctrl+B` fills that gap, reusing the existing `navigateTree(targetId, { summarize: false })` primitive (so it's a leaf move, not a new session file — siblings stay reachable in the tree).

`Ctrl+B` was chosen over `Shift+B` on purpose: under the kitty / CSI-u keyboard protocol the shifted-letter sequence decodes to printable text (`decodeKittyPrintable` only suppresses Ctrl/Alt/Super combos), so `Shift+B` would land in the tree's search box. `Ctrl+B` carries a modifier the decoder treats as a binding, so it can never leak into search.

## Testing

- `bun check` passes (full-workspace `check:ts` clean; biome clean).
- New contract test `packages/coding-agent/test/modes/components/tree-selector-branch.test.ts`: `Ctrl+B` invokes `onBranch` with the highlighted entry (not the active leaf), and a plain printable key does not branch.
- Existing `tree-selector` tests still pass (`tree-selector-developer`, `tree-selector-overflow`).
- Manually exercised in a compiled build: `Esc Esc` → highlight an entry → `Ctrl+B` drops you at that point; header shows the new shortcut.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
