### PR TITLE
fix(ai): support impersonated service account ADC for vertex

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Added
+
+- Added support for `impersonated_service_account` Application Default Credentials (ADC) in Vertex AI to enable chained impersonation without failing via 401 `invalid_client`.
 # Changelog
 
 ## [Unreleased]

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,11 +1,10 @@
+# Changelog
 ## [Unreleased]
 
 ### Added
 
 - Added support for `impersonated_service_account` Application Default Credentials (ADC) in Vertex AI to enable chained impersonation without failing via 401 `invalid_client`.
-# Changelog
 
-## [Unreleased]
 
 ## [15.10.1] - 2026-06-07
 

--- a/packages/ai/src/providers/__tests__/google-auth.test.ts
+++ b/packages/ai/src/providers/__tests__/google-auth.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, mock } from "bun:test";
+import { getVertexAccessToken, __resetVertexTokenCache } from "../google-auth";
+
+describe("getVertexAccessToken", () => {
+	it("should exchange impersonated ADC correctly", async () => {
+		__resetVertexTokenCache();
+		Bun.env.GOOGLE_APPLICATION_CREDENTIALS = "/tmp/mock-impersonated-adc.json";
+		
+		await Bun.write("/tmp/mock-impersonated-adc.json", JSON.stringify({
+			type: "impersonated_service_account",
+			service_account_impersonation_url: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/target@project.iam.gserviceaccount.com:generateAccessToken",
+			source_credentials: {
+				type: "authorized_user",
+				client_id: "client-id",
+				client_secret: "client-secret",
+				refresh_token: "refresh-token"
+			},
+			delegates: ["delegate1"]
+		}));
+
+		let fetchCalls: any[] = [];
+		const mockFetch = mock(async (url: string, opts: any) => {
+			fetchCalls.push({ url, opts });
+			if (url.includes("oauth2.googleapis.com/token")) {
+				return { ok: true, json: async () => ({ access_token: "source-token", expires_in: 3600 }) };
+			}
+			if (url.includes("iamcredentials.googleapis.com")) {
+				return { ok: true, json: async () => ({ accessToken: "impersonated-token", expireTime: new Date(Date.now() + 3600000).toISOString() }) };
+			}
+			return { ok: false };
+		}) as any;
+
+		const token = await getVertexAccessToken({ fetch: mockFetch });
+		expect(token).toBe("impersonated-token");
+		expect(fetchCalls.length).toBe(2);
+		expect(fetchCalls[0].url).toContain("oauth2.googleapis.com");
+		expect(fetchCalls[1].url).toBe("https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/target@project.iam.gserviceaccount.com:generateAccessToken");
+		expect(fetchCalls[1].opts.headers.Authorization).toBe("Bearer source-token");
+		expect(JSON.parse(fetchCalls[1].opts.body).delegates).toEqual(["delegate1"]);
+	});
+});

--- a/packages/ai/src/providers/google-auth.ts
+++ b/packages/ai/src/providers/google-auth.ts
@@ -46,6 +46,7 @@ interface ImpersonatedServiceAccountCredentials {
 	type: "impersonated_service_account";
 	service_account_impersonation_url: string;
 	source_credentials: AuthorizedUserCredentials | ServiceAccountCredentials;
+	delegates?: string[];
 }
 
 type AdcFileCredentials = ServiceAccountCredentials | AuthorizedUserCredentials | ImpersonatedServiceAccountCredentials;
@@ -206,18 +207,28 @@ async function resolveAccessTokenUncached(
 		let token: TokenResponse;
 
 		if (creds.type === "impersonated_service_account") {
+			const targetPrincipalMatch = /(?<target>[^/]+):(generateAccessToken|generateIdToken)$/.exec(
+				creds.service_account_impersonation_url,
+			);
+			const targetPrincipal = targetPrincipalMatch?.groups?.target;
+			if (!targetPrincipal) {
+				throw new RangeError(
+					`Cannot extract target principal from ${creds.service_account_impersonation_url}`,
+				);
+			}
+
 			const sourceToken =
 				creds.source_credentials.type === "service_account"
 					? await exchangeJwtForToken(creds.source_credentials, signal, fetchImpl)
 					: await exchangeRefreshToken(creds.source_credentials, signal, fetchImpl);
 
-			const response = await fetchImpl(creds.service_account_impersonation_url, {
+			const response = await fetchImpl(`https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${targetPrincipal}:generateAccessToken`, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
 					Authorization: `Bearer ${sourceToken.access_token}`,
 				},
-				body: JSON.stringify({ delegates: [], scope: [CLOUD_PLATFORM_SCOPE], lifetime: "3600s" }),
+				body: JSON.stringify({ delegates: creds.delegates ?? [], scope: [CLOUD_PLATFORM_SCOPE], lifetime: "3600s" }),
 				signal,
 			});
 			if (!response.ok) {

--- a/packages/ai/src/providers/google-auth.ts
+++ b/packages/ai/src/providers/google-auth.ts
@@ -42,7 +42,13 @@ interface AuthorizedUserCredentials {
 	refresh_token: string;
 }
 
-type AdcFileCredentials = ServiceAccountCredentials | AuthorizedUserCredentials;
+interface ImpersonatedServiceAccountCredentials {
+	type: "impersonated_service_account";
+	service_account_impersonation_url: string;
+	source_credentials: AuthorizedUserCredentials | ServiceAccountCredentials;
+}
+
+type AdcFileCredentials = ServiceAccountCredentials | AuthorizedUserCredentials | ImpersonatedServiceAccountCredentials;
 
 interface TokenResponse {
 	access_token: string;
@@ -196,10 +202,37 @@ async function resolveAccessTokenUncached(
 ): Promise<{ source: string; token: TokenResponse }> {
 	const adc = await loadAdcCredentials();
 	if (adc) {
-		const token =
-			adc.creds.type === "service_account"
-				? await exchangeJwtForToken(adc.creds, signal, fetchImpl)
-				: await exchangeRefreshToken(adc.creds, signal, fetchImpl);
+		const creds = adc.creds;
+		let token: TokenResponse;
+
+		if (creds.type === "impersonated_service_account") {
+			const sourceToken =
+				creds.source_credentials.type === "service_account"
+					? await exchangeJwtForToken(creds.source_credentials, signal, fetchImpl)
+					: await exchangeRefreshToken(creds.source_credentials, signal, fetchImpl);
+
+			const response = await fetchImpl(creds.service_account_impersonation_url, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+					Authorization: `Bearer ${sourceToken.access_token}`,
+				},
+				body: JSON.stringify({ delegates: [], scope: [CLOUD_PLATFORM_SCOPE], lifetime: "3600s" }),
+				signal,
+			});
+			if (!response.ok) {
+				const detail = await response.text().catch(() => "");
+				throw new Error(`Google Impersonation token exchange failed (${response.status}): ${detail}`);
+			}
+			const data = (await response.json()) as { accessToken: string; expireTime: string };
+			const expiresIn = Math.max(0, Math.floor((new Date(data.expireTime).getTime() - Date.now()) / 1000));
+			token = { access_token: data.accessToken, expires_in: expiresIn, token_type: "Bearer" };
+		} else {
+			token =
+				creds.type === "service_account"
+					? await exchangeJwtForToken(creds, signal, fetchImpl)
+					: await exchangeRefreshToken(creds, signal, fetchImpl);
+		}
 		return { source: adc.source, token };
 	}
 	const metadata = await fetchMetadataToken(signal, fetchImpl);


### PR DESCRIPTION
## 📝 Pull Request Description

**Fixes:** 401 `invalid_client` error when using Vertex AI with impersonated service accounts.

### 🐛 1. How to Reproduce the Bug
1. Have the Google Cloud CLI installed and configured.
2. Authenticate using Service Account Impersonation to generate your Application Default Credentials (ADC):
   ```bash
   gcloud auth application-default login --impersonate-service-account=my-sa@my-project.iam.gserviceaccount.com
   ```
3. This creates an ADC JSON file at `~/.config/gcloud/application_default_credentials.json` with `"type": "impersonated_service_account"`.
4. Launch `omp` and attempt to send a message to any `google-vertex` model.
5. **Expected Error:** 
   `Google OAuth token exchange failed (401): {"error": "invalid_client", "error_description": "The OAuth client was not found."}`

### 🧠 2. Reasoning Behind the Fix
The custom lightweight ADC resolution in `@oh-my-pi/pi-ai/src/providers/google-auth.ts` only anticipated root-level `type: "service_account"` and `type: "authorized_user"`. 

When a user authenticates via impersonation, the ADC file has `type: "impersonated_service_account"`. The actual OAuth credentials (refresh token, client ID) are nested inside a `source_credentials` object. Because the original code didn't know how to unwrap this, it sent `undefined` fields to the Google OAuth endpoint, resulting in the 401 error.

This fix:
1. Detects `impersonated_service_account`.
2. Unwraps `source_credentials` and performs the standard JWT/Refresh token exchange to get a **source token**.
3. Uses the source token to call the IAM Credentials API (`service_account_impersonation_url`) to securely request an **impersonation token**.
4. Caches and returns the impersonation token for Vertex AI requests.

### ✅ 3. Post-Check Verification
To verify this fix works:
1. Apply the patch.
2. Run `gcloud auth application-default login --impersonate-service-account=...`
3. Clear the OMP cache to force token re-evaluation:
   ```bash
   bun run --bun scripts/clean.ts  # Or simply clear local token cache
   ```
4. Start `omp` and prompt a Vertex model.
5. The response should successfully stream back without authentication errors, and the GCP logs will show the impersonated service account making the Vertex API call.

