### PR TITLE
Add external editor for Plan Review annotations

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added external-editor support for Plan Review section annotations, preserving multiline feedback for Refine plan ([#2305](https://github.com/can1357/oh-my-pi/issues/2305)).
+
 ## [15.11.0] - 2026-06-10
 
 ### Breaking Changes

--- a/packages/coding-agent/src/modes/components/plan-review-overlay.ts
+++ b/packages/coding-agent/src/modes/components/plan-review-overlay.ts
@@ -83,6 +83,8 @@ export interface PlanReviewOverlayCallbacks {
 	onCancel: () => void;
 	/** Invoked when the external-editor key is pressed (overlay stays open). */
 	onExternalEditor?: () => void;
+	/** Invoked when the external-editor key edits the active annotation draft. */
+	onAnnotationExternalEditor?: (draft: string, commit: (text: string | null) => void) => void;
 	/** Invoked with the new full plan text after an in-overlay delete/undo. */
 	onPlanEdited?: (content: string) => void;
 	/** Invoked with the Refine feedback markdown whenever annotations change. */
@@ -282,6 +284,12 @@ export class PlanReviewOverlay implements Component {
 	handleInput(keyData: string): void {
 		if (keyData.startsWith("\x1b[<") && this.#handleMouse(keyData)) return;
 		if (this.#annotating) {
+			if (this.callbacks.onAnnotationExternalEditor && matchesAppExternalEditor(keyData)) {
+				this.callbacks.onAnnotationExternalEditor(this.#input.getValue(), text => {
+					if (text !== null) this.#submitAnnotation(text);
+				});
+				return;
+			}
 			this.#input.handleInput(keyData);
 			return;
 		}
@@ -603,9 +611,21 @@ export class PlanReviewOverlay implements Component {
 		}
 		for (const section of annotated) {
 			feedback += `\n## ${section.title}\n`;
-			for (const note of section.annotations) feedback += `- ${note}\n`;
+			for (const note of section.annotations) feedback += this.#formatAnnotationFeedback(note);
 		}
 		this.callbacks.onFeedbackChange?.(feedback);
+	}
+
+	#formatAnnotationFeedback(note: string): string {
+		if (!note.includes("\n")) return `- ${note}\n`;
+		const fence = this.#markdownFenceFor(note);
+		return `${fence}md\n${note}\n${fence}\n`;
+	}
+
+	#markdownFenceFor(text: string): string {
+		let fence = "```";
+		while (text.includes(fence)) fence += "`";
+		return fence;
 	}
 
 	#renderSliderLines(): string[] {
@@ -676,7 +696,14 @@ export class PlanReviewOverlay implements Component {
 			if (section.level >= 1 && section.annotations.length > 0 && rendered.length > 0) {
 				lines.push(rendered[0]!);
 				for (const note of section.annotations) {
-					lines.push(`${theme.fg("warning", "▎ ")}${theme.fg("dim", "note: ")}${theme.fg("accent", note)}`);
+					const noteLines = note.split(/\r?\n/);
+					for (let j = 0; j < noteLines.length; j++) {
+						const prefix =
+							j === 0
+								? `${theme.fg("warning", "▎ ")}${theme.fg("dim", "note: ")}`
+								: `${theme.fg("warning", "▎ ")}${theme.fg("dim", "      ")}`;
+						lines.push(`${prefix}${theme.fg("accent", noteLines[j] ?? "")}`);
+					}
 				}
 				for (let k = 1; k < rendered.length; k++) lines.push(rendered[k]!);
 			} else {
@@ -749,7 +776,9 @@ export class PlanReviewOverlay implements Component {
 			const section = this.#sections[this.#toc[this.#tocCursor]!];
 			const title = section?.title ?? "";
 			const caption = `${theme.fg("dim", "Annotate")} ${theme.fg("accent", `‹${title}›`)}`;
-			return [caption, this.#input.render(innerWidth)[0] ?? ""];
+			const hintParts = ["enter save", "esc cancel"];
+			if (this.#externalEditorLabel) hintParts.push(`${this.#externalEditorLabel} editor`);
+			return [caption, this.#input.render(innerWidth)[0] ?? "", theme.fg("dim", hintParts.join(" · "))];
 		}
 		return [theme.fg("dim", this.#buildHelp())];
 	}

--- a/packages/coding-agent/src/modes/interactive-mode.ts
+++ b/packages/coding-agent/src/modes/interactive-mode.ts
@@ -1780,6 +1780,7 @@ export class InteractiveMode implements InteractiveModeContext {
 				onPick: choice => finish(choice),
 				onCancel: () => finish(undefined),
 				onExternalEditor: dialogOptions?.onExternalEditor,
+				onAnnotationExternalEditor: (draft, commit) => void this.#openPlanAnnotationInExternalEditor(draft, commit),
 				onPlanEdited: dialogOptions?.onPlanEdited,
 				onFeedbackChange: dialogOptions?.onFeedbackChange,
 			},
@@ -1882,6 +1883,37 @@ export class InteractiveMode implements InteractiveModeContext {
 				await Bun.write(resolvedPath, result);
 				this.#planReviewOverlay?.setPlanContent(result);
 				this.showStatus("Plan updated in external editor.");
+			}
+		} catch (error) {
+			this.showWarning(`Failed to open external editor: ${error instanceof Error ? error.message : String(error)}`);
+		} finally {
+			if (ttyHandle) {
+				await ttyHandle.close();
+			}
+			this.ui.start();
+			this.ui.requestRender(true);
+		}
+	}
+
+	async #openPlanAnnotationInExternalEditor(draft: string, commit: (text: string | null) => void): Promise<void> {
+		const editorCmd = getEditorCommand();
+		if (!editorCmd) {
+			this.showWarning("No editor configured. Set $VISUAL or $EDITOR environment variable.");
+			return;
+		}
+
+		let ttyHandle: fs.FileHandle | null = null;
+		try {
+			ttyHandle = await this.#openEditorTerminalHandle();
+			this.ui.stop();
+
+			const stdio: [number | "inherit", number | "inherit", number | "inherit"] = ttyHandle
+				? [ttyHandle.fd, ttyHandle.fd, ttyHandle.fd]
+				: ["inherit", "inherit", "inherit"];
+
+			const result = await openInEditor(editorCmd, draft, { extension: ".md", stdio });
+			if (result !== null) {
+				commit(result);
 			}
 		} catch (error) {
 			this.showWarning(`Failed to open external editor: ${error instanceof Error ? error.message : String(error)}`);

--- a/packages/coding-agent/test/interactive-mode-plan-review.test.ts
+++ b/packages/coding-agent/test/interactive-mode-plan-review.test.ts
@@ -3,17 +3,20 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { Agent } from "@oh-my-pi/pi-agent-core";
 import type { AssistantMessage, Usage } from "@oh-my-pi/pi-ai";
+import { KeybindingsManager } from "@oh-my-pi/pi-coding-agent/config/keybindings";
 import { ModelRegistry } from "@oh-my-pi/pi-coding-agent/config/model-registry";
 import { resetSettingsForTest, Settings } from "@oh-my-pi/pi-coding-agent/config/settings";
 import { resolveLocalUrlToPath } from "@oh-my-pi/pi-coding-agent/internal-urls";
 import { AssistantMessageComponent } from "@oh-my-pi/pi-coding-agent/modes/components/assistant-message";
 import type { HookSelectorSlider } from "@oh-my-pi/pi-coding-agent/modes/components/hook-selector";
+import type { PlanReviewOverlay } from "@oh-my-pi/pi-coding-agent/modes/components/plan-review-overlay";
 import { InteractiveMode } from "@oh-my-pi/pi-coding-agent/modes/interactive-mode";
 import { initTheme } from "@oh-my-pi/pi-coding-agent/modes/theme/theme";
 import { AgentSession } from "@oh-my-pi/pi-coding-agent/session/agent-session";
 import { AuthStorage } from "@oh-my-pi/pi-coding-agent/session/auth-storage";
 import { SILENT_ABORT_MARKER, USER_INTERRUPT_LABEL } from "@oh-my-pi/pi-coding-agent/session/messages";
 import { SessionManager } from "@oh-my-pi/pi-coding-agent/session/session-manager";
+import { setKeybindings } from "@oh-my-pi/pi-tui";
 import { formatNumber, TempDir } from "@oh-my-pi/pi-utils";
 
 /**
@@ -109,6 +112,7 @@ describe("InteractiveMode plan review rendering", () => {
 		await currentSession?.dispose();
 		currentAuthStorage?.close();
 		currentTempDir?.removeSync();
+		setKeybindings(KeybindingsManager.inMemory());
 		resetSettingsForTest();
 	});
 
@@ -237,6 +241,63 @@ describe("InteractiveMode plan review rendering", () => {
 
 		expect(startSpy).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining("needs detail") }));
 		expect(onInput).toHaveBeenCalledTimes(1);
+	});
+
+	it("opens the annotation external editor from the real plan review overlay", async () => {
+		const editorPath = path.join(tempDir.path(), "annotation-editor.sh");
+		await Bun.write(
+			editorPath,
+			"#!/bin/sh\nprintf '%s\\n%s\\n' '- add rollback command' '- include smoke test' > \"$1\"\n",
+		);
+		await fs.chmod(editorPath, 0o755);
+		const previousEditor = Bun.env.EDITOR;
+		const previousVisual = Bun.env.VISUAL;
+		const keybindings = KeybindingsManager.inMemory({
+			"app.editor.external": "ctrl+e",
+			"tui.select.cancel": "ctrl+g",
+		});
+		mode.keybindings = keybindings;
+		setKeybindings(keybindings);
+		let capturedOverlay: PlanReviewOverlay | undefined;
+		vi.spyOn(mode.ui, "showOverlay").mockImplementation(component => {
+			capturedOverlay = component as PlanReviewOverlay;
+			return { hide: vi.fn() } as never;
+		});
+		let feedback = "";
+
+		try {
+			Bun.env.EDITOR = editorPath;
+			delete Bun.env.VISUAL;
+			const choice = mode.showPlanReview(
+				"# Plan\n\nIntro\n\n## Rollout\n\nSteps\n\n## Verify\n\nChecks\n",
+				"Plan mode - next step",
+				["Approve and execute", "Refine plan"],
+				{ onFeedbackChange: value => (feedback = value) },
+			);
+
+			expect(capturedOverlay).toBeDefined();
+			const overlay = capturedOverlay!;
+			overlay.render(80);
+			overlay.handleInput("\t"); // -> toc (Rollout)
+			overlay.handleInput("a");
+			for (const ch of "draft") overlay.handleInput(ch);
+			overlay.handleInput("\x05"); // ctrl+e
+			for (let i = 0; i < 50 && !feedback.includes("- include smoke test"); i++) {
+				await Bun.sleep(10);
+			}
+			expect(feedback).toContain("## Rollout\n```md\n- add rollback command\n- include smoke test\n```");
+
+			overlay.handleInput("\x1b[B"); // Rollout -> Verify
+			overlay.handleInput("\x1b[B"); // toc -> actions
+			overlay.handleInput("\x1b[B"); // select Refine plan
+			overlay.handleInput("\r");
+			expect(await choice).toBe("Refine plan");
+		} finally {
+			if (previousEditor === undefined) delete Bun.env.EDITOR;
+			else Bun.env.EDITOR = previousEditor;
+			if (previousVisual === undefined) delete Bun.env.VISUAL;
+			else Bun.env.VISUAL = previousVisual;
+		}
 	});
 
 	it("Refine with no annotations does not re-prompt the model", async () => {

--- a/packages/coding-agent/test/modes/components/plan-review-overlay.test.ts
+++ b/packages/coding-agent/test/modes/components/plan-review-overlay.test.ts
@@ -341,6 +341,65 @@ describe("PlanReviewOverlay", () => {
 		const feedback = onFeedbackChange.mock.calls.at(-1)?.[0] as string;
 		expect(feedback).toContain("Overview");
 		expect(feedback).toContain("needs detail");
+		expect(feedback).toContain("## Overview\n- needs detail\n");
+		expect(feedback).not.toContain("```md");
+	});
+
+	it("opens the external editor for an active annotation draft", () => {
+		setKeybindings(KeybindingsManager.inMemory({ "tui.select.cancel": "ctrl+g", "app.editor.external": "ctrl+e" }));
+		const onFeedbackChange = vi.fn();
+		let editorDraft: string | undefined;
+		const overlay = new PlanReviewOverlay(
+			SECTION_PLAN,
+			{ promptTitle: "next", options: APPROVAL_OPTIONS, externalEditorLabel: "ctrl+e" },
+			{
+				onPick: vi.fn(),
+				onCancel: vi.fn(),
+				onFeedbackChange,
+				onAnnotationExternalEditor: (draft, commit) => {
+					editorDraft = draft;
+					commit("- add rollback command\n- include smoke test");
+				},
+			},
+		);
+		render(overlay);
+		overlay.handleInput(TAB); // -> toc (Overview)
+		overlay.handleInput("a");
+		for (const ch of "draft") overlay.handleInput(ch);
+		overlay.handleInput("\x05"); // ctrl+e
+
+		expect(editorDraft).toBe("draft");
+		const out = render(overlay);
+		expect(out).toContain("- add rollback command");
+		expect(out).toContain("- include smoke test");
+		expect(out).toContain("✎");
+		const feedback = onFeedbackChange.mock.calls.at(-1)?.[0] as string;
+		expect(feedback).toContain("## Overview\n```md\n- add rollback command\n- include smoke test\n```");
+	});
+
+	it("keeps the annotation draft when the external editor is cancelled", () => {
+		setKeybindings(KeybindingsManager.inMemory({ "tui.select.cancel": "ctrl+g", "app.editor.external": "ctrl+e" }));
+		const onFeedbackChange = vi.fn();
+		const overlay = new PlanReviewOverlay(
+			SECTION_PLAN,
+			{ promptTitle: "next", options: APPROVAL_OPTIONS, externalEditorLabel: "ctrl+e" },
+			{
+				onPick: vi.fn(),
+				onCancel: vi.fn(),
+				onFeedbackChange,
+				onAnnotationExternalEditor: (_draft, commit) => commit(null),
+			},
+		);
+		render(overlay);
+		overlay.handleInput(TAB); // -> toc (Overview)
+		overlay.handleInput("a");
+		for (const ch of "draft") overlay.handleInput(ch);
+		overlay.handleInput("\x05"); // ctrl+e
+
+		const out = render(overlay);
+		expect(out).toContain("Annotate");
+		expect(out).toContain("draft");
+		expect(onFeedbackChange).not.toHaveBeenCalled();
 	});
 
 	// Click a rendered row. The fullscreen overlay paints from screen row 0, so a


### PR DESCRIPTION
## Summary
- Route the external-editor key to the active Plan Review annotation draft instead of the full-plan editor.
- Preserve multiline annotation rendering and emit fenced markdown feedback for Refine plan.
- Add overlay and interactive-mode tests for annotation editor save/cancel behavior.

## Verification
- `bun test packages/coding-agent/test/modes/components/plan-review-overlay.test.ts` — pass
- `bun test packages/coding-agent/test/interactive-mode-plan-review.test.ts` — pass
- `bun --cwd=packages/coding-agent run check` — Biome passed; `tsgo` fails on existing unrelated type errors in `packages/ai/src/providers/cursor.ts` and ACP SDK surfaces (`packages/coding-agent/src/modes/acp/acp-agent.ts`, `packages/coding-agent/test/acp-agent.test.ts`).