### PR TITLE
fix(coding-agent): handle legacy plugin config settings

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -52,6 +52,7 @@
 
 ### Fixed
 
+- Fixed plugin config writes against older `omp-plugins.lock.json` files that did not have a top-level `settings` object, which crashed `omp plugin config set` before persisting the option ([#2236](https://github.com/can1357/oh-my-pi/issues/2236)).
 - Fixed `ask` question/result renders so option and answer rows are no longer duplicated when the component is re-rendered
 - Fixed streaming `write`/`diff` previews to keep line-number gutter widths stable while content grows, preventing already-rendered preview rows from being reflowed mid-stream
 - Fixed the welcome screen showing "No LSP servers" when `lsp.lazy` is enabled: recognized servers are now still discovered at startup and listed with a dim "available" dot (no warmup), and `/status` reports them as `available` instead of omitting the section

--- a/packages/coding-agent/src/extensibility/plugins/loader.ts
+++ b/packages/coding-agent/src/extensibility/plugins/loader.ts
@@ -9,6 +9,7 @@ import * as path from "node:path";
 import { getPluginsLockfile, getPluginsNodeModules, getPluginsPackageJson, isEnoent } from "@oh-my-pi/pi-utils";
 import { getConfigDirPaths } from "../../config";
 import { installLegacyPiSpecifierShim } from "./legacy-pi-compat";
+import { normalizePluginRuntimeConfig } from "./runtime-config";
 import type { InstalledPlugin, PluginManifest, PluginRuntimeConfig, ProjectPluginOverrides } from "./types";
 
 installLegacyPiSpecifierShim();
@@ -28,9 +29,9 @@ installLegacyPiSpecifierShim();
 async function loadRuntimeConfig(home?: string): Promise<PluginRuntimeConfig> {
 	const lockPath = getPluginsLockfile(home);
 	try {
-		return await Bun.file(lockPath).json();
+		return normalizePluginRuntimeConfig(await Bun.file(lockPath).json());
 	} catch (err) {
-		if (isEnoent(err)) return { plugins: {}, settings: {} };
+		if (isEnoent(err)) return normalizePluginRuntimeConfig({});
 		throw err;
 	}
 }

--- a/packages/coding-agent/src/extensibility/plugins/manager.ts
+++ b/packages/coding-agent/src/extensibility/plugins/manager.ts
@@ -12,6 +12,7 @@ import {
 } from "@oh-my-pi/pi-utils";
 import { type GitSource, parseGitUrl } from "./git-url";
 import { extractPackageName, parsePluginSpec } from "./parser";
+import { normalizePluginRuntimeConfig } from "./runtime-config";
 import type {
 	DoctorCheck,
 	DoctorOptions,
@@ -93,11 +94,11 @@ export class PluginManager {
 	async #loadRuntimeConfig(): Promise<PluginRuntimeConfig> {
 		const lockPath = getPluginsLockfile();
 		try {
-			return await Bun.file(lockPath).json();
+			return normalizePluginRuntimeConfig(await Bun.file(lockPath).json());
 		} catch (err) {
-			if (isEnoent(err)) return { plugins: {}, settings: {} };
+			if (isEnoent(err)) return normalizePluginRuntimeConfig({});
 			logger.warn("Failed to load plugin runtime config", { path: lockPath, error: String(err) });
-			return { plugins: {}, settings: {} };
+			return normalizePluginRuntimeConfig({});
 		}
 	}
 

--- a/packages/coding-agent/src/extensibility/plugins/runtime-config.ts
+++ b/packages/coding-agent/src/extensibility/plugins/runtime-config.ts
@@ -1,0 +1,9 @@
+import type { PluginRuntimeConfig } from "./types";
+
+/** Normalizes persisted plugin runtime config across legacy lockfile shapes. */
+export function normalizePluginRuntimeConfig(config: Partial<PluginRuntimeConfig>): PluginRuntimeConfig {
+	return {
+		plugins: config.plugins ?? {},
+		settings: config.settings ?? {},
+	};
+}

--- a/packages/coding-agent/test/plugin-config.test.ts
+++ b/packages/coding-agent/test/plugin-config.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { PluginManager } from "@oh-my-pi/pi-coding-agent/extensibility/plugins/manager";
+import * as piUtils from "@oh-my-pi/pi-utils";
+
+describe("plugin config", () => {
+	let tmpRoot: string;
+	let pluginsDir: string;
+	let lockfile: string;
+
+	beforeEach(async () => {
+		tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-plugin-config-"));
+		pluginsDir = path.join(tmpRoot, "plugins");
+		lockfile = path.join(pluginsDir, "omp-plugins.lock.json");
+
+		spyOn(piUtils, "getPluginsDir").mockReturnValue(pluginsDir);
+		spyOn(piUtils, "getPluginsLockfile").mockReturnValue(lockfile);
+		spyOn(piUtils, "getProjectDir").mockReturnValue(tmpRoot);
+		spyOn(piUtils, "getProjectPluginOverridesPath").mockReturnValue(path.join(tmpRoot, "plugin-overrides.json"));
+	});
+
+	afterEach(async () => {
+		mock.restore();
+		await fs.rm(tmpRoot, { recursive: true, force: true });
+	});
+
+	async function writeLegacyLockfile(pluginName: string): Promise<void> {
+		await Bun.write(
+			lockfile,
+			JSON.stringify({
+				plugins: {
+					[pluginName]: { version: "0.2.2", enabledFeatures: null, enabled: true },
+				},
+			}),
+		);
+	}
+
+	test("set initializes missing settings in legacy runtime config", async () => {
+		const pluginName = "@gaodes/pi-graphify";
+		await writeLegacyLockfile(pluginName);
+
+		await new PluginManager(tmpRoot).setPluginSetting(pluginName, "autoContext.enabled", true);
+
+		const lock = await Bun.file(lockfile).json();
+		expect(lock.settings[pluginName]).toEqual({ "autoContext.enabled": true });
+		expect(lock.plugins[pluginName]).toEqual({ version: "0.2.2", enabledFeatures: null, enabled: true });
+	});
+
+	test("list treats missing settings in legacy runtime config as empty", async () => {
+		const pluginName = "@gaodes/pi-graphify";
+		await writeLegacyLockfile(pluginName);
+
+		await expect(new PluginManager(tmpRoot).getPluginSettings(pluginName)).resolves.toEqual({});
+	});
+});


### PR DESCRIPTION
## Repro
A legacy plugin lockfile containing `plugins` but no top-level `settings` crashes when setting an option. Reproduced with `tmp=$(mktemp -d); HOME="$tmp" bun -e 'import { mkdir } from "node:fs/promises"; import { getPluginsDir, getPluginsLockfile } from "@oh-my-pi/pi-utils"; import { PluginManager } from "./packages/coding-agent/src/extensibility/plugins/manager.ts"; await mkdir(getPluginsDir(), { recursive: true }); await Bun.write(getPluginsLockfile(), JSON.stringify({ plugins: { "@gaodes/pi-graphify": { version: "0.2.2", enabledFeatures: null, enabled: true } } }, null, 2)); await new PluginManager(process.cwd()).setPluginSetting("@gaodes/pi-graphify", "autoContext.enabled", true);'`, which threw `TypeError: undefined is not an object (evaluating 'config.settings[name]')` before the fix.

## Cause
`packages/coding-agent/src/extensibility/plugins/manager.ts` and `loader.ts` trusted the persisted `omp-plugins.lock.json` shape to already match `PluginRuntimeConfig`. Older lockfiles can contain `plugins` without `settings`, so `PluginManager.setPluginSetting()` dereferenced `config.settings[name]` before initializing the top-level settings record.

## Fix
- Added `normalizePluginRuntimeConfig()` to normalize missing `plugins`/`settings` records after reading persisted plugin runtime config.
- Used the normalizer in both plugin runtime config readers (`manager.ts` and `loader.ts`).
- Added a regression test proving `setPluginSetting()` initializes `settings` and preserves the existing plugin state for a legacy lockfile.
- Added a coding-agent changelog entry for #2236.

## Verification
`bun test packages/coding-agent/test/plugin-config.test.ts` passed. `bun --cwd=packages/coding-agent run check` passed. Re-ran the original `bun -e` repro and observed the lockfile persisted `settings["@gaodes/pi-graphify"].autoContext.enabled = true`. Fixes #2236