### PR TITLE
fix(tui): replaced thinking.autoPending question-mark glyphs with loading indicators

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed the `thinking.autoPending` statusbar indicator using question-mark glyphs (`▣?`, nf-md-help_box, `[?]`) in every symbol preset, which made the auto-thinking pending state indistinguishable from a terminal missing-glyph fallback. Replaced with clear loading indicators (`⟳`, fa-circle-o-notch, `[~]`) ([#2267](https://github.com/can1357/oh-my-pi/issues/2267)).
+
 ## [15.10.12] - 2026-06-10
 
 ### Added

--- a/packages/coding-agent/src/modes/theme/theme.ts
+++ b/packages/coding-agent/src/modes/theme/theme.ts
@@ -328,7 +328,7 @@ const UNICODE_SYMBOLS: SymbolMap = {
 	"thinking.medium": "◒ med",
 	"thinking.high": "◕ high",
 	"thinking.xhigh": "◉ xhigh",
-	"thinking.autoPending": "▣?",
+	"thinking.autoPending": "⟳",
 	// Checkboxes
 	"checkbox.checked": "☑",
 	"checkbox.unchecked": "☐",
@@ -610,8 +610,8 @@ const NERD_SYMBOLS: SymbolMap = {
 	"thinking.high": "\u{F111} high",
 	// pick: 🧠 xhi | alt:  xhi  xhi
 	"thinking.xhigh": "\u{F06D} xhi",
-	// pick: 󰞋 (nf-md-help_box) | alt:  [?]
-	"thinking.autoPending": "\u{f078b}",
+	// pick:  (fa-circle-o-notch) | alt: 󰂼 (nf-md-cached) ⟳
+	"thinking.autoPending": "\uf1ce",
 	// Checkboxes
 	// pick:  | alt:  
 	"checkbox.checked": "\uf14a",
@@ -814,7 +814,7 @@ const ASCII_SYMBOLS: SymbolMap = {
 	"thinking.medium": "[med]",
 	"thinking.high": "[high]",
 	"thinking.xhigh": "[xhi]",
-	"thinking.autoPending": "[?]",
+	"thinking.autoPending": "[~]",
 	// Checkboxes
 	"checkbox.checked": "[x]",
 	"checkbox.unchecked": "[ ]",


### PR DESCRIPTION
## Repro

In the status-bar, when auto-thinking is enabled but no level has been resolved for the current turn yet, the indicator next to the model name renders as a question-mark glyph in every symbol preset:

| Preset | Observed |
| :--- | :--- |
| Unicode | `▣? auto` |
| Nerd Font | `󰞋 auto` |
| ASCII | `[?] auto` |

All three are visually indistinguishable from a terminal missing-glyph fallback, so users assume the font/icon is broken and cycle through `/settings` presets without effect.

Reproduction is purely declarative — the values are wired in `packages/coding-agent/src/modes/theme/theme.ts` and surfaced via `theme.thinking.autoPending` from `footer.ts:210` and `status-line/segments.ts:98`.

## Cause

`thinking.autoPending` was intentionally given `?`-shaped glyphs to convey "unknown level":

- `theme.ts:331` (Unicode preset) — `"▣?"` = `U+25A3` (white square) + literal `U+003F` question mark.
- `theme.ts:614` (Nerd Font preset) — `"\u{f078b}"` = `nf-md-help_box`, which is a question mark inside a square.
- `theme.ts:817` (ASCII preset) — `"[?]"` = literal bracketed question mark.

The "?" semantics collide with the universal terminal convention of a `?` glyph indicating an unavailable codepoint, so the icon reads as broken rather than as "pending".

## Fix

`packages/coding-agent/src/modes/theme/theme.ts`

- Replaced each preset's `thinking.autoPending` value with an unambiguous loading indicator that doesn't carry `?` glyph semantics:
  - Unicode: `⟳` (`U+27F3` Clockwise Gapped Circle Arrow) — distinct from `icon.loop` (`↻`) and `icon.auto` (`⟲`).
  - Nerd Font: `\uf1ce` (`nf-fa-circle_o_notch`) — the de-facto FontAwesome loading-spinner glyph.
  - ASCII: `[~]`.
- Refreshed the inline `// pick / alt` comment on the Nerd Font entry.

`packages/coding-agent/CHANGELOG.md`

- Added an `[Unreleased] / Fixed` entry referencing #2267.

No call sites change; both `footer.ts` and `segments.ts` consume `theme.thinking.autoPending` directly.

## Verification

- `bun test test/theme-auto-detection.test.ts test/theme-islight.test.ts test/theme-spinner-frames.test.ts` → 11 pass / 0 fail.
- `bun test test/status-line-overflow.test.ts test/status-line-cache-hit.test.ts test/status-text-sanitization.test.ts` → 14 pass / 0 fail.
- `bun check` → clean (TS workspaces + Rust crates).

Fixes #2267