### PR TITLE
Fix Antigravity OAuth quota rotation

### DIFF
--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -31,7 +31,7 @@ import type {
 import { claudeRankingStrategy, claudeUsageProvider } from "./usage/claude";
 import { googleGeminiCliUsageProvider } from "./usage/gemini";
 import { githubCopilotUsageProvider } from "./usage/github-copilot";
-import { antigravityUsageProvider } from "./usage/google-antigravity";
+import { antigravityRankingStrategy, antigravityUsageProvider } from "./usage/google-antigravity";
 import { kimiUsageProvider } from "./usage/kimi";
 import { codexRankingStrategy, openaiCodexUsageProvider } from "./usage/openai-codex";
 import { zaiUsageProvider } from "./usage/zai";
@@ -650,6 +650,7 @@ function resolveDefaultUsageProvider(provider: Provider): UsageProvider | undefi
 const DEFAULT_RANKING_STRATEGIES = new Map<Provider, CredentialRankingStrategy>([
 	["openai-codex", codexRankingStrategy],
 	["anthropic", claudeRankingStrategy],
+	["google-antigravity", antigravityRankingStrategy],
 ]);
 
 function resolveDefaultRankingStrategy(provider: Provider): CredentialRankingStrategy | undefined {

--- a/packages/ai/src/rate-limit-utils.ts
+++ b/packages/ai/src/rate-limit-utils.ts
@@ -84,7 +84,7 @@ export function calculateRateLimitBackoffMs(reason: RateLimitReason): number {
 
 /** Detect usage/quota limit errors in error messages (persistent, requires credential switch). */
 const USAGE_LIMIT_PATTERN =
-	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?exceeded|resource.?exhausted/i;
+	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?(?:exceeded|reached)|individual.?quota.?reached|resource.?exhausted/i;
 
 export function isUsageLimitError(errorMessage: string): boolean {
 	return USAGE_LIMIT_PATTERN.test(errorMessage) || ACCOUNT_RATE_LIMIT_PATTERN.test(errorMessage);

--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -1,5 +1,6 @@
 import { getAntigravityUserAgent } from "../providers/google-gemini-headers";
 import type {
+	CredentialRankingStrategy,
 	UsageAmount,
 	UsageFetchContext,
 	UsageFetchParams,
@@ -293,6 +294,33 @@ async function fetchAntigravityUsage(params: UsageFetchParams, ctx: UsageFetchCo
 
 	return report;
 }
+
+const ANTIGRAVITY_DEFAULT_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+function usageRemainingFraction(limit: UsageLimit): number {
+	const remaining = limit.amount.remainingFraction;
+	if (typeof remaining === "number" && Number.isFinite(remaining)) return Math.max(0, Math.min(1, remaining));
+	const used = limit.amount.usedFraction;
+	if (typeof used === "number" && Number.isFinite(used)) return 1 - Math.max(0, Math.min(1, used));
+	return 0.5;
+}
+
+function compareAntigravityLimitPressure(left: UsageLimit, right: UsageLimit): number {
+	return usageRemainingFraction(left) - usageRemainingFraction(right);
+}
+
+export const antigravityRankingStrategy: CredentialRankingStrategy = {
+	findWindowLimits(report) {
+		const rankedLimits = [...report.limits].sort(compareAntigravityLimitPressure);
+		const primary = rankedLimits[0];
+		const secondary =
+			rankedLimits.find(limit => limit !== primary && limit.scope.windowId !== primary?.scope.windowId) ??
+			rankedLimits[1] ??
+			primary;
+		return { primary, secondary };
+	},
+	windowDefaults: { primaryMs: ANTIGRAVITY_DEFAULT_WINDOW_MS, secondaryMs: ANTIGRAVITY_DEFAULT_WINDOW_MS },
+};
 
 export const antigravityUsageProvider: UsageProvider = {
 	id: "google-antigravity",

--- a/packages/ai/test/auth-storage-codex-selection.test.ts
+++ b/packages/ai/test/auth-storage-codex-selection.test.ts
@@ -854,3 +854,137 @@ describe("AuthStorage claude oauth ranking", () => {
 		expect(apiKey).toBe("api-acct-solo");
 	});
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Antigravity ranking tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+function createAntigravityLimit(args: { windowId: string; remainingFraction: number; resetInMs: number }): UsageLimit {
+	const remaining = Math.min(Math.max(args.remainingFraction, 0), 1);
+	const used = 1 - remaining;
+	return {
+		id: `google-antigravity:${args.windowId}`,
+		label: "Antigravity Usage",
+		scope: {
+			provider: "google-antigravity",
+			windowId: args.windowId,
+		},
+		window: {
+			id: args.windowId,
+			label: args.windowId,
+			resetsAt: Date.now() + args.resetInMs,
+		},
+		amount: {
+			unit: "percent",
+			remaining: remaining * 100,
+			used: used * 100,
+			limit: 100,
+			remainingFraction: remaining,
+			usedFraction: used,
+		},
+		status: remaining <= 0 ? "exhausted" : remaining <= 0.1 ? "warning" : "ok",
+	};
+}
+
+function createAntigravityUsageReport(args: {
+	accountId: string;
+	primary: { remainingFraction: number; resetInMs: number };
+	secondary: { remainingFraction: number; resetInMs: number };
+}): UsageReport {
+	return {
+		provider: "google-antigravity",
+		fetchedAt: Date.now(),
+		limits: [
+			createAntigravityLimit({
+				windowId: "5h",
+				remainingFraction: args.primary.remainingFraction,
+				resetInMs: args.primary.resetInMs,
+			}),
+			createAntigravityLimit({
+				windowId: "daily",
+				remainingFraction: args.secondary.remainingFraction,
+				resetInMs: args.secondary.resetInMs,
+			}),
+		],
+		metadata: { accountId: args.accountId },
+	};
+}
+
+describe("AuthStorage Antigravity oauth ranking", () => {
+	let tempDir = "";
+	let store: AuthCredentialStore | null = null;
+	let authStorage: AuthStorage | null = null;
+	const usageByAccount = new Map<string, UsageReport>();
+
+	const usageProvider: UsageProvider = {
+		id: "google-antigravity",
+		async fetchUsage(params) {
+			const accountId = params.credential.accountId;
+			if (!accountId) return null;
+			return usageByAccount.get(accountId) ?? null;
+		},
+	};
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-auth-antigravity-selection-"));
+		store = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
+		authStorage = new AuthStorage(store, {
+			usageProviderResolver: provider => (provider === "google-antigravity" ? usageProvider : undefined),
+		});
+		usageByAccount.clear();
+		vi.spyOn(oauthUtils, "getOAuthApiKey").mockImplementation(async (_provider, credentials) => {
+			const credential = credentials["google-antigravity"] as OAuthCredentials | undefined;
+			if (!credential?.accountId) return null;
+			return {
+				apiKey: `api-${credential.accountId}`,
+				newCredentials: credential,
+			};
+		});
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		store?.close();
+		store = null;
+		authStorage = null;
+		if (tempDir) {
+			await fs.rm(tempDir, { recursive: true, force: true });
+			tempDir = "";
+		}
+	});
+
+	test("skips exhausted account using default ranking", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("google-antigravity", [
+			{ type: "oauth", ...createCredential("acct-exhausted", "exhausted@example.com") },
+			{ type: "oauth", ...createCredential("acct-healthy", "healthy@example.com") },
+		]);
+
+		usageByAccount.set(
+			"acct-exhausted",
+			createAntigravityUsageReport({
+				accountId: "acct-exhausted",
+				primary: { remainingFraction: 0, resetInMs: 5 * 60 * 1000 },
+				secondary: { remainingFraction: 0, resetInMs: 5 * 60 * 1000 },
+			}),
+		);
+		usageByAccount.set(
+			"acct-healthy",
+			createAntigravityUsageReport({
+				accountId: "acct-healthy",
+				primary: { remainingFraction: 0.5, resetInMs: 3 * HOUR_MS },
+				secondary: { remainingFraction: 0.4, resetInMs: 18 * HOUR_MS },
+			}),
+		);
+
+		const counts = await countApiKeySelections(
+			authStorage,
+			"google-antigravity",
+			"session-antigravity-exhausted",
+			50,
+		);
+		expect(countFor(counts, "api-acct-exhausted")).toBe(0);
+		expect(countFor(counts, "api-acct-healthy")).toBeGreaterThan(0);
+	});
+});

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -63,6 +63,12 @@ describe("isUsageLimitError", () => {
 			),
 		).toBe(true);
 	});
+
+	it("detects Antigravity individual quota exhaustion as a usage limit", () => {
+		expect(
+			isUsageLimitError("Cloud Code Assist API error (429): Individual quota reached. Contact your administrator."),
+		).toBe(true);
+	});
 });
 
 describe("calculateRateLimitBackoffMs", () => {


### PR DESCRIPTION
## Summary

Fixes #2198.

- Treat Antigravity `Individual quota reached` 429 responses as credential-rotatable usage limits.
- Add and register a `google-antigravity` usage-ranking strategy so OAuth account selection can avoid exhausted credentials.
- Add regression coverage for the matcher and exhausted-account avoidance.

## Tests

- `bun test packages/ai/test/rate-limit-utils.test.ts packages/ai/test/auth-storage-codex-selection.test.ts packages/ai/test/google-antigravity-usage.test.ts`
- `bun --cwd=packages/ai run check`