### PR TITLE
fix(eval): surface subagent abort reason through Python agent() bridge

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed framed read results rendering with an extra blank row above and below the output block.
 - Fixed collapsed search result previews that could show only "… N more matches" when the first grouped section exceeded the preview budget. Collapsed search output now compacts to match rows, fills the budget with visible hits before the summary, and keeps truncation details out of the bottom user-visible notice.
 - Fixed boolean environment flag overrides that were ORed with settings, so `PI_INTENT_TRACING=0`, `PI_AUTO_QA=0`, and per-backend eval flags now take precedence when present while falling back to config when unset.
+- Fixed Python eval `agent()` collapsing subagent runtime-limit aborts (and other empty-stderr aborts) into a generic `RuntimeError: bridge call '__agent__' failed`. `runEvalAgent` coalesced the failure message with `??`, which stopped at the empty `stderr` and never reached `abortReason`, shipping an empty error through the loopback bridge. The bridge now prefers `abortReason` for aborts and trims empty `stderr`/`error` out of the fallback chain, so Python surfaces the actionable reason (e.g. `Subagent runtime limit exceeded (task.maxRuntimeMs=900000)`) ([#2006](https://github.com/can1357/oh-my-pi/issues/2006)).
 
 ## [15.9.67] - 2026-06-06
 ### Added

--- a/packages/coding-agent/src/eval/__tests__/agent-bridge.test.ts
+++ b/packages/coding-agent/src/eval/__tests__/agent-bridge.test.ts
@@ -231,6 +231,57 @@ describe("runEvalAgent", () => {
 		});
 		await expect(runEvalAgent({ prompt: "fail" }, { session: makeSession() })).rejects.toThrow("boom");
 	});
+
+	// Regression: a runtime-limit abort returns exitCode=1, stderr="", error=undefined,
+	// aborted=true, abortReason="Subagent runtime limit exceeded (...)". The previous
+	// failure-message coalesce stopped at the empty `stderr` (since `??` only skips
+	// nullish values) and shipped an empty error through the bridge — Python then
+	// surfaced the generic `bridge call '__agent__' failed`. See #2006.
+	it("surfaces abortReason for aborts that leave stderr empty", async () => {
+		mockAgents();
+		const runSpy = vi.spyOn(taskExecutor, "runSubprocess");
+		runSpy.mockImplementationOnce(async options =>
+			singleResult(options, {
+				exitCode: 1,
+				output: "",
+				stderr: "",
+				error: undefined,
+				aborted: true,
+				abortReason: "Subagent runtime limit exceeded (task.maxRuntimeMs=900000)",
+			}),
+		);
+		runSpy.mockImplementationOnce(async options =>
+			singleResult(options, {
+				exitCode: 1,
+				output: "",
+				stderr: "   ",
+				error: "   ",
+				aborted: true,
+				abortReason: "Cancelled by caller",
+			}),
+		);
+		runSpy.mockImplementationOnce(async options =>
+			singleResult(options, {
+				exitCode: 1,
+				output: "",
+				stderr: "",
+				error: undefined,
+			}),
+		);
+
+		await expect(runEvalAgent({ prompt: "slow" }, { session: makeSession() })).rejects.toThrow(
+			"Subagent runtime limit exceeded (task.maxRuntimeMs=900000)",
+		);
+		// Whitespace-only stderr/error must not mask abortReason either.
+		await expect(runEvalAgent({ prompt: "cancelled" }, { session: makeSession() })).rejects.toThrow(
+			"Cancelled by caller",
+		);
+		// Last resort: still produce a non-empty message even when nothing useful is set,
+		// so Python never falls back to `bridge call '__agent__' failed`.
+		await expect(runEvalAgent({ prompt: "blank" }, { session: makeSession() })).rejects.toThrow(
+			"agent() subagent 'task' failed.",
+		);
+	});
 });
 
 describe("agent() through eval runtimes", () => {

--- a/packages/coding-agent/src/eval/agent-bridge.ts
+++ b/packages/coding-agent/src/eval/agent-bridge.ts
@@ -13,7 +13,7 @@ import subagentUserPromptTemplate from "../prompts/system/subagent-user-prompt.m
 import * as taskDiscovery from "../task/discovery";
 import * as taskExecutor from "../task/executor";
 import { AgentOutputManager } from "../task/output-manager";
-import type { AgentDefinition, AgentProgress } from "../task/types";
+import type { AgentDefinition, AgentProgress, SingleResult } from "../task/types";
 import type { ToolSession } from "../tools";
 import { ToolError } from "../tools/tool-errors";
 import { withBridgeTimeoutPause } from "./bridge-timeout";
@@ -174,6 +174,26 @@ function emitProgressStatus(emitStatus: ((event: JsStatusEvent) => void) | undef
 }
 
 /**
+ * Coalesce a subagent failure into a non-empty, human-meaningful error message.
+ *
+ * When the executor aborts a subagent (runtime limit, parent cancellation, …)
+ * the actionable explanation lives on `abortReason`, while `error`/`stderr`
+ * are routinely empty strings. Plain `??` coalescing stops at the empty string
+ * and ships an empty error through the bridge — Python then surfaces only the
+ * generic `bridge call '__agent__' failed`. See #2006.
+ */
+function buildSubagentFailureMessage(agentName: string, result: SingleResult): string {
+	const abortReason = trimToUndefined(result.abortReason);
+	if (result.aborted && abortReason) return abortReason;
+	return (
+		trimToUndefined(result.error) ??
+		trimToUndefined(result.stderr) ??
+		abortReason ??
+		`agent() subagent '${agentName}' failed.`
+	);
+}
+
+/**
  * Run a single subagent on behalf of an eval cell's `agent()` call.
  */
 export async function runEvalAgent(args: unknown, options: EvalAgentBridgeOptions): Promise<EvalAgentResult> {
@@ -278,10 +298,8 @@ export async function runEvalAgent(args: unknown, options: EvalAgentBridgeOption
 		}),
 	);
 
-	if (result.exitCode !== 0 || result.error) {
-		const failureMessage =
-			result.error ?? result.stderr ?? result.abortReason ?? `agent() subagent '${agentName}' failed.`;
-		throw new ToolError(failureMessage);
+	if (result.exitCode !== 0 || result.error || result.aborted) {
+		throw new ToolError(buildSubagentFailureMessage(agentName, result));
 	}
 
 	options.session.recordEvalSubagentUsage?.(result.usage?.output ?? 0);

--- a/packages/coding-agent/test/extensions-runner.test.ts
+++ b/packages/coding-agent/test/extensions-runner.test.ts
@@ -148,7 +148,6 @@ describe("ExtensionRunner", () => {
 			warnSpy.mockRestore();
 		});
 
-
 		it("warns when two extensions register same shortcut", async () => {
 			// Use a non-reserved shortcut
 			const extCode1 = `


### PR DESCRIPTION
## Repro

Python eval workflows that call `agent()` and let the subagent exceed a configured `task.maxRuntimeMs` cap surface the failure as a generic `RuntimeError: bridge call '__agent__' failed`, hiding the real reason.

Mock reproduction (added as `packages/coding-agent/src/eval/__tests__/agent-bridge.test.ts > runEvalAgent > surfaces abortReason for aborts that leave stderr empty`):

```
bun --cwd=packages/coding-agent test src/eval/__tests__/agent-bridge.test.ts -t "surfaces abortReason"
```

Before the fix: `Received message: ""`. After the fix: the test asserts `Subagent runtime limit exceeded (task.maxRuntimeMs=900000)` propagates verbatim, plus two adjacent cases (whitespace-only `stderr`/`error`, fully blank result).

## Cause

`packages/coding-agent/src/eval/agent-bridge.ts` (pre-fix `runEvalAgent`):

```ts
const failureMessage =
    result.error ?? result.stderr ?? result.abortReason ?? `agent() subagent '${agentName}' failed.`;
```

`??` is nullish-coalescing; for a runtime-limit abort the executor sets `result.stderr = ""` and `result.error = undefined`, so the chain stops at the empty string and never reaches `result.abortReason` (which carries the actionable `Subagent runtime limit exceeded (task.maxRuntimeMs=...)` string built in `executor.ts:760-765`).

The host bridge then ships `{ ok: false, error: "" }`. In `packages/coding-agent/src/eval/py/prelude.py`, `_bridge_call` does `raise RuntimeError(msg or f"bridge call {name!r} failed")`; `"" or <fallback>` selects the generic message.

## Fix

- `runEvalAgent` failure handling now goes through a small `buildSubagentFailureMessage(agentName, result)` helper:
  - Aborted subagents prefer the trimmed `result.abortReason` (this is where runtime-limit/cancellation messages live).
  - Otherwise fall through `result.error` → `result.stderr` → `result.abortReason` → named-bridge default, trimming each candidate so empty/whitespace strings cannot mask later, non-empty fields.
- The failure-detection condition also accepts `result.aborted`, so an abort without a non-zero exit (theoretical, but cheap to cover) still routes the abort reason out instead of being treated as success.
- Imports widened to bring `SingleResult` into scope for the helper signature.
- `packages/coding-agent/CHANGELOG.md` `[Unreleased] / Fixed` entry added.

## Verification

- `bun --cwd=packages/coding-agent test src/eval/__tests__/agent-bridge.test.ts` — 16 pass (1 new regression test + 15 pre-existing).
- `bun --cwd=packages/coding-agent test src/eval/__tests__` — 72 pass across 7 files.
- `bun --cwd=packages/coding-agent test test/eval/agent-bridge.test.ts` — 1 pass (legacy file unchanged).
- LSP diagnostics on `packages/coding-agent/src/eval/agent-bridge.ts`: clean.
- Pre-publish gate (`bun run fix` + `bun check`) ran on push.

Fixes #2006