### PR TITLE
docs(web-search): updated kagi description to v1 endpoint

### DIFF
--- a/docs/tools/web_search.md
+++ b/docs/tools/web_search.md
@@ -161,9 +161,9 @@ Streaming: none. `WebSearchTool.execute()` forwards its `AbortSignal` into `exec
     - Output: `sources`, `requestId`.
   - **Kagi** — `packages/coding-agent/src/web/search/providers/kagi.ts`, `packages/coding-agent/src/web/kagi.ts`
     - Availability: env or `agent.db` credential for `kagi`.
-    - Querying: GET `https://kagi.com/api/v0/search?q=<query>&limit=<n>` with `Authorization: Bot <key>`.
+    - Querying: POST `https://kagi.com/api/v1/search` with `Authorization: Bearer <key>` and JSON body `{ query, workflow: "search", limit, filters?: { after } }`. `recency` maps to `filters.after` as a UTC `YYYY-MM-DD` string (`day`/`week`/`month`/`year`).
     - `limit` and `num_search_results` are collapsed together before dispatch, clamped to `1..40`, default `10`.
-    - Output: `sources`, `relatedQuestions`, `requestId`.
+    - Output: `sources` (concatenated `data.search` + `data.video` + `data.news` + `data.infobox`, with video/news/infobox results tagged in the title), `relatedQuestions` (`data.adjacent_question` + `data.related_search` `props.question`), `answer` (`data.direct_answer[0].snippet ?? title`), `requestId` (`meta.trace`).
   - **Synthetic** — `packages/coding-agent/src/web/search/providers/synthetic.ts`
     - Availability: env or `agent.db` credential for `synthetic`.
     - Querying: POST `https://api.synthetic.new/v2/search` with `{ query }`.


### PR DESCRIPTION
## Repro
`docs/tools/web_search.md` (the `web_search` tool doc page) still described the Kagi provider as `GET https://kagi.com/api/v0/search?q=<query>&limit=<n>` with `Authorization: Bot <key>`, even though the runtime cut over to V1 in #1272. Anyone reading the docs would conclude `web_search → kagi` still talks to the sunset V0 endpoint.

## Cause
#1272 migrated `packages/coding-agent/src/web/kagi.ts` to `POST https://kagi.com/api/v1/search` with Bearer auth and a JSON request body, but left the prose description in `docs/tools/web_search.md:164,166` untouched. The Output bullet was also stale: V1 produces a `direct_answer` bucket that the adapter now surfaces as `answer`, and that wasn't listed either.

## Fix
- Rewrote the `Querying` bullet for the Kagi entry to describe the actual V1 request: `POST /api/v1/search`, `Authorization: Bearer <key>`, JSON body `{ query, workflow: "search", limit, filters?: { after } }`, and the `recency → filters.after` UTC date mapping used by `recencyToDate()` in `packages/coding-agent/src/web/kagi.ts`.
- Rewrote the `Output` bullet to match `searchWithKagi()`: concatenated `data.search` + `data.video` + `data.news` + `data.infobox` (with video/news/infobox tagged in the title), `relatedQuestions` drawn from `data.adjacent_question` + `data.related_search` `props.question`, `answer` from `data.direct_answer[0].snippet ?? title`, and `requestId` from `meta.trace`.

Docs only. The runtime, tests, and `packages/coding-agent/CHANGELOG.md` `[Unreleased]` entry for #1272 already reflect the V1 cutover; this PR just brings the prose into sync. No code, no tests changed.

## Verification
- Cross-checked every claim in the new bullet against `packages/coding-agent/src/web/kagi.ts` (`KAGI_SEARCH_URL`, `buildRequestBody`, `recencyToDate`, `collectSources`, `questionOf`, `direct_answer` handling) and `packages/coding-agent/src/web/search/providers/kagi.ts` (clamp constants `DEFAULT_NUM_RESULTS=10`, `MAX_NUM_RESULTS=40`).
- Cross-checked the request body fields against Kagi's published V1 spec (`https://kagi.com/api/docs/openapi/search/search`): `query`, `workflow`, `limit`, `filters.after` are all listed there.
- No `search` hits for `kagi.com/api/v0` or `Authorization: Bot` remain anywhere under `docs/`, `packages/`, or `scripts/` (the unrelated LM Studio `/api/v0/models` reference is for a different API).
- `bun run fix` clean; `bun check` ran as part of the publish gate.

Fixes #2009