### PR TITLE
fix(coding-agent): close JS eval workers gracefully

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -70,6 +70,7 @@
 ### Fixed
 
 - Fixed working-message loader session accents so spinner/message color math is cached per session name, session-accent setting, and theme luminance while still updating immediately on renames, setting toggles, and theme changes.
+- Fixed JS eval worker reset/dispose to close workers gracefully before forced termination, avoiding Bun 1.3.14 N-API teardown crashes with native modules such as `canvas`.
 - Fixed startup model fallback selection so sessions now prefer each provider’s configured default model before choosing the first available authenticated model
 - Fixed implicit model selection path for tools and sessions by honoring persisted model-provider order when no explicit pattern is provided
 - Fixed the working spinner appearing to ignore Esc for 2-3 seconds when an interrupt lands mid-tool. Esc fires the abort synchronously, but the agent loop only stops the loader at `agent_end`, which it cannot reach until every in-flight tool settles in `executeToolCalls`' `await Promise.allSettled(...)` — and process/subagent/kernel-owning tools tear down gracefully (SIGTERM, 2-3s grace, SIGKILL), so the loader kept showing the unchanged "Working…/<intent>" line and read as a dropped keypress. The loader now switches to "Interrupting…" the instant Esc requests the abort and freezes intent-driven label updates until the turn unwinds (`EventController.notifyInterrupting`), so the interrupt is acknowledged immediately even while teardown completes.

--- a/packages/coding-agent/src/eval/__tests__/js-context-manager.test.ts
+++ b/packages/coding-agent/src/eval/__tests__/js-context-manager.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { TempDir } from "@oh-my-pi/pi-utils";
+import { Settings } from "../../config/settings";
+import type { ToolSession } from "../../tools";
+import { disposeAllVmContexts } from "../js/context-manager";
+import { executeJs } from "../js/executor";
+
+const originalWorker = globalThis.Worker;
+
+interface FakeWorkerStats {
+	closeRequests: number;
+	terminateCalls: number;
+}
+
+interface FakeWorkerBehavior {
+	exitOnClose: boolean;
+	settleRuns: boolean;
+}
+
+function makeSession(cwd: string): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		settings: Settings.isolated({
+			"async.enabled": false,
+			"task.isolation.mode": "none",
+			"task.enableLsp": true,
+		}),
+		taskDepth: 0,
+		enableLsp: true,
+		getSessionFile: () => null,
+		getSessionSpawns: () => "*",
+		getActiveModelString: () => "p/active",
+		getModelString: () => "p/fallback",
+		getArtifactsDir: () => null,
+		getSessionId: () => "test-session",
+		getEvalSessionId: () => "test-eval-session",
+	};
+}
+
+function installFakeWorker(stats: FakeWorkerStats, behavior: FakeWorkerBehavior): void {
+	class FakeWorker {
+		#messageListeners = new Set<(event: MessageEvent) => void>();
+		#closeListeners = new Set<(event: Event) => void>();
+		#readyQueued = false;
+		#exited = false;
+
+		postMessage(message: unknown): void {
+			if (!message || typeof message !== "object") return;
+			const typed = message as { type?: string; runId?: string };
+			if (typed.type === "run" && typed.runId && behavior.settleRuns) {
+				queueMicrotask(() => this.#emitMessage({ type: "result", runId: typed.runId, ok: true }));
+				return;
+			}
+			if (typed.type === "close") {
+				stats.closeRequests++;
+				queueMicrotask(() => {
+					this.#emitMessage({ type: "closed" });
+					if (behavior.exitOnClose) this.#emitClose();
+				});
+			}
+		}
+
+		addEventListener(type: string, listener: (event: MessageEvent | Event) => void): void {
+			if (type === "close") {
+				this.#closeListeners.add(listener as (event: Event) => void);
+				return;
+			}
+			if (type !== "message") return;
+			this.#messageListeners.add(listener as (event: MessageEvent) => void);
+			if (!this.#readyQueued) {
+				this.#readyQueued = true;
+				queueMicrotask(() => this.#emitMessage({ type: "ready" }));
+			}
+		}
+
+		removeEventListener(type: string, listener: (event: MessageEvent | Event) => void): void {
+			if (type === "close") {
+				this.#closeListeners.delete(listener as (event: Event) => void);
+				return;
+			}
+			if (type !== "message") return;
+			this.#messageListeners.delete(listener as (event: MessageEvent) => void);
+		}
+
+		terminate(): void {
+			stats.terminateCalls++;
+			this.#emitClose();
+		}
+
+		#emitMessage(data: unknown): void {
+			const event = new MessageEvent("message", { data });
+			for (const listener of this.#messageListeners) listener(event);
+		}
+
+		#emitClose(): void {
+			if (this.#exited) return;
+			this.#exited = true;
+			const event = new Event("close");
+			for (const listener of this.#closeListeners) listener(event);
+		}
+	}
+
+	Object.defineProperty(globalThis, "Worker", {
+		configurable: true,
+		writable: true,
+		value: FakeWorker as unknown as typeof Worker,
+	});
+}
+
+describe("JavaScript eval worker lifecycle", () => {
+	afterEach(async () => {
+		await disposeAllVmContexts();
+		Object.defineProperty(globalThis, "Worker", {
+			configurable: true,
+			writable: true,
+			value: originalWorker,
+		});
+	});
+
+	it("waits for the worker to close on reset instead of force-terminating it", async () => {
+		using tempDir = TempDir.createSync("@omp-js-worker-close-");
+		const stats: FakeWorkerStats = { closeRequests: 0, terminateCalls: 0 };
+		installFakeWorker(stats, { exitOnClose: true, settleRuns: true });
+
+		const session = makeSession(tempDir.path());
+		const sessionId = `js-close:${crypto.randomUUID()}`;
+
+		const first = await executeJs("globalThis.marker = 1;", { cwd: tempDir.path(), sessionId, session });
+		expect(first.exitCode).toBe(0);
+
+		const second = await executeJs("globalThis.marker = 2;", {
+			cwd: tempDir.path(),
+			sessionId,
+			session,
+			reset: true,
+		});
+		expect(second.exitCode).toBe(0);
+		expect(stats.closeRequests).toBe(1);
+		expect(stats.terminateCalls).toBe(0);
+	});
+
+	it("terminates when close is acknowledged but the worker does not exit", async () => {
+		using tempDir = TempDir.createSync("@omp-js-worker-close-hung-");
+		const stats: FakeWorkerStats = { closeRequests: 0, terminateCalls: 0 };
+		installFakeWorker(stats, { exitOnClose: false, settleRuns: true });
+
+		const session = makeSession(tempDir.path());
+		const sessionId = `js-close-hung:${crypto.randomUUID()}`;
+
+		const first = await executeJs("globalThis.marker = 1;", { cwd: tempDir.path(), sessionId, session });
+		expect(first.exitCode).toBe(0);
+
+		const second = await executeJs("globalThis.marker = 2;", {
+			cwd: tempDir.path(),
+			sessionId,
+			session,
+			reset: true,
+		});
+		expect(second.exitCode).toBe(0);
+		expect(stats.closeRequests).toBe(1);
+		expect(stats.terminateCalls).toBe(1);
+	});
+
+	it("force-terminates instead of closing when an in-flight run is aborted", async () => {
+		using tempDir = TempDir.createSync("@omp-js-worker-abort-");
+		const stats: FakeWorkerStats = { closeRequests: 0, terminateCalls: 0 };
+		installFakeWorker(stats, { exitOnClose: true, settleRuns: false });
+
+		const session = makeSession(tempDir.path());
+		const sessionId = `js-abort:${crypto.randomUUID()}`;
+		const controller = new AbortController();
+		const resultPromise = executeJs("globalThis.neverFinishes = true;", {
+			cwd: tempDir.path(),
+			sessionId,
+			session,
+			signal: controller.signal,
+		});
+		setTimeout(() => controller.abort(new DOMException("Execution aborted", "AbortError")), 0);
+
+		const result = await resultPromise;
+		expect(result.cancelled).toBe(true);
+		expect(stats.closeRequests).toBe(0);
+		expect(stats.terminateCalls).toBe(1);
+	});
+});

--- a/packages/coding-agent/src/eval/__tests__/js-context-manager.test.ts
+++ b/packages/coding-agent/src/eval/__tests__/js-context-manager.test.ts
@@ -38,6 +38,55 @@ function makeSession(cwd: string): ToolSession {
 	};
 }
 
+async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+	let timeout: NodeJS.Timeout | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_, reject) => {
+				timeout = setTimeout(() => reject(new Error(`${label} timed out`)), ms);
+			}),
+		]);
+	} finally {
+		if (timeout) clearTimeout(timeout);
+	}
+}
+
+async function waitForRealWorkerExitAfterClose(cwd: string): Promise<void> {
+	const worker = new originalWorker(new URL("../js/worker-entry.ts", import.meta.url).href, { type: "module" });
+	const ready = Promise.withResolvers<void>();
+	const runComplete = Promise.withResolvers<void>();
+	const closedAck = Promise.withResolvers<void>();
+	const workerClosed = Promise.withResolvers<void>();
+	const runId = `keep-alive:${crypto.randomUUID()}`;
+	const snapshot = { cwd, sessionId: `worker-exit:${crypto.randomUUID()}` };
+
+	worker.addEventListener("message", event => {
+		const msg = event.data as { type?: string; runId?: string; ok?: boolean };
+		if (msg.type === "ready") ready.resolve();
+		else if (msg.type === "result" && msg.runId === runId && msg.ok) runComplete.resolve();
+		else if (msg.type === "closed") closedAck.resolve();
+	});
+	worker.addEventListener("close", () => workerClosed.resolve());
+
+	try {
+		await withTimeout(ready.promise, 1_000, "worker ready");
+		worker.postMessage({
+			type: "run",
+			runId,
+			code: "globalThis.__keepAlive = setInterval(() => {}, 1000);\nundefined;",
+			filename: "keep-alive.js",
+			snapshot,
+		});
+		await withTimeout(runComplete.promise, 1_000, "worker run");
+		worker.postMessage({ type: "close" });
+		await withTimeout(closedAck.promise, 1_000, "worker closed ack");
+		await withTimeout(workerClosed.promise, 1_000, "worker close event");
+	} finally {
+		worker.terminate();
+	}
+}
+
 function installFakeWorker(stats: FakeWorkerStats, behavior: FakeWorkerBehavior): void {
 	class FakeWorker {
 		#messageListeners = new Set<(event: MessageEvent) => void>();
@@ -116,6 +165,12 @@ describe("JavaScript eval worker lifecycle", () => {
 			writable: true,
 			value: originalWorker,
 		});
+	});
+
+	it("exits a real worker on graceful close even with ref'ed user handles", async () => {
+		using tempDir = TempDir.createSync("@omp-js-worker-real-close-");
+
+		await waitForRealWorkerExitAfterClose(tempDir.path());
 	});
 
 	it("waits for the worker to close on reset instead of force-terminating it", async () => {

--- a/packages/coding-agent/src/eval/js/context-manager.ts
+++ b/packages/coding-agent/src/eval/js/context-manager.ts
@@ -406,35 +406,34 @@ function wrapBunWorker(worker: Worker): WorkerHandle {
 			return () => worker.removeEventListener("message", wrap);
 		},
 		async close() {
-			const closed = new Promise<boolean>(resolve => {
-				let settled = false;
-				let sawClosedAck = false;
-				let sawWorkerExit = false;
-				let timeout: NodeJS.Timeout | undefined;
-				let unsubscribe = (): void => {};
-				const finish = (value: boolean): void => {
-					if (settled) return;
-					settled = true;
-					if (timeout) clearTimeout(timeout);
-					unsubscribe();
-					worker.removeEventListener("close", onClose);
-					resolve(value);
-				};
-				const finishIfClosed = (): void => {
-					if (sawClosedAck && sawWorkerExit) finish(true);
-				};
-				const onClose = (): void => {
-					sawWorkerExit = true;
-					finishIfClosed();
-				};
-				unsubscribe = this.onMessage(msg => {
-					if (msg.type !== "closed") return;
-					sawClosedAck = true;
-					finishIfClosed();
-				});
-				worker.addEventListener("close", onClose);
-				timeout = setTimeout(() => finish(false), WORKER_CLOSE_TIMEOUT_MS);
+			const { promise: closed, resolve } = Promise.withResolvers<boolean>();
+			let settled = false;
+			let sawClosedAck = false;
+			let sawWorkerExit = false;
+			let timeout: NodeJS.Timeout | undefined;
+			let unsubscribe = (): void => {};
+			const finish = (value: boolean): void => {
+				if (settled) return;
+				settled = true;
+				if (timeout) clearTimeout(timeout);
+				unsubscribe();
+				worker.removeEventListener("close", onClose);
+				resolve(value);
+			};
+			const finishIfClosed = (): void => {
+				if (sawClosedAck && sawWorkerExit) finish(true);
+			};
+			const onClose = (): void => {
+				sawWorkerExit = true;
+				finishIfClosed();
+			};
+			unsubscribe = this.onMessage(msg => {
+				if (msg.type !== "closed") return;
+				sawClosedAck = true;
+				finishIfClosed();
 			});
+			worker.addEventListener("close", onClose);
+			timeout = setTimeout(() => finish(false), WORKER_CLOSE_TIMEOUT_MS);
 			worker.postMessage({ type: "close" } satisfies WorkerInbound);
 			return await closed;
 		},
@@ -475,25 +474,24 @@ function spawnInlineWorker(): WorkerHandle {
 			return () => hostListeners.delete(handler);
 		},
 		async close() {
-			const closed = new Promise<boolean>(resolve => {
-				let settled = false;
-				let timeout: NodeJS.Timeout | undefined;
-				let unsubscribe = (): void => {};
-				const finish = (value: boolean): void => {
-					if (settled) return;
-					settled = true;
-					if (timeout) clearTimeout(timeout);
-					unsubscribe();
-					hostListeners.clear();
-					workerListeners.clear();
-					resolve(value);
-				};
-				unsubscribe = this.onMessage(msg => {
-					if (msg.type === "closed") finish(true);
-				});
-				this.send({ type: "close" });
-				timeout = setTimeout(() => finish(false), WORKER_CLOSE_TIMEOUT_MS);
+			const { promise: closed, resolve } = Promise.withResolvers<boolean>();
+			let settled = false;
+			let timeout: NodeJS.Timeout | undefined;
+			let unsubscribe = (): void => {};
+			const finish = (value: boolean): void => {
+				if (settled) return;
+				settled = true;
+				if (timeout) clearTimeout(timeout);
+				unsubscribe();
+				hostListeners.clear();
+				workerListeners.clear();
+				resolve(value);
+			};
+			unsubscribe = this.onMessage(msg => {
+				if (msg.type === "closed") finish(true);
 			});
+			this.send({ type: "close" });
+			timeout = setTimeout(() => finish(false), WORKER_CLOSE_TIMEOUT_MS);
 			return await closed;
 		},
 		async terminate() {

--- a/packages/coding-agent/src/eval/js/context-manager.ts
+++ b/packages/coding-agent/src/eval/js/context-manager.ts
@@ -30,6 +30,7 @@ interface WorkerHandle {
 	mode: "worker" | "inline";
 	send(msg: WorkerInbound): void;
 	onMessage(handler: (msg: WorkerOutbound) => void): () => void;
+	close(): Promise<boolean>;
 	terminate(): Promise<void>;
 }
 
@@ -60,6 +61,7 @@ const resettingSessions = new Map<string, Promise<void>>();
 // avoiding `vm.runInContext` (see shared/indirect-eval.ts), here surfacing as a
 // SIGILL/SIGSEGV. Callers that pass a larger per-cell budget still dominate.
 const WORKER_INIT_TIMEOUT_MS = 15_000;
+const WORKER_CLOSE_TIMEOUT_MS = 1_000;
 
 export async function executeInVmContext(options: {
 	sessionKey: string;
@@ -108,7 +110,7 @@ export async function resetVmContext(sessionKey: string): Promise<void> {
 	const session = sessions.get(sessionKey) ?? (await startingSessions.get(sessionKey)?.catch(() => undefined));
 	if (!session) return;
 	sessions.delete(sessionKey);
-	await killSession(session, new ToolError("JS context reset"));
+	await killSession(session, new ToolError("JS context reset"), { force: false });
 }
 
 export async function disposeAllVmContexts(): Promise<void> {
@@ -121,7 +123,7 @@ export async function disposeAllVmContexts(): Promise<void> {
 		if (!all.includes(result.value)) all.push(result.value);
 	}
 	sessions.clear();
-	await Promise.all(all.map(session => killSession(session, new ToolError("JS context disposed"))));
+	await Promise.all(all.map(session => killSession(session, new ToolError("JS context disposed"), { force: false })));
 }
 
 async function runOnce(
@@ -154,7 +156,7 @@ async function runOnce(
 		// Cancel any in-flight tool calls first.
 		for (const ctrl of pending.toolCalls.values()) ctrl.abort(abortError);
 		// Hard-kill the worker — only way to interrupt synchronous user code.
-		void killSessionFor(session, abortError);
+		void killSessionFor(session, abortError, { force: true });
 	};
 
 	if (options.runState.signal?.aborted) {
@@ -294,14 +296,14 @@ function settlePending(session: JsSession, msg: Extract<WorkerOutbound, { type: 
 	pending.reject(errorFromPayload(msg.error));
 }
 
-async function killSessionFor(session: JsSession, error: Error): Promise<void> {
+async function killSessionFor(session: JsSession, error: Error, options: { force: boolean }): Promise<void> {
 	if (sessions.get(session.sessionKey) === session) {
 		sessions.delete(session.sessionKey);
 	}
-	await killSession(session, error);
+	await killSession(session, error, options);
 }
 
-async function killSession(session: JsSession, error: Error): Promise<void> {
+async function killSession(session: JsSession, error: Error, options: { force: boolean }): Promise<void> {
 	if (session.state === "dead") return;
 	session.state = "dead";
 	for (const pending of session.pending.values()) {
@@ -311,6 +313,11 @@ async function killSession(session: JsSession, error: Error): Promise<void> {
 		pending.reject(error);
 	}
 	session.pending.clear();
+	if (options.force) {
+		await session.worker.terminate().catch(() => undefined);
+		return;
+	}
+	if (await session.worker.close().catch(() => false)) return;
 	await session.worker.terminate().catch(() => undefined);
 }
 
@@ -398,6 +405,39 @@ function wrapBunWorker(worker: Worker): WorkerHandle {
 			worker.addEventListener("message", wrap);
 			return () => worker.removeEventListener("message", wrap);
 		},
+		async close() {
+			const closed = new Promise<boolean>(resolve => {
+				let settled = false;
+				let sawClosedAck = false;
+				let sawWorkerExit = false;
+				let timeout: NodeJS.Timeout | undefined;
+				let unsubscribe = (): void => {};
+				const finish = (value: boolean): void => {
+					if (settled) return;
+					settled = true;
+					if (timeout) clearTimeout(timeout);
+					unsubscribe();
+					worker.removeEventListener("close", onClose);
+					resolve(value);
+				};
+				const finishIfClosed = (): void => {
+					if (sawClosedAck && sawWorkerExit) finish(true);
+				};
+				const onClose = (): void => {
+					sawWorkerExit = true;
+					finishIfClosed();
+				};
+				unsubscribe = this.onMessage(msg => {
+					if (msg.type !== "closed") return;
+					sawClosedAck = true;
+					finishIfClosed();
+				});
+				worker.addEventListener("close", onClose);
+				timeout = setTimeout(() => finish(false), WORKER_CLOSE_TIMEOUT_MS);
+			});
+			worker.postMessage({ type: "close" } satisfies WorkerInbound);
+			return await closed;
+		},
 		async terminate() {
 			worker.terminate();
 		},
@@ -433,6 +473,28 @@ function spawnInlineWorker(): WorkerHandle {
 		onMessage: handler => {
 			hostListeners.add(handler);
 			return () => hostListeners.delete(handler);
+		},
+		async close() {
+			const closed = new Promise<boolean>(resolve => {
+				let settled = false;
+				let timeout: NodeJS.Timeout | undefined;
+				let unsubscribe = (): void => {};
+				const finish = (value: boolean): void => {
+					if (settled) return;
+					settled = true;
+					if (timeout) clearTimeout(timeout);
+					unsubscribe();
+					hostListeners.clear();
+					workerListeners.clear();
+					resolve(value);
+				};
+				unsubscribe = this.onMessage(msg => {
+					if (msg.type === "closed") finish(true);
+				});
+				this.send({ type: "close" });
+				timeout = setTimeout(() => finish(false), WORKER_CLOSE_TIMEOUT_MS);
+			});
+			return await closed;
 		},
 		async terminate() {
 			hostListeners.clear();

--- a/packages/coding-agent/src/eval/js/worker-entry.ts
+++ b/packages/coding-agent/src/eval/js/worker-entry.ts
@@ -18,6 +18,12 @@ const transport: Transport = {
 		} catch {
 			// Already closed.
 		}
+
+		// `parentPort.close()` only disconnects the channel in Bun; it does not
+		// make the Worker emit `close` or reap ref'ed user handles. Exit from
+		// inside the worker after `WorkerCore` has sent the `closed` ack so the
+		// host can observe real worker exit without calling `Worker.terminate()`.
+		setTimeout(() => process.exit(0), 0);
 	},
 };
 


### PR DESCRIPTION
## Summary
- close JS eval workers through the worker protocol during reset/dispose instead of always calling Worker.terminate()
- keep hard termination for aborts, where synchronous user code must still be interrupted
- add a lifecycle regression test proving reset sends close and does not call terminate

## Why
Bun 1.3.14 can crash when a worker that loaded native N-API modules such as canvas is force-terminated after successful work. Graceful close lets the worker release its runtime before the host tears it down.

## Verification
- bun test src/eval/__tests__/js-context-manager.test.ts
- bun run check