### PR TITLE
fix(eval): floor JS worker init timeout to stop terminate-mid-init CI flake

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+
+- Fixed a flaky JS eval worker startup that intermittently failed unrelated CI runs. The worker-ready wait reused Bun's 5s default per-test timeout as its floor, so a slow cold-start under `--isolate` + high concurrency was aborted mid-init; terminating a still-initializing Bun worker is the documented SIGILL/SIGTRAP crash trigger, which took down the whole test file. Worker init now floors at a fixed 15s infrastructure budget (independent of, and still dominated by, a larger per-cell `timeout`), and the JS eval test suites set a 20s file-local timeout so cold starts complete instead of being torn down.
 
 ## [15.9.5] - 2026-06-05
 ### Added

--- a/packages/coding-agent/src/eval/js/context-manager.ts
+++ b/packages/coding-agent/src/eval/js/context-manager.ts
@@ -56,8 +56,9 @@ const resettingSessions = new Set<string>();
 // Worker startup (module-graph import + WorkerCore construction) is infrastructure
 // cost, not user compute. Floor it independently of Bun's 5s default per-test timeout
 // so a slow cold-start under load isn't aborted mid-init — terminating a still-
-// initializing Bun worker is the documented SIGILL/SIGTRAP crash trigger (see
-// shared/indirect-eval.ts). Callers that pass a larger per-cell budget still dominate.
+// initializing Bun worker triggers the same kind of terminate-race that motivates
+// avoiding `vm.runInContext` (see shared/indirect-eval.ts), here surfacing as a
+// SIGILL/SIGSEGV. Callers that pass a larger per-cell budget still dominate.
 const WORKER_INIT_TIMEOUT_MS = 15_000;
 
 export async function executeInVmContext(options: {

--- a/packages/coding-agent/src/eval/js/context-manager.ts
+++ b/packages/coding-agent/src/eval/js/context-manager.ts
@@ -53,7 +53,12 @@ interface JsSession {
 const sessions = new Map<string, JsSession>();
 const startingSessions = new Map<string, Promise<JsSession>>();
 const resettingSessions = new Set<string>();
-const READY_TIMEOUT_MS_DEFAULT = 5_000;
+// Worker startup (module-graph import + WorkerCore construction) is infrastructure
+// cost, not user compute. Floor it independently of Bun's 5s default per-test timeout
+// so a slow cold-start under load isn't aborted mid-init — terminating a still-
+// initializing Bun worker is the documented SIGILL/SIGTRAP crash trigger (see
+// shared/indirect-eval.ts). Callers that pass a larger per-cell budget still dominate.
+const WORKER_INIT_TIMEOUT_MS = 15_000;
 
 export async function executeInVmContext(options: {
 	sessionKey: string;
@@ -191,9 +196,9 @@ async function acquireSession(sessionKey: string, snapshot: SessionSnapshot, tim
 			handleSessionMessage(session, msg);
 		});
 		try {
-			// Cold-start can exceed 5s on slow hosts. Let the caller's per-cell timeout dominate so
-			// users can grant more headroom when they raise `timeout` on a cell.
-			const readyTimeoutMs = Math.max(READY_TIMEOUT_MS_DEFAULT, timeoutMs ?? 0);
+			// Init headroom is the fixed infrastructure floor; the caller's per-cell timeout
+			// dominates when larger so users can grant more by raising `timeout` on a cell.
+			const readyTimeoutMs = Math.max(WORKER_INIT_TIMEOUT_MS, timeoutMs ?? 0);
 			await raceWithTimeout(readyPromise, readyTimeoutMs, "Timed out initializing JS eval worker");
 			worker.send({ type: "init", snapshot });
 			sessions.set(sessionKey, session);

--- a/packages/coding-agent/test/core/js-executor.test.ts
+++ b/packages/coding-agent/test/core/js-executor.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, it, setDefaultTimeout, vi } from "bun:test";
 import * as path from "node:path";
 import type { AgentTool, AgentToolResult } from "@oh-my-pi/pi-agent-core";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
@@ -7,6 +7,11 @@ import { TempDir } from "@oh-my-pi/pi-utils";
 import * as z from "zod/v4";
 import { disposeAllVmContexts } from "../../src/eval/js/context-manager";
 import { executeJs, type JsResult } from "../../src/eval/js/executor";
+
+// JS eval cold-starts a Bun worker; under --isolate + high CI concurrency that startup
+// can exceed Bun's 5s default per-test timeout, flaking the suite. Give the worker-backed
+// tests headroom above the worker-init floor (context-manager WORKER_INIT_TIMEOUT_MS).
+setDefaultTimeout(20_000);
 
 function createTool(
 	name: string,

--- a/packages/coding-agent/test/core/js-workflow-helpers.test.ts
+++ b/packages/coding-agent/test/core/js-workflow-helpers.test.ts
@@ -1,10 +1,15 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it, setDefaultTimeout } from "bun:test";
 import * as path from "node:path";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 import { TempDir } from "@oh-my-pi/pi-utils";
 import { disposeAllVmContexts } from "../../src/eval/js/context-manager";
 import { executeJs, type JsResult } from "../../src/eval/js/executor";
+
+// JS eval cold-starts a Bun worker; under --isolate + high CI concurrency that startup
+// can exceed Bun's 5s default per-test timeout, flaking the suite. Give the worker-backed
+// tests headroom above the worker-init floor (context-manager WORKER_INIT_TIMEOUT_MS).
+setDefaultTimeout(20_000);
 
 function statusEvents(result: JsResult) {
 	return result.displayOutputs.filter(


### PR DESCRIPTION
## Problem

The `test` CI job is intermittently red across PRs touching **unrelated** subsystems (tui, lsp, ai, eval). The failure is always the same and always in the JS eval suites:

```
ToolError: Timed out initializing JS eval worker   (context-manager.ts:350)
... cascade of executeJs exitCode 1 / "test timed out after 5000ms" ...
panic: Segmentation fault
worker crashed: SIGILL while running test/core/js-workflow-helpers.test.ts
```

It's nondeterministic — a load/timing flake, not a real regression in any PR.

## Root cause

`acquireSession()` waits for the worker's `ready` message with
`readyTimeoutMs = Math.max(READY_TIMEOUT_MS_DEFAULT /* 5_000 */, timeoutMs ?? 0)`.

The eval tests call `executeJs(...)` with **no** timeout, so the worker-ready budget collapses to **5000ms** — which also happens to be Bun's *default per-test timeout*. Under `bun test --isolate --max-concurrency=20`, each test file runs in its own Bun worker process and then spawns a **nested** Bun `Worker` for eval. Cold-starting that nested worker (module-graph import + `WorkerCore` construction) can exceed 5s under CI load.

When it does, `raceWithTimeout` throws and the catch immediately `await worker.terminate()`s a **still-initializing** worker. Terminating a Bun worker mid-init is the exact crash condition the code already documents in `shared/indirect-eval.ts` ("Bun crashes the parent … when `Worker.terminate()` fires while a worker is mid-init") — producing the `SIGILL`/`SIGSEGV` that takes down the whole test file.

So worker startup — pure infrastructure cost, before any user code runs — was being bounded by a value meant for user compute.

## Fix

1. **`context-manager.ts`** — decouple the worker-init budget from the user compute timeout. Introduce a fixed `WORKER_INIT_TIMEOUT_MS = 15_000` infrastructure floor: `readyTimeoutMs = Math.max(WORKER_INIT_TIMEOUT_MS, timeoutMs ?? 0)`. A larger per-cell `timeout` still dominates; it still fails after the floor, so a genuinely hung worker is not masked indefinitely. Production callers already pass ~30s budgets, so this only changes the no-timeout path.
2. **`js-executor.test.ts` / `js-workflow-helpers.test.ts`** — add a file-local `setDefaultTimeout(20_000)` so the (now-completing) cold start fits the per-test budget instead of being torn down. Scoped to these two files only — no package-wide timeout change.

Inline-worker-for-tests was considered and rejected: user code runs via indirect eval in the **host worker's global scope** (not `node:vm`), so per-session isolation requires a dedicated worker thread; the inline fallback shares the main realm and would break session isolation and the `globalThis`-non-leak test.

## Verification

- `bun test test/core/js-executor.test.ts test/core/js-workflow-helpers.test.ts` → **25 pass, 0 fail**.
- `tsgo -p tsconfig.json --noEmit` → clean.
- `biome check` on the three changed files → OK.

## Notes / follow-up

This removes the *observed* trigger (terminate-mid-init at the 5s boundary). A fully independent hardening — observing worker `error`/`exit` to evict stale `alive` sessions, and only terminating after `ready` — is a sensible follow-up if any worker-death flake persists, but is out of scope here.
