### PR TITLE
fix(coding-agent): show Claude max thinking label

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 
+- Fixed the Claude model selector to display the adaptive top thinking effort as `max` instead of the internal `xhigh` selector value ([#2022](https://github.com/can1357/oh-my-pi/issues/2022)).
 - Fixed `omp dry-balance --bench` to recover from 401 token failures by re-minting the failing OAuth credential in place before switching accounts
 - Fixed the bash tool corrupting commands that embed multi-byte UTF-8 (e.g. `✓`/`×` inside a `grep -E` pattern) ahead of a trailing `| head`/`| tail`. The `bash.stripTrailingHeadTail` rewrite cut at char-offset positions reported by `brush-parser` while slicing the command by byte offset, so the trailing-pipe strip landed mid-pattern and dropped the closing quote — turning `… |✓|×|XCTAssert" | tail -80` into `… |✓|×-80` and making execution fail with `pi-natives:command: unterminated double quote`. Fixed in `pi_shell::fixup` (`@oh-my-pi/pi-natives`).
 - Fixed `omp dry-balance --bench` to recover from 401 token failures by re-minting the failing OAuth credential in place before switching accounts

--- a/packages/coding-agent/src/modes/components/model-selector.ts
+++ b/packages/coding-agent/src/modes/components/model-selector.ts
@@ -21,7 +21,11 @@ import { resolveModelRoleValue } from "../../config/model-resolver";
 import type { Settings } from "../../config/settings";
 import { type ThemeColor, theme } from "../../modes/theme/theme";
 import { matchesSelectDown, matchesSelectUp } from "../../modes/utils/keybinding-matchers";
-import { AUTO_THINKING, type ConfiguredThinkingLevel, getConfiguredThinkingLevelMetadata } from "../../thinking";
+import {
+	AUTO_THINKING,
+	type ConfiguredThinkingLevel,
+	getConfiguredThinkingLevelMetadataForModel,
+} from "../../thinking";
 import { getTabBarTheme } from "../shared";
 import { DynamicBorder } from "./dynamic-border";
 
@@ -879,7 +883,10 @@ export class ModelSelectorComponent extends Container {
 				if (!tag || !assigned || !modelsAreEqual(assigned.model, item.model)) continue;
 
 				const badge = makeInvertedBadge(tag, color ?? "success");
-				const thinkingLabel = getConfiguredThinkingLevelMetadata(assigned.thinkingLevel).label;
+				const thinkingLabel = getConfiguredThinkingLevelMetadataForModel(
+					assigned.model,
+					assigned.thinkingLevel,
+				).label;
 				roleBadgeTokens.push(`${badge} ${theme.fg("dim", `(${thinkingLabel})`)}`);
 			}
 			// Custom role badges
@@ -888,7 +895,10 @@ export class ModelSelectorComponent extends Container {
 				const roleInfo = getRoleInfo(role, this.#settings);
 				const badgeLabel = roleInfo.tag ?? roleInfo.name;
 				const badge = makeInvertedBadge(badgeLabel, roleInfo.color ?? "muted");
-				const thinkingLabel = getConfiguredThinkingLevelMetadata(assigned.thinkingLevel).label;
+				const thinkingLabel = getConfiguredThinkingLevelMetadataForModel(
+					assigned.model,
+					assigned.thinkingLevel,
+				).label;
 				roleBadgeTokens.push(`${badge} ${theme.fg("dim", `(${thinkingLabel})`)}`);
 			}
 			const badgeText = roleBadgeTokens.length > 0 ? ` ${roleBadgeTokens.join(" ")}` : "";
@@ -1016,7 +1026,7 @@ export class ModelSelectorComponent extends Container {
 		const optionLines = showingThinking
 			? thinkingOptions.map((thinkingLevel, index) => {
 					const prefix = index === this.#menuSelectedIndex ? `  ${theme.nav.cursor} ` : "    ";
-					const label = getConfiguredThinkingLevelMetadata(thinkingLevel).label;
+					const label = getConfiguredThinkingLevelMetadataForModel(selectedItem.model, thinkingLevel).label;
 					return `${prefix}${label}`;
 				})
 			: this.#menuRoleActions.map((action, index) => {

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -36,6 +36,12 @@ const THINKING_LEVEL_METADATA: Record<ThinkingLevel, ThinkingLevelMetadata> = {
 	},
 };
 
+const CLAUDE_MAX_THINKING_METADATA: ConfiguredThinkingLevelMetadata = {
+	value: ThinkingLevel.XHigh,
+	label: "max",
+	description: "Maximum Claude adaptive reasoning",
+};
+
 const THINKING_LEVELS = new Set<string>([ThinkingLevel.Inherit, ThinkingLevel.Off, ...THINKING_EFFORTS]);
 const EFFORT_LEVELS = new Set<string>(THINKING_EFFORTS);
 
@@ -123,6 +129,17 @@ export function parseConfiguredThinkingLevel(value: string | null | undefined): 
 /** Returns display metadata for a configured selector, including `auto`. */
 export function getConfiguredThinkingLevelMetadata(level: ConfiguredThinkingLevel): ConfiguredThinkingLevelMetadata {
 	return level === AUTO_THINKING ? AUTO_THINKING_METADATA : getThinkingLevelMetadata(level);
+}
+
+/** Returns selector metadata using provider-native labels for model-specific efforts. */
+export function getConfiguredThinkingLevelMetadataForModel(
+	model: Model | undefined,
+	level: ConfiguredThinkingLevel,
+): ConfiguredThinkingLevelMetadata {
+	if (level === ThinkingLevel.XHigh && model?.thinking?.mode === "anthropic-adaptive") {
+		return CLAUDE_MAX_THINKING_METADATA;
+	}
+	return getConfiguredThinkingLevelMetadata(level);
 }
 
 /**

--- a/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
+++ b/packages/coding-agent/test/model-selector-role-badge-thinking.test.ts
@@ -137,6 +137,32 @@ describe("ModelSelector role badge thinking display", () => {
 		expect(menuRendered).toContain("Set as SMOL (Quick)");
 	});
 
+	test("shows Claude adaptive top effort as max in badges and model menu", async () => {
+		installTestTheme();
+		const model = getBundledModel("anthropic", "claude-opus-4-7");
+		if (!model) throw new Error("Expected bundled model anthropic/claude-opus-4-7");
+
+		const settings = Settings.isolated({
+			modelRoles: {
+				default: `${model.provider}/${model.id}:xhigh`,
+			},
+		});
+		const selector = createSelector(model, settings);
+		await Bun.sleep(0);
+		installTestTheme();
+
+		const rendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(rendered).toContain("DEFAULT (max)");
+		expect(rendered).not.toContain("DEFAULT (xhigh)");
+
+		selector.handleInput("\n");
+		selector.handleInput("\n");
+		installTestTheme();
+		const menuRendered = normalizeRenderedText(selector.render(220).join("\n"));
+		expect(menuRendered).toContain("max");
+		expect(menuRendered).not.toContain("xhigh");
+	});
+
 	test("dims and disables models below the current context size", async () => {
 		installTestTheme();
 		const settings = Settings.isolated({});


### PR DESCRIPTION
## Repro
Selecting a Claude adaptive model currently renders the top thinking effort as `xhigh`; the repro command `bun -e 'import { enrichModelThinking, getSupportedEfforts } from "./packages/ai/src/model-thinking"; const model = enrichModelThinking({ id: "claude-opus-4.7", name: "Claude Opus 4.7", api: "anthropic-messages", provider: "anthropic", baseUrl: "", reasoning: true, input: ["text"], cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }, contextWindow: 200000, maxTokens: 32000 }); const efforts = getSupportedEfforts(model); console.log(efforts.join(",")); console.log(`has max: ${efforts.includes("max")}`);'` prints `minimal,low,medium,high,xhigh` and `has max: false`, matching the missing visible `max` option.

## Cause
`packages/coding-agent/src/modes/components/model-selector.ts` rendered every thinking selector through `getConfiguredThinkingLevelMetadata`, whose static metadata labels `ThinkingLevel.XHigh` as `xhigh`. For Claude adaptive models, that internal selector value is mapped to Anthropic’s provider-native `max` effort, but the selector never used model-specific metadata.

## Fix
- Added `getConfiguredThinkingLevelMetadataForModel` in `packages/coding-agent/src/thinking.ts` to label Claude adaptive `xhigh` as `max` without changing the persisted/internal selector value.
- Updated model selector role badges and thinking menus to render labels through the model-aware metadata helper.
- Added a regression test covering both the assigned-role badge and the model selector thinking menu for Claude Opus 4.7.
- Added the fix to the coding-agent changelog.

## Verification
`bun test packages/coding-agent/test/model-selector-role-badge-thinking.test.ts` passed (6 tests, 29 assertions). `bun check` passed in `packages/coding-agent`. Fixes #2022