### PR TITLE
feat(minimizer): deterministic shell-output minimizer

### DIFF
--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -25,33 +25,43 @@ use crate::task;
 #[derive(Debug, Clone, Default)]
 pub struct MinimizerOptions {
 	/// Master switch. Absent / false = disabled.
-	pub enabled:           Option<bool>,
+	pub enabled:              Option<bool>,
 	/// Optional path to a TOML settings file whose values override
 	/// field-level defaults. `~` is expanded.
-	pub settings_path:     Option<String>,
+	pub settings_path:        Option<String>,
 	/// Optional xxHash64 digest (hex) of the settings file contents. When
 	/// supplied, the engine refuses to honor a settings file whose hash does
 	/// not match — a lightweight trust gate for agent-controllable paths.
-	pub settings_hash:     Option<String>,
+	pub settings_hash:        Option<String>,
 	/// Opt-in allowlist of program names (e.g. `"git"`). When empty or
 	/// absent, all built-in filters are active.
-	pub only:              Option<Vec<String>>,
+	pub only:                 Option<Vec<String>>,
 	/// Program names explicitly excluded from minimization.
-	pub except:            Option<Vec<String>>,
+	pub except:               Option<Vec<String>>,
 	/// Maximum captured bytes per command before the engine falls back to
 	/// the raw, un-minimized output. Default 4 MiB.
-	pub max_capture_bytes: Option<u32>,
+	pub max_capture_bytes:    Option<u32>,
+	/// Source-outline level for `cat <source-file>` minimization. Accepts
+	/// `"default"` (current behavior) or `"aggressive"` (strip function bodies).
+	pub source_outline_level: Option<String>,
+	/// Kill-switch to fall back to the pre-PR (legacy) filter behavior for
+	/// grep / find / pytest. When `Some(true)`, filters that opted into the
+	/// always-shrink Tier 1 / Tier 2 behavior skip the new code path. When
+	/// `None`, defers to the `OMP_MINIMIZER_LEGACY_FILTERS` env var.
+	pub legacy_filters:       Option<bool>,
 }
 
 impl From<MinimizerOptions> for minimizer::MinimizerOptions {
 	fn from(value: MinimizerOptions) -> Self {
 		Self {
-			enabled:           value.enabled,
-			settings_path:     value.settings_path,
-			settings_hash:     value.settings_hash,
-			only:              value.only,
-			except:            value.except,
-			max_capture_bytes: value.max_capture_bytes,
+			enabled:              value.enabled,
+			settings_path:        value.settings_path,
+			settings_hash:        value.settings_hash,
+			only:                 value.only,
+			except:               value.except,
+			max_capture_bytes:    value.max_capture_bytes,
+			source_outline_level: value.source_outline_level,
+			legacy_filters:       value.legacy_filters,
 		}
 	}
 }
@@ -334,6 +344,85 @@ pub fn apply_bash_fixups(command: String) -> BashFixupResult {
 	core_apply_bash_fixups(&command).into()
 }
 
+/// Inputs for [`apply_shell_minimizer`]: a captured command's text plus the
+/// minimizer configuration to run against it.
+#[napi(object)]
+pub struct ShellMinimizerApplyOptions {
+	/// The command line that produced `captured` (used to select a filter).
+	pub command:   String,
+	/// The full captured stdout/stderr to minimize.
+	pub captured:  String,
+	/// The command's exit status; omitted is treated as success (`0`).
+	pub exit_code: Option<i32>,
+	/// Minimizer configuration; when omitted the call is a no-op (`null`).
+	pub minimizer: Option<MinimizerOptions>,
+}
+
+/// Run the shell-output minimizer over an already-captured command result,
+/// without spawning a shell.
+///
+/// This is the one-shot counterpart to the minimization that
+/// [`execute_shell`] performs inline: callers that captured a command's output
+/// elsewhere can pass it here to obtain the same telemetry.
+///
+/// Returns [`MinimizerResult`] **only** when the minimizer actually rewrote the
+/// output (`changed == true`) and retained the original buffer, mirroring the
+/// persistent-shell path. Returns `null` for every no-op case: when
+/// `minimizer` is omitted, when the config is disabled, or when the filter
+/// passes the output through unchanged. A missing `exit_code` is treated as
+/// success (`0`).
+///
+/// Async (returns a Promise): minimization can scan multi-megabyte captured
+/// output, so the work runs on a blocking pool to avoid stalling the JS event
+/// loop.
+#[napi(ts_return_type = "Promise<MinimizerResult | null>")]
+pub fn apply_shell_minimizer(
+	env: &Env,
+	options: ShellMinimizerApplyOptions,
+) -> Result<PromiseRaw<'_, Option<MinimizerResult>>> {
+	// Returns a Promise rather than a sync value: minimization can run over a
+	// multi-megabyte capture buffer, and a sync `#[napi]` fn would do that CPU
+	// work on the JS main thread and stall the event loop. Run the whole pass on
+	// a blocking pool, mirroring `execute_shell`.
+	task::future(env, "shell.minimize", async move {
+		napi::tokio::task::spawn_blocking(move || run_shell_minimizer(options))
+			.await
+			.map_err(|err| Error::from_reason(err.to_string()))
+	})
+}
+
+/// Pure, blocking core of [`apply_shell_minimizer`], factored out so it can run
+/// inside `spawn_blocking` and be unit-tested without an N-API `Env`.
+///
+/// Mirrors the persistent-shell path (`pi_shell::shell`): surface telemetry
+/// only when the minimizer actually rewrote the output and kept the original
+/// buffer. The disabled / passthrough cases report `changed: false` with no
+/// `original_text`, and yield `None`.
+fn run_shell_minimizer(options: ShellMinimizerApplyOptions) -> Option<MinimizerResult> {
+	let minimizer = options.minimizer?;
+	let minimizer_options: minimizer::MinimizerOptions = minimizer.into();
+	let config = minimizer::MinimizerConfig::from_options(&minimizer_options);
+	let output = minimizer::apply(
+		&options.command,
+		&options.captured,
+		options.exit_code.unwrap_or(0),
+		&config,
+	);
+	if output.changed
+		&& let Some(original_text) = output.original_text
+	{
+		let output_bytes = u32::try_from(output.text.len()).unwrap_or(u32::MAX);
+		return Some(MinimizerResult {
+			filter: output.filter.to_string(),
+			text: output.text,
+			original_text,
+			input_bytes: u32::try_from(output.input_bytes).unwrap_or(u32::MAX),
+			output_bytes,
+		});
+	}
+	None
+}
+
 #[cfg(test)]
 mod tests {
 	use std::time::Duration;
@@ -345,6 +434,48 @@ mod tests {
 	use tokio::{sync::mpsc, time};
 
 	use super::CoreShell;
+
+	#[test]
+	fn apply_shell_minimizer_surfaces_rewrite_with_original() {
+		let captured = "diff --git a/file.rs b/file.rs\n@@\n-old\n+new\n";
+		let result = super::run_shell_minimizer(super::ShellMinimizerApplyOptions {
+			command:   "git diff".to_string(),
+			captured:  captured.to_string(),
+			exit_code: Some(0),
+			minimizer: Some(super::MinimizerOptions { enabled: Some(true), ..Default::default() }),
+		})
+		.expect("an enabled, supported command should surface a rewrite");
+		assert_eq!(result.filter, "git");
+		// A genuine rewrite carries the untouched capture in `original_text`
+		// and a strictly different minimized `text`.
+		assert_eq!(result.original_text, captured);
+		assert_ne!(result.text, result.original_text);
+		assert_eq!(result.input_bytes as usize, captured.len());
+	}
+
+	#[test]
+	fn apply_shell_minimizer_returns_none_when_disabled() {
+		// `enabled: false` keeps the engine in passthrough — no telemetry.
+		assert!(
+			super::run_shell_minimizer(super::ShellMinimizerApplyOptions {
+				command:   "git diff".to_string(),
+				captured:  "diff --git a/file.rs b/file.rs\n@@\n-old\n+new\n".to_string(),
+				exit_code: Some(0),
+				minimizer: Some(super::MinimizerOptions { enabled: Some(false), ..Default::default() }),
+			})
+			.is_none()
+		);
+		// A missing minimizer handle is also a no-op.
+		assert!(
+			super::run_shell_minimizer(super::ShellMinimizerApplyOptions {
+				command:   "git diff".to_string(),
+				captured:  "diff --git a/file.rs b/file.rs\n".to_string(),
+				exit_code: Some(0),
+				minimizer: None,
+			})
+			.is_none()
+		);
+	}
 
 	mod child_session_action_tests {
 		use pi_shell::{ChildSessionAction, child_session_action};

--- a/crates/pi-natives/src/shell.rs
+++ b/crates/pi-natives/src/shell.rs
@@ -344,85 +344,6 @@ pub fn apply_bash_fixups(command: String) -> BashFixupResult {
 	core_apply_bash_fixups(&command).into()
 }
 
-/// Inputs for [`apply_shell_minimizer`]: a captured command's text plus the
-/// minimizer configuration to run against it.
-#[napi(object)]
-pub struct ShellMinimizerApplyOptions {
-	/// The command line that produced `captured` (used to select a filter).
-	pub command:   String,
-	/// The full captured stdout/stderr to minimize.
-	pub captured:  String,
-	/// The command's exit status; omitted is treated as success (`0`).
-	pub exit_code: Option<i32>,
-	/// Minimizer configuration; when omitted the call is a no-op (`null`).
-	pub minimizer: Option<MinimizerOptions>,
-}
-
-/// Run the shell-output minimizer over an already-captured command result,
-/// without spawning a shell.
-///
-/// This is the one-shot counterpart to the minimization that
-/// [`execute_shell`] performs inline: callers that captured a command's output
-/// elsewhere can pass it here to obtain the same telemetry.
-///
-/// Returns [`MinimizerResult`] **only** when the minimizer actually rewrote the
-/// output (`changed == true`) and retained the original buffer, mirroring the
-/// persistent-shell path. Returns `null` for every no-op case: when
-/// `minimizer` is omitted, when the config is disabled, or when the filter
-/// passes the output through unchanged. A missing `exit_code` is treated as
-/// success (`0`).
-///
-/// Async (returns a Promise): minimization can scan multi-megabyte captured
-/// output, so the work runs on a blocking pool to avoid stalling the JS event
-/// loop.
-#[napi(ts_return_type = "Promise<MinimizerResult | null>")]
-pub fn apply_shell_minimizer(
-	env: &Env,
-	options: ShellMinimizerApplyOptions,
-) -> Result<PromiseRaw<'_, Option<MinimizerResult>>> {
-	// Returns a Promise rather than a sync value: minimization can run over a
-	// multi-megabyte capture buffer, and a sync `#[napi]` fn would do that CPU
-	// work on the JS main thread and stall the event loop. Run the whole pass on
-	// a blocking pool, mirroring `execute_shell`.
-	task::future(env, "shell.minimize", async move {
-		napi::tokio::task::spawn_blocking(move || run_shell_minimizer(options))
-			.await
-			.map_err(|err| Error::from_reason(err.to_string()))
-	})
-}
-
-/// Pure, blocking core of [`apply_shell_minimizer`], factored out so it can run
-/// inside `spawn_blocking` and be unit-tested without an N-API `Env`.
-///
-/// Mirrors the persistent-shell path (`pi_shell::shell`): surface telemetry
-/// only when the minimizer actually rewrote the output and kept the original
-/// buffer. The disabled / passthrough cases report `changed: false` with no
-/// `original_text`, and yield `None`.
-fn run_shell_minimizer(options: ShellMinimizerApplyOptions) -> Option<MinimizerResult> {
-	let minimizer = options.minimizer?;
-	let minimizer_options: minimizer::MinimizerOptions = minimizer.into();
-	let config = minimizer::MinimizerConfig::from_options(&minimizer_options);
-	let output = minimizer::apply(
-		&options.command,
-		&options.captured,
-		options.exit_code.unwrap_or(0),
-		&config,
-	);
-	if output.changed
-		&& let Some(original_text) = output.original_text
-	{
-		let output_bytes = u32::try_from(output.text.len()).unwrap_or(u32::MAX);
-		return Some(MinimizerResult {
-			filter: output.filter.to_string(),
-			text: output.text,
-			original_text,
-			input_bytes: u32::try_from(output.input_bytes).unwrap_or(u32::MAX),
-			output_bytes,
-		});
-	}
-	None
-}
-
 #[cfg(test)]
 mod tests {
 	use std::time::Duration;
@@ -434,48 +355,6 @@ mod tests {
 	use tokio::{sync::mpsc, time};
 
 	use super::CoreShell;
-
-	#[test]
-	fn apply_shell_minimizer_surfaces_rewrite_with_original() {
-		let captured = "diff --git a/file.rs b/file.rs\n@@\n-old\n+new\n";
-		let result = super::run_shell_minimizer(super::ShellMinimizerApplyOptions {
-			command:   "git diff".to_string(),
-			captured:  captured.to_string(),
-			exit_code: Some(0),
-			minimizer: Some(super::MinimizerOptions { enabled: Some(true), ..Default::default() }),
-		})
-		.expect("an enabled, supported command should surface a rewrite");
-		assert_eq!(result.filter, "git");
-		// A genuine rewrite carries the untouched capture in `original_text`
-		// and a strictly different minimized `text`.
-		assert_eq!(result.original_text, captured);
-		assert_ne!(result.text, result.original_text);
-		assert_eq!(result.input_bytes as usize, captured.len());
-	}
-
-	#[test]
-	fn apply_shell_minimizer_returns_none_when_disabled() {
-		// `enabled: false` keeps the engine in passthrough — no telemetry.
-		assert!(
-			super::run_shell_minimizer(super::ShellMinimizerApplyOptions {
-				command:   "git diff".to_string(),
-				captured:  "diff --git a/file.rs b/file.rs\n@@\n-old\n+new\n".to_string(),
-				exit_code: Some(0),
-				minimizer: Some(super::MinimizerOptions { enabled: Some(false), ..Default::default() }),
-			})
-			.is_none()
-		);
-		// A missing minimizer handle is also a no-op.
-		assert!(
-			super::run_shell_minimizer(super::ShellMinimizerApplyOptions {
-				command:   "git diff".to_string(),
-				captured:  "diff --git a/file.rs b/file.rs\n".to_string(),
-				exit_code: Some(0),
-				minimizer: None,
-			})
-			.is_none()
-		);
-	}
 
 	mod child_session_action_tests {
 		use pi_shell::{ChildSessionAction, child_session_action};

--- a/crates/pi-shell/ATTRIBUTION-RTK.md
+++ b/crates/pi-shell/ATTRIBUTION-RTK.md
@@ -1,0 +1,46 @@
+# Third-party attribution — RTK
+
+Portions of the shell-output minimizer adapt algorithms from **RTK**
+(`rtk-ai/rtk`), used under the MIT License, which is compatible with this
+workspace's MIT License.
+
+## Ported component
+
+- **Upstream:** [`rtk-ai/rtk`](https://github.com/rtk-ai/rtk) @ commit
+  `878af7de99e0ba71da2e8fd996f6b52a1836e06c`
+- **Upstream path:** `src/cmds/python/pytest_cmd.rs`
+- **Local path:** `crates/pi-shell/src/minimizer/filters/python.rs`
+- **What was adapted:** the `build_pytest_summary` algorithm — re-implemented
+  here as the pytest state machine (`filter_pytest`, `pytest_success`,
+  `is_pytest_*`, `looks_like_pytest_summary_part`). It preserves failures,
+  errors, and the final summary line; strips header framing, progress dots, and
+  verbose `PASSED` rows; and falls through unchanged on unknown-state lines
+  (RTK's defensive default) so xdist `[gwN]` prefixes and custom reporters never
+  cause data loss.
+
+## License (MIT)
+
+RTK is distributed under the MIT License. A copy of the upstream license text
+is reproduced below for the pinned revision above.
+
+```
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/crates/pi-shell/Cargo.toml
+++ b/crates/pi-shell/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 repository.workspace = true
+# Portions of the minimizer adapt MIT-licensed algorithms from rtk-ai/rtk.
+# See ATTRIBUTION-RTK.md at this crate root (packaged on publish).
 
 [lints]
 workspace = true

--- a/crates/pi-shell/src/minimizer.rs
+++ b/crates/pi-shell/src/minimizer.rs
@@ -44,8 +44,11 @@ pub struct MinimizerOutput {
 	/// Byte length of `text` after minimization.
 	#[allow(dead_code, reason = "test-only API surface")]
 	pub output_bytes:  usize,
-	/// Name of the dispatch path that produced this output (e.g. `"git"`,
-	/// `"pipeline:gradle"`, or `"passthrough"`). Useful for telemetry.
+	/// Label for the dispatch path that produced this output (e.g. `"git"`,
+	/// `"pipeline:gradle"`, or `"passthrough"`). For non-rewrite misses, this
+	/// carries the reason label (e.g. `"compound"`, `"piped"`, `"parse-error"`,
+	/// `"too-large"`, `"disabled"`, `"unknown"`, `"unsupported"`,
+	/// `"pipeline-noop"`).
 	pub filter:        &'static str,
 	/// Original (un-minimized) capture, surfaced only when the filter
 	/// actually rewrote the output. The caller (JS session layer) is expected
@@ -79,7 +82,7 @@ impl MinimizerOutput {
 	}
 
 	/// Attach a `filter` label (e.g. `"git"`, `"pipeline:gradle"`) to an
-	/// output for telemetry. No-op on passthrough outputs.
+	/// output for telemetry, including non-rewrite miss reasons.
 	#[must_use]
 	pub const fn labeled(mut self, filter: &'static str) -> Self {
 		self.filter = filter;
@@ -113,8 +116,29 @@ impl MinimizerOutput {
 	}
 }
 
+/// Aggregate output for a segmented chain.
+#[allow(
+	clippy::missing_const_for_fn,
+	reason = "kept non-const because this constructs owned output used only at runtime"
+)]
+pub(crate) fn chain_output(
+	text: String,
+	original_text: String,
+	input_bytes: usize,
+	changed: bool,
+) -> MinimizerOutput {
+	let filter = if changed { "chain" } else { "chain-noop" };
+	let output_bytes = text.len();
+	MinimizerOutput {
+		text,
+		changed,
+		input_bytes,
+		output_bytes,
+		filter,
+		original_text: Some(original_text),
+	}
+}
 /// Apply the configured filter pipeline to a captured buffer.
-///
 /// Returns the original text unchanged when minimization is disabled, no
 /// filter matches, or a filter panics.
 pub fn apply(

--- a/crates/pi-shell/src/minimizer/config.rs
+++ b/crates/pi-shell/src/minimizer/config.rs
@@ -18,50 +18,91 @@ use crate::minimizer::pipeline::{self, PipelineRegistry, SUPPORTED_SCHEMA_VERSIO
 
 const DEFAULT_MAX_CAPTURE_BYTES: u32 = 4 * 1024 * 1024;
 
+/// Source-outline aggressiveness for `cat <source-file>` minimization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OutlineLevel {
+	/// Current behavior: only outline when input is large enough to warrant it.
+	#[default]
+	Default,
+	/// Strip function/method bodies regardless of size for supported source
+	/// languages (`ts`, `tsx`, `js`, `jsx`, `py`, `rs`, `go`).
+	Aggressive,
+}
+
+impl OutlineLevel {
+	fn parse(raw: &str) -> Option<Self> {
+		match raw.trim().to_ascii_lowercase().as_str() {
+			"default" | "" => Some(Self::Default),
+			"aggressive" => Some(Self::Aggressive),
+			_ => None,
+		}
+	}
+}
+
 /// N-API opt-in handle for the minimizer.
 #[derive(Debug, Clone, Default)]
 pub struct MinimizerOptions {
 	/// Master switch. Absent / false = disabled.
-	pub enabled:           Option<bool>,
+	pub enabled:              Option<bool>,
 	/// Optional path to a TOML settings file whose values override
 	/// field-level defaults. `~` is expanded.
-	pub settings_path:     Option<String>,
+	pub settings_path:        Option<String>,
 	/// Optional xxHash64 digest (hex) of the settings file contents. When
 	/// supplied, the engine refuses to honor a settings file whose hash does
 	/// not match — a lightweight trust gate for agent-controllable paths.
-	pub settings_hash:     Option<String>,
+	pub settings_hash:        Option<String>,
 	/// Opt-in allowlist of program names (e.g. `"git"`). When empty or
 	/// absent, all built-in filters are active.
-	pub only:              Option<Vec<String>>,
+	pub only:                 Option<Vec<String>>,
 	/// Program names explicitly excluded from minimization.
-	pub except:            Option<Vec<String>>,
+	pub except:               Option<Vec<String>>,
 	/// Maximum captured bytes per command before the engine falls back to
 	/// the raw, un-minimized output. Default 4 MiB.
-	pub max_capture_bytes: Option<u32>,
+	pub max_capture_bytes:    Option<u32>,
+	/// Source-outline level for `cat <source-file>` minimization. Accepts
+	/// `"default"` (current behavior) or `"aggressive"` (strip function bodies).
+	pub source_outline_level: Option<String>,
+	/// Kill-switch to fall back to the pre-PR (legacy) filter behavior for
+	/// grep / find / pytest. When `Some(true)`, filters that opted into the
+	/// always-shrink Tier 1 / Tier 2 behavior skip the new code path and
+	/// return the legacy passthrough. When `None`, defers to the
+	/// `OMP_MINIMIZER_LEGACY_FILTERS` environment variable (truthy = "1",
+	/// "true", or "yes", case-insensitive); default `false`.
+	pub legacy_filters:       Option<bool>,
 }
 
 /// Resolved minimizer configuration used by the engine.
 #[derive(Debug, Clone)]
 pub struct MinimizerConfig {
-	pub enabled:           bool,
-	pub only:              HashSet<String>,
-	pub except:            HashSet<String>,
-	pub max_capture_bytes: u32,
-	pub per_command:       HashMap<String, toml::Value>,
+	pub enabled:               bool,
+	pub only:                  HashSet<String>,
+	pub except:                HashSet<String>,
+	pub max_capture_bytes:     u32,
+	pub per_command:           HashMap<String, toml::Value>,
 	/// Compiled user-defined pipelines parsed from `settings_path`. Searched
 	/// before the built-in pipelines so user filters win.
-	pub user_pipelines:    Option<Arc<PipelineRegistry>>,
+	pub user_pipelines:        Option<Arc<PipelineRegistry>>,
+	/// Aggressiveness for source-outline body stripping in `compact_cat_output`.
+	pub source_outline_level:  OutlineLevel,
+	/// Resolved kill-switch: when true, opted-in filters (Tier 1 grep/find,
+	/// Tier 2 pytest) return the pre-PR legacy behavior. Resolved at
+	/// `from_options()` time from caller-supplied
+	/// `MinimizerOptions.legacy_filters` or the `OMP_MINIMIZER_LEGACY_FILTERS`
+	/// env var; default `false`.
+	pub legacy_filters_active: bool,
 }
 
 impl Default for MinimizerConfig {
 	fn default() -> Self {
 		Self {
-			enabled:           false,
-			only:              HashSet::new(),
-			except:            HashSet::new(),
-			max_capture_bytes: DEFAULT_MAX_CAPTURE_BYTES,
-			per_command:       HashMap::new(),
-			user_pipelines:    None,
+			enabled:               false,
+			only:                  HashSet::new(),
+			except:                HashSet::new(),
+			max_capture_bytes:     DEFAULT_MAX_CAPTURE_BYTES,
+			per_command:           HashMap::new(),
+			user_pipelines:        None,
+			source_outline_level:  OutlineLevel::Default,
+			legacy_filters_active: false,
 		}
 	}
 }
@@ -83,6 +124,18 @@ impl MinimizerConfig {
 		if let Some(n) = opts.max_capture_bytes {
 			cfg.max_capture_bytes = n.max(1024);
 		}
+		if let Some(raw) = opts.source_outline_level.as_deref()
+			&& let Some(level) = OutlineLevel::parse(raw)
+		{
+			cfg.source_outline_level = level;
+		}
+		let legacy_requested = resolve_legacy_filters(
+			opts.legacy_filters,
+			std::env::var("OMP_MINIMIZER_LEGACY_FILTERS")
+				.ok()
+				.as_deref(),
+		);
+		cfg.legacy_filters_active = legacy_requested;
 		if let Some(path) = opts.settings_path.as_deref()
 			&& !path.is_empty()
 		{
@@ -106,6 +159,15 @@ impl MinimizerConfig {
 				}
 				if let Ok(file) = toml::from_str::<SettingsFile>(&contents) {
 					file.merge_into(&mut cfg);
+					if opts.enabled == Some(false) {
+						cfg.enabled = false;
+					}
+					if legacy_requested {
+						cfg.legacy_filters_active = true;
+					}
+					if opts.legacy_filters == Some(false) {
+						cfg.legacy_filters_active = false;
+					}
 				}
 				match pipeline::parse_file(&contents, "user") {
 					Ok((pipelines, tests)) => {
@@ -141,18 +203,25 @@ impl MinimizerConfig {
 	pub fn per_command(&self, program: &str) -> Option<&toml::Value> {
 		self.per_command.get(&program.to_lowercase())
 	}
+
+	/// Whether opted-in filters should fall back to pre-PR legacy behavior.
+	pub const fn legacy_filters_active(&self) -> bool {
+		self.legacy_filters_active
+	}
 }
 
 #[derive(Debug, Default, Deserialize)]
 struct SettingsFile {
 	#[serde(default)]
-	schema_version:    Option<u32>,
-	enabled:           Option<bool>,
-	only:              Option<Vec<String>>,
-	except:            Option<Vec<String>>,
-	max_capture_bytes: Option<u32>,
+	schema_version:       Option<u32>,
+	enabled:              Option<bool>,
+	only:                 Option<Vec<String>>,
+	except:               Option<Vec<String>>,
+	max_capture_bytes:    Option<u32>,
+	source_outline_level: Option<String>,
+	legacy_filters:       Option<bool>,
 	#[serde(flatten)]
-	tables:            HashMap<String, toml::Value>,
+	tables:               HashMap<String, toml::Value>,
 }
 
 impl SettingsFile {
@@ -178,11 +247,35 @@ impl SettingsFile {
 		if let Some(n) = self.max_capture_bytes {
 			cfg.max_capture_bytes = n.max(1024);
 		}
+		if let Some(raw) = self.source_outline_level.as_deref()
+			&& let Some(level) = OutlineLevel::parse(raw)
+		{
+			cfg.source_outline_level = level;
+		}
+		if let Some(v) = self.legacy_filters {
+			cfg.legacy_filters_active = resolve_legacy_filters(Some(v), None);
+		}
 		for (k, v) in self.tables {
 			if v.is_table() && k != "filters" && k != "tests" {
 				cfg.per_command.insert(k.to_lowercase(), v);
 			}
 		}
+	}
+}
+
+/// Resolve the effective `legacy_filters_active` flag from the caller option
+/// and the raw `OMP_MINIMIZER_LEGACY_FILTERS` env value.
+///
+/// Pure so it can be unit-tested without mutating the process-global
+/// environment (the test harness runs tests in one process in parallel). An
+/// explicit option always wins; otherwise a truthy env value enables the
+/// legacy path.
+fn resolve_legacy_filters(option: Option<bool>, env_value: Option<&str>) -> bool {
+	match option {
+		Some(v) => v,
+		None => env_value.is_some_and(|raw| {
+			matches!(raw.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes")
+		}),
 	}
 }
 
@@ -264,5 +357,92 @@ mod tests {
 			..Default::default()
 		});
 		assert!(cfg.enabled);
+	}
+
+	#[test]
+	fn legacy_filters_option_some_true_sets_active() {
+		// Explicit caller-supplied `Some(true)` must result in
+		// `legacy_filters_active == true` regardless of env. This is the
+		// test-friendly invocation path that avoids env-var mutation.
+		let cfg = MinimizerConfig::from_options(&MinimizerOptions {
+			enabled: Some(true),
+			legacy_filters: Some(true),
+			..Default::default()
+		});
+		assert!(cfg.legacy_filters_active());
+	}
+
+	#[test]
+	fn legacy_filters_option_some_false_overrides_env() {
+		// Explicit `Some(false)` must override any env var (verified by
+		// inspecting the resolver — `Some(_)` arm short-circuits before
+		// reading the env). We assert behavior via a default-constructed
+		// `MinimizerOptions { legacy_filters: Some(false), .. }`.
+		let cfg = MinimizerConfig::from_options(&MinimizerOptions {
+			enabled: Some(true),
+			legacy_filters: Some(false),
+			..Default::default()
+		});
+		assert!(!cfg.legacy_filters_active());
+	}
+
+	#[test]
+	fn resolve_legacy_filters_prefers_option_over_env() {
+		// The pure resolver lets us exercise every branch without mutating the
+		// process-global env var (which would race the parallel test harness).
+		assert!(super::resolve_legacy_filters(Some(true), Some("0")));
+		assert!(!super::resolve_legacy_filters(Some(false), Some("1")));
+	}
+
+	#[test]
+	fn resolve_legacy_filters_defaults_false_without_env() {
+		assert!(!super::resolve_legacy_filters(None, None));
+	}
+
+	#[test]
+	fn resolve_legacy_filters_honors_truthy_env_when_option_absent() {
+		for raw in ["1", "true", "yes", " TRUE ", "Yes"] {
+			assert!(super::resolve_legacy_filters(None, Some(raw)), "{raw:?} should enable");
+		}
+		for raw in ["0", "false", "no", ""] {
+			assert!(!super::resolve_legacy_filters(None, Some(raw)), "{raw:?} should not enable");
+		}
+	}
+
+	#[test]
+	fn settings_file_parses_legacy_filters_switch() {
+		let file: SettingsFile = toml::from_str("legacy_filters = true\n").unwrap();
+		let mut cfg = MinimizerConfig::default();
+		file.merge_into(&mut cfg);
+		assert!(cfg.legacy_filters_active());
+	}
+
+	#[test]
+	fn explicit_disabled_option_overrides_enabled_settings_file() {
+		let path = std::env::temp_dir()
+			.join(format!("omp-minimizer-config-disabled-{}.toml", std::process::id()));
+		std::fs::write(&path, "enabled = true\n").unwrap();
+		let cfg = MinimizerConfig::from_options(&MinimizerOptions {
+			enabled: Some(false),
+			settings_path: Some(path.display().to_string()),
+			..Default::default()
+		});
+		let _ = std::fs::remove_file(&path);
+		assert!(!cfg.enabled);
+	}
+
+	#[test]
+	fn explicit_legacy_true_overrides_disabled_settings_file() {
+		let path = std::env::temp_dir()
+			.join(format!("omp-minimizer-config-legacy-{}.toml", std::process::id()));
+		std::fs::write(&path, "legacy_filters = false\n").unwrap();
+		let cfg = MinimizerConfig::from_options(&MinimizerOptions {
+			enabled: Some(true),
+			settings_path: Some(path.display().to_string()),
+			legacy_filters: Some(true),
+			..Default::default()
+		});
+		let _ = std::fs::remove_file(&path);
+		assert!(cfg.legacy_filters_active());
 	}
 }

--- a/crates/pi-shell/src/minimizer/defs/apt.toml
+++ b/crates/pi-shell/src/minimizer/defs/apt.toml
@@ -1,0 +1,52 @@
+[filters.apt]
+description = "Compact apt/apt-get/yum/dnf/apk package manager output — strip progress lines, keep errors and final result"
+match_command = "^(apt|apt-get|yum|dnf|apk)$"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^\\s*(Get:|Hit:|Ign:)",
+  "^\\s*(Fetched|Processing|Selecting|Preparing|Unpacking|Setting up|Reading|Building)\\s",
+  "^\\s*\\[\\d+%\\]",
+  "^\\(Reading database",
+  "^Loaded plugins:",
+  "^Loading mirror",
+  "^\\s*-->",
+  "^\\s*Package\\s",
+  "^\\s*Marking\\s",
+  "^fetch\\s",
+  "^\\(\\d+/\\d+\\)",
+  "^OK:",
+  "^\\s*\\d+/\\d+:",
+]
+max_lines = 60
+on_empty = "ok"
+
+[[tests.apt]]
+name = "successful apt-get install strips noise and keeps summary"
+input = """
+Reading package lists... Done
+Building dependency tree... Done
+Reading state information... Done
+The following NEW packages will be installed:
+  curl
+0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
+Get:1 http://archive.ubuntu.com/ubuntu focal/main amd64 curl amd64 7.68.0-1ubuntu2 [161 kB]
+Fetched 161 kB in 1s (189 kB/s)
+Selecting previously unselected package curl.
+(Reading database ... 112300 files and directories currently installed.)
+Preparing to unpack .../curl_7.68.0-1ubuntu2_amd64.deb ...
+Unpacking curl (7.68.0-1ubuntu2) ...
+Setting up curl (7.68.0-1ubuntu2) ...
+Processing triggers for man-db (2.9.1-1) ...
+"""
+expected = "The following NEW packages will be installed:\n  curl\n0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.\n"
+
+[[tests.apt]]
+name = "failed install passes through error block"
+input = """
+Reading package lists... Done
+Building dependency tree... Done
+Reading state information... Done
+E: Unable to locate package nonexistent-pkg
+"""
+expected = "E: Unable to locate package nonexistent-pkg\n"

--- a/crates/pi-shell/src/minimizer/defs/conda.toml
+++ b/crates/pi-shell/src/minimizer/defs/conda.toml
@@ -1,0 +1,51 @@
+[filters.conda]
+description = "Compact conda install/create/update output — strip download progress and transaction noise"
+match_command = "^conda$"
+strip_ansi = true
+strip_lines_matching = [
+  "^\\s*$",
+  "^(Downloading|Extracting|Preparing transaction|Verifying transaction|Executing transaction)",
+  "^\\s*##",
+  "^\\s*\\d+%",
+  "^\\s*[#=]{3,}",
+]
+max_lines = 50
+on_empty = "ok"
+
+[[tests.conda]]
+name = "successful install strips progress and keeps package list"
+input = """
+Collecting package metadata (current_repodata.json): done
+Solving environment: done
+
+## Package Plan ##
+
+  environment location: /opt/conda
+
+  added / updated specs:
+    - numpy
+
+
+The following packages will be downloaded:
+
+    package                    |            build
+    ---------------------------|-----------------
+    numpy-1.24.3               |   py310h8e6c1ab_0         5.5 MB
+
+Preparing transaction: done
+Verifying transaction: done
+Executing transaction: done
+"""
+expected = "Collecting package metadata (current_repodata.json): done\nSolving environment: done\n  environment location: /opt/conda\n  added / updated specs:\n    - numpy\nThe following packages will be downloaded:\n    package                    |            build\n    ---------------------------|-----------------\n    numpy-1.24.3               |   py310h8e6c1ab_0         5.5 MB\n"
+
+[[tests.conda]]
+name = "failed install passes through error"
+input = """
+Collecting package metadata (current_repodata.json): done
+Solving environment: failed
+
+PackagesNotFoundError: The following packages are not available from current channels:
+
+  - fake-package-xyz
+"""
+expected = "Collecting package metadata (current_repodata.json): done\nSolving environment: failed\nPackagesNotFoundError: The following packages are not available from current channels:\n  - fake-package-xyz\n"

--- a/crates/pi-shell/src/minimizer/defs/gcc.toml
+++ b/crates/pi-shell/src/minimizer/defs/gcc.toml
@@ -3,15 +3,13 @@
 
 [filters.gcc]
 description = "Compact gcc/g++ compiler output — strip notes, keep errors and warnings"
-match_command = "^(gcc|g\\+\\+)$"
+match_command = "^(gcc|g\\+\\+|clang|clang\\+\\+)$"
 strip_ansi = true
 strip_lines_matching = [
   "^\\s*$",
   "^\\s+\\|\\s*$",
   "^In file included from",
   "^\\s+from\\s",
-  "^\\d+ warnings? generated",
-  "^\\d+ errors? generated",
 ]
 max_lines = 50
 on_empty = "gcc: ok"
@@ -30,7 +28,7 @@ main.c:15:12: warning: unused variable 'x' [-Wunused-variable]
 2 warnings generated.
 1 error generated.
 """
-expected = "main.c:10:5: error: use of undeclared identifier 'foo'\n    foo();\n    ^\nmain.c:15:12: warning: unused variable 'x' [-Wunused-variable]\n    int x = 42;\n        ^\n"
+expected = "main.c:10:5: error: use of undeclared identifier 'foo'\n    foo();\n    ^\nmain.c:15:12: warning: unused variable 'x' [-Wunused-variable]\n    int x = 42;\n        ^\n2 warnings generated.\n1 error generated.\n"
 
 [[tests.gcc]]
 name = "clean compilation"
@@ -50,3 +48,23 @@ expected = "/usr/bin/ld: /tmp/main.o: undefined reference to 'missing_func'\ncol
 name = "empty input returns on_empty message"
 input = ""
 expected = "gcc: ok"
+
+[[tests.gcc]]
+name = "clang variant errors"
+input = """
+foo.c:3:10: fatal error: 'missing.h' file not found
+#include "missing.h"
+         ^~~~~~~~~~~
+1 error generated.
+"""
+expected = "foo.c:3:10: fatal error: 'missing.h' file not found\n#include \"missing.h\"\n         ^~~~~~~~~~~\n1 error generated.\n"
+
+[[tests.gcc]]
+name = "clang++ variant errors"
+input = """
+foo.cpp:8:5: error: unknown type name 'Widget'
+    Widget w;
+    ^
+1 error generated.
+"""
+expected = "foo.cpp:8:5: error: unknown type name 'Widget'\n    Widget w;\n    ^\n1 error generated.\n"

--- a/crates/pi-shell/src/minimizer/detect.rs
+++ b/crates/pi-shell/src/minimizer/detect.rs
@@ -168,6 +168,71 @@ fn skip_time_options(tokens: &[String], mut index: usize) -> Option<usize> {
 	Some(index)
 }
 
+fn skip_aws_global_options(args: &[String]) -> Option<usize> {
+	const VALUE_FLAGS: &[&str] = &[
+		"--profile",
+		"--region",
+		"--endpoint-url",
+		"--cli-binary-format",
+		"--output",
+		"--cli-read-timeout",
+		"--cli-connect-timeout",
+		"--ca-bundle",
+		"--color",
+		"--query",
+		"--cli-input-json",
+		"--cli-input-yaml",
+	];
+	const BOOL_FLAGS: &[&str] = &[
+		"--no-cli-pager",
+		"--debug",
+		"--no-verify-ssl",
+		"--no-paginate",
+		"--no-sign-request",
+		"--cli-auto-prompt",
+		"--no-cli-auto-prompt",
+	];
+
+	let mut index = 0;
+	while let Some(arg) = args.get(index) {
+		if arg == "--" {
+			return args.get(index + 1).map(|_| index + 1);
+		}
+		if BOOL_FLAGS.contains(&arg.as_str()) {
+			index += 1;
+			continue;
+		}
+		if arg == "--generate-cli-skeleton" {
+			index += 1;
+			if args
+				.get(index)
+				.is_some_and(|value| matches!(value.as_str(), "input" | "output" | "yaml-input"))
+			{
+				index += 1;
+			}
+			continue;
+		}
+		if arg.starts_with("--generate-cli-skeleton=") {
+			index += 1;
+			continue;
+		}
+		if option_consumes_value(arg, VALUE_FLAGS) {
+			index = if option_has_inline_value(arg, VALUE_FLAGS) {
+				index + 1
+			} else {
+				index + 2
+			};
+			continue;
+		}
+		break;
+	}
+	if index > args.len() {
+		None
+	} else {
+		Some(index)
+	}
+}
+
 fn skip_option_value(tokens: &[String], index: usize) -> Option<usize> {
 	let token = tokens.get(index)?;
 	if token.starts_with("--") && token.contains('=') {
@@ -254,6 +319,24 @@ fn detect_subcommand(program: &str, args: &[String]) -> Option<String> {
 			],
 			&[],
 		),
+		"npx" => first_non_global_arg(
+			args,
+			&[
+				"--workspace",
+				"-w",
+				"--package",
+				"-p",
+				"--prefix",
+				"--cache",
+				"--registry",
+				"--userconfig",
+				"--call",
+				"--shell",
+				"--node-arg",
+			],
+			&["--yes", "--no", "--no-install", "--quiet", "--silent", "--verbose"],
+			&[],
+		),
 		"pnpm" => first_non_global_arg(
 			args,
 			&["--dir", "-C", "--filter", "-F", "--workspace", "--config", "--store-dir"],
@@ -290,6 +373,48 @@ fn detect_subcommand(program: &str, args: &[String]) -> Option<String> {
 			args,
 			&["--gemfile", "--path", "--jobs", "--retry"],
 			&["--verbose", "--quiet", "--no-color"],
+			&[],
+		),
+		"aws" => skip_aws_global_options(args)
+			.and_then(|index| args.get(index))
+			.map(|arg| arg.to_lowercase()),
+		"uv" | "uvx" => first_non_global_arg(
+			args,
+			&[
+				"--directory",
+				"-C",
+				"--project",
+				"-p",
+				"--cache-dir",
+				"--config-file",
+				"--config-setting",
+				"--python",
+				"--python-preference",
+				"--exclude-newer",
+				"--color",
+				"--allow-insecure-host",
+				"--no-binary",
+				"--only-binary",
+			],
+			&[
+				"--offline",
+				"--no-cache",
+				"--no-cache-dir",
+				"--no-progress",
+				"--native-tls",
+				"--no-native-tls",
+				"--quiet",
+				"-q",
+				"--verbose",
+				"-v",
+				"--upgrade",
+				"--no-upgrade",
+				"--require-hashes",
+				"--verify-hashes",
+				"--no-verify-hashes",
+				"--no-build",
+				"--reinstall",
+			],
 			&[],
 		),
 		"jest" | "vitest" => first_non_global_arg(args, &[], &[], &[]),
@@ -463,6 +588,17 @@ mod tests {
 	}
 
 	#[test]
+	fn detects_direct_lint_tools() {
+		let command = detect("eslint src/foo.ts").expect("eslint command is detected");
+		assert_eq!(command.program, "eslint");
+		assert_eq!(command.subcommand.as_deref(), Some("src/foo.ts"));
+
+		let command = detect("tsc --project tsconfig.json").expect("tsc command is detected");
+		assert_eq!(command.program, "tsc");
+		assert_eq!(command.subcommand.as_deref(), Some("tsconfig.json"));
+	}
+
+	#[test]
 	fn detects_gt_through_wrappers_and_globals() {
 		let command = detect("env GRAPHITE_TOKEN=x command gt --repo owner/repo submit --stack")
 			.expect("gt command is detected");
@@ -476,6 +612,63 @@ mod tests {
 		assert_eq!(command.program, "gt");
 		assert_eq!(command.subcommand.as_deref(), Some("sync"));
 	}
+
+	#[test]
+	fn skips_aws_global_options() {
+		let command = detect(
+			"aws --profile foo --region=us-east-1 --endpoint-url http://localhost:4566 \
+			 --no-cli-pager --generate-cli-skeleton output s3 ls",
+		)
+		.expect("aws command is detected");
+		assert_eq!(command.program, "aws");
+		assert_eq!(command.subcommand.as_deref(), Some("s3"));
+	}
+
+	#[test]
+	fn aws_double_dash_terminates_global_options() {
+		let command = detect("aws -- --literal-service op").expect("aws command is detected");
+		assert_eq!(command.program, "aws");
+		assert_eq!(command.subcommand.as_deref(), Some("--literal-service"));
+	}
+
+	#[test]
+	fn aws_global_option_permutations_keep_service_subcommand() {
+		let flags = [
+			"--profile dev",
+			"--region us-east-1",
+			"--endpoint-url=http://localhost:4566",
+			"--cli-binary-format raw-in-base64-out",
+			"--output json",
+			"--cli-read-timeout=5",
+			"--cli-connect-timeout 5",
+			"--ca-bundle /tmp/ca.pem",
+			"--color off",
+			"--query Buckets[].Name",
+			"--cli-input-json file://input.json",
+			"--cli-input-yaml file://input.yaml",
+			"--no-cli-pager",
+			"--debug",
+			"--no-verify-ssl",
+			"--no-paginate",
+			"--no-sign-request",
+			"--cli-auto-prompt",
+			"--no-cli-auto-prompt",
+			"--generate-cli-skeleton",
+			"--generate-cli-skeleton=output",
+		];
+		for idx in 0..128 {
+			let mut command = String::from("aws");
+			for (bit, flag) in flags.iter().enumerate() {
+				if idx & (1 << (bit % 7)) != 0 && (idx + bit) % 3 == 0 {
+					command.push(' ');
+					command.push_str(flag);
+				}
+			}
+			command.push_str(" lambda list-functions");
+			let detected = detect(&command).expect("aws command is detected");
+			assert_eq!(detected.subcommand.as_deref(), Some("lambda"), "{command}");
+		}
+	}
 }
 
 #[test]
@@ -487,4 +680,25 @@ fn detects_bun_globals_and_subcommands() {
 	let command = detect("env CI=1 /usr/local/bin/bun test").expect("bun test is detected");
 	assert_eq!(command.program, "bun");
 	assert_eq!(command.subcommand.as_deref(), Some("test"));
+}
+
+#[test]
+fn npx_workspace_value_is_skipped_in_subcommand_detection() {
+	// `npx -w <workspace>` is a value-taking option; the workspace name must
+	// not be returned as the subcommand. The actual tool name follows after
+	// the option value.
+	let command = detect("npx -w vitest echo PASS").expect("npx command is detected");
+	assert_eq!(command.program, "npx");
+	assert_eq!(command.subcommand.as_deref(), Some("echo"));
+
+	// plain npx invocation with an actual tool still resolves correctly
+	let command = detect("npx vitest").expect("npx vitest is detected");
+	assert_eq!(command.program, "npx");
+	assert_eq!(command.subcommand.as_deref(), Some("vitest"));
+
+	// workspace value that happens to be a tool name is skipped; the next
+	// token is the actual tool
+	let command = detect("npx -w my-workspace vitest").expect("npx with workspace is detected");
+	assert_eq!(command.program, "npx");
+	assert_eq!(command.subcommand.as_deref(), Some("vitest"));
 }

--- a/crates/pi-shell/src/minimizer/engine.rs
+++ b/crates/pi-shell/src/minimizer/engine.rs
@@ -21,6 +21,8 @@ pub enum MinimizerMode {
 	None,
 	/// Capture the whole command and apply one filter to the whole buffer.
 	WholeCommand,
+	/// Execute a safe `&&` / `;` chain segment-by-segment.
+	SegmentedChain,
 }
 
 /// Return the minimization mode for a command.
@@ -32,6 +34,22 @@ pub fn mode_for(command: &str, config: &MinimizerConfig) -> MinimizerMode {
 			};
 			if identity_has_filter(&identity, config) {
 				MinimizerMode::WholeCommand
+			} else {
+				MinimizerMode::None
+			}
+		},
+		plan::CommandPlan::Chain { segments } => {
+			// Only route a chain through the segmented runner when the minimizer is
+			// enabled, the legacy kill-switch is off, at least one segment is
+			// eligible, and no segment can permanently rewire the shell's own file
+			// descriptors (`exec >out`). Any failed guard restores the pre-PR
+			// single-exec passthrough behaviour.
+			if config.enabled
+				&& !config.legacy_filters_active()
+				&& chain_has_eligible_segment(&segments, config)
+				&& !chain_mutates_shell_fds(&segments)
+			{
+				MinimizerMode::SegmentedChain
 			} else {
 				MinimizerMode::None
 			}
@@ -72,11 +90,15 @@ pub fn apply(
 	}
 
 	// Structural guard: this whole-buffer path only handles single simple
-	// commands. Compound commands and pipes can feed downstream parsers
-	// (awk, jq, rg, …), so rewriting their combined output is a correctness
-	// bug.
+	// commands. Safe chains are intentionally kept opaque here so the engine
+	// can only segment them when the shell executes each piece separately.
+	// Pipes can feed downstream parsers (awk, jq, rg, …), so rewriting their
+	// combined output is a correctness bug.
 	match plan::analyze(command) {
 		plan::CommandPlan::Single { .. } => {},
+		plan::CommandPlan::Chain { segments } => {
+			return apply_chain(command, &segments, captured, exit_code, config);
+		},
 		plan::CommandPlan::Piped => {
 			return MinimizerOutput::passthrough(captured).labeled("piped");
 		},
@@ -95,6 +117,41 @@ pub fn apply(
 	apply_identity(&identity, command, captured, exit_code, config)
 }
 
+/// Apply the whole-buffer dispatch path for a `Chain { segments }` plan.
+///
+/// The FFI whole-buffer entry point sees the entire chain's captured stdout
+/// (interleaved across segments) — it cannot split it back into per-segment
+/// slices. That makes the whole-buffer path fundamentally unable to minimize a
+/// chain safely: every git renderer that condenses output (`condense_status`,
+/// `compact_diff_output`, `condense_stash`, …) parses the buffer and rebuilds a
+/// single synthetic result, so feeding it two segments' interleaved captures
+/// produces output that never existed for any one command.
+///
+/// Concretely, `git -C a status && git -C b status` would let `condense_status`
+/// overwrite `summary.branch` with the *last* repo and sum both repos'
+/// clean/dirty counts into one fabricated status. The same multi-capture merge
+/// corrupts same-subcommand `diff`/`stash`/`log`/… chains: none of these
+/// renderers is associative over concatenated captures, and the whole-buffer
+/// path has no way to attribute lines back to their originating segment.
+///
+/// Per-segment minimization (where each segment is captured in isolation and is
+/// safe to route through its own filter) is handled separately by the segmented
+/// chain runner. The whole-buffer path therefore stays opaque for every chain:
+/// it preserves the captured bytes verbatim and labels the result `compound`.
+///
+/// Kill-switch parity (M2): `legacy_filters_active` also returns the opaque
+/// passthrough so callers can rollback without recompile.
+fn apply_chain(
+	command: &str,
+	segments: &[plan::ChainSegment],
+	captured: &str,
+	_exit_code: i32,
+	_config: &MinimizerConfig,
+) -> MinimizerOutput {
+	let _ = (command, segments);
+	MinimizerOutput::passthrough(captured).labeled("compound")
+}
+
 fn identity_has_filter(identity: &detect::CommandIdentity, config: &MinimizerConfig) -> bool {
 	if !config.is_program_enabled(&identity.program) {
 		return false;
@@ -103,6 +160,133 @@ fn identity_has_filter(identity: &detect::CommandIdentity, config: &MinimizerCon
 	let subcommand = identity.subcommand.as_deref();
 	filters::supports(&identity.program, subcommand)
 		|| resolve_pipeline(config, &identity.program, subcommand).is_some()
+}
+
+fn chain_has_eligible_segment(segments: &[plan::ChainSegment], config: &MinimizerConfig) -> bool {
+	segments.iter().any(|segment| {
+		detect::detect(&segment.command)
+			.is_some_and(|identity| identity_has_filter(&identity, config))
+			|| is_common_chain_utility(&segment.program)
+	})
+}
+
+/// True when any segment can permanently rewire the shell's own file
+/// descriptors. The segmented chain runner executes each segment in a fresh
+/// capture context with its own stdout/stderr pipe, so fd mutations made by one
+/// segment (e.g. `exec >out`, `exec 2>err`) are not honored by the segments
+/// that follow: output the user redirected to a file would instead be captured
+/// and returned to the caller. When such a segment is present we refuse to
+/// segment and leave the chain opaque (passthrough), preserving the original
+/// redirection semantics.
+fn chain_mutates_shell_fds(segments: &[plan::ChainSegment]) -> bool {
+	segments.iter().any(is_shell_fd_mutating_segment)
+}
+
+/// True when a segment's effective command can mutate the shell parse/runtime
+/// environment in a way that segmented execution cannot preserve.
+///
+/// `exec` rewires fds; `eval` / `source` / `.` can introduce that opaquely;
+/// `alias` / `unalias` change how later words in separate `run_string` calls
+/// are expanded. Resolves the simple direct case from the parsed program word
+/// first so quoted assignments such as `FOO="a b" exec >out` cannot fool the
+/// fallback whitespace scan.
+fn is_shell_fd_mutating_segment(segment: &plan::ChainSegment) -> bool {
+	if is_shell_state_mutating_program(&segment.program) {
+		return true;
+	}
+	if matches!(segment.program.as_str(), "command" | "builtin")
+		&& command_wrapper_invokes_mutator(segment)
+	{
+		return true;
+	}
+	false
+}
+
+fn is_shell_state_mutating_program(program: &str) -> bool {
+	matches!(program, "exec" | "eval" | "source" | "." | "alias" | "unalias")
+}
+
+fn command_wrapper_invokes_mutator(segment: &plan::ChainSegment) -> bool {
+	for word in segment.command.split_whitespace() {
+		if is_shell_state_mutating_program(word) {
+			return true;
+		}
+		// A split quoted assignment means we are no longer looking at real shell
+		// words. Stay opaque rather than proving safety from corrupted tokens.
+		if is_ambiguous_assignment_fragment(word) {
+			return true;
+		}
+		if word == "command" || word == "builtin" || word.starts_with('-') || is_env_assignment(word)
+		{
+			continue;
+		}
+		return false;
+	}
+	false
+}
+
+fn is_ambiguous_assignment_fragment(word: &str) -> bool {
+	is_env_assignment(word) && (word.contains('"') || word.contains('\''))
+}
+
+/// True for a leading `KEY=value` environment assignment (a prefix that does
+/// not change which command word ultimately runs).
+fn is_env_assignment(word: &str) -> bool {
+	word.split_once('=').is_some_and(|(key, _)| {
+		!key.is_empty() && key.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
+	})
+}
+
+/// Common shell utilities that on their own would not warrant whole-command
+/// minimization, but whose presence in a `&&` / `;` chain alongside other
+/// segments is enough to fire the segmented chain runner. Each such segment
+/// is captured and passes through `minimizer::apply` which will treat it as
+/// `Single` with no matching filter and stream the text unchanged.
+fn is_common_chain_utility(program: &str) -> bool {
+	matches!(
+		program,
+		"echo"
+			| "printf"
+			| "head"
+			| "tail"
+			| "file"
+			| "which"
+			| "type"
+			| "sed"
+			| "awk"
+			| "sleep"
+			| "seq"
+			| "cp" | "mv"
+			| "rm" | "mkdir"
+			| "rmdir"
+			| "touch"
+			| "basename"
+			| "dirname"
+			| "realpath"
+			| "readlink"
+			| "true"
+			| "false"
+			| "yes"
+			| "tr" | "tee"
+			| "sort"
+			| "uniq"
+			| "cut"
+			| "paste"
+			| "rev"
+			| "split"
+			| "comm"
+			| "patch"
+			| "xargs"
+			| "unzip"
+			| "zip"
+			| "tar"
+			| "gzip"
+			| "gunzip"
+			| "cd" | "pwd"
+			| "export"
+			| "env"
+			| "test"
+	)
 }
 
 fn apply_identity(
@@ -120,13 +304,22 @@ fn apply_identity(
 
 	if filters::supports(&identity.program, subcommand) {
 		let ctx = MinimizerCtx { program: &identity.program, subcommand, command, config };
-		let rust_output =
-			match catch_unwind(AssertUnwindSafe(|| filters::filter(&ctx, captured, exit_code))) {
-				Ok(out) => out,
-				Err(_) => MinimizerOutput::passthrough(captured),
-			};
+		let Ok(rust_output) =
+			catch_unwind(AssertUnwindSafe(|| filters::filter(&ctx, captured, exit_code)))
+		else {
+			return MinimizerOutput::passthrough(captured)
+				.labeled(program_label(&identity.program))
+				.with_original(captured);
+		};
 		let label = program_label(&identity.program);
-		let overlaid = apply_pipeline_overlay(config, &identity.program, rust_output, label);
+		let overlaid = apply_pipeline_overlay(
+			config,
+			&identity.program,
+			subcommand,
+			exit_code,
+			rust_output,
+			label,
+		);
 		return ensure_success_visible(overlaid, exit_code).with_original(captured);
 	}
 
@@ -190,6 +383,10 @@ fn program_label(program: &str) -> &'static str {
 		"rake" => "rake",
 		"rails" => "rails",
 		"rubocop" => "rubocop",
+		"rustfmt" => "rustfmt",
+		"xxd" => "xxd",
+		"strings" => "strings",
+		"od" => "od",
 		"tsc" => "tsc",
 		"eslint" => "eslint",
 		"biome" => "biome",
@@ -232,12 +429,17 @@ fn program_label(program: &str) -> &'static str {
 fn apply_pipeline_overlay(
 	config: &MinimizerConfig,
 	program: &str,
+	subcommand: Option<&str>,
+	exit_code: i32,
 	inner: MinimizerOutput,
 	primary_label: &'static str,
 ) -> MinimizerOutput {
-	let Some(pipeline) = resolve_pipeline(config, program, None) else {
+	let Some(pipeline) = resolve_pipeline(config, program, subcommand) else {
 		return inner.labeled(primary_label);
 	};
+	if pipeline.skipped_by_exit(exit_code) {
+		return inner.labeled(primary_label);
+	}
 	let text = catch_unwind(AssertUnwindSafe(|| pipeline.apply(&inner.text).into_owned()))
 		.unwrap_or_else(|_| inner.text.clone());
 	if text == inner.text {
@@ -312,8 +514,28 @@ pub fn verify_builtin_filters() -> Vec<pipeline::TestOutcome> {
 
 #[cfg(test)]
 mod tests {
-	use super::*;
+	use std::{
+		fs,
+		sync::atomic::{AtomicUsize, Ordering},
+	};
 
+	static CONFIG_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+	use super::*;
+	use crate::minimizer::MinimizerOptions;
+	fn config_from_settings(contents: &str) -> MinimizerConfig {
+		let nonce = CONFIG_COUNTER.fetch_add(1, Ordering::Relaxed);
+		let path = std::env::temp_dir()
+			.join(format!("pi-shell-minimizer-engine-{}-{nonce}.toml", std::process::id()));
+		fs::write(&path, contents).expect("write minimizer settings");
+		let cfg = MinimizerConfig::from_options(&MinimizerOptions {
+			enabled: Some(true),
+			settings_path: Some(path.to_string_lossy().into_owned()),
+			..Default::default()
+		});
+		let _ = fs::remove_file(path);
+		cfg
+	}
 	#[test]
 	fn disabled_config_does_not_minimize() {
 		let cfg = MinimizerConfig::default();
@@ -322,6 +544,55 @@ mod tests {
 		assert!(!out.changed);
 	}
 
+	#[test]
+	fn disabled_minimizer_and_disabled_program_do_not_transform_supported_command() {
+		let input = "diff --git a/file.rs b/file.rs\n@@\n-old\n+new\n";
+
+		let disabled = MinimizerConfig::default();
+		assert!(!should_minimize("git diff", &disabled));
+		let out = apply("git diff", input, 0, &disabled);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+		assert_eq!(out.filter, "disabled");
+
+		let except_git = MinimizerConfig {
+			enabled: true,
+			except: std::iter::once("git".to_string()).collect(),
+			..Default::default()
+		};
+		assert!(!should_minimize("git diff", &except_git));
+		let out = apply("git diff", input, 0, &except_git);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+		assert_eq!(out.filter, "disabled");
+	}
+
+	#[test]
+	fn pipeline_overlay_honors_subcommand_and_exit_gates() {
+		let cfg = config_from_settings(
+			r#"
+schema_version = 1
+[filters.git_diff_overlay]
+match_command = "^git$"
+match_subcommand = "^diff$"
+strip_lines_matching = [".*"]
+on_empty = "OVERLAY"
+only_on_exit = [0]
+"#,
+		);
+		let diff_input = "diff --git a/file.rs b/file.rs\n@@\n-old\n+new\n";
+		let diff = apply("git diff", diff_input, 0, &cfg);
+		assert_eq!(diff.filter, "pipeline+builtin");
+		assert_eq!(diff.text, "OVERLAY");
+
+		let status = apply("git status", "## main\n M file.rs\n", 0, &cfg);
+		assert_ne!(status.filter, "pipeline+builtin");
+		assert!(status.text.contains("unstaged 1"));
+
+		let failed = apply("git diff", diff_input, 1, &cfg);
+		assert_ne!(failed.filter, "pipeline+builtin");
+		assert!(failed.text.contains("file changed"));
+	}
 	#[test]
 	fn enabled_known_filter_minimizes() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
@@ -332,13 +603,14 @@ mod tests {
 	}
 
 	#[test]
-	fn enabled_config_does_not_minimize_git_status() {
+	fn enabled_config_minimizes_git_status() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
-		assert!(!should_minimize("git status", &cfg));
+		assert!(should_minimize("git status", &cfg));
 		let input = "## main\n M file.rs\n";
 		let out = apply("git status", input, 0, &cfg);
-		assert!(!out.changed);
-		assert_eq!(out.text, input);
+		assert!(out.changed);
+		assert!(out.text.contains("unstaged 1"));
+		assert_eq!(out.filter, "git");
 	}
 
 	#[test]
@@ -356,6 +628,27 @@ mod tests {
 		assert_eq!(out.text, "OK\n");
 		assert_eq!(out.output_bytes, out.text.len());
 		assert!(out.original_text.is_some());
+	}
+
+	#[test]
+	fn successful_user_pipeline_empty_output_returns_visible_ok() {
+		let cfg = config_from_settings(
+			r#"
+schema_version = 1
+[filters.empty_ok]
+match_command = "^printf$"
+strip_lines_matching = [".*"]
+"#,
+		);
+
+		assert!(should_minimize("printf done", &cfg));
+		let out = apply("printf done", "drop me\n", 0, &cfg);
+
+		assert!(out.changed);
+		assert_eq!(out.text, "OK\n");
+		assert_eq!(out.filter, "pipeline");
+		assert_eq!(out.output_bytes, out.text.len());
+		assert_eq!(out.original_text.as_deref(), Some("drop me\n"));
 	}
 
 	#[test]
@@ -378,11 +671,44 @@ mod tests {
 	}
 
 	#[test]
-	fn compound_and_piped_commands_do_not_minimize() {
+	fn segmented_chain_mode_is_only_for_eligible_safe_chains() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
-		assert_eq!(mode_for("echo start ; git status", &cfg), MinimizerMode::None);
-		assert_eq!(mode_for("false && git status", &cfg), MinimizerMode::None);
+		assert_eq!(
+			mode_for("git diff --stat && git diff --name-only", &cfg),
+			MinimizerMode::SegmentedChain
+		);
+		assert_eq!(mode_for("git diff ; printf done", &cfg), MinimizerMode::SegmentedChain);
+		// Common shell utilities make a chain eligible for the segmented runner
+		// even when no segment has a dedicated filter — segments stream through
+		// per-segment passthrough so the chain itself is captured for telemetry.
+		assert_eq!(mode_for("false && echo no ; echo yes", &cfg), MinimizerMode::SegmentedChain);
+		assert_eq!(mode_for("foo || bar", &cfg), MinimizerMode::None);
 		assert_eq!(mode_for("git status | cat", &cfg), MinimizerMode::None);
+		assert_eq!(mode_for("sleep 1 &", &cfg), MinimizerMode::None);
+		assert_eq!(mode_for("(cd foo && make)", &cfg), MinimizerMode::None);
+	}
+
+	#[test]
+	fn segmented_chain_supported_command_does_not_record_unknown() {
+		// Phase 7 (Mode α resolution): supported chains route through
+		// filters::dispatch via the chain decomposer instead of falling
+		// back to passthrough. The unknown-command counter must remain
+		// stable — the chain entry point is structurally known.
+		reset_unknown_command_count();
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = "diff --git a/file.rs b/file.rs\n@@\n-old\n+new\n";
+		let before = unknown_command_count();
+
+		assert_eq!(mode_for("git diff ; printf done", &cfg), MinimizerMode::SegmentedChain);
+		let out = apply("git diff ; printf done", input, 0, &cfg);
+
+		// Whole-buffer entry: a mixed chain (`git diff` + `printf`) stays opaque
+		// rather than running the git filter over the interleaved capture. The
+		// chain entry point is still structurally known, so no unknown-command is
+		// recorded (per-segment minimization is the segmented runner's job).
+		assert!(!out.changed, "mixed chain must stay passthrough in whole-buffer minimization");
+		assert_eq!(out.filter, "compound");
+		assert_eq!(unknown_command_count(), before);
 	}
 
 	#[test]
@@ -414,6 +740,216 @@ mod tests {
 		assert_eq!(gtest.filter, "gtest");
 		assert!(!gtest.text.contains("Foo.Pass"));
 		assert!(gtest.text.contains("foo_test.cc:42: Failure"));
+	}
+
+	#[test]
+	fn git_status_chain_stays_opaque() {
+		// `condense_status` rebuilds a single synthetic status from the whole
+		// buffer: it keeps only the last `On branch …` it sees and sums every
+		// segment's clean/dirty counts. For `git -C a status && git -C b status`
+		// that fabricates one status that never existed for either repo, so the
+		// whole-buffer path must stay opaque and preserve the captured bytes.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = "On branch feature-a\n M a.rs\nOn branch feature-b\n M b.rs\n";
+		let out = apply("git -C a status && git -C b status", input, 0, &cfg);
+		assert!(!out.changed, "same-subcommand status chain must stay passthrough");
+		assert_eq!(out.filter, "compound");
+		assert_eq!(out.text, input, "captured output must be preserved verbatim");
+		// Both repos' branch headers survive — no synthetic merged status.
+		assert!(out.text.contains("feature-a") && out.text.contains("feature-b"));
+	}
+
+	#[test]
+	fn git_commit_chain_differing_actions_stays_opaque() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = "On branch main\nChanges to be committed:\n  modified: src/lib.rs\n[main \
+		             abc1234] init\n 1 file changed, 1 insertion(+)\n";
+		let out = apply("git commit --dry-run && git commit -m init", input, 0, &cfg);
+		assert!(!out.changed, "commit actions share a subcommand but not an output contract");
+		assert_eq!(out.filter, "compound");
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn git_only_chain_differing_subcommands_stays_opaque() {
+		// `git status && git log` must NOT route the whole buffer through one
+		// subcommand filter: `condense_status` rebuilds output from its own parse
+		// and would silently drop the `git log` segment's lines. Stay opaque and
+		// preserve the captured output verbatim.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = "## main\n M file.rs\n";
+		let out = apply("git status && git log -1", input, 0, &cfg);
+		assert!(!out.changed, "differing-subcommand git chain must stay passthrough");
+		assert_eq!(out.filter, "compound");
+		assert_eq!(out.text, input, "captured output must be preserved verbatim");
+	}
+
+	#[test]
+	fn git_diff_chain_differing_formats_stays_opaque() {
+		// `git diff --name-only && git diff --stat` share the `diff` subcommand but
+		// select incompatible renderers. Routing the combined buffer through one
+		// (the whole-chain command carries BOTH `--name-only` and `--stat`, so the
+		// diff filter would treat it as a stat buffer) corrupts the listing
+		// segment's output. Diverging diff formats must stay opaque.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input =
+			"src/a.rs\nsrc/b.rs\n src/a.rs | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)\n";
+		let out = apply("git diff --name-only && git diff --stat", input, 0, &cfg);
+		assert!(!out.changed, "differing diff formats must stay passthrough");
+		assert_eq!(out.filter, "compound");
+		assert_eq!(out.text, input, "captured output must be preserved verbatim");
+	}
+
+	#[test]
+	fn git_diff_chain_same_format_stays_opaque() {
+		// Even same-format diff chains stay opaque on the whole-buffer path: the
+		// renderer parses the combined buffer and rebuilds one summary, with no
+		// way to attribute files back to each segment's repo/ref. `git -C a diff
+		// && git -C b diff` would merge both repos into one fabricated stat, so
+		// the captured bytes must be preserved verbatim.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let mut listing = String::new();
+		for i in 0..30 {
+			use std::fmt::Write as _;
+			let _ = writeln!(listing, "src/file{i}.rs");
+		}
+		let out = apply("git diff --name-only && git diff --name-only HEAD~1", &listing, 0, &cfg);
+		assert!(!out.changed, "same-format diff chain must stay passthrough");
+		assert_eq!(out.filter, "compound");
+		assert_eq!(out.text, listing, "captured output must be preserved verbatim");
+	}
+
+	#[test]
+	fn git_diff_raw_and_default_diff_stays_opaque() {
+		// `git diff --raw && git diff` share the `diff` subcommand but have
+		// incompatible output formats (raw vs unified). They MUST get distinct
+		// format keys so the chain stays opaque.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = ":100644 100644 12345... abcde... M\tsrc/a.rs\n diff --git a/src/a.rs \
+		             b/src/a.rs\nindex abc..def 100644\n--- a/src/a.rs\n+++ b/src/a.rs\n@@ -1 +1 \
+		             @@\n-old\n+new\n";
+		let out = apply("git diff --raw && git diff", input, 0, &cfg);
+		assert!(!out.changed, "raw+unified diff must stay opaque");
+		assert_eq!(out.filter, "compound");
+		assert_eq!(out.text, input, "captured output must be preserved verbatim");
+	}
+
+	#[test]
+	fn git_diff_summary_and_default_diff_stays_opaque() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = " create mode 100644 src/a.rs\n delete mode 100644 src/b.rs\n";
+		let out = apply("git diff --summary && git diff", input, 0, &cfg);
+		assert!(!out.changed, "summary+unified diff must stay opaque");
+		assert_eq!(out.filter, "compound");
+	}
+
+	#[test]
+	fn git_diff_check_and_default_diff_stays_opaque() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = "src/a.rs:1: leftover conflict marker\n";
+		let out = apply("git diff --check && git diff", input, 0, &cfg);
+		assert!(!out.changed, "check+unified diff must stay opaque");
+		assert_eq!(out.filter, "compound");
+	}
+
+	#[test]
+	fn git_diff_same_raw_format_stays_opaque() {
+		// Same subcommand AND same raw format still stays opaque on the
+		// whole-buffer path: like every git chain here, the combined capture
+		// cannot be attributed back to each segment, so it is preserved verbatim.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = ":100644 100644 12345... abcde... M\tsrc/a.rs\n:100644 100644 67890... fghij... \
+		             M\tsrc/b.rs\n";
+		let out = apply("git diff --raw && git diff --raw HEAD~1", input, 0, &cfg);
+		assert!(!out.changed, "same-raw-format diff chain must stay passthrough");
+		assert_eq!(out.filter, "compound");
+		assert_eq!(out.text, input, "captured output must be preserved verbatim");
+	}
+	#[test]
+	fn mixed_chain_stays_opaque_in_whole_buffer_minimization() {
+		// A mixed chain (`git status` + unrelated `echo`) must NOT route the whole
+		// interleaved capture through the first segment's filter: `condense_status`
+		// rebuilds from its own parse and would drop the `echo` segment's output.
+		// Stay opaque and preserve the captured bytes verbatim.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = "## main\n M file.rs\nIMPORTANT side-effect line\n";
+		let out = apply("git status && echo IMPORTANT side-effect line", input, 0, &cfg);
+		assert!(!out.changed, "mixed chain must stay passthrough");
+		assert_eq!(out.filter, "compound");
+		assert_eq!(out.text, input, "captured output must be preserved verbatim");
+		assert!(out.text.contains("IMPORTANT side-effect line"));
+	}
+
+	#[test]
+	fn unsupported_first_segment_chain_is_passthrough() {
+		// Phase 7: chains whose first segment has no filter fall back to
+		// passthrough labeled "compound" (preserves legacy behavior).
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let out = apply("zzzobscure && zzznever", "noise\n", 0, &cfg);
+		assert!(!out.changed);
+		assert_eq!(out.filter, "compound");
+	}
+
+	#[test]
+	fn chain_legacy_filters_active_passes_through() {
+		// Phase 7 kill-switch parity (M2): legacy_filters_active=true returns
+		// passthrough.labeled("compound") regardless of segment shape.
+		let cfg =
+			MinimizerConfig { enabled: true, legacy_filters_active: true, ..Default::default() };
+		let input = "## main\n M file.rs\n";
+		let out = apply("git status && git log -1", input, 0, &cfg);
+		assert!(!out.changed);
+		assert_eq!(out.filter, "compound");
+	}
+
+	#[test]
+	fn legacy_filters_active_disables_segmented_chain() {
+		// Kill-switch parity: with the legacy filters flag set, an otherwise
+		// eligible safe chain must NOT route through the segmented runner so
+		// pre-segmentation single-exec behavior is restored.
+		let mut cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		cfg.legacy_filters_active = true;
+		assert_eq!(mode_for("git diff --stat && git diff --name-only", &cfg), MinimizerMode::None);
+		assert_eq!(mode_for("git diff ; printf done", &cfg), MinimizerMode::None);
+	}
+
+	#[test]
+	fn disabled_config_does_not_segment_chain() {
+		// With the master switch off, no chain is segmented even when a segment
+		// would otherwise be eligible.
+		let cfg = MinimizerConfig::default();
+		assert!(!cfg.enabled);
+		assert_eq!(mode_for("git diff ; printf done", &cfg), MinimizerMode::None);
+	}
+
+	#[test]
+	fn chains_with_exec_fd_mutation_are_not_segmented() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		// `exec >out` rewires the shell's stdout; segmenting would run the
+		// following segment with a fresh capture pipe and lose the redirection,
+		// returning output to the caller that should have gone to the file.
+		assert_eq!(mode_for("exec >out ; echo hi", &cfg), MinimizerMode::None);
+		assert_eq!(mode_for("exec 2>err ; git status", &cfg), MinimizerMode::None);
+		// The fd-mutating segment poisons the chain even when it is not first.
+		assert_eq!(mode_for("git status ; exec >out", &cfg), MinimizerMode::None);
+		// `exec` wrapped by `command`/`builtin` (with flags or env assignments)
+		// mutates the same fds and must also block segmentation.
+		assert_eq!(mode_for("command exec >out ; echo hi", &cfg), MinimizerMode::None);
+		assert_eq!(mode_for("builtin exec >out ; echo hi", &cfg), MinimizerMode::None);
+		assert_eq!(mode_for("git diff ; command -p exec 2>err", &cfg), MinimizerMode::None);
+		assert_eq!(mode_for("FOO=\"a b\" exec >out ; echo hi", &cfg), MinimizerMode::None);
+		assert_eq!(mode_for("FOO=\"a b\" command exec >out ; echo hi", &cfg), MinimizerMode::None);
+		// Alias mutations affect later words when segments are parsed in separate
+		// calls, so they must stay on the original single-parse path too.
+		assert_eq!(mode_for("alias cat='printf hacked' ; cat file", &cfg), MinimizerMode::None);
+		assert_eq!(mode_for("unalias cat ; cat file", &cfg), MinimizerMode::None);
+		// A real command merely named with `exec` as an argument is not the
+		// builtin and must NOT block segmentation.
+		assert_eq!(mode_for("echo exec ; printf done", &cfg), MinimizerMode::SegmentedChain);
+		// Such chains pass through untouched.
+		let out = apply("exec >out ; echo hi", "hi\n", 0, &cfg);
+		assert_eq!(out.text, "hi\n");
+		assert!(!out.changed);
 	}
 }
 

--- a/crates/pi-shell/src/minimizer/filters/binary_tools.rs
+++ b/crates/pi-shell/src/minimizer/filters/binary_tools.rs
@@ -1,0 +1,121 @@
+//! Binary-inspection tool filters (Tier 3b): `xxd`, `strings`, `od`.
+//!
+//! These tools all share the same failure mode in the minimizer's
+//! `unknown` bucket: very long head-or-tail-or-elide outputs (5000+
+//! lines) on multi-megabyte binaries dwarf the 64 KB capture budget and
+//! waste the agent's context window on repetitive hex/string dumps. We
+//! preserve the first 50 lines and last 20 lines and elide the middle
+//! with a count marker — diagnostic anchors (magic bytes at the head,
+//! footer/trailer bytes at the tail) survive intact while the bulk
+//! middle is dropped.
+
+use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
+
+const HEAD_LINES: usize = 50;
+const TAIL_LINES: usize = 20;
+
+pub fn supports(program: &str, _subcommand: Option<&str>) -> bool {
+	matches!(program, "xxd" | "strings" | "od")
+}
+
+pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerOutput {
+	// Kill-switch parity (M2): legacy_filters_active=true skips this
+	// filter so callers can rollback without recompile.
+	if ctx.config.legacy_filters_active() {
+		return MinimizerOutput::passthrough(input);
+	}
+
+	let cleaned = primitives::strip_ansi(input);
+	let total_lines = cleaned.lines().count();
+	if total_lines <= HEAD_LINES + TAIL_LINES {
+		// Short dump — passthrough. Even errored runs are tiny enough
+		// here that the head/tail cap would not help.
+		let _ = exit_code;
+		return MinimizerOutput::passthrough(input);
+	}
+
+	let text = primitives::head_tail_lines(&cleaned, HEAD_LINES, TAIL_LINES);
+	if text == input {
+		MinimizerOutput::passthrough(input)
+	} else {
+		MinimizerOutput::transformed(text, input.len())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::minimizer::MinimizerConfig;
+
+	fn ctx<'a>(program: &'a str, command: &'a str, config: &'a MinimizerConfig) -> MinimizerCtx<'a> {
+		MinimizerCtx { program, subcommand: None, command, config }
+	}
+
+	fn build_lines(prefix: &str, count: usize) -> String {
+		let mut s = String::new();
+		for i in 0..count {
+			s.push_str(&format!("{prefix}{i:08x}\n"));
+		}
+		s
+	}
+
+	#[test]
+	fn xxd_long_dump_compacts_with_head_tail_marker() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = build_lines("00000000: ", 5000);
+		let context = ctx("xxd", "xxd /bin/ls", &cfg);
+		let out = filter(&context, &input, 0);
+		assert!(out.changed);
+		// 50 head + 20 tail + 1 marker = 71 lines
+		let line_count = out.text.lines().count();
+		assert_eq!(line_count, HEAD_LINES + TAIL_LINES + 1, "got {line_count} lines: {out:?}");
+		assert!(out.text.contains("lines omitted"));
+		// Head anchor preserved.
+		assert!(out.text.starts_with("00000000: 00000000"));
+	}
+
+	#[test]
+	fn xxd_short_dump_passthrough() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = build_lines("00000000: ", 60);
+		let context = ctx("xxd", "xxd small", &cfg);
+		let out = filter(&context, &input, 0);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn strings_long_output_compacts() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = build_lines("symbol_", 2000);
+		let context = ctx("strings", "strings /bin/ls", &cfg);
+		let out = filter(&context, &input, 0);
+		assert!(out.changed);
+		assert!(out.text.contains("lines omitted"));
+	}
+
+	#[test]
+	fn od_long_output_compacts() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = build_lines("0000000 ", 1500);
+		let context = ctx("od", "od -c /bin/ls", &cfg);
+		let out = filter(&context, &input, 0);
+		assert!(out.changed);
+		assert!(out.text.contains("lines omitted"));
+	}
+
+	#[test]
+	fn binary_tools_legacy_filters_active_passes_through() {
+		// Kill-switch parity (M2).
+		let mut cfg = MinimizerConfig::default();
+		cfg.enabled = true;
+		cfg.legacy_filters_active = true;
+		let input = build_lines("00000000: ", 5000);
+		for prog in ["xxd", "strings", "od"] {
+			let context = ctx(prog, "binary-tool", &cfg);
+			let out = filter(&context, &input, 0);
+			assert!(!out.changed, "{prog} should passthrough with kill-switch");
+			assert_eq!(out.text, input);
+		}
+	}
+}

--- a/crates/pi-shell/src/minimizer/filters/bun.rs
+++ b/crates/pi-shell/src/minimizer/filters/bun.rs
@@ -5,7 +5,7 @@ use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
 
 const BUN_PACKAGE_SUBCOMMANDS: &[&str] = &[
 	"install", "i", "add", "update", "up", "upgrade", "remove", "rm", "outdated", "pm", "audit",
-	"run", "exec",
+	"run", "exec", "check",
 ];
 const BUN_TEST_SUBCOMMANDS: &[&str] = &["test"];
 const BUN_BUILD_SUBCOMMANDS: &[&str] = &["build"];
@@ -36,6 +36,9 @@ pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerO
 	{
 		return pkg::filter(ctx, input, exit_code);
 	}
+	if is_check_invocation(ctx.program, subcommand, ctx.command) {
+		return filter_bun_check(ctx, input, exit_code);
+	}
 	if is_test_invocation(ctx.program, subcommand, ctx.command) {
 		return node_tests::filter(ctx, input, exit_code);
 	}
@@ -49,6 +52,7 @@ pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerO
 		return js_tools::filter(ctx, input, exit_code);
 	}
 	match (ctx.program, subcommand) {
+		("bun", Some("check")) => filter_bun_check(ctx, input, exit_code),
 		("bun", Some(subcommand)) if BUN_PACKAGE_SUBCOMMANDS.contains(&subcommand) => {
 			pkg::filter(ctx, input, exit_code)
 		},
@@ -58,7 +62,7 @@ pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerO
 }
 
 fn is_non_exec_package_subcommand(subcommand: &str) -> bool {
-	BUN_PACKAGE_SUBCOMMANDS.contains(&subcommand) && !matches!(subcommand, "run" | "exec")
+	BUN_PACKAGE_SUBCOMMANDS.contains(&subcommand) && !matches!(subcommand, "run" | "exec" | "check")
 }
 
 fn is_test_invocation(program: &str, subcommand: Option<&str>, command: &str) -> bool {
@@ -66,33 +70,227 @@ fn is_test_invocation(program: &str, subcommand: Option<&str>, command: &str) ->
 		(program, subcommand),
 		("bun", Some("test")) | ("bunx", Some("jest" | "vitest" | "playwright"))
 	) || is_exec_package_subcommand(program, subcommand)
-		&& command_contains_tool(command, &["jest", "vitest", "playwright"])
+		&& command_invoked_word(command).is_some_and(|token| {
+			["jest", "vitest", "playwright"].contains(&token) || is_test_script_token(token)
+		})
+}
+
+fn command_invoked_word(command: &str) -> Option<&str> {
+	let mut after_marker = false;
+	let mut skip_option_value = false;
+	for raw in command.split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '|' | '&')) {
+		let token = trim_command_token(raw);
+		if token.is_empty() {
+			continue;
+		}
+		if !after_marker {
+			if matches!(token, "run" | "exec") {
+				after_marker = true;
+			}
+			continue;
+		}
+		if skip_option_value {
+			skip_option_value = false;
+			continue;
+		}
+		if token.starts_with('-') {
+			if bun_wrapper_option_takes_value(token) && !token.contains('=') {
+				skip_option_value = true;
+			}
+			continue;
+		}
+		return Some(token);
+	}
+	None
+}
+
+fn trim_command_token(token: &str) -> &str {
+	token.trim_matches(|ch| matches!(ch, '\'' | '"' | '`'))
+}
+
+fn bun_wrapper_option_takes_value(token: &str) -> bool {
+	matches!(token, "--filter" | "--cwd" | "--env-file" | "--preload" | "-F" | "-C" | "-r")
+}
+
+fn is_test_script_token(token: &str) -> bool {
+	let token = trim_command_token(token);
+	matches!(token, "test" | "t" | "e2e" | "spec") || token.starts_with("test:")
 }
 
 fn is_exec_package_subcommand(program: &str, subcommand: Option<&str>) -> bool {
 	matches!((program, subcommand), ("bun", Some("run" | "exec")))
 }
 
+fn is_check_invocation(program: &str, subcommand: Option<&str>, command: &str) -> bool {
+	is_exec_package_subcommand(program, subcommand)
+		&& command_invoked_word(command).is_some_and(is_check_script_token)
+}
+fn is_check_script_token(token: &str) -> bool {
+	let token = trim_command_token(token);
+	matches!(token, "check") || token.starts_with("check:")
+}
+
+fn is_lint_script_token(token: &str) -> bool {
+	let token = trim_command_token(token);
+	matches!(token, "lint" | "typecheck" | "type-check")
+		|| token.starts_with("lint:")
+		|| token.starts_with("typecheck:")
+		|| token.starts_with("type-check:")
+}
+
 fn is_lint_invocation(program: &str, subcommand: Option<&str>, command: &str) -> bool {
 	matches!((program, subcommand), ("bun" | "bunx", Some("tsc" | "eslint" | "biome")))
 		|| is_exec_package_subcommand(program, subcommand)
-			&& command_contains_tool(command, &["tsc", "eslint", "biome"])
+			&& command_invoked_word(command).is_some_and(|token| {
+				["tsc", "eslint", "biome"].contains(&token) || is_lint_script_token(token)
+			})
 }
 
 fn is_js_tool_invocation(program: &str, subcommand: Option<&str>, command: &str) -> bool {
 	matches!((program, subcommand), ("bun" | "bunx", Some("next" | "prettier" | "prisma")))
 		|| is_exec_package_subcommand(program, subcommand)
-			&& command_contains_tool(command, &["next", "prettier", "prisma"])
-}
-fn is_cpp_invocation(program: &str, subcommand: Option<&str>, command: &str) -> bool {
-	matches!((program, subcommand), ("bunx", Some(subcommand)) if BUN_CPP_TOOL_SUBCOMMANDS.contains(&subcommand))
-		|| is_exec_package_subcommand(program, subcommand) && cpp::supports_invocation(command)
+			&& command_invoked_word(command)
+				.is_some_and(|token| ["next", "prettier", "prisma"].contains(&token))
 }
 
-fn command_contains_tool(command: &str, tools: &[&str]) -> bool {
-	command
-		.split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '|' | '&'))
-		.any(|token| tools.contains(&token))
+fn is_cpp_invocation(program: &str, subcommand: Option<&str>, command: &str) -> bool {
+	matches!((program, subcommand), ("bunx", Some(subcommand)) if BUN_CPP_TOOL_SUBCOMMANDS.contains(&subcommand))
+		|| is_exec_package_subcommand(program, subcommand)
+			&& command_invoked_word(command).is_some_and(|token| {
+				BUN_CPP_TOOL_SUBCOMMANDS.contains(&token) || cpp::supports_invocation(token)
+			})
+}
+
+fn filter_bun_check(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerOutput {
+	let cleaned = primitives::strip_ansi(input);
+	let text = compact_bun_check_output(ctx, &cleaned, exit_code)
+		.unwrap_or_else(|| lint::condense_lint_output(ctx.program, &cleaned, exit_code));
+	if text == input {
+		MinimizerOutput::passthrough(input)
+	} else {
+		MinimizerOutput::transformed(text, input.len())
+	}
+}
+
+fn compact_bun_check_output(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> Option<String> {
+	let mut root_checked = false;
+	let mut packages: Vec<&str> = Vec::new();
+	let mut diagnostics: Vec<&str> = Vec::new();
+	let mut nonzero_exits: Vec<&str> = Vec::new();
+	let mut timeout: Option<&str> = None;
+
+	for line in input.lines() {
+		let trimmed = line.trim();
+		if trimmed.is_empty() {
+			continue;
+		}
+		let lower = trimmed.to_ascii_lowercase();
+		if lower.contains("timeout") || lower.contains("timed out") {
+			timeout = Some(trimmed);
+			continue;
+		}
+		if trimmed.starts_with("$ ") || lower.contains(" check: $ ") {
+			continue;
+		}
+		if let Some(package) = parse_checked_package(trimmed) {
+			if !packages.contains(&package) {
+				packages.push(package);
+			}
+			continue;
+		}
+		if lower.starts_with("checked ") && lower.contains("no fixes applied") {
+			root_checked = true;
+			continue;
+		}
+		if let Some(code) = parse_exited_code(trimmed) {
+			if code != "0" {
+				nonzero_exits.push(trimmed);
+			}
+			continue;
+		}
+		if is_bun_check_noise(trimmed, &lower) {
+			continue;
+		}
+		if exit_code != 0 && is_important(trimmed) {
+			diagnostics.push(trimmed);
+		}
+	}
+
+	if !root_checked && packages.is_empty() && diagnostics.is_empty() && nonzero_exits.is_empty() {
+		return None;
+	}
+
+	let mut out = String::new();
+	out.push_str(command_summary(ctx.command));
+	out.push_str(": ");
+	if !nonzero_exits.is_empty() || !diagnostics.is_empty() {
+		out.push_str("failed\n");
+	} else if timeout.is_some() {
+		out.push_str("visible checks passed; wrapper timed out\n");
+	} else if exit_code == 0 {
+		out.push_str("passed\n");
+	} else {
+		out.push_str("incomplete\n");
+	}
+	if root_checked {
+		out.push_str("root biome: ok\n");
+	}
+	if !packages.is_empty() {
+		out.push_str("packages checked: ");
+		out.push_str(&packages.join(", "));
+		out.push('\n');
+	}
+	if let Some(timeout) = timeout {
+		out.push_str("timeout: ");
+		out.push_str(trim_notice_brackets(timeout));
+		out.push('\n');
+	}
+	for line in nonzero_exits.iter().chain(diagnostics.iter()).take(40) {
+		out.push_str(line);
+		out.push('\n');
+	}
+	let omitted = nonzero_exits.len() + diagnostics.len();
+	if omitted > 40 {
+		out.push_str("… ");
+		out.push_str(&(omitted - 40).to_string());
+		out.push_str(" diagnostic lines omitted\n");
+	}
+	Some(out)
+}
+
+fn command_summary(command: &str) -> &str {
+	let mut parts = command.split_whitespace();
+	match (parts.next(), parts.next(), parts.next()) {
+		(Some("bun"), Some("run"), Some(script)) => {
+			script.trim_matches(|ch| matches!(ch, '\'' | '"' | '`'))
+		},
+		_ => "bun check",
+	}
+}
+
+fn parse_checked_package(line: &str) -> Option<&str> {
+	let (package, rest) = line.split_once(" check: Checked ")?;
+	if rest.contains("No fixes applied") {
+		Some(package)
+	} else {
+		None
+	}
+}
+
+fn parse_exited_code(line: &str) -> Option<&str> {
+	let (_, code) = line.rsplit_once("Exited with code ")?;
+	Some(code.trim())
+}
+
+fn is_bun_check_noise(line: &str, lower: &str) -> bool {
+	line.starts_with("$ ")
+		|| lower.contains(" check: $ ")
+		|| lower.starts_with("checked ")
+		|| lower.ends_with("no fixes applied.")
+}
+
+fn trim_notice_brackets(line: &str) -> &str {
+	line.trim_matches(|ch| matches!(ch, '[' | ']' | '⟦' | '⟧'))
 }
 
 fn filter_bun_build(input: &str, exit_code: i32) -> MinimizerOutput {
@@ -155,12 +353,29 @@ mod tests {
 
 	#[test]
 	fn supports_bun_package_test_and_tool_subcommands() {
-		for subcommand in ["install", "add", "run", "test", "build", "tsc", "next", "ctest"] {
+		for subcommand in ["install", "add", "run", "test", "build", "tsc", "next", "ctest", "check"]
+		{
 			assert!(supports("bun", Some(subcommand)), "{subcommand} should be supported");
 		}
 		assert!(supports("bunx", Some("vitest")));
 		assert!(supports("bunx", Some("cmake")));
 		assert!(!supports("bun", Some("unknown")));
+	}
+
+	#[test]
+	fn bun_check_direct_subcommand_is_supported_and_routes_to_check_filter() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		// supports() must admit "check" as a subcommand
+		assert!(supports("bun", Some("check")), "bun check should be supported");
+		// filter() must route directly to filter_bun_check
+		let ctx = ctx("bun", Some("check"), "bun check", &cfg);
+		let biome_output = "packages/coding-agent/src/foo.ts:1:1 lint/suspicious/noExplicitAny \
+		                    ━━━━━━━━━\n\n  ✖ Unexpected any.\n\nChecked 127 files in 234ms. 1 error \
+		                    found.\n";
+		let out = filter(&ctx, biome_output, 1);
+		assert!(out.changed, "bun check output should be changed/compressed");
+		// should not route to pkg::filter (which would strip the error details)
+		assert!(out.text.contains("error"), "check filter must preserve error output");
 	}
 
 	#[test]
@@ -245,5 +460,276 @@ mod tests {
 		);
 		assert!(!out.text.contains("Bundled 12 modules"));
 		assert!(out.text.contains("error: missing export"));
+	}
+
+	#[test]
+	fn bun_run_test_routes_to_node_tests() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("bun", Some("run"), "bun run test", &cfg);
+		let out = filter(&ctx, "✓ pass 1\n✓ pass 2\nFAIL app.test.ts\nTests 1 failed, 2 passed\n", 1);
+		assert!(!out.text.contains("✓ pass 1"));
+		assert!(out.text.contains("FAIL app.test.ts"));
+		assert!(out.text.contains("Tests 1 failed, 2 passed"));
+	}
+
+	#[test]
+	fn bun_run_lint_and_typecheck_route_to_lint_filter() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = concat!(
+			"src/app.ts:1:1: error TS2322: Type 'string' is not assignable to type 'number'.\n",
+			"src/app.ts:2:1: error TS7006: Parameter 'x' implicitly has an 'any' type.\n",
+		);
+
+		for command in
+			["bun run lint", "bun run lint:ci", "bun run typecheck", "bun run typecheck:ci"]
+		{
+			let ctx = ctx("bun", Some("run"), command, &cfg);
+			let routed = filter(&ctx, input, 1).text;
+			let expected = lint::filter(&ctx, input, 1).text;
+			assert_eq!(routed, expected, "{command} should use lint filter");
+			assert!(
+				routed.contains("2 diagnostics in 1 files"),
+				"{command} should condense lint output"
+			);
+		}
+	}
+
+	#[test]
+	fn quoted_bun_run_test_routes_to_node_tests() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("bun", Some("run"), "bun run 'test'", &cfg);
+		let out = filter(&ctx, "✓ pass 1\nFAIL app.test.ts\nTests 1 failed, 1 passed\n", 1);
+		assert!(!out.text.contains("✓ pass 1"));
+		assert!(out.text.contains("FAIL app.test.ts"));
+	}
+
+	#[test]
+	fn bun_run_test_colon_routes_to_node_tests() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("bun", Some("run"), "bun run test:unit", &cfg);
+		let out = filter(&ctx, "✓ passes\nFAIL src/example.test.ts\nTests 1 failed, 1 passed\n", 1);
+		assert!(!out.text.contains("✓ passes"));
+		assert!(out.text.contains("FAIL src/example.test.ts"));
+	}
+
+	#[test]
+	fn bun_run_e2e_routes_to_node_tests() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("bun", Some("run"), "bun run e2e", &cfg);
+		let out = filter(&ctx, "✓ passes\nFAIL e2e/spec.ts\nTests 1 failed, 1 passed\n", 1);
+		assert!(!out.text.contains("✓ passes"));
+		assert!(out.text.contains("FAIL e2e/spec.ts"));
+	}
+
+	#[test]
+	fn bun_run_check_colon_compacts_workspace_success_noise() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("bun", Some("run"), "bun run 'check:ts'", &cfg);
+		let out = filter(
+			&ctx,
+			"$ bun run check:tools && bun run --workspaces --if-present check\n$ biome check . \
+			 --no-errors-on-unmatched\nChecked 1690 files in 371ms. No fixes \
+			 applied.\n@oh-my-pi/pi-utils check: Checked 40 files in 11ms. No fixes \
+			 applied.\n@oh-my-pi/pi-utils check: $ tsgo -p tsconfig.json \
+			 --noEmit\n@oh-my-pi/pi-utils check: Exited with code 0\n@oh-my-pi/pi-coding-agent \
+			 check: Checked 1178 files in 287ms. No fixes applied.\n@oh-my-pi/pi-coding-agent check: \
+			 $ tsgo -p tsconfig.json --noEmit\n@oh-my-pi/pi-coding-agent check: Exited with code 0\n",
+			0,
+		);
+
+		assert!(out.text.contains("check:ts: passed"));
+		assert!(out.text.contains("root biome: ok"));
+		assert!(out.text.contains("@oh-my-pi/pi-utils"));
+		assert!(out.text.contains("@oh-my-pi/pi-coding-agent"));
+		assert!(!out.text.contains("No fixes applied"));
+		assert!(!out.text.contains("tsgo -p"));
+		assert!(!out.text.contains("Exited with code 0"));
+	}
+
+	#[test]
+	fn bun_run_check_timeout_preserves_ambiguous_success() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("bun", Some("run"), "bun run check:ts", &cfg);
+		let out = filter(
+			&ctx,
+			"@oh-my-pi/pi-utils check: Checked 40 files in 11ms. No fixes \
+			 applied.\n@oh-my-pi/pi-utils check: Exited with code 0\n[Command timed out after 300 \
+			 seconds]\n",
+			1,
+		);
+
+		assert!(
+			out.text
+				.contains("visible checks passed; wrapper timed out")
+		);
+		assert!(
+			out.text
+				.contains("timeout: Command timed out after 300 seconds")
+		);
+		assert!(!out.text.contains("failed"));
+	}
+
+	#[test]
+	fn bun_run_build_still_uses_pkg_filter() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("bun", Some("run"), "bun run build", &cfg);
+		let out = filter(&ctx, "Resolving dependencies\nDownloaded foo\nerror: failed\n", 1);
+		assert!(!out.text.contains("Resolving dependencies"));
+		assert!(out.text.contains("error: failed"));
+	}
+
+	#[test]
+	fn bun_run_build_argument_named_test_stays_on_package_filter() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("bun", Some("run"), "bun run build -- test", &cfg);
+		let out = filter(&ctx, "PASS emitted by build\n✓ emitted by build\nerror: failed\n", 1);
+		assert!(out.text.contains("PASS emitted by build"));
+		assert!(out.text.contains("✓ emitted by build"));
+		assert!(out.text.contains("error: failed"));
+	}
+
+	// --- bun test failure — failure lines and summary survive ---
+
+	#[test]
+	fn bun_test_failure_keeps_fail_file_and_summary() {
+		// `bun test` failure: FAIL lines, error text, and the totals line
+		// must survive.  Passing checkmarks must be stripped.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let bun_ctx = ctx("bun", Some("test"), "bun test", &cfg);
+		let input = concat!(
+			"✓ auth.test.ts > login passes (12ms)\n",
+			"✓ auth.test.ts > logout ok (8ms)\n",
+			"FAIL auth.test.ts\n",
+			"● register fails when email taken\n",
+			"  Error: expected status 409, got 200\n",
+			"      at auth.test.ts:88:5\n",
+			"Tests 1 failed, 2 passed (33ms)\n",
+		);
+
+		let out = filter(&bun_ctx, input, 1);
+
+		assert!(
+			!out.text.contains("✓ auth.test.ts > login"),
+			"passing lines must be stripped: {:?}",
+			out.text
+		);
+		assert!(out.text.contains("FAIL auth.test.ts"), "FAIL line must survive: {:?}", out.text);
+		assert!(
+			out.text.contains("Error: expected status 409"),
+			"error body must survive: {:?}",
+			out.text
+		);
+		assert!(out.text.contains("Tests 1 failed"), "summary line must survive: {:?}", out.text);
+		assert!(out.text.contains("2 passed"), "passed count must survive: {:?}", out.text);
+	}
+
+	#[test]
+	fn bun_test_success_strips_all_pass_lines() {
+		// On success all ✓ lines are noise — the agent only needs the summary.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let bun_ctx = ctx("bun", Some("test"), "bun test", &cfg);
+		let input = concat!(
+			"✓ foo.test.ts > passes (5ms)\n",
+			"✓ bar.test.ts > also passes (3ms)\n",
+			"Tests 2 passed (8ms)\n",
+		);
+
+		let out = filter(&bun_ctx, input, 0);
+
+		assert!(
+			!out.text.contains("✓ foo.test.ts"),
+			"passing lines must be stripped: {:?}",
+			out.text
+		);
+		assert!(
+			!out.text.contains("✓ bar.test.ts"),
+			"passing lines must be stripped: {:?}",
+			out.text
+		);
+		// Summary or some indication of passing must survive.
+		assert!(
+			out.text.contains("passed") || !out.changed,
+			"summary must survive or output unchanged"
+		);
+	}
+
+	// --- bun check failure — diagnostic lines survive, noise stripped ---
+
+	#[test]
+	fn bun_check_failure_keeps_diagnostic_and_emits_failed_status() {
+		// `bun check` (routed via `bun run check:ts`) with real type errors
+		// must surface the diagnostic lines and emit a `failed` verdict.
+		// Package-manager download noise and `Exited with code 0` lines
+		// must not appear.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let bun_ctx = ctx("bun", Some("run"), "bun run check:ts", &cfg);
+		let input = concat!(
+			"$ bun run --workspaces check\n",
+			"@oh-my-pi/pi-utils check: $ tsgo -p tsconfig.json --noEmit\n",
+			"@oh-my-pi/pi-utils check: Exited with code 0\n",
+			"@oh-my-pi/pi-coding-agent check: $ tsgo -p tsconfig.json --noEmit\n",
+			"src/tools/bash.ts(42,7): error TS2322: Type 'string' is not assignable to type \
+			 'number'.\n",
+			"@oh-my-pi/pi-coding-agent check: Exited with code 1\n",
+		);
+
+		let out = filter(&bun_ctx, input, 1);
+
+		assert!(out.text.contains("failed"), "failed verdict must appear: {:?}", out.text);
+		assert!(out.text.contains("error TS2322"), "diagnostic must survive: {:?}", out.text);
+		assert!(
+			!out.text.contains("tsgo -p"),
+			"internal command lines must be stripped: {:?}",
+			out.text
+		);
+		// Nonzero exit lines are preserved as evidence (code 0 exits are stripped).
+		assert!(
+			out.text.contains("Exited with code 1"),
+			"nonzero exit line must survive as evidence: {:?}",
+			out.text
+		);
+		assert!(
+			!out.text.contains("Exited with code 0"),
+			"zero exit noise must be stripped: {:?}",
+			out.text
+		);
+	}
+
+	#[test]
+	fn bun_check_success_emits_passed_status_and_no_noise() {
+		// Clean `bun run check:ts` (all packages exit 0) must compact to a
+		// single `passed` summary line without biome/tsgo details.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let bun_ctx = ctx("bun", Some("run"), "bun run check:ts", &cfg);
+		let input = concat!(
+			"$ bun run --workspaces check\n",
+			"Checked 1690 files in 371ms. No fixes applied.\n",
+			"@oh-my-pi/pi-utils check: Checked 40 files in 11ms. No fixes applied.\n",
+			"@oh-my-pi/pi-utils check: $ tsgo -p tsconfig.json --noEmit\n",
+			"@oh-my-pi/pi-utils check: Exited with code 0\n",
+			"@oh-my-pi/pi-coding-agent check: Checked 1178 files in 287ms. No fixes applied.\n",
+			"@oh-my-pi/pi-coding-agent check: $ tsgo -p tsconfig.json --noEmit\n",
+			"@oh-my-pi/pi-coding-agent check: Exited with code 0\n",
+		);
+
+		let out = filter(&bun_ctx, input, 0);
+
+		assert!(out.changed, "clean check must be compacted");
+		assert!(out.text.contains("passed"), "passed verdict must appear: {:?}", out.text);
+		assert!(
+			!out.text.contains("No fixes applied"),
+			"biome noise must be stripped: {:?}",
+			out.text
+		);
+		assert!(
+			!out.text.contains("tsgo -p"),
+			"internal command lines must be stripped: {:?}",
+			out.text
+		);
+		assert!(
+			!out.text.contains("Exited with code"),
+			"exit noise must be stripped: {:?}",
+			out.text
+		);
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/cargo.rs
+++ b/crates/pi-shell/src/minimizer/filters/cargo.rs
@@ -1,5 +1,7 @@
 //! Cargo build/test output filters.
 
+use std::{collections::BTreeMap, fmt::Write as _};
+
 use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
 
 pub fn supports(subcommand: Option<&str>) -> bool {
@@ -26,9 +28,11 @@ pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerO
 		Some("metadata") => input.to_string(),
 		Some("test" | "bench") => failures_only(&cleaned, exit_code),
 		Some("nextest") => filter_nextest(&cleaned),
-		Some("build" | "check" | "clippy" | "doc" | "run") => condense_build(&cleaned),
+		Some("clippy") => filter_clippy(&cleaned, exit_code),
+		Some("build" | "check" | "doc" | "run") => condense_build(&cleaned),
 		Some("fmt") => condense_fmt(&cleaned),
-		Some("tree" | "update" | "install" | "publish") => compact_general(&cleaned),
+		Some("install") => filter_install(&cleaned, exit_code),
+		Some("tree" | "update" | "publish") => compact_general(&cleaned),
 		_ => cleaned,
 	};
 	if text == input {
@@ -289,6 +293,182 @@ fn is_general_cargo_noise(line: &str) -> bool {
 		|| trimmed.starts_with("Checking ")
 		|| trimmed.starts_with("Fresh ")
 }
+/// Filter `cargo install` output: strip compilation/download noise, keep
+/// install/error summaries.
+fn filter_install(input: &str, exit_code: i32) -> String {
+	let stripped = primitives::strip_lines(input, &[is_compiling_noise]);
+
+	if exit_code != 0 {
+		return primitives::head_tail_lines(&stripped, 100, 40);
+	}
+
+	let mut summaries = String::new();
+	for line in stripped.lines() {
+		let trimmed = line.trim_start();
+		if is_install_summary(trimmed) || trimmed.starts_with("WARNING:") {
+			summaries.push_str(line);
+			summaries.push('\n');
+		}
+	}
+
+	if summaries.is_empty() {
+		let deduped = primitives::dedup_consecutive_lines(&stripped);
+		primitives::head_tail_lines(&deduped, 60, 20)
+	} else {
+		primitives::dedup_consecutive_lines(&summaries)
+	}
+}
+
+fn is_install_summary(line: &str) -> bool {
+	line.starts_with("Installed ")
+		|| line.starts_with("Replaced ")
+		|| line.starts_with("Replacing ")
+		|| line.starts_with("Ignored ")
+}
+
+#[derive(Debug)]
+struct ClippyWarning {
+	location:  String,
+	message:   String,
+	lint_rule: Option<String>,
+}
+
+/// Filter `cargo clippy`: group warnings by lint rule; keep errors verbatim.
+fn filter_clippy(input: &str, exit_code: i32) -> String {
+	let no_noise = primitives::strip_lines(input, &[is_compiling_noise]);
+
+	let has_compile_error = no_noise.lines().any(|l| {
+		let t = l.trim_start();
+		(t.starts_with("error:")
+			&& !t.starts_with("error: could not compile")
+			&& !t.starts_with("error: aborting"))
+			|| t.starts_with("error[")
+	});
+
+	if has_compile_error {
+		let grouped = primitives::group_by_file(&no_noise, 20);
+		return primitives::head_tail_lines(&grouped, 120, 60);
+	}
+
+	let warnings = parse_clippy_warnings(&no_noise);
+	if warnings.is_empty() {
+		let deduped = primitives::dedup_consecutive_lines(&no_noise);
+		return primitives::head_tail_lines(&deduped, 80, 40);
+	}
+
+	format_clippy_grouped(&warnings, exit_code)
+}
+
+fn parse_clippy_warnings(input: &str) -> Vec<ClippyWarning> {
+	let mut warnings = Vec::new();
+	let lines: Vec<&str> = input.lines().collect();
+	let mut i = 0;
+
+	while i < lines.len() {
+		let trimmed = lines[i].trim();
+		if !trimmed.starts_with("warning: ") {
+			i += 1;
+			continue;
+		}
+
+		let msg = trimmed.strip_prefix("warning: ").unwrap_or("");
+		// Skip summary lines like "warning: `crate` (lib) generated N warning(s)"
+		if msg.contains(" generated ") && (msg.ends_with(" warnings") || msg.ends_with(" warning")) {
+			i += 1;
+			continue;
+		}
+
+		let message = msg.to_string();
+		let mut location = String::new();
+		let mut lint_rule = None;
+
+		i += 1;
+		while i < lines.len() {
+			let t = lines[i].trim();
+			if t.starts_with("--> ") {
+				location = t.strip_prefix("--> ").unwrap_or("").to_string();
+			}
+			if let Some(rule) = extract_lint_rule(t) {
+				lint_rule = Some(rule);
+			}
+			i += 1;
+			if i >= lines.len() {
+				break;
+			}
+			let next = lines[i].trim();
+			if next.starts_with("warning: ")
+				|| next.starts_with("error:")
+				|| next.starts_with("error[")
+			{
+				break;
+			}
+		}
+
+		if !message.is_empty() {
+			warnings.push(ClippyWarning { location, message, lint_rule });
+		}
+	}
+
+	warnings
+}
+
+fn extract_lint_rule(line: &str) -> Option<String> {
+	let line = line.trim();
+	if !line.starts_with("= note:") {
+		return None;
+	}
+	let after_note = line.strip_prefix("= note:")?.trim();
+	let rest = after_note
+		.strip_prefix("`#[warn(")
+		.or_else(|| after_note.strip_prefix("`#[deny("))
+		.or_else(|| after_note.strip_prefix("`#[allow("))?;
+	Some(rest.split(")]`").next()?.to_string())
+}
+
+fn format_clippy_grouped(warnings: &[ClippyWarning], exit_code: i32) -> String {
+	let mut groups: BTreeMap<String, Vec<&ClippyWarning>> = BTreeMap::new();
+	let mut ungrouped = Vec::new();
+
+	for w in warnings {
+		if let Some(ref rule) = w.lint_rule {
+			groups.entry(rule.clone()).or_default().push(w);
+		} else {
+			ungrouped.push(w);
+		}
+	}
+
+	let mut out = String::new();
+
+	for (rule, warns) in &groups {
+		if warns.len() == 1 {
+			let loc = if warns[0].location.is_empty() {
+				String::new()
+			} else {
+				format!("{}  ", warns[0].location)
+			};
+			let _ = writeln!(out, "clippy: {} — {}{}", rule, loc, warns[0].message);
+		} else {
+			let _ = writeln!(out, "clippy: {} ({} warnings)", rule, warns.len());
+			for w in warns {
+				let _ = writeln!(out, "  {}  {}", w.location, w.message);
+			}
+		}
+	}
+
+	for w in &ungrouped {
+		let _ = writeln!(out, "clippy warning: {}  {}", w.location, w.message);
+	}
+
+	if exit_code != 0 {
+		out.push_str("(clippy found issues)\n");
+	}
+
+	if out.is_empty() {
+		"cargo clippy: ok\n".to_string()
+	} else {
+		out
+	}
+}
 
 #[cfg(test)]
 mod tests {
@@ -337,21 +517,170 @@ mod tests {
 		assert!(out.contains("stdout text"));
 		assert!(out.contains("Summary [0.2s] 2 tests run: 1 passed, 1 failed"));
 	}
+	#[test]
+	fn install_strips_noise_keeps_summary() {
+		assert!(supports(Some("install")));
+		let input = concat!(
+			"    Updating crates.io index\n",
+			"  Downloaded foo v1.0.0\n",
+			"   Compiling bar v0.1.0\n",
+			"   Compiling tool v3.0.0\n",
+			"    Finished release [optimized] target(s) in 45.2s\n",
+			"  Installing /home/user/.cargo/bin/tool\n",
+			"   Installed package `tool v3.0.0` (executable `tool`)\n",
+		);
+		let out = filter_install(input, 0);
+		assert!(!out.contains("Compiling"));
+		assert!(!out.contains("Downloaded"));
+		assert!(!out.contains("Updating"));
+		assert!(!out.contains("Finished"));
+		assert!(out.contains("Installed package `tool v3.0.0`"));
+	}
 
 	#[test]
-	fn install_uses_general_head_tail_dedup_strategy() {
-		assert!(supports(Some("install")));
-		let mut input = "Downloading crate\n".repeat(2);
-		input.push_str("Installed package `tool v1.0.0`\n");
-		for i in 0..130 {
-			input.push_str("line ");
-			input.push_str(&i.to_string());
-			input.push('\n');
-		}
-		let out = compact_general(&input);
-		assert!(!out.contains("Downloading crate"));
-		assert!(out.contains("Installed package `tool v1.0.0`"));
-		assert!(out.contains("lines omitted"));
+	fn install_already_installed() {
+		let input = concat!(
+			"    Updating crates.io index\n",
+			"     Ignored package `tool v1.0.0` is already installed, use --force to override\n",
+		);
+		let out = filter_install(input, 0);
+		assert!(!out.contains("Updating"));
+		assert!(out.contains("Ignored package `tool v1.0.0`"));
+	}
+
+	#[test]
+	fn install_error_preserves_context() {
+		let input = concat!(
+			"    Updating crates.io index\n",
+			"   Compiling foo v0.1.0\n",
+			"error[E0425]: cannot find value `x` in this scope\n",
+			" --> src/main.rs:5:9\n",
+			"  |\n",
+			"5 |     let y = x;\n",
+			"  |             ^ not found in this scope\n",
+			"error: could not compile `foo` due to 1 previous error\n",
+		);
+		let out = filter_install(input, 1);
+		assert!(!out.contains("Compiling"));
+		assert!(!out.contains("Updating"));
+		assert!(out.contains("error[E0425]"));
+		assert!(out.contains("cannot find value `x`"));
+	}
+
+	#[test]
+	fn clippy_groups_warnings_by_lint_rule() {
+		assert!(supports(Some("clippy")));
+		let input = concat!(
+			"    Checking foo v0.1.0\n",
+			"warning: unused variable: `x`\n",
+			" --> src/lib.rs:2:9\n",
+			"  |\n",
+			"2 |     let x = 1;\n",
+			"  |         ^ help: if this is intentional, prefix with an underscore: `_x`\n",
+			"  |\n",
+			"  = note: `#[warn(unused_variables)]` on by default\n",
+			"\n",
+			"warning: unused variable: `y`\n",
+			" --> src/lib.rs:5:9\n",
+			"  |\n",
+			"5 |     let y = 2;\n",
+			"  |         ^ help: if this is intentional, prefix with an underscore: `_y`\n",
+			"  |\n",
+			"  = note: `#[warn(unused_variables)]` on by default\n",
+			"\n",
+			"warning: `foo` (lib) generated 2 warnings\n",
+		);
+		let out = filter_clippy(input, 0);
+		assert!(!out.contains("Checking"));
+		assert!(!out.contains("generated"));
+		assert!(out.contains("unused_variables"));
+		assert!(out.contains("2 warnings"));
+		assert!(out.contains("src/lib.rs:2:9"));
+		assert!(out.contains("src/lib.rs:5:9"));
+	}
+
+	#[test]
+	fn clippy_single_warning_compact() {
+		let input = concat!(
+			"warning: redundant clone\n",
+			" --> src/main.rs:10:3\n",
+			"  |\n",
+			"10|     foo.clone()\n",
+			"  |     ^^^^^^^^^^^^ help: remove this\n",
+			"  |\n",
+			"  = note: `#[warn(clippy::redundant_clone)]` on by default\n",
+			"\n",
+			"warning: `foo` (bin \"foo\") generated 1 warning\n",
+		);
+		let out = filter_clippy(input, 0);
+		assert!(!out.contains("generated"));
+		assert!(out.contains("clippy::redundant_clone"));
+		assert!(out.contains("src/main.rs:10:3"));
+		assert!(out.contains("redundant clone"));
+	}
+
+	#[test]
+	fn clippy_multiple_rules_grouped_separately() {
+		let input = concat!(
+			"warning: unused variable: `x`\n",
+			" --> src/lib.rs:2:9\n",
+			"  |\n",
+			"2 |     let x = 1;\n",
+			"  |         ^\n",
+			"  |\n",
+			"  = note: `#[warn(unused_variables)]` on by default\n",
+			"\n",
+			"warning: redundant clone\n",
+			" --> src/main.rs:10:3\n",
+			"  |\n",
+			"10|     foo.clone()\n",
+			"  |     ^^^^^^^^^^^^ help: remove this\n",
+			"  |\n",
+			"  = note: `#[warn(clippy::redundant_clone)]` on by default\n",
+			"\n",
+			"warning: `foo` (lib) generated 2 warnings\n",
+		);
+		let out = filter_clippy(input, 0);
+		assert!(out.contains("unused_variables"));
+		assert!(out.contains("clippy::redundant_clone"));
+		// Two separate groups, not merged
+		let unused_pos = out.find("unused_variables").unwrap();
+		let clone_pos = out.find("clippy::redundant_clone").unwrap();
+		assert!(unused_pos != clone_pos);
+	}
+
+	#[test]
+	fn clippy_compile_error_falls_back_to_build_style() {
+		let input = concat!(
+			"   Compiling foo v0.1.0\n",
+			"error[E0425]: cannot find value `x` in this scope\n",
+			" --> src/lib.rs:5:9\n",
+			"  |\n",
+			"5 |     let y = x;\n",
+			"  |             ^ not found in this scope\n",
+			"error: could not compile `foo` due to 1 previous error\n",
+		);
+		let out = filter_clippy(input, 1);
+		assert!(!out.contains("Compiling"));
+		assert!(out.contains("error[E0425]"));
+		assert!(out.contains("cannot find value `x`"));
+		// Should NOT have clippy: prefix since it fell back to build style
+		assert!(!out.contains("clippy:"));
+	}
+
+	#[test]
+	fn clippy_exit_code_signals_issues() {
+		let input = concat!(
+			"warning: unused variable: `x`\n",
+			" --> src/lib.rs:2:9\n",
+			"  |\n",
+			"2 |     let x = 1;\n",
+			"  |         ^\n",
+			"  |\n",
+			"  = note: `#[deny(unused_variables)]` on by default\n",
+		);
+		let out = filter_clippy(input, 1);
+		assert!(out.contains("(clippy found issues)"));
 	}
 
 	#[test]
@@ -367,5 +696,122 @@ mod tests {
 		let out = filter(&ctx, input, 0);
 		assert_eq!(out.text, input);
 		assert!(!out.changed);
+	}
+
+	// --- cargo test failure — failure block and panic line survive ---
+
+	#[test]
+	fn cargo_test_failure_keeps_thread_panic_and_failures_block() {
+		// `cargo test` with exit 101 must surface the thread panic message,
+		// the `failures:` block listing the failing test names, and the
+		// `test result: FAILED` summary line.  Passing test lines and
+		// `Compiling` noise must not appear.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = MinimizerCtx {
+			program:    "cargo",
+			subcommand: Some("test"),
+			command:    "cargo test",
+			config:     &cfg,
+		};
+		let input = concat!(
+			"   Compiling pi-shell v0.1.0\n",
+			"running 3 tests\n",
+			"test ok_one ... ok\n",
+			"test ok_two ... ok\n",
+			"test bad_parse ... FAILED\n",
+			"\n",
+			"---- bad_parse stdout ----\n",
+			"thread 'bad_parse' panicked at 'assertion failed: result.is_ok()', src/lib.rs:42:5\n",
+			"note: run with RUST_BACKTRACE=1 for a backtrace.\n",
+			"\n",
+			"failures:\n",
+			"    bad_parse\n",
+			"\n",
+			"test result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured\n",
+		);
+
+		let out = filter(&ctx, input, 101);
+
+		// Failure evidence must survive.
+		assert!(
+			out.text.contains("thread 'bad_parse' panicked"),
+			"panic line must survive: {:?}",
+			out.text
+		);
+		assert!(out.text.contains("failures:\n"), "failures block must survive: {:?}", out.text);
+		assert!(out.text.contains("bad_parse"), "failing test name must survive: {:?}", out.text);
+		assert!(out.text.contains("test result: FAILED"), "result line must survive: {:?}", out.text);
+		// Noise must be stripped.
+		assert!(!out.text.contains("Compiling"), "Compiling noise must be stripped");
+		assert!(!out.text.contains("test ok_one"), "passing test lines must be stripped");
+		assert!(!out.text.contains("test ok_two"), "passing test lines must be stripped");
+	}
+
+	#[test]
+	fn cargo_test_success_via_filter_produces_one_line_summary() {
+		// The token-savings contract: a full passing run must collapse to a
+		// single `cargo test: N passed (M suite[s])` line through filter(),
+		// not through the helper directly.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = MinimizerCtx {
+			program:    "cargo",
+			subcommand: Some("test"),
+			command:    "cargo test --workspace",
+			config:     &cfg,
+		};
+		let input = concat!(
+			"   Compiling pi-shell v0.1.0\n",
+			"running 42 tests\n",
+			"test a ... ok\n",
+			"test b ... ok\n",
+			"test result: ok. 42 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n",
+			"running 18 tests\n",
+			"test c ... ok\n",
+			"test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out\n",
+			"warning: `pi-shell` (test \"integration\") generated 2 warnings\n",
+		);
+
+		let out = filter(&ctx, input, 0);
+
+		assert!(out.changed, "successful run must be compacted");
+		// One-line summary: total passed, suite count, warnings.
+		assert!(out.text.contains("60 passed"), "total across suites must be summed: {:?}", out.text);
+		assert!(out.text.contains("2 suites"), "suite count must appear: {:?}", out.text);
+		assert!(out.text.contains("2 warnings"), "warning count must appear: {:?}", out.text);
+		// No per-test lines.
+		assert!(!out.text.contains("test a"), "individual test lines must be stripped");
+		assert!(!out.text.contains("Compiling"), "Compiling noise must be stripped");
+	}
+
+	#[test]
+	fn cargo_test_failure_exit_code_non_zero_is_not_summarized() {
+		// A run that reports `test result: ok` but then exits non-zero
+		// (e.g. a post-test hook failing) must not be falsely summarized
+		// as a clean pass — failures_only should fall through to condense_build
+		// rather than fabricating a `cargo test: N passed` line.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = MinimizerCtx {
+			program:    "cargo",
+			subcommand: Some("test"),
+			command:    "cargo test",
+			config:     &cfg,
+		};
+		// The test suite itself says ok, but a subsequent build step failed.
+		let input = concat!(
+			"running 1 tests\n",
+			"test it_works ... ok\n",
+			"test result: ok. 1 passed; 0 failed\n",
+			"error: could not compile `pi-shell` due to 1 previous error\n",
+		);
+
+		let out = filter(&ctx, input, 1);
+
+		// Must not emit a clean "cargo test: N passed" summary because exit was
+		// non-zero.
+		assert!(
+			!out.text.starts_with("cargo test:"),
+			"must not fabricate a pass summary on non-zero exit: {:?}",
+			out.text
+		);
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/cloud.rs
+++ b/crates/pi-shell/src/minimizer/filters/cloud.rs
@@ -1,9 +1,32 @@
 //! Cloud and data command output filters.
 
+use std::fmt::Write as _;
+
+use serde_json::{Map, Value};
+
 use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
 
 const MAX_PSQL_ROWS: usize = 30;
 const MAX_LINE_CHARS: usize = 500;
+const MAX_AWS_ROWS: usize = 40;
+
+const SENSITIVE_AWS_KEYS: &[&str] = &[
+	"Policy",
+	"PolicyDocument",
+	"AssumeRolePolicyDocument",
+	"Environment",
+	"SecretString",
+	"SecretBinary",
+	"Token",
+	"SessionToken",
+	"Credentials",
+	"Password",
+	"PrivateKey",
+	"KeyMaterial",
+	"PlaintextKeyMaterial",
+	"CiphertextBlob",
+	"ResponseMetadata",
+];
 
 pub fn supports(program: &str, _subcommand: Option<&str>) -> bool {
 	matches!(program, "aws" | "curl" | "wget" | "psql")
@@ -12,9 +35,15 @@ pub fn supports(program: &str, _subcommand: Option<&str>) -> bool {
 pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerOutput {
 	let cleaned = primitives::strip_ansi(input);
 	let text = match ctx.program {
-		"aws" => filter_aws(&cleaned, exit_code),
-		"curl" | "wget" => filter_http_transfer(&cleaned, exit_code),
-		"psql" => filter_psql(&cleaned, exit_code),
+		"aws" => filter_aws(ctx, &cleaned, exit_code),
+		"curl" | "wget" => filter_http_transfer(ctx, &cleaned, exit_code),
+		"psql" => {
+			if is_psql_machine_readable(ctx.command) {
+				cleaned
+			} else {
+				filter_psql(&cleaned, exit_code)
+			}
+		},
 		_ => head_tail_dedup(&cleaned, 80, 40),
 	};
 
@@ -25,8 +54,56 @@ pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerO
 	}
 }
 
-fn filter_aws(input: &str, _exit_code: i32) -> String {
+/// Returns `true` when the full command is `aws s3 ls [...]` (not `cp`, `sync`,
+/// `rm`, etc.). Skips flags between `s3` and the action token so
+/// `aws --no-cli-pager s3 ls` is still recognised while `aws s3 cp` is
+/// excluded.
+fn is_s3_ls(command: &str) -> bool {
+	let mut past_s3 = false;
+	for token in command.split_whitespace() {
+		if !past_s3 {
+			if token == "s3" {
+				past_s3 = true;
+			}
+		} else if token.starts_with('-') {
+			// skip flags between "s3" and the action word
+		} else {
+			return token == "ls";
+		}
+	}
+	false
+}
+
+/// Returns `true` when an AWS CLI invocation streams object content to
+/// stdout (`-` as the destination), e.g. `aws s3 cp s3://bucket/key -`.
+/// In that mode the captured text is the object body, not CLI progress,
+/// so `strip_transfer_progress` must not run.
+fn is_aws_stdout_pipe(command: &str) -> bool {
+	command
+		.split_whitespace()
+		.rfind(|token| *token == "-" || !token.starts_with('-'))
+		.is_some_and(|token| token == "-")
+}
+
+fn filter_aws(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> String {
+	if is_aws_stdout_pipe(ctx.command) {
+		return input.to_string();
+	}
+
 	let without_progress = strip_transfer_progress(input);
+	// Only the `ls` listing form should be reshaped into a bucket/date table;
+	// `aws s3 cp`/`sync`/`rm` emit progress/result lines (`upload: ... to
+	// s3://...`) that must not be misparsed as listing rows.
+	if exit_code == 0
+		&& ctx.subcommand == Some("s3")
+		&& is_s3_ls(ctx.command)
+		&& let Some(compacted) = compact_aws_s3_ls_text(&without_progress)
+	{
+		return compacted;
+	}
+	if let Some(compacted) = try_compact_aws_json(ctx, &without_progress) {
+		return compacted;
+	}
 	if looks_like_table(&without_progress) {
 		compact_delimited_table(&without_progress, 40)
 	} else {
@@ -34,8 +111,774 @@ fn filter_aws(input: &str, _exit_code: i32) -> String {
 	}
 }
 
-fn filter_http_transfer(input: &str, _exit_code: i32) -> String {
-	strip_transfer_progress(input)
+/// Try to parse AWS CLI JSON output and produce a compact representation.
+/// Returns None if input is not recognized JSON or if schema is unexpected.
+fn try_compact_aws_json(ctx: &MinimizerCtx<'_>, input: &str) -> Option<String> {
+	let trimmed = input.trim();
+	if !(trimmed.starts_with('{') || trimmed.starts_with('[')) {
+		return None;
+	}
+	let root: Value = serde_json::from_str(trimmed).ok()?;
+
+	if let Some(compacted) = compact_aws_service_json(ctx, &root) {
+		return Some(compacted);
+	}
+
+	// EC2 describe-instances: {"Reservations":[{"Instances":[...]}]}
+	if let Some(instances) = extract_aws_ec2_instances(&root) {
+		return Some(compact_aws_ec2_instances(&instances));
+	}
+
+	// CloudWatch logs / filtered log events: {"events":[...]}
+	if let Some(events) = extract_aws_cloudwatch_events(&root) {
+		return Some(compact_aws_cloudwatch_events(&events));
+	}
+
+	// DynamoDB get-item/query/scan: {"Item":{...}} or {"Items":[{...}]}
+	if let Some(items) = extract_aws_dynamodb_items(&root) {
+		return Some(compact_aws_dynamodb_items(&items));
+	}
+
+	compact_aws_generic(&root)
+}
+
+fn compact_aws_service_json(ctx: &MinimizerCtx<'_>, root: &Value) -> Option<String> {
+	match ctx.subcommand {
+		Some("sts") => extract_aws_sts_caller(root).map(compact_aws_sts_caller),
+		Some("s3" | "s3api") => extract_aws_s3_buckets(root).map(|rows| {
+			compact_named_rows(
+				&["bucket", "date"],
+				&rows
+					.iter()
+					.map(|bucket| {
+						vec![
+							string_field_map(bucket, &["Name", "Bucket", "bucket", "name"]),
+							string_field_map(bucket, &["CreationDate", "CreationDateTime", "date"]),
+						]
+					})
+					.collect::<Vec<_>>(),
+			)
+		}),
+		Some("lambda") => extract_array(root, &["Functions"]).map(|rows| {
+			compact_named_rows(
+				&["function", "runtime", "memory", "modified"],
+				&rows
+					.iter()
+					.map(|item| {
+						vec![
+							string_field_map(item, &["FunctionName", "Name"]),
+							string_field_map(item, &["Runtime"]),
+							string_field_map(item, &["MemorySize"]),
+							string_field_map(item, &["LastModified"]),
+						]
+					})
+					.collect::<Vec<_>>(),
+			)
+		}),
+		Some("iam") => extract_aws_iam_entities(root).map(|rows| {
+			compact_named_rows(
+				&["name", "arn", "created"],
+				&rows
+					.iter()
+					.map(|item| {
+						vec![
+							string_field_map(item, &["UserName", "RoleName", "GroupName", "Name"]),
+							string_field_map(item, &["Arn"]),
+							string_field_map(item, &["CreateDate"]),
+						]
+					})
+					.collect::<Vec<_>>(),
+			)
+		}),
+		Some("logs") => extract_aws_logs_events(root).map(compact_aws_logs_events),
+		Some("ecs") => extract_aws_arn_list(root, &["clusterArns", "taskArns", "serviceArns"])
+			.map(|rows| compact_single_col("arn", &rows)),
+		Some("rds") => extract_array(root, &["DBInstances"]).map(|rows| {
+			compact_named_rows(
+				&["identifier", "engine", "status", "endpoint"],
+				&rows
+					.iter()
+					.map(|item| {
+						vec![
+							string_field_map(item, &["DBInstanceIdentifier"]),
+							string_field_map(item, &["Engine"]),
+							string_field_map(item, &["DBInstanceStatus"]),
+							item
+								.get("Endpoint")
+								.and_then(Value::as_object)
+								.map_or_else(|| "-".to_string(), |ep| string_field_map(ep, &["Address"])),
+						]
+					})
+					.collect::<Vec<_>>(),
+			)
+		}),
+		Some("cloudformation") => extract_array(root, &["Stacks"]).map(|rows| {
+			compact_named_rows(
+				&["stack", "status", "updated"],
+				&rows
+					.iter()
+					.map(|item| {
+						vec![
+							string_field_map(item, &["StackName"]),
+							string_field_map(item, &["StackStatus"]),
+							string_field_map(item, &["LastUpdatedTime", "CreationTime"]),
+						]
+					})
+					.collect::<Vec<_>>(),
+			)
+		}),
+		Some("eks") => compact_aws_eks(root),
+		Some("sqs") => compact_aws_sqs(root),
+		Some("secretsmanager") => extract_array(root, &["SecretList"]).map(|rows| {
+			compact_named_rows(
+				&["name", "arn", "changed"],
+				&rows
+					.iter()
+					.map(|item| {
+						vec![
+							string_field_map(item, &["Name"]),
+							string_field_map(item, &["ARN", "Arn"]),
+							string_field_map(item, &["LastChangedDate", "LastAccessedDate"]),
+						]
+					})
+					.collect::<Vec<_>>(),
+			)
+		}),
+		_ => None,
+	}
+}
+
+fn extract_aws_sts_caller(root: &Value) -> Option<&Map<String, Value>> {
+	let map = root.as_object()?;
+	if map.contains_key("Account") && map.contains_key("Arn") {
+		Some(map)
+	} else {
+		None
+	}
+}
+
+fn compact_aws_sts_caller(map: &Map<String, Value>) -> String {
+	format!(
+		"account={} arn={} user-id={}\n",
+		string_field_map(map, &["Account"]),
+		string_field_map(map, &["Arn"]),
+		string_field_map(map, &["UserId"])
+	)
+}
+
+fn extract_aws_s3_buckets(root: &Value) -> Option<Vec<&Map<String, Value>>> {
+	extract_array(root, &["Buckets", "buckets"])
+}
+
+/// True for an `aws s3 ls` date column (`YYYY-MM-DD`).
+fn is_s3_date(token: &str) -> bool {
+	let mut parts = token.split('-');
+	matches!(
+		(parts.next(), parts.next(), parts.next(), parts.next()),
+		(Some(y), Some(m), Some(d), None)
+			if y.len() == 4
+				&& m.len() == 2
+				&& d.len() == 2
+				&& [y, m, d].iter().all(|p| p.bytes().all(|b| b.is_ascii_digit()))
+	)
+}
+
+/// True for an `aws s3 ls` time column (`HH:MM:SS`).
+fn is_s3_time(token: &str) -> bool {
+	let mut parts = token.split(':');
+	matches!(
+		(parts.next(), parts.next(), parts.next(), parts.next()),
+		(Some(h), Some(m), Some(s), None)
+			if [h, m, s].iter().all(|p| p.len() == 2 && p.bytes().all(|b| b.is_ascii_digit()))
+	)
+}
+
+fn compact_aws_s3_ls_text(input: &str) -> Option<String> {
+	let mut rows = Vec::new();
+	let mut passthrough_lines = Vec::new();
+	for line in input.lines() {
+		let mut parts = line.split_whitespace();
+		let Some(first) = parts.next() else {
+			continue;
+		};
+		if first == "PRE" {
+			// A common-prefix name may contain spaces (`PRE my folder/`), so
+			// join the remaining tokens instead of keeping only the first one.
+			let prefix: Vec<&str> = parts.collect();
+			if prefix.is_empty() {
+				passthrough_lines.push(line);
+			} else {
+				rows.push(vec![
+					prefix.join(" ").trim_end_matches('/').to_string(),
+					"prefix".to_string(),
+				]);
+			}
+			continue;
+		}
+		let Some(time) = parts.next() else {
+			passthrough_lines.push(line);
+			continue;
+		};
+		// Require a real date/time prefix so `--summarize` footers
+		// (`Total Objects: 1`, `Total Size: ...`) and any diagnostic/error
+		// text are not reinterpreted as object rows.
+		if !is_s3_date(first) || !is_s3_time(time) {
+			passthrough_lines.push(line);
+			continue;
+		}
+		let Some(third) = parts.next() else {
+			passthrough_lines.push(line);
+			continue;
+		};
+		if third == "0" && parts.clone().next().is_none() {
+			continue;
+		}
+		// Collect all remaining tokens as the key so that S3 keys
+		// containing spaces (e.g. "reports/June 2026.csv") are
+		// preserved in full rather than truncated to the last token.
+		let rest: Vec<&str> = parts.collect();
+		let name = if rest.is_empty() {
+			third.to_string()
+		} else {
+			rest.join(" ")
+		};
+		rows.push(vec![name, format!("{first} {time}")]);
+	}
+	if rows.is_empty() {
+		None
+	} else {
+		let mut out = compact_named_rows(&["bucket", "date"], &rows);
+		if !passthrough_lines.is_empty() {
+			if !out.ends_with('\n') {
+				out.push('\n');
+			}
+			for line in passthrough_lines {
+				out.push_str(line);
+				out.push('\n');
+			}
+		}
+		Some(out)
+	}
+}
+
+fn extract_aws_iam_entities(root: &Value) -> Option<Vec<&Map<String, Value>>> {
+	extract_array(root, &["Users", "Roles", "Groups", "Policies"])
+}
+
+fn extract_aws_logs_events(root: &Value) -> Option<Vec<&Map<String, Value>>> {
+	extract_array(root, &["events", "Events", "logEvents"])
+}
+
+fn compact_aws_logs_events(rows: Vec<&Map<String, Value>>) -> String {
+	compact_named_rows(
+		&["timestamp", "level", "message"],
+		&rows
+			.iter()
+			.map(|event| {
+				let msg = string_field_map(event, &["message", "Message"]);
+				vec![
+					string_field_map(event, &["timestamp", "eventTimestamp"]),
+					infer_level(&msg).to_string(),
+					primitives::truncate_line(&msg, MAX_LINE_CHARS),
+				]
+			})
+			.collect::<Vec<_>>(),
+	)
+}
+
+fn extract_aws_arn_list(root: &Value, keys: &[&str]) -> Option<Vec<String>> {
+	for key in keys {
+		if let Some(values) = root.get(key).and_then(Value::as_array) {
+			let rows = values
+				.iter()
+				.filter_map(Value::as_str)
+				.map(ToOwned::to_owned)
+				.collect::<Vec<_>>();
+			if !rows.is_empty() {
+				return Some(rows);
+			}
+		}
+	}
+	None
+}
+
+fn compact_aws_eks(root: &Value) -> Option<String> {
+	if let Some(values) = root.get("clusters").and_then(Value::as_array) {
+		let rows = values
+			.iter()
+			.filter_map(Value::as_str)
+			.map(|name| vec![name.to_string(), "-".to_string(), "-".to_string(), "-".to_string()])
+			.collect::<Vec<_>>();
+		return Some(compact_named_rows(&["cluster", "status", "version", "endpoint"], &rows));
+	}
+	let cluster = root.get("cluster")?.as_object()?;
+	Some(compact_named_rows(&["cluster", "status", "version", "endpoint"], &[vec![
+		string_field_map(cluster, &["name"]),
+		string_field_map(cluster, &["status"]),
+		string_field_map(cluster, &["version"]),
+		string_field_map(cluster, &["endpoint"]),
+	]]))
+}
+
+fn compact_aws_sqs(root: &Value) -> Option<String> {
+	if let Some(values) = root.get("QueueUrls").and_then(Value::as_array) {
+		let rows = values
+			.iter()
+			.filter_map(Value::as_str)
+			.map(|url| vec![url.to_string(), "-".to_string(), "-".to_string()])
+			.collect::<Vec<_>>();
+		return Some(compact_named_rows(&["url", "visibility", "messages"], &rows));
+	}
+	let attrs = root.get("Attributes").and_then(Value::as_object)?;
+	Some(compact_named_rows(&["url", "visibility", "messages"], &[vec![
+		string_field(root, &["QueueUrl"]),
+		string_field_map(attrs, &["VisibilityTimeout"]),
+		string_field_map(attrs, &["ApproximateNumberOfMessages"]),
+	]]))
+}
+
+fn extract_array<'a>(root: &'a Value, keys: &[&str]) -> Option<Vec<&'a Map<String, Value>>> {
+	for key in keys {
+		if let Some(values) = root.get(key).and_then(Value::as_array) {
+			let rows = values
+				.iter()
+				.filter_map(Value::as_object)
+				.collect::<Vec<_>>();
+			if !rows.is_empty() {
+				return Some(rows);
+			}
+		}
+	}
+	None
+}
+
+fn compact_aws_generic(root: &Value) -> Option<String> {
+	let pruned = prune_aws_sensitive(root);
+	if let Some((name, rows)) = first_object_array(&pruned) {
+		let columns = generic_columns(&rows);
+		if columns.is_empty() {
+			return None;
+		}
+		let values = rows
+			.iter()
+			.take(MAX_AWS_ROWS)
+			.map(|row| {
+				columns
+					.iter()
+					.map(|column| string_field_map(row, &[column.as_str()]))
+					.collect::<Vec<_>>()
+			})
+			.collect::<Vec<_>>();
+		let mut out =
+			compact_named_rows(&columns.iter().map(String::as_str).collect::<Vec<_>>(), &values);
+		if rows.len() > MAX_AWS_ROWS {
+			let _ = writeln!(out, "... +{} more {name}", rows.len() - MAX_AWS_ROWS);
+		}
+		return Some(out);
+	}
+	None
+}
+
+fn prune_aws_sensitive(value: &Value) -> Value {
+	match value {
+		Value::Object(map) => Value::Object(
+			map.iter()
+				.filter_map(|(key, value)| {
+					if SENSITIVE_AWS_KEYS.iter().any(|sensitive| sensitive == key) {
+						None
+					} else {
+						Some((key.clone(), prune_aws_sensitive(value)))
+					}
+				})
+				.collect(),
+		),
+		Value::Array(values) => Value::Array(values.iter().map(prune_aws_sensitive).collect()),
+		_ => value.clone(),
+	}
+}
+
+fn first_object_array(root: &Value) -> Option<(&str, Vec<Map<String, Value>>)> {
+	let map = root.as_object()?;
+	for (key, value) in map {
+		let Some(values) = value.as_array() else {
+			continue;
+		};
+		let rows = values
+			.iter()
+			.filter_map(Value::as_object)
+			.cloned()
+			.collect::<Vec<_>>();
+		if !rows.is_empty() {
+			return Some((key.as_str(), rows));
+		}
+	}
+	None
+}
+
+fn generic_columns(rows: &[Map<String, Value>]) -> Vec<String> {
+	let mut columns = Vec::new();
+	for row in rows {
+		for key in row.keys() {
+			let lower = key.to_ascii_lowercase();
+			if (matches!(
+				lower.as_str(),
+				"id"
+					| "name" | "arn"
+					| "status" | "state"
+					| "created"
+					| "modified"
+					| "type" | "engine"
+					| "version"
+			) || lower.ends_with("id")
+				|| lower.ends_with("name")
+				|| lower.ends_with("arn")
+				|| lower.ends_with("status")
+				|| lower.ends_with("state")
+				|| lower.contains("created")
+				|| lower.contains("modified"))
+				&& !columns.contains(key)
+			{
+				columns.push(key.clone());
+			}
+			if columns.len() >= 6 {
+				return columns;
+			}
+		}
+	}
+	columns
+}
+
+fn compact_named_rows(headers: &[&str], rows: &[Vec<String>]) -> String {
+	let mut out = String::new();
+	out.push_str(&headers.join("\t"));
+	out.push('\n');
+	for row in rows.iter().take(MAX_AWS_ROWS) {
+		out.push_str(&row.join("\t"));
+		out.push('\n');
+	}
+	if rows.len() > MAX_AWS_ROWS {
+		let _ = writeln!(out, "... +{} more rows", rows.len() - MAX_AWS_ROWS);
+	}
+	out
+}
+
+fn compact_single_col(header: &str, rows: &[String]) -> String {
+	let values = rows.iter().map(|row| vec![row.clone()]).collect::<Vec<_>>();
+	compact_named_rows(&[header], &values)
+}
+
+fn string_field(value: &Value, keys: &[&str]) -> String {
+	value
+		.as_object()
+		.map_or_else(|| "-".to_string(), |map| string_field_map(map, keys))
+}
+
+fn string_field_map(map: &Map<String, Value>, keys: &[&str]) -> String {
+	for key in keys {
+		if let Some(value) = map.get(*key) {
+			return value_to_cell(value);
+		}
+	}
+	"-".to_string()
+}
+
+fn value_to_cell(value: &Value) -> String {
+	match value {
+		Value::String(value) => value.clone(),
+		Value::Number(value) => value.to_string(),
+		Value::Bool(value) => value.to_string(),
+		Value::Null => "-".to_string(),
+		Value::Array(values) => format!("{} item(s)", values.len()),
+		Value::Object(_) => "{...}".to_string(),
+	}
+}
+
+fn infer_level(message: &str) -> &str {
+	let upper = message.to_ascii_uppercase();
+	for level in ["ERROR", "WARN", "INFO", "DEBUG", "TRACE"] {
+		if upper.contains(level) {
+			return level;
+		}
+	}
+	"-"
+}
+
+// ── AWS EC2 ──────────────────────────────────────────────────────────────────
+
+fn extract_aws_ec2_instances(root: &Value) -> Option<Vec<&Value>> {
+	let reservations = root.get("Reservations")?.as_array()?;
+	let mut instances = Vec::new();
+	for res in reservations {
+		let insts = res.get("Instances")?.as_array()?;
+		for inst in insts {
+			instances.push(inst);
+		}
+	}
+	if instances.is_empty() {
+		None
+	} else {
+		Some(instances)
+	}
+}
+
+fn compact_aws_ec2_instances(instances: &[&Value]) -> String {
+	let mut out = String::new();
+	for inst in instances {
+		let id = inst
+			.get("InstanceId")
+			.and_then(|v| v.as_str())
+			.unwrap_or("?");
+		let typ = inst
+			.get("InstanceType")
+			.and_then(|v| v.as_str())
+			.unwrap_or("?");
+		let state = inst
+			.get("State")
+			.and_then(|v| v.get("Name"))
+			.and_then(|v| v.as_str())
+			.unwrap_or("?");
+		let ip = inst
+			.get("PrivateIpAddress")
+			.and_then(|v| v.as_str())
+			.unwrap_or("-");
+		let name = inst
+			.get("Tags")
+			.and_then(|v| v.as_array())
+			.and_then(|tags| {
+				tags.iter().find_map(|tag| {
+					let key = tag.get("Key")?.as_str()?;
+					if key == "Name" {
+						tag.get("Value")?.as_str()
+					} else {
+						None
+					}
+				})
+			})
+			.unwrap_or("-");
+		let _ = writeln!(out, "{id}\t{typ}\t{state}\t{ip}\t{name}");
+	}
+	if instances.len() > 1 {
+		out.push('\n');
+	}
+	let _ = writeln!(out, "{} instance(s)", instances.len());
+	out
+}
+
+// ── AWS CloudWatch ───────────────────────────────────────────────────────────
+
+fn extract_aws_cloudwatch_events(root: &Value) -> Option<Vec<&Value>> {
+	let events = root.get("events")?.as_array()?;
+	if events.is_empty() {
+		None
+	} else {
+		Some(events.iter().collect())
+	}
+}
+
+fn epoch_ms_to_iso(ms: i64) -> String {
+	let secs = ms / 1000;
+	let sub_ms = (ms % 1000) as u32;
+	let days_since_epoch = secs / 86400;
+	let secs_of_day = secs % 86400;
+	let hour = secs_of_day / 3600;
+	let minute = (secs_of_day % 3600) / 60;
+	let second = secs_of_day % 60;
+	let total_days = days_since_epoch as i32;
+	let (year, month, day) = civil_from_days(total_days + 719468);
+	format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{sub_ms:03}Z")
+}
+
+const fn civil_from_days(z: i32) -> (i32, u32, u32) {
+	let z = z as i64;
+	let era = (if z >= 0 { z } else { z - 146096 }) / 146097;
+	let doe = (z - era * 146097) as u32;
+	let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+	let y = yoe as i64 + era * 400;
+	let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+	let mp = (5 * doy + 2) / 153;
+	let d = doy - (153 * mp + 2) / 5 + 1;
+	let m = if mp < 10 { mp + 3 } else { mp - 9 };
+	let y = if m <= 2 { y + 1 } else { y };
+	(y as i32, m, d)
+}
+
+fn compact_aws_cloudwatch_events(events: &[&Value]) -> String {
+	let mut out = String::new();
+	let mut count = 0usize;
+	for event in events {
+		let ts = event
+			.get("timestamp")
+			.and_then(|v| v.as_i64())
+			.map_or_else(|| "?".to_string(), epoch_ms_to_iso);
+		let msg = event.get("message").and_then(|v| v.as_str()).unwrap_or("?");
+		// Truncate long messages
+		let msg = primitives::truncate_line(msg, MAX_LINE_CHARS);
+		out.push_str(&ts);
+		out.push('\t');
+		out.push_str(&msg);
+		out.push('\n');
+		count += 1;
+	}
+	if count > 1 {
+		out.push('\n');
+	}
+	let _ = writeln!(out, "{count} event(s)");
+	out
+}
+
+// ── AWS DynamoDB
+// ──────────────────────────────────────────────────────────────
+
+fn extract_aws_dynamodb_items(root: &Value) -> Option<Vec<&serde_json::Map<String, Value>>> {
+	if let Some(item) = root.get("Item").and_then(Value::as_object) {
+		return Some(vec![item]);
+	}
+	let items = root.get("Items")?.as_array()?;
+	let mut out = Vec::new();
+	for item in items {
+		if let Some(map) = item.as_object() {
+			out.push(map);
+		}
+	}
+	if out.is_empty() { None } else { Some(out) }
+}
+
+fn compact_aws_dynamodb_items(items: &[&serde_json::Map<String, Value>]) -> String {
+	let mut out = String::new();
+	for item in items.iter().take(40) {
+		let mut first = true;
+		for (key, value) in *item {
+			if !first {
+				out.push('\t');
+			}
+			first = false;
+			out.push_str(key);
+			out.push('=');
+			push_dynamodb_value(&mut out, value);
+		}
+		out.push('\n');
+	}
+	if items.len() > 40 {
+		out.push_str("… ");
+		out.push_str(&(items.len() - 40).to_string());
+		out.push_str(" item(s) omitted …\n");
+	}
+	let _ = writeln!(out, "{} item(s)", items.len());
+	out
+}
+
+fn push_dynamodb_value(out: &mut String, value: &Value) {
+	let Some(map) = value.as_object() else {
+		push_json_scalar(out, value);
+		return;
+	};
+	if map.len() == 1 {
+		if let Some(value) = map.get("S").and_then(Value::as_str) {
+			out.push_str(value);
+			return;
+		}
+		if let Some(value) = map.get("N").and_then(Value::as_str) {
+			out.push_str(value);
+			return;
+		}
+		if let Some(value) = map.get("BOOL").and_then(Value::as_bool) {
+			out.push_str(if value { "true" } else { "false" });
+			return;
+		}
+		if map.get("NULL").and_then(Value::as_bool) == Some(true) {
+			out.push_str("null");
+			return;
+		}
+		if let Some(values) = map.get("SS").and_then(Value::as_array) {
+			push_json_array(out, values);
+			return;
+		}
+		if let Some(values) = map.get("NS").and_then(Value::as_array) {
+			push_json_array(out, values);
+			return;
+		}
+		if let Some(values) = map.get("L").and_then(Value::as_array) {
+			out.push('[');
+			for (idx, value) in values.iter().enumerate() {
+				if idx > 0 {
+					out.push(',');
+				}
+				push_dynamodb_value(out, value);
+			}
+			out.push(']');
+			return;
+		}
+		if let Some(values) = map.get("M").and_then(Value::as_object) {
+			push_dynamodb_map(out, values);
+			return;
+		}
+	}
+	push_dynamodb_map(out, map);
+}
+
+fn push_dynamodb_map(out: &mut String, values: &serde_json::Map<String, Value>) {
+	out.push('{');
+	for (idx, (key, value)) in values.iter().enumerate() {
+		if idx > 0 {
+			out.push(',');
+		}
+		out.push_str(key);
+		out.push(':');
+		push_dynamodb_value(out, value);
+	}
+	out.push('}');
+}
+
+fn push_json_array(out: &mut String, values: &[Value]) {
+	out.push('[');
+	for (idx, value) in values.iter().enumerate() {
+		if idx > 0 {
+			out.push(',');
+		}
+		push_json_scalar(out, value);
+	}
+	out.push(']');
+}
+
+fn push_json_scalar(out: &mut String, value: &Value) {
+	if let Some(value) = value.as_str() {
+		out.push_str(value);
+	} else {
+		out.push_str(&value.to_string());
+	}
+}
+
+fn filter_http_transfer(ctx: &MinimizerCtx<'_>, input: &str, _exit_code: i32) -> String {
+	if http_transfer_suppresses_progress(ctx) {
+		input.to_string()
+	} else {
+		strip_transfer_progress(input)
+	}
+}
+
+fn http_transfer_suppresses_progress(ctx: &MinimizerCtx<'_>) -> bool {
+	ctx.command
+		.split_whitespace()
+		.any(|token| match ctx.program {
+			"curl" => {
+				token == "--silent"
+					|| token == "--no-progress-meter"
+					|| token.starts_with('-') && !token.starts_with("--") && token.contains('s')
+			},
+			"wget" => {
+				token == "--quiet"
+					|| token.starts_with('-') && !token.starts_with("--") && token.contains('q')
+			},
+			_ => false,
+		})
+}
+
+/// Returns `true` when the psql invocation requests machine-readable
+/// (unaligned, tuples-only, or CSV) output that must not be truncated.
+fn is_psql_machine_readable(command: &str) -> bool {
+	command
+		.split_whitespace()
+		.any(|t| matches!(t, "-A" | "--no-align" | "-t" | "--tuples-only" | "--csv"))
 }
 
 fn filter_psql(input: &str, exit_code: i32) -> String {
@@ -407,6 +1250,22 @@ mod tests {
 		MinimizerCtx { program, subcommand: None, command: program, config: cfg }
 	}
 
+	fn ctx_command<'a>(
+		program: &'a str,
+		command: &'a str,
+		cfg: &'a MinimizerConfig,
+	) -> MinimizerCtx<'a> {
+		MinimizerCtx { program, subcommand: None, command, config: cfg }
+	}
+
+	fn aws_ctx<'a>(
+		subcommand: &'a str,
+		command: &'a str,
+		cfg: &'a MinimizerConfig,
+	) -> MinimizerCtx<'a> {
+		MinimizerCtx { program: "aws", subcommand: Some(subcommand), command, config: cfg }
+	}
+
 	#[test]
 	fn strips_curl_progress_and_preserves_long_multiline_body() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
@@ -440,6 +1299,26 @@ mod tests {
 		let expected = "100% real body\n[{\"id\":1}]\n";
 		let out = filter(&ctx, input, 0);
 		assert_eq!(out.text, expected);
+	}
+
+	#[test]
+	fn curl_silent_preserves_body_lines_that_look_like_progress() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx_command("curl", "curl -s https://example.test/body", &cfg);
+		let input = "% Total legitimate response header\n100%[body]\n";
+		let out = filter(&ctx, input, 0);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn wget_quiet_preserves_body_lines_that_look_like_progress() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx_command("wget", "wget -qO- https://example.test/body", &cfg);
+		let input = "--body marker with https://example.test\n100%[body]\n";
+		let out = filter(&ctx, input, 0);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
 	}
 
 	#[test]
@@ -486,5 +1365,302 @@ mod tests {
 		}
 		let out = filter(&ctx, &input, 0);
 		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn aws_s3_cp_to_stdout_preserves_body() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = aws_ctx("s3", "aws s3 cp s3://bucket/file.json -", &cfg);
+		let input = "{\"key\": \"value\", \"% Total\": 100}\n";
+		let out = filter(&ctx, input, 0);
+		assert!(!out.changed, "stdout pipe body must not be rewritten: {:?}", out.text);
+	}
+
+	#[test]
+	fn compacts_ec2_describe_instances_json() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("aws", &cfg);
+		let input = r#"{
+    "Reservations": [
+        {
+            "Groups": [],
+            "Instances": [
+                {
+                    "InstanceId": "i-1234567890abcdef0",
+                    "InstanceType": "t2.micro",
+                    "State": { "Code": 16, "Name": "running" },
+                    "PrivateIpAddress": "10.0.0.1",
+                    "Tags": [
+                        { "Key": "Name", "Value": "web-server" },
+                        { "Key": "env", "Value": "prod" }
+                    ]
+                },
+                {
+                    "InstanceId": "i-abcdef1234567890",
+                    "InstanceType": "t3.large",
+                    "State": { "Code": 80, "Name": "stopped" },
+                    "PrivateIpAddress": "10.0.0.2",
+                    "Tags": []
+                }
+            ],
+            "OwnerId": "123456789012",
+            "ReservationId": "r-1234567890abcdef0"
+        }
+    ]
+}"#;
+		let out = filter(&ctx, input, 0);
+		assert!(
+			out.text
+				.contains("i-1234567890abcdef0\tt2.micro\trunning\t10.0.0.1\tweb-server")
+		);
+		assert!(
+			out.text
+				.contains("i-abcdef1234567890\tt3.large\tstopped\t10.0.0.2\t-")
+		);
+		assert!(out.text.contains("2 instance(s)"));
+	}
+
+	#[test]
+	fn compacts_cloudwatch_log_events_json() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("aws", &cfg);
+		let input = r#"{
+    "events": [
+        {
+            "timestamp": 1705310100000,
+            "message": "START RequestId: abc123 Version: $LATEST",
+            "ingestionTime": 1705310101000
+        },
+        {
+            "timestamp": 1705310101000,
+            "message": "END RequestId: abc123",
+            "ingestionTime": 1705310102000
+        }
+    ],
+    "nextForwardToken": "f/123",
+    "nextBackwardToken": "b/123"
+}"#;
+		let out = filter(&ctx, input, 0);
+		assert!(
+			out.text
+				.contains("START RequestId: abc123 Version: $LATEST")
+		);
+		assert!(out.text.contains("END RequestId: abc123"));
+		assert!(out.text.contains("2 event(s)"));
+	}
+
+	#[test]
+	fn compacts_dynamodb_typed_json() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("aws", &cfg);
+		let input = r#"{
+    "Items": [
+        {
+            "pk": { "S": "user#1" },
+            "age": { "N": "42" },
+            "active": { "BOOL": true },
+            "tags": { "SS": ["a", "b"] },
+            "meta": { "M": { "city": { "S": "Paris" } } }
+        }
+    ],
+    "Count": 1
+}"#;
+		let out = filter(&ctx, input, 0);
+		assert!(out.text.contains("pk=user#1"));
+		assert!(out.text.contains("age=42"));
+		assert!(out.text.contains("active=true"));
+		assert!(out.text.contains("tags=[a,b]"));
+		assert!(out.text.contains("meta={city:Paris}"));
+		assert!(out.text.contains("1 item(s)"));
+	}
+
+	#[test]
+	fn aws_json_parse_failure_falls_back_to_progress_strip() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("aws", &cfg);
+		// Invalid JSON should fall back to existing behavior
+		let input = "{invalid json here}\nsome output\n";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn aws_unknown_json_uses_generic_safe_table() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("aws", &cfg);
+		let input =
+			r#"{"Things": [{"Name": "alpha", "Status": "ready", "Password": "LEAK_SENTINEL"}]}"#;
+		let out = filter(&ctx, input, 0);
+		assert!(out.text.contains("Name\tStatus"));
+		assert!(out.text.contains("alpha\tready"));
+		assert!(!out.text.contains("LEAK_SENTINEL"));
+	}
+
+	#[test]
+	fn compacts_new_aws_service_shapes() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let cases = [
+			(
+				"sts",
+				"aws sts get-caller-identity",
+				r#"{"UserId":"AIDA","Account":"123456789012","Arn":"arn:aws:iam::123456789012:user/alice","ResponseMetadata":{"RequestId":"LEAK_SENTINEL"}}"#,
+				"account=123456789012 arn=arn:aws:iam::123456789012:user/alice user-id=AIDA",
+			),
+			(
+				"s3api",
+				"aws s3api list-buckets",
+				r#"{"Buckets":[{"Name":"builds","CreationDate":"2026-05-27T00:00:00Z"}]}"#,
+				"builds\t2026-05-27T00:00:00Z",
+			),
+			(
+				"lambda",
+				"aws lambda list-functions",
+				r#"{"Functions":[{"FunctionName":"api","Runtime":"nodejs20.x","MemorySize":256,"LastModified":"today","Environment":{"Variables":{"SECRET":"LEAK_SENTINEL"}}}]}"#,
+				"api\tnodejs20.x\t256\ttoday",
+			),
+			(
+				"iam",
+				"aws iam list-roles",
+				r#"{"Roles":[{"RoleName":"deploy","Arn":"arn:role/deploy","CreateDate":"today","AssumeRolePolicyDocument":"LEAK_SENTINEL"}]}"#,
+				"deploy\tarn:role/deploy\ttoday",
+			),
+			(
+				"logs",
+				"aws logs get-log-events",
+				r#"{"events":[{"timestamp":1,"message":"ERROR failed"}]}"#,
+				"1\tERROR\tERROR failed",
+			),
+			(
+				"ecs",
+				"aws ecs list-clusters",
+				r#"{"clusterArns":["arn:aws:ecs:cluster/default"]}"#,
+				"arn:aws:ecs:cluster/default",
+			),
+			(
+				"rds",
+				"aws rds describe-db-instances",
+				r#"{"DBInstances":[{"DBInstanceIdentifier":"db1","Engine":"postgres","DBInstanceStatus":"available","Endpoint":{"Address":"db.local"}}]}"#,
+				"db1\tpostgres\tavailable\tdb.local",
+			),
+			(
+				"cloudformation",
+				"aws cloudformation describe-stacks",
+				r#"{"Stacks":[{"StackName":"app","StackStatus":"CREATE_COMPLETE","LastUpdatedTime":"today"}]}"#,
+				"app\tCREATE_COMPLETE\ttoday",
+			),
+			(
+				"eks",
+				"aws eks describe-cluster",
+				r#"{"cluster":{"name":"prod","status":"ACTIVE","version":"1.30","endpoint":"https://eks"}}"#,
+				"prod\tACTIVE\t1.30\thttps://eks",
+			),
+			(
+				"sqs",
+				"aws sqs list-queues",
+				r#"{"QueueUrls":["https://sqs.local/q"]}"#,
+				"https://sqs.local/q",
+			),
+			(
+				"secretsmanager",
+				"aws secretsmanager list-secrets",
+				r#"{"SecretList":[{"Name":"db","ARN":"arn:secret:db","LastChangedDate":"today","SecretString":"LEAK_SENTINEL"}]}"#,
+				"db\tarn:secret:db\ttoday",
+			),
+		];
+		for (service, command, input, expected) in cases {
+			let ctx = aws_ctx(service, command, &cfg);
+			let out = filter(&ctx, input, 0);
+			assert!(out.text.contains(expected), "{service}: {}", out.text);
+			assert!(!out.text.contains("LEAK_SENTINEL"), "{service}");
+			assert_output_pure(&out.text);
+		}
+	}
+
+	#[test]
+	fn compacts_s3_text_ls() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = aws_ctx("s3", "aws s3 ls", &cfg);
+		let out = filter(&ctx, "2026-05-27 01:02:03 builds\n2026-05-27 01:03:04 logs\n", 0);
+		assert!(out.text.contains("builds\t2026-05-27 01:02:03"));
+		assert_output_pure(&out.text);
+	}
+
+	#[test]
+	fn s3_ls_summarize_footer_is_not_parsed_as_row() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = aws_ctx("s3", "aws s3 ls --summarize s3://b/", &cfg);
+		// `--summarize` appends `Total Objects:`/`Total Size:` footers that lack a
+		// real date/time prefix; they must not be reshaped into bogus object rows or
+		// silently dropped.
+		let input = "2026-05-27 01:02:03 100 builds\n\nTotal Objects: 1\nTotal Size: 100\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.text.contains("builds\t2026-05-27 01:02:03"), "{:?}", out.text);
+		assert!(out.text.contains("Total Objects: 1"), "{:?}", out.text);
+		assert!(out.text.contains("Total Size: 100"), "{:?}", out.text);
+	}
+
+	#[test]
+	fn s3_ls_common_prefix_with_spaces_is_preserved() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = aws_ctx("s3", "aws s3 ls s3://b/", &cfg);
+		// `PRE` common-prefix names can contain spaces; the full name must survive
+		// rather than being truncated to the first token.
+		let out = filter(&ctx, "                           PRE my folder/\n", 0);
+		assert!(out.text.contains("my folder"), "{:?}", out.text);
+	}
+
+	#[test]
+	fn s3_cp_output_is_not_parsed_as_listing() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = aws_ctx("s3", "aws s3 cp ./file.txt s3://bucket/file.txt", &cfg);
+		// `aws s3 cp` emits a transfer result line, not a listing; it must pass
+		// through untouched rather than be reshaped into a bucket/date table.
+		let input = "upload: ./file.txt to s3://bucket/file.txt\n";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn malformed_new_aws_service_json_passthroughs() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		for service in [
+			"sts",
+			"s3",
+			"lambda",
+			"iam",
+			"logs",
+			"ecs",
+			"rds",
+			"cloudformation",
+			"eks",
+			"sqs",
+			"secretsmanager",
+		] {
+			let ctx = aws_ctx(service, "aws service op", &cfg);
+			let input = "{not-json";
+			let out = filter(&ctx, input, 0);
+			assert_eq!(out.text, input, "{service}");
+		}
+	}
+
+	#[test]
+	fn sensitive_aws_keys_never_leak_from_generic() {
+		let mut fields = String::new();
+		for key in SENSITIVE_AWS_KEYS {
+			fields.push_str(&format!(r#""{key}":"LEAK_SENTINEL","#));
+		}
+		let input = format!(r#"{{"Unknowns":[{{"Name":"safe",{fields}"Status":"ok"}}]}}"#);
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("aws", &cfg);
+		let out = filter(&ctx, &input, 0);
+		assert!(out.text.contains("safe"));
+		assert!(!out.text.contains("LEAK_SENTINEL"));
+	}
+
+	fn assert_output_pure(out: &str) {
+		assert!(!out.contains('\x1b'));
+		assert!(!out.contains("&&"));
+		assert!(!out.contains(';'));
+		assert!(!out.contains('`'));
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/cloud.rs
+++ b/crates/pi-shell/src/minimizer/filters/cloud.rs
@@ -74,15 +74,15 @@ fn is_s3_ls(command: &str) -> bool {
 	false
 }
 
-/// Returns `true` when an AWS CLI invocation streams object content to
-/// stdout (`-` as the destination), e.g. `aws s3 cp s3://bucket/key -`.
-/// In that mode the captured text is the object body, not CLI progress,
-/// so `strip_transfer_progress` must not run.
+/// Returns `true` when an AWS CLI invocation streams object content via a
+/// `-` positional (stdout download `aws s3 cp s3://bucket/key -`, or stdin
+/// upload `aws s3 cp - s3://bucket/key`). In that mode the captured text is
+/// the object body, not CLI progress, so `strip_transfer_progress` must not
+/// run. Any bare `-` token triggers passthrough — even when trailing options
+/// follow the positional (`aws s3 cp s3://bucket/key - --request-payer
+/// requester`); a false positive only skips minimization, which is safe.
 fn is_aws_stdout_pipe(command: &str) -> bool {
-	command
-		.split_whitespace()
-		.rfind(|token| *token == "-" || !token.starts_with('-'))
-		.is_some_and(|token| token == "-")
+	command.split_whitespace().any(|token| token == "-")
 }
 
 fn filter_aws(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> String {
@@ -1371,6 +1371,15 @@ mod tests {
 	fn aws_s3_cp_to_stdout_preserves_body() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
 		let ctx = aws_ctx("s3", "aws s3 cp s3://bucket/file.json -", &cfg);
+		let input = "{\"key\": \"value\", \"% Total\": 100}\n";
+		let out = filter(&ctx, input, 0);
+		assert!(!out.changed, "stdout pipe body must not be rewritten: {:?}", out.text);
+	}
+
+	#[test]
+	fn aws_s3_cp_to_stdout_with_trailing_options_preserves_body() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = aws_ctx("s3", "aws s3 cp s3://bucket/file.json - --request-payer requester", &cfg);
 		let input = "{\"key\": \"value\", \"% Total\": 100}\n";
 		let out = filter(&ctx, input, 0);
 		assert!(!out.changed, "stdout pipe body must not be rewritten: {:?}", out.text);

--- a/crates/pi-shell/src/minimizer/filters/docker.rs
+++ b/crates/pi-shell/src/minimizer/filters/docker.rs
@@ -1,5 +1,9 @@
 //! Container and cloud command output filters.
 
+use std::fmt::Write as _;
+
+use serde_json::Value;
+
 use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
 
 pub fn supports(subcommand: Option<&str>) -> bool {
@@ -40,13 +44,17 @@ pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerO
 
 fn filter_docker(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> String {
 	if is_log_command(ctx) {
-		return filter_logs(input);
+		return filter_docker_logs(input);
 	}
 	if exit_code != 0 {
 		return input.to_string();
 	}
-	if is_table_command(ctx) {
-		return compact_table(input, 12);
+	if is_docker_listing_command(ctx) {
+		return if is_table_command(ctx) {
+			compact_table(input, 12)
+		} else {
+			input.to_string()
+		};
 	}
 	compact_build_or_progress(input)
 }
@@ -57,12 +65,333 @@ fn filter_kubectl(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> String
 	}
 	match ctx.subcommand {
 		Some("logs") => filter_logs(input),
-		Some("get") => compact_table(input, 20),
+		Some("get") => {
+			// Explicit JSON/YAML output — passthrough, never compact to table
+			if is_explicit_kubectl_json_yaml(ctx.command) {
+				return input.to_string();
+			}
+			if let Some(compacted) = try_compact_kubectl_json(input) {
+				return compacted;
+			}
+			// `-o yaml` or single-object `-o json` from content (already
+			// caught above by flag check, but handle content-detected too).
+			if is_structured_kubectl_output(input) {
+				return primitives::head_tail_lines(input, 80, 40);
+			}
+			// Non-table output formats produce listings, not tables
+			if is_kubectl_non_table_format(ctx.command) {
+				return primitives::head_tail_lines(input, 80, 40);
+			}
+			compact_table(input, 20)
+		},
 		Some("describe") => {
 			primitives::head_tail_lines(&primitives::dedup_consecutive_lines(input), 120, 80)
 		},
 		_ => compact_build_or_progress(input),
 	}
+}
+
+// ── kubectl JSON compaction ──────────────────────────────────────────────────
+
+/// Returns true when the `kubectl get` output is structured JSON or YAML
+/// (i.e. `-o json` single-object or `-o yaml`) rather than a tabular listing.
+/// Used to avoid rewriting manifests as a fake row-count table.
+fn is_structured_kubectl_output(input: &str) -> bool {
+	let t = input.trim_start();
+	// Single-object -o json (starts with '{' but is not a List handled above)
+	// or -o yaml (starts with "apiVersion:" or "kind:").
+	t.starts_with('{') || t.starts_with("apiVersion:") || t.starts_with("kind:")
+}
+
+/// Whether `kubectl get` was invoked with explicit `-o json` or `-o yaml`.
+///
+/// Handles all three kubectl `-o` forms:
+///   `-o json`      (space-separated)
+///   `-o=json`      (attached with `=`)
+///   `-ojson`       (fully attached, no separator — common CLI shorthand)
+fn is_explicit_kubectl_json_yaml(command: &str) -> bool {
+	let mut tokens = command.split_whitespace();
+	while let Some(tok) = tokens.next() {
+		if (tok == "-o" || tok == "--output")
+			&& let Some(fmt) = tokens.next()
+		{
+			let base = fmt.split('=').next().unwrap_or(fmt);
+			if matches!(base, "json" | "yaml") {
+				return true;
+			}
+		}
+		if let Some(val) = tok
+			.strip_prefix("-o=")
+			.or_else(|| tok.strip_prefix("--output="))
+		{
+			let base = val.split('=').next().unwrap_or(val);
+			if matches!(base, "json" | "yaml") {
+				return true;
+			}
+		}
+		// Fully-attached form: `-ojson`, `-oyaml`, `-ojsonpath=...`, etc.
+		if let Some(val) = tok
+			.strip_prefix("-o")
+			.filter(|v| !v.is_empty() && !v.starts_with('='))
+		{
+			let base = val.split('=').next().unwrap_or(val);
+			if matches!(base, "json" | "yaml") {
+				return true;
+			}
+		}
+	}
+	false
+}
+
+/// Whether `kubectl get` was invoked with a non-table output format.
+/// These formats (`-o name`, `-o jsonpath/...`, `-o go-template/...`,
+/// `-o template/...`, `-o custom-columns/...`, `--no-headers`) produce
+/// listings or single values, not tables — `compact_table` would treat
+/// the first entry as a header and corrupt the requested format.
+///
+/// Handles all three kubectl `-o` forms:
+///   `-o name`      (space-separated)
+///   `-o=name`      (attached with `=`)
+///   `-oname`       (fully attached, no separator — common CLI shorthand)
+fn is_kubectl_non_table_format(command: &str) -> bool {
+	let mut tokens = command.split_whitespace();
+	while let Some(tok) = tokens.next() {
+		if (tok == "-o" || tok == "--output")
+			&& let Some(fmt) = tokens.next()
+		{
+			let base = fmt.split('=').next().unwrap_or(fmt);
+			if matches!(
+				base,
+				"name"
+					| "jsonpath"
+					| "go-template"
+					| "go-template-file"
+					| "template"
+					| "templatefile"
+					| "custom-columns"
+					| "custom-columns-file"
+			) {
+				return true;
+			}
+		}
+		if let Some(val) = tok
+			.strip_prefix("-o=")
+			.or_else(|| tok.strip_prefix("--output="))
+		{
+			let base = val.split('=').next().unwrap_or(val);
+			if matches!(
+				base,
+				"name"
+					| "jsonpath"
+					| "go-template"
+					| "go-template-file"
+					| "template"
+					| "templatefile"
+					| "custom-columns"
+					| "custom-columns-file"
+			) {
+				return true;
+			}
+		}
+		// Fully-attached form: `-oname`, `-ojsonpath=...`, `-ogo-template=...`, etc.
+		if let Some(val) = tok
+			.strip_prefix("-o")
+			.filter(|v| !v.is_empty() && !v.starts_with('='))
+		{
+			let base = val.split('=').next().unwrap_or(val);
+			if matches!(
+				base,
+				"name"
+					| "jsonpath"
+					| "go-template"
+					| "go-template-file"
+					| "template"
+					| "templatefile"
+					| "custom-columns"
+					| "custom-columns-file"
+			) {
+				return true;
+			}
+		}
+		if tok == "--no-headers" {
+			return true;
+		}
+	}
+	false
+}
+
+/// Try to parse kubectl `get -o json` output and produce a compact table.
+/// Returns None if input is not recognized JSON or if schema is unexpected.
+fn try_compact_kubectl_json(input: &str) -> Option<String> {
+	let trimmed = input.trim();
+	if !trimmed.starts_with('{') {
+		return None;
+	}
+	let root: Value = serde_json::from_str(trimmed).ok()?;
+
+	// kubectl list JSON: {"kind":"List","items":[...]}
+	if root.get("kind")?.as_str()? != "List" {
+		return None;
+	}
+	let items = root.get("items")?.as_array()?;
+	if items.is_empty() {
+		return None;
+	}
+
+	// Determine resource kind from first item
+	let first = &items[0];
+	let kind = first.get("kind")?.as_str()?;
+
+	match kind {
+		"Pod" => Some(compact_kubectl_pods(items)),
+		"Service" => Some(compact_kubectl_services(items)),
+		_ => None,
+	}
+}
+
+fn compact_kubectl_pods(items: &[Value]) -> String {
+	let mut out = String::from("NAME\tREADY\tSTATUS\tRESTARTS\tAGE\tIP\tNODE\n");
+	let mut count = 0usize;
+	for item in items {
+		let meta = item.get("metadata").unwrap_or(&Value::Null);
+		let spec = item.get("spec").unwrap_or(&Value::Null);
+		let status = item.get("status").unwrap_or(&Value::Null);
+
+		let name = meta.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+		let namespace = meta
+			.get("namespace")
+			.and_then(|v| v.as_str())
+			.unwrap_or("default");
+		let phase = status.get("phase").and_then(|v| v.as_str()).unwrap_or("?");
+		let pod_ip = status
+			.get("podIP")
+			.and_then(|v| v.as_str())
+			.unwrap_or("<none>");
+		let node = spec
+			.get("nodeName")
+			.and_then(|v| v.as_str())
+			.unwrap_or("<none>");
+
+		// Compute READY and RESTARTS from containerStatuses
+		let (ready, total, restarts) = compute_pod_container_stats(status);
+
+		let start_time = status
+			.get("startTime")
+			.and_then(|v| v.as_str())
+			.unwrap_or("");
+		// Simple age extraction (just show startTime if available)
+		let age = start_time;
+
+		let display = if namespace == "default" {
+			name.to_string()
+		} else {
+			format!("{namespace}/{name}")
+		};
+
+		let _ =
+			writeln!(out, "{display}\t{ready}/{total}\t{phase}\t{restarts}\t{age}\t{pod_ip}\t{node}");
+		count += 1;
+	}
+	out.push('\n');
+	let _ = writeln!(out, "{count} pod(s)");
+	out
+}
+
+fn compute_pod_container_stats(status: &Value) -> (usize, usize, i32) {
+	let Some(container_statuses) = status.get("containerStatuses").and_then(|v| v.as_array()) else {
+		return (0, 0, 0);
+	};
+	let total = container_statuses.len();
+	let mut ready = 0usize;
+	let mut restarts = 0i32;
+	for cs in container_statuses {
+		if cs.get("ready").and_then(|v| v.as_bool()).unwrap_or(false) {
+			ready += 1;
+		}
+		restarts += cs.get("restartCount").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+	}
+	(ready, total, restarts)
+}
+
+fn compact_kubectl_services(items: &[Value]) -> String {
+	let mut out = String::from("NAME\tTYPE\tCLUSTER-IP\tEXTERNAL-IP\tPORT(S)\n");
+	let mut count = 0usize;
+	for item in items {
+		let meta = item.get("metadata").unwrap_or(&Value::Null);
+		let spec = item.get("spec").unwrap_or(&Value::Null);
+
+		let name = meta.get("name").and_then(|v| v.as_str()).unwrap_or("?");
+		let namespace = meta
+			.get("namespace")
+			.and_then(|v| v.as_str())
+			.unwrap_or("default");
+		let svc_type = spec
+			.get("type")
+			.and_then(|v| v.as_str())
+			.unwrap_or("ClusterIP");
+		let cluster_ip = spec
+			.get("clusterIP")
+			.and_then(|v| v.as_str())
+			.unwrap_or("<none>");
+
+		// External IP from loadBalancer status
+		let external_ip = item
+			.get("status")
+			.and_then(|s| s.get("loadBalancer"))
+			.and_then(|lb| lb.get("ingress"))
+			.and_then(|ing| ing.as_array())
+			.and_then(|ingress| ingress.first())
+			.and_then(|i| i.get("ip").or_else(|| i.get("hostname")))
+			.and_then(|v| v.as_str())
+			.unwrap_or("<none>");
+
+		// Ports
+		let ports = format_k8s_ports(spec.get("ports").and_then(|v| v.as_array()));
+
+		let display = if namespace == "default" {
+			name.to_string()
+		} else {
+			format!("{namespace}/{name}")
+		};
+
+		let _ = writeln!(out, "{display}\t{svc_type}\t{cluster_ip}\t{external_ip}\t{ports}");
+		count += 1;
+	}
+	out.push('\n');
+	let _ = writeln!(out, "{count} service(s)");
+	out
+}
+
+fn format_k8s_ports(ports: Option<&Vec<Value>>) -> String {
+	let Some(ports) = ports else {
+		return "<none>".to_string();
+	};
+	if ports.is_empty() {
+		return "<none>".to_string();
+	}
+	let parts: Vec<String> = ports
+		.iter()
+		.map(|p| {
+			let port = p
+				.get("port")
+				.and_then(|v| v.as_i64())
+				.map_or_else(|| "?".to_string(), |v| v.to_string());
+			let proto = p.get("protocol").and_then(|v| v.as_str()).unwrap_or("TCP");
+			let node_port = p.get("nodePort").and_then(|v| v.as_i64());
+			let target_port = p.get("targetPort");
+			let target = target_port
+				.and_then(|v| v.as_i64())
+				.map(|v| v.to_string())
+				.or_else(|| target_port.and_then(|v| v.as_str()).map(|s| s.to_string()));
+			match (target, node_port) {
+				(Some(t), Some(np)) => format!("{port}/{t}:{np}->{port}/{proto}"),
+				(Some(t), None) => format!("{port}/{t}:{port}/{proto}"),
+				(None, Some(np)) => format!("{np}:{port}->{port}/{proto}"),
+				(None, None) => format!("{port}/{proto}"),
+			}
+		})
+		.collect();
+	parts.join(",")
 }
 
 fn filter_helm(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> String {
@@ -71,27 +400,191 @@ fn filter_helm(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> String {
 	}
 	match ctx.subcommand {
 		Some("list" | "ls" | "status") => compact_table(input, 20),
-		Some("install" | "upgrade" | "template" | "lint") => compact_build_or_progress(input),
+		Some("install" | "upgrade" | "lint") => compact_build_or_progress(input),
+		Some("template") => input.to_string(),
 		_ => head_tail_dedup(input),
 	}
 }
 
+/// Returns `true` when `tok` is a known docker-compose option that consumes
+/// the next token as its value (i.e. is space-separated, not `--flag=value`).
+fn compose_option_consumes_next(tok: &str) -> bool {
+	matches!(
+		tok,
+		"--ansi"
+			| "--env-file"
+			| "--file"
+			| "-f" | "--parallel"
+			| "--profile"
+			| "--progress"
+			| "--project-directory"
+			| "--project-name"
+			| "--workdir"
+			| "-w"
+	)
+}
+
 fn is_log_command(ctx: &MinimizerCtx<'_>) -> bool {
-	ctx.subcommand == Some("logs") || ctx.command.split_whitespace().any(|part| part == "logs")
+	if ctx.subcommand == Some("logs") {
+		return true;
+	}
+	// `docker compose logs <service>` — the action is `logs` but subcommand
+	// resolves to `compose`.  Find the first non-option token after `compose`
+	// (the action) and check only that.  Scanning further tokens would
+	// misclassify service names or command args: for example,
+	// `docker compose exec logs cat file` has action `exec` and service name
+	// `logs`, and must NOT be routed through log dedup/truncation.
+	if ctx.subcommand == Some("compose") {
+		let mut tokens = ctx.command.split_whitespace();
+		while let Some(tok) = tokens.next() {
+			if tok == "compose" {
+				loop {
+					match tokens.next() {
+						None => return false,
+						Some(tok)
+							if tok.starts_with('-')
+								&& !tok.contains('=')
+								&& compose_option_consumes_next(tok) =>
+						{
+							tokens.next(); // skip value
+						},
+						Some(tok) if tok.starts_with('-') => {}, // skip boolean flag
+						Some(tok) => return tok == "logs",
+					}
+				}
+			}
+		}
+	}
+	false
 }
 
 fn is_table_command(ctx: &MinimizerCtx<'_>) -> bool {
+	// Match `docker ps`, `docker images` (subcommand is argv[1])
+	// or `docker compose ps`, `docker compose images` (subcommand is "compose",
+	// action is argv[2]). Machine-readable listing modes (`-q`/`--quiet`, or
+	// `--format` without Docker's `table` directive) must stay opaque: callers
+	// commonly pipe these IDs/templates into other commands, and `compact_table`
+	// would treat the first ID as a header and drop middle rows.
+	if !is_docker_listing_command(ctx) {
+		return false;
+	}
+	docker_listing_requests_table(ctx.command)
+}
+fn is_docker_listing_command(ctx: &MinimizerCtx<'_>) -> bool {
 	matches!(ctx.subcommand, Some("ps" | "images"))
-		|| ctx
-			.command
-			.split_whitespace()
-			.any(|part| matches!(part, "ps" | "images"))
+		|| ctx.subcommand == Some("compose") && is_compose_listing_action(ctx.command)
+}
+
+fn is_compose_listing_action(command: &str) -> bool {
+	// Advance past the `compose` token, then find the first non-option token
+	// (the action).  Only that token decides whether this is a listing command.
+	// Scanning further tokens would misclassify service names: for example,
+	// `docker compose up ps` has action `up` and service name `ps`, and must
+	// NOT be routed through compact_table.
+	let mut tokens = command
+		.split_whitespace()
+		.skip_while(|token| *token != "compose");
+	if tokens.next() != Some("compose") {
+		return false;
+	}
+	loop {
+		match tokens.next() {
+			None => return false,
+			Some(tok)
+				if tok.starts_with('-') && !tok.contains('=') && compose_option_consumes_next(tok) =>
+			{
+				tokens.next(); // skip value
+			},
+			Some(tok) if tok.starts_with('-') => {}, // skip boolean flag
+			Some(tok) => return matches!(tok, "ps" | "images"),
+		}
+	}
+}
+
+fn docker_listing_requests_table(command: &str) -> bool {
+	let mut tokens = command.split_whitespace();
+	while let Some(token) = tokens.next() {
+		if matches!(token, "-q" | "--quiet") {
+			return false;
+		}
+		if token == "--format" {
+			return tokens.next().is_some_and(docker_format_requests_table);
+		}
+		if let Some(format) = token.strip_prefix("--format=") {
+			return docker_format_requests_table(format);
+		}
+	}
+	true
+}
+
+fn docker_format_requests_table(format: &str) -> bool {
+	let format = format.trim_matches(|c| matches!(c, '"' | '\''));
+	format == "table" || format.starts_with("table ")
 }
 
 fn filter_logs(input: &str) -> String {
 	let without_empty_runs = drop_repeated_blank_lines(input);
 	let deduped = primitives::dedup_consecutive_lines(&without_empty_runs);
 	primitives::head_tail_lines(&deduped, 120, 80)
+}
+
+fn filter_docker_logs(input: &str) -> String {
+	let without_empty_runs = drop_repeated_blank_lines(input);
+	let deduped = dedup_consecutive_log_lines(&without_empty_runs);
+	primitives::head_tail_lines(&deduped, 120, 80)
+}
+
+fn dedup_consecutive_log_lines(input: &str) -> String {
+	let mut out = String::new();
+	let mut previous: Option<&str> = None;
+	let mut previous_key: Option<&str> = None;
+	let mut count = 0usize;
+
+	for line in input.lines() {
+		let key = log_dedup_key(line);
+		if previous_key == Some(key) {
+			count += 1;
+			continue;
+		}
+		flush_repeated_log_line(&mut out, previous, count);
+		previous = Some(line);
+		previous_key = Some(key);
+		count = 1;
+	}
+	flush_repeated_log_line(&mut out, previous, count);
+	out
+}
+
+fn flush_repeated_log_line(out: &mut String, line: Option<&str>, count: usize) {
+	let Some(line) = line else {
+		return;
+	};
+	out.push_str(line);
+	if count > 1 {
+		out.push_str(" (×");
+		out.push_str(&count.to_string());
+		out.push(')');
+	}
+	out.push('\n');
+}
+
+fn log_dedup_key(line: &str) -> &str {
+	if let Some((service, message)) = line.split_once('|') {
+		let service = service.trim();
+		if is_compose_log_service(service) {
+			return message.trim_start();
+		}
+	}
+	line
+}
+
+fn is_compose_log_service(value: &str) -> bool {
+	!value.is_empty()
+		&& !matches!(value, "debug" | "error" | "fatal" | "info" | "trace" | "warn" | "warning")
+		&& value.bytes().any(|byte| byte.is_ascii_lowercase())
+		&& value.bytes().all(|byte| {
+			byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'-' | b'_' | b'.')
+		})
 }
 
 fn compact_table(input: &str, visible_rows: usize) -> String {
@@ -136,11 +629,27 @@ fn compact_build_or_progress(input: &str) -> String {
 fn is_progress_line(line: &str) -> bool {
 	line.starts_with("=> ")
 		|| line.starts_with('#') && line.contains("DONE")
+		|| line.starts_with('#') && line.contains("CACHED")
+		|| line.starts_with('#') && line.contains("transferring ")
+		|| line.starts_with('#') && line.contains("extracting ")
 		|| line.contains("Pulling fs layer")
+		|| line.contains("Pull complete")
 		|| line.contains("Download complete")
+		|| line.contains("Downloading")
 		|| line.contains("Extracting")
 		|| line.contains("Waiting")
 		|| line.contains("Verifying Checksum")
+		|| line.starts_with("Attaching to ")
+		|| line.starts_with("Gracefully stopping")
+		|| is_compose_container_status_line(line)
+}
+
+fn is_compose_container_status_line(line: &str) -> bool {
+	let line = line.trim_start();
+	line.starts_with("Container ")
+		&& ["Creating", "Created", "Starting", "Started", "Waiting", "Healthy", "Running"]
+			.iter()
+			.any(|status| line.contains(status))
 }
 
 fn drop_repeated_blank_lines(input: &str) -> String {
@@ -172,10 +681,170 @@ mod tests {
 
 	#[test]
 	fn dedups_repeated_log_lines_before_truncation() {
-		let input = "api | ready\napi | ready\napi | ready\napi | failed\n";
-		let out = filter_logs(input);
+		let input = "api | ready\napi | ready\napi | ready\napi | done\n";
+		let out = filter_docker_logs(input);
 		assert!(out.contains("api | ready (×3)"));
-		assert!(out.contains("api | failed"));
+		assert!(out.contains("api | done"));
+	}
+
+	#[test]
+	fn dedups_compose_service_prefixed_log_messages() {
+		let input = "api-1  | ready\napi-2  | ready\napi | ready\nworker | busy\n";
+		let out = filter_docker_logs(input);
+		assert!(out.contains("api-1  | ready (×3)"));
+		assert!(out.contains("worker | busy"));
+	}
+
+	#[test]
+	fn docker_compose_logs_uses_log_filter() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let compose_ctx = MinimizerCtx {
+			program:    "docker",
+			subcommand: Some("compose"),
+			command:    "docker compose logs api",
+			config:     &cfg,
+		};
+		let input = "api-1  | ready\napi-2  | ready\napi | ready\n";
+		let out = filter(&compose_ctx, input, 0).text;
+		assert!(out.contains("api-1  | ready (×3)"));
+	}
+
+	#[test]
+	fn docker_compose_logs_skips_option_values() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = MinimizerCtx {
+			program:    "docker",
+			subcommand: Some("compose"),
+			command:    "docker compose --profile ps logs api",
+			config:     &cfg,
+		};
+		assert!(is_log_command(&ctx));
+	}
+
+	#[test]
+	fn compose_exec_with_service_named_logs_is_not_log_command() {
+		// `docker compose exec logs cat file` — action is `exec`, `logs` is a
+		// service name.  Must NOT be routed through log dedup/truncation.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		for cmd in &[
+			"docker compose exec logs cat /etc/hosts",
+			"docker compose run logs bash",
+			"docker compose restart logs",
+		] {
+			let ctx = MinimizerCtx {
+				program:    "docker",
+				subcommand: Some("compose"),
+				command:    cmd,
+				config:     &cfg,
+			};
+			assert!(!is_log_command(&ctx), "`{cmd}` must not be classified as a log command");
+		}
+	}
+
+	#[test]
+	fn docker_logs_preserves_short_context_around_warning() {
+		let input = "starting\nWARN retrying\nready\n";
+		let out = filter_docker_logs(input);
+		assert_eq!(out, input);
+	}
+
+	#[test]
+	fn docker_compose_ps_uses_table_filter() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let compose_ctx = MinimizerCtx {
+			program:    "docker",
+			subcommand: Some("compose"),
+			command:    "docker compose ps",
+			config:     &cfg,
+		};
+		let mut input = String::from("NAME IMAGE COMMAND SERVICE CREATED STATUS PORTS\n");
+		for idx in 0..20 {
+			input.push_str(&format!("svc-{idx} img command api 1m running 8080/tcp\n"));
+		}
+		let out = filter(&compose_ctx, &input, 0).text;
+		assert!(out.contains("20 rows"));
+		assert!(out.contains("svc-0"));
+		assert!(out.contains("… 8 more rows"));
+	}
+
+	#[test]
+	fn docker_compose_ps_skips_option_values() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = MinimizerCtx {
+			program:    "docker",
+			subcommand: Some("compose"),
+			command:    "docker compose --profile logs ps",
+			config:     &cfg,
+		};
+		assert!(is_table_command(&ctx));
+	}
+
+	#[test]
+	fn compose_up_with_service_named_ps_is_not_table_command() {
+		// `docker compose up ps` — action is `up`, `ps` is a service name.
+		// Must NOT be routed through compact_table.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		for cmd in &["docker compose up ps", "docker compose up images", "docker compose restart ps"]
+		{
+			let ctx = MinimizerCtx {
+				program:    "docker",
+				subcommand: Some("compose"),
+				command:    cmd,
+				config:     &cfg,
+			};
+			assert!(!is_table_command(&ctx), "`{cmd}` must not be classified as a table command");
+		}
+	}
+
+	#[test]
+	fn strips_compose_up_progress_lines() {
+		let input = "Attaching to api-1, worker-1\n Container api-1  Creating\n Container api-1  \
+		             Created\napi-1  | ready\n";
+		let out = compact_build_or_progress(input);
+		assert!(!out.contains("Attaching to"));
+		assert!(!out.contains("Container api-1  Creating"));
+		assert!(out.contains("api-1  | ready"));
+	}
+
+	#[test]
+	fn strips_compose_build_progress_lines() {
+		let input = "#1 [internal] load build definition from Dockerfile\n#1 transferring \
+		             dockerfile: 512B done\n#2 [1/2] FROM docker.io/library/node:22\n#2 CACHED\n#3 \
+		             exporting to image\n#3 DONE 0.1s\nnaming to docker.io/library/app:latest\n";
+		let out = compact_build_or_progress(input);
+		assert!(!out.contains("transferring dockerfile"));
+		assert!(!out.contains("#2 CACHED"));
+		assert!(!out.contains("#3 DONE"));
+		assert!(out.contains("naming to docker.io/library/app:latest"));
+	}
+
+	#[test]
+	fn strips_compose_pull_progress_lines() {
+		let input = "app Pulling fs layer\napp Downloading\napp Verifying Checksum\napp Download \
+		             complete\napp Extracting\napp Pull complete\nStatus: Downloaded newer image \
+		             for docker.io/library/app:latest\n";
+		let out = compact_build_or_progress(input);
+		assert!(!out.contains("Pulling fs layer"));
+		assert!(!out.contains("Pull complete"));
+		assert!(out.contains("Status: Downloaded newer image for docker.io/library/app:latest"));
+	}
+
+	#[test]
+	fn truncates_large_logs_without_dropping_all_context() {
+		let mut input = String::new();
+		for i in 0..260 {
+			input.push_str("api-1  | request ");
+			input.push_str(&i.to_string());
+			input.push_str(" complete\n");
+		}
+		input.push_str("api-1  | WARN cache miss\n");
+		input.push_str("worker | failed to process job\n");
+
+		let out = filter_docker_logs(&input);
+		assert!(out.contains("api-1  | request 0 complete"));
+		assert!(out.contains("api-1  | WARN cache miss"));
+		assert!(out.contains("worker | failed to process job"));
+		assert!(out.contains("omitted"));
 	}
 
 	#[test]
@@ -199,6 +868,90 @@ mod tests {
 	}
 
 	#[test]
+	fn docker_ps_quiet_preserves_id_listing_verbatim() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = MinimizerCtx {
+			program:    "docker",
+			subcommand: Some("ps"),
+			command:    "docker ps -q",
+			config:     &cfg,
+		};
+		let mut input = String::new();
+		for idx in 0..220 {
+			let _ = writeln!(input, "{idx:012x}");
+		}
+
+		let out = filter(&ctx, &input, 0).text;
+
+		assert_eq!(out, input, "docker ps -q output is machine-readable and must not be compacted");
+	}
+
+	#[test]
+	fn docker_ps_format_without_table_preserves_template_output_verbatim() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = MinimizerCtx {
+			program:    "docker",
+			subcommand: Some("ps"),
+			command:    "docker ps --format '{{.ID}}'",
+			config:     &cfg,
+		};
+		let mut input = String::new();
+		for idx in 0..220 {
+			let _ = writeln!(input, "{idx:012x}");
+		}
+
+		let out = filter(&ctx, &input, 0).text;
+
+		assert_eq!(
+			out, input,
+			"docker --format without the table directive is exact template output and must not be \
+			 compacted",
+		);
+	}
+
+	#[test]
+	fn docker_images_format_table_still_compacts() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = MinimizerCtx {
+			program:    "docker",
+			subcommand: Some("images"),
+			command:    "docker images --format 'table {{.ID}} {{.Repository}}'",
+			config:     &cfg,
+		};
+		let mut input = String::from("ID REPOSITORY\n");
+		for idx in 0..25 {
+			let _ = writeln!(input, "{idx:012x} repo-{idx}");
+		}
+
+		let out = filter(&ctx, &input, 0).text;
+
+		assert!(out.contains("25 rows"), "docker --format table output should still compact: {out}");
+		assert!(
+			out.contains("… 13 more rows"),
+			"docker --format table should keep table omission: {out}"
+		);
+	}
+
+	#[test]
+	fn docker_compose_ps_format_without_table_preserves_template_output_verbatim() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = MinimizerCtx {
+			program:    "docker",
+			subcommand: Some("compose"),
+			command:    "docker compose ps --format '{{.ID}}'",
+			config:     &cfg,
+		};
+		let mut input = String::new();
+		for idx in 0..220 {
+			let _ = writeln!(input, "{idx:012x}");
+		}
+
+		let out = filter(&ctx, &input, 0).text;
+
+		assert_eq!(out, input, "docker compose ps formatted output must not be compacted");
+	}
+
+	#[test]
 	fn failing_table_commands_preserve_full_diagnostics() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
 		let docker_ctx = ctx("docker", Some("ps"), &cfg);
@@ -213,5 +966,242 @@ mod tests {
 		assert_eq!(filter(&docker_ctx, &input, 1).text, input);
 		assert_eq!(filter(&kubectl_ctx, &input, 1).text, input);
 		assert_eq!(filter(&helm_ctx, &input, 1).text, input);
+	}
+
+	// ── kubectl JSON tests ───────────────────────────────────────────────
+
+	#[test]
+	fn compacts_kubectl_get_pods_json() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let kubectl_ctx = ctx("kubectl", Some("get"), &cfg);
+		let input = r#"{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "metadata": {
+                "name": "nginx-pod",
+                "namespace": "default"
+            },
+            "spec": {
+                "nodeName": "node-1",
+                "containers": [{"name": "nginx", "image": "nginx:latest"}]
+            },
+            "status": {
+                "phase": "Running",
+                "podIP": "10.0.0.1",
+                "startTime": "2024-01-15T10:00:00Z",
+                "containerStatuses": [
+                    {"name": "nginx", "ready": true, "restartCount": 0}
+                ]
+            },
+            "kind": "Pod"
+        },
+        {
+            "metadata": {
+                "name": "failing-pod",
+                "namespace": "kube-system"
+            },
+            "spec": {
+                "nodeName": "node-2",
+                "containers": [
+                    {"name": "app", "image": "app:v1"},
+                    {"name": "sidecar", "image": "sidecar:v1"}
+                ]
+            },
+            "status": {
+                "phase": "Running",
+                "podIP": "10.0.0.2",
+                "startTime": "2024-01-15T09:00:00Z",
+                "containerStatuses": [
+                    {"name": "app", "ready": true, "restartCount": 3},
+                    {"name": "sidecar", "ready": false, "restartCount": 1}
+                ]
+            },
+            "kind": "Pod"
+        }
+    ],
+    "kind": "List"
+}"#;
+		let out = filter(&kubectl_ctx, input, 0).text;
+		assert!(out.contains("nginx-pod\t1/1\tRunning\t0"));
+		assert!(out.contains("kube-system/failing-pod\t1/2\tRunning\t4"));
+		assert!(out.contains("2 pod(s)"));
+	}
+
+	#[test]
+	fn compacts_kubectl_get_services_json() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let kubectl_ctx = ctx("kubectl", Some("get"), &cfg);
+		let input = r#"{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "metadata": { "name": "my-svc", "namespace": "default" },
+            "spec": {
+                "type": "ClusterIP",
+                "clusterIP": "10.0.0.10",
+                "ports": [
+                    {"port": 80, "targetPort": 8080, "protocol": "TCP"}
+                ]
+            },
+            "kind": "Service"
+        },
+        {
+            "metadata": { "name": "lb-svc", "namespace": "prod" },
+            "spec": {
+                "type": "LoadBalancer",
+                "clusterIP": "10.0.0.20",
+                "ports": [
+                    {"port": 443, "targetPort": 8443, "protocol": "TCP", "nodePort": 30001}
+                ]
+            },
+            "status": {
+                "loadBalancer": {
+                    "ingress": [{"ip": "203.0.113.1"}]
+                }
+            },
+            "kind": "Service"
+        }
+    ],
+    "kind": "List"
+}"#;
+		let out = filter(&kubectl_ctx, input, 0).text;
+		assert!(out.contains("my-svc\tClusterIP\t10.0.0.10\t<none>\t80/8080:80/TCP"));
+		assert!(
+			out.contains("prod/lb-svc\tLoadBalancer\t10.0.0.20\t203.0.113.1\t443/8443:30001->443/TCP")
+		);
+		assert!(out.contains("2 service(s)"));
+	}
+
+	#[test]
+	fn kubectl_json_parse_failure_falls_back_to_table() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let kubectl_ctx = ctx("kubectl", Some("get"), &cfg);
+		let mut input = String::from("NAME STATUS\n");
+		for i in 0..25 {
+			input.push_str(&format!("pod-{} running\n", i));
+		}
+		let out = filter(&kubectl_ctx, &input, 0).text;
+		// Should use table compaction, not crash
+		assert!(out.contains("25 rows"));
+		assert!(out.contains("pod-0"));
+	}
+
+	#[test]
+	fn kubectl_non_list_json_returns_unchanged() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let kubectl_ctx = ctx("kubectl", Some("get"), &cfg);
+		// Valid JSON but not a kubectl List — unrecognized
+		let input = r#"{"apiVersion": "v1", "kind": "Pod", "metadata": {"name": "single"}}"#;
+		let out = filter(&kubectl_ctx, input, 0).text;
+		// Falls back — table compaction would try to process this
+		// The key is: doesn't crash, doesn't lose data
+		assert!(!out.is_empty());
+	}
+
+	#[test]
+	fn failing_kubectl_get_json_preserves_error() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let kubectl_ctx = ctx("kubectl", Some("get"), &cfg);
+		let input = "Error from server (Forbidden): pods is forbidden\n";
+		let out = filter(&kubectl_ctx, input, 1).text;
+		// Non-zero exit with non-logs → preserve verbatim
+		assert_eq!(out, input);
+	}
+
+	#[test]
+	fn helm_template_keeps_manifest_yaml_opaque() {
+		// `helm template` renders chart manifests — arbitrary YAML, not build
+		// progress. Lines like "phase: Waiting" are field values, not status
+		// noise, so they must not be dropped by compact_build_or_progress.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let helm_ctx = ctx("helm", Some("template"), &cfg);
+		let input =
+			"apiVersion: v1\nkind: ConfigMap\ndata:\n  phase: Waiting\n  action: Downloading\n";
+		let out = filter(&helm_ctx, input, 0).text;
+		assert_eq!(out, input, "helm template output must be preserved verbatim");
+	}
+
+	// ── Attached -o format tests ────────────────────────────────────────────
+
+	#[test]
+	fn kubectl_get_ojson_attached_preserves_json() {
+		// `-ojson` (no space, no `=`) must be treated as `-o json`.
+		// A kubectl List JSON must NOT be rewritten into a table summary.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = MinimizerCtx {
+			program:    "kubectl",
+			subcommand: Some("get"),
+			command:    "kubectl get pods -ojson",
+			config:     &cfg,
+		};
+		let input = r#"{"apiVersion":"v1","kind":"List","items":[{"kind":"Pod","metadata":{"name":"p","namespace":"default"},"spec":{"nodeName":"n","containers":[{"name":"c","image":"img"}]},"status":{"phase":"Running","podIP":"1.2.3.4","startTime":"2024-01-01T00:00:00Z","containerStatuses":[{"name":"c","ready":true,"restartCount":0}]}}]}"#;
+		let out = filter(&ctx, input, 0).text;
+		assert_eq!(out, input, "-ojson must passthrough verbatim, not be compacted to a table");
+	}
+
+	#[test]
+	fn kubectl_get_oyaml_attached_preserves_yaml() {
+		// `-oyaml` must be treated as `-o yaml` — passthrough, no table compaction.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = MinimizerCtx {
+			program:    "kubectl",
+			subcommand: Some("get"),
+			command:    "kubectl get pod my-pod -oyaml",
+			config:     &cfg,
+		};
+		let input = "apiVersion: v1\nkind: Pod\nmetadata:\n  name: my-pod\nspec:\n  containers: []\n";
+		let out = filter(&ctx, input, 0).text;
+		assert_eq!(out, input, "-oyaml must passthrough verbatim");
+	}
+
+	#[test]
+	fn kubectl_get_oname_attached_skips_table_compaction() {
+		// `-oname` must be treated as `-o name` — listings, not tables.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = MinimizerCtx {
+			program:    "kubectl",
+			subcommand: Some("get"),
+			command:    "kubectl get pods -oname",
+			config:     &cfg,
+		};
+		// `-o name` output is one `resource/name` per line — compact_table
+		// would corrupt it by treating the first line as a header.
+		let input = "pod/alpha\npod/beta\npod/gamma\n";
+		let out = filter(&ctx, input, 0).text;
+		assert!(!out.contains("rows"), "-oname output must not be table-compacted, got: {out}");
+	}
+
+	#[test]
+	fn kubectl_get_ojsonpath_attached_skips_table_compaction() {
+		// `-ojsonpath=...` must be treated as non-table.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = MinimizerCtx {
+			program:    "kubectl",
+			subcommand: Some("get"),
+			command:    "kubectl get pods -ojsonpath={.items[*].metadata.name}",
+			config:     &cfg,
+		};
+		let input = "alpha beta gamma\n";
+		let out = filter(&ctx, input, 0).text;
+		assert!(!out.contains("rows"), "-ojsonpath output must not be table-compacted, got: {out}");
+	}
+
+	#[test]
+	fn kubectl_get_owide_attached_still_compacts_table() {
+		// `-owide` IS a table format — it must still go through compact_table.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = MinimizerCtx {
+			program:    "kubectl",
+			subcommand: Some("get"),
+			command:    "kubectl get pods -owide",
+			config:     &cfg,
+		};
+		let mut input = String::from("NAME READY STATUS RESTARTS AGE IP NODE\n");
+		for i in 0..25 {
+			input.push_str(&format!("pod-{i} 1/1 Running 0 1h 10.0.0.{i} node\n"));
+		}
+		let out = filter(&ctx, input.as_str(), 0).text;
+		assert!(out.contains("rows"), "-owide is a table format and must be compacted, got: {out}");
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/generic.rs
+++ b/crates/pi-shell/src/minimizer/filters/generic.rs
@@ -5,8 +5,8 @@ use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
 pub fn filter(_ctx: &MinimizerCtx<'_>, input: &str, _exit_code: i32) -> MinimizerOutput {
 	let stripped = primitives::strip_ansi(input);
 	let deduped = primitives::dedup_consecutive_lines(&stripped);
-	let text = if deduped.lines().count() > 200 {
-		primitives::head_tail_lines(&deduped, 100, 60)
+	let text = if deduped.lines().count() > primitives::CapClass::Errors.lines() {
+		primitives::head_tail_cap(&deduped, primitives::CapClass::Errors)
 	} else {
 		deduped
 	};

--- a/crates/pi-shell/src/minimizer/filters/git.rs
+++ b/crates/pi-shell/src/minimizer/filters/git.rs
@@ -1,14 +1,17 @@
 //! Git output filters.
 
+use std::fmt::Write as _;
+
 use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
 
 pub fn supports(subcommand: Option<&str>) -> bool {
 	matches!(
 		subcommand,
 		Some(
-			"diff"
-				| "show" | "log"
-				| "add" | "commit"
+			"status"
+				| "diff" | "show"
+				| "log" | "add"
+				| "commit"
 				| "push" | "pull"
 				| "branch"
 				| "fetch"
@@ -26,22 +29,53 @@ pub fn supports(subcommand: Option<&str>) -> bool {
 	)
 }
 
-pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, _exit_code: i32) -> MinimizerOutput {
+pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerOutput {
 	if is_show_path_content(ctx.command) || is_stash_patch(ctx.command) {
 		return MinimizerOutput::passthrough(input);
 	}
 
 	let cleaned = primitives::strip_ansi(input);
 	let text = match ctx.subcommand {
-		Some("diff") => condense_diff(&cleaned),
-		Some("show") => primitives::head_tail_lines(&cleaned, 80, 40),
+		Some("status") if is_status_machine_format(ctx.command) => cleaned,
+		Some("status") => condense_status(&cleaned),
+		Some("diff") if has_token(ctx.command, "--summary") => cleaned,
+		Some("diff") if is_stat_format(ctx.command) => condense_diff_stat(&cleaned),
+		Some("diff") => {
+			if exit_code == 0 {
+				if let Some(mode) = diff_listing_mode(ctx.command) {
+					compact_diff_listing(&cleaned, mode)
+				} else {
+					compact_diff_output(&cleaned)
+				}
+			} else {
+				compact_diff_output(&cleaned)
+			}
+		},
+		Some("show") if is_show_custom_format(ctx.command) => cleaned,
+		Some("show") => condense_show(&cleaned),
+		Some("log") if is_log_custom_format(ctx.command) => cleaned,
 		Some("log") => condense_log(&cleaned, 32, 16),
-		Some("branch" | "stash" | "tag") => primitives::compact_listing(&cleaned, 40),
+		// Non-listing branch formats produce single values or one-liner
+		// confirmations (e.g. `--show-current` → `main`, `--delete` →
+		// `Deleted branch feature (was abc123).`).  `condense_branch`
+		// would rewrite those as `local: main\n` / `local: Deleted
+		// branch…`, changing the meaning of the requested output, so
+		// skip it and passthrough the cleaned buffer.
+		Some("branch") if is_branch_non_listing(ctx.command) => cleaned,
+		Some("branch") => condense_branch(&cleaned),
+		Some("tag") if is_tag_non_listing(ctx.command) => cleaned,
+		Some("tag") => primitives::compact_listing(&cleaned, 40),
+		Some("stash") => condense_stash(ctx.command, &cleaned, exit_code),
 		Some("worktree") => cleaned,
-		Some(
-			"push" | "pull" | "fetch" | "merge" | "rebase" | "checkout" | "switch" | "restore"
-			| "clean" | "reset" | "add" | "commit",
-		) => condense_noisy_output(&cleaned),
+		Some("push") if has_token(ctx.command, "--porcelain") => cleaned,
+		Some("push") => condense_push(&cleaned, exit_code),
+		Some("pull") => condense_pull(&cleaned, exit_code),
+		Some("fetch") if has_token(ctx.command, "--porcelain") => cleaned,
+		Some("fetch") => condense_fetch(&cleaned, exit_code),
+		Some("commit") => condense_commit(&cleaned, exit_code),
+		Some("merge" | "rebase" | "checkout" | "switch" | "restore" | "clean" | "reset" | "add") => {
+			condense_noisy_output(&cleaned)
+		},
 		_ => cleaned,
 	};
 	if text == input {
@@ -84,6 +118,368 @@ fn has_ordered_tokens(command: &str, first: &str, second: &str) -> bool {
 
 fn has_token(command: &str, token: &str) -> bool {
 	command.split_whitespace().any(|part| part == token)
+}
+
+/// Whether `command` carries `--flag` in either the space-separated
+/// (`--flag value`) or the inline (`--flag=value`) form. `has_token` only
+/// matches the bare token, so inline `=`-joined flags (e.g. `--format=%H`)
+/// would otherwise slip through guards that key off the flag name alone.
+fn has_flag(command: &str, flag: &str) -> bool {
+	let inline_prefix = format!("{flag}=");
+	command
+		.split_whitespace()
+		.any(|part| part == flag || part.starts_with(&inline_prefix))
+}
+
+fn is_status_machine_format(command: &str) -> bool {
+	command.split_whitespace().any(|part| {
+		matches!(part, "--porcelain" | "--porcelain=v1" | "--porcelain=v2" | "--null")
+			|| part == "-z"
+			|| part.starts_with('-') && !part.starts_with("--") && part.contains('z')
+	})
+}
+
+fn is_stat_format(command: &str) -> bool {
+	command
+		.split_whitespace()
+		.any(|part| part == "--stat" || part.starts_with("--stat="))
+}
+
+#[derive(Clone, Copy)]
+enum DiffListingMode {
+	NameOnly,
+	NameStatus,
+	Numstat,
+}
+
+const DIFF_LISTING_LIMIT: usize = 20;
+
+impl DiffListingMode {
+	const fn label(self) -> &'static str {
+		match self {
+			Self::NameOnly => "--name-only",
+			Self::NameStatus => "--name-status",
+			Self::Numstat => "--numstat",
+		}
+	}
+}
+
+fn diff_listing_mode(command: &str) -> Option<DiffListingMode> {
+	if has_token(command, "--name-only") {
+		Some(DiffListingMode::NameOnly)
+	} else if has_token(command, "--name-status") {
+		Some(DiffListingMode::NameStatus)
+	} else if has_token(command, "--numstat") {
+		Some(DiffListingMode::Numstat)
+	} else {
+		None
+	}
+}
+
+fn compact_diff_listing(input: &str, mode: DiffListingMode) -> String {
+	let mut entries = Vec::new();
+	for line in input.lines() {
+		if line.is_empty() {
+			continue;
+		}
+		if !is_diff_listing_line(mode, line) {
+			return input.to_string();
+		}
+		entries.push(line.to_string());
+	}
+
+	if entries.len() <= DIFF_LISTING_LIMIT {
+		return input.to_string();
+	}
+
+	let mut out = String::new();
+	let _ = writeln!(out, "git diff {}: {}", mode.label(), format_file_count(entries.len()));
+	for entry in entries.iter().take(DIFF_LISTING_LIMIT) {
+		out.push_str(entry);
+		out.push('\n');
+	}
+	let _ = writeln!(out, "… {} files omitted …", entries.len() - DIFF_LISTING_LIMIT);
+	out
+}
+
+fn is_diff_listing_line(mode: DiffListingMode, line: &str) -> bool {
+	match mode {
+		DiffListingMode::NameOnly => true,
+		DiffListingMode::NameStatus => line.split('\t').count() >= 2,
+		DiffListingMode::Numstat => line.split('\t').count() >= 3,
+	}
+}
+
+#[derive(Default)]
+struct StatusSummary {
+	branch:     Option<String>,
+	stash:      Option<String>,
+	divergence: Option<String>,
+	clean:      bool,
+	staged:     usize,
+	unstaged:   usize,
+	untracked:  usize,
+	conflicts:  usize,
+	paths:      Vec<String>,
+}
+
+fn condense_status(input: &str) -> String {
+	let mut summary = StatusSummary::default();
+	let mut in_untracked = false;
+	// Long-format `git status` groups entries under section headers. `modified:`
+	// and `deleted:` appear in both the staged ("Changes to be committed:") and
+	// unstaged ("Changes not staged for commit:") sections, so we must track the
+	// active section to count them correctly.
+	let mut in_staged = false;
+	let mut state: Option<&str> = None;
+
+	for line in input.lines() {
+		let line = line.trim_end();
+		let trimmed = line.trim();
+		if trimmed.is_empty() {
+			continue;
+		}
+		if let Some(branch) = line.strip_prefix("## ") {
+			summary.branch = Some(branch.to_string());
+			continue;
+		}
+		if parse_short_status_line(line, &mut summary) {
+			continue;
+		}
+		if let Some(branch) = trimmed.strip_prefix("On branch ") {
+			summary.branch = Some(branch.to_string());
+			continue;
+		}
+		if trimmed.starts_with("Your branch is ahead")
+			|| trimmed.starts_with("Your branch is behind")
+			|| trimmed.starts_with("Your branch and")
+			|| trimmed.starts_with("HEAD detached")
+		{
+			summary.divergence = Some(trimmed.to_string());
+			continue;
+		}
+		if trimmed.starts_with("Your stash currently has ") {
+			summary.stash = Some(trimmed.to_string());
+			continue;
+		}
+		if trimmed.starts_with("nothing to commit") || trimmed == "working tree clean" {
+			summary.clean = true;
+			continue;
+		}
+		if let Some(detected) = detect_status_state(trimmed) {
+			if state.is_none() {
+				state = Some(detected);
+			}
+			continue;
+		}
+		if trimmed.starts_with("Changes to be committed:") {
+			in_staged = true;
+			in_untracked = false;
+			continue;
+		}
+		if trimmed.starts_with("Changes not staged for commit:")
+			|| trimmed.starts_with("Unmerged paths:")
+		{
+			in_staged = false;
+			in_untracked = false;
+			continue;
+		}
+		if trimmed.starts_with("Untracked files:") {
+			in_untracked = true;
+			in_staged = false;
+			continue;
+		}
+		if parse_long_status_line(trimmed, in_staged, in_untracked, &mut summary) {
+			continue;
+		}
+		if !trimmed.starts_with('(')
+			&& !trimmed.ends_with(':')
+			&& !trimmed.starts_with("use ")
+			&& !trimmed.starts_with("no changes added")
+			&& in_untracked
+		{
+			summary.untracked += 1;
+			push_status_path(&mut summary, "??", trimmed);
+		}
+	}
+
+	if status_has_no_signal(&summary) && state.is_none() {
+		return input.to_string();
+	}
+	let body = format_status_summary(&summary);
+	match state {
+		Some(s) => {
+			let mut out = String::with_capacity(7 + s.len() + 1 + body.len());
+			out.push_str("state: ");
+			out.push_str(s);
+			out.push('\n');
+			out.push_str(&body);
+			out
+		},
+		None => body,
+	}
+}
+fn detect_status_state(line: &str) -> Option<&str> {
+	if line.starts_with("You are currently rebasing") {
+		Some("rebasing")
+	} else if line.starts_with("You are currently cherry-picking") {
+		Some("cherry-pick")
+	} else if line.starts_with("You are currently reverting") {
+		Some("revert")
+	} else if line.starts_with("You are currently bisecting") {
+		Some("bisect")
+	} else if line.starts_with("You are in the middle of an am session") {
+		Some("am")
+	} else if line.starts_with("You are in a sparse checkout") {
+		Some("sparse-checkout")
+	} else if line == "You have unmerged paths." {
+		Some("merge-conflict")
+	} else {
+		None
+	}
+}
+
+fn parse_short_status_line(line: &str, summary: &mut StatusSummary) -> bool {
+	let Some(status) = line.get(..2) else {
+		return false;
+	};
+	let Some(path) = line.get(3..) else {
+		return false;
+	};
+	if !is_short_status(status) {
+		return false;
+	}
+	if status == "  " {
+		return false;
+	}
+	if status == "!!" {
+		return true;
+	}
+	if status == "??" {
+		summary.untracked += 1;
+	} else if status.contains('U') {
+		summary.conflicts += 1;
+	} else {
+		let bytes = status.as_bytes();
+		if bytes[0] != b' ' {
+			summary.staged += 1;
+		}
+		if bytes[1] != b' ' {
+			summary.unstaged += 1;
+		}
+	}
+	push_status_path(summary, status.trim(), path.trim());
+	true
+}
+
+fn is_short_status(status: &str) -> bool {
+	status
+		.bytes()
+		.all(|byte| matches!(byte, b' ' | b'M' | b'A' | b'D' | b'R' | b'C' | b'U' | b'?' | b'!'))
+}
+
+fn parse_long_status_line(
+	line: &str,
+	in_staged: bool,
+	in_untracked: bool,
+	summary: &mut StatusSummary,
+) -> bool {
+	// `modified:`/`deleted:` are staged or unstaged depending on the active
+	// section; `new file:`/`renamed:` only appear staged. The unmerged-path
+	// forms are always conflicts regardless of section.
+	for (prefix, label, staged) in [
+		("modified:", "M", in_staged),
+		("deleted:", "D", in_staged),
+		("new file:", "A", true),
+		("renamed:", "R", true),
+		("both modified:", "UU", false),
+		("both added:", "AA", false),
+		("both deleted:", "DD", false),
+		("added by us:", "AU", false),
+		("added by them:", "UA", false),
+		("deleted by us:", "DU", false),
+		("deleted by them:", "UD", false),
+	] {
+		if let Some(path) = line.strip_prefix(prefix) {
+			if matches!(label, "UU" | "AA" | "DD" | "AU" | "UA" | "DU" | "UD") {
+				summary.conflicts += 1;
+			} else if staged {
+				summary.staged += 1;
+			} else {
+				summary.unstaged += 1;
+			}
+			push_status_path(summary, label, path.trim());
+			return true;
+		}
+	}
+	if in_untracked && !line.starts_with('(') && !line.ends_with(':') {
+		summary.untracked += 1;
+		push_status_path(summary, "??", line);
+		return true;
+	}
+	false
+}
+
+fn push_status_path(summary: &mut StatusSummary, label: &str, path: &str) {
+	if path.is_empty() {
+		return;
+	}
+	summary
+		.paths
+		.push(format!("{label} {}", primitives::truncate_line(path, 160)));
+}
+
+const fn status_has_no_signal(summary: &StatusSummary) -> bool {
+	summary.branch.is_none()
+		&& summary.stash.is_none()
+		&& summary.divergence.is_none()
+		&& !summary.clean
+		&& summary.staged == 0
+		&& summary.unstaged == 0
+		&& summary.untracked == 0
+		&& summary.conflicts == 0
+}
+
+fn format_status_summary(summary: &StatusSummary) -> String {
+	let mut out = String::new();
+	if let Some(branch) = &summary.branch {
+		out.push_str("branch ");
+		out.push_str(branch);
+		out.push('\n');
+	}
+	if let Some(div) = &summary.divergence {
+		out.push_str(div);
+		out.push('\n');
+	}
+	if let Some(stash) = &summary.stash {
+		out.push_str(stash);
+		out.push('\n');
+	}
+	if summary.clean && summary.paths.is_empty() {
+		out.push_str("clean\n");
+		return out;
+	}
+	out.push_str("staged ");
+	out.push_str(&summary.staged.to_string());
+	out.push_str(", unstaged ");
+	out.push_str(&summary.unstaged.to_string());
+	out.push_str(", untracked ");
+	out.push_str(&summary.untracked.to_string());
+	if summary.conflicts > 0 {
+		out.push_str(", conflicts ");
+		out.push_str(&summary.conflicts.to_string());
+	}
+	out.push('\n');
+	for path in summary.paths.iter().take(40) {
+		out.push_str(path);
+		out.push('\n');
+	}
+	if summary.paths.len() > 40 {
+		out.push_str("… ");
+		out.push_str(&(summary.paths.len() - 40).to_string());
+		out.push_str(" paths omitted\n");
+	}
+	out
 }
 
 fn condense_log(input: &str, head: usize, tail: usize) -> String {
@@ -131,6 +527,7 @@ fn condense_log(input: &str, head: usize, tail: usize) -> String {
 struct LogEntry {
 	hash:    String,
 	subject: String,
+	body:    Vec<String>,
 }
 
 fn push_log_entry(out: &mut String, entry: &LogEntry) {
@@ -140,6 +537,11 @@ fn push_log_entry(out: &mut String, entry: &LogEntry) {
 		out.push_str(&entry.subject);
 	}
 	out.push('\n');
+	for line in &entry.body {
+		out.push_str("  ");
+		out.push_str(line);
+		out.push('\n');
+	}
 }
 
 fn parse_log_entries(input: &str) -> Vec<LogEntry> {
@@ -155,28 +557,26 @@ fn parse_log_entries(input: &str) -> Vec<LogEntry> {
 			let (hash, subject) = trimmed
 				.split_once(' ')
 				.map_or((trimmed, ""), |(hash, subject)| (hash, subject.trim()));
-			current = Some(LogEntry { hash: short_hash(hash), subject: subject.to_string() });
+			current = Some(LogEntry {
+				hash:    short_hash(hash),
+				subject: subject.to_string(),
+				body:    Vec::new(),
+			});
 			continue;
 		}
 
 		let Some(entry) = current.as_mut() else {
 			continue;
 		};
-		if !entry.subject.is_empty() {
-			continue;
-		}
 		let trimmed = line.trim();
-		if trimmed.is_empty()
-			|| trimmed.starts_with("Author:")
-			|| trimmed.starts_with("Date:")
-			|| trimmed.starts_with("Merge:")
-			|| trimmed.contains('|')
-			|| trimmed.contains("files changed")
-			|| trimmed.contains("file changed")
-		{
+		if skip_log_line(trimmed) {
 			continue;
 		}
-		entry.subject = trimmed.to_string();
+		if entry.subject.is_empty() {
+			entry.subject = trimmed.to_string();
+		} else if entry.body.len() < 3 && !is_git_trailer(trimmed) {
+			entry.body.push(trimmed.to_string());
+		}
 	}
 
 	if let Some(entry) = current {
@@ -187,6 +587,254 @@ fn parse_log_entries(input: &str) -> Vec<LogEntry> {
 
 fn short_hash(hash: &str) -> String {
 	hash.chars().take(7).collect()
+}
+
+fn skip_log_line(trimmed: &str) -> bool {
+	trimmed.is_empty()
+		|| trimmed.starts_with("Author:")
+		|| trimmed.starts_with("Date:")
+		|| trimmed.starts_with("Merge:")
+		|| is_log_stat_line(trimmed)
+		|| trimmed.contains("files changed")
+		|| trimmed.contains("file changed")
+}
+
+fn is_log_stat_line(trimmed: &str) -> bool {
+	let Some((_path, stat)) = trimmed.split_once(" | ") else {
+		return false;
+	};
+	stat
+		.trim_start()
+		.bytes()
+		.next()
+		.is_some_and(|byte| byte.is_ascii_digit())
+}
+
+fn is_git_trailer(trimmed: &str) -> bool {
+	const TRAILERS: &[&str] = &[
+		"Signed-off-by:",
+		"Co-authored-by:",
+		"Acked-by:",
+		"Reviewed-by:",
+		"Tested-by:",
+		"Reported-by:",
+		"Helped-by:",
+		"Suggested-by:",
+		"Change-Id:",
+		"Refs:",
+	];
+	TRAILERS.iter().any(|prefix| trimmed.starts_with(prefix))
+}
+
+fn condense_show(input: &str) -> String {
+	let Some(diff_start) = input.find("\ndiff --git ") else {
+		return primitives::head_tail_lines(input, 80, 40);
+	};
+	let prelude = &input[..diff_start];
+	let diff = &input[diff_start + 1..];
+	let diff_summary = compact_diff_output(diff);
+	if diff_summary == diff {
+		return primitives::head_tail_lines(input, 80, 40);
+	}
+
+	let mut out = String::new();
+	push_show_commit_summary(&mut out, prelude);
+	if !out.is_empty() {
+		out.push('\n');
+	}
+	out.push_str(&diff_summary);
+	out
+}
+
+fn push_show_commit_summary(out: &mut String, prelude: &str) {
+	let mut body_lines = 0usize;
+	for line in prelude.lines() {
+		let trimmed = line.trim();
+		if let Some(rest) = trimmed.strip_prefix("commit ") {
+			out.push_str("commit ");
+			out.push_str(&short_hash(rest));
+			out.push('\n');
+			continue;
+		}
+		if skip_log_line(trimmed) || is_git_trailer(trimmed) {
+			continue;
+		}
+		if trimmed.starts_with("diff --git") {
+			break;
+		}
+		if body_lines >= 4 {
+			continue;
+		}
+		out.push_str(trimmed);
+		out.push('\n');
+		body_lines += 1;
+	}
+}
+/// Whether `git branch` was invoked with non-listing flags (mutations, value
+/// retrieval, or config) whose output `condense_branch` would corrupt by
+/// treating the output as a listing.
+fn is_branch_non_listing(command: &str) -> bool {
+	let tokens: Vec<&str> = command.split_whitespace().collect();
+	// Find the "branch" token and scan flags after it
+	let idx = tokens.iter().position(|&t| t == "branch");
+	let Some(idx) = idx else { return false };
+	tokens[idx + 1..].iter().any(|&tok| {
+		if !tok.starts_with('-') {
+			return false; // non-flag args after the command (branch names) are fine
+		}
+		!matches!(
+			tok,
+			// Listing flags — skip to allow `condense_branch` to handle them
+			"--list"
+				| "-l" | "--merged"
+				| "--no-merged"
+				| "--contains"
+				| "--no-contains"
+				| "--points-at"
+				| "--verbose"
+				| "-v" | "--all"
+				| "-a" | "--remotes"
+				| "-r" | "--sort"
+				| "--column"
+				| "--no-column"
+				| "--ignore-case"
+				| "--abbrev"
+		)
+	})
+}
+/// Whether `git tag` was invoked with non-listing flags (verification,
+/// deletion, creation, or custom formatting) whose output `compact_listing`
+/// would corrupt by treating it as a plain tag-name listing.
+fn is_tag_non_listing(command: &str) -> bool {
+	if !has_token(command, "tag") {
+		return false;
+	}
+
+	let tokens: Vec<&str> = command.split_whitespace().collect();
+	let idx = tokens.iter().position(|&t| t == "tag");
+	let Some(idx) = idx else { return false };
+	tokens[idx + 1..].iter().any(|&tok| {
+		if !tok.starts_with('-') {
+			return false;
+		}
+		!matches!(
+			tok,
+			"--list"
+				| "-l" | "--contains"
+				| "--no-contains"
+				| "--merged"
+				| "--no-merged"
+				| "--points-at"
+				| "--sort"
+				| "--column"
+				| "--no-column"
+				| "--ignore-case"
+		)
+	})
+}
+
+/// Whether `git show` was invoked with custom output format flags that
+/// `condense_show` would corrupt (pre-diff content would be truncated/
+/// rewritten as commit summary).
+fn is_show_custom_format(command: &str) -> bool {
+	// `--format`/`--pretty` accept both space-separated (`--format fuller`) and
+	// inline (`--format=%H`, `--pretty=fuller`) forms; both rewrite the commit
+	// prelude that `condense_show` would otherwise truncate, so treat either
+	// form as a custom format. `--diff-filter` likewise takes an inline value.
+	has_flag(command, "--format")
+		|| has_flag(command, "--pretty")
+		|| has_flag(command, "--diff-filter")
+		|| has_token(command, "--name-only")
+		|| has_token(command, "--name-status")
+		|| has_token(command, "--stat")
+		|| has_token(command, "--numstat")
+		|| has_token(command, "--shortstat")
+		|| has_token(command, "--summary")
+		|| has_token(command, "--check")
+		|| has_token(command, "--dirstat")
+}
+
+fn is_log_custom_format(command: &str) -> bool {
+	has_flag(command, "--format") || has_flag(command, "--pretty") || has_token(command, "--oneline")
+}
+
+fn condense_branch(input: &str) -> String {
+	let mut current: Option<String> = None;
+	let mut local = Vec::new();
+	let mut remote_only = Vec::new();
+
+	for line in input.lines() {
+		let trimmed = line.trim();
+		if trimmed.is_empty() || trimmed.contains(" -> ") {
+			continue;
+		}
+		let (is_current, name) = trimmed
+			.strip_prefix('*')
+			.map_or((false, trimmed), |rest| (true, rest.trim()));
+		if name.is_empty() {
+			continue;
+		}
+		if is_current {
+			current = Some(name.to_string());
+		} else if name.starts_with("remotes/") {
+			remote_only.push(name.trim_start_matches("remotes/").to_string());
+		} else {
+			local.push(name.to_string());
+		}
+	}
+
+	if current.is_none() && local.is_empty() && remote_only.is_empty() {
+		return input.to_string();
+	}
+
+	let mut out = String::new();
+	if let Some(current) = current.as_deref() {
+		out.push_str("* ");
+		out.push_str(current);
+		out.push('\n');
+	}
+	if !local.is_empty() {
+		out.push_str("local:");
+		for branch in local.iter().take(24) {
+			out.push(' ');
+			out.push_str(branch);
+		}
+		if local.len() > 24 {
+			out.push_str(" … +");
+			out.push_str(&(local.len() - 24).to_string());
+		}
+		out.push('\n');
+	}
+	let remote_only = remote_only
+		.into_iter()
+		.filter(|branch| !has_local_tracking_branch(branch, current.as_deref(), &local))
+		.collect::<Vec<_>>();
+	if !remote_only.is_empty() {
+		out.push_str("remote-only (");
+		out.push_str(&remote_only.len().to_string());
+		out.push_str("):");
+		for branch in remote_only.iter().take(24) {
+			out.push(' ');
+			out.push_str(branch);
+		}
+		if remote_only.len() > 24 {
+			out.push_str(" … +");
+			out.push_str(&(remote_only.len() - 24).to_string());
+		}
+		out.push('\n');
+	}
+	out
+}
+
+fn has_local_tracking_branch(remote: &str, current: Option<&str>, local: &[String]) -> bool {
+	// Only the conventional `origin/<branch>` mirror is treated as redundant with
+	// a local branch of the same name. Same-named branches on other remotes
+	// (e.g. `upstream/main` alongside `origin/main`) are distinct refs and must
+	// be preserved in the summary.
+	let Some(branch) = remote.strip_prefix("origin/") else {
+		return false;
+	};
+	current == Some(branch) || local.iter().any(|local| local == branch)
 }
 
 struct DiffFile {
@@ -201,7 +849,7 @@ struct DiffHunk {
 	lines:  Vec<String>,
 }
 
-fn condense_diff(input: &str) -> String {
+pub(crate) fn compact_diff_output(input: &str) -> String {
 	let files = parse_unified_diff(input);
 	if files.is_empty() {
 		return input.to_string();
@@ -273,6 +921,7 @@ fn parse_unified_diff(input: &str) -> Vec<DiffFile> {
 	let mut files = Vec::new();
 	let mut current: Option<DiffFile> = None;
 	let mut current_hunk: Option<DiffHunk> = None;
+	let mut pending_old_path: Option<String> = None;
 
 	for line in input.lines() {
 		if let Some(path) = parse_diff_git_path(line) {
@@ -281,12 +930,45 @@ fn parse_unified_diff(input: &str) -> Vec<DiffFile> {
 				files.push(file);
 			}
 			current = Some(DiffFile { path, added: 0, removed: 0, hunks: Vec::new() });
+			pending_old_path = None;
 			continue;
 		}
-		if let Some(path) = line.strip_prefix("+++ b/") {
-			if let Some(file) = current.as_mut() {
-				file.path = path.to_string();
+		if let Some(path) = line.strip_prefix("--- ") {
+			pending_old_path = Some(path.strip_prefix("a/").unwrap_or(path).to_string());
+			continue;
+		}
+		if let Some(path) = line.strip_prefix("+++ ") {
+			let path = path.strip_prefix("b/").unwrap_or(path);
+			let path = if path == "/dev/null" {
+				pending_old_path.as_deref().unwrap_or(path)
+			} else {
+				path
+			};
+			flush_hunk(&mut current, &mut current_hunk);
+			let update_current_path = current
+				.as_ref()
+				.is_some_and(|file| file.added == 0 && file.removed == 0 && file.hunks.is_empty());
+			if update_current_path {
+				if let Some(file) = current.as_mut() {
+					file.path = path.to_string();
+				}
+			} else if let Some(file) = current.take() {
+				files.push(file);
+				current = Some(DiffFile {
+					path:    path.to_string(),
+					added:   0,
+					removed: 0,
+					hunks:   Vec::new(),
+				});
+			} else {
+				current = Some(DiffFile {
+					path:    path.to_string(),
+					added:   0,
+					removed: 0,
+					hunks:   Vec::new(),
+				});
 			}
+			pending_old_path = None;
 			continue;
 		}
 		if line.starts_with("@@") {
@@ -364,7 +1046,393 @@ fn format_file_count(files: usize) -> String {
 
 fn condense_noisy_output(input: &str) -> String {
 	let deduped = primitives::dedup_consecutive_lines(input);
-	primitives::head_tail_lines(&deduped, 80, 40)
+	primitives::head_tail_cap(&deduped, primitives::CapClass::Errors)
+}
+
+fn condense_commit(input: &str, exit_code: i32) -> String {
+	if exit_code == 0 {
+		for line in input.lines() {
+			let trimmed = line.trim();
+			if let Some(hash) = parse_commit_hash(trimmed) {
+				return format!("ok {hash}\n");
+			}
+		}
+		// No commit hash found — likely a `--dry-run` invocation that exits 0
+		// but prints a status-style listing instead of a "[branch hash]" line.
+		// Preserve/condense the output rather than replacing it with bare "ok".
+		return condense_noisy_output(input);
+	}
+
+	if input.contains("nothing to commit") {
+		return format!("nothing to commit (exit {exit_code})\n");
+	}
+
+	condense_noisy_output(input)
+}
+
+fn parse_commit_hash(line: &str) -> Option<&str> {
+	let rest = line.strip_prefix('[')?;
+	let (prefix, _message) = rest.split_once(']')?;
+	prefix.split_whitespace().last()
+}
+
+fn is_push_progress(line: &str) -> bool {
+	let t = line.trim_start();
+	t.starts_with("Enumerating objects:")
+		|| t.starts_with("Counting objects:")
+		|| t.starts_with("Delta compression")
+		|| t.starts_with("Compressing objects:")
+		|| t.starts_with("Writing objects:")
+		|| t.starts_with("Total ")
+}
+
+fn is_remote_progress(line: &str) -> bool {
+	let Some(rest) = line
+		.trim()
+		.strip_prefix("remote:")
+		.or_else(|| line.trim().strip_prefix("remote: "))
+	else {
+		return false;
+	};
+	let rest = rest.trim();
+	rest.starts_with("Resolving deltas:")
+		|| rest.starts_with("Enumerating objects:")
+		|| rest.starts_with("Counting objects:")
+		|| rest.starts_with("Compressing objects:")
+		|| rest.starts_with("Writing objects:")
+		|| rest.starts_with("Total ")
+}
+
+fn extract_pushed_ref(line: &str) -> Option<&str> {
+	if let Some((_before, after_arrow)) = line.split_once(" -> ") {
+		return after_arrow.split_whitespace().next();
+	}
+	let deleted = line.split_once("[deleted]")?.1.trim();
+	deleted.split_whitespace().next()
+}
+
+fn is_fetch_ref_update(line: &str) -> bool {
+	let Some((_before, after_arrow)) = line.split_once(" -> ") else {
+		return false;
+	};
+	after_arrow
+		.split_whitespace()
+		.next()
+		.is_some_and(|dest| dest != "FETCH_HEAD")
+}
+
+fn condense_push(input: &str, exit_code: i32) -> String {
+	let cleaned = primitives::strip_ansi(input);
+	let stripped = primitives::strip_lines(&cleaned, &[is_push_progress]);
+
+	let mut out = String::new();
+	if exit_code == 0 {
+		let mut pushed_ref = None;
+
+		for line in stripped.lines() {
+			let trimmed = line.trim();
+			if trimmed.is_empty() {
+				continue;
+			}
+			if is_remote_progress(trimmed) {
+				continue;
+			}
+			// Keep remote warnings / notes (non-progress remote lines)
+			if trimmed.starts_with("remote:") {
+				out.push_str(line);
+				out.push('\n');
+				continue;
+			}
+			// Keep destination lines
+			if trimmed.starts_with("To ") {
+				out.push_str(line);
+				out.push('\n');
+				continue;
+			}
+			// Keep ref update lines: "* [new ...]", "- [deleted] ...", branch setup,
+			// or "hash..hash ref -> ref"
+			if trimmed.starts_with("* [new")
+				|| trimmed.starts_with("- [deleted]")
+				|| trimmed.starts_with("Branch ")
+				|| trimmed.contains(" -> ")
+			{
+				if pushed_ref.is_none() {
+					pushed_ref = extract_pushed_ref(trimmed);
+				}
+				out.push_str(line);
+				out.push('\n');
+			}
+		}
+
+		if out.is_empty() {
+			out.push_str("ok (up-to-date)\n");
+		} else if let Some(dest) = pushed_ref {
+			out.push_str("ok ");
+			out.push_str(dest);
+			out.push('\n');
+		} else {
+			out.push_str("ok\n");
+		}
+	} else {
+		// Failure: keep diagnostics, strip only progress noise
+		for line in stripped.lines() {
+			let trimmed = line.trim();
+			if trimmed.is_empty() {
+				continue;
+			}
+			if is_remote_progress(trimmed) {
+				continue;
+			}
+			out.push_str(line);
+			out.push('\n');
+		}
+	}
+	out
+}
+fn condense_pull(input: &str, exit_code: i32) -> String {
+	if exit_code == 0 {
+		if input.contains("Already up to date.") || input.contains("Already up-to-date.") {
+			return "ok (up-to-date)\n".to_string();
+		}
+		for line in input.lines() {
+			let trimmed = line.trim();
+			if let Some((files, added, deleted)) = parse_stat_summary(trimmed) {
+				return format!("ok {files} files +{added} -{deleted}\n");
+			}
+		}
+		return "ok\n".to_string();
+	}
+	condense_noisy_output(input)
+}
+
+fn condense_diff_stat(input: &str) -> String {
+	let mut entries = Vec::new();
+	let mut summary = None;
+	for line in input.lines() {
+		let trimmed = line.trim();
+		if trimmed.is_empty() {
+			continue;
+		}
+		if let Some((files, added, deleted)) = parse_stat_summary(trimmed) {
+			summary = Some((files, added, deleted));
+			continue;
+		}
+		if trimmed.contains('|') {
+			entries.push(primitives::truncate_line(trimmed, 140));
+		}
+	}
+
+	let Some((files, added, deleted)) = summary else {
+		return primitives::head_tail_cap(input, primitives::CapClass::List);
+	};
+
+	let mut out = String::new();
+	let _ = writeln!(out, "git diff --stat: {files} files +{added} -{deleted}");
+	for entry in entries.iter().take(20) {
+		out.push_str(entry);
+		out.push('\n');
+	}
+	if entries.len() > 20 {
+		let _ = writeln!(out, "… {} files omitted …", entries.len() - 20);
+	}
+	out
+}
+
+fn parse_stat_summary(line: &str) -> Option<(&str, &str, &str)> {
+	// Parse "N file(s) changed, I insertion(s)(+), D deletion(s)(-)"
+	// or variants with only insertions or only deletions.
+	if !line.contains("file") || !line.contains("changed") {
+		return None;
+	}
+	let mut files = "";
+	let mut inserted = "0";
+	let mut deleted = "0";
+
+	for segment in line.split(", ") {
+		if segment.contains("file") && segment.contains("changed") {
+			files = segment.split_whitespace().next().unwrap_or("");
+		} else if segment.contains("insertion") {
+			inserted = segment.split_whitespace().next().unwrap_or("0");
+		} else if segment.contains("deletion") {
+			deleted = segment.split_whitespace().next().unwrap_or("0");
+		}
+	}
+
+	if files.is_empty() {
+		return None;
+	}
+	Some((files, inserted, deleted))
+}
+
+fn condense_fetch(input: &str, exit_code: i32) -> String {
+	let cleaned = primitives::strip_ansi(input);
+	let stripped = primitives::strip_lines(&cleaned, &[is_remote_progress]);
+
+	if exit_code == 0 {
+		let mut updates: usize = 0;
+		let mut kept = Vec::new();
+
+		for line in stripped.lines() {
+			let trimmed = line.trim();
+			if trimmed.is_empty() {
+				continue;
+			}
+			if trimmed.starts_with("From ") || trimmed.starts_with("To ") {
+				kept.push(trimmed.to_string());
+				continue;
+			}
+			// remote: warnings/errors
+			if trimmed.starts_with("remote:") && !is_remote_progress(trimmed) {
+				kept.push(trimmed.to_string());
+				continue;
+			}
+			// Branch fetch lines: " * branch       name -> FETCH_HEAD", " * [new branch]
+			// name -> origin/name", or "   hash..hash name -> name"
+			if trimmed.starts_with('*') || trimmed.starts_with(" *") {
+				if is_fetch_ref_update(trimmed) {
+					updates += 1;
+				}
+				kept.push(trimmed.to_string());
+				continue;
+			}
+			if trimmed.contains(" -> ") && (trimmed.starts_with('-') || trimmed.contains("..")) {
+				if is_fetch_ref_update(trimmed) {
+					updates += 1;
+				}
+				kept.push(trimmed.to_string());
+			}
+			// Keep error/warning lines
+			if trimmed.starts_with("error:")
+				|| trimmed.starts_with("fatal:")
+				|| trimmed.starts_with("warning:")
+			{
+				kept.push(trimmed.to_string());
+			}
+		}
+
+		let mut out = String::new();
+		for line in kept {
+			out.push_str(&line);
+			out.push('\n');
+		}
+		if updates == 0 {
+			out.push_str("ok fetched (up-to-date)\n");
+		} else {
+			out.push_str("ok fetched, ");
+			out.push_str(&updates.to_string());
+			out.push_str(" update");
+			if updates != 1 {
+				out.push('s');
+			}
+			out.push('\n');
+		}
+		return out;
+	}
+
+	// Failure: keep diagnostics, dedup like old condense_noisy_output
+	// Don't strip progress on failure; keep verbatim for debugging.
+	let deduped = primitives::dedup_consecutive_lines(input);
+	let mut out = String::new();
+	for line in deduped.lines() {
+		let trimmed = line.trim();
+		if trimmed.is_empty() {
+			continue;
+		}
+		out.push_str(trimmed);
+		out.push('\n');
+	}
+	primitives::head_tail_lines(&out, 80, 40)
+}
+
+fn condense_stash(command: &str, input: &str, exit_code: i32) -> String {
+	if has_token(command, "list") {
+		return condense_stash_list(input);
+	}
+	if input.contains("No local changes to save") {
+		return "No local changes to save\n".to_string();
+	}
+	if exit_code == 0 {
+		let sub = stash_subcommand(command);
+		// Bare "stash" defaults to push
+		let sub = if sub.is_empty() { "push" } else { sub };
+		if sub == "push" || sub == "save" {
+			return "ok stashed\n".to_string();
+		}
+		if sub == "apply" || sub == "pop" || sub == "branch" {
+			let compacted = condense_status(input);
+			return if compacted == input {
+				input.to_string()
+			} else {
+				compacted
+			};
+		}
+		if sub == "create" {
+			return input.to_string();
+		}
+		if sub == "drop" || sub == "clear" {
+			return format!("ok stash {sub}\n");
+		}
+		// Default: compact listing fallback
+		return primitives::compact_listing(input, 40);
+	}
+
+	condense_noisy_output(input)
+}
+
+fn condense_stash_list(input: &str) -> String {
+	let mut out = String::new();
+	let mut count = 0usize;
+	for line in input.lines() {
+		let trimmed = line.trim();
+		if trimmed.is_empty() {
+			continue;
+		}
+		count += 1;
+		// Format: "stash@{N}: WIP on <branch>: <hash> <message>"
+		// or    : "stash@{N}: On <branch>: <hash> <message>"
+		let (stash_ref, after_stash) = if let Some((stash_ref, rest)) = trimmed.split_once(": ") {
+			(stash_ref, rest)
+		} else {
+			("", trimmed)
+		};
+		// Strip the "WIP on "/"On " prefix but KEEP <branch> — it's the primary
+		// thing users scan a stash list for ("which branch is this stash from?").
+		// Re-emit it compactly as `[branch] <message>` instead of dropping it.
+		let compact = match after_stash
+			.strip_prefix("WIP on ")
+			.or_else(|| after_stash.strip_prefix("On "))
+		{
+			Some(rest) => rest.split_once(": ").map_or_else(
+				|| after_stash.to_string(),
+				|(branch, msg)| format!("[{}] {}", branch.trim(), msg.trim()),
+			),
+			None => after_stash.to_string(),
+		};
+		if !stash_ref.is_empty() {
+			out.push_str(stash_ref);
+			out.push_str(": ");
+		}
+		out.push_str(&compact);
+		out.push('\n');
+	}
+	if count == 0 {
+		return input.to_string();
+	}
+	// Remove trailing newline then add exactly one
+	out.pop();
+	out.push('\n');
+	out
+}
+
+fn stash_subcommand(command: &str) -> &str {
+	for part in command.split_whitespace() {
+		match part {
+			"push" | "save" | "apply" | "pop" | "drop" | "branch" | "clear" | "create" | "show"
+			| "list" => return part,
+			_ => {},
+		}
+	}
+	""
 }
 
 #[cfg(test)]
@@ -381,8 +1449,89 @@ mod tests {
 	}
 
 	#[test]
-	fn status_is_not_supported() {
-		assert!(!supports(Some("status")));
+	fn status_is_supported() {
+		assert!(supports(Some("status")));
+	}
+
+	#[test]
+	fn short_status_is_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status --short", &cfg);
+		let input = " M src/main.rs\nM  Cargo.toml\n?? scratch.txt\nUU conflicted.rs\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert_eq!(
+			out.text,
+			"staged 1, unstaged 1, untracked 1, conflicts 1\nM src/main.rs\nM Cargo.toml\n?? \
+			 scratch.txt\nUU conflicted.rs\n"
+		);
+	}
+
+	#[test]
+	fn short_status_with_branch_preserves_branch_summary() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status -sb", &cfg);
+		let input = "## main...origin/main [ahead 2]\n M src/main.rs\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert_eq!(
+			out.text,
+			"branch main...origin/main [ahead 2]\nstaged 0, unstaged 1, untracked 0\nM src/main.rs\n",
+		);
+	}
+
+	#[test]
+	fn status_null_output_is_passthrough() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status -sz", &cfg);
+		let input = " M src/main.rs\0?? scratch.txt\0";
+		let out = filter(&ctx, input, 0);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn short_status_ignored_only_preserves_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status --short --ignored", &cfg);
+		let input = "!! ignored.log\n!! target/\n";
+		let out = filter(&ctx, input, 0);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn short_status_ignored_rows_do_not_count_dirty() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status --short --ignored", &cfg);
+		let input = " M src/main.rs\n!! ignored.log\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert_eq!(out.text, "staged 0, unstaged 1, untracked 0\nM src/main.rs\n");
+	}
+
+	#[test]
+	fn long_status_clean_is_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status", &cfg);
+		let input = "On branch main\nYour branch is up to date with 'origin/main'.\n\nnothing to \
+		             commit, working tree clean\n";
+		let out = filter(&ctx, input, 0);
+
+		assert!(out.changed);
+		assert_eq!(out.text, "branch main\nclean\n");
+	}
+
+	#[test]
+	fn long_status_show_stash_preserves_requested_stash_info() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status --show-stash", &cfg);
+		let input = "On branch main\nYour branch is up to date with 'origin/main'.\n\nYour stash \
+		             currently has 2 entries\n\nnothing to commit, working tree clean\n";
+		let out = filter(&ctx, input, 0);
+
+		assert!(out.changed);
+		assert_eq!(out.text, "branch main\nYour stash currently has 2 entries\nclean\n");
 	}
 
 	#[test]
@@ -396,17 +1545,75 @@ mod tests {
 	fn branch_listing_is_compacted() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
 		let ctx = test_ctx(Some("branch"), "git branch -a", &cfg);
-		let mut input = String::new();
-		for idx in 0..60 {
-			input.push_str("  feature/");
-			input.push_str(&idx.to_string());
-			input.push('\n');
-		}
+		let input = "\
+* main
+  feat/a
+  fix/b
+  remotes/origin/main
+  remotes/origin/x
+  remotes/upstream/y
+  remotes/origin/HEAD -> origin/main
+";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, "* main\nlocal: feat/a fix/b\nremote-only (2): origin/x upstream/y\n");
+	}
+
+	#[test]
+	fn branch_listing_keeps_same_named_branch_on_other_remote() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("branch"), "git branch -a", &cfg);
+		// Local `main` makes `origin/main` redundant, but `upstream/main` is a
+		// distinct ref and must survive.
+		let input = "\
+* main
+  remotes/origin/main
+  remotes/upstream/main
+";
+		let out = filter(&ctx, input, 0);
+		assert!(out.text.contains("upstream/main"), "{:?}", out.text);
+		assert!(!out.text.contains("origin/main"), "{:?}", out.text);
+	}
+
+	#[test]
+	fn tag_format_output_is_passthrough() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx =
+			test_ctx(Some("tag"), "git tag --format=%(refname:short)|%(taggerdate:short)", &cfg);
+		let input = (0..45)
+			.map(|idx| format!("v1.{idx}|2026-06-06\n"))
+			.collect::<String>();
+
 		let out = filter(&ctx, &input, 0);
-		assert!(out.text.starts_with("60 entries\n"));
-		assert!(out.text.contains("feature/0"));
-		assert!(out.text.contains("feature/59"));
-		assert!(out.text.contains("…"));
+
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn tag_delete_output_is_passthrough() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("tag"), "git tag -d v1.0 v1.1", &cfg);
+		let input = (0..45)
+			.map(|idx| format!("Deleted tag 'v1.{idx}' (was abc1234)\n"))
+			.collect::<String>();
+
+		let out = filter(&ctx, &input, 0);
+
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn tag_listing_is_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("tag"), "git tag --list", &cfg);
+		let input = (0..45).map(|idx| format!("v1.{idx}\n")).collect::<String>();
+
+		let out = filter(&ctx, &input, 0);
+
+		assert!(out.changed);
+		assert!(out.text.starts_with("45 entries\n"));
+		assert!(out.text.contains("…\n"));
 	}
 
 	#[test]
@@ -422,6 +1629,51 @@ mod tests {
 	}
 
 	#[test]
+	fn fetch_output_counts_new_refs_as_updates() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("fetch"), "git fetch origin", &cfg);
+		let out = filter(
+			&ctx,
+			"From github.com:can1357/oh-my-pi\n * [new branch]      feature -> origin/feature\n",
+			0,
+		);
+		assert!(out.changed);
+		assert!(
+			out.text
+				.contains("* [new branch]      feature -> origin/feature")
+		);
+		assert!(out.text.contains("ok fetched, 1 update"));
+		assert!(!out.text.contains("up-to-date"));
+	}
+
+	#[test]
+	fn push_output_keeps_deleted_refs() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("push"), "git push origin --delete old-branch", &cfg);
+		let out =
+			filter(&ctx, "To github.com:can1357/oh-my-pi.git\n - [deleted]         old-branch\n", 0);
+		assert!(out.changed);
+		assert!(out.text.contains("- [deleted]         old-branch"));
+		assert!(out.text.contains("ok old-branch"));
+	}
+
+	#[test]
+	fn stash_apply_preserves_changed_paths() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash apply", &cfg);
+		let out = filter(
+			&ctx,
+			"On branch main\nChanges not staged for commit:\n  modified:   src/main.rs\n\nno changes \
+			 added to commit\n",
+			0,
+		);
+		assert!(out.changed);
+		assert!(out.text.contains("branch main"));
+		assert!(out.text.contains("M src/main.rs"));
+		assert!(!out.text.contains("ok stash apply"));
+	}
+
+	#[test]
 	fn show_path_content_is_passthrough() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
 		let ctx = test_ctx(Some("show"), "git show HEAD:path/to/file.json", &cfg);
@@ -431,6 +1683,47 @@ mod tests {
 
 		assert!(!out.changed);
 		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn show_condenses_commit_stat_and_diff_samples() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("show"), "git show HEAD", &cfg);
+		let input = "commit abcdef1234567890\nAuthor: Somebody\nDate: today\n\n    fix: update \
+		             thing\n\n    Keep useful body line.\n    Signed-off-by: Somebody \
+		             <s@example.com>\n\ndiff --git a/src/lib.rs b/src/lib.rs\n--- a/src/lib.rs\n+++ \
+		             b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.contains("commit abcdef1"));
+		assert!(out.text.contains("fix: update thing"));
+		assert!(out.text.contains("Keep useful body line."));
+		assert!(!out.text.contains("Signed-off-by"));
+		assert!(out.text.contains("src/lib.rs | 2"));
+		assert!(out.text.contains("--- Changes ---"));
+		assert!(out.text.contains("-old"));
+		assert!(out.text.contains("+new"));
+	}
+
+	#[test]
+	fn show_custom_format_passes_through_inline_and_space_forms() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		// `--format`/`--pretty` reshape the commit prelude `condense_show` would
+		// otherwise rewrite, in both `--flag value` and `--flag=value` forms.
+		let custom = [
+			"git show --format=fuller HEAD",
+			"git show --format=%H HEAD",
+			"git show --format fuller HEAD",
+			"git show --pretty=fuller HEAD",
+			"git show --pretty=%h%n%s HEAD",
+		];
+		let input = "abcdef1234567890\nfix: update thing\ndiff --git a/x b/x\n@@ -1 +1 @@\n-a\n+b\n";
+		for command in custom {
+			let ctx = test_ctx(Some("show"), command, &cfg);
+			let out = filter(&ctx, input, 0);
+			assert!(!out.changed, "`{command}` must pass through custom-format show output");
+			assert_eq!(out.text, input, "`{command}` must preserve output verbatim");
+		}
 	}
 
 	#[test]
@@ -479,6 +1772,31 @@ mod tests {
 	}
 
 	#[test]
+	fn log_stat_line_detection_preserves_graph_pipes() {
+		assert!(skip_log_line("README.md | 8 ++++++++"));
+		assert!(skip_log_line("src/lib.rs |  18 ++"));
+		assert!(!skip_log_line("| * commit message"));
+		assert!(!skip_log_line("|\\"));
+		assert!(!skip_log_line("discussion uses | as separator"));
+	}
+
+	#[test]
+	fn log_keeps_useful_body_lines_and_strips_trailers() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("log"), "git log", &cfg);
+		let input = "commit abcdef1234567890\nAuthor: Somebody\nDate: today\n\n    feat: add \
+		             API\n\n    BREAKING CHANGE: response shape changed\n    Fixes #123\n    \
+		             Signed-off-by: Somebody <s@example.com>\n    Co-authored-by: Other \
+		             <o@example.com>\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.text.contains("abcdef1 feat: add API"));
+		assert!(out.text.contains("BREAKING CHANGE: response shape changed"));
+		assert!(out.text.contains("Fixes #123"));
+		assert!(!out.text.contains("Signed-off-by"));
+		assert!(!out.text.contains("Co-authored-by"));
+	}
+
+	#[test]
 	fn diff_condenses_unified_patch_to_stat_and_hunk_samples() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
 		let ctx = test_ctx(Some("diff"), "git diff HEAD~1", &cfg);
@@ -501,11 +1819,683 @@ mod tests {
 	}
 
 	#[test]
+	fn diff_stat_is_summarized() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("diff"), "git diff --stat", &cfg);
+		let input = "\
+ crates/pi-shell/src/minimizer/filters/git.rs     | 385 +++++++++++++++++------
+ packages/coding-agent/src/exec/bash-executor.ts  |  18 ++
+ packages/coding-agent/test/bash-executor.test.ts |  45 ++-
+ 3 files changed, 448 insertions(+), 100 deletions(-)
+";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.starts_with("git diff --stat: 3 files +448 -100\n"));
+		assert!(
+			out.text
+				.contains("crates/pi-shell/src/minimizer/filters/git.rs")
+		);
+		assert!(
+			out.text
+				.contains("packages/coding-agent/test/bash-executor.test.ts")
+		);
+		assert!(!out.text.contains("3 files changed"));
+	}
+
+	#[test]
+	fn diff_name_only_is_compacted_and_bounded() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("diff"), "git diff --name-only HEAD~1", &cfg);
+		let mut input = String::new();
+		for idx in 0..26 {
+			input.push_str("src/file-");
+			input.push_str(&idx.to_string());
+			input.push_str(".rs\n");
+		}
+
+		let out = filter(&ctx, &input, 0);
+
+		assert!(out.changed);
+		assert!(out.text.starts_with("git diff --name-only: 26 files\n"));
+		assert!(out.text.contains("src/file-0.rs\n"));
+		assert!(out.text.contains("src/file-19.rs\n"));
+		assert!(!out.text.contains("src/file-20.rs\n"));
+		assert!(out.text.contains("… 6 files omitted …"));
+	}
+
+	#[test]
+	fn diff_name_status_is_compacted_and_bounded() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("diff"), "git diff --name-status HEAD~1", &cfg);
+		let mut input = String::new();
+		for idx in 0..24 {
+			input.push_str(if idx % 3 == 0 {
+				"R100\told-"
+			} else {
+				"M\tpath-"
+			});
+			input.push_str(&idx.to_string());
+			if idx % 3 == 0 {
+				input.push_str(".rs\tnew-");
+				input.push_str(&idx.to_string());
+				input.push_str(".rs\n");
+			} else {
+				input.push_str(".rs\n");
+			}
+		}
+
+		let out = filter(&ctx, &input, 0);
+
+		assert!(out.changed);
+		assert!(out.text.starts_with("git diff --name-status: 24 files\n"));
+		assert!(out.text.contains("R100\told-0.rs\tnew-0.rs\n"));
+		assert!(out.text.contains("M\tpath-1.rs\n"));
+		assert!(!out.text.contains("path-20.rs\n"));
+		assert!(out.text.contains("… 4 files omitted …"));
+	}
+
+	#[test]
+	fn diff_stat_summary_preserves_extended_summary_lines() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("diff"), "git diff --stat --summary", &cfg);
+		let input = " foo | 1 +\n 1 file changed, 1 insertion(+)\n create mode 100644 foo\n";
+		let out = filter(&ctx, input, 0);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn log_custom_format_preserves_machine_readable_hashes() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("log"), "git log --format=%H -n 100", &cfg);
+		let mut input = String::new();
+		for idx in 0..80 {
+			let _ = writeln!(input, "{idx:040x}");
+		}
+		let out = filter(&ctx, &input, 0);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn diff_numstat_is_compacted_and_bounded() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("diff"), "git diff --numstat HEAD~1", &cfg);
+		let mut input = String::new();
+		for idx in 0..22 {
+			input.push_str(&(idx + 1).to_string());
+			input.push('\t');
+			input.push_str(&(idx % 7).to_string());
+			input.push('\t');
+			input.push_str("src/file-");
+			input.push_str(&idx.to_string());
+			input.push_str(".rs\n");
+		}
+
+		let out = filter(&ctx, &input, 0);
+
+		assert!(out.changed);
+		assert!(out.text.starts_with("git diff --numstat: 22 files\n"));
+		assert!(out.text.contains("1\t0\tsrc/file-0.rs\n"));
+		assert!(out.text.contains("20\t5\tsrc/file-19.rs\n"));
+		assert!(!out.text.contains("src/file-20.rs\n"));
+		assert!(out.text.contains("… 2 files omitted …"));
+	}
+
+	#[test]
+	fn diff_name_only_failure_keeps_diagnostics() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("diff"), "git diff --name-only badrev", &cfg);
+		let input =
+			"fatal: ambiguous argument 'badrev': unknown revision or path not in the working tree.\n";
+
+		let out = filter(&ctx, input, 128);
+
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
 	fn legacy_log_fallback_removes_metadata_when_no_commit_records_parse() {
 		let input = "commitish output\nAuthor: Somebody <s@example.com>\nDate: today\nmessage 0\n";
 		let out = condense_log(input, 32, 16);
 		assert!(out.contains("message 0"));
 		assert!(!out.contains("Author:"));
 		assert!(!out.contains("Date:"));
+	}
+
+	#[test]
+	fn commit_success_compacts_to_hash_only() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("commit"), "git commit -m msg", &cfg);
+		let input = "\
+[fix/omlx-local-model-limits 5f490f764] chore: checkpoint workspace changes
+ 70 files changed, 3081 insertions(+), 403 deletions(-)
+ create mode 100644 packages/example.ts
+ delete mode 100644 old-file.ts
+";
+		let out = filter(&ctx, input, 0);
+
+		assert_eq!(out.text, "ok 5f490f764\n");
+		assert!(!out.text.contains("files changed"));
+		assert!(!out.text.contains("create mode"));
+	}
+
+	#[test]
+	fn commit_nothing_to_commit_is_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("commit"), "git commit -m msg", &cfg);
+		let input = "On branch main\nnothing to commit, working tree clean\n";
+		let out = filter(&ctx, input, 1);
+
+		assert_eq!(out.text, "nothing to commit (exit 1)\n");
+	}
+
+	#[test]
+	fn push_noisy_success_is_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("push"), "git push", &cfg);
+		let input = "\
+Enumerating objects: 5, done.
+Counting objects: 100% (5/5), done.
+Delta compression using up to 8 threads
+Compressing objects: 100% (3/3), done.
+Writing objects: 100% (3/3), 1.23 KiB | 1.23 MiB/s, done.
+Total 3 (delta 2), reused 0 (delta 0), pack-reused 0
+remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
+To github.com:user/repo.git
+   abc1234..def5678  main -> main
+";
+		let out = filter(&ctx, input, 0);
+
+		assert!(out.changed);
+		assert!(out.text.contains("To github.com:user/repo.git"));
+		assert!(out.text.contains("main -> main"));
+		assert!(out.text.contains("ok main\n"));
+		assert!(!out.text.contains("Enumerating objects"));
+		assert!(!out.text.contains("Counting objects"));
+		assert!(!out.text.contains("Delta compression"));
+		assert!(!out.text.contains("Compressing objects"));
+		assert!(!out.text.contains("Writing objects"));
+		assert!(!out.text.contains("Total "));
+		assert!(!out.text.contains("remote: Resolving deltas"));
+	}
+
+	#[test]
+	fn push_up_to_date_is_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("push"), "git push", &cfg);
+		let input = "Everything up-to-date\n";
+		let out = filter(&ctx, input, 0);
+
+		assert!(out.changed);
+		assert_eq!(out.text, "ok (up-to-date)\n");
+	}
+
+	#[test]
+	fn push_remote_warning_is_kept() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("push"), "git push", &cfg);
+		let input = "\
+Enumerating objects: 3, done.
+Counting objects: 100% (3/3), done.
+Writing objects: 100% (3/3), done.
+Total 3 (delta 0), reused 0 (delta 0), pack-reused 0
+remote: warning: Large object detected, consider using Git LFS
+To github.com:user/repo.git
+   def5678..abc1234  main -> main
+";
+		let out = filter(&ctx, input, 0);
+
+		assert!(out.changed);
+		assert!(out.text.contains("remote: warning: Large object detected"));
+		assert!(out.text.contains("ok main\n"));
+		assert!(!out.text.contains("Enumerating objects"));
+	}
+
+	#[test]
+	fn push_rejected_failure_keeps_diagnostics() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("push"), "git push", &cfg);
+		let input = "\
+To github.com:user/repo.git
+ ! [rejected]        main -> main (non-fast-forward)
+error: failed to push some refs to 'github.com:user/repo.git'
+hint: Updates were rejected because the tip of your current branch is behind
+hint: its remote counterpart. Integrate the remote changes (e.g.
+hint: 'git pull ...') before pushing again.
+hint: See the 'Note about fast-forwards' in 'git push --help' for details.
+";
+		let out = filter(&ctx, input, 1);
+
+		assert!(!out.text.contains("ok\n"));
+		assert!(!out.text.contains("ok (up-to-date)"));
+		assert!(out.text.contains("rejected"));
+		assert!(out.text.contains("error: failed to push"));
+		assert!(out.text.contains("hint:"));
+	}
+
+	// --- Status state detection ---
+
+	#[test]
+	fn status_detects_rebasing() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status", &cfg);
+		let input = "On branch feature\nYou are currently rebasing.\n  (fix conflicts and then run \
+		             \"git rebase --continue\")\n\nChanges not staged for commit:\n  modified:   \
+		             src/main.rs\n\nno changes added to commit (use \"git add\")\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.starts_with("state: rebasing\n"));
+		assert!(out.text.contains("branch feature"));
+		assert!(out.text.contains("src/main.rs"));
+	}
+
+	#[test]
+	fn status_detects_cherry_pick() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status", &cfg);
+		let input = "On branch main\nYou are currently cherry-picking commit abc1234.\n  (fix \
+		             conflicts and run \"git cherry-pick --continue\")\n\nnothing to commit, \
+		             working tree clean\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.starts_with("state: cherry-pick\n"));
+	}
+
+	#[test]
+	fn status_detects_revert() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status", &cfg);
+		let input = "On branch main\nYou are currently reverting commit abc1234.\n\nnothing to \
+		             commit, working tree clean\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.starts_with("state: revert\n"));
+	}
+
+	#[test]
+	fn status_detects_bisect() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status", &cfg);
+		let input = "On branch main\nYou are currently bisecting, started from branch 'feature'.\n  \
+		             (use \"git bisect reset\" to get back to the original branch)\n\nnothing to \
+		             commit, working tree clean\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.starts_with("state: bisect\n"));
+	}
+
+	#[test]
+	fn status_detects_am_session() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status", &cfg);
+		let input = "On branch main\nYou are in the middle of an am session.\n  (fix conflicts and \
+		             then run \"git am --continue\")\n\nnothing to commit, working tree clean\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.starts_with("state: am\n"));
+	}
+
+	#[test]
+	fn status_detects_sparse_checkout() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status", &cfg);
+		let input = "On branch main\nYou are in a sparse checkout with 42% of tracked files \
+		             present.\n\nnothing to commit, working tree clean\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.starts_with("state: sparse-checkout\n"));
+	}
+
+	#[test]
+	fn status_detects_unmerged_paths() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status", &cfg);
+		let input = "On branch main\nYou have unmerged paths.\n  (fix conflicts and run \"git \
+		             commit\")\n\nUnmerged paths:\n  both modified:   conflicted.rs\n\nno changes \
+		             added to commit (use \"git add\")\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.starts_with("state: merge-conflict\n"));
+		assert!(out.text.contains("conflicts 1"));
+	}
+
+	#[test]
+	fn status_state_not_emitted_when_no_state() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("status"), "git status", &cfg);
+		let input = "On branch main\nYour branch is up to date with 'origin/main'.\n\nnothing to \
+		             commit, working tree clean\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(!out.text.contains("state:"));
+		assert_eq!(out.text, "branch main\nclean\n");
+	}
+
+	// --- Pull summaries ---
+
+	#[test]
+	fn pull_up_to_date_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("pull"), "git pull", &cfg);
+		let out = filter(&ctx, "Already up to date.\n", 0);
+		assert!(out.changed);
+		assert_eq!(out.text, "ok (up-to-date)\n");
+	}
+
+	#[test]
+	fn pull_up_to_date_hyphenated() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("pull"), "git pull", &cfg);
+		let out = filter(&ctx, "Already up-to-date.\n", 0);
+		assert!(out.changed);
+		assert_eq!(out.text, "ok (up-to-date)\n");
+	}
+
+	#[test]
+	fn pull_with_stat_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("pull"), "git pull", &cfg);
+		let input = "Updating abc1234..def5678\nFast-forward\n src/lib.rs | 12 ++++++++++++\n 1 \
+		             file changed, 12 insertions(+)\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert_eq!(out.text, "ok 1 files +12 -0\n");
+	}
+
+	#[test]
+	fn pull_with_delete_stat_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("pull"), "git pull", &cfg);
+		let input =
+			"Updating abc1234..def5678\n src/lib.rs | 3 ---\n 1 file changed, 3 deletions(-)\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert_eq!(out.text, "ok 1 files +0 -3\n");
+	}
+
+	#[test]
+	fn pull_conflict_keeps_diagnostics() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("pull"), "git pull", &cfg);
+		let input = "Auto-merging src/lib.rs\nCONFLICT (content): Merge conflict in \
+		             src/lib.rs\nAutomatic merge failed; fix conflicts and then commit the result.\n";
+		let out = filter(&ctx, input, 1);
+		assert!(out.text.contains("CONFLICT"));
+		assert!(!out.text.contains("ok"));
+	}
+
+	// --- Fetch summaries ---
+
+	#[test]
+	fn fetch_up_to_date_compacted() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("fetch"), "git fetch", &cfg);
+		let input = "From github.com:user/repo\n * branch            main       -> FETCH_HEAD\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.contains("From github.com:user/repo"));
+		assert!(out.text.contains("ok fetched (up-to-date)"));
+	}
+
+	#[test]
+	fn fetch_with_updates() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("fetch"), "git fetch", &cfg);
+		let input = "From github.com:user/repo\n   abc1234..def5678  main       -> origin/main\n   \
+		             aabbccd..eeff001  feature    -> origin/feature\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.contains("ok fetched, 2 updates"));
+	}
+
+	#[test]
+	fn fetch_single_update() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("fetch"), "git fetch", &cfg);
+		let input = "From github.com:user/repo\n   abc1234..def5678  main       -> origin/main\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert!(out.text.contains("ok fetched, 1 update\n"));
+	}
+
+	#[test]
+	fn fetch_preserves_remote_warnings() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("fetch"), "git fetch origin", &cfg);
+		let input = "From github.com:user/repo\nremote: warning: this is a test warning\n   \
+		             abc1234..def5678  main       -> origin/main\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.text.contains("remote: warning:"));
+		assert!(out.text.contains("ok fetched, 1 update"));
+	}
+
+	#[test]
+	fn fetch_failure_keeps_diagnostics() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("fetch"), "git fetch origin", &cfg);
+		let input = "fatal: 'origin' does not appear to be a git repository\nfatal: Could not read \
+		             from remote repository.\n";
+		let out = filter(&ctx, input, 128);
+		assert!(out.text.contains("fatal:"));
+		assert!(!out.text.contains("ok"));
+	}
+
+	// --- Stash improvements ---
+
+	#[test]
+	fn stash_push_success() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash push", &cfg);
+		let input = "Saved working directory and index state WIP on main: abc1234 some message\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		assert_eq!(out.text, "ok stashed\n");
+	}
+
+	#[test]
+	fn stash_save_success() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash save", &cfg);
+		let input = "Saved working directory and index state On main: abc1234 some message\n";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, "ok stashed\n");
+	}
+
+	#[test]
+	fn stash_bare_defaults_to_push() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash", &cfg);
+		let input = "Saved working directory and index state WIP on main: abc1234 some message\n";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, "ok stashed\n");
+	}
+
+	#[test]
+	fn stash_empty_message_stays_opaque() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash", &cfg);
+		let out = filter(&ctx, "No local changes to save\n", 0);
+		assert_eq!(out.text, "No local changes to save\n");
+	}
+
+	#[test]
+	fn stash_apply_success() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash apply", &cfg);
+		let input = "On branch main\nnothing to commit, working tree clean\n";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, "branch main\nclean\n");
+	}
+
+	#[test]
+	fn stash_pop_success() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash pop", &cfg);
+		let input = "Dropped refs/stash@{0} (abc1234...)\n";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn stash_drop_success() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash drop", &cfg);
+		let input = "Dropped refs/stash@{0} (abc1234...)\n";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, "ok stash drop\n");
+	}
+
+	#[test]
+	fn stash_branch_success() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash branch new-branch", &cfg);
+		let input = "Switched to a new branch 'new-branch'\nDropped refs/stash@{0}\n";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn stash_clear_success() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash clear", &cfg);
+		let out = filter(&ctx, "", 0);
+		assert_eq!(out.text, "ok stash clear\n");
+	}
+
+	#[test]
+	fn stash_no_local_changes() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash", &cfg);
+		let input = "No local changes to save\n";
+		let out = filter(&ctx, input, 1);
+		assert_eq!(out.text, "No local changes to save\n");
+	}
+
+	#[test]
+	fn stash_list_compacts_wip_prefix() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash list", &cfg);
+		let input = "stash@{0}: WIP on feature-x: abc1234 fix: something\nstash@{1}: On main: \
+		             def5678 chore: clean up\nstash@{2}: WIP on dev: ghi9012 feat: add widget\n";
+		let out = filter(&ctx, input, 0);
+		assert!(out.changed);
+		// Branch is preserved (re-emitted as `[branch]`) — it's the primary thing
+		// users scan stash lists for — while the "WIP on "/"On " noise is stripped.
+		assert!(
+			out.text
+				.contains("stash@{0}: [feature-x] abc1234 fix: something")
+		);
+		assert!(
+			out.text
+				.contains("stash@{1}: [main] def5678 chore: clean up")
+		);
+		assert!(
+			out.text
+				.contains("stash@{2}: [dev] ghi9012 feat: add widget")
+		);
+		assert!(!out.text.contains("WIP on "));
+		assert!(!out.text.contains("On main:"));
+	}
+
+	#[test]
+	fn stash_list_empty_passthrough() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("stash"), "git stash list", &cfg);
+		let out = filter(&ctx, "", 0);
+		assert!(!out.changed);
+	}
+
+	// --- Log failure passthrough ---
+
+	#[test]
+	fn log_failure_keeps_diagnostics() {
+		// `git log` on a bad rev fails with exit 128.  The filter must not
+		// silently swallow the error into a zero-entry commit listing.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("log"), "git log --oneline badref", &cfg);
+		let input = "fatal: ambiguous argument 'badref': unknown revision or path not in the \
+		             working tree.\nfatal: bad default revision 'HEAD'\n";
+
+		let out = filter(&ctx, input, 128);
+
+		assert!(out.text.contains("fatal:"), "error header must survive: {:?}", out.text);
+		assert!(out.text.contains("badref"), "offending ref must survive: {:?}", out.text);
+		assert!(!out.text.contains("commits omitted"), "must not fabricate commit listing on error");
+	}
+
+	#[test]
+	fn log_oneline_short_run_emits_all_entries() {
+		// A short log that fits within head+tail should emit all entries
+		// without any "omitted" line, and each entry should carry the
+		// 7-char short hash followed by the subject.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("log"), "git log -5", &cfg);
+		let input = "\
+commit abcdef1234567890\nAuthor: A <a@x.com>\nDate: today\n    feat: first\ncommit \
+		             1111111111111111\nAuthor: A <a@x.com>\nDate: today\n    fix: second\ncommit \
+		             2222222222222222\nAuthor: A <a@x.com>\nDate: today\n    chore: third\n";
+
+		let out = filter(&ctx, input, 0);
+
+		assert!(!out.text.contains("commits omitted"));
+		assert!(out.text.contains("abcdef1 feat: first"), "{:?}", out.text);
+		assert!(out.text.contains("1111111 fix: second"), "{:?}", out.text);
+		assert!(out.text.contains("2222222 chore: third"), "{:?}", out.text);
+		assert!(!out.text.contains("Author:"), "author noise must be stripped");
+		assert!(!out.text.contains("Date:"), "date noise must be stripped");
+	}
+
+	// --- Merge/rebase error preservation ---
+
+	#[test]
+	fn merge_conflict_failure_keeps_diagnostics() {
+		// `git merge` that ends in conflicts must surface the conflict
+		// paths, not be silently compacted into an empty success message.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("merge"), "git merge feat/x", &cfg);
+		let input = "\
+Auto-merging src/lib.rs\nCONFLICT (content): Merge conflict in src/lib.rs\nAutomatic merge failed; \
+		             fix conflicts and then commit the result.\n";
+
+		let out = filter(&ctx, input, 1);
+
+		assert!(out.text.contains("CONFLICT"), "conflict marker must survive: {:?}", out.text);
+		assert!(out.text.contains("src/lib.rs"), "conflict path must survive: {:?}", out.text);
+		assert!(!out.text.contains("ok"), "must not emit an ok summary on failure");
+	}
+
+	#[test]
+	fn rebase_conflict_failure_keeps_diagnostics() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("rebase"), "git rebase main", &cfg);
+		let input = "\
+error: could not apply abc1234... fix: something\nhint: Resolve all conflicts manually, mark them \
+		             as resolved with\nhint: \"git add/rm <conflicted_files>\", then run \"git \
+		             rebase --continue\".\nCONFLICT (content): Merge conflict in src/config.rs\n";
+
+		let out = filter(&ctx, input, 1);
+
+		assert!(out.text.contains("CONFLICT"), "conflict marker must survive: {:?}", out.text);
+		assert!(out.text.contains("error:"), "error line must survive: {:?}", out.text);
+		assert!(out.text.contains("src/config.rs"), "conflict path must survive: {:?}", out.text);
+	}
+
+	// --- Push porcelain passthrough ---
+
+	#[test]
+	fn push_porcelain_output_is_passthrough() {
+		// Scripts that parse `git push --porcelain` rely on the exact byte
+		// sequence; the minimizer must not touch it.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = test_ctx(Some("push"), "git push --porcelain origin main", &cfg);
+		let input =
+			"To github.com:user/repo.git\n=\trefs/heads/main:refs/heads/main\t[up to date]\nDone\n";
+
+		let out = filter(&ctx, input, 0);
+
+		assert!(!out.changed, "porcelain output must not be rewritten");
+		assert_eq!(out.text, input);
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/js_tools.rs
+++ b/crates/pi-shell/src/minimizer/filters/js_tools.rs
@@ -40,7 +40,7 @@ pub fn effective_tool<'a>(program: &'a str, subcommand: Option<&'a str>) -> Opti
 	{
 		return Some(tool);
 	}
-	if is_npx_like(program) {
+	if is_npx_like(program, subcommand) {
 		let tool = subcommand?;
 		if NPX_ROUTABLE_TOOLS.contains(&tool) {
 			return Some(tool);
@@ -62,8 +62,8 @@ fn effective_tool_from_command<'a>(
 		.find(|token| SUPPORTED_TOOLS.contains(token))
 }
 
-fn is_npx_like(program: &str) -> bool {
-	matches!(program, "npx" | "bunx" | "pnpm dlx")
+fn is_npx_like(program: &str, subcommand: Option<&str>) -> bool {
+	matches!(program, "npx" | "bunx") || matches!((program, subcommand), ("pnpm", Some("dlx")))
 }
 
 fn filter_next(input: &str, exit_code: i32) -> String {

--- a/crates/pi-shell/src/minimizer/filters/lint.rs
+++ b/crates/pi-shell/src/minimizer/filters/lint.rs
@@ -9,7 +9,7 @@ pub fn supports(subcommand: Option<&str>) -> bool {
 }
 
 pub fn supports_program(program: &str, subcommand: Option<&str>) -> bool {
-	matches!(program, "ruff" | "mypy" | "rubocop")
+	matches!(program, "ruff" | "mypy" | "rubocop" | "pyright" | "basedpyright")
 		|| matches!(
 			subcommand,
 			None | Some("check" | "lint" | "run" | "format" | "fmt" | "typecheck")
@@ -58,6 +58,7 @@ fn is_lint_noise(program: &str, line: &str, exit_code: i32) -> bool {
 		|| matches!(program, "eslint" | "biome") && lower.starts_with("warning: react version")
 		|| matches!(program, "ruff") && lower.starts_with("all checks passed")
 		|| matches!(program, "mypy") && lower.starts_with("success: no issues found")
+		|| matches!(program, "pyright" | "basedpyright") && lower.starts_with("0 errors, 0 warnings")
 		|| matches!(program, "rubocop")
 			&& (lower.starts_with("inspecting ")
 				|| lower == "offenses:"
@@ -250,5 +251,25 @@ mod tests {
 		let out = group_diagnostics(&input);
 		assert!(out.contains("src/main.rs (20 diagnostics)"));
 		assert!(out.contains("… 8 more"));
+	}
+
+	#[test]
+	fn direct_pyright_support_and_grouping_work() {
+		assert!(supports_program("pyright", None));
+		let input = "0 errors, 0 warnings, 0 informations\nsrc/app.ts:4:7 - error TS2322: Type \
+		             'string' is not assignable to type 'number'.\nsrc/app.ts:9:3 - error TS7006: \
+		             Parameter 'x' implicitly has an 'any' type.\n";
+		let out = condense_lint_output("pyright", input, 1);
+		assert!(out.contains("2 diagnostics in 1 files"));
+		assert!(out.contains("src/app.ts (2 diagnostics)"));
+		assert!(out.contains("TS2322"));
+		assert!(out.contains("TS7006"));
+	}
+
+	#[test]
+	fn direct_basedpyright_success_noise_is_stripped() {
+		assert!(supports_program("basedpyright", None));
+		let out = condense_lint_output("basedpyright", "0 errors, 0 warnings, 0 notes\n", 0);
+		assert_eq!(out, "");
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/listing.rs
+++ b/crates/pi-shell/src/minimizer/filters/listing.rs
@@ -2,18 +2,70 @@
 
 use std::{collections::BTreeMap, path::Path};
 
-use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
+use crate::minimizer::{MinimizerCtx, MinimizerOutput, config::OutlineLevel, primitives};
+
+/// For `grep`: `-z` / `--null-data` (NUL line terminators) and `-Z` /
+/// `--null` (NUL after file names).
+/// For `rg`: `-0` / `--null` and `--null-data`.
+fn context_has_nul_output(command: &str, program: &str) -> bool {
+	command.split_whitespace().any(|tok| match program {
+		// -z may be clustered with other short flags (e.g. -zHn); --null-data is long.
+		"grep" => {
+			tok == "--null-data"
+				|| tok == "--null"
+				|| (tok.starts_with('-')
+					&& !tok.starts_with("--")
+					&& tok.chars().skip(1).any(|ch| matches!(ch, 'z' | 'Z')))
+		},
+		"rg" => matches!(tok, "-0" | "--null" | "--null-data"),
+		_ => matches!(tok, "-print0" | "-fprint0"),
+	})
+}
+
+fn find_outputs_paths_only(command: &str) -> bool {
+	!command.split_whitespace().any(|word| {
+		matches!(
+			word,
+			"-print0"
+				| "-printf"
+				| "-fprintf"
+				| "-ls" | "-fls"
+				| "-exec"
+				| "-execdir"
+				| "-ok" | "-okdir"
+		)
+	})
+}
 
 pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerOutput {
 	let cleaned = primitives::strip_ansi(input);
+	let legacy = ctx.config.legacy_filters_active();
 	let text = if exit_code != 0 {
 		cleaned
 	} else {
 		match ctx.program {
-			"grep" | "rg" => compact_grep_output(&cleaned),
+			"grep" | "rg" => {
+				if context_has_nul_output(ctx.command, ctx.program) {
+					cleaned
+				} else if legacy {
+					compact_grep_output_legacy(&cleaned)
+				} else {
+					compact_grep_output(&cleaned)
+				}
+			},
 			"ls" => compact_ls_output(&cleaned).unwrap_or_else(|| compact_listing_output(&cleaned)),
 			"tree" => compact_listing_output(&cleaned),
-			"find" => compact_find_output(&cleaned),
+			"find" => {
+				if context_has_nul_output(ctx.command, ctx.program)
+					|| !find_outputs_paths_only(ctx.command)
+				{
+					cleaned
+				} else if legacy {
+					compact_find_output_legacy(&cleaned)
+				} else {
+					compact_find_output(&cleaned)
+				}
+			},
 			"cat" | "read" => compact_cat_output(ctx, &cleaned),
 			"stat" | "du" | "df" | "wc" => compact_summary_output(&cleaned),
 			"jq" | "json" => cleaned,
@@ -36,7 +88,10 @@ struct GrepMatch {
 	text:    String,
 }
 
-fn compact_grep_output(input: &str) -> String {
+/// Legacy pre-PR behavior for grep/rg output: passthrough when
+/// `match_count <= 12 && grouped.len() <= 3` (or no recognized matches).
+/// Retained for the `legacy_filters_active` kill-switch.
+fn compact_grep_output_legacy(input: &str) -> String {
 	let mut grouped: BTreeMap<String, Vec<GrepMatch>> = BTreeMap::new();
 	let mut ungrouped = Vec::new();
 
@@ -56,10 +111,41 @@ fn compact_grep_output(input: &str) -> String {
 		return primitives::group_by_file(input, 12);
 	}
 
+	compact_grep_grouped(&grouped, &ungrouped, match_count)
+}
+
+fn compact_grep_output(input: &str) -> String {
+	let mut grouped: BTreeMap<String, Vec<GrepMatch>> = BTreeMap::new();
+	let mut ungrouped = Vec::new();
+
+	for line in input.lines() {
+		if let Some((file, line_no, text)) = split_grep_line(line) {
+			grouped
+				.entry(file.to_string())
+				.or_default()
+				.push(GrepMatch { line_no: line_no.to_string(), text: collapse_match_text(text) });
+		} else if !line.trim().is_empty() {
+			ungrouped.push(line.to_string());
+		}
+	}
+
+	let match_count: usize = grouped.values().map(Vec::len).sum();
+	if grouped.is_empty() {
+		return primitives::group_by_file(input, 12);
+	}
+
+	compact_grep_grouped(&grouped, &ungrouped, match_count)
+}
+
+fn compact_grep_grouped(
+	grouped: &BTreeMap<String, Vec<GrepMatch>>,
+	ungrouped: &[String],
+	match_count: usize,
+) -> String {
 	let mut out = format!("grep: {match_count} matches in {} files\n", grouped.len());
 	let mut shown_matches = 0usize;
 	let mut shown_files = 0usize;
-	for (file, matches) in &grouped {
+	for (file, matches) in grouped {
 		if shown_files >= 12 {
 			break;
 		}
@@ -96,7 +182,7 @@ fn compact_grep_output(input: &str) -> String {
 		out.push_str(" omitted\n");
 	}
 	for line in ungrouped {
-		out.push_str(&line);
+		out.push_str(line);
 		out.push('\n');
 	}
 	out
@@ -116,7 +202,77 @@ fn split_grep_line(line: &str) -> Option<(&str, &str, &str)> {
 
 fn collapse_match_text(text: &str) -> String {
 	let collapsed = collapse_parenthesized_segment(text, 48);
-	primitives::truncate_line(&collapsed, 140)
+	center_truncate_match(&collapsed, 140)
+}
+
+/// Center-truncate grep/ripgrep match text so the match region stays visible.
+///
+/// Instead of truncating from the front (which loses matches deep in long
+/// lines), this centers the visible window. The heuristic biases toward
+/// non-whitespace content when the line has significant leading whitespace.
+fn center_truncate_match(text: &str, max_chars: usize) -> String {
+	if max_chars == 0 {
+		return String::new();
+	}
+	let char_count = text.chars().count();
+	if char_count <= max_chars {
+		return text.to_string();
+	}
+
+	// Heuristic:
+	// - If the line has significant leading whitespace, bias toward the code region
+	//   shortly after indentation (common for grep hits inside indented code).
+	// - If the line is effectively one long token, bias earlier so identifiers that
+	//   appear before a long suffix still remain visible.
+	// - Otherwise center in the middle of the full line.
+	// Count leading whitespace in CHARS, not bytes: this value is compared and
+	// combined with char-based quantities (`char_count`, `max_chars`) and used as
+	// a char-stepping floor below. `str::find` returns a byte offset, which would
+	// overstate the index for any multibyte leading whitespace (NBSP, U+3000).
+	let first_non_ws = text.chars().take_while(|c| c.is_whitespace()).count();
+	let has_whitespace = text.chars().any(char::is_whitespace);
+	let anchor = if first_non_ws > 0 && first_non_ws < char_count / 3 {
+		first_non_ws + max_chars / 4
+	} else if !has_whitespace {
+		char_count / 3
+	} else {
+		char_count / 2
+	};
+
+	let window_size = max_chars;
+	let half = window_size / 2;
+	let mut window_start = anchor.saturating_sub(half);
+	if first_non_ws > 0 {
+		window_start = window_start.max(first_non_ws);
+	}
+	// Clamp so the window doesn't overshoot the end.
+	window_start = window_start.min(char_count.saturating_sub(window_size));
+
+	let mut out = String::with_capacity(max_chars + 12);
+	let mut chars = text.chars();
+	for _ in 0..window_start {
+		chars.next();
+	}
+	let dropped_before = window_start;
+	if dropped_before > 0 {
+		out.push('\u{2026}');
+	}
+	let mut shown = 0usize;
+	for _ in 0..window_size {
+		match chars.next() {
+			Some(ch) => {
+				out.push(ch);
+				shown += 1;
+			},
+			None => break,
+		}
+	}
+	let total_dropped = char_count.saturating_sub(shown);
+	if total_dropped > 0 {
+		use std::fmt::Write as _;
+		let _ = write!(out, "\u{2026}[+{total_dropped}]");
+	}
+	out
 }
 
 fn collapse_parenthesized_segment(text: &str, min_len: usize) -> String {
@@ -137,7 +293,9 @@ fn collapse_parenthesized_segment(text: &str, min_len: usize) -> String {
 	out
 }
 
-fn compact_find_output(input: &str) -> String {
+/// Legacy pre-PR behavior for find output: passthrough when `paths.len() <=
+/// 20`. Retained for the `legacy_filters_active` kill-switch.
+fn compact_find_output_legacy(input: &str) -> String {
 	let paths: Vec<&str> = input
 		.lines()
 		.filter(|line| !line.trim().is_empty())
@@ -145,10 +303,24 @@ fn compact_find_output(input: &str) -> String {
 	if paths.len() <= 20 {
 		return input.to_string();
 	}
+	compact_find_output_inner(input, &paths)
+}
 
+fn compact_find_output(input: &str) -> String {
+	let paths: Vec<&str> = input
+		.lines()
+		.filter(|line| !line.trim().is_empty())
+		.collect();
+	if paths.is_empty() {
+		return input.to_string();
+	}
+	compact_find_output_inner(input, &paths)
+}
+
+fn compact_find_output_inner(input: &str, paths: &[&str]) -> String {
 	let mut grouped: BTreeMap<String, Vec<String>> = BTreeMap::new();
 	let mut skipped_noise = 0usize;
-	for raw in &paths {
+	for raw in paths {
 		let normalized = normalize_listing_path(raw);
 		if normalized.is_empty() {
 			continue;
@@ -345,11 +517,12 @@ fn compact_cat_output(ctx: &MinimizerCtx<'_>, input: &str) -> String {
 	if !is_source_path(&path) {
 		return input.to_string();
 	}
-	compact_source_outline(input)
+	compact_source_outline(input, &path, ctx.config.source_outline_level)
 }
 
 fn extract_single_path_arg(command: &str, program: &str) -> Option<String> {
 	let mut saw_program = false;
+	let mut path: Option<String> = None;
 	for raw in command.split_whitespace() {
 		let token = raw.trim_matches(|ch| ch == '\'' || ch == '"');
 		let normalized = token.rsplit('/').next().unwrap_or(token);
@@ -359,12 +532,18 @@ fn extract_single_path_arg(command: &str, program: &str) -> Option<String> {
 			}
 			continue;
 		}
-		if token.starts_with('-') {
+		if token == "--" {
 			continue;
 		}
-		return Some(token.to_string());
+		if token.starts_with('-') {
+			return None;
+		}
+		if path.is_some() {
+			return None;
+		}
+		path = Some(token.to_string());
 	}
-	None
+	path
 }
 
 fn summarize_manifest(path: &str, input: &str) -> Option<String> {
@@ -590,7 +769,12 @@ fn is_source_path(path: &str) -> bool {
 	)
 }
 
-fn compact_source_outline(input: &str) -> String {
+fn compact_source_outline(input: &str, path: &str, level: OutlineLevel) -> String {
+	if level == OutlineLevel::Aggressive
+		&& let Some(stripped) = aggressive_strip_bodies(input, path)
+	{
+		return stripped;
+	}
 	let lines: Vec<&str> = input.lines().collect();
 	if lines.len() < 160 && input.len() < 12_000 {
 		return input.to_string();
@@ -686,6 +870,254 @@ fn render_source_declaration(trimmed: &str) -> String {
 	line
 }
 
+/// Aggressive source-outline body stripping for brace-based and indent-based
+/// languages. Returns `None` for languages we don't have a strip path for so
+/// the caller falls back to default outline rendering.
+fn aggressive_strip_bodies(input: &str, path: &str) -> Option<String> {
+	let ext = Path::new(path)
+		.extension()
+		.and_then(|e| e.to_str())
+		.unwrap_or("");
+	match ext {
+		"rs" | "ts" | "tsx" | "js" | "jsx" | "go" => Some(strip_brace_bodies(input)),
+		"py" => Some(strip_python_bodies(input)),
+		_ => None,
+	}
+}
+
+/// Replace the body of every function/method declaration with `{ ... }`,
+/// keeping signatures, doc comments, attributes, imports, and container
+/// declarations (`class`/`struct`/`enum`/`trait`/`impl`/`interface`/
+/// `namespace`/`module`) intact. We descend into container bodies so inner
+/// method signatures stay visible.
+///
+/// Brace depth tracking handles nested braces inside string/macro content
+/// imperfectly but conservatively — when in doubt we re-emit the original
+/// line.
+fn strip_brace_bodies(input: &str) -> String {
+	let mut out = String::with_capacity(input.len() / 2);
+	let mut skip_depth: i32 = 0;
+	for line in input.lines() {
+		if skip_depth > 0 {
+			skip_depth += brace_delta(line);
+			if skip_depth <= 0 {
+				skip_depth = 0;
+			}
+			continue;
+		}
+		let trimmed = line.trim_start();
+		let delta = brace_delta(line);
+		if delta > 0 && is_function_body_starter(trimmed) {
+			let Some(cut) = line.find('{') else {
+				out.push_str(line);
+				out.push('\n');
+				continue;
+			};
+			out.push_str(line[..cut].trim_end());
+			out.push_str(" { ... }\n");
+			if delta > 0 {
+				skip_depth = delta;
+			}
+			continue;
+		}
+		out.push_str(line);
+		out.push('\n');
+	}
+	out
+}
+
+fn brace_delta(line: &str) -> i32 {
+	let mut delta: i32 = 0;
+	let mut in_str: Option<char> = None;
+	let mut chars = line.chars().peekable();
+	let mut prev = '\0';
+	while let Some(ch) = chars.next() {
+		match in_str {
+			Some(q) => {
+				if ch == q && prev != '\\' {
+					in_str = None;
+				}
+			},
+			None => match ch {
+				'/' if chars.peek() == Some(&'/') => break,
+				'"' | '\'' | '`' => in_str = Some(ch),
+				'{' => delta += 1,
+				'}' => delta -= 1,
+				_ => {},
+			},
+		}
+		prev = ch;
+	}
+	delta
+}
+
+/// Only function-like declarations whose body we want to strip. Container
+/// declarations (`class`/`struct`/`enum`/`trait`/`impl`/`interface`/
+/// `namespace`/`module`) are intentionally NOT in this set so we keep
+/// descending and strip the methods inside them.
+fn is_function_body_starter(trimmed: &str) -> bool {
+	let without_attr = trimmed.trim_start_matches(['#', '[', ']']);
+	let without_vis = strip_leading_keywords(without_attr.trim_start());
+	if without_vis.starts_with("fn ")
+		|| without_vis.starts_with("function ")
+		|| without_vis.starts_with("function(")
+		|| without_vis.starts_with("function*")
+		|| without_vis.starts_with("func ")
+		|| without_vis.starts_with("method ")
+		|| without_vis.starts_with("constructor(")
+		|| without_vis.starts_with("constructor ")
+	{
+		return true;
+	}
+	// Reject container keywords explicitly so the TS-method fallback below
+	// can't mistakenly latch onto `class Foo(...)`/`type Foo = (...) => …`.
+	for kw in [
+		"class ",
+		"struct ",
+		"enum ",
+		"trait ",
+		"impl ",
+		"impl<",
+		"interface ",
+		"type ",
+		"namespace ",
+		"module ",
+	] {
+		if without_vis.starts_with(kw) {
+			return false;
+		}
+	}
+	starts_with_ts_method(without_vis)
+}
+
+fn strip_leading_keywords(s: &str) -> &str {
+	let mut current = s;
+	loop {
+		let next = current
+			.strip_prefix("pub ")
+			.or_else(|| current.strip_prefix("pub(crate) "))
+			.or_else(|| current.strip_prefix("export "))
+			.or_else(|| current.strip_prefix("export default "))
+			.or_else(|| current.strip_prefix("async "))
+			.or_else(|| current.strip_prefix("default "))
+			.or_else(|| current.strip_prefix("static "))
+			.or_else(|| current.strip_prefix("private "))
+			.or_else(|| current.strip_prefix("protected "))
+			.or_else(|| current.strip_prefix("public "))
+			.or_else(|| current.strip_prefix("readonly "))
+			.or_else(|| current.strip_prefix("abstract "))
+			.or_else(|| current.strip_prefix("override "))
+			.or_else(|| current.strip_prefix("const "));
+		match next {
+			Some(rest) => current = rest,
+			None => break,
+		}
+	}
+	current
+}
+
+/// Heuristic for TypeScript-style class methods: `name(args): Ret {` or
+/// `name(args) {`. We accept any identifier-like token followed by `(`.
+fn starts_with_ts_method(s: &str) -> bool {
+	let mut chars = s.char_indices();
+	let Some((_, first)) = chars.next() else {
+		return false;
+	};
+	if !(first.is_ascii_alphabetic() || first == '_' || first == '$') {
+		return false;
+	}
+	let mut paren_idx = None;
+	for (idx, ch) in chars {
+		if ch.is_ascii_alphanumeric() || ch == '_' || ch == '$' {
+			continue;
+		}
+		if ch == '(' {
+			paren_idx = Some(idx);
+		}
+		break;
+	}
+	paren_idx.is_some()
+}
+
+/// Strip Python function bodies while preserving class members. Function and
+/// method declarations keep their signatures with a single placeholder body;
+/// class bodies are recursively outlined so method signatures and class
+/// attributes stay visible.
+fn strip_python_bodies(input: &str) -> String {
+	let lines: Vec<&str> = input.lines().collect();
+	let mut out = String::with_capacity(input.len() / 2);
+	let mut i = 0;
+	while i < lines.len() {
+		let line = lines[i];
+		let indent = line.chars().take_while(|c| *c == ' ' || *c == '\t').count();
+		let trimmed = line.trim_start();
+		let is_def = trimmed.starts_with("def ") || trimmed.starts_with("async def ");
+		let is_class = trimmed.starts_with("class ");
+		let ends_with_colon = trimmed.trim_end().ends_with(':');
+		if is_class && ends_with_colon {
+			out.push_str(line);
+			out.push('\n');
+			i += 1;
+			let body_start = i;
+			while i < lines.len() {
+				let body_line = lines[i];
+				if body_line.trim().is_empty() {
+					i += 1;
+					continue;
+				}
+				let body_indent = body_line
+					.chars()
+					.take_while(|c| *c == ' ' || *c == '\t')
+					.count();
+				if body_indent <= indent {
+					break;
+				}
+				i += 1;
+			}
+			if body_start < i {
+				out.push_str(&strip_python_bodies(&lines[body_start..i].join("\n")));
+			}
+			continue;
+		}
+		if is_def && ends_with_colon {
+			out.push_str(line);
+			out.push('\n');
+			i += 1;
+			let mut stripped_any = false;
+			while i < lines.len() {
+				let body_line = lines[i];
+				let body_indent = body_line
+					.chars()
+					.take_while(|c| *c == ' ' || *c == '\t')
+					.count();
+				if body_line.trim().is_empty() {
+					if !stripped_any {
+						out.push_str(body_line);
+						out.push('\n');
+					}
+					i += 1;
+					continue;
+				}
+				if body_indent <= indent {
+					break;
+				}
+				stripped_any = true;
+				i += 1;
+			}
+			if stripped_any {
+				let pad: String = " ".repeat(indent + 4);
+				out.push_str(&pad);
+				out.push_str("...\n");
+			}
+			continue;
+		}
+		out.push_str(line);
+		out.push('\n');
+		i += 1;
+	}
+	out
+}
+
 fn compact_summary_output(input: &str) -> String {
 	let lines: Vec<&str> = input.lines().collect();
 	if lines.len() <= 30 {
@@ -739,11 +1171,27 @@ mod tests {
 	}
 
 	#[test]
+	fn find_printf_output_stays_opaque() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx_command("find", "find . -printf '%p %s\\n'", &cfg);
+		let input = "./a 10\n./b 20\n";
+		let out = filter(&ctx, input, 0);
+		assert_eq!(out.text, input);
+	}
+
+	// migrated for always-group: see T1a (minimizer-filter-remediation).
+	// Previously asserted passthrough-style `group_by_file` output. The
+	// Tier 1 unconditional grouping path now produces the `grep: N matches
+	// in M files` header even for small inputs.
+	#[test]
 	fn groups_grep_by_file() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
 		let ctx = ctx("rg", &cfg);
 		let out = filter(&ctx, "a.rs:1:foo\na.rs:2:bar\n", 0);
-		assert_eq!(out.text, "a.rs:\n  1:foo\n  2:bar\n");
+		assert!(out.text.starts_with("grep: 2 matches in 1 files"), "{:?}", out.text);
+		assert!(out.text.contains("a.rs:"));
+		assert!(out.text.contains("1: foo"));
+		assert!(out.text.contains("2: bar"));
 	}
 
 	#[test]
@@ -762,6 +1210,87 @@ mod tests {
 		assert!(out.text.starts_with("grep: 20 matches in 20 files"));
 		assert!(out.text.contains("17: pub fn run(...) -> Result<()> {"));
 		assert!(out.text.contains("matches in 8 files omitted"));
+	}
+
+	#[test]
+	fn center_truncate_short_line_passes_through() {
+		assert_eq!(center_truncate_match("fn foo() {}", 140), "fn foo() {}");
+	}
+
+	#[test]
+	fn center_truncate_long_line_with_leading_whitespace_centers_in_code() {
+		// Match is in the code region after significant indentation.
+		let indent = "                              ";
+		let body = "let result = deeply_nested_function(arg1, arg2, arg3, arg4, arg5, arg6, arg7, \
+		            arg8, arg9, arg10, arg11, arg12, arg13, extra, more, stuff, padding, fill, end);";
+		let line = format!("{indent}{body}");
+		assert!(line.chars().count() > 140, "test line must exceed max_chars");
+		let out = center_truncate_match(&line, 140);
+		// Should show leading … (indentation was skipped), centered code, and …[+N]
+		// tally.
+		assert!(out.starts_with('\u{2026}'), "should start with …: {out}");
+		assert!(out.ends_with(']'), "should end with tally: {out}");
+		assert!(out.contains("result"), "match region 'result' should be visible: {out}");
+		assert!(out.contains("arg5"), "middle args should be visible: {out}");
+		// Should NOT show the raw "let result" from the very front (since indentation
+		// was dropped). But it might appear inside the window. The key assertion:
+		// leading indent chars are dropped.
+		let after_ellipsis = &out['\u{2026}'.len_utf8()..];
+		assert!(
+			!after_ellipsis.starts_with(' '),
+			"window should not start with leading spaces: {out}"
+		);
+	}
+
+	#[test]
+	fn center_truncate_long_line_no_whitespace_centers_in_middle() {
+		let mut line = String::from("use std::collections::{");
+		for i in 0..30 {
+			line.push_str("Module");
+			line.push_str(&i.to_string());
+			line.push_str(", ");
+		}
+		line.push_str("ExtraLongModuleName};");
+		assert!(line.chars().count() > 140, "test line must exceed max_chars");
+		let out = center_truncate_match(&line, 140);
+		assert!(out.starts_with('\u{2026}'), "should start with …: {out}");
+		assert!(out.ends_with(']'), "should end with tally: {out}");
+		// Middle modules like Module14, Module15 should be visible.
+		assert!(out.contains("Module14"), "middle modules should be visible: {out}");
+		assert!(!out.starts_with("use std"), "front content should be dropped: {out}");
+	}
+
+	#[test]
+	fn center_truncate_match_near_end_visible() {
+		let prefix = "x".repeat(40);
+		let marker = "MATCH_NEAR_END_HERE";
+		let suffix = "y".repeat(200);
+		let line = format!("{prefix}{marker}{suffix}");
+		assert!(line.chars().count() > 140, "test line must exceed max_chars");
+		let out = center_truncate_match(&line, 140);
+		// marker starts at char 40, window is centered, should include the marker.
+		assert!(out.contains(marker), "match should be visible: {out}");
+	}
+
+	#[test]
+	fn center_truncate_max_zero_returns_empty() {
+		assert_eq!(center_truncate_match("anything", 0), "");
+	}
+
+	#[test]
+	fn center_truncate_exact_length_returns_unchanged() {
+		let line = "a".repeat(140);
+		assert_eq!(center_truncate_match(&line, 140), line);
+	}
+
+	#[test]
+	fn center_truncate_one_over_shows_tally() {
+		let line = "a".repeat(141);
+		let out = center_truncate_match(&line, 140);
+		assert!(out.contains("\u{2026}[+"), "should have tally: {out}");
+		// With 141 chars, centering produces window_start=0, shows 140 a's, drops 1.
+		let content_chars: String = out.chars().filter(|c| *c == 'a').collect();
+		assert_eq!(content_chars.len(), 140);
 	}
 
 	#[test]
@@ -784,6 +1313,38 @@ mod tests {
 			out.text,
 			"Cargo.toml: rtk\ndependencies: 3\n  clap 4\n  anyhow 1.0\n  serde_json 1\n"
 		);
+	}
+
+	#[test]
+	fn aggressive_python_outline_preserves_class_members() {
+		let cfg = MinimizerConfig {
+			enabled: true,
+			source_outline_level: OutlineLevel::Aggressive,
+			..Default::default()
+		};
+		let ctx = ctx_command("cat", "cat src/example.py", &cfg);
+		let input = concat!(
+			"class Example:\n",
+			"    kind = \"demo\"\n",
+			"\n",
+			"    def one(self):\n",
+			"        print('hidden')\n",
+			"\n",
+			"    async def two(self):\n",
+			"        return 2\n",
+			"\n",
+			"def outside():\n",
+			"    return 3\n",
+		);
+		let out = filter(&ctx, input, 0);
+		assert!(out.text.contains("class Example:"));
+		assert!(out.text.contains("    kind = \"demo\""));
+		assert!(out.text.contains("    def one(self):"));
+		assert!(out.text.contains("    async def two(self):"));
+		assert!(out.text.contains("def outside():"));
+		assert!(!out.text.contains("print('hidden')"));
+		assert!(!out.text.contains("return 2"));
+		assert!(!out.text.contains("return 3"));
 	}
 
 	#[test]
@@ -915,5 +1476,329 @@ mod tests {
 			out.push('\n');
 		}
 		out
+	}
+
+	fn aggressive_cfg() -> MinimizerConfig {
+		MinimizerConfig {
+			enabled: true,
+			source_outline_level: OutlineLevel::Aggressive,
+			..Default::default()
+		}
+	}
+
+	#[test]
+	fn default_level_keeps_small_source_files_intact() {
+		// Default behavior: short source files pass through unchanged so
+		// existing callers (and `default_level_keeps_small_source_files_intact`)
+		// never see surprise body stripping.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx_command("cat", "cat src/foo.rs", &cfg);
+		let body = "fn foo() {\n    let x = 1;\n    x + 1\n}\n";
+		let out = filter(&ctx, body, 0);
+		assert!(!out.changed, "default level on tiny file must passthrough");
+	}
+
+	#[test]
+	fn aggressive_strips_rust_function_body() {
+		let cfg = aggressive_cfg();
+		let ctx = ctx_command("cat", "cat src/foo.rs", &cfg);
+		let body = "use std::io;\n\npub fn foo(x: i32) -> i32 {\n    let y = x + 1;\n    y * 2\n}\n";
+		let out = filter(&ctx, body, 0);
+		assert!(out.changed, "aggressive must rewrite");
+		assert!(out.text.contains("use std::io;"));
+		assert!(out.text.contains("pub fn foo(x: i32) -> i32 { ... }"));
+		assert!(!out.text.contains("y * 2"));
+	}
+
+	#[test]
+	fn brace_in_line_comment_not_counted() {
+		let cfg = aggressive_cfg();
+		let ctx = ctx_command("cat", "cat src/lib.rs", &cfg);
+		let input = concat!(
+			"fn outer() {\n",
+			"    // This comment has { braces } in it\n",
+			"    let x = 1;\n",
+			"}\n",
+			"fn preserved() {\n",
+			"    let y = 2;\n",
+			"}\n",
+		);
+		let out = filter(&ctx, input, 0);
+		assert!(
+			out.text.contains("fn preserved()"),
+			"fn after comment-brace must survive: {:?}",
+			out.text
+		);
+	}
+
+	#[test]
+	fn aggressive_multi_file_cat_preserves_combined_output() {
+		let cfg = aggressive_cfg();
+		let ctx = ctx_command("cat", "cat src/a.rs src/b.rs", &cfg);
+		let body = concat!(
+			"pub fn a() -> i32 {\n",
+			"    1\n",
+			"}\n",
+			"pub fn b() -> i32 {\n",
+			"    2\n",
+			"}\n",
+		);
+		let out = filter(&ctx, body, 0);
+		assert!(!out.changed, "multi-file cat output must remain verbatim");
+		assert_eq!(out.text, body);
+	}
+
+	#[test]
+	fn aggressive_cat_with_behavior_flags_preserves_output() {
+		let cfg = aggressive_cfg();
+		let ctx = ctx_command("cat", "cat -n src/foo.rs", &cfg);
+		let body = "     1\tpub fn foo() -> i32 {\n     2\t    1\n     3\t}\n";
+		let out = filter(&ctx, body, 0);
+		assert!(!out.changed, "cat flags that alter output must remain verbatim");
+		assert_eq!(out.text, body);
+	}
+
+	#[test]
+	fn aggressive_strips_typescript_method_body() {
+		let cfg = aggressive_cfg();
+		let ctx = ctx_command("cat", "cat src/foo.ts", &cfg);
+		let body = "import { z } from 'x';\n\nexport class Svc {\n    run(): number {\n        \
+		            return 1;\n    }\n}\n";
+		let out = filter(&ctx, body, 0);
+		assert!(out.changed);
+		assert!(out.text.contains("import { z } from 'x';"));
+		assert!(out.text.contains("run(): number { ... }"));
+		assert!(!out.text.contains("return 1;"));
+	}
+
+	#[test]
+	fn aggressive_strips_python_function_body() {
+		let cfg = aggressive_cfg();
+		let ctx = ctx_command("cat", "cat src/foo.py", &cfg);
+		let body = "import os\n\ndef compute(x):\n    y = x + 1\n    return y * 2\n";
+		let out = filter(&ctx, body, 0);
+		assert!(out.changed);
+		assert!(out.text.contains("import os"));
+		assert!(out.text.contains("def compute(x):"));
+		assert!(out.text.contains("    ..."));
+		assert!(!out.text.contains("y * 2"));
+	}
+
+	#[test]
+	fn aggressive_unknown_extension_passes_through() {
+		let cfg = aggressive_cfg();
+		let ctx = ctx_command("cat", "cat src/foo.swift", &cfg);
+		let body = "func compute() {}\n";
+		let out = filter(&ctx, body, 0);
+		assert!(!out.changed, "aggressive must not touch unsupported langs");
+	}
+
+	#[test]
+	fn aggressive_output_has_no_chain_corrupting_chars() {
+		let cfg = aggressive_cfg();
+		let ctx = ctx_command("cat", "cat src/foo.ts", &cfg);
+		let body = "export function foo() {\n  const a = `template`;\n  return a;\n}\n";
+		let out = filter(&ctx, body, 0);
+		assert!(out.changed);
+		assert!(!out.text.contains('\x1b'));
+		// signature retained without dangling backtick from template body
+		assert!(!out.text.contains("template"));
+	}
+
+	// ---------------------------------------------------------------
+	// Tier 1: always-group grep/find tests (minimizer-filter-remediation)
+	// ---------------------------------------------------------------
+
+	fn legacy_cfg() -> MinimizerConfig {
+		let mut cfg = MinimizerConfig::default();
+		cfg.enabled = true;
+		cfg.legacy_filters_active = true;
+		cfg
+	}
+
+	fn synthesize_grep(matches_per_file: usize, files: usize) -> String {
+		let mut out = String::new();
+		for f in 0..files {
+			for m in 0..matches_per_file {
+				out.push_str(&format!(
+					"src/module{f}/file{f}.rs:{ln}:    pub fn handler_{f}_{m}(req: Request) -> \
+					 Result<Response, AppError> {{ /* body */ }}\n",
+					ln = m * 7 + 1,
+					f = f,
+					m = m,
+				));
+			}
+		}
+		out
+	}
+
+	fn synthesize_find_paths(per_dir: usize, dirs: usize) -> String {
+		let mut out = String::new();
+		for d in 0..dirs {
+			for f in 0..per_dir {
+				out.push_str(&format!(
+					"./crates/pi-shell/src/minimizer/filters/category{d}/\
+					 handler_{f}_with_descriptive_name.rs\n",
+				));
+			}
+		}
+		out
+	}
+
+	fn ratio(input: &str, output: &str) -> f64 {
+		1.0 - (output.len() as f64 / input.len() as f64)
+	}
+
+	#[test]
+	fn grep_small_1m1f_always_groups() {
+		// 1 match in 1 file. Pre-PR: passthrough. Post: grouped header.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("grep", &cfg);
+		let input = synthesize_grep(1, 1);
+		let out = filter(&ctx, &input, 0);
+		assert!(out.text.contains("grep: 1 matches in 1 files"));
+	}
+
+	#[test]
+	fn grep_medium_3m1f_always_groups() {
+		// 3 matches in 1 file. Pre-PR: passthrough (was within thresholds).
+		// Post: grouped header.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("grep", &cfg);
+		let input = synthesize_grep(3, 1);
+		let out = filter(&ctx, &input, 0);
+		assert!(
+			out.text.contains("grep: 3 matches in 1 files"),
+			"expected always-group header, got: {}",
+			out.text
+		);
+	}
+
+	#[test]
+	fn grep_large_100m10f_savedratio_threshold() {
+		// 100 matches × 10 files: pre-existing grouping path. SavedRatio
+		// must be substantial (≥0.50 from m3 acceptance; we assert ≥0.50).
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("grep", &cfg);
+		let input = synthesize_grep(10, 10);
+		let out = filter(&ctx, &input, 0);
+		assert!(out.text.starts_with("grep: 100 matches in 10 files"));
+		let r = ratio(&input, &out.text);
+		assert!(r >= 0.50, "savedRatio={r}");
+	}
+
+	#[test]
+	fn grep_null_filename_output_is_passthrough() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx_command("grep", "grep -ZHn pattern src/*.rs", &cfg);
+		let input = concat!("src/a.rs\0", "10:pattern\nsrc/b.rs\0", "20:pattern\n");
+		let out = filter(&ctx, input, 0);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn rg_null_data_output_is_passthrough() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx_command("rg", "rg --null-data pattern src", &cfg);
+		let input = "src/a.rs:10:pattern\0src/b.rs:20:pattern\0";
+		let out = filter(&ctx, input, 0);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn find_shallow_5p1d_always_groups() {
+		// 5 paths in 1 dir. Pre-PR: passthrough. Post: grouped.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("find", &cfg);
+		let input = synthesize_find_paths(5, 1);
+		let out = filter(&ctx, &input, 0);
+		assert!(
+			out.text.contains("find: 5 paths in 1 dirs"),
+			"expected always-group header, got: {}",
+			out.text
+		);
+	}
+
+	#[test]
+	fn find_deep_50p8d_savedratio_threshold() {
+		// 50 paths × 8 dirs. Was already grouped pre-PR; regression guard
+		// + savedRatio threshold per m3 (≥0.60 deep fixture).
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("find", &cfg);
+		let input = synthesize_find_paths(50, 8);
+		let out = filter(&ctx, &input, 0);
+		assert!(out.text.starts_with("find: 400 paths in 8 dirs"));
+		let r = ratio(&input, &out.text);
+		assert!(r >= 0.60, "savedRatio={r}");
+	}
+
+	#[test]
+	fn find_wide_200p1d_grouped() {
+		// 200 paths in 1 dir. Was already grouped pre-PR.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("find", &cfg);
+		let input = synthesize_find_paths(200, 1);
+		let out = filter(&ctx, &input, 0);
+		assert!(out.text.starts_with("find: 200 paths in 1 dirs"));
+	}
+
+	#[test]
+	fn grep_legacy_filters_active_passes_through_small_input() {
+		// Kill-switch parity (M2): with legacy_filters_active=true, the
+		// pre-PR "small input passthrough" path is preserved byte-for-byte.
+		let cfg = legacy_cfg();
+		let ctx = ctx("grep", &cfg);
+		let input = synthesize_grep(2, 1);
+		let out = filter(&ctx, &input, 0);
+		// Legacy path: group_by_file primitive style for inputs at/below
+		// 12 matches × 3 files. Compare against direct invocation.
+		let expected = compact_grep_output_legacy(&primitives::strip_ansi(&input));
+		assert_eq!(out.text, expected);
+		assert!(
+			!out.text.starts_with("grep: 2 matches"),
+			"legacy path must NOT emit always-group header"
+		);
+	}
+
+	#[test]
+	fn grep_null_data_flag_bypasses_compaction() {
+		// grep -z / --null-data produces NUL-delimited records; the compactor
+		// splits on newlines and would corrupt the output. Passthrough instead.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = synthesize_grep(5, 2);
+		for cmd in &["grep -zHn pattern file", "grep --null-data pattern file"] {
+			let ctx = ctx_command("grep", cmd, &cfg);
+			let out = filter(&ctx, &input, 0);
+			assert!(!out.changed, "grep NUL-output flag must passthrough: {cmd}");
+			assert_eq!(out.text, input, "grep NUL-output flag must passthrough: {cmd}");
+		}
+	}
+
+	#[test]
+	fn rg_null_flag_bypasses_compaction() {
+		// rg -0 / --null appends a NUL after each path; same concern.
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let input = synthesize_grep(5, 2);
+		for cmd in &["rg -0 pattern", "rg --null pattern"] {
+			let ctx = ctx_command("rg", cmd, &cfg);
+			let out = filter(&ctx, &input, 0);
+			assert!(!out.changed, "rg NUL-output flag must passthrough: {cmd}");
+			assert_eq!(out.text, input, "rg NUL-output flag must passthrough: {cmd}");
+		}
+	}
+
+	#[test]
+	fn find_legacy_filters_active_passes_through_under_threshold() {
+		// Kill-switch parity (M2): legacy_filters_active=true reverts to
+		// the pre-PR `paths.len() <= 20` passthrough.
+		let cfg = legacy_cfg();
+		let ctx = ctx("find", &cfg);
+		let input = synthesize_find_paths(5, 1);
+		let out = filter(&ctx, &input, 0);
+		// Legacy: small input passes through unchanged.
+		assert_eq!(out.text, input);
+		assert!(!out.changed);
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/listing.rs
+++ b/crates/pi-shell/src/minimizer/filters/listing.rs
@@ -879,6 +879,7 @@ fn aggressive_strip_bodies(input: &str, path: &str) -> Option<String> {
 		.and_then(|e| e.to_str())
 		.unwrap_or("");
 	match ext {
+		"rs" if contains_rust_raw_string_literal(input) => None,
 		"rs" | "ts" | "tsx" | "js" | "jsx" | "go" => Some(strip_brace_bodies(input)),
 		"py" => Some(strip_python_bodies(input)),
 		_ => None,
@@ -924,6 +925,10 @@ fn strip_brace_bodies(input: &str) -> String {
 		out.push('\n');
 	}
 	out
+}
+
+fn contains_rust_raw_string_literal(input: &str) -> bool {
+	input.contains("r#") || input.contains("r\"") || input.contains("br#") || input.contains("br\"")
 }
 
 fn brace_delta(line: &str) -> i32 {
@@ -1508,6 +1513,17 @@ mod tests {
 		assert!(out.text.contains("use std::io;"));
 		assert!(out.text.contains("pub fn foo(x: i32) -> i32 { ... }"));
 		assert!(!out.text.contains("y * 2"));
+	}
+
+	#[test]
+	fn aggressive_rust_outline_bails_on_raw_strings() {
+		let cfg = aggressive_cfg();
+		let ctx = ctx_command("cat", "cat src/foo.rs", &cfg);
+		let body =
+			"pub fn shader() -> &'static str {\n    r#\"fn main() { println!(\\\"hi\\\"); }\"#\n}\n";
+		let out = filter(&ctx, body, 0);
+		assert!(!out.changed, "raw-string Rust source should fall back to default outline");
+		assert_eq!(out.text, body);
 	}
 
 	#[test]

--- a/crates/pi-shell/src/minimizer/filters/mod.rs
+++ b/crates/pi-shell/src/minimizer/filters/mod.rs
@@ -5,6 +5,7 @@ use crate::minimizer::{MinimizerCtx, MinimizerOutput};
 pub mod cloud;
 pub mod cpp;
 
+pub mod binary_tools;
 pub mod bun;
 
 pub mod cargo;
@@ -29,6 +30,7 @@ pub mod pkg;
 
 pub mod python;
 pub mod ruby;
+pub mod rust_tools;
 pub mod system;
 
 pub fn supports(program: &str, subcommand: Option<&str>) -> bool {
@@ -52,6 +54,8 @@ pub fn supports(program: &str, subcommand: Option<&str>) -> bool {
 			python::supports(program, subcommand)
 		},
 		"rspec" | "rake" | "rails" | "rubocop" => ruby::supports(program, subcommand),
+		"rustfmt" => rust_tools::supports(program, subcommand),
+		"xxd" | "strings" | "od" => binary_tools::supports(program, subcommand),
 		"tsc" | "eslint" | "biome" | "shellcheck" | "markdownlint" | "hadolint" | "yamllint"
 		| "oxlint" | "pyright" | "basedpyright" => {
 			lint::supports(subcommand) || lint::supports_program(program, subcommand)
@@ -63,12 +67,66 @@ pub fn supports(program: &str, subcommand: Option<&str>) -> bool {
 				|| js_tools::supports(program, subcommand)
 		},
 		"pnpm" if matches!(subcommand, Some("dlx")) => true,
-		"npm" | "pnpm" | "yarn" | "pip" | "pip3" | "bundle" | "brew" | "composer" | "uv"
-		| "poetry" => pkg::supports(subcommand),
+		"uv" if matches!(subcommand, Some("run")) => true,
+		"npm" | "pnpm" | "yarn" | "pip" | "pip3" | "bundle" | "brew" | "composer" | "poetry" => {
+			pkg::supports(subcommand)
+		},
+		"uv" => {
+			// uv dispatch coverage (B1 / m4): admit additional subcommand forms
+			// that wrap a known tool. `uv run` is already handled above; this
+			// arm covers `uv pytest`, `uv -m pytest`, `uv ruff`, `uv mypy`,
+			// and other wrapped-tool forms that pre-PR fell through to the
+			// package-manager filter.
+			matches!(subcommand, Some("pytest" | "ruff" | "mypy" | "-m")) || pkg::supports(subcommand)
+		},
 		"env" | "log" | "deps" | "summary" | "err" | "test" | "diff" | "format" | "pipe" | "ps"
 		| "ping" | "ssh" | "sops" => system::supports(program),
 		_ => false,
 	}
+}
+
+fn is_test_script_token(token: &str) -> bool {
+	let token = token.trim_matches(|ch| matches!(ch, '\'' | '"' | '`'));
+	matches!(token, "test" | "t" | "e2e" | "spec") || token.starts_with("test:")
+}
+
+/// The script/command word a `run`-style invocation targets: the first
+/// non-flag token after the `run`/`-m`/`--module` marker. Returns `None` when
+/// no marker (or no following word) is present.
+///
+/// Selecting only this word — instead of scanning the entire command line —
+/// keeps tool/script names that appear merely as later arguments from
+/// mis-routing output through a test/lint/wrapped-tool filter. Examples that
+/// must NOT route as tests: `npm run build -- test`, `uv run echo pytest`.
+fn run_invoked_word(command: &str) -> Option<&str> {
+	let mut tokens = command
+		.split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '|' | '&'))
+		.filter(|tok| !tok.is_empty());
+	tokens
+		.by_ref()
+		.find(|tok| matches!(*tok, "run" | "-m" | "--module"))?;
+	tokens.find(|tok| !tok.starts_with('-'))
+}
+
+fn is_pkg_test_invocation(ctx: &MinimizerCtx<'_>) -> bool {
+	matches!(ctx.subcommand, Some("test" | "t"))
+		|| (matches!(ctx.subcommand, Some("run"))
+			&& run_invoked_word(ctx.command).is_some_and(is_test_script_token))
+}
+
+fn is_pkg_lint_invocation(ctx: &MinimizerCtx<'_>) -> bool {
+	matches!(ctx.subcommand, Some("run"))
+		&& run_invoked_word(ctx.command).is_some_and(|word| {
+			is_lint_script_token(word) || matches!(word, "tsc" | "eslint" | "biome")
+		})
+}
+
+fn is_lint_script_token(token: &str) -> bool {
+	let token = token.trim_matches(|ch| matches!(ch, '\'' | '"' | '`'));
+	matches!(token, "lint" | "typecheck" | "type-check")
+		|| token.starts_with("lint:")
+		|| token.starts_with("typecheck:")
+		|| token.starts_with("type-check:")
 }
 
 /// Apply the matching built-in filter.
@@ -95,14 +153,29 @@ pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerO
 			python::filter(ctx, input, exit_code)
 		},
 		"rspec" | "rake" | "rails" | "rubocop" => ruby::filter(ctx, input, exit_code),
+		"rustfmt" => rust_tools::filter(ctx, input, exit_code),
+		"xxd" | "strings" | "od" => binary_tools::filter(ctx, input, exit_code),
 		"tsc" | "eslint" | "biome" | "shellcheck" | "markdownlint" | "hadolint" | "yamllint"
 		| "oxlint" | "pyright" | "basedpyright" => lint::filter(ctx, input, exit_code),
 		"jest" | "vitest" | "playwright" => node_tests::filter(ctx, input, exit_code),
 		"next" | "prettier" | "prisma" => js_tools::filter(ctx, input, exit_code),
 		"npx" => filter_js_wrapper(ctx, input, exit_code),
 		"pnpm" if matches!(ctx.subcommand, Some("dlx")) => filter_js_wrapper(ctx, input, exit_code),
-		"npm" | "pnpm" | "yarn" | "pip" | "pip3" | "bundle" | "brew" | "composer" | "uv"
-		| "poetry" => pkg::filter(ctx, input, exit_code),
+		"uv" if matches!(ctx.subcommand, Some("run" | "pytest" | "ruff" | "mypy" | "-m")) => {
+			filter_uv_wrapper(ctx, input, exit_code)
+		},
+		"npm" | "pnpm" | "yarn" => {
+			if is_pkg_test_invocation(ctx) {
+				node_tests::filter(ctx, input, exit_code)
+			} else if is_pkg_lint_invocation(ctx) {
+				lint::filter(ctx, input, exit_code)
+			} else {
+				pkg::filter(ctx, input, exit_code)
+			}
+		},
+		"pip" | "pip3" | "bundle" | "brew" | "composer" | "uv" | "poetry" => {
+			pkg::filter(ctx, input, exit_code)
+		},
 		"env" | "log" | "deps" | "summary" | "err" | "test" | "diff" | "format" | "pipe" | "ps"
 		| "ping" | "ssh" | "sops" => system::filter(ctx, input, exit_code),
 		_ => generic::filter(ctx, input, exit_code),
@@ -121,13 +194,227 @@ fn filter_js_wrapper(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> Min
 	}
 }
 
+fn filter_uv_wrapper(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerOutput {
+	// uv dispatch normalization (B1 / m4): admit `uv pytest`, `uv -m pytest`,
+	// `uv ruff`, `uv mypy` in addition to the pre-existing `uv run …` path.
+	if let Some(tool) = normalize_uv_form(ctx.subcommand, ctx.command) {
+		let routed = MinimizerCtx {
+			program:    tool,
+			subcommand: Some(tool),
+			command:    ctx.command,
+			config:     ctx.config,
+		};
+		return match tool {
+			"pytest" | "ruff" | "mypy" => python::filter(&routed, input, exit_code),
+			_ => MinimizerOutput::passthrough(input),
+		};
+	}
+	match uv_wrapper_tool(ctx) {
+		Some("pytest") => {
+			let routed = MinimizerCtx {
+				program:    "pytest",
+				subcommand: Some("pytest"),
+				command:    ctx.command,
+				config:     ctx.config,
+			};
+			python::filter(&routed, input, exit_code)
+		},
+		Some("ruff") => {
+			let subcommand = if ctx.command.split_whitespace().any(|part| part == "format") {
+				Some("format")
+			} else {
+				Some("ruff")
+			};
+			let routed =
+				MinimizerCtx { program: "ruff", subcommand, command: ctx.command, config: ctx.config };
+			python::filter(&routed, input, exit_code)
+		},
+		Some("mypy") => {
+			let routed = MinimizerCtx {
+				program:    "mypy",
+				subcommand: Some("mypy"),
+				command:    ctx.command,
+				config:     ctx.config,
+			};
+			python::filter(&routed, input, exit_code)
+		},
+		Some(tool @ ("tsc" | "eslint" | "biome" | "pyright" | "basedpyright" | "oxlint")) => {
+			let routed = MinimizerCtx {
+				program:    tool,
+				subcommand: Some(tool),
+				command:    ctx.command,
+				config:     ctx.config,
+			};
+			lint::filter(&routed, input, exit_code)
+		},
+		Some("jest" | "vitest" | "playwright") => node_tests::filter(ctx, input, exit_code),
+		_ => MinimizerOutput::passthrough(input),
+	}
+}
+
+/// Normalize uv invocation forms into a routable tool name (B1 / m4).
+///
+/// Resolution order:
+///   1. If `subcommand` is itself a known python tool name (pytest, ruff,
+///      mypy), return `Some(<tool>)`.
+///   2. If `subcommand` is `"-m"`, scan `command` tokens for the first non-flag
+///      word matching the python-tool allowlist; return `Some(<tool>)`.
+///   3. If `subcommand` is `"run"`, return `None` so the caller falls through
+///      to the existing `uv_wrapper_tool` path (regression guard).
+///   4. Otherwise return `None`.
+///
+/// The returned `&'static str` is one of `"pytest"`, `"ruff"`, `"mypy"`;
+/// the caller is expected to route via the python filter.
+fn normalize_uv_form(subcommand: Option<&str>, command: &str) -> Option<&'static str> {
+	const ALLOWLIST: &[&str] = &["pytest", "ruff", "mypy"];
+	let sub = subcommand?;
+	if let Some(&tool) = ALLOWLIST.iter().find(|&&tool| tool == sub) {
+		return Some(tool);
+	}
+	if sub == "-m" {
+		// Only the immediate next non-flag token after `-m` may select a tool;
+		// scanning all subsequent tokens would pick up positional arguments
+		// (e.g. `uv -m my_module pytest` where `pytest` is an arg to `my_module`).
+		let mut tokens = command.split_whitespace().skip_while(|t| t != &"-m");
+		tokens.next(); // consume `-m` itself
+		let next = tokens.next().filter(|tok| !tok.starts_with('-'))?;
+		ALLOWLIST.iter().find(|&&tool| tool == next).copied()
+	} else {
+		None
+	}
+}
+
+fn uv_wrapper_tool<'a>(ctx: &'a MinimizerCtx<'_>) -> Option<&'a str> {
+	wrapper_invoked_tool(ctx, &[
+		"pytest",
+		"ruff",
+		"mypy",
+		"tsc",
+		"eslint",
+		"biome",
+		"pyright",
+		"basedpyright",
+		"oxlint",
+		"jest",
+		"vitest",
+		"playwright",
+	])
+}
+
+/// Wrapper options whose value is the *following* token (`--with pytest`),
+/// rather than being self-contained (`--with=pytest`). When skipping flags to
+/// find the invoked command word we must also skip these options' values, or
+/// the value (`pytest`) is mistaken for the command and routes arbitrary output
+/// through that tool's filter. Covers the value-taking options of the wrappers
+/// routed here — `uv run`, `npx`, `pnpm dlx`, `bun x`. The `--opt=value` form
+/// is already a single flag token and needs no entry here.
+const WRAPPER_VALUE_OPTIONS: &[&str] = &[
+	// uv run
+	"--with",
+	"--with-requirements",
+	"--with-editable",
+	"--python",
+	"-p",
+	"--from",
+	"--directory",
+	"--project",
+	"--index",
+	"--default-index",
+	"--index-url",
+	"--extra-index-url",
+	"--find-links",
+	"-f",
+	"--cache-dir",
+	"--config-file",
+	"--refresh-package",
+	"--resolution",
+	"--prerelease",
+	"--exclude-newer",
+	"--link-mode",
+	"--color",
+	"--python-preference",
+	// npx / pnpm dlx
+	"--package",
+	"-c",
+	"--call",
+	"--workspace",
+	"-w",
+	"--node-arg",
+];
+
+/// Advance `tokens` to the next invoked-command word, skipping flag tokens and
+/// the space-separated values of value-taking options (see
+/// [`WRAPPER_VALUE_OPTIONS`]). Inline `--opt=value` flags are skipped whole.
+fn next_command_word<'a>(tokens: &mut impl Iterator<Item = &'a str>) -> Option<&'a str> {
+	while let Some(tok) = tokens.next() {
+		if !tok.starts_with('-') {
+			return Some(tok);
+		}
+		if !tok.contains('=') && WRAPPER_VALUE_OPTIONS.contains(&tok) {
+			tokens.next(); // consume the option's value
+		}
+	}
+	None
+}
+
+/// The command/tool word a wrapper invocation actually executes: the first
+/// non-flag token after a single wrapper keyword (`run`/`dlx`/`exec`), or —
+/// when none is present — the first non-flag token after the program.
+/// Value-taking options (`--with pytest`) have their value skipped so it is not
+/// mistaken for the command. A leading `python`/`python3`/`py` interpreter is
+/// descended through its `-m`/`--module` argument so `uv run python -m pytest`
+/// resolves to `pytest`. Tool names that appear only as later arguments
+/// (`uv run build -- pytest`, `uv run echo pytest`, `uv run --with pytest
+/// echo`) are never returned.
+fn wrapper_command_word(command: &str) -> Option<&str> {
+	let mut tokens = command
+		.split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '|' | '&'))
+		.filter(|tok| !tok.is_empty());
+	tokens.next()?; // drop the program token
+	let mut word = next_command_word(&mut tokens)?;
+	if matches!(word, "run" | "dlx" | "exec") {
+		word = next_command_word(&mut tokens)?;
+	}
+	if matches!(word, "python" | "python3" | "py") {
+		while let Some(tok) = tokens.next() {
+			if tok == "--" {
+				return Some(word);
+			}
+			if matches!(tok, "-c" | "--command") {
+				return Some(word);
+			}
+			if matches!(tok, "-m" | "--module") {
+				return tokens
+					.find(|candidate| !candidate.starts_with('-'))
+					.or(Some(word));
+			}
+			if tok.starts_with('-') {
+				continue;
+			}
+			return Some(tok);
+		}
+	}
+	Some(word)
+}
+
 fn wrapper_invokes(ctx: &MinimizerCtx<'_>, tools: &[&str]) -> bool {
-	ctx.subcommand
-		.is_some_and(|subcommand| tools.contains(&subcommand))
-		|| ctx
-			.command
-			.split(|ch: char| ch.is_whitespace() || matches!(ch, ';' | '|' | '&'))
-			.any(|token| tools.contains(&token))
+	wrapper_invoked_tool(ctx, tools).is_some()
+}
+
+fn wrapper_invoked_tool<'a>(ctx: &'a MinimizerCtx<'_>, tools: &[&'a str]) -> Option<&'a str> {
+	// Prefer wrapper_command_word over ctx.subcommand: it properly skips
+	// value-taking option values (e.g. -w, --workspace, --with) that
+	// detect_subcommand may mistake for the invoked tool name.
+	let word = wrapper_command_word(ctx.command)?;
+	match tools.iter().copied().find(|&tool| tool == word) {
+		Some(tool) => Some(tool),
+		None => {
+			// Fallback: detect_subcommand may have normalized case or
+			// resolved through program-specific logic.
+			ctx.subcommand
+				.and_then(|subcommand| tools.iter().copied().find(|tool| *tool == subcommand))
+		},
+	}
 }
 
 #[cfg(test)]
@@ -167,8 +454,404 @@ mod tests {
 	}
 
 	#[test]
+	fn run_invoked_word_picks_script_not_arguments() {
+		assert_eq!(run_invoked_word("npm run build -- test"), Some("build"));
+		assert_eq!(run_invoked_word("npm run test"), Some("test"));
+		assert_eq!(run_invoked_word("npm run --silent test:unit"), Some("test:unit"));
+		assert_eq!(run_invoked_word("uv run echo pytest"), Some("echo"));
+		assert_eq!(run_invoked_word("uv run build -- pytest"), Some("build"));
+		assert_eq!(run_invoked_word("uv run -- pytest"), Some("pytest"));
+		assert_eq!(run_invoked_word("uv run python -m pytest"), Some("python"));
+		assert_eq!(run_invoked_word("npm ci"), None);
+	}
+
+	#[test]
+	fn pkg_test_routing_ignores_test_as_argument() {
+		let config = MinimizerConfig::default();
+		// a non-test script that merely passes `test` as an argument must not route as
+		// a test
+		assert!(!is_pkg_test_invocation(&ctx("npm", Some("run"), "npm run build -- test", &config)));
+		assert!(is_pkg_test_invocation(&ctx("npm", Some("run"), "npm run test", &config)));
+		assert!(is_pkg_test_invocation(&ctx("npm", Some("test"), "npm test", &config)));
+	}
+
+	#[test]
+	fn pkg_lint_routing_ignores_tool_as_argument() {
+		let config = MinimizerConfig::default();
+		assert!(!is_pkg_lint_invocation(&ctx(
+			"pnpm",
+			Some("run"),
+			"pnpm run build -- eslint",
+			&config
+		)));
+		assert!(is_pkg_lint_invocation(&ctx("pnpm", Some("run"), "pnpm run lint", &config)));
+		assert!(is_pkg_lint_invocation(&ctx("pnpm", Some("run"), "pnpm run tsc", &config)));
+	}
+
+	#[test]
+	fn uv_wrapper_ignores_tool_as_argument() {
+		let config = MinimizerConfig::default();
+		assert_eq!(
+			uv_wrapper_tool(&ctx("uv", Some("run"), "uv run pytest", &config)),
+			Some("pytest")
+		);
+		assert_eq!(uv_wrapper_tool(&ctx("uv", Some("run"), "uv run echo pytest", &config)), None);
+		assert_eq!(uv_wrapper_tool(&ctx("uv", Some("run"), "uv run build -- pytest", &config)), None);
+	}
+
+	#[test]
+	fn uv_wrapper_skips_value_taking_option_values() {
+		let config = MinimizerConfig::default();
+		// `--with <pkg>` consumes the following token as its value; that value must
+		// not be mistaken for the invoked command and route output through it.
+		assert_eq!(
+			uv_wrapper_tool(&ctx("uv", Some("run"), "uv run --with pytest echo hi", &config)),
+			None
+		);
+		assert_eq!(
+			uv_wrapper_tool(&ctx("uv", Some("run"), "uv run --with pytest build", &config)),
+			None
+		);
+		// the genuinely invoked tool still routes when preceded by a value option
+		assert_eq!(
+			uv_wrapper_tool(&ctx("uv", Some("run"), "uv run --python 3.12 pytest", &config)),
+			Some("pytest")
+		);
+		// inline `--opt=value` is a single token; the command word follows it
+		assert_eq!(
+			uv_wrapper_tool(&ctx("uv", Some("run"), "uv run --with=pytest echo hi", &config)),
+			None
+		);
+		// `python -m <module>` descent still resolves through a value option
+		assert_eq!(
+			uv_wrapper_tool(&ctx("uv", Some("run"), "uv run --with foo python -m pytest", &config)),
+			Some("pytest")
+		);
+	}
+
+	#[test]
+	fn uv_run_with_option_value_is_left_opaque() {
+		let config = MinimizerConfig::default();
+		// `pytest` is the value of `--with`, the invoked command is `echo` — output
+		// (including PASS/✓-style lines) must pass through untouched.
+		let context = ctx("uv", Some("run"), "uv run --with pytest echo PASS", &config);
+		let input = "collected 2 items\nPASS\n";
+		let out = filter(&context, input, 0);
+		assert_eq!(out.text, input);
+		assert!(!out.changed);
+	}
+
+	#[test]
+	fn uv_run_echo_pytest_is_left_opaque() {
+		let config = MinimizerConfig::default();
+		// `pytest` is an argument to `echo`, not the invoked command — output must pass
+		// through
+		let context = ctx("uv", Some("run"), "uv run echo pytest", &config);
+		let input = "collected 2 items\npytest\n";
+		let out = filter(&context, input, 0);
+		assert_eq!(out.text, input);
+		assert!(!out.changed);
+	}
+
+	#[test]
+	fn uv_run_pytest_routes_to_python_filter() {
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("run"), "uv run pytest", &config);
+		let input = "============================= test session starts \
+		             ==============================\ncollected 2 items\n\na.py .\nb.py \
+		             F\n\n=================================== FAILURES \
+		             ===================================\nFAILED b.py::test_fail - AssertionError: \
+		             expected 2 == 1\n=========================== short test summary info \
+		             ============================\nFAILED b.py::test_fail - AssertionError: \
+		             expected 2 == 1\n========================= 1 failed, 1 passed in 0.12s \
+		             =========================\n";
+		let out = filter(&context, input, 1).text;
+		assert!(out.contains("FAILED b.py::test_fail"));
+		assert!(!out.contains("collected 2 items"));
+		assert!(out.contains("pytest: 1 failed, 1 passed"));
+	}
+
+	#[test]
+	fn uv_run_ruff_routes_to_python_filter() {
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("run"), "uv run ruff check .", &config);
+		let input = "src/app.py:1:1: F401 imported but unused\nFound 1 error.\n";
+		let out = filter(&context, input, 1).text;
+		assert!(out.contains("F401"));
+	}
+
+	#[test]
+	fn uv_run_python_module_pytest_routes_to_python_filter() {
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("run"), "uv run python -m pytest", &config);
+		let input = "============================= test session starts \
+		             ==============================\ncollected 1 item\n\na.py \
+		             F\n\n=================================== FAILURES \
+		             ===================================\nFAILED a.py::test_fail - \
+		             AssertionError\n========================= 1 failed in 0.03s \
+		             =========================\n";
+		let out = filter(&context, input, 1).text;
+		assert!(out.contains("FAILED a.py::test_fail"));
+		assert!(!out.contains("collected 1 item"));
+	}
+
+	#[test]
+	fn uv_run_pyright_routes_to_lint_filter() {
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("run"), "uv run pyright", &config);
+		let input = "0 errors, 0 warnings, 0 informations\nsrc/app.ts:4:7 - error TS2322: Type \
+		             'string' is not assignable to type 'number'.\n";
+		let out = filter(&context, input, 1).text;
+		assert!(out.contains("TS2322"));
+	}
+
+	#[test]
+	fn uv_run_basedpyright_routes_to_lint_filter() {
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("run"), "uv run basedpyright", &config);
+		let input = "0 errors, 0 warnings, 0 notes\nsrc/app.ts:4:7 - error TS2322: Type 'string' is \
+		             not assignable to type 'number'.\n";
+		let out = filter(&context, input, 1).text;
+		assert!(out.contains("TS2322"));
+	}
+
+	#[test]
+	fn uv_run_unknown_tool_is_passthrough() {
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("run"), "uv run custom-tool", &config);
+		let input = "line 1\nline 2\n";
+		let out = filter(&context, input, 0);
+		assert_eq!(out.text, input);
+		assert!(!out.changed);
+	}
+
+	#[test]
+	fn npm_test_routes_to_node_tests() {
+		let config = MinimizerConfig::default();
+		let context = ctx("npm", Some("test"), "npm test", &config);
+		let out = filter(&context, "✓ ok\nFAIL app.test.ts\nTests 1 failed\n", 1).text;
+		assert!(!out.contains("✓ ok"));
+		assert!(out.contains("FAIL app.test.ts"));
+	}
+
+	#[test]
+	fn npm_run_test_routes_to_node_tests() {
+		let config = MinimizerConfig::default();
+		let context = ctx("npm", Some("run"), "npm run test", &config);
+		let out = filter(&context, "✓ ok\nFAIL app.test.ts\nTests 1 failed\n", 1).text;
+		assert!(!out.contains("✓ ok"));
+		assert!(out.contains("FAIL app.test.ts"));
+	}
+
+	#[test]
+	fn npm_run_quoted_test_routes_to_node_tests() {
+		let config = MinimizerConfig::default();
+		let context = ctx("npm", Some("run"), "npm run \"test\"", &config);
+		let out = filter(&context, "✓ ok\nFAIL app.test.ts\nTests 1 failed\n", 1).text;
+		assert!(!out.contains("✓ ok"));
+		assert!(out.contains("FAIL app.test.ts"));
+	}
+
+	#[test]
+	fn pnpm_test_routes_to_node_tests() {
+		let config = MinimizerConfig::default();
+		let context = ctx("pnpm", Some("test"), "pnpm test", &config);
+		let out = filter(&context, "✓ ok\nFAIL app.test.ts\nTests 1 failed\n", 1).text;
+		assert!(!out.contains("✓ ok"));
+		assert!(out.contains("FAIL app.test.ts"));
+	}
+
+	#[test]
+	fn pnpm_run_test_routes_to_node_tests() {
+		let config = MinimizerConfig::default();
+		let context = ctx("pnpm", Some("run"), "pnpm run test", &config);
+		let out = filter(&context, "✓ ok\nFAIL app.test.ts\nTests 1 failed\n", 1).text;
+		assert!(!out.contains("✓ ok"));
+		assert!(out.contains("FAIL app.test.ts"));
+	}
+
+	#[test]
+	fn yarn_test_routes_to_node_tests() {
+		let config = MinimizerConfig::default();
+		let context = ctx("yarn", Some("test"), "yarn test", &config);
+		let out = filter(&context, "✓ ok\nFAIL app.test.ts\nTests 1 failed\n", 1).text;
+		assert!(!out.contains("✓ ok"));
+		assert!(out.contains("FAIL app.test.ts"));
+	}
+
+	#[test]
+	fn yarn_run_test_routes_to_node_tests() {
+		let config = MinimizerConfig::default();
+		let context = ctx("yarn", Some("run"), "yarn run test", &config);
+		let out = filter(&context, "✓ ok\nFAIL app.test.ts\nTests 1 failed\n", 1).text;
+		assert!(!out.contains("✓ ok"));
+		assert!(out.contains("FAIL app.test.ts"));
+	}
+
+	#[test]
+	fn npm_run_build_still_uses_pkg_filter() {
+		let config = MinimizerConfig::default();
+		let context = ctx("npm", Some("run"), "npm run build", &config);
+		let out = filter(&context, "Resolving dependencies\nDownloaded foo\nerror: failed\n", 1).text;
+		assert!(!out.contains("Resolving dependencies"));
+		assert!(out.contains("error: failed"));
+	}
+
+	#[test]
+	fn package_manager_lint_scripts_route_to_lint_filter() {
+		let config = MinimizerConfig::default();
+		let input = concat!(
+			"src/app.ts:1:1: error TS2322: Type 'string' is not assignable to type 'number'.\n",
+			"src/app.ts:2:1: error TS7006: Parameter 'x' implicitly has an 'any' type.\n",
+		);
+
+		for (program, command) in [
+			("npm", "npm run lint"),
+			("npm", "npm run typecheck"),
+			("pnpm", "pnpm run lint:ci"),
+			("yarn", "yarn run typecheck:ci"),
+		] {
+			let context = ctx(program, Some("run"), command, &config);
+			let routed = filter(&context, input, 1).text;
+			let expected = lint::filter(&context, input, 1).text;
+			assert_eq!(routed, expected, "{command} should use lint filter");
+			assert!(
+				routed.contains("2 diagnostics in 1 files"),
+				"{command} should condense lint output"
+			);
+		}
+	}
+
+	#[test]
+	fn npm_t_routes_to_node_tests() {
+		let config = MinimizerConfig::default();
+		let context = ctx("npm", Some("t"), "npm t", &config);
+		let out = filter(&context, "✓ ok\nFAIL app.test.ts\nTests 1 failed\n", 1).text;
+		assert!(!out.contains("✓ ok"));
+		assert!(out.contains("FAIL app.test.ts"));
+	}
+
+	#[test]
 	fn pi_cli_names_are_not_supported() {
 		assert!(!supports("rtk", None));
 		assert!(!supports("pi", None));
+	}
+
+	// ---------------------------------------------------------------
+	// Tier 2a: uv dispatch coverage tests (m4)
+	// ---------------------------------------------------------------
+
+	const PYTEST_FAILURE_INPUT: &str = "============================= test session starts \
+	                                    ==============================\ncollected 2 \
+	                                    items\n\nFAILED tests/test_x.py::test_fail - \
+	                                    AssertionError\n========================= 1 failed, 1 \
+	                                    passed in 0.05s =========================\n";
+
+	#[test]
+	fn uv_pytest_routes_to_python_filter() {
+		// B1 fix: `uv pytest <args>` now routes to the python filter.
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("pytest"), "uv pytest tests/", &config);
+		assert!(supports("uv", Some("pytest")));
+		let out = filter(&context, PYTEST_FAILURE_INPUT, 1).text;
+		assert!(out.contains("FAILED tests/test_x.py::test_fail"));
+		assert!(out.contains("pytest: 1 failed, 1 passed"));
+	}
+
+	#[test]
+	fn uv_dash_m_pytest_routes_to_python_filter() {
+		// B1 fix: `uv -m pytest <args>` now routes via -m token scan.
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("-m"), "uv -m pytest tests/", &config);
+		assert!(supports("uv", Some("-m")));
+		let out = filter(&context, PYTEST_FAILURE_INPUT, 1).text;
+		assert!(out.contains("FAILED tests/test_x.py::test_fail"));
+		assert!(out.contains("pytest: 1 failed, 1 passed"));
+	}
+
+	#[test]
+	fn uv_ruff_routes_to_python_filter() {
+		// B1 fix: `uv ruff <args>` now routes to the python filter.
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("ruff"), "uv ruff check .", &config);
+		assert!(supports("uv", Some("ruff")));
+		let out =
+			filter(&context, "src/a.py:1:1: F401 imported but unused\nFound 1 error.\n", 1).text;
+		assert!(out.contains("F401"));
+	}
+
+	#[test]
+	fn uv_mypy_routes_to_python_filter() {
+		// B1 fix: `uv mypy <args>` now routes to the python filter.
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("mypy"), "uv mypy src/", &config);
+		assert!(supports("uv", Some("mypy")));
+		// mypy filter routes through lint::condense_lint_output; smoke-check
+		// it does not crash and produces a string output.
+		let _ = filter(&context, "src/a.py:1: error: foo\n", 1).text;
+	}
+
+	#[test]
+	fn uv_run_pytest_still_routes_regression_guard() {
+		// Regression guard for the pre-existing `uv run pytest` path.
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("run"), "uv run pytest tests/", &config);
+		let out = filter(&context, PYTEST_FAILURE_INPUT, 1).text;
+		assert!(out.contains("FAILED tests/test_x.py::test_fail"));
+		assert!(out.contains("pytest: 1 failed, 1 passed"));
+	}
+
+	#[test]
+	fn uv_run_python_dash_m_pytest_still_routes() {
+		// Regression guard: `uv run python -m pytest` was supported pre-PR.
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("run"), "uv run python -m pytest tests/", &config);
+		let out = filter(&context, PYTEST_FAILURE_INPUT, 1).text;
+		assert!(out.contains("FAILED tests/test_x.py::test_fail"));
+		assert!(out.contains("pytest: 1 failed, 1 passed"));
+	}
+
+	#[test]
+	fn uv_run_python_script_with_pytest_argument_stays_opaque() {
+		let config = MinimizerConfig::default();
+		let context = ctx("uv", Some("run"), "uv run python scripts/report.py -m pytest", &config);
+		let out = filter(&context, PYTEST_FAILURE_INPUT, 1);
+		assert_eq!(out.text, PYTEST_FAILURE_INPUT);
+		assert!(!out.changed);
+	}
+
+	#[test]
+	fn normalize_uv_form_unit_pytest_subcommand() {
+		assert_eq!(super::normalize_uv_form(Some("pytest"), "uv pytest"), Some("pytest"));
+	}
+
+	#[test]
+	fn normalize_uv_form_unit_dash_m_pytest() {
+		assert_eq!(super::normalize_uv_form(Some("-m"), "uv -m pytest tests/"), Some("pytest"));
+	}
+
+	#[test]
+	fn normalize_uv_form_unit_run_returns_none() {
+		// `uv run` is handled by the pre-existing path; normalize returns None.
+		assert_eq!(super::normalize_uv_form(Some("run"), "uv run pytest"), None);
+	}
+
+	#[test]
+	fn normalize_uv_form_unit_unknown_returns_none() {
+		assert_eq!(super::normalize_uv_form(Some("unknown"), "uv unknown"), None);
+		assert_eq!(super::normalize_uv_form(None, "uv"), None);
+	}
+
+	#[test]
+	fn pytest_legacy_filters_active_passes_through() {
+		// Kill-switch parity (M2): legacy_filters_active=true skips the
+		// pytest state machine even when invoked via `uv pytest`.
+		let mut config = MinimizerConfig::default();
+		config.enabled = true;
+		config.legacy_filters_active = true;
+		let context = ctx("uv", Some("pytest"), "uv pytest tests/", &config);
+		let out = filter(&context, PYTEST_FAILURE_INPUT, 1);
+		assert_eq!(out.text, PYTEST_FAILURE_INPUT);
+		assert!(!out.changed);
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/node_tests.rs
+++ b/crates/pi-shell/src/minimizer/filters/node_tests.rs
@@ -65,7 +65,7 @@ fn failures_only(input: &str) -> String {
 		}
 
 		if keeping_block {
-			if is_pass_noise(trimmed) && !is_error_context_line(trimmed) {
+			if is_pass_noise(trimmed) {
 				keeping_block = false;
 				trailing_context = 0;
 				continue;
@@ -112,6 +112,7 @@ fn is_summary_line(trimmed: &str) -> bool {
 		|| trimmed.starts_with("% ")
 		|| trimmed.starts_with("Failed Tests")
 		|| trimmed.starts_with("Playwright Test Report")
+		|| (trimmed.starts_with("Ran ") && trimmed.contains("tests across"))
 		|| starts_count_summary(trimmed)
 }
 
@@ -123,7 +124,7 @@ fn starts_count_summary(trimmed: &str) -> bool {
 	if !count.chars().all(|ch| ch.is_ascii_digit()) {
 		return false;
 	}
-	matches!(parts.next(), Some("failed" | "passed" | "skipped" | "flaky"))
+	matches!(parts.next(), Some("failed" | "passed" | "skipped" | "flaky" | "pass" | "fail"))
 }
 
 fn is_pass_noise(trimmed: &str) -> bool {
@@ -134,6 +135,13 @@ fn is_pass_noise(trimmed: &str) -> bool {
 		|| trimmed.starts_with("○")
 		|| trimmed.starts_with(" RUN ")
 		|| trimmed.starts_with("DEV ")
+		|| trimmed.starts_with("bun test ")
+		|| trimmed.ends_with(".test.ts:")
+		|| trimmed.ends_with(".test.js:")
+		|| trimmed.ends_with(".test.tsx:")
+		|| trimmed.ends_with(".test.jsx:")
+		|| trimmed.ends_with(".spec.ts:")
+		|| trimmed.ends_with(".spec.js:")
 }
 
 fn starts_failure_block(trimmed: &str) -> bool {
@@ -160,6 +168,7 @@ fn is_error_context_line(trimmed: &str) -> bool {
 		|| trimmed.starts_with("Expected")
 		|| trimmed.starts_with("Received")
 		|| trimmed.starts_with("Error:")
+		|| trimmed.starts_with("error:")
 		|| trimmed.starts_with("AssertionError")
 		|| trimmed.starts_with("TimeoutError")
 		|| trimmed.contains(" › ")
@@ -234,5 +243,103 @@ mod tests {
 	fn success_keeps_summary_when_everything_else_is_pass_noise() {
 		let filtered = drop_passed_lines("✓ one passed\n✓ two passed\n3 passed (1.2s)\n");
 		assert_eq!(filtered, "3 passed (1.2s)\n");
+	}
+	#[test]
+	fn bun_pass_only_collapses_to_counts() {
+		let input = "\
+✓ a.test.ts > add works [0.50ms]
+✓ a.test.ts > subtract works [0.30ms]
+✓ b.test.ts > multiply works [0.40ms]
+✓ b.test.ts > divide works [0.60ms]
+✓ c.test.ts > negate works [0.20ms]
+
+ 5 pass
+ 0 fail
+ 7 expect() calls
+Ran 5 tests across 3 files. [102.00ms]
+";
+		let filtered = drop_passed_lines(input);
+
+		assert!(!filtered.contains("add works"));
+		assert!(!filtered.contains("subtract works"));
+		assert!(!filtered.contains("multiply works"));
+		assert!(filtered.contains("5 pass"));
+		assert!(filtered.contains("0 fail"));
+		assert!(filtered.contains("7 expect() calls"));
+		assert!(filtered.contains("Ran 5 tests across 3 files"));
+	}
+
+	#[test]
+	fn bun_failure_keeps_error_and_counts() {
+		let input = "\
+✗ a.test.ts > bad test [0.40ms]
+error: expect(received).toBe(expected)
+Expected: 2
+Received: 3
+      at a.test.ts:5:7
+
+✓ b.test.ts > another good [0.60ms]
+
+ 2 pass
+ 1 fail
+Ran 3 tests across 2 files. [150.00ms]
+";
+		let filtered = failures_only(input);
+
+		assert!(!filtered.contains("another good"));
+		assert!(filtered.contains("✗ a.test.ts > bad test"));
+		assert!(filtered.contains("error: expect(received).toBe(expected)"));
+		assert!(filtered.contains("Expected: 2"));
+		assert!(filtered.contains("Received: 3"));
+		assert!(filtered.contains("at a.test.ts:5:7"));
+		assert!(filtered.contains("2 pass"));
+		assert!(filtered.contains("1 fail"));
+	}
+
+	#[test]
+	fn vitest_many_passes_collapses_to_summary() {
+		let input = "\
+ ✓ src/a.test.ts > suite > test1 (2ms)
+ ✓ src/a.test.ts > suite > test2 (1ms)
+ ✓ src/a.test.ts > other > test3 (3ms)
+ ✓ src/b.test.ts > feature > test4 (1ms)
+ ✓ src/b.test.ts > feature > test5 (2ms)
+ ✓ src/b.test.ts > edge > test6 (5ms)
+
+ Test Files  2 passed (2)
+      Tests  6 passed (6)
+   Start at  12:00:00
+   Duration  1.23s
+";
+		let filtered = drop_passed_lines(input);
+
+		assert!(!filtered.contains("test1"));
+		assert!(!filtered.contains("test6"));
+		assert!(filtered.contains("Test Files  2 passed (2)"));
+		assert!(filtered.contains("Tests  6 passed (6)"));
+		assert!(filtered.contains("Duration  1.23s"));
+	}
+
+	#[test]
+	fn jest_many_passes_collapses_to_summary() {
+		let input = "\
+ PASS  src/a.test.ts
+ PASS  src/b.test.ts
+ PASS  src/c.test.ts
+ PASS  src/d.test.ts
+ PASS  src/e.test.ts
+
+Test Suites: 5 passed, 5 total
+Tests:       32 passed, 32 total
+Snapshots:   0 total
+Time:        2.345s
+";
+		let filtered = drop_passed_lines(input);
+
+		assert!(!filtered.contains("src/a.test.ts"));
+		assert!(!filtered.contains("src/e.test.ts"));
+		assert!(filtered.contains("Test Suites: 5 passed, 5 total"));
+		assert!(filtered.contains("Tests:       32 passed, 32 total"));
+		assert!(filtered.contains("Time:        2.345s"));
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/pkg.rs
+++ b/crates/pi-shell/src/minimizer/filters/pkg.rs
@@ -1,6 +1,9 @@
 //! Package manager output filters.
 
+use std::{collections::HashSet, fmt::Write as _};
+
 use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
+const PACKAGE_TREE_HEAD_LINES: usize = 80;
 
 pub fn supports(subcommand: Option<&str>) -> bool {
 	matches!(
@@ -13,6 +16,7 @@ pub fn supports(subcommand: Option<&str>) -> bool {
 				| "remove"
 				| "rm" | "uninstall"
 				| "list" | "ls"
+				| "tree" | "pip"
 				| "outdated"
 				| "sync" | "lock"
 				| "run" | "exec"
@@ -30,19 +34,42 @@ pub fn supports(subcommand: Option<&str>) -> bool {
 				| "dedupe"
 				| "publish"
 				| "pack" | "link"
-				| "why"
+				| "why" | "export"
 		)
 	)
 }
 
 pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerOutput {
+	if exit_code == 0
+		&& (command_contains_any(ctx.command, &["--json"])
+			|| ctx.program == "uv"
+				&& matches!(ctx.subcommand, Some("pip"))
+				&& command_contains_any(ctx.command, &["freeze"]))
+	{
+		return MinimizerOutput::passthrough(input);
+	}
+
 	let cleaned = primitives::strip_ansi(input);
-	let stripped = strip_package_noise(ctx.program, &cleaned, exit_code);
-	let deduped = primitives::dedup_consecutive_lines(&stripped);
-	let text = if contains_audit_or_security_summary(&deduped) {
-		deduped
+	let text = if exit_code == 0 && is_package_lock_command(ctx) {
+		compact_package_lock_output(ctx, &cleaned)
 	} else {
-		primitives::head_tail_lines(&deduped, 120, 80)
+		let stripped = strip_package_noise(ctx, &cleaned, exit_code);
+		let deduped = primitives::dedup_consecutive_lines(&stripped);
+		if contains_audit_or_security_summary(&deduped) {
+			deduped
+		} else if exit_code == 0
+			&& (is_package_tree_command(ctx) || is_package_export_command(ctx))
+			&& !command_contains_any(ctx.command, &["--json"])
+		{
+			compact_package_tree_output(&deduped)
+		} else {
+			let cap = if exit_code == 0 {
+				primitives::CapClass::Inventory
+			} else {
+				primitives::CapClass::Errors
+			};
+			primitives::head_tail_cap(&deduped, cap)
+		}
 	};
 
 	if text == input {
@@ -52,7 +79,7 @@ pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerO
 	}
 }
 
-fn strip_package_noise(program: &str, input: &str, exit_code: i32) -> String {
+fn strip_package_noise(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> String {
 	let mut out = String::new();
 	let mut previous_blank = false;
 	for line in input.lines() {
@@ -66,7 +93,7 @@ fn strip_package_noise(program: &str, input: &str, exit_code: i32) -> String {
 		}
 		previous_blank = false;
 
-		if is_noise_line(program, trimmed, exit_code) {
+		if is_noise_line(ctx, trimmed, exit_code) {
 			continue;
 		}
 		out.push_str(line.trim_end());
@@ -75,19 +102,248 @@ fn strip_package_noise(program: &str, input: &str, exit_code: i32) -> String {
 	out
 }
 
-fn is_noise_line(program: &str, line: &str, exit_code: i32) -> bool {
-	if is_audit_or_security_summary(line) {
+fn is_package_tree_command(ctx: &MinimizerCtx<'_>) -> bool {
+	match ctx.program {
+		"npm" | "pnpm" | "yarn" => {
+			matches!(ctx.subcommand, Some("list" | "ls" | "tree" | "why" | "explain"))
+		},
+		"bun" => {
+			matches!(ctx.subcommand, Some("list" | "ls" | "tree" | "why" | "explain"))
+				|| matches!(ctx.subcommand, Some("pm"))
+					&& command_contains_any(ctx.command, &["list", "ls", "tree", "why"])
+		},
+		"uv" => {
+			matches!(ctx.subcommand, Some("list" | "ls" | "tree"))
+				|| matches!(ctx.subcommand, Some("pip"))
+					&& command_contains_any(ctx.command, &["list", "ls", "tree"])
+		},
+		"poetry" => {
+			matches!(ctx.subcommand, Some("tree"))
+				|| matches!(ctx.subcommand, Some("show"))
+					&& command_contains_any(ctx.command, &["--tree"])
+		},
+		_ => false,
+	}
+}
+
+fn is_package_export_command(ctx: &MinimizerCtx<'_>) -> bool {
+	match ctx.program {
+		"uv" | "poetry" => ctx.subcommand == Some("export"),
+		_ => false,
+	}
+}
+
+fn is_package_lock_command(ctx: &MinimizerCtx<'_>) -> bool {
+	matches!((ctx.program, ctx.subcommand), ("uv" | "poetry", Some("lock")))
+}
+
+fn command_contains_any(command: &str, words: &[&str]) -> bool {
+	command.split_whitespace().any(|part| words.contains(&part))
+}
+
+fn compact_package_tree_output(input: &str) -> String {
+	if let Some(summary) = compact_package_tree_json_output(input) {
+		return summary;
+	}
+	if let Some(summary) = compact_package_tree_ndjson_output(input) {
+		return summary;
+	}
+	let lines: Vec<&str> = input
+		.lines()
+		.map(str::trim_end)
+		.filter(|line| !line.trim().is_empty())
+		.collect();
+	if lines.len() <= PACKAGE_TREE_HEAD_LINES {
+		return input.to_string();
+	}
+
+	let mut out = format!("package tree/list: {} entries\n", lines.len());
+	for line in lines.iter().take(PACKAGE_TREE_HEAD_LINES) {
+		out.push_str(line);
+		out.push('\n');
+	}
+	let _ = writeln!(out, "… {} package entries omitted …", lines.len() - PACKAGE_TREE_HEAD_LINES);
+	out
+}
+
+fn compact_package_tree_json_output(input: &str) -> Option<String> {
+	let value: serde_json::Value = serde_json::from_str(input).ok()?;
+	let mut rows = Vec::new();
+	let mut seen = HashSet::new();
+	collect_package_tree_json_rows(&value, &mut rows, &mut seen);
+	summarize_package_rows(rows)
+}
+
+fn compact_package_tree_ndjson_output(input: &str) -> Option<String> {
+	let mut rows = Vec::new();
+	let mut seen = HashSet::new();
+	for line in input.lines().map(str::trim).filter(|line| !line.is_empty()) {
+		let value: serde_json::Value = serde_json::from_str(line).ok()?;
+		collect_package_tree_json_rows(&value, &mut rows, &mut seen);
+		if let Some(data) = value.get("data").and_then(serde_json::Value::as_str) {
+			for row in data
+				.lines()
+				.map(str::trim_end)
+				.filter(|row| !row.trim().is_empty())
+			{
+				push_unique_row(&mut rows, &mut seen, row.to_string());
+			}
+		}
+	}
+	summarize_package_rows(rows)
+}
+
+fn summarize_package_rows(rows: Vec<String>) -> Option<String> {
+	if rows.is_empty() {
+		return None;
+	}
+	let mut out = format!("package tree/list: {} entries\n", rows.len());
+	for row in rows.iter().take(PACKAGE_TREE_HEAD_LINES) {
+		out.push_str(row);
+		out.push('\n');
+	}
+	if rows.len() > PACKAGE_TREE_HEAD_LINES {
+		let _ = writeln!(out, "… {} package entries omitted …", rows.len() - PACKAGE_TREE_HEAD_LINES);
+	}
+	Some(out)
+}
+
+fn collect_package_tree_json_rows(
+	value: &serde_json::Value,
+	rows: &mut Vec<String>,
+	seen: &mut HashSet<String>,
+) {
+	match value {
+		serde_json::Value::Object(map) => {
+			if let Some(name) = map.get("name").and_then(serde_json::Value::as_str) {
+				let version = map
+					.get("version")
+					.and_then(serde_json::Value::as_str)
+					.unwrap_or("");
+				push_unique_row(
+					rows,
+					seen,
+					if version.is_empty() {
+						name.to_string()
+					} else {
+						format!("{name} {version}")
+					},
+				);
+			}
+			if let Some(dependencies) = map
+				.get("dependencies")
+				.and_then(serde_json::Value::as_object)
+			{
+				for (name, child) in dependencies {
+					push_json_dependency_row(rows, seen, name, child);
+				}
+			}
+			for value in map.values() {
+				if value.is_array() || value.is_object() {
+					collect_package_tree_json_rows(value, rows, seen);
+				}
+			}
+		},
+		serde_json::Value::Array(items) => {
+			for item in items {
+				collect_package_tree_json_rows(item, rows, seen);
+			}
+		},
+		_ => {},
+	}
+}
+
+fn push_json_dependency_row(
+	rows: &mut Vec<String>,
+	seen: &mut HashSet<String>,
+	name: &str,
+	child: &serde_json::Value,
+) {
+	let version = child
+		.get("version")
+		.and_then(serde_json::Value::as_str)
+		.unwrap_or("");
+	push_unique_row(
+		rows,
+		seen,
+		if version.is_empty() {
+			name.to_string()
+		} else {
+			format!("{name} {version}")
+		},
+	);
+}
+
+fn push_unique_row(rows: &mut Vec<String>, seen: &mut HashSet<String>, row: String) {
+	if seen.insert(row.clone()) {
+		rows.push(row);
+	}
+}
+
+fn is_noise_line(ctx: &MinimizerCtx<'_>, line: &str, exit_code: i32) -> bool {
+	let lower = line.to_ascii_lowercase();
+
+	// Strip: "found 0 vulnerabilities" (non-actionable success noise)
+	if lower.contains("found 0 vulnerabilities") {
+		return true;
+	}
+	// Strip: "audited X packages" timing summaries (non-actionable)
+	if lower.contains("audited") && lower.contains("package") {
+		return true;
+	}
+	// Keep: vulnerability mentions (actionable — real findings)
+	if lower.contains("vulnerab") {
 		return false;
 	}
 	if exit_code != 0 && is_error_or_summary(line) {
 		return false;
 	}
 
-	let lower = line.to_ascii_lowercase();
+	if is_package_lock_command(ctx) && is_lock_summary_line(&lower) {
+		return false;
+	}
 	is_generic_progress(line, &lower)
-		|| is_js_package_noise(program, line, &lower)
-		|| is_python_package_noise(program, line, &lower)
-		|| is_ruby_php_brew_noise(program, line, &lower)
+		|| is_js_package_noise(ctx.program, line, &lower)
+		|| is_python_package_noise(ctx.program, line, &lower)
+		|| is_ruby_php_brew_noise(ctx.program, line, &lower)
+}
+
+fn compact_package_lock_output(ctx: &MinimizerCtx<'_>, input: &str) -> String {
+	let mut out = String::new();
+	for line in input.lines() {
+		let trimmed = line.trim();
+		if trimmed.is_empty() {
+			continue;
+		}
+		let lower = trimmed.to_ascii_lowercase();
+		if is_lock_summary_line(&lower) {
+			out.push_str(trimmed);
+			out.push('\n');
+			continue;
+		}
+		if is_generic_progress(trimmed, &lower)
+			|| is_python_package_noise(ctx.program, trimmed, &lower)
+			|| is_js_package_noise(ctx.program, trimmed, &lower)
+		{
+			continue;
+		}
+		out.push_str(trimmed);
+		out.push('\n');
+	}
+	if out.trim().is_empty() {
+		primitives::head_tail_cap(input, primitives::CapClass::Inventory)
+	} else {
+		primitives::head_tail_cap(&out, primitives::CapClass::Inventory)
+	}
+}
+
+fn is_lock_summary_line(lower: &str) -> bool {
+	lower.starts_with("writing lock file")
+		|| lower.starts_with("updated lockfile")
+		|| lower.starts_with("resolved ")
+		|| lower.starts_with("installing dependencies from lock file")
+		|| lower == "no changes."
+		|| lower.starts_with("no dependencies to install or update")
 }
 
 fn is_generic_progress(line: &str, lower: &str) -> bool {
@@ -110,7 +366,6 @@ fn is_js_package_noise(program: &str, line: &str, lower: &str) -> bool {
 	}
 	line.starts_with('>') && line.contains('@')
 		|| lower.starts_with("npm notice")
-		|| lower.starts_with("npm warn deprecated")
 		|| lower.starts_with("npm http fetch")
 		|| lower.starts_with("pnpm: progress")
 		|| lower.starts_with("packages:")
@@ -119,6 +374,7 @@ fn is_js_package_noise(program: &str, line: &str, lower: &str) -> bool {
 		|| lower.starts_with("added ") && lower.contains("packages")
 		|| lower.starts_with("done in ")
 		|| lower.contains("already up-to-date")
+		|| lower.contains("up to date")
 }
 
 fn is_python_package_noise(program: &str, _line: &str, lower: &str) -> bool {
@@ -133,6 +389,17 @@ fn is_python_package_noise(program: &str, _line: &str, lower: &str) -> bool {
 		|| lower.starts_with("resolving dependencies")
 		|| lower.starts_with("writing lock file")
 		|| lower.starts_with("package operations:")
+		|| program == "uv" && is_uv_progress_noise(lower)
+}
+
+fn is_uv_progress_noise(lower: &str) -> bool {
+	lower.starts_with("resolved ")
+		|| lower.starts_with("prepared ")
+		|| lower.starts_with("installed ")
+		|| lower.starts_with("uninstalled ")
+		|| lower.starts_with("updated ")
+		|| lower.starts_with("built ")
+		|| lower.starts_with("downloaded ")
 }
 
 fn is_ruby_php_brew_noise(program: &str, _line: &str, lower: &str) -> bool {
@@ -177,12 +444,15 @@ fn is_error_or_summary(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::minimizer::MinimizerConfig;
 
 	#[test]
 	fn strips_progress_but_keeps_package_errors() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("npm", Some("install"), "npm install", &cfg);
 		let input = "Resolving: total 10\nDownloading: left-pad\nERROR failed to install \
 		             left-pad\nfound 1 vulnerability\n";
-		let out = strip_package_noise("npm", input, 1);
+		let out = strip_package_noise(&ctx, input, 1);
 		assert!(!out.contains("Resolving:"));
 		assert!(!out.contains("Downloading:"));
 		assert!(out.contains("ERROR failed"));
@@ -190,22 +460,34 @@ mod tests {
 	}
 
 	#[test]
-	fn preserves_successful_install_audit_and_security_summaries() {
+	fn strips_success_noise_audited_and_zero_vulnerabilities() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("npm", Some("install"), "npm install", &cfg);
 		let input = "Resolving: total 10\nadded 3 packages, and audited 4 packages in 1s\n2 \
 		             packages are looking for funding\nfound 0 vulnerabilities\n";
-		let out = strip_package_noise("npm", input, 0);
+		let out = strip_package_noise(&ctx, input, 0);
 		assert!(!out.contains("Resolving:"));
-		assert!(out.contains("added 3 packages, and audited 4 packages in 1s"));
-		assert!(out.contains("2 packages are looking for funding"));
-		assert!(out.contains("found 0 vulnerabilities"));
+		assert!(!out.contains("audited 4 packages"));
+		assert!(!out.contains("found 0 vulnerabilities"));
+	}
+
+	#[test]
+	fn preserves_deprecation_warnings() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("npm", Some("install"), "npm install", &cfg);
+		let input = "npm warn deprecated left-pad@1.0.0: Please upgrade to left-pad@2.0.0\nnpm warn \
+		             deprecated old-lib@2.0.0: Use new-lib instead\n";
+		let out = strip_package_noise(&ctx, input, 0);
+		assert!(out.contains("npm warn deprecated left-pad@1.0.0: Please upgrade to left-pad@2.0.0"));
+		assert!(out.contains("npm warn deprecated old-lib@2.0.0: Use new-lib instead"));
 	}
 
 	#[test]
 	fn supports_common_package_subcommands_for_future_dispatch() {
 		for subcommand in [
-			"ci", "add", "outdated", "sync", "audit", "why", "view", "fund", "explain", "test", "t",
-			"start", "stop", "restart", "config", "cache", "prune", "dedupe", "publish", "pack",
-			"link",
+			"ci", "add", "outdated", "sync", "audit", "why", "tree", "pip", "view", "fund", "explain",
+			"test", "t", "start", "stop", "restart", "config", "cache", "prune", "dedupe", "publish",
+			"pack", "link",
 		] {
 			assert!(supports(Some(subcommand)), "{subcommand} should be supported");
 		}
@@ -213,10 +495,234 @@ mod tests {
 
 	#[test]
 	fn bun_install_noise_uses_js_package_rules() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("bun", Some("install"), "bun install", &cfg);
 		let input = "Resolving dependencies\nDownloaded foo\nerror: failed\n";
-		let out = strip_package_noise("bun", input, 1);
+		let out = strip_package_noise(&ctx, input, 1);
 		assert!(!out.contains("Resolving dependencies"));
 		assert!(!out.contains("Downloaded foo"));
 		assert!(out.contains("error: failed"));
+	}
+
+	fn ctx<'a>(
+		program: &'a str,
+		subcommand: Option<&'a str>,
+		command: &'a str,
+		config: &'a MinimizerConfig,
+	) -> MinimizerCtx<'a> {
+		MinimizerCtx { program, subcommand, command, config }
+	}
+
+	#[test]
+	fn compacts_large_js_package_tree() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("npm", Some("list"), "npm list --all", &cfg);
+		let mut input = String::from("app@1.0.0\n");
+		for idx in 0..90 {
+			input.push_str(&format!("├── dep{idx:03}@1.0.0\n"));
+		}
+
+		let out = filter(&context, &input, 0);
+		assert!(out.text.starts_with("package tree/list: 91 entries\n"));
+		assert!(out.text.contains("├── dep000@1.0.0"));
+		assert!(out.text.contains("├── dep078@1.0.0"));
+		assert!(!out.text.contains("├── dep089@1.0.0"));
+		assert!(out.text.contains("… 11 package entries omitted …"));
+	}
+
+	#[test]
+	fn compacts_depth_limited_package_tree_commands() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("npm", Some("ls"), "npm ls --depth=0", &cfg);
+		let mut input = String::from("app@1.0.0\n");
+		for idx in 0..90 {
+			input.push_str(&format!("├── dep{idx:03}@1.0.0\n"));
+		}
+
+		let out = filter(&context, &input, 0);
+		assert!(out.text.starts_with("package tree/list: 91 entries\n"));
+		assert!(out.text.contains("dep000"));
+		assert!(out.text.contains("… 11 package entries omitted …"));
+	}
+
+	#[test]
+	fn compacts_pnpm_why_style_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("pnpm", Some("why"), "pnpm why react", &cfg);
+		let mut input =
+			String::from("Legend: production dependency, optional only, dev only\nreact 19.0.0\n");
+		for idx in 0..90 {
+			input.push_str(&format!("└─ dependent{idx:03}\n"));
+		}
+
+		let out = filter(&context, &input, 0);
+		assert!(out.text.starts_with("package tree/list: 92 entries\n"));
+		assert!(out.text.contains("react 19.0.0"));
+		assert!(out.text.contains("└─ dependent000"));
+		assert!(out.text.contains("… 12 package entries omitted …"));
+	}
+
+	#[test]
+	fn passes_through_npm_json_dependency_tree() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("npm", Some("ls"), "npm ls --json", &cfg);
+		let input = r#"{"name":"app","version":"1.0.0","dependencies":{"react":{"version":"19.0.0","dependencies":{"scheduler":{"version":"0.25.0"}}},"zod":{"version":"4.0.0"}}}"#;
+		let out = filter(&context, input, 0);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn passes_through_pnpm_why_json_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("pnpm", Some("why"), "pnpm why react --json", &cfg);
+		let input = r#"[{"name":"react","version":"19.0.0","dependents":[{"name":"app","version":"1.0.0"},{"name":"docs","version":"1.0.0"}]}]"#;
+		let out = filter(&context, input, 0);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn passes_through_yarn_why_ndjson_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("yarn", Some("why"), "yarn why react --json", &cfg);
+		let input = "{\"type\":\"info\",\"data\":\"=> Found \
+		             \\\"react@npm:19.0.0\\\"\"}\n{\"type\":\"tree\",\"data\":\"react@npm:19.0.0\\\
+		             n└─ app@workspace:.\"}\n";
+		let out = filter(&context, input, 0);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn passes_through_npm_explain_json_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("npm", Some("explain"), "npm explain react --json", &cfg);
+		let input = r#"{"name":"react","version":"19.0.0","dependents":[{"name":"app","version":"1.0.0","location":"."}]}"#;
+		let out = filter(&context, input, 0);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+
+	#[test]
+	fn compacts_uv_pip_list_and_strips_progress_noise() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("uv", Some("pip"), "uv pip list", &cfg);
+		let mut input = String::from(
+			"Resolved 91 packages in 12ms\nPrepared 2 packages in 3ms\nPackage Version\n",
+		);
+		for idx in 0..90 {
+			input.push_str(&format!("pkg{idx:03} 1.0.{idx}\n"));
+		}
+
+		let out = filter(&context, &input, 0);
+		assert!(!out.text.contains("Resolved 91 packages"));
+		assert!(!out.text.contains("Prepared 2 packages"));
+		assert!(out.text.starts_with("package tree/list: 91 entries\n"));
+		assert!(out.text.contains("Package Version"));
+		assert!(out.text.contains("pkg000 1.0.0"));
+		assert!(out.text.contains("pkg078 1.0.78"));
+		assert!(!out.text.contains("pkg089 1.0.89"));
+		assert!(out.text.contains("… 11 package entries omitted …"));
+	}
+
+	#[test]
+	fn compacts_uv_tree_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("uv", Some("tree"), "uv tree", &cfg);
+		let mut input = String::from("project v1.0.0\n");
+		for idx in 0..90 {
+			input.push_str(&format!("├── pkg{idx:03} v1.0.{idx}\n"));
+		}
+
+		let out = filter(&context, &input, 0);
+		assert!(out.text.starts_with("package tree/list: 91 entries\n"));
+		assert!(out.text.contains("project v1.0.0"));
+		assert!(out.text.contains("pkg000"));
+		assert!(out.text.contains("… 11 package entries omitted …"));
+	}
+
+	#[test]
+	fn compacts_poetry_show_tree_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("poetry", Some("show"), "poetry show --tree", &cfg);
+		let mut input = String::from("requests 2.32.0 Python HTTP for Humans.\n");
+		for idx in 0..90 {
+			input.push_str(&format!("├── dep{idx:03} 1.0.{idx}\n"));
+		}
+
+		let out = filter(&context, &input, 0);
+		assert!(out.text.starts_with("package tree/list: 91 entries\n"));
+		assert!(out.text.contains("requests 2.32.0"));
+		assert!(out.text.contains("… 11 package entries omitted …"));
+	}
+
+	#[test]
+	fn passes_through_uv_pip_freeze_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("uv", Some("pip"), "uv pip freeze", &cfg);
+		let mut input = String::new();
+		for idx in 0..90 {
+			input.push_str(&format!("pkg{idx:03}==1.0.{idx}\n"));
+		}
+
+		let out = filter(&context, &input, 0);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+		assert!(out.text.contains("pkg089==1.0.89"));
+		assert!(!out.text.starts_with("package tree/list:"));
+	}
+
+	#[test]
+	fn compacts_uv_export_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("uv", Some("export"), "uv export -f requirements-txt", &cfg);
+		let mut input = String::from("# generated by uv\n");
+		for idx in 0..90 {
+			input.push_str(&format!("pkg{idx:03}==1.0.{idx}\n"));
+		}
+
+		let out = filter(&context, &input, 0);
+		assert!(out.text.starts_with("package tree/list: 91 entries\n"));
+		assert!(out.text.contains("pkg000==1.0.0"));
+		assert!(out.text.contains("… 11 package entries omitted …"));
+	}
+
+	#[test]
+	fn compacts_poetry_export_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("poetry", Some("export"), "poetry export -f requirements.txt", &cfg);
+		let mut input = String::from("# generated by poetry\n");
+		for idx in 0..90 {
+			input.push_str(&format!("dep{idx:03}==2.0.{idx}\n"));
+		}
+
+		let out = filter(&context, &input, 0);
+		assert!(out.text.starts_with("package tree/list: 91 entries\n"));
+		assert!(out.text.contains("dep000==2.0.0"));
+		assert!(out.text.contains("… 11 package entries omitted …"));
+	}
+
+	#[test]
+	fn compacts_uv_lock_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("uv", Some("lock"), "uv lock", &cfg);
+		let input =
+			"Resolved 42 packages in 7ms\nDownloading requests\nUpdated lockfile at uv.lock\n";
+		let out = filter(&context, input, 0);
+		assert!(out.text.contains("Resolved 42 packages in 7ms"));
+		assert!(out.text.contains("Updated lockfile at uv.lock"));
+		assert!(!out.text.contains("Downloading requests"));
+	}
+
+	#[test]
+	fn compacts_poetry_lock_output() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("poetry", Some("lock"), "poetry lock", &cfg);
+		let input =
+			"Resolving dependencies...\nInstalling dependencies from lock file\nWriting lock file\n";
+		let out = filter(&context, input, 0);
+		assert!(out.text.contains("Installing dependencies from lock file"));
+		assert!(out.text.contains("Writing lock file"));
 	}
 }

--- a/crates/pi-shell/src/minimizer/filters/python.rs
+++ b/crates/pi-shell/src/minimizer/filters/python.rs
@@ -1,4 +1,17 @@
 //! Python test, type-check, and lint output filters.
+//!
+//! Ported from rtk-ai/rtk@878af7de99e0ba71da2e8fd996f6b52a1836e06c
+//! Path: `src/cmds/python/pytest_cmd.rs`
+//! License: MIT (compatible with workspace MIT). See `ATTRIBUTION-RTK.md` at
+//! the `pi-shell` crate root.
+//!
+//! The pytest state machine (`filter_pytest`, `pytest_success`,
+//! `is_pytest_*`, `looks_like_pytest_summary_part`) adapts the
+//! `build_pytest_summary` algorithm from RTK at the pinned SHA above:
+//! preserve failures, errors, and the final summary line; strip header
+//! framing, progress dots, and verbose PASSED rows. Unknown-state lines
+//! fall through unchanged (RTK's defensive default), so xdist `[gwN]`
+//! prefixes and custom reporters never cause data loss.
 
 use super::lint;
 use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
@@ -12,6 +25,12 @@ pub fn supports(program: &str, subcommand: Option<&str>) -> bool {
 }
 
 pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerOutput {
+	// Kill-switch parity (M2): when `legacy_filters_active`, fall back to
+	// the pre-PR passthrough so callers can rollback an RTK-port regression
+	// without recompile.
+	if ctx.config.legacy_filters_active() {
+		return MinimizerOutput::passthrough(input);
+	}
 	let tool = python_tool(ctx.program, ctx.subcommand);
 	let cleaned = primitives::strip_ansi(input);
 	let text = match tool {
@@ -50,9 +69,14 @@ fn filter_pytest(input: &str, exit_code: i32) -> String {
 
 	for line in input.lines() {
 		let trimmed = line.trim();
-		if is_pytest_summary_header(trimmed) || is_pytest_summary_line(trimmed) {
+		if is_pytest_summary_header(trimmed) {
 			in_failure = false;
 			push_line(&mut out, line);
+			continue;
+		}
+		if is_pytest_summary_line(trimmed) {
+			in_failure = false;
+			push_pytest_summary_line(&mut out, trimmed);
 			continue;
 		}
 
@@ -91,9 +115,14 @@ fn pytest_success(input: &str) -> String {
 
 	for line in input.lines() {
 		let trimmed = line.trim();
-		if is_pytest_summary_line(trimmed) || is_pytest_summary_header(trimmed) {
+		if is_pytest_summary_header(trimmed) {
 			push_line(&mut summary, line);
 			push_line(&mut out, line);
+			continue;
+		}
+		if is_pytest_summary_line(trimmed) {
+			push_pytest_summary_line(&mut summary, trimmed);
+			push_pytest_summary_line(&mut out, trimmed);
 			continue;
 		}
 		if is_pytest_pass_noise(trimmed) {
@@ -162,6 +191,14 @@ fn looks_like_pytest_summary_part(part: &str) -> bool {
 	false
 }
 
+fn compact_pytest_summary_line(trimmed: &str) -> &str {
+	if trimmed.starts_with('=') {
+		trimmed.trim_matches('=').trim()
+	} else {
+		trimmed
+	}
+}
+
 fn is_pytest_section_delimiter(trimmed: &str) -> bool {
 	trimmed.len() >= 6
 		&& trimmed
@@ -180,6 +217,7 @@ fn is_pytest_pass_noise(trimmed: &str) -> bool {
 		|| trimmed.starts_with("platform ")
 		|| trimmed.starts_with("cachedir:")
 		|| is_pytest_verbose_pass_line(trimmed)
+		|| is_pytest_progress_line(trimmed)
 		|| trimmed
 			.chars()
 			.all(|ch| matches!(ch, '.' | 's' | 'S' | 'x' | 'X' | 'f' | 'F' | 'E'))
@@ -191,6 +229,19 @@ fn is_pytest_verbose_pass_line(trimmed: &str) -> bool {
 	}
 	let mut parts = trimmed.split_whitespace();
 	parts.any(|part| matches!(part, "PASSED" | "SKIPPED" | "XPASS" | "XFAIL"))
+}
+
+fn is_pytest_progress_line(trimmed: &str) -> bool {
+	let Some((path, statuses)) = trimmed.split_once(char::is_whitespace) else {
+		return false;
+	};
+	std::path::Path::new(path)
+		.extension()
+		.is_some_and(|ext| ext.eq_ignore_ascii_case("py"))
+		&& statuses
+			.trim()
+			.chars()
+			.all(|ch| matches!(ch, '.' | 's' | 'S' | 'x' | 'X' | 'f' | 'F' | 'E'))
 }
 
 fn is_ruff_format(ctx: &MinimizerCtx<'_>) -> bool {
@@ -236,6 +287,12 @@ fn push_line(out: &mut String, line: &str) {
 	out.push('\n');
 }
 
+fn push_pytest_summary_line(out: &mut String, trimmed: &str) {
+	out.push_str("pytest: ");
+	out.push_str(compact_pytest_summary_line(trimmed));
+	out.push('\n');
+}
+
 fn has_content(text: &str) -> bool {
 	text.lines().any(|line| !line.trim().is_empty())
 }
@@ -269,7 +326,7 @@ mod tests {
 		assert!(!out.contains("test session starts"));
 		assert!(out.contains("test_adds_badly"));
 		assert!(out.contains("AssertionError"));
-		assert!(out.contains("1 failed, 1 passed"));
+		assert!(out.contains("pytest: 1 failed, 1 passed"));
 	}
 
 	#[test]
@@ -298,7 +355,7 @@ mod tests {
 		let out = filter_pytest(input, 1);
 
 		assert!(!out.contains("................................................................"));
-		assert!(out.contains("5 failed, 1698 passed, 2 skipped in 108.89s"));
+		assert!(out.contains("pytest: 5 failed, 1698 passed, 2 skipped in 108.89s"));
 	}
 
 	#[test]
@@ -309,7 +366,26 @@ mod tests {
 		             PASSED    [  3%]\ntest_utils.py::TestListOps::test_flatten PASSED      \
 		             [100%]\n\n====== 33 passed in 0.05s ======\n";
 		let out = filter_pytest(input, 0);
-		assert_eq!(out, "====== 33 passed in 0.05s ======\n");
+		assert_eq!(out, "pytest: 33 passed in 0.05s\n");
+	}
+
+	#[test]
+	fn direct_pytest_success_routes_to_compact_summary() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = MinimizerCtx {
+			program:    "pytest",
+			subcommand: None,
+			command:    "pytest",
+			config:     &cfg,
+		};
+		let out = filter(
+			&context,
+			"===== test session starts =====\ncollected 2 items\n\ntests/test_a.py ..\n===== 2 \
+			 passed in 0.01s =====\n",
+			0,
+		);
+
+		assert_eq!(out.text, "pytest: 2 passed in 0.01s\n");
 	}
 
 	#[test]

--- a/crates/pi-shell/src/minimizer/filters/rust_tools.rs
+++ b/crates/pi-shell/src/minimizer/filters/rust_tools.rs
@@ -1,0 +1,170 @@
+//! Rust toolchain filters that are not `cargo` subcommands (Tier 3a).
+//!
+//! Today this module hosts the `rustfmt` filter — real-data evidence (~6
+//! invocations / 7d, 38 KB average, ~0.23 MB total) showed rustfmt landing
+//! in the minimizer's `unknown` bucket. The filter groups diff-style
+//! output by file and elides per-file unified-diff chunks for `--check`
+//! mode while letting silent runs (no diffs / formatter no-op) pass
+//! through unchanged.
+
+use std::fmt::Write;
+
+use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
+
+pub fn supports(program: &str, _subcommand: Option<&str>) -> bool {
+	matches!(program, "rustfmt")
+}
+
+pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerOutput {
+	// Kill-switch parity (M2): legacy_filters_active=true skips this
+	// filter so callers can rollback without recompile.
+	if ctx.config.legacy_filters_active() {
+		return MinimizerOutput::passthrough(input);
+	}
+
+	let cleaned = primitives::strip_ansi(input);
+	let text = match ctx.program {
+		"rustfmt" => condense_rustfmt(&cleaned, exit_code),
+		_ => cleaned,
+	};
+
+	if text == input {
+		MinimizerOutput::passthrough(input)
+	} else {
+		MinimizerOutput::transformed(text, input.len())
+	}
+}
+
+/// Condense `rustfmt`/`rustfmt --check` output.
+///
+/// Two main shapes are handled:
+///
+/// - **Check mode** emits `Diff in <path> at line <N>:` headers followed by
+///   per-hunk `+`/`-` lines. We collect the set of affected files, print a
+///   one-line header (`N files reformatted (M with diffs):`), the first 3 file
+///   paths, and elide every diff body — the agent rarely needs the full diff
+///   inline; the artifact reference carries the original.
+/// - **Silent runs** (rustfmt formatted in place, no `--check`) emit no stdout.
+///   The empty buffer passes through; no transformation.
+///
+/// On compile errors / panics rustfmt prints to stderr in tens-of-lines
+/// form, well under the head/tail cap below — we keep it as-is.
+fn condense_rustfmt(input: &str, exit_code: i32) -> String {
+	if input.trim().is_empty() {
+		return input.to_string();
+	}
+
+	let files: Vec<&str> = collect_diff_files(input);
+	if files.is_empty() {
+		// No `Diff in ` markers — likely a panic / parse error / usage
+		// message. Cap with the standard error head/tail budget.
+		if exit_code != 0 {
+			return primitives::head_tail_lines(input, 80, 40);
+		}
+		return input.to_string();
+	}
+
+	let mut out = String::new();
+	let unique: Vec<&&str> = {
+		let mut seen = std::collections::BTreeSet::new();
+		files.iter().filter(|f| seen.insert(**f)).collect()
+	};
+	let total = unique.len();
+	let _ = writeln!(out, "{total} files reformatted ({total} with diffs):");
+	for file in unique.iter().take(3) {
+		out.push_str("  ");
+		out.push_str(file);
+		out.push('\n');
+	}
+	if total > 3 {
+		let _ = writeln!(out, "  … {} more", total - 3);
+	}
+	out
+}
+
+fn collect_diff_files(input: &str) -> Vec<&str> {
+	let mut files = Vec::new();
+	for line in input.lines() {
+		if let Some(rest) = line.strip_prefix("Diff in ") {
+			// rest looks like: `<path> at line <N>:`
+			let path = rest
+				.split(" at line ")
+				.next()
+				.unwrap_or(rest)
+				.trim_end_matches(':');
+			files.push(path);
+		}
+	}
+	files
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::minimizer::MinimizerConfig;
+
+	fn ctx<'a>(program: &'a str, command: &'a str, config: &'a MinimizerConfig) -> MinimizerCtx<'a> {
+		MinimizerCtx { program, subcommand: None, command, config }
+	}
+
+	#[test]
+	fn rustfmt_diff_output_compacts() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let mut input = String::new();
+		for i in 0..50 {
+			input.push_str(&format!("Diff in src/file_{i}.rs at line 10:\n"));
+			for _ in 0..8 {
+				input.push_str("-    old line\n");
+				input.push_str("+    new line\n");
+			}
+		}
+		let context = ctx("rustfmt", "rustfmt --check src/", &cfg);
+		let out = filter(&context, &input, 1);
+		assert!(out.changed);
+		assert!(out.text.contains("50 files reformatted"));
+		assert!(out.text.contains("src/file_0.rs"));
+		assert!(out.text.contains("… 47 more"));
+		// Diff bodies must be elided.
+		assert!(!out.text.contains("old line"));
+		// Savings ratio ≥ 0.7
+		let saved_ratio = 1.0 - (out.text.len() as f64 / input.len() as f64);
+		assert!(saved_ratio >= 0.7, "expected ≥0.7 savings, got {saved_ratio}");
+	}
+
+	#[test]
+	fn rustfmt_silent_output_passthrough() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("rustfmt", "rustfmt src/lib.rs", &cfg);
+		let out = filter(&context, "", 0);
+		assert!(!out.changed);
+		assert_eq!(out.text, "");
+	}
+
+	#[test]
+	fn rustfmt_error_output_capped() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let context = ctx("rustfmt", "rustfmt --check missing.rs", &cfg);
+		// Simulate a long usage/error dump with no `Diff in ` headers.
+		let mut input = String::new();
+		for i in 0..400 {
+			input.push_str(&format!("error: usage line {i}\n"));
+		}
+		let out = filter(&context, &input, 1);
+		assert!(out.changed);
+		// head_tail_lines(input, 80, 40) keeps 120 lines + marker.
+		assert!(out.text.contains("lines omitted"));
+	}
+
+	#[test]
+	fn rustfmt_legacy_filters_active_passes_through() {
+		// Kill-switch parity (M2).
+		let mut cfg = MinimizerConfig::default();
+		cfg.enabled = true;
+		cfg.legacy_filters_active = true;
+		let context = ctx("rustfmt", "rustfmt --check src/", &cfg);
+		let input = "Diff in src/a.rs at line 1:\n-old\n+new\n";
+		let out = filter(&context, input, 1);
+		assert!(!out.changed);
+		assert_eq!(out.text, input);
+	}
+}

--- a/crates/pi-shell/src/minimizer/filters/rust_tools.rs
+++ b/crates/pi-shell/src/minimizer/filters/rust_tools.rs
@@ -70,7 +70,7 @@ fn condense_rustfmt(input: &str, exit_code: i32) -> String {
 		files.iter().filter(|f| seen.insert(**f)).collect()
 	};
 	let total = unique.len();
-	let _ = writeln!(out, "{total} files reformatted ({total} with diffs):");
+	let _ = writeln!(out, "{total} files reformatted:");
 	for file in unique.iter().take(3) {
 		out.push_str("  ");
 		out.push_str(file);

--- a/crates/pi-shell/src/minimizer/filters/system.rs
+++ b/crates/pi-shell/src/minimizer/filters/system.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 
+use super::git;
 use crate::minimizer::{MinimizerCtx, MinimizerOutput, primitives};
 
 pub fn supports(program: &str) -> bool {
@@ -26,13 +27,23 @@ pub fn filter(ctx: &MinimizerCtx<'_>, input: &str, exit_code: i32) -> MinimizerO
 	let cleaned = primitives::strip_ansi(input);
 	let command = ctx.program;
 	let text = match command {
-		"env" => compact_env(&cleaned),
+		"env" => {
+			if ctx
+				.command
+				.split_whitespace()
+				.any(|t| t == "-0" || t == "--null")
+			{
+				cleaned
+			} else {
+				compact_env(&cleaned)
+			}
+		},
 		"log" => compact_log(&cleaned),
 		"deps" => compact_dependency_output(&cleaned),
 		"summary" => compact_summary_output(&cleaned, exit_code),
-		"err" => cleaned,
+		"err" => compact_err_output(&cleaned),
 		"test" => compact_test_output(&cleaned),
-		"diff" => cleaned,
+		"diff" => git::compact_diff_output(&cleaned),
 		"format" => compact_format_output(&cleaned),
 		"pipe" => compact_pipe_like_output(&cleaned, exit_code),
 		"ps" => compact_ps_output(&cleaned),
@@ -215,17 +226,13 @@ struct LogLine {
 fn normalize_log_line(line: &str) -> String {
 	let without_timestamp = strip_leading_timestamp(line.trim());
 	let mut out = String::new();
-	let mut digits = String::new();
-	for ch in without_timestamp.chars() {
-		if ch.is_ascii_digit() {
-			digits.push(ch);
-			continue;
+	for token in without_timestamp.split_whitespace() {
+		if !out.is_empty() {
+			out.push(' ');
 		}
-		flush_digits(&mut out, &mut digits);
-		out.push(ch);
+		push_normalized_token(&mut out, token);
 	}
-	flush_digits(&mut out, &mut digits);
-	out.split_whitespace().collect::<Vec<_>>().join(" ")
+	out
 }
 
 fn strip_leading_timestamp(line: &str) -> &str {
@@ -241,6 +248,54 @@ fn strip_leading_timestamp(line: &str) -> &str {
 		return "";
 	}
 	line
+}
+
+fn push_normalized_token(out: &mut String, token: &str) {
+	let core = token.trim_matches(|ch: char| ch.is_ascii_punctuation() && ch != '/' && ch != '.');
+	if is_uuid_like(core) {
+		out.push_str("<uuid>");
+		return;
+	}
+	if is_hex_like(core) {
+		out.push_str("<hex>");
+		return;
+	}
+	if is_path_like(core) {
+		out.push_str("<path>");
+		return;
+	}
+
+	let mut digits = String::new();
+	for ch in token.chars() {
+		if ch.is_ascii_digit() {
+			digits.push(ch);
+			continue;
+		}
+		flush_digits(out, &mut digits);
+		out.push(ch);
+	}
+	flush_digits(out, &mut digits);
+}
+
+fn is_uuid_like(token: &str) -> bool {
+	token.len() == 36
+		&& token.bytes().enumerate().all(|(idx, byte)| {
+			if matches!(idx, 8 | 13 | 18 | 23) {
+				byte == b'-'
+			} else {
+				byte.is_ascii_hexdigit()
+			}
+		})
+}
+
+fn is_hex_like(token: &str) -> bool {
+	let token = token.strip_prefix("0x").unwrap_or(token);
+	token.len() >= 8 && token.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn is_path_like(token: &str) -> bool {
+	(token.starts_with('/') || token.starts_with("./") || token.starts_with("../"))
+		&& token.len() > 1
 }
 
 fn flush_digits(out: &mut String, digits: &mut String) {
@@ -324,15 +379,265 @@ fn compact_summary_output(input: &str, exit_code: i32) -> String {
 	out
 }
 
+fn compact_err_output(input: &str) -> String {
+	compact_failure_output(
+		input,
+		2,
+		12,
+		is_err_signal_line,
+		is_err_summary_line,
+		is_err_noise,
+		is_err_relevant_line,
+	)
+}
+
 fn compact_test_output(input: &str) -> String {
+	compact_failure_output(
+		input,
+		1,
+		12,
+		is_test_signal_line,
+		is_test_summary_line,
+		is_test_noise,
+		is_test_relevant_line,
+	)
+}
+
+fn compact_failure_output(
+	input: &str,
+	keep_before: usize,
+	keep_after: usize,
+	is_signal_line: fn(&str) -> bool,
+	is_summary_line: fn(&str) -> bool,
+	is_noise_line: fn(&str) -> bool,
+	is_relevant_line: fn(&str) -> bool,
+) -> String {
 	let lines: Vec<&str> = input.lines().collect();
-	if lines.len() <= 120 {
-		return primitives::dedup_consecutive_lines(input);
+	if lines.is_empty() {
+		return input.to_string();
 	}
-	let mut out = format!("test output: {} lines\n", lines.len());
-	push_important_lines(&mut out, input, 80);
-	out.push_str(&primitives::head_tail_lines(input, 35, 35));
-	out
+
+	let mut keep = vec![false; lines.len()];
+	let mut saw_relevant = false;
+
+	for (idx, line) in lines.iter().enumerate() {
+		let trimmed = line.trim_start();
+		if is_relevant_line(trimmed) {
+			saw_relevant = true;
+		}
+		if is_summary_line(trimmed) {
+			keep[idx] = true;
+			continue;
+		}
+		if is_signal_line(trimmed) {
+			let start = idx.saturating_sub(keep_before);
+			let end = idx
+				.saturating_add(keep_after)
+				.min(lines.len().saturating_sub(1));
+			for slot in keep.iter_mut().take(end + 1).skip(start) {
+				*slot = true;
+			}
+		}
+	}
+
+	if !saw_relevant {
+		return input.to_string();
+	}
+
+	let mut out = String::new();
+	for (idx, line) in lines.iter().enumerate() {
+		if !keep[idx] {
+			continue;
+		}
+		let trimmed = line.trim_start();
+		if is_noise_line(trimmed) {
+			continue;
+		}
+		out.push_str(line);
+		out.push('\n');
+	}
+
+	primitives::dedup_consecutive_lines(&out)
+}
+
+fn is_err_signal_line(trimmed: &str) -> bool {
+	let lower = trimmed.to_ascii_lowercase();
+	lower.starts_with("error:")
+		|| lower.starts_with("fatal:")
+		|| lower.starts_with("failed:")
+		|| lower.starts_with("panic:")
+		|| lower.starts_with("exception:")
+		|| lower.starts_with("traceback ")
+		|| lower.starts_with("assertionerror")
+		|| lower.starts_with("timeouterror")
+		|| lower.starts_with("caused by:")
+		|| lower.starts_with("warning:")
+		|| lower.starts_with("warn:")
+		|| lower.contains(": error:")
+		|| lower.contains(": warning:")
+		|| lower.contains(" fatal error")
+		|| lower.contains(" failed")
+		|| lower.contains(" panic")
+		|| lower.contains(" exception")
+}
+
+fn is_err_summary_line(trimmed: &str) -> bool {
+	let lower = trimmed.to_ascii_lowercase();
+	lower.starts_with("build failed")
+		|| lower.starts_with("failures!")
+		|| lower.starts_with("failed")
+		|| lower.starts_with("errors:")
+		|| lower.starts_with("warnings:")
+		|| lower.starts_with("play recap")
+		|| lower.starts_with("summary")
+		|| lower.starts_with("test result")
+		|| lower.starts_with("test files")
+		|| lower.starts_with("tests:")
+		|| is_count_summary(trimmed)
+}
+
+fn is_err_noise(trimmed: &str) -> bool {
+	let lower = trimmed.to_ascii_lowercase();
+	lower.starts_with("compiling ")
+		|| lower.starts_with("building ")
+		|| lower.starts_with("checking ")
+		|| lower.starts_with("running ")
+		|| lower.starts_with("executing ")
+		|| lower.starts_with("fetching ")
+		|| lower.starts_with("resolving ")
+		|| lower.starts_with("downloading ")
+		|| lower.starts_with("installing ")
+		|| lower.starts_with("finished ")
+		|| lower.starts_with("done ")
+		|| lower.starts_with("pass ")
+		|| lower.starts_with("✓")
+		|| lower.starts_with("✔")
+		|| lower.starts_with("√")
+		|| lower.starts_with("○")
+		|| lower.starts_with("ok ")
+		|| lower.contains(" ... ok")
+}
+
+fn is_test_signal_line(trimmed: &str) -> bool {
+	let lower = trimmed.to_ascii_lowercase();
+	trimmed.starts_with("FAIL ")
+		|| trimmed.starts_with("FAILURES")
+		|| trimmed.starts_with("Failed Tests")
+		|| trimmed.starts_with("● ")
+		|| trimmed.starts_with("✕")
+		|| trimmed.starts_with("×")
+		|| trimmed.starts_with("✗")
+		|| trimmed.starts_with("❯")
+		|| lower.starts_with("error:")
+		|| lower.starts_with("assertionerror")
+		|| lower.starts_with("timeouterror")
+		|| lower.starts_with("panic:")
+		|| lower.starts_with("failed ")
+}
+
+fn is_test_summary_line(trimmed: &str) -> bool {
+	let lower = trimmed.to_ascii_lowercase();
+	trimmed.starts_with("Test Suites:")
+		|| trimmed.starts_with("Test Suites")
+		|| trimmed.starts_with("Tests:")
+		|| trimmed.starts_with("Tests")
+		|| trimmed.starts_with("Test Files")
+		|| trimmed.starts_with("Snapshots:")
+		|| trimmed.starts_with("Snapshots")
+		|| trimmed.starts_with("Time:")
+		|| trimmed.starts_with("Duration")
+		|| trimmed.starts_with("Start at")
+		|| trimmed.starts_with("Ran all test suites")
+		|| trimmed.starts_with("Ran ")
+		|| trimmed.starts_with("Failed Tests")
+		|| trimmed.starts_with("FAILURES")
+		|| trimmed.starts_with("Summary")
+		|| lower.starts_with("build failed")
+		|| lower.starts_with("test run failed")
+		|| lower.starts_with("test result")
+		|| is_count_summary(trimmed)
+}
+
+fn is_test_noise(trimmed: &str) -> bool {
+	let lower = trimmed.to_ascii_lowercase();
+	lower.starts_with("pass ")
+		|| trimmed.starts_with("✓")
+		|| trimmed.starts_with("✔")
+		|| trimmed.starts_with("√")
+		|| trimmed.starts_with("○")
+		|| lower.starts_with("running ")
+		|| lower.starts_with("run ")
+		|| lower.starts_with("dev ")
+		|| lower.starts_with("ok ")
+		|| lower.contains(" ... ok")
+}
+
+fn is_err_relevant_line(trimmed: &str) -> bool {
+	is_err_signal_line(trimmed) || is_err_summary_line(trimmed)
+}
+
+fn is_test_relevant_line(trimmed: &str) -> bool {
+	is_test_signal_line(trimmed) || is_test_summary_line(trimmed) || is_test_noise(trimmed)
+}
+
+fn is_count_summary(trimmed: &str) -> bool {
+	let mut parts = trimmed.split_whitespace();
+	let Some(count) = parts.next() else {
+		return false;
+	};
+	if !count.chars().all(|ch| ch.is_ascii_digit()) {
+		return false;
+	}
+
+	let Some(kind) = parts
+		.next()
+		.map(|word| word.trim_matches(|ch: char| ch.is_ascii_punctuation()))
+	else {
+		return false;
+	};
+	if matches!(
+		kind,
+		"failed"
+			| "passed"
+			| "skipped"
+			| "flaky"
+			| "pass"
+			| "fail"
+			| "error"
+			| "errors"
+			| "warning"
+			| "warnings"
+			| "information"
+			| "informations"
+	) {
+		return true;
+	}
+
+	if kind == "of" {
+		let Some(total) = parts.next() else {
+			return false;
+		};
+		if !total.chars().all(|ch| ch.is_ascii_digit()) {
+			return false;
+		}
+		return parts
+			.next()
+			.map(|word| word.trim_matches(|ch: char| ch.is_ascii_punctuation()))
+			.is_some_and(|kind| {
+				matches!(
+					kind,
+					"failed"
+						| "passed" | "skipped"
+						| "flaky" | "pass"
+						| "fail" | "error"
+						| "errors" | "warning"
+						| "warnings" | "information"
+						| "informations"
+				)
+			});
+	}
+
+	false
 }
 
 fn push_important_lines(out: &mut String, input: &str, max: usize) {
@@ -614,6 +919,18 @@ mod tests {
 	}
 
 	#[test]
+	fn log_dedups_normalized_uuid_hex_and_paths() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("log", &cfg);
+		let input = "2026-01-01T10:00:00 ERROR request 550e8400-e29b-41d4-a716-446655440000 file \
+		             /tmp/a.rs hash deadbeef failed\n2026-01-01T10:00:01 ERROR request \
+		             123e4567-e89b-12d3-a456-426614174000 file /tmp/b.rs hash cafebabe failed\n";
+		let out = filter(&ctx, input, 1);
+		assert!(out.text.contains("2 lines, 1 unique"));
+		assert!(out.text.contains("(×2)"));
+	}
+
+	#[test]
 	fn env_masks_secrets_and_compacts_long_values() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
 		let ctx = ctx("env", &cfg);
@@ -625,11 +942,39 @@ mod tests {
 	}
 
 	#[test]
-	fn diff_output_passthrough_is_lossless() {
+	fn err_output_keeps_diagnostics_and_context() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("err", &cfg);
+		let input = "\
+Compiling app v0.1.0
+running 1 test
+test pass ... ok
+src/main.rs:10:5: error: cannot find value `foo` in this scope
+   |
+10 |     foo();
+   |     ^^^
+note: required by a bound in `bar`
+warning: unused import: `baz`
+";
+		let out = filter(&ctx, input, 1);
+		assert!(out.changed);
+		assert!(!out.text.contains("Compiling app v0.1.0"));
+		assert!(!out.text.contains("running 1 test"));
+		assert!(!out.text.contains("test pass ... ok"));
+		assert!(
+			out.text
+				.contains("src/main.rs:10:5: error: cannot find value `foo` in this scope")
+		);
+		assert!(out.text.contains("10 |     foo();"));
+		assert!(out.text.contains("note: required by a bound in `bar`"));
+		assert!(out.text.contains("warning: unused import: `baz`"));
+	}
+
+	#[test]
+	fn diff_output_reuses_unified_diff_compaction() {
 		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
 		let ctx = ctx("diff", &cfg);
-		let mut input =
-			String::from("diff --git a/a.rs b/a.rs\n--- a/a.rs\n+++ b/a.rs\n@@ -1,140 +1,140 @@\n");
+		let mut input = String::from("--- a/a.rs\n+++ b/a.rs\n@@ -1,140 +1,140 @@\n");
 		for idx in 0..140 {
 			input.push_str("-old ");
 			input.push_str(&idx.to_string());
@@ -638,7 +983,43 @@ mod tests {
 			input.push('\n');
 		}
 		let out = filter(&ctx, &input, 0);
-		assert_eq!(out.text, input);
+		assert!(out.changed);
+		assert!(out.text.contains("a.rs | 280"));
+		assert!(
+			out.text
+				.contains("1 file changed, 140 insertions(+), 140 deletions(-)")
+		);
+		assert!(out.text.contains("--- Changes ---"));
+		assert!(out.text.contains("-old 0"));
+		assert!(out.text.contains("+new 0"));
+		assert_ne!(out.text, input);
+	}
+
+	#[test]
+	fn test_output_drops_pass_chatter_and_keeps_failure_summary() {
+		let cfg = MinimizerConfig { enabled: true, ..Default::default() };
+		let ctx = ctx("test", &cfg);
+		let input = "\
+PASS src/pass.test.ts
+✓ src/ok.test.ts (3ms)
+FAIL src/fail.test.ts
+  suite > breaks
+    Error: expected 1 to equal 2
+      at src/fail.test.ts:12:3
+
+Test Files  1 failed | 1 passed (2)
+Tests       1 failed | 3 passed (4)
+Time        0.42s
+";
+		let out = filter(&ctx, input, 1);
+		assert!(out.changed);
+		assert!(!out.text.contains("PASS src/pass.test.ts"));
+		assert!(!out.text.contains("✓ src/ok.test.ts"));
+		assert!(out.text.contains("FAIL src/fail.test.ts"));
+		assert!(out.text.contains("Error: expected 1 to equal 2"));
+		assert!(out.text.contains("Test Files  1 failed | 1 passed (2)"));
+		assert!(out.text.contains("Tests       1 failed | 3 passed (4)"));
+		assert!(out.text.contains("Time        0.42s"));
 	}
 
 	#[test]

--- a/crates/pi-shell/src/minimizer/plan.rs
+++ b/crates/pi-shell/src/minimizer/plan.rs
@@ -11,9 +11,13 @@
 //!   regardless of what `bar` is. A user piping through `awk`, `jq`, `rg`, or
 //!   any other consumer is almost certainly parsing the output; rewriting it
 //!   would be a correctness bug. The engine falls back to passthrough.
-//! - **Compound commands are opaque.** `a && b`, `a ; b`, and `a || b` cannot
-//!   be minimized as one combined buffer without risking semantic corruption,
-//!   so they are left unchanged.
+//! - **Safe chains are segmented, not rewritten whole.** Top-level simple
+//!   commands joined only by `&&` and `;` may be split into `ChainSegment`s for
+//!   the segmented engine path, but the whole-buffer minimizer still treats the
+//!   combined chain as opaque.
+//! - **Other compound commands are opaque.** `a || b`, background jobs, and
+//!   compound shell syntax such as subshells or function definitions are left
+//!   unchanged.
 //! - **Single simple commands** are safe for the whole-buffer path; the engine
 //!   dispatches them through `detect.rs` as before.
 //!
@@ -22,8 +26,20 @@
 
 use brush_parser::{
 	ParserOptions, SourceInfo,
-	ast::{AndOrList, Command, CompoundListItem, Pipeline, Program, SeparatorOperator},
+	ast::{
+		AndOr, Command, CommandPrefixOrSuffixItem, CompoundListItem, IoFileRedirectTarget,
+		IoRedirect, Pipeline, Program, SeparatorOperator, Word,
+	},
 };
+
+/// One segment of a safe `&&` / `;` chain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainSegment {
+	pub command:                   String,
+	pub program:                   String,
+	pub run_if_previous_succeeded: bool,
+	pub suppress_errexit:          bool,
+}
 
 /// Outcome of analyzing a raw command string.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -35,9 +51,12 @@ pub enum CommandPlan {
 	/// NOT identify upstream / downstream programs here — any pipe defeats
 	/// safe minimization for this engine.
 	Piped,
-	/// The command has multiple segments joined by `&&`, `||`, `;`, or `&`.
-	/// This shape is left unchanged; the minimizer only rewrites whole simple
-	/// command output.
+	/// Top-level simple commands joined by `&&` and/or `;`. These can be
+	/// minimized segment-by-segment, but not as one combined buffer.
+	Chain { segments: Vec<ChainSegment> },
+	/// The command has multiple segments joined by `||`, `&`, or other
+	/// unsupported shell syntax. This shape is left unchanged; the minimizer
+	/// only rewrites whole simple command output.
 	Compound,
 	/// Parse failed, a compound shell construct (for loops, subshells, etc.)
 	/// was encountered, or the command was empty.
@@ -52,9 +71,9 @@ pub fn analyze(command: &str) -> CommandPlan {
 	}
 
 	let options = ParserOptions::default();
-	let source = SourceInfo::default();
+	let source_info = SourceInfo::default();
 	let reader = std::io::Cursor::new(command.as_bytes());
-	let mut parser = brush_parser::Parser::new(reader, &options, &source);
+	let mut parser = brush_parser::Parser::new(reader, &options, &source_info);
 
 	let Ok(program) = parser.parse_program() else {
 		return CommandPlan::Unsupported;
@@ -64,6 +83,10 @@ pub fn analyze(command: &str) -> CommandPlan {
 }
 
 fn classify(program: &Program) -> CommandPlan {
+	if let Some(chain) = classify_chain(program) {
+		return chain;
+	}
+
 	// Count separator-separated top-level items across all complete_commands.
 	let items: Vec<&CompoundListItem> = program
 		.complete_commands
@@ -96,7 +119,143 @@ fn classify(program: &Program) -> CommandPlan {
 	}
 
 	// Only a single pipeline at this point.
-	classify_pipeline(&and_or.first).unwrap_or_else(|| classify_andorlist(and_or))
+	classify_pipeline(&and_or.first).unwrap_or(CommandPlan::Unsupported)
+}
+
+fn classify_chain(program: &Program) -> Option<CommandPlan> {
+	let items: Vec<&CompoundListItem> = program
+		.complete_commands
+		.iter()
+		.flat_map(|cl| cl.0.iter())
+		.collect();
+
+	if items.is_empty() {
+		return None;
+	}
+
+	let mut segments = Vec::new();
+	let mut run_if_previous_succeeded = false;
+
+	for (item_index, item) in items.iter().enumerate() {
+		if matches!(item.1, SeparatorOperator::Async) {
+			return None;
+		}
+
+		let is_last_item = item_index + 1 == items.len();
+		let mut pipeline = &item.0.first;
+		let mut additional = item.0.additional.iter().peekable();
+
+		loop {
+			let (command, program) = simple_segment(pipeline)?;
+
+			let suppress_errexit = additional
+				.peek()
+				.is_some_and(|and_or| matches!(and_or, AndOr::And(_)));
+			segments.push(ChainSegment {
+				command,
+				program,
+				run_if_previous_succeeded,
+				suppress_errexit,
+			});
+
+			let Some(and_or) = additional.next() else {
+				run_if_previous_succeeded = false;
+				break;
+			};
+
+			match and_or {
+				AndOr::And(next_pipeline) => {
+					run_if_previous_succeeded = true;
+					pipeline = next_pipeline;
+				},
+				AndOr::Or(_) => return None,
+			}
+		}
+
+		if !is_last_item {
+			run_if_previous_succeeded = false;
+		}
+	}
+
+	(segments.len() >= 2).then_some(CommandPlan::Chain { segments })
+}
+
+fn word_has_command_substitution(word: &Word) -> bool {
+	word.value.contains("$(") || word.value.contains('`')
+}
+
+fn command_prefix_or_suffix_item_is_safe(item: &CommandPrefixOrSuffixItem) -> bool {
+	match item {
+		CommandPrefixOrSuffixItem::IoRedirect(io) => io_redirect_is_safe(io),
+		CommandPrefixOrSuffixItem::Word(word) => !word_has_command_substitution(word),
+		CommandPrefixOrSuffixItem::AssignmentWord(_, word) => !word_has_command_substitution(word),
+		CommandPrefixOrSuffixItem::ProcessSubstitution(..) => false,
+	}
+}
+
+fn io_redirect_is_safe(io: &IoRedirect) -> bool {
+	match io {
+		IoRedirect::File(_, _, target) => match target {
+			IoFileRedirectTarget::Filename(word) | IoFileRedirectTarget::Duplicate(word) => {
+				!word_has_command_substitution(word)
+			},
+			IoFileRedirectTarget::Fd(_) => true,
+			IoFileRedirectTarget::ProcessSubstitution(..) => false,
+		},
+		IoRedirect::HereDocument(_, here_doc) => {
+			!word_has_command_substitution(&here_doc.here_end)
+				&& !word_has_command_substitution(&here_doc.doc)
+		},
+		IoRedirect::HereString(_, word) => !word_has_command_substitution(word),
+		IoRedirect::OutputAndError(word, _) => !word_has_command_substitution(word),
+	}
+}
+
+fn simple_segment(pipeline: &Pipeline) -> Option<(String, String)> {
+	if pipeline.timed.is_some() || pipeline.bang || pipeline.seq.is_empty() {
+		return None;
+	}
+
+	// For multi-stage pipes inside a chain segment, identify the segment by its
+	// first stage's program. The downstream per-segment minimizer::apply will
+	// detect the pipeline at runtime via plan::CommandPlan::Piped and pass it
+	// through unchanged — so a piped segment is safely captured but never
+	// rewritten. This keeps the chain decomposable when even one inner stage
+	// uses a pipe (e.g. `ls | head -10 && git status`).
+	let first = pipeline.seq.first()?;
+	match first {
+		Command::Simple(simple) => {
+			if simple.prefix.as_ref().is_some_and(|prefix| {
+				prefix
+					.0
+					.iter()
+					.any(|item| !command_prefix_or_suffix_item_is_safe(item))
+			}) {
+				return None;
+			}
+			if simple.suffix.as_ref().is_some_and(|suffix| {
+				suffix
+					.0
+					.iter()
+					.any(|item| !command_prefix_or_suffix_item_is_safe(item))
+			}) {
+				return None;
+			}
+
+			let program_word = simple.word_or_name.as_ref()?;
+			if word_has_command_substitution(program_word) {
+				return None;
+			}
+			let program = program_word.to_string();
+			if program.trim().is_empty() {
+				return None;
+			}
+			Some((pipeline.to_string(), program))
+		},
+		// Compound shell syntax (if / for / while / subshell / { ... }) is
+		// not something the minimizer should touch.
+		Command::Compound(..) | Command::Function(_) | Command::ExtendedTest(..) => None,
+	}
 }
 
 fn classify_pipeline(pipeline: &Pipeline) -> Option<CommandPlan> {
@@ -115,14 +274,10 @@ fn classify_pipeline(pipeline: &Pipeline) -> Option<CommandPlan> {
 		},
 		// Compound shell syntax (if / for / while / subshell / { ... }) is
 		// not something the minimizer should touch.
-		Command::Compound(..) | Command::Function(_) | Command::ExtendedTest(_) => {
+		Command::Compound(..) | Command::Function(_) | Command::ExtendedTest(..) => {
 			Some(CommandPlan::Compound)
 		},
 	}
-}
-
-const fn classify_andorlist(_and_or: &AndOrList) -> CommandPlan {
-	CommandPlan::Unsupported
 }
 
 #[cfg(test)]
@@ -134,6 +289,20 @@ mod tests {
 			CommandPlan::Single { program } => Some(program),
 			_ => None,
 		}
+	}
+
+	fn chain_of(plan: CommandPlan) -> Option<Vec<ChainSegment>> {
+		match plan {
+			CommandPlan::Chain { segments } => Some(segments),
+			_ => None,
+		}
+	}
+
+	fn assert_not_chain(command: &str) {
+		assert!(
+			!matches!(analyze(command), CommandPlan::Chain { .. }),
+			"{command:?} unexpectedly classified as Chain"
+		);
 	}
 
 	#[test]
@@ -150,42 +319,119 @@ mod tests {
 	}
 
 	#[test]
-	fn pipe_is_piped() {
-		assert_eq!(analyze("git status | cat"), CommandPlan::Piped);
-		assert_eq!(analyze("ls -la | awk '{print $1}'"), CommandPlan::Piped);
+	fn safe_and_chain_is_segmented() {
+		let plan = analyze("git diff --stat && git diff --name-only");
+		assert_eq!(
+			chain_of(plan),
+			Some(vec![
+				ChainSegment {
+					command:                   "git diff --stat".to_string(),
+					program:                   "git".to_string(),
+					run_if_previous_succeeded: false,
+					suppress_errexit:          true,
+				},
+				ChainSegment {
+					command:                   "git diff --name-only".to_string(),
+					program:                   "git".to_string(),
+					run_if_previous_succeeded: true,
+					suppress_errexit:          false,
+				},
+			])
+		);
 	}
 
 	#[test]
-	fn and_or_is_compound() {
-		assert_eq!(analyze("cd foo && cargo test"), CommandPlan::Compound);
+	fn safe_sequence_chain_is_segmented() {
+		let plan = analyze("git status ; bun test");
+		assert_eq!(
+			chain_of(plan),
+			Some(vec![
+				ChainSegment {
+					command:                   "git status".to_string(),
+					program:                   "git".to_string(),
+					run_if_previous_succeeded: false,
+					suppress_errexit:          false,
+				},
+				ChainSegment {
+					command:                   "bun test".to_string(),
+					program:                   "bun".to_string(),
+					run_if_previous_succeeded: false,
+					suppress_errexit:          false,
+				},
+			])
+		);
+	}
+
+	#[test]
+	fn mixed_chain_is_segmented() {
+		let plan = analyze("false && echo no ; echo yes");
+		assert_eq!(
+			chain_of(plan),
+			Some(vec![
+				ChainSegment {
+					command:                   "false".to_string(),
+					program:                   "false".to_string(),
+					run_if_previous_succeeded: false,
+					suppress_errexit:          true,
+				},
+				ChainSegment {
+					command:                   "echo no".to_string(),
+					program:                   "echo".to_string(),
+					run_if_previous_succeeded: true,
+					suppress_errexit:          false,
+				},
+				ChainSegment {
+					command:                   "echo yes".to_string(),
+					program:                   "echo".to_string(),
+					run_if_previous_succeeded: false,
+					suppress_errexit:          false,
+				},
+			])
+		);
+	}
+
+	#[test]
+	fn chain_with_piped_segment_is_segmented() {
+		// A chain that contains a piped segment (`ls | head -5`) must still be
+		// classified as Chain so the segmented runner can decompose it. The
+		// piped segment is identified by its first stage's program; the
+		// per-segment minimizer::apply will treat that segment as Piped at
+		// runtime and pass it through unchanged.
+		let plan = analyze("ls -lh *.txt | head -5 && git status --short");
+		let segments = chain_of(plan).expect("expected Chain");
+		assert_eq!(segments.len(), 2);
+		assert_eq!(segments[0].program, "ls");
+		assert_eq!(segments[1].program, "git");
+	}
+
+	#[test]
+	fn rejects_unsafe_chain_segments() {
+		for command in [
+			"echo $(pwd) ; git status",
+			"echo `pwd` ; git status",
+			"cat <(printf hi) ; git status",
+			"git status > >(cat) ; bun test",
+			"! git status ; bun test",
+		] {
+			assert_not_chain(command);
+		}
+	}
+
+	#[test]
+	fn rejects_legacy_opaque_shapes() {
 		assert_eq!(analyze("foo || bar"), CommandPlan::Compound);
-	}
-
-	#[test]
-	fn sequence_is_compound() {
-		assert_eq!(analyze("echo a ; echo b"), CommandPlan::Compound);
-	}
-
-	#[test]
-	fn async_is_compound() {
+		assert_eq!(analyze("git status | cat"), CommandPlan::Piped);
 		assert_eq!(analyze("sleep 1 &"), CommandPlan::Compound);
+		assert_eq!(analyze("(cd foo && make)"), CommandPlan::Compound);
+		assert_eq!(analyze("{ echo hi; }"), CommandPlan::Compound);
+		assert_eq!(analyze("f() { echo hi; }"), CommandPlan::Compound);
+		assert_eq!(analyze("[[ -f foo ]]"), CommandPlan::Compound);
+		assert_eq!(analyze("a && && b"), CommandPlan::Unsupported);
 	}
 
 	#[test]
 	fn empty_is_unsupported() {
 		assert_eq!(analyze(""), CommandPlan::Unsupported);
 		assert_eq!(analyze("   "), CommandPlan::Unsupported);
-	}
-
-	#[test]
-	fn subshell_is_compound_not_single() {
-		// `(cmd)` is a compound-command variant, not Simple.
-		let plan = analyze("(cd foo && make)");
-		assert!(matches!(plan, CommandPlan::Compound | CommandPlan::Unsupported));
-	}
-
-	#[test]
-	fn malformed_is_unsupported() {
-		assert_eq!(analyze("a && && b"), CommandPlan::Unsupported);
 	}
 }

--- a/crates/pi-shell/src/minimizer/primitives.rs
+++ b/crates/pi-shell/src/minimizer/primitives.rs
@@ -2,7 +2,31 @@
 
 use std::collections::BTreeMap;
 
-/// Remove ANSI CSI escape sequences and carriage-return progress frames.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CapClass {
+	Errors,
+	Warnings,
+	List,
+	Inventory,
+}
+
+impl CapClass {
+	pub const fn lines(self) -> usize {
+		match self {
+			Self::Errors => 160,
+			Self::Warnings => 120,
+			Self::List => 80,
+			Self::Inventory => 40,
+		}
+	}
+}
+
+pub const fn reduced(cap: usize, by: usize) -> usize {
+	let reduced = cap.saturating_sub(by);
+	if reduced == 0 && cap > 0 { 1 } else { reduced }
+}
+
+/// Remove ANSI CSI escape sequences while preserving line endings verbatim.
 pub fn strip_ansi(input: &str) -> String {
 	let mut out = String::with_capacity(input.len());
 	let mut chars = input.chars().peekable();
@@ -14,10 +38,6 @@ pub fn strip_ansi(input: &str) -> String {
 					break;
 				}
 			}
-			continue;
-		}
-		if ch == '\r' {
-			out.push('\n');
 			continue;
 		}
 		out.push(ch);
@@ -76,6 +96,14 @@ pub fn head_tail_lines(input: &str, head: usize, tail: usize) -> String {
 		out.push('\n');
 	}
 	out
+}
+
+/// Keep head/tail lines using a named cap class.
+pub fn head_tail_cap(input: &str, class: CapClass) -> String {
+	let cap = class.lines();
+	let head = reduced(cap, cap / 3);
+	let tail = cap - head;
+	head_tail_lines(input, head, tail)
 }
 
 /// Drop lines matching any of the supplied predicates.
@@ -288,6 +316,11 @@ mod tests {
 	}
 
 	#[test]
+	fn strip_ansi_preserves_carriage_returns() {
+		assert_eq!(strip_ansi("a\r\nb\rc"), "a\r\nb\rc");
+	}
+
+	#[test]
 	fn dedups_consecutive_lines() {
 		assert_eq!(dedup_consecutive_lines("a\na\nb\n"), "a (×2)\nb\n");
 	}
@@ -296,6 +329,24 @@ mod tests {
 	fn head_tail_marks_omitted_lines() {
 		let out = head_tail_lines("1\n2\n3\n4\n5\n", 2, 1);
 		assert_eq!(out, "1\n2\n… 2 lines omitted …\n5\n");
+	}
+
+	#[test]
+	fn named_caps_have_nonzero_reductions() {
+		assert_eq!(CapClass::Errors.lines(), 160);
+		assert_eq!(reduced(1, 10), 1);
+		assert_eq!(reduced(0, 10), 0);
+	}
+
+	#[test]
+	fn head_tail_cap_uses_named_budget() {
+		let input = (0..100)
+			.map(|idx| idx.to_string())
+			.collect::<Vec<_>>()
+			.join("\n");
+		let out = head_tail_cap(&input, CapClass::List);
+		assert!(out.contains("lines omitted"));
+		assert!(out.lines().count() <= CapClass::List.lines() + 1);
 	}
 
 	#[test]

--- a/crates/pi-shell/src/shell.rs
+++ b/crates/pi-shell/src/shell.rs
@@ -12,9 +12,9 @@ use std::{
 use anyhow::{Error, Result};
 use brush_builtins::{BuiltinSet, default_builtins};
 use brush_core::{
-	ExecutionContext, ExecutionControlFlow, ExecutionExitCode, ExecutionResult, ProcessGroupPolicy,
-	ProfileLoadBehavior, RcLoadBehavior, Shell as BrushShell, ShellValue, ShellVariable, SourceInfo,
-	builtins,
+	ExecutionContext, ExecutionControlFlow, ExecutionExitCode, ExecutionParameters, ExecutionResult,
+	ProcessGroupPolicy, ProfileLoadBehavior, RcLoadBehavior, Shell as BrushShell, ShellValue,
+	ShellVariable, SourceInfo, builtins,
 	env::EnvironmentScope,
 	openfiles::{self, OpenFile, OpenFiles},
 };
@@ -571,6 +571,42 @@ async fn source_snapshot(shell: &mut BrushShell, snapshot_path: &str) -> Result<
 	Ok(())
 }
 
+#[derive(Clone, Copy)]
+enum CommandCaptureMode {
+	Streaming,
+	Buffered { max_capture_bytes: usize },
+}
+
+struct CommandRunOutput {
+	result:   ExecutionResult,
+	buffered: Option<BufferedOutput>,
+}
+
+struct ChainCapture {
+	original_text: String,
+	text:          String,
+	input_bytes:   usize,
+	changed:       bool,
+}
+
+impl ChainCapture {
+	const fn new() -> Self {
+		Self {
+			original_text: String::new(),
+			text:          String::new(),
+			input_bytes:   0,
+			changed:       false,
+		}
+	}
+
+	fn push(&mut self, original: &str, original_input_bytes: usize, minimized: &str, changed: bool) {
+		self.original_text.push_str(original);
+		self.text.push_str(minimized);
+		self.input_bytes = self.input_bytes.saturating_add(original_input_bytes);
+		self.changed |= changed;
+	}
+}
+
 async fn run_shell_command(
 	session: &mut ShellSessionCore,
 	options: &ShellRunConfig,
@@ -591,13 +627,252 @@ async fn run_shell_command(
 	} else {
 		minimizer::engine::MinimizerMode::None
 	};
-	let should_minimize = !matches!(minimizer_mode, minimizer::engine::MinimizerMode::None);
-	let max_capture_bytes = if let Some(config) = options.minimizer.as_ref() {
-		config.max_capture_bytes as usize
-	} else {
-		0
+
+	let result = match minimizer_mode {
+		minimizer::engine::MinimizerMode::SegmentedChain => {
+			run_shell_command_segmented_chain(session, options, on_chunk, cancel_token).await
+		},
+		minimizer::engine::MinimizerMode::WholeCommand | minimizer::engine::MinimizerMode::None => {
+			run_shell_command_single(session, options, on_chunk, cancel_token, minimizer_mode).await
+		},
 	};
 
+	if env_scope_pushed {
+		session
+			.shell
+			.env_mut()
+			.pop_scope(EnvironmentScope::Command)
+			.map_err(|err| Error::msg(format!("Failed to pop env scope: {err}")))?;
+	}
+
+	result
+}
+
+async fn run_shell_command_single(
+	session: &mut ShellSessionCore,
+	options: &ShellRunConfig,
+	on_chunk: Option<mpsc::UnboundedSender<String>>,
+	cancel_token: CancellationToken,
+	minimizer_mode: minimizer::engine::MinimizerMode,
+) -> Result<(ExecutionResult, Option<MinimizerResult>)> {
+	debug_assert!(!matches!(minimizer_mode, minimizer::engine::MinimizerMode::SegmentedChain));
+
+	let params = session.shell.default_exec_params();
+	let capture_mode = match minimizer_mode {
+		minimizer::engine::MinimizerMode::WholeCommand => {
+			let Some(config) = options.minimizer.as_ref() else {
+				return Err(Error::msg("Missing minimizer config for whole-command mode"));
+			};
+			CommandCaptureMode::Buffered { max_capture_bytes: config.max_capture_bytes as usize }
+		},
+		minimizer::engine::MinimizerMode::None => CommandCaptureMode::Streaming,
+		minimizer::engine::MinimizerMode::SegmentedChain => CommandCaptureMode::Streaming,
+	};
+
+	let command_run = run_shell_command_once(
+		session,
+		options.command.clone(),
+		params,
+		on_chunk,
+		cancel_token,
+		capture_mode,
+	)
+	.await?;
+
+	let mut minimized_out = None;
+	if let Some(buffered) = command_run.buffered
+		&& let Some(config) = options.minimizer.as_ref()
+	{
+		// When the capture cap is exceeded the output was streamed raw and never
+		// buffered, so nothing was minimized — leave `minimized` absent, matching
+		// every other passthrough path and `apply_shell_minimizer`. Previously a
+		// `too-large` result with empty `text`/`original_text` was emitted, which a
+		// consumer keying off `minimized` presence could mistake for a real rewrite
+		// that produced empty output.
+		if !buffered.exceeded {
+			let minimized = match minimizer_mode {
+				minimizer::engine::MinimizerMode::WholeCommand => minimizer::apply(
+					&options.command,
+					&buffered.text,
+					exit_code(&command_run.result),
+					config,
+				),
+				minimizer::engine::MinimizerMode::None => {
+					minimizer::MinimizerOutput::passthrough(&buffered.text)
+				},
+				minimizer::engine::MinimizerMode::SegmentedChain => {
+					minimizer::MinimizerOutput::passthrough(&buffered.text)
+				},
+			};
+			// Surface telemetry only when the filter actually rewrote the output
+			// and kept the original buffer — same contract as `apply_shell_minimizer`
+			// in `pi-natives`. A supported filter that runs but leaves the output
+			// unchanged (e.g. a short `git diff --name-only`) reports `changed:
+			// false` with no `original_text` and must NOT set `minimized`, or API
+			// consumers keying off `result.minimized` are misled. The separate
+			// `too-large` reason path above is unaffected.
+			if minimized.changed
+				&& let Some(original_text) = minimized.original_text
+			{
+				let output_bytes = u32::try_from(minimized.text.len()).unwrap_or(u32::MAX);
+				minimized_out = Some(MinimizerResult {
+					filter: minimized.filter.to_string(),
+					text: minimized.text,
+					original_text,
+					input_bytes: u32::try_from(minimized.input_bytes).unwrap_or(u32::MAX),
+					output_bytes,
+				});
+			}
+		}
+	}
+
+	Ok((command_run.result, minimized_out))
+}
+
+async fn run_shell_command_segmented_chain(
+	session: &mut ShellSessionCore,
+	options: &ShellRunConfig,
+	on_chunk: Option<mpsc::UnboundedSender<String>>,
+	cancel_token: CancellationToken,
+) -> Result<(ExecutionResult, Option<MinimizerResult>)> {
+	let Some(config) = options.minimizer.as_ref() else {
+		return run_shell_command_single(
+			session,
+			options,
+			on_chunk,
+			cancel_token,
+			minimizer::engine::MinimizerMode::None,
+		)
+		.await;
+	};
+
+	// When minimizer is disabled, don't segment — stream the original single path.
+	if !config.enabled {
+		return run_shell_command_single(
+			session,
+			options,
+			on_chunk,
+			cancel_token,
+			minimizer::engine::MinimizerMode::None,
+		)
+		.await;
+	}
+
+	let minimizer::plan::CommandPlan::Chain { segments } =
+		minimizer::plan::analyze(&options.command)
+	else {
+		return run_shell_command_single(
+			session,
+			options,
+			on_chunk,
+			cancel_token,
+			minimizer::engine::MinimizerMode::None,
+		)
+		.await;
+	};
+
+	let params = session.shell.default_exec_params();
+	let mut aggregate = Some(ChainCapture::new());
+	let mut previous_succeeded = true;
+	let mut last_result = None;
+	let max_capture_bytes = config.max_capture_bytes as usize;
+	for segment in segments {
+		if segment.run_if_previous_succeeded && !previous_succeeded {
+			continue;
+		}
+
+		let mut segment_params = params.clone();
+		segment_params.suppress_errexit = segment.suppress_errexit;
+		let capture_mode = if aggregate.is_some() {
+			CommandCaptureMode::Buffered { max_capture_bytes }
+		} else {
+			CommandCaptureMode::Streaming
+		};
+
+		let command_run = run_shell_command_once(
+			session,
+			segment.command.clone(),
+			segment_params,
+			on_chunk.clone(),
+			cancel_token.clone(),
+			capture_mode,
+		)
+		.await?;
+
+		let exit = exit_code(&command_run.result);
+		previous_succeeded = exit == 0;
+
+		if let Some(buffered) = command_run.buffered {
+			if buffered.exceeded {
+				// Cap exceeded mid-chain: output streamed raw, drop the buffered
+				// aggregate so the remaining segments stream too. No minimization
+				// happened, so we emit no `minimized` telemetry (see below).
+				aggregate = None;
+			} else if let Some(capture) = aggregate.as_mut() {
+				let next_input_bytes = capture.input_bytes.saturating_add(buffered.input_bytes);
+				if next_input_bytes > max_capture_bytes {
+					aggregate = None;
+				} else {
+					let minimized = minimizer::apply(&segment.command, &buffered.text, exit, config);
+					capture.push(
+						&buffered.text,
+						buffered.input_bytes,
+						&minimized.text,
+						minimized.changed,
+					);
+				}
+			}
+		} else if aggregate.is_some() {
+			aggregate = None;
+		}
+
+		let keep_running = session_keepalive(&command_run.result) && !cancel_token.is_cancelled();
+		last_result = Some(command_run.result);
+		if !keep_running {
+			break;
+		}
+	}
+
+	let Some(result) = last_result else {
+		return Err(Error::msg("Segmented chain executed no segments"));
+	};
+
+	let minimized_out = aggregate
+		// Only surface telemetry when the segmented chain actually rewrote the
+		// output; a `chain-noop` capture (`changed == false`) must yield `None`,
+		// matching the public `ShellRunResult.minimized` contract.
+		.filter(|capture| capture.changed)
+		.map(|capture| {
+			let minimized = minimizer::chain_output(
+				capture.text,
+				capture.original_text,
+				capture.input_bytes,
+				capture.changed,
+			);
+			MinimizerResult {
+				filter:        minimized.filter.to_string(),
+				text:          minimized.text,
+				original_text: minimized.original_text.unwrap_or_default(),
+				input_bytes:   u32::try_from(minimized.input_bytes).unwrap_or(u32::MAX),
+				output_bytes:  u32::try_from(minimized.output_bytes).unwrap_or(u32::MAX),
+			}
+		});
+	// A chain that overflowed the aggregate cap streamed its output raw and was
+	// not minimized — `minimized_out` stays `None`, matching the whole-command
+	// path and `apply_shell_minimizer`. (Previously a `too-large` result with
+	// empty `text` was emitted, a footgun for consumers keying off presence.)
+
+	Ok((result, minimized_out))
+}
+
+async fn run_shell_command_once(
+	session: &mut ShellSessionCore,
+	command: String,
+	mut params: ExecutionParameters,
+	on_chunk: Option<mpsc::UnboundedSender<String>>,
+	cancel_token: CancellationToken,
+	capture_mode: CommandCaptureMode,
+) -> Result<CommandRunOutput> {
 	let (reader_file, writer_file) = pipe_to_files("output")?;
 
 	let stdout_file = OpenFile::from(
@@ -607,7 +882,6 @@ async fn run_shell_command(
 	);
 	let stderr_file = OpenFile::from(writer_file);
 
-	let mut params = session.shell.default_exec_params();
 	params.set_fd(OpenFiles::STDIN_FD, null_file()?);
 	params.set_fd(OpenFiles::STDOUT_FD, stdout_file);
 	params.set_fd(OpenFiles::STDERR_FD, stderr_file);
@@ -616,28 +890,27 @@ async fn run_shell_command(
 	let baseline_descendants = process::current_descendant_pids();
 	let reader_cancel = CancellationToken::new();
 	let (activity_tx, mut activity_rx) = mpsc::channel::<()>(1);
-	// Stream every raw chunk to the caller live, regardless of whether
-	// minimization is enabled. When minimization actually transforms the
-	// output, we propagate the replacement text via `MinimizerResult.text`
-	// so the caller can swap their accumulated buffer for the minimized
-	// version without losing intermediate progress updates.
 	let reader_callback = on_chunk;
 	let mut reader_handle = tokio::spawn({
 		let reader_cancel = reader_cancel.clone();
 		async move {
-			if should_minimize {
-				let output = read_output_buffered(
-					reader_file,
-					reader_callback,
-					reader_cancel,
-					activity_tx,
-					max_capture_bytes,
-				)
-				.await;
-				Result::<OutputRead>::Ok(OutputRead::Buffered(output))
-			} else {
-				Box::pin(read_output(reader_file, reader_callback, reader_cancel, activity_tx)).await;
-				Result::<OutputRead>::Ok(OutputRead::Streaming)
+			match capture_mode {
+				CommandCaptureMode::Buffered { max_capture_bytes } => {
+					let output = read_output_buffered(
+						reader_file,
+						reader_callback,
+						reader_cancel,
+						activity_tx,
+						max_capture_bytes,
+					)
+					.await;
+					Result::<OutputRead>::Ok(OutputRead::Buffered(output))
+				},
+				CommandCaptureMode::Streaming => {
+					Box::pin(read_output(reader_file, reader_callback, reader_cancel, activity_tx))
+						.await;
+					Result::<OutputRead>::Ok(OutputRead::Streaming)
+				},
 			}
 		}
 	});
@@ -660,19 +933,11 @@ async fn run_shell_command(
 	let source_info = SourceInfo::from("pi-natives:command");
 	let result = session
 		.shell
-		.run_string(options.command.clone(), &source_info, &params)
+		.run_string(command, &source_info, &params)
 		.await;
 
 	if cancel_token.is_cancelled() {
 		terminate_background_jobs(&mut session.shell);
-	}
-
-	if env_scope_pushed {
-		session
-			.shell
-			.env_mut()
-			.pop_scope(EnvironmentScope::Command)
-			.map_err(|err| Error::msg(format!("Failed to pop env scope: {err}")))?;
 	}
 
 	drop(params);
@@ -737,33 +1002,11 @@ async fn run_shell_command(
 	}
 
 	let result = result.map_err(|err| Error::msg(format!("Shell execution failed: {err}")))?;
-	let mut minimized_out: Option<MinimizerResult> = None;
-	if let Some(OutputRead::Buffered(output)) = reader_output
-		&& let Some(config) = options.minimizer.as_ref()
-		&& !output.exceeded
-	{
-		let minimized = match minimizer_mode {
-			minimizer::engine::MinimizerMode::WholeCommand => {
-				minimizer::apply(&options.command, &output.text, exit_code(&result), config)
-			},
-			minimizer::engine::MinimizerMode::None => {
-				minimizer::MinimizerOutput::passthrough(&output.text)
-			},
-		};
-		if minimized.changed
-			&& let Some(original) = minimized.original_text
-		{
-			let output_bytes = u32::try_from(minimized.text.len()).unwrap_or(u32::MAX);
-			minimized_out = Some(MinimizerResult {
-				filter: minimized.filter.to_string(),
-				text: minimized.text,
-				original_text: original,
-				input_bytes: u32::try_from(minimized.input_bytes).unwrap_or(u32::MAX),
-				output_bytes,
-			});
-		}
-	}
-	Ok((result, minimized_out))
+	let buffered = match reader_output {
+		Some(OutputRead::Buffered(output)) => Some(output),
+		Some(OutputRead::Streaming) | None => None,
+	};
+	Ok(CommandRunOutput { result, buffered })
 }
 
 async fn run_shell_command_streams(
@@ -824,7 +1067,28 @@ async fn run_shell_command_streams(
 		let baseline_descendants = baseline_descendants.clone();
 		async move {
 			cancel_token.cancelled().await;
-			terminate_new_descendants(&baseline_descendants).await;
+			const WAVES: u32 = 3;
+			for wave in 0..WAVES {
+				let mut targets = process::TerminationTargets::new();
+				process::add_new_descendants(&mut targets, &baseline_descendants);
+				if targets.is_empty() {
+					return;
+				}
+				let signal = if wave == 0 {
+					process::TERM_SIGNAL
+				} else {
+					process::KILL_SIGNAL
+				};
+				targets.signal(signal);
+				if wave + 1 < WAVES {
+					let pause = if wave == 0 {
+						Duration::from_millis(75)
+					} else {
+						Duration::from_millis(150)
+					};
+					time::sleep(pause).await;
+				}
+			}
 		}
 	});
 	let source_info = SourceInfo::from("pi-shell:streams");
@@ -1150,8 +1414,9 @@ enum OutputRead {
 }
 
 struct BufferedOutput {
-	text:     String,
-	exceeded: bool,
+	text:        String,
+	input_bytes: usize,
+	exceeded:    bool,
 }
 
 async fn read_output(
@@ -1272,6 +1537,7 @@ async fn read_output_buffered(
 	const REPLACEMENT: &str = "\u{FFFD}";
 	const BUF: usize = 65536;
 	let mut buf = vec![0u8; BUF];
+	let mut input_bytes = 0usize;
 	let mut captured = Vec::new();
 	let mut exceeded = false;
 	// Pending bytes from a prior read that ended mid-UTF-8 sequence. We hold
@@ -1281,7 +1547,7 @@ async fn read_output_buffered(
 
 	#[cfg(unix)]
 	let Ok(reader) = register_nonblocking_pipe(reader) else {
-		return BufferedOutput { text: String::new(), exceeded: true };
+		return BufferedOutput { text: String::new(), input_bytes: 0, exceeded: true };
 	};
 	#[cfg(not(unix))]
 	let reader = tokio::fs::File::from_std(reader);
@@ -1321,6 +1587,7 @@ async fn read_output_buffered(
 		};
 		if n > 0 {
 			let _ = activity.try_send(());
+			input_bytes = input_bytes.saturating_add(n);
 		}
 		// Once `exceeded`, the post-process minimizer is bypassed (see the
 		// `!output.exceeded` gate at the call site), so further appends just
@@ -1379,7 +1646,7 @@ async fn read_output_buffered(
 		}
 	}
 
-	BufferedOutput { text: String::from_utf8_lossy(&captured).into_owned(), exceeded }
+	BufferedOutput { text: String::from_utf8_lossy(&captured).into_owned(), input_bytes, exceeded }
 }
 
 #[cfg(unix)]
@@ -1692,9 +1959,9 @@ mod tests {
 		/// Brush leading a new pgroup with non-terminal stdin always detaches —
 		/// including the first stage of a pipeline. `setsid()` keeps the child
 		/// off the host's controlling tty; the spawn path skips
-		/// `process_group(...)` for detached children, so later stages no
-		/// longer try to `setpgid`-join a leader that has moved sessions (the
-		/// historical EPERM hazard).
+		/// `process_group(...)` for detached children, so later stages no longer
+		/// try to `setpgid`-join a leader that has moved sessions (the historical
+		/// EPERM hazard).
 		#[test]
 		fn non_terminal_stdin_detaches_regardless_of_pipeline() {
 			assert_eq!(child_session_action(true, false, false), ChildSessionAction::DetachSession,);
@@ -1736,6 +2003,256 @@ mod tests {
 		}
 	}
 
+	#[cfg(unix)]
+	fn shell_test_lock() -> &'static TokioMutex<()> {
+		static LOCK: std::sync::OnceLock<TokioMutex<()>> = std::sync::OnceLock::new();
+		LOCK.get_or_init(|| TokioMutex::new(()))
+	}
+
+	#[cfg(unix)]
+	async fn run_command_capture(
+		command: &str,
+		cwd: Option<&std::path::Path>,
+		minimizer: Option<minimizer::MinimizerOptions>,
+		cancel_token: CancelToken,
+	) -> (ShellExecuteResult, String) {
+		let _guard = shell_test_lock().lock().await;
+		let (tx, mut rx) = mpsc::unbounded_channel::<String>();
+		let options = ShellExecuteOptions {
+			command: command.to_string(),
+			cwd: cwd.map(|path| path.to_string_lossy().into_owned()),
+			minimizer,
+			..Default::default()
+		};
+		let result = execute_shell(options, Some(tx), cancel_token)
+			.await
+			.expect("execute_shell");
+		let mut output = String::new();
+		while let Some(chunk) = rx.recv().await {
+			output.push_str(&chunk);
+		}
+		(result, output)
+	}
+
+	#[cfg(unix)]
+	fn unique_temp_dir(prefix: &str) -> std::path::PathBuf {
+		let mut path = std::env::temp_dir();
+		let nonce = std::time::SystemTime::now()
+			.duration_since(std::time::UNIX_EPOCH)
+			.expect("system time")
+			.as_nanos();
+		path.push(format!("pi-shell-{prefix}-{}-{nonce}", std::process::id()));
+		std::fs::create_dir_all(&path).expect("create temp dir");
+		path
+	}
+
+	#[cfg(unix)]
+	fn printf_minimizer(
+		settings_path: &std::path::Path,
+		max_capture_bytes: Option<u32>,
+	) -> minimizer::MinimizerOptions {
+		std::fs::write(
+			settings_path,
+			r#"
+schema_version = 1
+
+[filters.printf]
+match_command = "^printf$"
+replace = [{ pattern = "hello", replacement = "HI" }]
+"#,
+		)
+		.expect("write settings");
+		minimizer::MinimizerOptions {
+			enabled: Some(true),
+			settings_path: Some(settings_path.to_string_lossy().into_owned()),
+			max_capture_bytes,
+			..Default::default()
+		}
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn segmented_false_and_printf_skips_second_and_returns_nonzero() {
+		let root = unique_temp_dir("false-and");
+		let minimizer = printf_minimizer(&root.join("minimizer.toml"), None);
+		let (result, output) = run_command_capture(
+			"false && printf skipped",
+			None,
+			Some(minimizer),
+			CancelToken::default(),
+		)
+		.await;
+		let _ = std::fs::remove_dir_all(&root);
+		assert_eq!(result.exit_code, Some(1));
+		assert!(!result.cancelled);
+		assert!(!result.timed_out);
+		assert_eq!(output, "");
+		// `false && printf` short-circuits: nothing is rewritten, so a no-op chain
+		// must surface no minimizer telemetry (None).
+		assert!(result.minimized.is_none(), "chain noop must not surface telemetry");
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn segmented_false_semicolon_printf_continues_and_returns_last_code() {
+		let root = unique_temp_dir("false-semi");
+		let minimizer = printf_minimizer(&root.join("minimizer.toml"), None);
+		let (result, output) = run_command_capture(
+			"false ; printf 'hello\n'",
+			None,
+			Some(minimizer),
+			CancelToken::default(),
+		)
+		.await;
+		let _ = std::fs::remove_dir_all(&root);
+		let minimized = result.minimized.expect("minimized result");
+		assert_eq!(result.exit_code, Some(0));
+		assert_eq!(output, "hello\n");
+		assert_eq!(minimized.filter, "chain");
+		assert_eq!(minimized.original_text, "hello\n");
+		assert_eq!(minimized.text, "HI\n");
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn segmented_cd_tmp_and_pwd_persists_state_across_segments() {
+		let root = unique_temp_dir("cwd");
+		let tmp_dir = root.join("tmp");
+		std::fs::create_dir_all(&tmp_dir).expect("create nested tmp dir");
+		let settings_path = root.join("minimizer.toml");
+		std::fs::write(
+			&settings_path,
+			r#"
+schema_version = 1
+
+[filters.pwd]
+match_command = "^pwd$"
+replace = [{ pattern = "^.+$", replacement = "PWD" }]
+"#,
+		)
+		.expect("write settings");
+		let minimizer = minimizer::MinimizerOptions {
+			enabled: Some(true),
+			settings_path: Some(settings_path.to_string_lossy().into_owned()),
+			..Default::default()
+		};
+
+		let expected = format!("{}\n", tmp_dir.display());
+		let (result, output) =
+			run_command_capture("cd tmp && pwd", Some(&root), Some(minimizer), CancelToken::default())
+				.await;
+		let _ = std::fs::remove_dir_all(&root);
+		let minimized = result.minimized.expect("minimized result");
+		assert_eq!(result.exit_code, Some(0));
+		assert_eq!(output, expected);
+		assert_eq!(minimized.filter, "chain");
+		assert_eq!(minimized.text, "PWD\n");
+		assert_eq!(minimized.original_text, expected);
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn whole_command_exceeding_capture_cap_streams_raw_without_minimized() {
+		let root = unique_temp_dir("whole-cap");
+		let minimizer = printf_minimizer(&root.join("minimizer.toml"), Some(1024));
+		let (result, output) =
+			run_command_capture("printf '%1200s' x", None, Some(minimizer), CancelToken::default())
+				.await;
+		let _ = std::fs::remove_dir_all(&root);
+		assert_eq!(result.exit_code, Some(0));
+		assert_eq!(output.len(), 1200);
+		assert!(output.ends_with('x'));
+		// Output exceeded the capture cap: streamed raw and never buffered, so
+		// nothing was minimized. `minimized` must be absent (not a `too-large`
+		// result with empty `text`, which would mislead presence-keyed consumers).
+		assert!(result.minimized.is_none());
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn segmented_printf_chain_preserves_raw_original_text() {
+		let root = unique_temp_dir("minimizer");
+		let minimizer = printf_minimizer(&root.join("minimizer.toml"), None);
+		let (result, output) = run_command_capture(
+			"printf 'hello\n' ; printf 'world\n'",
+			None,
+			Some(minimizer),
+			CancelToken::default(),
+		)
+		.await;
+		let _ = std::fs::remove_dir_all(&root);
+		let minimized = result.minimized.expect("minimized result");
+		assert_eq!(result.exit_code, Some(0));
+		assert_eq!(output, "hello\nworld\n");
+		assert_eq!(minimized.filter, "chain");
+		assert_eq!(minimized.original_text, "hello\nworld\n");
+		assert_eq!(minimized.text, "HI\nworld\n");
+		assert_eq!(minimized.input_bytes, 12);
+		assert_eq!(minimized.output_bytes, 9);
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn segmented_chain_exceeding_aggregate_capture_cap_stays_raw() {
+		let root = unique_temp_dir("aggregate-cap");
+		let minimizer = printf_minimizer(&root.join("minimizer.toml"), Some(1024));
+		let (result, output) = run_command_capture(
+			"printf '%600s' x ; printf '%600s' y",
+			None,
+			Some(minimizer),
+			CancelToken::default(),
+		)
+		.await;
+		let _ = std::fs::remove_dir_all(&root);
+		assert_eq!(result.exit_code, Some(0));
+		assert_eq!(output.len(), 1200);
+		assert!(output.ends_with('y'));
+		// Aggregate cap exceeded: the chain streamed its output raw and was not
+		// minimized, so `minimized` is absent (not an empty-text `too-large`).
+		assert!(result.minimized.is_none());
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn segmented_timeout_in_first_segment_prevents_later_segments() {
+		let root = unique_temp_dir("timeout");
+		let minimizer = printf_minimizer(&root.join("minimizer.toml"), None);
+		let (result, output) = run_command_capture(
+			"sleep 1 && printf later",
+			None,
+			Some(minimizer),
+			CancelToken::new(Some(10)),
+		)
+		.await;
+		let _ = std::fs::remove_dir_all(&root);
+		assert!(result.exit_code.is_none());
+		assert!(!result.cancelled);
+		assert!(result.timed_out);
+		assert!(result.minimized.is_none());
+		assert!(!output.contains("later"));
+	}
+
+	#[cfg(unix)]
+	#[tokio::test(flavor = "multi_thread")]
+	async fn segmented_cancel_in_first_segment_prevents_later_segments() {
+		let root = unique_temp_dir("cancel");
+		let minimizer = printf_minimizer(&root.join("minimizer.toml"), None);
+		let mut cancel_token = CancelToken::default();
+		let abort_token = cancel_token.emplace_abort_token();
+		let cancel_task = tokio::spawn(async move {
+			time::sleep(Duration::from_millis(10)).await;
+			abort_token.abort(AbortReason::Signal);
+		});
+		let (result, output) =
+			run_command_capture("sleep 1 && printf later", None, Some(minimizer), cancel_token).await;
+		let _ = cancel_task.await;
+		let _ = std::fs::remove_dir_all(&root);
+		assert!(result.exit_code.is_none());
+		assert!(result.cancelled);
+		assert!(!result.timed_out);
+		assert!(result.minimized.is_none());
+		assert!(!output.contains("later"));
+	}
 	/// End-to-end verification that brush, when embedded as a non-interactive
 	/// library (`interactive: false`, exactly what `create_session` produces),
 	/// spawns external commands in a **separate session** from the host.
@@ -2024,7 +2541,6 @@ mod tests {
 		assert!(!result.cancelled);
 		assert!(!result.timed_out);
 	}
-
 	#[tokio::test]
 	async fn abort_state_signals_cancel_token() {
 		let abort_state = ShellAbortState::default();

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added opt-in `shellMinimizer.sourceOutlineLevel` and `shellMinimizer.legacyFilters` settings so shell minimization can tune source outlining and selectively fall back to conservative legacy routing.
+
+### Changed
+
+- Bash execution now preserves minimized shell output inline while saving the untouched capture as an `artifact://…` footer when shell minimization rewrites a command's output.
+
 ## [15.10.11] - 2026-06-10
 
 ### Added
@@ -132,14 +140,6 @@
 - Fixed SSH tool cancellation hanging behind OpenSSH ControlMaster streams that stayed open after an Esc/user interrupt ([#2180](https://github.com/can1357/oh-my-pi/issues/2180)).
 - Fixed Windows stdio MCP servers launched through PATH shims such as `codegraph.cmd` so bare commands like `codegraph` resolve via `PATHEXT` before spawn ([#2174](https://github.com/can1357/oh-my-pi/issues/2174)).
 - Fixed compiled-binary extensions failing to load `@oh-my-pi/pi-*` packages when `bun --compile` quietly dropped one of the extra entrypoints (observed on macOS arm64 release builds): the legacy-pi compat shim's package-root override branch returned the bunfs path without checking the target was present, so the rewrite emitted a `file://` URL to a missing module and the #1216 fallback (scoped to the throwing `getResolvedSpecifier` path) never ran. Override targets are now validated against the on-disk filesystem at module init, missing entries are dropped, and resolution falls through to canonical lookup so Bun resolves the import from the extension's own `node_modules` ([#2168](https://github.com/can1357/oh-my-pi/issues/2168)).
-
-### Added
-
-- Added opt-in `shellMinimizer.sourceOutlineLevel` and `shellMinimizer.legacyFilters` settings so shell minimization can tune source outlining and selectively fall back to conservative legacy routing.
-
-### Changed
-
-- Bash execution now preserves minimized shell output inline while saving the untouched capture as an `artifact://…` footer when shell minimization rewrites a command's output.
 
 ## [15.10.8] - 2026-06-09
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -133,6 +133,14 @@
 - Fixed Windows stdio MCP servers launched through PATH shims such as `codegraph.cmd` so bare commands like `codegraph` resolve via `PATHEXT` before spawn ([#2174](https://github.com/can1357/oh-my-pi/issues/2174)).
 - Fixed compiled-binary extensions failing to load `@oh-my-pi/pi-*` packages when `bun --compile` quietly dropped one of the extra entrypoints (observed on macOS arm64 release builds): the legacy-pi compat shim's package-root override branch returned the bunfs path without checking the target was present, so the rewrite emitted a `file://` URL to a missing module and the #1216 fallback (scoped to the throwing `getResolvedSpecifier` path) never ran. Override targets are now validated against the on-disk filesystem at module init, missing entries are dropped, and resolution falls through to canonical lookup so Bun resolves the import from the extension's own `node_modules` ([#2168](https://github.com/can1357/oh-my-pi/issues/2168)).
 
+### Added
+
+- Added opt-in `shellMinimizer.sourceOutlineLevel` and `shellMinimizer.legacyFilters` settings so shell minimization can tune source outlining and selectively fall back to conservative legacy routing.
+
+### Changed
+
+- Bash execution now preserves minimized shell output inline while saving the untouched capture as an `artifact://…` footer when shell minimization rewrites a command's output.
+
 ## [15.10.8] - 2026-06-09
 
 ### Added

--- a/packages/coding-agent/src/cli/shell-cli.ts
+++ b/packages/coding-agent/src/cli/shell-cli.ts
@@ -52,7 +52,7 @@ export async function runShellCommand(cmd: ShellCommandArgs): Promise<void> {
 	const settings = await Settings.init({ cwd });
 	const { shell, env: shellEnv } = settings.getShellConfig();
 	const snapshotPath = cmd.noSnapshot || !shell.includes("bash") ? null : await getOrCreateSnapshot(shell, shellEnv);
-	const minimizer = buildMinimizerOptions(settings.getGroup("shellMinimizer"));
+	const minimizer = await buildMinimizerOptions(settings.getGroup("shellMinimizer"));
 	const shellSession = new Shell({ sessionEnv: shellEnv, snapshotPath: snapshotPath ?? undefined, minimizer });
 
 	let active = false;

--- a/packages/coding-agent/src/cli/shell-cli.ts
+++ b/packages/coding-agent/src/cli/shell-cli.ts
@@ -52,7 +52,7 @@ export async function runShellCommand(cmd: ShellCommandArgs): Promise<void> {
 	const settings = await Settings.init({ cwd });
 	const { shell, env: shellEnv } = settings.getShellConfig();
 	const snapshotPath = cmd.noSnapshot || !shell.includes("bash") ? null : await getOrCreateSnapshot(shell, shellEnv);
-	const minimizer = await buildMinimizerOptions(settings.getGroup("shellMinimizer"));
+	const minimizer = buildMinimizerOptions(settings.getGroup("shellMinimizer"));
 	const shellSession = new Shell({ sessionEnv: shellEnv, snapshotPath: snapshotPath ?? undefined, minimizer });
 
 	let active = false;

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2067,6 +2067,24 @@ export const SETTINGS_SCHEMA = {
 		type: "number",
 		default: 4 * 1024 * 1024,
 	},
+	"shellMinimizer.sourceOutlineLevel": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "editing",
+			label: "Shell Minimizer Source Outline",
+			description: "Source outline mode for cat/read of source files: default or aggressive",
+		},
+	},
+	"shellMinimizer.legacyFilters": {
+		type: "boolean",
+		default: undefined,
+		ui: {
+			tab: "editing",
+			label: "Shell Minimizer Legacy Filters",
+			description: "Optional rollback switch for conservative legacy filter behavior",
+		},
+	},
 
 	// Eval (per-backend toggles; add more as new backends ship, e.g. eval.ts)
 	"eval.py": {
@@ -3461,6 +3479,8 @@ export interface ShellMinimizerSettings {
 	only: string[];
 	except: string[];
 	maxCaptureBytes: number;
+	sourceOutlineLevel: string | undefined;
+	legacyFilters: boolean | undefined;
 }
 
 /** Map group prefix -> typed settings interface */

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2068,8 +2068,9 @@ export const SETTINGS_SCHEMA = {
 		default: 4 * 1024 * 1024,
 	},
 	"shellMinimizer.sourceOutlineLevel": {
-		type: "string",
-		default: undefined,
+		type: "enum",
+		values: ["default", "aggressive"] as const,
+		default: "default",
 		ui: {
 			tab: "editing",
 			label: "Shell Minimizer Source Outline",
@@ -3479,7 +3480,7 @@ export interface ShellMinimizerSettings {
 	only: string[];
 	except: string[];
 	maxCaptureBytes: number;
-	sourceOutlineLevel: string | undefined;
+	sourceOutlineLevel: "default" | "aggressive";
 	legacyFilters: boolean | undefined;
 }
 

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -95,6 +95,8 @@ export function buildMinimizerOptions(group: ShellMinimizerSettings): MinimizerO
 		only: group.only.length > 0 ? group.only : undefined,
 		except: group.except.length > 0 ? group.except : undefined,
 		maxCaptureBytes: group.maxCaptureBytes,
+		sourceOutlineLevel: group.sourceOutlineLevel || undefined,
+		legacyFilters: group.legacyFilters,
 	};
 }
 

--- a/packages/coding-agent/src/exec/bash-executor.ts
+++ b/packages/coding-agent/src/exec/bash-executor.ts
@@ -95,7 +95,7 @@ export function buildMinimizerOptions(group: ShellMinimizerSettings): MinimizerO
 		only: group.only.length > 0 ? group.only : undefined,
 		except: group.except.length > 0 ? group.except : undefined,
 		maxCaptureBytes: group.maxCaptureBytes,
-		sourceOutlineLevel: group.sourceOutlineLevel || undefined,
+		sourceOutlineLevel: group.sourceOutlineLevel === "default" ? undefined : group.sourceOutlineLevel,
 		legacyFilters: group.legacyFilters,
 	};
 }

--- a/packages/coding-agent/test/bash-executor.test.ts
+++ b/packages/coding-agent/test/bash-executor.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
-import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
-import { executeBash } from "@oh-my-pi/pi-coding-agent/exec/bash-executor";
+import { resetSettingsForTest, Settings, type ShellMinimizerSettings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { buildMinimizerOptions, executeBash } from "@oh-my-pi/pi-coding-agent/exec/bash-executor";
 import { DEFAULT_MAX_BYTES } from "@oh-my-pi/pi-coding-agent/session/streaming-output";
 import * as shellSnapshot from "@oh-my-pi/pi-coding-agent/utils/shell-snapshot";
 import type { Shell } from "@oh-my-pi/pi-natives";
@@ -52,6 +52,39 @@ describe("executeBash", () => {
 		}
 	});
 
+	it("omits minimizer options when the feature is disabled", () => {
+		const group: ShellMinimizerSettings = {
+			enabled: false,
+			settingsPath: undefined,
+			only: [],
+			except: [],
+			maxCaptureBytes: 4096,
+			sourceOutlineLevel: "default",
+			legacyFilters: undefined,
+		};
+		expect(buildMinimizerOptions(group)).toBeUndefined();
+	});
+
+	it("forwards source outline and legacy filter settings to native minimizer options", () => {
+		const group: ShellMinimizerSettings = {
+			enabled: true,
+			settingsPath: "minimizer.toml",
+			only: ["git"],
+			except: ["docker"],
+			maxCaptureBytes: 1234,
+			sourceOutlineLevel: "aggressive",
+			legacyFilters: true,
+		};
+		expect(buildMinimizerOptions(group)).toEqual({
+			enabled: true,
+			settingsPath: "minimizer.toml",
+			only: ["git"],
+			except: ["docker"],
+			maxCaptureBytes: 1234,
+			sourceOutlineLevel: "aggressive",
+			legacyFilters: true,
+		});
+	});
 	it("returns non-zero exit codes without cancellation", async () => {
 		const result = await executeBash("exit 7", { cwd: tempDir, timeout: 5000 });
 		expect(result.exitCode).toBe(7);

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added deterministic shell-output minimization to the native shell pipeline, including opt-in per-command rewrite telemetry surfaced through `executeShell().minimized` for callers that want compact inline output plus a separately persisted original capture.
+
 ## [15.10.11] - 2026-06-10
 
 ### Added
@@ -17,10 +21,6 @@
 ### Fixed
 
 - Fixed cross-line grep being a silent no-op on real files: `multiline` set the `(?m)` flag on the regex matcher but never enabled `multi_line` on the `Searcher`, which stayed line-oriented, so any pattern spanning a `\n` returned zero matches with no error.
-
-### Added
-
-- Added deterministic shell-output minimization to the native shell pipeline, including opt-in per-command rewrite telemetry surfaced through `executeShell().minimized` for callers that want compact inline output plus a separately persisted original capture.
 
 ## [15.10.5] - 2026-06-08
 

--- a/packages/natives/CHANGELOG.md
+++ b/packages/natives/CHANGELOG.md
@@ -18,6 +18,10 @@
 
 - Fixed cross-line grep being a silent no-op on real files: `multiline` set the `(?m)` flag on the regex matcher but never enabled `multi_line` on the `Searcher`, which stayed line-oriented, so any pattern spanning a `\n` returned zero matches with no error.
 
+### Added
+
+- Added deterministic shell-output minimization to the native shell pipeline, including opt-in per-command rewrite telemetry surfaced through `executeShell().minimized` for callers that want compact inline output plus a separately persisted original capture.
+
 ## [15.10.5] - 2026-06-08
 
 ### Added

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -148,6 +148,27 @@ export declare function __piNativesV15_10_11(): void
 export declare function applyBashFixups(command: string): BashFixupResult
 
 /**
+ * Run the shell-output minimizer over an already-captured command result,
+ * without spawning a shell.
+ *
+ * This is the one-shot counterpart to the minimization that
+ * [`execute_shell`] performs inline: callers that captured a command's output
+ * elsewhere can pass it here to obtain the same telemetry.
+ *
+ * Returns [`MinimizerResult`] **only** when the minimizer actually rewrote the
+ * output (`changed == true`) and retained the original buffer, mirroring the
+ * persistent-shell path. Returns `null` for every no-op case: when
+ * `minimizer` is omitted, when the config is disabled, or when the filter
+ * passes the output through unchanged. A missing `exit_code` is treated as
+ * success (`0`).
+ *
+ * Async (returns a Promise): minimization can scan multi-megabyte captured
+ * output, so the work runs on a blocking pool to avoid stalling the JS event
+ * loop.
+ */
+export declare function applyShellMinimizer(options: ShellMinimizerApplyOptions): Promise<MinimizerResult | null>
+
+/**
  * Apply ast-grep rewrite rules to matching files; honors `dryRun` and returns
  * a promise.
  */
@@ -1139,6 +1160,18 @@ export interface MinimizerOptions {
    * the raw, un-minimized output. Default 4 MiB.
    */
   maxCaptureBytes?: number
+  /**
+   * Source-outline level for `cat <source-file>` minimization. Accepts
+   * `"default"` (current behavior) or `"aggressive"` (strip function bodies).
+   */
+  sourceOutlineLevel?: string
+  /**
+   * Kill-switch to fall back to the pre-PR (legacy) filter behavior for
+   * grep / find / pytest. When `Some(true)`, filters that opted into the
+   * always-shrink Tier 1 / Tier 2 behavior skip the new code path. When
+   * `None`, defers to the `OMP_MINIMIZER_LEGACY_FILTERS` env var.
+   */
+  legacyFilters?: boolean
 }
 
 /**
@@ -1339,6 +1372,21 @@ export interface ShellExecuteOptions {
   minimizer?: MinimizerOptions
   /** Abort signal for cancelling the operation. */
   signal?: unknown
+}
+
+/**
+ * Inputs for [`apply_shell_minimizer`]: a captured command's text plus the
+ * minimizer configuration to run against it.
+ */
+export interface ShellMinimizerApplyOptions {
+  /** The command line that produced `captured` (used to select a filter). */
+  command: string
+  /** The full captured stdout/stderr to minimize. */
+  captured: string
+  /** The command's exit status; omitted is treated as success (`0`). */
+  exitCode?: number
+  /** Minimizer configuration; when omitted the call is a no-op (`null`). */
+  minimizer?: MinimizerOptions
 }
 
 /** Options for configuring a persistent shell session. */

--- a/packages/natives/native/index.d.ts
+++ b/packages/natives/native/index.d.ts
@@ -148,27 +148,6 @@ export declare function __piNativesV15_10_11(): void
 export declare function applyBashFixups(command: string): BashFixupResult
 
 /**
- * Run the shell-output minimizer over an already-captured command result,
- * without spawning a shell.
- *
- * This is the one-shot counterpart to the minimization that
- * [`execute_shell`] performs inline: callers that captured a command's output
- * elsewhere can pass it here to obtain the same telemetry.
- *
- * Returns [`MinimizerResult`] **only** when the minimizer actually rewrote the
- * output (`changed == true`) and retained the original buffer, mirroring the
- * persistent-shell path. Returns `null` for every no-op case: when
- * `minimizer` is omitted, when the config is disabled, or when the filter
- * passes the output through unchanged. A missing `exit_code` is treated as
- * success (`0`).
- *
- * Async (returns a Promise): minimization can scan multi-megabyte captured
- * output, so the work runs on a blocking pool to avoid stalling the JS event
- * loop.
- */
-export declare function applyShellMinimizer(options: ShellMinimizerApplyOptions): Promise<MinimizerResult | null>
-
-/**
  * Apply ast-grep rewrite rules to matching files; honors `dryRun` and returns
  * a promise.
  */
@@ -1372,21 +1351,6 @@ export interface ShellExecuteOptions {
   minimizer?: MinimizerOptions
   /** Abort signal for cancelling the operation. */
   signal?: unknown
-}
-
-/**
- * Inputs for [`apply_shell_minimizer`]: a captured command's text plus the
- * minimizer configuration to run against it.
- */
-export interface ShellMinimizerApplyOptions {
-  /** The command line that produced `captured` (used to select a filter). */
-  command: string
-  /** The full captured stdout/stderr to minimize. */
-  captured: string
-  /** The command's exit status; omitted is treated as success (`0`). */
-  exitCode?: number
-  /** Minimizer configuration; when omitted the call is a no-op (`null`). */
-  minimizer?: MinimizerOptions
 }
 
 /** Options for configuring a persistent shell session. */

--- a/packages/natives/native/index.js
+++ b/packages/natives/native/index.js
@@ -25,6 +25,7 @@ export const Shell = nativeBindings.Shell;
 // functions
 export const __piNativesV15_10_11 = nativeBindings.__piNativesV15_10_11;
 export const applyBashFixups = nativeBindings.applyBashFixups;
+export const applyShellMinimizer = nativeBindings.applyShellMinimizer;
 export const astEdit = nativeBindings.astEdit;
 export const astGrep = nativeBindings.astGrep;
 export const astMatch = nativeBindings.astMatch;

--- a/packages/natives/native/index.js
+++ b/packages/natives/native/index.js
@@ -25,7 +25,6 @@ export const Shell = nativeBindings.Shell;
 // functions
 export const __piNativesV15_10_11 = nativeBindings.__piNativesV15_10_11;
 export const applyBashFixups = nativeBindings.applyBashFixups;
-export const applyShellMinimizer = nativeBindings.applyShellMinimizer;
 export const astEdit = nativeBindings.astEdit;
 export const astGrep = nativeBindings.astGrep;
 export const astMatch = nativeBindings.astMatch;


### PR DESCRIPTION
Clean replacement for #2041.

This PR keeps the deterministic shell-output minimizer work and drops unrelated fork-only scope from the prior branch.

Supersedes / references:
- #2041
- #2104
- #1750
- #2017

## What this PR does

Adds deterministic, offline shell-output minimization to the native shell pipeline and wires the coding-agent/bash path to surface minimized output while preserving the lossless original capture behind an `artifact://...` footer when output is rewritten.

Behavioral constraints:
- `MinimizerConfig.enabled` defaults to `false`
- no network-backed summarization
- no `reqwest` / TLS path
- too-large captures pass through instead of partially minimizing
- unsafe whole-buffer chains stay opaque instead of being falsely recombined

Coverage includes:
- git
- cargo / rustfmt / gcc-family output
- bun / node test & check output
- docker / compose listings and log detection
- aws / curl / wget / psql
- ls / find / grep / rg routing
- source-file outlining

## Reviewer follow-up requested in #2104

### Regression coverage

This branch includes per-filter regression tests for the dominant savings paths:
- `git`: failure-line survival, short-log collapse, merge/rebase conflict preservation, `push --porcelain` passthrough
- `cargo test`: failure preserves panic/failures/FAILED summary; success collapses to a one-line summary; non-zero exits do not become false passes
- `bun`: failure preserves `FAIL <file>`, error body, totals; `bun run check:ts` preserves diagnostics + failed verdict; success strips noise but preserves verdict

### Concrete before/after captures on identical inputs

Repro on this branch:

```bash
cargo test -p pi-shell --lib pr_vs_upstream_savings -- --nocapture --ignored
```

#### `bun run test` — 200 passing tests

**Upstream / generic path**
```text
✓ src/minimizer.test.ts > case_0 (3ms)
✓ src/minimizer.test.ts > case_1 (3ms)
... [197 more lines]
Tests 200 passed (0.62s)
```
6,777 bytes / ~1,694 tokens

**This PR / `node_tests::filter`**
```text
Tests 200 passed (0.62s)
```
25 bytes / ~6 tokens — ~99% shrink, ~1,688 tokens saved

#### `bun run check:ts` — 3-package clean workspace

**Upstream / generic path**
```text
$ bun run --workspaces check
Checked 1690 files in 371ms. No fixes applied.
@oh-my-pi/pi-utils check: Checked 40 files in 11ms. No fixes applied.
@oh-my-pi/pi-utils check: $ tsgo -p tsconfig.json --noEmit
@oh-my-pi/pi-utils check: Exited with code 0
@oh-my-pi/pi-coding-agent check: Checked 1178 files in 287ms. No fixes applied.
@oh-my-pi/pi-coding-agent check: $ tsgo -p tsconfig.json --noEmit
@oh-my-pi/pi-coding-agent check: Exited with code 0
@oh-my-pi/pi-tui check: Checked 312 files in 48ms. No fixes applied.
@oh-my-pi/pi-tui check: $ tsgo -p tsconfig.json --noEmit
@oh-my-pi/pi-tui check: Exited with code 0
```
617 bytes / ~154 tokens

**This PR / `filter_bun_check`**
```text
check:ts: passed
root biome: ok
packages checked: @oh-my-pi/pi-utils, @oh-my-pi/pi-coding-agent, @oh-my-pi/pi-tui
```
114 bytes / ~28 tokens — ~81% shrink, ~126 tokens saved per run

#### `cargo test` — 429 tests, 1 suite

**Upstream / current routing**
429 individual `test foo::bar ... ok` lines, 35,652 bytes / ~8,913 tokens

**This PR**
```text
cargo test: 429 passed (1 suite, 42 filtered, 0.01s)
```
53 bytes / ~13 tokens — ~99% shrink

## Verification

Focused checks on this branch:

```bash
bun run check:rs
cargo test -p pi-shell minimizer --quiet
bun test packages/coding-agent/test/bash-executor.test.ts
```

All pass locally.
