### PR TITLE
test(tui): widened slash autocomplete settle slack past debounce jitter

### DIFF
--- a/packages/tui/test/slash-autocomplete-viewport.test.ts
+++ b/packages/tui/test/slash-autocomplete-viewport.test.ts
@@ -36,7 +36,15 @@ class UnknownViewportTerminal extends VirtualTerminal {
 
 async function settle(term: VirtualTerminal): Promise<void> {
 	await new Promise<void>(resolve => process.nextTick(resolve));
-	await Bun.sleep(120);
+	// Each keystroke arms Editor's autocomplete debounce (100ms) before the
+	// provider is re-queried, and the resulting onAutocompleteUpdate render is
+	// throttled by the TUI's MIN_RENDER_INTERVAL_MS (16ms). 120ms left only a
+	// ~4ms margin once the debounce fires, which macOS setTimeout jitter
+	// reliably overran — the stale (unfiltered) menu was still being painted at
+	// capture time, pushing the live editor row out of a 6-row viewport
+	// (issue #1979). Stay well above 100+16ms so the post-debounce render lands
+	// before getViewport() runs.
+	await Bun.sleep(250);
 	await term.flush();
 }
 


### PR DESCRIPTION
## Repro

`bun test packages/tui/test/slash-autocomplete-viewport.test.ts` intermittently failed on macOS in `repaints autocomplete updates coalesced with offscreen background mutations` with:

```
Expected to contain: "/m"
Received: "> model\n  settings\n  skill:semantic-compression\n  status\n  stats\n  (1/6)"
```

Tightening `Bun.sleep(120)` in `settle()` down to `Bun.sleep(80)` reproduces the failure deterministically on Linux as well.

## Cause

After each keystroke the editor arms a 100 ms debounce (`Editor.#debouncedUpdateAutocomplete` in `packages/tui/src/components/editor.ts`) before re-querying the autocomplete provider. The resulting `onAutocompleteUpdate` then schedules a render that is throttled by the TUI's 16 ms `MIN_RENDER_INTERVAL_MS`. The test's `settle()` only slept 120 ms — ≈4 ms past the 100 ms debounce — so `setTimeout` jitter on macOS reliably consumed the slack. `getViewport()` captured the frame painted with the *stale* unfiltered menu (6 commands matching `/`), which exactly fills the 6-row viewport and pushes the live editor row off-screen, so `viewport.toContain("/m")` fails.

## Fix

- `packages/tui/test/slash-autocomplete-viewport.test.ts`: bump `settle()`'s sleep from 120 ms to 250 ms and document the 100 ms debounce + 16 ms render-throttle budget so the slack isn't quietly trimmed back later.

## Verification

- Repeated the failing test 8× with the fix in place: all pass.
  ```
  cd packages/tui && for i in 1 2 3 4 5 6 7 8; do
    bun test test/slash-autocomplete-viewport.test.ts 2>&1 | tail -3
  done
  ```
- Re-stressed the original failure mode by re-applying `Bun.sleep(80)` and confirmed it fails as in the report; reverted.
- `cd packages/tui && bun test` — the only remaining failures are 6 unrelated OSC 66 text-sizing tests in `markdown.test.ts` / `text-utils.test.ts` that fail identically on `main` (pre-existing, untouched by this change).

Fixes #1979