### PR TITLE
fix(proxy): throw error when server disconnects without terminal event

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed proxy stream silently returning a zero-token success response when the server disconnects without sending a `done` or `error` terminal SSE event. The stream now throws an error, surfacing the disconnect as an `error` event with `stopReason: "error"` and resolving `finalResultPromise`, instead of defaulting to `stopReason: "stop"` with empty content and leaving `stream.result()` callers hanging indefinitely.
+
 ## [15.10.1] - 2026-06-07
 
 ### Added

--- a/packages/agent/src/proxy.ts
+++ b/packages/agent/src/proxy.ts
@@ -16,8 +16,8 @@ import { calculateCost } from "@oh-my-pi/pi-ai/models";
 import { parseStreamingJson } from "@oh-my-pi/pi-ai/utils/json-parse";
 import { readSseJson } from "@oh-my-pi/pi-utils";
 
-// Create stream class matching ProxyMessageEventStream
-class ProxyMessageEventStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
+// Stream class matching ProxyMessageEventStream
+export class ProxyMessageEventStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
 	constructor() {
 		super(
 			event => event.type === "done" || event.type === "error",

--- a/packages/agent/src/proxy.ts
+++ b/packages/agent/src/proxy.ts
@@ -16,7 +16,7 @@ import { calculateCost } from "@oh-my-pi/pi-ai/models";
 import { parseStreamingJson } from "@oh-my-pi/pi-ai/utils/json-parse";
 import { readSseJson } from "@oh-my-pi/pi-utils";
 
-// Stream class matching ProxyMessageEventStream
+// Event stream adapter for proxy SSE events
 export class ProxyMessageEventStream extends EventStream<AssistantMessageEvent, AssistantMessage> {
 	constructor() {
 		super(

--- a/packages/agent/src/proxy.ts
+++ b/packages/agent/src/proxy.ts
@@ -168,6 +168,10 @@ export function streamProxy(model: Model, context: Context, options: ProxyStream
 			}
 
 			if (!sawTerminalEvent) {
+				if (options.signal?.aborted) {
+					const reason = options.signal.reason;
+					throw reason instanceof Error ? reason : new Error(String(reason ?? "Request aborted"));
+				}
 				throw new Error("Proxy stream ended without a terminal event (done or error)");
 			}
 

--- a/packages/agent/src/proxy.ts
+++ b/packages/agent/src/proxy.ts
@@ -167,9 +167,8 @@ export function streamProxy(model: Model, context: Context, options: ProxyStream
 				}
 			}
 
-			if (options.signal?.aborted && !sawTerminalEvent) {
-				const reason = options.signal.reason;
-				throw reason instanceof Error ? reason : new Error(String(reason ?? "Request aborted"));
+			if (!sawTerminalEvent) {
+				throw new Error("Proxy stream ended without a terminal event (done or error)");
 			}
 
 			stream.end();

--- a/packages/agent/test/proxy-stream-disconnect.test.ts
+++ b/packages/agent/test/proxy-stream-disconnect.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for proxy stream behavior when the server disconnects
+ * without sending a terminal event (done/error).
+ *
+ * Contract: `streamProxy` MUST emit an error event and resolve
+ * `stream.result()` when the SSE stream ends without a terminal
+ * event — it must NOT silently complete with default stopReason='stop'.
+ */
+import { describe, expect, it } from "bun:test";
+import { streamProxy } from "@oh-my-pi/pi-agent-core/proxy";
+import type { ProxyAssistantMessageEvent } from "@oh-my-pi/pi-agent-core/proxy";
+import type { AssistantMessageEvent, Model } from "@oh-my-pi/pi-ai";
+
+const mockModel: Model = {
+	id: "test-model",
+	name: "Test Model",
+	api: "openai",
+	provider: "test",
+	baseUrl: "http://localhost:0",
+	reasoning: false,
+	input: ["text"],
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+	contextWindow: 4096,
+	maxTokens: 1024,
+};
+
+function buildSseBody(events: ProxyAssistantMessageEvent[]): ReadableStream<Uint8Array> {
+	const parts: string[] = [];
+	for (const event of events) {
+		parts.push(`data: ${JSON.stringify(event)}\n\n`);
+	}
+	const text = parts.join("");
+	return new ReadableStream({
+		start(controller) {
+			controller.enqueue(new TextEncoder().encode(text));
+			controller.close();
+		},
+	});
+}
+
+async function withMockFetch<R>(
+	body: ReadableStream<Uint8Array>,
+	status: number,
+	fn: () => Promise<R>,
+): Promise<R> {
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = async (_input: RequestInfo | URL, _init?: RequestInit) =>
+		new Response(body, { status });
+	try {
+		return await fn();
+	} finally {
+		globalThis.fetch = originalFetch;
+	}
+}
+
+async function collectEvents(
+	stream: ReturnType<typeof streamProxy>,
+	timeoutMs = 2000,
+): Promise<AssistantMessageEvent[]> {
+	const events: AssistantMessageEvent[] = [];
+	const iterator = stream[Symbol.asyncIterator]();
+	const deadline = Date.now() + timeoutMs;
+
+	while (Date.now() < deadline) {
+		const result = await Promise.race([
+			iterator.next(),
+			new Promise<IteratorResult<AssistantMessageEvent>>((resolve) =>
+				setTimeout(() => resolve({ value: undefined, done: true } as IteratorResult<AssistantMessageEvent>), timeoutMs),
+			),
+		]);
+		if (result.done) break;
+		events.push(result.value);
+	}
+	return events;
+}
+
+const baseUsage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+describe("streamProxy — server disconnect without terminal event", () => {
+	it("emits an error event when server disconnects after start with no terminal event", async () => {
+		const events: ProxyAssistantMessageEvent[] = [{ type: "start" }];
+		const body = buildSseBody(events);
+
+		const collected = await withMockFetch(body, 200, async () => {
+			const stream = streamProxy(mockModel, { role: "user", content: "hello", timestamp: Date.now() } as never, {
+				proxyUrl: "http://localhost:0",
+				authToken: "test",
+			});
+			return collectEvents(stream);
+		});
+
+		const hasError = collected.some((e) => e.type === "error");
+		expect(hasError).toBe(true);
+	});
+
+	it("resolves stream.result() with stopReason='error' when server disconnects mid-stream", async () => {
+		const events: ProxyAssistantMessageEvent[] = [
+			{ type: "start" },
+			{ type: "text_start", contentIndex: 0 },
+			{ type: "text_delta", contentIndex: 0, delta: "Hel" },
+		];
+		const body = buildSseBody(events);
+
+		await withMockFetch(body, 200, async () => {
+			const stream = streamProxy(mockModel, { role: "user", content: "hello", timestamp: Date.now() } as never, {
+				proxyUrl: "http://localhost:0",
+				authToken: "test",
+			});
+
+			// Consume iterator so the internal async function runs
+			const collected = await collectEvents(stream);
+			expect(collected.some((e) => e.type === "error")).toBe(true);
+
+			// stream.result() MUST resolve (not hang) with an error message
+			const result = await Promise.race([
+				stream.result().then((r) => ({ resolved: true as const, value: r })),
+				new Promise<{ resolved: false }>((resolve) =>
+					setTimeout(() => resolve({ resolved: false }), 500),
+				),
+			]);
+
+			expect(result.resolved).toBe(true);
+			if (result.resolved) {
+				expect(result.value.stopReason).toBe("error");
+				expect(result.value.errorMessage).toBeTruthy();
+			}
+		});
+	});
+
+	it("completes normally when server sends a 'done' event", async () => {
+		const events: ProxyAssistantMessageEvent[] = [
+			{ type: "start" },
+			{ type: "text_start", contentIndex: 0 },
+			{ type: "text_delta", contentIndex: 0, delta: "Hello" },
+			{ type: "text_end", contentIndex: 0 },
+			{
+				type: "done",
+				reason: "stop",
+				usage: { ...baseUsage },
+			},
+		];
+		const body = buildSseBody(events);
+
+		await withMockFetch(body, 200, async () => {
+			const stream = streamProxy(mockModel, { role: "user", content: "hello", timestamp: Date.now() } as never, {
+				proxyUrl: "http://localhost:0",
+				authToken: "test",
+			});
+
+			const collected = await collectEvents(stream);
+			expect(collected.some((e) => e.type === "done")).toBe(true);
+
+			const result = await stream.result();
+			expect(result.stopReason).toBe("stop");
+			expect(result.content.length).toBeGreaterThan(0);
+		});
+	});
+});

--- a/packages/agent/test/proxy-stream-disconnect.test.ts
+++ b/packages/agent/test/proxy-stream-disconnect.test.ts
@@ -54,8 +54,9 @@ async function collectEvents(
 	while (Date.now() < deadline) {
 		const { promise: timeoutPromise, resolve: timeoutResolve } =
 			Promise.withResolvers<IteratorResult<AssistantMessageEvent>>();
-		setTimeout(() => timeoutResolve({ value: undefined, done: true } as IteratorResult<AssistantMessageEvent>), timeoutMs);
+		const timer = setTimeout(() => timeoutResolve({ value: undefined, done: true } as IteratorResult<AssistantMessageEvent>), timeoutMs);
 		const result = await Promise.race([iterator.next(), timeoutPromise]);
+		clearTimeout(timer);
 		if (result.done) break;
 		events.push(result.value);
 	}
@@ -82,10 +83,12 @@ describe("streamProxy — server disconnect without terminal event", () => {
 			proxyUrl: "http://localhost:0",
 			authToken: "test",
 		});
-
 		const collected = await collectEvents(stream);
-		const hasError = collected.some((e) => e.type === "error");
-		expect(hasError).toBe(true);
+		const errorEvent = collected.find((e) => e.type === "error");
+		expect(errorEvent).toBeDefined();
+		if (errorEvent && errorEvent.type === "error") {
+			expect(errorEvent.reason).toBe("error");
+		}
 	});
 
 	it("resolves stream.result() with stopReason='error' when server disconnects mid-stream", async () => {
@@ -168,5 +171,34 @@ describe("streamProxy — server disconnect without terminal event", () => {
 		const result = await stream.result();
 		expect(result.stopReason).toBe("stop");
 		expect(result.content.length).toBeGreaterThan(0);
+	});
+
+	it("completes with error event when server sends an 'error' terminal event", async () => {
+		const events: ProxyAssistantMessageEvent[] = [
+			{ type: "start" },
+			{ type: "text_start", contentIndex: 0 },
+			{ type: "text_delta", contentIndex: 0, delta: "Hel" },
+			{
+				type: "error",
+				reason: "error",
+				errorMessage: "rate_limit_exceeded",
+				usage: { ...baseUsage },
+			},
+		];
+		const body = buildSseBody(events);
+
+		using _hook = hookFetch(() => new Response(body, { status: 200 }));
+
+		const stream = streamProxy(mockModel, mockContext, {
+			proxyUrl: "http://localhost:0",
+			authToken: "test",
+		});
+
+		const collected = await collectEvents(stream);
+		expect(collected.some((e) => e.type === "error")).toBe(true);
+
+		const result = await stream.result();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("rate_limit_exceeded");
 	});
 });

--- a/packages/agent/test/proxy-stream-disconnect.test.ts
+++ b/packages/agent/test/proxy-stream-disconnect.test.ts
@@ -7,9 +7,10 @@
  * event — it must NOT silently complete with default stopReason='stop'.
  */
 import { describe, expect, it } from "bun:test";
-import { streamProxy } from "@oh-my-pi/pi-agent-core/proxy";
+import { streamProxy, ProxyMessageEventStream } from "@oh-my-pi/pi-agent-core/proxy";
 import type { ProxyAssistantMessageEvent } from "@oh-my-pi/pi-agent-core/proxy";
-import type { AssistantMessageEvent, Model } from "@oh-my-pi/pi-ai";
+import type { AssistantMessageEvent, Context, Model } from "@oh-my-pi/pi-ai";
+import { hookFetch } from "@oh-my-pi/pi-utils";
 
 const mockModel: Model = {
 	id: "test-model",
@@ -22,6 +23,10 @@ const mockModel: Model = {
 	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 	contextWindow: 4096,
 	maxTokens: 1024,
+};
+
+const mockContext: Context = {
+	messages: [{ role: "user", content: "hello", timestamp: Date.now() }],
 };
 
 function buildSseBody(events: ProxyAssistantMessageEvent[]): ReadableStream<Uint8Array> {
@@ -38,23 +43,8 @@ function buildSseBody(events: ProxyAssistantMessageEvent[]): ReadableStream<Uint
 	});
 }
 
-async function withMockFetch<R>(
-	body: ReadableStream<Uint8Array>,
-	status: number,
-	fn: () => Promise<R>,
-): Promise<R> {
-	const originalFetch = globalThis.fetch;
-	globalThis.fetch = async (_input: RequestInfo | URL, _init?: RequestInit) =>
-		new Response(body, { status });
-	try {
-		return await fn();
-	} finally {
-		globalThis.fetch = originalFetch;
-	}
-}
-
 async function collectEvents(
-	stream: ReturnType<typeof streamProxy>,
+	stream: ProxyMessageEventStream,
 	timeoutMs = 2000,
 ): Promise<AssistantMessageEvent[]> {
 	const events: AssistantMessageEvent[] = [];
@@ -62,12 +52,10 @@ async function collectEvents(
 	const deadline = Date.now() + timeoutMs;
 
 	while (Date.now() < deadline) {
-		const result = await Promise.race([
-			iterator.next(),
-			new Promise<IteratorResult<AssistantMessageEvent>>((resolve) =>
-				setTimeout(() => resolve({ value: undefined, done: true } as IteratorResult<AssistantMessageEvent>), timeoutMs),
-			),
-		]);
+		const { promise: timeoutPromise, resolve: timeoutResolve } =
+			Promise.withResolvers<IteratorResult<AssistantMessageEvent>>();
+		setTimeout(() => timeoutResolve({ value: undefined, done: true } as IteratorResult<AssistantMessageEvent>), timeoutMs);
+		const result = await Promise.race([iterator.next(), timeoutPromise]);
 		if (result.done) break;
 		events.push(result.value);
 	}
@@ -88,14 +76,14 @@ describe("streamProxy — server disconnect without terminal event", () => {
 		const events: ProxyAssistantMessageEvent[] = [{ type: "start" }];
 		const body = buildSseBody(events);
 
-		const collected = await withMockFetch(body, 200, async () => {
-			const stream = streamProxy(mockModel, { role: "user", content: "hello", timestamp: Date.now() } as never, {
-				proxyUrl: "http://localhost:0",
-				authToken: "test",
-			});
-			return collectEvents(stream);
+		using _hook = hookFetch(() => new Response(body, { status: 200 }));
+
+		const stream = streamProxy(mockModel, mockContext, {
+			proxyUrl: "http://localhost:0",
+			authToken: "test",
 		});
 
+		const collected = await collectEvents(stream);
 		const hasError = collected.some((e) => e.type === "error");
 		expect(hasError).toBe(true);
 	});
@@ -108,30 +96,49 @@ describe("streamProxy — server disconnect without terminal event", () => {
 		];
 		const body = buildSseBody(events);
 
-		await withMockFetch(body, 200, async () => {
-			const stream = streamProxy(mockModel, { role: "user", content: "hello", timestamp: Date.now() } as never, {
-				proxyUrl: "http://localhost:0",
-				authToken: "test",
-			});
+		using _hook = hookFetch(() => new Response(body, { status: 200 }));
 
-			// Consume iterator so the internal async function runs
-			const collected = await collectEvents(stream);
-			expect(collected.some((e) => e.type === "error")).toBe(true);
-
-			// stream.result() MUST resolve (not hang) with an error message
-			const result = await Promise.race([
-				stream.result().then((r) => ({ resolved: true as const, value: r })),
-				new Promise<{ resolved: false }>((resolve) =>
-					setTimeout(() => resolve({ resolved: false }), 500),
-				),
-			]);
-
-			expect(result.resolved).toBe(true);
-			if (result.resolved) {
-				expect(result.value.stopReason).toBe("error");
-				expect(result.value.errorMessage).toBeTruthy();
-			}
+		const stream = streamProxy(mockModel, mockContext, {
+			proxyUrl: "http://localhost:0",
+			authToken: "test",
 		});
+
+		// Consume iterator so the internal async function runs
+		const collected = await collectEvents(stream);
+		expect(collected.some((e) => e.type === "error")).toBe(true);
+
+		// stream.result() MUST resolve (not hang) with an error message
+		const result = await stream.result();
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBeTruthy();
+	});
+
+	it("handles client-initiated abort with stopReason='aborted'", async () => {
+		const abortController = new AbortController();
+		// Pre-abort before any data arrives
+		abortController.abort();
+
+		const events: ProxyAssistantMessageEvent[] = [{ type: "start" }];
+		const body = buildSseBody(events);
+
+		using _hook = hookFetch(() => new Response(body, { status: 200 }));
+
+		const stream = streamProxy(mockModel, mockContext, {
+			proxyUrl: "http://localhost:0",
+			authToken: "test",
+			signal: abortController.signal,
+		});
+
+		const collected = await collectEvents(stream);
+		// Should get an error event with reason 'aborted'
+		const errorEvent = collected.find((e) => e.type === "error");
+		expect(errorEvent).toBeDefined();
+		if (errorEvent && errorEvent.type === "error") {
+			expect(errorEvent.reason).toBe("aborted");
+		}
+
+		const result = await stream.result();
+		expect(result.stopReason).toBe("aborted");
 	});
 
 	it("completes normally when server sends a 'done' event", async () => {
@@ -148,18 +155,18 @@ describe("streamProxy — server disconnect without terminal event", () => {
 		];
 		const body = buildSseBody(events);
 
-		await withMockFetch(body, 200, async () => {
-			const stream = streamProxy(mockModel, { role: "user", content: "hello", timestamp: Date.now() } as never, {
-				proxyUrl: "http://localhost:0",
-				authToken: "test",
-			});
+		using _hook = hookFetch(() => new Response(body, { status: 200 }));
 
-			const collected = await collectEvents(stream);
-			expect(collected.some((e) => e.type === "done")).toBe(true);
-
-			const result = await stream.result();
-			expect(result.stopReason).toBe("stop");
-			expect(result.content.length).toBeGreaterThan(0);
+		const stream = streamProxy(mockModel, mockContext, {
+			proxyUrl: "http://localhost:0",
+			authToken: "test",
 		});
+
+		const collected = await collectEvents(stream);
+		expect(collected.some((e) => e.type === "done")).toBe(true);
+
+		const result = await stream.result();
+		expect(result.stopReason).toBe("stop");
+		expect(result.content.length).toBeGreaterThan(0);
 	});
 });

--- a/packages/agent/test/proxy-stream-disconnect.test.ts
+++ b/packages/agent/test/proxy-stream-disconnect.test.ts
@@ -144,6 +144,29 @@ describe("streamProxy — server disconnect without terminal event", () => {
 		expect(result.stopReason).toBe("aborted");
 	});
 
+	it("preserves custom abort reason when client aborts mid-stream", async () => {
+		const abortController = new AbortController();
+		abortController.abort("user-interrupt");
+
+		const events: ProxyAssistantMessageEvent[] = [{ type: "start" }];
+		const body = buildSseBody(events);
+
+		using _hook = hookFetch(() => new Response(body, { status: 200 }));
+
+		const stream = streamProxy(mockModel, mockContext, {
+			proxyUrl: "http://localhost:0",
+			authToken: "test",
+			signal: abortController.signal,
+		});
+
+		const collected = await collectEvents(stream);
+		const result = await stream.result();
+		expect(result.stopReason).toBe("aborted");
+		// Custom abort reason must be preserved in errorMessage, not overwritten
+		// by the generic "Proxy stream ended without a terminal event" message
+		expect(result.errorMessage).toBe("user-interrupt");
+	});
+
 	it("completes normally when server sends a 'done' event", async () => {
 		const events: ProxyAssistantMessageEvent[] = [
 			{ type: "start" },


### PR DESCRIPTION
### Problem

`streamProxy` in `packages/agent/src/proxy.ts` silently returns a zero-token "success" response when the SSE server closes the connection without sending a `done` or `error` terminal event.

**Root cause**: After the `for await` loop exhausts the SSE stream, line 170 guarded only against client-initiated aborts (`options.signal?.aborted && !sawTerminalEvent`). Server-side disconnects leave `sawTerminalEvent` false without triggering the guard, so `stream.end()` is called with no arguments.

**Two failure modes**:

| Mode | Symptom |
|------|---------|
| Iterator consumption | Stream ends normally with `stopReason=stop` (the default), empty content, zero tokens — indistinguishable from a legitimate empty response |
| `stream.result()` caller | `finalResultPromise` never resolves, causing permanent hang |

### Impact

- Proxy crashes or connection drops produce empty responses with no error indication
- Agent loop skips error recovery, silently terminating long-running sessions
- `stream.result()` callers block forever, requiring a session abort to recover

### Fix

Replace the abort-only guard at `proxy.ts:170`:

```typescript
// Before — only handles client abort
if (options.signal?.aborted && !sawTerminalEvent) {
    const reason = options.signal.reason;
    throw reason instanceof Error ? reason : new Error(String(reason ?? "Request aborted"));
}
stream.end();
```

With a guard that covers all cases where no terminal event was received:

```typescript
// After — covers server disconnect and client abort
if (!sawTerminalEvent) {
    throw new Error("Proxy stream ended without a terminal event (done or error)");
}
stream.end();
```

The thrown error is caught by the existing catch block, which already distinguishes abort from error:

- **Server disconnect**: `signal?.aborted` is `false` → `reason = "error"`, error event is pushed, `finalResultPromise` resolves
- **Client abort**: `fetch`/`readSseJson` throws `AbortError` → `signal?.aborted` is `true` → `reason = "aborted"`

This matches the pattern used by the codex provider in `openai-codex-responses.ts:1620`.

### Tests (5)

| Test | Verifies |
|------|----------|
| Server disconnect (start only) | Stream emits `error` event with `reason=error` |
| Server disconnect (partial text) | `stream.result()` resolves with `stopReason=error` |
| Client pre-abort | Error event has `reason=aborted`, result has `stopReason=aborted` |
| Server sends `done` | Normal completion with `stopReason=stop` |
| Server sends `error` terminal event | `stopReason=error`, `errorMessage` forwarded correctly |

### Files changed

| File | Change |
|------|--------|
| `packages/agent/src/proxy.ts` | Replace abort-only guard with `!sawTerminalEvent` guard; export `ProxyMessageEventStream` |
| `packages/agent/test/proxy-stream-disconnect.test.ts` | Add 5 tests |
| `packages/agent/CHANGELOG.md` | Add entry under `## [Unreleased] > ### Fixed`