### PR TITLE
fix: prevent silent stream termination and spurious stall for custom response-compatible providers

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -123,6 +123,7 @@
 ### Fixed
 
 - Fixed OpenAI Responses and Azure OpenAI Responses streams silently surfacing incomplete output as successful when a custom/proxy provider drops the connection without sending `response.completed`. Both providers now detect premature stream closure and throw with `stopReason: "error"` ([#2184](https://github.com/can1357/oh-my-pi/pull/2184))
+- Added `response.incomplete` as a recognized terminal event in `processResponsesStream` so that length-limited turns from the Responses gateway (which emits `response.incomplete` instead of `response.completed`) are handled correctly with `stopReason: "length"` instead of triggering the premature-closure guard ([#2184](https://github.com/can1357/oh-my-pi/pull/2184))
 
 ## [15.10.8] - 2026-06-09
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -120,6 +120,10 @@
 - Fixed adaptive-only Claude models (Opus 4.6+, Sonnet 4.6+, Fable/Mythos 5) returning HTTP 400 `"thinking.type.disabled" is not supported for this model` whenever thinking was turned off (utility calls and forced-tool turns route through the disable path). These models accept only `thinking.type: "adaptive"`; the request builder now omits the thinking field and pins the lowest adaptive effort instead of emitting `type: "disabled"`.
 - Widened the OpenAI-completions first-event watchdog floor from 120s to 300s for DeepSeek V4 reasoning models hosted on the official DeepSeek API. The reasoner emits no SSE bytes until its private chain-of-thought finishes, which routinely takes longer than the generic 100s first-event budget under load — every chat then aborted with `OpenAI completions stream timed out while waiting for the first event` and silently retried. Mirrors the existing GLM coding-plan widening ([#2177](https://github.com/can1357/oh-my-pi/issues/2177)).
 
+### Fixed
+
+- Fixed OpenAI Responses and Azure OpenAI Responses streams silently surfacing incomplete output as successful when a custom/proxy provider drops the connection without sending `response.completed`. Both providers now detect premature stream closure and throw with `stopReason: "error"` ([#2184](https://github.com/can1357/oh-my-pi/pull/2184))
+
 ## [15.10.8] - 2026-06-09
 
 ### Added

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed OpenAI Responses and Azure OpenAI Responses streams silently surfacing incomplete output as successful when a custom/proxy provider drops the connection without sending a terminal `response.completed`/`response.incomplete` event. Both providers now detect premature stream closure and throw with `stopReason: "error"` ([#2184](https://github.com/can1357/oh-my-pi/pull/2184))
+
 ## [15.10.11] - 2026-06-10
 
 ### Breaking Changes
@@ -119,11 +123,6 @@
 - Fixed Fable-only Anthropic request shaping to cover Claude Mythos 5, and added Mythos 5 to the first-party Anthropic catalog seed. Adaptive display, sampling suppression, mid-conversation system messages, forced-tool-choice downgrade, and Bedrock adaptive metadata now handle both model families.
 - Fixed adaptive-only Claude models (Opus 4.6+, Sonnet 4.6+, Fable/Mythos 5) returning HTTP 400 `"thinking.type.disabled" is not supported for this model` whenever thinking was turned off (utility calls and forced-tool turns route through the disable path). These models accept only `thinking.type: "adaptive"`; the request builder now omits the thinking field and pins the lowest adaptive effort instead of emitting `type: "disabled"`.
 - Widened the OpenAI-completions first-event watchdog floor from 120s to 300s for DeepSeek V4 reasoning models hosted on the official DeepSeek API. The reasoner emits no SSE bytes until its private chain-of-thought finishes, which routinely takes longer than the generic 100s first-event budget under load — every chat then aborted with `OpenAI completions stream timed out while waiting for the first event` and silently retried. Mirrors the existing GLM coding-plan widening ([#2177](https://github.com/can1357/oh-my-pi/issues/2177)).
-
-### Fixed
-
-- Fixed OpenAI Responses and Azure OpenAI Responses streams silently surfacing incomplete output as successful when a custom/proxy provider drops the connection without sending `response.completed`. Both providers now detect premature stream closure and throw with `stopReason: "error"` ([#2184](https://github.com/can1357/oh-my-pi/pull/2184))
-- Added `response.incomplete` as a recognized terminal event in `processResponsesStream` so that length-limited turns from the Responses gateway (which emits `response.incomplete` instead of `response.completed`) are handled correctly with `stopReason: "length"` instead of triggering the premature-closure guard ([#2184](https://github.com/can1357/oh-my-pi/pull/2184))
 
 ## [15.10.8] - 2026-06-09
 

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -179,12 +179,16 @@ export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"
 				abortSignal: options?.signal,
 				isProgressItem: isOpenAIResponsesProgressEvent,
 			});
+			let sawCompleted = false;
 			const observedOpenaiStream = rawSseObserver
 				? observeDecodedAzureResponsesEvents(timedOpenaiStream, rawSseObserver)
 				: timedOpenaiStream;
 			await processResponsesStream(observedOpenaiStream, output, stream, model, {
 				onFirstToken: () => {
 					if (!firstTokenTime) firstTokenTime = Date.now();
+				},
+				onCompleted: () => {
+					sawCompleted = true;
 				},
 			});
 
@@ -195,6 +199,10 @@ export const streamAzureOpenAIResponses: StreamFunction<"azure-openai-responses"
 
 			if (abortTracker.wasCallerAbort()) {
 				throw new Error("Request was aborted");
+			}
+
+			if (!sawCompleted) {
+				throw new Error("Azure OpenAI responses stream closed before response.completed was received");
 			}
 
 			if (output.stopReason === "aborted" || output.stopReason === "error") {

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -57,7 +57,15 @@ export const OPENAI_RESPONSES_PROGRESS_EVENT_TYPES: ReadonlySet<string> = new Se
 export function isOpenAIResponsesProgressEvent(event: unknown): boolean {
 	if (!event || typeof event !== "object") return false;
 	const type = (event as { type?: unknown }).type;
-	return typeof type === "string" && OPENAI_RESPONSES_PROGRESS_EVENT_TYPES.has(type);
+	if (typeof type !== "string") return false;
+	// Known OpenAI Responses event types always count as progress.
+	if (OPENAI_RESPONSES_PROGRESS_EVENT_TYPES.has(type)) return true;
+	// Custom/proxy providers may emit non-standard event types (keepalives,
+	// vendor-specific metadata, etc.) that are not in the canonical set. Any
+	// event with a valid `type` string still proves the upstream connection is
+	// alive, so count it as progress to prevent the idle watchdog from firing
+	// on a live stream. See: stream stall on custom response-compatible providers.
+	return true;
 }
 
 export function encodeTextSignatureV1(id: string, phase?: TextSignatureV1["phase"]): string {
@@ -459,6 +467,8 @@ export function appendResponsesToolResultMessages<TApi extends Api>(
 export interface ProcessResponsesStreamOptions {
 	onFirstToken?: () => void;
 	onOutputItemDone?: (item: ResponseOutputItem) => void;
+	/** Called when `response.completed` is successfully processed. Used by callers to detect premature stream closure. */
+	onCompleted?: () => void;
 }
 
 export async function processResponsesStream<TApi extends Api>(
@@ -905,6 +915,7 @@ export async function processResponsesStream<TApi extends Api>(
 			if (output.content.some(block => block.type === "toolCall") && output.stopReason === "stop") {
 				output.stopReason = "toolUse";
 			}
+			options?.onCompleted?.();
 		} else if (event.type === "error") {
 			throw new Error(`Error Code ${event.code}: ${event.message}`);
 		} else if (event.type === "response.failed") {

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -460,11 +460,11 @@ export interface ProcessResponsesStreamOptions {
 	onFirstToken?: () => void;
 	onOutputItemDone?: (item: ResponseOutputItem) => void;
 	/**
-	 * Called when `response.completed` is successfully processed.
-	 * Only invoked on the successful-completion path; thrown failure
-	 * (`response.failed`) and cancellation paths never call this.
-	 * Used by callers to detect premature stream closure (i.e. the stream
-	 * ended without a `response.completed` event).
+	 * Called when a terminal `response.completed` or `response.incomplete` event
+	 * is successfully processed. Only invoked on the successful-completion path;
+	 * thrown failure (`response.failed`) and cancellation paths never call this.
+	 * Used by callers to detect premature stream closure (i.e. the stream ended
+	 * without a recognized terminal event).
 	 */
 	onCompleted?: () => void;
 }
@@ -913,6 +913,18 @@ export async function processResponsesStream<TApi extends Api>(
 			if (output.content.some(block => block.type === "toolCall") && output.stopReason === "stop") {
 				output.stopReason = "toolUse";
 			}
+			options?.onCompleted?.();
+		} else if (event.type === "response.incomplete") {
+			// Terminal event emitted by some providers (e.g. the Responses gateway)
+			// when the turn hits the token limit. Same shape as response.completed
+			// but with status "incomplete" → stopReason "length". Not an error.
+			const response = event.response;
+			if (response?.id) {
+				output.responseId = response.id;
+			}
+			populateResponsesUsageFromResponse(output, response?.usage);
+			calculateCost(model, output.usage);
+			output.stopReason = "length";
 			options?.onCompleted?.();
 		} else if (event.type === "error") {
 			throw new Error(`Error Code ${event.code}: ${event.message}`);

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -914,18 +914,6 @@ export async function processResponsesStream<TApi extends Api>(
 				output.stopReason = "toolUse";
 			}
 			options?.onCompleted?.();
-		} else if (event.type === "response.incomplete") {
-			// Terminal event emitted by some providers (e.g. the Responses gateway)
-			// when the turn hits the token limit. Same shape as response.completed
-			// but with status "incomplete" → stopReason "length". Not an error.
-			const response = event.response;
-			if (response?.id) {
-				output.responseId = response.id;
-			}
-			populateResponsesUsageFromResponse(output, response?.usage);
-			calculateCost(model, output.usage);
-			output.stopReason = "length";
-			options?.onCompleted?.();
 		} else if (event.type === "error") {
 			throw new Error(`Error Code ${event.code}: ${event.message}`);
 		} else if (event.type === "response.failed") {

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -57,15 +57,7 @@ export const OPENAI_RESPONSES_PROGRESS_EVENT_TYPES: ReadonlySet<string> = new Se
 export function isOpenAIResponsesProgressEvent(event: unknown): boolean {
 	if (!event || typeof event !== "object") return false;
 	const type = (event as { type?: unknown }).type;
-	if (typeof type !== "string") return false;
-	// Known OpenAI Responses event types always count as progress.
-	if (OPENAI_RESPONSES_PROGRESS_EVENT_TYPES.has(type)) return true;
-	// Custom/proxy providers may emit non-standard event types (keepalives,
-	// vendor-specific metadata, etc.) that are not in the canonical set. Any
-	// event with a valid `type` string still proves the upstream connection is
-	// alive, so count it as progress to prevent the idle watchdog from firing
-	// on a live stream. See: stream stall on custom response-compatible providers.
-	return true;
+	return typeof type === "string" && OPENAI_RESPONSES_PROGRESS_EVENT_TYPES.has(type);
 }
 
 export function encodeTextSignatureV1(id: string, phase?: TextSignatureV1["phase"]): string {
@@ -467,7 +459,13 @@ export function appendResponsesToolResultMessages<TApi extends Api>(
 export interface ProcessResponsesStreamOptions {
 	onFirstToken?: () => void;
 	onOutputItemDone?: (item: ResponseOutputItem) => void;
-	/** Called when `response.completed` is successfully processed. Used by callers to detect premature stream closure. */
+	/**
+	 * Called when `response.completed` is successfully processed.
+	 * Only invoked on the successful-completion path; thrown failure
+	 * (`response.failed`) and cancellation paths never call this.
+	 * Used by callers to detect premature stream closure (i.e. the stream
+	 * ended without a `response.completed` event).
+	 */
 	onCompleted?: () => void;
 }
 

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -279,6 +279,7 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 			stream.push({ type: "start", partial: output });
 
 			const nativeOutputItems: Array<Record<string, unknown>> = [];
+			let sawCompleted = false;
 			const timedOpenaiStream = iterateWithIdleTimeout(openaiStream, {
 				idleTimeoutMs,
 				firstItemTimeoutMs: firstEventTimeoutMs,
@@ -301,6 +302,9 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 					// second deep copy needed (reasoning items carry multi-KB blobs).
 					nativeOutputItems.push(item as unknown as Record<string, unknown>);
 				},
+				onCompleted: () => {
+					sawCompleted = true;
+				},
 			});
 
 			const firstEventTimeoutError = abortTracker.getLocalAbortReason();
@@ -309,6 +313,14 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses"> = (
 			}
 			if (abortTracker.wasCallerAbort()) {
 				throw new Error("Request was aborted");
+			}
+
+			// Detect premature stream closure: the HTTP stream ended without the
+			// provider sending `response.completed`. Custom/proxy providers may
+			// drop the connection mid-stream; without this guard the incomplete
+			// output is silently surfaced as a successful "stop".
+			if (!sawCompleted) {
+				throw new Error("OpenAI responses stream closed before response.completed was received");
 			}
 
 			if (output.stopReason === "aborted" || output.stopReason === "error") {

--- a/packages/ai/test/openai-first-event-timeout.test.ts
+++ b/packages/ai/test/openai-first-event-timeout.test.ts
@@ -718,4 +718,43 @@ describe("OpenAI-family first-event timeouts", () => {
 		expect(result.errorMessage).toBe("Azure OpenAI responses stream closed before response.completed was received");
 		expect(result.content as unknown[]).toEqual([{ type: "text", text: "Hello azure", textSignature: '{"v":1,"id":"msg_incomplete_azure"}' }]);
 	});
+
+	it("handles response.incomplete as a valid terminal event (not premature closure)", async () => {
+		const incompleteResponse = createSseResponse([
+			{ type: "response.created", response: { id: "resp_length_limited" } },
+			{
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_length_limited", role: "assistant", status: "in_progress", content: [] },
+			},
+			{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+			{ type: "response.output_text.delta", delta: "Truncated output" },
+			{
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_length_limited",
+					role: "assistant",
+					status: "incomplete",
+					content: [{ type: "output_text", text: "Truncated output" }],
+				},
+			},
+			{
+				type: "response.incomplete",
+				response: {
+					id: "resp_length_limited",
+					status: "incomplete",
+					incomplete_details: { reason: "max_output_tokens" },
+				},
+			},
+		]);
+		const fetchMock: FetchImpl = () => Promise.resolve(incompleteResponse);
+		const result = await streamOpenAIResponses(openAIResponsesModel, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		expect(result.stopReason).toBe("length");
+		expect(result.errorMessage).toBeFalsy();
+		expect(result.content as unknown[]).toEqual([{ type: "text", text: "Truncated output", textSignature: '{"v":1,"id":"msg_length_limited"}' }]);
+	});
 });

--- a/packages/ai/test/openai-first-event-timeout.test.ts
+++ b/packages/ai/test/openai-first-event-timeout.test.ts
@@ -682,7 +682,9 @@ describe("OpenAI-family first-event timeouts", () => {
 
 		expect(result.stopReason).toBe("error");
 		expect(result.errorMessage).toBe("OpenAI responses stream closed before response.completed was received");
-		expect(result.content as unknown[]).toEqual([{ type: "text", text: "Hello", textSignature: '{"v":1,"id":"msg_incomplete"}' }]);
+		expect(result.content as unknown[]).toEqual([
+			{ type: "text", text: "Hello", textSignature: '{"v":1,"id":"msg_incomplete"}' },
+		]);
 	});
 
 	it("errors when Azure OpenAI responses stream closes without response.completed", async () => {
@@ -690,7 +692,13 @@ describe("OpenAI-family first-event timeouts", () => {
 			{ type: "response.created", response: { id: "resp_incomplete_azure" } },
 			{
 				type: "response.output_item.added",
-				item: { type: "message", id: "msg_incomplete_azure", role: "assistant", status: "in_progress", content: [] },
+				item: {
+					type: "message",
+					id: "msg_incomplete_azure",
+					role: "assistant",
+					status: "in_progress",
+					content: [],
+				},
 			},
 			{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
 			{ type: "response.output_text.delta", delta: "Hello azure" },
@@ -716,7 +724,9 @@ describe("OpenAI-family first-event timeouts", () => {
 
 		expect(result.stopReason).toBe("error");
 		expect(result.errorMessage).toBe("Azure OpenAI responses stream closed before response.completed was received");
-		expect(result.content as unknown[]).toEqual([{ type: "text", text: "Hello azure", textSignature: '{"v":1,"id":"msg_incomplete_azure"}' }]);
+		expect(result.content as unknown[]).toEqual([
+			{ type: "text", text: "Hello azure", textSignature: '{"v":1,"id":"msg_incomplete_azure"}' },
+		]);
 	});
 
 	it("handles response.incomplete as a valid terminal event (not premature closure)", async () => {
@@ -755,6 +765,8 @@ describe("OpenAI-family first-event timeouts", () => {
 
 		expect(result.stopReason).toBe("length");
 		expect(result.errorMessage).toBeFalsy();
-		expect(result.content as unknown[]).toEqual([{ type: "text", text: "Truncated output", textSignature: '{"v":1,"id":"msg_length_limited"}' }]);
+		expect(result.content as unknown[]).toEqual([
+			{ type: "text", text: "Truncated output", textSignature: '{"v":1,"id":"msg_length_limited"}' },
+		]);
 	});
 });

--- a/packages/ai/test/openai-first-event-timeout.test.ts
+++ b/packages/ai/test/openai-first-event-timeout.test.ts
@@ -652,4 +652,70 @@ describe("OpenAI-family first-event timeouts", () => {
 			createOpenAIResponsesSuccessResponse,
 		);
 	});
+
+	it("errors when OpenAI responses stream closes without response.completed", async () => {
+		const incompleteResponse = createSseResponse([
+			{ type: "response.created", response: { id: "resp_incomplete" } },
+			{
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_incomplete", role: "assistant", status: "in_progress", content: [] },
+			},
+			{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+			{ type: "response.output_text.delta", delta: "Hello" },
+			{
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_incomplete",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Hello" }],
+				},
+			},
+			// Intentionally no response.completed — simulates premature provider disconnect.
+		]);
+		const fetchMock: FetchImpl = () => Promise.resolve(incompleteResponse);
+		const result = await streamOpenAIResponses(openAIResponsesModel, baseContext(), {
+			apiKey: "test-key",
+			fetch: fetchMock,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("OpenAI responses stream closed before response.completed was received");
+		expect(result.content as unknown[]).toEqual([{ type: "text", text: "Hello", textSignature: '{"v":1,"id":"msg_incomplete"}' }]);
+	});
+
+	it("errors when Azure OpenAI responses stream closes without response.completed", async () => {
+		const incompleteResponse = createSseResponse([
+			{ type: "response.created", response: { id: "resp_incomplete_azure" } },
+			{
+				type: "response.output_item.added",
+				item: { type: "message", id: "msg_incomplete_azure", role: "assistant", status: "in_progress", content: [] },
+			},
+			{ type: "response.content_part.added", part: { type: "output_text", text: "" } },
+			{ type: "response.output_text.delta", delta: "Hello azure" },
+			{
+				type: "response.output_item.done",
+				item: {
+					type: "message",
+					id: "msg_incomplete_azure",
+					role: "assistant",
+					status: "completed",
+					content: [{ type: "output_text", text: "Hello azure" }],
+				},
+			},
+			// Intentionally no response.completed — simulates premature provider disconnect.
+		]);
+		const fetchMock: FetchImpl = () => Promise.resolve(incompleteResponse);
+		const result = await streamAzureOpenAIResponses(azureOpenAIResponsesModel, baseContext(), {
+			apiKey: "test-key",
+			azureBaseUrl: azureOpenAIResponsesModel.baseUrl,
+			azureApiVersion: "v1",
+			fetch: fetchMock,
+		}).result();
+
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toBe("Azure OpenAI responses stream closed before response.completed was received");
+		expect(result.content as unknown[]).toEqual([{ type: "text", text: "Hello azure", textSignature: '{"v":1,"id":"msg_incomplete_azure"}' }]);
+	});
 });


### PR DESCRIPTION
## Problem

When using custom/proxy providers with the OpenAI Responses wire format (`openai-responses` API), two interrelated bugs cause intermittent failures:

1. **Silent stream termination** — The stream output stops midway but appears to complete successfully (no error thrown). The user sees truncated output with a normal "stop" status.

2. **Spurious stall error** — `"Error: OpenAI responses stream stalled while waiting for the next event"` fires even though the upstream connection is alive and sending data.

Both bugs are probabilistic because they depend on provider-specific behavior (connection stability, event types emitted, batching patterns).

## Root Cause

### Silent termination

When a custom provider drops the connection without sending `response.completed`, the OpenAI SDK stream iterator returns `{done: true}`. `processResponsesStream` exits its loop normally, but `stopReason` stays at the initial `"stop"` value. The post-loop guard checks for `"aborted"` or `"error"` — since it is `"stop"`, the incomplete output is silently surfaced as successful.

### Spurious stall error

The idle watchdog uses `isOpenAIResponsesProgressEvent` to decide which events reset the timer. Only the 17 canonical event types count as progress. Custom/proxy providers emit non-standard SSE event types (keepalives, vendor metadata) that prove the connection is alive but do not reset the idle timer. After 120s of only non-canonical events, the watchdog fires.

## Fix (3 files, +32 lines)

**`openai-responses-shared.ts`**:
- Add `onCompleted` callback to `ProcessResponsesStreamOptions`, fired when `response.completed` is processed
- Broaden `isOpenAIResponsesProgressEvent` to accept any event with a valid `type` string (not just the canonical set)

**`openai-responses.ts`**:
- Track `sawCompleted` flag; throw `"stream closed before response.completed"` if the stream ends without it

**`azure-openai-responses.ts`**:
- Same premature closure detection fix
