### PR TITLE
feat(ai): add Volcengine Coding Plan (火山引擎) provider

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+
+- Added Volcengine Coding Plan (火山引擎) as a new upstream provider (`volcengine-coding-plan`) with 10 bundled models including `doubao-seed-2.0-code` as the default, using Anthropic-compatible wire protocol with bearer auth
 
 ## [15.10.8] - 2026-06-09
 ### Added

--- a/packages/ai/src/models.json
+++ b/packages/ai/src/models.json
@@ -69029,5 +69029,213 @@
 				"maxLevel": "xhigh"
 			}
 		}
+	},
+	"volcengine-coding-plan": {
+		"doubao-seed-2.0-code": {
+			"id": "doubao-seed-2.0-code",
+			"name": "Doubao Seed 2.0 Code",
+			"api": "anthropic-messages",
+			"provider": "volcengine-coding-plan",
+			"baseUrl": "https://ark.cn-beijing.volces.com/api/coding",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384
+		},
+		"doubao-seed-2.0-pro": {
+			"id": "doubao-seed-2.0-pro",
+			"name": "Doubao Seed 2.0 Pro",
+			"api": "anthropic-messages",
+			"provider": "volcengine-coding-plan",
+			"baseUrl": "https://ark.cn-beijing.volces.com/api/coding",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384
+		},
+		"doubao-seed-2.0-lite": {
+			"id": "doubao-seed-2.0-lite",
+			"name": "Doubao Seed 2.0 Lite",
+			"api": "anthropic-messages",
+			"provider": "volcengine-coding-plan",
+			"baseUrl": "https://ark.cn-beijing.volces.com/api/coding",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384
+		},
+		"doubao-seed-code": {
+			"id": "doubao-seed-code",
+			"name": "Doubao Seed Code",
+			"api": "anthropic-messages",
+			"provider": "volcengine-coding-plan",
+			"baseUrl": "https://ark.cn-beijing.volces.com/api/coding",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384
+		},
+		"minimax-m2.7": {
+			"id": "minimax-m2.7",
+			"name": "MiniMax M2.7",
+			"api": "anthropic-messages",
+			"provider": "volcengine-coding-plan",
+			"baseUrl": "https://ark.cn-beijing.volces.com/api/coding",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384
+		},
+		"minimax-m3": {
+			"id": "minimax-m3",
+			"name": "MiniMax M3",
+			"api": "anthropic-messages",
+			"provider": "volcengine-coding-plan",
+			"baseUrl": "https://ark.cn-beijing.volces.com/api/coding",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384
+		},
+		"glm-5.1": {
+			"id": "glm-5.1",
+			"name": "GLM-5.1",
+			"api": "anthropic-messages",
+			"provider": "volcengine-coding-plan",
+			"baseUrl": "https://ark.cn-beijing.volces.com/api/coding",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 200000,
+			"maxTokens": 131072,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"deepseek-v4-flash": {
+			"id": "deepseek-v4-flash",
+			"name": "DeepSeek V4 Flash",
+			"api": "anthropic-messages",
+			"provider": "volcengine-coding-plan",
+			"baseUrl": "https://ark.cn-beijing.volces.com/api/coding",
+			"reasoning": false,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384
+		},
+		"deepseek-v4-pro": {
+			"id": "deepseek-v4-pro",
+			"name": "DeepSeek V4 Pro",
+			"api": "anthropic-messages",
+			"provider": "volcengine-coding-plan",
+			"baseUrl": "https://ark.cn-beijing.volces.com/api/coding",
+			"reasoning": true,
+			"input": [
+				"text"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 128000,
+			"maxTokens": 16384,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		},
+		"kimi-k2.6": {
+			"id": "kimi-k2.6",
+			"name": "Kimi K2.6",
+			"api": "anthropic-messages",
+			"provider": "volcengine-coding-plan",
+			"baseUrl": "https://ark.cn-beijing.volces.com/api/coding",
+			"reasoning": true,
+			"input": [
+				"text",
+				"image"
+			],
+			"cost": {
+				"input": 0,
+				"output": 0,
+				"cacheRead": 0,
+				"cacheWrite": 0
+			},
+			"contextWindow": 262144,
+			"maxTokens": 32768,
+			"thinking": {
+				"mode": "effort",
+				"minLevel": "minimal",
+				"maxLevel": "high"
+			}
+		}
 	}
 }

--- a/packages/ai/src/provider-models/openai-compat.ts
+++ b/packages/ai/src/provider-models/openai-compat.ts
@@ -1009,6 +1009,26 @@ const ZHIPU_REASONING_MODELS: Readonly<Record<string, true>> = {
 const ZHIPU_VISION_PATTERN = /^glm-[45](?:\.\d+)?v(?:-|$)/;
 
 // ---------------------------------------------------------------------------
+// 7.4 Volcengine Coding Plan (火山引擎)
+// ---------------------------------------------------------------------------
+
+export interface VolcengineCodingPlanModelManagerConfig {
+	apiKey?: string;
+	baseUrl?: string;
+	fetch?: FetchImpl;
+}
+
+export function volcengineCodingPlanModelManagerOptions(
+	config?: VolcengineCodingPlanModelManagerConfig,
+): ModelManagerOptions<"anthropic-messages"> {
+	return createSimpleAnthropicProviderOptions(
+		"volcengine-coding-plan",
+		"https://ark.cn-beijing.volces.com/api/coding",
+		config,
+	);
+}
+
+// ---------------------------------------------------------------------------
 // 7.5 Fireworks
 // ---------------------------------------------------------------------------
 

--- a/packages/ai/src/registry/api-key-login.ts
+++ b/packages/ai/src/registry/api-key-login.ts
@@ -25,6 +25,8 @@ type AnthropicMessagesValidation = {
 	provider: string;
 	baseUrl: string;
 	model: string;
+	/** Auth header style. Defaults to "x-api-key" (Anthropic native); use "bearer" for third-party Anthropic-compatible providers. */
+	authStyle?: "x-api-key" | "bearer";
 };
 
 type ModelsEndpointValidation = {
@@ -92,6 +94,7 @@ export function createApiKeyLogin(config: ApiKeyLoginConfig): (options: OAuthCon
 					model: config.validation.model,
 					signal: options.signal,
 					fetch: options.fetch,
+					authStyle: config.validation.authStyle,
 				});
 			} else {
 				await validateApiKeyAgainstModelsEndpoint({

--- a/packages/ai/src/registry/api-key-validation.ts
+++ b/packages/ai/src/registry/api-key-validation.ts
@@ -15,6 +15,8 @@ type AnthropicCompatibleValidationOptions = {
 	model: string;
 	signal?: AbortSignal;
 	fetch?: FetchImpl;
+	/** Auth header style. Defaults to "x-api-key" (Anthropic native); use "bearer" for third-party Anthropic-compatible providers. */
+	authStyle?: "x-api-key" | "bearer";
 };
 
 type ModelListValidationOptions = {
@@ -83,13 +85,18 @@ export async function validateAnthropicCompatibleApiKey(options: AnthropicCompat
 	const baseUrl = normalizeAnthropicCompatibleBaseUrl(options.baseUrl);
 	const fetchImpl = options.fetch ?? fetch;
 
+	const headers: Record<string, string> = {
+		"Content-Type": "application/json",
+		"anthropic-version": "2023-06-01",
+	};
+	if (options.authStyle === "bearer") {
+		headers.Authorization = `Bearer ${options.apiKey}`;
+	} else {
+		headers["x-api-key"] = options.apiKey;
+	}
 	const response = await fetchImpl(`${baseUrl}/v1/messages`, {
 		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-			"anthropic-version": "2023-06-01",
-			"x-api-key": options.apiKey,
-		},
+		headers,
 		body: JSON.stringify({
 			model: options.model,
 			messages: [{ role: "user", content: "ping" }],

--- a/packages/ai/src/registry/registry.ts
+++ b/packages/ai/src/registry/registry.ts
@@ -47,6 +47,7 @@ import type { ProviderDefinition } from "./types";
 import { veniceProvider } from "./venice";
 import { vercelAiGatewayProvider } from "./vercel-ai-gateway";
 import { vllmProvider } from "./vllm";
+import { volcengineCodingPlanProvider } from "./volcengine-coding-plan";
 import { waferPassProvider } from "./wafer-pass";
 import { waferServerlessProvider } from "./wafer-serverless";
 import { xaiProvider } from "./xai";
@@ -82,6 +83,7 @@ const ALL = [
 	alibabaCodingPlanProvider,
 	aimlApiProvider,
 	zhipuCodingPlanProvider,
+	volcengineCodingPlanProvider,
 	qwenPortalProvider,
 	minimaxCodeProvider,
 	minimaxCodeCnProvider,

--- a/packages/ai/src/registry/volcengine-coding-plan.ts
+++ b/packages/ai/src/registry/volcengine-coding-plan.ts
@@ -1,0 +1,53 @@
+import { volcengineCodingPlanModelManagerOptions } from "../provider-models/openai-compat";
+import { validateAnthropicCompatibleApiKey } from "./api-key-validation";
+import type { OAuthController, OAuthLoginCallbacks } from "./oauth/types";
+import type { ModelManagerConfig, ProviderDefinition } from "./types";
+
+const AUTH_URL = "https://console.volcengine.com/ark/region:ark+cn-beijing/apikey";
+const API_BASE_URL = "https://ark.cn-beijing.volces.com/api/coding";
+const VALIDATION_MODEL = "doubao-seed-2.0-code";
+
+export async function loginVolcengineCodingPlan(options: OAuthController): Promise<string> {
+	if (!options.onPrompt) {
+		throw new Error("Volcengine Coding Plan login requires onPrompt callback");
+	}
+
+	options.onAuth?.({
+		url: AUTH_URL,
+		instructions: "Copy your API key from the Volcengine Ark console",
+	});
+
+	const apiKey = await options.onPrompt({
+		message: "Paste your Volcengine API key",
+		placeholder: "sk-...",
+	});
+
+	if (options.signal?.aborted) {
+		throw new Error("Login cancelled");
+	}
+
+	const trimmed = apiKey.trim();
+	if (!trimmed) {
+		throw new Error("API key is required");
+	}
+
+	options.onProgress?.("Validating API key...");
+	await validateAnthropicCompatibleApiKey({
+		provider: "Volcengine Coding Plan",
+		apiKey: trimmed,
+		baseUrl: API_BASE_URL,
+		model: VALIDATION_MODEL,
+		signal: options.signal,
+	});
+	return trimmed;
+}
+
+export const volcengineCodingPlanProvider = {
+	id: "volcengine-coding-plan",
+	name: "Volcengine Coding Plan (火山引擎)",
+	defaultModel: "doubao-seed-2.0-code",
+	createModelManagerOptions: (config: ModelManagerConfig) => volcengineCodingPlanModelManagerOptions(config),
+	catalogDiscovery: { label: "Volcengine Coding Plan", envVars: ["VOLCENGINE_API_KEY"] },
+	envKeys: "VOLCENGINE_API_KEY",
+	login: (cb: OAuthLoginCallbacks) => loginVolcengineCodingPlan(cb),
+} as const satisfies ProviderDefinition;

--- a/packages/ai/src/registry/volcengine-coding-plan.ts
+++ b/packages/ai/src/registry/volcengine-coding-plan.ts
@@ -1,46 +1,22 @@
 import { volcengineCodingPlanModelManagerOptions } from "../provider-models/openai-compat";
-import { validateAnthropicCompatibleApiKey } from "./api-key-validation";
-import type { OAuthController, OAuthLoginCallbacks } from "./oauth/types";
+import { createApiKeyLogin } from "./api-key-login";
+import type { OAuthLoginCallbacks } from "./oauth/types";
 import type { ModelManagerConfig, ProviderDefinition } from "./types";
 
-const AUTH_URL = "https://console.volcengine.com/ark/region:ark+cn-beijing/apikey";
-const API_BASE_URL = "https://ark.cn-beijing.volces.com/api/coding";
-const VALIDATION_MODEL = "doubao-seed-2.0-code";
-
-export async function loginVolcengineCodingPlan(options: OAuthController): Promise<string> {
-	if (!options.onPrompt) {
-		throw new Error("Volcengine Coding Plan login requires onPrompt callback");
-	}
-
-	options.onAuth?.({
-		url: AUTH_URL,
-		instructions: "Copy your API key from the Volcengine Ark console",
-	});
-
-	const apiKey = await options.onPrompt({
-		message: "Paste your Volcengine API key",
-		placeholder: "sk-...",
-	});
-
-	if (options.signal?.aborted) {
-		throw new Error("Login cancelled");
-	}
-
-	const trimmed = apiKey.trim();
-	if (!trimmed) {
-		throw new Error("API key is required");
-	}
-
-	options.onProgress?.("Validating API key...");
-	await validateAnthropicCompatibleApiKey({
+const loginVolcengineCodingPlan = createApiKeyLogin({
+	providerLabel: "Volcengine Coding Plan",
+	authUrl: "https://console.volcengine.com/ark/region:ark+cn-beijing/apikey",
+	instructions: "Copy your API key from the Volcengine Ark console",
+	promptMessage: "Paste your Volcengine API key",
+	placeholder: "sk-...",
+	validation: {
+		kind: "anthropic-messages",
 		provider: "Volcengine Coding Plan",
-		apiKey: trimmed,
-		baseUrl: API_BASE_URL,
-		model: VALIDATION_MODEL,
-		signal: options.signal,
-	});
-	return trimmed;
-}
+		baseUrl: "https://ark.cn-beijing.volces.com/api/coding",
+		model: "doubao-seed-2.0-code",
+		authStyle: "bearer",
+	},
+});
 
 export const volcengineCodingPlanProvider = {
 	id: "volcengine-coding-plan",


### PR DESCRIPTION
## Summary

Add support for [Volcengine Ark Coding Plan](https://www.volcengine.com/docs/82379/1928261) as a new upstream provider. Volcengine (火山引擎/豆包) is ByteDance's cloud platform providing access to coding-optimized LLMs through an Anthropic-compatible API endpoint.

## Provider Details

| Field | Value |
|---|---|
| ID | `volcengine-coding-plan` |
| Wire protocol | `anthropic-messages` |
| Base URL | `https://ark.cn-beijing.volces.com/api/coding` |
| Default model | `doubao-seed-2.0-code` |
| Env key | `VOLCENGINE_API_KEY` |
| Auth | API key via [Volcengine Ark console](https://console.volcengine.com/ark/region:ark+cn-beijing/apikey) |

## Bundled Models (10)

All models are subscription-based (cost = 0).

| Model | Context | Max Tokens | Reasoning | Vision |
|---|---|---|---|---|
| doubao-seed-2.0-code (default) | 128K | 16K | ✗ | ✗ |
| doubao-seed-2.0-pro | 128K | 16K | ✗ | ✗ |
| doubao-seed-2.0-lite | 128K | 16K | ✗ | ✗ |
| doubao-seed-code | 128K | 16K | ✗ | ✗ |
| minimax-m2.7 | 128K | 16K | ✗ | ✗ |
| minimax-m3 | 128K | 16K | ✗ | ✗ |
| glm-5.1 | 200K | 131K | ✓ | ✗ |
| deepseek-v4-flash | 128K | 16K | ✗ | ✗ |
| deepseek-v4-pro | 128K | 16K | ✓ | ✗ |
| kimi-k2.6 | 262K | 32K | ✓ | ✓ |

## Changes

- `packages/ai/src/registry/volcengine-coding-plan.ts` — **New** provider definition with API key login flow
- `packages/ai/src/provider-models/openai-compat.ts` — Added `volcengineCodingPlanModelManagerOptions()`
- `packages/ai/src/registry/registry.ts` — Import + entry in ALL array
- `packages/ai/src/models.json` — 10 bundled models

## CI Status

- ✅ Biome lint/format: passed (415 files, no fixes needed)
- ✅ models.json validation: passed (49 providers, 3195 models)
- ⚠️ `tsgo` type check: skipped (not installed locally; CI installs it)
- ⚠️ Unit tests: pre-existing native addon dependency failure (unrelated to this change)