### PR TITLE
fix(models): split direct model role fallback chains

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -43,6 +43,7 @@
 
 ### Fixed
 
+- Fixed direct `modelRoles` consumers so comma-separated fallback chains are split before model parsing, preserving explicit thinking selectors instead of treating the comma tail as an invalid suffix.
 - Fixed model-provider detection for append-only mode, authoritative Vertex endpoint checks, and upstream-routing selection by switching from URL substring checks to catalog host-matching helpers
 - Fixed pasting into the ask tool's "Other (type your own)" text box (and hook input/editor dialogs) on terminals with OSC 5522 enhanced paste (kitty protocol): the enhanced-paste focus routing only targets components exposing a `pasteText` hook, and the dialog wrappers had none, so the payload was stuffed into the main prompt editor hidden behind the dialog. `HookEditorComponent` and `HookInputComponent` now forward `pasteText` to their inner editor/input (pasting also resets the input dialog's timeout countdown like any keystroke).
 - Fixed auto-retry giving up after one attempt ("Provider requested Xms wait, exceeds retry.maxDelayMs") on a usage-limit 429 when every sibling account was only momentarily blocked: the retry delay now waits for the earliest sibling unblock when that comes sooner than the provider's multi-hour retry-after, so the next attempt picks up the recovered account instead of failing fast.

--- a/packages/coding-agent/src/config/model-resolver.ts
+++ b/packages/coding-agent/src/config/model-resolver.ts
@@ -723,7 +723,7 @@ export function resolveModelRoleValue(
 		return { model: undefined, thinkingLevel: undefined, explicitThinkingLevel: false, warning: undefined };
 	}
 
-	const effectivePatterns = resolveConfiguredRolePattern(normalized, options?.settings);
+	const effectivePatterns = resolveConfiguredModelPatterns(normalized, options?.settings);
 	if (!effectivePatterns || effectivePatterns.length === 0) {
 		return { model: undefined, thinkingLevel: undefined, explicitThinkingLevel: false, warning: undefined };
 	}

--- a/packages/coding-agent/test/model-resolver.test.ts
+++ b/packages/coding-agent/test/model-resolver.test.ts
@@ -476,6 +476,26 @@ describe("resolveModelRoleValue", () => {
 		expect(result.warning).toBeUndefined();
 	});
 
+	test("splits direct comma fallback chains before parsing thinking selectors", () => {
+		const result = resolveModelRoleValue("anthropic/claude-sonnet-4-5:off,openai/gpt-4o:off", allModels);
+
+		expect(result.model?.provider).toBe("anthropic");
+		expect(result.model?.id).toBe("claude-sonnet-4-5");
+		expect(result.thinkingLevel).toBe("off");
+		expect(result.explicitThinkingLevel).toBe(true);
+		expect(result.warning).toBeUndefined();
+	});
+
+	test("tries later direct comma fallback entries when earlier entries miss", () => {
+		const result = resolveModelRoleValue("anthropic/missing:off,openai/gpt-4o:off", allModels);
+
+		expect(result.model?.provider).toBe("openai");
+		expect(result.model?.id).toBe("gpt-4o");
+		expect(result.thinkingLevel).toBe("off");
+		expect(result.explicitThinkingLevel).toBe(true);
+		expect(result.warning).toBeUndefined();
+	});
+
 	test("does not resolve exact codex role values to codex-spark via substring matching", () => {
 		const providerQualified = resolveModelRoleValue("openai-codex/gpt-5.3-codex:xhigh", allModels);
 		expect(providerQualified.model?.provider).toBe("openai-codex");


### PR DESCRIPTION
## Repro
A direct role value such as `anthropic/claude-sonnet-4-5:off,openai/gpt-4o:off` was reproduced with `bun --eval "$REPRO"`: before the fix, `resolveModelRoleValue` resolved the Anthropic model but returned `explicitThinkingLevel: false`, `thinkingLevel: undefined`, and an invalid-thinking warning for `off,openai/gpt-4o`.

## Cause
`packages/coding-agent/src/config/model-resolver.ts` routed `resolveModelRoleValue` through `resolveConfiguredRolePattern` directly. For non-`pi/<role>` values that function returned the whole comma chain as one pattern, so `parseModelPattern` treated the comma tail as part of a colon suffix and stripped back to the first model.

## Fix
- Route direct role resolution through `resolveConfiguredModelPatterns`, the same comma-normalizing expansion path used by configured agent model patterns.
- Add resolver regression coverage for preserving `:off` on the first direct fallback entry.
- Add resolver regression coverage for trying later direct fallback entries after an earlier miss.
- Document the fix in `packages/coding-agent/CHANGELOG.md`.

## Verification
`bun test packages/coding-agent/test/model-resolver.test.ts` passed: 68 tests, 225 assertions. The original `bun --eval "$REPRO"` now prints `{"provider":"anthropic","id":"claude-sonnet-4-5","thinkingLevel":"off","explicitThinkingLevel":true}` and exits 0. `bun check` fails on `main` for the unrelated pre-existing `packages/catalog/test/ollama-cloud-output-caps.test.ts` missing `compat` property on a `Model<"ollama-chat">`; skipped pre-publish gate. Fixes #2228