### PR TITLE
feat(models): resolve secrets from commands

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -137,6 +137,20 @@ Must define at least one of:
 - `id` required
 - `contextWindow` and `maxTokens` must be positive if provided
 
+### Command-resolved secrets
+
+Provider `apiKey` values and provider/model `headers` values may start with `!` to read a secret from command stdout. The command is run with a 10 s timeout, stdout is trimmed, and empty/failing commands are omitted:
+
+```yaml
+providers:
+  openai:
+    apiKey: "!op read op://dev/openai/api-key"
+    headers:
+      X-Team-Key: "!bw get password omp-team-key"
+```
+
+Successful command outputs are cached for the process lifetime so the command is not re-run for every model.
+
 ## Merge and override order
 
 ModelRegistry pipeline (on refresh):

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -119,6 +119,10 @@
 - Removed the `clearOnShrink` setting and its `PI_CLEAR_ON_SHRINK` environment variable: the rewritten renderer always clears shrunken rows exactly, so the flicker/perf tradeoff the setting controlled no longer exists. Existing config entries are ignored.
 - Removed the prompt-submit native-scrollback reconciliation checkpoint and the eager streaming render mode from the interactive controllers — the renderer's append-only contract made both obsolete.
 
+### Added
+
+- Added `!command` resolution for `models.yml` provider `apiKey` values and provider/model headers ([#1888](https://github.com/can1357/oh-my-pi/issues/1888)).
+
 ## [15.10.9] - 2026-06-09
 
 ### Fixed

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1052,16 +1052,19 @@ export class ModelRegistry {
 			// so it wins over OAuth tokens from the broker — when the user pins a
 			// bearer in models.yml (e.g. for an auth-gateway baseUrl), that bearer
 			// must authenticate the outbound request.
-			if (resolvedProviderApiKey) {
-				this.#customProviderApiKeys.set(providerName, resolvedProviderApiKey);
-				this.authStorage.setConfigApiKey(providerName, resolvedProviderApiKey);
+			if (providerConfig.apiKey) {
+				this.#customProviderApiKeys.set(providerName, providerConfig.apiKey);
+				if (resolvedProviderApiKey) this.authStorage.setConfigApiKey(providerName, resolvedProviderApiKey);
 			}
 
 			// Parse per-model overrides
 			if (providerConfig.modelOverrides) {
 				const perModel = new Map<string, ModelOverride>();
 				for (const [modelId, override] of Object.entries(providerConfig.modelOverrides)) {
-					perModel.set(modelId, override);
+					perModel.set(
+						modelId,
+						override.headers ? { ...override, headers: resolveConfigHeaders(override.headers) } : override,
+					);
 				}
 				allModelOverrides.set(providerName, perModel);
 			}

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import * as path from "node:path";
 import { registerCustomApi, unregisterCustomApis } from "@oh-my-pi/pi-ai/api-registry";
 import type { Api, Context, Model, ModelSpec, SimpleStreamOptions, ThinkingConfig } from "@oh-my-pi/pi-ai/types";
@@ -226,14 +227,41 @@ interface CustomModelsResult {
 	found: boolean;
 }
 
+const commandValueCache = new Map<string, string | undefined>();
+
+function resolveCommandConfig(command: string): string | undefined {
+	if (commandValueCache.has(command)) return commandValueCache.get(command);
+	let resolved: string | undefined;
+	try {
+		const stdout = execSync(command, { encoding: "utf8", timeout: 10_000, windowsHide: true });
+		const trimmed = stdout.trim();
+		resolved = trimmed.length > 0 ? trimmed : undefined;
+	} catch {
+		resolved = undefined;
+	}
+	commandValueCache.set(command, resolved);
+	return resolved;
+}
 /**
- * Resolve an API key config value to an actual key.
- * Checks environment variable first, then treats as literal.
+ * Resolve a models.yml secret/config value to an actual value.
+ * `!cmd` runs a shell command and returns trimmed stdout, otherwise env vars are
+ * checked first and the input falls back to a literal value.
  */
-function resolveApiKeyConfig(keyConfig: string): string | undefined {
-	const envValue = Bun.env[keyConfig];
+function resolveConfigValue(valueConfig: string): string | undefined {
+	if (valueConfig.startsWith("!")) return resolveCommandConfig(valueConfig.slice(1).trim());
+	const envValue = Bun.env[valueConfig];
 	if (envValue) return envValue;
-	return keyConfig;
+	return valueConfig;
+}
+
+function resolveConfigHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
+	if (!headers) return undefined;
+	const resolved: Record<string, string> = {};
+	for (const [key, value] of Object.entries(headers)) {
+		const next = resolveConfigValue(value);
+		if (next) resolved[key] = next;
+	}
+	return Object.keys(resolved).length > 0 ? resolved : undefined;
 }
 
 function extractGoogleOAuthToken(value: string | undefined): string | undefined {
@@ -394,7 +422,8 @@ function mergeCustomModelHeaders(
 	authHeader: boolean | undefined,
 	apiKeyConfig: string | undefined,
 ): Record<string, string> | undefined {
-	return mergeAuthHeader({ ...providerHeaders, ...modelHeaders }, authHeader, apiKeyConfig);
+	const resolvedModelHeaders = resolveConfigHeaders(modelHeaders);
+	return mergeAuthHeader({ ...providerHeaders, ...resolvedModelHeaders }, authHeader, apiKeyConfig);
 }
 
 function mergeAuthHeader(
@@ -406,7 +435,7 @@ function mergeAuthHeader(
 	if (!authHeader || !apiKeyConfig) {
 		return nextHeaders;
 	}
-	const resolvedKey = resolveApiKeyConfig(apiKeyConfig);
+	const resolvedKey = resolveConfigValue(apiKeyConfig);
 	return resolvedKey ? { ...nextHeaders, Authorization: `Bearer ${resolvedKey}` } : nextHeaders;
 }
 
@@ -580,7 +609,7 @@ export class ModelRegistry {
 		this.authStorage.setFallbackResolver(provider => {
 			const keyConfig = this.#customProviderApiKeys.get(provider);
 			if (keyConfig) {
-				return resolveApiKeyConfig(keyConfig);
+				return resolveConfigValue(keyConfig);
 			}
 			return undefined;
 		});
@@ -975,11 +1004,13 @@ export class ModelRegistry {
 		const configuredProviders = new Set(Object.keys(value.providers ?? {}));
 
 		for (const [providerName, providerConfig] of providerEntries) {
+			const resolvedProviderHeaders = resolveConfigHeaders(providerConfig.headers);
+			const resolvedProviderApiKey = providerConfig.apiKey ? resolveConfigValue(providerConfig.apiKey) : undefined;
 			// Always set overrides when baseUrl/headers/apiKey/authHeader/compat/disableStrictTools/transport are present
 			if (
 				providerConfig.baseUrl ||
-				providerConfig.headers ||
-				providerConfig.apiKey ||
+				resolvedProviderHeaders ||
+				resolvedProviderApiKey ||
 				providerConfig.authHeader !== undefined ||
 				providerConfig.compat ||
 				providerConfig.disableStrictTools ||
@@ -988,8 +1019,8 @@ export class ModelRegistry {
 				const disableStrictCompat = providerConfig.disableStrictTools ? { disableStrictTools: true } : undefined;
 				overrides.set(providerName, {
 					baseUrl: providerConfig.baseUrl,
-					headers: providerConfig.headers,
-					apiKey: providerConfig.apiKey,
+					headers: resolvedProviderHeaders,
+					apiKey: resolvedProviderApiKey,
 					authHeader: providerConfig.authHeader,
 					compat: mergeCompat(providerConfig.compat, disableStrictCompat),
 					transport: providerConfig.transport,
@@ -1010,7 +1041,7 @@ export class ModelRegistry {
 					// fallback for entries that don't advertise one.
 					api: (providerConfig.api ?? "openai-completions") as Api,
 					baseUrl: providerConfig.baseUrl,
-					headers: providerConfig.headers,
+					headers: resolvedProviderHeaders,
 					compat: mergeCompat(providerConfig.compat, disableStrictCompat),
 					discovery: providerConfig.discovery,
 					optional: false,
@@ -1021,10 +1052,9 @@ export class ModelRegistry {
 			// so it wins over OAuth tokens from the broker — when the user pins a
 			// bearer in models.yml (e.g. for an auth-gateway baseUrl), that bearer
 			// must authenticate the outbound request.
-			if (providerConfig.apiKey) {
-				this.#customProviderApiKeys.set(providerName, providerConfig.apiKey);
-				const resolved = resolveApiKeyConfig(providerConfig.apiKey);
-				if (resolved) this.authStorage.setConfigApiKey(providerName, resolved);
+			if (resolvedProviderApiKey) {
+				this.#customProviderApiKeys.set(providerName, resolvedProviderApiKey);
+				this.authStorage.setConfigApiKey(providerName, resolvedProviderApiKey);
 			}
 
 			// Parse per-model overrides
@@ -1443,10 +1473,11 @@ export class ModelRegistry {
 		for (const [providerName, providerConfig] of Object.entries(config.providers ?? {})) {
 			const modelDefs = providerConfig.models ?? [];
 			if (modelDefs.length === 0) continue; // Override-only, no custom models
-			if (providerConfig.apiKey) {
-				this.#customProviderApiKeys.set(providerName, providerConfig.apiKey);
-				const resolved = resolveApiKeyConfig(providerConfig.apiKey);
-				if (resolved) this.authStorage.setConfigApiKey(providerName, resolved);
+			const resolvedProviderHeaders = resolveConfigHeaders(providerConfig.headers);
+			const resolvedProviderApiKey = providerConfig.apiKey ? resolveConfigValue(providerConfig.apiKey) : undefined;
+			if (resolvedProviderApiKey) {
+				this.#customProviderApiKeys.set(providerName, resolvedProviderApiKey);
+				this.authStorage.setConfigApiKey(providerName, resolvedProviderApiKey);
 			}
 			for (const modelDef of modelDefs) {
 				const providerCompat = providerConfig.disableStrictTools
@@ -1456,8 +1487,8 @@ export class ModelRegistry {
 					providerName,
 					providerConfig.baseUrl!,
 					providerConfig.api as Api | undefined,
-					providerConfig.headers,
-					providerConfig.apiKey,
+					resolvedProviderHeaders,
+					resolvedProviderApiKey,
 					providerConfig.authHeader,
 					providerCompat,
 					(providerConfig.auth as ProviderAuthMode | undefined) ?? undefined,
@@ -1822,7 +1853,7 @@ export class ModelRegistry {
 			this.#customProviderApiKeys.set(providerName, config.apiKey);
 			// Persist runtime API keys so they survive #reloadStaticModels() cycles
 			this.#runtimeProviderApiKeys.set(providerName, config.apiKey);
-			const resolved = resolveApiKeyConfig(config.apiKey);
+			const resolved = resolveConfigValue(config.apiKey);
 			if (resolved) this.authStorage.setConfigApiKey(providerName, resolved);
 		}
 

--- a/packages/coding-agent/src/config/model-registry.ts
+++ b/packages/coding-agent/src/config/model-registry.ts
@@ -1010,7 +1010,7 @@ export class ModelRegistry {
 			if (
 				providerConfig.baseUrl ||
 				resolvedProviderHeaders ||
-				resolvedProviderApiKey ||
+				providerConfig.apiKey ||
 				providerConfig.authHeader !== undefined ||
 				providerConfig.compat ||
 				providerConfig.disableStrictTools ||
@@ -1020,7 +1020,7 @@ export class ModelRegistry {
 				overrides.set(providerName, {
 					baseUrl: providerConfig.baseUrl,
 					headers: resolvedProviderHeaders,
-					apiKey: resolvedProviderApiKey,
+					apiKey: providerConfig.apiKey,
 					authHeader: providerConfig.authHeader,
 					compat: mergeCompat(providerConfig.compat, disableStrictCompat),
 					transport: providerConfig.transport,
@@ -1478,9 +1478,9 @@ export class ModelRegistry {
 			if (modelDefs.length === 0) continue; // Override-only, no custom models
 			const resolvedProviderHeaders = resolveConfigHeaders(providerConfig.headers);
 			const resolvedProviderApiKey = providerConfig.apiKey ? resolveConfigValue(providerConfig.apiKey) : undefined;
-			if (resolvedProviderApiKey) {
-				this.#customProviderApiKeys.set(providerName, resolvedProviderApiKey);
-				this.authStorage.setConfigApiKey(providerName, resolvedProviderApiKey);
+			if (providerConfig.apiKey) {
+				this.#customProviderApiKeys.set(providerName, providerConfig.apiKey);
+				if (resolvedProviderApiKey) this.authStorage.setConfigApiKey(providerName, resolvedProviderApiKey);
 			}
 			for (const modelDef of modelDefs) {
 				const providerCompat = providerConfig.disableStrictTools
@@ -1491,7 +1491,7 @@ export class ModelRegistry {
 					providerConfig.baseUrl!,
 					providerConfig.api as Api | undefined,
 					resolvedProviderHeaders,
-					resolvedProviderApiKey,
+					providerConfig.apiKey,
 					providerConfig.authHeader,
 					providerCompat,
 					(providerConfig.auth as ProviderAuthMode | undefined) ?? undefined,

--- a/packages/coding-agent/test/model-registry-command-values.test.ts
+++ b/packages/coding-agent/test/model-registry-command-values.test.ts
@@ -57,4 +57,31 @@ describe("ModelRegistry command-resolved models.yml values", () => {
 		}
 		expect(await registry.getApiKey(models[0])).toBe("cmd-api-key");
 	});
+
+	test("modelOverrides headers resolve from command stdout", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					"custom-proxy": {
+						baseUrl: "https://custom-proxy.example.com/v1",
+						api: "openai-completions",
+						apiKey: `!${stdoutCommand("cmd-api-key")}`,
+						authHeader: true,
+						models: [{ id: "custom-model", name: "Custom Model" }],
+						modelOverrides: {
+							"custom-model": { headers: { "X-Model-Key": `!${stdoutCommand("cmd-model-header")}` } },
+						},
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		const model = registry.find("custom-proxy", "custom-model");
+
+		expect(model).toBeDefined();
+		expect(model?.headers?.["X-Model-Key"]).toBe("cmd-model-header");
+		expect(model?.headers?.Authorization).toBe("Bearer cmd-api-key");
+	});
 });

--- a/packages/coding-agent/test/model-registry-command-values.test.ts
+++ b/packages/coding-agent/test/model-registry-command-values.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { Snowflake } from "@oh-my-pi/pi-utils";
+
+function stdoutCommand(value: string): string {
+	return `${JSON.stringify(process.execPath)} -e ${JSON.stringify(`process.stdout.write(${JSON.stringify(value)})`)}`;
+}
+
+describe("ModelRegistry command-resolved models.yml values", () => {
+	let tempDir = "";
+	let authStorage: AuthStorage;
+	let modelsPath = "";
+
+	beforeEach(async () => {
+		tempDir = path.join(os.tmpdir(), `pi-test-model-command-values-${Snowflake.next()}`);
+		fs.mkdirSync(tempDir, { recursive: true });
+		modelsPath = path.join(tempDir, "models.json");
+		authStorage = await AuthStorage.create(":memory:");
+	});
+
+	afterEach(() => {
+		authStorage.close();
+		if (!tempDir || !fs.existsSync(tempDir)) return;
+		try {
+			fs.rmSync(tempDir, { recursive: true, force: true });
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code !== "EBUSY") throw error;
+		}
+	});
+
+	test("provider apiKey and headers resolve from command stdout", async () => {
+		fs.writeFileSync(
+			modelsPath,
+			JSON.stringify({
+				providers: {
+					anthropic: {
+						baseUrl: "https://anthropic-proxy.example.com/v1",
+						apiKey: `!${stdoutCommand("cmd-api-key")}`,
+						authHeader: true,
+						headers: { "X-Api-Key": `!${stdoutCommand("cmd-header")}` },
+					},
+				},
+			}),
+		);
+
+		const registry = new ModelRegistry(authStorage, modelsPath);
+		const models = registry.getAll().filter(model => model.provider === "anthropic");
+
+		expect(models.length).toBeGreaterThan(1);
+		for (const model of models) {
+			expect(model.headers?.Authorization).toBe("Bearer cmd-api-key");
+			expect(model.headers?.["X-Api-Key"]).toBe("cmd-header");
+		}
+		expect(await registry.getApiKey(models[0])).toBe("cmd-api-key");
+	});
+});


### PR DESCRIPTION
Fixes #1888.

## Summary
- add `!command` resolution for `models.yml` provider `apiKey` values
- add `!command` resolution for provider/model header values
- trim stdout, cache command output for the process lifetime, and omit empty/failing commands
- document the new config form

## Verification
- bun test packages/coding-agent/test/model-registry-command-values.test.ts
- bun --cwd=packages/coding-agent run check