### PR TITLE
fix(coding-agent): document read URI targets

### DIFF
--- a/docs/tools/read.md
+++ b/docs/tools/read.md
@@ -10,7 +10,7 @@
   - `packages/coding-agent/src/tools/archive-reader.ts` — detect `archive.ext:inner/path`, index archives, list/read entries.
   - `packages/coding-agent/src/tools/sqlite-reader.ts` — detect SQLite targets, parse selectors, render tables.
   - `packages/coding-agent/src/tools/fetch.ts` — URL parsing, fetch/render pipeline, URL cache/artifacts.
-  - `packages/coding-agent/src/internal-urls/router.ts` — resolve `agent://`, `artifact://`, `local://`, `mcp://`, `memory://`, `omp://`, `rule://`, `skill://`.
+  - `packages/coding-agent/src/internal-urls/router.ts` — resolve `agent://`, `artifact://`, `issue://`, `local://`, `mcp://`, `memory://`, `omp://`, `pr://`, `rule://`, `skill://`, and `vault://`.
   - `packages/coding-agent/src/edit/notebook.ts` — convert `.ipynb` to editable `# %% [...] cell:N` text.
   - `packages/coding-agent/src/utils/file-display-mode.ts` — decide hashline vs line-number vs raw display.
   - `packages/coding-agent/src/workspace-tree.ts` — render directory trees.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### Fixed
 
+- Fixed the read tool's provider-visible `path` schema and docs so web URLs and internal URI targets (`omp://`, `issue://`, `pr://`, etc.) are advertised alongside local files ([#2215](https://github.com/can1357/oh-my-pi/issues/2215)).
 - Kept IRC cards from being removed after their TTL once everything above them finalized: their rows may already be committed to native scrollback, and removing them was an interior deletion of the committed prefix that the engine could only repair by recommitting everything below the gap (duplicated blocks). Such cards now stay in the transcript as durable history.
 - Fixed the recommit storm that sprayed stale snapshots of a running task's progress tree into native scrollback. The stable-prefix ratchet promoted any row quiet for one 30-frame window, so slowly ticking rows (per-agent tool/cost counters updating every few seconds) were repeatedly promoted, committed, rewritten, and recommitted by the engine audit for the whole run. The ratchet now floors itself permanently at the first row that mutates after being promoted — settled heads (a task's prompt/context) still reach scrollback, genuine tickers never re-promote.
 - **Fixed the artifact spill dropping the first ~20KB of output**: head-retained bytes were never written to the artifact file, so for every bash/eval/ssh command exceeding the 50KB spill threshold, the `artifact://` advertised as the "full capture" was permanently missing its head — the agent re-reading it got truncated data presented as lossless.

--- a/packages/coding-agent/src/commands/read.ts
+++ b/packages/coding-agent/src/commands/read.ts
@@ -1,16 +1,17 @@
 /**
- * Show what the read tool will return for a given path.
+ * Show what the read tool will return for a path, URL, or internal URI.
  */
 import { Args, Command } from "@oh-my-pi/pi-utils/cli";
 import { type ReadCommandArgs, runReadCommand } from "../cli/read-cli";
 import { initTheme } from "../modes/theme/theme";
 
 export default class Read extends Command {
-	static description = "Show what the read tool will return for a path or URL";
+	static description = "Show what the read tool will return for a path, URL, or internal URI";
 
 	static args = {
 		path: Args.string({
-			description: "Path or URL to read (append :sel for line ranges or raw mode, e.g. src/foo.ts:50-100)",
+			description:
+				"Path, URL, or internal URI to read (append :sel for line ranges or raw mode, e.g. src/foo.ts:50-100)",
 			required: true,
 		}),
 	};
@@ -20,6 +21,8 @@ export default class Read extends Command {
 		"omp read src/foo.ts:50-100",
 		"omp read src/foo.ts:raw",
 		"omp read https://example.com",
+		"omp read omp://",
+		"omp read issue://123",
 		"omp read path/to/archive.zip:dir/file.ts",
 		"omp read path/to/db.sqlite:users:42",
 	];

--- a/packages/coding-agent/src/internal-urls/router.ts
+++ b/packages/coding-agent/src/internal-urls/router.ts
@@ -1,5 +1,5 @@
 /**
- * Internal URL router for internal protocols (agent://, artifact://, memory://, skill://, rule://, mcp://, omp://, local://).
+ * Internal URL router for internal protocols (`agent://`, `artifact://`, `issue://`, `local://`, `mcp://`, `memory://`, `omp://`, `pr://`, `rule://`, `skill://`, and `vault://`).
  *
  * One process-global router with one handler per scheme. Access via
  * `InternalUrlRouter.instance()`. Handlers are stateless; per-session and

--- a/packages/coding-agent/src/internal-urls/types.ts
+++ b/packages/coding-agent/src/internal-urls/types.ts
@@ -1,7 +1,7 @@
 /**
  * Types for the internal URL routing system.
  *
- * Internal URLs (agent://, artifact://, memory://, skill://, rule://, mcp://, omp://, local://) are resolved by tools like read,
+ * Internal URLs (`agent://`, `artifact://`, `issue://`, `local://`, `mcp://`, `memory://`, `omp://`, `pr://`, `rule://`, `skill://`, and `vault://`) are resolved by tools like read,
  * providing access to agent outputs and server resources without exposing filesystem paths.
  */
 

--- a/packages/coding-agent/src/prompts/tools/read.md
+++ b/packages/coding-agent/src/prompts/tools/read.md
@@ -8,7 +8,7 @@ Read files, directories, archives, SQLite databases, images, documents, internal
 
 ## Parameters
 
-- `path` — required. Local path, internal URI (`skill://`, `agent://`, `artifact://`, `memory://`, `rule://`, `local://`, `vault://`, `mcp://`), or URL. Append `:<sel>` for line ranges, raw mode, or special modes (e.g. `src/foo.ts:50-200`, `src/foo.ts:raw`, `db.sqlite:users:42`).
+- `path` — required. Local path, internal URI (`skill://`, `agent://`, `artifact://`, `memory://`, `rule://`, `local://`, `vault://`, `mcp://`, `omp://`, `issue://`, `pr://`), or URL. Append `:<sel>` for line ranges, raw mode, or special modes (e.g. `src/foo.ts:50-200`, `src/foo.ts:raw`, `db.sqlite:users:42`).
 
 ## Selectors
 
@@ -74,7 +74,7 @@ For `.sqlite`, `.sqlite3`, `.db`, `.db3`:
 
 # Internal URIs
 
-`skill://<name>`, `agent://<id>`, `artifact://<id>`, `memory://root`, `rule://<name>`, `local://<name>.md`, `vault://<vault>/<path>`, `mcp://<uri>` resolve transparently and accept the same line selectors as filesystem paths. Use `artifact://<id>` to recover full output that a previous bash/eval/tool result spilled or truncated.
+`skill://<name>`, `agent://<id>`, `artifact://<id>`, `memory://root`, `rule://<name>`, `local://<name>.md`, `vault://<vault>/<path>`, `mcp://<uri>`, `omp://<doc>.md`, `issue://<N>`, and `pr://<N>` resolve transparently and accept the same line selectors as filesystem paths. Use `artifact://<id>` to recover full output that a previous bash/eval/tool result spilled or truncated.
 
 <critical>
 - You MUST use `read` for every file, directory, archive, and URL inspection. `cat`, `head`, `tail`, `less`, `more`, `ls`, `tar`, `unzip`, `curl`, `wget` are FORBIDDEN — any such bash call is a bug, regardless of how short or convenient it looks.

--- a/packages/coding-agent/src/tools/read.ts
+++ b/packages/coding-agent/src/tools/read.ts
@@ -620,7 +620,11 @@ function prependSuffixResolutionNotice(text: string, suffixResolution?: { from: 
 
 const readSchema = z
 	.object({
-		path: z.string().describe('path or url; append :<sel> for line ranges or raw mode (e.g. "src/foo.ts:50-100")'),
+		path: z
+			.string()
+			.describe(
+				'Local path, internal URI (e.g. "omp://", "issue://123", "pr://123"), or URL; append :<sel> for line ranges or raw mode (e.g. "src/foo.ts:50-100")',
+			),
 	})
 	.strict();
 

--- a/packages/coding-agent/test/tools/schema-validation.test.ts
+++ b/packages/coding-agent/test/tools/schema-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { normalizeSchemaForGoogle } from "@oh-my-pi/pi-ai";
+import { normalizeSchemaForGoogle, toolWireSchema } from "@oh-my-pi/pi-ai";
 import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { createTools, HIDDEN_TOOLS, type ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
 
@@ -267,6 +267,25 @@ describe("tool schema validation (post-sanitization)", () => {
 		}
 
 		expect(allViolations).toEqual([]);
+	});
+
+	it("read path schema advertises local, URL, and internal URI targets", async () => {
+		const session = createTestSession();
+		const tools = await createTools(session);
+		const readTool = tools.find(tool => tool.name === "read");
+		if (!readTool?.parameters) throw new Error("read tool parameters missing");
+
+		const schema = toolWireSchema(readTool) as {
+			properties?: { path?: { description?: string } };
+		};
+		const description = schema.properties?.path?.description ?? "";
+
+		expect(description).toContain("Local path");
+		expect(description).toContain("internal URI");
+		expect(description).toContain("URL");
+		expect(description).toContain("omp://");
+		expect(description).toContain("issue://123");
+		expect(description).toContain("pr://123");
 	});
 
 	it("hidden tools also have valid sanitized schemas", async () => {


### PR DESCRIPTION
## Repro
The provider-visible read schema could be inspected with `read packages/coding-agent/src/tools/read.ts:621-624`, which showed the `path` argument documented only as `path or url`; meanwhile `read packages/coding-agent/src/internal-urls/router.ts:26-37` showed registered `omp://`, `issue://`, and `pr://` handlers.

## Cause
`packages/coding-agent/src/tools/read.ts` exposed a terse `path or url` Zod description to providers, while `packages/coding-agent/src/prompts/tools/read.md`, `docs/tools/read.md`, and the internal URL router docs did not consistently enumerate the registered internal URI schemes.

## Fix
- Expanded the read tool `path` schema and model-facing prompt to say local path, internal URI, or URL, with `omp://`, `issue://`, and `pr://` examples.
- Updated `omp read --help` and internal URL docs to match the supported source classes.
- Added schema coverage in `packages/coding-agent/test/tools/schema-validation.test.ts` so provider-visible read path guidance keeps advertising local, URL, and internal URI targets.
- Added an Unreleased changelog entry.

## Verification
- `bun test packages/coding-agent/test/tools/schema-validation.test.ts` passed.
- `bun packages/coding-agent/src/cli.ts read --help` shows `path, URL, or internal URI` and examples for `https://`, `omp://`, and `issue://`.
- `bun --cwd=packages/coding-agent run check` passed.

Fixes #2215