### PR TITLE
fix(cli): reject ambiguous extensions command

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -133,6 +133,10 @@
 - Fixed Windows stdio MCP servers launched through PATH shims such as `codegraph.cmd` so bare commands like `codegraph` resolve via `PATHEXT` before spawn ([#2174](https://github.com/can1357/oh-my-pi/issues/2174)).
 - Fixed compiled-binary extensions failing to load `@oh-my-pi/pi-*` packages when `bun --compile` quietly dropped one of the extra entrypoints (observed on macOS arm64 release builds): the legacy-pi compat shim's package-root override branch returned the bunfs path without checking the target was present, so the rewrite emitted a `file://` URL to a missing module and the #1216 fallback (scoped to the throwing `getResolvedSpecifier` path) never ran. Override targets are now validated against the on-disk filesystem at module init, missing entries are dropped, and resolution falls through to canonical lookup so Bun resolves the import from the extension's own `node_modules` ([#2168](https://github.com/can1357/oh-my-pi/issues/2168)).
 
+### Fixed
+
+- Fixed bare `omp extensions` being treated as a chat prompt instead of returning an actionable plugin-command error ([#2089](https://github.com/can1357/oh-my-pi/issues/2089)).
+
 ## [15.10.8] - 2026-06-09
 
 ### Added

--- a/packages/coding-agent/src/cli-commands.ts
+++ b/packages/coding-agent/src/cli-commands.ts
@@ -45,8 +45,8 @@ const RESERVED_TOP_LEVEL_WORDS = new Map<string, string>([
 	],
 ]);
 
-export function reservedTopLevelWordMessage(first: string | undefined): string | undefined {
-	if (!first || first.startsWith("-") || first.startsWith("@")) return undefined;
+export function reservedTopLevelWordMessage(first: string | undefined, argc = 1): string | undefined {
+	if (argc !== 1 || !first || first.startsWith("-") || first.startsWith("@")) return undefined;
 	return RESERVED_TOP_LEVEL_WORDS.get(first);
 }
 
@@ -59,4 +59,21 @@ export function reservedTopLevelWordMessage(first: string | undefined): string |
 export function isSubcommand(first: string | undefined): boolean {
 	if (!first || first.startsWith("-") || first.startsWith("@")) return false;
 	return commands.some(entry => entry.name === first || entry.aliases?.includes(first));
+}
+
+export type ResolvedCliArgv = { argv: string[] } | { error: string };
+
+/**
+ * Decide what the CLI runner should do with raw argv: reject bare reserved
+ * management words, pass help/version through untouched, and route everything
+ * that is not a known subcommand to `launch`.
+ */
+export function resolveCliArgv(argv: string[]): ResolvedCliArgv {
+	const first = argv[0];
+	const reservedMessage = reservedTopLevelWordMessage(first, argv.length);
+	if (reservedMessage) return { error: reservedMessage };
+	if (first === "--help" || first === "-h" || first === "--version" || first === "-v" || first === "help") {
+		return { argv };
+	}
+	return { argv: isSubcommand(first) ? argv : ["launch", ...argv] };
 }

--- a/packages/coding-agent/src/cli-commands.ts
+++ b/packages/coding-agent/src/cli-commands.ts
@@ -38,6 +38,18 @@ export const commands: CommandEntry[] = [
 	{ name: "search", load: () => import("./commands/web-search").then(m => m.default), aliases: ["q"] },
 ];
 
+const RESERVED_TOP_LEVEL_WORDS = new Map<string, string>([
+	[
+		"extensions",
+		'`omp extensions` is not a management command. Use `omp plugin list` / `omp plugin install`, or run `omp launch extensions` if you meant to send "extensions" as a prompt.',
+	],
+]);
+
+export function reservedTopLevelWordMessage(first: string | undefined): string | undefined {
+	if (!first || first.startsWith("-") || first.startsWith("@")) return undefined;
+	return RESERVED_TOP_LEVEL_WORDS.get(first);
+}
+
 /**
  * Return true when `first` matches a registered subcommand name or alias.
  *

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -161,26 +161,19 @@ export async function runCli(argv: string[]): Promise<void> {
 	if (await runWorkerEntrypoint(argv[0])) {
 		return;
 	}
-	const [{ run }, { commands, isSubcommand, reservedTopLevelWordMessage }] = await Promise.all([
+	const [{ run }, { commands, resolveCliArgv }] = await Promise.all([
 		import("@oh-my-pi/pi-utils/cli"),
 		import("./cli-commands"),
 	]);
 	// --help and --version are handled by run() directly, don't rewrite those.
 	// Everything else that isn't a known subcommand routes to "launch".
-	const first = argv[0];
-	const reservedMessage = reservedTopLevelWordMessage(first);
-	if (reservedMessage) {
-		process.stderr.write(`error: ${reservedMessage}\n`);
+	const resolved = resolveCliArgv(argv);
+	if ("error" in resolved) {
+		process.stderr.write(`error: ${resolved.error}\n`);
 		process.exitCode = 1;
 		return;
 	}
-	const runArgv =
-		first === "--help" || first === "-h" || first === "--version" || first === "-v" || first === "help"
-			? argv
-			: isSubcommand(first)
-				? argv
-				: ["launch", ...argv];
-	return run({ bin: APP_NAME, version: VERSION, argv: runArgv, commands, help: showHelp });
+	return run({ bin: APP_NAME, version: VERSION, argv: resolved.argv, commands, help: showHelp });
 }
 
 // Floating call instead of top-level await: TLA forces `--bytecode` (CJS

--- a/packages/coding-agent/src/cli.ts
+++ b/packages/coding-agent/src/cli.ts
@@ -161,13 +161,19 @@ export async function runCli(argv: string[]): Promise<void> {
 	if (await runWorkerEntrypoint(argv[0])) {
 		return;
 	}
-	const [{ run }, { commands, isSubcommand }] = await Promise.all([
+	const [{ run }, { commands, isSubcommand, reservedTopLevelWordMessage }] = await Promise.all([
 		import("@oh-my-pi/pi-utils/cli"),
 		import("./cli-commands"),
 	]);
 	// --help and --version are handled by run() directly, don't rewrite those.
 	// Everything else that isn't a known subcommand routes to "launch".
 	const first = argv[0];
+	const reservedMessage = reservedTopLevelWordMessage(first);
+	if (reservedMessage) {
+		process.stderr.write(`error: ${reservedMessage}\n`);
+		process.exitCode = 1;
+		return;
+	}
 	const runArgv =
 		first === "--help" || first === "-h" || first === "--version" || first === "-v" || first === "help"
 			? argv

--- a/packages/coding-agent/test/install-command.test.ts
+++ b/packages/coding-agent/test/install-command.test.ts
@@ -15,25 +15,23 @@ import { describe, expect, test } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { commands, isSubcommand, resolveCliArgv } from "@oh-my-pi/pi-coding-agent/cli-commands";
 import { looksLikeLocalPath } from "@oh-my-pi/pi-coding-agent/commands/install";
 
 describe("install command is registered as a top-level subcommand", () => {
-	test("CLI runner sees `install` as a known command", async () => {
-		const cli = await import("@oh-my-pi/pi-coding-agent/cli-commands");
-		expect(cli.commands.some(c => c.name === "install")).toBe(true);
-		expect(cli.isSubcommand("install")).toBe(true);
+	test("CLI runner sees `install` as a known command", () => {
+		expect(commands.some(c => c.name === "install")).toBe(true);
+		expect(isSubcommand("install")).toBe(true);
 	});
 
-	test("CLI runner rejects only bare reserved management words", async () => {
-		const cli = await import("@oh-my-pi/pi-coding-agent/cli-commands");
-
-		expect(cli.resolveCliArgv(["extensions"])).toEqual({
+	test("CLI runner rejects only bare reserved management words", () => {
+		expect(resolveCliArgv(["extensions"])).toEqual({
 			error: '`omp extensions` is not a management command. Use `omp plugin list` / `omp plugin install`, or run `omp launch extensions` if you meant to send "extensions" as a prompt.',
 		});
-		expect(cli.resolveCliArgv(["extensions", "are", "not", "loading"])).toEqual({
+		expect(resolveCliArgv(["extensions", "are", "not", "loading"])).toEqual({
 			argv: ["launch", "extensions", "are", "not", "loading"],
 		});
-		expect(cli.resolveCliArgv(["launch", "extensions"])).toEqual({ argv: ["launch", "extensions"] });
+		expect(resolveCliArgv(["launch", "extensions"])).toEqual({ argv: ["launch", "extensions"] });
 	});
 });
 

--- a/packages/coding-agent/test/install-command.test.ts
+++ b/packages/coding-agent/test/install-command.test.ts
@@ -24,11 +24,16 @@ describe("install command is registered as a top-level subcommand", () => {
 		expect(cli.isSubcommand("install")).toBe(true);
 	});
 
-	test("CLI runner rejects reserved management words instead of launching a prompt", async () => {
+	test("CLI runner rejects only bare reserved management words", async () => {
 		const cli = await import("@oh-my-pi/pi-coding-agent/cli-commands");
-		expect(cli.isSubcommand("extensions")).toBe(false);
-		expect(cli.reservedTopLevelWordMessage("extensions")).toContain("omp plugin list");
-		expect(cli.reservedTopLevelWordMessage("hello")).toBeUndefined();
+
+		expect(cli.resolveCliArgv(["extensions"])).toEqual({
+			error: '`omp extensions` is not a management command. Use `omp plugin list` / `omp plugin install`, or run `omp launch extensions` if you meant to send "extensions" as a prompt.',
+		});
+		expect(cli.resolveCliArgv(["extensions", "are", "not", "loading"])).toEqual({
+			argv: ["launch", "extensions", "are", "not", "loading"],
+		});
+		expect(cli.resolveCliArgv(["launch", "extensions"])).toEqual({ argv: ["launch", "extensions"] });
 	});
 });
 

--- a/packages/coding-agent/test/install-command.test.ts
+++ b/packages/coding-agent/test/install-command.test.ts
@@ -23,6 +23,13 @@ describe("install command is registered as a top-level subcommand", () => {
 		expect(cli.commands.some(c => c.name === "install")).toBe(true);
 		expect(cli.isSubcommand("install")).toBe(true);
 	});
+
+	test("CLI runner rejects reserved management words instead of launching a prompt", async () => {
+		const cli = await import("@oh-my-pi/pi-coding-agent/cli-commands");
+		expect(cli.isSubcommand("extensions")).toBe(false);
+		expect(cli.reservedTopLevelWordMessage("extensions")).toContain("omp plugin list");
+		expect(cli.reservedTopLevelWordMessage("hello")).toBeUndefined();
+	});
 });
 
 describe("looksLikeLocalPath", () => {


### PR DESCRIPTION
Fixes #2089.

## Summary
- reserve the bare `omp extensions` token so it cannot be silently rewritten to `omp launch extensions`
- print an actionable error pointing users at plugin commands or explicit `omp launch extensions`
- keep ordinary prompt launch behavior unchanged for non-reserved words

## Verification
- bun test packages/coding-agent/test/install-command.test.ts
- bun --cwd=packages/coding-agent run check