### PR TITLE
Add configurable status line placement

### DIFF
--- a/docs/tui-runtime-internals.md
+++ b/docs/tui-runtime-internals.md
@@ -33,6 +33,7 @@ Boundary rule: the TUI engine is message-agnostic. It only knows `Component.rend
 - `statusLine`
 - `hookWidgetContainerAbove`
 - `editorContainer` (holds `CustomEditor`)
+- `statusLineBelowEditor` (renders main status line when `statusLine.placement=below`)
 - `hookWidgetContainerBelow`
 
 `init()` wires the tree in that order, focuses the editor, registers input handlers via `InputController`, subscribes terminal appearance changes into theme auto-detection, starts TUI, and requests a forced render.
@@ -152,7 +153,7 @@ Read-tool grouping is intentionally stateful (`#lastReadGroup`) to coalesce cons
 Status lane ownership:
 
 - `statusContainer` holds transient loaders (`loadingAnimation`, `autoCompactionLoader`, `retryLoader`).
-- `statusLine` renders persistent status/hooks/plan indicators and drives editor top border updates.
+- `statusLine` renders persistent hook/plan indicators and drives editor top border updates. The main status line lives in the editor top border by default; when `statusLine.placement=below`, `statusLineBelowEditor` renders that main row below the editor and the editor top border falls back to plain chrome.
 
 Loader behavior:
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -441,6 +441,21 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"statusLine.placement": {
+		type: "enum",
+		values: ["above", "below"] as const,
+		default: "above",
+		ui: {
+			tab: "appearance",
+			label: "Status Line Placement",
+			description: "Render the main status line in the editor top border or below the editor",
+			options: [
+				{ value: "above", label: "Above", description: "In the editor top border" },
+				{ value: "below", label: "Below", description: "Below the editor" },
+			],
+		},
+	},
+
 	"statusLine.sessionAccent": {
 		type: "boolean",
 		default: true,
@@ -3266,6 +3281,9 @@ export type StatusLinePreset = SettingValue<"statusLine.preset">;
 /** Status line separator style - derived from schema */
 export type StatusLineSeparatorStyle = SettingValue<"statusLine.separator">;
 
+/** Status line placement - derived from schema */
+export type StatusLinePlacement = SettingValue<"statusLine.placement">;
+
 /** Tree selector filter mode - derived from schema */
 export type TreeFilterMode = SettingValue<"treeFilterMode">;
 
@@ -3372,6 +3390,7 @@ export interface ExaSettings {
 export interface StatusLineSettings {
 	preset: StatusLinePreset;
 	separator: StatusLineSeparatorStyle;
+	placement: StatusLinePlacement;
 	showHookStatus: boolean;
 	leftSegments: StatusLineSegmentId[];
 	rightSegments: StatusLineSegmentId[];

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -16,6 +16,7 @@ import {
 import { getDefault, type SettingPath, settings } from "../../config/settings";
 import type {
 	SettingTab,
+	StatusLinePlacement,
 	StatusLinePreset,
 	StatusLineSegmentId,
 	StatusLineSeparatorStyle,
@@ -195,6 +196,7 @@ export interface StatusLinePreviewSettings {
 	leftSegments?: StatusLineSegmentId[];
 	rightSegments?: StatusLineSegmentId[];
 	separator?: StatusLineSeparatorStyle;
+	placement?: StatusLinePlacement;
 	sessionAccent?: boolean;
 }
 
@@ -430,6 +432,16 @@ export class SettingsSelectorComponent extends Container {
 				this.callbacks.onStatusLinePreview?.({ separator });
 				this.#updateStatusPreview();
 			};
+		} else if (def.path === "statusLine.placement") {
+			onPreview = value => {
+				this.callbacks.onStatusLinePreview?.({ placement: value as StatusLinePlacement });
+				this.#updateStatusPreview();
+			};
+			onPreviewCancel = () => {
+				const placement = settings.get("statusLine.placement");
+				this.callbacks.onStatusLinePreview?.({ placement });
+				this.#updateStatusPreview();
+			};
 		}
 
 		// Provide status line preview for theme selection
@@ -589,6 +601,7 @@ export class SettingsSelectorComponent extends Container {
 			leftSegments: settings.get("statusLine.leftSegments"),
 			rightSegments: settings.get("statusLine.rightSegments"),
 			separator: settings.get("statusLine.separator"),
+			placement: settings.get("statusLine.placement"),
 			sessionAccent: settings.get("statusLine.sessionAccent"),
 		};
 		this.callbacks.onStatusLinePreview?.(statusLineSettings);

--- a/packages/coding-agent/src/modes/components/status-line.ts
+++ b/packages/coding-agent/src/modes/components/status-line.ts
@@ -5,7 +5,12 @@ import { type Component, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui"
 import { formatCount, getProjectDir } from "@oh-my-pi/pi-utils";
 import { $ } from "bun";
 import { settings } from "../../config/settings";
-import type { StatusLinePreset, StatusLineSegmentId, StatusLineSeparatorStyle } from "../../config/settings-schema";
+import type {
+	StatusLinePlacement,
+	StatusLinePreset,
+	StatusLineSegmentId,
+	StatusLineSeparatorStyle,
+} from "../../config/settings-schema";
 import { theme } from "../../modes/theme/theme";
 import type { AgentSession } from "../../session/agent-session";
 import * as git from "../../utils/git";
@@ -35,6 +40,7 @@ export interface StatusLineSettings {
 	leftSegments?: StatusLineSegmentId[];
 	rightSegments?: StatusLineSegmentId[];
 	separator?: StatusLineSeparatorStyle;
+	placement?: StatusLinePlacement;
 	segmentOptions?: StatusLineSegmentOptions;
 	showHookStatus?: boolean;
 	sessionAccent?: boolean;
@@ -196,6 +202,7 @@ export class StatusLineComponent implements Component {
 			leftSegments: settings.get("statusLine.leftSegments"),
 			rightSegments: settings.get("statusLine.rightSegments"),
 			separator: settings.get("statusLine.separator"),
+			placement: settings.get("statusLine.placement"),
 			showHookStatus: settings.get("statusLine.showHookStatus"),
 			segmentOptions: settings.getGroup("statusLine").segmentOptions,
 			sessionAccent: settings.get("statusLine.sessionAccent"),
@@ -628,6 +635,7 @@ export class StatusLineComponent implements Component {
 			rightSegments,
 			separator: this.#settings.separator ?? presetDef.separator,
 			segmentOptions: mergedSegmentOptions,
+			placement: this.#settings.placement ?? "above",
 		};
 	}
 
@@ -776,6 +784,20 @@ export class StatusLineComponent implements Component {
 			content,
 			width: visibleWidth(content),
 		};
+	}
+
+	getEditorTopBorder(width: number): { content: string; width: number } | undefined {
+		if ((this.#settings.placement ?? "above") === "below") {
+			return undefined;
+		}
+		return this.getTopBorder(width);
+	}
+
+	getLineBelowEditor(width: number): string[] {
+		if ((this.#settings.placement ?? "above") !== "below") {
+			return [];
+		}
+		return [this.#buildStatusLine(width)];
 	}
 
 	render(width: number): string[] {

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -121,6 +121,7 @@ export class SelectorController {
 								leftSegments: settings.get("statusLine.leftSegments"),
 								rightSegments: settings.get("statusLine.rightSegments"),
 								separator: settings.get("statusLine.separator"),
+								placement: settings.get("statusLine.placement"),
 								showHookStatus: settings.get("statusLine.showHookStatus"),
 								sessionAccent: settings.get("statusLine.sessionAccent"),
 								...previewSettings,
@@ -131,7 +132,11 @@ export class SelectorController {
 						getStatusLinePreview: () => {
 							// Return the rendered status line for inline preview
 							const availableWidth = this.ctx.editor.getTopBorderAvailableWidth(this.ctx.ui.terminal.columns);
-							return this.ctx.statusLine.getTopBorder(availableWidth).content;
+							return (
+								this.ctx.statusLine.getEditorTopBorder(availableWidth)?.content ??
+								this.ctx.statusLine.getLineBelowEditor(this.ctx.ui.terminal.columns)[0] ??
+								""
+							);
 						},
 						onPluginsChanged: async () => {
 							const projectPath = await resolveActiveProjectRegistryPath(this.ctx.sessionManager.getCwd());
@@ -148,6 +153,7 @@ export class SelectorController {
 								leftSegments: settings.get("statusLine.leftSegments"),
 								rightSegments: settings.get("statusLine.rightSegments"),
 								separator: settings.get("statusLine.separator"),
+								placement: settings.get("statusLine.placement"),
 								showHookStatus: settings.get("statusLine.showHookStatus"),
 								sessionAccent: settings.get("statusLine.sessionAccent"),
 							});
@@ -355,6 +361,7 @@ export class SelectorController {
 			case "statusLine.preset":
 			case "statusLineSeparator":
 			case "statusLine.separator":
+			case "statusLine.placement":
 			case "statusLineShowHooks":
 			case "statusLine.showHookStatus":
 			case "statusLine.sessionAccent":
@@ -374,6 +381,7 @@ export class SelectorController {
 					leftSegments: settings.get("statusLine.leftSegments"),
 					rightSegments: settings.get("statusLine.rightSegments"),
 					separator: settings.get("statusLine.separator"),
+					placement: settings.get("statusLine.placement"),
 					showHookStatus: settings.get("statusLine.showHookStatus"),
 					sessionAccent: settings.get("statusLine.sessionAccent"),
 					segmentOptions: settings.get("statusLine.segmentOptions"),

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -235,6 +235,16 @@ function formatContextTokenCount(value: number): string {
 	return formatNumber(Math.max(0, Math.round(value))).toLowerCase();
 }
 
+class StatusLineBelowEditorComponent implements Component {
+	constructor(private readonly statusLine: StatusLineComponent) {}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		return this.statusLine.getLineBelowEditor(width);
+	}
+}
+
 /** Options for creating an InteractiveMode instance (for future API use) */
 export interface InteractiveModeOptions {
 	/** Providers that were migrated during startup */
@@ -269,6 +279,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	hookWidgetContainerAbove: Container;
 	hookWidgetContainerBelow: Container;
 	statusLine: StatusLineComponent;
+	statusLineBelowEditor: StatusLineBelowEditorComponent;
 
 	isInitialized = false;
 	isBackgrounded = false;
@@ -432,6 +443,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.editorContainer = new Container();
 		this.editorContainer.addChild(this.editor);
 		this.statusLine = new StatusLineComponent(session);
+		this.statusLineBelowEditor = new StatusLineBelowEditorComponent(this.statusLine);
 		this.statusLine.setAutoCompactEnabled(session.autoCompactionEnabled);
 
 		this.hideThinkingBlock = settings.get("hideThinkingBlock");
@@ -568,6 +580,7 @@ export class InteractiveMode implements InteractiveModeContext {
 		this.ui.addChild(this.statusLine); // Only renders hook statuses (main status in editor border)
 		this.ui.addChild(this.hookWidgetContainerAbove);
 		this.ui.addChild(this.editorContainer);
+		this.ui.addChild(this.statusLineBelowEditor);
 		this.ui.addChild(this.hookWidgetContainerBelow);
 		this.ui.setFocus(this.editor);
 
@@ -1031,7 +1044,7 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	updateEditorTopBorder(): void {
 		const availableWidth = this.editor.getTopBorderAvailableWidth(this.ui.terminal.columns);
-		const topBorder = this.statusLine.getTopBorder(availableWidth);
+		const topBorder = this.statusLine.getEditorTopBorder(availableWidth);
 		this.editor.setTopBorder(topBorder);
 	}
 

--- a/packages/coding-agent/test/status-line-overflow.test.ts
+++ b/packages/coding-agent/test/status-line-overflow.test.ts
@@ -122,6 +122,37 @@ describe("status line session accent", () => {
 	});
 });
 
+describe("status line placement", () => {
+	function buildComponent(placement: "above" | "below") {
+		const component = new StatusLineComponent(createStatusLineSession("Named session"));
+		component.updateSettings({
+			preset: "custom",
+			leftSegments: ["pi"],
+			rightSegments: ["session_name"],
+			separator: "powerline-thin",
+			placement,
+		});
+		return component;
+	}
+
+	it("keeps the main status line in the editor top border by default", () => {
+		const component = buildComponent("above");
+
+		expect(component.getEditorTopBorder(80)?.content).toBe(component.getTopBorder(80).content);
+		expect(component.getLineBelowEditor(80)).toEqual([]);
+	});
+
+	it("can render the main status line below the editor", () => {
+		const component = buildComponent("below");
+		const belowLines = component.getLineBelowEditor(80);
+
+		expect(component.getEditorTopBorder(80)).toBeUndefined();
+		expect(belowLines).toHaveLength(1);
+		expect(belowLines[0]).toBe(component.getTopBorder(80).content);
+		expect(visibleWidth(belowLines[0] ?? "")).toBe(80);
+	});
+});
+
 describe("path segment truncation at varying maxLength", () => {
 	let tmpDir: string;
 


### PR DESCRIPTION
## Summary

- add `statusLine.placement` with `above` default and `below` support
- render the main status line below the editor when configured, leaving the editor top border plain
- wire placement into settings preview/update flow
- document the TUI component tree and add placement tests

Closes #1943

## Tests

- `npx --yes bun@1.3.14 --cwd=packages/coding-agent run check`
- `npx --yes bun@1.3.14 test packages/coding-agent/test/status-line-overflow.test.ts`