### PR TITLE
fix(coding-agent): unblock omp startup when an MCP server stalls

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `omp` startup blocking 25–30 s on a single unresponsive MCP server when no cached tools were available for it. `MCPManager.connectServers` used to fall through to an unbounded `Promise.allSettled` over every still-pending server without a cached tool list, so one server stuck waiting on the per-request MCP timeout (`OMP_MCP_TIMEOUT_MS`, default 30 000 ms) gated the entire UI ready signal. Pending-without-cache servers are now left in flight: their tools surface via the existing background `#onToolsChanged` → `refreshMCPTools` path the moment the connect completes, and failures continue to log through the background catch handler ([#2100](https://github.com/can1357/oh-my-pi/issues/2100)).
+
 ## [15.10.3] - 2026-06-08
 
 ### Added

--- a/packages/coding-agent/src/mcp/manager.ts
+++ b/packages/coding-agent/src/mcp/manager.ts
@@ -472,23 +472,24 @@ export class MCPManager {
 			const cachedTools = new Map<string, MCPToolDefinition[]>();
 			const pendingTasks = connectionTasks.filter(task => task.tracked.status === "pending");
 
-			if (pendingTasks.length > 0) {
-				if (this.toolCache) {
-					await Promise.all(
-						pendingTasks.map(async task => {
-							const cached = await this.toolCache?.get(task.name, task.config);
-							if (cached) {
-								cachedTools.set(task.name, cached);
-							}
-						}),
-					);
-				}
-
-				const pendingWithoutCache = pendingTasks.filter(task => !cachedTools.has(task.name));
-				if (pendingWithoutCache.length > 0) {
-					await Promise.allSettled(pendingWithoutCache.map(task => task.tracked.promise));
-				}
+			if (pendingTasks.length > 0 && this.toolCache) {
+				await Promise.all(
+					pendingTasks.map(async task => {
+						const cached = await this.toolCache?.get(task.name, task.config);
+						if (cached) {
+							cachedTools.set(task.name, cached);
+						}
+					}),
+				);
 			}
+
+			// Pending tasks without cached tools used to be awaited synchronously here,
+			// which gated the entire UI on the slowest server's per-request timeout
+			// (issue #2100: a single unresponsive MCP server blocked startup for the
+			// full 30 s `OMP_MCP_TIMEOUT_MS`). Leave them in flight — the background
+			// `void toolsPromise.then(...)` chain above registers their tools and
+			// fires `#onToolsChanged` once the connect finishes, or logs the failure
+			// after `allowBackgroundLogging` flips below.
 
 			for (const task of connectionTasks) {
 				const { name } = task;

--- a/packages/coding-agent/test/fixtures/hang-during-init-mcp.ts
+++ b/packages/coding-agent/test/fixtures/hang-during-init-mcp.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env bun
+/**
+ * Test fixture: a stdio MCP server that accepts the connection but never
+ * answers `initialize`. Models a remote endpoint that's reachable at the
+ * transport layer but unresponsive at the protocol layer (e.g. the
+ * `sbox-superdocs` timeout described in issue #2100) — exactly the shape
+ * that used to gate `omp` startup on a 30 s per-server MCP timeout.
+ *
+ * Reads stdin to keep the pipe open and ignores every message. The process
+ * stays alive until the parent closes stdin or kills it.
+ */
+import * as readline from "node:readline";
+
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", () => {
+	// Intentionally drop every message — server never responds.
+});
+rl.on("close", () => process.exit(0));

--- a/packages/coding-agent/test/mcp-startup-no-block.test.ts
+++ b/packages/coding-agent/test/mcp-startup-no-block.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Regression test for issue #2100: omp startup blocked >25s while connecting
+ * to MCP servers.
+ *
+ * The scenario: a configured MCP server is reachable at the transport layer
+ * but never answers `initialize`. Before the fix `MCPManager.connectServers`
+ * awaited every still-pending server that had no cached tools with an
+ * unbounded `Promise.allSettled`, so the slowest server's per-request timeout
+ * (`OMP_MCP_TIMEOUT_MS`, default 30 000 ms) gated the entire UI.
+ *
+ * Contract this test defends: when an MCP server stalls and has no cached
+ * tools, `connectServers` MUST return inside the bounded startup window
+ * (currently `STARTUP_TIMEOUT_MS = 250 ms`, padded here for scheduling
+ * jitter) so the rest of session bring-up — model registry, prompt setup,
+ * UI ready signal — is not gated on slow/dead servers. The slow server is
+ * left in flight; its tools surface via the background `#onToolsChanged`
+ * path if/when it eventually connects.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { MCPManager } from "../src/mcp/manager";
+import type { MCPStdioServerConfig } from "../src/mcp/types";
+
+const FIXTURE_PATH = path.join(import.meta.dir, "fixtures", "hang-during-init-mcp.ts");
+const BUN_EXEC = process.execPath;
+
+describe("MCP startup (issue #2100)", () => {
+	let workDir: string;
+
+	beforeEach(() => {
+		workDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-mcp-startup-"));
+	});
+
+	afterEach(() => {
+		fs.rmSync(workDir, { recursive: true, force: true });
+	});
+
+	it("returns promptly when a configured MCP server stalls on initialize", async () => {
+		const manager = new MCPManager(workDir);
+		const config: MCPStdioServerConfig = {
+			type: "stdio",
+			command: BUN_EXEC,
+			args: [FIXTURE_PATH],
+		};
+
+		try {
+			const start = performance.now();
+			const result = await manager.connectServers({ hang: config }, {});
+			const elapsedMs = performance.now() - start;
+
+			// `STARTUP_TIMEOUT_MS` is 250 ms; allow generous headroom for
+			// process spawn + scheduling jitter in CI. The pre-fix code path
+			// blocked 30 000 ms, so anything under a few seconds proves the
+			// regression is closed.
+			expect(elapsedMs).toBeLessThan(5_000);
+
+			// Slow server with no cached tools surfaces no tools at startup
+			// and no error (it's still pending in the background). The fact
+			// that startup returned at all is the contract.
+			expect(result.tools).toEqual([]);
+			expect(result.connectedServers).toEqual([]);
+			expect(result.errors.has("hang")).toBe(false);
+
+			// Manager retains the pending connection so reconnect/dedup logic
+			// continues to function — a second `connectServers` call must not
+			// double-spawn while the first is still in flight.
+			const second = await manager.connectServers({ hang: config }, {});
+			expect(second.tools).toEqual([]);
+			expect(second.errors.has("hang")).toBe(false);
+		} finally {
+			await manager.disconnectAll();
+		}
+	}, 15_000);
+});


### PR DESCRIPTION
## Repro

With multiple MCP servers configured and at least one of them unresponsive (transport opens but `initialize` never answers — the `sbox-superdocs` failure mode in the report), `omp` stays on `Connecting to MCP servers: …` for ~30 s before the UI becomes ready. The reporter saw a 30.282 s gap between session-file creation and the first `model_change` event; the same window contains the local log line `mcp:sbox-superdocs: connection timed out after 30000ms`.

A minimal driver against `MCPManager.connectServers` with an unresponsive stdio fixture returns:

```
$ bun packages/coding-agent/test/mcp-startup-no-block.test.ts  # pre-fix
(fail) returns promptly when a configured MCP server stalls on initialize [15001.07ms]
  ^ this test timed out after 15000ms.
```

(`connectServers` would have run to the full 30 s `OMP_MCP_TIMEOUT_MS` had the test allowed it.)

## Cause

`packages/coding-agent/src/mcp/manager.ts → MCPManager.connectServers` races every per-server connect against a 250 ms `STARTUP_TIMEOUT_MS` window. Servers that miss the window but have cached tools surface via `DeferredMCPTool` and execute lazily once the real connection lands. But the post-race fallback awaited every still-pending server **without** cached tools with an unbounded `Promise.allSettled`:

```ts
const pendingWithoutCache = pendingTasks.filter(task => !cachedTools.has(task.name));
if (pendingWithoutCache.length > 0) {
    await Promise.allSettled(pendingWithoutCache.map(task => task.tracked.promise));
}
```

So a single new/un-cached server stuck on its 30 s MCP timeout gated the entire startup, the status line, and everything downstream of `createAgentSession` (`model_change`, prompt build, UI ready).

## Fix

- `packages/coding-agent/src/mcp/manager.ts`: drop the `pendingWithoutCache` await. Pending tasks are left in flight; the existing background `void toolsPromise.then(...) / .catch(...)` chain already registers their tools via `#replaceServerTools` → `#onToolsChanged` → `AgentSession.refreshMCPTools` the moment the connect completes, and the catch handler logs the failure through `logger.error("MCP tool load failed", …)` after `allowBackgroundLogging` flips. Cache-aware lookup for pending tasks (so `DeferredMCPTool` can be wired) is preserved.
- `packages/coding-agent/test/fixtures/hang-during-init-mcp.ts`: stdio MCP fixture that drops every JSON-RPC message and never answers `initialize` — models the reporter's stalled server.
- `packages/coding-agent/test/mcp-startup-no-block.test.ts`: regression test that asserts `connectServers` returns inside ~5 s (well under the 30 s default MCP timeout) when only an unresponsive server is configured, and that a second call dedupes against the still-pending connection.
- `packages/coding-agent/CHANGELOG.md`: `[Unreleased] → Fixed` entry.

## Verification

`bun test test/mcp-startup-no-block.test.ts test/mcp-reconnect.test.ts test/mcp-reconnect-storm.test.ts test/mcp-tool-ordering.test.ts test/mcp-timeout.test.ts test/mcp-render-status.test.ts test/mcp-manager-oauth-refresh.test.ts test/mcp-manager-subscription-action.test.ts test/mcp-stdio-transport.test.ts` → 64 pass / 0 fail.

The new regression test fails (times out at 15 s) on `main` and passes in 561 ms with this patch; reverting the manager hunk and re-running confirms the test catches the regression both directions.

Fixes #2100