### PR TITLE
fix(tui): suppress tiny-title worker output

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed local tiny-title worker stdout/stderr leaking raw native model output such as `</title>` and cache/status lines into the interactive TUI scrollback ([#2206](https://github.com/can1357/oh-my-pi/issues/2206)).
+
 ## [15.10.9] - 2026-06-09
 
 ### Fixed

--- a/packages/coding-agent/src/tiny/title-client.ts
+++ b/packages/coding-agent/src/tiny/title-client.ts
@@ -122,7 +122,7 @@ function tinyWorkerSpawnCmd(): string[] {
 }
 
 interface SpawnedSubprocess {
-	proc: Subprocess<"ignore", "inherit", "inherit">;
+	proc: Subprocess<"ignore", "ignore", "ignore">;
 	inbound: Set<(message: TinyTitleWorkerOutbound) => void>;
 	errors: Set<(error: Error) => void>;
 	/**
@@ -147,10 +147,13 @@ export function createTinyTitleSubprocess(): SpawnedSubprocess {
 		cmd: tinyWorkerSpawnCmd(),
 		env: tinyWorkerEnv(),
 		stdin: "ignore",
-		stdout: "inherit",
-		stderr: "inherit",
+		stdout: "ignore",
+		stderr: "ignore",
 		serialization: "advanced",
 		windowsHide: true,
+		// The worker is an implementation detail of the interactive TUI. Native
+		// model runtimes may print progress or decoded text directly; never let
+		// those bytes inherit the terminal and corrupt the chat scrollback.
 		ipc(message) {
 			for (const handler of inbound) handler(message as TinyTitleWorkerOutbound);
 		},

--- a/packages/coding-agent/test/tiny-title-generator.test.ts
+++ b/packages/coding-agent/test/tiny-title-generator.test.ts
@@ -20,12 +20,13 @@ import {
 	TINY_TITLE_MODEL_OPTIONS,
 	TINY_TITLE_MODEL_VALUES,
 } from "@oh-my-pi/pi-coding-agent/tiny/models";
-import { tinyTitleClient } from "@oh-my-pi/pi-coding-agent/tiny/title-client";
+import { createTinyTitleSubprocess, tinyTitleClient } from "@oh-my-pi/pi-coding-agent/tiny/title-client";
 import {
 	generateSessionTitle,
 	raceFirstNonNull,
 	TITLE_LOCAL_FALLBACK_DELAY_MS,
 } from "@oh-my-pi/pi-coding-agent/utils/title-generator";
+import type { Subprocess } from "bun";
 
 async function flushMicrotasks(turns = 4): Promise<void> {
 	for (let i = 0; i < turns; i += 1) await Promise.resolve();
@@ -58,6 +59,33 @@ function createRegistry(model: Model<Api>) {
 		getApiKey: async () => "test-key",
 		resolver: vi.fn(() => async () => "test-key"),
 	} as never;
+}
+
+type TinyWorkerSpawnOptions = Bun.SpawnOptions.SpawnOptions<"ignore", "ignore", "ignore">;
+
+type TinyWorkerSpawnCall = {
+	options: TinyWorkerSpawnOptions & { cmd: string[] };
+};
+
+function createTinyWorkerSpawnMock(calls: TinyWorkerSpawnCall[]) {
+	function mockSpawn(options: TinyWorkerSpawnOptions & { cmd: string[] }): Subprocess<"ignore", "ignore", "ignore">;
+	function mockSpawn(cmd: string[], options?: TinyWorkerSpawnOptions): Subprocess<"ignore", "ignore", "ignore">;
+	function mockSpawn(
+		first: string[] | (TinyWorkerSpawnOptions & { cmd: string[] }),
+		second?: TinyWorkerSpawnOptions,
+	): Subprocess<"ignore", "ignore", "ignore"> {
+		const options = Array.isArray(first) ? { ...(second ?? {}), cmd: first } : first;
+		calls.push({ options });
+		return {
+			pid: 12345,
+			send: () => undefined,
+			kill: () => true,
+			unref: () => undefined,
+			exited: Promise.resolve(0),
+		} as unknown as Subprocess<"ignore", "ignore", "ignore">;
+	}
+
+	return mockSpawn;
 }
 
 function mockOnlineTitle(title: string | null) {
@@ -282,6 +310,20 @@ describe("tiny title generator routing", () => {
 		local.resolve("Late Local Title");
 		await flushMicrotasks();
 		expect(localSettled).toBe(true);
+	});
+});
+
+describe("tiny title subprocess", () => {
+	it("does not inherit worker output into the interactive terminal", async () => {
+		const calls: TinyWorkerSpawnCall[] = [];
+		vi.spyOn(Bun, "spawn").mockImplementation(createTinyWorkerSpawnMock(calls));
+
+		const worker = createTinyTitleSubprocess();
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.options.stdout).toBe("ignore");
+		expect(calls[0]?.options.stderr).toBe("ignore");
+		await worker.proc.exited;
 	});
 });
 


### PR DESCRIPTION
## Repro
The tiny-title subprocess was configured with inherited output streams. Source inspection of `packages/coding-agent/src/tiny/title-client.ts` showed `stdout: "inherit"` and `stderr: "inherit"`, matching the reported raw `</title>` and cache/status lines bypassing title extraction and landing in interactive scrollback.

## Cause
`createTinyTitleSubprocess()` in `packages/coding-agent/src/tiny/title-client.ts` spawned the hidden tiny-model worker with inherited stdout/stderr. Native model/runtime writes therefore went straight to the parent terminal instead of through the IPC title pipeline and TUI renderer.

## Fix
- Changed the tiny-title subprocess to use `stdout: "ignore"` and `stderr: "ignore"`.
- Kept worker progress/errors on the existing IPC/log paths instead of terminal inheritance.
- Added a regression test that pins the worker stdio contract.
- Added a coding-agent changelog entry for #2206.

## Verification
`bun test packages/coding-agent/test/tiny-title-generator.test.ts` passes: 16 tests. `bun --cwd=packages/coding-agent run check` passes. Fixes #2206