### PR TITLE
feat(eval): add python interpreter setting

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -119,6 +119,10 @@
 - Removed the `clearOnShrink` setting and its `PI_CLEAR_ON_SHRINK` environment variable: the rewritten renderer always clears shrunken rows exactly, so the flicker/perf tradeoff the setting controlled no longer exists. Existing config entries are ignored.
 - Removed the prompt-submit native-scrollback reconciliation checkpoint and the eager streaming render mode from the interactive controllers — the renderer's append-only contract made both obsolete.
 
+### Added
+
+- Added `python.interpreter` to pin eval's Python backend to an explicit interpreter and skip automatic runtime discovery ([#1802](https://github.com/can1357/oh-my-pi/issues/1802)).
+
 ## [15.10.9] - 2026-06-09
 
 ### Fixed

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -2100,6 +2100,16 @@ export const SETTINGS_SCHEMA = {
 			description: "Whether to keep IPython kernel alive across calls",
 		},
 	},
+	"python.interpreter": {
+		type: "string",
+		default: "",
+		ui: {
+			tab: "editing",
+			label: "Python Interpreter",
+			description:
+				"Optional path to an exact Python executable. When set, automatic Python runtime discovery is skipped.",
+		},
+	},
 
 	// ────────────────────────────────────────────────────────────────────────
 	// Tools

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -42,6 +42,11 @@ export interface PythonExecutorOptions {
 	kernelOwnerId?: string;
 	/** Kernel mode (session reuse vs per-call) */
 	kernelMode?: PythonKernelMode;
+	/**
+	 * Explicit interpreter path (`python.interpreter` resolved from the
+	 * session's settings). Skips automatic runtime discovery when set.
+	 */
+	interpreter?: string;
 	/** Restart the kernel before executing */
 	reset?: boolean;
 	/** Session file path for accessing task outputs */
@@ -326,6 +331,7 @@ async function startKernel(cwd: string, options: PythonExecutorOptions): Promise
 		env: buildKernelEnv(options),
 		signal: options.signal,
 		deadlineMs: options.deadlineMs,
+		interpreter: options.interpreter,
 	});
 }
 
@@ -587,7 +593,10 @@ async function executeWithKernel(
 }
 
 async function ensureKernelAvailable(cwd: string, options: PythonExecutorOptions): Promise<void> {
-	const availability = await waitForPromiseWithCancellation(checkPythonKernelAvailability(cwd), options);
+	const availability = await waitForPromiseWithCancellation(
+		checkPythonKernelAvailability(cwd, options.interpreter),
+		options,
+	);
 	if (!availability.ok) {
 		throw new Error(availability.reason ?? "Python kernel unavailable");
 	}

--- a/packages/coding-agent/src/eval/py/index.ts
+++ b/packages/coding-agent/src/eval/py/index.ts
@@ -19,13 +19,17 @@ function readSetting<T>(session: ToolSession, key: string): T | undefined {
 	return settings?.get?.(key);
 }
 
+function readInterpreterSetting(session: ToolSession): string | undefined {
+	return readSetting<string>(session, "python.interpreter")?.trim() || undefined;
+}
+
 export default {
 	id: "python",
 	label: "Python",
 	highlightLang: "python",
 
 	async isAvailable(session: ToolSession): Promise<boolean> {
-		const availability = await checkPythonKernelAvailability(session.cwd);
+		const availability = await checkPythonKernelAvailability(session.cwd, readInterpreterSetting(session));
 		return availability.ok;
 	},
 
@@ -37,6 +41,7 @@ export default {
 			signal: opts.signal,
 			sessionId: namespaceSessionId(opts.sessionId),
 			kernelMode,
+			interpreter: readInterpreterSetting(opts.session),
 			sessionFile: opts.sessionFile,
 			artifactsDir: opts.session.getArtifactsDir?.() ?? undefined,
 			localRoots: resolveEvalUrlRoots(opts.session),

--- a/packages/coding-agent/src/eval/py/kernel.ts
+++ b/packages/coding-agent/src/eval/py/kernel.ts
@@ -17,7 +17,13 @@ import { Settings } from "../../config/settings";
 import { type KernelDisplayOutput, renderKernelDisplay } from "./display";
 import { PYTHON_PRELUDE } from "./prelude";
 import RUNNER_SCRIPT from "./runner.py" with { type: "text" };
-import { enumeratePythonRuntimes, filterEnv, type PythonRuntime, resolvePythonRuntime } from "./runtime";
+import {
+	enumeratePythonRuntimes,
+	filterEnv,
+	type PythonRuntime,
+	resolveExplicitPythonRuntime,
+	resolvePythonRuntime,
+} from "./runtime";
 import { hostHasInheritableConsole, shouldHideKernelWindow } from "./spawn-options";
 
 export type { KernelDisplayOutput, PythonStatusEvent } from "./display";
@@ -156,7 +162,10 @@ async function probePythonKernelAvailability(cwd: string): Promise<PythonKernelA
 		const settings = await Settings.init();
 		const { env } = settings.getShellConfig();
 		const baseEnv = filterEnv(env);
-		const runtimes = enumeratePythonRuntimes(cwd, baseEnv);
+		const explicitInterpreter = settings.get("python.interpreter")?.trim();
+		const runtimes = explicitInterpreter
+			? [resolveExplicitPythonRuntime(explicitInterpreter, cwd, baseEnv)]
+			: enumeratePythonRuntimes(cwd, baseEnv);
 		if (runtimes.length === 0) {
 			return { ok: false, reason: "Python executable not found on PATH" };
 		}
@@ -250,8 +259,12 @@ export class PythonKernel {
 		// PI_PYTHON_SKIP_CHECK), where no candidate was probed.
 		let runtime = availability.runtime;
 		if (!runtime) {
-			const { env: shellEnv } = (await Settings.init()).getShellConfig();
-			runtime = resolvePythonRuntime(options.cwd, filterEnv(shellEnv));
+			const settings = await Settings.init();
+			const { env: shellEnv } = settings.getShellConfig();
+			const explicitInterpreter = settings.get("python.interpreter")?.trim();
+			runtime = explicitInterpreter
+				? resolveExplicitPythonRuntime(explicitInterpreter, options.cwd, filterEnv(shellEnv))
+				: resolvePythonRuntime(options.cwd, filterEnv(shellEnv));
 		}
 		const spawnEnv: Record<string, string> = {};
 		for (const [key, value] of Object.entries(runtime.env)) {

--- a/packages/coding-agent/src/eval/py/kernel.ts
+++ b/packages/coding-agent/src/eval/py/kernel.ts
@@ -102,6 +102,11 @@ interface KernelLifecycleOptions {
 interface KernelStartOptions extends KernelLifecycleOptions {
 	cwd: string;
 	env?: Record<string, string | undefined>;
+	/**
+	 * Explicit interpreter path (`python.interpreter` from the session's
+	 * settings). When set, runtime discovery is skipped entirely.
+	 */
+	interpreter?: string;
 }
 
 interface KernelShutdownOptions {
@@ -135,20 +140,24 @@ function throwIfAborted(signal: AbortSignal | undefined, fallbackReason: string)
 	throw createAbortError("AbortError", typeof reason === "string" ? reason : fallbackReason);
 }
 
-// Cache successful probes per resolved cwd: every cell otherwise pays one (or
-// two — backend.isAvailable + ensureKernelAvailable) interpreter spawns even
-// when the kernel is already hot. Failures are not cached so installing a
-// Python mid-session is picked up on the next attempt.
+// Cache successful probes per resolved cwd + explicit interpreter: every cell
+// otherwise pays one (or two — backend.isAvailable + ensureKernelAvailable)
+// interpreter spawns even when the kernel is already hot. Failures are not
+// cached so installing a Python mid-session is picked up on the next attempt.
 const availabilityCache = new Map<string, Promise<PythonKernelAvailability>>();
 
-export async function checkPythonKernelAvailability(cwd: string): Promise<PythonKernelAvailability> {
+export async function checkPythonKernelAvailability(
+	cwd: string,
+	interpreter?: string,
+): Promise<PythonKernelAvailability> {
 	if (isBunTestRuntime() || $flag("PI_PYTHON_SKIP_CHECK")) {
 		return { ok: true };
 	}
-	const key = path.resolve(cwd);
+	const resolvedCwd = path.resolve(cwd);
+	const key = `${resolvedCwd}\0${interpreter ?? ""}`;
 	const cached = availabilityCache.get(key);
 	if (cached) return await cached;
-	const probe = probePythonKernelAvailability(key);
+	const probe = probePythonKernelAvailability(resolvedCwd, interpreter);
 	availabilityCache.set(key, probe);
 	const result = await probe;
 	if (!result.ok && availabilityCache.get(key) === probe) {
@@ -157,14 +166,13 @@ export async function checkPythonKernelAvailability(cwd: string): Promise<Python
 	return result;
 }
 
-async function probePythonKernelAvailability(cwd: string): Promise<PythonKernelAvailability> {
+async function probePythonKernelAvailability(cwd: string, interpreter?: string): Promise<PythonKernelAvailability> {
 	try {
 		const settings = await Settings.init();
 		const { env } = settings.getShellConfig();
 		const baseEnv = filterEnv(env);
-		const explicitInterpreter = settings.get("python.interpreter")?.trim();
-		const runtimes = explicitInterpreter
-			? [resolveExplicitPythonRuntime(explicitInterpreter, cwd, baseEnv)]
+		const runtimes = interpreter
+			? [resolveExplicitPythonRuntime(interpreter, cwd, baseEnv)]
 			: enumeratePythonRuntimes(cwd, baseEnv);
 		if (runtimes.length === 0) {
 			return { ok: false, reason: "Python executable not found on PATH" };
@@ -248,6 +256,7 @@ export class PythonKernel {
 			"PythonKernel.start:availabilityCheck",
 			checkPythonKernelAvailability,
 			options.cwd,
+			options.interpreter,
 		);
 		if (!availability.ok) {
 			throw new Error(availability.reason ?? "Python kernel unavailable");
@@ -259,11 +268,9 @@ export class PythonKernel {
 		// PI_PYTHON_SKIP_CHECK), where no candidate was probed.
 		let runtime = availability.runtime;
 		if (!runtime) {
-			const settings = await Settings.init();
-			const { env: shellEnv } = settings.getShellConfig();
-			const explicitInterpreter = settings.get("python.interpreter")?.trim();
-			runtime = explicitInterpreter
-				? resolveExplicitPythonRuntime(explicitInterpreter, options.cwd, filterEnv(shellEnv))
+			const { env: shellEnv } = (await Settings.init()).getShellConfig();
+			runtime = options.interpreter
+				? resolveExplicitPythonRuntime(options.interpreter, options.cwd, filterEnv(shellEnv))
 				: resolvePythonRuntime(options.cwd, filterEnv(shellEnv));
 		}
 		const spawnEnv: Record<string, string> = {};

--- a/packages/coding-agent/src/eval/py/runtime.ts
+++ b/packages/coding-agent/src/eval/py/runtime.ts
@@ -182,6 +182,27 @@ function venvBinDir(venvPath: string): string {
 	return process.platform === "win32" ? path.join(venvPath, "Scripts") : path.join(venvPath, "bin");
 }
 
+function detectExplicitVenv(pythonPath: string): { venvPath: string; binDir: string } | undefined {
+	const binDir = path.dirname(pythonPath);
+	const venvPath = path.dirname(binDir);
+	if (fs.existsSync(path.join(venvPath, "pyvenv.cfg"))) {
+		return { venvPath, binDir };
+	}
+	return undefined;
+}
+
+export function resolveExplicitPythonRuntime(
+	interpreter: string,
+	cwd: string,
+	baseEnv: Record<string, string | undefined>,
+): PythonRuntime {
+	const pythonPath = path.isAbsolute(interpreter) ? interpreter : path.resolve(cwd, interpreter);
+	const venv = detectExplicitVenv(pythonPath);
+	if (venv) {
+		return { pythonPath, env: applyVenvEnv(baseEnv, venv.venvPath, venv.binDir), venvPath: venv.venvPath };
+	}
+	return { pythonPath, env: { ...baseEnv } };
+}
 /**
  * Enumerate candidate Python runtimes in priority order: an active/project venv,
  * the managed `~/.omp/python-env`, then the system interpreter on PATH. Every

--- a/packages/coding-agent/src/eval/py/runtime.ts
+++ b/packages/coding-agent/src/eval/py/runtime.ts
@@ -5,6 +5,7 @@
  * for both the shared gateway and local kernel spawning.
  */
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import { $env, $which, getPythonEnvDir } from "@oh-my-pi/pi-utils";
 
@@ -191,18 +192,33 @@ function detectExplicitVenv(pythonPath: string): { venvPath: string; binDir: str
 	return undefined;
 }
 
+/**
+ * Resolve an explicitly configured interpreter (`python.interpreter`) into a
+ * runtime, bypassing discovery. Does not probe or validate the executable —
+ * callers must check it actually runs. `~` expands to the home directory and
+ * relative paths resolve against `cwd`. When the interpreter sits inside a
+ * virtualenv (a `pyvenv.cfg` above its bin dir), the venv activation env is
+ * applied so subprocesses and `pip` resolve consistently.
+ */
 export function resolveExplicitPythonRuntime(
 	interpreter: string,
 	cwd: string,
 	baseEnv: Record<string, string | undefined>,
 ): PythonRuntime {
-	const pythonPath = path.isAbsolute(interpreter) ? interpreter : path.resolve(cwd, interpreter);
+	const expanded =
+		interpreter === "~"
+			? os.homedir()
+			: interpreter.startsWith("~/")
+				? path.join(os.homedir(), interpreter.slice(2))
+				: interpreter;
+	const pythonPath = path.isAbsolute(expanded) ? expanded : path.resolve(cwd, expanded);
 	const venv = detectExplicitVenv(pythonPath);
 	if (venv) {
 		return { pythonPath, env: applyVenvEnv(baseEnv, venv.venvPath, venv.binDir), venvPath: venv.venvPath };
 	}
 	return { pythonPath, env: { ...baseEnv } };
 }
+
 /**
  * Enumerate candidate Python runtimes in priority order: an active/project venv,
  * the managed `~/.omp/python-env`, then the system interpreter on PATH. Every

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -8690,6 +8690,7 @@ export class AgentSession {
 				sessionId: namespacePythonSessionId(sessionId),
 				kernelOwnerId: this.#evalKernelOwnerId,
 				kernelMode: this.settings.get("python.kernelMode"),
+				interpreter: this.settings.get("python.interpreter")?.trim() || undefined,
 				onChunk,
 				signal: abortController.signal,
 			});

--- a/packages/coding-agent/src/tools/index.ts
+++ b/packages/coding-agent/src/tools/index.ts
@@ -463,7 +463,12 @@ export async function createTools(session: ToolSession, toolNames?: string[]): P
 		!allowJs &&
 		(requestedTools === undefined || requestedTools.includes("eval"))
 	) {
-		const availability = await logger.time("createTools:pythonCheck", checkPythonKernelAvailability, session.cwd);
+		const availability = await logger.time(
+			"createTools:pythonCheck",
+			checkPythonKernelAvailability,
+			session.cwd,
+			session.settings.get("python.interpreter")?.trim() || undefined,
+		);
 		pythonAvailable = availability.ok;
 		if (!availability.ok) {
 			logger.warn("Python kernel unavailable and JS backend disabled; eval will be unavailable", {

--- a/packages/coding-agent/test/core/python-kernel-env.test.ts
+++ b/packages/coding-agent/test/core/python-kernel-env.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { enumeratePythonRuntimes, filterEnv, resolvePythonRuntime } from "@oh-my-pi/pi-coding-agent/eval/py/runtime";
+import {
+	enumeratePythonRuntimes,
+	filterEnv,
+	resolveExplicitPythonRuntime,
+	resolvePythonRuntime,
+} from "@oh-my-pi/pi-coding-agent/eval/py/runtime";
 import * as piUtils from "@oh-my-pi/pi-utils";
 
 describe("Python gateway environment filtering", () => {
@@ -92,6 +97,35 @@ describe("enumeratePythonRuntimes", () => {
 		expect(resolvePythonRuntime(path.join(path.sep, "work"), {}).pythonPath).toBe(systemPy);
 	});
 
+	it("resolves an explicit interpreter without falling through to discovery", () => {
+		vi.spyOn(piUtils, "getPythonEnvDir").mockReturnValue(managedDir);
+		vi.spyOn(piUtils, "$which").mockImplementation(bin => (bin === "python" ? systemPy : null));
+		vi.spyOn(fs, "existsSync").mockReturnValue(false);
+		const explicitPy = path.join(path.sep, "custom", "python3.13");
+
+		const runtime = resolveExplicitPythonRuntime(explicitPy, path.join(path.sep, "work"), {
+			PATH: path.join(path.sep, "usr", "bin"),
+		});
+
+		expect(runtime.pythonPath).toBe(explicitPy);
+		expect(runtime.venvPath).toBeUndefined();
+		expect(runtime.env.PATH).toBe(path.join(path.sep, "usr", "bin"));
+	});
+
+	it("sets venv env vars for an explicit interpreter inside a virtualenv", () => {
+		const venvDir = path.join(path.sep, "work", ".venv");
+		const binDir = path.join(venvDir, process.platform === "win32" ? "Scripts" : "bin");
+		const explicitPy = path.join(binDir, process.platform === "win32" ? "python.exe" : "python");
+		vi.spyOn(fs, "existsSync").mockImplementation(candidate => candidate === path.join(venvDir, "pyvenv.cfg"));
+
+		const runtime = resolveExplicitPythonRuntime(explicitPy, path.join(path.sep, "work"), {
+			PATH: path.join(path.sep, "usr", "bin"),
+		});
+
+		expect(runtime.venvPath).toBe(venvDir);
+		expect(runtime.env.VIRTUAL_ENV).toBe(venvDir);
+		expect(runtime.env.PATH).toBe(`${binDir}${path.delimiter}${path.join(path.sep, "usr", "bin")}`);
+	});
 	it("throws from resolvePythonRuntime when no interpreter can be found", () => {
 		vi.spyOn(piUtils, "getPythonEnvDir").mockReturnValue(managedDir);
 		vi.spyOn(piUtils, "$which").mockReturnValue(null);

--- a/packages/coding-agent/test/core/python-kernel-env.test.ts
+++ b/packages/coding-agent/test/core/python-kernel-env.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "bun:test";
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
 import {
 	enumeratePythonRuntimes,
@@ -126,6 +127,29 @@ describe("enumeratePythonRuntimes", () => {
 		expect(runtime.env.VIRTUAL_ENV).toBe(venvDir);
 		expect(runtime.env.PATH).toBe(`${binDir}${path.delimiter}${path.join(path.sep, "usr", "bin")}`);
 	});
+
+	it("expands a home-relative explicit interpreter instead of resolving against cwd", () => {
+		const home = path.join(path.sep, "home", "tester");
+		vi.spyOn(os, "homedir").mockReturnValue(home);
+		vi.spyOn(fs, "existsSync").mockReturnValue(false);
+
+		const runtime = resolveExplicitPythonRuntime("~/venvs/py/bin/python", path.join(path.sep, "work"), {});
+
+		expect(runtime.pythonPath).toBe(path.join(home, "venvs", "py", "bin", "python"));
+	});
+
+	it("resolves a relative explicit interpreter against cwd", () => {
+		vi.spyOn(fs, "existsSync").mockReturnValue(false);
+
+		const runtime = resolveExplicitPythonRuntime(
+			path.join(".venv", "bin", "python"),
+			path.join(path.sep, "work"),
+			{},
+		);
+
+		expect(runtime.pythonPath).toBe(path.join(path.sep, "work", ".venv", "bin", "python"));
+	});
+
 	it("throws from resolvePythonRuntime when no interpreter can be found", () => {
 		vi.spyOn(piUtils, "getPythonEnvDir").mockReturnValue(managedDir);
 		vi.spyOn(piUtils, "$which").mockReturnValue(null);


### PR DESCRIPTION
Fixes #1802.

## Summary
- add `python.interpreter` setting to pin eval Python to an exact executable
- skip automatic Python runtime discovery when configured
- preserve virtualenv env handling for explicit interpreters inside a venv

## Verification
- bun test packages/coding-agent/test/core/python-kernel-env.test.ts
- bun --cwd=packages/coding-agent run check