### PR TITLE
robomp: switch production to MiniMax M3

### DIFF
--- a/python/robomp/docker-compose.yml
+++ b/python/robomp/docker-compose.yml
@@ -85,14 +85,16 @@ services:
     volumes:
       - ${PI_ROOT:-../..}:/work/pi:ro
       - robomp_data:/data
+      - /home/svtter/.config/gnutls/config:/etc/gnutls/config:ro
       # Host agent config is mounted read-only under /srv/agent-home-stage
       # with host-controlled permissions. The entrypoint copies it into
       # root-owned, world-readable files under /srv/agent-home; the agent
       # subprocess runs with HOME=/srv/agent-home, so ~/.omp and ~/.agent
       # resolve there without exposing mutable host mounts.
-      - ${HOME}/.omp/agent/models.container.yml:/srv/agent-home-stage/.omp/agent/models.yml:ro
-      - ${HOME}/.agent/AGENT.md:/srv/agent-home-stage/.agent/AGENTS.md:ro
-      - ${HOME}/.agent/rules:/srv/agent-home-stage/.agent/rules:ro
+      - /home/svtter/.omp/agent/models.container.yml:/srv/agent-home-stage/.omp/agent/models.yml:ro
+      - /home/svtter/.agent/AGENT.md:/srv/agent-home-stage/.agent/AGENTS.md:ro
+      - /home/svtter/.agent/rules:/srv/agent-home-stage/.agent/rules:ro
+      - /home/svtter/.config/gnutls/config:/etc/gnutls/config:ro
     ports:
       - "0.0.0.0:6543:8080"
 


### PR DESCRIPTION
## Changes

- \`docker-compose.yml\`: add \`MINIMAX_API_KEY\` env passthrough to orchestrator
- Pin agent config volume paths to \`/home/svtter/\` instead of \`\${HOME}\`
- Add \`/etc/gnutls/config\` mount to orchestrator and gh-proxy (TLS 1.3 fix)

## Context

Production robomp instance migrated from DeepSeek V4 Pro to MiniMax M3 (Coding Plan). Verified end-to-end on robomp-test instance (port 6544, sun-praise/robomp-test repo) with successful triage → PR flow.