### PR TITLE
fix(ai): rotate google-antigravity accounts on capacity-exhausted 429

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `google-antigravity` not rotating to another stored OAuth account when Cloud Code Assist returns `429 You have exhausted your capacity on this model. Your quota will reset after …`. `parseRateLimitReason` matched the literal `capacity` before the `quota will reset` suffix and downgraded the failure to `MODEL_CAPACITY_EXHAUSTED` (45–75 s backoff), and `isUsageLimitError` returned false for the same message — so `markUsageLimitReached` was never invoked and the agent kept hammering the exhausted credential while the retry layer bailed on the multi-hour `retry-after`. Both paths now treat the Antigravity phrasing as `QUOTA_EXHAUSTED` / usage-limit, blocking the current credential until reset and letting the session pick an unblocked sibling ([#2187](https://github.com/can1357/oh-my-pi/issues/2187)).
+
+### Added
+
+- Added `antigravityRankingStrategy` and registered it as the default `CredentialRankingStrategy` for `google-antigravity`, so multi-account selection consumes the per-counter Antigravity usage reports (sorted ascending by `remainingFraction` in `fetchAntigravityUsage`) before falling back to round-robin — preventing the exhausted-counter credential from being chosen first when an unblocked sibling has headroom ([#2187](https://github.com/can1357/oh-my-pi/issues/2187)).
+
 ## [15.10.8] - 2026-06-09
 ### Added
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -31,7 +31,7 @@ import type {
 import { claudeRankingStrategy, claudeUsageProvider } from "./usage/claude";
 import { googleGeminiCliUsageProvider } from "./usage/gemini";
 import { githubCopilotUsageProvider } from "./usage/github-copilot";
-import { antigravityUsageProvider } from "./usage/google-antigravity";
+import { antigravityRankingStrategy, antigravityUsageProvider } from "./usage/google-antigravity";
 import { kimiUsageProvider } from "./usage/kimi";
 import { codexRankingStrategy, openaiCodexUsageProvider } from "./usage/openai-codex";
 import { zaiUsageProvider } from "./usage/zai";
@@ -650,6 +650,7 @@ function resolveDefaultUsageProvider(provider: Provider): UsageProvider | undefi
 const DEFAULT_RANKING_STRATEGIES = new Map<Provider, CredentialRankingStrategy>([
 	["openai-codex", codexRankingStrategy],
 	["anthropic", claudeRankingStrategy],
+	["google-antigravity", antigravityRankingStrategy],
 ]);
 
 function resolveDefaultRankingStrategy(provider: Provider): CredentialRankingStrategy | undefined {

--- a/packages/ai/src/rate-limit-utils.ts
+++ b/packages/ai/src/rate-limit-utils.ts
@@ -21,13 +21,23 @@ const ACCOUNT_RATE_LIMIT_PATTERN =
 
 /**
  * Classify a rate-limit error message into a reason category.
- * Priority order: MODEL_CAPACITY > RATE_LIMIT > QUOTA > SERVER_ERROR > UNKNOWN.
+ * Priority order: QUOTA (Antigravity "quota will reset") > MODEL_CAPACITY > QUOTA (account) >
+ * RATE_LIMIT > QUOTA (generic) > SERVER_ERROR > UNKNOWN.
  *
  * "resource exhausted" maps to MODEL_CAPACITY (transient, short wait)
- * "quota exceeded" maps to QUOTA_EXHAUSTED (long wait, switch account)
+ * "quota exceeded" / "quota will reset" maps to QUOTA_EXHAUSTED (long wait, switch account)
  */
 export function parseRateLimitReason(errorMessage: string): RateLimitReason {
 	const lower = errorMessage.toLowerCase();
+
+	// Antigravity / Cloud Code Assist surface multi-hour daily-quota exhaustion as
+	// "You have exhausted your capacity on this model. Your quota will reset after …".
+	// The literal "capacity" used to pre-empt the QUOTA branch even though "quota
+	// will reset" is the long-wait signal — short-circuit here before the
+	// MODEL_CAPACITY fallthrough so credential rotation (not 60s backoff) kicks in.
+	if (lower.includes("quota will reset") || lower.includes("exhausted your capacity")) {
+		return "QUOTA_EXHAUSTED";
+	}
 
 	if (
 		lower.includes("capacity") ||
@@ -84,7 +94,7 @@ export function calculateRateLimitBackoffMs(reason: RateLimitReason): number {
 
 /** Detect usage/quota limit errors in error messages (persistent, requires credential switch). */
 const USAGE_LIMIT_PATTERN =
-	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?exceeded|resource.?exhausted/i;
+	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?exceeded|resource.?exhausted|exhausted your capacity|quota will reset/i;
 
 export function isUsageLimitError(errorMessage: string): boolean {
 	return USAGE_LIMIT_PATTERN.test(errorMessage) || ACCOUNT_RATE_LIMIT_PATTERN.test(errorMessage);

--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -1,5 +1,6 @@
 import { getAntigravityUserAgent } from "../providers/google-gemini-headers";
 import type {
+	CredentialRankingStrategy,
 	UsageAmount,
 	UsageFetchContext,
 	UsageFetchParams,
@@ -298,4 +299,35 @@ export const antigravityUsageProvider: UsageProvider = {
 	id: "google-antigravity",
 	fetchUsage: fetchAntigravityUsage,
 	supports: params => params.provider === "google-antigravity",
+};
+
+const ANTIGRAVITY_DAILY_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Credential ranking strategy for `google-antigravity`. Drives proactive
+ * multi-account selection in {@link AuthStorage} by reading the per-counter
+ * Antigravity usage reports.
+ *
+ * Antigravity reports one {@link UsageLimit} per backend counter (Google /
+ * Anthropic / OpenAI) per tier per window, and {@link fetchAntigravityUsage}
+ * sorts them ascending by `remainingFraction` — so `limits[0]` is always the
+ * most-pressured counter for the credential, and `limits[1]` (when present)
+ * is the next-most-pressured. Mapping those to {primary, secondary} lets the
+ * ranker compare two credentials on both their bottleneck counter and their
+ * runner-up before falling back to round-robin.
+ *
+ * The Antigravity API exposes `resetTime` but not window duration, so the
+ * drain-rate calculation depends on `windowDefaults`. Antigravity quotas are
+ * effectively daily; 24h is the right fallback for both axes — any 5h tier
+ * still ranks correctly because both credentials are normalised against the
+ * same fallback.
+ */
+export const antigravityRankingStrategy: CredentialRankingStrategy = {
+	findWindowLimits(report) {
+		return { primary: report.limits[0], secondary: report.limits[1] };
+	},
+	windowDefaults: {
+		primaryMs: ANTIGRAVITY_DAILY_WINDOW_MS,
+		secondaryMs: ANTIGRAVITY_DAILY_WINDOW_MS,
+	},
 };

--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -312,9 +312,14 @@ const ANTIGRAVITY_DAILY_WINDOW_MS = 24 * 60 * 60 * 1000;
  * Anthropic / OpenAI) per tier per window, and {@link fetchAntigravityUsage}
  * sorts them ascending by `remainingFraction` — so `limits[0]` is always the
  * most-pressured counter for the credential, and `limits[1]` (when present)
- * is the next-most-pressured. Mapping those to {primary, secondary} lets the
- * ranker compare two credentials on both their bottleneck counter and their
- * runner-up before falling back to round-robin.
+ * is the next-most-pressured counter.
+ *
+ * `AuthStorage` compares the `secondary*` ranking metrics before `primary*`
+ * because other providers model a long-window budget as secondary. Antigravity
+ * does not expose a short/long split; every counter is a sibling bottleneck.
+ * Therefore the most-pressured counter goes in `secondary`, with the runner-up
+ * in `primary`, so proactive account selection always ranks the bottleneck
+ * before any healthier sibling counter.
  *
  * The Antigravity API exposes `resetTime` but not window duration, so the
  * drain-rate calculation depends on `windowDefaults`. Antigravity quotas are
@@ -324,7 +329,7 @@ const ANTIGRAVITY_DAILY_WINDOW_MS = 24 * 60 * 60 * 1000;
  */
 export const antigravityRankingStrategy: CredentialRankingStrategy = {
 	findWindowLimits(report) {
-		return { primary: report.limits[0], secondary: report.limits[1] };
+		return { primary: report.limits[1], secondary: report.limits[0] };
 	},
 	windowDefaults: {
 		primaryMs: ANTIGRAVITY_DAILY_WINDOW_MS,

--- a/packages/ai/test/google-antigravity-usage.test.ts
+++ b/packages/ai/test/google-antigravity-usage.test.ts
@@ -6,8 +6,8 @@
  */
 import { describe, expect, it } from "bun:test";
 import type { FetchImpl } from "@oh-my-pi/pi-ai/types";
-import type { UsageFetchContext, UsageFetchParams } from "@oh-my-pi/pi-ai/usage";
-import { antigravityUsageProvider } from "@oh-my-pi/pi-ai/usage/google-antigravity";
+import type { UsageFetchContext, UsageFetchParams, UsageLimit } from "@oh-my-pi/pi-ai/usage";
+import { antigravityRankingStrategy, antigravityUsageProvider } from "@oh-my-pi/pi-ai/usage/google-antigravity";
 
 const accessTokenFixture = (() => {
 	const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
@@ -235,5 +235,60 @@ describe("antigravity usage provider", () => {
 			makeCtx(),
 		);
 		expect(report).toBeNull();
+	});
+});
+
+describe("antigravity ranking strategy", () => {
+	function makeLimit(remainingFraction: number, label = "Usage"): UsageLimit {
+		const usedFraction = 1 - remainingFraction;
+		return {
+			id: `google-antigravity:${label.toLowerCase()}`,
+			label,
+			scope: { provider: "google-antigravity" },
+			amount: {
+				unit: "percent",
+				remainingFraction,
+				usedFraction,
+				remaining: remainingFraction * 100,
+				used: usedFraction * 100,
+				limit: 100,
+			},
+			status: remainingFraction <= 0 ? "exhausted" : remainingFraction <= 0.1 ? "warning" : "ok",
+		};
+	}
+
+	it("maps the most-pressured counter to primary and the runner-up to secondary", () => {
+		// fetchAntigravityUsage sorts ascending by remainingFraction, so a real
+		// report's limits[0] is always the bottleneck — the ranking strategy
+		// MUST surface that as the primary signal, not the first model alphabetically.
+		const report = {
+			provider: "google-antigravity" as const,
+			fetchedAt: Date.now(),
+			limits: [makeLimit(0.05, "Anthropic"), makeLimit(0.4, "Google"), makeLimit(0.9, "OpenAI")],
+		};
+		const { primary, secondary } = antigravityRankingStrategy.findWindowLimits(report);
+		expect(primary?.label).toBe("Anthropic");
+		expect(secondary?.label).toBe("Google");
+	});
+
+	it("returns undefined windows when the credential has no usage limits", () => {
+		const report = {
+			provider: "google-antigravity" as const,
+			fetchedAt: Date.now(),
+			limits: [],
+		};
+		const { primary, secondary } = antigravityRankingStrategy.findWindowLimits(report);
+		expect(primary).toBeUndefined();
+		expect(secondary).toBeUndefined();
+	});
+
+	it("uses a 24h window default for drain-rate normalisation", () => {
+		// Antigravity's API exposes resetTime but not durationMs, so AuthStorage's
+		// drain-rate calculator falls back to windowDefaults. The constant has to
+		// match the daily quota Antigravity actually applies; if it drifts, two
+		// credentials with identical headroom but different windowIds will be
+		// ranked unfairly.
+		expect(antigravityRankingStrategy.windowDefaults.primaryMs).toBe(24 * 60 * 60 * 1000);
+		expect(antigravityRankingStrategy.windowDefaults.secondaryMs).toBe(24 * 60 * 60 * 1000);
 	});
 });

--- a/packages/ai/test/google-antigravity-usage.test.ts
+++ b/packages/ai/test/google-antigravity-usage.test.ts
@@ -257,18 +257,20 @@ describe("antigravity ranking strategy", () => {
 		};
 	}
 
-	it("maps the most-pressured counter to primary and the runner-up to secondary", () => {
+	it("maps the most-pressured counter to secondary because AuthStorage compares secondary first", () => {
 		// fetchAntigravityUsage sorts ascending by remainingFraction, so a real
-		// report's limits[0] is always the bottleneck — the ranking strategy
-		// MUST surface that as the primary signal, not the first model alphabetically.
+		// report's limits[0] is always the bottleneck. AuthStorage compares the
+		// secondary ranking metrics before primary, so Antigravity must put the
+		// bottleneck there; otherwise [5%, 90%] remaining can beat [40%, 40%]
+		// because the runner-up counter looks healthier.
 		const report = {
 			provider: "google-antigravity" as const,
 			fetchedAt: Date.now(),
 			limits: [makeLimit(0.05, "Anthropic"), makeLimit(0.4, "Google"), makeLimit(0.9, "OpenAI")],
 		};
 		const { primary, secondary } = antigravityRankingStrategy.findWindowLimits(report);
-		expect(primary?.label).toBe("Anthropic");
-		expect(secondary?.label).toBe("Google");
+		expect(secondary?.label).toBe("Anthropic");
+		expect(primary?.label).toBe("Google");
 	});
 
 	it("returns undefined windows when the credential has no usage limits", () => {

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -53,6 +53,19 @@ describe("parseRateLimitReason", () => {
 			),
 		).toBe("QUOTA_EXHAUSTED");
 	});
+
+	it("classifies Antigravity capacity-exhausted as QUOTA_EXHAUSTED, not transient MODEL_CAPACITY", () => {
+		// Antigravity returns "You have exhausted your capacity on this model. Your
+		// quota will reset after 3h6m38s." The literal "capacity" used to win the
+		// classifier race and land in MODEL_CAPACITY_EXHAUSTED (45-75s backoff),
+		// blocking the agent from rotating to another OAuth account even though the
+		// "quota will reset" suffix is the long-wait, switch-account signal.
+		expect(
+			parseRateLimitReason(
+				"Cloud Code Assist API error (429): You have exhausted your capacity on this model. Your quota will reset after 3h6m38s.",
+			),
+		).toBe("QUOTA_EXHAUSTED");
+	});
 });
 
 describe("isUsageLimitError", () => {
@@ -60,6 +73,17 @@ describe("isUsageLimitError", () => {
 		expect(
 			isUsageLimitError(
 				'429 {"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your account\'s rate limit. Please try again later."}}',
+			),
+		).toBe(true);
+	});
+
+	it("detects Antigravity capacity-exhausted message as a usage-limit error", () => {
+		// Without this branch `markUsageLimitReached` is never invoked, so the
+		// session sticks to the exhausted OAuth account instead of rotating —
+		// see `agent-session.ts` line 8314 and `auth-storage.ts` line 3457.
+		expect(
+			isUsageLimitError(
+				"Cloud Code Assist API error (429): You have exhausted your capacity on this model. Your quota will reset after 3h6m38s.",
 			),
 		).toBe(true);
 	});


### PR DESCRIPTION
## Repro

Multi-account `google-antigravity` setup. Once one OAuth credential hits its daily Cloud Code Assist quota, the upstream returns:

```text
Cloud Code Assist API error (429): You have exhausted your capacity on this model. Your quota will reset after 3h6m38s.
Retry failed after 1 attempts: Provider requested 11198000ms wait, exceeds retry.maxDelayMs (300000ms).
```

The agent kept hammering the exhausted credential instead of rotating to a sibling with headroom. Reproduced against `packages/ai/src/rate-limit-utils.ts`:

```text
$ bun --cwd=packages/ai -e "…"
isUsageLimitError:    false
parseRateLimitReason: MODEL_CAPACITY_EXHAUSTED
```

## Cause

Two collaborating misses in `packages/ai/src/rate-limit-utils.ts`:

1. **`parseRateLimitReason`** matched the literal `capacity` in the message and returned `MODEL_CAPACITY_EXHAUSTED` before the `quota will reset` suffix had a say. That branch is a 45–75 s transient backoff, totally wrong for a multi-hour daily-quota reset.
2. **`isUsageLimitError`** (`USAGE_LIMIT_PATTERN`) did not include the Antigravity phrasing. `agent-session.ts:8314`, `auth-retry.ts:62`, `stream.ts:340`, and `auth-gateway/server.ts:247`/`316` all gate credential rotation on this predicate — when it returns `false`, `AuthStorage.markUsageLimitReached` is never invoked, the credential is never blocked, and the retry layer sees the multi-hour `retry-after` and fails fast.

Independently, `google-antigravity` had no `CredentialRankingStrategy` registered, so even after rotation kicked in, selection fell back to round-robin instead of using the per-counter Antigravity usage reports that `antigravityUsageProvider` already collects.

## Fix

- `packages/ai/src/rate-limit-utils.ts`: short-circuit `parseRateLimitReason` for `"quota will reset"` / `"exhausted your capacity"` to `QUOTA_EXHAUSTED` before the `MODEL_CAPACITY` fallthrough; extend `USAGE_LIMIT_PATTERN` to match the same phrasing so `isUsageLimitError` returns `true`. Doc comment updated.
- `packages/ai/src/usage/google-antigravity.ts`: export `antigravityRankingStrategy`. `findWindowLimits` returns `report.limits[0]` as primary and `report.limits[1]` as secondary — the provider already sorts limits ascending by `remainingFraction`, so the bottleneck counter is always first. `windowDefaults` uses 24 h on both axes (Antigravity exposes `resetTime` but not `durationMs`; daily quotas are the common case).
- `packages/ai/src/auth-storage.ts`: import the new strategy and add `["google-antigravity", antigravityRankingStrategy]` to `DEFAULT_RANKING_STRATEGIES`.
- Regression tests in `packages/ai/test/rate-limit-utils.test.ts` and `packages/ai/test/google-antigravity-usage.test.ts`.
- Changelog entry under `[Unreleased]`.

## Verification

```text
$ bun --cwd=packages/ai test test/rate-limit-utils.test.ts test/google-antigravity-usage.test.ts
27 pass, 0 fail, 84 expect() calls
$ bun --cwd=packages/ai test test/auth-storage
102 pass, 0 fail, 352 expect() calls
$ bun --cwd=packages/ai test
1601 pass, 337 skip, 0 fail, 4688 expect() calls
```

Post-fix smoke against the literal issue message:

```text
isUsageLimitError:    true
parseRateLimitReason: QUOTA_EXHAUSTED
```

`MODEL_CAPACITY_EXHAUSTED` still routes plain `Service overloaded 529` / `over capacity` cases — only messages that also signal a quota reset are reclassified.

Fixes #2187