### PR TITLE
fix(tui): recognized Ghostty's super+alt+backspace as word delete

### DIFF
--- a/crates/pi-natives/src/keys.rs
+++ b/crates/pi-natives/src/keys.rs
@@ -70,6 +70,7 @@ const CP_KP_EQUALS: i32 = 57415;
 const MOD_SHIFT: u32 = 1;
 const MOD_ALT: u32 = 2;
 const MOD_CTRL: u32 = 4;
+const MOD_SUPER: u32 = 8;
 const MOD_NUM_LOCK: u32 = 128;
 
 /// Event types from Kitty keyboard protocol (flag 2).
@@ -455,6 +456,10 @@ fn parse_key_id(key_id: &str) -> Option<ParsedKeyId<'_>> {
 			},
 			b's' | b'S' if p.eq_ignore_ascii_case("shift") => {
 				modifier |= MOD_SHIFT;
+				continue;
+			},
+			b's' | b'S' if p.eq_ignore_ascii_case("super") => {
+				modifier |= MOD_SUPER;
 				continue;
 			},
 			b'a' | b'A' if p.eq_ignore_ascii_case("alt") => {
@@ -1378,7 +1383,7 @@ fn parse_functional(bytes: &[u8]) -> Option<ParsedKittySequence> {
 
 fn format_kitty_key(parsed: &ParsedKittySequence) -> Option<Cow<'static, str>> {
 	let effective_mod = parsed.modifier & !LOCK_MASK;
-	if effective_mod & !(MOD_SHIFT | MOD_CTRL | MOD_ALT) != 0 {
+	if effective_mod & !(MOD_SHIFT | MOD_CTRL | MOD_ALT | MOD_SUPER) != 0 {
 		return None;
 	}
 	let effective_codepoint =
@@ -1479,6 +1484,9 @@ fn format_with_mods(mods: u32, key_name: &str) -> String {
 	}
 	if mods & MOD_ALT != 0 {
 		result.push_str("alt+");
+	}
+	if mods & MOD_SUPER != 0 {
+		result.push_str("super+");
 	}
 	result.push_str(key_name);
 	result
@@ -1585,7 +1593,11 @@ mod tests {
 
 	#[test]
 	fn parse_key_ignores_kitty_sequences_with_unsupported_modifiers() {
-		assert_eq!(parse_key_inner(b"\x1b[99;9u", true).as_deref(), None);
+		// Hyper (16) and meta (32) are kitty modifier bits we do not surface
+		// because nothing in the editor binds them. Wire mod 17 = mask 16 = hyper.
+		assert_eq!(parse_key_inner(b"\x1b[99;17u", true).as_deref(), None);
+		// Wire mod 33 = mask 32 = meta.
+		assert_eq!(parse_key_inner(b"\x1b[99;33u", true).as_deref(), None);
 	}
 
 	#[test]
@@ -1674,5 +1686,33 @@ mod tests {
 		// CSI-u / modifyOtherKeys forms still resolve ctrl+alt+<colliding>.
 		assert!(matches_key_inner(b"\x1b[109;7u", "ctrl+alt+m", true));
 		assert!(matches_key_inner(b"\x1b[27;7;109~", "ctrl+alt+m", false));
+	}
+
+	#[test]
+	fn super_alt_backspace_matches_ghostty_default() {
+		// Issue #2064: Ghostty on macOS reports Option+Backspace as kitty
+		// modifier 11 (wire) = 10 (mask) = super(8)|alt(2). Before super
+		// support landed, the matcher rejected this entirely.
+		assert!(matches_key_inner(b"\x1b[127;11u", "super+alt+backspace", true));
+		assert!(matches_key_inner(b"\x1b[127;11u", "alt+super+backspace", true));
+		assert_eq!(parse_key_inner(b"\x1b[127;11u", true).as_deref(), Some("alt+super+backspace"));
+		// Plain alt+backspace must still NOT match — the modifier really is super|alt.
+		assert!(!matches_key_inner(b"\x1b[127;11u", "alt+backspace", true));
+		// And plain backspace (mod 0) must still not match a super+alt-modified press.
+		assert!(!matches_key_inner(b"\x1b[127;11u", "backspace", true));
+		// Release events stay ignored: super+alt+backspace release must not match a press.
+		assert!(!matches_key_inner(b"\x1b[127;11:3u", "super+alt+backspace", true));
+		assert_eq!(parse_key_inner(b"\x1b[127;11:3u", true).as_deref(), None);
+	}
+
+	#[test]
+	fn super_modifier_parses_for_arbitrary_keys() {
+		// Cmd+letter on macOS under kitty flag=1+: super(8)+'a'(97) → wire mod 9.
+		assert!(matches_key_inner(b"\x1b[97;9u", "super+a", true));
+		assert_eq!(parse_key_inner(b"\x1b[97;9u", true).as_deref(), Some("super+a"));
+		// Cmd+Shift+letter: super(8)|shift(1) = 9 mask, wire 10.
+		assert!(matches_key_inner(b"\x1b[97;10u", "super+shift+a", true));
+		assert!(matches_key_inner(b"\x1b[97;10u", "shift+super+a", true));
+		assert_eq!(parse_key_inner(b"\x1b[97;10u", true).as_deref(), Some("shift+super+a"));
 	}
 }

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the `super` modifier to `matchesKey` / `parseKey` / `parseKittySequence`. Key identifiers may now include `super+` (anywhere in the modifier prefix), and Kitty CSI-u sequences whose modifier mask contains the super bit (8) — e.g. Ghostty's macOS Option+Backspace `ESC [127;11u` — are now recognised instead of dropped ([#2064](https://github.com/can1357/oh-my-pi/issues/2064)).
+
 ## [15.10.1] - 2026-06-07
 
 ### Fixed

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `super` modifier support to native key parsing/matching and bound `super+alt+backspace` / `super+alt+delete` (and `super+alt+d`) into the word-delete defaults so Ghostty's default macOS Option+Backspace wire (`ESC [127;11u` — kitty modifier 11 = super|alt) deletes a word instead of falling through to single-char delete ([#2064](https://github.com/can1357/oh-my-pi/issues/2064)).
+
 ## [15.10.1] - 2026-06-07
 ### Breaking Changes
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -1109,12 +1109,18 @@ export class Editor implements Component, Focusable {
 		else if (matchesKey(data, "ctrl+w")) {
 			this.#deleteWordBackwards();
 		}
-		// Option/Alt+Backspace - Delete word backwards
-		else if (matchesKey(data, "alt+backspace")) {
+		// Option/Alt+Backspace - Delete word backwards.
+		// Ghostty on macOS reports Option+Backspace as super+alt (kitty mod 11) — see #2064.
+		else if (matchesKey(data, "alt+backspace") || matchesKey(data, "super+alt+backspace")) {
 			this.#deleteWordBackwards();
 		}
-		// Option/Alt+D - Delete word forwards
-		else if (matchesKey(data, "alt+d") || matchesKey(data, "alt+delete")) {
+		// Option/Alt+D and Option+Delete - Delete word forwards. Same Ghostty quirk applies.
+		else if (
+			matchesKey(data, "alt+d") ||
+			matchesKey(data, "alt+delete") ||
+			matchesKey(data, "super+alt+d") ||
+			matchesKey(data, "super+alt+delete")
+		) {
 			this.#deleteWordForwards();
 		}
 		// Ctrl+Y - Yank from kill ring

--- a/packages/tui/src/keybindings.ts
+++ b/packages/tui/src/keybindings.ts
@@ -100,11 +100,11 @@ export const TUI_KEYBINDINGS = {
 		description: "Delete character forward",
 	},
 	"tui.editor.deleteWordBackward": {
-		defaultKeys: ["ctrl+w", "alt+backspace", "ctrl+backspace"],
+		defaultKeys: ["ctrl+w", "alt+backspace", "ctrl+backspace", "super+alt+backspace"],
 		description: "Delete word backward",
 	},
 	"tui.editor.deleteWordForward": {
-		defaultKeys: ["alt+delete", "alt+d"],
+		defaultKeys: ["alt+delete", "alt+d", "super+alt+delete", "super+alt+d"],
 		description: "Delete word forward",
 	},
 	"tui.editor.deleteToLineStart": {

--- a/packages/tui/test/editor.test.ts
+++ b/packages/tui/test/editor.test.ts
@@ -3,6 +3,7 @@ import { stripVTControlCharacters } from "node:util";
 import { CURSOR_MARKER } from "@oh-my-pi/pi-tui";
 import { CombinedAutocompleteProvider } from "@oh-my-pi/pi-tui/autocomplete";
 import { Editor } from "@oh-my-pi/pi-tui/components/editor";
+import { setKittyProtocolActive } from "@oh-my-pi/pi-tui/keys";
 import { visibleWidth } from "@oh-my-pi/pi-tui/utils";
 import { setDefaultTabWidth } from "@oh-my-pi/pi-utils";
 import { KeybindingsManager, setKeybindings, TUI_KEYBINDINGS } from "../src/keybindings";
@@ -616,6 +617,16 @@ describe("Editor component", () => {
 			editor.setText("foo bar");
 			editor.handleInput("\x1b\x7f"); // Alt+Backspace (legacy)
 			expect(editor.getText()).toBe("foo ");
+
+			// Issue #2064: Ghostty on macOS reports Option+Backspace as `ESC [127;11u`
+			// (kitty modifier 11 wire = super(8)|alt(2)). Without super support the
+			// editor used to ignore this entirely and the previous word survived.
+			setKittyProtocolActive(true);
+			editor.setText("foo bar");
+			editor.handleInput("\x1b[F"); // End — park cursor at EOL
+			editor.handleInput("\x1b[127;11u"); // Ghostty Option+Backspace
+			expect(editor.getText()).toBe("foo ");
+			setKittyProtocolActive(false);
 		});
 
 		it("navigates words correctly with Ctrl+Left/Right", () => {

--- a/packages/tui/test/keys.test.ts
+++ b/packages/tui/test/keys.test.ts
@@ -77,6 +77,19 @@ describe("matchesKey", () => {
 		expect(matchesKey("\x1b[57400;133u", "1")).toBe(false);
 		setKittyProtocolActive(false);
 	});
+
+	it("recognises super+alt+backspace from Ghostty's default Option+Backspace wire (#2064)", () => {
+		setKittyProtocolActive(true);
+		// Modifier 11 (wire) = 10 (mask) = super(8)|alt(2). Ghostty's keyboard
+		// inspector on macOS reports `ESC [127;11u` for Option+Backspace without
+		// any user-defined keybind.
+		expect(matchesKey("\x1b[127;11u", "super+alt+backspace")).toBe(true);
+		expect(matchesKey("\x1b[127;11u", "alt+super+backspace")).toBe(true);
+		// Plain alt+backspace must NOT consume this — the modifier truly is super|alt.
+		expect(matchesKey("\x1b[127;11u", "alt+backspace")).toBe(false);
+		expect(matchesKey("\x1b[127;11u", "backspace")).toBe(false);
+		setKittyProtocolActive(false);
+	});
 });
 
 describe("parseKey", () => {
@@ -132,7 +145,9 @@ describe("parseKey", () => {
 
 	it("ignores Kitty sequences with unsupported modifiers", () => {
 		setKittyProtocolActive(true);
-		expect(parseKey("\x1b[99;9u")).toBeUndefined();
+		// Hyper (16) and meta (32) bits aren't surfaced because nothing binds them.
+		expect(parseKey("\x1b[99;17u")).toBeUndefined(); // hyper-only
+		expect(parseKey("\x1b[99;33u")).toBeUndefined(); // meta-only
 		setKittyProtocolActive(false);
 	});
 });


### PR DESCRIPTION
## Repro

On macOS Ghostty with the Kitty keyboard protocol active, pressing Option+Backspace deletes only a single character instead of the previous word. Ghostty's keyboard inspector reports the wire as `ESC [127;11u` — kitty modifier 11 (wire) = 10 (mask) = `super(8) | alt(2)`. The CLI then bypasses `deleteWordBackwards` and either no-op's or falls back to single-char delete.

Reproducible end-to-end against the editor:

```ts
import { Editor } from "@oh-my-pi/pi-tui/components/editor";
import { setKittyProtocolActive } from "@oh-my-pi/pi-tui/keys";

setKittyProtocolActive(true);
const e = new Editor(defaultEditorTheme);
e.setText("foo bar");
e.handleInput("\x1b[F");
e.handleInput("\x1b[127;11u"); // Ghostty Option+Backspace
e.getText(); // before fix: "foo bar"   after fix: "foo "
```

## Cause

The native key matcher in `crates/pi-natives/src/keys.rs` only knew about `shift`, `ctrl`, and `alt`:

- `format_kitty_key` at `keys.rs:1386` explicitly rejected any Kitty sequence whose effective modifier had bits beyond `shift|ctrl|alt`, so `parseKey("\x1b[127;11u")` returned `undefined`.
- `parse_key_id` at `keys.rs:451-465` recognised only those three modifiers; even an explicit `"super+alt+backspace"` silently degraded to `"alt+backspace"` and then failed the strict-equality modifier compare against mask 10.
- Consequently the editor's `matchesKey(data, "alt+backspace")` branch at `packages/tui/src/components/editor.ts:1113` never fired for Ghostty's default Option+Backspace wire.

## Fix

- Added `MOD_SUPER = 8` and threaded it through `parse_key_id`, `format_with_mods`, and the `format_kitty_key` allow-mask.
- Bound `super+alt+backspace` into `tui.editor.deleteWordBackward` defaults and `super+alt+delete` / `super+alt+d` into `tui.editor.deleteWordForward` so kb-based call sites (e.g. `Input.handleInput`) handle the Ghostty wire too.
- Broadened the editor's direct `matchesKey` calls in `editor.ts` so `alt+backspace` / `alt+d` / `alt+delete` keep working while also accepting their `super+alt+…` variants.
- The legacy `ESC + DEL` (`\x1b\x7f`) path and the documented Ghostty `keybind = alt+backspace=text:\x1b\x7f` workaround keep working unchanged.

## Verification

- `cd crates/pi-natives && cargo test --lib keys::` — 15 passing, including new `super_alt_backspace_matches_ghostty_default` and `super_modifier_parses_for_arbitrary_keys` cases. The unrelated `shell::tests::embedded_external_command_runs_in_its_own_session` failure pre-exists on `main` (exits 137 in this CI container, untouched by this diff).
- `cd packages/tui && bun test` — 712 pass / 3 skip / 0 fail, including a new keys.test regression for `\x1b[127;11u → super+alt+backspace` and an editor.test regression that exercises the full handleInput path end-to-end.
- `cd packages/natives && bun test` — 51 pass / 0 fail.

Fixes #2064