### PR TITLE
fix: apply enabledModels filter to ACP model list (Zed model picker)

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `enabledModels` being ignored by the ACP model picker (Zed and other ACP clients) — `AgentSession.getAvailableModels()` now applies the configured allow-list, so only the models listed in `enabledModels` appear in the UI. Also applies consistently to the RPC `get_available_models` endpoint and the `/model` slash command.
+
 ## [15.10.11] - 2026-06-10
 
 ### Added
@@ -358,10 +362,6 @@
 - Fixed `lsp config` accepting `fileTypes` entries with or without a leading dot inconsistently across actions; both `.ts` and `ts` are now normalized so a missing-dot entry no longer silently excludes a server from extension-based routing.
 - Fixed `lsp request` error path swallowing the params that were sent, making shape/coercion bugs on raw LSP calls impossible to diagnose in one round-trip; the error now echoes a truncated copy of the request params.
 - Fixed `find` with a single-star segment like `dir/*` recursing into subdirectories and returning nested matches. `parseFindPattern` already prepends `**/` for top-level globs (`*.ts` → `**/*.ts`), so anything reaching native without `**/` was deliberately scoped by the user; `recursive: false` is now passed to `natives.glob` to honor that scope.
-
-### Fixed
-
-- Fixed `enabledModels` being ignored by the ACP model picker (Zed and other ACP clients) — `AgentSession.getAvailableModels()` now applies the configured allow-list, so only the models listed in `enabledModels` appear in the UI. Also applies consistently to the RPC `get_available_models` endpoint and the `/model` slash command.
 
 ## [15.10.1] - 2026-06-07
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -359,6 +359,10 @@
 - Fixed `lsp request` error path swallowing the params that were sent, making shape/coercion bugs on raw LSP calls impossible to diagnose in one round-trip; the error now echoes a truncated copy of the request params.
 - Fixed `find` with a single-star segment like `dir/*` recursing into subdirectories and returning nested matches. `parseFindPattern` already prepends `**/` for top-level globs (`*.ts` → `**/*.ts`), so anything reaching native without `**/` was deliberately scoped by the user; `recursive: false` is now passed to `natives.glob` to honor that scope.
 
+### Fixed
+
+- Fixed `enabledModels` being ignored by the ACP model picker (Zed and other ACP clients) — `AgentSession.getAvailableModels()` now applies the configured allow-list, so only the models listed in `enabledModels` appear in the UI. Also applies consistently to the RPC `get_available_models` endpoint and the `/model` slash command.
+
 ## [15.10.1] - 2026-06-07
 
 ### Added

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1060,19 +1060,25 @@ export async function resolveAllowedModels(
 
 /**
  * Synchronous subset of {@link resolveAllowedModels} for contexts where async is unavailable
- * (e.g. the ACP model-list advertisement). Handles the patterns that cover real-world configs:
+ * (e.g. `getAvailableModels()` which is called from the ACP model-list advertisement, RPC
+ * `get_available_models`, and the `/model` slash command). Handles the patterns that cover
+ * real-world configs:
  *
  * - Exact `provider/modelId` selectors
  * - Canonical ids (expanded via `getCanonicalVariants`)
  * - Bare model ids (matched across all available providers)
- * - Optional `:thinkingLevel` suffix on any of the above is stripped before matching
+ * - Optional `:thinkingLevel` suffix validated via `parseThinkingLevel` before stripping,
+ *   so colon-bearing OpenRouter ids (e.g. `openrouter/qwen/qwen3-coder:exacto`) are preserved
  *
- * Glob patterns (`*`, `?`, `[`) require async resolution; when any pattern contains a glob
- * the full unfiltered list is returned so the UI is never accidentally empty.
+ * Glob patterns (`*`, `?`, `[`) require the async `resolveModelScope` path; they are skipped
+ * here with a warning. When ALL patterns are globs (none can be evaluated synchronously) the
+ * full available list is returned so the UI is never accidentally empty. Mixed glob + exact
+ * patterns apply only the exact ones.
  *
- * Returns the unfiltered list when no pattern resolves to any model, mirroring the
- * "no usable model" guard in {@link resolveAllowedModels} but leaning toward showing
- * more rather than nothing in a UI context.
+ * When no pattern resolves to any model (misconfiguration / typo) an empty list is returned,
+ * consistent with the empty-list contract of {@link resolveAllowedModels}. Callers that render
+ * a UI picker should treat an empty list as "hide the picker entry", matching how the SDK
+ * surfaces the same misconfiguration during session initialization.
  */
 export function filterAvailableModelsByEnabledPatterns(
 	available: Model<Api>[],
@@ -1082,16 +1088,26 @@ export function filterAvailableModelsByEnabledPatterns(
 	if (patterns.length === 0) return available;
 
 	const allowed = new Set<string>();
+	let allGlobs = true;
 	for (const pattern of patterns) {
-		// Glob patterns need the async resolveModelScope path; return all rather than
-		// accidentally hiding models.
+		// Glob patterns need the async resolveModelScope path; skip them here and warn.
 		if (pattern.includes("*") || pattern.includes("?") || pattern.includes("[")) {
-			return available;
+			logger.warn(
+				"filterAvailableModelsByEnabledPatterns: glob pattern skipped in sync context (use exact provider/modelId or canonical ids in enabledModels for ACP model filtering)",
+				{ pattern },
+			);
+			continue;
 		}
+		allGlobs = false;
 
-		// Strip optional thinking-level suffix (e.g. "claude-sonnet-4-6:high").
+		// Strip a `:thinkingLevel` suffix only when the part after the last colon is a
+		// recognised thinking level. This preserves colon-bearing OpenRouter ids such as
+		// `openrouter/qwen/qwen3-coder:exacto` where the suffix is NOT a thinking level.
 		const colonIdx = pattern.lastIndexOf(":");
-		const basePattern = colonIdx !== -1 ? pattern.slice(0, colonIdx) : pattern;
+		const basePattern =
+			colonIdx !== -1 && parseThinkingLevel(pattern.slice(colonIdx + 1))
+				? pattern.slice(0, colonIdx)
+				: pattern;
 
 		// Explicit provider/modelId — resolve directly via the existing reference matcher.
 		if (basePattern.includes("/")) {
@@ -1119,10 +1135,13 @@ export function filterAvailableModelsByEnabledPatterns(
 		}
 	}
 
-	if (allowed.size === 0) return available;
-	return available.filter(m => allowed.has(`${m.provider}/${m.id}`));
-}
+	// All patterns were globs — fall back to the full list since we cannot evaluate them.
+	if (allGlobs) return available;
 
+	// Empty allowed set means every non-glob pattern failed to resolve (misconfiguration).
+	// Return [] consistent with resolveAllowedModels so callers can surface the problem.
+	return allowed.size === 0 ? [] : available.filter(m => allowed.has(`${m.provider}/${m.id}`));
+}
 
 export interface ResolveCliModelResult {
 	model: Model<Api> | undefined;

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1105,9 +1105,7 @@ export function filterAvailableModelsByEnabledPatterns(
 		// `openrouter/qwen/qwen3-coder:exacto` where the suffix is NOT a thinking level.
 		const colonIdx = pattern.lastIndexOf(":");
 		const basePattern =
-			colonIdx !== -1 && parseThinkingLevel(pattern.slice(colonIdx + 1))
-				? pattern.slice(0, colonIdx)
-				: pattern;
+			colonIdx !== -1 && parseThinkingLevel(pattern.slice(colonIdx + 1)) ? pattern.slice(0, colonIdx) : pattern;
 
 		// Explicit provider/modelId — resolve directly via the existing reference matcher.
 		if (basePattern.includes("/")) {

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1114,6 +1114,14 @@ export function filterAvailableModelsByEnabledPatterns(
 			const match = findExactModelReferenceMatch(basePattern, available);
 			if (match) {
 				allowed.add(`${match.provider}/${match.id}`);
+				continue;
+			}
+			// Fallback: treat the whole pattern as a model ID (handles OpenRouter-style bare IDs
+			// like "qwen/qwen3-coder:exacto" where the "/" is part of the id, not a provider separator).
+			for (const m of available) {
+				if (m.id === basePattern) {
+					allowed.add(`${m.provider}/${m.id}`);
+				}
 			}
 			continue;
 		}

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1058,6 +1058,72 @@ export async function resolveAllowedModels(
 	return available.filter(model => allowed.has(`${model.provider}/${model.id}`));
 }
 
+/**
+ * Synchronous subset of {@link resolveAllowedModels} for contexts where async is unavailable
+ * (e.g. the ACP model-list advertisement). Handles the patterns that cover real-world configs:
+ *
+ * - Exact `provider/modelId` selectors
+ * - Canonical ids (expanded via `getCanonicalVariants`)
+ * - Bare model ids (matched across all available providers)
+ * - Optional `:thinkingLevel` suffix on any of the above is stripped before matching
+ *
+ * Glob patterns (`*`, `?`, `[`) require async resolution; when any pattern contains a glob
+ * the full unfiltered list is returned so the UI is never accidentally empty.
+ *
+ * Returns the unfiltered list when no pattern resolves to any model, mirroring the
+ * "no usable model" guard in {@link resolveAllowedModels} but leaning toward showing
+ * more rather than nothing in a UI context.
+ */
+export function filterAvailableModelsByEnabledPatterns(
+	available: Model<Api>[],
+	patterns: readonly string[],
+	registry: Pick<ModelRegistry, "getCanonicalVariants">,
+): Model<Api>[] {
+	if (patterns.length === 0) return available;
+
+	const allowed = new Set<string>();
+	for (const pattern of patterns) {
+		// Glob patterns need the async resolveModelScope path; return all rather than
+		// accidentally hiding models.
+		if (pattern.includes("*") || pattern.includes("?") || pattern.includes("[")) {
+			return available;
+		}
+
+		// Strip optional thinking-level suffix (e.g. "claude-sonnet-4-6:high").
+		const colonIdx = pattern.lastIndexOf(":");
+		const basePattern = colonIdx !== -1 ? pattern.slice(0, colonIdx) : pattern;
+
+		// Explicit provider/modelId — resolve directly via the existing reference matcher.
+		if (basePattern.includes("/")) {
+			const match = findExactModelReferenceMatch(basePattern, available);
+			if (match) {
+				allowed.add(`${match.provider}/${match.id}`);
+			}
+			continue;
+		}
+
+		// Canonical id — expand to all available concrete variants.
+		const variants = registry.getCanonicalVariants(basePattern, { availableOnly: true, candidates: available });
+		if (variants.length > 0) {
+			for (const { model } of variants) {
+				allowed.add(`${model.provider}/${model.id}`);
+			}
+			continue;
+		}
+
+		// Bare model id — match across all available providers.
+		for (const m of available) {
+			if (m.id === basePattern) {
+				allowed.add(`${m.provider}/${m.id}`);
+			}
+		}
+	}
+
+	if (allowed.size === 0) return available;
+	return available.filter(m => allowed.has(`${m.provider}/${m.id}`));
+}
+
+
 export interface ResolveCliModelResult {
 	model: Model<Api> | undefined;
 	selector?: string;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -108,6 +108,7 @@ import { shouldEnableAppendOnlyContext } from "../config/append-only-context-mod
 import type { ModelRegistry } from "../config/model-registry";
 import {
 	extractExplicitThinkingSelector,
+	filterAvailableModelsByEnabledPatterns,
 	formatModelSelectorValue,
 	formatModelString,
 	getModelMatchPreferences,
@@ -5694,10 +5695,14 @@ export class AgentSession {
 	}
 
 	/**
-	 * Get all available models with valid API keys.
+	 * Get all available models with valid API keys, filtered by `enabledModels` when configured.
+	 * See {@link filterAvailableModelsByEnabledPatterns} for supported pattern forms and limitations.
 	 */
 	getAvailableModels(): Model[] {
-		return this.#modelRegistry.getAvailable();
+		const all = this.#modelRegistry.getAvailable();
+		const patterns = this.settings.get("enabledModels");
+		if (!patterns || patterns.length === 0) return all;
+		return filterAvailableModelsByEnabledPatterns(all, patterns, this.#modelRegistry);
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1066,6 +1066,18 @@ describe("filterAvailableModelsByEnabledPatterns", () => {
 		expect(result[0].id).toBe("qwen/qwen3-coder:exacto");
 	});
 
+	test("matches bare OpenRouter-style model id with slash but no provider prefix", () => {
+		const openRouterModels = mockOpenRouterModels as Model[];
+		const result = filterAvailableModelsByEnabledPatterns(
+			openRouterModels,
+			["qwen/qwen3-coder:exacto"],
+			registry,
+		);
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe("qwen/qwen3-coder:exacto");
+		expect(result[0].provider).toBe("openrouter");
+	});
+
 	test("returns all models when ALL patterns are globs (cannot evaluate)", () => {
 		const result = filterAvailableModelsByEnabledPatterns(models, ["anthropic/*"], registry);
 		expect(result).toEqual(models);

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -13,6 +13,7 @@ import {
 	resolveModelRoleValue,
 	resolveModelScope,
 } from "@oh-my-pi/pi-coding-agent/config/model-resolver";
+import type { CanonicalModelVariant } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 
 // Mock models for testing
@@ -1020,7 +1021,7 @@ describe("provider routing selector (@upstream)", () => {
 describe("filterAvailableModelsByEnabledPatterns", () => {
 	const models = mockModels as Model[];
 	const registry = {
-		getCanonicalVariants: (_id: string, _opts?: unknown) => [] as { model: Model }[],
+		getCanonicalVariants: (_id: string, _opts?: unknown): CanonicalModelVariant[] => [],
 	};
 
 	test("returns all models when patterns is empty", () => {
@@ -1041,8 +1042,17 @@ describe("filterAvailableModelsByEnabledPatterns", () => {
 
 	test("expands canonical id via registry", () => {
 		const canonicalRegistry = {
-			getCanonicalVariants: (id: string, _opts?: unknown) =>
-				id === "claude-sonnet-4-5" ? [{ model: models[0] }] : [],
+			getCanonicalVariants: (id: string, _opts?: unknown): CanonicalModelVariant[] =>
+				id === "claude-sonnet-4-5"
+					? [
+							{
+								canonicalId: "claude-sonnet-4-5",
+								selector: "anthropic/claude-sonnet-4-5",
+								model: models[0],
+								source: "bundled",
+							},
+						]
+					: [],
 		};
 		const result = filterAvailableModelsByEnabledPatterns(models, ["claude-sonnet-4-5"], canonicalRegistry);
 		expect(result).toHaveLength(1);
@@ -1068,11 +1078,7 @@ describe("filterAvailableModelsByEnabledPatterns", () => {
 
 	test("matches bare OpenRouter-style model id with slash but no provider prefix", () => {
 		const openRouterModels = mockOpenRouterModels as Model[];
-		const result = filterAvailableModelsByEnabledPatterns(
-			openRouterModels,
-			["qwen/qwen3-coder:exacto"],
-			registry,
-		);
+		const result = filterAvailableModelsByEnabledPatterns(openRouterModels, ["qwen/qwen3-coder:exacto"], registry);
 		expect(result).toHaveLength(1);
 		expect(result[0].id).toBe("qwen/qwen3-coder:exacto");
 		expect(result[0].provider).toBe("openrouter");
@@ -1084,11 +1090,7 @@ describe("filterAvailableModelsByEnabledPatterns", () => {
 	});
 
 	test("applies exact patterns when mixed with globs", () => {
-		const result = filterAvailableModelsByEnabledPatterns(
-			models,
-			["anthropic/*", "openai/gpt-4o"],
-			registry,
-		);
+		const result = filterAvailableModelsByEnabledPatterns(models, ["anthropic/*", "openai/gpt-4o"], registry);
 		expect(result).toHaveLength(1);
 		expect(result[0].id).toBe("gpt-4o");
 	});

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -1049,20 +1049,41 @@ describe("filterAvailableModelsByEnabledPatterns", () => {
 		expect(result[0].id).toBe("claude-sonnet-4-5");
 	});
 
-	test("strips thinking-level suffix before matching", () => {
+	test("strips :thinkingLevel suffix before matching", () => {
 		const result = filterAvailableModelsByEnabledPatterns(models, ["anthropic/claude-sonnet-4-5:high"], registry);
 		expect(result).toHaveLength(1);
 		expect(result[0].id).toBe("claude-sonnet-4-5");
 	});
 
-	test("returns all models when a glob pattern is present", () => {
+	test("preserves colon-bearing OpenRouter ids (suffix is not a thinking level)", () => {
+		const openRouterModels = mockOpenRouterModels as Model[];
+		const result = filterAvailableModelsByEnabledPatterns(
+			openRouterModels,
+			["openrouter/qwen/qwen3-coder:exacto"],
+			registry,
+		);
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe("qwen/qwen3-coder:exacto");
+	});
+
+	test("returns all models when ALL patterns are globs (cannot evaluate)", () => {
 		const result = filterAvailableModelsByEnabledPatterns(models, ["anthropic/*"], registry);
 		expect(result).toEqual(models);
 	});
 
-	test("returns all models when no pattern matches (rather than empty)", () => {
+	test("applies exact patterns when mixed with globs", () => {
+		const result = filterAvailableModelsByEnabledPatterns(
+			models,
+			["anthropic/*", "openai/gpt-4o"],
+			registry,
+		);
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe("gpt-4o");
+	});
+
+	test("returns empty list when no pattern matches (misconfiguration)", () => {
 		const result = filterAvailableModelsByEnabledPatterns(models, ["nonexistent-model"], registry);
-		expect(result).toEqual(models);
+		expect(result).toHaveLength(0);
 	});
 
 	test("includes multiple patterns from different providers", () => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -3,6 +3,7 @@ import { type Api, Effort, type Model } from "@oh-my-pi/pi-ai";
 import { buildModel } from "@oh-my-pi/pi-catalog/build";
 import {
 	expandRoleAlias,
+	filterAvailableModelsByEnabledPatterns,
 	parseModelPattern,
 	parseModelString,
 	resolveAgentModelPatterns,
@@ -1013,5 +1014,63 @@ describe("provider routing selector (@upstream)", () => {
 		expect(result.model?.id).toBe("z-ai/glm-4.7");
 		expect(result.selector).toBe("openrouter/z-ai/glm-4.7@cerebras");
 		expect(openRouterOnly(result.model)).toEqual(["cerebras"]);
+	});
+});
+
+describe("filterAvailableModelsByEnabledPatterns", () => {
+	const models = mockModels as Model[];
+	const registry = {
+		getCanonicalVariants: (_id: string, _opts?: unknown) => [] as { model: Model }[],
+	};
+
+	test("returns all models when patterns is empty", () => {
+		expect(filterAvailableModelsByEnabledPatterns(models, [], registry)).toEqual(models);
+	});
+
+	test("filters by exact provider/modelId", () => {
+		const result = filterAvailableModelsByEnabledPatterns(models, ["anthropic/claude-sonnet-4-5"], registry);
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe("claude-sonnet-4-5");
+	});
+
+	test("filters by bare model id matching across providers", () => {
+		const result = filterAvailableModelsByEnabledPatterns(models, ["claude-sonnet-4-5"], registry);
+		expect(result).toHaveLength(1);
+		expect(result[0].provider).toBe("anthropic");
+	});
+
+	test("expands canonical id via registry", () => {
+		const canonicalRegistry = {
+			getCanonicalVariants: (id: string, _opts?: unknown) =>
+				id === "claude-sonnet-4-5" ? [{ model: models[0] }] : [],
+		};
+		const result = filterAvailableModelsByEnabledPatterns(models, ["claude-sonnet-4-5"], canonicalRegistry);
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe("claude-sonnet-4-5");
+	});
+
+	test("strips thinking-level suffix before matching", () => {
+		const result = filterAvailableModelsByEnabledPatterns(models, ["anthropic/claude-sonnet-4-5:high"], registry);
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe("claude-sonnet-4-5");
+	});
+
+	test("returns all models when a glob pattern is present", () => {
+		const result = filterAvailableModelsByEnabledPatterns(models, ["anthropic/*"], registry);
+		expect(result).toEqual(models);
+	});
+
+	test("returns all models when no pattern matches (rather than empty)", () => {
+		const result = filterAvailableModelsByEnabledPatterns(models, ["nonexistent-model"], registry);
+		expect(result).toEqual(models);
+	});
+
+	test("includes multiple patterns from different providers", () => {
+		const result = filterAvailableModelsByEnabledPatterns(
+			models,
+			["anthropic/claude-sonnet-4-5", "openai/gpt-4o"],
+			registry,
+		);
+		expect(result).toHaveLength(2);
 	});
 });


### PR DESCRIPTION
## Problem

`getAvailableModels()` in `AgentSession` was calling `modelRegistry.getAvailable()` directly, which skips the `enabledModels` setting entirely. As a result, ACP clients (Zed, etc.) always see the full model catalog regardless of what the user configured in `enabledModels`.

The setting was only applied during session initialization to pick the *starting* model — it never filtered the list advertised to the ACP model picker.

## Fix

Add `filterAvailableModelsByEnabledPatterns()` to `model-resolver.ts` — a synchronous subset of `resolveAllowedModels()` that covers the patterns found in real-world configs:

- Exact `provider/modelId` selectors (`anthropic/claude-sonnet-4-6`)
- Canonical ids expanded to all concrete variants via `getCanonicalVariants`
- Bare model ids matched across all available providers
- Optional `:thinkingLevel` suffix stripped before matching

Glob patterns (`*`, `?`, `[`) require the async `resolveModelScope` path which is unavailable in a sync context; when a glob is present the function returns the full list rather than accidentally emptying the picker.

Update `getAvailableModels()` to call it, so the Zed ACP model dropdown (and any other ACP client) respects `enabledModels`.

## Unchanged behavior

- No `enabledModels` configured → identical behavior (returns `getAvailable()` directly)
- Session model selection / `resolveAllowedModels` path → unchanged
- All existing ACP tests pass (they stub `getAvailableModels()` at the session level)

## Tests

Added unit tests for `filterAvailableModelsByEnabledPatterns` in `model-resolver.test.ts` covering:
- Empty patterns → all models returned
- Exact `provider/modelId` filter
- Bare model id filter
- Canonical id expansion via registry
- Thinking-level suffix stripping
- Glob passthrough (returns all)
- No-match fallback (returns all, not empty)