### PR TITLE
fix(coding-agent): parse --cwd launch flag

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `--cwd` launch flag so it is parsed and can override the startup directory instead of always falling back to the current process directory or home auto-switch target.
+
 ## [15.10.1] - 2026-06-07
 
 ### Added

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -109,6 +109,8 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 			result.version = true;
 		} else if (arg === "--allow-home") {
 			result.allowHome = true;
+		} else if (arg === "--cwd" && i + 1 < args.length) {
+			result.cwd = args[++i];
 		} else if (arg === "--mode" && i + 1 < args.length) {
 			const mode = args[++i];
 			if (mode === "text" || mode === "json" || mode === "rpc" || mode === "acp" || mode === "rpc-ui") {

--- a/packages/coding-agent/src/cli/startup-cwd.ts
+++ b/packages/coding-agent/src/cli/startup-cwd.ts
@@ -1,0 +1,63 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getProjectDir, normalizePathForComparison, setProjectDir } from "@oh-my-pi/pi-utils";
+import type { Args } from "./args";
+
+async function maybeAutoChdir(parsed: Args): Promise<void> {
+	if (parsed.allowHome || parsed.cwd) {
+		return;
+	}
+
+	const home = os.homedir();
+	if (!home) {
+		return;
+	}
+
+	const normalizePath = normalizePathForComparison;
+
+	const cwd = normalizePath(getProjectDir());
+	const normalizedHome = normalizePath(home);
+	if (cwd !== normalizedHome) {
+		return;
+	}
+
+	const isDirectory = async (p: string) => {
+		try {
+			const s = await fs.stat(p);
+			return s.isDirectory();
+		} catch {
+			return false;
+		}
+	};
+
+	const candidates = [path.join(home, "tmp"), "/tmp", "/var/tmp"];
+	for (const candidate of candidates) {
+		try {
+			if (!(await isDirectory(candidate))) {
+				continue;
+			}
+			setProjectDir(candidate);
+			return;
+		} catch {
+			// Try next candidate.
+		}
+	}
+
+	try {
+		const fallback = os.tmpdir();
+		if (fallback && normalizePath(fallback) !== cwd && (await isDirectory(fallback))) {
+			setProjectDir(fallback);
+		}
+	} catch {
+		// Ignore fallback errors.
+	}
+}
+
+export async function applyStartupCwd(parsed: Args): Promise<void> {
+	if (parsed.cwd) {
+		setProjectDir(parsed.cwd);
+		return;
+	}
+	await maybeAutoChdir(parsed);
+}

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -49,6 +49,9 @@ export default class Index extends Command {
 		"allow-home": Flags.boolean({
 			description: "Allow starting in ~ without auto-switching to a temp dir",
 		}),
+		cwd: Flags.string({
+			description: "Directory to start in (overrides the launch cwd)",
+		}),
 		mode: Flags.string({
 			description: "Output mode: text (default), json, rpc, or rpc-ui",
 			options: ["text", "json", "rpc", "acp", "rpc-ui"],

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -5,9 +5,7 @@
  * createAgentSession() options. The SDK does the heavy lifting.
  */
 
-import * as fs from "node:fs/promises";
 import * as os from "node:os";
-import * as path from "node:path";
 import { createInterface } from "node:readline/promises";
 import { EventLoopKeepalive } from "@oh-my-pi/pi-agent-core";
 import type { ImageContent } from "@oh-my-pi/pi-ai";
@@ -28,6 +26,7 @@ import { processFileArguments } from "./cli/file-processor";
 import { buildInitialMessage } from "./cli/initial-message";
 import { runListModelsCommand } from "./cli/list-models";
 import { selectSession } from "./cli/session-picker";
+import { applyStartupCwd } from "./cli/startup-cwd";
 import { findConfigFile } from "./config";
 import { ModelRegistry, ModelsConfigFile } from "./config/model-registry";
 import { resolveCliModel, resolveModelRoleValue, resolveModelScope, type ScopedModel } from "./config/model-resolver";
@@ -478,64 +477,6 @@ export async function createSessionManager(
 	}
 	// Default case (new session) returns undefined, SDK will create one
 	return undefined;
-}
-
-async function maybeAutoChdir(parsed: Args): Promise<void> {
-	if (parsed.allowHome || parsed.cwd) {
-		return;
-	}
-
-	const home = os.homedir();
-	if (!home) {
-		return;
-	}
-
-	const normalizePath = normalizePathForComparison;
-
-	const cwd = normalizePath(getProjectDir());
-	const normalizedHome = normalizePath(home);
-	if (cwd !== normalizedHome) {
-		return;
-	}
-
-	const isDirectory = async (p: string) => {
-		try {
-			const s = await fs.stat(p);
-			return s.isDirectory();
-		} catch {
-			return false;
-		}
-	};
-
-	const candidates = [path.join(home, "tmp"), "/tmp", "/var/tmp"];
-	for (const candidate of candidates) {
-		try {
-			if (!(await isDirectory(candidate))) {
-				continue;
-			}
-			setProjectDir(candidate);
-			return;
-		} catch {
-			// Try next candidate.
-		}
-	}
-
-	try {
-		const fallback = os.tmpdir();
-		if (fallback && normalizePath(fallback) !== cwd && (await isDirectory(fallback))) {
-			setProjectDir(fallback);
-		}
-	} catch {
-		// Ignore fallback errors.
-	}
-}
-
-export async function applyStartupCwd(parsed: Args): Promise<void> {
-	if (parsed.cwd) {
-		setProjectDir(parsed.cwd);
-		return;
-	}
-	await maybeAutoChdir(parsed);
 }
 
 /** Discover SYSTEM.md file if no CLI system prompt was provided */

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -530,6 +530,14 @@ async function maybeAutoChdir(parsed: Args): Promise<void> {
 	}
 }
 
+export async function applyStartupCwd(parsed: Args): Promise<void> {
+	if (parsed.cwd) {
+		setProjectDir(parsed.cwd);
+		return;
+	}
+	await maybeAutoChdir(parsed);
+}
+
 /** Discover SYSTEM.md file if no CLI system prompt was provided */
 function discoverSystemPromptFile(): string | undefined {
 	// Check project-local first (.omp/SYSTEM.md, .pi/SYSTEM.md legacy)
@@ -745,7 +753,7 @@ export async function runRootCommand(
 	await logger.time("initTheme:initial", initTheme);
 
 	const parsedArgs = parsed;
-	await logger.time("maybeAutoChdir", maybeAutoChdir, parsedArgs);
+	await logger.time("applyStartupCwd", applyStartupCwd, parsedArgs);
 
 	const notifs: (InteractiveModeNotify | null)[] = [];
 

--- a/packages/coding-agent/test/cli-cwd-flag.test.ts
+++ b/packages/coding-agent/test/cli-cwd-flag.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { parseArgs } from "../src/cli/args";
+
+describe("parseArgs — --cwd flag", () => {
+	it("parses --cwd with a space-separated directory", () => {
+		const result = parseArgs(["--cwd", "/work/project", "hello"]);
+
+		expect(result.cwd).toBe("/work/project");
+		expect(result.messages).toEqual(["hello"]);
+	});
+
+	it("parses --cwd=value without leaking the value into messages", () => {
+		const result = parseArgs(["--cwd=/work/project", "hello"]);
+
+		expect(result.cwd).toBe("/work/project");
+		expect(result.messages).toEqual(["hello"]);
+	});
+});

--- a/packages/coding-agent/test/cli-cwd-flag.test.ts
+++ b/packages/coding-agent/test/cli-cwd-flag.test.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
 import { parseArgs } from "../src/cli/args";
-import { applyStartupCwd } from "../src/main";
+import { applyStartupCwd } from "../src/cli/startup-cwd";
 
 const originalProjectDir = getProjectDir();
 

--- a/packages/coding-agent/test/cli-cwd-flag.test.ts
+++ b/packages/coding-agent/test/cli-cwd-flag.test.ts
@@ -1,6 +1,16 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
 import { parseArgs } from "../src/cli/args";
+import { applyStartupCwd } from "../src/main";
 
+const originalProjectDir = getProjectDir();
+
+afterEach(() => {
+	setProjectDir(originalProjectDir);
+});
 describe("parseArgs — --cwd flag", () => {
 	it("parses --cwd with a space-separated directory", () => {
 		const result = parseArgs(["--cwd", "/work/project", "hello"]);
@@ -14,5 +24,18 @@ describe("parseArgs — --cwd flag", () => {
 
 		expect(result.cwd).toBe("/work/project");
 		expect(result.messages).toEqual(["hello"]);
+	});
+
+	it("applies --cwd before session lookup callers read the project directory", async () => {
+		const launchDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-cwd-launch-"));
+		const targetDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-cwd-target-"));
+		setProjectDir(launchDir);
+
+		const parsed = parseArgs(["--cwd", targetDir, "--continue"]);
+		await applyStartupCwd(parsed);
+
+		expect(parsed.continue).toBe(true);
+		expect(getProjectDir()).toBe(targetDir);
+		expect(process.cwd()).toBe(targetDir);
 	});
 });


### PR DESCRIPTION
## Summary
- parse the existing `--cwd` CLI flag into `Args.cwd`
- expose `--cwd` in the launch command help
- add parser coverage for both `--cwd <dir>` and `--cwd=<dir>`

## Testing
- `bun test packages/coding-agent/test/cli-cwd-flag.test.ts packages/coding-agent/test/cli-hide-thinking-flag.test.ts`
- `bun run --cwd packages/coding-agent check:types`
- `bunx @biomejs/biome check packages/coding-agent/src/cli/args.ts packages/coding-agent/src/commands/launch.ts packages/coding-agent/test/cli-cwd-flag.test.ts packages/coding-agent/CHANGELOG.md --no-errors-on-unmatched`