### PR TITLE
fix(coding-agent): scanned skill args for magic keywords and +Nk turn budget (#2126)

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -147,6 +147,8 @@ If `skills.enableSkillCommands` is true, interactive mode registers one slash co
   - **Enter** → invokes the skill on the `steer` queue while streaming (matches free-text Enter, which also steers), or as a normal idle prompt when the agent is not streaming
   - **Ctrl+Enter** (`app.message.followUp`) → invokes the skill on the `followUp` queue while streaming, or as a normal idle prompt when the agent is not streaming
 - appends metadata (`Skill: <path>`, optional `User: <args>`)
+- args capture: everything after the first **space** is the arg string, verbatim — newlines included. `indexOf(" ")` is the only delimiter; there is no escape sequence and no way to mix unrelated trailing prose with a skill invocation. To send free prose alongside a skill, invoke the skill bare (`/skill:name`) and send the prose as a separate turn.
+- magic-keyword scan: the args are scanned for the editor's gradient-highlighted keywords (`ultrathink`, `orchestrate`, `workflowz`) and the `+Nk` turn-budget directive, so `/skill:foo workflowz compare …` injects the workflow notice just as a plain `workflowz compare …` message would. Keywords inside the **skill body** are never scanned — that text belongs to the skill author, not the user — so a body that mentions `orchestrate` in prose does not silently enable orchestration mode.
 
 There is no flag, mode-selector, or frontmatter knob to override this — the keybinding _is_ the choice, identical to how free text is routed during streaming (`input-controller.ts:243-249` for Enter, `input-controller.ts:462-500` for Ctrl+Enter; both dispatch through `#invokeSkillCommand`).
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed magic keywords (`ultrathink`, `orchestrate`, `workflowz`) and the `+Nk` turn-budget directive being silently inert when typed inside a `/skill:<name> …` invocation. Skill dispatch routes through `AgentSession.promptCustomMessage`, which never ran the keyword/budget scan that `prompt()` runs on user input — so a highlighted keyword in skill args looked active in the editor but never injected its hidden system notice. `promptCustomMessage` now accepts an optional `keywordText` parameter; both skill dispatch sites (interactive `InputController.#invokeSkillCommand` and `AcpAgent.#tryRunSkillCommand`) pass the user-typed args, so a highlighted `workflowz`/`orchestrate`/`ultrathink`/`+500k` in `/skill:foo workflowz compare …` now takes effect ([#2126](https://github.com/can1357/oh-my-pi/issues/2126)).
+
 ## [15.10.5] - 2026-06-08
 
 ### Added

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -718,13 +718,16 @@ export class AcpAgent implements Agent {
 			return false;
 		}
 		const built = await buildSkillPromptMessage(skill, args);
-		await record.session.promptCustomMessage({
-			customType: SKILL_PROMPT_MESSAGE_TYPE,
-			content: built.message,
-			display: true,
-			details: built.details,
-			attribution: "user",
-		});
+		await record.session.promptCustomMessage(
+			{
+				customType: SKILL_PROMPT_MESSAGE_TYPE,
+				content: built.message,
+				display: true,
+				details: built.details,
+				attribution: "user",
+			},
+			{ keywordText: args },
+		);
 		return true;
 	}
 

--- a/packages/coding-agent/src/modes/controllers/input-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/input-controller.ts
@@ -609,7 +609,7 @@ export class InputController {
 					details,
 					attribution: "user",
 				},
-				{ streamingBehavior },
+				{ streamingBehavior, keywordText: args },
 			);
 			if (this.ctx.session.isStreaming) {
 				this.ctx.updatePendingMessagesDisplay();

--- a/packages/coding-agent/src/modes/magic-keyword-notices.ts
+++ b/packages/coding-agent/src/modes/magic-keyword-notices.ts
@@ -1,0 +1,69 @@
+import type { CustomMessage } from "../session/messages";
+import { containsOrchestrate, ORCHESTRATE_NOTICE } from "./orchestrate";
+import { parseTurnBudget, type TurnBudget } from "./turn-budget";
+import { containsUltrathink, ULTRATHINK_NOTICE } from "./ultrathink";
+import { containsWorkflow, WORKFLOW_NOTICE } from "./workflow";
+
+/**
+ * Result of {@link scanMagicKeywords}: the hidden system notices to append
+ * after the user's message and the parsed turn-budget directive (or `null`
+ * when absent).
+ */
+export interface MagicKeywordScan {
+	notices: CustomMessage[];
+	turnBudget: TurnBudget | null;
+}
+
+/**
+ * Scan user-typed prose for the magic keywords (`ultrathink`, `orchestrate`,
+ * `workflowz`) and a `+Nk`-style turn-budget directive. Returns the custom
+ * notices to inject after the user's message and the parsed budget. Stateless:
+ * the caller is responsible for actually starting the budget via
+ * {@link SessionManager.beginTurnBudget}.
+ *
+ * Two entry points feed this helper today:
+ *
+ * - `AgentSession.prompt()` for plain user prompts;
+ * - `AgentSession.promptCustomMessage({...}, { keywordText })` for skill
+ *   invocations (`/skill:<name> …`) — the user-typed args are scanned so a
+ *   highlighted `workflowz`/`orchestrate`/`ultrathink`/`+500k` inside a skill
+ *   line takes effect, matching what the editor's gradient implies (#2126).
+ *
+ * Notices are flagged `attribution: "user"` because they encode user intent,
+ * not agent-side state.
+ */
+export function scanMagicKeywords(text: string): MagicKeywordScan {
+	const notices: CustomMessage[] = [];
+	const timestamp = Date.now();
+	if (containsUltrathink(text)) {
+		notices.push({
+			role: "custom",
+			customType: "ultrathink-notice",
+			content: ULTRATHINK_NOTICE,
+			display: false,
+			attribution: "user",
+			timestamp,
+		});
+	}
+	if (containsOrchestrate(text)) {
+		notices.push({
+			role: "custom",
+			customType: "orchestrate-notice",
+			content: ORCHESTRATE_NOTICE,
+			display: false,
+			attribution: "user",
+			timestamp,
+		});
+	}
+	if (containsWorkflow(text)) {
+		notices.push({
+			role: "custom",
+			customType: "workflow-notice",
+			content: WORKFLOW_NOTICE,
+			display: false,
+			attribution: "user",
+			timestamp,
+		});
+	}
+	return { notices, turnBudget: parseTurnBudget(text) };
+}

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -163,12 +163,10 @@ import type { HindsightSessionState } from "../hindsight/state";
 import { type LocalProtocolOptions, resolveLocalUrlToPath } from "../internal-urls";
 import { resolveMemoryBackend } from "../memory-backend";
 import { getMnemopiSessionState, type MnemopiSessionState, setMnemopiSessionState } from "../mnemopi/state";
-import { containsOrchestrate, ORCHESTRATE_NOTICE } from "../modes/orchestrate";
+import { scanMagicKeywords } from "../modes/magic-keyword-notices";
 import { getCurrentThemeName, theme } from "../modes/theme/theme";
-import { parseTurnBudget } from "../modes/turn-budget";
-import { containsUltrathink, ULTRATHINK_NOTICE } from "../modes/ultrathink";
+import { containsUltrathink } from "../modes/ultrathink";
 import { computeNonMessageTokens } from "../modes/utils/context-usage";
-import { containsWorkflow, WORKFLOW_NOTICE } from "../modes/workflow";
 import { createPlanReadMatcher } from "../plan-mode/plan-protection";
 import type { PlanModeState } from "../plan-mode/state";
 import autoContinuePrompt from "../prompts/system/auto-continue.md" with { type: "text" };
@@ -4373,44 +4371,14 @@ export class AgentSession {
 		// Expand file-based prompt templates if requested
 		const expandedText = expandPromptTemplates ? expandPromptTemplate(text, [...this.#promptTemplates]) : text;
 
-		// Magic keywords ("ultrathink", "orchestrate"): append hidden system notices after the
-		// user's message that steer this turn. User-authored prompts only — synthetic /
+		// Magic keywords (`ultrathink`, `orchestrate`, `workflowz`) and the `+Nk`
+		// turn-budget directive: scan user-authored prompts only. Synthetic /
 		// agent-initiated turns never trigger them.
-		const keywordNotices: CustomMessage[] = [];
+		let keywordNotices: CustomMessage[] = [];
 		if (!options?.synthetic) {
-			const timestamp = Date.now();
-			const turnBudget = parseTurnBudget(expandedText);
-			this.sessionManager.beginTurnBudget(turnBudget?.total ?? null, turnBudget?.hard ?? false);
-			if (containsUltrathink(expandedText)) {
-				keywordNotices.push({
-					role: "custom",
-					customType: "ultrathink-notice",
-					content: ULTRATHINK_NOTICE,
-					display: false,
-					attribution: "user",
-					timestamp,
-				});
-			}
-			if (containsOrchestrate(expandedText)) {
-				keywordNotices.push({
-					role: "custom",
-					customType: "orchestrate-notice",
-					content: ORCHESTRATE_NOTICE,
-					display: false,
-					attribution: "user",
-					timestamp,
-				});
-			}
-			if (containsWorkflow(expandedText)) {
-				keywordNotices.push({
-					role: "custom",
-					customType: "workflow-notice",
-					content: WORKFLOW_NOTICE,
-					display: false,
-					attribution: "user",
-					timestamp,
-				});
-			}
+			const scan = scanMagicKeywords(expandedText);
+			this.sessionManager.beginTurnBudget(scan.turnBudget?.total ?? null, scan.turnBudget?.hard ?? false);
+			keywordNotices = scan.notices;
 		}
 
 		// If streaming, queue via steer() or followUp() based on option
@@ -4471,7 +4439,19 @@ export class AgentSession {
 
 	async promptCustomMessage<T = unknown>(
 		message: Pick<CustomMessage<T>, "customType" | "content" | "display" | "details" | "attribution">,
-		options?: Pick<PromptOptions, "streamingBehavior" | "toolChoice">,
+		options?: Pick<PromptOptions, "streamingBehavior" | "toolChoice"> & {
+			/**
+			 * User-typed prose to scan for magic keywords (`ultrathink`,
+			 * `orchestrate`, `workflowz`) and a `+Nk` turn-budget directive.
+			 * Skill dispatch (`/skill:<name> …`) routes here instead of through
+			 * `prompt()`, so without this hook a highlighted keyword inside the
+			 * skill args would be inert despite the editor painting it (#2126).
+			 * Passing the trimmed args here lets the keyword scan run on the
+			 * user-authored fragment of the message — never the skill body
+			 * (which is owned by the skill author).
+			 */
+			keywordText?: string;
+		},
 	): Promise<void> {
 		const textContent =
 			typeof message.content === "string"
@@ -4481,11 +4461,23 @@ export class AgentSession {
 						.map(content => content.text)
 						.join("");
 
+		let keywordNotices: CustomMessage[] = [];
+		if (options?.keywordText) {
+			const scan = scanMagicKeywords(options.keywordText);
+			this.sessionManager.beginTurnBudget(scan.turnBudget?.total ?? null, scan.turnBudget?.hard ?? false);
+			keywordNotices = scan.notices;
+		}
+
 		if (this.isStreaming) {
 			if (!options?.streamingBehavior) {
 				throw new AgentBusyError();
 			}
 			await this.sendCustomMessage(message, { deliverAs: options.streamingBehavior });
+			// Steer/follow-up the keyword notices alongside the queued custom message
+			// so they reach the same turn the user just dispatched.
+			for (const notice of keywordNotices) {
+				await this.sendCustomMessage(notice, { deliverAs: options.streamingBehavior });
+			}
 			return;
 		}
 
@@ -4499,7 +4491,10 @@ export class AgentSession {
 			timestamp: Date.now(),
 		};
 
-		await this.#promptWithMessage(customMessage, textContent, options);
+		await this.#promptWithMessage(customMessage, textContent, {
+			...options,
+			appendMessages: keywordNotices.length > 0 ? keywordNotices : undefined,
+		});
 	}
 
 	async #promptWithMessage(

--- a/packages/coding-agent/test/agent-session-skill-keywords.test.ts
+++ b/packages/coding-agent/test/agent-session-skill-keywords.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AgentMessage } from "@oh-my-pi/pi-agent-core";
+import { createMockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm, SKILL_PROMPT_MESSAGE_TYPE } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+/**
+ * Regression coverage for #2126: skill invocations dispatch through
+ * `promptCustomMessage`, which used to bypass the magic-keyword scan that
+ * `prompt()` runs on user input — so a highlighted `workflowz`/`orchestrate`/
+ * `ultrathink`/`+Nk` typed inside `/skill:<name> …` looked active but never
+ * injected its hidden system notice. The fix threads `keywordText` through
+ * `promptCustomMessage`; both skill dispatch sites (interactive +
+ * ACP) now pass the trimmed args.
+ */
+
+type Harness = { session: AgentSession; authStorage: AuthStorage; tempDir: TempDir };
+const harnesses: Harness[] = [];
+
+async function createHarness(responses: MockResponse[]): Promise<AgentSession> {
+	const tempDir = TempDir.createSync("@pi-skill-keywords-");
+	const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+	authStorage.setRuntimeApiKey("mock", "test-key");
+
+	const mock = createMockModel({ responses });
+	const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+	const settings = Settings.isolated({
+		"compaction.enabled": false,
+		"retry.enabled": false,
+		"todo.enabled": false,
+		"todo.eager": false,
+		"todo.reminders": false,
+	});
+	settings.setModelRole("default", `${mock.provider}/${mock.id}`);
+
+	const sessionManager = SessionManager.inMemory(tempDir.path());
+	const agent = new Agent({
+		getApiKey: () => "test-key",
+		initialState: {
+			model: mock,
+			systemPrompt: ["Test"],
+			tools: [],
+			messages: [],
+		},
+		convertToLlm,
+		streamFn: mock.stream,
+	});
+
+	const session = new AgentSession({
+		agent,
+		sessionManager,
+		settings,
+		modelRegistry,
+		toolRegistry: new Map(),
+	});
+
+	harnesses.push({ session, authStorage, tempDir });
+	return session;
+}
+
+afterEach(async () => {
+	for (const h of harnesses.splice(0)) {
+		await h.session.dispose();
+		h.authStorage.close();
+		h.tempDir.removeSync();
+	}
+	vi.restoreAllMocks();
+});
+
+const SKILL_BODY = "Skill body. No keywords here.\n\n---\n\nSkill: /tmp/dummy.md";
+const SKILL_DETAILS = { name: "dummy", path: "/tmp/dummy.md", lineCount: 1 };
+
+describe("AgentSession skill keyword wiring (#2126)", () => {
+	it("injects the matching notices when keywordText carries magic keywords", async () => {
+		const session = await createHarness([{ content: ["done"], stopReason: "stop" }]);
+
+		await session.promptCustomMessage(
+			{
+				customType: SKILL_PROMPT_MESSAGE_TYPE,
+				content: `${SKILL_BODY}\nUser: workflowz and orchestrate`,
+				display: true,
+				details: SKILL_DETAILS,
+				attribution: "user",
+			},
+			{ keywordText: "workflowz and orchestrate" },
+		);
+		await session.waitForIdle();
+
+		const customTypes = session.agent.state.messages
+			.filter((m): m is Extract<AgentMessage, { role: "custom" }> => m.role === "custom")
+			.map(m => m.customType);
+
+		expect(customTypes).toContain("orchestrate-notice");
+		expect(customTypes).toContain("workflow-notice");
+		expect(customTypes).not.toContain("ultrathink-notice");
+	});
+
+	it("starts the +Nk turn budget parsed out of keywordText", async () => {
+		const session = await createHarness([{ content: ["ack"], stopReason: "stop" }]);
+
+		await session.promptCustomMessage(
+			{
+				customType: SKILL_PROMPT_MESSAGE_TYPE,
+				content: `${SKILL_BODY}\nUser: compare these +500k`,
+				display: true,
+				details: SKILL_DETAILS,
+				attribution: "user",
+			},
+			{ keywordText: "compare these +500k" },
+		);
+		await session.waitForIdle();
+
+		const budget = session.sessionManager.getTurnBudget();
+		expect(budget.total).toBe(500_000);
+		expect(budget.hard).toBe(false);
+	});
+
+	it("ignores keywords that appear only in the skill body, not in keywordText", async () => {
+		// Skill author's prose mentioning a keyword is NOT user intent.
+		// `keywordText` is the user-typed args only; the body should never trigger.
+		const session = await createHarness([{ content: ["ack"], stopReason: "stop" }]);
+
+		await session.promptCustomMessage(
+			{
+				customType: SKILL_PROMPT_MESSAGE_TYPE,
+				content: "Skill body mentions orchestrate and workflowz inline.\n\n---\n\nSkill: /tmp/dummy.md",
+				display: true,
+				details: SKILL_DETAILS,
+				attribution: "user",
+			},
+			{ keywordText: "" },
+		);
+		await session.waitForIdle();
+
+		const customTypes = session.agent.state.messages
+			.filter((m): m is Extract<AgentMessage, { role: "custom" }> => m.role === "custom")
+			.map(m => m.customType);
+		expect(customTypes).not.toContain("orchestrate-notice");
+		expect(customTypes).not.toContain("workflow-notice");
+	});
+
+	it("stays back-compat: no keywordText means no scan and no notices", async () => {
+		const session = await createHarness([{ content: ["ack"], stopReason: "stop" }]);
+
+		await session.promptCustomMessage({
+			customType: SKILL_PROMPT_MESSAGE_TYPE,
+			content: "Plain custom message; pretend workflowz is in the args.",
+			display: true,
+			details: SKILL_DETAILS,
+			attribution: "user",
+		});
+		await session.waitForIdle();
+
+		const customTypes = session.agent.state.messages
+			.filter((m): m is Extract<AgentMessage, { role: "custom" }> => m.role === "custom")
+			.map(m => m.customType);
+		expect(customTypes).not.toContain("orchestrate-notice");
+		expect(customTypes).not.toContain("workflow-notice");
+		expect(customTypes).not.toContain("ultrathink-notice");
+		expect(session.sessionManager.getTurnBudget().total).toBeNull();
+	});
+});

--- a/packages/coding-agent/test/modes/magic-keyword-notices.test.ts
+++ b/packages/coding-agent/test/modes/magic-keyword-notices.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { scanMagicKeywords } from "@oh-my-pi/pi-coding-agent/modes/magic-keyword-notices";
+
+describe("scanMagicKeywords", () => {
+	it("returns no notices and no budget for plain prose", () => {
+		const result = scanMagicKeywords("just a regular message");
+		expect(result.notices).toEqual([]);
+		expect(result.turnBudget).toBeNull();
+	});
+
+	it("emits each keyword notice exactly once with attribution=user and display=false", () => {
+		const result = scanMagicKeywords("please ultrathink and orchestrate the workflowz");
+
+		const customTypes = result.notices.map(notice => notice.customType);
+		expect(customTypes).toEqual(["ultrathink-notice", "orchestrate-notice", "workflow-notice"]);
+
+		for (const notice of result.notices) {
+			expect(notice.role).toBe("custom");
+			expect(notice.display).toBe(false);
+			expect(notice.attribution).toBe("user");
+			expect(typeof notice.content).toBe("string");
+			expect((notice.content as string).length).toBeGreaterThan(0);
+		}
+	});
+
+	it("never flags keywords inside code spans, fenced blocks, or XML sections", () => {
+		const result = scanMagicKeywords("`ultrathink`\n```\norchestrate\n```\n<n>workflowz</n>");
+		expect(result.notices).toEqual([]);
+	});
+
+	it("parses the +Nk turn budget directive and surfaces hard mode", () => {
+		expect(scanMagicKeywords("compare these +500k").turnBudget).toEqual({ total: 500_000, hard: false });
+		expect(scanMagicKeywords("+2m! hard cap").turnBudget).toEqual({ total: 2_000_000, hard: true });
+		// +N without a unit is allowed (advisory).
+		expect(scanMagicKeywords("budget +250 tokens").turnBudget).toEqual({ total: 250, hard: false });
+	});
+
+	it("ignores numbers that aren't whitespace-bounded budget tokens", () => {
+		// `+500` inside a longer token, or attached to surrounding non-whitespace, doesn't match.
+		expect(scanMagicKeywords("price=+500usd").turnBudget).toBeNull();
+		expect(scanMagicKeywords("nothing here").turnBudget).toBeNull();
+	});
+
+	it("scans skill-style multi-line args so a keyword on its own line still triggers (#2126)", () => {
+		// Mirrors the bug-report shape: user types `/skill:foo bar\nworkflowz` and the
+		// fragment passed in is the trimmed args.
+		const result = scanMagicKeywords("bar\nworkflowz");
+		expect(result.notices.map(n => n.customType)).toEqual(["workflow-notice"]);
+	});
+});


### PR DESCRIPTION
## Repro

In the interactive editor, type a `/skill:<name> …` invocation that includes a magic keyword in the args, e.g.:

```
/skill:deep-research workflowz compare these three approaches
```

The editor paints `workflowz` with its gradient — implying it's active — but submitting runs the skill without the `workflow-notice` system injection. Same for `orchestrate`, `ultrathink`, and the `+Nk` turn-budget directive: highlighted in the editor, but silently inert when typed inside a skill line.

## Cause

Skill dispatch routes through `AgentSession.promptCustomMessage()` (both `InputController.#invokeSkillCommand` in interactive mode and `AcpAgent.#tryRunSkillCommand` in ACP). The keyword + turn-budget scan only lived inline inside `AgentSession.prompt()` (the plain user-message path) — `promptCustomMessage()` went straight to `#promptWithMessage` with no scan, so `containsUltrathink` / `containsOrchestrate` / `containsWorkflow` / `parseTurnBudget` never ran on skill input. Meanwhile the editor's `highlightMagicKeywords` decorates the whole buffer unconditionally, producing the cosmetic-vs-behavioral mismatch.

## Fix

- Extract the keyword + budget scan from `agent-session.ts` into a shared helper `modes/magic-keyword-notices.ts` (`scanMagicKeywords(text) → { notices, turnBudget }`). `prompt()` now calls it instead of duplicating the block.
- Add an optional `keywordText` parameter to `promptCustomMessage()`. When supplied, the helper runs on that text; the resulting notices ride the same paths the `prompt()` flow uses — `appendMessages` on the idle path, `sendCustomMessage(notice, { deliverAs })` on the streaming/steer/follow-up path.
- Both skill dispatch sites (`input-controller.ts` and `acp-agent.ts`) pass the trimmed user args as `keywordText`, so the scan runs on **user intent only** — never on the skill body (which is owned by the skill author and would otherwise generate spurious notices).
- Document the arg-capture rule (everything after the first space, newlines included, no escape) and the new keyword-scan behavior in `docs/skills.md`.

The unbounded arg-capture itself is intentional and untouched — the PR documents it instead of changing it, since changing the parsing would break existing skill workflows.

## Verification

- `bun --cwd packages/coding-agent run check:types` → clean.
- `bun --cwd packages/coding-agent test test/modes/magic-keyword-notices.test.ts test/agent-session-skill-keywords.test.ts test/modes/magic-keywords.test.ts test/modes/orchestrate.test.ts test/modes/workflow.test.ts test/agent-session-empty-stop-guard.test.ts test/agent-session-eager-todo.test.ts` → 39 tests pass.
- New `magic-keyword-notices.test.ts` unit-tests the scan helper (notices, budget, code-span masking, multi-line args).
- New `agent-session-skill-keywords.test.ts` integration-tests `promptCustomMessage` with `keywordText`: notices land in `agent.state.messages`, `+500k` starts the turn budget, body-only keywords do **not** trigger, and no `keywordText` stays back-compat.

Fixes #2126