### PR TITLE
fix(debug): accept directory programs for dlv and auto-select dlv mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed `debug` tool refusing every `dlv` launch on Go modules. The launch handler ran `validateLaunchProgram` before adapter selection and rejected any directory program with `launch program resolves to a directory`, while dlv's default `mode=debug` requires a Go package path (a directory or `.go` source file). Adapter resolution now precedes validation, the rejection only fires when the resolved adapter does not advertise `acceptsDirectoryProgram` (set on `dlv` in `dap/defaults.json`), and dlv's `mode` is derived from the program shape — directories and `.go` files launch as `mode=debug`, other files as `mode=exec` — so `omp` can debug both Go packages and pre-built binaries ([#2020](https://github.com/can1357/oh-my-pi/issues/2020)).
+- Fixed `debug` tool refusing every `dlv` launch on Go modules. The launch handler ran `validateLaunchProgram` before adapter selection and rejected any directory program with `launch program resolves to a directory`, while dlv's default `mode=debug` requires a Go package path (a directory or `.go` source file). Adapter resolution now precedes validation, directory programs prefer adapters that advertise `acceptsDirectoryProgram` before falling back to native extensionless debuggers, the rejection only fires when the resolved adapter does not advertise that flag (set on `dlv` in `dap/defaults.json`), and dlv's `mode` is derived from the program shape — directories and `.go` files launch as `mode=debug`, other files as `mode=exec` — so `omp` can debug both Go packages and pre-built binaries ([#2020](https://github.com/can1357/oh-my-pi/issues/2020)).
 
 ## [15.10.0] - 2026-06-06
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `debug` tool refusing every `dlv` launch on Go modules. The launch handler ran `validateLaunchProgram` before adapter selection and rejected any directory program with `launch program resolves to a directory`, while dlv's default `mode=debug` requires a Go package path (a directory or `.go` source file). Adapter resolution now precedes validation, the rejection only fires when the resolved adapter does not advertise `acceptsDirectoryProgram` (set on `dlv` in `dap/defaults.json`), and dlv's `mode` is derived from the program shape — directories and `.go` files launch as `mode=debug`, other files as `mode=exec` — so `omp` can debug both Go packages and pre-built binaries ([#2020](https://github.com/can1357/oh-my-pi/issues/2020)).
+
 ## [15.10.0] - 2026-06-06
 
 ### Breaking Changes

--- a/packages/coding-agent/src/dap/config.ts
+++ b/packages/coding-agent/src/dap/config.ts
@@ -126,12 +126,19 @@ function sortAdaptersForLaunch(program: string, cwd: string, adapters: DapResolv
 	return rootAware.map(entry => entry.adapter);
 }
 
-export function selectLaunchAdapter(program: string, cwd: string, adapterName?: string): DapResolvedAdapter | null {
+export function selectLaunchAdapter(
+	program: string,
+	cwd: string,
+	adapterName?: string,
+	programKind: LaunchProgramKind = "file",
+): DapResolvedAdapter | null {
 	if (adapterName) {
 		return resolveAdapter(adapterName, cwd);
 	}
 	const matches = getMatchingAdapters(program, cwd);
-	const sorted = sortAdaptersForLaunch(program, cwd, matches);
+	const candidates =
+		programKind === "directory" ? matches.filter(adapter => adapter.acceptsDirectoryProgram) : matches;
+	const sorted = sortAdaptersForLaunch(program, cwd, candidates.length > 0 ? candidates : matches);
 	return sorted[0] ?? null;
 }
 

--- a/packages/coding-agent/src/dap/config.ts
+++ b/packages/coding-agent/src/dap/config.ts
@@ -27,6 +27,7 @@ function normalizeAdapterConfig(config: unknown): DapAdapterConfig | null {
 		rootMarkers: normalizeStringArray(config.rootMarkers),
 		launchDefaults: normalizeObject(config.launchDefaults),
 		attachDefaults: normalizeObject(config.attachDefaults),
+		acceptsDirectoryProgram: config.acceptsDirectoryProgram === true,
 		...(connectMode ? { connectMode } : {}),
 	};
 }
@@ -64,6 +65,7 @@ export function resolveAdapter(adapterName: string, cwd: string): DapResolvedAda
 		launchDefaults: config.launchDefaults ?? {},
 		attachDefaults: config.attachDefaults ?? {},
 		connectMode: config.connectMode ?? "stdio",
+		acceptsDirectoryProgram: config.acceptsDirectoryProgram === true,
 	};
 }
 
@@ -147,4 +149,34 @@ export function selectAttachAdapter(cwd: string, adapterName?: string, port?: nu
 		if (match) return match;
 	}
 	return available[0] ?? null;
+}
+
+/** How the launch `program` resolves on disk. `"missing"` is reserved for
+ *  programs the adapter creates on demand (rare); we treat them like files. */
+export type LaunchProgramKind = "file" | "directory" | "missing";
+
+/** Compute adapter-specific launch arguments that depend on the resolved
+ *  program. Returned values are spread over `adapter.launchDefaults` so they
+ *  take precedence over the static defaults but can still be overridden by
+ *  the fields `DapSessionManager.launch` sets explicitly (program, cwd, args).
+ *
+ *  Currently scoped to dlv, where `mode` selects how the program path is
+ *  interpreted: directories and `.go` source files debug as a Go package
+ *  (`mode=debug`), anything else is treated as a compiled binary (`mode=exec`).
+ */
+export function resolveLaunchOverrides(
+	adapter: DapResolvedAdapter,
+	program: string,
+	programKind: LaunchProgramKind,
+): Record<string, unknown> {
+	if (adapter.name === "dlv") {
+		const extension = path.extname(program).toLowerCase();
+		if (programKind === "directory" || extension === ".go") {
+			return { mode: "debug" };
+		}
+		if (programKind === "file") {
+			return { mode: "exec" };
+		}
+	}
+	return {};
 }

--- a/packages/coding-agent/src/dap/defaults.json
+++ b/packages/coding-agent/src/dap/defaults.json
@@ -65,6 +65,7 @@
 		"languages": ["go"],
 		"fileTypes": [".go"],
 		"rootMarkers": ["go.mod", "go.sum"],
+		"acceptsDirectoryProgram": true,
 		"launchDefaults": {
 			"request": "launch",
 			"mode": "debug",

--- a/packages/coding-agent/src/dap/session.ts
+++ b/packages/coding-agent/src/dap/session.ts
@@ -259,6 +259,7 @@ export class DapSessionManager {
 			session.needsConfigurationDone = session.capabilities.supportsConfigurationDoneRequest === true;
 			const launchArguments: DapLaunchArguments = {
 				...options.adapter.launchDefaults,
+				...(options.extraLaunchArguments ?? {}),
 				program: options.program,
 				cwd: options.cwd,
 				args: options.args,

--- a/packages/coding-agent/src/dap/types.ts
+++ b/packages/coding-agent/src/dap/types.ts
@@ -488,6 +488,10 @@ export interface DapAdapterConfig {
 	 *  On Linux, connects via a unix domain socket.
 	 *  On macOS, the adapter dials into a local TCP listener (--client-addr). */
 	connectMode?: "stdio" | "socket";
+	/** When true, the adapter accepts a directory as the launch `program`
+	 *  (e.g. dlv treats it as a Go package path). When false/undefined, the
+	 *  debug tool rejects directory programs upfront. */
+	acceptsDirectoryProgram?: boolean;
 }
 
 export interface DapResolvedAdapter {
@@ -501,6 +505,7 @@ export interface DapResolvedAdapter {
 	launchDefaults: Record<string, unknown>;
 	attachDefaults: Record<string, unknown>;
 	connectMode: "stdio" | "socket";
+	acceptsDirectoryProgram: boolean;
 }
 
 export interface DapBreakpointRecord {
@@ -589,6 +594,11 @@ export interface DapLaunchSessionOptions {
 	program: string;
 	args?: string[];
 	cwd: string;
+	/** Per-launch overrides merged over `adapter.launchDefaults`. Used to
+	 *  inject adapter-specific values that depend on the resolved program
+	 *  (e.g. dlv's `mode` switches between `debug` and `exec` based on
+	 *  whether `program` is a Go package path or a compiled binary). */
+	extraLaunchArguments?: Record<string, unknown>;
 }
 
 export interface DapAttachSessionOptions {

--- a/packages/coding-agent/src/tools/debug.ts
+++ b/packages/coding-agent/src/tools/debug.ts
@@ -687,7 +687,7 @@ export class DebugTool implements AgentTool<typeof debugSchema, DebugToolDetails
 				const commandCwd = params.cwd ? resolveToCwd(params.cwd, this.session.cwd) : this.session.cwd;
 				const program = resolveToCwd(params.program, commandCwd);
 				const programKind = await classifyLaunchProgram(program);
-				const adapter = selectLaunchAdapter(program, commandCwd, params.adapter);
+				const adapter = selectLaunchAdapter(program, commandCwd, params.adapter, programKind);
 				if (!adapter) {
 					if (params.adapter === "debugpy") {
 						throw new ToolError("adapter 'debugpy' is not available: python not found in PATH");

--- a/packages/coding-agent/src/tools/debug.ts
+++ b/packages/coding-agent/src/tools/debug.ts
@@ -22,6 +22,7 @@ import {
 	type DapFunctionBreakpointRecord,
 	type DapInstructionBreakpointRecord,
 	type DapModule,
+	type DapResolvedAdapter,
 	type DapScope,
 	type DapSessionSummary,
 	type DapSource,
@@ -30,6 +31,8 @@ import {
 	type DapVariable,
 	dapSessionManager,
 	getAvailableAdapters,
+	type LaunchProgramKind,
+	resolveLaunchOverrides,
 	selectAttachAdapter,
 	selectLaunchAdapter,
 } from "../dap";
@@ -489,16 +492,23 @@ function getConfiguredAdapters(cwd: string): string {
 	const adapters = getAvailableAdapters(cwd).map(adapter => adapter.name);
 	return adapters.length > 0 ? adapters.join(", ") : "none";
 }
-async function validateLaunchProgram(program: string, cwd: string): Promise<void> {
-	let isDirectory: boolean;
+
+async function classifyLaunchProgram(program: string): Promise<LaunchProgramKind> {
 	try {
-		isDirectory = (await fs.stat(program)).isDirectory();
+		return (await fs.stat(program)).isDirectory() ? "directory" : "file";
 	} catch (error) {
-		if (isEnoent(error)) return;
+		if (isEnoent(error)) return "missing";
 		throw error;
 	}
-	if (!isDirectory) return;
+}
 
+function validateLaunchProgram(
+	program: string,
+	cwd: string,
+	programKind: LaunchProgramKind,
+	adapter: DapResolvedAdapter,
+): void {
+	if (programKind !== "directory" || adapter.acceptsDirectoryProgram) return;
 	const displayPath = formatPathRelativeToCwd(program, cwd, { trailingSlash: true });
 	throw new ToolError(
 		`launch program resolves to a directory: ${displayPath}. Pass an executable file path, or for Python use adapter "debugpy" with program set to the .py file.`,
@@ -676,7 +686,7 @@ export class DebugTool implements AgentTool<typeof debugSchema, DebugToolDetails
 				}
 				const commandCwd = params.cwd ? resolveToCwd(params.cwd, this.session.cwd) : this.session.cwd;
 				const program = resolveToCwd(params.program, commandCwd);
-				await validateLaunchProgram(program, commandCwd);
+				const programKind = await classifyLaunchProgram(program);
 				const adapter = selectLaunchAdapter(program, commandCwd, params.adapter);
 				if (!adapter) {
 					if (params.adapter === "debugpy") {
@@ -686,8 +696,10 @@ export class DebugTool implements AgentTool<typeof debugSchema, DebugToolDetails
 						`No debugger adapter available. Installed adapters: ${getConfiguredAdapters(commandCwd)}`,
 					);
 				}
+				validateLaunchProgram(program, commandCwd, programKind, adapter);
+				const extraLaunchArguments = resolveLaunchOverrides(adapter, program, programKind);
 				const snapshot = await dapSessionManager.launch(
-					{ adapter, program, args: params.args, cwd: commandCwd },
+					{ adapter, program, args: params.args, cwd: commandCwd, extraLaunchArguments },
 					combinedSignal,
 					timeoutSec * 1000,
 				);

--- a/packages/coding-agent/test/debug/dap-launch-failures.test.ts
+++ b/packages/coding-agent/test/debug/dap-launch-failures.test.ts
@@ -411,6 +411,43 @@ describe("DebugTool launch validation", () => {
 		}
 	});
 
+	it("prefers directory-capable dlv over native adapters for extensionless Go package directories", async () => {
+		const dapModule = await import("../../src/dap");
+		const sessionLaunchSpy = spyOn(dapModule.dapSessionManager, "launch").mockImplementation(async opts => {
+			throw Object.assign(new Error("captured launch"), { capturedOptions: opts });
+		});
+		try {
+			const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-debug-dlv-mixed-roots-"));
+			try {
+				await fs.writeFile(path.join(cwd, "go.mod"), "module hello\n\ngo 1.22\n");
+				await fs.writeFile(path.join(cwd, "Makefile"), "all:\n\tgo build ./...\n");
+				await fs.mkdir(path.join(cwd, "bin"));
+				await fs.writeFile(path.join(cwd, "bin", "dlv"), "");
+				await fs.writeFile(path.join(cwd, "bin", "gdb"), "");
+				await fs.mkdir(path.join(cwd, "cmd", "hello"), { recursive: true });
+				const session: ToolSession = {
+					cwd,
+					hasUI: false,
+					getSessionFile: () => null,
+					getSessionSpawns: () => "*",
+					settings: Settings.isolated({ "debug.enabled": true }),
+				};
+				const tool = new DebugTool(session);
+
+				await expect(tool.execute("call", { action: "launch", program: "cmd/hello" })).rejects.toThrow(
+					/captured launch/,
+				);
+				const [opts] = sessionLaunchSpy.mock.calls[0]!;
+				expect(opts.adapter.name).toBe("dlv");
+				expect(opts.extraLaunchArguments).toEqual({ mode: "debug" });
+			} finally {
+				await fs.rm(cwd, { recursive: true, force: true });
+			}
+		} finally {
+			sessionLaunchSpy.mockRestore();
+		}
+	});
+
 	it("dlv launch with a compiled binary switches mode from debug to exec", async () => {
 		const dapModule = await import("../../src/dap");
 		const dlvAdapter: DapResolvedAdapter = {

--- a/packages/coding-agent/test/debug/dap-launch-failures.test.ts
+++ b/packages/coding-agent/test/debug/dap-launch-failures.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { Settings } from "../../src/config/settings";
+import * as dapModule from "../../src/dap";
 import { DapClient } from "../../src/dap/client";
 import { DapSessionManager } from "../../src/dap/session";
 import type { DapCapabilities, DapClientState, DapEventMessage, DapResolvedAdapter } from "../../src/dap/types";
@@ -340,7 +341,6 @@ describe("DAP launch failure handling", () => {
 
 describe("DebugTool launch validation", () => {
 	it("rejects directory programs when the selected adapter cannot debug a directory", async () => {
-		const dapModule = await import("../../src/dap");
 		const launchSpy = spyOn(dapModule, "selectLaunchAdapter").mockReturnValue(TEST_ADAPTER);
 		try {
 			const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-debug-program-"));
@@ -367,7 +367,6 @@ describe("DebugTool launch validation", () => {
 	});
 
 	it("allows directory programs when the selected adapter accepts them (dlv on a Go package)", async () => {
-		const dapModule = await import("../../src/dap");
 		const dlvAdapter: DapResolvedAdapter = {
 			...TEST_ADAPTER,
 			name: "dlv",
@@ -412,7 +411,6 @@ describe("DebugTool launch validation", () => {
 	});
 
 	it("prefers directory-capable dlv over native adapters for extensionless Go package directories", async () => {
-		const dapModule = await import("../../src/dap");
 		const sessionLaunchSpy = spyOn(dapModule.dapSessionManager, "launch").mockImplementation(async opts => {
 			throw Object.assign(new Error("captured launch"), { capturedOptions: opts });
 		});
@@ -449,7 +447,6 @@ describe("DebugTool launch validation", () => {
 	});
 
 	it("dlv launch with a compiled binary switches mode from debug to exec", async () => {
-		const dapModule = await import("../../src/dap");
 		const dlvAdapter: DapResolvedAdapter = {
 			...TEST_ADAPTER,
 			name: "dlv",
@@ -490,7 +487,6 @@ describe("DebugTool launch validation", () => {
 	});
 
 	it("throws targeted 'python not found in PATH' when adapter:'debugpy' is unresolvable for launch", async () => {
-		const dapModule = await import("../../src/dap");
 		const launchSpy = spyOn(dapModule, "selectLaunchAdapter").mockReturnValue(null);
 		try {
 			const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-debug-debugpy-"));
@@ -517,7 +513,6 @@ describe("DebugTool launch validation", () => {
 	});
 
 	it("throws targeted 'python not found in PATH' when adapter:'debugpy' is unresolvable for attach", async () => {
-		const dapModule = await import("../../src/dap");
 		const attachSpy = spyOn(dapModule, "selectAttachAdapter").mockReturnValue(null);
 		try {
 			const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-debug-debugpy-attach-"));
@@ -543,7 +538,6 @@ describe("DebugTool launch validation", () => {
 	});
 
 	it("falls back to the generic 'No debugger adapter' error when adapter is unspecified", async () => {
-		const dapModule = await import("../../src/dap");
 		const launchSpy = spyOn(dapModule, "selectLaunchAdapter").mockReturnValue(null);
 		try {
 			const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-debug-noadapter-"));

--- a/packages/coding-agent/test/debug/dap-launch-failures.test.ts
+++ b/packages/coding-agent/test/debug/dap-launch-failures.test.ts
@@ -20,6 +20,7 @@ const TEST_ADAPTER: DapResolvedAdapter = {
 	launchDefaults: {},
 	attachDefaults: {},
 	connectMode: "stdio",
+	acceptsDirectoryProgram: false,
 };
 
 const DELAYED_UNIX_SOCKET_ADAPTER = `
@@ -338,24 +339,116 @@ describe("DAP launch failure handling", () => {
 });
 
 describe("DebugTool launch validation", () => {
-	it("rejects directory-valued launch programs before adapter selection", async () => {
-		const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-debug-program-"));
+	it("rejects directory programs when the selected adapter cannot debug a directory", async () => {
+		const dapModule = await import("../../src/dap");
+		const launchSpy = spyOn(dapModule, "selectLaunchAdapter").mockReturnValue(TEST_ADAPTER);
 		try {
-			await fs.mkdir(path.join(cwd, "python"));
-			const session: ToolSession = {
-				cwd,
-				hasUI: false,
-				getSessionFile: () => null,
-				getSessionSpawns: () => "*",
-				settings: Settings.isolated({ "debug.enabled": true }),
-			};
-			const tool = new DebugTool(session);
+			const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-debug-program-"));
+			try {
+				await fs.mkdir(path.join(cwd, "python"));
+				const session: ToolSession = {
+					cwd,
+					hasUI: false,
+					getSessionFile: () => null,
+					getSessionSpawns: () => "*",
+					settings: Settings.isolated({ "debug.enabled": true }),
+				};
+				const tool = new DebugTool(session);
 
-			await expect(tool.execute("call", { action: "launch", program: "python" })).rejects.toThrow(
-				/launch program resolves to a directory.*python/,
-			);
+				await expect(tool.execute("call", { action: "launch", program: "python" })).rejects.toThrow(
+					/launch program resolves to a directory.*python/,
+				);
+			} finally {
+				await fs.rm(cwd, { recursive: true, force: true });
+			}
 		} finally {
-			await fs.rm(cwd, { recursive: true, force: true });
+			launchSpy.mockRestore();
+		}
+	});
+
+	it("allows directory programs when the selected adapter accepts them (dlv on a Go package)", async () => {
+		const dapModule = await import("../../src/dap");
+		const dlvAdapter: DapResolvedAdapter = {
+			...TEST_ADAPTER,
+			name: "dlv",
+			command: "dlv",
+			resolvedCommand: "dlv",
+			launchDefaults: { request: "launch", mode: "debug", stopOnEntry: true },
+			acceptsDirectoryProgram: true,
+		};
+		const launchSpy = spyOn(dapModule, "selectLaunchAdapter").mockReturnValue(dlvAdapter);
+		const sessionLaunchSpy = spyOn(dapModule.dapSessionManager, "launch").mockImplementation(async opts => {
+			throw Object.assign(new Error("captured launch"), { capturedOptions: opts });
+		});
+		try {
+			const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-debug-dlv-dir-"));
+			try {
+				await fs.mkdir(path.join(cwd, "cmd"));
+				const session: ToolSession = {
+					cwd,
+					hasUI: false,
+					getSessionFile: () => null,
+					getSessionSpawns: () => "*",
+					settings: Settings.isolated({ "debug.enabled": true }),
+				};
+				const tool = new DebugTool(session);
+
+				// Validation must pass and propagate to dapSessionManager.launch; we
+				// stop the actual spawn there and inspect the launch arguments.
+				await expect(tool.execute("call", { action: "launch", program: "cmd", adapter: "dlv" })).rejects.toThrow(
+					/captured launch/,
+				);
+				expect(sessionLaunchSpy).toHaveBeenCalledTimes(1);
+				const [opts] = sessionLaunchSpy.mock.calls[0]!;
+				expect(opts.extraLaunchArguments).toEqual({ mode: "debug" });
+				expect(opts.program).toBe(path.join(cwd, "cmd"));
+			} finally {
+				await fs.rm(cwd, { recursive: true, force: true });
+			}
+		} finally {
+			sessionLaunchSpy.mockRestore();
+			launchSpy.mockRestore();
+		}
+	});
+
+	it("dlv launch with a compiled binary switches mode from debug to exec", async () => {
+		const dapModule = await import("../../src/dap");
+		const dlvAdapter: DapResolvedAdapter = {
+			...TEST_ADAPTER,
+			name: "dlv",
+			command: "dlv",
+			resolvedCommand: "dlv",
+			launchDefaults: { request: "launch", mode: "debug", stopOnEntry: true },
+			acceptsDirectoryProgram: true,
+		};
+		const launchSpy = spyOn(dapModule, "selectLaunchAdapter").mockReturnValue(dlvAdapter);
+		const sessionLaunchSpy = spyOn(dapModule.dapSessionManager, "launch").mockImplementation(async opts => {
+			throw Object.assign(new Error("captured launch"), { capturedOptions: opts });
+		});
+		try {
+			const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "omp-debug-dlv-exec-"));
+			try {
+				await fs.writeFile(path.join(cwd, "hello"), "#!/usr/bin/env sh\necho hi\n");
+				const session: ToolSession = {
+					cwd,
+					hasUI: false,
+					getSessionFile: () => null,
+					getSessionSpawns: () => "*",
+					settings: Settings.isolated({ "debug.enabled": true }),
+				};
+				const tool = new DebugTool(session);
+
+				await expect(tool.execute("call", { action: "launch", program: "hello", adapter: "dlv" })).rejects.toThrow(
+					/captured launch/,
+				);
+				const [opts] = sessionLaunchSpy.mock.calls[0]!;
+				expect(opts.extraLaunchArguments).toEqual({ mode: "exec" });
+			} finally {
+				await fs.rm(cwd, { recursive: true, force: true });
+			}
+		} finally {
+			sessionLaunchSpy.mockRestore();
+			launchSpy.mockRestore();
 		}
 	});
 


### PR DESCRIPTION
## Repro

Tell the agent to debug a Go module with `dlv` installed (`hello/main.go` under a `go.mod` workspace). Every launch fails:

- `debug action=launch program=hello` (the package directory) → `ToolError: launch program resolves to a directory: hello/. Pass an executable file path, …`
- `debug action=launch program=./hello-bin` (a pre-built binary) → `dlv` rejects it with `Failed to launch: not a valid go module` because its default `mode=debug` interprets `program` as a Go package, not an executable.

The root cause is `DebugTool.execute(launch)` calling `validateLaunchProgram` before adapter selection and unconditionally rejecting directories, plus `dap/defaults.json#dlv.launchDefaults.mode` being hard-coded to `"debug"` with no awareness of the program shape.

## Cause

`packages/coding-agent/src/tools/debug.ts` — the `launch` arm ran `validateLaunchProgram(program, commandCwd)` (which threw on any directory) before `selectLaunchAdapter`, so dlv never got a chance to receive its package path. `packages/coding-agent/src/dap/defaults.json` then locked dlv's launch defaults to `mode=debug`, so even when a binary slipped through, dlv saw `mode=debug` and refused it.

## Fix

- `packages/coding-agent/src/dap/types.ts`: add `acceptsDirectoryProgram` to `DapAdapterConfig`/`DapResolvedAdapter`, plus `extraLaunchArguments` on `DapLaunchSessionOptions`.
- `packages/coding-agent/src/dap/defaults.json`: set `"acceptsDirectoryProgram": true` on the `dlv` entry; leave `mode: "debug"` as the static default (overridden per-launch when needed).
- `packages/coding-agent/src/dap/config.ts`: normalise/resolve the new flag and export `resolveLaunchOverrides(adapter, program, programKind)`. For dlv: directories and `.go` source files → `{ mode: "debug" }`, any other file → `{ mode: "exec" }`. All other adapters return `{}`.
- `packages/coding-agent/src/dap/session.ts`: spread `options.extraLaunchArguments` over `adapter.launchDefaults` (and below the hard-coded `program`/`cwd`/`args`) when building DAP launch arguments.
- `packages/coding-agent/src/tools/debug.ts`: replace the boolean `validateLaunchProgram` with `classifyLaunchProgram` (single `fs.stat`, returns `"file" | "directory" | "missing"`) plus an adapter-aware `validateLaunchProgram`. The launch arm now resolves the adapter first, validates against it, then calls `resolveLaunchOverrides` and threads the result through `dapSessionManager.launch`.
- `packages/coding-agent/test/debug/dap-launch-failures.test.ts`: refresh the existing directory-rejection test to spy `selectLaunchAdapter` (so the adapter actually drives the rejection), and add two new specs — dlv on a package directory passes validation and forwards `mode: "debug"`; dlv on a compiled binary forwards `mode: "exec"`.
- `packages/coding-agent/CHANGELOG.md`: `[Unreleased] → Fixed` entry citing #2020.

## Verification

`bun run check` (biome + tsgo) — clean.
`bun test test/debug/` (coding-agent) — 54 pass / 0 fail (12 pre-existing in `dap-launch-failures.test.ts` plus the 3 new specs, all green).

Fixes #2020