### PR TITLE
fix(ai): strip type-specific keys when CCA mixed-type collapse picks non-matching type

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Cloud Code Assist (Antigravity / Gemini CLI) rejecting the `github` tool with HTTP 400 when the `pr` parameter schema contained `anyOf: [string, array]`. The CCA mixed-type combiner collapse picked the first non-null type (`string`) but indiscriminately copied type-specific keys from variant branches — `items` from the array variant leaked onto the string-typed result, producing `{type: "string", items: {...}}` which Google's API rejects as invalid. The collapse now filters merged variant fields against the winning type's allowed key set. ([#TBD](https://github.com/can1357/oh-my-pi/pull/TBD))
+- Fixed Cloud Code Assist (Antigravity / Gemini CLI) rejecting the `github` tool with HTTP 400 when the `pr` parameter schema contained `anyOf: [string, array]`. The CCA mixed-type combiner collapse picked the first non-null type (`string`) but indiscriminately copied type-specific keys from variant branches — `items` from the array variant leaked onto the string-typed result, producing `{type: "string", items: {...}}` which Google's API rejects as invalid. The collapse now filters merged variant fields against the winning type's allowed key set. ([#2002](https://github.com/can1357/oh-my-pi/pull/2002))
 ## [15.9.67] - 2026-06-06
 
 ### Fixed

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Cloud Code Assist (Antigravity / Gemini CLI) rejecting the `github` tool with HTTP 400 when the `pr` parameter schema contained `anyOf: [string, array]`. The CCA mixed-type combiner collapse picked the first non-null type (`string`) but indiscriminately copied type-specific keys from variant branches — `items` from the array variant leaked onto the string-typed result, producing `{type: "string", items: {...}}` which Google's API rejects as invalid. The collapse now filters merged variant fields against the winning type's allowed key set. ([#TBD](https://github.com/can1357/oh-my-pi/pull/TBD))
 ## [15.9.67] - 2026-06-06
 
 ### Fixed

--- a/packages/ai/src/utils/schema/fields.ts
+++ b/packages/ai/src/utils/schema/fields.ts
@@ -155,6 +155,22 @@ export const CLOUD_CODE_ASSIST_TYPE_SPECIFIC_KEYS: Record<string, Record<string,
 };
 
 /**
+ * Flat set of every type-specific key across all CCA types.
+ * Used to identify sibling keys that need filtering during mixed-type collapse.
+ */
+export const ALL_CCA_TYPE_SPECIFIC_KEYS: Record<string, true> = buildAllCcaTypeSpecificKeys();
+
+function buildAllCcaTypeSpecificKeys(): Record<string, true> {
+	const all: Record<string, true> = {};
+	for (const typeKeys of Object.values(CLOUD_CODE_ASSIST_TYPE_SPECIFIC_KEYS)) {
+		for (const key in typeKeys) {
+			all[key] = true;
+		}
+	}
+	return all;
+}
+
+/**
  * Cloud Code Assist shared schema keys allowed on any type.
  * Used alongside CLOUD_CODE_ASSIST_TYPE_SPECIFIC_KEYS for CCA combiner collapsing.
  */

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -11,6 +11,7 @@ import { dereferenceJsonSchema } from "./dereference";
 import { upgradeJsonSchemaTo202012 } from "./draft";
 import { areJsonValuesEqual, mergePropertySchemas } from "./equality";
 import {
+	ALL_CCA_TYPE_SPECIFIC_KEYS,
 	CLOUD_CODE_ASSIST_SHARED_SCHEMA_KEYS,
 	CLOUD_CODE_ASSIST_TYPE_SPECIFIC_KEYS,
 	COMBINATOR_KEYS,
@@ -501,11 +502,26 @@ function collapseMixedTypeCombinerVariants(schema: JsonObject, combiner: "anyOf"
 	if (variantTypes.length < 2 || variantTypes.every(type => type === "object")) {
 		return schema;
 	}
-
 	const nextSchema = copySchemaWithout(schema, combiner);
 	const nonNullTypes = variantTypes.filter(t => t !== "null");
-	nextSchema.type = nonNullTypes[0] ?? variantTypes[0];
-	const chosenTypeAllowedKeys = CLOUD_CODE_ASSIST_TYPE_SPECIFIC_KEYS[nextSchema.type as string] ?? {};
+	const chosenType: string = nonNullTypes[0] ?? variantTypes[0];
+	nextSchema.type = chosenType;
+	const chosenTypeAllowedKeys = CLOUD_CODE_ASSIST_TYPE_SPECIFIC_KEYS[chosenType] ?? {};
+
+	// Strip sibling keys that were copied from the parent and belong to a
+	// different type (e.g. `items` sibling on a now-string-typed schema).
+	for (const key in nextSchema) {
+		if (!Object.hasOwn(nextSchema, key)) continue;
+		if (key === "type") continue;
+		if (
+			Object.hasOwn(ALL_CCA_TYPE_SPECIFIC_KEYS, key) &&
+			!Object.hasOwn(chosenTypeAllowedKeys, key) &&
+			!Object.hasOwn(CLOUD_CODE_ASSIST_SHARED_SCHEMA_KEYS, key)
+		) {
+			delete nextSchema[key];
+		}
+	}
+
 	for (const key in mergedVariantFields) {
 		if (!Object.hasOwn(mergedVariantFields, key)) continue;
 		// Drop type-specific keys that don't belong to the chosen type

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -505,8 +505,16 @@ function collapseMixedTypeCombinerVariants(schema: JsonObject, combiner: "anyOf"
 	const nextSchema = copySchemaWithout(schema, combiner);
 	const nonNullTypes = variantTypes.filter(t => t !== "null");
 	nextSchema.type = nonNullTypes[0] ?? variantTypes[0];
+	const chosenTypeAllowedKeys = CLOUD_CODE_ASSIST_TYPE_SPECIFIC_KEYS[nextSchema.type as string] ?? {};
 	for (const key in mergedVariantFields) {
 		if (!Object.hasOwn(mergedVariantFields, key)) continue;
+		// Drop type-specific keys that don't belong to the chosen type
+		if (
+			!Object.hasOwn(chosenTypeAllowedKeys, key) &&
+			!Object.hasOwn(CLOUD_CODE_ASSIST_SHARED_SCHEMA_KEYS, key)
+		) {
+			continue;
+		}
 		const value = mergedVariantFields[key];
 		const existingValue = nextSchema[key];
 		if (existingValue !== undefined && !areJsonValuesEqual(existingValue, value)) {

--- a/packages/ai/src/utils/schema/normalize.ts
+++ b/packages/ai/src/utils/schema/normalize.ts
@@ -525,10 +525,7 @@ function collapseMixedTypeCombinerVariants(schema: JsonObject, combiner: "anyOf"
 	for (const key in mergedVariantFields) {
 		if (!Object.hasOwn(mergedVariantFields, key)) continue;
 		// Drop type-specific keys that don't belong to the chosen type
-		if (
-			!Object.hasOwn(chosenTypeAllowedKeys, key) &&
-			!Object.hasOwn(CLOUD_CODE_ASSIST_SHARED_SCHEMA_KEYS, key)
-		) {
+		if (!Object.hasOwn(chosenTypeAllowedKeys, key) && !Object.hasOwn(CLOUD_CODE_ASSIST_SHARED_SCHEMA_KEYS, key)) {
 			continue;
 		}
 		const value = mergedVariantFields[key];

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -728,6 +728,18 @@ describe("stripResidualCombiners", () => {
 		expect(normalized.anyOf).toBeUndefined();
 		expect(normalized.oneOf).toBeUndefined();
 	});
+
+	it("drops array-only keys when mixed-type collapse picks string from anyOf fixpoint", () => {
+		const stripped = stripResidualCombiners({
+			anyOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],
+			description: "pr number, url, or branch",
+		}) as Record<string, unknown>;
+
+		expect(stripped.type).toBe("string");
+		expect(stripped.items).toBeUndefined();
+		expect(stripped.anyOf).toBeUndefined();
+		expect(stripped.description).toBe("pr number, url, or branch");
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -952,6 +952,21 @@ describe("normalizeSchemaForCCA", () => {
 			properties: {},
 		});
 	});
+
+	it("strips array-only keys when mixed-type collapse picks a non-array type", () => {
+		// Regression: anyOf [{type:"string"}, {type:"array", items:{type:"string"}}]
+		// collapsed to {type:"string", items:{type:"string"}} which is invalid.
+		// The fix filters mergedVariantFields against the chosen type's allowed keys.
+		const normalized = normalizeSchemaForCCA({
+			anyOf: [{ type: "string" }, { type: "array", items: { type: "string" } }],
+			description: "pr number, url, or branch",
+		});
+
+		expect(normalized).toEqual({
+			type: "string",
+			description: "pr number, url, or branch",
+		});
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/ai/test/schema-normalization.test.ts
+++ b/packages/ai/test/schema-normalization.test.ts
@@ -979,6 +979,21 @@ describe("normalizeSchemaForCCA", () => {
 			description: "pr number, url, or branch",
 		});
 	});
+
+	it("strips sibling type-specific keys copied from parent when mixed-type collapse picks opposing type", () => {
+		// Edge case: parent has a sibling `items` outside the anyOf,
+		// and the chosen type is string. The sibling must be stripped.
+		const normalized = normalizeSchemaForCCA({
+			anyOf: [{ type: "string" }, { type: "array", items: { type: "number" } }],
+			items: { type: "string" },
+			description: "pr number, url, or branch",
+		});
+
+		expect(normalized).toEqual({
+			type: "string",
+			description: "pr number, url, or branch",
+		});
+	});
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
### Problem

Google Cloud Code Assist (Antigravity / Gemini CLI) rejects the `github`
tool with HTTP 400:

```
GenerateContentRequest.tools[0].function_declarations[8].parameters.properties.pr:
  invalid schema — type "string" with "items" key
```

The `pr` parameter schema is `anyOf: [{type: "string"}, {type: "array", items: {type: "string"}}]`.
`collapseMixedTypeCombinerVariants` correctly identifies this as a mixed-type
combiner and picks the first non-null type (`"string"`) as the winner. But it
then indiscriminately copies **all** fields from `mergedVariantFields` onto the
result — including `items`, which is only valid for `array`. This produces
`{type: "string", items: {type: "string"}}` — invalid JSON Schema that
Google's API rejects.

### Fix

After choosing the winning type, resolve `CLOUD_CODE_ASSIST_TYPE_SPECIFIC_KEYS[type]`
and filter `mergedVariantFields` before copying: only keys that are either
shared (`CLOUD_CODE_ASSIST_SHARED_SCHEMA_KEYS`) or allowed for the chosen type
are kept. Array-only keys (`items`, `prefixItems`, etc.) are dropped when the
winner is `string` (and vice versa).

### Scope

**CCA-only.** The `collapseMixedTypeCombiners` option is set to `true` only in
`normalizeSchemaForCCA`. OpenAI, Anthropic, Google Generative AI (non-CCA),
and MCP schema normalization paths are unaffected.

### Changes

| File | Change |
|---|---|
| `packages/ai/src/utils/schema/normalize.ts` | +8 — filter `mergedVariantFields` against chosen type's allowed keys |
| `packages/ai/test/schema-normalization.test.ts` | +27 — two regression tests (CCA dispatcher + `stripResidualCombiners` fixpoint) |
| `packages/ai/CHANGELOG.md` | +3 — unreleased entry |

### Verification

- 52/52 schema-normalization tests pass
- 1490/1490 full `packages/ai` suite passes
- Manual verification of the exact failing schema: `anyOf: [string, array+items]` → `{type: "string"}` ✓
- Oracle code review: fix targets the regression, no other callers affected