### PR TITLE
Add ScrollView component

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `ScrollView`, a fixed-height viewport component for pre-rendered lines with optional right-edge scrollbars and imperative scroll/page controls.
+
 ## [15.9.5] - 2026-06-05
 
 ### Changed

--- a/packages/tui/src/components/scroll-view.ts
+++ b/packages/tui/src/components/scroll-view.ts
@@ -1,0 +1,166 @@
+import type { Component } from "../tui";
+import { Ellipsis, replaceTabs, truncateToWidth, visibleWidth } from "../utils";
+
+const DEFAULT_TRACK = "│";
+const DEFAULT_THUMB = "█";
+
+type ScrollbarMode = "auto" | "always" | "never";
+
+export interface ScrollViewTheme {
+	track?: (text: string) => string;
+	thumb?: (text: string) => string;
+}
+
+export interface ScrollViewOptions {
+	height: number;
+	/** Defaults to "auto". "auto" reserves a scrollbar column only when content overflows. */
+	scrollbar?: ScrollbarMode | boolean;
+	/** Logical row count for pre-windowed line slices. Defaults to lines.length. */
+	totalRows?: number;
+	theme?: ScrollViewTheme;
+	trackChar?: string;
+	thumbChar?: string;
+}
+
+function normalizeScrollbarMode(scrollbar: ScrollViewOptions["scrollbar"]): ScrollbarMode {
+	if (scrollbar === true) return "auto";
+	if (scrollbar === false) return "never";
+	return scrollbar ?? "auto";
+}
+
+function firstCellGlyph(value: string, fallback: string): string {
+	const glyph = Array.from(value)[0] ?? fallback;
+	return visibleWidth(glyph) === 1 ? glyph : fallback;
+}
+
+/**
+ * Fixed-height viewport over pre-rendered lines, with optional right-edge scrollbar.
+ *
+ * ScrollView owns only the row offset. Callers remain responsible for producing
+ * already-wrapped logical lines appropriate for the current render width.
+ */
+export class ScrollView implements Component {
+	#lines: string[];
+	#height: number;
+	#scrollOffset = 0;
+	#totalRows: number | undefined;
+	#scrollbar: ScrollbarMode;
+	#theme: Required<ScrollViewTheme>;
+	#trackChar: string;
+	#thumbChar: string;
+
+	constructor(lines: readonly string[], options: ScrollViewOptions) {
+		this.#lines = [...lines];
+		this.#height = Number.isFinite(options.height) ? Math.max(0, Math.trunc(options.height)) : 0;
+		this.#totalRows = options.totalRows === undefined ? undefined : Math.max(0, Math.trunc(options.totalRows));
+		this.#scrollbar = normalizeScrollbarMode(options.scrollbar);
+		this.#theme = {
+			track: options.theme?.track ?? (text => text),
+			thumb: options.theme?.thumb ?? (text => text),
+		};
+		this.#trackChar = firstCellGlyph(options.trackChar ?? DEFAULT_TRACK, DEFAULT_TRACK);
+		this.#thumbChar = firstCellGlyph(options.thumbChar ?? DEFAULT_THUMB, DEFAULT_THUMB);
+		this.#clampScrollOffset();
+	}
+
+	setLines(lines: readonly string[]): void {
+		this.#lines = [...lines];
+		this.#clampScrollOffset();
+	}
+
+	setTotalRows(totalRows: number | undefined): void {
+		this.#totalRows = totalRows === undefined ? undefined : Math.max(0, Math.trunc(totalRows));
+		this.#clampScrollOffset();
+	}
+
+	setHeight(height: number): void {
+		this.#height = Number.isFinite(height) ? Math.max(0, Math.trunc(height)) : 0;
+		this.#clampScrollOffset();
+	}
+
+	setScrollbar(scrollbar: ScrollViewOptions["scrollbar"]): void {
+		this.#scrollbar = normalizeScrollbarMode(scrollbar);
+	}
+
+	getScrollOffset(): number {
+		return this.#scrollOffset;
+	}
+
+	getMaxScrollOffset(): number {
+		const rowCount = this.#totalRows ?? this.#lines.length;
+		return Math.max(0, rowCount - this.#height);
+	}
+
+	setScrollOffset(offset: number): void {
+		this.#scrollOffset = Number.isFinite(offset) ? Math.trunc(offset) : 0;
+		this.#clampScrollOffset();
+	}
+
+	scroll(delta: number): void {
+		this.setScrollOffset(this.#scrollOffset + (Number.isFinite(delta) ? Math.trunc(delta) : 0));
+	}
+
+	page(delta: number): void {
+		const step = Math.max(1, this.#height - 1);
+		this.scroll(step * (Number.isFinite(delta) ? Math.trunc(delta) : 0));
+	}
+
+	scrollToTop(): void {
+		this.#scrollOffset = 0;
+	}
+
+	scrollToBottom(): void {
+		this.#scrollOffset = this.getMaxScrollOffset();
+	}
+
+	invalidate(): void {
+		// No cached layout to invalidate.
+	}
+
+	render(width: number): string[] {
+		this.#clampScrollOffset();
+		const safeWidth = Number.isFinite(width) ? Math.max(0, Math.trunc(width)) : 0;
+		if (this.#height === 0) return [];
+		const showScrollbar = safeWidth > 0 && this.#shouldRenderScrollbar();
+		const contentWidth = Math.max(0, safeWidth - (showScrollbar ? 1 : 0));
+		const thumb = showScrollbar ? this.#thumbRange() : undefined;
+		const lines: string[] = [];
+		for (let row = 0; row < this.#height; row++) {
+			const sourceIndex = this.#totalRows === undefined ? this.#scrollOffset + row : row;
+			const source = this.#lines[sourceIndex] ?? "";
+			const truncated = truncateToWidth(replaceTabs(source), contentWidth, Ellipsis.Unicode);
+			if (!showScrollbar) {
+				lines.push(truncated);
+				continue;
+			}
+			const content = `${truncated}${" ".repeat(Math.max(0, contentWidth - visibleWidth(truncated)))}`;
+			const barGlyph = thumb && row >= thumb.start && row < thumb.end ? this.#thumbChar : this.#trackChar;
+			const styledBar =
+				thumb && row >= thumb.start && row < thumb.end ? this.#theme.thumb(barGlyph) : this.#theme.track(barGlyph);
+			lines.push(`${content}${styledBar}`);
+		}
+		return lines;
+	}
+
+	#clampScrollOffset(): void {
+		this.#scrollOffset = Math.max(0, Math.min(this.#scrollOffset, this.getMaxScrollOffset()));
+	}
+
+	#shouldRenderScrollbar(): boolean {
+		if (this.#height <= 0) return false;
+		if (this.#scrollbar === "never") return false;
+		if (this.#scrollbar === "always") return true;
+		return (this.#totalRows ?? this.#lines.length) > this.#height;
+	}
+
+	#thumbRange(): { start: number; end: number } {
+		if (this.#height <= 0) return { start: 0, end: 0 };
+		const rowCount = this.#totalRows ?? this.#lines.length;
+		if (rowCount <= this.#height) return { start: 0, end: this.#height };
+		const thumbSize = Math.max(1, Math.min(Math.floor((this.#height * this.#height) / rowCount), this.#height));
+		const travel = this.#height - thumbSize;
+		const maxOffset = this.getMaxScrollOffset();
+		const start = maxOffset === 0 ? 0 : Math.round((this.#scrollOffset / maxOffset) * travel);
+		return { start, end: start + thumbSize };
+	}
+}

--- a/packages/tui/src/components/settings-list.ts
+++ b/packages/tui/src/components/settings-list.ts
@@ -1,6 +1,7 @@
 import { getKeybindings } from "../keybindings";
 import type { Component } from "../tui";
 import { Ellipsis, padding, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "../utils";
+import { ScrollView } from "./scroll-view";
 
 export interface SettingItem {
 	/** Unique identifier for this setting */
@@ -90,6 +91,22 @@ export class SettingsList implements Component {
 		return this.#renderMainList(width);
 	}
 
+	#renderItemRow(item: SettingItem, index: number, maxLabelWidth: number, rowWidth: number): string {
+		const isSelected = index === this.#selectedIndex;
+		const prefix = isSelected ? this.#theme.cursor : "  ";
+		const prefixWidth = visibleWidth(prefix);
+		const labelPadded = item.label + padding(Math.max(0, maxLabelWidth - visibleWidth(item.label)));
+		const labelText = this.#theme.label(labelPadded, isSelected, item.changed === true);
+		const separator = "  ";
+		const valueMaxWidth = rowWidth - prefixWidth - maxLabelWidth - visibleWidth(separator) - 2;
+		const valueText = this.#theme.value(
+			truncateToWidth(item.currentValue, valueMaxWidth, Ellipsis.Omit),
+			isSelected,
+			item.changed === true,
+		);
+		return truncateToWidth(prefix + labelText + separator + valueText, Math.max(0, rowWidth));
+	}
+
 	#renderMainList(width: number): string[] {
 		const lines: string[] = [];
 
@@ -98,48 +115,29 @@ export class SettingsList implements Component {
 			return lines;
 		}
 
-		// Calculate visible range with scrolling
+		const viewportHeight = Math.min(this.#maxVisible, this.#items.length);
 		const startIndex = Math.max(
 			0,
-			Math.min(this.#selectedIndex - Math.floor(this.#maxVisible / 2), this.#items.length - this.#maxVisible),
+			Math.min(this.#selectedIndex - Math.floor(viewportHeight / 2), this.#items.length - viewportHeight),
 		);
-		const endIndex = Math.min(startIndex + this.#maxVisible, this.#items.length);
-
-		// Calculate max label width for alignment
 		const maxLabelWidth = Math.min(30, Math.max(...this.#items.map(item => visibleWidth(item.label))));
-
-		// Render visible items
-		for (let i = startIndex; i < endIndex; i++) {
-			const item = this.#items[i];
-			if (!item) continue;
-
-			const isSelected = i === this.#selectedIndex;
-			const prefix = isSelected ? this.#theme.cursor : "  ";
-			const prefixWidth = visibleWidth(prefix);
-
-			// Pad label to align values
-			const labelPadded = item.label + padding(Math.max(0, maxLabelWidth - visibleWidth(item.label)));
-			const labelText = this.#theme.label(labelPadded, isSelected, item.changed === true);
-
-			// Calculate space for value
-			const separator = "  ";
-			const usedWidth = prefixWidth + maxLabelWidth + visibleWidth(separator);
-			const valueMaxWidth = width - usedWidth - 2;
-
-			const valueText = this.#theme.value(
-				truncateToWidth(item.currentValue, valueMaxWidth, Ellipsis.Omit),
-				isSelected,
-				item.changed === true,
-			);
-
-			lines.push(truncateToWidth(prefix + labelText + separator + valueText, width));
-		}
-
-		// Add scroll indicator if needed
-		if (startIndex > 0 || endIndex < this.#items.length) {
-			const scrollText = `  (${this.#selectedIndex + 1}/${this.#items.length})`;
-			lines.push(this.#theme.hint(truncateToWidth(scrollText, width - 2, Ellipsis.Omit)));
-		}
+		const itemRowsOverflow = this.#items.length > viewportHeight;
+		const itemRowWidth = Math.max(0, width - (itemRowsOverflow ? 1 : 0));
+		const visibleItems = this.#items.slice(startIndex, startIndex + viewportHeight);
+		const itemRows = visibleItems.map((item, index) =>
+			this.#renderItemRow(item, startIndex + index, maxLabelWidth, itemRowWidth),
+		);
+		const scrollView = new ScrollView(itemRows, {
+			height: viewportHeight,
+			scrollbar: "auto",
+			totalRows: this.#items.length,
+			theme: {
+				track: text => this.#theme.hint(text),
+				thumb: text => this.#theme.label(text, true, false),
+			},
+		});
+		scrollView.setScrollOffset(startIndex);
+		lines.push(...scrollView.render(width));
 
 		// Add description for selected item
 		const selectedItem = this.#items[this.#selectedIndex];

--- a/packages/tui/src/index.ts
+++ b/packages/tui/src/index.ts
@@ -10,6 +10,7 @@ export * from "./components/image";
 export * from "./components/input";
 export * from "./components/loader";
 export * from "./components/markdown";
+export * from "./components/scroll-view";
 export * from "./components/select-list";
 export * from "./components/settings-list";
 export * from "./components/spacer";

--- a/packages/tui/test/scroll-view.test.ts
+++ b/packages/tui/test/scroll-view.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import { ScrollView } from "../src/components/scroll-view";
+import { visibleWidth } from "../src/utils";
+
+const theme = {
+	track: () => "T",
+	thumb: () => "B",
+};
+
+describe("ScrollView", () => {
+	it("renders a fixed-height viewport and omits auto scrollbar when content fits", () => {
+		const view = new ScrollView(["one", "two"], { height: 3, theme });
+
+		expect(view.render(10)).toEqual(["one", "two", ""]);
+	});
+
+	it("renders a right-edge scrollbar when content overflows", () => {
+		const view = new ScrollView(["alpha", "beta", "gamma", "delta", "omega"], { height: 3, theme });
+
+		expect(view.render(6)).toEqual(["alphaB", "beta T", "gammaT"]);
+	});
+
+	it("scrolls and clamps offsets", () => {
+		const view = new ScrollView(["one", "two", "three", "four", "five"], { height: 3, theme });
+
+		view.scroll(10);
+
+		expect(view.getScrollOffset()).toBe(2);
+		expect(view.render(6)).toEqual(["threeT", "four T", "five B"]);
+
+		view.scroll(-10);
+
+		expect(view.getScrollOffset()).toBe(0);
+	});
+
+	it("reserves a scrollbar column in always mode", () => {
+		const view = new ScrollView(["one"], { height: 2, scrollbar: "always", theme });
+
+		expect(view.render(5)).toEqual(["one B", "    B"]);
+	});
+
+	it("does not reserve a scrollbar column in never mode", () => {
+		const view = new ScrollView(["alpha", "beta", "gamma"], { height: 2, scrollbar: "never", theme });
+
+		expect(view.render(6)).toEqual(["alpha", "beta"]);
+	});
+
+	it("renders scrollbar geometry for pre-windowed lines", () => {
+		const view = new ScrollView(["gamma", "delta"], { height: 2, totalRows: 4, theme });
+		view.setScrollOffset(2);
+
+		expect(view.render(6)).toEqual(["gammaT", "deltaB"]);
+	});
+
+	it("does not render a scrollbar when width is zero", () => {
+		const view = new ScrollView(["one", "two"], { height: 1, theme });
+
+		expect(view.render(0)).toEqual([""]);
+	});
+
+	it("clamps scroll offset when content shrinks", () => {
+		const view = new ScrollView(["one", "two", "three", "four"], { height: 2, theme });
+		view.scrollToBottom();
+
+		view.setLines(["one"]);
+
+		expect(view.getScrollOffset()).toBe(0);
+		expect(view.render(10)).toEqual(["one", ""]);
+	});
+
+	it("keeps rendered rows within requested width with ANSI input", () => {
+		const view = new ScrollView(["\x1b[31malphabet\x1b[0m", "plain", "tail"], { height: 2, theme });
+		const rendered = view.render(5);
+
+		expect(rendered).toHaveLength(2);
+		expect(rendered.every(line => visibleWidth(line) <= 5)).toBe(true);
+		expect(rendered[0]).toContain("B");
+	});
+});

--- a/packages/tui/test/settings-list.test.ts
+++ b/packages/tui/test/settings-list.test.ts
@@ -70,4 +70,41 @@ describe("SettingsList", () => {
 		expect(output).toContain("[changed-value]on");
 		expect(output).not.toContain("[changed-label]Default");
 	});
+
+	it("renders long settings tabs through a scrollbar viewport", () => {
+		const list = new SettingsList(
+			Array.from({ length: 6 }, (_, i) => ({
+				id: `item-${i}`,
+				label: `Item ${i}`,
+				currentValue: `value-${i}`,
+				values: [`value-${i}`],
+			})),
+			3,
+			{
+				...testTheme,
+				label: (text: string, selected: boolean) => (selected ? `[selected]${text}` : text),
+				hint: (text: string) => `[dim]${text}`,
+			},
+			() => {},
+			() => {},
+		);
+
+		const output = list.render(32);
+
+		expect(output.slice(0, 3).join("\n")).toContain("[selected]");
+		expect(output.slice(0, 3).join("\n")).toContain("[dim]");
+		expect(output).not.toContain("(1/6)");
+	});
+
+	it("does not reserve a scrollbar column when all settings fit", () => {
+		const list = new SettingsList(
+			[{ id: "mode", label: "Mode", currentValue: "123456", values: ["123456"] }],
+			3,
+			testTheme,
+			() => {},
+			() => {},
+		);
+
+		expect(list.render(16)[0]).toBe("→ Mode  123456");
+	});
 });


### PR DESCRIPTION
## Summary
- add a reusable `ScrollView` component to `@oh-my-pi/pi-tui` for fixed-height pre-rendered line viewports
- support auto/always/never right-edge scrollbars with imperative scroll/page/top/bottom controls
- use `ScrollView` inside `SettingsList` so long `/settings` tabs get a real scrollbar instead of only a textual position hint

## UX
This gives `/settings` a visible scrollbar for overflowing tabs; useful for dense tabs like Appearance.

## Tests
- `bun --cwd=packages/tui run check`
- `bun --cwd=packages/tui test test/scroll-view.test.ts test/settings-list.test.ts`
