### PR TITLE
fix(ssh): cancel ControlMaster stream waits on abort

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed SSH tool cancellation hanging behind OpenSSH ControlMaster streams that stayed open after an Esc/user interrupt ([#2180](https://github.com/can1357/oh-my-pi/issues/2180)).
+
 ## [15.10.8] - 2026-06-09
 
 ### Added

--- a/packages/coding-agent/src/ssh/ssh-executor.ts
+++ b/packages/coding-agent/src/ssh/ssh-executor.ts
@@ -42,6 +42,42 @@ export interface SSHResult {
 	artifactId?: string;
 }
 
+type SSHExitEvent = { kind: "exit"; exitCode: number } | { kind: "error"; error: unknown };
+
+function sshExitEvent(exitCode: number): SSHExitEvent {
+	return { kind: "exit", exitCode };
+}
+
+function sshErrorEvent(error: unknown): SSHExitEvent {
+	return { kind: "error", error };
+}
+
+function createAbortWaiter(
+	signal: AbortSignal | undefined,
+	streamAbort: AbortController,
+): { promise: Promise<ptree.AbortError> | undefined; cleanup: () => void } {
+	if (!signal) {
+		return { promise: undefined, cleanup: () => {} };
+	}
+
+	const { promise, resolve } = Promise.withResolvers<ptree.AbortError>();
+	const onAbort = () => {
+		const error = new ptree.AbortError(signal.reason, "<cancelled>");
+		if (!streamAbort.signal.aborted) {
+			streamAbort.abort(error);
+		}
+		resolve(error);
+	};
+
+	if (signal.aborted) {
+		onAbort();
+		return { promise, cleanup: () => {} };
+	}
+
+	signal.addEventListener("abort", onAbort, { once: true });
+	return { promise, cleanup: () => signal.removeEventListener("abort", onAbort) };
+}
+
 function quoteForCompatShell(command: string): string {
 	if (command.length === 0) {
 		return "''";
@@ -94,19 +130,34 @@ export async function executeSSH(
 		maxColumns: resolveOutputMaxColumns(settings),
 	});
 
-	const streams = [child.stdout.pipeTo(sink.createInput())];
+	const streamAbort = new AbortController();
+	const abortWaiter = createAbortWaiter(options?.signal, streamAbort);
+	const streamOptions = { signal: streamAbort.signal };
+	const streams = [child.stdout.pipeTo(sink.createInput(), streamOptions)];
 	if (child.stderr) {
-		streams.push(child.stderr.pipeTo(sink.createInput()));
+		streams.push(child.stderr.pipeTo(sink.createInput(), streamOptions));
 	}
-	await Promise.allSettled(streams).catch(() => {});
+	const streamsSettled = Promise.allSettled(streams).then(() => {});
 
 	try {
+		const exitEvent = child.exited.then(sshExitEvent, sshErrorEvent);
+		const abortEvent = abortWaiter.promise?.then(sshErrorEvent);
+		const event = await (abortEvent ? Promise.race([exitEvent, abortEvent]) : exitEvent);
+		if (event.kind === "error") {
+			throw event.error;
+		}
+
+		await streamsSettled;
 		return {
-			exitCode: await child.exited,
+			exitCode: event.exitCode,
 			cancelled: false,
 			...(await sink.dump()),
 		};
 	} catch (err) {
+		if (!streamAbort.signal.aborted) {
+			streamAbort.abort(err);
+		}
+		void streamsSettled;
 		if (err instanceof ptree.Exception) {
 			if (err instanceof ptree.TimeoutError) {
 				return {
@@ -129,5 +180,7 @@ export async function executeSSH(
 			};
 		}
 		throw err;
+	} finally {
+		abortWaiter.cleanup();
 	}
 }

--- a/packages/coding-agent/src/ssh/ssh-executor.ts
+++ b/packages/coding-agent/src/ssh/ssh-executor.ts
@@ -147,7 +147,10 @@ export async function executeSSH(
 			throw event.error;
 		}
 
-		await streamsSettled;
+		const streamEvent = await (abortEvent ? Promise.race([streamsSettled, abortEvent]) : streamsSettled);
+		if (streamEvent?.kind === "error") {
+			throw streamEvent.error;
+		}
 		return {
 			exitCode: event.exitCode,
 			cancelled: false,

--- a/packages/coding-agent/test/ssh/ssh-executor.test.ts
+++ b/packages/coding-agent/test/ssh/ssh-executor.test.ts
@@ -14,13 +14,13 @@ function createNeverClosingStream(): ReadableStream<Uint8Array> {
 	});
 }
 
-function createBlockedChild<In extends TestStdin>(): ChildProcess<In> {
+function createBlockedChild<In extends TestStdin>(exited?: Promise<number>): ChildProcess<In> {
 	const { promise } = Promise.withResolvers<number>();
 
 	return {
 		stdout: createNeverClosingStream(),
 		stderr: undefined,
-		exited: promise,
+		exited: exited ?? promise,
 		[Symbol.dispose]() {},
 	} as unknown as ChildProcess<In>;
 }
@@ -36,19 +36,49 @@ describe("executeSSH", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("returns promptly when an abort races a ControlMaster stream that stays open", async () => {
+	function mockOpenStreamChild(exited?: Promise<number>) {
 		vi.spyOn(connectionManager, "ensureConnection").mockResolvedValue();
 		vi.spyOn(connectionManager, "buildRemoteCommand").mockResolvedValue(["remote", "sleep 60"]);
 		vi.spyOn(sshfsMount, "hasSshfs").mockReturnValue(false);
-		vi.spyOn(ptree, "spawn").mockImplementation(<In extends TestStdin>() => createBlockedChild<In>());
+		vi.spyOn(ptree, "spawn").mockImplementation(<In extends TestStdin>() => createBlockedChild<In>(exited));
+	}
 
+	function startOpenStreamCommand(controller: AbortController) {
 		const chunked = Promise.withResolvers<void>();
-		const controller = new AbortController();
 		const resultPromise = executeSSH({ name: "remote", host: "remote" }, "sleep 60", {
 			signal: controller.signal,
 			onChunk: () => chunked.resolve(),
 		});
-		await chunked.promise;
+		return { resultPromise, chunked: chunked.promise };
+	}
+
+	it("returns promptly when an abort races a ControlMaster stream that stays open", async () => {
+		mockOpenStreamChild();
+
+		const controller = new AbortController();
+		const { resultPromise, chunked } = startOpenStreamCommand(controller);
+		await chunked;
+
+		let result: Awaited<typeof resultPromise> | undefined;
+		resultPromise.then(value => {
+			result = value;
+		});
+		controller.abort("user interrupt");
+		await flushMicrotasks(20);
+		expect(result).toBeDefined();
+		if (!result) return;
+		expect(result.cancelled).toBe(true);
+		expect(result.exitCode).toBeUndefined();
+		expect(result.output).toContain("Command aborted");
+	});
+
+	it("reports cancellation when abort unblocks streams after the ssh process exits", async () => {
+		mockOpenStreamChild(Promise.resolve(0));
+
+		const controller = new AbortController();
+		const { resultPromise, chunked } = startOpenStreamCommand(controller);
+		await chunked;
+		await flushMicrotasks(20);
 
 		let result: Awaited<typeof resultPromise> | undefined;
 		resultPromise.then(value => {

--- a/packages/coding-agent/test/ssh/ssh-executor.test.ts
+++ b/packages/coding-agent/test/ssh/ssh-executor.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "bun:test";
+import * as connectionManager from "@oh-my-pi/pi-coding-agent/ssh/connection-manager";
+import { executeSSH } from "@oh-my-pi/pi-coding-agent/ssh/ssh-executor";
+import * as sshfsMount from "@oh-my-pi/pi-coding-agent/ssh/sshfs-mount";
+import { type ChildProcess, ptree } from "@oh-my-pi/pi-utils";
+
+type TestStdin = "pipe" | "ignore" | Buffer | Uint8Array | null;
+
+function createNeverClosingStream(): ReadableStream<Uint8Array> {
+	return new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(new TextEncoder().encode("started\n"));
+		},
+	});
+}
+
+function createBlockedChild<In extends TestStdin>(): ChildProcess<In> {
+	const { promise } = Promise.withResolvers<number>();
+
+	return {
+		stdout: createNeverClosingStream(),
+		stderr: undefined,
+		exited: promise,
+		[Symbol.dispose]() {},
+	} as unknown as ChildProcess<In>;
+}
+
+async function flushMicrotasks(count: number): Promise<void> {
+	for (let i = 0; i < count; i++) {
+		await Promise.resolve();
+	}
+}
+
+describe("executeSSH", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("returns promptly when an abort races a ControlMaster stream that stays open", async () => {
+		vi.spyOn(connectionManager, "ensureConnection").mockResolvedValue();
+		vi.spyOn(connectionManager, "buildRemoteCommand").mockResolvedValue(["remote", "sleep 60"]);
+		vi.spyOn(sshfsMount, "hasSshfs").mockReturnValue(false);
+		vi.spyOn(ptree, "spawn").mockImplementation(<In extends TestStdin>() => createBlockedChild<In>());
+
+		const chunked = Promise.withResolvers<void>();
+		const controller = new AbortController();
+		const resultPromise = executeSSH({ name: "remote", host: "remote" }, "sleep 60", {
+			signal: controller.signal,
+			onChunk: () => chunked.resolve(),
+		});
+		await chunked.promise;
+
+		let result: Awaited<typeof resultPromise> | undefined;
+		resultPromise.then(value => {
+			result = value;
+		});
+		controller.abort("user interrupt");
+		await flushMicrotasks(20);
+		expect(result).toBeDefined();
+		if (!result) return;
+		expect(result.cancelled).toBe(true);
+		expect(result.exitCode).toBeUndefined();
+		expect(result.output).toContain("Command aborted");
+	});
+});


### PR DESCRIPTION
## Repro
A focused executor regression test simulates an SSH command whose stdout stream remains open after the user interrupt path fires, matching an OpenSSH ControlMaster/mux session that keeps the remote `sleep 60` stream alive. Command: `bun test test/ssh/ssh-executor.test.ts` from `packages/coding-agent`; before the fix the test failed because `executeSSH()` never produced a result after `controller.abort("user interrupt")`.

## Cause
`packages/coding-agent/src/ssh/ssh-executor.ts` awaited `Promise.allSettled()` for stdout/stderr `pipeTo()` drains before observing `child.exited`. When ControlMaster kept the stream open after Esc killed or detached the mux client, the executor stayed blocked on stream drainage and never reached the abort handling path.

## Fix
- Added an abort waiter in `executeSSH()` that races the child exit with the tool `AbortSignal`.
- Aborted stdout/stderr pipe drains on cancellation so open ControlMaster streams cannot hold the tool result hostage.
- Added `packages/coding-agent/test/ssh/ssh-executor.test.ts` to lock the open-stream interrupt case.
- Added a coding-agent changelog entry for #2180.

## Verification
Passed `bun test test/ssh/ssh-executor.test.ts test/ssh/connection-manager.test.ts` and `bun run check` in `packages/coding-agent`. `gh_push_branch` also completed its pre-publish gate. Fixes #2180