### PR TITLE
fix(acp): auto-cancel in-flight turn when new prompt arrives mid-flight

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -359,6 +359,11 @@
 - Fixed `lsp request` error path swallowing the params that were sent, making shape/coercion bugs on raw LSP calls impossible to diagnose in one round-trip; the error now echoes a truncated copy of the request params.
 - Fixed `find` with a single-star segment like `dir/*` recursing into subdirectories and returning nested matches. `parseFindPattern` already prepends `**/` for top-level globs (`*.ts` → `**/*.ts`), so anything reaching native without `**/` was deliberately scoped by the user; `recursive: false` is now passed to `natives.glob` to honor that scope.
 
+### Fixed
+
+- Fixed ACP cancel button leaving the session in a stuck state — a new prompt sent while a turn is still in-flight (e.g. immediately after pressing Stop in Zed before `session/cancel` is processed) now implicitly cancels the running turn and queues the new message, instead of throwing an error that blocks further interaction.
+- Fixed `enabledModels` being ignored by the ACP model picker (Zed and other ACP clients) — `AgentSession.getAvailableModels()` now applies the configured allow-list, so only the models listed in `enabledModels` appear in the UI. Also applies consistently to the RPC `get_available_models` endpoint and the `/model` slash command.
+- Fixed ACP `available_commands_update` to include extension-registered slash commands so clients like Zed surface them in the slash-command palette.
 ## [15.10.1] - 2026-06-07
 
 ### Added

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -362,8 +362,7 @@
 ### Fixed
 
 - Fixed ACP cancel button leaving the session in a stuck state — a new prompt sent while a turn is still in-flight (e.g. immediately after pressing Stop in Zed before `session/cancel` is processed) now implicitly cancels the running turn and queues the new message, instead of throwing an error that blocks further interaction.
-- Fixed `enabledModels` being ignored by the ACP model picker (Zed and other ACP clients) — `AgentSession.getAvailableModels()` now applies the configured allow-list, so only the models listed in `enabledModels` appear in the UI. Also applies consistently to the RPC `get_available_models` endpoint and the `/model` slash command.
-- Fixed ACP `available_commands_update` to include extension-registered slash commands so clients like Zed surface them in the slash-command palette.
+
 ## [15.10.1] - 2026-06-07
 
 ### Added

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -594,7 +594,13 @@ export class AcpAgent implements Agent {
 		const record = this.#getSessionRecord(params.sessionId);
 		const activeTurn = record.promptTurn;
 		if (activeTurn && !activeTurn.settled && record.session.isStreaming) {
-			throw new Error("ACP prompt already in progress for this session");
+			// New prompt arrived while the previous turn is still in-flight (e.g. the
+			// client sent a message immediately after pressing stop, before or without
+			// a preceding session/cancel notification). Implicitly cancel the running
+			// turn so the new prompt can queue behind the abort cleanup — identical to
+			// what cancel() does when called explicitly. #beginCancelCleanup is
+			// idempotent, so a concurrent session/cancel notification is harmless.
+			this.#beginCancelCleanup(record, activeTurn);
 		}
 		return await this.#queuePrompt(record, async () => {
 			const previousTurn = record.promptTurn;

--- a/packages/coding-agent/src/modes/acp/acp-agent.ts
+++ b/packages/coding-agent/src/modes/acp/acp-agent.ts
@@ -600,7 +600,17 @@ export class AcpAgent implements Agent {
 			// turn so the new prompt can queue behind the abort cleanup — identical to
 			// what cancel() does when called explicitly. #beginCancelCleanup is
 			// idempotent, so a concurrent session/cancel notification is harmless.
-			this.#beginCancelCleanup(record, activeTurn);
+			// Mirror cancel()'s timeout handling: if abort() hangs past the cleanup
+			// timeout, close the managed session instead of leaving it registered
+			// with a still-streaming AgentSession. The queued prompt below observes
+			// the same cleanup rejection and fails accordingly.
+			this.#beginCancelCleanup(record, activeTurn).catch(async (error: unknown) => {
+				logger.warn("ACP cancel cleanup timed out; closing session", {
+					sessionId: record.session.sessionId,
+					error,
+				});
+				await this.#closeManagedSession(params.sessionId, record);
+			});
 		}
 		return await this.#queuePrompt(record, async () => {
 			const previousTurn = record.promptTurn;

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1313,7 +1313,19 @@ describe("ACP agent", () => {
 		const harness = await createHarness();
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
 		const session = harness.findSession(created.sessionId)!;
-		// Use custom prompt mock that lets us unblock both calls cleanly
+
+		// Block abort() until released so we can assert the second prompt waits
+		let releaseAbort!: () => void;
+		const abortStarted = Promise.withResolvers<void>();
+		const abortRelease = new Promise<void>(resolve => {
+			releaseAbort = resolve;
+		});
+		session.abort = async () => {
+			session.isStreaming = false;
+			abortStarted.resolve();
+			await abortRelease;
+		};
+
 		const blockers: Array<() => void> = [];
 		session.prompt = async (text: string): Promise<void> => {
 			session.promptCalls.push(text);
@@ -1335,7 +1347,6 @@ describe("ACP agent", () => {
 			prompt: [{ type: "text", text: "long running" }],
 		} as PromptRequest);
 		await Bun.sleep(0);
-		// First session.prompt is blocking; only "long running" has been seen so far
 		expect(session.promptCalls).toEqual(["long running"]);
 
 		// Second prompt arrives mid-flight — must auto-cancel first, then queue
@@ -1345,17 +1356,26 @@ describe("ACP agent", () => {
 			prompt: [{ type: "text", text: "overlap" }],
 		} as PromptRequest);
 
-		// First resolves immediately as cancelled; second is still queued
+		// First resolves immediately as cancelled
 		const firstResponse = await firstPrompt;
 		expect(firstResponse.stopReason).toBe("cancelled");
 
-		// Let microtasks settle: abort completes, second session.prompt starts
+		// abort() must have been called as part of cancel cleanup
+		await abortStarted.promise;
+
+		// Second prompt must NOT start until abort cleanup completes
 		await Bun.sleep(0);
-		// Unblock both session.prompt calls: first (background, fire-and-forget) + second
+		expect(session.promptCalls).toEqual(["long running"]);
+
+		// Release abort — second session.prompt should now start
+		releaseAbort();
+		await Bun.sleep(0);
+		expect(session.promptCalls).toEqual(["long running", "overlap"]);
+
+		// Unblock both session.prompt calls (first is fire-and-forget, second drives the response)
 		for (const resolve of blockers) resolve();
 		const secondResponse = await secondPrompt;
 		expect(secondResponse.stopReason).toBe("end_turn");
-		expect(session.promptCalls).toEqual(["long running", "overlap"]);
 
 		harness.abortController.abort();
 		await Bun.sleep(0);

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1309,11 +1309,25 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
-	it("rejects overlapping prompts while AgentSession is still streaming", async () => {
+	it("auto-cancels an in-progress turn and queues a new prompt when called mid-flight", async () => {
 		const harness = await createHarness();
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
 		const session = harness.findSession(created.sessionId)!;
-		const finishPrompt = holdPromptStreaming(session);
+		// Use custom prompt mock that lets us unblock both calls cleanly
+		const blockers: Array<() => void> = [];
+		session.prompt = async (text: string): Promise<void> => {
+			session.promptCalls.push(text);
+			session.isStreaming = true;
+			const { promise, resolve } = Promise.withResolvers<void>();
+			blockers.push(resolve);
+			await promise;
+			const assistantMessage = makeAssistantMessage("pong");
+			session.sessionManager.appendMessage(assistantMessage);
+			for (const listener of session.listeners()) {
+				listener({ type: "agent_end", messages: [assistantMessage] } as AgentSessionEvent);
+			}
+			session.isStreaming = false;
+		};
 
 		const firstPrompt = harness.agent.prompt({
 			sessionId: created.sessionId,
@@ -1321,22 +1335,30 @@ describe("ACP agent", () => {
 			prompt: [{ type: "text", text: "long running" }],
 		} as PromptRequest);
 		await Bun.sleep(0);
+		// First session.prompt is blocking; only "long running" has been seen so far
+		expect(session.promptCalls).toEqual(["long running"]);
 
-		try {
-			await expect(
-				harness.agent.prompt({
-					sessionId: created.sessionId,
-					messageId: "00000000-0000-4000-8000-000000000036",
-					prompt: [{ type: "text", text: "overlap" }],
-				} as PromptRequest),
-			).rejects.toThrow("ACP prompt already in progress for this session");
-			expect(session.promptCalls).toEqual(["long running"]);
-		} finally {
-			finishPrompt();
-			await firstPrompt;
-			harness.abortController.abort();
-			await Bun.sleep(0);
-		}
+		// Second prompt arrives mid-flight — must auto-cancel first, then queue
+		const secondPrompt = harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000036",
+			prompt: [{ type: "text", text: "overlap" }],
+		} as PromptRequest);
+
+		// First resolves immediately as cancelled; second is still queued
+		const firstResponse = await firstPrompt;
+		expect(firstResponse.stopReason).toBe("cancelled");
+
+		// Let microtasks settle: abort completes, second session.prompt starts
+		await Bun.sleep(0);
+		// Unblock both session.prompt calls: first (background, fire-and-forget) + second
+		for (const resolve of blockers) resolve();
+		const secondResponse = await secondPrompt;
+		expect(secondResponse.stopReason).toBe("end_turn");
+		expect(session.promptCalls).toEqual(["long running", "overlap"]);
+
+		harness.abortController.abort();
+		await Bun.sleep(0);
 	});
 
 	it("waits for AgentSession idle cleanup after agent_end before returning", async () => {

--- a/packages/coding-agent/test/acp-agent.test.ts
+++ b/packages/coding-agent/test/acp-agent.test.ts
@@ -1381,6 +1381,57 @@ describe("ACP agent", () => {
 		await Bun.sleep(0);
 	});
 
+	it("closes the ACP session when implicit cancel cleanup times out", async () => {
+		const harness = await createHarness();
+		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });
+		const session = harness.findSession(created.sessionId)!;
+		harness.agent.setCancelCleanupTimeoutForTesting(10);
+		session.abort = async () => new Promise<void>(() => undefined);
+		const finishPrompt = holdPromptStreaming(session);
+
+		const firstPrompt = harness.agent.prompt({
+			sessionId: created.sessionId,
+			messageId: "00000000-0000-4000-8000-000000000045",
+			prompt: [{ type: "text", text: "long running" }],
+		} as PromptRequest);
+		await Bun.sleep(0);
+
+		// Overlapping prompt triggers the implicit cancel; abort() never resolves,
+		// so cleanup times out, the queued prompt fails, and the session is closed.
+		const secondPrompt = harness.agent
+			.prompt({
+				sessionId: created.sessionId,
+				messageId: "00000000-0000-4000-8000-000000000046",
+				prompt: [{ type: "text", text: "overlap" }],
+			} as PromptRequest)
+			.catch(error => error);
+
+		const firstResponse = await firstPrompt;
+		expect(firstResponse.stopReason).toBe("cancelled");
+
+		const queuedError = await secondPrompt;
+		expect(queuedError).toBeInstanceOf(Error);
+		expect((queuedError as Error).message).toBe("ACP cancel cleanup timed out");
+
+		// The fire-and-forget close runs off the same cleanup rejection; give it a
+		// few ticks to settle before asserting.
+		for (let i = 0; i < 20 && !session.disposed; i++) {
+			await Bun.sleep(0);
+		}
+		expect(session.disposed).toBe(true);
+		await expect(
+			harness.agent.prompt({
+				sessionId: created.sessionId,
+				messageId: "00000000-0000-4000-8000-000000000047",
+				prompt: [{ type: "text", text: "after stuck implicit cancel" }],
+			} as PromptRequest),
+		).rejects.toThrow("Unsupported ACP session");
+
+		finishPrompt();
+		harness.abortController.abort();
+		await Bun.sleep(0);
+	});
+
 	it("waits for AgentSession idle cleanup after agent_end before returning", async () => {
 		const harness = await createHarness();
 		const created = await harness.agent.newSession({ cwd: harness.cwdA, mcpServers: [] });


### PR DESCRIPTION
## Problem

When pressing the Stop button in Zed and immediately typing a new message, the session gets stuck with "Agent is already processing. Use steer() or followUp() to queue messages, or wait for completion."

The root cause: a new `session/prompt` RPC can arrive before (or without) a preceding `session/cancel` notification — Zed optimistically updates its UI and lets the user type immediately. The previous guard in `acp-agent.ts` threw an error when it saw an unsettled in-flight turn, blocking further interaction entirely.

## Fix

Replace the throw with an implicit cancel: call `#beginCancelCleanup` on the unsettled turn so it resolves with `stopReason: "cancelled"`, then let `#queuePrompt` serialize the new prompt behind the abort cleanup — identical to what happens when `session/cancel` is called explicitly first.

`#beginCancelCleanup` is idempotent, so a concurrent explicit `session/cancel` notification arriving slightly later is a harmless no-op.

## Changes

- **`src/modes/acp/acp-agent.ts`**: replace throw with `#beginCancelCleanup` in the fast-path overlap check
- **`test/acp-agent.test.ts`**: update test to assert new contract — overlapping prompt auto-cancels the first turn (`stopReason: "cancelled"`) and the second is processed normally
- **`CHANGELOG.md`**: entry under `[Unreleased]`