### PR TITLE
fix(tui): reset scrollback high-water on full repaint so a multiplexer rewind doesn't strand the viewport

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed rewinding/branching to an earlier message inside tmux (and other multiplexers) permanently corrupting the viewport once an assistant reply had grown past the pane: the chat input anchored to the top of the screen and scrolling back through pane history showed overlaid/discontinuous transcript. Regression from #1974, which started committing a streamed reply's scrolled-off head into pane history and tracking it in `#scrollbackHighWater`. A rewind collapses the transcript below that peak, but the `sessionReplace`/`historyRebuild` full paint cannot erase multiplexer pane history (`clearScrollback` is forced off there) and `#emitFullPaint` only ever *raised* `#scrollbackHighWater` — so the stale peak survived the shrink and the pinned emitter positioned every subsequent frame past the real content (the `naturalViewportTop < #scrollbackHighWater` shrink rebuild that would otherwise reconcile it is gated `!isMultiplexerSession()`). A full repaint now resets `#scrollbackHighWater` to the rows it actually pushed above the viewport, so the rewind reconciles the high-water even when pane history cannot be cleared ([#2130](https://github.com/can1357/oh-my-pi/issues/2130)).
+
 ## [15.10.5] - 2026-06-08
 
 ### Added

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -3063,11 +3063,26 @@ export class TUI extends Container {
 
 		this.#maxLinesRendered = options.clearViewport ? lines.length : Math.max(this.#maxLinesRendered, lines.length);
 		if (options.clearScrollback) {
-			this.#scrollbackHighWater = 0;
 			this.#suppressNextSuffixScroll = lines.length > height;
 		}
 		const pushedNow = Math.max(0, lines.length - height);
-		if (pushedNow > this.#scrollbackHighWater) {
+		if (options.clearViewport) {
+			// A full repaint rewrites the entire transcript from home, so exactly
+			// `pushedNow` rows now sit above the viewport — that is the new high-water,
+			// not the max with the previous frame's. This must *lower* it on a shrink,
+			// not just raise it. Multiplexers (`clearScrollback: false`) cannot erase
+			// the stale pane-history rows left above the fresh content, but those rows
+			// are no longer part of the logical transcript and must not leak into the
+			// live-region/diff math: a stale-high `#scrollbackHighWater` makes the
+			// pinned emitter's `appendFrom`/`committedSealedEnd` point past the real
+			// content, mispositioning every frame after a rewind (the input drifts to
+			// the top of the pane and scrollback overlays incorrectly). Resetting here
+			// is the rewind-shrink reconcile that `#resolveRenderIntent` skips inside a
+			// multiplexer (its `naturalViewportTop < #scrollbackHighWater` rebuild is
+			// gated `!isMultiplexerSession()`). Equivalent to the old reset-to-0 path
+			// for `clearScrollback`, since every full paint clears the viewport.
+			this.#scrollbackHighWater = pushedNow;
+		} else if (pushedNow > this.#scrollbackHighWater) {
 			this.#scrollbackHighWater = pushedNow;
 		}
 		this.#commit(lines, width, height, Math.max(0, this.#maxLinesRendered - height), cursorControl);
@@ -3645,7 +3660,8 @@ export class TUI extends Container {
 							? `${intent.kind}(row=${intent.row})`
 							: intent.kind;
 		const state =
-			`shw=${this.#scrollbackHighWater}, max=${this.#maxLinesRendered}, vpTop=${this.#viewportTopRow}, ` +
+			`shw=${this.#scrollbackHighWater}, streamHW=${this.#streamingHighWater}, mux=${isMultiplexerSession()}, ` +
+			`max=${this.#maxLinesRendered}, vpTop=${this.#viewportTopRow}, ` +
 			`dirty=${this.#nativeScrollbackDirty}, eager=${this.#eagerNativeScrollbackRebuild}, ` +
 			`lrStart=${this.#nativeScrollbackLiveRegionStart}, commitSafeEnd=${this.#nativeScrollbackCommitSafeEnd}`;
 		const msg = `[${new Date().toISOString()}] render: ${detail} (prev=${this.#previousLines.length}, new=${newLength}, height=${height}, ${state})\n`;

--- a/packages/tui/test/issue-1974-repro.test.ts
+++ b/packages/tui/test/issue-1974-repro.test.ts
@@ -359,4 +359,77 @@ describe("issue #1974: tmux scrollback rendering", () => {
 			}
 		});
 	});
+
+	// Regression for the rewind/branch viewport corruption introduced by the
+	// #1974 fix. Once streaming commits a large `#scrollbackHighWater` to tmux
+	// pane history, a rewind that collapses the transcript below that peak used
+	// to leave the high-water stale: `#emitFullPaint` only ever *raised* it, and
+	// the `naturalViewportTop < #scrollbackHighWater` shrink rebuild that would
+	// reconcile it is gated `!isMultiplexerSession()`. The pinned emitter then
+	// positioned the next reply past the real content — the input anchored to the
+	// top of the pane and scrollback overlaid incorrectly. A full repaint must
+	// reset the high-water to the rows it actually pushed above the viewport.
+	it("repositions the next reply after a rewind shrinks below the streaming high-water", async () => {
+		if (process.platform === "win32") return;
+
+		await withEnvPatch(TMUX_ENV, async () => {
+			await withTerminalRisk(true, async () => {
+				const term = new VirtualTerminal(80, 8, 10_000);
+				overrideProbe(term, undefined);
+				const tui = new TUI(term);
+				const stream = new StreamingLiveRegion([]);
+				tui.addChild(stream);
+
+				try {
+					tui.start();
+					tui.setEagerNativeScrollbackRebuild(true);
+					await settle(term);
+
+					// 1. Stream a tall first reply so the renderer commits a large
+					//    high-water of rows into tmux pane history.
+					const replyA = Array.from({ length: 40 }, (_unused, i) => `A-${String(i).padStart(3, "0")}`);
+					for (let chunk = 5; chunk <= replyA.length; chunk += 5) {
+						stream.setLines(replyA.slice(0, chunk));
+						tui.requestRender();
+						await settle(term);
+					}
+
+					// 2. Rewind/branch: the transcript collapses to a short prefix and
+					//    the caller forces a clear-scrollback full paint — exactly what
+					//    `branch()` drives. In tmux this is a `sessionReplace` that
+					//    cannot erase pane history (`clearScrollback` forced off), so the
+					//    only chance to drop the stale high-water is the full repaint.
+					stream.setLines(["A-000"]);
+					tui.requestRender(true, { clearScrollback: true });
+					await settle(term);
+
+					// 3. Stream the post-rewind reply. With a stale high-water the
+					//    pinned emitter positions these rows past the real content and
+					//    they overlay / duplicate in pane history.
+					const replyB = Array.from({ length: 30 }, (_unused, i) => `B-${String(i).padStart(3, "0")}`);
+					for (let chunk = 5; chunk <= replyB.length; chunk += 5) {
+						stream.setLines(["A-000", ...replyB.slice(0, chunk)]);
+						tui.requestRender();
+						await settle(term);
+					}
+
+					// Every post-rewind row appears exactly once across pane history +
+					// viewport: no "missing sections", no "repeating chunks".
+					const buffer = strip(term.getScrollBuffer()).join("\n");
+					const missing = replyB.filter(mark => occurrencesOf(buffer, mark) === 0);
+					const duplicated = replyB.filter(mark => occurrencesOf(buffer, mark) > 1);
+					expect(missing).toEqual([]);
+					expect(duplicated).toEqual([]);
+
+					// The live tail is anchored in the viewport, not stranded above a
+					// blank pane or pushed off the top.
+					const viewport = strip(term.getViewport());
+					expect(viewport.some(row => row.includes("B-029"))).toBe(true);
+				} finally {
+					tui.stop();
+					await term.flush();
+				}
+			});
+		});
+	});
 });


### PR DESCRIPTION
## Repro

Inside a tmux pane, send a prompt whose reply is taller than the viewport so the transcript fills the pane and scrolls. Let it finish, then double-ESC → Enter to branch/rewind to the user message. The chat input anchors to the top of the pane and stays there; scrolling back through pane history shows the new transcript overlaid on stale pre-rewind rows with no continuity. The state is permanent for the session. Confirmed by `git bisect` to first appear in `c7cb451` (the #1974 fix); the previous commit is clean.

Captured live via `PI_DEBUG_REDRAW=1`, the rewind frame:

```
sessionReplace (prev=588, new=453, height=79, shw=509, streamHW=0, mux=true, clearScrollback=false, ...)
diff(first=451, last=458, appended=true) (prev=453, new=459, shw=509, max=453, vpTop=374, ...)
```

— transcript shrank 588→453 but `#scrollbackHighWater` stayed 509, and every subsequent frame kept `shw=509` against a 453-row transcript.

## Cause

#1974 enabled the pinned live-region emitter inside multiplexers and exempted them from the cap-to-viewport branch, so a streamed reply now genuinely commits its scrolled-off head into tmux pane history and tracks the peak in `#scrollbackHighWater`. A rewind collapses the transcript below that peak. The `sessionReplace`/`historyRebuild` full paint that handles the rewind cannot erase multiplexer pane history (`clearScrollback` is forced off there), and `#emitFullPaint` only ever *raised* `#scrollbackHighWater`. The stale peak therefore survived the shrink, and the pinned emitter's `appendFrom` / `committedSealedEnd` (`Math.min(#scrollbackHighWater, …)`) pointed ~135 rows past the real content, mispositioning every frame after the rewind. The one path that would reconcile a shrink that re-exposes committed scrollback (`naturalViewportTop < #scrollbackHighWater` → rebuild) is gated `!isMultiplexerSession()`, so it never fires in tmux. Pre-#1974 the cap reset `#scrollbackHighWater` to 0 each streaming frame in tmux, so the peak was ~0 at rewind time and nothing was stranded.

## Fix

`packages/tui/src/tui.ts`
- `#emitFullPaint` now sets `#scrollbackHighWater = pushedNow` on any full repaint (`clearViewport`), lowering it on a shrink rather than only raising. A full repaint rewrites the whole transcript from home, so exactly `pushedNow` rows sit above the viewport — any earlier peak belonged to the old transcript. Behaviorally identical to the prior reset-to-0 path for `clearScrollback` (every full paint clears the viewport); only the multiplexer shrink case changes. This is the rewind-shrink reconcile that `#resolveRenderIntent` skips inside a multiplexer.
- Surfaced `streamHW` / `mux` / `clearScrollback` in the `PI_DEBUG_REDRAW` render log (the field set that localized this bug).

`packages/tui/test/issue-1974-repro.test.ts`
- New regression test: stream a tall reply, force a clear-scrollback rewind to a short prefix, then stream the next reply. Asserts every post-rewind row appears exactly once across pane history + viewport (no missing/duplicated rows) and the live tail stays in the viewport. Fails without the fix (the post-rewind reply is stranded out of the buffer entirely).

`packages/tui/CHANGELOG.md` — entry under `## [Unreleased]`.

## Verification

`cd packages/tui && bun test --parallel test/*.test.ts` → 762 pass / 0 fail across 54 files. New test red without the fix (761/1), green with it; the failing-test diff confirms it's the only delta. (Note: the suite must not be run from inside a multiplexer — an inherited `$TMUX` flips `isMultiplexerSession()` and spuriously fails the non-multiplexer regression tests.)

`bun run --cwd packages/tui check:types` and biome check on the changed files both pass.

Fixes #2130

Co-Authored using AI