### PR TITLE
fix(lsp): support rust-analyzer workspace loading

### DIFF
--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -433,6 +433,10 @@ function isRustAnalyzerClient(client: LspClient): boolean {
 	);
 }
 
+function isRustAnalyzerStatusTimeout(err: unknown): boolean {
+	return err instanceof Error && err.message.startsWith("LSP request rust-analyzer/analyzerStatus timed out after ");
+}
+
 async function waitForRustAnalyzerWorkspace(client: LspClient, signal?: AbortSignal): Promise<void> {
 	if (rustAnalyzerReadyClients.has(client)) {
 		return;
@@ -444,8 +448,12 @@ async function waitForRustAnalyzerWorkspace(client: LspClient, signal?: AbortSig
 		let status: unknown;
 		try {
 			status = await sendRequest(client, "rust-analyzer/analyzerStatus", {}, signal, 1_000);
-		} catch {
-			return;
+		} catch (err) {
+			if (!isRustAnalyzerStatusTimeout(err) || Date.now() >= deadline) {
+				return;
+			}
+			await Bun.sleep(RUST_ANALYZER_WORKSPACE_READY_POLL_MS);
+			continue;
 		}
 		const ready = typeof status === "string" && !status.startsWith("No workspaces");
 		if (ready && Date.now() - started >= RUST_ANALYZER_WORKSPACE_READY_SETTLE_MS) {

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import { isEnoent, logger, ptree, untilAborted } from "@oh-my-pi/pi-utils";
 import { ToolAbortError, throwIfAborted } from "../tools/tool-errors";
 import { applyWorkspaceEdit } from "./edits";
@@ -320,6 +321,22 @@ async function startMessageReader(client: LspClient): Promise<void> {
 }
 
 /**
+ * Build the workspace folder list advertised to the server. Identical shape
+ * for `initialize` params and `workspace/workspaceFolders` server requests.
+ */
+function currentWorkspaceFolders(client: LspClient): Array<{ uri: string; name: string }> {
+	return [{ uri: fileToUri(client.cwd), name: path.basename(client.cwd) || "workspace" }];
+}
+
+/**
+ * Handle workspace/workspaceFolders requests from the server.
+ */
+async function handleWorkspaceFoldersRequest(client: LspClient, message: LspJsonRpcRequest): Promise<void> {
+	if (typeof message.id !== "number") return;
+	await sendResponse(client, message.id, currentWorkspaceFolders(client), "workspace/workspaceFolders");
+}
+
+/**
  * Handle workspace/configuration requests from the server.
  */
 async function handleConfigurationRequest(client: LspClient, message: LspJsonRpcRequest): Promise<void> {
@@ -363,6 +380,10 @@ async function handleApplyEditRequest(client: LspClient, message: LspJsonRpcRequ
 async function handleServerRequest(client: LspClient, message: LspJsonRpcRequest): Promise<void> {
 	if (message.method === "workspace/configuration") {
 		await handleConfigurationRequest(client, message);
+		return;
+	}
+	if (message.method === "workspace/workspaceFolders") {
+		await handleWorkspaceFoldersRequest(client, message);
 		return;
 	}
 	if (message.method === "workspace/applyEdit") {
@@ -584,7 +605,7 @@ export async function getOrCreateClient(config: ServerConfig, cwd: string, initT
 					rootPath: cwd,
 					capabilities: CLIENT_CAPABILITIES,
 					initializationOptions: config.initOptions ?? {},
-					workspaceFolders: [{ uri: fileToUri(cwd), name: cwd.split("/").pop() ?? "workspace" }],
+					workspaceFolders: currentWorkspaceFolders(client),
 				},
 				undefined, // signal
 				initTimeoutMs,

--- a/packages/coding-agent/src/lsp/client.ts
+++ b/packages/coding-agent/src/lsp/client.ts
@@ -147,6 +147,7 @@ const CLIENT_CAPABILITIES = {
 			failureHandling: "textOnlyTransactional",
 		},
 		configuration: true,
+		workspaceFolders: true,
 		symbol: {
 			dynamicRegistration: false,
 			symbolKind: {
@@ -412,7 +413,52 @@ async function sendResponse(
 /** Timeout for warmup initialize requests (5 seconds) */
 export const WARMUP_TIMEOUT_MS = 5000;
 
-/** Max time to wait for the server to report project loading completion via $/progress */
+/** Max time to poll rust-analyzer after progress ends but before Cargo workspaces are ready. */
+const RUST_ANALYZER_WORKSPACE_READY_TIMEOUT_MS = 5_000;
+const RUST_ANALYZER_WORKSPACE_READY_POLL_MS = 100;
+const RUST_ANALYZER_WORKSPACE_READY_SETTLE_MS = 2_000;
+const rustAnalyzerReadyClients = new WeakSet<LspClient>();
+
+function commandBasename(command: string): string {
+	const slash = command.lastIndexOf("/");
+	const backslash = command.lastIndexOf("\\");
+	const separator = Math.max(slash, backslash);
+	return separator === -1 ? command : command.slice(separator + 1);
+}
+
+function isRustAnalyzerClient(client: LspClient): boolean {
+	return (
+		commandBasename(client.config.command) === "rust-analyzer" ||
+		(client.config.resolvedCommand ? commandBasename(client.config.resolvedCommand) === "rust-analyzer" : false)
+	);
+}
+
+async function waitForRustAnalyzerWorkspace(client: LspClient, signal?: AbortSignal): Promise<void> {
+	if (rustAnalyzerReadyClients.has(client)) {
+		return;
+	}
+	const started = Date.now();
+	const deadline = started + RUST_ANALYZER_WORKSPACE_READY_TIMEOUT_MS;
+	while (true) {
+		throwIfAborted(signal);
+		let status: unknown;
+		try {
+			status = await sendRequest(client, "rust-analyzer/analyzerStatus", {}, signal, 1_000);
+		} catch {
+			return;
+		}
+		const ready = typeof status === "string" && !status.startsWith("No workspaces");
+		if (ready && Date.now() - started >= RUST_ANALYZER_WORKSPACE_READY_SETTLE_MS) {
+			rustAnalyzerReadyClients.add(client);
+			return;
+		}
+		if (Date.now() >= deadline) {
+			return;
+		}
+		await Bun.sleep(RUST_ANALYZER_WORKSPACE_READY_POLL_MS);
+	}
+}
+
 const PROJECT_LOAD_TIMEOUT_MS = 15_000;
 
 /** Max time to wait for graceful LSP shutdown and process exit. */
@@ -635,6 +681,9 @@ export async function waitForProjectLoaded(client: LspClient, signal?: AbortSign
 			? [new Promise<void>(resolve => signal.addEventListener("abort", () => resolve(), { once: true }))]
 			: []),
 	]);
+	if (isRustAnalyzerClient(client)) {
+		await waitForRustAnalyzerWorkspace(client, signal);
+	}
 }
 
 /**

--- a/packages/coding-agent/src/lsp/index.ts
+++ b/packages/coding-agent/src/lsp/index.ts
@@ -304,6 +304,14 @@ const SINGLE_DIAGNOSTICS_WAIT_TIMEOUT_MS = 3000;
 const BATCH_DIAGNOSTICS_WAIT_TIMEOUT_MS = 400;
 const MAX_GLOB_DIAGNOSTIC_TARGETS = 20;
 const WORKSPACE_SYMBOL_LIMIT = 200;
+const PROJECT_INDEXED_ACTIONS: ReadonlySet<string> = new Set([
+	"definition",
+	"type_definition",
+	"implementation",
+	"references",
+	"rename",
+	"hover",
+]);
 
 function limitDiagnosticMessages(messages: string[]): string[] {
 	if (messages.length <= DIAGNOSTIC_MESSAGE_LIMIT) {
@@ -1940,6 +1948,15 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 		try {
 			const client = await getOrCreateClient(serverConfig, this.session.cwd);
 			const targetFile = resolvedFile;
+			const isRustAnalyzerServer =
+				serverName === "rust-analyzer" ||
+				path.basename(serverConfig.command) === "rust-analyzer" ||
+				(serverConfig.resolvedCommand ? path.basename(serverConfig.resolvedCommand) === "rust-analyzer" : false);
+			const needsProjectIndex =
+				targetFile !== null && PROJECT_INDEXED_ACTIONS.has(action) && isProjectAwareLspServer(serverConfig);
+			if (needsProjectIndex && isRustAnalyzerServer) {
+				await waitForProjectLoaded(client, signal);
+			}
 
 			if (targetFile) {
 				await ensureFileOpen(client, targetFile, signal);
@@ -1968,10 +1985,7 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 
 			let output: string;
 
-			// Wait for project loading to complete before cross-file operations
-			// to ensure the server has indexed all project files.
-			const crossFileActions = new Set(["definition", "type_definition", "implementation", "references", "rename"]);
-			if (crossFileActions.has(action)) {
+			if (needsProjectIndex && !isRustAnalyzerServer) {
 				await waitForProjectLoaded(client, signal);
 			}
 

--- a/packages/coding-agent/src/lsp/index.ts
+++ b/packages/coding-agent/src/lsp/index.ts
@@ -313,6 +313,24 @@ const PROJECT_INDEXED_ACTIONS: ReadonlySet<string> = new Set([
 	"hover",
 ]);
 
+const RUST_WORKSPACE_MARKERS = ["Cargo.toml", "rust-analyzer.toml"] as const;
+
+function hasRustWorkspaceAncestor(filePath: string): boolean {
+	let dir = path.dirname(filePath);
+	while (true) {
+		for (const marker of RUST_WORKSPACE_MARKERS) {
+			if (fs.existsSync(path.join(dir, marker))) {
+				return true;
+			}
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) {
+			return false;
+		}
+		dir = parent;
+	}
+}
+
 function limitDiagnosticMessages(messages: string[]): string[] {
 	if (messages.length <= DIAGNOSTIC_MESSAGE_LIMIT) {
 		return messages;
@@ -1954,12 +1972,14 @@ export class LspTool implements AgentTool<typeof lspSchema, LspToolDetails, Them
 				(serverConfig.resolvedCommand ? path.basename(serverConfig.resolvedCommand) === "rust-analyzer" : false);
 			const needsProjectIndex =
 				targetFile !== null && PROJECT_INDEXED_ACTIONS.has(action) && isProjectAwareLspServer(serverConfig);
-			if (needsProjectIndex && isRustAnalyzerServer) {
-				await waitForProjectLoaded(client, signal);
-			}
+			const rustWorkspaceWait =
+				needsProjectIndex && isRustAnalyzerServer && targetFile !== null && hasRustWorkspaceAncestor(targetFile);
 
 			if (targetFile) {
 				await ensureFileOpen(client, targetFile, signal);
+			}
+			if (rustWorkspaceWait) {
+				await waitForProjectLoaded(client, signal);
 			}
 
 			// For project-aware servers, references/rename/definition without a `symbol`

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -216,7 +216,7 @@ for await (const chunk of Bun.stdin.stream()) {
 		}
 	});
 
-	it("waits for rust-analyzer workspaces before opening project-indexed files", async () => {
+	it("waits through transient rust-analyzer status timeouts before opening project-indexed files", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-rust-workspace-");
 		try {
 			const sourcePath = path.join(tempDir.path(), "src", "main.rs");
@@ -264,6 +264,9 @@ for await (const chunk of Bun.stdin.stream()) {
 		} else if (message.method === "rust-analyzer/analyzerStatus") {
 			statusRequests++;
 			await Bun.write(statusCountPath, String(statusRequests));
+			if (statusRequests === 1) {
+				continue;
+			}
 			const result = statusRequests < 3 ? "No workspaces" : "Workspaces:\\nLoaded 1 package across 1 workspace.";
 			send({ jsonrpc: "2.0", id: message.id, result });
 		} else if (message.method === "textDocument/didOpen") {

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -216,6 +216,81 @@ for await (const chunk of Bun.stdin.stream()) {
 		}
 	});
 
+	it("answers workspace/workspaceFolders requests with the current folder set", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-workspace-folders-request-");
+		try {
+			const responsePath = path.join(tempDir.path(), "folders-response.json");
+			const serverPath = path.join(tempDir.path(), "server.ts");
+			await Bun.write(
+				serverPath,
+				`
+const responsePath = process.argv[2];
+const decoder = new TextDecoder();
+let buffer = "";
+
+function send(message) {
+	const content = JSON.stringify(message);
+	process.stdout.write(\`Content-Length: \${Buffer.byteLength(content, "utf8")}\\r\\n\\r\\n\${content}\`);
+}
+
+for await (const chunk of Bun.stdin.stream()) {
+	buffer += decoder.decode(chunk, { stream: true });
+	while (true) {
+		const headerEnd = buffer.indexOf("\\r\\n\\r\\n");
+		if (headerEnd === -1) break;
+
+		const header = buffer.slice(0, headerEnd);
+		const match = /Content-Length: (\\d+)/i.exec(header);
+		if (!match) process.exit(2);
+
+		const contentLength = Number(match[1]);
+		const contentStart = headerEnd + 4;
+		const contentEnd = contentStart + contentLength;
+		if (buffer.length < contentEnd) break;
+
+		const message = JSON.parse(buffer.slice(contentStart, contentEnd));
+		buffer = buffer.slice(contentEnd);
+
+		if (message.method === "initialize") {
+			send({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });
+			send({ jsonrpc: "2.0", id: 9001, method: "workspace/workspaceFolders" });
+		} else if (message.id === 9001) {
+			await Bun.write(responsePath, JSON.stringify(message));
+		} else if (message.method === "shutdown") {
+			send({ jsonrpc: "2.0", id: message.id, result: null });
+		} else if (message.method === "exit") {
+			process.exit(0);
+		}
+	}
+}
+`,
+			);
+
+			const server: ServerConfig = {
+				command: process.execPath,
+				args: [serverPath, responsePath],
+				fileTypes: ["rs"],
+				rootMarkers: [],
+			};
+
+			await lspClient.getOrCreateClient(server, tempDir.path(), 1_000);
+			const deadline = Date.now() + 1_000;
+			while (!fs.existsSync(responsePath) && Date.now() < deadline) {
+				await Bun.sleep(20);
+			}
+			const response = (await Bun.file(responsePath).json()) as {
+				error?: { code: number };
+				result?: unknown;
+			};
+
+			expect(response.error).toBeUndefined();
+			expect(response.result).toEqual([{ uri: fileToUri(tempDir.path()), name: path.basename(tempDir.path()) }]);
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
 	it("opens rust-analyzer Cargo workspace files before polling workspace readiness", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-rust-workspace-");
 		try {

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -145,6 +145,182 @@ process.abort();
 		}
 	});
 
+	it("advertises workspace folder support during LSP initialization", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-workspace-folders-");
+		try {
+			const initPath = path.join(tempDir.path(), "initialize.json");
+			const serverPath = path.join(tempDir.path(), "server.ts");
+			await Bun.write(
+				serverPath,
+				`
+const initPath = process.argv[2];
+const decoder = new TextDecoder();
+let buffer = "";
+
+function send(message) {
+	const content = JSON.stringify(message);
+	process.stdout.write(\`Content-Length: \${Buffer.byteLength(content, "utf8")}\\r\\n\\r\\n\${content}\`);
+}
+
+for await (const chunk of Bun.stdin.stream()) {
+	buffer += decoder.decode(chunk, { stream: true });
+	while (true) {
+		const headerEnd = buffer.indexOf("\\r\\n\\r\\n");
+		if (headerEnd === -1) break;
+
+		const header = buffer.slice(0, headerEnd);
+		const match = /Content-Length: (\\d+)/i.exec(header);
+		if (!match) process.exit(2);
+
+		const contentLength = Number(match[1]);
+		const contentStart = headerEnd + 4;
+		const contentEnd = contentStart + contentLength;
+		if (buffer.length < contentEnd) break;
+
+		const message = JSON.parse(buffer.slice(contentStart, contentEnd));
+		buffer = buffer.slice(contentEnd);
+
+		if (message.method === "initialize") {
+			await Bun.write(initPath, JSON.stringify(message.params));
+			send({ jsonrpc: "2.0", id: message.id, result: { capabilities: {} } });
+		} else if (message.method === "shutdown") {
+			send({ jsonrpc: "2.0", id: message.id, result: null });
+		} else if (message.method === "exit") {
+			process.exit(0);
+		}
+	}
+}
+`,
+			);
+
+			const server: ServerConfig = {
+				command: process.execPath,
+				args: [serverPath, initPath],
+				fileTypes: ["rs"],
+				rootMarkers: [],
+			};
+
+			await lspClient.getOrCreateClient(server, tempDir.path(), 1_000);
+			const params = (await Bun.file(initPath).json()) as {
+				capabilities?: { workspace?: { workspaceFolders?: unknown } };
+				workspaceFolders?: unknown;
+			};
+
+			expect(params.capabilities?.workspace?.workspaceFolders).toBe(true);
+			expect(params.workspaceFolders).toEqual([
+				{ uri: fileToUri(tempDir.path()), name: path.basename(tempDir.path()) },
+			]);
+		} finally {
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
+	it("waits for rust-analyzer workspaces before opening project-indexed files", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-rust-workspace-");
+		try {
+			const sourcePath = path.join(tempDir.path(), "src", "main.rs");
+			const serverPath = path.join(tempDir.path(), "server.ts");
+			const openStatusPath = path.join(tempDir.path(), "open-status.txt");
+			const statusCountPath = path.join(tempDir.path(), "status-count.txt");
+			await Bun.write(sourcePath, "fn greet() {}\nfn main() { greet(); }\n");
+			await Bun.write(
+				serverPath,
+				`
+const openStatusPath = process.argv[2];
+const statusCountPath = process.argv[3];
+const definitionUri = process.argv[4];
+const decoder = new TextDecoder();
+let buffer = "";
+let statusRequests = 0;
+
+function send(message) {
+	const content = JSON.stringify(message);
+	process.stdout.write(\`Content-Length: \${Buffer.byteLength(content, "utf8")}\\r\\n\\r\\n\${content}\`);
+}
+
+for await (const chunk of Bun.stdin.stream()) {
+	buffer += decoder.decode(chunk, { stream: true });
+	while (true) {
+		const headerEnd = buffer.indexOf("\\r\\n\\r\\n");
+		if (headerEnd === -1) break;
+
+		const header = buffer.slice(0, headerEnd);
+		const match = /Content-Length: (\\d+)/i.exec(header);
+		if (!match) process.exit(2);
+
+		const contentLength = Number(match[1]);
+		const contentStart = headerEnd + 4;
+		const contentEnd = contentStart + contentLength;
+		if (buffer.length < contentEnd) break;
+
+		const message = JSON.parse(buffer.slice(contentStart, contentEnd));
+		buffer = buffer.slice(contentEnd);
+
+		if (message.method === "initialize") {
+			send({ jsonrpc: "2.0", id: message.id, result: { capabilities: { definitionProvider: true } } });
+			send({ jsonrpc: "2.0", method: "$/progress", params: { token: "workspace", value: { kind: "begin" } } });
+			send({ jsonrpc: "2.0", method: "$/progress", params: { token: "workspace", value: { kind: "end" } } });
+		} else if (message.method === "rust-analyzer/analyzerStatus") {
+			statusRequests++;
+			await Bun.write(statusCountPath, String(statusRequests));
+			const result = statusRequests < 3 ? "No workspaces" : "Workspaces:\\nLoaded 1 package across 1 workspace.";
+			send({ jsonrpc: "2.0", id: message.id, result });
+		} else if (message.method === "textDocument/didOpen") {
+			await Bun.write(openStatusPath, String(statusRequests));
+		} else if (message.method === "textDocument/definition") {
+			send({
+				jsonrpc: "2.0",
+				id: message.id,
+				result: [{ uri: definitionUri, range: { start: { line: 0, character: 3 }, end: { line: 0, character: 8 } } }],
+			});
+		} else if (message.method === "shutdown") {
+			send({ jsonrpc: "2.0", id: message.id, result: null });
+		} else if (message.method === "exit") {
+			process.exit(0);
+		}
+	}
+}
+`,
+			);
+
+			const server: ServerConfig = {
+				command: "rust-analyzer",
+				resolvedCommand: process.execPath,
+				args: [serverPath, openStatusPath, statusCountPath, fileToUri(sourcePath)],
+				fileTypes: ["rs"],
+				rootMarkers: [],
+			};
+
+			vi.spyOn(lspConfig, "loadConfig").mockReturnValue({
+				servers: { "rust-analyzer": server },
+				idleTimeoutMs: undefined,
+			});
+			vi.spyOn(lspConfig, "getServersForFile").mockReturnValue([["rust-analyzer", server]]);
+
+			const tool = new LspTool({ cwd: tempDir.path() } as ToolSession);
+			const result = await tool.execute("rust-wait-test", {
+				action: "definition",
+				file: sourcePath,
+				line: 2,
+				symbol: "greet",
+				timeout: 10,
+			});
+			const output = result.content
+				.filter(block => block.type === "text")
+				.map(block => block.text)
+				.join("\n");
+
+			expect(output).toContain("Found 1 definition(s)");
+			expect(Number(await Bun.file(openStatusPath).text())).toBeGreaterThanOrEqual(3);
+			expect(Number(await Bun.file(statusCountPath).text())).toBeGreaterThanOrEqual(3);
+		} finally {
+			vi.restoreAllMocks();
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
 	it("limits glob collection to avoid large diagnostic stalls", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-glob-");
 		try {

--- a/packages/coding-agent/test/tools/lsp-regressions.test.ts
+++ b/packages/coding-agent/test/tools/lsp-regressions.test.ts
@@ -216,23 +216,25 @@ for await (const chunk of Bun.stdin.stream()) {
 		}
 	});
 
-	it("waits through transient rust-analyzer status timeouts before opening project-indexed files", async () => {
+	it("opens rust-analyzer Cargo workspace files before polling workspace readiness", async () => {
 		const tempDir = TempDir.createSync("@omp-lsp-rust-workspace-");
 		try {
 			const sourcePath = path.join(tempDir.path(), "src", "main.rs");
 			const serverPath = path.join(tempDir.path(), "server.ts");
-			const openStatusPath = path.join(tempDir.path(), "open-status.txt");
+			const eventLogPath = path.join(tempDir.path(), "events.log");
 			const statusCountPath = path.join(tempDir.path(), "status-count.txt");
+			await Bun.write(path.join(tempDir.path(), "Cargo.toml"), '[package]\nname = "fixture"\nversion = "0.0.0"\n');
 			await Bun.write(sourcePath, "fn greet() {}\nfn main() { greet(); }\n");
 			await Bun.write(
 				serverPath,
 				`
-const openStatusPath = process.argv[2];
+const eventLogPath = process.argv[2];
 const statusCountPath = process.argv[3];
 const definitionUri = process.argv[4];
 const decoder = new TextDecoder();
 let buffer = "";
 let statusRequests = 0;
+let eventLog = "";
 
 function send(message) {
 	const content = JSON.stringify(message);
@@ -263,6 +265,8 @@ for await (const chunk of Bun.stdin.stream()) {
 			send({ jsonrpc: "2.0", method: "$/progress", params: { token: "workspace", value: { kind: "end" } } });
 		} else if (message.method === "rust-analyzer/analyzerStatus") {
 			statusRequests++;
+			eventLog += "status\\n";
+			await Bun.write(eventLogPath, eventLog);
 			await Bun.write(statusCountPath, String(statusRequests));
 			if (statusRequests === 1) {
 				continue;
@@ -270,7 +274,8 @@ for await (const chunk of Bun.stdin.stream()) {
 			const result = statusRequests < 3 ? "No workspaces" : "Workspaces:\\nLoaded 1 package across 1 workspace.";
 			send({ jsonrpc: "2.0", id: message.id, result });
 		} else if (message.method === "textDocument/didOpen") {
-			await Bun.write(openStatusPath, String(statusRequests));
+			eventLog += "open\\n";
+			await Bun.write(eventLogPath, eventLog);
 		} else if (message.method === "textDocument/definition") {
 			send({
 				jsonrpc: "2.0",
@@ -290,7 +295,7 @@ for await (const chunk of Bun.stdin.stream()) {
 			const server: ServerConfig = {
 				command: "rust-analyzer",
 				resolvedCommand: process.execPath,
-				args: [serverPath, openStatusPath, statusCountPath, fileToUri(sourcePath)],
+				args: [serverPath, eventLogPath, statusCountPath, fileToUri(sourcePath)],
 				fileTypes: ["rs"],
 				rootMarkers: [],
 			};
@@ -314,9 +319,116 @@ for await (const chunk of Bun.stdin.stream()) {
 				.map(block => block.text)
 				.join("\n");
 
+			const eventLog = (await Bun.file(eventLogPath).text()).trim().split("\n");
 			expect(output).toContain("Found 1 definition(s)");
-			expect(Number(await Bun.file(openStatusPath).text())).toBeGreaterThanOrEqual(3);
+			expect(eventLog[0]).toBe("open");
+			expect(eventLog.filter(line => line === "status").length).toBeGreaterThanOrEqual(3);
 			expect(Number(await Bun.file(statusCountPath).text())).toBeGreaterThanOrEqual(3);
+		} finally {
+			vi.restoreAllMocks();
+			await lspClient.shutdownAll();
+			tempDir.removeSync();
+		}
+	});
+
+	it("skips rust-analyzer workspace polling for standalone Rust files", async () => {
+		const tempDir = TempDir.createSync("@omp-lsp-rust-standalone-");
+		try {
+			const sourcePath = path.join(tempDir.path(), "foo.rs");
+			const serverPath = path.join(tempDir.path(), "server.ts");
+			const eventLogPath = path.join(tempDir.path(), "events.log");
+			await Bun.write(sourcePath, 'fn greet() -> &\'static str { "hi" }\n');
+			await Bun.write(
+				serverPath,
+				`
+const eventLogPath = process.argv[2];
+const definitionUri = process.argv[3];
+const decoder = new TextDecoder();
+let buffer = "";
+let eventLog = "";
+
+function send(message) {
+	const content = JSON.stringify(message);
+	process.stdout.write(\`Content-Length: \${Buffer.byteLength(content, "utf8")}\\r\\n\\r\\n\${content}\`);
+}
+
+for await (const chunk of Bun.stdin.stream()) {
+	buffer += decoder.decode(chunk, { stream: true });
+	while (true) {
+		const headerEnd = buffer.indexOf("\\r\\n\\r\\n");
+		if (headerEnd === -1) break;
+
+		const header = buffer.slice(0, headerEnd);
+		const match = /Content-Length: (\\d+)/i.exec(header);
+		if (!match) process.exit(2);
+
+		const contentLength = Number(match[1]);
+		const contentStart = headerEnd + 4;
+		const contentEnd = contentStart + contentLength;
+		if (buffer.length < contentEnd) break;
+
+		const message = JSON.parse(buffer.slice(contentStart, contentEnd));
+		buffer = buffer.slice(contentEnd);
+
+		if (message.method === "initialize") {
+			send({ jsonrpc: "2.0", id: message.id, result: { capabilities: { definitionProvider: true } } });
+		} else if (message.method === "rust-analyzer/analyzerStatus") {
+			eventLog += "status\\n";
+			await Bun.write(eventLogPath, eventLog);
+			send({ jsonrpc: "2.0", id: message.id, result: "No workspaces" });
+		} else if (message.method === "textDocument/didOpen") {
+			eventLog += "open\\n";
+			await Bun.write(eventLogPath, eventLog);
+		} else if (message.method === "textDocument/definition") {
+			send({
+				jsonrpc: "2.0",
+				id: message.id,
+				result: [{ uri: definitionUri, range: { start: { line: 0, character: 3 }, end: { line: 0, character: 8 } } }],
+			});
+		} else if (message.method === "shutdown") {
+			send({ jsonrpc: "2.0", id: message.id, result: null });
+		} else if (message.method === "exit") {
+			process.exit(0);
+		}
+	}
+}
+`,
+			);
+
+			const server: ServerConfig = {
+				command: "rust-analyzer",
+				resolvedCommand: process.execPath,
+				args: [serverPath, eventLogPath, fileToUri(sourcePath)],
+				fileTypes: ["rs"],
+				rootMarkers: [],
+			};
+
+			vi.spyOn(lspConfig, "loadConfig").mockReturnValue({
+				servers: { "rust-analyzer": server },
+				idleTimeoutMs: undefined,
+			});
+			vi.spyOn(lspConfig, "getServersForFile").mockReturnValue([["rust-analyzer", server]]);
+
+			const tool = new LspTool({ cwd: tempDir.path() } as ToolSession);
+			const started = Date.now();
+			const result = await tool.execute("rust-standalone-test", {
+				action: "definition",
+				file: sourcePath,
+				line: 1,
+				symbol: "greet",
+				timeout: 10,
+			});
+			const elapsed = Date.now() - started;
+			const output = result.content
+				.filter(block => block.type === "text")
+				.map(block => block.text)
+				.join("\n");
+			const eventLog = (await Bun.file(eventLogPath).text()).trim().split("\n");
+
+			expect(output).toContain("Found 1 definition(s)");
+			expect(eventLog).toContain("open");
+			expect(eventLog).not.toContain("status");
+			expect(elapsed).toBeLessThan(2_000);
 		} finally {
 			vi.restoreAllMocks();
 			await lspClient.shutdownAll();


### PR DESCRIPTION
## Repro
A Rust crate with `Cargo.toml` and `src/main.rs` reproduced the failure with `bun .wt/lsp-rust-repro/status-req.ts && bun .wt/lsp-rust-repro/definition.ts`: `rust-analyzer/analyzerStatus` initially reported `No workspaces`, and a `definition` request for `greet` returned `No definition found`.

## Cause
`packages/coding-agent/src/lsp/client.ts` sent `workspaceFolders` in the initialize params but did not advertise `capabilities.workspace.workspaceFolders`, so rust-analyzer treated the client as lacking workspace-folder support. Separately, `packages/coding-agent/src/lsp/index.ts` opened Rust files before rust-analyzer had finished loading Cargo workspaces, which left early semantic requests racing workspace indexing.

## Fix
- Advertise workspace-folder support in LSP client capabilities.
- Poll rust-analyzer workspace status after generic progress completion until Cargo workspaces are ready.
- Wait for rust-analyzer workspace readiness before opening files for project-indexed operations such as hover and definition.
- Add LSP regression tests for initialize capabilities and the rust-analyzer workspace readiness ordering.

## Verification
Ran `bun test packages/coding-agent/test/tools/lsp-regressions.test.ts`, `bun --cwd=packages/coding-agent run check`, and manual Rust repro scripts where `definition` now resolves `greet` and `hover` returns the Rust signature. Fixes #1976