### PR TITLE
fix(render): guard completeData against non-array yield value

### DIFF
--- a/packages/coding-agent/src/task/render.ts
+++ b/packages/coding-agent/src/task/render.ts
@@ -912,7 +912,11 @@ function renderAgentResult(result: SingleResult, isLast: boolean, expanded: bool
 		);
 	}
 	// Check for review result (yield with review schema + report_finding)
-	const completeData = result.extractedToolData?.yield as Array<{ data: unknown }> | undefined;
+	const completeData = Array.isArray(result.extractedToolData?.yield)
+		? (result.extractedToolData?.yield as Array<{ data: unknown }>)
+		: result.extractedToolData?.yield != null
+			? ([result.extractedToolData.yield] as Array<{ data: unknown }>)
+			: undefined;
 	const reportFindingData = normalizeReportFindings(result.extractedToolData?.report_finding);
 
 	// Extract review verdict from yield tool's data field if it matches SubmitReviewDetails


### PR DESCRIPTION
## Problem

When the `review` task calls the `yield` tool with a single result object (rather than an array), `result.extractedToolData?.yield` is a plain object. The cast `as Array<{ data: unknown }> | undefined` suppresses the TypeScript error but at runtime `completeData?.map` evaluates to `undefined` (optional chaining only guards `null`/`undefined`, not non-array objects), crashing the TUI renderer:

```
[Uncaught Exception] TypeError: completeData?.map is not a function.
(In 'completeData?.map((c) => c.data)', 'completeData?.map' is undefined)
    at renderAgentResult (…/task/render.ts:920:5)
```

## Fix

Normalize `completeData` to an array at the point of assignment:

- If `yield` is already an array → use it as-is (original happy path).
- If `yield` is a non-null non-array value → wrap it in `[...]`.
- If `yield` is `null`/`undefined` → `completeData` stays `undefined`, existing downstream guards hold.

```ts
const completeData = Array.isArray(result.extractedToolData?.yield)
    ? (result.extractedToolData?.yield as Array<{ data: unknown }>)
    : result.extractedToolData?.yield != null
        ? ([result.extractedToolData.yield] as Array<{ data: unknown }>)
        : undefined;
```

## Verification

Reproduced by running the `review` task; after this patch the renderer handles both the array and single-object cases without throwing.