### PR TITLE
feat(tui): add experimental app viewport renderer

### DIFF
--- a/packages/coding-agent/src/modes/components/transcript-container.ts
+++ b/packages/coding-agent/src/modes/components/transcript-container.ts
@@ -1,4 +1,5 @@
 import {
+	type AppViewportScrollRegion,
 	type Component,
 	Container,
 	type NativeScrollbackCommittedRows,
@@ -418,7 +419,12 @@ function deriveLiveCommitState(
  */
 export class TranscriptContainer
 	extends Container
-	implements NativeScrollbackLiveRegion, NativeScrollbackCommittedRows, RenderStablePrefix, ViewportTailProvider
+	implements
+		NativeScrollbackLiveRegion,
+		NativeScrollbackCommittedRows,
+		AppViewportScrollRegion,
+		RenderStablePrefix,
+		ViewportTailProvider
 {
 	// Bumped to retire every block's diff snapshot at once (theme change /
 	// clear); a snapshot is only honored when its stored generation matches.
@@ -489,6 +495,14 @@ export class TranscriptContainer
 
 	getNativeScrollbackSnapshotSafeEnd(): number | undefined {
 		return this.#nativeScrollbackSnapshotSafeEnd;
+	}
+
+	getAppViewportScrollRegionStart(): number | undefined {
+		return 0;
+	}
+
+	getAppViewportScrollRegionEnd(): number | undefined {
+		return undefined;
 	}
 
 	/**

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -83,6 +83,10 @@ const MOUSE_TRACKING_ON = "\x1b[?1000h\x1b[?1003h\x1b[?1006h";
 const MOUSE_TRACKING_OFF = "\x1b[?1006l\x1b[?1003l\x1b[?1000l";
 const ALT_SCREEN_ENTER = "\x1b[?1049h";
 const ALT_SCREEN_EXIT = "\x1b[?1049l";
+const APP_VIEWPORT_MOUSE_TRACKING_ON = "\x1b[?1000h\x1b[?1006h";
+const APP_VIEWPORT_MOUSE_TRACKING_OFF = "\x1b[?1006l\x1b[?1000l";
+const APP_VIEWPORT_SCROLLBAR_DOTS = [0x08, 0x10, 0x20, 0x80] as const;
+const APP_VIEWPORT_SCROLLBAR_BLANK = " ";
 
 type InputListenerResult = { consume?: boolean; data?: string } | undefined;
 type InputListener = (data: string) => InputListenerResult;
@@ -229,6 +233,24 @@ export interface NativeScrollbackCommittedRows {
 
 function setNativeScrollbackCommittedRows(component: Component, rows: number): void {
 	(component as Component & Partial<NativeScrollbackCommittedRows>).setNativeScrollbackCommittedRows?.(rows);
+}
+
+/**
+ * Optional experimental app-owned transcript viewport seam. Components that
+ * implement it identify the root-line range that may scroll inside the app
+ * frame; siblings below that range are rendered as sticky chrome.
+ */
+export interface AppViewportScrollRegion {
+	getAppViewportScrollRegionStart(): number | undefined;
+	getAppViewportScrollRegionEnd(): number | undefined;
+}
+
+function getAppViewportScrollRegionStart(component: Component): number | undefined {
+	return (component as Component & Partial<AppViewportScrollRegion>).getAppViewportScrollRegionStart?.();
+}
+
+function getAppViewportScrollRegionEnd(component: Component): number | undefined {
+	return (component as Component & Partial<AppViewportScrollRegion>).getAppViewportScrollRegionEnd?.();
 }
 
 function isOverlayFocusTarget(owner: Component, component: Component | null): boolean {
@@ -1019,6 +1041,13 @@ export class TUI extends Container {
 	// pushing wrapped fragments into native scrollback.
 	#resizeAltActive = false;
 	#stopped = false;
+	#appViewportBackend = Bun.env.PI_TUI_RENDER_BACKEND === "app-viewport";
+	#appViewportActive = false;
+	#appViewportPreviousLines: string[] = [];
+	#appViewportPreviousWidth = 0;
+	#appViewportScrollRegionEnd: number | undefined;
+	#appViewportScrollTop = 0;
+	#appViewportFollow = true;
 	// Always-on event-loop lag probe. The high default threshold keeps it quiet;
 	// it only logs `ui.loop-blocked` (with the current loop phase) when a frame
 	// budget is genuinely starved. Armed in start(), disarmed in stop().
@@ -1029,6 +1058,7 @@ export class TUI extends Container {
 	// normal-screen accounting field (#previousFrameLength, #viewportTopRow, …)
 	// untouched, so exiting reconciles cleanly against the terminal-restored
 	// normal screen. #altPreviousLines is the last alt frame, for repaint-skip.
+	// Disabled when the main app-viewport backend owns the alternate screen.
 	#altActive = false;
 	#altPreviousLines: string[] = [];
 	#altEnterWidth = 0;
@@ -1095,6 +1125,7 @@ export class TUI extends Container {
 		this.#nativeScrollbackLiveRegionStart = undefined;
 		this.#nativeScrollbackCommitSafeEnd = undefined;
 		this.#nativeScrollbackSnapshotSafeEnd = undefined;
+		this.#appViewportScrollRegionEnd = undefined;
 		const children = this.children;
 		const previousSegments = this.#frameSegments;
 		const segments: FrameSegment[] = new Array(children.length);
@@ -1174,6 +1205,18 @@ export class TUI extends Container {
 				if (snapshotLocalEnd !== undefined) {
 					this.#nativeScrollbackSnapshotSafeEnd = offset + snapshotLocalEnd;
 				}
+			}
+			const appScrollStart = getAppViewportScrollRegionStart(child);
+			if (appScrollStart !== undefined) {
+				const boundedStart = Number.isFinite(appScrollStart)
+					? Math.max(0, Math.min(childLines.length, Math.trunc(appScrollStart)))
+					: 0;
+				const appScrollEnd = getAppViewportScrollRegionEnd(child);
+				const boundedEnd =
+					appScrollEnd !== undefined && Number.isFinite(appScrollEnd)
+						? Math.max(boundedStart, Math.min(childLines.length, Math.trunc(appScrollEnd)))
+						: childLines.length;
+				this.#appViewportScrollRegionEnd = offset + boundedEnd;
 			}
 			if (chainStable) {
 				if (previous !== undefined && previous.component === child && previous.start === offset) {
@@ -1686,9 +1729,24 @@ export class TUI extends Container {
 		this.#cursorEndSequence = enabled ? CURSOR_END : CURSOR_END_NO_SYNC;
 	}
 
+	#enterAppViewport(): void {
+		if (this.#appViewportActive) return;
+		this.terminal.write(`\x1b[?1049h${APP_VIEWPORT_MOUSE_TRACKING_ON}`);
+		this.terminal.hideCursor();
+		this.#appViewportActive = true;
+		this.#appViewportPreviousLines = [];
+		this.#appViewportPreviousWidth = 0;
+	}
 	stop(): void {
+		if (this.#appViewportActive) {
+			this.terminal.write(`${APP_VIEWPORT_MOUSE_TRACKING_OFF}\x1b[?1049l`);
+			this.#appViewportActive = false;
+			this.#previousWindow = [];
+			this.#appViewportPreviousLines = [];
+			this.#appViewportPreviousWidth = 0;
+		}
 		// Leave the alt buffer first so the teardown cursor math below runs against
-		// the restored normal screen (which #previousLines still describes).
+		// the restored normal screen (which #previousWindow still describes).
 		if (this.#resizeAltActive) {
 			this.terminal.write(this.#leaveResizeAltSequence());
 		}
@@ -2075,6 +2133,60 @@ export class TUI extends Container {
 		}, delay);
 	}
 
+	#handleAppViewportInput(data: string): boolean {
+		if (!this.#appViewportBackend || this.hasOverlay()) return false;
+		if (data.startsWith("\x1b[<")) {
+			return this.#handleAppViewportMouse(data);
+		}
+		const page = Math.max(1, this.terminal.rows - 2);
+		if (matchesKey(data, "pageUp") || matchesKey(data, "alt+pageUp")) {
+			this.#scrollAppViewport(-page);
+			return true;
+		}
+		if (matchesKey(data, "pageDown") || matchesKey(data, "alt+pageDown")) {
+			this.#scrollAppViewport(page);
+			return true;
+		}
+		// Plain Home/End are editor line navigation; keep transcript absolute jumps
+		// on Alt+Home/Alt+End for this hidden backend demo.
+		if (matchesKey(data, "alt+home")) {
+			this.#scrollAppViewportToTop();
+			return true;
+		}
+		if (matchesKey(data, "alt+end")) {
+			this.#scrollAppViewportToBottom();
+			return true;
+		}
+		return false;
+	}
+
+	#handleAppViewportMouse(data: string): boolean {
+		const match = /^\x1b\[<(\d+);\d+;\d+([Mm])$/.exec(data);
+		if (!match) return true;
+		const button = Number(match[1]);
+		if (button & 64) {
+			this.#scrollAppViewport(button & 1 ? 3 : -3);
+		}
+		return true;
+	}
+
+	#scrollAppViewport(delta: number): void {
+		this.#appViewportScrollTop = Math.max(0, this.#appViewportScrollTop + delta);
+		this.#appViewportFollow = false;
+		this.requestRender(true);
+	}
+
+	#scrollAppViewportToTop(): void {
+		this.#appViewportScrollTop = 0;
+		this.#appViewportFollow = false;
+		this.requestRender(true);
+	}
+
+	#scrollAppViewportToBottom(): void {
+		this.#appViewportFollow = true;
+		this.requestRender(true);
+	}
+
 	#handleInput(data: string): void {
 		if (this.#inputListeners.size > 0) {
 			let current = data;
@@ -2104,6 +2216,7 @@ export class TUI extends Container {
 			return;
 		}
 
+		if (this.#handleAppViewportInput(data)) return;
 		// If focused component is an overlay, verify it's still visible
 		// (visibility can change due to terminal resize or visible() callback)
 		const focusedOverlay = this.overlayStack.find(o => o.component === this.#focusedComponent);
@@ -2368,6 +2481,7 @@ export class TUI extends Container {
 		if (resultWidth <= totalWidth) {
 			return result;
 		}
+
 		// Truncate with strict=true to ensure we don't exceed totalWidth
 		return sliceByColumn(result, 0, totalWidth, true);
 	}
@@ -2421,6 +2535,11 @@ export class TUI extends Container {
 		// requests made up to this frame, whichever path the frame takes.
 		const componentScopedOnly = this.#pendingRenderComponentsOnly;
 		this.#pendingRenderComponentsOnly = false;
+
+		if (this.#appViewportBackend) {
+			this.#renderAppViewportFrame(width, height);
+			return;
+		}
 
 		// Fullscreen alt-screen short-circuit. While the topmost visible overlay
 		// requests it, borrow the terminal's alternate buffer and paint only the
@@ -3259,6 +3378,173 @@ export class TUI extends Container {
 		this.terminal.write(buffer);
 	}
 
+	#renderAppViewportFrame(width: number, height: number): void {
+		this.#enterAppViewport();
+		this.#imageBudget.beginPass();
+		const contentWidth = Math.max(1, width - 1);
+		const rawFrame = this.render(contentWidth);
+		if (this.#imageBudget.endPass()) {
+			this.#clearScrollbackOnNextRender = true;
+			this.#appViewportPreviousLines = [];
+		}
+		if (this.#maybeDeferGhosttyInitialImagePaint()) return;
+
+		let cursorPos: { row: number; col: number } | null = null;
+		const cursorMarkers = this.#frameCursorMarkers;
+		if (cursorMarkers.length > 0) cursorPos = cursorMarkers[cursorMarkers.length - 1]!;
+		const frame = this.#prepareFrame(rawFrame, contentWidth);
+		const imageTransmits = this.#imageBudget.takeTransmits();
+		if (imageTransmits.length > 0) {
+			let transmitBuffer = "";
+			for (const seq of imageTransmits) transmitBuffer += seq;
+			this.terminal.write(transmitBuffer);
+		}
+		this.#emitAppViewportFrame(frame, width, height, cursorPos);
+		this.#clearScrollbackOnNextRender = false;
+		this.#hasEverRendered = true;
+	}
+
+	#emitAppViewportFrame(
+		lines: string[],
+		width: number,
+		height: number,
+		cursorPos: { row: number; col: number } | null,
+	): void {
+		let fitted = this.#buildAppViewportLines(lines, width, height);
+		let fittedCursorPos = this.#appViewportCursorPosition(cursorPos, lines.length, height);
+		let hasVisibleOverlay = false;
+		for (const entry of this.overlayStack) {
+			if (this.#isOverlayVisible(entry)) {
+				hasVisibleOverlay = true;
+				break;
+			}
+		}
+		if (hasVisibleOverlay) {
+			fitted = this.#compositeOverlaysIntoWindow(fitted, width, height);
+			const overlayMarkers = this.#extractCursorMarkers(fitted);
+			if (overlayMarkers.length > 0) fittedCursorPos = overlayMarkers[0]!;
+			fitted = this.#prepareLinesArray(fitted, width);
+		}
+		if (this.#appViewportPreviousWidth === width && this.#appViewportPreviousLines.length === height) {
+			let same = true;
+			for (let r = 0; r < height; r++) {
+				if (fitted[r] !== this.#appViewportPreviousLines[r]) {
+					same = false;
+					break;
+				}
+			}
+			if (same) {
+				this.#writeAppViewportCursor(fittedCursorPos, height);
+				return;
+			}
+		}
+		this.#fullRedrawCount += 1;
+		let buffer = `${this.#paintBeginSequence}\x1b[H`;
+		const purgeIds = this.#imageBudget.takePurgeIds();
+		if (TERMINAL.imageProtocol === ImageProtocol.Kitty) {
+			for (const id of purgeIds) buffer += encodeKittyDeleteImage(id);
+		}
+		for (let r = 0; r < height; r++) {
+			if (r > 0) buffer += "\r\n";
+			buffer += this.#lineRewriteSequence(fitted[r] ?? "", width);
+		}
+		const cursorControl = this.#cursorControlSequence(fittedCursorPos, height, Math.max(0, height - 1));
+		buffer += cursorControl.seq;
+		buffer += this.#paintEndSequence;
+		this.terminal.write(buffer);
+		this.#appViewportPreviousLines = fitted;
+		this.#appViewportPreviousWidth = width;
+		this.#commit(lines, fitted, width, height, cursorControl);
+	}
+
+	#writeAppViewportCursor(cursorPos: { row: number; col: number } | null, height: number): void {
+		const cursorControl = this.#cursorControlSequence(cursorPos, height, this.#hardwareCursorRow);
+		this.#recordHardwareCursorUpdate(cursorControl);
+		this.terminal.write(`${this.#cursorBeginSequence}${cursorControl.seq}${this.#cursorEndSequence}`);
+	}
+
+	#appViewportCursorPosition(
+		cursorPos: { row: number; col: number } | null,
+		totalLines: number,
+		height: number,
+	): { row: number; col: number } | null {
+		if (!cursorPos) return null;
+		const scrollEnd = this.#appViewportScrollRegionEnd ?? totalLines;
+		const boundedScrollEnd = Math.max(0, Math.min(scrollEnd, totalLines));
+		const suffixCount = Math.max(0, Math.min(totalLines - boundedScrollEnd, height));
+		const scrollHeight = Math.max(0, height - suffixCount);
+		if (cursorPos.row >= boundedScrollEnd) {
+			const suffixRow = cursorPos.row - boundedScrollEnd;
+			if (suffixRow >= suffixCount) return null;
+			return { row: height - suffixCount + suffixRow, col: cursorPos.col };
+		}
+		if (cursorPos.row < this.#appViewportScrollTop || cursorPos.row >= this.#appViewportScrollTop + scrollHeight) {
+			return null;
+		}
+		return { row: cursorPos.row - this.#appViewportScrollTop, col: cursorPos.col };
+	}
+
+	#buildAppViewportLines(lines: string[], width: number, height: number): string[] {
+		const fitted: string[] = new Array(Math.max(0, height)).fill("");
+		const scrollEnd = this.#appViewportScrollRegionEnd ?? lines.length;
+		const boundedScrollEnd = Math.max(0, Math.min(scrollEnd, lines.length));
+		const suffixCount = Math.max(0, Math.min(lines.length - boundedScrollEnd, height));
+		const scrollHeight = Math.max(0, height - suffixCount);
+		const maxTop = Math.max(0, boundedScrollEnd - scrollHeight);
+		if (this.#appViewportFollow) {
+			this.#appViewportScrollTop = maxTop;
+		} else {
+			this.#appViewportScrollTop = Math.max(0, Math.min(this.#appViewportScrollTop, maxTop));
+			if (this.#appViewportScrollTop >= maxTop) this.#appViewportFollow = true;
+		}
+		for (let row = 0; row < scrollHeight; row++) {
+			const sourceRow = this.#appViewportScrollTop + row;
+			fitted[row] = sourceRow < boundedScrollEnd ? (lines[sourceRow] ?? "") : "";
+		}
+		this.#applyAppViewportScrollbar(fitted, width, scrollHeight, boundedScrollEnd, maxTop);
+		const suffixStart = height - suffixCount;
+		for (let i = 0; i < suffixCount; i++) fitted[suffixStart + i] = lines[boundedScrollEnd + i] ?? "";
+		return fitted;
+	}
+
+	#applyAppViewportScrollbar(
+		lines: string[],
+		width: number,
+		scrollHeight: number,
+		totalRows: number,
+		maxTop: number,
+	): void {
+		if (width <= 0 || scrollHeight <= 0 || totalRows <= scrollHeight) return;
+		const slotsPerRow = APP_VIEWPORT_SCROLLBAR_DOTS.length;
+		const totalSlots = scrollHeight * slotsPerRow;
+		const proportionalThumbSlots = Math.floor((totalSlots * scrollHeight) / totalRows);
+		const minThumbSlots = Math.min(slotsPerRow, totalSlots);
+		const thumbSlots = Math.max(minThumbSlots, Math.min(proportionalThumbSlots, totalSlots));
+		const travelSlots = totalSlots - thumbSlots;
+		const thumbStart = maxTop === 0 ? 0 : Math.round((this.#appViewportScrollTop / maxTop) * travelSlots);
+		const thumbEnd = thumbStart + thumbSlots;
+		const contentWidth = Math.max(0, width - 1);
+		for (let row = 0; row < scrollHeight; row++) {
+			const line = lines[row] ?? "";
+			if (TERMINAL.isImageLine(line)) continue;
+			const content = sliceByColumn(line, 0, contentWidth, true);
+			const pad = " ".repeat(Math.max(0, contentWidth - visibleWidth(content)));
+			const glyph = this.#appViewportScrollbarGlyph(row, slotsPerRow, thumbStart, thumbEnd);
+			lines[row] = `${content}${pad}${LINE_TERMINATOR}${glyph}`;
+		}
+	}
+
+	#appViewportScrollbarGlyph(row: number, slotsPerRow: number, thumbStart: number, thumbEnd: number): string {
+		let mask = 0;
+		const rowStart = row * slotsPerRow;
+		for (let slot = 0; slot < slotsPerRow; slot++) {
+			const absoluteSlot = rowStart + slot;
+			if (absoluteSlot >= thumbStart && absoluteSlot < thumbEnd) mask |= APP_VIEWPORT_SCROLLBAR_DOTS[slot] ?? 0;
+		}
+		return mask === 0
+			? APP_VIEWPORT_SCROLLBAR_BLANK
+			: `\x1b[2m${String.fromCodePoint(0x2800 | mask)}${SEGMENT_RESET}`;
+	}
 	/** Topmost visible overlay requests the alternate-screen buffer. */
 	#wantsAltScreen(): boolean {
 		for (let i = this.overlayStack.length - 1; i >= 0; i--) {

--- a/packages/tui/test/app-viewport-stress.test.ts
+++ b/packages/tui/test/app-viewport-stress.test.ts
@@ -1,0 +1,14 @@
+import { describe, it } from "bun:test";
+import { buildAppViewportScenarios, runStressScenario } from "./render-stress-harness";
+
+describe("TUI app viewport stress harness", () => {
+	for (const scenario of buildAppViewportScenarios()) {
+		it(
+			`${scenario.name} seed=${scenario.seed.toString(16)}`,
+			async () => {
+				await runStressScenario(scenario);
+			},
+			scenario.timeoutMs,
+		);
+	}
+});

--- a/packages/tui/test/app-viewport.test.ts
+++ b/packages/tui/test/app-viewport.test.ts
@@ -1,0 +1,251 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { type AppViewportScrollRegion, type Component, CURSOR_MARKER, type Focusable, TUI } from "@oh-my-pi/pi-tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+class TranscriptComponent implements Component, AppViewportScrollRegion {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = [...lines];
+	}
+
+	append(line: string): void {
+		this.#lines.push(line);
+	}
+
+	invalidate(): void {
+		// No cached state.
+	}
+
+	getAppViewportScrollRegionStart(): number | undefined {
+		return 0;
+	}
+
+	getAppViewportScrollRegionEnd(): number | undefined {
+		return this.#lines.length;
+	}
+
+	render(_width: number): string[] {
+		return [...this.#lines];
+	}
+}
+
+class StaticLines implements Component {
+	constructor(private readonly lines: string[]) {}
+
+	invalidate(): void {
+		// No cached state.
+	}
+
+	render(_width: number): string[] {
+		return [...this.lines];
+	}
+}
+
+class WidthFill implements Component {
+	invalidate(): void {
+		// No cached state.
+	}
+
+	render(width: number): string[] {
+		return ["A".repeat(width)];
+	}
+}
+
+class CursorLine implements Component, Focusable {
+	focused = false;
+
+	invalidate(): void {
+		// No cached state.
+	}
+
+	render(): string[] {
+		return [`prompt>${this.focused ? CURSOR_MARKER : ""}`];
+	}
+}
+
+function captureWrites(term: VirtualTerminal): string[] {
+	const writes: string[] = [];
+	const realWrite = term.write.bind(term);
+	vi.spyOn(term, "write").mockImplementation((data: string) => {
+		writes.push(data);
+		realWrite(data);
+	});
+	return writes;
+}
+
+async function flushRender(term: VirtualTerminal): Promise<void> {
+	const nextTick = Promise.withResolvers<void>();
+	process.nextTick(nextTick.resolve);
+	await nextTick.promise;
+	await Bun.sleep(1);
+	await term.flush();
+}
+
+async function withEnv(name: string, value: string, run: () => Promise<void>): Promise<void> {
+	const previous = Bun.env[name];
+	Bun.env[name] = value;
+	try {
+		await run();
+	} finally {
+		if (previous === undefined) {
+			delete Bun.env[name];
+		} else {
+			Bun.env[name] = previous;
+		}
+	}
+}
+
+function viewportContent(term: VirtualTerminal): string[] {
+	return term.getViewport().map(line => line.replace(/[ \t]*[\u2800-\u28ff]?$/, "").trim());
+}
+
+function viewportScrollbarRows(term: VirtualTerminal): number[] {
+	const rows: number[] = [];
+	const viewport = term.getViewport();
+	for (let row = 0; row < viewport.length; row++) {
+		const code = viewport[row]?.trimEnd().codePointAt((viewport[row]?.trimEnd().length ?? 1) - 1) ?? 0;
+		if (code >= 0x2800 && code <= 0x28ff) rows.push(row);
+	}
+	return rows;
+}
+
+describe("TUI app viewport backend", () => {
+	it("keeps transcript app-scrolled and sticky chrome fixed without ED3 frames", async () => {
+		await withEnv("PI_TUI_RENDER_BACKEND", "app-viewport", async () => {
+			const term = new VirtualTerminal(40, 5);
+			const writes = captureWrites(term);
+			const transcript = new TranscriptComponent(Array.from({ length: 10 }, (_value, index) => `row-${index}`));
+			const tui = new TUI(term);
+			tui.addChild(transcript);
+			tui.addChild(new StaticLines(["status", "editor"]));
+
+			let stopped = false;
+			try {
+				tui.start();
+				await flushRender(term);
+
+				expect(writes.join("")).toContain("\x1b[?1049h");
+				expect(writes.join("")).not.toContain("\x1b[3J");
+				expect(viewportContent(term)).toEqual(["row-7", "row-8", "row-9", "status", "editor"]);
+				expect(viewportScrollbarRows(term)).toEqual([2]);
+
+				expect(writes.join("")).toContain("\x1b[?1000h\x1b[?1006h");
+				term.sendInput("\x1b[<64;1;1M");
+				await flushRender(term);
+				expect(viewportContent(term)).toEqual(["row-4", "row-5", "row-6", "status", "editor"]);
+				expect(viewportScrollbarRows(term)).toEqual([1, 2]);
+
+				term.sendInput("\x1b[<65;1;1M");
+				await flushRender(term);
+				expect(viewportContent(term)).toEqual(["row-7", "row-8", "row-9", "status", "editor"]);
+				expect(viewportScrollbarRows(term)).toEqual([2]);
+
+				term.sendInput("\x1b[5~");
+				await flushRender(term);
+				expect(viewportContent(term)).toEqual(["row-4", "row-5", "row-6", "status", "editor"]);
+
+				transcript.append("row-10");
+				transcript.append("row-11");
+				tui.requestRender(true);
+				await flushRender(term);
+				expect(viewportContent(term)).toEqual(["row-4", "row-5", "row-6", "status", "editor"]);
+
+				term.sendInput("\x1b[6~");
+				term.sendInput("\x1b[6~");
+				await flushRender(term);
+				expect(viewportContent(term)).toEqual(["row-9", "row-10", "row-11", "status", "editor"]);
+
+				transcript.append("row-12");
+				tui.requestRender(true);
+				await flushRender(term);
+				expect(viewportContent(term)).toEqual(["row-10", "row-11", "row-12", "status", "editor"]);
+
+				expect(writes.join("")).not.toContain("\x1b[3J");
+
+				tui.stop();
+				stopped = true;
+				expect(writes.join("")).toContain("\x1b[?1049l");
+			} finally {
+				if (!stopped) tui.stop();
+			}
+		});
+	});
+
+	it("does not duplicate sticky chrome when transcript is shorter than the viewport", async () => {
+		await withEnv("PI_TUI_RENDER_BACKEND", "app-viewport", async () => {
+			const term = new VirtualTerminal(40, 8);
+			const transcript = new TranscriptComponent(["short"]);
+			const tui = new TUI(term);
+			tui.addChild(transcript);
+			tui.addChild(new StaticLines(["status", "editor"]));
+
+			try {
+				tui.start();
+				await flushRender(term);
+				expect(viewportContent(term)).toEqual(["short", "", "", "", "", "", "status", "editor"]);
+			} finally {
+				tui.stop();
+			}
+		});
+	});
+
+	it("reserves one content column for the scrollbar", async () => {
+		await withEnv("PI_TUI_RENDER_BACKEND", "app-viewport", async () => {
+			const term = new VirtualTerminal(8, 3);
+			const tui = new TUI(term);
+			tui.addChild(new TranscriptComponent(["row-0", "row-1", "row-2", "row-3", "row-4"]));
+			tui.addChild(new WidthFill());
+
+			try {
+				tui.start();
+				await flushRender(term);
+				expect(viewportContent(term)).toEqual(["row-3", "row-4", "AAAAAAA"]);
+			} finally {
+				tui.stop();
+			}
+		});
+	});
+	it("positions the hardware cursor in sticky chrome", async () => {
+		await withEnv("PI_TUI_RENDER_BACKEND", "app-viewport", async () => {
+			const term = new VirtualTerminal(40, 5);
+			const writes = captureWrites(term);
+			const tui = new TUI(term, true);
+			const cursor = new CursorLine();
+			tui.addChild(new TranscriptComponent(["row-0", "row-1", "row-2", "row-3"]));
+			tui.addChild(cursor);
+			tui.setFocus(cursor);
+
+			try {
+				tui.start();
+				await flushRender(term);
+				expect(viewportContent(term)).toEqual(["row-0", "row-1", "row-2", "row-3", "prompt>"]);
+				expect(term.getCursor()).toEqual({ row: 4, col: 7 });
+				expect(writes.join("")).toContain("\x1b[?25h");
+			} finally {
+				tui.stop();
+			}
+		});
+	});
+
+	it("stays on the native renderer unless the app viewport backend is requested", async () => {
+		await withEnv("PI_TUI_RENDER_BACKEND", "", async () => {
+			const term = new VirtualTerminal(40, 5);
+			const writes = captureWrites(term);
+			const tui = new TUI(term);
+			tui.addChild(new StaticLines(["one", "two"]));
+
+			try {
+				tui.start();
+				await flushRender(term);
+				expect(writes.join("")).not.toContain("\x1b[?1049h");
+			} finally {
+				tui.stop();
+			}
+		});
+	});
+});

--- a/packages/tui/test/render-stress-harness.ts
+++ b/packages/tui/test/render-stress-harness.ts
@@ -55,7 +55,8 @@ export type ScenarioTag =
 	| "strictScrollback"
 	| "unknownViewport"
 	| "foregroundStream"
-	| "ed3Risk";
+	| "ed3Risk"
+	| "appViewport";
 const ENV_KEYS = [
 	"TMUX",
 	"STY",
@@ -78,6 +79,7 @@ type JsonPrimitive = string | number | boolean | null;
 type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
 type JsonObject = { [key: string]: JsonValue };
 
+type RenderBackend = "native" | "app-viewport";
 export type OperationKind =
 	| "appendSmall"
 	| "appendExactWidth"
@@ -279,6 +281,7 @@ export interface Scenario {
 	// real Ghostty-backed terminal's cell widths.
 	reflow: boolean;
 	tags: readonly ScenarioTag[];
+	renderBackend: RenderBackend;
 	replayOperations?: readonly OperationKind[];
 }
 
@@ -582,6 +585,7 @@ function scenarioTags(
 	template: Pick<Scenario, "envMode" | "terminalMode" | "geometryMode">,
 	strictNativeScrollback: boolean,
 	foregroundStreaming: boolean,
+	renderBackend: RenderBackend,
 ): readonly ScenarioTag[] {
 	const tags: ScenarioTag[] = [template.geometryMode];
 	if (template.envMode === "tmux") tags.push("tmux");
@@ -589,6 +593,7 @@ function scenarioTags(
 	if (template.terminalMode !== "normal") tags.push("unknownViewport");
 	if (foregroundStreaming) tags.push("foregroundStream");
 	if (isEd3RiskScenario(template.terminalMode, template.envMode)) tags.push("ed3Risk");
+	if (renderBackend === "app-viewport") tags.push("appViewport");
 	return tags;
 }
 
@@ -1157,6 +1162,7 @@ class StressDriver {
 	// boundary and never go out of {0,1}.
 	#syncDepth = 0;
 	#autowrapOffDepth = 0;
+	#appViewportWriteLogScanned = 0;
 
 	constructor(scenario: Scenario) {
 		this.#scenario = scenario;
@@ -1325,9 +1331,10 @@ class StressDriver {
 	#expectedFrame(): ExpectedFrame {
 		const width = this.#term.columns;
 		const height = this.#term.rows;
-		const baseLines = this.#baseFrameLines(width);
+		const contentWidth = this.#scenario.renderBackend === "app-viewport" ? Math.max(1, width - 1) : width;
+		const baseLines = this.#baseFrameLines(contentWidth);
 		const composed = compositeExpectedOverlays(baseLines, this.#overlays, width, height);
-		return expectedFrameFromLines(composed, width, height);
+		return expectedFrameFromLines(composed, contentWidth, height);
 	}
 
 	#baseFrameLines(width: number): string[] {
@@ -2135,6 +2142,12 @@ class StressDriver {
 		});
 	}
 	#assertOracles(op: AppliedOperation, before: Snapshot, after: Snapshot, index: number): void {
+		if (this.#scenario.renderBackend === "app-viewport") {
+			this.#assertSyncOutputDiscipline(op, before, after, index);
+			this.#assertAppViewportNoEd3(op, before, after, index);
+			this.#assertAppViewportGridBounded(op, before, after, index);
+			return;
+		}
 		this.#assertSyncOutputDiscipline(op, before, after, index);
 		this.#assertTapeScrollParity(op, before, after, index);
 		this.#assertViewportFidelity(op, before, after, index);
@@ -2180,6 +2193,28 @@ class StressDriver {
 			this.#fail("tape/physical scroll parity", op, before, after, index, {
 				physicalDelta,
 				tapeDelta,
+			});
+		}
+	}
+
+	#assertAppViewportNoEd3(op: AppliedOperation, before: Snapshot, after: Snapshot, index: number): void {
+		for (; this.#appViewportWriteLogScanned < this.#writeLog.length; this.#appViewportWriteLogScanned++) {
+			const data = this.#writeLog[this.#appViewportWriteLogScanned]!;
+			if (data.includes("\x1b[3J")) this.#fail("app viewport emitted ED3", op, before, after, index, {});
+		}
+	}
+
+	#assertAppViewportGridBounded(op: AppliedOperation, before: Snapshot, after: Snapshot, index: number): void {
+		if (after.position.baseY !== 0 || after.position.viewportY !== 0) {
+			this.#fail("app viewport mutated terminal scrollback", op, before, after, index, {
+				baseY: after.position.baseY,
+				viewportY: after.position.viewportY,
+			});
+		}
+		if (after.buffer.length > after.height) {
+			this.#fail("app viewport buffer exceeded visible grid", op, before, after, index, {
+				bufferLength: after.buffer.length,
+				height: after.height,
 			});
 		}
 	}
@@ -3415,6 +3450,71 @@ export function buildScenarios(): Scenario[] {
 	return scenarios;
 }
 
+export function buildAppViewportScenarios(): Scenario[] {
+	const iterations = parsePositiveInt("TUI_APP_VIEWPORT_STRESS_ITER", 40);
+	const timeoutMs = parsePositiveInt("TUI_APP_VIEWPORT_STRESS_TIMEOUT_MS", 30_000);
+	const templates: ScenarioTemplate[] = [
+		{
+			name: "app-viewport-linux-normal-small",
+			platform: "linux",
+			terminalMode: "normal",
+			envMode: "plain",
+			geometryMode: "small",
+			columns: 40,
+			rows: 6,
+			widthChoices: [10, 18, 32, 40],
+			heightChoices: [3, 4, 6],
+			renderBackend: "app-viewport",
+		},
+		{
+			name: "app-viewport-win32-unknown-small",
+			platform: "win32",
+			terminalMode: "unknown",
+			envMode: "plain",
+			geometryMode: "small",
+			columns: 32,
+			rows: 4,
+			widthChoices: [10, 16, 32],
+			heightChoices: [3, 4, 6],
+			renderBackend: "app-viewport",
+		},
+		{
+			name: "app-viewport-linux-unknown-wsl-small",
+			platform: "linux",
+			terminalMode: "unknown",
+			envMode: "wsl",
+			geometryMode: "small",
+			columns: 32,
+			rows: 4,
+			widthChoices: [10, 16, 32],
+			heightChoices: [3, 4, 6],
+			renderBackend: "app-viewport",
+		},
+		{
+			name: "app-viewport-darwin-normal-tmux-small",
+			platform: "darwin",
+			terminalMode: "normal",
+			envMode: "tmux",
+			geometryMode: "small",
+			columns: 32,
+			rows: 4,
+			widthChoices: [10, 16, 32],
+			heightChoices: [3, 4, 6],
+			renderBackend: "app-viewport",
+		},
+	];
+	return templates.map((template, index) =>
+		materializeScenario(
+			template,
+			mixSeed(0xa9971000, index),
+			iterations,
+			CORE_BULK_MAX,
+			timeoutMs,
+			maxOf(template.heightChoices),
+		),
+	);
+}
+
 function materializeScenario(
 	template: ScenarioTemplate,
 	seed: number,
@@ -3428,6 +3528,7 @@ function materializeScenario(
 		template.envMode !== "tmux" && template.terminalMode === "normal" && template.platform !== "win32";
 	const foregroundStream = template.foregroundStream ?? false;
 	const reflow = template.reflow ?? false;
+	const renderBackend = template.renderBackend ?? "native";
 	return {
 		...template,
 		seed,
@@ -3439,7 +3540,8 @@ function materializeScenario(
 		uniqueContent: template.uniqueContent ?? false,
 		foregroundStream,
 		reflow,
-		tags: scenarioTags(template, strictScrollback, foregroundStream),
+		renderBackend,
+		tags: scenarioTags(template, strictScrollback, foregroundStream, renderBackend),
 		replayOperations,
 	};
 }
@@ -3542,6 +3644,7 @@ type ScenarioTemplate = Omit<
 	| "uniqueContent"
 	| "foregroundStream"
 	| "reflow"
+	| "renderBackend"
 	| "tags"
 	| "replayOperations"
 > & {
@@ -3549,6 +3652,7 @@ type ScenarioTemplate = Omit<
 	uniqueContent?: boolean;
 	foregroundStream?: boolean;
 	reflow?: boolean;
+	renderBackend?: RenderBackend;
 };
 
 function writeReplayLog(scenario: Scenario, operations: readonly OperationLogEntry[]): string {
@@ -3950,6 +4054,24 @@ async function withPatchedEnv<T>(envMode: Scenario["envMode"], run: () => Promis
 	}
 }
 
+async function withPatchedRenderBackend<T>(renderBackend: RenderBackend, run: () => Promise<T>): Promise<T> {
+	const previous = Bun.env.PI_TUI_RENDER_BACKEND;
+	if (renderBackend === "app-viewport") {
+		Bun.env.PI_TUI_RENDER_BACKEND = "app-viewport";
+	} else {
+		delete Bun.env.PI_TUI_RENDER_BACKEND;
+	}
+	try {
+		return await run();
+	} finally {
+		if (previous === undefined) {
+			delete Bun.env.PI_TUI_RENDER_BACKEND;
+		} else {
+			Bun.env.PI_TUI_RENDER_BACKEND = previous;
+		}
+	}
+}
+
 async function withPatchedPlatform<T>(platform: Scenario["platform"], run: () => Promise<T>): Promise<T> {
 	if (platformPatchDepth > 0) throw new Error("Nested stress platform patching is not supported");
 	platformPatchDepth += 1;
@@ -3989,8 +4111,10 @@ export type StressScenarioResult = StressScenarioSuccess | StressScenarioFailure
 export async function runStressScenario(scenario: Scenario, options?: { patchEnv?: boolean }): Promise<void> {
 	const run = async (): Promise<void> => {
 		await withPatchedPlatform(scenario.platform, async () => {
-			const driver = new StressDriver(scenario);
-			await driver.run();
+			await withPatchedRenderBackend(scenario.renderBackend, async () => {
+				const driver = new StressDriver(scenario);
+				await driver.run();
+			});
 		});
 	};
 	if (options?.patchEnv === false) {


### PR DESCRIPTION
## Summary

Draft prototype for #2040.

- Adds an experimental `PI_TUI_RENDER_BACKEND=app-viewport` renderer path.
- Runs the main TUI in alternate screen with app-owned transcript scrolling.
- Keeps status/editor chrome sticky while the transcript scrolls.
- Adds keyboard and mouse-wheel scrolling for the app viewport.
- Uses a lightweight right-edge scrollbar in the reserved viewport column.
- Keeps the existing native-scrollback renderer as the default.

## Notes

This is intentionally a draft/demo branch, not a default cutover. It does not attempt to solve app-side selection/copy/export/search yet.

## Verification

- `bun test packages/tui/test/app-viewport.test.ts`
- `bun --cwd=packages/tui run check`
- `bun --cwd=packages/coding-agent run check`