### PR TITLE
fix(commit): reject empty split hunk selectors

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -182,7 +182,7 @@
 
 ### Fixed
 
-- Fixed `omp commit` split plans rejecting hunk selectors that resolve to no parsed hunks before resetting the index ([#2098](https://github.com/can1357/oh-my-pi/issues/2098)).
+- Fixed `omp commit` split plans accepting hunk selectors that resolve to no parsed hunks, which crashed the apply step after the index reset and left the working tree fully unstaged ([#2098](https://github.com/can1357/oh-my-pi/issues/2098)).
 
 - Fixed inline `find` and `search` result blocks to align with grouped `read` output and render their success headers with the normal tool-title color instead of accent blue.
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -182,6 +182,8 @@
 
 ### Fixed
 
+- Fixed `omp commit` split plans rejecting hunk selectors that resolve to no parsed hunks before resetting the index ([#2098](https://github.com/can1357/oh-my-pi/issues/2098)).
+
 - Fixed inline `find` and `search` result blocks to align with grouped `read` output and render their success headers with the normal tool-title color instead of accent blue.
 
 - Fixed the working-status shimmer to opt into the loader's 30fps animated-message repaint path while keeping both the status spinner and pending bash/eval tool spinners on their normal 80 ms glyph cadence.

--- a/packages/coding-agent/src/commit/agentic/tools/split-commit.ts
+++ b/packages/coding-agent/src/commit/agentic/tools/split-commit.ts
@@ -68,6 +68,7 @@ export function createSplitCommitTool(
 			const errors: string[] = [];
 			const warnings: string[] = [];
 			const diffText = await git.diff(cwd, { cached: true });
+			const validateHunksForDiff = git.createHunkSelectionValidator(diffText);
 
 			const commits: SplitCommitGroup[] = params.commits.map((commit, index) => {
 				const scope = commit.scope?.trim() || null;
@@ -102,7 +103,7 @@ export function createSplitCommitTool(
 				}
 				warnings.push(...summaryValidation.warnings.map(warning => `Commit ${index + 1}: ${warning}`));
 				warnings.push(...typeValidation.warnings.map(warning => `Commit ${index + 1}: ${warning}`));
-				const hunkValidation = validateHunkSelectors(index, changes, files, diffText);
+				const hunkValidation = validateHunkSelectors(index, changes, files, validateHunksForDiff);
 				warnings.push(...hunkValidation.warnings);
 				errors.push(...hunkValidation.errors);
 				errors.push(...validateDependencies(index, dependencies, params.commits.length));
@@ -186,7 +187,7 @@ function validateHunkSelectors(
 	commitIndex: number,
 	changes: SplitCommitGroup["changes"],
 	files: string[],
-	diffText: string,
+	validateHunksForDiff: (changes: SplitCommitGroup["changes"]) => git.HunkSelectionValidationError[],
 ): { errors: string[]; warnings: string[] } {
 	const errors: string[] = [];
 	const warnings: string[] = [];
@@ -217,7 +218,7 @@ function validateHunkSelectors(
 		}
 	}
 	if (errors.length === 0) {
-		for (const error of git.validateHunkSelections(diffText, changes)) {
+		for (const error of validateHunksForDiff(changes)) {
 			errors.push(`${prefix}: ${error.message}`);
 		}
 	}

--- a/packages/coding-agent/src/commit/agentic/tools/split-commit.ts
+++ b/packages/coding-agent/src/commit/agentic/tools/split-commit.ts
@@ -102,7 +102,7 @@ export function createSplitCommitTool(
 				}
 				warnings.push(...summaryValidation.warnings.map(warning => `Commit ${index + 1}: ${warning}`));
 				warnings.push(...typeValidation.warnings.map(warning => `Commit ${index + 1}: ${warning}`));
-				const hunkValidation = validateHunkSelectors(index, changes, files);
+				const hunkValidation = validateHunkSelectors(index, changes, files, diffText);
 				warnings.push(...hunkValidation.warnings);
 				errors.push(...hunkValidation.errors);
 				errors.push(...validateDependencies(index, dependencies, params.commits.length));
@@ -186,6 +186,7 @@ function validateHunkSelectors(
 	commitIndex: number,
 	changes: SplitCommitGroup["changes"],
 	files: string[],
+	diffText: string,
 ): { errors: string[]; warnings: string[] } {
 	const errors: string[] = [];
 	const warnings: string[] = [];
@@ -213,6 +214,11 @@ function validateHunkSelectors(
 			if (Math.floor(start) !== start || Math.floor(end) !== end || start < 1 || end < start) {
 				errors.push(`${prefix}: invalid line range for ${change.path}`);
 			}
+		}
+	}
+	if (errors.length === 0) {
+		for (const error of git.validateHunkSelections(diffText, changes)) {
+			errors.push(`${prefix}: ${error.message}`);
 		}
 	}
 	return { errors, warnings };

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -692,10 +692,7 @@ export function validateHunkSelections(
 
 	for (const selection of selections) {
 		const fileDiff = fileDiffMap.get(selection.path);
-		if (!fileDiff) {
-			errors.push({ path: selection.path, message: `No diff found for ${selection.path}` });
-			continue;
-		}
+		if (!fileDiff) continue;
 		if (selection.hunks.type === "all") continue;
 		if (fileDiff.isBinary) {
 			errors.push({ path: selection.path, message: `Cannot select hunks for binary file ${selection.path}` });

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -682,12 +682,17 @@ function selectHunks(file: FileHunks, selector: HunkSelection["hunks"]): FileHun
 	return file.hunks;
 }
 
-export function validateHunkSelections(
+export function createHunkSelectionValidator(
 	rawDiff: string,
+): (selections: readonly HunkSelection[]) => HunkSelectionValidationError[] {
+	const fileDiffMap = new Map(parseFileDiffs(rawDiff).map(entry => [entry.filename, entry]));
+	return selections => validateHunkSelectionsFromMap(fileDiffMap, selections);
+}
+
+function validateHunkSelectionsFromMap(
+	fileDiffMap: ReadonlyMap<string, FileDiff>,
 	selections: readonly HunkSelection[],
 ): HunkSelectionValidationError[] {
-	const fileDiffs = parseFileDiffs(rawDiff);
-	const fileDiffMap = new Map(fileDiffs.map(entry => [entry.filename, entry]));
 	const errors: HunkSelectionValidationError[] = [];
 
 	for (const selection of selections) {
@@ -705,6 +710,13 @@ export function validateHunkSelections(
 	}
 
 	return errors;
+}
+
+export function validateHunkSelections(
+	rawDiff: string,
+	selections: readonly HunkSelection[],
+): HunkSelectionValidationError[] {
+	return createHunkSelectionValidator(rawDiff)(selections);
 }
 
 function parseStatusPorcelain(text: string): GitStatusSummary {

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -45,6 +45,10 @@ export interface StageHunksOptions {
 	readonly rawDiff?: string;
 	readonly signal?: AbortSignal;
 }
+export interface HunkSelectionValidationError {
+	readonly path: string;
+	readonly message: string;
+}
 
 export interface DiffOptions {
 	readonly allowFailure?: boolean;
@@ -676,6 +680,34 @@ function selectHunks(file: FileHunks, selector: HunkSelection["hunks"]): FileHun
 		return file.hunks.filter(hunk => hunk.newStart <= end && hunk.newStart + hunk.newLines - 1 >= start);
 	}
 	return file.hunks;
+}
+
+export function validateHunkSelections(
+	rawDiff: string,
+	selections: readonly HunkSelection[],
+): HunkSelectionValidationError[] {
+	const fileDiffs = parseFileDiffs(rawDiff);
+	const fileDiffMap = new Map(fileDiffs.map(entry => [entry.filename, entry]));
+	const errors: HunkSelectionValidationError[] = [];
+
+	for (const selection of selections) {
+		const fileDiff = fileDiffMap.get(selection.path);
+		if (!fileDiff) {
+			errors.push({ path: selection.path, message: `No diff found for ${selection.path}` });
+			continue;
+		}
+		if (selection.hunks.type === "all") continue;
+		if (fileDiff.isBinary) {
+			errors.push({ path: selection.path, message: `Cannot select hunks for binary file ${selection.path}` });
+			continue;
+		}
+		const selected = selectHunks(parseFileHunks(fileDiff), selection.hunks);
+		if (selected.length === 0) {
+			errors.push({ path: selection.path, message: `No hunks selected for ${selection.path}` });
+		}
+	}
+
+	return errors;
 }
 
 function parseStatusPorcelain(text: string): GitStatusSummary {

--- a/packages/coding-agent/test/commit-split-hunk-validation.test.ts
+++ b/packages/coding-agent/test/commit-split-hunk-validation.test.ts
@@ -95,4 +95,38 @@ describe("split_commit hunk selector validation", () => {
 		expect(result.details.errors).toContain("Commit 1: No hunks selected for src/a.ts");
 		expect(state.splitProposal).toBeUndefined();
 	});
+
+	it("allows deferred changelog targets that are not in the staged diff yet", async () => {
+		vi.spyOn(git, "diff").mockResolvedValue(STAGED_DIFF);
+		const state: CommitAgentState = {
+			overview: { files: ["src/a.ts", "src/b.ts"], stat: "", numstat: [], scopeCandidates: "", isWideScope: false },
+		};
+		const tool = createSplitCommitTool("/repo", state, ["packages/coding-agent/CHANGELOG.md"]);
+
+		const result = await tool.execute(
+			"split-commit",
+			{
+				commits: [
+					{
+						changes: [
+							{ path: "src/a.ts", hunks: { type: "all" } },
+							{ path: "src/b.ts", hunks: { type: "all" } },
+							{ path: "packages/coding-agent/CHANGELOG.md", hunks: { type: "all" } },
+						],
+						type: "fix",
+						scope: null,
+						summary: "Fixed deferred changelog validation",
+					},
+				],
+			},
+			undefined,
+			{} as never,
+		);
+
+		expect(result.details.valid).toBe(true);
+		expect(result.details.errors).not.toContain("Commit 1: No diff found for packages/coding-agent/CHANGELOG.md");
+		expect(state.splitProposal?.commits[0]?.changes.map(change => change.path)).toContain(
+			"packages/coding-agent/CHANGELOG.md",
+		);
+	});
 });

--- a/packages/coding-agent/test/commit-split-hunk-validation.test.ts
+++ b/packages/coding-agent/test/commit-split-hunk-validation.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import type { CommitAgentState } from "../src/commit/agentic/state";
+import { createSplitCommitTool } from "../src/commit/agentic/tools/split-commit";
+import * as git from "../src/utils/git";
+
+const STAGED_DIFF = `diff --git a/src/a.ts b/src/a.ts
+index 1111111..2222222 100644
+--- a/src/a.ts
++++ b/src/a.ts
+@@ -1,3 +1,3 @@
+ export function a() {
+-	return 1;
++	return 2;
+ }
+diff --git a/src/b.ts b/src/b.ts
+index 3333333..4444444 100644
+--- a/src/b.ts
++++ b/src/b.ts
+@@ -1,3 +1,3 @@
+ export function b() {
+-	return 1;
++	return 2;
+ }
+`;
+
+describe("split_commit hunk selector validation", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("rejects hunk index selectors that match no parsed hunk", async () => {
+		vi.spyOn(git, "diff").mockResolvedValue(STAGED_DIFF);
+		const state: CommitAgentState = {
+			overview: { files: ["src/a.ts", "src/b.ts"], stat: "", numstat: [], scopeCandidates: "", isWideScope: false },
+		};
+		const tool = createSplitCommitTool("/repo", state, []);
+
+		const result = await tool.execute(
+			"split-commit",
+			{
+				commits: [
+					{
+						changes: [{ path: "src/a.ts", hunks: { type: "indices", indices: [2] } }],
+						type: "fix",
+						scope: null,
+						summary: "Fixed invalid selector handling",
+					},
+					{
+						changes: [{ path: "src/b.ts", hunks: { type: "all" } }],
+						type: "fix",
+						scope: null,
+						summary: "Fixed split commit coverage",
+					},
+				],
+			},
+			undefined,
+			{} as never,
+		);
+
+		expect(result.details.valid).toBe(false);
+		expect(result.details.errors).toContain("Commit 1: No hunks selected for src/a.ts");
+		expect(state.splitProposal).toBeUndefined();
+	});
+
+	it("rejects line selectors that overlap no parsed hunk", async () => {
+		vi.spyOn(git, "diff").mockResolvedValue(STAGED_DIFF);
+		const state: CommitAgentState = {
+			overview: { files: ["src/a.ts", "src/b.ts"], stat: "", numstat: [], scopeCandidates: "", isWideScope: false },
+		};
+		const tool = createSplitCommitTool("/repo", state, []);
+
+		const result = await tool.execute(
+			"split-commit",
+			{
+				commits: [
+					{
+						changes: [{ path: "src/a.ts", hunks: { type: "lines", start: 50, end: 60 } }],
+						type: "fix",
+						scope: null,
+						summary: "Fixed invalid line selectors",
+					},
+					{
+						changes: [{ path: "src/b.ts", hunks: { type: "all" } }],
+						type: "fix",
+						scope: null,
+						summary: "Fixed split commit coverage",
+					},
+				],
+			},
+			undefined,
+			{} as never,
+		);
+
+		expect(result.details.valid).toBe(false);
+		expect(result.details.errors).toContain("Commit 1: No hunks selected for src/a.ts");
+		expect(state.splitProposal).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Fixes #2098.

## Summary
- validate split-commit hunk selectors against the parsed staged diff before accepting a proposal
- reuse the same selector resolution semantics as selective staging
- add regression tests for out-of-range hunk indices and non-overlapping line ranges

## Verification
- bun test packages/coding-agent/test/commit-split-hunk-validation.test.ts
- bun --cwd=packages/coding-agent run check