### PR TITLE
fix(robomp): parameterize bot identity in system prompts

### DIFF
--- a/python/robomp/src/persona.py
+++ b/python/robomp/src/persona.py
@@ -128,12 +128,18 @@ def classify_next_step(primary: str) -> str:
     )
 
 
-def system_append(*, repo: RepoInfo, issue: IssueInfo, workspace: Workspace) -> str:
-    return render(_load("system_append.md"), {"repo": repo, "issue": issue, "workspace": workspace})
+def system_append(*, repo: RepoInfo, issue: IssueInfo, workspace: Workspace, bot_login: str) -> str:
+    return render(
+        _load("system_append.md"),
+        {"repo": repo, "issue": issue, "workspace": workspace, "bot_login": bot_login},
+    )
 
 
-def system_append_pr_review(*, repo: RepoInfo, issue: IssueInfo, workspace: Workspace) -> str:
-    return render(_load("system_append_pr_review.md"), {"repo": repo, "issue": issue, "workspace": workspace})
+def system_append_pr_review(*, repo: RepoInfo, issue: IssueInfo, workspace: Workspace, bot_login: str) -> str:
+    return render(
+        _load("system_append_pr_review.md"),
+        {"repo": repo, "issue": issue, "workspace": workspace, "bot_login": bot_login},
+    )
 
 
 def kickoff(*, repo: RepoInfo, issue: IssueInfo, workspace: Workspace) -> str:

--- a/python/robomp/src/prompts/system_append.md
+++ b/python/robomp/src/prompts/system_append.md
@@ -1,4 +1,4 @@
-You are **robomp**, an autonomous triage-and-fix bot operating on `{{repo.full_name}}`.
+You are **@{{bot_login}}**, an autonomous triage-and-fix bot operating on `{{repo.full_name}}`.
 
 <critical>
 - **Triage first.** Fresh, unclassified issue → first action is `classify_issue(primary=..., rationale=...)`. NEVER comment, push, open a PR, or run a repro until labels land.

--- a/python/robomp/src/prompts/system_append_pr_review.md
+++ b/python/robomp/src/prompts/system_append_pr_review.md
@@ -1,4 +1,4 @@
-You are **robomp**, reviewing an incoming pull request on `{{repo.full_name}}`.
+You are **@{{bot_login}}**, reviewing an incoming pull request on `{{repo.full_name}}`.
 
 <critical>
 - **Read-only PR review.** Never edit files, commit, push, open a PR, approve, request changes, merge, or close.

--- a/python/robomp/src/worker.py
+++ b/python/robomp/src/worker.py
@@ -512,9 +512,19 @@ def _run_rpc_blocking(
     )
     inputs.db.set_event_model(inputs.delivery_id, chosen_model)
     append_system_prompt = (
-        persona.system_append_pr_review(repo=inputs.repo, issue=inputs.issue, workspace=inputs.workspace)
+        persona.system_append_pr_review(
+            repo=inputs.repo,
+            issue=inputs.issue,
+            workspace=inputs.workspace,
+            bot_login=inputs.settings.bot_login,
+        )
         if task_kind == "review_pr"
-        else persona.system_append(repo=inputs.repo, issue=inputs.issue, workspace=inputs.workspace)
+        else persona.system_append(
+            repo=inputs.repo,
+            issue=inputs.issue,
+            workspace=inputs.workspace,
+            bot_login=inputs.settings.bot_login,
+        )
     )
 
     with RpcClient(

--- a/python/robomp/tests/test_persona.py
+++ b/python/robomp/tests/test_persona.py
@@ -181,3 +181,27 @@ def test_review_completion_reminder_mentions_submit_only() -> None:
     )
     assert "submit_pr_review" in out
     assert "gh_open_pr" not in out
+
+
+def test_system_append_renders_configured_bot_login() -> None:
+    out = persona.system_append(
+        repo=_Repo(),
+        issue=_Issue(),
+        workspace=_Workspace(),
+        bot_login="Svitter",
+    )
+    # The hardcoded persona name MUST be replaced by the configured login so
+    # the agent self-mentions the account that actually receives webhooks.
+    assert "You are **@Svitter**" in out
+    assert "**robomp**" not in out
+
+
+def test_system_append_pr_review_renders_configured_bot_login() -> None:
+    out = persona.system_append_pr_review(
+        repo=_Repo(),
+        issue=_Issue(),
+        workspace=_Workspace(),
+        bot_login="Svitter",
+    )
+    assert "You are **@Svitter**" in out
+    assert "**robomp**" not in out

--- a/python/robomp/tests/test_worker.py
+++ b/python/robomp/tests/test_worker.py
@@ -149,7 +149,7 @@ def _patch_worker(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr("robomp.worker.host_tools.build", lambda _b: ())
     monkeypatch.setattr(
         "robomp.worker.persona.system_append",
-        lambda *, repo, issue, workspace: "SYS",
+        lambda *, repo, issue, workspace, bot_login: "SYS",
     )
     monkeypatch.setattr(
         "robomp.worker.persona.seed_phases",


### PR DESCRIPTION
## Repro

`python/robomp/src/prompts/system_append.md:1` and
`python/robomp/src/prompts/system_append_pr_review.md:1` both open with
the literal `You are **robomp**, …`. When `ROBOMP_BOT_LOGIN` is set to
anything other than `robomp` (e.g. `Svitter`), the system prompt still
introduces the agent as `robomp`, so the model then asks users to
`@robomp proceed` in comments — but `@robomp` is not the deployed
account and GitHub never delivers a webhook for it.

```
$ grep -nE "You are \*\*[A-Za-z_-]+\*\*" python/robomp/src/prompts/system_append.md python/robomp/src/prompts/system_append_pr_review.md
python/robomp/src/prompts/system_append.md:1:You are **robomp**, an autonomous triage-and-fix bot operating on `{{repo.full_name}}`.
python/robomp/src/prompts/system_append_pr_review.md:1:You are **robomp**, reviewing an incoming pull request on `{{repo.full_name}}`.
```

## Cause

`persona.system_append()` / `persona.system_append_pr_review()`
(`python/robomp/src/persona.py:131-136` pre-fix) built the render
scope from `{repo, issue, workspace}` only. The configured
`Settings.bot_login` (`python/robomp/src/config.py:36`) was never threaded
into the scope, so the `robomp` literal in the prompt body had no
runtime substitute and shipped verbatim to the model. The worker
callsite in `python/robomp/src/worker.py:514-518` mirrored the gap.

## Fix

- Added `bot_login: str` keyword to `persona.system_append()` and
  `persona.system_append_pr_review()`; the value lands in the render
  scope under the `bot_login` key.
- Replaced `**robomp**` with `**@{{bot_login}}**` in both
  `system_append.md` and `system_append_pr_review.md`. The `@` prefix
  matches the GitHub-mention form the agent should use when referring
  to itself in comments.
- `worker._build_prompt` now passes `inputs.settings.bot_login` to both
  branches of the system-prompt selector.
- Updated the worker test stub in `tests/test_worker.py` to mirror the
  new keyword signature.

## Verification

`bun run --cwd=python/robomp .venv/bin/python -m pytest tests/test_persona.py tests/test_worker.py -q`
→ 38 passed. Two new regression tests (`test_system_append_renders_configured_bot_login`,
`test_system_append_pr_review_renders_configured_bot_login`) assert both prompts render `You are **@Svitter**` and no longer contain the `**robomp**` literal.

Full suite (`pytest tests`) surfaces two failures unrelated to this diff and pre-existing on the branch base, confirmed by stashing the diff and re-running both alone:

- `tests/test_sandbox.py::test_run_git_injects_safe_directory_and_subprocess_identity` — asserts `GIT_CONFIG_COUNT == "1"` but `_run_git` already injects two `git -c` entries; reproduces on stashed `HEAD`.
- `tests/test_server.py::test_trigger_triage_replaces_inactive_manual_delivery` — flaky dispatcher/mock race: the dispatcher claims the queued event and calls `proxy_client.list_closing_pull_requests` against `gh-proxy.invalid:8081` before `_install_github_mock()` runs, surfacing `httpx.ConnectError` and a `running` row instead of `queued`.

Neither path is touched by this diff (prompts + persona signature + worker callsite + persona/worker tests only).

Fixes #1932