### PR TITLE
feat(skills): skill description redaction with BM25 search deferral

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# AI assistant session artifacts (Claude Code memory, plans, workflow transcripts)
+.claude/
+
 # Dependencies
 node_modules/
 .npm/

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### Added
 
 - Added frequency-based skill-description redaction behind `skills.redactDescriptions` (default `false`).
-  When enabled, infrequently-used skills are hidden from the `<skills>` system-prompt block and surfaced
-  via `search_tool_bm25`; a deferred count pointer in `<skills>` directs the model to search. Frequent
+  When enabled, infrequently-used skills are still listed in the `<skills>` system-prompt block but
+  WITHOUT their descriptions, and those descriptions are surfaced via `search_tool_bm25`; a deferred
+  count pointer in `<skills>` directs the model to search. Frequent
   skills are selected as: pinned glob patterns (`skills.alwaysInclude`), skills used within the last 7 days,
   and the top-N by exponentially-decayed usage score (half-life 21 days, configurable via
   `skills.frequentSkillCount`, default 20). The frequent set is cached daily (invalidated on catalog or

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added frequency-based skill-description redaction behind `skills.redactDescriptions` (default `false`).
+  When enabled, infrequently-used skills are hidden from the `<skills>` system-prompt block and surfaced
+  via `search_tool_bm25`; a deferred count pointer in `<skills>` directs the model to search. Frequent
+  skills are selected as: pinned glob patterns (`skills.alwaysInclude`), skills used within the last 7 days,
+  and the top-N by exponentially-decayed usage score (half-life 21 days, configurable via
+  `skills.frequentSkillCount`, default 20). The frequent set is cached daily (invalidated on catalog or
+  settings change) and frozen at SDK-init for prompt-cache stability. New settings:
+  `skills.redactDescriptions`, `skills.frequentSkillCount`, `skills.alwaysInclude`.
+
 ## [15.9.5] - 2026-06-05
 ### Added
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2852,6 +2852,39 @@ export const SETTINGS_SCHEMA = {
 
 	"skills.includeSkills": { type: "array", default: [] as string[] },
 
+	"skills.redactDescriptions": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "tasks",
+			label: "Redact Skill Descriptions",
+			description:
+				"Hide infrequently-used skill descriptions from the system prompt. Frequent skills (top-N by usage) remain visible; others are discoverable via search_tool_bm25.",
+		},
+	},
+
+	"skills.frequentSkillCount": {
+		type: "number",
+		default: 20,
+		ui: {
+			tab: "tasks",
+			label: "Frequent Skill Count",
+			description:
+				"Number of most-used skills to keep visible in the system prompt when redactDescriptions is enabled.",
+		},
+	},
+
+	"skills.alwaysInclude": {
+		type: "array",
+		default: [] as string[],
+		ui: {
+			tab: "tasks",
+			label: "Always Include Skills",
+			description:
+				"Glob patterns for skills always shown in the system prompt, even when redactDescriptions is enabled.",
+		},
+	},
+
 	// Commands
 	"commands.enableClaudeUser": {
 		type: "boolean",
@@ -3349,6 +3382,9 @@ export interface SkillsSettings {
 	ignoredSkills?: string[];
 	includeSkills?: string[];
 	disabledExtensions?: string[];
+	redactDescriptions?: boolean;
+	frequentSkillCount?: number;
+	alwaysInclude?: string[];
 }
 
 export interface CommitSettings {

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2870,7 +2870,7 @@ export const SETTINGS_SCHEMA = {
 			tab: "tasks",
 			label: "Frequent Skill Count",
 			description:
-				"Number of most-used skills to keep visible in the system prompt when redactDescriptions is enabled.",
+				"Number of most-used skills to keep descriptions for in the system prompt when redactDescriptions is enabled.",
 		},
 	},
 
@@ -2881,7 +2881,7 @@ export const SETTINGS_SCHEMA = {
 			tab: "tasks",
 			label: "Always Include Skills",
 			description:
-				"Glob patterns for skills always shown in the system prompt, even when redactDescriptions is enabled.",
+				"Glob patterns for skills always shown with descriptions in the system prompt, even when redactDescriptions is enabled.",
 		},
 	},
 

--- a/packages/coding-agent/src/extensibility/skill-frequency.ts
+++ b/packages/coding-agent/src/extensibility/skill-frequency.ts
@@ -39,20 +39,21 @@ export function computeFrequentSkillNames({
 	nowSec: number;
 }): Set<string> {
 	const nonHiddenSkills = skills.filter(s => !s.hide);
+	const loadedNames = new Set(nonHiddenSkills.map(s => s.name));
 
-	// Warmup gate: not enough data → render everything
-	const totalInvocations = usage.reduce((sum, u) => sum + u.totalCount, 0);
+	// Warmup gate: not enough data from loaded skills → render everything
+	const totalInvocations = usage.filter(u => loadedNames.has(u.name)).reduce((sum, u) => sum + u.totalCount, 0);
 	if (totalInvocations < SKILL_FREQUENCY_WARMUP_THRESHOLD) {
-		return new Set(nonHiddenSkills.map(s => s.name));
+		return new Set(loadedNames);
 	}
 
-	const loadedNames = new Set(nonHiddenSkills.map(s => s.name));
 	const frequent = new Set<string>();
 
-	// Pinned: alwaysInclude glob patterns
+	// Pinned: alwaysInclude glob patterns — pre-compile outside the per-skill loop
 	if (alwaysInclude.length > 0) {
+		const globs = alwaysInclude.map(pattern => new Bun.Glob(pattern));
 		for (const skill of nonHiddenSkills) {
-			if (alwaysInclude.some(pattern => new Bun.Glob(pattern).match(skill.name))) {
+			if (globs.some(glob => glob.match(skill.name))) {
 				frequent.add(skill.name);
 			}
 		}
@@ -98,7 +99,7 @@ export function resolveFrequentSkillNames(
 		.sort();
 	const settingsHash = JSON.stringify({
 		frequentCount: settings.frequentCount,
-		alwaysInclude: settings.alwaysInclude,
+		alwaysInclude: [...settings.alwaysInclude].sort(),
 		skillNames: nonHiddenNames,
 	});
 
@@ -108,9 +109,9 @@ export function resolveFrequentSkillNames(
 			const raw = storage.getCache(FREQUENT_SKILL_CACHE_KEY);
 			const cached = raw ? (JSON.parse(raw) as FrequentSkillsPayload) : null;
 			if (cached && cached.settingsHash === settingsHash) {
-				// Intersect with currently-loaded skills (handles uninstalls)
-				const loadedSet = new Set(nonHiddenNames);
-				return new Set(cached.names.filter(n => loadedSet.has(n)));
+				// Hash encodes catalog identity (skillNames), so a match guarantees
+				// cached.names is a subset of the current non-hidden names — no intersection needed.
+				return new Set(cached.names);
 			}
 		} catch {
 			// cache miss / parse error → recompute
@@ -133,7 +134,7 @@ export function resolveFrequentSkillNames(
 				settingsHash,
 				names: Array.from(frequent),
 			};
-			storage.setCache(FREQUENT_SKILL_CACHE_KEY, JSON.stringify(payload), Math.floor(nowSec) + 86_400);
+			storage.setCache(FREQUENT_SKILL_CACHE_KEY, JSON.stringify(payload), nowSec + 86_400);
 		} catch {
 			// cache write failure is non-fatal
 		}

--- a/packages/coding-agent/src/extensibility/skill-frequency.ts
+++ b/packages/coding-agent/src/extensibility/skill-frequency.ts
@@ -34,6 +34,12 @@ export function computeFrequentSkillNames({
 }: {
 	skills: Pick<Skill, "name" | "hide">[];
 	usage: UsageEntry[];
+	/**
+	 * Soft upper bound on the returned set size.
+	 * Applied only to the top-N pass; skills added via `alwaysInclude` globs or
+	 * the recent-7d override are included unconditionally and may push the total
+	 * above this number.
+	 */
 	frequentCount: number;
 	alwaysInclude: string[];
 	nowSec: number;
@@ -86,6 +92,13 @@ export function computeFrequentSkillNames({
  * Resolves the frequent skill set with a daily SQLite cache.
  * Cache is authoritative on hit; recomputed on hash mismatch or miss.
  * Null storage: compute without caching.
+ *
+ * **Intentional staleness:** the cache TTL is 24 hours. A skill first used
+ * today stays out of the frequent set until cache expiry or recompute — up to
+ * 24 hours, which may span multiple sessions. The skill is reachable via
+ * `search_tool_bm25` during this window. Within a single session the set is
+ * frozen at SDK-init, so the `<skills>` block stays byte-identical across all
+ * prompt rebuilds and preserves Anthropic's prompt-cache prefix.
  */
 export function resolveFrequentSkillNames(
 	storage: AgentStorage | null,

--- a/packages/coding-agent/src/extensibility/skill-frequency.ts
+++ b/packages/coding-agent/src/extensibility/skill-frequency.ts
@@ -1,0 +1,143 @@
+import type { AgentStorage } from "../session/agent-storage";
+import type { Skill } from "./skills";
+
+/** Minimum total invocations before switching from full-list to top-N mode. */
+const SKILL_FREQUENCY_WARMUP_THRESHOLD = 10;
+/** Recent-use window for inclusion in the frequent set. */
+const SKILL_FREQUENCY_RECENT_DAYS = 7;
+const SKILL_FREQUENCY_RECENT_SECS = SKILL_FREQUENCY_RECENT_DAYS * 86_400;
+/** SQLite cache key for the daily-computed frequent skill names. */
+const FREQUENT_SKILL_CACHE_KEY = "skills.frequentSet";
+
+interface FrequentSkillsPayload {
+	settingsHash: string;
+	names: string[];
+}
+
+interface UsageEntry {
+	name: string;
+	score: number;
+	lastUsedAt: number;
+	totalCount: number;
+}
+
+/**
+ * Pure computation of the frequent skill set.
+ * `nowSec` is injected so tests can control time.
+ */
+export function computeFrequentSkillNames({
+	skills,
+	usage,
+	frequentCount,
+	alwaysInclude,
+	nowSec,
+}: {
+	skills: Pick<Skill, "name" | "hide">[];
+	usage: UsageEntry[];
+	frequentCount: number;
+	alwaysInclude: string[];
+	nowSec: number;
+}): Set<string> {
+	const nonHiddenSkills = skills.filter(s => !s.hide);
+
+	// Warmup gate: not enough data → render everything
+	const totalInvocations = usage.reduce((sum, u) => sum + u.totalCount, 0);
+	if (totalInvocations < SKILL_FREQUENCY_WARMUP_THRESHOLD) {
+		return new Set(nonHiddenSkills.map(s => s.name));
+	}
+
+	const loadedNames = new Set(nonHiddenSkills.map(s => s.name));
+	const frequent = new Set<string>();
+
+	// Pinned: alwaysInclude glob patterns
+	if (alwaysInclude.length > 0) {
+		for (const skill of nonHiddenSkills) {
+			if (alwaysInclude.some(pattern => new Bun.Glob(pattern).match(skill.name))) {
+				frequent.add(skill.name);
+			}
+		}
+	}
+
+	// Recent: used within the last 7 days
+	const recentCutoff = nowSec - SKILL_FREQUENCY_RECENT_SECS;
+	for (const entry of usage) {
+		if (entry.lastUsedAt >= recentCutoff && loadedNames.has(entry.name)) {
+			frequent.add(entry.name);
+		}
+	}
+
+	// Top-N by decayed score, alphabetical tiebreak
+	const usageByName = new Map(usage.map(u => [u.name, u]));
+	const scored = nonHiddenSkills
+		.filter(s => !frequent.has(s.name))
+		.map(s => ({ name: s.name, score: usageByName.get(s.name)?.score ?? 0 }))
+		.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name))
+		.slice(0, Math.max(0, frequentCount - frequent.size));
+
+	for (const { name } of scored) {
+		frequent.add(name);
+	}
+
+	return frequent;
+}
+
+/**
+ * Resolves the frequent skill set with a daily SQLite cache.
+ * Cache is authoritative on hit; recomputed on hash mismatch or miss.
+ * Null storage: compute without caching.
+ */
+export function resolveFrequentSkillNames(
+	storage: AgentStorage | null,
+	skills: Pick<Skill, "name" | "hide">[],
+	settings: { frequentCount: number; alwaysInclude: string[] },
+	nowSec: number,
+): Set<string> {
+	const nonHiddenNames = skills
+		.filter(s => !s.hide)
+		.map(s => s.name)
+		.sort();
+	const settingsHash = JSON.stringify({
+		frequentCount: settings.frequentCount,
+		alwaysInclude: settings.alwaysInclude,
+		skillNames: nonHiddenNames,
+	});
+
+	// Try cache hit
+	if (storage) {
+		try {
+			const raw = storage.getCache(FREQUENT_SKILL_CACHE_KEY);
+			const cached = raw ? (JSON.parse(raw) as FrequentSkillsPayload) : null;
+			if (cached && cached.settingsHash === settingsHash) {
+				// Intersect with currently-loaded skills (handles uninstalls)
+				const loadedSet = new Set(nonHiddenNames);
+				return new Set(cached.names.filter(n => loadedSet.has(n)));
+			}
+		} catch {
+			// cache miss / parse error → recompute
+		}
+	}
+
+	// Recompute
+	const usage = storage ? storage.getSkillUsage() : [];
+	const frequent = computeFrequentSkillNames({
+		skills,
+		usage,
+		frequentCount: settings.frequentCount,
+		alwaysInclude: settings.alwaysInclude,
+		nowSec,
+	});
+
+	if (storage) {
+		try {
+			const payload: FrequentSkillsPayload = {
+				settingsHash,
+				names: Array.from(frequent),
+			};
+			storage.setCache(FREQUENT_SKILL_CACHE_KEY, JSON.stringify(payload), Math.floor(nowSec) + 86_400);
+		} catch {
+			// cache write failure is non-fatal
+		}
+	}
+
+	return frequent;
+}

--- a/packages/coding-agent/src/extensibility/skills.ts
+++ b/packages/coding-agent/src/extensibility/skills.ts
@@ -39,12 +39,22 @@ let activeSkills: readonly Skill[] = [];
 /**
  * Process-global snapshot of skills the active session loaded.
  * Read by internal URL protocol handlers (skill://).
+ *
+ * KNOWN HAZARD (ARCH-03): two concurrent top-level sessions with different
+ * skill catalogs will race on this global — the second setActiveSkills()
+ * overwrites the first's snapshot, causing session A's frozen skill://
+ * deferredSkillEntries to resolve against session B's catalog. Current
+ * usage is single top-level session so the invariant holds in practice.
+ * Fix: thread a per-session skill catalog into SkillProtocolHandler.resolve()
+ * instead of reading this global.
  */
 export function getActiveSkills(): readonly Skill[] {
 	return activeSkills;
 }
 
-/** Replace the active skill snapshot. Called once per top-level session. */
+/** Replace the active skill snapshot. Called once per top-level session.
+ *
+ * NOTE: see getActiveSkills() comment on the concurrent-session hazard. */
 export function setActiveSkills(value: readonly Skill[]): void {
 	activeSkills = value;
 }

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -716,8 +716,6 @@ export class AcpAgent implements Agent {
 		if (!skill) {
 			return false;
 		}
-		// Track explicit skill invocations via slash command
-		record.session.settings.getStorage()?.recordSkillUsage(skillName);
 		const built = await buildSkillPromptMessage(skill, args);
 		await record.session.promptCustomMessage({
 			customType: SKILL_PROMPT_MESSAGE_TYPE,
@@ -726,6 +724,16 @@ export class AcpAgent implements Agent {
 			details: built.details,
 			attribution: "user",
 		});
+		// Track only after successful dispatch; failure to record usage is not fatal
+		try {
+			record.session.settings.getStorage()?.recordSkillUsage(skillName);
+		} catch (storageErr) {
+			// Log but don't fail the skill invocation if recording usage fails
+			logger.warn("Failed to record skill usage", {
+				skillName,
+				error: storageErr instanceof Error ? storageErr.message : String(storageErr),
+			});
+		}
 		return true;
 	}
 

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -716,6 +716,8 @@ export class AcpAgent implements Agent {
 		if (!skill) {
 			return false;
 		}
+		// Track explicit skill invocations via slash command
+		record.session.settings.getStorage()?.recordSkillUsage(skillName);
 		const built = await buildSkillPromptMessage(skill, args);
 		await record.session.promptCustomMessage({
 			customType: SKILL_PROMPT_MESSAGE_TYPE,

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -509,7 +509,6 @@ export class InputController {
 		if (!skillPath) return false;
 		// Track explicit skill invocations via slash command
 		const skillName = commandName.slice("skill:".length);
-		this.ctx.settings.getStorage()?.recordSkillUsage(skillName);
 		this.ctx.editor.addToHistory(text);
 		this.ctx.editor.setText("");
 		try {
@@ -549,6 +548,16 @@ export class InputController {
 			if (this.ctx.session.isStreaming) {
 				this.ctx.updatePendingMessagesDisplay();
 				this.ctx.ui.requestRender();
+			}
+			// Track only after successful dispatch; failure to record usage is not fatal
+			try {
+				this.ctx.settings.getStorage()?.recordSkillUsage(skillName);
+			} catch (storageErr) {
+				// Log but don't fail the skill invocation if recording usage fails
+				logger.warn("Failed to record skill usage", {
+					skillName,
+					error: storageErr instanceof Error ? storageErr.message : String(storageErr),
+				});
 			}
 		} catch (err) {
 			this.ctx.showError(`Failed to load skill: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -507,6 +507,9 @@ export class InputController {
 		const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
 		const skillPath = this.ctx.skillCommands?.get(commandName);
 		if (!skillPath) return false;
+		// Track explicit skill invocations via slash command
+		const skillName = commandName.slice("skill:".length);
+		this.ctx.settings.getStorage()?.recordSkillUsage(skillName);
 		this.ctx.editor.addToHistory(text);
 		this.ctx.editor.setText("");
 		try {
@@ -517,7 +520,7 @@ export class InputController {
 				metaLines.push(`User: ${args}`);
 			}
 			const message = `${body}\n\n---\n\n${metaLines.join("\n")}`;
-			const skillName = commandName.slice("skill:".length);
+
 			const details: SkillPromptDetails = {
 				name: skillName || commandName,
 				path: skillPath,

--- a/packages/coding-agent/src/prompts/system/custom-system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/custom-system-prompt.md
@@ -33,10 +33,17 @@ Skills are specialized knowledge. Scan descriptions for your task domain.
 If a skill applies, you MUST read `skill://<name>` before proceeding.
 <skills>
 {{#list skills join="\n"}}
+{{#if description}}
 <skill name="{{name}}">
 {{description}}
 </skill>
+{{else}}
+<skill name="{{name}}"/>
+{{/if}}
 {{/list}}
+{{#if skillsRedacted}}
+({{deferredSkillCount}} skills above are listed without descriptions — search `search_tool_bm25` to match by capability, then read `skill://<name>` to use one.)
+{{/if}}
 </skills>
 {{/if}}
 {{#if alwaysApplyRules.length}}

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -125,7 +125,7 @@ ENV
 {{#if showSkillsBlock}}
 <skills>
 {{#each skills}}
-- {{name}}: {{description}}
+- {{escapeXml name}}: {{escapeXml description}}
 {{/each}}
 {{#if skillsRedacted}}
 - ({{deferredSkillCount}} more skills not listed — search with `search_tool_bm25`, then read `skill://<name>` to use one.)
@@ -144,7 +144,7 @@ ENV
 {{#if rules.length}}
 <domain-rules>
 {{#each rules}}
-- {{name}} ({{#list globs join=", "}}{{this}}{{/list}}): {{description}}
+- {{escapeXml name}} ({{#list globs join=", "}}{{escapeXml this}}{{/list}}): {{escapeXml description}}
 {{/each}}
 </domain-rules>
 {{/if}}

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -125,10 +125,10 @@ ENV
 {{#if showSkillsBlock}}
 <skills>
 {{#each skills}}
-- {{escapeXml name}}: {{escapeXml description}}
+- {{escapeXml name}}{{#if description}}: {{escapeXml description}}{{/if}}
 {{/each}}
 {{#if skillsRedacted}}
-- ({{deferredSkillCount}} more skills not listed — search with `search_tool_bm25`, then read `skill://<name>` to use one.)
+- ({{deferredSkillCount}} skills above are listed without descriptions — search `search_tool_bm25` to match by capability, then read `skill://<name>` to use one.)
 {{/if}}
 </skills>
 {{/if}}

--- a/packages/coding-agent/src/prompts/system/system-prompt.md
+++ b/packages/coding-agent/src/prompts/system/system-prompt.md
@@ -122,11 +122,14 @@ ENV
 ===================================
 
 # Skills & Rules
-{{#if skills.length}}
+{{#if showSkillsBlock}}
 <skills>
 {{#each skills}}
 - {{name}}: {{description}}
 {{/each}}
+{{#if skillsRedacted}}
+- ({{deferredSkillCount}} more skills not listed — search with `search_tool_bm25`, then read `skill://<name>` to use one.)
+{{/if}}
 </skills>
 {{/if}}
 

--- a/packages/coding-agent/src/prompts/tools/search-tool-bm25.md
+++ b/packages/coding-agent/src/prompts/tools/search-tool-bm25.md
@@ -10,6 +10,9 @@ Discoverable built-in tools: {{#list discoverableBuiltinToolNames join=", "}}{{t
 {{#if discoverableToolCount}}
 Total discoverable tools available: {{discoverableToolCount}}.
 {{/if}}
+{{#if hasDiscoverableSkills}}
+Skills: {{discoverableSkillCount}} skills are also searchable. Skill matches include a `read` field with a `skill://<name>` URL — use the read tool with that URL to load the skill. Skills are not activated like tools.
+{{/if}}
 Input:
 - `query` — required natural-language or keyword query
 - `limit` — optional maximum number of tools to return and activate (default `8`)

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1361,6 +1361,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			activateDiscoveredMCPTools: toolNames => session.activateDiscoveredMCPTools(toolNames),
 			// Generic tool discovery (unified — covers built-in + MCP + extension)
 			isToolDiscoveryEnabled: () => session.isToolDiscoveryEnabled(),
+			isSkillDiscoveryEnabled: () => session.isSkillDiscoveryEnabled?.() ?? false,
 			getDiscoverableTools: filter => session.getDiscoverableTools(filter),
 			getDiscoverableToolSearchIndex: () => session.getDiscoverableToolSearchIndex(),
 			getSelectedDiscoveredToolNames: () => session.getSelectedDiscoveredToolNames(),
@@ -1736,7 +1737,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			settings,
 			countToolsForAutoDiscovery(toolRegistry.keys()),
 		);
-		if (effectiveDiscoveryMode !== "off" && !toolRegistry.has("search_tool_bm25")) {
+		if ((effectiveDiscoveryMode !== "off" || settings.get("skills.redactDescriptions")) && !toolRegistry.has("search_tool_bm25")) {
 			const searchTool: Tool = new SearchToolBm25Tool(toolSession);
 			toolRegistry.set(
 				searchTool.name,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1166,11 +1166,30 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				)
 			: null;
 
+	// Gate the deferred set on read-tool presence, mirroring system-prompt.ts
+	// (`hasRead = tools?.has("read")` → `allVisibleSkills`). Without `read` the
+	// model cannot fetch skill content, so advertising skill:// read URLs via
+	// search_tool_bm25 surfaces tools it can never invoke (ARCH-02).
+	//
+	// The two sites use different tool-name sources but stay equivalent: the
+	// prompt checks the live `tools` Map, while here the registry does not exist
+	// yet (built below), so we mirror the `hasEditTool` getter and check the
+	// requested set. `read` is an essential tool (loadMode "essential"), so it is
+	// present in the Map iff it is requested at init and cannot toggle across
+	// rebuilds — the init-time boolean can never diverge from the per-rebuild
+	// `tools.has("read")`. Undefined `toolNames` means "all defaults" (includes
+	// `read`), so the default-true branch is load-bearing.
+	const requestedToolNamesForSkillGate = options.toolNames
+		? [...new Set(options.toolNames.map(name => name.toLowerCase()))]
+		: undefined;
+	const hasRead = !requestedToolNamesForSkillGate || requestedToolNamesForSkillGate.includes("read");
+
 	// Single owner of the deferred-skill partition. Consumers receive the
 	// pre-computed result — neither rebuildSystemPrompt nor AgentSession re-derive it.
-	const deferredSkillEntries: DiscoverableTool[] = frequentSkillNames
-		? skills.filter(s => !s.hide && !frequentSkillNames.has(s.name)).map(s => getDiscoverableSkill(s))
-		: [];
+	const deferredSkillEntries: DiscoverableTool[] =
+		frequentSkillNames && hasRead
+			? skills.filter(s => !s.hide && !frequentSkillNames.has(s.name)).map(s => getDiscoverableSkill(s))
+			: [];
 
 	// Discover rules and bucket them in one pass to avoid repeated scans over large rule sets.
 	const { ttsrManager, rulebookRules, alwaysApplyRules } = await logger.time("discoverTtsrRules", async () => {

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -78,6 +78,7 @@ import {
 	type ToolDefinition,
 	wrapRegisteredTools,
 } from "./extensibility/extensions";
+import { resolveFrequentSkillNames } from "./extensibility/skill-frequency";
 import {
 	loadSkills as loadSkillsInternal,
 	type Skill,
@@ -136,6 +137,7 @@ import {
 	type DiscoverableTool,
 	filterBySource,
 	formatDiscoverableToolServerSummary,
+	getDiscoverableSkill,
 	selectDiscoverableToolNamesByServer,
 	summarizeDiscoverableTools,
 } from "./tool-discovery/tool-index";
@@ -1148,6 +1150,28 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 		skillWarnings = discovered.warnings;
 	}
 
+	// Freeze the frequent skill set at SDK-init scope. This is captured by the
+	// rebuildSystemPrompt closure and passed into AgentSession — same frozen set
+	// for every rebuild ensures byte-identical <skills> prefix → prompt cache stable.
+	const frequentSkillNames: ReadonlySet<string> | null =
+		!options.parentTaskPrefix && skillsSettings?.redactDescriptions
+			? resolveFrequentSkillNames(
+					settings.getStorage(),
+					skills,
+					{
+						frequentCount: skillsSettings.frequentSkillCount ?? 20,
+						alwaysInclude: skillsSettings.alwaysInclude ?? [],
+					},
+					Math.floor(Date.now() / 1000),
+				)
+			: null;
+
+	// Single owner of the deferred-skill partition. Consumers receive the
+	// pre-computed result — neither rebuildSystemPrompt nor AgentSession re-derive it.
+	const deferredSkillEntries: DiscoverableTool[] = frequentSkillNames
+		? skills.filter(s => !s.hide && !frequentSkillNames.has(s.name)).map(s => getDiscoverableSkill(s))
+		: [];
+
 	// Discover rules and bucket them in one pass to avoid repeated scans over large rule sets.
 	const { ttsrManager, rulebookRules, alwaysApplyRules } = await logger.time("discoverTtsrRules", async () => {
 		const ttsrSettings = settings.getGroup("ttsr");
@@ -1742,7 +1766,11 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 							{ source: "builtin" },
 						)
 					: [];
-			const discoverableToolsForDesc: DiscoverableTool[] = [...discoverableBuiltinTools, ...discoverableMCPTools];
+			const discoverableToolsForDesc: DiscoverableTool[] = [
+				...discoverableBuiltinTools,
+				...discoverableMCPTools,
+				...deferredSkillEntries,
+			];
 			const discoverableToolSummary = summarizeDiscoverableTools(discoverableToolsForDesc);
 			const hasDiscoverableTools =
 				mcpDiscoveryEnabled && toolNames.includes("search_tool_bm25") && discoverableToolsForDesc.length > 0;
@@ -1779,6 +1807,7 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 				rules: rulebookRules,
 				alwaysApplyRules,
 				skillsSettings: settings.getGroup("skills"),
+				frequentSkillNames,
 				appendSystemPrompt: appendPrompt,
 				repeatToolDescriptions,
 				intentField,
@@ -2132,6 +2161,8 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			skills,
 			skillWarnings,
 			skillsSettings: settings.getGroup("skills"),
+			frequentSkillNames,
+			deferredSkillEntries,
 			modelRegistry,
 			toolRegistry,
 			transformContext,

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -1737,7 +1737,10 @@ export async function createAgentSession(options: CreateAgentSessionOptions = {}
 			settings,
 			countToolsForAutoDiscovery(toolRegistry.keys()),
 		);
-		if ((effectiveDiscoveryMode !== "off" || settings.get("skills.redactDescriptions")) && !toolRegistry.has("search_tool_bm25")) {
+		if (
+			(effectiveDiscoveryMode !== "off" || settings.get("skills.redactDescriptions")) &&
+			!toolRegistry.has("search_tool_bm25")
+		) {
 			const searchTool: Tool = new SearchToolBm25Tool(toolSession);
 			toolRegistry.set(
 				searchTool.name,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -317,6 +317,10 @@ export interface AgentSessionConfig {
 	/** Custom commands (TypeScript slash commands) */
 	customCommands?: LoadedCustomCommand[];
 	skillsSettings?: SkillsSettings;
+	/** Frozen frequent-skill set computed at SDK-init. Null = no redaction. */
+	frequentSkillNames?: ReadonlySet<string> | null;
+	/** Deferred (non-frequent) skills exposed for search_tool_bm25 discovery. */
+	deferredSkillEntries?: readonly DiscoverableTool[];
 	/** Model registry for API key resolution and model discovery */
 	modelRegistry: ModelRegistry;
 	/** Tool registry for LSP and settings */
@@ -929,6 +933,8 @@ export class AgentSession {
 
 	#skills: Skill[];
 	#skillWarnings: SkillWarning[];
+	#frequentSkillNames: ReadonlySet<string> | null = null;
+	#deferredSkillEntries: readonly DiscoverableTool[] = [];
 
 	// Custom commands (TypeScript slash commands)
 	#customCommands: LoadedCustomCommand[] = [];
@@ -1123,6 +1129,8 @@ export class AgentSession {
 		this.#extensionRunner = config.extensionRunner;
 		this.#skills = config.skills ?? [];
 		this.#skillWarnings = config.skillWarnings ?? [];
+		this.#frequentSkillNames = config.frequentSkillNames ?? null;
+		this.#deferredSkillEntries = config.deferredSkillEntries ?? [];
 		this.#customCommands = config.customCommands ?? [];
 		this.#skillsSettings = config.skillsSettings;
 		this.#modelRegistry = config.modelRegistry;
@@ -3340,6 +3348,10 @@ export class AgentSession {
 		return this.#resolveEffectiveDiscoveryMode() !== "off";
 	}
 
+	isSkillDiscoveryEnabled(): boolean {
+		return this.settings.get("skills.redactDescriptions") === true && this.#deferredSkillEntries.length > 0;
+	}
+
 	getDiscoverableTools(filter?: { source?: DiscoverableTool["source"] }): DiscoverableTool[] {
 		// For "all" mode we combine built-in registry entries + MCP tools.
 		// For "mcp-only" mode we only return MCP tools.
@@ -3347,7 +3359,11 @@ export class AgentSession {
 		const activeNames = new Set(this.getActiveToolNames());
 		const mcpTools = Array.from(this.#discoverableMCPTools.values()).filter(t => !activeNames.has(t.name));
 		const builtinTools: DiscoverableTool[] = mode === "all" ? this.#collectDiscoverableBuiltinTools() : [];
-		const allTools = [...builtinTools, ...mcpTools];
+		// Deferred skill entries are appended unconditionally — they must survive the
+		// mode-gate that empties builtins/mcp under discoveryMode:"off" (the default),
+		// or the BM25 index is empty in exactly the config a user hits by enabling
+		// skills.redactDescriptions alone.
+		const allTools = [...builtinTools, ...mcpTools, ...this.#deferredSkillEntries];
 		return filter?.source ? allTools.filter(t => t.source === filter.source) : allTools;
 	}
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -933,7 +933,6 @@ export class AgentSession {
 
 	#skills: Skill[];
 	#skillWarnings: SkillWarning[];
-	#frequentSkillNames: ReadonlySet<string> | null = null;
 	#deferredSkillEntries: readonly DiscoverableTool[] = [];
 
 	// Custom commands (TypeScript slash commands)
@@ -1129,7 +1128,6 @@ export class AgentSession {
 		this.#extensionRunner = config.extensionRunner;
 		this.#skills = config.skills ?? [];
 		this.#skillWarnings = config.skillWarnings ?? [];
-		this.#frequentSkillNames = config.frequentSkillNames ?? null;
 		this.#deferredSkillEntries = config.deferredSkillEntries ?? [];
 		this.#customCommands = config.customCommands ?? [];
 		this.#skillsSettings = config.skillsSettings;
@@ -3349,6 +3347,10 @@ export class AgentSession {
 	}
 
 	isSkillDiscoveryEnabled(): boolean {
+		// Note: reads live settings each call, but #deferredSkillEntries is frozen at session init.
+		// A mid-session toggle of skills.redactDescriptions therefore changes the gate outcome
+		// without changing the deferred set — which is intentional (prompt caching requires the
+		// frozen set; the live flag controls whether BM25 surfaces the already-computed entries).
 		return this.settings.get("skills.redactDescriptions") === true && this.#deferredSkillEntries.length > 0;
 	}
 

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -22,9 +22,21 @@ type ModelUsageRow = {
 	last_used_at: number;
 };
 
+/** Row shape for skill_usage table queries */
+type SkillUsageRow = {
+	skill_name: string;
+	decayed_count: number;
+	last_used_at: number;
+	total_count: number;
+};
+
 /** Bump when schema changes require migration */
-const SCHEMA_VERSION = 5;
+const SCHEMA_VERSION = 6;
 const SQLITE_NOW_EPOCH = "CAST(strftime('%s','now') AS INTEGER)";
+
+const SKILL_USAGE_HALF_LIFE_DAYS = 21;
+const SKILL_USAGE_DECAY_LAMBDA = Math.LN2 / (SKILL_USAGE_HALF_LIFE_DAYS * 86_400);
+const SKILL_USAGE_THROTTLE_SECS = 300; // 5 min burst-dedup window
 
 /** Singleton instances per database path */
 const instances = new Map<string, AgentStorage>();
@@ -42,6 +54,9 @@ export class AgentStorage {
 	#upsertModelUsageStmt: Statement;
 	#listModelUsageStmt: Statement;
 	#modelUsageCache: string[] | null = null;
+	#upsertSkillUsageStmt: Statement;
+	#selectSkillUsageStmt: Statement;
+	#listSkillUsageStmt: Statement;
 
 	private constructor(dbPath: string) {
 		this.#ensureDir(dbPath);
@@ -71,6 +86,15 @@ export class AgentStorage {
 		this.#listModelUsageStmt = this.#db.prepare(
 			"SELECT model_key, last_used_at FROM model_usage ORDER BY last_used_at DESC",
 		);
+		this.#upsertSkillUsageStmt = this.#db.prepare(
+			"INSERT INTO skill_usage (skill_name, decayed_count, last_used_at, total_count) VALUES (?, ?, ?, 1) ON CONFLICT(skill_name) DO UPDATE SET decayed_count = ?, last_used_at = ?, total_count = total_count + 1",
+		);
+		this.#selectSkillUsageStmt = this.#db.prepare(
+			"SELECT skill_name, decayed_count, last_used_at, total_count FROM skill_usage WHERE skill_name = ?",
+		);
+		this.#listSkillUsageStmt = this.#db.prepare(
+			"SELECT skill_name, decayed_count, last_used_at, total_count FROM skill_usage ORDER BY decayed_count DESC",
+		);
 	}
 
 	/**
@@ -86,6 +110,13 @@ PRAGMA busy_timeout=5000;
 CREATE TABLE IF NOT EXISTS model_usage (
 	model_key TEXT PRIMARY KEY,
 	last_used_at INTEGER NOT NULL DEFAULT (${SQLITE_NOW_EPOCH})
+);
+
+CREATE TABLE IF NOT EXISTS skill_usage (
+	skill_name TEXT PRIMARY KEY,
+	decayed_count REAL NOT NULL DEFAULT 0,
+	last_used_at INTEGER NOT NULL DEFAULT 0,
+	total_count INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS schema_version (version INTEGER PRIMARY KEY);
@@ -169,6 +200,9 @@ CREATE TABLE settings (
 		}
 		if (fromVersion < 5) {
 			this.#migrateSchemaV4ToV5();
+		}
+		if (fromVersion < 6) {
+			// v5 → v6: skill_usage table added via idempotent CREATE TABLE IF NOT EXISTS in #initializeSchema
 		}
 	}
 
@@ -290,6 +324,55 @@ FROM model_usage_legacy
 			return this.#modelUsageCache;
 		} catch (error) {
 			logger.warn("AgentStorage failed to get model usage order", { error: String(error) });
+			return [];
+		}
+	}
+
+	/**
+	 * Records a skill usage event with exponential-decay scoring.
+	 * Calls within the 5-minute throttle window are silently skipped.
+	 * @param skillName - Identifier of the skill being used
+	 */
+	recordSkillUsage(skillName: string): void {
+		try {
+			const nowSec = Math.floor(Date.now() / 1000);
+			const prior = this.#selectSkillUsageStmt.get(skillName) as SkillUsageRow | undefined;
+
+			// 5-minute burst throttle: skip if already recorded recently
+			if (prior && nowSec - prior.last_used_at < SKILL_USAGE_THROTTLE_SECS) {
+				return;
+			}
+
+			// Decay prior score to now, then add 1
+			const dt = prior ? nowSec - prior.last_used_at : 0;
+			const newScore = prior
+				? prior.decayed_count * Math.exp(-SKILL_USAGE_DECAY_LAMBDA * dt) + 1
+				: 1;
+
+			this.#upsertSkillUsageStmt.run(skillName, newScore, nowSec, newScore, nowSec);
+		} catch (error) {
+			logger.warn("AgentStorage failed to record skill usage", { skillName, error: String(error) });
+		}
+	}
+
+	/**
+	 * Returns all skill usage entries with scores decayed to the current time,
+	 * ordered by descending decayed score.
+	 * @returns Array of skill usage entries
+	 */
+	getSkillUsage(): Array<{ name: string; score: number; lastUsedAt: number; totalCount: number }> {
+		try {
+			const nowSec = Math.floor(Date.now() / 1000);
+			const rows = this.#listSkillUsageStmt.all() as SkillUsageRow[];
+			return rows
+				.map(row => {
+					const dt = nowSec - row.last_used_at;
+					const score = row.decayed_count * Math.exp(-SKILL_USAGE_DECAY_LAMBDA * dt);
+					return { name: row.skill_name, score, lastUsedAt: row.last_used_at, totalCount: row.total_count };
+				})
+				.sort((a, b) => b.score - a.score);
+		} catch (error) {
+			logger.warn("AgentStorage failed to get skill usage", { error: String(error) });
 			return [];
 		}
 	}

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -93,7 +93,7 @@ export class AgentStorage {
 			"SELECT skill_name, decayed_count, last_used_at, total_count FROM skill_usage WHERE skill_name = ?",
 		);
 		this.#listSkillUsageStmt = this.#db.prepare(
-			"SELECT skill_name, decayed_count, last_used_at, total_count FROM skill_usage ORDER BY decayed_count DESC",
+			"SELECT skill_name, decayed_count, last_used_at, total_count FROM skill_usage",
 		);
 	}
 

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -341,12 +341,12 @@ FROM model_usage_legacy
 			const prior = this.#selectSkillUsageStmt.get(skillName) as SkillUsageRow | undefined;
 
 			// 5-minute burst throttle: skip if already recorded recently
-			if (prior && nowSec - prior.last_used_at < SKILL_USAGE_THROTTLE_SECS) {
+			if (prior && Math.max(0, nowSec - prior.last_used_at) < SKILL_USAGE_THROTTLE_SECS) {
 				return;
 			}
 
 			// Decay prior score to now, then add 1
-			const dt = prior ? nowSec - prior.last_used_at : 0;
+			const dt = prior ? Math.max(0, nowSec - prior.last_used_at) : 0;
 			const newScore = prior ? prior.decayed_count * Math.exp(-SKILL_USAGE_DECAY_LAMBDA * dt) + 1 : 1;
 
 			this.#upsertSkillUsageStmt.run(skillName, newScore, nowSec, newScore, nowSec);
@@ -366,7 +366,7 @@ FROM model_usage_legacy
 			const rows = this.#listSkillUsageStmt.all() as SkillUsageRow[];
 			return rows
 				.map(row => {
-					const dt = nowSec - row.last_used_at;
+					const dt = Math.max(0, nowSec - row.last_used_at);
 					const score = row.decayed_count * Math.exp(-SKILL_USAGE_DECAY_LAMBDA * dt);
 					return { name: row.skill_name, score, lastUsedAt: row.last_used_at, totalCount: row.total_count };
 				})

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -190,8 +190,12 @@ CREATE TABLE settings (
 		if (schemaVersion < SCHEMA_VERSION) {
 			this.#migrateSchema(schemaVersion);
 		}
-		this.#db.prepare("DELETE FROM schema_version").run();
-		this.#db.prepare("INSERT INTO schema_version(version) VALUES (?)").run(SCHEMA_VERSION);
+		// Only rewrite schema_version when we own it (equal or older).
+		// A newer version means a newer binary ran this DB; preserve it.
+		if (schemaVersion <= SCHEMA_VERSION) {
+			this.#db.prepare("DELETE FROM schema_version").run();
+			this.#db.prepare("INSERT INTO schema_version(version) VALUES (?)").run(SCHEMA_VERSION);
+		}
 	}
 
 	#migrateSchema(fromVersion: number): void {

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -347,9 +347,7 @@ FROM model_usage_legacy
 
 			// Decay prior score to now, then add 1
 			const dt = prior ? nowSec - prior.last_used_at : 0;
-			const newScore = prior
-				? prior.decayed_count * Math.exp(-SKILL_USAGE_DECAY_LAMBDA * dt) + 1
-				: 1;
+			const newScore = prior ? prior.decayed_count * Math.exp(-SKILL_USAGE_DECAY_LAMBDA * dt) + 1 : 1;
 
 			this.#upsertSkillUsageStmt.run(skillName, newScore, nowSec, newScore, nowSec);
 		} catch (error) {

--- a/packages/coding-agent/src/session/agent-storage.ts
+++ b/packages/coding-agent/src/session/agent-storage.ts
@@ -181,7 +181,7 @@ CREATE TABLE settings (
 			| { version?: number }
 			| undefined;
 		const schemaVersion = typeof versionRow?.version === "number" ? versionRow.version : 0;
-		if (versionRow?.version !== undefined && versionRow.version !== SCHEMA_VERSION) {
+		if (versionRow?.version !== undefined && versionRow.version > SCHEMA_VERSION) {
 			logger.warn("AgentStorage schema version mismatch", {
 				current: versionRow.version,
 				expected: SCHEMA_VERSION,
@@ -190,7 +190,8 @@ CREATE TABLE settings (
 		if (schemaVersion < SCHEMA_VERSION) {
 			this.#migrateSchema(schemaVersion);
 		}
-		this.#db.prepare("INSERT OR REPLACE INTO schema_version(version) VALUES (?)").run(SCHEMA_VERSION);
+		this.#db.prepare("DELETE FROM schema_version").run();
+		this.#db.prepare("INSERT INTO schema_version(version) VALUES (?)").run(SCHEMA_VERSION);
 	}
 
 	#migrateSchema(fromVersion: number): void {
@@ -334,6 +335,7 @@ FROM model_usage_legacy
 	 * @param skillName - Identifier of the skill being used
 	 */
 	recordSkillUsage(skillName: string): void {
+		if (!skillName || skillName.length > 255) return;
 		try {
 			const nowSec = Math.floor(Date.now() / 1000);
 			const prior = this.#selectSkillUsageStmt.get(skillName) as SkillUsageRow | undefined;

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -546,24 +546,19 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 	const hasRead = tools?.has("read");
 	const allVisibleSkills = hasRead ? skills.filter(skill => skill.hide !== true) : [];
 
-	let renderedSkills: typeof allVisibleSkills;
-	let deferredSkillCount = 0;
-	const skillsRedacted =
+	// Redaction keeps every visible skill's name but blanks the description of
+	// any skill not in the frequent set. Names are ~5 tokens each and make
+	// `skill://<name>` reads directly inferable; descriptions are deferred to
+	// BM25 search. frequentSkillNames! is load-bearing: TS cannot narrow the
+	// non-null check through the separate redactionActive const.
+	const redactionActive =
 		!!skillsSettings?.redactDescriptions && frequentSkillNames != null && allVisibleSkills.length > 0;
-	if (skillsRedacted) {
-		renderedSkills = allVisibleSkills.filter(s => frequentSkillNames!.has(s.name));
-		deferredSkillCount = allVisibleSkills.length - renderedSkills.length;
-		// If nothing is actually deferred, clear the redacted flag for the template
-		if (deferredSkillCount === 0) {
-			// All skills fit in the frequent set (e.g. warmup gate or small catalog).
-			// skillsRedacted stays true here but is guarded at the template-data boundary
-			// (`skillsRedacted && deferredSkillCount > 0`) so the pointer never renders.
-			renderedSkills = allVisibleSkills;
-		}
-	} else {
-		renderedSkills = allVisibleSkills;
-	}
-	const showSkillsBlock = renderedSkills.length > 0 || (skillsRedacted && deferredSkillCount > 0);
+	const renderedSkills = allVisibleSkills.map(s => ({
+		name: s.name,
+		description: redactionActive && !frequentSkillNames!.has(s.name) ? undefined : s.description,
+	}));
+	const deferredSkillCount = renderedSkills.reduce((n, s) => n + (s.description === undefined ? 1 : 0), 0);
+	const showSkillsBlock = renderedSkills.length > 0;
 
 	const effectiveSystemPromptCustomization = dedupePromptSource(systemPromptCustomization, [
 		resolvedCustomPrompt,
@@ -586,7 +581,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		agentsMdSearch: { files: agentsMdFiles },
 		workspaceTree,
 		skills: renderedSkills,
-		skillsRedacted: skillsRedacted && deferredSkillCount > 0,
+		skillsRedacted: deferredSkillCount > 0,
 		deferredSkillCount,
 		showSkillsBlock,
 		rules: rules ?? [],

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -339,6 +339,8 @@ export interface BuildSystemPromptOptions {
 	repeatToolDescriptions?: boolean;
 	/** Skills settings for discovery. */
 	skillsSettings?: SkillsSettings;
+	/** Frozen set of skill names to show inline; others get a pointer. Null = no redaction. */
+	frequentSkillNames?: ReadonlySet<string> | null;
 	/** Working directory. Default: getProjectDir() */
 	cwd?: string;
 	/** Pre-loaded context files (skips discovery if provided). */
@@ -385,6 +387,7 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		appendSystemPrompt,
 		repeatToolDescriptions = false,
 		skillsSettings,
+		frequentSkillNames,
 		toolNames: providedToolNames,
 		cwd,
 		contextFiles: providedContextFiles,
@@ -541,7 +544,26 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 	// - require the `read` tool so the model can actually fetch skill content;
 	// - drop skills with frontmatter `hide: true` (still loadable via skill:// and /skill:<name>).
 	const hasRead = tools?.has("read");
-	const filteredSkills = hasRead ? skills.filter(skill => skill.hide !== true) : [];
+	const allVisibleSkills = hasRead ? skills.filter(skill => skill.hide !== true) : [];
+
+	let renderedSkills: typeof allVisibleSkills;
+	let deferredSkillCount = 0;
+	const skillsRedacted =
+		!!skillsSettings?.redactDescriptions && frequentSkillNames != null && allVisibleSkills.length > 0;
+	if (skillsRedacted) {
+		renderedSkills = allVisibleSkills.filter(s => frequentSkillNames!.has(s.name));
+		deferredSkillCount = allVisibleSkills.length - renderedSkills.length;
+		// If nothing is actually deferred, clear the redacted flag for the template
+		if (deferredSkillCount === 0) {
+			// All skills fit in the frequent set (e.g. warmup gate or small catalog).
+			// skillsRedacted stays true here but is guarded at the template-data boundary
+			// (`skillsRedacted && deferredSkillCount > 0`) so the pointer never renders.
+			renderedSkills = allVisibleSkills;
+		}
+	} else {
+		renderedSkills = allVisibleSkills;
+	}
+	const showSkillsBlock = renderedSkills.length > 0 || (skillsRedacted && deferredSkillCount > 0);
 
 	const effectiveSystemPromptCustomization = dedupePromptSource(systemPromptCustomization, [
 		resolvedCustomPrompt,
@@ -563,7 +585,10 @@ export async function buildSystemPrompt(options: BuildSystemPromptOptions = {}):
 		contextFiles,
 		agentsMdSearch: { files: agentsMdFiles },
 		workspaceTree,
-		skills: filteredSkills,
+		skills: renderedSkills,
+		skillsRedacted: skillsRedacted && deferredSkillCount > 0,
+		deferredSkillCount,
+		showSkillsBlock,
 		rules: rules ?? [],
 		alwaysApplyRules: injectedAlwaysApplyRules,
 		date,

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -1415,6 +1415,7 @@ export async function runSubprocess(options: ExecutorOptions): Promise<SingleRes
 
 			checkAbort();
 			// Autoload skills via sendCustomMessage (same mechanic as /skill:<name>)
+			// Skill usage tracking intentionally excluded: programmatic injection by task specs, not organic user selection
 			if (options.autoloadSkills?.length) {
 				for (const skill of options.autoloadSkills) {
 					const { message } = await buildSkillPromptMessage(skill, "");

--- a/packages/coding-agent/src/tool-discovery/tool-index.ts
+++ b/packages/coding-agent/src/tool-discovery/tool-index.ts
@@ -156,7 +156,7 @@ export function getDiscoverableSkill(skill: { name: string; description: string 
 	return {
 		name: skill.name,
 		label: skill.name,
-		summary: skill.description,
+		summary: skill.description.slice(0, 200),
 		source: "skill" as const,
 		schemaKeys: [],
 	};

--- a/packages/coding-agent/src/tool-discovery/tool-index.ts
+++ b/packages/coding-agent/src/tool-discovery/tool-index.ts
@@ -2,7 +2,7 @@ import type { AgentTool } from "@oh-my-pi/pi-agent-core";
 
 // ─── Generic Tool Discovery Types ────────────────────────────────────────────
 
-export type DiscoverableToolSource = "builtin" | "mcp" | "extension" | "custom";
+export type DiscoverableToolSource = "builtin" | "mcp" | "extension" | "custom" | "skill";
 
 export interface DiscoverableTool {
 	name: string;
@@ -148,6 +148,17 @@ export function getDiscoverableTool(
 		serverName: typeof toolRecord.mcpServerName === "string" ? toolRecord.mcpServerName : undefined,
 		mcpToolName: typeof toolRecord.mcpToolName === "string" ? toolRecord.mcpToolName : undefined,
 		schemaKeys: getSchemaPropertyKeys(toolRecord.parameters),
+	};
+}
+
+/** Build a DiscoverableTool descriptor for a skill so it is searchable via search_tool_bm25. */
+export function getDiscoverableSkill(skill: { name: string; description: string }): DiscoverableTool {
+	return {
+		name: skill.name,
+		label: skill.name,
+		summary: skill.description,
+		source: "skill" as const,
+		schemaKeys: [],
 	};
 }
 

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -446,8 +446,10 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		if (name === "render_mermaid") return session.settings.get("renderMermaid.enabled");
 		if (name === "inspect_image") return session.settings.get("inspect_image.enabled");
 		if (name === "web_search") return session.settings.get("web_search.enabled");
-		// search_tool_bm25 is allowed when either legacy mcp.discoveryMode or new tools.discoveryMode is active.
-		if (name === "search_tool_bm25") return discoveryActive;
+		// search_tool_bm25 is allowed when tool discovery is active OR when skill-description
+		// redaction is enabled (deferred skills need BM25 to be discoverable).
+		if (name === "search_tool_bm25")
+			return discoveryActive || session.settings.get("skills.redactDescriptions") === true;
 		if (name === "browser") return session.settings.get("browser.enabled");
 		if (name === "checkpoint" || name === "rewind") return session.settings.get("checkpoint.enabled");
 		if (name === "irc") {

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -237,6 +237,8 @@ export interface ToolSession {
 	// ── Generic tool discovery (unified — covers built-in + MCP + extension) ──
 	/** Whether any form of tool discovery is active (tools.discoveryMode !== "off" or mcp.discoveryMode). */
 	isToolDiscoveryEnabled?: () => boolean;
+	/** Whether skill-description redaction has deferred skills discoverable via search_tool_bm25. */
+	isSkillDiscoveryEnabled?(): boolean;
 	/** Get all hidden-but-discoverable tools for search_tool_bm25 prompts. */
 	getDiscoverableTools?: (filter?: {
 		source?: import("../tool-discovery/tool-index").DiscoverableToolSource;

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -2190,6 +2190,15 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 			signal,
 			localProtocolOptions: this.session.localProtocolOptions,
 		});
+		// Track skill usage for root skill:// reads.
+		// Placed after a successful resolve — failed resolves throw before this point,
+		// so only deliberate reads are counted (sub-paths excluded).
+		if (
+			scheme === "skill" &&
+			(!urlMeta.pathname || urlMeta.pathname === "/" || urlMeta.pathname === "")
+		) {
+			this.session.settings.getStorage()?.recordSkillUsage(urlMeta.rawHost);
+		}
 		const details: ReadToolDetails = { resolvedPath: resource.sourcePath, contentType: resource.contentType };
 
 		// If extraction was used, return directly (no pagination)

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -2193,10 +2193,7 @@ export class ReadTool implements AgentTool<typeof readSchema, ReadToolDetails> {
 		// Track skill usage for root skill:// reads.
 		// Placed after a successful resolve — failed resolves throw before this point,
 		// so only deliberate reads are counted (sub-paths excluded).
-		if (
-			scheme === "skill" &&
-			(!urlMeta.pathname || urlMeta.pathname === "/" || urlMeta.pathname === "")
-		) {
+		if (scheme === "skill" && (!urlMeta.pathname || urlMeta.pathname === "/" || urlMeta.pathname === "")) {
 			this.session.settings.getStorage()?.recordSkillUsage(urlMeta.rawHost);
 		}
 		const details: ReadToolDetails = { resolvedPath: resource.sourcePath, contentType: resource.contentType };

--- a/packages/coding-agent/src/tools/search-tool-bm25.ts
+++ b/packages/coding-agent/src/tools/search-tool-bm25.ts
@@ -307,7 +307,7 @@ export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema
 					? skillResults.map(result => ({
 							name: result.tool.name,
 							description: result.tool.summary,
-							read: `skill://${result.tool.name}`,
+							read: `skill://${encodeURIComponent(result.tool.name)}`,
 							score: Number(result.score.toFixed(6)),
 						}))
 					: undefined,

--- a/packages/coding-agent/src/tools/search-tool-bm25.ts
+++ b/packages/coding-agent/src/tools/search-tool-bm25.ts
@@ -236,7 +236,9 @@ export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema
 		// auto mode is activated later by createAgentSession after the full registry exists.
 		// Skill discovery (skills.redactDescriptions) keeps this tool alive even when
 		// tool discovery is "off" — it needs search_tool_bm25 to surface deferred skills.
-		if (resolveEffectiveToolDiscoveryMode(session.settings, 0) === "off" && !session.isSkillDiscoveryEnabled?.())
+		// Use settings directly (not isSkillDiscoveryEnabled) because session is not yet
+		// constructed at createTools() time.
+		if (resolveEffectiveToolDiscoveryMode(session.settings, 0) === "off" && !session.settings.get("skills.redactDescriptions"))
 			return null;
 		return supportsToolDiscoveryExecution(session) ? new SearchToolBm25Tool(session) : null;
 	}

--- a/packages/coding-agent/src/tools/search-tool-bm25.ts
+++ b/packages/coding-agent/src/tools/search-tool-bm25.ts
@@ -51,6 +51,12 @@ export interface SearchToolBm25Details {
 	activated_tools: string[];
 	active_selected_tools: string[];
 	tools: SearchToolBm25Match[];
+	skills?: Array<{
+		name: string;
+		description: string;
+		read: string; // "skill://<name>"
+		score: number;
+	}>;
 }
 
 function formatMatch(tool: DiscoverableTool, score: number): SearchToolBm25Match {
@@ -71,6 +77,12 @@ function buildSearchToolBm25Content(details: SearchToolBm25Details): string {
 		activated_tools: details.activated_tools,
 		match_count: details.tools.length,
 		total_tools: details.total_tools,
+		...(details.skills && details.skills.length > 0
+			? {
+					skill_matches: details.skills,
+					skill_match_count: details.skills.length,
+				}
+			: {}),
 	});
 }
 
@@ -146,12 +158,15 @@ export function renderSearchToolBm25Description(discoverableTools: DiscoverableT
 	const builtinToolNames = filterBySource(discoverableTools, "builtin")
 		.map(t => t.name)
 		.sort();
+	const skillCount = discoverableTools.filter(t => t.source === "skill").length;
 	return prompt.render(searchToolBm25Description, {
 		discoverableToolCount: summary.toolCount,
 		discoverableMCPServerSummaries: summary.servers.map(formatDiscoverableToolServerSummary),
 		hasDiscoverableMCPServers: summary.servers.length > 0,
 		discoverableBuiltinToolNames: builtinToolNames,
 		hasDiscoverableBuiltinTools: builtinToolNames.length > 0,
+		discoverableSkillCount: skillCount,
+		hasDiscoverableSkills: skillCount > 0,
 	});
 }
 
@@ -201,7 +216,9 @@ export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema
 	static createIf(session: ToolSession): SearchToolBm25Tool | null {
 		// Direct createTools() calls do not know the final MCP/extension catalog yet, so
 		// auto mode is activated later by createAgentSession after the full registry exists.
-		if (resolveEffectiveToolDiscoveryMode(session.settings, 0) === "off") return null;
+		// Skill discovery (skills.redactDescriptions) keeps this tool alive even when
+		// tool discovery is "off" — it needs search_tool_bm25 to surface deferred skills.
+		if (resolveEffectiveToolDiscoveryMode(session.settings, 0) === "off" && !session.isSkillDiscoveryEnabled?.()) return null;
 		return supportsToolDiscoveryExecution(session) ? new SearchToolBm25Tool(session) : null;
 	}
 
@@ -215,9 +232,9 @@ export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema
 		if (!supportsToolDiscoveryExecution(this.session)) {
 			throw new ToolError("Tool discovery is unavailable in this session.");
 		}
-		if (!isDiscoveryEnabled(this.session)) {
+		if (!isDiscoveryEnabled(this.session) && !(this.session.isSkillDiscoveryEnabled?.() === true)) {
 			throw new ToolError(
-				"Tool discovery is disabled. Enable tools.discoveryMode or mcp.discoveryMode to use search_tool_bm25.",
+				"Tool discovery is disabled. Enable tools.discoveryMode, mcp.discoveryMode, or skills.redactDescriptions to use search_tool_bm25.",
 			);
 		}
 
@@ -243,11 +260,14 @@ export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema
 			}
 			throw error;
 		}
+		const skillResults = ranked.filter(r => r.tool.source === "skill");
+		const toolResults = ranked.filter(r => r.tool.source !== "skill");
+
 		const activated =
-			ranked.length > 0
+			toolResults.length > 0
 				? await activateTools(
 						this.session,
-						ranked.map(result => result.tool.name),
+						toolResults.map(result => result.tool.name),
 					)
 				: [];
 
@@ -257,7 +277,15 @@ export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema
 			total_tools: searchIndex.documents.length,
 			activated_tools: activated,
 			active_selected_tools: getSelectedToolNames(this.session),
-			tools: ranked.map(result => formatMatch(result.tool, result.score)),
+			tools: toolResults.map(result => formatMatch(result.tool, result.score)),
+			skills: skillResults.length > 0
+				? skillResults.map(result => ({
+						name: result.tool.name,
+						description: result.tool.summary,
+						read: `skill://${result.tool.name}`,
+						score: Number(result.score.toFixed(6)),
+					}))
+				: undefined,
 		};
 
 		return {
@@ -296,6 +324,8 @@ export const searchToolBm25Renderer = {
 		}
 
 		const { details } = result;
+		const hasToolMatches = details.tools.length > 0;
+		const hasSkillMatches = details.skills !== undefined && details.skills.length > 0;
 		const meta = [
 			formatCount("match", details.tools.length),
 			`${details.active_selected_tools.length} active`,
@@ -305,31 +335,46 @@ export const searchToolBm25Renderer = {
 		const safeQuery = replaceTabs(details.query);
 		const header = renderStatusLine(
 			{
-				icon: details.tools.length > 0 ? "success" : "warning",
+				icon: hasToolMatches || hasSkillMatches ? "success" : "warning",
 				title: TOOL_DISCOVERY_TITLE,
 				description: truncateToWidth(safeQuery, MATCH_LABEL_LEN),
 				meta,
 			},
 			uiTheme,
 		);
-		if (details.tools.length === 0) {
+		if (!hasToolMatches && !hasSkillMatches) {
 			const emptyMessage =
 				details.total_tools === 0 ? "No discoverable tools are currently loaded." : "No matching tools found.";
 			return new Text(`${header}\n${uiTheme.fg("muted", emptyMessage)}`, 0, 0);
 		}
 
 		const lines = [header];
-		const treeLines = renderTreeList(
-			{
-				items: details.tools,
-				expanded: options.expanded,
-				maxCollapsed: COLLAPSED_MATCH_LIMIT,
-				itemType: "tool",
-				renderItem: match => renderMatchLines(match, uiTheme),
-			},
-			uiTheme,
-		);
-		lines.push(...treeLines);
+		if (hasToolMatches) {
+			const treeLines = renderTreeList(
+				{
+					items: details.tools,
+					expanded: options.expanded,
+					maxCollapsed: COLLAPSED_MATCH_LIMIT,
+					itemType: "tool",
+					renderItem: match => renderMatchLines(match, uiTheme),
+				},
+				uiTheme,
+			);
+			lines.push(...treeLines);
+		}
+		if (hasSkillMatches) {
+			lines.push(uiTheme.fg("dim", `Skills (${details.skills!.length}):`));
+			for (const skill of details.skills!) {
+				const truncName = truncateToWidth(skill.name, MATCH_LABEL_LEN);
+				const truncDesc = skill.description
+					? truncateToWidth(replaceTabs(skill.description), MATCH_DESCRIPTION_LEN)
+					: "";
+				const scoreStr = uiTheme.fg("dim", `score ${skill.score.toFixed(3)}`);
+				lines.push(`  ${uiTheme.fg("accent", truncName)} ${scoreStr}`);
+				if (truncDesc) lines.push(`  ${uiTheme.fg("muted", truncDesc)}`);
+				lines.push(`  ${uiTheme.fg("dim", `read: ${skill.read}`)}`);
+			}
+		}
 		return new Text(lines.join("\n"), 0, 0);
 	},
 

--- a/packages/coding-agent/src/tools/search-tool-bm25.ts
+++ b/packages/coding-agent/src/tools/search-tool-bm25.ts
@@ -236,7 +236,8 @@ export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema
 		// auto mode is activated later by createAgentSession after the full registry exists.
 		// Skill discovery (skills.redactDescriptions) keeps this tool alive even when
 		// tool discovery is "off" — it needs search_tool_bm25 to surface deferred skills.
-		if (resolveEffectiveToolDiscoveryMode(session.settings, 0) === "off" && !session.isSkillDiscoveryEnabled?.()) return null;
+		if (resolveEffectiveToolDiscoveryMode(session.settings, 0) === "off" && !session.isSkillDiscoveryEnabled?.())
+			return null;
 		return supportsToolDiscoveryExecution(session) ? new SearchToolBm25Tool(session) : null;
 	}
 
@@ -296,14 +297,15 @@ export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema
 			activated_tools: activated,
 			active_selected_tools: getSelectedToolNames(this.session),
 			tools: toolResults.map(result => formatMatch(result.tool, result.score)),
-			skills: skillResults.length > 0
-				? skillResults.map(result => ({
-						name: result.tool.name,
-						description: result.tool.summary,
-						read: `skill://${result.tool.name}`,
-						score: Number(result.score.toFixed(6)),
-					}))
-				: undefined,
+			skills:
+				skillResults.length > 0
+					? skillResults.map(result => ({
+							name: result.tool.name,
+							description: result.tool.summary,
+							read: `skill://${result.tool.name}`,
+							score: Number(result.score.toFixed(6)),
+						}))
+					: undefined,
 		};
 
 		return {

--- a/packages/coding-agent/src/tools/search-tool-bm25.ts
+++ b/packages/coding-agent/src/tools/search-tool-bm25.ts
@@ -238,7 +238,10 @@ export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema
 		// tool discovery is "off" — it needs search_tool_bm25 to surface deferred skills.
 		// Use settings directly (not isSkillDiscoveryEnabled) because session is not yet
 		// constructed at createTools() time.
-		if (resolveEffectiveToolDiscoveryMode(session.settings, 0) === "off" && !session.settings.get("skills.redactDescriptions"))
+		if (
+			resolveEffectiveToolDiscoveryMode(session.settings, 0) === "off" &&
+			!session.settings.get("skills.redactDescriptions")
+		)
 			return null;
 		return supportsToolDiscoveryExecution(session) ? new SearchToolBm25Tool(session) : null;
 	}

--- a/packages/coding-agent/src/tools/search-tool-bm25.ts
+++ b/packages/coding-agent/src/tools/search-tool-bm25.ts
@@ -387,14 +387,14 @@ export const searchToolBm25Renderer = {
 		if (hasSkillMatches) {
 			lines.push(uiTheme.fg("dim", `Skills (${details.skills!.length}):`));
 			for (const skill of details.skills!) {
-				const truncName = truncateToWidth(skill.name, MATCH_LABEL_LEN);
+				const truncName = truncateToWidth(replaceTabs(skill.name), MATCH_LABEL_LEN);
 				const truncDesc = skill.description
 					? truncateToWidth(replaceTabs(skill.description), MATCH_DESCRIPTION_LEN)
 					: "";
 				const scoreStr = uiTheme.fg("dim", `score ${skill.score.toFixed(3)}`);
 				lines.push(`  ${uiTheme.fg("accent", truncName)} ${scoreStr}`);
 				if (truncDesc) lines.push(`  ${uiTheme.fg("muted", truncDesc)}`);
-				lines.push(`  ${uiTheme.fg("dim", `read: ${skill.read}`)}`);
+				lines.push(`  ${uiTheme.fg("dim", `read: ${replaceTabs(skill.read)}`)}`);
 			}
 		}
 		return new Text(lines.join("\n"), 0, 0);

--- a/packages/coding-agent/src/tools/search-tool-bm25.ts
+++ b/packages/coding-agent/src/tools/search-tool-bm25.ts
@@ -205,8 +205,26 @@ export class SearchToolBm25Tool implements AgentTool<typeof searchToolBm25Schema
 	readonly approval = "read" as const;
 	readonly label = "SearchTools";
 	readonly loadMode = "essential";
+	// Cache description alongside the search index: same invalidation signal
+	// (getDiscoverableToolSearchIndex returns a new reference when the tool list changes),
+	// so we avoid O(tools+skills) re-render on every normalizeTools() call per API turn.
+	#descriptionCache: { index: DiscoverableToolSearchIndex; text: string } | null = null;
 	get description(): string {
-		return renderSearchToolBm25Description(getDiscoverableToolsForDescription(this.session));
+		// Guard: during early SDK init the session proxy exists but the captured AgentSession
+		// is not constructed yet — getDiscoverableToolSearchIndex() would throw from inside the
+		// closure. Swallow and fall through to uncached render (same as getDiscoverableToolsForDescription).
+		let index: DiscoverableToolSearchIndex | undefined;
+		try {
+			index = this.session.getDiscoverableToolSearchIndex?.();
+		} catch {
+			// session not yet fully initialized
+		}
+		if (index && this.#descriptionCache?.index === index) {
+			return this.#descriptionCache.text;
+		}
+		const text = renderSearchToolBm25Description(getDiscoverableToolsForDescription(this.session));
+		if (index) this.#descriptionCache = { index, text };
+		return text;
 	}
 	readonly parameters = searchToolBm25Schema;
 	readonly strict = true;

--- a/packages/coding-agent/test/acp-agent-skill-tracking.test.ts
+++ b/packages/coding-agent/test/acp-agent-skill-tracking.test.ts
@@ -1,0 +1,393 @@
+/**
+ * Tests for skill invocation tracking in AcpAgent.#tryRunSkillCommand.
+ *
+ * Drives `/skill:<name>` prompts through the real AcpAgent using a minimal
+ * FakeAgentSession that emits the lifecycle events AcpAgent needs to settle
+ * its prompt turn.
+ */
+import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AgentSideConnection, PromptRequest, SessionNotification } from "@agentclientprotocol/sdk";
+import type { Model } from "@oh-my-pi/pi-ai";
+import { getConfigRootDir, setAgentDir } from "@oh-my-pi/pi-utils";
+import { resetSettingsForTest, Settings } from "../src/config/settings";
+import { ACP_BOOTSTRAP_RACE_GUARD_MS, AcpAgent } from "../src/modes/acp/acp-agent";
+import type { PlanModeState } from "../src/plan-mode/state";
+import type { AgentSession, AgentSessionEvent } from "../src/session/agent-session";
+import type { AgentStorage } from "../src/session/agent-storage";
+import { SessionManager } from "../src/session/session-manager";
+
+// ---------------------------------------------------------------------------
+// Minimal model
+// ---------------------------------------------------------------------------
+
+const TEST_MODEL: Model = {
+	id: "claude-sonnet-4-20250514",
+	name: "Claude Sonnet",
+	api: "anthropic-messages",
+	provider: "anthropic",
+	baseUrl: "https://example.invalid",
+	reasoning: true,
+	input: ["text", "image"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 200_000,
+	maxTokens: 8_192,
+};
+
+function makeAssistantMessage() {
+	return {
+		role: "assistant" as const,
+		content: [{ type: "text" as const, text: "skill pong" }],
+		api: "anthropic-messages" as const,
+		provider: "anthropic" as const,
+		model: TEST_MODEL.id,
+		usage: {
+			input: 1,
+			output: 1,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 2,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "stop" as const,
+		timestamp: Date.now(),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// FakeAgentSession — emits lifecycle events so AcpAgent prompt turn settles
+// ---------------------------------------------------------------------------
+
+class FakeAgentSession {
+	sessionManager: SessionManager;
+	sessionId: string;
+	agent: { sessionId: string; waitForIdle: () => Promise<void> };
+	model: Model | undefined = TEST_MODEL;
+	thinkingLevel: string | undefined;
+	customCommands: [] = [];
+	extensionRunner = undefined;
+	isStreaming = false;
+	queuedMessageCount = 0;
+	systemPrompt = "system";
+	disposed = false;
+	fastMode = false;
+	forcedToolChoice: string | undefined;
+	get settings(): Settings {
+		return Settings.instance;
+	}
+	promptCalls: string[] = [];
+	customMessages: Array<{ customType: string; content: string; details?: unknown }> = [];
+	skillsSettings = { enableSkillCommands: true };
+	skills: Array<{ name: string; description: string; filePath: string; baseDir: string; source: string }> = [];
+	planModeState: PlanModeState | undefined;
+	#listeners = new Set<(event: AgentSessionEvent) => void>();
+
+	constructor(cwd: string) {
+		this.sessionManager = SessionManager.create(cwd);
+		this.sessionId = this.sessionManager.getSessionId();
+		this.agent = {
+			sessionId: this.sessionId,
+			waitForIdle: async () => this.waitForIdle(),
+		};
+	}
+
+	get sessionName(): string {
+		return this.sessionManager.getHeader()?.title ?? `Session ${this.sessionId}`;
+	}
+
+	get modelRegistry(): { getApiKey: (model: Model) => Promise<string> } {
+		return { getApiKey: async () => "test-key" };
+	}
+
+	getAvailableModels(): Model[] {
+		return [TEST_MODEL];
+	}
+
+	getAvailableThinkingLevels(): ReadonlyArray<string> {
+		return ["low", "medium", "high"];
+	}
+
+	setThinkingLevel(level: string | undefined): void {
+		this.thinkingLevel = level;
+	}
+
+	setSlashCommands(_commands: unknown[]): void {}
+
+	async refreshSshTool(): Promise<void> {}
+
+	async setModel(model: Model): Promise<void> {
+		this.model = model;
+	}
+
+	subscribe(listener: (event: AgentSessionEvent) => void): () => void {
+		this.#listeners.add(listener);
+		return () => this.#listeners.delete(listener);
+	}
+
+	#emit(event: AgentSessionEvent): void {
+		for (const listener of this.#listeners) {
+			listener(event);
+		}
+	}
+
+	async prompt(text: string): Promise<void> {
+		this.promptCalls.push(text);
+		this.isStreaming = true;
+		const msg = makeAssistantMessage();
+		this.#emit({
+			type: "message_update",
+			message: msg,
+			assistantMessageEvent: { type: "text_delta", delta: "skill pong" },
+		} as AgentSessionEvent);
+		this.sessionManager.appendMessage(msg);
+		this.#emit({ type: "agent_end", messages: [msg] } as AgentSessionEvent);
+		this.isStreaming = false;
+	}
+
+	async waitForIdle(): Promise<void> {}
+
+	async drainAsyncJobDeliveriesForAcp(): Promise<boolean> {
+		return false;
+	}
+
+	async abort(): Promise<void> {
+		this.isStreaming = false;
+	}
+
+	/** Must emit agent_end so AcpAgent's prompt turn settles. */
+	async promptCustomMessage(message: { customType: string; content: string; details?: unknown }): Promise<void> {
+		this.customMessages.push(message);
+		this.isStreaming = true;
+		const msg = makeAssistantMessage();
+		this.#emit({
+			type: "message_update",
+			message: msg,
+			assistantMessageEvent: { type: "text_delta", delta: "skill pong" },
+		} as AgentSessionEvent);
+		this.sessionManager.appendMessage(msg);
+		this.#emit({ type: "agent_end", messages: [msg] } as AgentSessionEvent);
+		this.isStreaming = false;
+	}
+
+	async refreshMCPTools(): Promise<void> {}
+
+	getContextUsage(): undefined {
+		return undefined;
+	}
+
+	async switchSession(sessionPath: string): Promise<boolean> {
+		await this.sessionManager.setSessionFile(sessionPath);
+		this.sessionId = this.sessionManager.getSessionId();
+		this.agent.sessionId = this.sessionId;
+		return true;
+	}
+
+	async dispose(): Promise<void> {
+		this.disposed = true;
+		await this.sessionManager.close();
+	}
+
+	async reload(): Promise<void> {}
+
+	async newSession(): Promise<boolean> {
+		await this.sessionManager.newSession();
+		this.sessionId = this.sessionManager.getSessionId();
+		this.agent.sessionId = this.sessionId;
+		return true;
+	}
+
+	async branch(): Promise<{ cancelled: boolean }> {
+		return { cancelled: false };
+	}
+
+	async navigateTree(): Promise<{ cancelled: boolean }> {
+		return { cancelled: false };
+	}
+
+	getActiveToolNames(): string[] {
+		return [];
+	}
+
+	getAllToolNames(): string[] {
+		return [];
+	}
+
+	setActiveToolsByName(): void {}
+	setClientBridge(): void {}
+
+	getPlanModeState(): PlanModeState | undefined {
+		return this.planModeState;
+	}
+
+	setPlanModeState(state: PlanModeState | undefined): void {
+		this.planModeState = state;
+	}
+
+	standingResolveHandler: ((input: unknown) => Promise<unknown> | unknown) | undefined;
+
+	setStandingResolveHandler(handler: ((input: unknown) => Promise<unknown> | unknown) | null): void {
+		this.standingResolveHandler = handler ?? undefined;
+	}
+
+	peekStandingResolveHandler(): ((input: unknown) => Promise<unknown> | unknown) | undefined {
+		return this.standingResolveHandler;
+	}
+
+	planReferencePath: string | undefined;
+
+	setPlanReferencePath(p: string): void {
+		this.planReferencePath = p;
+	}
+
+	getToolByName(): undefined {
+		return undefined;
+	}
+
+	toggleFastMode(): boolean {
+		this.fastMode = !this.fastMode;
+		return this.fastMode;
+	}
+
+	setFastMode(enabled: boolean): void {
+		this.fastMode = enabled;
+	}
+
+	isFastModeEnabled(): boolean {
+		return this.fastMode;
+	}
+
+	setForcedToolChoice(toolName: string): void {
+		this.forcedToolChoice = toolName;
+	}
+
+	async sendCustomMessage(): Promise<void> {}
+	async sendUserMessage(): Promise<void> {}
+	async compact(): Promise<void> {}
+
+	async fork(): Promise<boolean> {
+		await this.sessionManager.flush();
+		const forked = await this.sessionManager.fork();
+		if (!forked) return false;
+		this.sessionId = this.sessionManager.getSessionId();
+		this.agent.sessionId = this.sessionId;
+		return true;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+const cleanupRoots: string[] = [];
+const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+const fallbackAgentDir = path.join(getConfigRootDir(), "agent");
+
+afterEach(async () => {
+	if (originalAgentDir) {
+		setAgentDir(originalAgentDir);
+	} else {
+		setAgentDir(fallbackAgentDir);
+		delete process.env.PI_CODING_AGENT_DIR;
+	}
+	resetSettingsForTest();
+	for (const root of cleanupRoots.splice(0)) {
+		await fs.promises.rm(root, { recursive: true, force: true });
+	}
+});
+
+async function createHarness(): Promise<{
+	agent: AcpAgent;
+	fakeSession: FakeAgentSession;
+	sessionId: string;
+}> {
+	const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-acp-skill-track-"));
+	cleanupRoots.push(root);
+	const agentDir = path.join(root, "agent");
+	const cwd = path.join(root, "cwd");
+	await fs.promises.mkdir(agentDir, { recursive: true });
+	await fs.promises.mkdir(cwd, { recursive: true });
+	setAgentDir(agentDir);
+	await Settings.init({ agentDir, inMemory: true });
+
+	const updates: SessionNotification[] = [];
+	const abortController = new AbortController();
+	const connection = {
+		sessionUpdate: async (notification: SessionNotification) => {
+			updates.push(notification);
+		},
+		signal: abortController.signal,
+		closed: Promise.withResolvers<void>().promise,
+	} as unknown as AgentSideConnection;
+
+	const fakeSession = new FakeAgentSession(cwd);
+	const agent = new AcpAgent(
+		connection,
+		async () => fakeSession as unknown as AgentSession,
+		fakeSession as unknown as AgentSession,
+	);
+
+	const created = await agent.newSession({ cwd, mcpServers: [] });
+	const sessionId = created.sessionId;
+	await Bun.sleep(ACP_BOOTSTRAP_RACE_GUARD_MS + 30);
+
+	return { agent, fakeSession, sessionId };
+}
+
+function makeFakeStorage(): AgentStorage & { _calls: string[] } {
+	const calls: string[] = [];
+	return {
+		_calls: calls,
+		recordSkillUsage(skillName: string) {
+			calls.push(skillName);
+		},
+	} as unknown as AgentStorage & { _calls: string[] };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AcpAgent #tryRunSkillCommand skill tracking", () => {
+	it("/skill:foo via ACP prompt records skill usage", async () => {
+		const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "omp-acp-skill-file-"));
+		cleanupRoots.push(tmpDir);
+		const skillFile = path.join(tmpDir, "SKILL.md");
+		await fs.promises.writeFile(skillFile, "# my-skill\nDoes things.\n");
+
+		const { agent, fakeSession, sessionId } = await createHarness();
+
+		fakeSession.skills.push({
+			name: "my-skill",
+			description: "A test skill",
+			filePath: skillFile,
+			baseDir: tmpDir,
+			source: "test",
+		});
+
+		const storage = makeFakeStorage();
+		spyOn(Settings.instance, "getStorage").mockReturnValue(storage);
+
+		await agent.prompt({
+			sessionId,
+			prompt: [{ type: "text", text: "/skill:my-skill" }],
+		} as PromptRequest);
+
+		expect(storage._calls).toEqual(["my-skill"]);
+	});
+
+	it("unknown /skill:missing via ACP prompt does NOT record usage", async () => {
+		const { agent, sessionId } = await createHarness();
+
+		const storage = makeFakeStorage();
+		spyOn(Settings.instance, "getStorage").mockReturnValue(storage);
+
+		await agent.prompt({
+			sessionId,
+			prompt: [{ type: "text", text: "/skill:missing" }],
+		} as PromptRequest);
+
+		expect(storage._calls).toEqual([]);
+	});
+});

--- a/packages/coding-agent/test/agent-session-skill-discovery.test.ts
+++ b/packages/coding-agent/test/agent-session-skill-discovery.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Integration coverage for the real AgentSession skill-discovery gate.
+ *
+ * The BM25 unit tests exercise hand-rolled mock sessions; they never touch the
+ * actual `AgentSession.isSkillDiscoveryEnabled()` / `getDiscoverableTools()`
+ * implementations. This file pins three integration seams at the class level:
+ *
+ *   (a) `isSkillDiscoveryEnabled()` returns false when the frozen
+ *       `#deferredSkillEntries` set is empty — even when the live
+ *       `skills.redactDescriptions` flag is true.
+ *   (b) `getDiscoverableTools()` returns deferred skill entries even under
+ *       `discoveryMode:"off"` (the effective default for an empty registry),
+ *       and honors the `{ source: "skill" }` filter.
+ *   (c) A mid-session toggle of `skills.redactDescriptions` changes the gate
+ *       outcome (because the gate reads live settings) without mutating the
+ *       frozen deferred set returned by `getDiscoverableTools()`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { getBundledModel } from "@oh-my-pi/pi-ai";
+import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
+import { AsyncJobManager } from "@oh-my-pi/pi-coding-agent/async";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import type { DiscoverableTool } from "@oh-my-pi/pi-coding-agent/tool-discovery/tool-index";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+
+describe("AgentSession skill discovery gate", () => {
+	let tempDir: string;
+	const sessions: AgentSession[] = [];
+	const authStorages: AuthStorage[] = [];
+
+	beforeEach(() => {
+		tempDir = path.join(os.tmpdir(), `pi-skill-discovery-test-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		for (const session of sessions.splice(0)) {
+			await session.dispose();
+		}
+		for (const authStorage of authStorages.splice(0)) {
+			authStorage.close();
+		}
+		if (tempDir && fs.existsSync(tempDir)) {
+			fs.rmSync(tempDir, { recursive: true });
+		}
+		vi.restoreAllMocks();
+		AsyncJobManager.resetForTests();
+	});
+
+	/**
+	 * Build a real AgentSession with the supplied settings overrides and deferred
+	 * skill entries. Each call gets its own `Settings` instance so runtime
+	 * `override()` writes in one test cannot leak into siblings. The settings
+	 * reference is returned so tests can mutate it mid-session.
+	 */
+	async function createSession(options: {
+		settingsOverrides?: Partial<Record<"skills.redactDescriptions" | "tools.discoveryMode", unknown>>;
+		deferredSkillEntries?: readonly DiscoverableTool[];
+		skillsSettings?: { redactDescriptions?: boolean };
+	}): Promise<{ session: AgentSession; settings: Settings }> {
+		const model = getBundledModel("anthropic", "claude-sonnet-4-5")!;
+		const agent = new Agent({
+			getApiKey: () => "test-key",
+			initialState: {
+				model,
+				systemPrompt: ["Test"],
+				tools: [],
+			},
+			streamFn: () => new AssistantMessageEventStream(),
+		});
+
+		const sessionManager = SessionManager.inMemory();
+		const settings = Settings.isolated(options.settingsOverrides ?? {});
+		const authStorage = await AuthStorage.create(path.join(tempDir, `testauth-${Snowflake.next()}.db`));
+		authStorages.push(authStorage);
+		const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir, `models-${Snowflake.next()}.yml`));
+		authStorage.setRuntimeApiKey("anthropic", "test-key");
+
+		const session = new AgentSession({
+			agent,
+			sessionManager,
+			settings,
+			modelRegistry,
+			deferredSkillEntries: options.deferredSkillEntries,
+			skillsSettings: options.skillsSettings,
+		});
+		sessions.push(session);
+
+		return { session, settings };
+	}
+
+	function makeDeferredSkill(overrides?: Partial<DiscoverableTool>): DiscoverableTool {
+		return {
+			name: "my-skill",
+			label: "my-skill",
+			summary: "test skill",
+			source: "skill",
+			schemaKeys: [],
+			...overrides,
+		};
+	}
+
+	it("isSkillDiscoveryEnabled returns false when deferredSkillEntries is empty", async () => {
+		// The flag is genuinely on; the gate must still return false purely
+		// because the frozen deferred set is empty.
+		const { session } = await createSession({
+			settingsOverrides: { "skills.redactDescriptions": true },
+			deferredSkillEntries: [],
+			skillsSettings: { redactDescriptions: true },
+		});
+
+		expect(session.settings.get("skills.redactDescriptions")).toBe(true);
+		expect(session.isSkillDiscoveryEnabled()).toBe(false);
+	});
+
+	it("isSkillDiscoveryEnabled gate is driven by both the flag and a non-empty deferred set", async () => {
+		// Guards against (a) being a tautology: prove the gate also reacts to the
+		// flag and to a non-empty set, so the false result above is "false because
+		// empty" rather than "always false".
+
+		// flag true + non-empty deferred set → enabled.
+		const enabled = await createSession({
+			settingsOverrides: { "skills.redactDescriptions": true },
+			deferredSkillEntries: [makeDeferredSkill()],
+		});
+		expect(enabled.session.isSkillDiscoveryEnabled()).toBe(true);
+
+		// flag false + non-empty deferred set → disabled (flag gates it).
+		const flagOff = await createSession({
+			settingsOverrides: { "skills.redactDescriptions": false },
+			deferredSkillEntries: [makeDeferredSkill()],
+		});
+		expect(flagOff.session.isSkillDiscoveryEnabled()).toBe(false);
+	});
+
+	it("getDiscoverableTools includes deferred skills even under discoveryMode:'off'", async () => {
+		const deferredEntry = makeDeferredSkill();
+		const { session } = await createSession({
+			// Pin discoveryMode explicitly so the assertion does not depend on the
+			// empty-registry auto-resolution path.
+			settingsOverrides: { "tools.discoveryMode": "off" },
+			deferredSkillEntries: [deferredEntry],
+		});
+
+		// Deferred entries are appended unconditionally; they must survive the
+		// mode-gate that empties builtin/MCP tools under discoveryMode:"off".
+		const tools = session.getDiscoverableTools();
+		expect(tools.some(t => t.name === "my-skill")).toBe(true);
+
+		// Source filter narrows to the skill entry only.
+		const skillsOnly = session.getDiscoverableTools({ source: "skill" });
+		expect(skillsOnly).toHaveLength(1);
+		expect(skillsOnly[0].name).toBe("my-skill");
+		expect(skillsOnly[0].source).toBe("skill");
+	});
+
+	it("mid-session redactDescriptions toggle flips the gate without mutating the frozen deferred set", async () => {
+		const deferredEntry = makeDeferredSkill();
+		// Start with the flag explicitly off so the initial assertion is meaningful.
+		const { session, settings } = await createSession({
+			settingsOverrides: { "skills.redactDescriptions": false, "tools.discoveryMode": "off" },
+			deferredSkillEntries: [deferredEntry],
+		});
+
+		// Flag off + non-empty deferred set → gate closed; entries still surface.
+		expect(session.isSkillDiscoveryEnabled()).toBe(false);
+		const before = session.getDiscoverableTools();
+		expect(before.some(t => t.name === "my-skill")).toBe(true);
+
+		// Toggle the live flag on (runtime override, not persisted).
+		settings.override("skills.redactDescriptions", true);
+
+		// The gate reads live settings → now open.
+		expect(session.isSkillDiscoveryEnabled()).toBe(true);
+
+		// The deferred set is frozen at init; getDiscoverableTools never reads
+		// redactDescriptions, so the discoverable set is unchanged by the toggle.
+		const after = session.getDiscoverableTools();
+		expect(after).toEqual(before);
+
+		// Toggling back off re-closes the gate, still without touching the set.
+		settings.override("skills.redactDescriptions", false);
+		expect(session.isSkillDiscoveryEnabled()).toBe(false);
+		expect(session.getDiscoverableTools()).toEqual(before);
+	});
+});

--- a/packages/coding-agent/test/agent-storage-skill-usage.test.ts
+++ b/packages/coding-agent/test/agent-storage-skill-usage.test.ts
@@ -154,4 +154,23 @@ describe("AgentStorage skill_usage tracking", () => {
 		// After one half-life, initial score of 1 decays to 0.5
 		expect(usage[0].score).toBeCloseTo(0.5, 4);
 	});
+
+	it("throttle boundary: dt=300s exactly is NOT throttled (strict < 300)", async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-skill-usage-boundary-"));
+		const dbPath = path.join(tempDir, "agent.db");
+
+		const baseTime = new Date("2026-01-01T00:00:00Z");
+		setSystemTime(baseTime);
+
+		const storage = await AgentStorage.open(dbPath);
+		storage.recordSkillUsage("read_file");
+
+		// Advance by exactly 300s — condition is `< 300`, so dt=300 is NOT throttled
+		setSystemTime(new Date(baseTime.getTime() + 300_000));
+		storage.recordSkillUsage("read_file");
+
+		const usage = storage.getSkillUsage();
+		expect(usage).toHaveLength(1);
+		expect(usage[0].totalCount).toBe(2);
+	});
 });

--- a/packages/coding-agent/test/agent-storage-skill-usage.test.ts
+++ b/packages/coding-agent/test/agent-storage-skill-usage.test.ts
@@ -1,0 +1,157 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, it, setSystemTime } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AgentStorage } from "../src/session/agent-storage";
+import { readTableSql } from "./helpers/sqlite-inspect";
+
+const HALF_LIFE_DAYS = 21;
+const HALF_LIFE_MS = HALF_LIFE_DAYS * 86_400 * 1000;
+const THROTTLE_SECS = 300;
+
+describe("AgentStorage skill_usage tracking", () => {
+	let tempDir = "";
+
+	afterEach(async () => {
+		// Reset fake time after each test
+		setSystemTime();
+		if (tempDir) {
+			await fs.rm(tempDir, { recursive: true, force: true });
+			tempDir = "";
+		}
+	});
+
+	it("round-trip: record once, getSkillUsage returns the skill with score ≈ 1.0", async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-skill-usage-roundtrip-"));
+		const dbPath = path.join(tempDir, "agent.db");
+
+		const baseTime = new Date("2026-01-01T00:00:00Z");
+		setSystemTime(baseTime);
+
+		const storage = await AgentStorage.open(dbPath);
+
+		storage.recordSkillUsage("bash");
+
+		// Pin time to same moment to avoid decay (dt = 0 → score = 1.0)
+		setSystemTime(baseTime);
+
+		const usage = storage.getSkillUsage();
+		expect(usage).toHaveLength(1);
+		expect(usage[0].name).toBe("bash");
+		expect(usage[0].score).toBeCloseTo(1.0, 5);
+		expect(usage[0].totalCount).toBe(1);
+	});
+
+	it("throttle: second call within 300s is skipped, total_count stays at 1", async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-skill-usage-throttle-"));
+		const dbPath = path.join(tempDir, "agent.db");
+
+		const baseTime = new Date("2026-01-01T00:00:00Z");
+		setSystemTime(baseTime);
+
+		const storage = await AgentStorage.open(dbPath);
+		storage.recordSkillUsage("read_file");
+
+		// Advance by 299 seconds — still within throttle window
+		setSystemTime(new Date(baseTime.getTime() + 299_000));
+		storage.recordSkillUsage("read_file");
+
+		const usage = storage.getSkillUsage();
+		expect(usage).toHaveLength(1);
+		expect(usage[0].totalCount).toBe(1);
+	});
+
+	it("no-throttle: record past 300s window increments total_count to 2", async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-skill-usage-nothrottle-"));
+		const dbPath = path.join(tempDir, "agent.db");
+
+		const baseTime = new Date("2026-01-01T00:00:00Z");
+		setSystemTime(baseTime);
+
+		const storage = await AgentStorage.open(dbPath);
+		storage.recordSkillUsage("write_file");
+
+		// Advance by 301 seconds — past the throttle window
+		setSystemTime(new Date(baseTime.getTime() + 301_000));
+		storage.recordSkillUsage("write_file");
+
+		const usage = storage.getSkillUsage();
+		expect(usage).toHaveLength(1);
+		expect(usage[0].totalCount).toBe(2);
+	});
+
+	it("total_count increments correctly across multiple allowed recordings", async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-skill-usage-count-"));
+		const dbPath = path.join(tempDir, "agent.db");
+
+		const baseTime = new Date("2026-01-01T00:00:00Z");
+		setSystemTime(baseTime);
+
+		const storage = await AgentStorage.open(dbPath);
+
+		for (let i = 0; i < 5; i++) {
+			setSystemTime(new Date(baseTime.getTime() + i * 301_000));
+			storage.recordSkillUsage("grep");
+		}
+
+		const usage = storage.getSkillUsage();
+		expect(usage[0].name).toBe("grep");
+		expect(usage[0].totalCount).toBe(5);
+	});
+
+	it("v5→v6 migration: open a v5 DB, migrates cleanly and skill_usage table exists", async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-skill-usage-migrate-"));
+		const dbPath = path.join(tempDir, "agent.db");
+
+		// Seed a v5 database (no skill_usage table)
+		const legacyDb = new Database(dbPath);
+		legacyDb.exec(`
+			CREATE TABLE schema_version (version INTEGER PRIMARY KEY);
+			INSERT INTO schema_version(version) VALUES (5);
+			CREATE TABLE settings (
+				key TEXT PRIMARY KEY,
+				value TEXT NOT NULL,
+				updated_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s','now') AS INTEGER))
+			);
+			CREATE TABLE model_usage (
+				model_key TEXT PRIMARY KEY,
+				last_used_at INTEGER NOT NULL DEFAULT (CAST(strftime('%s','now') AS INTEGER))
+			);
+		`);
+		legacyDb.close();
+
+		const storage = await AgentStorage.open(dbPath);
+
+		// skill_usage table should now exist
+		const tableSql = readTableSql(dbPath, "skill_usage");
+		expect(tableSql).not.toBeNull();
+		expect(tableSql).toContain("skill_name");
+		expect(tableSql).toContain("decayed_count");
+
+		// Should be able to record and retrieve skill usage on migrated DB
+		storage.recordSkillUsage("ls");
+		const usage = storage.getSkillUsage();
+		expect(usage).toHaveLength(1);
+		expect(usage[0].name).toBe("ls");
+	});
+
+	it("decay math: score after one half-life ≈ 0.5", async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-skill-usage-decay-"));
+		const dbPath = path.join(tempDir, "agent.db");
+
+		const baseTime = new Date("2026-01-01T00:00:00Z");
+		setSystemTime(baseTime);
+
+		const storage = await AgentStorage.open(dbPath);
+		storage.recordSkillUsage("edit_file");
+
+		// Advance by exactly one half-life
+		setSystemTime(new Date(baseTime.getTime() + HALF_LIFE_MS));
+
+		const usage = storage.getSkillUsage();
+		expect(usage).toHaveLength(1);
+		// After one half-life, initial score of 1 decays to 0.5
+		expect(usage[0].score).toBeCloseTo(0.5, 4);
+	});
+});

--- a/packages/coding-agent/test/agent-storage-skill-usage.test.ts
+++ b/packages/coding-agent/test/agent-storage-skill-usage.test.ts
@@ -8,7 +8,6 @@ import { readTableSql } from "./helpers/sqlite-inspect";
 
 const HALF_LIFE_DAYS = 21;
 const HALF_LIFE_MS = HALF_LIFE_DAYS * 86_400 * 1000;
-const THROTTLE_SECS = 300;
 
 describe("AgentStorage skill_usage tracking", () => {
 	let tempDir = "";

--- a/packages/coding-agent/test/agent-storage-sqlite-compat.test.ts
+++ b/packages/coding-agent/test/agent-storage-sqlite-compat.test.ts
@@ -51,7 +51,7 @@ describe("AgentStorage SQLite compatibility", () => {
 		storage.recordModelUsage("openai/gpt-5");
 
 		expect(storage.getModelUsageOrder()).toEqual(["openai/gpt-5"]);
-		expect(readSchemaVersion(dbPath)).toBe(5);
+		expect(readSchemaVersion(dbPath)).toBe(6);
 		expect(readTableSql(dbPath, "settings")).not.toContain("unixepoch(");
 		expect(readTableSql(dbPath, "settings")).toContain("strftime('%s','now')");
 		expect(readTableSql(dbPath, "model_usage")).not.toContain("unixepoch(");
@@ -85,7 +85,7 @@ describe("AgentStorage SQLite compatibility", () => {
 
 		const storage = await AgentStorage.open(dbPath);
 
-		expect(readSchemaVersion(dbPath)).toBe(5);
+		expect(readSchemaVersion(dbPath)).toBe(6);
 		expect(readTableSql(dbPath, "settings")).not.toContain("unixepoch(");
 		expect(readTableSql(dbPath, "settings")).toContain("strftime('%s','now')");
 		expect(readTableSql(dbPath, "model_usage")).not.toContain("unixepoch(");

--- a/packages/coding-agent/test/extensibility/skill-frequency.test.ts
+++ b/packages/coding-agent/test/extensibility/skill-frequency.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { computeFrequentSkillNames } from "@oh-my-pi/pi-coding-agent/extensibility/skill-frequency";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AgentStorage } from "../../src/session/agent-storage";
+import { computeFrequentSkillNames, resolveFrequentSkillNames } from "@oh-my-pi/pi-coding-agent/extensibility/skill-frequency";
 
 const skills = (names: string[]) => names.map(name => ({ name, hide: false }));
 const NOW = 1_700_000_000;
@@ -55,9 +59,11 @@ describe("computeFrequentSkillNames", () => {
 	});
 
 	it("alphabetical tiebreak for zero-score skills", () => {
+		// Use a loaded skill ("zzz") to carry the warmup count so the gate passes.
+		// All three have score 0 and stale timestamps; alphabetical top-2 picks "aaa" and "mmm".
 		const result = computeFrequentSkillNames({
 			skills: skills(["zzz", "aaa", "mmm"]),
-			usage: [{ name: "dummy", score: 0, lastUsedAt: 0, totalCount: 10 }],
+			usage: [{ name: "zzz", score: 0, lastUsedAt: NOW - 86_400 * 30, totalCount: 10 }],
 			frequentCount: 2,
 			alwaysInclude: [],
 			nowSec: NOW,
@@ -80,5 +86,136 @@ describe("computeFrequentSkillNames", () => {
 		});
 		expect(result.has("visible")).toBe(true);
 		expect(result.has("hidden")).toBe(false);
+	});
+
+	it("warmup accumulates across multiple rows: 5+5=10 crosses threshold", () => {
+		// Use stale timestamps (> 7 days) so neither skill qualifies via recent-7d path.
+		// Only top-N applies; "a" wins with higher score, result size = 1.
+		const result = computeFrequentSkillNames({
+			skills: skills(["a", "b", "c"]),
+			usage: [
+				{ name: "a", score: 5, lastUsedAt: NOW - 86_400 * 30, totalCount: 5 },
+				{ name: "b", score: 3, lastUsedAt: NOW - 86_400 * 30, totalCount: 5 },
+			],
+			frequentCount: 1,
+			alwaysInclude: [],
+			nowSec: NOW,
+		});
+		// Total loaded invocations = 10, threshold crossed → top-N applies (only 1)
+		expect(result.has("a")).toBe(true);
+		expect(result.size).toBe(1);
+	});
+
+	it("warmup: uninstalled-skill totalCount is excluded from threshold sum", () => {
+		// "ghost" has 9 invocations but is not in the loaded skills list → should not count
+		const result = computeFrequentSkillNames({
+			skills: skills(["a", "b", "c"]), // no "ghost"
+			usage: [
+				{ name: "ghost", score: 5, lastUsedAt: NOW - 100, totalCount: 9 },
+				{ name: "a", score: 1, lastUsedAt: NOW - 100, totalCount: 1 },
+			],
+			frequentCount: 1,
+			alwaysInclude: [],
+			nowSec: NOW,
+		});
+		// Only "a" counts toward warmup (totalCount=1), ghost is unloaded; total=1 < 10 → full list
+		expect([...result].sort()).toEqual(["a", "b", "c"]);
+	});
+});
+
+const CACHE_KEY = "skills.frequentSet";
+// T0 is used for pure-computation tests only; SQLite cache tests use actual clock.
+const T0 = 1_700_000_000;
+
+describe("resolveFrequentSkillNames", () => {
+	async function withStorage(fn: (storage: AgentStorage, dbPath: string) => Promise<void>): Promise<void> {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-skill-freq-"));
+		try {
+			const dbPath = path.join(tempDir, "agent.db");
+			const storage = await AgentStorage.open(dbPath);
+			await fn(storage, dbPath);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	}
+
+	it("cache hit: matching hash returns cached names without recomputing", async () => {
+		await withStorage(async storage => {
+			const skillList = [{ name: "alpha", hide: false }, { name: "beta", hide: false }];
+			const settings = { frequentCount: 1, alwaysInclude: [] };
+
+			// Prime the cache with a far-future expiry (SQLite strftime uses OS clock,
+			// so we must set a TTL that's in the future by the real wall clock).
+			const nowSec = Math.floor(Date.now() / 1000);
+			const nonHiddenNames = ["alpha", "beta"].sort();
+			const settingsHash = JSON.stringify({
+				frequentCount: settings.frequentCount,
+				alwaysInclude: [],
+				skillNames: nonHiddenNames,
+			});
+			const payload = JSON.stringify({ settingsHash, names: ["alpha"] });
+			storage.setCache(CACHE_KEY, payload, nowSec + 86_400 * 365);
+
+			const result = resolveFrequentSkillNames(storage, skillList, settings, nowSec);
+			expect([...result]).toEqual(["alpha"]);
+		});
+	});
+
+	it("cache hit with hash mismatch (different frequentCount) triggers recompute", async () => {
+		await withStorage(async storage => {
+			const skillList = [{ name: "a", hide: false }, { name: "b", hide: false }];
+			// Write cache with frequentCount: 1
+			const settingsHashOld = JSON.stringify({ frequentCount: 1, alwaysInclude: [], skillNames: ["a", "b"] });
+			storage.setCache(CACHE_KEY, JSON.stringify({ settingsHash: settingsHashOld, names: ["a"] }), T0 + 86_400);
+
+			// Record enough usage so warmup passes and top-N produces "b" (higher score)
+			for (let i = 0; i < 10; i++) {
+				storage.recordSkillUsage("b");
+			}
+
+			// Now resolve with frequentCount: 2 — hash won't match
+			const result = resolveFrequentSkillNames(storage, skillList, { frequentCount: 2, alwaysInclude: [] }, T0 + 86_401 * 100);
+			// Both a and b should be in the result (frequentCount=2, 2 skills)
+			expect(result.has("a")).toBe(true);
+			expect(result.has("b")).toBe(true);
+		});
+	});
+
+	it("null storage: computes without throwing and returns a Set", () => {
+		const skillList = [{ name: "x", hide: false }];
+		const settings = { frequentCount: 5, alwaysInclude: [] };
+		// Should not throw; warmup gate fires (no usage) → all skills returned
+		const result = resolveFrequentSkillNames(null, skillList, settings, T0);
+		expect(result instanceof Set).toBe(true);
+		expect(result.has("x")).toBe(true);
+	});
+
+	it("writes cache with TTL = nowSec + 86400 on recompute", async () => {
+		await withStorage(async storage => {
+			const skillList = [{ name: "a", hide: false }];
+			const settings = { frequentCount: 5, alwaysInclude: [] };
+			// Use actual wall-clock time so the written TTL (nowSec + 86400) is in the future
+			// and SQLite's strftime('now') considers it unexpired on the subsequent getCache call.
+			const nowSec = Math.floor(Date.now() / 1000);
+			resolveFrequentSkillNames(storage, skillList, settings, nowSec);
+
+			// Cache should now exist and be readable
+			const raw = storage.getCache(CACHE_KEY);
+			expect(raw).not.toBeNull();
+			const parsed = JSON.parse(raw!);
+			expect(Array.isArray(parsed.names)).toBe(true);
+		});
+	});
+
+	it("corrupt JSON in cache silently falls back to recompute", async () => {
+		await withStorage(async storage => {
+			storage.setCache(CACHE_KEY, "not-valid-json{{{", T0 + 86_400);
+			const skillList = [{ name: "a", hide: false }];
+			const settings = { frequentCount: 5, alwaysInclude: [] };
+			// Should not throw
+			expect(() => resolveFrequentSkillNames(storage, skillList, settings, T0)).not.toThrow();
+			const result = resolveFrequentSkillNames(storage, skillList, settings, T0);
+			expect(result.has("a")).toBe(true);
+		});
 	});
 });

--- a/packages/coding-agent/test/extensibility/skill-frequency.test.ts
+++ b/packages/coding-agent/test/extensibility/skill-frequency.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import {
+	computeFrequentSkillNames,
+	resolveFrequentSkillNames,
+} from "@oh-my-pi/pi-coding-agent/extensibility/skill-frequency";
 import { AgentStorage } from "../../src/session/agent-storage";
-import { computeFrequentSkillNames, resolveFrequentSkillNames } from "@oh-my-pi/pi-coding-agent/extensibility/skill-frequency";
 
 const skills = (names: string[]) => names.map(name => ({ name, hide: false }));
 const NOW = 1_700_000_000;
@@ -141,7 +144,10 @@ describe("resolveFrequentSkillNames", () => {
 
 	it("cache hit: matching hash returns cached names without recomputing", async () => {
 		await withStorage(async storage => {
-			const skillList = [{ name: "alpha", hide: false }, { name: "beta", hide: false }];
+			const skillList = [
+				{ name: "alpha", hide: false },
+				{ name: "beta", hide: false },
+			];
 			const settings = { frequentCount: 1, alwaysInclude: [] };
 
 			// Prime the cache with a far-future expiry (SQLite strftime uses OS clock,
@@ -163,7 +169,10 @@ describe("resolveFrequentSkillNames", () => {
 
 	it("cache hit with hash mismatch (different frequentCount) triggers recompute", async () => {
 		await withStorage(async storage => {
-			const skillList = [{ name: "a", hide: false }, { name: "b", hide: false }];
+			const skillList = [
+				{ name: "a", hide: false },
+				{ name: "b", hide: false },
+			];
 			// Write cache with frequentCount: 1
 			const settingsHashOld = JSON.stringify({ frequentCount: 1, alwaysInclude: [], skillNames: ["a", "b"] });
 			storage.setCache(CACHE_KEY, JSON.stringify({ settingsHash: settingsHashOld, names: ["a"] }), T0 + 86_400);
@@ -174,7 +183,12 @@ describe("resolveFrequentSkillNames", () => {
 			}
 
 			// Now resolve with frequentCount: 2 — hash won't match
-			const result = resolveFrequentSkillNames(storage, skillList, { frequentCount: 2, alwaysInclude: [] }, T0 + 86_401 * 100);
+			const result = resolveFrequentSkillNames(
+				storage,
+				skillList,
+				{ frequentCount: 2, alwaysInclude: [] },
+				T0 + 86_401 * 100,
+			);
 			// Both a and b should be in the result (frequentCount=2, 2 skills)
 			expect(result.has("a")).toBe(true);
 			expect(result.has("b")).toBe(true);

--- a/packages/coding-agent/test/extensibility/skill-frequency.test.ts
+++ b/packages/coding-agent/test/extensibility/skill-frequency.test.ts
@@ -173,9 +173,14 @@ describe("resolveFrequentSkillNames", () => {
 				{ name: "a", hide: false },
 				{ name: "b", hide: false },
 			];
+			// Use wall-clock-relative TTL so the row is live when getCache runs.
+			// T0 + 86_400 is Nov 2023 + 1 day — already expired by the OS clock — so
+			// getCache's `expires_at > strftime('%s','now')` returns null before the
+			// settingsHash comparison is ever reached.
+			const nowSec = Math.floor(Date.now() / 1000);
 			// Write cache with frequentCount: 1
 			const settingsHashOld = JSON.stringify({ frequentCount: 1, alwaysInclude: [], skillNames: ["a", "b"] });
-			storage.setCache(CACHE_KEY, JSON.stringify({ settingsHash: settingsHashOld, names: ["a"] }), T0 + 86_400);
+			storage.setCache(CACHE_KEY, JSON.stringify({ settingsHash: settingsHashOld, names: ["a"] }), nowSec + 86_400);
 
 			// Record enough usage so warmup passes and top-N produces "b" (higher score)
 			for (let i = 0; i < 10; i++) {
@@ -183,12 +188,7 @@ describe("resolveFrequentSkillNames", () => {
 			}
 
 			// Now resolve with frequentCount: 2 — hash won't match
-			const result = resolveFrequentSkillNames(
-				storage,
-				skillList,
-				{ frequentCount: 2, alwaysInclude: [] },
-				T0 + 86_401 * 100,
-			);
+			const result = resolveFrequentSkillNames(storage, skillList, { frequentCount: 2, alwaysInclude: [] }, nowSec);
 			// Both a and b should be in the result (frequentCount=2, 2 skills)
 			expect(result.has("a")).toBe(true);
 			expect(result.has("b")).toBe(true);
@@ -223,12 +223,17 @@ describe("resolveFrequentSkillNames", () => {
 
 	it("corrupt JSON in cache silently falls back to recompute", async () => {
 		await withStorage(async storage => {
-			storage.setCache(CACHE_KEY, "not-valid-json{{{", T0 + 86_400);
+			// Use wall-clock-relative TTL so the corrupt row is live when getCache runs.
+			// T0 + 86_400 is Nov 2023 + 1 day — already expired — so without this fix
+			// getCache returns null from TTL expiry before JSON.parse is ever reached,
+			// leaving the try/catch in resolveFrequentSkillNames untested.
+			const nowSec = Math.floor(Date.now() / 1000);
+			storage.setCache(CACHE_KEY, "not-valid-json{{{", nowSec + 86_400);
 			const skillList = [{ name: "a", hide: false }];
 			const settings = { frequentCount: 5, alwaysInclude: [] };
-			// Should not throw
-			expect(() => resolveFrequentSkillNames(storage, skillList, settings, T0)).not.toThrow();
-			const result = resolveFrequentSkillNames(storage, skillList, settings, T0);
+			// Should not throw — getCache returns the live corrupt row, JSON.parse fires, catch handles it
+			expect(() => resolveFrequentSkillNames(storage, skillList, settings, nowSec)).not.toThrow();
+			const result = resolveFrequentSkillNames(storage, skillList, settings, nowSec);
 			expect(result.has("a")).toBe(true);
 		});
 	});

--- a/packages/coding-agent/test/extensibility/skill-frequency.test.ts
+++ b/packages/coding-agent/test/extensibility/skill-frequency.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, setSystemTime } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -172,26 +172,31 @@ describe("resolveFrequentSkillNames", () => {
 			const skillList = [
 				{ name: "a", hide: false },
 				{ name: "b", hide: false },
+				{ name: "c", hide: false },
 			];
-			// Use wall-clock-relative TTL so the row is live when getCache runs.
-			// T0 + 86_400 is Nov 2023 + 1 day — already expired by the OS clock — so
-			// getCache's `expires_at > strftime('%s','now')` returns null before the
-			// settingsHash comparison is ever reached.
+			// Anchor TTL to real OS clock so SQLite's strftime('now') sees it as live.
 			const nowSec = Math.floor(Date.now() / 1000);
-			// Write cache with frequentCount: 1
-			const settingsHashOld = JSON.stringify({ frequentCount: 1, alwaysInclude: [], skillNames: ["a", "b"] });
+			// Write cache with frequentCount: 2 — will mismatch the resolve call below
+			const settingsHashOld = JSON.stringify({ frequentCount: 2, alwaysInclude: [], skillNames: ["a", "b", "c"] });
 			storage.setCache(CACHE_KEY, JSON.stringify({ settingsHash: settingsHashOld, names: ["a"] }), nowSec + 86_400);
 
-			// Record enough usage so warmup passes and top-N produces "b" (higher score)
-			for (let i = 0; i < 10; i++) {
-				storage.recordSkillUsage("b");
+			// Advance fake clock 301s per iteration so the 300s throttle clears each time.
+			const baseMs = Date.now();
+			try {
+				for (let i = 0; i < 10; i++) {
+					setSystemTime(baseMs + i * 301_000);
+					storage.recordSkillUsage("b");
+				}
+			} finally {
+				setSystemTime();
 			}
 
-			// Now resolve with frequentCount: 2 — hash won't match
-			const result = resolveFrequentSkillNames(storage, skillList, { frequentCount: 2, alwaysInclude: [] }, nowSec);
-			// Both a and b should be in the result (frequentCount=2, 2 skills)
-			expect(result.has("a")).toBe(true);
+			// Now resolve with frequentCount: 1 — hash won't match (old had 2)
+			const result = resolveFrequentSkillNames(storage, skillList, { frequentCount: 1, alwaysInclude: [] }, nowSec);
+			// "b" wins top-1 (10 usages); "a" and "c" are pruned — proves top-N ran
 			expect(result.has("b")).toBe(true);
+			expect(result.has("a")).toBe(false);
+			expect(result.size).toBe(1);
 		});
 	});
 

--- a/packages/coding-agent/test/extensibility/skill-frequency.test.ts
+++ b/packages/coding-agent/test/extensibility/skill-frequency.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "bun:test";
+import { computeFrequentSkillNames } from "@oh-my-pi/pi-coding-agent/extensibility/skill-frequency";
+
+const skills = (names: string[]) => names.map(name => ({ name, hide: false }));
+const NOW = 1_700_000_000;
+
+describe("computeFrequentSkillNames", () => {
+	it("warmup gate: returns all skills when totalCount < 10", () => {
+		const result = computeFrequentSkillNames({
+			skills: skills(["a", "b", "c"]),
+			usage: [{ name: "a", score: 5, lastUsedAt: NOW - 100, totalCount: 9 }],
+			frequentCount: 1, // would only return 1 without gate
+			alwaysInclude: [],
+			nowSec: NOW,
+		});
+		expect([...result].sort()).toEqual(["a", "b", "c"]);
+	});
+
+	it("top-N applies once totalCount >= 10", () => {
+		const result = computeFrequentSkillNames({
+			skills: skills(["a", "b", "c", "d"]),
+			usage: [{ name: "a", score: 5, lastUsedAt: NOW - 86400 * 30, totalCount: 10 }],
+			frequentCount: 1,
+			alwaysInclude: [],
+			nowSec: NOW,
+		});
+		expect(result.has("a")).toBe(true);
+		expect(result.size).toBe(1);
+	});
+
+	it("pin globs include matching skills regardless of score", () => {
+		const result = computeFrequentSkillNames({
+			skills: skills(["odin:foo", "other"]),
+			usage: [{ name: "other", score: 10, lastUsedAt: NOW - 100, totalCount: 20 }],
+			frequentCount: 1,
+			alwaysInclude: ["odin:*"],
+			nowSec: NOW,
+		});
+		expect(result.has("odin:foo")).toBe(true);
+	});
+
+	it("recent-7d override includes recently used skills", () => {
+		const result = computeFrequentSkillNames({
+			skills: skills(["new", "old"]),
+			usage: [
+				{ name: "new", score: 0.1, lastUsedAt: NOW - 86400, totalCount: 15 }, // 1 day ago
+				{ name: "old", score: 10, lastUsedAt: NOW - 86400 * 30, totalCount: 15 }, // 30 days ago
+			],
+			frequentCount: 1,
+			alwaysInclude: [],
+			nowSec: NOW,
+		});
+		// "new" is recent (< 7d), included regardless of low score
+		expect(result.has("new")).toBe(true);
+	});
+
+	it("alphabetical tiebreak for zero-score skills", () => {
+		const result = computeFrequentSkillNames({
+			skills: skills(["zzz", "aaa", "mmm"]),
+			usage: [{ name: "dummy", score: 0, lastUsedAt: 0, totalCount: 10 }],
+			frequentCount: 2,
+			alwaysInclude: [],
+			nowSec: NOW,
+		});
+		expect(result.has("aaa")).toBe(true);
+		expect(result.has("mmm")).toBe(true);
+		expect(result.has("zzz")).toBe(false);
+	});
+
+	it("hidden skills are excluded", () => {
+		const result = computeFrequentSkillNames({
+			skills: [
+				{ name: "visible", hide: false },
+				{ name: "hidden", hide: true },
+			],
+			usage: [{ name: "dummy", score: 0, lastUsedAt: 0, totalCount: 10 }],
+			frequentCount: 5,
+			alwaysInclude: [],
+			nowSec: NOW,
+		});
+		expect(result.has("visible")).toBe(true);
+		expect(result.has("hidden")).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -88,6 +88,7 @@ function createStubInputControllerContext(opts: { skillCommands: Map<string, str
 			enqueueCustomMessageDisplay,
 			promptCustomMessage,
 		},
+		settings: Settings.isolated(),
 		showError,
 		updatePendingMessagesDisplay,
 		// Defaults that InputController touches on submit but don't matter here.

--- a/packages/coding-agent/test/sdk-skills.test.ts
+++ b/packages/coding-agent/test/sdk-skills.test.ts
@@ -80,7 +80,7 @@ Loaded via symbolic link.
 		// Skills should be discovered and exposed on the session
 		expect(session.skills.length).toBeGreaterThan(0);
 		expect(session.skills.some((s: Skill) => s.name === "test-skill")).toBe(true);
-	});
+	}, { timeout: 30_000 });
 
 	it("should discover skills when skill directory is a symlink", async () => {
 		const { session } = await createAgentSession({
@@ -91,7 +91,7 @@ Loaded via symbolic link.
 		});
 
 		expect(session.skills.some((s: Skill) => s.name === "symlinked-skill")).toBe(true);
-	});
+	}, { timeout: 30_000 });
 
 	it("should still discover project skills when user skills directory is missing", async () => {
 		const userAgentDir = path.join(tempHomeDir, ".omp", "agent");
@@ -106,7 +106,7 @@ Loaded via symbolic link.
 		});
 
 		expect(session.skills.some((s: Skill) => s.name === "test-skill")).toBe(true);
-	});
+	}, { timeout: 30_000 });
 	it("should have empty skills when options.skills is empty array (--no-skills)", async () => {
 		const { session } = await createAgentSession({
 			cwd: tempDir,
@@ -120,7 +120,7 @@ Loaded via symbolic link.
 		expect(session.skills).toEqual([]);
 		// No warnings since we didn't discover
 		expect(session.skillWarnings).toEqual([]);
-	});
+	}, { timeout: 30_000 });
 
 	it("should use provided skills when options.skills is explicitly set", async () => {
 		const customSkill: Skill = {
@@ -143,5 +143,5 @@ Loaded via symbolic link.
 		expect(session.skills).toEqual([customSkill]);
 		// No warnings since we didn't discover
 		expect(session.skillWarnings).toEqual([]);
-	});
+	}, { timeout: 30_000 });
 });

--- a/packages/coding-agent/test/sdk-skills.test.ts
+++ b/packages/coding-agent/test/sdk-skills.test.ts
@@ -69,79 +69,99 @@ Loaded via symbolic link.
 
 	afterEach(cleanupTempHome(() => ({ tempDir, tempHomeDir, originalHome })));
 
-	it("should discover skills by default and expose them on session.skills", async () => {
-		const { session } = await createAgentSession({
-			cwd: tempDir,
-			agentDir: tempDir,
-			sessionManager: SessionManager.inMemory(),
-			settings: createIsolatedSkillsSettings(),
-		});
+	it(
+		"should discover skills by default and expose them on session.skills",
+		async () => {
+			const { session } = await createAgentSession({
+				cwd: tempDir,
+				agentDir: tempDir,
+				sessionManager: SessionManager.inMemory(),
+				settings: createIsolatedSkillsSettings(),
+			});
 
-		// Skills should be discovered and exposed on the session
-		expect(session.skills.length).toBeGreaterThan(0);
-		expect(session.skills.some((s: Skill) => s.name === "test-skill")).toBe(true);
-	}, { timeout: 30_000 });
+			// Skills should be discovered and exposed on the session
+			expect(session.skills.length).toBeGreaterThan(0);
+			expect(session.skills.some((s: Skill) => s.name === "test-skill")).toBe(true);
+		},
+		{ timeout: 30_000 },
+	);
 
-	it("should discover skills when skill directory is a symlink", async () => {
-		const { session } = await createAgentSession({
-			cwd: tempDir,
-			agentDir: tempDir,
-			sessionManager: SessionManager.inMemory(),
-			settings: createIsolatedSkillsSettings(),
-		});
+	it(
+		"should discover skills when skill directory is a symlink",
+		async () => {
+			const { session } = await createAgentSession({
+				cwd: tempDir,
+				agentDir: tempDir,
+				sessionManager: SessionManager.inMemory(),
+				settings: createIsolatedSkillsSettings(),
+			});
 
-		expect(session.skills.some((s: Skill) => s.name === "symlinked-skill")).toBe(true);
-	}, { timeout: 30_000 });
+			expect(session.skills.some((s: Skill) => s.name === "symlinked-skill")).toBe(true);
+		},
+		{ timeout: 30_000 },
+	);
 
-	it("should still discover project skills when user skills directory is missing", async () => {
-		const userAgentDir = path.join(tempHomeDir, ".omp", "agent");
-		fs.rmSync(path.join(userAgentDir, "skills"), { recursive: true, force: true });
-		fs.writeFileSync(path.join(userAgentDir, "placeholder.txt"), "placeholder");
+	it(
+		"should still discover project skills when user skills directory is missing",
+		async () => {
+			const userAgentDir = path.join(tempHomeDir, ".omp", "agent");
+			fs.rmSync(path.join(userAgentDir, "skills"), { recursive: true, force: true });
+			fs.writeFileSync(path.join(userAgentDir, "placeholder.txt"), "placeholder");
 
-		const { session } = await createAgentSession({
-			cwd: tempDir,
-			agentDir: tempDir,
-			sessionManager: SessionManager.inMemory(),
-			settings: createIsolatedSkillsSettings(),
-		});
+			const { session } = await createAgentSession({
+				cwd: tempDir,
+				agentDir: tempDir,
+				sessionManager: SessionManager.inMemory(),
+				settings: createIsolatedSkillsSettings(),
+			});
 
-		expect(session.skills.some((s: Skill) => s.name === "test-skill")).toBe(true);
-	}, { timeout: 30_000 });
-	it("should have empty skills when options.skills is empty array (--no-skills)", async () => {
-		const { session } = await createAgentSession({
-			cwd: tempDir,
-			agentDir: tempDir,
-			sessionManager: SessionManager.inMemory(),
-			skills: [], // Explicitly empty - like --no-skills
-			settings: createIsolatedSkillsSettings(),
-		});
+			expect(session.skills.some((s: Skill) => s.name === "test-skill")).toBe(true);
+		},
+		{ timeout: 30_000 },
+	);
+	it(
+		"should have empty skills when options.skills is empty array (--no-skills)",
+		async () => {
+			const { session } = await createAgentSession({
+				cwd: tempDir,
+				agentDir: tempDir,
+				sessionManager: SessionManager.inMemory(),
+				skills: [], // Explicitly empty - like --no-skills
+				settings: createIsolatedSkillsSettings(),
+			});
 
-		// session.skills should be empty
-		expect(session.skills).toEqual([]);
-		// No warnings since we didn't discover
-		expect(session.skillWarnings).toEqual([]);
-	}, { timeout: 30_000 });
+			// session.skills should be empty
+			expect(session.skills).toEqual([]);
+			// No warnings since we didn't discover
+			expect(session.skillWarnings).toEqual([]);
+		},
+		{ timeout: 30_000 },
+	);
 
-	it("should use provided skills when options.skills is explicitly set", async () => {
-		const customSkill: Skill = {
-			name: "custom-skill",
-			description: "A custom skill",
-			filePath: "/fake/path/SKILL.md",
-			baseDir: "/fake/path",
-			source: "custom" as const,
-		};
+	it(
+		"should use provided skills when options.skills is explicitly set",
+		async () => {
+			const customSkill: Skill = {
+				name: "custom-skill",
+				description: "A custom skill",
+				filePath: "/fake/path/SKILL.md",
+				baseDir: "/fake/path",
+				source: "custom" as const,
+			};
 
-		const { session } = await createAgentSession({
-			cwd: tempDir,
-			agentDir: tempDir,
-			sessionManager: SessionManager.inMemory(),
-			skills: [customSkill],
-			settings: createIsolatedSkillsSettings(),
-		});
+			const { session } = await createAgentSession({
+				cwd: tempDir,
+				agentDir: tempDir,
+				sessionManager: SessionManager.inMemory(),
+				skills: [customSkill],
+				settings: createIsolatedSkillsSettings(),
+			});
 
-		// session.skills should contain only the provided skill
-		expect(session.skills).toEqual([customSkill]);
-		// No warnings since we didn't discover
-		expect(session.skillWarnings).toEqual([]);
-	}, { timeout: 30_000 });
+			// session.skills should contain only the provided skill
+			expect(session.skills).toEqual([customSkill]);
+			// No warnings since we didn't discover
+			expect(session.skillWarnings).toEqual([]);
+		},
+		{ timeout: 30_000 },
+	);
 });

--- a/packages/coding-agent/test/skill-invocation-tracking.test.ts
+++ b/packages/coding-agent/test/skill-invocation-tracking.test.ts
@@ -10,13 +10,13 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "../src/config/settings";
-import { InternalUrlRouter } from "../src/internal-urls";
 import { resetActiveSkillsForTests, setActiveSkills } from "../src/extensibility/skills";
-import type { ToolSession } from "../src/tools";
-import { ReadTool } from "../src/tools/read";
+import { InternalUrlRouter } from "../src/internal-urls";
 import { InputController } from "../src/modes/controllers/input-controller";
 import type { InteractiveModeContext } from "../src/modes/types";
 import type { AgentStorage } from "../src/session/agent-storage";
+import type { ToolSession } from "../src/tools";
+import { ReadTool } from "../src/tools/read";
 
 // ---------------------------------------------------------------------------
 // Shared helpers

--- a/packages/coding-agent/test/skill-invocation-tracking.test.ts
+++ b/packages/coding-agent/test/skill-invocation-tracking.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for skill invocation tracking hooks added in:
+ *   - packages/coding-agent/src/tools/read.ts  (#handleInternalUrl)
+ *   - packages/coding-agent/src/modes/controllers/input-controller.ts (#invokeSkillCommand)
+ *
+ * All tests use spy-based isolation — no real DB is opened.
+ */
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "../src/config/settings";
+import { InternalUrlRouter } from "../src/internal-urls";
+import { resetActiveSkillsForTests, setActiveSkills } from "../src/extensibility/skills";
+import type { ToolSession } from "../src/tools";
+import { ReadTool } from "../src/tools/read";
+import { InputController } from "../src/modes/controllers/input-controller";
+import type { InteractiveModeContext } from "../src/modes/types";
+import type { AgentStorage } from "../src/session/agent-storage";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function makeFakeStorage(): AgentStorage & { _calls: string[] } {
+	const calls: string[] = [];
+	return {
+		_calls: calls,
+		recordSkillUsage(skillName: string) {
+			calls.push(skillName);
+		},
+	} as unknown as AgentStorage & { _calls: string[] };
+}
+
+// ---------------------------------------------------------------------------
+// Read tool — skill:// tracking
+// ---------------------------------------------------------------------------
+
+function createReadSession(cwd: string): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		getSessionFile: () => path.join(cwd, "session.jsonl"),
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated(),
+	} as unknown as ToolSession;
+}
+
+describe("read tool skill:// tracking", () => {
+	let tmpDir: string;
+	let skillDir: string;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "skill-track-read-"));
+		skillDir = path.join(tmpDir, "my-skill");
+		await fs.mkdir(skillDir, { recursive: true });
+		await fs.writeFile(path.join(skillDir, "SKILL.md"), "# my-skill\nDoes things.\n");
+		await fs.writeFile(path.join(skillDir, "helper.md"), "# helper\nExtra context.\n");
+
+		// Register the skill globally so SkillProtocolHandler can find it
+		setActiveSkills([
+			{
+				name: "my-skill",
+				description: "A test skill",
+				filePath: path.join(skillDir, "SKILL.md"),
+				baseDir: skillDir,
+				source: "test",
+			},
+		]);
+
+		// Reset the router singleton so the test gets a clean handler map
+		InternalUrlRouter.resetForTests();
+	});
+
+	afterEach(async () => {
+		resetActiveSkillsForTests();
+		InternalUrlRouter.resetForTests();
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("root skill:// read records skill usage", async () => {
+		const session = createReadSession(tmpDir);
+		const storage = makeFakeStorage();
+		spyOn(session.settings, "getStorage").mockReturnValue(storage);
+
+		const tool = new ReadTool(session);
+		await tool.execute("t1", { path: "skill://my-skill" });
+
+		expect(storage._calls).toEqual(["my-skill"]);
+	});
+
+	it("sub-path skill://foo/bar.md read does NOT record usage", async () => {
+		const session = createReadSession(tmpDir);
+		const storage = makeFakeStorage();
+		spyOn(session.settings, "getStorage").mockReturnValue(storage);
+
+		const tool = new ReadTool(session);
+		await tool.execute("t2", { path: "skill://my-skill/helper.md" });
+
+		expect(storage._calls).toEqual([]);
+	});
+
+	it("failed skill:// resolve (unknown skill) does NOT record usage", async () => {
+		const session = createReadSession(tmpDir);
+		const storage = makeFakeStorage();
+		spyOn(session.settings, "getStorage").mockReturnValue(storage);
+
+		const tool = new ReadTool(session);
+		await expect(tool.execute("t3", { path: "skill://no-such-skill" })).rejects.toThrow();
+
+		expect(storage._calls).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// InputController — /skill:<name> tracking via handleFollowUp() public path
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal InteractiveModeContext sufficient for handleFollowUp().
+ * The editor returns whatever `editorText` is set to.
+ */
+function buildInputCtx(params: {
+	storage: (AgentStorage & { _calls: string[] }) | null;
+	skillCommands: Map<string, string>;
+	editorText: string;
+	onPromptCustomMessage?: (msg: unknown) => Promise<void>;
+}): { ctx: InteractiveModeContext; settings: Settings } {
+	const settings = Settings.isolated();
+	if (params.storage) {
+		spyOn(settings, "getStorage").mockReturnValue(params.storage);
+	}
+
+	const ctx: InteractiveModeContext = {
+		editor: {
+			getText: () => params.editorText,
+			addToHistory: () => {},
+			setText: () => {},
+		},
+		ui: { requestRender: () => {} },
+		session: {
+			isStreaming: false,
+			isCompacting: false,
+			promptCustomMessage: params.onPromptCustomMessage ?? (async () => {}),
+			prompt: async () => {},
+		},
+		settings,
+		skillCommands: params.skillCommands,
+		showError: () => {},
+		updatePendingMessagesDisplay: () => {},
+		// Required by handleFollowUp's non-skill fallthrough path
+		withLocalSubmission: async (_text: string, fn: () => Promise<unknown>) => fn(),
+		locallySubmittedUserSignatures: new Set<string>(),
+		recordLocalSubmission: () => () => {},
+	} as unknown as InteractiveModeContext;
+
+	return { ctx, settings };
+}
+
+describe("InputController /skill: tracking via handleFollowUp", () => {
+	let tmpDir: string;
+	let skillFile: string;
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "skill-track-ic-"));
+		skillFile = path.join(tmpDir, "SKILL.md");
+		await fs.writeFile(skillFile, "# my-skill\nDoes things.\n");
+	});
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("/skill:foo dispatches and records skill usage", async () => {
+		const storage = makeFakeStorage();
+		const skillCommands = new Map([["skill:my-skill", skillFile]]);
+		const { ctx } = buildInputCtx({ storage, skillCommands, editorText: "/skill:my-skill" });
+
+		const controller = new InputController(ctx);
+		await controller.handleFollowUp();
+
+		expect(storage._calls).toEqual(["my-skill"]);
+	});
+
+	it("unknown /skill:missing returns without recording usage", async () => {
+		const storage = makeFakeStorage();
+		const skillCommands = new Map<string, string>(); // no skills registered
+		const { ctx } = buildInputCtx({ storage, skillCommands, editorText: "/skill:missing" });
+
+		const controller = new InputController(ctx);
+		await controller.handleFollowUp();
+
+		expect(storage._calls).toEqual([]);
+	});
+
+	it("/skill:foo with trailing args records usage once", async () => {
+		const storage = makeFakeStorage();
+		const skillCommands = new Map([["skill:my-skill", skillFile]]);
+		const prompted: unknown[] = [];
+		const { ctx } = buildInputCtx({
+			storage,
+			skillCommands,
+			editorText: "/skill:my-skill some extra args",
+			onPromptCustomMessage: async (msg: unknown) => {
+				prompted.push(msg);
+			},
+		});
+
+		const controller = new InputController(ctx);
+		await controller.handleFollowUp();
+
+		expect(storage._calls).toEqual(["my-skill"]);
+		expect(prompted).toHaveLength(1);
+	});
+});

--- a/packages/coding-agent/test/system-prompt-skill-redaction.test.ts
+++ b/packages/coding-agent/test/system-prompt-skill-redaction.test.ts
@@ -86,23 +86,28 @@ describe("system prompt skill redaction", () => {
 		expect(offWithSet).toBe(plainBaseline);
 	});
 
-	it("redactDescriptions:true renders only frequent skills plus a pointer with the deferred count", async () => {
+	it("redactDescriptions:true keeps every skill name, redacts descriptions of non-frequent skills, plus a pointer", async () => {
 		const skills = [makeSkill("alpha"), makeSkill("beta"), makeSkill("gamma"), makeSkill("delta")];
 		const text = await render({
 			skills,
 			redactDescriptions: true,
 			frequentSkillNames: new Set(["alpha", "beta"]),
 		});
+		// Frequent skills render with their descriptions.
 		expect(text).toContain("- alpha: desc for alpha");
 		expect(text).toContain("- beta: desc for beta");
-		expect(text).not.toContain("- gamma: desc for gamma");
-		expect(text).not.toContain("- delta: desc for delta");
-		// 2 deferred (gamma, delta)
-		expect(text).toContain("(2 more skills not listed");
+		// Redacted skills keep their name but lose the description.
+		expect(text).toContain("- gamma");
+		expect(text).not.toContain("desc for gamma");
+		expect(text).toContain("- delta");
+		expect(text).not.toContain("desc for delta");
+		// 2 redacted (gamma, delta)
+		expect(text).toContain("(2 skills above are listed without descriptions");
 		expect(text).toContain("search_tool_bm25");
+		expect(text).toContain("skill://<name>");
 	});
 
-	it("deferredSkillCount === 0 (all skills frequent) renders all skills and no pointer", async () => {
+	it("deferredSkillCount === 0 (all skills frequent) renders all skills with descriptions and no pointer", async () => {
 		const skills = [makeSkill("alpha"), makeSkill("beta")];
 		const text = await render({
 			skills,
@@ -111,10 +116,10 @@ describe("system prompt skill redaction", () => {
 		});
 		expect(text).toContain("- alpha: desc for alpha");
 		expect(text).toContain("- beta: desc for beta");
-		expect(text).not.toContain("more skills not listed");
+		expect(text).not.toContain("skills above are listed without descriptions");
 	});
 
-	it("hidden skills never appear in rendered output or the deferred count", async () => {
+	it("hidden skills never appear; deferred skills keep names but lose descriptions", async () => {
 		const skills = [makeSkill("alpha"), makeSkill("beta"), makeSkill("secret", { hide: true }), makeSkill("gamma")];
 		const text = await render({
 			skills,
@@ -123,36 +128,73 @@ describe("system prompt skill redaction", () => {
 		});
 		// hidden skill is never rendered
 		expect(text).not.toContain("secret");
-		// rendered: alpha; deferred: beta, gamma (hidden "secret" excluded from both)
+		// frequent: alpha (name + desc)
 		expect(text).toContain("- alpha: desc for alpha");
-		expect(text).toContain("(2 more skills not listed");
+		// deferred: beta, gamma — names present, descriptions absent (hidden "secret" excluded from both)
+		expect(text).toContain("- beta");
+		expect(text).not.toContain("desc for beta");
+		expect(text).toContain("- gamma");
+		expect(text).not.toContain("desc for gamma");
+		expect(text).toContain("(2 skills above are listed without descriptions");
 	});
 
-	it("empty frequentSkillNames Set defers all skills — pointer-only block", async () => {
+	it("empty frequentSkillNames Set redacts all descriptions while keeping every name", async () => {
 		const skillList = [makeSkill("alpha"), makeSkill("beta")];
 		const text = await render({
 			skills: skillList,
 			redactDescriptions: true,
 			frequentSkillNames: new Set<string>([]),
 		});
-		// No skill entries rendered
-		expect(text).not.toContain("- alpha:");
-		expect(text).not.toContain("- beta:");
-		// Pointer line references both deferred skills
-		expect(text).toContain("(2 more skills not listed");
+		// Every skill name still rendered...
+		expect(text).toContain("- alpha");
+		expect(text).toContain("- beta");
+		// ...but no descriptions remain.
+		expect(text).not.toContain("desc for alpha");
+		expect(text).not.toContain("desc for beta");
+		// Pointer line references both redacted skills
+		expect(text).toContain("(2 skills above are listed without descriptions");
 		expect(text).toContain("search_tool_bm25");
 	});
 
 	it("subagent path: redactDescriptions:true + frequentSkillNames:null renders full block (no pointer)", async () => {
 		// Subagent sessions always pass frequentSkillNames=null (gated at sdk.ts:1157).
-		// system-prompt.ts requires `frequentSkillNames != null` for skillsRedacted to be true,
+		// system-prompt.ts requires `frequentSkillNames != null` for redaction to be active,
 		// so a null set means redaction is inactive even when redactDescriptions is on:
-		// every visible skill renders inline and no pointer line appears.
+		// every visible skill renders inline with its description and no pointer line appears.
 		const skills = [makeSkill("alpha"), makeSkill("beta")];
 		const text = await render({ skills, redactDescriptions: true, frequentSkillNames: null });
 		expect(text).toContain("- alpha: desc for alpha");
 		expect(text).toContain("- beta: desc for beta");
-		expect(text).not.toContain("more skills not listed");
+		expect(text).not.toContain("skills above are listed without descriptions");
 		expect(text).not.toContain("search_tool_bm25");
+	});
+
+	it("custom system prompt: redacted skills render as name-only <skill> entries plus the pointer", async () => {
+		const skills = [makeSkill("alpha"), makeSkill("beta"), makeSkill("gamma")];
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: projectDir,
+			customPrompt: "You are a custom agent.",
+			contextFiles: [],
+			skills,
+			rules: [],
+			toolNames: ["read"],
+			tools: READ_TOOLS,
+			skillsSettings: { redactDescriptions: true },
+			frequentSkillNames: new Set(["alpha"]),
+			workspaceTree: workspaceTree(projectDir),
+		});
+		const text = systemPrompt.join("\n\n");
+		// Frequent skill keeps its full <skill> element with description.
+		expect(text).toContain('<skill name="alpha">');
+		expect(text).toContain("desc for alpha");
+		// Redacted skills render as self-closing name-only entries.
+		expect(text).toContain('<skill name="beta"/>');
+		expect(text).toContain('<skill name="gamma"/>');
+		expect(text).not.toContain("desc for beta");
+		expect(text).not.toContain("desc for gamma");
+		// Pointer present with the redacted count.
+		expect(text).toContain("(2 skills above are listed without descriptions");
+		expect(text).toContain("search_tool_bm25");
+		expect(text).toContain("skill://<name>");
 	});
 });

--- a/packages/coding-agent/test/system-prompt-skill-redaction.test.ts
+++ b/packages/coding-agent/test/system-prompt-skill-redaction.test.ts
@@ -127,4 +127,19 @@ describe("system prompt skill redaction", () => {
 		expect(text).toContain("- alpha: desc for alpha");
 		expect(text).toContain("(2 more skills not listed");
 	});
+
+	it("empty frequentSkillNames Set defers all skills — pointer-only block", async () => {
+		const skillList = [makeSkill("alpha"), makeSkill("beta")];
+		const text = await render({
+			skills: skillList,
+			redactDescriptions: true,
+			frequentSkillNames: new Set<string>([]),
+		});
+		// No skill entries rendered
+		expect(text).not.toContain("- alpha:");
+		expect(text).not.toContain("- beta:");
+		// Pointer line references both deferred skills
+		expect(text).toContain("(2 more skills not listed");
+		expect(text).toContain("search_tool_bm25");
+	});
 });

--- a/packages/coding-agent/test/system-prompt-skill-redaction.test.ts
+++ b/packages/coding-agent/test/system-prompt-skill-redaction.test.ts
@@ -142,4 +142,17 @@ describe("system prompt skill redaction", () => {
 		expect(text).toContain("(2 more skills not listed");
 		expect(text).toContain("search_tool_bm25");
 	});
+
+	it("subagent path: redactDescriptions:true + frequentSkillNames:null renders full block (no pointer)", async () => {
+		// Subagent sessions always pass frequentSkillNames=null (gated at sdk.ts:1157).
+		// system-prompt.ts requires `frequentSkillNames != null` for skillsRedacted to be true,
+		// so a null set means redaction is inactive even when redactDescriptions is on:
+		// every visible skill renders inline and no pointer line appears.
+		const skills = [makeSkill("alpha"), makeSkill("beta")];
+		const text = await render({ skills, redactDescriptions: true, frequentSkillNames: null });
+		expect(text).toContain("- alpha: desc for alpha");
+		expect(text).toContain("- beta: desc for beta");
+		expect(text).not.toContain("more skills not listed");
+		expect(text).not.toContain("search_tool_bm25");
+	});
 });

--- a/packages/coding-agent/test/system-prompt-skill-redaction.test.ts
+++ b/packages/coding-agent/test/system-prompt-skill-redaction.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Skill } from "@oh-my-pi/pi-coding-agent/extensibility/skills";
+import { buildSystemPrompt, type SystemPromptToolMetadata } from "@oh-my-pi/pi-coding-agent/system-prompt";
+import { cleanupTempHome } from "./helpers/temp-home-cleanup";
+
+function makeSkill(name: string, opts: { hide?: boolean } = {}): Skill {
+	return {
+		name,
+		description: `desc for ${name}`,
+		filePath: `/skills/${name}.md`,
+		baseDir: "/skills",
+		source: "test",
+		hide: opts.hide,
+	};
+}
+
+const READ_TOOLS = new Map<string, SystemPromptToolMetadata>([["read", { label: "Read", description: "Read a file" }]]);
+
+function workspaceTree(projectDir: string) {
+	return {
+		rootPath: projectDir,
+		rendered: "",
+		truncated: false,
+		totalLines: 0,
+		agentsMdFiles: [],
+	};
+}
+
+describe("system prompt skill redaction", () => {
+	let tempDir = "";
+	let tempHomeDir = "";
+	let originalHome: string | undefined;
+	let projectDir = "";
+
+	beforeEach(() => {
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-skill-redact-"));
+		tempHomeDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-skill-redact-home-"));
+		originalHome = process.env.HOME;
+		process.env.HOME = tempHomeDir;
+		projectDir = path.join(tempDir, "project");
+		fs.mkdirSync(projectDir, { recursive: true });
+	});
+
+	afterEach(cleanupTempHome(() => ({ tempDir, tempHomeDir, originalHome })));
+
+	async function render(options: {
+		skills: Skill[];
+		redactDescriptions?: boolean;
+		frequentSkillNames?: ReadonlySet<string> | null;
+	}): Promise<string> {
+		const { systemPrompt } = await buildSystemPrompt({
+			cwd: projectDir,
+			contextFiles: [],
+			skills: options.skills,
+			rules: [],
+			toolNames: ["read"],
+			tools: READ_TOOLS,
+			skillsSettings: { redactDescriptions: options.redactDescriptions ?? false },
+			frequentSkillNames: options.frequentSkillNames ?? null,
+			workspaceTree: workspaceTree(projectDir),
+		});
+		return systemPrompt.join("\n\n");
+	}
+
+	it("redactDescriptions:false renders all skills with no pointer (baseline)", async () => {
+		const skills = [makeSkill("alpha"), makeSkill("beta"), makeSkill("gamma")];
+		const text = await render({ skills, redactDescriptions: false });
+		expect(text).toContain("- alpha: desc for alpha");
+		expect(text).toContain("- beta: desc for beta");
+		expect(text).toContain("- gamma: desc for gamma");
+		expect(text).not.toContain("more skills not listed");
+	});
+
+	it("baseline output is byte-identical whether frequentSkillNames is null or redaction is off", async () => {
+		const skills = [makeSkill("alpha"), makeSkill("beta"), makeSkill("gamma")];
+		// Off-path: redactDescriptions:false but a frequent set is supplied — must be ignored.
+		const offWithSet = await render({
+			skills,
+			redactDescriptions: false,
+			frequentSkillNames: new Set(["alpha"]),
+		});
+		const plainBaseline = await render({ skills, redactDescriptions: false, frequentSkillNames: null });
+		expect(offWithSet).toBe(plainBaseline);
+	});
+
+	it("redactDescriptions:true renders only frequent skills plus a pointer with the deferred count", async () => {
+		const skills = [makeSkill("alpha"), makeSkill("beta"), makeSkill("gamma"), makeSkill("delta")];
+		const text = await render({
+			skills,
+			redactDescriptions: true,
+			frequentSkillNames: new Set(["alpha", "beta"]),
+		});
+		expect(text).toContain("- alpha: desc for alpha");
+		expect(text).toContain("- beta: desc for beta");
+		expect(text).not.toContain("- gamma: desc for gamma");
+		expect(text).not.toContain("- delta: desc for delta");
+		// 2 deferred (gamma, delta)
+		expect(text).toContain("(2 more skills not listed");
+		expect(text).toContain("search_tool_bm25");
+	});
+
+	it("deferredSkillCount === 0 (all skills frequent) renders all skills and no pointer", async () => {
+		const skills = [makeSkill("alpha"), makeSkill("beta")];
+		const text = await render({
+			skills,
+			redactDescriptions: true,
+			frequentSkillNames: new Set(["alpha", "beta"]),
+		});
+		expect(text).toContain("- alpha: desc for alpha");
+		expect(text).toContain("- beta: desc for beta");
+		expect(text).not.toContain("more skills not listed");
+	});
+
+	it("hidden skills never appear in rendered output or the deferred count", async () => {
+		const skills = [makeSkill("alpha"), makeSkill("beta"), makeSkill("secret", { hide: true }), makeSkill("gamma")];
+		const text = await render({
+			skills,
+			redactDescriptions: true,
+			frequentSkillNames: new Set(["alpha"]),
+		});
+		// hidden skill is never rendered
+		expect(text).not.toContain("secret");
+		// rendered: alpha; deferred: beta, gamma (hidden "secret" excluded from both)
+		expect(text).toContain("- alpha: desc for alpha");
+		expect(text).toContain("(2 more skills not listed");
+	});
+});

--- a/packages/coding-agent/test/tools/search-tool-bm25-skills.test.ts
+++ b/packages/coding-agent/test/tools/search-tool-bm25-skills.test.ts
@@ -3,7 +3,11 @@ import type { Component } from "@oh-my-pi/pi-tui";
 import { Settings } from "../../src/config/settings";
 import type { RenderResultOptions } from "../../src/extensibility/custom-tools/types";
 import { getThemeByName, initTheme, type Theme } from "../../src/modes/theme/theme";
-import type { DiscoverableTool, DiscoverableToolSearchIndex } from "../../src/tool-discovery/tool-index";
+import {
+	buildDiscoverableToolSearchIndex,
+	type DiscoverableTool,
+	type DiscoverableToolSearchIndex,
+} from "../../src/tool-discovery/tool-index";
 import type { ToolSession } from "../../src/tools/index";
 import { SearchToolBm25Tool, searchToolBm25Renderer } from "../../src/tools/search-tool-bm25";
 
@@ -225,5 +229,103 @@ describe("SearchToolBm25Tool — skill discovery", () => {
 		const tool = new SearchToolBm25Tool(session);
 
 		await expect(tool.execute("call-disabled", { query: "anything" })).rejects.toThrow("Tool discovery is disabled.");
+	});
+});
+
+// ─── Regression guard: description getter caching (TC-006) ─────────────────────
+//
+// The `description` getter caches its rendered text keyed on the
+// DiscoverableToolSearchIndex object reference returned by
+// getDiscoverableToolSearchIndex(). The rendered text itself is built from
+// getDiscoverableTools() (via getDiscoverableToolsForDescription) — and that
+// call only happens on the cache-MISS path. So counting getDiscoverableTools
+// invocations is a direct, non-coupled measurement of how many times the
+// description re-rendered. That is the backbone of these tests.
+describe("SearchToolBm25Tool — description getter caching", () => {
+	/**
+	 * Build a minimal stub session that exercises only the two methods the
+	 * description getter touches: getDiscoverableTools (the render source, spied)
+	 * and getDiscoverableToolSearchIndex (the cache key / invalidation signal).
+	 */
+	function createDescriptionCacheSession(opts: {
+		getDiscoverableTools: () => DiscoverableTool[];
+		getDiscoverableToolSearchIndex: () => DiscoverableToolSearchIndex;
+	}): ToolSession {
+		return {
+			isToolDiscoveryEnabled: () => true,
+			isSkillDiscoveryEnabled: () => false,
+			getDiscoverableTools: opts.getDiscoverableTools,
+			getDiscoverableToolSearchIndex: opts.getDiscoverableToolSearchIndex,
+			getSelectedDiscoveredToolNames: () => [],
+			activateDiscoveredTools: async (toolNames: string[]) => toolNames,
+		} as unknown as ToolSession;
+	}
+
+	it("same index reference: returns cached text and does not re-render", () => {
+		const idx = buildDiscoverableToolSearchIndex([]);
+		const getTools = mock(() => [] as DiscoverableTool[]);
+		const session = createDescriptionCacheSession({
+			getDiscoverableTools: getTools,
+			getDiscoverableToolSearchIndex: () => idx,
+		});
+		const tool = new SearchToolBm25Tool(session);
+
+		const d1 = tool.description;
+		const d2 = tool.description;
+
+		// Identical output AND the render source was consulted exactly once:
+		// the second access was served from cache.
+		expect(d1).toBe(d2);
+		expect(getTools.mock.calls.length).toBe(1);
+	});
+
+	it("changed index reference: busts cache and re-renders", () => {
+		let currentIndex = buildDiscoverableToolSearchIndex([]);
+		const getTools = mock(() => [] as DiscoverableTool[]);
+		const session = createDescriptionCacheSession({
+			getDiscoverableTools: getTools,
+			getDiscoverableToolSearchIndex: () => currentIndex,
+		});
+		const tool = new SearchToolBm25Tool(session);
+
+		const d1 = tool.description;
+		// Swap to a brand-new index object reference — same contents, new identity.
+		currentIndex = buildDiscoverableToolSearchIndex([]);
+		const d2 = tool.description;
+
+		// Both accesses re-rendered because the cache key (index reference) changed.
+		expect(getTools.mock.calls.length).toBe(2);
+		expect(typeof d1).toBe("string");
+		expect(typeof d2).toBe("string");
+	});
+
+	it("throwing getDiscoverableToolSearchIndex falls back to uncached render and never poisons the cache", () => {
+		let tools: DiscoverableTool[] = [];
+		const getTools = mock(() => tools);
+		const session = createDescriptionCacheSession({
+			getDiscoverableTools: getTools,
+			getDiscoverableToolSearchIndex: () => {
+				throw new Error("pre-init");
+			},
+		});
+		const tool = new SearchToolBm25Tool(session);
+
+		// The getter must swallow the pre-init throw, never propagate it.
+		// Read d1 inside this assertion path so this is the FIRST access (not a
+		// separate extra one) — keeping the access count at exactly two below.
+		let d1 = "";
+		expect(() => {
+			d1 = tool.description;
+		}).not.toThrow();
+		// Change the underlying tool set and read again. If the throw path had
+		// wrongly written #descriptionCache, the second access would serve a stale
+		// (poisoned) string. A correct uncached fallback re-renders every time.
+		tools = [skillTool("deploy-pipeline", "Deploy the application")];
+		const d2 = tool.description;
+
+		expect(typeof d1).toBe("string");
+		expect(d1).not.toBe(d2);
+		// Re-rendered on every access (no caching when the index getter throws).
+		expect(getTools.mock.calls.length).toBe(2);
 	});
 });

--- a/packages/coding-agent/test/tools/search-tool-bm25-skills.test.ts
+++ b/packages/coding-agent/test/tools/search-tool-bm25-skills.test.ts
@@ -1,0 +1,233 @@
+import { beforeAll, describe, expect, it, mock } from "bun:test";
+import type { Component } from "@oh-my-pi/pi-tui";
+import { Settings } from "../../src/config/settings";
+import type { RenderResultOptions } from "../../src/extensibility/custom-tools/types";
+import { getThemeByName, initTheme, type Theme } from "../../src/modes/theme/theme";
+import type { DiscoverableTool, DiscoverableToolSearchIndex } from "../../src/tool-discovery/tool-index";
+import type { ToolSession } from "../../src/tools/index";
+import { searchToolBm25Renderer, SearchToolBm25Tool } from "../../src/tools/search-tool-bm25";
+
+let uiTheme: Theme;
+
+beforeAll(async () => {
+	await initTheme(false, undefined, undefined, "dark", "light");
+	const t = await getThemeByName("dark");
+	if (!t) throw new Error("Missing dark theme");
+	uiTheme = t;
+});
+
+const renderOptions: RenderResultOptions = { expanded: false, isPartial: false };
+
+function renderText(component: Component): string {
+	return Bun.stripANSI(component.render(160).join("\n"));
+}
+
+// ─── Session type with generic discovery triple ───────────────────────────────
+
+type GenericDiscoverySession = ToolSession & {
+	isToolDiscoveryEnabled: () => boolean;
+	isSkillDiscoveryEnabled: () => boolean;
+	getDiscoverableTools: (filter?: { source?: DiscoverableTool["source"] }) => DiscoverableTool[];
+	getDiscoverableToolSearchIndex?: () => DiscoverableToolSearchIndex;
+	getSelectedDiscoveredToolNames: () => string[];
+	activateDiscoveredTools: (toolNames: string[]) => Promise<string[]>;
+	getSelected: () => string[];
+};
+
+function createGenericSession(
+	tools: DiscoverableTool[],
+	skillDiscoveryEnabled: boolean,
+	toolDiscoveryEnabled: boolean,
+	overrides: Partial<GenericDiscoverySession> = {},
+): GenericDiscoverySession {
+	const selected: string[] = [];
+	return {
+		cwd: "/tmp/test",
+		hasUI: false,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		settings: Settings.isolated({
+			"tools.discoveryMode": toolDiscoveryEnabled ? "all" : "off",
+			"skills.redactDescriptions": skillDiscoveryEnabled,
+		}),
+		isToolDiscoveryEnabled: () => toolDiscoveryEnabled,
+		isSkillDiscoveryEnabled: () => skillDiscoveryEnabled,
+		getDiscoverableTools: () => tools,
+		getSelectedDiscoveredToolNames: () => [...selected],
+		activateDiscoveredTools: async (toolNames: string[]) => {
+			for (const name of toolNames) {
+				if (!selected.includes(name)) {
+					selected.push(name);
+				}
+			}
+			return toolNames;
+		},
+		getSelected: () => [...selected],
+		...overrides,
+	};
+}
+
+/** Helper to create a discoverable skill tool entry (deferred/redacted). */
+function skillTool(name: string, summary: string): DiscoverableTool {
+	return {
+		name,
+		label: name,
+		summary,
+		source: "skill",
+		schemaKeys: [],
+	};
+}
+
+/** Helper to create a discoverable MCP tool. */
+function mcpTool(
+	name: string,
+	serverName: string,
+	mcpToolName: string,
+	summary: string,
+	schemaKeys: string[],
+): DiscoverableTool {
+	return {
+		name,
+		label: `${serverName}/${mcpToolName}`,
+		summary,
+		source: "mcp",
+		serverName,
+		mcpToolName,
+		schemaKeys,
+	};
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("SearchToolBm25Tool — skill discovery", () => {
+	it("skill entries are searchable and returned in details.skills", async () => {
+		const tools: DiscoverableTool[] = [
+			skillTool("deploy-pipeline", "Deploy the application using the CI/CD pipeline"),
+			skillTool("run-tests", "Execute the project test suite"),
+			mcpTool("mcp__github_create_issue", "github", "create_issue", "Create a GitHub issue", ["owner", "repo"]),
+		];
+		const session = createGenericSession(tools, true, false);
+		const tool = new SearchToolBm25Tool(session);
+
+		const result = await tool.execute("call-1", { query: "deploy pipeline" });
+
+		// Skill must appear in details.skills
+		expect(result.details?.skills).toBeDefined();
+		const skillNames = result.details!.skills!.map(s => s.name);
+		expect(skillNames).toContain("deploy-pipeline");
+
+		// Each skill entry must have the expected shape
+		const deploySkill = result.details!.skills!.find(s => s.name === "deploy-pipeline")!;
+		expect(deploySkill.read).toBe("skill://deploy-pipeline");
+		expect(typeof deploySkill.score).toBe("number");
+		expect(deploySkill.description).toBe("Deploy the application using the CI/CD pipeline");
+	});
+
+	it("skills are NOT passed to activateDiscoveredTools", async () => {
+		const activateSpy = mock(async (toolNames: string[]) => toolNames);
+		const tools: DiscoverableTool[] = [
+			skillTool("run-tests", "Execute the project test suite"),
+			mcpTool("mcp__github_create_issue", "github", "create_issue", "Create a GitHub issue", ["owner", "repo"]),
+		];
+		const selected: string[] = [];
+		const session = createGenericSession(tools, true, true, {
+			activateDiscoveredTools: activateSpy,
+			getSelectedDiscoveredToolNames: () => [...selected],
+		});
+		const tool = new SearchToolBm25Tool(session);
+
+		await tool.execute("call-2", { query: "run tests" });
+
+		// activateDiscoveredTools must not have been called with any skill name
+		const allActivatedNames = activateSpy.mock.calls.flatMap(call => call[0] as string[]);
+		expect(allActivatedNames).not.toContain("run-tests");
+		// Skills must not appear in activated_tools in the result
+		const result = await tool.execute("call-3", { query: "run tests suite" });
+		expect(result.details?.activated_tools).not.toContain("run-tests");
+	});
+
+	it("createIf returns a tool when isSkillDiscoveryEnabled=true and discoveryMode=off", () => {
+		const tools: DiscoverableTool[] = [skillTool("deploy-pipeline", "Deploy app")];
+		const session = createGenericSession(tools, true, false);
+
+		// discoveryMode is "off", mcp.discoveryMode is not set — only skill discovery is active
+		const result = SearchToolBm25Tool.createIf(session);
+		expect(result).not.toBeNull();
+		expect(result).toBeInstanceOf(SearchToolBm25Tool);
+	});
+
+	it("createIf returns null when both discoveryMode and isSkillDiscoveryEnabled are off", () => {
+		const tools: DiscoverableTool[] = [skillTool("deploy-pipeline", "Deploy app")];
+		const session = createGenericSession(tools, false, false);
+
+		const result = SearchToolBm25Tool.createIf(session);
+		expect(result).toBeNull();
+	});
+
+	it("skill-only result: details.tools is empty, skills has match, renderer shows skills section", async () => {
+		const tools: DiscoverableTool[] = [
+			skillTool("deploy-pipeline", "Deploy the application using the CI/CD pipeline"),
+		];
+		// skill-only session: no regular tools discoverable
+		const session = createGenericSession(tools, true, false);
+		const tool = new SearchToolBm25Tool(session);
+
+		const result = await tool.execute("call-skills-only", { query: "deploy pipeline" });
+
+		// tools array must be empty (skill not leaked into tools)
+		expect(result.details?.tools).toHaveLength(0);
+		// skills array must have the match
+		expect(result.details?.skills?.length).toBeGreaterThan(0);
+		expect(result.details?.skills?.[0]?.name).toBe("deploy-pipeline");
+		// activated_tools must be empty (skills never activated)
+		expect(result.details?.activated_tools).toHaveLength(0);
+
+		// Renderer must show skills section and NOT report "No matching tools found"
+		const component = searchToolBm25Renderer.renderResult(result, renderOptions, uiTheme);
+		const text = renderText(component);
+		expect(text).not.toContain("No matching tools found");
+		expect(text).toContain("deploy-pipeline");
+		expect(text).toContain("skill://deploy-pipeline");
+		expect(text).toContain("Skills (1):");
+	});
+
+	it("JSON content includes skill_matches and skill_match_count when skills match", async () => {
+		const tools: DiscoverableTool[] = [
+			skillTool("run-tests", "Execute the project test suite and report results"),
+		];
+		const session = createGenericSession(tools, true, false);
+		const tool = new SearchToolBm25Tool(session);
+
+		const result = await tool.execute("call-json", { query: "run test suite" });
+
+		const parsed = JSON.parse((result.content[0] as { type: "text"; text: string }).text);
+		expect(parsed.skill_match_count).toBe(1);
+		expect(parsed.skill_matches).toHaveLength(1);
+		expect(parsed.skill_matches[0].name).toBe("run-tests");
+		expect(parsed.skill_matches[0].read).toBe("skill://run-tests");
+	});
+
+	it("JSON content omits skill fields when no skills match", async () => {
+		const tools: DiscoverableTool[] = [
+			mcpTool("mcp__github_create_issue", "github", "create_issue", "Create a GitHub issue", ["owner", "repo"]),
+		];
+		const session = createGenericSession(tools, false, true);
+		const tool = new SearchToolBm25Tool(session);
+
+		const result = await tool.execute("call-no-skill", { query: "github" });
+
+		const parsed = JSON.parse((result.content[0] as { type: "text"; text: string }).text);
+		expect(parsed.skill_match_count).toBeUndefined();
+		expect(parsed.skill_matches).toBeUndefined();
+	});
+
+	it("execute throws when both discovery modes are disabled", async () => {
+		const tools: DiscoverableTool[] = [];
+		const session = createGenericSession(tools, false, false);
+		const tool = new SearchToolBm25Tool(session);
+
+		await expect(tool.execute("call-disabled", { query: "anything" })).rejects.toThrow(
+			"Tool discovery is disabled.",
+		);
+	});
+});

--- a/packages/coding-agent/test/tools/search-tool-bm25-skills.test.ts
+++ b/packages/coding-agent/test/tools/search-tool-bm25-skills.test.ts
@@ -5,7 +5,7 @@ import type { RenderResultOptions } from "../../src/extensibility/custom-tools/t
 import { getThemeByName, initTheme, type Theme } from "../../src/modes/theme/theme";
 import type { DiscoverableTool, DiscoverableToolSearchIndex } from "../../src/tool-discovery/tool-index";
 import type { ToolSession } from "../../src/tools/index";
-import { searchToolBm25Renderer, SearchToolBm25Tool } from "../../src/tools/search-tool-bm25";
+import { SearchToolBm25Tool, searchToolBm25Renderer } from "../../src/tools/search-tool-bm25";
 
 let uiTheme: Theme;
 
@@ -192,9 +192,7 @@ describe("SearchToolBm25Tool — skill discovery", () => {
 	});
 
 	it("JSON content includes skill_matches and skill_match_count when skills match", async () => {
-		const tools: DiscoverableTool[] = [
-			skillTool("run-tests", "Execute the project test suite and report results"),
-		];
+		const tools: DiscoverableTool[] = [skillTool("run-tests", "Execute the project test suite and report results")];
 		const session = createGenericSession(tools, true, false);
 		const tool = new SearchToolBm25Tool(session);
 
@@ -226,8 +224,6 @@ describe("SearchToolBm25Tool — skill discovery", () => {
 		const session = createGenericSession(tools, false, false);
 		const tool = new SearchToolBm25Tool(session);
 
-		await expect(tool.execute("call-disabled", { query: "anything" })).rejects.toThrow(
-			"Tool discovery is disabled.",
-		);
+		await expect(tool.execute("call-disabled", { query: "anything" })).rejects.toThrow("Tool discovery is disabled.");
 	});
 });


### PR DESCRIPTION
Closes #1958

## Summary

Reduces system-prompt token cost for large skill catalogs by hiding infrequently-used skill descriptions from the `<skills>` block and surfacing them through `search_tool_bm25`.

**Feature is opt-in** (`skills.redactDescriptions`, default `false`). Off-path is byte-identical to today.

---

## Commits

### `feat(storage): add skill_usage tracking table with decayed counts`
- `session/agent-storage.ts`: schema v5→v6, `skill_usage` table, `recordSkillUsage()` with 5-min burst throttle + exponential decay (half-life 21 days), `getSkillUsage()`
- New test suite: `test/agent-storage-skill-usage.test.ts`

### `feat(skills): record skill invocations from read and slash paths`
- `tools/read.ts`: hook after successful `skill://` root-URL resolve
- `modes/acp/acp-agent.ts` + `modes/controllers/input-controller.ts`: hook on `/skill:` dispatch
- `task/executor.ts`: programmatic autoload explicitly excluded
- New test suites: `test/skill-invocation-tracking.test.ts`, `test/acp-agent-skill-tracking.test.ts`

### `feat(skills): frequency-based skill description redaction behind skills.redactDescriptions`
- `config/settings-schema.ts`: three new settings (`skills.redactDescriptions`, `skills.frequentSkillCount`, `skills.alwaysInclude`)
- `extensibility/skill-frequency.ts` (new): pure `computeFrequentSkillNames` + daily-cached `resolveFrequentSkillNames` with `settingsHash` for self-validating cache
- `sdk.ts`: compute `frequentSkillNames` once at SDK-init, freeze into `rebuildSystemPrompt` closure for prompt-cache stability
- `session/agent-session.ts`: `#deferredSkillEntries`, `getDiscoverableTools()` appends unconditionally (bypasses mode-gate), `isSkillDiscoveryEnabled()`
- `system-prompt.ts` + `prompts/system/system-prompt.md`: partition + pointer line
- New test suites: `test/extensibility/skill-frequency.test.ts`, `test/system-prompt-skill-redaction.test.ts`

### `feat(discovery): surface deferred skills through search_tool_bm25`
- `tool-discovery/tool-index.ts`: `"skill"` source, `getDiscoverableSkill()` factory
- `tools/search-tool-bm25.ts`: `createIf` + execute guard OR'd with `isSkillDiscoveryEnabled`, skill partition, `skill://<name>` read URLs, never activated
- `prompts/tools/search-tool-bm25.md`: conditional skill-count note
- New test suite: `test/tools/search-tool-bm25-skills.test.ts`

### `test(sdk-skills): extend per-test timeout to 30s for createAgentSession`
- Pre-existing tests call `createAgentSession` (full SDK init, ~10-12s); adds the established `{ timeout: 30_000 }` pattern

---

## Design notes

- **Warmup gate**: < 10 total invocations → all skills rendered (no alphabetical-bias day-1)
- **Cache-authoritative**: `settingsHash` includes catalog identity, prevents cross-catalog poisoning; within-session staleness accepted for byte-stable prompt prefix
- **Skills never activated**: they return `skill://<name>` informationally; `activateTools` only receives non-skill matches
- **Mode-gate bypass**: `getDiscoverableTools()` appends deferred skills unconditionally so the BM25 index has content when `tools.discoveryMode` is `"off"` (the default)

## Test results

```
4607 pass / 358 skip / 1 pre-existing fail (memory-tools.test.ts:537, unrelated)
```