### PR TITLE
fix(tools): normalize Windows search paths

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Windows-style backslash paths and globs being parsed as literal POSIX path segments by search/find tools ([#2245](https://github.com/can1357/oh-my-pi/issues/2245)).
+
 ## [15.10.12] - 2026-06-10
 
 ### Added
@@ -16,10 +20,6 @@
 - Added a structured memory runtime surface for extensions and UI integrations to query backend status, search memories, and save explicit memories across the configured memory backend.
 - Added support for Git repositories using the `reftable` storage format by detecting `extensions.refStorage = reftable` in the repository configuration and falling back to shelling out to Git commands (`git symbolic-ref`, `git rev-parse`) for reference and HEAD resolution.
 - Added `/setup providers` (also available as `/setup` or `/providers`) to reopen the interactive provider setup scene from an active TUI session, letting users sign in and choose a web search provider without rerunning the full onboarding flow.
-
-### Fixed
-
-- Fixed Windows-style backslash paths and globs being parsed as literal POSIX path segments by search/find tools ([#2245](https://github.com/can1357/oh-my-pi/issues/2245)).
 
 ### Changed
 

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Added support for Git repositories using the `reftable` storage format by detecting `extensions.refStorage = reftable` in the repository configuration and falling back to shelling out to Git commands (`git symbolic-ref`, `git rev-parse`) for reference and HEAD resolution.
 - Added `/setup providers` (also available as `/setup` or `/providers`) to reopen the interactive provider setup scene from an active TUI session, letting users sign in and choose a web search provider without rerunning the full onboarding flow.
 
+### Fixed
+
+- Fixed Windows-style backslash paths and globs being parsed as literal POSIX path segments by search/find tools ([#2245](https://github.com/can1357/oh-my-pi/issues/2245)).
+
 ### Changed
 
 - Bash execution now preserves minimized shell output inline while saving the untouched capture as an `artifact://…` footer when shell minimization rewrites a command's output.

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -405,7 +405,7 @@ function normalizePathSeparators(input: string): string {
 }
 
 export function normalizePathLikeInput(input: string): string {
-	return normalizePathSeparators(stripOuterDoubleQuotes(input.trim()));
+	return stripOuterDoubleQuotes(input.trim());
 }
 
 const GLOB_PATH_CHARS = ["*", "?", "[", "{"] as const;

--- a/packages/coding-agent/src/tools/path-utils.ts
+++ b/packages/coding-agent/src/tools/path-utils.ts
@@ -398,9 +398,14 @@ export function formatPathRelativeToCwd(
 export function stripOuterDoubleQuotes(input: string): string {
 	return input.startsWith('"') && input.endsWith('"') && input.length > 1 ? input.slice(1, -1) : input;
 }
+function normalizePathSeparators(input: string): string {
+	if (isInternalUrlPath(input)) return input;
+	if (!input.includes("\\")) return input;
+	return input.replace(/\\/g, "/");
+}
 
 export function normalizePathLikeInput(input: string): string {
-	return stripOuterDoubleQuotes(input.trim());
+	return normalizePathSeparators(stripOuterDoubleQuotes(input.trim()));
 }
 
 const GLOB_PATH_CHARS = ["*", "?", "[", "{"] as const;
@@ -582,19 +587,20 @@ export interface ResolvedMultiFindPattern {
 	targets: ResolvedFindTarget[];
 	scopePath: string;
 }
-
-/**
- * Split a user path into a base path + glob pattern for tools that delegate to
- * APIs accepting separate `path` and `glob` arguments.
- */
 export function parseSearchPath(filePath: string): ParsedSearchPath {
-	const normalizedPath = filePath.replace(/\\/g, "/");
-	if (!hasGlobPathChars(normalizedPath)) {
-		return { basePath: filePath };
+	const normalizedPath = normalizePathSeparators(filePath);
+	const segments = normalizedPath.split("/");
+	let firstGlobIndex = -1;
+	for (let i = 0; i < segments.length; i++) {
+		if (hasGlobPathChars(segments[i])) {
+			firstGlobIndex = i;
+			break;
+		}
 	}
 
-	const segments = normalizedPath.split("/");
-	const firstGlobIndex = segments.findIndex(segment => hasGlobPathChars(segment));
+	if (firstGlobIndex === -1) {
+		return { basePath: normalizedPath };
+	}
 
 	if (firstGlobIndex <= 0) {
 		return { basePath: ".", glob: normalizedPath };
@@ -617,7 +623,7 @@ export async function parseSearchPathPreferringLiteral(filePath: string, cwd: st
 	if (!hasGlobPathChars(filePath) || isInternalUrlPath(filePath)) return parseSearchPath(filePath);
 	try {
 		await fs.promises.stat(resolveToCwd(filePath, cwd));
-		return { basePath: filePath };
+		return { basePath: normalizePathSeparators(filePath) };
 	} catch {
 		return parseSearchPath(filePath);
 	}
@@ -632,7 +638,8 @@ export async function parseSearchPathPreferringLiteral(filePath: string, cwd: st
 //   /abs/path/**/\*.ts -> { basePath: "/abs/path", globPattern: "**/*.ts", hasGlob: true }
 //   src/app -> { basePath: "src/app", globPattern: "**/*", hasGlob: false }
 export function parseFindPattern(pattern: string): ParsedFindPattern {
-	const segments = pattern.split("/");
+	const normalizedPattern = normalizePathSeparators(pattern);
+	const segments = normalizedPattern.split("/");
 	let firstGlobIndex = -1;
 	for (let i = 0; i < segments.length; i++) {
 		if (hasGlobPathChars(segments[i])) {
@@ -642,14 +649,14 @@ export function parseFindPattern(pattern: string): ParsedFindPattern {
 	}
 
 	if (firstGlobIndex === -1) {
-		return { basePath: pattern, globPattern: "**/*", hasGlob: false };
+		return { basePath: normalizedPattern, globPattern: "**/*", hasGlob: false };
 	}
 
 	if (firstGlobIndex === 0) {
-		const needsRecursive = !pattern.startsWith("**/");
+		const needsRecursive = !normalizedPattern.startsWith("**/");
 		return {
 			basePath: ".",
-			globPattern: needsRecursive ? `**/${pattern}` : pattern,
+			globPattern: needsRecursive ? `**/${normalizedPattern}` : normalizedPattern,
 			hasGlob: true,
 		};
 	}

--- a/packages/coding-agent/test/tools/find-validate-paths.test.ts
+++ b/packages/coding-agent/test/tools/find-validate-paths.test.ts
@@ -8,6 +8,7 @@ import { findToolRenderer } from "@oh-my-pi/pi-coding-agent/tools/find";
 import {
 	expandDelimitedPathEntries,
 	parseFindPattern,
+	resolveToolSearchScope,
 	splitDelimitedPathEntry,
 } from "@oh-my-pi/pi-coding-agent/tools/path-utils";
 import type { Component } from "@oh-my-pi/pi-tui";
@@ -105,16 +106,30 @@ describe("delimited path expansion", () => {
 	});
 
 	it("normalizes Windows path separators before parsing find globs", async () => {
-		expect(await expandDelimitedPathEntries(["apps\\**\\*.txt"], tempDir, { splitter: parseFindPattern })).toEqual([
-			"apps/**/*.txt",
-		]);
+		expect(parseFindPattern("apps\\**\\*.txt")).toEqual({
+			basePath: "apps",
+			globPattern: "**/*.txt",
+			hasGlob: true,
+		});
 
+		expect(await splitDelimitedPathEntry("apps/a.txt\\,packages/b.txt", tempDir)).toBeNull();
 		const parsed = parseFindPattern("C:\\work\\repo\\src\\**\\*.ts");
 		expect(parsed).toEqual({
 			basePath: "C:/work/repo/src",
 			globPattern: "**/*.ts",
 			hasGlob: true,
 		});
+	});
+
+	it("normalizes Windows separators for search scope globs", async () => {
+		const scope = await resolveToolSearchScope({
+			rawPaths: ["apps\\**\\*.txt"],
+			cwd: tempDir,
+			internalUrlAction: "search",
+		});
+
+		expect(scope.searchPath).toBe(path.join(tempDir, "apps"));
+		expect(scope.globFilter).toBe("**/*.txt");
 	});
 });
 

--- a/packages/coding-agent/test/tools/find-validate-paths.test.ts
+++ b/packages/coding-agent/test/tools/find-validate-paths.test.ts
@@ -103,6 +103,19 @@ describe("delimited path expansion", () => {
 			}),
 		).toEqual(["apps/**/*.txt", "packages/**/*.txt"]);
 	});
+
+	it("normalizes Windows path separators before parsing find globs", async () => {
+		expect(await expandDelimitedPathEntries(["apps\\**\\*.txt"], tempDir, { splitter: parseFindPattern })).toEqual([
+			"apps/**/*.txt",
+		]);
+
+		const parsed = parseFindPattern("C:\\work\\repo\\src\\**\\*.ts");
+		expect(parsed).toEqual({
+			basePath: "C:/work/repo/src",
+			globPattern: "**/*.ts",
+			hasGlob: true,
+		});
+	});
 });
 
 describe("findToolRenderer", () => {


### PR DESCRIPTION
Fixes #2245.

## Summary
- normalize Windows backslash paths before search/find path parsing
- keep internal URL handling intact
- cover absolute Windows globs and relative backslash globs

## Verification
- bun test packages/coding-agent/test/tools/find-validate-paths.test.ts -t "normalizes Windows path separators"
- bun --cwd=packages/coding-agent run check