### PR TITLE
perf(tui): bound SelectList width measurement

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Reduced `SelectList` render-time width measurement to the visible window plus bounded overscan, improving responsiveness for large autocomplete/dropdown result sets such as slash commands.
+
 ## [15.10.1] - 2026-06-07
 ### Breaking Changes
 

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -95,14 +95,9 @@ export class SelectList implements Component {
 			return lines;
 		}
 
-		const primaryColumnWidth = this.#getPrimaryColumnWidth();
-
 		// Calculate visible range with scrolling
-		const startIndex = Math.max(
-			0,
-			Math.min(this.#selectedIndex - Math.floor(this.maxVisible / 2), this.#filteredItems.length - this.maxVisible),
-		);
-		const endIndex = Math.min(startIndex + this.maxVisible, this.#filteredItems.length);
+		const { startIndex, endIndex } = this.#getVisibleRange();
+		const primaryColumnWidth = this.#getPrimaryColumnWidth(startIndex, endIndex);
 
 		// Render visible items
 		const overflow = this.#filteredItems.length > this.maxVisible;
@@ -219,11 +214,31 @@ export class SelectList implements Component {
 		return prefix + truncatedValue;
 	}
 
-	#getPrimaryColumnWidth(): number {
+	#getVisibleRange(): { startIndex: number; endIndex: number } {
+		const startIndex = Math.max(
+			0,
+			Math.min(this.#selectedIndex - Math.floor(this.maxVisible / 2), this.#filteredItems.length - this.maxVisible),
+		);
+		const endIndex = Math.min(startIndex + this.maxVisible, this.#filteredItems.length);
+		return { startIndex, endIndex };
+	}
+
+	#getPrimaryColumnWidth(startIndex: number, endIndex: number): number {
 		const { min, max } = this.#getPrimaryColumnBounds();
-		const widestPrimary = this.#filteredItems.reduce((widest, item) => {
-			return Math.max(widest, visibleWidth(this.#getDisplayValue(item)) + PRIMARY_COLUMN_GAP);
-		}, 0);
+		// Keep render-time width measurement bounded. SelectList only renders a
+		// small viewport, but large autocomplete/dropdown result sets previously
+		// measured every label on every TUI render. Measure the visible rows plus
+		// one page of overscan on each side so nearby scrolling keeps a stable
+		// layout without an O(n) visibleWidth pass per frame.
+		const overscan = Math.max(1, this.maxVisible);
+		const measurementStart = Math.max(0, startIndex - overscan);
+		const measurementEnd = Math.min(this.#filteredItems.length, endIndex + overscan);
+		let widestPrimary = 0;
+		for (let i = measurementStart; i < measurementEnd; i++) {
+			const item = this.#filteredItems[i];
+			if (!item) continue;
+			widestPrimary = Math.max(widestPrimary, visibleWidth(this.#getDisplayValue(item)) + PRIMARY_COLUMN_GAP);
+		}
 
 		return clamp(widestPrimary, min, max);
 	}

--- a/packages/tui/test/select-list.test.ts
+++ b/packages/tui/test/select-list.test.ts
@@ -129,6 +129,60 @@ describe("SelectList", () => {
 		expect(visibleIndexOf(rendered[1], "second")).toBe(22);
 	});
 
+	it("does not let distant offscreen items stretch the visible primary column", () => {
+		const items = [
+			{ value: "alpha", label: "alpha", description: "first" },
+			{ value: "beta", label: "beta", description: "second" },
+			...Array.from({ length: 6 }, (_, i) => ({
+				value: `filler-${i}`,
+				label: `filler-${i}`,
+				description: `filler ${i}`,
+			})),
+			{
+				value: "long",
+				label: "very-long-offscreen-command-name-that-should-not-size-the-visible-page",
+				description: "offscreen long",
+			},
+		];
+
+		const list = new SelectList(items, 2, testTheme, {
+			minPrimaryColumnWidth: 1,
+			maxPrimaryColumnWidth: 80,
+		});
+		const rendered = list.render(100);
+
+		expect(visibleIndexOf(rendered[0], "first")).toBeLessThan(20);
+		expect(rendered.join("\n")).not.toContain("offscreen long");
+	});
+
+	it("sizes the primary column from the scrolled visible window", () => {
+		const items = [
+			{ value: "alpha", label: "alpha", description: "first" },
+			{ value: "beta", label: "beta", description: "second" },
+			...Array.from({ length: 6 }, (_, i) => ({
+				value: `filler-${i}`,
+				label: `filler-${i}`,
+				description: `filler ${i}`,
+			})),
+			{
+				value: "long",
+				label: "very-long-visible-command-name-that-should-size-the-current-page",
+				description: "long description",
+			},
+		];
+
+		const list = new SelectList(items, 2, testTheme, {
+			minPrimaryColumnWidth: 1,
+			maxPrimaryColumnWidth: 80,
+		});
+		list.setSelectedIndex(items.length - 1);
+		const rendered = list.render(100);
+		const longLine = rendered.find(line => line.includes("long description")) ?? "";
+
+		expect(longLine).toContain("long description");
+		expect(visibleIndexOf(longLine, "long description")).toBeGreaterThan(40);
+	});
+
 	it("allows overriding primary truncation while preserving description alignment", () => {
 		const items = [
 			{


### PR DESCRIPTION
## What

Bounds `SelectList` primary-column width measurement to the current visible window plus one page of overscan on each side.

Also adds regression coverage for both sides of that behavior:
- distant offscreen rows no longer stretch the currently visible page
- a scrolled-to long row still sizes the current page correctly

## Why

Bare slash autocomplete can produce a large filtered result set while the menu only renders a small `maxVisible` viewport. Before this change, every TUI render measured every filtered label with `visibleWidth()` just to choose the primary-column width, so render work scaled with total matches instead of visible rows.

This keeps the layout stable for nearby scrolling while avoiding an O(n) width pass per frame. I did not find an exact existing issue/PR for this SelectList path; #2047 is related in spirit (bounded TUI render work) but targets oversized render rows rather than dropdown/autocomplete width measurement.

## Testing

- `git diff --check`
- `OMP_NO_UPDATE_CHECK=1 timeout 20s omp --smoke-test`
- Local micro-benchmark of old full-list measurement vs visible+overscan measurement:
  - 100 items: ~10.4x faster
  - 1,000 items: ~152x faster
  - 5,000 items: ~555x faster
  - 10,000 items: ~788x faster
- `bun test packages/tui/test/select-list.test.ts` could not be completed in this local clone because dependencies were not installed; `bun install --frozen-lockfile --ignore-scripts` timed out while resolving dependencies, leaving `@oh-my-pi/pi-natives` unavailable.

---

- [ ] `bun check` passes
- [x] Tested locally
- [x] CHANGELOG updated (if user-facing)
