### PR TITLE
fix(acp): skip permission gate in yolo mode when effective policy is allow

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- ACP sessions now skip the client permission gate for bash/edit/delete/move when the user explicitly opts into yolo approval mode (`--yolo`/`--auto-approve` or a configured `tools.approvalMode: yolo`) and the effective per-tool policy is "allow"; default-config sessions keep the gate ([#2097](https://github.com/can1357/oh-my-pi/pull/2097) by [@Mokto](https://github.com/Mokto))
+
 ## [15.10.11] - 2026-06-10
 
 ### Added

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -304,6 +304,14 @@ export class Settings {
 	}
 
 	/**
+	 * Whether `path` has an explicitly configured value (global config, project
+	 * config, or runtime override) rather than falling back to the schema default.
+	 */
+	isConfigured(path: SettingPath): boolean {
+		return getByPath(this.#merged, SETTING_PATH_SEGMENTS[path]) !== undefined;
+	}
+
+	/**
 	 * Set a setting value (sync).
 	 * Updates global settings and queues a background save.
 	 * Triggers hooks for settings that have side effects.

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -988,6 +988,10 @@ export async function runRootCommand(
 		// Runtime override (not persisted): every settings.get("tools.approvalMode") downstream
 		// sees this value. The wrapper still honours --auto-approve / --yolo on top of it.
 		settingsInstance.override("tools.approvalMode", parsedArgs.approvalMode);
+	} else if (parsedArgs.autoApprove) {
+		// --auto-approve / --yolo without an explicit --approval-mode: reflect in settings so
+		// setup-time checks (e.g. #wrapToolForAcpPermission) also see the yolo intent.
+		settingsInstance.override("tools.approvalMode", "yolo");
 	}
 	if (parsedArgs.mode === "rpc" || parsedArgs.mode === "rpc-ui") {
 		applyRpcDefaultSettingOverrides(settingsInstance);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3532,6 +3532,8 @@ export class AgentSession {
 	 *
 	 * In `yolo` mode, skips the gate unless the user policy explicitly requires a
 	 * prompt or deny (matching the behaviour of the normal approval wrapper).
+	 * `--auto-approve` / `--yolo` CLI flags also reach here because `main.ts`
+	 * reflects them into a `tools.approvalMode` settings override at startup.
 	 */
 	#wrapToolForAcpPermission<T extends AgentTool>(tool: T): T {
 		const bridge = this.#clientBridge;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3529,12 +3529,23 @@ export class AgentSession {
 	 * Wrap a tool with a permission-gate proxy when an ACP client is connected.
 	 * Only wraps tools whose name is in PERMISSION_REQUIRED_TOOLS and only when
 	 * the bridge exposes `requestPermission`. No-ops for all other cases.
+	 *
+	 * In `yolo` mode, skips the gate unless the user policy explicitly requires a
+	 * prompt or deny (matching the behaviour of the normal approval wrapper).
 	 */
 	#wrapToolForAcpPermission<T extends AgentTool>(tool: T): T {
 		const bridge = this.#clientBridge;
 		// Match the capability+method gating pattern used by read/write/bash.
 		if (!bridge?.capabilities.requestPermission || !bridge.requestPermission) return tool;
 		if (!PERMISSION_REQUIRED_TOOLS.has(tool.name)) return tool;
+		// In yolo mode, honour the user per-tool policy but skip the ACP gate when
+		// the effective decision is "allow" (absent policy or explicit "allow").
+		const approvalMode = (this.settings.get("tools.approvalMode") ?? "yolo") as string;
+		if (approvalMode === "yolo") {
+			const userPolicies = (this.settings.get("tools.approval") ?? {}) as Record<string, unknown>;
+			const toolPolicy = userPolicies[tool.name];
+			if (!toolPolicy || toolPolicy === "allow") return tool;
+		}
 		return new Proxy(tool, {
 			get: (target, prop) => {
 				if (prop !== "execute") return Reflect.get(target, prop, target);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3530,20 +3530,22 @@ export class AgentSession {
 	 * Only wraps tools whose name is in PERMISSION_REQUIRED_TOOLS and only when
 	 * the bridge exposes `requestPermission`. No-ops for all other cases.
 	 *
-	 * In `yolo` mode, skips the gate unless the user policy explicitly requires a
-	 * prompt or deny (matching the behaviour of the normal approval wrapper).
-	 * `--auto-approve` / `--yolo` CLI flags also reach here because `main.ts`
-	 * reflects them into a `tools.approvalMode` settings override at startup.
+	 * When the user has explicitly opted into `yolo` approval mode (via the
+	 * `--yolo` / `--auto-approve` CLI flags — reflected into a
+	 * `tools.approvalMode` settings override by `main.ts` — or a configured
+	 * `tools.approvalMode: yolo`), skips the gate unless the per-tool policy
+	 * explicitly requires a prompt or deny. The schema default is also `yolo`,
+	 * so an explicit configuration is required: default-config ACP sessions
+	 * keep the client-side permission gate.
 	 */
 	#wrapToolForAcpPermission<T extends AgentTool>(tool: T): T {
 		const bridge = this.#clientBridge;
 		// Match the capability+method gating pattern used by read/write/bash.
 		if (!bridge?.capabilities.requestPermission || !bridge.requestPermission) return tool;
 		if (!PERMISSION_REQUIRED_TOOLS.has(tool.name)) return tool;
-		// In yolo mode, honour the user per-tool policy but skip the ACP gate when
-		// the effective decision is "allow" (absent policy or explicit "allow").
-		const approvalMode = (this.settings.get("tools.approvalMode") ?? "yolo") as string;
-		if (approvalMode === "yolo") {
+		// Skip the gate only on explicit yolo opt-in; honour per-tool policies
+		// that require a prompt or deny (matching the normal approval wrapper).
+		if (this.settings.isConfigured("tools.approvalMode") && this.settings.get("tools.approvalMode") === "yolo") {
 			const userPolicies = (this.settings.get("tools.approval") ?? {}) as Record<string, unknown>;
 			const toolPolicy = userPolicies[tool.name];
 			if (!toolPolicy || toolPolicy === "allow") return tool;

--- a/packages/coding-agent/test/agent-session-acp-permission.test.ts
+++ b/packages/coding-agent/test/agent-session-acp-permission.test.ts
@@ -10,7 +10,7 @@ import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
 import { createMockModel, type MockModelOptions } from "@oh-my-pi/pi-ai/providers/mock";
 import { AssistantMessageEventStream } from "@oh-my-pi/pi-ai/utils/event-stream";
 import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
-import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { type SettingPath, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { EditTool } from "@oh-my-pi/pi-coding-agent/edit";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import type {
@@ -72,11 +72,15 @@ function makeBridge(outcome: ClientBridgePermissionOutcome): ClientBridge {
 	};
 }
 
-async function createSession(tools: AgentTool[], bridge?: ClientBridge): Promise<AgentSession> {
+async function createSession(
+	tools: AgentTool[],
+	bridge?: ClientBridge,
+	settingsOverrides: Partial<Record<SettingPath, unknown>> = {},
+): Promise<AgentSession> {
 	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
 	if (!model) throw new Error("Expected claude-sonnet-4-5 model to exist");
 
-	const settings = Settings.isolated({ "compaction.enabled": false });
+	const settings = Settings.isolated({ "compaction.enabled": false, ...settingsOverrides });
 	const sessionManager = SessionManager.inMemory(tempDir.path());
 
 	const agent = new Agent({
@@ -156,6 +160,41 @@ it("allow_once: calls bridge once and executes the underlying tool", async () =>
 
 	await session.setActiveToolsByName(["bash"]);
 	// Get the wrapped tool from the agent's active set.
+	const wrappedBash = session.agent.state.tools.find(t => t.name === "bash");
+	expect(wrappedBash).toBeDefined();
+
+	await wrappedBash!.execute("call-1", { command: "echo hi" }, undefined, undefined as never, undefined as never);
+
+	expect(permissionSpy).toHaveBeenCalledTimes(1);
+	expect(bashTool.executeCalls).toBe(1);
+});
+
+it("explicit yolo approval mode skips the ACP permission gate", async () => {
+	const bashTool = makeFakeTool("bash");
+	const bridge = makeBridge({ outcome: "selected", optionId: "allow_once", kind: "allow_once" });
+	const permissionSpy = spyOn(bridge, "requestPermission");
+	session = await createSession([bashTool], bridge, { "tools.approvalMode": "yolo" });
+
+	await session.setActiveToolsByName(["bash"]);
+	const wrappedBash = session.agent.state.tools.find(t => t.name === "bash");
+	expect(wrappedBash).toBeDefined();
+
+	await wrappedBash!.execute("call-1", { command: "echo hi" }, undefined, undefined as never, undefined as never);
+
+	expect(permissionSpy).not.toHaveBeenCalled();
+	expect(bashTool.executeCalls).toBe(1);
+});
+
+it("explicit yolo still gates tools whose per-tool policy requires a prompt", async () => {
+	const bashTool = makeFakeTool("bash");
+	const bridge = makeBridge({ outcome: "selected", optionId: "allow_once", kind: "allow_once" });
+	const permissionSpy = spyOn(bridge, "requestPermission");
+	session = await createSession([bashTool], bridge, {
+		"tools.approvalMode": "yolo",
+		"tools.approval": { bash: "prompt" },
+	});
+
+	await session.setActiveToolsByName(["bash"]);
 	const wrappedBash = session.agent.state.tools.find(t => t.name === "bash");
 	expect(wrappedBash).toBeDefined();
 


### PR DESCRIPTION
## Problem

In `yolo` mode, `#wrapToolForAcpPermission` was still routing all `PERMISSION_REQUIRED_TOOLS` through the ACP permission gate — triggering approval prompts even when no per-tool policy (or an explicit `"allow"`) would have bypassed the normal approval wrapper.

## Fix

Before wrapping the tool in the ACP proxy, check the effective approval decision when `approvalMode === "yolo"`: if no per-tool policy exists or the policy is `"allow"`, return the unwrapped tool. The gate is still engaged when a policy explicitly requires a prompt or deny, matching the behavior of the normal approval wrapper.