### PR TITLE
fix(catalog): handle missing thinking efforts

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `buildModel` so malformed explicit thinking metadata without `efforts` is treated as sparse input and inferred instead of crashing during model resolution ([#2251](https://github.com/can1357/oh-my-pi/issues/2251)).
+
 ## [15.10.12] - 2026-06-10
 
 ### Added

--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -97,7 +97,7 @@ export function resolveModelThinking<TApi extends Api>(
 ): ThinkingConfig | undefined {
 	if (!spec.reasoning) return undefined;
 	if (omitsWireReasoningEffort(spec.api, compat)) return undefined;
-	if (spec.thinking && spec.thinking.efforts.length > 0) {
+	if (spec.thinking && Array.isArray(spec.thinking.efforts) && spec.thinking.efforts.length > 0) {
 		return fillThinkingWireDefaults(spec, spec.thinking);
 	}
 	// Empty/malformed explicit metadata is treated as absent — infer instead.

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -184,6 +184,29 @@ describe("model thinking derivation", () => {
 		expect(pinned.thinking?.supportsDisplay).toBe(false);
 	});
 
+	it("infers thinking when explicit metadata omits efforts", () => {
+		const model = buildModel(
+			JSON.parse(`{
+				"id": "gpt-5",
+				"name": "gpt-5",
+				"api": "openai-completions",
+				"provider": "openai",
+				"baseUrl": "",
+				"reasoning": true,
+				"thinking": { "mode": "effort" },
+				"input": ["text"],
+				"cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
+				"contextWindow": 200000,
+				"maxTokens": 32000
+			}`),
+		);
+
+		expect(model.thinking).toEqual({
+			mode: "effort",
+			efforts: [Effort.Minimal, Effort.Low, Effort.Medium, Effort.High],
+		});
+	});
+
 	it("bakes sampling-param rejection into anthropic compat", () => {
 		const sonnet45 = createModel({ id: "claude-sonnet-4-5", api: "anthropic-messages", provider: "anthropic" });
 		const opus47 = createModel({ id: "claude-opus-4.7", api: "anthropic-messages", provider: "anthropic" });


### PR DESCRIPTION
## Repro
A model spec with `reasoning: true` and explicit `thinking` metadata that omits `efforts` crashes during model resolution. Reproduced with `bun --cwd=packages/catalog -e 'import { buildModel } from "./src/build"; buildModel({ provider: "openai", id: "gpt-5", api: "openai-completions", reasoning: true, thinking: { mode: "openai-reasoning" } });'`, which threw `TypeError: undefined is not an object (evaluating 'spec.thinking.efforts.length')` at `packages/catalog/src/model-thinking.ts:100`.

## Cause
`resolveModelThinking` in `packages/catalog/src/model-thinking.ts` checked `spec.thinking.efforts.length` whenever `spec.thinking` was truthy. Runtime specs can be sparse/malformed even though `ThinkingConfig.efforts` is typed as required, so missing `efforts` reached `.length` before the existing inference fallback could run.

## Fix
- Guard explicit thinking metadata with `Array.isArray(spec.thinking.efforts)` before trusting `efforts.length`.
- Treat missing/non-array `efforts` as sparse metadata and let `deriveThinking` infer the canonical thinking config.
- Added a regression test covering a JSON-authored spec with `thinking` but no `efforts`.
- Added the catalog changelog entry.

## Verification
Ran `bun --cwd=packages/catalog test test/model-thinking.test.ts` (18 pass) and `bun --cwd=packages/catalog run check` (Biome + `tsgo` passed). Re-ran the minimal `buildModel` repro and it returned `minimal,low,medium,high` instead of throwing. Fixes #2251