### PR TITLE
fix(ai): preserve prior-turn thinking on anthropic-messages replay

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed prior-turn reasoning blocks being demoted to text (or dropped, for `redactedThinking`) on `anthropic-messages` continuation requests whenever the conversation crossed a provider/model boundary — e.g. custom providers configured via `models.yaml`, or any session that switched between two anthropic-messages endpoints. `transformMessages` only preserved thinking content on the latest surviving assistant turn; every earlier turn fell through to the cross-API text-demotion path and lost its reasoning chain. Anthropic-compatible source/target combinations now keep all `thinking`/`redactedThinking` blocks across every prior turn (Anthropic's all-or-none replay contract), with cross-model signatures stripped so the downstream encoder applies the correct `replayUnsignedThinking` policy ([#2257](https://github.com/can1357/oh-my-pi/issues/2257)).
+
 ## [15.10.12] - 2026-06-10
 
 ### Added

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -184,10 +184,20 @@ export function transformMessages<TApi extends Api>(
 					assistantMsg.api === model.api &&
 					assistantMsg.model === model.id;
 
-				const mustPreserveLatestAnthropicThinking =
-					index === latestSurvivingAssistantIndex &&
-					model.api === "anthropic-messages" &&
-					assistantMsg.api === "anthropic-messages";
+				// Anthropic enforces an all-or-none contract on prior-turn thinking
+				// blocks: "if you include thinking blocks in prior assistant turns,
+				// you must include ALL thinking blocks (including redacted ones)".
+				// As long as both the source and target speak `anthropic-messages`,
+				// every prior assistant turn's thinking chain must reach the wire
+				// as native `thinking`/`redacted_thinking` blocks — even across
+				// model/provider boundaries (custom providers configured via
+				// `models.yaml`, switching between two anthropic-compatible
+				// endpoints, etc.). The previous logic only honored this for the
+				// LATEST surviving assistant; every earlier turn was demoted to
+				// text or dropped on cross-model replay, breaking continuation
+				// for Anthropic-compatible reasoning endpoints (#2257).
+				const isAnthropicReplay = model.api === "anthropic-messages" && assistantMsg.api === "anthropic-messages";
+				const isLatestSurvivingAssistant = index === latestSurvivingAssistantIndex;
 				// Thinking signatures can be untrustworthy for two distinct reasons with very
 				// different blast radii:
 				//
@@ -226,11 +236,30 @@ export function transformMessages<TApi extends Api>(
 						// untrustworthy signature so the encoder can downgrade the block to text.
 						const signatureUntrustworthy =
 							abandonedToolUse || (invalidStopReason && blockIndex === lastBlockIndex);
-						const sanitized =
+						let sanitized: typeof block =
 							signatureUntrustworthy && block.thinkingSignature
 								? { ...block, thinkingSignature: undefined }
 								: block;
-						if (mustPreserveLatestAnthropicThinking) return abandonedToolUse ? block : sanitized;
+						if (isAnthropicReplay) {
+							// Latest abandoned turn: Anthropic's byte-for-byte rule forbids
+							// even stripping a signature on the latest message.
+							if (isLatestSurvivingAssistant && abandonedToolUse) return block;
+							// Cross-model prior turns: the source provider's signature is
+							// not trusted by the new target. Strip it so the downstream
+							// encoder applies its `replayUnsignedThinking` policy
+							// (unsigned thinking is emitted natively on Anthropic-compatible
+							// reasoning endpoints and demoted to text on official Anthropic).
+							if (!isLatestSurvivingAssistant && !isSameModel && sanitized.thinkingSignature) {
+								sanitized = { ...sanitized, thinkingSignature: undefined };
+							}
+							// Drop blocks with neither a signature anchor nor any text —
+							// nothing for the next turn to replay.
+							if (!sanitized.thinkingSignature && (!sanitized.thinking || sanitized.thinking.trim() === "")) {
+								return [];
+							}
+							return sanitized;
+						}
+						// Cross-API target: keep the existing text-demotion fallback.
 						// For same model: keep thinking blocks with signatures (needed for replay)
 						// even if the thinking text is empty (OpenAI encrypted reasoning)
 						if (isSameModel && sanitized.thinkingSignature) return sanitized;
@@ -244,7 +273,9 @@ export function transformMessages<TApi extends Api>(
 					}
 
 					if (block.type === "redactedThinking") {
-						if (mustPreserveLatestAnthropicThinking) return block;
+						// Same all-or-none rule applies: a prior turn that keeps any
+						// thinking content must keep its redacted siblings too.
+						if (isAnthropicReplay) return block;
 						if (isSameModel) return block;
 						return [];
 					}

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -139,6 +139,10 @@ function getLatestSurvivingAssistantIndex(messages: readonly Message[]): number 
 	return -1;
 }
 
+function isAnthropicMessagesModel(model: Model): model is Model<"anthropic-messages"> {
+	return model.api === "anthropic-messages";
+}
+
 /**
  * Normalize tool call ID for cross-provider compatibility.
  * OpenAI Responses API generates IDs that are 450+ chars with special characters like `|`.
@@ -184,19 +188,21 @@ export function transformMessages<TApi extends Api>(
 					assistantMsg.api === model.api &&
 					assistantMsg.model === model.id;
 
+				const isAnthropicTarget = isAnthropicMessagesModel(model);
 				// Anthropic enforces an all-or-none contract on prior-turn thinking
 				// blocks: "if you include thinking blocks in prior assistant turns,
 				// you must include ALL thinking blocks (including redacted ones)".
-				// As long as both the source and target speak `anthropic-messages`,
-				// every prior assistant turn's thinking chain must reach the wire
-				// as native `thinking`/`redacted_thinking` blocks — even across
-				// model/provider boundaries (custom providers configured via
-				// `models.yaml`, switching between two anthropic-compatible
-				// endpoints, etc.). The previous logic only honored this for the
-				// LATEST surviving assistant; every earlier turn was demoted to
-				// text or dropped on cross-model replay, breaking continuation
-				// for Anthropic-compatible reasoning endpoints (#2257).
-				const isAnthropicReplay = model.api === "anthropic-messages" && assistantMsg.api === "anthropic-messages";
+				// As long as both the source and target speak `anthropic-messages`
+				// AND the target can replay unsigned thinking natively, every prior
+				// assistant turn's thinking chain must reach the wire as native
+				// `thinking`/`redacted_thinking` blocks — even across model/provider
+				// boundaries (custom providers configured via `models.yaml`, switching
+				// between two anthropic-compatible endpoints, etc.). For official
+				// Anthropic targets, unsigned cross-model thinking is demoted to text
+				// downstream, so matching redacted siblings must be dropped instead of
+				// sent as lone native `redacted_thinking` blocks.
+				const isAnthropicReplay = isAnthropicTarget && assistantMsg.api === "anthropic-messages";
+				const replaysUnsignedAnthropicThinking = isAnthropicTarget && model.compat.replayUnsignedThinking;
 				const isLatestSurvivingAssistant = index === latestSurvivingAssistantIndex;
 				// Thinking signatures can be untrustworthy for two distinct reasons with very
 				// different blast radii:
@@ -273,9 +279,15 @@ export function transformMessages<TApi extends Api>(
 					}
 
 					if (block.type === "redactedThinking") {
-						// Same all-or-none rule applies: a prior turn that keeps any
-						// thinking content must keep its redacted siblings too.
-						if (isAnthropicReplay) return block;
+						// Redacted thinking is native-only. Keep it for same-model
+						// signed replay, the latest byte-for-byte Anthropic turn, or
+						// compatible targets that will also emit sibling unsigned
+						// thinking natively. Drop it when the visible thinking was
+						// cross-model stripped and will be demoted to text.
+						if (isAnthropicReplay) {
+							if (isSameModel || isLatestSurvivingAssistant || replaysUnsignedAnthropicThinking) return block;
+							return [];
+						}
 						if (isSameModel) return block;
 						return [];
 					}

--- a/packages/ai/test/anthropic-prior-turn-thinking.test.ts
+++ b/packages/ai/test/anthropic-prior-turn-thinking.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "bun:test";
+import { convertAnthropicMessages } from "@oh-my-pi/pi-ai/providers/anthropic";
+import type {
+	AssistantMessage,
+	Message,
+	Model,
+	ModelSpec,
+	ToolResultMessage,
+	UserMessage,
+} from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+/**
+ * Regression for #2257: prior assistant turns from an `anthropic-messages`
+ * source must keep their thinking chain when the next request also targets
+ * `anthropic-messages`, even across model/provider boundaries. The previous
+ * logic only honored this for the latest assistant turn, demoting every
+ * earlier `thinking` block to plain `text` and dropping every
+ * `redactedThinking` whenever the conversation crossed provider/model lines —
+ * a violation of Anthropic's all-or-none thinking-block contract and a loss
+ * of reasoning context for compatible reasoning endpoints (DeepSeek,
+ * Z.AI, custom anthropic-messages providers configured via `models.yaml`).
+ */
+function makeAnthropicModel(overrides: Partial<ModelSpec<"anthropic-messages">> = {}): Model<"anthropic-messages"> {
+	return buildModel({
+		api: "anthropic-messages",
+		provider: "custom-anthropic",
+		id: "reasoning-model",
+		name: "Reasoning Anthropic-Compatible Model",
+		baseUrl: "https://llm.example.com/anthropic",
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		maxTokens: 8_192,
+		contextWindow: 200_000,
+		reasoning: true,
+		...overrides,
+	} as ModelSpec<"anthropic-messages">);
+}
+
+function makeUser(text: string): UserMessage {
+	return { role: "user", content: text, timestamp: 0 };
+}
+
+function makeAssistant(
+	content: AssistantMessage["content"],
+	overrides: Partial<AssistantMessage> = {},
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "custom-anthropic",
+		model: "reasoning-model",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: 0,
+		...overrides,
+	};
+}
+
+function toolResult(toolCallId: string, text: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "read",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: 0,
+	};
+}
+
+interface WireThinkingBlock {
+	type: "thinking";
+	thinking: string;
+	signature: string;
+}
+interface WireTextBlock {
+	type: "text";
+	text: string;
+}
+interface WireRedactedBlock {
+	type: "redacted_thinking";
+	data: string;
+}
+interface WireToolUseBlock {
+	type: "tool_use";
+	id: string;
+	name: string;
+	input: Record<string, unknown>;
+}
+type WireBlock =
+	| WireThinkingBlock
+	| WireTextBlock
+	| WireRedactedBlock
+	| WireToolUseBlock
+	| { type: string; [key: string]: unknown };
+
+describe("Anthropic prior-turn thinking preservation (#2257)", () => {
+	it("preserves prior assistant thinking when crossing models on the same compatible endpoint", () => {
+		// Conversation history was produced by `reasoning-model-v1`; the next
+		// request targets `reasoning-model-v2` on the same anthropic-messages
+		// custom provider. The first assistant turn is PRIOR (there is a later
+		// assistant turn from v2), so the latest-only preservation path doesn't
+		// help — without the fix the prior thinking block is demoted to text.
+		const target = makeAnthropicModel({ id: "reasoning-model-v2" });
+		const priorThinkingText = "Plan: read README, then summarize.";
+		const messages: Message[] = [
+			makeUser("Summarize README"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: priorThinkingText, thinkingSignature: "sig_v1" },
+					{ type: "toolCall", id: "toolu_prior", name: "read", arguments: { path: "README.md" } },
+				],
+				{ model: "reasoning-model-v1" },
+			),
+			toolResult("toolu_prior", "README body"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "Got the body, now translating", thinkingSignature: "sig_v2" },
+					{ type: "text", text: "Voici le résumé en français." },
+				],
+				{ model: "reasoning-model-v2", stopReason: "stop" },
+			),
+			makeUser("Now translate it to Spanish"),
+		];
+
+		const params = convertAnthropicMessages(messages, target, false);
+		const assistants = params.filter(p => p.role === "assistant");
+		expect(assistants).toHaveLength(2);
+		const priorBlocks = assistants[0].content as WireBlock[];
+		// The prior thinking block must survive as a `thinking` block (not be
+		// silently downgraded to `text`). Cross-model signatures are stripped so
+		// the downstream emits unsigned thinking, which compatible reasoning
+		// endpoints (`replayUnsignedThinking: true`) accept on continuation.
+		const thinking = priorBlocks.find(b => b.type === "thinking") as WireThinkingBlock | undefined;
+		expect(thinking).toBeDefined();
+		expect(thinking?.thinking).toBe(priorThinkingText);
+		expect(thinking?.signature).toBe("");
+		// And the paired tool_use must still be present right after it.
+		const toolUse = priorBlocks.find(b => b.type === "tool_use") as WireToolUseBlock | undefined;
+		expect(toolUse?.id).toBe("toolu_prior");
+	});
+
+	it("keeps the signature on prior turns when the source model matches the target", () => {
+		// Same provider+api+id throughout: signatures are valid and must ride
+		// the wire untouched (prompt-cache stability + Anthropic's all-or-none
+		// invariant).
+		const target = makeAnthropicModel();
+		const messages: Message[] = [
+			makeUser("Summarize README"),
+			makeAssistant([
+				{ type: "thinking", thinking: "plan", thinkingSignature: "sig_same" },
+				{ type: "toolCall", id: "toolu_prior", name: "read", arguments: { path: "README.md" } },
+			]),
+			toolResult("toolu_prior", "README body"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "summarising", thinkingSignature: "sig_latest" },
+					{ type: "text", text: "summary" },
+				],
+				{ stopReason: "stop" },
+			),
+			makeUser("And now in Spanish"),
+		];
+
+		const params = convertAnthropicMessages(messages, target, false);
+		const assistants = params.filter(p => p.role === "assistant");
+		const priorBlocks = assistants[0].content as WireBlock[];
+		const thinking = priorBlocks.find(b => b.type === "thinking") as WireThinkingBlock | undefined;
+		expect(thinking?.thinking).toBe("plan");
+		expect(thinking?.signature).toBe("sig_same");
+	});
+
+	it("preserves redacted_thinking blocks from prior anthropic-messages turns", () => {
+		// Anthropic's "include ALL thinking blocks (including redacted ones)"
+		// rule means redacted_thinking from earlier turns must survive whenever
+		// we replay any thinking content from the same turn.
+		const target = makeAnthropicModel({ id: "reasoning-model-v2" });
+		const messages: Message[] = [
+			makeUser("Summarize README"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "visible reasoning", thinkingSignature: "sig" },
+					{ type: "redactedThinking", data: "encrypted-blob" },
+					{ type: "toolCall", id: "toolu_prior", name: "read", arguments: { path: "README.md" } },
+				],
+				{ model: "reasoning-model-v1" },
+			),
+			toolResult("toolu_prior", "README body"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "later", thinkingSignature: "sig_latest" },
+					{ type: "text", text: "summary" },
+				],
+				{ model: "reasoning-model-v2", stopReason: "stop" },
+			),
+			makeUser("Translate"),
+		];
+
+		const params = convertAnthropicMessages(messages, target, false);
+		const assistants = params.filter(p => p.role === "assistant");
+		const priorBlocks = assistants[0].content as WireBlock[];
+		const redacted = priorBlocks.find(b => b.type === "redacted_thinking") as WireRedactedBlock | undefined;
+		expect(redacted).toBeDefined();
+		expect(redacted?.data).toBe("encrypted-blob");
+	});
+
+	it("does not promote prior unsigned thinking from non-anthropic sources to thinking blocks", () => {
+		// Cross-API replay: prior turn came from OpenAI-responses with no
+		// Anthropic signature. The all-or-none rule scope is per-API; we must
+		// not invent thinking blocks for a turn whose source can't sign them —
+		// the existing cross-API text demotion is the right behavior.
+		const target = makeAnthropicModel();
+		const messages: Message[] = [
+			makeUser("Summarize README"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "openai chain-of-thought", thinkingSignature: "" },
+					{ type: "toolCall", id: "toolu_prior", name: "read", arguments: { path: "README.md" } },
+				],
+				{
+					api: "openai-responses",
+					provider: "openai",
+					model: "o1-preview",
+				} as Partial<AssistantMessage>,
+			),
+			toolResult("toolu_prior", "README body"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "anthropic latest", thinkingSignature: "sig_latest" },
+					{ type: "text", text: "summary" },
+				],
+				{ stopReason: "stop" },
+			),
+			makeUser("Translate"),
+		];
+
+		const params = convertAnthropicMessages(messages, target, false);
+		const assistants = params.filter(p => p.role === "assistant");
+		const priorBlocks = assistants[0].content as WireBlock[];
+		expect(priorBlocks.find(b => b.type === "thinking")).toBeUndefined();
+		// Reasoning text still survives on the wire (as text, via the existing
+		// cross-API demotion path).
+		const text = priorBlocks.find(b => b.type === "text") as WireTextBlock | undefined;
+		expect(text?.text).toBe("openai chain-of-thought");
+	});
+});

--- a/packages/ai/test/anthropic-prior-turn-thinking.test.ts
+++ b/packages/ai/test/anthropic-prior-turn-thinking.test.ts
@@ -212,6 +212,50 @@ describe("Anthropic prior-turn thinking preservation (#2257)", () => {
 		expect(redacted?.data).toBe("encrypted-blob");
 	});
 
+	it("drops prior redacted_thinking when unsigned thinking is demoted to text", () => {
+		// Official Anthropic targets do not replay unsigned thinking natively.
+		// Once a cross-model prior turn's visible thinking signature is stripped,
+		// that thinking becomes text on the wire; the redacted sibling must not
+		// remain as a lone native redacted_thinking block.
+		const target = makeAnthropicModel({
+			provider: "anthropic",
+			id: "claude-sonnet-4-6",
+			baseUrl: "https://api.anthropic.com",
+		});
+		const messages: Message[] = [
+			makeUser("Summarize README"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "visible reasoning", thinkingSignature: "sig_custom" },
+					{ type: "redactedThinking", data: "foreign-encrypted-blob" },
+					{ type: "toolCall", id: "toolu_prior", name: "read", arguments: { path: "README.md" } },
+				],
+				{ model: "reasoning-model-v1" },
+			),
+			toolResult("toolu_prior", "README body"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "official latest", thinkingSignature: "sig_latest" },
+					{ type: "text", text: "summary" },
+				],
+				{
+					provider: "anthropic",
+					model: "claude-sonnet-4-6",
+					stopReason: "stop",
+				},
+			),
+			makeUser("Translate"),
+		];
+
+		const params = convertAnthropicMessages(messages, target, false);
+		const assistants = params.filter(p => p.role === "assistant");
+		const priorBlocks = assistants[0].content as WireBlock[];
+		const text = priorBlocks.find(b => b.type === "text") as WireTextBlock | undefined;
+		expect(text?.text).toBe("visible reasoning");
+		expect(priorBlocks.find(b => b.type === "thinking")).toBeUndefined();
+		expect(priorBlocks.find(b => b.type === "redacted_thinking")).toBeUndefined();
+	});
+
 	it("does not promote prior unsigned thinking from non-anthropic sources to thinking blocks", () => {
 		// Cross-API replay: prior turn came from OpenAI-responses with no
 		// Anthropic signature. The all-or-none rule scope is per-API; we must


### PR DESCRIPTION
## Repro

Configure any non-trivial conversation through an `anthropic-messages` target where a prior assistant turn came from a different model id (e.g. a custom provider via `models.yaml`, or two anthropic-compatible endpoints in the same session). On the next request, the prior turn's reasoning chain disappears from the wire: `thinking` blocks are silently downgraded to `text` and `redactedThinking` blocks are dropped entirely. The new test suite reproduces both losses against a custom anthropic-compatible model:

```sh
bun test packages/ai/test/anthropic-prior-turn-thinking.test.ts
```

Before this change the cross-model "thinking" and "redactedThinking" cases fail with `Received: undefined` — the prior block never reaches the wire.

## Cause

`packages/ai/src/providers/transform-messages.ts` gated the anthropic preservation flag on `index === latestSurvivingAssistantIndex`:

```ts
const mustPreserveLatestAnthropicThinking =
    index === latestSurvivingAssistantIndex &&
    model.api === "anthropic-messages" &&
    assistantMsg.api === "anthropic-messages";
```

Every prior anthropic-messages assistant turn that wasn't `isSameModel` therefore fell through to the cross-API text-demotion path:

```ts
return { type: "text" as const, text: sanitized.thinking };  // thinking
return [];                                                    // redactedThinking
```

That violates Anthropic's "if you include any thinking blocks in prior turns, you must include all (including redacted ones)" contract on every cross-model continuation.

## Fix

- Lift the latest-only restriction: any `anthropic-messages → anthropic-messages` replay now preserves prior `thinking`/`redactedThinking` blocks as native blocks (covers `models.yaml` custom providers and session-level model switches).
- Strip cross-model thinking signatures so the downstream encoder applies the existing `replayUnsignedThinking` policy — unsigned thinking is emitted natively on Anthropic-compatible reasoning endpoints and demoted to text on official Anthropic.
- Keep Anthropic's byte-for-byte rule for the latest abandoned-tool-use turn (`abandonedToolUse` exemption is now scoped to `isLatestSurvivingAssistant`).
- Existing aborted/errored last-block sanitization (signatures on the truncated trailing block) is unchanged.
- Cross-API replays (e.g. OpenAI-responses → anthropic-messages) keep the original text-demotion fallback so foreign chains-of-thought are not promoted into native `thinking` blocks they can't sign.

## Verification

```sh
bun test packages/ai/test/anthropic-prior-turn-thinking.test.ts
# 4 pass, 0 fail

bun test packages/ai/test/anthropic-prior-turn-thinking.test.ts \
  packages/ai/test/anthropic-thinking-immutability.test.ts \
  packages/ai/test/anthropic-thinking-only-length-truncated.test.ts \
  packages/ai/test/anthropic-unsigned-thinking-replay.test.ts \
  packages/ai/test/transform-messages-dedup.test.ts
# 17 pass, 0 fail

bun test packages/ai/
# 1569 pass, 337 skip, 0 fail

bun check
# 0 errors
```

Fixes #2257