### PR TITLE
fix(tui): restore MCP auth hyperlink fallback

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed MCP OAuth fallback prompts so the "Click here to authorize" label emits an auth-safe terminal hyperlink even when hyperlink auto-detection is unavailable, keeping non-browser MCP setup usable ([#2196](https://github.com/can1357/oh-my-pi/issues/2196)).
+
 ## [15.10.8] - 2026-06-09
 
 ### Added

--- a/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/mcp-command-controller.ts
@@ -36,7 +36,7 @@ import {
 import type { MCPAuthConfig, MCPServerConfig, MCPServerConnection } from "../../mcp/types";
 import type { OAuthCredential } from "../../session/auth-storage";
 import { shortenPath } from "../../tools/render-utils";
-import { urlHyperlink } from "../../tui";
+import { urlHyperlinkAlways } from "../../tui";
 import { openPath } from "../../utils/open";
 import { ChatBlock } from "../components/chat-block";
 import { MCPAddWizard } from "../components/mcp-add-wizard";
@@ -63,7 +63,7 @@ export class MCPAuthorizationLinkPrompt implements Component {
 	invalidate(): void {}
 
 	render(_width: number): string[] {
-		const link = urlHyperlink(this.#url, "Click here to authorize");
+		const link = urlHyperlinkAlways(this.#url, "Click here to authorize");
 		return [
 			` ${theme.fg("success", "Open authorization URL:")}`,
 			` ${theme.fg("accent", link)}`,

--- a/packages/coding-agent/src/tui/hyperlink.ts
+++ b/packages/coding-agent/src/tui/hyperlink.ts
@@ -18,6 +18,7 @@ import {
 
 const OSC = "\x1b]";
 const ST = "\x1b\\";
+const BEL = "\x07";
 
 /** Stable 8-char hex ID derived from a URI — hints terminals to coalesce identical adjacent links. */
 function buildLinkId(uri: string): string {
@@ -60,14 +61,18 @@ function safeHyperlinkUri(uri: string): string | undefined {
 	return uri;
 }
 
-function wrapHyperlink(uri: string, displayText: string): string {
-	if (!isHyperlinkEnabled()) return displayText;
+function wrapHyperlinkCore(uri: string, displayText: string, terminator: typeof ST | typeof BEL): string {
 	// Do not double-wrap if the text already embeds an OSC 8 sequence.
 	if (displayText.includes("\x1b]8;")) return displayText;
 	const safeUri = safeHyperlinkUri(uri);
 	if (!safeUri) return displayText;
 	const id = buildLinkId(safeUri);
-	return `${OSC}8;id=${id};${safeUri}${ST}${displayText}${OSC}8;;${ST}`;
+	return `${OSC}8;id=${id};${safeUri}${terminator}${displayText}${OSC}8;;${terminator}`;
+}
+
+function wrapHyperlink(uri: string, displayText: string): string {
+	if (!isHyperlinkEnabled()) return displayText;
+	return wrapHyperlinkCore(uri, displayText, ST);
 }
 
 /**
@@ -90,6 +95,22 @@ export function urlHyperlink(url: string, displayText: string): string {
 		const parsed = new URL(normalized);
 		if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return displayText;
 		return wrapHyperlink(parsed.href, displayText);
+	} catch {
+		return displayText;
+	}
+}
+
+/**
+ * Wrap `displayText` in an OSC 8 hyperlink pointing at an HTTP(S) URL without
+ * terminal capability gating. Used for auth prompts where an inert "click"
+ * label blocks login on terminals with incomplete capability detection.
+ */
+export function urlHyperlinkAlways(url: string, displayText: string): string {
+	const normalized = url.match(/^www\./i) ? `https://${url}` : url;
+	try {
+		const parsed = new URL(normalized);
+		if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return displayText;
+		return wrapHyperlinkCore(parsed.href, displayText, BEL);
 	} catch {
 		return displayText;
 	}

--- a/packages/coding-agent/src/tui/hyperlink.ts
+++ b/packages/coding-agent/src/tui/hyperlink.ts
@@ -101,11 +101,14 @@ export function urlHyperlink(url: string, displayText: string): string {
 }
 
 /**
- * Wrap `displayText` in an OSC 8 hyperlink pointing at an HTTP(S) URL without
- * terminal capability gating. Used for auth prompts where an inert "click"
- * label blocks login on terminals with incomplete capability detection.
+ * Wrap `displayText` in an OSC 8 hyperlink pointing at an HTTP(S) URL,
+ * bypassing terminal capability auto-detection. Used for auth prompts where
+ * an inert "click" label blocks login on terminals whose capabilities are
+ * not advertised. Still returns plain text when the user has explicitly
+ * opted out via `tui.hyperlinks=off`.
  */
 export function urlHyperlinkAlways(url: string, displayText: string): string {
+	if (settings.get("tui.hyperlinks") === "off") return displayText;
 	const normalized = url.match(/^www\./i) ? `https://${url}` : url;
 	try {
 		const parsed = new URL(normalized);

--- a/packages/coding-agent/test/modes/controllers/mcp-authorization-link.test.ts
+++ b/packages/coding-agent/test/modes/controllers/mcp-authorization-link.test.ts
@@ -5,10 +5,10 @@ import { MCPAuthorizationLinkPrompt } from "@oh-my-pi/pi-coding-agent/modes/cont
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 
 const OSC = "\x1b]";
-const ST = "\x1b\\";
+const BEL = "\x07";
 
 function extractLinkUri(text: string): string | undefined {
-	return text.match(/\x1b\]8;[^;]*;([^\x1b]+)\x1b\\/)?.[1];
+	return text.match(/\x1b\]8;[^;]*;([^\x1b\x07]+)(?:\x1b\\|\x07)/)?.[1];
 }
 
 const LONG_AUTH_URL =
@@ -26,15 +26,13 @@ describe("MCPAuthorizationLinkPrompt", () => {
 		resetSettingsForTest();
 	});
 
-	it("renders a short clickable label and keeps the copy URL on one line", () => {
-		settings.override("tui.hyperlinks", "always");
-
+	it("renders a clickable label even when hyperlink auto-detection is false", () => {
 		const lines = new MCPAuthorizationLinkPrompt(LONG_AUTH_URL).render(80);
 		const plainLines = lines.map(line => stripVTControlCharacters(line));
 
 		expect(lines).toHaveLength(3);
 		expect(lines[1]).toContain(`${OSC}8;`);
-		expect(lines[1]).toContain(`${OSC}8;;${ST}`);
+		expect(lines[1]).toContain(`${OSC}8;;${BEL}`);
 		expect(extractLinkUri(lines[1])).toBe(LONG_AUTH_URL);
 		expect(plainLines[1]).toContain("Click here to authorize");
 		expect(plainLines[2]).toBe(` Copy URL: ${LONG_AUTH_URL}`);

--- a/packages/coding-agent/test/tui/hyperlink.test.ts
+++ b/packages/coding-agent/test/tui/hyperlink.test.ts
@@ -6,12 +6,14 @@ import {
 	tryResolveInternalUrlSync,
 	uriHyperlink,
 	urlHyperlink,
+	urlHyperlinkAlways,
 } from "@oh-my-pi/pi-coding-agent/tui/hyperlink";
 import * as terminalCaps from "@oh-my-pi/pi-tui";
 
 // OSC 8 sequence markers
 const OSC = "\x1b]";
 const ST = "\x1b\\";
+const BEL = "\x07";
 const LINK_END = `${OSC}8;;${ST}`;
 const ORIGINAL_NO_COLOR = Bun.env.NO_COLOR;
 
@@ -19,6 +21,10 @@ const ORIGINAL_NO_COLOR = Bun.env.NO_COLOR;
 function extractLinkUri(text: string): string | undefined {
 	const match = text.match(/\x1b\]8;[^;]*;([^\x1b]+)\x1b\\/);
 	return match?.[1];
+}
+
+function extractAnyTerminatorLinkUri(text: string): string | undefined {
+	return text.match(/\x1b\]8;[^;]*;([^\x1b\x07]+)(?:\x1b\\|\x07)/)?.[1];
 }
 
 /** Returns true if the string contains an OSC 8 hyperlink wrapping a given display text. */
@@ -214,6 +220,22 @@ describe("urlHyperlink", () => {
 	it("does not wrap non-HTTP URL schemes", () => {
 		setHyperlinkMode("always");
 		expect(urlHyperlink("ftp://example.com/file", "file")).toBe("file");
+	});
+});
+
+describe("urlHyperlinkAlways", () => {
+	it("wraps HTTP URLs when hyperlink auto-detection is disabled", () => {
+		setHyperlinkMode("off");
+		const result = urlHyperlinkAlways("www.example.com/path", "example");
+
+		expect(result).toContain(`${OSC}8;`);
+		expect(result).toContain(`${OSC}8;;${BEL}`);
+		expect(extractAnyTerminatorLinkUri(result)).toBe("https://www.example.com/path");
+	});
+
+	it("does not wrap non-HTTP URL schemes", () => {
+		setHyperlinkMode("off");
+		expect(urlHyperlinkAlways("ftp://example.com/file", "file")).toBe("file");
 	});
 });
 

--- a/packages/coding-agent/test/tui/hyperlink.test.ts
+++ b/packages/coding-agent/test/tui/hyperlink.test.ts
@@ -224,17 +224,24 @@ describe("urlHyperlink", () => {
 });
 
 describe("urlHyperlinkAlways", () => {
-	it("wraps HTTP URLs when hyperlink auto-detection is disabled", () => {
-		setHyperlinkMode("off");
+	it("wraps HTTP URLs in auto mode even when capability detection would suppress", () => {
+		setHyperlinkMode("auto");
+		Bun.env.NO_COLOR = "1"; // forces isHyperlinkEnabled() to false in auto mode
 		const result = urlHyperlinkAlways("www.example.com/path", "example");
 
+		expect(isHyperlinkEnabled()).toBe(false);
 		expect(result).toContain(`${OSC}8;`);
 		expect(result).toContain(`${OSC}8;;${BEL}`);
 		expect(extractAnyTerminatorLinkUri(result)).toBe("https://www.example.com/path");
 	});
 
-	it("does not wrap non-HTTP URL schemes", () => {
+	it("returns plain text when the user opts out with tui.hyperlinks=off", () => {
 		setHyperlinkMode("off");
+		expect(urlHyperlinkAlways("https://example.com/path", "example")).toBe("example");
+	});
+
+	it("does not wrap non-HTTP URL schemes", () => {
+		setHyperlinkMode("always");
 		expect(urlHyperlinkAlways("ftp://example.com/file", "file")).toBe("file");
 	});
 });


### PR DESCRIPTION
## Repro
Running the MCP authorization prompt renderer with default hyperlink auto-detection produced `hasOscLink: false`: the visible `Click here to authorize` label was plain text, and the only full authorization URL remained on an overlong copy line. Command: `bun --cwd packages/coding-agent -e '<MCPAuthorizationLinkPrompt render repro>'`.

## Cause
`packages/coding-agent/src/modes/controllers/mcp-command-controller.ts` used `urlHyperlink()` for `MCPAuthorizationLinkPrompt`, and `urlHyperlink()` intentionally suppresses OSC 8 output when `tui.hyperlinks=auto` cannot prove terminal support. That left the auth prompt showing a non-URL label with no terminal hyperlink, unlike the provider login flow.

## Fix
- Added `urlHyperlinkAlways()` in `packages/coding-agent/src/tui/hyperlink.ts` for trusted auth prompts that must remain clickable even when terminal capability detection is incomplete.
- Switched `MCPAuthorizationLinkPrompt` to use the always-emitted auth hyperlink while preserving the raw `Copy URL:` line.
- Added regression coverage for MCP auth prompts and the new hyperlink helper.
- Added a coding-agent changelog entry for #2196.

## Verification
- `bun --cwd packages/coding-agent -e '<MCPAuthorizationLinkPrompt render repro>'` now reports `hasOscLink: true`.
- `bun --cwd packages/coding-agent test test/modes/controllers/mcp-authorization-link.test.ts test/tui/hyperlink.test.ts` passed: 27 pass, 0 fail.
- `bun run check` in `packages/coding-agent` passed.

Fixes #2196