### PR TITLE
fix(ai): parse MiniMax think tags across providers

### DIFF
--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -537,7 +537,6 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 			}
 			stream.push({ type: "start", partial: output });
 
-			const parseMiniMaxThinkTags = model.provider === "minimax-code" || model.provider === "minimax-code-cn";
 			// Some OpenAI-compatible DeepSeek hosts (including NVIDIA NIM and DeepSeek's
 			// native API) leak chat-template tool-call markers in `delta.content` even
 			// though tool calls are also surfaced structurally. Strip the leaked markers
@@ -678,9 +677,7 @@ export const streamOpenAICompletions: StreamFunction<"openai-completions"> = (
 				}
 			};
 
-			const streamMarkupHealingPattern = getStreamMarkupHealingPattern(model.provider, model.id, {
-				parseThinkingTags: parseMiniMaxThinkTags,
-			});
+			const streamMarkupHealingPattern = getStreamMarkupHealingPattern(model.provider, model.id);
 			const streamMarkupHealing = streamMarkupHealingPattern
 				? new StreamMarkupHealing({ pattern: streamMarkupHealingPattern })
 				: undefined;

--- a/packages/ai/src/utils/stream-markup-healing.ts
+++ b/packages/ai/src/utils/stream-markup-healing.ts
@@ -600,12 +600,17 @@ export function modelMayLeakDsmlToolCalls(provider: string, modelId: string): bo
 	);
 }
 
+/** Cheap model/provider gate for MiniMax plain thinking tag leaks. */
+export function modelMayLeakThinkingTags(provider: string, modelId: string): boolean {
+	return /minimax/i.test(provider) || /minimax/i.test(modelId);
+}
+
 export function getStreamMarkupHealingPattern(
 	provider: string,
 	modelId: string,
 	options?: { readonly parseThinkingTags?: boolean },
 ): StreamMarkupHealingPattern | undefined {
-	if (options?.parseThinkingTags) return "thinking";
+	if (options?.parseThinkingTags || modelMayLeakThinkingTags(provider, modelId)) return "thinking";
 	if (modelMayLeakKimiToolCalls(provider, modelId)) return "kimi";
 	if (modelMayLeakDsmlToolCalls(provider, modelId)) return "dsml";
 	return undefined;

--- a/packages/ai/test/stream-markup-healing.test.ts
+++ b/packages/ai/test/stream-markup-healing.test.ts
@@ -148,6 +148,7 @@ describe("StreamMarkupHealing pattern selection", () => {
 		expect(getStreamMarkupHealingPattern("minimax-code", "MiniMax-M2.5", { parseThinkingTags: true })).toBe(
 			"thinking",
 		);
+		expect(getStreamMarkupHealingPattern("opencode-zen", "minimax-m3")).toBe("thinking");
 		expect(getStreamMarkupHealingPattern("nanogpt", "deepseek/deepseek-v4-pro")).toBe("dsml");
 		expect(getStreamMarkupHealingPattern("ollama-cloud", "gpt-oss:120b")).toBeUndefined();
 		expect(getStreamMarkupHealingPattern("openai", "deepseek-v4-pro")).toBeUndefined();
@@ -579,6 +580,39 @@ describe("Ollama provider DSML envelope healing", () => {
 			.join("");
 		expect(text).toBe("Inline `<｜literal｜>` token in prose.");
 		expect(result.stopReason).toBe("stop");
+	});
+});
+
+describe("OpenAI completions MiniMax thinking healing", () => {
+	it("parses OpenCode Zen MiniMax think tags into a thinking block", async () => {
+		const model: Model<"openai-completions"> = {
+			id: "minimax-m3",
+			name: "MiniMax M3",
+			api: "openai-completions",
+			provider: "opencode-zen",
+			baseUrl: "https://opencode.ai/zen/v1",
+			reasoning: true,
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: 200_000,
+			maxTokens: 8_192,
+		};
+		global.fetch = mockFetch([
+			chunk(model.id, { content: "visible <thin" }),
+			chunk(model.id, { content: "k>hidden reasoning</think" }),
+			chunk(model.id, { content: ">" }),
+			chunk(model.id, { content: " answer" }),
+			chunk(model.id, {}, "stop"),
+			"[DONE]",
+		]);
+
+		const result = await streamOpenAICompletions(model, baseContext(), { apiKey: "test-key" }).result();
+
+		expect(result.content).toEqual([
+			{ type: "text", text: "visible " },
+			{ type: "thinking", thinking: "hidden reasoning", thinkingSignature: undefined },
+			{ type: "text", text: " answer" },
+		]);
 	});
 });
 


### PR DESCRIPTION
## Repro
OpenCode Zen MiniMax streams currently route through `openai-completions` with `provider: "opencode-zen"` and model ids such as `minimax-m3`; a focused mocked SSE stream split across `<think>` boundaries reproduced the bug with `bun --cwd=packages/ai test test/stream-markup-healing.test.ts -t "OpenCode Zen MiniMax"`, producing one visible text block containing raw `<think>hidden reasoning</think>` before the fix.

## Cause
`packages/ai/src/providers/openai-completions.ts` enabled `StreamMarkupHealing`'s `thinking` pattern only when `model.provider` was `minimax-code` or `minimax-code-cn`, so MiniMax-family models served by OpenCode Zen never used the existing `<think>` parser in `packages/ai/src/utils/stream-markup-healing.ts`.

## Fix
- Moved MiniMax model/provider detection into `getStreamMarkupHealingPattern` via `modelMayLeakThinkingTags` so any MiniMax-family provider or model id selects the existing `thinking` healing pattern.
- Removed the OpenAI-completions provider-local MiniMax provider allowlist.
- Added a regression test for `opencode-zen` + `minimax-m3` chunks split across `<think>` / `</think>` boundaries.

## Verification
`bun --cwd=packages/ai test test/stream-markup-healing.test.ts test/issue-1203-repro.test.ts` passed with 24 tests; `bun --cwd=packages/ai run check` passed. Fixes #2049