### PR TITLE
fix(tui): preserve tmux viewport on unchanged offscreen shrink

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 ### Fixed
 
+- Fixed tmux offscreen-shrink frames to skip repainting when the visible tail is unchanged, avoiding intermittent blank/refresh flashes in pane terminals ([#2046](https://github.com/can1357/oh-my-pi/issues/2046)).
+
 - Fixed `Loader` text updates to skip identical messages and preserve the rendered `Text` cache instead of invalidating it every timer tick.
 
 - Fixed fullscreen overlay alt-frame rendering to reuse the current line-preparation path instead of calling removed fitting helpers.

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed tmux offscreen-shrink frames to skip repainting when the visible tail is unchanged, avoiding intermittent blank/refresh flashes in pane terminals ([#2046](https://github.com/can1357/oh-my-pi/issues/2046)).
+
 ## [15.10.1] - 2026-06-07
 ### Breaking Changes
 
@@ -28,8 +32,6 @@
 - `TERMINAL` is now a `RuntimeTerminal` whose post-construction capabilities (image protocol and the probe-driven flags) are writable, replacing the `as unknown as MutableTerminalInfo` cast pattern and the positional `withTerminalOverrides` rebuild with a prototype-preserving `clone()`.
 
 ### Fixed
-
-- Fixed tmux offscreen-shrink frames to skip repainting when the visible tail is unchanged, avoiding intermittent blank/refresh flashes in pane terminals ([#2046](https://github.com/can1357/oh-my-pi/issues/2046)).
 
 - Fixed `Loader` text updates to skip identical messages and preserve the rendered `Text` cache instead of invalidating it every timer tick.
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -2049,7 +2049,9 @@ export class TUI extends Container {
 			newLines.length < this.#previousLines.length &&
 			naturalViewportTop !== prevViewportTop
 		) {
-			return { kind: "viewportRepaint" };
+			return this.#bottomAnchoredViewportUnchanged(newLines, height)
+				? { kind: "deferredMutation" }
+				: { kind: "viewportRepaint" };
 		}
 
 		// Direct-input shrink can also move the natural viewport upward even when
@@ -2435,6 +2437,17 @@ export class TUI extends Container {
 		const committedSealedEnd = Math.min(this.#scrollbackHighWater, commitBoundary);
 		const renderViewportTop = Math.max(naturalViewportTop, committedSealedEnd);
 		return { kind: "liveRegionPinned", appendFrom, appendTo, renderViewportTop };
+	}
+
+	#bottomAnchoredViewportUnchanged(newLines: string[], height: number): boolean {
+		const previousViewportTop = Math.max(0, this.#previousLines.length - height);
+		const newViewportTop = Math.max(0, newLines.length - height);
+		for (let row = 0; row < height; row++) {
+			if ((newLines[newViewportTop + row] ?? "") !== (this.#previousLines[previousViewportTop + row] ?? "")) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	#planDeferredTailRepaint(newLines: string[], prevViewportTop: number, height: number): RenderIntent {

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -1469,6 +1469,40 @@ describe("TUI terminal-state regressions", () => {
 			});
 		});
 
+		it("tmux: offscreen shrink preserving the visible tail emits no repaint bytes", async () => {
+			await withEnvPatch({ TMUX: "1", STY: undefined, ZELLIJ: undefined }, async () => {
+				const term = new UnknownViewportTerminal(40, 4, 10_000);
+				const tui = new TUI(term);
+				const component = new MutableLinesComponent([
+					"old-0",
+					"remove-me",
+					"old-2",
+					"old-3",
+					"tail-0",
+					"tail-1",
+					"tail-2",
+					"tail-3",
+				]);
+				tui.addChild(component);
+
+				try {
+					tui.start();
+					await settle(term);
+					expect(visible(term)).toEqual(["tail-0", "tail-1", "tail-2", "tail-3"]);
+
+					const writes = captureWrites(term);
+					component.setLines(["old-0", "old-2", "old-3", "tail-0", "tail-1", "tail-2", "tail-3"]);
+					tui.requestRender();
+					await settle(term);
+
+					expect(visible(term)).toEqual(["tail-0", "tail-1", "tail-2", "tail-3"]);
+					expect(writes).toEqual([]);
+				} finally {
+					tui.stop();
+				}
+			});
+		});
+
 		// Root cause family: the dirty/replay machinery assumes native scrollback
 		// can be cleared and rebuilt, which is never true inside a multiplexer —
 		// tmux owns pane history, reflows it on resize itself, and a "replay" can


### PR DESCRIPTION
## Repro
A tmux pane can shrink logical content above the visible viewport while the bottom-anchored visible tail is byte-for-byte unchanged. Before the fix, `bun test packages/tui/test/render-regressions.test.ts -t "tmux: offscreen shrink preserving"` failed because the renderer emitted a viewport repaint containing `tail-0` through `tail-3` instead of emitting no content bytes.

## Cause
`packages/tui/src/tui.ts` routed multiplexer shrink frames whose natural viewport top moved to `viewportRepaint` unconditionally. For a pure offscreen deletion, padding/repainting or repainting the same bottom tail needlessly rewrites the pane even though the visible rows already match the new bottom-anchored viewport.

## Fix
- Added a bottom-anchored viewport comparison in `TUI.#planRender()` for multiplexer shrink frames.
- Return the deferred/no-content mutation path when the new bottom viewport already matches what is on screen; keep the existing viewport repaint when exposed rows actually differ.
- Added a regression test covering the tmux no-repaint contract and documented the TUI fix in the changelog.

## Verification
`bun test packages/tui/test/render-regressions.test.ts -t "tmux: offscreen shrink preserving"` passes; `bun test packages/tui/test/render-regressions.test.ts` passes; `bun test packages/tui/test/issue-1974-repro.test.ts packages/tui/test/overlay-scroll.test.ts` passes; `bun check` passes. Fixes #2046