### PR TITLE
fix(coding-agent): honor ttsr.enabled: false in TtsrManager

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `ttsr.enabled: false` being ignored at runtime. TTSR rules were still being registered with `TtsrManager.addRule` and matched against stream deltas even when the global toggle was off, so disabling TTSR did not suppress rule injection or stream abort. The manager now gates `addRule`, `hasRules`, and `#matchBuffer` on the enabled flag, so disabling fully short-circuits the TTSR path. Condition rules fall through to the rulebook bucket instead of being silently swallowed. ([#1767](https://github.com/can1357/oh-my-pi/issues/1767))
+
 ## [15.9.5] - 2026-06-05
 ### Added
 

--- a/packages/coding-agent/src/export/ttsr.ts
+++ b/packages/coding-agent/src/export/ttsr.ts
@@ -294,6 +294,9 @@ export class TtsrManager {
 
 	/** Add a TTSR rule to be monitored. */
 	addRule(rule: Rule): boolean {
+		if (!this.#settings.enabled) {
+			return false;
+		}
 		if (this.#rules.has(rule.name)) {
 			return false;
 		}
@@ -357,6 +360,9 @@ export class TtsrManager {
 	}
 
 	#matchBuffer(buffer: string, context: TtsrMatchContext): Rule[] {
+		if (!this.#settings.enabled) {
+			return [];
+		}
 		const matches: Rule[] = [];
 		for (const [name, entry] of this.#rules) {
 			if (!this.#canTrigger(name)) {
@@ -433,6 +439,9 @@ export class TtsrManager {
 
 	/** Check if any TTSR rules are registered. */
 	hasRules(): boolean {
+		if (!this.#settings.enabled) {
+			return false;
+		}
 		return this.#rules.size > 0;
 	}
 

--- a/packages/coding-agent/test/capability/rule-buckets.test.ts
+++ b/packages/coding-agent/test/capability/rule-buckets.test.ts
@@ -96,4 +96,23 @@ describe("bucketRules", () => {
 
 		expect(mgr.checkDelta("contains FORBIDDEN token", { source: "text" }).map(r => r.name)).toEqual(["builtin-foo"]);
 	});
+
+	it("falls condition rules through to the rulebook when ttsr is disabled on the manager", () => {
+		const mgr = new TtsrManager({
+			enabled: false,
+			contextMode: "discard",
+			interruptMode: "always",
+			repeatMode: "once",
+			repeatGap: 10,
+		});
+		const ttsr = makeRule({ name: "no-foo", condition: ["FORBIDDEN"], description: "blocks foo" });
+
+		const { rulebookRules, alwaysApplyRules } = bucketRules([ttsr], mgr);
+
+		// Manager refused to register; condition rule degrades to its rulebook shape.
+		expect(mgr.hasRules()).toBe(false);
+		expect(mgr.checkDelta("contains FORBIDDEN token", { source: "text" })).toEqual([]);
+		expect(alwaysApplyRules.map(r => r.name)).toEqual([]);
+		expect(rulebookRules.map(r => r.name)).toEqual(["no-foo"]);
+	});
 });

--- a/packages/coding-agent/test/ttsr.test.ts
+++ b/packages/coding-agent/test/ttsr.test.ts
@@ -1,8 +1,20 @@
 import { describe, expect, it } from "bun:test";
 import * as path from "node:path";
 import { parseRuleConditionAndScope, type Rule } from "@oh-my-pi/pi-coding-agent/capability/rule";
+import type { TtsrSettings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { EDIT_MODE_STRATEGIES } from "@oh-my-pi/pi-coding-agent/edit";
 import { TtsrManager } from "@oh-my-pi/pi-coding-agent/export/ttsr";
+
+function ttsrManager(overrides: Partial<TtsrSettings> = {}): TtsrManager {
+	return new TtsrManager({
+		enabled: true,
+		contextMode: "discard",
+		interruptMode: "always",
+		repeatMode: "once",
+		repeatGap: 10,
+		...overrides,
+	});
+}
 
 function makeRule(partial: Partial<Rule>): Rule {
 	return {
@@ -271,6 +283,52 @@ describe("TtsrManager scope matching", () => {
 				filePaths: [absolutePath],
 			}),
 		).toEqual([rule]);
+	});
+});
+
+describe("TtsrManager enabled gate", () => {
+	it("rejects registration when ttsr is disabled", () => {
+		const manager = ttsrManager({ enabled: false });
+		const rule = makeRule({
+			name: "no-foo",
+			condition: ["FORBIDDEN"],
+			scope: ["text"],
+		});
+
+		expect(manager.addRule(rule)).toBe(false);
+	});
+
+	it("reports no rules when ttsr is disabled, even after a registration attempt", () => {
+		const manager = ttsrManager({ enabled: false });
+		manager.addRule(
+			makeRule({
+				name: "no-foo",
+				condition: ["FORBIDDEN"],
+				scope: ["text"],
+			}),
+		);
+
+		expect(manager.hasRules()).toBe(false);
+	});
+
+	it("returns no matches from stream deltas when ttsr is disabled", () => {
+		const manager = ttsrManager({ enabled: false });
+
+		expect(manager.checkDelta("contains FORBIDDEN token", { source: "text" })).toEqual([]);
+		expect(manager.checkDelta("FORBIDDEN", { source: "tool", toolName: "edit" })).toEqual([]);
+	});
+
+	it("preserves the default (enabled) registration and matching contract", () => {
+		const manager = ttsrManager();
+		const rule = makeRule({
+			name: "no-foo",
+			condition: ["FORBIDDEN"],
+			scope: ["text"],
+		});
+
+		expect(manager.addRule(rule)).toBe(true);
+		expect(manager.hasRules()).toBe(true);
+		expect(manager.checkDelta("FORBIDDEN", { source: "text" })).toEqual([rule]);
 	});
 });
 


### PR DESCRIPTION
## What

Gate `TtsrManager.addRule`, `hasRules`, and `#matchBuffer` on the
`ttsr.enabled` setting so disabling TTSR fully short-circuits the
runtime path. Source-gate inside the manager (rather than at each
caller in `rule-buckets.ts:52`, `omfg-controller.ts:261`, and
`agent-session.ts:1651` + `agent-session.ts:2402`) so every existing
call site complies for free; the other public methods (`markInjected`,
`restoreInjected`, `incrementMessageCount`, `getMessageCount`,
`resetBuffer`) stay un-gated so persisted injection state and
message-count semantics survive session resume.

## Why

Closes #1767. `ttsr.enabled: false` was silently ignored: rules
still registered with `addRule`, `hasRules()` still returned `true`
on every `message_update`, and `checkDelta` / `checkSnapshot` (via
`#matchBuffer`) still matched patterns — so disabling did not stop
rule injection or stream abort. The issue's acceptance criteria also
required that condition rules fall through to the rulebook bucket
instead of being silently swallowed when TTSR is off, which is
exactly what `bucketRules` does once `addRule` starts returning
`false`.

## How

3 sites inside `TtsrManager` (`packages/coding-agent/src/export/ttsr.ts`):

```typescript
// addRule() — refuse registration
if (!this.#settings.enabled) return false;

// hasRules() — report empty
if (!this.#settings.enabled) return false;

// #matchBuffer() — the common sink for checkDelta / checkSnapshot
if (!this.#settings.enabled) return [];
```

## Testing

- `bun run check` (biome + `tsgo --noEmit`): clean
- `bun test packages/coding-agent/test/ttsr.test.ts packages/coding-agent/test/capability/rule-buckets.test.ts`:
  **33 pass, 0 fail, 77 expect() calls** (4 new contract tests for
  the manager, 1 new end-to-end test for the bucketing fall-through)

New regression coverage:

- `TtsrManager enabled gate > rejects registration when ttsr is disabled`
- `TtsrManager enabled gate > reports no rules when ttsr is disabled, even after a registration attempt`
- `TtsrManager enabled gate > returns no matches from stream deltas when ttsr is disabled`
- `TtsrManager enabled gate > preserves the default (enabled) registration and matching contract`
- `bucketRules > falls condition rules through to the rulebook when ttsr is disabled on the manager`

`CHANGELOG` entry added under `[Unreleased] / Fixed`, attribution
per the repo's internal-issue format.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
