### PR TITLE
fix(ai): honor OpenAI idle timeout for native Ollama streams

### DIFF
--- a/packages/ai/src/providers/register-builtins.ts
+++ b/packages/ai/src/providers/register-builtins.ts
@@ -21,7 +21,13 @@ import type {
 } from "../types";
 import { type AbortSourceTracker, createAbortSourceTracker } from "../utils/abort";
 import { AssistantMessageEventStream as EventStreamImpl } from "../utils/event-stream";
-import { getStreamFirstEventTimeoutMs, getStreamIdleTimeoutMs, iterateWithIdleTimeout } from "../utils/idle-iterator";
+import {
+	getOpenAIStreamFirstEventTimeoutMs,
+	getOpenAIStreamIdleTimeoutMs,
+	getStreamFirstEventTimeoutMs,
+	getStreamIdleTimeoutMs,
+	iterateWithIdleTimeout,
+} from "../utils/idle-iterator";
 import type { BedrockOptions } from "./amazon-bedrock";
 import type { AnthropicOptions } from "./anthropic";
 import type { AzureOpenAIResponsesOptions } from "./azure-openai-responses";
@@ -167,11 +173,10 @@ function hasFinalResult(
 }
 
 /**
- * Per-provider default overrides for the lazy stream watchdogs. These widen the
- * floor used when neither caller option nor env var pins a value. The env vars
- * (`PI_STREAM_FIRST_EVENT_TIMEOUT_MS`, `PI_STREAM_IDLE_TIMEOUT_MS`) still take
- * precedence; `StreamOptions.streamFirstEventTimeoutMs` / `streamIdleTimeoutMs`
- * still trump everything.
+ * floor used when neither caller option nor env var pins a value. Generic env
+ * vars (`PI_STREAM_FIRST_EVENT_TIMEOUT_MS`, `PI_STREAM_IDLE_TIMEOUT_MS`) still
+ * take precedence unless a provider opts into OpenAI-family idle flooring for
+ * local backends that users historically tuned with `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS`.
  */
 interface LazyStreamLimits {
 	defaultFirstEventTimeoutMs?: number;
@@ -181,6 +186,12 @@ interface LazyStreamLimits {
 	 * stream timeouts. Keep the lazy loader from racing it with generic errors.
 	 */
 	providerHandlesStreamTimeouts?: boolean;
+	/**
+	 * Apply OpenAI-family idle timeout precedence in the lazy wrapper. Used by
+	 * local backends whose users historically tune slow prompt-processing gaps
+	 * with `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS`.
+	 */
+	openAIIdleEnvFloorsFirstEvent?: boolean;
 }
 /**
  * Cloud Code Assist (google-gemini-cli / google-antigravity) routinely takes
@@ -199,6 +210,10 @@ const PROVIDER_HANDLED_STREAM_TIMEOUTS: LazyStreamLimits = {
 	providerHandlesStreamTimeouts: true,
 };
 
+const OPENAI_IDLE_FLOORED_LAZY_STREAM_LIMITS: LazyStreamLimits = {
+	openAIIdleEnvFloorsFirstEvent: true,
+};
+
 function forwardStream<TApi extends Api>(
 	target: EventStreamImpl,
 	source: AsyncIterable<AssistantMessageEvent>,
@@ -212,13 +227,19 @@ function forwardStream<TApi extends Api>(
 			const providerHandlesStreamTimeouts = limits?.providerHandlesStreamTimeouts === true;
 			const idleTimeoutMs = providerHandlesStreamTimeouts
 				? undefined
-				: (options.streamIdleTimeoutMs ?? getStreamIdleTimeoutMs(limits?.defaultIdleTimeoutMs));
+				: (options.streamIdleTimeoutMs ??
+					(limits?.openAIIdleEnvFloorsFirstEvent
+						? getOpenAIStreamIdleTimeoutMs(limits.defaultIdleTimeoutMs)
+						: getStreamIdleTimeoutMs(limits?.defaultIdleTimeoutMs)));
+			const firstItemTimeoutMs = providerHandlesStreamTimeouts
+				? 0
+				: (options.streamFirstEventTimeoutMs ??
+					(limits?.openAIIdleEnvFloorsFirstEvent
+						? getOpenAIStreamFirstEventTimeoutMs(idleTimeoutMs, limits.defaultFirstEventTimeoutMs)
+						: getStreamFirstEventTimeoutMs(idleTimeoutMs, limits?.defaultFirstEventTimeoutMs)));
 			const watchedSource = iterateWithIdleTimeout(source, {
 				idleTimeoutMs,
-				firstItemTimeoutMs: providerHandlesStreamTimeouts
-					? 0
-					: (options.streamFirstEventTimeoutMs ??
-						getStreamFirstEventTimeoutMs(idleTimeoutMs, limits?.defaultFirstEventTimeoutMs)),
+				firstItemTimeoutMs,
 				errorMessage: LAZY_STREAM_IDLE_TIMEOUT_ERROR,
 				firstItemErrorMessage: LAZY_STREAM_FIRST_EVENT_TIMEOUT_ERROR,
 				onIdle: () => abortTracker.abortLocally(new Error(LAZY_STREAM_IDLE_TIMEOUT_ERROR)),
@@ -431,6 +452,6 @@ export const streamOpenAIResponses = createLazyStream(
 	PROVIDER_HANDLED_STREAM_TIMEOUTS,
 );
 export const streamCursor = createLazyStream(loadCursorProviderModule);
-export const streamOllama = createLazyStream(loadOllamaProviderModule);
+export const streamOllama = createLazyStream(loadOllamaProviderModule, OPENAI_IDLE_FLOORED_LAZY_STREAM_LIMITS);
 
 export const streamBedrock = createLazyStream(loadBedrockProviderModule);

--- a/packages/ai/test/openai-first-event-timeout.test.ts
+++ b/packages/ai/test/openai-first-event-timeout.test.ts
@@ -26,6 +26,18 @@ const azureOpenAIResponsesModel: Model<"azure-openai-responses"> = {
 	contextWindow: 400000,
 	maxTokens: 128000,
 };
+const ollamaChatModel: Model<"ollama-chat"> = {
+	id: "llama-local",
+	name: "llama-local",
+	api: "ollama-chat",
+	provider: "ollama",
+	baseUrl: "http://127.0.0.1:11434",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 128000,
+	maxTokens: 8192,
+};
 
 function baseContext(): Context {
 	return {
@@ -228,6 +240,18 @@ function createOpenAICompletionsSuccessResponse(modelId: string): Response {
 	]);
 }
 
+function createOllamaChatSuccessResponse(): Response {
+	return new Response(
+		`${JSON.stringify({ message: { content: "Hello delayed" }, done: false })}\n${JSON.stringify({
+			done: true,
+			done_reason: "stop",
+			prompt_eval_count: 5,
+			eval_count: 2,
+		})}\n`,
+		{ status: 200 },
+	);
+}
+
 async function expectFirstEventTimeout(
 	run: (streamFirstEventTimeoutMs: number) => Promise<{ stopReason: string; errorMessage?: string }>,
 	expectedMessage: string,
@@ -344,6 +368,34 @@ describe("OpenAI-family first-event timeouts", () => {
 			expect(result.stopReason).toBe("stop");
 			expect(getFirstTextContent(result)).toMatchObject({ type: "text", text: "Hello delayed" });
 			expect(timeoutHeaders).toContain("1");
+		} finally {
+			if (previousOpenAIIdleTimeout === undefined) {
+				delete Bun.env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS;
+			} else {
+				Bun.env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS = previousOpenAIIdleTimeout;
+			}
+			if (previousGenericFirstEventTimeout === undefined) {
+				delete Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS;
+			} else {
+				Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS = previousGenericFirstEventTimeout;
+			}
+		}
+	});
+
+	it("lets PI_OPENAI_STREAM_IDLE_TIMEOUT_MS widen native Ollama first-event request setup", async () => {
+		const previousOpenAIIdleTimeout = Bun.env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS;
+		const previousGenericFirstEventTimeout = Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS;
+		Bun.env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS = "1500";
+		Bun.env.PI_STREAM_FIRST_EVENT_TIMEOUT_MS = "20";
+		global.fetch = createDelayedFetch(30, createOllamaChatSuccessResponse);
+
+		try {
+			const result = await streamSimple(ollamaChatModel, baseContext(), {
+				apiKey: "test-key",
+			}).result();
+
+			expect(result.stopReason).toBe("stop");
+			expect(getFirstTextContent(result)).toMatchObject({ type: "text", text: "Hello delayed" });
 		} finally {
 			if (previousOpenAIIdleTimeout === undefined) {
 				delete Bun.env.PI_OPENAI_STREAM_IDLE_TIMEOUT_MS;


### PR DESCRIPTION
## Repro
A delayed native Ollama stream setup failed when `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS=1500` but `PI_STREAM_FIRST_EVENT_TIMEOUT_MS=20`, even though the OpenAI idle alias should keep local backends from timing out before the first event. Repro command: `bun .wt/repro-openai-idle-timeout.ts` returned `stopReason: "error"` with `Provider stream timed out while waiting for the first event` before the fix.

## Cause
`packages/ai/src/providers/register-builtins.ts:forwardStream` used the generic `getStreamIdleTimeoutMs()` / `getStreamFirstEventTimeoutMs()` pair for lazy providers that do not own their transport watchdogs. Native Ollama streams therefore accepted `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS` as an idle alias but still let a lower `PI_STREAM_FIRST_EVENT_TIMEOUT_MS` undercut the first-event wait before the local server returned headers/output.

## Fix
- Added an OpenAI-idle-floored lazy-stream limit mode in `register-builtins.ts`.
- Routed native `streamOllama` through `getOpenAIStreamIdleTimeoutMs()` and `getOpenAIStreamFirstEventTimeoutMs()` while leaving provider-owned OpenAI/Azure/Codex timeouts and generic lazy providers unchanged.
- Added regression coverage for delayed native Ollama request setup with `PI_OPENAI_STREAM_IDLE_TIMEOUT_MS > PI_STREAM_FIRST_EVENT_TIMEOUT_MS`.

## Verification
`bun test packages/ai/test/openai-first-event-timeout.test.ts packages/ai/test/register-builtins.test.ts packages/ai/test/stream-timeout-defaults.test.ts` passed with 42 tests. `bun --cwd=packages/ai run check` passed. Fixes #1952