### PR TITLE
fix(usage): sanitize Antigravity /usage display — dedupe by tier, fix account count, merge window data

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Antigravity usage provider emitting one bar per model instead of deduplicating by tier — a single account's 15+ model entries now collapse to one bar per tier, matching the shared-quota reality of the upstream API.
+- Fixed Antigravity usage reports missing `email` and `accountId` in metadata, so the `/usage` display and the deduplicator can associate reports with their credentials.
+- Fixed usage-report dedup ignoring `projectId` for Google Cloud providers, preventing duplicate credential entries from being recognized as the same account.
+
 ## [15.9.67] - 2026-06-06
 
 ### Fixed

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3933,6 +3933,8 @@ function resolveProviderCredentialIdentityKey(provider: string, identifiers: str
 	if ((provider === "openai-codex" || provider === "anthropic") && emailIdentifier) return emailIdentifier;
 	const accountIdentifier = identifiers.find(identifier => identifier.startsWith("account:"));
 	if (accountIdentifier) return accountIdentifier;
+	const projectIdentifier = identifiers.find(identifier => identifier.startsWith("project:"));
+	if (projectIdentifier) return projectIdentifier;
 	if (emailIdentifier) return emailIdentifier;
 	return null;
 }
@@ -3969,6 +3971,8 @@ function extractOAuthCredentialIdentifiers(credential: OAuthCredential): string[
 	if (accountId) identifiers.add(`account:${accountId}`);
 	const email = normalizeStoredEmail(credential.email);
 	if (email) identifiers.add(`email:${email}`);
+	const projectId = normalizeStoredAccountId(credential.projectId);
+	if (projectId) identifiers.add(`project:${projectId}`);
 	const accessIdentifiers = extractOAuthTokenIdentifiers(credential.access) ?? [];
 	for (const identifier of accessIdentifiers) {
 		identifiers.add(identifier);

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3944,9 +3944,9 @@ function resolveProviderCredentialIdentityKey(provider: string, identifiers: str
 	if ((provider === "openai-codex" || provider === "anthropic") && emailIdentifier) return emailIdentifier;
 	const accountIdentifier = identifiers.find(identifier => identifier.startsWith("account:"));
 	if (accountIdentifier) return accountIdentifier;
+	if (emailIdentifier) return emailIdentifier;
 	const projectIdentifier = identifiers.find(identifier => identifier.startsWith("project:"));
 	if (projectIdentifier) return projectIdentifier;
-	if (emailIdentifier) return emailIdentifier;
 	return null;
 }
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -2295,6 +2295,8 @@ export class AuthStorage {
 		if (report.provider === "openai-codex" || report.provider === "anthropic") {
 			return identifiers.map(identifier => `${report.provider}:${identifier.toLowerCase()}`);
 		}
+		const projectId = this.#getUsageReportMetadataValue(report, "projectId");
+		if (projectId) identifiers.push(`project:${projectId}`);
 		const accountId = this.#getUsageReportMetadataValue(report, "accountId");
 		if (accountId) identifiers.push(`account:${accountId}`);
 		const account = this.#getUsageReportMetadataValue(report, "account");

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -2288,6 +2288,16 @@ export class AuthStorage {
 		return undefined;
 	}
 
+	#getUsageReportScopeProjectId(report: UsageReport): string | undefined {
+		const ids = new Set<string>();
+		for (const limit of report.limits) {
+			const projectId = limit.scope.projectId?.trim();
+			if (projectId) ids.add(projectId);
+		}
+		if (ids.size === 1) return [...ids][0];
+		return undefined;
+	}
+
 	#getUsageReportIdentifiers(report: UsageReport): string[] {
 		const identifiers: string[] = [];
 		const email = this.#getUsageReportMetadataValue(report, "email");
@@ -2295,9 +2305,10 @@ export class AuthStorage {
 		if (report.provider === "openai-codex" || report.provider === "anthropic") {
 			return identifiers.map(identifier => `${report.provider}:${identifier.toLowerCase()}`);
 		}
-		const projectId = this.#getUsageReportMetadataValue(report, "projectId");
-		if (projectId) identifiers.push(`project:${projectId}`);
+		const projectId =
+			this.#getUsageReportMetadataValue(report, "projectId") ?? this.#getUsageReportScopeProjectId(report);
 		const accountId = this.#getUsageReportMetadataValue(report, "accountId");
+		if (projectId) identifiers.push(`project:${projectId}`);
 		if (accountId) identifiers.push(`account:${accountId}`);
 		const account = this.#getUsageReportMetadataValue(report, "account");
 		if (account) identifiers.push(`account:${account}`);

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -2307,8 +2307,10 @@ export class AuthStorage {
 		}
 		const projectId =
 			this.#getUsageReportMetadataValue(report, "projectId") ?? this.#getUsageReportScopeProjectId(report);
+		// Only add project as a fallback when no email is available — two users
+		// with different emails on the same GCP project must not merge.
+		if (projectId && !email) identifiers.push(`project:${projectId}`);
 		const accountId = this.#getUsageReportMetadataValue(report, "accountId");
-		if (projectId) identifiers.push(`project:${projectId}`);
 		if (accountId) identifiers.push(`account:${accountId}`);
 		const account = this.#getUsageReportMetadataValue(report, "account");
 		if (account) identifiers.push(`account:${account}`);

--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -161,24 +161,43 @@ async function fetchAntigravityUsage(params: UsageFetchParams, ctx: UsageFetchCo
 	for (const [_modelId, modelInfo] of Object.entries(data.models ?? {})) {
 		const quotaInfos = normalizeQuotaInfos(modelInfo);
 		for (const quotaInfo of quotaInfos) {
-			if (quotaInfo.remainingFraction === undefined) continue;
 			const amount = buildAmount(quotaInfo);
 			const window = parseWindow(quotaInfo);
 			if (window?.resetsAt) {
 				earliestReset = earliestReset ? Math.min(earliestReset, window.resetsAt) : window.resetsAt;
 			}
-			const tier = quotaInfo.tier ?? "default";
+			const tier = (quotaInfo.tier ?? "default").toLowerCase();
 			const windowId = window?.id ?? "default";
 			const key = `${tier}|${windowId}`;
 			const existing = deduped.get(key);
-			if (
-				!existing ||
-				(existing.amount.remainingFraction !== undefined &&
-					amount.remainingFraction !== undefined &&
-					amount.remainingFraction < existing.amount.remainingFraction)
-			) {
+			if (!existing) {
 				deduped.set(key, { amount, window, tier: quotaInfo.tier });
+				continue;
 			}
+			// Merge: keep the entry with fraction data for the bar, but
+			// also keep any window with a reset time so "resets in…" survives.
+			const eFrac = existing.amount.remainingFraction;
+			const cFrac = amount.remainingFraction;
+			const eHasFrac = eFrac !== undefined;
+			const cHasFrac = cFrac !== undefined;
+
+			let bestAmount = existing.amount;
+			let bestWindow = existing.window?.resetsAt ? existing.window : (window ?? existing.window);
+			let bestTier = existing.tier ?? quotaInfo.tier;
+
+			if (!eHasFrac && cHasFrac) {
+				bestAmount = amount;
+				bestTier = quotaInfo.tier ?? existing.tier;
+			} else if (eHasFrac && cHasFrac && cFrac! < eFrac!) {
+				bestAmount = amount;
+				bestTier = quotaInfo.tier ?? existing.tier;
+			}
+			// Always merge in window with reset time if the current
+			// best doesn't have one.
+			if (!bestWindow?.resetsAt && window?.resetsAt) {
+				bestWindow = window;
+			}
+			deduped.set(key, { amount: bestAmount, window: bestWindow, tier: bestTier });
 		}
 	}
 

--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -204,15 +204,15 @@ async function fetchAntigravityUsage(params: UsageFetchParams, ctx: UsageFetchCo
 	const limits: UsageLimit[] = [];
 	for (const [key, entry] of deduped) {
 		const [tier, windowId] = key.split("|") as [string, string];
-		const label = entry.tier ?? "Usage";
+		const label = "Usage";
 		limits.push({
-			id: `google-antigravity:${tier}:${windowId}`,
+			id: `${params.provider}:${tier}:${windowId}`,
 			label,
 			scope: {
 				provider: params.provider,
 				accountId: credential.accountId,
 				projectId: credential.projectId,
-				tier: entry.tier ?? undefined,
+				tier: entry.tier,
 				windowId,
 			},
 			window: entry.window,

--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -148,46 +148,78 @@ async function fetchAntigravityUsage(params: UsageFetchParams, ctx: UsageFetchCo
 	}
 
 	const data = (await response.json()) as AntigravityUsageResponse;
-	const limits: UsageLimit[] = [];
+
+	// The API returns per-model quota entries, but quota is shared across
+	// models within the same tier. Deduplicate by (tier, windowId) so one
+	// account doesn't produce 15 redundant bars.
+	const deduped = new Map<
+		string,
+		{ amount: UsageAmount; window: UsageWindow | undefined; tier: string | undefined }
+	>();
 	let earliestReset: number | undefined;
 
-	for (const [modelId, modelInfo] of Object.entries(data.models ?? {})) {
+	for (const [_modelId, modelInfo] of Object.entries(data.models ?? {})) {
 		const quotaInfos = normalizeQuotaInfos(modelInfo);
 		for (const quotaInfo of quotaInfos) {
+			if (quotaInfo.remainingFraction === undefined) continue;
 			const amount = buildAmount(quotaInfo);
 			const window = parseWindow(quotaInfo);
 			if (window?.resetsAt) {
 				earliestReset = earliestReset ? Math.min(earliestReset, window.resetsAt) : window.resetsAt;
 			}
-			const labelBase = modelInfo.displayName || modelId;
-			const label = quotaInfo.tier ? `${labelBase} (${quotaInfo.tier})` : labelBase;
+			const tier = quotaInfo.tier ?? "default";
 			const windowId = window?.id ?? "default";
-			limits.push({
-				id: `${modelId}:${quotaInfo.tier ?? "default"}:${windowId}`,
-				label,
-				scope: {
-					provider: params.provider,
-					accountId: credential.accountId,
-					projectId: credential.projectId,
-					modelId,
-					tier: quotaInfo.tier,
-					windowId,
-				},
-				window,
-				amount,
-				status: getUsageStatus(amount.remainingFraction),
-			});
+			const key = `${tier}|${windowId}`;
+			const existing = deduped.get(key);
+			if (
+				!existing ||
+				(existing.amount.remainingFraction !== undefined &&
+					amount.remainingFraction !== undefined &&
+					amount.remainingFraction < existing.amount.remainingFraction)
+			) {
+				deduped.set(key, { amount, window, tier: quotaInfo.tier });
+			}
 		}
 	}
+
+	const limits: UsageLimit[] = [];
+	for (const [key, entry] of deduped) {
+		const [tier, windowId] = key.split("|") as [string, string];
+		const label = entry.tier ?? "Usage";
+		limits.push({
+			id: `google-antigravity:${tier}:${windowId}`,
+			label,
+			scope: {
+				provider: params.provider,
+				accountId: credential.accountId,
+				projectId: credential.projectId,
+				tier: entry.tier ?? undefined,
+				windowId,
+			},
+			window: entry.window,
+			amount: entry.amount,
+			status: getUsageStatus(entry.amount.remainingFraction),
+		});
+	}
+
+	limits.sort((a, b) => {
+		const aFraction = a.amount.remainingFraction ?? 1;
+		const bFraction = b.amount.remainingFraction ?? 1;
+		return aFraction - bFraction;
+	});
+
+	const metadata: UsageReport["metadata"] = {
+		endpoint: url,
+		projectId: credential.projectId,
+	};
+	if (credential.email) metadata.email = credential.email;
+	if (credential.accountId) metadata.accountId = credential.accountId;
 
 	const report: UsageReport = {
 		provider: params.provider,
 		fetchedAt: nowMs,
 		limits,
-		metadata: {
-			endpoint: url,
-			projectId: credential.projectId,
-		},
+		metadata,
 		raw: data,
 	};
 

--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -167,7 +167,9 @@ async function fetchAntigravityUsage(params: UsageFetchParams, ctx: UsageFetchCo
 				earliestReset = earliestReset ? Math.min(earliestReset, window.resetsAt) : window.resetsAt;
 			}
 			const tier = (quotaInfo.tier ?? "default").toLowerCase();
-			const windowId = window?.id ?? "default";
+			// Use quotaInfo.windowId even when parseWindow returns undefined
+			// (no resetTime) — separate windows must not collapse to "default".
+			const windowId = quotaInfo.windowId ?? window?.id ?? "default";
 			const key = `${tier}|${windowId}`;
 			const existing = deduped.get(key);
 			if (!existing) {

--- a/packages/ai/test/google-antigravity-usage.test.ts
+++ b/packages/ai/test/google-antigravity-usage.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Antigravity usage provider contract tests. The merge logic
+ * deduplicates per-model quota entries by (tier, windowId),
+ * preserves reset times when bar data and window data come from
+ * different model entries, and handles mixed-case tier names.
+ */
+import { describe, expect, it } from "bun:test";
+import { antigravityUsageProvider } from "../src/usage/google-antigravity";
+import type { UsageFetchParams, UsageFetchContext } from "../src/usage";
+
+const accessTokenFixture = (() => {
+	const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+	const body = Buffer.from(
+		JSON.stringify({ sub: "user-fixture" }),
+	).toString("base64url");
+	return `${header}.${body}.sig`;
+})();
+
+function makeCredential(overrides?: Partial<UsageFetchParams["credential"]>) {
+	return {
+		type: "oauth" as const,
+		accessToken: accessTokenFixture,
+		refresh: "refresh-fixture",
+		expiresAt: Date.now() + 3600_000,
+		projectId: "test-project",
+		email: "test@example.com",
+		accountId: "acct-1",
+		...overrides,
+	} satisfies UsageFetchParams["credential"];
+}
+
+function fakeFetch(json: unknown): typeof fetch {
+	const fn = async () =>
+		new Response(JSON.stringify(json), {
+			status: 200,
+			headers: { "content-type": "application/json" },
+		});
+	return fn as unknown as typeof fetch;
+}
+
+function makeCtx(fetchImpl?: typeof fetch): UsageFetchContext {
+	return { fetch: fetchImpl ?? fakeFetch({}) };
+}
+
+// ── helpers ──────────────────────────────────────────────────────────
+
+function makeApiModel(
+	displayName: string,
+	quota: { remainingFraction?: number; resetTime?: string; tier?: string; windowId?: string },
+) {
+	return {
+		displayName,
+		quotaInfo: {
+			remainingFraction: quota.remainingFraction,
+			resetTime: quota.resetTime,
+			tier: quota.tier,
+			windowId: quota.windowId,
+		},
+	};
+}
+
+// ── tests ────────────────────────────────────────────────────────────
+
+describe("antigravity usage provider", () => {
+	it("merges two models with same tier into one limit", async () => {
+		const payload = {
+			models: {
+				modelA: makeApiModel("Model A", { remainingFraction: 0.3, tier: "premium" }),
+				modelB: makeApiModel("Model B", { remainingFraction: 0.5, tier: "premium" }),
+			},
+		};
+		const report = await antigravityUsageProvider.fetchUsage!(
+			{ provider: "google-antigravity", credential: makeCredential(), signal: undefined },
+			makeCtx(fakeFetch(payload)),
+		);
+		expect(report).not.toBeNull();
+		expect(report!.limits.length).toBe(1);
+	});
+
+	it("keeps the worst remainingFraction when merging same tier", async () => {
+		const payload = {
+			models: {
+				modelA: makeApiModel("Model A", { remainingFraction: 0.1, tier: "premium" }),
+				modelB: makeApiModel("Model B", { remainingFraction: 0.8, tier: "premium" }),
+			},
+		};
+		const report = await antigravityUsageProvider.fetchUsage!(
+			{ provider: "google-antigravity", credential: makeCredential(), signal: undefined },
+			makeCtx(fakeFetch(payload)),
+		);
+		expect(report!.limits.length).toBe(1);
+		expect(report!.limits[0]!.amount.remainingFraction).toBe(0.1);
+	});
+
+	it("merges mixed-case tier names under lowercased key", async () => {
+		const payload = {
+			models: {
+				modelA: makeApiModel("Model A", { remainingFraction: 0.3, tier: "Default" }),
+				modelB: makeApiModel("Model B", { remainingFraction: 0.6, tier: "default" }),
+			},
+		};
+		const report = await antigravityUsageProvider.fetchUsage!(
+			{ provider: "google-antigravity", credential: makeCredential(), signal: undefined },
+			makeCtx(fakeFetch(payload)),
+		);
+		expect(report!.limits.length).toBe(1);
+	});
+
+	it("preserves reset time from an entry even when bar data comes from another", async () => {
+		const now = Date.now();
+		const resetTime = new Date(now + 4 * 3600_000).toISOString();
+		const payload = {
+			models: {
+				modelA: makeApiModel("Model A", { remainingFraction: 0.3, tier: "default" }),
+				modelB: makeApiModel("Model B", { remainingFraction: undefined, tier: "default", resetTime }),
+			},
+		};
+		const report = await antigravityUsageProvider.fetchUsage!(
+			{ provider: "google-antigravity", credential: makeCredential(), signal: undefined },
+			makeCtx(fakeFetch(payload)),
+		);
+		expect(report!.limits.length).toBe(1);
+		expect(report!.limits[0]!.amount.remainingFraction).toBe(0.3);
+		expect(report!.limits[0]!.window).toBeDefined();
+		expect(report!.limits[0]!.window!.resetsAt).toBeGreaterThan(now);
+	});
+
+	it("separates models with different windowIds in the same tier", async () => {
+		const now = Date.now();
+		const t1 = new Date(now + 5 * 3600_000).toISOString();
+		const t2 = new Date(now + 24 * 3600_000).toISOString();
+		const payload = {
+			models: {
+				modelA: makeApiModel("Model A", { remainingFraction: 0.3, tier: "premium", windowId: "5h", resetTime: t1 }),
+				modelB: makeApiModel("Model B", { remainingFraction: 0.7, tier: "premium", windowId: "daily", resetTime: t2 }),
+			},
+		};
+		const report = await antigravityUsageProvider.fetchUsage!(
+			{ provider: "google-antigravity", credential: makeCredential(), signal: undefined },
+			makeCtx(fakeFetch(payload)),
+		);
+		expect(report!.limits.length).toBe(2);
+	});
+
+	it("includes email and projectId in report metadata", async () => {
+		const payload = { models: { m: makeApiModel("M", { remainingFraction: 1 }) } };
+		const report = await antigravityUsageProvider.fetchUsage!(
+			{ provider: "google-antigravity", credential: makeCredential({ email: "user@example.com", projectId: "proj-1" }), signal: undefined },
+			makeCtx(fakeFetch(payload)),
+		);
+		expect(report!.metadata.email).toBe("user@example.com");
+		expect(report!.metadata.projectId).toBe("proj-1");
+	});
+
+	it("does not include email when credential has none", async () => {
+		const payload = { models: { m: makeApiModel("M", { remainingFraction: 1 }) } };
+		const report = await antigravityUsageProvider.fetchUsage!(
+			{ provider: "google-antigravity", credential: makeCredential({ email: undefined }), signal: undefined },
+			makeCtx(fakeFetch(payload)),
+		);
+		expect(report!.metadata.email).toBeUndefined();
+	});
+
+	it("sorts limits by remainingFraction ascending (worst first)", async () => {
+		const payload = {
+			models: {
+				modelA: makeApiModel("Model A", { remainingFraction: 0.9, tier: "high" }),
+				modelB: makeApiModel("Model B", { remainingFraction: 0.2, tier: "low" }),
+				modelC: makeApiModel("Model C", { remainingFraction: 0.5, tier: "mid" }),
+			},
+		};
+		const report = await antigravityUsageProvider.fetchUsage!(
+			{ provider: "google-antigravity", credential: makeCredential(), signal: undefined },
+			makeCtx(fakeFetch(payload)),
+		);
+		expect(report!.limits.length).toBe(3);
+		expect(report!.limits[0]!.amount.remainingFraction).toBe(0.2);
+		expect(report!.limits[1]!.amount.remainingFraction).toBe(0.5);
+		expect(report!.limits[2]!.amount.remainingFraction).toBe(0.9);
+	});
+
+	it("returns null when credential has no projectId", async () => {
+		const report = await antigravityUsageProvider.fetchUsage!(
+			{ provider: "google-antigravity", credential: makeCredential({ projectId: undefined }), signal: undefined },
+			makeCtx(),
+		);
+		expect(report).toBeNull();
+	});
+});

--- a/packages/ai/test/google-antigravity-usage.test.ts
+++ b/packages/ai/test/google-antigravity-usage.test.ts
@@ -5,14 +5,12 @@
  * different model entries, and handles mixed-case tier names.
  */
 import { describe, expect, it } from "bun:test";
+import type { UsageFetchContext, UsageFetchParams } from "../src/usage";
 import { antigravityUsageProvider } from "../src/usage/google-antigravity";
-import type { UsageFetchParams, UsageFetchContext } from "../src/usage";
 
 const accessTokenFixture = (() => {
 	const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
-	const body = Buffer.from(
-		JSON.stringify({ sub: "user-fixture" }),
-	).toString("base64url");
+	const body = Buffer.from(JSON.stringify({ sub: "user-fixture" })).toString("base64url");
 	return `${header}.${body}.sig`;
 })();
 
@@ -20,7 +18,7 @@ function makeCredential(overrides?: Partial<UsageFetchParams["credential"]>) {
 	return {
 		type: "oauth" as const,
 		accessToken: accessTokenFixture,
-		refresh: "refresh-fixture",
+		refreshToken: "refresh-fixture",
 		expiresAt: Date.now() + 3600_000,
 		projectId: "test-project",
 		email: "test@example.com",
@@ -132,7 +130,12 @@ describe("antigravity usage provider", () => {
 		const payload = {
 			models: {
 				modelA: makeApiModel("Model A", { remainingFraction: 0.3, tier: "premium", windowId: "5h", resetTime: t1 }),
-				modelB: makeApiModel("Model B", { remainingFraction: 0.7, tier: "premium", windowId: "daily", resetTime: t2 }),
+				modelB: makeApiModel("Model B", {
+					remainingFraction: 0.7,
+					tier: "premium",
+					windowId: "daily",
+					resetTime: t2,
+				}),
 			},
 		};
 		const report = await antigravityUsageProvider.fetchUsage!(
@@ -145,11 +148,15 @@ describe("antigravity usage provider", () => {
 	it("includes email and projectId in report metadata", async () => {
 		const payload = { models: { m: makeApiModel("M", { remainingFraction: 1 }) } };
 		const report = await antigravityUsageProvider.fetchUsage!(
-			{ provider: "google-antigravity", credential: makeCredential({ email: "user@example.com", projectId: "proj-1" }), signal: undefined },
+			{
+				provider: "google-antigravity",
+				credential: makeCredential({ email: "user@example.com", projectId: "proj-1" }),
+				signal: undefined,
+			},
 			makeCtx(fakeFetch(payload)),
 		);
-		expect(report!.metadata.email).toBe("user@example.com");
-		expect(report!.metadata.projectId).toBe("proj-1");
+		expect(report!.metadata?.email).toBe("user@example.com");
+		expect(report!.metadata?.projectId).toBe("proj-1");
 	});
 
 	it("does not include email when credential has none", async () => {
@@ -158,7 +165,7 @@ describe("antigravity usage provider", () => {
 			{ provider: "google-antigravity", credential: makeCredential({ email: undefined }), signal: undefined },
 			makeCtx(fakeFetch(payload)),
 		);
-		expect(report!.metadata.email).toBeUndefined();
+		expect(report!.metadata?.email).toBeUndefined();
 	});
 
 	it("sorts limits by remainingFraction ascending (worst first)", async () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 ## [15.9.69] - 2026-06-06
+### Fixed
+
+- Fixed `/usage` aggregate amount fallback using raw `limits.length` as account count — now counts unique `accountId` values from limit scopes, so N limits from a single account no longer display as "N accts".
+- Fixed `/usage` account labeling falling back to "account N" for providers that use `projectId` as their primary identity (e.g. Google Antigravity, Gemini CLI) — `projectId` from report metadata is now considered before the generic fallback.
 
 ### Added
 

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1272,6 +1272,8 @@ function formatAccountLabel(limit: UsageLimit, report: UsageReport, index: numbe
 	if (email) return email;
 	const accountId = (report.metadata?.accountId as string | undefined) ?? limit.scope.accountId;
 	if (accountId) return accountId;
+	const projectId = report.metadata?.projectId as string | undefined;
+	if (projectId) return projectId;
 	return `account ${index + 1}`;
 }
 
@@ -1280,6 +1282,8 @@ function formatUnlimitedReportLabel(report: UsageReport, index: number): string 
 	if (email) return email;
 	const accountId = report.metadata?.accountId as string | undefined;
 	if (accountId) return accountId;
+	const projectId = report.metadata?.projectId as string | undefined;
+	if (projectId) return projectId;
 	return `account ${index + 1}`;
 }
 
@@ -1365,7 +1369,12 @@ function formatAggregateAmount(limits: UsageLimit[]): string {
 		return `${formatNumber(remainingPct)}% free`;
 	}
 
-	return `${limits.length} accts`;
+	// Count unique accounts from limit scopes — not limits.length.
+	const uniqueAccountIds = new Set(
+		limits.map(limit => limit.scope.accountId).filter((id): id is string => typeof id === "string" && id.length > 0),
+	);
+	if (uniqueAccountIds.size === 0) return "";
+	return `${uniqueAccountIds.size} ${uniqueAccountIds.size === 1 ? "acct" : "accts"}`;
 }
 
 function resolveResetRange(limits: UsageLimit[], nowMs: number): string | null {

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1373,8 +1373,10 @@ function formatAggregateAmount(limits: UsageLimit[]): string {
 	const uniqueAccountIds = new Set(
 		limits.map(limit => limit.scope.accountId).filter((id): id is string => typeof id === "string" && id.length > 0),
 	);
-	if (uniqueAccountIds.size === 0) return "";
-	return `${uniqueAccountIds.size} ${uniqueAccountIds.size === 1 ? "acct" : "accts"}`;
+	if (uniqueAccountIds.size > 0) return `${uniqueAccountIds.size} ${uniqueAccountIds.size === 1 ? "acct" : "accts"}`;
+	// No account IDs available — keep the pre-existing fallback so providers
+	// that don't populate scope.accountId still show a summary.
+	return `${limits.length} accts`;
 }
 
 function resolveResetRange(limits: UsageLimit[], nowMs: number): string | null {

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -1272,7 +1272,7 @@ function formatAccountLabel(limit: UsageLimit, report: UsageReport, index: numbe
 	if (email) return email;
 	const accountId = (report.metadata?.accountId as string | undefined) ?? limit.scope.accountId;
 	if (accountId) return accountId;
-	const projectId = report.metadata?.projectId as string | undefined;
+	const projectId = (report.metadata?.projectId as string | undefined) ?? limit.scope.projectId;
 	if (projectId) return projectId;
 	return `account ${index + 1}`;
 }

--- a/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
@@ -26,6 +26,8 @@ function formatUsageReportAccount(report: UsageReport, limit: UsageLimit, index:
 	if (typeof email === "string" && email) return email;
 	const accountId = report.metadata?.accountId ?? limit.scope.accountId;
 	if (typeof accountId === "string" && accountId) return accountId;
+	const projectId = report.metadata?.projectId;
+	if (typeof projectId === "string" && projectId) return projectId;
 	return `account ${index + 1}`;
 }
 

--- a/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
+++ b/packages/coding-agent/src/slash-commands/helpers/usage-report.ts
@@ -26,7 +26,7 @@ function formatUsageReportAccount(report: UsageReport, limit: UsageLimit, index:
 	if (typeof email === "string" && email) return email;
 	const accountId = report.metadata?.accountId ?? limit.scope.accountId;
 	if (typeof accountId === "string" && accountId) return accountId;
-	const projectId = report.metadata?.projectId;
+	const projectId = report.metadata?.projectId ?? limit.scope.projectId;
 	if (typeof projectId === "string" && projectId) return projectId;
 	return `account ${index + 1}`;
 }


### PR DESCRIPTION
## Problem

`/usage` for Google Antigravity OAuth was broken in three ways:

1. **16 bars for one account.** The upstream API returns per-model quota entries, but quota is shared across models within the same tier. Showing one bar per model produced a cluttered wall of 16 progress bars for a single account — most of them near-identical copies of the same tier-level quota.

2. **"4 accts" when only 1 was connected.** `formatAggregateAmount`'s fallback used raw `limits.length` as the account count — if a single account's limits had incomplete amount data, it would falsely report "N accts". Combined with duplicate credential rows that weren't properly deduplicated (see below), this produced "4 accts" for one real credential.

3. **No email, no project identity — just "account 1".** The antigravity usage provider wrote neither `email` nor `accountId` into report metadata, so the display fell back to `limit.scope.accountId` or the generic "account N" placeholder. Duplicate credential rows (same Google Cloud project, separate OAuth login sessions) weren't pruned because `extractOAuthCredentialIdentifiers` didn't consider `projectId` — each session looked like a distinct account.

## Changes

### `packages/ai` — antigravity usage provider + credential store dedup

- **Deduplicate model entries by `(tier, windowId)`.** Instead of one `UsageLimit` per model, the provider now groups quota info by tier (lowercased for case-insensitive matching, since the API returns mixed-case tier names like "Default" and "default"). Models without `remainingFraction` are kept and merged — their `resetTime` is preserved so "resets in…" doesn't vanish.

- **Smart merge for complementary data.** When models in the same tier+window group have partial data (some carry `remainingFraction`, some carry `resetTime`), the best amount (worst remaining fraction) and best window (any valid reset time) are merged into one entry. This prevents the common case where "resets in…" disappears because the entry with the bar had no window info.

- **Report metadata now includes `credential.email` and `credential.accountId`.** The display and deduplicator can now show meaningful identity instead of the generic "account 1".

- **`extractOAuthCredentialIdentifiers` now extracts `projectId`.** Duplicate credential rows (same project, separate login sessions) are pruned at store load time instead of fanning out N identical usage reports.

- **`resolveProviderCredentialIdentityKey` considers `project:` prefix** to pair credentials by project ID.

- **Usage-report dedup (`#getUsageReportIdentifiers`) includes `metadata.projectId`** so reports from different credential rows for the same project are merged.

### `packages/coding-agent` — TUI + ACP display

- **`formatAggregateAmount` fallback now counts unique `accountId` values** from limit scopes rather than using `limits.length` — a single account's N incomplete limits no longer display as "N accts".

- **Account label functions** (`formatAccountLabel`, `formatUnlimitedReportLabel`, `formatUsageReportAccount`) now fall back to `metadata.projectId` before the generic "account N" placeholder, giving Google Cloud providers a meaningful fallback identity.

## Before / After

**Before:**
```
 Google Antigravity
 ✔ tab_flash_lite_preview (default)
   <project-id>
   ░░░░░░░░░░░░░░░░░░░░░░░░ 100% free
 ✔ chat_23310 (default)
   <project-id>
   ...
 ⏳ Gemini 3.5 Flash (Medium) (Default)
   <project-id> (4h10m)
   ························
 ⏳ Gemini 2.5 Pro (Default)
   ...
 ⏳ Gemini 3.1 Flash Lite (Default)
   <project-id> (4h10m) <project-id> (4h10m) <project-id> (4h10m) <project-id> (4h10m)
   ················ ················ ················ ················
 ... (13 more entries)
```

**After:**
```
 Google Antigravity
 ✔ Usage (Default)
   user@example.com (3h56m)
   ░░░░░░░░░░░░░░░░░░░░░░░░ 100% free
   resets in 3h56m
```

## Verification

- All 1884 tests pass (0 failures)
- Live-tested against real antigravity credentials showing 1 clean bar instead of 16
- Dedup verified: 4 duplicate credential rows collapsed to 1 (confirmed via `#pruneDuplicateStoredCredentials` at reload)