### PR TITLE
fix(ai): preserve completed thinking signatures when a turn is aborted mid-output

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed first-party Anthropic requests returning HTTP 400 "Invalid `signature` in `thinking` block" after interrupting the model during its visible output. `transformMessages` stripped the signature from every `thinking` block of an `aborted`/`error` turn, including blocks that had already finished streaming — Anthropic delivers a block's signature at `content_block_stop` before the next block starts, so a thinking block followed by `text`/`tool_use` is fully signed. The valid signature was then replayed empty (`signature: ""`), which signature-enforcing Anthropic rejects, including when the provider is routed through an LLM gateway baseUrl. Only the single mid-stream block at the abort point is now treated as untrustworthy; completed thinking blocks keep their replayable signatures ([#2144](https://github.com/can1357/oh-my-pi/issues/2144)).
+
 ## [15.10.6] - 2026-06-08
 
 ### Added

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -209,7 +209,8 @@ export function transformMessages<TApi extends Api>(
 						// Only an aborted/errored turn's final (mid-stream) block can hold a
 						// partial signature; abandoned tool-use turns strip all. Drop the
 						// untrustworthy signature so the encoder can downgrade the block to text.
-						const signatureUntrustworthy = abandonedToolUse || (invalidStopReason && blockIndex === lastBlockIndex);
+						const signatureUntrustworthy =
+							abandonedToolUse || (invalidStopReason && blockIndex === lastBlockIndex);
 						const sanitized =
 							signatureUntrustworthy && block.thinkingSignature
 								? { ...block, thinkingSignature: undefined }

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -173,32 +173,45 @@ export function transformMessages<TApi extends Api>(
 					index === latestSurvivingAssistantIndex &&
 					model.api === "anthropic-messages" &&
 					assistantMsg.api === "anthropic-messages";
-				// Aborted/errored messages may have partially-streamed thinking signatures.
-				// A partial signature is invalid and will be rejected by the API, so we must
-				// strip signatures from thinking blocks in these messages.
+				// Thinking signatures can be untrustworthy for two distinct reasons with very
+				// different blast radii:
 				//
-				// Abandoned tool-use turns get the same treatment once they are no longer
-				// the latest assistant message. When a turn carries toolCall blocks but did
-				// NOT request tool execution (stopReason !== "toolUse" — e.g.
-				// adaptive-thinking Opus emitting tool calls and then ending the turn on
-				// `end_turn`/`stop`), the agent loop pairs those calls with placeholder
-				// tool_results to keep the tool_use/tool_result contract valid. Historical
-				// abandoned turns cannot safely replay their end_turn-bound signatures in
-				// that continuation, so stripping downgrades them to plain text downstream.
-				// Latest abandoned turns are exempt because Anthropic requires thinking
-				// blocks from its most recent response to remain byte-for-byte unmodified.
+				// 1. Aborted/errored turns: the stream stopped mid-block, so only the block
+				//    that was streaming at the abort point — always the FINAL content block —
+				//    can carry a partially-streamed (invalid) signature. Every earlier block
+				//    completed: Anthropic delivers a block's signature at its
+				//    `content_block_stop`, which necessarily fired before the next block began,
+				//    so those signatures are whole and valid. Stripping them would needlessly
+				//    discard a replayable thinking chain — e.g. interrupting during the visible
+				//    text output after thinking already finished leaves a fully-signed thinking
+				//    block that must be kept, or Anthropic rejects the replay with HTTP 400
+				//    "Invalid `signature` in `thinking` block".
+				//
+				// 2. Abandoned tool-use turns: a turn that carries toolCall blocks but did NOT
+				//    request tool execution (stopReason !== "toolUse" — e.g. adaptive-thinking
+				//    Opus emitting tool calls and then ending on `end_turn`/`stop`). The agent
+				//    loop pairs those calls with placeholder tool_results to keep the
+				//    tool_use/tool_result contract valid. The turn completed cleanly, but its
+				//    signatures are end_turn-bound and cannot be replayed in that synthesized
+				//    continuation, so EVERY thinking signature is stripped.
+				//
+				// Latest abandoned turns are exempt because Anthropic requires thinking blocks
+				// from its most recent response to remain byte-for-byte unmodified.
 				const invalidStopReason = assistantMsg.stopReason === "aborted" || assistantMsg.stopReason === "error";
 				const abandonedToolUse =
 					!invalidStopReason &&
 					assistantMsg.stopReason !== "toolUse" &&
 					assistantMsg.content.some(b => b.type === "toolCall");
-				const hasInvalidSignatures = invalidStopReason || abandonedToolUse;
+				const lastBlockIndex = assistantMsg.content.length - 1;
 
-				const transformedContent = assistantMsg.content.flatMap(block => {
+				const transformedContent = assistantMsg.content.flatMap((block, blockIndex) => {
 					if (block.type === "thinking") {
-						// Strip untrustworthy signatures so the encoder can downgrade to text.
+						// Only an aborted/errored turn's final (mid-stream) block can hold a
+						// partial signature; abandoned tool-use turns strip all. Drop the
+						// untrustworthy signature so the encoder can downgrade the block to text.
+						const signatureUntrustworthy = abandonedToolUse || (invalidStopReason && blockIndex === lastBlockIndex);
 						const sanitized =
-							hasInvalidSignatures && block.thinkingSignature
+							signatureUntrustworthy && block.thinkingSignature
 								? { ...block, thinkingSignature: undefined }
 								: block;
 						if (mustPreserveLatestAnthropicThinking) return abandonedToolUse ? block : sanitized;

--- a/packages/ai/test/anthropic-abandoned-tooluse-replay.test.ts
+++ b/packages/ai/test/anthropic-abandoned-tooluse-replay.test.ts
@@ -11,9 +11,12 @@ import type { AssistantMessage, Message, Model, ToolResultMessage, UserMessage }
 //   * `stop_reason` is never replayed on the wire, so it does NOT constrain whether a
 //     continuation is valid — a tool_use turn replays fine with tool_results appended
 //     whether it ended on `tool_use` or `end_turn`.
-//   * Therefore the safe recovery for a historical turn whose signature is untrustworthy
-//     (abandoned `end_turn`+tool_use, or a half-streamed `aborted` turn) is to strip the
-//     signature and let the encoder downgrade the block to text — which the API accepts.
+//   * Therefore the safe recovery for a turn whose signature is untrustworthy is to strip it
+//     and let the encoder downgrade that block to text — which the API accepts. Two cases
+//     qualify: an abandoned `end_turn`+tool_use turn (all signatures are end_turn-bound and
+//     unreplayable), and the single mid-stream block of an `aborted`/`error` turn (only the
+//     block streaming at the abort point can hold a partial signature; earlier blocks
+//     completed and keep their valid, replayable signatures).
 //   * The latest assistant message is different: Anthropic requires thinking blocks from
 //     its most recent response to remain unmodified, so valid signatures must be preserved
 //     even when the turn is abandoned.
@@ -122,11 +125,64 @@ describe("Anthropic abandoned/aborted tool-use replay", () => {
 		expect(blocks.some(b => b.type === "tool_use")).toBe(true);
 	});
 
-	it("recovers a half-streamed aborted turn (partial/invalid signature) by downgrading to text", () => {
-		const blocks = assistantBlocks(buildHistory("aborted", "trunc"));
+	it("strips only the mid-stream final block of an aborted interleaved turn, keeping earlier signed thinking", () => {
+		// Interleaved thinking: a fully-signed thinking block and a tool_use completed, then the
+		// model began a second thinking block and was interrupted mid-stream. Only that trailing
+		// block can carry a partial (invalid) signature; the earlier one stays intact.
+		const user: UserMessage = { role: "user", content: "go", timestamp: 1 };
+		const aborted: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "first, list them", thinkingSignature: "sig_done" },
+				{ type: "toolCall", id: "toolu_1", name: "list", arguments: {} },
+				{ type: "thinking", thinking: "now decide", thinkingSignature: "trunc" },
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: model.id,
+			usage: emptyUsage,
+			stopReason: "aborted",
+			timestamp: 2,
+		};
+		const blocks = assistantBlocks([user, aborted]);
 		expectNoUnsignedThinking(blocks);
-		expect(blocks.some(b => b.type === "thinking")).toBe(false);
+		expect(blocks.some(b => b.type === "thinking" && b.signature === "sig_done")).toBe(true);
+		expect(blocks.some(b => b.type === "thinking" && b.signature === "trunc")).toBe(false);
+		expect(blocks.some(b => b.type === "text" && b.text === "now decide")).toBe(true);
 		expect(blocks.some(b => b.type === "tool_use")).toBe(true);
+	});
+
+	it("replays completed signed thinking when an aborted turn is interrupted during output behind a gateway baseUrl", () => {
+		// Exact shape behind HTTP 400 "Invalid `signature` in `thinking` block": the model finished
+		// thinking (block fully signed) and the user interrupted while it streamed the visible text.
+		// The whole signature must replay as native signed thinking even when the first-party
+		// provider is routed through an LLM gateway baseUrl, which still reaches signature-enforcing
+		// Anthropic. Dropping it would emit signature:"" and 400 the gateway.
+		const gatewayModel: Model<"anthropic-messages"> = {
+			...model,
+			baseUrl: "https://llm2.example.com/abc/v1/messages",
+		};
+		const user: UserMessage = { role: "user", content: "deploy the update", timestamp: 1 };
+		const aborted: AssistantMessage = {
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "23 phones are ready to update", thinkingSignature: "sig_valid" },
+				{ type: "text", text: "Updating the phones now" },
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: model.id,
+			usage: emptyUsage,
+			stopReason: "aborted",
+			timestamp: 2,
+		};
+		const followUp: UserMessage = { role: "user", content: "don't update phones", timestamp: 3 };
+		const params = convertAnthropicMessages([user, aborted, followUp], gatewayModel, false);
+		const assistant = params.find(p => p.role === "assistant");
+		const blocks = (assistant?.content as WireBlock[] | undefined) ?? [];
+		expectNoUnsignedThinking(blocks);
+		expect(blocks.some(b => b.type === "thinking" && b.signature === "sig_valid")).toBe(true);
+		expect(blocks.some(b => b.type === "text" && b.text === "Updating the phones now")).toBe(true);
 	});
 });
 

--- a/packages/ai/test/anthropic-prefill.test.ts
+++ b/packages/ai/test/anthropic-prefill.test.ts
@@ -178,7 +178,13 @@ it("preserves latest Anthropic thinking blocks even when model id changes", () =
 	expect(transformedAssistant?.content[1]).toEqual(assistant.content[1]);
 });
 
-it("strips invalid thinking signatures from aborted Anthropic replay messages", () => {
+it("preserves a completed thinking signature on an aborted turn interrupted during later output", () => {
+	// When a turn is aborted, only the block that was streaming at the abort point can carry a
+	// partial (invalid) signature. A thinking block followed by another block already completed
+	// — Anthropic emits its signature at content_block_stop before the next block starts — so its
+	// signature is whole and must survive transform. Interrupting during the visible text output
+	// after thinking finished is the common case; dropping the valid signature and replaying it
+	// empty makes Anthropic reject the request with 400 "Invalid `signature` in `thinking` block".
 	const model: Model<"anthropic-messages"> = {
 		api: "anthropic-messages",
 		provider: "anthropic",
@@ -194,7 +200,7 @@ it("strips invalid thinking signatures from aborted Anthropic replay messages", 
 	const assistant: AssistantMessage = {
 		role: "assistant",
 		content: [
-			{ type: "thinking", thinking: "partial reasoning", thinkingSignature: "sig_partial" },
+			{ type: "thinking", thinking: "completed reasoning", thinkingSignature: "sig_complete" },
 			{ type: "text", text: "partial answer" },
 		],
 		api: "anthropic-messages",
@@ -220,8 +226,8 @@ it("strips invalid thinking signatures from aborted Anthropic replay messages", 
 
 	expect(transformedAssistant).toBeDefined();
 	const thinkingBlock = transformedAssistant?.content[0];
-	expect(thinkingBlock).toMatchObject({ type: "thinking", thinking: "partial reasoning" });
-	expect(
-		thinkingBlock && "thinkingSignature" in thinkingBlock ? thinkingBlock.thinkingSignature : undefined,
-	).toBeUndefined();
+	expect(thinkingBlock).toMatchObject({ type: "thinking", thinking: "completed reasoning" });
+	expect(thinkingBlock && "thinkingSignature" in thinkingBlock ? thinkingBlock.thinkingSignature : undefined).toBe(
+		"sig_complete",
+	);
 });


### PR DESCRIPTION
## Repro

Interrupt the model during its visible output after the thinking block has finished streaming (so the assistant turn ends as `thinking(signed) + partial text` with `stopReason: "aborted"`). On the next request through a first-party Anthropic provider — including when routed through an LLM gateway `baseUrl` — Anthropic rejects with HTTP 400 ``"Invalid `signature` in `thinking` block"``. The pre-fix behaviour is captured by the two new assertions in `packages/ai/test/anthropic-abandoned-tooluse-replay.test.ts` (`strips only the mid-stream final block of an aborted interleaved turn, keeping earlier signed thinking` and `replays completed signed thinking when an aborted turn is interrupted during output behind a gateway baseUrl`) plus the rewritten case in `packages/ai/test/anthropic-prefill.test.ts` (`preserves a completed thinking signature on an aborted turn interrupted during later output`). Run `cd packages/ai && bun test test/anthropic-prefill.test.ts test/anthropic-abandoned-tooluse-replay.test.ts` against `main` with those tests applied → 3 fail.

## Cause

`transformMessages` in `packages/ai/src/providers/transform-messages.ts` treated every thinking block of an `aborted`/`error` turn as untrustworthy (`hasInvalidSignatures = invalidStopReason || abandonedToolUse`) and stripped the signature off all of them. Anthropic delivers a block's signature at `content_block_stop` before the next block begins, so any thinking block followed by `text`/`tool_use` necessarily completed and is fully signed — only the single mid-stream block at the abort point can hold a partial signature. The stripped-then-replayed empty signature (`signature: ""`) is what signature-enforcing Anthropic 400s on, including when proxied through an LLM gateway `baseUrl`.

## Fix

- Replace the all-or-nothing `hasInvalidSignatures` flag with a per-block `signatureUntrustworthy = abandonedToolUse || (invalidStopReason && blockIndex === lastBlockIndex)` decision inside the `flatMap`. Completed thinking blocks of an aborted/errored turn keep their replayable signatures; only the final (mid-stream) block is downgraded.
- Abandoned `end_turn`+tool_use turns are unchanged: every signature still strips because they are end_turn-bound and cannot replay in the synthesized continuation.
- The `mustPreserveLatestAnthropicThinking` short-circuit still defers to the original block for abandoned-tool-use turns and to the per-block sanitisation otherwise.
- Update the existing prefill assertion to pin the new contract (completed signature survives) and add two assertions to `anthropic-abandoned-tooluse-replay.test.ts` covering interleaved abort and the gateway `baseUrl` shape.
- CHANGELOG entry under `packages/ai`.

Credit to @DeprecatedLuke for the original diagnosis and patch (commit [`de45239`](https://github.com/DeprecatedLuke/oh-my-pi/commit/de452392df8ea9ef6f211b2a48cd9c29f6105e9e)).

## Verification

`cd packages/ai && bun test test/anthropic-prefill.test.ts test/anthropic-abandoned-tooluse-replay.test.ts` → 11 pass, 0 fail (was 10 before; +1 new test).
`cd packages/ai && bun test` → 1584 pass / 0 fail / 337 skip (provider e2e gated on `E2E` env).

Fixes #2144