### PR TITLE
fix(tui): add Ctrl+0 expand shortcut alias

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Fixed the expand shortcut so `Ctrl+0` also toggles collapsed tool/code previews, matching users who read or type the hint as zero instead of letter O. ([#1964](https://github.com/can1357/oh-my-pi/issues/1964))
 
 ## [15.9.5] - 2026-06-05
 ### Added

--- a/packages/coding-agent/src/config/keybindings.ts
+++ b/packages/coding-agent/src/config/keybindings.ts
@@ -111,7 +111,7 @@ export const KEYBINDINGS = {
 		description: "Select temporary model for current session",
 	},
 	"app.tools.expand": {
-		defaultKeys: "ctrl+o",
+		defaultKeys: ["ctrl+o", "ctrl+0"],
 		description: "Expand tools",
 	},
 	"app.editor.external": {

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -352,6 +352,7 @@ export class ExtensionRunner {
 		"ctrl+p": true,
 		"ctrl+l": true,
 		"ctrl+o": true,
+		"ctrl+0": true,
 		"ctrl+t": true,
 		"ctrl+g": true,
 		"shift+tab": true,

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -35,7 +35,7 @@ const DEFAULT_ACTION_KEYS: Record<ConfigurableEditorAction, KeyId[]> = {
 	"app.model.cycleBackward": ["shift+ctrl+p"],
 	"app.model.select": ["ctrl+l"],
 	"app.model.selectTemporary": ["alt+p"],
-	"app.tools.expand": ["ctrl+o"],
+	"app.tools.expand": ["ctrl+o", "ctrl+0"],
 	"app.thinking.toggle": ["ctrl+t"],
 	"app.editor.external": ["ctrl+g"],
 	"app.history.search": ["ctrl+r"],

--- a/packages/coding-agent/test/keybindings-display.test.ts
+++ b/packages/coding-agent/test/keybindings-display.test.ts
@@ -18,6 +18,13 @@ describe("KeybindingsManager.getDisplayString", () => {
 		expect(keybindings.getDisplayString("app.clipboard.copyPrompt")).toBe("Alt+Shift+C/Ctrl+Shift+C");
 	});
 
+	it("registers Ctrl+0 as a default expand alias", () => {
+		const keybindings = KeybindingsManager.inMemory();
+
+		expect(keybindings.getKeys("app.tools.expand")).toEqual(["ctrl+o", "ctrl+0"]);
+		expect(keybindings.getDisplayString("app.tools.expand")).toBe("Ctrl+O/Ctrl+0");
+	});
+
 	it("returns an empty string when the action has no binding", () => {
 		const keybindings = KeybindingsManager.inMemory({
 			"app.clipboard.copyPrompt": [],


### PR DESCRIPTION
## Repro
The default expand action only registered `ctrl+o`, so users pressing `Ctrl+0` could not expand collapsed code/tool previews. Reproduced with `bun -e 'import { KeybindingsManager } from "./src/config/keybindings.ts"; console.log(JSON.stringify(KeybindingsManager.inMemory().getKeys("app.tools.expand")));'` in `packages/coding-agent`, which printed `["ctrl+o"]` before the fix.

## Cause
`packages/coding-agent/src/config/keybindings.ts` declared `app.tools.expand` with only `ctrl+o`, and the fallback editor action map in `packages/coding-agent/src/modes/components/custom-editor.ts` mirrored that single binding. Extension shortcut reservation in `packages/coding-agent/src/extensibility/extensions/runner.ts` also only protected `ctrl+o`, so `ctrl+0` was never routed to the expand handler.

## Fix
- Registered `ctrl+0` as a default alias for `app.tools.expand` while preserving `ctrl+o`.
- Mirrored the alias in the editor fallback action-key map.
- Reserved `ctrl+0` from extension shortcuts so extensions cannot steal the app-level expand action.
- Added regression coverage for the resolved default expand bindings and display string.

## Verification
Ran `bun test test/keybindings-display.test.ts test/custom-editor-keybindings.test.ts` and `bun run check` in `packages/coding-agent`; both passed. Verified the repro command now prints `["ctrl+o","ctrl+0"]`. Fixes #1964