### PR TITLE
fix(mcp): resolve Windows stdio shims

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+- Fixed Windows stdio MCP servers launched through PATH shims such as `codegraph.cmd` so bare commands like `codegraph` resolve via `PATHEXT` before spawn ([#2174](https://github.com/can1357/oh-my-pi/issues/2174)).
 - Fixed a turn-ending provider error (e.g. a 502 whose body is the proxy's full HTML page) flooding the transcript: `AnthropicApiError` folds the entire response body into `errorMessage`, and the inline transcript render reprinted it verbatim — every embedded blank line included — leaving a tall mostly-empty block ending in `</html>`. The inline error now drops blank lines, clamps to 8 lines, and width-truncates each line via `getPreviewLines`, matching the pinned error banner.
 
 ## [15.10.7] - 2026-06-08

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Windows stdio MCP servers launched through PATH shims such as `codegraph.cmd` so bare commands like `codegraph` resolve via `PATHEXT` before spawn ([#2174](https://github.com/can1357/oh-my-pi/issues/2174)).
+
 ## [15.10.8] - 2026-06-09
 
 ### Added
@@ -13,7 +17,6 @@
 
 ### Fixed
 
-- Fixed Windows stdio MCP servers launched through PATH shims such as `codegraph.cmd` so bare commands like `codegraph` resolve via `PATHEXT` before spawn ([#2174](https://github.com/can1357/oh-my-pi/issues/2174)).
 - Fixed a turn-ending provider error (e.g. a 502 whose body is the proxy's full HTML page) flooding the transcript: `AnthropicApiError` folds the entire response body into `errorMessage`, and the inline transcript render reprinted it verbatim — every embedded blank line included — leaving a tall mostly-empty block ending in `</html>`. The inline error now drops blank lines, clamps to 8 lines, and width-truncates each line via `getPreviewLines`, matching the pinned error banner.
 
 ## [15.10.7] - 2026-06-08

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -5,6 +5,9 @@
  * Messages are newline-delimited JSON.
  */
 
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
 import { getProjectDir, readJsonl, Snowflake } from "@oh-my-pi/pi-utils";
 import { type Subprocess, spawn } from "bun";
 import type {
@@ -18,6 +21,140 @@ import type {
 } from "../../mcp/types";
 import { toJsonRpcError } from "../../mcp/types";
 import { isMCPTimeoutEnabled, resolveMCPTimeoutMs } from "../timeout";
+
+/** Subprocess argv for launching an MCP stdio server. */
+export interface StdioSpawnCommand {
+	cmd: string[];
+}
+
+/** Inputs used to resolve platform-specific stdio spawn behavior. */
+export interface ResolveStdioSpawnOptions {
+	cwd: string;
+	env: Record<string, string | undefined>;
+	platform?: NodeJS.Platform;
+}
+
+const DEFAULT_WINDOWS_PATHEXT = [".COM", ".EXE", ".BAT", ".CMD"];
+const WINDOWS_BATCH_EXTENSIONS = new Set([".bat", ".cmd"]);
+
+function getCaseInsensitiveEnv(env: Record<string, string | undefined>, name: string): string | undefined {
+	const direct = env[name];
+	if (direct !== undefined) return direct;
+	const normalized = name.toLowerCase();
+	for (const [key, value] of Object.entries(env)) {
+		if (key.toLowerCase() === normalized) return value;
+	}
+	return undefined;
+}
+
+function getWindowsPathExt(env: Record<string, string | undefined>): string[] {
+	const raw = getCaseInsensitiveEnv(env, "PATHEXT");
+	if (!raw) return DEFAULT_WINDOWS_PATHEXT;
+	const extensions: string[] = [];
+	for (const part of raw.split(";")) {
+		const trimmed = part.trim();
+		if (!trimmed) continue;
+		extensions.push(trimmed.startsWith(".") ? trimmed : `.${trimmed}`);
+	}
+	return extensions.length > 0 ? extensions : DEFAULT_WINDOWS_PATHEXT;
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+	try {
+		await fs.access(filePath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function hasPathSegment(command: string): boolean {
+	return command.includes("/") || command.includes("\\") || path.isAbsolute(command);
+}
+
+function hasExecutableExtension(command: string, extensions: string[]): boolean {
+	const ext = path.extname(command).toLowerCase();
+	if (!ext) return false;
+	return extensions.some(candidate => candidate.toLowerCase() === ext);
+}
+
+async function resolveWindowsCommandPath(
+	command: string,
+	cwd: string,
+	env: Record<string, string | undefined>,
+): Promise<string | null> {
+	const extensions = getWindowsPathExt(env);
+	if (hasExecutableExtension(command, extensions)) return command;
+
+	const candidates = extensions.map(ext => `${command}${ext}`);
+	if (hasPathSegment(command)) {
+		for (const candidate of candidates) {
+			const resolved = path.isAbsolute(candidate) ? candidate : path.resolve(cwd, candidate);
+			if (await fileExists(resolved)) return resolved;
+		}
+		return null;
+	}
+
+	const pathValue = getCaseInsensitiveEnv(env, "PATH");
+	if (!pathValue) return null;
+	for (const dir of pathValue.split(";")) {
+		if (!dir) continue;
+		for (const candidate of candidates) {
+			const resolved = path.join(dir, candidate);
+			if (await fileExists(resolved)) return resolved;
+		}
+	}
+	return null;
+}
+
+function quoteCmdArg(value: string): string {
+	if (value.length === 0) return '""';
+	let result = '"';
+	let backslashes = 0;
+	for (const char of value) {
+		if (char === "\\") {
+			backslashes++;
+			continue;
+		}
+		if (char === '"') {
+			result += "\\".repeat(backslashes * 2 + 1);
+			result += '"';
+			backslashes = 0;
+			continue;
+		}
+		result += "\\".repeat(backslashes);
+		backslashes = 0;
+		result += char;
+	}
+	result += "\\".repeat(backslashes * 2);
+	return `${result}"`;
+}
+
+function isWindowsBatchCommand(command: string): boolean {
+	return WINDOWS_BATCH_EXTENSIONS.has(path.extname(command).toLowerCase());
+}
+
+function resolveComSpec(env: Record<string, string | undefined>): string {
+	const comspec = getCaseInsensitiveEnv(env, "COMSPEC");
+	return comspec && comspec.length > 0 ? comspec : "cmd.exe";
+}
+
+/** Resolve the subprocess argv used to launch an MCP stdio server. */
+export async function resolveStdioSpawnCommand(
+	config: MCPStdioServerConfig,
+	options: ResolveStdioSpawnOptions,
+): Promise<StdioSpawnCommand> {
+	const args = config.args ?? [];
+	if (options.platform !== "win32") return { cmd: [config.command, ...args] };
+
+	const resolvedCommand =
+		(await resolveWindowsCommandPath(config.command, options.cwd, options.env)) ?? config.command;
+	if (!isWindowsBatchCommand(resolvedCommand)) return { cmd: [resolvedCommand, ...args] };
+
+	return {
+		cmd: [resolveComSpec(options.env), "/d", "/s", "/c", [resolvedCommand, ...args].map(quoteCmdArg).join(" ")],
+	};
+}
 
 /** Minimal write surface of `Subprocess.stdin` we need for framed sends. */
 interface FrameSink {
@@ -100,15 +237,20 @@ export class StdioTransport implements MCPTransport {
 	async connect(): Promise<void> {
 		if (this.#connected) return;
 
-		const args = this.config.args ?? [];
 		const env = {
 			...Bun.env,
 			...this.config.env,
 		};
+		const cwd = this.config.cwd ?? getProjectDir();
+		const spawnCommand = await resolveStdioSpawnCommand(this.config, {
+			cwd,
+			env,
+			platform: process.platform,
+		});
 
 		this.#process = spawn({
-			cmd: [this.config.command, ...args],
-			cwd: this.config.cwd ?? getProjectDir(),
+			cmd: spawnCommand.cmd,
+			cwd,
 			env,
 			stdin: "pipe",
 			stdout: "pipe",

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -124,7 +124,7 @@ function quoteCmdArg(value: string): string {
 		}
 		result += "\\".repeat(backslashes);
 		backslashes = 0;
-		result += char;
+		result += char === "%" ? "^%" : char;
 	}
 	result += "\\".repeat(backslashes * 2);
 	return `${result}"`;

--- a/packages/coding-agent/src/mcp/transports/stdio.ts
+++ b/packages/coding-agent/src/mcp/transports/stdio.ts
@@ -110,23 +110,17 @@ async function resolveWindowsCommandPath(
 function quoteCmdArg(value: string): string {
 	if (value.length === 0) return '""';
 	let result = '"';
-	let backslashes = 0;
 	for (const char of value) {
-		if (char === "\\") {
-			backslashes++;
-			continue;
-		}
 		if (char === '"') {
-			result += "\\".repeat(backslashes * 2 + 1);
-			result += '"';
-			backslashes = 0;
-			continue;
+			result += '^"';
+		} else if (char === "^") {
+			result += "^^";
+		} else if (char === "%") {
+			result += "^%";
+		} else {
+			result += char;
 		}
-		result += "\\".repeat(backslashes);
-		backslashes = 0;
-		result += char === "%" ? "^%" : char;
 	}
-	result += "\\".repeat(backslashes * 2);
 	return `${result}"`;
 }
 

--- a/packages/coding-agent/test/mcp-stdio-transport.test.ts
+++ b/packages/coding-agent/test/mcp-stdio-transport.test.ts
@@ -1,5 +1,45 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { StdioTransport, writeFrame } from "@oh-my-pi/pi-coding-agent/mcp/transports/stdio";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { resolveStdioSpawnCommand, StdioTransport, writeFrame } from "@oh-my-pi/pi-coding-agent/mcp/transports/stdio";
+
+describe("resolveStdioSpawnCommand", () => {
+	it("resolves bare Windows commands through PATHEXT and wraps .cmd shims with cmd.exe", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-stdio-"));
+		try {
+			const shim = path.join(tempDir, "codegraph.cmd");
+			await Bun.write(shim, "@echo off\r\n");
+
+			const result = await resolveStdioSpawnCommand(
+				{ type: "stdio", command: "codegraph", args: ["serve", "--mcp"] },
+				{
+					cwd: tempDir,
+					env: {
+						COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+						PATH: tempDir,
+						PATHEXT: ".cmd",
+					},
+					platform: "win32",
+				},
+			);
+
+			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/s", "/c", `"${shim}" "serve" "--mcp"`]);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("leaves non-Windows commands untouched", async () => {
+		const result = await resolveStdioSpawnCommand(
+			{ type: "stdio", command: "codegraph", args: ["serve", "--mcp"] },
+			{ cwd: "/", env: {}, platform: "linux" },
+		);
+
+		expect(result.cmd).toEqual(["codegraph", "serve", "--mcp"]);
+	});
+});
 
 // ---------------------------------------------------------------------------
 // writeFrame — the seam that catches synchronous FileSink throws AND neutralizes

--- a/packages/coding-agent/test/mcp-stdio-transport.test.ts
+++ b/packages/coding-agent/test/mcp-stdio-transport.test.ts
@@ -31,6 +31,37 @@ describe("resolveStdioSpawnCommand", () => {
 		}
 	});
 
+	it("escapes percent-delimited args before routing .cmd shims through cmd.exe", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-percent-"));
+		try {
+			const shim = path.join(tempDir, "codegraph.cmd");
+			await Bun.write(shim, "@echo off\r\n");
+
+			const result = await resolveStdioSpawnCommand(
+				{ type: "stdio", command: "codegraph", args: ["serve", "--header", "Authorization=%TOKEN%"] },
+				{
+					cwd: tempDir,
+					env: {
+						COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+						PATH: tempDir,
+						PATHEXT: ".cmd",
+					},
+					platform: "win32",
+				},
+			);
+
+			expect(result.cmd).toEqual([
+				"C:\\Windows\\System32\\cmd.exe",
+				"/d",
+				"/s",
+				"/c",
+				`"${shim}" "serve" "--header" "Authorization=^%TOKEN^%"`,
+			]);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("resolves extension-less absolute Windows paths to the sibling .cmd shim", async () => {
 		// Mirrors npm's Windows shim layout: bare `codegraph` (shebang script),
 		// `codegraph.cmd` (cmd.exe wrapper), and `codegraph.ps1` siblings under

--- a/packages/coding-agent/test/mcp-stdio-transport.test.ts
+++ b/packages/coding-agent/test/mcp-stdio-transport.test.ts
@@ -62,6 +62,37 @@ describe("resolveStdioSpawnCommand", () => {
 		}
 	});
 
+	it("escapes quoted JSON args before routing .cmd shims through cmd.exe", async () => {
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-quotes-"));
+		try {
+			const shim = path.join(tempDir, "codegraph.cmd");
+			await Bun.write(shim, "@echo off\r\n");
+
+			const result = await resolveStdioSpawnCommand(
+				{ type: "stdio", command: "codegraph", args: ["--config", '{"a":"b&c|d"}'] },
+				{
+					cwd: tempDir,
+					env: {
+						COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+						PATH: tempDir,
+						PATHEXT: ".cmd",
+					},
+					platform: "win32",
+				},
+			);
+
+			expect(result.cmd).toEqual([
+				"C:\\Windows\\System32\\cmd.exe",
+				"/d",
+				"/s",
+				"/c",
+				`"${shim}" "--config" "{^"a^":^"b&c|d^"}"`,
+			]);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("resolves extension-less absolute Windows paths to the sibling .cmd shim", async () => {
 		// Mirrors npm's Windows shim layout: bare `codegraph` (shebang script),
 		// `codegraph.cmd` (cmd.exe wrapper), and `codegraph.ps1` siblings under

--- a/packages/coding-agent/test/mcp-stdio-transport.test.ts
+++ b/packages/coding-agent/test/mcp-stdio-transport.test.ts
@@ -31,6 +31,39 @@ describe("resolveStdioSpawnCommand", () => {
 		}
 	});
 
+	it("resolves extension-less absolute Windows paths to the sibling .cmd shim", async () => {
+		// Mirrors npm's Windows shim layout: bare `codegraph` (shebang script),
+		// `codegraph.cmd` (cmd.exe wrapper), and `codegraph.ps1` siblings under
+		// %AppData%\Roaming\npm. uv_spawn rejects the extensionless script;
+		// the resolver must promote the bare absolute path to its `.cmd`
+		// sibling so the launch succeeds (see #2174). The test rig pins
+		// PATHEXT to a single lowercase extension so the candidate filename
+		// matches the file we create on the case-sensitive test host.
+		const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "omp-mcp-abs-"));
+		try {
+			const bare = path.join(tempDir, "codegraph");
+			const shim = `${bare}.cmd`;
+			await Bun.write(bare, "#!/bin/sh\n");
+			await Bun.write(shim, "@echo off\r\n");
+
+			const result = await resolveStdioSpawnCommand(
+				{ type: "stdio", command: bare, args: ["serve", "--mcp"] },
+				{
+					cwd: tempDir,
+					env: {
+						COMSPEC: "C:\\Windows\\System32\\cmd.exe",
+						PATHEXT: ".cmd",
+					},
+					platform: "win32",
+				},
+			);
+
+			expect(result.cmd).toEqual(["C:\\Windows\\System32\\cmd.exe", "/d", "/s", "/c", `"${shim}" "serve" "--mcp"`]);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("leaves non-Windows commands untouched", async () => {
 		const result = await resolveStdioSpawnCommand(
 			{ type: "stdio", command: "codegraph", args: ["serve", "--mcp"] },


### PR DESCRIPTION
## Repro
A stdio MCP config with `command: "codegraph"` fails when the available PATH entry is the Windows shim `codegraph.cmd`, matching the reporter's `ENOENT`/`uv_spawn 'codegraph'` failure. Reproduced with `bun -e 'import { mkdtemp, chmod } from "node:fs/promises"; import { tmpdir } from "node:os"; import { join, delimiter } from "node:path"; const dir = await mkdtemp(join(tmpdir(), "omp-mcp-")); const exe = join(dir, "codegraph.cmd"); await Bun.write(exe, "#!/bin/sh\nprintf '\''{}\\n'\''\n"); await chmod(exe, 0o755); try { const proc = Bun.spawn({ cmd: ["codegraph", "serve", "--mcp"], env: { ...Bun.env, PATH: `${dir}${delimiter}${Bun.env.PATH ?? ""}`, PATHEXT: ".COM;.EXE;.BAT;.CMD" }, stdout: "pipe", stderr: "pipe" }); console.log(`exit=${await proc.exited}`); } catch (error) { console.error(error instanceof Error ? error.message : String(error)); process.exit(127); }'`, which exits 127 with `Executable not found in $PATH: "codegraph"`.

## Cause
`packages/coding-agent/src/mcp/transports/stdio.ts` passed `[config.command, ...args]` directly to `Bun.spawn`. On Windows, MCP commands installed by package managers commonly appear as `.cmd`/`.bat` PATH shims, but the direct stdio spawn path did not apply `PATHEXT` resolution or run batch shims through `cmd.exe`, so a terminal-resolvable `codegraph` config reached `uv_spawn` as an unresolved bare executable.

## Fix
- Added `resolveStdioSpawnCommand` to resolve Windows stdio MCP commands against `PATHEXT` and case-insensitive `PATH`/`COMSPEC` environment keys.
- Wrapped resolved `.cmd`/`.bat` shims with `cmd.exe /d /s /c` while preserving direct argv spawning for non-Windows and non-batch executables.
- Added focused tests covering the `codegraph` → `codegraph.cmd` Windows shim path and the unchanged non-Windows path.
- Added a coding-agent changelog entry for the Windows MCP shim fix.

## Verification
`bun test test/mcp-stdio-transport.test.ts` passed with 13 tests. `bun run check` passed for `packages/coding-agent`. Pre-publish `gh_push_branch` checks passed before pushing. Fixes #2174