### PR TITLE
feat(ai): add grok-composer-2.5-fast to the SuperGrok catalog

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -124,6 +124,10 @@
 
 - Added `grok-composer-2.5-fast` (Cursor "Composer 2.5 Fast") to the xAI Grok OAuth (SuperGrok) catalog: non-reasoning, text-only, 200K context.
 
+### Changed
+
+- Set every xAI Grok OAuth (SuperGrok) curated model's max output tokens to mirror its context window (`grok-build`, `grok-4.3`, `grok-4.20-0309-{reasoning,non-reasoning}`, `grok-4.20-multi-agent-0309`, `grok-composer-2.5-fast`), replacing the `8888` `UNK_MAX_TOKENS` placeholder (and a stale `30000` on three grok-4.x entries). xAI's OAuth `/v1/models` reports no per-request output limit, so the curated catalog now owns `maxTokens` like `contextWindow`, deterministic on both the static-seed and online-overlay paths; the `openai-responses` wire still clamps the actual request to `OPENAI_MAX_OUTPUT_TOKENS` (64k).
+
 ## [15.10.8] - 2026-06-09
 
 ### Added

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -120,6 +120,10 @@
 - Fixed adaptive-only Claude models (Opus 4.6+, Sonnet 4.6+, Fable/Mythos 5) returning HTTP 400 `"thinking.type.disabled" is not supported for this model` whenever thinking was turned off (utility calls and forced-tool turns route through the disable path). These models accept only `thinking.type: "adaptive"`; the request builder now omits the thinking field and pins the lowest adaptive effort instead of emitting `type: "disabled"`.
 - Widened the OpenAI-completions first-event watchdog floor from 120s to 300s for DeepSeek V4 reasoning models hosted on the official DeepSeek API. The reasoner emits no SSE bytes until its private chain-of-thought finishes, which routinely takes longer than the generic 100s first-event budget under load — every chat then aborted with `OpenAI completions stream timed out while waiting for the first event` and silently retried. Mirrors the existing GLM coding-plan widening ([#2177](https://github.com/can1357/oh-my-pi/issues/2177)).
 
+### Added
+
+- Added `grok-composer-2.5-fast` (Cursor "Composer 2.5 Fast") to the xAI Grok OAuth (SuperGrok) catalog: non-reasoning, text-only, 200K context.
+
 ## [15.10.8] - 2026-06-09
 
 ### Added

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -120,14 +120,6 @@
 - Fixed adaptive-only Claude models (Opus 4.6+, Sonnet 4.6+, Fable/Mythos 5) returning HTTP 400 `"thinking.type.disabled" is not supported for this model` whenever thinking was turned off (utility calls and forced-tool turns route through the disable path). These models accept only `thinking.type: "adaptive"`; the request builder now omits the thinking field and pins the lowest adaptive effort instead of emitting `type: "disabled"`.
 - Widened the OpenAI-completions first-event watchdog floor from 120s to 300s for DeepSeek V4 reasoning models hosted on the official DeepSeek API. The reasoner emits no SSE bytes until its private chain-of-thought finishes, which routinely takes longer than the generic 100s first-event budget under load — every chat then aborted with `OpenAI completions stream timed out while waiting for the first event` and silently retried. Mirrors the existing GLM coding-plan widening ([#2177](https://github.com/can1357/oh-my-pi/issues/2177)).
 
-### Added
-
-- Added `grok-composer-2.5-fast` (Cursor "Composer 2.5 Fast") to the xAI Grok OAuth (SuperGrok) catalog: non-reasoning, text-only, 200K context.
-
-### Changed
-
-- Set every xAI Grok OAuth (SuperGrok) curated model's max output tokens to mirror its context window (`grok-build`, `grok-4.3`, `grok-4.20-0309-{reasoning,non-reasoning}`, `grok-4.20-multi-agent-0309`, `grok-composer-2.5-fast`), replacing the `8888` `UNK_MAX_TOKENS` placeholder (and a stale `30000` on three grok-4.x entries). xAI's OAuth `/v1/models` reports no per-request output limit, so the curated catalog now owns `maxTokens` like `contextWindow`, deterministic on both the static-seed and online-overlay paths; the `openai-responses` wire still clamps the actual request to `OPENAI_MAX_OUTPUT_TOKENS` (64k).
-
 ## [15.10.8] - 2026-06-09
 
 ### Added

--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `grok-composer-2.5-fast` (Cursor "Composer 2.5 Fast") to the xAI Grok OAuth (SuperGrok) catalog: non-reasoning, text-only, 200K context.
+
+### Changed
+
+- Set every xAI Grok OAuth (SuperGrok) curated model's max output tokens to mirror its context window (`grok-build`, `grok-4.3`, `grok-4.20-0309-{reasoning,non-reasoning}`, `grok-4.20-multi-agent-0309`, `grok-composer-2.5-fast`), replacing the `8888` `UNK_MAX_TOKENS` placeholder (and a stale `30000` on three grok-4.x entries). xAI's OAuth `/v1/models` reports no per-request output limit, so the curated catalog now owns `maxTokens` like `contextWindow`, deterministic on both the static-seed and online-overlay paths; the `openai-responses` wire still clamps the actual request to `OPENAI_MAX_OUTPUT_TOKENS` (64k).
+
 ## [15.10.11] - 2026-06-10
 
 ### Added

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -69968,7 +69968,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 2000000,
-			"maxTokens": 30000,
+			"maxTokens": 2000000,
 			"compat": {
 				"reasoningEffortMap": {
 					"minimal": "low"
@@ -69993,7 +69993,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 2000000,
-			"maxTokens": 30000,
+			"maxTokens": 2000000,
 			"compat": {
 				"reasoningEffortMap": {
 					"minimal": "low"
@@ -70018,7 +70018,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 2000000,
-			"maxTokens": 8888,
+			"maxTokens": 2000000,
 			"compat": {
 				"reasoningEffortMap": {
 					"minimal": "low"
@@ -70053,7 +70053,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 1000000,
-			"maxTokens": 30000,
+			"maxTokens": 1000000,
 			"compat": {
 				"reasoningEffortMap": {
 					"minimal": "low"
@@ -70087,7 +70087,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 512000,
-			"maxTokens": 8888,
+			"maxTokens": 512000,
 			"compat": {
 				"reasoningEffortMap": {
 					"minimal": "low"
@@ -70112,7 +70112,7 @@
 				"cacheWrite": 0
 			},
 			"contextWindow": 200000,
-			"maxTokens": 8888,
+			"maxTokens": 200000,
 			"compat": {
 				"reasoningEffortMap": {
 					"minimal": "low"

--- a/packages/catalog/src/models.json
+++ b/packages/catalog/src/models.json
@@ -70094,6 +70094,30 @@
 				},
 				"supportsReasoningEffort": false
 			}
+		},
+		"grok-composer-2.5-fast": {
+			"id": "grok-composer-2.5-fast",
+			"name": "Grok Composer 2.5 Fast",
+			"api": "openai-responses",
+			"provider": "xai-oauth",
+			"baseUrl": "https://api.x.ai/v1",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 8888,
+			"compat": {
+				"reasoningEffortMap": {
+					"minimal": "low"
+				}
+			}
 		}
 	},
 	"xiaomi": {

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -759,6 +759,13 @@ const XAI_NON_CHAT_PREFIXES = ["grok-imagine-", "grok-stt-", "grok-voice-"] as c
 // at request time, downstream of the omitReasoningEffort gate in xai-responses.ts.
 const XAI_REASONING_EFFORT_MAP = { minimal: "low" } as const;
 
+// xai-oauth's /v1/models exposes no per-request output limit on the OAuth
+// (Grok Build / SuperGrok) surface, so the curated catalog owns `maxTokens`
+// like it owns `contextWindow`: each entry mirrors its context window. The
+// openai-responses wire clamps the actual request to
+// min(requested, model.maxTokens, OPENAI_MAX_OUTPUT_TOKENS=64000), so this is
+// just "no model-specific sub-cap below 64k", not an unbounded output budget.
+
 // Single source of truth for curated → Model fan-in. Used by the static-seed
 // and the dynamic overlay/inject paths (applyXAIOAuthCuration) so curated
 // reasoning/effort flags survive an online refresh (xAI's /v1/models lacks
@@ -781,6 +788,7 @@ function mergeCuratedIntoModel(
 	return {
 		...base,
 		contextWindow: curated.contextWindow,
+		maxTokens: curated.contextWindow,
 		name: curated.name ?? base.name,
 		reasoning: curated.reasoning ?? true,
 		input: curated.input ?? base.input,
@@ -855,8 +863,9 @@ function applyXAIOAuthCuration(dynamic: readonly ModelSpec<"openai-responses">[]
  *
  * `reasoning` defaults to `true` for the Grok-4.x family; the explicit
  * `grok-4.20-0309-non-reasoning` entry opts out via `XAICuratedModel.reasoning`.
- * `maxTokens` uses `UNK_MAX_TOKENS` so id-keyed overlays from a successful
- * dynamic fetch merge cleanly. Mirrors
+ * `maxTokens` mirrors each model's `contextWindow` (the OAuth surface reports
+ * no per-request output limit); the openai-responses wire still clamps the
+ * actual request to OPENAI_MAX_OUTPUT_TOKENS. Mirrors
  * `hermes-agent/hermes_cli/models.py:_XAI_STATIC_FALLBACK`.
  */
 export function buildXaiOAuthStaticSeed(baseUrl?: string): ModelSpec<"openai-responses">[] {
@@ -876,7 +885,7 @@ export function buildXaiOAuthStaticSeed(baseUrl?: string): ModelSpec<"openai-res
 			input: ["text"],
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 			contextWindow: curated.contextWindow,
-			maxTokens: UNK_MAX_TOKENS,
+			maxTokens: curated.contextWindow,
 			compat: { reasoningEffortMap: XAI_REASONING_EFFORT_MAP },
 		};
 		return mergeCuratedIntoModel(base, curated);

--- a/packages/catalog/src/provider-models/openai-compat.ts
+++ b/packages/catalog/src/provider-models/openai-compat.ts
@@ -739,6 +739,11 @@ export const XAI_OAUTH_CURATED_MODELS: readonly XAICuratedModel[] = [
 		reasoning: false,
 		input: ["text", "image"],
 	},
+	// Cursor's "Composer 2.5 Fast" exposed via SuperGrok: non-reasoning,
+	// text-only, 200K context (mirrors Cursor's composer-* catalog entries).
+	// Off the GROK_EFFORT_CAPABLE_PREFIXES allowlist, so the wire side already
+	// sets omitReasoningEffort=true; reasoning:false also hides the effort dial.
+	{ id: "grok-composer-2.5-fast", contextWindow: 200_000, name: "Grok Composer 2.5 Fast", reasoning: false },
 ] as const;
 
 // xAI /v1/models returns chat, image, voice, and STT entries. Tool surfaces

--- a/packages/catalog/test/xai-oauth-bundle.test.ts
+++ b/packages/catalog/test/xai-oauth-bundle.test.ts
@@ -58,8 +58,21 @@ describe("xai-oauth bundled catalog (regression)", () => {
 		// exact bytes; only unrelated other-provider network churn was excluded
 		// to keep the diff scoped. Pin its zero-cost invariant (overlay-stable
 		// for the SuperGrok subscription), which the parity loop above never
-		// compares. maxTokens is deliberately not asserted: a future online
-		// /v1/models overlay may legitimately change it.
+		// compares. (maxTokens is pinned by the maxTokens-equals-contextWindow
+		// test below.)
 		expect(bundled["grok-composer-2.5-fast"]?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+	});
+
+	// The OAuth surface's /v1/models reports no per-request output limit, so the
+	// curated catalog owns maxTokens — set to mirror each model's contextWindow
+	// (the openai-responses wire still clamps the actual request to
+	// OPENAI_MAX_OUTPUT_TOKENS). Pin maxTokens === contextWindow on both the
+	// static-seed and bundled paths so the 8888 UNK_MAX_TOKENS placeholder can
+	// never silently leak back into the bundle.
+	it("sets maxTokens equal to contextWindow for every xai-oauth model", () => {
+		for (const model of seed) {
+			expect(model.maxTokens, `seed ${model.id} maxTokens`).toBe(model.contextWindow);
+			expect(bundled[model.id]?.maxTokens, `bundled ${model.id} maxTokens`).toBe(model.contextWindow);
+		}
 	});
 });

--- a/packages/catalog/test/xai-oauth-bundle.test.ts
+++ b/packages/catalog/test/xai-oauth-bundle.test.ts
@@ -40,4 +40,26 @@ describe("xai-oauth bundled catalog (regression)", () => {
 			expect(bundledEntry.compat?.supportsReasoningEffort).toBe(seededModel.compat?.supportsReasoningEffort);
 		});
 	}
+
+	// Absolute contract for the user-specified SuperGrok addition. The parity
+	// loop above can't catch a value typo (e.g. 2_000_000) or a flipped
+	// reasoning flag — both sides regenerate from the same seed together — so
+	// pin the literal attributes here.
+	it("exposes grok-composer-2.5-fast as a non-reasoning 200K text model", () => {
+		const composer = seed.find(model => model.id === "grok-composer-2.5-fast");
+		expect(composer, "grok-composer-2.5-fast must be in the SuperGrok curated seed").toBeDefined();
+		expect(composer!.reasoning).toBe(false);
+		expect(composer!.contextWindow).toBe(200_000);
+		expect(composer!.input).toEqual(["text"]);
+		// The bundled models.json entry is byte-identical to the generator's
+		// deterministic xai-oauth output: generate-models.ts pushes
+		// buildXaiOAuthStaticSeed() (offline — xai-oauth has no upstream catalog
+		// source) and applyGeneratedModelPolicies(), so a regen reproduces these
+		// exact bytes; only unrelated other-provider network churn was excluded
+		// to keep the diff scoped. Pin its zero-cost invariant (overlay-stable
+		// for the SuperGrok subscription), which the parity loop above never
+		// compares. maxTokens is deliberately not asserted: a future online
+		// /v1/models overlay may legitimately change it.
+		expect(bundled["grok-composer-2.5-fast"]?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+	});
 });


### PR DESCRIPTION
## Summary

SuperGrok subscribers can now select Cursor's "Composer 2.5 Fast" from the chat model picker. It joins the `xai-oauth` curated catalog and resolves synchronously at boot like the other SuperGrok models — non-reasoning, text-only, 200K context, zero cost.

## Notes for reviewers

- **Single source edit.** The model is declared once in `XAI_OAUTH_CURATED_MODELS` (`openai-compat.ts`); `buildXaiOAuthStaticSeed` renders it into `models.json` so the synchronous boot-time default-model resolver honors a persisted `xai-oauth/grok-composer-2.5-fast` default without waiting for an online refresh.
- **The `models.json` hunk is byte-identical to the generator's deterministic output** — not a free-hand edit. `xai-oauth` has no upstream catalog source (models.dev / descriptors), so `generate-models.ts` builds it purely offline from `buildXaiOAuthStaticSeed()` + `applyGeneratedModelPolicies()` (see `generate-models.ts:384`). A regen reproduces these exact bytes, in the same sort order. Verified locally: re-running the seed + policies and diffing against the committed `xai-oauth` block, the `grok-composer-2.5-fast` entry matches byte-for-byte.
- **Why not commit a raw `generate-models` run.** A full run also (a) pulls ~2.3k lines of unrelated other-provider catalog drift, and (b) **regresses** `grok-4.3` / `grok-4.20-0309-reasoning` / `grok-4.20-0309-non-reasoning` `maxTokens` from the committed overlay-baked `30000` down to the `8888` (`UNK_MAX_TOKENS`) placeholder the current static seed emits. That unrelated churn was excluded to keep the diff scoped and avoid regressing sibling models.
- The id is intentionally off the `GROK_EFFORT_CAPABLE_PREFIXES` allowlist, so the wire side omits `reasoning.effort` and the picker hides the inert effort dial.

## Verification of the wire id

`grok-composer-2.5-fast` is the exact `/model` selector xAI's Grok Build OAuth surface exposes for Composer 2.5 Fast (200K context, "does not accept configurable reasoning effort"), confirmed against the published xAI-OAuth integration. Composer 2.5 is a CLI/OAuth-only model — it is **not** on the pay-per-token xAI API (`docs.x.ai/developers/models` lists no `composer` id), which is why this stays scoped to `xai-oauth` and the plain `xai` API-key provider is untouched.

## Test plan

- `bun --cwd=packages/ai test test/xai-oauth-bundle.test.ts test/xai-oauth-effort-strip.test.ts` → all pass. The contract test pins `reasoning:false` / 200K / text-only plus the bundled entry's zero-cost invariant — the seed/bundle parity loop alone can't catch a curated-source typo, since both sides regenerate together.
- `bun --cwd=packages/ai run check` (biome + tsgo) → clean.