### PR TITLE
feat(coding-agent): guard jj mutation workflows

### DIFF
--- a/packages/coding-agent/src/autoresearch/git.ts
+++ b/packages/coding-agent/src/autoresearch/git.ts
@@ -1,9 +1,21 @@
+import { Settings } from "../config/settings";
 import type { ExtensionAPI } from "../extensibility/extensions";
 import * as git from "../utils/git";
+import { resolveRepositoryMode } from "../utils/repository-mode";
 import { normalizePathSpec } from "./helpers";
 
 const AUTORESEARCH_BRANCH_PREFIX = "autoresearch/";
 const BRANCH_NAME_MAX_LENGTH = 48;
+const PURE_JJ_AUTORESEARCH_ERROR =
+	"Autoresearch branch isolation is not supported in pure jj repositories yet. Use a colocated Git repository or run without branch isolation.";
+
+function repositoryModeProbeError(err: unknown): string {
+	return `Unable to resolve repository mode before autoresearch branch isolation: ${err instanceof Error ? err.message : String(err)}`;
+}
+
+function isNoSupportedRepositoryError(err: unknown): boolean {
+	return err instanceof Error && err.message.startsWith("No supported repository mode detected.");
+}
 
 export interface EnsureAutoresearchBranchFailure {
 	error: string;
@@ -37,6 +49,11 @@ export async function ensureAutoresearchBranch(
 	workDir: string,
 	goal: string | null,
 ): Promise<EnsureAutoresearchBranchResult> {
+	const gitInteropGuard = await checkGitInteropMutations(workDir);
+	if (gitInteropGuard) {
+		return { ok: false, error: gitInteropGuard };
+	}
+
 	const repoRoot = await git.repo.root(workDir);
 	if (!repoRoot) {
 		return {
@@ -82,6 +99,18 @@ export async function ensureAutoresearchBranch(
 		};
 	}
 	return { ok: true, branchName, created: true };
+}
+
+async function checkGitInteropMutations(workDir: string): Promise<string | null> {
+	try {
+		const settings = await Settings.init({ cwd: workDir });
+		const mode = await resolveRepositoryMode(workDir, settings.get("repository.mode"));
+		if (mode.capabilities.canUseGitInteropMutations && mode.gitRepository !== null) return null;
+		return PURE_JJ_AUTORESEARCH_ERROR;
+	} catch (err) {
+		if (isNoSupportedRepositoryError(err)) return null;
+		return repositoryModeProbeError(err);
+	}
 }
 
 export function parseWorkDirDirtyPaths(statusOutput: string, workDirPrefix: string): string[] {

--- a/packages/coding-agent/src/commit/agentic/index.ts
+++ b/packages/coding-agent/src/commit/agentic/index.ts
@@ -11,6 +11,12 @@ import { ModelRegistry } from "../../config/model-registry";
 import { Settings } from "../../config/settings";
 import { discoverAuthStorage, discoverContextFiles } from "../../sdk";
 import * as git from "../../utils/git";
+import * as jj from "../../utils/jj";
+import {
+	assertRepositoryModeCapability,
+	type RepositoryMode,
+	resolveRepositoryMode,
+} from "../../utils/repository-mode";
 import { type ExistingChangelogEntries, runCommitAgentSession } from "./agent";
 import { generateFallbackProposal } from "./fallback";
 import splitConfirmPrompt from "./prompts/split-confirm.md" with { type: "text" };
@@ -21,19 +27,23 @@ import { detectTrivialChange } from "./trivial";
 interface CommitExecutionContext {
 	cwd: string;
 	dryRun: boolean;
+	repositoryMode: RepositoryMode;
 	push: boolean;
 }
 
 export async function runAgenticCommit(args: CommitCommandArgs): Promise<void> {
 	const cwd = getProjectDir();
 	const [settings, authStorage] = await Promise.all([Settings.init({ cwd }), discoverAuthStorage()]);
+	const repositoryMode = await resolveRepositoryMode(cwd, settings.get("repository.mode"));
+	assertSupportedJjCommitOptions(repositoryMode, args);
+	const useJj = repositoryMode.kind !== "git";
 
 	process.stdout.write("● Resolving model...\n");
 	const modelRegistry = new ModelRegistry(authStorage);
 	await modelRegistry.refresh();
 	const stagedFilesPromise = (async () => {
-		let stagedFiles = await git.diff.changedFiles(cwd, { cached: true });
-		if (stagedFiles.length === 0) {
+		let stagedFiles = useJj ? await jj.diff.changedFiles(cwd) : await git.diff.changedFiles(cwd, { cached: true });
+		if (!useJj && stagedFiles.length === 0) {
 			process.stdout.write("No staged changes detected, staging all changes...\n");
 			await git.stage.files(cwd);
 			stagedFiles = await git.diff.changedFiles(cwd, { cached: true });
@@ -58,17 +68,18 @@ export async function runAgenticCommit(args: CommitCommandArgs): Promise<void> {
 		return;
 	}
 
-	if (!args.noChangelog) {
+	const changelogEnabled = !args.noChangelog && !useJj;
+	if (changelogEnabled) {
 		process.stdout.write("● Detecting changelog targets...\n");
 	}
 	const [changelogBoundaries, contextFiles, numstat, diff] = await Promise.all([
-		args.noChangelog ? [] : detectChangelogBoundaries(cwd, stagedFiles),
+		changelogEnabled ? detectChangelogBoundaries(cwd, stagedFiles) : [],
 		discoverContextFiles(cwd),
-		git.diff.numstat(cwd, { cached: true }),
-		git.diff(cwd, { cached: true }),
+		useJj ? [] : git.diff.numstat(cwd, { cached: true }),
+		useJj ? jj.diff(cwd) : git.diff(cwd, { cached: true }),
 	]);
 	const changelogTargets = changelogBoundaries.map(boundary => boundary.changelogPath);
-	if (!args.noChangelog) {
+	if (changelogEnabled) {
 		if (changelogTargets.length > 0) {
 			for (const path of changelogTargets) {
 				process.stdout.write(`  └─ ${path}\n`);
@@ -91,7 +102,7 @@ export async function runAgenticCommit(args: CommitCommandArgs): Promise<void> {
 	if (forceFallback) {
 		process.stdout.write("● Forcing fallback commit generation...\n");
 		const fallbackProposal = generateFallbackProposal(numstat);
-		await runSingleCommit(fallbackProposal, { cwd, dryRun: args.dryRun, push: args.push });
+		await runSingleCommit(fallbackProposal, { cwd, dryRun: args.dryRun, repositoryMode, push: args.push });
 		return;
 	}
 
@@ -108,12 +119,12 @@ export async function runAgenticCommit(args: CommitCommandArgs): Promise<void> {
 			summary: trivialChange.summary,
 			warnings: [],
 		};
-		await runSingleCommit(trivialProposal, { cwd, dryRun: args.dryRun, push: args.push });
+		await runSingleCommit(trivialProposal, { cwd, dryRun: args.dryRun, repositoryMode, push: args.push });
 		return;
 	}
 
 	let existingChangelogEntries: ExistingChangelogEntries[] | undefined;
-	if (!args.noChangelog && changelogTargets.length > 0) {
+	if (changelogEnabled && changelogTargets.length > 0) {
 		existingChangelogEntries = await loadExistingChangelogEntries(changelogTargets);
 		if (existingChangelogEntries.length === 0) {
 			existingChangelogEntries = undefined;
@@ -159,7 +170,7 @@ export async function runAgenticCommit(args: CommitCommandArgs): Promise<void> {
 	}
 
 	let updatedChangelogFiles: string[] = [];
-	if (!args.noChangelog && changelogTargets.length > 0 && !usedFallback) {
+	if (changelogEnabled && changelogTargets.length > 0 && !usedFallback) {
 		if (!commitState.changelogProposal) {
 			process.stderr.write("Commit agent did not provide changelog entries.\n");
 			return;
@@ -184,7 +195,7 @@ export async function runAgenticCommit(args: CommitCommandArgs): Promise<void> {
 	}
 
 	if (commitState.proposal) {
-		await runSingleCommit(commitState.proposal, { cwd, dryRun: args.dryRun, push: args.push });
+		await runSingleCommit(commitState.proposal, { cwd, dryRun: args.dryRun, repositoryMode, push: args.push });
 		return;
 	}
 
@@ -192,6 +203,7 @@ export async function runAgenticCommit(args: CommitCommandArgs): Promise<void> {
 		await runSplitCommit(commitState.splitProposal, {
 			cwd,
 			dryRun: args.dryRun,
+			repositoryMode,
 			push: args.push,
 			additionalFiles: updatedChangelogFiles,
 		});
@@ -199,6 +211,20 @@ export async function runAgenticCommit(args: CommitCommandArgs): Promise<void> {
 	}
 
 	process.stderr.write("Commit agent did not provide a proposal.\n");
+}
+
+function assertSupportedJjCommitOptions(mode: RepositoryMode, args: CommitCommandArgs): void {
+	if (mode.kind === "git") return;
+	if (args.push) {
+		throw new Error(
+			`Repository mode '${mode.kind}' does not support push after jj commit. Supported alternative: single commit without --push.`,
+		);
+	}
+	if (!args.noChangelog) {
+		throw new Error(
+			`Repository mode '${mode.kind}' does not support changelog updates in jj commit flow yet. Supported alternative: pass --no-changelog for jj commit flow, or use Git mode.`,
+		);
+	}
 }
 
 async function runSingleCommit(proposal: CommitProposal, ctx: CommitExecutionContext): Promise<void> {
@@ -211,9 +237,13 @@ async function runSingleCommit(proposal: CommitProposal, ctx: CommitExecutionCon
 		process.stdout.write(`${commitMessage}\n`);
 		return;
 	}
-	await git.commit(ctx.cwd, commitMessage);
+	if (ctx.repositoryMode.kind === "git") {
+		await git.commit(ctx.cwd, commitMessage);
+	} else {
+		await jj.commit(ctx.cwd, commitMessage);
+	}
 	process.stdout.write("Commit created.\n");
-	if (ctx.push) {
+	if (ctx.push && ctx.repositoryMode.kind === "git") {
 		await git.push(ctx.cwd);
 		process.stdout.write("Pushed to remote.\n");
 	}
@@ -223,6 +253,7 @@ async function runSplitCommit(
 	plan: SplitCommitPlan,
 	ctx: CommitExecutionContext & { additionalFiles?: string[] },
 ): Promise<void> {
+	assertRepositoryModeCapability(ctx.repositoryMode, "canSplitCommit", "split commit", "single commit");
 	if (plan.warnings.length > 0) {
 		process.stdout.write(formatWarnings(plan.warnings));
 	}

--- a/packages/coding-agent/src/commit/pipeline.ts
+++ b/packages/coding-agent/src/commit/pipeline.ts
@@ -7,6 +7,8 @@ import { Settings } from "../config/settings";
 import { discoverAuthStorage } from "../sdk";
 import { loadProjectContextFiles } from "../system-prompt";
 import * as git from "../utils/git";
+import * as jj from "../utils/jj";
+import { type RepositoryMode, resolveRepositoryMode } from "../utils/repository-mode";
 import { runAgenticCommit } from "./agentic";
 import {
 	extractScopeCandidates,
@@ -41,6 +43,8 @@ export async function runCommitCommand(args: CommitCommandArgs): Promise<void> {
 async function runLegacyCommitCommand(args: CommitCommandArgs): Promise<void> {
 	const cwd = getProjectDir();
 	const settings = await Settings.init();
+	const repositoryMode = await resolveRepositoryMode(cwd, settings.get("repository.mode"));
+	assertSupportedJjCommitOptions(repositoryMode, args);
 	const commitSettings = settings.getGroup("commit");
 	const authStorage = await discoverAuthStorage();
 	const modelRegistry = new ModelRegistry(authStorage);
@@ -57,8 +61,9 @@ async function runLegacyCommitCommand(args: CommitCommandArgs): Promise<void> {
 		thinkingLevel: smolThinkingLevel,
 	} = await resolveSmolModel(settings, modelRegistry, primaryModel, primaryApiKey);
 
-	let stagedFiles = await git.diff.changedFiles(cwd, { cached: true });
-	if (stagedFiles.length === 0) {
+	const useJj = repositoryMode.kind !== "git";
+	let stagedFiles = useJj ? await jj.diff.changedFiles(cwd) : await git.diff.changedFiles(cwd, { cached: true });
+	if (!useJj && stagedFiles.length === 0) {
 		process.stdout.write("No staged changes detected, staging all changes...\n");
 		await git.stage.files(cwd);
 		stagedFiles = await git.diff.changedFiles(cwd, { cached: true });
@@ -68,7 +73,7 @@ async function runLegacyCommitCommand(args: CommitCommandArgs): Promise<void> {
 		return;
 	}
 
-	if (!args.noChangelog) {
+	if (!args.noChangelog && !useJj) {
 		await runChangelogFlow({
 			cwd,
 			model: primaryModel,
@@ -80,11 +85,11 @@ async function runLegacyCommitCommand(args: CommitCommandArgs): Promise<void> {
 		});
 	}
 
-	const diff = await git.diff(cwd, { cached: true });
-	const stat = await git.diff(cwd, { stat: true, cached: true });
-	const numstat = await git.diff.numstat(cwd, { cached: true });
+	const diff = useJj ? await jj.diff(cwd) : await git.diff(cwd, { cached: true });
+	const stat = useJj ? "" : await git.diff(cwd, { stat: true, cached: true });
+	const numstat = useJj ? [] : await git.diff.numstat(cwd, { cached: true });
 	const scopeCandidates = extractScopeCandidates(numstat).scopeCandidates;
-	const recentCommits = await git.log.subjects(cwd, RECENT_COMMITS_COUNT);
+	const recentCommits = useJj ? [] : await git.log.subjects(cwd, RECENT_COMMITS_COUNT);
 	const contextFiles = await loadProjectContextFiles({ cwd });
 	const formattedContextFiles = contextFiles.map(file => ({
 		path: path.relative(cwd, file.path),
@@ -129,11 +134,29 @@ async function runLegacyCommitCommand(args: CommitCommandArgs): Promise<void> {
 		return;
 	}
 
-	await git.commit(cwd, commitMessage);
+	if (useJj) {
+		await jj.commit(cwd, commitMessage);
+	} else {
+		await git.commit(cwd, commitMessage);
+	}
 	process.stdout.write("Commit created.\n");
-	if (args.push) {
+	if (args.push && !useJj) {
 		await git.push(cwd);
 		process.stdout.write("Pushed to remote.\n");
+	}
+}
+
+function assertSupportedJjCommitOptions(mode: RepositoryMode, args: CommitCommandArgs): void {
+	if (mode.kind === "git") return;
+	if (args.push) {
+		throw new Error(
+			`Repository mode '${mode.kind}' does not support push after jj commit. Supported alternative: single commit without --push.`,
+		);
+	}
+	if (!args.noChangelog) {
+		throw new Error(
+			`Repository mode '${mode.kind}' does not support changelog updates in jj commit flow yet. Supported alternative: pass --no-changelog for jj commit flow, or use Git mode.`,
+		);
 	}
 }
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -23,6 +23,7 @@ import {
 	TINY_TITLE_MODEL_VALUES,
 } from "../tiny/models";
 import { EDIT_MODES } from "../utils/edit-mode";
+import type { RepositoryModeSetting } from "../utils/repository-mode";
 import { SEARCH_PROVIDER_OPTIONS, SEARCH_PROVIDER_PREFERENCES } from "../web/search/types";
 
 /** Unified settings schema - single source of truth for all settings.
@@ -214,6 +215,7 @@ const EMPTY_STRING_RECORD: Record<string, string> = {};
 const DEFAULT_CYCLE_ORDER: string[] = ["smol", "default", "slow"];
 const EMPTY_MODEL_TAGS_RECORD: ModelTagsSettings = {};
 const HINDSIGHT_RECALL_TYPES_DEFAULT: string[] = ["world", "experience"];
+const REPOSITORY_MODE_VALUES = ["auto", "git", "jj"] as const satisfies readonly RepositoryModeSetting[];
 export const DEFAULT_BASH_INTERCEPTOR_RULES: BashInterceptorRule[] = [
 	{
 		pattern: "^\\s*(cat|head|tail|less|more)\\s+",
@@ -316,6 +318,12 @@ export const SETTINGS_SCHEMA = {
 	shellPath: { type: "string", default: undefined },
 
 	extensions: { type: "array", default: EMPTY_STRING_ARRAY },
+
+	"repository.mode": {
+		type: "enum",
+		values: REPOSITORY_MODE_VALUES,
+		default: "auto",
+	},
 
 	"marketplace.autoUpdate": {
 		type: "enum",

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -9,6 +9,8 @@ import type { StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle } 
 import { theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
 import * as git from "../../utils/git";
+import * as jj from "../../utils/jj";
+import { type RepositoryKind, type RepositoryMode, resolveRepositoryMode } from "../../utils/repository-mode";
 import { getSessionAccentAnsi, getSessionAccentHex } from "../../utils/session-color";
 import { sanitizeStatusText } from "../shared";
 import { computeNonMessageTokens } from "../utils/context-usage";
@@ -167,6 +169,9 @@ export class StatusLineComponent implements Component {
 	#defaultBranch?: string;
 	#lastTokensPerSecond: number | null = null;
 	#lastTokensPerSecondTimestamp: number | null = null;
+	#cachedRepositoryMode: RepositoryMode | null = null;
+	#repositoryModeCacheKey: string | null = null;
+	#repositoryModeInFlight = false;
 
 	// Anthropic usage caching (5-min TTL, OAuth/sub only)
 	#cachedUsage: {
@@ -249,6 +254,10 @@ export class StatusLineComponent implements Component {
 			this.#gitWatcher = null;
 		}
 
+		if (settings.get("repository.mode") === "jj" && this.#cachedRepositoryMode?.kind !== "jj-git-interop") {
+			return;
+		}
+
 		const gitHeadPath = git.repo.resolveSync(getProjectDir())?.headPath ?? null;
 		if (!gitHeadPath) return;
 
@@ -280,6 +289,58 @@ export class StatusLineComponent implements Component {
 		this.#cachedBranchRepoId = undefined;
 		this.#cachedPrContext = undefined;
 	}
+	#repositoryModeKey(): string {
+		return `${getProjectDir()}:${settings.get("repository.mode")}`;
+	}
+
+	#getRepositoryMode(): RepositoryMode | null {
+		const cacheKey = this.#repositoryModeKey();
+		if (this.#repositoryModeCacheKey === cacheKey) {
+			return this.#cachedRepositoryMode;
+		}
+		this.#repositoryModeCacheKey = cacheKey;
+		this.#cachedRepositoryMode = null;
+		this.#cachedGitStatus = null;
+		this.#gitStatusLastFetch = 0;
+		this.#invalidateGitCaches();
+		if (this.#repositoryModeInFlight) return null;
+
+		this.#repositoryModeInFlight = true;
+		const cwd = getProjectDir();
+		const modeSetting = settings.get("repository.mode");
+		(async () => {
+			try {
+				const mode = await resolveRepositoryMode(cwd, modeSetting);
+				if (this.#repositoryModeCacheKey === `${cwd}:${modeSetting}`) {
+					this.#cachedRepositoryMode = mode;
+					if (this.#onBranchChange) {
+						this.#onBranchChange();
+					}
+				}
+			} catch {
+				if (this.#repositoryModeCacheKey === `${cwd}:${modeSetting}`) {
+					this.#cachedRepositoryMode = null;
+				}
+			} finally {
+				this.#repositoryModeInFlight = false;
+			}
+		})();
+
+		return null;
+	}
+
+	#canUseGitFirstRenderFallback(): boolean {
+		const modeSetting = settings.get("repository.mode");
+		if (modeSetting === "git") return true;
+		if (modeSetting === "jj") return false;
+		return git.repo.resolveSync(getProjectDir()) !== null;
+	}
+
+	#getRenderRepositoryKind(mode: RepositoryMode | null): RepositoryKind | null {
+		if (mode) return mode.kind;
+		return this.#canUseGitFirstRenderFallback() ? "git" : null;
+	}
+
 	#getCurrentBranch(): string | null {
 		const head = git.head.resolveSync(getProjectDir());
 		const gitHeadPath = head?.headPath ?? null;
@@ -314,16 +375,18 @@ export class StatusLineComponent implements Component {
 		return branch === this.#defaultBranch;
 	}
 
-	#getGitStatus(): { staged: number; unstaged: number; untracked: number } | null {
+	#getRepositoryStatus(kind: RepositoryKind | null): { staged: number; unstaged: number; untracked: number } | null {
+		if (!kind) return null;
 		if (this.#gitStatusInFlight || Date.now() - this.#gitStatusLastFetch < 1000) {
 			return this.#cachedGitStatus;
 		}
 
 		this.#gitStatusInFlight = true;
+		const cwd = getProjectDir();
 
 		(async () => {
 			try {
-				this.#cachedGitStatus = await git.status.summary(getProjectDir());
+				this.#cachedGitStatus = kind === "git" ? await git.status.summary(cwd) : await jj.status.summary(cwd);
 			} catch {
 				this.#cachedGitStatus = null;
 			} finally {
@@ -333,6 +396,13 @@ export class StatusLineComponent implements Component {
 		})();
 
 		return this.#cachedGitStatus;
+	}
+
+	#getRepositoryLabel(kind: RepositoryKind | null): string | null {
+		if (!kind) return null;
+		if (kind === "jj") return "jj";
+		if (kind === "jj-git-interop") return this.#getCurrentBranch() ?? "jj";
+		return this.#getCurrentBranch();
 	}
 
 	#lookupPr(): { number: number; url: string } | null {
@@ -571,6 +641,8 @@ export class StatusLineComponent implements Component {
 		const contextTokens = breakdown.usedTokens;
 		const contextWindow = breakdown.contextWindow || state.model?.contextWindow || 0;
 		const contextPercent = contextWindow > 0 ? (contextTokens / contextWindow) * 100 : 0;
+		const repositoryMode = this.#getRepositoryMode();
+		const repositoryKind = this.#getRenderRepositoryKind(repositoryMode);
 
 		return {
 			session: this.session,
@@ -586,9 +658,9 @@ export class StatusLineComponent implements Component {
 			subagentCount: this.#subagentCount,
 			sessionStartTime: this.#sessionStartTime,
 			git: {
-				branch: this.#getCurrentBranch(),
-				status: this.#getGitStatus(),
-				pr: this.#lookupPr(),
+				branch: this.#getRepositoryLabel(repositoryKind),
+				status: this.#getRepositoryStatus(repositoryKind),
+				pr: repositoryKind === "git" ? this.#lookupPr() : null,
 			},
 			usage: this.#cachedUsage,
 		};

--- a/packages/coding-agent/src/task/worktree.ts
+++ b/packages/coding-agent/src/task/worktree.ts
@@ -4,10 +4,25 @@ import * as os from "node:os";
 import * as path from "node:path";
 import * as natives from "@oh-my-pi/pi-natives";
 import { getWorktreeDir, hashPath, logger, Snowflake } from "@oh-my-pi/pi-utils";
+import { Settings } from "../config/settings";
 import * as git from "../utils/git";
+import { resolveRepositoryMode } from "../utils/repository-mode";
 
 const { IsoBackendKind } = natives;
 type IsoBackendKind = natives.IsoBackendKind;
+
+const PURE_JJ_TASK_ISOLATION_ERROR =
+	"Task isolation is not supported in pure jj repositories yet. Use a colocated Git repository or disable task isolation for this run.";
+
+function repositoryModeProbeError(operation: string, err: unknown): Error {
+	return new Error(
+		`Unable to resolve repository mode before ${operation}: ${err instanceof Error ? err.message : String(err)}`,
+	);
+}
+
+function isNoSupportedRepositoryError(err: unknown): boolean {
+	return err instanceof Error && err.message.startsWith("No supported repository mode detected.");
+}
 
 /** Baseline state for a single git repository. */
 export interface RepoBaseline {
@@ -26,7 +41,33 @@ export interface WorktreeBaseline {
 	nested: Array<{ relativePath: string; baseline: RepoBaseline }>;
 }
 
+async function resolveGitInteropRepoRoot(cwd: string): Promise<string | null> {
+	try {
+		const settings = await Settings.init({ cwd });
+		const mode = await resolveRepositoryMode(cwd, settings.get("repository.mode"));
+		if (!mode.capabilities.canUseGitInteropMutations || !mode.gitRepository) {
+			throw new Error(PURE_JJ_TASK_ISOLATION_ERROR);
+		}
+		return mode.gitRepository.repoRoot;
+	} catch (err) {
+		if (err instanceof Error && err.message === PURE_JJ_TASK_ISOLATION_ERROR) {
+			throw err;
+		}
+		if (isNoSupportedRepositoryError(err)) {
+			return null;
+		}
+		throw repositoryModeProbeError("task isolation", err);
+	}
+}
+
+async function assertGitInteropMutationsSupported(cwd: string): Promise<void> {
+	await resolveGitInteropRepoRoot(cwd);
+}
+
 export async function getRepoRoot(cwd: string): Promise<string> {
+	const resolvedRepoRoot = await resolveGitInteropRepoRoot(cwd);
+	if (resolvedRepoRoot) return resolvedRepoRoot;
+
 	const repoRoot = await git.repo.root(cwd);
 	if (!repoRoot) {
 		throw new Error("Git repository not found for isolated task execution.");
@@ -125,6 +166,7 @@ async function writeSyntheticTree(repoDir: string, baseTreeish: string, patches:
 }
 
 export async function captureBaseline(repoRoot: string): Promise<WorktreeBaseline> {
+	await assertGitInteropMutationsSupported(repoRoot);
 	const [root, nestedPaths] = await Promise.all([captureRepoBaseline(repoRoot), discoverNestedRepos(repoRoot)]);
 	const nested = await Promise.all(
 		nestedPaths.map(async relativePath => ({

--- a/packages/coding-agent/src/utils/jj.ts
+++ b/packages/coding-agent/src/utils/jj.ts
@@ -35,6 +35,16 @@ export interface DiffOptions {
 	readonly signal?: AbortSignal;
 }
 
+export interface JjStatusSummary {
+	staged: number;
+	unstaged: number;
+	untracked: number;
+}
+
+export interface CommitOptions {
+	readonly signal?: AbortSignal;
+}
+
 interface CommandOptions {
 	readonly signal?: AbortSignal;
 }
@@ -219,6 +229,26 @@ export const diff = Object.assign(
 		},
 	},
 );
+
+// ════════════════════════════════════════════════════════════════════════════
+// API: status
+// ════════════════════════════════════════════════════════════════════════════
+
+export const status = {
+	/** Parsed working-copy status counts. JJ has no Git-style staging area, so all diff names are unstaged. */
+	async summary(cwd: string, signal?: AbortSignal): Promise<JjStatusSummary> {
+		const changedFiles = await diff.changedFiles(cwd, { signal });
+		return { staged: 0, unstaged: changedFiles.length, untracked: 0 };
+	},
+};
+
+// ════════════════════════════════════════════════════════════════════════════
+// API: commit
+// ════════════════════════════════════════════════════════════════════════════
+
+export async function commit(cwd: string, message: string, options: CommitOptions = {}): Promise<JjCommandResult> {
+	return runChecked(cwd, ["commit", "--message", message], { signal: options.signal });
+}
 
 // ════════════════════════════════════════════════════════════════════════════
 // API: repo

--- a/packages/coding-agent/src/utils/repository-mode.ts
+++ b/packages/coding-agent/src/utils/repository-mode.ts
@@ -1,0 +1,123 @@
+import * as git from "./git";
+import * as jj from "./jj";
+
+export type RepositoryModeSetting = "auto" | "git" | "jj";
+export type RepositoryKind = "git" | "jj-git-interop" | "jj";
+
+export type RepositoryModeCapability =
+	| "canReadWorkingCopyDiff"
+	| "canReadRevDiff"
+	| "canReadStatus"
+	| "canSingleCommit"
+	| "canSplitCommit"
+	| "canUseGitInteropMutations"
+	| "canUseNativeWorkspaceMutations";
+
+export type RepositoryModeCapabilities = Record<RepositoryModeCapability, boolean>;
+
+export interface RepositoryMode {
+	readonly setting: RepositoryModeSetting;
+	readonly kind: RepositoryKind;
+	readonly capabilities: RepositoryModeCapabilities;
+	readonly gitRepository: git.GitRepository | null;
+	readonly jjRepository: jj.JjRepository | null;
+}
+
+export interface ResolveRepositoryModeOptions {
+	readonly detectGit?: (cwd: string) => Promise<git.GitRepository | null>;
+	readonly detectJj?: (cwd: string) => Promise<jj.JjRepository | null>;
+}
+
+const GIT_CAPABILITIES: RepositoryModeCapabilities = {
+	canReadWorkingCopyDiff: true,
+	canReadRevDiff: true,
+	canReadStatus: true,
+	canSingleCommit: true,
+	canSplitCommit: true,
+	canUseGitInteropMutations: true,
+	canUseNativeWorkspaceMutations: false,
+};
+
+const JJ_GIT_INTEROP_CAPABILITIES: RepositoryModeCapabilities = {
+	canReadWorkingCopyDiff: true,
+	canReadRevDiff: true,
+	canReadStatus: true,
+	canSingleCommit: true,
+	canSplitCommit: false,
+	canUseGitInteropMutations: true,
+	canUseNativeWorkspaceMutations: false,
+};
+
+const JJ_CAPABILITIES: RepositoryModeCapabilities = {
+	canReadWorkingCopyDiff: true,
+	canReadRevDiff: true,
+	canReadStatus: true,
+	canSingleCommit: true,
+	canSplitCommit: false,
+	canUseGitInteropMutations: false,
+	canUseNativeWorkspaceMutations: false,
+};
+
+export async function resolveRepositoryMode(
+	cwd: string,
+	setting: RepositoryModeSetting = "auto",
+	options: ResolveRepositoryModeOptions = {},
+): Promise<RepositoryMode> {
+	const detectGit = options.detectGit ?? git.repo.resolve;
+	const detectJj = options.detectJj ?? jj.repo.resolve;
+
+	if (setting === "git") {
+		const gitRepository = await detectGit(cwd);
+		if (!gitRepository) throw new Error("Repository mode 'git' requires a Git repository.");
+		return buildRepositoryMode(setting, "git", gitRepository, null);
+	}
+
+	const jjRepository = await detectJj(cwd);
+	if (setting === "jj" && !jjRepository) {
+		throw new Error("Repository mode 'jj' requires a JJ workspace.");
+	}
+
+	if (jjRepository) {
+		const gitRepository = await detectGit(cwd);
+		const kind: RepositoryKind = gitRepository ? "jj-git-interop" : "jj";
+		return buildRepositoryMode(setting, kind, gitRepository, jjRepository);
+	}
+
+	const gitRepository = await detectGit(cwd);
+	if (gitRepository) return buildRepositoryMode(setting, "git", gitRepository, null);
+
+	throw new Error("No supported repository mode detected. Expected a Git repository or JJ workspace.");
+}
+
+export function assertRepositoryModeCapability(
+	mode: RepositoryMode,
+	capability: RepositoryModeCapability,
+	operation: string,
+	supportedAlternative: string,
+): void {
+	if (mode.capabilities[capability]) return;
+	throw new Error(
+		`Repository mode '${mode.kind}' does not support ${operation}. Supported alternative: ${supportedAlternative}.`,
+	);
+}
+
+function buildRepositoryMode(
+	setting: RepositoryModeSetting,
+	kind: RepositoryKind,
+	gitRepository: git.GitRepository | null,
+	jjRepository: jj.JjRepository | null,
+): RepositoryMode {
+	return {
+		setting,
+		kind,
+		capabilities: capabilitiesFor(kind),
+		gitRepository,
+		jjRepository,
+	};
+}
+
+function capabilitiesFor(kind: RepositoryKind): RepositoryModeCapabilities {
+	if (kind === "git") return GIT_CAPABILITIES;
+	if (kind === "jj-git-interop") return JJ_GIT_INTEROP_CAPABILITIES;
+	return JJ_CAPABILITIES;
+}

--- a/packages/coding-agent/test/autoresearch-git.test.ts
+++ b/packages/coding-agent/test/autoresearch-git.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+
+import { ensureAutoresearchBranch } from "../src/autoresearch/git";
+import { Settings } from "../src/config/settings";
+import type { ExtensionAPI } from "../src/extensibility/extensions";
+import * as git from "../src/utils/git";
+import * as jj from "../src/utils/jj";
+
+const CWD = "/repo";
+const PURE_JJ_AUTORESEARCH_ERROR =
+	"Autoresearch branch isolation is not supported in pure jj repositories yet. Use a colocated Git repository or run without branch isolation.";
+
+const api = {} as ExtensionAPI;
+
+function gitRepository(): git.GitRepository {
+	return {
+		commonDir: `${CWD}/.git`,
+		gitDir: `${CWD}/.git`,
+		gitEntryPath: `${CWD}/.git`,
+		headPath: `${CWD}/.git/HEAD`,
+		repoRoot: CWD,
+	};
+}
+
+describe("autoresearch Git branch isolation", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns an error in pure jj repositories before Git status or branch mutation", async () => {
+		vi.spyOn(Settings, "init").mockResolvedValue(Settings.isolated({ "repository.mode": "jj" }));
+		vi.spyOn(jj.repo, "resolve").mockResolvedValue({ repoRoot: CWD, storeDir: `${CWD}/.jj/repo/store` });
+		vi.spyOn(git.repo, "resolve").mockResolvedValue(null);
+		const status = vi.spyOn(git, "status");
+		const checkoutNew = vi.spyOn(git.branch, "checkoutNew");
+
+		const result = await ensureAutoresearchBranch(api, CWD, "measure runtime");
+
+		expect(result).toEqual({ ok: false, error: PURE_JJ_AUTORESEARCH_ERROR });
+		expect(status).not.toHaveBeenCalled();
+		expect(checkoutNew).not.toHaveBeenCalled();
+	});
+
+	it("returns an error when repository mode probing fails before Git status or branch mutation", async () => {
+		vi.spyOn(Settings, "init").mockRejectedValue(new Error("settings unavailable"));
+		const status = vi.spyOn(git, "status");
+		const checkoutNew = vi.spyOn(git.branch, "checkoutNew");
+
+		const result = await ensureAutoresearchBranch(api, CWD, "measure runtime");
+
+		expect(result).toEqual({
+			ok: false,
+			error: "Unable to resolve repository mode before autoresearch branch isolation: settings unavailable",
+		});
+		expect(status).not.toHaveBeenCalled();
+		expect(checkoutNew).not.toHaveBeenCalled();
+	});
+
+	it("allows jj mode with colocated Git to use existing autoresearch Git branch isolation", async () => {
+		vi.spyOn(Settings, "init").mockResolvedValue(Settings.isolated({ "repository.mode": "jj" }));
+		vi.spyOn(jj.repo, "resolve").mockResolvedValue({ repoRoot: CWD, storeDir: `${CWD}/.jj/repo/store` });
+		vi.spyOn(git.repo, "resolve").mockResolvedValue(gitRepository());
+		vi.spyOn(git.repo, "root").mockResolvedValue(CWD);
+		vi.spyOn(git, "status").mockResolvedValue("");
+		vi.spyOn(git.show, "prefix").mockResolvedValue("");
+		vi.spyOn(git.branch, "current").mockResolvedValue("main");
+		vi.spyOn(git.ref, "exists").mockResolvedValue(false);
+		const checkoutNew = vi.spyOn(git.branch, "checkoutNew").mockResolvedValue(undefined);
+
+		const result = await ensureAutoresearchBranch(api, CWD, "measure runtime");
+
+		expect(result.ok).toBe(true);
+		expect(result.ok ? result.created : false).toBe(true);
+		expect(checkoutNew.mock.calls[0]?.[1]).toMatch(/^autoresearch\/measure-runtime-\d{8}$/);
+	});
+});

--- a/packages/coding-agent/test/commit-jj-flow.test.ts
+++ b/packages/coding-agent/test/commit-jj-flow.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
+import { getBundledModel } from "@oh-my-pi/pi-ai";
+import * as piUtils from "@oh-my-pi/pi-utils";
+import type { Subprocess } from "bun";
+import { runAgenticCommit } from "../src/commit/agentic";
+import * as commitAgentModule from "../src/commit/agentic/agent";
+import * as analysisModule from "../src/commit/analysis";
+import { runCommitCommand } from "../src/commit/pipeline";
+import { ModelRegistry } from "../src/config/model-registry";
+import { Settings } from "../src/config/settings";
+import * as sdkModule from "../src/sdk";
+import * as git from "../src/utils/git";
+import * as jj from "../src/utils/jj";
+
+const CWD = "/repo";
+const MODEL = getBundledModel("anthropic", "claude-sonnet-4-5");
+if (!MODEL) {
+	throw new Error("Expected claude-sonnet-4-5 model to exist");
+}
+
+const JJ_REPOSITORY: jj.JjRepository = {
+	repoRoot: CWD,
+	storeDir: `${CWD}/.jj/repo/store`,
+};
+const JJ_PUSH_ERROR =
+	"Repository mode 'jj' does not support push after jj commit. Supported alternative: single commit without --push.";
+const JJ_CHANGELOG_ERROR =
+	"Repository mode 'jj' does not support changelog updates in jj commit flow yet. Supported alternative: pass --no-changelog for jj commit flow, or use Git mode.";
+
+function commitArgs(
+	overrides: Partial<Parameters<typeof runCommitCommand>[0]> = {},
+): Parameters<typeof runCommitCommand>[0] {
+	return {
+		push: false,
+		dryRun: false,
+		model: `${MODEL.provider}/${MODEL.id}`,
+		noChangelog: true,
+		...overrides,
+	};
+}
+
+function installCommonSpies(): void {
+	spyOn(piUtils, "getProjectDir").mockReturnValue(CWD);
+	spyOn(sdkModule, "discoverAuthStorage").mockResolvedValue({
+		hasAuth: () => false,
+		setFallbackResolver: () => {},
+	} as never);
+	spyOn(sdkModule, "discoverContextFiles").mockResolvedValue([]);
+	spyOn(Settings, "init").mockResolvedValue(Settings.isolated({ "repository.mode": "jj" }));
+	spyOn(ModelRegistry.prototype, "refresh").mockResolvedValue(undefined);
+	spyOn(ModelRegistry.prototype, "getAvailable").mockReturnValue([MODEL]);
+	spyOn(ModelRegistry.prototype, "getApiKey").mockResolvedValue("test-key");
+	spyOn(jj.repo, "resolve").mockResolvedValue(JJ_REPOSITORY);
+	spyOn(git.repo, "resolve").mockResolvedValue(null);
+	const spawn = ((command: string[]) => {
+		if (command[0] !== "jj") {
+			throw new Error(`Unexpected command in jj flow test: ${command.join(" ")}`);
+		}
+		return {
+			stdout: new Response("diff --git a/src/a.ts b/src/a.ts\n").body,
+			stderr: new Response("").body,
+			exited: Promise.resolve(0),
+		} as Subprocess;
+	}) as typeof Bun.spawn;
+	spyOn(Bun, "spawn").mockImplementation(spawn);
+	spyOn(analysisModule, "generateConventionalAnalysis").mockResolvedValue({
+		type: "chore",
+		scope: null,
+		details: [],
+		issueRefs: [],
+	});
+	spyOn(analysisModule, "generateSummary").mockResolvedValue({ summary: "support jj commits" });
+}
+
+describe("jj commit flow", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		delete process.env.PI_COMMIT_TEST_FALLBACK;
+	});
+
+	it("legacy jj single commit uses working-copy jj diff and jj commit without Git staging", async () => {
+		installCommonSpies();
+		const gitStageSpy = spyOn(git.stage, "files").mockResolvedValue(undefined);
+		const gitCommitSpy = spyOn(git, "commit").mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+		const jjCommitSpy = spyOn(jj, "commit").mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+		spyOn(jj.diff, "changedFiles").mockResolvedValue(["src/a.ts"]);
+
+		await runCommitCommand(commitArgs({ legacy: true, dryRun: true }));
+
+		expect(gitStageSpy).not.toHaveBeenCalled();
+		expect(gitCommitSpy).not.toHaveBeenCalled();
+		expect(jj.diff.changedFiles).toHaveBeenCalledWith(CWD);
+		expect(Bun.spawn).toHaveBeenCalledWith(
+			["jj", "--no-pager", "--color=never", "diff", "--git"],
+			expect.objectContaining({ cwd: CWD }),
+		);
+		expect(jjCommitSpy).not.toHaveBeenCalled();
+	});
+
+	it("agentic jj single commit uses jj commit and does not use Git staging", async () => {
+		installCommonSpies();
+		process.env.PI_COMMIT_TEST_FALLBACK = "true";
+		const gitStageSpy = spyOn(git.stage, "files").mockResolvedValue(undefined);
+		const gitCommitSpy = spyOn(git, "commit").mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+		const jjCommitSpy = spyOn(jj, "commit").mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+		spyOn(jj.diff, "changedFiles").mockResolvedValue(["src/a.ts"]);
+
+		await runAgenticCommit(commitArgs());
+
+		expect(gitStageSpy).not.toHaveBeenCalled();
+		expect(gitCommitSpy).not.toHaveBeenCalled();
+		expect(jjCommitSpy).toHaveBeenCalledWith(CWD, expect.stringContaining("chore: updated files"));
+	});
+
+	it("agentic jj split proposal fails before Git index mutation", async () => {
+		installCommonSpies();
+		const gitResetSpy = spyOn(git.stage, "reset").mockResolvedValue(undefined);
+		const gitHunksSpy = spyOn(git.stage, "hunks").mockResolvedValue(undefined);
+		const gitCommitSpy = spyOn(git, "commit").mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+		spyOn(jj.diff, "changedFiles").mockResolvedValue(["src/a.ts"]);
+		spyOn(commitAgentModule, "runCommitAgentSession").mockResolvedValue({
+			splitProposal: {
+				warnings: [],
+				commits: [
+					{
+						changes: [{ path: "src/a.ts", hunks: { type: "all" } }],
+						type: "chore",
+						scope: null,
+						summary: "update a",
+						details: [],
+						issueRefs: [],
+						dependencies: [],
+					},
+				],
+			},
+		});
+
+		await expect(runAgenticCommit(commitArgs())).rejects.toThrow(
+			"Repository mode 'jj' does not support split commit. Supported alternative: single commit.",
+		);
+
+		expect(gitResetSpy).not.toHaveBeenCalled();
+		expect(gitHunksSpy).not.toHaveBeenCalled();
+		expect(gitCommitSpy).not.toHaveBeenCalled();
+	});
+
+	it("legacy jj push fails before commit mutation", async () => {
+		installCommonSpies();
+		const gitCommitSpy = spyOn(git, "commit").mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+		const jjCommitSpy = spyOn(jj, "commit").mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+		await expect(runCommitCommand(commitArgs({ legacy: true, push: true }))).rejects.toThrow(JJ_PUSH_ERROR);
+
+		expect(gitCommitSpy).not.toHaveBeenCalled();
+		expect(jjCommitSpy).not.toHaveBeenCalled();
+	});
+
+	it("agentic jj push fails before commit mutation", async () => {
+		installCommonSpies();
+		process.env.PI_COMMIT_TEST_FALLBACK = "true";
+		const gitCommitSpy = spyOn(git, "commit").mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+		const jjCommitSpy = spyOn(jj, "commit").mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+		await expect(runAgenticCommit(commitArgs({ push: true }))).rejects.toThrow(JJ_PUSH_ERROR);
+
+		expect(gitCommitSpy).not.toHaveBeenCalled();
+		expect(jjCommitSpy).not.toHaveBeenCalled();
+	});
+
+	it("legacy jj changelog flow fails before commit mutation", async () => {
+		installCommonSpies();
+		const gitCommitSpy = spyOn(git, "commit").mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+		const jjCommitSpy = spyOn(jj, "commit").mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+		await expect(runCommitCommand(commitArgs({ legacy: true, noChangelog: false }))).rejects.toThrow(
+			JJ_CHANGELOG_ERROR,
+		);
+
+		expect(gitCommitSpy).not.toHaveBeenCalled();
+		expect(jjCommitSpy).not.toHaveBeenCalled();
+	});
+
+	it("agentic jj changelog flow fails before commit mutation", async () => {
+		installCommonSpies();
+		process.env.PI_COMMIT_TEST_FALLBACK = "true";
+		const gitCommitSpy = spyOn(git, "commit").mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+		const jjCommitSpy = spyOn(jj, "commit").mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" });
+
+		await expect(runAgenticCommit(commitArgs({ noChangelog: false }))).rejects.toThrow(JJ_CHANGELOG_ERROR);
+
+		expect(gitCommitSpy).not.toHaveBeenCalled();
+		expect(jjCommitSpy).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/status-line-repository-mode.test.ts
+++ b/packages/coding-agent/test/status-line-repository-mode.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeAll, describe, expect, it, spyOn, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+import { resetSettingsForTest, Settings, settings } from "../src/config/settings";
+import { StatusLineComponent } from "../src/modes/components/status-line";
+import { initTheme } from "../src/modes/theme/theme";
+import type { AgentSession } from "../src/session/agent-session";
+import * as git from "../src/utils/git";
+import * as jj from "../src/utils/jj";
+
+const originalProjectDir = getProjectDir();
+const components: StatusLineComponent[] = [];
+
+function makeSession(): AgentSession {
+	return {
+		messages: [],
+		state: { messages: [] },
+		isStreaming: false,
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		model: { id: "test-model", contextWindow: 200_000 },
+		modelRegistry: { isUsingOAuth: () => false },
+		sessionManager: {
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+		},
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		isFastModeActive: () => false,
+		isFastModeEnabled: () => false,
+	} as unknown as AgentSession;
+}
+
+async function flushBackgroundWork(): Promise<void> {
+	await Bun.sleep(0);
+	await Bun.sleep(0);
+}
+
+function createComponent(): StatusLineComponent {
+	const component = new StatusLineComponent(makeSession());
+	components.push(component);
+	return component;
+}
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterEach(async () => {
+	for (const component of components.splice(0)) {
+		component.dispose();
+	}
+	await flushBackgroundWork();
+	vi.restoreAllMocks();
+	settings.set("repository.mode", "auto");
+	setProjectDir(originalProjectDir);
+	jj.repo.clearRootCache();
+});
+
+describe("StatusLineComponent repository-aware git segment", () => {
+	it("preserves Git branch and status lookup on the first forced-git render", () => {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "omp-status-line-git-first-"));
+		setProjectDir(cwd);
+		settings.set("repository.mode", "git");
+		const gitHead = spyOn(git.head, "resolveSync").mockReturnValue({
+			branchName: "feature/git-first-render",
+			commit: "abc123",
+			commonDir: `${cwd}/.git`,
+			gitDir: `${cwd}/.git`,
+			gitEntryPath: `${cwd}/.git`,
+			headContent: "ref: refs/heads/feature/git-first-render",
+			headPath: `${cwd}/.git/HEAD`,
+			kind: "ref",
+			ref: "refs/heads/feature/git-first-render",
+			repoRoot: cwd,
+		});
+		const gitStatus = spyOn(git.status, "summary").mockResolvedValue({ staged: 1, unstaged: 2, untracked: 3 });
+
+		const component = createComponent();
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["git"],
+			rightSegments: [],
+			separator: "none",
+		});
+
+		const rendered = component.getTopBorder(80).content;
+
+		expect(gitHead).toHaveBeenCalledWith(cwd);
+		expect(gitStatus).toHaveBeenCalledWith(cwd);
+		expect(rendered).toContain("feature/git-first-render");
+	});
+
+	it("uses jj status and skips Git-only lookups in pure jj mode", async () => {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "omp-status-line-jj-"));
+		setProjectDir(cwd);
+		settings.set("repository.mode", "jj");
+		spyOn(jj.repo, "resolve").mockResolvedValue({
+			repoRoot: cwd,
+			storeDir: `${cwd}/.jj/repo/store`,
+		});
+		spyOn(git.repo, "resolve").mockResolvedValue(null);
+		const jjStatus = spyOn(jj.status, "summary").mockResolvedValue({ staged: 0, unstaged: 2, untracked: 0 });
+		const gitStatus = spyOn(git.status, "summary").mockResolvedValue({ staged: 7, unstaged: 7, untracked: 7 });
+		const gitHead = spyOn(git.head, "resolveSync").mockReturnValue(null);
+		const defaultBranch = spyOn(git.branch, "default").mockResolvedValue("main");
+
+		const component = createComponent();
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["git"],
+			rightSegments: [],
+			separator: "none",
+		});
+
+		component.getTopBorder(80);
+		await flushBackgroundWork();
+		component.getTopBorder(80);
+		await flushBackgroundWork();
+		const rendered = component.getTopBorder(80).content;
+
+		expect(jjStatus).toHaveBeenCalledWith(cwd);
+		expect(gitStatus).not.toHaveBeenCalled();
+		expect(gitHead).not.toHaveBeenCalled();
+		expect(defaultBranch).not.toHaveBeenCalled();
+		expect(rendered).toContain("jj");
+		expect(rendered).toContain("*2");
+		expect(rendered).not.toContain("*7");
+	});
+
+	it("does not watch Git HEAD when repository mode is forced to jj", () => {
+		const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "omp-status-line-jj-watch-"));
+		setProjectDir(cwd);
+		settings.set("repository.mode", "jj");
+		const gitRepoResolve = spyOn(git.repo, "resolveSync").mockReturnValue({
+			commonDir: `${cwd}/.git`,
+			gitDir: `${cwd}/.git`,
+			gitEntryPath: `${cwd}/.git`,
+			headPath: `${cwd}/.git/HEAD`,
+			repoRoot: cwd,
+		});
+
+		const component = createComponent();
+		component.watchBranch(() => {});
+		component.dispose();
+
+		expect(gitRepoResolve).not.toHaveBeenCalled();
+	});
+});

--- a/packages/coding-agent/test/task/worktree.test.ts
+++ b/packages/coding-agent/test/task/worktree.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as natives from "@oh-my-pi/pi-natives";
+import { Settings } from "../../src/config/settings";
 import {
 	captureBaseline,
 	captureDeltaPatch,
@@ -11,8 +12,12 @@ import {
 	mergeTaskBranches,
 	parseIsolationMode,
 } from "../../src/task/worktree";
+import * as gitUtils from "../../src/utils/git";
+import * as jj from "../../src/utils/jj";
 
 const tempDirs: string[] = [];
+const PURE_JJ_TASK_ISOLATION_ERROR =
+	"Task isolation is not supported in pure jj repositories yet. Use a colocated Git repository or disable task isolation for this run.";
 
 async function runGit(repo: string, args: string[]): Promise<string> {
 	const proc = Bun.spawn(["git", ...args], {
@@ -100,6 +105,85 @@ describe("worktree isolation helpers", () => {
 		expect(handle.backend).toBe(natives.IsoBackendKind.Rcopy);
 		expect(handle.fellBack).toBe(true);
 		expect(handle.fallbackReason).toBe(unavailable.message);
+	});
+
+	it("rejects pure jj repositories before starting task isolation", async () => {
+		const cwd = "/repo";
+		vi.spyOn(Settings, "init").mockResolvedValue(Settings.isolated({ "repository.mode": "jj" }));
+		vi.spyOn(jj.repo, "resolve").mockResolvedValue({ repoRoot: cwd, storeDir: `${cwd}/.jj/repo/store` });
+		vi.spyOn(gitUtils.repo, "resolve").mockResolvedValue(null);
+		const isoResolve = vi.spyOn(natives, "isoResolve");
+		const isoStart = vi.spyOn(natives, "isoStart");
+
+		await expect(ensureIsolation(cwd, "pure-jj")).rejects.toThrow(PURE_JJ_TASK_ISOLATION_ERROR);
+
+		expect(isoResolve).not.toHaveBeenCalled();
+		expect(isoStart).not.toHaveBeenCalled();
+	});
+
+	it("allows jj mode with colocated Git to use existing task isolation", async () => {
+		const cwd = "/repo";
+		vi.spyOn(Settings, "init").mockResolvedValue(Settings.isolated({ "repository.mode": "jj" }));
+		vi.spyOn(jj.repo, "resolve").mockResolvedValue({ repoRoot: cwd, storeDir: `${cwd}/.jj/repo/store` });
+		vi.spyOn(gitUtils.repo, "resolve").mockResolvedValue({
+			commonDir: `${cwd}/.git`,
+			gitDir: `${cwd}/.git`,
+			gitEntryPath: `${cwd}/.git`,
+			headPath: `${cwd}/.git/HEAD`,
+			repoRoot: cwd,
+		});
+		vi.spyOn(natives, "isoResolve").mockReturnValue({
+			kind: natives.IsoBackendKind.Rcopy,
+			candidates: [natives.IsoBackendKind.Rcopy],
+			fellBack: false,
+			reason: undefined,
+		});
+		const isoStart = vi.spyOn(natives, "isoStart").mockResolvedValue(undefined);
+
+		const handle = await ensureIsolation(cwd, "jj-git");
+
+		expect(handle.backend).toBe(natives.IsoBackendKind.Rcopy);
+		expect(isoStart.mock.calls[0]?.[1]).toBe(cwd);
+	});
+
+	it("rejects pure jj repositories before capturing a Git baseline", async () => {
+		const cwd = "/repo";
+		vi.spyOn(Settings, "init").mockResolvedValue(Settings.isolated({ "repository.mode": "jj" }));
+		vi.spyOn(jj.repo, "resolve").mockResolvedValue({ repoRoot: cwd, storeDir: `${cwd}/.jj/repo/store` });
+		vi.spyOn(gitUtils.repo, "resolve").mockResolvedValue(null);
+		const headSha = vi.spyOn(gitUtils.head, "sha");
+
+		await expect(captureBaseline(cwd)).rejects.toThrow(PURE_JJ_TASK_ISOLATION_ERROR);
+
+		expect(headSha).not.toHaveBeenCalled();
+	});
+
+	it("fails closed when repository mode probing fails before starting task isolation", async () => {
+		const cwd = "/repo";
+		vi.spyOn(Settings, "init").mockRejectedValue(new Error("settings unavailable"));
+		const gitRoot = vi.spyOn(gitUtils.repo, "root");
+		const isoResolve = vi.spyOn(natives, "isoResolve");
+		const isoStart = vi.spyOn(natives, "isoStart");
+
+		await expect(ensureIsolation(cwd, "probe-failure")).rejects.toThrow(
+			"Unable to resolve repository mode before task isolation: settings unavailable",
+		);
+
+		expect(gitRoot).not.toHaveBeenCalled();
+		expect(isoResolve).not.toHaveBeenCalled();
+		expect(isoStart).not.toHaveBeenCalled();
+	});
+
+	it("fails closed when repository mode probing fails before capturing a Git baseline", async () => {
+		const cwd = "/repo";
+		vi.spyOn(Settings, "init").mockRejectedValue(new Error("settings unavailable"));
+		const headSha = vi.spyOn(gitUtils.head, "sha");
+
+		await expect(captureBaseline(cwd)).rejects.toThrow(
+			"Unable to resolve repository mode before task isolation: settings unavailable",
+		);
+
+		expect(headSha).not.toHaveBeenCalled();
 	});
 
 	it("does not pop an unrelated pre-existing stash when the working tree is clean", async () => {

--- a/packages/coding-agent/test/utils/jj.test.ts
+++ b/packages/coding-agent/test/utils/jj.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { Subprocess } from "bun";
 import * as jj from "../../src/utils/jj";
 
 describe("jj workspace detection", () => {
@@ -75,5 +76,46 @@ describe("jj workspace detection", () => {
 		const resolved = await jj.repo.resolve(secondary);
 		expect(resolved?.repoRoot).toBe(secondary);
 		expect(resolved?.storeDir).toBe(path.join(dir, ".jj", "repo", "store"));
+	});
+});
+
+describe("jj working-copy helpers", () => {
+	const cwd = "/repo";
+	const spawnArgs: string[][] = [];
+
+	afterEach(() => {
+		jj.repo.clearRootCache();
+		spawnArgs.length = 0;
+		vi.restoreAllMocks();
+	});
+
+	function mockJjSpawn(stdout: string): void {
+		const spawn = ((command: string[]) => {
+			spawnArgs.push(command);
+			return {
+				stdout: new Response(stdout).body,
+				stderr: new Response("").body,
+				exited: Promise.resolve(0),
+			} as Subprocess;
+		}) as typeof Bun.spawn;
+		spyOn(Bun, "spawn").mockImplementation(spawn);
+	}
+
+	it("summarizes jj working-copy changes from diff names", async () => {
+		mockJjSpawn("src/a.ts\nsrc/b.ts\n");
+
+		await expect(jj.status.summary(cwd)).resolves.toEqual({ staged: 0, unstaged: 2, untracked: 0 });
+
+		expect(spawnArgs).toEqual([["jj", "--no-pager", "--color=never", "diff", "--name-only"]]);
+	});
+
+	it("commits with an explicit message without opening an editor", async () => {
+		mockJjSpawn("");
+
+		await jj.commit(cwd, "test: support jj commits");
+
+		expect(spawnArgs).toEqual([
+			["jj", "--no-pager", "--color=never", "commit", "--message", "test: support jj commits"],
+		]);
 	});
 });

--- a/packages/coding-agent/test/utils/repository-mode.test.ts
+++ b/packages/coding-agent/test/utils/repository-mode.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, it, spyOn, vi } from "bun:test";
+
+import { SETTINGS_SCHEMA } from "../../src/config/settings-schema";
+import * as git from "../../src/utils/git";
+import * as jj from "../../src/utils/jj";
+import {
+	assertRepositoryModeCapability,
+	type RepositoryMode,
+	resolveRepositoryMode,
+} from "../../src/utils/repository-mode";
+
+const CWD = "/repo";
+const JJ_REPOSITORY: jj.JjRepository = {
+	repoRoot: CWD,
+	storeDir: `${CWD}/.jj/repo/store`,
+};
+const GIT_REPOSITORY: git.GitRepository = {
+	commonDir: `${CWD}/.git`,
+	gitDir: `${CWD}/.git`,
+	gitEntryPath: `${CWD}/.git`,
+	headPath: `${CWD}/.git/HEAD`,
+	repoRoot: CWD,
+};
+
+function expectCapabilities(
+	mode: RepositoryMode,
+	expected: {
+		canReadWorkingCopyDiff: boolean;
+		canReadRevDiff: boolean;
+		canReadStatus: boolean;
+		canSingleCommit: boolean;
+		canSplitCommit: boolean;
+		canUseGitInteropMutations: boolean;
+		canUseNativeWorkspaceMutations: boolean;
+	},
+): void {
+	expect(mode.capabilities).toEqual(expected);
+}
+
+describe("repository mode resolver", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		jj.repo.clearRootCache();
+	});
+
+	it("auto detects colocated JJ and Git as jj-git-interop", async () => {
+		const jjResolve = spyOn(jj.repo, "resolve").mockResolvedValue(JJ_REPOSITORY);
+		const gitResolve = spyOn(git.repo, "resolve").mockResolvedValue(GIT_REPOSITORY);
+
+		const mode = await resolveRepositoryMode(CWD, "auto");
+
+		expect(mode.kind).toBe("jj-git-interop");
+		expect(mode.setting).toBe("auto");
+		expect(mode.jjRepository).toBe(JJ_REPOSITORY);
+		expect(mode.gitRepository).toBe(GIT_REPOSITORY);
+		expect(jjResolve).toHaveBeenCalledWith(CWD);
+		expect(gitResolve).toHaveBeenCalledWith(CWD);
+		expectCapabilities(mode, {
+			canReadWorkingCopyDiff: true,
+			canReadRevDiff: true,
+			canReadStatus: true,
+			canSingleCommit: true,
+			canSplitCommit: false,
+			canUseGitInteropMutations: true,
+			canUseNativeWorkspaceMutations: false,
+		});
+	});
+
+	it("auto detects pure JJ when Git is absent", async () => {
+		spyOn(jj.repo, "resolve").mockResolvedValue(JJ_REPOSITORY);
+		spyOn(git.repo, "resolve").mockResolvedValue(null);
+
+		const mode = await resolveRepositoryMode(CWD, "auto");
+
+		expect(mode.kind).toBe("jj");
+		expect(mode.gitRepository).toBeNull();
+		expectCapabilities(mode, {
+			canReadWorkingCopyDiff: true,
+			canReadRevDiff: true,
+			canReadStatus: true,
+			canSingleCommit: true,
+			canSplitCommit: false,
+			canUseGitInteropMutations: false,
+			canUseNativeWorkspaceMutations: false,
+		});
+	});
+
+	it("auto falls back to Git when JJ is absent", async () => {
+		spyOn(jj.repo, "resolve").mockResolvedValue(null);
+		spyOn(git.repo, "resolve").mockResolvedValue(GIT_REPOSITORY);
+
+		const mode = await resolveRepositoryMode(CWD, "auto");
+
+		expect(mode.kind).toBe("git");
+		expect(mode.jjRepository).toBeNull();
+		expectCapabilities(mode, {
+			canReadWorkingCopyDiff: true,
+			canReadRevDiff: true,
+			canReadStatus: true,
+			canSingleCommit: true,
+			canSplitCommit: true,
+			canUseGitInteropMutations: true,
+			canUseNativeWorkspaceMutations: false,
+		});
+	});
+
+	it("forced git ignores JJ detection and requires Git", async () => {
+		const jjResolve = spyOn(jj.repo, "resolve").mockResolvedValue(JJ_REPOSITORY);
+		spyOn(git.repo, "resolve").mockResolvedValue(GIT_REPOSITORY);
+
+		const mode = await resolveRepositoryMode(CWD, "git");
+
+		expect(mode.kind).toBe("git");
+		expect(mode.setting).toBe("git");
+		expect(mode.jjRepository).toBeNull();
+		expect(jjResolve).not.toHaveBeenCalled();
+	});
+
+	it("forced JJ reports interop when colocated Git exists", async () => {
+		spyOn(jj.repo, "resolve").mockResolvedValue(JJ_REPOSITORY);
+		spyOn(git.repo, "resolve").mockResolvedValue(GIT_REPOSITORY);
+
+		const mode = await resolveRepositoryMode(CWD, "jj");
+
+		expect(mode.kind).toBe("jj-git-interop");
+		expect(mode.setting).toBe("jj");
+	});
+
+	it("throws when the forced repository mode is unavailable", async () => {
+		spyOn(jj.repo, "resolve").mockResolvedValue(null);
+		spyOn(git.repo, "resolve").mockResolvedValue(null);
+
+		await expect(resolveRepositoryMode(CWD, "git")).rejects.toThrow(
+			"Repository mode 'git' requires a Git repository",
+		);
+		await expect(resolveRepositoryMode(CWD, "jj")).rejects.toThrow("Repository mode 'jj' requires a JJ workspace");
+	});
+
+	it("describes unsupported operations with mode and supported alternative", async () => {
+		const mode = await resolveRepositoryMode(CWD, "auto", {
+			detectJj: async () => JJ_REPOSITORY,
+			detectGit: async () => null,
+		});
+
+		expect(() => assertRepositoryModeCapability(mode, "canSplitCommit", "split commit", "single commit")).toThrow(
+			"Repository mode 'jj' does not support split commit. Supported alternative: single commit.",
+		);
+	});
+});
+
+describe("repository mode settings schema", () => {
+	it("defaults repository.mode to auto", () => {
+		expect(SETTINGS_SCHEMA["repository.mode"]).toMatchObject({
+			type: "enum",
+			values: ["auto", "git", "jj"],
+			default: "auto",
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Reject pure jj repositories before worktree setup performs Git-only mutation.
- Allow colocated jj-git repositories where Git interop is available.
- Guard autoresearch Git preparation with the same repository-mode checks.

Fixes #1935
Depends on #1936

## Verification

- `bun --cwd=packages/coding-agent test test/task/worktree.test.ts test/autoresearch-git.test.ts`
- `bun --cwd=packages/coding-agent test test/utils/repository-mode.test.ts test/utils/jj.test.ts test/commit-jj-flow.test.ts test/status-line-repository-mode.test.ts test/status-line-git-utils.test.ts test/task/worktree.test.ts test/autoresearch-git.test.ts`
- `bun --cwd=packages/coding-agent run check`
- Real colocated jj smoke: `jj git init --colocate` plus `packages/coding-agent/src/utils/jj.ts` status parsing.

## Notes

This branch is stacked on #1936. Because this account cannot push an upstream base branch, GitHub shows this PR against upstream `main`; once #1936 lands, this PR can be rebased or reviewed as the second commit in the stack.
