### PR TITLE
fix(tui): apply follow-up slash commands

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed follow-up shortcut submission of builtin slash commands so `/goal set ...` applies goal mode instead of queueing as plain text.
+
 ## [15.10.1] - 2026-06-07
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -589,7 +589,7 @@ export class InputController {
 
 	/** Send editor text as a follow-up message (queued behind current stream). */
 	async handleFollowUp(): Promise<void> {
-		const text = this.ctx.editor.getText().trim();
+		let text = this.ctx.editor.getText().trim();
 		if (!text) return;
 
 		// Compaction first: while compacting, free text gets queued via
@@ -601,6 +601,16 @@ export class InputController {
 		if (this.ctx.session.isCompacting) {
 			this.ctx.queueCompactionMessage(text, "followUp");
 			return;
+		}
+
+		const slashResult = await executeBuiltinSlashCommand(text, {
+			ctx: this.ctx,
+		});
+		if (slashResult === true) {
+			return;
+		}
+		if (typeof slashResult === "string") {
+			text = slashResult;
 		}
 
 		// Skill commands invoke through the custom-message path regardless of

--- a/packages/coding-agent/test/input-controller-skill-queue.test.ts
+++ b/packages/coding-agent/test/input-controller-skill-queue.test.ts
@@ -71,6 +71,8 @@ function createStubInputControllerContext(opts: { skillCommands: Map<string, str
 	// Annotate parameters so `mock.calls[N]` is typed as a tuple (not `[]`) and
 	// `message` carries required skill prompt details for assertion below.
 	const promptCustomMessage = vi.fn(async (_message: { details: SkillPromptDetails }, _options?: unknown) => {});
+	const prompt = vi.fn(async (_text: string, _options?: unknown) => {});
+	const handleGoalModeCommand = vi.fn(async (_rest?: string) => {});
 	const updatePendingMessagesDisplay = vi.fn();
 	const requestRender = vi.fn();
 	const showError = vi.fn();
@@ -86,9 +88,12 @@ function createStubInputControllerContext(opts: { skillCommands: Map<string, str
 			isEvalRunning: false,
 			extensionRunner: undefined,
 			enqueueCustomMessageDisplay,
+			prompt,
 			promptCustomMessage,
 		},
 		showError,
+		handleGoalModeCommand,
+		goalModeEnabled: false,
 		updatePendingMessagesDisplay,
 		// Defaults that InputController touches on submit but don't matter here.
 		isBashMode: false,
@@ -101,7 +106,7 @@ function createStubInputControllerContext(opts: { skillCommands: Map<string, str
 		withLocalSubmission: async (_text: string, fn: () => unknown) => fn(),
 	} as unknown as InteractiveModeContext;
 
-	return { ctx, editor, enqueueCustomMessageDisplay, promptCustomMessage };
+	return { ctx, editor, enqueueCustomMessageDisplay, prompt, promptCustomMessage, handleGoalModeCommand };
 }
 
 describe("InputController #invokeSkillCommand (E1-E3)", () => {
@@ -164,6 +169,21 @@ describe("InputController #invokeSkillCommand (E1-E3)", () => {
 		}
 		const messageArg = firstCall[0];
 		expect(messageArg.details.__pendingDisplayTag).toBe("sk-test-0");
+	});
+
+	it("E2b: streaming follow-up applies builtin slash commands instead of queueing them", async () => {
+		const { ctx, editor, prompt, handleGoalModeCommand } = createStubInputControllerContext({
+			skillCommands,
+			isStreaming: true,
+		});
+
+		const controller = new InputController(ctx);
+		editor.setText("/goal set Ship the release");
+		await controller.handleFollowUp();
+
+		expect(handleGoalModeCommand).toHaveBeenCalledWith("set Ship the release");
+		expect(prompt).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("");
 	});
 
 	it("E3: not streaming -> enqueueCustomMessageDisplay NOT called and tag absent", async () => {


### PR DESCRIPTION
## Repro
Submitting `/goal set Ship the release` through `InputController.handleFollowUp()` while `session.isStreaming` is true reproduced the issue with `bun test packages/coding-agent/test/input-controller-skill-queue.test.ts`: the regression assertion showed `handleGoalModeCommand("set Ship the release")` was never called, so the text fell through to follow-up prompt queueing.

## Cause
`packages/coding-agent/src/modes/controllers/input-controller.ts` dispatched builtin slash commands only in the normal Enter submit path via `executeBuiltinSlashCommand`; `handleFollowUp()` skipped that dispatcher and only special-cased `/skill:*` before calling `session.prompt(..., { streamingBehavior: "followUp" })`, so `/goal set ...` became queued user text.

## Fix
- Route follow-up shortcut text through `executeBuiltinSlashCommand` before `/skill:*` and follow-up queue handling.
- Keep command-returned prompt text flowing through the existing follow-up path when a builtin expands to a prompt.
- Add regression coverage for streaming `/goal set ...` submitted through `handleFollowUp()`.
- Add an Unreleased changelog entry for the TUI fix.

## Verification
`bun test packages/coding-agent/test/input-controller-skill-queue.test.ts` passed (11 tests). `bun --cwd=packages/coding-agent run check` passed. Pre-publish `gh_push_branch` gate passed. Fixes #2038