### PR TITLE
fix(tui): chunk oversized writes on Windows ConPTY so viewport tracks the cursor

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Windows ConPTY hosts (Windows Terminal, Tabby, Hyper, VS Code) parking the viewport at the top of a full paint after a `/resume` or any long-session repaint. `ProcessTerminal#safeWrite` now splits oversized writes into ≤ 8 KiB pieces at line boundaries on `win32` so each underlying `WriteFile` stays below the ~32 KiB threshold where ConPTY stops tracking the cursor; the data was always delivered, but the host UI's scroll position would not follow until any focus event forced a re-query. ([#2034](https://github.com/can1357/oh-my-pi/issues/2034))
+
 ## [15.10.1] - 2026-06-07
 ### Breaking Changes
 

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed Windows ConPTY hosts (Windows Terminal, Tabby, Hyper, VS Code) parking the viewport at the top of a full paint after a `/resume` or any long-session repaint. `ProcessTerminal#safeWrite` now splits oversized writes into ≤ 8 KiB pieces at line boundaries on `win32` so each underlying `WriteFile` stays below the ~32 KiB threshold where ConPTY stops tracking the cursor; the data was always delivered, but the host UI's scroll position would not follow until any focus event forced a re-query. ([#2034](https://github.com/can1357/oh-my-pi/issues/2034))
+- Fixed Windows ConPTY hosts (Windows Terminal, Tabby, Hyper, VS Code) parking the viewport at the top of a full paint after a `/resume` or any long-session repaint. `ProcessTerminal#safeWrite` now splits oversized writes into ≤ 8 KiB pieces at line boundaries on `win32` and inside WSL (where stdout still crosses ConPTY at the `wslhost` boundary) so each underlying `WriteFile` stays below the ~32 KiB threshold where ConPTY stops tracking the cursor; the data was always delivered, but the host UI's scroll position would not follow until any focus event forced a re-query. ([#2034](https://github.com/can1357/oh-my-pi/issues/2034))
 
 ## [15.10.1] - 2026-06-07
 ### Breaking Changes

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -10,6 +10,58 @@ const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1b]9;4;3\x07";
 const TERMINAL_PROGRESS_CLEAR_SEQUENCE = "\x1b]9;4;0;\x07";
 
 /**
+ * Maximum bytes per `process.stdout.write` call on Windows.
+ *
+ * Windows ConPTY ties viewport tracking to per-`WriteFile` boundaries: when a
+ * single write exceeds ~32-64 KB, the pseudo-console stops following the
+ * cursor and the host UI's viewport stays parked at whatever scroll position
+ * the write started from. The visible symptom is that a full-paint of a long
+ * session (resume, history rebuild, large permission dialog) shows only the
+ * first ~30 lines until any focus event forces the host to re-query the
+ * cursor. The data is delivered correctly — it's purely a viewport-sync bug.
+ *
+ * 8 KiB is well below the 32 KiB threshold reported on Windows Terminal and
+ * leaves headroom for the other ConPTY hosts (Tabby, Hyper, VS Code) where
+ * the exact limit is undocumented. The cost is a handful of extra syscalls
+ * per full paint — invisible compared to the cost of the paint itself.
+ */
+const MAX_CONPTY_WRITE_CHUNK = 8 * 1024;
+
+/**
+ * Split `data` into chunks no larger than `maxChunkSize`, preferring a line
+ * boundary (`\n`) as the cut point so escape sequences (which never contain
+ * `\n`) stay intact. The TUI's full-paint buffers are line-structured
+ * (`buffer += "\r\n"` between rows), so a newline almost always exists within
+ * the window. The fallback for a buffer with no newline in range is a hard
+ * cut at `maxChunkSize`: the ConPTY viewport bug from a single oversized
+ * write is strictly worse than a one-frame escape-sequence glitch on a buffer
+ * the renderer effectively never produces.
+ *
+ * Exported for unit testing of the chunking contract; `#safeWrite` is the
+ * sole production caller.
+ */
+export function chunkForConPTY(data: string, maxChunkSize: number = MAX_CONPTY_WRITE_CHUNK): string[] {
+	if (data.length <= maxChunkSize) return [data];
+	const chunks: string[] = [];
+	let pos = 0;
+	while (pos < data.length) {
+		const remaining = data.length - pos;
+		if (remaining <= maxChunkSize) {
+			chunks.push(data.slice(pos));
+			break;
+		}
+		const windowEnd = pos + maxChunkSize;
+		// Prefer the last newline inside the window so escape sequences stay
+		// intact within their chunk; hard-cut at `windowEnd` otherwise.
+		const nl = data.lastIndexOf("\n", windowEnd - 1);
+		const cut = nl >= pos ? nl + 1 : windowEnd;
+		chunks.push(data.slice(pos, cut));
+		pos = cut;
+	}
+	return chunks;
+}
+
+/**
  * Minimal terminal interface for TUI
  */
 
@@ -978,7 +1030,19 @@ export class ProcessTerminal implements Terminal {
 		// files). They serve no purpose there and would surface as visible noise.
 		if (!process.stdout.isTTY) return;
 		try {
-			process.stdout.write(data);
+			// Windows ConPTY drops viewport tracking when a single write exceeds
+			// ~32-64 KB: the host UI's scroll position stays parked at wherever
+			// the write began, even though every byte landed in scrollback. Split
+			// large paints into newline-aligned chunks so each underlying
+			// `WriteFile` stays well below the threshold. Non-win32 PTYs do not
+			// share the bug, so they keep the single-write fast path. See #2034.
+			if (process.platform === "win32" && data.length > MAX_CONPTY_WRITE_CHUNK) {
+				for (const chunk of chunkForConPTY(data, MAX_CONPTY_WRITE_CHUNK)) {
+					process.stdout.write(chunk);
+				}
+			} else {
+				process.stdout.write(data);
+			}
 		} catch (err) {
 			// Any write failure means terminal is dead - no recovery possible
 			this.#dead = true;

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -1034,9 +1034,13 @@ export class ProcessTerminal implements Terminal {
 			// ~32-64 KB: the host UI's scroll position stays parked at wherever
 			// the write began, even though every byte landed in scrollback. Split
 			// large paints into newline-aligned chunks so each underlying
-			// `WriteFile` stays well below the threshold. Non-win32 PTYs do not
-			// share the bug, so they keep the single-write fast path. See #2034.
-			if (process.platform === "win32" && data.length > MAX_CONPTY_WRITE_CHUNK) {
+			// `WriteFile` stays well below the threshold. The gate also covers
+			// WSL — `process.platform === "linux"` there, but stdout still
+			// crosses into ConPTY at the `wslhost` boundary, so the same per-
+			// WriteFile cap applies. Non-ConPTY PTYs keep the single-write fast
+			// path. See #2034.
+			const conptyHosted = process.platform === "win32" || isWindowsSubsystemForLinux();
+			if (conptyHosted && data.length > MAX_CONPTY_WRITE_CHUNK) {
 				for (const chunk of chunkForConPTY(data, MAX_CONPTY_WRITE_CHUNK)) {
 					process.stdout.write(chunk);
 				}

--- a/packages/tui/test/issue-2034-repro.test.ts
+++ b/packages/tui/test/issue-2034-repro.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import { chunkForConPTY, ProcessTerminal } from "@oh-my-pi/pi-tui/terminal";
+
+// Regression test for https://github.com/can1357/oh-my-pi/issues/2034
+//
+// Windows ConPTY ties viewport tracking to per-`WriteFile` boundaries: when
+// a single `process.stdout.write` exceeds ~32-64 KB, the pseudo-console
+// stops following the cursor and the host UI's scroll position stays parked
+// at wherever the write began. The data lands in scrollback — Alt+Tab forces
+// the host to re-query the cursor and the viewport jumps to the bottom —
+// but until then the user sees only the first screenful of a long session
+// or resume payload.
+//
+// Fix: `ProcessTerminal#safeWrite` chunks oversized writes into ≤ 8 KiB
+// pieces on `process.platform === "win32"`. Non-win32 PTYs do not share the
+// bug and keep the single-write fast path.
+
+const ESC = "\x1b";
+
+function buildFullPaint(lines: number, lineLength: number): string {
+	// Mirrors the shape of `TUI#emitFullPaint`'s buffer: a clear-screen prefix,
+	// rows terminated with `\r\n` and a per-line SGR reset, and a cursor/end
+	// sequence trailer. The exact bytes do not matter for the chunker — only
+	// that escapes are present and the buffer crosses the ConPTY threshold.
+	let buf = `${ESC}[2J${ESC}[H${ESC}[3J`;
+	for (let i = 0; i < lines; i++) {
+		if (i > 0) buf += "\r\n";
+		const content = `${ESC}[38;5;${i % 256}mrow-${i.toString().padStart(4, "0")}: ${"x".repeat(lineLength)}${ESC}[0m`;
+		buf += content;
+	}
+	buf += `${ESC}[H${ESC}[?25h`;
+	return buf;
+}
+
+describe("issue #2034: chunk large terminal writes on Windows ConPTY", () => {
+	describe("chunkForConPTY()", () => {
+		it("returns the original buffer untouched when under the chunk size", () => {
+			const data = "small payload";
+			expect(chunkForConPTY(data, 1024)).toEqual([data]);
+		});
+
+		it("splits a large multi-line buffer into pieces no larger than the chunk size", () => {
+			const data = buildFullPaint(2000, 60);
+			const max = 8 * 1024;
+			expect(data.length).toBeGreaterThan(max);
+
+			const chunks = chunkForConPTY(data, max);
+
+			expect(chunks.length).toBeGreaterThan(1);
+			for (const chunk of chunks) {
+				expect(chunk.length).toBeLessThanOrEqual(max);
+			}
+		});
+
+		it("preserves the full payload across chunks (no data loss or reordering)", () => {
+			const data = buildFullPaint(500, 120);
+			const chunks = chunkForConPTY(data, 4 * 1024);
+			expect(chunks.join("")).toBe(data);
+		});
+
+		it("splits at newline boundaries so escape sequences are never sliced apart", () => {
+			// Every row is bracketed by SGR escapes. If the chunker cut inside a
+			// chunk's escape sequence, the trailing chunk would not start with
+			// either an escape or the post-newline state — instead it would
+			// start with a stray CSI byte (`[`, digits, `m`).
+			const data = buildFullPaint(400, 80);
+			const chunks = chunkForConPTY(data, 4 * 1024);
+			// Exclude the head chunk (starts with the clear-screen prefix).
+			for (const chunk of chunks.slice(1)) {
+				// Every subsequent chunk begins on a fresh line: either the new
+				// line's first byte is the SGR escape, the row's plaintext
+				// prefix, or — for the trailing tail — the cursor sequence.
+				const firstByte = chunk.charCodeAt(0);
+				const startsWithEsc = chunk.startsWith(ESC);
+				const startsWithRowText = chunk.startsWith("row-");
+				expect(startsWithEsc || startsWithRowText).toBe(true);
+				if (!startsWithEsc) {
+					// Plain-text starts cannot be control characters that would
+					// indicate a sliced escape (CSI `[`, digits, or `m`).
+					expect(firstByte).toBeGreaterThanOrEqual(0x20);
+				}
+			}
+		});
+
+		it("makes forward progress on a single line longer than the chunk size", () => {
+			// Pathological case: one very long line with no embedded `\n`. The
+			// chunker must not loop, and the joined chunks must equal the input.
+			const giantLine = "a".repeat(20_000);
+			const data = `${giantLine}\nshort\n`;
+			const chunks = chunkForConPTY(data, 4 * 1024);
+			expect(chunks.length).toBeGreaterThanOrEqual(2);
+			expect(chunks.join("")).toBe(data);
+		});
+
+		it("falls back to a raw split when the buffer contains no newlines", () => {
+			const data = "x".repeat(20_000);
+			const chunks = chunkForConPTY(data, 4 * 1024);
+			expect(chunks.join("")).toBe(data);
+			expect(chunks.length).toBeGreaterThan(1);
+			// Every chunk except possibly the tail is exactly the chunk size.
+			for (const chunk of chunks.slice(0, -1)) {
+				expect(chunk.length).toBe(4 * 1024);
+			}
+		});
+	});
+
+	describe("ProcessTerminal#write on win32", () => {
+		const stdinIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
+		const stdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+		const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+
+		beforeEach(() => {
+			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+			Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+		});
+
+		afterEach(() => {
+			vi.restoreAllMocks();
+			if (platformDescriptor) Object.defineProperty(process, "platform", platformDescriptor);
+			if (stdinIsTtyDescriptor) Object.defineProperty(process.stdin, "isTTY", stdinIsTtyDescriptor);
+			else Reflect.deleteProperty(process.stdin, "isTTY");
+			if (stdoutIsTtyDescriptor) Object.defineProperty(process.stdout, "isTTY", stdoutIsTtyDescriptor);
+			else Reflect.deleteProperty(process.stdout, "isTTY");
+		});
+
+		function captureStdoutWrites(): string[] {
+			const writes: string[] = [];
+			vi.spyOn(process.stdout, "write").mockImplementation(chunk => {
+				writes.push(typeof chunk === "string" ? chunk : chunk.toString());
+				return true;
+			});
+			return writes;
+		}
+
+		it("splits >8 KiB writes into chunks on win32 so ConPTY can track the viewport", () => {
+			Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+			const writes = captureStdoutWrites();
+			const terminal = new ProcessTerminal();
+			const payload = buildFullPaint(2000, 60);
+
+			terminal.write(payload);
+
+			const conptyChunks = writes.filter(w => w.length > 0);
+			expect(conptyChunks.length).toBeGreaterThan(1);
+			for (const chunk of conptyChunks) {
+				expect(chunk.length).toBeLessThanOrEqual(8 * 1024);
+			}
+			expect(conptyChunks.join("")).toBe(payload);
+		});
+
+		it("keeps the single-write fast path on non-win32 platforms", () => {
+			Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+			const writes = captureStdoutWrites();
+			const terminal = new ProcessTerminal();
+			const payload = buildFullPaint(2000, 60);
+
+			terminal.write(payload);
+
+			expect(writes).toEqual([payload]);
+		});
+
+		it("does not chunk small writes on win32", () => {
+			Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+			const writes = captureStdoutWrites();
+			const terminal = new ProcessTerminal();
+			const payload = `${ESC}[H${ESC}[K`;
+
+			terminal.write(payload);
+
+			expect(writes).toEqual([payload]);
+		});
+	});
+});

--- a/packages/tui/test/issue-2034-repro.test.ts
+++ b/packages/tui/test/issue-2034-repro.test.ts
@@ -104,14 +104,24 @@ describe("issue #2034: chunk large terminal writes on Windows ConPTY", () => {
 		});
 	});
 
-	describe("ProcessTerminal#write on win32", () => {
+	describe("ProcessTerminal#write platform gate", () => {
 		const stdinIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
 		const stdoutIsTtyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
 		const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+		const originalWslDistro = Bun.env.WSL_DISTRO_NAME;
+		const originalWslInterop = Bun.env.WSL_INTEROP;
+
+		function setEnv(key: string, value: string | undefined): void {
+			if (value === undefined) delete Bun.env[key];
+			else Bun.env[key] = value;
+		}
 
 		beforeEach(() => {
 			Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
 			Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+			// Clear WSL markers by default; tests opt in.
+			setEnv("WSL_DISTRO_NAME", undefined);
+			setEnv("WSL_INTEROP", undefined);
 		});
 
 		afterEach(() => {
@@ -121,6 +131,8 @@ describe("issue #2034: chunk large terminal writes on Windows ConPTY", () => {
 			else Reflect.deleteProperty(process.stdin, "isTTY");
 			if (stdoutIsTtyDescriptor) Object.defineProperty(process.stdout, "isTTY", stdoutIsTtyDescriptor);
 			else Reflect.deleteProperty(process.stdout, "isTTY");
+			setEnv("WSL_DISTRO_NAME", originalWslDistro);
+			setEnv("WSL_INTEROP", originalWslInterop);
 		});
 
 		function captureStdoutWrites(): string[] {
@@ -148,7 +160,25 @@ describe("issue #2034: chunk large terminal writes on Windows ConPTY", () => {
 			expect(conptyChunks.join("")).toBe(payload);
 		});
 
-		it("keeps the single-write fast path on non-win32 platforms", () => {
+		it("splits >8 KiB writes inside WSL because stdout still crosses ConPTY at wslhost", () => {
+			Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+			setEnv("WSL_DISTRO_NAME", "Ubuntu");
+			setEnv("WSL_INTEROP", "/run/WSL/123_interop");
+			const writes = captureStdoutWrites();
+			const terminal = new ProcessTerminal();
+			const payload = buildFullPaint(2000, 60);
+
+			terminal.write(payload);
+
+			const conptyChunks = writes.filter(w => w.length > 0);
+			expect(conptyChunks.length).toBeGreaterThan(1);
+			for (const chunk of conptyChunks) {
+				expect(chunk.length).toBeLessThanOrEqual(8 * 1024);
+			}
+			expect(conptyChunks.join("")).toBe(payload);
+		});
+
+		it("keeps the single-write fast path on non-ConPTY platforms (clean linux, darwin)", () => {
 			Object.defineProperty(process, "platform", { value: "linux", configurable: true });
 			const writes = captureStdoutWrites();
 			const terminal = new ProcessTerminal();


### PR DESCRIPTION
## Repro

On Windows Terminal (or any ConPTY host: Tabby, Hyper, VS Code), `/resume` of a long session or the initial render of a session with several hundred rendered lines leaves the visible viewport parked at the top — only the first ~30 lines are on screen even though the rest of the transcript is in scrollback. Mouse wheel / Page Up reveals the missing rows; Alt+Tab away and back forces the host to re-query the cursor and the viewport snaps to the latest content.

Sessions under ~300 lines never trip it because their full-paint buffer stays under the threshold.

## Cause

`TUI` builds each full paint (see `packages/tui/src/tui.ts` — `#emitFullPaint`, `#emitInitialLiveRegionPinnedPaint`, the viewport / scrollback emitters) into a single `buffer` string and hands it to `this.terminal.write(buffer)`. `ProcessTerminal#safeWrite` (`packages/tui/src/terminal.ts:975`) then passed that buffer to `process.stdout.write` in one shot.

ConPTY ties its viewport tracking to per-`WriteFile` boundaries: a single write larger than ~32–64 KB stops it from following the cursor for that write, so the host UI's scroll position stays at whatever it had after processing the `\x1b[2J\x1b[H\x1b[3J` prefix. Every byte still reaches scrollback — the symptom is purely a viewport-sync bug, which is why Alt+Tab restores everything.

## Fix

- Added `chunkForConPTY(data, maxChunkSize)` in `packages/tui/src/terminal.ts`. Splits at the last `\n` inside each window so escape sequences (which never contain `\n`) stay intact within their chunk; falls back to a hard cut at the chunk size for the (essentially unreachable) no-newline-anywhere buffer. Forward progress is guaranteed.
- `ProcessTerminal#safeWrite` now routes oversized writes through `chunkForConPTY` only when `process.platform === "win32"` and `data.length > MAX_CONPTY_WRITE_CHUNK` (8 KiB — 4× headroom below ConPTY's reported limit). Non-win32 PTYs keep the single-write fast path.
- Added `packages/tui/test/issue-2034-repro.test.ts` covering the chunker's invariants (size cap, payload preservation, line-aligned cuts, forward progress on pathological inputs) and `ProcessTerminal#write`'s platform-gated behavior (chunks on win32, passes through on linux, leaves small writes alone everywhere).
- CHANGELOG `[Unreleased] → Fixed` entry.

## Verification

- `bun --cwd packages/tui test test/issue-2034-repro.test.ts` — 9 pass, 0 fail.
- `bun --cwd packages/tui run check` — biome + tsgo clean.

Pre-existing `bun test` failures in `packages/tui/test/{text-utils,visible-width}.test.ts` (9 OSC 66 parity cases) reproduce verbatim on `origin/main` with this PR's changes stashed; unrelated to the chunking change.

Fixes #2034