### PR TITLE
fix(edit): route glm-5.1 through replace mode

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `glm-5.1` sessions using the strict hashline edit grammar by default; they now use the tolerant replace edit mode unless the user explicitly configures `edit.mode` or an `edit.modelVariants` override ([#2241](https://github.com/can1357/oh-my-pi/issues/2241)).
+
 ## [15.10.12] - 2026-06-10
 
 ### Added
@@ -25,7 +29,6 @@
 
 ### Fixed
 
-- Fixed `glm-5.1` sessions using the strict hashline edit grammar by default; they now use the tolerant replace edit mode unless the user explicitly configures `edit.mode` or an `edit.modelVariants` override ([#2241](https://github.com/can1357/oh-my-pi/issues/2241)).
 - Fixed Ollama chat turns using the `:off` thinking selector so requests explicitly send reasoning disablement instead of falling back to the provider default ([#2239](https://github.com/can1357/oh-my-pi/issues/2239)).
 - Fixed long-running sessions becoming sluggish because the status line recomputed context usage by walking the full message history on every refresh. Message-token totals are now cached incrementally, and status lines that do not render context segments skip context accounting entirely. ([#2089](https://github.com/can1357/oh-my-pi/issues/2089))
 - Fixed extension-registered slash commands being allowed to shadow builtin command names in the ACP/RPC command list: both the TUI and `getSessionSlashCommands()` now filter against the shared builtin reserved-name registry.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixed
 
+- Fixed `glm-5.1` sessions using the strict hashline edit grammar by default; they now use the tolerant replace edit mode unless the user explicitly configures `edit.mode` or an `edit.modelVariants` override ([#2241](https://github.com/can1357/oh-my-pi/issues/2241)).
 - Fixed Ollama chat turns using the `:off` thinking selector so requests explicitly send reasoning disablement instead of falling back to the provider default ([#2239](https://github.com/can1357/oh-my-pi/issues/2239)).
 - Fixed long-running sessions becoming sluggish because the status line recomputed context usage by walking the full message history on every refresh. Message-token totals are now cached incrementally, and status lines that do not render context segments skip context accounting entirely. ([#2089](https://github.com/can1357/oh-my-pi/issues/2089))
 - Fixed extension-registered slash commands being allowed to shadow builtin command names in the ACP/RPC command list: both the TUI and `getSessionSlashCommands()` now filter against the shared builtin reserved-name registry.

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1804,6 +1804,16 @@ export const SETTINGS_SCHEMA = {
 		},
 	},
 
+	"edit.modelVariants": {
+		type: "record",
+		default: EMPTY_STRING_RECORD,
+		ui: {
+			tab: "editing",
+			label: "Model Edit Variants",
+			description: "Map model name substrings to edit tool variants (replace, patch, hashline, or apply_patch)",
+		},
+	},
+
 	"edit.fuzzyMatch": {
 		type: "boolean",
 		default: true,

--- a/packages/coding-agent/src/config/settings.ts
+++ b/packages/coding-agent/src/config/settings.ts
@@ -482,8 +482,7 @@ export class Settings {
 	 */
 	getEditVariantForModel(model: string | undefined): EditMode | null {
 		if (!model) return null;
-		const variants = (this.#merged.edit as { modelVariants?: Record<string, string> })?.modelVariants;
-		if (!variants) return null;
+		const variants = shallowStringRecord(this.get("edit.modelVariants"));
 		for (const pattern in variants) {
 			if (model.includes(pattern)) {
 				const value = normalizeEditMode(variants[pattern]);

--- a/packages/coding-agent/src/utils/edit-mode.ts
+++ b/packages/coding-agent/src/utils/edit-mode.ts
@@ -53,7 +53,7 @@ export function resolveEditMode(session: EditModeSessionLike): EditMode {
 	if (envMode) return envMode;
 
 	const settingsMode = normalizeEditMode(String(session.settings.get("edit.mode") ?? ""));
-	if (settingsMode && session.settings.isConfigured?.("edit.mode")) return settingsMode;
+	if (settingsMode && (session.settings.isConfigured?.("edit.mode") ?? true)) return settingsMode;
 
 	const defaultModelVariant = getDefaultEditVariantForModel(activeModel);
 	if (defaultModelVariant) return defaultModelVariant;

--- a/packages/coding-agent/src/utils/edit-mode.ts
+++ b/packages/coding-agent/src/utils/edit-mode.ts
@@ -13,6 +13,21 @@ const EDIT_MODE_IDS = {
 
 export const EDIT_MODES = Object.keys(EDIT_MODE_IDS) as EditMode[];
 
+type DefaultModelEditVariant = {
+	pattern: string;
+	mode: EditMode;
+};
+
+const DEFAULT_MODEL_EDIT_VARIANTS: readonly DefaultModelEditVariant[] = [{ pattern: "glm-5.1", mode: "replace" }];
+
+function getDefaultEditVariantForModel(model: string | undefined): EditMode | null {
+	if (!model) return null;
+	for (const variant of DEFAULT_MODEL_EDIT_VARIANTS) {
+		if (model.includes(variant.pattern)) return variant.mode;
+	}
+	return null;
+}
+
 export function normalizeEditMode(mode?: string | null): EditMode | undefined {
 	if (!mode) return undefined;
 	return EDIT_MODE_IDS[mode as keyof typeof EDIT_MODE_IDS];
@@ -20,6 +35,7 @@ export function normalizeEditMode(mode?: string | null): EditMode | undefined {
 
 export interface EditModeSettingsLike {
 	get(key: "edit.mode"): unknown;
+	isConfigured?(key: "edit.mode"): boolean;
 	getEditVariantForModel?(model: string | undefined): EditMode | null;
 }
 
@@ -37,5 +53,10 @@ export function resolveEditMode(session: EditModeSessionLike): EditMode {
 	if (envMode) return envMode;
 
 	const settingsMode = normalizeEditMode(String(session.settings.get("edit.mode") ?? ""));
+	if (settingsMode && session.settings.isConfigured?.("edit.mode")) return settingsMode;
+
+	const defaultModelVariant = getDefaultEditVariantForModel(activeModel);
+	if (defaultModelVariant) return defaultModelVariant;
+
 	return settingsMode ?? DEFAULT_EDIT_MODE;
 }

--- a/packages/coding-agent/test/edit-mode.test.ts
+++ b/packages/coding-agent/test/edit-mode.test.ts
@@ -40,6 +40,17 @@ describe("resolveEditMode", () => {
 		).toBe("hashline");
 	});
 
+	test("preserves edit.mode from lightweight settings without isConfigured", () => {
+		expect(
+			resolveEditMode({
+				settings: {
+					get: () => "patch",
+				},
+				getActiveModelString: () => "zhipu/glm-5.1",
+			}),
+		).toBe("patch");
+	});
+
 	test("keeps configured model variants above built-in model defaults", () => {
 		const settings = Settings.isolated({ "edit.modelVariants": { "glm-5.1": "patch" } });
 

--- a/packages/coding-agent/test/edit-mode.test.ts
+++ b/packages/coding-agent/test/edit-mode.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Settings } from "../src/config/settings";
+import { resolveEditMode } from "../src/utils/edit-mode";
+
+let originalEditVariant: string | undefined;
+
+beforeEach(() => {
+	originalEditVariant = Bun.env.PI_EDIT_VARIANT;
+	delete Bun.env.PI_EDIT_VARIANT;
+});
+
+afterEach(() => {
+	if (originalEditVariant === undefined) {
+		delete Bun.env.PI_EDIT_VARIANT;
+	} else {
+		Bun.env.PI_EDIT_VARIANT = originalEditVariant;
+	}
+});
+
+describe("resolveEditMode", () => {
+	test("uses replace mode for glm-5.1 when no edit mode is configured", () => {
+		const settings = Settings.isolated({});
+
+		expect(
+			resolveEditMode({
+				settings,
+				getActiveModelString: () => "zhipu/glm-5.1",
+			}),
+		).toBe("replace");
+	});
+
+	test("keeps explicit edit.mode above model defaults", () => {
+		const settings = Settings.isolated({ "edit.mode": "hashline" });
+
+		expect(
+			resolveEditMode({
+				settings,
+				getActiveModelString: () => "zhipu/glm-5.1",
+			}),
+		).toBe("hashline");
+	});
+
+	test("keeps configured model variants above built-in model defaults", () => {
+		const settings = Settings.isolated({ "edit.modelVariants": { "glm-5.1": "patch" } });
+
+		expect(
+			resolveEditMode({
+				settings,
+				getActiveModelString: () => "zhipu/glm-5.1",
+			}),
+		).toBe("patch");
+	});
+});


### PR DESCRIPTION
## Repro
With no user edit override configured, `resolveEditMode()` returned `hashline` for active model `glm-5.1`: `bun -e "import { Settings } from './packages/coding-agent/src/config/settings.ts'; import { resolveEditMode } from './packages/coding-agent/src/utils/edit-mode.ts'; const settings = Settings.isolated({}); const mode = resolveEditMode({ settings, getActiveModelString: () => 'glm-5.1' }); console.log(mode); process.exit(mode === 'replace' ? 0 : 1);"` printed `hashline` and exited 1.

## Cause
`packages/coding-agent/src/utils/edit-mode.ts` only honored explicit `edit.modelVariants`, `PI_EDIT_VARIANT`, and `edit.mode`; because `edit.mode` falls back to the schema default `hashline`, `glm-5.1` had no built-in model-specific fallback and was routed through the strict hashline grammar.

## Fix
- Added a built-in `glm-5.1` edit-mode fallback to `replace`, applied only when no explicit model variant, env variant, or configured `edit.mode` is present.
- Added `edit.modelVariants` to the settings schema and typed `Settings.getEditVariantForModel()` through that setting.
- Added regression tests for the `glm-5.1` default plus explicit `edit.mode` and `edit.modelVariants` precedence.
- Added the coding-agent changelog entry.

## Verification
`bun test packages/coding-agent/test/edit-mode.test.ts` passed; `bun --cwd=packages/coding-agent run check` passed; the repro command now prints `replace` and exits 0. `gh_push_branch` pre-publish gate also completed before pushing. Fixes #2241