### PR TITLE
fix(commit): reject empty split hunk selections

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 
+- Fixed `omp commit` split-commit validation to reject hunk selectors that match no staged hunk before the apply step resets the index ([#2098](https://github.com/can1357/oh-my-pi/issues/2098)).
 - Fixed duplicate `find` matches in multi-target queries by deduplicating overlapping paths in merged results
 - Fixed `find` partial updates to avoid repeated streamed rows while scans are still running
 - Fixed stale late diagnostics from older edits being shown after a file was edited again

--- a/packages/coding-agent/src/commit/agentic/tools/split-commit.ts
+++ b/packages/coding-agent/src/commit/agentic/tools/split-commit.ts
@@ -10,6 +10,7 @@ import {
 	validateTypeConsistency,
 } from "../../../commit/agentic/validation";
 import { validateScope } from "../../../commit/analysis/validation";
+import type { FileHunks } from "../../../commit/types";
 import { normalizeDetails } from "../../../commit/utils";
 import type { CustomTool } from "../../../extensibility/custom-tools/types";
 import * as git from "../../../utils/git";
@@ -68,6 +69,7 @@ export function createSplitCommitTool(
 			const errors: string[] = [];
 			const warnings: string[] = [];
 			const diffText = await git.diff(cwd, { cached: true });
+			const stagedHunksByFile = new Map(git.diff.parseHunks(diffText).map(file => [file.filename, file]));
 
 			const commits: SplitCommitGroup[] = params.commits.map((commit, index) => {
 				const scope = commit.scope?.trim() || null;
@@ -102,7 +104,7 @@ export function createSplitCommitTool(
 				}
 				warnings.push(...summaryValidation.warnings.map(warning => `Commit ${index + 1}: ${warning}`));
 				warnings.push(...typeValidation.warnings.map(warning => `Commit ${index + 1}: ${warning}`));
-				const hunkValidation = validateHunkSelectors(index, changes, files);
+				const hunkValidation = validateHunkSelectors(index, changes, files, stagedHunksByFile);
 				warnings.push(...hunkValidation.warnings);
 				errors.push(...hunkValidation.errors);
 				errors.push(...validateDependencies(index, dependencies, params.commits.length));
@@ -186,6 +188,7 @@ function validateHunkSelectors(
 	commitIndex: number,
 	changes: SplitCommitGroup["changes"],
 	files: string[],
+	stagedHunksByFile: ReadonlyMap<string, FileHunks>,
 ): { errors: string[]; warnings: string[] } {
 	const errors: string[] = [];
 	const warnings: string[] = [];
@@ -195,24 +198,41 @@ function validateHunkSelectors(
 		return { errors, warnings };
 	}
 	for (const change of changes) {
+		const fileHunks = stagedHunksByFile.get(change.path);
+		if (change.hunks.type === "all") continue;
+		if (fileHunks?.isBinary) {
+			errors.push(`${prefix}: cannot select hunks for binary file ${change.path}`);
+			continue;
+		}
 		if (change.hunks.type === "indices") {
 			const invalid = change.hunks.indices.filter(
 				value => !Number.isFinite(value) || Math.floor(value) !== value || value < 1,
 			);
 			if (invalid.length > 0) {
 				errors.push(`${prefix}: invalid hunk indices for ${change.path}`);
+				continue;
+			}
+			if (fileHunks) {
+				const outOfRange = change.hunks.indices.filter(index => index > fileHunks.hunks.length);
+				if (outOfRange.length > 0) {
+					errors.push(`${prefix}: hunk index out of range for ${change.path}`);
+				} else if (git.selectHunks(fileHunks, change.hunks).length === 0) {
+					errors.push(`${prefix}: hunk indices select no hunks for ${change.path}`);
+				}
 			}
 			continue;
 		}
-		if (change.hunks.type === "lines") {
-			const { start, end } = change.hunks;
-			if (!Number.isFinite(start) || !Number.isFinite(end)) {
-				errors.push(`${prefix}: invalid line range for ${change.path}`);
-				continue;
-			}
-			if (Math.floor(start) !== start || Math.floor(end) !== end || start < 1 || end < start) {
-				errors.push(`${prefix}: invalid line range for ${change.path}`);
-			}
+		const { start, end } = change.hunks;
+		if (!Number.isFinite(start) || !Number.isFinite(end)) {
+			errors.push(`${prefix}: invalid line range for ${change.path}`);
+			continue;
+		}
+		if (Math.floor(start) !== start || Math.floor(end) !== end || start < 1 || end < start) {
+			errors.push(`${prefix}: invalid line range for ${change.path}`);
+			continue;
+		}
+		if (fileHunks && git.selectHunks(fileHunks, change.hunks).length === 0) {
+			errors.push(`${prefix}: line range selects no hunks for ${change.path}`);
 		}
 	}
 	return { errors, warnings };

--- a/packages/coding-agent/src/utils/git.ts
+++ b/packages/coding-agent/src/utils/git.ts
@@ -665,7 +665,8 @@ function extractFileHeader(diffText: string): string {
 	return headerLines.join("\n");
 }
 
-function selectHunks(file: FileHunks, selector: HunkSelection["hunks"]): FileHunks["hunks"] {
+/** Select hunks from a parsed file diff using the split-commit hunk selector semantics. */
+export function selectHunks(file: FileHunks, selector: HunkSelection["hunks"]): FileHunks["hunks"] {
 	if (selector.type === "indices") {
 		const wanted = new Set(selector.indices.map(v => Math.max(1, Math.floor(v))));
 		return file.hunks.filter(hunk => wanted.has(hunk.index + 1));

--- a/packages/coding-agent/test/issue-2098-repro.test.ts
+++ b/packages/coding-agent/test/issue-2098-repro.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { $ } from "bun";
+import type { HunkSelector } from "../src/commit/agentic/state";
+import { createSplitCommitTool } from "../src/commit/agentic/tools/split-commit";
+
+async function createStagedRepo(): Promise<string> {
+	const dir = await mkdtemp(path.join(os.tmpdir(), "omp-issue-2098-"));
+	await $`git init --initial-branch=main`.cwd(dir).quiet();
+	await $`git config user.email tester@example.com`.cwd(dir).quiet();
+	await $`git config user.name Tester`.cwd(dir).quiet();
+	await writeFile(path.join(dir, "a.txt"), "one\n");
+	await writeFile(path.join(dir, "b.txt"), "two\n");
+	await $`git add a.txt b.txt`.cwd(dir).quiet();
+	await $`git commit -m baseline`.cwd(dir).quiet();
+	await writeFile(path.join(dir, "a.txt"), "one changed\n");
+	await writeFile(path.join(dir, "b.txt"), "two changed\n");
+	await $`git add a.txt b.txt`.cwd(dir).quiet();
+	return dir;
+}
+
+async function evaluateSelector(hunks: HunkSelector) {
+	const dir = await createStagedRepo();
+	try {
+		const state = {};
+		const tool = createSplitCommitTool(dir, state, []);
+		const context = {
+			sessionManager: undefined!,
+			modelRegistry: undefined!,
+			model: undefined,
+			isIdle: () => true,
+			hasQueuedMessages: () => false,
+			abort() {},
+		};
+		return await tool.execute(
+			"call-1",
+			{
+				commits: [
+					{
+						changes: [{ path: "a.txt", hunks }],
+						type: "chore",
+						scope: null,
+						summary: "updated alpha",
+					},
+					{
+						changes: [{ path: "b.txt", hunks: { type: "all" } }],
+						type: "chore",
+						scope: null,
+						summary: "updated beta",
+					},
+				],
+			},
+			undefined,
+			context,
+		);
+	} finally {
+		await rm(dir, { recursive: true, force: true });
+	}
+}
+
+describe("issue #2098 split commit hunk selector validation", () => {
+	it("rejects an out-of-range hunk index before storing a proposal", async () => {
+		const result = await evaluateSelector({ type: "indices", indices: [2] });
+
+		expect(result.details.valid).toBe(false);
+		expect(result.details.proposal).toBeUndefined();
+		expect(result.details.errors).toContain("Commit 1: hunk index out of range for a.txt");
+	});
+
+	it("rejects a line range that overlaps no parsed hunk", async () => {
+		const result = await evaluateSelector({ type: "lines", start: 100, end: 110 });
+
+		expect(result.details.valid).toBe(false);
+		expect(result.details.proposal).toBeUndefined();
+		expect(result.details.errors).toContain("Commit 1: line range selects no hunks for a.txt");
+	});
+});


### PR DESCRIPTION
## Repro
A staged split plan with two one-hunk files reproduced the failure by submitting `indices: [2]` for `a.txt`: `split_commit` returned `valid: true`, then the apply path threw `Error: No hunks selected for a.txt` after `git.stage.reset`, leaving both files unstaged. Command: `bun --cwd packages/coding-agent --eval "$REPRO"`.

## Cause
`packages/coding-agent/src/commit/agentic/tools/split-commit.ts` validated hunk selector syntax only; it never checked `indices` or `lines` selectors against the parsed staged diff. `packages/coding-agent/src/utils/git.ts` then resolved those selectors to an empty hunk list and `stage.hunks` threw during `runSplitCommit` after the index reset.

## Fix
- Exported `git.selectHunks` so validation and apply use the same selector semantics.
- Parsed the staged diff during `split_commit` validation and rejected out-of-range hunk indices, non-overlapping line ranges, and binary-file hunk selectors before storing a proposal.
- Added issue #2098 regression tests for empty `indices` and `lines` selectors.
- Added a coding-agent changelog entry.

## Verification
Reproduced before the fix with `bun --cwd packages/coding-agent --eval "$REPRO"`; after the fix the same scenario returns `valid: false` with `Commit 1: hunk index out of range for a.txt`. Ran `bun test test/issue-2098-repro.test.ts` and `bun run check` in `packages/coding-agent`; both passed. Fixes #2098