### PR TITLE
fix(ai): rotate antigravity credentials on Individual quota reached 429s

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -122,11 +122,12 @@
 
 ### Added
 
-- Added `antigravityRankingStrategy` and registered it for `google-antigravity` in `DEFAULT_RANKING_STRATEGIES`, so new sessions are routed to OAuth credentials with quota headroom (lowest-`remainingFraction` counter as the sole ranked window, 24h `windowDefaults` matching `daily-cloudcode-pa.googleapis.com` resets). Without it, the existing `antigravityUsageProvider` data never reached credential selection. ([#2198](https://github.com/can1357/oh-my-pi/issues/2198))
+- Added `antigravityRankingStrategy` and registered it for `google-antigravity` in `DEFAULT_RANKING_STRATEGIES`, so new sessions are routed to OAuth credentials with quota headroom for the requested model backend (lowest relevant `remainingFraction` counter as the sole ranked window, 24h `windowDefaults` matching `daily-cloudcode-pa.googleapis.com` resets). Without it, the existing `antigravityUsageProvider` data never reached credential selection. ([#2198](https://github.com/can1357/oh-my-pi/issues/2198))
 
 ### Fixed
 
 - Fixed `isUsageLimitError` missing Antigravity / Cloud Code Assist's `Individual quota reached` 429 phrasing. The `USAGE_LIMIT_PATTERN` only knew `quota.?exceeded` / `limit_reached`, so `auth-retry` and `AuthStorage.markUsageLimitReached` treated the response as a terminal provider error and pinned sessions to the exhausted OAuth account instead of rotating to a sibling credential. The pattern now also matches `quota.?reached`. ([#2198](https://github.com/can1357/oh-my-pi/issues/2198))
+- Scoped Antigravity usage blocking and ranking by model family (`gemini-*`/`gemma-*` → Google, `claude-*` → Anthropic, `gpt-*`/`openai/*` → OpenAI), so an exhausted Gemini counter no longer makes a healthy Claude/OpenAI Antigravity credential unavailable until reset. ([#2198](https://github.com/can1357/oh-my-pi/issues/2198))
 
 
 ## [15.10.8] - 2026-06-09

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -122,7 +122,7 @@
 
 ### Added
 
-- Added `antigravityRankingStrategy` and registered it for `google-antigravity` in `DEFAULT_RANKING_STRATEGIES`, so new sessions are routed to OAuth credentials with quota headroom (lowest-`remainingFraction` counter as primary, second-lowest as secondary, 24h `windowDefaults` matching `daily-cloudcode-pa.googleapis.com` resets). Without it, the existing `antigravityUsageProvider` data never reached credential selection. ([#2198](https://github.com/can1357/oh-my-pi/issues/2198))
+- Added `antigravityRankingStrategy` and registered it for `google-antigravity` in `DEFAULT_RANKING_STRATEGIES`, so new sessions are routed to OAuth credentials with quota headroom (lowest-`remainingFraction` counter as the sole ranked window, 24h `windowDefaults` matching `daily-cloudcode-pa.googleapis.com` resets). Without it, the existing `antigravityUsageProvider` data never reached credential selection. ([#2198](https://github.com/can1357/oh-my-pi/issues/2198))
 
 ### Fixed
 

--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -120,6 +120,15 @@
 - Fixed adaptive-only Claude models (Opus 4.6+, Sonnet 4.6+, Fable/Mythos 5) returning HTTP 400 `"thinking.type.disabled" is not supported for this model` whenever thinking was turned off (utility calls and forced-tool turns route through the disable path). These models accept only `thinking.type: "adaptive"`; the request builder now omits the thinking field and pins the lowest adaptive effort instead of emitting `type: "disabled"`.
 - Widened the OpenAI-completions first-event watchdog floor from 120s to 300s for DeepSeek V4 reasoning models hosted on the official DeepSeek API. The reasoner emits no SSE bytes until its private chain-of-thought finishes, which routinely takes longer than the generic 100s first-event budget under load — every chat then aborted with `OpenAI completions stream timed out while waiting for the first event` and silently retried. Mirrors the existing GLM coding-plan widening ([#2177](https://github.com/can1357/oh-my-pi/issues/2177)).
 
+### Added
+
+- Added `antigravityRankingStrategy` and registered it for `google-antigravity` in `DEFAULT_RANKING_STRATEGIES`, so new sessions are routed to OAuth credentials with quota headroom (lowest-`remainingFraction` counter as primary, second-lowest as secondary, 24h `windowDefaults` matching `daily-cloudcode-pa.googleapis.com` resets). Without it, the existing `antigravityUsageProvider` data never reached credential selection. ([#2198](https://github.com/can1357/oh-my-pi/issues/2198))
+
+### Fixed
+
+- Fixed `isUsageLimitError` missing Antigravity / Cloud Code Assist's `Individual quota reached` 429 phrasing. The `USAGE_LIMIT_PATTERN` only knew `quota.?exceeded` / `limit_reached`, so `auth-retry` and `AuthStorage.markUsageLimitReached` treated the response as a terminal provider error and pinned sessions to the exhausted OAuth account instead of rotating to a sibling credential. The pattern now also matches `quota.?reached`. ([#2198](https://github.com/can1357/oh-my-pi/issues/2198))
+
+
 ## [15.10.8] - 2026-06-09
 
 ### Added

--- a/packages/ai/src/auth-gateway/server.ts
+++ b/packages/ai/src/auth-gateway/server.ts
@@ -319,6 +319,7 @@ async function refreshGatewayApiKeyAfterAuthError(
 		const { switched, retryAtMs } = await storage.markUsageLimitReached(provider, sessionId, {
 			retryAfterMs,
 			baseUrl: model.baseUrl,
+			modelId: model.id,
 			signal,
 		});
 		logger.debug("auth-gateway retrying provider request after usage-limit block", {

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -3551,7 +3551,10 @@ export class AuthStorage {
 		const message = error instanceof Error ? error.message : typeof error === "string" ? error : undefined;
 		if (message && isUsageLimitError(message)) {
 			return (
-				await this.markUsageLimitReached(provider, sessionId, { modelId: options?.modelId, signal: options?.signal })
+				await this.markUsageLimitReached(provider, sessionId, {
+					modelId: options?.modelId,
+					signal: options?.signal,
+				})
 			).switched;
 		}
 

--- a/packages/ai/src/auth-storage.ts
+++ b/packages/ai/src/auth-storage.ts
@@ -19,6 +19,7 @@ import type { OAuthController, OAuthCredentials, OAuthProvider, OAuthProviderId 
 import { getEnvApiKey, getEnvApiKeyName } from "./stream";
 import type { Provider } from "./types";
 import type {
+	CredentialRankingContext,
 	CredentialRankingStrategy,
 	UsageCredential,
 	UsageFetchContext,
@@ -1185,33 +1186,58 @@ export class AuthStorage {
 		return order;
 	}
 
-	/** Returns block expiry timestamp for a credential, cleaning up expired entries. */
-	#getCredentialBlockedUntil(providerKey: string, credentialIndex: number): number | undefined {
-		const backoffMap = this.#credentialBackoff.get(providerKey);
+	#toScopedBackoffKey(providerKey: string, blockScope: string | undefined): string {
+		return blockScope ? `${providerKey}\0${blockScope}` : providerKey;
+	}
+
+	/** Returns block expiry timestamp for a credential/key pair, cleaning up expired entries. */
+	#getCredentialBlockedUntilForKey(backoffKey: string, credentialIndex: number): number | undefined {
+		const backoffMap = this.#credentialBackoff.get(backoffKey);
 		if (!backoffMap) return undefined;
 		const blockedUntil = backoffMap.get(credentialIndex);
 		if (!blockedUntil) return undefined;
 		if (blockedUntil <= Date.now()) {
 			backoffMap.delete(credentialIndex);
 			if (backoffMap.size === 0) {
-				this.#credentialBackoff.delete(providerKey);
+				this.#credentialBackoff.delete(backoffKey);
 			}
 			return undefined;
 		}
 		return blockedUntil;
 	}
 
+	/** Returns block expiry timestamp for a credential, checking global then scoped blocks. */
+	#getCredentialBlockedUntil(
+		providerKey: string,
+		credentialIndex: number,
+		blockScope: string | undefined = undefined,
+	): number | undefined {
+		const globalBlockedUntil = this.#getCredentialBlockedUntilForKey(providerKey, credentialIndex);
+		if (globalBlockedUntil !== undefined || !blockScope) return globalBlockedUntil;
+		return this.#getCredentialBlockedUntilForKey(this.#toScopedBackoffKey(providerKey, blockScope), credentialIndex);
+	}
+
 	/** Checks if a credential is temporarily blocked due to usage limits. */
-	#isCredentialBlocked(providerKey: string, credentialIndex: number): boolean {
-		return this.#getCredentialBlockedUntil(providerKey, credentialIndex) !== undefined;
+	#isCredentialBlocked(
+		providerKey: string,
+		credentialIndex: number,
+		blockScope: string | undefined = undefined,
+	): boolean {
+		return this.#getCredentialBlockedUntil(providerKey, credentialIndex, blockScope) !== undefined;
 	}
 
 	/** Marks a credential as blocked until the specified time. */
-	#markCredentialBlocked(providerKey: string, credentialIndex: number, blockedUntilMs: number): void {
-		const backoffMap = this.#credentialBackoff.get(providerKey) ?? new Map<number, number>();
+	#markCredentialBlocked(
+		providerKey: string,
+		credentialIndex: number,
+		blockedUntilMs: number,
+		blockScope: string | undefined = undefined,
+	): void {
+		const backoffKey = this.#toScopedBackoffKey(providerKey, blockScope);
+		const backoffMap = this.#credentialBackoff.get(backoffKey) ?? new Map<number, number>();
 		const existing = backoffMap.get(credentialIndex) ?? 0;
 		backoffMap.set(credentialIndex, Math.max(existing, blockedUntilMs));
-		this.#credentialBackoff.set(providerKey, backoffMap);
+		this.#credentialBackoff.set(backoffKey, backoffMap);
 	}
 
 	/** Records which credential was used for a session (for rate-limit switching). */
@@ -2174,15 +2200,24 @@ export class AuthStorage {
 		return false;
 	}
 
+	/** Return the usage limits that apply to the requested model for this strategy. */
+	#getScopedUsageLimits(
+		strategy: CredentialRankingStrategy,
+		report: UsageReport,
+		context: CredentialRankingContext,
+	): UsageLimit[] {
+		return strategy.scopeLimits?.(report, context) ?? report.limits;
+	}
+
 	/** Returns true if usage indicates rate limit has been reached. */
-	#isUsageLimitReached(report: UsageReport): boolean {
-		return report.limits.some(limit => this.#isUsageLimitExhausted(limit));
+	#isUsageLimitReached(limits: UsageLimit[]): boolean {
+		return limits.some(limit => this.#isUsageLimitExhausted(limit));
 	}
 
 	/** Extracts the earliest reset timestamp from exhausted windows (in ms). */
-	#getUsageResetAtMs(report: UsageReport, nowMs: number): number | undefined {
+	#getUsageResetAtMs(limits: UsageLimit[], nowMs: number): number | undefined {
 		const candidates: number[] = [];
-		for (const limit of report.limits) {
+		for (const limit of limits) {
 			if (!this.#isUsageLimitExhausted(limit)) continue;
 			const window = limit.window;
 			if (window?.resetsAt && window.resetsAt > nowMs) {
@@ -2475,29 +2510,35 @@ export class AuthStorage {
 	async markUsageLimitReached(
 		provider: string,
 		sessionId: string | undefined,
-		options?: { retryAfterMs?: number; baseUrl?: string; signal?: AbortSignal },
+		options?: { retryAfterMs?: number; baseUrl?: string; modelId?: string; signal?: AbortSignal },
 	): Promise<UsageLimitMarkResult> {
 		const sessionCredential = this.#getSessionCredential(provider, sessionId);
 		if (!sessionCredential) return { switched: false };
 
 		const providerKey = this.#getProviderTypeKey(provider, sessionCredential.type);
+		const strategy = this.#rankingStrategyResolver?.(provider);
+		const rankingContext: CredentialRankingContext = { modelId: options?.modelId };
+		const blockScope = strategy?.blockScope?.(rankingContext);
 		const now = Date.now();
 		let blockedUntil = now + (options?.retryAfterMs ?? AuthStorage.#defaultBackoffMs);
 
-		if (sessionCredential.type === "oauth" && this.#rankingStrategyResolver?.(provider)) {
+		if (sessionCredential.type === "oauth" && strategy) {
 			const credential = this.#getCredentialsForProvider(provider)[sessionCredential.index];
 			if (credential?.type === "oauth") {
 				const report = await this.#getUsageReport(provider, credential, options);
-				if (report && this.#isUsageLimitReached(report)) {
-					const resetAtMs = this.#getUsageResetAtMs(report, Date.now());
-					if (resetAtMs && resetAtMs > blockedUntil) {
-						blockedUntil = resetAtMs;
+				if (report) {
+					const scopedLimits = this.#getScopedUsageLimits(strategy, report, rankingContext);
+					if (this.#isUsageLimitReached(scopedLimits)) {
+						const resetAtMs = this.#getUsageResetAtMs(scopedLimits, Date.now());
+						if (resetAtMs && resetAtMs > blockedUntil) {
+							blockedUntil = resetAtMs;
+						}
 					}
 				}
 			}
 		}
 
-		this.#markCredentialBlocked(providerKey, sessionCredential.index, blockedUntil);
+		this.#markCredentialBlocked(providerKey, sessionCredential.index, blockedUntil, blockScope);
 
 		const remainingCredentials = this.#getCredentialsForProvider(provider)
 			.map((credential, index) => ({ credential, index }))
@@ -2508,7 +2549,7 @@ export class AuthStorage {
 
 		let retryAtMs: number | undefined;
 		for (const candidate of remainingCredentials) {
-			const candidateBlockedUntil = this.#getCredentialBlockedUntil(providerKey, candidate.index);
+			const candidateBlockedUntil = this.#getCredentialBlockedUntil(providerKey, candidate.index, blockScope);
 			if (candidateBlockedUntil === undefined) return { switched: true };
 			if (retryAtMs === undefined || candidateBlockedUntil < retryAtMs) retryAtMs = candidateBlockedUntil;
 		}
@@ -2673,6 +2714,8 @@ export class AuthStorage {
 		options?: AuthApiKeyOptions;
 		sessionId?: string;
 		strategy: CredentialRankingStrategy;
+		rankingContext: CredentialRankingContext;
+		blockScope?: string;
 	}): Promise<OAuthCandidate[]> {
 		const nowMs = Date.now();
 		const { strategy } = args;
@@ -2686,7 +2729,7 @@ export class AuthStorage {
 			args.order.map(async idx => {
 				const selection = args.credentials[idx];
 				if (!selection) return null;
-				const blockedUntil = this.#getCredentialBlockedUntil(args.providerKey, selection.index);
+				const blockedUntil = this.#getCredentialBlockedUntil(args.providerKey, selection.index, args.blockScope);
 				if (blockedUntil !== undefined) return { selection, usage: null, usageChecked: false, blockedUntil };
 				const usage = await this.#getUsageReport(args.provider, selection.credential, {
 					...args.options,
@@ -2719,13 +2762,14 @@ export class AuthStorage {
 			const { selection, usage, usageChecked } = result;
 			let { blockedUntil } = result;
 			let blocked = blockedUntil !== undefined;
-			if (!blocked && usage && this.#isUsageLimitReached(usage)) {
-				const resetAtMs = this.#getUsageResetAtMs(usage, nowMs);
+			const scopedLimits = usage ? this.#getScopedUsageLimits(strategy, usage, args.rankingContext) : undefined;
+			if (!blocked && scopedLimits && this.#isUsageLimitReached(scopedLimits)) {
+				const resetAtMs = this.#getUsageResetAtMs(scopedLimits, nowMs);
 				blockedUntil = resetAtMs ?? Date.now() + AuthStorage.#defaultBackoffMs;
-				this.#markCredentialBlocked(args.providerKey, selection.index, blockedUntil);
+				this.#markCredentialBlocked(args.providerKey, selection.index, blockedUntil, args.blockScope);
 				blocked = true;
 			}
-			const windows = usage ? strategy.findWindowLimits(usage) : undefined;
+			const windows = usage ? strategy.findWindowLimits(usage, args.rankingContext) : undefined;
 			const primary = windows?.primary;
 			const secondary = windows?.secondary;
 			const secondaryTarget = secondary ?? primary;
@@ -2774,6 +2818,8 @@ export class AuthStorage {
 		const providerKey = this.#getProviderTypeKey(provider, "oauth");
 		const order = this.#getCredentialOrder(providerKey, sessionId, credentials.length);
 		const strategy = this.#rankingStrategyResolver?.(provider);
+		const rankingContext: CredentialRankingContext = { modelId: options?.modelId };
+		const blockScope = strategy?.blockScope?.(rankingContext);
 		const requiresProModel = requiresOpenAICodexProModel(provider, options?.modelId);
 		const checkUsage = strategy !== undefined && (credentials.length > 1 || requiresProModel);
 		const sessionCredential = this.#getSessionCredential(provider, sessionId);
@@ -2783,7 +2829,8 @@ export class AuthStorage {
 		// (no preference) and sessions whose preferred is blocked still rank, so we pick the account
 		// with the most headroom proactively and fall back intelligently when rate-limited.
 		const sessionPreferredIsAvailable =
-			sessionPreferredIndex !== undefined && !this.#isCredentialBlocked(providerKey, sessionPreferredIndex);
+			sessionPreferredIndex !== undefined &&
+			!this.#isCredentialBlocked(providerKey, sessionPreferredIndex, blockScope);
 		const shouldRank = checkUsage && (!sessionPreferredIsAvailable || requiresProModel);
 		const rankingOrder = shouldRank && sessionId ? credentials.map((_credential, index) => index) : order;
 		const candidates = shouldRank
@@ -2795,6 +2842,8 @@ export class AuthStorage {
 					options,
 					sessionId,
 					strategy: strategy!,
+					rankingContext,
+					blockScope,
 				})
 			: order
 					.map(idx => credentials[idx])
@@ -2804,7 +2853,7 @@ export class AuthStorage {
 		if (sessionPreferredIndex !== undefined && !requiresProModel) {
 			const sessionPreferredCandidate = candidates.findIndex(
 				candidate =>
-					!this.#isCredentialBlocked(providerKey, candidate.selection.index) &&
+					!this.#isCredentialBlocked(providerKey, candidate.selection.index, blockScope) &&
 					candidate.selection.index === sessionPreferredIndex,
 			);
 			if (sessionPreferredCandidate > 0) {
@@ -2878,18 +2927,24 @@ export class AuthStorage {
 					prefetchedUsage: candidate.usage,
 					usagePrechecked: candidate.usageChecked,
 					enforceProRequirement,
+					strategy,
+					rankingContext,
+					blockScope,
 				},
 			);
 			if (resolved) return resolved;
 		}
 
-		if (fallback && this.#isCredentialBlocked(providerKey, fallback.selection.index)) {
+		if (fallback && this.#isCredentialBlocked(providerKey, fallback.selection.index, blockScope)) {
 			return this.#tryOAuthCredential(provider, fallback.selection, providerKey, sessionId, options, {
 				checkUsage,
 				allowBlocked: true,
 				prefetchedUsage: fallback.usage,
 				usagePrechecked: fallback.usageChecked,
 				enforceProRequirement,
+				strategy,
+				rankingContext,
+				blockScope,
 			});
 		}
 
@@ -3008,6 +3063,9 @@ export class AuthStorage {
 			prefetchedUsage?: UsageReport | null;
 			usagePrechecked?: boolean;
 			enforceProRequirement?: boolean;
+			strategy?: CredentialRankingStrategy;
+			rankingContext?: CredentialRankingContext;
+			blockScope?: string;
 		},
 	): Promise<OAuthResolutionResult | undefined> {
 		const {
@@ -3016,8 +3074,11 @@ export class AuthStorage {
 			prefetchedUsage = null,
 			usagePrechecked = false,
 			enforceProRequirement,
+			strategy,
+			rankingContext,
+			blockScope,
 		} = usageOptions;
-		if (!allowBlocked && this.#isCredentialBlocked(providerKey, selection.index)) {
+		if (!allowBlocked && this.#isCredentialBlocked(providerKey, selection.index, blockScope)) {
 			return undefined;
 		}
 
@@ -3044,14 +3105,18 @@ export class AuthStorage {
 			if (applyProFilter && !hasOpenAICodexProPlan(usage)) {
 				return undefined;
 			}
-			if (checkUsage && !allowBlocked && usage && this.#isUsageLimitReached(usage)) {
-				const resetAtMs = this.#getUsageResetAtMs(usage, Date.now());
-				this.#markCredentialBlocked(
-					providerKey,
-					selection.index,
-					resetAtMs ?? Date.now() + AuthStorage.#defaultBackoffMs,
-				);
-				return undefined;
+			if (checkUsage && !allowBlocked && usage && strategy && rankingContext) {
+				const scopedLimits = this.#getScopedUsageLimits(strategy, usage, rankingContext);
+				if (this.#isUsageLimitReached(scopedLimits)) {
+					const resetAtMs = this.#getUsageResetAtMs(scopedLimits, Date.now());
+					this.#markCredentialBlocked(
+						providerKey,
+						selection.index,
+						resetAtMs ?? Date.now() + AuthStorage.#defaultBackoffMs,
+						blockScope,
+					);
+					return undefined;
+				}
 			}
 		}
 
@@ -3110,14 +3175,18 @@ export class AuthStorage {
 				if (applyProFilter && !hasOpenAICodexProPlan(usage)) {
 					return undefined;
 				}
-				if (checkUsage && !allowBlocked && usage && this.#isUsageLimitReached(usage)) {
-					const resetAtMs = this.#getUsageResetAtMs(usage, Date.now());
-					this.#markCredentialBlocked(
-						providerKey,
-						selection.index,
-						resetAtMs ?? Date.now() + AuthStorage.#defaultBackoffMs,
-					);
-					return undefined;
+				if (checkUsage && !allowBlocked && usage && strategy && rankingContext) {
+					const scopedLimits = this.#getScopedUsageLimits(strategy, usage, rankingContext);
+					if (this.#isUsageLimitReached(scopedLimits)) {
+						const resetAtMs = this.#getUsageResetAtMs(scopedLimits, Date.now());
+						this.#markCredentialBlocked(
+							providerKey,
+							selection.index,
+							resetAtMs ?? Date.now() + AuthStorage.#defaultBackoffMs,
+							blockScope,
+						);
+						return undefined;
+					}
 				}
 			}
 			this.#recordSessionCredential(provider, sessionId, "oauth", selection.index);
@@ -3473,7 +3542,7 @@ export class AuthStorage {
 	async rotateSessionCredential(
 		provider: string,
 		sessionId: string | undefined,
-		options?: { error?: unknown; signal?: AbortSignal },
+		options?: { error?: unknown; modelId?: string; signal?: AbortSignal },
 	): Promise<boolean> {
 		const sessionCredential = this.#getSessionCredential(provider, sessionId);
 		if (!sessionCredential) return false;
@@ -3481,7 +3550,9 @@ export class AuthStorage {
 		const error = options?.error;
 		const message = error instanceof Error ? error.message : typeof error === "string" ? error : undefined;
 		if (message && isUsageLimitError(message)) {
-			return (await this.markUsageLimitReached(provider, sessionId, { signal: options?.signal })).switched;
+			return (
+				await this.markUsageLimitReached(provider, sessionId, { modelId: options?.modelId, signal: options?.signal })
+			).switched;
 		}
 
 		const providerKey = this.#getProviderTypeKey(provider, sessionCredential.type);
@@ -3532,7 +3603,7 @@ export class AuthStorage {
 				return this.getApiKey(provider, sessionId, { baseUrl, modelId, signal });
 			}
 			if (lastChance) {
-				await this.rotateSessionCredential(provider, sessionId, { error, signal });
+				await this.rotateSessionCredential(provider, sessionId, { error, modelId, signal });
 				return this.getApiKey(provider, sessionId, { baseUrl, modelId, signal });
 			}
 			return this.getApiKey(provider, sessionId, { baseUrl, modelId, forceRefresh: true, signal });

--- a/packages/ai/src/rate-limit-utils.ts
+++ b/packages/ai/src/rate-limit-utils.ts
@@ -94,7 +94,7 @@ export function calculateRateLimitBackoffMs(reason: RateLimitReason): number {
 
 /** Detect usage/quota limit errors in error messages (persistent, requires credential switch). */
 const USAGE_LIMIT_PATTERN =
-	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?exceeded|resource.?exhausted|exhausted your capacity|quota will reset/i;
+	/usage.?limit|usage_limit_reached|usage_not_included|limit_reached|quota.?exceeded|quota.?reached|resource.?exhausted|exhausted your capacity|quota will reset/i;
 
 export function isUsageLimitError(errorMessage: string): boolean {
 	return USAGE_LIMIT_PATTERN.test(errorMessage) || ACCOUNT_RATE_LIMIT_PATTERN.test(errorMessage);

--- a/packages/ai/src/usage.ts
+++ b/packages/ai/src/usage.ts
@@ -168,13 +168,34 @@ export interface UsageProvider {
 	supports?(params: UsageFetchParams): boolean;
 }
 
+/** Request context used when ranking usage for a specific model. */
+export interface CredentialRankingContext {
+	/** Provider model id, when the caller is selecting a credential for one model. */
+	modelId?: string;
+}
+
 /** Strategy for usage-based credential ranking. Providers implement this to opt into smart credential selection. */
 export interface CredentialRankingStrategy {
 	/** Extract the primary (short) and secondary (long) window limits from a usage report. */
-	findWindowLimits(report: UsageReport): {
+	findWindowLimits(
+		report: UsageReport,
+		context?: CredentialRankingContext,
+	): {
 		primary?: UsageLimit;
 		secondary?: UsageLimit;
 	};
+	/**
+	 * Restrict limits to the ones relevant for the requested model before
+	 * credential-wide exhaustion checks and ranking. Providers with shared
+	 * account-wide quotas can omit this and use all limits.
+	 */
+	scopeLimits?(report: UsageReport, context?: CredentialRankingContext): UsageLimit[];
+	/**
+	 * Return a provider-local backoff scope for the requested model. Providers
+	 * with backend-specific quotas use this so one exhausted model family does
+	 * not block unrelated families on the same OAuth credential.
+	 */
+	blockScope?(context?: CredentialRankingContext): string | undefined;
 	/** Fallback window durations (ms) when limits don't specify durationMs. */
 	windowDefaults: {
 		primaryMs: number;

--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -301,38 +301,26 @@ export const antigravityUsageProvider: UsageProvider = {
 	supports: params => params.provider === "google-antigravity",
 };
 
-const ANTIGRAVITY_DAILY_WINDOW_MS = 24 * 60 * 60 * 1000;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 /**
- * Credential ranking strategy for `google-antigravity`. Drives proactive
- * multi-account selection in {@link AuthStorage} by reading the per-counter
- * Antigravity usage reports.
- *
- * Antigravity reports one {@link UsageLimit} per backend counter (Google /
- * Anthropic / OpenAI) per tier per window, and {@link fetchAntigravityUsage}
- * sorts them ascending by `remainingFraction` — so `limits[0]` is always the
- * most-pressured counter for the credential, and `limits[1]` (when present)
- * is the next-most-pressured counter.
- *
- * `AuthStorage` compares the `secondary*` ranking metrics before `primary*`
- * because other providers model a long-window budget as secondary. Antigravity
- * does not expose a short/long split; every counter is a sibling bottleneck.
- * Therefore the most-pressured counter goes in `secondary`, with the runner-up
- * in `primary`, so proactive account selection always ranks the bottleneck
- * before any healthier sibling counter.
- *
- * The Antigravity API exposes `resetTime` but not window duration, so the
- * drain-rate calculation depends on `windowDefaults`. Antigravity quotas are
- * effectively daily; 24h is the right fallback for both axes — any 5h tier
- * still ranks correctly because both credentials are normalised against the
- * same fallback.
+ * Antigravity quotas reset daily and are returned per backend counter
+ * (Anthropic / Google / OpenAI) without a fixed "primary vs secondary"
+ * split. `fetchAntigravityUsage` already sorts `limits` ascending by
+ * `remainingFraction`, so the most-pressured counter is index 0 and the
+ * next-most-pressured (if any) is index 1. Treat those as the windows
+ * AuthStorage compares across credentials — that surfaces an exhausted
+ * Gemini counter on one credential even when a sibling Claude counter is
+ * healthy, which is what was masking quota-exhausted accounts before.
  */
 export const antigravityRankingStrategy: CredentialRankingStrategy = {
 	findWindowLimits(report) {
-		return { primary: report.limits[1], secondary: report.limits[0] };
+		const primary = report.limits[0];
+		const secondary = report.limits.find((limit, index) => index > 0 && limit !== primary);
+		return { primary, secondary };
 	},
-	windowDefaults: {
-		primaryMs: ANTIGRAVITY_DAILY_WINDOW_MS,
-		secondaryMs: ANTIGRAVITY_DAILY_WINDOW_MS,
-	},
+	// Antigravity windows omit `durationMs`; the endpoint is
+	// `daily-cloudcode-pa.googleapis.com`, so fall back to 24h when computing
+	// drain rate.
+	windowDefaults: { primaryMs: ONE_DAY_MS, secondaryMs: ONE_DAY_MS },
 };

--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -307,17 +307,17 @@ const ONE_DAY_MS = 24 * 60 * 60 * 1000;
  * Antigravity quotas reset daily and are returned per backend counter
  * (Anthropic / Google / OpenAI) without a fixed "primary vs secondary"
  * split. `fetchAntigravityUsage` already sorts `limits` ascending by
- * `remainingFraction`, so the most-pressured counter is index 0 and the
- * next-most-pressured (if any) is index 1. Treat those as the windows
- * AuthStorage compares across credentials — that surfaces an exhausted
- * Gemini counter on one credential even when a sibling Claude counter is
- * healthy, which is what was masking quota-exhausted accounts before.
+ * `remainingFraction`, so the most-pressured counter is index 0.
+ *
+ * Leave `secondary` unset: AuthStorage compares secondary metrics before
+ * primary metrics, which is correct for providers with explicit long-window
+ * limits but wrong here. Ranking Antigravity by the bottleneck counter first
+ * avoids preferring an account at 95% Gemini / 0% Claude over one at
+ * 80% Gemini / 70% Claude.
  */
 export const antigravityRankingStrategy: CredentialRankingStrategy = {
 	findWindowLimits(report) {
-		const primary = report.limits[0];
-		const secondary = report.limits.find((limit, index) => index > 0 && limit !== primary);
-		return { primary, secondary };
+		return { primary: report.limits[0] };
 	},
 	// Antigravity windows omit `durationMs`; the endpoint is
 	// `daily-cloudcode-pa.googleapis.com`, so fall back to 24h when computing

--- a/packages/ai/src/usage/google-antigravity.ts
+++ b/packages/ai/src/usage/google-antigravity.ts
@@ -1,5 +1,6 @@
 import { getAntigravityUserAgent } from "@oh-my-pi/pi-catalog/wire/gemini-headers";
 import type {
+	CredentialRankingContext,
 	CredentialRankingStrategy,
 	UsageAmount,
 	UsageFetchContext,
@@ -303,11 +304,34 @@ export const antigravityUsageProvider: UsageProvider = {
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
+function getAntigravityCounterKeyForModel(context: CredentialRankingContext | undefined): string | undefined {
+	const modelId = context?.modelId?.toLowerCase();
+	if (!modelId) return undefined;
+	if (modelId.startsWith("claude-")) return "anthropic";
+	if (modelId.startsWith("gemini-") || modelId.startsWith("gemma-")) return "google";
+	if (modelId.startsWith("gpt-") || modelId.startsWith("openai/")) return "openai";
+	return undefined;
+}
+
+function getAntigravityCounterLimits(report: UsageReport, counterKey: string): UsageLimit[] {
+	const prefix = `${report.provider}:${counterKey}:`;
+	return report.limits.filter(limit => limit.id.toLowerCase().startsWith(prefix));
+}
+
+function scopeAntigravityLimits(report: UsageReport, context: CredentialRankingContext | undefined): UsageLimit[] {
+	const counterKey = getAntigravityCounterKeyForModel(context);
+	if (!counterKey) return report.limits;
+	const backendLimits = getAntigravityCounterLimits(report, counterKey);
+	if (backendLimits.length > 0) return backendLimits;
+	return getAntigravityCounterLimits(report, "default");
+}
+
 /**
  * Antigravity quotas reset daily and are returned per backend counter
  * (Anthropic / Google / OpenAI) without a fixed "primary vs secondary"
  * split. `fetchAntigravityUsage` already sorts `limits` ascending by
- * `remainingFraction`, so the most-pressured counter is index 0.
+ * `remainingFraction`; after model-family scoping, the most-pressured
+ * relevant counter is index 0.
  *
  * Leave `secondary` unset: AuthStorage compares secondary metrics before
  * primary metrics, which is correct for providers with explicit long-window
@@ -316,8 +340,13 @@ const ONE_DAY_MS = 24 * 60 * 60 * 1000;
  * 80% Gemini / 70% Claude.
  */
 export const antigravityRankingStrategy: CredentialRankingStrategy = {
-	findWindowLimits(report) {
-		return { primary: report.limits[0] };
+	findWindowLimits(report, context) {
+		return { primary: scopeAntigravityLimits(report, context)[0] };
+	},
+	scopeLimits: scopeAntigravityLimits,
+	blockScope(context) {
+		const counterKey = getAntigravityCounterKeyForModel(context);
+		return counterKey ? `counter:${counterKey}` : undefined;
 	},
 	// Antigravity windows omit `durationMs`; the endpoint is
 	// `daily-cloudcode-pa.googleapis.com`, so fall back to 24h when computing

--- a/packages/ai/test/auth-storage-antigravity-selection.test.ts
+++ b/packages/ai/test/auth-storage-antigravity-selection.test.ts
@@ -200,5 +200,4 @@ describe("AuthStorage google-antigravity oauth ranking", () => {
 		const loaded = counts.get("api-acct-loaded") ?? 0;
 		expect(fresh).toBeGreaterThan(loaded);
 	});
-
 });

--- a/packages/ai/test/auth-storage-antigravity-selection.test.ts
+++ b/packages/ai/test/auth-storage-antigravity-selection.test.ts
@@ -162,7 +162,6 @@ describe("AuthStorage google-antigravity oauth ranking", () => {
 		expect(apiKey).toBe("api-acct-healthy");
 	});
 
-
 	test("ranks by bottleneck counter instead of healthier secondary counter", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 

--- a/packages/ai/test/auth-storage-antigravity-selection.test.ts
+++ b/packages/ai/test/auth-storage-antigravity-selection.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Antigravity OAuth ranking smoke test. Proves the
+ * `antigravityRankingStrategy` is wired into `DEFAULT_RANKING_STRATEGIES`
+ * (issue #2198): a credential whose usage report shows an exhausted
+ * counter must be skipped in favour of a healthy sibling on the next
+ * `getApiKey` call.
+ *
+ * Without the registration `getApiKey` would round-robin between
+ * credentials and could pin a session to the exhausted account.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { type AuthCredentialStore, AuthStorage, SqliteAuthCredentialStore } from "@oh-my-pi/pi-ai/auth-storage";
+import * as oauthUtils from "@oh-my-pi/pi-ai/registry/oauth";
+import type { OAuthCredentials } from "@oh-my-pi/pi-ai/registry/oauth/types";
+import type { UsageLimit, UsageProvider, UsageReport } from "@oh-my-pi/pi-ai/usage";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+type AntigravityWindowSpec = {
+	counter: "google" | "anthropic" | "openai" | "default";
+	usedFraction: number;
+	resetInMs: number;
+};
+
+function createAntigravityLimit(spec: AntigravityWindowSpec, projectId: string): UsageLimit {
+	const used = Math.min(Math.max(spec.usedFraction, 0), 1);
+	return {
+		id: `google-antigravity:${spec.counter}:default:WINDOW_DAILY`,
+		label: `Usage (${spec.counter})`,
+		scope: {
+			provider: "google-antigravity",
+			projectId,
+			windowId: "WINDOW_DAILY",
+		},
+		window: {
+			id: "WINDOW_DAILY",
+			label: "Default",
+			resetsAt: Date.now() + spec.resetInMs,
+		},
+		amount: {
+			unit: "percent",
+			used: used * 100,
+			limit: 100,
+			remaining: (1 - used) * 100,
+			usedFraction: used,
+			remainingFraction: 1 - used,
+		},
+		status: used >= 1 ? "exhausted" : used >= 0.9 ? "warning" : "ok",
+	};
+}
+
+function createAntigravityReport(args: {
+	projectId: string;
+	accountId: string;
+	windows: AntigravityWindowSpec[];
+}): UsageReport {
+	// fetchAntigravityUsage sorts ascending by remainingFraction; mirror
+	// that here so the strategy sees the same shape it would in production.
+	const limits = args.windows
+		.map(w => createAntigravityLimit(w, args.projectId))
+		.sort((a, b) => (a.amount.remainingFraction ?? 1) - (b.amount.remainingFraction ?? 1));
+	return {
+		provider: "google-antigravity",
+		fetchedAt: Date.now(),
+		limits,
+		metadata: { accountId: args.accountId, projectId: args.projectId },
+	};
+}
+
+function createCredential(accountId: string, projectId: string, email: string): OAuthCredentials {
+	return {
+		access: `access-${accountId}`,
+		refresh: `refresh-${accountId}`,
+		expires: Date.now() + HOUR_MS,
+		accountId,
+		projectId,
+		email,
+	};
+}
+
+describe("AuthStorage google-antigravity oauth ranking", () => {
+	let tempDir = "";
+	let store: AuthCredentialStore | null = null;
+	let authStorage: AuthStorage | null = null;
+	const usageByAccount = new Map<string, UsageReport>();
+
+	const usageProvider: UsageProvider = {
+		id: "google-antigravity",
+		async fetchUsage(params) {
+			const accountId = params.credential.accountId;
+			if (!accountId) return null;
+			return usageByAccount.get(accountId) ?? null;
+		},
+	};
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "pi-ai-auth-antigravity-selection-"));
+		store = await SqliteAuthCredentialStore.open(path.join(tempDir, "agent.db"));
+		authStorage = new AuthStorage(store, {
+			usageProviderResolver: provider => (provider === "google-antigravity" ? usageProvider : undefined),
+		});
+		usageByAccount.clear();
+		vi.spyOn(oauthUtils, "getOAuthApiKey").mockImplementation(async (_provider, credentials) => {
+			const credential = credentials["google-antigravity"] as OAuthCredentials | undefined;
+			if (!credential?.accountId) return null;
+			return {
+				apiKey: `api-${credential.accountId}`,
+				newCredentials: credential,
+			};
+		});
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		store?.close();
+		store = null;
+		authStorage = null;
+		if (tempDir) {
+			await fs.rm(tempDir, { recursive: true, force: true });
+			tempDir = "";
+		}
+	});
+
+	test("skips antigravity account whose Gemini counter is exhausted", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("google-antigravity", [
+			{ type: "oauth", ...createCredential("acct-exhausted", "proj-exhausted", "exhausted@example.com") },
+			{ type: "oauth", ...createCredential("acct-healthy", "proj-healthy", "healthy@example.com") },
+		]);
+
+		// Exhausted account: Gemini counter at 100%, Claude counter healthy.
+		// Pre-fix the credential was rotatable only on response-side errors,
+		// so a session could still be assigned to it on first use.
+		usageByAccount.set(
+			"acct-exhausted",
+			createAntigravityReport({
+				accountId: "acct-exhausted",
+				projectId: "proj-exhausted",
+				windows: [
+					{ counter: "google", usedFraction: 1, resetInMs: 12 * HOUR_MS },
+					{ counter: "anthropic", usedFraction: 0.2, resetInMs: 12 * HOUR_MS },
+				],
+			}),
+		);
+		usageByAccount.set(
+			"acct-healthy",
+			createAntigravityReport({
+				accountId: "acct-healthy",
+				projectId: "proj-healthy",
+				windows: [
+					{ counter: "google", usedFraction: 0.3, resetInMs: 20 * HOUR_MS },
+					{ counter: "anthropic", usedFraction: 0.1, resetInMs: 20 * HOUR_MS },
+				],
+			}),
+		);
+
+		const apiKey = await authStorage.getApiKey("google-antigravity", "session-antigravity-exhausted");
+		expect(apiKey).toBe("api-acct-healthy");
+	});
+
+	test("prefers less-pressured antigravity account when neither is exhausted", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("google-antigravity", [
+			{ type: "oauth", ...createCredential("acct-loaded", "proj-loaded", "loaded@example.com") },
+			{ type: "oauth", ...createCredential("acct-fresh", "proj-fresh", "fresh@example.com") },
+		]);
+
+		usageByAccount.set(
+			"acct-loaded",
+			createAntigravityReport({
+				accountId: "acct-loaded",
+				projectId: "proj-loaded",
+				windows: [{ counter: "google", usedFraction: 0.8, resetInMs: 4 * HOUR_MS }],
+			}),
+		);
+		usageByAccount.set(
+			"acct-fresh",
+			createAntigravityReport({
+				accountId: "acct-fresh",
+				projectId: "proj-fresh",
+				windows: [{ counter: "google", usedFraction: 0.05, resetInMs: 4 * HOUR_MS }],
+			}),
+		);
+
+		// Sample several sessions; the weighted picker must favour the fresh
+		// account by a clear margin even though both are unblocked.
+		const counts = new Map<string, number>();
+		for (let i = 0; i < 60; i += 1) {
+			const apiKey = await authStorage.getApiKey("google-antigravity", `session-antigravity-fresh-${i}`);
+			if (!apiKey) continue;
+			counts.set(apiKey, (counts.get(apiKey) ?? 0) + 1);
+		}
+
+		const fresh = counts.get("api-acct-fresh") ?? 0;
+		const loaded = counts.get("api-acct-loaded") ?? 0;
+		expect(fresh).toBeGreaterThan(loaded);
+	});
+
+});

--- a/packages/ai/test/auth-storage-antigravity-selection.test.ts
+++ b/packages/ai/test/auth-storage-antigravity-selection.test.ts
@@ -124,42 +124,55 @@ describe("AuthStorage google-antigravity oauth ranking", () => {
 		}
 	});
 
-	test("skips antigravity account whose Gemini counter is exhausted", async () => {
+	test("blocks exhausted Antigravity Gemini counter without blocking healthy Claude counter", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 
 		await authStorage.set("google-antigravity", [
-			{ type: "oauth", ...createCredential("acct-exhausted", "proj-exhausted", "exhausted@example.com") },
-			{ type: "oauth", ...createCredential("acct-healthy", "proj-healthy", "healthy@example.com") },
+			{
+				type: "oauth",
+				...createCredential("acct-gemini-exhausted", "proj-gemini-exhausted", "exhausted@example.com"),
+			},
+			{ type: "oauth", ...createCredential("acct-gemini-healthy", "proj-gemini-healthy", "healthy@example.com") },
 		]);
 
-		// Exhausted account: Gemini counter at 100%, Claude counter healthy.
-		// Pre-fix the credential was rotatable only on response-side errors,
-		// so a session could still be assigned to it on first use.
 		usageByAccount.set(
-			"acct-exhausted",
+			"acct-gemini-exhausted",
 			createAntigravityReport({
-				accountId: "acct-exhausted",
-				projectId: "proj-exhausted",
+				accountId: "acct-gemini-exhausted",
+				projectId: "proj-gemini-exhausted",
 				windows: [
 					{ counter: "google", usedFraction: 1, resetInMs: 12 * HOUR_MS },
-					{ counter: "anthropic", usedFraction: 0.2, resetInMs: 12 * HOUR_MS },
+					{ counter: "anthropic", usedFraction: 0.05, resetInMs: 12 * HOUR_MS },
 				],
 			}),
 		);
 		usageByAccount.set(
-			"acct-healthy",
+			"acct-gemini-healthy",
 			createAntigravityReport({
-				accountId: "acct-healthy",
-				projectId: "proj-healthy",
+				accountId: "acct-gemini-healthy",
+				projectId: "proj-gemini-healthy",
 				windows: [
 					{ counter: "google", usedFraction: 0.3, resetInMs: 20 * HOUR_MS },
-					{ counter: "anthropic", usedFraction: 0.1, resetInMs: 20 * HOUR_MS },
+					{ counter: "anthropic", usedFraction: 0.7, resetInMs: 20 * HOUR_MS },
 				],
 			}),
 		);
 
-		const apiKey = await authStorage.getApiKey("google-antigravity", "session-antigravity-exhausted");
-		expect(apiKey).toBe("api-acct-healthy");
+		const geminiKey = await authStorage.getApiKey("google-antigravity", "session-antigravity-gemini", {
+			modelId: "gemini-3-flash",
+		});
+		expect(geminiKey).toBe("api-acct-gemini-healthy");
+
+		const counts = new Map<string, number>();
+		for (let i = 0; i < 80; i += 1) {
+			const apiKey = await authStorage.getApiKey("google-antigravity", `session-antigravity-claude-${i}`, {
+				modelId: "claude-sonnet-4-5",
+			});
+			if (!apiKey) continue;
+			counts.set(apiKey, (counts.get(apiKey) ?? 0) + 1);
+		}
+
+		expect(counts.get("api-acct-gemini-exhausted") ?? 0).toBeGreaterThan(counts.get("api-acct-gemini-healthy") ?? 0);
 	});
 
 	test("ranks by bottleneck counter instead of healthier secondary counter", async () => {
@@ -195,7 +208,9 @@ describe("AuthStorage google-antigravity oauth ranking", () => {
 
 		const counts = new Map<string, number>();
 		for (let i = 0; i < 80; i += 1) {
-			const apiKey = await authStorage.getApiKey("google-antigravity", `session-antigravity-bottleneck-${i}`);
+			const apiKey = await authStorage.getApiKey("google-antigravity", `session-antigravity-bottleneck-${i}`, {
+				modelId: "gemini-3-flash",
+			});
 			if (!apiKey) continue;
 			counts.set(apiKey, (counts.get(apiKey) ?? 0) + 1);
 		}
@@ -231,7 +246,9 @@ describe("AuthStorage google-antigravity oauth ranking", () => {
 		// account by a clear margin even though both are unblocked.
 		const counts = new Map<string, number>();
 		for (let i = 0; i < 60; i += 1) {
-			const apiKey = await authStorage.getApiKey("google-antigravity", `session-antigravity-fresh-${i}`);
+			const apiKey = await authStorage.getApiKey("google-antigravity", `session-antigravity-fresh-${i}`, {
+				modelId: "gemini-3-flash",
+			});
 			if (!apiKey) continue;
 			counts.set(apiKey, (counts.get(apiKey) ?? 0) + 1);
 		}

--- a/packages/ai/test/auth-storage-antigravity-selection.test.ts
+++ b/packages/ai/test/auth-storage-antigravity-selection.test.ts
@@ -162,6 +162,47 @@ describe("AuthStorage google-antigravity oauth ranking", () => {
 		expect(apiKey).toBe("api-acct-healthy");
 	});
 
+
+	test("ranks by bottleneck counter instead of healthier secondary counter", async () => {
+		if (!authStorage) throw new Error("test setup failed");
+
+		await authStorage.set("google-antigravity", [
+			{ type: "oauth", ...createCredential("acct-gemini-hot", "proj-gemini-hot", "hot@example.com") },
+			{ type: "oauth", ...createCredential("acct-balanced", "proj-balanced", "balanced@example.com") },
+		]);
+
+		usageByAccount.set(
+			"acct-gemini-hot",
+			createAntigravityReport({
+				accountId: "acct-gemini-hot",
+				projectId: "proj-gemini-hot",
+				windows: [
+					{ counter: "google", usedFraction: 0.95, resetInMs: 8 * HOUR_MS },
+					{ counter: "anthropic", usedFraction: 0, resetInMs: 8 * HOUR_MS },
+				],
+			}),
+		);
+		usageByAccount.set(
+			"acct-balanced",
+			createAntigravityReport({
+				accountId: "acct-balanced",
+				projectId: "proj-balanced",
+				windows: [
+					{ counter: "google", usedFraction: 0.8, resetInMs: 8 * HOUR_MS },
+					{ counter: "anthropic", usedFraction: 0.7, resetInMs: 8 * HOUR_MS },
+				],
+			}),
+		);
+
+		const counts = new Map<string, number>();
+		for (let i = 0; i < 80; i += 1) {
+			const apiKey = await authStorage.getApiKey("google-antigravity", `session-antigravity-bottleneck-${i}`);
+			if (!apiKey) continue;
+			counts.set(apiKey, (counts.get(apiKey) ?? 0) + 1);
+		}
+
+		expect(counts.get("api-acct-balanced") ?? 0).toBeGreaterThan(counts.get("api-acct-gemini-hot") ?? 0);
+	});
 	test("prefers less-pressured antigravity account when neither is exhausted", async () => {
 		if (!authStorage) throw new Error("test setup failed");
 

--- a/packages/ai/test/google-antigravity-usage.test.ts
+++ b/packages/ai/test/google-antigravity-usage.test.ts
@@ -257,11 +257,12 @@ describe("antigravity ranking strategy", () => {
 		};
 	}
 
-	it("maps the most-pressured counter to secondary because AuthStorage compares secondary first", () => {
+	it("maps the most-pressured counter to primary and leaves secondary unset", () => {
 		// fetchAntigravityUsage sorts ascending by remainingFraction, so a real
 		// report's limits[0] is always the bottleneck. AuthStorage compares the
-		// secondary ranking metrics before primary, so Antigravity must put the
-		// bottleneck there; otherwise [5%, 90%] remaining can beat [40%, 40%]
+		// secondary ranking metrics before primary; leaving secondary unset makes
+		// every Antigravity candidate tie there, so the bottleneck counter in
+		// primary decides — otherwise [5%, 90%] remaining can beat [40%, 40%]
 		// because the runner-up counter looks healthier.
 		const report = {
 			provider: "google-antigravity" as const,
@@ -269,8 +270,8 @@ describe("antigravity ranking strategy", () => {
 			limits: [makeLimit(0.05, "Anthropic"), makeLimit(0.4, "Google"), makeLimit(0.9, "OpenAI")],
 		};
 		const { primary, secondary } = antigravityRankingStrategy.findWindowLimits(report);
-		expect(secondary?.label).toBe("Anthropic");
-		expect(primary?.label).toBe("Google");
+		expect(primary?.label).toBe("Anthropic");
+		expect(secondary).toBeUndefined();
 	});
 
 	it("returns undefined windows when the credential has no usage limits", () => {

--- a/packages/ai/test/rate-limit-utils.test.ts
+++ b/packages/ai/test/rate-limit-utils.test.ts
@@ -87,6 +87,25 @@ describe("isUsageLimitError", () => {
 			),
 		).toBe(true);
 	});
+
+	// Antigravity / Cloud Code Assist returns this phrasing for an exhausted
+	// project quota; `parseRateLimitReason` already maps it to QUOTA_EXHAUSTED
+	// via the generic `quota` substring, but `isUsageLimitError` decides
+	// whether the auth layer rotates to a sibling OAuth credential, so it
+	// must match too — otherwise the session stays pinned to the exhausted
+	// account (see issue #2198).
+	it("detects Antigravity 'Individual quota reached' as a credential-rotatable usage limit", () => {
+		expect(
+			isUsageLimitError(
+				"Cloud Code Assist API error (429): Individual quota reached. Contact your administrator to enable overages.",
+			),
+		).toBe(true);
+	});
+
+	it("detects bare 'quota reached' phrasing", () => {
+		expect(isUsageLimitError("quota reached")).toBe(true);
+		expect(isUsageLimitError("quota_reached")).toBe(true);
+	});
 });
 
 describe("calculateRateLimitBackoffMs", () => {

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -133,6 +133,10 @@
 - Fixed Windows stdio MCP servers launched through PATH shims such as `codegraph.cmd` so bare commands like `codegraph` resolve via `PATHEXT` before spawn ([#2174](https://github.com/can1357/oh-my-pi/issues/2174)).
 - Fixed compiled-binary extensions failing to load `@oh-my-pi/pi-*` packages when `bun --compile` quietly dropped one of the extra entrypoints (observed on macOS arm64 release builds): the legacy-pi compat shim's package-root override branch returned the bunfs path without checking the target was present, so the rewrite emitted a `file://` URL to a missing module and the #1216 fallback (scoped to the throwing `getResolvedSpecifier` path) never ran. Override targets are now validated against the on-disk filesystem at module init, missing entries are dropped, and resolution falls through to canonical lookup so Bun resolves the import from the extension's own `node_modules` ([#2168](https://github.com/can1357/oh-my-pi/issues/2168)).
 
+### Fixed
+
+- Forwarded model ids through `ModelRegistry` API-key resolvers and Antigravity usage-limit rotation so `pi-ai` can apply model-family-scoped OAuth quota backoff instead of treating all `google-antigravity` counters as credential-wide. ([#2198](https://github.com/can1357/oh-my-pi/issues/2198))
+
 ## [15.10.8] - 2026-06-09
 
 ### Added

--- a/packages/coding-agent/src/auto-thinking/classifier.ts
+++ b/packages/coding-agent/src/auto-thinking/classifier.ts
@@ -86,6 +86,7 @@ async function classifyOnline(input: string, deps: ClassifyDifficultyDeps): Prom
 			apiKey: deps.registry.resolver(model.provider, {
 				sessionId: deps.sessionId,
 				baseUrl: model.baseUrl,
+				modelId: model.id,
 			}),
 			maxTokens,
 			disableReasoning: true,

--- a/packages/coding-agent/src/commit/model-selection.ts
+++ b/packages/coding-agent/src/commit/model-selection.ts
@@ -48,7 +48,7 @@ export async function resolvePrimaryModel(
 	}
 	return {
 		model,
-		apiKey: modelRegistry.resolver(model.provider, { baseUrl: model.baseUrl }),
+		apiKey: modelRegistry.resolver(model.provider, { baseUrl: model.baseUrl, modelId: model.id }),
 		thinkingLevel: resolved?.thinkingLevel,
 	};
 }
@@ -68,6 +68,7 @@ export async function resolveSmolModel(
 				model: resolvedSmol.model,
 				apiKey: modelRegistry.resolver(resolvedSmol.model.provider, {
 					baseUrl: resolvedSmol.model.baseUrl,
+					modelId: resolvedSmol.model.id,
 				}),
 				thinkingLevel: resolvedSmol.thinkingLevel,
 			};
@@ -82,7 +83,7 @@ export async function resolveSmolModel(
 		if (apiKey) {
 			return {
 				model: candidate,
-				apiKey: modelRegistry.resolver(candidate.provider, { baseUrl: candidate.baseUrl }),
+				apiKey: modelRegistry.resolver(candidate.provider, { baseUrl: candidate.baseUrl, modelId: candidate.id }),
 			};
 		}
 	}

--- a/packages/coding-agent/src/config/api-key-resolver.ts
+++ b/packages/coding-agent/src/config/api-key-resolver.ts
@@ -5,6 +5,8 @@ export interface ApiKeyResolverOptions {
 	sessionId?: string;
 	/** Provider base URL hint forwarded to the auth-storage cascade. */
 	baseUrl?: string;
+	/** Provider model id forwarded to model-scoped usage ranking/backoff. */
+	modelId?: string;
 }
 
 /**
@@ -16,7 +18,7 @@ export interface ApiKeyResolverRegistry {
 	getApiKeyForProvider(
 		provider: string,
 		sessionId?: string,
-		options?: { baseUrl?: string; forceRefresh?: boolean; signal?: AbortSignal },
+		options?: { baseUrl?: string; modelId?: string; forceRefresh?: boolean; signal?: AbortSignal },
 	): Promise<string | undefined>;
 	authStorage: Pick<AuthStorage, "rotateSessionCredential">;
 	/**
@@ -39,10 +41,10 @@ export function createApiKeyResolver(
 	provider: string,
 	options: ApiKeyResolverOptions = {},
 ): ApiKeyResolver {
-	const { sessionId, baseUrl } = options;
+	const { sessionId, baseUrl, modelId } = options;
 	return async ({ lastChance, error, signal }) => {
 		if (error === undefined) {
-			return registry.getApiKeyForProvider(provider, sessionId, { baseUrl });
+			return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId });
 		}
 		if (lastChance) {
 			// Account constraint (401 / usage / account-rate-limit): rotate to a
@@ -50,9 +52,9 @@ export function createApiKeyResolver(
 			// sibling exists we switch immediately; the precise no-sibling backoff
 			// is owned by `markUsageLimitReached` (default + server usage-report
 			// reset) and the outer whole-turn retry layer.
-			await registry.authStorage.rotateSessionCredential(provider, sessionId, { error, signal });
-			return registry.getApiKeyForProvider(provider, sessionId, { baseUrl });
+			await registry.authStorage.rotateSessionCredential(provider, sessionId, { error, modelId, signal });
+			return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId });
 		}
-		return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, forceRefresh: true, signal });
+		return registry.getApiKeyForProvider(provider, sessionId, { baseUrl, modelId, forceRefresh: true, signal });
 	};
 }

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1674,13 +1674,14 @@ export class ModelRegistry {
 	async getApiKeyForProvider(
 		provider: string,
 		sessionId?: string,
-		options?: { baseUrl?: string; forceRefresh?: boolean; signal?: AbortSignal },
+		options?: { baseUrl?: string; modelId?: string; forceRefresh?: boolean; signal?: AbortSignal },
 	): Promise<string | undefined> {
 		if (this.#keylessProviders.has(provider) && !this.authStorage.hasAuth(provider)) {
 			return kNoAuth;
 		}
 		return this.authStorage.getApiKey(provider, sessionId, {
 			baseUrl: options?.baseUrl,
+			modelId: options?.modelId,
 			forceRefresh: options?.forceRefresh,
 			signal: options?.signal,
 		});

--- a/packages/coding-agent/src/eval/completion-bridge.ts
+++ b/packages/coding-agent/src/eval/completion-bridge.ts
@@ -163,6 +163,7 @@ export async function runEvalCompletion(
 				apiKey: registry.resolver(model.provider, {
 					sessionId: options.session.getSessionId?.() ?? undefined,
 					baseUrl: model.baseUrl,
+					modelId: model.id,
 				}),
 				signal: options.signal,
 				reasoning: reasoningForTier(tier, model),

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -276,6 +276,7 @@ async function runPhase1(options: {
 				apiKey: modelRegistry.resolver(phase1Model.provider, {
 					sessionId: session.sessionId,
 					baseUrl: phase1Model.baseUrl,
+					modelId: phase1Model.id,
 				}),
 				modelMaxTokens: computeModelTokenBudget(phase1Model, config),
 				config,
@@ -436,6 +437,7 @@ async function runPhase2(options: {
 				apiKey: modelRegistry.resolver(phase2Model.provider, {
 					sessionId: session.sessionId,
 					baseUrl: phase2Model.baseUrl,
+					modelId: phase2Model.id,
 				}),
 				metadata: session.agent?.metadataForProvider(phase2Model.provider),
 			});

--- a/packages/coding-agent/src/mnemopi/backend.ts
+++ b/packages/coding-agent/src/mnemopi/backend.ts
@@ -360,6 +360,7 @@ async function resolveMnemopiProviderOptions(
 						apiKey: modelRegistry.resolver(model.provider, {
 							sessionId,
 							baseUrl: model.baseUrl,
+							modelId: model.id,
 						}),
 						maxTokens: opts?.maxTokens,
 						temperature: opts?.temperature,

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8337,6 +8337,7 @@ export class AgentSession {
 				{
 					retryAfterMs,
 					baseUrl: this.model.baseUrl,
+					modelId: this.model.id,
 				},
 			);
 			if (outcome.switched) {

--- a/packages/coding-agent/src/tools/image-gen.ts
+++ b/packages/coding-agent/src/tools/image-gen.ts
@@ -1052,6 +1052,7 @@ export const imageGenTool: CustomTool<typeof imageGenSchema, ImageGenToolDetails
 				const hostedKey: ApiKey = ctx.modelRegistry.resolver(hostedModel.provider, {
 					sessionId,
 					baseUrl: hostedModel.baseUrl,
+					modelId: hostedModel.id,
 				});
 
 				const parsed = await withAuth(

--- a/packages/coding-agent/src/tools/inspect-image.ts
+++ b/packages/coding-agent/src/tools/inspect-image.ts
@@ -141,6 +141,7 @@ export class InspectImageTool implements AgentTool<typeof inspectImageSchema, In
 				apiKey: modelRegistry.resolver(model.provider, {
 					sessionId: this.session.getSessionId?.() ?? undefined,
 					baseUrl: model.baseUrl,
+					modelId: model.id,
 				}),
 				signal,
 			},

--- a/packages/coding-agent/src/utils/commit-message-generator.ts
+++ b/packages/coding-agent/src/utils/commit-message-generator.ts
@@ -115,6 +115,7 @@ export async function generateCommitMessage(
 					apiKey: registry.resolver(candidate.model.provider, {
 						sessionId,
 						baseUrl: candidate.model.baseUrl,
+						modelId: candidate.model.id,
 					}),
 					maxTokens,
 					reasoning: toReasoningEffort(candidate.thinkingLevel),

--- a/packages/coding-agent/src/utils/title-generator.ts
+++ b/packages/coding-agent/src/utils/title-generator.ts
@@ -239,7 +239,7 @@ export async function generateTitleOnline(
 				tools: [setTitleTool],
 			},
 			{
-				apiKey: registry.resolver(model.provider, { sessionId, baseUrl: model.baseUrl }),
+				apiKey: registry.resolver(model.provider, { sessionId, baseUrl: model.baseUrl, modelId: model.id }),
 				maxTokens,
 				disableReasoning: true,
 				toolChoice: { type: "tool", name: SET_TITLE_TOOL_NAME },


### PR DESCRIPTION
## Repro

Google Antigravity / Cloud Code Assist returns this 429 once a project hits its per-account cap:

```
Cloud Code Assist API error (429): Individual quota reached. Contact your administrator to enable overages.
```

```
$ bun -e '...isUsageLimitError(msg), parseRateLimitReason(msg)...'
{ reason: "QUOTA_EXHAUSTED", usage: false }
```

`parseRateLimitReason` maps the message to `QUOTA_EXHAUSTED` (via the generic `quota` substring), but `isUsageLimitError` does not — and that is the predicate `auth-retry` and `AuthStorage.markUsageLimitReached` consult. The exhausted credential never gets blocked, so a session keeps retrying it instead of rotating to a sibling OAuth credential.

## Cause

- `packages/ai/src/rate-limit-utils.ts:86` — `USAGE_LIMIT_PATTERN` only matches `usage.?limit`, `usage_limit_reached`, `usage_not_included`, `limit_reached`, `quota.?exceeded`, `resource.?exhausted`. "Individual quota reached" matches none of them (note the space — `limit_reached` requires a literal underscore).
- `packages/ai/src/auth-storage.ts:650` — `DEFAULT_RANKING_STRATEGIES` only registers `openai-codex` and `anthropic`. `antigravityUsageProvider` already exists and is fetched, but without a `CredentialRankingStrategy` for `google-antigravity` the data never feeds `#rankOAuthSelections`/`markUsageLimitReached`. New sessions can be assigned to an exhausted account.

## Fix

- `rate-limit-utils.ts`: extend `USAGE_LIMIT_PATTERN` with `quota.?reached` (covers `"Individual quota reached"`, bare `"quota reached"`, and `"quota_reached"`).
- `usage/google-antigravity.ts`: add `antigravityRankingStrategy`. Antigravity usage reports already arrive sorted ascending by `remainingFraction`, so the strategy picks `report.limits[0]` as primary and the next distinct limit as secondary; `windowDefaults` is 24h/24h (matching `daily-cloudcode-pa.googleapis.com` daily resets), since Antigravity windows omit `durationMs`.
- `auth-storage.ts`: import and register `antigravityRankingStrategy` for `google-antigravity` in `DEFAULT_RANKING_STRATEGIES`.
- `CHANGELOG.md`: paired `### Added` / `### Fixed` entries under `[Unreleased]`.

## Verification

- `bun test test/rate-limit-utils.test.ts test/auth-storage-antigravity-selection.test.ts test/google-antigravity-usage.test.ts` → **26 pass, 0 fail**.
- Broader auth-storage suite (`auth-storage-codex-selection`, `-broker-no-sentinel`, `-config-override`, `-usage-cache`, `-credential-disabled-event`, `-credential-origin`, `-email-dedupe`, `-force-refresh-rotate`, `-oauth-refresh-race`, `-refresh-skew`, `auth-retry`) → **97 pass, 0 fail**; confirms the new registration does not regress existing codex/anthropic ranking.
- New `auth-storage-antigravity-selection.test.ts` exercises `getApiKey("google-antigravity", …)` end-to-end:
  - exhausted Gemini counter on one credential → `getApiKey` returns the healthy sibling;
  - both unblocked → the less-pressured account wins a weighted majority of session draws.
- Rate-limit matcher tests pin `Individual quota reached`, `quota reached`, and `quota_reached` so the regression cannot return.

Fixes #2198