### PR TITLE
fix(coding-agent): friendly error when --resume/--fork session id is unknown

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp --resume <id>` / `--fork <id>` crashing with `[Uncaught Exception]` when the id did not match a known session. `createSessionManager` now throws a dedicated `SessionResolutionError`, which `runRootCommand` catches to print `Error: Session "..." not found.` plus a hint to stderr and exit with code 1. The same path covers `--fork` combined with `--no-session` and the non-interactive cross-project / moved-cwd prompts that previously surfaced raw stack traces ([#2084](https://github.com/can1357/oh-my-pi/issues/2084)).
+
 ## [15.10.2] - 2026-06-08
 ### Added
 

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -381,6 +381,22 @@ async function promptMoveSession(session: SessionInfo): Promise<SessionPromptRes
 	}
 }
 
+/**
+ * Friendly CLI failure raised by {@link createSessionManager} when the user's
+ * session-resolution flags (`--resume`/`--fork`/cross-project prompts) cannot
+ * be satisfied. {@link runRootCommand} catches it and prints a clean stderr
+ * message instead of letting it surface as `[Uncaught Exception]`
+ * (see issue #2084).
+ */
+export class SessionResolutionError extends Error {
+	readonly hint?: string;
+	constructor(message: string, hint?: string) {
+		super(message);
+		this.name = "SessionResolutionError";
+		this.hint = hint;
+	}
+}
+
 type MissingCwdMoveResult =
 	| { status: "not-needed" }
 	| { status: "declined" }
@@ -400,7 +416,7 @@ async function moveMissingCwdSessionIfNeeded(
 
 	const movePromptResult = await askToMoveSession(session);
 	if (movePromptResult === "unavailable") {
-		throw new Error(
+		throw new SessionResolutionError(
 			`Session "${sessionArg}" belongs to a directory that no longer exists (${sourceCwd}); run interactively to move it into the current project.`,
 		);
 	}
@@ -463,7 +479,7 @@ export async function createSessionManager(
 ): Promise<SessionManager | undefined> {
 	if (parsed.fork) {
 		if (parsed.noSession) {
-			throw new Error("--fork requires session persistence");
+			throw new SessionResolutionError("--fork requires session persistence");
 		}
 		const forkSource = parsed.fork;
 		if (forkSource.includes("/") || forkSource.includes("\\") || forkSource.endsWith(".jsonl")) {
@@ -471,7 +487,10 @@ export async function createSessionManager(
 		}
 		const match = await resolveResumableSession(forkSource, cwd, parsed.sessionDir);
 		if (!match) {
-			throw new Error(`Session "${forkSource}" not found.`);
+			throw new SessionResolutionError(
+				`Session "${forkSource}" not found.`,
+				"Run `omp --resume` without an argument to pick from recent sessions, or `omp` to start a new one.",
+			);
 		}
 		return await SessionManager.forkFrom(match.session.path, cwd, parsed.sessionDir);
 	}
@@ -486,7 +505,10 @@ export async function createSessionManager(
 		}
 		const match = await resolveResumableSession(sessionArg, cwd, parsed.sessionDir);
 		if (!match) {
-			throw new Error(`Session "${sessionArg}" not found.`);
+			throw new SessionResolutionError(
+				`Session "${sessionArg}" not found.`,
+				"Run `omp --resume` without an argument to pick from recent sessions, or `omp` to start a new one.",
+			);
 		}
 		if (match.scope === "local") {
 			const moveResult = await moveMissingCwdSessionIfNeeded(
@@ -522,7 +544,7 @@ export async function createSessionManager(
 				}
 				const forkPromptResult = await askToForkSession(match.session);
 				if (forkPromptResult === "unavailable") {
-					throw new Error(
+					throw new SessionResolutionError(
 						`Session "${sessionArg}" is in another project (${match.session.cwd}); run interactively to fork it into the current project.`,
 					);
 				}
@@ -919,14 +941,29 @@ export async function runRootCommand(
 		);
 	}
 
-	// Create session manager based on CLI flags
-	let sessionManager = await logger.time(
-		"createSessionManager",
-		createSessionManager,
-		parsedArgs,
-		cwd,
-		settingsInstance,
-	);
+	// Create session manager based on CLI flags. SessionResolutionError signals a
+	// user-facing failure (unknown --resume/--fork id, non-interactive fork
+	// prompt, --fork with --no-session): print + exit cleanly instead of letting
+	// it surface as `[Uncaught Exception]` (see issue #2084).
+	let sessionManager: SessionManager | undefined;
+	try {
+		sessionManager = await logger.time(
+			"createSessionManager",
+			createSessionManager,
+			parsedArgs,
+			cwd,
+			settingsInstance,
+		);
+	} catch (error: unknown) {
+		if (error instanceof SessionResolutionError) {
+			process.stderr.write(`${chalk.red(`Error: ${error.message}`)}\n`);
+			if (error.hint) {
+				process.stderr.write(`${chalk.dim(error.hint)}\n`);
+			}
+			process.exit(1);
+		}
+		throw error;
+	}
 
 	// User declined the cross-project fork prompt — exit cleanly with a friendly
 	// message rather than letting the decline bubble up as an uncaught exception

--- a/packages/coding-agent/test/main-session-resolution-error.test.ts
+++ b/packages/coding-agent/test/main-session-resolution-error.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Regression for #2084: `createSessionManager` must reject with
+ * `SessionResolutionError` (and a usage hint) when `--resume` / `--fork` are
+ * given a non-existent session id, so `runRootCommand` can convert it into a
+ * clean stderr message + non-zero exit instead of letting it surface as
+ * `[Uncaught Exception]`.
+ */
+import { describe, expect, it, vi } from "bun:test";
+import type { Args } from "@oh-my-pi/pi-coding-agent/cli/args";
+import type { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { createSessionManager, SessionResolutionError } from "@oh-my-pi/pi-coding-agent/main";
+import * as sessionManagerModule from "@oh-my-pi/pi-coding-agent/session/session-manager";
+
+function buildResumeArgs(resume: string): Args {
+	return {
+		resume,
+		messages: [],
+		fileArgs: [],
+		unknownFlags: new Map(),
+	};
+}
+
+function buildForkArgs(fork: string, noSession = false): Args {
+	return {
+		fork,
+		noSession: noSession || undefined,
+		messages: [],
+		fileArgs: [],
+		unknownFlags: new Map(),
+	};
+}
+
+const stubSettings = { get: () => undefined } as unknown as Settings;
+
+describe("createSessionManager — missing session (#2084)", () => {
+	it("rejects --resume with SessionResolutionError carrying a usage hint", async () => {
+		vi.spyOn(sessionManagerModule, "resolveResumableSession").mockResolvedValue(undefined);
+		try {
+			await expect(
+				createSessionManager(
+					buildResumeArgs("019ea530-0000-7000-0000-000000000000"),
+					"/current/project",
+					stubSettings,
+				),
+			).rejects.toMatchObject({
+				name: "SessionResolutionError",
+				message: 'Session "019ea530-0000-7000-0000-000000000000" not found.',
+				hint: expect.stringContaining("omp --resume"),
+			});
+
+			// Confirm it's the exported class so `runRootCommand`'s `instanceof` check works.
+			const caught = await createSessionManager(
+				buildResumeArgs("019ea530-0000-7000-0000-000000000000"),
+				"/current/project",
+				stubSettings,
+			).catch((err: unknown) => err);
+			expect(caught).toBeInstanceOf(SessionResolutionError);
+		} finally {
+			vi.restoreAllMocks();
+		}
+	});
+
+	it("rejects --fork with SessionResolutionError carrying a usage hint", async () => {
+		vi.spyOn(sessionManagerModule, "resolveResumableSession").mockResolvedValue(undefined);
+		try {
+			await expect(
+				createSessionManager(
+					buildForkArgs("019ea530-0000-7000-0000-000000000000"),
+					"/current/project",
+					stubSettings,
+				),
+			).rejects.toMatchObject({
+				name: "SessionResolutionError",
+				message: 'Session "019ea530-0000-7000-0000-000000000000" not found.',
+				hint: expect.stringContaining("omp --resume"),
+			});
+		} finally {
+			vi.restoreAllMocks();
+		}
+	});
+
+	it("rejects --fork combined with --no-session as a SessionResolutionError (no hint)", async () => {
+		await expect(
+			createSessionManager(buildForkArgs("019ea530", true), "/current/project", stubSettings),
+		).rejects.toMatchObject({
+			name: "SessionResolutionError",
+			message: "--fork requires session persistence",
+			hint: undefined,
+		});
+	});
+});


### PR DESCRIPTION
## Repro

```
$ omp --resume 019ea530-0000-7000-0000-000000000000

[Uncaught Exception] Error: Session "019ea530-0000-7000-0000-000000000000" not found.
    at createSessionManager (packages/coding-agent/src/main.ts:489:14)
    at processTicksAndRejections (native:7:39)
```

`omp --fork <unknown-id>` and `omp --fork <id> --no-session` crashed the same way. Confirmed on the working tree before applying the fix with `bun run src/cli.ts --print --resume 019ea530-0000-7000-0000-000000000000 hello`.

## Cause

`createSessionManager` (in `packages/coding-agent/src/main.ts`) throws plain `Error` instances for several user-facing failures — unknown `--resume` id (line 489), unknown `--fork` id (line 474), `--fork` combined with `--no-session` (line 466), and the non-interactive cross-project / moved-cwd prompts (lines 404, 525). Nothing in `runRootCommand` or the CLI runner (`packages/utils/src/cli.ts`) catches them, so the rejected promise falls through to the global `unhandledRejection` handler in `packages/utils/src/postmortem.ts`, which formats it as `[Uncaught Exception] ...` plus a stack trace and exits with code 1.

## Fix

- Add `SessionResolutionError` in `packages/coding-agent/src/main.ts`: subclass of `Error` carrying an optional `hint` for usage guidance.
- Replace the five `throw new Error(...)` sites in `createSessionManager` / `moveMissingCwdSessionIfNeeded` with `SessionResolutionError`, attaching the "Run `omp --resume` without an argument to pick from recent sessions, or `omp` to start a new one." hint to the two "not found" cases.
- Wrap the `createSessionManager` call in `runRootCommand` with a `try` / `catch`: on `SessionResolutionError` write `Error: <message>` (and the hint when present) to stderr, then `process.exit(1)`. Other (unexpected) errors still propagate to the postmortem handler.
- Regression test `test/main-session-resolution-error.test.ts` covers all three thrown shapes and asserts they are `SessionResolutionError` instances so the `instanceof` check in `runRootCommand` keeps working.
- Changelog entry under `## [Unreleased]` in `packages/coding-agent/CHANGELOG.md`.

The existing `main-cross-project-resume.test.ts` keeps passing unchanged because it asserts thrown messages (substring match) and `SessionResolutionError` is still an `Error`.

## Verification

```
$ bun run src/cli.ts --print --resume 019ea530-0000-7000-0000-000000000000 hello
Error: Session "019ea530-0000-7000-0000-000000000000" not found.
Run `omp --resume` without an argument to pick from recent sessions, or `omp` to start a new one.
$ echo $?
1

$ bun run src/cli.ts --print --fork 019ea530-0000-7000-0000-000000000000 hello
Error: Session "019ea530-0000-7000-0000-000000000000" not found.
Run `omp --resume` without an argument to pick from recent sessions, or `omp` to start a new one.

$ bun run src/cli.ts --print --no-session --fork 019ea530 hello
Error: --fork requires session persistence
```

- `bun test test/main-session-resolution-error.test.ts test/main-cross-project-resume.test.ts` — 8 pass / 0 fail / 18 assertions
- `bun check` (workspace-wide biome + tsgo + cargo check) — clean

Fixes #2084