### PR TITLE
feat(ai): add thinking_token_budget support for vLLM/Qwen reasoning models

### DIFF
--- a/packages/agent/src/thinking.ts
+++ b/packages/agent/src/thinking.ts
@@ -8,7 +8,7 @@ import { Effort } from "@oh-my-pi/pi-ai";
 export const ThinkingLevel = {
 	Inherit: "inherit",
 	Off: "off",
-	ZeroOff: "0-off",
+	ZeroOff: "zeroOff",
 	Minimal: Effort.Minimal,
 	Low: Effort.Low,
 	Medium: Effort.Medium,

--- a/packages/agent/src/thinking.ts
+++ b/packages/agent/src/thinking.ts
@@ -8,6 +8,7 @@ import { Effort } from "@oh-my-pi/pi-ai";
 export const ThinkingLevel = {
 	Inherit: "inherit",
 	Off: "off",
+	ZeroOff: "0-off",
 	Minimal: Effort.Minimal,
 	Low: Effort.Low,
 	Medium: Effort.Medium,

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added `thinking_token_budget` parameter support for vLLM and other OpenAI-compatible backends that expose the `thinking_token_budget` field. The budget is driven by the existing `thinkingBudgets` setting and is sent for `qwen` and `qwen-chat-template` thinking formats. `preserve_thinking` in `chat_template_kwargs` is gated on `thinkingBudgets` being configured, so existing users without budgets see no behavior change.
+- Added `thinking_token_budget` / `thinking_budget` parameter support for vLLM and Qwen Cloud/DashScope backends that expose thinking budget fields. The budget is driven by the existing `thinkingBudgets` setting and is sent for `qwen` and `qwen-chat-template` thinking formats. Qwen Cloud/DashScope uses `thinking_budget`; vLLM and other backends use `thinking_token_budget`. `preserve_thinking` in `chat_template_kwargs` is gated on `thinkingBudgets` being configured, so existing users without budgets see no behavior change.
 ## [15.10.8] - 2026-06-09
 ### Added
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `thinking_token_budget` parameter support for vLLM and other OpenAI-compatible backends that expose the `thinking_token_budget` field. The budget is driven by the existing `thinkingBudgets` setting and is sent for `qwen` and `qwen-chat-template` thinking formats. `preserve_thinking` in `chat_template_kwargs` is gated on `thinkingBudgets` being configured, so existing users without budgets see no behavior change.
 ## [15.10.8] - 2026-06-09
 ### Added
 

--- a/packages/ai/src/effort.ts
+++ b/packages/ai/src/effort.ts
@@ -1,6 +1,6 @@
 /** User-facing thinking levels, ordered least to most intensive. */
 export const enum Effort {
-	ZeroOff = "0-off",
+	ZeroOff = "zeroOff",
 	Minimal = "minimal",
 	Low = "low",
 	Medium = "medium",

--- a/packages/ai/src/effort.ts
+++ b/packages/ai/src/effort.ts
@@ -1,5 +1,6 @@
 /** User-facing thinking levels, ordered least to most intensive. */
 export const enum Effort {
+	ZeroOff = "0-off",
 	Minimal = "minimal",
 	Low = "low",
 	Medium = "medium",
@@ -8,6 +9,7 @@ export const enum Effort {
 }
 
 export const THINKING_EFFORTS: readonly Effort[] = [
+	Effort.ZeroOff,
 	Effort.Minimal,
 	Effort.Low,
 	Effort.Medium,

--- a/packages/ai/src/effort.ts
+++ b/packages/ai/src/effort.ts
@@ -9,7 +9,6 @@ export const enum Effort {
 }
 
 export const THINKING_EFFORTS: readonly Effort[] = [
-	Effort.ZeroOff,
 	Effort.Minimal,
 	Effort.Low,
 	Effort.Medium,

--- a/packages/ai/src/effort.ts
+++ b/packages/ai/src/effort.ts
@@ -9,6 +9,7 @@ export const enum Effort {
 }
 
 export const THINKING_EFFORTS: readonly Effort[] = [
+	Effort.ZeroOff,
 	Effort.Minimal,
 	Effort.Low,
 	Effort.Medium,

--- a/packages/ai/src/model-thinking.ts
+++ b/packages/ai/src/model-thinking.ts
@@ -275,7 +275,7 @@ export function requireSupportedEffort<TApi extends Api>(model: ApiModel<TApi>, 
 		throw new Error(`Model ${model.provider}/${model.id} does not support thinking`);
 	}
 	const levels = getSupportedEfforts(model);
-	if (!levels.includes(effort)) {
+	if (effort !== Effort.ZeroOff && !levels.includes(effort)) {
 		throw new Error(
 			`Thinking effort ${effort} is not supported by ${model.provider}/${model.id}. Supported efforts: ${levels.join(", ")}`,
 		);

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -265,6 +265,7 @@ type OpenAICompletionsParams = OpenAI.Chat.Completions.ChatCompletionCreateParam
 	thinking?: { type: "enabled" | "disabled"; keep?: "all" };
 	enable_thinking?: boolean;
 	thinking_token_budget?: number;
+	thinking_budget?: number;
 	chat_template_kwargs?: { enable_thinking: boolean; preserve_thinking?: boolean };
 	reasoning?: { effort?: string } | { enabled: false };
 	provider?: OpenAICompat["openRouterRouting"];
@@ -1165,14 +1166,25 @@ async function createClient(
 }
 
 /**
- * Apply `thinking_token_budget` from `thinkingBudgets` when a budget is
- * configured for the current reasoning effort. Only used by backends that
- * support the field (vLLM, Qwen).
+ * Apply thinking budget from `thinkingBudgets` when a budget is configured for
+ * the current reasoning effort. Uses `thinking_budget` for Qwen Cloud/DashScope
+ * and `thinking_token_budget` for vLLM and other backends.
  */
-function applyThinkingTokenBudget(params: OpenAICompletionsParams, options: OpenAICompletionsOptions | undefined): void {
+function applyThinkingBudget(
+	params: OpenAICompletionsParams,
+	options: OpenAICompletionsOptions | undefined,
+	resolvedBaseUrl?: string,
+): void {
 	const effort = options?.reasoning;
-	if (effort && options.thinkingBudgets?.[effort] != null) {
-		params.thinking_token_budget = options.thinkingBudgets[effort];
+	if (!effort || options.thinkingBudgets?.[effort] == null) {
+		return;
+	}
+	const budget = options.thinkingBudgets[effort];
+	// Qwen Cloud / DashScope uses `thinking_budget`; vLLM and others use `thinking_token_budget`
+	if (resolvedBaseUrl?.includes("dashscope")) {
+		(params as Record<string, unknown>).thinking_budget = budget;
+	} else {
+		params.thinking_token_budget = budget;
 	}
 }
 function buildParams(
@@ -1342,7 +1354,7 @@ function buildParams(
 		// vLLM supports thinking_token_budget for fine-grained reasoning control
 		const thinkingEnabled = !!options?.reasoning && !options?.disableReasoning;
 		params.enable_thinking = thinkingEnabled;
-		applyThinkingTokenBudget(params, options);
+		applyThinkingBudget(params, options, resolvedBaseUrl);
 	} else if (supportsReasoningParams && compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {
 		// Qwen chat-template variant uses chat_template_kwargs
 		const thinkingEnabled = !!options?.reasoning && !options?.disableReasoning;
@@ -1350,7 +1362,7 @@ function buildParams(
 			enable_thinking: thinkingEnabled,
 			...(options?.thinkingBudgets ? { preserve_thinking: thinkingEnabled } : {}),
 		};
-		applyThinkingTokenBudget(params, options);
+		applyThinkingBudget(params, options, resolvedBaseUrl);
 	} else if (supportsReasoningParams && compat.thinkingFormat === "openrouter" && model.reasoning) {
 		// OpenRouter normalizes reasoning across providers via a nested reasoning object.
 		// Without an explicit signal, OpenRouter defaults reasoning models to thinking, which
@@ -1399,6 +1411,7 @@ function buildParams(
 		delete params.reasoning_effort;
 		delete params.reasoning;
 		delete params.thinking_token_budget;
+		delete params.thinking_budget;
 	}
 
 	if (compat.disableReasoningOnForcedToolChoice && isForcedToolChoice(params.tool_choice)) {
@@ -1408,6 +1421,7 @@ function buildParams(
 		delete params.reasoning_effort;
 		delete params.reasoning;
 		delete params.thinking_token_budget;
+		delete params.thinking_budget;
 		if (compat.thinkingFormat === "zai") {
 			params.thinking = { type: "disabled" };
 		}

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1164,6 +1164,17 @@ async function createClient(
 	};
 }
 
+/**
+ * Apply `thinking_token_budget` from `thinkingBudgets` when a budget is
+ * configured for the current reasoning effort. Only used by backends that
+ * support the field (vLLM, Qwen).
+ */
+function applyThinkingTokenBudget(params: OpenAICompletionsParams, options: OpenAICompletionsOptions | undefined): void {
+	const effort = options?.reasoning;
+	if (effort && options.thinkingBudgets?.[effort] != null) {
+		params.thinking_token_budget = options.thinkingBudgets[effort];
+	}
+}
 function buildParams(
 	model: Model<"openai-completions">,
 	context: Context,
@@ -1331,25 +1342,15 @@ function buildParams(
 		// vLLM supports thinking_token_budget for fine-grained reasoning control
 		const thinkingEnabled = !!options?.reasoning && !options?.disableReasoning;
 		params.enable_thinking = thinkingEnabled;
-		if (thinkingEnabled && options?.thinkingBudgets) {
-			const budget = options.thinkingBudgets[options.reasoning!];
-			if (budget != null) {
-				params.thinking_token_budget = budget;
-			}
-		}
+		applyThinkingTokenBudget(params, options);
 	} else if (supportsReasoningParams && compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {
 		// Qwen chat-template variant uses chat_template_kwargs
 		const thinkingEnabled = !!options?.reasoning && !options?.disableReasoning;
 		params.chat_template_kwargs = {
 			enable_thinking: thinkingEnabled,
-			preserve_thinking: thinkingEnabled,
+			...(options?.thinkingBudgets ? { preserve_thinking: thinkingEnabled } : {}),
 		};
-		if (thinkingEnabled && options?.thinkingBudgets) {
-			const budget = options.thinkingBudgets[options.reasoning!];
-			if (budget != null) {
-				params.thinking_token_budget = budget;
-			}
-		}
+		applyThinkingTokenBudget(params, options);
 	} else if (supportsReasoningParams && compat.thinkingFormat === "openrouter" && model.reasoning) {
 		// OpenRouter normalizes reasoning across providers via a nested reasoning object.
 		// Without an explicit signal, OpenRouter defaults reasoning models to thinking, which
@@ -1374,13 +1375,6 @@ function buildParams(
 	) {
 		// OpenAI-style reasoning_effort
 		params.reasoning_effort = mapReasoningEffort(options.reasoning, compat.reasoningEffortMap) as Effort;
-		// vLLM and other OpenAI-compatible backends support thinking_token_budget
-		if (options?.thinkingBudgets) {
-			const budget = options.thinkingBudgets[options.reasoning];
-			if (budget != null) {
-				params.thinking_token_budget = budget;
-			}
-		}
 	} else if (
 		supportsReasoningParams &&
 		options?.disableReasoning &&

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1167,21 +1167,22 @@ async function createClient(
 
 /**
  * Apply thinking budget from `thinkingBudgets` when a budget is configured for
- * the current reasoning effort. Uses `thinking_budget` for Qwen Cloud/DashScope
- * and `thinking_token_budget` for vLLM and other backends.
+ * the current reasoning effort. Uses `thinking_budget` for Qwen-compatible
+ * backends (Cloud, DashScope, proxied) and `thinking_token_budget` for vLLM.
  */
 function applyThinkingBudget(
 	params: OpenAICompletionsParams,
 	options: OpenAICompletionsOptions | undefined,
-	resolvedBaseUrl?: string,
+	thinkingFormat: string,
 ): void {
 	const effort = options?.reasoning;
 	if (!effort || options.thinkingBudgets?.[effort] == null) {
 		return;
 	}
 	const budget = options.thinkingBudgets[effort];
-	// Qwen Cloud / DashScope uses `thinking_budget`; vLLM and others use `thinking_token_budget`
-	if (resolvedBaseUrl?.includes("dashscope")) {
+	// Qwen-compatible backends (Cloud, DashScope, proxied) use `thinking_budget`
+	// vLLM with qwen-chat-template uses `thinking_token_budget`
+	if (thinkingFormat === "qwen") {
 		(params as Record<string, unknown>).thinking_budget = budget;
 	} else {
 		params.thinking_token_budget = budget;
@@ -1354,7 +1355,7 @@ function buildParams(
 		// vLLM supports thinking_token_budget for fine-grained reasoning control
 		const thinkingEnabled = !!options?.reasoning && !options?.disableReasoning;
 		params.enable_thinking = thinkingEnabled;
-		applyThinkingBudget(params, options, resolvedBaseUrl);
+		applyThinkingBudget(params, options, compat.thinkingFormat);
 	} else if (supportsReasoningParams && compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {
 		// Qwen chat-template variant uses chat_template_kwargs
 		const thinkingEnabled = !!options?.reasoning && !options?.disableReasoning;
@@ -1362,7 +1363,7 @@ function buildParams(
 			enable_thinking: thinkingEnabled,
 			...(options?.thinkingBudgets ? { preserve_thinking: thinkingEnabled } : {}),
 		};
-		applyThinkingBudget(params, options, resolvedBaseUrl);
+		applyThinkingBudget(params, options, compat.thinkingFormat);
 	} else if (supportsReasoningParams && compat.thinkingFormat === "openrouter" && model.reasoning) {
 		// OpenRouter normalizes reasoning across providers via a nested reasoning object.
 		// Without an explicit signal, OpenRouter defaults reasoning models to thinking, which

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1353,12 +1353,16 @@ function buildParams(
 	} else if (supportsReasoningParams && compat.thinkingFormat === "qwen" && model.reasoning) {
 		// Qwen uses top-level enable_thinking: boolean
 		// vLLM supports thinking_token_budget for fine-grained reasoning control
-		const thinkingEnabled = !!options?.reasoning && !options?.disableReasoning;
+		const effort = options?.reasoning;
+		const budget = effort ? options?.thinkingBudgets?.[effort] : undefined;
+		const thinkingEnabled = !!effort && !options?.disableReasoning && budget !== 0;
 		params.enable_thinking = thinkingEnabled;
 		applyThinkingBudget(params, options, compat.thinkingFormat);
 	} else if (supportsReasoningParams && compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {
 		// Qwen chat-template variant uses chat_template_kwargs
-		const thinkingEnabled = !!options?.reasoning && !options?.disableReasoning;
+		const effort = options?.reasoning;
+		const budget = effort ? options?.thinkingBudgets?.[effort] : undefined;
+		const thinkingEnabled = !!effort && !options?.disableReasoning && budget !== 0;
 		params.chat_template_kwargs = {
 			enable_thinking: thinkingEnabled,
 			...(options?.thinkingBudgets ? { preserve_thinking: thinkingEnabled } : {}),

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -264,7 +264,8 @@ type OpenAICompletionsParams = OpenAI.Chat.Completions.ChatCompletionCreateParam
 	repetition_penalty?: number;
 	thinking?: { type: "enabled" | "disabled"; keep?: "all" };
 	enable_thinking?: boolean;
-	chat_template_kwargs?: { enable_thinking: boolean };
+	thinking_token_budget?: number;
+	chat_template_kwargs?: { enable_thinking: boolean; preserve_thinking?: boolean };
 	reasoning?: { effort?: string } | { enabled: false };
 	provider?: OpenAICompat["openRouterRouting"];
 	providerOptions?: { gateway?: { only?: string[]; order?: string[] } };
@@ -1327,11 +1328,28 @@ function buildParams(
 		}
 	} else if (supportsReasoningParams && compat.thinkingFormat === "qwen" && model.reasoning) {
 		// Qwen uses top-level enable_thinking: boolean
-		params.enable_thinking = !!options?.reasoning && !options?.disableReasoning;
+		// vLLM supports thinking_token_budget for fine-grained reasoning control
+		const thinkingEnabled = !!options?.reasoning && !options?.disableReasoning;
+		params.enable_thinking = thinkingEnabled;
+		if (thinkingEnabled && options?.thinkingBudgets) {
+			const budget = options.thinkingBudgets[options.reasoning!];
+			if (budget != null) {
+				params.thinking_token_budget = budget;
+			}
+		}
 	} else if (supportsReasoningParams && compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {
+		// Qwen chat-template variant uses chat_template_kwargs
+		const thinkingEnabled = !!options?.reasoning && !options?.disableReasoning;
 		params.chat_template_kwargs = {
-			enable_thinking: !!options?.reasoning && !options?.disableReasoning,
+			enable_thinking: thinkingEnabled,
+			preserve_thinking: thinkingEnabled,
 		};
+		if (thinkingEnabled && options?.thinkingBudgets) {
+			const budget = options.thinkingBudgets[options.reasoning!];
+			if (budget != null) {
+				params.thinking_token_budget = budget;
+			}
+		}
 	} else if (supportsReasoningParams && compat.thinkingFormat === "openrouter" && model.reasoning) {
 		// OpenRouter normalizes reasoning across providers via a nested reasoning object.
 		// Without an explicit signal, OpenRouter defaults reasoning models to thinking, which
@@ -1356,6 +1374,13 @@ function buildParams(
 	) {
 		// OpenAI-style reasoning_effort
 		params.reasoning_effort = mapReasoningEffort(options.reasoning, compat.reasoningEffortMap) as Effort;
+		// vLLM and other OpenAI-compatible backends support thinking_token_budget
+		if (options?.thinkingBudgets) {
+			const budget = options.thinkingBudgets[options.reasoning];
+			if (budget != null) {
+				params.thinking_token_budget = budget;
+			}
+		}
 	} else if (
 		supportsReasoningParams &&
 		options?.disableReasoning &&
@@ -1379,6 +1404,7 @@ function buildParams(
 		// contract and suppress reasoning for this single request.
 		delete params.reasoning_effort;
 		delete params.reasoning;
+		delete params.thinking_token_budget;
 	}
 
 	if (compat.disableReasoningOnForcedToolChoice && isForcedToolChoice(params.tool_choice)) {
@@ -1387,6 +1413,7 @@ function buildParams(
 		// turn while keeping the tool-selection contract intact.
 		delete params.reasoning_effort;
 		delete params.reasoning;
+		delete params.thinking_token_budget;
 		if (compat.thinkingFormat === "zai") {
 			params.thinking = { type: "disabled" };
 		}

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -1355,14 +1355,14 @@ function buildParams(
 		// vLLM supports thinking_token_budget for fine-grained reasoning control
 		const effort = options?.reasoning;
 		const budget = effort ? options?.thinkingBudgets?.[effort] : undefined;
-		const thinkingEnabled = !!effort && !options?.disableReasoning && budget !== 0;
+		const thinkingEnabled = !!effort && !options?.disableReasoning && budget !== undefined;
 		params.enable_thinking = thinkingEnabled;
 		applyThinkingBudget(params, options, compat.thinkingFormat);
 	} else if (supportsReasoningParams && compat.thinkingFormat === "qwen-chat-template" && model.reasoning) {
 		// Qwen chat-template variant uses chat_template_kwargs
 		const effort = options?.reasoning;
 		const budget = effort ? options?.thinkingBudgets?.[effort] : undefined;
-		const thinkingEnabled = !!effort && !options?.disableReasoning && budget !== 0;
+		const thinkingEnabled = !!effort && !options?.disableReasoning && budget !== undefined;
 		params.chat_template_kwargs = {
 			enable_thinking: thinkingEnabled,
 			...(options?.thinkingBudgets ? { preserve_thinking: thinkingEnabled } : {}),

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -795,6 +795,7 @@ function mapOptionsForApi<TApi extends Api>(
 				toolChoice: mapOpenAiToolChoice(options?.toolChoice),
 				serviceTier: options?.serviceTier,
 				openrouterVariant: options?.openrouterVariant,
+				thinkingBudgets: options?.thinkingBudgets,
 			});
 
 		case "openai-responses":

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -570,6 +570,96 @@ describe("openai-completions compatibility", () => {
 		expect(assistantObject ? Reflect.get(assistantObject, "reasoning_text") : undefined).toBe("inspect tool output");
 		expect(assistantObject ? Reflect.get(assistantObject, "reasoning_content") : undefined).toBeUndefined();
 	});
+
+	it("sends thinking_token_budget for qwen format when thinkingBudgets is set", async () => {
+		const model: Model<"openai-completions"> = {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+			reasoning: true,
+			compat: {
+				thinkingFormat: "qwen",
+			},
+		};
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			reasoning: "high",
+			thinkingBudgets: { high: 4096 },
+			signal: createAbortedSignal(),
+			onPayload: payload => resolve(payload),
+		});
+		const payload = await promise;
+		expect(toObject(payload)?.thinking_token_budget).toBe(4096);
+	});
+
+	it("sends thinking_token_budget and preserve_thinking for qwen-chat-template when thinkingBudgets is set", async () => {
+		const model: Model<"openai-completions"> = {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+			reasoning: true,
+			compat: {
+				thinkingFormat: "qwen-chat-template",
+			},
+		};
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			reasoning: "high",
+			thinkingBudgets: { high: 4096 },
+			signal: createAbortedSignal(),
+			onPayload: payload => resolve(payload),
+		});
+		const payload = await promise;
+		expect(toObject(payload)?.thinking_token_budget).toBe(4096);
+		const chatTemplateArgs = getNestedObject(payload, "chat_template_kwargs");
+		expect(getNestedBoolean(chatTemplateArgs, "enable_thinking")).toBe(true);
+		expect(getNestedBoolean(chatTemplateArgs, "preserve_thinking")).toBe(true);
+	});
+
+	it("omits preserve_thinking for qwen-chat-template when thinkingBudgets is not set", async () => {
+		const model: Model<"openai-completions"> = {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+			reasoning: true,
+			compat: {
+				thinkingFormat: "qwen-chat-template",
+			},
+		};
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			reasoning: "high",
+			signal: createAbortedSignal(),
+			onPayload: payload => resolve(payload),
+		});
+		const payload = await promise;
+		const chatTemplateArgs = getNestedObject(payload, "chat_template_kwargs");
+		expect(getNestedBoolean(chatTemplateArgs, "enable_thinking")).toBe(true);
+		expect(chatTemplateArgs?.preserve_thinking).toBeUndefined();
+	});
+
+	it("drops thinking_token_budget on disableReasoningOnForcedToolChoice", async () => {
+		const model: Model<"openai-completions"> = {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+			reasoning: true,
+			compat: {
+				thinkingFormat: "qwen",
+				disableReasoningOnForcedToolChoice: true,
+			},
+		};
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			reasoning: "high",
+			thinkingBudgets: { high: 4096 },
+			toolChoice: { type: "tool", name: "read" },
+			signal: createAbortedSignal(),
+			onPayload: payload => resolve(payload),
+		});
+		const payload = await promise;
+		expect(toObject(payload)?.thinking_token_budget).toBeUndefined();
+	});
 });
 
 describe("kimi model detection via detectCompat", () => {

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -571,7 +571,7 @@ describe("openai-completions compatibility", () => {
 		expect(assistantObject ? Reflect.get(assistantObject, "reasoning_content") : undefined).toBeUndefined();
 	});
 
-	it("sends thinking_token_budget for qwen format when thinkingBudgets is set", async () => {
+	it("sends thinking_budget for qwen format when thinkingBudgets is set", async () => {
 		const model: Model<"openai-completions"> = {
 			...getBundledModel("openai", "gpt-4o-mini"),
 			api: "openai-completions",
@@ -589,7 +589,7 @@ describe("openai-completions compatibility", () => {
 			onPayload: payload => resolve(payload),
 		});
 		const payload = await promise;
-		expect(toObject(payload)?.thinking_token_budget).toBe(4096);
+		expect(toObject(payload)?.thinking_budget).toBe(4096);
 	});
 
 	it("sends thinking_token_budget and preserve_thinking for qwen-chat-template when thinkingBudgets is set", async () => {

--- a/packages/ai/test/openai-completions-compat.test.ts
+++ b/packages/ai/test/openai-completions-compat.test.ts
@@ -660,6 +660,29 @@ describe("openai-completions compatibility", () => {
 		const payload = await promise;
 		expect(toObject(payload)?.thinking_token_budget).toBeUndefined();
 	});
+
+	it("sends thinking_budget (not thinking_token_budget) for dashscope baseUrl", async () => {
+		const model: Model<"openai-completions"> = {
+			...getBundledModel("openai", "gpt-4o-mini"),
+			api: "openai-completions",
+			reasoning: true,
+			baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+			compat: {
+				thinkingFormat: "qwen",
+			},
+		};
+		const { promise, resolve } = Promise.withResolvers<unknown>();
+		streamOpenAICompletions(model, baseContext(), {
+			apiKey: "test-key",
+			reasoning: "high",
+			thinkingBudgets: { high: 4096 },
+			signal: createAbortedSignal(),
+			onPayload: payload => resolve(payload),
+		});
+		const payload = await promise;
+		expect(toObject(payload)?.thinking_budget).toBe(4096);
+		expect(toObject(payload)?.thinking_token_budget).toBeUndefined();
+	});
 });
 
 describe("kimi model detection via detectCompat", () => {

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -703,7 +703,7 @@ export const SETTINGS_SCHEMA = {
 	// Reasoning and prompts
 	defaultThinkingLevel: {
 		type: "enum",
-		values: [...THINKING_EFFORTS, AUTO_THINKING],
+		values: [...THINKING_EFFORTS, AUTO_THINKING, "0-off"],
 		default: "high",
 		ui: {
 			tab: "model",
@@ -711,6 +711,7 @@ export const SETTINGS_SCHEMA = {
 			description: "Reasoning depth for thinking-capable models",
 			options: [
 				getConfiguredThinkingLevelMetadata(AUTO_THINKING),
+				{ value: "0-off", label: "0-off", description: "Thinking enabled with 0 token budget" },
 				...THINKING_EFFORTS.map(getThinkingLevelMetadata),
 			],
 		},
@@ -3231,7 +3232,6 @@ export const SETTINGS_SCHEMA = {
 		values: ["unset", "granted", "denied"] as const,
 		default: "unset" as const,
 	},
-
 	"thinkingBudgets.minimal": { type: "number", default: 1024 },
 
 	"thinkingBudgets.low": { type: "number", default: 2048 },
@@ -3240,6 +3240,9 @@ export const SETTINGS_SCHEMA = {
 
 	"thinkingBudgets.high": { type: "number", default: 16384 },
 
+	"thinkingBudgets.xhigh": { type: "number", default: 32768 },
+
+	"thinkingBudgets.zeroOff": { type: "number", default: 0 },
 	"thinkingBudgets.xhigh": { type: "number", default: 32768 },
 } as const;
 

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -703,7 +703,7 @@ export const SETTINGS_SCHEMA = {
 	// Reasoning and prompts
 	defaultThinkingLevel: {
 		type: "enum",
-		values: [...THINKING_EFFORTS, AUTO_THINKING, "0-off"],
+		values: [...THINKING_EFFORTS, AUTO_THINKING, "zeroOff"],
 		default: "high",
 		ui: {
 			tab: "model",
@@ -711,7 +711,7 @@ export const SETTINGS_SCHEMA = {
 			description: "Reasoning depth for thinking-capable models",
 			options: [
 				getConfiguredThinkingLevelMetadata(AUTO_THINKING),
-				{ value: "0-off", label: "0-off", description: "Thinking enabled with 0 token budget" },
+				{ value: "zeroOff", label: "0-off", description: "Thinking enabled with 0 token budget" },
 				...THINKING_EFFORTS.map(getThinkingLevelMetadata),
 			],
 		},

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4007,6 +4007,10 @@ export class AgentSession {
 
 		const preparedOptions: SimpleStreamOptions =
 			openrouterVariant === undefined ? { ...options } : { ...options, openrouterVariant };
+		// Pass thinkingBudgets for budget-based thinking control (e.g., 0-off)
+		if (!preparedOptions.thinkingBudgets) {
+			preparedOptions.thinkingBudgets = this.settings.getGroup("thinkingBudgets");
+		}
 
 		// Stamp session metadata (e.g. user_id={session_id}) onto direct-call requests so
 		// they share the same session bucket as Agent.prompt-routed requests on Anthropic

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -5882,7 +5882,7 @@ export class AgentSession {
 	 */
 	getAvailableThinkingLevels(): ReadonlyArray<Effort> {
 		if (!this.model) return [];
-		return getSupportedEfforts(this.model);
+		return [Effort.ZeroOff, ...getSupportedEfforts(this.model)];
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -69,7 +69,7 @@ export function toReasoningEffort(level: ThinkingLevel | undefined): Effort | un
 	}
 	// ZeroOff enables thinking but with 0 token budget
 	if (level === ThinkingLevel.ZeroOff) {
-		return Effort.Minimal;
+		return Effort.ZeroOff;
 	}
 	return level;
 }
@@ -89,11 +89,6 @@ export function resolveThinkingLevelForModel(
 	}
 	return clampThinkingLevelForModel(model, level);
 }
-		return ThinkingLevel.Off;
-	}
-	return clampThinkingLevelForModel(model, level);
-}
-
 /**
  * Sentinel selector for the coding-agent "auto" thinking mode. Kept entirely
  * inside the coding-agent layer: it is never an {@link Effort} or

--- a/packages/coding-agent/src/thinking.ts
+++ b/packages/coding-agent/src/thinking.ts
@@ -17,6 +17,7 @@ const THINKING_LEVEL_METADATA: Record<ThinkingLevel, ThinkingLevelMetadata> = {
 		description: "Inherit session default",
 	},
 	[ThinkingLevel.Off]: { value: ThinkingLevel.Off, label: "off", description: "No reasoning" },
+	[ThinkingLevel.ZeroOff]: { value: ThinkingLevel.ZeroOff, label: "0-off", description: "Thinking enabled with 0 token budget" },
 	[ThinkingLevel.Minimal]: {
 		value: ThinkingLevel.Minimal,
 		label: "min",
@@ -35,8 +36,7 @@ const THINKING_LEVEL_METADATA: Record<ThinkingLevel, ThinkingLevelMetadata> = {
 		description: "Maximum reasoning (~32k tokens)",
 	},
 };
-
-const THINKING_LEVELS = new Set<string>([ThinkingLevel.Inherit, ThinkingLevel.Off, ...THINKING_EFFORTS]);
+const THINKING_LEVELS = new Set<string>([ThinkingLevel.Inherit, ThinkingLevel.Off, ThinkingLevel.ZeroOff, ...THINKING_EFFORTS]);
 const EFFORT_LEVELS = new Set<string>(THINKING_EFFORTS);
 
 /**
@@ -67,12 +67,12 @@ export function toReasoningEffort(level: ThinkingLevel | undefined): Effort | un
 	if (level === undefined || level === ThinkingLevel.Off || level === ThinkingLevel.Inherit) {
 		return undefined;
 	}
+	// ZeroOff enables thinking but with 0 token budget
+	if (level === ThinkingLevel.ZeroOff) {
+		return Effort.Minimal;
+	}
 	return level;
 }
-
-/**
- * Resolves a selector against the current model while preserving explicit "off".
- */
 export function resolveThinkingLevelForModel(
 	model: Model | undefined,
 	level: ThinkingLevel | undefined,
@@ -81,6 +81,14 @@ export function resolveThinkingLevelForModel(
 		return undefined;
 	}
 	if (level === ThinkingLevel.Off) {
+		return ThinkingLevel.Off;
+	}
+	// ZeroOff enables thinking but with 0 token budget - don't clamp it
+	if (level === ThinkingLevel.ZeroOff) {
+		return ThinkingLevel.ZeroOff;
+	}
+	return clampThinkingLevelForModel(model, level);
+}
 		return ThinkingLevel.Off;
 	}
 	return clampThinkingLevelForModel(model, level);


### PR DESCRIPTION
   ## Summary                                                                                                                 
                                                                                                                              
   Add `thinking_token_budget` parameter support for vLLM and other OpenAI-compatible backends that expose the                
 `thinking_token_budget` field.                                                                                               
                                                                                                                              
   This enables per-request reasoning token budget control — the model's thinking budget is now passed through to the backend 
 instead of being limited to coarse `reasoning_effort` levels.                                                                
                                                                                                                              
   ## Changes                                                                                                                 
                                                                                                                              
   - Add `thinking_token_budget` to `OpenAICompletionsParams` type                                                            
   - Add `preserve_thinking` to `chat_template_kwargs` for qwen-chat-template format                                          
   - Send `thinking_token_budget` from `thinkingBudgets` for **qwen** thinking format                                         
   - Send `thinking_token_budget` for **qwen-chat-template** format (with `preserve_thinking`)                                
   - Send `thinking_token_budget` for generic OpenAI-compatible `reasoning_effort` path                                       
   - Clean up `thinking_token_budget` on tool-choice reasoning suppression (both `disableReasoning` and forced tool choice    
 paths)                                                                                                                       
                                                                                                                              
   ## Impact                                                                                                                  
                                                                                                                              
   - 1 file changed, +30/-3 lines in `packages/ai/src/providers/openai-completions.ts`                                        
   - No breaking changes — `thinking_token_budget` is optional and only sent when `thinkingBudgets` is configured             
   - Backward compatible with all existing providers