### PR TITLE
fix(catalog): route NVIDIA-hosted qwen to chat_template_kwargs.enable_thinking

### DIFF
--- a/packages/catalog/CHANGELOG.md
+++ b/packages/catalog/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed NVIDIA NIM Qwen turns failing with `400 Validation: Unsupported parameter(s): enable_thinking`. NIM's chat-completions schema is `additionalProperties: false` and exposes thinking via the vLLM convention `chat_template_kwargs.enable_thinking`; `buildOpenAICompat` was sending top-level `enable_thinking` for every `qwen/*` id regardless of host. Registered `nvidia` as a known host (`integrate.api.nvidia.com`) and routed NVIDIA-hosted Qwen models to `thinkingFormat: "qwen-chat-template"` ([#2299](https://github.com/can1357/oh-my-pi/issues/2299)).
+
 ## [15.11.0] - 2026-06-10
 
 ### Fixed

--- a/packages/catalog/src/compat/openai.ts
+++ b/packages/catalog/src/compat/openai.ts
@@ -107,6 +107,7 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 	const isAnthropicModel =
 		modelMatchesHost(hostModel, "anthropic") || isClaudeModelId(spec.id) || isAnthropicNamespacedModelId(spec.id);
 	const isAlibaba = modelMatchesHost(hostModel, "alibabaDashscope");
+	const isNvidiaNim = modelMatchesHost(hostModel, "nvidia");
 	const isQwen = isQwenModelId(spec.id);
 	// DeepSeek V4 (and other reasoning-capable DeepSeek models) reject follow-up requests in
 	// thinking mode unless prior assistant tool-call turns include `reasoning_content`. The
@@ -266,14 +267,20 @@ export function buildOpenAICompat(spec: ModelSpec<"openai-completions">): Resolv
 		// OpenAI-compatible proxies — Fireworks' Fire Pass router, OpenCode's gateway,
 		// etc. — drives reasoning via OpenAI-style `reasoning_effort`
 		// (low|medium|high|xhigh|max|none), so those stay on the "openai" path.
+		// NVIDIA NIM hosts Qwen with the vLLM convention
+		// (`chat_template_kwargs.enable_thinking`); top-level `enable_thinking`
+		// is rejected by NIM's `additionalProperties: false` request schema
+		// (issue #2299).
 		thinkingFormat:
 			isZai || isZhipu || isMoonshotKimi || isXiaomiMimo
 				? "zai"
 				: isOpenRouter
 					? "openrouter"
-					: isAlibaba || isQwen
-						? "qwen"
-						: "openai",
+					: isQwen && isNvidiaNim
+						? "qwen-chat-template"
+						: isAlibaba || isQwen
+							? "qwen"
+							: "openai",
 		thinkingKeep: usesMoonshotKimiPreservedThinking ? "all" : undefined,
 		reasoningContentField: "reasoning_content",
 		// Backends that 400 follow-up requests when prior assistant tool-call turns lack `reasoning_content`:

--- a/packages/catalog/src/hosts.ts
+++ b/packages/catalog/src/hosts.ts
@@ -54,6 +54,8 @@ export const KNOWN_HOSTS = {
 		urlMarkers: ["api.minimax.io", "api.minimaxi.com"],
 	},
 	qwenPortal: { providers: ["qwen-portal"], urlMarkers: ["portal.qwen.ai"] },
+	/** NVIDIA NIM (`integrate.api.nvidia.com`). Qwen NIM endpoints take `chat_template_kwargs.enable_thinking`, never top-level `enable_thinking`. */
+	nvidia: { providers: ["nvidia"], urlMarkers: ["integrate.api.nvidia.com"] },
 	moonshotNative: { providers: ["moonshot", "kimi-code"], urlMarkers: ["api.moonshot.ai", "api.kimi.com"] },
 	opencode: { providers: ["opencode-go", "opencode-zen"], urlMarkers: ["opencode.ai"] },
 	chutes: { urlMarkers: ["chutes.ai"] },

--- a/packages/catalog/test/issue-2299-repro.test.ts
+++ b/packages/catalog/test/issue-2299-repro.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Issue #2299 — `NVIDIA as provider was selected and models not working correctly.`
+ *
+ * Reporter: with `NVIDIA_API_KEY` set, selecting any reasoning-capable Qwen
+ * model on NVIDIA NIM (e.g. `qwen/qwen3.5-397b-a17b`) and sending a turn
+ * returns `400 Validation: Unsupported parameter(s): enable_thinking`.
+ *
+ * Root cause: NVIDIA NIM's chat-completions schema is
+ * `additionalProperties: false`. Its qwen models accept the vLLM convention
+ * `chat_template_kwargs: { enable_thinking: bool }`, not the top-level
+ * `enable_thinking: bool` that Alibaba DashScope speaks. `buildOpenAICompat`
+ * picked `thinkingFormat: "qwen"` from the `qwen/*` id pattern regardless of
+ * host, so every NVIDIA-hosted qwen turn 400'd.
+ *
+ * Fix: register `nvidia` as a known host (`integrate.api.nvidia.com`) and
+ * route NVIDIA-hosted qwen models to `thinkingFormat: "qwen-chat-template"`
+ * so the wire body carries `chat_template_kwargs.enable_thinking` instead.
+ */
+import { describe, expect, it } from "bun:test";
+import { streamOpenAICompletions } from "@oh-my-pi/pi-ai/providers/openai-completions";
+import type { Context } from "@oh-my-pi/pi-ai/types";
+import { buildOpenAICompat } from "@oh-my-pi/pi-catalog/compat/openai";
+import { getBundledModel } from "@oh-my-pi/pi-catalog/models";
+import type { FetchImpl, Model, ModelSpec } from "@oh-my-pi/pi-catalog/types";
+
+function sseDoneResponse(): Response {
+	return new Response("data: [DONE]\n\n", {
+		status: 200,
+		headers: { "content-type": "text/event-stream" },
+	});
+}
+
+describe("issue #2299 — NVIDIA NIM qwen thinking format", () => {
+	it("resolves NVIDIA-hosted qwen models to the chat_template_kwargs thinking format", () => {
+		const spec: ModelSpec<"openai-completions"> = {
+			api: "openai-completions",
+			id: "qwen/qwen3.5-397b-a17b",
+			name: "Qwen3.5-397B-A17B",
+			provider: "nvidia",
+			baseUrl: "https://integrate.api.nvidia.com/v1",
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			maxTokens: 8192,
+			contextWindow: 262144,
+			reasoning: true,
+		};
+		const compat = buildOpenAICompat(spec);
+		expect(compat.thinkingFormat).toBe("qwen-chat-template");
+	});
+
+	it("keeps non-NVIDIA qwen models on the top-level enable_thinking format", () => {
+		// Alibaba DashScope (the upstream native API) still wants top-level
+		// `enable_thinking` — only NVIDIA NIM diverges.
+		const dashscope: ModelSpec<"openai-completions"> = {
+			api: "openai-completions",
+			id: "qwen3-coder-plus",
+			name: "Qwen3 Coder Plus",
+			provider: "alibaba-coding-plan",
+			baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+			input: ["text"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			maxTokens: 8192,
+			contextWindow: 131072,
+			reasoning: true,
+		};
+		expect(buildOpenAICompat(dashscope).thinkingFormat).toBe("qwen");
+	});
+
+	it("emits chat_template_kwargs.enable_thinking — never top-level enable_thinking — on the wire", async () => {
+		const model = getBundledModel<"openai-completions">("nvidia", "qwen/qwen3.5-397b-a17b");
+		expect(model.provider).toBe("nvidia");
+		expect(model.baseUrl).toBe("https://integrate.api.nvidia.com/v1");
+		expect(model.reasoning).toBe(true);
+		expect(model.compatConfig?.thinkingFormat).toBeUndefined();
+
+		const captured: { body: string | null } = { body: null };
+		const fetchMock: FetchImpl = async (_input, init) => {
+			captured.body = typeof init?.body === "string" ? init.body : null;
+			return sseDoneResponse();
+		};
+
+		const context: Context = {
+			messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+		};
+		const stream = streamOpenAICompletions(model as Model<"openai-completions">, context, {
+			apiKey: "nvapi-test",
+			reasoning: "high",
+			fetch: fetchMock,
+		});
+		for await (const _ of stream) {
+			// drain
+		}
+
+		expect(captured.body).not.toBeNull();
+		const parsed = JSON.parse(captured.body ?? "{}") as Record<string, unknown>;
+		// Issue #2299: NVIDIA NIM 400s on top-level `enable_thinking`. The
+		// vLLM-compatible `chat_template_kwargs.enable_thinking` is what the
+		// official `qwen/qwen3.5-122b-a10b` docs example uses.
+		expect(parsed.enable_thinking).toBeUndefined();
+		expect(parsed.chat_template_kwargs).toEqual({ enable_thinking: true });
+	});
+});


### PR DESCRIPTION
## Repro

With `NVIDIA_API_KEY` set and any reasoning-capable Qwen model selected on NVIDIA NIM (e.g. `qwen/qwen3.5-397b-a17b`, `qwen/qwen3.5-122b-a10b`), the first turn fails:

```
400 Validation: Unsupported parameter(s): `enable_thinking`
```

New unit `packages/catalog/test/issue-2299-repro.test.ts` exercises both `buildOpenAICompat` and the openai-completions wire writer end-to-end. Without the fix it observes `parsed.enable_thinking === true` and `compat.thinkingFormat === "qwen"` on a bundled `nvidia/qwen/qwen3.5-397b-a17b` spec — the exact body NIM rejects.

## Cause

NVIDIA NIM's chat-completions request schema is `additionalProperties: false` (see [`qwen/qwen3.5-122b-a10b` OpenAPI](https://docs.api.nvidia.com/nim/reference/qwen-qwen3-5-122b-a10b-infer)); its official example sends thinking via the vLLM convention `chat_template_kwargs: { enable_thinking: true }`, never top-level.

`buildOpenAICompat` in `packages/catalog/src/compat/openai.ts` picked `thinkingFormat: "qwen"` for every `qwen/*` id regardless of host:

```ts
: isAlibaba || isQwen
    ? "qwen"
    : "openai",
```

`streamOpenAICompletions` then wrote a top-level `enable_thinking` for every NVIDIA-hosted qwen request, and NIM 400'd. The 410 the screenshot also shows on the default `nvidia/qwen/qwen3-coder-480b-a35b-instruct` is an upstream availability response from NIM (the model is still listed in their catalog), not a client-side bug.

## Fix

- `packages/catalog/src/hosts.ts`: registered `nvidia` (`integrate.api.nvidia.com`) in `KNOWN_HOSTS`.
- `packages/catalog/src/compat/openai.ts`: detected `isNvidiaNim = modelMatchesHost(hostModel, "nvidia")` and inserted a branch above `isAlibaba || isQwen` so NVIDIA-hosted qwen models resolve to `thinkingFormat: "qwen-chat-template"` (already produces `chat_template_kwargs.enable_thinking` in `packages/ai/src/providers/openai-completions.ts`).
- `packages/catalog/test/issue-2299-repro.test.ts`: pins the compat resolution on a fresh spec, asserts the non-NVIDIA qwen path stays on top-level `enable_thinking`, and asserts the actual wire body for the bundled `nvidia/qwen/qwen3.5-397b-a17b` carries `chat_template_kwargs.enable_thinking` and not the top-level field.
- `packages/catalog/CHANGELOG.md`: documented the fix under `[Unreleased]`.

## Verification

- `bun test packages/catalog/test/issue-2299-repro.test.ts` → 3 pass / 0 fail.
- Confirmed the test catches the regression by temporarily reverting the compat change → 2 fail (`thinkingFormat` expected `"qwen-chat-template"` got `"qwen"`; wire body emits `enable_thinking: true`).
- `bun test packages/catalog` → 155 pass / 0 fail (full suite, no regressions on the existing wafer/zhipu qwen branches).
- `bun test packages/ai` → 1577 pass / 337 skip / 0 fail.

Fixes #2299