### PR TITLE
fix(tui): avoid dirty scrollback replay on arrow input

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed focused Up/Down navigation on ED3-risk macOS/POSIX terminals replaying the whole transcript after dirty foreground-stream renders; selector/editor frames now repaint non-destructively instead of emitting `CSI 3 J` on every arrow-key move ([#1962](https://github.com/can1357/oh-my-pi/issues/1962)).
+
 ## [15.9.5] - 2026-06-05
 
 ### Changed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1718,6 +1718,11 @@ export class TUI extends Container {
 			return hasVisibleOverlay ? { kind: "overlayRebuild" } : { kind: "historyRebuild" };
 		}
 
+		// Same dirty-scrollback opt-in policy as the non-overlay branch below: an
+		// ED3-risk macOS/POSIX terminal with an unobservable viewport ignores
+		// focused-input unknown opt-ins, so overlay selector Up/Down moves do not
+		// become ED3 clears plus full transcript replays. Non-ED3-risk POSIX still
+		// honors direct-input/IME/autocomplete opt-ins.
 		if (hasVisibleOverlay) {
 			const nativeViewportAtBottom = this.#readNativeViewportAtBottom();
 			// Multiplexer panes never get a destructive scrollback clear
@@ -1725,10 +1730,11 @@ export class TUI extends Container {
 			// "rebuild" would only append a full duplicate copy of the transcript
 			// to pane history on every dirty frame. Keep repainting the viewport
 			// and leave reconciliation to explicit checkpoints.
+			const allowDirtyUnknownViewportMutation = allowUnknownViewportMutation && !eagerEraseScrollbackRisk;
 			if (
 				this.#nativeScrollbackDirty &&
 				!isMultiplexerSession() &&
-				this.#canRebuildNativeScrollbackLive(nativeViewportAtBottom, allowUnknownViewportMutation)
+				this.#canRebuildNativeScrollbackLive(nativeViewportAtBottom, allowDirtyUnknownViewportMutation)
 			) {
 				return { kind: "overlayRebuild" };
 			}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1761,10 +1761,15 @@ export class TUI extends Container {
 
 		if (this.#nativeScrollbackDirty && !isMultiplexerSession()) {
 			// A dirty flag means older native history is stale; it is not required to
-			// make the current focused-input frame correct. Rebuilding it here on
-			// macOS/POSIX terminals with an unobservable viewport turns every
-			// Up/Down selector move into an ED3 clear plus full transcript replay.
-			if (this.#canRebuildNativeScrollbackLive(this.#readNativeViewportAtBottom(), false)) {
+			// make the current focused-input frame correct. On ED3-risk macOS/POSIX
+			// terminals with an unobservable viewport, ignore focused-input unknown
+			// opt-ins so Up/Down selector moves do not become ED3 clears plus full
+			// transcript replays. Non-ED3-risk POSIX terminals keep their safe
+			// direct-input/IME/autocomplete opt-in.
+			const allowDirtyUnknownViewportMutation = allowUnknownViewportMutation && !eagerEraseScrollbackRisk;
+			if (
+				this.#canRebuildNativeScrollbackLive(this.#readNativeViewportAtBottom(), allowDirtyUnknownViewportMutation)
+			) {
 				return { kind: "historyRebuild" };
 			}
 		}

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -569,8 +569,8 @@ export class TUI extends Container {
 	 * (the viewport is never observable there and ConPTY hosts erase host
 	 * scrollback on ED3 — #1635/#1746); only the unknown POSIX case is forced to
 	 * rebuild. POSIX hosts known to disturb scrolled readers on xterm ED3
-	 * (`CSI 3 J`, erase saved lines) also defer the eager opt-in; checkpoint and
-	 * direct user-input rebuilds are unaffected.
+	 * (`CSI 3 J`, erase saved lines) also defer the eager opt-in; checkpoint
+	 * rebuilds are unaffected.
 	 *
 	 * Disabling stays active through one already-requested frame: the event batch
 	 * that ends a foreground stream both removes its UI rows (loader/status
@@ -1759,12 +1759,14 @@ export class TUI extends Container {
 			this.#streamingHighWater = 0;
 		}
 
-		if (
-			this.#nativeScrollbackDirty &&
-			!isMultiplexerSession() &&
-			this.#canRebuildNativeScrollbackLive(this.#readNativeViewportAtBottom(), allowUnknownViewportMutation)
-		) {
-			return { kind: "historyRebuild" };
+		if (this.#nativeScrollbackDirty && !isMultiplexerSession()) {
+			// A dirty flag means older native history is stale; it is not required to
+			// make the current focused-input frame correct. Rebuilding it here on
+			// macOS/POSIX terminals with an unobservable viewport turns every
+			// Up/Down selector move into an ED3 clear plus full transcript replay.
+			if (this.#canRebuildNativeScrollbackLive(this.#readNativeViewportAtBottom(), false)) {
+				return { kind: "historyRebuild" };
+			}
 		}
 
 		const diff = this.#diffLines(newLines);

--- a/packages/tui/test/issue-1682-repro.test.ts
+++ b/packages/tui/test/issue-1682-repro.test.ts
@@ -267,6 +267,45 @@ describe("issue #1682: TUI eager scrollback rebuild", () => {
 		});
 	});
 
+	it("preserves focused-input dirty scrollback rebuilds on non-ED3-risk terminals", async () => {
+		await withEnvPatch(CLEAR_MULTIPLEXER_ENV, async () => {
+			await withTerminalRisk(false, async () => {
+				const term = new VirtualTerminal(40, 6);
+				overrideProbe(term, false);
+				const tui = new TUI(term);
+				const transcript = new LineList(Array.from({ length: 12 }, (_value, index) => `init-${index}`));
+				const prompt = new PromptInput();
+				tui.addChild(transcript);
+				tui.addChild(prompt);
+				tui.setFocus(prompt);
+
+				try {
+					tui.start();
+					await settle(term);
+					const writes = capture(term);
+
+					transcript.setLines([
+						"init-0 edited",
+						...Array.from({ length: 11 }, (_value, index) => `init-${index + 1}`),
+					]);
+					tui.requestRender();
+					await settle(term);
+
+					expect(eraseScrollbackCount(writes)).toBe(0);
+					overrideProbe(term, undefined);
+
+					term.sendInput("x");
+					await settle(term);
+
+					expect(term.getViewport().map(line => line.trim())).toContain("prompt> x");
+					expect(eraseScrollbackCount(writes)).toBe(1);
+				} finally {
+					tui.stop();
+				}
+			});
+		});
+	});
+
 	it("keeps eager live rebuilds for other terminal traits", async () => {
 		await withEnvPatch(CLEAR_MULTIPLEXER_ENV, async () => {
 			await withTerminalRisk(false, async () => {

--- a/packages/tui/test/issue-1682-repro.test.ts
+++ b/packages/tui/test/issue-1682-repro.test.ts
@@ -229,7 +229,7 @@ describe("issue #1682: TUI eager scrollback rebuild", () => {
 		});
 	});
 
-	it("treats focused keyboard input as a user-input opt-in after an ED3-risk shrink defers", async () => {
+	it("treats focused keyboard input as a non-destructive repaint after an ED3-risk shrink defers", async () => {
 		await withEnvPatch(CLEAR_MULTIPLEXER_ENV, async () => {
 			await withTerminalRisk(true, async () => {
 				const term = new VirtualTerminal(40, 10);
@@ -258,7 +258,7 @@ describe("issue #1682: TUI eager scrollback rebuild", () => {
 					await settle(term);
 
 					expect(term.getViewport().map(line => line.trim())).toContain("prompt> x");
-					expect(eraseScrollbackCount(writes)).toBe(1);
+					expect(eraseScrollbackCount(writes)).toBe(0);
 					expect(tui.refreshNativeScrollbackIfDirty({ allowUnknownViewport: true })).toBe(false);
 				} finally {
 					tui.stop();

--- a/packages/tui/test/issue-1962-repro.test.ts
+++ b/packages/tui/test/issue-1962-repro.test.ts
@@ -127,4 +127,42 @@ describe("issue #1962: arrow navigation after dirty scrollback", () => {
 			}
 		});
 	});
+
+	it("does not clear and replay the whole transcript for a focused arrow-key frame inside an overlay", async () => {
+		await withTerminalRisk(true, async () => {
+			const term = new UnknownViewportTerminal(40, 6);
+			const tui = new TUI(term);
+			const transcript = new MutableLinesComponent(
+				Array.from({ length: 12 }, (_value, index) => `history-${index}`),
+			);
+			tui.addChild(transcript);
+			const selector = new ArrowSelectorComponent();
+			tui.showOverlay(selector);
+
+			try {
+				tui.start();
+				await settle(term);
+
+				tui.setEagerNativeScrollbackRebuild(true);
+				transcript.setLines([
+					"history-0 updated",
+					...Array.from({ length: 11 }, (_value, index) => `history-${index + 1}`),
+				]);
+				tui.requestRender();
+				await settle(term);
+				tui.setEagerNativeScrollbackRebuild(false);
+
+				const writes = captureWrites(term);
+				term.sendInput("\x1b[B");
+				await settle(term);
+
+				const output = writes.join("");
+				expect(output.match(ERASE_SCROLLBACK) ?? []).toHaveLength(0);
+				expect(output).not.toContain("history-0 updated");
+				expect(term.getViewport().map(line => line.trimEnd())).toContain("> second");
+			} finally {
+				tui.stop();
+			}
+		});
+	});
 });

--- a/packages/tui/test/issue-1962-repro.test.ts
+++ b/packages/tui/test/issue-1962-repro.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { type Component, type Focusable, TERMINAL, TUI } from "@oh-my-pi/pi-tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+class MutableLinesComponent implements Component {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = [...lines];
+	}
+
+	setLines(lines: string[]): void {
+		this.#lines = [...lines];
+	}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		return this.#lines.map(line => line.slice(0, width));
+	}
+}
+
+class ArrowSelectorComponent implements Component, Focusable {
+	focused = true;
+	#selectedIndex = 0;
+
+	handleInput(data: string): void {
+		if (data === "\x1b[B") this.#selectedIndex = 1;
+		if (data === "\x1b[A") this.#selectedIndex = 0;
+	}
+
+	invalidate(): void {}
+
+	render(): string[] {
+		return [this.#selectedIndex === 0 ? "> first" : "  first", this.#selectedIndex === 1 ? "> second" : "  second"];
+	}
+}
+
+class UnknownViewportTerminal extends VirtualTerminal {
+	isNativeViewportAtBottom(): undefined {
+		return undefined;
+	}
+}
+
+type MutableTerminalInfo = {
+	eagerEraseScrollbackRisk: boolean;
+};
+
+const mutableTerminalInfo = TERMINAL as unknown as MutableTerminalInfo;
+const ERASE_SCROLLBACK = /\x1b\[3J/g;
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	const nextTick = Promise.withResolvers<void>();
+	process.nextTick(nextTick.resolve);
+	await nextTick.promise;
+	await Bun.sleep(20);
+	await term.flush();
+}
+
+function captureWrites(term: VirtualTerminal): string[] {
+	const writes: string[] = [];
+	const realWrite = term.write.bind(term);
+	vi.spyOn(term, "write").mockImplementation((data: string) => {
+		writes.push(data);
+		realWrite(data);
+	});
+	return writes;
+}
+
+async function withTerminalRisk<T>(risk: boolean, run: () => T | Promise<T>): Promise<T> {
+	const saved = TERMINAL.eagerEraseScrollbackRisk;
+	mutableTerminalInfo.eagerEraseScrollbackRisk = risk;
+	try {
+		return await run();
+	} finally {
+		mutableTerminalInfo.eagerEraseScrollbackRisk = saved;
+	}
+}
+
+describe("issue #1962: arrow navigation after dirty scrollback", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("does not clear and replay the whole transcript for a focused arrow-key frame", async () => {
+		await withTerminalRisk(true, async () => {
+			const term = new UnknownViewportTerminal(40, 6);
+			const tui = new TUI(term);
+			const transcript = new MutableLinesComponent(
+				Array.from({ length: 12 }, (_value, index) => `history-${index}`),
+			);
+			const selector = new ArrowSelectorComponent();
+			tui.addChild(transcript);
+			tui.addChild(selector);
+			tui.setFocus(selector);
+
+			try {
+				tui.start();
+				await settle(term);
+
+				tui.setEagerNativeScrollbackRebuild(true);
+				transcript.setLines([
+					"history-0 updated",
+					...Array.from({ length: 11 }, (_value, index) => `history-${index + 1}`),
+				]);
+				tui.requestRender();
+				await settle(term);
+				tui.setEagerNativeScrollbackRebuild(false);
+
+				const writes = captureWrites(term);
+				term.sendInput("\x1b[B");
+				await settle(term);
+
+				const output = writes.join("");
+				expect(output.match(ERASE_SCROLLBACK) ?? []).toHaveLength(0);
+				expect(output).not.toContain("history-0 updated");
+				expect(term.getViewport().map(line => line.trimEnd())).toEqual([
+					"history-8",
+					"history-9",
+					"history-10",
+					"history-11",
+					"  first",
+					"> second",
+				]);
+			} finally {
+				tui.stop();
+			}
+		});
+	});
+});


### PR DESCRIPTION
## Repro
On an ED3-risk macOS/POSIX-style terminal whose native viewport position is unobservable, dirty foreground-stream rendering left native scrollback marked stale. The focused arrow-key reproduction is `bun test packages/tui/test/issue-1962-repro.test.ts`; before the fix, the arrow frame emitted `CSI 3 J` and replayed the transcript.

## Cause
`TUI.#planRender` in `packages/tui/src/tui.ts` allowed `allowUnknownViewportMutation` to satisfy the dirty-scrollback rebuild branch before diffing the focused input frame. `TUI.#handleInput` sets that flag for every focused component input, so Up/Down selector movement after dirty streaming became a destructive `historyRebuild` instead of a small visible-row repaint.

## Fix
- Changed the dirty-native-scrollback branch to rebuild only with a positive at-bottom proof, not from focused-input unknown-viewport opt-ins.
- Updated the #1682 focused-input regression to assert non-destructive repaint behavior.
- Added `packages/tui/test/issue-1962-repro.test.ts` covering Up/Down navigation after dirty foreground-stream rendering.
- Added the `packages/tui` changelog entry for #1962.

## Verification
Ran `bun test packages/tui/test/issue-1962-repro.test.ts packages/tui/test/issue-1682-repro.test.ts packages/tui/test/render-regressions.test.ts` — 105 pass. Ran `bun --cwd=packages/tui run check` successfully. Fixes #1962