### PR TITLE
fix(tui): prevent tool background flicker without sync output

### DIFF
--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -148,7 +148,6 @@ describe("ExtensionRunner", () => {
 			warnSpy.mockRestore();
 		});
 
-
 		it("warns when two extensions register same shortcut", async () => {
 			// Use a non-reserved shortcut
 			const extCode1 = `

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Added `TUI.resetDisplay()` to force an immediate full-frame replay, including native scrollback when the host can safely clear it.
 - Added `setPaddingY` to `Box` so vertical padding can be updated programmatically after creation.
 
+### Fixed
+
+- Fixed DECCARA background-fill optimization running when synchronized output is disabled, which could expose default-background gaps during rapidly updating tool-use panels ([#2000](https://github.com/can1357/oh-my-pi/issues/2000)).
+
 ## [15.9.67] - 2026-06-06
 ### Added
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -571,6 +571,11 @@ export class TUI extends Container {
 	get synchronizedOutput(): boolean {
 		return this.#synchronizedOutputEnabled;
 	}
+	#deccaraFillsEnabled(): boolean {
+		// DECCARA fill rectangles arrive after shortened row text; synchronized
+		// output hides that intermediate default-background state from users.
+		return TERMINAL.deccara && this.#synchronizedOutputEnabled;
+	}
 
 	/**
 	 * When enabled, live render frames rebuild native scrollback on offscreen and
@@ -2404,7 +2409,7 @@ export class TUI extends Container {
 		const visibleStart = Math.max(0, lines.length - height);
 		let fillSequence = "";
 		let visibleTexts: string[] | null = null;
-		if (TERMINAL.deccara && visibleStart < lines.length) {
+		if (this.#deccaraFillsEnabled() && visibleStart < lines.length) {
 			const visible: string[] = new Array(lines.length - visibleStart);
 			for (let k = 0; k < visible.length; k++) {
 				visible[k] = this.#fitLineToWidth(lines[visibleStart + k], width);
@@ -2504,7 +2509,7 @@ export class TUI extends Container {
 		for (let screenRow = 0; screenRow < height; screenRow++) {
 			visible[screenRow] = this.#fitLineToWidth(lines[viewportTop + screenRow] ?? "", width);
 		}
-		const { texts, sequence } = TERMINAL.deccara
+		const { texts, sequence } = this.#deccaraFillsEnabled()
 			? planDeccaraFills(visible, width)
 			: { texts: visible, sequence: "" };
 		let buffer = `${this.#paintBeginSequence}\x1b[H`;
@@ -2814,7 +2819,12 @@ export class TUI extends Container {
 		const fillStart = Math.max(firstChanged, fillViewportTop);
 		let fillSequence = "";
 		let fillTexts: string[] | null = null;
-		if (TERMINAL.deccara && !appendStart && moveTargetRow <= prevViewportBottom && renderEnd >= fillStart) {
+		if (
+			this.#deccaraFillsEnabled() &&
+			!appendStart &&
+			moveTargetRow <= prevViewportBottom &&
+			renderEnd >= fillStart
+		) {
 			const slice: string[] = new Array(renderEnd - fillStart + 1);
 			for (let i = fillStart; i <= renderEnd; i++) {
 				slice[i - fillStart] = this.#fitLineToWidth(lines[i], width);

--- a/packages/tui/test/deccara.test.ts
+++ b/packages/tui/test/deccara.test.ts
@@ -74,6 +74,41 @@ function countOccurrences(haystack: string, needle: string): number {
 	}
 }
 
+async function withEnvPatch<T>(patch: Record<string, string | undefined>, run: () => T | Promise<T>): Promise<T> {
+	const bunSnapshot: Record<string, string | undefined> = {};
+	const processSnapshot: Record<string, string | undefined> = {};
+	for (const key in patch) {
+		bunSnapshot[key] = Bun.env[key];
+		processSnapshot[key] = process.env[key];
+		const value = patch[key];
+		if (value === undefined) {
+			delete Bun.env[key];
+			delete process.env[key];
+		} else {
+			Bun.env[key] = value;
+			process.env[key] = value;
+		}
+	}
+	try {
+		return await run();
+	} finally {
+		for (const key in patch) {
+			const bunValue = bunSnapshot[key];
+			if (bunValue === undefined) {
+				delete Bun.env[key];
+			} else {
+				Bun.env[key] = bunValue;
+			}
+			const processValue = processSnapshot[key];
+			if (processValue === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = processValue;
+			}
+		}
+	}
+}
+
 describe("detectRectangularSgrSupport", () => {
 	it("enables only kitty, which implements the SGR-background extension", () => {
 		expect(detectRectangularSgrSupport("kitty", {})).toBe(true);
@@ -240,8 +275,17 @@ describe("planDeccaraFills", () => {
 
 describe("TUI DECCARA integration", () => {
 	const savedDeccara = TERMINAL.deccara;
+	const savedForceSyncOutput = Bun.env.PI_FORCE_SYNC_OUTPUT;
+	const savedNoSyncOutput = Bun.env.PI_NO_SYNC_OUTPUT;
+	const savedTuiSyncOutput = Bun.env.PI_TUI_SYNC_OUTPUT;
 
 	beforeEach(() => {
+		Bun.env.PI_FORCE_SYNC_OUTPUT = "1";
+		process.env.PI_FORCE_SYNC_OUTPUT = "1";
+		delete Bun.env.PI_NO_SYNC_OUTPUT;
+		delete process.env.PI_NO_SYNC_OUTPUT;
+		delete Bun.env.PI_TUI_SYNC_OUTPUT;
+		delete process.env.PI_TUI_SYNC_OUTPUT;
 		let monotonic = 0;
 		vi.spyOn(performance, "now").mockImplementation(() => {
 			monotonic += 20;
@@ -250,6 +294,27 @@ describe("TUI DECCARA integration", () => {
 	});
 
 	afterEach(() => {
+		if (savedForceSyncOutput === undefined) {
+			delete Bun.env.PI_FORCE_SYNC_OUTPUT;
+			delete process.env.PI_FORCE_SYNC_OUTPUT;
+		} else {
+			Bun.env.PI_FORCE_SYNC_OUTPUT = savedForceSyncOutput;
+			process.env.PI_FORCE_SYNC_OUTPUT = savedForceSyncOutput;
+		}
+		if (savedNoSyncOutput === undefined) {
+			delete Bun.env.PI_NO_SYNC_OUTPUT;
+			delete process.env.PI_NO_SYNC_OUTPUT;
+		} else {
+			Bun.env.PI_NO_SYNC_OUTPUT = savedNoSyncOutput;
+			process.env.PI_NO_SYNC_OUTPUT = savedNoSyncOutput;
+		}
+		if (savedTuiSyncOutput === undefined) {
+			delete Bun.env.PI_TUI_SYNC_OUTPUT;
+			delete process.env.PI_TUI_SYNC_OUTPUT;
+		} else {
+			Bun.env.PI_TUI_SYNC_OUTPUT = savedTuiSyncOutput;
+			process.env.PI_TUI_SYNC_OUTPUT = savedTuiSyncOutput;
+		}
 		setTerminalDeccara(savedDeccara);
 		vi.restoreAllMocks();
 	});
@@ -297,6 +362,32 @@ describe("TUI DECCARA integration", () => {
 		} finally {
 			tui.stop();
 		}
+	});
+
+	it("keeps padded fallback bytes when synchronized output is disabled", async () => {
+		await withEnvPatch(
+			{ PI_NO_SYNC_OUTPUT: "1", PI_FORCE_SYNC_OUTPUT: undefined, PI_TUI_SYNC_OUTPUT: undefined },
+			async () => {
+				setTerminalDeccara(true);
+				const term = new VirtualTerminal(40, 8);
+				const tui = new TUI(term);
+				tui.addChild(new BgPanelComponent(["", "", "", ""]));
+				const writes = captureWrites(term);
+
+				try {
+					tui.start();
+					await settle(term);
+					const out = writes.join("");
+
+					expect(out).not.toContain("$r");
+					expect(out).not.toContain(DECSACE_RECT);
+					expect(out).toContain(`${BG_OPEN}${" ".repeat(40)}`);
+					expect(term.getViewportRowBackgroundColumns(0)).toHaveLength(40);
+				} finally {
+					tui.stop();
+				}
+			},
+		);
 	});
 
 	it("preserves viewport text identically whether DECCARA is on or off", async () => {


### PR DESCRIPTION
## Repro
A Kitty-compatible terminal profile can disable synchronized output while still reporting DECCARA rectangular-SGR support; the repro command was `bun -e 'import { shouldEnableSynchronizedOutputByDefault, detectRectangularSgrSupport } from "./packages/tui/src/terminal-capabilities.ts"; const env = { TERM: "xterm-kitty", SSH_CONNECTION: "1 2 3 4" }; const sync = shouldEnableSynchronizedOutputByDefault(env, "darwin", "kitty"); const deccara = detectRectangularSgrSupport("kitty", env); console.log(JSON.stringify({ sync, deccara, unsafe: deccara && !sync }));'`, which printed `{"sync":false,"deccara":true,"unsafe":true}`.

## Cause
`packages/tui/src/tui.ts` used `TERMINAL.deccara` directly in the full-paint, viewport-repaint, and diff repaint paths. `planDeccaraFills()` shortens background-padded rows and emits DECCARA fill rectangles later in the same paint, so when DEC 2026 synchronized output is disabled the terminal can briefly show default-background trailing cells during rapidly updating tool panels.

## Fix
- Added a `TUI.#deccaraFillsEnabled()` guard that requires both terminal DECCARA support and active synchronized-output paint wrappers.
- Routed full-paint, viewport-repaint, and diff repaint DECCARA optimization through that guard.
- Added regression coverage that keeps padded fallback bytes when synchronized output is disabled, while forcing sync output in the existing DECCARA optimization tests so the optimized path remains covered.
- Added the TUI changelog entry for #2000.

## Verification
`bun test packages/tui/test/deccara.test.ts packages/tui/test/issue-1765-repro.test.ts packages/tui/test/deccara-grid-parity.test.ts` passed with 44 tests; `bun --cwd=packages/tui run check` passed. Fixes #2000