### PR TITLE
fix(tui): bound oversized render rows

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Bounded TUI line fitting for oversized raw rows so ANSI-heavy subagent output cannot grow render buffers independently of the viewport ([#2045](https://github.com/can1357/oh-my-pi/issues/2045)).
+
 ## [15.10.1] - 2026-06-07
 ### Breaking Changes
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2501,7 +2501,55 @@ export class TUI extends Container {
 			Math.max(LINE_FIT_MIN_SOURCE_CODE_UNITS, safeWidth * LINE_FIT_SOURCE_WIDTH_MULTIPLIER),
 		);
 		if (raw.length <= maxSourceLength) return raw;
-		return raw.slice(0, maxSourceLength) + SEGMENT_RESET;
+
+		const chunks: string[] = [];
+		let emitted = 0;
+		for (let i = 0; i < raw.length && emitted < maxSourceLength; ) {
+			if (raw.charCodeAt(i) === 0x1b) {
+				const end = this.#ansiSequenceEnd(raw, i);
+				if (end === -1) break;
+				const sequenceLength = end - i;
+				if (emitted > 0 && sequenceLength <= maxSourceLength - emitted) {
+					chunks.push(raw.slice(i, end));
+					emitted += sequenceLength;
+				}
+				i = end;
+				continue;
+			}
+
+			const start = i;
+			const end = Math.min(raw.length, start + maxSourceLength - emitted);
+			while (i < end && raw.charCodeAt(i) !== 0x1b) i++;
+			if (i === start) break;
+			chunks.push(raw.slice(start, i));
+			emitted += i - start;
+		}
+
+		return chunks.join("") + SEGMENT_RESET;
+	}
+
+	#ansiSequenceEnd(line: string, start: number): number {
+		const next = line.charCodeAt(start + 1);
+		if (next === 0x5b) {
+			let i = start + 2;
+			while (i < line.length) {
+				const final = line.charCodeAt(i);
+				if (final >= 0x40 && final <= 0x7e) return i + 1;
+				i++;
+			}
+			return -1;
+		}
+		if (next === 0x5d) {
+			let i = start + 2;
+			while (i < line.length) {
+				const osc = line.charCodeAt(i);
+				if (osc === 0x07) return i + 1;
+				if (osc === 0x1b && line.charCodeAt(i + 1) === 0x5c) return i + 2;
+				i++;
+			}
+			return -1;
+		}
+		return start + 2 <= line.length ? start + 2 : -1;
 	}
 
 	#ansiAsciiLineWidth(line: string, maxWidth: number): number | undefined {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2509,6 +2509,16 @@ export class TUI extends Container {
 				const end = this.#ansiSequenceEnd(raw, i);
 				if (end === -1) break;
 				const sequenceLength = end - i;
+				if (this.#ansiSequenceHasVisiblePayload(raw, i)) {
+					// OSC 66 text-sizing spans carry their visible cells inside the
+					// OSC payload. Always include the whole sequence — splitting it
+					// would corrupt the terminator — and let the next loop iteration
+					// terminate on the budget overflow.
+					chunks.push(raw.slice(i, end));
+					emitted += sequenceLength;
+					i = end;
+					continue;
+				}
 				if (emitted > 0 && sequenceLength <= maxSourceLength - emitted) {
 					chunks.push(raw.slice(i, end));
 					emitted += sequenceLength;
@@ -2550,6 +2560,17 @@ export class TUI extends Container {
 			return -1;
 		}
 		return start + 2 <= line.length ? start + 2 : -1;
+	}
+
+	#ansiSequenceHasVisiblePayload(line: string, start: number): boolean {
+		// OSC 66 (`\x1b]66;META;TEXT\x1b\\`) carries its visible cells inside the
+		// payload, mirroring the special case in {@link #ansiAsciiLineWidth}.
+		return (
+			line.charCodeAt(start + 1) === 0x5d &&
+			line.charCodeAt(start + 2) === 0x36 &&
+			line.charCodeAt(start + 3) === 0x36 &&
+			line.charCodeAt(start + 4) === 0x3b
+		);
 	}
 
 	#ansiAsciiLineWidth(line: string, maxWidth: number): number | undefined {

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -47,6 +47,12 @@ const SEGMENT_RESET = "\x1b[0m";
 const LINE_TERMINATOR = "\x1b[0m\x1b]8;;\x07";
 const ERASE_LINE = "\x1b[2K";
 const ERASE_TO_END_OF_LINE = "\x1b[K";
+// Bound the raw code-unit span handed to native width/truncation. A terminal
+// row can only display `width` cells, so oversized component rows should not
+// force proportional JS/native copies while deciding what the viewport shows.
+const LINE_FIT_MIN_SOURCE_CODE_UNITS = 4096;
+const LINE_FIT_MAX_SOURCE_CODE_UNITS = 65536;
+const LINE_FIT_SOURCE_WIDTH_MULTIPLIER = 64;
 // Hide the hardware cursor before each paint/move write. Ghostty-style bar
 // cursors can otherwise leave visual afterimages while the TUI repaints the
 // row under a visible cursor. Paint writes also disable terminal autowrap:
@@ -2478,13 +2484,24 @@ export class TUI extends Container {
 		if (TERMINAL.isImageLine(raw)) {
 			return { raw, width, line: raw };
 		}
-		const normalized = normalizeTerminalOutput(raw);
+		const source = this.#lineFitSource(raw, width);
+		const normalized = normalizeTerminalOutput(source);
 		const asciiWidth = this.#ansiAsciiLineWidth(normalized, width);
 		if ((asciiWidth ?? visibleWidth(normalized)) <= width) {
 			return { raw, width, line: normalized };
 		}
 		const line = truncateToWidth(normalized, width, Ellipsis.Omit);
 		return { raw, width, line };
+	}
+
+	#lineFitSource(raw: string, width: number): string {
+		const safeWidth = Number.isFinite(width) ? Math.max(1, Math.trunc(width)) : 1;
+		const maxSourceLength = Math.min(
+			LINE_FIT_MAX_SOURCE_CODE_UNITS,
+			Math.max(LINE_FIT_MIN_SOURCE_CODE_UNITS, safeWidth * LINE_FIT_SOURCE_WIDTH_MULTIPLIER),
+		);
+		if (raw.length <= maxSourceLength) return raw;
+		return raw.slice(0, maxSourceLength) + SEGMENT_RESET;
 	}
 
 	#ansiAsciiLineWidth(line: string, maxWidth: number): number | undefined {

--- a/packages/tui/test/issue-2045-repro.test.ts
+++ b/packages/tui/test/issue-2045-repro.test.ts
@@ -64,7 +64,7 @@ async function settle(): Promise<void> {
 }
 
 describe("issue #2045: renderer bounds oversized rows", () => {
-	it("clips pathological zero-width ANSI rows before building terminal writes", async () => {
+	it("preserves visible text after pathological zero-width ANSI prefixes", async () => {
 		const term = new CaptureTerminal(80, 4);
 		const tui = new TUI(term);
 		const line = `${"\x1b[31m".repeat(20_000)}payload`;
@@ -77,7 +77,26 @@ describe("issue #2045: renderer bounds oversized rows", () => {
 			tui.stop();
 		}
 
-		const renderedBytes = term.writes.join("").length;
-		expect(renderedBytes).toBeLessThan(12_000);
+		const rendered = term.writes.join("");
+		expect(rendered).toContain("payload");
+		expect(rendered.length).toBeLessThan(12_000);
+	});
+
+	it("preserves visible text after oversized OSC hyperlink prefixes", async () => {
+		const term = new CaptureTerminal(80, 4);
+		const tui = new TUI(term);
+		const line = `\x1b]8;;https://example.com/${"a".repeat(70_000)}\x07link-label\x1b]8;;\x07`;
+
+		tui.addChild(new RawLinesComponent([line]));
+		try {
+			tui.start();
+			await settle();
+		} finally {
+			tui.stop();
+		}
+
+		const rendered = term.writes.join("");
+		expect(rendered).toContain("link-label");
+		expect(rendered.length).toBeLessThan(12_000);
 	});
 });

--- a/packages/tui/test/issue-2045-repro.test.ts
+++ b/packages/tui/test/issue-2045-repro.test.ts
@@ -99,4 +99,22 @@ describe("issue #2045: renderer bounds oversized rows", () => {
 		expect(rendered).toContain("link-label");
 		expect(rendered.length).toBeLessThan(12_000);
 	});
+
+	it("preserves OSC 66 text-sizing payloads at the start of long rows", async () => {
+		const term = new CaptureTerminal(80, 4);
+		const tui = new TUI(term);
+		const visibleText = "H".repeat(70);
+		const line = `\x1b]66;s=1;${visibleText}\x1b\\${"\x1b[31m".repeat(20_000)}`;
+
+		tui.addChild(new RawLinesComponent([line]));
+		try {
+			tui.start();
+			await settle();
+		} finally {
+			tui.stop();
+		}
+
+		const rendered = term.writes.join("");
+		expect(rendered).toContain(visibleText);
+	});
 });

--- a/packages/tui/test/issue-2045-repro.test.ts
+++ b/packages/tui/test/issue-2045-repro.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import { type Component, TUI } from "@oh-my-pi/pi-tui";
+import type { Terminal, TerminalAppearance } from "@oh-my-pi/pi-tui/terminal";
+
+class CaptureTerminal implements Terminal {
+	writes: string[] = [];
+	#columns: number;
+	#rows: number;
+
+	constructor(columns = 80, rows = 4) {
+		this.#columns = columns;
+		this.#rows = rows;
+	}
+
+	get columns(): number {
+		return this.#columns;
+	}
+
+	get rows(): number {
+		return this.#rows;
+	}
+
+	get kittyProtocolActive(): boolean {
+		return false;
+	}
+
+	get appearance(): TerminalAppearance | undefined {
+		return undefined;
+	}
+
+	start(): void {}
+	stop(): void {}
+	async drainInput(): Promise<void> {}
+	write(data: string): void {
+		this.writes.push(data);
+	}
+	moveBy(): void {}
+	hideCursor(): void {}
+	showCursor(): void {}
+	clearLine(): void {}
+	clearFromCursor(): void {}
+	clearScreen(): void {}
+	setTitle(): void {}
+	setProgress(): void {}
+	onAppearanceChange(): void {}
+}
+
+class RawLinesComponent implements Component {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = lines;
+	}
+
+	invalidate(): void {}
+
+	render(): string[] {
+		return this.#lines;
+	}
+}
+
+async function settle(): Promise<void> {
+	await Bun.sleep(0);
+}
+
+describe("issue #2045: renderer bounds oversized rows", () => {
+	it("clips pathological zero-width ANSI rows before building terminal writes", async () => {
+		const term = new CaptureTerminal(80, 4);
+		const tui = new TUI(term);
+		const line = `${"\x1b[31m".repeat(20_000)}payload`;
+
+		tui.addChild(new RawLinesComponent([line]));
+		try {
+			tui.start();
+			await settle();
+		} finally {
+			tui.stop();
+		}
+
+		const renderedBytes = term.writes.join("").length;
+		expect(renderedBytes).toBeLessThan(12_000);
+	});
+});


### PR DESCRIPTION
## Repro
A pathological subagent row can contain a very large amount of ANSI control text while occupying only a few visible cells. The minimal line-fitting repro is: `python3 -c 'import re, json, sys; width = 80; line = "\x1b[31m" * 20000 + "payload"; visible = len(re.sub(r"\x1b\[[0-9;]*m", "", line)); fitted = line if visible <= width else line[:width]; print(json.dumps({"inputBytes": len(line), "visibleWidth": visible, "fittedBytes": len(fitted)})); sys.exit(1 if len(fitted) > 12000 else 0)'`, which prints `{"inputBytes": 100007, "visibleWidth": 7, "fittedBytes": 100007}`.

## Cause
`packages/tui/src/tui.ts` line preparation normalized and measured the full raw row before truncation. For ANSI-heavy rows, the fitter could decide the row fit by visible width while still preserving all raw bytes; for oversized visible rows, native width/truncation also received the full string, forcing proportional JS/native copies during rendering.

## Fix
- Bound the raw code-unit span passed into TUI line fitting based on viewport width, with a hard cap before normalization and native width/truncation.
- Append a reset when clipping the raw source so truncated ANSI state cannot leak across rows.
- Add `packages/tui/test/issue-2045-repro.test.ts` covering pathological zero-width ANSI rows and asserting render writes stay bounded.
- Add the `packages/tui` changelog entry for #2045.

## Verification
Attempted `bun test packages/tui/test/issue-2045-repro.test.ts`, but this worktree’s Bun runtime exits 133 before executing tests; `bun -e "console.log('hi')"` and `bun install --frozen-lockfile` also exit 133, and the pre-publish `bun run fix` gate fails because `biome` is unavailable. Skipped pre-publish checks because the local Bun/toolchain failure is unrelated to this diff. Fixes #2045