### PR TITLE
feat(config): add runtime config overlays

### DIFF
--- a/docs/config-usage.md
+++ b/docs/config-usage.md
@@ -138,12 +138,13 @@ The runtime settings model is layered:
 
 1. Global settings: `~/.omp/agent/config.yml`
 2. Project settings: discovered via settings capability (`settings.json` and `config.yml` from providers)
-3. Runtime overrides: in-memory, non-persistent
-4. Schema defaults: from `SETTINGS_SCHEMA`
+3. CLI config overlays: `omp --config <path>` / repeated `--config` files, loaded as `config.yml`-style YAML for this process only
+4. Runtime overrides: in-memory, non-persistent
+5. Schema defaults: from `SETTINGS_SCHEMA`
 
-Effective read path:
+Effective precedence:
 
-`defaults <- global <- project <- overrides`
+`defaults <- global <- project <- CLI config overlays <- overrides`
 
 Write behavior:
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -119,6 +119,10 @@
 - Removed the `clearOnShrink` setting and its `PI_CLEAR_ON_SHRINK` environment variable: the rewritten renderer always clears shrunken rows exactly, so the flicker/perf tradeoff the setting controlled no longer exists. Existing config entries are ignored.
 - Removed the prompt-submit native-scrollback reconciliation checkpoint and the eager streaming render mode from the interactive controllers — the renderer's append-only contract made both obsolete.
 
+### Added
+
+- Added repeatable `--config <path>` CLI overlays for temporary `config.yml`-style settings without editing the persistent global config ([#1733](https://github.com/can1357/oh-my-pi/issues/1733)).
+
 ## [15.10.9] - 2026-06-09
 
 ### Fixed

--- a/packages/coding-agent/src/cli/args.ts
+++ b/packages/coding-agent/src/cli/args.ts
@@ -14,6 +14,7 @@ export interface Args {
 	allowHome?: boolean;
 	provider?: string;
 	model?: string;
+	config?: string[];
 	smol?: string;
 	slow?: string;
 	plan?: string;
@@ -111,6 +112,8 @@ export function parseArgs(inputArgs: string[], extensionFlags?: Map<string, { ty
 			result.allowHome = true;
 		} else if (arg === "--cwd" && i + 1 < args.length) {
 			result.cwd = args[++i];
+		} else if (arg === "--config" && i + 1 < args.length) {
+			result.config = [...(result.config ?? []), args[++i]];
 		} else if (arg === "--mode" && i + 1 < args.length) {
 			const mode = args[++i];
 			if (mode === "text" || mode === "json" || mode === "rpc" || mode === "acp" || mode === "rpc-ui") {

--- a/packages/coding-agent/src/commands/launch.ts
+++ b/packages/coding-agent/src/commands/launch.ts
@@ -56,6 +56,10 @@ export default class Index extends Command {
 			description: "Output mode: text (default), json, rpc, or rpc-ui",
 			options: ["text", "json", "rpc", "acp", "rpc-ui"],
 		}),
+		config: Flags.string({
+			description: "Load an extra config.yml-style overlay for this run (repeatable)",
+			multiple: true,
+		}),
 		print: Flags.boolean({
 			char: "p",
 			description: "Non-interactive mode: process prompt and exit",

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -118,10 +118,12 @@ type PathScopedStringArrayEntry = {
 	providers?: unknown;
 };
 
+function expandTilde(p: string): string {
+	return p === "~" ? os.homedir() : p.startsWith("~/") ? path.join(os.homedir(), p.slice(2)) : p;
+}
+
 function normalizePathPrefix(prefix: string): string {
-	const expanded =
-		prefix === "~" ? os.homedir() : prefix.startsWith("~/") ? path.join(os.homedir(), prefix.slice(2)) : prefix;
-	return path.resolve(expanded);
+	return path.resolve(expandTilde(prefix));
 }
 
 function pathMatchesPrefix(cwd: string, prefix: string): boolean {
@@ -226,7 +228,7 @@ export class Settings {
 		this.#cwd = path.normalize(options.cwd ?? getProjectDir());
 		this.#agentDir = path.normalize(options.agentDir ?? getAgentDir());
 		this.#configPath = options.inMemory ? null : path.join(this.#agentDir, "config.yml");
-		this.#configFiles = options.configFiles?.map(file => path.resolve(this.#cwd, file)) ?? [];
+		this.#configFiles = options.configFiles?.map(file => path.resolve(this.#cwd, expandTilde(file))) ?? [];
 		this.#persist = !options.inMemory;
 
 		if (options.overrides) {
@@ -606,9 +608,38 @@ export class Settings {
 	async #loadConfigOverlays(): Promise<RawSettings> {
 		let merged: RawSettings = {};
 		for (const filePath of this.#configFiles) {
-			merged = this.#deepMerge(merged, await this.#loadYaml(filePath));
+			merged = this.#deepMerge(merged, await this.#loadOverlayYaml(filePath));
 		}
 		return merged;
+	}
+
+	/**
+	 * Strict loader for explicit `--config` overlays: unlike `#loadYaml`,
+	 * missing or malformed files are hard errors so a typo'd path cannot
+	 * silently fall back to the persistent settings.
+	 */
+	async #loadOverlayYaml(filePath: string): Promise<RawSettings> {
+		let content: string;
+		try {
+			content = await Bun.file(filePath).text();
+		} catch (error) {
+			throw new Error(
+				isEnoent(error)
+					? `Config overlay not found: ${filePath}`
+					: `Failed to read config overlay ${filePath}: ${String(error)}`,
+			);
+		}
+		let parsed: unknown;
+		try {
+			parsed = YAML.parse(content);
+		} catch (error) {
+			throw new Error(`Failed to parse config overlay ${filePath}: ${String(error)}`);
+		}
+		if (parsed === null || parsed === undefined) return {};
+		if (typeof parsed !== "object" || Array.isArray(parsed)) {
+			throw new Error(`Config overlay must be a YAML mapping: ${filePath}`);
+		}
+		return this.#migrateRawSettings(parsed as RawSettings);
 	}
 
 	async #migrateFromLegacy(): Promise<void> {

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -64,6 +64,8 @@ export interface SettingsOptions {
 	inMemory?: boolean;
 	/** Initial overrides */
 	overrides?: Partial<Record<SettingPath, unknown>>;
+	/** Extra config.yml-style overlays loaded after global/project settings */
+	configFiles?: string[];
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -193,10 +195,13 @@ export class Settings {
 	#agentDir: string;
 	#storage: AgentStorage | null = null;
 
+	#configFiles: string[] = [];
 	/** Global settings from config.yml */
 	#global: RawSettings = {};
 	/** Project settings from .claude/settings.yml etc */
 	#project: RawSettings = {};
+	/** Extra config.yml-style overlays passed by CLI */
+	#configOverlay: RawSettings = {};
 	/** Runtime overrides (not persisted) */
 	#overrides: RawSettings = {};
 	/** Merged view (global + project + overrides) */
@@ -221,6 +226,7 @@ export class Settings {
 		this.#cwd = path.normalize(options.cwd ?? getProjectDir());
 		this.#agentDir = path.normalize(options.agentDir ?? getAgentDir());
 		this.#configPath = options.inMemory ? null : path.join(this.#agentDir, "config.yml");
+		this.#configFiles = options.configFiles?.map(file => path.resolve(this.#cwd, file)) ?? [];
 		this.#persist = !options.inMemory;
 
 		if (options.overrides) {
@@ -386,6 +392,8 @@ export class Settings {
 		cloned.#storage = this.#storage;
 		cloned.#global = structuredClone(this.#global);
 		cloned.#project = this.#persist ? await cloned.#loadProjectSettings() : structuredClone(this.#project);
+		cloned.#configFiles = [...this.#configFiles];
+		cloned.#configOverlay = structuredClone(this.#configOverlay);
 		cloned.#overrides = structuredClone(this.#overrides);
 		cloned.#rebuildMerged();
 		cloned.#fireAllHooks();
@@ -557,6 +565,7 @@ export class Settings {
 		}
 
 		this.#project = await projectPromise;
+		this.#configOverlay = await this.#loadConfigOverlays();
 
 		// Build merged view (global → project → overrides; project wins over global)
 		this.#rebuildMerged();
@@ -592,6 +601,14 @@ export class Settings {
 		} catch {
 			return {};
 		}
+	}
+
+	async #loadConfigOverlays(): Promise<RawSettings> {
+		let merged: RawSettings = {};
+		for (const filePath of this.#configFiles) {
+			merged = this.#deepMerge(merged, await this.#loadYaml(filePath));
+		}
+		return merged;
 	}
 
 	async #migrateFromLegacy(): Promise<void> {
@@ -898,6 +915,7 @@ export class Settings {
 
 	#rebuildMerged(): void {
 		this.#merged = this.#deepMerge(this.#deepMerge({}, this.#global), this.#project);
+		this.#merged = this.#deepMerge(this.#merged, this.#configOverlay);
 		this.#merged = this.#deepMerge(this.#merged, this.#overrides);
 		this.#resolvedCache.clear();
 	}

--- a/packages/coding-agent/src/main.ts
+++ b/packages/coding-agent/src/main.ts
@@ -920,6 +920,7 @@ export async function runRootCommand(
 	if (parsedArgs.listModels !== undefined) {
 		const settingsInstance = await logger.time("settings:init:list-models", Settings.init, {
 			cwd: getProjectDir(),
+			configFiles: parsedArgs.config,
 		});
 		await modelRegistry.refresh("online");
 		const cliExtensionPaths = parsedArgs.noExtensions
@@ -983,7 +984,8 @@ export async function runRootCommand(
 	}
 
 	let cwd = getProjectDir();
-	const settingsInstance = deps.settings ?? (await logger.time("settings:init", Settings.init, { cwd }));
+	const settingsInstance =
+		deps.settings ?? (await logger.time("settings:init", Settings.init, { cwd, configFiles: parsedArgs.config }));
 	if (parsedArgs.approvalMode) {
 		// Runtime override (not persisted): every settings.get("tools.approvalMode") downstream
 		// sees this value. The wrapper still honours --auto-approve / --yolo on top of it.

--- a/packages/coding-agent/test/cli-cwd-flag.test.ts
+++ b/packages/coding-agent/test/cli-cwd-flag.test.ts
@@ -26,6 +26,12 @@ describe("parseArgs — --cwd flag", () => {
 		expect(result.messages).toEqual(["hello"]);
 	});
 
+	it("parses repeated --config overlays", () => {
+		const result = parseArgs(["--config", "base.yml", "--config=team.yml", "hello"]);
+
+		expect(result.config).toEqual(["base.yml", "team.yml"]);
+		expect(result.messages).toEqual(["hello"]);
+	});
 	it("applies --cwd before session lookup callers read the project directory", async () => {
 		const launchDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-cwd-launch-"));
 		const targetDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-cwd-target-"));

--- a/packages/coding-agent/test/settings-reload-cwd.test.ts
+++ b/packages/coding-agent/test/settings-reload-cwd.test.ts
@@ -68,6 +68,39 @@ describe("Settings.reloadForCwd", () => {
 		}
 	});
 
+	it("rejects a missing --config overlay instead of silently ignoring it", async () => {
+		const testDir = path.join(os.tmpdir(), "test-config-overlay-missing", Snowflake.next());
+		try {
+			resetSettingsForTest();
+			fs.mkdirSync(testDir, { recursive: true });
+
+			const missingPath = path.join(testDir, "nope.yml");
+			expect(Settings.init({ cwd: testDir, inMemory: true, configFiles: [missingPath] })).rejects.toThrow(
+				`Config overlay not found: ${missingPath}`,
+			);
+		} finally {
+			resetSettingsForTest();
+			if (fs.existsSync(testDir)) fs.rmSync(testDir, { recursive: true, force: true });
+		}
+	});
+
+	it("rejects a malformed --config overlay", async () => {
+		const testDir = path.join(os.tmpdir(), "test-config-overlay-bad", Snowflake.next());
+		const overlayPath = path.join(testDir, "bad.yml");
+		try {
+			resetSettingsForTest();
+			fs.mkdirSync(testDir, { recursive: true });
+			fs.writeFileSync(overlayPath, "compaction: [unclosed\n");
+
+			expect(Settings.init({ cwd: testDir, inMemory: true, configFiles: [overlayPath] })).rejects.toThrow(
+				"Failed to parse config overlay",
+			);
+		} finally {
+			resetSettingsForTest();
+			if (fs.existsSync(testDir)) fs.rmSync(testDir, { recursive: true, force: true });
+		}
+	});
+
 	describe("project layer (on disk)", () => {
 		let testDir: string;
 		let agentDir: string;

--- a/packages/coding-agent/test/settings-reload-cwd.test.ts
+++ b/packages/coding-agent/test/settings-reload-cwd.test.ts
@@ -43,6 +43,31 @@ describe("Settings.reloadForCwd", () => {
 		expect(settings.get("enabledModels")).toEqual(["model-a"]);
 	});
 
+	it("loads extra config overlays after project settings", async () => {
+		const testDir = path.join(os.tmpdir(), "test-config-overlay", Snowflake.next());
+		const projectDir = path.join(testDir, "project");
+		const overlayPath = path.join(testDir, "overlay.yml");
+		try {
+			resetSettingsForTest();
+			fs.mkdirSync(projectDir, { recursive: true });
+			fs.mkdirSync(getProjectAgentDir(projectDir), { recursive: true });
+			fs.writeFileSync(
+				path.join(getProjectAgentDir(projectDir), "settings.json"),
+				JSON.stringify({ compaction: { enabled: true } }),
+			);
+			fs.writeFileSync(overlayPath, "compaction:\n  enabled: false\n");
+
+			const settings = await Settings.init({ cwd: projectDir, inMemory: true, configFiles: [overlayPath] });
+			expect(settings.get("compaction.enabled")).toBe(false);
+
+			settings.override("compaction.enabled", true);
+			expect(settings.get("compaction.enabled")).toBe(true);
+		} finally {
+			resetSettingsForTest();
+			if (fs.existsSync(testDir)) fs.rmSync(testDir, { recursive: true, force: true });
+		}
+	});
+
 	describe("project layer (on disk)", () => {
 		let testDir: string;
 		let agentDir: string;


### PR DESCRIPTION
Fixes #1733.

## Summary
- add repeatable `--config <path>` CLI overlays
- load overlay files as `config.yml`-style YAML after global/project settings and before runtime overrides
- document precedence in config usage docs

## Verification
- bun test packages/coding-agent/test/settings-reload-cwd.test.ts -t "loads extra config overlays"
- bun test packages/coding-agent/test/cli-cwd-flag.test.ts
- bun --cwd=packages/coding-agent run check