### PR TITLE
fix(coding-agent): rendered extension sendMessage(display:true) once during session_start

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 - Fixed chat transcript updates after submitting input so frozen scrollback is only thawed when native scrollback replay succeeds, preventing misplaced or duplicated rows when the viewport is not at the tail
 - Fixed `read` of `.zip` archives to list the central directory without inflating every member, so large or corrupt zip payloads no longer freeze directory reads; member contents are inflated only when a specific entry is read.
+- Fixed `pi.sendMessage({ display: true })` rendering the custom message twice when fired from a `session_start` extension handler (or any other non-streaming dispatch before the initial transcript render). `ExtensionUiController.#applyCustomMessageDisplay` rebuilt the chat from the freshly-persisted session entry, and `main.ts`'s subsequent `renderInitialMessages(undefined, { preserveExistingChat: true })` then both re-rendered from session entries AND re-appended the preserved chat children — duplicating the message. The rebuild now waits until `renderInitialMessages` has completed at least once (tracked via `InteractiveModeContext.initialChatRendered`); after that, post-init extension sends still rebuild as before so messages from `tool_result` / `agent_end` / etc. surface immediately ([#1955](https://github.com/can1357/oh-my-pi/issues/1955)).
 
 ## [15.9.3] - 2026-06-05
 

--- a/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/extension-ui-controller.ts
@@ -890,11 +890,19 @@ export class ExtensionUiController {
 	};
 
 	#applyCustomMessageDisplay(wasStreaming: boolean, shouldDisplay: boolean | undefined): void {
-		// For non-streaming cases with display=true, update UI
-		// (streaming cases update via message_end event)
-		if (!this.ctx.isBackgrounded && !wasStreaming && shouldDisplay) {
-			this.ctx.rebuildChatFromMessages();
-		}
+		// For non-streaming cases with display=true, refresh the chat from session.
+		// (Streaming cases update via message_end event.)
+		if (this.ctx.isBackgrounded || wasStreaming || !shouldDisplay) return;
+		// Defer to the initial transcript render: when an extension's
+		// `session_start` handler fires `sendMessage({ display: true })`, this
+		// runs *before* `mode.renderInitialMessages(undefined, { preserveExistingChat: true })`.
+		// Rebuilding now plants a session-derived component into the chat that
+		// `renderInitialMessages` then both re-renders from session entries AND
+		// re-appends via `preserveExistingChat`, duplicating the message (#1955).
+		// After the initial render, the rebuild is the only thing surfacing the
+		// new entry, so it MUST run.
+		if (!this.ctx.initialChatRendered) return;
+		this.ctx.rebuildChatFromMessages();
 	}
 
 	#createHookDialogState(

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -271,6 +271,7 @@ export class InteractiveMode implements InteractiveModeContext {
 	statusLine: StatusLineComponent;
 
 	isInitialized = false;
+	initialChatRendered = false;
 	isBackgrounded = false;
 	isBashMode = false;
 	toolOutputExpanded = false;

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -93,6 +93,17 @@ export interface InteractiveModeContext {
 
 	// State
 	isInitialized: boolean;
+	/**
+	 * `true` once `renderInitialMessages` has rendered the session transcript
+	 * into `chatContainer` at least once.
+	 *
+	 * Extension chat-rebuilds (`ExtensionUiController.#applyCustomMessageDisplay`)
+	 * are gated on this: rebuilding before the initial render would plant a
+	 * session-derived component into the chat that `renderInitialMessages` then
+	 * both re-renders from session entries AND re-appends via
+	 * `preserveExistingChat`, duplicating the message (issue #1955).
+	 */
+	initialChatRendered: boolean;
 	isBackgrounded: boolean;
 	isBashMode: boolean;
 	toolOutputExpanded: boolean;

--- a/packages/coding-agent/src/modes/utils/ui-helpers.ts
+++ b/packages/coding-agent/src/modes/utils/ui-helpers.ts
@@ -472,6 +472,12 @@ export class UiHelpers {
 		// This path is used to rebuild the visible chat transcript (e.g. after custom/debug UI).
 		// Clear existing rendered chat first to avoid duplicating the full session in the container.
 		const preservedChatChildren = options.preserveExistingChat ? this.ctx.chatContainer.children : undefined;
+		// Mark the chat as rendered BEFORE clearing — gates extension-driven
+		// rebuilds (`ExtensionUiController.#applyCustomMessageDisplay`) so the
+		// next `sendMessage({display:true})` outside startup goes through its
+		// rebuild path. Must come before `chatContainer.clear()` so concurrent
+		// renders coming in mid-rebuild see a consistent post-render state.
+		this.ctx.initialChatRendered = true;
 		this.ctx.chatContainer.clear();
 		this.ctx.pendingMessagesContainer.clear();
 		this.ctx.pendingBashComponents = [];

--- a/packages/coding-agent/test/repro-issue-1955-sendmessage-double-render.test.ts
+++ b/packages/coding-agent/test/repro-issue-1955-sendmessage-double-render.test.ts
@@ -197,7 +197,7 @@ describe("issue #1955 — sendMessage(display:true) during session_start", () =>
 
 		// Drain the `.then(applyCustomMessageDisplay)` microtask chain queued by
 		// `actions.sendMessage` before the host's renderInitialMessages fires.
-		await new Promise<void>(resolve => setTimeout(resolve, 0));
+		await Bun.sleep(0);
 
 		// Mirror main.ts: after `mode.init()` returns, the host renders the
 		// initial transcript while preserving anything previously added to chat.
@@ -227,7 +227,7 @@ describe("issue #1955 — sendMessage(display:true) during session_start", () =>
 			},
 			{ deliverAs: "nextTurn" },
 		);
-		await new Promise<void>(resolve => setTimeout(resolve, 0));
+		await Bun.sleep(0);
 
 		const rendered = Bun.stripANSI(harness.ctx.chatContainer.render(120).join("\n"));
 		expect(countOccurrences(rendered, marker)).toBe(1);

--- a/packages/coding-agent/test/repro-issue-1955-sendmessage-double-render.test.ts
+++ b/packages/coding-agent/test/repro-issue-1955-sendmessage-double-render.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, beforeAll, describe, expect, test, vi } from "bun:test";
+import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
+import type { ImageContent, TextContent } from "@oh-my-pi/pi-ai";
+import type {
+	ExtensionActions,
+	ExtensionCommandContextActions,
+	ExtensionContextActions,
+	ExtensionUIContext,
+} from "@oh-my-pi/pi-coding-agent/extensibility/extensions";
+import { ExtensionUiController } from "@oh-my-pi/pi-coding-agent/modes/controllers/extension-ui-controller";
+import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import { UiHelpers } from "@oh-my-pi/pi-coding-agent/modes/utils/ui-helpers";
+import {
+	buildSessionContext,
+	type CustomMessageEntry,
+	type SessionContext,
+	type SessionEntry,
+} from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { Container } from "@oh-my-pi/pi-tui";
+
+/**
+ * Issue #1955: `sendMessage` with `display: true` renders twice during
+ * `session_start`.
+ *
+ * Repro:
+ * - Extension calls `pi.sendMessage({ display: true, ... })` from a
+ *   `session_start` handler while the session is idle.
+ * - `ExtensionUiController.#applyCustomMessageDisplay` rebuilds the chat from
+ *   the freshly-persisted session entry, so the chat container ends up holding
+ *   one custom-message component.
+ * - `main.ts` then calls `mode.renderInitialMessages(undefined, { preserveExistingChat: true })`,
+ *   which snapshots the chat children, clears, re-renders from session entries
+ *   (adding the same custom message again), and re-appends the snapshot —
+ *   leaving two identical custom-message components in the chat.
+ */
+beforeAll(async () => {
+	await initTheme();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function makeCustomEntry(id: number, text: string, parentId: string | null): CustomMessageEntry {
+	return {
+		type: "custom_message",
+		customType: "issue-1955-probe",
+		content: [{ type: "text", text }],
+		display: true,
+		attribution: "agent",
+		id: `entry-${id}`,
+		parentId,
+		timestamp: new Date(2026, 5, 5, 0, 0, id).toISOString(),
+	};
+}
+
+interface Harness {
+	ctx: InteractiveModeContext;
+	helpers: UiHelpers;
+	entries: SessionEntry[];
+	controller: ExtensionUiController;
+	getActions: () => ExtensionActions | undefined;
+}
+
+function createHarness(): Harness {
+	const entries: SessionEntry[] = [];
+	let capturedActions: ExtensionActions | undefined;
+	let helpers!: UiHelpers;
+	const fakeRunner = {
+		initialize: (
+			a: ExtensionActions,
+			_ca: ExtensionContextActions,
+			_cca: ExtensionCommandContextActions,
+			_ui: ExtensionUIContext,
+		) => {
+			capturedActions = a;
+		},
+		onError: () => {},
+		emit: async () => undefined,
+		getMessageRenderer: () => undefined,
+		getAssistantThinkingRenderers: () => undefined,
+	};
+
+	const sessionMock = {
+		isStreaming: false,
+		extensionRunner: fakeRunner,
+		/**
+		 * Mirror `AgentSession.sendCustomMessage` non-streaming
+		 * `deliverAs: "nextTurn"` / no-trigger path: persist the message as a
+		 * `custom_message` session entry. (The real implementation also calls
+		 * `agent.appendMessage`, but that path is silent — no event, no render —
+		 * so the bug surface is unaffected by omitting it here.)
+		 */
+		sendCustomMessage: async (msg: {
+			customType: string;
+			content: string | (TextContent | ImageContent)[];
+			display?: boolean;
+			details?: unknown;
+			attribution?: string;
+		}) => {
+			const parent = entries.length === 0 ? null : entries[entries.length - 1].id;
+			entries.push(makeCustomEntry(entries.length + 1, extractText(msg.content), parent));
+		},
+	};
+
+	const ctx = {
+		chatContainer: new Container(),
+		pendingMessagesContainer: new Container(),
+		pendingBashComponents: [],
+		pendingPythonComponents: [],
+		pendingTools: new Map(),
+		ui: { requestRender: vi.fn() },
+		isBackgrounded: false,
+		initialChatRendered: false,
+		statusLine: { invalidate: vi.fn() },
+		updateEditorBorderColor: vi.fn(),
+		settings: { get: () => false },
+		session: sessionMock,
+		sessionManager: {
+			buildSessionContext: () => buildSessionContext(entries),
+			getEntries: () => entries,
+		},
+		setToolUIContext: vi.fn(),
+		setEditorComponent: vi.fn(),
+		setWorkingMessage: vi.fn(),
+		setToolsExpanded: vi.fn(),
+		toolOutputExpanded: false,
+		hideThinkingBlock: false,
+		showError: vi.fn(),
+		editor: {
+			setText: vi.fn(),
+			handleInput: vi.fn(),
+			getText: () => "",
+		},
+		renderSessionContext: (c: SessionContext, o?: { updateFooter?: boolean; populateHistory?: boolean }) =>
+			helpers.renderSessionContext(c, o),
+		addMessageToChat: (m: AgentMessage) => helpers.addMessageToChat(m),
+		rebuildChatFromMessages: () => {
+			ctx.chatContainer.clear();
+			helpers.renderSessionContext(buildSessionContext(entries));
+		},
+	} as unknown as InteractiveModeContext;
+	helpers = new UiHelpers(ctx);
+
+	const controller = new ExtensionUiController(ctx);
+
+	return {
+		ctx,
+		helpers,
+		entries,
+		controller,
+		getActions: () => capturedActions,
+	};
+}
+
+function extractText(content: string | (TextContent | ImageContent)[]): string {
+	if (typeof content === "string") return content;
+	for (const part of content) {
+		if (part.type === "text") return part.text;
+	}
+	return "";
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+	if (needle.length === 0) return 0;
+	let count = 0;
+	let idx = 0;
+	while (true) {
+		const found = haystack.indexOf(needle, idx);
+		if (found === -1) return count;
+		count++;
+		idx = found + needle.length;
+	}
+}
+
+describe("issue #1955 — sendMessage(display:true) during session_start", () => {
+	test("renders the custom message exactly once after the initial transcript render", async () => {
+		const marker = "issue-1955-marker-text";
+		const harness = createHarness();
+		await harness.controller.initHooksAndCustomTools();
+
+		const actions = harness.getActions();
+		expect(actions).toBeDefined();
+
+		// Simulate the extension's session_start handler firing
+		// `pi.sendMessage({ display: true, ... })`.
+		actions!.sendMessage(
+			{
+				customType: "issue-1955-probe",
+				content: [{ type: "text", text: marker }],
+				display: true,
+				attribution: "agent",
+			},
+			{ deliverAs: "nextTurn" },
+		);
+
+		// Drain the `.then(applyCustomMessageDisplay)` microtask chain queued by
+		// `actions.sendMessage` before the host's renderInitialMessages fires.
+		await new Promise<void>(resolve => setTimeout(resolve, 0));
+
+		// Mirror main.ts: after `mode.init()` returns, the host renders the
+		// initial transcript while preserving anything previously added to chat.
+		harness.helpers.renderInitialMessages(undefined, { preserveExistingChat: true });
+
+		const rendered = Bun.stripANSI(harness.ctx.chatContainer.render(120).join("\n"));
+		const occurrences = countOccurrences(rendered, marker);
+		expect(occurrences).toBe(1);
+	});
+
+	test("after the initial render, sendMessage(display:true) still renders the message", async () => {
+		const marker = "issue-1955-late-marker";
+		const harness = createHarness();
+		await harness.controller.initHooksAndCustomTools();
+
+		// Establish the initial render — the host's `renderInitialMessages`
+		// flips `initialChatRendered` so subsequent extension sends can rebuild.
+		harness.helpers.renderInitialMessages(undefined, { preserveExistingChat: true });
+
+		const actions = harness.getActions();
+		actions!.sendMessage(
+			{
+				customType: "issue-1955-probe",
+				content: [{ type: "text", text: marker }],
+				display: true,
+				attribution: "agent",
+			},
+			{ deliverAs: "nextTurn" },
+		);
+		await new Promise<void>(resolve => setTimeout(resolve, 0));
+
+		const rendered = Bun.stripANSI(harness.ctx.chatContainer.render(120).join("\n"));
+		expect(countOccurrences(rendered, marker)).toBe(1);
+	});
+});


### PR DESCRIPTION
## Repro

When an extension calls `pi.sendMessage({ display: true, … })` from a `session_start` handler (or any other non-streaming, pre-initial-render path), the custom message renders **twice** in the TUI. Steps from #1955:

```ts
// extensions/double-render/index.ts
export default function (pi: ExtensionAPI): void {
    pi.on("session_start", (_event, _ctx) => {
        pi.sendMessage(
            {
                customType: "test",
                content: [{ type: "text", text: "## This appears twice" }],
                display: true,
            },
            { deliverAs: "nextTurn" },
        );
    });
}
```

Repro test: `bun test packages/coding-agent/test/repro-issue-1955-sendmessage-double-render.test.ts` — fails on `main` with `Received: 2`, passes on this branch.

## Cause

Not the `agent.appendMessage` + `appendCustomMessageEntry` pair the original ticket suspected — `agent.appendMessage` is silent (no event, no render). The duplication is the interaction between two render paths:

1. `ExtensionUiController.#applyCustomMessageDisplay` (`packages/coding-agent/src/modes/controllers/extension-ui-controller.ts:892`) runs on the `.then` of every `actions.sendMessage` non-streaming dispatch and calls `ctx.rebuildChatFromMessages()`, planting one custom-message component built from the freshly-persisted session entry.
2. After `mode.init()` returns, `main.ts:288` calls `mode.renderInitialMessages(undefined, { preserveExistingChat: true })`. `UiHelpers.renderInitialMessages` (`packages/coding-agent/src/modes/utils/ui-helpers.ts:471-507`) snapshots the chat children, clears the container, re-renders from session entries (adds a second copy of the same custom message), then re-appends the snapshot — two identical components.

`preserveExistingChat: true` was added in commit `a916ae5` to keep startup `showWarning`/`showStatus`/`showError` chips that don't live in session entries (#1316). It's correct for those — the bug is that `applyCustomMessageDisplay` plants a session-derived component into the snapshot before the initial render gets a chance to run.

## Fix

- Added `InteractiveModeContext.initialChatRendered` (default `false`).
- `UiHelpers.renderInitialMessages` flips it to `true` at the top of each run.
- `ExtensionUiController.#applyCustomMessageDisplay` now returns early when the flag is still `false`. Before the initial render: skip — `renderInitialMessages` will pick up the session entry once. After it: rebuild as today, so post-init extension sends (`tool_result`, `agent_end`, etc.) still surface immediately.
- Refactored `#applyCustomMessageDisplay` to early-return guards instead of nested condition for readability.
- Added regression test `packages/coding-agent/test/repro-issue-1955-sendmessage-double-render.test.ts` covering both the bug case (`session_start` dispatch → exactly one render after initial transcript) and the still-must-work case (post-init dispatch → exactly one render via rebuild).
- CHANGELOG entry under `## [Unreleased]` / `### Fixed`.

Existing `preserves startup notifications while rendering the initial transcript` test (#1316 regression) still passes — `showWarning` still preserves correctly because it never sets `initialChatRendered` and never feeds session entries.

## Verification

- `bun test packages/coding-agent/test/repro-issue-1955-sendmessage-double-render.test.ts` — 2/2 pass.
- `bun test packages/coding-agent/test/interactive-mode-status.test.ts packages/coding-agent/test/hook-editor.test.ts packages/coding-agent/test/repro-issue-1020-ctx-shutdown.test.ts packages/coding-agent/test/extension-flag-initial-message.test.ts packages/coding-agent/test/extensions-discovery.test.ts packages/coding-agent/test/extensions-runner.test.ts` — 105/105 pass.
- `bun test packages/coding-agent/test/agent-session-concurrent.test.ts packages/coding-agent/test/agent-session-message-pipeline.test.ts packages/coding-agent/test/agent-session-handoff.test.ts packages/coding-agent/test/agent-session-openai-responses-replay.test.ts` — 58/58 pass.
- `bun check` clean on this branch.

Fixes #1955