### PR TITLE
fix(ci): opt into Node 24 actions runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ concurrency:
    group: ${{ github.workflow }}-${{ github.ref }}
    cancel-in-progress: true
 
+env:
+   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
    # scripts/release.ts pushes the version-bump commit and its `v*` tag
    # atomically (`git push --atomic origin main refs/tags/v*`), so a release

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "test:rs": "bun scripts/run-rs-task.ts test:rs",
     "check": "bun run --parallel check:ts check:rs",
     "check:ts": "bun run check:tools && bun run --workspaces --if-present check",
-    "check:tools": "biome check . --no-errors-on-unmatched",
+    "check:tools": "biome check . --no-errors-on-unmatched && bun scripts/check-ci-workflow.ts",
     "check:rs": "bun scripts/run-rs-task.ts check:rs",
     "lint": "bun run --parallel lint:ts lint:rs",
     "lint:ts": "bun run --parallel lint:tools && bun run --workspaces --if-present lint",

--- a/scripts/check-ci-workflow.test.ts
+++ b/scripts/check-ci-workflow.test.ts
@@ -1,51 +1,123 @@
 import { describe, expect, it } from "bun:test";
 import { checkCiWorkflowNode24OptIn } from "./check-ci-workflow";
 
+const WORKFLOW = { path: ".github/workflows/ci.yml" };
+
 describe("checkCiWorkflowNode24OptIn", () => {
-	it("accepts affected action pins when the workflow has a top-level Node 24 opt-in", () => {
-		const result = checkCiWorkflowNode24OptIn([
-			"name: CI",
-			"env:",
-			"   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true",
-			"jobs:",
-			"   check:",
-			"      steps:",
-			"         - uses: actions/checkout@v4",
-			"         - name: Cache bun dependencies",
-			"           uses: actions/cache@v4",
-		].join("\n"));
+	it("accepts affected workflow pins when the workflow has the top-level opt-in", () => {
+		const result = checkCiWorkflowNode24OptIn({
+			...WORKFLOW,
+			contents: [
+				"name: CI",
+				"env:",
+				"   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true",
+				"jobs:",
+				"   check:",
+				"      steps:",
+				"         - uses: actions/checkout@v4",
+				"         - name: Cache bun dependencies",
+				"           uses: actions/cache@v4",
+			].join("\n"),
+		});
 
 		expect(result.hasTopLevelNode24OptIn).toBe(true);
 		expect(result.messages).toEqual([]);
-		expect(result.affectedActions).toEqual([
-			{ action: "actions/checkout@v4", count: 1 },
-			{ action: "actions/cache@v4", count: 1 },
-		]);
+		expect(result.totalAffected).toBe(2);
 	});
 
-	it("rejects affected action pins without the workflow-level opt-in", () => {
-		const result = checkCiWorkflowNode24OptIn([
-			"name: CI",
-			"jobs:",
-			"   check:",
-			"      steps:",
-			"         - uses: actions/download-artifact@v4",
-		].join("\n"));
+	it("rejects affected workflow pins without the workflow-level opt-in", () => {
+		const result = checkCiWorkflowNode24OptIn({
+			...WORKFLOW,
+			contents: [
+				"name: CI",
+				"jobs:",
+				"   release:",
+				"      steps:",
+				"         - uses: actions/download-artifact@v4",
+				"         - uses: actions/upload-artifact@v4",
+			].join("\n"),
+		});
 
 		expect(result.hasTopLevelNode24OptIn).toBe(false);
-		expect(result.messages).toContain("Add a top-level env block with FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true.");
+		expect(result.totalAffected).toBe(2);
+		expect(result.messages.length).toBe(1);
+		expect(result.messages[0]).toContain("FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true");
+	});
+
+	it("flags affected pins discovered only in local composite actions", () => {
+		const result = checkCiWorkflowNode24OptIn(
+			{
+				...WORKFLOW,
+				contents: [
+					"name: CI",
+					"jobs:",
+					"   build:",
+					"      steps:",
+					"         - uses: ./.github/actions/build-native",
+				].join("\n"),
+			},
+			[
+				{
+					path: ".github/actions/build-native/action.yml",
+					contents: [
+						"runs:",
+						"   using: composite",
+						"   steps:",
+						"      - uses: actions/cache@v4",
+						"      - uses: actions/upload-artifact@v4",
+					].join("\n"),
+				},
+			],
+		);
+
+		expect(result.hasTopLevelNode24OptIn).toBe(false);
+		expect(result.totalAffected).toBe(2);
+		expect(result.messages[0]).toContain(".github/actions/build-native/action.yml");
+		expect(result.messages[0]).toContain("actions/cache@v4 (1)");
+		expect(result.messages[0]).toContain("actions/upload-artifact@v4 (1)");
+	});
+
+	it("accepts composite-action pins when the workflow carries the opt-in", () => {
+		const result = checkCiWorkflowNode24OptIn(
+			{
+				...WORKFLOW,
+				contents: [
+					"name: CI",
+					"env:",
+					"   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true",
+					"jobs:",
+					"   build:",
+					"      steps:",
+					"         - uses: ./.github/actions/build-native",
+				].join("\n"),
+			},
+			[
+				{
+					path: ".github/actions/build-native/action.yml",
+					contents: ["runs:", "   using: composite", "   steps:", "      - uses: actions/cache@v4"].join(
+						"\n",
+					),
+				},
+			],
+		);
+
+		expect(result.hasTopLevelNode24OptIn).toBe(true);
+		expect(result.messages).toEqual([]);
 	});
 
 	it("does not accept a job-level opt-in as workflow-wide coverage", () => {
-		const result = checkCiWorkflowNode24OptIn([
-			"name: CI",
-			"jobs:",
-			"   check:",
-			"      env:",
-			"         FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true",
-			"      steps:",
-			"         - uses: actions/setup-node@v4",
-		].join("\n"));
+		const result = checkCiWorkflowNode24OptIn({
+			...WORKFLOW,
+			contents: [
+				"name: CI",
+				"jobs:",
+				"   check:",
+				"      env:",
+				"         FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true",
+				"      steps:",
+				"         - uses: actions/setup-node@v4",
+			].join("\n"),
+		});
 
 		expect(result.hasTopLevelNode24OptIn).toBe(false);
 		expect(result.messages.length).toBeGreaterThan(0);

--- a/scripts/check-ci-workflow.test.ts
+++ b/scripts/check-ci-workflow.test.ts
@@ -33,8 +33,8 @@ describe("checkCiWorkflowNode24OptIn", () => {
 				"jobs:",
 				"   release:",
 				"      steps:",
-				"         - uses: actions/download-artifact@v4",
-				"         - uses: actions/upload-artifact@v4",
+				"         - uses:  actions/download-artifact@v4",
+				"         - uses:   actions/upload-artifact@v4",
 			].join("\n"),
 		});
 

--- a/scripts/check-ci-workflow.test.ts
+++ b/scripts/check-ci-workflow.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import { checkCiWorkflowNode24OptIn } from "./check-ci-workflow";
+
+describe("checkCiWorkflowNode24OptIn", () => {
+	it("accepts affected action pins when the workflow has a top-level Node 24 opt-in", () => {
+		const result = checkCiWorkflowNode24OptIn([
+			"name: CI",
+			"env:",
+			"   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true",
+			"jobs:",
+			"   check:",
+			"      steps:",
+			"         - uses: actions/checkout@v4",
+			"         - name: Cache bun dependencies",
+			"           uses: actions/cache@v4",
+		].join("\n"));
+
+		expect(result.hasTopLevelNode24OptIn).toBe(true);
+		expect(result.messages).toEqual([]);
+		expect(result.affectedActions).toEqual([
+			{ action: "actions/checkout@v4", count: 1 },
+			{ action: "actions/cache@v4", count: 1 },
+		]);
+	});
+
+	it("rejects affected action pins without the workflow-level opt-in", () => {
+		const result = checkCiWorkflowNode24OptIn([
+			"name: CI",
+			"jobs:",
+			"   check:",
+			"      steps:",
+			"         - uses: actions/download-artifact@v4",
+		].join("\n"));
+
+		expect(result.hasTopLevelNode24OptIn).toBe(false);
+		expect(result.messages).toContain("Add a top-level env block with FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true.");
+	});
+
+	it("does not accept a job-level opt-in as workflow-wide coverage", () => {
+		const result = checkCiWorkflowNode24OptIn([
+			"name: CI",
+			"jobs:",
+			"   check:",
+			"      env:",
+			"         FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true",
+			"      steps:",
+			"         - uses: actions/setup-node@v4",
+		].join("\n"));
+
+		expect(result.hasTopLevelNode24OptIn).toBe(false);
+		expect(result.messages.length).toBeGreaterThan(0);
+	});
+});

--- a/scripts/check-ci-workflow.ts
+++ b/scripts/check-ci-workflow.ts
@@ -1,70 +1,113 @@
+import { Glob } from "bun";
+
 const WORKFLOW_PATH = ".github/workflows/ci.yml";
+const COMPOSITE_GLOB = ".github/actions/**/action.{yml,yaml}";
 const NODE24_OPT_IN = "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24";
-/** Action pins covered by the workflow Node 24 JavaScript runtime opt-in. */
+
+/** Action pins still on the Node 20 JavaScript runtime that need the workflow Node 24 opt-in. */
 export type AffectedAction =
-	| "actions/checkout@v4"
 	| "actions/cache@v4"
+	| "actions/checkout@v4"
 	| "actions/download-artifact@v4"
-	| "actions/setup-node@v4";
+	| "actions/setup-node@v4"
+	| "actions/upload-artifact@v4";
 
 const AFFECTED_ACTIONS: readonly AffectedAction[] = [
-	"actions/checkout@v4",
 	"actions/cache@v4",
+	"actions/checkout@v4",
 	"actions/download-artifact@v4",
 	"actions/setup-node@v4",
+	"actions/upload-artifact@v4",
 ];
 
-/** Count of an action reference that still needs the Node 24 opt-in. */
+/** Count of affected pins found at a particular path. */
 export interface AffectedActionCount {
 	action: AffectedAction;
 	count: number;
 }
 
+/** Affected pins discovered in a single workflow or composite-action YAML file. */
+export interface FileAffectedPins {
+	path: string;
+	counts: AffectedActionCount[];
+}
+
+/** YAML file that should be scanned for affected pins. */
+export interface ScannedYamlFile {
+	path: string;
+	contents: string;
+}
+
 /** Validation result for the CI workflow Node 24 JavaScript action opt-in. */
 export interface CiWorkflowNode24Check {
-	affectedActions: AffectedActionCount[];
+	totalAffected: number;
+	perFile: FileAffectedPins[];
 	hasTopLevelNode24OptIn: boolean;
 	messages: string[];
 }
 
-/** Verifies that affected JavaScript action pins are protected by the Node 24 opt-in. */
-export function checkCiWorkflowNode24OptIn(workflow: string): CiWorkflowNode24Check {
-	const affectedActions = countAffectedActions(workflow);
-	const hasTopLevelNode24OptIn = findTopLevelNode24OptIn(workflow);
+/**
+ * Verifies that every affected JavaScript action pin reachable from `workflow`
+ * — directly or via a local composite action — is protected by a workflow-level
+ * `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env opt-in.
+ *
+ * `composites` defaults to no extra files so callers can scan a single workflow
+ * in isolation; production callers pass every local composite action because a
+ * composite's `uses:` lines execute under the calling workflow's env.
+ */
+export function checkCiWorkflowNode24OptIn(
+	workflow: ScannedYamlFile,
+	composites: readonly ScannedYamlFile[] = [],
+): CiWorkflowNode24Check {
+	const perFile = collectAffectedPins([workflow, ...composites]);
+	const totalAffected = perFile.reduce(
+		(sum, file) => sum + file.counts.reduce((acc, entry) => acc + entry.count, 0),
+		0,
+	);
+	const hasTopLevelNode24OptIn = findTopLevelNode24OptIn(workflow.contents);
 	const messages: string[] = [];
 
-	if (affectedActions.length > 0 && !hasTopLevelNode24OptIn) {
+	if (totalAffected > 0 && !hasTopLevelNode24OptIn) {
+		const summary = perFile
+			.filter((file) => file.counts.length > 0)
+			.map(
+				(file) =>
+					`${file.path}: ${file.counts.map(({ action, count }) => `${action} (${count})`).join(", ")}`,
+			)
+			.join("; ");
 		messages.push(
-			`${WORKFLOW_PATH} uses JavaScript actions covered by the Node 20 runner deprecation: ${affectedActions
-				.map(({ action, count }) => `${action} (${count})`)
-				.join(", ")}.`,
+			`Affected JavaScript action pins still present (${summary}); add a top-level env block to ${workflow.path} with ${NODE24_OPT_IN}: true.`,
 		);
-		messages.push(`Add a top-level env block with ${NODE24_OPT_IN}: true.`);
 	}
 
-	return { affectedActions, hasTopLevelNode24OptIn, messages };
+	return { totalAffected, perFile, hasTopLevelNode24OptIn, messages };
 }
 
-function countAffectedActions(workflow: string): AffectedActionCount[] {
+function collectAffectedPins(files: readonly ScannedYamlFile[]): FileAffectedPins[] {
+	return files.map((file) => ({ path: file.path, counts: countAffectedActions(file.contents) }));
+}
+
+function countAffectedActions(contents: string): AffectedActionCount[] {
 	const counts: Record<AffectedAction, number> = {
 		"actions/cache@v4": 0,
 		"actions/checkout@v4": 0,
 		"actions/download-artifact@v4": 0,
 		"actions/setup-node@v4": 0,
+		"actions/upload-artifact@v4": 0,
 	};
 
-	for (const line of workflow.split(/\r?\n/)) {
+	for (const line of contents.split(/\r?\n/)) {
 		const action = parseUsesAction(line);
 		if (action === null) continue;
 		counts[action]++;
 	}
 
-	const affectedActions: AffectedActionCount[] = [];
+	const result: AffectedActionCount[] = [];
 	for (const action of AFFECTED_ACTIONS) {
 		const count = counts[action];
-		if (count > 0) affectedActions.push({ action, count });
+		if (count > 0) result.push({ action, count });
 	}
-	return affectedActions;
+	return result;
 }
 
 function parseUsesAction(line: string): AffectedAction | null {
@@ -81,6 +124,7 @@ function toAffectedAction(value: string): AffectedAction | null {
 		case "actions/checkout@v4":
 		case "actions/download-artifact@v4":
 		case "actions/setup-node@v4":
+		case "actions/upload-artifact@v4":
 			return action;
 		default:
 			return null;
@@ -101,7 +145,7 @@ function findTopLevelNode24OptIn(workflow: string): boolean {
 	return false;
 }
 
-function topLevelEnvContainsOptIn(lines: string[], startIndex: number): boolean {
+function topLevelEnvContainsOptIn(lines: readonly string[], startIndex: number): boolean {
 	for (let index = startIndex; index < lines.length; index++) {
 		const line = lines[index];
 		if (line.length === 0 || line.trimStart().startsWith("#")) continue;
@@ -111,9 +155,19 @@ function topLevelEnvContainsOptIn(lines: string[], startIndex: number): boolean 
 	return false;
 }
 
+async function loadYaml(path: string): Promise<ScannedYamlFile> {
+	return { path, contents: await Bun.file(path).text() };
+}
+
 if (import.meta.main) {
-	const workflow = await Bun.file(WORKFLOW_PATH).text();
-	const result = checkCiWorkflowNode24OptIn(workflow);
+	const workflow = await loadYaml(WORKFLOW_PATH);
+	const compositePaths: string[] = [];
+	for await (const path of new Glob(COMPOSITE_GLOB).scan(".")) {
+		compositePaths.push(path);
+	}
+	compositePaths.sort();
+	const composites = await Promise.all(compositePaths.map(loadYaml));
+	const result = checkCiWorkflowNode24OptIn(workflow, composites);
 	if (result.messages.length > 0) {
 		process.stderr.write(`${result.messages.join("\n")}\n`);
 		process.exit(1);

--- a/scripts/check-ci-workflow.ts
+++ b/scripts/check-ci-workflow.ts
@@ -132,8 +132,9 @@ function toAffectedAction(value: string): AffectedAction | null {
 }
 
 function readActionReference(value: string): string {
-	const separator = value.search(/\s/);
-	return separator === -1 ? value : value.slice(0, separator);
+	const normalized = value.trim();
+	const separator = normalized.search(/\s/);
+	return separator === -1 ? normalized : normalized.slice(0, separator);
 }
 
 function findTopLevelNode24OptIn(workflow: string): boolean {

--- a/scripts/check-ci-workflow.ts
+++ b/scripts/check-ci-workflow.ts
@@ -1,0 +1,121 @@
+const WORKFLOW_PATH = ".github/workflows/ci.yml";
+const NODE24_OPT_IN = "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24";
+/** Action pins covered by the workflow Node 24 JavaScript runtime opt-in. */
+export type AffectedAction =
+	| "actions/checkout@v4"
+	| "actions/cache@v4"
+	| "actions/download-artifact@v4"
+	| "actions/setup-node@v4";
+
+const AFFECTED_ACTIONS: readonly AffectedAction[] = [
+	"actions/checkout@v4",
+	"actions/cache@v4",
+	"actions/download-artifact@v4",
+	"actions/setup-node@v4",
+];
+
+/** Count of an action reference that still needs the Node 24 opt-in. */
+export interface AffectedActionCount {
+	action: AffectedAction;
+	count: number;
+}
+
+/** Validation result for the CI workflow Node 24 JavaScript action opt-in. */
+export interface CiWorkflowNode24Check {
+	affectedActions: AffectedActionCount[];
+	hasTopLevelNode24OptIn: boolean;
+	messages: string[];
+}
+
+/** Verifies that affected JavaScript action pins are protected by the Node 24 opt-in. */
+export function checkCiWorkflowNode24OptIn(workflow: string): CiWorkflowNode24Check {
+	const affectedActions = countAffectedActions(workflow);
+	const hasTopLevelNode24OptIn = findTopLevelNode24OptIn(workflow);
+	const messages: string[] = [];
+
+	if (affectedActions.length > 0 && !hasTopLevelNode24OptIn) {
+		messages.push(
+			`${WORKFLOW_PATH} uses JavaScript actions covered by the Node 20 runner deprecation: ${affectedActions
+				.map(({ action, count }) => `${action} (${count})`)
+				.join(", ")}.`,
+		);
+		messages.push(`Add a top-level env block with ${NODE24_OPT_IN}: true.`);
+	}
+
+	return { affectedActions, hasTopLevelNode24OptIn, messages };
+}
+
+function countAffectedActions(workflow: string): AffectedActionCount[] {
+	const counts: Record<AffectedAction, number> = {
+		"actions/cache@v4": 0,
+		"actions/checkout@v4": 0,
+		"actions/download-artifact@v4": 0,
+		"actions/setup-node@v4": 0,
+	};
+
+	for (const line of workflow.split(/\r?\n/)) {
+		const action = parseUsesAction(line);
+		if (action === null) continue;
+		counts[action]++;
+	}
+
+	const affectedActions: AffectedActionCount[] = [];
+	for (const action of AFFECTED_ACTIONS) {
+		const count = counts[action];
+		if (count > 0) affectedActions.push({ action, count });
+	}
+	return affectedActions;
+}
+
+function parseUsesAction(line: string): AffectedAction | null {
+	const trimmed = line.trim();
+	if (trimmed.startsWith("- uses: ")) return toAffectedAction(trimmed.slice(8));
+	if (trimmed.startsWith("uses: ")) return toAffectedAction(trimmed.slice(6));
+	return null;
+}
+
+function toAffectedAction(value: string): AffectedAction | null {
+	const action = readActionReference(value);
+	switch (action) {
+		case "actions/cache@v4":
+		case "actions/checkout@v4":
+		case "actions/download-artifact@v4":
+		case "actions/setup-node@v4":
+			return action;
+		default:
+			return null;
+	}
+}
+
+function readActionReference(value: string): string {
+	const separator = value.search(/\s/);
+	return separator === -1 ? value : value.slice(0, separator);
+}
+
+function findTopLevelNode24OptIn(workflow: string): boolean {
+	const lines = workflow.split(/\r?\n/);
+	for (let index = 0; index < lines.length; index++) {
+		if (lines[index] !== "env:") continue;
+		if (topLevelEnvContainsOptIn(lines, index + 1)) return true;
+	}
+	return false;
+}
+
+function topLevelEnvContainsOptIn(lines: string[], startIndex: number): boolean {
+	for (let index = startIndex; index < lines.length; index++) {
+		const line = lines[index];
+		if (line.length === 0 || line.trimStart().startsWith("#")) continue;
+		if (!line.startsWith(" ")) return false;
+		if (line.trim() === `${NODE24_OPT_IN}: true`) return true;
+	}
+	return false;
+}
+
+if (import.meta.main) {
+	const workflow = await Bun.file(WORKFLOW_PATH).text();
+	const result = checkCiWorkflowNode24OptIn(workflow);
+	if (result.messages.length > 0) {
+		process.stderr.write(`${result.messages.join("\n")}\n`);
+		process.exit(1);
+	}
+}


### PR DESCRIPTION
## Repro
`.github/workflows/ci.yml` still used the affected JavaScript action pins: 10 `actions/checkout@v4`, 5 `actions/cache@v4`, 3 `actions/download-artifact@v4`, and 2 `actions/setup-node@v4` entries. Reproduced with `python3 -c 'from pathlib import Path; ...'`, which printed each matching `uses:` line and exited 0.

## Cause
The workflow had no top-level `env` opt-in for `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`, so every `actions/*@v4` JavaScript action in `.github/workflows/ci.yml` remained subject to GitHub's Node 20 runner deprecation path until GitHub forced the runtime migration.

## Fix
- Added a workflow-level `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env entry in `.github/workflows/ci.yml` so all jobs opt into the Node 24 JavaScript action runtime now.
- Added `scripts/check-ci-workflow.ts` to fail repository checks if affected action pins remain without the workflow-level opt-in.
- Wired that check into `check:tools` and covered the parser with `scripts/check-ci-workflow.test.ts`.

## Verification
Ran `bun scripts/check-ci-workflow.ts`, `bun test scripts/check-ci-workflow.test.ts`, and `bun run check:tools`; all passed after installing repository dependencies with `bun install --frozen-lockfile`. Fixes #2029