### PR TITLE
fix(stats): ship dashboard assets in npm bundle

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the published npm CLI bundle to include the prebuilt stats dashboard client so `omp stats` can start after global installs. ([#2254](https://github.com/can1357/oh-my-pi/issues/2254))
+
 ## [15.10.12] - 2026-06-10
 
 ### Added
@@ -25,7 +29,6 @@
 
 ### Fixed
 
-- Fixed the published npm CLI bundle to include the prebuilt stats dashboard client so `omp stats` can start after global installs. ([#2254](https://github.com/can1357/oh-my-pi/issues/2254))
 - Fixed Ollama chat turns using the `:off` thinking selector so requests explicitly send reasoning disablement instead of falling back to the provider default ([#2239](https://github.com/can1357/oh-my-pi/issues/2239)).
 - Fixed long-running sessions becoming sluggish because the status line recomputed context usage by walking the full message history on every refresh. Message-token totals are now cached incrementally, and status lines that do not render context segments skip context accounting entirely. ([#2089](https://github.com/can1357/oh-my-pi/issues/2089))
 - Fixed extension-registered slash commands being allowed to shadow builtin command names in the ACP/RPC command list: both the TUI and `getSessionSlashCommands()` now filter against the shared builtin reserved-name registry.

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixed
 
+- Fixed the published npm CLI bundle to include the prebuilt stats dashboard client so `omp stats` can start after global installs. ([#2254](https://github.com/can1357/oh-my-pi/issues/2254))
 - Fixed Ollama chat turns using the `:off` thinking selector so requests explicitly send reasoning disablement instead of falling back to the provider default ([#2239](https://github.com/can1357/oh-my-pi/issues/2239)).
 - Fixed long-running sessions becoming sluggish because the status line recomputed context usage by walking the full message history on every refresh. Message-token totals are now cached incrementally, and status lines that do not render context segments skip context accounting entirely. ([#2089](https://github.com/can1357/oh-my-pi/issues/2089))
 - Fixed extension-registered slash commands being allowed to shadow builtin command names in the ACP/RPC command list: both the TUI and `getSessionSlashCommands()` now filter against the shared builtin reserved-name registry.

--- a/packages/coding-agent/package.json
+++ b/packages/coding-agent/package.json
@@ -89,6 +89,7 @@
 	"files": [
 		"src",
 		"dist/cli.js",
+		"dist/client",
 		"dist/*.node",
 		"scripts",
 		"examples",

--- a/packages/coding-agent/scripts/bundle-dist.ts
+++ b/packages/coding-agent/scripts/bundle-dist.ts
@@ -5,13 +5,16 @@ import * as path from "node:path";
 import { isEnoent } from "@oh-my-pi/pi-utils";
 
 const packageDir = path.join(import.meta.dir, "..");
+const statsPackageDir = path.join(packageDir, "..", "stats");
 const outDir = path.join(packageDir, "dist");
 const cliPath = path.join(outDir, "cli.js");
+const statsClientDir = path.join(statsPackageDir, "dist", "client");
+const bundledClientDir = path.join(outDir, "client");
 const shebang = "#!/usr/bin/env bun\n";
 
-async function runCommand(command: string[]): Promise<void> {
+async function runCommand(command: string[], cwd = packageDir): Promise<void> {
 	const proc = Bun.spawn(command, {
-		cwd: packageDir,
+		cwd,
 		stdout: "inherit",
 		stderr: "inherit",
 	});
@@ -33,7 +36,8 @@ function formatBytes(bytes: number): string {
 
 async function cleanBundleOutputs(): Promise<void> {
 	// dist/ is shared with the dev binary (dist/omp); only remove this
-	// script's own outputs (entry bundle + copied native assets).
+	// script's own outputs (entry bundle, copied native assets, and copied
+	// stats dashboard client assets).
 	let entries: string[];
 	try {
 		entries = await fs.readdir(outDir);
@@ -43,14 +47,22 @@ async function cleanBundleOutputs(): Promise<void> {
 	}
 	await Promise.all(
 		entries
-			.filter(entry => entry === "cli.js" || entry.endsWith(".node") || entry.endsWith(".js.map"))
-			.map(entry => fs.rm(path.join(outDir, entry), { force: true })),
+			.filter(
+				entry => entry === "client" || entry === "cli.js" || entry.endsWith(".node") || entry.endsWith(".js.map"),
+			)
+			.map(entry => fs.rm(path.join(outDir, entry), { recursive: true, force: true })),
 	);
+}
+
+async function copyStatsClientAssets(): Promise<void> {
+	await fs.cp(statsClientDir, bundledClientDir, { recursive: true });
 }
 
 async function main(): Promise<void> {
 	const start = Bun.nanoseconds();
 	await cleanBundleOutputs();
+	await runCommand(["bun", "run", "build"], statsPackageDir);
+	await copyStatsClientAssets();
 	await runCommand([
 		"bun",
 		"build",

--- a/packages/coding-agent/test/stats-bundle.test.ts
+++ b/packages/coding-agent/test/stats-bundle.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const packageDir = path.resolve(import.meta.dir, "..");
+const repoRoot = path.resolve(packageDir, "../..");
+const cliPath = path.join(packageDir, "dist", "cli.js");
+const clientIndexPath = path.join(packageDir, "dist", "client", "index.html");
+
+async function waitForStatsIndex(port: number, proc: Bun.Subprocess): Promise<boolean> {
+	for (let attempt = 0; attempt < 80; attempt++) {
+		const exitCode = await Promise.race([proc.exited, Bun.sleep(0).then(() => undefined)]);
+		if (exitCode !== undefined) return false;
+
+		try {
+			const response = await fetch(`http://127.0.0.1:${port}/`);
+			const text = await response.text();
+			if (response.status === 200 && text.includes('<div id="root"></div>')) return true;
+		} catch {}
+
+		await Bun.sleep(100);
+	}
+	return false;
+}
+
+describe("stats dashboard bundle", () => {
+	it("serves the copied client assets from the bundled CLI", async () => {
+		const build = Bun.spawn([process.execPath, "scripts/bundle-dist.ts"], {
+			cwd: packageDir,
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		const [buildStdout, buildStderr, buildExitCode] = await Promise.all([
+			new Response(build.stdout).text(),
+			new Response(build.stderr).text(),
+			build.exited,
+		]);
+		expect(`${buildStdout}${buildStderr}`).toContain("Bundled coding-agent CLI to dist/cli.js");
+		expect(buildExitCode).toBe(0);
+		expect(await Bun.file(clientIndexPath).exists()).toBe(true);
+
+		const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "omp-stats-bundle-"));
+		const port = 48_700 + Math.floor(Math.random() * 1_000);
+		const server = Bun.spawn([process.execPath, cliPath, "stats", "--port", String(port)], {
+			cwd: repoRoot,
+			env: {
+				...Bun.env,
+				HOME: path.join(tempRoot, "home"),
+				OMP_HOME: path.join(tempRoot, "omp"),
+			},
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+
+		try {
+			const servedIndex = await waitForStatsIndex(port, server);
+			if (!servedIndex) {
+				const [stdout, stderr, exitCode] = await Promise.all([
+					new Response(server.stdout).text(),
+					new Response(server.stderr).text(),
+					server.exited,
+				]);
+				throw new Error(`stats server did not serve index.html; exit=${exitCode}\n${stdout}${stderr}`);
+			}
+		} finally {
+			server.kill();
+			await server.exited;
+			await fs.rm(tempRoot, { recursive: true, force: true });
+		}
+	}, 30_000);
+});

--- a/packages/stats/CHANGELOG.md
+++ b/packages/stats/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed bundled `omp stats` installs treating the published `dist/client` assets as rebuildable source and crashing before the dashboard server starts. ([#2254](https://github.com/can1357/oh-my-pi/issues/2254))
+
 ## [15.10.11] - 2026-06-10
 
 ### Changed

--- a/packages/stats/src/server.ts
+++ b/packages/stats/src/server.ts
@@ -83,6 +83,22 @@ async function getCompiledClientDir(): Promise<string> {
 	return compiledClientDirPromise;
 }
 
+async function isDirectory(dir: string): Promise<boolean> {
+	try {
+		return (await fs.stat(dir)).isDirectory();
+	} catch {
+		return false;
+	}
+}
+
+async function isFile(filePath: string): Promise<boolean> {
+	try {
+		return (await fs.stat(filePath)).isFile();
+	} catch {
+		return false;
+	}
+}
+
 async function getLatestMtime(dir: string): Promise<number> {
 	const entries = await fs.readdir(dir, { withFileTypes: true });
 
@@ -111,6 +127,13 @@ const ensureClientBuild = async () => {
 	if (IS_BUN_COMPILED) return;
 	const indexPath = path.join(STATIC_DIR, "index.html");
 	const cssPath = path.join(STATIC_DIR, "styles.css");
+	if (CLIENT_DIR === STATIC_DIR) {
+		if ((await isFile(indexPath)) && (await isFile(cssPath))) return;
+		throw new Error(`Bundled stats client assets missing at ${STATIC_DIR}. Rebuild the CLI package.`);
+	}
+	if (!(await isDirectory(CLIENT_DIR))) {
+		throw new Error(`Stats client source directory missing at ${CLIENT_DIR}. Rebuild the stats package.`);
+	}
 	const clientSourceMtime = await getLatestMtime(CLIENT_DIR);
 	const tailwindConfigPath = path.join(import.meta.dir, "..", "tailwind.config.js");
 	let tailwindConfigMtime = 0;


### PR DESCRIPTION
## Repro
Bundled the CLI with `bun scripts/bundle-dist.ts`, then ran `HOME=/tmp/omp-stats-repro-home OMP_HOME=/tmp/omp-stats-repro-omp bun packages/coding-agent/dist/cli.js stats --port 48547`; sync completed and the bundled server failed with `ENOENT` scanning `packages/coding-agent/dist/client`.

## Cause
`packages/stats/src/server.ts` resolves both `CLIENT_DIR` and `STATIC_DIR` from `import.meta.dir`; after `@oh-my-pi/omp-stats` is bundled into `packages/coding-agent/dist/cli.js`, that directory is `packages/coding-agent/dist`, but `packages/coding-agent/scripts/bundle-dist.ts` only emitted `dist/cli.js` and native assets. The npm package also excluded `dist/client`, so `ensureClientBuild()` tried to scan missing dashboard assets as source.

## Fix
- Build the stats dashboard during `scripts/bundle-dist.ts` and copy `packages/stats/dist/client` into `packages/coding-agent/dist/client`.
- Publish `dist/client` from `packages/coding-agent/package.json` with the npm bundle.
- Teach `packages/stats/src/server.ts` that bundled static layouts are prebuilt assets, not rebuildable source.
- Add a regression test that builds the bundled CLI and verifies `omp stats` serves `index.html` from the copied client assets.

## Verification
Ran `bun run check` in `packages/coding-agent`, `bun run check` in `packages/stats`, and `bun test packages/coding-agent/test/stats-bundle.test.ts`; all passed. Manually verified the rebuilt `packages/coding-agent/dist/cli.js stats --port 48547` served the dashboard index. Fixes #2254