### PR TITLE
fix(agent): anchor post-shake threshold re-check to provider usage with a recovery band

### DIFF
--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -50,6 +50,7 @@ import {
 	generateBranchSummary,
 	generateHandoff,
 	prepareCompaction,
+	resolveThresholdTokens,
 	type ShakeConfig,
 	type ShakeRegion,
 	type SummaryOptions,
@@ -297,6 +298,15 @@ export type AsyncJobSnapshotItem = Pick<AsyncJob, "id" | "type" | "status" | "la
 const EMPTY_STOP_MAX_RETRIES = 3;
 const RETRY_BACKOFF_MAX_DELAY_MS = 8_000;
 const RETRY_BACKOFF_JITTER_RATIO = 0.25;
+/**
+ * Recovery band for the post-shake pressure re-check: shake must bring the
+ * provider-anchored context size below this fraction of the compaction
+ * threshold, otherwise we fall back to context-full compaction. Requiring
+ * real headroom (rather than "just under the threshold") prevents sessions
+ * from oscillating at the boundary, where each turn re-triggers shake and
+ * re-fires the auto-continue prompt.
+ */
+const SHAKE_RECOVERY_FACTOR = 0.8;
 
 function calculateRetryBackoffDelayMs(baseDelayMs: number, attempt: number): number {
 	const cappedDelayMs = Math.min(Math.max(0, baseDelayMs) * 2 ** Math.max(0, attempt - 1), RETRY_BACKOFF_MAX_DELAY_MS);
@@ -6552,6 +6562,26 @@ export class AgentSession {
 		return tokens;
 	}
 
+	/**
+	 * Provider-reported context size at the end of the last completed turn, or
+	 * `undefined` when no assistant message carries usable usage data. Anchors
+	 * the post-shake pressure re-check to real token counts: the pre-flight
+	 * estimator can drift far below provider-reported usage, which silently
+	 * disarms the #2119 dead-loop guard.
+	 */
+	#lastReportedContextTokens(): number | undefined {
+		const messages = this.agent.state.messages;
+		for (let i = messages.length - 1; i >= 0; i--) {
+			const message = messages[i];
+			if (message.role !== "assistant") continue;
+			const usage = (message as AssistantMessage).usage;
+			if (!usage) continue;
+			const tokens = calculateContextTokens(usage);
+			if (Number.isFinite(tokens) && tokens > 0) return tokens;
+		}
+		return undefined;
+	}
+
 	async #runPrePromptCompactionIfNeeded(messages: AgentMessage[]): Promise<void> {
 		const model = this.model;
 		if (!model) return;
@@ -7982,6 +8012,16 @@ export class AgentSession {
 			// shake runs, but the resulting context is still above the configured
 			// threshold. The next agent_end would re-trigger shake, which has nothing
 			// new to drop on the second pass, so the loop spins until the user kills it.
+			// Two hardenings over the original re-check:
+			// - Anchor the post-shake figure to the provider-reported usage of the
+			//   last completed turn minus what shake freed; fall back to the local
+			//   estimator only when no usage data exists. The estimator can read far
+			//   below provider-reported usage, silently disarming this guard while
+			//   the threshold trigger (which uses provider usage) keeps re-firing.
+			// - Require shake to bring the context into a recovery band below the
+			//   threshold (SHAKE_RECOVERY_FACTOR) instead of merely under it, so a
+			//   shake that frees a trickle each turn cannot oscillate at the boundary
+			//   and re-inject the auto-continue prompt after every turn.
 			// Same hazard for "incomplete" (the retry would re-hit the length cap) and
 			// for the existing "overflow + nothing reclaimed" case. In every recovery
 			// reason we hand off to the summarization-driven context-full path so the
@@ -7989,8 +8029,16 @@ export class AgentSession {
 			// re-checks usage before re-firing and cannot dead-loop on its own.
 			const contextWindow = this.model?.contextWindow ?? 0;
 			const compactionSettings = this.settings.getGroup("compaction");
-			const postShakeTokens = contextWindow > 0 ? this.#estimatePendingPromptTokens([]) : 0;
-			const stillOverThreshold = shouldCompact(postShakeTokens, contextWindow, compactionSettings);
+			const lastReportedTokens = this.#lastReportedContextTokens();
+			const postShakeTokens =
+				lastReportedTokens !== undefined
+					? Math.max(0, lastReportedTokens - result.tokensFreed)
+					: contextWindow > 0
+						? this.#estimatePendingPromptTokens([])
+						: 0;
+			const stillOverThreshold =
+				contextWindow > 0 &&
+				postShakeTokens > SHAKE_RECOVERY_FACTOR * resolveThresholdTokens(contextWindow, compactionSettings);
 			const shouldFallBack = reason !== "idle" && ((reason === "overflow" && !reclaimed) || stillOverThreshold);
 			if (shouldFallBack) {
 				const errorMessage = reclaimed

--- a/packages/coding-agent/test/shake.test.ts
+++ b/packages/coding-agent/test/shake.test.ts
@@ -157,9 +157,11 @@ describe("AgentSession shake", () => {
 			session.settings.set("compaction.thresholdPercent", 1);
 			session.settings.set("contextPromotion.enabled", false);
 
+			// Free enough that the post-shake re-check (provider-anchored, with the
+			// recovery band) sees the pressure as resolved and no fallback runs.
 			const shakeSpy = vi
 				.spyOn(session, "shake")
-				.mockResolvedValue({ mode: "elide", toolResultsDropped: 1, blocksDropped: 0, tokensFreed: 500 });
+				.mockResolvedValue({ mode: "elide", toolResultsDropped: 1, blocksDropped: 0, tokensFreed: 10_000 });
 
 			const assistantMessage: AssistantMessage = {
 				role: "assistant",
@@ -244,6 +246,128 @@ describe("AgentSession shake", () => {
 				e => e.type === "auto_compaction_start" && (e as { action?: string }).action === "context-full",
 			);
 			expect(fullStart).toBeDefined();
+		});
+
+		it("falls back when provider-reported usage stays above the threshold even though the local estimate is below it", async () => {
+			session.settings.set("compaction.strategy", "shake");
+			session.settings.set("compaction.thresholdTokens", 2000);
+			session.settings.set("contextPromotion.enabled", false);
+
+			// Agent state: a short assistant turn whose *provider-reported* usage is
+			// far above the threshold. The local estimator only sees a few dozen
+			// tokens of text, so the pre-fix re-check declared the pressure resolved
+			// ("handled") and re-armed the auto-continue prompt after every turn.
+			const bigUsage = { ...usage, input: 10_000, output: 1_000, totalTokens: 11_000 };
+			session.agent.replaceMessages([
+				{ role: "user", content: [{ type: "text", text: "hi" }], timestamp: Date.now() - 2 } as never,
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "short" }],
+					...apiInfo,
+					stopReason: "stop",
+					usage: bigUsage,
+					timestamp: Date.now() - 1,
+				} as never,
+			]);
+
+			const shakeSpy = vi
+				.spyOn(session, "shake")
+				.mockResolvedValue({ mode: "elide", toolResultsDropped: 1, blocksDropped: 0, tokensFreed: 100 });
+
+			const assistantMessage: AssistantMessage = {
+				role: "assistant",
+				content: [{ type: "text", text: "trigger" }],
+				...apiInfo,
+				stopReason: "stop",
+				usage: bigUsage,
+				timestamp: Date.now(),
+			};
+			session.agent.emitExternalEvent({ type: "message_end", message: assistantMessage });
+			session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMessage] });
+			await Bun.sleep(50);
+
+			expect(shakeSpy).toHaveBeenCalledTimes(1);
+			const shakeEnd = events.find(
+				e => e.type === "auto_compaction_end" && (e as { action?: string }).action === "shake",
+			) as { errorMessage?: string } | undefined;
+			expect(shakeEnd).toBeDefined();
+			expect(shakeEnd?.errorMessage).toMatch(/falling back to context-full/i);
+			const fullStart = events.find(
+				e => e.type === "auto_compaction_start" && (e as { action?: string }).action === "context-full",
+			);
+			expect(fullStart).toBeDefined();
+		});
+
+		it("falls back when shake lands inside the recovery band just under the threshold", async () => {
+			session.settings.set("compaction.strategy", "shake");
+			session.settings.set("compaction.thresholdTokens", 2000);
+			session.settings.set("contextPromotion.enabled", false);
+
+			// 2,500 reported - 600 freed = 1,900: under the 2,000 threshold but above
+			// the 0.8 recovery band (1,600). Without hysteresis this is "handled" and
+			// the session oscillates at the boundary, re-firing shake every turn.
+			const nearUsage = { ...usage, input: 2_000, output: 500, totalTokens: 2_500 };
+			const assistantMessage: AssistantMessage = {
+				role: "assistant",
+				content: [{ type: "text", text: "trigger" }],
+				...apiInfo,
+				stopReason: "stop",
+				usage: nearUsage,
+				timestamp: Date.now(),
+			};
+			session.agent.replaceMessages([assistantMessage as never]);
+
+			const shakeSpy = vi
+				.spyOn(session, "shake")
+				.mockResolvedValue({ mode: "elide", toolResultsDropped: 1, blocksDropped: 0, tokensFreed: 600 });
+
+			session.agent.emitExternalEvent({ type: "message_end", message: assistantMessage });
+			session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMessage] });
+			await Bun.sleep(50);
+
+			expect(shakeSpy).toHaveBeenCalledTimes(1);
+			const shakeEnd = events.find(
+				e => e.type === "auto_compaction_end" && (e as { action?: string }).action === "shake",
+			) as { errorMessage?: string } | undefined;
+			expect(shakeEnd?.errorMessage).toMatch(/falling back to context-full/i);
+		});
+
+		it("stays handled when shake brings the reported usage below the recovery band", async () => {
+			session.settings.set("compaction.strategy", "shake");
+			session.settings.set("compaction.thresholdTokens", 2000);
+			session.settings.set("contextPromotion.enabled", false);
+
+			// 2,500 reported - 1,200 freed = 1,300: below the 0.8 recovery band
+			// (1,600), so shake genuinely resolved the pressure and no fallback runs.
+			const nearUsage = { ...usage, input: 2_000, output: 500, totalTokens: 2_500 };
+			const assistantMessage: AssistantMessage = {
+				role: "assistant",
+				content: [{ type: "text", text: "trigger" }],
+				...apiInfo,
+				stopReason: "stop",
+				usage: nearUsage,
+				timestamp: Date.now(),
+			};
+			session.agent.replaceMessages([assistantMessage as never]);
+
+			const shakeSpy = vi
+				.spyOn(session, "shake")
+				.mockResolvedValue({ mode: "elide", toolResultsDropped: 1, blocksDropped: 0, tokensFreed: 1_200 });
+
+			session.agent.emitExternalEvent({ type: "message_end", message: assistantMessage });
+			session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMessage] });
+			await Bun.sleep(50);
+
+			expect(shakeSpy).toHaveBeenCalledTimes(1);
+			const shakeEnd = events.find(
+				e => e.type === "auto_compaction_end" && (e as { action?: string }).action === "shake",
+			) as { errorMessage?: string } | undefined;
+			expect(shakeEnd).toBeDefined();
+			expect(shakeEnd?.errorMessage).toBeUndefined();
+			const fullStart = events.find(
+				e => e.type === "auto_compaction_start" && (e as { action?: string }).action === "context-full",
+			);
+			expect(fullStart).toBeUndefined();
 		});
 	});
 });


### PR DESCRIPTION
Fixes #2275.

## Problem

With `compaction.strategy: shake`, the #2119 dead-loop guard re-checks post-shake pressure with the **local token estimator** (`#estimatePendingPromptTokens([])`), while the threshold trigger fires off **provider-reported usage**. The estimator can read far below real usage (observed: estimator < 150k while the provider reported 205k). When that happens:

1. Turn ends; provider-reported usage ≥ `thresholdTokens` → threshold maintenance fires.
2. Shake runs (often reclaiming nothing); the estimator-based `stillOverThreshold` evaluates false → `"handled"`, no fallback.
3. `#scheduleAutoContinuePrompt` injects the "Resume work…" developer prompt ~130 ms after turn end.
4. The reply's usage is still over the threshold → goto 1.

Result: the auto-continue prompt is re-injected after **every** assistant turn, indefinitely. Observed live in a production session: 30 injections across three bursts, one per turn, each 118–186 ms after turn end, with reported context above the 150k threshold (151k–205k) the entire time; full evidence in #2275.

## Fix (two changes, one function)

In `#runAutoShake`:

1. **Provider-anchored re-check.** Anchor post-shake pressure to the provider-reported usage of the last completed turn minus what shake freed (`lastReportedTokens - result.tokensFreed`), via a new `#lastReportedContextTokens()` helper. The estimator is only used as a fallback when no assistant usage exists (e.g. fresh sessions) — and it remains the sole option on the pre-flight path (`#runPrePromptCompactionIfNeeded`), which is untouched: there, nothing has been sent yet, so no provider number exists.
2. **Recovery band (hysteresis).** Shake only counts as having resolved the pressure when it brings the anchored figure below `SHAKE_RECOVERY_FACTOR (0.8) × resolveThresholdTokens(...)`, not merely under the threshold. Without this, a shake that frees a trickle each turn (e.g. the previous reply's elidable blocks) can land just under the line every iteration and sustain the loop at the boundary. With it, every pressure episode ends in either real headroom or a summarizing context-full compaction.

A `reclaimed`-only gate was considered and rejected: a tool-calling turn deposits fresh elidable output every iteration, so shake can report `reclaimed === true` indefinitely.

Behavioral note: the old check went through `shouldCompact`, which also tests `settings.enabled`/`strategy !== "off"`; both are guaranteed by the time `#runAutoShake` runs (the caller returns early otherwise), so comparing against `resolveThresholdTokens` directly is equivalent on reachable paths.

## Tests

`packages/coding-agent/test/shake.test.ts`:

- **New:** "falls back when provider-reported usage stays above the threshold even though the local estimate is below it" — the estimator-divergence loop scenario; **fails on `main`** (pre-fix the shake is declared handled, re-arming the loop).
- **New:** "falls back when shake lands inside the recovery band just under the threshold" — 2,500 reported − 600 freed = 1,900 vs threshold 2,000 / band 1,600; **fails on `main`**.
- **New:** "stays handled when shake brings the reported usage below the recovery band" — 2,500 − 1,200 = 1,300 < 1,600; non-regression for the resolved case.
- **Adjusted:** "dispatches the elide path…" — its mocked shake now frees 10,000 tokens so the (provider-anchored) re-check sees the 11,000-token pressure as resolved; previously it "passed" only because the estimator was blind to the 11k usage. Test intent (event dispatch) unchanged.

All 9 shake tests pass, plus the adjacent `agent-session-auto-compaction-queue` and `agent-session-handoff` suites (21 tests). `tsgo -p tsconfig.json --noEmit` clean.

### End-to-end: live differential repro

The loop reproduces live on `anthropic/claude-sonnet-4-5` with `--thinking high` once the threshold sits inside the estimator-divergence band (provider usage runs ~0.9–1.3k above the local estimate there; the production case hit 85k of divergence on a thinking-heavier model). Setup: `--mode json -p --auto-approve`, isolated `PI_CODING_AGENT_DIR`, `thresholdTokens: 30300` over ~29k of system overhead, 12 short reason-then-verify-with-bash prompts. Identical script and config on both builds:

| | unpatched (`main`) | this branch |
|---|---|---|
| "Resume work…" developer injections | **53** | **0** |
| shake ended "handled" while over threshold | 79 | 0 |
| threshold crossings falling back to context-full | 37 of 116 | 10 of 10 |
| peak provider usage | 90,333 (3× threshold) | 30,555 |
| outcome | killed by external 25-min `timeout` | clean exit, 3.5 min |

Earlier patched-only runs at `thresholdTokens` 3,000 / 30,000 / 50,000 with plain-text filler (no estimator divergence) also showed zero injections and clean fallback, including one run where the provider refused a summarization request — degraded without looping.

## Known limitation

Within a single maintenance pass right after a successful context-full compaction, the anchor (last turn's usage) is briefly stale, which can cost one extra no-op fallback check before the pass settles; the next real turn refreshes the anchor. Bounded, no LLM calls wasted, observed terminating in the e2e runs.
