### PR TITLE
fix(coding-agent): block scripted file edit bypasses

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -37,6 +37,7 @@
 
 ### Fixed
 
+- Fixed hashline edit enforcement by blocking scripted Python/JavaScript file writes in bash/eval and returning actionable guidance for malformed hashline edit payloads ([#2272](https://github.com/can1357/oh-my-pi/issues/2272)).
 - Fixed startup Ctrl+C handling in pre-TUI mode so it now clears typed text before exiting on a second press
 - Fixed npm CLI distribution bundles by embedding the stats dashboard client bundle so dashboard assets are served in prebuilt installs
 - Fixed the CLI smoke-test command to start the stats server and verify dashboard HTML is served, catching bundled-asset regressions

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -247,7 +247,7 @@ export const DEFAULT_BASH_INTERCEPTOR_RULES: BashInterceptorRule[] = [
 	},
 	{
 		pattern:
-			"^\\s*(?:python\\d*(?:\\.\\d+)?|uv\\s+run\\s+python)\\s+(?:-[cCm]|--command)\\s+.*(?:\\.write_text\\s*\\(|\\.write_bytes\\s*\\(|open\\s*\\([^)]*,\\s*[\"'][^\"']*[wax+]|\\.write\\s*\\()",
+			"^\\s*(?:python\\d*(?:\\.\\d+)?|uv\\s+run\\s+python)\\s+(?:-[cCm]|--command)\\s+.*(?:\\.write_text\\s*\\(|\\.write_bytes\\s*\\(|\\bopen\\s*\\([^)]*(?:,\\s*[\"'][^\"']*[wax+]|,\\s*mode\\s*=\\s*[\"'][^\"']*[wax+])|\\.open\\s*\\([^)]*(?:,\\s*[\"'][^\"']*[wax+]|,\\s*mode\\s*=\\s*[\"'][^\"']*[wax+]))",
 		flags: "s",
 		tool: "edit",
 		message:

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -246,6 +246,22 @@ export const DEFAULT_BASH_INTERCEPTOR_RULES: BashInterceptorRule[] = [
 		message: "Use the `edit` tool instead of awk -i inplace. It provides diff preview and fuzzy matching.",
 	},
 	{
+		pattern:
+			"^\\s*(?:python\\d*(?:\\.\\d+)?|uv\\s+run\\s+python)\\s+(?:-[cCm]|--command)\\s+.*(?:\\.write_text\\s*\\(|\\.write_bytes\\s*\\(|open\\s*\\([^)]*,\\s*[\"'][^\"']*[wax+]|\\.write\\s*\\()",
+		flags: "s",
+		tool: "edit",
+		message:
+			"Use the `edit` tool instead of scripted Python file writes. It preserves hashline snapshots and diff preview.",
+	},
+	{
+		pattern:
+			"^\\s*(?:node|bun)\\s+(?:-e|--eval)\\s+.*(?:\\b(?:writeFileSync|writeFile|appendFileSync|appendFile|createWriteStream)\\s*\\(|\\bBun\\.write\\s*\\()",
+		flags: "s",
+		tool: "edit",
+		message:
+			"Use the `edit` tool instead of scripted JavaScript file writes. It preserves hashline snapshots and diff preview.",
+	},
+	{
 		// `>` must sit outside quoted regions (so `echo "a -> b"` passes) and be
 		// followed by a plausible filename — including `$VAR` targets; `>|`
 		// (clobber) counts as a redirect; `>&2`/`2>&1` style fd duplication is

--- a/packages/coding-agent/src/edit/hashline/execute.ts
+++ b/packages/coding-agent/src/edit/hashline/execute.ts
@@ -157,12 +157,29 @@ function renderSection(result: PatchSectionResult, diagnostics: FileDiagnosticsR
 	};
 }
 
+function noHashlineSectionsDiagnostic(): string {
+	return [
+		"No hashline sections found in input.",
+		"",
+		"Use the hashline edit format exactly: start with a `[PATH#TAG]` header copied from `read` or `search`, then one or more hashline ops such as `replace N..M:`, `insert after N:`, or `delete N`.",
+		"Do not send prose, JSON, Markdown fences, or an object with separate path/edits fields as `input`; the entire hashline patch must be the `input` string.",
+	].join("\n");
+}
+
 export async function executeHashlineSingle(
 	options: ExecuteHashlineSingleOptions,
 ): Promise<AgentToolResult<EditToolDetails, typeof hashlineEditParamsSchema>> {
-	const patch = Patch.parse(options.input, { cwd: options.session.cwd });
+	let patch: Patch;
+	try {
+		patch = Patch.parse(options.input, { cwd: options.session.cwd });
+	} catch (error) {
+		if (error instanceof Error && error.message.includes("input must begin with")) {
+			throw new ToolError(`${noHashlineSectionsDiagnostic()}\n\nParser detail: ${error.message}`);
+		}
+		throw error;
+	}
 	if (patch.sections.length === 0) {
-		throw new Error("No hashline sections found in input.");
+		throw new ToolError(noHashlineSectionsDiagnostic());
 	}
 
 	const fs = new HashlineFilesystem({

--- a/packages/coding-agent/src/prompts/tools/bash.md
+++ b/packages/coding-agent/src/prompts/tools/bash.md
@@ -13,7 +13,7 @@ Executes bash command in shell session for terminal operations like git, bun, ca
 </instruction>
 
 <critical>
-- NEVER use shell to fetch, display, list, page, or search content a dedicated tool serves: `cat`/`head`/`tail`/`less`/`more`/`ls` → `read`; `grep`/`rg`/`ag`/`ack` → `search`; `find`/`fd` → `find`; `sed -i`/`perl -i`/`awk -i` → `edit`; `echo >`/heredoc → `write`. The tools keep gitignore semantics, line anchors, and structured output that shell loses.
+- NEVER use shell to fetch, display, list, page, search, or edit content a dedicated tool serves: `cat`/`head`/`tail`/`less`/`more`/`ls` → `read`; `grep`/`rg`/`ag`/`ack` → `search`; `find`/`fd` → `find`; `sed -i`/`perl -i`/`awk -i`/scripted `python -c` or `node -e` file writes → `edit`; `echo >`/heredoc → `write`. The tools keep gitignore semantics, line anchors, hashline snapshots, and structured output that shell loses.
 - NEVER trim or silence output: no `| head -n N`, `| tail -n N`, `| less`, `2>&1`, `2>/dev/null`. stderr is already merged; long output is auto-truncated with the FULL capture kept at `artifact://<id>`. Defensive trimming is a habit from harnesses without artifact recovery — here it only destroys data the artifact would have saved.
 - Pipelines that COMPUTE a new fact are correct bash: `wc -l`, `sort | uniq -c`, `comm`, `cut`, `diff a b`, `shasum`. Litmus: produces a count, frequency table, set difference, or checksum no tool returns → bash. Merely moves or trims bytes a tool can fetch → use the tool.
 </critical>

--- a/packages/coding-agent/src/prompts/tools/eval.md
+++ b/packages/coding-agent/src/prompts/tools/eval.md
@@ -31,9 +31,9 @@ print(value, ...) → None
 read(path, offset?=1, limit?=None) → str
     Read file contents as text. offset/limit are 1-indexed line bounds. Accepts `local://…` (resolved to the session-local root, same place `read local://…` reads).
 write(path, content) → str
-    Write content to a file (creates parent directories). Returns the resolved path. Accepts `local://…` to persist artifacts across turns / share with subagents.
+    Persist artifacts only. Workspace/source-file changes are blocked here; use `edit` with `[PATH#TAG]` hashline ops from `read`/`search`. `local://…` remains allowed to share artifacts across turns/subagents.
 append(path, content) → str
-    Append content to a file. Returns the resolved path. Accepts `local://…`.
+    Append to artifacts only. Workspace/source-file changes are blocked here; use `edit`; `local://…` remains allowed.
 tree(path?=".", max_depth?=3, show_hidden?=False) → str
     Render a directory tree.
 diff(a, b) → str

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -145,7 +145,7 @@ const EVAL_WORKSPACE_WRITE_PATTERNS: Record<EvalCellInput["language"], RegExp[]>
 	py: [
 		/(?:^|[^\w.])(?:write|append)\s*\(\s*(?!["']local:\/\/)/,
 		/\b(?:write_text|write_bytes)\s*\(/,
-		/\bopen\s*\([^,\n]+,\s*["'][^"']*[wax+]/,
+		/\bopen\s*\([^)\n]*(?:,\s*["'][^"']*[wax+]|,\s*mode\s*=\s*["'][^"']*[wax+])/,
 		/\b(?:shutil\.(?:copy|copyfile|move)|os\.(?:rename|replace))\s*\(/,
 	],
 };

--- a/packages/coding-agent/src/tools/eval.ts
+++ b/packages/coding-agent/src/tools/eval.ts
@@ -134,6 +134,33 @@ function detailsNotice(cells: ResolvedEvalCell[]): string | undefined {
 	return notices.length > 0 ? notices.join(" ") : undefined;
 }
 
+const EVAL_WRITE_DIAGNOSTIC =
+	"Eval cannot modify workspace files directly. Use `read` or `search` to get a `[PATH#TAG]` snapshot, then use `edit` with hashline ops. Use `write` only for new files or `local://` artifacts.";
+
+const EVAL_WORKSPACE_WRITE_PATTERNS: Record<EvalCellInput["language"], RegExp[]> = {
+	js: [
+		/(?:^|[^\w.])(?:write|append)\s*\(\s*(?!["'`]local:\/\/)/,
+		/\b(?:Bun\.write|writeFile(?:Sync)?|appendFile(?:Sync)?|createWriteStream)\s*\(/,
+	],
+	py: [
+		/(?:^|[^\w.])(?:write|append)\s*\(\s*(?!["']local:\/\/)/,
+		/\b(?:write_text|write_bytes)\s*\(/,
+		/\bopen\s*\([^,\n]+,\s*["'][^"']*[wax+]/,
+		/\b(?:shutil\.(?:copy|copyfile|move)|os\.(?:rename|replace))\s*\(/,
+	],
+};
+
+function assertNoEvalWorkspaceWrites(params: EvalToolParams): void {
+	for (let index = 0; index < params.cells.length; index++) {
+		const cell = params.cells[index];
+		const patterns = EVAL_WORKSPACE_WRITE_PATTERNS[cell.language];
+		if (patterns.some(pattern => pattern.test(cell.code))) {
+			const title = cell.title ? ` (${cell.title})` : "";
+			throw new ToolError(`Blocked cell ${index + 1}${title}: ${EVAL_WRITE_DIAGNOSTIC}`);
+		}
+	}
+}
+
 function timeoutSecondsFromMs(timeoutMs: number): number {
 	return clampTimeout("eval", timeoutMs / 1000);
 }
@@ -211,6 +238,8 @@ export class EvalTool implements AgentTool<typeof evalSchema> {
 		onUpdate?: AgentToolUpdateCallback,
 		_ctx?: AgentToolContext,
 	): Promise<AgentToolResult<EvalToolDetails | undefined>> {
+		assertNoEvalWorkspaceWrites(params);
+
 		if (this.#proxyExecutor) {
 			return this.#proxyExecutor(params, signal);
 		}

--- a/packages/coding-agent/test/core/hashline.test.ts
+++ b/packages/coding-agent/test/core/hashline.test.ts
@@ -128,6 +128,17 @@ describe("hashline executor", () => {
 		});
 	});
 
+	it("rejects non-hashline input with format recovery guidance", async () => {
+		await withTempDir(async tempDir => {
+			await expect(
+				executeHashlineSingle(hashlineExecuteOptions(tempDir, '{"path":"a.ts","edits":[]}')),
+			).rejects.toThrow(/hashline edit format/);
+			await expect(executeHashlineSingle(hashlineExecuteOptions(tempDir, "Here is the patch:"))).rejects.toThrow(
+				/Do not send prose, JSON, Markdown fences/,
+			);
+		});
+	});
+
 	it("preflights every section before writing multi-file edits", async () => {
 		await withTempDir(async tempDir => {
 			const aPath = path.join(tempDir, "a.ts");

--- a/packages/coding-agent/test/tools/bash-interceptor.test.ts
+++ b/packages/coding-agent/test/tools/bash-interceptor.test.ts
@@ -98,6 +98,11 @@ describe("default scripted file-write rules", () => {
 			tools,
 			DEFAULT_BASH_INTERCEPTOR_RULES,
 		);
+		const open = checkBashInterception(
+			"python -c \"open('src.py', mode='w').write('x')\"",
+			tools,
+			DEFAULT_BASH_INTERCEPTOR_RULES,
+		);
 
 		expect(python.block).toBe(true);
 		expect(python.suggestedTool).toBe("edit");
@@ -105,12 +110,22 @@ describe("default scripted file-write rules", () => {
 		expect(node.block).toBe(true);
 		expect(node.suggestedTool).toBe("edit");
 		expect(node.message).toContain("hashline snapshots");
+		expect(open.block).toBe(true);
+		expect(open.suggestedTool).toBe("edit");
+		expect(open.message).toContain("hashline snapshots");
 	});
 
 	it("allows Python and JavaScript one-liners that only compute output", () => {
 		expect(checkBashInterception('python -c "print(1 + 1)"', tools, DEFAULT_BASH_INTERCEPTOR_RULES).block).toBe(
 			false,
 		);
+		expect(
+			checkBashInterception(
+				"python -c \"import sys; sys.stdout.write('ok'); sys.stderr.write('progress')\"",
+				tools,
+				DEFAULT_BASH_INTERCEPTOR_RULES,
+			).block,
+		).toBe(false);
 		expect(checkBashInterception('node -e "console.log(1 + 1)"', tools, DEFAULT_BASH_INTERCEPTOR_RULES).block).toBe(
 			false,
 		);

--- a/packages/coding-agent/test/tools/bash-interceptor.test.ts
+++ b/packages/coding-agent/test/tools/bash-interceptor.test.ts
@@ -84,6 +84,39 @@ describe("default echo/printf redirect rule", () => {
 	});
 });
 
+describe("default scripted file-write rules", () => {
+	const tools = ["edit"];
+
+	it("blocks Python and JavaScript one-liners that write files", () => {
+		const python = checkBashInterception(
+			"python -c \"from pathlib import Path; Path('src.ts').write_text('x')\"",
+			tools,
+			DEFAULT_BASH_INTERCEPTOR_RULES,
+		);
+		const node = checkBashInterception(
+			"node -e \"require('fs').writeFileSync('src.ts','x')\"",
+			tools,
+			DEFAULT_BASH_INTERCEPTOR_RULES,
+		);
+
+		expect(python.block).toBe(true);
+		expect(python.suggestedTool).toBe("edit");
+		expect(python.message).toContain("hashline snapshots");
+		expect(node.block).toBe(true);
+		expect(node.suggestedTool).toBe("edit");
+		expect(node.message).toContain("hashline snapshots");
+	});
+
+	it("allows Python and JavaScript one-liners that only compute output", () => {
+		expect(checkBashInterception('python -c "print(1 + 1)"', tools, DEFAULT_BASH_INTERCEPTOR_RULES).block).toBe(
+			false,
+		);
+		expect(checkBashInterception('node -e "console.log(1 + 1)"', tools, DEFAULT_BASH_INTERCEPTOR_RULES).block).toBe(
+			false,
+		);
+	});
+});
+
 describe("BashTool argument validation", () => {
 	it("preserves async requests so disabled async mode returns the explicit error", async () => {
 		const tool = createBashTool([]);

--- a/packages/coding-agent/test/tools/eval-fallback.test.ts
+++ b/packages/coding-agent/test/tools/eval-fallback.test.ts
@@ -142,4 +142,40 @@ describe("EvalTool language dispatch", () => {
 			}),
 		).rejects.toThrow(/PI_JS=0/);
 	});
+
+	it("blocks eval cells that try to write workspace files", async () => {
+		const tool = new EvalTool(null, {
+			proxyExecutor: async () => {
+				throw new Error("proxy should not execute blocked code");
+			},
+		});
+
+		await expect(
+			tool.execute("call-js-write", {
+				cells: [{ language: "js", code: "await Bun.write('src.ts', 'x')" }],
+			}),
+		).rejects.toThrow(/Use `read` or `search` to get a `\[PATH#TAG\]` snapshot/);
+		await expect(
+			tool.execute("call-py-write", {
+				cells: [{ language: "py", code: "from pathlib import Path\nPath('src.py').write_text('x')" }],
+			}),
+		).rejects.toThrow(/use `edit` with hashline ops/);
+	});
+
+	it("allows eval cells to persist local artifacts", async () => {
+		const proxyExecutor = vi.fn(async () => ({
+			content: [{ type: "text" as const, text: "ok" }],
+			details: undefined,
+		}));
+		const tool = new EvalTool(null, { proxyExecutor });
+
+		await tool.execute("call-local-write", {
+			cells: [
+				{ language: "js", code: "await write('local://notes.txt', 'x')" },
+				{ language: "py", code: "write('local://notes.txt', 'x')" },
+			],
+		});
+
+		expect(proxyExecutor).toHaveBeenCalledTimes(1);
+	});
 });

--- a/packages/coding-agent/test/tools/eval-fallback.test.ts
+++ b/packages/coding-agent/test/tools/eval-fallback.test.ts
@@ -160,6 +160,16 @@ describe("EvalTool language dispatch", () => {
 				cells: [{ language: "py", code: "from pathlib import Path\nPath('src.py').write_text('x')" }],
 			}),
 		).rejects.toThrow(/use `edit` with hashline ops/);
+		await expect(
+			tool.execute("call-py-open-keyword-write", {
+				cells: [{ language: "py", code: "open('src.py', mode='w').write('x')" }],
+			}),
+		).rejects.toThrow(/use `edit` with hashline ops/);
+		await expect(
+			tool.execute("call-py-open-keyword-append", {
+				cells: [{ language: "py", code: "open('src.py', mode='a').write('x')" }],
+			}),
+		).rejects.toThrow(/use `edit` with hashline ops/);
 	});
 
 	it("allows eval cells to persist local artifacts", async () => {


### PR DESCRIPTION
## Repro
`checkBashInterception()` allowed scripted file writes to run through bash instead of the hashline edit path. Reproduced with `bun -e "$REPRO"`, which reported `python -c "from pathlib import Path; Path('src.ts').write_text('x')" => block=false` and `node -e "require('fs').writeFileSync('src.ts','x')" => block=false` before the fix.

## Cause
`packages/coding-agent/src/config/settings-schema.ts` only redirected `sed -i`, `perl -i`, `awk -i`, and simple shell redirects, so Python/JavaScript write one-liners never matched the bash interceptor. `packages/coding-agent/src/tools/eval.ts` also executed cells before checking for workspace file writes, and `packages/coding-agent/src/edit/hashline/execute.ts` surfaced parser misses as the opaque `No hashline sections found in input.` or raw parser text.

## Fix
- Added default bash interceptor rules for Python and JavaScript one-liners that write files, with `edit` guidance mentioning hashline snapshots and diff preview.
- Added an eval preflight that blocks direct workspace file writes while preserving `local://` artifact writes.
- Replaced empty/non-hashline edit failures with actionable hashline format guidance and parser detail.
- Updated tool prompts, regression tests, and the coding-agent changelog.

## Verification
`bun --cwd packages/coding-agent test test/tools/bash-interceptor.test.ts test/core/hashline.test.ts test/tools/eval-fallback.test.ts` passed: 34 pass, 0 fail. `bun run check` in `packages/coding-agent` passed. Re-ran `bun -e "$REPRO"` and both Python/Node commands now report `block=true; suggested=edit`. Fixes #2272