### PR TITLE
fix(tui): reset scrollbackHighWater on full repaint inside multiplexers

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed tmux/screen/zellij rewind/branch (`requestRender(true, { clearScrollback: true })`) permanently anchoring the input box to the pane top and overlaying scrollback after a streamed reply had grown past the viewport. `#emitFullPaint` only reset `#scrollbackHighWater` inside the `clearScrollback` branch and otherwise raised it monotonically, so inside multiplexers (where `\x1b[3J` is a no-op and `clearScrollback` is forced off) the streaming peak survived the rewind; on the next frame `#planLiveRegionPinnedRender` saw the stale high-water and anchored `renderViewportTop` past the actual content, repainting every visible row blank and parking the cursor at screen row 0 for the rest of the session. A full repaint with `clearViewport: true` re-emits the entire transcript from row 0, so `#scrollbackHighWater` is now assigned (not max-clamped) to the natural push count regardless of whether ED 3 was issued ([#2130](https://github.com/can1357/oh-my-pi/issues/2130)).
+
 ## [15.10.5] - 2026-06-08
 
 ### Added

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -3063,13 +3063,22 @@ export class TUI extends Container {
 
 		this.#maxLinesRendered = options.clearViewport ? lines.length : Math.max(this.#maxLinesRendered, lines.length);
 		if (options.clearScrollback) {
-			this.#scrollbackHighWater = 0;
 			this.#suppressNextSuffixScroll = lines.length > height;
 		}
 		const pushedNow = Math.max(0, lines.length - height);
-		if (pushedNow > this.#scrollbackHighWater) {
-			this.#scrollbackHighWater = pushedNow;
-		}
+		// A full repaint physically re-emits the entire transcript from row 0, so
+		// the rows committed to native scrollback by this paint are exactly
+		// `pushedNow`. Outside multiplexers an `\x1b[3J` above wiped pre-paint
+		// scrollback as well, so the assignment matches reality. Inside
+		// multiplexers `\x1b[3J` is a no-op and stale pre-paint rows remain in
+		// pane history, but those belong to the previous logical transcript and
+		// must drop out of the renderer's bookkeeping: leaving a stale
+		// `#scrollbackHighWater` above `pushedNow` mis-anchors the pinned emitter
+		// on every subsequent frame, pinning the input box to the top of the pane
+		// after a rewind/branch shrinks the transcript (issue #2130). When
+		// `clearViewport` is false (no current caller), keep the monotonic
+		// behavior so deferred paints do not lower the tracker.
+		this.#scrollbackHighWater = options.clearViewport ? pushedNow : Math.max(this.#scrollbackHighWater, pushedNow);
 		this.#commit(lines, width, height, Math.max(0, this.#maxLinesRendered - height), cursorControl);
 	}
 

--- a/packages/tui/test/issue-2130-repro.test.ts
+++ b/packages/tui/test/issue-2130-repro.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "bun:test";
+import { type Component, type NativeScrollbackLiveRegion, TERMINAL, TUI } from "@oh-my-pi/pi-tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+// Regression test for https://github.com/can1357/oh-my-pi/issues/2130
+//
+// Inside tmux (and other multiplexers), `requestRender(true, { clearScrollback: true })`
+// dispatches the `sessionReplace` intent, which re-emits the entire transcript
+// through `#emitFullPaint` with `options.clearScrollback === false` (ED 3 is a
+// no-op in pane history). Before the fix, `#emitFullPaint` only reset
+// `#scrollbackHighWater` inside the `clearScrollback` branch and otherwise
+// raised it monotonically (`if (pushedNow > #scrollbackHighWater)`), so the
+// high-water from a tall pre-rewind streamed reply survived the shrink. On
+// the next frame `#planLiveRegionPinnedRender` saw `#scrollbackHighWater`
+// far above the new natural viewport top and anchored `renderViewportTop`
+// past the actual content — repainting every visible row blank and parking
+// the cursor at the pane top, persistent until session end.
+//
+// A full repaint with `clearViewport: true` physically re-emits the entire
+// transcript from row 0, so the rows committed to native scrollback by that
+// paint are exactly `Math.max(0, lines.length - height)` regardless of
+// whether ED 3 cleared pre-paint scrollback. Assigning instead of monotonic-
+// max keeps the renderer's bookkeeping in sync with the freshly painted
+// transcript in both mux and non-mux modes.
+
+class StreamingLiveRegion implements Component, NativeScrollbackLiveRegion {
+	#lines: string[];
+
+	constructor(lines: string[]) {
+		this.#lines = [...lines];
+	}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		return this.#lines.map(line => line.slice(0, width));
+	}
+
+	setLines(lines: string[]): void {
+		this.#lines = [...lines];
+	}
+
+	getNativeScrollbackLiveRegionStart(): number | undefined {
+		return 0;
+	}
+
+	getNativeScrollbackCommitSafeEnd(): number | undefined {
+		return this.#lines.length;
+	}
+}
+
+async function settle(term: VirtualTerminal): Promise<void> {
+	const nextTick = Promise.withResolvers<void>();
+	process.nextTick(nextTick.resolve);
+	await nextTick.promise;
+	await Bun.sleep(40);
+	await term.flush();
+}
+
+async function withTmuxEnv<T>(run: () => T | Promise<T>): Promise<T> {
+	const saved = { TMUX: Bun.env.TMUX, STY: Bun.env.STY, ZELLIJ: Bun.env.ZELLIJ };
+	Bun.env.TMUX = "tmux-2130";
+	delete Bun.env.STY;
+	delete Bun.env.ZELLIJ;
+	try {
+		return await run();
+	} finally {
+		if (saved.TMUX === undefined) delete Bun.env.TMUX;
+		else Bun.env.TMUX = saved.TMUX;
+		if (saved.STY === undefined) delete Bun.env.STY;
+		else Bun.env.STY = saved.STY;
+		if (saved.ZELLIJ === undefined) delete Bun.env.ZELLIJ;
+		else Bun.env.ZELLIJ = saved.ZELLIJ;
+	}
+}
+
+async function withTerminalRisk<T>(risk: boolean, run: () => T | Promise<T>): Promise<T> {
+	const mutable = TERMINAL as unknown as { eagerEraseScrollbackRisk: boolean };
+	const saved = mutable.eagerEraseScrollbackRisk;
+	mutable.eagerEraseScrollbackRisk = risk;
+	try {
+		return await run();
+	} finally {
+		mutable.eagerEraseScrollbackRisk = saved;
+	}
+}
+
+describe("issue #2130: tmux rewind/branch leaves the viewport anchored to the pane top", () => {
+	it("recovers normal rendering after a clearScrollback render shrinks a tall transcript", async () => {
+		if (process.platform === "win32") return;
+
+		await withTmuxEnv(async () => {
+			await withTerminalRisk(true, async () => {
+				const term = new VirtualTerminal(40, 8, 10_000);
+				// Real tmux/ProcessTerminal does not implement the at-bottom
+				// probe; match production by returning undefined.
+				(term as unknown as { isNativeViewportAtBottom: () => boolean | undefined }).isNativeViewportAtBottom =
+					() => undefined;
+
+				const tui = new TUI(term);
+				const stream = new StreamingLiveRegion([]);
+				tui.addChild(stream);
+
+				try {
+					tui.start();
+					tui.setEagerNativeScrollbackRebuild(true);
+					await settle(term);
+
+					// Stream a tall reply so `#planLiveRegionPinnedRender` ramps
+					// `#scrollbackHighWater` past the viewport boundary.
+					const tall = Array.from({ length: 25 }, (_unused, i) => `TALL-${String(i).padStart(3, "0")}`);
+					for (let chunk = 5; chunk <= tall.length; chunk += 5) {
+						stream.setLines(tall.slice(0, chunk));
+						tui.requestRender();
+						await settle(term);
+					}
+
+					// Branch/rewind: the coding-agent replaces the transcript with
+					// the shorter pre-branch slice and forces a clearScrollback
+					// render (the same path `selector-controller.handleRewind`
+					// and friends take). The new content fits entirely inside
+					// the viewport (4 rows vs height = 8).
+					stream.setLines(["A", "B", "C", "D"]);
+					tui.requestRender(true, { clearScrollback: true });
+					await settle(term);
+
+					// Any subsequent frame after the rewind would re-route through
+					// `#planLiveRegionPinnedRender`. Before the fix the stale
+					// `#scrollbackHighWater` (~17, from streaming) made the
+					// planner pick `liveRegionPinned` with `renderViewportTop`
+					// at 5, so the emitter clamped `viewportTop` to
+					// `lines.length` and wrote eight blank rows.
+					stream.setLines(["A", "B", "C", "D", "E"]);
+					tui.requestRender();
+					await settle(term);
+
+					const viewport = term.getViewport().map(row => Bun.stripANSI(row).trimEnd());
+
+					// The visible viewport is bottom-anchored to the new content:
+					// five live rows followed by three blank rows below the live
+					// tail. Pre-fix: every row was blank.
+					expect(viewport.slice(0, 5)).toEqual(["A", "B", "C", "D", "E"]);
+
+					// The cursor lands on the last content row, not at the pane
+					// top. Pre-fix: `parkUp` from the pinned emitter dragged the
+					// cursor up to screen row 0.
+					expect(term.getCursor().row).toBe(4);
+				} finally {
+					tui.stop();
+					await term.flush();
+				}
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Repro

Inside a tmux pane: stream a reply taller than the viewport so the transcript scrolls past the pane top; then double-ESC on the empty editor → select the user message → Enter to branch/rewind. The next frame and every frame after it repaints the visible viewport blank and parks the input box at the pane top; scrolling back through tmux pane history shows new content overlaid on stale pre-rewind rows. State persists for the rest of the session. New regression test `packages/tui/test/issue-2130-repro.test.ts` automates this — `bun --cwd packages/tui test test/issue-2130-repro.test.ts` fails pre-fix with the entire visible viewport blank.

## Cause

`requestRender(true, { clearScrollback: true })` dispatches the `sessionReplace` intent, which re-emits the entire transcript through `#emitFullPaint` with `options.clearScrollback === false` inside multiplexers (`\x1b[3J` is a no-op in pane history). The pre-fix `#emitFullPaint` reset `#scrollbackHighWater` to `0` only inside the `if (options.clearScrollback)` branch and otherwise raised it monotonically (`if (pushedNow > #scrollbackHighWater)`), so the streaming peak from the pre-rewind reply (~509 in the reporter's transcript) survived the shrink to 453 rows. On the next frame `#planLiveRegionPinnedRender` (`packages/tui/src/tui.ts:2697-2699`) saw `#scrollbackHighWater` far above `naturalViewportTop`, set `renderViewportTop = max(naturalViewportTop, min(scrollbackHighWater, commitBoundary))`, and `#emitLiveRegionPinnedRepaint` (`packages/tui/src/tui.ts:3288`) clamped `viewportTop` to `lines.length` — writing eight empty viewport rows and then `parkUp` pulled the hardware cursor up to screen row 0.

The streaming cap branch added in #1974 stopped resetting `#scrollbackHighWater = 0` inside multiplexers (that branch is now skipped for mux), but no other path lowered it after a shrink either.

## Fix

A full repaint with `clearViewport: true` physically re-emits the entire transcript from row 0, so the rows committed to native scrollback by that paint are exactly `Math.max(0, lines.length - height)` regardless of whether ED 3 also wiped pre-paint scrollback. Mirror the existing `#maxLinesRendered = options.clearViewport ? lines.length : Math.max(...)` pattern in `#emitFullPaint`:

- Assign `#scrollbackHighWater = pushedNow` whenever `clearViewport` is true (current callers always pass it).
- Fall back to the monotonic `Math.max` when `clearViewport` is false so a hypothetical deferred paint cannot lower the tracker.
- Keep the `#suppressNextSuffixScroll` update inside the `clearScrollback` branch since it is unrelated to the high-water bookkeeping.

In non-multiplexer sessions the behavior is unchanged (`clearScrollback: true` used to reset to `0` then raise to `pushedNow` — equivalent to the new direct assignment). Inside multiplexers the assignment is the actual fix.

## Verification

- `bun --cwd packages/tui test test/issue-2130-repro.test.ts` — new regression test passes; reverting only `packages/tui/src/tui.ts` makes it fail with all five visible rows blank (the exact symptom).
- `bun --cwd packages/tui test test/issue-1974-repro.test.ts test/issue-2095-repro.test.ts test/overlay-scroll.test.ts test/image-budget.test.ts` — 51 pass / 0 fail; the original `#1974` multiplexer streaming behavior is preserved.
- `bun --cwd packages/tui test test/render-regressions.test.ts` — 103 pass / 0 fail.
- `bun --cwd packages/tui test` — 770 pass / 3 skip / 0 fail across the full TUI suite.

Fixes #2130