### PR TITLE
fix(coding-agent): cap read investigation loops

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -53,6 +53,7 @@
 ### Fixed
 
 - Fixed `ask` question/result renders so option and answer rows are no longer duplicated when the component is re-rendered
+- Fixed unbounded tool-call investigation spirals (sessions where every assistant turn ended in `toolUse` until LLM calls hit 6+ minutes and the session went silent): an `InvestigationGuard` now caps per-prompt `read` calls / read-output tokens and forces a no-tool synthesis turn after a configurable number of consecutive tool-use turns, so the agent has to answer from the evidence already gathered instead of continuing to read or search ([#2234](https://github.com/can1357/oh-my-pi/issues/2234)).
 - Fixed streaming `write`/`diff` previews to keep line-number gutter widths stable while content grows, preventing already-rendered preview rows from being reflowed mid-stream
 - Fixed the welcome screen showing "No LSP servers" when `lsp.lazy` is enabled: recognized servers are now still discovered at startup and listed with a dim "available" dot (no warmup), and `/status` reports them as `available` instead of omitting the section
 - Fixed edit-tool diffs stacking adjacent `...` markers around inserted block-context rows (each row added its own gap markers from a snapshot of the diff, so neighboring insertions doubled them, and a marker could be left stranded between contiguous lines): non-contiguous regions are now separated by a single blank row, normalized after insertion, and rendered as one dim `…` in the TUI and HTML export

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed unbounded investigation spirals (sessions where every assistant turn ended in a read/search tool call until LLM calls hit 6+ minutes and the session went silent): an `InvestigationGuard` now tracks uninterrupted streaks of read-only investigation turns (`read`, `search`, `find`, `lsp`, ...), caps `read` calls and read-output tokens per streak, and forces a no-tool synthesis turn after `investigationGuard.maxInvestigationTurns` consecutive investigation-only turns so the agent answers from the evidence already gathered. Any productive tool call (edit, write, bash, todo, ...) resets the guard, so normal long-running coding work is unaffected ([#2234](https://github.com/can1357/oh-my-pi/issues/2234)).
+
 ## [15.10.11] - 2026-06-10
 
 ### Added
@@ -53,7 +57,6 @@
 ### Fixed
 
 - Fixed `ask` question/result renders so option and answer rows are no longer duplicated when the component is re-rendered
-- Fixed unbounded tool-call investigation spirals (sessions where every assistant turn ended in `toolUse` until LLM calls hit 6+ minutes and the session went silent): an `InvestigationGuard` now caps per-prompt `read` calls / read-output tokens and forces a no-tool synthesis turn after a configurable number of consecutive tool-use turns, so the agent has to answer from the evidence already gathered instead of continuing to read or search ([#2234](https://github.com/can1357/oh-my-pi/issues/2234)).
 - Fixed streaming `write`/`diff` previews to keep line-number gutter widths stable while content grows, preventing already-rendered preview rows from being reflowed mid-stream
 - Fixed the welcome screen showing "No LSP servers" when `lsp.lazy` is enabled: recognized servers are now still discovered at startup and listed with a dim "available" dot (no warmup), and `/status` reports them as `available` instead of omitting the section
 - Fixed edit-tool diffs stacking adjacent `...` markers around inserted block-context rows (each row added its own gap markers from a snapshot of the diff, so neighboring insertions doubled them, and a marker could be left stranded between contiguous lines): non-contiguous regions are now separated by a single blank row, normalized after insertion, and rendered as one dim `…` in the TUI and HTML export

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1970,6 +1970,64 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"investigationGuard.enabled": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "tools",
+			label: "Investigation Guard",
+			description: "Force a no-tool synthesis turn when repeated read calls risk an investigation spiral",
+		},
+	},
+
+	"investigationGuard.maxReadCalls": {
+		type: "number",
+		default: 12,
+		ui: {
+			tab: "tools",
+			label: "Investigation Guard Read Calls",
+			description: "Maximum read calls allowed in one investigation turn before forcing synthesis",
+			options: [
+				{ value: "5", label: "5 reads" },
+				{ value: "12", label: "12 reads" },
+				{ value: "20", label: "20 reads" },
+				{ value: "40", label: "40 reads" },
+			],
+		},
+	},
+
+	"investigationGuard.maxReadTokens": {
+		type: "number",
+		default: 80_000,
+		ui: {
+			tab: "tools",
+			label: "Investigation Guard Read Tokens",
+			description: "Maximum read-output tokens allowed before forcing synthesis",
+			options: [
+				{ value: "40000", label: "40K tokens" },
+				{ value: "80000", label: "80K tokens" },
+				{ value: "160000", label: "160K tokens" },
+			],
+		},
+	},
+
+	"investigationGuard.maxConsecutiveToolUseTurns": {
+		type: "number",
+		default: 15,
+		ui: {
+			tab: "tools",
+			label: "Investigation Guard Consecutive Tool Turns",
+			description:
+				"After this many assistant turns in a row end in a tool call, the next model call is forced with no tools so the agent answers from what it already has",
+			options: [
+				{ value: "10", label: "10 turns" },
+				{ value: "15", label: "15 turns" },
+				{ value: "25", label: "25 turns" },
+				{ value: "40", label: "40 turns" },
+			],
+		},
+	},
+
 	// LSP
 	"lsp.enabled": {
 		type: "boolean",

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1976,22 +1976,23 @@ export const SETTINGS_SCHEMA = {
 		ui: {
 			tab: "tools",
 			label: "Investigation Guard",
-			description: "Force a no-tool synthesis turn when repeated read calls risk an investigation spiral",
+			description:
+				"Detect read/search-only investigation spirals and force a no-tool synthesis turn; any non-investigation tool (edit, bash, ...) resets the guard",
 		},
 	},
 
 	"investigationGuard.maxReadCalls": {
 		type: "number",
-		default: 12,
+		default: 40,
 		ui: {
 			tab: "tools",
 			label: "Investigation Guard Read Calls",
-			description: "Maximum read calls allowed in one investigation turn before forcing synthesis",
+			description: "Maximum read calls in one uninterrupted investigation streak before forcing synthesis",
 			options: [
-				{ value: "5", label: "5 reads" },
 				{ value: "12", label: "12 reads" },
-				{ value: "20", label: "20 reads" },
+				{ value: "25", label: "25 reads" },
 				{ value: "40", label: "40 reads" },
+				{ value: "80", label: "80 reads" },
 			],
 		},
 	},
@@ -2002,7 +2003,7 @@ export const SETTINGS_SCHEMA = {
 		ui: {
 			tab: "tools",
 			label: "Investigation Guard Read Tokens",
-			description: "Maximum read-output tokens allowed before forcing synthesis",
+			description: "Maximum read-output tokens in one uninterrupted investigation streak before forcing synthesis",
 			options: [
 				{ value: "40000", label: "40K tokens" },
 				{ value: "80000", label: "80K tokens" },
@@ -2011,14 +2012,14 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
-	"investigationGuard.maxConsecutiveToolUseTurns": {
+	"investigationGuard.maxInvestigationTurns": {
 		type: "number",
 		default: 15,
 		ui: {
 			tab: "tools",
-			label: "Investigation Guard Consecutive Tool Turns",
+			label: "Investigation Guard Turns",
 			description:
-				"After this many assistant turns in a row end in a tool call, the next model call is forced with no tools so the agent answers from what it already has",
+				"After this many consecutive assistant turns whose tool calls are all read-only investigation tools (read, search, find, lsp, ...), the next model call is forced with no tools so the agent answers from what it already has",
 			options: [
 				{ value: "10", label: "10 turns" },
 				{ value: "15", label: "15 turns" },

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -29,6 +29,8 @@ import {
 	type AgentState,
 	type AgentTool,
 	AppendOnlyContextManager,
+	type BeforeToolCallContext,
+	type BeforeToolCallResult,
 	resolveTelemetry,
 	ThinkingLevel,
 } from "@oh-my-pi/pi-agent-core";
@@ -221,6 +223,7 @@ import { normalizeModelContextImages } from "../utils/image-loading";
 import { buildNamedToolChoice } from "../utils/tool-choice";
 import type { AuthStorage } from "./auth-storage";
 import type { ClientBridge, ClientBridgePermissionOption, ClientBridgePermissionOutcome } from "./client-bridge";
+import { INVESTIGATION_GUARD_TOOL_CHOICE_LABEL, InvestigationGuard } from "./investigation-guard";
 import {
 	type BashExecutionMessage,
 	type CompactionSummaryMessage,
@@ -905,7 +908,8 @@ export class AgentSession {
 	#todoReminderCount = 0;
 	#todoPhases: TodoPhase[] = [];
 	#toolChoiceQueue = new ToolChoiceQueue();
-
+	#investigationGuard: InvestigationGuard;
+	#investigationGuardSynthesisQueued = false;
 	// Bash execution state
 	#bashAbortControllers = new Set<AbortController>();
 	#pendingBashMessages: BashExecutionMessage[] = [];
@@ -1118,6 +1122,7 @@ export class AgentSession {
 		this.agent = config.agent;
 		this.sessionManager = config.sessionManager;
 		this.settings = config.settings;
+		this.#investigationGuard = new InvestigationGuard(this.settings);
 		// Power assertions are taken per turn (see #beginInFlight); nothing acquired here.
 		this.#evalKernelOwnerId = config.evalKernelOwnerId ?? `agent-session:${Snowflake.next()}`;
 		this.#parentEvalSessionId = config.parentEvalSessionId;
@@ -1234,8 +1239,8 @@ export class AgentSession {
 			this.#preCacheStreamingEditFile(event);
 			this.#maybeAbortStreamingEdit(event);
 		});
-		// Per-tool TTSR reminders are folded into the matched tool's result via this hook.
-		this.agent.afterToolCall = ctx => this.#ttsrAfterToolCall(ctx);
+		this.agent.beforeToolCall = ctx => this.#beforeToolCall(ctx);
+		this.agent.afterToolCall = ctx => this.#afterToolCall(ctx);
 		this.agent.providerSessionState = this.#providerSessionState;
 		this.#syncAgentSessionId();
 		this.#syncTodoPhasesFromBranch();
@@ -1301,6 +1306,21 @@ export class AgentSession {
 	/** Advance the tool-choice queue and return the next directive for the upcoming LLM call. */
 	nextToolChoice(): ToolChoice | undefined {
 		return this.#toolChoiceQueue.nextToolChoice();
+	}
+
+	#queueInvestigationGuardSynthesisTurn(): void {
+		if (this.#investigationGuardSynthesisQueued) return;
+		this.#investigationGuardSynthesisQueued = true;
+		this.#toolChoiceQueue.pushOnce("none", {
+			label: INVESTIGATION_GUARD_TOOL_CHOICE_LABEL,
+			now: true,
+			onResolved: () => {
+				this.#investigationGuardSynthesisQueued = false;
+			},
+			onRejected: () => {
+				this.#investigationGuardSynthesisQueued = false;
+			},
+		});
 	}
 
 	/**
@@ -1653,6 +1673,13 @@ export class AgentSession {
 				this.#toolChoiceQueue.reject(msg.stopReason === "error" ? "error" : "aborted");
 			} else {
 				this.#toolChoiceQueue.resolve();
+			}
+		}
+		if (event.type === "turn_end") {
+			const msg = event.message as AssistantMessage;
+			this.#investigationGuard.noteAssistantStop(msg.stopReason);
+			if (this.#investigationGuard.consumeSynthesisRequest()) {
+				this.#queueInvestigationGuardSynthesisTurn();
 			}
 		}
 		if (event.type === "tool_execution_end") {
@@ -2201,6 +2228,22 @@ export class AgentSession {
 		if (newlyAdded.length > 0) {
 			this.#ttsrManager?.markInjectedByNames(newlyAdded);
 		}
+	}
+
+	#beforeToolCall(ctx: BeforeToolCallContext): BeforeToolCallResult | undefined {
+		const result = this.#investigationGuard.beforeToolCall(ctx);
+		if (this.#investigationGuard.consumeSynthesisRequest()) {
+			this.#queueInvestigationGuardSynthesisTurn();
+		}
+		return result;
+	}
+
+	#afterToolCall(ctx: AfterToolCallContext): AfterToolCallResult | undefined {
+		this.#investigationGuard.afterToolCall(ctx);
+		if (this.#investigationGuard.consumeSynthesisRequest()) {
+			this.#queueInvestigationGuardSynthesisTurn();
+		}
+		return this.#ttsrAfterToolCall(ctx);
 	}
 
 	/** `afterToolCall` hook: fold any per-tool TTSR reminders into the result. */
@@ -4554,9 +4597,12 @@ export class AgentSession {
 			this.#flushPendingPythonMessages();
 			this.#flushPendingBackgroundExchanges();
 
-			// Reset todo reminder count on new user prompt
+			// Reset per-prompt maintenance counters
 			this.#todoReminderCount = 0;
 			this.#emptyStopRetryCount = 0;
+			this.#investigationGuard.reset();
+			this.#investigationGuardSynthesisQueued = false;
+			this.#toolChoiceQueue.removeByLabel(INVESTIGATION_GUARD_TOOL_CHOICE_LABEL);
 
 			await this.#maybeRestoreRetryFallbackPrimary();
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -1676,8 +1676,10 @@ export class AgentSession {
 			}
 		}
 		if (event.type === "turn_end") {
-			const msg = event.message as AssistantMessage;
-			this.#investigationGuard.noteAssistantStop(msg.stopReason);
+			// Synthesis is queued only here, after the turn's executed tools are
+			// known: a turn that ran any non-investigation tool resets the guard,
+			// which must win over a read budget crossed mid-batch in that turn.
+			this.#investigationGuard.noteTurnEnd(event.message as AssistantMessage, event.toolResults);
 			if (this.#investigationGuard.consumeSynthesisRequest()) {
 				this.#queueInvestigationGuardSynthesisTurn();
 			}
@@ -2231,18 +2233,11 @@ export class AgentSession {
 	}
 
 	#beforeToolCall(ctx: BeforeToolCallContext): BeforeToolCallResult | undefined {
-		const result = this.#investigationGuard.beforeToolCall(ctx);
-		if (this.#investigationGuard.consumeSynthesisRequest()) {
-			this.#queueInvestigationGuardSynthesisTurn();
-		}
-		return result;
+		return this.#investigationGuard.beforeToolCall(ctx);
 	}
 
 	#afterToolCall(ctx: AfterToolCallContext): AfterToolCallResult | undefined {
 		this.#investigationGuard.afterToolCall(ctx);
-		if (this.#investigationGuard.consumeSynthesisRequest()) {
-			this.#queueInvestigationGuardSynthesisTurn();
-		}
 		return this.#ttsrAfterToolCall(ctx);
 	}
 

--- a/packages/coding-agent/src/session/investigation-guard.ts
+++ b/packages/coding-agent/src/session/investigation-guard.ts
@@ -1,0 +1,143 @@
+import type { AfterToolCallContext, BeforeToolCallContext, BeforeToolCallResult } from "@oh-my-pi/pi-agent-core";
+import type { AssistantMessage, TextContent } from "@oh-my-pi/pi-ai";
+import { countTokens } from "@oh-my-pi/pi-natives";
+import type { Settings } from "../config/settings";
+
+const READ_TOOL_NAME = "read";
+
+/** Tool-choice queue label used when the investigation guard forces a synthesis turn. */
+export const INVESTIGATION_GUARD_TOOL_CHOICE_LABEL = "investigation-guard";
+
+interface InvestigationGuardLimits {
+	enabled: boolean;
+	maxReadCalls: number;
+	maxReadTokens: number;
+	maxConsecutiveToolUseTurns: number;
+}
+
+type SynthesisTrigger = "read-call" | "read-token" | "consecutive-tool-use";
+
+/**
+ * Tracks repeated investigation loops at two granularities and asks the model
+ * to synthesize before context spirals:
+ *
+ * - Per-prompt `read` budget: too many `read` calls or too many read-output
+ *   tokens means the agent should stop pulling more files into context.
+ * - Per-prompt consecutive-`toolUse` turn cap: every turn ending in `toolUse`
+ *   indicates the agent never broke out to answer. Once the count crosses
+ *   the configured threshold the next LLM call is forced with no tools so
+ *   the model has to produce a text response.
+ */
+export class InvestigationGuard {
+	readonly #settings: Settings;
+	#readCalls = 0;
+	#readTokens = 0;
+	#consecutiveToolUseTurns = 0;
+	#synthesisRequested = false;
+
+	constructor(settings: Settings) {
+		this.#settings = settings;
+	}
+
+	/** Clear per-prompt counters when a fresh user or synthetic turn starts. */
+	reset(): void {
+		this.#readCalls = 0;
+		this.#readTokens = 0;
+		this.#consecutiveToolUseTurns = 0;
+		this.#synthesisRequested = false;
+	}
+
+	/** Block read calls that exceed the current investigation budget. */
+	beforeToolCall(ctx: BeforeToolCallContext): BeforeToolCallResult | undefined {
+		if (ctx.toolCall.name !== READ_TOOL_NAME) return undefined;
+		const limits = this.#limits();
+		if (!limits.enabled) return undefined;
+
+		const projectedReadCalls = this.#readCalls + this.#readOrdinalInAssistantMessage(ctx);
+		const callLimitExceeded = projectedReadCalls > limits.maxReadCalls;
+		const tokenLimitExceeded = this.#readTokens >= limits.maxReadTokens;
+		if (!callLimitExceeded && !tokenLimitExceeded) return undefined;
+
+		this.#synthesisRequested = true;
+		return {
+			block: true,
+			reason: this.#blockReason(limits, callLimitExceeded ? "read-call" : "read-token"),
+		};
+	}
+
+	/** Account for read-tool output and request synthesis once accumulated output crosses the token budget. */
+	afterToolCall(ctx: AfterToolCallContext): void {
+		if (ctx.toolCall.name !== READ_TOOL_NAME || ctx.isError) return;
+		const limits = this.#limits();
+		if (!limits.enabled) return;
+
+		this.#readCalls++;
+		const texts = ctx.result.content.filter((content): content is TextContent => content.type === "text");
+		if (texts.length > 0) {
+			this.#readTokens += countTokens(texts.map(content => content.text));
+		}
+		if (this.#readTokens >= limits.maxReadTokens || this.#readCalls >= limits.maxReadCalls) {
+			this.#synthesisRequested = true;
+		}
+	}
+
+	/**
+	 * Record an assistant turn's stop reason. A `toolUse` stop bumps the
+	 * consecutive-tool-use counter and may request synthesis; a clean `stop`
+	 * (text response) is treated as the agent breaking out of investigation
+	 * and clears all counters. `error`/`aborted` leaves counters untouched.
+	 */
+	noteAssistantStop(stopReason: AssistantMessage["stopReason"]): void {
+		if (stopReason === "toolUse") {
+			this.#consecutiveToolUseTurns++;
+			const limits = this.#limits();
+			if (limits.enabled && this.#consecutiveToolUseTurns >= limits.maxConsecutiveToolUseTurns) {
+				this.#synthesisRequested = true;
+			}
+		} else if (stopReason === "stop") {
+			this.reset();
+		}
+	}
+
+	/** Consume the pending request to force the next LLM call to run without tools. */
+	consumeSynthesisRequest(): boolean {
+		if (!this.#synthesisRequested) return false;
+		this.#synthesisRequested = false;
+		return true;
+	}
+
+	#limits(): InvestigationGuardLimits {
+		const maxReadCalls = Math.max(1, Math.floor(this.#settings.get("investigationGuard.maxReadCalls")));
+		const maxReadTokens = Math.max(1, Math.floor(this.#settings.get("investigationGuard.maxReadTokens")));
+		const maxConsecutiveToolUseTurns = Math.max(
+			1,
+			Math.floor(this.#settings.get("investigationGuard.maxConsecutiveToolUseTurns")),
+		);
+		return {
+			enabled: this.#settings.get("investigationGuard.enabled"),
+			maxReadCalls,
+			maxReadTokens,
+			maxConsecutiveToolUseTurns,
+		};
+	}
+
+	#readOrdinalInAssistantMessage(ctx: BeforeToolCallContext): number {
+		let ordinal = 0;
+		for (const block of ctx.assistantMessage.content) {
+			if (block.type !== "toolCall" || block.name !== READ_TOOL_NAME) continue;
+			ordinal++;
+			if (block.id === ctx.toolCall.id) return ordinal;
+		}
+		return 1;
+	}
+
+	#blockReason(limits: InvestigationGuardLimits, trigger: SynthesisTrigger): string {
+		const detail =
+			trigger === "read-call"
+				? `${limits.maxReadCalls} read calls`
+				: trigger === "read-token"
+					? `${limits.maxReadTokens} read-output tokens`
+					: `${limits.maxConsecutiveToolUseTurns} consecutive tool-use turns`;
+		return `Read investigation limit reached after ${detail}. Stop reading more files and answer from the evidence already gathered; if exact missing lines are required, explain the narrow follow-up read instead of continuing the tool loop.`;
+	}
+}

--- a/packages/coding-agent/src/session/investigation-guard.ts
+++ b/packages/coding-agent/src/session/investigation-guard.ts
@@ -1,9 +1,25 @@
 import type { AfterToolCallContext, BeforeToolCallContext, BeforeToolCallResult } from "@oh-my-pi/pi-agent-core";
-import type { AssistantMessage, TextContent } from "@oh-my-pi/pi-ai";
+import type { AssistantMessage, TextContent, ToolResultMessage } from "@oh-my-pi/pi-ai";
 import { countTokens } from "@oh-my-pi/pi-natives";
 import type { Settings } from "../config/settings";
 
 const READ_TOOL_NAME = "read";
+
+/**
+ * Read-only tools whose calls count toward an investigation streak. A turn
+ * counts as "investigation" only when every tool it executed is in this table;
+ * any other tool (edit, write, bash, todo, task, MCP, ...) is treated as the
+ * agent making progress and resets the guard entirely.
+ */
+const INVESTIGATION_TOOLS: Record<string, true> = {
+	[READ_TOOL_NAME]: true,
+	search: true,
+	find: true,
+	ast_grep: true,
+	lsp: true,
+	web_search: true,
+	inspect_image: true,
+};
 
 /** Tool-choice queue label used when the investigation guard forces a synthesis turn. */
 export const INVESTIGATION_GUARD_TOOL_CHOICE_LABEL = "investigation-guard";
@@ -12,38 +28,54 @@ interface InvestigationGuardLimits {
 	enabled: boolean;
 	maxReadCalls: number;
 	maxReadTokens: number;
-	maxConsecutiveToolUseTurns: number;
+	maxInvestigationTurns: number;
 }
 
-type SynthesisTrigger = "read-call" | "read-token" | "consecutive-tool-use";
+type SynthesisTrigger = "read-call" | "read-token";
 
 /**
- * Tracks repeated investigation loops at two granularities and asks the model
- * to synthesize before context spirals:
+ * Detects unbounded investigation spirals (#2234: 77 consecutive read/search
+ * turns, zero text answers, context and thinking growing until the session
+ * went silent) and asks the model to synthesize before context blows up:
  *
- * - Per-prompt `read` budget: too many `read` calls or too many read-output
- *   tokens means the agent should stop pulling more files into context.
- * - Per-prompt consecutive-`toolUse` turn cap: every turn ending in `toolUse`
- *   indicates the agent never broke out to answer. Once the count crosses
- *   the configured threshold the next LLM call is forced with no tools so
- *   the model has to produce a text response.
+ * - Read budget per investigation streak: too many `read` calls or too many
+ *   read-output tokens means the agent should stop pulling more files into
+ *   context and answer from what it has.
+ * - Investigation-turn cap: consecutive assistant turns whose tool calls are
+ *   all read-only investigation tools. Once the cap is reached the next LLM
+ *   call is forced with `toolChoice: "none"` so the model must produce text.
+ *
+ * Any turn that executes a non-investigation tool resets all counters —
+ * normal coding work (read a few files, edit, run tests, read more) never
+ * accumulates a streak, no matter how long the session runs.
  */
 export class InvestigationGuard {
 	readonly #settings: Settings;
 	#readCalls = 0;
 	#readTokens = 0;
-	#consecutiveToolUseTurns = 0;
+	#investigationTurns = 0;
+	/**
+	 * Read calls that passed `beforeToolCall` but have not completed yet.
+	 * Same-message reads run concurrently, so the call budget must count
+	 * in-flight reads — `#readCalls` alone lags until results land. The token
+	 * budget cannot be projected the same way (output size is unknown until a
+	 * read completes), so within one concurrent batch it can overshoot by at
+	 * most the remaining call budget; the synthesis turn forced right after
+	 * the batch bounds the damage.
+	 */
+	readonly #pendingReads = new Set<string>();
 	#synthesisRequested = false;
 
 	constructor(settings: Settings) {
 		this.#settings = settings;
 	}
 
-	/** Clear per-prompt counters when a fresh user or synthetic turn starts. */
+	/** Clear all counters: new prompt, text answer, or a productive (non-investigation) turn. */
 	reset(): void {
 		this.#readCalls = 0;
 		this.#readTokens = 0;
-		this.#consecutiveToolUseTurns = 0;
+		this.#investigationTurns = 0;
+		this.#pendingReads.clear();
 		this.#synthesisRequested = false;
 	}
 
@@ -53,10 +85,13 @@ export class InvestigationGuard {
 		const limits = this.#limits();
 		if (!limits.enabled) return undefined;
 
-		const projectedReadCalls = this.#readCalls + this.#readOrdinalInAssistantMessage(ctx);
+		const projectedReadCalls = this.#readCalls + this.#pendingReads.size + 1;
 		const callLimitExceeded = projectedReadCalls > limits.maxReadCalls;
 		const tokenLimitExceeded = this.#readTokens >= limits.maxReadTokens;
-		if (!callLimitExceeded && !tokenLimitExceeded) return undefined;
+		if (!callLimitExceeded && !tokenLimitExceeded) {
+			this.#pendingReads.add(ctx.toolCall.id);
+			return undefined;
+		}
 
 		this.#synthesisRequested = true;
 		return {
@@ -67,7 +102,9 @@ export class InvestigationGuard {
 
 	/** Account for read-tool output and request synthesis once accumulated output crosses the token budget. */
 	afterToolCall(ctx: AfterToolCallContext): void {
-		if (ctx.toolCall.name !== READ_TOOL_NAME || ctx.isError) return;
+		if (ctx.toolCall.name !== READ_TOOL_NAME) return;
+		this.#pendingReads.delete(ctx.toolCall.id);
+		if (ctx.isError) return;
 		const limits = this.#limits();
 		if (!limits.enabled) return;
 
@@ -82,20 +119,30 @@ export class InvestigationGuard {
 	}
 
 	/**
-	 * Record an assistant turn's stop reason. A `toolUse` stop bumps the
-	 * consecutive-tool-use counter and may request synthesis; a clean `stop`
-	 * (text response) is treated as the agent breaking out of investigation
-	 * and clears all counters. `error`/`aborted` leaves counters untouched.
+	 * Classify a completed assistant turn by the tools it actually executed
+	 * (not `stopReason` — interleaved-thinking models routinely emit tool
+	 * calls under `end_turn`):
+	 *
+	 * - All executed tools are investigation tools → the streak grows and may
+	 *   request synthesis.
+	 * - Any non-investigation tool ran → the agent made progress; reset.
+	 * - No tools and a clean `stop` → the agent answered in text; reset.
+	 * - `error`/`aborted` turns leave counters untouched.
 	 */
-	noteAssistantStop(stopReason: AssistantMessage["stopReason"]): void {
-		if (stopReason === "toolUse") {
-			this.#consecutiveToolUseTurns++;
-			const limits = this.#limits();
-			if (limits.enabled && this.#consecutiveToolUseTurns >= limits.maxConsecutiveToolUseTurns) {
-				this.#synthesisRequested = true;
-			}
-		} else if (stopReason === "stop") {
+	noteTurnEnd(message: AssistantMessage, toolResults: readonly ToolResultMessage[]): void {
+		if (message.stopReason === "error" || message.stopReason === "aborted") return;
+		if (toolResults.length === 0) {
+			if (message.stopReason === "stop") this.reset();
+			return;
+		}
+		if (!toolResults.every(result => INVESTIGATION_TOOLS[result.toolName] === true)) {
 			this.reset();
+			return;
+		}
+		this.#investigationTurns++;
+		const limits = this.#limits();
+		if (limits.enabled && this.#investigationTurns >= limits.maxInvestigationTurns) {
+			this.#synthesisRequested = true;
 		}
 	}
 
@@ -109,35 +156,21 @@ export class InvestigationGuard {
 	#limits(): InvestigationGuardLimits {
 		const maxReadCalls = Math.max(1, Math.floor(this.#settings.get("investigationGuard.maxReadCalls")));
 		const maxReadTokens = Math.max(1, Math.floor(this.#settings.get("investigationGuard.maxReadTokens")));
-		const maxConsecutiveToolUseTurns = Math.max(
+		const maxInvestigationTurns = Math.max(
 			1,
-			Math.floor(this.#settings.get("investigationGuard.maxConsecutiveToolUseTurns")),
+			Math.floor(this.#settings.get("investigationGuard.maxInvestigationTurns")),
 		);
 		return {
 			enabled: this.#settings.get("investigationGuard.enabled"),
 			maxReadCalls,
 			maxReadTokens,
-			maxConsecutiveToolUseTurns,
+			maxInvestigationTurns,
 		};
-	}
-
-	#readOrdinalInAssistantMessage(ctx: BeforeToolCallContext): number {
-		let ordinal = 0;
-		for (const block of ctx.assistantMessage.content) {
-			if (block.type !== "toolCall" || block.name !== READ_TOOL_NAME) continue;
-			ordinal++;
-			if (block.id === ctx.toolCall.id) return ordinal;
-		}
-		return 1;
 	}
 
 	#blockReason(limits: InvestigationGuardLimits, trigger: SynthesisTrigger): string {
 		const detail =
-			trigger === "read-call"
-				? `${limits.maxReadCalls} read calls`
-				: trigger === "read-token"
-					? `${limits.maxReadTokens} read-output tokens`
-					: `${limits.maxConsecutiveToolUseTurns} consecutive tool-use turns`;
-		return `Read investigation limit reached after ${detail}. Stop reading more files and answer from the evidence already gathered; if exact missing lines are required, explain the narrow follow-up read instead of continuing the tool loop.`;
+			trigger === "read-call" ? `${limits.maxReadCalls} read calls` : `${limits.maxReadTokens} read-output tokens`;
+		return `Read investigation limit reached after ${detail} without intervening progress. Stop reading more files and answer from the evidence already gathered; if exact missing lines are required, explain the narrow follow-up read instead of continuing the tool loop.`;
 	}
 }

--- a/packages/coding-agent/test/agent-session-read-spiral-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-read-spiral-guard.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, expect, it } from "bun:test";
+import * as path from "node:path";
+import { Agent, type AgentTool } from "@oh-my-pi/pi-agent-core";
+import { type ToolResultMessage, z } from "@oh-my-pi/pi-ai";
+import { createMockModel, type MockModel, type MockResponse } from "@oh-my-pi/pi-ai/providers/mock";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { convertToLlm } from "@oh-my-pi/pi-coding-agent/session/messages";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+const readSchema = z.object({ path: z.string() });
+const searchSchema = z.object({ pattern: z.string() });
+
+interface Harness {
+	session: AgentSession;
+	tempDir: TempDir;
+	authStorage: AuthStorage;
+	mock: MockModel;
+	executedReads: string[];
+	executedSearches: string[];
+}
+
+interface HarnessOptions {
+	settings?: Record<string, unknown>;
+	responses: MockResponse[];
+}
+
+let harness: Harness | undefined;
+
+async function createHarness({ settings: settingsOverrides = {}, responses }: HarnessOptions): Promise<Harness> {
+	const tempDir = TempDir.createSync("@pi-read-spiral-guard-");
+	const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+	authStorage.setRuntimeApiKey("mock", "test-key");
+	const modelRegistry = new ModelRegistry(authStorage, path.join(tempDir.path(), "models.yml"));
+	const settings = Settings.isolated({
+		"compaction.enabled": false,
+		"retry.enabled": false,
+		"todo.enabled": false,
+		"todo.eager": false,
+		"todo.reminders": false,
+		...settingsOverrides,
+	});
+
+	const executedReads: string[] = [];
+	const executedSearches: string[] = [];
+	const readTool: AgentTool<typeof readSchema> = {
+		name: "read",
+		label: "Read",
+		description: "Mock read tool",
+		parameters: readSchema,
+		approval: "read",
+		execute: async (_toolCallId, params) => {
+			executedReads.push(params.path);
+			return { content: [{ type: "text", text: `contents for ${params.path}\n${"x".repeat(256)}` }] };
+		},
+	};
+	const searchTool: AgentTool<typeof searchSchema> = {
+		name: "search",
+		label: "Search",
+		description: "Mock search tool",
+		parameters: searchSchema,
+		approval: "read",
+		execute: async (_toolCallId, params) => ({
+			content: [{ type: "text", text: `no hits for ${params.pattern}` }],
+		}),
+	};
+	searchTool.execute = async (_toolCallId, params) => {
+		executedSearches.push(params.pattern);
+		return { content: [{ type: "text", text: `no hits for ${params.pattern}` }] };
+	};
+
+	const mock = createMockModel({ responses });
+
+	let session: AgentSession;
+	const agent = new Agent({
+		getApiKey: () => "test-key",
+		initialState: {
+			model: mock,
+			systemPrompt: ["Test"],
+			tools: [readTool, searchTool],
+			messages: [],
+		},
+		convertToLlm,
+		getToolChoice: () => session.nextToolChoice(),
+		streamFn: mock.stream,
+	});
+
+	session = new AgentSession({
+		agent,
+		sessionManager: SessionManager.inMemory(tempDir.path()),
+		settings,
+		modelRegistry,
+		toolRegistry: new Map<string, AgentTool>([
+			[readTool.name, readTool as AgentTool],
+			[searchTool.name, searchTool as AgentTool],
+		]),
+	});
+
+	return { session, tempDir, authStorage, mock, executedReads, executedSearches };
+}
+
+afterEach(async () => {
+	if (!harness) return;
+	await harness.session.dispose();
+	harness.authStorage.close();
+	harness.tempDir.removeSync();
+	harness = undefined;
+});
+
+it("forces a no-tool synthesis turn after the per-prompt read budget is exhausted", async () => {
+	harness = await createHarness({
+		settings: { "investigationGuard.maxReadCalls": 5 },
+		responses: [
+			{
+				content: Array.from({ length: 6 }, (_, index) => ({
+					type: "toolCall" as const,
+					id: `read-${index}`,
+					name: "read",
+					arguments: { path: `engine-${index}.cs` },
+				})),
+				stopReason: "toolUse",
+			},
+			{ content: ["I have enough context to answer now."], stopReason: "stop" },
+		],
+	});
+
+	await harness.session.prompt("investigate engine clipping");
+	await harness.session.waitForIdle();
+
+	expect(harness.executedReads).toEqual(["engine-0.cs", "engine-1.cs", "engine-2.cs", "engine-3.cs", "engine-4.cs"]);
+	expect(harness.mock.calls).toHaveLength(2);
+	expect(harness.mock.calls[1]?.options?.toolChoice).toBe("none");
+
+	const blockedResult = harness.session.agent.state.messages.find(
+		(message): message is ToolResultMessage => message.role === "toolResult" && message.toolCallId === "read-5",
+	);
+	expect(blockedResult?.isError).toBe(true);
+	expect(JSON.stringify(blockedResult?.content)).toContain("Read investigation limit reached");
+});
+
+it("forces a no-tool synthesis turn after consecutive tool-use turns hit the cap", async () => {
+	const spiralResponse = (turn: number): MockResponse => ({
+		content: [
+			{
+				type: "toolCall" as const,
+				id: `search-${turn}`,
+				name: "search",
+				arguments: { pattern: `term-${turn}` },
+			},
+		],
+		stopReason: "toolUse",
+	});
+	harness = await createHarness({
+		settings: { "investigationGuard.maxConsecutiveToolUseTurns": 3 },
+		responses: [
+			spiralResponse(0),
+			spiralResponse(1),
+			spiralResponse(2),
+			{ content: ["I have enough context to answer now."], stopReason: "stop" },
+		],
+	});
+
+	await harness.session.prompt("look around");
+	await harness.session.waitForIdle();
+
+	expect(harness.executedSearches).toEqual(["term-0", "term-1", "term-2"]);
+	expect(harness.mock.calls).toHaveLength(4);
+	expect(harness.mock.calls[0]?.options?.toolChoice).toBeUndefined();
+	expect(harness.mock.calls[1]?.options?.toolChoice).toBeUndefined();
+	expect(harness.mock.calls[2]?.options?.toolChoice).toBeUndefined();
+	expect(harness.mock.calls[3]?.options?.toolChoice).toBe("none");
+});

--- a/packages/coding-agent/test/agent-session-read-spiral-guard.test.ts
+++ b/packages/coding-agent/test/agent-session-read-spiral-guard.test.ts
@@ -13,6 +13,7 @@ import { TempDir } from "@oh-my-pi/pi-utils";
 
 const readSchema = z.object({ path: z.string() });
 const searchSchema = z.object({ pattern: z.string() });
+const noteSchema = z.object({ text: z.string() });
 
 interface Harness {
 	session: AgentSession;
@@ -21,6 +22,7 @@ interface Harness {
 	mock: MockModel;
 	executedReads: string[];
 	executedSearches: string[];
+	executedNotes: string[];
 }
 
 interface HarnessOptions {
@@ -46,6 +48,7 @@ async function createHarness({ settings: settingsOverrides = {}, responses }: Ha
 
 	const executedReads: string[] = [];
 	const executedSearches: string[] = [];
+	const executedNotes: string[] = [];
 	const readTool: AgentTool<typeof readSchema> = {
 		name: "read",
 		label: "Read",
@@ -63,13 +66,22 @@ async function createHarness({ settings: settingsOverrides = {}, responses }: Ha
 		description: "Mock search tool",
 		parameters: searchSchema,
 		approval: "read",
-		execute: async (_toolCallId, params) => ({
-			content: [{ type: "text", text: `no hits for ${params.pattern}` }],
-		}),
+		execute: async (_toolCallId, params) => {
+			executedSearches.push(params.pattern);
+			return { content: [{ type: "text", text: `no hits for ${params.pattern}` }] };
+		},
 	};
-	searchTool.execute = async (_toolCallId, params) => {
-		executedSearches.push(params.pattern);
-		return { content: [{ type: "text", text: `no hits for ${params.pattern}` }] };
+	// Stand-in for a productive (non-investigation) tool such as edit/write/bash.
+	const noteTool: AgentTool<typeof noteSchema> = {
+		name: "note",
+		label: "Note",
+		description: "Mock productive tool",
+		parameters: noteSchema,
+		approval: "write",
+		execute: async (_toolCallId, params) => {
+			executedNotes.push(params.text);
+			return { content: [{ type: "text", text: `noted ${params.text}` }] };
+		},
 	};
 
 	const mock = createMockModel({ responses });
@@ -80,7 +92,7 @@ async function createHarness({ settings: settingsOverrides = {}, responses }: Ha
 		initialState: {
 			model: mock,
 			systemPrompt: ["Test"],
-			tools: [readTool, searchTool],
+			tools: [readTool, searchTool, noteTool],
 			messages: [],
 		},
 		convertToLlm,
@@ -96,10 +108,11 @@ async function createHarness({ settings: settingsOverrides = {}, responses }: Ha
 		toolRegistry: new Map<string, AgentTool>([
 			[readTool.name, readTool as AgentTool],
 			[searchTool.name, searchTool as AgentTool],
+			[noteTool.name, noteTool as AgentTool],
 		]),
 	});
 
-	return { session, tempDir, authStorage, mock, executedReads, executedSearches };
+	return { session, tempDir, authStorage, mock, executedReads, executedSearches, executedNotes };
 }
 
 afterEach(async () => {
@@ -141,7 +154,7 @@ it("forces a no-tool synthesis turn after the per-prompt read budget is exhauste
 	expect(JSON.stringify(blockedResult?.content)).toContain("Read investigation limit reached");
 });
 
-it("forces a no-tool synthesis turn after consecutive tool-use turns hit the cap", async () => {
+it("forces a no-tool synthesis turn after consecutive investigation-only turns hit the cap", async () => {
 	const spiralResponse = (turn: number): MockResponse => ({
 		content: [
 			{
@@ -154,7 +167,7 @@ it("forces a no-tool synthesis turn after consecutive tool-use turns hit the cap
 		stopReason: "toolUse",
 	});
 	harness = await createHarness({
-		settings: { "investigationGuard.maxConsecutiveToolUseTurns": 3 },
+		settings: { "investigationGuard.maxInvestigationTurns": 3 },
 		responses: [
 			spiralResponse(0),
 			spiralResponse(1),
@@ -172,4 +185,50 @@ it("forces a no-tool synthesis turn after consecutive tool-use turns hit the cap
 	expect(harness.mock.calls[1]?.options?.toolChoice).toBeUndefined();
 	expect(harness.mock.calls[2]?.options?.toolChoice).toBeUndefined();
 	expect(harness.mock.calls[3]?.options?.toolChoice).toBe("none");
+});
+
+it("resets the investigation streak when a turn runs a productive tool", async () => {
+	const searchResponse = (turn: number): MockResponse => ({
+		content: [
+			{
+				type: "toolCall" as const,
+				id: `search-${turn}`,
+				name: "search",
+				arguments: { pattern: `term-${turn}` },
+			},
+		],
+		stopReason: "toolUse",
+	});
+	const noteResponse = (turn: number): MockResponse => ({
+		content: [
+			{
+				type: "toolCall" as const,
+				id: `note-${turn}`,
+				name: "note",
+				arguments: { text: `progress-${turn}` },
+			},
+		],
+		stopReason: "toolUse",
+	});
+	harness = await createHarness({
+		settings: { "investigationGuard.maxInvestigationTurns": 3 },
+		responses: [
+			searchResponse(0),
+			searchResponse(1),
+			noteResponse(2),
+			searchResponse(3),
+			searchResponse(4),
+			{ content: ["Done."], stopReason: "stop" },
+		],
+	});
+
+	await harness.session.prompt("investigate and fix");
+	await harness.session.waitForIdle();
+
+	expect(harness.executedSearches).toEqual(["term-0", "term-1", "term-3", "term-4"]);
+	expect(harness.executedNotes).toEqual(["progress-2"]);
+	expect(harness.mock.calls).toHaveLength(6);
+	for (const call of harness.mock.calls) {
+		expect(call.options?.toolChoice).toBeUndefined();
+	}
 });


### PR DESCRIPTION
## Repro
A focused session test reproduces the reported spiral: a model emits six `read` calls in one tool-use turn, and without the guard all six execute before another model turn. Command: `bun test packages/coding-agent/test/agent-session-read-spiral-guard.test.ts`.

## Cause
`packages/coding-agent/src/session/agent-session.ts` only handled context maintenance after completed agent turns and did not limit repeated `read` calls inside a tool loop; `packages/agent/src/agent-loop.ts` therefore executed every read in the assistant message and continued with unrestricted tools on the next LLM call.

## Fix
- Added `InvestigationGuard` in `packages/coding-agent/src/session/investigation-guard.ts` to track per-prompt read-call and read-output token budgets.
- Wired the guard into `AgentSession` before/after tool hooks so excessive reads are blocked and the next model call is forced with `toolChoice: "none"`.
- Added configurable `investigationGuard.*` settings and a regression test for the repeated-read spiral.
- Added a coding-agent changelog entry for #2234.

## Verification
- `bun test packages/coding-agent/test/agent-session-read-spiral-guard.test.ts` — passed.
- `bun test packages/coding-agent/test/agent-session-force-tool-choice.test.ts` — passed.
- `bun --cwd=packages/coding-agent run check` — passed.

Fixes #2234