### PR TITLE
fix(providers): recycle failed local model workers

### DIFF
--- a/packages/coding-agent/src/tiny/title-client.ts
+++ b/packages/coding-agent/src/tiny/title-client.ts
@@ -261,6 +261,11 @@ export class TinyTitleClient {
 	#pending = new Map<string, PendingRequest>();
 	#progressListeners = new Set<(event: TinyTitleProgressEvent) => void>();
 	#nextRequestId = 0;
+	#spawnWorker: () => WorkerHandle;
+
+	constructor(spawnWorker: () => WorkerHandle = spawnTinyTitleWorker) {
+		this.#spawnWorker = spawnWorker;
+	}
 
 	onProgress(listener: (event: TinyTitleProgressEvent) => void): () => void {
 		this.#progressListeners.add(listener);
@@ -392,7 +397,7 @@ export class TinyTitleClient {
 
 	#ensureWorker(): WorkerHandle {
 		if (this.#worker) return this.#worker;
-		const worker = spawnTinyTitleWorker();
+		const worker = this.#spawnWorker();
 		this.#worker = worker;
 		this.#unsubscribeMessage = worker.onMessage(message => this.#handleMessage(message));
 		this.#unsubscribeError = worker.onError(error => this.#handleWorkerError(error));
@@ -429,6 +434,7 @@ export class TinyTitleClient {
 		this.#emitProgress({ modelKey: pending.modelKey, status: "error" });
 		if (pending.kind === "generate" || pending.kind === "complete") pending.resolve(null);
 		else pending.resolve(false);
+		void this.terminate();
 	}
 
 	#emitProgress(event: TinyTitleProgressEvent): void {

--- a/packages/coding-agent/test/issue-1940-repro.test.ts
+++ b/packages/coding-agent/test/issue-1940-repro.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "bun:test";
+import { TinyTitleClient } from "../src/tiny/title-client";
+import type { TinyTitleWorkerInbound, TinyTitleWorkerOutbound } from "../src/tiny/title-protocol";
+
+class FakeTinyWorker {
+	terminated = false;
+	#messageHandlers = new Set<(message: TinyTitleWorkerOutbound) => void>();
+	#onSend: (message: TinyTitleWorkerInbound, worker: FakeTinyWorker) => void;
+
+	constructor(onSend: (message: TinyTitleWorkerInbound, worker: FakeTinyWorker) => void) {
+		this.#onSend = onSend;
+	}
+
+	send(message: TinyTitleWorkerInbound): void {
+		this.#onSend(message, this);
+	}
+
+	onMessage(handler: (message: TinyTitleWorkerOutbound) => void): () => void {
+		this.#messageHandlers.add(handler);
+		return () => this.#messageHandlers.delete(handler);
+	}
+
+	onError(): () => void {
+		return () => {};
+	}
+
+	async terminate(): Promise<void> {
+		this.terminated = true;
+	}
+
+	emit(message: TinyTitleWorkerOutbound): void {
+		for (const handler of this.#messageHandlers) handler(message);
+	}
+}
+
+describe("issue #1940 — local model failures release the worker process", () => {
+	it("recycles the tiny-model worker after model execution returns an error", async () => {
+		const first = new FakeTinyWorker((message, worker) => {
+			if (message.type === "complete") {
+				worker.emit({ type: "error", id: message.id, error: "Error: Unknown failure" });
+			}
+		});
+		const second = new FakeTinyWorker((message, worker) => {
+			if (message.type === "complete") {
+				worker.emit({ type: "completion", id: message.id, text: "recovered" });
+			}
+		});
+		const workers = [first, second];
+		let nextWorker = 0;
+		const client = new TinyTitleClient(() => {
+			const worker = workers[nextWorker];
+			if (!worker) throw new Error("unexpected worker spawn");
+			nextWorker += 1;
+			return worker;
+		});
+
+		try {
+			expect(await client.complete("qwen3-1.7b", "long prompt")).toBeNull();
+			expect(first.terminated).toBe(true);
+			expect(await client.complete("qwen3-1.7b", "retry prompt")).toBe("recovered");
+			expect(nextWorker).toBe(2);
+		} finally {
+			await client.terminate();
+		}
+	});
+
+	it("faults queued local completions when the failed worker is recycled", async () => {
+		let firstRequestId = "";
+		const worker = new FakeTinyWorker(message => {
+			if (message.type !== "complete") return;
+			firstRequestId ||= message.id;
+		});
+		const client = new TinyTitleClient(() => worker);
+
+		try {
+			const first = client.complete("qwen3-1.7b", "first prompt");
+			const second = client.complete("qwen3-1.7b", "second prompt");
+			worker.emit({ type: "error", id: firstRequestId, error: "Error: Unknown failure" });
+
+			expect(await first).toBeNull();
+			expect(await second).toBeNull();
+			expect(worker.terminated).toBe(true);
+		} finally {
+			await client.terminate();
+		}
+	});
+});


### PR DESCRIPTION
## Repro
A CI-safe fake tiny-model worker reproduces the failure path by returning `Error: Unknown failure` for a local completion. Without recycling the worker, `bun test test/issue-1940-repro.test.ts` fails because the failed worker is not terminated and a queued completion hangs.

## Cause
`TinyTitleClient.#handleMessage` in `packages/coding-agent/src/tiny/title-client.ts` resolved worker-reported `error` messages but left the same subprocess alive. For ONNX Runtime failures, that preserved native allocations in the long-lived Bun subprocess and let later queued requests wait on a worker that should have been discarded.

## Fix
- Added a `TinyTitleClient` worker factory seam so lifecycle behavior can be tested without loading ONNX models.
- Terminate the tiny-model subprocess whenever it reports a model execution error, releasing the child process address space and clearing queued local requests.
- Added `packages/coding-agent/test/issue-1940-repro.test.ts` covering retry after `Unknown failure` and queued completions during worker recycle.

## Verification
Reproduced the pre-fix failure with `bun test test/issue-1940-repro.test.ts` after removing the recycle call: 0 pass, 2 fail. After the fix, `bun test test/issue-1606-repro.test.ts test/issue-1940-repro.test.ts` passes with 6 tests, and `bun run check` passes in `packages/coding-agent`. Fixes #1940