### PR TITLE
fix(ai): mark moonshot kimi-k2.x as reasoning + vision during discovery

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Moonshot `kimi-k2.6` (and any future `kimi-k2.x`) discovered via `MOONSHOT_API_KEY` stalling on first turn with no output. The `moonshotModelManagerOptions` discovery mapper only marked ids containing `"thinking"` as `reasoning: true`, so dynamic `kimi-k2.6` entries fell through with `reasoning: false`; the openai-completions z.ai branch was then skipped and the request reached Moonshot with no `thinking` parameter at all. Moonshot K2.6 requires an explicit `thinking: {type}` field (the same native-API wire shape #1838 introduced `thinking.keep` for), so the server held the stream silently. The mapper now stamps `reasoning: true`, vision input, and default `thinking` metadata on every `kimi-k2.x` id, restoring the explicit `thinking: {type: "disabled"|"enabled"}` wire body the Moonshot endpoint expects. ([#2113](https://github.com/can1357/oh-my-pi/issues/2113))
 ## [15.10.4] - 2026-06-08
 ### Added
 

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -1916,12 +1916,23 @@ export function moonshotModelManagerOptions(
 						const reference = references.get(defaults.id);
 						const model = mapWithBundledReference(entry, defaults, reference);
 						const id = model.id.toLowerCase();
-						const isThinking = id.includes("thinking");
-						const isVision = id.includes("vision") || id.includes("vl") || id.includes("k2.5");
+						// Moonshot's K2.x family (K2.5, K2.6, kimi-k2-thinking, …) is reasoning-capable
+						// and vision-capable on the native API. Without these flags the openai-completions
+						// path skips the z.ai-format `thinking` block, and Moonshot K2.6 stalls on first
+						// turn because its endpoint expects an explicit `thinking: {type}` (#2113). Match
+						// the bundled K2.5 metadata for every K2.x id we discover.
+						const isKimiK2Reasoning = id.includes("thinking") || /(^|\/)kimi-k2(?:\.\d+)?(?:[-:]|$)/.test(id);
+						const isVision =
+							id.includes("vision") || id.includes("vl") || /(^|\/)kimi-k2(?:\.\d+)?(?:[-:]|$)/.test(id);
 						return {
 							...model,
-							reasoning: isThinking || model.reasoning,
+							reasoning: isKimiK2Reasoning || model.reasoning,
 							input: isVision ? ["text", "image"] : model.input,
+							thinking:
+								model.thinking ??
+								(isKimiK2Reasoning
+									? { mode: "effort", minLevel: Effort.Minimal, maxLevel: Effort.High }
+									: undefined),
 						};
 					},
 				}),

--- a/packages/ai/test/issue-2113-repro.test.ts
+++ b/packages/ai/test/issue-2113-repro.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Issue #2113 — `kimik2 does not work on the latest omp`
+ *
+ * Reporter: with only `MOONSHOT_API_KEY` set, selecting `kimi-k2.6` and
+ * sending any text leaves the agent stuck on "Working..." with no output.
+ *
+ * Root cause: the `moonshot` provider only bundled `kimi-k2.5`, and the
+ * `moonshotModelManagerOptions` discovery mapper only promoted ids
+ * containing `"thinking"` to `reasoning: true`. `kimi-k2.6` fell through
+ * with `reasoning: false`, so the openai-completions `buildParams` z.ai
+ * branch was skipped entirely and Moonshot received a request with no
+ * `thinking` parameter — Moonshot K2.6 stalls under that shape (the same
+ * native-API quirk documented in the #1838 fix that introduced
+ * `thinking.keep` for K2.6).
+ *
+ * The fix marks every `kimi-k2.x` id as reasoning + vision in the
+ * moonshot discovery mapper and stamps default thinking metadata.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import { Effort } from "../src/effort";
+import { getBundledModel } from "../src/models";
+import { moonshotModelManagerOptions } from "../src/provider-models/openai-compat";
+import { streamOpenAICompletions } from "../src/providers/openai-completions";
+import type { AssistantMessage, Context, Model } from "../src/types";
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+	global.fetch = originalFetch;
+});
+
+function moonshotKimiModel(id: string, reasoning: boolean): Model<"openai-completions"> {
+	return {
+		...getBundledModel("openai", "gpt-4o-mini"),
+		api: "openai-completions",
+		provider: "moonshot",
+		baseUrl: "https://api.moonshot.ai/v1",
+		id,
+		reasoning,
+	};
+}
+
+function basicContext(): Context {
+	return {
+		messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+	};
+}
+
+function encodeSseChunks(chunks: ReadonlyArray<Record<string, unknown>>): string {
+	const lines = chunks.map(c => `data: ${JSON.stringify(c)}\n\n`);
+	lines.push("data: [DONE]\n\n");
+	return lines.join("");
+}
+
+function buildMockMoonshotResponse(): Response {
+	const body = encodeSseChunks([
+		{
+			id: "chatcmpl-k26-1",
+			object: "chat.completion.chunk",
+			created: 1,
+			model: "kimi-k2.6",
+			choices: [{ index: 0, delta: { role: "assistant", content: "Hello!" }, finish_reason: null }],
+		},
+		{
+			id: "chatcmpl-k26-1",
+			object: "chat.completion.chunk",
+			created: 1,
+			model: "kimi-k2.6",
+			choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+		},
+	]);
+	return new Response(body, {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+interface CapturedRequest {
+	url: string;
+	body: Record<string, unknown>;
+}
+
+async function runHiTurn(
+	model: Model<"openai-completions">,
+): Promise<{ captured: CapturedRequest; assistant: AssistantMessage }> {
+	const captured: CapturedRequest = { url: "", body: {} };
+	const fetchImpl = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+		const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+		captured.url = url;
+		const raw = typeof init?.body === "string" ? init.body : "";
+		captured.body = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+		return buildMockMoonshotResponse();
+	};
+	global.fetch = Object.assign(fetchImpl, { preconnect: originalFetch.preconnect });
+
+	const stream = streamOpenAICompletions(model, basicContext(), { apiKey: "test-key" });
+	for await (const _ of stream) {
+		// drain until terminal event
+	}
+	const assistant = await stream.result();
+	return { captured, assistant };
+}
+
+describe("issue #2113 — moonshot kimi-k2.6 discovery and wire format", () => {
+	it("moonshot discovery mapper marks kimi-k2.6 as reasoning + vision with thinking metadata", async () => {
+		const opts = moonshotModelManagerOptions({ apiKey: "test-key" });
+		const fetchImpl = async (input: string | URL | Request): Promise<Response> => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			expect(url).toContain("api.moonshot.ai/v1/models");
+			const body = {
+				object: "list",
+				data: [
+					{ id: "kimi-k2.5", object: "model", owned_by: "moonshot" },
+					{ id: "kimi-k2.6", object: "model", owned_by: "moonshot" },
+					{ id: "kimi-k2-thinking", object: "model", owned_by: "moonshot" },
+				],
+			};
+			return new Response(JSON.stringify(body), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		};
+		global.fetch = Object.assign(fetchImpl, { preconnect: originalFetch.preconnect });
+
+		const models = await opts.fetchDynamicModels?.();
+		expect(models).toBeDefined();
+		const byId = new Map(models?.map(m => [m.id, m]));
+
+		const k25 = byId.get("kimi-k2.5");
+		expect(k25?.reasoning).toBe(true);
+		expect(k25?.input).toEqual(["text", "image"]);
+		expect(k25?.thinking).toBeDefined();
+
+		const k26 = byId.get("kimi-k2.6");
+		expect(k26?.reasoning).toBe(true);
+		expect(k26?.input).toEqual(["text", "image"]);
+		expect(k26?.thinking).toEqual({ mode: "effort", minLevel: Effort.Minimal, maxLevel: Effort.High });
+
+		const thinkingOnly = byId.get("kimi-k2-thinking");
+		expect(thinkingOnly?.reasoning).toBe(true);
+		expect(thinkingOnly?.thinking).toBeDefined();
+	});
+
+	it("wire body for moonshot kimi-k2.6 carries an explicit thinking parameter", async () => {
+		// The discovery mapper now stamps reasoning=true on Moonshot K2.6, so the
+		// openai-completions z.ai branch fires and emits `thinking: {type}`. Without
+		// this, Moonshot K2.6 stalls on first turn (the original #2113 symptom).
+		const model = moonshotKimiModel("kimi-k2.6", true);
+		const { captured, assistant } = await runHiTurn(model);
+
+		expect(captured.url).toContain("api.moonshot.ai/v1/chat/completions");
+		expect(captured.body.thinking).toEqual({ type: "disabled" });
+		expect(assistant.errorMessage).toBeUndefined();
+		const textBlock = assistant.content.find(b => b.type === "text");
+		expect(textBlock).toBeDefined();
+	});
+
+	it("wire body includes thinking.keep='all' when reasoning is explicitly requested", async () => {
+		const model = moonshotKimiModel("kimi-k2.6", true);
+		const captured: CapturedRequest = { url: "", body: {} };
+		const fetchImpl = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+			const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+			captured.url = url;
+			const raw = typeof init?.body === "string" ? init.body : "";
+			captured.body = raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+			return buildMockMoonshotResponse();
+		};
+		global.fetch = Object.assign(fetchImpl, { preconnect: originalFetch.preconnect });
+
+		const stream = streamOpenAICompletions(model, basicContext(), {
+			apiKey: "test-key",
+			reasoning: "high",
+		});
+		for await (const _ of stream) {
+			// drain
+		}
+
+		expect(captured.body.thinking).toEqual({ type: "enabled", keep: "all" });
+	});
+});


### PR DESCRIPTION
## Repro

With only `MOONSHOT_API_KEY` set, select `kimi-k2.6` from the model picker and send any prompt (e.g. `hi`). The agent sticks on `Working...` forever and never emits content. Worked on June 3 (~v15.9.0), broken on v15.10.4.

Captured wire body for `moonshot/kimi-k2.6` before the fix:

```json
{
  "model": "kimi-k2.6",
  "messages": [{"role":"user","content":"hi"}],
  "stream": true,
  "stream_options": {"include_usage": true},
  "store": false,
  "max_completion_tokens": 16384
}
```

No `thinking` field at all — Moonshot K2.6 stalls silently under that shape.

## Cause

The `moonshot` provider block in `packages/ai/src/models.json` only bundles `kimi-k2.5`. Every other provider's K2.6 catalog entry (`fireworks`, `kilo`, `openrouter`, `vercel-ai-gateway`, etc.) already carries `reasoning: true`; the moonshot block does not.

When the user has `MOONSHOT_API_KEY` set, `moonshotModelManagerOptions` (in `packages/ai/src/provider-models/openai-compat.ts`) discovers `kimi-k2.6` dynamically from `https://api.moonshot.ai/v1/models`. The discovery `mapModel` mapper only promoted ids containing `"thinking"` (e.g. `kimi-k2-thinking`) to `reasoning: true`. `kimi-k2.6` fell through with `reasoning: false`, so the openai-completions `buildParams` z.ai branch was skipped — no `thinking: {type}` field reached the wire. Moonshot's K2.6 endpoint requires an explicit `thinking` parameter (the same native-API wire shape #1838 introduced `thinking.keep` for); without it the server holds the stream open.

## Fix

`packages/ai/src/provider-models/openai-compat.ts` — moonshot discovery mapper:
- Reasoning detection now matches every `kimi-k2.x` id (existing `"thinking"` substring plus a `kimi-k2(\.<n>)?` regex) instead of only `"thinking"`.
- Vision detection now matches every `kimi-k2.x` id instead of just `"k2.5"`.
- Stamps default Moonshot-effort `thinking` metadata (`{mode: "effort", minLevel: Effort.Minimal, maxLevel: Effort.High}`) on reasoning-capable ids that have no reference entry, so the runtime model registry has thinking shape information for the picker and `buildParams`.

With `reasoning: true`, the openai-completions z.ai branch emits the explicit `thinking` block — `{type: "disabled"}` by default or `{type: "enabled", keep: "all"}` when the user enables thinking — and Moonshot K2.6 responds normally.

`packages/ai/test/issue-2113-repro.test.ts` (new): asserts the mapper promotes `kimi-k2.5`, `kimi-k2.6`, and `kimi-k2-thinking` to `reasoning: true` + vision, and that the wire body for `moonshot/kimi-k2.6` carries the explicit `thinking` parameter (`{type: "disabled"}` by default, `{type: "enabled", keep: "all"}` when reasoning is requested).

## Verification

`bun --cwd=packages/ai test test/issue-2113-repro.test.ts test/issue-1838-repro.test.ts test/openai-completions-compat.test.ts` → `59 pass, 0 fail`.

`bun --cwd=packages/ai test` → `1553 pass, 337 skip, 0 fail` across 186 files (skipped tests are E2E/network suites gated by env).

`models.json` was intentionally left untouched (regenerated artifact per repo rules); the next `bun --cwd=packages/ai run generate-models` regen against a Moonshot key will pick up the corrected mapper and bake `kimi-k2.6` into the bundled `moonshot` block.

Fixes #2113