### PR TITLE
fix(debug): wait for dlv unix socket before connecting

### DIFF
--- a/packages/coding-agent/src/dap/client.ts
+++ b/packages/coding-agent/src/dap/client.ts
@@ -1,4 +1,5 @@
-import { logger, ptree } from "@oh-my-pi/pi-utils";
+import * as fs from "node:fs/promises";
+import { isEnoent, logger, ptree } from "@oh-my-pi/pi-utils";
 import { NON_INTERACTIVE_ENV } from "../exec/non-interactive-env";
 import { ToolAbortError } from "../tools/tool-errors";
 import type {
@@ -165,16 +166,8 @@ export class DapClient {
 			detached: true,
 		});
 
-		// Wait for the socket file to appear (dlv needs to start listening)
 		await waitForCondition(
-			() => {
-				try {
-					Bun.file(socketPath).size;
-					return true;
-				} catch {
-					return false;
-				}
-			},
+			() => isUnixSocketReady(socketPath),
 			10_000,
 			proc,
 		);
@@ -553,15 +546,24 @@ export class DapClient {
 	}
 }
 
+async function isUnixSocketReady(socketPath: string): Promise<boolean> {
+	try {
+		return (await fs.stat(socketPath)).isSocket();
+	} catch (error) {
+		if (isEnoent(error)) return false;
+		throw error;
+	}
+}
+
 /** Poll a condition until it returns true, or timeout/process exit. */
 async function waitForCondition(
-	check: () => boolean,
+	check: () => boolean | Promise<boolean>,
 	timeoutMs: number,
 	proc: { exitCode: number | null },
 ): Promise<void> {
 	const deadline = Date.now() + timeoutMs;
 	while (Date.now() < deadline) {
-		if (check()) return;
+		if (await check()) return;
 		if (proc.exitCode !== null) {
 			throw new Error("Adapter process exited before socket was ready");
 		}

--- a/packages/coding-agent/src/dap/client.ts
+++ b/packages/coding-agent/src/dap/client.ts
@@ -166,11 +166,7 @@ export class DapClient {
 			detached: true,
 		});
 
-		await waitForCondition(
-			() => isUnixSocketReady(socketPath),
-			10_000,
-			proc,
-		);
+		await waitForCondition(() => isUnixSocketReady(socketPath), 10_000, proc);
 
 		const { readable, writeSink, socket } = await connectSocket({ unix: socketPath });
 		const client = new DapClient(adapter, cwd, proc, { readable, writeSink, socket });

--- a/packages/coding-agent/test/debug/dap-launch-failures.test.ts
+++ b/packages/coding-agent/test/debug/dap-launch-failures.test.ts
@@ -22,6 +22,32 @@ const TEST_ADAPTER: DapResolvedAdapter = {
 	connectMode: "stdio",
 };
 
+const DELAYED_UNIX_SOCKET_ADAPTER = `
+const listenPrefix = "--listen=unix:";
+const listenArg = process.argv.find(arg => arg.startsWith(listenPrefix));
+if (!listenArg) {
+	throw new Error("missing --listen=unix argument");
+}
+const socketPath = listenArg.slice(listenPrefix.length);
+let server;
+process.on("SIGTERM", () => {
+	server?.stop();
+	process.exit(0);
+});
+await Bun.sleep(100);
+server = Bun.listen({
+	unix: socketPath,
+	socket: {
+		open() {},
+		data() {},
+		close() {},
+		error() {},
+	},
+});
+await Bun.sleep(2_000);
+server.stop();
+`;
+
 type DapEventHandler = (body: unknown, event: DapEventMessage) => void | Promise<void>;
 
 class FakeDapClient {
@@ -285,6 +311,29 @@ describe("DAP launch failure handling", () => {
 		// regression-prone case is omitting the launch line entirely.
 		expect(message).toContain("launch: 'C:\\repo\\program' is not a valid executable");
 		expect(message).toContain("configurationDone: Expected process to be stopped.");
+	});
+
+	it("waits for delayed Unix socket adapters before connecting on Linux", async () => {
+		if (process.platform !== "linux") return;
+		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-debug-dlv-socket-"));
+		const adapterPath = path.join(cwd, "delayed-unix-socket-adapter.mjs");
+		await fs.writeFile(adapterPath, DELAYED_UNIX_SOCKET_ADAPTER);
+		const adapter: DapResolvedAdapter = {
+			...TEST_ADAPTER,
+			name: "dlv",
+			command: process.execPath,
+			args: [adapterPath],
+			resolvedCommand: process.execPath,
+			connectMode: "socket",
+		};
+		let client: DapClient | undefined;
+		try {
+			client = await DapClient.spawn({ adapter, cwd });
+			expect(client.isAlive()).toBe(true);
+		} finally {
+			await client?.dispose();
+			await fs.rm(cwd, { recursive: true, force: true });
+		}
 	});
 });
 


### PR DESCRIPTION
## Repro
On Linux with Bun 1.3.14, the DAP Unix socket readiness check treats a missing socket as ready because `Bun.file(socketPath).size` returns `0` rather than throwing; running a minimal `Bun.connect({ unix })` reproduction immediately fails with `ENOENT` / `Failed to connect`, matching the reported `dlv` crash path.

## Cause
`packages/coding-agent/src/dap/client.ts` used `Bun.file(socketPath).size` inside `DapClient.#spawnSocketUnix` as a readiness predicate before `connectSocket`, so `waitForCondition` returned on the first poll even when `dlv dap --listen=unix:<path>` had not created the socket yet.

## Fix
- Replaced the `Bun.file(...).size` probe with an async `fs.stat(...).isSocket()` readiness check that only returns true once the Unix socket exists.
- Kept `waitForCondition` polling until the async socket check succeeds or the adapter exits/times out.
- Added a Linux regression test with a delayed socket-mode adapter so `DapClient.spawn` must wait before connecting.

## Verification
Ran `bun test test/debug/dap-launch-failures.test.ts` and `bun run check:types` in `packages/coding-agent`; both passed. Fixes #2013