### PR TITLE
fix(coding-agent): require explicit workflow trigger

### DIFF
--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -275,6 +275,16 @@ export const SETTINGS_SCHEMA = {
 			description: "Automatically resume the most recent session in the current directory",
 		},
 	},
+	"modes.workflow.enabled": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "interaction",
+			label: "Workflow mode",
+			description:
+				"Enable the /workflow mode that injects eval/subagent orchestration guidance. Disabled by default to avoid accidental fan-out from normal prose.",
+		},
+	},
 
 	// macOS power assertions (caffeinate flags). No-op on other platforms.
 	"power.preventIdleSleep": {

--- a/packages/coding-agent/src/modes/components/custom-editor.ts
+++ b/packages/coding-agent/src/modes/components/custom-editor.ts
@@ -1,7 +1,8 @@
 import { addKeyAliases, canonicalKeyId, Editor, type KeyId, parseKey, parseKittySequence } from "@oh-my-pi/pi-tui";
 import type { AppKeybinding } from "../../config/keybindings";
+import { isSettingsInitialized, settings } from "../../config/settings";
 import { imageReferenceHyperlink, PLACEHOLDER_REGEX, renderPlaceholders } from "../image-references";
-import { highlightMagicKeywords } from "../magic-keywords";
+import { highlightMagicKeywords, type MagicKeywordOptions } from "../magic-keywords";
 import { theme } from "../theme/theme";
 
 type ConfigurableEditorAction = Extract<
@@ -70,6 +71,10 @@ export function extractBracketedImagePastePath(data: string): string | undefined
 	return pasted;
 }
 
+function getMagicKeywordOptions(): MagicKeywordOptions {
+	return { workflowEnabled: isSettingsInitialized() && settings.get("modes.workflow.enabled") };
+}
+
 /**
  * Custom editor that handles configurable app-level shortcuts for coding-agent.
  */
@@ -80,12 +85,12 @@ export class CustomEditor extends Editor {
 	 *  instead of corrupting `[Paste #1, +30 lines]` into plain text. */
 	override atomicTokenPattern = PLACEHOLDER_REGEX;
 
-	/** Gradient-highlight the "ultrathink" / "orchestrate" / "workflowz" keywords as the user types
-	 *  them, skipping any occurrence inside code spans, fenced blocks, or XML sections. Also make
+	/** Gradient-highlight active magic keywords as the user types, skipping any
+	 *  occurrence inside code spans, fenced blocks, or XML sections. Also make
 	 *  pasted image placeholders visually distinct and hyperlink them once their blob file exists. */
 	decorateText = (text: string): string =>
 		renderPlaceholders(text, {
-			renderText: value => highlightMagicKeywords(value),
+			renderText: value => highlightMagicKeywords(value, undefined, getMagicKeywordOptions()),
 			renderReference: (value, kind, index) =>
 				kind === "image"
 					? imageReferenceHyperlink(value, index, this.imageLinks, label =>

--- a/packages/coding-agent/src/modes/components/tips.txt
+++ b/packages/coding-agent/src/modes/components/tips.txt
@@ -9,7 +9,7 @@ Spaghetti code? Try complaining with /omfg
 Did you know? Each kitty/tmux/cmux split keeps its own session — `omp -c` resumes the right one
 Drop the word `ultrathink` in your message for harder multi-step reasoning — watch it glow rainbow as you type
 Say `orchestrate` in your message to drive a multi-phase task with parallel subagents — watch it glow as you type
-Say `workflowz` in your message to drive the task with parallel subagents in eval — watch it glow as you type
+
 Log in to several accounts of the same provider — `/login` again — and omp load-balances across them automatically
 Run `omp auth-broker serve` once and every machine pulls live tokens over the wire — refresh keys never leave the host; `omp auth-gateway` fronts it as a drop-in proxy any OpenAI-compatible client can hit
 Press alt+p (or /switch) to switch provider, and ctrl+p to cycle role models smol -> slow -> etc

--- a/packages/coding-agent/src/modes/components/user-message.ts
+++ b/packages/coding-agent/src/modes/components/user-message.ts
@@ -1,12 +1,17 @@
 import { Container, Markdown } from "@oh-my-pi/pi-tui";
+import { isSettingsInitialized, settings } from "../../config/settings";
 import { getMarkdownTheme, theme } from "../../modes/theme/theme";
 import { imageReferenceHyperlink, renderPlaceholders } from "../image-references";
-import { highlightMagicKeywords } from "../magic-keywords";
+import { highlightMagicKeywords, type MagicKeywordOptions } from "../magic-keywords";
 
 // OSC 133 shell integration: marks prompt zones for terminal multiplexers
 const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
 const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
+
+function getMagicKeywordOptions(): MagicKeywordOptions {
+	return { workflowEnabled: isSettingsInitialized() && settings.get("modes.workflow.enabled") };
+}
 
 /**
  * Component that renders a user message
@@ -15,15 +20,17 @@ export class UserMessageComponent extends Container {
 	constructor(text: string, synthetic = false, imageLinks?: readonly (string | undefined)[]) {
 		super();
 		const bgColor = (value: string) => theme.bg("userMessageBg", value);
-		// Paint the magic keywords ("ultrathink"/"orchestrate"/"workflowz") inside the rendered
-		// bubble too — matching the live editor glow. The Markdown component routes code spans and
-		// fenced blocks through its own code styling (never `color`), so those are already excluded;
-		// `highlightMagicKeywords` additionally restores the bubble's own foreground after each
-		// painted keyword so the gradient never bleeds into the rest of the line.
+		// Paint active magic keywords inside the rendered bubble too — matching
+		// the live editor glow. The Markdown component routes code spans and
+		// fenced blocks through its own code styling (never `color`), so those are
+		// already excluded; `highlightMagicKeywords` additionally restores the
+		// bubble's own foreground after each painted keyword so the gradient never
+		// bleeds into the rest of the line.
 		const keywordReset = theme.getFgAnsi("userMessageText") || "\x1b[39m";
 		const baseText = synthetic
 			? (value: string) => theme.fg("dim", value)
-			: (value: string) => theme.fg("userMessageText", highlightMagicKeywords(value, keywordReset));
+			: (value: string) =>
+					theme.fg("userMessageText", highlightMagicKeywords(value, keywordReset, getMagicKeywordOptions()));
 		const imageLabel = (value: string) => theme.fg("accent", `\x1b[1m\x1b[4m${value}\x1b[24m\x1b[22m`);
 		const color = (value: string) =>
 			renderPlaceholders(value, {

--- a/packages/coding-agent/src/modes/magic-keywords.ts
+++ b/packages/coding-agent/src/modes/magic-keywords.ts
@@ -2,19 +2,24 @@ import { highlightOrchestrate } from "./orchestrate";
 import { highlightUltrathink } from "./ultrathink";
 import { highlightWorkflow } from "./workflow";
 
+export interface MagicKeywordOptions {
+	workflowEnabled?: boolean;
+}
+
 /**
- * Gradient-highlight every magic keyword ("ultrathink", "orchestrate",
- * "workflowz") that appears as standalone prose, skipping any occurrence inside a
- * code block, inline code span, or XML/HTML section. Each highlighter paints its
- * own keyword with its own gradient, so chaining is order-independent — the
- * earlier passes only inject zero-width SGR escapes (no backticks or angle
- * brackets), which never confuse the later passes' markdown masking.
+ * Gradient-highlight magic keywords that are active for the current settings,
+ * skipping any occurrence inside a code block, inline code span, or XML/HTML
+ * section. Each highlighter paints its own keyword with its own gradient, so
+ * chaining is order-independent — the earlier passes only inject zero-width SGR
+ * escapes (no backticks or angle brackets), which never confuse the later
+ * passes' markdown masking.
  *
  * `resetTo` is the SGR foreground sequence restored after each painted keyword;
  * pass the surrounding text color when decorating already-colored content (e.g.
  * a themed message bubble) so the gradient does not bleed into the rest of the
  * line. Defaults to a plain foreground reset for default-colored editor text.
  */
-export function highlightMagicKeywords(text: string, resetTo?: string): string {
-	return highlightWorkflow(highlightOrchestrate(highlightUltrathink(text, resetTo), resetTo), resetTo);
+export function highlightMagicKeywords(text: string, resetTo?: string, options: MagicKeywordOptions = {}): string {
+	const base = highlightOrchestrate(highlightUltrathink(text, resetTo), resetTo);
+	return options.workflowEnabled ? highlightWorkflow(base, resetTo) : base;
 }

--- a/packages/coding-agent/src/modes/workflow.ts
+++ b/packages/coding-agent/src/modes/workflow.ts
@@ -5,38 +5,36 @@ import { keywordInProse } from "./markdown-prose";
 /**
  * "workflowz" keyword support.
  *
- * Typing the standalone word in the input editor paints it with a warm
- * amber→green gradient ({@link highlightWorkflow}); submitting a message that
- * mentions it appends a hidden {@link WORKFLOW_NOTICE} that steers the model to
- * author a deterministic multi-subagent workflow in eval cells (agent/parallel/
- * pipeline). Matching is whitespace-delimited and case-sensitive (lowercase
- * only) — "workflowz" triggers, but "workflowzed", "Workflowz", and
- * "workflowz.ts" never do.
+ * Typing the explicit "/workflow" prefix in the input editor paints it with a
+ * warm amber→green gradient ({@link highlightWorkflow}); submitting a message
+ * that starts with it appends a hidden {@link WORKFLOW_NOTICE} that steers the
+ * model to author a deterministic multi-subagent workflow in eval cells
+ * (agent/parallel/pipeline). Matching is case-sensitive and command-prefixed
+ * only, so ordinary prose mentioning "workflow" never triggers.
  */
 
-// Detection: lowercase keyword flanked by whitespace or a string edge. Non-global so `.test` stays stateless.
-const WORKFLOW_WORD = /(?<!\S)workflowz(?!\S)/;
+// Detection: explicit slash command prefix only. Non-global so `.test` stays stateless.
+const WORKFLOW_COMMAND = /^\s*\/workflow(?:\s|$)/;
 
-/** Hidden system notice appended after a user message that mentions "workflowz". */
+/** Hidden system notice appended after a user message starts with "/workflow". */
 export const WORKFLOW_NOTICE: string = workflowNotice.trim();
 
 /**
- * Whether `text` contains the standalone keyword "workflowz"
- * (lowercase, whitespace-delimited) in prose — never inside a code block, inline
- * code span, or XML/HTML section.
+ * Whether `text` starts with the explicit "/workflow" command prefix in prose —
+ * never inside a code block, inline code span, or XML/HTML section.
  */
 export function containsWorkflow(text: string): boolean {
-	return keywordInProse(text, WORKFLOW_WORD);
+	return keywordInProse(text, WORKFLOW_COMMAND);
 }
 
 /**
- * Highlight every standalone "workflowz" in `text` for editor display
- * with a warm amber→green gradient (hue 30..150), visually distinct from
- * ultrathink's rainbow and orchestrate's teal→violet.
+ * Highlight the explicit "/workflow" command prefix in `text` for editor
+ * display with a warm amber→green gradient (hue 30..150), visually distinct
+ * from ultrathink's rainbow and orchestrate's teal→violet.
  */
 export const highlightWorkflow: KeywordHighlighter = createGradientHighlighter({
-	probe: /workflowz/,
-	highlight: /(?<!\S)workflowz(?!\S)/g,
+	probe: /\/workflow/,
+	highlight: /^\s*\/workflow(?=\s|$)/g,
 	stops: 14,
 	hue: t => 30 + t * 120,
 });

--- a/packages/coding-agent/src/prompts/system/workflow-notice.md
+++ b/packages/coding-agent/src/prompts/system/workflow-notice.md
@@ -1,5 +1,7 @@
 <system-notice>
-The user's message above contains the **workflowz** keyword: drive this task as a deterministic multi-subagent workflow. Author the orchestration as Python in the `eval` tool and fan out subagents — to be comprehensive (decompose and cover in parallel), to be confident (independent perspectives and adversarial checks before you commit), or to take on scale one context can't hold (audits, migrations, broad sweeps). This overrides any default tendency to do the whole task inline when fanning out would be more thorough.
+The user explicitly requested `/workflow`: drive this task as a deterministic multi-subagent workflow. Author the orchestration as Python in the `eval` tool and fan out subagents — to be comprehensive (decompose and cover in parallel), to be confident (independent perspectives and adversarial checks before you commit), or to take on scale one context can't hold (audits, migrations, broad sweeps). This overrides any default tendency to do the whole task inline when fanning out would be more thorough.
+
+Do not use this mode for direct execution commands, simple lookups, setup scripts, or single-file edits unless the user explicitly asks for orchestration, audit, review fanout, or broad migration.
 
 <when>
 Worth it when the task benefits from decomposition + parallel coverage, or from independent/adversarial cross-checking before you commit. For a quick lookup or single edit, just do it directly — don't spin up agents. Scout inline FIRST (list the files, scope the diff, find the call sites) to discover the work-list, then fan out over it — you don't need to know the shape before the *task*, only before the *fan-out*. Common shapes, each a well-scoped `eval` call you can chain across turns:

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4361,7 +4361,7 @@ export class AgentSession {
 				timestamp,
 			});
 		}
-		if (containsWorkflow(text)) {
+		if (this.settings.get("modes.workflow.enabled") && containsWorkflow(text)) {
 			keywordNotices.push({
 				role: "custom",
 				customType: "workflow-notice",

--- a/packages/coding-agent/test/modes/magic-keywords.test.ts
+++ b/packages/coding-agent/test/modes/magic-keywords.test.ts
@@ -8,23 +8,31 @@ beforeAll(async () => {
 });
 
 describe("highlightMagicKeywords", () => {
-	it("paints every magic keyword in a single prose pass, preserving visible text", () => {
-		const input = "first ultrathink then orchestrate the workflowz";
+	it("paints default-enabled magic keywords in a single prose pass, preserving visible text", () => {
+		const input = "first ultrathink then orchestrate the workflow";
 		const decorated = highlightMagicKeywords(input);
 		expect(decorated).not.toBe(input);
 		expect(decorated).toContain("\x1b[38");
 		expect(Bun.stripANSI(decorated)).toBe(input);
-		// Each keyword is gradient-painted character-by-character, so none survives as a
-		// contiguous run in the decorated output.
-		for (const keyword of ["ultrathink", "orchestrate", "workflowz"]) {
+		for (const keyword of ["ultrathink", "orchestrate"]) {
 			expect(decorated).not.toContain(keyword);
 			expect(Bun.stripANSI(decorated)).toContain(keyword);
 		}
+		expect(decorated).toContain("workflow");
+	});
+
+	it("paints workflow only when the workflow mode is enabled", () => {
+		const input = "/workflow audit";
+		expect(highlightMagicKeywords(input)).toBe(input);
+		const decorated = highlightMagicKeywords(input, undefined, { workflowEnabled: true });
+		expect(decorated).not.toBe(input);
+		expect(Bun.stripANSI(decorated)).toBe(input);
+		expect(decorated).not.toContain("/workflow");
 	});
 
 	it("never paints keywords inside code spans, fenced blocks, or XML sections", () => {
-		const input = "`ultrathink`\n```\norchestrate\n```\n<x>workflowz</x>";
-		expect(highlightMagicKeywords(input)).toBe(input);
+		const input = "`ultrathink`\n```\norchestrate\n```\n<x>/workflow</x>";
+		expect(highlightMagicKeywords(input, undefined, { workflowEnabled: true })).toBe(input);
 	});
 
 	it("paints only the prose occurrence when the keyword also appears in code", () => {

--- a/packages/coding-agent/test/modes/workflow.test.ts
+++ b/packages/coding-agent/test/modes/workflow.test.ts
@@ -1,4 +1,5 @@
 import { beforeAll, describe, expect, it } from "bun:test";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { containsWorkflow, highlightWorkflow, WORKFLOW_NOTICE } from "@oh-my-pi/pi-coding-agent/modes/workflow";
 
@@ -7,50 +8,63 @@ beforeAll(() => {
 	initTheme();
 });
 
-describe("workflow keyword detection", () => {
-	it("matches the lowercase trigger word delimited by whitespace", () => {
-		expect(containsWorkflow("workflowz")).toBe(true);
-		expect(containsWorkflow("please workflowz this rollout")).toBe(true);
-		expect(containsWorkflow("design the workflowz")).toBe(true);
-		expect(containsWorkflow("run these workflowz")).toBe(true);
+describe("workflow command detection", () => {
+	it("matches only the explicit /workflow command prefix", () => {
+		expect(containsWorkflow("/workflow")).toBe(true);
+		expect(containsWorkflow("/workflow audit src/session")).toBe(true);
+		expect(containsWorkflow("  /workflow audit src/session")).toBe(true);
 	});
 
-	it("ignores old triggers, casing, inflections, punctuation-adjacent, and path-embedded forms", () => {
+	it("ignores prose mentions, casing, inflections, punctuation-adjacent, and path-embedded forms", () => {
 		expect(containsWorkflow("workflow")).toBe(false);
-		expect(containsWorkflow("workflows")).toBe(false);
-		expect(containsWorkflow("Workflowz")).toBe(false);
-		expect(containsWorkflow("WORKFLOWZ")).toBe(false);
-		expect(containsWorkflow("workflowzed the build")).toBe(false);
-		expect(containsWorkflow("reworkflowz everything")).toBe(false);
-		// A path/extension is not whitespace, so the word never triggers.
-		expect(containsWorkflow("packages/coding-agent/test/modes/workflowz.test.ts")).toBe(false);
-		expect(containsWorkflow("do it. workflowz.")).toBe(false);
+		expect(containsWorkflow("please workflow this rollout")).toBe(false);
+		expect(containsWorkflow("run these workflows")).toBe(false);
+		expect(containsWorkflow("design the workflow")).toBe(false);
+		expect(containsWorkflow("why is the workflow keyword active?")).toBe(false);
+		expect(containsWorkflow("/Workflow")).toBe(false);
+		expect(containsWorkflow("/workflowed the build")).toBe(false);
+		expect(containsWorkflow("reworkflow everything")).toBe(false);
+		expect(containsWorkflow("packages/coding-agent/test/modes/workflow.test.ts")).toBe(false);
+		expect(containsWorkflow("do it. /workflow")).toBe(false);
 		expect(containsWorkflow("nothing to see here")).toBe(false);
+	});
+
+	it("ignores /workflow inside code spans, fenced blocks, and XML sections", () => {
+		expect(containsWorkflow("`/workflow audit`")).toBe(false);
+		expect(containsWorkflow("```\n/workflow audit\n```")).toBe(false);
+		expect(containsWorkflow("<x>/workflow audit</x>")).toBe(false);
 	});
 });
 
 describe("workflow keyword highlighting", () => {
-	it("decorates the keyword with zero-width escapes, preserving visible text", () => {
-		const input = "please workflowz this";
+	it("decorates the command prefix with zero-width escapes, preserving visible text", () => {
+		const input = "/workflow audit this";
 		const decorated = highlightWorkflow(input);
 		expect(decorated).not.toBe(input);
 		expect(decorated).toContain("\x1b");
 		expect(Bun.stripANSI(decorated)).toBe(input);
 	});
 
-	it("leaves text without the standalone keyword untouched", () => {
-		// Probe hits the substring but the whitespace boundary fails — no decoration.
-		expect(highlightWorkflow("workflowzed builds")).toBe("workflowzed builds");
-		expect(highlightWorkflow("Workflowz this")).toBe("Workflowz this");
-		const filePath = "packages/coding-agent/test/modes/workflowz.test.ts";
+	it("leaves text without the command prefix untouched", () => {
+		expect(highlightWorkflow("workflowed builds")).toBe("workflowed builds");
+		expect(highlightWorkflow("Workflow this")).toBe("Workflow this");
+		expect(highlightWorkflow("please workflow this")).toBe("please workflow this");
+		expect(highlightWorkflow("do it. /workflow")).toBe("do it. /workflow");
+		const filePath = "packages/coding-agent/test/modes/workflow.test.ts";
 		expect(highlightWorkflow(filePath)).toBe(filePath);
+	});
+});
+
+describe("workflow mode setting", () => {
+	it("is disabled by default", () => {
+		expect(Settings.isolated().get("modes.workflow.enabled")).toBe(false);
 	});
 });
 
 describe("workflow notice", () => {
 	it("is a non-empty system notice carrying the eval-fan-out contract", () => {
 		expect(WORKFLOW_NOTICE.length).toBeGreaterThan(0);
-		expect(WORKFLOW_NOTICE).toContain("**workflowz** keyword");
+		expect(WORKFLOW_NOTICE).toContain("explicitly requested `/workflow`");
 		expect(WORKFLOW_NOTICE).toContain("parallel(");
 	});
 });


### PR DESCRIPTION
Require `/workflow` as the explicit workflow trigger so ordinary prose containing “workflow” does not inject the workflow orchestration notice.

Checks:
- `bun run check` in `packages/coding-agent`