### PR TITLE
fix(hindsight): scope per-project tagged mental model seeds

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -29,6 +29,8 @@
 
 ### Fixed
 
+- Fixed Hindsight `per-project-tagged` mental-model seeding so each project gets its own conventions/decisions models and session context only injects active-project or untagged models ([#2218](https://github.com/can1357/oh-my-pi/issues/2218)).
+
 - Fixed the bundled `explore` agent's `thinking-level: med` frontmatter — not a valid effort (`minimal`/`low`/`medium`/`high`/`xhigh`), so it silently parsed to undefined and the agent ran without its intended thinking level
 - Discovery context-file reads (`~/.claude`, `~/.cursor`, project trees, `@`-imports) now stat-gate to regular files before reading: a FIFO/socket/char device dropped where a context file is expected previously blocked startup forever on a read that can never see EOF.
 - Kept IRC cards from being removed after their TTL once everything above them finalized: their rows may already be committed to native scrollback, and removing them was an interior deletion of the committed prefix that the engine could only repair by recommitting everything below the gap (duplicated blocks). Such cards now stay in the transcript as durable history.

--- a/packages/coding-agent/src/hindsight/mental-models.ts
+++ b/packages/coding-agent/src/hindsight/mental-models.ts
@@ -26,8 +26,10 @@
  * retain side to emit them.
  *
  * Seed tags are baked from `seeds.json` plus, for `projectTagged: true`
- * entries, the active scope's `retainTags` (i.e. `project:<cwd>`). Untagged
- * seeds (e.g. `user-preferences`) read every memory in the bank — the
+ * entries, the active scope's `retainTags` (i.e. `project:<cwd>`). In
+ * `per-project-tagged`, those project seeds also get project-suffixed ids so
+ * each tag can own its conventions/decisions models in the shared bank.
+ * Untagged seeds (e.g. `user-preferences`) read every memory in the bank — the
  * reflect call applies no tag filter when `tags` is empty.
  *
  * Seed lifecycle is **create-only**: changes to `source_query`, `tags`,
@@ -72,31 +74,52 @@ export interface MentalModelSeed {
 	sourceQuery: string;
 	tags: string[];
 	maxTokens?: number;
+	/** Legacy unqualified seed ids accepted as already-present when tags match. */
+	legacyIds?: string[];
 	trigger?: MentalModelTrigger;
 }
 
 /**
  * Resolve the seed list that applies to the active bank scope. Per-project
  * seeds are skipped in `global` mode (where there is no project axis) and
- * `projectTagged` seeds inherit the scope's `retainTags`.
+ * `projectTagged` seeds inherit the scope's `retainTags`. In shared tagged
+ * banks, project seeds use project-suffixed ids and accept matching legacy
+ * bare ids as already present.
  */
 export function resolveSeedsForScope(scope: BankScope, scoping: HindsightScoping): MentalModelSeed[] {
 	const out: MentalModelSeed[] = [];
 	for (const seed of BUILTIN_SEEDS) {
 		if (!seed.scopes.includes(scoping)) continue;
 		const tags = collectSeedTags(seed, scope);
+		const id = resolveSeedId(seed, tags, scoping);
 		out.push({
-			id: seed.id,
+			id,
 			name: seed.name,
 			sourceQuery: seed.source_query,
 			tags,
 			maxTokens: seed.max_tokens,
 			trigger: seed.trigger,
+			legacyIds: id === seed.id ? undefined : [seed.id],
 		});
 	}
 	return out;
 }
 
+const PROJECT_TAG_PREFIX = "project:";
+
+function resolveSeedId(seed: RawSeed, tags: string[], scoping: HindsightScoping): string {
+	if (scoping !== "per-project-tagged" || !seed.projectTagged || tags.length === 0) return seed.id;
+	return `${seed.id}-${seedIdSuffixFromProjectTag(tags[0])}`;
+}
+
+function seedIdSuffixFromProjectTag(tag: string): string {
+	const raw = tag.startsWith(PROJECT_TAG_PREFIX) ? tag.slice(PROJECT_TAG_PREFIX.length) : tag;
+	const sanitized = raw
+		.trim()
+		.replace(/[^A-Za-z0-9._-]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return sanitized || "project";
+}
 function collectSeedTags(seed: RawSeed, scope: BankScope): string[] {
 	const collected: string[] = [];
 	if (seed.projectTagged && scope.retainTags) collected.push(...scope.retainTags);
@@ -124,17 +147,17 @@ export async function ensureMentalModels(
 ): Promise<void> {
 	if (seeds.length === 0) return;
 
-	let existing: Set<string>;
+	let existing: MentalModelSummary[];
 	try {
 		const list = await client.listMentalModels(bankId, { detail: "metadata" });
-		existing = new Set((list.items ?? []).map(m => m.id));
+		existing = list.items ?? [];
 	} catch (err) {
 		logger.debug("Hindsight: ensureMentalModels list failed", { bankId, error: String(err) });
 		return;
 	}
 
 	for (const seed of seeds) {
-		if (existing.has(seed.id)) continue;
+		if (seedAlreadyExists(seed, existing)) continue;
 		try {
 			await client.createMentalModel(bankId, seed.name, seed.sourceQuery, {
 				id: seed.id,
@@ -149,6 +172,19 @@ export async function ensureMentalModels(
 			logger.debug("Hindsight: createMentalModel failed", { bankId, id: seed.id, error: String(err) });
 		}
 	}
+}
+
+/** Return whether a seed is already represented by current bank metadata. */
+export function seedAlreadyExists(seed: MentalModelSeed, models: readonly MentalModelSummary[]): boolean {
+	for (const model of models) {
+		if (model.id === seed.id) return true;
+		if (seed.legacyIds?.includes(model.id) && sameStringSet(model.tags ?? [], seed.tags)) return true;
+	}
+	return false;
+}
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+	return left.length === right.length && left.every(item => right.includes(item));
 }
 
 /**
@@ -170,15 +206,17 @@ export const MENTAL_MODEL_RENDER_BUDGET_CHARS_DEFAULT = 16_000;
  * reflect for a freshly-seeded model hasn't completed yet).
  *
  * The rendered block is bounded by `budgetChars` (default
- * MENTAL_MODEL_RENDER_BUDGET_CHARS_DEFAULT). Per-model content is truncated
- * before assembly; if assembly still exceeds the budget, trailing models are
- * dropped. A budget overflow leaves a `…` marker so the LLM can tell the
- * snapshot is truncated.
+ * MENTAL_MODEL_RENDER_BUDGET_CHARS_DEFAULT). When `visibleTags` is supplied,
+ * tagged models must match at least one active tag; untagged models remain
+ * visible in every scope. Per-model content is truncated before assembly; if
+ * assembly still exceeds the budget, trailing models are dropped. A budget
+ * overflow leaves a `…` marker so the LLM can tell the snapshot is truncated.
  */
 export async function loadMentalModelsBlock(
 	client: HindsightApi,
 	bankId: string,
 	budgetChars: number = MENTAL_MODEL_RENDER_BUDGET_CHARS_DEFAULT,
+	visibleTags?: readonly string[],
 ): Promise<string | undefined> {
 	let response: MentalModelListResponse;
 	try {
@@ -188,12 +226,21 @@ export async function loadMentalModelsBlock(
 		return undefined;
 	}
 
-	const models = (response.items ?? []).filter(m => typeof m.content === "string" && m.content.trim().length > 0);
+	const models = (response.items ?? []).filter(
+		m => modelVisibleForTags(m, visibleTags) && typeof m.content === "string" && m.content.trim().length > 0,
+	);
 	if (models.length === 0) return undefined;
 
 	models.sort((a, b) => a.name.localeCompare(b.name));
 	const block = renderMentalModelsBlock(models, budgetChars);
 	return block || undefined;
+}
+
+function modelVisibleForTags(model: MentalModelSummary, visibleTags?: readonly string[]): boolean {
+	if (!visibleTags || visibleTags.length === 0) return true;
+	const tags = model.tags ?? [];
+	if (tags.length === 0) return true;
+	return tags.some(tag => visibleTags.includes(tag));
 }
 
 const PREAMBLE =

--- a/packages/coding-agent/src/hindsight/state.ts
+++ b/packages/coding-agent/src/hindsight/state.ts
@@ -426,7 +426,12 @@ export class HindsightSessionState {
 	}
 
 	async refreshMentalModelsSnippet(): Promise<void> {
-		const snippet = await loadMentalModelsBlock(this.client, this.bankId, this.config.mentalModelMaxRenderChars);
+		const snippet = await loadMentalModelsBlock(
+			this.client,
+			this.bankId,
+			this.config.mentalModelMaxRenderChars,
+			this.recallTags,
+		);
 		this.mentalModelsSnippet = snippet;
 		this.mentalModelsLoadedAt = Date.now();
 	}

--- a/packages/coding-agent/src/modes/controllers/command-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/command-controller.ts
@@ -21,6 +21,7 @@ import {
 	loadHindsightConfig,
 	reloadMentalModelsForSession,
 	resolveSeedsForScope,
+	seedAlreadyExists,
 	summarizeMentalModel,
 } from "../../hindsight";
 import { resolveMemoryBackend } from "../../memory-backend";
@@ -712,11 +713,11 @@ export class CommandController {
 				return;
 			}
 			const list = await state.client.listMentalModels(state.bankId, { detail: "metadata" });
-			const existing = new Set((list.items ?? []).map(m => m.id));
+			const existing = list.items ?? [];
 			let created = 0;
 			let skipped = 0;
 			for (const seed of seeds) {
-				if (existing.has(seed.id)) {
+				if (seedAlreadyExists(seed, existing)) {
 					skipped++;
 					continue;
 				}

--- a/packages/coding-agent/test/hindsight-mental-models.test.ts
+++ b/packages/coding-agent/test/hindsight-mental-models.test.ts
@@ -48,9 +48,9 @@ describe("resolveSeedsForScope", () => {
 			recallTagsMatch: "any",
 		};
 		const seeds = resolveSeedsForScope(scope, "per-project-tagged");
-		const projectConv = seeds.find(s => s.id === "project-conventions");
+		const projectConv = seeds.find(s => s.id === "project-conventions-omp");
 		const userPrefs = seeds.find(s => s.id === "user-preferences");
-		expect(projectConv).toBeDefined();
+		expect(projectConv?.legacyIds).toEqual(["project-conventions"]);
 		expect(projectConv?.tags).toEqual(["project:omp"]);
 		// user-preferences is intentionally untagged so the refresh reads the
 		// whole bank, not just the project subset.
@@ -109,6 +109,50 @@ describe("ensureMentalModels", () => {
 		expect(calls.created).toHaveLength(1);
 		expect(calls.created[0].id).toBe("project-conventions");
 		expect(calls.created[0].tags).toEqual(["project:omp"]);
+	});
+
+	it("matches legacy bare project seeds only when their tags match the active project", async () => {
+		const legacyProjectA: MentalModelSummary = {
+			id: "project-conventions",
+			bank_id: "omp",
+			name: "Project Conventions",
+			tags: ["project:a"],
+		};
+
+		const matching = makeFakeApi([legacyProjectA]);
+		await ensureMentalModels(
+			matching.api,
+			"omp",
+			[
+				{
+					id: "project-conventions-a",
+					name: "Project Conventions",
+					sourceQuery: "q",
+					tags: ["project:a"],
+					legacyIds: ["project-conventions"],
+				},
+			],
+			false,
+		);
+		expect(matching.calls.created).toHaveLength(0);
+
+		const differentProject = makeFakeApi([legacyProjectA]);
+		await ensureMentalModels(
+			differentProject.api,
+			"omp",
+			[
+				{
+					id: "project-conventions-b",
+					name: "Project Conventions",
+					sourceQuery: "q",
+					tags: ["project:b"],
+					legacyIds: ["project-conventions"],
+				},
+			],
+			false,
+		);
+		expect(differentProject.calls.created).toHaveLength(1);
+		expect(differentProject.calls.created[0].id).toBe("project-conventions-b");
 	});
 
 	it("does not modify existing models even if their fields drift from the seed list", async () => {
@@ -227,6 +271,21 @@ describe("loadMentalModelsBlock", () => {
 		const api = new HindsightApiCtor({ baseUrl: "http://localhost:8888" });
 		const block = await loadMentalModelsBlock(api, "b");
 		expect(block).toBeUndefined();
+	});
+
+	it("filters project-tagged models to the active project while keeping untagged models", async () => {
+		vi.spyOn(HindsightApiCtor.prototype, "listMentalModels").mockResolvedValue({
+			items: [
+				{ id: "u", bank_id: "b", name: "User Preferences", content: "global preference" },
+				{ id: "a", bank_id: "b", name: "Project A", tags: ["project:a"], content: "a convention" },
+				{ id: "b", bank_id: "b", name: "Project B", tags: ["project:b"], content: "b convention" },
+			],
+		});
+		const api = new HindsightApiCtor({ baseUrl: "http://localhost:8888" });
+		const block = await loadMentalModelsBlock(api, "b", MENTAL_MODEL_RENDER_BUDGET_CHARS_DEFAULT, ["project:b"]);
+		expect(block).toContain("global preference");
+		expect(block).toContain("b convention");
+		expect(block).not.toContain("a convention");
 	});
 
 	it("returns undefined on list failure rather than throwing (best-effort surface)", async () => {


### PR DESCRIPTION
## Repro
A fake Hindsight API reproduces the shared-bank failure: seed project `a`, then seed project `b`; before the fix, only bare `project-conventions` / `project-decisions` tagged `project:a` existed and project `b`'s rendered block contained `project:a` content. Command: `bun -e "$REPRO"`.

## Cause
`packages/coding-agent/src/hindsight/mental-models.ts` emitted the literal built-in ids from `resolveSeedsForScope`, and both `ensureMentalModels` plus `/memory mm seed` skipped by id only. In `per-project-tagged`, that let the first project claim the shared bank's `project-conventions` and `project-decisions` ids; `loadMentalModelsBlock` then listed all model content without applying the active session's project tags.

## Fix
- Project-tagged seeds in shared tagged banks now resolve to project-suffixed ids while treating matching legacy bare ids as already present.
- `/memory mm seed` and auto-seeding share the same seed-existence check, so legacy bare ids only skip the matching project tag.
- Mental-model injection now filters tagged models to the active project tags while keeping untagged bank-wide models visible.
- Added regression coverage for project-suffixed seed ids, legacy bare-id tolerance, and active-project render filtering.

## Verification
Repro command now creates `project-conventions-b` / `project-decisions-b` for project `b` and reports `block for project b contains project:a: false`. `bun test packages/coding-agent/test/hindsight-mental-models.test.ts` passed (19 tests). `bun --cwd=packages/coding-agent run check:types` passed. Fixes #2218