### PR TITLE
fix(ai): negotiate Anthropic OAuth streams as SSE

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Anthropic OAuth streaming requests negotiating `Accept: application/json` even when `stream: true`, which could make Opus 4.7/4.8 Claude Pro/Max streams drop mid-response with `Connection error.` instead of reading SSE through `message_stop` ([#2151](https://github.com/can1357/oh-my-pi/issues/2151)).
+
 ## [15.10.7] - 2026-06-08
 
 ### Fixed

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -206,7 +206,7 @@ export function buildAnthropicHeaders(options: AnthropicHeaderOptions): Record<s
 	const extraBetas = options.extraBetas ?? [];
 	const stream = options.stream ?? false;
 	const betaHeader = buildBetaHeader(options.claudeCodeBetas ?? buildClaudeCodeBetas(true, true, false), extraBetas);
-	const acceptHeader = oauthToken ? "application/json" : stream ? "text/event-stream" : "application/json";
+	const acceptHeader = stream ? "text/event-stream" : "application/json";
 	const modelHeaders = Object.fromEntries(
 		Object.entries(options.modelHeaders ?? {}).filter(([key]) => !enforcedHeaderKeys.has(key.toLowerCase())),
 	);

--- a/packages/ai/test/anthropic-alignment.test.ts
+++ b/packages/ai/test/anthropic-alignment.test.ts
@@ -143,7 +143,7 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(headers["X-Stainless-Arch"]).toBe(mapStainlessArch(process.arch));
 	});
 
-	it("matches Claude Code OAuth header defaults", () => {
+	it("uses SSE accept on OAuth streams while keeping Claude Code headers", () => {
 		const sessionId = "167ec5b4-e711-4169-879f-84fa52679d9c";
 		const headers = buildAnthropicHeaders({
 			apiKey: "sk-ant-oat-test",
@@ -152,12 +152,19 @@ describe("Anthropic request fingerprint alignment", () => {
 			claudeCodeSessionId: sessionId,
 		});
 
-		expect(headers.Accept).toBe("application/json");
+		expect(headers.Accept).toBe("text/event-stream");
 		expect(headers["User-Agent"]).toBe(
 			`claude-cli/${claudeCodeVersion} (external, local-agent, agent-sdk/${claudeAgentSdkVersion})`,
 		);
 		expect(headers["X-Claude-Code-Session-Id"]).toBe(sessionId);
 		expect(headers["x-client-request-id"]).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+
+		const nonStreaming = buildAnthropicHeaders({
+			apiKey: "sk-ant-oat-test",
+			isOAuth: true,
+			stream: false,
+		});
+		expect(nonStreaming.Accept).toBe("application/json");
 	});
 
 	it("sends redact-thinking beta only when thinking display is omitted", () => {
@@ -583,7 +590,7 @@ describe("Anthropic request fingerprint alignment", () => {
 		expect(await promise).toEqual({
 			sessionHeader: sessionId,
 			url: "https://api.anthropic.com/v1/messages?beta=true",
-			accept: "application/json",
+			accept: "text/event-stream",
 		});
 	});
 


### PR DESCRIPTION
## Repro
Anthropic OAuth streaming headers reproduced the mismatch with: `bun -e 'import { buildAnthropicHeaders } from "./packages/ai/src/providers/anthropic.ts"; const headers = buildAnthropicHeaders({ apiKey: "sk-ant-oat-test", isOAuth: true, stream: true }); console.log(JSON.stringify({ accept: headers.Accept, stream: true, isOAuth: true }));'`, which printed `{"accept":"application/json","stream":true,"isOAuth":true}` before the fix.

## Cause
`packages/ai/src/providers/anthropic.ts` built OAuth Anthropic headers with `const acceptHeader = oauthToken ? "application/json" : stream ? "text/event-stream" : "application/json"`, so OAuth calls kept JSON negotiation even when `stream: true`. Opus 4.7/4.8 OAuth requests then sent streaming bodies through a non-SSE Accept header, unlike API-key Anthropic and GitHub Copilot stream paths.

## Fix
- Changed `buildAnthropicHeaders` to use `Accept: text/event-stream` whenever `stream` is true, including OAuth.
- Kept non-streaming OAuth requests on `Accept: application/json`.
- Updated Anthropic alignment tests to lock the OAuth streaming/non-streaming Accept contract and the session-header request path.
- Added the `packages/ai` changelog entry for #2151.

## Verification
Ran `bun test packages/ai/test/anthropic-alignment.test.ts` and `bun --cwd=packages/ai run check`; both passed. `gh_push_branch` also completed its pre-publish gate before pushing. Fixes #2151