### PR TITLE
fix(ai): coerce singleton array arguments

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -557,9 +557,9 @@ For `anthropic-messages` models the runtime uses a separate `AnthropicCompat` sh
 
 ### Strict tool schemas (`disableStrictTools`)
 
-Anthropic's API supports a `strict` field on tool definitions that forces the model to always follow the provided schema exactly. This is enabled by default for all `anthropic-messages` providers because it guarantees schema conformance in agentic systems.
+Anthropic's API supports a `strict` field on tool definitions that forces the model to always follow the provided schema exactly. OMP enables it by default for a small allowlist of high-frequency built-in `anthropic-messages` tools (`bash`, `python`, `edit`, and `find`) whose schemas fit Anthropic's strict grammar limits; other tools still send normalized schemas but omit `strict`.
 
-Third-party providers that front the Anthropic API (AWS Bedrock, Azure, self-hosted proxies) do not always implement this field and will reject requests that include it. Set `disableStrictTools: true` at the provider level to opt out:
+Third-party providers that front the Anthropic API (AWS Bedrock, Azure, self-hosted proxies) do not always implement this field and will reject requests that include it. Set `disableStrictTools: true` at the provider level to opt out of strict mode for the allowlisted tools:
 
 ```yaml
 providers:
@@ -581,7 +581,7 @@ providers:
           cacheWrite: 3.75
 ```
 
-`disableStrictTools` is a provider-level flag that applies to all models in the provider.
+`disableStrictTools` is a provider-level flag that applies to all models in the provider. It disables the Anthropic `strict` marker only for tools that OMP would otherwise mark strict; it does not change runtime tool argument validation. OMP can automatically retry without strict tools after Anthropic reports a strict-grammar-too-large error before the first streamed token, but proxies that reject the `strict` field for other reasons should set this flag explicitly.
 
 Tool schemas going on the wire are normalized by the unified flow in
 `packages/ai/src/utils/schema/normalize.ts` (Google/CCA/MCP dispatchers

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Fixed
 
 - Fixed streaming auth retries to handle `401` and usage-limit errors before replay-unsafe content is emitted, including failures surfaced only via `errorStatus`
+- Fixed tool argument validation to coerce singleton non-string values into arrays when the schema expects an array, preventing Anthropic-compatible models that emit `todo.ops` as an object from getting stuck in repeated validation-error loops. ([#2026](https://github.com/can1357/oh-my-pi/issues/2026))
 - Fixed streaming retries to buffer and suppress partial `start` events from failed auth attempts so only clean retried events are delivered
 
 ## [15.10.0] - 2026-06-06

--- a/packages/ai/src/utils/schema/json-schema-validator.ts
+++ b/packages/ai/src/utils/schema/json-schema-validator.ts
@@ -250,8 +250,16 @@ function validateSchemaNode(
 		const branchValid = keyword === "anyOf" ? matches > 0 : matches === 1;
 		if (!branchValid) {
 			if (matches === 0 && firstIssues && firstIssues.length > 0) {
+				// Only tag issues that sit at the combinator's own path as
+				// union-branch; deeper issues describe a specific field within
+				// the failed branch and should remain individually repairable.
+				const unionDepth = path.length;
 				for (const branchIssue of firstIssues) {
-					issues.push({ ...branchIssue, fromUnionBranch: true });
+					if (branchIssue.path.length === unionDepth) {
+						issues.push({ ...branchIssue, fromUnionBranch: true });
+					} else {
+						issues.push(branchIssue);
+					}
 				}
 			} else {
 				pushIssue(

--- a/packages/ai/src/utils/schema/json-schema-validator.ts
+++ b/packages/ai/src/utils/schema/json-schema-validator.ts
@@ -20,6 +20,14 @@ export interface JsonSchemaValidationIssue {
 	message: string;
 	expectedTypes?: string[];
 	keyword?: string;
+	/**
+	 * Marks issues that originate inside a failed `anyOf` / `oneOf` branch.
+	 * Consumers such as the tool-argument coercion layer use this to avoid
+	 * applying type repairs (e.g. singleton-array wrapping) that would be
+	 * authoritative outside of a combinator but are only one candidate
+	 * branch's expectation here.
+	 */
+	fromUnionBranch?: boolean;
 }
 
 export interface JsonSchemaValidationResult {
@@ -242,7 +250,9 @@ function validateSchemaNode(
 		const branchValid = keyword === "anyOf" ? matches > 0 : matches === 1;
 		if (!branchValid) {
 			if (matches === 0 && firstIssues && firstIssues.length > 0) {
-				issues.push(...firstIssues);
+				for (const branchIssue of firstIssues) {
+					issues.push({ ...branchIssue, fromUnionBranch: true });
+				}
 			} else {
 				pushIssue(
 					issues,

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -784,9 +784,13 @@ function flattenIssues(issues: ReadonlyArray<ZodIssue>): FlatIssue[] {
 		if (issue.code === "invalid_union") {
 			const inner = (issue as unknown as { errors?: ReadonlyArray<ReadonlyArray<ZodIssue>> }).errors;
 			if (inner) {
+				// A union-branch issue only competes with a sibling branch when it
+				// sits at the union node's own path. Issues whose own path is
+				// non-empty live on a deeper field that an already-identified
+				// branch owns, so the singleton-array repair should still apply.
 				for (const branch of inner) {
 					for (const child of branch) {
-						walk(child, fullPath, true);
+						walk(child, fullPath, child.path.length === 0);
 					}
 				}
 			}

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -724,6 +724,7 @@ interface FlatIssue {
 	keyword: "type" | "unrecognized" | "other";
 	instancePath: string;
 	expectedTypes: string[];
+	unionBranch: boolean;
 }
 
 /**
@@ -759,12 +760,12 @@ function mapZodExpectedToJsonSchemaType(expected: unknown): string | null {
  */
 function flattenIssues(issues: ReadonlyArray<ZodIssue>): FlatIssue[] {
 	const out: FlatIssue[] = [];
-	const walk = (issue: ZodIssue, prefix: ReadonlyArray<PropertyKey>): void => {
+	const walk = (issue: ZodIssue, prefix: ReadonlyArray<PropertyKey>, unionBranch: boolean): void => {
 		const fullPath = prefix.length === 0 ? issue.path : [...prefix, ...issue.path];
 		if (issue.code === "invalid_type") {
 			const mapped = mapZodExpectedToJsonSchemaType((issue as { expected?: unknown }).expected);
 			if (mapped) {
-				out.push({ keyword: "type", instancePath: pathToPointer(fullPath), expectedTypes: [mapped] });
+				out.push({ keyword: "type", instancePath: pathToPointer(fullPath), expectedTypes: [mapped], unionBranch });
 				return;
 			}
 		}
@@ -775,6 +776,7 @@ function flattenIssues(issues: ReadonlyArray<ZodIssue>): FlatIssue[] {
 					keyword: "unrecognized",
 					instancePath: pathToPointer([...fullPath, key]),
 					expectedTypes: [],
+					unionBranch,
 				});
 			}
 			return;
@@ -784,15 +786,15 @@ function flattenIssues(issues: ReadonlyArray<ZodIssue>): FlatIssue[] {
 			if (inner) {
 				for (const branch of inner) {
 					for (const child of branch) {
-						walk(child, fullPath);
+						walk(child, fullPath, true);
 					}
 				}
 			}
 			return;
 		}
-		out.push({ keyword: "other", instancePath: pathToPointer(fullPath), expectedTypes: [] });
+		out.push({ keyword: "other", instancePath: pathToPointer(fullPath), expectedTypes: [], unionBranch });
 	};
-	for (const issue of issues) walk(issue, []);
+	for (const issue of issues) walk(issue, [], false);
 	return out;
 }
 
@@ -801,7 +803,9 @@ function flattenIssues(issues: ReadonlyArray<ZodIssue>): FlatIssue[] {
  *
  * Two kinds of repair are applied:
  *  - **type**: when a value is a JSON-encoded string and the schema wants
- *    something else, parse it and substitute the parsed value.
+ *    something else, parse it and substitute the parsed value. When a
+ *    non-union schema wants an array but receives a singleton value, wrap that
+ *    value in a one-element array.
  *  - **unrecognized**: when a strict object received an extra key (Zod's
  *    `unrecognized_keys` or JSON Schema's `additionalProperties: false`),
  *    drop that key so re-validation succeeds. This effectively coerces every
@@ -811,6 +815,7 @@ function flattenIssues(issues: ReadonlyArray<ZodIssue>): FlatIssue[] {
  * The function is safe and conservative:
  *   - Only processes "type" and "unrecognized" issues
  *   - Only attempts JSON coercion on string values
+ *   - Only wraps singleton array values for non-union type expectations
  *   - Only accepts parsed results that match the expected type
  *   - Clones the args object before mutation (copy-on-write)
  */
@@ -842,7 +847,10 @@ function coerceArgsFromIssues(args: unknown, issues: FlatIssue[]): { value: unkn
 				: { value: currentValue, changed: false };
 		const coercedValue = result.changed
 			? result.value
-			: issue.expectedTypes.includes("array") && currentValue !== undefined && !Array.isArray(currentValue)
+			: issue.expectedTypes.includes("array") &&
+					!issue.unionBranch &&
+					currentValue !== undefined &&
+					!Array.isArray(currentValue)
 				? [currentValue]
 				: undefined;
 		if (coercedValue === undefined) continue;
@@ -911,12 +919,14 @@ function flattenJsonSchemaIssues(issues: ReadonlyArray<JsonSchemaValidationIssue
 				keyword: "unrecognized",
 				instancePath: pathToPointer(issue.path),
 				expectedTypes: [],
+				unionBranch: false,
 			};
 		}
 		return {
 			keyword: issue.keyword === "type" ? "type" : "other",
 			instancePath: pathToPointer(issue.path),
 			expectedTypes: issue.expectedTypes ?? [],
+			unionBranch: false,
 		};
 	});
 }

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -836,12 +836,13 @@ function coerceArgsFromIssues(args: unknown, issues: FlatIssue[]): { value: unkn
 		if (issue.expectedTypes.length === 0) continue;
 
 		const currentValue = getValueAtPointer(nextArgs, issue.instancePath);
-		if (typeof currentValue !== "string") continue;
-
-		const result = tryParseJsonForTypes(currentValue, issue.expectedTypes);
+		const result =
+			typeof currentValue === "string"
+				? tryParseJsonForTypes(currentValue, issue.expectedTypes)
+				: { value: currentValue, changed: false };
 		const coercedValue = result.changed
 			? result.value
-			: issue.expectedTypes.includes("array")
+			: issue.expectedTypes.includes("array") && currentValue !== undefined && !Array.isArray(currentValue)
 				? [currentValue]
 				: undefined;
 		if (coercedValue === undefined) continue;

--- a/packages/ai/src/utils/validation.ts
+++ b/packages/ai/src/utils/validation.ts
@@ -914,19 +914,20 @@ function preserveUnknownRootFields(input: unknown, parsed: unknown): unknown {
 
 function flattenJsonSchemaIssues(issues: ReadonlyArray<JsonSchemaValidationIssue>): FlatIssue[] {
 	return issues.map(issue => {
+		const unionBranch = issue.fromUnionBranch === true;
 		if (issue.keyword === "additionalProperties") {
 			return {
 				keyword: "unrecognized",
 				instancePath: pathToPointer(issue.path),
 				expectedTypes: [],
-				unionBranch: false,
+				unionBranch,
 			};
 		}
 		return {
 			keyword: issue.keyword === "type" ? "type" : "other",
 			instancePath: pathToPointer(issue.path),
 			expectedTypes: issue.expectedTypes ?? [],
-			unionBranch: false,
+			unionBranch,
 		};
 	});
 }

--- a/packages/ai/test/tool-argument-coercion.test.ts
+++ b/packages/ai/test/tool-argument-coercion.test.ts
@@ -195,6 +195,61 @@ describe("Tool argument coercion", () => {
 		).toThrow("Validation failed");
 	});
 
+	it("still wraps nested array fields inside a tag-selected Zod union branch", () => {
+		const tool: Tool = {
+			name: "tagged_union",
+			description: "",
+			parameters: z.union([
+				z.object({ type: z.literal("indices"), indices: z.array(z.number()) }),
+				z.object({ type: z.literal("all") }),
+			]),
+		};
+
+		const result = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-tagged-union",
+			name: "tagged_union",
+			arguments: { type: "indices", indices: 1 },
+		});
+
+		expect(result).toEqual({ type: "indices", indices: [1] });
+	});
+
+	it("still wraps nested array fields inside a tag-selected JSON Schema anyOf branch", () => {
+		const tool: Tool = {
+			name: "tagged_json_union",
+			description: "",
+			parameters: {
+				anyOf: [
+					{
+						type: "object",
+						properties: {
+							type: { const: "indices" },
+							indices: { type: "array", items: { type: "number" } },
+						},
+						required: ["type", "indices"],
+						additionalProperties: false,
+					},
+					{
+						type: "object",
+						properties: { type: { const: "all" } },
+						required: ["type"],
+						additionalProperties: false,
+					},
+				],
+			},
+		};
+
+		const result = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-tagged-json-union",
+			name: "tagged_json_union",
+			arguments: { type: "indices", indices: 1 },
+		});
+
+		expect(result).toEqual({ type: "indices", indices: [1] });
+	});
+
 	it("parses JSON objects in string values when schema expects object", () => {
 		const tool: Tool = {
 			name: "t4",

--- a/packages/ai/test/tool-argument-coercion.test.ts
+++ b/packages/ai/test/tool-argument-coercion.test.ts
@@ -78,6 +78,59 @@ describe("Tool argument coercion", () => {
 		expect(result.paths).toEqual(["src/**/*.ts"]);
 	});
 
+	it("wraps a singleton object in an array when schema expects object array", () => {
+		const tool: Tool = {
+			name: "todo_like",
+			description: "",
+			parameters: z.object({
+				ops: z.array(
+					z.object({
+						op: z.literal("init"),
+						list: z.array(
+							z.object({
+								phase: z.string(),
+								items: z.array(z.string()),
+							}),
+						),
+					}),
+				),
+			}),
+		};
+
+		const result = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-singleton-object-array",
+			name: "todo_like",
+			arguments: {
+				ops: {
+					op: "init",
+					list: [{ phase: "Repro", items: ["capture"] }],
+				},
+			},
+		});
+
+		expect(result).toEqual({
+			ops: [{ op: "init", list: [{ phase: "Repro", items: ["capture"] }] }],
+		});
+	});
+
+	it("wraps a singleton number in an array when schema expects number array", () => {
+		const tool: Tool = {
+			name: "numeric_list",
+			description: "",
+			parameters: z.object({ values: z.array(z.number()) }),
+		};
+
+		const result = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-singleton-number-array",
+			name: "numeric_list",
+			arguments: { values: 7 },
+		});
+
+		expect(result).toEqual({ values: [7] });
+	});
+
 	it("parses JSON objects in string values when schema expects object", () => {
 		const tool: Tool = {
 			name: "t4",

--- a/packages/ai/test/tool-argument-coercion.test.ts
+++ b/packages/ai/test/tool-argument-coercion.test.ts
@@ -149,6 +149,52 @@ describe("Tool argument coercion", () => {
 		expect(result).toEqual({ id: 1 });
 	});
 
+	it("does not wrap singleton values for JSON Schema anyOf array branches", () => {
+		const tool: Tool = {
+			name: "json_schema_union",
+			description: "",
+			parameters: {
+				type: "object",
+				properties: {
+					target: {
+						anyOf: [
+							{
+								type: "array",
+								items: {
+									type: "object",
+									properties: { a: { type: "boolean" } },
+									required: ["a"],
+									additionalProperties: false,
+								},
+							},
+							{
+								type: "object",
+								properties: { a: { type: "boolean" } },
+								required: ["a"],
+								additionalProperties: false,
+							},
+						],
+					},
+				},
+				required: ["target"],
+				additionalProperties: false,
+			},
+		};
+
+		// The bug would silently coerce `{ a: "true" }` into `[{ a: true }]` by
+		// wrapping the object to satisfy the failed `anyOf` array branch and
+		// then coercing the inner string into a boolean. Branch tracking keeps
+		// the wrap from firing so the wrong shape never makes it through.
+		expect(() =>
+			validateToolArguments(tool, {
+				type: "toolCall",
+				id: "call-jsonschema-union",
+				name: "json_schema_union",
+				arguments: { target: { a: "true" } },
+			}),
+		).toThrow("Validation failed");
+	});
+
 	it("parses JSON objects in string values when schema expects object", () => {
 		const tool: Tool = {
 			name: "t4",

--- a/packages/ai/test/tool-argument-coercion.test.ts
+++ b/packages/ai/test/tool-argument-coercion.test.ts
@@ -131,6 +131,24 @@ describe("Tool argument coercion", () => {
 		expect(result).toEqual({ values: [7] });
 	});
 
+	it("does not wrap singleton values for array expectations from failed union branches", () => {
+		const entry = z.object({ id: z.number() });
+		const tool: Tool = {
+			name: "union_shape",
+			description: "",
+			parameters: z.union([z.array(entry), entry]),
+		};
+
+		const result = validateToolArguments(tool, {
+			type: "toolCall",
+			id: "call-union-shape",
+			name: "union_shape",
+			arguments: { id: "1" },
+		});
+
+		expect(result).toEqual({ id: 1 });
+	});
+
 	it("parses JSON objects in string values when schema expects object", () => {
 		const tool: Tool = {
 			name: "t4",


### PR DESCRIPTION
## Repro
A focused `validateToolArguments()` repro with a `todo`-style schema and `ops: { op: "init", list: [...] }` failed with `ops: Invalid input: expected array, received object`, matching the model-level validation error loop described in #2026.

## Cause
`coerceArgsFromIssues()` in `packages/ai/src/utils/validation.ts` only attempted array repair when the invalid value was a string. Non-string singleton values at array-typed paths, including an object-valued `todo.ops`, skipped coercion and were surfaced as validation errors back to the model.

## Fix
- Wrapped non-string singleton values in an array when validation reports an array-typed field, while preserving existing JSON-string parsing behavior and avoiding missing-field coercion.
- Added regression coverage for object-valued `todo`-like operations and scalar singleton arrays in `packages/ai/test/tool-argument-coercion.test.ts`.
- Clarified `docs/models.md` so `disableStrictTools` documents Anthropic strict mode as an allowlisted wire-schema feature, separate from runtime argument validation.
- Added an Unreleased changelog entry for `@oh-my-pi/pi-ai`.

## Verification
Ran `bun --cwd=packages/ai -e '<focused repro>'` and observed `{"ops":[{"op":"init","list":[{"phase":"Repro","items":["capture"]}]}]}` after the fix. Ran `bun --cwd=packages/ai test test/tool-argument-coercion.test.ts` (41 pass) and `bun --cwd=packages/ai run check` (Biome and tsgo passed). Fixes #2026