### PR TITLE
fix(acp): auto-cancel in-flight turn when new prompt arrives mid-flight

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Fixed
 
+- Fixed ACP cancel button leaving the session in a stuck state — a new prompt sent while a turn is still in-flight (e.g. immediately after pressing Stop in Zed before `session/cancel` is processed) now implicitly cancels the running turn and queues the new message, instead of throwing an error that blocks further interaction.
 - Fixed `enabledModels` being ignored by the ACP model picker (Zed and other ACP clients) — `AgentSession.getAvailableModels()` now applies the configured allow-list, so only the models listed in `enabledModels` appear in the UI. Also applies consistently to the RPC `get_available_models` endpoint and the `/model` slash command.
 - Fixed ACP `available_commands_update` to include extension-registered slash commands so clients like Zed surface them in the slash-command palette.
-
 ## [15.10.1] - 2026-06-07
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed ACP `available_commands_update` to include extension-registered slash commands so clients like Zed surface them in the slash-command palette.
+
 ## [15.10.1] - 2026-06-07
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `enabledModels` being ignored by the ACP model picker (Zed and other ACP clients) — `AgentSession.getAvailableModels()` now applies the configured allow-list, so only the models listed in `enabledModels` appear in the UI. Also applies consistently to the RPC `get_available_models` endpoint and the `/model` slash command.
+
 ## [15.10.1] - 2026-06-07
 
 ### Added

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -1044,6 +1044,14 @@ export function filterAvailableModelsByEnabledPatterns(
 			const match = findExactModelReferenceMatch(basePattern, available);
 			if (match) {
 				allowed.add(`${match.provider}/${match.id}`);
+				continue;
+			}
+			// Fallback: treat the whole pattern as a model ID (handles OpenRouter-style bare IDs
+			// like "qwen/qwen3-coder:exacto" where the "/" is part of the id, not a provider separator).
+			for (const m of available) {
+				if (m.id === basePattern) {
+					allowed.add(`${m.provider}/${m.id}`);
+				}
 			}
 			continue;
 		}

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -990,19 +990,25 @@ export async function resolveAllowedModels(
 
 /**
  * Synchronous subset of {@link resolveAllowedModels} for contexts where async is unavailable
- * (e.g. the ACP model-list advertisement). Handles the patterns that cover real-world configs:
+ * (e.g. `getAvailableModels()` which is called from the ACP model-list advertisement, RPC
+ * `get_available_models`, and the `/model` slash command). Handles the patterns that cover
+ * real-world configs:
  *
  * - Exact `provider/modelId` selectors
  * - Canonical ids (expanded via `getCanonicalVariants`)
  * - Bare model ids (matched across all available providers)
- * - Optional `:thinkingLevel` suffix on any of the above is stripped before matching
+ * - Optional `:thinkingLevel` suffix validated via `parseThinkingLevel` before stripping,
+ *   so colon-bearing OpenRouter ids (e.g. `openrouter/qwen/qwen3-coder:exacto`) are preserved
  *
- * Glob patterns (`*`, `?`, `[`) require async resolution; when any pattern contains a glob
- * the full unfiltered list is returned so the UI is never accidentally empty.
+ * Glob patterns (`*`, `?`, `[`) require the async `resolveModelScope` path; they are skipped
+ * here with a warning. When ALL patterns are globs (none can be evaluated synchronously) the
+ * full available list is returned so the UI is never accidentally empty. Mixed glob + exact
+ * patterns apply only the exact ones.
  *
- * Returns the unfiltered list when no pattern resolves to any model, mirroring the
- * "no usable model" guard in {@link resolveAllowedModels} but leaning toward showing
- * more rather than nothing in a UI context.
+ * When no pattern resolves to any model (misconfiguration / typo) an empty list is returned,
+ * consistent with the empty-list contract of {@link resolveAllowedModels}. Callers that render
+ * a UI picker should treat an empty list as "hide the picker entry", matching how the SDK
+ * surfaces the same misconfiguration during session initialization.
  */
 export function filterAvailableModelsByEnabledPatterns(
 	available: Model<Api>[],
@@ -1012,16 +1018,26 @@ export function filterAvailableModelsByEnabledPatterns(
 	if (patterns.length === 0) return available;
 
 	const allowed = new Set<string>();
+	let allGlobs = true;
 	for (const pattern of patterns) {
-		// Glob patterns need the async resolveModelScope path; return all rather than
-		// accidentally hiding models.
+		// Glob patterns need the async resolveModelScope path; skip them here and warn.
 		if (pattern.includes("*") || pattern.includes("?") || pattern.includes("[")) {
-			return available;
+			logger.warn(
+				"filterAvailableModelsByEnabledPatterns: glob pattern skipped in sync context (use exact provider/modelId or canonical ids in enabledModels for ACP model filtering)",
+				{ pattern },
+			);
+			continue;
 		}
+		allGlobs = false;
 
-		// Strip optional thinking-level suffix (e.g. "claude-sonnet-4-6:high").
+		// Strip a `:thinkingLevel` suffix only when the part after the last colon is a
+		// recognised thinking level. This preserves colon-bearing OpenRouter ids such as
+		// `openrouter/qwen/qwen3-coder:exacto` where the suffix is NOT a thinking level.
 		const colonIdx = pattern.lastIndexOf(":");
-		const basePattern = colonIdx !== -1 ? pattern.slice(0, colonIdx) : pattern;
+		const basePattern =
+			colonIdx !== -1 && parseThinkingLevel(pattern.slice(colonIdx + 1))
+				? pattern.slice(0, colonIdx)
+				: pattern;
 
 		// Explicit provider/modelId — resolve directly via the existing reference matcher.
 		if (basePattern.includes("/")) {
@@ -1049,10 +1065,13 @@ export function filterAvailableModelsByEnabledPatterns(
 		}
 	}
 
-	if (allowed.size === 0) return available;
-	return available.filter(m => allowed.has(`${m.provider}/${m.id}`));
-}
+	// All patterns were globs — fall back to the full list since we cannot evaluate them.
+	if (allGlobs) return available;
 
+	// Empty allowed set means every non-glob pattern failed to resolve (misconfiguration).
+	// Return [] consistent with resolveAllowedModels so callers can surface the problem.
+	return allowed.size === 0 ? [] : available.filter(m => allowed.has(`${m.provider}/${m.id}`));
+}
 
 export interface ResolveCliModelResult {
 	model: Model<Api> | undefined;

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -988,6 +988,72 @@ export async function resolveAllowedModels(
 	return available.filter(model => allowed.has(`${model.provider}/${model.id}`));
 }
 
+/**
+ * Synchronous subset of {@link resolveAllowedModels} for contexts where async is unavailable
+ * (e.g. the ACP model-list advertisement). Handles the patterns that cover real-world configs:
+ *
+ * - Exact `provider/modelId` selectors
+ * - Canonical ids (expanded via `getCanonicalVariants`)
+ * - Bare model ids (matched across all available providers)
+ * - Optional `:thinkingLevel` suffix on any of the above is stripped before matching
+ *
+ * Glob patterns (`*`, `?`, `[`) require async resolution; when any pattern contains a glob
+ * the full unfiltered list is returned so the UI is never accidentally empty.
+ *
+ * Returns the unfiltered list when no pattern resolves to any model, mirroring the
+ * "no usable model" guard in {@link resolveAllowedModels} but leaning toward showing
+ * more rather than nothing in a UI context.
+ */
+export function filterAvailableModelsByEnabledPatterns(
+	available: Model<Api>[],
+	patterns: readonly string[],
+	registry: Pick<ModelRegistry, "getCanonicalVariants">,
+): Model<Api>[] {
+	if (patterns.length === 0) return available;
+
+	const allowed = new Set<string>();
+	for (const pattern of patterns) {
+		// Glob patterns need the async resolveModelScope path; return all rather than
+		// accidentally hiding models.
+		if (pattern.includes("*") || pattern.includes("?") || pattern.includes("[")) {
+			return available;
+		}
+
+		// Strip optional thinking-level suffix (e.g. "claude-sonnet-4-6:high").
+		const colonIdx = pattern.lastIndexOf(":");
+		const basePattern = colonIdx !== -1 ? pattern.slice(0, colonIdx) : pattern;
+
+		// Explicit provider/modelId — resolve directly via the existing reference matcher.
+		if (basePattern.includes("/")) {
+			const match = findExactModelReferenceMatch(basePattern, available);
+			if (match) {
+				allowed.add(`${match.provider}/${match.id}`);
+			}
+			continue;
+		}
+
+		// Canonical id — expand to all available concrete variants.
+		const variants = registry.getCanonicalVariants(basePattern, { availableOnly: true, candidates: available });
+		if (variants.length > 0) {
+			for (const { model } of variants) {
+				allowed.add(`${model.provider}/${model.id}`);
+			}
+			continue;
+		}
+
+		// Bare model id — match across all available providers.
+		for (const m of available) {
+			if (m.id === basePattern) {
+				allowed.add(`${m.provider}/${m.id}`);
+			}
+		}
+	}
+
+	if (allowed.size === 0) return available;
+	return available.filter(m => allowed.has(`${m.provider}/${m.id}`));
+}
+
+
 export interface ResolveCliModelResult {
 	model: Model<Api> | undefined;
 	selector?: string;

--- a/packages/coding-agent/src/extensibility/extensions/runner.ts
+++ b/packages/coding-agent/src/extensibility/extensions/runner.ts
@@ -427,7 +427,7 @@ export class ExtensionRunner {
 		return this.extensions.flatMap(ext => ext.assistantThinkingRenderers);
 	}
 
-	getRegisteredCommands(reserved?: Set<string>): RegisteredCommand[] {
+	getRegisteredCommands(reserved?: ReadonlySet<string>): RegisteredCommand[] {
 		this.#commandDiagnostics = [];
 
 		const commands = new Map<string, RegisteredCommand>();

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -829,6 +829,10 @@ export async function runRootCommand(
 		// Runtime override (not persisted): every settings.get("tools.approvalMode") downstream
 		// sees this value. The wrapper still honours --auto-approve / --yolo on top of it.
 		settingsInstance.override("tools.approvalMode", parsedArgs.approvalMode);
+	} else if (parsedArgs.autoApprove) {
+		// --auto-approve / --yolo without an explicit --approval-mode: reflect in settings so
+		// setup-time checks (e.g. #wrapToolForAcpPermission) also see the yolo intent.
+		settingsInstance.override("tools.approvalMode", "yolo");
 	}
 	if (parsedArgs.mode === "rpc" || parsedArgs.mode === "rpc-ui") {
 		applyRpcDefaultSettingOverrides(settingsInstance);

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -703,7 +703,13 @@ export class AcpAgent implements Agent {
 			return;
 		}
 
-		await record.session.prompt(text, { images });
+		const agentInvoked = await record.session.prompt(text, { images });
+		// Extension and custom-TS commands are handled locally inside session.prompt()
+		// without calling the LLM, so no agent_end event fires and the turn would hang.
+		// Finish it here when the session confirms no agent was invoked.
+		if (!agentInvoked) {
+			this.#finishPrompt(record, { stopReason: "end_turn" });
+		}
 	}
 
 	async #tryRunSkillCommand(record: ManagedSessionRecord, text: string): Promise<boolean> {

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -71,7 +71,11 @@ import {
 	type SessionInfo as StoredSessionInfo,
 	type UsageStatistics,
 } from "../../session/session-manager";
-import { ACP_BUILTIN_SLASH_COMMANDS, executeAcpBuiltinSlashCommand } from "../../slash-commands/acp-builtins";
+import {
+	ACP_BUILTIN_RESERVED_NAMES,
+	ACP_BUILTIN_SLASH_COMMANDS,
+	executeAcpBuiltinSlashCommand,
+} from "../../slash-commands/acp-builtins";
 import { AUTO_THINKING, parseConfiguredThinkingLevel } from "../../thinking";
 import { normalizeLocalScheme } from "../../tools/path-utils";
 import { runResolveInvocation } from "../../tools/resolve";
@@ -1602,8 +1606,7 @@ export class AcpAgent implements Agent {
 			}
 		}
 
-		const acpBuiltinNames = new Set(ACP_BUILTIN_SLASH_COMMANDS.map(c => c.name));
-		for (const command of session.extensionRunner?.getRegisteredCommands(acpBuiltinNames) ?? []) {
+		for (const command of session.extensionRunner?.getRegisteredCommands(ACP_BUILTIN_RESERVED_NAMES) ?? []) {
 			appendCommand({
 				name: command.name,
 				description: command.description ?? "(extension command)",

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1584,8 +1584,12 @@ export class AcpAgent implements Agent {
 
 		// Advertise in the order dispatch resolves them: ACP builtins first
 		// (so core commands like `/model`, `/mcp`, `/todo` cannot be shadowed),
-		// then skills, then custom/user commands, then file-based slash
-		// commands. `appendCommand` dedupes by name so earlier entries win.
+		// then skills, then custom/user (TypeScript) commands, then
+		// extension-registered commands, then file-based slash commands.
+		// `appendCommand` dedupes by name so earlier entries win; skills and
+		// custom TS commands intentionally shadow extension commands of the
+		// same name (unlike interactive mode, which inserts extension commands
+		// before customs/skills).
 		for (const command of ACP_BUILTIN_SLASH_COMMANDS) {
 			appendCommand(command);
 		}

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1582,14 +1582,12 @@ export class AcpAgent implements Agent {
 			commands.push(command);
 		};
 
-		// Advertise in the order dispatch resolves them: ACP builtins first
-		// (so core commands like `/model`, `/mcp`, `/todo` cannot be shadowed),
-		// then skills, then custom/user (TypeScript) commands, then
-		// extension-registered commands, then file-based slash commands.
-		// `appendCommand` dedupes by name so earlier entries win; skills and
-		// custom TS commands intentionally shadow extension commands of the
-		// same name (unlike interactive mode, which inserts extension commands
-		// before customs/skills).
+		// Advertise in the order dispatch resolves them (mirrors AgentSession
+		// dispatch: builtins → skills → extensions → custom TS → file-based).
+		// `appendCommand` dedupes by name so earlier entries win; extension
+		// commands therefore correctly shadow custom TS commands of the same
+		// name, matching the runtime behaviour of #tryExecuteExtensionCommand
+		// running before #tryExecuteCustomCommand.
 		for (const command of ACP_BUILTIN_SLASH_COMMANDS) {
 			appendCommand(command);
 		}
@@ -1604,19 +1602,19 @@ export class AcpAgent implements Agent {
 			}
 		}
 
-		for (const command of session.customCommands) {
-			appendCommand({
-				name: command.command.name,
-				description: command.command.description,
-				input: { hint: "arguments" },
-			});
-		}
-
 		const acpBuiltinNames = new Set(ACP_BUILTIN_SLASH_COMMANDS.map(c => c.name));
 		for (const command of session.extensionRunner?.getRegisteredCommands(acpBuiltinNames) ?? []) {
 			appendCommand({
 				name: command.name,
 				description: command.description ?? "(extension command)",
+				input: { hint: "arguments" },
+			});
+		}
+
+		for (const command of session.customCommands) {
+			appendCommand({
+				name: command.command.name,
+				description: command.command.description,
 				input: { hint: "arguments" },
 			});
 		}

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -1608,6 +1608,15 @@ export class AcpAgent implements Agent {
 			});
 		}
 
+		const acpBuiltinNames = new Set(ACP_BUILTIN_SLASH_COMMANDS.map(c => c.name));
+		for (const command of session.extensionRunner?.getRegisteredCommands(acpBuiltinNames) ?? []) {
+			appendCommand({
+				name: command.name,
+				description: command.description ?? "(extension command)",
+				input: { hint: "arguments" },
+			});
+		}
+
 		for (const command of await loadSlashCommands({ cwd: session.sessionManager.getCwd() })) {
 			appendCommand({
 				name: command.name,

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -598,7 +598,13 @@ export class AcpAgent implements Agent {
 		const record = this.#getSessionRecord(params.sessionId);
 		const activeTurn = record.promptTurn;
 		if (activeTurn && !activeTurn.settled && record.session.isStreaming) {
-			throw new Error("ACP prompt already in progress for this session");
+			// New prompt arrived while the previous turn is still in-flight (e.g. the
+			// client sent a message immediately after pressing stop, before or without
+			// a preceding session/cancel notification). Implicitly cancel the running
+			// turn so the new prompt can queue behind the abort cleanup — identical to
+			// what cancel() does when called explicitly. #beginCancelCleanup is
+			// idempotent, so a concurrent session/cancel notification is harmless.
+			this.#beginCancelCleanup(record, activeTurn);
 		}
 		return await this.#queuePrompt(record, async () => {
 			const previousTurn = record.promptTurn;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3477,12 +3477,23 @@ export class AgentSession {
 	 * Wrap a tool with a permission-gate proxy when an ACP client is connected.
 	 * Only wraps tools whose name is in PERMISSION_REQUIRED_TOOLS and only when
 	 * the bridge exposes `requestPermission`. No-ops for all other cases.
+	 *
+	 * In `yolo` mode, skips the gate unless the user policy explicitly requires a
+	 * prompt or deny (matching the behaviour of the normal approval wrapper).
 	 */
 	#wrapToolForAcpPermission<T extends AgentTool>(tool: T): T {
 		const bridge = this.#clientBridge;
 		// Match the capability+method gating pattern used by read/write/bash.
 		if (!bridge?.capabilities.requestPermission || !bridge.requestPermission) return tool;
 		if (!PERMISSION_REQUIRED_TOOLS.has(tool.name)) return tool;
+		// In yolo mode, honour the user per-tool policy but skip the ACP gate when
+		// the effective decision is "allow" (absent policy or explicit "allow").
+		const approvalMode = (this.settings.get("tools.approvalMode") ?? "yolo") as string;
+		if (approvalMode === "yolo") {
+			const userPolicies = (this.settings.get("tools.approval") ?? {}) as Record<string, unknown>;
+			const toolPolicy = userPolicies[tool.name];
+			if (!toolPolicy || toolPolicy === "allow") return tool;
+		}
 		return new Proxy(tool, {
 			get: (target, prop) => {
 				if (prop !== "execute") return Reflect.get(target, prop, target);

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3480,6 +3480,8 @@ export class AgentSession {
 	 *
 	 * In `yolo` mode, skips the gate unless the user policy explicitly requires a
 	 * prompt or deny (matching the behaviour of the normal approval wrapper).
+	 * `--auto-approve` / `--yolo` CLI flags also reach here because `main.ts`
+	 * reflects them into a `tools.approvalMode` settings override at startup.
 	 */
 	#wrapToolForAcpPermission<T extends AgentTool>(tool: T): T {
 		const bridge = this.#clientBridge;

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4287,21 +4287,28 @@ export class AgentSession {
 	 * @throws Error if streaming and no streamingBehavior specified
 	 * @throws Error if no model selected or no API key available (when not streaming)
 	 */
-	async prompt(text: string, options?: PromptOptions): Promise<void> {
+	/**
+	 * Returns `false` when the command was fully handled locally (extension or
+	 * custom-TS command consumed without calling the LLM). Returns `true` when
+	 * the prompt was forwarded to the agent — either directly or queued as a
+	 * steer/follow-up. Callers that render a UI or manage turn lifecycle (e.g.
+	 * the ACP agent) use this to know whether to expect an `agent_end` event.
+	 */
+	async prompt(text: string, options?: PromptOptions): Promise<boolean> {
 		const expandPromptTemplates = options?.expandPromptTemplates ?? true;
 
 		// Handle extension commands first (execute immediately, even during streaming)
 		if (expandPromptTemplates && text.startsWith("/")) {
 			const handled = await this.#tryExecuteExtensionCommand(text);
 			if (handled) {
-				return;
+				return false;
 			}
 
 			// Try custom commands (TypeScript slash commands)
 			const customResult = await this.#tryExecuteCustomCommand(text);
 			if (customResult !== null) {
 				if (customResult === "") {
-					return;
+					return false;
 				}
 				text = customResult;
 			}
@@ -4370,7 +4377,7 @@ export class AgentSession {
 			for (const notice of keywordNotices) {
 				await this.sendCustomMessage(notice, { deliverAs: options.streamingBehavior });
 			}
-			return;
+			return true;
 		}
 
 		// Skip eager todo prelude when the user has already queued a directive
@@ -4408,6 +4415,7 @@ export class AgentSession {
 		if (!options?.synthetic) {
 			await this.#enforcePlanModeToolDecision();
 		}
+		return true;
 	}
 
 	async promptCustomMessage<T = unknown>(

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -107,6 +107,7 @@ import { shouldEnableAppendOnlyContext } from "../config/append-only-context-mod
 import { MODEL_ROLE_IDS, type ModelRegistry } from "../config/model-registry";
 import {
 	extractExplicitThinkingSelector,
+	filterAvailableModelsByEnabledPatterns,
 	formatModelSelectorValue,
 	formatModelString,
 	parseModelString,
@@ -5592,10 +5593,14 @@ export class AgentSession {
 	}
 
 	/**
-	 * Get all available models with valid API keys.
+	 * Get all available models with valid API keys, filtered by `enabledModels` when configured.
+	 * See {@link filterAvailableModelsByEnabledPatterns} for supported pattern forms and limitations.
 	 */
 	getAvailableModels(): Model[] {
-		return this.#modelRegistry.getAvailable();
+		const all = this.#modelRegistry.getAvailable();
+		const patterns = this.settings.get("enabledModels");
+		if (!patterns || patterns.length === 0) return all;
+		return filterAvailableModelsByEnabledPatterns(all, patterns, this.#modelRegistry);
 	}
 
 	// =========================================================================

--- a/packages/coding-agent/src/slash-commands/acp-builtins.ts
+++ b/packages/coding-agent/src/slash-commands/acp-builtins.ts
@@ -6,6 +6,19 @@ import type { AcpBuiltinSlashCommandResult, SlashCommandRuntime } from "./types"
 export type { AcpBuiltinSlashCommandResult } from "./types";
 
 /**
+ * All names (primary + aliases) that are reserved by ACP builtins. Used to
+ * filter out extension commands that would shadow a builtin or its alias at
+ * dispatch time (e.g. `models` is an alias for `/model`, so an extension
+ * registering `models` would appear in the palette but execute the builtin).
+ */
+export const ACP_BUILTIN_RESERVED_NAMES: ReadonlySet<string> = new Set(
+	BUILTIN_SLASH_COMMANDS_INTERNAL.filter(c => c.handle !== undefined).flatMap(c => [
+		c.name,
+		...(c.aliases ?? []),
+	]),
+);
+
+/**
  * Commands advertised to ACP clients. Entries without a text-mode `handle`
  * (e.g. `/quit`, `/login`, dashboards) are filtered out so the client doesn't
  * see commands it cannot drive.

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1274,8 +1274,11 @@ describe("ACP agent", () => {
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
 		const session = harness.findSession(created.sessionId)!;
 
-		// Attach a fake extensionRunner that exposes two extension commands:
-		// one unique and one whose name collides with an ACP builtin ("fast").
+		// Extension command colliding with a custom TS command; extension wins (dispatch order).
+		(session as unknown as { customCommands: unknown[] }).customCommands = [
+			{ command: { name: "my-ext-cmd", description: "Custom TS version" } },
+		];
+		// Extension runner: unique command + one colliding with an ACP builtin ("fast").
 		(session as unknown as { extensionRunner: unknown }).extensionRunner = {
 			getRegisteredCommands(reserved?: Set<string>) {
 				return [
@@ -1291,24 +1294,19 @@ describe("ACP agent", () => {
 			update =>
 				update.sessionId === created.sessionId && update.update.sessionUpdate === "available_commands_update",
 		);
-		const names = commandUpdates.flatMap(update =>
-			update.update.sessionUpdate === "available_commands_update"
-				? update.update.availableCommands.map(command => command.name)
-				: [],
+		// Flatten all advertised commands from all updates for this session.
+		const allCommands = commandUpdates.flatMap(update =>
+			update.update.sessionUpdate === "available_commands_update" ? update.update.availableCommands : [],
 		);
+		const names = allCommands.map(c => c.name);
 
 		// Extension command must surface.
 		expect(names).toContain("my-ext-cmd");
-		// ACP builtin "fast" must still appear exactly once (not shadowed/duplicated).
+		// Extension wins the name collision: advertised description is the extension's, not the custom TS one.
+		const extCmdEntry = allCommands.find(c => c.name === "my-ext-cmd");
+		expect(extCmdEntry?.description).toBe("Extension command");
+		// ACP builtin "fast" appears exactly once (reserved-set exclusion, no duplicate from extension).
 		expect(names.filter(n => n === "fast").length).toBe(1);
-		// Extension command that collided with the builtin must not add a duplicate.
-		// (The builtin "fast" entry wins via the reserved-set exclusion.)
-		const fastEntries = commandUpdates.flatMap(update =>
-			update.update.sessionUpdate === "available_commands_update"
-				? update.update.availableCommands.filter(c => c.name === "fast")
-				: [],
-		);
-		expect(fastEntries.length).toBe(1);
 
 		harness.abortController.abort();
 		await Bun.sleep(0);

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1269,6 +1269,51 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("includes extension-registered commands in available_commands_update and excludes ACP-builtin collisions", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+
+		// Attach a fake extensionRunner that exposes two extension commands:
+		// one unique and one whose name collides with an ACP builtin ("fast").
+		(session as unknown as { extensionRunner: unknown }).extensionRunner = {
+			getRegisteredCommands(reserved?: Set<string>) {
+				return [
+					{ name: "my-ext-cmd", description: "Extension command", handler: async () => {} },
+					{ name: "fast", description: "Would shadow builtin", handler: async () => {} },
+				].filter(cmd => !reserved?.has(cmd.name));
+			},
+		};
+
+		await waitForBootstrapGuard();
+
+		const commandUpdates = harness.updates.filter(
+			update =>
+				update.sessionId === created.sessionId && update.update.sessionUpdate === "available_commands_update",
+		);
+		const names = commandUpdates.flatMap(update =>
+			update.update.sessionUpdate === "available_commands_update"
+				? update.update.availableCommands.map(command => command.name)
+				: [],
+		);
+
+		// Extension command must surface.
+		expect(names).toContain("my-ext-cmd");
+		// ACP builtin "fast" must still appear exactly once (not shadowed/duplicated).
+		expect(names.filter(n => n === "fast").length).toBe(1);
+		// Extension command that collided with the builtin must not add a duplicate.
+		// (The builtin "fast" entry wins via the reserved-set exclusion.)
+		const fastEntries = commandUpdates.flatMap(update =>
+			update.update.sessionUpdate === "available_commands_update"
+				? update.update.availableCommands.filter(c => c.name === "fast")
+				: [],
+		);
+		expect(fastEntries.length).toBe(1);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
 	it("executes skill commands through custom skill messages", async () => {
 		const harness = await createHarness();
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1347,11 +1347,25 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
-	it("rejects overlapping prompts while AgentSession is still streaming", async () => {
+	it("auto-cancels an in-progress turn and queues a new prompt when called mid-flight", async () => {
 		const harness = await createHarness();
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
 		const session = harness.findSession(created.sessionId)!;
-		const finishPrompt = holdPromptStreaming(session);
+		// Use custom prompt mock that lets us unblock both calls cleanly
+		const blockers: Array<() => void> = [];
+		session.prompt = async (text: string): Promise<void> => {
+			session.promptCalls.push(text);
+			session.isStreaming = true;
+			const { promise, resolve } = Promise.withResolvers<void>();
+			blockers.push(resolve);
+			await promise;
+			const assistantMessage = makeAssistantMessage("pong");
+			session.sessionManager.appendMessage(assistantMessage);
+			for (const listener of session.listeners()) {
+				listener({ type: "agent_end", messages: [assistantMessage] } as AgentSessionEvent);
+			}
+			session.isStreaming = false;
+		};
 
 		const firstPrompt = harness.agent.prompt({
 			sessionId: created.sessionId,
@@ -1359,22 +1373,30 @@ describe("ACP agent", () => {
 			prompt: [{ type: "text", text: "long running" }],
 		} as PromptRequest);
 		await Bun.sleep(0);
+		// First session.prompt is blocking; only "long running" has been seen so far
+		expect(session.promptCalls).toEqual(["long running"]);
 
-		try {
-			await expect(
-				harness.agent.prompt({
-					sessionId: created.sessionId,
-					messageId: "00000000-0000-4000-8000-000000000036",
-					prompt: [{ type: "text", text: "overlap" }],
-				} as PromptRequest),
-			).rejects.toThrow("ACP prompt already in progress for this session");
-			expect(session.promptCalls).toEqual(["long running"]);
-		} finally {
-			finishPrompt();
-			await firstPrompt;
-			harness.abortController.abort();
-			await Bun.sleep(0);
-		}
+		// Second prompt arrives mid-flight — must auto-cancel first, then queue
+		const secondPrompt = harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000036",
+			prompt: [{ type: "text", text: "overlap" }],
+		} as PromptRequest);
+
+		// First resolves immediately as cancelled; second is still queued
+		const firstResponse = await firstPrompt;
+		expect(firstResponse.stopReason).toBe("cancelled");
+
+		// Let microtasks settle: abort completes, second session.prompt starts
+		await Bun.sleep(0);
+		// Unblock both session.prompt calls: first (background, fire-and-forget) + second
+		for (const resolve of blockers) resolve();
+		const secondResponse = await secondPrompt;
+		expect(secondResponse.stopReason).toBe("end_turn");
+		expect(session.promptCalls).toEqual(["long running", "overlap"]);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
 	});
 
 	it("waits for AgentSession idle cleanup after agent_end before returning", async () => {

--- a/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-empty-stop-guard.test.ts
@@ -128,7 +128,7 @@ function reminderMessages(messages: AgentMessage[]): AgentMessage[] {
 	});
 }
 
-async function expectPromptCompletes(prompt: Promise<void>): Promise<void> {
+async function expectPromptCompletes(prompt: Promise<boolean>): Promise<void> {
 	await Promise.race([
 		prompt,
 		Bun.sleep(1_000).then(() => {

--- a/packages/coding-agent/test/issue-927-repro.test.ts
+++ b/packages/coding-agent/test/issue-927-repro.test.ts
@@ -44,7 +44,7 @@ describe("issue #927 optimistic pending spinner", () => {
 			settings: Settings.isolated(),
 			modelRegistry,
 		});
-		vi.spyOn(session, "prompt").mockResolvedValue(undefined);
+		vi.spyOn(session, "prompt").mockResolvedValue(true);
 		mode = new InteractiveMode(session, "test");
 		mode.addMessageToChat = vi.fn();
 		mode.ui.requestRender = vi.fn();

--- a/packages/coding-agent/test/main-interactive-input.test.ts
+++ b/packages/coding-agent/test/main-interactive-input.test.ts
@@ -21,7 +21,7 @@ describe("submitInteractiveInput", () => {
 			checkShutdownRequested: vi.fn(async () => {}),
 		};
 		const session = {
-			prompt: vi.fn(async () => {}),
+			prompt: vi.fn(async () => true),
 			promptCustomMessage: vi.fn(async () => {}),
 		};
 		const input = createInput({ text: "", started: true });
@@ -42,7 +42,7 @@ describe("submitInteractiveInput", () => {
 			checkShutdownRequested: vi.fn(async () => {}),
 		};
 		const session = {
-			prompt: vi.fn(async () => {}),
+			prompt: vi.fn(async () => true),
 			promptCustomMessage: vi.fn(async () => {}),
 		};
 		const input = createInput();
@@ -63,7 +63,7 @@ describe("submitInteractiveInput", () => {
 			checkShutdownRequested: vi.fn(async () => {}),
 		};
 		const session = {
-			prompt: vi.fn(async () => {}),
+			prompt: vi.fn(async () => true),
 			promptCustomMessage: vi.fn(async () => {}),
 		};
 		const input = createInput({ text: "continue goal", customType: "goal-continuation" });

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -973,6 +973,18 @@ describe("filterAvailableModelsByEnabledPatterns", () => {
 		expect(result[0].id).toBe("qwen/qwen3-coder:exacto");
 	});
 
+	test("matches bare OpenRouter-style model id with slash but no provider prefix", () => {
+		const openRouterModels = mockOpenRouterModels as Model[];
+		const result = filterAvailableModelsByEnabledPatterns(
+			openRouterModels,
+			["qwen/qwen3-coder:exacto"],
+			registry,
+		);
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe("qwen/qwen3-coder:exacto");
+		expect(result[0].provider).toBe("openrouter");
+	});
+
 	test("returns all models when ALL patterns are globs (cannot evaluate)", () => {
 		const result = filterAvailableModelsByEnabledPatterns(models, ["anthropic/*"], registry);
 		expect(result).toEqual(models);

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -956,20 +956,41 @@ describe("filterAvailableModelsByEnabledPatterns", () => {
 		expect(result[0].id).toBe("claude-sonnet-4-5");
 	});
 
-	test("strips thinking-level suffix before matching", () => {
+	test("strips :thinkingLevel suffix before matching", () => {
 		const result = filterAvailableModelsByEnabledPatterns(models, ["anthropic/claude-sonnet-4-5:high"], registry);
 		expect(result).toHaveLength(1);
 		expect(result[0].id).toBe("claude-sonnet-4-5");
 	});
 
-	test("returns all models when a glob pattern is present", () => {
+	test("preserves colon-bearing OpenRouter ids (suffix is not a thinking level)", () => {
+		const openRouterModels = mockOpenRouterModels as Model[];
+		const result = filterAvailableModelsByEnabledPatterns(
+			openRouterModels,
+			["openrouter/qwen/qwen3-coder:exacto"],
+			registry,
+		);
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe("qwen/qwen3-coder:exacto");
+	});
+
+	test("returns all models when ALL patterns are globs (cannot evaluate)", () => {
 		const result = filterAvailableModelsByEnabledPatterns(models, ["anthropic/*"], registry);
 		expect(result).toEqual(models);
 	});
 
-	test("returns all models when no pattern matches (rather than empty)", () => {
+	test("applies exact patterns when mixed with globs", () => {
+		const result = filterAvailableModelsByEnabledPatterns(
+			models,
+			["anthropic/*", "openai/gpt-4o"],
+			registry,
+		);
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe("gpt-4o");
+	});
+
+	test("returns empty list when no pattern matches (misconfiguration)", () => {
 		const result = filterAvailableModelsByEnabledPatterns(models, ["nonexistent-model"], registry);
-		expect(result).toEqual(models);
+		expect(result).toHaveLength(0);
 	});
 
 	test("includes multiple patterns from different providers", () => {

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { Effort, type Model } from "@oh-my-pi/pi-ai";
 import {
 	expandRoleAlias,
+	filterAvailableModelsByEnabledPatterns,
 	parseModelPattern,
 	parseModelString,
 	resolveAgentModelPatterns,
@@ -920,5 +921,63 @@ describe("expandRoleAlias", () => {
 		settings.setModelRole("default", "anthropic/claude-sonnet-4-5");
 
 		expect(expandRoleAlias("pi/vision", settings)).toBe("pi/vision");
+	});
+});
+
+describe("filterAvailableModelsByEnabledPatterns", () => {
+	const models = mockModels as Model[];
+	const registry = {
+		getCanonicalVariants: (_id: string, _opts?: unknown) => [] as { model: Model }[],
+	};
+
+	test("returns all models when patterns is empty", () => {
+		expect(filterAvailableModelsByEnabledPatterns(models, [], registry)).toEqual(models);
+	});
+
+	test("filters by exact provider/modelId", () => {
+		const result = filterAvailableModelsByEnabledPatterns(models, ["anthropic/claude-sonnet-4-5"], registry);
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe("claude-sonnet-4-5");
+	});
+
+	test("filters by bare model id matching across providers", () => {
+		const result = filterAvailableModelsByEnabledPatterns(models, ["claude-sonnet-4-5"], registry);
+		expect(result).toHaveLength(1);
+		expect(result[0].provider).toBe("anthropic");
+	});
+
+	test("expands canonical id via registry", () => {
+		const canonicalRegistry = {
+			getCanonicalVariants: (id: string, _opts?: unknown) =>
+				id === "claude-sonnet-4-5" ? [{ model: models[0] }] : [],
+		};
+		const result = filterAvailableModelsByEnabledPatterns(models, ["claude-sonnet-4-5"], canonicalRegistry);
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe("claude-sonnet-4-5");
+	});
+
+	test("strips thinking-level suffix before matching", () => {
+		const result = filterAvailableModelsByEnabledPatterns(models, ["anthropic/claude-sonnet-4-5:high"], registry);
+		expect(result).toHaveLength(1);
+		expect(result[0].id).toBe("claude-sonnet-4-5");
+	});
+
+	test("returns all models when a glob pattern is present", () => {
+		const result = filterAvailableModelsByEnabledPatterns(models, ["anthropic/*"], registry);
+		expect(result).toEqual(models);
+	});
+
+	test("returns all models when no pattern matches (rather than empty)", () => {
+		const result = filterAvailableModelsByEnabledPatterns(models, ["nonexistent-model"], registry);
+		expect(result).toEqual(models);
+	});
+
+	test("includes multiple patterns from different providers", () => {
+		const result = filterAvailableModelsByEnabledPatterns(
+			models,
+			["anthropic/claude-sonnet-4-5", "openai/gpt-4o"],
+			registry,
+		);
+		expect(result).toHaveLength(2);
 	});
 });

--- a/packages/coding-agent/test/task/executor-wall-clock.test.ts
+++ b/packages/coding-agent/test/task/executor-wall-clock.test.ts
@@ -41,6 +41,7 @@ function createHangingSession(): HangingSessionHandle {
 		subscribe: (_listener: (event: AgentSessionEvent) => void) => () => {},
 		prompt: async (_text: string, _options?: PromptOptions) => {
 			await hang;
+			return true;
 		},
 		waitForIdle: async () => {
 			await hang;
@@ -140,7 +141,7 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 				});
 				return () => {};
 			},
-			prompt: async () => {},
+			prompt: async () => true,
 			waitForIdle: async () => {},
 			getLastAssistantMessage: () => undefined,
 			abort: async () => {},
@@ -218,6 +219,7 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 			},
 			prompt: async (_text: string, _options?: PromptOptions) => {
 				await hang;
+				return true;
 			},
 			waitForIdle: async () => {
 				await hang;
@@ -294,7 +296,7 @@ describe("runSubprocess wall clock (task.maxRuntimeMs)", () => {
 				});
 				return () => {};
 			},
-			prompt: async () => {},
+			prompt: async () => true,
 			waitForIdle: async () => {},
 			getLastAssistantMessage: () => undefined,
 			abort: async () => {},


### PR DESCRIPTION
## Problem

When pressing the Stop button in Zed and immediately typing a new message, the session gets stuck with "Agent is already processing. Use steer() or followUp() to queue messages, or wait for completion."

The root cause: a new `session/prompt` RPC can arrive before (or without) a preceding `session/cancel` notification — Zed optimistically updates its UI and lets the user type immediately. The previous guard in `acp-agent.ts` threw an error when it saw an unsettled in-flight turn, blocking further interaction entirely.

## Fix

Replace the throw with an implicit cancel: call `#beginCancelCleanup` on the unsettled turn so it resolves with `stopReason: "cancelled"`, then let `#queuePrompt` serialize the new prompt behind the abort cleanup — identical to what happens when `session/cancel` is called explicitly first.

`#beginCancelCleanup` is idempotent, so a concurrent explicit `session/cancel` notification arriving slightly later is a harmless no-op.

## Changes

- **`src/modes/acp/acp-agent.ts`**: replace throw with `#beginCancelCleanup` in the fast-path overlap check
- **`test/acp-agent.test.ts`**: update test to assert new contract — overlapping prompt auto-cancels the first turn (`stopReason: "cancelled"`) and the second is processed normally
- **`CHANGELOG.md`**: entry under `[Unreleased]`