### PR TITLE
fix(coding-agent): hashline edit steering for Grok Composer + enforced eval/bash write blocks

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Grok Composer 2.5 Fast bypassing hashline `edit` via scripted `bash` and `eval` writes when `edit` is available ([#2272](https://github.com/can1357/oh-my-pi/issues/2272)): bash interceptor rules for write-only `python -c` / `node -e` / `bun -e` (including `Bun.write`, `appendFile*`, multiline payloads, `Path.open`/`write_bytes`, env/`/usr/bin/env` wrappers) with shared `HASHLINE_EDIT_INPUT_GUIDANCE` on block; enforced eval project-path write blocks for JS (`node:fs`, `fs/promises`, prelude `write`/`append`, guarded `Bun.write`) and Python (`builtins.open`, `io.open`, `Path.open`, `write_text`/`write_bytes` via immutable `eval_guard`); malformed hashline `edit` input surfaces actionable `ToolError` via `parseHashlineEditInput`.
+
 ## [15.11.0] - 2026-06-10
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -245,6 +245,20 @@ export const DEFAULT_BASH_INTERCEPTOR_RULES: BashInterceptorRule[] = [
 		message: "Use the `edit` tool instead of awk -i inplace. It provides diff preview and fuzzy matching.",
 	},
 	{
+		pattern:
+			"^\\s*python(?:3(?:\\.\\d+)?)?(?:\\.exe)?\\b[^\\n\\r]*\\s+-c\\b[\\s\\S]*(?:\\.(?:write_text|write_bytes)\\s*\\(|Path\\s*\\([^\\)]*\\)\\s*\\.open\\s*\\(\\s*['\"](?:(?:w|a|x)[^'\"]*|[^'\"]*\\+[^'\"]*)[^'\"]*['\"]|Path\\s*\\([^\\)]*\\)\\s*\\.writelines\\s*\\(|open\\s*\\([^\\)]*\\)\\s*\\.writelines\\s*\\(|open\\s*\\([^\\)]*,\\s*['\"][^'\"]*(?:(?:w|a|x)[^'\"]*|[^'\"]*\\+[^'\"]*)[^'\"]*['\"]|open\\s*\\([^\\)]*mode\\s*=\\s*['\"](?:(?:w|a|x)[^'\"]*|[^'\"]*\\+[^'\"]*)[^'\"]*['\"]|open\\s*\\([^\\)]*\\)\\s*\\.write\\s*\\()",
+		tool: "edit",
+		message:
+			"Use the `edit` tool (hashline `input`) instead of `python -c` to change files. Copy `[PATH#TAG]` from `read`/`search`, then add hashline ops.",
+	},
+	{
+		pattern:
+			"^\\s*(?:node|nodejs|bun)(?:\\.exe)?\\b[^\\n\\r]*\\s+-e\\b[\\s\\S]*(?:\\b(?:write|append)File(?:Sync)?\\s*\\(|Bun\\.write\\s*\\()",
+		tool: "edit",
+		message:
+			"Use the `edit` tool instead of `node -e` / `bun -e` file writes. Pass hashline sections in `edit`'s `input` parameter.",
+	},
+	{
 		// `>` must sit outside quoted regions (so `echo "a -> b"` passes) and be
 		// followed by a plausible filename — including `$VAR` targets; `>|`
 		// (clobber) counts as a redirect; `>&2`/`2>&1` style fd duplication is

--- a/packages/coding-agent/src/edit/hashline/execute.ts
+++ b/packages/coding-agent/src/edit/hashline/execute.ts
@@ -14,7 +14,6 @@ import {
 	type BlockResolution,
 	buildCompactDiffPreview,
 	MismatchError as HashlineMismatchError,
-	Patch,
 	Patcher,
 	type PatchSectionResult,
 	type PreparedSection,
@@ -31,6 +30,7 @@ import { nativeBlockResolver } from "./block-resolver";
 import { HashlineFilesystem } from "./filesystem";
 import { hashPatchInput, NOOP_HARD_LIMIT, recordNoopEdit, resetNoopEdit } from "./noop-loop-guard";
 import { type HashlineParams, hashlineEditParamsSchema } from "./params";
+import { parseHashlineEditInput } from "./parse-input";
 
 export interface ExecuteHashlineSingleOptions {
 	session: ToolSession;
@@ -160,10 +160,7 @@ function renderSection(result: PatchSectionResult, diagnostics: FileDiagnosticsR
 export async function executeHashlineSingle(
 	options: ExecuteHashlineSingleOptions,
 ): Promise<AgentToolResult<EditToolDetails, typeof hashlineEditParamsSchema>> {
-	const patch = Patch.parse(options.input, { cwd: options.session.cwd });
-	if (patch.sections.length === 0) {
-		throw new Error("No hashline sections found in input.");
-	}
+	const patch = parseHashlineEditInput(options.input, options.session.cwd);
 
 	const fs = new HashlineFilesystem({
 		session: options.session,

--- a/packages/coding-agent/src/edit/hashline/guidance.ts
+++ b/packages/coding-agent/src/edit/hashline/guidance.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared inline guidance for hashline `edit` — surfaced on parse failures and bash
+ * interceptor blocks (not model-specific system prompts).
+ */
+export const HASHLINE_EDIT_INPUT_GUIDANCE =
+	"Call `edit` with a hashline `input` string: copy a `[PATH#TAG]` header from your latest `read`/`search`, then add ops (`replace N..M:`, `insert after N:`, `delete N`, …) with `+` body rows. Do not edit files via `bash` (`python -c`, `node -e`, `bun -e`, `sed`) or `eval` when `edit` is available.";
+
+/** Message body when bash blocks scripted file IO in favor of `edit`. */
+export function bashInterceptScriptedEditMessage(shellHint: string): string {
+	return `Use the \`edit\` tool instead of ${shellHint} to change files. ${HASHLINE_EDIT_INPUT_GUIDANCE}`;
+}

--- a/packages/coding-agent/src/edit/hashline/parse-input.ts
+++ b/packages/coding-agent/src/edit/hashline/parse-input.ts
@@ -1,0 +1,18 @@
+import { Patch } from "@oh-my-pi/hashline";
+import { ToolError } from "../../tools/tool-errors";
+import { HASHLINE_EDIT_INPUT_GUIDANCE } from "./guidance";
+
+/** Parse hashline edit input; surfaces a single actionable {@link ToolError} for prose/JSON/malformed input. */
+export function parseHashlineEditInput(input: string, cwd: string) {
+	try {
+		const patch = Patch.parse(input, { cwd });
+		if (patch.sections.length === 0) {
+			throw new ToolError(`No hashline sections found in input. ${HASHLINE_EDIT_INPUT_GUIDANCE}`);
+		}
+		return patch;
+	} catch (error) {
+		if (error instanceof ToolError) throw error;
+		const detail = error instanceof Error ? error.message : String(error);
+		throw new ToolError(`${detail} ${HASHLINE_EDIT_INPUT_GUIDANCE}`);
+	}
+}

--- a/packages/coding-agent/src/eval/eval-fs-guard.ts
+++ b/packages/coding-agent/src/eval/eval-fs-guard.ts
@@ -1,0 +1,515 @@
+import type * as FsType from "node:fs";
+import type * as FsPromisesType from "node:fs/promises";
+import { ToolError } from "../tools/tool-errors";
+import { createBlockedBunSpawn, guardChildProcessModule, isChildProcessModuleId } from "./eval-subprocess-guard";
+import {
+	EVAL_SOURCE_WRITE_BLOCKED_MESSAGE,
+	isEvalArtifactWritePath,
+	isEvalLocalRootFilesystemPath,
+} from "./eval-write-guard";
+
+export type EvalFsPathGuard = (rawPath: unknown) => void;
+
+/** Options for dynamic `import()` in eval (matches runtime `__omp_import__`; global from Bun types). */
+export type EvalDynamicImportOptions = ImportCallOptions;
+
+function pathArgFromUnknown(arg: unknown): string | URL | undefined {
+	if (typeof arg === "string" || arg instanceof URL) return arg;
+	if (typeof Buffer !== "undefined" && Buffer.isBuffer(arg)) {
+		return arg.toString("utf8");
+	}
+	if (arg && typeof arg === "object" && "path" in arg) {
+		const nested = (arg as { path?: unknown }).path;
+		if (typeof nested === "string" || nested instanceof URL) return nested;
+		if (typeof Buffer !== "undefined" && Buffer.isBuffer(nested)) {
+			return nested.toString("utf8");
+		}
+	}
+	return undefined;
+}
+
+function firstPathArg(args: unknown[]): unknown {
+	for (const arg of args) {
+		const path = pathArgFromUnknown(arg);
+		if (path !== undefined) return path;
+	}
+	return undefined;
+}
+
+const guardedWriteFdPaths = new Map<number, string>();
+
+function isNodeFsWriteOpenMode(mode: unknown): boolean {
+	if (mode === undefined || mode === null) return false;
+	if (typeof mode === "number") {
+		// Node O_* flags: O_WRONLY (1), O_RDWR (2), O_CREAT (64), O_TRUNC (512), O_APPEND (1024)
+		return (mode & 0x41) !== 0 || (mode & 0x402) !== 0 || (mode & 0x200) !== 0;
+	}
+	const m = String(mode);
+	if (!m || m === "r") return false;
+	if (m.includes("+")) return true;
+	return /[wax+]/i.test(m);
+}
+
+function registerGuardedFd(fd: unknown, rawPath: unknown): void {
+	if (typeof fd !== "number" || rawPath === undefined || rawPath === null) return;
+	guardedWriteFdPaths.set(fd, rawPath instanceof URL ? rawPath.pathname : String(rawPath));
+}
+
+function pathFromFd(fd: number): string | undefined {
+	return guardedWriteFdPaths.get(fd);
+}
+
+function unregisterGuardedFd(fd: unknown): void {
+	if (typeof fd === "number") guardedWriteFdPaths.delete(fd);
+}
+
+/** Stdio fds are not project paths; allow writes without fd-map lookup. */
+const STDIO_FD_MAX = 2;
+
+function pathFromWriteFdArg(args: unknown[]): unknown {
+	const fd = args[0];
+	if (typeof fd !== "number") return firstPathArg(args);
+	if (fd >= 0 && fd <= STDIO_FD_MAX) return undefined;
+	const mapped = pathFromFd(fd);
+	if (mapped === undefined) {
+		throw new ToolError(EVAL_SOURCE_WRITE_BLOCKED_MESSAGE);
+	}
+	return mapped;
+}
+
+function pathFromWriteTargetArg(args: unknown[]): unknown {
+	const first = args[0];
+	if (typeof first === "number") {
+		if (first >= 0 && first <= STDIO_FD_MAX) return undefined;
+		const mapped = pathFromFd(first);
+		if (mapped === undefined) {
+			throw new ToolError(EVAL_SOURCE_WRITE_BLOCKED_MESSAGE);
+		}
+		return mapped;
+	}
+	return firstPathArg(args);
+}
+
+export function createEvalFsPathGuard(block: boolean, localRoots: Record<string, string>): EvalFsPathGuard | undefined {
+	if (!block) return undefined;
+	return (rawPath: unknown) => {
+		if (rawPath === undefined || rawPath === null) return;
+		const text = rawPath instanceof URL ? rawPath.pathname : String(rawPath);
+		if (isEvalArtifactWritePath(text, localRoots)) return;
+		if (isEvalLocalRootFilesystemPath(text, localRoots)) return;
+		throw new ToolError(EVAL_SOURCE_WRITE_BLOCKED_MESSAGE);
+	};
+}
+
+function guardFileHandleWrites(handle: unknown, _guard: EvalFsPathGuard): unknown {
+	// Open path is guarded in fs.promises.open / openSync; handle methods take data, not paths.
+	return handle;
+}
+
+function renamePaths(args: unknown[]): unknown[] {
+	const paths: unknown[] = [];
+	for (const index of [0, 1]) {
+		const raw = pathArgFromUnknown(args[index]);
+		if (raw !== undefined) paths.push(raw);
+	}
+	return paths;
+}
+
+function linkPaths(args: unknown[]): unknown[] {
+	const paths: unknown[] = [];
+	for (const index of [0, 1]) {
+		const raw = pathArgFromUnknown(args[index]);
+		if (raw !== undefined) paths.push(raw);
+	}
+	return paths;
+}
+
+function wrapCallback(
+	fn: (...args: unknown[]) => unknown,
+	guard: EvalFsPathGuard | undefined,
+	getPath: (args: unknown[]) => unknown,
+): (...args: unknown[]) => unknown {
+	if (!guard) return fn;
+	return (...args: unknown[]) => {
+		applyPathGuard(guard, getPath(args));
+		return fn(...args);
+	};
+}
+
+function applyPathGuard(guard: EvalFsPathGuard, raw: unknown): void {
+	if (Array.isArray(raw)) {
+		for (const entry of raw) {
+			if (entry !== undefined) guard(entry);
+		}
+		return;
+	}
+	if (raw !== undefined) guard(raw);
+}
+
+function wrapSync(
+	fn: (...args: unknown[]) => unknown,
+	guard: EvalFsPathGuard | undefined,
+	getPath: (args: unknown[]) => unknown,
+): (...args: unknown[]) => unknown {
+	if (!guard) return fn;
+	return (...args: unknown[]) => {
+		applyPathGuard(guard, getPath(args));
+		return fn(...args);
+	};
+}
+
+const WRITE_SYNC_METHODS: Array<{
+	key: string;
+	getPath: (args: unknown[]) => unknown;
+}> = [
+	{ key: "writeFileSync", getPath: pathFromWriteTargetArg },
+	{ key: "openSync", getPath: firstPathArg },
+	{ key: "appendFileSync", getPath: pathFromWriteTargetArg },
+	{ key: "writeSync", getPath: pathFromWriteFdArg },
+	{ key: "truncateSync", getPath: firstPathArg },
+	{ key: "renameSync", getPath: renamePaths },
+	{ key: "copyFileSync", getPath: args => args[1] },
+	{ key: "cpSync", getPath: args => args[1] },
+	{ key: "mkdirSync", getPath: firstPathArg },
+	{ key: "rmSync", getPath: firstPathArg },
+	{ key: "rmdirSync", getPath: firstPathArg },
+	{ key: "unlinkSync", getPath: firstPathArg },
+	{ key: "symlinkSync", getPath: linkPaths },
+	{ key: "linkSync", getPath: linkPaths },
+];
+
+const WRITE_CALLBACK_METHODS: Array<{
+	key: string;
+	getPath: (args: unknown[]) => unknown;
+}> = [
+	{ key: "writeFile", getPath: pathFromWriteTargetArg },
+	{ key: "appendFile", getPath: pathFromWriteTargetArg },
+	{ key: "truncate", getPath: firstPathArg },
+	{ key: "rename", getPath: renamePaths },
+	{ key: "copyFile", getPath: args => args[1] },
+	{ key: "cp", getPath: args => args[1] },
+	{ key: "mkdir", getPath: firstPathArg },
+	{ key: "rm", getPath: firstPathArg },
+	{ key: "rmdir", getPath: firstPathArg },
+	{ key: "unlink", getPath: firstPathArg },
+	{ key: "symlink", getPath: linkPaths },
+	{ key: "link", getPath: linkPaths },
+];
+
+const WRITE_PROMISE_METHODS: Array<{
+	key: keyof typeof FsPromisesType;
+	getPath: (args: unknown[]) => unknown;
+}> = [
+	{ key: "writeFile", getPath: pathFromWriteTargetArg },
+	{ key: "appendFile", getPath: pathFromWriteTargetArg },
+	{ key: "truncate", getPath: firstPathArg },
+	{ key: "rename", getPath: renamePaths },
+	{ key: "copyFile", getPath: args => args[1] },
+	{ key: "cp", getPath: args => args[1] },
+	{ key: "mkdir", getPath: firstPathArg },
+	{ key: "rm", getPath: firstPathArg },
+	{ key: "rmdir", getPath: firstPathArg },
+	{ key: "unlink", getPath: firstPathArg },
+	{ key: "symlink", getPath: linkPaths },
+	{ key: "link", getPath: linkPaths },
+];
+
+export function createGuardedFsModule(fs: typeof FsType, guard: EvalFsPathGuard | undefined): typeof FsType {
+	if (!guard) return fs;
+	const out = { ...fs } as typeof FsType;
+	for (const { key, getPath } of WRITE_SYNC_METHODS) {
+		const fn = (fs as Record<string, unknown>)[key];
+		if (typeof fn === "function") {
+			if (key === "openSync") {
+				(out as Record<string, unknown>).openSync = ((...args: unknown[]) => {
+					const raw = getPath(args);
+					const mode = args[1];
+					if (isNodeFsWriteOpenMode(mode)) guard!(raw);
+					const fd = (fn as (...a: unknown[]) => number)(...args);
+					if (isNodeFsWriteOpenMode(mode)) registerGuardedFd(fd, raw);
+					return fd;
+				}) as typeof fs.openSync;
+				const realClose = fs.closeSync;
+				if (typeof realClose === "function") {
+					(out as Record<string, unknown>).closeSync = ((fd: number) => {
+						unregisterGuardedFd(fd);
+						return realClose(fd);
+					}) as typeof fs.closeSync;
+				}
+				continue;
+			}
+			(out as Record<string, unknown>)[key as string] = wrapSync(
+				fn as (...args: unknown[]) => unknown,
+				guard,
+				getPath,
+			);
+		}
+	}
+
+	const realOpen = fs.open;
+	if (typeof realOpen === "function") {
+		(out as Record<string, unknown>).open = ((...args: unknown[]) => {
+			const raw = firstPathArg(args);
+			let cbIndex = -1;
+			for (let i = args.length - 1; i >= 0; i--) {
+				if (typeof args[i] === "function") {
+					cbIndex = i;
+					break;
+				}
+			}
+			let mode: unknown = "r";
+			if (cbIndex === 2) mode = args[1];
+			else if (cbIndex === 3) mode = args[2];
+			else if (cbIndex < 0 && args.length >= 2) mode = args[1];
+			if (isNodeFsWriteOpenMode(mode)) guard!(raw);
+			if (cbIndex < 0) {
+				return (realOpen as (...a: unknown[]) => unknown).apply(fs, args);
+			}
+			const userCb = args[cbIndex] as (err: NodeJS.ErrnoException | null, fd?: number) => void;
+			const next = [...args];
+			next[cbIndex] = (err: NodeJS.ErrnoException | null, fd?: number) => {
+				if (!err && fd !== undefined && isNodeFsWriteOpenMode(mode)) {
+					registerGuardedFd(fd, raw);
+				}
+				userCb(err, fd);
+			};
+			return (realOpen as (...a: unknown[]) => unknown).apply(fs, next);
+		}) as typeof fs.open;
+	}
+	const realClose = fs.close;
+	if (typeof realClose === "function") {
+		(out as Record<string, unknown>).close = ((...args: unknown[]) => {
+			const fd = args[0];
+			let cbIndex = -1;
+			for (let i = args.length - 1; i >= 0; i--) {
+				if (typeof args[i] === "function") {
+					cbIndex = i;
+					break;
+				}
+			}
+			if (cbIndex < 0) {
+				unregisterGuardedFd(fd);
+				return (realClose as (...a: unknown[]) => unknown).apply(fs, args);
+			}
+			const userCb = args[cbIndex] as (err: NodeJS.ErrnoException | null) => void;
+			const next = [...args];
+			next[cbIndex] = (err: NodeJS.ErrnoException | null) => {
+				if (!err) unregisterGuardedFd(fd);
+				userCb(err);
+			};
+			return (realClose as (...a: unknown[]) => unknown).apply(fs, next);
+		}) as typeof fs.close;
+	}
+	for (const { key, getPath } of WRITE_CALLBACK_METHODS) {
+		const fn = (fs as Record<string, unknown>)[key];
+		if (typeof fn === "function") {
+			(out as Record<string, unknown>)[key] = wrapCallback(fn as (...args: unknown[]) => unknown, guard, getPath);
+		}
+	}
+	const promises = { ...fs.promises };
+	for (const { key, getPath } of WRITE_PROMISE_METHODS) {
+		const fn = fs.promises[key];
+		if (typeof fn === "function") {
+			(promises as Record<string, unknown>)[key as string] = wrapSync(
+				fn as (...args: unknown[]) => unknown,
+				guard,
+				getPath,
+			);
+		}
+	}
+
+	const realPromisesOpen = fs.promises.open;
+	if (typeof realPromisesOpen === "function") {
+		(promises as Record<string, unknown>).open = (async (...args: unknown[]) => {
+			const raw = firstPathArg(args);
+			const mode = args[1];
+			if (isNodeFsWriteOpenMode(mode)) guard!(raw);
+			const fh = await (realPromisesOpen as (...a: unknown[]) => Promise<unknown>).apply(fs.promises, args);
+			if (isNodeFsWriteOpenMode(mode)) return guardFileHandleWrites(fh, guard!);
+			return fh;
+		}) as typeof fs.promises.open;
+	}
+	(promises as Record<string, unknown>).default = promises;
+
+	const realCreateWriteStream = fs.createWriteStream;
+	if (typeof realCreateWriteStream === "function") {
+		(out as Record<string, unknown>).createWriteStream = ((...args: unknown[]) => {
+			guard!(firstPathArg(args));
+			return realCreateWriteStream.apply(fs, args as never);
+		}) as typeof fs.createWriteStream;
+	}
+	out.promises = promises;
+	(out as Record<string, unknown>).default = out;
+	return out;
+}
+
+export function wrapBuiltinModuleForGuard(
+	specifier: string,
+	mod: unknown,
+	guard: EvalFsPathGuard | undefined,
+	fsModule: typeof FsType,
+): unknown {
+	if (!guard) return mod;
+	const id = specifier.replace(/^node:/, "");
+	if (id === "fs") {
+		return createGuardedFsModule(fsModule, guard);
+	}
+	if (id === "fs/promises") {
+		return createGuardedFsModule(fsModule, guard).promises;
+	}
+	if (id === "child_process") {
+		return guardChildProcessModule(mod as object, true);
+	}
+	return mod;
+}
+
+export function createGuardedRequire(
+	baseRequire: NodeJS.Require,
+	guard: EvalFsPathGuard | undefined,
+	fsModule: typeof FsType,
+): NodeJS.Require {
+	if (!guard) return baseRequire;
+	const guardedFs = createGuardedFsModule(fsModule, guard);
+	const guardedRequire = ((id: string) => {
+		if (id === "fs" || id === "node:fs") {
+			return guardedFs;
+		}
+		if (id === "node:fs/promises" || id === "fs/promises") {
+			return guardedFs.promises;
+		}
+		if (isChildProcessModuleId(id)) {
+			return guardChildProcessModule(baseRequire(id) as object, true);
+		}
+		return baseRequire(id);
+	}) as NodeJS.Require;
+	Object.defineProperties(guardedRequire, {
+		resolve: { value: baseRequire.resolve.bind(baseRequire), configurable: true },
+		cache: { get: () => baseRequire.cache, configurable: true },
+		extensions: { get: () => baseRequire.extensions, configurable: true },
+		main: { get: () => baseRequire.main, configurable: true },
+	});
+	return guardedRequire;
+}
+
+function isFsModuleSpecifier(specifier: string): boolean {
+	return (
+		specifier === "fs" || specifier === "node:fs" || specifier === "fs/promises" || specifier === "node:fs/promises"
+	);
+}
+
+function isNodeModuleSpecifier(specifier: string): boolean {
+	return specifier === "module" || specifier === "node:module";
+}
+
+function wrapImportedModuleNamespace(
+	specifier: string,
+	mod: Record<string, unknown>,
+	guard: EvalFsPathGuard,
+	fsModule: typeof FsType,
+): Record<string, unknown> {
+	if (!isNodeModuleSpecifier(specifier)) {
+		return mod;
+	}
+	const createRequireFn = mod.createRequire;
+	if (typeof createRequireFn !== "function") {
+		return mod;
+	}
+	const guardedCreateRequire = createGuardedCreateRequire(
+		createRequireFn as typeof import("node:module").createRequire,
+		guard,
+		fsModule,
+	);
+	const out: Record<string, unknown> = { ...mod, createRequire: guardedCreateRequire };
+	if (mod.default && typeof mod.default === "object") {
+		out.default = { ...(mod.default as Record<string, unknown>), createRequire: guardedCreateRequire };
+	}
+	return out;
+}
+
+export async function guardedImportModuleNamespace(
+	specifier: string,
+	guard: EvalFsPathGuard | undefined,
+	fsModule: typeof FsType,
+	importFn: (target: string, options?: EvalDynamicImportOptions) => Promise<unknown>,
+	options?: EvalDynamicImportOptions,
+): Promise<unknown> {
+	const target = specifier;
+	const mod = (await (options !== undefined ? importFn(target, options) : importFn(target))) as Record<
+		string,
+		unknown
+	>;
+	if (!guard) return mod;
+	if (isChildProcessModuleId(target)) {
+		return guardChildProcessModule(mod as object, true);
+	}
+	if (isNodeModuleSpecifier(target)) {
+		return wrapImportedModuleNamespace(target, mod, guard, fsModule);
+	}
+	if (!isFsModuleSpecifier(target)) return mod;
+	if (target === "node:fs/promises" || target === "fs/promises") {
+		const guarded = createGuardedFsModule(fsModule, guard);
+		const promises = guarded.promises as typeof guarded.promises & { default?: typeof guarded.promises };
+		(promises as Record<string, unknown>).default ??= promises;
+		return promises;
+	}
+	return createGuardedFsModule(fsModule, guard);
+}
+
+export function createGuardedCreateRequire(
+	baseCreateRequire: typeof import("node:module").createRequire,
+	guard: EvalFsPathGuard | undefined,
+	fsModule: typeof FsType,
+): typeof import("node:module").createRequire {
+	if (!guard) return baseCreateRequire;
+	return ((filenameOrUrl: string | URL) => {
+		const base = baseCreateRequire(filenameOrUrl);
+		return createGuardedRequire(base, guard, fsModule);
+	}) as typeof import("node:module").createRequire;
+}
+
+export function createGuardedBunNamespace(guard: EvalFsPathGuard | undefined): unknown | undefined {
+	if (!guard || typeof globalThis.Bun === "undefined") return undefined;
+	const bun = globalThis.Bun as { write?: (destination: unknown, ...rest: unknown[]) => Promise<unknown> };
+	if (typeof bun.write !== "function") return globalThis.Bun;
+	const realWrite = bun.write.bind(bun);
+	const blockSpawn = createBlockedBunSpawn();
+	return new Proxy(bun, {
+		get(target, prop, receiver) {
+			if (prop === "write") {
+				return async (destination: unknown, ...rest: unknown[]) => {
+					guard(destination);
+					return realWrite(destination, ...rest);
+				};
+			}
+			if (prop === "file") {
+				const realFile = Reflect.get(target, prop, receiver);
+				if (typeof realFile !== "function") {
+					return realFile;
+				}
+				return (path: unknown, ...rest: unknown[]) => {
+					const handle = realFile.call(target, path, ...rest) as {
+						writer?: (...args: unknown[]) => unknown;
+						writerSync?: (...args: unknown[]) => unknown;
+					};
+					const wrapWriter =
+						(fn: (...args: unknown[]) => unknown) =>
+						(...wArgs: unknown[]) => {
+							guard(path);
+							return fn.apply(handle, wArgs);
+						};
+					if (typeof handle.writer === "function") {
+						handle.writer = wrapWriter(handle.writer.bind(handle));
+					}
+					if (typeof handle.writerSync === "function") {
+						handle.writerSync = wrapWriter(handle.writerSync.bind(handle));
+					}
+					return handle;
+				};
+			}
+			if (prop === "spawn" || prop === "spawnSync") {
+				return blockSpawn;
+			}
+			return Reflect.get(target, prop, receiver);
+		},
+	});
+}

--- a/packages/coding-agent/src/eval/eval-subprocess-guard.ts
+++ b/packages/coding-agent/src/eval/eval-subprocess-guard.ts
@@ -1,0 +1,66 @@
+import { ToolError } from "../tools/tool-errors";
+import { EVAL_SOURCE_WRITE_BLOCKED_MESSAGE } from "./eval-write-guard";
+
+const CHILD_PROCESS_IDS = new Set(["child_process", "node:child_process"]);
+
+function throwEvalSubprocessBlocked(): never {
+	throw new ToolError(EVAL_SOURCE_WRITE_BLOCKED_MESSAGE);
+}
+
+function wrapChildProcessModule<T extends object>(mod: T): T {
+	const handler: ProxyHandler<object> = {
+		get(target, prop, receiver) {
+			if (
+				prop === "spawn" ||
+				prop === "spawnSync" ||
+				prop === "exec" ||
+				prop === "execSync" ||
+				prop === "execFile" ||
+				prop === "execFileSync" ||
+				prop === "fork"
+			) {
+				return () => throwEvalSubprocessBlocked();
+			}
+			return Reflect.get(target, prop, receiver);
+		},
+	};
+	return new Proxy(mod, handler) as T;
+}
+
+/** When source-write blocking is on, block subprocess APIs that can mutate project files. */
+export function guardChildProcessModule<T extends object>(mod: T, guardActive: boolean): T {
+	if (!guardActive) return mod;
+	return wrapChildProcessModule(mod);
+}
+
+export function isChildProcessModuleId(id: string): boolean {
+	return CHILD_PROCESS_IDS.has(id);
+}
+
+export function createBlockedBunSpawn(): () => never {
+	return () => throwEvalSubprocessBlocked();
+}
+
+/** When guard is active, route Bun/Node getBuiltinModule through guarded builtins. */
+export function guardProcessGetBuiltinModule(
+	processObj: NodeJS.Process,
+	guardActive: boolean,
+	wrapBuiltin: (specifier: string, mod: unknown) => unknown,
+): NodeJS.Process {
+	if (!guardActive) return processObj;
+	const proc = processObj as NodeJS.Process & {
+		getBuiltinModule?: (id: string) => unknown;
+	};
+	if (typeof proc.getBuiltinModule !== "function") {
+		return processObj;
+	}
+	const real = proc.getBuiltinModule.bind(proc);
+	return new Proxy(processObj, {
+		get(target, prop, receiver) {
+			if (prop === "getBuiltinModule") {
+				return (specifier: string) => wrapBuiltin(specifier, real(specifier));
+			}
+			return Reflect.get(target, prop, receiver);
+		},
+	}) as NodeJS.Process;
+}

--- a/packages/coding-agent/src/eval/eval-write-guard.ts
+++ b/packages/coding-agent/src/eval/eval-write-guard.ts
@@ -1,0 +1,38 @@
+import * as path from "node:path";
+import { HASHLINE_EDIT_INPUT_GUIDANCE } from "../edit/hashline/guidance";
+import type { ToolSession } from "../tools";
+
+/** Error message when eval `write`/`append` targets project source while `edit` is available. */
+export const EVAL_SOURCE_WRITE_BLOCKED_MESSAGE = `eval write() and append() cannot change project source files when the edit tool is available. ${HASHLINE_EDIT_INPUT_GUIDANCE}`;
+
+export function sessionHasEditTool(session: ToolSession | undefined): boolean {
+	if (!session) return false;
+	if (session.hasEditTool === true) return true;
+	if (session.hasEditTool === false) return false;
+	return true;
+}
+
+export function shouldBlockEvalSourceWrites(session: ToolSession | undefined): boolean {
+	return sessionHasEditTool(session);
+}
+
+const INTERNAL_URL_RE = /^([a-z][a-z0-9+.-]*):\/\/(.*)$/i;
+
+/** Artifact/session `local://` (and other injected roots) stays writable in eval. */
+export function isEvalArtifactWritePath(rawPath: string, localRoots: Record<string, string>): boolean {
+	const match = INTERNAL_URL_RE.exec(rawPath.trim());
+	if (!match) return false;
+	const scheme = match[1].toLowerCase();
+	return Object.hasOwn(localRoots, scheme);
+}
+/** Resolved artifact paths (after `local://` → disk) stay writable in eval. */
+export function isEvalLocalRootFilesystemPath(rawPath: string, localRoots: Record<string, string>): boolean {
+	const normalized = path.normalize(rawPath);
+	for (const root of Object.values(localRoots)) {
+		const normRoot = path.normalize(root);
+		if (normalized === normRoot || normalized.startsWith(`${normRoot}${path.sep}`)) {
+			return true;
+		}
+	}
+	return false;
+}

--- a/packages/coding-agent/src/eval/js/context-manager.ts
+++ b/packages/coding-agent/src/eval/js/context-manager.ts
@@ -66,6 +66,7 @@ export async function executeInVmContext(options: {
 	cwd: string;
 	session: ToolSession;
 	localRoots?: Record<string, string>;
+	blockProjectSourceWrites?: boolean;
 	reset?: boolean;
 	code: string;
 	filename: string;
@@ -98,7 +99,12 @@ export async function executeInVmContext(options: {
 	}
 	const session = await acquireSession(
 		options.sessionKey,
-		{ cwd: options.cwd, sessionId: options.sessionId, localRoots: options.localRoots },
+		{
+			cwd: options.cwd,
+			sessionId: options.sessionId,
+			localRoots: options.localRoots,
+			blockProjectSourceWrites: options.blockProjectSourceWrites,
+		},
 		options.timeoutMs,
 	);
 	return await runOnce(session, options);
@@ -131,6 +137,7 @@ async function runOnce(
 		cwd: string;
 		session: ToolSession;
 		localRoots?: Record<string, string>;
+		blockProjectSourceWrites?: boolean;
 		code: string;
 		filename: string;
 		runState: VmRunState;
@@ -170,7 +177,12 @@ async function runOnce(
 			runId,
 			code: options.code,
 			filename: options.filename,
-			snapshot: { cwd: options.cwd, sessionId: options.sessionId, localRoots: options.localRoots },
+			snapshot: {
+				cwd: options.cwd,
+				sessionId: options.sessionId,
+				localRoots: options.localRoots,
+				blockProjectSourceWrites: options.blockProjectSourceWrites,
+			},
 		});
 		return await promise;
 	} finally {

--- a/packages/coding-agent/src/eval/js/executor.ts
+++ b/packages/coding-agent/src/eval/js/executor.ts
@@ -26,6 +26,7 @@ export interface JsExecutorOptions {
 	session: ToolSession;
 	/** On-disk roots the helpers substitute for internal-URL schemes (e.g. `local://`). */
 	localRoots?: Record<string, string>;
+	blockProjectSourceWrites?: boolean;
 }
 
 export interface JsResult {
@@ -103,6 +104,7 @@ export async function executeJs(code: string, options: JsExecutorOptions): Promi
 			cwd: options.cwd ?? options.session.cwd,
 			session: options.session,
 			localRoots: options.localRoots,
+			blockProjectSourceWrites: options.blockProjectSourceWrites,
 			reset: options.reset,
 			code,
 			filename: `js-cell-${crypto.randomUUID()}.js`,

--- a/packages/coding-agent/src/eval/js/index.ts
+++ b/packages/coding-agent/src/eval/js/index.ts
@@ -5,6 +5,7 @@ import {
 	type ExecutorBackendResult,
 	resolveEvalUrlRoots,
 } from "../backend";
+import { shouldBlockEvalSourceWrites } from "../eval-write-guard";
 import { executeJs } from "./executor";
 
 const JS_SESSION_PREFIX = "js:";
@@ -34,6 +35,7 @@ export default {
 			onStatus: opts.onStatus,
 			session: opts.session,
 			localRoots: resolveEvalUrlRoots(opts.session),
+			blockProjectSourceWrites: shouldBlockEvalSourceWrites(opts.session),
 		});
 		return {
 			output: result.output,

--- a/packages/coding-agent/src/eval/js/shared/helpers.ts
+++ b/packages/coding-agent/src/eval/js/shared/helpers.ts
@@ -3,6 +3,11 @@ import * as path from "node:path";
 
 import * as Diff from "diff";
 import { ToolError } from "../../../tools/tool-errors";
+import {
+	EVAL_SOURCE_WRITE_BLOCKED_MESSAGE,
+	isEvalArtifactWritePath,
+	isEvalLocalRootFilesystemPath,
+} from "../../eval-write-guard";
 import type { JsStatusEvent } from "./types";
 
 export interface HelperOptions {
@@ -30,6 +35,8 @@ export interface HelperContext {
 	 * to `<root>/x.md` before any filesystem op; unknown schemes are rejected.
 	 */
 	localRoots(): Record<string, string>;
+	/** When true, `write`/`append` reject non-artifact project paths (edit tool available). */
+	blockProjectSourceWrites?: boolean;
 	emitStatus(event: JsStatusEvent): void;
 }
 
@@ -48,6 +55,14 @@ export interface HelperBundle {
 	diff(rawA: string, rawB: string): Promise<string>;
 	tree(searchPath?: string, options?: HelperOptions): Promise<string>;
 	env(key?: string, value?: string): string | Record<string, string> | undefined;
+}
+
+function assertEvalWriteAllowed(ctx: HelperContext, rawPath: string): void {
+	if (!ctx.blockProjectSourceWrites) return;
+	const roots = ctx.localRoots();
+	if (isEvalArtifactWritePath(rawPath, roots)) return;
+	if (isEvalLocalRootFilesystemPath(rawPath, roots)) return;
+	throw new ToolError(EVAL_SOURCE_WRITE_BLOCKED_MESSAGE);
 }
 
 const utf8Encoder = new TextEncoder();
@@ -69,6 +84,7 @@ export function createHelpers(ctx: HelperContext): HelperBundle {
 			return text;
 		},
 		writeFile: async (rawPath, data) => {
+			assertEvalWriteAllowed(ctx, rawPath);
 			if (!isWriteData(data)) {
 				throw new ToolError("write() expects string, Blob, ArrayBuffer, or TypedArray data");
 			}
@@ -82,6 +98,7 @@ export function createHelpers(ctx: HelperContext): HelperBundle {
 			return filePath;
 		},
 		append: async (rawPath, content) => {
+			assertEvalWriteAllowed(ctx, rawPath);
 			const target = resolveHelperPath(ctx, rawPath, "write");
 			// O(1) append; read-all+rewrite both raced concurrent writers and went
 			// quadratic when called in a loop. Bun.write creates parent dirs, so

--- a/packages/coding-agent/src/eval/js/shared/local-module-loader.ts
+++ b/packages/coding-agent/src/eval/js/shared/local-module-loader.ts
@@ -1,8 +1,11 @@
 import * as fs from "node:fs";
+import * as nodeFs from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import * as vm from "node:vm";
+import type { EvalFsPathGuard } from "../../eval-fs-guard";
+import { guardedImportModuleNamespace } from "../../eval-fs-guard";
 import { collectModuleSourceSpecifiers, stripTypeScriptSyntax } from "./rewrite-imports";
 
 interface LocalModuleEntry {
@@ -28,11 +31,23 @@ export class LocalModuleLoader {
 	#moduleBuilds = new Map<string, Promise<LocalModuleEntry>>();
 	#externalModules = new Map<string, Promise<vm.Module>>();
 	#requireCache = new Map<string, NodeJS.Require>();
+	#requireWrapper: ((base: NodeJS.Require) => NodeJS.Require) | undefined;
+	#fsGuard: EvalFsPathGuard | undefined;
 	#modulePaths = new WeakMap<vm.Module, string>();
 
 	constructor(sessionId: string) {
 		this.#context = vm.createContext(globalThis);
 		this.#sessionTag = Bun.hash(sessionId).toString(16);
+	}
+
+	setRequireWrapper(wrapper: ((base: NodeJS.Require) => NodeJS.Require) | undefined): void {
+		this.#requireWrapper = wrapper;
+		this.#requireCache.clear();
+	}
+
+	setFsWriteGuard(guard: EvalFsPathGuard | undefined): void {
+		this.#fsGuard = guard;
+		this.#externalModules.clear();
 	}
 
 	async resolveForRun(cwd: string, source: string): Promise<LocalImportResolution> {
@@ -52,6 +67,7 @@ export class LocalModuleLoader {
 		let cached = this.#requireCache.get(basePath);
 		if (!cached) {
 			cached = buildRequire(basePath);
+			if (this.#requireWrapper) cached = this.#requireWrapper(cached);
 			this.#requireCache.set(basePath, cached);
 		}
 		return cached;
@@ -209,8 +225,12 @@ export class LocalModuleLoader {
 		const existing = this.#externalModules.get(target);
 		if (existing) return await existing;
 		const loadPromise = (async () => {
-			const namespace = await import(target);
-			const exportNames = Object.keys(namespace);
+			const namespace = this.#fsGuard
+				? await guardedImportModuleNamespace(target, this.#fsGuard, nodeFs, (t, o) =>
+						o !== undefined ? import(t, o) : import(t),
+					)
+				: await import(target);
+			const exportNames = Object.keys(namespace as object);
 			const module = new vm.SyntheticModule(
 				exportNames,
 				function () {

--- a/packages/coding-agent/src/eval/js/shared/runtime.ts
+++ b/packages/coding-agent/src/eval/js/shared/runtime.ts
@@ -7,7 +7,20 @@ import { Writable } from "node:stream";
 import * as util from "node:util";
 
 import { logger } from "@oh-my-pi/pi-utils";
-
+import {
+	createEvalFsPathGuard,
+	createGuardedBunNamespace,
+	createGuardedCreateRequire,
+	createGuardedFsModule,
+	createGuardedRequire,
+	guardedImportModuleNamespace,
+	wrapBuiltinModuleForGuard,
+} from "../../eval-fs-guard";
+import {
+	guardChildProcessModule,
+	guardProcessGetBuiltinModule,
+	isChildProcessModuleId,
+} from "../../eval-subprocess-guard";
 import { createHelpers, type HelperBundle } from "./helpers";
 import { awaitMaybePromise, indirectEval } from "./indirect-eval";
 import { LocalModuleLoader } from "./local-module-loader";
@@ -47,6 +60,7 @@ export interface RuntimeOptions {
 	 * `{ local: "/…/artifacts/local" }`). Stable for the worker's lifetime.
 	 */
 	localRoots?: Record<string, string>;
+	blockProjectSourceWrites?: boolean;
 }
 
 // Strict base64: characters from the standard alphabet plus optional `=` padding, and a
@@ -132,6 +146,7 @@ export class JsRuntime {
 	#als = new AsyncLocalStorage<RunContext>();
 	#moduleLoader: LocalModuleLoader;
 	#localRoots: Record<string, string>;
+	#blockProjectSourceWrites: boolean;
 
 	constructor(opts: RuntimeOptions) {
 		this.#cwd = opts.initialCwd;
@@ -139,10 +154,12 @@ export class JsRuntime {
 		this.#env = new Map();
 		this.#moduleLoader = new LocalModuleLoader(this.sessionId);
 		this.#localRoots = opts.localRoots ?? {};
+		this.#blockProjectSourceWrites = opts.blockProjectSourceWrites === true;
 		this.helpers = createHelpers({
 			cwd: () => this.#activeCwd(),
 			env: this.#env,
 			localRoots: () => this.#localRoots,
+			blockProjectSourceWrites: opts.blockProjectSourceWrites,
 			emitStatus: event => this.#activeHooks("emitStatus")?.onDisplay({ type: "status", event }),
 		});
 		this.#install(opts.extraGlobals);
@@ -258,7 +275,14 @@ export class JsRuntime {
 	}
 
 	#buildDynamicRequire(): NodeJS.Require {
-		const dynamicRequire = ((id: string) => this.#activeRequire()(id)) as NodeJS.Require;
+		const guard = createEvalFsPathGuard(this.#blockProjectSourceWrites, this.#localRoots);
+		const dynamicRequire = ((id: string) => {
+			const base = this.#activeRequire();
+			if (guard) {
+				return createGuardedRequire(base, guard, fs)(id);
+			}
+			return base(id);
+		}) as NodeJS.Require;
 		const resolve = ((id: string, options?: { paths?: string[] }) =>
 			this.#activeRequire().resolve(id, options)) as NodeJS.Require["resolve"] & {
 			paths(request: string): string[] | null;
@@ -273,7 +297,18 @@ export class JsRuntime {
 		return dynamicRequire;
 	}
 
+	#fsGuard() {
+		return createEvalFsPathGuard(this.#blockProjectSourceWrites, this.#localRoots);
+	}
+
+	#guardedFsModule() {
+		return createGuardedFsModule(fs, this.#fsGuard());
+	}
+
 	#install(extraGlobals: Record<string, unknown> | undefined): void {
+		const guard = this.#fsGuard();
+		this.#moduleLoader.setRequireWrapper(guard ? base => createGuardedRequire(base, guard, fs) : undefined);
+		this.#moduleLoader.setFsWriteGuard(guard);
 		const injected: Record<string, unknown> = {
 			__omp_session__: { cwd: this.#cwd, sessionId: this.sessionId },
 			__omp_helpers__: this.helpers,
@@ -286,13 +321,35 @@ export class JsRuntime {
 				const resolved = await this.#moduleLoader.resolveForRun(this.#activeCwd(), source);
 				if (resolved.mode === "local") return resolved.value;
 				const target = resolved.target;
-				return options !== undefined ? await import(target, options) : await import(target);
+				const g = this.#fsGuard();
+				const loaded = await guardedImportModuleNamespace(
+					target,
+					g,
+					fs,
+					(t, o) => (o !== undefined ? import(t, o) : import(t)),
+					options,
+				);
+				if (g && isChildProcessModuleId(target)) {
+					return guardChildProcessModule(loaded as object, true);
+				}
+				return loaded;
 			},
 			__omp_import_from__: async (moduleUrl: string, source: string, options?: ImportCallOptions) => {
 				const resolved = await this.#moduleLoader.resolveForModule(moduleUrl, source, this.#activeCwd());
 				if (resolved.mode === "local") return resolved.value;
 				const target = resolved.target;
-				return options !== undefined ? await import(target, options) : await import(target);
+				const g = this.#fsGuard();
+				const loaded = await guardedImportModuleNamespace(
+					target,
+					g,
+					fs,
+					(t, o) => (o !== undefined ? import(t, o) : import(t)),
+					options,
+				);
+				if (g && isChildProcessModuleId(target)) {
+					return guardChildProcessModule(loaded as object, true);
+				}
+				return loaded;
 			},
 			__omp_get_require__: (moduleUrl?: string) => this.#activeRequire(moduleUrl),
 			__omp_get_filename__: (moduleUrl?: string) => this.#moduleFilename(moduleUrl),
@@ -335,10 +392,28 @@ export class JsRuntime {
 			// `process` object. Subsetting it caused segfaults in workers that share state with
 			// puppeteer/worker_threads internals.
 			require: this.#buildDynamicRequire(),
-			createRequire,
-			fs,
+			createRequire: createGuardedCreateRequire(createRequire, guard, fs),
+			fs: this.#guardedFsModule(),
 		};
+		const guardedBun = createGuardedBunNamespace(guard);
+		if (guardedBun !== undefined) {
+			injected.Bun = guardedBun;
+		}
 		Object.assign(globalThis, injected, extraGlobals ?? {});
+
+		if (guard) {
+			const hostProcess = globalThis.process as NodeJS.Process;
+			const wrappedProcess = guardProcessGetBuiltinModule(hostProcess, true, (specifier, mod) =>
+				wrapBuiltinModuleForGuard(specifier, mod, guard, fs),
+			);
+			Object.defineProperty(globalThis, "process", {
+				value: wrappedProcess,
+				configurable: true,
+				writable: true,
+				enumerable: true,
+			});
+		}
+
 		// Prelude assigns console bridge + short aliases (`read`, `write`, `tool`, `display`, ...)
 		// onto globalThis. Must run after helpers are in place.
 		indirectEval(JAVASCRIPT_PRELUDE_SOURCE);

--- a/packages/coding-agent/src/eval/js/worker-core.ts
+++ b/packages/coding-agent/src/eval/js/worker-core.ts
@@ -72,6 +72,7 @@ export class WorkerCore {
 			initialCwd: snapshot.cwd,
 			sessionId: snapshot.sessionId,
 			localRoots: snapshot.localRoots,
+			blockProjectSourceWrites: snapshot.blockProjectSourceWrites,
 		});
 		return this.#runtime;
 	}

--- a/packages/coding-agent/src/eval/js/worker-protocol.ts
+++ b/packages/coding-agent/src/eval/js/worker-protocol.ts
@@ -11,6 +11,7 @@ export interface SessionSnapshot {
 	 * accept `local://…` paths instead of writing a literal `local:/` directory.
 	 */
 	localRoots?: Record<string, string>;
+	blockProjectSourceWrites?: boolean;
 }
 
 export interface RunErrorPayload {

--- a/packages/coding-agent/src/eval/py/eval_guard.py
+++ b/packages/coding-agent/src/eval/py/eval_guard.py
@@ -1,0 +1,58 @@
+"""Host-controlled eval write guard (not user-mutable via os.environ)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Union
+
+PathLike = Union[str, Path]
+
+_block_source_writes = False
+_eval_write_blocked_message = ""
+# Host snapshot of PI_EVAL_LOCAL_ROOTS (scheme -> absolute path); not read from os.environ at check time.
+_local_roots: dict[str, str] = {}
+
+
+def _host_set_guard_state(*, block_source_writes: bool, blocked_message: str) -> None:
+    """Called only from the OMP runner host (runner.py / kernel init)."""
+    global _block_source_writes, _eval_write_blocked_message
+    _block_source_writes = block_source_writes
+    _eval_write_blocked_message = blocked_message
+
+
+def _host_set_local_roots(roots: dict[str, str]) -> None:
+    """Called only from the OMP runner host when request env is applied."""
+    global _local_roots
+    _local_roots = {k.lower(): v for k, v in roots.items() if isinstance(k, str) and isinstance(v, str)}
+
+
+def configure(*, block_source_writes: bool, blocked_message: str) -> None:
+    """User-visible stub — guard state is host-controlled only."""
+    raise RuntimeError(
+        "eval_guard.configure cannot be called from eval cells; "
+        "source-write blocking is controlled by the OMP host."
+    )
+
+
+def block_source_writes_enabled() -> bool:
+    return _block_source_writes
+
+
+def blocked_message() -> str:
+    return _eval_write_blocked_message
+
+
+def local_roots_snapshot() -> dict[str, str]:
+    return dict(_local_roots)
+
+
+def is_managed_env_key(key: str) -> bool:
+    return key in {
+        "PI_SESSION_FILE",
+        "PI_ARTIFACTS_DIR",
+        "PI_TOOL_BRIDGE_URL",
+        "PI_TOOL_BRIDGE_TOKEN",
+        "PI_TOOL_BRIDGE_SESSION",
+        "PI_EVAL_LOCAL_ROOTS",
+        "PI_EVAL_BLOCK_SOURCE_WRITES",
+    }

--- a/packages/coding-agent/src/eval/py/eval_io_guard.py
+++ b/packages/coding-agent/src/eval/py/eval_io_guard.py
@@ -1,0 +1,347 @@
+"""Shim builtin open and pathlib.Path write APIs when eval source writes are blocked."""
+
+from __future__ import annotations
+
+import builtins
+import io
+import json
+import os
+import re
+import shutil
+from pathlib import Path
+from typing import Any, Union
+
+PathLike = Union[str, os.PathLike[str]]
+
+_WRITE_MODES = frozenset({"w", "a", "x", "+", "wb", "ab", "xb", "w+", "a+", "x+", "w+b", "a+b", "x+b", "r+", "rb+", "r+b"})
+
+
+def _is_write_mode(mode: str | None) -> bool:
+    if mode is None:
+        return True
+    m = str(mode).strip()
+    if not m:
+        return True
+    if m == "r":
+        return False
+    if "+" in m:
+        return True
+    base = re.sub(r"[bt]+$", "", m, flags=re.IGNORECASE)
+    return base in _WRITE_MODES or any(ch in base for ch in ("w", "a", "x"))
+
+
+
+def _is_under_local_roots(raw_path: str) -> bool:
+    import eval_guard
+
+    normalized = os.path.normpath(raw_path)
+    for root in eval_guard.local_roots_snapshot().values():
+        norm_root = os.path.normpath(root)
+        if normalized == norm_root or normalized.startswith(norm_root + os.sep):
+            return True
+    return False
+
+def _assert_path_allowed(path: PathLike) -> None:
+    try:
+        import eval_guard
+    except ImportError:
+        return
+    if not eval_guard.block_source_writes_enabled():
+        return
+    raw = os.fspath(path)
+    match = re.match(r"^([a-z][a-z0-9+.-]*)://(.*)$", raw.strip(), re.IGNORECASE)
+    if match:
+        if match.group(1).lower() in eval_guard.local_roots_snapshot():
+            return
+    if _is_under_local_roots(raw):
+        return
+    msg = eval_guard.blocked_message() or "eval cannot write project source when edit is available."
+    raise ValueError(msg)
+
+
+
+_guarded_write_fds: dict[int, str] = {}
+
+
+def _is_os_write_flags(flags: int) -> bool:
+    """True when os.open flags can write or create/truncate."""
+    if flags & getattr(os, "O_WRONLY", 1):
+        return True
+    if flags & getattr(os, "O_RDWR", 2):
+        return True
+    if flags & getattr(os, "O_CREAT", 64):
+        return True
+    if flags & getattr(os, "O_TRUNC", 512):
+        return True
+    if flags & getattr(os, "O_APPEND", 1024):
+        return True
+    return False
+
+
+def _register_guarded_fd(fd: int, raw_path: str) -> None:
+    _guarded_write_fds[fd] = raw_path
+
+
+def _unregister_guarded_fd(fd: int) -> None:
+    _guarded_write_fds.pop(fd, None)
+
+
+def _path_for_guarded_fd(fd: int) -> str | None:
+    return _guarded_write_fds.get(fd)
+
+
+_subprocess_originals: dict[str, object] | None = None
+
+
+def _restore_subprocess_if_patched() -> None:
+    global _subprocess_originals
+    if _subprocess_originals is None:
+        return
+    import subprocess as _subprocess_mod
+
+    for name, value in _subprocess_originals.items():
+        setattr(_subprocess_mod, name, value)
+    _subprocess_originals = None
+
+
+def install() -> None:
+    try:
+        import eval_guard
+    except ImportError:
+        return
+    if not eval_guard.block_source_writes_enabled():
+        _restore_subprocess_if_patched()
+        return
+
+    _real_open = builtins.open
+
+    def guarded_open(
+        file: PathLike,
+        mode: str = "r",
+        buffering: int = -1,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str | None = None,
+        closefd: bool = True,
+        opener: Any = None,
+    ):
+        if _is_write_mode(mode):
+            _assert_path_allowed(file)
+        return _real_open(
+            file,
+            mode,
+            buffering,
+            encoding,
+            errors,
+            newline,
+            closefd,
+            opener,
+        )
+
+    builtins.open = guarded_open  # type: ignore[assignment]
+    io.open = guarded_open  # type: ignore[assignment]
+
+    _orig_write_text = Path.write_text
+    _orig_write_bytes = Path.write_bytes
+    _orig_unlink = Path.unlink
+
+    def write_text(self: Path, data: str, encoding: str | None = None, errors: str | None = None, newline: str | None = None) -> int:
+        _assert_path_allowed(self)
+        return _orig_write_text(self, data, encoding=encoding, errors=errors, newline=newline)
+
+    def write_bytes(self: Path, data: bytes) -> int:
+        _assert_path_allowed(self)
+        return _orig_write_bytes(self, data)
+
+    def path_unlink(self: Path, missing_ok: bool = False) -> None:
+        _assert_path_allowed(self)
+        return _orig_unlink(self, missing_ok=missing_ok)
+
+    _orig_path_open = Path.open
+
+    def path_open(
+        self: Path,
+        mode: str = "r",
+        buffering: int = -1,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str | None = None,
+    ):
+        if _is_write_mode(mode):
+            _assert_path_allowed(self)
+        return _orig_path_open(self, mode, buffering, encoding, errors, newline)
+
+    Path.open = path_open  # type: ignore[method-assign]
+    Path.write_text = write_text  # type: ignore[method-assign]
+    Path.write_bytes = write_bytes  # type: ignore[method-assign]
+    Path.unlink = path_unlink  # type: ignore[method-assign]
+    _orig_symlink_to = Path.symlink_to
+    _orig_link_to = Path.link_to
+
+    def path_symlink_to(self, target: PathLike, target_is_directory: bool = False) -> None:
+        _assert_path_allowed(target)
+        _assert_path_allowed(self)
+        return _orig_symlink_to(self, target, target_is_directory=target_is_directory)
+
+    def path_link_to(self, target: PathLike) -> None:
+        _assert_path_allowed(target)
+        _assert_path_allowed(self)
+        return _orig_link_to(self, target)
+
+    Path.symlink_to = path_symlink_to  # type: ignore[method-assign]
+    Path.link_to = path_link_to  # type: ignore[method-assign]
+
+    _orig_os_remove = os.remove
+    _orig_os_rename = os.rename
+    _orig_os_replace = getattr(os, "replace", None)
+    _orig_os_unlink = os.unlink
+    _orig_os_symlink = getattr(os, "symlink", None)
+    _orig_os_link = getattr(os, "link", None)
+    _orig_shutil_move = shutil.move
+    _orig_shutil_rmtree = shutil.rmtree
+
+    def guarded_symlink(src: PathLike, dst: PathLike, target_is_directory: bool = False) -> None:
+        _assert_path_allowed(src)
+        _assert_path_allowed(dst)
+        if _orig_os_symlink is None:
+            raise OSError("os.symlink is not available")
+        return _orig_os_symlink(src, dst, target_is_directory=target_is_directory)
+
+    def guarded_link(src: PathLike, dst: PathLike) -> None:
+        _assert_path_allowed(src)
+        _assert_path_allowed(dst)
+        if _orig_os_link is None:
+            raise OSError("os.link is not available")
+        return _orig_os_link(src, dst)
+
+    def guarded_remove(path: PathLike, *, dir_fd: int | None = None) -> None:
+        _assert_path_allowed(path)
+        if dir_fd is not None:
+            return _orig_os_remove(path, dir_fd=dir_fd)
+        return _orig_os_remove(path)
+
+    def guarded_rename(src: PathLike, dst: PathLike, *, src_dir_fd: int | None = None, dst_dir_fd: int | None = None) -> None:
+        _assert_path_allowed(src)
+        _assert_path_allowed(dst)
+        if src_dir_fd is not None or dst_dir_fd is not None:
+            return _orig_os_rename(src, dst, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd)
+        return _orig_os_rename(src, dst)
+
+    def guarded_replace(src: PathLike, dst: PathLike, *, src_dir_fd: int | None = None, dst_dir_fd: int | None = None) -> None:
+        _assert_path_allowed(src)
+        _assert_path_allowed(dst)
+        if _orig_os_replace is None:
+            raise OSError("os.replace is not available")
+        if src_dir_fd is not None or dst_dir_fd is not None:
+            return _orig_os_replace(src, dst, src_dir_fd=src_dir_fd, dst_dir_fd=dst_dir_fd)
+        return _orig_os_replace(src, dst)
+
+    def guarded_os_unlink(path: PathLike, *, dir_fd: int | None = None) -> None:
+        _assert_path_allowed(path)
+        if dir_fd is not None:
+            return _orig_os_unlink(path, dir_fd=dir_fd)
+        return _orig_os_unlink(path)
+
+    def guarded_move(src: PathLike, dst: PathLike, copy_function=shutil.copy2) -> str:
+        _assert_path_allowed(src)
+        _assert_path_allowed(dst)
+        return _orig_shutil_move(src, dst, copy_function=copy_function)
+
+    def guarded_rmtree(
+        path: PathLike,
+        ignore_errors: bool = False,
+        onerror: Any = None,
+        *,
+        onexc: Any = None,
+        dir_fd: int | None = None,
+    ) -> None:
+        _assert_path_allowed(path)
+        if onexc is not None or dir_fd is not None:
+            return _orig_shutil_rmtree(path, ignore_errors=ignore_errors, onerror=onerror, onexc=onexc, dir_fd=dir_fd)
+        return _orig_shutil_rmtree(path, ignore_errors=ignore_errors, onerror=onerror)
+
+    os.remove = guarded_remove  # type: ignore[assignment]
+    os.rename = guarded_rename  # type: ignore[assignment]
+    if _orig_os_replace is not None:
+        os.replace = guarded_replace  # type: ignore[assignment]
+    os.unlink = guarded_os_unlink  # type: ignore[assignment]
+    if _orig_os_symlink is not None:
+        os.symlink = guarded_symlink  # type: ignore[assignment]
+    if _orig_os_link is not None:
+        os.link = guarded_link  # type: ignore[assignment]
+    shutil.move = guarded_move  # type: ignore[assignment]
+    shutil.rmtree = guarded_rmtree  # type: ignore[assignment]
+    _orig_os_open = os.open
+    _orig_os_write = os.write
+    _orig_os_close = os.close
+
+    def guarded_os_open(path: PathLike, flags: int, mode: int = 0o777, *, dir_fd: int | None = None) -> int:
+        if _is_os_write_flags(flags):
+            _assert_path_allowed(path)
+        if dir_fd is not None:
+            fd = _orig_os_open(path, flags, mode, dir_fd=dir_fd)
+        else:
+            fd = _orig_os_open(path, flags, mode)
+        if _is_os_write_flags(flags):
+            _register_guarded_fd(fd, os.fspath(path))
+        return fd
+
+    def guarded_os_write(fd: int, data: bytes | bytearray, /) -> int:
+        tracked = _path_for_guarded_fd(fd)
+        if tracked is not None:
+            _assert_path_allowed(tracked)
+        return _orig_os_write(fd, data)
+
+    def guarded_os_close(fd: int, /) -> None:
+        _unregister_guarded_fd(fd)
+        return _orig_os_close(fd)
+
+    os.open = guarded_os_open  # type: ignore[assignment]
+    os.write = guarded_os_write  # type: ignore[assignment]
+    os.close = guarded_os_close  # type: ignore[assignment]
+    import subprocess as _subprocess_mod
+
+    global _subprocess_originals
+    _spawn_names = (
+        "Popen",
+        "run",
+        "call",
+        "check_call",
+        "check_output",
+        "getoutput",
+        "getstatusoutput",
+    )
+    if _subprocess_originals is None:
+        _subprocess_originals = {name: getattr(_subprocess_mod, name) for name in _spawn_names}
+
+    _subprocess_msg = (
+        eval_guard.blocked_message()
+        or "eval cannot spawn subprocesses that may write project source when the edit tool is available."
+    )
+
+    _orig_popen = _subprocess_originals["Popen"]
+
+    class _GuardedPopen:
+        def __new__(cls, *args: object, **kwargs: object) -> object:
+            if not eval_guard.block_source_writes_enabled():
+                return _orig_popen(*args, **kwargs)  # type: ignore[misc,operator]
+            raise ValueError(_subprocess_msg)
+
+    _subprocess_mod.Popen = _GuardedPopen  # type: ignore[misc,assignment]
+
+    for _name in _spawn_names:
+        if _name == "Popen":
+            continue
+        _orig_fn = _subprocess_originals[_name]
+
+        def _make_wrapper(fn_name: str, orig: object):
+            def _wrapper(*args: object, **kwargs: object) -> object:
+                if not eval_guard.block_source_writes_enabled():
+                    return orig(*args, **kwargs)  # type: ignore[operator]
+                raise ValueError(_subprocess_msg)
+
+            _wrapper.__name__ = fn_name
+            return _wrapper
+
+        setattr(_subprocess_mod, _name, _make_wrapper(_name, _orig_fn))
+

--- a/packages/coding-agent/src/eval/py/executor.ts
+++ b/packages/coding-agent/src/eval/py/executor.ts
@@ -89,6 +89,8 @@ export interface PythonExecutorOptions {
 	bridgeSessionId?: string;
 	/** @internal Bridge endpoint info, set by `executePython` before delegating. */
 	bridge?: { url: string; token: string };
+	/** Block prelude write/append to project paths when edit is available. */
+	blockSourceWrites?: boolean;
 }
 
 export interface PythonKernelExecutor {
@@ -301,6 +303,7 @@ const MANAGED_KERNEL_ENV_KEYS = [
 	"PI_TOOL_BRIDGE_TOKEN",
 	"PI_TOOL_BRIDGE_SESSION",
 	"PI_EVAL_LOCAL_ROOTS",
+	"PI_EVAL_BLOCK_SOURCE_WRITES",
 ] as const;
 
 function buildKernelEnvPatch(options: {
@@ -309,6 +312,7 @@ function buildKernelEnvPatch(options: {
 	bridgeSessionId?: string;
 	bridge?: { url: string; token: string };
 	localRoots?: Record<string, string>;
+	blockSourceWrites?: boolean;
 }): KernelRuntimeEnv {
 	const localRoots = options.localRoots;
 	return {
@@ -318,6 +322,7 @@ function buildKernelEnvPatch(options: {
 		PI_TOOL_BRIDGE_TOKEN: options.bridge?.token ?? null,
 		PI_TOOL_BRIDGE_SESSION: options.bridge && options.bridgeSessionId ? options.bridgeSessionId : null,
 		PI_EVAL_LOCAL_ROOTS: localRoots && Object.keys(localRoots).length > 0 ? JSON.stringify(localRoots) : null,
+		PI_EVAL_BLOCK_SOURCE_WRITES: options.blockSourceWrites ? "1" : null,
 	};
 }
 
@@ -327,6 +332,7 @@ function buildKernelEnv(options: {
 	bridgeSessionId?: string;
 	bridge?: { url: string; token: string };
 	localRoots?: Record<string, string>;
+	blockSourceWrites?: boolean;
 }): Record<string, string> | undefined {
 	const patch = buildKernelEnvPatch(options);
 	const env: Record<string, string> = {};

--- a/packages/coding-agent/src/eval/py/index.ts
+++ b/packages/coding-agent/src/eval/py/index.ts
@@ -5,6 +5,7 @@ import {
 	type ExecutorBackendResult,
 	resolveEvalUrlRoots,
 } from "../backend";
+import { shouldBlockEvalSourceWrites } from "../eval-write-guard";
 import { executePython, type PythonExecutorOptions } from "./executor";
 import { checkPythonKernelAvailability } from "./kernel";
 
@@ -50,6 +51,7 @@ export default {
 			onChunk: opts.onChunk,
 			onStatus: opts.onStatus,
 			toolSession: opts.session,
+			blockSourceWrites: shouldBlockEvalSourceWrites(opts.session),
 		};
 		const result = await executePython(code, executorOptions);
 		return {

--- a/packages/coding-agent/src/eval/py/kernel.ts
+++ b/packages/coding-agent/src/eval/py/kernel.ts
@@ -14,7 +14,10 @@ import { $flag, isBunTestRuntime, logger, Snowflake } from "@oh-my-pi/pi-utils";
 import type { Subprocess } from "bun";
 import { $ } from "bun";
 import { Settings } from "../../config/settings";
+import { EVAL_SOURCE_WRITE_BLOCKED_MESSAGE } from "../eval-write-guard";
 import { type KernelDisplayOutput, renderKernelDisplay } from "./display";
+import EVAL_GUARD_SCRIPT from "./eval_guard.py" with { type: "text" };
+import EVAL_IO_GUARD_SCRIPT from "./eval_io_guard.py" with { type: "text" };
 import { PYTHON_PRELUDE } from "./prelude";
 import RUNNER_SCRIPT from "./runner.py" with { type: "text" };
 import {
@@ -39,13 +42,18 @@ let RUNNER_SCRIPT_PATH: string | null = null;
 async function ensureRunnerScript(): Promise<string> {
 	if (RUNNER_SCRIPT_PATH) return RUNNER_SCRIPT_PATH;
 	await fs.promises.mkdir(RUNNER_CACHE_DIR, { recursive: true });
-	const hash = Bun.hash(RUNNER_SCRIPT).toString(36);
-	const target = path.join(RUNNER_CACHE_DIR, `runner-${hash}.py`);
-	if (!fs.existsSync(target)) {
-		await Bun.write(target, RUNNER_SCRIPT);
+	const bundle = `${EVAL_GUARD_SCRIPT}\n\n${EVAL_IO_GUARD_SCRIPT}\n\n${RUNNER_SCRIPT}`;
+	const hash = Bun.hash(bundle).toString(36);
+	const cacheRoot = path.join(RUNNER_CACHE_DIR, `bundle-${hash}`);
+	const runnerPath = path.join(cacheRoot, "runner.py");
+	if (!fs.existsSync(runnerPath)) {
+		await fs.promises.mkdir(cacheRoot, { recursive: true });
+		await Bun.write(path.join(cacheRoot, "eval_guard.py"), EVAL_GUARD_SCRIPT);
+		await Bun.write(path.join(cacheRoot, "eval_io_guard.py"), EVAL_IO_GUARD_SCRIPT);
+		await Bun.write(runnerPath, RUNNER_SCRIPT);
 	}
-	RUNNER_SCRIPT_PATH = target;
-	return target;
+	RUNNER_SCRIPT_PATH = runnerPath;
+	return runnerPath;
 }
 
 const SHUTDOWN_GRACE_MS = 1_000;
@@ -319,7 +327,9 @@ export class PythonKernel {
 		const startupBudget = Math.min(getRemainingTimeMs(startup.deadlineMs) ?? STARTUP_TIMEOUT_MS, STARTUP_TIMEOUT_MS);
 
 		try {
-			const initScript = buildInitScript(options.cwd, options.env);
+			const initScript = buildInitScript(options.cwd, options.env, {
+				blockSourceWrites: options.env?.PI_EVAL_BLOCK_SOURCE_WRITES === "1",
+			});
 			await kernel.#executeWithBudget(initScript, startup.signal, startupBudget, "Python kernel init");
 			await kernel.#executeWithBudget(PYTHON_PRELUDE, startup.signal, startupBudget, "Python kernel prelude");
 			return kernel;
@@ -734,15 +744,28 @@ function isTimeoutReason(reason: unknown): boolean {
 	return false;
 }
 
-function buildInitScript(cwd: string, env?: Record<string, string | undefined>): string {
+function buildInitScript(
+	cwd: string,
+	env?: Record<string, string | undefined>,
+	guard?: { blockSourceWrites: boolean },
+): string {
 	const envEntries = Object.entries(env ?? {}).filter(([, value]) => value !== undefined);
 	const envPayload = Object.fromEntries(envEntries);
-	return [
+	const block = guard?.blockSourceWrites === true;
+	const lines = [
 		"import os, sys",
+		"import eval_guard",
 		`__omp_cwd = ${JSON.stringify(cwd)}`,
 		"os.chdir(__omp_cwd)",
 		`__omp_env = ${JSON.stringify(envPayload)}`,
 		"for __omp_key, __omp_val in __omp_env.items():\n    os.environ[__omp_key] = __omp_val",
 		"if __omp_cwd not in sys.path:\n    sys.path.insert(0, __omp_cwd)",
-	].join("\n");
+		`eval_guard._host_set_guard_state(block_source_writes=${block ? "True" : "False"}, blocked_message=${JSON.stringify(EVAL_SOURCE_WRITE_BLOCKED_MESSAGE)})`,
+		"import json",
+		"__omp_lr = json.loads(os.environ.get('PI_EVAL_LOCAL_ROOTS') or '{}')",
+		"eval_guard._host_set_local_roots({k: str(v) for k, v in __omp_lr.items() if isinstance(k, str) and isinstance(v, str)}) if isinstance(__omp_lr, dict) else None",
+		"import eval_io_guard",
+		"eval_io_guard.install()",
+	];
+	return lines.join("\n");
 }

--- a/packages/coding-agent/src/eval/py/prelude.py
+++ b/packages/coding-agent/src/eval/py/prelude.py
@@ -47,6 +47,15 @@ if "__omp_prelude_loaded__" not in globals():
             _emit_status("env", count=len(items), keys=list(items.keys())[:20])
             return items
         if value is not None:
+            try:
+                import eval_guard
+            except ImportError:
+                eval_guard = None  # type: ignore[assignment]
+            if eval_guard is not None and eval_guard.is_managed_env_key(key):
+                raise ValueError(
+                    f"env() cannot change host-managed variable {key!r} during eval; "
+                    "project source writes stay blocked when the edit tool is available."
+                )
             os.environ[key] = value
             _emit_status("env", key=key, value=value, action="set")
             return value
@@ -106,8 +115,57 @@ if "__omp_prelude_loaded__" not in globals():
         _emit_status("read", path=str(p), chars=len(data), preview=preview)
         return data
 
+    _EVAL_WRITE_BLOCKED = (
+        "eval write() and append() cannot change project source files when the edit tool is available. "
+        "Call `edit` with a hashline `input` string: copy a `[PATH#TAG]` header from your latest `read`/`search`, "
+        "then add ops (`replace N..M:`, `insert after N:`, `delete N`, …) with `+` body rows. "
+        "Do not edit files via `bash` (`python -c`, `node -e`, `bun -e`, `sed`) or `eval` when `edit` is available."
+    )
+
+    def _is_eval_artifact_path(path: str | Path) -> bool:
+        if not isinstance(path, str):
+            return False
+        match = _OMP_INTERNAL_URL_RE.match(path.strip())
+        if not match:
+            return False
+        try:
+            roots = json.loads(os.environ.get("PI_EVAL_LOCAL_ROOTS") or "{}")
+        except (ValueError, TypeError):
+            roots = {}
+        if not isinstance(roots, dict):
+            return False
+        return match.group(1).lower() in roots
+
+    def _is_under_eval_local_roots(path: str | Path) -> bool:
+        try:
+            import eval_guard
+        except ImportError:
+            return False
+        raw = str(path)
+        normalized = os.path.normpath(raw)
+        for root in eval_guard.local_roots_snapshot().values():
+            norm_root = os.path.normpath(root)
+            if normalized == norm_root or normalized.startswith(norm_root + os.sep):
+                return True
+        return False
+
+    def _assert_eval_write_allowed(path: str | Path) -> None:
+        try:
+            import eval_guard
+        except ImportError:
+            return
+        if not eval_guard.block_source_writes_enabled():
+            return
+        if _is_eval_artifact_path(path):
+            return
+        if _is_under_eval_local_roots(path):
+            return
+        msg = eval_guard.blocked_message() or _EVAL_WRITE_BLOCKED
+        raise ValueError(msg)
+
     def write(path: str | Path, content: str) -> Path:
         """Write file contents (create parents)."""
+        _assert_eval_write_allowed(path)
         p = _resolve_omp_path(path)
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(content, encoding="utf-8")
@@ -116,6 +174,7 @@ if "__omp_prelude_loaded__" not in globals():
 
     def append(path: str | Path, content: str) -> Path:
         """Append to file."""
+        _assert_eval_write_allowed(path)
         p = _resolve_omp_path(path)
         p.parent.mkdir(parents=True, exist_ok=True)
         with p.open("a", encoding="utf-8") as f:

--- a/packages/coding-agent/src/eval/py/runner.py
+++ b/packages/coding-agent/src/eval/py/runner.py
@@ -42,6 +42,11 @@ import signal
 import subprocess
 import sys
 import threading
+_OMP_RUNNER_DIR = os.path.dirname(os.path.abspath(__file__))
+if _OMP_RUNNER_DIR not in sys.path:
+    sys.path.insert(0, _OMP_RUNNER_DIR)
+
+
 import time
 import traceback
 from pathlib import Path
@@ -586,16 +591,54 @@ def _magic_cell_timeit(args: str, body: str) -> None:
     _emit_status("timeit", loops=iters, total_ms=round(total * 1000, 3))
 
 
+
+
+def _eval_assert_write_allowed(path: str | Path) -> None:
+    try:
+        import eval_guard
+    except ImportError:
+        return
+    if not eval_guard.block_source_writes_enabled():
+        return
+    raw = str(path)
+    match = re.match(r"^([a-z][a-z0-9+.-]*)://(.*)$", raw.strip(), re.IGNORECASE)
+    if match:
+        try:
+            roots = json.loads(os.environ.get("PI_EVAL_LOCAL_ROOTS") or "{}")
+        except (ValueError, TypeError):
+            roots = {}
+        if isinstance(roots, dict) and match.group(1).lower() in roots:
+            return
+    raise ValueError(eval_guard.blocked_message() or "eval cannot write project source when edit is available.")
+
+
 @cell_magic("writefile")
 def _magic_cell_writefile(args: str, body: str) -> str:
     path = Path(os.path.expanduser(args.strip()))
+    _eval_assert_write_allowed(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(body, encoding="utf-8")
     _emit_status("writefile", path=str(path), bytes=len(body))
     return str(path)
 
 
+
+
+def _assert_shell_magic_allowed() -> None:
+    try:
+        import eval_guard
+    except ImportError:
+        return
+    if not eval_guard.block_source_writes_enabled():
+        return
+    msg = eval_guard.blocked_message() or (
+        "eval cannot run shell magics that may write project source when the edit tool is available."
+    )
+    raise ValueError(msg)
+
+
 def _run_shell_body(body: str, *, shell_arg: str) -> int:
+    _assert_shell_magic_allowed()
     proc = subprocess.Popen(
         [shell_arg, "-c", body],
         stdout=subprocess.PIPE,
@@ -641,6 +684,7 @@ class _ShellResult(list):
 
 
 def __omp_shell(cmd: str) -> _ShellResult:
+    _assert_shell_magic_allowed()
     proc = subprocess.run(
         cmd,
         shell=True,
@@ -918,7 +962,21 @@ _MANAGED_ENV_KEYS = (
     "PI_TOOL_BRIDGE_TOKEN",
     "PI_TOOL_BRIDGE_SESSION",
     "PI_EVAL_LOCAL_ROOTS",
+    "PI_EVAL_BLOCK_SOURCE_WRITES",
 )
+
+
+def _host_local_roots_from_env() -> dict[str, str]:
+    raw = os.environ.get("PI_EVAL_LOCAL_ROOTS")
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (ValueError, TypeError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {str(k): str(v) for k, v in parsed.items() if isinstance(k, str) and isinstance(v, str)}
 
 
 def _apply_request_runtime(req: dict) -> None:
@@ -939,6 +997,25 @@ def _apply_request_runtime(req: dict) -> None:
                 os.environ[key] = value
             elif value is None:
                 os.environ.pop(key, None)
+        try:
+            import eval_guard
+        except ImportError:
+            eval_guard = None  # type: ignore[assignment]
+        if eval_guard is not None:
+            block = os.environ.get("PI_EVAL_BLOCK_SOURCE_WRITES") == "1"
+            msg = eval_guard.blocked_message()
+            if not msg:
+                msg = (
+                    "eval write() and append() cannot change project source files when the edit tool is available."
+                )
+            eval_guard._host_set_guard_state(block_source_writes=block, blocked_message=msg)
+            eval_guard._host_set_local_roots(_host_local_roots_from_env())
+        try:
+            import eval_io_guard
+        except ImportError:
+            eval_io_guard = None  # type: ignore[assignment]
+        if eval_io_guard is not None:
+            eval_io_guard.install()
 
 def _start_parent_watchdog() -> None:
     """Self-terminate when the host process dies.

--- a/packages/coding-agent/src/prompts/tools/eval.md
+++ b/packages/coding-agent/src/prompts/tools/eval.md
@@ -18,6 +18,7 @@ Cell fields:
 - Define small reusable functions for individual debugging.
 - Put workflow explanations in the assistant message or `title` — never inside cell code.
 {{#if py}}- Python cells run inside an IPython kernel with a live event loop. Use top-level `await` directly (e.g. `await main()`); `asyncio.run(…)` raises "cannot be called from a running event loop".{{/if}}
+**File edits:** use the `edit` tool (hashline `input`), not `write()` in eval cells, when changing existing project source files.
 **On failure:** errors identify the failing cell (e.g., "Cell 3 failed"). Resubmit only the fixed cell (or fixed cell + remaining cells).
 </instruction>
 

--- a/packages/coding-agent/src/tools/bash-interceptor.ts
+++ b/packages/coding-agent/src/tools/bash-interceptor.ts
@@ -6,6 +6,7 @@
  * the specialized tools instead.
  */
 import { type BashInterceptorRule, DEFAULT_BASH_INTERCEPTOR_RULES } from "../config/settings-schema";
+import { bashInterceptScriptedEditMessage } from "../edit/hashline/guidance";
 
 export interface InterceptionResult {
 	/** If true, the bash command should be blocked */
@@ -14,6 +15,30 @@ export interface InterceptionResult {
 	message?: string;
 	/** Suggested tool to use instead */
 	suggestedTool?: string;
+}
+
+/** Default scripted-edit rule for `python -c` file writes (not arbitrary custom `python` patterns). */
+function isDefaultPythonScriptedEditRule(rule: BashInterceptorRule): boolean {
+	return (
+		rule.tool === "edit" &&
+		rule.pattern.includes("python(?:3") &&
+		rule.pattern.includes("-c\\b") &&
+		rule.pattern.includes("write_text|write_bytes")
+	);
+}
+
+/** Default scripted-edit rule for `node -e` / `bun -e` file writes. */
+function isDefaultNodeBunScriptedEditRule(rule: BashInterceptorRule): boolean {
+	return (
+		rule.tool === "edit" &&
+		rule.pattern.includes("node|nodejs|bun") &&
+		rule.pattern.includes("-e\\b") &&
+		rule.pattern.includes("Bun\\.write")
+	);
+}
+
+function isDefaultScriptedEditNormalizationRule(rule: BashInterceptorRule): boolean {
+	return isDefaultPythonScriptedEditRule(rule) || isDefaultNodeBunScriptedEditRule(rule);
 }
 
 /**
@@ -32,6 +57,159 @@ function compileRules(rules: BashInterceptorRule[]): Array<{ rule: BashIntercept
 	return compiled;
 }
 
+/** Strip leading `VAR=value` assignments so interceptor patterns match the real command. */
+function stripInlineEnvAssignments(command: string): string {
+	let rest = command.trim();
+	for (;;) {
+		const match = /^([A-Za-z_][A-Za-z0-9_]*)=(?:"[^"]*"|'[^']*'|[^\s]*)\s+/.exec(rest);
+		if (!match) {
+			return rest;
+		}
+		rest = rest.slice(match[0].length);
+	}
+}
+
+/** GNU env options that consume a separate argv operand (see `env --help`). */
+const ENV_OPTION_WITH_OPERAND: Record<string, true> = {
+	"-u": true,
+	"--unset": true,
+	"-C": true,
+	"--chdir": true,
+	"--block-signal": true,
+};
+
+const ENV_OPTION_INLINE: Record<string, true> = {
+	"-i": true,
+	"--ignore-environment": true,
+	"-0": true,
+	"--null": true,
+};
+
+function splitShellWords(command: string): string[] {
+	const tokens: string[] = [];
+	let i = 0;
+	const s = command.trim();
+	while (i < s.length) {
+		while (i < s.length && /\s/.test(s[i]!)) {
+			i++;
+		}
+		if (i >= s.length) {
+			break;
+		}
+		const quote = s[i];
+		if (quote === '"' || quote === "'") {
+			i++;
+			const start = i;
+			while (i < s.length) {
+				if (s[i] === "\\" && i + 1 < s.length) {
+					i += 2;
+					continue;
+				}
+				if (s[i] === quote) {
+					break;
+				}
+				i++;
+			}
+			tokens.push(s.slice(start, i));
+			if (i < s.length) {
+				i++;
+			}
+			continue;
+		}
+		const start = i;
+		while (i < s.length && !/\s/.test(s[i]!)) {
+			i++;
+		}
+		tokens.push(s.slice(start, i));
+	}
+	return tokens;
+}
+
+function isEnvExecutable(token: string): boolean {
+	return token === "env" || token.endsWith("/env");
+}
+
+function isEnvAssignmentToken(token: string): boolean {
+	return /^[A-Za-z_][A-Za-z0-9_]*=/.test(token);
+}
+
+/** Expand `env -S` / `--split-string` operand into the command argv (GNU env splits the string). */
+function envSplitStringCommandTokens(operand: string): string[] {
+	return splitShellWords(operand);
+}
+
+/** Drop a leading `env` / `/usr/bin/env` argv prefix; return remaining tokens or null if none. */
+function stripLeadingEnvArgv(tokens: string[]): string[] | null {
+	if (tokens.length === 0 || !isEnvExecutable(tokens[0]!)) {
+		return null;
+	}
+	let i = 1;
+	while (i < tokens.length) {
+		const tok = tokens[i]!;
+		if (tok === "--") {
+			i++;
+			break;
+		}
+		if (tok === "-S" || tok === "--split-string") {
+			i++;
+			if (i >= tokens.length) {
+				return [];
+			}
+			return envSplitStringCommandTokens(tokens[i]!);
+		}
+		if (tok.startsWith("--split-string=")) {
+			return envSplitStringCommandTokens(tok.slice("--split-string=".length));
+		}
+		if (isEnvAssignmentToken(tok)) {
+			i++;
+			continue;
+		}
+		if (tok.startsWith("-")) {
+			if (ENV_OPTION_INLINE[tok]) {
+				i++;
+				continue;
+			}
+			if (ENV_OPTION_WITH_OPERAND[tok]) {
+				i += 2;
+				continue;
+			}
+			const eq = tok.indexOf("=");
+			if (eq > 1) {
+				i++;
+				continue;
+			}
+		}
+		break;
+	}
+	return tokens.slice(i);
+}
+
+/**
+ * Normalize `env VAR=val python -c ...` / `/usr/bin/env python -c ...` so anchored python rules match.
+ */
+function stripEnvWrapper(command: string): string {
+	const trimmed = command.trim();
+	const rest = stripLeadingEnvArgv(splitShellWords(trimmed));
+	if (!rest || rest.length === 0) {
+		return trimmed;
+	}
+	return stripInlineEnvAssignments(rest.join(" "));
+}
+
+function scriptedEditNormalizedCommand(command: string): string {
+	return stripEnvWrapper(stripInlineEnvAssignments(command.trim()));
+}
+
+/** Command strings to test against a rule (raw first; normalized only for default scripted-edit rules). */
+function commandMatchCandidates(command: string, rule: BashInterceptorRule): string[] {
+	const trimmed = command.trim();
+	if (!isDefaultScriptedEditNormalizationRule(rule)) {
+		return [trimmed];
+	}
+	const normalized = scriptedEditNormalizedCommand(command);
+	return normalized === trimmed ? [trimmed] : [trimmed, normalized];
+}
+
 /**
  * Check if a bash command should be intercepted.
  *
@@ -44,8 +222,6 @@ export function checkBashInterception(
 	availableTools: string[],
 	rules: BashInterceptorRule[] = DEFAULT_BASH_INTERCEPTOR_RULES,
 ): InterceptionResult {
-	// Normalize command for pattern matching
-	const normalizedCommand = command.trim();
 	const compiled = compileRules(rules);
 
 	for (const { rule, regex } of compiled) {
@@ -54,13 +230,22 @@ export function checkBashInterception(
 			continue;
 		}
 
-		if (regex.test(normalizedCommand)) {
-			return {
-				block: true,
-				message: `Blocked: ${rule.message}\n\nOriginal command: ${command}`,
-				suggestedTool: rule.tool,
-			};
+		const matched = commandMatchCandidates(command, rule).some(candidate => regex.test(candidate));
+		if (!matched) {
+			continue;
 		}
+
+		let body = rule.message;
+		if (isDefaultPythonScriptedEditRule(rule)) {
+			body = bashInterceptScriptedEditMessage("`python -c`");
+		} else if (isDefaultNodeBunScriptedEditRule(rule)) {
+			body = bashInterceptScriptedEditMessage("`node -e` / `bun -e`");
+		}
+		return {
+			block: true,
+			message: `Blocked: ${body}\n\nOriginal command: ${command}`,
+			suggestedTool: rule.tool,
+		};
 	}
 
 	return { block: false };

--- a/packages/coding-agent/test/edit/hashline-empty-input-message.test.ts
+++ b/packages/coding-agent/test/edit/hashline-empty-input-message.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import { ToolError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
+import { executeHashlineSingle } from "../../src/edit/hashline/execute";
+import { parseHashlineEditInput } from "../../src/edit/hashline/parse-input";
+import type { ToolSession } from "../../src/tools";
+
+describe("parseHashlineEditInput", () => {
+	it("wraps prose-only input in ToolError with hashline guidance", () => {
+		expect(() => parseHashlineEditInput("please update MapBuilder.cs for me", "/tmp")).toThrow(ToolError);
+		try {
+			parseHashlineEditInput("please update MapBuilder.cs for me", "/tmp");
+		} catch (error) {
+			expect(error).toBeInstanceOf(ToolError);
+			const message = (error as ToolError).message;
+			expect(message).toMatch(/PATH#TAG|anchored edits/i);
+			expect(message).toMatch(/python -c|node -e|bun -e/i);
+		}
+	});
+});
+
+describe("executeHashlineSingle prose input", () => {
+	it("surfaces ToolError for prose-only edit input", async () => {
+		const session = { cwd: "/tmp" } as ToolSession;
+		await expect(
+			executeHashlineSingle({
+				session,
+				input: "please update MapBuilder.cs for me",
+				writethrough: async () => undefined,
+				beginDeferredDiagnosticsForPath: () => ({
+					onDeferredDiagnostics: () => {},
+					signal: new AbortController().signal,
+					finalize: () => {},
+				}),
+			}),
+		).rejects.toThrow(ToolError);
+	});
+});

--- a/packages/coding-agent/test/edit/hashline-guidance.test.ts
+++ b/packages/coding-agent/test/edit/hashline-guidance.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { DEFAULT_BASH_INTERCEPTOR_RULES } from "@oh-my-pi/pi-coding-agent/config/settings-schema";
+import { checkBashInterception } from "@oh-my-pi/pi-coding-agent/tools/bash-interceptor";
+import { bashInterceptScriptedEditMessage, HASHLINE_EDIT_INPUT_GUIDANCE } from "../../src/edit/hashline/guidance";
+
+describe("HASHLINE_EDIT_INPUT_GUIDANCE", () => {
+	it("mentions hashline edit and bash scripting", () => {
+		expect(HASHLINE_EDIT_INPUT_GUIDANCE).toMatch(/PATH#TAG/);
+		expect(HASHLINE_EDIT_INPUT_GUIDANCE).toMatch(/python -c/);
+	});
+});
+
+describe("bash intercept scripted edit messages", () => {
+	const tools = ["read", "edit"];
+	const pythonRules = DEFAULT_BASH_INTERCEPTOR_RULES.filter(r => r.tool === "edit" && r.pattern.includes("python"));
+
+	it("includes shared guidance when blocking python -c writes", () => {
+		const result = checkBashInterception("python -c \"open('a.ts','w').write('x')\"", tools, pythonRules);
+		expect(result.block).toBe(true);
+		expect(result.message).toContain(HASHLINE_EDIT_INPUT_GUIDANCE);
+	});
+
+	it("bashInterceptScriptedEditMessage embeds guidance", () => {
+		const msg = bashInterceptScriptedEditMessage("`python -c`");
+		expect(msg).toContain("`python -c`");
+		expect(msg).toContain(HASHLINE_EDIT_INPUT_GUIDANCE);
+	});
+});

--- a/packages/coding-agent/test/eval/eval-write-guard.test.ts
+++ b/packages/coding-agent/test/eval/eval-write-guard.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it } from "bun:test";
+import type * as childProcess from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+	createEvalFsPathGuard,
+	createGuardedBunNamespace,
+	createGuardedCreateRequire,
+	createGuardedFsModule,
+	createGuardedRequire,
+	guardedImportModuleNamespace,
+	wrapBuiltinModuleForGuard,
+} from "@oh-my-pi/pi-coding-agent/eval/eval-fs-guard";
+import { guardProcessGetBuiltinModule } from "@oh-my-pi/pi-coding-agent/eval/eval-subprocess-guard";
+import {
+	EVAL_SOURCE_WRITE_BLOCKED_MESSAGE,
+	isEvalArtifactWritePath,
+} from "@oh-my-pi/pi-coding-agent/eval/eval-write-guard";
+import { createHelpers } from "@oh-my-pi/pi-coding-agent/eval/js/shared/helpers";
+import { ToolError } from "@oh-my-pi/pi-coding-agent/tools/tool-errors";
+
+describe("eval write guard", () => {
+	it("allows local:// writes when blocking project source", async () => {
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omp-eval-guard-"));
+		const helpers = createHelpers({
+			cwd: () => process.cwd(),
+			env: new Map(),
+			localRoots: () => ({ local: tmp }),
+			blockProjectSourceWrites: true,
+			emitStatus: () => {},
+		});
+		const target = path.join(tmp, "note.md");
+		await helpers.writeFile("local://note.md", "ok");
+		expect(fs.readFileSync(target, "utf8")).toBe("ok");
+	});
+
+	it("append to resolved local path when blocking project source", async () => {
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omp-eval-guard-"));
+		const helpers = createHelpers({
+			cwd: () => process.cwd(),
+			env: new Map(),
+			localRoots: () => ({ local: tmp }),
+			blockProjectSourceWrites: true,
+			emitStatus: () => {},
+		});
+		const written = await helpers.writeFile("local://note.md", "a");
+		await helpers.append(written, "b");
+		expect(fs.readFileSync(path.join(tmp, "note.md"), "utf8")).toBe("ab");
+	});
+
+	it("blocks plain-path write when blockProjectSourceWrites is set", async () => {
+		const helpers = createHelpers({
+			cwd: () => process.cwd(),
+			env: new Map(),
+			localRoots: () => ({}),
+			blockProjectSourceWrites: true,
+			emitStatus: () => {},
+		});
+		await expect(helpers.writeFile("src/foo.ts", "x")).rejects.toThrow(ToolError);
+		await expect(helpers.append("src/foo.ts", "x")).rejects.toThrow(EVAL_SOURCE_WRITE_BLOCKED_MESSAGE);
+	});
+
+	it("allows plain-path write when guard is off", async () => {
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omp-eval-guard-"));
+		const helpers = createHelpers({
+			cwd: () => tmp,
+			env: new Map(),
+			localRoots: () => ({}),
+			blockProjectSourceWrites: false,
+			emitStatus: () => {},
+		});
+		await helpers.writeFile("a.txt", "z");
+		expect(fs.readFileSync(path.join(tmp, "a.txt"), "utf8")).toBe("z");
+	});
+
+	it("classifies local:// as artifact path", () => {
+		expect(isEvalArtifactWritePath("local://x.md", { local: "/tmp" })).toBe(true);
+		expect(isEvalArtifactWritePath("src/x.ts", { local: "/tmp" })).toBe(false);
+	});
+
+	it("blocks fs.writeFileSync when guard is on", () => {
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omp-eval-fs-guard-"));
+		const guard = createEvalFsPathGuard(true, {});
+		const gfs = createGuardedFsModule(fs, guard);
+		const target = path.join(tmp, "blocked.ts");
+		expect(() => gfs.writeFileSync(target, "x")).toThrow(ToolError);
+	});
+	it("blocks createRequire('fs') when guard is on", () => {
+		const { createRequire: nodeCreateRequire } = require("node:module") as typeof import("node:module");
+		const guard = createEvalFsPathGuard(true, {});
+		const wrapped = createGuardedCreateRequire(nodeCreateRequire, guard, fs);
+		const req = wrapped(import.meta.url);
+		const gfs = req("fs") as ReturnType<typeof createGuardedFsModule>;
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omp-eval-req-guard-"));
+		const target = path.join(tmp, "blocked.ts");
+		expect(() => gfs.writeFileSync(target, "x")).toThrow(ToolError);
+	});
+
+	it("blocks require('fs') via createGuardedRequire", () => {
+		const { createRequire: nodeCreateRequire } = require("node:module") as typeof import("node:module");
+		const guard = createEvalFsPathGuard(true, {});
+		const base = nodeCreateRequire(import.meta.url);
+		const req = createGuardedRequire(base, guard, fs);
+		const gfs = req("node:fs") as ReturnType<typeof createGuardedFsModule>;
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omp-eval-req-guard-"));
+		expect(() => gfs.writeFileSync(path.join(tmp, "x.ts"), "x")).toThrow(ToolError);
+	});
+	it("guarded fs module default export is guarded", () => {
+		const guard = createEvalFsPathGuard(true, {});
+		const gfs = createGuardedFsModule(fs, guard) as typeof fs & { default: typeof fs };
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omp-eval-fs-default-"));
+		const target = path.join(tmp, "blocked.ts");
+		expect(() => gfs.default.writeFileSync(target, "x")).toThrow(ToolError);
+	});
+
+	it("guardedImportModuleNamespace default export blocks writes", async () => {
+		const guard = createEvalFsPathGuard(true, {});
+		const ns = (await guardedImportModuleNamespace(
+			"node:fs",
+			guard,
+			fs,
+			async target => await import(target),
+		)) as typeof fs & { default: typeof fs };
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omp-eval-import-default-"));
+		const target = path.join(tmp, "blocked.ts");
+		expect(() => ns.default.writeFileSync(target, "x")).toThrow(ToolError);
+	});
+
+	it("blocks openSync in write mode on project paths", () => {
+		const guard = createEvalFsPathGuard(true, {});
+		const gfs = createGuardedFsModule(fs, guard);
+		const target = path.join(process.cwd(), "src", "__eval_guard_open_sync_probe__.ts");
+		expect(() => gfs.openSync(target, "w")).toThrow(ToolError);
+	});
+
+	it("blocks writeSync on unregistered fd when guard is on", () => {
+		const guard = createEvalFsPathGuard(true, {});
+		const gfs = createGuardedFsModule(fs, guard);
+		expect(() => gfs.writeSync(999_999, Buffer.from("x"))).toThrow(ToolError);
+	});
+
+	it("allows writeSync to stdio fd when guard is on", () => {
+		const guard = createEvalFsPathGuard(true, {});
+		const gfs = createGuardedFsModule(fs, guard);
+		expect(() => gfs.writeSync(1, Buffer.from("ok"))).not.toThrow();
+	});
+
+	it("allows writeFileSync to guarded open fd under local root", () => {
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omp-eval-guard-"));
+		const guard = createEvalFsPathGuard(true, { local: tmp });
+		const gfs = createGuardedFsModule(fs, guard);
+		const target = path.join(tmp, "out.txt");
+		const fd = gfs.openSync(target, "w");
+		gfs.writeFileSync(fd, "ok");
+		gfs.closeSync(fd);
+		expect(fs.readFileSync(target, "utf8")).toBe("ok");
+	});
+
+	it("allows writeSync after callback fs.open under local root", async () => {
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omp-eval-guard-"));
+		const guard = createEvalFsPathGuard(true, { local: tmp });
+		const gfs = createGuardedFsModule(fs, guard);
+		const target = path.join(tmp, "cb.txt");
+		await new Promise<void>((resolve, reject) => {
+			gfs.open(target, "w", (err, fd) => {
+				if (err) {
+					reject(err);
+					return;
+				}
+				try {
+					gfs.writeSync(fd!, Buffer.from("cb"));
+					gfs.closeSync(fd!);
+					resolve();
+				} catch (e) {
+					reject(e);
+				}
+			});
+		});
+		expect(fs.readFileSync(target, "utf8")).toBe("cb");
+	});
+
+	it("blocks fs.writeFileSync with Buffer path", () => {
+		const guard = createEvalFsPathGuard(true, {});
+		const gfs = createGuardedFsModule(fs, guard);
+		const target = path.join(process.cwd(), "src", "__eval_guard_buf__.ts");
+		expect(() => gfs.writeFileSync(Buffer.from(target), "x")).toThrow(ToolError);
+	});
+
+	it("blocks openSync with rs+ on project paths", () => {
+		const guard = createEvalFsPathGuard(true, {});
+		const gfs = createGuardedFsModule(fs, guard);
+		const target = path.join(process.cwd(), "src", "__eval_guard_rsp__.ts");
+		expect(() => gfs.openSync(target, "rs+")).toThrow(ToolError);
+	});
+
+	it("guardedImportModuleNamespace sets promises default", async () => {
+		const guard = createEvalFsPathGuard(true, {});
+		const ns = (await guardedImportModuleNamespace(
+			"node:fs/promises",
+			guard,
+			fs,
+			async target => await import(target),
+		)) as { default?: { readFile?: unknown } };
+		expect(ns.default).toBeDefined();
+		expect(typeof ns.default?.readFile).toBe("function");
+	});
+	it("blocks fs.writeFile callback API when guard is on", () => {
+		const guard = createEvalFsPathGuard(true, {});
+		const gfs = createGuardedFsModule(fs, guard);
+		const target = path.join(process.cwd(), "src", "__eval_guard_writefile_cb__.ts");
+		expect(() => gfs.writeFile(target, "x", () => {})).toThrow(ToolError);
+	});
+
+	it("createGuardedBunNamespace allows Bun.file read on project paths", () => {
+		if (typeof globalThis.Bun === "undefined") return;
+		const guard = createEvalFsPathGuard(true, { local: os.tmpdir() });
+		const proxy = createGuardedBunNamespace(guard) as typeof Bun;
+		expect(proxy).toBeDefined();
+		const f = proxy.file(path.join(process.cwd(), "package.json"));
+		expect(f.size).toBeGreaterThan(0);
+	});
+
+	it("createGuardedBunNamespace blocks Bun.file writer on project paths", () => {
+		if (typeof globalThis.Bun === "undefined") return;
+		const guard = createEvalFsPathGuard(true, { local: os.tmpdir() });
+		const proxy = createGuardedBunNamespace(guard) as typeof Bun;
+		const target = path.join(process.cwd(), "src", "__eval_guard_bun_file_writer__.ts");
+		const f = proxy.file(target);
+		expect(() => f.writer()).toThrow(ToolError);
+	});
+
+	it("createGuardedBunNamespace blocks Bun.write on project paths", async () => {
+		if (typeof globalThis.Bun === "undefined") return;
+		const { createGuardedBunNamespace } = await import("@oh-my-pi/pi-coding-agent/eval/eval-fs-guard");
+		const guard = createEvalFsPathGuard(true, {});
+		const bun = createGuardedBunNamespace(guard) as { write: (d: unknown, d2: unknown) => Promise<unknown> };
+		const target = path.join(process.cwd(), "src", "__eval_guard_bun_write__.ts");
+		await expect(bun.write(target, "x")).rejects.toThrow(ToolError);
+	});
+	it("allows writes under eval localRoots filesystem paths", () => {
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omp-eval-local-root-"));
+		const guard = createEvalFsPathGuard(true, { local: tmp });
+		const gfs = createGuardedFsModule(fs, guard);
+		const target = path.join(tmp, "artifact.txt");
+		gfs.writeFileSync(target, "ok");
+		expect(fs.readFileSync(target, "utf8")).toBe("ok");
+	});
+
+	it("blocks fs.cpSync to project destination", () => {
+		if (typeof fs.cpSync !== "function") return;
+		const guard = createEvalFsPathGuard(true, {});
+		const gfs = createGuardedFsModule(fs, guard);
+		const src = path.join(os.tmpdir(), `omp-eval-cp-src-${process.pid}.txt`);
+		const dest = path.join(process.cwd(), "src", "__eval_guard_cp__.ts");
+		fs.writeFileSync(src, "payload");
+		try {
+			expect(() => gfs.cpSync(src, dest)).toThrow(ToolError);
+		} finally {
+			try {
+				fs.unlinkSync(src);
+			} catch {
+				/* ignore */
+			}
+		}
+	});
+
+	it("blocks openSync with O_TRUNC on project paths", () => {
+		const guard = createEvalFsPathGuard(true, {});
+		const gfs = createGuardedFsModule(fs, guard);
+		const target = path.join(process.cwd(), "src", "__eval_guard_otrunc__.ts");
+		expect(() => gfs.openSync(target, fs.constants.O_TRUNC)).toThrow(ToolError);
+	});
+	it("blocks child_process execFileSync when guard is on", () => {
+		const { createRequire: nodeCreateRequire } = require("node:module") as typeof import("node:module");
+		const guard = createEvalFsPathGuard(true, {});
+		const req = createGuardedRequire(nodeCreateRequire(import.meta.url), guard, fs);
+		const cp = req("node:child_process") as typeof childProcess;
+		expect(() => cp.execFileSync("echo", ["hi"])).toThrow(ToolError);
+	});
+	it("guards process.getBuiltinModule fs when available", () => {
+		const proc = globalThis.process as NodeJS.Process & {
+			getBuiltinModule?: (id: string) => unknown;
+		};
+		if (typeof proc.getBuiltinModule !== "function") return;
+		const guard = createEvalFsPathGuard(true, {});
+		const wrapped = guardProcessGetBuiltinModule(proc, true, (specifier, mod) =>
+			wrapBuiltinModuleForGuard(specifier, mod, guard, fs),
+		);
+		const gfs = wrapped.getBuiltinModule!("node:fs") as ReturnType<typeof createGuardedFsModule>;
+		const target = path.join(process.cwd(), "src", "__eval_guard_builtin__.ts");
+		expect(() => gfs.writeFileSync(target, "x")).toThrow(ToolError);
+	});
+	it("allows FileHandle writeFile under localRoots after guarded open", async () => {
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omp-eval-fh-"));
+		const guard = createEvalFsPathGuard(true, { local: tmp });
+		const gfs = createGuardedFsModule(fs, guard);
+		const file = path.join(tmp, "out.txt");
+		const fh = await gfs.promises.open(file, "w");
+		await fh.writeFile("ok");
+		await fh.close();
+		expect(fs.readFileSync(file, "utf8")).toBe("ok");
+	});
+	it("blocks renameSync from project source even when dest is local root", () => {
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omp-eval-rename-"));
+		const guard = createEvalFsPathGuard(true, { local: tmp });
+		const gfs = createGuardedFsModule(fs, guard);
+		const src = path.join(process.cwd(), "src", "__eval_guard_rename_src__.ts");
+		const dest = path.join(tmp, "moved.ts");
+		fs.writeFileSync(src, "x");
+		try {
+			expect(() => gfs.renameSync(src, dest)).toThrow(ToolError);
+		} finally {
+			try {
+				fs.unlinkSync(src);
+			} catch {
+				/* ignore */
+			}
+		}
+	});
+
+	it("guardedImportModuleNamespace wraps node:module createRequire", async () => {
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omp-eval-guard-"));
+		const guard = createEvalFsPathGuard(true, { local: tmp });
+		const mod = (await guardedImportModuleNamespace("node:module", guard, fs, target => import(target))) as {
+			createRequire: typeof createGuardedCreateRequire extends (a: infer A) => unknown ? A : never;
+		};
+		const cr = (mod as { createRequire: ReturnType<typeof createGuardedCreateRequire> }).createRequire(
+			import.meta.url,
+		);
+		const gfs = cr("fs") as typeof fs;
+		expect(() => gfs.writeFileSync(path.join(process.cwd(), "package.json"), "x")).toThrow(
+			EVAL_SOURCE_WRITE_BLOCKED_MESSAGE,
+		);
+	});
+
+	it("blocks symlinkSync from project source into local root", () => {
+		const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "omp-eval-guard-"));
+		const src = path.join(process.cwd(), "package.json");
+		const dest = path.join(tmp, "alias.json");
+		const guard = createEvalFsPathGuard(true, { local: tmp });
+		const gfs = createGuardedFsModule(fs, guard);
+		expect(() => gfs.symlinkSync(src, dest)).toThrow(EVAL_SOURCE_WRITE_BLOCKED_MESSAGE);
+	});
+});

--- a/packages/coding-agent/test/eval/test_eval_io_guard.py
+++ b/packages/coding-agent/test/eval/test_eval_io_guard.py
@@ -1,0 +1,132 @@
+"""Contract: eval_io_guard blocks open() writes when eval_guard is on."""
+import io
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# Simulate runner bundle layout: eval_guard + eval_io_guard alongside runner
+ROOT = Path(__file__).resolve().parents[2] / "src" / "eval" / "py"
+sys.path.insert(0, str(ROOT))
+
+import eval_guard  # noqa: E402
+import eval_io_guard  # noqa: E402
+
+tmpdir = tempfile.mkdtemp()
+target = os.path.join(tmpdir, "src", "foo.py")
+os.makedirs(os.path.dirname(target), exist_ok=True)
+
+eval_guard._host_set_guard_state(block_source_writes=True, blocked_message="blocked")
+eval_io_guard.install()
+
+try:
+    open(target, "w").write("x")
+    raise SystemExit("expected ValueError")
+except ValueError as e:
+    assert "blocked" in str(e).lower() or "edit" in str(e).lower()
+
+p = Path(target)
+try:
+    open(target, "r+").write("z")
+    raise SystemExit("expected ValueError for r+")
+except ValueError:
+    pass
+
+try:
+    with p.open("w") as f:
+        f.write("w")
+    raise SystemExit("expected ValueError for Path.open")
+except ValueError:
+    pass
+
+try:
+    io.open(target, "w").write("io")
+    raise SystemExit("expected ValueError for io.open")
+except ValueError:
+    pass
+
+try:
+    open(target, "rt+").write("rt")
+    raise SystemExit("expected ValueError for rt+")
+except ValueError:
+    pass
+
+try:
+    p.write_text("y")
+    raise SystemExit("expected ValueError for Path.write_text")
+except ValueError:
+    pass
+
+try:
+    p.unlink()
+    raise SystemExit("expected ValueError for Path.unlink")
+except ValueError:
+    pass
+
+
+if hasattr(os, "symlink"):
+    try:
+        os.symlink(target, os.path.join(tmpdir, "alias.py"))
+        raise SystemExit("expected ValueError for os.symlink from blocked path")
+    except ValueError:
+        pass
+
+artifact_root = os.path.join(tmpdir, "artifact-root")
+os.makedirs(artifact_root, exist_ok=True)
+eval_guard._host_set_local_roots({"local": artifact_root})
+artifact_file = os.path.join(artifact_root, "note.txt")
+Path(artifact_file).write_text("ok")
+assert Path(artifact_file).read_text() == "ok"
+
+# User cannot widen allowlist via os.environ
+os.environ["PI_EVAL_LOCAL_ROOTS"] = json.dumps({"local": os.path.dirname(target)})
+try:
+    open(target, "w").write("spoof")
+    raise SystemExit("expected ValueError after env spoof")
+except ValueError:
+    pass
+
+try:
+    fd = os.open(target, os.O_WRONLY | os.O_CREAT)
+    os.write(fd, b"x")
+    raise SystemExit("expected ValueError for os.open/write")
+except ValueError:
+    pass
+finally:
+    try:
+        os.close(fd)
+    except Exception:
+        pass
+
+import subprocess
+
+try:
+    subprocess.run(["echo", "hi"])
+    raise SystemExit("expected ValueError for subprocess.run")
+except ValueError:
+    pass
+
+try:
+    eval_guard.configure(block_source_writes=False, blocked_message="")
+    raise SystemExit("expected RuntimeError for configure from cell")
+except RuntimeError:
+    pass
+
+if hasattr(os, "replace"):
+    try:
+        os.replace(target, target + ".moved")
+        raise SystemExit("expected ValueError for os.replace")
+    except ValueError:
+        pass
+
+eval_guard._host_set_guard_state(block_source_writes=False, blocked_message="")
+eval_io_guard.install()
+subprocess.run(
+    [sys.executable, "-c", "pass"],
+    check=True,
+    capture_output=True,
+)
+print("subprocess ok when guard off")
+
+print("eval_io_guard ok")

--- a/packages/coding-agent/test/eval/test_eval_shell_magic.py
+++ b/packages/coding-agent/test/eval/test_eval_shell_magic.py
@@ -1,0 +1,29 @@
+"""Shell magics blocked when eval source-write guard is on."""
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2] / "src" / "eval" / "py"
+sys.path.insert(0, str(ROOT))
+
+import eval_guard  # noqa: E402
+
+# Import runner helpers without starting main loop
+import runner  # noqa: E402
+
+eval_guard._host_set_guard_state(block_source_writes=True, blocked_message="blocked")
+
+try:
+    runner.__omp_shell("echo hi")
+    raise SystemExit("expected ValueError for ! shell")
+except ValueError:
+    pass
+
+try:
+    runner._run_shell_body("echo hi", shell_arg="/bin/sh")
+    raise SystemExit("expected ValueError for %%bash")
+except ValueError:
+    pass
+
+print("eval_shell_magic ok")

--- a/packages/coding-agent/test/eval/test_kernel_guard_layout.py
+++ b/packages/coding-agent/test/eval/test_kernel_guard_layout.py
@@ -1,0 +1,24 @@
+"""eval_guard modules are importable next to runner.py (kernel cache layout)."""
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2] / "src" / "eval" / "py"
+guard_src = (ROOT / "eval_guard.py").read_text(encoding="utf-8")
+io_src = (ROOT / "eval_io_guard.py").read_text(encoding="utf-8")
+
+tmpdir = tempfile.mkdtemp()
+cache = os.path.join(tmpdir, "bundle-test")
+os.makedirs(cache)
+Path(cache, "eval_guard.py").write_text(guard_src, encoding="utf-8")
+Path(cache, "eval_io_guard.py").write_text(io_src, encoding="utf-8")
+Path(cache, "runner.py").write_text("# stub\n", encoding="utf-8")
+
+sys.path.insert(0, cache)
+import eval_guard  # noqa: E402
+import eval_io_guard  # noqa: E402
+
+eval_guard._host_set_guard_state(block_source_writes=True, blocked_message="blocked")
+eval_io_guard.install()
+print("kernel guard layout ok")

--- a/packages/coding-agent/test/integration/grok-hashline-steering.test.ts
+++ b/packages/coding-agent/test/integration/grok-hashline-steering.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { DEFAULT_BASH_INTERCEPTOR_RULES } from "@oh-my-pi/pi-coding-agent/config/settings-schema";
+import { writethroughNoop } from "@oh-my-pi/pi-coding-agent/lsp";
+import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools";
+import { checkBashInterception } from "@oh-my-pi/pi-coding-agent/tools/bash-interceptor";
+import { WriteTool } from "@oh-my-pi/pi-coding-agent/tools/write";
+import { executeHashlineSingle } from "../../src/edit/hashline/execute";
+import { HASHLINE_EDIT_INPUT_GUIDANCE } from "../../src/edit/hashline/guidance";
+import { parseHashlineEditInput } from "../../src/edit/hashline/parse-input";
+
+const tools = ["read", "search", "find", "edit", "write", "bash"];
+const scriptedRules = DEFAULT_BASH_INTERCEPTOR_RULES.filter(
+	r => r.tool === "edit" && (r.pattern.includes("python") || r.pattern.includes("node|nodejs|bun")),
+);
+const HASHLINE_HEADER_LINE = /^\[([^#\r\n]+)#([0-9A-F]{4})\]$/;
+
+function createSession(cwd: string): ToolSession {
+	return {
+		cwd,
+		hasUI: false,
+		getSessionFile: () => path.join(cwd, "session.jsonl"),
+		getSessionSpawns: () => "*",
+		getArtifactsDir: () => path.join(cwd, "artifacts"),
+		allocateOutputArtifact: async () => ({ id: "artifact-1", path: path.join(cwd, "artifact-1.log") }),
+		settings: Settings.isolated(),
+		enableLsp: false,
+	} as ToolSession;
+}
+
+function resultText(result: { content: { type: string; text?: string }[] }): string {
+	return result.content
+		.filter((b): b is { type: "text"; text: string } => b.type === "text" && typeof b.text === "string")
+		.map(b => b.text)
+		.join("\n");
+}
+
+function deferredDiagnosticsStub() {
+	return {
+		onDeferredDiagnostics: () => {},
+		signal: new AbortController().signal,
+		finalize: () => {},
+	};
+}
+
+describe("Grok hashline steering integration", () => {
+	let tmpDir: string;
+
+	beforeAll(async () => {
+		await Settings.init({ inMemory: true });
+	});
+
+	beforeEach(async () => {
+		tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "grok-hashline-"));
+	});
+
+	afterEach(async () => {
+		await fs.rm(tmpDir, { recursive: true, force: true });
+	});
+
+	it("blocks python -c file write with shared HASHLINE_EDIT_INPUT_GUIDANCE", () => {
+		const cmd = "python -c \"open('target.ts','w').write('x')\"";
+		const result = checkBashInterception(cmd, tools, scriptedRules);
+		expect(result.block).toBe(true);
+		expect(result.message).toContain(HASHLINE_EDIT_INPUT_GUIDANCE);
+		expect(result.suggestedTool).toBe("edit");
+	});
+
+	it("applies hashline edit after write tag (Grok happy path)", async () => {
+		const filePath = path.join(tmpDir, "target.ts");
+		const session = createSession(tmpDir);
+		const writeTool = new WriteTool(session);
+		const content = 'export const GROK_HASHLINE_MARKER = "before-grok-edit";\n';
+		const writeResult = await writeTool.execute("w1", { path: filePath, content });
+		const headerLine = resultText(writeResult).split("\n")[0] ?? "";
+		expect(HASHLINE_HEADER_LINE.test(headerLine)).toBe(true);
+
+		const input = `${headerLine}\nreplace 1..1:\n+export const GROK_HASHLINE_MARKER = "after-grok-hashline-edit";`;
+		await executeHashlineSingle({
+			session,
+			input,
+			writethrough: writethroughNoop,
+			beginDeferredDiagnosticsForPath: deferredDiagnosticsStub,
+		});
+		const after = await fs.readFile(filePath, "utf8");
+		expect(after).toContain("after-grok-hashline-edit");
+	});
+
+	it("rejects prose-only edit input with guidance (Grok failure mode)", () => {
+		try {
+			parseHashlineEditInput("please change target.ts for me", tmpDir);
+			expect(true).toBe(false);
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			expect(msg).toContain(HASHLINE_EDIT_INPUT_GUIDANCE);
+		}
+	});
+});

--- a/packages/coding-agent/test/tools/bash-interceptor-custom-message.test.ts
+++ b/packages/coding-agent/test/tools/bash-interceptor-custom-message.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "bun:test";
+import type { BashInterceptorRule } from "@oh-my-pi/pi-coding-agent/config/settings-schema";
+import { HASHLINE_EDIT_INPUT_GUIDANCE } from "@oh-my-pi/pi-coding-agent/edit/hashline/guidance";
+import { checkBashInterception } from "@oh-my-pi/pi-coding-agent/tools/bash-interceptor";
+
+describe("custom edit interceptor messages", () => {
+	const tools = ["edit"];
+
+	it("preserves configured message for custom python edit rules", () => {
+		const custom: BashInterceptorRule[] = [
+			{
+				pattern: "^python\\s+manage\\.py",
+				tool: "edit",
+				message: "Use the project task runner, not bash, for manage.py.",
+			},
+		];
+		const result = checkBashInterception("python manage.py migrate", tools, custom);
+		expect(result.block).toBe(true);
+		expect(result.message).toContain("Use the project task runner");
+		expect(result.message).not.toContain(HASHLINE_EDIT_INPUT_GUIDANCE);
+	});
+
+	it("matches custom rules against raw command with leading env assignment", () => {
+		const custom: BashInterceptorRule[] = [
+			{
+				pattern: "^AWS_PROFILE=prod\\s+terraform",
+				tool: "bash",
+				message: "Run terraform via the approved wrapper.",
+			},
+		];
+		const result = checkBashInterception("AWS_PROFILE=prod terraform apply", ["bash"], custom);
+		expect(result.block).toBe(true);
+		expect(result.message).toContain("approved wrapper");
+	});
+});

--- a/packages/coding-agent/test/tools/bash-interceptor-scripted-edit.test.ts
+++ b/packages/coding-agent/test/tools/bash-interceptor-scripted-edit.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "bun:test";
+import { DEFAULT_BASH_INTERCEPTOR_RULES } from "@oh-my-pi/pi-coding-agent/config/settings-schema";
+import { checkBashInterception } from "@oh-my-pi/pi-coding-agent/tools/bash-interceptor";
+
+const tools = ["read", "search", "find", "edit", "write"];
+
+function scriptedEditRules() {
+	return DEFAULT_BASH_INTERCEPTOR_RULES.filter(
+		r => r.tool === "edit" && (r.pattern.includes("python") || r.pattern.includes("node|nodejs|bun")),
+	);
+}
+
+describe("default bash interceptor scripted file edits", () => {
+	const rules = scriptedEditRules();
+
+	it("blocks python -c open with write mode", () => {
+		const result = checkBashInterception("python -c \"open('foo.ts','w').write('x')\"", tools, rules);
+		expect(result.block).toBe(true);
+		expect(result.suggestedTool).toBe("edit");
+	});
+
+	it("blocks python -c open().write()", () => {
+		const result = checkBashInterception("python -c \"open('foo.ts').write('x')\"", tools, rules);
+		expect(result.block).toBe(true);
+	});
+
+	it("blocks python -c with open mode keyword", () => {
+		const result = checkBashInterception(
+			"python -c \"with open('a.ts', mode='w') as f: f.write('x')\"",
+			tools,
+			rules,
+		);
+		expect(result.block).toBe(true);
+		expect(result.suggestedTool).toBe("edit");
+	});
+
+	it("blocks python -c with open mode w+", () => {
+		const result = checkBashInterception(
+			"python -c \"with open('a.ts', mode='w+') as f: f.write('x')\"",
+			tools,
+			rules,
+		);
+		expect(result.block).toBe(true);
+		expect(result.suggestedTool).toBe("edit");
+	});
+
+	it("blocks python -c with open mode r+", () => {
+		const result = checkBashInterception(
+			"python -c \"with open('a.ts', mode='r+') as f: f.write('x')\"",
+			tools,
+			rules,
+		);
+		expect(result.block).toBe(true);
+		expect(result.suggestedTool).toBe("edit");
+	});
+
+	it("blocks python -c with open mode r+b", () => {
+		const result = checkBashInterception(`python -c "open('src/foo.py','r+b').write(b'x')"`, tools, rules);
+		expect(result.block).toBe(true);
+		expect(result.suggestedTool).toBe("edit");
+	});
+
+	it("blocks python -c with open mode rb+", () => {
+		const result = checkBashInterception(
+			"python -c \"with open('a.ts', mode='rb+') as f: f.write(b'x')\"",
+			tools,
+			rules,
+		);
+		expect(result.block).toBe(true);
+		expect(result.suggestedTool).toBe("edit");
+	});
+
+	it("blocks multiline python -c Path.write_text", () => {
+		const result = checkBashInterception(
+			"python -c \"from pathlib import Path\nPath('a.ts').write_text('x')\"",
+			tools,
+			rules,
+		);
+		expect(result.block).toBe(true);
+		expect(result.suggestedTool).toBe("edit");
+	});
+
+	it("blocks multiline python -c Path.open write mode", () => {
+		const result = checkBashInterception(
+			"python -c \"from pathlib import Path\nwith Path('a.ts').open('w') as f: f.write('x')\"",
+			tools,
+			rules,
+		);
+		expect(result.block).toBe(true);
+		expect(result.suggestedTool).toBe("edit");
+	});
+
+	it("blocks python -c Path.write_bytes", () => {
+		const result = checkBashInterception(
+			"python -c \"from pathlib import Path; Path('a.ts').write_bytes(b'x')\"",
+			tools,
+			rules,
+		);
+		expect(result.block).toBe(true);
+		expect(result.suggestedTool).toBe("edit");
+	});
+
+	it("blocks python -c after inline env prefix", () => {
+		const result = checkBashInterception("PYTHONPATH=. python -c \"open('a.ts','w').write('x')\"", tools, rules);
+		expect(result.block).toBe(true);
+		expect(result.suggestedTool).toBe("edit");
+	});
+
+	it("blocks env -S split-string python -c write", () => {
+		const result = checkBashInterception("env -S \"python -c \\\"open('a.ts','w').write('x')\\\"\"", tools, rules);
+		expect(result.block).toBe(true);
+		expect(result.suggestedTool).toBe("edit");
+	});
+	it("blocks env -u python -c write", () => {
+		const result = checkBashInterception("env -u PYTHONPATH python -c \"open('a.ts','w').write('x')\"", tools, rules);
+		expect(result.block).toBe(true);
+	});
+
+	it("blocks env -C node -e write", () => {
+		const result = checkBashInterception(
+			"env -C /tmp node -e \"require('fs').writeFileSync('a.ts','')\"",
+			tools,
+			rules,
+		);
+		expect(result.block).toBe(true);
+	});
+	it("blocks env-wrapped python -c write", () => {
+		const result = checkBashInterception("env PYTHONPATH=. python -c \"open('a.ts','w').write('x')\"", tools, rules);
+		expect(result.block).toBe(true);
+		expect(result.suggestedTool).toBe("edit");
+	});
+
+	it("blocks usr-bin-env python -c write", () => {
+		const result = checkBashInterception("/usr/bin/env python -c \"open('a.ts','w').write('x')\"", tools, rules);
+		expect(result.block).toBe(true);
+	});
+
+	it("blocks env-wrapped node -e write", () => {
+		const result = checkBashInterception("env node -e \"require('fs').writeFileSync('a.ts','')\"", tools, rules);
+		expect(result.block).toBe(true);
+		expect(result.suggestedTool).toBe("edit");
+	});
+
+	it("blocks usr-bin-env bun -e write", () => {
+		const result = checkBashInterception("/usr/bin/env bun -e \"Bun.write('a.ts', 'x')\"", tools, rules);
+		expect(result.block).toBe(true);
+	});
+	it("blocks node -e writeFileSync", () => {
+		const result = checkBashInterception("node -e \"require('fs').writeFileSync('a.ts','')\"", tools, rules);
+		expect(result.block).toBe(true);
+		expect(result.suggestedTool).toBe("edit");
+	});
+
+	it("blocks node -e appendFileSync", () => {
+		const result = checkBashInterception("node -e \"require('fs').appendFileSync('a.ts','x')\"", tools, rules);
+		expect(result.block).toBe(true);
+		expect(result.suggestedTool).toBe("edit");
+	});
+
+	it("blocks node -e after inline env prefix", () => {
+		const result = checkBashInterception(
+			"NODE_OPTIONS= node -e \"require('fs').writeFileSync('a.ts','')\"",
+			tools,
+			rules,
+		);
+		expect(result.block).toBe(true);
+		expect(result.suggestedTool).toBe("edit");
+	});
+
+	it("blocks bun -e Bun.write", () => {
+		const result = checkBashInterception("bun -e \"await Bun.write('a.ts', 'x')\"", tools, rules);
+		expect(result.block).toBe(true);
+		expect(result.suggestedTool).toBe("edit");
+	});
+
+	it("does not block python -c read-only open", () => {
+		const result = checkBashInterception("python -c \"print(open('a.ts').read())\"", tools, rules);
+		expect(result.block).toBe(false);
+	});
+
+	it("does not block python -c Path read_text", () => {
+		const result = checkBashInterception(
+			"python -c \"from pathlib import Path; print(Path('a.ts').read_text())\"",
+			tools,
+			rules,
+		);
+		expect(result.block).toBe(false);
+	});
+
+	it("does not block python -c sys.stdout.write", () => {
+		const result = checkBashInterception("python -c \"import sys; sys.stdout.write('ok')\"", tools, rules);
+		expect(result.block).toBe(false);
+	});
+
+	it("does not block python -c sys.stdout.writelines", () => {
+		const result = checkBashInterception("python -c \"import sys; sys.stdout.writelines(['ok'])\"", tools, rules);
+		expect(result.block).toBe(false);
+	});
+
+	it("blocks python -c Path.writelines", () => {
+		const result = checkBashInterception(
+			"python -c \"from pathlib import Path; Path('a.ts').writelines(['x'])\"",
+			tools,
+			rules,
+		);
+		expect(result.block).toBe(true);
+		expect(result.suggestedTool).toBe("edit");
+	});
+
+	it("blocks python -c open().writelines", () => {
+		const result = checkBashInterception("python -c \"open('a.ts','w').writelines(['x'])\"", tools, rules);
+		expect(result.block).toBe(true);
+	});
+
+	it("does not block python -c that only prints", () => {
+		const result = checkBashInterception('python -c "print(1)"', tools, rules);
+		expect(result.block).toBe(false);
+	});
+});


### PR DESCRIPTION
## Problem

`xai-oauth/grok-composer-2.5-fast` often changes project source via **`bash`** (`python -c`, `node -e`, `bun -e`, env wrappers) or **`eval`** (`write`, `fs`, `pathlib`, `Bun.write`) instead of hashline **`edit`**, and sometimes calls **`edit`** with prose/JSON/empty `input` → opaque parser errors instead of actionable guidance.

Fixes [#2272](https://github.com/can1357/oh-my-pi/issues/2272)

## Approach

**Inline tool guidance** (shared `HASHLINE_EDIT_INPUT_GUIDANCE` in `edit/hashline/guidance.ts`) — not a Grok-specific system prompt. Same string when bash blocks scripted writes and when `parseHashlineEditInput` rejects bad `edit` input.

**Enforcement, not prompts-only:** when `edit` is available, eval blocks project-path writes through guarded prelude helpers, **`node:fs`** / **`fs/promises`** (require, import, callback + sync + promises APIs, streams, fds, `Bun.write`), and Python **`builtins.open`**, **`io.open`**, **`Path.open`**, **`write_text`** / **`write_bytes`** (immutable guard flag via `eval_guard`, not user-mutable `os.environ`).

## Changes

### Bash interceptor
- Default rules in `settings-schema.ts` + `bash-interceptor.ts`: write-only `python -c` / `node -e` / `bun -e` (incl. `Bun.write`, `appendFile*`, multiline payloads, keyword/positional write modes, `Path.open('w')`, `write_bytes`, etc.).
- Strip leading `VAR=value`, `env` / `/usr/bin/env` (incl. `-u`/`-C`/`-S` operands) before matching; custom rules still match **raw** command first.
- `eval.md`: steer file changes to `edit` for existing source files.

### Hashline `edit`
- `parse-input.ts`: wrap `Patch.parse` failures → `ToolError` + `HASHLINE_EDIT_INPUT_GUIDANCE`.
- `execute.ts`: actionable empty/malformed input handling.

### Eval write guard (JS)
- `eval-write-guard.ts`, `eval-fs-guard.ts`, `runtime.ts`, `local-module-loader.ts`, `helpers.ts`: block prelude `write`/`append` and project paths; guarded `fs`, `require`/`createRequire`, dynamic `import` of `node:fs` / `fs/promises`, callback APIs, `createWriteStream`, `promises.open` + FileHandle writes, injected guarded **`Bun`** namespace.

### Eval write guard (Python)
- `eval_guard.py` (immutable block flag), `eval_io_guard.py` (`open`, `io.open`, `Path.open`, write helpers), `kernel.ts` bundle layout (`eval_guard` / `eval_io_guard` / `runner` siblings), `runner.py` import order fix.

### Tests
- Production `DEFAULT_BASH_INTERCEPTOR_RULES` + `checkBashInterception`
- Hashline guidance / empty-input / integration `grok-hashline-steering.test.ts`
- `eval-write-guard.test.ts`, `test_eval_io_guard.py`, `test_kernel_guard_layout.py`

## Verification

```bash
cd packages/coding-agent
bun run ci:check:full   # same as CI "Lint & type check"
bun test test/integration/grok-hashline-steering.test.ts \
  test/tools/bash-interceptor-scripted-edit.test.ts \
  test/edit/hashline-guidance.test.ts \
  test/edit/hashline-empty-input-message.test.ts \
  test/eval/eval-write-guard.test.ts
python test/eval/test_eval_io_guard.py
python test/eval/test_kernel_guard_layout.py
```

## Manual check (OAuth Grok Composer)

```bash
cd packages/coding-agent
bun run src/cli.ts --no-session --auto-approve --print \
  --model "xai-oauth/grok-composer-2.5-fast" \
  -p "Read an existing file in this package, then change one line with a single hashline edit ([PATH#TAG] from read). Do not use bash/python/eval to write files."
```

Expect hashline `edit`; scripted bash/eval writes should surface the shared guidance or `ToolError`.