### PR TITLE
fix(github): honor explicit `repo` in `run_watch` instead of falling back to cwd

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Fixed chat transcript updates after submitting input so frozen scrollback is only thawed when native scrollback replay succeeds, preventing misplaced or duplicated rows when the viewport is not at the tail
 - Fixed `read` of `.zip` archives to list the central directory without inflating every member, so large or corrupt zip payloads no longer freeze directory reads; member contents are inflated only when a specific entry is read.
+- Fixed `github` tool `run_watch` op ignoring the explicit `repo` argument and silently watching the cwd-inferred repository in nested/umbrella workspaces. `executeRunWatch` passed `undefined` for the user-supplied `repo` to `resolveGitHubRepo`, so a call like `{op: "run_watch", repo: "owner/cxf", branch: "main"}` fell back to `gh repo view` in cwd and streamed `watching <sha> on <cwd-repo>` against the wrong repository. The explicit `repo` now takes precedence over the cwd inference, and the no-`branch`/no-`run` path refuses to derive the watched commit from `git HEAD` unless the cwd actually points at the resolved repo — otherwise it raises a `ToolError` telling the caller to pass `branch` or `run` instead of silently rebinding to an unrelated commit ([#1949](https://github.com/can1357/oh-my-pi/issues/1949)).
 
 ## [15.9.3] - 2026-06-05
 

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -1713,6 +1713,19 @@ export async function resolveDefaultRepoMemoized(cwd: string, signal?: AbortSign
 }
 
 /**
+ * Best-effort cwd → `owner/repo` resolution that swallows any failure (not a
+ * git checkout, no GitHub remote, `gh` unauthenticated, …) into `undefined`.
+ * Use where the cwd repo is a fallback or a guard, not a requirement.
+ */
+async function tryResolveCurrentRepo(cwd: string, signal: AbortSignal | undefined): Promise<string | undefined> {
+	try {
+		return await resolveDefaultRepoMemoized(cwd, signal);
+	} catch {
+		return undefined;
+	}
+}
+
+/**
  * Matches search-query qualifiers that already scope to a repository, org, or
  * user. When present, callers should avoid layering a default `repo:<current>`
  * on top — the user has already expressed an explicit scope.
@@ -1738,11 +1751,7 @@ async function resolveSearchRepoScope(
 ): Promise<string | undefined> {
 	if (repo) return repo;
 	if (query && REPO_SCOPE_QUALIFIER_PATTERN.test(query)) return undefined;
-	try {
-		return await resolveDefaultRepoMemoized(cwd, signal);
-	} catch {
-		return undefined;
-	}
+	return tryResolveCurrentRepo(cwd, signal);
 }
 
 async function resolveGitHubBranchHead(
@@ -3338,8 +3347,9 @@ async function executeRunWatch(
 	onUpdate: AgentToolUpdateCallback<GhToolDetails> | undefined,
 ): Promise<AgentToolResult<GhToolDetails>> {
 	const branchInput = normalizeOptionalString(params.branch);
+	const explicitRepo = normalizeOptionalString(params.repo);
 	const runReference = parseRunReference(params.run);
-	const repo = await resolveGitHubRepo(session.cwd, undefined, runReference.repo, signal);
+	const repo = await resolveGitHubRepo(session.cwd, explicitRepo, runReference.repo, signal);
 	const intervalSeconds = RUN_WATCH_INTERVAL_DEFAULT;
 	const graceSeconds = RUN_WATCH_GRACE_DEFAULT;
 	const tail = resolveTailLimit(params.tail);
@@ -3419,10 +3429,25 @@ async function executeRunWatch(
 		}
 	}
 
-	const branch = branchInput ?? (await requireCurrentGitBranch(session.cwd, signal));
-	const headSha = branchInput
-		? await resolveGitHubBranchHead(session.cwd, repo, branch, signal)
-		: await requireCurrentGitHead(session.cwd, signal);
+	let branch: string;
+	let headSha: string;
+	if (branchInput) {
+		branch = branchInput;
+		headSha = await resolveGitHubBranchHead(session.cwd, repo, branch, signal);
+	} else {
+		// No branch/run selector — derive the commit from the current checkout,
+		// but only when cwd actually points at `repo`. Otherwise we'd watch an
+		// unrelated commit SHA against the explicit repo and silently stream a
+		// confident wrong-repo status (issue #1949).
+		const cwdRepo = await tryResolveCurrentRepo(session.cwd, signal);
+		if (cwdRepo !== repo) {
+			throw new ToolError(
+				`Cannot infer the watched commit for ${repo}: current checkout is ${cwdRepo ?? "not a GitHub repository"}. Pass \`branch\` or \`run\` to scope the watch.`,
+			);
+		}
+		branch = await requireCurrentGitBranch(session.cwd, signal);
+		headSha = await requireCurrentGitHead(session.cwd, signal);
+	}
 	let pollCount = 0;
 	let settledSuccessSignature: string | undefined;
 

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -1751,7 +1751,6 @@ async function tryResolveCurrentRepoFresh(cwd: string, signal: AbortSignal | und
 	}
 }
 
-
 /**
  * Matches search-query qualifiers that already scope to a repository, org, or
  * user. When present, callers should avoid layering a default `repo:<current>`

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -792,6 +792,19 @@ function repoFromRepositoryUrl(value: string | undefined): string | undefined {
 	return value.slice(REPO_API_URL_PREFIX.length);
 }
 
+function githubRepoSlugEquals(left: string | undefined, right: string): boolean {
+	if (left === undefined || left.length !== right.length) return false;
+	for (let idx = 0; idx < left.length; idx += 1) {
+		let leftCode = left.charCodeAt(idx);
+		let rightCode = right.charCodeAt(idx);
+		if (leftCode >= 65 && leftCode <= 90) leftCode += 32;
+		if (rightCode >= 65 && rightCode <= 90) rightCode += 32;
+		if (leftCode !== rightCode) return false;
+	}
+	return true;
+}
+
+
 function apiUserToGhUser(user: GhApiUser | null | undefined): GhUser | undefined {
 	if (!user) return undefined;
 	const login = user.login ?? undefined;
@@ -1646,7 +1659,7 @@ async function resolveGitHubRepo(
 	runRepo: string | undefined,
 	signal?: AbortSignal,
 ): Promise<string> {
-	if (repo && runRepo && repo !== runRepo) {
+	if (repo && runRepo && !githubRepoSlugEquals(repo, runRepo)) {
 		throw new ToolError("run URL repository does not match the provided repo");
 	}
 
@@ -3443,7 +3456,7 @@ async function executeRunWatch(
 		// while callers may pass any casing — so the equality check normalizes
 		// both sides before deciding the cwd is a different repo (PR #1951).
 		const cwdRepo = await tryResolveCurrentRepo(session.cwd, signal);
-		if (cwdRepo?.toLowerCase() !== repo.toLowerCase()) {
+		if (!githubRepoSlugEquals(cwdRepo, repo)) {
 			throw new ToolError(
 				`Cannot infer the watched commit for ${repo}: current checkout is ${cwdRepo ?? "not a GitHub repository"}. Pass \`branch\` or \`run\` to scope the watch.`,
 			);

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -1725,9 +1725,10 @@ export async function resolveDefaultRepoMemoized(cwd: string, signal?: AbortSign
 }
 
 /**
- * Best-effort cwd → `owner/repo` resolution that swallows any failure (not a
- * git checkout, no GitHub remote, `gh` unauthenticated, …) into `undefined`.
- * Use where the cwd repo is a fallback or a guard, not a requirement.
+ * Best-effort cached cwd → `owner/repo` resolution that swallows any failure
+ * (not a git checkout, no GitHub remote, `gh` unauthenticated, …) into
+ * `undefined`. Use where the cwd repo is a convenience fallback, not a safety
+ * check.
  */
 async function tryResolveCurrentRepo(cwd: string, signal: AbortSignal | undefined): Promise<string | undefined> {
 	try {
@@ -1736,6 +1737,20 @@ async function tryResolveCurrentRepo(cwd: string, signal: AbortSignal | undefine
 		return undefined;
 	}
 }
+
+/**
+ * Best-effort fresh cwd → `owner/repo` resolution for safety checks that must
+ * reflect the repository currently mounted at `cwd`, not the process-lifetime
+ * default-repo cache.
+ */
+async function tryResolveCurrentRepoFresh(cwd: string, signal: AbortSignal | undefined): Promise<string | undefined> {
+	try {
+		return await resolveGitHubRepo(cwd, undefined, undefined, signal);
+	} catch {
+		return undefined;
+	}
+}
+
 
 /**
  * Matches search-query qualifiers that already scope to a repository, org, or
@@ -3454,7 +3469,7 @@ async function executeRunWatch(
 		// are case-insensitive — `gh repo view` returns the canonical casing
 		// while callers may pass any casing — so the equality check normalizes
 		// both sides before deciding the cwd is a different repo (PR #1951).
-		const cwdRepo = await tryResolveCurrentRepo(session.cwd, signal);
+		const cwdRepo = await tryResolveCurrentRepoFresh(session.cwd, signal);
 		if (!githubRepoSlugEquals(cwdRepo, repo)) {
 			throw new ToolError(
 				`Cannot infer the watched commit for ${repo}: current checkout is ${cwdRepo ?? "not a GitHub repository"}. Pass \`branch\` or \`run\` to scope the watch.`,

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -804,7 +804,6 @@ function githubRepoSlugEquals(left: string | undefined, right: string): boolean 
 	return true;
 }
 
-
 function apiUserToGhUser(user: GhApiUser | null | undefined): GhUser | undefined {
 	if (!user) return undefined;
 	const login = user.login ?? undefined;

--- a/packages/coding-agent/src/tools/gh.ts
+++ b/packages/coding-agent/src/tools/gh.ts
@@ -3438,9 +3438,12 @@ async function executeRunWatch(
 		// No branch/run selector — derive the commit from the current checkout,
 		// but only when cwd actually points at `repo`. Otherwise we'd watch an
 		// unrelated commit SHA against the explicit repo and silently stream a
-		// confident wrong-repo status (issue #1949).
+		// confident wrong-repo status (issue #1949). GitHub `owner/repo` slugs
+		// are case-insensitive — `gh repo view` returns the canonical casing
+		// while callers may pass any casing — so the equality check normalizes
+		// both sides before deciding the cwd is a different repo (PR #1951).
 		const cwdRepo = await tryResolveCurrentRepo(session.cwd, signal);
-		if (cwdRepo !== repo) {
+		if (cwdRepo?.toLowerCase() !== repo.toLowerCase()) {
 			throw new ToolError(
 				`Cannot infer the watched commit for ${repo}: current checkout is ${cwdRepo ?? "not a GitHub repository"}. Pass \`branch\` or \`run\` to scope the watch.`,
 			);

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -979,4 +979,116 @@ describe("github tool", () => {
 			await fs.rm(artifactsDir, { recursive: true, force: true });
 		}
 	});
+
+	it("honors the explicit `repo` argument and does not fall back to the cwd repo (issue #1949)", async () => {
+		// Reporter's scenario: cwd lives in repo A (`cagedbird043/cagedbird-ecosystem`),
+		// caller passes `repo: cagedbird043/cxf`. Before the fix, executeRunWatch
+		// passed `undefined` for the explicit repo and `resolveGitHubRepo` fell back
+		// to `gh repo view` in cwd, silently watching repo A. The fix routes
+		// `params.repo` through, so all `/repos/...` API calls must target cxf.
+		const targetRepo = "cagedbird043/cxf";
+		const runId = 42;
+
+		const jsonSpy = vi
+			.spyOn(git.github, "json")
+			.mockResolvedValueOnce({
+				// `fetchRunSnapshot` → run details
+				id: runId,
+				name: "CI",
+				display_title: "explicit-repo run",
+				status: "completed",
+				conclusion: "failure",
+				head_branch: "main",
+				created_at: "2026-06-05T10:00:00Z",
+				updated_at: "2026-06-05T10:05:00Z",
+				html_url: `https://github.com/${targetRepo}/actions/runs/${runId}`,
+			})
+			.mockResolvedValueOnce({
+				// `fetchRunJobs` page 1
+				total_count: 1,
+				jobs: [
+					{
+						id: 7,
+						name: "test",
+						status: "completed",
+						conclusion: "failure",
+						started_at: "2026-06-05T10:00:00Z",
+						completed_at: "2026-06-05T10:05:00Z",
+						html_url: `https://github.com/${targetRepo}/actions/runs/${runId}/job/7`,
+					},
+				],
+			});
+		const runSpy = vi
+			.spyOn(git.github, "run")
+			.mockResolvedValue({ exitCode: 0, stdout: "log line\n", stderr: "" });
+		const textSpy = vi
+			.spyOn(git.github, "text")
+			.mockRejectedValue(new Error("gh repo view must not be consulted when `repo` is explicit"));
+
+		const tool = new GithubTool(createSession("/tmp/run-watch-explicit-repo-cwd"));
+		const result = await tool.execute("run-watch", {
+			op: "run_watch",
+			repo: targetRepo,
+			run: String(runId),
+			tail: 1,
+		});
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		// Repo precedence — every API surface stayed scoped to `cagedbird043/cxf`.
+		expect(textSpy).not.toHaveBeenCalled();
+		for (const call of jsonSpy.mock.calls) {
+			const argv = call[1] as string[];
+			const apiPath = argv.find(arg => arg.startsWith("/repos/"));
+			expect(apiPath, `every json call must target ${targetRepo}, got ${argv.join(" ")}`).toContain(
+				`/repos/${targetRepo}/`,
+			);
+		}
+		const logsCall = runSpy.mock.calls.find(call =>
+			(call[1] as string[]).some(arg => typeof arg === "string" && arg.includes("/actions/jobs/")),
+		);
+		expect(logsCall?.[1] as string[]).toContain(`/repos/${targetRepo}/actions/jobs/7/logs`);
+
+		expect(text).toContain(`Repository: ${targetRepo}`);
+		expect(text).not.toContain("cagedbird043/cagedbird-ecosystem");
+		expect(result.details?.repo).toBe(targetRepo);
+	});
+
+	it("fails fast when explicit `repo` differs from the cwd repo and no `branch`/`run` selector is given (issue #1949)", async () => {
+		// Without a selector, the legacy code grabbed the cwd's HEAD SHA and
+		// queried it against the explicit repo — yielding an unrelated commit
+		// that surfaced as `Waiting for workflow runs for this commit`. The fix
+		// refuses to silently rebind: callers must scope explicitly.
+		const targetRepo = "cagedbird043/cxf";
+		const cwdRepo = "cagedbird043/cagedbird-ecosystem";
+		// Unique cwd per test — `resolveDefaultRepoMemoized` caches by absolute
+		// path for the lifetime of the process.
+		const cwd = `/tmp/run-watch-explicit-repo-mismatch-${Date.now()}`;
+		const textSpy = vi.spyOn(git.github, "text").mockResolvedValue(cwdRepo);
+		const jsonSpy = vi.spyOn(git.github, "json");
+
+		const tool = new GithubTool(createSession(cwd));
+		await expect(
+			tool.execute("run-watch", { op: "run_watch", repo: targetRepo }),
+		).rejects.toThrow(
+			`Cannot infer the watched commit for ${targetRepo}: current checkout is ${cwdRepo}. Pass \`branch\` or \`run\` to scope the watch.`,
+		);
+		expect(textSpy).toHaveBeenCalled();
+		// No API requests fired — we bailed before issuing any /repos/... call.
+		expect(jsonSpy).not.toHaveBeenCalled();
+	});
+
+	it("fails fast when explicit `repo` is given and cwd has no GitHub repository context (issue #1949)", async () => {
+		const targetRepo = "cagedbird043/cxf";
+		const cwd = `/tmp/run-watch-explicit-repo-no-git-${Date.now()}`;
+		vi.spyOn(git.github, "text").mockRejectedValue(new Error("not a git repository"));
+		const jsonSpy = vi.spyOn(git.github, "json");
+
+		const tool = new GithubTool(createSession(cwd));
+		await expect(
+			tool.execute("run-watch", { op: "run_watch", repo: targetRepo }),
+		).rejects.toThrow(
+			`Cannot infer the watched commit for ${targetRepo}: current checkout is not a GitHub repository. Pass \`branch\` or \`run\` to scope the watch.`,
+		);
+		expect(jsonSpy).not.toHaveBeenCalled();
+	});
 });

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -1137,7 +1137,6 @@ describe("github tool", () => {
 		expect(jsonSpy).not.toHaveBeenCalled();
 	});
 
-
 	it("fails fast when explicit `repo` is given and cwd has no GitHub repository context (issue #1949)", async () => {
 		const targetRepo = "cagedbird043/cxf";
 		const cwd = `/tmp/run-watch-explicit-repo-no-git-${Date.now()}`;

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -1091,7 +1091,6 @@ describe("github tool", () => {
 		expect(result.details?.repo).toBe(targetRepo);
 	});
 
-
 	it("fails fast when explicit `repo` differs from the cwd repo and no `branch`/`run` selector is given (issue #1949)", async () => {
 		// Without a selector, the legacy code grabbed the cwd's HEAD SHA and
 		// queried it against the explicit repo — yielding an unrelated commit

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -1085,4 +1085,36 @@ describe("github tool", () => {
 		);
 		expect(jsonSpy).not.toHaveBeenCalled();
 	});
+
+	it("treats explicit `repo` and the cwd repo as matching when only casing differs (PR #1951)", async () => {
+		// `gh repo view --json nameWithOwner` returns the canonical GitHub casing.
+		// A caller who types `cagedbird043/cxf` while the canonical form is
+		// `CagedBird043/cxf` MUST be treated as the same repo — GitHub repository
+		// paths are case-insensitive — and run_watch must NOT force them to pass
+		// a redundant `branch`/`run` selector.
+		const canonicalRepo = "CagedBird043/CXF";
+		const userRepo = "cagedbird043/cxf";
+		const cwd = `/tmp/run-watch-explicit-repo-casing-${Date.now()}`;
+		vi.spyOn(git.github, "text").mockResolvedValue(canonicalRepo);
+		// Past the case-insensitive guard, run_watch keeps using the caller's
+		// `repo` (downstream `/repos/...` paths are case-insensitive on GitHub).
+		// Stub the cwd's git HEAD/branch lookups so the watch proceeds to its
+		// first poll, then trip an abort to terminate the loop deterministically.
+		vi.spyOn(git.branch, "current").mockResolvedValue("main");
+		vi.spyOn(git.head, "sha").mockResolvedValue("c215f3a91217c215f3a91217c215f3a91217c215");
+		const abort = new AbortController();
+		const jsonSpy = vi.spyOn(git.github, "json").mockImplementation((async () => {
+			abort.abort();
+			return { workflow_runs: [] };
+		}) as unknown as typeof git.github.json);
+
+		const tool = new GithubTool(createSession(cwd));
+		// We don't care about the outcome — just that the casing guard let us
+		// reach the polling loop instead of throwing the mismatch ToolError.
+		await tool.execute("run-watch", { op: "run_watch", repo: userRepo }, abort.signal).catch(() => {});
+
+		expect(jsonSpy).toHaveBeenCalled();
+		const firstCall = jsonSpy.mock.calls[0]?.[1] as string[];
+		expect(firstCall.some(arg => arg === `/repos/${userRepo}/actions/runs`)).toBe(true);
+	});
 });

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -1051,6 +1051,47 @@ describe("github tool", () => {
 		expect(result.details?.repo).toBe(targetRepo);
 	});
 
+	it("accepts case-only differences between explicit `repo` and a run URL repo (PR #1951)", async () => {
+		const targetRepo = "cagedbird043/cxf";
+		const runUrlRepo = "CagedBird043/CXF";
+		const runId = 123;
+		const jsonSpy = vi
+			.spyOn(git.github, "json")
+			.mockResolvedValueOnce({
+				id: runId,
+				name: "CI",
+				display_title: "case-only run URL repo match",
+				status: "completed",
+				conclusion: "success",
+				head_branch: "main",
+				created_at: "2026-06-05T10:00:00Z",
+				updated_at: "2026-06-05T10:05:00Z",
+				html_url: `https://github.com/${runUrlRepo}/actions/runs/${runId}`,
+			})
+			.mockResolvedValueOnce({ total_count: 0, jobs: [] });
+		const textSpy = vi
+			.spyOn(git.github, "text")
+			.mockRejectedValue(new Error("gh repo view must not be consulted when `repo` is explicit"));
+
+		const tool = new GithubTool(createSession("/tmp/run-watch-run-url-casing"));
+		const result = await tool.execute("run-watch", {
+			op: "run_watch",
+			repo: targetRepo,
+			run: `https://github.com/${runUrlRepo}/actions/runs/${runId}`,
+		});
+		const text = result.content[0]?.type === "text" ? result.content[0].text : "";
+
+		expect(textSpy).not.toHaveBeenCalled();
+		for (const call of jsonSpy.mock.calls) {
+			const argv = call[1];
+			const apiPath = argv.find(arg => arg.startsWith("/repos/"));
+			expect(apiPath).toContain(`/repos/${targetRepo}/`);
+		}
+		expect(text).toContain(`Repository: ${targetRepo}`);
+		expect(result.details?.repo).toBe(targetRepo);
+	});
+
+
 	it("fails fast when explicit `repo` differs from the cwd repo and no `branch`/`run` selector is given (issue #1949)", async () => {
 		// Without a selector, the legacy code grabbed the cwd's HEAD SHA and
 		// queried it against the explicit repo — yielding an unrelated commit

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -9,6 +9,7 @@ import {
 	GithubTool,
 	parsePrUnifiedDiff,
 	parseSearchDateBound,
+	resolveDefaultRepoMemoized,
 } from "@oh-my-pi/pi-coding-agent/tools/gh";
 import * as git from "@oh-my-pi/pi-coding-agent/utils/git";
 import { getAgentDir, hashPath, setAgentDir } from "@oh-my-pi/pi-utils";
@@ -1112,6 +1113,30 @@ describe("github tool", () => {
 		// No API requests fired — we bailed before issuing any /repos/... call.
 		expect(jsonSpy).not.toHaveBeenCalled();
 	});
+
+	it("revalidates cwd repo without using the process-lifetime default repo cache before trusting HEAD (PR #1951)", async () => {
+		const targetRepo = "cagedbird043/cxf";
+		const replacedCwdRepo = "cagedbird043/cagedbird-ecosystem";
+		const cwd = `/tmp/run-watch-stale-cwd-repo-cache-${Date.now()}`;
+		const textSpy = vi
+			.spyOn(git.github, "text")
+			.mockResolvedValueOnce(targetRepo)
+			.mockResolvedValueOnce(replacedCwdRepo);
+		const jsonSpy = vi.spyOn(git.github, "json");
+
+		// Populate `resolveDefaultRepoMemoized` for this exact cwd, simulating a
+		// long-lived process that resolved the path before its checkout/remote
+		// was replaced.
+		await expect(resolveDefaultRepoMemoized(cwd)).resolves.toBe(targetRepo);
+
+		const tool = new GithubTool(createSession(cwd));
+		await expect(tool.execute("run-watch", { op: "run_watch", repo: targetRepo })).rejects.toThrow(
+			`Cannot infer the watched commit for ${targetRepo}: current checkout is ${replacedCwdRepo}. Pass \`branch\` or \`run\` to scope the watch.`,
+		);
+		expect(textSpy).toHaveBeenCalledTimes(2);
+		expect(jsonSpy).not.toHaveBeenCalled();
+	});
+
 
 	it("fails fast when explicit `repo` is given and cwd has no GitHub repository context (issue #1949)", async () => {
 		const targetRepo = "cagedbird043/cxf";

--- a/packages/coding-agent/test/tools/gh.test.ts
+++ b/packages/coding-agent/test/tools/gh.test.ts
@@ -1018,9 +1018,7 @@ describe("github tool", () => {
 					},
 				],
 			});
-		const runSpy = vi
-			.spyOn(git.github, "run")
-			.mockResolvedValue({ exitCode: 0, stdout: "log line\n", stderr: "" });
+		const runSpy = vi.spyOn(git.github, "run").mockResolvedValue({ exitCode: 0, stdout: "log line\n", stderr: "" });
 		const textSpy = vi
 			.spyOn(git.github, "text")
 			.mockRejectedValue(new Error("gh repo view must not be consulted when `repo` is explicit"));
@@ -1067,9 +1065,7 @@ describe("github tool", () => {
 		const jsonSpy = vi.spyOn(git.github, "json");
 
 		const tool = new GithubTool(createSession(cwd));
-		await expect(
-			tool.execute("run-watch", { op: "run_watch", repo: targetRepo }),
-		).rejects.toThrow(
+		await expect(tool.execute("run-watch", { op: "run_watch", repo: targetRepo })).rejects.toThrow(
 			`Cannot infer the watched commit for ${targetRepo}: current checkout is ${cwdRepo}. Pass \`branch\` or \`run\` to scope the watch.`,
 		);
 		expect(textSpy).toHaveBeenCalled();
@@ -1084,9 +1080,7 @@ describe("github tool", () => {
 		const jsonSpy = vi.spyOn(git.github, "json");
 
 		const tool = new GithubTool(createSession(cwd));
-		await expect(
-			tool.execute("run-watch", { op: "run_watch", repo: targetRepo }),
-		).rejects.toThrow(
+		await expect(tool.execute("run-watch", { op: "run_watch", repo: targetRepo })).rejects.toThrow(
 			`Cannot infer the watched commit for ${targetRepo}: current checkout is not a GitHub repository. Pass \`branch\` or \`run\` to scope the watch.`,
 		);
 		expect(jsonSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
## Repro

In an umbrella / nested workspace where cwd is inside repo A (e.g. `cagedbird043/cagedbird-ecosystem`) but the caller targets repo B, the `github` tool's `run_watch` op silently watches repo A instead of B:

```json
{ "op": "run_watch", "repo": "cagedbird043/cxf", "branch": "main" }
```

streamed `watching <sha> on cagedbird043/cagedbird-ecosystem` — wrong repo, with no warning. A regression test pinned the bug:

```sh
bun test --cwd=packages/coding-agent test/tools/gh.test.ts -t "issue #1949"
```

## Cause

`executeRunWatch` in `packages/coding-agent/src/tools/gh.ts` passed `undefined` for the explicit `repo` arg to `resolveGitHubRepo`:

```ts
const repo = await resolveGitHubRepo(session.cwd, undefined, runReference.repo, signal);
```

With no explicit `repo` and no run URL, `resolveGitHubRepo` fell through to `gh repo view --json nameWithOwner` in cwd, so the user's `params.repo` was silently discarded for every downstream `/repos/{repo}/...` call. The no-`branch`/no-`run` path then took cwd's HEAD SHA via `requireCurrentGitHead(session.cwd)` and queried it against whatever repo finally won — yielding an unrelated commit on either side.

## Fix

- Route `params.repo` through `resolveGitHubRepo` so an explicit `owner/repo` wins over both cwd inference and the run-URL inference.
- When no `branch`/`run` selector is supplied, refuse to derive the watched commit from `git HEAD` unless cwd actually points at the resolved repo; otherwise raise a `ToolError` telling the caller to pass `branch` or `run` rather than silently rebinding to an unrelated commit.
- Dedupe `resolveSearchRepoScope`'s best-effort cwd lookup into a shared `tryResolveCurrentRepo` helper used by the new guard.
- Three regression tests in `packages/coding-agent/test/tools/gh.test.ts`:
  - explicit `repo` + numeric `run` keeps every `/repos/...` call scoped to the explicit owner/repo and never touches `gh repo view`
  - explicit `repo` with no selector + mismatched cwd repo throws the new `ToolError` before issuing any API call
  - explicit `repo` with no selector + cwd that is not a GitHub repo throws the same error
- Changelog entry under `[Unreleased] > Fixed`.

## Verification

```sh
bun test --cwd=packages/coding-agent test/tools/gh.test.ts -t "issue #1949"
# 3 pass / 0 fail
bun --cwd=packages/coding-agent run check:types
# clean
```

Full `gh.test.ts` run has two pre-existing `pr_checkout` failures (`ENOENT … .omp/wt/<sha>` from `gh pr checkout` worktree creation in the sandbox); confirmed those failures reproduce on `main` with my changes stashed, so they're unrelated to this PR. `bun run check`'s biome step is skipped via the auto-`style:` commit in `gh_open_pr`.

Fixes #1949