### PR TITLE
fix(mcp): declare approval tier for MCP tools to prevent hangs in non-yolo mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MCP tools hanging in non-yolo modes by declaring `approval = "write"` on `MCPTool` and `DeferredMCPTool`, and propagating the `approval` property through `customToolToDefinition()` in `sdk.ts`
+
 ## [15.10.1] - 2026-06-07
 
 ### Added

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -7,7 +7,13 @@
  * - Register commands, keyboard shortcuts, and CLI flags
  * - Interact with the user via UI primitives
  */
-import type { AgentMessage, AgentToolResult, AgentToolUpdateCallback, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import type {
+	AgentMessage,
+	AgentToolResult,
+	AgentToolUpdateCallback,
+	ThinkingLevel,
+	ToolApproval,
+} from "@oh-my-pi/pi-agent-core";
 import type { CompactionResult } from "@oh-my-pi/pi-agent-core/compaction";
 import type {
 	Api,
@@ -392,6 +398,9 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 	defaultInactive?: boolean;
 	/** If true, tool may stage deferred changes that require explicit resolve/discard. */
 	deferrable?: boolean;
+	/** Tool approval tier. Defaults to `"exec"` when omitted.
+	 *  `"read"`: read-only operations. `"write"`: mutations. `"exec"`: code execution. */
+	approval?: ToolApproval;
 	/** MCP server name for discovery/search metadata when this tool fronts an MCP server. */
 	mcpServerName?: string;
 	/** Original MCP tool name for discovery/search metadata. */

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -220,6 +220,7 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	readonly mcpToolName: string;
 	/** Server name */
 	readonly mcpServerName: string;
+	readonly approval = "write" as const;
 	/** Render completed MCP calls with the result header replacing the pending call header. */
 	readonly mergeCallAndResult = true;
 
@@ -305,6 +306,7 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	readonly mcpToolName: string;
 	/** Server name */
 	readonly mcpServerName: string;
+	readonly approval = "write" as const;
 	/** Render completed MCP calls with the result header replacing the pending call header. */
 	readonly mergeCallAndResult = true;
 

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -709,6 +709,7 @@ function customToolToDefinition(tool: CustomTool): ToolDefinition {
 		parameters: tool.parameters,
 		hidden: tool.hidden,
 		deferrable: tool.deferrable,
+		approval: tool.approval,
 		mcpServerName: tool.mcpServerName,
 		mcpToolName: tool.mcpToolName,
 		execute: (toolCallId, params, signal, onUpdate, ctx) =>

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -709,7 +709,7 @@ function customToolToDefinition(tool: CustomTool): ToolDefinition {
 		parameters: tool.parameters,
 		hidden: tool.hidden,
 		deferrable: tool.deferrable,
-		approval: tool.approval,
+		approval: typeof tool.approval === "function" ? tool.approval.bind(tool) : tool.approval,
 		mcpServerName: tool.mcpServerName,
 		mcpToolName: tool.mcpToolName,
 		execute: (toolCallId, params, signal, onUpdate, ctx) =>

--- a/packages/coding-agent/test/tools/approval.test.ts
+++ b/packages/coding-agent/test/tools/approval.test.ts
@@ -115,6 +115,17 @@ describe("MCP fallback and prompt formatting", () => {
 		expect(resolveApproval(subject, {}, "yolo")).toMatchObject({ policy: "allow", tier: "exec" });
 	});
 
+	it("allows MCP tools with write approval in write mode", () => {
+		const subject = tool("mcp__server__safe", "write");
+		expect(resolveApproval(subject, {}, "write")).toMatchObject({ policy: "allow", tier: "write" });
+		expect(resolveApproval(subject, {}, "yolo")).toMatchObject({ policy: "allow", tier: "write" });
+	});
+
+	it("prompts for MCP tools with write approval in always-ask mode", () => {
+		const subject = tool("mcp__server__safe", "write");
+		expect(resolveApproval(subject, {}, "always-ask")).toMatchObject({ policy: "prompt", tier: "write" });
+	});
+
 	it("formats MCP origin, reason, and per-tool details", () => {
 		const subject = tool("mcp__server__dangerous", undefined, () => ["Path: /tmp/out", "Content:\nhello"]);
 		expect(formatApprovalPrompt(subject, {}, "Needs confirmation").split("\n")).toEqual([


### PR DESCRIPTION
 ## What                                                                                      
                                                                                              
 Declare `approval = "write"` on `MCPTool` and `DeferredMCPTool`, and propagate the           
`approval` property through `customToolToDefinition()` in `sdk.ts`.                            
                                                                                              
 ## Why                                                                                       
                                                                                              
 MCP tools were missing an `approval` declaration, causing them to implicitly default to tier 
`"exec"` the highest tier in the approval system. In non-yolo modes (`write` or              
`always-ask`), this forced a user confirmation prompt for every MCP tool call. The prompt      
never rendered in the TUI while the agent was streaming, so the session hung indefinitely      
waiting for input that never appeared.                                                         
                                                                                              
 Two bugs were involved:                                                                      
                                                                                              
 1. `MCPTool` / `DeferredMCPTool` didn't declare `approval`, defaulting to `"exec"` instead   
of the appropriate `"write"` tier.                                                             
 2. `customToolToDefinition()` in `sdk.ts` didn't copy the `approval` property from           
`CustomTool` to `ToolDefinition`, so even if MCP tools had declared it, it would be silently   
dropped.                                                                                       
                                                                                              
 ## Behavior After Fix                                                                        
                                                                                              
 | Mode | MCP Tools |                                                                         
 |------|-----------|                                                                         
 | `yolo` | Pass (unchanged) |                                                                
 | `write` | Pass (fixed — was broken) |                                                      
 | `always-ask` | Prompt for approval (correct) |                                             
                                                                                              
 ## Testing                                                                                   
                                                                                              
 Tested all three approval modes using `searchMCP-LAN/safe_search`:                           
                                                                                              
 - **`yolo`**: MCP tool executed without prompting ✅                                         
 - **`write`**: MCP tool executed without prompting ✅ (was hanging before)                   
 - **`always-ask`**: MCP tool showed approval prompt and waited for user confirmation ✅      
                                                                                              
 `bun check` passes (TypeScript + biome clean across all packages).     