### PR TITLE
fix(tui): bound ConPTY resume full paints

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Windows ConPTY large-session resumes replaying megabyte-scale CJK transcripts as one synchronized full-paint frame. The renderer now truncates oversized ConPTY frames at logical line boundaries, keeps the recent tail visible, and inserts an `older lines hidden` marker instead of forcing legacy console hosts through the entire historical replay ([#2115](https://github.com/can1357/oh-my-pi/issues/2115)).
+
 ## [15.10.4] - 2026-06-08
 
 ### Fixed

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -512,6 +512,8 @@ export class TUI extends Container {
 	// ConPTY hosts (`isConPTYHosted()`); other terminals do not exhibit the
 	// drift and would just see an unnecessary post-paint latency. See #2095.
 	static readonly #CONPTY_POST_FULL_PAINT_SETTLE_MS = 150;
+	static readonly #CONPTY_FRAME_TRUNCATE_THRESHOLD_BYTES = 512 * 1024;
+	static readonly #CONPTY_FRAME_RETAIN_BYTES = 64 * 1024;
 	#postFullPaintSettleUntilMs = 0;
 	#postFullPaintSettleTimer: RenderTimer | undefined;
 	#cursorRow = 0; // Logical cursor row (end of rendered content)
@@ -1788,6 +1790,56 @@ export class TUI extends Container {
 		return cursor;
 	}
 
+	#truncateLargeConptyFrame(
+		lines: string[],
+		width: number,
+		height: number,
+		cursorPos: { row: number; col: number } | null,
+	): { lines: string[]; cursorPos: { row: number; col: number } | null } {
+		if (!isConPTYHosted()) return { lines, cursorPos };
+
+		let totalBytes = 0;
+		let exceedsThreshold = false;
+		for (const line of lines) {
+			totalBytes += Buffer.byteLength(line, "utf8") + 8;
+			if (totalBytes > TUI.#CONPTY_FRAME_TRUNCATE_THRESHOLD_BYTES) {
+				exceedsThreshold = true;
+				break;
+			}
+		}
+		if (!exceedsThreshold) return { lines, cursorPos };
+
+		let retainedBytes = 0;
+		let retainedStart = lines.length;
+		while (
+			retainedStart > 0 &&
+			(retainedBytes < TUI.#CONPTY_FRAME_RETAIN_BYTES || lines.length - retainedStart < height)
+		) {
+			retainedStart -= 1;
+			retainedBytes += Buffer.byteLength(lines[retainedStart] ?? "", "utf8") + 8;
+		}
+		if (retainedStart <= 0) return { lines, cursorPos };
+
+		const marker = truncateToWidth(
+			`[${retainedStart} older lines hidden to keep Windows console resume responsive]`,
+			width,
+			Ellipsis.Omit,
+		);
+		const truncated = new Array<string>(lines.length - retainedStart + 1);
+		truncated[0] = marker;
+		for (let i = retainedStart; i < lines.length; i++) {
+			truncated[i - retainedStart + 1] = lines[i] ?? "";
+		}
+
+		if (cursorPos === null || cursorPos.row < retainedStart) {
+			return { lines: truncated, cursorPos: null };
+		}
+		return {
+			lines: truncated,
+			cursorPos: { row: cursorPos.row - retainedStart + 1, col: cursorPos.col },
+		};
+	}
+
 	#terminalLine(line: string): string {
 		if (TERMINAL.isImageLine(line)) return line;
 		return line + (line.includes("\x1b]8;") ? LINE_TERMINATOR : SEGMENT_RESET);
@@ -1855,8 +1907,11 @@ export class TUI extends Container {
 		this.#visibleOverlayComponentsThisRender = visibleOverlayComponents;
 		const overlayVisibilityReduced = this.#overlayVisibilityReduced(visibleOverlayComponents);
 		let lines = visibleOverlayComponents.length > 0 ? this.#compositeOverlays(baseLines, width, height) : baseLines;
-		const cursorPos = this.#extractCursorPosition(lines, height);
+		let cursorPos = this.#extractCursorPosition(lines, height);
 		lines = this.#prepareLines(lines, width, true);
+		const truncatedFrame = this.#truncateLargeConptyFrame(lines, width, height, cursorPos);
+		lines = truncatedFrame.lines;
+		cursorPos = truncatedFrame.cursorPos;
 
 		// 2. Capture transition + pre-render state before any emitter runs.
 		const prevViewportTop = this.#viewportTopRow;
@@ -2046,6 +2101,7 @@ export class TUI extends Container {
 				this.#clearNativeScrollbackDirty();
 				this.#extractCursorPosition(baseLines, height);
 				baseLines = this.#prepareLines(baseLines, width, false);
+				baseLines = this.#truncateLargeConptyFrame(baseLines, width, height, null).lines;
 				this.#emitFullPaint(baseLines, width, height, null, {
 					clearViewport: true,
 					clearScrollback: !isMultiplexerSession(),

--- a/packages/tui/test/issue-2115-repro.test.ts
+++ b/packages/tui/test/issue-2115-repro.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import { type Component, TUI } from "@oh-my-pi/pi-tui";
+import { VirtualTerminal } from "./virtual-terminal";
+
+// Regression test for https://github.com/can1357/oh-my-pi/issues/2115
+//
+// Large CJK session resumes on Windows legacy console hosts used to feed the
+// terminal a full synchronized paint for the entire transcript. ProcessTerminal
+// split that payload into ConPTY-sized writes, but the renderer still built a
+// multi-megabyte paint and asked the Windows host to process every historical
+// row in one DEC 2026 frame. Legacy conhost/ConPTY byte parsing could park the
+// viewport mid-conversation, and even ASCII sessions became sluggish once the
+// replay crossed ~1-2 MiB.
+
+const PLATFORM_DESCRIPTOR = Object.getOwnPropertyDescriptor(process, "platform");
+
+class LargeCjkContent implements Component {
+	#lines: string[];
+
+	constructor(lineCount: number) {
+		this.#lines = new Array<string>(lineCount);
+		for (let i = 0; i < lineCount; i++) {
+			this.#lines[i] = `第${i.toString().padStart(5, "0")}行：${"界".repeat(80)}`;
+		}
+	}
+
+	invalidate(): void {}
+
+	render(width: number): string[] {
+		const rendered = new Array<string>(this.#lines.length);
+		for (let i = 0; i < this.#lines.length; i++) {
+			rendered[i] = this.#lines[i]!.slice(0, width);
+		}
+		return rendered;
+	}
+}
+
+describe("issue #2115: ConPTY large-session resume truncates at logical lines", () => {
+	afterEach(() => {
+		if (PLATFORM_DESCRIPTOR) Object.defineProperty(process, "platform", PLATFORM_DESCRIPTOR);
+		vi.restoreAllMocks();
+	});
+
+	it("bounds a Windows CJK resume paint while preserving the visible tail", async () => {
+		Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+		const term = new VirtualTerminal(80, 24, 12_000);
+		const writes: string[] = [];
+		const realWrite = term.write.bind(term);
+		vi.spyOn(term, "write").mockImplementation((data: string) => {
+			writes.push(data);
+			realWrite(data);
+		});
+		const tui = new TUI(term);
+		tui.addChild(new LargeCjkContent(9000));
+
+		try {
+			tui.start({ clearScrollback: true });
+			await term.waitForRender();
+
+			const fullPaint = writes.find(write => write.includes("\x1b[2J"));
+			expect(fullPaint).toBeDefined();
+			expect(Buffer.byteLength(fullPaint ?? "", "utf8")).toBeLessThan(128 * 1024);
+			expect(fullPaint).toContain("older lines hidden");
+			expect(fullPaint).not.toContain("第00000行");
+
+			const viewport = term.getViewport().map(line => line.trimEnd());
+			expect(viewport[viewport.length - 1]).toContain("第08999行");
+			expect(term.getScrollBuffer().some(line => line.includes("older lines hidden"))).toBe(true);
+		} finally {
+			tui.stop();
+		}
+	});
+});


### PR DESCRIPTION
## Repro
A synthetic Windows CJK resume frame with 9,000 rendered rows reproduced the issue in the TUI full-paint path: `bun --cwd packages/tui -e "$REPRO"` emitted one `#emitFullPaint` write of 1,098,031 UTF-8 bytes with no hidden-line marker before the fix.

## Cause
`packages/tui/src/tui.ts` rendered every prepared row from a large transcript into one synchronized full-paint frame, then relied on `ProcessTerminal#safeWrite` to split the already-built string for ConPTY. That kept legacy Windows console hosts processing a megabyte-scale DEC 2026 replay and let large CJK resumes park the viewport mid-conversation.

## Fix
- Added a ConPTY-only frame truncation step in `TUI` that activates after 512 KiB of prepared line output and retains the recent tail at logical line boundaries.
- Inserted an `older lines hidden` marker above the retained tail and translated cursor rows into the truncated frame.
- Covered the regression with `packages/tui/test/issue-2115-repro.test.ts` using a large CJK resume frame.
- Added the `packages/tui` changelog entry.

## Verification
`bun test packages/tui/test/issue-2095-repro.test.ts packages/tui/test/issue-2115-repro.test.ts` passed (6 tests). `bun --cwd=packages/tui run check` passed. `bun --cwd=packages/tui run test` passed (759 pass, 3 skip). Manual repro after the fix on simulated `win32` emitted a 64,642-byte first paint containing the visible tail and `older lines hidden`. Fixes #2115