### PR TITLE
fix(tui): omit hidden thinking placeholder

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -133,6 +133,10 @@
 - Fixed Windows stdio MCP servers launched through PATH shims such as `codegraph.cmd` so bare commands like `codegraph` resolve via `PATHEXT` before spawn ([#2174](https://github.com/can1357/oh-my-pi/issues/2174)).
 - Fixed compiled-binary extensions failing to load `@oh-my-pi/pi-*` packages when `bun --compile` quietly dropped one of the extra entrypoints (observed on macOS arm64 release builds): the legacy-pi compat shim's package-root override branch returned the bunfs path without checking the target was present, so the rewrite emitted a `file://` URL to a missing module and the #1216 fallback (scoped to the throwing `getResolvedSpecifier` path) never ran. Override targets are now validated against the on-disk filesystem at module init, missing entries are dropped, and resolution falls through to canonical lookup so Bun resolves the import from the extension's own `node_modules` ([#2168](https://github.com/can1357/oh-my-pi/issues/2168)).
 
+### Fixed
+
+- Fixed hidden thinking blocks leaving placeholder `Thinking...` lines in the transcript ([#2068](https://github.com/can1357/oh-my-pi/issues/2068)).
+
 ## [15.10.8] - 2026-06-09
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed hidden thinking blocks leaving placeholder `Thinking...` lines in the transcript ([#2068](https://github.com/can1357/oh-my-pi/issues/2068)).
+
 ## [15.10.11] - 2026-06-10
 
 ### Added
@@ -132,10 +136,6 @@
 - Fixed SSH tool cancellation hanging behind OpenSSH ControlMaster streams that stayed open after an Esc/user interrupt ([#2180](https://github.com/can1357/oh-my-pi/issues/2180)).
 - Fixed Windows stdio MCP servers launched through PATH shims such as `codegraph.cmd` so bare commands like `codegraph` resolve via `PATHEXT` before spawn ([#2174](https://github.com/can1357/oh-my-pi/issues/2174)).
 - Fixed compiled-binary extensions failing to load `@oh-my-pi/pi-*` packages when `bun --compile` quietly dropped one of the extra entrypoints (observed on macOS arm64 release builds): the legacy-pi compat shim's package-root override branch returned the bunfs path without checking the target was present, so the rewrite emitted a `file://` URL to a missing module and the #1216 fallback (scoped to the throwing `getResolvedSpecifier` path) never ran. Override targets are now validated against the on-disk filesystem at module init, missing entries are dropped, and resolution falls through to canonical lookup so Bun resolves the import from the extension's own `node_modules` ([#2168](https://github.com/can1357/oh-my-pi/issues/2168)).
-
-### Fixed
-
-- Fixed hidden thinking blocks leaving placeholder `Thinking...` lines in the transcript ([#2068](https://github.com/can1357/oh-my-pi/issues/2068)).
 
 ## [15.10.8] - 2026-06-09
 

--- a/packages/coding-agent/src/modes/components/assistant-message.ts
+++ b/packages/coding-agent/src/modes/components/assistant-message.ts
@@ -222,7 +222,9 @@ export class AssistantMessageComponent extends Container {
 		this.#contentContainer.clear();
 
 		const hasVisibleContent = message.content.some(
-			c => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()),
+			c =>
+				(c.type === "text" && c.text.trim()) ||
+				(!this.hideThinkingBlock && c.type === "thinking" && c.thinking.trim()),
 		);
 
 		// Render content in order
@@ -236,32 +238,28 @@ export class AssistantMessageComponent extends Container {
 				markdown.transientRenderCache = this.#lastUpdateTransient;
 				this.#contentContainer.addChild(markdown);
 			} else if (content.type === "thinking" && content.thinking.trim()) {
+				if (this.hideThinkingBlock) {
+					thinkingIndex += 1;
+					continue;
+				}
 				// Add spacing only when another visible assistant content block follows.
 				// This avoids a superfluous blank line before separately-rendered tool execution blocks.
 				const hasVisibleContentAfter = message.content
 					.slice(i + 1)
 					.some(c => (c.type === "text" && c.text.trim()) || (c.type === "thinking" && c.thinking.trim()));
 
-				if (this.hideThinkingBlock) {
-					// Show static "Thinking..." label when hidden
-					this.#contentContainer.addChild(new Text(theme.italic(theme.fg("thinkingText", "Thinking...")), 1, 0));
-					if (hasVisibleContentAfter) {
-						this.#contentContainer.addChild(new Spacer(1));
-					}
-				} else {
-					const thinkingText = content.thinking.trim();
-					// Thinking traces in thinkingText color, italic
-					const thinkingMarkdown = new Markdown(thinkingText, 1, 0, getMarkdownTheme(), {
-						color: (text: string) => theme.fg("thinkingText", text),
-						italic: true,
-					});
-					thinkingMarkdown.transientRenderCache = this.#lastUpdateTransient;
-					this.#contentContainer.addChild(thinkingMarkdown);
-					this.#appendThinkingExtensions(i, thinkingIndex, thinkingText);
-					thinkingIndex += 1;
-					if (hasVisibleContentAfter) {
-						this.#contentContainer.addChild(new Spacer(1));
-					}
+				const thinkingText = content.thinking.trim();
+				// Thinking traces in thinkingText color, italic
+				const thinkingMarkdown = new Markdown(thinkingText, 1, 0, getMarkdownTheme(), {
+					color: (text: string) => theme.fg("thinkingText", text),
+					italic: true,
+				});
+				thinkingMarkdown.transientRenderCache = this.#lastUpdateTransient;
+				this.#contentContainer.addChild(thinkingMarkdown);
+				this.#appendThinkingExtensions(i, thinkingIndex, thinkingText);
+				thinkingIndex += 1;
+				if (hasVisibleContentAfter) {
+					this.#contentContainer.addChild(new Spacer(1));
 				}
 			}
 		}

--- a/packages/coding-agent/test/modes/components/assistant-message-error.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-error.test.ts
@@ -30,8 +30,8 @@ function erroredMessage(errorMessage: string): AssistantMessage {
 	};
 }
 
-function renderLines(message: AssistantMessage): string[] {
-	const component = new AssistantMessageComponent(message);
+function renderLines(message: AssistantMessage, hideThinkingBlock = false): string[] {
+	const component = new AssistantMessageComponent(message, hideThinkingBlock);
 	return Bun.stripANSI(component.render(RENDER_WIDTH).join("\n"))
 		.split("\n")
 		.map(line => line.trimEnd());
@@ -99,5 +99,42 @@ describe("AssistantMessageComponent error rendering", () => {
 	it("renders a short single-line error unchanged", () => {
 		const lines = renderLines(erroredMessage("overloaded_error: Overloaded"));
 		expect(lines.some(line => line.includes("Error: overloaded_error: Overloaded"))).toBe(true);
+	});
+});
+
+describe("AssistantMessageComponent hidden thinking rendering", () => {
+	function thinkingMessage(): AssistantMessage {
+		return {
+			role: "assistant",
+			content: [
+				{ type: "thinking", thinking: "private reasoning" },
+				{ type: "text", text: "Visible answer" },
+			],
+			api: "anthropic-messages",
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "stop",
+			timestamp: Date.now(),
+		};
+	}
+
+	it("omits hidden thinking instead of rendering a placeholder", () => {
+		const lines = renderLines(thinkingMessage(), true);
+		expect(lines.some(line => line.includes("Thinking..."))).toBe(false);
+		expect(lines.some(line => line.includes("private reasoning"))).toBe(false);
+		expect(lines.some(line => line.includes("Visible answer"))).toBe(true);
+	});
+
+	it("still renders thinking when it is not hidden", () => {
+		const lines = renderLines(thinkingMessage());
+		expect(lines.some(line => line.includes("private reasoning"))).toBe(true);
 	});
 });

--- a/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
+++ b/packages/coding-agent/test/modes/components/assistant-message-mermaid.test.ts
@@ -179,7 +179,7 @@ describe("AssistantMessageComponent thinking renderers", () => {
 		);
 
 		const rendered = Bun.stripANSI(component.render(120).join("\n"));
-		expect(rendered).toContain("Thinking...");
+		expect(rendered).not.toContain("Thinking...");
 		expect(rendered).not.toContain("I should inspect the input.");
 		expect(rendered).not.toContain("hidden note");
 		expect(rendererCalled).toBe(false);


### PR DESCRIPTION
Addresses part of #2068: `hideThinkingBlock` now removes hidden thinking blocks instead of replacing each one with another `Thinking...` transcript line.

## Summary
- omit hidden thinking blocks entirely when `hideThinkingBlock` is enabled
- keep visible answer text and normal thinking rendering unchanged
- add focused AssistantMessage rendering coverage

## Verification
- bun test packages/coding-agent/test/modes/components/assistant-message-error.test.ts
- bun --cwd=packages/coding-agent run check