### PR TITLE
fix(memory): scope project memory by repo identity

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -9,6 +9,8 @@ memory:
   backend: local
 ```
 
+Project-scoped memory uses a stable project identity. Set `memory.projectKey` for an explicit cross-worktree key such as `github.com/org/repo`; otherwise OMP derives identity from the git remote, then git common-dir, and only falls back to cwd outside git.
+
 ## Usage
 
 ### What gets injected
@@ -82,6 +84,7 @@ If the requested memory role is not configured, memory model resolution falls ba
 | Setting                               | Default | Description                                                                                                                              |
 | ------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | `memory.backend`                      | `off`   | Select `local` for this pipeline; legacy `memories.enabled: true` is migrated to `memory.backend: local` when no explicit backend is set |
+| `memory.projectKey`                   | —       | Optional stable project identity shared across worktrees, e.g. `github.com/org/repo`; falls back to git remote, git common-dir, then cwd |
 | `memories.maxRolloutAgeDays`          | `30`    | Sessions older than this are not processed                                                                                               |
 | `memories.minRolloutIdleHours`        | `12`    | Sessions active more recently than this are skipped                                                                                      |
 | `memories.maxRolloutsPerStartup`      | `64`    | Cap on sessions processed in a single startup                                                                                            |

--- a/docs/tools/recall.md
+++ b/docs/tools/recall.md
@@ -60,8 +60,8 @@ When no matches exist:
 - Backend auto-recall has a richer query-composition path in `HindsightSessionState.beforeAgentStartPrompt(...)` / `maybeRecallOnAgentStart(...)` and `MnemopiSessionState.beforeAgentStartPrompt(...)` / `maybeRecallOnAgentStart(...)`.
 - Hindsight bank scoping:
   - `global` — no tag filter.
-  - `per-project` — separate bank id per cwd basename.
-  - `per-project-tagged` — shared bank id plus `project:<cwd basename>` filter with `tagsMatch = "any"`, so project-tagged and untagged global memories can both surface.
+  - `per-project` — separate bank id per memory project identity.
+  - `per-project-tagged` — shared bank id plus `project:<key>` filter with `tagsMatch = "any"`, so project-tagged and untagged global memories can both surface.
 - Mnemopi bank scoping:
   - `global` — recall reads the shared bank.
   - `per-project` — recall reads the project bank.

--- a/docs/tools/reflect.md
+++ b/docs/tools/reflect.md
@@ -57,8 +57,8 @@ Mnemopi:
 - Mnemopi tool path: one local scoped recall followed by context formatting.
 - Hindsight bank scoping:
   - `global` — no tag filter.
-  - `per-project` — separate bank id per cwd basename.
-  - `per-project-tagged` — shared bank id plus `project:<cwd basename>` filter with `tagsMatch = "any"`.
+  - `per-project` — separate bank id per memory project identity.
+  - `per-project-tagged` — shared bank id plus `project:<key>` filter with `tagsMatch = "any"`.
 - Mnemopi bank scoping:
   - `global` — reads the shared bank.
   - `per-project` — reads the project bank.

--- a/docs/tools/retain.md
+++ b/docs/tools/retain.md
@@ -59,8 +59,8 @@ Mnemopi:
 - Mnemopi tool path: direct local `remember(...)` into the scoped retain bank.
 - Hindsight bank scoping from `computeBankScope(...)`:
   - `global` — one shared bank, no project tags.
-  - `per-project` — bank id gets `-<cwd basename>` appended.
-  - `per-project-tagged` — shared bank plus `project:<cwd basename>` tags on retained memories.
+  - `per-project` — bank id gets `-<project-segment>` appended.
+  - `per-project-tagged` — shared bank plus `project:<key>` tags on retained memories.
 - Mnemopi bank scoping from `resolveBankScope(...)`:
   - `global` — retain and recall use the shared bank.
   - `per-project` — retain and recall use the project bank.

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -97,8 +97,9 @@ export function resolveModelThinking<TApi extends Api>(
 ): ThinkingConfig | undefined {
 	if (!spec.reasoning) return undefined;
 	if (omitsWireReasoningEffort(spec.api, compat)) return undefined;
-	if (spec.thinking && spec.thinking.efforts.length > 0) {
-		return fillThinkingWireDefaults(spec, spec.thinking);
+	const thinking = spec.thinking;
+	if (thinking?.mode && Array.isArray(thinking.efforts) && thinking.efforts.length > 0) {
+		return fillThinkingWireDefaults(spec, thinking);
 	}
 	// Empty/malformed explicit metadata is treated as absent — infer instead.
 	return deriveThinking(spec, compat);

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -184,6 +184,20 @@ describe("model thinking derivation", () => {
 		expect(pinned.thinking?.supportsDisplay).toBe(false);
 	});
 
+	it("infers thinking when explicit metadata is malformed", () => {
+		const model = createModel({
+			id: "gpt-5.2",
+			api: "openai-responses",
+			provider: "openai",
+			thinking: { mode: "effort" } as ModelSpec<"openai-responses">["thinking"],
+		});
+
+		expect(model.thinking).toEqual({
+			mode: "effort",
+			efforts: [Effort.Low, Effort.Medium, Effort.High, Effort.XHigh],
+		});
+	});
+
 	it("bakes sampling-param rejection into anthropic compat", () => {
 		const sonnet45 = createModel({ id: "claude-sonnet-4-5", api: "anthropic-messages", provider: "anthropic" });
 		const opus47 = createModel({ id: "claude-opus-4.7", api: "anthropic-messages", provider: "anthropic" });

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -153,6 +153,9 @@
 
 - Removed the `clearOnShrink` setting and its `PI_CLEAR_ON_SHRINK` environment variable: the rewritten renderer always clears shrunken rows exactly, so the flicker/perf tradeoff the setting controlled no longer exists. Existing config entries are ignored.
 - Removed the prompt-submit native-scrollback reconciliation checkpoint and the eager streaming render mode from the interactive controllers — the renderer's append-only contract made both obsolete.
+### Fixed
+
+- Fixed memory project scoping so Hindsight, Mnemopi, and local memory derive project identity from `memory.projectKey`, git remote, or git common-dir instead of cwd/worktree path.
 
 ## [15.10.9] - 2026-06-09
 

--- a/packages/coding-agent/README.md
+++ b/packages/coding-agent/README.md
@@ -22,13 +22,15 @@ The agent supports three mutually-exclusive memory backends, selected via the `m
 - `local` — existing rollout-summarisation pipeline; writes `memory_summary.md` and consolidated artifacts under the agent dir.
 - `hindsight` — talks to a [Hindsight](https://hindsight.vectorize.io) server (Cloud or self-hosted Docker), retains transcripts every Nth user turn, recalls memories on the first turn of a session, and exposes `retain`, `recall`, and `reflect`.
 
+All project-scoped backends derive memory identity from `memory.projectKey` when set, then git remote, git common-dir, and cwd. This keeps linked git worktrees of the same repository on one memory scope.
+
 ### Hindsight quickstart
 
 1. Run a Hindsight server (Cloud or `docker run -p 8888:8888 ghcr.io/vectorize-io/hindsight:latest`).
 2. Set `memory.backend = "hindsight"` and `hindsight.apiUrl = "http://localhost:8888"` (or your Cloud URL).
 3. Optional environment overrides (env wins over settings):
    - `HINDSIGHT_API_URL`, `HINDSIGHT_API_TOKEN` — connection
-   - `HINDSIGHT_BANK_ID`, `HINDSIGHT_DYNAMIC_BANK_ID`, `HINDSIGHT_AGENT_NAME` — bank addressing
+   - `HINDSIGHT_BANK_ID`, `OMP_PROJECT_KEY` / `HINDSIGHT_PROJECT_KEY` — bank and project addressing
    - `HINDSIGHT_AUTO_RECALL`, `HINDSIGHT_AUTO_RETAIN`, `HINDSIGHT_RETAIN_MODE` — lifecycle
    - `HINDSIGHT_RECALL_BUDGET`, `HINDSIGHT_RECALL_MAX_TOKENS` — recall sizing
    - `HINDSIGHT_BANK_MISSION`, `HINDSIGHT_DEBUG`

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1398,6 +1398,17 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"memory.projectKey": {
+		type: "string",
+		default: undefined,
+		ui: {
+			tab: "memory",
+			label: "Memory Project Key",
+			description:
+				"Optional stable project identity shared across worktrees, e.g. github.com/org/repo. Falls back to git remote, git common-dir, then cwd.",
+		},
+	},
+
 	// Mnemopi local SQLite memory backend.
 	"mnemopi.dbPath": {
 		type: "string",
@@ -1427,7 +1438,7 @@ export const SETTINGS_SCHEMA = {
 			tab: "memory",
 			label: "Mnemopi Scoping",
 			description:
-				"global = one shared bank; per-project = isolated bank per cwd; per-project-tagged = project-local writes plus global recall visibility",
+				"global = one shared bank; per-project = isolated bank per memory project identity; per-project-tagged = project-local writes plus global recall visibility",
 			options: [
 				{
 					value: "global",
@@ -1437,7 +1448,7 @@ export const SETTINGS_SCHEMA = {
 				{
 					value: "per-project",
 					label: "Per project",
-					description: "Project-local Mnemopi bank per cwd basename",
+					description: "Project-local Mnemopi bank per memory project identity",
 				},
 				{
 					value: "per-project-tagged",
@@ -1595,7 +1606,7 @@ export const SETTINGS_SCHEMA = {
 			tab: "memory",
 			label: "Hindsight Scoping",
 			description:
-				"global = one shared bank; per-project = isolated bank per cwd; per-project-tagged = shared bank with project tags so global + project memories merge on recall",
+				"global = one shared bank; per-project = isolated bank per memory project identity; per-project-tagged = shared bank with project tags so global + project memories merge on recall",
 			options: [
 				{
 					value: "global",
@@ -1605,13 +1616,13 @@ export const SETTINGS_SCHEMA = {
 				{
 					value: "per-project",
 					label: "Per project",
-					description: "Isolated bank per cwd basename — projects cannot see each other's memories",
+					description: "Isolated bank per memory project identity — projects cannot see each other's memories",
 				},
 				{
 					value: "per-project-tagged",
 					label: "Per project (tagged)",
 					description:
-						"Shared bank, retains tagged with project:<cwd>. Recall surfaces project + untagged global memories together",
+						"Shared bank, retains tagged with project:<key>. Recall surfaces project + untagged global memories together",
 				},
 			],
 			condition: "hindsightActive",

--- a/packages/coding-agent/src/hindsight/bank.ts
+++ b/packages/coding-agent/src/hindsight/bank.ts
@@ -3,8 +3,8 @@
  *
  * Three scoping modes (`HindsightConfig.scoping`):
  *   - `global`              — single shared bank, no per-project filter.
- *   - `per-project`         — one bank per cwd basename, hard isolation.
- *   - `per-project-tagged`  — single shared bank, retains carry a `project:<name>`
+ *   - `per-project`         — one bank per memory project identity, hard isolation.
+ *   - `per-project-tagged`  — single shared bank, retains carry a `project:<key>`
  *                              tag and recall filters on it but still surfaces
  *                              untagged ("global") memories alongside.
  *
@@ -20,15 +20,13 @@
  * lands against a missing bank.
  */
 
-import * as path from "node:path";
 import { logger } from "@oh-my-pi/pi-utils";
-import * as git from "../utils/git";
+import { resolveMemoryProjectIdentity } from "../memory-project-identity";
 import type { HindsightApi } from "./client";
 import type { HindsightConfig } from "./config";
 
 const DEFAULT_BANK_NAME = "omp";
 const PROJECT_TAG_PREFIX = "project:";
-const UNKNOWN_PROJECT = "unknown";
 const MISSION_SET_CAP = 10_000;
 
 export type RecallTagsMatch = "any" | "all" | "any_strict" | "all_strict";
@@ -54,24 +52,9 @@ function baseBankId(config: HindsightConfig): string {
 	return prefix ? `${prefix}-${base}` : base;
 }
 
-/**
- * Best-effort project label from a working-directory path.
- *
- * When `directory` lives inside a git repository we resolve the primary
- * checkout root (or the shared common dir for bare-repo worktrees) via
- * {@link git.repo.primaryRootSync} and basename that, so every linked
- * worktree of one repo shares the same `project:<name>` tag.
- * Outside a repo (or when resolution fails), fall back to the cwd basename.
- *
- * Sync only: this runs on the hot path of `computeBankScope`, which is
- * exposed as a sync API to callers like `backend.ts` and must stay sync.
- * `git.repo.primaryRootSync` walks `.git`/`commondir` with sync file reads —
- * no subprocess — so the cost is one or two `stat`s and a small `readFile`.
- */
-function projectLabel(directory: string): string {
-	if (!directory) return UNKNOWN_PROJECT;
-	const primary = git.repo.primaryRootSync(directory);
-	return path.basename(primary ?? directory) || UNKNOWN_PROJECT;
+/** Best-effort project identity from explicit config, git repository, then cwd. */
+function projectIdentity(config: HindsightConfig, directory: string) {
+	return resolveMemoryProjectIdentity(directory, config.projectKey);
 }
 
 /**
@@ -85,10 +68,13 @@ export function computeBankScope(config: HindsightConfig, directory: string): Ba
 	switch (config.scoping) {
 		case "global":
 			return { bankId: base };
-		case "per-project":
-			return { bankId: `${base}-${projectLabel(directory)}` };
+		case "per-project": {
+			const identity = projectIdentity(config, directory);
+			return { bankId: `${base}-${identity.segment}` };
+		}
 		case "per-project-tagged": {
-			const tag = `${PROJECT_TAG_PREFIX}${projectLabel(directory)}`;
+			const identity = projectIdentity(config, directory);
+			const tag = `${PROJECT_TAG_PREFIX}${identity.key}`;
 			return {
 				bankId: base,
 				retainTags: [tag],

--- a/packages/coding-agent/src/hindsight/config.ts
+++ b/packages/coding-agent/src/hindsight/config.ts
@@ -22,6 +22,7 @@ export interface HindsightConfig {
 	bankId: string | null;
 	bankIdPrefix: string;
 	scoping: HindsightScoping;
+	projectKey: string | null;
 	bankMission: string;
 	retainMission: string | null;
 
@@ -104,6 +105,7 @@ export function loadHindsightConfig(settings: Settings, env: NodeJS.ProcessEnv =
 	const apiUrlEnv = envString(env.HINDSIGHT_API_URL);
 	const apiTokenEnv = envString(env.HINDSIGHT_API_TOKEN);
 	const bankIdEnv = envString(env.HINDSIGHT_BANK_ID);
+	const projectKeyEnv = envString(env.OMP_PROJECT_KEY) ?? envString(env.HINDSIGHT_PROJECT_KEY);
 	const bankMissionEnv = envString(env.HINDSIGHT_BANK_MISSION);
 	const retainModeEnv = pickRetainMode(env.HINDSIGHT_RETAIN_MODE);
 	const recallBudgetEnv = pickBudget(env.HINDSIGHT_RECALL_BUDGET);
@@ -138,6 +140,7 @@ export function loadHindsightConfig(settings: Settings, env: NodeJS.ProcessEnv =
 		bankId: bankIdEnv ?? settings.get("hindsight.bankId") ?? null,
 		bankIdPrefix: settings.get("hindsight.bankIdPrefix") ?? "",
 		scoping: scopingEnv ?? settingsScoping ?? "per-project-tagged",
+		projectKey: projectKeyEnv ?? settings.get("memory.projectKey") ?? null,
 		bankMission: bankMissionEnv ?? settings.get("hindsight.bankMission") ?? "",
 		retainMission: settings.get("hindsight.retainMission") ?? null,
 

--- a/packages/coding-agent/src/hindsight/mental-models.ts
+++ b/packages/coding-agent/src/hindsight/mental-models.ts
@@ -22,11 +22,11 @@
  * write at retain time will refresh empty. Therefore seed tags MUST be a
  * subset of the tags actually attached by `retainSession` / `enqueueRetain`
  * for the active scoping mode. In `per-project-tagged` we only carry
- * `project:<cwd>`; do not invent new tag axes here without first wiring the
+ * `project:<key>`; do not invent new tag axes here without first wiring the
  * retain side to emit them.
  *
  * Seed tags are baked from `seeds.json` plus, for `projectTagged: true`
- * entries, the active scope's `retainTags` (i.e. `project:<cwd>`). In
+ * entries, the active scope's `retainTags` (i.e. `project:<key>`). In
  * `per-project-tagged`, those project seeds also get project-suffixed ids so
  * each tag can own its conventions/decisions models in the shared bank.
  * Untagged seeds (e.g. `user-preferences`) read every memory in the bank — the

--- a/packages/coding-agent/src/internal-urls/memory-protocol.ts
+++ b/packages/coding-agent/src/internal-urls/memory-protocol.ts
@@ -11,8 +11,8 @@ const MEMORY_NAMESPACE = "root";
 
 /**
  * Snapshot of memory roots for every registered session, deduped.
- * Each session has its own cwd (possibly a worktree), so subagents and main
- * may see different roots.
+ * Linked worktrees of the same repository resolve to the same memory project
+ * root unless an explicit `memory.projectKey` overrides that identity.
  */
 export function memoryRootsFromRegistry(): string[] {
 	const agentDir = getAgentDir();
@@ -20,7 +20,7 @@ export function memoryRootsFromRegistry(): string[] {
 	for (const ref of AgentRegistry.global().list()) {
 		const sm = ref.session?.sessionManager;
 		if (!sm) continue;
-		const root = getMemoryRoot(agentDir, sm.getCwd());
+		const root = getMemoryRoot(agentDir, sm.getCwd(), ref.session?.settings.get("memory.projectKey"));
 		if (root && !roots.includes(root)) roots.push(root);
 	}
 	return roots;
@@ -123,9 +123,8 @@ async function tryResolveInRoot(url: InternalUrl, memoryRoot: string): Promise<I
 /**
  * Protocol handler for memory:// URLs.
  *
- * Walks every active session's memory root. Worktree-based subagents have
- * their own root; first one containing the file wins. Parent and subagent
- * sharing a cwd see the same file regardless of order.
+ * Walks every active session's memory root. Linked worktrees of the same
+ * repository normally share a root; first one containing the file wins.
  */
 export class MemoryProtocolHandler implements ProtocolHandler {
 	readonly scheme = "memory";

--- a/packages/coding-agent/src/memories/index.ts
+++ b/packages/coding-agent/src/memories/index.ts
@@ -10,6 +10,7 @@ import { getAgentDbPath, getMemoriesDir, logger, parseJsonlLenient, prompt } fro
 import type { ModelRegistry } from "../config/model-registry";
 import { getModelMatchPreferences, resolveModelRoleValue } from "../config/model-resolver";
 import type { Settings } from "../config/settings";
+import { resolveMemoryProjectIdentity } from "../memory-project-identity";
 import consolidationTemplate from "../prompts/memories/consolidation.md" with { type: "text" };
 import readPathTemplate from "../prompts/memories/read-path.md" with { type: "text" };
 import stageOneInputTemplate from "../prompts/memories/stage_one_input.md" with { type: "text" };
@@ -154,7 +155,7 @@ export async function buildMemoryToolDeveloperInstructions(
 ): Promise<string | undefined> {
 	const cfg = loadMemoryConfig(settings);
 	if (!cfg.enabled) return undefined;
-	const memoryRoot = getMemoryRoot(agentDir, settings.getCwd());
+	const memoryRoot = getMemoryRoot(agentDir, settings.getCwd(), settings.get("memory.projectKey"));
 	const summaryPath = path.join(memoryRoot, "memory_summary.md");
 
 	let text: string;
@@ -177,20 +178,25 @@ export async function buildMemoryToolDeveloperInstructions(
 /**
  * Clear all persisted memory state and generated artifacts.
  */
-export async function clearMemoryData(agentDir: string, cwd: string): Promise<void> {
+export async function clearMemoryData(agentDir: string, cwd: string, projectKey?: string): Promise<void> {
 	const db = openMemoryDb(getAgentDbPath(agentDir));
 	try {
 		clearMemoryDataInDb(db);
 	} finally {
 		closeMemoryDb(db);
 	}
-	await fs.rm(getMemoryRoot(agentDir, cwd), { recursive: true, force: true });
+	await fs.rm(getMemoryRoot(agentDir, cwd, projectKey), { recursive: true, force: true });
 }
 
 /**
  * Force-enqueue global consolidation maintenance work.
  */
-export function enqueueMemoryConsolidation(agentDir: string, cwd: string, sourceUpdatedAt = unixNow()): void {
+export function enqueueMemoryConsolidation(
+	agentDir: string,
+	cwd: string,
+	sourceUpdatedAt = unixNow(),
+	_projectKey?: string,
+): void {
 	const db = openMemoryDb(getAgentDbPath(agentDir));
 	try {
 		enqueueGlobalWatermark(db, sourceUpdatedAt, cwd, { forceDirtyWhenNotAdvanced: true });
@@ -222,7 +228,11 @@ async function runPhase1(options: {
 	const db = openMemoryDb(getAgentDbPath(agentDir));
 	const nowSec = unixNow();
 	const workerId = `memory-${process.pid}`;
-	const memoryRoot = getMemoryRoot(agentDir, session.sessionManager.getCwd());
+	const memoryRoot = getMemoryRoot(
+		agentDir,
+		session.sessionManager.getCwd(),
+		options.settings.get("memory.projectKey"),
+	);
 	const currentThreadId = session.sessionManager.getSessionId();
 
 	try {
@@ -359,7 +369,7 @@ async function runPhase2(options: {
 	const db = openMemoryDb(getAgentDbPath(agentDir));
 	const nowSec = unixNow();
 	const workerId = `memory-${process.pid}`;
-	const memoryRoot = getMemoryRoot(agentDir, cwd);
+	const memoryRoot = getMemoryRoot(agentDir, cwd, options.settings.get("memory.projectKey"));
 
 	try {
 		const claimResult = tryClaimGlobalPhase2Job(db, {
@@ -1121,12 +1131,8 @@ function loadMemoryConfig(settings: Settings): MemoryRuntimeConfig {
 	};
 }
 
-export function getMemoryRoot(agentDir: string, cwd: string): string {
-	return path.join(getMemoriesDir(agentDir), encodeProjectPath(cwd));
-}
-
-function encodeProjectPath(cwd: string): string {
-	return `--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
+export function getMemoryRoot(agentDir: string, cwd: string, projectKey?: string): string {
+	return path.join(getMemoriesDir(agentDir), `--${resolveMemoryProjectIdentity(cwd, projectKey).segment}--`);
 }
 
 function unixNow(): number {

--- a/packages/coding-agent/src/memories/storage.ts
+++ b/packages/coding-agent/src/memories/storage.ts
@@ -1,4 +1,5 @@
 import { Database } from "bun:sqlite";
+import { resolveMemoryProjectIdentity } from "../memory-project-identity";
 
 export interface MemoryThread {
 	id: string;
@@ -37,11 +38,11 @@ const GLOBAL_KIND = "memory_consolidate_global";
 const DEFAULT_RETRY_REMAINING = 3;
 
 /**
- * Per-project job key so Phase 2 consolidation is isolated to a single cwd.
- * Previously a single "global" key caused cross-project memory contamination.
+ * Per-project job key keyed by stable memory project identity, not by cwd.
+ * Linked git worktrees therefore share one local-memory consolidation lane.
  */
 function globalJobKey(cwd: string): string {
-	return `global:${cwd}`;
+	return `global:${resolveMemoryProjectIdentity(cwd).segment}`;
 }
 
 export function openMemoryDb(dbPath: string): Database {
@@ -486,21 +487,19 @@ WHERE kind = ? AND job_key = ? AND status = 'running' AND ownership_token = ?
 	return Number(result.changes ?? 0) > 0;
 }
 
-// Filter by cwd so each project only consolidates its own thread outputs.
-// Before this filter existed, whichever project ran Phase 2 first got every
-// project's data written into its memory directory (see #369).
+// Filter by stable memory project identity so linked worktrees of the same
+// repository consolidate together without reintroducing cross-project leakage.
 export function listStage1OutputsForGlobal(db: Database, limit: number, cwd: string): Stage1OutputRow[] {
+	const projectSegment = resolveMemoryProjectIdentity(cwd).segment;
 	const rows = db
 		.prepare(`
 SELECT o.thread_id, o.source_updated_at, o.raw_memory, o.rollout_summary, o.rollout_slug, o.generated_at, t.cwd
 FROM stage1_outputs o
 LEFT JOIN threads t ON t.id = o.thread_id
 WHERE (TRIM(COALESCE(o.raw_memory, '')) != '' OR TRIM(COALESCE(o.rollout_summary, '')) != '')
-  AND t.cwd = ?
 ORDER BY o.source_updated_at DESC
-LIMIT ?
 `)
-		.all(cwd, limit) as Array<{
+		.all() as Array<{
 		thread_id: string;
 		source_updated_at: number;
 		raw_memory: string;
@@ -509,15 +508,18 @@ LIMIT ?
 		generated_at: number;
 		cwd: string | null;
 	}>;
-	return rows.map(row => ({
-		threadId: row.thread_id,
-		sourceUpdatedAt: row.source_updated_at,
-		rawMemory: row.raw_memory,
-		rolloutSummary: row.rollout_summary,
-		rolloutSlug: row.rollout_slug,
-		generatedAt: row.generated_at,
-		cwd: row.cwd ?? "",
-	}));
+	return rows
+		.filter(row => resolveMemoryProjectIdentity(row.cwd ?? "").segment === projectSegment)
+		.slice(0, limit)
+		.map(row => ({
+			threadId: row.thread_id,
+			sourceUpdatedAt: row.source_updated_at,
+			rawMemory: row.raw_memory,
+			rolloutSummary: row.rollout_summary,
+			rolloutSlug: row.rollout_slug,
+			generatedAt: row.generated_at,
+			cwd: row.cwd ?? "",
+		}));
 }
 
 export function markGlobalPhase2Succeeded(

--- a/packages/coding-agent/src/memory-backend/local-backend.ts
+++ b/packages/coding-agent/src/memory-backend/local-backend.ts
@@ -9,9 +9,8 @@ import type { MemoryBackend } from "./types";
 /**
  * Wraps the existing `memories/` module as a `MemoryBackend`.
  *
- * No behavioural change — every call delegates to the legacy entry points so
- * the local memory pipeline (rollout summarisation → SQLite → memory_summary.md)
- * keeps working exactly as before.
+ * Delegates to the legacy entry points while sharing local memory by stable
+ * memory project identity instead of cwd/worktree path.
  */
 export const localBackend: MemoryBackend = {
 	id: "local",
@@ -21,11 +20,11 @@ export const localBackend: MemoryBackend = {
 	async buildDeveloperInstructions(agentDir, settings) {
 		return buildMemoryToolDeveloperInstructions(agentDir, settings);
 	},
-	async clear(agentDir, cwd) {
-		await clearMemoryData(agentDir, cwd);
+	async clear(agentDir, cwd, session) {
+		await clearMemoryData(agentDir, cwd, session?.settings.get("memory.projectKey"));
 	},
-	async enqueue(agentDir, cwd) {
-		enqueueMemoryConsolidation(agentDir, cwd);
+	async enqueue(agentDir, cwd, session) {
+		enqueueMemoryConsolidation(agentDir, cwd, undefined, session?.settings.get("memory.projectKey"));
 	},
 	async status() {
 		return {

--- a/packages/coding-agent/src/memory-project-identity.test.ts
+++ b/packages/coding-agent/src/memory-project-identity.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { computeBankScope } from "./hindsight/bank";
+import type { HindsightConfig } from "./hindsight/config";
+import { getMemoryRoot } from "./memories";
+import { closeMemoryDb, listStage1OutputsForGlobal, openMemoryDb } from "./memories/storage";
+import { resolveMemoryProjectIdentity } from "./memory-project-identity";
+
+const baseHindsightConfig: HindsightConfig = {
+	hindsightApiUrl: null,
+	hindsightApiToken: null,
+	bankId: "omp",
+	bankIdPrefix: "",
+	scoping: "per-project-tagged",
+	projectKey: null,
+	bankMission: "",
+	retainMission: null,
+	autoRecall: true,
+	autoRetain: true,
+	retainMode: "full-session",
+	retainEveryNTurns: 0,
+	retainOverlapTurns: 0,
+	retainContext: "omp",
+	recallBudget: "mid",
+	recallMaxTokens: 1000,
+	recallTypes: [],
+	recallContextTurns: 0,
+	recallMaxQueryChars: 1000,
+	recallPromptPreamble: "",
+	debug: false,
+	mentalModelsEnabled: false,
+	mentalModelAutoSeed: false,
+	mentalModelRefreshIntervalMs: 0,
+	mentalModelMaxRenderChars: 0,
+};
+
+function withTempRepo<T>(fn: (paths: { root: string; main: string; linked: string; other: string }) => T): T {
+	const root = mkdtempSync(join(tmpdir(), "omp-memory-identity-"));
+	try {
+		const main = join(root, "repo-main");
+		const linked = join(root, "repo-feature-worktree");
+		const other = join(root, "other-repo");
+		const mainGit = join(main, ".git");
+		const linkedGitDir = join(mainGit, "worktrees", "repo-feature-worktree");
+		mkdirSync(linkedGitDir, { recursive: true });
+		mkdirSync(linked, { recursive: true });
+		mkdirSync(join(other, ".git"), { recursive: true });
+		writeFileSync(join(linked, ".git"), `gitdir: ${linkedGitDir}\n`);
+		writeFileSync(join(linkedGitDir, "commondir"), "../..\n");
+		writeFileSync(join(linkedGitDir, "HEAD"), "ref: refs/heads/feature\n");
+		return fn({ root, main, linked, other });
+	} finally {
+		rmSync(root, { recursive: true, force: true });
+	}
+}
+
+describe("memory project identity", () => {
+	it("uses an explicit project key across tags, banks, and path segments", () => {
+		const identity = resolveMemoryProjectIdentity("/tmp/any-worktree", " github.com/Org/Repo.git ");
+
+		expect(identity.key).toBe("github.com/org/repo");
+		expect(identity.segment).toBe("github-com-org-repo");
+		expect(identity.source).toBe("explicit");
+
+		const scope = computeBankScope(
+			{ ...baseHindsightConfig, projectKey: "github.com/Org/Repo.git" },
+			"/tmp/any-worktree",
+		);
+		expect(scope.bankId).toBe("omp");
+		expect(scope.retainTags).toEqual(["project:github.com/org/repo"]);
+		expect(scope.recallTags).toEqual(["project:github.com/org/repo"]);
+	});
+
+	it("prefers a normalized git remote when one is configured", () => {
+		withTempRepo(({ main, linked }) => {
+			writeFileSync(join(main, ".git", "config"), `[remote "origin"]\n\turl = git@github.com:Org/Repo.git\n`);
+
+			const mainIdentity = resolveMemoryProjectIdentity(main);
+			const linkedIdentity = resolveMemoryProjectIdentity(linked);
+
+			expect(mainIdentity.key).toBe("github.com/org/repo");
+			expect(mainIdentity.source).toBe("git-remote");
+			expect(linkedIdentity.key).toBe(mainIdentity.key);
+			expect(linkedIdentity.segment).toBe("github-com-org-repo");
+		});
+	});
+
+	it("prefers upstream over fork origin when both remotes exist", () => {
+		withTempRepo(({ main, linked }) => {
+			writeFileSync(
+				join(main, ".git", "config"),
+				`[remote "origin"]\n\turl = git@github.com:Fork/Repo.git\n[remote "upstream"]\n\turl = https://github.com/Org/Repo.git\n`,
+			);
+
+			const mainIdentity = resolveMemoryProjectIdentity(main);
+			const linkedIdentity = resolveMemoryProjectIdentity(linked);
+
+			expect(mainIdentity.key).toBe("github.com/org/repo");
+			expect(mainIdentity.source).toBe("git-remote");
+			expect(linkedIdentity.key).toBe(mainIdentity.key);
+			expect(linkedIdentity.segment).toBe("github-com-org-repo");
+		});
+	});
+
+	it("derives the same project identity for linked git worktrees", () => {
+		withTempRepo(({ main, linked }) => {
+			const mainIdentity = resolveMemoryProjectIdentity(main);
+			const linkedIdentity = resolveMemoryProjectIdentity(linked);
+
+			expect(mainIdentity.key).toStartWith("local/repo-main/");
+			expect(mainIdentity.source).toBe("git-common-dir");
+			expect(linkedIdentity.key).toBe(mainIdentity.key);
+			expect(linkedIdentity.segment).toBe(mainIdentity.segment);
+
+			expect(getMemoryRoot("/tmp/agent", linked)).toBe(getMemoryRoot("/tmp/agent", main));
+		});
+	});
+
+	it("consolidates local rollout outputs by repo identity instead of worktree cwd", () => {
+		withTempRepo(({ root, main, linked, other }) => {
+			const db = openMemoryDb(join(root, "memory.db"));
+			try {
+				const insertThread = db.prepare(
+					"INSERT INTO threads (id, updated_at, rollout_path, cwd, source_kind) VALUES (?, ?, ?, ?, 'cli')",
+				);
+				insertThread.run("main", 100, join(main, "main.jsonl"), main);
+				insertThread.run("linked", 200, join(linked, "linked.jsonl"), linked);
+				insertThread.run("other", 300, join(other, "other.jsonl"), other);
+
+				const insertOutput = db.prepare(
+					"INSERT INTO stage1_outputs (thread_id, source_updated_at, raw_memory, rollout_summary, rollout_slug, generated_at) VALUES (?, ?, ?, ?, NULL, ?)",
+				);
+				insertOutput.run("main", 100, "main raw", "main summary", 1000);
+				insertOutput.run("linked", 200, "linked raw", "linked summary", 2000);
+				insertOutput.run("other", 300, "other raw", "other summary", 3000);
+
+				const threadIds = listStage1OutputsForGlobal(db, 10, linked).map(row => row.threadId);
+				expect(threadIds).toEqual(["linked", "main"]);
+			} finally {
+				closeMemoryDb(db);
+			}
+		});
+	});
+});

--- a/packages/coding-agent/src/memory-project-identity.ts
+++ b/packages/coding-agent/src/memory-project-identity.ts
@@ -1,0 +1,160 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { type GitRepository, repo } from "./utils/git";
+
+const UNKNOWN_PROJECT = "unknown";
+const SSH_REMOTE_PATTERN = /^(?:[^@\s/]+@)?([^:\s/]+):(.+)$/;
+const UNSAFE_SEGMENT_CHARS = /[^a-z0-9_-]+/g;
+const REPEATED_DASHES = /-+/g;
+
+export type MemoryProjectIdentitySource = "explicit" | "git-remote" | "git-common-dir" | "cwd";
+
+export interface MemoryProjectIdentity {
+	/** Stable project key used for memory tags and human-facing identity. */
+	key: string;
+	/** Filesystem/bank-safe key segment derived from `key`. */
+	segment: string;
+	source: MemoryProjectIdentitySource;
+}
+
+export function normalizeMemoryProjectKey(value: string | null | undefined): string | undefined {
+	let key = value?.trim();
+	if (!key) return undefined;
+	key = key.replace(/\\/g, "/").replace(/\/+$/g, "");
+	const looksLikeUrl = /^[a-z][a-z0-9+.-]*:\/\//i.test(key);
+
+	if (looksLikeUrl) {
+		try {
+			const url = new URL(key);
+			const pathname = url.pathname.replace(/^\/+/, "");
+			key = pathname ? `${url.hostname}/${pathname}` : url.hostname;
+		} catch {
+			// Plain keys such as `github.com/org/repo` or `repo-name` are valid.
+		}
+	} else {
+		const sshMatch = SSH_REMOTE_PATTERN.exec(key);
+		if (sshMatch) {
+			const sshHost = sshMatch[1];
+			const sshPath = sshMatch[2];
+			if (sshHost && sshPath?.includes("/")) key = `${sshHost}/${sshPath}`;
+		}
+	}
+
+	key = key
+		.replace(/\.git$/i, "")
+		.replace(/^\/+|\/+$/g, "")
+		.toLowerCase();
+	return key || undefined;
+}
+
+export function memoryProjectSegment(key: string | null | undefined): string {
+	const normalized = normalizeMemoryProjectKey(key) ?? UNKNOWN_PROJECT;
+	const segment = normalized.replace(UNSAFE_SEGMENT_CHARS, "-").replace(REPEATED_DASHES, "-").replace(/^-|-$/g, "");
+	return segment || UNKNOWN_PROJECT;
+}
+
+function readGitConfig(configPath: string): string | undefined {
+	try {
+		return fs.readFileSync(configPath, "utf8");
+	} catch {
+		return undefined;
+	}
+}
+
+function canonicalPath(filePath: string): string {
+	try {
+		return fs.realpathSync.native(filePath);
+	} catch {
+		return path.resolve(filePath);
+	}
+}
+
+function normalizeGitRemoteProjectKey(value: string | undefined): string | undefined {
+	const remote = value?.trim();
+	if (!remote) return undefined;
+
+	const sshMatch = SSH_REMOTE_PATTERN.exec(remote);
+	if (sshMatch?.[1] && sshMatch[2]?.includes("/")) {
+		return normalizeMemoryProjectKey(remote);
+	}
+
+	try {
+		const url = new URL(remote);
+		if (!url.hostname) return undefined;
+		return normalizeMemoryProjectKey(remote);
+	} catch {
+		return undefined;
+	}
+}
+
+function remoteProjectKey(repository: GitRepository): string | undefined {
+	const configText = readGitConfig(path.join(repository.commonDir, "config"));
+	if (!configText) return undefined;
+
+	let remoteName: string | undefined;
+	const remotes: Array<{ name: string; key: string }> = [];
+	for (const rawLine of configText.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		const section = /^\[remote\s+"([^"]+)"\]$/.exec(line);
+		if (section) {
+			remoteName = section[1];
+			continue;
+		}
+		if (line.startsWith("[")) {
+			remoteName = undefined;
+			continue;
+		}
+		if (!remoteName) continue;
+
+		const url = /^url\s*=\s*(.+)$/.exec(line);
+		if (!url) continue;
+		const key = normalizeGitRemoteProjectKey(url[1]);
+		if (!key) continue;
+		remotes.push({ name: remoteName, key });
+	}
+
+	return (
+		remotes.find(remote => remote.name === "upstream")?.key ??
+		remotes.find(remote => remote.name === "origin")?.key ??
+		remotes[0]?.key
+	);
+}
+
+function localGitProjectKey(repository: GitRepository): string | undefined {
+	const commonDir = canonicalPath(repository.commonDir);
+	const primaryRoot = path.basename(commonDir) === ".git" ? path.dirname(commonDir) : commonDir;
+	const basename = normalizeMemoryProjectKey(path.basename(primaryRoot));
+	if (!basename) return undefined;
+	return `local/${basename}/${Bun.hash(commonDir).toString(36)}`;
+}
+
+function gitProjectIdentity(cwd: string): MemoryProjectIdentity | undefined {
+	const repository = repo.resolveSync(cwd);
+	if (!repository) return undefined;
+	const remoteKey = remoteProjectKey(repository);
+	if (remoteKey) {
+		return { key: remoteKey, segment: memoryProjectSegment(remoteKey), source: "git-remote" };
+	}
+	const localKey = localGitProjectKey(repository);
+	if (!localKey) return undefined;
+	return { key: localKey, segment: memoryProjectSegment(localKey), source: "git-common-dir" };
+}
+
+export function resolveMemoryProjectIdentity(cwd: string, explicitProjectKey?: string | null): MemoryProjectIdentity {
+	const explicit = normalizeMemoryProjectKey(explicitProjectKey);
+	if (explicit) {
+		return { key: explicit, segment: memoryProjectSegment(explicit), source: "explicit" };
+	}
+
+	if (!cwd) {
+		return { key: UNKNOWN_PROJECT, segment: UNKNOWN_PROJECT, source: "cwd" };
+	}
+
+	const gitIdentity = gitProjectIdentity(cwd);
+	if (gitIdentity) {
+		return gitIdentity;
+	}
+
+	const fallback = normalizeMemoryProjectKey(path.basename(path.resolve(cwd))) ?? UNKNOWN_PROJECT;
+	return { key: fallback, segment: memoryProjectSegment(fallback), source: "cwd" };
+}

--- a/packages/coding-agent/src/mnemopi/config.ts
+++ b/packages/coding-agent/src/mnemopi/config.ts
@@ -2,7 +2,7 @@ import * as path from "node:path";
 import type { MnemopiOptions } from "@oh-my-pi/pi-mnemopi";
 import { getMemoriesDir } from "@oh-my-pi/pi-utils";
 import type { Settings } from "../config/settings";
-import * as git from "../utils/git";
+import { resolveMemoryProjectIdentity } from "../memory-project-identity";
 
 export type MnemopiLlmMode = "none" | "smol" | "remote";
 
@@ -40,7 +40,7 @@ export function loadMnemopiConfig(settings: Settings, agentDir: string): Mnemopi
 	const configuredDbPath = settings.get("mnemopi.dbPath");
 	const cwd = settings.getCwd();
 	const scoping = settings.get("mnemopi.scoping");
-	const scope = resolveBankScope(settings.get("mnemopi.bank"), cwd, scoping);
+	const scope = resolveBankScope(settings.get("mnemopi.bank"), cwd, scoping, settings.get("memory.projectKey"));
 	const llmMode = settings.get("mnemopi.llmMode");
 	return {
 		dbPath: configuredDbPath ?? path.join(getMemoriesDir(agentDir), "mnemopi", "mnemopi.db"),
@@ -91,8 +91,13 @@ interface MnemopiBankScope {
 
 // Mnemopi does not have built-in tag-filtered recall, so `per-project-tagged`
 // maps to a project-local write bank plus a shared recall-visible bank.
-function resolveBankScope(configured: string | undefined, cwd: string, scoping: MnemopiScoping): MnemopiBankScope {
-	const project = projectBank(configured, cwd);
+function resolveBankScope(
+	configured: string | undefined,
+	cwd: string,
+	scoping: MnemopiScoping,
+	projectKey?: string,
+): MnemopiBankScope {
+	const project = projectBank(configured, cwd, projectKey);
 	const globalBank = sharedBank(configured);
 	switch (scoping) {
 		case "global":
@@ -126,16 +131,14 @@ function sharedBank(configured: string | undefined): string {
 	return sanitizeBankName(configured) ?? DEFAULT_SHARED_BANK;
 }
 
-function projectBank(configured: string | undefined, cwd: string): string {
-	const projectRoot = git.repo.resolveSync(cwd)?.repoRoot ?? path.resolve(cwd);
-	const project = projectBankSegment(projectRoot);
+function projectBank(configured: string | undefined, cwd: string, projectKey?: string): string {
+	const identity = resolveMemoryProjectIdentity(cwd, projectKey);
+	const project =
+		identity.source === "cwd"
+			? limitBankName(`${identity.segment}-${Bun.hash(path.resolve(cwd)).toString(36)}`)
+			: identity.segment;
 	const base = sanitizeBankName(configured);
 	return limitBankName(base ? `${base}-${project}` : project);
-}
-
-function projectBankSegment(projectRoot: string): string {
-	const project = sanitizeBankName(path.basename(projectRoot)) ?? "default";
-	return limitBankName(`${project}-${Bun.hash(path.resolve(projectRoot)).toString(36)}`);
 }
 
 function sanitizeBankName(value: string | undefined): string | undefined {

--- a/packages/coding-agent/test/hindsight-bank.test.ts
+++ b/packages/coding-agent/test/hindsight-bank.test.ts
@@ -44,6 +44,7 @@ const baseConfig = (overrides: Partial<HindsightConfig> = {}): HindsightConfig =
 	bankId: null,
 	bankIdPrefix: "",
 	scoping: "global",
+	projectKey: null,
 	bankMission: "",
 	retainMission: null,
 	autoRecall: true,
@@ -144,9 +145,9 @@ describe("computeBankScope", () => {
 	});
 
 	// Regression for #2232: linked git worktrees used to silo memory into
-	// distinct `project:<basename>` tags. The fix resolves the primary
-	// checkout root via `git.repo.primaryRootSync`, so every worktree of one
-	// repo collapses to the same tag (and the same per-project bank id).
+	// distinct `project:<basename>` tags. Project identity now resolves through
+	// the git remote when possible and otherwise a common-dir-derived local key,
+	// so every worktree of one repo shares the same tag and per-project bank id.
 	describe("git worktree handling", () => {
 		let baseDir: string;
 		let primaryRoot: string;
@@ -184,31 +185,31 @@ describe("computeBankScope", () => {
 		it("emits the same project tag from the primary checkout and a linked worktree", () => {
 			const fromPrimary = computeBankScope(baseConfig({ scoping: "per-project-tagged" }), primaryRoot);
 			const fromWorktree = computeBankScope(baseConfig({ scoping: "per-project-tagged" }), worktreeRoot);
-			expect(fromPrimary.retainTags).toEqual(["project:myrepo"]);
-			expect(fromWorktree.retainTags).toEqual(["project:myrepo"]);
+			expect(fromPrimary.retainTags?.[0]).toStartWith("project:local/myrepo/");
+			expect(fromWorktree.retainTags).toEqual(fromPrimary.retainTags);
 			expect(fromWorktree).toEqual(fromPrimary);
 		});
 
-		it("uses the primary root basename for the per-project bank id from a worktree", () => {
-			expect(computeBankScope(baseConfig({ scoping: "per-project" }), worktreeRoot)).toEqual({
-				bankId: "omp-myrepo",
-			});
+		it("uses the shared local repository key for the per-project bank id from a worktree", () => {
+			expect(computeBankScope(baseConfig({ scoping: "per-project" }), worktreeRoot).bankId).toStartWith(
+				"omp-local-myrepo-",
+			);
 		});
 
 		it("emits one shared project label across worktrees attached to a bare repository", () => {
 			const fromA = computeBankScope(baseConfig({ scoping: "per-project-tagged" }), bareWorktreeA);
 			const fromB = computeBankScope(baseConfig({ scoping: "per-project-tagged" }), bareWorktreeB);
-			expect(fromA.retainTags).toEqual(["project:bare-repo.git"]);
+			expect(fromA.retainTags?.[0]).toStartWith("project:local/bare-repo/");
 			expect(fromB).toEqual(fromA);
-			expect(computeBankScope(baseConfig({ scoping: "per-project" }), bareWorktreeB)).toEqual({
-				bankId: "omp-bare-repo.git",
-			});
+			expect(computeBankScope(baseConfig({ scoping: "per-project" }), bareWorktreeB).bankId).toStartWith(
+				"omp-local-bare-repo-",
+			);
 		});
 
 		it("falls back to the cwd basename outside any repository", () => {
 			// The temp parent dir is not itself a repo — it just contains one.
 			expect(computeBankScope(baseConfig({ scoping: "per-project-tagged" }), baseDir).retainTags).toEqual([
-				`project:${path.basename(baseDir)}`,
+				`project:${path.basename(baseDir).toLowerCase()}`,
 			]);
 		});
 	});

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -47,6 +47,7 @@ function makeConfig(overrides: Partial<HindsightConfig> = {}): HindsightConfig {
 		bankId: null,
 		bankIdPrefix: "",
 		scoping: "global",
+		projectKey: null,
 		bankMission: "",
 		retainMission: null,
 		autoRecall: true,


### PR DESCRIPTION
## Summary

Project-scoped memory now follows the repository instead of each checkout path. Linked git worktrees share Hindsight tags/banks, Mnemopi banks, and local markdown memory roots; repos with the same folder name avoid collisions by using remote identity when available or a common-dir-derived local key.

## Design

- Adds a shared memory project identity resolver: explicit `memory.projectKey` / env override, normalized git remote, git common-dir local key, then cwd fallback.
- Uses that resolver in Hindsight scoping, Mnemopi bank naming, local memory roots, memory protocol roots, and local rollout consolidation filtering.
- Documents `memory.projectKey` and updates memory tool docs so the advertised scoping matches runtime behavior.

## Test plan

- `bun test packages/coding-agent/src/memory-project-identity.test.ts packages/coding-agent/test/hindsight-bank.test.ts packages/coding-agent/test/memory-tools.test.ts`
- `bun --cwd=packages/coding-agent run check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![openai-codex/gpt-5.5](https://img.shields.io/badge/openai--codex%2Fgpt--5.5-000000)