### PR TITLE
fix(coding-agent): drain Mnemopi extractions before dispose closes DB

### DIFF
--- a/packages/coding-agent/CHANGELOG.md
+++ b/packages/coding-agent/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `MnemopiSessionState.dispose()` closing the SQLite handle before background `embed()` writes scheduled by `remember()`/`update()`/consolidation could complete: dispose now awaits `flushExtractions()` on each owned `Mnemopi` before `close()`. Without this drain, the v15.11.0 fix for `withMemory`/MCP paths from #1832 was silently undone by every session shutdown — `memory_embeddings` stayed empty across the live runtime even though the underlying mnemopi fix was in place ([#2314](https://github.com/can1357/oh-my-pi/issues/2314)).
+
 ## [15.11.2] - 2026-06-11
 
 ### Added

--- a/packages/coding-agent/src/mnemopi/backend.ts
+++ b/packages/coding-agent/src/mnemopi/backend.ts
@@ -82,7 +82,7 @@ export const mnemopiBackend: MemoryBackend = {
 					hasRecalledForFirstTurn: true,
 				}),
 			);
-			previous?.dispose();
+			await previous?.dispose();
 			return;
 		}
 
@@ -91,7 +91,7 @@ export const mnemopiBackend: MemoryBackend = {
 			await Promise.all([loadMnemopi(), loadMnemopiCore()]);
 			const state = new MnemopiSessionState({ sessionId, config, session });
 			const previous = setMnemopiSessionState(session, state);
-			previous?.dispose();
+			await previous?.dispose();
 			state.attachSessionListeners();
 		} catch (error) {
 			logger.warn("Mnemopi: backend startup failed; memory backend inert.", { error: String(error) });
@@ -115,7 +115,7 @@ export const mnemopiBackend: MemoryBackend = {
 
 	async clear(agentDir, _cwd, session): Promise<void> {
 		const previous = session ? setMnemopiSessionState(session, undefined) : undefined;
-		previous?.dispose();
+		await previous?.dispose();
 		const config = previous?.config ?? (session ? loadMnemopiConfig(session.settings, agentDir) : undefined);
 		if (!config) return;
 		await loadMnemopiCore();

--- a/packages/coding-agent/src/mnemopi/state.ts
+++ b/packages/coding-agent/src/mnemopi/state.ts
@@ -370,11 +370,22 @@ export class MnemopiSessionState {
 		}
 	}
 
-	dispose(): void {
+	async dispose(): Promise<void> {
 		this.unsubscribe?.();
 		this.unsubscribe = undefined;
-		if (!this.aliasOf) {
-			for (const memory of this.scoped.owned) memory.close();
+		if (this.aliasOf) return;
+		// Drain background embedding/extraction tasks before closing the SQLite
+		// handle. Without this, `scheduleEmbedding`'s deferred `embed()` writes
+		// race the close and silently drop into a closed DB — `memory_embeddings`
+		// stays empty across the live runtime even though the v15.11.0 fix from
+		// #1832 is present in the mnemopi package itself. See issue #2314.
+		for (const memory of this.scoped.owned) {
+			try {
+				await memory.flushExtractions();
+			} catch (error) {
+				logger.warn("Mnemopi: flushExtractions during dispose failed", { error: String(error) });
+			}
+			memory.close();
 		}
 	}
 }

--- a/packages/coding-agent/src/session/agent-session.ts
+++ b/packages/coding-agent/src/session/agent-session.ts
@@ -3213,7 +3213,7 @@ export class AgentSession {
 		this.setHindsightSessionState(undefined);
 		hindsightState?.dispose();
 		const mnemopiState = setMnemopiSessionState(this, undefined);
-		mnemopiState?.dispose();
+		await mnemopiState?.dispose();
 		this.#disconnectFromAgent();
 		if (this.#unsubscribeAppendOnly) {
 			this.#unsubscribeAppendOnly();

--- a/packages/coding-agent/test/memory-tools.test.ts
+++ b/packages/coding-agent/test/memory-tools.test.ts
@@ -23,6 +23,7 @@ import {
 	loadMnemopi,
 	loadMnemopiCore,
 	MnemopiSessionState,
+	requireMnemopi,
 	setMnemopiSessionState,
 } from "@oh-my-pi/pi-coding-agent/mnemopi/state";
 import type { ToolSession } from "@oh-my-pi/pi-coding-agent/tools/index";
@@ -338,9 +339,9 @@ describe("retain.execute (Mnemopi backend)", () => {
 		tempDbPath = undefined;
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		vi.restoreAllMocks();
-		registeredMnemopiState?.dispose();
+		await registeredMnemopiState?.dispose();
 		registeredMnemopiState = undefined;
 		if (tempDbPath) {
 			try {
@@ -406,13 +407,13 @@ describe("retain.execute (Mnemopi backend)", () => {
 		await MemoryRetainTool.createIf(makeSession(settings))!.execute("call-mnemopi-alpha-store", {
 			items: [{ content: "alpha uses tabs" }],
 		});
-		registeredMnemopiState?.dispose();
+		await registeredMnemopiState?.dispose();
 		registerMnemopiState(betaConfig, { cwd: "/work/project-beta" });
 		const betaRecall = await MemoryRecallTool.createIf(makeSession(settings))!.execute("call-mnemopi-beta-recall", {
 			query: "tabs",
 		});
 		expect(betaRecall.content[0]).toEqual({ type: "text", text: "No relevant memories found." });
-		registeredMnemopiState?.dispose();
+		await registeredMnemopiState?.dispose();
 		registerMnemopiState(alphaConfig, { cwd: "/work/project-alpha" });
 		const alphaRecall = await MemoryRecallTool.createIf(makeSession(settings))!.execute("call-mnemopi-alpha-recall", {
 			query: "tabs",
@@ -435,9 +436,9 @@ describe("Mnemopi backend lifecycle", () => {
 		tempDbPath = undefined;
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		vi.restoreAllMocks();
-		registeredMnemopiState?.dispose();
+		await registeredMnemopiState?.dispose();
 		registeredMnemopiState = undefined;
 		if (tempDbPath) {
 			try {
@@ -470,6 +471,27 @@ describe("Mnemopi backend lifecycle", () => {
 		expect(state.lastRetainedTurn).toBe(4);
 	});
 
+	// Regression for https://github.com/can1357/oh-my-pi/issues/2314 — the v15.11.0
+	// fix to #1832 made `withMemory`/MCP paths drain pending embed() tasks before
+	// closing the SQLite handle, but the coding-agent's `MnemopiSessionState.dispose()`
+	// kept closing first, so scheduled embeddings raced the close and silently
+	// dropped — leaving `memory_embeddings` permanently empty across the live runtime.
+	it("dispose() drains pending embeddings before closing the SQLite handle (issue #2314)", async () => {
+		const { Mnemopi } = requireMnemopi();
+		const flushSpy = vi.spyOn(Mnemopi.prototype, "flushExtractions");
+		const closeSpy = vi.spyOn(Mnemopi.prototype, "close");
+
+		const state = registerMnemopiState();
+		await state.dispose();
+		registeredMnemopiState = undefined;
+
+		expect(flushSpy).toHaveBeenCalled();
+		expect(closeSpy).toHaveBeenCalled();
+		const firstFlush = flushSpy.mock.invocationCallOrder[0];
+		const firstClose = closeSpy.mock.invocationCallOrder[0];
+		expect(firstFlush).toBeLessThan(firstClose);
+	});
+
 	it("registers subagent aliases from parent Mnemopi state without Hindsight", async () => {
 		const settings = Settings.isolated({ "memory.backend": "mnemopi" });
 		const parentState = registerMnemopiState();
@@ -495,7 +517,7 @@ describe("Mnemopi backend lifecycle", () => {
 		const childState = getMnemopiSessionState(childSession);
 		expect(childState?.aliasOf).toBe(parentState);
 		expect(childState?.getScopedRetainTarget().bank).toBe(parentState.getScopedRetainTarget().bank);
-		childState?.dispose();
+		await childState?.dispose();
 	});
 
 	it("clears every scoped Mnemopi database for per-project-tagged mode", async () => {
@@ -707,9 +729,9 @@ describe("recall.execute (Mnemopi backend)", () => {
 		tempDbPath = undefined;
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		vi.restoreAllMocks();
-		registeredMnemopiState?.dispose();
+		await registeredMnemopiState?.dispose();
 		registeredMnemopiState = undefined;
 		if (tempDbPath) {
 			try {
@@ -760,7 +782,7 @@ describe("recall.execute (Mnemopi backend)", () => {
 		await MemoryRetainTool.createIf(makeSession(settings))!.execute("call-mnemopi-global-store", {
 			items: [{ content: "global memory survives project switches" }],
 		});
-		registeredMnemopiState?.dispose();
+		await registeredMnemopiState?.dispose();
 		registerMnemopiState(config, { cwd: "/work/project-beta" });
 		const result = await MemoryRecallTool.createIf(makeSession(settings))!.execute("call-mnemopi-global-recall", {
 			query: "project switches",
@@ -782,7 +804,7 @@ describe("recall.execute (Mnemopi backend)", () => {
 			items: [{ content: "the user likes concise CLI output" }],
 		});
 		// Store project-alpha local memory
-		registeredMnemopiState?.dispose();
+		await registeredMnemopiState?.dispose();
 		registerMnemopiState(
 			makeMnemopiConfig({ scoping: "per-project-tagged", bank: "project-alpha", globalBank: "default" }),
 			{ cwd: "/work/project-alpha" },
@@ -791,7 +813,7 @@ describe("recall.execute (Mnemopi backend)", () => {
 			items: [{ content: "project alpha uses pnpm workspaces" }],
 		});
 		// Store project-beta local memory
-		registeredMnemopiState?.dispose();
+		await registeredMnemopiState?.dispose();
 		registerMnemopiState(
 			makeMnemopiConfig({ scoping: "per-project-tagged", bank: "project-beta", globalBank: "default" }),
 			{ cwd: "/work/project-beta" },
@@ -800,7 +822,7 @@ describe("recall.execute (Mnemopi backend)", () => {
 			items: [{ content: "project beta deploys to staging first" }],
 		});
 		// Recall from project-alpha should merge global + alpha, exclude beta
-		registeredMnemopiState?.dispose();
+		await registeredMnemopiState?.dispose();
 		registerMnemopiState(
 			makeMnemopiConfig({ scoping: "per-project-tagged", bank: "project-alpha", globalBank: "default" }),
 			{ cwd: "/work/project-alpha" },
@@ -828,9 +850,9 @@ describe("memory_edit.execute (Mnemopi backend)", () => {
 		tempDbPath = undefined;
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		vi.restoreAllMocks();
-		registeredMnemopiState?.dispose();
+		await registeredMnemopiState?.dispose();
 		registeredMnemopiState = undefined;
 		if (tempDbPath) {
 			try {
@@ -981,9 +1003,9 @@ describe("reflect.execute (Mnemopi backend)", () => {
 		tempDbPath = undefined;
 	});
 
-	afterEach(() => {
+	afterEach(async () => {
 		vi.restoreAllMocks();
-		registeredMnemopiState?.dispose();
+		await registeredMnemopiState?.dispose();
 		registeredMnemopiState = undefined;
 		if (tempDbPath) {
 			try {
@@ -1070,8 +1092,7 @@ describe("reflect.execute (Mnemopi backend)", () => {
 		await MemoryRetainTool.createIf(makeSession(settings))!.execute("call-mnemopi-reflect-global", {
 			items: [{ content: "the user prefers concise summaries" }],
 		});
-		// Store project-alpha local memory
-		registeredMnemopiState?.dispose();
+		await registeredMnemopiState?.dispose();
 		registerMnemopiState(
 			makeMnemopiConfig({ scoping: "per-project-tagged", bank: "project-alpha", globalBank: "default" }),
 			{ cwd: "/work/project-alpha" },


### PR DESCRIPTION
## Repro

`MnemopiSessionState.dispose()` closed every owned SQLite handle synchronously, so the background `embed()` task that `scheduleEmbedding()` queues during `remember()` / `update()` / consolidation lost its race against `close()` and silently dropped (`runEmbedding` swallows errors). Across the live coding-agent runtime this left `memory_embeddings` permanently empty even though the v15.11.0 fix from #1832 was present in the mnemopi package itself. Reproduced with a new test that spies on `Mnemopi.prototype.{flushExtractions, close}` and asserts the invocation order after `await state.dispose()`:

```
$ cd packages/coding-agent && bun test test/memory-tools.test.ts -t "issue #2314"
 1 pass   0 fail   3 expect() calls
```

Pre-fix the spy never records a `flushExtractions` call, so the order assertion fails.

## Cause

- `packages/coding-agent/src/mnemopi/state.ts` `MnemopiSessionState.dispose()` only iterated `this.scoped.owned` and called `memory.close()`. There was no flush, so any background task tracked on `beam.pendingExtractions` resolved against an already-closed `Database`. The mnemopi-package fix from #1832 added a `flushExtractions()` drain to the `withMemory` / MCP `withBeam` paths but did not change the coding-agent embedding's dispose path.
- `flushExtractions()` was only awaited from the `/memory enqueue` command handler in `packages/coding-agent/src/mnemopi/backend.ts`; ordinary session shutdown never drained it.
- All four dispose call sites — `backend.start` (alias + primary branches), `backend.clear`, and `AgentSession.dispose` in `packages/coding-agent/src/session/agent-session.ts` — invoked `previous?.dispose()` synchronously, so even after making dispose async we needed to await each one.

## Fix

- `packages/coding-agent/src/mnemopi/state.ts`: convert `dispose()` to `async`; iterate `scoped.owned`, await `memory.flushExtractions()` before `memory.close()` for each owned Mnemopi, and log+swallow flush errors so close still runs.
- `packages/coding-agent/src/mnemopi/backend.ts`: `await previous?.dispose()` in both `start` branches and in `clear`.
- `packages/coding-agent/src/session/agent-session.ts`: `await mnemopiState?.dispose()` inside `AgentSession.dispose`.
- `packages/coding-agent/test/memory-tools.test.ts`: import `requireMnemopi`; convert every Mnemopi `afterEach` hook and inline `dispose()` call site to `await`; add the regression test under "Mnemopi backend lifecycle" pinning the flush-then-close order via `spy.mock.invocationCallOrder`.
- `packages/coding-agent/CHANGELOG.md`: log the fix under `## [Unreleased]`.

The issue also asks whether `sleepAllSessions()` should run automatically after `maybeRetainOnAgentEnd()` so consolidation does not require a manual `/memory enqueue`. That is a behavioural change with cost (every agent_end would trigger an LLM consolidation pass) and is out of scope for this fix; happy to follow up once a maintainer decides the policy.

## Verification

- `cd packages/coding-agent && bun test test/memory-tools.test.ts` → 41 pass / 0 fail (includes the new regression test and every existing Mnemopi lifecycle/retain/recall/reflect/edit case under the now-async dispose).
- `bun check` (workspace root) → clean (`Done in 8.12s`).
- Pre-existing failures in `packages/mnemopi/test/{local-llm,optional-embeddings}.test.ts` reproduce on `main` with `EACCES: permission denied, mkdir '/srv/agent-home/.hermes'` — unrelated sandbox HOME perms, not caused by this diff.

`Fixes #2314`
