### PR TITLE
feat: add Copilot MCP discovery provider for ~/.copilot/mcp-config.json (#1917)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,11 +2,6 @@
 
 ## [Unreleased]
 
-## [15.9.3] - 2026-06-05
-
-### Fixed
-
-- Fixed `@`-mention auto-read injecting an unrelated, same-named file when a mention did not point at a real path — e.g. an npm scope like `@scope/`, a partial path, or a bare token. `generateFileMentionMessages` resolution previously fell back to prefix and repo-wide fuzzy matching (globbing the whole project on every such mention) and auto-read the single "best" guess. Resolution is now exact-only: a mention is auto-read only when it resolves to an existing file or directory; otherwise it is left as prose. The TUI `@`-selector already inserts the real, complete path before send, so post-send guessing was both unnecessary and the source of the wrong-file reads. Directories still resolve and are listed. Removes the per-mention `**/*` project scan.
 ### Added
 
 - Added Copilot MCP discovery provider (priority 30) that reads `~/.copilot/mcp-config.json`, with `COPILOT_HOME` env override and `mcpServers`/`servers` key fallback. ([#1917](https://github.com/can1357/oh-my-pi/issues/1917))
@@ -18,6 +13,12 @@
 ### Fixed
 
 - Fixed Copilot `type: "local"` MCP transport entries not being recognized: `transformMCPConfig` now normalizes `"local"` to `"stdio"` at assignment time so Copilot-local MCP servers connect correctly. ([#1917](https://github.com/can1357/oh-my-pi/issues/1917))
+- Fixed test isolation in Copilot MCP discovery tests: replaced `HOME`/`USERPROFILE` mutation (ineffective under Bun's `os.homedir()`) with `COPILOT_HOME` override, and added `fs.rm` guard against empty temp directory. ([#1917](https://github.com/can1357/oh-my-pi/issues/1917))
+
+## [15.9.3] - 2026-06-05
+
+### Fixed
+
 - Fixed `@`-mention auto-read injecting an unrelated, same-named file when a mention did not point at a real path — e.g. an npm scope like `@scope/`, a partial path, or a bare token. `generateFileMentionMessages` resolution previously fell back to prefix and repo-wide fuzzy matching (globbing the whole project on every such mention) and auto-read the single "best" guess. Resolution is now exact-only: a mention is auto-read only when it resolves to an existing file or directory; otherwise it is left as prose. The TUI `@`-selector already inserts the real, complete path before send, so post-send guessing was both unnecessary and the source of the wrong-file reads. Directories still resolve and are listed. Removes the per-mention `**/*` project scan.
 
 ## [15.9.2] - 2026-06-05

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -7,6 +7,13 @@
 ### Fixed
 
 - Fixed `@`-mention auto-read injecting an unrelated, same-named file when a mention did not point at a real path — e.g. an npm scope like `@scope/`, a partial path, or a bare token. `generateFileMentionMessages` resolution previously fell back to prefix and repo-wide fuzzy matching (globbing the whole project on every such mention) and auto-read the single "best" guess. Resolution is now exact-only: a mention is auto-read only when it resolves to an existing file or directory; otherwise it is left as prose. The TUI `@`-selector already inserts the real, complete path before send, so post-send guessing was both unnecessary and the source of the wrong-file reads. Directories still resolve and are listed. Removes the per-mention `**/*` project scan.
+### Added
+
+- Added Copilot MCP discovery provider (priority 30) that reads `~/.copilot/mcp-config.json`, with `COPILOT_HOME` env override and `mcpServers`/`servers` key fallback. ([#1917](https://github.com/can1357/oh-my-pi/issues/1917))
+
+### Fixed
+
+- Fixed Copilot `type: "local"` MCP transport entries not being recognized: `transformMCPConfig` now normalizes `"local"` to `"stdio"` at assignment time so Copilot-local MCP servers connect correctly.
 
 ## [15.9.2] - 2026-06-05
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -11,9 +11,14 @@
 
 - Added Copilot MCP discovery provider (priority 30) that reads `~/.copilot/mcp-config.json`, with `COPILOT_HOME` env override and `mcpServers`/`servers` key fallback. ([#1917](https://github.com/can1357/oh-my-pi/issues/1917))
 
+### Changed
+
+- Exported `MCPConfigFile` interface and `transformMCPConfig` function from `mcp-json.ts` so they can be reused by other MCP discovery providers (e.g. the new Copilot provider). ([#1917](https://github.com/can1357/oh-my-pi/issues/1917))
+
 ### Fixed
 
-- Fixed Copilot `type: "local"` MCP transport entries not being recognized: `transformMCPConfig` now normalizes `"local"` to `"stdio"` at assignment time so Copilot-local MCP servers connect correctly.
+- Fixed Copilot `type: "local"` MCP transport entries not being recognized: `transformMCPConfig` now normalizes `"local"` to `"stdio"` at assignment time so Copilot-local MCP servers connect correctly. ([#1917](https://github.com/can1357/oh-my-pi/issues/1917))
+- Fixed `@`-mention auto-read injecting an unrelated, same-named file when a mention did not point at a real path — e.g. an npm scope like `@scope/`, a partial path, or a bare token. `generateFileMentionMessages` resolution previously fell back to prefix and repo-wide fuzzy matching (globbing the whole project on every such mention) and auto-read the single "best" guess. Resolution is now exact-only: a mention is auto-read only when it resolves to an existing file or directory; otherwise it is left as prose. The TUI `@`-selector already inserts the real, complete path before send, so post-send guessing was both unnecessary and the source of the wrong-file reads. Directories still resolve and are listed. Removes the per-mention `**/*` project scan.
 
 ## [15.9.2] - 2026-06-05
 

--- a/packages/coding-agent/src/discovery/copilot.ts
+++ b/packages/coding-agent/src/discovery/copilot.ts
@@ -1,0 +1,76 @@
+/**
+ * GitHub Copilot MCP Provider
+ *
+ * Discovers MCP servers from ~/.copilot/mcp-config.json.
+ * This is the user-level config file written by the GitHub Copilot CLI.
+ *
+ * Priority: 30 (tool-specific, same as github.ts)
+ */
+import * as path from "node:path";
+import { tryParseJson } from "@oh-my-pi/pi-utils";
+import { registerProvider } from "../capability";
+import { readFile } from "../capability/fs";
+import { type MCPServer, mcpCapability } from "../capability/mcp";
+import type { LoadContext, LoadResult } from "../capability/types";
+import { createSourceMeta } from "./helpers";
+import { type MCPConfigFile, transformMCPConfig } from "./mcp-json";
+
+const PROVIDER_ID = "copilot";
+const DISPLAY_NAME = "GitHub Copilot";
+const PRIORITY = 30;
+
+/**
+ * Copilot MCP config file format.
+ * `mcpServers` is the official key; `servers` is a compatibility fallback.
+ */
+interface CopilotMCPConfig {
+	mcpServers?: MCPConfigFile["mcpServers"];
+	servers?: MCPConfigFile["mcpServers"];
+}
+
+/**
+ * Resolve the Copilot home directory.
+ * Prefers COPILOT_HOME env var; falls back to ~/.copilot.
+ */
+export function resolveCopilotHome(ctx: LoadContext): string {
+	return process.env.COPILOT_HOME || path.join(ctx.home, ".copilot");
+}
+
+/**
+ * Load MCP servers from ~/.copilot/mcp-config.json.
+ */
+async function loadMCPServers(ctx: LoadContext): Promise<LoadResult<MCPServer>> {
+	const copilotHome = resolveCopilotHome(ctx);
+	const configPath = path.join(copilotHome, "mcp-config.json");
+
+	const content = await readFile(configPath);
+	if (content === null) {
+		return { items: [], warnings: [] };
+	}
+
+	const config = tryParseJson<CopilotMCPConfig>(content);
+	if (!config) {
+		return { items: [], warnings: [`Failed to parse JSON in ${configPath}`] };
+	}
+
+	// mcpServers is the official Copilot key; "servers" is a compatibility fallback
+	const mcpServers = config.mcpServers ?? config.servers;
+	if (!mcpServers) {
+		return { items: [], warnings: [] };
+	}
+
+	const mcpConfig: MCPConfigFile = { mcpServers };
+	const source = createSourceMeta(PROVIDER_ID, configPath, "user");
+	const servers = transformMCPConfig(mcpConfig, source);
+
+	return { items: servers, warnings: [] };
+}
+
+// Register provider
+registerProvider<MCPServer>(mcpCapability.id, {
+	id: PROVIDER_ID,
+	displayName: DISPLAY_NAME,
+	description: "Load MCP servers from ~/.copilot/mcp-config.json",
+	priority: PRIORITY,
+	load: loadMCPServers,
+});

--- a/packages/coding-agent/src/discovery/copilot.ts
+++ b/packages/coding-agent/src/discovery/copilot.ts
@@ -32,7 +32,7 @@ interface CopilotMCPConfig {
  * Resolve the Copilot home directory.
  * Prefers COPILOT_HOME env var; falls back to ~/.copilot.
  */
-export function resolveCopilotHome(ctx: LoadContext): string {
+function resolveCopilotHome(ctx: LoadContext): string {
 	return process.env.COPILOT_HOME || path.join(ctx.home, ".copilot");
 }
 

--- a/packages/coding-agent/src/discovery/index.ts
+++ b/packages/coding-agent/src/discovery/index.ts
@@ -28,6 +28,7 @@ import "./claude-plugins";
 import "./cline";
 import "./agents";
 import "./codex";
+import "./copilot";
 import "./cursor";
 import "./gemini";
 import "./opencode";

--- a/packages/coding-agent/src/discovery/mcp-json.ts
+++ b/packages/coding-agent/src/discovery/mcp-json.ts
@@ -20,7 +20,7 @@ const DISPLAY_NAME = "MCP Config";
 /**
  * Raw MCP JSON format (matches Claude Desktop's format).
  */
-interface MCPConfigFile {
+export interface MCPConfigFile {
 	mcpServers?: Record<
 		string,
 		{
@@ -39,7 +39,7 @@ interface MCPConfigFile {
 				clientId?: string;
 				clientSecret?: string;
 			};
-			type?: "stdio" | "sse" | "http";
+			type?: "stdio" | "sse" | "http" | "local";
 			oauth?: {
 				clientId?: string;
 				clientSecret?: string;
@@ -54,7 +54,7 @@ interface MCPConfigFile {
 /**
  * Transform raw MCP config to canonical MCPServer format.
  */
-function transformMCPConfig(config: MCPConfigFile, source: SourceMeta): MCPServer[] {
+export function transformMCPConfig(config: MCPConfigFile, source: SourceMeta): MCPServer[] {
 	const servers: MCPServer[] = [];
 
 	if (config.mcpServers) {
@@ -94,7 +94,8 @@ function transformMCPConfig(config: MCPConfigFile, source: SourceMeta): MCPServe
 				headers: serverConfig.headers,
 				auth: serverConfig.auth,
 				oauth: serverConfig.oauth,
-				transport: serverConfig.type,
+				// Normalize Copilot "local" transport to OMP "stdio"
+				transport: serverConfig.type === "local" ? "stdio" : serverConfig.type,
 				_source: source,
 			};
 

--- a/packages/coding-agent/src/discovery/mcp-json.ts
+++ b/packages/coding-agent/src/discovery/mcp-json.ts
@@ -18,7 +18,7 @@ const PROVIDER_ID = "mcp-json";
 const DISPLAY_NAME = "MCP Config";
 
 /**
- * Raw MCP JSON format (matches Claude Desktop's format).
+ * Raw MCP JSON format (Claude Desktop + Copilot extensions).
  */
 export interface MCPConfigFile {
 	mcpServers?: Record<

--- a/packages/coding-agent/test/discovery/copilot.test.ts
+++ b/packages/coding-agent/test/discovery/copilot.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type MCPServer, mcpCapability } from "@oh-my-pi/pi-coding-agent/capability/mcp";
+import { loadCapability } from "@oh-my-pi/pi-coding-agent/discovery";
+
+/**
+ * Load MCP servers using only the "copilot" provider.
+ * Caller must set HOME/USERPROFILE before calling so resolveCopilotHome
+ * picks up the temp fixture directory. loadCapability derives ctx.home
+ * from os.homedir() — it does NOT accept a home option.
+ */
+async function loadCopilotMcpServers(cwd: string): Promise<MCPServer[]> {
+	const result = await loadCapability<MCPServer>(mcpCapability.id, {
+		cwd,
+		providers: ["copilot"],
+	});
+	return result.items;
+}
+
+function envPlaceholder(name: string): string {
+	return `\${${name}}`;
+}
+
+describe("copilot MCP discovery", () => {
+	let tempDir = "";
+	let originalHome = "";
+	let originalCopilotHome: string | undefined;
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-copilot-"));
+		originalHome = process.env.HOME ?? process.env.USERPROFILE ?? "";
+		originalCopilotHome = process.env.COPILOT_HOME;
+		// Point HOME to tempDir so resolveCopilotHome returns tempDir/.copilot
+		process.env.HOME = tempDir;
+		process.env.USERPROFILE = tempDir;
+		delete process.env.COPILOT_HOME;
+	});
+
+	afterEach(async () => {
+		await fs.rm(tempDir, { recursive: true, force: true });
+		process.env.HOME = originalHome;
+		process.env.USERPROFILE = originalHome;
+		if (originalCopilotHome === undefined) {
+			delete process.env.COPILOT_HOME;
+		} else {
+			process.env.COPILOT_HOME = originalCopilotHome;
+		}
+	});
+
+	test("discovers servers from mcpServers key", async () => {
+		const copilotDir = path.join(tempDir, ".copilot");
+		await fs.mkdir(copilotDir, { recursive: true });
+		await fs.writeFile(
+			path.join(copilotDir, "mcp-config.json"),
+			JSON.stringify({
+				mcpServers: {
+					"my-server": {
+						command: "node",
+						args: ["server.js"],
+					},
+				},
+			}),
+		);
+
+		const servers = await loadCopilotMcpServers(tempDir);
+		expect(servers).toHaveLength(1);
+		expect(servers[0]?.name).toBe("my-server");
+		expect(servers[0]?.command).toBe("node");
+		expect(servers[0]?.args).toEqual(["server.js"]);
+	});
+
+	test("discovers servers from servers key (compatibility fallback)", async () => {
+		const copilotDir = path.join(tempDir, ".copilot");
+		await fs.mkdir(copilotDir, { recursive: true });
+		await fs.writeFile(
+			path.join(copilotDir, "mcp-config.json"),
+			JSON.stringify({
+				servers: {
+					"fallback-server": {
+						url: "https://example.com/mcp",
+					},
+				},
+			}),
+		);
+
+		const servers = await loadCopilotMcpServers(tempDir);
+		expect(servers).toHaveLength(1);
+		expect(servers[0]?.name).toBe("fallback-server");
+		expect(servers[0]?.url).toBe("https://example.com/mcp");
+	});
+
+	test("mcpServers takes priority over servers when both present", async () => {
+		const copilotDir = path.join(tempDir, ".copilot");
+		await fs.mkdir(copilotDir, { recursive: true });
+		await fs.writeFile(
+			path.join(copilotDir, "mcp-config.json"),
+			JSON.stringify({
+				mcpServers: {
+					"official-server": {
+						command: "official",
+					},
+				},
+				servers: {
+					"fallback-server": {
+						command: "fallback",
+					},
+				},
+			}),
+		);
+
+		const servers = await loadCopilotMcpServers(tempDir);
+		expect(servers).toHaveLength(1);
+		expect(servers[0]?.name).toBe("official-server");
+	});
+
+	test("returns empty when mcp-config.json is missing", async () => {
+		// No .copilot directory created
+		const servers = await loadCopilotMcpServers(tempDir);
+		expect(servers).toHaveLength(0);
+	});
+
+	test("returns warning on invalid JSON", async () => {
+		const copilotDir = path.join(tempDir, ".copilot");
+		await fs.mkdir(copilotDir, { recursive: true });
+		await fs.writeFile(path.join(copilotDir, "mcp-config.json"), "{bad json}");
+
+		const result = await loadCapability<MCPServer>(mcpCapability.id, {
+			cwd: tempDir,
+			providers: ["copilot"],
+		});
+		expect(result.items).toHaveLength(0);
+		expect(result.warnings.some(w => w.includes("Failed to parse JSON"))).toBe(true);
+	});
+
+	test("respects COPILOT_HOME env var", async () => {
+		const customDir = path.join(tempDir, "custom-copilot");
+		await fs.mkdir(customDir, { recursive: true });
+		await fs.writeFile(
+			path.join(customDir, "mcp-config.json"),
+			JSON.stringify({
+				mcpServers: {
+					"custom-server": {
+						command: "custom",
+					},
+				},
+			}),
+		);
+
+		process.env.COPILOT_HOME = customDir;
+		const servers = await loadCopilotMcpServers(tempDir);
+		expect(servers).toHaveLength(1);
+		expect(servers[0]?.name).toBe("custom-server");
+	});
+
+	test("expands environment variables in config values", async () => {
+		const copilotDir = path.join(tempDir, ".copilot");
+		await fs.mkdir(copilotDir, { recursive: true });
+
+		process.env.OMP_TEST_TOKEN = "secret-token";
+		process.env.OMP_TEST_URL = "https://mcp.example.com";
+
+		await fs.writeFile(
+			path.join(copilotDir, "mcp-config.json"),
+			JSON.stringify({
+				mcpServers: {
+					"env-server": {
+						url: envPlaceholder("OMP_TEST_URL"),
+						headers: { Authorization: envPlaceholder("OMP_TEST_TOKEN") },
+					},
+				},
+			}),
+		);
+
+		const servers = await loadCopilotMcpServers(tempDir);
+		expect(servers).toHaveLength(1);
+		expect(servers[0]?.url).toBe("https://mcp.example.com");
+		expect(servers[0]?.headers).toEqual({ Authorization: "secret-token" });
+
+		delete process.env.OMP_TEST_TOKEN;
+		delete process.env.OMP_TEST_URL;
+	});
+
+	test("normalizes type 'local' to transport 'stdio'", async () => {
+		const copilotDir = path.join(tempDir, ".copilot");
+		await fs.mkdir(copilotDir, { recursive: true });
+		await fs.writeFile(
+			path.join(copilotDir, "mcp-config.json"),
+			JSON.stringify({
+				mcpServers: {
+					"local-server": {
+						command: "node",
+						args: ["local.js"],
+						type: "local",
+					},
+				},
+			}),
+		);
+
+		const servers = await loadCopilotMcpServers(tempDir);
+		expect(servers).toHaveLength(1);
+		expect(servers[0]?.transport).toBe("stdio");
+	});
+});

--- a/packages/coding-agent/test/discovery/copilot.test.ts
+++ b/packages/coding-agent/test/discovery/copilot.test.ts
@@ -7,9 +7,8 @@ import { loadCapability } from "@oh-my-pi/pi-coding-agent/discovery";
 
 /**
  * Load MCP servers using only the "copilot" provider.
- * Caller must set HOME/USERPROFILE before calling so resolveCopilotHome
- * picks up the temp fixture directory. loadCapability derives ctx.home
- * from os.homedir() — it does NOT accept a home option.
+ * beforeEach sets COPILOT_HOME to the temp fixture directory so
+ * resolveCopilotHome reads from there instead of the real home.
  */
 async function loadCopilotMcpServers(cwd: string): Promise<MCPServer[]> {
 	const result = await loadCapability<MCPServer>(mcpCapability.id, {
@@ -25,27 +24,22 @@ function envPlaceholder(name: string): string {
 
 describe("copilot MCP discovery", () => {
 	let tempDir = "";
-	let originalHome = "";
 	let originalCopilotHome: string | undefined;
 	let originalTestToken: string | undefined;
 	let originalTestUrl: string | undefined;
 
 	beforeEach(async () => {
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-copilot-"));
-		originalHome = process.env.HOME ?? process.env.USERPROFILE ?? "";
 		originalCopilotHome = process.env.COPILOT_HOME;
 		originalTestToken = process.env.OMP_TEST_TOKEN;
 		originalTestUrl = process.env.OMP_TEST_URL;
-		// Point HOME to tempDir so resolveCopilotHome returns tempDir/.copilot
-		process.env.HOME = tempDir;
-		process.env.USERPROFILE = tempDir;
-		delete process.env.COPILOT_HOME;
+		// Drive all tests through COPILOT_HOME — os.homedir() is not
+		// reliably overridable via process.env.HOME in Bun.
+		process.env.COPILOT_HOME = path.join(tempDir, ".copilot");
 	});
 
 	afterEach(async () => {
-		await fs.rm(tempDir, { recursive: true, force: true });
-		process.env.HOME = originalHome;
-		process.env.USERPROFILE = originalHome;
+		if (tempDir) await fs.rm(tempDir, { recursive: true, force: true });
 		if (originalCopilotHome === undefined) {
 			delete process.env.COPILOT_HOME;
 		} else {

--- a/packages/coding-agent/test/discovery/copilot.test.ts
+++ b/packages/coding-agent/test/discovery/copilot.test.ts
@@ -27,11 +27,15 @@ describe("copilot MCP discovery", () => {
 	let tempDir = "";
 	let originalHome = "";
 	let originalCopilotHome: string | undefined;
+	let originalTestToken: string | undefined;
+	let originalTestUrl: string | undefined;
 
 	beforeEach(async () => {
 		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-copilot-"));
 		originalHome = process.env.HOME ?? process.env.USERPROFILE ?? "";
 		originalCopilotHome = process.env.COPILOT_HOME;
+		originalTestToken = process.env.OMP_TEST_TOKEN;
+		originalTestUrl = process.env.OMP_TEST_URL;
 		// Point HOME to tempDir so resolveCopilotHome returns tempDir/.copilot
 		process.env.HOME = tempDir;
 		process.env.USERPROFILE = tempDir;
@@ -46,6 +50,16 @@ describe("copilot MCP discovery", () => {
 			delete process.env.COPILOT_HOME;
 		} else {
 			process.env.COPILOT_HOME = originalCopilotHome;
+		}
+		if (originalTestToken === undefined) {
+			delete process.env.OMP_TEST_TOKEN;
+		} else {
+			process.env.OMP_TEST_TOKEN = originalTestToken;
+		}
+		if (originalTestUrl === undefined) {
+			delete process.env.OMP_TEST_URL;
+		} else {
+			process.env.OMP_TEST_URL = originalTestUrl;
 		}
 	});
 
@@ -177,9 +191,6 @@ describe("copilot MCP discovery", () => {
 		expect(servers).toHaveLength(1);
 		expect(servers[0]?.url).toBe("https://mcp.example.com");
 		expect(servers[0]?.headers).toEqual({ Authorization: "secret-token" });
-
-		delete process.env.OMP_TEST_TOKEN;
-		delete process.env.OMP_TEST_URL;
 	});
 
 	test("normalizes type 'local' to transport 'stdio'", async () => {


### PR DESCRIPTION
## Summary

Adds a `copilot` discovery provider that reads `~/.copilot/mcp-config.json` and registers the MCP servers found inside. Users who configure MCP servers via GitHub Copilot CLI no longer need to duplicate their config into `.omp/mcp.json` — OMP discovers them automatically.

Closes #1917.

## Changes

### New: `discovery/copilot.ts`
- Registers `mcpCapability` provider (priority 30, same as `github.ts`)
- Reads `~/.copilot/mcp-config.json` via `resolveCopilotHome(ctx)`
- Supports `COPILOT_HOME` env var override (forward-compatible with #1915)
- Handles both `mcpServers` (official) and `servers` (compatibility fallback) top-level keys
- Delegates parsing to shared `transformMCPConfig` from `mcp-json.ts`

### Modified: `discovery/mcp-json.ts`
- Exported `MCPConfigFile` interface and `transformMCPConfig` function
- Widened `MCPConfigFile.type` to accept `"local"` (Copilot transport)
- Normalizes `"local"` → `"stdio"` at assignment time in `transformMCPConfig`

### Modified: `discovery/index.ts`
- Added `import "./copilot"` to register the provider

### New: `test/discovery/copilot.test.ts`
8 tests covering:
- `mcpServers` key discovery
- `servers` key fallback
- Priority when both keys present
- Missing file (graceful empty)
- Invalid JSON (warning)
- `COPILOT_HOME` env var override
- Environment variable expansion in config values
- `"local"` → `"stdio"` transport normalization

### CHANGELOG.md
Added entries under `[Unreleased]` (Added, Changed, Fixed) with issue links.

## Out of scope

- `.github/mcp.json` (not a stable Copilot convention)
- Agent discovery (#1914)
- Prompt file discovery (#1916)
- `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` (#1915)

## Testing

```
bun test packages/coding-agent/test/discovery/copilot.test.ts  # 8 pass
bun test packages/coding-agent/test/discovery/mcp-json.test.ts  # 2 pass (no regression)
bun test packages/coding-agent/test/discovery/                  # 117 pass across 16 files
```