### PR TITLE
feat(coding-agent): add support for git reftables

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -433,6 +433,10 @@
 - Fixed the `todo` and `job` tools rendering a success icon and success styling on a failed/error result; error results now show the error icon and a red frame border.
 - Fixed `debug` tool refusing every `dlv` launch on Go modules. The launch handler ran `validateLaunchProgram` before adapter selection and rejected any directory program with `launch program resolves to a directory`, while dlv's default `mode=debug` requires a Go package path (a directory or `.go` source file). Adapter resolution now precedes validation, directory programs prefer adapters that advertise `acceptsDirectoryProgram` before falling back to native extensionless debuggers, the rejection only fires when the resolved adapter does not advertise that flag (set on `dlv` in `dap/defaults.json`), and dlv's `mode` is derived from the program shape — directories and `.go` files launch as `mode=debug`, other files as `mode=exec` — so `omp` can debug both Go packages and pre-built binaries ([#2020](https://github.com/can1357/oh-my-pi/issues/2020)).
 
+### Added
+
+- Added support for Git repositories using the `reftable` storage format by detecting `extensions.refStorage = reftable` in the repository configuration and falling back to shelling out to Git commands (`git symbolic-ref`, `git rev-parse`) for reference and HEAD resolution.
+
 ## [15.10.0] - 2026-06-06
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -66,7 +66,7 @@ export class FooterComponent implements Component {
 				}
 
 				try {
-					const watchPath = head.isReftable ? path.join(head.commonDir, "reftable", "tables.list") : head.headPath;
+					const watchPath = head.isReftable ? path.join(head.gitDir, "reftable", "tables.list") : head.headPath;
 					this.#gitWatcher = fs.watch(watchPath, () => {
 						this.#cachedBranch = undefined; // Invalidate cache
 						if (this.#onBranchChange) {

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as path from "node:path";
 import { stripVTControlCharacters } from "node:util";
 import { ThinkingLevel } from "@oh-my-pi/pi-agent-core";
 import { type Component, padding, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
@@ -65,7 +66,8 @@ export class FooterComponent implements Component {
 				}
 
 				try {
-					this.#gitWatcher = fs.watch(head.headPath, () => {
+					const watchPath = head.isReftable ? path.join(head.commonDir, "reftable", "tables.list") : head.headPath;
+					this.#gitWatcher = fs.watch(watchPath, () => {
 						this.#cachedBranch = undefined; // Invalidate cache
 						if (this.#onBranchChange) {
 							this.#onBranchChange();

--- a/packages/coding-agent/src/modes/components/footer.ts
+++ b/packages/coding-agent/src/modes/components/footer.ts
@@ -66,7 +66,7 @@ export class FooterComponent implements Component {
 				}
 
 				try {
-					const watchPath = head.isReftable ? path.join(head.gitDir, "reftable", "tables.list") : head.headPath;
+					const watchPath = head.isReftable ? path.join(head.gitDir, "reftable") : head.headPath;
 					this.#gitWatcher = fs.watch(watchPath, () => {
 						this.#cachedBranch = undefined; // Invalidate cache
 						if (this.#onBranchChange) {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -243,7 +243,7 @@ export class StatusLineComponent implements Component {
 		if (!repository) return;
 
 		const watchPath = git.repo.isReftableSync(repository)
-			? path.join(repository.commonDir, "reftable", "tables.list")
+			? path.join(repository.gitDir, "reftable", "tables.list")
 			: repository.headPath;
 
 		try {

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as path from "node:path";
 import type { AgentMessage } from "@oh-my-pi/pi-agent-core";
 import { estimateTokens } from "@oh-my-pi/pi-agent-core/compaction";
 import { type Component, truncateToWidth, visibleWidth } from "@oh-my-pi/pi-tui";
@@ -238,11 +239,15 @@ export class StatusLineComponent implements Component {
 			this.#gitWatcher = null;
 		}
 
-		const gitHeadPath = git.repo.resolveSync(getProjectDir())?.headPath ?? null;
-		if (!gitHeadPath) return;
+		const repository = git.repo.resolveSync(getProjectDir());
+		if (!repository) return;
+
+		const watchPath = git.repo.isReftableSync(repository)
+			? path.join(repository.commonDir, "reftable", "tables.list")
+			: repository.headPath;
 
 		try {
-			this.#gitWatcher = fs.watch(gitHeadPath, () => {
+			this.#gitWatcher = fs.watch(watchPath, () => {
 				this.#invalidateGitCaches();
 				if (this.#onBranchChange) {
 					this.#onBranchChange();

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -243,7 +243,7 @@ export class StatusLineComponent implements Component {
 		if (!repository) return;
 
 		const watchPath = git.repo.isReftableSync(repository)
-			? path.join(repository.gitDir, "reftable", "tables.list")
+			? path.join(repository.gitDir, "reftable")
 			: repository.headPath;
 
 		try {

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -583,10 +583,7 @@ function parseGitConfigHasReftable(content: string): boolean {
 							inQuotes = !inQuotes;
 							cleanValue += char;
 						} else if (!inQuotes && (char === ";" || char === "#")) {
-							if (i === 0 || /\s/.test(value[i - 1])) {
-								break;
-							}
-							cleanValue += char;
+							break;
 						} else {
 							cleanValue += char;
 						}

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -710,7 +710,7 @@ function readRefSync(repository: GitRepository, targetRef: string): string | nul
 			const stdoutText = new TextDecoder().decode(symResult.stdout).trim();
 			return `${HEAD_REF_PREFIX} ${stdoutText}`;
 		}
-		const revArgs = withShortLivedGitConfig(withNoOptionalLocks(["rev-parse", targetRef]));
+		const revArgs = withShortLivedGitConfig(withNoOptionalLocks(["rev-parse", "--verify", targetRef]));
 		const revResult = Bun.spawnSync(["git", ...revArgs], {
 			cwd: repository.repoRoot,
 			stdout: "pipe",
@@ -752,17 +752,18 @@ async function readRef(repository: GitRepository, targetRef: string, signal?: Ab
 			return `${HEAD_REF_PREFIX} ${symResult.stdout.trim()}`;
 		}
 		throwIfAborted(signal);
-		const revResult = await git(repository.repoRoot, ["rev-parse", targetRef], { readOnly: true, signal }).catch(
-			err => {
-				if (
-					signal?.aborted ||
-					(err instanceof Error && (err.name === "AbortError" || err.name === "ToolAbortError"))
-				) {
-					throw err;
-				}
-				return null;
-			},
-		);
+		const revResult = await git(repository.repoRoot, ["rev-parse", "--verify", targetRef], {
+			readOnly: true,
+			signal,
+		}).catch(err => {
+			if (
+				signal?.aborted ||
+				(err instanceof Error && (err.name === "AbortError" || err.name === "ToolAbortError"))
+			) {
+				throw err;
+			}
+			return null;
+		});
 		if (revResult && revResult.exitCode === 0) {
 			return revResult.stdout.trim() || null;
 		}

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -27,6 +27,7 @@ export interface GitRepository {
 	gitEntryPath: string;
 	headPath: string;
 	repoRoot: string;
+	isReftable?: boolean;
 }
 
 export interface GitStatusSummary {
@@ -560,8 +561,6 @@ function parsePackedRefs(content: string | null, targetRef: string): string | nu
 	return null;
 }
 
-const reftableCache = new Map<string, boolean>();
-
 function parseGitConfigHasReftable(content: string): boolean {
 	let inExtensions = false;
 	for (const line of content.split("\n")) {
@@ -570,12 +569,35 @@ function parseGitConfigHasReftable(content: string): boolean {
 			const section = trimmed.slice(1, -1).trim().toLowerCase();
 			inExtensions = section === "extensions";
 		} else if (inExtensions) {
-			const parts = trimmed.split("=");
-			if (parts.length >= 2) {
-				const key = parts[0].trim().toLowerCase();
-				const value = parts.slice(1).join("=").trim().toLowerCase();
-				if (key === "refstorage" && value === "reftable") {
-					return true;
+			const eqIndex = trimmed.indexOf("=");
+			if (eqIndex !== -1) {
+				const key = trimmed.slice(0, eqIndex).trim().toLowerCase();
+				const value = trimmed.slice(eqIndex + 1).trim();
+				if (key === "refstorage") {
+					// Strip trailing comments per git-config(5)
+					let cleanValue = "";
+					let inQuotes = false;
+					for (let i = 0; i < value.length; i++) {
+						const char = value[i];
+						if (char === '"') {
+							inQuotes = !inQuotes;
+							cleanValue += char;
+						} else if (!inQuotes && (char === ";" || char === "#")) {
+							if (i === 0 || /\s/.test(value[i - 1])) {
+								break;
+							}
+							cleanValue += char;
+						} else {
+							cleanValue += char;
+						}
+					}
+					cleanValue = cleanValue.trim().toLowerCase();
+					if (cleanValue.startsWith('"') && cleanValue.endsWith('"')) {
+						cleanValue = cleanValue.slice(1, -1).trim();
+					}
+					if (cleanValue === "reftable") {
+						return true;
+					}
 				}
 			}
 		}
@@ -584,28 +606,36 @@ function parseGitConfigHasReftable(content: string): boolean {
 }
 
 function isReftableRepoSync(repository: GitRepository): boolean {
-	const cached = reftableCache.get(repository.commonDir);
-	if (cached !== undefined) return cached;
+	if (repository.isReftable !== undefined) return repository.isReftable;
 	const configPath = path.join(repository.commonDir, "config");
 	const content = readOptionalTextSync(configPath);
-	const hasReftable = content ? parseGitConfigHasReftable(content) : false;
-	reftableCache.set(repository.commonDir, hasReftable);
-	return hasReftable;
+	repository.isReftable = content ? parseGitConfigHasReftable(content) : false;
+	return repository.isReftable;
 }
 
 async function isReftableRepo(repository: GitRepository): Promise<boolean> {
-	const cached = reftableCache.get(repository.commonDir);
-	if (cached !== undefined) return cached;
+	if (repository.isReftable !== undefined) return repository.isReftable;
 	const configPath = path.join(repository.commonDir, "config");
 	const content = await readOptionalText(configPath);
-	const hasReftable = content ? parseGitConfigHasReftable(content) : false;
-	reftableCache.set(repository.commonDir, hasReftable);
-	return hasReftable;
+	repository.isReftable = content ? parseGitConfigHasReftable(content) : false;
+	return repository.isReftable;
 }
 
-async function resolveHeadStateReftable(repository: GitRepository): Promise<GitHeadState | null> {
-	const symResult = await git(repository.repoRoot, ["symbolic-ref", "HEAD"], { readOnly: true }).catch(() => null);
-	const revResult = await git(repository.repoRoot, ["rev-parse", "HEAD"], { readOnly: true }).catch(() => null);
+async function resolveHeadStateReftable(repository: GitRepository, signal?: AbortSignal): Promise<GitHeadState | null> {
+	throwIfAborted(signal);
+	const symResult = await git(repository.repoRoot, ["symbolic-ref", "HEAD"], { readOnly: true, signal }).catch(err => {
+		if (signal?.aborted || (err instanceof Error && (err.name === "AbortError" || err.name === "ToolAbortError"))) {
+			throw err;
+		}
+		return null;
+	});
+	throwIfAborted(signal);
+	const revResult = await git(repository.repoRoot, ["rev-parse", "HEAD"], { readOnly: true, signal }).catch(err => {
+		if (signal?.aborted || (err instanceof Error && (err.name === "AbortError" || err.name === "ToolAbortError"))) {
+			throw err;
+		}
+		return null;
+	});
 	const commit = revResult && revResult.exitCode === 0 ? revResult.stdout.trim() || null : null;
 
 	if (symResult && symResult.exitCode === 0) {
@@ -707,15 +737,35 @@ function readRefSync(repository: GitRepository, targetRef: string): string | nul
 	return null;
 }
 
-async function readRef(repository: GitRepository, targetRef: string): Promise<string | null> {
+async function readRef(repository: GitRepository, targetRef: string, signal?: AbortSignal): Promise<string | null> {
 	if (await isReftableRepo(repository)) {
-		const symResult = await git(repository.repoRoot, ["symbolic-ref", targetRef], { readOnly: true }).catch(
-			() => null,
+		throwIfAborted(signal);
+		const symResult = await git(repository.repoRoot, ["symbolic-ref", targetRef], { readOnly: true, signal }).catch(
+			err => {
+				if (
+					signal?.aborted ||
+					(err instanceof Error && (err.name === "AbortError" || err.name === "ToolAbortError"))
+				) {
+					throw err;
+				}
+				return null;
+			},
 		);
 		if (symResult && symResult.exitCode === 0) {
 			return `${HEAD_REF_PREFIX} ${symResult.stdout.trim()}`;
 		}
-		const revResult = await git(repository.repoRoot, ["rev-parse", targetRef], { readOnly: true }).catch(() => null);
+		throwIfAborted(signal);
+		const revResult = await git(repository.repoRoot, ["rev-parse", targetRef], { readOnly: true, signal }).catch(
+			err => {
+				if (
+					signal?.aborted ||
+					(err instanceof Error && (err.name === "AbortError" || err.name === "ToolAbortError"))
+				) {
+					throw err;
+				}
+				return null;
+			},
+		);
 		if (revResult && revResult.exitCode === 0) {
 			return revResult.stdout.trim() || null;
 		}
@@ -1146,7 +1196,7 @@ export const branch = {
 		const repository = await resolveRepository(cwd);
 		if (repository) {
 			for (const refPath of DEFAULT_BRANCH_REFS) {
-				const target = await readRef(repository, refPath);
+				const target = await readRef(repository, refPath, signal);
 				const branchName = parseDefaultBranchRef(refPath, target);
 				if (branchName) return branchName;
 			}
@@ -1244,7 +1294,7 @@ export const ref = {
 	async exists(cwd: string, refName: string, signal?: AbortSignal): Promise<boolean> {
 		if (refName === "HEAD") return (await head.sha(cwd, signal)) !== null;
 		const repository = await resolveRepository(cwd);
-		if (repository && refName.startsWith("refs/")) return (await readRef(repository, refName)) !== null;
+		if (repository && refName.startsWith("refs/")) return (await readRef(repository, refName, signal)) !== null;
 		const result = await git(cwd, ["show-ref", "--verify", "--quiet", refName], { readOnly: true, signal });
 		return result.exitCode === 0;
 	},
@@ -1253,7 +1303,7 @@ export const ref = {
 	async resolve(cwd: string, refName: string, signal?: AbortSignal): Promise<string | null> {
 		if (refName === "HEAD") return head.sha(cwd, signal);
 		const repository = await resolveRepository(cwd);
-		if (repository && refName.startsWith("refs/")) return readRef(repository, refName);
+		if (repository && refName.startsWith("refs/")) return readRef(repository, refName, signal);
 		const result = await git(cwd, ["rev-parse", refName], { readOnly: true, signal });
 		if (result.exitCode !== 0) return null;
 		return result.stdout.trim() || null;
@@ -1546,11 +1596,11 @@ export const ls = {
 
 export const head = {
 	/** Full HEAD state (branch, commit, repo info). */
-	async resolve(cwd: string): Promise<GitHeadState | null> {
+	async resolve(cwd: string, signal?: AbortSignal): Promise<GitHeadState | null> {
 		const repository = await resolveRepository(cwd);
 		if (!repository) return null;
 		if (await isReftableRepo(repository)) {
-			return resolveHeadStateReftable(repository);
+			return resolveHeadStateReftable(repository, signal);
 		}
 		const content = await readOptionalText(repository.headPath);
 		if (content === null) return null;
@@ -1571,7 +1621,7 @@ export const head = {
 
 	/** Current HEAD commit SHA. */
 	async sha(cwd: string, signal?: AbortSignal): Promise<string | null> {
-		const headState = await head.resolve(cwd);
+		const headState = await head.resolve(cwd, signal);
 		if (headState?.commit) return headState.commit;
 		const result = await git(cwd, ["rev-parse", "HEAD"], { readOnly: true, signal });
 		if (result.exitCode !== 0) return null;
@@ -1626,11 +1676,21 @@ export const repo = {
 	resolve(cwd: string): Promise<GitRepository | null> {
 		return resolveRepository(cwd);
 	},
+
+	/** Check if the repository uses the reftable reference storage format (sync). */
+	isReftableSync(repository: GitRepository): boolean {
+		return isReftableRepoSync(repository);
+	},
+
+	/** Check if the repository uses the reftable reference storage format. */
+	isReftable(repository: GitRepository): Promise<boolean> {
+		return isReftableRepo(repository);
+	},
 };
 
 // Helper used during head resolution — defined here to reference `head` namespace.
-async function resolveHead(cwd: string): Promise<GitHeadState | null> {
-	return head.resolve(cwd);
+async function resolveHead(cwd: string, signal?: AbortSignal): Promise<GitHeadState | null> {
+	return head.resolve(cwd, signal);
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -560,7 +560,142 @@ function parsePackedRefs(content: string | null, targetRef: string): string | nu
 	return null;
 }
 
+const reftableCache = new Map<string, boolean>();
+
+function parseGitConfigHasReftable(content: string): boolean {
+	let inExtensions = false;
+	for (const line of content.split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+			const section = trimmed.slice(1, -1).trim().toLowerCase();
+			inExtensions = section === "extensions";
+		} else if (inExtensions) {
+			const parts = trimmed.split("=");
+			if (parts.length >= 2) {
+				const key = parts[0].trim().toLowerCase();
+				const value = parts.slice(1).join("=").trim().toLowerCase();
+				if (key === "refstorage" && value === "reftable") {
+					return true;
+				}
+			}
+		}
+	}
+	return false;
+}
+
+function isReftableRepoSync(repository: GitRepository): boolean {
+	const cached = reftableCache.get(repository.commonDir);
+	if (cached !== undefined) return cached;
+	const configPath = path.join(repository.commonDir, "config");
+	const content = readOptionalTextSync(configPath);
+	const hasReftable = content ? parseGitConfigHasReftable(content) : false;
+	reftableCache.set(repository.commonDir, hasReftable);
+	return hasReftable;
+}
+
+async function isReftableRepo(repository: GitRepository): Promise<boolean> {
+	const cached = reftableCache.get(repository.commonDir);
+	if (cached !== undefined) return cached;
+	const configPath = path.join(repository.commonDir, "config");
+	const content = await readOptionalText(configPath);
+	const hasReftable = content ? parseGitConfigHasReftable(content) : false;
+	reftableCache.set(repository.commonDir, hasReftable);
+	return hasReftable;
+}
+
+async function resolveHeadStateReftable(repository: GitRepository): Promise<GitHeadState | null> {
+	const symResult = await git(repository.repoRoot, ["symbolic-ref", "HEAD"], { readOnly: true }).catch(() => null);
+	const revResult = await git(repository.repoRoot, ["rev-parse", "HEAD"], { readOnly: true }).catch(() => null);
+	const commit = revResult && revResult.exitCode === 0 ? revResult.stdout.trim() || null : null;
+
+	if (symResult && symResult.exitCode === 0) {
+		const ref = symResult.stdout.trim();
+		const branchName = ref.startsWith(LOCAL_BRANCH_PREFIX) ? ref.slice(LOCAL_BRANCH_PREFIX.length) : null;
+		return {
+			...repository,
+			kind: "ref",
+			ref,
+			branchName,
+			commit,
+			headContent: `${HEAD_REF_PREFIX} ${ref}`,
+		};
+	}
+
+	return {
+		...repository,
+		kind: "detached",
+		commit,
+		headContent: commit || "",
+	};
+}
+
+function resolveHeadStateReftableSync(repository: GitRepository): GitHeadState | null {
+	ensureAvailable();
+	const symArgs = withShortLivedGitConfig(withNoOptionalLocks(["symbolic-ref", "HEAD"]));
+	const symResult = Bun.spawnSync(["git", ...symArgs], {
+		cwd: repository.repoRoot,
+		stdout: "pipe",
+		stderr: "pipe",
+		windowsHide: true,
+	});
+
+	const revArgs = withShortLivedGitConfig(withNoOptionalLocks(["rev-parse", "HEAD"]));
+	const revResult = Bun.spawnSync(["git", ...revArgs], {
+		cwd: repository.repoRoot,
+		stdout: "pipe",
+		stderr: "pipe",
+		windowsHide: true,
+	});
+	const commit = revResult.exitCode === 0 ? new TextDecoder().decode(revResult.stdout).trim() || null : null;
+
+	if (symResult.exitCode === 0) {
+		const ref = new TextDecoder().decode(symResult.stdout).trim();
+		const branchName = ref.startsWith(LOCAL_BRANCH_PREFIX) ? ref.slice(LOCAL_BRANCH_PREFIX.length) : null;
+		return {
+			...repository,
+			kind: "ref",
+			ref,
+			branchName,
+			commit,
+			headContent: `${HEAD_REF_PREFIX} ${ref}`,
+		};
+	}
+
+	return {
+		...repository,
+		kind: "detached",
+		commit,
+		headContent: commit || "",
+	};
+}
+
 function readRefSync(repository: GitRepository, targetRef: string): string | null {
+	if (isReftableRepoSync(repository)) {
+		ensureAvailable();
+		const symArgs = withShortLivedGitConfig(withNoOptionalLocks(["symbolic-ref", targetRef]));
+		const symResult = Bun.spawnSync(["git", ...symArgs], {
+			cwd: repository.repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+			windowsHide: true,
+		});
+		if (symResult.exitCode === 0) {
+			const stdoutText = new TextDecoder().decode(symResult.stdout).trim();
+			return `${HEAD_REF_PREFIX} ${stdoutText}`;
+		}
+		const revArgs = withShortLivedGitConfig(withNoOptionalLocks(["rev-parse", targetRef]));
+		const revResult = Bun.spawnSync(["git", ...revArgs], {
+			cwd: repository.repoRoot,
+			stdout: "pipe",
+			stderr: "pipe",
+			windowsHide: true,
+		});
+		if (revResult.exitCode === 0) {
+			return new TextDecoder().decode(revResult.stdout).trim() || null;
+		}
+		return null;
+	}
+
 	for (const dir of getRefLookupDirs(repository)) {
 		const value = normalizeRefValue(readOptionalTextSync(path.join(dir, targetRef)));
 		if (value) return value;
@@ -573,6 +708,20 @@ function readRefSync(repository: GitRepository, targetRef: string): string | nul
 }
 
 async function readRef(repository: GitRepository, targetRef: string): Promise<string | null> {
+	if (await isReftableRepo(repository)) {
+		const symResult = await git(repository.repoRoot, ["symbolic-ref", targetRef], { readOnly: true }).catch(
+			() => null,
+		);
+		if (symResult && symResult.exitCode === 0) {
+			return `${HEAD_REF_PREFIX} ${symResult.stdout.trim()}`;
+		}
+		const revResult = await git(repository.repoRoot, ["rev-parse", targetRef], { readOnly: true }).catch(() => null);
+		if (revResult && revResult.exitCode === 0) {
+			return revResult.stdout.trim() || null;
+		}
+		return null;
+	}
+
 	for (const dir of getRefLookupDirs(repository)) {
 		const value = normalizeRefValue(await readOptionalText(path.join(dir, targetRef)));
 		if (value) return value;
@@ -1400,6 +1549,9 @@ export const head = {
 	async resolve(cwd: string): Promise<GitHeadState | null> {
 		const repository = await resolveRepository(cwd);
 		if (!repository) return null;
+		if (await isReftableRepo(repository)) {
+			return resolveHeadStateReftable(repository);
+		}
 		const content = await readOptionalText(repository.headPath);
 		if (content === null) return null;
 		return parseHeadState(repository, content);
@@ -1409,6 +1561,9 @@ export const head = {
 	resolveSync(cwd: string): GitHeadState | null {
 		const repository = resolveRepositorySync(cwd);
 		if (!repository) return null;
+		if (isReftableRepoSync(repository)) {
+			return resolveHeadStateReftableSync(repository);
+		}
 		const content = readOptionalTextSync(repository.headPath);
 		if (content === null) return null;
 		return parseHeadStateSync(repository, content);

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -629,7 +629,10 @@ async function resolveHeadStateReftable(repository: GitRepository, signal?: Abor
 		return null;
 	});
 	throwIfAborted(signal);
-	const revResult = await git(repository.repoRoot, ["rev-parse", "HEAD"], { readOnly: true, signal }).catch(err => {
+	const revResult = await git(repository.repoRoot, ["rev-parse", "--verify", "HEAD"], {
+		readOnly: true,
+		signal,
+	}).catch(err => {
 		if (signal?.aborted || (err instanceof Error && (err.name === "AbortError" || err.name === "ToolAbortError"))) {
 			throw err;
 		}
@@ -668,7 +671,7 @@ function resolveHeadStateReftableSync(repository: GitRepository): GitHeadState |
 		windowsHide: true,
 	});
 
-	const revArgs = withShortLivedGitConfig(withNoOptionalLocks(["rev-parse", "HEAD"]));
+	const revArgs = withShortLivedGitConfig(withNoOptionalLocks(["rev-parse", "--verify", "HEAD"]));
 	const revResult = Bun.spawnSync(["git", ...revArgs], {
 		cwd: repository.repoRoot,
 		stdout: "pipe",

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -561,10 +561,27 @@ function parsePackedRefs(content: string | null, targetRef: string): string | nu
 	return null;
 }
 
+function stripGitConfigComments(line: string): string {
+	let clean = "";
+	let inQuotes = false;
+	for (let i = 0; i < line.length; i++) {
+		const char = line[i];
+		if (char === '"') {
+			inQuotes = !inQuotes;
+			clean += char;
+		} else if (!inQuotes && (char === ";" || char === "#")) {
+			break;
+		} else {
+			clean += char;
+		}
+	}
+	return clean.trim();
+}
+
 function parseGitConfigHasReftable(content: string): boolean {
 	let inExtensions = false;
 	for (const line of content.split("\n")) {
-		const trimmed = line.trim();
+		const trimmed = stripGitConfigComments(line);
 		if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
 			const section = trimmed.slice(1, -1).trim().toLowerCase();
 			inExtensions = section === "extensions";
@@ -572,27 +589,12 @@ function parseGitConfigHasReftable(content: string): boolean {
 			const eqIndex = trimmed.indexOf("=");
 			if (eqIndex !== -1) {
 				const key = trimmed.slice(0, eqIndex).trim().toLowerCase();
-				const value = trimmed.slice(eqIndex + 1).trim();
+				let value = trimmed.slice(eqIndex + 1).trim();
 				if (key === "refstorage") {
-					// Strip trailing comments per git-config(5)
-					let cleanValue = "";
-					let inQuotes = false;
-					for (let i = 0; i < value.length; i++) {
-						const char = value[i];
-						if (char === '"') {
-							inQuotes = !inQuotes;
-							cleanValue += char;
-						} else if (!inQuotes && (char === ";" || char === "#")) {
-							break;
-						} else {
-							cleanValue += char;
-						}
+					if (value.startsWith('"') && value.endsWith('"')) {
+						value = value.slice(1, -1).trim();
 					}
-					cleanValue = cleanValue.trim().toLowerCase();
-					if (cleanValue.startsWith('"') && cleanValue.endsWith('"')) {
-						cleanValue = cleanValue.slice(1, -1).trim();
-					}
-					if (cleanValue === "reftable") {
+					if (value.toLowerCase() === "reftable") {
 						return true;
 					}
 				}

--- a/packages/coding-agent/test/git-reftable.test.ts
+++ b/packages/coding-agent/test/git-reftable.test.ts
@@ -130,6 +130,34 @@ describe.skipIf(!supportsReftable)("git reftable support", () => {
 			expect(await git.repo.isReftable(repository4)).toBe(false);
 			expect(git.repo.isReftableSync(repository4)).toBe(false);
 		}
+
+		// Test adjacent hash comment (no preceding space)
+		const newConfigWithAdjacentHash = baseConfig.replace(
+			"refstorage = reftable",
+			"refstorage = reftable#adjacenthash",
+		);
+		await fs.writeFile(configPath, newConfigWithAdjacentHash);
+
+		const repository5 = await git.repo.resolve(testRepoDir);
+		expect(repository5).not.toBeNull();
+		if (repository5) {
+			expect(await git.repo.isReftable(repository5)).toBe(true);
+			expect(git.repo.isReftableSync(repository5)).toBe(true);
+		}
+
+		// Test adjacent semicolon comment (no preceding space)
+		const newConfigWithAdjacentSemicolon = baseConfig.replace(
+			"refstorage = reftable",
+			"refstorage = reftable;adjacentsemi",
+		);
+		await fs.writeFile(configPath, newConfigWithAdjacentSemicolon);
+
+		const repository6 = await git.repo.resolve(testRepoDir);
+		expect(repository6).not.toBeNull();
+		if (repository6) {
+			expect(await git.repo.isReftable(repository6)).toBe(true);
+			expect(git.repo.isReftableSync(repository6)).toBe(true);
+		}
 	});
 
 	test("resolves references in a reftable worktree", async () => {

--- a/packages/coding-agent/test/git-reftable.test.ts
+++ b/packages/coding-agent/test/git-reftable.test.ts
@@ -131,4 +131,47 @@ describe.skipIf(!supportsReftable)("git reftable support", () => {
 			expect(git.repo.isReftableSync(repository4)).toBe(false);
 		}
 	});
+
+	test("resolves references in a reftable worktree", async () => {
+		// Initialize the repository with reftable format
+		const initResult = await $`git init --ref-format=reftable --initial-branch=main`.cwd(testRepoDir).quiet();
+		expect(initResult.exitCode).toBe(0);
+
+		// Configure basic user details so we can commit
+		await $`git config user.name "Test User"`.cwd(testRepoDir).quiet();
+		await $`git config user.email "test@example.com"`.cwd(testRepoDir).quiet();
+
+		// Create a file and commit it
+		await fs.writeFile(path.join(testRepoDir, "file.txt"), "hello world");
+		await $`git add file.txt`.cwd(testRepoDir).quiet();
+		await $`git commit -m "initial commit"`.cwd(testRepoDir).quiet();
+
+		// Create a linked worktree
+		const worktreeDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-reftable-wt-"));
+		try {
+			await $`git worktree add ${worktreeDir} -b wt-branch`.cwd(testRepoDir).quiet();
+
+			// Resolve the repository for the worktree
+			const repository = await git.repo.resolve(worktreeDir);
+			expect(repository).not.toBeNull();
+			if (!repository) return;
+
+			expect(repository.gitDir).not.toBe(repository.commonDir);
+			expect(await git.repo.isReftable(repository)).toBe(true);
+
+			// Check current branch on worktree
+			const currentBranch = await git.branch.current(worktreeDir);
+			expect(currentBranch).toBe("wt-branch");
+
+			// Check that HEAD resolves correctly in the worktree
+			const headState = await git.head.resolve(worktreeDir);
+			expect(headState).not.toBeNull();
+			if (headState?.kind !== "ref") throw new Error("expected ref head in worktree");
+			expect(headState.branchName).toBe("wt-branch");
+		} finally {
+			// Clean up the worktree
+			await $`git worktree remove ${worktreeDir} -f`.cwd(testRepoDir).quiet().nothrow();
+			await fs.rm(worktreeDir, { recursive: true, force: true }).catch(() => {});
+		}
+	});
 });

--- a/packages/coding-agent/test/git-reftable.test.ts
+++ b/packages/coding-agent/test/git-reftable.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { $ } from "bun";
+import * as git from "../src/utils/git";
+
+describe("git reftable support", () => {
+	let testRepoDir: string;
+
+	beforeEach(async () => {
+		testRepoDir = path.join(import.meta.dir, `tmp-reftable-test-${Date.now()}`);
+		await fs.mkdir(testRepoDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await fs.rm(testRepoDir, { recursive: true, force: true });
+	});
+
+	test("resolves references in a reftable repository", async () => {
+		// Initialize the repository with reftable format
+		const initResult = await $`git init --ref-format=reftable`.cwd(testRepoDir).quiet().nothrow();
+		if (initResult.exitCode !== 0) {
+			// If the installed git doesn't support --ref-format=reftable, skip the test
+			console.warn("Skipping reftable test: Git does not support --ref-format=reftable");
+			return;
+		}
+
+		// Configure basic user details so we can commit
+		await $`git config user.name "Test User"`.cwd(testRepoDir).quiet();
+		await $`git config user.email "test@example.com"`.cwd(testRepoDir).quiet();
+
+		// Create a file and commit it
+		await fs.writeFile(path.join(testRepoDir, "file.txt"), "hello world");
+		await $`git add file.txt`.cwd(testRepoDir).quiet();
+		await $`git commit -m "initial commit"`.cwd(testRepoDir).quiet();
+
+		// Create and checkout a branch
+		await $`git checkout -b feature-branch`.cwd(testRepoDir).quiet();
+		await fs.writeFile(path.join(testRepoDir, "file2.txt"), "hello feature");
+		await $`git add file2.txt`.cwd(testRepoDir).quiet();
+		await $`git commit -m "feature commit"`.cwd(testRepoDir).quiet();
+
+		// Let's test the git utilities on this repo
+		const repository = await git.repo.resolve(testRepoDir);
+		expect(repository).not.toBeNull();
+
+		const currentBranch = await git.branch.current(testRepoDir);
+		expect(currentBranch).toBe("feature-branch");
+
+		const headSha = await git.head.sha(testRepoDir);
+		expect(headSha).not.toBeNull();
+		expect(headSha).toHaveLength(40);
+
+		// Resolve refs/heads/main and refs/heads/feature-branch
+		const mainSha = await git.ref.resolve(testRepoDir, "refs/heads/main");
+		const featureSha = await git.ref.resolve(testRepoDir, "refs/heads/feature-branch");
+		expect(mainSha).not.toBeNull();
+		expect(featureSha).not.toBeNull();
+		expect(mainSha).toHaveLength(40);
+		expect(featureSha).toHaveLength(40);
+		expect(featureSha).toBe(headSha);
+
+		// Test HEAD resolution (object shape)
+		const headState = await git.head.resolve(testRepoDir);
+		expect(headState).not.toBeNull();
+		expect(headState?.kind).toBe("ref");
+		expect((headState as any).branchName).toBe("feature-branch");
+		expect(headState?.commit).toBe(headSha);
+
+		// Test HEAD resolution sync
+		const headStateSync = git.head.resolveSync(testRepoDir);
+		expect(headStateSync).not.toBeNull();
+		expect(headStateSync?.kind).toBe("ref");
+		expect((headStateSync as any).branchName).toBe("feature-branch");
+		expect(headStateSync?.commit).toBe(headSha);
+
+		// Test exists check
+		const mainExists = await git.ref.exists(testRepoDir, "refs/heads/main");
+		const nonexistentExists = await git.ref.exists(testRepoDir, "refs/heads/nonexistent");
+		expect(mainExists).toBe(true);
+		expect(nonexistentExists).toBe(false);
+	});
+});

--- a/packages/coding-agent/test/git-reftable.test.ts
+++ b/packages/coding-agent/test/git-reftable.test.ts
@@ -1,15 +1,18 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import * as fs from "node:fs/promises";
+import * as os from "node:os";
 import * as path from "node:path";
 import { $ } from "bun";
 import * as git from "../src/utils/git";
 
-describe("git reftable support", () => {
+const gitInitHelp = await $`git init -h`.quiet().nothrow().text();
+const supportsReftable = gitInitHelp.includes("--ref-format");
+
+describe.skipIf(!supportsReftable)("git reftable support", () => {
 	let testRepoDir: string;
 
 	beforeEach(async () => {
-		testRepoDir = path.join(import.meta.dir, `tmp-reftable-test-${Date.now()}`);
-		await fs.mkdir(testRepoDir, { recursive: true });
+		testRepoDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-reftable-"));
 	});
 
 	afterEach(async () => {
@@ -18,15 +21,8 @@ describe("git reftable support", () => {
 
 	test("resolves references in a reftable repository", async () => {
 		// Initialize the repository with reftable format
-		const initResult = await $`git init --ref-format=reftable --initial-branch=main`
-			.cwd(testRepoDir)
-			.quiet()
-			.nothrow();
-		if (initResult.exitCode !== 0) {
-			// If the installed git doesn't support --ref-format=reftable, skip the test
-			console.warn("Skipping reftable test: Git does not support --ref-format=reftable");
-			return;
-		}
+		const initResult = await $`git init --ref-format=reftable --initial-branch=main`.cwd(testRepoDir).quiet();
+		expect(initResult.exitCode).toBe(0);
 
 		// Configure basic user details so we can commit
 		await $`git config user.name "Test User"`.cwd(testRepoDir).quiet();
@@ -66,21 +62,73 @@ describe("git reftable support", () => {
 		// Test HEAD resolution (object shape)
 		const headState = await git.head.resolve(testRepoDir);
 		expect(headState).not.toBeNull();
-		expect(headState?.kind).toBe("ref");
-		expect((headState as any).branchName).toBe("feature-branch");
-		expect(headState?.commit).toBe(headSha);
+		if (headState?.kind !== "ref") throw new Error("expected ref head");
+		expect(headState.branchName).toBe("feature-branch");
+		expect(headState.commit).toBe(headSha);
 
 		// Test HEAD resolution sync
 		const headStateSync = git.head.resolveSync(testRepoDir);
 		expect(headStateSync).not.toBeNull();
-		expect(headStateSync?.kind).toBe("ref");
-		expect((headStateSync as any).branchName).toBe("feature-branch");
-		expect(headStateSync?.commit).toBe(headSha);
+		if (headStateSync?.kind !== "ref") throw new Error("expected ref head sync");
+		expect(headStateSync.branchName).toBe("feature-branch");
+		expect(headStateSync.commit).toBe(headSha);
 
 		// Test exists check
 		const mainExists = await git.ref.exists(testRepoDir, "refs/heads/main");
 		const nonexistentExists = await git.ref.exists(testRepoDir, "refs/heads/nonexistent");
 		expect(mainExists).toBe(true);
 		expect(nonexistentExists).toBe(false);
+	});
+
+	test("handles git config trailing comments correctly", async () => {
+		// Initialize the repository with reftable format
+		const initResult = await $`git init --ref-format=reftable --initial-branch=main`.cwd(testRepoDir).quiet();
+		expect(initResult.exitCode).toBe(0);
+
+		const repository = await git.repo.resolve(testRepoDir);
+		expect(repository).not.toBeNull();
+		if (!repository) return;
+		expect(await git.repo.isReftable(repository)).toBe(true);
+
+		// Now let's manually write to .git/config with comments and test
+		const configPath = path.join(repository.commonDir, "config");
+		const baseConfig = await fs.readFile(configPath, "utf8");
+
+		// Test trailing semicolon comment
+		const newConfigWithSemicolon = baseConfig.replace(
+			"refstorage = reftable",
+			"refstorage = reftable ; trailing comment",
+		);
+		await fs.writeFile(configPath, newConfigWithSemicolon);
+
+		const repository2 = await git.repo.resolve(testRepoDir);
+		expect(repository2).not.toBeNull();
+		if (repository2) {
+			expect(await git.repo.isReftable(repository2)).toBe(true);
+			expect(git.repo.isReftableSync(repository2)).toBe(true);
+		}
+
+		// Test trailing hash comment
+		const newConfigWithHash = baseConfig.replace("refstorage = reftable", "refstorage = reftable # trailing hash");
+		await fs.writeFile(configPath, newConfigWithHash);
+
+		const repository3 = await git.repo.resolve(testRepoDir);
+		expect(repository3).not.toBeNull();
+		if (repository3) {
+			expect(await git.repo.isReftable(repository3)).toBe(true);
+			expect(git.repo.isReftableSync(repository3)).toBe(true);
+		}
+
+		// Test double-quoted value containing semicolon (not a comment)
+		const newConfigWithQuotes = baseConfig.replace("refstorage = reftable", 'refstorage = "reftable ; not comment"');
+		await fs.writeFile(configPath, newConfigWithQuotes);
+
+		const repository4 = await git.repo.resolve(testRepoDir);
+		expect(repository4).not.toBeNull();
+		if (repository4) {
+			// This value would be "reftable ; not comment", which shouldn't match "reftable"
+			expect(await git.repo.isReftable(repository4)).toBe(false);
+			expect(git.repo.isReftableSync(repository4)).toBe(false);
+		}
 	});
 });

--- a/packages/coding-agent/test/git-reftable.test.ts
+++ b/packages/coding-agent/test/git-reftable.test.ts
@@ -158,6 +158,20 @@ describe.skipIf(!supportsReftable)("git reftable support", () => {
 			expect(await git.repo.isReftable(repository6)).toBe(true);
 			expect(git.repo.isReftableSync(repository6)).toBe(true);
 		}
+
+		// Test section header with trailing comment
+		const newConfigWithSectionComment = baseConfig.replace(
+			"[extensions]",
+			"[extensions] # extensions section comment",
+		);
+		await fs.writeFile(configPath, newConfigWithSectionComment);
+
+		const repository7 = await git.repo.resolve(testRepoDir);
+		expect(repository7).not.toBeNull();
+		if (repository7) {
+			expect(await git.repo.isReftable(repository7)).toBe(true);
+			expect(git.repo.isReftableSync(repository7)).toBe(true);
+		}
 	});
 
 	test("resolves references in a reftable worktree", async () => {

--- a/packages/coding-agent/test/git-reftable.test.ts
+++ b/packages/coding-agent/test/git-reftable.test.ts
@@ -18,7 +18,10 @@ describe("git reftable support", () => {
 
 	test("resolves references in a reftable repository", async () => {
 		// Initialize the repository with reftable format
-		const initResult = await $`git init --ref-format=reftable`.cwd(testRepoDir).quiet().nothrow();
+		const initResult = await $`git init --ref-format=reftable --initial-branch=main`
+			.cwd(testRepoDir)
+			.quiet()
+			.nothrow();
 		if (initResult.exitCode !== 0) {
 			// If the installed git doesn't support --ref-format=reftable, skip the test
 			console.warn("Skipping reftable test: Git does not support --ref-format=reftable");


### PR DESCRIPTION
## What

add support for repositories using the git reftable format by shelling out to git when detected as the git libraries used don't support it yet.

## Why

Reftable will be the default in git 3.0

## Testing

Locally

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
