### PR TITLE
fix(agent): skip Claude Code custom agents in task discovery

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed task-agent discovery advertising Claude Code custom agents from `.claude/agents/*.md` as OMP subagents; direct task-agent discovery now only loads OMP-native `.omp` agent roots, while Claude marketplace plugin agents keep their existing provider path ([#2209](https://github.com/can1357/oh-my-pi/issues/2209)).
+
 ## [15.10.9] - 2026-06-09
 
 ### Fixed

--- a/packages/coding-agent/src/task/discovery.ts
+++ b/packages/coding-agent/src/task/discovery.ts
@@ -1,13 +1,14 @@
 /**
  * Agent discovery from filesystem.
  *
- * Discovers agent definitions from:
- *   - ~/.omp/agent/agents/*.md (user-level, primary)
- *   - ~/.pi/agent/agents/*.md (user-level, legacy)
- *   - ~/.claude/agents/*.md (user-level, legacy)
- *   - .omp/agents/*.md (project-level, primary)
- *   - .pi/agents/*.md (project-level, legacy)
- *   - .claude/agents/*.md (project-level, legacy)
+ * Discovers agent definitions from OMP-native task-agent roots:
+ *   - ~/.omp/agent/agents/*.md (user-level)
+ *   - .omp/agents/*.md (project-level)
+ *
+ * Claude Code marketplace plugin agents are discovered separately via the
+ * claude-plugins provider. Direct cross-harness roots such as .claude/agents
+ * are intentionally skipped because their frontmatter schema is not the OMP
+ * task-agent contract.
  *
  * Agent files use markdown with YAML frontmatter.
  */
@@ -20,6 +21,8 @@ import { findAllNearestProjectConfigDirs, getConfigDirs } from "../config";
 import { listClaudePluginRoots } from "../discovery/helpers";
 import { loadBundledAgents, parseAgent } from "./agents";
 import type { AgentDefinition, AgentSource } from "./types";
+
+const TASK_AGENT_CONFIG_SOURCE = ".omp";
 
 /** Result of agent discovery */
 export interface DiscoveryResult {
@@ -52,41 +55,31 @@ async function loadAgentsFromDir(dir: string, source: AgentSource): Promise<Agen
 /**
  * Discover agents from filesystem and merge with bundled agents.
  *
- * Precedence (highest wins): .omp > .pi > .claude (project before user), then bundled
- *
+ * Precedence (highest wins): project .omp, user .omp, Claude plugin agents, then bundled
  * @param cwd - Current working directory for project agent discovery
  */
 export async function discoverAgents(cwd: string, home: string = os.homedir()): Promise<DiscoveryResult> {
 	const resolvedCwd = path.resolve(cwd);
-	const agentSources = Array.from(new Set(getConfigDirs("", { project: false }).map(entry => entry.source)));
 
-	// Get user directories (priority order: .omp, .pi, .claude, ...)
 	const userDirs = getConfigDirs("agents", { project: false })
-		.filter(entry => agentSources.includes(entry.source))
+		.filter(entry => entry.source === TASK_AGENT_CONFIG_SOURCE)
 		.map(entry => ({
 			...entry,
 			path: path.resolve(entry.path),
 		}));
 
-	// Get project directories by walking up from cwd (priority order)
 	const projectDirs = findAllNearestProjectConfigDirs("agents", resolvedCwd)
-		.filter(entry => agentSources.includes(entry.source))
+		.filter(entry => entry.source === TASK_AGENT_CONFIG_SOURCE)
 		.map(entry => ({
 			...entry,
 			path: path.resolve(entry.path),
 		}));
-
-	const orderedSources = agentSources.filter(
-		source => userDirs.some(entry => entry.source === source) || projectDirs.some(entry => entry.source === source),
-	);
 
 	const orderedDirs: Array<{ dir: string; source: AgentSource }> = [];
-	for (const source of orderedSources) {
-		const project = projectDirs.find(entry => entry.source === source);
-		if (project) orderedDirs.push({ dir: project.path, source: "project" });
-		const user = userDirs.find(entry => entry.source === source);
-		if (user) orderedDirs.push({ dir: user.path, source: "user" });
-	}
+	const project = projectDirs[0];
+	if (project) orderedDirs.push({ dir: project.path, source: "project" });
+	const user = userDirs[0];
+	if (user) orderedDirs.push({ dir: user.path, source: "user" });
 
 	// Load agents from Claude Code marketplace plugins (respects disabledProviders)
 	const { roots: pluginRoots } = isProviderEnabled("claude-plugins")

--- a/packages/coding-agent/test/task/discovery.test.ts
+++ b/packages/coding-agent/test/task/discovery.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { discoverAgents } from "@oh-my-pi/pi-coding-agent/task/discovery";
+
+const OMP_AGENT_MD = [
+	"---",
+	"name: omp-test-agent",
+	"description: OMP-native test agent.",
+	"---",
+	"You are an OMP task agent.",
+].join("\n");
+
+const CLAUDE_AGENT_MD = [
+	"---",
+	"name: cc-test-agent",
+	"description: Test Claude Code agent.",
+	"tools: Read, Grep, Glob, Bash",
+	"model: sonnet",
+	"color: purple",
+	"---",
+	"You are a Claude Code custom subagent.",
+].join("\n");
+
+describe("discoverAgents", () => {
+	let tempHome: string;
+	let projectDir: string;
+
+	beforeEach(async () => {
+		tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "omp-task-agent-discovery-"));
+		projectDir = path.join(tempHome, "project");
+		await fs.mkdir(projectDir, { recursive: true });
+	});
+
+	afterEach(async () => {
+		await fs.rm(tempHome, { recursive: true, force: true });
+	});
+
+	test("loads OMP agents but skips Claude Code custom agents", async () => {
+		await fs.mkdir(path.join(projectDir, ".omp", "agents"), { recursive: true });
+		await fs.writeFile(path.join(projectDir, ".omp", "agents", "omp-test-agent.md"), OMP_AGENT_MD);
+
+		await fs.mkdir(path.join(tempHome, ".claude", "agents"), { recursive: true });
+		await fs.writeFile(path.join(tempHome, ".claude", "agents", "user-cc-test-agent.md"), CLAUDE_AGENT_MD);
+		await fs.mkdir(path.join(projectDir, ".claude", "agents"), { recursive: true });
+		await fs.writeFile(path.join(projectDir, ".claude", "agents", "project-cc-test-agent.md"), CLAUDE_AGENT_MD);
+
+		const { agents, projectAgentsDir } = await discoverAgents(projectDir, tempHome);
+		const names = agents.map(agent => agent.name);
+
+		expect(names).toContain("omp-test-agent");
+		expect(names).not.toContain("cc-test-agent");
+		expect(projectAgentsDir).toBe(path.join(projectDir, ".omp", "agents"));
+	});
+});


### PR DESCRIPTION
## Repro
A temp project containing only `.claude/agents/cc-test-agent.md` with Claude Code frontmatter was passed to `discoverAgents()`. Before the fix, `bun -e 'create temp .claude/agents/cc-test-agent.md, import discoverAgents(), print whether cc-test-agent is discovered'` printed `{"hasClaudeAgent":true,"names":["cc-test-agent"]}`.

## Cause
`packages/coding-agent/src/task/discovery.ts` built task-agent search roots from `getConfigDirs()` / `findAllNearestProjectConfigDirs()` without constraining the config source, so the shared config priority list in `packages/coding-agent/src/config.ts` made `.claude/agents` look like an OMP task-agent directory.

## Fix
- Restrict direct task-agent filesystem discovery to the OMP-native `.omp` source for both project and user roots.
- Keep the existing Claude marketplace plugin agent path behind the `claude-plugins` provider.
- Add `packages/coding-agent/test/task/discovery.test.ts` covering OMP project agents alongside user and project Claude Code custom agents.
- Add the coding-agent changelog entry for #2209.

## Verification
Passed: `bun test test/task/discovery.test.ts`; `bun run check:types`; `bun run check`. Manual repro now prints `{"hasClaudeAgent":false,"names":[]}` for the same `.claude/agents/cc-test-agent.md` setup. Fixes #2209