### PR TITLE
fix(tui): preserve scrollback during overflow growth

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed TUI renders repeatedly clearing terminal scrollback after content filled the viewport. Unknown viewport probes no longer let foreground-streaming offscreen growth take the destructive `historyRebuild` path on every frame; newly appended tail rows stay reachable while stale history waits for a safe checkpoint. ([#2154](https://github.com/can1357/oh-my-pi/issues/2154))
+
 ## [15.10.6] - 2026-06-08
 
 ### Added

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1879,11 +1879,10 @@ export class TUI extends Container {
 			(this.#previousHeight > 0 && this.#previousHeight !== height) ||
 			(resizeEventOccurred && this.#previousHeight > 0);
 		const eagerEraseScrollbackRisk = this.#hasEagerEraseScrollbackRisk();
-		const eagerRebuildAllowed = this.#eagerNativeScrollbackRebuild && !eagerEraseScrollbackRisk;
 		const focusChanged = this.#focusChangedSinceLastRender;
 		this.#focusChangedSinceLastRender = false;
 		const explicitViewportMutation = this.#allowUnknownViewportMutationOnNextRender || focusChanged;
-		const allowUnknownViewportMutation = explicitViewportMutation || eagerRebuildAllowed;
+		const allowUnknownViewportMutation = explicitViewportMutation;
 		this.#allowUnknownViewportMutationOnNextRender = false;
 
 		// 3. Classify intent.

--- a/packages/tui/test/render-regressions.test.ts
+++ b/packages/tui/test/render-regressions.test.ts
@@ -2711,12 +2711,11 @@ describe("TUI terminal-state regressions", () => {
 				Object.defineProperty(process, "platform", { configurable: true, value: originalPlatform });
 			}
 		});
-		it("rebuilds offscreen edits into clean scrollback while eager rebuild is enabled (active tool)", async () => {
-			// The streaming-text default defers offscreen edits on POSIX (no yank, but a
-			// growing/re-laying-out tool result leaves stale duplicated rows above the
-			// fold). While a foreground tool is active the agent opts into eager rebuild:
-			// offscreen edits rebuild native scrollback cleanly even though the viewport
-			// position is unknown (a snap to the tail is acceptable mid-tool).
+		it("keeps offscreen streaming growth incremental when the viewport is unknown", async () => {
+			// Unknown viewport probes are not proof that the user is at the tail. While
+			// a foreground tool is active, same-size/growing offscreen edits must keep
+			// using append/repaint primitives instead of clearing scrollback once per
+			// streaming tick after the transcript fills the viewport.
 			const originalPlatform = process.platform;
 			Object.defineProperty(process, "platform", { configurable: true, value: "linux" });
 			try {
@@ -2742,7 +2741,7 @@ describe("TUI terminal-state regressions", () => {
 						try {
 							tui.start();
 							await settle(term);
-							// Default (no active tool) would defer the offscreen edit; confirm the flag flips behavior.
+							const writes = captureWrites(term);
 							tui.setEagerNativeScrollbackRebuild(true);
 
 							// A streaming tool result re-laying out: an offscreen header changes and the
@@ -2751,12 +2750,13 @@ describe("TUI terminal-state regressions", () => {
 							tui.requestRender();
 							await settle(term);
 
+							const output = writes.join("");
+							expect(output).not.toContain("\x1b[2J");
+							expect(output).not.toContain("\x1b[3J");
 							const buffer = term.getScrollBuffer().map(line => line.trimEnd());
-							// History was rebuilt at the new content: offscreen edit reflected, no stale copy.
-							expect(buffer).toContain("HEADER-EDITED");
-							expect(buffer).not.toContain("row-0");
-							// The grown tail is reachable exactly once — no duplicated rows above the viewport.
-							expect(buffer.filter(line => line === "tail-3")).toHaveLength(1);
+							expect(buffer).toContain("row-0");
+							expect(buffer).toContain("tail-3");
+							expect(buffer).not.toContain("HEADER-EDITED");
 							expect(tui.refreshNativeScrollbackIfDirty({ allowUnknownViewport: true })).toBe(false);
 						} finally {
 							mutableTerminalInfo.eagerEraseScrollbackRisk = savedTerminalRisk;


### PR DESCRIPTION
## Repro
A focused TUI render probe fills a 4-row viewport, then applies five foreground-streaming frames that mutate an offscreen row while appending tail rows. Before the fix, `bun --eval "$CODE"` reported `{"ed2":5,"ed3":4,"home":5}`, showing repeated destructive clears after overflow.

## Cause
`packages/tui/src/tui.ts` folded `#eagerNativeScrollbackRebuild` into `allowUnknownViewportMutation`, so on terminals without a native viewport-position probe the ordinary foreground-streaming path treated `undefined` as safe to rebuild. Once `#scrollbackHighWater` was non-zero, offscreen growth repeatedly selected `historyRebuild`, which emits `\x1b[2J\x1b[H\x1b[3J` and clears native scrollback every frame.

## Fix
- Keep `allowUnknownViewportMutation` scoped to explicit viewport mutations such as focused input instead of eager foreground streaming.
- Preserve explicit user-driven rebuild behavior while routing unknown-viewport streaming growth through append/repaint primitives.
- Update the TUI regression test to assert no `\x1b[2J`/`\x1b[3J` is emitted for offscreen streaming growth with an unknown viewport.
- Add a TUI changelog entry for #2154.

## Verification
`bun test packages/tui/test/render-regressions.test.ts packages/tui/test/issue-1682-repro.test.ts packages/tui/test/streaming-scrollback-defer.test.ts` passed: 123 tests, 607 assertions. `bun --cwd=packages/tui run check` passed. Manual repro after the fix reported `{"ed2":1,"ed3":0,"home":5}`; the remaining ED2 is the initial paint before the captured overflow frames. Fixes #2154