### PR TITLE
fix(coding-agent): expand @-imports in AGENTS.md / CLAUDE.md context files

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Expanded `@path/to/file` import references in CLAUDE.md / AGENTS.md / GEMINI.md (and the other discovered context-file flavors) when loading them into the system prompt, matching the convention used by Claude Code, Goose, and other agents. Imports resolve relative to the importing file's directory, support `~/...`, recurse up to 5 hops, and are skipped inside fenced code blocks and inline code spans so technical examples like `npm install @types/node` survive intact ([#2111](https://github.com/can1357/oh-my-pi/issues/2111)).
+
 ## [15.10.4] - 2026-06-08
 
 ### Added

--- a/packages/coding-agent/src/discovery/at-imports.ts
+++ b/packages/coding-agent/src/discovery/at-imports.ts
@@ -1,0 +1,273 @@
+/**
+ * @-import expansion for context files (AGENTS.md / CLAUDE.md / GEMINI.md / …).
+ *
+ * Other coding agents (Claude Code, Goose, Cline, …) treat `@path/to/file`
+ * references inside their markdown memory files as inline includes. omp
+ * loads the same files in their native shape, so this module performs the
+ * same expansion before content lands in the system prompt.
+ *
+ * Semantics mirror Claude Code's documented behavior:
+ * - `@` must sit at start of line or after whitespace (so `git@github.com`
+ *   and `user@example.com` are not treated as imports).
+ * - Relative paths resolve against the importing file's directory, not the
+ *   working directory.
+ * - `~/...` resolves to the user's home directory.
+ * - Imports inside fenced code blocks (` ``` ` / `~~~`) and inline code
+ *   spans (`` `…` ``) are preserved verbatim so technical examples like
+ *   `npm install @types/node` survive intact.
+ * - Recursive imports are followed up to {@link MAX_AT_IMPORT_DEPTH} hops;
+ *   cycles are broken silently.
+ * - When the referenced file cannot be read, the original `@token` is
+ *   left untouched and a debug log is emitted.
+ *
+ * @see https://docs.claude.com/en/docs/claude-code/memory#import-additional-files
+ */
+import * as os from "node:os";
+import * as path from "node:path";
+import { logger } from "@oh-my-pi/pi-utils";
+import { readFile } from "../capability/fs";
+
+/** Maximum number of recursive `@`-import hops. Matches Claude Code's documented cap. */
+export const MAX_AT_IMPORT_DEPTH = 5;
+
+/**
+ * Matches a candidate `@import` token: a leading boundary (start-of-string
+ * or single whitespace char) and a token whose first character is path-like.
+ *
+ * The boundary character is captured separately so the slice arithmetic in
+ * {@link expandLine} aligns with the `@` position, not the whitespace.
+ */
+const AT_IMPORT_REGEX = /(^|[ \t])@([./~A-Za-z0-9_-][^\s]*)/g;
+
+/**
+ * Trailing characters stripped from a captured path token: sentence-ending
+ * punctuation, closing brackets, quotes. A lone trailing period is treated
+ * as sentence grammar (e.g. `See @AGENTS.md.`) — legitimate file extensions
+ * still match because the stripped set is anchored at the very end of the
+ * token, so `@AGENTS.md` keeps the `.md` (the `d` is not in the set).
+ */
+const TRAILING_PUNCT = /[.,;:!?)\]}"']+$/;
+
+export interface ExpandAtImportsOptions {
+	/** Maximum hop depth (default: {@link MAX_AT_IMPORT_DEPTH}). */
+	maxDepth?: number;
+	/** Override the home directory used to resolve `~/...` (default: `os.homedir()`). */
+	home?: string;
+}
+
+/**
+ * Expand `@path/to/file` references in `content` against `filePath`'s directory.
+ *
+ * Returns the expanded text. When no imports match, the original string is
+ * returned unchanged.
+ */
+export async function expandAtImports(
+	content: string,
+	filePath: string,
+	options: ExpandAtImportsOptions = {},
+): Promise<string> {
+	const maxDepth = options.maxDepth ?? MAX_AT_IMPORT_DEPTH;
+	const home = options.home ?? os.homedir();
+	const absoluteSource = path.resolve(filePath);
+	const visited = new Set<string>([absoluteSource]);
+	return await expand(content, path.dirname(absoluteSource), 0, maxDepth, home, visited);
+}
+
+async function expand(
+	content: string,
+	baseDir: string,
+	depth: number,
+	maxDepth: number,
+	home: string,
+	visited: Set<string>,
+): Promise<string> {
+	if (depth >= maxDepth) return content;
+
+	const segments = splitMarkdownSegments(content);
+	const out: string[] = [];
+	for (const segment of segments) {
+		if (segment.kind === "code") {
+			out.push(segment.text);
+			continue;
+		}
+		out.push(await expandTextSegment(segment.text, baseDir, depth, maxDepth, home, visited));
+	}
+	return out.join("");
+}
+
+async function expandTextSegment(
+	text: string,
+	baseDir: string,
+	depth: number,
+	maxDepth: number,
+	home: string,
+	visited: Set<string>,
+): Promise<string> {
+	const lines = text.split("\n");
+	for (let i = 0; i < lines.length; i++) {
+		lines[i] = await expandLine(lines[i], baseDir, depth, maxDepth, home, visited);
+	}
+	return lines.join("\n");
+}
+
+async function expandLine(
+	line: string,
+	baseDir: string,
+	depth: number,
+	maxDepth: number,
+	home: string,
+	visited: Set<string>,
+): Promise<string> {
+	if (!line.includes("@")) return line;
+
+	const matches: Array<{ start: number; end: number; importPath: string }> = [];
+	for (const m of line.matchAll(AT_IMPORT_REGEX)) {
+		const matchIndex = m.index ?? 0;
+		const leading = m[1];
+		const rawToken = m[2];
+		const atPos = matchIndex + leading.length;
+		if (isInsideInlineCode(line, atPos)) continue;
+
+		const trimmedToken = rawToken.replace(TRAILING_PUNCT, "");
+		if (trimmedToken.length === 0) continue;
+
+		matches.push({
+			start: atPos,
+			end: atPos + 1 + trimmedToken.length,
+			importPath: trimmedToken,
+		});
+	}
+
+	if (matches.length === 0) return line;
+
+	const parts: string[] = [];
+	let cursor = 0;
+	for (const m of matches) {
+		parts.push(line.slice(cursor, m.start));
+		const expanded = await resolveAndExpand(m.importPath, baseDir, depth, maxDepth, home, visited);
+		parts.push(expanded ?? line.slice(m.start, m.end));
+		cursor = m.end;
+	}
+	parts.push(line.slice(cursor));
+	return parts.join("");
+}
+
+async function resolveAndExpand(
+	importPath: string,
+	baseDir: string,
+	depth: number,
+	maxDepth: number,
+	home: string,
+	visited: Set<string>,
+): Promise<string | null> {
+	const resolved = resolveImportPath(importPath, baseDir, home);
+	if (visited.has(resolved)) {
+		logger.debug("@-import: skipping cyclic include", { path: resolved });
+		return null;
+	}
+
+	const content = await readFile(resolved);
+	if (content === null) {
+		logger.debug("@-import: file not found", { path: resolved });
+		return null;
+	}
+
+	// Visited is shared across the whole expansion tree to break cycles,
+	// even cycles that span multiple importing files.
+	visited.add(resolved);
+	return await expand(content, path.dirname(resolved), depth + 1, maxDepth, home, visited);
+}
+
+function resolveImportPath(importPath: string, baseDir: string, home: string): string {
+	if (importPath === "~") return path.resolve(home);
+	if (importPath.startsWith("~/")) return path.resolve(home, importPath.slice(2));
+	if (path.isAbsolute(importPath)) return path.resolve(importPath);
+	return path.resolve(baseDir, importPath);
+}
+
+interface MarkdownSegment {
+	kind: "text" | "code";
+	text: string;
+}
+
+/**
+ * Split markdown into alternating text/code segments by tracking fenced
+ * code blocks. Inline code spans are handled per-line by {@link isInsideInlineCode}.
+ *
+ * A fence is recognized as a line whose first non-whitespace run is three or
+ * more backticks (or tildes). The closing fence must use the same character
+ * with at least as many marks as the opener.
+ */
+function splitMarkdownSegments(content: string): MarkdownSegment[] {
+	const segments: MarkdownSegment[] = [];
+	const lines = content.split("\n");
+	let buffer: string[] = [];
+	let bufferKind: MarkdownSegment["kind"] = "text";
+	let fenceChar = "";
+	let fenceLen = 0;
+
+	const flush = (): void => {
+		if (buffer.length === 0) return;
+		segments.push({ kind: bufferKind, text: buffer.join("") });
+		buffer = [];
+	};
+
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i];
+		const isLast = i === lines.length - 1;
+		// Re-attach each line's trailing newline so adjacent segments
+		// concatenate without losing the boundary `\n`.
+		const lineText = isLast ? line : `${line}\n`;
+		const fence = matchFence(line);
+
+		if (fence && bufferKind === "text") {
+			flush();
+			bufferKind = "code";
+			buffer.push(lineText);
+			fenceChar = fence.char;
+			fenceLen = fence.len;
+		} else if (fence && bufferKind === "code" && fence.char === fenceChar && fence.len >= fenceLen) {
+			buffer.push(lineText);
+			flush();
+			bufferKind = "text";
+			fenceChar = "";
+			fenceLen = 0;
+		} else {
+			buffer.push(lineText);
+		}
+
+		if (isLast) flush();
+	}
+	return segments;
+}
+
+function matchFence(line: string): { char: string; len: number } | null {
+	let i = 0;
+	while (i < line.length && (line[i] === " " || line[i] === "\t")) i++;
+	const char = line[i];
+	if (char !== "`" && char !== "~") return null;
+	let len = 0;
+	while (i + len < line.length && line[i + len] === char) len++;
+	if (len < 3) return null;
+	return { char, len };
+}
+
+/**
+ * Returns `true` when `position` falls inside an unclosed inline-code span on
+ * this line. Implemented as a backtick-parity scan so it handles repeated
+ * delimiters like `` `` literal ` backtick `` `` correctly enough for the
+ * "@-imports inside `code` should not expand" case.
+ */
+function isInsideInlineCode(line: string, position: number): boolean {
+	let inSpan = false;
+	let i = 0;
+	while (i < position && i < line.length) {
+		if (line[i] === "`") {
+			while (i < line.length && line[i] === "`") i++;
+			inSpan = !inSpan;
+		} else {
+			i++;
+		}
+	}
+	return inSpan;
+}

--- a/packages/coding-agent/src/system-prompt.ts
+++ b/packages/coding-agent/src/system-prompt.ts
@@ -10,6 +10,7 @@ import { contextFileCapability } from "./capability/context-file";
 import { systemPromptCapability } from "./capability/system-prompt";
 import type { SkillsSettings } from "./config/settings";
 import { type ContextFile, loadCapability, type SystemPrompt as SystemPromptFile } from "./discovery";
+import { expandAtImports } from "./discovery/at-imports";
 import { loadSkills, type Skill } from "./extensibility/skills";
 import { hasObsidian } from "./internal-urls/vault-protocol";
 import customSystemPromptTemplate from "./prompts/system/custom-system-prompt.md" with { type: "text" };
@@ -254,15 +255,20 @@ export async function loadProjectContextFiles(
 
 	const result = await loadCapability(contextFileCapability.id, { cwd: resolvedCwd });
 
-	// Convert ContextFile items and preserve depth info
-	const files = result.items.map(item => {
-		const contextFile = item as ContextFile;
-		return {
-			path: contextFile.path,
-			content: contextFile.content,
-			depth: contextFile.depth,
-		};
-	});
+	// Materialize ContextFile items, expanding any `@path/to/file` includes
+	// in their content. The expansion uses the file's own directory as the
+	// resolution base so relative imports work the same way Claude Code,
+	// Goose, and other tools document.
+	const files = await Promise.all(
+		result.items.map(async item => {
+			const contextFile = item as ContextFile;
+			return {
+				path: contextFile.path,
+				content: await expandAtImports(contextFile.content, contextFile.path),
+				depth: contextFile.depth,
+			};
+		}),
+	);
 
 	// Sort by depth (descending): higher depth (farther from cwd) comes first,
 	// so files closer to cwd appear later and are more prominent

--- a/packages/coding-agent/test/discovery/at-imports.test.ts
+++ b/packages/coding-agent/test/discovery/at-imports.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { clearCache as clearFsCache } from "@oh-my-pi/pi-coding-agent/capability/fs";
+import { expandAtImports, MAX_AT_IMPORT_DEPTH } from "@oh-my-pi/pi-coding-agent/discovery/at-imports";
+
+/**
+ * Behavior contract for the @-import expander used by every AGENTS.md /
+ * CLAUDE.md / GEMINI.md loader. Each test names one externally-observable
+ * promise — relative-resolution, code-block opacity, cycle/depth caps, etc.
+ */
+describe("expandAtImports", () => {
+	let tmp: string;
+
+	beforeEach(async () => {
+		tmp = await fs.mkdtemp(path.join(os.tmpdir(), "omp-at-import-"));
+	});
+
+	afterEach(async () => {
+		clearFsCache();
+		await fs.rm(tmp, { recursive: true, force: true });
+	});
+
+	const writeFile = async (relPath: string, content: string): Promise<string> => {
+		const abs = path.join(tmp, relPath);
+		await fs.mkdir(path.dirname(abs), { recursive: true });
+		await fs.writeFile(abs, content);
+		return abs;
+	};
+
+	test("inlines the entire referenced file when the line is just @path", async () => {
+		// User's reported case from issue #2111 — CLAUDE.md with body `@AGENTS.md`.
+		const agents = await writeFile("AGENTS.md", "ALWAYS use uppercase letters.");
+		const claude = await writeFile("CLAUDE.md", "@AGENTS.md\n");
+
+		const expanded = await expandAtImports(await fs.readFile(claude, "utf8"), claude);
+
+		expect(expanded.trim()).toBe("ALWAYS use uppercase letters.");
+		// Sanity: the actual file path resolved was the sibling, not anything else.
+		expect(await fs.readFile(agents, "utf8")).toBe("ALWAYS use uppercase letters.");
+	});
+
+	test("resolves relative paths against the importing file's directory, not cwd", async () => {
+		// Importing file lives in a subdir; the @-import must look for the
+		// target alongside the importer, not in process.cwd().
+		await writeFile("rules/no-push.md", "NEVER push.");
+		const agentsPath = await writeFile("rules/AGENTS.md", "Rule: @./no-push.md\n");
+
+		const expanded = await expandAtImports("Rule: @./no-push.md\n", agentsPath);
+
+		expect(expanded).toContain("Rule: NEVER push.");
+		expect(expanded).not.toContain("@./no-push.md");
+	});
+
+	test("resolves ~/path against the home override", async () => {
+		const fakeHome = await fs.mkdtemp(path.join(os.tmpdir(), "omp-at-home-"));
+		try {
+			await fs.writeFile(path.join(fakeHome, "prefs.md"), "use 2 spaces");
+			const expanded = await expandAtImports("See @~/prefs.md.\n", path.join(tmp, "AGENTS.md"), {
+				home: fakeHome,
+			});
+			expect(expanded).toContain("See use 2 spaces");
+		} finally {
+			await fs.rm(fakeHome, { recursive: true, force: true });
+		}
+	});
+
+	test("nests imports recursively", async () => {
+		await writeFile("c.md", "LEAF.");
+		await writeFile("b.md", "B then @c.md\n");
+		const a = await writeFile("a.md", "A then @b.md\n");
+
+		const expanded = await expandAtImports(await fs.readFile(a, "utf8"), a);
+
+		expect(expanded).toContain("A then B then LEAF.");
+	});
+
+	test("caps recursion at MAX_AT_IMPORT_DEPTH hops", async () => {
+		// Build a chain longer than the depth cap. At depth=MAX, expand()
+		// short-circuits before resolving the file's own @-imports, so the
+		// content at that depth is included verbatim and the import token
+		// inside it (`@step${MAX+1}.md`) survives unexpanded.
+		const total = MAX_AT_IMPORT_DEPTH + 2;
+		for (let i = 0; i < total; i++) {
+			const body = i === total - 1 ? "TERMINAL" : `step-${i} -> @step${i + 1}.md`;
+			await writeFile(`step${i}.md`, `${body}\n`);
+		}
+		const entry = path.join(tmp, "step0.md");
+		const expanded = await expandAtImports(await fs.readFile(entry, "utf8"), entry);
+		expect(expanded).toContain(`@step${MAX_AT_IMPORT_DEPTH + 1}.md`);
+		expect(expanded).not.toContain("TERMINAL");
+	});
+
+	test("breaks cycles silently", async () => {
+		// `@` must follow whitespace or start-of-line to count as an import,
+		// so the loop bodies use a space before each reference.
+		const a = await writeFile("loop-a.md", "A: @loop-b.md\n");
+		await writeFile("loop-b.md", "B: @loop-a.md\n");
+
+		const expanded = await expandAtImports(await fs.readFile(a, "utf8"), a);
+
+		// The second hop sees the original importer in `visited` and bails,
+		// leaving its literal @-token but emitting all earlier text.
+		expect(expanded).toContain("A: B:");
+		expect(expanded).toContain("@loop-a.md");
+	});
+
+	test("leaves the original token untouched when the file is missing", async () => {
+		const source = path.join(tmp, "AGENTS.md");
+		const expanded = await expandAtImports("See @./does-not-exist.md\n", source);
+		expect(expanded).toContain("@./does-not-exist.md");
+	});
+
+	test("does not expand inside fenced code blocks", async () => {
+		await writeFile("guide.md", "INLINED");
+		const source = path.join(tmp, "AGENTS.md");
+		const input = ["Run this:", "```bash", "echo @./guide.md", "```", "Also see @./guide.md."].join("\n");
+
+		const expanded = await expandAtImports(input, source);
+
+		// Inside the fence the @-token is preserved verbatim.
+		expect(expanded).toContain("echo @./guide.md");
+		// Outside the fence it expands.
+		expect(expanded).toContain("Also see INLINED");
+	});
+
+	test("does not expand inside inline code spans", async () => {
+		await writeFile("guide.md", "INLINED");
+		const source = path.join(tmp, "AGENTS.md");
+		const input = "Install via `npm i @./guide.md` and also @./guide.md.\n";
+
+		const expanded = await expandAtImports(input, source);
+
+		expect(expanded).toContain("`npm i @./guide.md`");
+		expect(expanded).toContain("also INLINED");
+	});
+
+	test("ignores @ embedded mid-token like emails and SSH URLs", async () => {
+		// Guard against false positives that would otherwise spam debug logs
+		// or worse, leak filesystem reads triggered by user-supplied text.
+		await writeFile("guide.md", "INLINED");
+		const source = path.join(tmp, "AGENTS.md");
+		const input = "Ping me at me@example.com or use git@github.com:foo/bar.git for clones.\n";
+
+		const expanded = await expandAtImports(input, source);
+
+		expect(expanded).toBe(input);
+	});
+
+	test("strips trailing sentence punctuation from the path", async () => {
+		// The trailing comma/period is sentence grammar, not part of the filename.
+		await writeFile("guide.md", "INLINED");
+		const source = path.join(tmp, "AGENTS.md");
+		const input = "See @./guide.md, and then continue.\n";
+
+		const expanded = await expandAtImports(input, source);
+
+		expect(expanded).toContain("See INLINED, and then continue.");
+	});
+});


### PR DESCRIPTION
## Repro

In a project whose `AGENTS.md` (or `CLAUDE.md`) references another file with the documented `@path/to/file` syntax, the reference is shipped to the model verbatim instead of being inlined:

```sh
mkdir -p /tmp/omp-2111/.ruleset
echo 'See @./.ruleset/no-push.md for git policy.' > /tmp/omp-2111/AGENTS.md
echo 'YOU MUST NOT PUSH UNDER ANY CIRCUMSTANCES, EVER.' > /tmp/omp-2111/.ruleset/no-push.md

bun --cwd=packages/coding-agent -e '
  import { discoverContextFiles } from "./src/sdk";
  for (const f of await discoverContextFiles("/tmp/omp-2111")) {
    if (f.path.startsWith("/tmp/")) process.stdout.write(`---\n${f.path}\n---\n${f.content}\n`);
  }'
# → See @./.ruleset/no-push.md for git policy.   (literal; the rule file is never injected)
```

The marketing line "omp reads the eight formats already on disk in their native shape" promises the import semantics every other agent (Claude Code, Goose, …) ships, so this is a compatibility bug rather than a feature request.

## Cause

`packages/coding-agent/src/discovery/{claude,agents,agents-md,codex,opencode,gemini,github,builtin}.ts` each load their respective memory file via `readFile()` and stash the bytes straight into the `context-file` capability. The aggregator in `packages/coding-agent/src/system-prompt.ts` (`loadProjectContextFiles`) then maps capability items into `{path, content, depth}` triples without ever interpreting `@…` references, so the system prompt and `discoverContextFiles` SDK entry surface unexpanded content.

## Fix

- **`packages/coding-agent/src/discovery/at-imports.ts` (new)** — `expandAtImports(content, filePath, options?)` implementing the Claude-Code semantics: `@` must follow start-of-line or whitespace; relative paths resolve against the importing file's directory; `~/...` expands against the user's home; recursion is capped at `MAX_AT_IMPORT_DEPTH = 5` with cycle detection; fenced code blocks (` ``` ` / `~~~`) and inline code spans (`` `…` ``) are opaque so `npm install @types/node`, `git@github.com:foo/bar`, and `user@example.com` round-trip verbatim; missing files keep the literal `@token` intact.
- **`packages/coding-agent/src/system-prompt.ts`** — wired the expander into `loadProjectContextFiles`, the single choke point used by both the system-prompt builder and the `discoverContextFiles` SDK helper (and therefore the commit-agent's `loadProjectContextFiles({ cwd })` call). Per-provider loaders stay untouched.
- **`packages/coding-agent/CHANGELOG.md`** — added a `Fixed` entry under `[Unreleased]`.

## Verification

- `bun test test/discovery/at-imports.test.ts` (11 pass) covers each contract individually: user's `@AGENTS.md` case, relative-to-importer resolution, `~/` expansion, recursive nesting, hard depth cap, cycle break, missing-file passthrough, fence/inline-code opacity, mid-token `@` rejection, and trailing-punctuation stripping. Counterpart tests for the discovery dedup, monorepo, and capability registration suites (`bun test test/discovery/ test/system-prompt-dedup.test.ts test/append-only-context-mode.test.ts` → 130/130 pass) confirm the wiring does not regress existing behavior.
- `bun check` clean in `packages/coding-agent`.
- End-to-end repro after the change emits the inlined rule:
  ```
  ---
  /tmp/omp-2111/AGENTS.md
  ---
  See YOU MUST NOT PUSH UNDER ANY CIRCUMSTANCES, EVER.
   for git policy.
  ```

Fixes #2111
