### PR TITLE
fix(ai): widen first-event watchdog for DeepSeek V4 reasoning

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Widened the OpenAI-completions first-event watchdog floor from 120s to 300s for DeepSeek V4 reasoning models hosted on the official DeepSeek API. The reasoner emits no SSE bytes until its private chain-of-thought finishes, which routinely takes longer than the generic 100s first-event budget under load — every chat then aborted with `OpenAI completions stream timed out while waiting for the first event` and silently retried. Mirrors the existing GLM coding-plan widening ([#2177](https://github.com/can1357/oh-my-pi/issues/2177)).
+
 ## [15.10.8] - 2026-06-09
 ### Added
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -392,17 +392,36 @@ const OPENAI_COMPLETIONS_FIRST_EVENT_TIMEOUT_MESSAGE =
 const GLM_CODING_PLAN_STREAM_IDLE_TIMEOUT_MS = 600_000;
 const GLM_CODING_PLAN_MODEL_PATTERN = /^glm-5(?:[.-]|$)/i;
 
-/** Returns the widened OpenAI stream watchdog floor for slow GLM coding-plan reasoning models. */
+// DeepSeek V4 reasoning models on the official api.deepseek.com emit no SSE
+// bytes while the model finishes its private chain-of-thought, which routinely
+// takes longer than the generic 100s first-event floor under load (issue
+// #2177). Mirror the GLM coding-plan widening: a 5-minute idle floor lifts the
+// first-event watchdog (it floors at idle) without changing the runtime
+// streaming behavior, so reasoning warm-ups stop aborting and retrying.
+const DEEPSEEK_REASONING_STREAM_IDLE_TIMEOUT_MS = 300_000;
+
+function isDirectDeepseekReasoningModel(model: Model<"openai-completions">): boolean {
+	if (!model.reasoning) return false;
+	if (model.provider === "deepseek") return true;
+	return model.baseUrl.toLowerCase().includes("api.deepseek.com");
+}
+
+/** Returns the widened OpenAI stream watchdog floor for slow reasoning models hosted on OpenAI-compatible endpoints. */
 export function getOpenAICompletionsStreamIdleTimeoutFallbackMs(
 	model: Model<"openai-completions">,
 ): number | undefined {
-	if (!GLM_CODING_PLAN_MODEL_PATTERN.test(model.id)) return undefined;
-	if (model.provider === "zhipu-coding-plan" || model.provider === "zai")
-		return GLM_CODING_PLAN_STREAM_IDLE_TIMEOUT_MS;
+	if (GLM_CODING_PLAN_MODEL_PATTERN.test(model.id)) {
+		if (model.provider === "zhipu-coding-plan" || model.provider === "zai")
+			return GLM_CODING_PLAN_STREAM_IDLE_TIMEOUT_MS;
 
-	const baseUrl = model.baseUrl.toLowerCase();
-	if (baseUrl.includes("open.bigmodel.cn") || baseUrl.includes("api.z.ai")) {
-		return GLM_CODING_PLAN_STREAM_IDLE_TIMEOUT_MS;
+		const baseUrl = model.baseUrl.toLowerCase();
+		if (baseUrl.includes("open.bigmodel.cn") || baseUrl.includes("api.z.ai")) {
+			return GLM_CODING_PLAN_STREAM_IDLE_TIMEOUT_MS;
+		}
+	}
+
+	if (isDirectDeepseekReasoningModel(model)) {
+		return DEEPSEEK_REASONING_STREAM_IDLE_TIMEOUT_MS;
 	}
 
 	return undefined;

--- a/packages/ai/test/openai-completions-progress-chunk.test.ts
+++ b/packages/ai/test/openai-completions-progress-chunk.test.ts
@@ -103,6 +103,58 @@ describe("getOpenAICompletionsStreamIdleTimeoutFallbackMs", () => {
 		expect(getOpenAICompletionsStreamIdleTimeoutFallbackMs(model)).toBe(600_000);
 	});
 
+	it("widens DeepSeek V4 reasoning streams on the official DeepSeek API", () => {
+		const model = {
+			...openAICompletionsModel,
+			id: "deepseek-v4-pro",
+			name: "DeepSeek V4 Pro",
+			provider: "deepseek",
+			baseUrl: "https://api.deepseek.com",
+			reasoning: true,
+		} satisfies Model<"openai-completions">;
+
+		expect(getOpenAICompletionsStreamIdleTimeoutFallbackMs(model)).toBe(300_000);
+	});
+
+	it("widens DeepSeek reasoning streams routed through an aliased OpenAI-compatible provider id", () => {
+		const model = {
+			...openAICompletionsModel,
+			id: "deepseek-v4-pro",
+			name: "DeepSeek V4 Pro",
+			provider: "openai",
+			baseUrl: "https://api.deepseek.com/v1",
+			reasoning: true,
+		} satisfies Model<"openai-completions">;
+
+		expect(getOpenAICompletionsStreamIdleTimeoutFallbackMs(model)).toBe(300_000);
+	});
+
+	it("leaves non-reasoning DeepSeek-hosted models on the global timeout", () => {
+		const model = {
+			...openAICompletionsModel,
+			id: "deepseek-chat",
+			name: "DeepSeek Chat",
+			provider: "deepseek",
+			baseUrl: "https://api.deepseek.com",
+			reasoning: false,
+		} satisfies Model<"openai-completions">;
+
+		expect(getOpenAICompletionsStreamIdleTimeoutFallbackMs(model)).toBeUndefined();
+	});
+
+	it("does not widen DeepSeek V4 reasoning models hosted on third-party OpenAI-compatible proxies", () => {
+		const model = {
+			...openAICompletionsModel,
+			id: "deepseek-v4-pro",
+			name: "DeepSeek V4 Pro",
+			provider: "aimlapi",
+			baseUrl: "https://api.aimlapi.com/v1",
+			reasoning: true,
+		} satisfies Model<"openai-completions">;
+
+		expect(getOpenAICompletionsStreamIdleTimeoutFallbackMs(model)).toBeUndefined();
+	});
+
 	it("keeps ordinary OpenAI-compatible models on the global timeout", () => {
 		expect(getOpenAICompletionsStreamIdleTimeoutFallbackMs(openAICompletionsModel)).toBeUndefined();
 	});


### PR DESCRIPTION
## Repro

Every chat against `deepseek-v4-pro` (or `deepseek-v4-flash`) on the official DeepSeek API aborts once with `OpenAI completions stream timed out while waiting for the first event` before the agent retries and the second attempt succeeds. Reproduced at the helper level on this branch:

```
{ id: "deepseek-v4-pro", provider: "deepseek", baseUrl: "https://api.deepseek.com", reasoning: true }
{ idleTimeoutFallbackMs: undefined, idleTimeoutMs: 120000, firstEventTimeoutMs: 120000 }
```

A 120s first-event budget is the same generic floor every OpenAI-compat provider gets (`max(100000 fallback, 120000 idle)`).

## Cause

`getOpenAICompletionsStreamIdleTimeoutFallbackMs` in `packages/ai/src/providers/openai-completions.ts` only widens the idle/first-event floor for GLM coding-plan reasoning models. DeepSeek V4 is a reasoning model that emits no SSE bytes while its private chain-of-thought is running — under load on `api.deepseek.com` this routinely runs past 100s, so `firstEventTimeoutAbortError` (line 440) trips before the first token lands. The error is bubbled, the agent retries, and the warm second attempt usually beats the cold reasoning path. That matches the "errors every chat, then retries succeed" symptom and the reporter's pi-coding-agent comparison (no equivalent watchdog there).

## Fix

- Extended `getOpenAICompletionsStreamIdleTimeoutFallbackMs` with a `DEEPSEEK_REASONING_STREAM_IDLE_TIMEOUT_MS = 300_000` branch for any `model.reasoning === true` whose `provider === "deepseek"` or whose `baseUrl` includes `api.deepseek.com`. Idle floors first-event, so the watchdog gains 5 minutes for reasoning warm-up without changing steady-state streaming behavior. The GLM branch is unchanged.
- Added `isDirectDeepseekReasoningModel(model)` helper to keep the scoping readable and the gate easy to extend.
- Added 4 regression tests in `packages/ai/test/openai-completions-progress-chunk.test.ts` covering: official `deepseek` provider widening, baseUrl-only widening (aliased provider id), non-reasoning DeepSeek-hosted models staying on the global floor, and third-party DeepSeek-V4-Pro hosts (e.g. `aimlapi`) staying on the global floor.
- Added `CHANGELOG.md` entry under `[Unreleased]` → `Fixed`.

## Verification

```
$ bun --cwd=packages/ai test test/openai-completions-progress-chunk.test.ts test/openai-first-event-timeout.test.ts
 42 pass
 0 fail
 79 expect() calls
```

Helper probe confirms the resolved budget moves from 120s to 300s for the affected models without touching unrelated provider/host combinations:

```
deepseek-v4-pro                   { idleFallback: 300000, idle: 300000, firstEvent: 300000 }
deepseek-v4-flash                 { idleFallback: 300000, idle: 300000, firstEvent: 300000 }
synthetic non-reasoning deepseek  { idleFallback: undefined }
aimlapi deepseek-v4-pro           { idleFallback: undefined, baseUrl: "https://api.aimlapi.com/v1" }
```

Fixes #2177