### PR TITLE
fix(tui): commit tmux pane history during streaming via pinned emit

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed tmux (and screen/zellij) pane scrollback losing the head of a long streamed assistant reply once it grew past the visible pane, and stranding the chrome/footer in pane history after a later collapse — producing the "repeating chunks and missing sections" reporters saw when scrolling back through tmux pane history ([#1974](https://github.com/can1357/oh-my-pi/issues/1974)). The renderer's foreground-streaming cap-to-viewport branch (introduced in 15.9.2 for ED3-risk hosts that can checkpoint-rebuild later) also activated inside multiplexers, where checkpoint reconcile is a no-op (`refreshNativeScrollbackIfDirty` short-circuits because `\x1b[3J` cannot erase pane history). Every streaming frame clipped `lines` to the visible tail and reset `#scrollbackHighWater` to 0, so any row that scrolled above the viewport top was committed nowhere — pane history stayed empty until streaming ended. Meanwhile `#planLiveRegionPinnedRender` was explicitly disabled for multiplexers, but its `#emitLiveRegionPinnedRepaint` is built from the exact primitives tmux accepts (relative cursor moves, per-line `\x1b[2K`, `\r\n` to scroll the sealed prefix past the viewport bottom) and never emits `\x1b[2J`/`\x1b[3J`. The pinned planner now runs in multiplexers too, the cap branch skips them, and the diff/append path commits incrementally into pane history; the actively-mutating live tail stays in the visible viewport only.
+
 ## [15.9.5] - 2026-06-05
 
 ### Changed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1528,6 +1528,7 @@ export class TUI extends Container {
 			} else if (
 				!explicitReconcile &&
 				nativeViewportAtBottom !== true &&
+				!isMultiplexerSession() &&
 				(intent.kind === "sessionReplace" ||
 					intent.kind === "historyRebuild" ||
 					intent.kind === "overlayRebuild" ||
@@ -1535,6 +1536,13 @@ export class TUI extends Container {
 			) {
 				// Cap the frame to the viewport and keep scrollback dirty: transient
 				// rows never enter history, and the checkpoint reconciles later.
+				// Multiplexers (tmux/screen/zellij) are excluded: their checkpoint
+				// reconcile is a no-op (pane history cannot be erased), so any rows
+				// dropped here are dropped forever. Pane history is append-only
+				// anyway, so a normal diff/append `\r\n` commit is exactly what the
+				// multiplexer needs — and the `liveRegionPinned` planner above
+				// keeps the actively-mutating live tail out of pane history while
+				// committing only the sealed prefix (issue #1974).
 				this.#markNativeScrollbackDirty();
 				this.#streamingHighWater = Math.max(this.#streamingHighWater, lines.length);
 				this.#scrollbackHighWater = 0;
@@ -2174,11 +2182,18 @@ export class TUI extends Container {
 			liveRegionStart >= newLines.length ||
 			!this.#eagerNativeScrollbackRebuild ||
 			!eagerEraseScrollbackRisk ||
-			allowUnknownViewportMutation ||
-			isMultiplexerSession()
+			allowUnknownViewportMutation
 		) {
 			return undefined;
 		}
+		// Multiplexers (tmux/screen/zellij) cannot erase pane history with `\x1b[3J`
+		// and cannot answer a viewport-position probe, so the destructive checkpoint
+		// rebuild path is forever unavailable. The pinned emitter is built from the
+		// opposite primitives — relative cursor moves, per-line `\x1b[2K`, and
+		// `\r\n` to scroll sealed rows past the viewport bottom — which are exactly
+		// what tmux pane history accepts. Without this commit-as-you-go path, the
+		// streaming cap below clipped every frame to the visible tail and the
+		// scrolled-off head was committed nowhere (issue #1974).
 		if (newLines.length <= height && this.#scrollbackHighWater === 0) return undefined;
 		if (this.#readNativeViewportAtBottom() !== undefined) return undefined;
 

--- a/packages/tui/test/issue-1974-repro.test.ts
+++ b/packages/tui/test/issue-1974-repro.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import {
-	type Component,
-	type NativeScrollbackLiveRegion,
-	TERMINAL,
-	TUI,
-} from "@oh-my-pi/pi-tui";
+import { type Component, type NativeScrollbackLiveRegion, TERMINAL, TUI } from "@oh-my-pi/pi-tui";
 import { VirtualTerminal } from "./virtual-terminal";
 
 // Regression test for https://github.com/can1357/oh-my-pi/issues/1974
@@ -83,10 +78,7 @@ async function settle(term: VirtualTerminal): Promise<void> {
 	await term.flush();
 }
 
-async function withEnvPatch<T>(
-	patch: Record<string, string | undefined>,
-	run: () => T | Promise<T>,
-): Promise<T> {
+async function withEnvPatch<T>(patch: Record<string, string | undefined>, run: () => T | Promise<T>): Promise<T> {
 	const saved: Record<string, string | undefined> = {};
 	for (const key in patch) {
 		saved[key] = Bun.env[key];
@@ -233,9 +225,7 @@ describe("issue #1974: tmux scrollback rendering", () => {
 
 					const writes = capture(term);
 					for (let chunk = 5; chunk <= 40; chunk += 5) {
-						stream.setLines(
-							Array.from({ length: chunk }, (_unused, i) => `row-${String(i).padStart(3, "0")}`),
-						);
+						stream.setLines(Array.from({ length: chunk }, (_unused, i) => `row-${String(i).padStart(3, "0")}`));
 						tui.requestRender();
 						await settle(term);
 					}

--- a/packages/tui/test/issue-1974-repro.test.ts
+++ b/packages/tui/test/issue-1974-repro.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it } from "bun:test";
+import {
+	type Component,
+	type NativeScrollbackLiveRegion,
+	TERMINAL,
+	TUI,
+} from "@oh-my-pi/pi-tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+// Regression test for https://github.com/can1357/oh-my-pi/issues/1974
+//
+// Inside tmux (and other multiplexers), a long streamed reply that grows past
+// the viewport lost its scrolled-off head from pane history and, after a
+// later viewport repaint, the same content reappeared inside the visible
+// pane while the original streamed rows were stranded above — leaving
+// "missing sections" interleaved with "repeating chunks" when the user
+// scrolled back through the tmux pane buffer. The renderer's foreground-
+// streaming cap-to-viewport branch clipped `lines` to the visible tail and
+// reset `#scrollbackHighWater` to 0 for every streaming frame, so no rows
+// ever entered tmux pane history while the assistant reply was active.
+//
+// The `liveRegionPinned` intent already knows how to push the sealed prefix
+// of an append-only live block into native scrollback via `\r\n` without
+// emitting ED3 — exactly what tmux can accept — but it used to short-circuit
+// inside multiplexers. Enabling it (and skipping the cap when the planner
+// picks it) commits the assistant reply's head into pane history exactly
+// once while the live tail keeps repainting in place.
+
+class LineList implements Component {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = [...lines];
+	}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		return this.#lines.map(line => line.slice(0, width));
+	}
+
+	setLines(lines: string[]): void {
+		this.#lines = [...lines];
+	}
+}
+
+/**
+ * Minimal append-only live region. Models the real omp setup where
+ * `TranscriptContainer` wraps an `AssistantMessageComponent` that reports
+ * itself as `isTranscriptBlockAppendOnly() === true`.
+ */
+class StreamingLiveRegion implements Component, NativeScrollbackLiveRegion {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = [...lines];
+	}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		return this.#lines.map(line => line.slice(0, width));
+	}
+
+	setLines(lines: string[]): void {
+		this.#lines = [...lines];
+	}
+
+	getNativeScrollbackLiveRegionStart(): number | undefined {
+		return 0;
+	}
+
+	getNativeScrollbackCommitSafeEnd(): number | undefined {
+		return this.#lines.length;
+	}
+}
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	const nextTick = Promise.withResolvers<void>();
+	process.nextTick(nextTick.resolve);
+	await nextTick.promise;
+	await Bun.sleep(20);
+	await term.flush();
+}
+
+async function withEnvPatch<T>(
+	patch: Record<string, string | undefined>,
+	run: () => T | Promise<T>,
+): Promise<T> {
+	const saved: Record<string, string | undefined> = {};
+	for (const key in patch) {
+		saved[key] = Bun.env[key];
+		const value = patch[key];
+		if (value === undefined) {
+			delete Bun.env[key];
+		} else {
+			Bun.env[key] = value;
+		}
+	}
+	try {
+		return await run();
+	} finally {
+		for (const key in saved) {
+			const value = saved[key];
+			if (value === undefined) {
+				delete Bun.env[key];
+			} else {
+				Bun.env[key] = value;
+			}
+		}
+	}
+}
+
+type MutableTerminalInfo = { eagerEraseScrollbackRisk: boolean };
+
+async function withTerminalRisk<T>(risk: boolean, run: () => T | Promise<T>): Promise<T> {
+	const mutable = TERMINAL as unknown as MutableTerminalInfo;
+	const saved = mutable.eagerEraseScrollbackRisk;
+	mutable.eagerEraseScrollbackRisk = risk;
+	try {
+		return await run();
+	} finally {
+		mutable.eagerEraseScrollbackRisk = saved;
+	}
+}
+
+function overrideProbe(term: VirtualTerminal, answer: boolean | undefined): void {
+	(term as unknown as { isNativeViewportAtBottom: () => boolean | undefined }).isNativeViewportAtBottom = () => answer;
+}
+
+function strip(rows: string[]): string[] {
+	return rows.map(row => Bun.stripANSI(row).trimEnd());
+}
+
+const TMUX_ENV: Record<string, string | undefined> = {
+	TMUX: "1",
+	STY: undefined,
+	ZELLIJ: undefined,
+};
+
+const ERASE_SCROLLBACK = /\x1b\[3J/g;
+
+function capture(term: VirtualTerminal): string[] {
+	const writes: string[] = [];
+	const realWrite = term.write.bind(term);
+	(term as unknown as { write: (s: string) => void }).write = (data: string) => {
+		writes.push(data);
+		realWrite(data);
+	};
+	return writes;
+}
+
+function occurrencesOf(haystack: string, needle: string): number {
+	return haystack.split(needle).length - 1;
+}
+
+describe("issue #1974: tmux scrollback rendering", () => {
+	it("commits a streaming reply's scrolled-off head to pane history exactly once", async () => {
+		if (process.platform === "win32") return;
+
+		await withEnvPatch(TMUX_ENV, async () => {
+			await withTerminalRisk(true, async () => {
+				const term = new VirtualTerminal(80, 8, 10_000);
+				// Real tmux/ProcessTerminal does not implement
+				// `isNativeViewportAtBottom`, so the renderer sees `undefined`
+				// in production. Match that here.
+				overrideProbe(term, undefined);
+
+				const tui = new TUI(term);
+				const stream = new StreamingLiveRegion([]);
+				tui.addChild(stream);
+
+				const markers = Array.from({ length: 40 }, (_unused, i) => `MARK-${String(i).padStart(3, "0")}`);
+
+				try {
+					tui.start();
+					tui.setEagerNativeScrollbackRebuild(true);
+					await settle(term);
+
+					// Stream the reply in chunks. Each chunk grows the live block
+					// by 5 rows — small enough that no single frame double-
+					// overflows the 8-row viewport, large enough that the head
+					// must scroll into pane history between frames.
+					for (let chunk = 5; chunk <= markers.length; chunk += 5) {
+						stream.setLines(markers.slice(0, chunk));
+						tui.requestRender();
+						await settle(term);
+					}
+
+					// `getScrollBuffer()` returns pane history + the active grid
+					// (i.e. what tmux would show when the user scrolled all the
+					// way up). Each MARK-NNN must appear in that combined buffer
+					// exactly once — no gaps ("missing sections") and no
+					// duplicates ("repeating chunks").
+					const scrollback = strip(term.getScrollBuffer());
+					const buffer = scrollback.join("\n");
+					const missing: string[] = [];
+					const duplicated: string[] = [];
+					for (const mark of markers) {
+						const occ = occurrencesOf(buffer, mark);
+						if (occ === 0) missing.push(mark);
+						if (occ > 1) duplicated.push(mark);
+					}
+					expect(missing).toEqual([]);
+					expect(duplicated).toEqual([]);
+
+					// The visible viewport still shows the live tail.
+					const viewport = strip(term.getViewport());
+					expect(viewport.some(row => row.includes("MARK-039"))).toBe(true);
+				} finally {
+					tui.stop();
+					await term.flush();
+				}
+			});
+		});
+	});
+
+	it("never emits ED3 (CSI 3 J) inside a tmux pane during streaming", async () => {
+		if (process.platform === "win32") return;
+
+		await withEnvPatch(TMUX_ENV, async () => {
+			await withTerminalRisk(true, async () => {
+				const term = new VirtualTerminal(80, 8, 10_000);
+				overrideProbe(term, undefined);
+				const tui = new TUI(term);
+				const stream = new StreamingLiveRegion([]);
+				tui.addChild(stream);
+
+				try {
+					tui.start();
+					tui.setEagerNativeScrollbackRebuild(true);
+					await settle(term);
+
+					const writes = capture(term);
+					for (let chunk = 5; chunk <= 40; chunk += 5) {
+						stream.setLines(
+							Array.from({ length: chunk }, (_unused, i) => `row-${String(i).padStart(3, "0")}`),
+						);
+						tui.requestRender();
+						await settle(term);
+					}
+
+					// ED3 would either be a no-op or yank a scrolled tmux reader.
+					// The tmux path must commit incrementally via \r\n.
+					expect(writes.join("").match(ERASE_SCROLLBACK)?.length ?? 0).toBe(0);
+				} finally {
+					tui.stop();
+					await term.flush();
+				}
+			});
+		});
+	});
+
+	it("does not push chrome below the live block into pane history", async () => {
+		// Models a real omp frame: streamed assistant reply on top, persistent
+		// chrome (status line / editor) below. The live region ends mid-frame,
+		// so the renderer must push only sealed rows of the live block into
+		// pane history while keeping the chrome rows transient and confined to
+		// the visible pane.
+		if (process.platform === "win32") return;
+
+		await withEnvPatch(TMUX_ENV, async () => {
+			await withTerminalRisk(true, async () => {
+				const term = new VirtualTerminal(80, 10, 10_000);
+				overrideProbe(term, undefined);
+				const tui = new TUI(term);
+				const stream = new StreamingLiveRegion([]);
+				const footer = new LineList(["── prompt ──", "> "]);
+				tui.addChild(stream);
+				tui.addChild(footer);
+
+				const markers = Array.from({ length: 30 }, (_unused, i) => `STREAM-${String(i).padStart(3, "0")}`);
+
+				try {
+					tui.start();
+					tui.setEagerNativeScrollbackRebuild(true);
+					await settle(term);
+
+					for (let chunk = 4; chunk <= markers.length; chunk += 4) {
+						stream.setLines(markers.slice(0, chunk));
+						tui.requestRender();
+						await settle(term);
+					}
+
+					// `getScrollBuffer()` returns pane history followed by the
+					// active grid (the visible viewport). For "what is in pane
+					// history alone", chop off the last `rows` entries.
+					const fullBuffer = strip(term.getScrollBuffer());
+					const viewport = strip(term.getViewport());
+					const history = fullBuffer.slice(0, Math.max(0, fullBuffer.length - viewport.length));
+
+					// Chrome must NEVER enter pane history (it sits below the live
+					// region and never sealed).
+					expect(history.some(row => row.includes("── prompt ──"))).toBe(false);
+					expect(history.some(row => row.includes("> "))).toBe(false);
+					// Chrome stays in the visible viewport.
+					expect(viewport.some(row => row.includes("── prompt ──"))).toBe(true);
+
+					// No streamed row appears twice across pane history.
+					const historyText = history.join("\n");
+					const duplicated = markers.filter(m => occurrencesOf(historyText, m) > 1);
+					expect(duplicated).toEqual([]);
+
+					// The pane-history slice runs in original streaming order so
+					// a tmux scroll-back is monotonic.
+					const historyMarks = history
+						.map(row => row.match(/STREAM-\d{3}/)?.[0] ?? null)
+						.filter((m): m is string => m !== null);
+					expect(historyMarks).toEqual(markers.slice(0, historyMarks.length));
+				} finally {
+					tui.stop();
+					await term.flush();
+				}
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Repro

Run `omp` inside tmux, drive a long-enough conversation that an
assistant reply overflows the visible pane, then scroll up in the tmux
buffer. The streamed reply's earlier rows are missing from pane history
(or in shorter sessions, the prompt chrome appears mid-history), so
scroll-back shows interleaved "repeating chunks and missing sections"
instead of a clean continuous transcript.

A renderer-level repro lives in
`packages/tui/test/issue-1974-repro.test.ts`: with `TMUX=1`,
`eagerEraseScrollbackRisk=true`, an overridden `isNativeViewportAtBottom
-> undefined` (matching real tmux/`ProcessTerminal`), and a
`NativeScrollbackLiveRegion` that streams 40 rows in 8 chunks, every
row that scrolled above the viewport top was committed nowhere — pane
history stayed empty until streaming ended, and the visible viewport
only ever held the last 8 rows.

```
bun --cwd packages/tui test test/issue-1974-repro.test.ts
```

(Before the fix: 2 of 3 tests fail with MARK-000..MARK-031 missing from
pane history and the chrome/footer pushed in alongside.)

## Cause

The foreground-streaming cap-to-viewport branch in `tui.ts`
(`#doRender` ~lines 1500-1548, added in 15.9.2 for ED3-risk hosts that
can checkpoint-rebuild later) also activated inside multiplexers,
where checkpoint reconcile is a no-op
(`refreshNativeScrollbackIfDirty` short-circuits because `\x1b[3J`
cannot erase pane history). Every streaming frame matched the
`intent.kind === "diff" && intent.appendedLines` predicate, so it
clipped `lines = lines.slice(-height)`, reset
`#scrollbackHighWater = 0`, and switched intent to
`viewportRepaint` — which only rewrites the visible rows and never
pushes anything past the bottom row. The result: nothing landed in
tmux pane history while the assistant reply was active.

Meanwhile `#planLiveRegionPinnedRender` was explicitly disabled for
multiplexers (`isMultiplexerSession()` in its disable gate), but its
`#emitLiveRegionPinnedRepaint` is built from the exact primitives tmux
accepts (relative cursor moves, per-line `\x1b[2K`, `\r\n` to scroll
the sealed prefix past the viewport bottom) and never emits
`\x1b[2J`/`\x1b[3J`. The right path was already in the renderer; it
was just gated off for the one host shape that actually needs it.

## Fix

- `#planLiveRegionPinnedRender`: drop the `isMultiplexerSession()`
  disable. Tmux now selects `liveRegionPinned` whenever
  eager streaming is active, an append-only live region is reported,
  and the live content overflows the viewport — exactly the same
  conditions as on POSIX ED3-risk hosts.
- Cap-to-viewport eligibility (`#doRender`): add
  `!isMultiplexerSession()` to the predicate so multiplexers never
  clip+reset `#scrollbackHighWater`. When pinned fires, the cap is
  already bypassed (`liveRegionPinned` isn't in the cap-eligible
  list); when pinned returns undefined (no live region reported, or
  no overflow yet), the original `diff` intent stands and pushes rows
  into pane history via `\r\n` exactly as the non-streaming path does.
- New `packages/tui/test/issue-1974-repro.test.ts` covers (1) a
  40-row append-only stream landing every row exactly once across
  pane history + viewport with no gaps and no duplicates, (2) zero
  `\x1b[3J` sequences during the stream, and (3) chrome below the
  live region staying out of pane history while streamed rows commit
  in original order.
- `packages/tui/CHANGELOG.md` adds an `[Unreleased]` `Fixed` entry.

## Verification

```
bun --cwd packages/tui test test/issue-1974-repro.test.ts        # 3 pass
bun --cwd packages/tui test                                      # 652 pass, 7 skip, 0 fail
bun --cwd packages/tui test test/issue-1610-repro.test.ts \
  test/issue-1682-repro.test.ts test/issue-1746-repro.test.ts \
  test/overlay-scroll.test.ts test/render-regressions.test.ts    # 130 pass, 0 fail
bun --cwd packages/coding-agent test test/tool-live-region-scrollback.test.ts \
  test/streaming-preview-height.test.ts \
  test/modes/components/transcript-container.test.ts             # 15 pass, 0 fail
```

`bun run fix` then `bun check` were run as the pre-publish gate; the
remaining pre-existing failures in the wider `coding-agent` suite
(ACP stdout hygiene, agent-session-retry-cap, sandboxed
`/srv/agent-home/.omp/logs` mkdir EACCES) reproduce on `main` without
this diff and are unrelated to the TUI renderer paths touched here.

Fixes #1974