### PR TITLE
fix(ai): preserve 3p anthropic-messages reasoning chains across model swaps

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Cross-model `anthropic-messages → anthropic-messages` continuations now preserve prior assistant turns' reasoning chains end-to-end: every prior `thinking`/`redactedThinking` block survives (not just the latest surviving assistant), and third-party ↔ third-party replays keep their signatures intact so the reasoning chain stays signed for the next turn. Signatures are stripped (and any `redacted_thinking` sibling without a native landing spot is dropped) only when an official Anthropic endpoint is on either end of the replay — official Anthropic cryptographically binds reasoning signatures to its key+session+model, while compatible reasoning endpoints (Z.AI, DeepSeek, custom anthropic-messages providers configured via `models.yaml`) treat them as opaque continuation hints. Source-side official detection uses the canonical catalog provider id `"anthropic"` (assistant messages carry no `baseUrl`); target-side detection reuses the baked `compat.officialEndpoint` flag. Latest-turn byte-for-byte behavior (Anthropic's "thinking blocks in the latest assistant message cannot be modified" rule) and existing aborted/errored last-block sanitization are unchanged. ([#2257](https://github.com/can1357/oh-my-pi/issues/2257), [#2265](https://github.com/can1357/oh-my-pi/issues/2265))
+
 ## [15.10.12] - 2026-06-10
 
 ### Added

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -139,6 +139,10 @@ function getLatestSurvivingAssistantIndex(messages: readonly Message[]): number 
 	return -1;
 }
 
+function isAnthropicMessagesModel(model: Model): model is Model<"anthropic-messages"> {
+	return model.api === "anthropic-messages";
+}
+
 /**
  * Normalize tool call ID for cross-provider compatibility.
  * OpenAI Responses API generates IDs that are 450+ chars with special characters like `|`.
@@ -184,10 +188,45 @@ export function transformMessages<TApi extends Api>(
 					assistantMsg.api === model.api &&
 					assistantMsg.model === model.id;
 
-				const mustPreserveLatestAnthropicThinking =
-					index === latestSurvivingAssistantIndex &&
-					model.api === "anthropic-messages" &&
-					assistantMsg.api === "anthropic-messages";
+				const isAnthropicTarget = isAnthropicMessagesModel(model);
+				// Anthropic's all-or-none contract on prior-turn thinking blocks
+				// applies to every `anthropic-messages → anthropic-messages` replay,
+				// not just the latest assistant turn. The legacy
+				// `mustPreserveLatestAnthropicThinking` flag only honored it for the
+				// latest turn; every prior turn fell through to the cross-API
+				// text-demotion path whenever the conversation crossed a model id,
+				// silently dropping the reasoning chain on continuation for custom
+				// anthropic-messages providers configured via `models.yaml` and
+				// session-level model swaps (#2257).
+				const isAnthropicReplay = isAnthropicTarget && assistantMsg.api === "anthropic-messages";
+				const isLatestSurvivingAssistant = index === latestSurvivingAssistantIndex;
+				// Signature policy is a second axis. Anthropic cryptographically
+				// binds reasoning signatures to its key+session+model, so cross-model
+				// signatures must be stripped whenever official Anthropic is on
+				// either end of the replay:
+				//   * official → 3p: the 3p target can't reverify the signature;
+				//     keeping it leaks private continuation metadata for no benefit.
+				//   * 3p → official: official rejects a foreign signature outright.
+				//   * official → official cross-model: the new model rejects the
+				//     previous model's signature.
+				// 3p ↔ 3p replays preserve signatures because compatible providers
+				// (Z.AI, DeepSeek, custom `models.yaml` providers) treat them as
+				// opaque continuation hints rather than verified material; stripping
+				// degrades the reasoning chain into unsigned/text on the next turn
+				// (#2265). Source-side official detection uses the canonical catalog
+				// provider id `"anthropic"` because assistant messages carry no
+				// `baseUrl` — a user who manually points `provider: "anthropic"` at
+				// a custom proxy via `models.yaml` will see signatures stripped, the
+				// conservative direction (degraded reasoning, not broken requests).
+				const isOfficialAnthropicSource = isAnthropicReplay && assistantMsg.provider === "anthropic";
+				const isOfficialAnthropicTarget = isAnthropicTarget && model.compat.officialEndpoint;
+				const officialAnthropicInvolved = isOfficialAnthropicSource || isOfficialAnthropicTarget;
+				// Compatible Anthropic-messages reasoning targets that accept
+				// unsigned thinking natively (Z.AI, DeepSeek, the generic
+				// `reasoning && !official` case in the compat builder). Used to keep
+				// `redacted_thinking` siblings beside unsigned visible thinking on
+				// targets that won't text-demote it.
+				const replaysUnsignedAnthropicThinking = isAnthropicTarget && model.compat.replayUnsignedThinking;
 				// Thinking signatures can be untrustworthy for two distinct reasons with very
 				// different blast radii:
 				//
@@ -226,11 +265,37 @@ export function transformMessages<TApi extends Api>(
 						// untrustworthy signature so the encoder can downgrade the block to text.
 						const signatureUntrustworthy =
 							abandonedToolUse || (invalidStopReason && blockIndex === lastBlockIndex);
-						const sanitized =
+						let sanitized: typeof block =
 							signatureUntrustworthy && block.thinkingSignature
 								? { ...block, thinkingSignature: undefined }
 								: block;
-						if (mustPreserveLatestAnthropicThinking) return abandonedToolUse ? block : sanitized;
+						if (isAnthropicReplay) {
+							// Latest abandoned turn: Anthropic's byte-for-byte rule forbids
+							// even stripping a signature on the latest message.
+							if (isLatestSurvivingAssistant && abandonedToolUse) return block;
+							// Cross-model prior turns crossing an official Anthropic endpoint
+							// must strip the source signature so the downstream encoder
+							// applies its `replayUnsignedThinking` policy (unsigned thinking
+							// is emitted natively on Anthropic-compatible reasoning endpoints
+							// and demoted to text on official Anthropic). 3p ↔ 3p replays
+							// keep the signature so the reasoning chain stays signed on
+							// continuation (#2265).
+							if (
+								!isLatestSurvivingAssistant &&
+								!isSameModel &&
+								officialAnthropicInvolved &&
+								sanitized.thinkingSignature
+							) {
+								sanitized = { ...sanitized, thinkingSignature: undefined };
+							}
+							// Drop blocks with neither a signature anchor nor any text —
+							// nothing for the next turn to replay.
+							if (!sanitized.thinkingSignature && (!sanitized.thinking || sanitized.thinking.trim() === "")) {
+								return [];
+							}
+							return sanitized;
+						}
+						// Cross-API target: keep the existing text-demotion fallback.
 						// For same model: keep thinking blocks with signatures (needed for replay)
 						// even if the thinking text is empty (OpenAI encrypted reasoning)
 						if (isSameModel && sanitized.thinkingSignature) return sanitized;
@@ -244,7 +309,15 @@ export function transformMessages<TApi extends Api>(
 					}
 
 					if (block.type === "redactedThinking") {
-						if (mustPreserveLatestAnthropicThinking) return block;
+						// Redacted thinking is native-only. Keep it for same-model
+						// signed replay, the latest byte-for-byte Anthropic turn, or
+						// compatible targets that will also emit sibling unsigned
+						// thinking natively. Drop it when the visible thinking was
+						// cross-model stripped and will be demoted to text.
+						if (isAnthropicReplay) {
+							if (isSameModel || isLatestSurvivingAssistant || replaysUnsignedAnthropicThinking) return block;
+							return [];
+						}
 						if (isSameModel) return block;
 						return [];
 					}

--- a/packages/ai/test/anthropic-prior-turn-thinking.test.ts
+++ b/packages/ai/test/anthropic-prior-turn-thinking.test.ts
@@ -1,0 +1,342 @@
+import { describe, expect, it } from "bun:test";
+import { convertAnthropicMessages } from "@oh-my-pi/pi-ai/providers/anthropic";
+import type {
+	AssistantMessage,
+	Message,
+	Model,
+	ModelSpec,
+	ToolResultMessage,
+	UserMessage,
+} from "@oh-my-pi/pi-ai/types";
+import { buildModel } from "@oh-my-pi/pi-catalog/build";
+
+/**
+ * Cross-model `anthropic-messages` continuations must preserve the prior
+ * turn's reasoning chain. Anthropic enforces an all-or-none contract on
+ * thinking blocks ("if you include thinking blocks in prior assistant turns,
+ * you must include ALL thinking blocks (including redacted ones)") but the
+ * legacy transform only honored that for the LATEST surviving assistant.
+ * Every earlier turn fell through to the cross-API text-demotion path
+ * whenever the conversation crossed a model boundary — silently dropping the
+ * reasoning chain on continuation for custom anthropic-messages providers
+ * configured via `models.yaml` and for session-level model swaps (#2257).
+ *
+ * The signature policy is a second axis: official Anthropic cryptographically
+ * binds signatures to its key+session+model, so cross-model signatures must
+ * be stripped (and matching redacted siblings dropped) whenever either side
+ * of the replay is official Anthropic. Third-party endpoints (Z.AI, DeepSeek,
+ * custom anthropic-messages providers) treat signatures as opaque
+ * continuation hints they pass through unchanged, so 3p ↔ 3p replays
+ * preserve them as-is to keep the reasoning chain signed for the next
+ * turn (#2265).
+ */
+function makeAnthropicModel(overrides: Partial<ModelSpec<"anthropic-messages">> = {}): Model<"anthropic-messages"> {
+	return buildModel({
+		api: "anthropic-messages",
+		provider: "custom-anthropic",
+		id: "reasoning-model",
+		name: "Reasoning Anthropic-Compatible Model",
+		baseUrl: "https://llm.example.com/anthropic",
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		maxTokens: 8_192,
+		contextWindow: 200_000,
+		reasoning: true,
+		...overrides,
+	} as ModelSpec<"anthropic-messages">);
+}
+
+function makeUser(text: string): UserMessage {
+	return { role: "user", content: text, timestamp: 0 };
+}
+
+function makeAssistant(
+	content: AssistantMessage["content"],
+	overrides: Partial<AssistantMessage> = {},
+): AssistantMessage {
+	return {
+		role: "assistant",
+		content,
+		api: "anthropic-messages",
+		provider: "custom-anthropic",
+		model: "reasoning-model",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason: "toolUse",
+		timestamp: 0,
+		...overrides,
+	};
+}
+
+function toolResult(toolCallId: string, text: string): ToolResultMessage {
+	return {
+		role: "toolResult",
+		toolCallId,
+		toolName: "read",
+		content: [{ type: "text", text }],
+		isError: false,
+		timestamp: 0,
+	};
+}
+
+interface WireThinkingBlock {
+	type: "thinking";
+	thinking: string;
+	signature: string;
+}
+interface WireTextBlock {
+	type: "text";
+	text: string;
+}
+interface WireRedactedBlock {
+	type: "redacted_thinking";
+	data: string;
+}
+interface WireToolUseBlock {
+	type: "tool_use";
+	id: string;
+	name: string;
+	input: Record<string, unknown>;
+}
+type WireBlock =
+	| WireThinkingBlock
+	| WireTextBlock
+	| WireRedactedBlock
+	| WireToolUseBlock
+	| { type: string; [key: string]: unknown };
+
+describe("Anthropic prior-turn thinking preservation (#2257, #2265)", () => {
+	it("preserves the prior thinking block as native `thinking` across compatible endpoints", () => {
+		// Source v1, target v2, both on the same custom anthropic-messages
+		// provider. The first assistant turn is PRIOR, so the latest-only
+		// preservation path doesn't help — without the fix the prior thinking
+		// block is demoted to plain `text` and the reasoning chain disappears.
+		const target = makeAnthropicModel({ id: "reasoning-model-v2" });
+		const priorThinkingText = "Plan: read README, then summarize.";
+		const messages: Message[] = [
+			makeUser("Summarize README"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: priorThinkingText, thinkingSignature: "sig_v1" },
+					{ type: "toolCall", id: "toolu_prior", name: "read", arguments: { path: "README.md" } },
+				],
+				{ model: "reasoning-model-v1" },
+			),
+			toolResult("toolu_prior", "README body"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "Got the body, now translating", thinkingSignature: "sig_v2" },
+					{ type: "text", text: "Voici le résumé en français." },
+				],
+				{ model: "reasoning-model-v2", stopReason: "stop" },
+			),
+			makeUser("Now translate it to Spanish"),
+		];
+
+		const params = convertAnthropicMessages(messages, target, false);
+		const assistants = params.filter(p => p.role === "assistant");
+		expect(assistants).toHaveLength(2);
+		const priorBlocks = assistants[0].content as WireBlock[];
+		const thinking = priorBlocks.find(b => b.type === "thinking") as WireThinkingBlock | undefined;
+		expect(thinking).toBeDefined();
+		expect(thinking?.thinking).toBe(priorThinkingText);
+		// 3p ↔ 3p replay: the source signature is opaque continuation metadata
+		// that compatible endpoints pass through. Stripping it (the pre-fix
+		// behavior) silently demotes the reasoning chain on the next turn.
+		expect(thinking?.signature).toBe("sig_v1");
+		// And the paired tool_use must still be present right after it.
+		const toolUse = priorBlocks.find(b => b.type === "tool_use") as WireToolUseBlock | undefined;
+		expect(toolUse?.id).toBe("toolu_prior");
+	});
+
+	it("keeps the signature on prior turns when the source model matches the target", () => {
+		// Same provider+api+id throughout: signatures are valid and must ride
+		// the wire untouched (prompt-cache stability + Anthropic's all-or-none
+		// invariant).
+		const target = makeAnthropicModel();
+		const messages: Message[] = [
+			makeUser("Summarize README"),
+			makeAssistant([
+				{ type: "thinking", thinking: "plan", thinkingSignature: "sig_same" },
+				{ type: "toolCall", id: "toolu_prior", name: "read", arguments: { path: "README.md" } },
+			]),
+			toolResult("toolu_prior", "README body"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "summarising", thinkingSignature: "sig_latest" },
+					{ type: "text", text: "summary" },
+				],
+				{ stopReason: "stop" },
+			),
+			makeUser("And now in Spanish"),
+		];
+
+		const params = convertAnthropicMessages(messages, target, false);
+		const assistants = params.filter(p => p.role === "assistant");
+		const priorBlocks = assistants[0].content as WireBlock[];
+		const thinking = priorBlocks.find(b => b.type === "thinking") as WireThinkingBlock | undefined;
+		expect(thinking?.thinking).toBe("plan");
+		expect(thinking?.signature).toBe("sig_same");
+	});
+
+	it("preserves redacted_thinking blocks from prior anthropic-messages turns", () => {
+		// Anthropic's "include ALL thinking blocks (including redacted ones)"
+		// rule means redacted_thinking from earlier turns must survive whenever
+		// any thinking content from the same turn is replayed.
+		const target = makeAnthropicModel({ id: "reasoning-model-v2" });
+		const messages: Message[] = [
+			makeUser("Summarize README"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "visible reasoning", thinkingSignature: "sig" },
+					{ type: "redactedThinking", data: "encrypted-blob" },
+					{ type: "toolCall", id: "toolu_prior", name: "read", arguments: { path: "README.md" } },
+				],
+				{ model: "reasoning-model-v1" },
+			),
+			toolResult("toolu_prior", "README body"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "later", thinkingSignature: "sig_latest" },
+					{ type: "text", text: "summary" },
+				],
+				{ model: "reasoning-model-v2", stopReason: "stop" },
+			),
+			makeUser("Translate"),
+		];
+
+		const params = convertAnthropicMessages(messages, target, false);
+		const assistants = params.filter(p => p.role === "assistant");
+		const priorBlocks = assistants[0].content as WireBlock[];
+		const redacted = priorBlocks.find(b => b.type === "redacted_thinking") as WireRedactedBlock | undefined;
+		expect(redacted).toBeDefined();
+		expect(redacted?.data).toBe("encrypted-blob");
+	});
+
+	it("strips foreign signatures and drops redacted_thinking when the target is official Anthropic", () => {
+		// 3p → official Anthropic. The official endpoint rejects foreign
+		// signatures cryptographically, and `replayUnsignedThinking: false`
+		// demotes the unsigned visible thinking to text downstream, so the
+		// matching redacted sibling must not remain as a lone native
+		// redacted_thinking block.
+		const target = makeAnthropicModel({
+			provider: "anthropic",
+			id: "claude-sonnet-4-6",
+			baseUrl: "https://api.anthropic.com",
+		});
+		const messages: Message[] = [
+			makeUser("Summarize README"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "visible reasoning", thinkingSignature: "sig_custom" },
+					{ type: "redactedThinking", data: "foreign-encrypted-blob" },
+					{ type: "toolCall", id: "toolu_prior", name: "read", arguments: { path: "README.md" } },
+				],
+				{ model: "reasoning-model-v1" },
+			),
+			toolResult("toolu_prior", "README body"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "official latest", thinkingSignature: "sig_latest" },
+					{ type: "text", text: "summary" },
+				],
+				{
+					provider: "anthropic",
+					model: "claude-sonnet-4-6",
+					stopReason: "stop",
+				},
+			),
+			makeUser("Translate"),
+		];
+
+		const params = convertAnthropicMessages(messages, target, false);
+		const assistants = params.filter(p => p.role === "assistant");
+		const priorBlocks = assistants[0].content as WireBlock[];
+		const text = priorBlocks.find(b => b.type === "text") as WireTextBlock | undefined;
+		expect(text?.text).toBe("visible reasoning");
+		expect(priorBlocks.find(b => b.type === "thinking")).toBeUndefined();
+		expect(priorBlocks.find(b => b.type === "redacted_thinking")).toBeUndefined();
+	});
+
+	it("strips official Anthropic source signatures on cross-model replay to a 3p target", () => {
+		// official Anthropic → 3p. Anthropic's signature is bound to the
+		// issuing model+session, so the 3p target cannot reverify or
+		// meaningfully continue from it; passing it through would leak
+		// private continuation metadata for no benefit. The unsigned thinking
+		// is still emitted natively because the 3p target's compat advertises
+		// `replayUnsignedThinking: true`.
+		const target = makeAnthropicModel({ id: "reasoning-model-v2" });
+		const messages: Message[] = [
+			makeUser("Summarize README"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "anthropic reasoning", thinkingSignature: "sig_anthropic" },
+					{ type: "toolCall", id: "toolu_prior", name: "read", arguments: { path: "README.md" } },
+				],
+				{ provider: "anthropic", model: "claude-sonnet-4-6" },
+			),
+			toolResult("toolu_prior", "README body"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "v2 reasoning", thinkingSignature: "sig_v2" },
+					{ type: "text", text: "summary" },
+				],
+				{ model: "reasoning-model-v2", stopReason: "stop" },
+			),
+			makeUser("Translate"),
+		];
+
+		const params = convertAnthropicMessages(messages, target, false);
+		const assistants = params.filter(p => p.role === "assistant");
+		const priorBlocks = assistants[0].content as WireBlock[];
+		const thinking = priorBlocks.find(b => b.type === "thinking") as WireThinkingBlock | undefined;
+		expect(thinking?.thinking).toBe("anthropic reasoning");
+		expect(thinking?.signature).toBe("");
+	});
+
+	it("does not promote prior unsigned thinking from non-anthropic sources to thinking blocks", () => {
+		// Cross-API replay: prior turn came from OpenAI-responses with no
+		// Anthropic signature. The all-or-none rule scope is per-API; we must
+		// not invent thinking blocks for a turn whose source can't sign them —
+		// the existing cross-API text demotion is the right behavior.
+		const target = makeAnthropicModel();
+		const messages: Message[] = [
+			makeUser("Summarize README"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "openai chain-of-thought", thinkingSignature: "" },
+					{ type: "toolCall", id: "toolu_prior", name: "read", arguments: { path: "README.md" } },
+				],
+				{
+					api: "openai-responses",
+					provider: "openai",
+					model: "o1-preview",
+				} as Partial<AssistantMessage>,
+			),
+			toolResult("toolu_prior", "README body"),
+			makeAssistant(
+				[
+					{ type: "thinking", thinking: "anthropic latest", thinkingSignature: "sig_latest" },
+					{ type: "text", text: "summary" },
+				],
+				{ stopReason: "stop" },
+			),
+			makeUser("Translate"),
+		];
+
+		const params = convertAnthropicMessages(messages, target, false);
+		const assistants = params.filter(p => p.role === "assistant");
+		const priorBlocks = assistants[0].content as WireBlock[];
+		expect(priorBlocks.find(b => b.type === "thinking")).toBeUndefined();
+		// Reasoning text still survives on the wire (as text, via the existing
+		// cross-API demotion path).
+		const text = priorBlocks.find(b => b.type === "text") as WireTextBlock | undefined;
+		expect(text?.text).toBe("openai chain-of-thought");
+	});
+});


### PR DESCRIPTION
## Repro

Run a multi-turn `anthropic-messages → anthropic-messages` conversation where prior turns came from a different model id (custom anthropic-messages providers via `models.yaml`, session-level model swaps, or 3p ↔ 3p continuations such as DeepSeek → Z.AI). Without this fix the prior `thinking` block is silently demoted to plain `text`, `redacted_thinking` siblings are dropped, and any source signatures the 3p target would have honored as opaque continuation hints are stripped.

```sh
bun test test/anthropic-prior-turn-thinking.test.ts
```

The new suite reproduces all three losses against a custom anthropic-compatible model on `main`; the failing cases are "preserves the prior thinking block as native `thinking` across compatible endpoints", "preserves redacted_thinking blocks from prior anthropic-messages turns", and "strips official Anthropic source signatures on cross-model replay to a 3p target".

## Cause

`packages/ai/src/providers/transform-messages.ts` gated the anthropic preservation flag on `index === latestSurvivingAssistantIndex`:

```ts
const mustPreserveLatestAnthropicThinking =
    index === latestSurvivingAssistantIndex &&
    model.api === "anthropic-messages" &&
    assistantMsg.api === "anthropic-messages";
```

Every prior `anthropic-messages → anthropic-messages` turn that wasn't `isSameModel` fell through to the cross-API text-demotion path (`thinking → text`, `redactedThinking → drop`), violating Anthropic's "include ALL thinking blocks (including redacted ones)" contract on every cross-model continuation (#2257). A separate axis — signature stripping — was applied to every cross-model boundary regardless of whether official Anthropic was involved, silently degrading 3p ↔ 3p replays whose target accepts source signatures as opaque continuation hints (#2265).

## Fix

- Lift the latest-only restriction with a new `isAnthropicReplay` (`isAnthropicTarget && assistantMsg.api === "anthropic-messages"`) plus `isLatestSurvivingAssistant`. Prior turns now keep `thinking` and `redactedThinking` blocks as native blocks across model/provider boundaries, covering custom anthropic-messages providers and session-level model switches.
- Gate cross-model signature stripping on whether official Anthropic is on either end of the replay. Source-side detection uses the canonical catalog provider id `"anthropic"` (assistant messages carry no `baseUrl`); target-side detection reads the baked `compat.officialEndpoint` flag. 3p ↔ 3p replays preserve signatures so the reasoning chain stays signed; official involvement strips them so the downstream encoder applies its existing `replayUnsignedThinking` policy (unsigned thinking is emitted natively on compatible reasoning endpoints and demoted to text on official Anthropic).
- Keep Anthropic's byte-for-byte rule for the latest abandoned-tool-use turn (the `abandonedToolUse` exemption is now scoped to `isLatestSurvivingAssistant`). Aborted/errored last-block sanitization is unchanged.
- Drop redacted_thinking only when the cross-model visible thinking will demote to text (target without `replayUnsignedThinking` and the turn is neither same-model nor the latest byte-for-byte one) to avoid a lone native `redacted_thinking` block beside text-demoted reasoning.
- Cross-API replays (e.g. OpenAI-responses → anthropic-messages) keep the original text-demotion fallback so foreign chains-of-thought are never promoted into native `thinking` blocks they can't sign.

## Verification

```sh
bun test test/anthropic-prior-turn-thinking.test.ts \
  test/anthropic-thinking-immutability.test.ts \
  test/anthropic-thinking-only-length-truncated.test.ts \
  test/anthropic-unsigned-thinking-replay.test.ts \
  test/anthropic-abandoned-tooluse-replay.test.ts \
  test/transform-messages-dedup.test.ts
# 25 pass, 0 fail

bun test
# 1571 pass, 337 skip, 0 fail (packages/ai)

bun check
# clean
```

Fixes #2257
Fixes #2265