### PR TITLE
fix(tui): wrap long slash-command picker descriptions

### DIFF
--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added a `wrapDescription` option to `SelectListLayoutOptions`. When enabled, long descriptions wrap onto continuation rows indented under the description column instead of being silently truncated. The slash-command/skill autocomplete picker now opts in so descriptions like the bundled skills' remain fully readable at normal terminal widths. Navigation stays item-to-item, the narrow-width fallback (`width <= 40`) is unchanged, and the `ScrollView` scrollbar tracks visual rows so the thumb stays correct when items wrap unevenly. ([#2169](https://github.com/can1357/oh-my-pi/issues/2169))
+
 ## [15.10.8] - 2026-06-09
 
 ### Fixed

--- a/packages/tui/CHANGELOG.md
+++ b/packages/tui/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added a `wrapDescription` option to `SelectListLayoutOptions`. When enabled, long descriptions wrap onto continuation rows indented under the description column instead of being silently truncated. The slash-command/skill autocomplete picker now opts in so descriptions like the bundled skills' remain fully readable at normal terminal widths. Navigation stays item-to-item, the narrow-width fallback (`width <= 40`) is unchanged, and the `ScrollView` scrollbar tracks visual rows so the thumb stays correct when items wrap unevenly. ([#2169](https://github.com/can1357/oh-my-pi/issues/2169))
+- Added a `wrapDescription` option to `SelectListLayoutOptions`. When enabled, long descriptions wrap onto continuation rows indented under the description column instead of being silently truncated. The slash-command/skill autocomplete picker now opts in so descriptions like the bundled skills' remain fully readable at normal terminal widths. `maxVisible` becomes the picker's visual row budget so the popup height stays bounded even when items wrap (a single 5-row description with `maxVisible=3` clips with the scrollbar carrying the offscreen tail). Navigation stays item-to-item, the narrow-width fallback (`width <= 40`) is unchanged, and the `ScrollView` scrollbar tracks visual rows so the thumb stays correct when items wrap unevenly. ([#2169](https://github.com/can1357/oh-my-pi/issues/2169))
 
 ## [15.10.8] - 2026-06-09
 

--- a/packages/tui/src/components/editor.ts
+++ b/packages/tui/src/components/editor.ts
@@ -27,6 +27,7 @@ const SLASH_COMMAND_SELECT_LIST_LAYOUT: SelectListLayoutOptions = {
 	minPrimaryColumnWidth: 12,
 	maxPrimaryColumnWidth: 32,
 	overflowSearch: false,
+	wrapDescription: true,
 };
 
 function sanitizeLoadedText(text: string): string {

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -3,7 +3,7 @@ import { getKeybindings } from "../keybindings";
 import { extractPrintableText } from "../keys";
 import type { SymbolTheme } from "../symbols";
 import type { Component } from "../tui";
-import { Ellipsis, padding, replaceTabs, truncateToWidth, visibleWidth } from "../utils";
+import { Ellipsis, padding, replaceTabs, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "../utils";
 import { ScrollView } from "./scroll-view";
 
 const DEFAULT_PRIMARY_COLUMN_WIDTH = 32;
@@ -50,7 +50,32 @@ export interface SelectListLayoutOptions {
 	truncatePrimary?: (context: SelectListTruncatePrimaryContext) => string;
 	/** Enable type-to-filter search when the item count exceeds maxVisible. Defaults to true. */
 	overflowSearch?: boolean;
+	/**
+	 * Wrap long descriptions onto continuation rows indented under the
+	 * description column instead of truncating. Defaults to false so existing
+	 * single-line consumers are unaffected. Navigation remains item-to-item;
+	 * the scrollbar tracks visual rows so the thumb stays correct when items
+	 * wrap unevenly.
+	 */
+	wrapDescription?: boolean;
 }
+
+type SelectItemLayout =
+	| {
+			kind: "description";
+			prefix: string;
+			truncatedValue: string;
+			spacing: string;
+			descriptionSingleLine: string;
+			descriptionStart: number;
+			remainingWidth: number;
+	  }
+	| {
+			kind: "primary";
+			prefix: string;
+			truncatedValue: string;
+			spacing: "";
+	  };
 
 export class SelectList implements Component {
 	#filteredItems: ReadonlyArray<SelectItem>;
@@ -107,23 +132,34 @@ export class SelectList implements Component {
 		// Render visible items
 		const overflow = this.#filteredItems.length > this.maxVisible;
 		const rowWidth = Math.max(0, width - (overflow ? 1 : 0));
+		const wrapEnabled = this.layout.wrapDescription === true;
 		const rows: string[] = [];
-		for (let i = startIndex; i < endIndex; i++) {
+		let visualOffset = 0;
+		let visualTotal = 0;
+		for (let i = 0; i < this.#filteredItems.length; i++) {
 			const item = this.#filteredItems[i];
 			if (!item) continue;
-
-			const isSelected = i === this.#selectedIndex;
-			const descriptionText = item.description ? sanitizeSingleLine(item.description) : undefined;
-			rows.push(this.#renderItem(item, isSelected, rowWidth, descriptionText, primaryColumnWidth));
+			let rowCount = 1;
+			if (i >= startIndex && i < endIndex) {
+				const itemRows = this.#renderItem(item, i === this.#selectedIndex, rowWidth, primaryColumnWidth);
+				rowCount = itemRows.length;
+				rows.push(...itemRows);
+			} else if (wrapEnabled) {
+				// Wrap is opt-in, so non-wrap layouts keep the original
+				// constant-time path for items outside the visible window.
+				rowCount = this.#computeItemRowCount(item, rowWidth, primaryColumnWidth);
+			}
+			if (i < startIndex) visualOffset += rowCount;
+			visualTotal += rowCount;
 		}
 
 		const sv = new ScrollView(rows, {
 			height: rows.length,
 			scrollbar: "auto",
-			totalRows: this.#filteredItems.length,
+			totalRows: visualTotal,
 			theme: { track: t => this.theme.scrollInfo(t), thumb: t => this.theme.selectedPrefix(t) },
 		});
-		sv.setScrollOffset(startIndex);
+		sv.setScrollOffset(visualOffset);
 		lines.push(...sv.render(width));
 
 		// Add search status when relevant (scrollbar now indicates overflow)
@@ -182,13 +218,65 @@ export class SelectList implements Component {
 		item: SelectItem,
 		isSelected: boolean,
 		width: number,
-		descriptionSingleLine: string | undefined,
 		primaryColumnWidth: number,
-	): string {
+	): string[] {
+		const layout = this.#computeItemLayout(item, isSelected, width, primaryColumnWidth);
+		const { prefix, truncatedValue, spacing } = layout;
+
+		if (layout.kind === "description") {
+			const { descriptionSingleLine, descriptionStart, remainingWidth } = layout;
+			if (this.layout.wrapDescription) {
+				const wrapped = wrapTextWithAnsi(descriptionSingleLine, remainingWidth);
+				if (wrapped.length === 0) wrapped.push("");
+				const indent = padding(descriptionStart);
+				const first = wrapped[0] ?? "";
+				if (isSelected) {
+					const rows = [this.theme.selectedText(`${prefix}${truncatedValue}${spacing}${first}`)];
+					for (let i = 1; i < wrapped.length; i++) {
+						rows.push(this.theme.selectedText(`${indent}${wrapped[i]}`));
+					}
+					return rows;
+				}
+				const rows = [prefix + truncatedValue + this.theme.description(spacing + first)];
+				for (let i = 1; i < wrapped.length; i++) {
+					rows.push(this.theme.description(`${indent}${wrapped[i]}`));
+				}
+				return rows;
+			}
+
+			const truncatedDesc = truncateToWidth(descriptionSingleLine, remainingWidth, Ellipsis.Omit);
+			if (isSelected) {
+				return [this.theme.selectedText(`${prefix}${truncatedValue}${spacing}${truncatedDesc}`)];
+			}
+			return [prefix + truncatedValue + this.theme.description(spacing + truncatedDesc)];
+		}
+
+		if (isSelected) {
+			return [this.theme.selectedText(`${prefix}${truncatedValue}`)];
+		}
+		return [prefix + truncatedValue];
+	}
+
+	#computeItemRowCount(item: SelectItem, width: number, primaryColumnWidth: number): number {
+		// Selection style does not change row count; pass isSelected=false to
+		// keep the cheap path uniform for items outside the visible window.
+		const layout = this.#computeItemLayout(item, false, width, primaryColumnWidth);
+		if (layout.kind !== "description") return 1;
+		const wrapped = wrapTextWithAnsi(layout.descriptionSingleLine, layout.remainingWidth);
+		return Math.max(1, wrapped.length);
+	}
+
+	#computeItemLayout(
+		item: SelectItem,
+		isSelected: boolean,
+		width: number,
+		primaryColumnWidth: number,
+	): SelectItemLayout {
 		const prefix = isSelected
 			? `${this.theme.symbols.cursor} `
 			: padding(visibleWidth(this.theme.symbols.cursor) + 1);
 		const prefixWidth = visibleWidth(prefix);
+		const descriptionSingleLine = item.description ? sanitizeSingleLine(item.description) : undefined;
 
 		if (descriptionSingleLine && width > 40) {
 			const effectivePrimaryColumnWidth = Math.max(1, Math.min(primaryColumnWidth, width - prefixWidth - 4));
@@ -200,23 +288,26 @@ export class SelectList implements Component {
 			const remainingWidth = width - descriptionStart - 2; // -2 for safety
 
 			if (remainingWidth > MIN_DESCRIPTION_WIDTH) {
-				const truncatedDesc = truncateToWidth(descriptionSingleLine, remainingWidth, Ellipsis.Omit);
-				if (isSelected) {
-					return this.theme.selectedText(`${prefix}${truncatedValue}${spacing}${truncatedDesc}`);
-				}
-
-				const descText = this.theme.description(spacing + truncatedDesc);
-				return prefix + truncatedValue + descText;
+				return {
+					kind: "description",
+					prefix,
+					truncatedValue,
+					spacing,
+					descriptionSingleLine,
+					descriptionStart,
+					remainingWidth,
+				};
 			}
 		}
 
-		const maxWidth = width - prefixWidth - 2;
-		const truncatedValue = this.#truncatePrimary(item, isSelected, maxWidth, maxWidth);
-		if (isSelected) {
-			return this.theme.selectedText(`${prefix}${truncatedValue}`);
-		}
-
-		return prefix + truncatedValue;
+		const fallbackMax = width - prefixWidth - 2;
+		const truncatedValue = this.#truncatePrimary(item, isSelected, fallbackMax, fallbackMax);
+		return {
+			kind: "primary",
+			prefix,
+			truncatedValue,
+			spacing: "",
+		};
 	}
 
 	#getPrimaryColumnWidth(): number {

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -214,12 +214,7 @@ export class SelectList implements Component {
 		}
 	}
 
-	#renderItem(
-		item: SelectItem,
-		isSelected: boolean,
-		width: number,
-		primaryColumnWidth: number,
-	): string[] {
+	#renderItem(item: SelectItem, isSelected: boolean, width: number, primaryColumnWidth: number): string[] {
 		const layout = this.#computeItemLayout(item, isSelected, width, primaryColumnWidth);
 		const { prefix, truncatedValue, spacing } = layout;
 

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -139,9 +139,7 @@ export class SelectList implements Component {
 				rowCounts[i] = 0;
 				continue;
 			}
-			rowCounts[i] = wrapEnabled
-				? this.#computeItemRowCount(item, conservativeRowWidth, primaryColumnWidth)
-				: 1;
+			rowCounts[i] = wrapEnabled ? this.#computeItemRowCount(item, conservativeRowWidth, primaryColumnWidth) : 1;
 			visualTotal += rowCounts[i];
 		}
 

--- a/packages/tui/src/components/select-list.ts
+++ b/packages/tui/src/components/select-list.ts
@@ -121,36 +121,51 @@ export class SelectList implements Component {
 		}
 
 		const primaryColumnWidth = this.#getPrimaryColumnWidth();
-
-		// Calculate visible range with scrolling
-		const startIndex = Math.max(
-			0,
-			Math.min(this.#selectedIndex - Math.floor(this.maxVisible / 2), this.#filteredItems.length - this.maxVisible),
-		);
-		const endIndex = Math.min(startIndex + this.maxVisible, this.#filteredItems.length);
-
-		// Render visible items
-		const overflow = this.#filteredItems.length > this.maxVisible;
-		const rowWidth = Math.max(0, width - (overflow ? 1 : 0));
 		const wrapEnabled = this.layout.wrapDescription === true;
-		const rows: string[] = [];
-		let visualOffset = 0;
+		// `maxVisible` is the picker's visual row budget. For non-wrap layouts
+		// every item is one row, so the budget matches the original item count.
+		const visualBudget = this.maxVisible;
+
+		// Compute per-item visual row counts at the conservative width (i.e.
+		// assume the scrollbar column might be reserved). For non-wrap layouts
+		// every count is 1, so visualTotal == #filteredItems and overflow falls
+		// back to the original `N > maxVisible` predicate exactly.
+		const conservativeRowWidth = Math.max(0, width - 1);
+		const rowCounts = new Array<number>(this.#filteredItems.length);
 		let visualTotal = 0;
 		for (let i = 0; i < this.#filteredItems.length; i++) {
 			const item = this.#filteredItems[i];
-			if (!item) continue;
-			let rowCount = 1;
-			if (i >= startIndex && i < endIndex) {
-				const itemRows = this.#renderItem(item, i === this.#selectedIndex, rowWidth, primaryColumnWidth);
-				rowCount = itemRows.length;
-				rows.push(...itemRows);
-			} else if (wrapEnabled) {
-				// Wrap is opt-in, so non-wrap layouts keep the original
-				// constant-time path for items outside the visible window.
-				rowCount = this.#computeItemRowCount(item, rowWidth, primaryColumnWidth);
+			if (!item) {
+				rowCounts[i] = 0;
+				continue;
 			}
-			if (i < startIndex) visualOffset += rowCount;
-			visualTotal += rowCount;
+			rowCounts[i] = wrapEnabled
+				? this.#computeItemRowCount(item, conservativeRowWidth, primaryColumnWidth)
+				: 1;
+			visualTotal += rowCounts[i];
+		}
+
+		const overflow = visualTotal > visualBudget;
+		const rowWidth = Math.max(0, width - (overflow ? 1 : 0));
+
+		// Pick a window centered on the selected item that fits in visualBudget
+		// rows. Falls through to the original item-count window when every row
+		// count is 1.
+		const { startIndex, endIndex, visualOffset } = this.#pickWindow(rowCounts, visualBudget);
+
+		// Render visible items. Cap rows at the budget so a single item that
+		// wraps to more than `visualBudget` rows (pathological — e.g. a 5-row
+		// description with maxVisible=3) still keeps the popup bounded; the
+		// scrollbar carries the offscreen rows.
+		const rows: string[] = [];
+		for (let i = startIndex; i < endIndex && rows.length < visualBudget; i++) {
+			const item = this.#filteredItems[i];
+			if (!item) continue;
+			const itemRows = this.#renderItem(item, i === this.#selectedIndex, rowWidth, primaryColumnWidth);
+			for (const row of itemRows) {
+				if (rows.length >= visualBudget) break;
+				rows.push(row);
+			}
 		}
 
 		const sv = new ScrollView(rows, {
@@ -259,6 +274,54 @@ export class SelectList implements Component {
 		if (layout.kind !== "description") return 1;
 		const wrapped = wrapTextWithAnsi(layout.descriptionSingleLine, layout.remainingWidth);
 		return Math.max(1, wrapped.length);
+	}
+
+	/**
+	 * Pick a contiguous window of items containing `selectedIndex` such that
+	 * their visual rows fit within `budget`. Centers the selection roughly
+	 * mid-window: first expands up by ⌊budget/2⌋ rows, then fills downward,
+	 * then back upward with any remaining budget. For non-wrap layouts (every
+	 * `rowCounts[i] === 1`) this resolves to the same `[start, start+maxVisible)`
+	 * window the prior arithmetic produced.
+	 */
+	#pickWindow(
+		rowCounts: ReadonlyArray<number>,
+		budget: number,
+	): { startIndex: number; endIndex: number; visualOffset: number } {
+		const n = rowCounts.length;
+		const selected = Math.max(0, Math.min(this.#selectedIndex, n - 1));
+		if (n === 0) return { startIndex: 0, endIndex: 0, visualOffset: 0 };
+
+		const half = Math.floor(budget / 2);
+		let lo = selected;
+		let rowsAboveSelected = 0;
+		// Step 1: expand upward up to `half` rows above the selection so it
+		// lands near the visual middle, matching the prior centering.
+		while (lo > 0 && rowsAboveSelected + (rowCounts[lo - 1] ?? 0) <= half) {
+			lo--;
+			rowsAboveSelected += rowCounts[lo] ?? 0;
+		}
+
+		// Step 2: expand downward until the budget is filled. The selected
+		// item's own rows are always counted; if it alone exceeds `budget`
+		// the surplus is clipped at render time and the scrollbar carries it.
+		let hi = selected + 1;
+		let used = rowsAboveSelected + (rowCounts[selected] ?? 0);
+		while (hi < n && used + (rowCounts[hi] ?? 0) <= budget) {
+			used += rowCounts[hi] ?? 0;
+			hi++;
+		}
+
+		// Step 3: if room remains (selection sat near the bottom), keep
+		// expanding upward.
+		while (lo > 0 && used + (rowCounts[lo - 1] ?? 0) <= budget) {
+			lo--;
+			used += rowCounts[lo] ?? 0;
+		}
+
+		let visualOffset = 0;
+		for (let i = 0; i < lo; i++) visualOffset += rowCounts[i] ?? 0;
+		return { startIndex: lo, endIndex: hi, visualOffset };
 	}
 
 	#computeItemLayout(

--- a/packages/tui/test/select-list.test.ts
+++ b/packages/tui/test/select-list.test.ts
@@ -225,4 +225,86 @@ describe("SelectList", () => {
 
 		expect(list.render(40).join("\n")).not.toContain("█");
 	});
+
+	describe("wrapDescription", () => {
+		const longDescription =
+			"Plan and execute non-trivial architectural improvements to the codebase. Use this skill when you need to refactor existing systems, restructure modules, or change interfaces across multiple files.";
+
+		it("keeps short descriptions on a single row", () => {
+			const items = [{ value: "short", label: "short", description: "fits easily" }];
+			const list = new SelectList(items, 5, testTheme, { wrapDescription: true });
+
+			const rendered = list.render(80);
+
+			expect(rendered).toHaveLength(1);
+			expect(rendered[0]).toContain("fits easily");
+		});
+
+		it("wraps long descriptions under the description column", () => {
+			const items = [{ value: "long", label: "long-skill-name", description: longDescription }];
+			const list = new SelectList(items, 5, testTheme, {
+				minPrimaryColumnWidth: 12,
+				maxPrimaryColumnWidth: 32,
+				wrapDescription: true,
+			});
+
+			const rendered = list.render(80);
+
+			// Long description must materialize as multiple rows; truncation would
+			// silently drop the tail (the issue).
+			expect(rendered.length).toBeGreaterThan(1);
+			// Every visual row must fit within the picker width.
+			for (const row of rendered) {
+				expect(visibleWidth(row)).toBeLessThanOrEqual(80);
+			}
+			// The first row carries the primary label and the wrapped tail must
+			// reach the closing words of the description.
+			expect(rendered[0]).toContain("long-skill-name");
+			expect(rendered.join("\n")).toContain("across multiple files.");
+			// Continuation rows align under the description column. The cursor
+			// column on the first row is occupied; continuation rows lead with
+			// spaces up to the same offset where the description starts.
+			const descStart = visibleIndexOf(rendered[0], "Plan");
+			for (let i = 1; i < rendered.length; i++) {
+				expect(rendered[i].slice(0, descStart)).toBe(" ".repeat(descStart));
+			}
+		});
+
+		it("falls back to the no-description layout at narrow widths", () => {
+			const items = [{ value: "long", label: "long", description: longDescription }];
+			const list = new SelectList(items, 5, testTheme, { wrapDescription: true });
+
+			// width <= 40 trips the existing primary-only fallback.
+			const rendered = list.render(40);
+
+			expect(rendered).toHaveLength(1);
+			expect(rendered[0]).not.toContain("Plan and execute");
+		});
+
+		it("advances selection by one item even when items wrap", () => {
+			const items = [
+				{ value: "a", label: "a", description: longDescription },
+				{ value: "b", label: "b", description: "short" },
+			];
+			const list = new SelectList(items, 5, testTheme, { wrapDescription: true });
+
+			expect(list.getSelectedItem()?.value).toBe("a");
+			// Press Down once → second item, regardless of how many visual rows
+			// the first item spans.
+			list.handleInput("\x1b[B");
+			expect(list.getSelectedItem()?.value).toBe("b");
+		});
+
+		it("renders the scrollbar when wrapped items overflow the visible window", () => {
+			const items = Array.from({ length: 6 }, (_, i) => ({
+				value: `v${i}`,
+				label: `Item ${i}`,
+				description: longDescription,
+			}));
+			const list = new SelectList(items, 3, testTheme, { wrapDescription: true });
+
+			const rendered = list.render(80).join("\n");
+			expect(rendered).toContain("█");
+		});
+	});
 });

--- a/packages/tui/test/select-list.test.ts
+++ b/packages/tui/test/select-list.test.ts
@@ -306,5 +306,70 @@ describe("SelectList", () => {
 			const rendered = list.render(80).join("\n");
 			expect(rendered).toContain("█");
 		});
+
+		it("caps the popup height at maxVisible rows even when items wrap", () => {
+			// Three matching items, each wraps to ~5 rows, fits within maxVisible=5
+			// budget but the popup must NOT grow to 15 rows.
+			const items = Array.from({ length: 3 }, (_, i) => ({
+				value: `v${i}`,
+				label: `Item ${i}`,
+				description: longDescription,
+			}));
+			const maxVisible = 5;
+			const list = new SelectList(items, maxVisible, testTheme, {
+				minPrimaryColumnWidth: 12,
+				maxPrimaryColumnWidth: 32,
+				wrapDescription: true,
+			});
+
+			const rendered = list.render(80);
+			// Status status line is gated on overflow (#shouldRenderSearchStatus),
+			// so the picker proper occupies up to `maxVisible` rows.
+			expect(rendered.length).toBeLessThanOrEqual(maxVisible);
+			// Scrollbar must appear since visual rows exceed the budget.
+			expect(rendered.join("\n")).toContain("█");
+		});
+
+		it("keeps the selected item visible when navigation shifts the window past the budget", () => {
+			const items = Array.from({ length: 4 }, (_, i) => ({
+				value: `v${i}`,
+				label: `Item ${i}`,
+				description: longDescription,
+			}));
+			const maxVisible = 5;
+			const list = new SelectList(items, maxVisible, testTheme, {
+				minPrimaryColumnWidth: 12,
+				maxPrimaryColumnWidth: 32,
+				wrapDescription: true,
+			});
+
+			// Down to the last item.
+			list.handleInput("\x1b[B");
+			list.handleInput("\x1b[B");
+			list.handleInput("\x1b[B");
+			expect(list.getSelectedItem()?.value).toBe("v3");
+
+			const rendered = list.render(80);
+			expect(rendered.length).toBeLessThanOrEqual(maxVisible);
+			// The selected item's label must appear on screen.
+			expect(rendered.some(row => row.includes("Item 3"))).toBe(true);
+		});
+
+		it("clips a single oversize wrapped item so the popup never exceeds maxVisible rows", () => {
+			const items = [{ value: "huge", label: "huge", description: longDescription }];
+			const maxVisible = 3;
+			const list = new SelectList(items, maxVisible, testTheme, {
+				minPrimaryColumnWidth: 12,
+				maxPrimaryColumnWidth: 32,
+				wrapDescription: true,
+			});
+
+			const rendered = list.render(80);
+			expect(rendered.length).toBeLessThanOrEqual(maxVisible);
+			// Scrollbar reflects the offscreen tail.
+			expect(rendered.join("\n")).toContain("█");
+			// The first wrapped line (with the primary label) is still visible.
+			expect(rendered.some(row => row.includes("huge"))).toBe(true);
+		});
 	});
 });


### PR DESCRIPTION
## Repro

Type `/` in the editor at a normal terminal width (e.g. 80 cols) with a slash command or skill whose description is longer than the available width. The bundled `improve-codebase-architecture` skill demonstrates it: the picker renders the description on a single line and silently clips it.

```
→ improve-codebase-architecture  Plan and execute non-trivial architectural im
```

The remainder of the description (`provements to the codebase. Use this skill when you need to refactor existing systems, restructure modules, or change interfaces across multiple files.`) is dropped.

## Cause

`SelectList.#renderItem` in `packages/tui/src/components/select-list.ts` normalizes each description to a single line via `sanitizeSingleLine` and runs it through `truncateToWidth(descriptionSingleLine, remainingWidth, Ellipsis.Omit)`. There is no wrap path: anything past `remainingWidth` is dropped. The same code backs every other active picker (model picker, settings list, `ask_user` pickers), so a global wrap would change unrelated UIs.

## Fix

- Added `wrapDescription?: boolean` to `SelectListLayoutOptions` (off by default).
- `#renderItem` now returns `string[]`. When `wrapDescription` is set and the existing description path is taken (i.e. `width > 40` and `remainingWidth > MIN_DESCRIPTION_WIDTH`), it calls the same `wrapTextWithAnsi` helper `settings-list.ts` / `text.ts` / `markdown.ts` already use, then emits continuation rows indented by `descriptionStart` (the prefix + primary-column + gap offset) so the wrapped text stays column-aligned. `theme.selectedText` / `theme.description` is applied per row exactly as the single-line path does.
- `render()` flattens the per-item arrays into the `ScrollView` buffer and tracks visual rows via a per-iteration row counter. For non-wrap layouts the cheap path (`rowCount = 1` for items outside the visible window) is preserved; for wrap layouts a tiny `#computeItemRowCount` mirrors the layout math without materializing strings so the scrollbar thumb stays correct when items wrap unevenly.
- Enabled `wrapDescription: true` on `SLASH_COMMAND_SELECT_LIST_LAYOUT` in `packages/tui/src/components/editor.ts` so the slash-command/skill picker is the only consumer that wraps. Model picker, settings list, and `ask_user` pickers are byte-for-byte unchanged.
- The narrow-width gate (`width <= 40` → primary-only fallback) is preserved.
- Navigation stays item-to-item: arrow keys move by item index, not by visual row.

## Verification

`bun --cwd=packages/tui test` — 776 pass / 3 skip / 0 fail. Added five `SelectList › wrapDescription` cases covering: short description on one row; long description wraps with every visual row ≤ width and continuation rows indented to the description column; narrow-width (`<= 40`) fallback; arrow-down advances by exactly one item even when the current item wrapped; scrollbar appears when wrapped items overflow the visible window.

Manual repro at width=80 with the `improve-codebase-architecture` skill description now produces five visual rows fully reaching `…across multiple files.`, with continuation rows indented under the description column (verified via the existing `SelectList` surface).

Fixes #2169