### PR TITLE
fix(tui): honor kitty reply when DA1 sentinel arrives first

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the kitty keyboard progressive-enhancement probe to honor the `CSI ? <flags> u` reply even when the terminal answers the DA1 sentinel first. Previously the kitty reply was discarded once the DA1-driven `modifyOtherKeys` fallback engaged, so terminals like Superset/xterm-on-Electron stayed on the fallback and delivered Shift+Enter as a bare `\r` ([#2042](https://github.com/can1357/oh-my-pi/issues/2042)).
+
 ## [15.10.1] - 2026-06-07
 ### Breaking Changes
 

--- a/packages/tui/src/terminal.ts
+++ b/packages/tui/src/terminal.ts
@@ -504,10 +504,19 @@ export class ProcessTerminal implements Terminal {
 			}
 
 			const match = sequence.match(kittyResponsePattern);
-			if (match && !this.#modifyOtherKeysActive) {
+			if (match) {
 				if (this.#modifyOtherKeysTimeout) {
 					clearTimeout(this.#modifyOtherKeysTimeout);
 					this.#modifyOtherKeysTimeout = undefined;
+				}
+				// A DA1 sentinel that beat the kitty reply may have already
+				// engaged the modifyOtherKeys fallback (terminals such as
+				// Superset/xterm-on-Electron answer DA1 before `\x1b[?u`).
+				// Kitty is strictly preferred — undo the fallback so the two
+				// modes do not stack. See #2042.
+				if (this.#modifyOtherKeysActive) {
+					this.#safeWrite("\x1b[>4;0m");
+					this.#modifyOtherKeysActive = false;
 				}
 				// Any reply to `\x1b[?u` means the terminal speaks the kitty keyboard
 				// protocol. The reported flag value is the *current* stack-top — fresh

--- a/packages/tui/test/kitty-keyboard-da1-ordering.test.ts
+++ b/packages/tui/test/kitty-keyboard-da1-ordering.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	createProcessTerminalRenderHarness,
+	type ProcessTerminalRenderHarness,
+} from "./process-terminal-render-harness";
+
+// Progressive-enhancement probe ordering contract. omp sends `CSI ? u \\ CSI c`
+// at startup: the kitty reply (`CSI ? <flags> u`) authoritatively says the
+// terminal speaks the kitty keyboard protocol; the DA1 reply (`CSI ? ... c`)
+// is only a sentinel that guarantees a reply even from terminals that ignore
+// `CSI ? u`. Some terminals (Superset / xterm-on-Electron) answer DA1 first;
+// the kitty reply must still be honored regardless of ordering.
+describe("ProcessTerminal kitty keyboard progressive-enhancement ordering", () => {
+	let harness: ProcessTerminalRenderHarness | undefined;
+
+	afterEach(() => {
+		harness?.dispose();
+		harness = undefined;
+	});
+
+	it("enables kitty when the kitty reply arrives before the DA1 sentinel", async () => {
+		harness = createProcessTerminalRenderHarness(100, 30);
+		await harness.settle();
+		expect(harness.writes.join("")).toContain("\x1b[?u\x1b[c");
+		harness.writes.length = 0;
+
+		await harness.feed("\x1b[?0u", "\x1b[?1;2c");
+
+		const out = harness.writes.join("");
+		expect(harness.terminal.kittyProtocolActive).toBe(true);
+		expect(out).toContain("\x1b[>1u");
+		expect(out).not.toContain("\x1b[>4;2m");
+	});
+
+	it("enables kitty when the DA1 sentinel arrives before the kitty reply (#2042)", async () => {
+		harness = createProcessTerminalRenderHarness(100, 30);
+		await harness.settle();
+		harness.writes.length = 0;
+
+		// Superset/Electron-xterm answers DA1 before `CSI ? u`. The kitty reply
+		// must override the premature modifyOtherKeys fallback.
+		await harness.feed("\x1b[?1;2c", "\x1b[?0u");
+
+		const out = harness.writes.join("");
+		expect(harness.terminal.kittyProtocolActive).toBe(true);
+		expect(out).toContain("\x1b[>1u");
+		const enableIdx = out.indexOf("\x1b[>4;2m");
+		const disableIdx = out.indexOf("\x1b[>4;0m");
+		const kittyIdx = out.indexOf("\x1b[>1u");
+		expect(enableIdx).toBeGreaterThanOrEqual(0);
+		expect(disableIdx).toBeGreaterThan(enableIdx);
+		expect(kittyIdx).toBeGreaterThan(enableIdx);
+	});
+
+	it("keeps the modifyOtherKeys fallback when only DA1 ever replies", async () => {
+		harness = createProcessTerminalRenderHarness(100, 30);
+		await harness.settle();
+		harness.writes.length = 0;
+
+		// Terminals that ignore `CSI ? u` answer DA1 only — modifyOtherKeys is
+		// the right answer there.
+		await harness.feed("\x1b[?1;2c");
+
+		const out = harness.writes.join("");
+		expect(harness.terminal.kittyProtocolActive).toBe(false);
+		expect(out).toContain("\x1b[>4;2m");
+		expect(out).not.toContain("\x1b[>1u");
+	});
+});


### PR DESCRIPTION
## Repro

On terminals that answer DA1 (`CSI c`) **before** the kitty keyboard progressive-enhancement query (`CSI ? u`) — e.g. Superset / xterm-on-Electron, which reports `TERM_PROGRAM=kitty` and fully implements the protocol — `omp` never enables the kitty keyboard protocol. `Shift+Enter` is delivered as a bare `\r` and the input box submits instead of inserting a newline. The reporter captured the offending reply ordering as `\x1b[?1;2c\x1b[?0u\x1b[?62;4;9;22c` (DA1 first, then `CSI ? 0 u`, then a duplicate DA1).

Reproduced via a new regression test that drives a real `ProcessTerminal` through the existing render harness:

```
cd packages/tui && bun test test/kitty-keyboard-da1-ordering.test.ts
```

Without the fix the DA1-then-kitty case fails (`terminal.kittyProtocolActive` stays `false`, `\x1b[>1u` never written); the kitty-first and DA1-only cases pass.

## Cause

`packages/tui/src/terminal.ts` uses DA1 as a fallback sentinel for the kitty probe. When the DA1 reply arrives while the 150 ms timer is still armed, the `keyboard` sentinel branch engages `modifyOtherKeys` (`\x1b[>4;2m`) and sets `#modifyOtherKeysActive = true`. The subsequent kitty reply hits

```ts
const match = sequence.match(kittyResponsePattern);
if (match && !this.#modifyOtherKeysActive) { ... }
```

at `terminal.ts:506-507` and is silently discarded by the guard, so `\x1b[>1u` is never pushed and `setKittyProtocolActive(true)` never runs.

## Fix

- Drop the `!this.#modifyOtherKeysActive` guard so the kitty reply is authoritative regardless of probe ordering.
- If `modifyOtherKeysActive` was already engaged by a premature DA1 sentinel, send `\x1b[>4;0m` to disable it before pushing the kitty stack frame. Kitty is strictly preferred (per the existing comment about regression #3259), so this is a clean cutover.
- Add `packages/tui/test/kitty-keyboard-da1-ordering.test.ts` covering three orderings: kitty-then-DA1 (control), DA1-then-kitty (#2042 regression), DA1-only (modifyOtherKeys fallback retained).
- Note the user-visible fix in `packages/tui/CHANGELOG.md`'s `[Unreleased]` section.

## Verification

```
cd packages/tui && bun test test/kitty-keyboard-da1-ordering.test.ts test/terminal-appearance.test.ts test/terminal-capabilities.test.ts test/process-terminal-render.test.ts test/kitty-graphics.test.ts
```

→ 67 pass / 0 fail.

Skipped the pre-publish gate (`skip_checks=true`) because `bun test` on a clean `main` already fails 9 OSC 66 / `visibleWidth` parity tests in `test/visible-width.test.ts` and `test/text-utils.test.ts` (native-engine width parity drift, unrelated to this change). Confirmed by stashing the diff and re-running the same files against unmodified `main` — identical 9 failures.

Fixes #2042