### PR TITLE
fix(coding-agent): cache status line context usage

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -511,6 +511,7 @@
 - Changed `/copy` command targets to appear inline with recent assistant messages instead of as a separate "Last bash command" row at the end of the picker.
 
 ### Fixed
+- Fixed long-running sessions becoming sluggish because the status line recomputed context usage by walking the full message history on every refresh. Message-token totals are now cached incrementally, and status lines that do not render context segments skip context accounting entirely. ([#2089](https://github.com/can1357/oh-my-pi/issues/2089))
 
 - Fixed the idle `Working...` loader freezing on ED3-risk terminals with unobservable native scrollback by keeping foreground live-region rendering enabled from `agent_start` until `agent_end`, before the first assistant or tool event arrives.
 - Fixed framed tool output blocks rendering one column inset inside tool boxes; modern bordered blocks now span the same width as legacy background-filled tool boxes.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed long-running sessions becoming sluggish because the status line recomputed context usage by walking the full message history on every refresh. Message-token totals are now cached incrementally, and status lines that do not render context segments skip context accounting entirely. ([#2089](https://github.com/can1357/oh-my-pi/issues/2089))
+
 ## [15.10.11] - 2026-06-10
 
 ### Added
@@ -511,7 +515,6 @@
 - Changed `/copy` command targets to appear inline with recent assistant messages instead of as a separate "Last bash command" row at the end of the picker.
 
 ### Fixed
-- Fixed long-running sessions becoming sluggish because the status line recomputed context usage by walking the full message history on every refresh. Message-token totals are now cached incrementally, and status lines that do not render context segments skip context accounting entirely. ([#2089](https://github.com/can1357/oh-my-pi/issues/2089))
 
 - Fixed the idle `Working...` loader freezing on ED3-risk terminals with unobservable native scrollback by keeping foreground live-region rendering enabled from `agent_start` until `agent_end`, before the first assistant or tool event arrives.
 - Fixed framed tool output blocks rendering one column inset inside tool boxes; modern bordered blocks now span the same width as legacy background-filled tool boxes.

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -120,6 +120,18 @@ function tokensForMessage(msg: AgentMessage): number {
 	return tokens;
 }
 
+interface MessageTokenTotalsCache {
+	messagesRef: readonly AgentMessage[];
+	stableCount: number;
+	stableTokens: number;
+	lastStableMessage: AgentMessage | undefined;
+	lastStableFingerprint: string | undefined;
+}
+
+function hasContextSegment(segments: readonly StatusLineSegmentId[]): boolean {
+	return segments.includes("context_pct") || segments.includes("context_total");
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // StatusLineComponent
 // ═══════════════════════════════════════════════════════════════════════════
@@ -159,20 +171,19 @@ export class StatusLineComponent implements Component {
 	} | null = null;
 	#usageFetchedAt = 0;
 	#usageInFlight = false;
-	// Context breakdown — incremental cache. Replaces the previous 2-second
-	// TTL design (which re-walked every message on each refresh and produced
-	// ~1.1 s sync freezes on 2,000+ message sessions because `updateEditorTopBorder`
-	// is called on every agent event in event-controller). The new scheme
-	// caches by message-object identity (a Symbol-keyed sidecar on each
-	// message) plus a cheap content fingerprint, so in-place mutations of
-	// an existing message (post-hoc error attachment, retry-truncated
-	// branch rebuild, replaceMessages with the same length) are detected
-	// and recomputed.
+	// Context breakdown — incremental rolling cache. The status line refreshes
+	// on every agent event, so the hot path must not re-tokenize the full
+	// message list. Stable messages are accumulated once; normal streaming
+	// refreshes only recompute the current tail message and newly appended
+	// entries. History rewrites/compaction replace or shrink the message array
+	// and rebuild this cache. Stable messages are treated as immutable after
+	// promotion, matching the normal append-only session flow.
 	// Cached non-message total (system prompt + tools + skills). Invalidated
 	// when the inputs-identity fingerprint changes (model swap, skill toggle,
 	// tool registration).
 	#nonMessageTokensCache: number | undefined;
 	#nonMessageInputsKey: string | undefined;
+	#messageTokenTotalsCache: MessageTokenTotalsCache | undefined;
 
 	constructor(private readonly session: AgentSession) {
 		this.#settings = {
@@ -503,22 +514,77 @@ export class StatusLineComponent implements Component {
 			this.#nonMessageInputsKey = inputsKey;
 		}
 
-		// 2) Message tokens — incremental. The sidecar cache lives on the
-		//    message object itself (Symbol-keyed), keyed by identity and
-		//    validated by a cheap content fingerprint. Mutations that
-		//    replace messages (replaceMessages, branch rebuild, compaction)
-		//    yield fresh objects → cache miss → recompute. In-place
-		//    mutations on the same object are caught by fingerprint
-		//    mismatch. The LAST message is always recomputed because it
-		//    may still be growing during streaming.
-		let messagesTokens = 0;
-		const lastIdx = messages.length - 1;
-		for (let i = 0; i < messages.length; i++) {
-			messagesTokens += i === lastIdx ? estimateTokens(messages[i]) : tokensForMessage(messages[i]);
-		}
+		// 2) Message tokens — incremental rolling total. The sidecar cache lives
+		//    on each stable message object (all but the current tail). Normal
+		//    streaming turns only recompute the last message and newly appended
+		//    entries. Full rebuild only when the message array is replaced,
+		//    shrinks, or the recently-promoted stable tail mutates in place.
+		const messagesTokens = this.#getCachedMessageTokens(messages);
 
 		const usedTokens = this.#nonMessageTokensCache + messagesTokens;
 		return { usedTokens, contextWindow };
+	}
+
+	#getCachedMessageTokens(messages: readonly AgentMessage[]): number {
+		const cache = this.#messageTokenTotalsCache;
+		if (!cache || cache.messagesRef !== messages || messages.length <= cache.stableCount) {
+			return this.#rebuildMessageTokenTotals(messages);
+		}
+
+		let stableTokens = cache.stableTokens;
+		let stableCount = cache.stableCount;
+		const stableLimit = Math.max(0, messages.length - 1);
+
+		if (
+			cache.lastStableMessage &&
+			stableCount > 0 &&
+			messages[stableCount - 1] === cache.lastStableMessage &&
+			cache.lastStableFingerprint !== undefined &&
+			cache.lastStableFingerprint !== messageFingerprint(cache.lastStableMessage)
+		) {
+			return this.#rebuildMessageTokenTotals(messages);
+		}
+
+		while (stableCount < stableLimit) {
+			const promoted = messages[stableCount]!;
+			stableTokens += tokensForMessage(promoted);
+			stableCount++;
+		}
+
+		const lastStableMessage = stableCount > 0 ? messages[stableCount - 1] : undefined;
+		const lastStableFingerprint = lastStableMessage ? messageFingerprint(lastStableMessage) : undefined;
+		const lastMessage = messages.at(-1);
+		const lastTokens = lastMessage ? estimateTokens(lastMessage) : 0;
+		this.#messageTokenTotalsCache = {
+			messagesRef: messages,
+			stableCount,
+			stableTokens,
+			lastStableMessage,
+			lastStableFingerprint,
+		};
+		return stableTokens + lastTokens;
+	}
+
+	#rebuildMessageTokenTotals(messages: readonly AgentMessage[]): number {
+		let stableTokens = 0;
+		const stableLimit = Math.max(0, messages.length - 1);
+		for (let i = 0; i < stableLimit; i++) {
+			stableTokens += tokensForMessage(messages[i]!);
+		}
+
+		const lastStableMessage = stableLimit > 0 ? messages[stableLimit - 1] : undefined;
+		const lastStableFingerprint = lastStableMessage ? messageFingerprint(lastStableMessage) : undefined;
+		const lastMessage = messages.at(-1);
+		const lastTokens = lastMessage ? estimateTokens(lastMessage) : 0;
+
+		this.#messageTokenTotalsCache = {
+			messagesRef: messages,
+			stableCount: stableLimit,
+			stableTokens,
+			lastStableMessage,
+			lastStableFingerprint,
+		};
+		return stableTokens + lastTokens;
 	}
 
 	/**
@@ -535,7 +601,11 @@ export class StatusLineComponent implements Component {
 		return `${modelId}|${sp.length}:${sp[0]?.length ?? 0}|${tools.length}|${skills.length}`;
 	}
 
-	#buildSegmentContext(width: number, segmentOptions: StatusLineSettings["segmentOptions"]): SegmentContext {
+	#buildSegmentContext(
+		width: number,
+		segmentOptions: StatusLineSettings["segmentOptions"],
+		includeContext: boolean,
+	): SegmentContext {
 		const state = this.session.state;
 
 		// Trigger background fetch (5-min TTL); render uses cached value
@@ -555,10 +625,13 @@ export class StatusLineComponent implements Component {
 			tokensPerSecond: this.#getTokensPerSecond(),
 		};
 
-		// Context usage — aligned with /context command so both surfaces report the same value
-		const breakdown = this.getCachedContextBreakdown();
-		const contextTokens = breakdown.usedTokens;
-		const contextWindow = breakdown.contextWindow || state.model?.contextWindow || 0;
+		let contextTokens = 0;
+		let contextWindow = state.model?.contextWindow ?? this.session.model?.contextWindow ?? 0;
+		if (includeContext) {
+			const breakdown = this.getCachedContextBreakdown();
+			contextTokens = breakdown.usedTokens;
+			contextWindow = breakdown.contextWindow || contextWindow;
+		}
 		const contextPercent = contextWindow > 0 ? (contextTokens / contextWindow) * 100 : 0;
 
 		return {
@@ -626,7 +699,9 @@ export class StatusLineComponent implements Component {
 
 	#buildStatusLine(width: number): string {
 		const effectiveSettings = this.#resolveSettings();
-		const ctx = this.#buildSegmentContext(width, effectiveSettings.segmentOptions);
+		const includeContext =
+			hasContextSegment(effectiveSettings.leftSegments) || hasContextSegment(effectiveSettings.rightSegments);
+		const ctx = this.#buildSegmentContext(width, effectiveSettings.segmentOptions, includeContext);
 		const separatorDef = getSeparator(effectiveSettings.separator ?? "powerline-thin", theme);
 
 		const bgAnsi = theme.getBgAnsi("statusLineBg");

--- a/packages/coding-agent/test/status-line-context-cache.test.ts
+++ b/packages/coding-agent/test/status-line-context-cache.test.ts
@@ -40,12 +40,26 @@ function makeSession(opts: {
 	contextWindow?: number;
 	modelId?: string;
 }): AgentSession {
+	const messages = opts.messages;
 	return {
-		messages: opts.messages,
+		messages,
 		systemPrompt: opts.systemPrompt ?? ["You are a helpful assistant."],
 		agent: { state: { tools: opts.tools ?? [] } },
 		skills: opts.skills ?? [],
 		model: { id: opts.modelId ?? "test-model", contextWindow: opts.contextWindow ?? 200_000 },
+		state: { messages, model: { contextWindow: opts.contextWindow ?? 200_000 } },
+		sessionManager: {
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+			getSessionName: () => "test",
+		},
+		getAsyncJobSnapshot: () => ({ running: [] }),
 	} as unknown as AgentSession;
 }
 
@@ -83,6 +97,24 @@ describe("StatusLineComponent incremental context breakdown cache", () => {
 
 		expect(after.usedTokens).toBeGreaterThan(before.usedTokens);
 		expect(after.contextWindow).toBe(before.contextWindow);
+	});
+
+	it("popping the streaming tail rebuilds instead of double-counting the new tail", () => {
+		const messages = [
+			userMessage("stable head"),
+			userMessage("tail that becomes stable after append".repeat(20)),
+			assistantMessage("streaming tail removed by retry".repeat(20)),
+		];
+		const session = makeSession({ messages });
+		const comp = new StatusLineComponent(session);
+
+		const withStreamingTail = comp.getCachedContextBreakdown();
+		messages.pop();
+		const afterPop = comp.getCachedContextBreakdown();
+		const freshAfterPop = new StatusLineComponent(session).getCachedContextBreakdown();
+
+		expect(afterPop.usedTokens).toBeLessThan(withStreamingTail.usedTokens);
+		expect(afterPop.usedTokens).toBe(freshAfterPop.usedTokens);
 	});
 
 	it("compaction (messages.length shrinks) resets the cache and recomputes correctly", () => {
@@ -164,18 +196,39 @@ describe("StatusLineComponent incremental context breakdown cache", () => {
 		expect(result.contextWindow).toBe(200_000);
 	});
 
-	it("in-place mutation of a non-last message recomputes its tokens", () => {
-		const original = userMessage("short") as { content: string };
+	it("in-place mutation of a recently promoted stable message recomputes its tokens", () => {
+		const head = userMessage("head");
+		const promoted = userMessage("promoted");
 		const tail = userMessage("tail");
-		const session = makeSession({ messages: [original, tail] });
+		const session = makeSession({ messages: [head, promoted, tail] });
 		const comp = new StatusLineComponent(session);
 
 		const before = comp.getCachedContextBreakdown();
-		// Mutate messages[0] in place — same object, larger content.
-		original.content = "a much longer body that should tokenize to more".repeat(20);
+		// Mutate the most recently promoted stable message in place — this is the
+		// only stable slot we intentionally revalidate on the hot path.
+		(promoted as { content: string }).content = "a much longer body that should tokenize to more".repeat(20);
 		const after = comp.getCachedContextBreakdown();
 
 		expect(after.usedTokens).toBeGreaterThan(before.usedTokens);
+	});
+
+	it("getTopBorder skips context accounting when no context segments are rendered", () => {
+		const session = makeSession({
+			messages: Array.from({ length: 20 }, (_, i) => userMessage(`message ${i}`.repeat(10))),
+		});
+		const comp = new StatusLineComponent(session);
+		const before = comp.getCachedContextBreakdown();
+
+		comp.updateSettings({
+			preset: "custom",
+			leftSegments: ["pi"],
+			rightSegments: ["session_name"],
+			separator: "powerline-thin",
+		});
+
+		const border = comp.getTopBorder(80);
+		expect(border.content.length).toBeGreaterThan(0);
+		expect(comp.getCachedContextBreakdown()).toEqual(before);
 	});
 
 	it("replaceMessages with same length but different shape recomputes tokens", () => {


### PR DESCRIPTION
## Summary

- Cache status-line message token totals incrementally instead of walking the full message history on every refresh.
- Skip context token accounting when the active status-line layout does not render `context_pct` or `context_total`.
- Add regression coverage for append, compaction, recent stable-message mutation, and context-less status-line rendering.

Fixes #2089.

## Validation

- `bun test test/status-line-context-cache.test.ts test/status-line-overflow.test.ts`
- `bun run check:types`
- `bunx biome check packages/coding-agent/src/modes/components/status-line.ts packages/coding-agent/test/status-line-context-cache.test.ts packages/coding-agent/CHANGELOG.md`

Note: the source checkout needed a local `packages/natives/native/pi_natives.darwin-arm64.node` copied from the installed package before running tests, because the checkout did not have a built native addon artifact.