### PR TITLE
feat(coding-agent): add provider setup command

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -433,6 +433,10 @@
 - Fixed the `todo` and `job` tools rendering a success icon and success styling on a failed/error result; error results now show the error icon and a red frame border.
 - Fixed `debug` tool refusing every `dlv` launch on Go modules. The launch handler ran `validateLaunchProgram` before adapter selection and rejected any directory program with `launch program resolves to a directory`, while dlv's default `mode=debug` requires a Go package path (a directory or `.go` source file). Adapter resolution now precedes validation, directory programs prefer adapters that advertise `acceptsDirectoryProgram` before falling back to native extensionless debuggers, the rejection only fires when the resolved adapter does not advertise that flag (set on `dlv` in `dap/defaults.json`), and dlv's `mode` is derived from the program shape — directories and `.go` files launch as `mode=debug`, other files as `mode=exec` — so `omp` can debug both Go packages and pre-built binaries ([#2020](https://github.com/can1357/oh-my-pi/issues/2020)).
 
+### Added
+
+- Added `/setup providers` (also available as `/setup` or `/providers`) to reopen the interactive provider setup scene from an active TUI session, letting users sign in and choose a web search provider without rerunning the full onboarding flow.
+
 ## [15.10.0] - 2026-06-06
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -123,6 +123,7 @@ import {
 } from "./loop-limit";
 import { OAuthManualInputManager } from "./oauth-manual-input";
 import { SessionObserverRegistry } from "./session-observer-registry";
+import { runProviderSetupWizard } from "./setup-wizard/lazy";
 import { interruptHint } from "./shared";
 import { type ShimmerPalette, shimmerEnabled, shimmerSegments, shimmerText } from "./theme/shimmer";
 import type { Theme } from "./theme/theme";
@@ -3151,6 +3152,10 @@ export class InteractiveMode implements InteractiveModeContext {
 
 	showOAuthSelector(mode: "login" | "logout", providerId?: string): Promise<void> {
 		return this.#selectorController.showOAuthSelector(mode, providerId);
+	}
+
+	showProviderSetup(): Promise<void> {
+		return runProviderSetupWizard(this);
 	}
 
 	showHookConfirm(title: string, message: string): Promise<boolean> {

--- a/packages/coding-agent/src/modes/setup-wizard/index.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/index.ts
@@ -65,9 +65,15 @@ export async function markSetupWizardComplete(
 	await settings.flush();
 }
 
+export interface RunSetupWizardOptions {
+	markComplete?: boolean;
+	playWelcomeIntro?: boolean;
+}
+
 export async function runSetupWizard(
 	ctx: InteractiveModeContext,
 	scenes: readonly SetupScene[] = ALL_SCENES,
+	options: RunSetupWizardOptions = {},
 ): Promise<void> {
 	if (scenes.length === 0) return;
 	const component = new SetupWizardComponent(ctx, scenes);
@@ -79,11 +85,15 @@ export async function runSetupWizard(
 	});
 	try {
 		await component.run();
-		await markSetupWizardComplete(ctx.settings);
+		if (options.markComplete !== false) {
+			await markSetupWizardComplete(ctx.settings);
+		}
 	} finally {
 		component.dispose();
 		ctx.ui.setFocus(component);
 		overlay.hide();
 	}
-	ctx.playWelcomeIntro();
+	if (options.playWelcomeIntro !== false) {
+		ctx.playWelcomeIntro();
+	}
 }

--- a/packages/coding-agent/src/modes/setup-wizard/lazy.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/lazy.ts
@@ -1,0 +1,14 @@
+import type { InteractiveModeContext } from "../types";
+
+export async function runProviderSetupWizard(ctx: InteractiveModeContext): Promise<void> {
+	const { ALL_SCENES, runSetupWizard } = await import("./index");
+	const providersScene = ALL_SCENES.find(scene => scene.id === "providers");
+	if (!providersScene) {
+		ctx.showError("Provider setup is unavailable.");
+		return;
+	}
+	await runSetupWizard(ctx, [providersScene], {
+		markComplete: false,
+		playWelcomeIntro: false,
+	});
+}

--- a/packages/coding-agent/src/modes/setup-wizard/lazy.ts
+++ b/packages/coding-agent/src/modes/setup-wizard/lazy.ts
@@ -1,6 +1,8 @@
 import type { InteractiveModeContext } from "../types";
 
 export async function runProviderSetupWizard(ctx: InteractiveModeContext): Promise<void> {
+	// Keep the full setup wizard behind the existing cold-start boundary; a static
+	// import here would load provider/OAuth/search/theme setup deps on every TUI startup.
 	const { ALL_SCENES, runSetupWizard } = await import("./index");
 	const providersScene = ALL_SCENES.find(scene => scene.id === "providers");
 	if (!providersScene) {

--- a/packages/coding-agent/src/modes/types.ts
+++ b/packages/coding-agent/src/modes/types.ts
@@ -288,6 +288,7 @@ export interface InteractiveModeContext {
 	handleResumeSession(sessionPath: string): Promise<void>;
 	handleSessionDeleteCommand(): Promise<void>;
 	showOAuthSelector(mode: "login" | "logout", providerId?: string): Promise<void>;
+	showProviderSetup(): Promise<void>;
 	showHookConfirm(title: string, message: string): Promise<boolean>;
 	showDebugSelector(): Promise<void>;
 	showSessionObserver(): void;

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -83,6 +83,24 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		},
 	},
 	{
+		name: "setup",
+		aliases: ["providers"],
+		description: "Open provider setup",
+		inlineHint: "[providers]",
+		allowArgs: true,
+		subcommands: [{ name: "providers", description: "Configure sign-in and web search providers" }],
+		handleTui: async (command, runtime) => {
+			const args = command.args.trim().toLowerCase();
+			const opensProviders = args === "" || args === "providers";
+			if (opensProviders) {
+				await runtime.ctx.showProviderSetup();
+			} else {
+				runtime.ctx.showWarning("Usage: /setup [providers]");
+			}
+			runtime.ctx.editor.setText("");
+		},
+	},
+	{
 		name: "plan",
 		description: "Toggle plan mode (agent plans before executing)",
 		inlineHint: "[prompt]",
@@ -1701,6 +1719,7 @@ for (const command of BUILTIN_SLASH_COMMAND_REGISTRY) {
 export const BUILTIN_SLASH_COMMAND_DEFS: ReadonlyArray<BuiltinSlashCommand> = BUILTIN_SLASH_COMMAND_REGISTRY.map(
 	command => ({
 		name: command.name,
+		aliases: command.aliases,
 		description: command.description,
 		subcommands: command.subcommands,
 		inlineHint: command.inlineHint,

--- a/packages/coding-agent/src/slash-commands/builtin-registry.ts
+++ b/packages/coding-agent/src/slash-commands/builtin-registry.ts
@@ -86,7 +86,6 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 		name: "setup",
 		aliases: ["providers"],
 		description: "Open provider setup",
-		inlineHint: "[providers]",
 		allowArgs: true,
 		subcommands: [{ name: "providers", description: "Configure sign-in and web search providers" }],
 		handleTui: async (command, runtime) => {
@@ -95,7 +94,7 @@ const BUILTIN_SLASH_COMMAND_REGISTRY: ReadonlyArray<SlashCommandSpec> = [
 			if (opensProviders) {
 				await runtime.ctx.showProviderSetup();
 			} else {
-				runtime.ctx.showWarning("Usage: /setup [providers]");
+				runtime.ctx.showWarning(`Usage: /${command.name} [providers]`);
 			}
 			runtime.ctx.editor.setText("");
 		},

--- a/packages/coding-agent/src/slash-commands/types.ts
+++ b/packages/coding-agent/src/slash-commands/types.ts
@@ -14,6 +14,7 @@ export interface SubcommandDef {
 /** Declarative builtin slash command metadata used by autocomplete and help UI. */
 export interface BuiltinSlashCommand {
 	name: string;
+	aliases?: string[];
 	description: string;
 	/** Subcommands for dropdown completion (e.g. /mcp add, /mcp list). */
 	subcommands?: SubcommandDef[];
@@ -82,7 +83,6 @@ export interface TuiSlashCommandRuntime {
 
 /** Unified slash-command spec consumed by both TUI and ACP dispatchers. */
 export interface SlashCommandSpec extends BuiltinSlashCommand {
-	aliases?: string[];
 	/** When false, the dispatcher refuses to handle invocations that include arguments. */
 	allowArgs?: boolean;
 	/**

--- a/packages/coding-agent/test/setup-wizard.test.ts
+++ b/packages/coding-agent/test/setup-wizard.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, mock } from "bun:test";
 import { runOnboardingSetup } from "@oh-my-pi/pi-coding-agent/commands/setup";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { SETTINGS_SCHEMA } from "@oh-my-pi/pi-coding-agent/config/settings-schema";
@@ -6,11 +6,13 @@ import {
 	ALL_SCENES,
 	CURRENT_SETUP_VERSION,
 	markSetupWizardComplete,
+	runSetupWizard,
 	type SetupScene,
 	type SetupSceneHost,
 	selectSetupScenes,
 } from "@oh-my-pi/pi-coding-agent/modes/setup-wizard";
 import { WebSearchTab } from "@oh-my-pi/pi-coding-agent/modes/setup-wizard/scenes/web-search";
+import type { SetupWizardComponent } from "@oh-my-pi/pi-coding-agent/modes/setup-wizard/wizard-overlay";
 import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
 import { SEARCH_PROVIDER_OPTIONS, SEARCH_PROVIDER_PREFERENCES } from "@oh-my-pi/pi-coding-agent/web/search/types";
@@ -113,6 +115,49 @@ describe("setup wizard persistence", () => {
 		const settings = Settings.isolated();
 		await markSetupWizardComplete(settings);
 		expect(settings.get("setupVersion")).toBe(CURRENT_SETUP_VERSION);
+	});
+
+	it("can run a targeted scene without setup-version or welcome-intro side effects", async () => {
+		const settings = Settings.isolated({ setupVersion: 0 });
+		const hideOverlay = mock(() => {});
+		const setFocus = mock((_component: unknown) => {});
+		const requestRender = mock(() => {});
+		const playWelcomeIntro = mock(() => {});
+		let component: SetupWizardComponent | undefined;
+		const scene: SetupScene = {
+			id: "providers",
+			title: "providers",
+			minVersion: 1,
+			mount: host => ({
+				title: "providers",
+				onMount: () => host.finish("done"),
+				render: () => [],
+				invalidate: () => {},
+			}),
+		};
+		const ctx = {
+			settings,
+			playWelcomeIntro,
+			ui: {
+				terminal: { rows: 24 },
+				showOverlay: (nextComponent: SetupWizardComponent) => {
+					component = nextComponent;
+					return { hide: hideOverlay };
+				},
+				setFocus,
+				requestRender,
+			},
+		} as unknown as InteractiveModeContext;
+
+		const pending = runSetupWizard(ctx, [scene], { markComplete: false, playWelcomeIntro: false });
+		component?.handleInput?.("\n");
+		component?.handleInput?.("\n");
+		await pending;
+
+		expect(settings.get("setupVersion")).toBe(0);
+		expect(playWelcomeIntro).not.toHaveBeenCalled();
+		expect(hideOverlay).toHaveBeenCalledTimes(1);
+		expect(setFocus).toHaveBeenCalled();
 	});
 });
 

--- a/packages/coding-agent/test/slash-commands/setup.test.ts
+++ b/packages/coding-agent/test/slash-commands/setup.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "bun:test";
+import type { InteractiveModeContext } from "@oh-my-pi/pi-coding-agent/modes/types";
+import {
+	BUILTIN_SLASH_COMMAND_DEFS,
+	executeBuiltinSlashCommand,
+} from "@oh-my-pi/pi-coding-agent/slash-commands/builtin-registry";
+
+function createRuntime() {
+	const showProviderSetup = vi.fn(async () => {});
+	const showWarning = vi.fn();
+	const setText = vi.fn();
+	return {
+		showProviderSetup,
+		showWarning,
+		setText,
+		runtime: {
+			ctx: {
+				editor: { setText } as unknown as InteractiveModeContext["editor"],
+				showProviderSetup,
+				showWarning,
+			} as unknown as InteractiveModeContext,
+			handleBackgroundCommand: () => {},
+		},
+	};
+}
+
+describe("/setup slash command", () => {
+	it("exposes the providers alias to slash command autocomplete", () => {
+		const setupCommand = BUILTIN_SLASH_COMMAND_DEFS.find(command => command.name === "setup");
+		expect(setupCommand?.aliases).toContain("providers");
+	});
+
+	it("opens provider setup for /setup", async () => {
+		const harness = createRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/setup", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.showProviderSetup).toHaveBeenCalledTimes(1);
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("opens provider setup for /setup providers", async () => {
+		const harness = createRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/setup providers", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.showProviderSetup).toHaveBeenCalledTimes(1);
+		expect(harness.showWarning).not.toHaveBeenCalled();
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("opens provider setup through the /providers alias", async () => {
+		const harness = createRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/providers", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.showProviderSetup).toHaveBeenCalledTimes(1);
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+
+	it("shows usage for unsupported setup scenes", async () => {
+		const harness = createRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/setup theme", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.showProviderSetup).not.toHaveBeenCalled();
+		expect(harness.showWarning).toHaveBeenCalledWith("Usage: /setup [providers]");
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
+});

--- a/packages/coding-agent/test/slash-commands/setup.test.ts
+++ b/packages/coding-agent/test/slash-commands/setup.test.ts
@@ -71,4 +71,15 @@ describe("/setup slash command", () => {
 		expect(harness.showWarning).toHaveBeenCalledWith("Usage: /setup [providers]");
 		expect(harness.setText).toHaveBeenCalledWith("");
 	});
+
+	it("shows alias-specific usage for unsupported providers alias arguments", async () => {
+		const harness = createRuntime();
+
+		const handled = await executeBuiltinSlashCommand("/providers theme", harness.runtime);
+
+		expect(handled).toBe(true);
+		expect(harness.showProviderSetup).not.toHaveBeenCalled();
+		expect(harness.showWarning).toHaveBeenCalledWith("Usage: /providers [providers]");
+		expect(harness.setText).toHaveBeenCalledWith("");
+	});
 });

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -231,7 +231,11 @@ function commandMatchesNameOrAlias(cmd: CommandEntry, commandName: string): bool
 function scoreCommandTextMatch(lowerPrefix: string, lowerTarget: string): number {
 	if (lowerPrefix.length === 0) return 1;
 	if (lowerPrefix === lowerTarget) return 1000;
-	if (lowerTarget.startsWith(lowerPrefix)) return 900 - Math.max(0, lowerTarget.length - lowerPrefix.length);
+	// Flat score for every prefix match so same-prefix commands keep registry
+	// order under the stable sort. A length penalty here would rank the shorter
+	// name first (e.g. `/set` → `setup` above `settings`), silently changing the
+	// command that the sync-completion path applies on Enter.
+	if (lowerTarget.startsWith(lowerPrefix)) return 900;
 	return fuzzyMatch(lowerPrefix, lowerTarget) ? fuzzyScore(lowerPrefix, lowerTarget) : 0;
 }
 

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -160,6 +160,7 @@ type Awaitable<T> = T | Promise<T>;
 
 export interface SlashCommand {
 	name: string;
+	aliases?: string[];
 	description?: string;
 	argumentHint?: string;
 	// Function to get argument completions for this command
@@ -210,9 +211,75 @@ export interface AutocompleteProvider {
 	trySyncInlineReplace?(textBeforeCursor: string): { replaceLen: number; insert: string } | null;
 }
 
+type CommandEntry = SlashCommand | AutocompleteItem;
+
+function getCommandName(cmd: CommandEntry): string | undefined {
+	return "name" in cmd ? cmd.name : cmd.value;
+}
+
+function getCommandAliases(cmd: CommandEntry): string[] {
+	if (!("aliases" in cmd) || !Array.isArray(cmd.aliases)) return [];
+	return cmd.aliases.filter(alias => typeof alias === "string" && alias.length > 0);
+}
+
+function commandMatchesNameOrAlias(cmd: CommandEntry, commandName: string): boolean {
+	const name = getCommandName(cmd);
+	if (name === commandName) return true;
+	return getCommandAliases(cmd).includes(commandName);
+}
+
+function scoreCommandTextMatch(lowerPrefix: string, lowerTarget: string): number {
+	if (lowerPrefix.length === 0) return 1;
+	if (lowerPrefix === lowerTarget) return 1000;
+	if (lowerTarget.startsWith(lowerPrefix)) return 900 - Math.max(0, lowerTarget.length - lowerPrefix.length);
+	return fuzzyMatch(lowerPrefix, lowerTarget) ? fuzzyScore(lowerPrefix, lowerTarget) : 0;
+}
+
+function buildSlashCommandCompletions(commands: CommandEntry[], lowerPrefix: string): AutocompleteItem[] {
+	return commands
+		.flatMap(cmd => {
+			const name = getCommandName(cmd);
+			if (!name) return [];
+			const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
+			const desc = cmd.description ?? "";
+			const fullDesc = hint ? (desc ? `${hint} — ${desc}` : hint) : desc;
+			const candidates: Array<AutocompleteItem & { score: number }> = [];
+
+			const nameScore = scoreCommandTextMatch(lowerPrefix, name.toLowerCase());
+			const lowerDesc = desc.toLowerCase();
+			const descScore =
+				lowerDesc && fuzzyMatch(lowerPrefix, lowerDesc) ? fuzzyScore(lowerPrefix, lowerDesc) * 0.5 : 0;
+			const primaryScore = Math.max(nameScore, descScore);
+			if (primaryScore > 0) {
+				candidates.push({
+					value: name,
+					label: "name" in cmd ? cmd.name : cmd.label,
+					score: primaryScore,
+					...(fullDesc && { description: fullDesc }),
+				});
+			}
+
+			for (const alias of getCommandAliases(cmd)) {
+				if (alias === name) continue;
+				const aliasScore = scoreCommandTextMatch(lowerPrefix, alias.toLowerCase());
+				if (aliasScore === 0) continue;
+				candidates.push({
+					value: alias,
+					label: alias,
+					score: aliasScore,
+					...(fullDesc && { description: fullDesc }),
+				});
+			}
+
+			return candidates;
+		})
+		.sort((a, b) => b.score - a.score)
+		.map(({ score: _, ...rest }) => rest);
+}
+
 // Combined provider that handles both slash commands and file paths.
 export class CombinedAutocompleteProvider implements AutocompleteProvider {
-	#commands: (SlashCommand | AutocompleteItem)[];
+	#commands: CommandEntry[];
 	#basePath: string;
 	// Intentionally separate from pi-natives cache: this cache is a local,
 	// per-directory readdir fast-path for prefix completions. Global fuzzy
@@ -220,7 +287,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 	#dirCache: Map<string, { entries: fs.Dirent[]; timestamp: number }> = new Map();
 	readonly #DIR_CACHE_TTL = 2000; // 2 seconds
 
-	constructor(commands: (SlashCommand | AutocompleteItem)[] = [], basePath: string = getProjectDir()) {
+	constructor(commands: CommandEntry[] = [], basePath: string = getProjectDir()) {
 		this.#commands = commands;
 		this.#basePath = basePath;
 	}
@@ -274,35 +341,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				const prefix = textBeforeCursor.slice(1); // Remove the "/"
 				const lowerPrefix = prefix.toLowerCase();
 
-				// Filter commands using fuzzy matching (subsequence match)
-				const matches = this.#commands
-					.filter(cmd => {
-						const name = "name" in cmd ? cmd.name : cmd.value;
-						if (!name) return false;
-						// Match name or description
-						if (fuzzyMatch(lowerPrefix, name.toLowerCase())) return true;
-						const desc = cmd.description?.toLowerCase();
-						return desc ? fuzzyMatch(lowerPrefix, desc) : false;
-					})
-					.map(cmd => {
-						const name = "name" in cmd ? cmd.name : cmd.value;
-						const lowerName = name?.toLowerCase() ?? "";
-						const lowerDesc = cmd.description?.toLowerCase() ?? "";
-						// Score name matches higher than description matches
-						const nameScore = fuzzyMatch(lowerPrefix, lowerName) ? fuzzyScore(lowerPrefix, lowerName) : 0;
-						const descScore = fuzzyMatch(lowerPrefix, lowerDesc) ? fuzzyScore(lowerPrefix, lowerDesc) * 0.5 : 0;
-						const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
-						const desc = cmd.description ?? "";
-						const fullDesc = hint ? (desc ? `${hint} — ${desc}` : hint) : desc;
-						return {
-							value: name,
-							label: "name" in cmd ? cmd.name : cmd.label,
-							score: Math.max(nameScore, descScore),
-							...(fullDesc && { description: fullDesc }),
-						};
-					})
-					.sort((a, b) => b.score - a.score)
-					.map(({ score: _, ...rest }) => rest);
+				const matches = buildSlashCommandCompletions(this.#commands, lowerPrefix);
 
 				if (matches.length === 0) return null;
 
@@ -315,10 +354,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 				const commandName = textBeforeCursor.slice(1, spaceIndex); // Command without "/"
 				const argumentText = textBeforeCursor.slice(spaceIndex + 1); // Text after space
 
-				const command = this.#commands.find(cmd => {
-					const name = "name" in cmd ? cmd.name : cmd.value;
-					return name === commandName;
-				});
+				const command = this.#commands.find(cmd => commandMatchesNameOrAlias(cmd, commandName));
 				if (!command || !("getArgumentCompletions" in command) || !command.getArgumentCompletions) {
 					return null; // No argument completion for this command
 				}
@@ -819,10 +855,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const commandName = textBeforeCursor.slice(1, spaceIndex);
 		const argumentText = textBeforeCursor.slice(spaceIndex + 1);
 
-		const command = this.#commands.find(cmd => {
-			const name = "name" in cmd ? cmd.name : cmd.value;
-			return name === commandName;
-		});
+		const command = this.#commands.find(cmd => commandMatchesNameOrAlias(cmd, commandName));
 
 		if (!command || !("getInlineHint" in command) || !command.getInlineHint) {
 			return null;
@@ -838,32 +871,7 @@ export class CombinedAutocompleteProvider implements AutocompleteProvider {
 		const prefix = textBeforeCursor.slice(1);
 		const lowerPrefix = prefix.toLowerCase();
 
-		const matches = this.#commands
-			.filter(cmd => {
-				const name = "name" in cmd ? cmd.name : cmd.value;
-				if (!name) return false;
-				if (fuzzyMatch(lowerPrefix, name.toLowerCase())) return true;
-				const desc = cmd.description?.toLowerCase();
-				return desc ? fuzzyMatch(lowerPrefix, desc) : false;
-			})
-			.map(cmd => {
-				const name = "name" in cmd ? cmd.name : cmd.value;
-				const lowerName = name?.toLowerCase() ?? "";
-				const lowerDesc = cmd.description?.toLowerCase() ?? "";
-				const nameScore = fuzzyMatch(lowerPrefix, lowerName) ? fuzzyScore(lowerPrefix, lowerName) : 0;
-				const descScore = fuzzyMatch(lowerPrefix, lowerDesc) ? fuzzyScore(lowerPrefix, lowerDesc) * 0.5 : 0;
-				const hint = "argumentHint" in cmd && cmd.argumentHint ? cmd.argumentHint : undefined;
-				const desc = cmd.description ?? "";
-				const fullDesc = hint ? (desc ? `${hint} — ${desc}` : hint) : desc;
-				return {
-					value: name,
-					label: "name" in cmd ? cmd.name : cmd.label,
-					score: Math.max(nameScore, descScore),
-					...(fullDesc && { description: fullDesc }),
-				} as AutocompleteItem & { score: number };
-			})
-			.sort((a, b) => b.score - a.score)
-			.map(({ score: _, ...rest }) => rest);
+		const matches = buildSlashCommandCompletions(this.#commands, lowerPrefix);
 
 		if (matches.length === 0) return null;
 		return { items: matches, prefix: textBeforeCursor };

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -259,16 +259,18 @@ function buildSlashCommandCompletions(commands: CommandEntry[], lowerPrefix: str
 				});
 			}
 
-			for (const alias of getCommandAliases(cmd)) {
-				if (alias === name) continue;
-				const aliasScore = scoreCommandTextMatch(lowerPrefix, alias.toLowerCase());
-				if (aliasScore === 0) continue;
-				candidates.push({
-					value: alias,
-					label: alias,
-					score: aliasScore,
-					...(fullDesc && { description: fullDesc }),
-				});
+			if (lowerPrefix.length > 0) {
+				for (const alias of getCommandAliases(cmd)) {
+					if (alias === name) continue;
+					const aliasScore = scoreCommandTextMatch(lowerPrefix, alias.toLowerCase());
+					if (aliasScore === 0) continue;
+					candidates.push({
+						value: alias,
+						label: alias,
+						score: aliasScore,
+						...(fullDesc && { description: fullDesc }),
+					});
+				}
 			}
 
 			return candidates;

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -292,6 +292,19 @@ describe("trySyncSlashCompletion", () => {
 		expect(result!.items.map(i => i.value)).toEqual(["model"]);
 	});
 
+	it("does not list aliases as separate rows for bare slash suggestions", async () => {
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{ name: "setup", aliases: ["providers"], description: "Open provider setup" },
+				{ name: "usage", description: "Show provider usage and limits" },
+			],
+			"/tmp",
+		);
+		const result = await provider.getSuggestions(["/"], 0, 1);
+		expect(result).not.toBeNull();
+		expect(result!.items.map(i => i.value)).toEqual(["setup", "usage"]);
+	});
+
 	it("prefers exact command aliases over fuzzy description matches", () => {
 		const provider = new CombinedAutocompleteProvider(
 			[

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -305,6 +305,21 @@ describe("trySyncSlashCompletion", () => {
 		expect(result!.items.map(i => i.value)).toEqual(["setup", "usage"]);
 	});
 
+	it("keeps registry order for same-prefix commands so /set still applies settings", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{ name: "settings", description: "Open settings menu", value: "settings" },
+				{ name: "setup", description: "Open provider setup", value: "setup" },
+			],
+			"/tmp",
+		);
+		const result = provider.trySyncSlashCompletion("/set");
+		expect(result).not.toBeNull();
+		// The sync-completion path applies items[0] on Enter; the shorter `setup`
+		// must not jump ahead of the earlier-registered `settings`.
+		expect(result!.items[0]?.value).toBe("settings");
+	});
+
 	it("prefers exact command aliases over fuzzy description matches", () => {
 		const provider = new CombinedAutocompleteProvider(
 			[

--- a/packages/tui/test/autocomplete.test.ts
+++ b/packages/tui/test/autocomplete.test.ts
@@ -291,4 +291,47 @@ describe("trySyncSlashCompletion", () => {
 		expect(result).not.toBeNull();
 		expect(result!.items.map(i => i.value)).toEqual(["model"]);
 	});
+
+	it("prefers exact command aliases over fuzzy description matches", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{ name: "setup", aliases: ["providers"], description: "Open provider setup" },
+				{ name: "usage", description: "Show provider usage and limits" },
+			],
+			"/tmp",
+		);
+		const result = provider.trySyncSlashCompletion("/providers");
+		expect(result).not.toBeNull();
+		expect(result!.items[0]?.value).toBe("providers");
+	});
+
+	it("uses aliases when completing slash command arguments", async () => {
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{
+					name: "setup",
+					aliases: ["onboarding"],
+					getArgumentCompletions: prefix =>
+						"providers".startsWith(prefix) ? [{ value: "providers ", label: "providers" }] : null,
+				},
+			],
+			"/tmp",
+		);
+		const result = await provider.getSuggestions(["/onboarding pro"], 0, "/onboarding pro".length);
+		expect(result?.items.map(i => i.value)).toEqual(["providers "]);
+	});
+
+	it("uses aliases when rendering inline slash command hints", () => {
+		const provider = new CombinedAutocompleteProvider(
+			[
+				{
+					name: "setup",
+					aliases: ["onboarding"],
+					getInlineHint: argumentText => (argumentText === "pro" ? "viders" : null),
+				},
+			],
+			"/tmp",
+		);
+		expect(provider.getInlineHint(["/onboarding pro"], 0, "/onboarding pro".length)).toBe("viders");
+	});
 });


### PR DESCRIPTION
## What

- Added a TUI-only `/setup` slash command that opens the existing provider setup scene.
- Supported `/setup`, `/setup providers`, and `/providers` so users can reopen sign-in and web-search provider setup after onboarding.
- Kept the setup wizard lazy-loaded by adding a targeted provider-setup loader instead of importing the full setup wizard on normal startup.
- Preserved setup-version and welcome-intro side effects when reopening only the providers scene.
- Made slash-command autocomplete alias-aware so `/providers` does not get fuzzy-completed into `/usage`.

## Why

Fixes #1921.

Repro: after the initial onboarding provider setup is dismissed, an active TUI session had no interactive way to reopen the web-search provider configuration.

Cause: the provider scene already existed inside the setup wizard, but the interactive context exposed no command path back to that scene. During manual TUI validation, the `/providers` alias also exposed a separate autocomplete gap: builtin aliases were handled by the dispatcher but not advertised to the autocomplete provider, so quick Enter could pick `/usage` from a fuzzy description match.

Fix: route `/setup` and `/setup providers` through a targeted provider-scene runner, carry builtin aliases into slash-command metadata, and teach the TUI autocomplete provider to match aliases for command-name completion, sync completion, argument completion, and inline hints.

## Testing

- `bun --cwd=packages/tui test test/autocomplete.test.ts`
- `bun --cwd=packages/coding-agent test test/slash-commands/setup.test.ts test/setup-wizard.test.ts test/startup-import-graph.test.ts`
- `bun --cwd=packages/tui run check`
- `bun --cwd=packages/coding-agent run check`
- `bun check`
- `git diff --check`
- Manual TUI E2E with isolated `HOME` and `PI_CODING_AGENT_DIR`: launched `src/cli.ts` in a PTY and verified `/setup`, `/setup providers`, and `/providers` each opened the `Set up your providers` screen with the web-search setup subtitle.

---

- [x] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)