### PR TITLE
fix(acp): skip permission gate in yolo mode when effective policy is allow

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ACP `available_commands_update` to include extension-registered slash commands so clients like Zed surface them in the slash-command palette.
+
 ## [15.10.1] - 2026-06-07
 
 ### Added

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -427,7 +427,7 @@ export class ExtensionRunner {
 		return this.extensions.flatMap(ext => ext.assistantThinkingRenderers);
 	}
 
-	getRegisteredCommands(reserved?: Set<string>): RegisteredCommand[] {
+	getRegisteredCommands(reserved?: ReadonlySet<string>): RegisteredCommand[] {
 		this.#commandDiagnostics = [];
 
 		const commands = new Map<string, RegisteredCommand>();

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -703,7 +703,13 @@ export class AcpAgent implements Agent {
 			return;
 		}
 
-		await record.session.prompt(text, { images });
+		const agentInvoked = await record.session.prompt(text, { images });
+		// Extension and custom-TS commands are handled locally inside session.prompt()
+		// without calling the LLM, so no agent_end event fires and the turn would hang.
+		// Finish it here when the session confirms no agent was invoked.
+		if (!agentInvoked) {
+			this.#finishPrompt(record, { stopReason: "end_turn" });
+		}
 	}
 
 	async #tryRunSkillCommand(record: ManagedSessionRecord, text: string): Promise<boolean> {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -71,7 +71,11 @@ import {
 	type SessionInfo as StoredSessionInfo,
 	type UsageStatistics,
 } from "../../session/session-manager";
-import { ACP_BUILTIN_SLASH_COMMANDS, executeAcpBuiltinSlashCommand } from "../../slash-commands/acp-builtins";
+import {
+	ACP_BUILTIN_RESERVED_NAMES,
+	ACP_BUILTIN_SLASH_COMMANDS,
+	executeAcpBuiltinSlashCommand,
+} from "../../slash-commands/acp-builtins";
 import { AUTO_THINKING, parseConfiguredThinkingLevel } from "../../thinking";
 import { normalizeLocalScheme } from "../../tools/path-utils";
 import { runResolveInvocation } from "../../tools/resolve";
@@ -1602,8 +1606,7 @@ export class AcpAgent implements Agent {
 			}
 		}
 
-		const acpBuiltinNames = new Set(ACP_BUILTIN_SLASH_COMMANDS.map(c => c.name));
-		for (const command of session.extensionRunner?.getRegisteredCommands(acpBuiltinNames) ?? []) {
+		for (const command of session.extensionRunner?.getRegisteredCommands(ACP_BUILTIN_RESERVED_NAMES) ?? []) {
 			appendCommand({
 				name: command.name,
 				description: command.description ?? "(extension command)",

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1584,8 +1584,12 @@ export class AcpAgent implements Agent {
 
 		// Advertise in the order dispatch resolves them: ACP builtins first
 		// (so core commands like `/model`, `/mcp`, `/todo` cannot be shadowed),
-		// then skills, then custom/user commands, then file-based slash
-		// commands. `appendCommand` dedupes by name so earlier entries win.
+		// then skills, then custom/user (TypeScript) commands, then
+		// extension-registered commands, then file-based slash commands.
+		// `appendCommand` dedupes by name so earlier entries win; skills and
+		// custom TS commands intentionally shadow extension commands of the
+		// same name (unlike interactive mode, which inserts extension commands
+		// before customs/skills).
 		for (const command of ACP_BUILTIN_SLASH_COMMANDS) {
 			appendCommand(command);
 		}

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1582,14 +1582,12 @@ export class AcpAgent implements Agent {
 			commands.push(command);
 		};
 
-		// Advertise in the order dispatch resolves them: ACP builtins first
-		// (so core commands like `/model`, `/mcp`, `/todo` cannot be shadowed),
-		// then skills, then custom/user (TypeScript) commands, then
-		// extension-registered commands, then file-based slash commands.
-		// `appendCommand` dedupes by name so earlier entries win; skills and
-		// custom TS commands intentionally shadow extension commands of the
-		// same name (unlike interactive mode, which inserts extension commands
-		// before customs/skills).
+		// Advertise in the order dispatch resolves them (mirrors AgentSession
+		// dispatch: builtins → skills → extensions → custom TS → file-based).
+		// `appendCommand` dedupes by name so earlier entries win; extension
+		// commands therefore correctly shadow custom TS commands of the same
+		// name, matching the runtime behaviour of #tryExecuteExtensionCommand
+		// running before #tryExecuteCustomCommand.
 		for (const command of ACP_BUILTIN_SLASH_COMMANDS) {
 			appendCommand(command);
 		}
@@ -1604,19 +1602,19 @@ export class AcpAgent implements Agent {
 			}
 		}
 
-		for (const command of session.customCommands) {
-			appendCommand({
-				name: command.command.name,
-				description: command.command.description,
-				input: { hint: "arguments" },
-			});
-		}
-
 		const acpBuiltinNames = new Set(ACP_BUILTIN_SLASH_COMMANDS.map(c => c.name));
 		for (const command of session.extensionRunner?.getRegisteredCommands(acpBuiltinNames) ?? []) {
 			appendCommand({
 				name: command.name,
 				description: command.description ?? "(extension command)",
+				input: { hint: "arguments" },
+			});
+		}
+
+		for (const command of session.customCommands) {
+			appendCommand({
+				name: command.command.name,
+				description: command.command.description,
 				input: { hint: "arguments" },
 			});
 		}

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1608,6 +1608,15 @@ export class AcpAgent implements Agent {
 			});
 		}
 
+		const acpBuiltinNames = new Set(ACP_BUILTIN_SLASH_COMMANDS.map(c => c.name));
+		for (const command of session.extensionRunner?.getRegisteredCommands(acpBuiltinNames) ?? []) {
+			appendCommand({
+				name: command.name,
+				description: command.description ?? "(extension command)",
+				input: { hint: "arguments" },
+			});
+		}
+
 		for (const command of await loadSlashCommands({ cwd: session.sessionManager.getCwd() })) {
 			appendCommand({
 				name: command.name,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3477,12 +3477,23 @@ export class AgentSession {
 	 * Wrap a tool with a permission-gate proxy when an ACP client is connected.
 	 * Only wraps tools whose name is in PERMISSION_REQUIRED_TOOLS and only when
 	 * the bridge exposes `requestPermission`. No-ops for all other cases.
+	 *
+	 * In `yolo` mode, skips the gate unless the user policy explicitly requires a
+	 * prompt or deny (matching the behaviour of the normal approval wrapper).
 	 */
 	#wrapToolForAcpPermission<T extends AgentTool>(tool: T): T {
 		const bridge = this.#clientBridge;
 		// Match the capability+method gating pattern used by read/write/bash.
 		if (!bridge?.capabilities.requestPermission || !bridge.requestPermission) return tool;
 		if (!PERMISSION_REQUIRED_TOOLS.has(tool.name)) return tool;
+		// In yolo mode, honour the user per-tool policy but skip the ACP gate when
+		// the effective decision is "allow" (absent policy or explicit "allow").
+		const approvalMode = (this.settings.get("tools.approvalMode") ?? "yolo") as string;
+		if (approvalMode === "yolo") {
+			const userPolicies = (this.settings.get("tools.approval") ?? {}) as Record<string, unknown>;
+			const toolPolicy = userPolicies[tool.name];
+			if (!toolPolicy || toolPolicy === "allow") return tool;
+		}
 		return new Proxy(tool, {
 			get: (target, prop) => {
 				if (prop !== "execute") return Reflect.get(target, prop, target);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4287,21 +4287,28 @@ export class AgentSession {
 	 * @throws Error if streaming and no streamingBehavior specified
 	 * @throws Error if no model selected or no API key available (when not streaming)
 	 */
-	async prompt(text: string, options?: PromptOptions): Promise<void> {
+	/**
+	 * Returns `false` when the command was fully handled locally (extension or
+	 * custom-TS command consumed without calling the LLM). Returns `true` when
+	 * the prompt was forwarded to the agent — either directly or queued as a
+	 * steer/follow-up. Callers that render a UI or manage turn lifecycle (e.g.
+	 * the ACP agent) use this to know whether to expect an `agent_end` event.
+	 */
+	async prompt(text: string, options?: PromptOptions): Promise<boolean> {
 		const expandPromptTemplates = options?.expandPromptTemplates ?? true;
 
 		// Handle extension commands first (execute immediately, even during streaming)
 		if (expandPromptTemplates && text.startsWith("/")) {
 			const handled = await this.#tryExecuteExtensionCommand(text);
 			if (handled) {
-				return;
+				return false;
 			}
 
 			// Try custom commands (TypeScript slash commands)
 			const customResult = await this.#tryExecuteCustomCommand(text);
 			if (customResult !== null) {
 				if (customResult === "") {
-					return;
+					return false;
 				}
 				text = customResult;
 			}
@@ -4370,7 +4377,7 @@ export class AgentSession {
 			for (const notice of keywordNotices) {
 				await this.sendCustomMessage(notice, { deliverAs: options.streamingBehavior });
 			}
-			return;
+			return true;
 		}
 
 		// Skip eager todo prelude when the user has already queued a directive
@@ -4408,6 +4415,7 @@ export class AgentSession {
 		if (!options?.synthetic) {
 			await this.#enforcePlanModeToolDecision();
 		}
+		return true;
 	}
 
 	async promptCustomMessage<T = unknown>(

--- a/packages/coding-agent/src/slash-commands/acp-builtins.ts
+++ b/packages/coding-agent/src/slash-commands/acp-builtins.ts
@@ -6,6 +6,19 @@ import type { AcpBuiltinSlashCommandResult, SlashCommandRuntime } from "./types"
 export type { AcpBuiltinSlashCommandResult } from "./types";
 
 /**
+ * All names (primary + aliases) that are reserved by ACP builtins. Used to
+ * filter out extension commands that would shadow a builtin or its alias at
+ * dispatch time (e.g. `models` is an alias for `/model`, so an extension
+ * registering `models` would appear in the palette but execute the builtin).
+ */
+export const ACP_BUILTIN_RESERVED_NAMES: ReadonlySet<string> = new Set(
+	BUILTIN_SLASH_COMMANDS_INTERNAL.filter(c => c.handle !== undefined).flatMap(c => [
+		c.name,
+		...(c.aliases ?? []),
+	]),
+);
+
+/**
  * Commands advertised to ACP clients. Entries without a text-mode `handle`
  * (e.g. `/quit`, `/login`, dashboards) are filtered out so the client doesn't
  * see commands it cannot drive.

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1274,8 +1274,11 @@ describe("ACP agent", () => {
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
 		const session = harness.findSession(created.sessionId)!;
 
-		// Attach a fake extensionRunner that exposes two extension commands:
-		// one unique and one whose name collides with an ACP builtin ("fast").
+		// Extension command colliding with a custom TS command; extension wins (dispatch order).
+		(session as unknown as { customCommands: unknown[] }).customCommands = [
+			{ command: { name: "my-ext-cmd", description: "Custom TS version" } },
+		];
+		// Extension runner: unique command + one colliding with an ACP builtin ("fast").
 		(session as unknown as { extensionRunner: unknown }).extensionRunner = {
 			getRegisteredCommands(reserved?: Set<string>) {
 				return [
@@ -1291,24 +1294,19 @@ describe("ACP agent", () => {
 			update =>
 				update.sessionId === created.sessionId && update.update.sessionUpdate === "available_commands_update",
 		);
-		const names = commandUpdates.flatMap(update =>
-			update.update.sessionUpdate === "available_commands_update"
-				? update.update.availableCommands.map(command => command.name)
-				: [],
+		// Flatten all advertised commands from all updates for this session.
+		const allCommands = commandUpdates.flatMap(update =>
+			update.update.sessionUpdate === "available_commands_update" ? update.update.availableCommands : [],
 		);
+		const names = allCommands.map(c => c.name);
 
 		// Extension command must surface.
 		expect(names).toContain("my-ext-cmd");
-		// ACP builtin "fast" must still appear exactly once (not shadowed/duplicated).
+		// Extension wins the name collision: advertised description is the extension's, not the custom TS one.
+		const extCmdEntry = allCommands.find(c => c.name === "my-ext-cmd");
+		expect(extCmdEntry?.description).toBe("Extension command");
+		// ACP builtin "fast" appears exactly once (reserved-set exclusion, no duplicate from extension).
 		expect(names.filter(n => n === "fast").length).toBe(1);
-		// Extension command that collided with the builtin must not add a duplicate.
-		// (The builtin "fast" entry wins via the reserved-set exclusion.)
-		const fastEntries = commandUpdates.flatMap(update =>
-			update.update.sessionUpdate === "available_commands_update"
-				? update.update.availableCommands.filter(c => c.name === "fast")
-				: [],
-		);
-		expect(fastEntries.length).toBe(1);
 
 		harness.abortController.abort();
 		await Bun.sleep(0);

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1269,6 +1269,51 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("includes extension-registered commands in available_commands_update and excludes ACP-builtin collisions", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+
+		// Attach a fake extensionRunner that exposes two extension commands:
+		// one unique and one whose name collides with an ACP builtin ("fast").
+		(session as unknown as { extensionRunner: unknown }).extensionRunner = {
+			getRegisteredCommands(reserved?: Set<string>) {
+				return [
+					{ name: "my-ext-cmd", description: "Extension command", handler: async () => {} },
+					{ name: "fast", description: "Would shadow builtin", handler: async () => {} },
+				].filter(cmd => !reserved?.has(cmd.name));
+			},
+		};
+
+		await waitForBootstrapGuard();
+
+		const commandUpdates = harness.updates.filter(
+			update =>
+				update.sessionId === created.sessionId && update.update.sessionUpdate === "available_commands_update",
+		);
+		const names = commandUpdates.flatMap(update =>
+			update.update.sessionUpdate === "available_commands_update"
+				? update.update.availableCommands.map(command => command.name)
+				: [],
+		);
+
+		// Extension command must surface.
+		expect(names).toContain("my-ext-cmd");
+		// ACP builtin "fast" must still appear exactly once (not shadowed/duplicated).
+		expect(names.filter(n => n === "fast").length).toBe(1);
+		// Extension command that collided with the builtin must not add a duplicate.
+		// (The builtin "fast" entry wins via the reserved-set exclusion.)
+		const fastEntries = commandUpdates.flatMap(update =>
+			update.update.sessionUpdate === "available_commands_update"
+				? update.update.availableCommands.filter(c => c.name === "fast")
+				: [],
+		);
+		expect(fastEntries.length).toBe(1);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
 	it("executes skill commands through custom skill messages", async () => {
 		const harness = await createHarness();
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });

--- a/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
@@ -128,7 +128,7 @@ function reminderMessages(messages: AgentMessage[]): AgentMessage[] {
 	});
 }
 
-async function expectPromptCompletes(prompt: Promise<void>): Promise<void> {
+async function expectPromptCompletes(prompt: Promise<boolean>): Promise<void> {
 	await Promise.race([
 		prompt,
 		Bun.sleep(1_000).then(() => {

--- a/packages/coding-agent/test/issue-927-repro.test.ts
+++ b/packages/coding-agent/test/issue-927-repro.test.ts
@@ -44,7 +44,7 @@ describe("issue #927 optimistic pending spinner", () => {
 			settings: Settings.isolated(),
 			modelRegistry,
 		});
-		vi.spyOn(session, "prompt").mockResolvedValue(undefined);
+		vi.spyOn(session, "prompt").mockResolvedValue(true);
 		mode = new InteractiveMode(session, "test");
 		mode.addMessageToChat = vi.fn();
 		mode.ui.requestRender = vi.fn();

--- a/packages/coding-agent/test/main-interactive-input.test.ts
+++ b/packages/coding-agent/test/main-interactive-input.test.ts
@@ -21,7 +21,7 @@ describe("submitInteractiveInput", () => {
 			checkShutdownRequested: vi.fn(async () => {}),
 		};
 		const session = {
-			prompt: vi.fn(async () => {}),
+			prompt: vi.fn(async () => true),
 			promptCustomMessage: vi.fn(async () => {}),
 		};
 		const input = createInput({ text: "", started: true });
@@ -42,7 +42,7 @@ describe("submitInteractiveInput", () => {
 			checkShutdownRequested: vi.fn(async () => {}),
 		};
 		const session = {
-			prompt: vi.fn(async () => {}),
+			prompt: vi.fn(async () => true),
 			promptCustomMessage: vi.fn(async () => {}),
 		};
 		const input = createInput();
@@ -63,7 +63,7 @@ describe("submitInteractiveInput", () => {
 			checkShutdownRequested: vi.fn(async () => {}),
 		};
 		const session = {
-			prompt: vi.fn(async () => {}),
+			prompt: vi.fn(async () => true),
 			promptCustomMessage: vi.fn(async () => {}),
 		};
 		const input = createInput({ text: "continue goal", customType: "goal-continuation" });

--- a/packages/coding-agent/test/task/executor-wall-clock.test.ts
+++ b/packages/coding-agent/test/task/executor-wall-clock.test.ts
@@ -41,6 +41,7 @@ function createHangingSession(): HangingSessionHandle {
 		subscribe: (_listener: (event: AgentSessionEvent) => void) => () => {},
 		prompt: async (_text: string, _options?: PromptOptions) => {
 			await hang;
+			return true;
 		},
 		waitForIdle: async () => {
 			await hang;
@@ -140,7 +141,7 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 				});
 				return () => {};
 			},
-			prompt: async () => {},
+			prompt: async () => true,
 			waitForIdle: async () => {},
 			getLastAssistantMessage: () => undefined,
 			abort: async () => {},
@@ -218,6 +219,7 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 			},
 			prompt: async (_text: string, _options?: PromptOptions) => {
 				await hang;
+				return true;
 			},
 			waitForIdle: async () => {
 				await hang;
@@ -294,7 +296,7 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 				});
 				return () => {};
 			},
-			prompt: async () => {},
+			prompt: async () => true,
 			waitForIdle: async () => {},
 			getLastAssistantMessage: () => undefined,
 			abort: async () => {},


### PR DESCRIPTION
## Problem

In `yolo` mode, `#wrapToolForAcpPermission` was still routing all `PERMISSION_REQUIRED_TOOLS` through the ACP permission gate — triggering approval prompts even when no per-tool policy (or an explicit `"allow"`) would have bypassed the normal approval wrapper.

## Fix

Before wrapping the tool in the ACP proxy, check the effective approval decision when `approvalMode === "yolo"`: if no per-tool policy exists or the policy is `"allow"`, return the unwrapped tool. The gate is still engaged when a policy explicitly requires a prompt or deny, matching the behavior of the normal approval wrapper.