### PR TITLE
fix(ai): corrected misleading Zhipu API key placeholder

### DIFF
--- a/docs/skills/authoring-hooks.md
+++ b/docs/skills/authoring-hooks.md
@@ -179,11 +179,15 @@ export default function rmRfBlocker(omp: HookAPI): void {
 ```ts
 import type { HookAPI } from "@oh-my-pi/pi-coding-agent/extensibility/hooks";
 
-// Matches common API key patterns: sk-..., pk-..., AKIA..., ghp_..., etc.
+// Common API-key shapes. Not exhaustive — providers using bespoke formats
+// (Anthropic `sk-ant-…`, JWT-style bearers, gateway-specific prefixes, etc.)
+// need their own entries.
 const SECRET_PATTERNS = [
   /\b(sk|pk)-[a-zA-Z0-9]{20,}\b/g,
   /\bAKIA[A-Z0-9]{16}\b/g,
   /\bghp_[a-zA-Z0-9]{36}\b/g,
+  // Zhipu / GLM Coding Plan: `<id>.<secret>` (no `sk-` prefix).
+  /\b[a-zA-Z0-9]{16,}\.[a-zA-Z0-9]{16,}\b/g,
   /\b[a-zA-Z0-9_-]{20,}\s*=\s*["']?[a-zA-Z0-9._/+=-]{20,}["']?/g,
 ];
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the Zhipu Coding Plan login prompt advertising a misleading `sk-...` placeholder. Zhipu API keys are formatted `<id>.<secret>` (no `sk-` prefix), so the placeholder now matches the actual format instead of suggesting the wrong shape. ([#2106](https://github.com/can1357/oh-my-pi/issues/2106))
+
 ## [15.10.4] - 2026-06-08
 ### Added
 

--- a/packages/ai/src/utils/oauth/zhipu.ts
+++ b/packages/ai/src/utils/oauth/zhipu.ts
@@ -36,7 +36,7 @@ export async function loginZhipuCodingPlan(options: OAuthController): Promise<st
 	// Prompt user to paste their API key
 	const apiKey = await options.onPrompt({
 		message: "Paste your Zhipu API key",
-		placeholder: "sk-...",
+		placeholder: "<id>.<secret>",
 	});
 
 	if (options.signal?.aborted) {


### PR DESCRIPTION
## Repro

Run `omp login zhipu-coding-plan` (or trigger the login flow from the auth UI). The prompt renders `Paste your Zhipu API key` with placeholder text `sk-...`. Zhipu Coding Plan keys issued at `https://bigmodel.cn/coding-plan/personal/overview` are formatted `<id>.<secret>` (e.g. `1234567890.abcdefghijklmnop`) with no `sk-` prefix, so the placeholder tells users their pasted key is the wrong shape.

## Cause

`packages/ai/src/utils/oauth/zhipu.ts` hard-coded `placeholder: "sk-..."` on the `onPrompt` call. Every other provider in `packages/ai/src/utils/oauth/` advertises a placeholder that matches the actual key prefix (`nvapi-...`, `csk-...`, `hf_...`, etc.) — Zhipu was the odd one out.

Separately, `docs/skills/authoring-hooks.md`'s `SECRET_PATTERNS` example only covered `sk-`/`pk-`/`AKIA`/`ghp_` prefixes and a generic `KEY=VALUE` shape, so hook authors copying the snippet silently skip Zhipu's `id.secret` keys.

## Fix

- `packages/ai/src/utils/oauth/zhipu.ts`: replaced `"sk-..."` with `"<id>.<secret>"` so the placeholder mirrors the real key shape.
- `docs/skills/authoring-hooks.md`: added a Zhipu-shaped pattern (`/\b[a-zA-Z0-9]{16,}\.[a-zA-Z0-9]{16,}\b/g`) to the example `SECRET_PATTERNS`, plus a comment noting the list is not exhaustive and providers with bespoke key formats need their own entries.
- `packages/ai/CHANGELOG.md`: `Unreleased / Fixed` entry.

## Verification

Manual diff review of the three files; no automated test touches the prompt placeholder. Pre-publish `bun run fix` + `bun check` will run via the host tool. Fixes #2106.