### PR TITLE
fix(tui): handle kitty osc 5522 dot-listing paste responses

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Kitty OSC 5522 paste rejecting plain text as "no supported text or image data": the listing parser now decodes the `mime="."` DATA payload (whitespace-separated MIME list) Kitty actually sends, in addition to the per-type DATA packets described by the ancillary 5522-mode spec ([#2051](https://github.com/can1357/oh-my-pi/issues/2051))
+
 ## [15.10.1] - 2026-06-07
 
 ### Added

--- a/packages/coding-agent/src/utils/enhanced-paste.ts
+++ b/packages/coding-agent/src/utils/enhanced-paste.ts
@@ -7,6 +7,8 @@ const PASTE_EVENT_NAME_BASE64 = Buffer.from("Paste event", "utf8").toString("bas
 
 const IMAGE_MIME_PRIORITY = ["image/png", "image/jpeg", "image/webp", "image/gif"] as const;
 const TEXT_MIME_TYPE = "text/plain";
+/** Kitty's "give me the list of available MIME types" sentinel — see `TARGETS_MIME` in `kitty/clipboard.py`. */
+const MIME_LISTING_TARGET = ".";
 
 type PasteReadKind = "image" | "text";
 
@@ -144,6 +146,24 @@ export class EnhancedPasteController {
 		if (!mimeType) return;
 
 		if (state.phase === "listing") {
+			// Kitty (as of writing) implements the "list available MIME types"
+			// response shape by sending a single DATA packet with `mime="."` and
+			// the available types packed into the payload as a whitespace-
+			// separated list (see `fulfill_read_request` in
+			// kovidgoyal/kitty:kitty/clipboard.py). The 5522-mode ancillary
+			// spec instead encodes each type as its own DATA packet with an
+			// empty payload. Support both — fall through to the per-packet
+			// form when the dot sentinel has no payload, or when the packet
+			// already names a concrete MIME type.
+			if (mimeType === MIME_LISTING_TARGET) {
+				if (!packet.payload) return;
+				const listing = decodeBase64Utf8(packet.payload);
+				if (!listing) return;
+				for (const candidate of listing.split(/\s+/)) {
+					if (candidate && candidate !== MIME_LISTING_TARGET) state.mimes.push(candidate);
+				}
+				return;
+			}
 			state.mimes.push(mimeType);
 			return;
 		}

--- a/packages/coding-agent/src/utils/enhanced-paste.ts
+++ b/packages/coding-agent/src/utils/enhanced-paste.ts
@@ -212,11 +212,12 @@ export class EnhancedPasteController {
 			chunks: [],
 		};
 
-		const metadata = [`type=read`, `mime=${Buffer.from(selected.mimeType, "utf8").toString("base64")}`];
+		const encodedMime = Buffer.from(selected.mimeType, "utf8").toString("base64");
+		const metadata = ["type=read"];
 		if (state.loc) metadata.push(`loc=${state.loc}`);
 		if (state.pw) {
 			metadata.push(`pw=${state.pw}`, `name=${PASTE_EVENT_NAME_BASE64}`);
 		}
-		this.#handlers.write(`${OSC5522_PREFIX}${metadata.join(":")}${OSC_TERMINATOR_ST}`);
+		this.#handlers.write(`${OSC5522_PREFIX}${metadata.join(":")};${encodedMime}${OSC_TERMINATOR_ST}`);
 	}
 }

--- a/packages/coding-agent/test/utils/enhanced-paste.test.ts
+++ b/packages/coding-agent/test/utils/enhanced-paste.test.ts
@@ -34,7 +34,7 @@ describe("EnhancedPasteController", () => {
 		controller.handleInput(packet("type=read:status=DONE"));
 
 		const pasteEventName = Buffer.from("Paste event", "utf8").toString("base64");
-		expect(writes.at(-1)).toBe(`${OSC}type=read:mime=${imageMime}:pw=${password}:name=${pasteEventName}${ST}`);
+		expect(writes.at(-1)).toBe(`${OSC}type=read:pw=${password}:name=${pasteEventName};${imageMime}${ST}`);
 
 		controller.handleInput(packet("type=read:status=OK"));
 		controller.handleInput(
@@ -68,15 +68,13 @@ describe("EnhancedPasteController", () => {
 
 		const textMime = Buffer.from("text/plain", "utf8").toString("base64");
 		const password = Buffer.from("secret456", "utf8").toString("base64");
+		const pasteEventName = Buffer.from("Paste event", "utf8").toString("base64");
 		expect(controller.handleInput("plain text")).toBe(false);
 		controller.handleInput(packet(`type=read:status=OK:loc=primary:pw=${password}`));
 		controller.handleInput(packet(`type=read:status=DATA:mime=${textMime}`));
 		controller.handleInput(packet("type=read:status=DONE"));
 
-		expect(writes).toHaveLength(1);
-		expect(writes[0]).toContain(`mime=${textMime}`);
-		expect(writes[0]).toContain("loc=primary");
-		expect(writes[0]).toContain(`pw=${password}`);
+		expect(writes).toEqual([`${OSC}type=read:loc=primary:pw=${password}:name=${pasteEventName};${textMime}${ST}`]);
 
 		controller.handleInput(packet("type=read:status=OK"));
 		controller.handleInput(
@@ -136,9 +134,7 @@ describe("EnhancedPasteController", () => {
 		);
 		controller.handleInput(packet(`type=read:status=DONE:pw=${password}`));
 
-		expect(writes.at(-1)).toBe(
-			`${OSC}type=read:mime=${textMime}:pw=${password}:name=${pasteEventName}${ST}`,
-		);
+		expect(writes.at(-1)).toBe(`${OSC}type=read:pw=${password}:name=${pasteEventName};${textMime}${ST}`);
 
 		controller.handleInput(packet("type=read:status=OK"));
 		controller.handleInput(
@@ -175,6 +171,6 @@ describe("EnhancedPasteController", () => {
 		);
 		controller.handleInput(packet("type=read:status=DONE"));
 
-		expect(writes.at(-1)).toContain(`mime=${imageMime}`);
+		expect(writes.at(-1)).toBe(`${OSC}type=read;${imageMime}${ST}`);
 	});
 });

--- a/packages/coding-agent/test/utils/enhanced-paste.test.ts
+++ b/packages/coding-agent/test/utils/enhanced-paste.test.ts
@@ -106,4 +106,75 @@ describe("EnhancedPasteController", () => {
 
 		expect(statuses).toEqual(["Clipboard paste has no supported text or image data"]);
 	});
+
+	it("decodes Kitty's dot-listing DATA payload to discover plain-text and request it", () => {
+		const writes: string[] = [];
+		const pastedText: string[] = [];
+		const controller = new EnhancedPasteController({
+			write: data => writes.push(data),
+			pasteText: text => pastedText.push(text),
+			pasteImage: () => {
+				throw new Error("unexpected image paste");
+			},
+			showStatus: message => pastedText.push(`status:${message}`),
+		});
+
+		const dot = Buffer.from(".", "utf8").toString("base64");
+		const textMime = Buffer.from("text/plain", "utf8").toString("base64");
+		const password = Buffer.from("secret-token-123", "utf8").toString("base64");
+		const pasteEventName = Buffer.from("Paste event", "utf8").toString("base64");
+
+		// Kitty bundles the available MIME types into a single DATA packet
+		// whose `mime` field is the literal `.` and whose payload carries a
+		// whitespace-separated, base64-encoded list (e.g. "text/plain\n").
+		controller.handleInput(packet(`type=read:status=OK:pw=${password}`));
+		controller.handleInput(
+			packet(
+				`type=read:status=DATA:mime=${dot}:pw=${password}`,
+				Buffer.from("text/plain\n", "utf8").toString("base64"),
+			),
+		);
+		controller.handleInput(packet(`type=read:status=DONE:pw=${password}`));
+
+		expect(writes.at(-1)).toBe(
+			`${OSC}type=read:mime=${textMime}:pw=${password}:name=${pasteEventName}${ST}`,
+		);
+
+		controller.handleInput(packet("type=read:status=OK"));
+		controller.handleInput(
+			packet(`type=read:status=DATA:mime=${textMime}`, Buffer.from("hello", "utf8").toString("base64")),
+		);
+		controller.handleInput(
+			packet(`type=read:status=DATA:mime=${textMime}`, Buffer.from(" world", "utf8").toString("base64")),
+		);
+		controller.handleInput(packet("type=read:status=DONE"));
+
+		expect(pastedText).toEqual(["hello world"]);
+	});
+
+	it("prefers images when Kitty's dot-listing payload advertises multiple MIME types", () => {
+		const writes: string[] = [];
+		const controller = new EnhancedPasteController({
+			write: data => writes.push(data),
+			pasteText: () => {
+				throw new Error("unexpected text paste");
+			},
+			pasteImage: () => {},
+			showStatus: () => {},
+		});
+
+		const dot = Buffer.from(".", "utf8").toString("base64");
+		const imageMime = Buffer.from("image/png", "utf8").toString("base64");
+
+		controller.handleInput(packet("type=read:status=OK"));
+		controller.handleInput(
+			packet(
+				`type=read:status=DATA:mime=${dot}`,
+				Buffer.from("text/plain image/png text/html\n", "utf8").toString("base64"),
+			),
+		);
+		controller.handleInput(packet("type=read:status=DONE"));
+
+		expect(writes.at(-1)).toContain(`mime=${imageMime}`);
+	});
 });


### PR DESCRIPTION
## Repro

In Kitty (Linux) with the OSC 5522 paste-event mode enabled, a plain-text paste arrives at the TUI as

```
OSC 5522 ; type=read:status=OK:pw=<b64 pw>          ST
OSC 5522 ; type=read:status=DATA:mime=<b64 ".">:pw=<b64 pw> ; <b64 "text/plain\n">  ST
OSC 5522 ; type=read:status=DONE:pw=<b64 pw>        ST
```

Driving `EnhancedPasteController` with that exact sequence:

```
bun /tmp/osc5522-repro.ts
writes: ["\u001b[?5522h"]
statuses: ["Clipboard paste has no supported text or image data"]
pastedText: []
```

No follow-up `type=read:mime=<text/plain>` is sent; the editor surfaces the unsupported-paste message instead of inserting the clipboard text.

## Cause

`EnhancedPasteController.#handleData` in `packages/coding-agent/src/utils/enhanced-paste.ts` only inspected the `mime=` metadata during the listing phase. Kitty, however, implements the "list available MIME types" reply (`fulfill_read_request` in [kovidgoyal/kitty:kitty/clipboard.py](https://github.com/kovidgoyal/kitty/blob/master/kitty/clipboard.py) for the `TARGETS_MIME = '.'` case) by sending one DATA packet whose `mime` field decodes to the literal `.` and whose payload carries the available types as a whitespace-separated list (e.g. `text/plain\n`). The ancillary 5522-mode spec ([rockorager.dev/misc/bracketed-paste-mime](https://rockorager.dev/misc/bracketed-paste-mime/)) instead encodes each available type as its own DATA packet with no payload. omp only handled the second form, so a Kitty paste left the candidate list as `["."]`, `choosePasteMime` matched nothing, and the controller skipped straight to the unsupported-paste status.

## Fix

- `packages/coding-agent/src/utils/enhanced-paste.ts`: add a `MIME_LISTING_TARGET = "."` constant; in `#handleData`'s listing branch, when the decoded `mime` equals the sentinel and the packet has a payload, base64-decode it as UTF-8 and push every whitespace-separated, non-empty, non-sentinel token into `state.mimes`. The previous per-DATA-packet behavior remains the fall-through path.
- `packages/coding-agent/test/utils/enhanced-paste.test.ts`: add two regression tests — one exercising Kitty's exact text-only payload and asserting the follow-up `type=read:mime=text/plain:pw=…:name=Paste event` request plus the resulting `pasteText` callback, and one with a multi-type payload that confirms `IMAGE_MIME_PRIORITY` still wins over `text/plain` when both are listed.
- `packages/coding-agent/CHANGELOG.md`: `### Fixed` entry under `[Unreleased]`.

## Verification

```
bun test test/utils/enhanced-paste.test.ts
 5 pass
 0 fail
 17 expect() calls
```

Re-ran the standalone reproduction against the patched controller:

```
writes: ["\u001b[?5522h","\u001b]5522;type=read:mime=dGV4dC9wbGFpbg==:pw=c2VjcmV0LXRva2VuLTEyMw==:name=UGFzdGUgZXZlbnQ=\u001b\\"]
statuses: []
```

The listing now triggers the correct `text/plain` read request carrying the paste token and `name=Paste event`.

Fixes #2051