### PR TITLE
fix(ai): dedupe duplicate tool_call_id in transformMessages

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed HTTP 400 "tool call result does not follow tool call" errors when upstream models (notably MiniMax-M3 via opencode-go and Kimi on certain proxies) emit the same `tool_call_id` for distinct tool calls. `transformMessages` now rewrites duplicate ids per-block as `<id>_dup<N>` while preserving call/result pairing, including across parallel tool-call batches and intra-message duplicates. ([#2055](https://github.com/can1357/oh-my-pi/issues/2055))
 ## [15.10.1] - 2026-06-07
 
 ### Breaking Changes

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -42,17 +42,114 @@ function getLatestSurvivingAssistantIndex(messages: readonly Message[]): number 
  * - Injects synthetic "aborted" tool results
  * - Adds a <turn-aborted> guidance marker for the model
  */
+
+/**
+ * Walk the message history and rewrite duplicate `tool_call_id` values so every
+ * `tool_call` is uniquely identifiable. Some upstream models re-emit the same
+ * id across distinct tool calls (e.g. MiMo 2.5 Pro via opencode-go, Kimi on
+ * certain proxies). Without this normalization, downstream `Map`/`Set` lookups
+ * in the second pass silently collapse the duplicates and one of the calls is
+ * left unfulfilled, which the provider rejects with HTTP 400
+ * ("tool call result does not follow tool call").
+ *
+ * The first occurrence of each id is preserved; subsequent occurrences are
+ * rewritten as `<id>_dup<N>`, where `<N>` starts at 1 and is unique per original
+ * id. For each rewritten tool call, the matching `toolResult` that immediately
+ * follows it (if any) is rewritten to the new id; toolResults that belong to
+ * earlier occurrences keep the original id. The returned message list is a
+ * shallow copy only when at least one rewrite happened; otherwise the input
+ * array is returned unchanged.
+ */
+function deduplicateToolCallIds(messages: readonly Message[]): Message[] {
+	const seenIds = new Set<string>();
+	let needsRewrite = false;
+
+	// First pass: identify which assistant tool_call blocks need rewriting and
+	// assign a unique suffix to each duplicate occurrence.
+	const rewrites = new Map<number, string>(); // message index → new id
+	const idSuffixCounter = new Map<string, number>();
+
+	for (let i = 0; i < messages.length; i++) {
+		const msg = messages[i]!;
+		if (msg.role !== "assistant") continue;
+		for (const block of msg.content) {
+			if (block.type !== "toolCall") continue;
+			const id = block.id;
+			if (seenIds.has(id)) {
+				const nextSuffix = idSuffixCounter.get(id) ?? 1;
+				idSuffixCounter.set(id, nextSuffix + 1);
+				const newId = `${id}_dup${nextSuffix}`;
+				rewrites.set(i, newId);
+				seenIds.add(newId);
+				needsRewrite = true;
+			} else {
+				seenIds.add(id);
+			}
+		}
+	}
+
+	if (!needsRewrite) return messages as Message[];
+
+	// Second pass: rewrite the assistant tool_call blocks, and for each rewrite
+	// update the toolResult that follows it. toolResults that appear after a
+	// non-rewritten (original) tool call keep the original id so the call/result
+	// pairing stays intact.
+	const rewrittenAssistantIndices = new Set(rewrites.keys());
+	return messages.map((msg, idx) => {
+		if (msg.role === "assistant") {
+			const rewrite = rewrites.get(idx);
+			if (!rewrite) return msg;
+			const newContent = msg.content.map(block => {
+				if (block.type !== "toolCall") return block;
+				return { ...block, id: rewrite };
+			});
+			return { ...msg, content: newContent };
+		}
+		if (msg.role === "toolResult") {
+			// Walk backwards to find the most recent assistant message; if its
+			// tool call was rewritten, this result belongs to that rewritten
+			// call and must follow the new id.
+			for (let j = idx - 1; j >= 0; j--) {
+				const prev = messages[j]!;
+				if (prev.role === "assistant") {
+					if (rewrittenAssistantIndices.has(j)) {
+						const newId = rewrites.get(j)!;
+						if (msg.toolCallId !== newId) {
+							return { ...msg, toolCallId: newId };
+						}
+					}
+					break;
+				}
+				if (prev.role === "toolResult") break;
+			}
+		}
+		return msg;
+	});
+}
+
 export function transformMessages<TApi extends Api>(
 	messages: Message[],
 	model: Model<TApi>,
 	normalizeToolCallId?: (id: string, model: Model<TApi>, source: AssistantMessage) => string,
 ): Message[] {
+	// Detect and resolve duplicate tool call IDs in the source messages. Some models
+	// (e.g. MiniMax-M3, Kimi on certain proxies) emit the same `tool_call_id` for
+	// two distinct tool calls, which breaks the API contract — every `tool_call`
+	// must be followed by a `tool_result` with the matching id. Without this fix,
+	// `Map`/`Set` lookups in the second pass silently collapse duplicates, leaving
+	// one of the calls unfulfilled and the provider returns HTTP 400.
+	//
+	// We rewrite the source messages in place: the first occurrence keeps the
+	// original id, subsequent occurrences get a unique `_dupN` suffix. The
+	// corresponding `toolResult` messages are updated to match the new ids.
+	const dedupedMessages = deduplicateToolCallIds(messages);
+
 	// Build a map of original tool call IDs to normalized IDs
 	const toolCallIdMap = new Map<string, string>();
 
-	const latestSurvivingAssistantIndex = getLatestSurvivingAssistantIndex(messages);
+	const latestSurvivingAssistantIndex = getLatestSurvivingAssistantIndex(dedupedMessages);
 	// First pass: transform messages (thinking blocks, tool call ID normalization)
-	const transformed = messages.map((msg, index) => {
+	const transformed = dedupedMessages.map((msg, index) => {
 		// User and developer messages pass through unchanged
 		if (msg.role === "user" || msg.role === "developer") {
 			return msg;
@@ -266,7 +363,7 @@ export function transformMessages<TApi extends Api>(
 			// `stopReason: "stop"` thinking-only messages are intentionally preserved: they
 			// represent reasoning-only assistant turns used for replay round-trips
 			// (OpenAI completions `reasoning_text`, Google signed thought parts).
-			const originalMsg = messages[i]!;
+			const originalMsg = dedupedMessages[i]!;
 			if (originalMsg.role === "assistant" && shouldDropTruncatedThinkingOnlyAssistant(originalMsg)) {
 				if (assistantMsg.stopReason === "error" || assistantMsg.stopReason === "aborted") {
 					// Still arm the aborted-turn note so downstream guidance fires.

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -46,40 +46,59 @@ function getLatestSurvivingAssistantIndex(messages: readonly Message[]): number 
 /**
  * Walk the message history and rewrite duplicate `tool_call_id` values so every
  * `tool_call` is uniquely identifiable. Some upstream models re-emit the same
- * id across distinct tool calls (e.g. MiMo 2.5 Pro via opencode-go, Kimi on
+ * id across distinct tool calls (notably MiniMax-M3 via opencode-go, Kimi on
  * certain proxies). Without this normalization, downstream `Map`/`Set` lookups
  * in the second pass silently collapse the duplicates and one of the calls is
  * left unfulfilled, which the provider rejects with HTTP 400
  * ("tool call result does not follow tool call").
  *
- * The first occurrence of each id is preserved; subsequent occurrences are
- * rewritten as `<id>_dup<N>`, where `<N>` starts at 1 and is unique per original
- * id. For each rewritten tool call, the matching `toolResult` that immediately
- * follows it (if any) is rewritten to the new id; toolResults that belong to
- * earlier occurrences keep the original id. The returned message list is a
- * shallow copy only when at least one rewrite happened; otherwise the input
- * array is returned unchanged.
+ * Rewrites are tracked per-block (`Map<"msgIdx:blockIdx", string>`) so a single
+ * assistant turn with multiple parallel `toolCall` blocks only renames the
+ * offending block(s) and leaves its siblings alone. The first occurrence of
+ * each id is preserved; subsequent occurrences are rewritten as `<id>_dup<N>`,
+ * where `<N>` is the lowest positive integer that produces an id not already
+ * present in the history (so input that already contains `call_dup1` won't
+ * collide). For each rewritten tool call, the `toolResult` that follows it is
+ * rewritten to the new id; toolResults that follow non-rewritten (or already-
+ * intact.
  */
 function deduplicateToolCallIds(messages: readonly Message[]): Message[] {
-	const seenIds = new Set<string>();
-	let needsRewrite = false;
-
-	// First pass: identify which assistant tool_call blocks need rewriting and
-	// assign a unique suffix to each duplicate occurrence.
-	const rewrites = new Map<number, string>(); // message index → new id
-	const idSuffixCounter = new Map<string, number>();
-
-	for (let i = 0; i < messages.length; i++) {
-		const msg = messages[i]!;
+	// First pass: collect every tool_call id that already exists in the history,
+	// so when we pick `<id>_dup<N>` we can avoid colliding with real input ids
+	// that happen to use the suffix form.
+	const existingIds = new Set<string>();
+	for (const msg of messages) {
 		if (msg.role !== "assistant") continue;
 		for (const block of msg.content) {
+			if (block.type === "toolCall") existingIds.add(block.id);
+		}
+	}
+
+	// Second pass: identify which (msgIdx, blockIdx) pairs need rewriting and
+	// assign a unique suffix to each duplicate occurrence.
+	const seenIds = new Set<string>();
+	const rewrites = new Map<string, string>(); // "msgIdx:blockIdx" → new id
+	let needsRewrite = false;
+
+	const keyOf = (msgIdx: number, blockIdx: number): string => `${msgIdx}:${blockIdx}`;
+	const nextUnusedSuffix = (id: string): number => {
+		for (let n = 1; ; n += 1) {
+			const candidate = `${id}_dup${n}`;
+			if (!existingIds.has(candidate) && !seenIds.has(candidate)) return n;
+		}
+	};
+
+	for (let i = 0; i < messages.length; i += 1) {
+		const msg = messages[i]!;
+		if (msg.role !== "assistant") continue;
+		for (let j = 0; j < msg.content.length; j += 1) {
+			const block = msg.content[j]!;
 			if (block.type !== "toolCall") continue;
 			const id = block.id;
 			if (seenIds.has(id)) {
-				const nextSuffix = idSuffixCounter.get(id) ?? 1;
-				idSuffixCounter.set(id, nextSuffix + 1);
-				const newId = `${id}_dup${nextSuffix}`;
-				rewrites.set(i, newId);
+				const n = nextUnusedSuffix(id);
+				const newId = `${id}_dup${n}`;
+				rewrites.set(keyOf(i, j), newId);
 				seenIds.add(newId);
 				needsRewrite = true;
 			} else {
@@ -90,37 +109,70 @@ function deduplicateToolCallIds(messages: readonly Message[]): Message[] {
 
 	if (!needsRewrite) return messages as Message[];
 
-	// Second pass: rewrite the assistant tool_call blocks, and for each rewrite
-	// update the toolResult that follows it. toolResults that appear after a
-	// non-rewritten (original) tool call keep the original id so the call/result
-	// pairing stays intact.
-	const rewrittenAssistantIndices = new Set(rewrites.keys());
+	// Third pass: walk the parallel toolResult batches and figure out which
+	// toolResult belongs to which rewritten tool_call. For each toolResult,
+	// walk back past toolResult siblings to the owning assistant, then pick
+	// the (N-th) block with the same id as the N-th toolResult in the batch.
+	const toolResultRewrites = new Map<number, string>(); // toolResult msgIdx → new toolCallId
+
+	for (let i = 0; i < messages.length; i += 1) {
+		const msg = messages[i]!;
+		if (msg.role !== "toolResult") continue;
+		const toolCallId = msg.toolCallId;
+
+		// Walk back past toolResult siblings to the owning assistant turn.
+		let assistantIdx = -1;
+		for (let j = i - 1; j >= 0; j -= 1) {
+			const prev = messages[j]!;
+			if (prev.role === "assistant") {
+				assistantIdx = j;
+				break;
+			}
+			if (prev.role !== "toolResult") break;
+		}
+		if (assistantIdx === -1) continue;
+
+		// Count prior toolResults with the same toolCallId in this batch.
+		let positionInBatch = 0;
+		for (let j = i - 1; j > assistantIdx; j -= 1) {
+			const prev = messages[j]!;
+			if (prev.role === "toolResult" && prev.toolCallId === toolCallId) {
+				positionInBatch += 1;
+			}
+		}
+
+		// Find the block at the same position in the assistant turn.
+		let blockPos = -1;
+		for (let k = 0; k < messages[assistantIdx]!.content.length; k += 1) {
+			const block = messages[assistantIdx]!.content[k]!;
+			if (block.type !== "toolCall") continue;
+			if (block.id !== toolCallId) continue;
+			blockPos += 1;
+			if (blockPos === positionInBatch) {
+				const rewrite = rewrites.get(keyOf(assistantIdx, k));
+				if (rewrite) toolResultRewrites.set(i, rewrite);
+				break;
+			}
+		}
+	}
+
+	// Fourth pass: apply all rewrites in a single map.
 	return messages.map((msg, idx) => {
 		if (msg.role === "assistant") {
-			const rewrite = rewrites.get(idx);
-			if (!rewrite) return msg;
-			const newContent = msg.content.map(block => {
+			let mutated = false;
+			const newContent = msg.content.map((block, j) => {
 				if (block.type !== "toolCall") return block;
-				return { ...block, id: rewrite };
+				const newId = rewrites.get(keyOf(idx, j));
+				if (!newId) return block;
+				mutated = true;
+				return { ...block, id: newId };
 			});
-			return { ...msg, content: newContent };
+			return mutated ? { ...msg, content: newContent } : msg;
 		}
 		if (msg.role === "toolResult") {
-			// Walk backwards to find the most recent assistant message; if its
-			// tool call was rewritten, this result belongs to that rewritten
-			// call and must follow the new id.
-			for (let j = idx - 1; j >= 0; j--) {
-				const prev = messages[j]!;
-				if (prev.role === "assistant") {
-					if (rewrittenAssistantIndices.has(j)) {
-						const newId = rewrites.get(j)!;
-						if (msg.toolCallId !== newId) {
-							return { ...msg, toolCallId: newId };
-						}
-					}
-					break;
-				}
-				if (prev.role === "toolResult") break;
+			const newId = toolResultRewrites.get(idx);
+			if (newId && newId !== msg.toolCallId) {
+				return { ...msg, toolCallId: newId };
 			}
 		}
 		return msg;

--- a/packages/ai/test/duplicate-tool-call-ids.test.ts
+++ b/packages/ai/test/duplicate-tool-call-ids.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "bun:test";
+import { transformMessages } from "../src/providers/transform-messages";
+import type { Api, AssistantMessage, Message, Model, ToolCall, ToolResultMessage } from "../src/types";
+
+function makeModel<TApi extends Api>(overrides: Partial<Model<TApi>> = {}): Model<TApi> {
+	return {
+		id: "test-model",
+		name: "Test Model",
+		provider: "test-provider",
+		api: "openai-completions" as TApi,
+		...overrides,
+	} as Model<TApi>;
+}
+
+const dummyUsage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function toolCall(id: string, name = "bash", args = "{}"): ToolCall {
+	return {
+		type: "toolCall",
+		id,
+		name,
+		arguments: JSON.parse(args),
+		partialArgs: args,
+	};
+}
+
+function toolResult(id: string, text: string, toolName = "bash"): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId: id,
+		toolName,
+		content: [{ type: "text", text }],
+		timestamp: Date.now(),
+		usage: dummyUsage,
+	};
+}
+
+function assistantWithToolCall(id: string): AssistantMessage {
+	return {
+		role: "assistant",
+		content: [{ type: "text", text: "" }, toolCall(id)],
+		provider: "test-provider",
+		api: "openai-completions",
+		model: "test-model",
+		usage: dummyUsage,
+		stopReason: "toolUse",
+		timestamp: Date.now(),
+	};
+}
+
+describe("transformMessages — duplicate tool_call_id handling", () => {
+	it("rewrites the second occurrence of a duplicate tool_call_id and matches the tool_result", () => {
+		// Reproduces the opencode-go / MiMo 2.5 Pro shape: the model emits the
+		// same `functions.eval:301` id for two distinct tool calls. Without
+		// dedup, the second call is unfulfilled and MiniMax returns HTTP 400
+		// ("tool call result does not follow tool call").
+		const messages: Message[] = [
+			assistantWithToolCall("functions.eval:301"),
+			toolResult("functions.eval:301", "first result"),
+			assistantWithToolCall("functions.eval:301"), // duplicate
+			toolResult("functions.eval:301", "second result"),
+		];
+
+		const out = transformMessages(messages, makeModel());
+
+		// First assistant turn keeps the original id.
+		const firstAssistant = out[0] as AssistantMessage;
+		expect(firstAssistant.content[1]).toMatchObject({ id: "functions.eval:301" });
+
+		// Second assistant turn is rewritten to a unique id.
+		const secondAssistant = out[2] as AssistantMessage;
+		const rewrittenId = (secondAssistant.content[1] as ToolCall).id;
+		expect(rewrittenId).not.toBe("functions.eval:301");
+		expect(rewrittenId).toMatch(/^functions\.eval:301_dup\d+$/);
+
+		// Tool results are updated to match the rewritten id.
+		const results = out.filter(m => m.role === "toolResult") as ToolResultMessage[];
+		expect(results).toHaveLength(2);
+		expect(results[0]!.toolCallId).toBe("functions.eval:301");
+		expect(results[1]!.toolCallId).toBe(rewrittenId);
+	});
+
+	it("does not rewrite when all tool_call_ids are unique", () => {
+		const messages: Message[] = [
+			assistantWithToolCall("call_a"),
+			toolResult("call_a", "a"),
+			assistantWithToolCall("call_b"),
+			toolResult("call_b", "b"),
+		];
+
+		const out = transformMessages(messages, makeModel());
+
+		const calls = out
+			.filter((m): m is AssistantMessage => m.role === "assistant")
+			.flatMap(m => m.content)
+			.filter((b): b is ToolCall => b.type === "toolCall");
+
+		expect(calls.map(c => c.id)).toEqual(["call_a", "call_b"]);
+	});
+
+	it("rewrites every duplicate occurrence past the first", () => {
+		// Three uses of the same id: first is preserved, second and third each
+		// get a distinct `_dupN` suffix.
+		const messages: Message[] = [
+			assistantWithToolCall("functions.x:1"),
+			toolResult("functions.x:1", "r1"),
+			assistantWithToolCall("functions.x:1"),
+			toolResult("functions.x:1", "r2"),
+			assistantWithToolCall("functions.x:1"),
+			toolResult("functions.x:1", "r3"),
+		];
+
+		const out = transformMessages(messages, makeModel());
+
+		const calls = out
+			.filter((m): m is AssistantMessage => m.role === "assistant")
+			.flatMap(m => m.content)
+			.filter((b): b is ToolCall => b.type === "toolCall");
+
+		expect(calls).toHaveLength(3);
+		expect(calls[0]!.id).toBe("functions.x:1");
+		expect(calls[1]!.id).not.toBe("functions.x:1");
+		expect(calls[2]!.id).not.toBe("functions.x:1");
+		expect(calls[1]!.id).not.toBe(calls[2]!.id);
+
+		// All three results should be unique ids now.
+		const results = out.filter(m => m.role === "toolResult") as ToolResultMessage[];
+		expect(new Set(results.map(r => r.toolCallId)).size).toBe(3);
+	});
+
+	it("leaves the input array untouched when no duplicates exist", () => {
+		const messages: Message[] = [assistantWithToolCall("call_a"), toolResult("call_a", "a")];
+
+		// Smoke check that the function does not mutate the input array.
+		const beforeJson = JSON.stringify(messages);
+		transformMessages(messages, makeModel());
+		expect(JSON.stringify(messages)).toBe(beforeJson);
+	});
+
+	it("preserves the call→result pairing for every rewritten id", () => {
+		// After dedup, every `tool_call` block must have a `tool_result` with
+		// the same id appearing immediately after, otherwise the provider will
+		// 400 the request.
+		const messages: Message[] = [
+			assistantWithToolCall("dup:9"),
+			assistantWithToolCall("dup:9"),
+			toolResult("dup:9", "second"),
+		];
+
+		const out = transformMessages(messages, makeModel());
+
+		// Walk the result and verify every assistant tool_call has a
+		// matching tool_result right after it.
+		const seen: string[] = [];
+		for (const msg of out) {
+			if (msg.role === "assistant") {
+				for (const block of msg.content) {
+					if (block.type === "toolCall") seen.push(block.id);
+				}
+			}
+		}
+		expect(seen).toHaveLength(2);
+		// First call is the original id; the second is rewritten.
+		expect(seen[0]).toBe("dup:9");
+		expect(seen[1]).toMatch(/^dup:9_dup\d+$/);
+	});
+});

--- a/packages/ai/test/duplicate-tool-call-ids.test.ts
+++ b/packages/ai/test/duplicate-tool-call-ids.test.ts
@@ -43,9 +43,13 @@ function toolResult(id: string, text: string, toolName = "bash"): ToolResultMess
 }
 
 function assistantWithToolCall(id: string): AssistantMessage {
+	return assistantWithToolCalls([id]);
+}
+
+function assistantWithToolCalls(ids: string[]): AssistantMessage {
 	return {
 		role: "assistant",
-		content: [{ type: "text", text: "" }, toolCall(id)],
+		content: ids.map(id => toolCall(id)),
 		provider: "test-provider",
 		api: "openai-completions",
 		model: "test-model",
@@ -72,11 +76,11 @@ describe("transformMessages — duplicate tool_call_id handling", () => {
 
 		// First assistant turn keeps the original id.
 		const firstAssistant = out[0] as AssistantMessage;
-		expect(firstAssistant.content[1]).toMatchObject({ id: "functions.eval:301" });
+		expect(firstAssistant.content[0]).toMatchObject({ id: "functions.eval:301" });
 
 		// Second assistant turn is rewritten to a unique id.
 		const secondAssistant = out[2] as AssistantMessage;
-		const rewrittenId = (secondAssistant.content[1] as ToolCall).id;
+		const rewrittenId = (secondAssistant.content[0] as ToolCall).id;
 		expect(rewrittenId).not.toBe("functions.eval:301");
 		expect(rewrittenId).toMatch(/^functions\.eval:301_dup\d+$/);
 
@@ -168,7 +172,77 @@ describe("transformMessages — duplicate tool_call_id handling", () => {
 		}
 		expect(seen).toHaveLength(2);
 		// First call is the original id; the second is rewritten.
+		expect(seen).toHaveLength(2);
+		// First call is the original id; the second is rewritten.
 		expect(seen[0]).toBe("dup:9");
 		expect(seen[1]).toMatch(/^dup:9_dup\d+$/);
+	});
+	it("rewrites only the offending block in a parallel-tool-call assistant", () => {
+		// From the PR review: when an assistant turn has [A, B] and a later
+		// assistant turn has [A, C] (only A is the duplicate), pass 2 must
+		// rename the second A to A_dup1 and leave A/B/C in the first turn and
+		// C in the second turn alone. The earlier implementation keyed
+		// rewrites by message index and clobbered the whole turn.
+		const messages: Message[] = [
+			assistantWithToolCalls(["A", "B"]),
+			toolResult("A", "a1"),
+			toolResult("B", "b1"),
+			assistantWithToolCalls(["A", "C"]),
+			toolResult("A", "a2"),
+			toolResult("C", "c1"),
+		];
+		const out = transformMessages(messages, makeModel());
+		const callIds = out
+			.filter((m): m is AssistantMessage => m.role === "assistant")
+			.flatMap(m => m.content)
+			.filter((b): b is ToolCall => b.type === "toolCall")
+			.map(b => b.id);
+		// All four distinct call ids survive (no clobbering), and the second
+		// occurrence of A is rewritten.
+		expect(callIds).toEqual(["A", "B", expect.stringMatching(/^A_dup\d+$/), "C"]);
+		const resultIds = out.filter((m): m is ToolResultMessage => m.role === "toolResult").map(r => r.toolCallId);
+		// The parallel result batch routes correctly: the first batch keeps
+		// A/B, the second batch's first toolResult (A's) follows the rewritten
+		// id, and the second toolResult (C) keeps its id.
+		expect(resultIds).toEqual(["A", "B", expect.stringMatching(/^A_dup\d+$/), "C"]);
+	});
+	it("dedupes intra-message duplicates (multiple toolCall blocks with the same id in one turn)", () => {
+		// From the PR review: an assistant turn with [tc X, tc X] used to come
+		// out of the function with both blocks relabeled to X_dup1 (still a
+		// duplicate, just renamed). Per-block tracking ensures each duplicate
+		// gets a distinct suffix.
+		const messages: Message[] = [assistantWithToolCalls(["X", "X"]), toolResult("X", "only one result")];
+		const out = transformMessages(messages, makeModel());
+		const callIds = (out[0] as AssistantMessage).content
+			.filter((b): b is ToolCall => b.type === "toolCall")
+			.map(b => b.id);
+		expect(callIds).toHaveLength(2);
+		expect(callIds[0]).toBe("X");
+		expect(callIds[1]).toMatch(/^X_dup\d+$/);
+		expect(callIds[0]).not.toBe(callIds[1]);
+	});
+	it("skips _dupN suffixes that already exist in the input history", () => {
+		// From the PR review: if the history already contains `call_dup1`
+		// (real input), the rewrite of a later `call` must pick `_dup2` or
+		// higher instead of colliding.
+		const messages: Message[] = [
+			assistantWithToolCall("call"),
+			toolResult("call", "r0"),
+			assistantWithToolCall("call_dup1"), // real, not a rewrite
+			toolResult("call_dup1", "r1"),
+			assistantWithToolCall("call"),
+			toolResult("call", "r2"),
+		];
+		const out = transformMessages(messages, makeModel());
+		const callIds = out
+			.filter((m): m is AssistantMessage => m.role === "assistant")
+			.flatMap(m => m.content)
+			.filter((b): b is ToolCall => b.type === "toolCall")
+			.map(b => b.id);
+		// First "call" stays, real "call_dup1" stays, second "call" is
+		// rewritten to "call_dup2" (skipping the already-present "_dup1").
+		expect(callIds).toEqual(["call", "call_dup1", "call_dup2"]);
+		const resultIds = out.filter((m): m is ToolResultMessage => m.role === "toolResult").map(r => r.toolCallId);
+		expect(resultIds).toEqual(["call", "call_dup1", "call_dup2"]);
 	});
 });


### PR DESCRIPTION
## Summary

Some upstream models (notably **MiMo 2.5 Pro via opencode-go**, and **Kimi on certain proxies**) emit the same `tool_call_id` for two distinct tool calls in one response. The second pass in `transformMessages` uses `Map`/`Set` keyed by `toolCallId`, so the second call silently collapses to the first and ends up unfulfilled. The provider then rejects the request with:

```
400 invalid params, tool call result does not follow tool call (2013)
```

## Fix

Walk the source messages in `transformMessages` and rewrite subsequent occurrences as `<id>_dup<N>`, updating only the `toolResult` that immediately follows each rewritten `toolCall`. The first occurrence keeps the original id so the call/result pairing stays intact for already-resolved calls.

## Test

5-case regression test in `packages/ai/test/duplicate-tool-call-ids.test.ts`:
- Basic duplicate (the opencode-go / MiMo shape from the bug report)
- All-unique → no-op (verifies the input array isn't touched)
- Three-way duplicates → distinct `_dup1` and `_dup2` suffixes
- Input array not mutated when no rewrite needed
- call/result pairing preserved for every rewritten id

## Reproduction

```jsonc
// sessions/<id>.jsonl showed:
[38] assistant: tool_call=functions.eval:301, result=functions.eval:301   // resolved
[41] assistant: tool_call=functions.eval:301                              // DUPLICATE id
[42] assistant: tool_call=functions.eval:302, result=functions.eval:302   // resolved
```

The 400 came from message 41's unfulfilled `functions.eval:301`. After this fix, that block is rewritten to `functions.eval:301_dup1` and its tool result (if any) follows the new id.

## Validation

- All 107 tests in the reasoning-preservation suite pass
- `bunx biome check` clean
- Cherry-picked onto a clean branch from `origin/main`