### PR TITLE
fix(coding-agent): classify MCP tools as write tier

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -50,6 +50,8 @@
 
 ### Fixed
 
+- Fixed MCP tools hanging in `write` approval mode by preserving custom-tool approval tiers and classifying MCP bridge tools as workspace-write operations ([#2062](https://github.com/can1357/oh-my-pi/issues/2062)).
+
 - Fixed inline `find` and `search` result blocks to align with grouped `read` output and render their success headers with the normal tool-title color instead of accent blue.
 
 - Fixed the working-status shimmer to opt into the loader's 30fps animated-message repaint path while keeping both the status spinner and pending bash/eval tool spinners on their normal 80 ms glyph cadence.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MCP tools hanging in `write` approval mode by preserving custom-tool approval tiers and classifying MCP bridge tools as workspace-write operations ([#2062](https://github.com/can1357/oh-my-pi/issues/2062)).
+
 ## [15.10.1] - 2026-06-07
 
 ### Added
@@ -49,8 +53,6 @@
 - Removed the `/background` (and `/bg`) slash command and the background-mode subsystem it was the sole entry point for — `InteractiveMode.isBackgrounded`, `createBackgroundUiContext`, `handleBackgroundEvent`, and every `isBackgrounded` guard across the input/event/extension-UI controllers and UI helpers. The command suspended the whole process group via `SIGTSTP` (a leftover testing shortcut) instead of detaching the running agent, which is not the expected workflow — use terminal panes or a multiplexer instead.
 
 ### Fixed
-
-- Fixed MCP tools hanging in `write` approval mode by preserving custom-tool approval tiers and classifying MCP bridge tools as workspace-write operations ([#2062](https://github.com/can1357/oh-my-pi/issues/2062)).
 
 - Fixed inline `find` and `search` result blocks to align with grouped `read` output and render their success headers with the normal tool-title color instead of accent blue.
 

--- a/packages/coding-agent/src/extensibility/extensions/types.ts
+++ b/packages/coding-agent/src/extensibility/extensions/types.ts
@@ -7,7 +7,13 @@
  * - Register commands, keyboard shortcuts, and CLI flags
  * - Interact with the user via UI primitives
  */
-import type { AgentMessage, AgentToolResult, AgentToolUpdateCallback, ThinkingLevel } from "@oh-my-pi/pi-agent-core";
+import type {
+	AgentMessage,
+	AgentToolResult,
+	AgentToolUpdateCallback,
+	ThinkingLevel,
+	ToolApproval,
+} from "@oh-my-pi/pi-agent-core";
 import type { CompactionResult } from "@oh-my-pi/pi-agent-core/compaction";
 import type {
 	Api,
@@ -396,6 +402,8 @@ export interface ToolDefinition<TParams extends TSchema = TSchema, TDetails = un
 	mcpServerName?: string;
 	/** Original MCP tool name for discovery/search metadata. */
 	mcpToolName?: string;
+	/** Capability tier declaration used by approval gates. Omitted means "exec". */
+	approval?: ToolApproval;
 	/** Execute the tool. */
 	execute(
 		toolCallId: string,

--- a/packages/coding-agent/src/mcp/tool-bridge.ts
+++ b/packages/coding-agent/src/mcp/tool-bridge.ts
@@ -222,6 +222,8 @@ export class MCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	readonly mcpServerName: string;
 	/** Render completed MCP calls with the result header replacing the pending call header. */
 	readonly mergeCallAndResult = true;
+	/** MCP tools may read or mutate external server state, but do not execute local commands. */
+	readonly approval = "write";
 
 	/** Create MCPTool instances for all tools from an MCP server connection */
 	static fromTools(connection: MCPServerConnection, tools: MCPToolDefinition[], reconnect?: MCPReconnect): MCPTool[] {
@@ -307,6 +309,8 @@ export class DeferredMCPTool implements CustomTool<TSchema, MCPToolDetails> {
 	readonly mcpServerName: string;
 	/** Render completed MCP calls with the result header replacing the pending call header. */
 	readonly mergeCallAndResult = true;
+	/** MCP tools may read or mutate external server state, but do not execute local commands. */
+	readonly approval = "write";
 
 	readonly #fallbackProvider: string | undefined;
 	readonly #fallbackProviderName: string | undefined;

--- a/packages/coding-agent/src/sdk.ts
+++ b/packages/coding-agent/src/sdk.ts
@@ -711,6 +711,7 @@ function customToolToDefinition(tool: CustomTool): ToolDefinition {
 		deferrable: tool.deferrable,
 		mcpServerName: tool.mcpServerName,
 		mcpToolName: tool.mcpToolName,
+		approval: tool.approval,
 		execute: (toolCallId, params, signal, onUpdate, ctx) =>
 			tool.execute(toolCallId, params, onUpdate, createCustomToolContext(ctx), signal),
 		onSession: tool.onSession ? (event, ctx) => tool.onSession?.(event, createCustomToolContext(ctx)) : undefined,

--- a/packages/coding-agent/test/tools/approval-mode.test.ts
+++ b/packages/coding-agent/test/tools/approval-mode.test.ts
@@ -5,15 +5,30 @@ import * as path from "node:path";
 import type { AgentToolContext } from "@oh-my-pi/pi-agent-core";
 import { getBundledModel } from "@oh-my-pi/pi-ai";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import type { CustomTool } from "@oh-my-pi/pi-coding-agent/extensibility/custom-tools/types";
 import { createAgentSession } from "@oh-my-pi/pi-coding-agent/sdk";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
 import { Snowflake } from "@oh-my-pi/pi-utils";
+import * as z from "zod/v4";
 
 const BASE_SETTINGS = {
 	"async.enabled": false,
 	"bash.autoBackground.enabled": false,
 	"bashInterceptor.enabled": false,
 } as const;
+
+const CUSTOM_WRITE_TOOL_NAME = "custom_write_tool";
+
+const customWriteTool = {
+	name: CUSTOM_WRITE_TOOL_NAME,
+	label: "Custom Write Tool",
+	description: "Exercises custom tool approval propagation",
+	parameters: z.object({}),
+	approval: "write",
+	async execute() {
+		return { content: [{ type: "text", text: "custom write ok" }] };
+	},
+} satisfies CustomTool;
 
 function emptyWorkspaceTree(cwd: string) {
 	return { rootPath: cwd, rendered: ".\n", truncated: false, totalLines: 1, agentsMdFiles: [] };
@@ -55,7 +70,8 @@ describe("tools.approvalMode setting", () => {
 			slashCommands: [],
 			enableMCP: false,
 			enableLsp: false,
-			toolNames: ["bash"],
+			toolNames: ["bash", CUSTOM_WRITE_TOOL_NAME],
+			customTools: [customWriteTool],
 		});
 		session = created.session;
 	});
@@ -136,6 +152,20 @@ describe("tools.approvalMode setting", () => {
 				settings,
 			} as AgentToolContext),
 		).rejects.toThrow(/requires approval but no interactive UI available/);
+	});
+
+	it("write mode allows custom tools that declare write approval", async () => {
+		const settings = approvalSettings({
+			"tools.approvalMode": "write",
+			"tools.approval": {},
+		});
+		const customTool = session.getToolByName(CUSTOM_WRITE_TOOL_NAME);
+		if (!customTool) throw new Error("Expected custom write tool");
+
+		const result = await customTool.execute("custom-write-mode", {}, undefined, undefined, {
+			settings,
+		} as AgentToolContext);
+		expect(textOf(result)).toContain("custom write ok");
 	});
 
 	it("critical bash patterns do not prompt in yolo mode with bash allowed", async () => {

--- a/packages/coding-agent/test/tools/approval.test.ts
+++ b/packages/coding-agent/test/tools/approval.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from "bun:test";
 import type { AgentTool, ToolApproval } from "@oh-my-pi/pi-agent-core";
 import { LSP_READONLY_ACTIONS } from "@oh-my-pi/pi-coding-agent/lsp";
 import {
+	DeferredMCPTool,
+	type MCPServerConnection,
+	MCPTool,
+	type MCPToolDefinition,
+} from "@oh-my-pi/pi-coding-agent/mcp";
+import {
 	type ApprovalMode,
 	formatApprovalPrompt,
 	requiresApproval,
@@ -47,6 +53,26 @@ function bashApproval(command: string) {
 	if (typeof approval !== "function") throw new Error("Bash approval must be dynamic");
 	return approval({ command });
 }
+
+const mcpToolDefinition: MCPToolDefinition = {
+	name: "safe_search",
+	inputSchema: { type: "object" },
+};
+
+const mcpConnection: MCPServerConnection = {
+	name: "searchMCP-LAN",
+	config: { type: "stdio", command: "search-mcp-lan" },
+	transport: {
+		connected: true,
+		async request() {
+			throw new Error("MCP transport request should not be called");
+		},
+		async notify() {},
+		async close() {},
+	},
+	serverInfo: { name: "search-mcp-lan", version: "1.0.0" },
+	capabilities: {},
+};
 
 describe("resolveApproval tier matrix", () => {
 	const cases: Array<[ApprovalMode, "read" | "write" | "exec", "allow" | "prompt"]> = [
@@ -109,7 +135,18 @@ describe("resolveApproval override and user policy", () => {
 });
 
 describe("MCP fallback and prompt formatting", () => {
-	it("treats MCP tools without approval declarations as exec tier", () => {
+	it("classifies MCP bridge tools as write tier", () => {
+		const connected = new MCPTool(mcpConnection, mcpToolDefinition);
+		const deferred = new DeferredMCPTool("searchMCP-LAN", mcpToolDefinition, async () => mcpConnection);
+
+		for (const subject of [connected, deferred]) {
+			expect(resolveApproval(subject, {}, "always-ask")).toMatchObject({ policy: "prompt", tier: "write" });
+			expect(resolveApproval(subject, {}, "write")).toMatchObject({ policy: "allow", tier: "write" });
+			expect(requiresApproval(subject, {}, "write").required).toBe(false);
+		}
+	});
+
+	it("treats unannotated MCP-shaped tools as exec tier", () => {
 		const subject = tool("mcp__server__dangerous");
 		expect(resolveApproval(subject, {}, "write")).toMatchObject({ policy: "prompt", tier: "exec" });
 		expect(resolveApproval(subject, {}, "yolo")).toMatchObject({ policy: "allow", tier: "exec" });


### PR DESCRIPTION
## Repro
`DeferredMCPTool` instances reproduced the reported behavior in `write` approval mode: `bun -e 'import { DeferredMCPTool } from "./packages/coding-agent/src/mcp/tool-bridge"; import { requiresApproval } from "./packages/coding-agent/src/tools/approval"; const tool = new DeferredMCPTool("searchMCP-LAN", { name: "safe_search", inputSchema: { type: "object" } }, async () => { throw new Error("not called"); }); const required = requiresApproval(tool, {}, "write").required; console.log(JSON.stringify({ approval: tool.approval, requiresWriteApproval: required })); if (!required) process.exit(1);'` printed `{"requiresWriteApproval":true}` before the fix.

## Cause
`packages/coding-agent/src/mcp/tool-bridge.ts` left `MCPTool` and `DeferredMCPTool` without an `approval` declaration, so `resolveApproval` defaulted them to `exec`; `customToolToDefinition()` in `packages/coding-agent/src/sdk.ts` also dropped `CustomTool.approval` because `ToolDefinition` in `packages/coding-agent/src/extensibility/extensions/types.ts` did not carry that field.

## Fix
- Added `approval = "write"` to both MCP bridge tool classes.
- Added `approval?: ToolApproval` to extension `ToolDefinition` and copied `tool.approval` in `customToolToDefinition()`.
- Added regression coverage for MCP bridge approval tiers and SDK custom-tool approval propagation.
- Added the coding-agent changelog entry for #2062.

## Verification
Ran `bun test packages/coding-agent/test/tools/approval.test.ts packages/coding-agent/test/tools/approval-mode.test.ts` (32 pass), `bun --cwd=packages/coding-agent run check:types`, `bun --cwd=packages/coding-agent run fix`, and a post-fix `bun -e` probe that printed `{"approval":"write","requiresWriteApproval":false}`. Fixes #2062