### PR TITLE
fix(agent): break shake auto-continue loop when local estimate diverges from provider usage

### DIFF
--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Fixed queued steering messages being drained into an externally aborted run: interrupting mid-tool execution (e.g. Enter with a pending steer) dequeued the steer into the dying run — it landed in history without a response and the post-abort resume saw an empty queue, so the agent stopped instead of continuing. Steering/follow-up/aside queue polls are now skipped once the run's abort signal fires, leaving the queue intact for `Agent.continue()`.
 - Fixed `<read-files>` compaction lists recording the same file once per line-range/raw selector (`src/foo.ts:50-200`, `:raw`, `:1-50:raw`, …): read-tool selectors are now stripped before tracking, so reads dedupe to the base path and match their write/edit path when splitting read-only vs modified lists. Selector-polluted lists stored by earlier compactions self-heal on the next compaction. `readToolSupersedeKey()` now shares the same splitter (`splitReadSelector()`), gaining the `..` range alias and `L`-prefix forms it previously missed.
+- Fixed `estimateTokens()` undercounting thinking-heavy assistant messages on replay: `thinkingSignature` payloads (OpenAI Responses encrypted reasoning items, Anthropic signed thinking blocks, etc.) and `redactedThinking.data` are now charged alongside the visible thinking text, so the local estimate tracks provider-reported usage instead of straddling the threshold on every turn ([#2275](https://github.com/can1357/oh-my-pi/issues/2275)).
 
 ## [15.10.12] - 2026-06-10
 

--- a/packages/agent/src/compaction/compaction.ts
+++ b/packages/agent/src/compaction/compaction.ts
@@ -287,9 +287,19 @@ export function estimateTokens(message: AgentMessage): number {
 					fragments.push(block.text);
 				} else if (block.type === "thinking") {
 					fragments.push(block.thinking);
+					// Providers charge for the opaque signature/reasoning payload that
+					// rides alongside the thinking text (OpenAI Responses encrypted
+					// reasoning items, Anthropic signed thinking blocks, etc.). Without
+					// counting it, this estimator can read ~half of the provider-reported
+					// usage on thinking-heavy turns — see #2275 for the resulting
+					// compaction-trigger / post-check metric divergence.
+					if (block.thinkingSignature) fragments.push(block.thinkingSignature);
 				} else if (block.type === "toolCall") {
 					fragments.push(block.name);
 					fragments.push(JSON.stringify(block.arguments));
+				} else if (block.type === "redactedThinking") {
+					// Encrypted reasoning blob the provider still bills for on replay.
+					fragments.push(block.data);
 				}
 			}
 			break;

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -46,6 +46,7 @@
 ### Fixed
 
 - Fixed the `thinking.autoPending` statusbar indicator using question-mark glyphs (`▣?`, nf-md-help_box, `[?]`) in every symbol preset, which made the auto-thinking pending state indistinguishable from a terminal missing-glyph fallback. Replaced with clear loading indicators (`⟳`, fa-circle-o-notch, `[~]`) ([#2267](https://github.com/can1357/oh-my-pi/issues/2267)).
+- Fixed an infinite `compaction.strategy: shake` auto-continue loop in thinking-heavy sessions: the post-shake check now uses the provider-anchored trigger metric (instead of a local estimate that undercounts `thinkingSignature` payloads) and only treats pressure as resolved when residual context lands inside an 80% recovery band, so shake reliably falls back to context-full compaction when it cannot create real headroom ([#2275](https://github.com/can1357/oh-my-pi/issues/2275)).
 
 ## [15.10.12] - 2026-06-10
 

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -51,6 +51,7 @@ import {
 	generateBranchSummary,
 	generateHandoff,
 	prepareCompaction,
+	resolveThresholdTokens,
 	type ShakeConfig,
 	type ShakeRegion,
 	type SummaryOptions,
@@ -302,6 +303,16 @@ export type AsyncJobSnapshotItem = Pick<AsyncJob, "id" | "type" | "status" | "la
 const EMPTY_STOP_MAX_RETRIES = 3;
 const RETRY_BACKOFF_MAX_DELAY_MS = 8_000;
 const RETRY_BACKOFF_JITTER_RATIO = 0.25;
+/**
+ * Hysteresis band for the post-shake "did we actually create headroom?" check.
+ * Shake counts as having resolved threshold pressure only when residual context
+ * lands at or below `SHAKE_RECOVERY_BAND × threshold`. Re-checking against the
+ * raw threshold lets shake keep reclaiming a trickle of the previous turn's
+ * output and land just under the line every turn, sustaining the auto-continue
+ * dead loop reported in #2275.
+ */
+const SHAKE_RECOVERY_BAND = 0.8;
+
 
 function calculateRetryBackoffDelayMs(baseDelayMs: number, attempt: number): number {
 	const cappedDelayMs = Math.min(Math.max(0, baseDelayMs) * 2 ** Math.max(0, attempt - 1), RETRY_BACKOFF_MAX_DELAY_MS);
@@ -6749,7 +6760,10 @@ export class AgentSession {
 					model: `${assistantMessage.provider}/${assistantMessage.model}`,
 					strategy: incompleteCompactionSettings.strategy,
 				});
-				await this.#runAutoCompaction("incomplete", true, false, allowDefer, { autoContinue });
+				await this.#runAutoCompaction("incomplete", true, false, allowDefer, {
+					autoContinue,
+					triggerContextTokens: calculateContextTokens(assistantMessage.usage),
+				});
 			} else {
 				// Neither promotion nor compaction is available — surface the dead-end so
 				// the user understands why the turn yielded with nothing.
@@ -6782,7 +6796,10 @@ export class AgentSession {
 			// Try promotion first — if a larger model is available, switch instead of compacting
 			const promoted = await this.#tryContextPromotion(assistantMessage);
 			if (!promoted) {
-				return await this.#runAutoCompaction("threshold", false, false, allowDefer, { autoContinue });
+				return await this.#runAutoCompaction("threshold", false, false, allowDefer, {
+					autoContinue,
+					triggerContextTokens: contextTokens,
+				});
 			}
 		}
 		return false;
@@ -7627,7 +7644,7 @@ export class AgentSession {
 		willRetry: boolean,
 		deferred = false,
 		allowDefer = true,
-		options: { autoContinue?: boolean } = {},
+		options: { autoContinue?: boolean; triggerContextTokens?: number } = {},
 	): Promise<boolean> {
 		const compactionSettings = this.settings.getGroup("compaction");
 		if (compactionSettings.strategy === "off") return false;
@@ -7638,7 +7655,13 @@ export class AgentSession {
 		// reclaims nothing we fall through to the summary-compaction body below so
 		// the oversized input still gets resolved.
 		if (compactionSettings.strategy === "shake") {
-			const outcome = await this.#runAutoShake(reason, willRetry, generation, shouldAutoContinue);
+			const outcome = await this.#runAutoShake(
+				reason,
+				willRetry,
+				generation,
+				shouldAutoContinue,
+				options.triggerContextTokens,
+			);
 			if (outcome !== "fallback") return false;
 		}
 		// "overflow" and "incomplete" force inline execution because they are recovery
@@ -8071,6 +8094,7 @@ export class AgentSession {
 		willRetry: boolean,
 		generation: number,
 		autoContinue: boolean,
+		triggerContextTokens?: number,
 	): Promise<"handled" | "fallback"> {
 		const action = "shake";
 		await this.#emitSessionEvent({ type: "auto_compaction_start", reason, action });
@@ -8091,8 +8115,8 @@ export class AgentSession {
 				return "handled";
 			}
 			const reclaimed = result.toolResultsDropped + result.blocksDropped > 0;
-			// Detect the dead-loop reported in issue #2119: the threshold check fires,
-			// shake runs, but the resulting context is still above the configured
+			// Detect the dead-loop reported in issues #2119/#2275: the threshold check
+			// fires, shake runs, but residual context is still above the configured
 			// threshold. The next agent_end would re-trigger shake, which has nothing
 			// new to drop on the second pass, so the loop spins until the user kills it.
 			// Same hazard for "incomplete" (the retry would re-hit the length cap) and
@@ -8100,10 +8124,30 @@ export class AgentSession {
 			// reason we hand off to the summarization-driven context-full path so the
 			// situation actually resolves; "idle" is exempt because its 60s+ timer
 			// re-checks usage before re-firing and cannot dead-loop on its own.
+			//
+			// #2275: the post-shake check MUST be anchored on the same metric that
+			// triggered compaction. The local estimator (`#estimatePendingPromptTokens`)
+			// undercounts thinking-signature payloads, so on thinking-heavy sessions it
+			// reads well below the provider-reported usage that fired the threshold.
+			// When that estimate slips under the threshold, the fallback never fires
+			// and the auto-continue prompt re-injects every turn. Prefer the trigger's
+			// own `contextTokens` (provider-anchored) when the caller supplies it, and
+			// add hysteresis (80% recovery band) so we don't oscillate at the boundary
+			// while shake keeps reclaiming a trickle of the previous turn's output.
 			const contextWindow = this.model?.contextWindow ?? 0;
 			const compactionSettings = this.settings.getGroup("compaction");
-			const postShakeTokens = contextWindow > 0 ? this.#estimatePendingPromptTokens([]) : 0;
-			const stillOverThreshold = shouldCompact(postShakeTokens, contextWindow, compactionSettings);
+			let stillOverThreshold = false;
+			if (contextWindow > 0) {
+				if (typeof triggerContextTokens === "number" && Number.isFinite(triggerContextTokens)) {
+					const correctedTokens = Math.max(0, triggerContextTokens - result.tokensFreed);
+					const thresholdTokens = resolveThresholdTokens(contextWindow, compactionSettings);
+					const recoveryBand = Math.floor(thresholdTokens * SHAKE_RECOVERY_BAND);
+					stillOverThreshold = correctedTokens > recoveryBand;
+				} else {
+					const postShakeTokens = this.#estimatePendingPromptTokens([]);
+					stillOverThreshold = shouldCompact(postShakeTokens, contextWindow, compactionSettings);
+				}
+			}
 			const shouldFallBack = reason !== "idle" && ((reason === "overflow" && !reclaimed) || stillOverThreshold);
 			if (shouldFallBack) {
 				const errorMessage = reclaimed

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -313,7 +313,6 @@ const RETRY_BACKOFF_JITTER_RATIO = 0.25;
  */
 const SHAKE_RECOVERY_BAND = 0.8;
 
-
 function calculateRetryBackoffDelayMs(baseDelayMs: number, attempt: number): number {
 	const cappedDelayMs = Math.min(Math.max(0, baseDelayMs) * 2 ** Math.max(0, attempt - 1), RETRY_BACKOFF_MAX_DELAY_MS);
 	const jitter = 1 - Math.random() * RETRY_BACKOFF_JITTER_RATIO;

--- a/packages/coding-agent/test/shake.test.ts
+++ b/packages/coding-agent/test/shake.test.ts
@@ -157,9 +157,12 @@ describe("AgentSession shake", () => {
 			session.settings.set("compaction.thresholdPercent", 1);
 			session.settings.set("contextPromotion.enabled", false);
 
+			// Reclaim enough that the corrected (provider − tokensFreed) figure lands
+			// inside the 80% recovery band — otherwise the #2275 post-shake check would
+			// (correctly) declare pressure unresolved and fall back to context-full.
 			const shakeSpy = vi
 				.spyOn(session, "shake")
-				.mockResolvedValue({ mode: "elide", toolResultsDropped: 1, blocksDropped: 0, tokensFreed: 500 });
+				.mockResolvedValue({ mode: "elide", toolResultsDropped: 1, blocksDropped: 0, tokensFreed: 10_000 });
 
 			const assistantMessage: AssistantMessage = {
 				role: "assistant",
@@ -240,6 +243,57 @@ describe("AgentSession shake", () => {
 			expect(shakeEnd?.errorMessage).toMatch(/falling back to context-full/i);
 
 			// Fallback enters the context-full path so the situation actually resolves.
+			const fullStart = events.find(
+				e => e.type === "auto_compaction_start" && (e as { action?: string }).action === "context-full",
+			);
+			expect(fullStart).toBeDefined();
+		});
+
+		it("falls back when provider-reported usage stays above the threshold even though the local estimate is below it (regression #2275)", async () => {
+			session.settings.set("compaction.strategy", "shake");
+			session.settings.set("compaction.thresholdTokens", 5_000);
+			session.settings.set("contextPromotion.enabled", false);
+
+			// Agent state holds almost no content, so #estimatePendingPromptTokens reads
+			// well below the 5K threshold. The pre-fix post-shake check trusted that
+			// estimate and treated the pressure as resolved, even though the assistant
+			// message's provider-reported usage (11K) was well above the threshold.
+			// This is the metric-divergence dead loop from #2275: thinking-heavy
+			// sessions hit it for real (thinkingSignature payloads aren't counted by
+			// the estimator), and an empty-state probe mimics it deterministically.
+			session.agent.replaceMessages([]);
+
+			const shakeSpy = vi
+				.spyOn(session, "shake")
+				.mockResolvedValue({ mode: "elide", toolResultsDropped: 1, blocksDropped: 0, tokensFreed: 10 });
+
+			const assistantMessage: AssistantMessage = {
+				role: "assistant",
+				content: [{ type: "text", text: "trigger" }],
+				...apiInfo,
+				stopReason: "stop",
+				usage: {
+					input: 10_000,
+					output: 1_000,
+					cacheRead: 0,
+					cacheWrite: 0,
+					totalTokens: 11_000,
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+				},
+				timestamp: Date.now(),
+			};
+			session.agent.emitExternalEvent({ type: "message_end", message: assistantMessage });
+			session.agent.emitExternalEvent({ type: "agent_end", messages: [assistantMessage] });
+			await Bun.sleep(50);
+
+			expect(shakeSpy).toHaveBeenCalledTimes(1);
+
+			const shakeEnd = events.find(
+				e => e.type === "auto_compaction_end" && (e as { action?: string }).action === "shake",
+			) as { errorMessage?: string; skipped?: boolean } | undefined;
+			expect(shakeEnd).toBeDefined();
+			expect(shakeEnd?.errorMessage).toMatch(/falling back to context-full/i);
+
 			const fullStart = events.find(
 				e => e.type === "auto_compaction_start" && (e as { action?: string }).action === "context-full",
 			);


### PR DESCRIPTION
## Repro

With `compaction.strategy: shake` and a thinking-heavy session on `claude-sonnet-4-5`, once provider-reported usage crosses `thresholdTokens` while the local token estimate sits just below it, threshold maintenance injects `auto-continue.md` ("Resume work on the user's most recent intent…") after every turn forever — the reporter measured 53 injections in a 25-minute window before an external timeout killed the run.

Unit-level repro added in `packages/coding-agent/test/shake.test.ts`:

```
$ bun test test/shake.test.ts -t 'regression #2275'
expect(shakeEnd?.errorMessage).toMatch(/falling back to context-full/i);
error: Received value must be a string: undefined
(fail) regression #2275
```

## Cause

`#runAutoShake` measured residual context with `#estimatePendingPromptTokens([])` while `#checkCompaction` triggered on `calculateContextTokens(assistantMessage.usage)`. The two metrics diverge whenever assistants emit signed/encrypted thinking: `compaction.ts`'s `estimateTokens()` counts `block.thinking` but not the much larger `block.thinkingSignature` (OpenAI Responses encrypted reasoning items, Anthropic signed thinking blocks, redacted thinking blobs). The reporter observed up to 2× divergence (~89k estimated vs ~174k provider-reported) in a real session.

Once the two metrics straddle the threshold, the #2119 dead-loop guard (`stillOverThreshold` against the estimate) never fires → shake reports "handled" → `#scheduleAutoContinuePrompt` re-injects → next turn's `usage` is still ≥ threshold → loop. Re-checking against the same 100% threshold (even on the correct metric) was also insufficient — shake can keep reclaiming a trickle of the previous turn's elidable blocks and land just under the line every turn, sustaining the oscillation.

## Fix

- Thread the trigger's provider-anchored `contextTokens` through `#checkCompaction` → `#runAutoCompaction` → `#runAutoShake` for the `threshold` and `incomplete` paths (`packages/coding-agent/src/session/agent-session.ts`).
- Compute residual pressure as `triggerContextTokens − result.tokensFreed` and gate the fallback with hysteresis (`SHAKE_RECOVERY_BAND = 0.8`): treat shake as "resolved" only when the corrected figure lands at or below 80% of the resolved threshold. Idle/no-trigger callers still fall back to the local estimate (no-op for the existing #2119 guard).
- Defense in depth in `packages/agent/src/compaction/compaction.ts`: `estimateTokens()` now charges `ThinkingContent.thinkingSignature` and `RedactedThinkingContent.data` alongside `block.thinking`, so the estimator no longer silently lags provider usage on every other site that uses it (idle compaction, pre-prompt check, status line).
- New regression test pins the contract: shake falls back to context-full when provider-reported usage stays above the threshold even with the local estimate at zero. Updated the existing "dispatches the elide path" test to mock `tokensFreed: 10_000` so its happy-path scenario lands inside the new recovery band (the previous mock of 500 against an 11K trigger would have correctly fallen back).

## Verification

```
$ cd packages/coding-agent && bun test test/shake.test.ts
 7 pass · 0 fail · 28 expect() calls

$ cd packages/coding-agent && bun test test/agent-session-compaction.test.ts \
  test/agent-session-auto-compaction-queue.test.ts \
  test/agent-session-context-promotion.test.ts \
  test/compaction.test.ts test/compaction-hooks.test.ts \
  test/compaction-thinking-model.test.ts \
  test/agent-session-compaction-thinking-threading.test.ts \
  test/agent-session-role-thinking.test.ts \
  test/status-line-context-cache.test.ts
 80 pass · 0 fail

$ cd packages/agent && bun test
 259 pass · 0 fail
```

Two unrelated `agent-session-retry-cap.test.ts` failures (credential switching for account rate limits) are pre-existing on `main` (verified against an `origin/main` worktree) and untouched by this diff.

Fixes #2275