### PR TITLE
feat(discovery): discover GitHub Copilot custom agents (#1914)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Added
 
-- Added GitHub Copilot custom-agent discovery: `discoverAgents()` now finds agent definitions in `.github/agents/` (project-level, resolved by walking up from the cwd) and `~/.copilot/agents/` (user-global, relocatable via `COPILOT_HOME`). Previously only `.omp`/`.claude`/`.codex`/`.gemini` agent sources were scanned, so Copilot CLI users' custom agents were invisible. Matches Copilot CLI semantics: a home-directory agent overrides a project agent of the same name, and `*.agent.md` profiles that omit `name` derive their identity from the filename. Gated on the `github` discovery provider. Closes #1914.
+- Added GitHub Copilot custom-agent discovery: `discoverAgents()` now finds agent definitions in `.github/agents/` (project-level, resolved by walking up from the cwd) and `~/.copilot/agents/` (user-global, relocatable via `COPILOT_HOME`). Previously only `.omp`/`.claude`/`.codex`/`.gemini` agent sources were scanned, so Copilot CLI users' custom agents were invisible. Matches Copilot CLI semantics: a project agent takes precedence over a personal agent of the same name (per the CLI config-dir reference), and `*.agent.md` profiles that omit `name` derive their identity from the filename. Gated on the `github` discovery provider. Closes #1914.
 
 ## [15.9.5] - 2026-06-05
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added GitHub Copilot custom-agent discovery: `discoverAgents()` now finds agent definitions in `.github/agents/` (project-level, resolved by walking up from the cwd) and `~/.copilot/agents/` (user-global, relocatable via `COPILOT_HOME`). Previously only `.omp`/`.claude`/`.codex`/`.gemini` agent sources were scanned, so Copilot CLI users' custom agents were invisible. Gated on the `github` discovery provider. Closes #1914.
 
 ## [15.9.5] - 2026-06-05
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Added
 
-- Added GitHub Copilot custom-agent discovery: `discoverAgents()` now finds agent definitions in `.github/agents/` (project-level, resolved by walking up from the cwd) and `~/.copilot/agents/` (user-global, relocatable via `COPILOT_HOME`). Previously only `.omp`/`.claude`/`.codex`/`.gemini` agent sources were scanned, so Copilot CLI users' custom agents were invisible. Matches Copilot CLI semantics: a project agent takes precedence over a personal agent of the same name (per the CLI config-dir reference), and `*.agent.md` profiles that omit `name` derive their identity from the filename. Gated on the `github` discovery provider. Closes #1914.
+- Added GitHub Copilot custom-agent discovery: `discoverAgents()` now finds agent definitions in `.github/agents/` (project-level, resolved by walking up from the cwd) and `~/.copilot/agents/` (user-global, relocatable via `COPILOT_HOME`). Previously only `.omp`/`.claude`/`.codex`/`.gemini` agent sources were scanned, so Copilot CLI users' custom agents were invisible. Matches Copilot CLI semantics: a project agent takes precedence over a personal agent of the same name and agents are deduped by file id (per the CLI config-dir reference), `*.agent.md` profiles that omit `name` derive their identity from the filename, profiles targeted at a non-Copilot environment (`target: vscode`) are skipped, and Copilot tool aliases (`execute`, `agent`, `*`, …) are translated to OMP tool names. Gated on the `github` discovery provider. Closes #1914.
 
 ## [15.9.5] - 2026-06-05
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Added
 
-- Added GitHub Copilot custom-agent discovery: `discoverAgents()` now finds agent definitions in `.github/agents/` (project-level, resolved by walking up from the cwd) and `~/.copilot/agents/` (user-global, relocatable via `COPILOT_HOME`). Previously only `.omp`/`.claude`/`.codex`/`.gemini` agent sources were scanned, so Copilot CLI users' custom agents were invisible. Gated on the `github` discovery provider. Closes #1914.
+- Added GitHub Copilot custom-agent discovery: `discoverAgents()` now finds agent definitions in `.github/agents/` (project-level, resolved by walking up from the cwd) and `~/.copilot/agents/` (user-global, relocatable via `COPILOT_HOME`). Previously only `.omp`/`.claude`/`.codex`/`.gemini` agent sources were scanned, so Copilot CLI users' custom agents were invisible. Matches Copilot CLI semantics: a home-directory agent overrides a project agent of the same name, and `*.agent.md` profiles that omit `name` derive their identity from the filename. Gated on the `github` discovery provider. Closes #1914.
 
 ## [15.9.5] - 2026-06-05
 ### Added

--- a/packages/coding-agent/src/task/agents.ts
+++ b/packages/coding-agent/src/task/agents.ts
@@ -104,11 +104,16 @@ export function parseAgent(
 	content: string,
 	source: AgentSource,
 	level: "fatal" | "warn" | "off" = "fatal",
+	fallbackName?: string,
 ): AgentDefinition {
 	const { frontmatter, body } = parseFrontmatter(content, {
 		location: filePath,
 		level,
 	});
+	// GitHub Copilot agent profiles may omit `name`, using the filename as identity.
+	if (fallbackName && typeof frontmatter.name !== "string") {
+		frontmatter.name = fallbackName;
+	}
 	const fields = parseAgentFields(frontmatter);
 	if (!fields) {
 		throw new AgentParsingError(new Error(`Invalid agent field: ${filePath}\n${content}`), filePath);

--- a/packages/coding-agent/src/task/discovery.ts
+++ b/packages/coding-agent/src/task/discovery.ts
@@ -8,6 +8,8 @@
  *   - .omp/agents/*.md (project-level, primary)
  *   - .pi/agents/*.md (project-level, legacy)
  *   - .claude/agents/*.md (project-level, legacy)
+ *   - ~/.copilot/agents/*.md (user-level, GitHub Copilot; relocatable via COPILOT_HOME)
+ *   - .github/agents/*.md (project-level, GitHub Copilot)
  *
  * Agent files use markdown with YAML frontmatter.
  */
@@ -47,6 +49,25 @@ async function loadAgentsFromDir(dir: string, source: AgentSource): Promise<Agen
 		});
 
 	return (await Promise.all(files)).filter(Boolean) as AgentDefinition[];
+}
+
+/**
+ * Find the nearest `.github/agents` directory, walking up from `startDir`. Mirrors how
+ * project config dirs are resolved so Copilot agents work from monorepo subdirectories.
+ */
+async function findNearestCopilotAgentsDir(startDir: string): Promise<string | null> {
+	let dir = startDir;
+	while (true) {
+		const candidate = path.join(dir, ".github", "agents");
+		const isDir = await fs
+			.stat(candidate)
+			.then(s => s.isDirectory())
+			.catch(() => false);
+		if (isDir) return candidate;
+		const parent = path.dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
 }
 
 /**
@@ -99,6 +120,16 @@ export async function discoverAgents(cwd: string, home: string = os.homedir()): 
 	for (const plugin of sortedPluginRoots) {
 		const agentsDir = path.join(plugin.path, "agents");
 		orderedDirs.push({ dir: agentsDir, source: plugin.scope === "project" ? "project" : "user" });
+	}
+
+	// GitHub Copilot custom agents: project `.github/agents/` (nearest, walking up from cwd)
+	// and user-global `~/.copilot/agents/` (relocatable via COPILOT_HOME). Gated on the
+	// github discovery provider so disabling it also disables Copilot agent discovery.
+	if (isProviderEnabled("github")) {
+		const projectCopilotDir = await findNearestCopilotAgentsDir(resolvedCwd);
+		if (projectCopilotDir) orderedDirs.push({ dir: projectCopilotDir, source: "project" });
+		const copilotHome = process.env.COPILOT_HOME?.trim() || path.join(home, ".copilot");
+		orderedDirs.push({ dir: path.join(copilotHome, "agents"), source: "user" });
 	}
 
 	const seen = new Set<string>();

--- a/packages/coding-agent/src/task/discovery.ts
+++ b/packages/coding-agent/src/task/discovery.ts
@@ -82,7 +82,7 @@ async function loadCopilotAgentsFromDir(dir: string, source: AgentSource): Promi
 		.sort((a, b) => a.name.localeCompare(b.name))
 		.map(file => {
 			const filePath = path.join(dir, file.name);
-			const fallbackName = file.name.replace(/\.agent\.md$/, "").replace(/\.md$/, "");
+			const fallbackName = copilotAgentId(file.name);
 			return fs
 				.readFile(filePath, "utf-8")
 				.then(content => parseAgent(filePath, content, source, "warn", fallbackName))
@@ -93,6 +93,11 @@ async function loadCopilotAgentsFromDir(dir: string, source: AgentSource): Promi
 		});
 
 	return (await Promise.all(files)).filter(Boolean) as AgentDefinition[];
+}
+
+/** Copilot agent ID = filename minus the `.agent.md`/`.md` extension; used for cross-level dedup. */
+function copilotAgentId(fileName: string): string {
+	return fileName.replace(/\.agent\.md$/, "").replace(/\.md$/, "");
 }
 
 /**
@@ -106,14 +111,27 @@ async function loadCopilotAgentsFromDir(dir: string, source: AgentSource): Promi
 async function loadCopilotAgents(cwd: string, home: string): Promise<AgentDefinition[]> {
 	if (!isProviderEnabled("github")) return [];
 
-	const agents: AgentDefinition[] = [];
+	// Copilot dedupes between levels by file ID (filename minus extension) — not the
+	// frontmatter `name` — with the project level winning. Add project agents first and
+	// skip any personal agent whose file ID was already seen.
+	const seenIds = new Set<string>();
+	const result: AgentDefinition[] = [];
+	const add = (loaded: AgentDefinition[]) => {
+		for (const agent of loaded) {
+			const id = agent.filePath ? copilotAgentId(path.basename(agent.filePath)) : agent.name;
+			if (seenIds.has(id)) continue;
+			seenIds.add(id);
+			result.push(agent);
+		}
+	};
+
 	const projectDir = await findNearestCopilotAgentsDir(cwd);
-	if (projectDir) agents.push(...(await loadCopilotAgentsFromDir(projectDir, "project")));
+	if (projectDir) add(await loadCopilotAgentsFromDir(projectDir, "project"));
 
 	const copilotHome = process.env.COPILOT_HOME?.trim() || path.join(home, ".copilot");
-	agents.push(...(await loadCopilotAgentsFromDir(path.join(copilotHome, "agents"), "user")));
+	add(await loadCopilotAgentsFromDir(path.join(copilotHome, "agents"), "user"));
 
-	return agents;
+	return result;
 }
 
 /**

--- a/packages/coding-agent/src/task/discovery.ts
+++ b/packages/coding-agent/src/task/discovery.ts
@@ -71,6 +71,50 @@ async function findNearestCopilotAgentsDir(startDir: string): Promise<string | n
 }
 
 /**
+ * Load GitHub Copilot agent files from a directory. Copilot agent profiles use the
+ * `.agent.md` (or `.md`) extension and may omit `name` — the filename (minus the
+ * extension) is then the identity — so a filename-derived fallback name is supplied.
+ */
+async function loadCopilotAgentsFromDir(dir: string, source: AgentSource): Promise<AgentDefinition[]> {
+	const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
+	const files = entries
+		.filter(entry => (entry.isFile() || entry.isSymbolicLink()) && entry.name.endsWith(".md"))
+		.sort((a, b) => a.name.localeCompare(b.name))
+		.map(file => {
+			const filePath = path.join(dir, file.name);
+			const fallbackName = file.name.replace(/\.agent\.md$/, "").replace(/\.md$/, "");
+			return fs
+				.readFile(filePath, "utf-8")
+				.then(content => parseAgent(filePath, content, source, "warn", fallbackName))
+				.catch(error => {
+					logger.warn("Failed to read Copilot agent file", { filePath, error });
+					return null;
+				});
+		});
+
+	return (await Promise.all(files)).filter(Boolean) as AgentDefinition[];
+}
+
+/**
+ * Discover GitHub Copilot custom agents from `~/.copilot/agents/` (user-global,
+ * relocatable via COPILOT_HOME) and `.github/agents/` (project, nearest walking up).
+ * Per Copilot CLI, a home-directory agent overrides a project agent of the same name,
+ * so user agents are returned first (the caller dedupes first-name-wins). Gated on the
+ * github discovery provider.
+ */
+async function loadCopilotAgents(cwd: string, home: string): Promise<AgentDefinition[]> {
+	if (!isProviderEnabled("github")) return [];
+
+	const copilotHome = process.env.COPILOT_HOME?.trim() || path.join(home, ".copilot");
+	const agents = await loadCopilotAgentsFromDir(path.join(copilotHome, "agents"), "user");
+
+	const projectDir = await findNearestCopilotAgentsDir(cwd);
+	if (projectDir) agents.push(...(await loadCopilotAgentsFromDir(projectDir, "project")));
+
+	return agents;
+}
+
+/**
  * Discover agents from filesystem and merge with bundled agents.
  *
  * Precedence (highest wins): .omp > .pi > .claude (project before user), then bundled
@@ -122,24 +166,17 @@ export async function discoverAgents(cwd: string, home: string = os.homedir()): 
 		orderedDirs.push({ dir: agentsDir, source: plugin.scope === "project" ? "project" : "user" });
 	}
 
-	// GitHub Copilot custom agents: project `.github/agents/` (nearest, walking up from cwd)
-	// and user-global `~/.copilot/agents/` (relocatable via COPILOT_HOME). Gated on the
-	// github discovery provider so disabling it also disables Copilot agent discovery.
-	if (isProviderEnabled("github")) {
-		const projectCopilotDir = await findNearestCopilotAgentsDir(resolvedCwd);
-		if (projectCopilotDir) orderedDirs.push({ dir: projectCopilotDir, source: "project" });
-		const copilotHome = process.env.COPILOT_HOME?.trim() || path.join(home, ".copilot");
-		orderedDirs.push({ dir: path.join(copilotHome, "agents"), source: "user" });
-	}
+	const baseResults = await Promise.all(orderedDirs.map(({ dir, source }) => loadAgentsFromDir(dir, source)));
+	// Copilot agents are lowest priority among discovered sources; within Copilot the
+	// user (home) dir wins over the project dir, so it is loaded first.
+	const copilotAgents = await loadCopilotAgents(resolvedCwd, home);
 
 	const seen = new Set<string>();
-	const loadedAgents = (await Promise.all(orderedDirs.map(({ dir, source }) => loadAgentsFromDir(dir, source))))
-		.flat()
-		.filter(agent => {
-			if (seen.has(agent.name)) return false;
-			seen.add(agent.name);
-			return true;
-		});
+	const loadedAgents = [...baseResults.flat(), ...copilotAgents].filter(agent => {
+		if (seen.has(agent.name)) return false;
+		seen.add(agent.name);
+		return true;
+	});
 
 	const bundledAgents = loadBundledAgents().filter(agent => {
 		if (seen.has(agent.name)) return false;

--- a/packages/coding-agent/src/task/discovery.ts
+++ b/packages/coding-agent/src/task/discovery.ts
@@ -16,7 +16,7 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { logger } from "@oh-my-pi/pi-utils";
+import { logger, parseFrontmatter } from "@oh-my-pi/pi-utils";
 import { isProviderEnabled } from "../capability";
 import { findAllNearestProjectConfigDirs, getConfigDirs } from "../config";
 import { listClaudePluginRoots } from "../discovery/helpers";
@@ -80,16 +80,22 @@ async function loadCopilotAgentsFromDir(dir: string, source: AgentSource): Promi
 	const files = entries
 		.filter(entry => (entry.isFile() || entry.isSymbolicLink()) && entry.name.endsWith(".md"))
 		.sort((a, b) => a.name.localeCompare(b.name))
-		.map(file => {
+		.map(async file => {
 			const filePath = path.join(dir, file.name);
-			const fallbackName = copilotAgentId(file.name);
-			return fs
-				.readFile(filePath, "utf-8")
-				.then(content => parseAgent(filePath, content, source, "warn", fallbackName))
-				.catch(error => {
-					logger.warn("Failed to read Copilot agent file", { filePath, error });
-					return null;
-				});
+			try {
+				const content = await fs.readFile(filePath, "utf-8");
+				const { frontmatter } = parseFrontmatter(content, { location: filePath, level: "warn" });
+				// Skip profiles targeted only at a non-Copilot environment (e.g. `target: vscode`);
+				// an unset target defaults to both environments.
+				const target = frontmatter.target;
+				if (typeof target === "string" && target !== "github-copilot") return null;
+				const agent = parseAgent(filePath, content, source, "warn", copilotAgentId(file.name));
+				agent.tools = translateCopilotTools(agent.tools);
+				return agent;
+			} catch (error) {
+				logger.warn("Failed to read Copilot agent file", { filePath, error });
+				return null;
+			}
 		});
 
 	return (await Promise.all(files)).filter(Boolean) as AgentDefinition[];
@@ -98,6 +104,44 @@ async function loadCopilotAgentsFromDir(dir: string, source: AgentSource): Promi
 /** Copilot agent ID = filename minus the `.agent.md`/`.md` extension; used for cross-level dedup. */
 function copilotAgentId(fileName: string): string {
 	return fileName.replace(/\.agent\.md$/, "").replace(/\.md$/, "");
+}
+
+/**
+ * Map GitHub Copilot tool aliases onto OMP tool names. Copilot's documented aliases
+ * (custom-agents-configuration reference) differ from OMP's tool ids, and OMP treats
+ * `agent.tools` as a strict allow-list — so untranslated aliases (or `*`) would silently
+ * leave a restricted agent with the wrong tools or none at all. `*` means all tools → no
+ * restriction; MCP-namespaced (`server/tool`) and unknown names pass through unchanged.
+ */
+const COPILOT_TOOL_ALIASES: Record<string, string> = {
+	execute: "bash",
+	shell: "bash",
+	bash: "bash",
+	powershell: "bash",
+	read: "read",
+	notebookread: "read",
+	edit: "edit",
+	multiedit: "edit",
+	write: "edit",
+	notebookedit: "edit",
+	search: "search",
+	grep: "search",
+	glob: "search",
+	agent: "task",
+	"custom-agent": "task",
+	task: "task",
+	web: "web_search",
+	websearch: "web_search",
+	webfetch: "web_search",
+	todo: "todo",
+	todowrite: "todo",
+};
+
+function translateCopilotTools(tools: string[] | undefined): string[] | undefined {
+	if (!tools || tools.length === 0) return tools;
+	if (tools.includes("*")) return undefined; // all tools → no restriction
+	const mapped = tools.map(tool => (tool.includes("/") ? tool : (COPILOT_TOOL_ALIASES[tool.toLowerCase()] ?? tool)));
+	return Array.from(new Set(mapped));
 }
 
 /**

--- a/packages/coding-agent/src/task/discovery.ts
+++ b/packages/coding-agent/src/task/discovery.ts
@@ -96,20 +96,22 @@ async function loadCopilotAgentsFromDir(dir: string, source: AgentSource): Promi
 }
 
 /**
- * Discover GitHub Copilot custom agents from `~/.copilot/agents/` (user-global,
- * relocatable via COPILOT_HOME) and `.github/agents/` (project, nearest walking up).
- * Per Copilot CLI, a home-directory agent overrides a project agent of the same name,
- * so user agents are returned first (the caller dedupes first-name-wins). Gated on the
- * github discovery provider.
+ * Discover GitHub Copilot custom agents from `.github/agents/` (project, nearest walking
+ * up) and `~/.copilot/agents/` (user-global, relocatable via COPILOT_HOME). Per the
+ * Copilot CLI config-dir reference, a project agent takes precedence over a personal
+ * agent of the same name (consistent with Copilot skills/MCP and OMP's own
+ * project-over-user convention), so project agents are returned first and the caller
+ * dedupes first-name-wins. Gated on the github discovery provider.
  */
 async function loadCopilotAgents(cwd: string, home: string): Promise<AgentDefinition[]> {
 	if (!isProviderEnabled("github")) return [];
 
-	const copilotHome = process.env.COPILOT_HOME?.trim() || path.join(home, ".copilot");
-	const agents = await loadCopilotAgentsFromDir(path.join(copilotHome, "agents"), "user");
-
+	const agents: AgentDefinition[] = [];
 	const projectDir = await findNearestCopilotAgentsDir(cwd);
 	if (projectDir) agents.push(...(await loadCopilotAgentsFromDir(projectDir, "project")));
+
+	const copilotHome = process.env.COPILOT_HOME?.trim() || path.join(home, ".copilot");
+	agents.push(...(await loadCopilotAgentsFromDir(path.join(copilotHome, "agents"), "user")));
 
 	return agents;
 }

--- a/packages/coding-agent/test/discovery/copilot-agents.test.ts
+++ b/packages/coding-agent/test/discovery/copilot-agents.test.ts
@@ -98,4 +98,32 @@ describe("discoverAgents — GitHub Copilot agents", () => {
 		expect(names).not.toContain("gated-user-agent");
 		expect(names).not.toContain("gated-proj-agent");
 	});
+
+	test("home-dir agent overrides project agent of the same name", async () => {
+		writeAgent(path.join(tempProject, ".github", "agents"), "shared", "project version");
+		writeAgent(path.join(tempHome, ".copilot", "agents"), "shared", "home version");
+
+		const { agents } = await discoverAgents(tempProject, tempHome);
+
+		const found = agents.filter(a => a.name === "shared");
+		expect(found).toHaveLength(1);
+		expect(found[0].source).toBe("user");
+		expect(found[0].description).toBe("home version");
+	});
+
+	test("derives the agent name from a *.agent.md filename when frontmatter omits name", async () => {
+		const dir = path.join(tempHome, ".copilot", "agents");
+		fs.mkdirSync(dir, { recursive: true });
+		// No `name` in frontmatter — Copilot uses the filename (minus .agent.md) as identity.
+		fs.writeFileSync(
+			path.join(dir, "security-expert.agent.md"),
+			"---\ndescription: Security review specialist\n---\nAudit code for vulnerabilities.\n",
+		);
+
+		const { agents } = await discoverAgents(tempProject, tempHome);
+
+		const found = agents.find(a => a.name === "security-expert");
+		expect(found).toBeDefined();
+		expect(found?.description).toBe("Security review specialist");
+	});
 });

--- a/packages/coding-agent/test/discovery/copilot-agents.test.ts
+++ b/packages/coding-agent/test/discovery/copilot-agents.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression for #1914: discoverAgents() must discover GitHub Copilot custom agents
+ * from `.github/agents/` (project, nearest walking up) and `~/.copilot/agents/`
+ * (user-global, relocatable via COPILOT_HOME). Gated on the `github` provider.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { disableProvider, enableProvider } from "../../src/capability";
+import { clearCache as clearFsCache } from "../../src/capability/fs";
+import { discoverAgents } from "../../src/task/discovery";
+
+function writeAgent(dir: string, name: string, description: string): void {
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(dir, `${name}.md`),
+		`---\nname: ${name}\ndescription: ${description}\n---\nBody for ${name}.\n`,
+	);
+}
+
+describe("discoverAgents — GitHub Copilot agents", () => {
+	let tempHome: string;
+	let tempProject: string;
+	let savedCopilotHome: string | undefined;
+
+	beforeEach(() => {
+		tempHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-copilot-agents-home-"));
+		tempProject = fs.mkdtempSync(path.join(os.tmpdir(), "pi-copilot-agents-proj-"));
+		savedCopilotHome = process.env.COPILOT_HOME;
+		delete process.env.COPILOT_HOME;
+		enableProvider("github");
+		clearFsCache();
+	});
+
+	afterEach(() => {
+		fs.rmSync(tempHome, { recursive: true, force: true });
+		fs.rmSync(tempProject, { recursive: true, force: true });
+		if (savedCopilotHome === undefined) delete process.env.COPILOT_HOME;
+		else process.env.COPILOT_HOME = savedCopilotHome;
+		enableProvider("github");
+		clearFsCache();
+	});
+
+	test("discovers user-global ~/.copilot/agents/*.md", async () => {
+		writeAgent(path.join(tempHome, ".copilot", "agents"), "copilot-user-agent", "A user-global Copilot agent");
+
+		const { agents } = await discoverAgents(tempProject, tempHome);
+
+		const found = agents.find(a => a.name === "copilot-user-agent");
+		expect(found).toBeDefined();
+		expect(found?.source).toBe("user");
+	});
+
+	test("discovers project .github/agents/*.md", async () => {
+		writeAgent(path.join(tempProject, ".github", "agents"), "copilot-proj-agent", "A project Copilot agent");
+
+		const { agents } = await discoverAgents(tempProject, tempHome);
+
+		const found = agents.find(a => a.name === "copilot-proj-agent");
+		expect(found).toBeDefined();
+		expect(found?.source).toBe("project");
+	});
+
+	test("finds the nearest .github/agents walking up from a subdirectory", async () => {
+		writeAgent(path.join(tempProject, ".github", "agents"), "repo-root-agent", "Repo-root Copilot agent");
+		const subdir = path.join(tempProject, "packages", "sub");
+		fs.mkdirSync(subdir, { recursive: true });
+
+		const { agents } = await discoverAgents(subdir, tempHome);
+
+		expect(agents.map(a => a.name)).toContain("repo-root-agent");
+	});
+
+	test("honors COPILOT_HOME for the user-global agents dir", async () => {
+		const copilotHome = fs.mkdtempSync(path.join(os.tmpdir(), "pi-copilot-home-"));
+		try {
+			writeAgent(path.join(copilotHome, "agents"), "relocated-agent", "Agent under COPILOT_HOME");
+			process.env.COPILOT_HOME = copilotHome;
+
+			const { agents } = await discoverAgents(tempProject, tempHome);
+
+			expect(agents.map(a => a.name)).toContain("relocated-agent");
+		} finally {
+			fs.rmSync(copilotHome, { recursive: true, force: true });
+		}
+	});
+
+	test("excludes Copilot agents when the github provider is disabled", async () => {
+		writeAgent(path.join(tempHome, ".copilot", "agents"), "gated-user-agent", "user");
+		writeAgent(path.join(tempProject, ".github", "agents"), "gated-proj-agent", "project");
+
+		disableProvider("github");
+		clearFsCache();
+		const { agents } = await discoverAgents(tempProject, tempHome);
+
+		const names = agents.map(a => a.name);
+		expect(names).not.toContain("gated-user-agent");
+		expect(names).not.toContain("gated-proj-agent");
+	});
+});

--- a/packages/coding-agent/test/discovery/copilot-agents.test.ts
+++ b/packages/coding-agent/test/discovery/copilot-agents.test.ts
@@ -148,4 +148,54 @@ describe("discoverAgents — GitHub Copilot agents", () => {
 		expect(agents.find(a => a.name === "project-reviewer")).toBeDefined();
 		expect(agents.find(a => a.name === "personal-reviewer")).toBeUndefined();
 	});
+
+	test("skips Copilot agents targeted at a non-Copilot environment (target: vscode)", async () => {
+		const dir = path.join(tempProject, ".github", "agents");
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(
+			path.join(dir, "vsonly.agent.md"),
+			"---\nname: vsonly\ndescription: d\ntarget: vscode\n---\nBody.\n",
+		);
+		fs.writeFileSync(
+			path.join(dir, "cli.agent.md"),
+			"---\nname: cli-agent\ndescription: d\ntarget: github-copilot\n---\nBody.\n",
+		);
+
+		const { agents } = await discoverAgents(tempProject, tempHome);
+
+		expect(agents.find(a => a.name === "vsonly")).toBeUndefined();
+		expect(agents.find(a => a.name === "cli-agent")).toBeDefined();
+	});
+
+	test("translates Copilot tool aliases to OMP tool names", async () => {
+		const dir = path.join(tempHome, ".copilot", "agents");
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(
+			path.join(dir, "restricted.agent.md"),
+			"---\nname: restricted\ndescription: d\ntools: [execute, read, agent]\n---\nBody.\n",
+		);
+
+		const { agents } = await discoverAgents(tempProject, tempHome);
+
+		const found = agents.find(a => a.name === "restricted");
+		expect(found?.tools).toContain("bash");
+		expect(found?.tools).toContain("read");
+		expect(found?.tools).toContain("task");
+		expect(found?.tools).not.toContain("execute");
+	});
+
+	test("treats Copilot tools: ['*'] as unrestricted (all tools)", async () => {
+		const dir = path.join(tempHome, ".copilot", "agents");
+		fs.mkdirSync(dir, { recursive: true });
+		fs.writeFileSync(
+			path.join(dir, "alltools.agent.md"),
+			"---\nname: alltools\ndescription: d\ntools: ['*']\n---\nBody.\n",
+		);
+
+		const { agents } = await discoverAgents(tempProject, tempHome);
+
+		const found = agents.find(a => a.name === "alltools");
+		expect(found).toBeDefined();
+		expect(found?.tools).toBeUndefined();
+	});
 });

--- a/packages/coding-agent/test/discovery/copilot-agents.test.ts
+++ b/packages/coding-agent/test/discovery/copilot-agents.test.ts
@@ -99,7 +99,7 @@ describe("discoverAgents — GitHub Copilot agents", () => {
 		expect(names).not.toContain("gated-proj-agent");
 	});
 
-	test("home-dir agent overrides project agent of the same name", async () => {
+	test("project agent overrides home-dir agent of the same name", async () => {
 		writeAgent(path.join(tempProject, ".github", "agents"), "shared", "project version");
 		writeAgent(path.join(tempHome, ".copilot", "agents"), "shared", "home version");
 
@@ -107,8 +107,8 @@ describe("discoverAgents — GitHub Copilot agents", () => {
 
 		const found = agents.filter(a => a.name === "shared");
 		expect(found).toHaveLength(1);
-		expect(found[0].source).toBe("user");
-		expect(found[0].description).toBe("home version");
+		expect(found[0].source).toBe("project");
+		expect(found[0].description).toBe("project version");
 	});
 
 	test("derives the agent name from a *.agent.md filename when frontmatter omits name", async () => {

--- a/packages/coding-agent/test/discovery/copilot-agents.test.ts
+++ b/packages/coding-agent/test/discovery/copilot-agents.test.ts
@@ -126,4 +126,26 @@ describe("discoverAgents — GitHub Copilot agents", () => {
 		expect(found).toBeDefined();
 		expect(found?.description).toBe("Security review specialist");
 	});
+
+	test("dedupes across levels by file id, not frontmatter name (project shadows personal)", async () => {
+		// Same filename in both levels but different frontmatter names: Copilot dedupes by
+		// the file id (reviewer), so the project file shadows the personal one.
+		const proj = path.join(tempProject, ".github", "agents");
+		const user = path.join(tempHome, ".copilot", "agents");
+		fs.mkdirSync(proj, { recursive: true });
+		fs.mkdirSync(user, { recursive: true });
+		fs.writeFileSync(
+			path.join(proj, "reviewer.agent.md"),
+			"---\nname: project-reviewer\ndescription: p\n---\nBody.\n",
+		);
+		fs.writeFileSync(
+			path.join(user, "reviewer.agent.md"),
+			"---\nname: personal-reviewer\ndescription: u\n---\nBody.\n",
+		);
+
+		const { agents } = await discoverAgents(tempProject, tempHome);
+
+		expect(agents.find(a => a.name === "project-reviewer")).toBeDefined();
+		expect(agents.find(a => a.name === "personal-reviewer")).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## Summary

Adds GitHub Copilot custom-agent discovery. `discoverAgents()` previously scanned only the `.omp` / `.claude` / `.codex` / `.gemini` agent sources, so Copilot CLI users' custom agents were invisible under OMP.

Closes #1914.

## Changes

### `task/discovery.ts`
- Discover Copilot agents in:
  - **project**: `.github/agents/*.md`, resolved by walking up from the cwd (so it works from monorepo subdirectories, mirroring how the existing project config dirs resolve) — via new `findNearestCopilotAgentsDir()`.
  - **user-global**: `~/.copilot/agents/*.md`, relocatable via the `COPILOT_HOME` override.
- Gated on `isProviderEnabled("github")`, so disabling the github discovery provider also disables Copilot agent discovery (consistent with how `claude-plugins` agents are gated).
- Copilot agent files parse through the existing `parseAgent` (YAML frontmatter `name` + `description`, body → system prompt); no new parser.
- Precedence: the established `.omp` > `.claude` > … config sources still win over Copilot agents (first-name-wins dedup).

### Tests — `test/discovery/copilot-agents.test.ts`
5 tests: user-global discovery, project discovery, nearest `.github/agents` walk-up from a subdirectory, `COPILOT_HOME` relocation, and provider-gating (disabled `github` excludes both). Uses temp `cwd`/`home` so nothing touches the real filesystem. Existing `agent-discovery-disabled-providers.test.ts` stays green.

## Scope / coordination

- Companion to #1983 (Copilot instructions/prompts/env-dirs) and #1938 (Copilot MCP, by @WodenJay). All three close the gap where OMP's GitHub Copilot integration covered only the project `.github/` tree and ignored the `~/.copilot/` user-global tree. Each honors `COPILOT_HOME`.

## Verification

- `bun test test/discovery/copilot-agents.test.ts test/discovery/agent-discovery-disabled-providers.test.ts` → **7 pass, 0 fail**.
- `tsgo -p tsconfig.json --noEmit` → clean.
- `biome check` → clean.
