### PR TITLE
docs: document Pi extension export drift in porting guide

### DIFF
--- a/docs/porting-from-pi-mono.md
+++ b/docs/porting-from-pi-mono.md
@@ -47,6 +47,9 @@ Upstream uses different package scopes. Replace them consistently.
   - `@mariozechner/pi-agent-core` → `@oh-my-pi/pi-agent-core`
   - `@mariozechner/pi-tui` → `@oh-my-pi/pi-tui`
   - `@mariozechner/pi-ai` → `@oh-my-pi/pi-ai`
+  - `@mariozechner/pi-utils` → `@oh-my-pi/pi-utils`
+- Some upstream packages publish under the `@earendil-works/*` scope instead of `@mariozechner/*`. Map it the same way (`@earendil-works/pi-coding-agent` → `@oh-my-pi/pi-coding-agent`, and so on).
+- The bare `typebox` package is not an `@oh-my-pi/*` scope; do not rewrite it as one. See the Extensions divergence in section 15 for how tool-parameter schemas map.
 
 ## 4) Use Bun APIs where they improve on Node
 
@@ -353,10 +356,13 @@ Our fork has architectural decisions that differ from upstream. **Do not port th
 
 ### Extensions
 
-| Upstream                      | Our Fork                                          |
-| ----------------------------- | ------------------------------------------------- |
-| `jiti` for TypeScript loading | Native Bun `import()`                             |
-| `pkg.pi` manifest field       | `pkg.omp` preferred; fallback to `pkg.pi` remains |
+| Upstream                                                         | Our Fork                                                                                          |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `jiti` for TypeScript loading                                    | Native Bun `import()`                                                                              |
+| `pkg.pi` manifest field                                          | `pkg.omp` preferred; fallback to `pkg.pi` remains                                                  |
+| `StringEnum` from `pi-ai`                                        | `Type.Enum` from the `pi.typebox` shim (or author the schema with `pi.zod`); `pi-ai` no longer exports `StringEnum` |
+| `formatSize` from `pi-coding-agent`                              | `formatBytes` from `@oh-my-pi/pi-utils`                                                            |
+| `DefaultResourceLoader` / `DefaultPackageManager` / `SettingsManager` / `createEventBus` | Capability-based discovery (`loadCapability(...)`) plus the `Settings` singleton and `EventBus` |
 
 ### Skip These Upstream Features
 


### PR DESCRIPTION
   ## What                                                                                                                                                     
                                                                                                                                                               
   Documents the export-level API drift that breaks a straight scope-rename when porting a Pi extension to OMP. Two edits to `docs/porting-from-pi-mono.md`:   
                                                                                                                                                               
   - **Section 3 (Replace import scopes):** add the `@earendil-works/*` scope alias and `@mariozechner/pi-utils` to the replacement list, and note that bare   
 `typebox` is not an `@oh-my-pi/*` scope.                                                                                                                      
   - **Section 15 (Extensions divergence table):** record the dropped/renamed exports a scope-rename misses — `StringEnum` (pi-ai), `formatSize`               
 (pi-coding-agent), and the removed `DefaultResourceLoader`/`DefaultPackageManager`/`SettingsManager`/`createEventBus` discovery classes — each with its OMP   
 replacement.                                                                                                                                                  
                                                                                                                                                               
   ## Why                                                                                                                                                      
                                                                                                                                                               
   A mechanical `@mariozechner/* → @oh-my-pi/*` rename gets you a package that imports cleanly but fails to load, because several symbols were removed or      
 moved in the fork. These were hit porting real extensions (browser-tools, oracle, autoresearch, etc.). The porting guide already lists scope renames but      
 didn't mention the second upstream scope or the removed exports, so the failures are non-obvious. This adds them in the guide's existing style (scope bullets 
 + the Section 15 divergence table).                                                                                                                           
                                                                                                                                                               
   ## Testing                                                                                                                                                  
                                                                                                                                                               
   Docs-only change. Regenerated `docs-index.generated.ts` locally via `bun run generate-docs-index` (gitignored build artifact, not committed) and confirmed  
 the new content embeds correctly. Verified the Markdown tables/lists render with consistent column counts.                                                    
                                                                                                                                                             
