### PR TITLE
fix(tui): honor resume clear replay before initial paint

### DIFF
--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -268,7 +268,7 @@ async function runInteractiveMode(
 		force: forceSetupWizard,
 	});
 
-	await mode.init({ suppressWelcomeIntro: setupScenes.length > 0 });
+	await mode.init({ suppressWelcomeIntro: resuming || setupScenes.length > 0 });
 
 	if (setupScenes.length > 0) {
 		await runSetupWizard(mode, setupScenes);

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1602,6 +1602,7 @@ export class TUI extends Container {
 					clearViewport: true,
 					clearScrollback: !isMultiplexerSession(),
 				});
+				this.#hasEverRendered = true;
 				return;
 			case "historyRebuild":
 				this.#clearNativeScrollbackDirty();
@@ -1686,13 +1687,17 @@ export class TUI extends Container {
 		liveRegionStart: number | undefined,
 		commitSafeEnd: number | undefined,
 	): RenderIntent {
+		// A forced scrollback wipe can be queued before start()'s initial paint runs
+		// (cold `omp --resume` does this while replacing the welcome frame with the
+		// restored transcript). Honor it before the normal initial-preserve path so
+		// the first committed frame is the clean session replay, not a deferred wipe
+		// that waits for the user's first keystroke.
+		if (this.#clearScrollbackOnNextRender) return { kind: "sessionReplace" };
+
 		// Initial paint after start(): scrollback must keep its prior shell
 		// content, but the viewport must be cleared so stale rows do not bleed
 		// into the new UI.
 		if (!this.#hasEverRendered) return { kind: "initial" };
-
-		// Caller opted into a scrollback wipe via requestRender(true, { clearScrollback: true }).
-		if (this.#clearScrollbackOnNextRender) return { kind: "sessionReplace" };
 
 		const forceViewportRepaint = this.#forceViewportRepaintOnNextRender;
 		const eagerEraseScrollbackRisk = process.platform !== "win32" && TERMINAL.eagerEraseScrollbackRisk;

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -3972,6 +3972,23 @@ describe("foreground-tool streaming on ED3-risk terminals", () => {
 		});
 	});
 
+	it("honors a clear-scrollback replay queued before the initial paint", async () => {
+		const term = new VirtualTerminal(40, 6);
+		const writes = captureWrites(term);
+		const tui = new TUI(term);
+		tui.addChild(new MutableLinesComponent(["resumed-message", "prompt>"]));
+
+		try {
+			tui.start();
+			tui.requestRender(true, { clearScrollback: true });
+			await settle(term);
+
+			expect(writes.join("")).toContain("\x1b[3J");
+		} finally {
+			tui.stop();
+		}
+	});
+
 	// Repro of the drag-resize line-duplication: dragging the terminal smaller
 	// fires a stream of height shrinks. While the transcript FITS the viewport,
 	// each shrink used to scroll live rows into native scrollback — the in-place


### PR DESCRIPTION
## Repro
Cold `omp --resume` starts the TUI, then immediately replaces the startup frame with the restored transcript via `requestRender(true, { clearScrollback: true })`. A focused repro that starts a `TUI`, queues that forced clear before the first scheduled paint settles, and inspects writes showed the first paint did not emit `ESC[3J`, so the cleanup was deferred until a later render/input event.

## Cause
`packages/tui/src/tui.ts` planned the normal `initial` render before checking `#clearScrollbackOnNextRender`, so a forced cold-start replay queued before the first paint was ignored by that first commit. `packages/coding-agent/src/main.ts` also allowed the welcome intro animation during resumed startup, adding extra offscreen churn above the restored transcript.

## Fix
- Prioritize `#clearScrollbackOnNextRender` over the initial-preserve render path and mark that session-replace paint as rendered.
- Suppress the welcome intro when interactive mode is started for `--resume`, `--continue`, or `--fork`.
- Add a TUI regression test covering a clear-scrollback replay queued before the initial paint.

## Verification
- `bun test packages/tui/test/render-regressions.test.ts` passed: 95 tests.
- `bun --cwd=packages/tui run check` passed.
- `bun --cwd=packages/coding-agent run check:types` passed.
- Pre-publish `gh_push_branch` gate passed and pushed the branch. Fixes #1972