### PR TITLE
feat(tui): add `statusLine.transparent` setting for terminal-native status bar background

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added the `statusLine.transparent` appearance setting (default off): when enabled, the status line skips the theme's `statusLineBg` fill and powerline end caps so the bar inherits the terminal's default background — useful in Ghostty and other terminals whose theme background does not match the theme's hardcoded status-line color ([#2306](https://github.com/can1357/oh-my-pi/issues/2306))
+
 ## [15.11.0] - 2026-06-10
 
 ### Breaking Changes

--- a/packages/coding-agent/src/config/settings-schema.ts
+++ b/packages/coding-agent/src/config/settings-schema.ts
@@ -452,6 +452,17 @@ export const SETTINGS_SCHEMA = {
 			description: "Use the session name color for the editor border and status line gap",
 		},
 	},
+
+	"statusLine.transparent": {
+		type: "boolean",
+		default: false,
+		ui: {
+			tab: "appearance",
+			label: "Transparent Status Line",
+			description:
+				"Use the terminal's default background for the status line instead of the theme's `statusLineBg`. Powerline end caps are dropped because they need a contrasting fill to bridge into the surrounding terminal.",
+		},
+	},
 	"tools.artifactSpillThreshold": {
 		type: "number",
 		default: 50,

--- a/packages/coding-agent/src/modes/components/settings-selector.ts
+++ b/packages/coding-agent/src/modes/components/settings-selector.ts
@@ -196,6 +196,7 @@ export interface StatusLinePreviewSettings {
 	rightSegments?: StatusLineSegmentId[];
 	separator?: StatusLineSeparatorStyle;
 	sessionAccent?: boolean;
+	transparent?: boolean;
 }
 
 export interface SettingsCallbacks {
@@ -590,6 +591,7 @@ export class SettingsSelectorComponent extends Container {
 			rightSegments: settings.get("statusLine.rightSegments"),
 			separator: settings.get("statusLine.separator"),
 			sessionAccent: settings.get("statusLine.sessionAccent"),
+			transparent: settings.get("statusLine.transparent"),
 		};
 		this.callbacks.onStatusLinePreview?.(statusLineSettings);
 		this.#updateStatusPreview();

--- a/packages/coding-agent/src/modes/components/status-line/component.ts
+++ b/packages/coding-agent/src/modes/components/status-line/component.ts
@@ -196,6 +196,7 @@ export class StatusLineComponent implements Component {
 			showHookStatus: settings.get("statusLine.showHookStatus"),
 			segmentOptions: settings.getGroup("statusLine").segmentOptions,
 			sessionAccent: settings.get("statusLine.sessionAccent"),
+			transparent: settings.get("statusLine.transparent"),
 		};
 	}
 
@@ -713,7 +714,15 @@ export class StatusLineComponent implements Component {
 		const ctx = this.#buildSegmentContext(width, effectiveSettings.segmentOptions, includeContext);
 		const separatorDef = getSeparator(effectiveSettings.separator ?? "powerline-thin", theme);
 
-		const bgAnsi = theme.getBgAnsi("statusLineBg");
+		// `transparent` reuses the empty-string sentinel (`\x1b[49m`) so the bar
+		// inherits the terminal's default background, matching custom themes that
+		// set `statusLineBg: ""`. Powerline end caps need a contrasting fill to
+		// bridge the bar into the surrounding terminal; without one they read as
+		// stray glyphs, so the cap renderer drops them when the fill is empty.
+		const TRANSPARENT_BG_ANSI = "\x1b[49m";
+		const themeBgAnsi = theme.getBgAnsi("statusLineBg");
+		const bgAnsi = effectiveSettings.transparent ? TRANSPARENT_BG_ANSI : themeBgAnsi;
+		const transparentBg = bgAnsi === TRANSPARENT_BG_ANSI;
 		const fgAnsi = theme.getFgAnsi("text");
 		const sepAnsi = theme.getFgAnsi("statusLineSep");
 
@@ -748,8 +757,10 @@ export class StatusLineComponent implements Component {
 
 		const leftSepWidth = visibleWidth(separatorDef.left);
 		const rightSepWidth = visibleWidth(separatorDef.right);
-		const leftCapWidth = separatorDef.endCaps ? visibleWidth(separatorDef.endCaps.right) : 0;
-		const rightCapWidth = separatorDef.endCaps ? visibleWidth(separatorDef.endCaps.left) : 0;
+		// Transparent mode drops powerline caps (they need a bg fill to bridge),
+		// so the width budget excludes them too.
+		const leftCapWidth = separatorDef.endCaps && !transparentBg ? visibleWidth(separatorDef.endCaps.right) : 0;
+		const rightCapWidth = separatorDef.endCaps && !transparentBg ? visibleWidth(separatorDef.endCaps.left) : 0;
 
 		const groupWidth = (parts: string[], capWidth: number, sepWidth: number): number => {
 			if (parts.length === 0) return 0;
@@ -810,11 +821,12 @@ export class StatusLineComponent implements Component {
 		const renderGroup = (parts: string[], direction: "left" | "right"): string => {
 			if (parts.length === 0) return "";
 			const sep = direction === "left" ? separatorDef.left : separatorDef.right;
-			const cap = separatorDef.endCaps
-				? direction === "left"
-					? separatorDef.endCaps.right
-					: separatorDef.endCaps.left
-				: "";
+			const cap =
+				separatorDef.endCaps && !transparentBg
+					? direction === "left"
+						? separatorDef.endCaps.right
+						: separatorDef.endCaps.left
+					: "";
 			const capPrefix = separatorDef.endCaps?.useBgAsFg ? bgAnsi.replace("\x1b[48;", "\x1b[38;") : bgAnsi + sepAnsi;
 			const capText = cap ? `${capPrefix}${cap}\x1b[0m` : "";
 

--- a/packages/coding-agent/src/modes/components/status-line/types.ts
+++ b/packages/coding-agent/src/modes/components/status-line/types.ts
@@ -18,6 +18,9 @@ export interface StatusLineSettings {
 	segmentOptions?: StatusLineSegmentOptions;
 	showHookStatus?: boolean;
 	sessionAccent?: boolean;
+	/** Drop the theme's `statusLineBg` fill and powerline caps so the bar
+	 *  inherits the terminal's default background. */
+	transparent?: boolean;
 }
 
 export type EffectiveStatusLineSettings = Required<

--- a/packages/coding-agent/src/modes/controllers/selector-controller.ts
+++ b/packages/coding-agent/src/modes/controllers/selector-controller.ts
@@ -120,6 +120,7 @@ export class SelectorController {
 								separator: settings.get("statusLine.separator"),
 								showHookStatus: settings.get("statusLine.showHookStatus"),
 								sessionAccent: settings.get("statusLine.sessionAccent"),
+								transparent: settings.get("statusLine.transparent"),
 								...previewSettings,
 							});
 							this.ctx.updateEditorTopBorder();
@@ -147,6 +148,7 @@ export class SelectorController {
 								separator: settings.get("statusLine.separator"),
 								showHookStatus: settings.get("statusLine.showHookStatus"),
 								sessionAccent: settings.get("statusLine.sessionAccent"),
+								transparent: settings.get("statusLine.transparent"),
 							});
 							this.ctx.updateEditorTopBorder();
 							this.ctx.ui.requestRender();
@@ -351,6 +353,7 @@ export class SelectorController {
 			case "statusLineShowHooks":
 			case "statusLine.showHookStatus":
 			case "statusLine.sessionAccent":
+			case "statusLine.transparent":
 			case "statusLineSegments":
 			case "statusLineModelThinking":
 			case "statusLinePathAbbreviate":
@@ -369,6 +372,7 @@ export class SelectorController {
 					separator: settings.get("statusLine.separator"),
 					showHookStatus: settings.get("statusLine.showHookStatus"),
 					sessionAccent: settings.get("statusLine.sessionAccent"),
+					transparent: settings.get("statusLine.transparent"),
 					segmentOptions: settings.get("statusLine.segmentOptions"),
 				};
 				this.ctx.statusLine.updateSettings(statusLineSettings);

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1050,6 +1050,7 @@ export class InteractiveMode implements InteractiveModeContext {
 			separator: settings.get("statusLine.separator"),
 			showHookStatus: settings.get("statusLine.showHookStatus"),
 			sessionAccent: settings.get("statusLine.sessionAccent"),
+			transparent: settings.get("statusLine.transparent"),
 			segmentOptions: settings.get("statusLine.segmentOptions"),
 		});
 	}

--- a/packages/coding-agent/test/status-line-transparent.test.ts
+++ b/packages/coding-agent/test/status-line-transparent.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
+import { StatusLineComponent } from "@oh-my-pi/pi-coding-agent/modes/components/status-line";
+import { initTheme, theme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
+import { getProjectDir, setProjectDir } from "@oh-my-pi/pi-utils";
+
+const originalProjectDir = getProjectDir();
+
+beforeAll(async () => {
+	resetSettingsForTest();
+	await Settings.init({ inMemory: true });
+	await initTheme();
+});
+
+afterAll(() => {
+	resetSettingsForTest();
+	setProjectDir(originalProjectDir);
+});
+
+function makeSession() {
+	return {
+		state: { messages: [], model: undefined },
+		messages: [],
+		model: undefined,
+		systemPrompt: [],
+		agent: { state: { tools: [] } },
+		skills: [],
+		isStreaming: false,
+		isAutoThinking: false,
+		autoResolvedThinkingLevel: () => undefined,
+		isFastModeActive: () => false,
+		isFastModeEnabled: () => false,
+		getGoalModeState: () => null,
+		getAsyncJobSnapshot: () => ({ running: [] }),
+		modelRegistry: { isUsingOAuth: () => false },
+		sessionManager: {
+			getSessionName: () => "transparent test",
+			getUsageStatistics: () => ({
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				premiumRequests: 0,
+				cost: 0,
+			}),
+		},
+	} as unknown as ConstructorParameters<typeof StatusLineComponent>[0];
+}
+
+function buildComponent(transparent: boolean) {
+	const component = new StatusLineComponent(makeSession());
+	component.updateSettings({
+		preset: "custom",
+		leftSegments: ["pi"],
+		rightSegments: ["session_name"],
+		separator: "powerline-thin",
+		sessionAccent: false,
+		transparent,
+	});
+	return component;
+}
+
+describe("status line transparent background", () => {
+	it("paints the theme's statusLineBg when disabled (default)", () => {
+		const themeBg = theme.getBgAnsi("statusLineBg");
+		// Sanity check the test fixture: the default `dark` theme paints a real bg color,
+		// otherwise the negative case below would be vacuous.
+		expect(themeBg).toMatch(/\x1b\[48;/);
+
+		const border = buildComponent(false).getTopBorder(80).content;
+		expect(border).toContain(themeBg);
+	});
+
+	it("drops the theme bg fill and powerline caps when enabled", () => {
+		const border = buildComponent(true).getTopBorder(80).content;
+		const themeBg = theme.getBgAnsi("statusLineBg");
+
+		// No 48; (background) ANSI escape anywhere in the rendered bar — every bg is
+		// the terminal default (`\x1b[49m`).
+		expect(border).not.toContain(themeBg);
+		expect(border).not.toMatch(/\x1b\[48;/);
+		expect(border).toContain("\x1b[49m");
+
+		// Powerline-thin endcap glyphs are sourced from theme.sep.powerlineLeft/Right and
+		// rely on the bg color as fg to visually bridge the bar; skipped under transparency.
+		const leftCap = theme.sep.powerlineRight; // cap on the left side of right group
+		const rightCap = theme.sep.powerlineLeft; // cap on the right side of left group
+		expect(border).not.toContain(leftCap);
+		expect(border).not.toContain(rightCap);
+	});
+});


### PR DESCRIPTION
## Repro

In Ghostty (and other terminals whose theme background is a non-black dark gray, or which use transparency), the inline status bar — `π`, model name, reasoning level, cwd label, etc. — renders with visible dark/black blocks instead of blending into the terminal background.

The bar is painted by `StatusLineComponent.#buildStatusLine()` in `packages/coding-agent/src/modes/components/status-line/component.ts`, which calls `theme.getBgAnsi("statusLineBg")` and spans that bg across the entire line. Every bundled dark theme hardcodes a near-black `statusLineBg` (e.g. `dark.json` → `#121212`, ANSI `\x1b[48;5;233m`), and the powerline end caps are drawn in that same color (as fg) to "bridge" the bar into the terminal — so they only look right against the exact bg they were painted with.

Programmatic confirmation (constructed status line at 80 cols):

```
themeBg ANSI: "\u001b[48;5;233m"
default render contains themeBg?: true
default render contains 48; bg?: true
```

## Cause

`StatusLineComponent.#buildStatusLine()` unconditionally reads `theme.getBgAnsi("statusLineBg")` and stamps it onto every part of the bar (including the powerline cap, via `useBgAsFg`). There was no way for a user to bypass that fill short of editing the theme JSON, and the cap rendering relies on a colored fill to make sense at all.

## Fix

- New appearance setting `statusLine.transparent` (boolean, default `false`).
- When enabled, `#buildStatusLine()` swaps the theme bg ANSI for `\x1b[49m` (the terminal default-background reset, the existing empty-string sentinel produced by `bgAnsi("", mode)`) and drops the powerline end caps — they have nothing to bridge into without a contrasting fill, so leaving them would render the cap glyph in the terminal's default fg, floating against the terminal bg.
- Threaded the new flag through the StatusLineComponent constructor, `interactive-mode.ts#syncStatusLineSettings`, the settings-selector preview path, and the selector-controller change handler so toggling it from the Settings UI takes effect immediately.
- Theme authors who want the same behavior for one specific theme can still set `"statusLineBg": ""` in the theme JSON — the empty-string sentinel already resolves to the same `\x1b[49m`; this PR doesn't change that path.

Files touched:

- `packages/coding-agent/src/config/settings-schema.ts` — new `statusLine.transparent` setting (appearance tab).
- `packages/coding-agent/src/modes/components/status-line/types.ts` — extended `StatusLineSettings`.
- `packages/coding-agent/src/modes/components/status-line/component.ts` — transparency-aware bg + end-cap dropping.
- `packages/coding-agent/src/modes/interactive-mode.ts`, `controllers/selector-controller.ts`, `components/settings-selector.ts` — propagate the flag through every status-line refresh path.
- `packages/coding-agent/test/status-line-transparent.test.ts` — new test covering both branches.
- `packages/coding-agent/CHANGELOG.md` — `[Unreleased]` entry.

## Verification

- `bun test packages/coding-agent/test/status-line-transparent.test.ts` — 2 pass / 0 fail.
- `bun test packages/coding-agent/test/status-line-*.test.ts` — 19 status-line tests pass; the two pre-existing `status-line-path.test.ts` failures are environmental (`EACCES` on `mkdir(/srv/agent-home/Projects)` in the sandbox) and reproduce identically on `main` — confirmed by re-running with `git stash`.
- `bun check` — clean (biome + tsgo across every workspace package, plus cargo check).
- Programmatic render check (script in repro) confirms the transparent branch removes both the theme bg ANSI and the powerline cap glyph, while the default branch is unchanged.

Fixes #2306