### PR TITLE
feat(prompting): add magic keyword toggles

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `magicKeywords.enabled` and per-keyword `magicKeywords.ultrathink`, `magicKeywords.orchestrate`, and `magicKeywords.workflow` settings to disable hidden magic-keyword notices and ultrathink auto-thinking escalation ([#1796](https://github.com/can1357/oh-my-pi/issues/1796)).
+
 ## [15.11.0] - 2026-06-10
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -1082,6 +1082,46 @@ export const SETTINGS_SCHEMA = {
 		ui: { tab: "interaction", label: "Collapse Changelog", description: "Show condensed changelog after updates" },
 	},
 
+	"magicKeywords.enabled": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "interaction",
+			label: "Magic Keywords",
+			description: "Enable hidden notices for standalone ultrathink, orchestrate, and workflowz keywords",
+		},
+	},
+
+	"magicKeywords.ultrathink": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "interaction",
+			label: "Ultrathink Keyword",
+			description: "Let standalone ultrathink request maximum automatic thinking and append its hidden notice",
+		},
+	},
+
+	"magicKeywords.orchestrate": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "interaction",
+			label: "Orchestrate Keyword",
+			description: "Let standalone orchestrate append its hidden multi-agent orchestration notice",
+		},
+	},
+
+	"magicKeywords.workflow": {
+		type: "boolean",
+		default: true,
+		ui: {
+			tab: "interaction",
+			label: "Workflow Keyword",
+			description: "Let standalone workflowz append its hidden eval workflow notice",
+		},
+	},
+
 	// Notifications
 	"completion.notify": {
 		type: "enum",

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -4464,12 +4464,16 @@ export class AgentSession {
 		return { ...message, content: normalized } as T;
 	}
 
+	#magicKeywordEnabled(keyword: "orchestrate" | "ultrathink" | "workflow"): boolean {
+		return this.settings.get("magicKeywords.enabled") && this.settings.get(`magicKeywords.${keyword}`);
+	}
+
 	#createMagicKeywordNotices(text: string): CustomMessage[] {
 		const timestamp = Date.now();
 		const turnBudget = parseTurnBudget(text);
 		this.sessionManager.beginTurnBudget(turnBudget?.total ?? null, turnBudget?.hard ?? false);
 		const keywordNotices: CustomMessage[] = [];
-		if (containsUltrathink(text)) {
+		if (this.#magicKeywordEnabled("ultrathink") && containsUltrathink(text)) {
 			keywordNotices.push({
 				role: "custom",
 				customType: "ultrathink-notice",
@@ -4479,7 +4483,7 @@ export class AgentSession {
 				timestamp,
 			});
 		}
-		if (containsOrchestrate(text)) {
+		if (this.#magicKeywordEnabled("orchestrate") && containsOrchestrate(text)) {
 			keywordNotices.push({
 				role: "custom",
 				customType: "orchestrate-notice",
@@ -4489,7 +4493,7 @@ export class AgentSession {
 				timestamp,
 			});
 		}
-		if (containsWorkflow(text)) {
+		if (this.#magicKeywordEnabled("workflow") && containsWorkflow(text)) {
 			keywordNotices.push({
 				role: "custom",
 				customType: "workflow-notice",
@@ -5920,7 +5924,7 @@ export class AgentSession {
 		if (!model?.reasoning) return;
 
 		let resolved: Effort | undefined;
-		if (containsUltrathink(promptText)) {
+		if (this.#magicKeywordEnabled("ultrathink") && containsUltrathink(promptText)) {
 			// The user explicitly asked for maximum thinking; bypass the classifier
 			// and jump straight to the highest auto-supported level for this model.
 			resolved = clampAutoThinkingEffort(model, Effort.XHigh);

--- a/packages/coding-agent/test/agent-session-magic-keywords.test.ts
+++ b/packages/coding-agent/test/agent-session-magic-keywords.test.ts
@@ -69,9 +69,37 @@ describe("AgentSession magic keyword settings", () => {
 
 		await session.prompt("please workflowz this and ultrathink through it");
 
-		expect(promptSpy).toHaveBeenCalledTimes(1);
-		const promptOptions = promptSpy.mock.calls[0]![1] as { appendMessages?: unknown[] } | undefined;
-		expect(promptOptions?.appendMessages ?? []).toEqual([]);
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
+		expect(promptMessages.map(message => message.customType).filter(Boolean)).toEqual([]);
+	});
+
+	it("honors non-ultrathink per-keyword notice toggles", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		created.settings.set("magicKeywords.orchestrate", false);
+		created.settings.set("magicKeywords.workflow", false);
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("please orchestrate and workflowz this");
+
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
+		expect(promptMessages.map(message => message.customType).filter(Boolean)).toEqual([]);
+	});
+
+	it("still appends enabled non-ultrathink notices", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("please orchestrate and workflowz this");
+
+		const promptMessages = promptSpy.mock.calls[0]![0] as unknown as Array<{ customType?: string }>;
+		expect(promptMessages.map(message => message.customType).filter(Boolean)).toEqual([
+			"orchestrate-notice",
+			"workflow-notice",
+		]);
 	});
 
 	it("does not use a disabled ultrathink keyword to force auto thinking", async () => {

--- a/packages/coding-agent/test/agent-session-magic-keywords.test.ts
+++ b/packages/coding-agent/test/agent-session-magic-keywords.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "bun:test";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { Agent } from "@oh-my-pi/pi-agent-core";
+import { Effort } from "@oh-my-pi/pi-ai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import * as autoThinkingClassifier from "@oh-my-pi/pi-coding-agent/auto-thinking/classifier";
+import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
+import { Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { AUTO_THINKING } from "@oh-my-pi/pi-coding-agent/thinking";
+
+async function createMagicKeywordSession(root: string): Promise<{
+	session: AgentSession;
+	settings: Settings;
+	authStorage: AuthStorage;
+}> {
+	const model = getBundledModel("anthropic", "claude-sonnet-4-5");
+	if (!model) throw new Error("Expected bundled Claude Sonnet model");
+	const agent = new Agent({
+		initialState: {
+			model,
+			systemPrompt: ["Test"],
+			tools: [],
+			messages: [],
+			thinkingLevel: Effort.High,
+		},
+	});
+	const authStorage = await AuthStorage.create(path.join(root, "auth.db"));
+	authStorage.setRuntimeApiKey("anthropic", "test-key");
+	const modelRegistry = new ModelRegistry(authStorage, path.join(root, "models.yml"));
+	const settings = Settings.isolated();
+	const session = new AgentSession({
+		agent,
+		sessionManager: SessionManager.inMemory(),
+		settings,
+		modelRegistry,
+	});
+	return { session, settings, authStorage };
+}
+
+describe("AgentSession magic keyword settings", () => {
+	let root: string;
+	let session: AgentSession | undefined;
+	let authStorage: AuthStorage | undefined;
+
+	beforeEach(async () => {
+		root = await fs.mkdtemp(path.join(os.tmpdir(), "omp-magic-keywords-"));
+	});
+
+	afterEach(async () => {
+		vi.restoreAllMocks();
+		if (session) await session.dispose();
+		authStorage?.close();
+		await fs.rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }).catch(() => undefined);
+		session = undefined;
+		authStorage = undefined;
+	});
+
+	it("does not append magic keyword notices when disabled", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		created.settings.set("magicKeywords.enabled", false);
+		const promptSpy = vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+
+		await session.prompt("please workflowz this and ultrathink through it");
+
+		expect(promptSpy).toHaveBeenCalledTimes(1);
+		const promptOptions = promptSpy.mock.calls[0]![1] as { appendMessages?: unknown[] } | undefined;
+		expect(promptOptions?.appendMessages ?? []).toEqual([]);
+	});
+
+	it("does not use a disabled ultrathink keyword to force auto thinking", async () => {
+		const created = await createMagicKeywordSession(root);
+		session = created.session;
+		authStorage = created.authStorage;
+		created.settings.set("magicKeywords.ultrathink", false);
+		vi.spyOn(session.agent, "prompt").mockResolvedValue(undefined);
+		const classifierSpy = vi.spyOn(autoThinkingClassifier, "classifyDifficulty").mockResolvedValue(Effort.Low);
+		session.setThinkingLevel(AUTO_THINKING);
+
+		await session.prompt("ultrathink through the unsafe refactor");
+
+		expect(classifierSpy).toHaveBeenCalledTimes(1);
+		expect(session.thinkingLevel).toBe(Effort.Low);
+		expect(session.autoResolvedThinkingLevel()).toBe(Effort.Low);
+	});
+});


### PR DESCRIPTION
## Summary
- add settings to disable all magic keyword notices or each keyword individually
- gate hidden ultrathink/orchestrate/workflowz notices before detection
- make disabled ultrathink skip the auto-thinking xhigh shortcut

Closes #1796

## Verification
- bun test packages/coding-agent/test/agent-session-magic-keywords.test.ts
- bun --cwd=packages/coding-agent run check