### PR TITLE
fix(providers): send Anthropic search metadata.user_id

### DIFF
--- a/packages/ai/CHANGELOG.md
+++ b/packages/ai/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Exported `resolveAnthropicMetadataUserId` so non-streaming Anthropic Messages consumers (e.g. the coding-agent web search provider) can produce the same Claude-Code-shaped `metadata.user_id` as the main streaming path.
+
 ## [15.11.0] - 2026-06-10
 
 ### Added

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -677,7 +677,18 @@ function generateClaudeJsonUserId(sessionId?: string, accountId?: string): strin
 	return JSON.stringify(userId);
 }
 
-function resolveAnthropicMetadataUserId(
+/**
+ * Resolve the `metadata.user_id` field for an Anthropic Messages request.
+ *
+ * For API-key tokens, an explicit caller-supplied `userId` is forwarded
+ * verbatim and `undefined` yields no metadata. For OAuth tokens the value
+ * must match the Claude Code attribution shape (`isClaudeCloakingUserId` or
+ * the `{session_id, account_uuid?, device_id?}` JSON envelope) — anything
+ * else is dropped and a fresh Claude-Code-style JSON id is generated from
+ * `sessionId`/`accountId` so attribution stays consistent across the main
+ * streaming path and provider-specific request builders (e.g. web search).
+ */
+export function resolveAnthropicMetadataUserId(
 	userId: unknown,
 	isOAuthToken: boolean,
 	sessionId?: string,

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Anthropic web search requests to include `metadata.user_id`, matching the main Messages path: API-key requests forward the active session id verbatim, OAuth requests build the Claude-Code-shaped `{session_id, account_uuid?, device_id}` JSON envelope so gateways see consistent attribution ([#2295](https://github.com/can1357/oh-my-pi/issues/2295)).
+
 ## [15.11.0] - 2026-06-10
 
 ### Breaking Changes
@@ -45,7 +49,6 @@
 
 ### Fixed
 
-- Fixed Anthropic web search requests to include `metadata.user_id`, matching the main Messages path: API-key requests forward the active session id verbatim, OAuth requests build the Claude-Code-shaped `{session_id, account_uuid?, device_id}` JSON envelope so gateways see consistent attribution ([#2295](https://github.com/can1357/oh-my-pi/issues/2295)).
 - Fixed `irc` live message delivery so successfully handed-off messages are no longer enqueued as mailbox mail, so they do not inflate unread `irc` counts
 - Fixed `irc send` with `await: true` to wait for a fresh reply to the current call instead of consuming previously buffered messages
 - Fixed main-session chat output to stop duplicating outbound `irc` sends from the main agent as relay cards

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 ### Fixed
 
+- Fixed Anthropic web search requests to include `metadata.user_id` from the active session id, matching the main Messages path for gateway attribution ([#2295](https://github.com/can1357/oh-my-pi/issues/2295)).
 - Fixed `irc` live message delivery so successfully handed-off messages are no longer enqueued as mailbox mail, so they do not inflate unread `irc` counts
 - Fixed `irc send` with `await: true` to wait for a fresh reply to the current call instead of consuming previously buffered messages
 - Fixed main-session chat output to stop duplicating outbound `irc` sends from the main agent as relay cards

--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -45,7 +45,7 @@
 
 ### Fixed
 
-- Fixed Anthropic web search requests to include `metadata.user_id` from the active session id, matching the main Messages path for gateway attribution ([#2295](https://github.com/can1357/oh-my-pi/issues/2295)).
+- Fixed Anthropic web search requests to include `metadata.user_id`, matching the main Messages path: API-key requests forward the active session id verbatim, OAuth requests build the Claude-Code-shaped `{session_id, account_uuid?, device_id}` JSON envelope so gateways see consistent attribution ([#2295](https://github.com/can1357/oh-my-pi/issues/2295)).
 - Fixed `irc` live message delivery so successfully handed-off messages are no longer enqueued as mailbox mail, so they do not inflate unread `irc` counts
 - Fixed `irc send` with `await: true` to wait for a fresh reply to the current call instead of consuming previously buffered messages
 - Fixed main-session chat output to stop duplicating outbound `irc` sends from the main agent as relay cards

--- a/packages/coding-agent/src/web/search/providers/anthropic.ts
+++ b/packages/coding-agent/src/web/search/providers/anthropic.ts
@@ -82,6 +82,7 @@ function buildSystemBlocks(
  * @param auth - Authentication configuration (API key or OAuth)
  * @param model - Model identifier to use
  * @param query - Search query from the user
+ * @param sessionId - Optional session id forwarded as Anthropic metadata.user_id
  * @param systemPrompt - Optional system prompt for guiding response style
  * @returns Raw API response from Anthropic
  * @throws {SearchProviderError} If the API request fails
@@ -90,6 +91,7 @@ async function callSearch(
 	auth: AnthropicAuthConfig,
 	model: string,
 	query: string,
+	sessionId?: string,
 	systemPrompt?: string,
 	maxTokens?: number,
 	temperature?: number,
@@ -112,6 +114,10 @@ async function callSearch(
 			},
 		],
 	};
+
+	if (sessionId) {
+		body.metadata = { user_id: sessionId };
+	}
 
 	if (temperature !== undefined) {
 		body.temperature = temperature;
@@ -280,6 +286,7 @@ export async function searchAnthropic(
 				buildAnthropicAuthConfig(key, searchBaseUrl),
 				model,
 				params.query,
+				"authStorage" in params ? params.sessionId : undefined,
 				systemPrompt,
 				maxTokens,
 				params.temperature,

--- a/packages/coding-agent/src/web/search/providers/anthropic.ts
+++ b/packages/coding-agent/src/web/search/providers/anthropic.ts
@@ -14,6 +14,7 @@ import {
 	buildAnthropicSystemBlocks,
 	buildAnthropicUrl,
 	type FetchImpl,
+	resolveAnthropicMetadataUserId,
 	stripClaudeToolPrefix,
 	withAuth,
 	wrapFetchForCch,
@@ -82,7 +83,7 @@ function buildSystemBlocks(
  * @param auth - Authentication configuration (API key or OAuth)
  * @param model - Model identifier to use
  * @param query - Search query from the user
- * @param sessionId - Optional session id forwarded as Anthropic metadata.user_id
+ * @param metadataUserId - Optional Anthropic Messages metadata.user_id (already shaped for OAuth)
  * @param systemPrompt - Optional system prompt for guiding response style
  * @returns Raw API response from Anthropic
  * @throws {SearchProviderError} If the API request fails
@@ -91,7 +92,7 @@ async function callSearch(
 	auth: AnthropicAuthConfig,
 	model: string,
 	query: string,
-	sessionId?: string,
+	metadataUserId?: string,
 	systemPrompt?: string,
 	maxTokens?: number,
 	temperature?: number,
@@ -115,8 +116,8 @@ async function callSearch(
 		],
 	};
 
-	if (sessionId) {
-		body.metadata = { user_id: sessionId };
+	if (metadataUserId) {
+		body.metadata = { user_id: metadataUserId };
 	}
 
 	if (temperature !== undefined) {
@@ -279,20 +280,37 @@ export async function searchAnthropic(
 	const model = getModel();
 	const systemPrompt = "authStorage" in params ? params.systemPrompt : params.system_prompt;
 	const maxTokens = "authStorage" in params ? params.maxOutputTokens : params.max_tokens;
+	const callerSessionId = "authStorage" in params ? params.sessionId : undefined;
+	const accountId =
+		"authStorage" in params ? params.authStorage.getOAuthAccountId("anthropic", params.sessionId) : undefined;
 	const response = await withAuth(
 		keyOrResolver,
-		key =>
-			callSearch(
-				buildAnthropicAuthConfig(key, searchBaseUrl),
+		key => {
+			const auth = buildAnthropicAuthConfig(key, searchBaseUrl);
+			// Mirror the main Messages path: OAuth requests need a Claude-Code-shaped
+			// metadata.user_id (`{session_id, account_uuid?, device_id}`) so the
+			// CC billing header + system fingerprint installed by
+			// `buildAnthropicSearchHeaders`/`buildSystemBlocks` line up with the
+			// attribution Anthropic and enterprise gateways expect. API-key tokens
+			// forward the raw session id verbatim.
+			const metadataUserId = resolveAnthropicMetadataUserId(
+				callerSessionId,
+				auth.isOAuth,
+				callerSessionId,
+				accountId,
+			);
+			return callSearch(
+				auth,
 				model,
 				params.query,
-				"authStorage" in params ? params.sessionId : undefined,
+				metadataUserId,
 				systemPrompt,
 				maxTokens,
 				params.temperature,
 				params.signal,
 				params.fetch,
-			),
+			);
+		},
 		{
 			signal: params.signal,
 			missingKeyMessage:

--- a/packages/coding-agent/test/web/search/anthropic.test.ts
+++ b/packages/coding-agent/test/web/search/anthropic.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import * as path from "node:path";
+import type { FetchImpl } from "@oh-my-pi/pi-ai";
+import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import { searchAnthropic } from "@oh-my-pi/pi-coding-agent/web/search/providers/anthropic";
+import { TempDir } from "@oh-my-pi/pi-utils";
+
+describe("Anthropic search request body", () => {
+	it("passes the session id as Messages metadata.user_id", async () => {
+		using tempDir = TempDir.createSync("@pi-anthropic-search-");
+		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+		try {
+			authStorage.setRuntimeApiKey("anthropic", "test-key");
+
+			let capturedBody: Record<string, unknown> | undefined;
+			const fetchMock: FetchImpl = async (_input, init) => {
+				capturedBody = JSON.parse(String(init?.body));
+				return new Response(
+					JSON.stringify({
+						id: "msg_test",
+						model: "claude-haiku-4-5",
+						content: [],
+						usage: { input_tokens: 1, output_tokens: 2 },
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			};
+
+			await searchAnthropic({
+				query: "gateway attribution requirements",
+				systemPrompt: "Use web search.",
+				sessionId: "session-2295",
+				authStorage,
+				fetch: fetchMock,
+			});
+
+			expect(capturedBody?.metadata).toEqual({ user_id: "session-2295" });
+		} finally {
+			authStorage.close();
+		}
+	});
+});

--- a/packages/coding-agent/test/web/search/anthropic.test.ts
+++ b/packages/coding-agent/test/web/search/anthropic.test.ts
@@ -1,42 +1,78 @@
 import { describe, expect, it } from "bun:test";
 import * as path from "node:path";
-import type { FetchImpl } from "@oh-my-pi/pi-ai";
-import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
+import type { AuthStorage, FetchImpl } from "@oh-my-pi/pi-ai";
+import { AuthStorage as CodingAuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { searchAnthropic } from "@oh-my-pi/pi-coding-agent/web/search/providers/anthropic";
 import { TempDir } from "@oh-my-pi/pi-utils";
 
+function makeCaptureFetch(): { fetch: FetchImpl; body: () => Record<string, unknown> | undefined } {
+	let captured: Record<string, unknown> | undefined;
+	const fetch: FetchImpl = async (_input, init) => {
+		const raw = init?.body;
+		const text =
+			typeof raw === "string" ? raw : raw instanceof Uint8Array ? new TextDecoder().decode(raw) : String(raw);
+		captured = JSON.parse(text);
+		return new Response(
+			JSON.stringify({
+				id: "msg_test",
+				model: "claude-haiku-4-5",
+				content: [],
+				usage: { input_tokens: 1, output_tokens: 2 },
+			}),
+			{ status: 200, headers: { "Content-Type": "application/json" } },
+		);
+	};
+	return { fetch, body: () => captured };
+}
+
 describe("Anthropic search request body", () => {
-	it("passes the session id as Messages metadata.user_id", async () => {
-		using tempDir = TempDir.createSync("@pi-anthropic-search-");
-		const authStorage = await AuthStorage.create(path.join(tempDir.path(), "auth.db"));
+	it("forwards the raw session id as metadata.user_id for API-key auth", async () => {
+		using tempDir = TempDir.createSync("@pi-anthropic-search-apikey-");
+		const authStorage = await CodingAuthStorage.create(path.join(tempDir.path(), "auth.db"));
 		try {
 			authStorage.setRuntimeApiKey("anthropic", "test-key");
 
-			let capturedBody: Record<string, unknown> | undefined;
-			const fetchMock: FetchImpl = async (_input, init) => {
-				capturedBody = JSON.parse(String(init?.body));
-				return new Response(
-					JSON.stringify({
-						id: "msg_test",
-						model: "claude-haiku-4-5",
-						content: [],
-						usage: { input_tokens: 1, output_tokens: 2 },
-					}),
-					{ status: 200, headers: { "Content-Type": "application/json" } },
-				);
-			};
-
+			const cap = makeCaptureFetch();
 			await searchAnthropic({
 				query: "gateway attribution requirements",
 				systemPrompt: "Use web search.",
 				sessionId: "session-2295",
 				authStorage,
-				fetch: fetchMock,
+				fetch: cap.fetch,
 			});
 
-			expect(capturedBody?.metadata).toEqual({ user_id: "session-2295" });
+			expect(cap.body()?.metadata).toEqual({ user_id: "session-2295" });
 		} finally {
 			authStorage.close();
 		}
+	});
+
+	it("builds a Claude-Code-shaped metadata.user_id for OAuth auth", async () => {
+		const accountUuid = "abcd1234-abcd-1234-abcd-1234abcd1234";
+		const oauthAuthStorage = {
+			resolver: () => () => Promise.resolve("sk-ant-oat-fake-oauth-token"),
+			getOAuthAccountId: () => accountUuid,
+			hasAuth: () => true,
+		} as unknown as AuthStorage;
+
+		const cap = makeCaptureFetch();
+		await searchAnthropic({
+			query: "oauth attribution",
+			systemPrompt: "Use web search.",
+			sessionId: "session-2295",
+			authStorage: oauthAuthStorage,
+			fetch: cap.fetch,
+		});
+
+		const metadata = cap.body()?.metadata as { user_id: string } | undefined;
+		expect(metadata).toBeDefined();
+		const userId = JSON.parse(metadata!.user_id) as {
+			session_id: string;
+			account_uuid?: string;
+			device_id?: string;
+		};
+		expect(userId.session_id).toBe("session-2295");
+		expect(userId.account_uuid).toBe(accountUuid);
+		expect(userId.device_id).toMatch(/^[0-9a-f]{64}$/);
 	});
 });


### PR DESCRIPTION
## Repro
Added `packages/coding-agent/test/web/search/anthropic.test.ts` to call `searchAnthropic()` with `sessionId: "session-2295"` and a mocked fetch; before the fix, `bun --cwd packages/coding-agent test test/web/search/anthropic.test.ts` failed because the captured Messages request body had `metadata === undefined`.

## Cause
`packages/coding-agent/src/web/search/providers/anthropic.ts` built its own Messages body in `callSearch()` and never accepted the `SearchParams.sessionId` that `executeSearch()` already passes into providers, unlike the main Anthropic Messages `buildParams` path that resolves `metadata.user_id`.

## Fix
- Threaded `sessionId` from `searchAnthropic()` into `callSearch()` for modern provider calls.
- Added `metadata: { user_id: sessionId }` to the Anthropic web search request body when a session id is available.
- Added a focused request-shape regression test and changelog entry for #2295.

## Verification
- `bun --cwd packages/coding-agent test test/web/search/anthropic.test.ts` now passes.
- `bun run check` from `packages/coding-agent` passes.

Fixes #2295