### PR TITLE
docs(models): document oMLX OpenAI-compatible setup

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -272,6 +272,8 @@ If `lm-studio` is not explicitly configured, registry adds an implicit discovera
 
 Runtime discovery fetches models (`GET /models`) and synthesizes model entries with local defaults.
 
+This path also works for local OpenAI-compatible servers that are not LM Studio. For example, set `LM_STUDIO_BASE_URL=http://127.0.0.1:11434/v1` to discover oMLX through the existing `/v1/models` flow. Do not configure oMLX as `ollama`: Ollama discovery uses native `/api/tags` and `/api/show` endpoints, not OpenAI `/v1/models`.
+
 ### Explicit provider discovery
 
 You can configure discovery yourself:
@@ -604,6 +606,18 @@ providers:
     models:
       - id: Qwen/Qwen2.5-Coder-32B-Instruct
         name: Qwen 2.5 Coder 32B (local)
+```
+
+For oMLX or another local OpenAI-compatible server with a discoverable `/v1/models` endpoint, prefer discovery instead of listing models by hand:
+
+```yaml
+providers:
+  omlx:
+    baseUrl: http://127.0.0.1:11434/v1
+    auth: none
+    api: openai-completions
+    discovery:
+      type: openai-models-list
 ```
 
 ### Hosted proxy with env-based key

--- a/docs/models.md
+++ b/docs/models.md
@@ -272,7 +272,7 @@ If `lm-studio` is not explicitly configured, registry adds an implicit discovera
 
 Runtime discovery fetches models (`GET /models`) and synthesizes model entries with local defaults.
 
-This path also works for local OpenAI-compatible servers that are not LM Studio. For example, set `LM_STUDIO_BASE_URL=http://127.0.0.1:11434/v1` to discover oMLX through the existing `/v1/models` flow. Do not configure oMLX as `ollama`: Ollama discovery uses native `/api/tags` and `/api/show` endpoints, not OpenAI `/v1/models`.
+This path also works for local OpenAI-compatible servers that are not LM Studio. For example, if oMLX is bound to Ollama's usual port, set `LM_STUDIO_BASE_URL=http://127.0.0.1:11434/v1` to discover it through the existing `/v1/models` flow. Running oMLX and Ollama side by side requires assigning a different port to one of them. Do not configure oMLX as `ollama`: Ollama discovery uses native `/api/tags` and `/api/show` endpoints, not OpenAI `/v1/models`.
 
 ### Explicit provider discovery
 
@@ -608,7 +608,7 @@ providers:
         name: Qwen 2.5 Coder 32B (local)
 ```
 
-For oMLX or another local OpenAI-compatible server with a discoverable `/v1/models` endpoint, prefer discovery instead of listing models by hand:
+For oMLX or another local OpenAI-compatible server with a discoverable `/v1/models` endpoint, prefer discovery instead of listing models by hand. Set `api` to the endpoint family your server actually exposes: `openai-completions` uses `/v1/chat/completions`; servers that expose `/v1/responses` need `openai-responses` instead.
 
 ```yaml
 providers:

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -133,6 +133,10 @@
 - Fixed Windows stdio MCP servers launched through PATH shims such as `codegraph.cmd` so bare commands like `codegraph` resolve via `PATHEXT` before spawn ([#2174](https://github.com/can1357/oh-my-pi/issues/2174)).
 - Fixed compiled-binary extensions failing to load `@oh-my-pi/pi-*` packages when `bun --compile` quietly dropped one of the extra entrypoints (observed on macOS arm64 release builds): the legacy-pi compat shim's package-root override branch returned the bunfs path without checking the target was present, so the rewrite emitted a `file://` URL to a missing module and the #1216 fallback (scoped to the throwing `getResolvedSpecifier` path) never ran. Override targets are now validated against the on-disk filesystem at module init, missing entries are dropped, and resolution falls through to canonical lookup so Bun resolves the import from the extension's own `node_modules` ([#2168](https://github.com/can1357/oh-my-pi/issues/2168)).
 
+### Added
+
+- Documented the oMLX setup path through existing OpenAI-compatible local discovery ([#1957](https://github.com/can1357/oh-my-pi/issues/1957)).
+
 ## [15.10.8] - 2026-06-09
 
 ### Added

--- a/packages/coding-agent/test/lm-studio-fix.test.ts
+++ b/packages/coding-agent/test/lm-studio-fix.test.ts
@@ -16,13 +16,17 @@ describe("ModelRegistry LM Studio Fixes", () => {
 		tempDir = path.join(os.tmpdir(), `pi-test-lm-studio-fixes-${Snowflake.next()}`);
 		fs.mkdirSync(tempDir, { recursive: true });
 		modelsJsonPath = path.join(tempDir, "models.json");
-		authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
+		authStorage = await AuthStorage.create(":memory:");
 	});
 
 	afterEach(() => {
 		authStorage.close();
 		if (tempDir && fs.existsSync(tempDir)) {
-			fs.rmSync(tempDir, { recursive: true });
+			try {
+				fs.rmSync(tempDir, { recursive: true, force: true });
+			} catch (error) {
+				if ((error as NodeJS.ErrnoException).code !== "EBUSY") throw error;
+			}
 		}
 	});
 
@@ -58,5 +62,38 @@ describe("ModelRegistry LM Studio Fixes", () => {
 		const available = registry.getAvailable();
 		expect(available.some(m => m.provider === "ollama")).toBe(true);
 		expect(available.some(m => m.provider === "lm-studio")).toBe(true);
+	});
+
+	test("LM_STUDIO_BASE_URL can target any local OpenAI-compatible /v1 server", async () => {
+		const originalBaseUrl = Bun.env.LM_STUDIO_BASE_URL;
+		Bun.env.LM_STUDIO_BASE_URL = "http://127.0.0.1:11434/v1";
+		let requestedUrl = "";
+		try {
+			const fetchMock: FetchImpl = input => {
+				const url = String(input);
+				if (url.includes(":11434/v1/models")) {
+					requestedUrl = url;
+					return Promise.resolve(
+						new Response(JSON.stringify({ data: [{ id: "omlx-model" }] }), {
+							status: 200,
+							headers: { "Content-Type": "application/json" },
+						}),
+					);
+				}
+				return Promise.resolve(new Response(null, { status: 404 }));
+			};
+
+			const registry = new ModelRegistry(authStorage, modelsJsonPath, { fetch: fetchMock });
+			await registry.refresh();
+
+			expect(requestedUrl).toBe("http://127.0.0.1:11434/v1/models");
+			expect(registry.getAll().some(m => m.provider === "lm-studio" && m.id === "omlx-model")).toBe(true);
+		} finally {
+			if (originalBaseUrl === undefined) {
+				delete Bun.env.LM_STUDIO_BASE_URL;
+			} else {
+				Bun.env.LM_STUDIO_BASE_URL = originalBaseUrl;
+			}
+		}
 	});
 });

--- a/packages/coding-agent/test/lm-studio-fix.test.ts
+++ b/packages/coding-agent/test/lm-studio-fix.test.ts
@@ -16,17 +16,13 @@ describe("ModelRegistry LM Studio Fixes", () => {
 		tempDir = path.join(os.tmpdir(), `pi-test-lm-studio-fixes-${Snowflake.next()}`);
 		fs.mkdirSync(tempDir, { recursive: true });
 		modelsJsonPath = path.join(tempDir, "models.json");
-		authStorage = await AuthStorage.create(":memory:");
+		authStorage = await AuthStorage.create(path.join(tempDir, "testauth.db"));
 	});
 
 	afterEach(() => {
 		authStorage.close();
 		if (tempDir && fs.existsSync(tempDir)) {
-			try {
-				fs.rmSync(tempDir, { recursive: true, force: true });
-			} catch (error) {
-				if ((error as NodeJS.ErrnoException).code !== "EBUSY") throw error;
-			}
+			fs.rmSync(tempDir, { recursive: true });
 		}
 	});
 
@@ -87,6 +83,7 @@ describe("ModelRegistry LM Studio Fixes", () => {
 			await registry.refresh();
 
 			expect(requestedUrl).toBe("http://127.0.0.1:11434/v1/models");
+			// Implicit discovery is still registered under the built-in lm-studio provider even when the base URL points to oMLX.
 			expect(registry.getAll().some(m => m.provider === "lm-studio" && m.id === "omlx-model")).toBe(true);
 		} finally {
 			if (originalBaseUrl === undefined) {


### PR DESCRIPTION
Addresses #1957 by documenting the supported OpenAI-compatible path for oMLX instead of adding an oMLX-specific provider.

## Summary
- document `LM_STUDIO_BASE_URL=http://127.0.0.1:11434/v1` for oMLX-style OpenAI-compatible discovery
- document explicit `discovery.type: openai-models-list` config for oMLX/local OpenAI-compatible servers
- add a regression test proving LM Studio discovery can target an arbitrary `/v1/models` endpoint

## Verification
- bun test packages/coding-agent/test/lm-studio-fix.test.ts
- bun --cwd=packages/coding-agent run check