### PR TITLE
fix(prompting): strengthen read prompt internal URI guidance

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -10,6 +10,7 @@
 - New `tts` tool synthesises speech via xAI Grok Voice behind the disabled-by-default `tts.enabled` setting. Built-in voices `ara`, `eve` (default), `leo`, `rex`, `sal`; custom voice IDs also accepted. Output codec inferred from the `output_path` suffix (`.wav` → `wav`, else `mp3`). Up to 15,000 characters per request.
 
 ### Fixed
+- Fixed the `read` tool prompt to show concrete internal URI calls and explicitly forbid empty argument objects ([#1459](https://github.com/can1357/oh-my-pi/issues/1459)).
 
 - Fixed plan-mode re-entry after approval reopening a fresh `local://PLAN.md` instead of the approved titled plan artifact, which could duplicate plan content and fail approval on an existing destination.
 - Fixed `read` URL reader mode aborting after a stalled Jina request instead of falling back to trafilatura/lynx/native: Jina (and Parallel extract) now have their own per-attempt sub-budget capped at 10s, the catch handler honours only real user cancellation, and the in-process native renderer is always attempted on already-loaded HTML ([#1449](https://github.com/can1357/oh-my-pi/issues/1449))

--- a/packages/coding-agent/src/prompts/tools/read.md
+++ b/packages/coding-agent/src/prompts/tools/read.md
@@ -10,6 +10,8 @@ Read files, directories, archives, SQLite databases, images, documents, internal
 
 - `path` — required. Local path, internal URI (`skill://`, `agent://`, `artifact://`, `memory://`, `rule://`, `local://`, `mcp://`), or URL. Append `:<sel>` for line ranges, raw mode, or special modes (e.g. `src/foo.ts:50-200`, `src/foo.ts:raw`, `db.sqlite:users:42`).
 
+  Examples: `read(path="rule://development-rules")`, `read(path="skill://ck:debug")`, `read(path="memory://root")`.
+
 ## Selectors
 
 Append `:<sel>` to `path`. The bare path falls back to the default mode.
@@ -75,7 +77,7 @@ For `.sqlite`, `.sqlite3`, `.db`, `.db3`:
 <critical>
 - You MUST use `read` for every file, directory, archive, and URL inspection. `cat`, `head`, `tail`, `less`, `more`, `ls`, `tar`, `unzip`, `curl`, `wget` are FORBIDDEN — any such bash call is a bug, regardless of how short or convenient it looks.
 - You MUST prefer `read` over a browser/puppeteer tool for URL content; only reach for a browser when `read` cannot deliver reasonable content.
-- You MUST always include `path`. NEVER call `read` with `{}`.
+- You MUST always include `path`. NEVER call `read` with `{}` or any empty argument object.
 - For line ranges, append the selector to `path` (`path="src/foo.ts:50-200"`, `path="src/foo.ts:50+150"`). NEVER substitute `sed -n`, `awk NR`, or `head`/`tail` pipelines.
 - Summary footer says `read <path>:raw …`? Re-issue the exact selector it names. NEVER guess what's inside `..` / `…` markers — they carry no content.
 - You MAY combine selectors with URL reads and internal URIs; both paginate the cached resolved output.

--- a/packages/coding-agent/test/tools.test.ts
+++ b/packages/coding-agent/test/tools.test.ts
@@ -264,6 +264,13 @@ describe("Coding Agent Tools", () => {
 	});
 
 	describe("read tool", () => {
+		it("describes internal URI reads and rejects empty argument objects", () => {
+			expect(readTool.description).toContain('read(path="rule://development-rules")');
+			expect(readTool.description).toContain('read(path="skill://ck:debug")');
+			expect(readTool.description).toContain('read(path="memory://root")');
+			expect(readTool.description).toContain("NEVER call `read` with `{}` or any empty argument object.");
+		});
+
 		it("should read file contents that fit within limits", async () => {
 			const testFile = path.join(testDir, "test.txt");
 			const content = "Hello, world!\nLine 2\nLine 3";


### PR DESCRIPTION
## Repro
A focused prompt check against `packages/coding-agent/src/prompts/tools/read.md` failed because the rendered read prompt lacked concrete `rule://development-rules` and `skill://ck:debug` examples and did not contain the stronger empty-argument-object guard. Command: `bun -e 'const path = "packages/coding-agent/src/prompts/tools/read.md"; const text = await Bun.file(path).text(); const required = ["rule:" + "//development-rules", "skill:" + "//ck:debug", "memory:" + "//root", "NEVER call `read` with `{}` or any empty argument object"]; const missing = required.filter((item) => !text.includes(item)); console.log(JSON.stringify({ path, missing }, null, 2)); process.exit(missing.length === 0 ? 0 : 1);'`.

## Cause
`packages/coding-agent/src/prompts/tools/read.md` listed internal URI schemes abstractly and warned against `read {}`, but it did not show model-facing `read(path="...")` internal URI examples next to the required `path` parameter or explicitly forbid any empty argument object.

## Fix
- Added concrete `rule://development-rules`, `skill://ck:debug`, and `memory://root` `read(path="...")` examples beside the `path` parameter.
- Strengthened the critical guard to forbid `{}` and any empty argument object.
- Added coverage in `packages/coding-agent/test/tools.test.ts` for the rendered `ReadTool.description` contract.
- Added the coding-agent changelog entry.

## Verification
`bun -e ...` prompt check now reports `missing: []`; `bun --cwd=packages/coding-agent test test/tools.test.ts -t "describes internal URI reads"` passed; `bun --cwd=packages/coding-agent test test/tools.test.ts` passed with 91 pass / 1 skip; `bun --cwd=packages/coding-agent run check` passed. Fixes #1459