### PR TITLE
feat(discovery): GitHub Copilot user-global instructions, env dirs, and prompts (#1913, #1915, #1916)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added GitHub Copilot user-global discovery to the `github` provider: it now loads user-global instructions from `~/.copilot/copilot-instructions.md`, honors the `COPILOT_HOME` relocation override, reads additional instruction directories listed in `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` (both `copilot-instructions.md` and `*.instructions.md`), and discovers Copilot prompt files (`*.prompt.md`) from `.github/prompts/` and `~/.copilot/prompts/`. Previously only the project `.github/` tree was scanned, so Copilot CLI users' cross-repo config was silently ignored. Closes #1913, #1915, #1916.
 
 ## [15.12.2] - 2026-06-12
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Added
 
-- Added GitHub Copilot user-global discovery to the `github` provider: it now loads user-global instructions from `~/.copilot/copilot-instructions.md`, honors the `COPILOT_HOME` relocation override, reads additional instruction directories listed in `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` (both `copilot-instructions.md` and `*.instructions.md`), and discovers Copilot prompt files (`*.prompt.md`) from `.github/prompts/` and `~/.copilot/prompts/`. Previously only the project `.github/` tree was scanned, so Copilot CLI users' cross-repo config was silently ignored. Closes #1913, #1915, #1916.
+- Added GitHub Copilot user-global discovery to the `github` provider: it now loads user-global instructions from `~/.copilot/copilot-instructions.md`, honors the `COPILOT_HOME` relocation override, reads each directory listed in `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` for an `AGENTS.md` and `.github/instructions/**/*.instructions.md` (matching Copilot CLI), scans the project `.github/instructions/` tree recursively, and surfaces VS Code Copilot prompt files (`*.prompt.md`) from `.github/prompts/` as slash commands. Previously only the project `.github/` tree was scanned, so Copilot CLI users' cross-repo config was silently ignored. Closes #1913, #1915, #1916.
 
 ## [15.12.2] - 2026-06-12
 

--- a/packages/coding-agent/src/discovery/github.ts
+++ b/packages/coding-agent/src/discovery/github.ts
@@ -5,11 +5,14 @@
  * Priority: 30 (shared standard provider)
  *
  * Sources:
- * - Project: .github/ (project-only, no user-level discovery)
+ * - Project: .github/ (repo-local Copilot config)
+ * - User: ~/.copilot/ (user-global Copilot CLI config; relocatable via COPILOT_HOME)
+ * - Extra: directories listed in COPILOT_CUSTOM_INSTRUCTIONS_DIRS
  *
  * Capabilities:
- * - context-files: copilot-instructions.md in .github/
- * - instructions: *.instructions.md in .github/instructions/ with applyTo frontmatter
+ * - context-files: copilot-instructions.md in .github/, ~/.copilot/, and custom dirs
+ * - instructions: *.instructions.md in .github/instructions/ and custom dirs (applyTo frontmatter)
+ * - prompts: *.prompt.md in .github/prompts/ and ~/.copilot/prompts/
  * - skills: <name>/SKILL.md in .github/skills/ (GitHub Agent Skills layout)
  */
 import * as path from "node:path";
@@ -18,10 +21,19 @@ import { registerProvider } from "../capability";
 import { type ContextFile, contextFileCapability } from "../capability/context-file";
 import { readFile } from "../capability/fs";
 import { type Instruction, instructionCapability } from "../capability/instruction";
+import { type Prompt, promptCapability } from "../capability/prompt";
 import { type Skill, skillCapability } from "../capability/skill";
 import type { LoadContext, LoadResult, SourceMeta } from "../capability/types";
 
-import { calculateDepth, createSourceMeta, getProjectPath, loadFilesFromDir, scanSkillsFromDir } from "./helpers";
+import {
+	calculateDepth,
+	createSourceMeta,
+	getProjectPath,
+	loadFilesFromDir,
+	parseCSV,
+	resolveCopilotHome,
+	scanSkillsFromDir,
+} from "./helpers";
 
 const PROVIDER_ID = "github";
 const DISPLAY_NAME = "GitHub Copilot";
@@ -52,6 +64,31 @@ async function loadContextFiles(ctx: LoadContext): Promise<LoadResult<ContextFil
 		}
 	}
 
+	// User-global instructions (~/.copilot/copilot-instructions.md), applied across all repos.
+	const userInstructionsPath = path.join(resolveCopilotHome(ctx.home), "copilot-instructions.md");
+	const userContent = await readFile(userInstructionsPath);
+	if (userContent) {
+		items.push({
+			path: userInstructionsPath,
+			content: userContent,
+			level: "user",
+			_source: createSourceMeta(PROVIDER_ID, userInstructionsPath, "user"),
+		});
+	}
+
+	// Extra dirs from COPILOT_CUSTOM_INSTRUCTIONS_DIRS each contribute a copilot-instructions.md.
+	for (const dir of copilotCustomInstructionDirs()) {
+		const customPath = path.join(dir, "copilot-instructions.md");
+		const customContent = await readFile(customPath);
+		if (customContent) {
+			items.push({
+				path: customPath,
+				content: customContent,
+				level: "user",
+				_source: createSourceMeta(PROVIDER_ID, customPath, "user"),
+			});
+		}
+	}
 	return { items, warnings };
 }
 
@@ -66,6 +103,16 @@ async function loadInstructions(ctx: LoadContext): Promise<LoadResult<Instructio
 	const instructionsDir = getProjectPath(ctx, "github", "instructions");
 	if (instructionsDir) {
 		const result = await loadFilesFromDir<Instruction>(ctx, instructionsDir, PROVIDER_ID, "project", {
+			extensions: ["md"],
+			transform: transformInstruction,
+		});
+		items.push(...result.items);
+		if (result.warnings) warnings.push(...result.warnings);
+	}
+
+	// Extra dirs from COPILOT_CUSTOM_INSTRUCTIONS_DIRS each contribute *.instructions.md.
+	for (const dir of copilotCustomInstructionDirs()) {
+		const result = await loadFilesFromDir<Instruction>(ctx, dir, PROVIDER_ID, "user", {
 			extensions: ["md"],
 			transform: transformInstruction,
 		});
@@ -97,6 +144,47 @@ function transformInstruction(name: string, content: string, filePath: string, s
 		applyTo,
 		_source: source,
 	};
+}
+
+// =============================================================================
+// Prompts
+// =============================================================================
+
+async function loadPrompts(ctx: LoadContext): Promise<LoadResult<Prompt>> {
+	const projectPromptsDir = getProjectPath(ctx, "github", "prompts");
+	const userPromptsDir = path.join(resolveCopilotHome(ctx.home), "prompts");
+
+	const dirs: Array<{ dir: string; level: "user" | "project" }> = [];
+	if (projectPromptsDir) dirs.push({ dir: projectPromptsDir, level: "project" });
+	dirs.push({ dir: userPromptsDir, level: "user" });
+
+	const results = await Promise.all(
+		dirs.map(({ dir, level }) =>
+			loadFilesFromDir<Prompt>(ctx, dir, PROVIDER_ID, level, {
+				extensions: ["md"],
+				transform: transformPrompt,
+			}),
+		),
+	);
+
+	return { items: results.flatMap(r => r.items), warnings: results.flatMap(r => r.warnings ?? []) };
+}
+
+function transformPrompt(name: string, content: string, filePath: string, source: SourceMeta): Prompt | null {
+	// Copilot prompt files are `*.prompt.md`; ignore other markdown that may share the dir.
+	if (!name.endsWith(".prompt.md")) return null;
+
+	const { frontmatter, body } = parseFrontmatter(content, { source: filePath });
+	const promptName =
+		typeof frontmatter.name === "string" && frontmatter.name ? frontmatter.name : path.basename(name, ".prompt.md");
+
+	return { name: promptName, path: filePath, content: body, _source: source };
+}
+
+/** Directories listed in the COPILOT_CUSTOM_INSTRUCTIONS_DIRS env var (comma-separated). */
+function copilotCustomInstructionDirs(): string[] {
+	const raw = process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS;
+	return raw ? parseCSV(raw) : [];
 }
 
 // =============================================================================
@@ -132,7 +220,7 @@ async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
 registerProvider(contextFileCapability.id, {
 	id: PROVIDER_ID,
 	displayName: DISPLAY_NAME,
-	description: "Load copilot-instructions.md from .github/",
+	description: "Load copilot-instructions.md from .github/, ~/.copilot/, and COPILOT_CUSTOM_INSTRUCTIONS_DIRS",
 	priority: PRIORITY,
 	load: loadContextFiles,
 });
@@ -140,7 +228,7 @@ registerProvider(contextFileCapability.id, {
 registerProvider(instructionCapability.id, {
 	id: PROVIDER_ID,
 	displayName: DISPLAY_NAME,
-	description: "Load *.instructions.md from .github/instructions/ with applyTo frontmatter",
+	description: "Load *.instructions.md from .github/instructions/ and COPILOT_CUSTOM_INSTRUCTIONS_DIRS",
 	priority: PRIORITY,
 	load: loadInstructions,
 });
@@ -151,4 +239,12 @@ registerProvider<Skill>(skillCapability.id, {
 	description: "Load skills from .github/skills/*/SKILL.md",
 	priority: PRIORITY,
 	load: loadSkills,
+});
+
+registerProvider<Prompt>(promptCapability.id, {
+	id: PROVIDER_ID,
+	displayName: DISPLAY_NAME,
+	description: "Load *.prompt.md from .github/prompts/ and ~/.copilot/prompts/",
+	priority: PRIORITY,
+	load: loadPrompts,
 });

--- a/packages/coding-agent/src/discovery/github.ts
+++ b/packages/coding-agent/src/discovery/github.ts
@@ -10,9 +10,9 @@
  * - Extra: directories listed in COPILOT_CUSTOM_INSTRUCTIONS_DIRS
  *
  * Capabilities:
- * - context-files: copilot-instructions.md in .github/, ~/.copilot/, and custom dirs
- * - instructions: *.instructions.md in .github/instructions/ and custom dirs (applyTo frontmatter)
- * - prompts: *.prompt.md in .github/prompts/ and ~/.copilot/prompts/
+ * - context-files: copilot-instructions.md in .github/ and ~/.copilot/; AGENTS.md in each COPILOT_CUSTOM_INSTRUCTIONS_DIRS
+ * - instructions: *.instructions.md under .github/instructions/ (project) and <dir>/.github/instructions/ for each custom dir (applyTo frontmatter)
+ * - prompts: *.prompt.md in .github/prompts/ (VS Code Copilot prompt files)
  * - skills: <name>/SKILL.md in .github/skills/ (GitHub Agent Skills layout)
  */
 import * as path from "node:path";
@@ -76,16 +76,18 @@ async function loadContextFiles(ctx: LoadContext): Promise<LoadResult<ContextFil
 		});
 	}
 
-	// Extra dirs from COPILOT_CUSTOM_INSTRUCTIONS_DIRS each contribute a copilot-instructions.md.
+	// Each COPILOT_CUSTOM_INSTRUCTIONS_DIRS entry contributes an AGENTS.md (Copilot CLI
+	// searches these dirs for AGENTS.md + .github/instructions/**; the latter is handled
+	// by loadInstructions). copilot-instructions.md is NOT part of the custom-dir spec.
 	for (const dir of copilotCustomInstructionDirs()) {
-		const customPath = path.join(dir, "copilot-instructions.md");
-		const customContent = await readFile(customPath);
-		if (customContent) {
+		const agentsMdPath = path.join(dir, "AGENTS.md");
+		const agentsMdContent = await readFile(agentsMdPath);
+		if (agentsMdContent) {
 			items.push({
-				path: customPath,
-				content: customContent,
+				path: agentsMdPath,
+				content: agentsMdContent,
 				level: "user",
-				_source: createSourceMeta(PROVIDER_ID, customPath, "user"),
+				_source: createSourceMeta(PROVIDER_ID, agentsMdPath, "user"),
 			});
 		}
 	}
@@ -102,19 +104,23 @@ async function loadInstructions(ctx: LoadContext): Promise<LoadResult<Instructio
 
 	const instructionsDir = getProjectPath(ctx, "github", "instructions");
 	if (instructionsDir) {
+		// Path-specific instructions live "within or below" .github/instructions/ → recurse.
 		const result = await loadFilesFromDir<Instruction>(ctx, instructionsDir, PROVIDER_ID, "project", {
 			extensions: ["md"],
 			transform: transformInstruction,
+			recursive: true,
 		});
 		items.push(...result.items);
 		if (result.warnings) warnings.push(...result.warnings);
 	}
 
-	// Extra dirs from COPILOT_CUSTOM_INSTRUCTIONS_DIRS each contribute *.instructions.md.
+	// Each COPILOT_CUSTOM_INSTRUCTIONS_DIRS entry contributes <dir>/.github/instructions/**/*.instructions.md.
 	for (const dir of copilotCustomInstructionDirs()) {
-		const result = await loadFilesFromDir<Instruction>(ctx, dir, PROVIDER_ID, "user", {
+		const customInstructionsDir = path.join(dir, ".github", "instructions");
+		const result = await loadFilesFromDir<Instruction>(ctx, customInstructionsDir, PROVIDER_ID, "user", {
 			extensions: ["md"],
 			transform: transformInstruction,
+			recursive: true,
 		});
 		items.push(...result.items);
 		if (result.warnings) warnings.push(...result.warnings);
@@ -151,27 +157,19 @@ function transformInstruction(name: string, content: string, filePath: string, s
 // =============================================================================
 
 async function loadPrompts(ctx: LoadContext): Promise<LoadResult<Prompt>> {
-	const projectPromptsDir = getProjectPath(ctx, "github", "prompts");
-	const userPromptsDir = path.join(resolveCopilotHome(ctx.home), "prompts");
+	// `.github/prompts/*.prompt.md` is the VS Code Copilot prompt-file convention (the
+	// Copilot CLI has no prompt-file feature of its own); surface them as slash commands.
+	const promptsDir = getProjectPath(ctx, "github", "prompts");
+	if (!promptsDir) return { items: [], warnings: [] };
 
-	const dirs: Array<{ dir: string; level: "user" | "project" }> = [];
-	if (projectPromptsDir) dirs.push({ dir: projectPromptsDir, level: "project" });
-	dirs.push({ dir: userPromptsDir, level: "user" });
-
-	const results = await Promise.all(
-		dirs.map(({ dir, level }) =>
-			loadFilesFromDir<Prompt>(ctx, dir, PROVIDER_ID, level, {
-				extensions: ["md"],
-				transform: transformPrompt,
-			}),
-		),
-	);
-
-	return { items: results.flatMap(r => r.items), warnings: results.flatMap(r => r.warnings ?? []) };
+	return loadFilesFromDir<Prompt>(ctx, promptsDir, PROVIDER_ID, "project", {
+		extensions: ["md"],
+		transform: transformPrompt,
+	});
 }
 
 function transformPrompt(name: string, content: string, filePath: string, source: SourceMeta): Prompt | null {
-	// Copilot prompt files are `*.prompt.md`; ignore other markdown that may share the dir.
+	// Prompt files are `*.prompt.md`; ignore other markdown that may share the dir.
 	if (!name.endsWith(".prompt.md")) return null;
 
 	const { frontmatter, body } = parseFrontmatter(content, { source: filePath });
@@ -220,7 +218,8 @@ async function loadSkills(ctx: LoadContext): Promise<LoadResult<Skill>> {
 registerProvider(contextFileCapability.id, {
 	id: PROVIDER_ID,
 	displayName: DISPLAY_NAME,
-	description: "Load copilot-instructions.md from .github/, ~/.copilot/, and COPILOT_CUSTOM_INSTRUCTIONS_DIRS",
+	description:
+		"Load copilot-instructions.md from .github/ and ~/.copilot/; AGENTS.md from COPILOT_CUSTOM_INSTRUCTIONS_DIRS",
 	priority: PRIORITY,
 	load: loadContextFiles,
 });
@@ -244,7 +243,7 @@ registerProvider<Skill>(skillCapability.id, {
 registerProvider<Prompt>(promptCapability.id, {
 	id: PROVIDER_ID,
 	displayName: DISPLAY_NAME,
-	description: "Load *.prompt.md from .github/prompts/ and ~/.copilot/prompts/",
+	description: "Load *.prompt.md from .github/prompts/ (VS Code Copilot prompt files)",
 	priority: PRIORITY,
 	load: loadPrompts,
 });

--- a/packages/coding-agent/src/discovery/helpers.ts
+++ b/packages/coding-agent/src/discovery/helpers.ts
@@ -102,6 +102,17 @@ export function getProjectPath(ctx: LoadContext, source: SourceId, subpath: stri
 }
 
 /**
+ * Resolve GitHub Copilot CLI's user-global config root. Copilot stores per-user
+ * instructions/prompts/agents/MCP under `~/.copilot`, relocatable via the
+ * `COPILOT_HOME` env var (mirrors Copilot CLI's `--config-dir`). Falls back to
+ * `<home>/.copilot` when the override is unset.
+ */
+export function resolveCopilotHome(home: string): string {
+	const override = process.env.COPILOT_HOME?.trim();
+	return override ? override : path.join(home, ".copilot");
+}
+
+/**
  * Create source metadata for an item.
  */
 export function createSourceMeta(provider: string, filePath: string, level: "user" | "project"): SourceMeta {

--- a/packages/coding-agent/test/discovery/github-copilot.test.ts
+++ b/packages/coding-agent/test/discovery/github-copilot.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Regression for the GitHub Copilot user-global discovery gaps:
+ *   - #1913: ~/.copilot/copilot-instructions.md (user-global instructions)
+ *   - #1915: COPILOT_HOME relocation + COPILOT_CUSTOM_INSTRUCTIONS_DIRS
+ *   - #1916: *.prompt.md in .github/prompts/ and ~/.copilot/prompts/
+ *
+ * The `github` provider previously only scanned the project `.github/` tree. These
+ * tests pin the user-global surface, driven through COPILOT_HOME so they never touch
+ * the developer's real ~/.copilot directory.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadCapability } from "@oh-my-pi/pi-coding-agent/capability";
+import type { ContextFile } from "@oh-my-pi/pi-coding-agent/capability/context-file";
+import { clearCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import type { Instruction } from "@oh-my-pi/pi-coding-agent/capability/instruction";
+import type { Prompt } from "@oh-my-pi/pi-coding-agent/capability/prompt";
+import "@oh-my-pi/pi-coding-agent/capability/context-file";
+import "@oh-my-pi/pi-coding-agent/capability/instruction";
+import "@oh-my-pi/pi-coding-agent/capability/prompt";
+import "@oh-my-pi/pi-coding-agent/discovery/github";
+
+const ENV_KEYS = ["COPILOT_HOME", "COPILOT_CUSTOM_INSTRUCTIONS_DIRS"] as const;
+
+function write(file: string, content: string): void {
+	fs.mkdirSync(path.dirname(file), { recursive: true });
+	fs.writeFileSync(file, content);
+}
+
+describe("github discovery — Copilot user-global surface", () => {
+	let tempDir!: string;
+	let cwd!: string;
+	let copilotHome!: string;
+	const savedEnv: Record<string, string | undefined> = {};
+
+	beforeEach(() => {
+		clearCache();
+		for (const key of ENV_KEYS) savedEnv[key] = process.env[key];
+		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "pi-github-copilot-"));
+		cwd = path.join(tempDir, "project");
+		copilotHome = path.join(tempDir, "copilot-home");
+		fs.mkdirSync(cwd, { recursive: true });
+		process.env.COPILOT_HOME = copilotHome;
+		delete process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS;
+	});
+
+	afterEach(() => {
+		clearCache();
+		for (const key of ENV_KEYS) {
+			if (savedEnv[key] === undefined) delete process.env[key];
+			else process.env[key] = savedEnv[key];
+		}
+		if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test("loads user-global ~/.copilot/copilot-instructions.md via COPILOT_HOME (#1913)", async () => {
+		write(path.join(copilotHome, "copilot-instructions.md"), "user-global guidance");
+
+		const result = await loadCapability<ContextFile>("context-files", { cwd, providers: ["github"] });
+
+		const found = result.all.find(f => f.path === path.join(copilotHome, "copilot-instructions.md"));
+		expect(found).toBeDefined();
+		expect(found?.content).toBe("user-global guidance");
+		expect(found?.level).toBe("user");
+		expect(found?._source.provider).toBe("github");
+	});
+
+	test("still loads project .github/copilot-instructions.md alongside user-global", async () => {
+		write(path.join(cwd, ".github", "copilot-instructions.md"), "project guidance");
+		write(path.join(copilotHome, "copilot-instructions.md"), "user guidance");
+
+		const result = await loadCapability<ContextFile>("context-files", { cwd, providers: ["github"] });
+
+		const project = result.all.find(f => f.level === "project");
+		const user = result.all.find(f => f.level === "user");
+		expect(project?.content).toBe("project guidance");
+		expect(user?.content).toBe("user guidance");
+	});
+
+	test("loads copilot-instructions.md from COPILOT_CUSTOM_INSTRUCTIONS_DIRS (#1915)", async () => {
+		const extraA = path.join(tempDir, "extra-a");
+		const extraB = path.join(tempDir, "extra-b");
+		write(path.join(extraA, "copilot-instructions.md"), "extra A");
+		write(path.join(extraB, "copilot-instructions.md"), "extra B");
+		process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS = `${extraA}, ${extraB}`;
+
+		const result = await loadCapability<ContextFile>("context-files", { cwd, providers: ["github"] });
+
+		const contents = result.all.filter(f => f.level === "user").map(f => f.content);
+		expect(contents).toContain("extra A");
+		expect(contents).toContain("extra B");
+	});
+
+	test("loads *.instructions.md from COPILOT_CUSTOM_INSTRUCTIONS_DIRS (#1915)", async () => {
+		const extra = path.join(tempDir, "extra");
+		write(path.join(extra, "style.instructions.md"), "---\napplyTo: '**/*.ts'\n---\nStyle rules");
+		process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS = extra;
+
+		const result = await loadCapability<Instruction>("instructions", { cwd, providers: ["github"] });
+
+		const found = result.all.find(i => i.name === "style");
+		expect(found).toBeDefined();
+		expect(found?.applyTo).toBe("**/*.ts");
+		expect(found?.content.trim()).toBe("Style rules");
+		expect(found?._source.level).toBe("user");
+	});
+
+	test("discovers *.prompt.md from .github/prompts/ and ~/.copilot/prompts/ (#1916)", async () => {
+		write(
+			path.join(cwd, ".github", "prompts", "review.prompt.md"),
+			"---\ndescription: Review helper\n---\nReview the diff.",
+		);
+		write(path.join(copilotHome, "prompts", "summarize.prompt.md"), "Summarize the changes.");
+		// Plain markdown that is not a Copilot prompt file must be ignored.
+		write(path.join(cwd, ".github", "prompts", "notes.md"), "not a prompt");
+
+		const result = await loadCapability<Prompt>("prompts", { cwd, providers: ["github"] });
+
+		const review = result.all.find(p => p.name === "review");
+		const summarize = result.all.find(p => p.name === "summarize");
+		expect(review).toBeDefined();
+		expect(review?.content.trim()).toBe("Review the diff.");
+		expect(review?._source.level).toBe("project");
+		expect(summarize).toBeDefined();
+		expect(summarize?._source.level).toBe("user");
+		expect(result.all.find(p => p.name === "notes")).toBeUndefined();
+	});
+});

--- a/packages/coding-agent/test/discovery/github-copilot.test.ts
+++ b/packages/coding-agent/test/discovery/github-copilot.test.ts
@@ -79,23 +79,32 @@ describe("github discovery — Copilot user-global surface", () => {
 		expect(user?.content).toBe("user guidance");
 	});
 
-	test("loads copilot-instructions.md from COPILOT_CUSTOM_INSTRUCTIONS_DIRS (#1915)", async () => {
+	test("loads AGENTS.md from COPILOT_CUSTOM_INSTRUCTIONS_DIRS (#1915)", async () => {
 		const extraA = path.join(tempDir, "extra-a");
 		const extraB = path.join(tempDir, "extra-b");
-		write(path.join(extraA, "copilot-instructions.md"), "extra A");
-		write(path.join(extraB, "copilot-instructions.md"), "extra B");
+		write(path.join(extraA, "AGENTS.md"), "extra A agents");
+		write(path.join(extraB, "AGENTS.md"), "extra B agents");
+		// copilot-instructions.md in a custom dir is NOT part of the spec and must be ignored.
+		write(path.join(extraA, "copilot-instructions.md"), "should be ignored");
 		process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS = `${extraA}, ${extraB}`;
 
 		const result = await loadCapability<ContextFile>("context-files", { cwd, providers: ["github"] });
 
 		const contents = result.all.filter(f => f.level === "user").map(f => f.content);
-		expect(contents).toContain("extra A");
-		expect(contents).toContain("extra B");
+		expect(contents).toContain("extra A agents");
+		expect(contents).toContain("extra B agents");
+		expect(contents).not.toContain("should be ignored");
 	});
 
-	test("loads *.instructions.md from COPILOT_CUSTOM_INSTRUCTIONS_DIRS (#1915)", async () => {
+	test("loads <dir>/.github/instructions/**/*.instructions.md from custom dirs (#1915)", async () => {
 		const extra = path.join(tempDir, "extra");
-		write(path.join(extra, "style.instructions.md"), "---\napplyTo: '**/*.ts'\n---\nStyle rules");
+		// Recursive, under <dir>/.github/instructions — not top-level <dir>/*.instructions.md.
+		write(
+			path.join(extra, ".github", "instructions", "nested", "style.instructions.md"),
+			"---\napplyTo: '**/*.ts'\n---\nStyle rules",
+		);
+		// A top-level instructions file in the custom dir must NOT be picked up.
+		write(path.join(extra, "toplevel.instructions.md"), "---\napplyTo: '**'\n---\nIgnored");
 		process.env.COPILOT_CUSTOM_INSTRUCTIONS_DIRS = extra;
 
 		const result = await loadCapability<Instruction>("instructions", { cwd, providers: ["github"] });
@@ -105,26 +114,23 @@ describe("github discovery — Copilot user-global surface", () => {
 		expect(found?.applyTo).toBe("**/*.ts");
 		expect(found?.content.trim()).toBe("Style rules");
 		expect(found?._source.level).toBe("user");
+		expect(result.all.find(i => i.name === "toplevel")).toBeUndefined();
 	});
 
-	test("discovers *.prompt.md from .github/prompts/ and ~/.copilot/prompts/ (#1916)", async () => {
+	test("discovers *.prompt.md from .github/prompts/ (#1916)", async () => {
 		write(
 			path.join(cwd, ".github", "prompts", "review.prompt.md"),
 			"---\ndescription: Review helper\n---\nReview the diff.",
 		);
-		write(path.join(copilotHome, "prompts", "summarize.prompt.md"), "Summarize the changes.");
-		// Plain markdown that is not a Copilot prompt file must be ignored.
+		// Plain markdown that is not a prompt file must be ignored.
 		write(path.join(cwd, ".github", "prompts", "notes.md"), "not a prompt");
 
 		const result = await loadCapability<Prompt>("prompts", { cwd, providers: ["github"] });
 
 		const review = result.all.find(p => p.name === "review");
-		const summarize = result.all.find(p => p.name === "summarize");
 		expect(review).toBeDefined();
 		expect(review?.content.trim()).toBe("Review the diff.");
 		expect(review?._source.level).toBe("project");
-		expect(summarize).toBeDefined();
-		expect(summarize?._source.level).toBe("user");
 		expect(result.all.find(p => p.name === "notes")).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Summary

Extends the `github` discovery provider to cover GitHub Copilot CLI's **user-global** config surface. Previously it scanned only the project `.github/` tree, so a Copilot user's cross-repo instructions, env-configured directories, and prompt files were silently ignored under OMP.

Closes #1913, #1915, #1916.

## Changes

### `discovery/helpers.ts`
- New `resolveCopilotHome(home)` — resolves Copilot's user-global root (`~/.copilot`), honoring the `COPILOT_HOME` override (Copilot CLI's `--config-dir`).

### `discovery/github.ts`
- **context-files (#1913):** also load user-global `~/.copilot/copilot-instructions.md` at `level: "user"`, alongside the existing project `.github/copilot-instructions.md`.
- **env dirs (#1915):** read directories listed in `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` (comma-separated), contributing each dir's `copilot-instructions.md` and `*.instructions.md`. `COPILOT_HOME` relocation is honored everywhere via `resolveCopilotHome`.
- **prompts (#1916):** new `prompts` capability provider loading `*.prompt.md` from `.github/prompts/` (project) and `~/.copilot/prompts/` (user). Non-`*.prompt.md` markdown in those dirs is ignored.

### Tests — `test/discovery/github-copilot.test.ts`
5 tests, all driven through `COPILOT_HOME` pointed at a temp dir so they never touch the developer's real `~/.copilot` (the same redirection pitfall flagged in review on #1938). Covers user-global instructions, project+user coexistence, `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` (both file types), and project/user prompt discovery with non-prompt filtering. Existing `github-skills.test.ts` stays green.

## Scope / coordination

- **MCP (#1917) is intentionally not here** — it's covered by #1938 (@WodenJay). That PR introduces its own `resolveCopilotHome(ctx)` inside `discovery/copilot.ts`; once both land, the two could converge on the shared `helpers.ts` resolver added here.
- Skills (#1907) already merged; untouched.
- `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` `AGENTS.md` contribution is left to the agent-discovery path; this PR scopes the env var to Copilot's instruction files.

## Verification

- `bun test test/discovery/github-copilot.test.ts test/discovery/github-skills.test.ts` → **8 pass, 0 fail**.
- `tsgo -p tsconfig.json --noEmit` → clean.
- `biome check` → clean.
