### PR TITLE
fix(catalog): tolerate sparse thinking metadata

### DIFF
--- a/packages/catalog/src/model-thinking.ts
+++ b/packages/catalog/src/model-thinking.ts
@@ -95,10 +95,15 @@ export function resolveModelThinking<TApi extends Api>(
 	spec: ModelSpec<TApi>,
 	compat: CompatOf<TApi>,
 ): ThinkingConfig | undefined {
-	if (!spec.reasoning) return undefined;
-	if (omitsWireReasoningEffort(spec.api, compat)) return undefined;
-	if (spec.thinking && spec.thinking.efforts.length > 0) {
-		return fillThinkingWireDefaults(spec, spec.thinking);
+	if (!spec.reasoning) {
+		return undefined;
+	}
+	if (omitsWireReasoningEffort(spec.api, compat)) {
+		return undefined;
+	}
+	const explicitThinking = spec.thinking;
+	if (explicitThinking?.efforts && explicitThinking.efforts.length > 0) {
+		return fillThinkingWireDefaults(spec, explicitThinking);
 	}
 	// Empty/malformed explicit metadata is treated as absent — infer instead.
 	return deriveThinking(spec, compat);

--- a/packages/catalog/test/model-thinking.test.ts
+++ b/packages/catalog/test/model-thinking.test.ts
@@ -184,6 +184,19 @@ describe("model thinking derivation", () => {
 		expect(pinned.thinking?.supportsDisplay).toBe(false);
 	});
 
+	it("infers defaults for sparse explicit thinking metadata", () => {
+		const model = createModel({
+			id: "gpt-5.2",
+			api: "openai-responses",
+			provider: "openai",
+			thinking: { mode: "effort" } as unknown as ModelSpec<"openai-responses">["thinking"],
+		});
+
+		expect(model.reasoning).toBe(true);
+		expect(model.thinking?.mode).toBe("effort");
+		expect(model.thinking?.efforts).toEqual([Effort.Low, Effort.Medium, Effort.High, Effort.XHigh]);
+	});
+
 	it("bakes sampling-param rejection into anthropic compat", () => {
 		const sonnet45 = createModel({ id: "claude-sonnet-4-5", api: "anthropic-messages", provider: "anthropic" });
 		const opus47 = createModel({ id: "claude-opus-4.7", api: "anthropic-messages", provider: "anthropic" });


### PR DESCRIPTION
## Summary
- guard explicit thinking metadata that omits `efforts`
- let sparse specs fall through to inferred defaults instead of throwing on `.efforts.length`
- add a regression test for sparse explicit thinking metadata

## Test
- bun test packages/catalog/test/model-thinking.test.ts
- bun --cwd=packages/catalog run check:types