### PR TITLE
fix(coding-agent): suppressed reviewer findings injection when schema rejects it

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed reviewer-style subagent yields crashing the calling eval cell when a caller-supplied output schema declares `additionalProperties: false` without a `findings` property. `normalizeCompleteData` now consults the active validator before splicing collected `report_finding` entries onto the yielded payload, so injection is suppressed when the schema would reject it — keeping the executor's post-mortem validation in lockstep with the in-tool `yield` validation that already accepted the same raw payload ([#2070](https://github.com/can1357/oh-my-pi/issues/2070))
+
 ## [15.10.1] - 2026-06-07
 
 ### Added

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -34,7 +34,11 @@ import { SessionManager } from "../session/session-manager";
 import { truncateTail } from "../session/streaming-output";
 import type { ContextFileEntry } from "../tools";
 import { normalizeSchema } from "../tools/jtd-to-json-schema";
-import { buildOutputValidator, type OutputValidator, summarizeValidationFailure } from "../tools/output-schema-validator";
+import {
+	buildOutputValidator,
+	type OutputValidator,
+	summarizeValidationFailure,
+} from "../tools/output-schema-validator";
 
 import { type ReportFindingDetails, toReviewFinding } from "../tools/review";
 import { ToolAbortError } from "../tools/tool-errors";

--- a/packages/coding-agent/src/task/executor.ts
+++ b/packages/coding-agent/src/task/executor.ts
@@ -34,7 +34,7 @@ import { SessionManager } from "../session/session-manager";
 import { truncateTail } from "../session/streaming-output";
 import type { ContextFileEntry } from "../tools";
 import { normalizeSchema } from "../tools/jtd-to-json-schema";
-import { buildOutputValidator, summarizeValidationFailure } from "../tools/output-schema-validator";
+import { buildOutputValidator, type OutputValidator, summarizeValidationFailure } from "../tools/output-schema-validator";
 
 import { type ReportFindingDetails, toReviewFinding } from "../tools/review";
 import { ToolAbortError } from "../tools/tool-errors";
@@ -256,21 +256,40 @@ function extractCompletionData(parsed: unknown): unknown {
 	return parsed;
 }
 
-function normalizeCompleteData(data: unknown, reportFindings?: ReviewFinding[]): unknown {
-	let normalized = parseStringifiedJson(data ?? null);
+/**
+ * Resolve the final yielded payload, optionally splicing collected
+ * `report_finding` entries into a top-level `findings` array.
+ *
+ * Injection is suppressed when an active validator would reject the augmented
+ * payload (e.g. a caller-supplied schema with `additionalProperties: false`
+ * that does not declare `findings`). That keeps the in-tool yield validator
+ * (which only sees the raw, pre-injection data) in lockstep with this
+ * post-mortem validator — honoring the "accepted in-tool ⇒ accepted
+ * post-mortem" guarantee documented in `output-schema-validator.ts`. The
+ * dropped findings are still preserved verbatim in the agent's progress
+ * stream and JSONL artifact, so no information is lost when injection is
+ * suppressed.
+ */
+function normalizeCompleteData(
+	data: unknown,
+	reportFindings: ReviewFinding[] | undefined,
+	validator: OutputValidator | undefined,
+): unknown {
+	const normalized = parseStringifiedJson(data ?? null);
 	if (
-		Array.isArray(reportFindings) &&
-		reportFindings.length > 0 &&
-		normalized &&
-		typeof normalized === "object" &&
-		!Array.isArray(normalized)
+		!Array.isArray(reportFindings) ||
+		reportFindings.length === 0 ||
+		!normalized ||
+		typeof normalized !== "object" ||
+		Array.isArray(normalized)
 	) {
-		const record = normalized as Record<string, unknown>;
-		if (!("findings" in record)) {
-			normalized = { ...record, findings: reportFindings };
-		}
+		return normalized;
 	}
-	return normalized;
+	const record = normalized as Record<string, unknown>;
+	if ("findings" in record) return normalized;
+	const injected = { ...record, findings: reportFindings };
+	if (validator && !validator.validate(injected).success) return normalized;
+	return injected;
 }
 
 function resolveFallbackCompletion(rawOutput: string, outputSchema: unknown): { data: unknown } | null {
@@ -360,13 +379,13 @@ export function finalizeSubprocessOutput(args: FinalizeSubprocessOutputArgs): Fi
 			if (submitData === null || submitData === undefined) {
 				rawOutput = rawOutput ? `${SUBAGENT_WARNING_NULL_YIELD}\n\n${rawOutput}` : SUBAGENT_WARNING_NULL_YIELD;
 			} else {
-				const completeData = normalizeCompleteData(submitData, reportFindings);
 				const { validator, error: schemaError } = buildOutputValidator(outputSchema);
 				if (schemaError) {
 					rawOutput = `{"error":"schema_violation","message":"invalid output schema: ${schemaError.replace(/"/g, '\\"')}"}`;
 					stderr = `schema_violation: invalid output schema: ${schemaError}`;
 					exitCode = 1;
 				} else {
+					const completeData = normalizeCompleteData(submitData, reportFindings, validator);
 					const result = validator?.validate(completeData) ?? { success: true as const };
 					if (!result.success) {
 						const summary = summarizeValidationFailure(result, completeData, validator?.requiredFields ?? []);
@@ -393,8 +412,8 @@ export function finalizeSubprocessOutput(args: FinalizeSubprocessOutputArgs): Fi
 		const hasOutputSchema = normalizedSchema !== undefined && !schemaError;
 		const fallback = allowFallback ? resolveFallbackCompletion(rawOutput, outputSchema) : null;
 		if (fallback) {
-			const completeData = normalizeCompleteData(fallback.data, reportFindings);
 			const { validator } = buildOutputValidator(outputSchema);
+			const completeData = normalizeCompleteData(fallback.data, reportFindings, validator);
 			const result = validator?.validate(completeData) ?? { success: true as const };
 			if (!result.success) {
 				const summary = summarizeValidationFailure(result, completeData, validator?.requiredFields ?? []);

--- a/packages/coding-agent/test/tools/review.test.ts
+++ b/packages/coding-agent/test/tools/review.test.ts
@@ -132,3 +132,170 @@ describe("toReviewFinding", () => {
 		expect(parsed.findings[0].priority).toBe(2);
 	});
 });
+
+describe("findings injection respects active output schema", () => {
+	const finding = toReviewFinding({
+		title: "[P0] Example finding",
+		body: "Details",
+		priority: "P0",
+		confidence: 0.95,
+		file_path: "/tmp/example.ts",
+		line_start: 10,
+		line_end: 12,
+	});
+
+	// Reproduces #2070: a caller-supplied JSON Schema with
+	// `additionalProperties: false` and no `findings` property is silently
+	// rejected post-mortem after the in-tool yield accepted it, because the
+	// executor auto-injects `findings` from `report_finding`. The injection
+	// must respect the active schema so that "accepted in-tool ⇒ accepted
+	// post-mortem" is honored.
+	it("suppresses findings injection when the schema forbids additional properties", () => {
+		const callerSchema = {
+			type: "object",
+			additionalProperties: false,
+			required: ["verdict", "acceptance_summary"],
+			properties: {
+				verdict: { enum: ["accept", "needs-work", "honest-stop"] },
+				acceptance_summary: { type: "string" },
+			},
+		};
+		const data = { verdict: "accept", acceptance_summary: "All good." };
+
+		const result = finalizeSubprocessOutput({
+			rawOutput: "",
+			exitCode: 0,
+			stderr: "",
+			doneAborted: false,
+			signalAborted: false,
+			yieldItems: [{ status: "success", data }],
+			reportFindings: [finding],
+			outputSchema: callerSchema,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toBe("");
+		const parsed = JSON.parse(result.rawOutput) as Record<string, unknown>;
+		expect(parsed).toEqual(data);
+		expect("findings" in parsed).toBe(false);
+	});
+
+	it("still injects findings when the schema declares them (bundled reviewer JTD)", () => {
+		// Mirrors the bundled reviewer agent's output: findings live under
+		// `optionalProperties`, so injection must continue to flow through.
+		const reviewerSchema = {
+			properties: {
+				overall_correctness: { enum: ["correct", "incorrect"] },
+				explanation: { type: "string" },
+				confidence: { type: "number" },
+			},
+			optionalProperties: {
+				findings: {
+					elements: {
+						properties: {
+							title: { type: "string" },
+							body: { type: "string" },
+							priority: { type: "number" },
+							confidence: { type: "number" },
+							file_path: { type: "string" },
+							line_start: { type: "number" },
+							line_end: { type: "number" },
+						},
+					},
+				},
+			},
+		};
+		const data = {
+			overall_correctness: "incorrect",
+			explanation: "Found one bug",
+			confidence: 0.9,
+		};
+
+		const result = finalizeSubprocessOutput({
+			rawOutput: "",
+			exitCode: 0,
+			stderr: "",
+			doneAborted: false,
+			signalAborted: false,
+			yieldItems: [{ status: "success", data }],
+			reportFindings: [finding],
+			outputSchema: reviewerSchema,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toBe("");
+		const parsed = JSON.parse(result.rawOutput) as { findings: Array<{ priority: number }> };
+		expect(parsed.findings).toHaveLength(1);
+		expect(parsed.findings[0].priority).toBe(0);
+	});
+
+	it("still injects findings when no schema is declared (legacy free-form)", () => {
+		const data = { note: "freeform" };
+
+		const result = finalizeSubprocessOutput({
+			rawOutput: "",
+			exitCode: 0,
+			stderr: "",
+			doneAborted: false,
+			signalAborted: false,
+			yieldItems: [{ status: "success", data }],
+			reportFindings: [finding],
+			outputSchema: undefined,
+		});
+
+		expect(result.exitCode).toBe(0);
+		const parsed = JSON.parse(result.rawOutput) as { findings?: unknown[] };
+		expect(parsed.findings).toHaveLength(1);
+	});
+
+	it("still injects findings when additionalProperties is open", () => {
+		const openSchema = {
+			type: "object",
+			required: ["verdict"],
+			properties: { verdict: { type: "string" } },
+		};
+		const data = { verdict: "accept" };
+
+		const result = finalizeSubprocessOutput({
+			rawOutput: "",
+			exitCode: 0,
+			stderr: "",
+			doneAborted: false,
+			signalAborted: false,
+			yieldItems: [{ status: "success", data }],
+			reportFindings: [finding],
+			outputSchema: openSchema,
+		});
+
+		expect(result.exitCode).toBe(0);
+		const parsed = JSON.parse(result.rawOutput) as { findings?: unknown[]; verdict: string };
+		expect(parsed.verdict).toBe("accept");
+		expect(parsed.findings).toHaveLength(1);
+	});
+
+	it("suppresses injection on the fallback (no-yield) path when the schema forbids it", () => {
+		const callerSchema = {
+			type: "object",
+			additionalProperties: false,
+			required: ["verdict"],
+			properties: { verdict: { type: "string" } },
+		};
+		const rawJson = JSON.stringify({ data: { verdict: "accept" } });
+
+		const result = finalizeSubprocessOutput({
+			rawOutput: rawJson,
+			exitCode: 0,
+			stderr: "",
+			doneAborted: false,
+			signalAborted: false,
+			yieldItems: undefined,
+			reportFindings: [finding],
+			outputSchema: callerSchema,
+		});
+
+		expect(result.exitCode).toBe(0);
+		expect(result.stderr).toBe("");
+		const parsed = JSON.parse(result.rawOutput) as Record<string, unknown>;
+		expect(parsed).toEqual({ verdict: "accept" });
+	});
+});


### PR DESCRIPTION
## Repro

A workflow `agent()` call targeting `agent_type="reviewer"` with a caller-supplied `schema=` that uses `additionalProperties: false` and omits `findings` crashes the entire eval cell as soon as the reviewer makes any `report_finding` calls. The in-tool `yield` validator accepts the raw payload (no `findings`), but the executor's post-mortem path injects `findings` from the collected `report_finding` entries and re-validates the augmented object, which the strict schema rejects. The resulting `schema_violation: findings: must not be present` becomes `exitCode=1`, the bridge re-throws it as `RuntimeError`, and the cell aborts — discarding any prior successful subagent work in that cell.

Reproduced with a focused unit test against `finalizeSubprocessOutput`:

```
bun --cwd=packages/coding-agent test test/tools/review.test.ts \
  -t "suppresses findings injection when the schema forbids additional properties"
# (fail) expected exitCode=0, received 1
# stderr: schema_violation: findings: must not be present
```

## Cause

`packages/coding-agent/src/task/executor.ts` — `normalizeCompleteData` unconditionally spliced collected `report_finding` entries onto a top-level `findings` array before `finalizeSubprocessOutput` ran validation. The yield tool (`packages/coding-agent/src/tools/yield.ts:213`) only sees the model's raw, pre-injection data, so it happily accepts a payload that the post-mortem validator then rejects. This breaks the lockstep invariant documented at the top of `packages/coding-agent/src/tools/output-schema-validator.ts` ("a schema accepted in-tool cannot be rejected post-mortem"). Once rejected, `buildSchemaViolationOutcome` forces `exitCode=1`, `agent-bridge.ts` throws `ToolError`, and `eval/py/prelude.py:_bridge_call` re-raises it as `RuntimeError` — the whole cell tears down.

The bundled `reviewer.md` happens to escape the bug because its JTD schema declares `findings` under `optionalProperties`, so the converted JSON Schema lists `findings` in `properties` and injection still validates. Any caller schema that omits `findings` and forbids extra properties hits it.

## Fix

- `normalizeCompleteData` now accepts the resolved `OutputValidator` and only performs the injection when the augmented candidate validates. When the schema would reject it, the raw payload is returned instead — which the in-tool yield validator already accepted, so post-mortem validation matches in-tool by construction. Suppressed findings remain visible via the agent progress stream and the JSONL artifact, so nothing is dropped.
- Both `finalizeSubprocessOutput` paths (yield-success and no-yield fallback) now build the validator first and pass it into `normalizeCompleteData`, instead of constructing it twice and injecting findings before validation has been resolved.
- Five regression tests in `test/tools/review.test.ts` cover the strict-schema suppression (yield path), the fallback (no-yield) suppression, the bundled reviewer JTD round-trip (injection still happens), the free-form / no-schema path, and an open `additionalProperties` schema (injection still happens). Existing tests for the bundled reviewer schema continue to pass.

## Verification

```
bun --cwd=packages/coding-agent test test/tools/review.test.ts test/task/executor-warnings.test.ts \
  test/tools/output-schema-validator.test.ts test/tools/yield.test.ts
# 51 pass / 0 fail / 159 expect() calls
```

Full `test/task` + `test/tools` sweep is green on the changed area; the only two failures (`test/tools/gh.test.ts` `pr-checkout` ENOENT in `.omp/wt/...`) reproduce identically against `main` with my diff stashed, so they are pre-existing and unrelated.

Fixes #2070