### PR TITLE
fix(legacy-pi-compat): validated package-root override targets before rewrite

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed compiled-binary extensions failing to load `@oh-my-pi/pi-*` packages when `bun --compile` quietly dropped one of the extra entrypoints (observed on macOS arm64 release builds): the legacy-pi compat shim's package-root override branch returned the bunfs path without checking the target was present, so the rewrite emitted a `file://` URL to a missing module and the #1216 fallback (scoped to the throwing `getResolvedSpecifier` path) never ran. Override targets are now validated against the on-disk filesystem at module init, missing entries are dropped, and resolution falls through to canonical lookup so Bun resolves the import from the extension's own `node_modules` ([#2168](https://github.com/can1357/oh-my-pi/issues/2168)).
+
 ## [15.10.8] - 2026-06-09
 
 ### Added

--- a/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
+++ b/packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts
@@ -1,4 +1,4 @@
-import * as fs from "node:fs/promises";
+import * as fs from "node:fs";
 import * as path from "node:path";
 import * as url from "node:url";
 import { isCompiledBinary } from "@oh-my-pi/pi-utils";
@@ -142,7 +142,31 @@ const LEGACY_PI_CODING_AGENT_SHIM_PATH = BUNFS_PACKAGE_ROOT
 // `Bun.resolveSync`, and hardcoding a relative source-tree path would break
 // installs where the bundled packages live at `node_modules/@oh-my-pi/pi-*`
 // rather than `packages/*`.
-const LEGACY_PI_PACKAGE_ROOT_OVERRIDES: Record<string, string> = {
+//
+// Every override target is validated against the on-disk filesystem at module
+// init: any entry whose file is missing (e.g. a compiled binary where Bun's
+// `--compile` quietly dropped an additional entrypoint — issue #2168) is left
+// out so `resolveCanonicalPiSpecifier` falls through to `getResolvedSpecifier`,
+// which throws under bunfs and triggers the catch in `rewriteLegacyPiImports`.
+// That catch leaves the specifier untouched so Bun resolves the canonical
+// `@oh-my-pi/pi-*` import from the extension's own `node_modules` instead of
+// emitting a bunfs `file://` URL to a module that isn't actually present.
+
+/**
+ * Drop overrides whose targets are missing on disk so they can fall through to
+ * the canonical-resolution path. Exported for the test seam in #2168.
+ *
+ * `pathExistsSync` defaults to `fs.existsSync`; the tests inject a stub to
+ * simulate the missing-entrypoint failure mode without touching the real FS.
+ */
+export function __validateLegacyPiPackageRootOverrides(
+	candidates: Record<string, string>,
+	pathExistsSync: (p: string) => boolean = fs.existsSync,
+): Record<string, string> {
+	return Object.fromEntries(Object.entries(candidates).filter(([, candidate]) => pathExistsSync(candidate)));
+}
+
+const LEGACY_PI_PACKAGE_ROOT_OVERRIDES = __validateLegacyPiPackageRootOverrides({
 	[`${CANONICAL_PI_SCOPE}/pi-ai`]: LEGACY_PI_AI_SHIM_PATH,
 	[`${CANONICAL_PI_SCOPE}/pi-coding-agent`]: LEGACY_PI_CODING_AGENT_SHIM_PATH,
 	...(BUNFS_PACKAGE_ROOT
@@ -153,7 +177,7 @@ const LEGACY_PI_PACKAGE_ROOT_OVERRIDES: Record<string, string> = {
 				[`${CANONICAL_PI_SCOPE}/pi-utils`]: bunfsPath("utils", "src", "index.js"),
 			}
 		: {}),
-};
+});
 
 let isLegacyPiSpecifierShimInstalled = false;
 
@@ -253,7 +277,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 async function pathExists(p: string): Promise<boolean> {
 	try {
-		await fs.stat(p);
+		await fs.promises.stat(p);
 		return true;
 	} catch {
 		return false;
@@ -267,7 +291,7 @@ function hasSourceModuleExtension(p: string): boolean {
 
 async function resolveSourceModuleFile(basePath: string): Promise<string | null> {
 	try {
-		const stats = await fs.stat(basePath);
+		const stats = await fs.promises.stat(basePath);
 		if (stats.isFile()) {
 			// Non-source files (JSON, WASM, text assets, etc.) bypass the on-load
 			// rewrite hook so Bun's native loaders handle them; our hook would
@@ -475,7 +499,7 @@ const hookedExtensionEntries = new Set<string>();
 /** Resolve symlinks in a path, falling back to the input if realpath fails. */
 async function realpathOrSelf(p: string): Promise<string> {
 	try {
-		return await fs.realpath(p);
+		return await fs.promises.realpath(p);
 	} catch {
 		return p;
 	}

--- a/packages/coding-agent/test/extensibility/legacy-pi-override-fallback.test.ts
+++ b/packages/coding-agent/test/extensibility/legacy-pi-override-fallback.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import { __validateLegacyPiPackageRootOverrides } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/legacy-pi-compat";
+
+// Regression for issue #2168: in compiled-binary mode the package-root
+// override branch of `resolveCanonicalPiSpecifier` returned a bunfs path
+// without checking the target was actually present. When `bun --compile`
+// quietly dropped one of the extra entrypoints (observed on macOS arm64
+// release builds), the rewrite still emitted a `file://` URL to a missing
+// module, defeating the #1216 fallback that only fired on the throwing
+// `getResolvedSpecifier` path. The fix validates each override at module
+// init so missing entries fall through to canonical resolution and Bun
+// resolves the import from the extension's own `node_modules`.
+describe("legacy pi compat package-root override validation (issue #2168)", () => {
+	it("keeps overrides whose targets exist", () => {
+		const candidates = {
+			"@oh-my-pi/pi-ai": "/tmp/exists-ai.js",
+			"@oh-my-pi/pi-utils": "/tmp/exists-utils.js",
+		};
+		const result = __validateLegacyPiPackageRootOverrides(candidates, () => true);
+		expect(result).toEqual(candidates);
+	});
+
+	it("drops overrides whose targets are missing on disk", () => {
+		const candidates = {
+			"@oh-my-pi/pi-ai": "/tmp/exists-ai.js",
+			"@oh-my-pi/pi-coding-agent": "/tmp/exists-shim.js",
+			"@oh-my-pi/pi-utils": "/$bunfs/root/packages/utils/src/index.js",
+			"@oh-my-pi/pi-tui": "/$bunfs/root/packages/tui/src/index.js",
+		};
+		const missing = new Set(["/$bunfs/root/packages/utils/src/index.js", "/$bunfs/root/packages/tui/src/index.js"]);
+		const result = __validateLegacyPiPackageRootOverrides(candidates, p => !missing.has(p));
+		expect(result).toEqual({
+			"@oh-my-pi/pi-ai": "/tmp/exists-ai.js",
+			"@oh-my-pi/pi-coding-agent": "/tmp/exists-shim.js",
+		});
+		// `pi-utils` and `pi-tui` are absent so the resolver falls through to
+		// `getResolvedSpecifier` (which throws under bunfs), which triggers
+		// the catch in `rewriteLegacyPiImports` that leaves the specifier
+		// unchanged for native `node_modules` resolution.
+		expect(result).not.toHaveProperty("@oh-my-pi/pi-utils");
+		expect(result).not.toHaveProperty("@oh-my-pi/pi-tui");
+	});
+
+	it("drops every override when none of the targets exist", () => {
+		const candidates = {
+			"@oh-my-pi/pi-utils": "/$bunfs/root/packages/utils/src/index.js",
+			"@oh-my-pi/pi-tui": "/$bunfs/root/packages/tui/src/index.js",
+		};
+		const result = __validateLegacyPiPackageRootOverrides(candidates, () => false);
+		expect(result).toEqual({});
+	});
+});


### PR DESCRIPTION
## Repro

On the 15.10.8 release binary (macOS arm64), any extension that imports `@oh-my-pi/pi-*` by package name silently fails to load. A minimal repro:

```bash
mkdir -p /tmp/piutil-ext
printf 'import { formatDuration } from "@oh-my-pi/pi-utils";\nexport default (_api) => { void formatDuration; };\n' > /tmp/piutil-ext/ext.ts
omp -e /tmp/piutil-ext/ext.ts -p "reply with: ok"
```

`~/.omp/logs/omp.<date>.log` reports:

```
Failed to load extension: ResolveMessage: Cannot find module
  '/$bunfs/root/packages/utils/src/index.js' from '/private/tmp/piutil-ext/ext.ts'
```

The same failure mode breaks the first-party `@oh-my-pi/swarm-extension`. After my fix, building from this branch and running the same command on Linux x64 prints:

```
EXT EVAL
formatDuration: function
ok
```

## Cause

`packages/coding-agent/src/extensibility/plugins/legacy-pi-compat.ts` `resolveCanonicalPiSpecifier` returned `LEGACY_PI_PACKAGE_ROOT_OVERRIDES[remappedSpecifier]` directly with no existence check. The static rewrite in `rewriteLegacyPiImports` then emitted a `file://` URL pointing at a bunfs path. When `bun --compile` quietly dropped one of the additional entrypoints, that URL resolved to a missing module — but the #1216 catch was scoped to the throwing `getResolvedSpecifier` path, so the override branch silently committed a bad URL and the import failed later, outside the try/catch. The graceful fallback to the importer's own `node_modules` therefore never ran.

## Fix

- `legacy-pi-compat.ts`: extracted a small pure `__validateLegacyPiPackageRootOverrides(candidates, pathExistsSync = fs.existsSync)` that returns only the candidates whose target is actually on disk. `LEGACY_PI_PACKAGE_ROOT_OVERRIDES` is built through it at module init, so a missing entry (binary missing the entrypoint, dev tree missing the shim, …) drops out of the map. `resolveCanonicalPiSpecifier` then falls through to `getResolvedSpecifier`, which throws under bunfs and triggers the existing rewrite catch — Bun resolves the canonical `@oh-my-pi/pi-*` specifier from the extension's own `node_modules`.
- Switched the file's `node:fs/promises` namespace import to `node:fs` so the same module can use `fs.existsSync` for the sync probe and `fs.promises.{stat,realpath}` for the existing async callers.
- Added `test/extensibility/legacy-pi-override-fallback.test.ts` covering the keep/drop/drop-all cases through the injected predicate.

## Verification

- `bun --cwd=packages/coding-agent test test/extensibility/legacy-pi-override-fallback.test.ts test/extensibility/legacy-pi-bunfs-root.test.ts test/extensibility/legacy-pi-inplace-load.test.ts test/extensibility/legacy-pi-ai-type-remap.test.ts test/issue-1215-legacy-pi-ai-import.test.ts test/issue-973-legacy-pi-plugin.test.ts` → 21 pass / 0 fail.
- Built the binary (`bun --cwd=packages/coding-agent run build`) and re-ran the minimal repro on Linux x64: extension loads, `formatDuration` resolves, no `ResolveMessage` in the logs. The fix is a no-op on this platform (every override target exists in the bunfs), but the validation seam now drops missing entries on platforms where `bun --compile` does.

Fixes #2168
